### PR TITLE
DXVA: fixes and rework

### DIFF
--- a/xbmc/cores/VideoRenderers/BaseRenderer.h
+++ b/xbmc/cores/VideoRenderers/BaseRenderer.h
@@ -29,7 +29,7 @@
 
 #define MAX_PLANES 3
 #define MAX_FIELDS 3
-#define NUM_BUFFERS 3
+#define NUM_BUFFERS 6
 
 class CSetting;
 
@@ -93,6 +93,7 @@ public:
   virtual unsigned int GetMaxBufferSize() { return 0; }
   virtual void         SetBufferSize(int numBuffers) { }
   virtual void         ReleaseBuffer(int idx) { }
+  virtual bool         NeedBufferForRef(int idx) { return false; }
 
   virtual bool Supports(ERENDERFEATURE feature) { return false; }
 

--- a/xbmc/cores/VideoRenderers/BaseRenderer.h
+++ b/xbmc/cores/VideoRenderers/BaseRenderer.h
@@ -89,7 +89,7 @@ public:
   /**
    * Returns number of references a single buffer can retain when rendering a single frame
    */
-  virtual unsigned int GetProcessorSize() { return 0; }
+  virtual unsigned int GetOptimalBufferSize() { return 0; }
   virtual unsigned int GetMaxBufferSize() { return 0; }
   virtual void         SetBufferSize(int numBuffers) { }
   virtual void         ReleaseBuffer(int idx) { }

--- a/xbmc/cores/VideoRenderers/DXVA.cpp
+++ b/xbmc/cores/VideoRenderers/DXVA.cpp
@@ -148,11 +148,9 @@ CProcessor::CProcessor()
 {
   m_service = NULL;
   m_process = NULL;
-  m_time    = 0;
   g_Windowing.Register(this);
 
   m_context = NULL;
-  m_index = 0;
   m_progressive = true;
 }
 
@@ -173,12 +171,6 @@ void CProcessor::Close()
 {
   CSingleLock lock(m_section);
   SAFE_RELEASE(m_process);
-  for(unsigned i = 0; i < m_samples.size(); i++)
-  {
-    SAFE_RELEASE(m_samples[i].renderPic);
-  }
-  m_samples.clear();
-
   SAFE_RELEASE(m_context);
 }
 
@@ -362,8 +354,6 @@ bool CProcessor::Open(UINT width, UINT height, unsigned int flags, unsigned int 
   if (!OpenProcessor())
     return false;
 
-  m_time = 0;
-
   return true;
 }
 
@@ -511,114 +501,71 @@ bool CProcessor::CreateSurfaces()
   return true;
 }
 
-REFERENCE_TIME CProcessor::Add(DVDVideoPicture* picture)
+CRenderPicture *CProcessor::Convert(DVDVideoPicture* picture)
 {
-  CSingleLock lock(m_section);
-
-  IDirect3DSurface9* surface = NULL;
-
-  if (picture->iFlags & DVP_FLAG_DROPPED)
-    return 0;
-
-  switch (picture->format)
+  if (picture->format != RENDER_FMT_YUV420P)
   {
-    case RENDER_FMT_DXVA:
-    {
-      surface = picture->dxva->surface;
-      break;
-    }
-
-    case RENDER_FMT_YUV420P:
-    {
-      surface = m_context->GetAtIndex(m_index);
-      m_index = (m_index + 1) % m_size;
-
-      D3DLOCKED_RECT rectangle;
-      if (FAILED(surface->LockRect(&rectangle, NULL, 0)))
-        return 0;
-
-      // Convert to NV12 - Luma
-      // TODO: Optimize this later using shaders/swscale/etc.
-      uint8_t *s = picture->data[0];
-      uint8_t* bits = (uint8_t*)(rectangle.pBits);
-      for (unsigned y = 0; y < picture->iHeight; y++)
-      {
-        memcpy(bits, s, picture->iWidth);
-        s += picture->iLineSize[0];
-        bits += rectangle.Pitch;
-      }
-
-      D3DSURFACE_DESC desc;
-      if (FAILED(surface->GetDesc(&desc)))
-        return 0;
-
-      // Convert to NV12 - Chroma
-      for (unsigned y = 0; y < picture->iHeight/2; y++)
-      {
-        uint8_t *s_u = picture->data[1] + (y * picture->iLineSize[1]);
-        uint8_t *s_v = picture->data[2] + (y * picture->iLineSize[2]);
-        uint8_t *d_uv = ((uint8_t*)(rectangle.pBits)) + (desc.Height + y) * rectangle.Pitch;
-        for (unsigned x = 0; x < picture->iWidth/2; x++)
-        {
-          *d_uv++ = *s_u++;
-          *d_uv++ = *s_v++;
-        }
-      }
-  
-      if (FAILED(surface->UnlockRect()))
-        return 0;
-
-      break;
-    }
-    
-    default:
-    {
-      CLog::Log(LOGWARNING, "DXVA - colorspace not supported by processor, skipping frame");
-      return 0;
-    }
+    CLog::Log(LOGERROR, "%s - colorspace not supported by processor, skipping frame.", __FUNCTION__);
+    return NULL;
   }
 
+  IDirect3DSurface9* surface = m_context->GetFree(NULL);
   if (!surface)
-    return 0;
-
-  m_time += 2;
-
-  SVideoSample vs = {};
-  vs.sample.Start          = m_time;
-  vs.sample.End            = 0; 
-  vs.sample.SampleFormat   = m_desc.SampleFormat;
-  vs.renderPic = NULL;
-  if (picture->format == RENDER_FMT_DXVA)
-    vs.renderPic = picture->dxva->Acquire();
-
-  if (picture->iFlags & DVP_FLAG_INTERLACED)
   {
-    if (picture->iFlags & DVP_FLAG_TOP_FIELD_FIRST)
-      vs.sample.SampleFormat.SampleFormat = DXVA2_SampleFieldInterleavedEvenFirst;
-    else
-      vs.sample.SampleFormat.SampleFormat = DXVA2_SampleFieldInterleavedOddFirst;
-  }
-  else
-  {
-    vs.sample.SampleFormat.SampleFormat = DXVA2_SampleProgressiveFrame;
+    CLog::Log(LOGERROR, "%s - no free video surface", __FUNCTION__);
+    return NULL;
   }
 
-  vs.sample.PlanarAlpha    = DXVA2_Fixed32OpaqueAlpha();
-  vs.sample.SampleData     = 0;
-  vs.sample.SrcSurface     = surface;
-
-
-  if(!m_samples.empty())
-    m_samples.back().sample.End = vs.sample.Start;
-
-  m_samples.push_back(vs);
-  if (m_samples.size() > m_size)
+  D3DLOCKED_RECT rectangle;
+  if (FAILED(surface->LockRect(&rectangle, NULL, 0)))
   {
-    SAFE_RELEASE(m_samples.front().renderPic);
-    m_samples.pop_front();
+    CLog::Log(LOGERROR, "%s - could not lock rect", __FUNCTION__);
+    m_context->ClearReference(surface);
+    return NULL;
   }
 
-  return m_time;
+  // Convert to NV12 - Luma
+  // TODO: Optimize this later using shaders/swscale/etc.
+  uint8_t *s = picture->data[0];
+  uint8_t* bits = (uint8_t*)(rectangle.pBits);
+  for (unsigned y = 0; y < picture->iHeight; y++)
+  {
+    memcpy(bits, s, picture->iWidth);
+    s += picture->iLineSize[0];
+    bits += rectangle.Pitch;
+  }
+  D3DSURFACE_DESC desc;
+  if (FAILED(surface->GetDesc(&desc)))
+  {
+    CLog::Log(LOGERROR, "%s - could not get surface descriptor", __FUNCTION__);
+    m_context->ClearReference(surface);
+    return NULL;
+  }
+  // Convert to NV12 - Chroma
+  uint8_t *s_u, *s_v, *d_uv;
+  for (unsigned y = 0; y < picture->iHeight / 2; y++)
+  {
+    s_u = picture->data[1] + (y * picture->iLineSize[1]);
+    s_v = picture->data[2] + (y * picture->iLineSize[2]);
+    d_uv = ((uint8_t*)(rectangle.pBits)) + (desc.Height + y) * rectangle.Pitch;
+    for (unsigned x = 0; x < picture->iWidth / 2; x++)
+    {
+      *d_uv++ = *s_u++;
+      *d_uv++ = *s_v++;
+    }
+  }
+  if (FAILED(surface->UnlockRect()))
+  {
+    CLog::Log(LOGERROR, "%s - failed to unlock surface", __FUNCTION__);
+    m_context->ClearReference(surface);
+    return NULL;
+  }
+
+  m_context->ClearReference(surface);
+  m_context->MarkRender(surface);
+  CRenderPicture *pic = new CRenderPicture(m_context);
+  pic->surface = surface;
+  return pic;
 }
 
 static DXVA2_Fixed32 ConvertRange(const DXVA2_ValueRange& range, int value, int min, int max, int def)
@@ -635,9 +582,12 @@ static DXVA2_Fixed32 ConvertRange(const DXVA2_ValueRange& range, int value, int 
     return range.DefaultValue;
 }
 
-bool CProcessor::Render(CRect src, CRect dst, IDirect3DSurface9* target, REFERENCE_TIME time, DWORD flags)
+bool CProcessor::Render(CRect src, CRect dst, IDirect3DSurface9* target, IDirect3DSurface9** source, DWORD flags, UINT frameIdx)
 {
   CSingleLock lock(m_section);
+
+  if (!source[2])
+    return false;
 
   // With auto deinterlacing, the Ion Gen. 1 drops some frames with deinterlacing processor + progressive flags for progressive material.
   // For that GPU (or when specified by an advanced setting), use the progressive processor.
@@ -657,29 +607,6 @@ bool CProcessor::Render(CRect src, CRect dst, IDirect3DSurface9* target, REFEREN
       return false;
   }
   
-  // MinTime and MaxTime are the first and last samples to keep. Delete the rest.
-  REFERENCE_TIME MinTime = time - m_max_back_refs*2;
-  REFERENCE_TIME MaxTime = time + m_max_fwd_refs*2;
-
-  std::deque<SVideoSample>::iterator it = m_samples.begin();
-  while (it != m_samples.end())
-  {
-    if (it->sample.Start < MinTime)
-    {
-      SAFE_RELEASE(it->renderPic);
-      it = m_samples.erase(it);
-    }
-    else
-      ++it;
-  }
-
-  if(m_samples.empty())
-    return false;
-
-  // MinTime and MaxTime are now the first and last samples to feed the processor.
-  MinTime = time - m_caps.NumBackwardRefSamples*2;
-  MaxTime = time + m_caps.NumForwardRefSamples*2;
-
   D3DSURFACE_DESC desc;
   CHECK(target->GetDesc(&desc));
   CRect rectTarget(0, 0, desc.Width, desc.Height);
@@ -687,63 +614,70 @@ bool CProcessor::Render(CRect src, CRect dst, IDirect3DSurface9* target, REFEREN
   RECT sourceRECT = { src.x1, src.y1, src.x2, src.y2 };
   RECT dstRECT    = { dst.x1, dst.y1, dst.x2, dst.y2 };
 
+  // set sample format for progressive and interlaced
+  UINT sampleFormat = DXVA2_SampleProgressiveFrame;
+  if (flags & RENDER_FLAG_FIELD0 && flags & RENDER_FLAG_TOP)
+    sampleFormat = DXVA2_SampleFieldInterleavedEvenFirst;
+  else if (flags & RENDER_FLAG_FIELD1 && flags & RENDER_FLAG_BOT)
+    sampleFormat = DXVA2_SampleFieldInterleavedEvenFirst;
+  if (flags & RENDER_FLAG_FIELD0 && flags & RENDER_FLAG_BOT)
+    sampleFormat = DXVA2_SampleFieldInterleavedOddFirst;
+  if (flags & RENDER_FLAG_FIELD1 && flags & RENDER_FLAG_TOP)
+    sampleFormat = DXVA2_SampleFieldInterleavedOddFirst;
 
   // How to prepare the samples array for VideoProcessBlt
   // - always provide current picture + the number of forward and backward references required by the current processor.
   // - provide the surfaces in the array in increasing temporal order
   // - at the start of playback, there may not be enough samples available. Use SampleFormat.SampleFormat = DXVA2_SampleUnknown for the missing samples.
 
-  int count = 1 + m_caps.NumBackwardRefSamples + m_caps.NumForwardRefSamples;
-  int valid = 0;
+  unsigned int providedPast = 0;
+  for (int i = 3; i < 8; i++)
+  {
+    if (source[i])
+      providedPast++;
+  }
+  unsigned int providedFuture = 0;
+  for (int i = 1; i >= 0; i--)
+  {
+    if (source[i])
+      providedFuture++;
+  }
+  int futureFrames = std::min(providedFuture, m_caps.NumForwardRefSamples);
+  int pastFrames = std::min(providedPast, m_caps.NumBackwardRefSamples);
+
+  int count = 1 + pastFrames + futureFrames;
   auto_aptr<DXVA2_VideoSample> samp(new DXVA2_VideoSample[count]);
 
-  for (int i = 0; i < count; i++)
-    samp[i].SampleFormat.SampleFormat = DXVA2_SampleUnknown;
-
-  for(it = m_samples.begin(); it != m_samples.end() && valid < count; ++it)
+  int start = 2 - futureFrames;
+  int end = 2 + pastFrames;
+  int sampIdx = 0;
+  for (int i = end; i >= start; i--)
   {
-    if (it->sample.Start >= MinTime && it->sample.Start <= MaxTime)
-    {
-      DXVA2_VideoSample& vs = samp[(it->sample.Start - MinTime) / 2];
-      vs = it->sample;
-      vs.SrcRect = sourceRECT;
-      vs.DstRect = dstRECT;
-      if(vs.End == 0)
-        vs.End = vs.Start + 2;
+    if (!source[i])
+      continue;
 
-      // Override the sample format when the processor doesn't need to deinterlace or when deinterlacing is forced and flags are missing.
-      if (m_progressive)
-        vs.SampleFormat.SampleFormat = DXVA2_SampleProgressiveFrame;
-      else if (m_deinterlace_mode == VS_DEINTERLACEMODE_FORCE && vs.SampleFormat.SampleFormat == DXVA2_SampleProgressiveFrame)
-        vs.SampleFormat.SampleFormat = DXVA2_SampleFieldInterleavedEvenFirst;
+    DXVA2_VideoSample& vs = samp[sampIdx];
+    vs.SrcSurface = source[i];
+    vs.SrcRect = sourceRECT;
+    vs.DstRect = dstRECT;
+    vs.SampleData = 0;
+    vs.Start = frameIdx + (sampIdx - pastFrames) * 2;
+    vs.End = vs.Start + 2;
+    vs.PlanarAlpha = DXVA2_Fixed32OpaqueAlpha();
+    vs.SampleFormat.SampleFormat = sampleFormat;
+    
+    // Override the sample format when the processor doesn't need to deinterlace or when deinterlacing is forced and flags are missing.
+    if (m_progressive)
+      vs.SampleFormat.SampleFormat = DXVA2_SampleProgressiveFrame;
+    else if (m_deinterlace_mode == VS_DEINTERLACEMODE_FORCE && vs.SampleFormat.SampleFormat == DXVA2_SampleProgressiveFrame)
+      vs.SampleFormat.SampleFormat = DXVA2_SampleFieldInterleavedEvenFirst;
 
-      valid++;
-    }
-  }
-  
-  // MS' guidelines above don't work. The blit fails when the processor is given DXVA2_SampleUnknown samples (with ATI at least).
-  // The ATI driver works with a reduced number of samples though, support that for now.
-  // Problem is an ambiguity if there are future refs requested by the processor. There are no such implementations at the moment.
-  int offset = 0;
-  if(valid < count)
-  {
-    CLog::Log(LOGWARNING, __FUNCTION__" - did not find all required samples, adjusting the sample array.");
-
-    for (int i = 0; i < count; i++)
-    {
-      if (samp[i].SampleFormat.SampleFormat == DXVA2_SampleUnknown)
-        offset = i+1;
-    }
-    count -= offset;
-    if (count == 0)
-    {
-      CLog::Log(LOGWARNING, __FUNCTION__" - no usable samples.");
-      return false;
-    }
+    sampIdx++;
   }
 
+ 
   DXVA2_VideoProcessBltParams blt = {};
-  blt.TargetFrame = time;
+  blt.TargetFrame = frameIdx;
   if (flags & RENDER_FLAG_FIELD1)
     blt.TargetFrame += 1;
   blt.TargetRect  = dstRECT;
@@ -776,7 +710,7 @@ bool CProcessor::Render(CRect src, CRect dst, IDirect3DSurface9* target, REFEREN
   float verts[2][3]= {};
   g_Windowing.Get3DDevice()->DrawPrimitiveUP(D3DPT_TRIANGLEFAN, 1, verts, 3*sizeof(float));
 
-  CHECK(m_process->VideoProcessBlt(target, &blt, &samp[offset], count, NULL));
+  CHECK(m_process->VideoProcessBlt(target, &blt, &samp[0], count, NULL));
   return true;
 }
 

--- a/xbmc/cores/VideoRenderers/DXVA.h
+++ b/xbmc/cores/VideoRenderers/DXVA.h
@@ -44,9 +44,10 @@ public:
   virtual void           UnInit();
   virtual bool           Open(UINT width, UINT height, unsigned int flags, unsigned int format, unsigned int extended_format);
   virtual void           Close();
-  virtual REFERENCE_TIME Add(DVDVideoPicture* picture);
-  virtual bool           Render(CRect src, CRect dst, IDirect3DSurface9* target, const REFERENCE_TIME time, DWORD flags);
+  virtual CRenderPicture *Convert(DVDVideoPicture* picture);
+  virtual bool           Render(CRect src, CRect dst, IDirect3DSurface9* target, IDirect3DSurface9** source, DWORD flags, UINT frameIdx);
   virtual unsigned       Size() { if (m_service) return m_size; return 0; }
+  virtual unsigned       PastRefs() { return m_max_back_refs; }
 
   virtual void OnCreateDevice()  {}
   virtual void OnDestroyDevice() { CSingleLock lock(m_section); Close(); }
@@ -72,21 +73,12 @@ protected:
   DXVA2_ValueRange m_contrast;
   DXVA2_ValueRange m_hue;
   DXVA2_ValueRange m_saturation;
-  REFERENCE_TIME   m_time;
   unsigned         m_size;
   unsigned         m_max_back_refs;
   unsigned         m_max_fwd_refs;
   EDEINTERLACEMODE m_deinterlace_mode;
   EINTERLACEMETHOD m_interlace_method;
   bool             m_progressive; // true for progressive source or to force ignoring interlacing flags.
-  unsigned         m_index;
-
-  struct SVideoSample
-  {
-    DXVA2_VideoSample sample;
-    CRenderPicture* renderPic;
-  };
-  std::deque<SVideoSample> m_samples;
 
   CCriticalSection    m_section;
   CSurfaceContext*    m_context;

--- a/xbmc/cores/VideoRenderers/DXVA.h
+++ b/xbmc/cores/VideoRenderers/DXVA.h
@@ -84,13 +84,11 @@ protected:
   struct SVideoSample
   {
     DXVA2_VideoSample sample;
-    CSurfaceContext* context;
+    CRenderPicture* renderPic;
   };
-  typedef std::deque<SVideoSample> SSamples;
-  SSamples         m_sample;
+  std::deque<SVideoSample> m_samples;
 
   CCriticalSection    m_section;
-  LPDIRECT3DSURFACE9* m_surfaces;
   CSurfaceContext*    m_context;
   bool                m_quirk_nodeintprocforprog;
   static CCriticalSection    m_dlSection;

--- a/xbmc/cores/VideoRenderers/DXVAHD.cpp
+++ b/xbmc/cores/VideoRenderers/DXVAHD.cpp
@@ -278,8 +278,8 @@ bool CProcessorHD::OpenProcessor()
   CHECK(m_pDXVAHD->CreateVideoProcessor(&m_device, &m_pDXVAVP));
 
   DXVAHD_STREAM_STATE_D3DFORMAT_DATA d3dformat = { m_format };
-  LOGIFERROR(m_pDXVAVP->SetVideoProcessStreamState( 0, DXVAHD_STREAM_STATE_D3DFORMAT
-                                                  , sizeof(d3dformat), &d3dformat ));
+  CHECK(m_pDXVAVP->SetVideoProcessStreamState( 0, DXVAHD_STREAM_STATE_D3DFORMAT
+                                             , sizeof(d3dformat), &d3dformat ));
 
   DXVAHD_STREAM_STATE_INPUT_COLOR_SPACE_DATA data =
   {
@@ -288,19 +288,19 @@ bool CProcessorHD::OpenProcessor()
     m_flags & CONF_FLAGS_YUVCOEF_BT709 ? 1 : 0, // YCbCr_Matrix: 0=BT.601, 1=BT.709
     m_flags & CONF_FLAGS_YUV_FULLRANGE ? 1 : 0  // YCbCr_xvYCC: 0=Conventional YCbCr, 1=xvYCC
   };
-  LOGIFERROR(m_pDXVAVP->SetVideoProcessStreamState( 0, DXVAHD_STREAM_STATE_INPUT_COLOR_SPACE
-                                                  , sizeof(data), &data ));
+  CHECK(m_pDXVAVP->SetVideoProcessStreamState( 0, DXVAHD_STREAM_STATE_INPUT_COLOR_SPACE
+                                             , sizeof(data), &data ));
 
   DXVAHD_COLOR_YCbCrA bgColor = { 0.0625f, 0.5f, 0.5f, 1.0f }; // black color
   DXVAHD_COLOR backgroundColor;
   backgroundColor.YCbCr = bgColor; 
   DXVAHD_BLT_STATE_BACKGROUND_COLOR_DATA backgroundData = { true, backgroundColor }; // {YCbCr, DXVAHD_COLOR}
-  LOGIFERROR(m_pDXVAVP->SetVideoProcessBltState( DXVAHD_BLT_STATE_BACKGROUND_COLOR
-                                               , sizeof (backgroundData), &backgroundData ));
+  CHECK(m_pDXVAVP->SetVideoProcessBltState( DXVAHD_BLT_STATE_BACKGROUND_COLOR
+                                          , sizeof (backgroundData), &backgroundData ));
 
   DXVAHD_STREAM_STATE_ALPHA_DATA alpha = { true, 1.0f };
-  LOGIFERROR(m_pDXVAVP->SetVideoProcessStreamState( 0, DXVAHD_STREAM_STATE_ALPHA
-                                                  , sizeof(alpha), &alpha ));
+  CHECK(m_pDXVAVP->SetVideoProcessStreamState( 0, DXVAHD_STREAM_STATE_ALPHA
+                                             , sizeof(alpha), &alpha ));
 
   return true;
 }

--- a/xbmc/cores/VideoRenderers/DXVAHD.h
+++ b/xbmc/cores/VideoRenderers/DXVAHD.h
@@ -59,9 +59,9 @@ public:
   virtual void           UnInit();
   virtual bool           Open(UINT width, UINT height, unsigned int flags, unsigned int format, unsigned int extended_format);
   virtual void           Close();
-  virtual REFERENCE_TIME Add(DVDVideoPicture* picture);
-  virtual bool           Render(CRect src, CRect dst, IDirect3DSurface9* target, const REFERENCE_TIME time, DWORD flags);
+  virtual bool           Render(CRect src, CRect dst, IDirect3DSurface9* target, IDirect3DSurface9 **source, DWORD flags, UINT frameIdx);
   virtual unsigned       Size() { if (m_pDXVAHD) return m_size; return 0; }
+  virtual unsigned       PastRefs() { return m_max_back_refs; }
 
   virtual void OnCreateDevice()  {}
   virtual void OnDestroyDevice() { CSingleLock lock(m_section); UnInit(); }
@@ -83,7 +83,6 @@ protected:
   unsigned int             m_width;
   unsigned int             m_height;
   D3DFORMAT                m_format;
-  REFERENCE_TIME           m_frame;
   unsigned int             m_flags;
   unsigned int             m_renderFormat;
 
@@ -94,15 +93,6 @@ protected:
   };
   ProcAmpInfo              m_Filters[NUM_FILTERS];
 
-  struct SFrame
-  {
-    IDirect3DSurface9*     pSurface;
-    CRenderPicture*        pRenderPic;
-    unsigned int           index;
-    unsigned               format;
-  };
-  typedef std::deque<SFrame> SFrames;
-  SFrames                  m_frames;
   static DXVAHDCreateVideoServicePtr m_DXVAHDCreateVideoService;
 };
 

--- a/xbmc/cores/VideoRenderers/DXVAHD.h
+++ b/xbmc/cores/VideoRenderers/DXVAHD.h
@@ -97,7 +97,7 @@ protected:
   struct SFrame
   {
     IDirect3DSurface9*     pSurface;
-    CSurfaceContext*       context;
+    CRenderPicture*        pRenderPic;
     unsigned int           index;
     unsigned               format;
   };

--- a/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
@@ -3496,16 +3496,12 @@ void CLinuxRendererGL::UnBindPbo(YUVBUFFER& buff)
     glBindBufferARB(GL_PIXEL_UNPACK_BUFFER_ARB, 0);
 }
 
-unsigned int CLinuxRendererGL::GetProcessorSize()
+unsigned int CLinuxRendererGL::GetOptimalBufferSize()
 {
-  if(m_format == RENDER_FMT_VDPAU
-  || m_format == RENDER_FMT_VDPAU_420
-  || m_format == RENDER_FMT_VAAPI
-  || m_format == RENDER_FMT_VAAPINV12
-  || m_format == RENDER_FMT_CVBREF)
-    return 1;
+  if(m_format == RENDER_FMT_CVBREF)
+    return 2;
   else
-    return 0;
+    return 3;
 }
 
 #ifdef HAVE_LIBVDPAU

--- a/xbmc/cores/VideoRenderers/LinuxRendererGL.h
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGL.h
@@ -136,7 +136,7 @@ public:
   virtual void         ReleaseBuffer(int idx);
   virtual void         SetBufferSize(int numBuffers) { m_NumYV12Buffers = numBuffers; }
   virtual unsigned int GetMaxBufferSize() { return NUM_BUFFERS; }
-  virtual unsigned int GetProcessorSize();
+  virtual unsigned int GetOptimalBufferSize();
 
 #ifdef HAVE_LIBVDPAU
   virtual void         AddProcessor(VDPAU::CVdpauRenderPicture* vdpau, int index);

--- a/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
@@ -2893,15 +2893,9 @@ EINTERLACEMETHOD CLinuxRendererGLES::AutoInterlaceMethod()
 #endif
 }
 
-unsigned int CLinuxRendererGLES::GetProcessorSize()
+unsigned int CLinuxRendererGLES::GetOptimalBufferSize()
 {
-  if(m_format == RENDER_FMT_OMXEGL
-  || m_format == RENDER_FMT_CVBREF
-  || m_format == RENDER_FMT_EGLIMG
-  || m_format == RENDER_FMT_MEDIACODEC)
-    return 1;
-  else
-    return 0;
+  return 2;
 }
 
 #ifdef HAVE_LIBOPENMAX

--- a/xbmc/cores/VideoRenderers/LinuxRendererGLES.h
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGLES.h
@@ -143,7 +143,7 @@ public:
   virtual void         ReleaseBuffer(int idx);
   virtual void         SetBufferSize(int numBuffers) { m_NumYV12Buffers = numBuffers; }
   virtual unsigned int GetMaxBufferSize() { return NUM_BUFFERS; }
-  virtual unsigned int GetProcessorSize();
+  virtual unsigned int GetOptimalBufferSize();
 
   virtual void RenderUpdate(bool clear, DWORD flags = 0, DWORD alpha = 255);
 

--- a/xbmc/cores/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoRenderers/RenderManager.cpp
@@ -261,14 +261,14 @@ bool CXBMCRenderManager::Configure(unsigned int width, unsigned int height, unsi
     lock2.Enter();
     m_format = format;
 
-    int processor = m_pRenderer->GetProcessorSize();
-    m_QueueSize = std::min(buffers, processor);
+    int renderbuffers = m_pRenderer->GetOptimalBufferSize();
+    m_QueueSize = std::min(buffers, renderbuffers);
     m_QueueSize = std::min(m_QueueSize, (int)m_pRenderer->GetMaxBufferSize());
     m_QueueSize = std::min(m_QueueSize, NUM_BUFFERS);
     if(m_QueueSize < 2)
     {
       m_QueueSize = 2;
-      CLog::Log(LOGWARNING, "CXBMCRenderManager::Configure - queue size too small (%d, %d, %d)", m_QueueSize, processor, buffers);
+      CLog::Log(LOGWARNING, "CXBMCRenderManager::Configure - queue size too small (%d, %d, %d)", m_QueueSize, renderbuffers, buffers);
     }
 
     m_pRenderer->SetBufferSize(m_QueueSize);
@@ -855,10 +855,14 @@ void CXBMCRenderManager::UpdateResolution()
 }
 
 
-unsigned int CXBMCRenderManager::GetProcessorSize()
+unsigned int CXBMCRenderManager::GetOptimalBufferSize()
 {
   CSharedLock lock(m_sharedSection);
-  return std::max(4, NUM_BUFFERS);
+  if (!m_pRenderer)
+  {
+    CLog::Log(LOGERROR, "%s - renderer is NULL", __FUNCTION__);
+  }
+  return m_pRenderer->GetMaxBufferSize();
 }
 
 // Supported pixel formats, can be called before configure

--- a/xbmc/cores/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoRenderers/RenderManager.h
@@ -153,7 +153,7 @@ public:
   CLinuxRenderer      *m_pRenderer;
 #endif
 
-  unsigned int GetProcessorSize();
+  unsigned int GetOptimalBufferSize();
 
   // Supported pixel formats, can be called before configure
   std::vector<ERenderFormat> SupportedFormats();

--- a/xbmc/cores/VideoRenderers/WinRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/WinRenderer.cpp
@@ -1263,8 +1263,14 @@ bool CWinRenderer::Supports(ESCALINGMETHOD method)
 {
   if (m_renderMethod == RENDER_PS || m_renderMethod == RENDER_DXVA)
   {
-    if(m_renderMethod == RENDER_DXVA && method == VS_SCALINGMETHOD_DXVA_HARDWARE)
-      return true;
+    if (m_renderMethod == RENDER_DXVA)
+    {
+      if (method == VS_SCALINGMETHOD_DXVA_HARDWARE ||
+          method == VS_SCALINGMETHOD_AUTO)
+        return true;
+      else
+        return false;
+    }
 
     if(m_deviceCaps.PixelShaderVersion >= D3DPS_VERSION(2, 0)
     && (   method == VS_SCALINGMETHOD_AUTO

--- a/xbmc/cores/VideoRenderers/WinRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/WinRenderer.cpp
@@ -198,6 +198,7 @@ void CWinRenderer::SelectRenderMethod()
 
   RenderMethodDetail *rmdet = FindRenderMethod(m_renderMethod);
   CLog::Log(LOGDEBUG, __FUNCTION__": Selected render method %d: %s", m_renderMethod, rmdet != NULL ? rmdet->name : "unknown");
+  m_frameIdx = 0;
 }
 
 bool CWinRenderer::UpdateRenderMethod()
@@ -270,6 +271,11 @@ int CWinRenderer::NextYV12Texture()
 
 bool CWinRenderer::AddVideoPicture(DVDVideoPicture* picture, int index)
 {
+  if (!m_NumYV12Buffers)
+  {
+    return false;
+  }
+
   if (m_renderMethod == RENDER_DXVA)
   {
     int source = index;
@@ -277,7 +283,17 @@ bool CWinRenderer::AddVideoPicture(DVDVideoPicture* picture, int index)
       return false;
 
     DXVABuffer *buf = (DXVABuffer*)m_VideoBuffers[source];
-    buf->id = m_processor->Add(picture);
+    SAFE_RELEASE(buf->pic);
+    if (picture->format == RENDER_FMT_DXVA)
+    {
+      buf->pic = picture->dxva->Acquire();
+    }
+    else
+    {
+      buf->pic = m_processor->Convert(picture);
+    }
+    buf->frameIdx = m_frameIdx;
+    m_frameIdx += 2;
     return true;
   }
   return false;
@@ -341,7 +357,9 @@ void CWinRenderer::RenderUpdate(bool clear, DWORD flags, DWORD alpha)
   else
     pD3DDevice->SetRenderState( D3DRS_ALPHABLENDENABLE, FALSE );
 
-  if (!m_bConfigured) return;
+  if (!m_bConfigured) 
+    return;
+
   ManageTextures();
 
   CSingleLock lock(g_graphicsContext);
@@ -998,6 +1016,9 @@ void CWinRenderer::RenderProcessor(DWORD flags)
 
   DXVABuffer *image = (DXVABuffer*)m_VideoBuffers[m_iYV12RenderBuffer];
 
+  if (!image->pic)
+    return;
+
   IDirect3DSurface9* target;
   if ( m_bUseHQScaler 
     || g_graphicsContext.GetStereoMode() == RENDER_STEREO_MODE_ANAGLYPH_RED_CYAN
@@ -1014,7 +1035,50 @@ void CWinRenderer::RenderProcessor(DWORD flags)
     }
   }
 
-  m_processor->Render(m_sourceRect, destRect, target, image->id, flags);
+  IDirect3DSurface9 *source[8];
+  memset(source, 0, 8 * sizeof(IDirect3DSurface9*));
+  source[2] = image->pic->surface;
+
+  int past = 0;
+  int future = 0;
+  DXVABuffer **buffers = (DXVABuffer**)m_VideoBuffers;
+
+  // set future frames
+  while (future < 2)
+  {
+    bool found = false;
+    for (int i = 0; i < m_NumYV12Buffers; i++)
+    {
+      if (buffers[i] && buffers[i]->pic && buffers[i]->frameIdx == image->frameIdx + (future*2 + 2))
+      {
+        source[1 - future++] = buffers[i]->pic->surface;
+        found = true;
+        break;
+      }
+    }
+    if (!found)
+      break;
+  }
+
+  // set past frames
+  while (past < 4)
+  {
+    bool found = false;
+    for (int i = 0; i < m_NumYV12Buffers; i++)
+    {
+      if (buffers[i] && buffers[i]->pic && buffers[i]->frameIdx == image->frameIdx - (past*2 + 2))
+      {
+        source[3 + past++] = buffers[i]->pic->surface;
+        found = true;
+        break;
+      }
+    }
+    if (!found)
+      break;
+  }
+
+
+  m_processor->Render(m_sourceRect, destRect, target, source, flags, image->frameIdx);
 
   target->Release();
 
@@ -1255,6 +1319,29 @@ unsigned int CWinRenderer::GetProcessorSize()
     return 0;
 }
 
+void CWinRenderer::ReleaseBuffer(int idx)
+{
+  if (m_renderMethod == RENDER_DXVA && m_VideoBuffers[idx])
+    SAFE_RELEASE(((DXVABuffer*)m_VideoBuffers[idx])->pic);
+}
+
+bool CWinRenderer::NeedBufferForRef(int idx)
+{
+  // check if processor wants to keep past frames
+  if (m_format == RENDER_FMT_DXVA && m_processor)
+  {
+    DXVABuffer** buffers = (DXVABuffer**)m_VideoBuffers;
+
+    int numPast = m_processor->PastRefs();
+    if (buffers[idx] && buffers[idx]->pic)
+    {
+      if (buffers[idx]->frameIdx + numPast*2 >= buffers[m_iYV12RenderBuffer]->frameIdx)
+        return true;
+    }
+  }
+  return false;
+}
+
 //============================================
 
 YUVBuffer::~YUVBuffer()
@@ -1405,21 +1492,4 @@ void YUVBuffer::Clear()
   }
 }
 
-
-//==================================
-
-DXVABuffer::~DXVABuffer()
-{
-  Release();
-}
-
-void DXVABuffer::Release()
-{
-  id = 0;
-}
-
-void DXVABuffer::StartDecode()
-{
-  Release();
-}
 #endif

--- a/xbmc/cores/VideoRenderers/WinRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/WinRenderer.cpp
@@ -1311,12 +1311,12 @@ EINTERLACEMETHOD CWinRenderer::AutoInterlaceMethod()
     return VS_INTERLACEMETHOD_DEINTERLACE_HALF;
 }
 
-unsigned int CWinRenderer::GetProcessorSize()
+unsigned int CWinRenderer::GetOptimalBufferSize()
 {
   if (m_format == RENDER_FMT_DXVA && m_processor)
     return m_processor->Size();
   else
-    return 0;
+    return 2;
 }
 
 void CWinRenderer::ReleaseBuffer(int idx)

--- a/xbmc/cores/VideoRenderers/WinRenderer.h
+++ b/xbmc/cores/VideoRenderers/WinRenderer.h
@@ -128,13 +128,11 @@ struct DXVABuffer : SVideoBuffer
 {
   DXVABuffer()
   {
-    id   = 0;
+    pic = NULL;
   }
-  ~DXVABuffer();
-  virtual void Release();
-  virtual void StartDecode();
-
-  int64_t           id;
+  ~DXVABuffer() { SAFE_RELEASE(pic); }
+  DXVA::CRenderPicture *pic;
+  unsigned int frameIdx;
 };
 
 class CWinRenderer : public CBaseRenderer
@@ -173,6 +171,8 @@ public:
   virtual unsigned int GetProcessorSize();
   virtual void         SetBufferSize(int numBuffers) { m_neededBuffers = numBuffers; }
   virtual unsigned int GetMaxBufferSize() { return NUM_BUFFERS; }
+  virtual void         ReleaseBuffer(int idx);
+  virtual bool         NeedBufferForRef(int idx);
 
 protected:
   virtual void Render(DWORD flags);
@@ -240,6 +240,7 @@ protected:
   unsigned int         m_destHeight;
 
   int                  m_neededBuffers;
+  unsigned int         m_frameIdx;
 };
 
 #else

--- a/xbmc/cores/VideoRenderers/WinRenderer.h
+++ b/xbmc/cores/VideoRenderers/WinRenderer.h
@@ -168,7 +168,7 @@ public:
 
   void                 RenderUpdate(bool clear, DWORD flags = 0, DWORD alpha = 255);
 
-  virtual unsigned int GetProcessorSize();
+  virtual unsigned int GetOptimalBufferSize();
   virtual void         SetBufferSize(int numBuffers) { m_neededBuffers = numBuffers; }
   virtual unsigned int GetMaxBufferSize() { return NUM_BUFFERS; }
   virtual void         ReleaseBuffer(int idx);

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodec.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodec.h
@@ -47,7 +47,7 @@ struct DVDCodecAvailableType
 #define FRAME_TYPE_B 3
 #define FRAME_TYPE_D 4
 
-namespace DXVA { class CSurfaceContext; }
+namespace DXVA { class CRenderPicture; }
 namespace VAAPI { class CVaapiRenderPicture; }
 namespace VDPAU { class CVdpauRenderPicture; }
 class COpenMax;
@@ -72,7 +72,7 @@ struct DVDVideoPicture
       int iLineSize[4];   // [4] = alpha channel, currently not used
     };
     struct {
-      DXVA::CSurfaceContext* context;
+      DXVA::CRenderPicture* dxva;
     };
     struct {
       VDPAU::CVdpauRenderPicture* vdpau;

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -101,6 +101,7 @@ enum PixelFormat CDVDVideoCodecFFmpeg::GetFormat( struct AVCodecContext * avctx
 #ifdef HAS_DX
   if(DXVA::CDecoder::Supports(*cur) && CSettings::Get().GetBool("videoplayer.usedxva2"))
   {
+    CLog::Log(LOGNOTICE, "CDVDVideoCodecFFmpeg::GetFormat - Creating DXVA(%ix%i)", avctx->width, avctx->height);
     DXVA::CDecoder* dec = new DXVA::CDecoder();
     if(dec->Open(avctx, *cur, ctx->m_uSurfacesCount))
     {

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DXVA.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DXVA.cpp
@@ -218,6 +218,10 @@ static const dxva2_mode_t *dxva2_find_mode(const GUID *guid)
     return NULL;
 }
 
+//-----------------------------------------------------------------------------
+// DXVA Context
+//-----------------------------------------------------------------------------
+
 CDXVAContext *CDXVAContext::m_context = NULL;
 CCriticalSection CDXVAContext::m_section;
 HMODULE CDXVAContext::m_dlHandle = NULL;
@@ -464,39 +468,164 @@ bool CDXVAContext::IsValidDecoder(CDecoder *decoder)
   return false;
 }
 
+//-----------------------------------------------------------------------------
+// DXVA Video Surface states
+//-----------------------------------------------------------------------------
+#define SURFACE_USED_FOR_REFERENCE 0x01
+#define SURFACE_USED_FOR_RENDER 0x02
+
 CSurfaceContext::CSurfaceContext()
 {
 }
 
 CSurfaceContext::~CSurfaceContext()
 {
-  for (vector<IDirect3DSurface9*>::iterator it = m_heldsurfaces.begin(); it != m_heldsurfaces.end(); ++it)
-    SAFE_RELEASE(*it);
+  CLog::Log(LOGDEBUG, "%s - destructing surface context", __FUNCTION__);
+  Reset();
 }
 
-void CSurfaceContext::HoldSurface(IDirect3DSurface9* surface)
+void CSurfaceContext::AddSurface(IDirect3DSurface9* surf)
 {
-  surface->AddRef();
-  m_heldsurfaces.push_back(surface);
+  CSingleLock lock(m_section);
+  surf->AddRef();
+  m_state[surf] = 0;
+  m_freeSurfaces.push_back(surf);
 }
 
-CDecoder::SVideoBuffer::SVideoBuffer()
+void CSurfaceContext::ClearReference(IDirect3DSurface9* surf)
 {
-  surface = NULL;
-  Clear();
+  CSingleLock lock(m_section);
+  if (m_state.find(surf) == m_state.end())
+  {
+    CLog::Log(LOGWARNING, "%s - surface invalid", __FUNCTION__);
+    return;
+  }
+  m_state[surf] &= ~SURFACE_USED_FOR_REFERENCE;
+  if (m_state[surf] == 0)
+  {
+    m_freeSurfaces.push_back(surf);
+  }
 }
 
-CDecoder::SVideoBuffer::~SVideoBuffer()
+bool CSurfaceContext::MarkRender(IDirect3DSurface9* surf)
 {
-  Clear();
+  CSingleLock lock(m_section);
+  if (m_state.find(surf) == m_state.end())
+  {
+    CLog::Log(LOGWARNING, "%s - surface invalid", __FUNCTION__);
+    return false;
+  }
+  std::list<IDirect3DSurface9*>::iterator it;
+  it = std::find(m_freeSurfaces.begin(), m_freeSurfaces.end(), surf);
+  if (it != m_freeSurfaces.end())
+  {
+    m_freeSurfaces.erase(it);
+  }
+  m_state[surf] |= SURFACE_USED_FOR_RENDER;
+  return true;
 }
 
-void CDecoder::SVideoBuffer::Clear()
+void CSurfaceContext::ClearRender(IDirect3DSurface9* surf)
 {
-  SAFE_RELEASE(surface);
-  age     = 0;
-  used    = 0;
+  CSingleLock lock(m_section);
+  if (m_state.find(surf) == m_state.end())
+  {
+    CLog::Log(LOGWARNING, "%s - surface invalid", __FUNCTION__);
+    return;
+  }
+  m_state[surf] &= ~SURFACE_USED_FOR_RENDER;
+  if (m_state[surf] == 0)
+  {
+    m_freeSurfaces.push_back(surf);
+  }
 }
+
+bool CSurfaceContext::IsValid(IDirect3DSurface9* surf)
+{
+  CSingleLock lock(m_section);
+  if (m_state.find(surf) != m_state.end())
+    return true;
+  else
+    return false;
+}
+
+IDirect3DSurface9* CSurfaceContext::GetFree(IDirect3DSurface9* surf)
+{
+  CSingleLock lock(m_section);
+  if (m_state.find(surf) != m_state.end())
+  {
+    std::list<IDirect3DSurface9*>::iterator it;
+    it = std::find(m_freeSurfaces.begin(), m_freeSurfaces.end(), surf);
+    if (it == m_freeSurfaces.end())
+    {
+      CLog::Log(LOGWARNING, "%s - surface not free", __FUNCTION__);
+    }
+    else
+    {
+      m_freeSurfaces.erase(it);
+      m_state[surf] = SURFACE_USED_FOR_REFERENCE;
+      return surf;
+    }
+  }
+  if (!m_freeSurfaces.empty())
+  {
+    IDirect3DSurface9* freeSurf = m_freeSurfaces.front();
+    m_freeSurfaces.pop_front();
+    m_state[freeSurf] = SURFACE_USED_FOR_REFERENCE;
+    return freeSurf;
+  }
+  return NULL;
+}
+
+IDirect3DSurface9* CSurfaceContext::GetAtIndex(unsigned int idx)
+{
+  if (idx >= m_state.size())
+    return NULL;
+  std::map<IDirect3DSurface9*, int>::iterator it = m_state.begin();
+  for (unsigned int i = 0; i < idx; i++)
+    ++it;
+  return it->first;
+}
+
+void CSurfaceContext::Reset()
+{
+  CSingleLock lock(m_section);
+  for (map<IDirect3DSurface9*, int>::iterator it = m_state.begin(); it != m_state.end(); ++it)
+    it->first->Release();
+  m_freeSurfaces.clear();
+  m_state.clear();
+}
+
+int CSurfaceContext::Size()
+{
+  CSingleLock lock(m_section);
+  return m_state.size();
+}
+
+bool CSurfaceContext::HasFree()
+{
+  CSingleLock lock(m_section);
+  return !m_freeSurfaces.empty();
+}
+
+//-----------------------------------------------------------------------------
+// DXVA RednerPictures
+//-----------------------------------------------------------------------------
+
+CRenderPicture::CRenderPicture(CSurfaceContext *context)
+{
+  surface_context = context->Acquire();
+}
+
+CRenderPicture::~CRenderPicture()
+{
+  surface_context->ClearRender(surface);
+  surface_context->Release();
+}
+
+//-----------------------------------------------------------------------------
+// DXVA Decoder
+//-----------------------------------------------------------------------------
 
 CDecoder::CDecoder()
  : m_event(true)
@@ -505,21 +634,21 @@ CDecoder::CDecoder()
   m_state     = DXVA_OPEN;
   m_device    = NULL;
   m_decoder   = NULL;
-  m_buffer_count = 0;
-  m_buffer_age   = 0;
   m_refs         = 0;
   m_shared       = 0;
   m_surface_context = NULL;
+  m_presentPicture = NULL;
   m_dxva_context = NULL;
   memset(&m_format, 0, sizeof(m_format));
   m_context          = (dxva_context*)calloc(1, sizeof(dxva_context));
   m_context->cfg     = (DXVA2_ConfigPictureDecode*)calloc(1, sizeof(DXVA2_ConfigPictureDecode));
-  m_context->surface = (IDirect3DSurface9**)calloc(m_buffer_max, sizeof(IDirect3DSurface9*));
+  m_context->surface = (IDirect3DSurface9**)calloc(32, sizeof(IDirect3DSurface9*));
   g_Windowing.Register(this);
 }
 
 CDecoder::~CDecoder()
 {
+  CLog::Log(LOGDEBUG, "%s - destructing decoder, %ld", __FUNCTION__, this);
   g_Windowing.Unregister(this);
   Close();
   free(m_context->surface);
@@ -532,13 +661,14 @@ void CDecoder::Close()
   CSingleLock lock(m_section);
   SAFE_RELEASE(m_decoder);
   SAFE_RELEASE(m_surface_context);
-  for(unsigned i = 0; i < m_buffer_count; i++)
-    m_buffer[i].Clear();
-  m_buffer_count = 0;
+  SAFE_RELEASE(m_presentPicture);
   memset(&m_format, 0, sizeof(m_format));
 
   if (m_dxva_context)
+  {
+    CLog::Log(LOGNOTICE, "%s - closing decoder", __FUNCTION__);
     m_dxva_context->Release(this);
+  }
   m_dxva_context = NULL;
 }
 
@@ -769,7 +899,7 @@ bool CDecoder::Open(AVCodecContext *avctx, enum PixelFormat fmt, unsigned int su
   if(!OpenDecoder())
     return false;
 
-  avctx->get_buffer2     = GetBufferS;
+  avctx->get_buffer2 = GetBufferS;
   avctx->hwaccel_context = m_context;
 
   D3DADAPTER_IDENTIFIER9 AIdentifier = g_Windowing.GetAIdentifier();
@@ -801,12 +931,16 @@ int CDecoder::Decode(AVCodecContext* avctx, AVFrame* frame)
   if(result)
     return result;
 
+  SAFE_RELEASE(m_presentPicture);
+
   if(frame)
   {
-    for(unsigned i = 0; i < m_buffer_count; i++)
+    if (m_surface_context->IsValid((IDirect3DSurface9*)frame->data[3]))
     {
-      if(m_buffer[i].surface == (IDirect3DSurface9*)frame->data[3])
-        return VC_BUFFER | VC_PICTURE;
+      m_presentPicture = new CRenderPicture(m_surface_context);
+      m_presentPicture->surface = (IDirect3DSurface9*)frame->data[3];
+      m_surface_context->MarkRender(m_presentPicture->surface);
+      return VC_BUFFER | VC_PICTURE;
     }
     CLog::Log(LOGWARNING, "DXVA - ignoring invalid surface");
     return VC_BUFFER;
@@ -819,10 +953,10 @@ bool CDecoder::GetPicture(AVCodecContext* avctx, AVFrame* frame, DVDVideoPicture
 {
   ((CDVDVideoCodecFFmpeg*)avctx->opaque)->GetPictureCommon(picture);
   CSingleLock lock(m_section);
+
+  picture->dxva = m_presentPicture;
   picture->format = RENDER_FMT_DXVA;
   picture->extended_format = (unsigned int)m_format.Format;
-  picture->context = m_surface_context;
-  picture->data[3]= frame->data[3];
   return true;
 }
 
@@ -922,21 +1056,15 @@ bool CDecoder::OpenDecoder()
 
   m_context->surface_count = m_refs + 1 + 1 + m_shared; // refs + 1 decode + 1 libavcodec safety + processor buffer
 
-  if(m_context->surface_count > m_buffer_count)
+  CLog::Log(LOGDEBUG, "DXVA - allocating %d surfaces", m_context->surface_count);
+
+  if (!m_dxva_context->CreateSurfaces(m_format.SampleWidth, m_format.SampleHeight, m_format.Format,
+                                      m_context->surface_count - 1, m_context->surface))
+    return false;
+
+  for(unsigned i = 0; i < m_context->surface_count; i++)
   {
-    CLog::Log(LOGDEBUG, "DXVA - allocating %d surfaces", m_context->surface_count - m_buffer_count);
-
-    if (!m_dxva_context->CreateSurfaces(m_format.SampleWidth, m_format.SampleHeight, m_format.Format,
-                                        m_context->surface_count - 1 - m_buffer_count, m_context->surface + m_buffer_count))
-      return false;
-
-    for(unsigned i = m_buffer_count; i < m_context->surface_count; i++)
-    {
-      m_buffer[i].surface = m_context->surface[i];
-      m_surface_context->HoldSurface(m_context->surface[i]);
-    }
-
-    m_buffer_count = m_context->surface_count;
+    m_surface_context->AddSurface(m_context->surface[i]);
   }
 
   if (!m_dxva_context->CreateDecoder(m_input, &m_format, m_context->cfg, m_context->surface, m_context->surface_count, &m_decoder))
@@ -957,17 +1085,14 @@ bool CDecoder::Supports(enum PixelFormat fmt)
 void CDecoder::RelBuffer(uint8_t *data)
 {
   CSingleLock lock(m_section);
-  IDirect3DSurface9* surface = (IDirect3DSurface9*)data;
+  IDirect3DSurface9* surface = (IDirect3DSurface9*)(uintptr_t)data;
 
-  for(unsigned i = 0; i < m_buffer_count; i++)
+  if (!m_surface_context->IsValid(surface))
   {
-    if(m_buffer[i].surface == surface)
-    {
-      m_buffer[i].used = false;
-      m_buffer[i].age  = ++m_buffer_age;
-      break;
-    }
+    CLog::Log(LOGWARNING, "%s - return of invalid surface", __FUNCTION__);
   }
+
+  m_surface_context->ClearReference(surface);
 
   Release();
 }
@@ -979,46 +1104,12 @@ int CDecoder::GetBuffer(AVCodecContext *avctx, AVFrame *pic, int flags)
   if (!m_decoder)
     return -1;
 
-  if(avctx->coded_width  != m_format.SampleWidth
-  || avctx->coded_height != m_format.SampleHeight)
+  IDirect3DSurface9* surf = (IDirect3DSurface9*)(uintptr_t)pic->data[3];
+  surf = m_surface_context->GetFree(surf != 0 ? surf : NULL);
+  if (surf == NULL)
   {
-    Close();
-    if(!Open(avctx, avctx->pix_fmt, m_shared))
-    {
-      Close();
-      return -1;
-    }
-  }
-
-  int           count = 0;
-  SVideoBuffer* buf   = NULL;
-  for(unsigned i = 0; i < m_buffer_count; i++)
-  {
-    if(m_buffer[i].used)
-      count++;
-    else
-    {
-      if(!buf || buf->age > m_buffer[i].age)
-        buf = m_buffer+i;
-    }
-  }
-
-  if(count >= m_refs+2)
-  {
-    m_refs++;
-#if ALLOW_ADDING_SURFACES
-    if(!OpenDecoder())
-      return -1;
-    return GetBuffer(avctx, pic);
-#else
-    Close();
-    return -1;
-#endif
-  }
-
-  if(!buf)
-  {
-    CLog::Log(LOGERROR, "DXVA - unable to find new unused buffer");
+    CLog::Log(LOGERROR, "%s - no surface available - dec: %d, render: %d", __FUNCTION__);
+    m_state = DXVA_LOST;
     return -1;
   }
 
@@ -1030,8 +1121,8 @@ int CDecoder::GetBuffer(AVCodecContext *avctx, AVFrame *pic, int flags)
     pic->linesize[i] = 0;
   }
 
-  pic->data[0] = (uint8_t*)buf->surface;
-  pic->data[3] = (uint8_t*)buf->surface;
+  pic->data[0] = (uint8_t*)surf;
+  pic->data[3] = (uint8_t*)surf;
   AVBufferRef *buffer = av_buffer_create(pic->data[3], 0, RelBufferS, this, 0);
   if (!buffer)
   {
@@ -1039,7 +1130,6 @@ int CDecoder::GetBuffer(AVCodecContext *avctx, AVFrame *pic, int flags)
     return -1;
   }
   pic->buf[0] = buffer;
-  buf->used = true;
 
   Acquire();
 

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DXVA.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DXVA.cpp
@@ -1091,7 +1091,6 @@ void CDecoder::RelBuffer(uint8_t *data)
   {
     CLog::Log(LOGWARNING, "%s - return of invalid surface", __FUNCTION__);
   }
-
   m_surface_context->ClearReference(surface);
 
   Release();

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DXVA.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DXVA.h
@@ -107,6 +107,7 @@ private:
   UINT m_input_count;
   GUID *m_input_list;
   std::vector<CDecoder*> m_decoders;
+  bool m_atiWorkaround;
 };
 
 class CDecoder

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DXVA.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DXVA.h
@@ -60,6 +60,7 @@ public:
   void Reset();
   int Size();
   bool HasFree();
+  bool HasRefs();
 
 protected:
   std::map<IDirect3DSurface9*, int> m_state;
@@ -122,6 +123,7 @@ public:
   virtual void Close();
   virtual const std::string Name() { return "dxva2"; }
   virtual unsigned GetAllowedReferences();
+  virtual long Release();
 
   bool  OpenTarget(const GUID &guid);
   bool  OpenDecoder();
@@ -155,6 +157,7 @@ protected:
 
   CSurfaceContext*             m_surface_context;
   CDXVAContext*                m_dxva_context;
+  AVCodecContext*              m_avctx;
 
   unsigned int                 m_shared;
 

--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
@@ -186,7 +186,7 @@ bool CDVDPlayerVideo::OpenStream( CDVDStreamInfo &hint )
   unsigned int surfaces = 0;
   std::vector<ERenderFormat> formats;
 #ifdef HAS_VIDEO_PLAYBACK
-  surfaces = g_renderManager.GetProcessorSize();
+  surfaces = g_renderManager.GetOptimalBufferSize();
   formats  = g_renderManager.SupportedFormats();
 #endif
 


### PR DESCRIPTION
this is based on #5340 (to RMs shameless ping, this PRs need approval) 

I reworked broken video surface handling for DXVA. A video surface is available for reuse when renderer has released it, not by some faulty age calculation.
Adapted DXVA to buffering in renderer. Renderer controls buffers, not the embedded processor. This give much better control.
When ffmpeg calls GetFormat and still has refs to the old decoder, ffmpeg buffers need to be flushed, otherwise it can crash.
Fix broken deinterlacing for DXVA-HD with more than 1 past references. @afedchin your were right with the order of past surfaces you had originally. Not sure if I had a faulty driver that time I changed it. Would be nice if you could review this PR.

@ace20022 could you please do some tests on this?
