### PR TITLE
[pvr] fix unexpected jumping of selected item if notified by observable

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -64,6 +64,7 @@ CGUIWindowPVRBase::~CGUIWindowPVRBase(void)
 
 void CGUIWindowPVRBase::Notify(const Observable &obs, const ObservableMessage msg)
 {
+  UpdateSelectedItemPath();
   CGUIMessage m(GUI_MSG_REFRESH_LIST, GetID(), 0, msg);
   CApplicationMessenger::Get().SendGUIMessage(m);
 }
@@ -121,13 +122,7 @@ void CGUIWindowPVRBase::OnInitWindow(void)
 
 void CGUIWindowPVRBase::OnDeinitWindow(int nextWindowID)
 {
-  int selectedItem = m_viewControl.GetSelectedItem();
-  if (selectedItem > -1)
-  {
-    CFileItemPtr fileItem = m_vecItems->Get(selectedItem);
-    if (fileItem)
-      m_selectedItemPaths.at(m_bRadio) = fileItem->GetPath();
-  }
+  UpdateSelectedItemPath();
 }
 
 bool CGUIWindowPVRBase::OnMessage(CGUIMessage& message)
@@ -706,4 +701,15 @@ void CGUIWindowPVRBase::UpdateButtons(void)
 {
   CGUIMediaWindow::UpdateButtons();
   SET_CONTROL_LABEL(CONTROL_BTNCHANNELGROUPS, g_localizeStrings.Get(19141) + ": " + (m_group->GroupType() == PVR_GROUP_TYPE_INTERNAL ? g_localizeStrings.Get(19287) : m_group->GroupName()));
+}
+
+void CGUIWindowPVRBase::UpdateSelectedItemPath()
+{
+  int selectedItem = m_viewControl.GetSelectedItem();
+  if (selectedItem > -1)
+  {
+    CFileItemPtr fileItem = m_vecItems->Get(selectedItem);
+    if (fileItem)
+      m_selectedItemPaths.at(m_bRadio) = fileItem->GetPath();
+  }
 }

--- a/xbmc/pvr/windows/GUIWindowPVRBase.h
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.h
@@ -89,6 +89,7 @@ namespace PVR
     virtual void ShowEPGInfo(CFileItem *item);
     virtual void ShowRecordingInfo(CFileItem *item);
     virtual bool UpdateEpgForChannel(CFileItem *item);
+    virtual void UpdateSelectedItemPath();
 
     static std::map<bool, std::string> m_selectedItemPaths;
 

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -102,7 +102,7 @@ void CGUIWindowPVRGuide::GetContextButtons(int itemNumber, CContextButtons &butt
     buttons.Add(CONTEXT_BUTTON_MENU_HOOKS, 19195);      /* PVR client specific action */
 }
 
-void CGUIWindowPVRGuide::OnDeinitWindow(int nextWindowID)
+void CGUIWindowPVRGuide::UpdateSelectedItemPath()
 {
   if (m_viewControl.GetCurrentControl() == GUIDE_VIEW_TIMELINE)
   {
@@ -115,7 +115,7 @@ void CGUIWindowPVRGuide::OnDeinitWindow(int nextWindowID)
     }
   }
   else
-    CGUIWindowPVRBase::OnDeinitWindow(nextWindowID);
+    CGUIWindowPVRBase::UpdateSelectedItemPath();
 }
 
 bool CGUIWindowPVRGuide::OnAction(const CAction &action)

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.h
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.h
@@ -35,7 +35,6 @@ namespace PVR
     CGUIWindowPVRGuide(bool bRadio);
     virtual ~CGUIWindowPVRGuide(void);
 
-    void OnDeinitWindow(int nextWindowID);
     bool OnMessage(CGUIMessage& message);
     bool OnAction(const CAction &action);
     void GetContextButtons(int itemNumber, CContextButtons &buttons);
@@ -43,6 +42,9 @@ namespace PVR
     bool Update(const std::string &strDirectory, bool updateFilterPath = true);
     void ResetObservers(void);
     void UnregisterObservers(void);
+
+  protected:
+    void UpdateSelectedItemPath();
 
   private:
     bool SelectPlayingFile(void);


### PR DESCRIPTION
In some cases we refresh the entire item list if we get a notification from the observable. This updates m_selectedItemPaths in Notify() to prevent the selected item from jumping.

@Jalle19 or @opdenkamp for a second look .. thanks ;)
