### PR TITLE
[pvr] fix internal group loading

### DIFF
--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -256,7 +256,7 @@ int CPVRDatabase::Get(CPVRChannelGroupInternal &results)
       "channels.iClientChannelNumber, channels.iClientSubChannelNumber, channels.sInputFormat, channels.sInputFormat, channels.sStreamURL, channels.iEncryptionSystem, map_channelgroups_channels.iChannelNumber, channels.idEpg "
       "FROM map_channelgroups_channels "
       "LEFT JOIN channels ON channels.idChannel = map_channelgroups_channels.idChannel "
-      "WHERE map_channelgroups_channels.idGroup = %u", results.IsRadio() ? XBMC_INTERNAL_GROUP_RADIO : XBMC_INTERNAL_GROUP_TV);
+      "WHERE map_channelgroups_channels.idGroup = %u", results.IsRadio() ? PVR_INTERNAL_GROUP_ID_RADIO : PVR_INTERNAL_GROUP_ID_TV);
   if (ResultQuery(strQuery))
   {
     try

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -34,8 +34,8 @@ namespace EPG
 
 namespace PVR
 {
-#define XBMC_INTERNAL_GROUP_RADIO 1
-#define XBMC_INTERNAL_GROUP_TV    2
+#define PVR_INTERNAL_GROUP_ID_RADIO 1
+#define PVR_INTERNAL_GROUP_ID_TV    2
 
 #define PVR_GROUP_TYPE_DEFAULT      0
 #define PVR_GROUP_TYPE_INTERNAL     1

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
@@ -37,7 +37,7 @@ using namespace PVR;
 using namespace EPG;
 
 CPVRChannelGroupInternal::CPVRChannelGroupInternal(bool bRadio) :
-  CPVRChannelGroup(bRadio, bRadio ? XBMC_INTERNAL_GROUP_RADIO : XBMC_INTERNAL_GROUP_TV, g_localizeStrings.Get(19287))
+  CPVRChannelGroup(bRadio, bRadio ? PVR_INTERNAL_GROUP_ID_RADIO : PVR_INTERNAL_GROUP_ID_TV, g_localizeStrings.Get(19287))
 {
   m_iHiddenChannels = 0;
   m_iGroupType      = PVR_GROUP_TYPE_INTERNAL;

--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -216,21 +216,12 @@ bool CPVRChannelGroups::UpdateGroupsEntries(const CPVRChannelGroups &groups)
 
 bool CPVRChannelGroups::LoadUserDefinedChannelGroups(void)
 {
-  CPVRDatabase *database = GetPVRDatabase();
-  if (!database)
-    return false;
-
   bool bSyncWithBackends = CSettings::Get().GetBool("pvrmanager.syncchannelgroups");
 
   CSingleLock lock(m_critSection);
 
-  // load the other groups from the database
-  int iSize = m_groups.size();
-  database->Get(*this);
-  CLog::Log(LOGDEBUG, "PVR - %s - %d user defined %s channel groups fetched from the database", __FUNCTION__, (int) (m_groups.size() - iSize), m_bRadio ? "radio" : "TV");
-
   // load groups from the backends if the option is enabled
-  iSize = m_groups.size();
+  int iSize = m_groups.size();
   if (bSyncWithBackends)
   {
     GetGroupsFromClients();
@@ -271,6 +262,10 @@ bool CPVRChannelGroups::LoadUserDefinedChannelGroups(void)
 
 bool CPVRChannelGroups::Load(void)
 {
+  CPVRDatabase *database = GetPVRDatabase();
+  if (!database)
+    return false;
+
   CSingleLock lock(m_critSection);
 
   // remove previous contents
@@ -278,10 +273,16 @@ bool CPVRChannelGroups::Load(void)
 
   CLog::Log(LOGDEBUG, "PVR - %s - loading all %s channel groups", __FUNCTION__, m_bRadio ? "radio" : "TV");
 
-  // create and load the internal channel group
-  CPVRChannelGroupPtr internalChannels = CPVRChannelGroupPtr(new CPVRChannelGroupInternal(m_bRadio));
-  m_groups.push_back(internalChannels);
-  if (!internalChannels->Load())
+  // create the internal channel group
+  CPVRChannelGroupPtr internalGroup = CPVRChannelGroupPtr(new CPVRChannelGroupInternal(m_bRadio));
+  m_groups.push_back(internalGroup);
+
+  // load groups from the database
+  database->Get(*this);
+  CLog::Log(LOGDEBUG, "PVR - %s - %d %s groups fetched from the database", __FUNCTION__, m_groups.size(), m_bRadio ? "radio" : "TV");
+
+  // load channels of internal group
+  if (!internalGroup->Load())
   {
     CLog::Log(LOGERROR, "PVR - %s - failed to load channels", __FUNCTION__);
     return false;
@@ -296,7 +297,7 @@ bool CPVRChannelGroups::Load(void)
 
   // set the last played group as selected group at startup
   CPVRChannelGroupPtr lastPlayedGroup = GetLastPlayedGroup();
-  SetSelectedGroup(lastPlayedGroup ? lastPlayedGroup : internalChannels);
+  SetSelectedGroup(lastPlayedGroup ? lastPlayedGroup : internalGroup);
 
   CLog::Log(LOGDEBUG, "PVR - %s - %d %s channel groups loaded", __FUNCTION__, (int) m_groups.size(), m_bRadio ? "radio" : "TV");
 

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -700,7 +700,7 @@ bool CGUIWindowPVRBase::Update(const std::string &strDirectory, bool updateFilte
 void CGUIWindowPVRBase::UpdateButtons(void)
 {
   CGUIMediaWindow::UpdateButtons();
-  SET_CONTROL_LABEL(CONTROL_BTNCHANNELGROUPS, g_localizeStrings.Get(19141) + ": " + (m_group->GroupType() == PVR_GROUP_TYPE_INTERNAL ? g_localizeStrings.Get(19287) : m_group->GroupName()));
+  SET_CONTROL_LABEL(CONTROL_BTNCHANNELGROUPS, g_localizeStrings.Get(19141) + ": " + m_group->GroupName());
 }
 
 void CGUIWindowPVRBase::UpdateSelectedItemPath()


### PR DESCRIPTION
As we never load the internal groups from our TV database, changing the group name in our group manager has no effect. This fixes the loading of the internal channel groups.

Furthermore I'm currently working on the feature to hide different channel groups and determined that my changes to the internal groups within the database are never reflected in the code. That would be the next issue if we don't fix it now.

@opdenkamp for review would be much appreciated ;)
