### PR TITLE
Fix access after free

### DIFF
--- a/xbmc/LangInfo.h
+++ b/xbmc/LangInfo.h
@@ -20,6 +20,7 @@
  */
 
 #include "settings/lib/ISettingCallback.h"
+#include "utils/GlobalsHandling.h"
 
 #include <map>
 #include <string>
@@ -186,4 +187,5 @@ protected:
 };
 
 
-extern CLangInfo g_langInfo;
+XBMC_GLOBAL_REF(CLangInfo, g_langInfo);
+#define g_langInfo XBMC_GLOBAL_USE(CLangInfo)

--- a/xbmc/SystemGlobals.cpp
+++ b/xbmc/SystemGlobals.cpp
@@ -28,7 +28,6 @@
 #include "filesystem/DllLibCurl.h"
 #include "filesystem/DirectoryCache.h"
 #include "GUIPassword.h"
-#include "LangInfo.h"
 #include "utils/LangCodeExpander.h"
 #include "PartyModeManager.h"
 #include "PlayListPlayer.h"
@@ -53,7 +52,6 @@
 #endif
 
   CXBMCRenderManager g_renderManager;
-  CLangInfo          g_langInfo;
   CLangCodeExpander  g_LangCodeExpander;
   CLocalizeStrings   g_localizeStrings;
   CLocalizeStrings   g_localizeStringsTemp;

--- a/xbmc/interfaces/legacy/AddonClass.cpp
+++ b/xbmc/interfaces/legacy/AddonClass.cpp
@@ -72,7 +72,7 @@ namespace XBMCAddon
 
     long ct = AtomicDecrement((long*)&refs);
 #ifdef LOG_LIFECYCLE_EVENTS
-    CLog::Log(LOGDEBUG,"NEWADDON REFCNT decrementing to %ld on %s 0x%lx", GetClassname(), (long)(((void*)this)));
+    CLog::Log(LOGDEBUG,"NEWADDON REFCNT decrementing to %ld on %s 0x%lx", refs, GetClassname(), (long)(((void*)this)));
 #endif
     if(ct == 0)
     {

--- a/xbmc/interfaces/legacy/CallbackFunction.cpp
+++ b/xbmc/interfaces/legacy/CallbackFunction.cpp
@@ -22,5 +22,5 @@
 
 namespace XBMCAddon
 {
-  Callback::~Callback() { deallocating(); }
+  Callback::~Callback() { XBMC_TRACE; deallocating(); }
 }

--- a/xbmc/interfaces/legacy/CallbackFunction.h
+++ b/xbmc/interfaces/legacy/CallbackFunction.h
@@ -38,13 +38,13 @@ namespace XBMCAddon
   { 
   protected:
     AddonClass* addonClassObject;
-    Callback(AddonClass* _object) : addonClassObject(_object) {}
+    Callback(AddonClass* _object) : addonClassObject(_object) { XBMC_TRACE; }
 
   public:
     virtual void executeCallback() = 0;
     virtual ~Callback();
 
-    AddonClass* getObject() { return addonClassObject; }
+    AddonClass* getObject() { XBMC_TRACE; return addonClassObject; }
   };
 
   struct cb_null_type {};
@@ -70,9 +70,9 @@ namespace XBMCAddon
 
   public:
     CallbackFunction(M* object, MemberFunction method) : 
-      Callback(object), meth(method), obj(object) {}
+      Callback(object), meth(method), obj(object) { XBMC_TRACE; }
 
-    virtual ~CallbackFunction() { deallocating(); }
+    virtual ~CallbackFunction() { XBMC_TRACE; deallocating(); }
 
     virtual void executeCallback() { XBMC_TRACE; ((*obj).*(meth))(); }
   };
@@ -94,9 +94,9 @@ namespace XBMCAddon
   public:
     CallbackFunction(M* object, MemberFunction method, P1 parameter) : 
       Callback(object), meth(method), obj(object),
-      param(parameter) {}
+      param(parameter) { XBMC_TRACE; }
 
-    virtual ~CallbackFunction() { deallocating(); }
+    virtual ~CallbackFunction() { XBMC_TRACE; deallocating(); }
 
     virtual void executeCallback() { XBMC_TRACE; ((*obj).*(meth))(param); }
   };
@@ -119,9 +119,9 @@ namespace XBMCAddon
   public:
     CallbackFunction(M* object, MemberFunction method, P1* parameter) : 
       Callback(object), meth(method), obj(object),
-      param(parameter) {}
+      param(parameter) { XBMC_TRACE; }
 
-    virtual ~CallbackFunction() { deallocating(); }
+    virtual ~CallbackFunction() { XBMC_TRACE; deallocating(); }
 
     virtual void executeCallback() { XBMC_TRACE; ((*obj).*(meth))(param); }
   };
@@ -145,9 +145,9 @@ namespace XBMCAddon
   public:
     CallbackFunction(M* object, MemberFunction method, P1 parameter, P2 parameter2) : 
       Callback(object), meth(method), obj(object),
-      param1(parameter), param2(parameter2) {}
+      param1(parameter), param2(parameter2) { XBMC_TRACE; }
 
-    virtual ~CallbackFunction() { deallocating(); }
+    virtual ~CallbackFunction() { XBMC_TRACE; deallocating(); }
 
     virtual void executeCallback() { XBMC_TRACE; ((*obj).*(meth))(param1,param2); }
   };
@@ -172,9 +172,9 @@ namespace XBMCAddon
   public:
     CallbackFunction(M* object, MemberFunction method, P1 parameter, P2 parameter2, P3 parameter3) : 
       Callback(object), meth(method), obj(object),
-      param1(parameter), param2(parameter2), param3(parameter3) {}
+      param1(parameter), param2(parameter2), param3(parameter3) { XBMC_TRACE; }
 
-    virtual ~CallbackFunction() { deallocating(); }
+    virtual ~CallbackFunction() { XBMC_TRACE; deallocating(); }
 
     virtual void executeCallback() { XBMC_TRACE; ((*obj).*(meth))(param1,param2,param3); }
   };

--- a/xbmc/interfaces/legacy/CallbackHandler.cpp
+++ b/xbmc/interfaces/legacy/CallbackHandler.cpp
@@ -30,7 +30,7 @@ namespace XBMCAddon
   {
   public:
     AddonClass::Ref<Callback> cb;
-    RetardedAsynchCallbackHandler* handler;
+    AddonClass::Ref<RetardedAsynchCallbackHandler> handler;
     AsynchCallbackMessage(Callback* _cb, RetardedAsynchCallbackHandler* _handler) :
       cb(_cb), handler(_handler) { XBMC_TRACE; }
   };
@@ -62,7 +62,7 @@ namespace XBMCAddon
     {
       AddonClass::Ref<AsynchCallbackMessage> cur(*iter);
       {
-        if (cur->handler == this) // then this message is because of me
+        if (cur->handler.get() == this) // then this message is because of me
         {
           g_callQueue.erase(iter);
           iter = g_callQueue.begin();
@@ -103,7 +103,9 @@ namespace XBMCAddon
 #ifdef ENABLE_XBMC_TRACE_API
           CLog::Log(LOGDEBUG,"%sNEWADDON executing callback 0x%lx",_tg.getSpaces(),(long)(p->cb.get()));
 #endif
-          CSingleLock lock2(*(p->cb->getObject()));
+          AddonClass* obj = (p->cb->getObject());
+          AddonClass::Ref<AddonClass> ref(obj);
+          CSingleLock lock2(*obj);
           if (!p->cb->getObject()->isDeallocating())
           {
             try

--- a/xbmc/interfaces/legacy/Monitor.cpp
+++ b/xbmc/interfaces/legacy/Monitor.cpp
@@ -27,6 +27,7 @@ namespace XBMCAddon
   {
     Monitor::Monitor(): abortEvent(true)
     {
+      XBMC_TRACE;
       if (languageHook)
       {
         Id = languageHook->GetAddonId();
@@ -68,6 +69,7 @@ namespace XBMCAddon
 
     Monitor::~Monitor()
     {
+      XBMC_TRACE;
       deallocating();
       DelayedCallGuard dg(languageHook);
       // we're shutting down so unregister me.


### PR DESCRIPTION
The key to this fix are the changes in CallbackHandler.cpp. The rest are things I did along the way that (I think) make sense to keep.

There was a "use after free." The callback execution resulted in the deletion of the object the callback was on but there were references to that callback still being used in the callback handler (for example, the CriticalSection that's part of every AddonCall instance).

Personally I think this fix is pretty critical.
