### PR TITLE
Fix incorrect usage of S_IFDIR flag

### DIFF
--- a/xbmc/filesystem/AFPDirectory.cpp
+++ b/xbmc/filesystem/AFPDirectory.cpp
@@ -216,7 +216,7 @@ bool CAFPDirectory::GetDirectory(const CURL& url, CFileItemList &items)
                 continue;
               }
               path = linkUrl.Get();
-              bIsDir = info.st_mode & S_IFDIR;            
+              bIsDir = S_ISDIR(info.st_mode);            
             }
             lTimeDate = info.st_mtime;
             if (lTimeDate == 0) // if modification date is missing, use create date
@@ -319,6 +319,6 @@ bool CAFPDirectory::Exists(const CURL& url)
   if (gAfpConnection.GetImpl()->afp_wrap_getattr(gAfpConnection.GetVolume(), strFileName.c_str(), &info) != 0)
     return false;
 
-  return (info.st_mode & S_IFDIR) ? true : false;
+  return S_ISDIR(info.st_mode);
 }
 #endif

--- a/xbmc/filesystem/SMBDirectory.cpp
+++ b/xbmc/filesystem/SMBDirectory.cpp
@@ -158,7 +158,7 @@ bool CSMBDirectory::GetDirectory(const CURL& url, CFileItemList &items)
             else
               CLog::Log(LOGERROR, "Getting extended attributes for the share: '%s'\nunix_err:'%x' error: '%s'", CURL::GetRedacted(strFullName).c_str(), errno, strerror(errno));
 
-            bIsDir = (info.st_mode & S_IFDIR) ? true : false;
+            bIsDir = S_ISDIR(info.st_mode);
             lTimeDate = info.st_mtime;
             if(lTimeDate == 0) // if modification date is missing, use create date
               lTimeDate = info.st_ctime;
@@ -334,7 +334,7 @@ bool CSMBDirectory::Exists(const CURL& url2)
   if (smbc_stat(strFileName.c_str(), &info) != 0)
     return false;
 
-  return (info.st_mode & S_IFDIR) ? true : false;
+  return S_ISDIR(info.st_mode);
 }
 
 std::string CSMBDirectory::MountShare(const std::string &smbPath, const std::string &strType, const std::string &strName,

--- a/xbmc/filesystem/posix/PosixDirectory.cpp
+++ b/xbmc/filesystem/posix/PosixDirectory.cpp
@@ -76,7 +76,7 @@ bool CPosixDirectory::GetDirectory(const CURL& url, CFileItemList &items)
         bStat = true;
     }
 
-    if (entry->d_type == DT_DIR || (bStat && buffer.st_mode & S_IFDIR))
+    if (entry->d_type == DT_DIR || (bStat && S_ISDIR(buffer.st_mode)))
     {
       pItem->m_bIsFolder = true;
       URIUtils::AddSlashAtEnd(itemPath);


### PR DESCRIPTION
Discovered while working on PR #5309.
If `st.st_mode & S_IFDIR != 0` it doesn't mean that it's directory. Correct check is `S_ISDIR(st.st_mode)`.
