### PR TITLE
[fix] Closes #15423 Addon update deadlock due to race condition deleting CThread

### DIFF
--- a/xbmc/dialogs/GUIDialogBusy.cpp
+++ b/xbmc/dialogs/GUIDialogBusy.cpp
@@ -27,23 +27,27 @@
 
 class CBusyWaiter : public CThread
 {
+  boost::shared_ptr<CEvent>  m_done;
 public:
-  CBusyWaiter(IRunnable *runnable) : CThread(runnable, "waiting")
-  {
-  }
+  CBusyWaiter(IRunnable *runnable) : CThread(runnable, "waiting"), m_done(new CEvent()) {  }
   
   bool Wait()
   {
+    boost::shared_ptr<CEvent> e_done(m_done);
+
     Create();
-    return CGUIDialogBusy::WaitOnEvent(m_done);
+    return CGUIDialogBusy::WaitOnEvent(*e_done);
   }
-  
+
+  // 'this' is actually deleted from the thread where it's on the stack
   virtual void Process()
   {
+    boost::shared_ptr<CEvent> e_done(m_done);
+
     CThread::Process();
-    m_done.Set();
+    (*e_done).Set();
   }
-  CEvent  m_done;
+
 };
 
 bool CGUIDialogBusy::Wait(IRunnable *runnable)


### PR DESCRIPTION
Addon update deadlock due to race condition resulting from a CThread (CBusyWaiter) being on the stack getting destroyed prior to the actual thread exiting.

Something like this can happen any time a CThread is instantiated on the stack. This should probably be fixed with a longer term fix but this will address the immediate problem.

I'm on vacation ('holiday' for the EU inclined :-)  ) for the week (did this in the car on the way) so I might be slow to respond. @MartijnKaijser this is the deadlock I promised to fix. 
