### PR TITLE
add virtual seeking feature

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3967,6 +3967,22 @@ PlayBackRet CApplication::PlayFile(const CFileItem& item, bool bRestart)
 
   CPlayerOptions options;
 
+  if (item.HasProperty("VirtualSeek")){
+	  options.virtualSeek = item.GetProperty("VirtualSeek").asBoolean();
+  }
+  if (item.HasProperty("VirtualResume")){
+	  options.virtualResume = item.GetProperty("VirtualResume").asBoolean();
+  }
+  if (item.HasProperty("VirtualStartTime")){
+	  options.virtualStartTime = item.GetProperty("VirtualStartTime").asDouble(0LL);
+  }
+  if (item.HasProperty("VirtualTotalTime")){
+	  options.virtualTotalTime = item.GetProperty("VirtualTotalTime").asDouble(0LL);
+  }
+  if (item.HasProperty("VirtualDirectCacheLevelCalculation")){
+	  options.virtualDirectCacheLevelCalculation = item.GetProperty("VirtualDirectCacheLevelCalculation").asBoolean();
+  }
+
   if( item.HasProperty("StartPercent") )
   {
     double fallback = 0.0f;

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3875,8 +3875,11 @@ PlayBackRet CApplication::PlayFile(const CFileItem& item, bool bRestart)
   {
     SaveFileState(true);
 
-    // Switch to default options
-    CMediaSettings::Get().GetCurrentVideoSettings() = CMediaSettings::Get().GetDefaultVideoSettings();
+    if (!item.HasProperty("VirtualSeekProcess") || !item.GetProperty("VirtualSeekProcess").asBoolean())
+    {
+      // Switch to default options
+      CMediaSettings::Get().GetCurrentVideoSettings() = CMediaSettings::Get().GetDefaultVideoSettings();
+    }
     // see if we have saved options in the database
 
     m_pPlayer->SetPlaySpeed(1, g_application.m_muted);
@@ -4014,8 +4017,10 @@ PlayBackRet CApplication::PlayFile(const CFileItem& item, bool bRestart)
   else
   {
     options.starttime = item.m_lStartOffset / 75.0;
-    LoadVideoSettings(item.GetPath());
-
+    if (!item.HasProperty("VirtualSeekProcess") || !item.GetProperty("VirtualSeekProcess").asBoolean())
+    {
+      LoadVideoSettings(item.GetPath());
+    }
     if (item.IsVideo())
     {
       // open the d/b and retrieve the bookmarks for the current movie

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3967,20 +3967,25 @@ PlayBackRet CApplication::PlayFile(const CFileItem& item, bool bRestart)
 
   CPlayerOptions options;
 
-  if (item.HasProperty("VirtualSeek")){
-	  options.virtualSeek = item.GetProperty("VirtualSeek").asBoolean();
+  if (item.HasProperty("VirtualSeek"))
+  {
+    options.virtualSeek = item.GetProperty("VirtualSeek").asBoolean();
   }
-  if (item.HasProperty("VirtualResume")){
-	  options.virtualResume = item.GetProperty("VirtualResume").asBoolean();
+  if (item.HasProperty("VirtualResume"))
+  {
+    options.virtualResume = item.GetProperty("VirtualResume").asBoolean();
   }
-  if (item.HasProperty("VirtualStartTime")){
-	  options.virtualStartTime = item.GetProperty("VirtualStartTime").asDouble(0LL);
+  if (item.HasProperty("VirtualStartTime"))
+  {
+    options.virtualStartTime = item.GetProperty("VirtualStartTime").asDouble(0LL);
   }
-  if (item.HasProperty("VirtualTotalTime")){
-	  options.virtualTotalTime = item.GetProperty("VirtualTotalTime").asDouble(0LL);
+  if (item.HasProperty("VirtualTotalTime"))
+  {
+    options.virtualTotalTime = item.GetProperty("VirtualTotalTime").asDouble(0LL);
   }
-  if (item.HasProperty("VirtualDirectCacheLevelCalculation")){
-	  options.virtualDirectCacheLevelCalculation = item.GetProperty("VirtualDirectCacheLevelCalculation").asBoolean();
+  if (item.HasProperty("VirtualDirectCacheLevelCalculation"))
+  {
+    options.virtualDirectCacheLevelCalculation = item.GetProperty("VirtualDirectCacheLevelCalculation").asBoolean();
   }
 
   if( item.HasProperty("StartPercent") )

--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -87,8 +87,8 @@ void CApplicationPlayer::CreatePlayer(PLAYERCOREID newCore, IPlayerCallback& cal
   if (!m_pPlayer)
   {
     m_eCurrentPlayer = newCore;
-	m_playerCallbacks = &callback;
-	m_pPlayer.reset(CPlayerCoreFactory::Get().CreatePlayer(newCore, callback));
+    m_playerCallbacks = &callback;
+    m_pPlayer.reset(CPlayerCoreFactory::Get().CreatePlayer(newCore, callback));
   }
 }
 
@@ -100,11 +100,12 @@ PlayBackRet CApplicationPlayer::OpenFile(const CFileItem& item, const CPlayerOpt
   {
     // op seq for detect cancel (CloseFile be called or OpenFile be called again) during OpenFile.
     unsigned int startingSeq = ++m_iPlayerOPSeq;
-	m_playerOptions = options;
-	if (m_playerOptions.virtualSeek){
-		m_playerOptions.starttime = 0;
-		m_playerOptions.startpercent = 0;
-	}
+    m_playerOptions = options;
+    if (m_playerOptions.virtualSeek)
+    {
+      m_playerOptions.starttime = 0;
+      m_playerOptions.startpercent = 0;
+    }
 	iResult = player->OpenFile(item, m_playerOptions) ? PLAYBACK_OK : PLAYBACK_FAIL;
     // check whether the OpenFile was canceled by either CloseFile or another OpenFile.
     if (m_iPlayerOPSeq != startingSeq)
@@ -186,11 +187,12 @@ bool CApplicationPlayer::IsPlayingVideo() const
 void CApplicationPlayer::Pause()
 {
   boost::shared_ptr<IPlayer> player = GetInternal();
-  if (player){
-	  if (m_playerOptions.virtualResume && IsPausedPlayback())
-	  	  SeekTime(-10);
-	  else
-		  player->Pause();
+  if (player)
+  {
+    if (m_playerOptions.virtualResume && IsPausedPlayback())
+      SeekTime(-10);
+    else
+      player->Pause();
   }
 }
 
@@ -217,46 +219,50 @@ void CApplicationPlayer::SetVolume(float volume)
 void CApplicationPlayer::Seek(bool bPlus, bool bLargeStep, bool bChapterOverride)
 {
   boost::shared_ptr<IPlayer> player = GetInternal();
-  if (player){
-	  if (m_playerOptions.virtualSeek){
-		  int64_t seek;
-		  if (g_advancedSettings.m_videoUseTimeSeeking && GetTotalTime() > 2000 * g_advancedSettings.m_videoTimeSeekForwardBig)
-		  {
-			  if (bLargeStep)
-				  seek = bPlus ? g_advancedSettings.m_videoTimeSeekForwardBig : g_advancedSettings.m_videoTimeSeekBackwardBig;
-			  else
-				  seek = bPlus ? g_advancedSettings.m_videoTimeSeekForward : g_advancedSettings.m_videoTimeSeekBackward;
-			  seek *= 1000;
-			  seek += GetTime();
-		  }
-		  else
-		  {
-			  int percent;
-			  if (bLargeStep)
-				  percent = bPlus ? g_advancedSettings.m_videoPercentSeekForwardBig : g_advancedSettings.m_videoPercentSeekBackwardBig;
-			  else
-				  percent = bPlus ? g_advancedSettings.m_videoPercentSeekForward : g_advancedSettings.m_videoPercentSeekBackward;
-			  seek = (int64_t)(GetTotalTime()*(GetPercentage() + percent) / 100);
-		  }
-		  int64_t time = GetTime();
-		  m_playerCallbacks->OnPlayBackSeek((int)seek, (int)(seek - time));
-	  }
-	  else
-		  player->Seek(bPlus, bLargeStep, bChapterOverride);
+  if (player)
+  {
+    if (m_playerOptions.virtualSeek)
+    {
+      int64_t seek;
+      if (g_advancedSettings.m_videoUseTimeSeeking && GetTotalTime() > 2000 * g_advancedSettings.m_videoTimeSeekForwardBig)
+      {
+        if (bLargeStep)
+          seek = bPlus ? g_advancedSettings.m_videoTimeSeekForwardBig : g_advancedSettings.m_videoTimeSeekBackwardBig;
+        else
+          seek = bPlus ? g_advancedSettings.m_videoTimeSeekForward : g_advancedSettings.m_videoTimeSeekBackward;
+        seek *= 1000;
+        seek += GetTime();
+      }
+      else
+      {
+        int percent;
+        if (bLargeStep)
+          percent = bPlus ? g_advancedSettings.m_videoPercentSeekForwardBig : g_advancedSettings.m_videoPercentSeekBackwardBig;
+        else
+          percent = bPlus ? g_advancedSettings.m_videoPercentSeekForward : g_advancedSettings.m_videoPercentSeekBackward;
+        seek = (int64_t)(GetTotalTime()*(GetPercentage() + percent) / 100);
+      }
+      int64_t time = GetTime();
+      m_playerCallbacks->OnPlayBackSeek((int)seek, (int)(seek - time));
+    }
+    else
+      player->Seek(bPlus, bLargeStep, bChapterOverride);
   }
-  
+
 }
 
 void CApplicationPlayer::SeekPercentage(float fPercent)
 {
   boost::shared_ptr<IPlayer> player = GetInternal();
-  if (player){
-	  if (m_playerOptions.virtualSeek){
-		  int64_t iTotalTime = GetTotalTime();
-		  SeekTime((int64_t)(iTotalTime * fPercent / 100));
-	  }
-	  else
-		player->SeekPercentage(fPercent);
+  if (player)
+  {
+    if (m_playerOptions.virtualSeek)
+    {
+      int64_t iTotalTime = GetTotalTime();
+      SeekTime((int64_t)(iTotalTime * fPercent / 100));
+    }
+    else
+      player->SeekPercentage(fPercent);
   }
 }
 
@@ -281,13 +287,15 @@ bool CApplicationPlayer::SeekScene(bool bPlus)
 void CApplicationPlayer::SeekTime(int64_t iTime)
 {
   boost::shared_ptr<IPlayer> player = GetInternal();
-  if (player){
-	  if (m_playerOptions.virtualSeek){
-		  int seekOffset = (int)(iTime - GetTime());		  
-		  m_playerCallbacks->OnPlayBackSeek((int)iTime, seekOffset);
-	  }
-	  else
-		player->SeekTime(iTime);
+  if (player)
+  {
+    if (m_playerOptions.virtualSeek)
+    {
+      int seekOffset = (int)(iTime - GetTime());
+      m_playerCallbacks->OnPlayBackSeek((int)iTime, seekOffset);
+    }
+    else
+      player->SeekTime(iTime);
   }
 }
 
@@ -303,12 +311,14 @@ std::string CApplicationPlayer::GetPlayingTitle()
 int64_t CApplicationPlayer::GetTime() const
 {
   boost::shared_ptr<IPlayer> player = GetInternal();
-  if (player){
-	  if (m_playerOptions.virtualSeek){
-		  return player->GetTime() + m_playerOptions.virtualStartTime * 1000;
-	  }
-	  else
-		return player->GetTime();
+  if (player)
+  {
+    if (m_playerOptions.virtualSeek)
+    {
+      return player->GetTime() + m_playerOptions.virtualStartTime * 1000;
+    }
+    else
+      return player->GetTime();
   }
   else
     return 0;
@@ -418,7 +428,8 @@ TextCacheStruct_t* CApplicationPlayer::GetTeletextCache()
 int64_t CApplicationPlayer::GetTotalTime() const
 {
   boost::shared_ptr<IPlayer> player = GetInternal();
-  if (player){
+  if (player)
+  {
 	  if (m_playerOptions.virtualSeek)
 		  return m_playerOptions.virtualTotalTime;
 	  else
@@ -431,12 +442,14 @@ int64_t CApplicationPlayer::GetTotalTime() const
 float CApplicationPlayer::GetPercentage() const
 {
   boost::shared_ptr<IPlayer> player = GetInternal();
-  if (player){
-	  if (m_playerOptions.virtualSeek){
-		  return GetTime() * 100 / (float)GetTotalTime();
-	  }
-	  else
-		return player->GetPercentage();
+  if (player)
+  {
+    if (m_playerOptions.virtualSeek)
+    {
+      return GetTime() * 100 / (float)GetTotalTime();
+    }
+    else
+      return player->GetPercentage();
   }
   else
     return 0.0;

--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -22,6 +22,7 @@
 #include "cores/IPlayer.h"
 #include "Application.h"
 #include "settings/MediaSettings.h"
+#include "settings/AdvancedSettings.h"
 
 CApplicationPlayer::CApplicationPlayer()
 {
@@ -86,7 +87,8 @@ void CApplicationPlayer::CreatePlayer(PLAYERCOREID newCore, IPlayerCallback& cal
   if (!m_pPlayer)
   {
     m_eCurrentPlayer = newCore;
-    m_pPlayer.reset(CPlayerCoreFactory::Get().CreatePlayer(newCore, callback));
+	m_playerCallbacks = &callback;
+	m_pPlayer.reset(CPlayerCoreFactory::Get().CreatePlayer(newCore, callback));
   }
 }
 
@@ -98,8 +100,12 @@ PlayBackRet CApplicationPlayer::OpenFile(const CFileItem& item, const CPlayerOpt
   {
     // op seq for detect cancel (CloseFile be called or OpenFile be called again) during OpenFile.
     unsigned int startingSeq = ++m_iPlayerOPSeq;
-
-    iResult = player->OpenFile(item, options) ? PLAYBACK_OK : PLAYBACK_FAIL;
+	m_playerOptions = options;
+	if (m_playerOptions.virtualSeek){
+		m_playerOptions.starttime = 0;
+		m_playerOptions.startpercent = 0;
+	}
+	iResult = player->OpenFile(item, m_playerOptions) ? PLAYBACK_OK : PLAYBACK_FAIL;
     // check whether the OpenFile was canceled by either CloseFile or another OpenFile.
     if (m_iPlayerOPSeq != startingSeq)
       iResult = PLAYBACK_CANCELED;
@@ -180,8 +186,12 @@ bool CApplicationPlayer::IsPlayingVideo() const
 void CApplicationPlayer::Pause()
 {
   boost::shared_ptr<IPlayer> player = GetInternal();
-  if (player)
-    player->Pause();
+  if (player){
+	  if (m_playerOptions.virtualResume && IsPausedPlayback())
+	  	  SeekTime(-10);
+	  else
+		  player->Pause();
+  }
 }
 
 bool CApplicationPlayer::ControlsVolume() const
@@ -207,15 +217,47 @@ void CApplicationPlayer::SetVolume(float volume)
 void CApplicationPlayer::Seek(bool bPlus, bool bLargeStep, bool bChapterOverride)
 {
   boost::shared_ptr<IPlayer> player = GetInternal();
-  if (player)
-    player->Seek(bPlus, bLargeStep, bChapterOverride);
+  if (player){
+	  if (m_playerOptions.virtualSeek){
+		  int64_t seek;
+		  if (g_advancedSettings.m_videoUseTimeSeeking && GetTotalTime() > 2000 * g_advancedSettings.m_videoTimeSeekForwardBig)
+		  {
+			  if (bLargeStep)
+				  seek = bPlus ? g_advancedSettings.m_videoTimeSeekForwardBig : g_advancedSettings.m_videoTimeSeekBackwardBig;
+			  else
+				  seek = bPlus ? g_advancedSettings.m_videoTimeSeekForward : g_advancedSettings.m_videoTimeSeekBackward;
+			  seek *= 1000;
+			  seek += GetTime();
+		  }
+		  else
+		  {
+			  int percent;
+			  if (bLargeStep)
+				  percent = bPlus ? g_advancedSettings.m_videoPercentSeekForwardBig : g_advancedSettings.m_videoPercentSeekBackwardBig;
+			  else
+				  percent = bPlus ? g_advancedSettings.m_videoPercentSeekForward : g_advancedSettings.m_videoPercentSeekBackward;
+			  seek = (int64_t)(GetTotalTime()*(GetPercentage() + percent) / 100);
+		  }
+		  int64_t time = GetTime();
+		  m_playerCallbacks->OnPlayBackSeek((int)seek, (int)(seek - time));
+	  }
+	  else
+		  player->Seek(bPlus, bLargeStep, bChapterOverride);
+  }
+  
 }
 
 void CApplicationPlayer::SeekPercentage(float fPercent)
 {
   boost::shared_ptr<IPlayer> player = GetInternal();
-  if (player)
-    player->SeekPercentage(fPercent);
+  if (player){
+	  if (m_playerOptions.virtualSeek){
+		  int64_t iTotalTime = GetTotalTime();
+		  SeekTime((int64_t)(iTotalTime * fPercent / 100));
+	  }
+	  else
+		player->SeekPercentage(fPercent);
+  }
 }
 
 bool CApplicationPlayer::IsPassthrough() const
@@ -227,20 +269,26 @@ bool CApplicationPlayer::IsPassthrough() const
 bool CApplicationPlayer::CanSeek()
 {
   boost::shared_ptr<IPlayer> player = GetInternal();
-  return (player && player->CanSeek());
+  return (player && (player->CanSeek() || m_playerOptions.virtualSeek));
 }
 
 bool CApplicationPlayer::SeekScene(bool bPlus)
 {
   boost::shared_ptr<IPlayer> player = GetInternal();
-  return (player && player->SeekScene(bPlus));
+  return (player && !m_playerOptions.virtualSeek && player->SeekScene(bPlus));
 }
 
 void CApplicationPlayer::SeekTime(int64_t iTime)
 {
   boost::shared_ptr<IPlayer> player = GetInternal();
-  if (player)
-    player->SeekTime(iTime);
+  if (player){
+	  if (m_playerOptions.virtualSeek){
+		  int seekOffset = (int)(iTime - GetTime());		  
+		  m_playerCallbacks->OnPlayBackSeek((int)iTime, seekOffset);
+	  }
+	  else
+		player->SeekTime(iTime);
+  }
 }
 
 std::string CApplicationPlayer::GetPlayingTitle()
@@ -255,8 +303,13 @@ std::string CApplicationPlayer::GetPlayingTitle()
 int64_t CApplicationPlayer::GetTime() const
 {
   boost::shared_ptr<IPlayer> player = GetInternal();
-  if (player)
-    return player->GetTime();
+  if (player){
+	  if (m_playerOptions.virtualSeek){
+		  return player->GetTime() + m_playerOptions.virtualStartTime * 1000;
+	  }
+	  else
+		return player->GetTime();
+  }
   else
     return 0;
 }
@@ -365,8 +418,12 @@ TextCacheStruct_t* CApplicationPlayer::GetTeletextCache()
 int64_t CApplicationPlayer::GetTotalTime() const
 {
   boost::shared_ptr<IPlayer> player = GetInternal();
-  if (player)
-    return player->GetTotalTime();
+  if (player){
+	  if (m_playerOptions.virtualSeek)
+		  return m_playerOptions.virtualTotalTime;
+	  else
+		return player->GetTotalTime();
+  }
   else
     return 0;
 }
@@ -374,8 +431,13 @@ int64_t CApplicationPlayer::GetTotalTime() const
 float CApplicationPlayer::GetPercentage() const
 {
   boost::shared_ptr<IPlayer> player = GetInternal();
-  if (player)
-    return player->GetPercentage();
+  if (player){
+	  if (m_playerOptions.virtualSeek){
+		  return GetTime() * 100 / (float)GetTotalTime();
+	  }
+	  else
+		return player->GetPercentage();
+  }
   else
     return 0.0;
 }
@@ -638,7 +700,7 @@ void CApplicationPlayer::SetPlaySpeed(int iSpeed, bool bApplicationMuted)
     return ;
   if (m_iPlaySpeed == iSpeed)
     return ;
-  if (!CanSeek())
+  if (!CanSeek() || m_playerOptions.virtualSeek)
     return;
   if (IsPaused())
   {

--- a/xbmc/ApplicationPlayer.h
+++ b/xbmc/ApplicationPlayer.h
@@ -24,6 +24,7 @@
 #include "threads/SingleLock.h"
 #include "threads/SystemClock.h"
 #include "cores/playercorefactory/PlayerCoreFactory.h"
+#include "cores/IPlayer.h"
 
 typedef enum
 {
@@ -59,7 +60,10 @@ class CApplicationPlayer
   int m_iAudioStream;
   XbmcThreads::EndTime m_subtitleStreamUpdate;
   int m_iSubtitleStream;
-  
+  CPlayerOptions m_playerOptions;
+  IPlayerCallback* m_playerCallbacks;
+
+
 public:
   CApplicationPlayer();
 

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -47,6 +47,7 @@ public:
     fullscreen = false;
     video_only = false;
     virtualSeek = false;
+    virtualResume = false;
     virtualDirectCacheLevelCalculation = false;
     virtualStartTime = 0LL;
     virtualTotalTime = 0LL;

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -46,10 +46,10 @@ public:
     identify = false;
     fullscreen = false;
     video_only = false;
-	virtualSeek = false;
-	virtualDirectCacheLevelCalculation = false;
-	virtualStartTime = 0LL;
-	virtualTotalTime = 0LL;
+    virtualSeek = false;
+    virtualDirectCacheLevelCalculation = false;
+    virtualStartTime = 0LL;
+    virtualTotalTime = 0LL;
 	
   }
   double  starttime; /* start time in seconds */

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -46,6 +46,11 @@ public:
     identify = false;
     fullscreen = false;
     video_only = false;
+	virtualSeek = false;
+	virtualDirectCacheLevelCalculation = false;
+	virtualStartTime = 0LL;
+	virtualTotalTime = 0LL;
+	
   }
   double  starttime; /* start time in seconds */
   double  startpercent; /* start time in percent */  
@@ -53,6 +58,11 @@ public:
   std::string state;  /* potential playerstate to restore to */
   bool    fullscreen; /* player is allowed to switch to fullscreen */
   bool    video_only; /* player is not allowed to play audio streams, video streams only */
+  bool    virtualSeek; /* stream must use virtual seeking*/
+  bool    virtualResume; /* using  seek for resumming of stream after pause*/
+  bool    virtualDirectCacheLevelCalculation; /* calculate cache level for streams with virtual seeking*/
+  double  virtualTotalTime; /* total time in seconds for stream with virtual seeking*/
+  double  virtualStartTime; /* start time in seconds for stream with virtual seeking*/
 };
 
 class CFileItem;

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -1687,11 +1687,14 @@ bool CDVDPlayer::GetCachingTimes(double& level, double& delay, double& offset)
   double cache_need  = std::max(0.0, remain - play_left / cache_sbp); /* bytes needed until play_left == cache_left */
 
   delay = cache_left - play_left;
-
-  if (full && (currate < maxrate) )
-    level = -1.0;                          /* buffer is full & our read rate is too low  */
+  if (m_PlayerOptions.virtualDirectCacheLevelCalculation && m_PlayerOptions.virtualSeek){
+	  level = std::max(0.0,std::max(m_dvdPlayerVideo->GetLevel(), m_dvdPlayerAudio->GetLevel())/100.0);
+  }
   else
-    level = (cached + queued) / (cache_need + queued);
+	  if (full && (currate < maxrate) )
+		level = -1.0;                          /* buffer is full & our read rate is too low  */
+	  else
+		level = (cached + queued) / (cache_need + queued);
 
   return true;
 }

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -1687,14 +1687,17 @@ bool CDVDPlayer::GetCachingTimes(double& level, double& delay, double& offset)
   double cache_need  = std::max(0.0, remain - play_left / cache_sbp); /* bytes needed until play_left == cache_left */
 
   delay = cache_left - play_left;
-  if (m_PlayerOptions.virtualDirectCacheLevelCalculation && m_PlayerOptions.virtualSeek){
-	  level = std::max(0.0,std::max(m_dvdPlayerVideo->GetLevel(), m_dvdPlayerAudio->GetLevel())/100.0);
+  if (m_PlayerOptions.virtualDirectCacheLevelCalculation && m_PlayerOptions.virtualSeek)
+  {
+    level = std::max(0.0, std::max(m_dvdPlayerVideo->GetLevel(), m_dvdPlayerAudio->GetLevel()) / 100.0);
   }
   else
-	  if (full && (currate < maxrate) )
-		level = -1.0;                          /* buffer is full & our read rate is too low  */
-	  else
-		level = (cached + queued) / (cache_need + queued);
+  {
+    if (full && (currate < maxrate))
+      level = -1.0;                          /* buffer is full & our read rate is too low  */
+    else
+      level = (cached + queued) / (cache_need + queued);
+  }
 
   return true;
 }

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -2360,7 +2360,10 @@ void CDVDPlayer::HandleMessages()
             CloseStream(m_CurrentAudio, false);
             OpenStream(m_CurrentAudio, st.id, st.source);
             AdaptForcedSubtitles();
-            m_messenger.Put(new CDVDMsgPlayerSeek((int) GetTime(), true, true, true, true, true));
+            if (!m_PlayerOptions.virtualSeek)
+            {
+              m_messenger.Put(new CDVDMsgPlayerSeek((int)GetTime(), true, true, true, true, true));
+            }
           }
         }
       }


### PR DESCRIPTION
Adding  virtual seeking for all players. The plugins can controll seeking (open other stream) and times of stream.(For some IPTV archives)

The plugin must set Properties of playing item and implement player callbacks
