### PR TITLE
[pvr] adds support for hiding groups

### DIFF
--- a/addons/library.xbmc.gui/libXBMC_gui.h
+++ b/addons/library.xbmc.gui/libXBMC_gui.h
@@ -36,7 +36,7 @@ typedef void* GUIHANDLE;
 #endif
 
 /* current ADDONGUI API version */
-#define XBMC_GUI_API_VERSION "5.3.0"
+#define XBMC_GUI_API_VERSION "5.5.0"
 
 /* min. ADDONGUI API version */
 #define XBMC_GUI_MIN_API_VERSION "5.3.0"

--- a/addons/skin.confluence/720p/DialogPVRGroupManager.xml
+++ b/addons/skin.confluence/720p/DialogPVRGroupManager.xml
@@ -429,6 +429,12 @@
 						<include>ButtonInfoDialogsCommonValues</include>
 						<label>31504</label>
 					</control>
+					<control type="radiobutton" id="25">
+						<description>Hide Group</description>
+						<width>200</width>
+						<include>ButtonInfoDialogsCommonValues</include>
+						<label>19289</label>
+					</control>
 					<control type="button" id="28">
 						<description>Delete Group</description>
 						<width>200</width>

--- a/addons/xbmc.gui/addon.xml
+++ b/addons/xbmc.gui/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="xbmc.gui" version="5.4.0" provider-name="Team-Kodi">
+<addon id="xbmc.gui" version="5.5.0" provider-name="Team-Kodi">
   <backwards-compatibility abi="5.3.0"/>
   <requires>
     <import addon="xbmc.core" version="0.1.0"/>

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -8839,7 +8839,13 @@ msgctxt "#19288"
 msgid "Foreground"
 msgstr ""
 
-#empty strings from id 19289 to 19498
+#. Label for button to hide a group in the group manager
+#: addons/skin/confluence
+msgctxt "#19289"
+msgid "Hide group"
+msgstr ""
+
+#empty strings from id 19290 to 19498
 
 #: xbmc/epg/Epg.cpp
 msgctxt "#19499"

--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -106,7 +106,8 @@ void CPVRDatabase::CreateTables()
         "bIsRadio        bool, "
         "iGroupType      integer, "
         "sName           varchar(64), "
-        "iLastWatched    integer"
+        "iLastWatched    integer, "
+        "bIsHidden       bool"
       ")"
   );
 
@@ -187,6 +188,9 @@ void CPVRDatabase::UpdateTables(int iVersion)
     m_pDS->exec("ALTER TABLE map_channelgroups_channels ADD iSubChannelNumber integer");
     m_pDS->exec("UPDATE map_channelgroups_channels SET iSubChannelNumber = 0");
   }
+
+  if (iVersion < 27)
+    m_pDS->exec("ALTER TABLE channelgroups ADD bIsHidden bool");
 }
 
 int CPVRDatabase::GetLastChannelId(void)
@@ -507,6 +511,7 @@ bool CPVRDatabase::Get(CPVRChannelGroups &results)
         CPVRChannelGroup data(m_pDS->fv("bIsRadio").get_asBool(), m_pDS->fv("idGroup").get_asInt(), m_pDS->fv("sName").get_asString());
         data.SetGroupType(m_pDS->fv("iGroupType").get_asInt());
         data.SetLastWatched((time_t) m_pDS->fv("iLastWatched").get_asInt());
+        data.SetHidden(m_pDS->fv("bIsHidden").get_asBool());
         results.Update(data);
 
         CLog::Log(LOGDEBUG, "PVR - %s - group '%s' loaded from the database", __FUNCTION__, data.GroupName().c_str());
@@ -701,11 +706,11 @@ bool CPVRDatabase::Persist(CPVRChannelGroup &group)
 
     /* insert a new entry when this is a new group, or replace the existing one otherwise */
     if (group.GroupID() <= 0)
-      strQuery = PrepareSQL("INSERT INTO channelgroups (bIsRadio, iGroupType, sName, iLastWatched) VALUES (%i, %i, '%s', %u)",
-          (group.IsRadio() ? 1 :0), group.GroupType(), group.GroupName().c_str(), group.LastWatched());
+      strQuery = PrepareSQL("INSERT INTO channelgroups (bIsRadio, iGroupType, sName, iLastWatched, bIsHidden) VALUES (%i, %i, '%s', %u, %i)",
+          (group.IsRadio() ? 1 :0), group.GroupType(), group.GroupName().c_str(), group.LastWatched(), group.IsHidden());
     else
-      strQuery = PrepareSQL("REPLACE INTO channelgroups (idGroup, bIsRadio, iGroupType, sName, iLastWatched) VALUES (%i, %i, %i, '%s', %u)",
-          group.GroupID(), (group.IsRadio() ? 1 :0), group.GroupType(), group.GroupName().c_str(), group.LastWatched());
+      strQuery = PrepareSQL("REPLACE INTO channelgroups (idGroup, bIsRadio, iGroupType, sName, iLastWatched, bIsHidden) VALUES (%i, %i, %i, '%s', %u, %i)",
+          group.GroupID(), (group.IsRadio() ? 1 :0), group.GroupType(), group.GroupName().c_str(), group.LastWatched(), group.IsHidden());
 
     bReturn = ExecuteQuery(strQuery);
 

--- a/xbmc/pvr/PVRDatabase.h
+++ b/xbmc/pvr/PVRDatabase.h
@@ -59,7 +59,7 @@ namespace PVR
      * @brief Get the minimal database version that is required to operate correctly.
      * @return The minimal database version.
      */
-    virtual int GetSchemaVersion() const { return 26; };
+    virtual int GetSchemaVersion() const { return 27; };
 
     /*!
      * @brief Get the default sqlite database filename.

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -54,7 +54,8 @@ CPVRChannelGroup::CPVRChannelGroup(void) :
     m_bUsingBackendChannelOrder(false),
     m_bSelectedGroup(false),
     m_bPreventSortAndRenumber(false),
-    m_iLastWatched(0)
+    m_iLastWatched(0),
+    m_bHidden(false)
 {
 }
 
@@ -68,7 +69,8 @@ CPVRChannelGroup::CPVRChannelGroup(bool bRadio, unsigned int iGroupId, const std
     m_bUsingBackendChannelOrder(false),
     m_bSelectedGroup(false),
     m_bPreventSortAndRenumber(false),
-    m_iLastWatched(0)
+    m_iLastWatched(0),
+    m_bHidden(false)
 {
 }
 
@@ -82,7 +84,8 @@ CPVRChannelGroup::CPVRChannelGroup(const PVR_CHANNEL_GROUP &group) :
     m_bUsingBackendChannelOrder(false),
     m_bSelectedGroup(false),
     m_bPreventSortAndRenumber(false),
-    m_iLastWatched(0)
+    m_iLastWatched(0),
+    m_bHidden(false)
 {
 }
 
@@ -115,6 +118,7 @@ CPVRChannelGroup::CPVRChannelGroup(const CPVRChannelGroup &group)
   m_bUsingBackendChannelOrder   = group.m_bUsingBackendChannelOrder;
   m_bUsingBackendChannelNumbers = group.m_bUsingBackendChannelNumbers;
   m_iLastWatched                = group.m_iLastWatched;
+  m_bHidden                     = group.m_bHidden;
 
   for (int iPtr = 0; iPtr < group.Size(); iPtr++)
     m_members.push_back(group.m_members.at(iPtr));
@@ -1357,4 +1361,21 @@ bool CPVRChannelGroup::CreateChannelEpgs(bool bForce /* = false */)
 {
   /* used only by internal channel groups */
   return true;
+}
+
+void CPVRChannelGroup::SetHidden(bool bHidden)
+{
+  CSingleLock lock(m_critSection);
+
+  if (m_bHidden != bHidden)
+  {
+    m_bHidden = bHidden;
+    m_bChanged = true;
+  }
+}
+
+bool CPVRChannelGroup::IsHidden(void) const
+{
+  CSingleLock lock(m_critSection);
+  return m_bHidden;
 }

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -442,6 +442,9 @@ namespace PVR
     void SetSelectedGroup(bool bSetTo);
     bool IsSelectedGroup(void) const;
 
+    void SetHidden(bool bHidden);
+    bool IsHidden(void) const;
+
   protected:
     /*!
      * @brief Load the channels stored in the database.
@@ -538,6 +541,7 @@ namespace PVR
     bool             m_bSelectedGroup;              /*!< true when this is the selected group, false otherwise */
     bool             m_bPreventSortAndRenumber;     /*!< true when sorting and renumbering should not be done after adding/updating channels to the group */
     time_t           m_iLastWatched;                /*!< last time group has been watched */
+    bool             m_bHidden;                     /*!< true if this group is hidden, false otherwise */
     std::vector<PVRChannelGroupMember> m_members;
     CCriticalSection m_critSection;
     

--- a/xbmc/pvr/channels/PVRChannelGroups.h
+++ b/xbmc/pvr/channels/PVRChannelGroups.h
@@ -125,9 +125,10 @@ namespace PVR
     /*!
      * @brief Get the list of groups.
      * @param results The file list to store the results in.
+     * @param bExcludeHidden Decides whether to filter hidden groups
      * @return The amount of items that were added.
      */
-    int GetGroupList(CFileItemList* results) const;
+    int GetGroupList(CFileItemList* results, bool bExcludeHidden = false) const;
 
     /*!
      * @brief Get the previous group in this container.

--- a/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
@@ -26,6 +26,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "guilib/Key.h"
 #include "guilib/LocalizeStrings.h"
+#include "guilib/GUIRadioButtonControl.h"
 #include "utils/StringUtils.h"
 
 #include "pvr/PVRManager.h"
@@ -39,6 +40,7 @@ using namespace PVR;
 #define CONTROL_CURRENT_GROUP_LABEL   20
 #define CONTROL_UNGROUPED_LABEL       21
 #define CONTROL_IN_GROUP_LABEL        22
+#define BUTTON_HIDE_GROUP             25
 #define BUTTON_NEWGROUP               26
 #define BUTTON_RENAMEGROUP            27
 #define BUTTON_DELGROUP               28
@@ -246,6 +248,25 @@ bool CGUIDialogPVRGroupManager::ActionButtonChannelGroups(CGUIMessage &message)
   return bReturn;
 }
 
+bool CGUIDialogPVRGroupManager::ActionButtonHideGroup(CGUIMessage &message)
+{
+  bool bReturn = false;
+
+  if (message.GetSenderId() == BUTTON_HIDE_GROUP && m_selectedGroup)
+  {
+    CGUIRadioButtonControl *button = (CGUIRadioButtonControl*) GetControl(message.GetSenderId());
+    if (button)
+    {
+      m_selectedGroup->SetHidden(button->IsSelected());
+      Update();
+    }
+
+    bReturn = true;
+  }
+
+  return bReturn;
+}
+
 bool CGUIDialogPVRGroupManager::OnMessageClick(CGUIMessage &message)
 {
   return ActionButtonOk(message) ||
@@ -254,7 +275,8 @@ bool CGUIDialogPVRGroupManager::OnMessageClick(CGUIMessage &message)
       ActionButtonRenameGroup(message) ||
       ActionButtonUngroupedChannels(message) ||
       ActionButtonGroupMembers(message) ||
-      ActionButtonChannelGroups(message);
+      ActionButtonChannelGroups(message) ||
+      ActionButtonHideGroup(message);
 }
 
 bool CGUIDialogPVRGroupManager::OnMessage(CGUIMessage& message)
@@ -336,6 +358,7 @@ void CGUIDialogPVRGroupManager::Update()
     /* set this group in the pvrmanager, so it becomes the selected group in other dialogs too */
     g_PVRManager.SetPlayingGroup(m_selectedGroup);
     SET_CONTROL_LABEL(CONTROL_CURRENT_GROUP_LABEL, m_selectedGroup->GroupName());
+    SET_CONTROL_SELECTED(GetID(), BUTTON_HIDE_GROUP, m_selectedGroup->IsHidden());
 
     if (m_selectedGroup->IsInternalGroup())
     {

--- a/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.h
@@ -54,6 +54,7 @@ namespace PVR
     bool ActionButtonUngroupedChannels(CGUIMessage &message);
     bool ActionButtonGroupMembers(CGUIMessage &message);
     bool ActionButtonChannelGroups(CGUIMessage &message);
+    bool ActionButtonHideGroup(CGUIMessage &message);
     bool OnMessageClick(CGUIMessage &message);
 
     CPVRChannelGroupPtr m_selectedGroup;

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -220,7 +220,7 @@ bool CGUIWindowPVRBase::OpenGroupSelectionDialog(void)
     return false;
 
   CFileItemList options;
-  g_PVRChannelGroups->Get(m_bRadio)->GetGroupList(&options);
+  g_PVRChannelGroups->Get(m_bRadio)->GetGroupList(&options, true);
 
   dialog->Reset();
   dialog->SetHeading(g_localizeStrings.Get(19146));


### PR DESCRIPTION
As the title says this adds support to control the visibility of channel groups. A hidden group is not shown within the channel group selection dialog nor if you switch between groups (previous/next).

PS: yep it's possible to hide the "All channels" group as every other user-defined group ;)
