### PR TITLE
[pvr] fix: last watched timestamps won't update after channel switch

### DIFF
--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -543,7 +543,7 @@ void CApplicationPlayer::SetDynamicRangeCompression(long drc)
     player->SetDynamicRangeCompression(drc);
 }
 
-bool CApplicationPlayer::SwitchChannel(const PVR::CPVRChannel &channel)
+bool CApplicationPlayer::SwitchChannel(PVR::CPVRChannel &channel)
 {
   boost::shared_ptr<IPlayer> player = GetInternal();
   return (player && player->SwitchChannel(channel));

--- a/xbmc/ApplicationPlayer.h
+++ b/xbmc/ApplicationPlayer.h
@@ -146,6 +146,6 @@ public:
   void  SetSubTitleDelay(float fValue = 0.0f);
   void  SetSubtitleVisible(bool bVisible);
   void  SetVolume(float volume);
-  bool  SwitchChannel(const PVR::CPVRChannel &channel);
+  bool  SwitchChannel(PVR::CPVRChannel &channel);
   void  ToFFRW(int iSpeed = 0);
 };

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -217,7 +217,7 @@ public:
   
   virtual std::string GetPlayingTitle() { return ""; };
 
-  virtual bool SwitchChannel(const PVR::CPVRChannel &channel) { return false; }
+  virtual bool SwitchChannel(PVR::CPVRChannel &channel) { return false; }
 
   // Note: the following "OMX" methods are deprecated and will be removed in the future
   // They should be handled by the video renderer, not the player

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -4410,7 +4410,7 @@ std::string CDVDPlayer::GetPlayingTitle()
   return "";
 }
 
-bool CDVDPlayer::SwitchChannel(const CPVRChannel &channel)
+bool CDVDPlayer::SwitchChannel(CPVRChannel &channel)
 {
   if (!g_PVRManager.CheckParentalLock(channel))
     return false;

--- a/xbmc/cores/dvdplayer/DVDPlayer.h
+++ b/xbmc/cores/dvdplayer/DVDPlayer.h
@@ -269,7 +269,7 @@ public:
 
   virtual std::string GetPlayingTitle();
 
-  virtual bool SwitchChannel(const PVR::CPVRChannel &channel);
+  virtual bool SwitchChannel(PVR::CPVRChannel &channel);
   virtual bool CachePVRStream(void) const;
 
   enum ECacheState

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -99,7 +99,7 @@ namespace PVR
      * @brief Updates the last watched timestamps of the channel and group which are currently playing.
      * @param channel The channel which is updated
      */
-    void UpdateLastWatched(CPVRChannelPtr channel);
+    void UpdateLastWatched(CPVRChannel &channel);
 
   public:
     /*!
@@ -305,7 +305,7 @@ namespace PVR
      * @param bPreview True to show a preview, false otherwise.
      * @return Trrue if the switch was successful, false otherwise.
      */
-    bool PerformChannelSwitch(const CPVRChannel &channel, bool bPreview);
+    bool PerformChannelSwitch(CPVRChannel &channel, bool bPreview);
 
     /*!
      * @brief Close an open PVR stream.

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -95,6 +95,12 @@ namespace PVR
      */
     CPVRManager(void);
 
+    /*!
+     * @brief Updates the last watched timestamps of the channel and group which are currently playing.
+     * @param channel The channel which is updated
+     */
+    void UpdateLastWatched(CPVRChannelPtr channel);
+
   public:
     /*!
      * @brief Stop the PVRManager and destroy all objects it created.


### PR DESCRIPTION
As we only update the last watched timestamp of the current playing channel before a successful channel switch is performed we sometimes continue the wrong last watched channel and group.

@opdenkamp or @Jalle19 for a second look.
