### PR TITLE
[pvr] fix deviations of selected item between PVR windows and channel OSD

### DIFF
--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -1022,6 +1022,10 @@ bool CPVRManager::OpenLiveStream(const CFileItem &channel)
       delete m_currentFile;
     m_currentFile = new CFileItem(channel);
 
+    // set channel as selected item
+    if (channel.HasPVRChannelInfoTag())
+      CGUIWindowPVRBase::SetSelectedItemPath(channel.GetPVRChannelInfoTag()->IsRadio(), channel.GetPVRChannelInfoTag()->Path());
+
     if (m_addons->GetPlayingChannel(playingChannel))
     {
       time_t tNow;
@@ -1331,6 +1335,9 @@ bool CPVRManager::PerformChannelSwitch(const CPVRChannel &channel, bool bPreview
     g_application.SaveFileState();
     g_application.LoadVideoSettings(channel.Path());
     
+    // set channel as selected item
+    CGUIWindowPVRBase::SetSelectedItemPath(channel.IsRadio(), channel.Path());
+
     CSingleLock lock(m_critSection);
     m_currentFile = new CFileItem(channel);
     m_bIsSwitchingChannels = false;

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
@@ -39,6 +39,7 @@
 #include "epg/Epg.h"
 #include "pvr/timers/PVRTimerInfoTag.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
+#include "pvr/windows/GUIWindowPVRBase.h"
 
 using namespace PVR;
 using namespace EPG;
@@ -115,6 +116,15 @@ void CGUIDialogPVRChannelsOSD::OnDeinitWindow(int nextWindowID)
     m_group.reset();
   }
 
+  // set selected item path
+  int selectedItem = m_viewControl.GetSelectedItem();
+  if (selectedItem > -1)
+  {
+    CFileItemPtr fileItem = m_vecItems->Get(selectedItem);
+    if (fileItem)
+      CGUIWindowPVRBase::SetSelectedItemPath(g_PVRManager.IsPlayingRadio(), fileItem->GetPath());
+  }
+
   CGUIDialog::OnDeinitWindow(nextWindowID);
 
   Clear();
@@ -168,19 +178,20 @@ void CGUIDialogPVRChannelsOSD::Update()
   Clear();
 
   CPVRChannelPtr channel;
-  g_PVRManager.GetCurrentChannel(channel);
-  CPVRChannelGroupPtr group = g_PVRManager.GetPlayingGroup(channel->IsRadio());
-
-  if (group)
+  if (g_PVRManager.GetCurrentChannel(channel))
   {
-    group->GetMembers(*m_vecItems);
-    m_viewControl.SetItems(*m_vecItems);
-
-    if(!m_group)
+    CPVRChannelGroupPtr group = g_PVRManager.GetPlayingGroup(channel->IsRadio());
+    if (group)
     {
-      m_group = group;
-      m_viewControl.SetSelectedItem(group->GetIndex(*channel));
-      SaveSelectedItem(group->GroupID());
+      group->GetMembers(*m_vecItems);
+      m_viewControl.SetItems(*m_vecItems);
+
+      if(!m_group)
+      {
+        m_group = group;
+        m_viewControl.SetSelectedItem(CGUIWindowPVRBase::GetSelectedItemPath(channel->IsRadio()));
+        SaveSelectedItem(group->GroupID());
+      }
     }
   }
 

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
@@ -158,7 +158,7 @@ bool CGUIDialogPVRChannelsOSD::OnAction(const CAction &action)
 CPVRChannelGroupPtr CGUIDialogPVRChannelsOSD::GetPlayingGroup()
 {
   CPVRChannelPtr channel;
-  if(g_PVRManager.GetCurrentChannel(channel))
+  if (g_PVRManager.GetCurrentChannel(channel))
     return g_PVRManager.GetPlayingGroup(channel->IsRadio());
   else
     return CPVRChannelGroupPtr();
@@ -186,7 +186,7 @@ void CGUIDialogPVRChannelsOSD::Update()
       group->GetMembers(*m_vecItems);
       m_viewControl.SetItems(*m_vecItems);
 
-      if(!m_group)
+      if (!m_group)
       {
         m_group = group;
         m_viewControl.SetSelectedItem(CGUIWindowPVRBase::GetSelectedItemPath(channel->IsRadio()));
@@ -203,7 +203,7 @@ void CGUIDialogPVRChannelsOSD::SaveControlStates()
   CGUIDialog::SaveControlStates();
 
   CPVRChannelGroupPtr group = GetPlayingGroup();
-  if(group)
+  if (group)
     SaveSelectedItem(group->GroupID());
 }
 
@@ -212,7 +212,7 @@ void CGUIDialogPVRChannelsOSD::RestoreControlStates()
   CGUIDialog::RestoreControlStates();
 
   CPVRChannelGroupPtr group = GetPlayingGroup();
-  if(group)
+  if (group)
   {
     m_viewControl.SetSelectedItem(GetLastSelectedItem(group->GroupID()));
   }
@@ -341,7 +341,7 @@ void CGUIDialogPVRChannelsOSD::SaveSelectedItem(int iGroupID)
 int CGUIDialogPVRChannelsOSD::GetLastSelectedItem(int iGroupID) const
 {
   std::map<int,int>::const_iterator it = m_groupSelectedItems.find(iGroupID);
-  if(it != m_groupSelectedItems.end())
+  if (it != m_groupSelectedItems.end())
     return it->second;
   return 0;
 }

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -62,6 +62,21 @@ CGUIWindowPVRBase::~CGUIWindowPVRBase(void)
 {
 }
 
+void CGUIWindowPVRBase::SetSelectedItemPath(bool bRadio, const std::string path)
+{
+  m_selectedItemPaths.at(bRadio) = path;
+}
+
+std::string CGUIWindowPVRBase::GetSelectedItemPath(bool bRadio)
+{
+  if (!m_selectedItemPaths.at(bRadio).empty())
+    return m_selectedItemPaths.at(bRadio);
+  else if (g_PVRManager.IsPlaying())
+    return g_application.CurrentFile();
+
+  return "";
+}
+
 void CGUIWindowPVRBase::Notify(const Observable &obs, const ObservableMessage msg)
 {
   UpdateSelectedItemPath();
@@ -109,15 +124,10 @@ void CGUIWindowPVRBase::OnInitWindow(void)
 
   m_vecItems->SetPath(GetDirectoryPath());
 
-  // use the path of the current playing channel if no previous selection exists
-  // to mark the corresponding item in the list as selected
-  if (m_selectedItemPaths.at(m_bRadio).empty() && g_PVRManager.IsPlaying())
-    m_selectedItemPaths.at(m_bRadio) = g_application.CurrentFile();
-
   CGUIMediaWindow::OnInitWindow();
 
   // mark item as selected by channel path
-  m_viewControl.SetSelectedItem(m_selectedItemPaths.at(m_bRadio));
+  m_viewControl.SetSelectedItem(GetSelectedItemPath(m_bRadio));
 }
 
 void CGUIWindowPVRBase::OnDeinitWindow(int nextWindowID)

--- a/xbmc/pvr/windows/GUIWindowPVRBase.h
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.h
@@ -67,6 +67,9 @@ namespace PVR
     virtual void ResetObservers(void) {};
     virtual void Notify(const Observable &obs, const ObservableMessage msg);
     virtual void SetInvalid();
+    
+    static std::string GetSelectedItemPath(bool bRadio);
+    static void SetSelectedItemPath(bool bRadio, const std::string path);
 
   protected:
     CGUIWindowPVRBase(bool bRadio, int id, const std::string &xmlFile);


### PR DESCRIPTION
As discussed in our forum (http://forum.xbmc.org/showthread.php?tid=175135&pid=1795411#pid1795411) this fix the deviations of the selected item between the PVR windows and the channel osd.

I also changed the way the current playing channel is used for the selected item. It's only used if we never have valid selected item or if we switch the channel otherwise we use the stored selected item. Thanks Jönke for this suggestion.
