### PR TITLE
[Fix] Make up missed ShowPicture in command array

### DIFF
--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -144,6 +144,7 @@ const BUILT_IN commands[] = {
   { "NotifyAll",                  true,   "Notify all connected clients" },
   { "Extract",                    true,   "Extracts the specified archive" },
   { "PlayMedia",                  true,   "Play the specified media file (or playlist)" },
+  { "ShowPicture",                true,   "Display a picture by file path" },
   { "SlideShow",                  true,   "Run a slideshow from the specified directory" },
   { "RecursiveSlideShow",         true,   "Run a slideshow from the specified directory, including all subdirs" },
   { "ReloadSkin",                 false,  "Reload XBMC's skin" },


### PR DESCRIPTION
As @t-nelson found, the ShowPicture command we introduced in v13 is missing from the command array in head of Builtins.cpp. Here I make it up.

As the wiki page: http://wiki.xbmc.org/index.php?title=List_of_built-in_functions
I've lost my login to the wiki system, so any dev can help make up there?
