### PR TITLE
dvdplayer: fix flushing message queue

### DIFF
--- a/xbmc/cores/dvdplayer/DVDMessageQueue.cpp
+++ b/xbmc/cores/dvdplayer/DVDMessageQueue.cpp
@@ -44,7 +44,7 @@ CDVDMessageQueue::CDVDMessageQueue(const string &owner) : m_hEvent(true), m_owne
 CDVDMessageQueue::~CDVDMessageQueue()
 {
   // remove all remaining messages
-  Flush();
+  Flush(CDVDMsg::NONE);
 }
 
 void CDVDMessageQueue::Init()
@@ -91,7 +91,7 @@ void CDVDMessageQueue::End()
 {
   CSingleLock lock(m_section);
 
-  Flush();
+  Flush(CDVDMsg::NONE);
 
   m_bInitialized  = false;
   m_iDataSize     = 0;


### PR DESCRIPTION
see title. flush without an argument just removes demuxer packets
@ace20022 I hope this fixes the issue.
