### PR TITLE
add additive seeking

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -6320,7 +6320,10 @@ msgctxt "#13555"
 msgid "%d Minutes"
 msgstr ""
 
-#empty strings from id 13556 to 13599
+msgctxt "#13556"
+msgid "Using additive seeking instead of variable speed seeking"
+msgstr ""
+#empty strings from id 13557 to 13599
 
 #: system/settings/darwin.xml
 msgctxt "#13600"
@@ -15877,4 +15880,10 @@ msgstr ""
 #: system/settings/rbp.xml
 msgctxt "#37030"
 msgid "Unlimited"
+msgstr ""
+
+#. Description of setting "Videos -> Playback -> Using additive seeking instead of variable speed seeking" with label #13556
+#: system/settings/settings.xml
+msgctxt "#37031"
+msgid "Configure seeking algorithm (additive instead of variable speed seeking)"
 msgstr ""

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -428,6 +428,11 @@
           <default>false</default>
           <control type="toggle" />
         </setting>
+        <setting id="videoplayer.useadditiveseeking" type="boolean" label="13556" help="37031">
+          <level>2</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
         <setting id="videoplayer.synctype" type="integer" parent="videoplayer.usedisplayasclock" label="13500" help="36167">
           <level>2</level>
           <default>2</default> <!-- SYNC_RESAMPLE -->

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -142,6 +142,15 @@ void CAdvancedSettings::Initialize()
   m_videoPercentSeekBackward = -2;
   m_videoPercentSeekForwardBig = 10;
   m_videoPercentSeekBackwardBig = -10;
+  m_videoAdditiveTimeSeekWaitForSeekingStart = 500;
+  m_videoAdditiveTimeSeekWaitForDisplayHide = 2000;
+  m_videoAdditiveTimeSeekStepOne = 30;
+  m_videoAdditiveTimeSeekStepTwo = 60;
+  m_videoAdditiveTimeSeekStepThree = 180;
+  m_videoAdditiveTimeSeekStepFour = 300;
+  m_videoAdditiveTimeSeekStepFive = 600;
+  m_videoAdditiveTimeSeekStepSix = 1800;
+  m_videoAdditiveTimeSeekStepOther = 3600;
   m_videoBlackBarColour = 0;
   m_videoPPFFmpegDeint = "linblenddeint";
   m_videoPPFFmpegPostProc = "ha:128:7,va,dr";
@@ -557,6 +566,16 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
     XMLUtils::GetInt(pElement, "timeseekbackward", m_videoTimeSeekBackward, -6000, 0);
     XMLUtils::GetInt(pElement, "timeseekforwardbig", m_videoTimeSeekForwardBig, 0, 6000);
     XMLUtils::GetInt(pElement, "timeseekbackwardbig", m_videoTimeSeekBackwardBig, -6000, 0);
+
+    XMLUtils::GetInt(pElement, "additivetimeseekwaitforseekingstart", m_videoAdditiveTimeSeekWaitForSeekingStart, 0, 60000);
+    XMLUtils::GetInt(pElement, "additivetimeseekwaitfordisplayhide", m_videoAdditiveTimeSeekWaitForDisplayHide, 0, 60000);
+    XMLUtils::GetInt(pElement, "additivetimeseekstepone", m_videoAdditiveTimeSeekStepOne, 0, 60*60*24);
+    XMLUtils::GetInt(pElement, "additivetimeseeksteptwo", m_videoAdditiveTimeSeekStepTwo, 0, 60 * 60 * 24);
+    XMLUtils::GetInt(pElement, "additivetimeseekstepthree", m_videoAdditiveTimeSeekStepThree, 0, 60 * 60 * 24);
+    XMLUtils::GetInt(pElement, "additivetimeseekstepfour", m_videoAdditiveTimeSeekStepFour, 0, 60 * 60 * 24);
+    XMLUtils::GetInt(pElement, "additivetimeseekstepfive", m_videoAdditiveTimeSeekStepFive, 0, 60 * 60 * 24);
+    XMLUtils::GetInt(pElement, "additivetimeseekstepsix", m_videoAdditiveTimeSeekStepSix, 0, 60 * 60 * 24);
+    XMLUtils::GetInt(pElement, "additivetimeseekstepother", m_videoAdditiveTimeSeekStepOther, 0, 60 * 60 * 24);
 
     XMLUtils::GetInt(pElement, "percentseekforward", m_videoPercentSeekForward, 0, 100);
     XMLUtils::GetInt(pElement, "percentseekbackward", m_videoPercentSeekBackward, -100, 0);

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -160,6 +160,16 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     int m_videoPercentSeekBackward;
     int m_videoPercentSeekForwardBig;
     int m_videoPercentSeekBackwardBig;
+    int m_videoAdditiveTimeSeekWaitForSeekingStart;
+    int m_videoAdditiveTimeSeekWaitForDisplayHide;
+    int m_videoAdditiveTimeSeekStepOne;
+    int m_videoAdditiveTimeSeekStepTwo;
+    int m_videoAdditiveTimeSeekStepThree;
+    int m_videoAdditiveTimeSeekStepFour;
+    int m_videoAdditiveTimeSeekStepFive;
+    int m_videoAdditiveTimeSeekStepSix;
+    int m_videoAdditiveTimeSeekStepOther;
+
     CStdString m_videoPPFFmpegDeint;
     CStdString m_videoPPFFmpegPostProc;
     bool m_videoVDPAUtelecine;

--- a/xbmc/utils/SeekHandler.cpp
+++ b/xbmc/utils/SeekHandler.cpp
@@ -21,28 +21,81 @@
 #include "SeekHandler.h"
 #include "GUIInfoManager.h"
 #include "Application.h"
+#include "settings/AdvancedSettings.h"
+#include "settings/Settings.h"
+#include "utils/log.h"
 
 CSeekHandler::CSeekHandler()
-: m_requireSeek(false),
-  m_percent(0.0f)
+  : m_requireSeek(false),
+  m_percent(0.0f),
+  m_seek_step(0),
+  m_percents_pro_sec(0.1f),
+  m_time_before_seek(500),
+  m_time_for_display(2000)
 {
+
 }
 
 void CSeekHandler::Reset()
 {
   m_requireSeek = false;
   m_percent = 0;
+  m_seek_step = 0;
+  m_percents_pro_sec = 1.0f;
+  m_time_before_seek = g_advancedSettings.m_videoAdditiveTimeSeekWaitForSeekingStart;
+  m_time_for_display = g_advancedSettings.m_videoAdditiveTimeSeekWaitForDisplayHide;
+}
+
+int CSeekHandler::GetSeekSeconds(bool forward)
+{
+  if (forward)
+  {
+    m_seek_step++;
+  }
+  else
+  {
+    m_seek_step--;
+  }
+
+  int seconds = 0;
+  switch (abs(m_seek_step))
+  {
+  case 1: seconds = g_advancedSettings.m_videoAdditiveTimeSeekStepOne; break;
+  case 2: seconds = g_advancedSettings.m_videoAdditiveTimeSeekStepTwo; break;
+  case 3: seconds = g_advancedSettings.m_videoAdditiveTimeSeekStepThree; break;
+  case 4: seconds = g_advancedSettings.m_videoAdditiveTimeSeekStepFour; break;
+  case 5: seconds = g_advancedSettings.m_videoAdditiveTimeSeekStepFive; break;
+  case 6: seconds = g_advancedSettings.m_videoAdditiveTimeSeekStepSix; break;
+  default:
+    seconds = (abs(m_seek_step) - 6) * g_advancedSettings.m_videoAdditiveTimeSeekStepOther; break;
+  }
+  if (m_seek_step < 0)
+  {
+    seconds = seconds * -1.0f;
+  }
+  return seconds;
 }
 
 void CSeekHandler::Seek(bool forward, float amount, float duration)
 {
   if (!m_requireSeek)
   { // not yet seeking
-    if (g_infoManager.GetTotalPlayTime())
-      m_percent = (float)g_infoManager.GetPlayTime() / g_infoManager.GetTotalPlayTime() * 0.1f;
+    if (CSettings::Get().GetBool("videoplayer.useadditiveseeking"))
+    {
+      if (g_infoManager.GetTotalPlayTime())
+      {
+        m_percents_pro_sec = 100.0f / (float)g_infoManager.GetTotalPlayTime();
+      }
+      m_seek_step = 0;
+      m_percent = GetSeekSeconds(forward)*m_percents_pro_sec;
+    }
     else
-      m_percent = 0.0f;
-
+    {
+      if (g_infoManager.GetTotalPlayTime())
+        m_percent = (float)g_infoManager.GetPlayTime() / g_infoManager.GetTotalPlayTime() * 0.1f;
+      else
+        m_percent = 0.0f;
+    }
     // tell info manager that we have started a seek operation
     m_requireSeek = true;
     g_infoManager.SetSeeking(true);
@@ -50,19 +103,26 @@ void CSeekHandler::Seek(bool forward, float amount, float duration)
   // calculate our seek amount
   if (!g_infoManager.m_performingSeek)
   {
-    //100% over 1 second.
-    float speed = 100.0f;
-    if( duration )
-      speed *= duration;
+    if (CSettings::Get().GetBool("videoplayer.useadditiveseeking"))
+    {
+      m_percent = GetSeekSeconds(forward)*m_percents_pro_sec;
+    }
     else
-      speed /= g_infoManager.GetFPS();
+    {
+      //100% over 1 second.
+      float speed = 100.0f;
+      if (duration)
+        speed *= duration;
+      else
+        speed /= g_infoManager.GetFPS();
 
-    if (forward)
-      m_percent += amount * amount * speed;
-    else
-      m_percent -= amount * amount * speed;
-    if (m_percent > 100.0f) m_percent = 100.0f;
-    if (m_percent < 0.0f)   m_percent = 0.0f;
+      if (forward)
+        m_percent += amount * amount * speed;
+      else
+        m_percent -= amount * amount * speed;
+      if (m_percent > 100.0f) m_percent = 100.0f;
+      if (m_percent < 0.0f)   m_percent = 0.0f;
+    }
   }
   m_timer.StartZero();
 }
@@ -79,14 +139,22 @@ bool CSeekHandler::InProgress() const
 
 void CSeekHandler::Process()
 {
-  if (m_timer.GetElapsedMilliseconds() > time_before_seek)
+  if (m_timer.GetElapsedMilliseconds() > m_time_before_seek)
   {
-    if (!g_infoManager.m_performingSeek && m_timer.GetElapsedMilliseconds() > time_for_display) // TODO: Why?
+    if (!g_infoManager.m_performingSeek && m_timer.GetElapsedMilliseconds() > m_time_for_display) // TODO: Why?
       g_infoManager.SetSeeking(false);
     if (m_requireSeek)
     {
       g_infoManager.m_performingSeek = true;
-      double time = g_infoManager.GetTotalPlayTime() * m_percent * 0.01;
+      double time;
+      if (CSettings::Get().GetBool("videoplayer.useadditiveseeking"))
+      {
+        time = (g_infoManager.GetTotalPlayTime() * m_percent / 100.0f + g_infoManager.GetPlayTime() / 1000.0f);
+      }
+      else
+      {
+        time = g_infoManager.GetTotalPlayTime() * m_percent * 0.01;
+      }
       g_application.SeekTime(time);
       m_requireSeek = false;
     }

--- a/xbmc/utils/SeekHandler.h
+++ b/xbmc/utils/SeekHandler.h
@@ -33,9 +33,12 @@ public:
   float GetPercent() const;
   bool InProgress() const;
 private:
-  static const int time_before_seek = 500;
-  static const int time_for_display = 2000; // TODO: WTF?
+  int        GetSeekSeconds(bool forward);
+  int        m_time_before_seek;
+  int        m_time_for_display;
   bool       m_requireSeek;
-  float      m_percent;
+  float      m_percent; 
+  float      m_percents_pro_sec;
+  int        m_seek_step;
   CStopWatch m_timer;
 };


### PR DESCRIPTION
Add additive seeking:
If useadditivetimeseeking property in advanced settings set to true, then functionality of analogseeking changed to additives seeking:
hitting analogseeking action more that once increases or decreases how far it will seek after a delay (currently 1500ms) using these step sizes 30s -60s - 3m - 5m - 10m - 30m- 1hr-2hr-3hr-etc.

The feature can be enabled in gui settings->playback->Using additive seeking instead of variable speed seeking
The steps and delays can be configurated in video section of advancedsettings.xml:
      additivetimeseekwaitforseekingstart - dealy between  two action,before starting seeking
      additivetimeseekwaitfordisplayhide - delay before hiding of seeking dialog 
      additivetimeseekstepone - seek time after frist hit
      additivetimeseeksteptwo - seek time after second hit
     additivetimeseekstepthree - seek time after third hit
     additivetimeseekstepfour  - seek time after fours hit
     additivetimeseekstepfive- seek time after fives hit
     additivetimeseekstepother- seek time for all other hits.
