### PR TITLE
[airplay] - fix broken airplay with ios8 clients

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -3761,9 +3761,13 @@ msgctxt "#1260"
 msgid "Announce these services to other systems via Zeroconf"
 msgstr ""
 
-#empty strings from id 1261 to 1268
+#empty strings from id 1261 to 1267
 
 #: system/settings/settings.xml
+msgctxt "#1268"
+msgid "iOS 8 compatibility mode"
+msgstr ""
+
 msgctxt "#1269"
 msgid "Allow volume control"
 msgstr ""
@@ -15670,7 +15674,13 @@ msgctxt "#36548"
 msgid "Limits resolution of GUI to save memory. Does not affect video playback. Requires restart."
 msgstr ""
 
-#empty strings from id 36549 to 36599
+#. Description of setting "Services -> AirPlay -> iOS 8 compatibility mode" with label #1268
+#: system/settings/settings.xml
+msgctxt "#36549"
+msgid "Use iOS8 compatible AirPlay support. If you have trouble with older iOS devices detecting Kodi as a valid target try switching this off. This option takes effect on the next restart of Kodi only!"
+msgstr ""
+
+#empty strings from id 36550 to 36599
 #reserved strings 365XX
 
 #. Description of settings category "Music -> Library" with label #14022

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2202,6 +2202,14 @@
             <hidden>true</hidden>
           </control>
         </setting>
+        <setting id="services.airplayios8compat" type="boolean" parent="services.airplay" label="1268" help="36549">
+          <level>3</level>
+          <default>true</default>
+          <dependencies>
+            <dependency type="enable" setting="services.airplay">true</dependency>
+          </dependencies>
+          <control type="toggle" />
+        </setting>
       </group>
     </category>
     <category id="smb" label="1200" help="36346">

--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -901,7 +901,26 @@ int CAirPlayServer::CTCPClient::ProcessRequest( std::string& responseHeader,
 
           tmpNode = m_pLibPlist->plist_dict_get_item(dict, "Content-Location");
           if (tmpNode)
+          {
             location = getStringFromPlist(m_pLibPlist, tmpNode);
+            tmpNode = NULL;
+          }
+          
+          // in newer protocol versions the location is given
+          // via host and path where host is ip:port and path is /path/file.mov
+          if (location.empty())
+              tmpNode = m_pLibPlist->plist_dict_get_item(dict, "host");
+          if (tmpNode)
+          {
+            location = "http://";
+            location += getStringFromPlist(m_pLibPlist, tmpNode);
+
+            tmpNode = m_pLibPlist->plist_dict_get_item(dict, "path");
+            if (tmpNode)
+            {
+              location += getStringFromPlist(m_pLibPlist, tmpNode);
+            }
+          }
 
           if (dict)
           {

--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -741,6 +741,29 @@ void CAirPlayServer::restoreVolume()
   }
 }
 
+void dumpPlist(DllLibPlist *pLibPlist, plist_t *dict)
+{
+  char *plist = NULL;
+  uint32_t len = 0;
+  pLibPlist->plist_to_xml(*dict,&plist, &len);
+  CLog::Log(LOGDEBUG, "AIRPLAY-DUMP: %s", plist);
+  
+}
+
+std::string getStringFromPlist(DllLibPlist *pLibPlist,plist_t node)
+{
+  std::string ret;
+  char *tmpStr = NULL;
+  pLibPlist->plist_get_string_val(node, &tmpStr);
+  ret = tmpStr;
+#ifdef TARGET_WINDOWS
+  pLibPlist->plist_free_string_val(tmpStr);
+#else
+  free(tmpStr);
+#endif
+  return ret;
+}
+
 int CAirPlayServer::CTCPClient::ProcessRequest( std::string& responseHeader,
                                                 std::string& responseBody)
 {
@@ -878,16 +901,7 @@ int CAirPlayServer::CTCPClient::ProcessRequest( std::string& responseHeader,
 
           tmpNode = m_pLibPlist->plist_dict_get_item(dict, "Content-Location");
           if (tmpNode)
-          {
-            char *tmpStr = NULL;
-            m_pLibPlist->plist_get_string_val(tmpNode, &tmpStr);
-            location=tmpStr;
-#ifdef TARGET_WINDOWS
-            m_pLibPlist->plist_free_string_val(tmpStr);
-#else
-            free(tmpStr);
-#endif
-          }
+            location = getStringFromPlist(m_pLibPlist, tmpNode);
 
           if (dict)
           {

--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -1135,6 +1135,11 @@ int CAirPlayServer::CTCPClient::ProcessRequest( std::string& responseHeader,
   else if (uri == "/getProperty")
   {
     status = AIRPLAY_STATUS_NOT_FOUND;
+  }
+
+  else if (uri == "/fp-setup")
+  {
+    status = AIRPLAY_STATUS_PRECONDITION_FAILED;
   }  
 
   else if (uri == "200") //response OK from the event reverse message

--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -876,7 +876,7 @@ int CAirPlayServer::CTCPClient::ProcessRequest( std::string& responseHeader,
     {
       status = AIRPLAY_STATUS_NEED_AUTH;
     }
-    else if (contentType == "application/x-apple-binary-plist")
+    else
     {
       CAirPlayServer::m_isPlaying++;    
       
@@ -887,7 +887,11 @@ int CAirPlayServer::CTCPClient::ProcessRequest( std::string& responseHeader,
         const char* bodyChr = m_httpParser->getBody();
 
         plist_t dict = NULL;
-        m_pLibPlist->plist_from_bin(bodyChr, m_httpParser->getContentLength(), &dict);
+        if (contentType == "application/x-apple-binary-plist")
+          m_pLibPlist->plist_from_bin(bodyChr, m_httpParser->getContentLength(), &dict);
+        else
+          m_pLibPlist->plist_from_xml(bodyChr, m_httpParser->getContentLength(), &dict);
+
 
         if (m_pLibPlist->plist_dict_get_size(dict))
         {
@@ -932,28 +936,6 @@ int CAirPlayServer::CTCPClient::ProcessRequest( std::string& responseHeader,
           CLog::Log(LOGERROR, "Error parsing plist");
         }
         m_pLibPlist->Unload();
-      }
-    }
-    else
-    {
-      CAirPlayServer::m_isPlaying++;        
-      // Get URL to play
-      std::string contentLocation = "Content-Location: ";
-      size_t start = body.find(contentLocation);
-      if (start == std::string::npos)
-        return AIRPLAY_STATUS_NOT_IMPLEMENTED;
-      start += contentLocation.size();
-      int end = body.find('\n', start);
-      location = body.substr(start, end - start);
-
-      std::string startPosition = "Start-Position: ";
-      start = body.find(startPosition);
-      if (start != std::string::npos)
-      {
-        start += startPosition.size();
-        int end = body.find('\n', start);
-        std::string positionStr = body.substr(start, end - start);
-        position = (float)atof(positionStr.c_str());
       }
     }
 

--- a/xbmc/network/AirTunesServer.cpp
+++ b/xbmc/network/AirTunesServer.cpp
@@ -389,9 +389,9 @@ bool CAirTunesServer::StartServer(int port, bool nonlocal, bool usePassword, con
     txt.push_back(std::make_pair("pw",  usePassword?"true":"false"));
     txt.push_back(std::make_pair("vn",  "3"));
     txt.push_back(std::make_pair("da",  "true"));
-    txt.push_back(std::make_pair("vs",  "130.14"));
     txt.push_back(std::make_pair("md",  "0,1,2"));
     txt.push_back(std::make_pair("am",  "Xbmc,1"));
+    txt.push_back(std::make_pair("vs",  "130.14"));
 
     CZeroconf::GetInstance()->PublishService("servers.airtunes", "_raop._tcp", appName, port, txt);
   }

--- a/xbmc/network/DllLibPlist.h
+++ b/xbmc/network/DllLibPlist.h
@@ -39,6 +39,9 @@ public:
 #ifdef TARGET_WINDOWS
   virtual void        plist_free_string_val (char *val                                                  )=0;
 #endif
+  virtual void        plist_to_xml          (plist_t plist,           char **plist_xml, uint32_t * length)=0;
+  virtual void        plist_dict_new_iter   (plist_t node,            plist_dict_iter *iter             )=0;
+  virtual void        plist_dict_next_item  (plist_t node,            plist_dict_iter iter, char **key, plist_t *val) = 0;
 
 };
 
@@ -50,8 +53,11 @@ class DllLibPlist : public DllDynamic, DllLibPlistInterface
   DEFINE_METHOD1(void,          plist_free,           (plist_t p1))
   DEFINE_METHOD2(void,          plist_get_string_val, (plist_t p1,      char **p2))
   DEFINE_METHOD2(void,          plist_get_real_val,   (plist_t p1,      double *p2))
+  DEFINE_METHOD2(void,          plist_dict_new_iter,  (plist_t p1,      plist_dict_iter* p2))
   DEFINE_METHOD2(plist_t,       plist_dict_get_item,  (plist_t p1,      const char* p2))
   DEFINE_METHOD3(void,          plist_from_bin,       (const char *p1,  uint32_t p2, plist_t *p3))
+  DEFINE_METHOD3(void,          plist_to_xml,         (plist_t p1,      char **p2, uint32_t *p3));
+  DEFINE_METHOD4(void,          plist_dict_next_item, (plist_t p1, plist_dict_iter p2, char **p3, plist_t *p4))
 #ifdef TARGET_WINDOWS
   DEFINE_METHOD1(void,          plist_free_string_val, (char *p1))
 #endif
@@ -65,6 +71,9 @@ class DllLibPlist : public DllDynamic, DllLibPlistInterface
     RESOLVE_METHOD_RENAME(plist_get_real_val,     plist_get_real_val)
     RESOLVE_METHOD_RENAME(plist_get_string_val,   plist_get_string_val)
     RESOLVE_METHOD_RENAME(plist_dict_get_item,    plist_dict_get_item)
+    RESOLVE_METHOD_RENAME(plist_dict_new_iter,    plist_dict_new_iter)
+    RESOLVE_METHOD_RENAME(plist_dict_next_item,   plist_dict_next_item)
+    RESOLVE_METHOD_RENAME(plist_to_xml,           plist_to_xml)
 #ifdef TARGET_WINDOWS
     RESOLVE_METHOD_RENAME(plist_free_string_val,  plist_free_string_val)
 #endif

--- a/xbmc/network/DllLibPlist.h
+++ b/xbmc/network/DllLibPlist.h
@@ -30,6 +30,7 @@ public:
   virtual ~DllLibPlistInterface() {}
 
   virtual void        plist_from_bin        (const char *plist_bin,   uint32_t length, plist_t * plist  )=0;
+  virtual void        plist_from_xml        (const char *plist_xml,   uint32_t length, plist_t * plist  )=0;
   virtual plist_t     plist_new_dict        (void                                                       )=0;
   virtual uint32_t    plist_dict_get_size   (plist_t node                                               )=0;
   virtual void        plist_get_string_val  (plist_t node,            char **val                        )=0;
@@ -56,6 +57,7 @@ class DllLibPlist : public DllDynamic, DllLibPlistInterface
   DEFINE_METHOD2(void,          plist_dict_new_iter,  (plist_t p1,      plist_dict_iter* p2))
   DEFINE_METHOD2(plist_t,       plist_dict_get_item,  (plist_t p1,      const char* p2))
   DEFINE_METHOD3(void,          plist_from_bin,       (const char *p1,  uint32_t p2, plist_t *p3))
+  DEFINE_METHOD3(void,          plist_from_xml,       (const char *p1,  uint32_t p2, plist_t *p3))
   DEFINE_METHOD3(void,          plist_to_xml,         (plist_t p1,      char **p2, uint32_t *p3));
   DEFINE_METHOD4(void,          plist_dict_next_item, (plist_t p1, plist_dict_iter p2, char **p3, plist_t *p4))
 #ifdef TARGET_WINDOWS
@@ -68,6 +70,7 @@ class DllLibPlist : public DllDynamic, DllLibPlistInterface
     RESOLVE_METHOD_RENAME(plist_free,             plist_free)
     RESOLVE_METHOD_RENAME(plist_dict_get_size,    plist_dict_get_size)
     RESOLVE_METHOD_RENAME(plist_from_bin,         plist_from_bin)
+    RESOLVE_METHOD_RENAME(plist_from_xml,         plist_from_xml)
     RESOLVE_METHOD_RENAME(plist_get_real_val,     plist_get_real_val)
     RESOLVE_METHOD_RENAME(plist_get_string_val,   plist_get_string_val)
     RESOLVE_METHOD_RENAME(plist_dict_get_item,    plist_dict_get_item)

--- a/xbmc/network/NetworkServices.cpp
+++ b/xbmc/network/NetworkServices.cpp
@@ -530,9 +530,22 @@ bool CNetworkServices::StartAirPlayServer()
   std::vector<std::pair<std::string, std::string> > txt;
   CNetworkInterface* iface = g_application.getNetwork().GetFirstConnectedInterface();
   txt.push_back(make_pair("deviceid", iface != NULL ? iface->GetMacAddress() : "FF:FF:FF:FF:FF:F2"));
-  txt.push_back(make_pair("features", "0x77"));
   txt.push_back(make_pair("model", "Xbmc,1"));
   txt.push_back(make_pair("srcvers", AIRPLAY_SERVER_VERSION_STR));
+
+  if (CSettings::Get().GetBool("services.airplayios8compat"))
+  {
+    // for ios8 clients we need to announce mirroring support
+    // else we won't get video urls anymore.
+    // We also announce photo caching support (as it seems faster and
+    // we have implemented it anyways). 
+    txt.push_back(make_pair("features", "0x20F7"));
+  }
+  else
+  {
+    txt.push_back(make_pair("features", "0x77"));
+  }
+
   CZeroconf::GetInstance()->PublishService("servers.airplay", "_airplay._tcp", g_infoManager.GetLabel(SYSTEM_FRIENDLY_NAME), g_advancedSettings.m_airPlayPort, txt);
 #endif // HAS_ZEROCONF
 


### PR DESCRIPTION
As some might have noticed forum is filling with ios8 airplay breakage reports. With ios8 clients only audio airplay works with current xbmc implementation. This PR fixes this as follows.
1. Add a new settings in the airplay category for ios8 compatibility which defaults to on and is only visible in the highest settings level (expert). I don't have all needed ios client constellations here for testing and there are way to much use cases via airplay these days to risk regressions here. While this PR works for all my test cases i still want a way to fallback to the old airplay behaviour by making this a setting (though i have the feeling won't be needed for 80% of use cases).
2. Based on this setting tweak our zeroconf announcements in a way that ios8 sends us video urls and photos again, by keeping the ability to still stream music as well (this is really tricky and a big thx goes to @DBMandrake who found out how to accomplish that)
3. The tweaked announcements forces us to implement the photo asset cache feature of the airplay protocol (i had implemente this in the ios7 phase already but since i found a different workaround for ios7 i didn't pr it). Its a simple file based cache and apple now fills it with photos for faster switching.
4. Reply with error code when the client wants a fairplay encryption handshake (not sure if it is needed really but it definitly doesn't hurt)
5. Support a different method of extracting the playback url from an /play request (again this is from the ios7 development and was needed for youtube.app which is totally broken forever currently - but who knows what other app uses this way to send the url - can't hurt to support it).

This sounds big somehow - but most of the code was already well tested when we worked on the ios7 airplay breakage.

Definitly helix stuff.

I have tested it successfully with photos, videos (camera roll), videos (youtube from safari) and music (music app and amazon cloud player) on clients with iOS 8.0, iOS 6.0.1, iOS 6.1.2, iOS 5.1.1. Awaiting test results from an iOS7 device aswell (which i don't have atm).

Sadly this won't change the story for android as the zeroconf reannounce hack is still needed for ios8 clients (and is still not available for android).
