### PR TITLE
dvdplayer: fix ass subs for AV_CODEC_ID_ASS after ffmpeg bump to 2.4

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayCodecSSA.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayCodecSSA.cpp
@@ -71,6 +71,8 @@ int CDVDOverlayCodecSSA::Decode(DemuxPacket *pPacket)
     return OC_ERROR;
   
   double pts = pPacket->dts != DVD_NOPTS_VALUE ? pPacket->dts : pPacket->pts;
+  if (pts == DVD_NOPTS_VALUE)
+    pts = 0;
   uint8_t *data = pPacket->pData;
   int size = pPacket->iSize;
   double duration = pPacket->duration;
@@ -117,6 +119,14 @@ int CDVDOverlayCodecSSA::Decode(DemuxPacket *pPacket)
   }
   else
     m_libass->DecodeDemuxPkt((char*)data, size, pts, duration);
+
+  if (m_pOverlay && m_pOverlay->iPTSStartTime == pts)
+  {
+    if (m_pOverlay->iPTSStopTime < pts + duration)
+      m_pOverlay->iPTSStopTime = pts + duration;
+    m_output = true;
+    return OC_OVERLAY;
+  }
 
   if(m_pOverlay)
   {


### PR DESCRIPTION
fix trac 15449 "Wrong display of subtitles after ffmpeg 2.4 bump"
