### PR TITLE
VobSub fixes

### DIFF
--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -2133,6 +2133,12 @@ void CUtil::GetExternalStreamDetailsFromFilename(const CStdString& strVideo, con
   // we check left part - if it's same as video base name - strip it
   if (StringUtils::StartsWithNoCase(toParse, videoBaseName))
     toParse = toParse.substr(videoBaseName.length());
+  else if (URIUtils::GetExtension(strStream) == ".sub" && URIUtils::IsInArchive(strStream))
+  {
+    // exclude parsing of vobsub file names that embedded in an archive
+    CLog::Log(LOGDEBUG, "%s - skipping archived vobsub filename parsing: %s", __FUNCTION__, strStream.c_str());
+    toParse.clear();
+  }
 
   // trim any non-alphanumeric char in the begining
   std::string::iterator result = std::find_if(toParse.begin(), toParse.end(), ::isalnum);

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxVobsub.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxVobsub.cpp
@@ -214,6 +214,7 @@ bool CDVDDemuxVobsub::ParseId(SState& state, char* line)
 
   stream->codec = AV_CODEC_ID_DVD_SUBTITLE;
   stream->iId = m_Streams.size();
+  stream->source = STREAM_SOURCE_DEMUX_SUB;
 
   state.id = stream->iId;
   m_Streams.push_back(stream.release());

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -481,6 +481,8 @@ void CSelectionStreams::Update(CDVDInputStream* input, CDVDDemux* demuxer, std::
         }
         s.channels = ((CDemuxStreamAudio*)stream)->iChannels;
       }
+      if (!s.filename2.empty())
+        s.name += " " + g_localizeStrings.Get(21602);
       Update(s);
     }
   }

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -252,11 +252,8 @@ public:
                    , rh.type_index == CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleStream);
 
     // prefer external subs
-    PREDICATE_RETURN(STREAM_SOURCE_MASK(lh.source) == STREAM_SOURCE_DEMUX_SUB
-                   , STREAM_SOURCE_MASK(rh.source) == STREAM_SOURCE_DEMUX_SUB);
-
-    PREDICATE_RETURN(STREAM_SOURCE_MASK(lh.source) == STREAM_SOURCE_TEXT
-                   , STREAM_SOURCE_MASK(rh.source) == STREAM_SOURCE_TEXT);
+    PREDICATE_RETURN(STREAM_SOURCE_MASK(lh.source) == STREAM_SOURCE_DEMUX_SUB || STREAM_SOURCE_MASK(lh.source) == STREAM_SOURCE_TEXT
+                   , STREAM_SOURCE_MASK(rh.source) == STREAM_SOURCE_DEMUX_SUB || STREAM_SOURCE_MASK(rh.source) == STREAM_SOURCE_TEXT);
 
     if(!subson || original)
     {

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -394,7 +394,7 @@ void CSelectionStreams::Update(SelectionStream& s)
   }
 }
 
-void CSelectionStreams::Update(CDVDInputStream* input, CDVDDemux* demuxer)
+void CSelectionStreams::Update(CDVDInputStream* input, CDVDDemux* demuxer, std::string filename2)
 {
   if(input && input->IsStreamType(DVDSTREAM_TYPE_DVD))
   {
@@ -466,6 +466,7 @@ void CSelectionStreams::Update(CDVDInputStream* input, CDVDDemux* demuxer)
       s.language = g_LangCodeExpander.ConvertToISO6392T(stream->language);
       s.flags    = stream->flags;
       s.filename = demuxer->GetFileName();
+      s.filename2 = filename2;
       stream->GetStreamName(s.name);
       std::string codec;
       demuxer->GetStreamCodecName(stream->iId, codec);
@@ -4143,10 +4144,9 @@ int CDVDPlayer::AddSubtitleFile(const std::string& filename, const std::string& 
     CDVDDemuxVobsub v;
     if(!v.Open(filename, vobsubfile))
       return -1;
-    m_SelectionStreams.Update(NULL, &v);
+    m_SelectionStreams.Update(NULL, &v, vobsubfile);
     int index = m_SelectionStreams.IndexOf(STREAM_SUBTITLE, m_SelectionStreams.Source(STREAM_SOURCE_DEMUX_SUB, filename), 0);
     m_SelectionStreams.Get(STREAM_SUBTITLE, index).flags = flags;
-    m_SelectionStreams.Get(STREAM_SUBTITLE, index).filename2 = vobsubfile;
     ExternalStreamInfo info;
     CUtil::GetExternalStreamDetailsFromFilename(m_filename, vobsubfile, info);
     m_SelectionStreams.Get(STREAM_SUBTITLE, index).name = info.name;

--- a/xbmc/cores/dvdplayer/DVDPlayer.h
+++ b/xbmc/cores/dvdplayer/DVDPlayer.h
@@ -188,7 +188,7 @@ public:
   int              Source  (StreamSource source, std::string filename);
 
   void             Update  (SelectionStream& s);
-  void             Update  (CDVDInputStream* input, CDVDDemux* demuxer);
+  void             Update  (CDVDInputStream* input, CDVDDemux* demuxer, std::string filename2 = "");
 };
 
 


### PR DESCRIPTION
This PR solves a variety of issues when using external vobsubs, especially in combination with external SRT. I encountered problems when trying to load external vobsubs but my preferred language was actually in an external SRT, and it was a total mess... 

Issues resolved:
- SRT is now equally prioritized, and gets a chance of being selected if it has the preferred language
- when switching from SRT to SUB there was a change in order and indices due to the "source" value not being set (STREAM_SOURCE_NONE) in the VOBSUB demuxer. This caused the selectionstreams to be cleared and reloaded. The result was that between saving the subtitle index to the settings db and resuming the video another subitle got selected! Setting the source value upon demuxer opening and stream creation, resolved this issue.
- the code has a couple of instances where it assumes that a VOBSUB contains only one subtitle, while in practice there's more than one. The fact of filename2 not being set also caused re-opening the streams unnecessarily. Also only one of the streams was named xxx (External) and they are now all marked (External).
- there was an issue whereby the .sub file is rar'ed and the stream-details-parser tries to analyse the filename as embedded within the rar. If just the archive name has the same name as the movie, but not the embedded file, this doesn't work correctly. 

@ace20022 - this is one for you to review
