### PR TITLE
Audio: Rename normalize audio to Maintain original volume and invert meaning

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -1455,7 +1455,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#346"
-msgid "Normalize levels on downmix"
+msgid "Maintain original volume on downmix"
 msgstr ""
 
 #: system/settings/settings.xml
@@ -15580,7 +15580,7 @@ msgstr ""
 #. Description of setting "System -> Audio output -> Normalize levels on downmix" with label #346
 #: settings/DisplaySettings.cpp
 msgctxt "#36533"
-msgid "Select how audio is downmixed, for example from 5.1 to 2.0: [Enabled] maintains the dynamic range of the original audio source when downmixed however volume will be lower [Disabled] maintains volume level of the original audio source however the dynamic range is compressed. Note - Dynamic range is the difference between the quietest and loudest sounds in a audio source."
+msgid "Select how audio is downmixed, for example from 5.1 to 2.0: [Enabled] maintains volume level of the original audio source however the dynamic range is compressed. [Disabled] maintains the dynamic range of the original audio source when downmixed however volume will be lower. Note - Dynamic range is the difference between the quietest and loudest sounds in an audio source. Enable this setting if movie dialogues are barely audible."
 msgstr ""
 
 #. Description of setting "System -> Debugging -> Component-specific logging..." with label #668

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2430,7 +2430,7 @@
           </dependencies>
           <control type="toggle" />
         </setting>
-        <setting id="audiooutput.normalizelevels" type="boolean" label="346" help="36533">
+        <setting id="audiooutput.maintainoriginalvolume" type="boolean" label="346" help="36533">
           <level>2</level>
           <default>true</default>
           <control type="toggle" />

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2431,7 +2431,7 @@
           <control type="toggle" />
         </setting>
         <setting id="audiooutput.maintainoriginalvolume" type="boolean" label="346" help="36533">
-          <level>2</level>
+          <level>3</level>
           <default>true</default>
           <control type="toggle" />
         </setting>

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -2152,7 +2152,7 @@ void CActiveAE::LoadSettings()
   m_settings.samplerate = CSettings::Get().GetInt("audiooutput.samplerate");
 
   m_settings.stereoupmix = IsSettingVisible("audiooutput.stereoupmix") ? CSettings::Get().GetBool("audiooutput.stereoupmix") : false;
-  m_settings.normalizelevels = CSettings::Get().GetBool("audiooutput.normalizelevels");
+  m_settings.normalizelevels = !CSettings::Get().GetBool("audiooutput.maintainoriginalvolume");
   m_settings.guisoundmode = CSettings::Get().GetInt("audiooutput.guisoundmode");
 
   m_settings.passthrough = m_settings.config == AE_CONFIG_FIXED ? false : CSettings::Get().GetBool("audiooutput.passthrough");
@@ -2213,22 +2213,22 @@ std::string CActiveAE::GetDefaultDevice(bool passthrough)
 
 void CActiveAE::OnSettingsChange(const std::string& setting)
 {
-  if (setting == "audiooutput.passthroughdevice" ||
-      setting == "audiooutput.audiodevice"       ||
-      setting == "audiooutput.config"            ||
-      setting == "audiooutput.ac3passthrough"    ||
-      setting == "audiooutput.ac3transcode"      ||
-      setting == "audiooutput.eac3passthrough"   ||
-      setting == "audiooutput.dtspassthrough"    ||
-      setting == "audiooutput.truehdpassthrough" ||
-      setting == "audiooutput.dtshdpassthrough"  ||
-      setting == "audiooutput.channels"          ||
-      setting == "audiooutput.stereoupmix"       ||
-      setting == "audiooutput.streamsilence"     ||
-      setting == "audiooutput.processquality"    ||
-      setting == "audiooutput.passthrough"       ||
-      setting == "audiooutput.samplerate"        ||
-      setting == "audiooutput.normalizelevels"   ||
+  if (setting == "audiooutput.passthroughdevice"      ||
+      setting == "audiooutput.audiodevice"            ||
+      setting == "audiooutput.config"                 ||
+      setting == "audiooutput.ac3passthrough"         ||
+      setting == "audiooutput.ac3transcode"           ||
+      setting == "audiooutput.eac3passthrough"        ||
+      setting == "audiooutput.dtspassthrough"         ||
+      setting == "audiooutput.truehdpassthrough"      ||
+      setting == "audiooutput.dtshdpassthrough"       ||
+      setting == "audiooutput.channels"               ||
+      setting == "audiooutput.stereoupmix"            ||
+      setting == "audiooutput.streamsilence"          ||
+      setting == "audiooutput.processquality"         ||
+      setting == "audiooutput.passthrough"            ||
+      setting == "audiooutput.samplerate"             ||
+      setting == "audiooutput.maintainoriginalvolume" ||
       setting == "audiooutput.guisoundmode")
   {
     m_controlPort.SendOutMessage(CActiveAEControlProtocol::RECONFIGURE);

--- a/xbmc/cores/omxplayer/OMXAudio.cpp
+++ b/xbmc/cores/omxplayer/OMXAudio.cpp
@@ -595,7 +595,7 @@ bool COMXAudio::Initialize(AEAudioFormat format, OMXClock *clock, CDVDStreamInfo
   if (!m_Passthrough)
   {
     bool upmix = CSettings::Get().GetBool("audiooutput.stereoupmix");
-    bool normalize = CSettings::Get().GetBool("audiooutput.normalizelevels");
+    bool normalize = !CSettings::Get().GetBool("audiooutput.maintainoriginalvolume");
     void *remapLayout = NULL;
 
     CAEChannelInfo stdLayout = (enum AEStdChLayout)CSettings::Get().GetInt("audiooutput.channels");

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -704,7 +704,7 @@ void CSettings::InitializeISettingCallbacks()
   settingSet.insert("audiooutput.audiodevice");
   settingSet.insert("audiooutput.passthroughdevice");
   settingSet.insert("audiooutput.streamsilence");
-  settingSet.insert("audiooutput.normalizelevels");
+  settingSet.insert("audiooutput.maintainoriginalvolume");
   settingSet.insert("lookandfeel.skin");
   settingSet.insert("lookandfeel.skinsettings");
   settingSet.insert("lookandfeel.font");


### PR DESCRIPTION
After reading this forum thread here: http://forum.xbmc.org/showthread.php?tid=196421&pid=1801222 I came to the conclucsion that though normalizelevels is fully correct, that users want to think with the inverse, e.g. boost volume on downmix.

This PR adjusts the code and inverts the flags in the relevant parts of the code.

Also the description - as correct it was - does not help the average joe much according to the above thread.
