### PR TITLE
AE: optimization and fixes

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -91,7 +91,8 @@ void CEngineStats::GetDelay(AEDelayStatus& status)
 void CEngineStats::GetDelay(AEDelayStatus& status, CActiveAEStream *stream)
 {
   CSingleLock lock(m_lock);
-  GetDelay(status);
+  status = m_sinkDelay;
+  status.delay += (double)m_bufferedSamples / m_sinkSampleRate;
 
   status.delay += m_sinkLatency;
   status.delay += stream->m_bufferedTime / stream->m_streamResampleRatio;

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
@@ -431,8 +431,9 @@ double CActiveAEStream::GetResampleRatio()
 
 bool CActiveAEStream::SetResampleRatio(double ratio)
 {
+  if (ratio != m_streamResampleRatio)
+    AE.SetStreamResampleRatio(this, ratio);
   m_streamResampleRatio = ratio;
-  AE.SetStreamResampleRatio(this, m_streamResampleRatio);
   return true;
 }
 


### PR DESCRIPTION
44f14c6 only send a message to ActiveAE if resample ration has changed. this reduced load on AE
79e0ba6 apart from  reducing load it seems to fix an issue which bothered me quite a while: system deadlocked waiting on a mutex which was not taken by any other thread. attaching a debugger made it run again. may have triggered some bug in a lower layer.
