### PR TITLE
set deinterlace mode to AUTO as default

### DIFF
--- a/xbmc/settings/VideoSettings.cpp
+++ b/xbmc/settings/VideoSettings.cpp
@@ -29,7 +29,7 @@
 
 CVideoSettings::CVideoSettings()
 {
-  m_DeinterlaceMode = VS_DEINTERLACEMODE_OFF;
+  m_DeinterlaceMode = VS_DEINTERLACEMODE_AUTO;
   m_InterlaceMethod = VS_INTERLACEMETHOD_AUTO;
   m_ScalingMethod = VS_SCALINGMETHOD_LINEAR;
   m_ViewMode = ViewModeNormal;


### PR DESCRIPTION
see title. there is no good reason why deinterlacing should be disabled on a fresh install
