### PR TITLE
[python] fix null pointer dereference when invoking non-addon scripts

### DIFF
--- a/xbmc/interfaces/python/PythonInvoker.cpp
+++ b/xbmc/interfaces/python/PythonInvoker.cpp
@@ -189,12 +189,15 @@ bool CPythonInvoker::execute(const std::string &script, const std::vector<std::s
   addPath(scriptDir);
 
   // add addon module dependecies
-  ADDON::ADDONDEPS deps = m_addon.get()->GetDeps();
-  for (ADDON::ADDONDEPS::const_iterator it = deps.begin(); it != deps.end(); ++it)
+  if (m_addon)
   {
-    ADDON::AddonPtr addon;
-    if (ADDON::CAddonMgr::Get().GetAddon(it->first, addon, ADDON::ADDON_SCRIPT_MODULE))
-      addPath(CSpecialProtocol::TranslatePath(addon->LibPath()));
+    ADDON::ADDONDEPS deps = m_addon.get()->GetDeps();
+    for (ADDON::ADDONDEPS::const_iterator it = deps.begin(); it != deps.end(); ++it)
+    {
+      ADDON::AddonPtr addon;
+      if (ADDON::CAddonMgr::Get().GetAddon(it->first, addon, ADDON::ADDON_SCRIPT_MODULE))
+        addPath(CSpecialProtocol::TranslatePath(addon->LibPath()));
+    }
   }
 
   // we want to use sys.path so it includes site-packages


### PR DESCRIPTION
As noted by @fritsch in https://github.com/xbmc/xbmc/commit/8772221e24b8f2651dd6fdc19bea53555e5b1d9b
