### PR TITLE
VAAPI: Give User of broken wrappers a chance to test their wrappers

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.cpp
@@ -477,15 +477,22 @@ CDecoder::~CDecoder()
 
 bool CDecoder::Open(AVCodecContext* avctx, const enum PixelFormat fmt, unsigned int surfaces)
 {
-  // don't support broken wrappers
+  // don't support broken wrappers by default
   // nvidia cards with a vaapi to vdpau wrapper
   // fglrx cards with xvba-va-driver
   std::string gpuvendor = g_Windowing.GetRenderVendor();
   std::transform(gpuvendor.begin(), gpuvendor.end(), gpuvendor.begin(), ::tolower);
   if (gpuvendor.compare(0, 5, "intel") != 0)
   {
-    CLog::Log(LOGNOTICE, "VAAPI is not correctly supported on your hardware - will close the decoder.");
-    return false;
+    // user might force VAAPI enabled, cause he might know better
+    if (g_advancedSettings.m_videoVAAPIforced)
+    {
+      CLog::Log(LOGWARNING, "VAAPI was not tested on your hardware / driver stack: %s. If it will crash and burn complain with your gpu vendor.", gpuvendor.c_str());
+    }
+    else
+    {
+      return false;
+    }
   }
 
   // check if user wants to decode this format with VAAPI

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -152,6 +152,7 @@ void CAdvancedSettings::Initialize()
   m_videoIgnorePercentAtEnd   = 8.0f;
   m_videoPlayCountMinimumPercent = 90.0f;
   m_videoVDPAUScaling = -1;
+  m_videoVAAPIforced = false;
   m_videoNonLinStretchRatio = 0.5f;
   m_videoEnableHighQualityHwScalers = false;
   m_videoAutoScaleMaxFps = 30.0f;
@@ -584,6 +585,9 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
     XMLUtils::GetString(pElement,"ppffmpegdeinterlacing",m_videoPPFFmpegDeint);
     XMLUtils::GetString(pElement,"ppffmpegpostprocessing",m_videoPPFFmpegPostProc);
     XMLUtils::GetInt(pElement,"vdpauscaling",m_videoVDPAUScaling);
+    // There is a large amount of drivers implementing VAAPI in a non stable way
+    // the forcevaapienabled setting let's the user decide to use it nevertheless
+    XMLUtils::GetBoolean(pElement, "forcevaapienabled", m_videoVAAPIforced);
     XMLUtils::GetFloat(pElement, "nonlinearstretchratio", m_videoNonLinStretchRatio, 0.01f, 1.0f);
     XMLUtils::GetBoolean(pElement,"enablehighqualityhwscalers", m_videoEnableHighQualityHwScalers);
     XMLUtils::GetFloat(pElement,"autoscalemaxfps",m_videoAutoScaleMaxFps, 0.0f, 1000.0f);

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -180,6 +180,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     bool m_useFfmpegVda;
 
     int   m_videoVDPAUScaling;
+    bool  m_videoVAAPIforced;
     float m_videoNonLinStretchRatio;
     bool  m_videoEnableHighQualityHwScalers;
     float m_videoAutoScaleMaxFps;


### PR DESCRIPTION
As it seems the opensource world is moving forward to VAAPI. We should make sure, that we will run on the new AMD opensource vaapi stack, too.

This allows to open the decoder - but warns so that users with broken fglrx wrappers still clearly see in their logfiles what the issues.
