### PR TITLE
VAAPI: fix some cppcheck oddities

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.cpp
@@ -693,7 +693,6 @@ int CDecoder::FFGetBuffer(AVCodecContext *avctx, AVFrame *pic, int flags)
 void CDecoder::FFReleaseBuffer(uint8_t *data)
 {
   VASurfaceID surf;
-  unsigned int i;
 
   CSingleLock lock(m_DecoderSection);
 

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.h
@@ -165,7 +165,8 @@ class CVaapiRenderPicture
   friend class COutput;
 public:
   CVaapiRenderPicture(CCriticalSection &section)
-    : texture(None), avFrame(NULL), refCount(0), renderPicSection(section) { fence = None; }
+    : texWidth(0), texHeight(0), texture(None), valid(false), vaapi(NULL), avFrame(NULL),
+      usefence(false), refCount(0), renderPicSection(section) { fence = None; }
   void Sync();
   DVDVideoPicture DVDPic;
   int texWidth, texHeight;


### PR DESCRIPTION
We missed some initializations.
