### PR TITLE
[omxplayer] Fix bad audio when sample_fmt is not reported on Open

### DIFF
--- a/xbmc/cores/omxplayer/OMXAudioCodecOMX.cpp
+++ b/xbmc/cores/omxplayer/OMXAudioCodecOMX.cpp
@@ -302,7 +302,7 @@ int COMXAudioCodecOMX::GetBitsPerSample()
 {
   if (!m_pCodecContext)
     return 0;
-  return m_pCodecContext->sample_fmt == AV_SAMPLE_FMT_S16 ? 16 : 32;
+  return m_desiredSampleFormat == AV_SAMPLE_FMT_S16 ? 16 : 32;
 }
 
 int COMXAudioCodecOMX::GetBitRate()


### PR DESCRIPTION
For most codecs ffmpeg reports m_pCodecContext->sample_fmt on the avcodec_open2 call (e.g. ac3, dts, aac).
However some (PCM on dvd) report AV_SAMPLE_FMT_NONE on open, and only provide the correct format on decode.

This can cause the GetBitsPerSample call to change between open and decode and results in white noise when the word size is misinterpreted.

The simple solution is to always convert to float when open doesn't report the format and ensure GetBitsPerSample reports this value
