### PR TITLE
[darwin] Move all function in DarwinUtils to static class, update functions names

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1177,8 +1177,8 @@ bool CApplication::InitDirectoriesOSX()
     CSpecialProtocol::SetXBMCBinPath(xbmcPath);
     CSpecialProtocol::SetXBMCPath(xbmcPath);
     #if defined(TARGET_DARWIN_IOS)
-      CSpecialProtocol::SetHomePath(userHome + "/" + CStdString(DarwinGetXbmcRootFolder()) + "/XBMC");
-      CSpecialProtocol::SetMasterProfilePath(userHome + "/" + CStdString(DarwinGetXbmcRootFolder()) + "/XBMC/userdata");
+      CSpecialProtocol::SetHomePath(userHome + "/" + CStdString(CDarwinUtils::GetAppRootFolder()) + "/XBMC");
+      CSpecialProtocol::SetMasterProfilePath(userHome + "/" + CStdString(CDarwinUtils::GetAppRootFolder()) + "/XBMC/userdata");
     #else
       CSpecialProtocol::SetHomePath(userHome + "/Library/Application Support/XBMC");
       CSpecialProtocol::SetMasterProfilePath(userHome + "/Library/Application Support/XBMC/userdata");
@@ -1186,7 +1186,7 @@ bool CApplication::InitDirectoriesOSX()
 
     // location for temp files
     #if defined(TARGET_DARWIN_IOS)
-      CStdString strTempPath = URIUtils::AddFileToFolder(userHome,  CStdString(DarwinGetXbmcRootFolder()) + "/XBMC/temp");
+      CStdString strTempPath = URIUtils::AddFileToFolder(userHome,  CStdString(CDarwinUtils::GetAppRootFolder()) + "/XBMC/temp");
     #else
       CStdString strTempPath = URIUtils::AddFileToFolder(userHome, ".xbmc/");
       CDirectory::Create(strTempPath);
@@ -1196,7 +1196,7 @@ bool CApplication::InitDirectoriesOSX()
 
     // xbmc.log file location
     #if defined(TARGET_DARWIN_IOS)
-      strTempPath = userHome + "/" + CStdString(DarwinGetXbmcRootFolder());
+      strTempPath = userHome + "/" + CStdString(CDarwinUtils::GetAppRootFolder());
     #else
       strTempPath = userHome + "/Library/Logs";
     #endif
@@ -4732,7 +4732,7 @@ bool CApplication::OnMessage(CGUIMessage& message)
   case GUI_MSG_PLAYBACK_STARTED:
     {
 #ifdef TARGET_DARWIN
-      DarwinSetScheduling(message.GetMessage());
+      CDarwinUtils::SetScheduling(message.GetMessage());
 #endif
       // reset the seek handler
       m_seekHandler->Reset();
@@ -4844,7 +4844,7 @@ bool CApplication::OnMessage(CGUIMessage& message)
         m_pKaraokeMgr->Stop();
 #endif
 #ifdef TARGET_DARWIN
-      DarwinSetScheduling(message.GetMessage());
+      CDarwinUtils::SetScheduling(message.GetMessage());
 #endif
       // first check if we still have items in the stack to play
       if (message.GetMessage() == GUI_MSG_PLAYBACK_ENDED)

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -439,7 +439,7 @@ void CUtil::GetHomePath(std::string& strPath, const std::string& strTarget)
     char     given_path[2*MAXPATHLEN];
     uint32_t path_size =2*MAXPATHLEN;
 
-    result = GetDarwinExecutablePath(given_path, &path_size);
+    result = CDarwinUtils::GetExecutablePath(given_path, &path_size);
     if (result == 0)
     {
       // Move backwards to last /.
@@ -1798,7 +1798,7 @@ CStdString CUtil::ResolveExecutablePath()
   char     given_path[2*MAXPATHLEN];
   uint32_t path_size =2*MAXPATHLEN;
 
-  GetDarwinExecutablePath(given_path, &path_size);
+  CDarwinUtils::GetExecutablePath(given_path, &path_size);
   strExecutablePath = given_path;
 #elif defined(TARGET_FREEBSD)                                                                                                                                                                   
   char buf[PATH_MAX];
@@ -1841,7 +1841,7 @@ CStdString CUtil::GetFrameworksPath(bool forPython)
   char     given_path[2*MAXPATHLEN];
   uint32_t path_size =2*MAXPATHLEN;
 
-  GetDarwinFrameworkPath(forPython, given_path, &path_size);
+  CDarwinUtils::GetFrameworkPath(forPython, given_path, &path_size);
   strFrameworksPath = given_path;
 #endif
   return strFrameworksPath;

--- a/xbmc/cores/AudioEngine/Sinks/osx/CoreAudioDevice.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/osx/CoreAudioDevice.cpp
@@ -658,7 +658,7 @@ std::string CCoreAudioDevice::GetDataSourceName(UInt32 dataSourceId) const
 
   if (( status == noErr ) && dataSourceNameCF )
   {
-    if (DarwinCFStringRefToUTF8String(dataSourceNameCF, dataSourceName))
+    if (CDarwinUtils::CFStringRefToUTF8String(dataSourceNameCF, dataSourceName))
     {
       ret = dataSourceName;
     }

--- a/xbmc/cores/AudioEngine/Sinks/osx/CoreAudioHardware.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/osx/CoreAudioHardware.cpp
@@ -226,7 +226,7 @@ void CCoreAudioHardware::GetOutputDeviceName(std::string& name)
     if (ret != noErr)
       return;
 
-    DarwinCFStringRefToUTF8String(theDeviceName, name);
+    CDarwinUtils::CFStringRefToUTF8String(theDeviceName, name);
 
     CFRelease(theDeviceName);
   }

--- a/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
@@ -308,7 +308,7 @@ bool CLinuxRendererGL::Configure(unsigned int width, unsigned int height, unsign
   // on osx 10.9 mavericks we get a strange ripple
   // effect when rendering with pbo
   // when used on intel gpu - we have to quirk it here
-  if (DarwinIsMavericks())
+  if (CDarwinUtils::IsMavericks())
   {
     std::string rendervendor = g_Windowing.GetRenderVendor();
     StringUtils::ToLower(rendervendor);

--- a/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
@@ -723,7 +723,7 @@ void CLinuxRendererGLES::UpdateVideoFilter()
 void CLinuxRendererGLES::LoadShaders(int field)
 {
 #ifdef TARGET_DARWIN_IOS
-  float ios_version = GetIOSVersion();
+  float ios_version = CDarwinUtils::GetIOSVersion();
 #endif
   int requestedMethod = CSettings::Get().GetInt("videoplayer.rendermethod");
   CLog::Log(LOGDEBUG, "GL: Requested render method: %d", requestedMethod);

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecVideoToolBox.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecVideoToolBox.cpp
@@ -340,7 +340,7 @@ CreateFormatDescriptionFromCodecData(VTFormatId format_id, int width, int height
 
   FigVideoHack.lpAddress = (void*)FigVideoFormatDescriptionCreateWithSampleDescriptionExtensionAtom;
   
-  if (GetIOSVersion() < 4.3)
+  if (CDarwinUtils::GetIOSVersion() < 4.3)
   {
     CLog::Log(LOGDEBUG, "%s - GetIOSVersion says < 4.3", __FUNCTION__);
     status = FigVideoHack.FigVideoFormatDescriptionCreateWithSampleDescriptionExtensionAtom1(

--- a/xbmc/main/osx/SDLMain.mm
+++ b/xbmc/main/osx/SDLMain.mm
@@ -549,7 +549,7 @@ int main(int argc, char *argv[])
   // as the whole ProcessSerialNumber approach is deprecated
   // in that case assume finder launch - else
   // we wouldn't handle documents/movies someone dragged on the app icon
-  if (DarwinIsMavericks())
+  if (CDarwinUtils::IsMavericks())
     gFinderLaunch = TRUE;
 
   // Ensure the application object is initialised

--- a/xbmc/network/osx/ZeroconfBrowserOSX.cpp
+++ b/xbmc/network/osx/ZeroconfBrowserOSX.cpp
@@ -59,7 +59,7 @@ namespace
           for(idx = 0; idx < numValues; idx++)
           {
             std::string key;
-            if (DarwinCFStringRefToUTF8String(keys[idx], key))
+            if (CDarwinUtils::CFStringRefToUTF8String(keys[idx], key))
             {
               recordMap.insert(
                 std::make_pair(
@@ -148,9 +148,9 @@ void CZeroconfBrowserOSX::BrowserCallback(CFNetServiceBrowserRef browser, CFOpti
 
     //store the service
     std::string name, type, domain;
-    if (!DarwinCFStringRefToUTF8String(CFNetServiceGetName(service), name) ||
-        !DarwinCFStringRefToUTF8String(CFNetServiceGetType(service), type) ||
-        !DarwinCFStringRefToUTF8String(CFNetServiceGetDomain(service), domain))
+    if (!CDarwinUtils::CFStringRefToUTF8String(CFNetServiceGetName(service), name) ||
+        !CDarwinUtils::CFStringRefToUTF8String(CFNetServiceGetType(service), type) ||
+        !CDarwinUtils::CFStringRefToUTF8String(CFNetServiceGetDomain(service), domain))
     {
       CLog::Log(LOGWARNING, "CZeroconfBrowserOSX::BrowserCallback failed to convert service strings.");
       return;

--- a/xbmc/osx/DarwinUtils.h
+++ b/xbmc/osx/DarwinUtils.h
@@ -27,37 +27,29 @@
 struct __CFString;
 typedef const struct __CFString * CFStringRef;
 
-#ifdef __cplusplus
-extern "C"
-{
-#endif
-  const char *getIosPlatformString(void);
-  bool        DarwinIsAppleTV2(void);
-  bool        DarwinIsMavericks(void);
-  bool        DarwinIsSnowLeopard(void);
-  bool        DarwinHasRetina(void);
-  const char *GetDarwinOSReleaseString(void);
-  const char *GetDarwinVersionString(void);
-  float       GetIOSVersion(void);
-  const char *GetIOSVersionString(void);
-  const char *GetOSXVersionString(void); 
-  int         GetDarwinFrameworkPath(bool forPython, char* path, uint32_t *pathsize);
-  int         GetDarwinExecutablePath(char* path, uint32_t *pathsize);
-  const char *DarwinGetXbmcRootFolder(void);
-  bool        DarwinIsIosSandboxed(void);
-  bool        DarwinHasVideoToolboxDecoder(void);
-  int         DarwinBatteryLevel(void);
-  void        DarwinSetScheduling(int message);
-  void        DarwinPrintDebugString(std::string debugString);
-  bool        DarwinCFStringRefToString(CFStringRef source, std::string& destination);
-  bool        DarwinCFStringRefToUTF8String(CFStringRef source, std::string& destination);
-#ifdef __cplusplus
-}
-#endif
-
 class CDarwinUtils
 {
 public:
+  static const char *getIosPlatformString(void);
+  static bool        IsAppleTV2(void);
+  static bool        IsMavericks(void);
+  static bool        IsSnowLeopard(void);
+  static bool        DeviceHasRetina(void);
+  static const char *GetOSReleaseString(void);
+  static const char *GetOSVersionString(void);
+  static float       GetIOSVersion(void);
+  static const char *GetIOSVersionString(void);
+  static const char *GetOSXVersionString(void);
+  static int         GetFrameworkPath(bool forPython, char* path, uint32_t *pathsize);
+  static int         GetExecutablePath(char* path, uint32_t *pathsize);
+  static const char *GetAppRootFolder(void);
+  static bool        IsIosSandboxed(void);
+  static bool        HasVideoToolboxDecoder(void);
+  static int         BatteryLevel(void);
+  static void        SetScheduling(int message);
+  static void        PrintDebugString(std::string debugString);
+  static bool        CFStringRefToString(CFStringRef source, std::string& destination);
+  static bool        CFStringRefToUTF8String(CFStringRef source, std::string& destination);
   static const std::string&  GetManufacturer(void);
 };
 

--- a/xbmc/osx/DarwinUtils.mm
+++ b/xbmc/osx/DarwinUtils.mm
@@ -94,7 +94,7 @@ enum iosPlatform
 };
 
 // platform strings are based on http://theiphonewiki.com/wiki/Models
-const char* getIosPlatformString(void)
+const char* CDarwinUtils::getIosPlatformString(void)
 {
   static std::string iOSPlatformString;
   if (iOSPlatformString.empty())
@@ -124,7 +124,7 @@ enum iosPlatform getIosPlatform()
 #if defined(TARGET_DARWIN_IOS)
   if (eDev == iDeviceUnknown)
   {
-    std::string devStr(getIosPlatformString());
+    std::string devStr(CDarwinUtils::getIosPlatformString());
     
     if (devStr == "iPhone1,1") eDev = iPhone2G;
     else if (devStr == "iPhone1,2") eDev = iPhone3G;
@@ -169,7 +169,7 @@ enum iosPlatform getIosPlatform()
   return eDev;
 }
 
-bool DarwinIsAppleTV2(void)
+bool CDarwinUtils::IsAppleTV2(void)
 {
   static enum iosPlatform platform = iDeviceUnknown;
 #if defined(TARGET_DARWIN_IOS)
@@ -181,7 +181,7 @@ bool DarwinIsAppleTV2(void)
   return (platform == AppleTV2);
 }
 
-bool DarwinIsMavericks(void)
+bool CDarwinUtils::IsMavericks(void)
 {
   static int isMavericks = -1;
 #if defined(TARGET_DARWIN_OSX)
@@ -198,7 +198,7 @@ bool DarwinIsMavericks(void)
   return isMavericks == 1;
 }
 
-bool DarwinIsSnowLeopard(void)
+bool CDarwinUtils::IsSnowLeopard(void)
 {
   static int isSnowLeopard = -1;
 #if defined(TARGET_DARWIN_OSX)
@@ -211,7 +211,7 @@ bool DarwinIsSnowLeopard(void)
   return isSnowLeopard == 1;
 }
 
-bool DarwinHasRetina(void)
+bool CDarwinUtils::DeviceHasRetina(void)
 {
   static enum iosPlatform platform = iDeviceUnknown;
 
@@ -224,7 +224,7 @@ bool DarwinHasRetina(void)
   return (platform >= iPhone4);
 }
 
-const char *GetDarwinOSReleaseString(void)
+const char *CDarwinUtils::GetOSReleaseString(void)
 {
   static std::string osreleaseStr;
   if (osreleaseStr.empty())
@@ -239,13 +239,13 @@ const char *GetDarwinOSReleaseString(void)
   return osreleaseStr.c_str();
 }
 
-const char *GetDarwinVersionString(void)
+const char *CDarwinUtils::GetOSVersionString(void)
 {
   CCocoaAutoPool pool;
   return [[[NSProcessInfo processInfo] operatingSystemVersionString] UTF8String];
 }
 
-float GetIOSVersion(void)
+float CDarwinUtils::GetIOSVersion(void)
 {
   CCocoaAutoPool pool;
   float version;
@@ -258,7 +258,7 @@ float GetIOSVersion(void)
   return(version);
 }
 
-const char *GetIOSVersionString(void)
+const char *CDarwinUtils::GetIOSVersionString(void)
 {
 #if defined(TARGET_DARWIN_IOS)
   static std::string iOSVersionString;
@@ -273,7 +273,7 @@ const char *GetIOSVersionString(void)
 #endif
 }
 
-const char *GetOSXVersionString(void)
+const char *CDarwinUtils::GetOSXVersionString(void)
 {
 #if defined(TARGET_DARWIN_OSX)
   static std::string OSXVersionString;
@@ -290,7 +290,7 @@ const char *GetOSXVersionString(void)
 #endif
 }
 
-int  GetDarwinFrameworkPath(bool forPython, char* path, uint32_t *pathsize)
+int  CDarwinUtils::GetFrameworkPath(bool forPython, char* path, uint32_t *pathsize)
 {
   CCocoaAutoPool pool;
   // see if we can figure out who we are
@@ -360,7 +360,7 @@ int  GetDarwinFrameworkPath(bool forPython, char* path, uint32_t *pathsize)
   return -1;
 }
 
-int  GetDarwinExecutablePath(char* path, uint32_t *pathsize)
+int  CDarwinUtils::GetExecutablePath(char* path, uint32_t *pathsize)
 {
   CCocoaAutoPool pool;
   // see if we can figure out who we are
@@ -387,12 +387,12 @@ int  GetDarwinExecutablePath(char* path, uint32_t *pathsize)
   return 0;
 }
 
-const char* DarwinGetXbmcRootFolder(void)
+const char* CDarwinUtils::GetAppRootFolder(void)
 {
   static std::string rootFolder = "";
   if ( rootFolder.length() == 0)
   {
-    if (DarwinIsIosSandboxed())
+    if (IsIosSandboxed())
     {
       // when we are sandbox make documents our root
       // so that user can access everything he needs 
@@ -407,7 +407,7 @@ const char* DarwinGetXbmcRootFolder(void)
   return rootFolder.c_str();
 }
 
-bool DarwinIsIosSandboxed(void)
+bool CDarwinUtils::IsIosSandboxed(void)
 {
   static int ret = -1;
   if (ret == -1)
@@ -418,7 +418,7 @@ bool DarwinIsIosSandboxed(void)
     ret = 0;
     memset(given_path, 0x0, path_size);
     /* Get Application directory */  
-    result = GetDarwinExecutablePath(given_path, &path_size);
+    result = GetExecutablePath(given_path, &path_size);
     if (result == 0)
     {
       // we re sandboxed if we are installed in /var/mobile/Applications
@@ -432,7 +432,7 @@ bool DarwinIsIosSandboxed(void)
   return ret == 1;
 }
 
-bool DarwinHasVideoToolboxDecoder(void)
+bool CDarwinUtils::HasVideoToolboxDecoder(void)
 {
   static int DecoderAvailable = -1;
 
@@ -447,7 +447,7 @@ bool DarwinHasVideoToolboxDecoder(void)
     else
     {
       /* When XBMC is started from a sandbox directory we have to check the sysctl values */      
-      if (DarwinIsIosSandboxed())
+      if (IsIosSandboxed())
       {
         uint64_t proc_enforce = 0;
         uint64_t vnode_enforce = 0; 
@@ -477,11 +477,11 @@ bool DarwinHasVideoToolboxDecoder(void)
   return (DecoderAvailable == 1);
 }
 
-int DarwinBatteryLevel(void)
+int CDarwinUtils::BatteryLevel(void)
 {
   float batteryLevel = 0;
 #if defined(TARGET_DARWIN_IOS)
-  if(!DarwinIsAppleTV2())
+  if(!IsAppleTV2())
     batteryLevel = [[UIDevice currentDevice] batteryLevel];
 #else
   CFTypeRef powerSourceInfo = IOPSCopyPowerSourcesInfo();
@@ -512,7 +512,7 @@ int DarwinBatteryLevel(void)
   return batteryLevel * 100;  
 }
 
-void DarwinSetScheduling(int message)
+void CDarwinUtils::SetScheduling(int message)
 {
   int policy;
   struct sched_param param;
@@ -537,7 +537,7 @@ void DarwinSetScheduling(int message)
   result = pthread_setschedparam(this_pthread_self, policy, &param );
 }
 
-bool DarwinCFStringRefToStringWithEncoding(CFStringRef source, std::string &destination, CFStringEncoding encoding)
+bool CFStringRefToStringWithEncoding(CFStringRef source, std::string &destination, CFStringEncoding encoding)
 {
   const char *cstr = CFStringGetCStringPtr(source, encoding);
   if (!cstr)
@@ -565,20 +565,20 @@ bool DarwinCFStringRefToStringWithEncoding(CFStringRef source, std::string &dest
   return true;
 }
 
-void DarwinPrintDebugString(std::string debugString)
+void CDarwinUtils::PrintDebugString(std::string debugString)
 {
   NSLog(@"Debug Print: %s", debugString.c_str());
 }
 
 
-bool DarwinCFStringRefToString(CFStringRef source, std::string &destination)
+bool CDarwinUtils::CFStringRefToString(CFStringRef source, std::string &destination)
 {
-  return DarwinCFStringRefToStringWithEncoding(source, destination, CFStringGetSystemEncoding());
+  return CFStringRefToStringWithEncoding(source, destination, CFStringGetSystemEncoding());
 }
 
-bool DarwinCFStringRefToUTF8String(CFStringRef source, std::string &destination)
+bool CDarwinUtils::CFStringRefToUTF8String(CFStringRef source, std::string &destination)
 {
-  return DarwinCFStringRefToStringWithEncoding(source, destination, kCFStringEncodingUTF8);
+  return CFStringRefToStringWithEncoding(source, destination, kCFStringEncodingUTF8);
 }
 
 const std::string& CDarwinUtils::GetManufacturer(void)

--- a/xbmc/osx/IOSEAGLView.mm
+++ b/xbmc/osx/IOSEAGLView.mm
@@ -123,7 +123,7 @@
     //if no retina display scale detected yet -
     //ensure retina resolution on supported devices mainScreen
     //even on older iOS SDKs
-    if (ret == 1.0 && screen == [UIScreen mainScreen] && DarwinHasRetina())
+    if (ret == 1.0 && screen == [UIScreen mainScreen] && CDarwinUtils::DeviceHasRetina())
     {
       ret = 2.0;//all retina devices have a scale factor of 2.0
     }

--- a/xbmc/peripherals/bus/osx/PeripheralBusUSB.cpp
+++ b/xbmc/peripherals/bus/osx/PeripheralBusUSB.cpp
@@ -250,7 +250,7 @@ void CPeripheralBusUSB::DeviceAttachCallback(CPeripheralBusUSB* refCon, io_itera
             if (deviceFilePathAsCFString)
             {
               // Convert the path from a CFString to a std::string
-              if (!DarwinCFStringRefToUTF8String(deviceFilePathAsCFString, ttlDeviceFilePath))
+              if (!CDarwinUtils::CFStringRefToUTF8String(deviceFilePathAsCFString, ttlDeviceFilePath))
                 CLog::Log(LOGWARNING, "CPeripheralBusUSB::DeviceAttachCallback failed to convert CFStringRef");
               CFRelease(deviceFilePathAsCFString);
             }

--- a/xbmc/powermanagement/osx/CocoaPowerSyscall.cpp
+++ b/xbmc/powermanagement/osx/CocoaPowerSyscall.cpp
@@ -226,7 +226,7 @@ bool CCocoaPowerSyscall::HasBattery(void)
 
 int CCocoaPowerSyscall::BatteryLevel(void)
 {
-  return DarwinBatteryLevel();
+  return CDarwinUtils::BatteryLevel();
 }
 
 bool CCocoaPowerSyscall::PumpPowerEvents(IPowerEventsCallback *callback)

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -408,7 +408,7 @@ void CAdvancedSettings::Initialize()
     #if defined(TARGET_DARWIN_OSX)
     logDir += "/Library/Logs/";
     #else // ios/atv2
-    logDir += "/" + CStdString(DarwinGetXbmcRootFolder()) + "/";
+    logDir += "/" + CStdString(CDarwinUtils::GetAppRootFolder()) + "/";
     #endif
     m_logFolder = logDir;
   #else

--- a/xbmc/settings/SettingConditions.cpp
+++ b/xbmc/settings/SettingConditions.cpp
@@ -260,7 +260,7 @@ void CSettingConditions::Initialize()
     m_simpleConditions.insert("isappletv2");
 #endif
 #ifdef TARGET_DARWIN_OSX
-  if (DarwinIsSnowLeopard())
+  if (CDarwinUtils::IsSnowLeopard())
     m_simpleConditions.insert("osxissnowleopard");
 #endif
 #if defined(TARGET_WINDOWS) && defined(HAS_DX)

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -511,7 +511,7 @@ void CSettings::InitializeVisibility()
   CSettingString* timezonecountry = (CSettingString*)m_settingsManager->GetSetting("locale.timezonecountry");
   CSettingString* timezone = (CSettingString*)m_settingsManager->GetSetting("locale.timezone");
 
-  if (!g_sysinfo.IsAppleTV2() || GetIOSVersion() >= 4.3)
+  if (!g_sysinfo.IsAppleTV2() || CDarwinUtils::GetIOSVersion() >= 4.3)
   {
     timezonecountry->SetRequirementsMet(false);
     timezone->SetRequirementsMet(false);

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -644,9 +644,9 @@ std::string CSysInfo::GetOsVersion(void)
 #if defined(TARGET_WINDOWS) || defined(TARGET_FREEBSD)
   osVersion = GetKernelVersion(); // FIXME: for Win32 and FreeBSD OS version is a kernel version
 #elif defined(TARGET_DARWIN_IOS)
-  osVersion = GetIOSVersionString();
+  osVersion = CDarwinUtils::GetIOSVersionString();
 #elif defined(TARGET_DARWIN_OSX)
-  osVersion = GetOSXVersionString();
+  osVersion = CDarwinUtils::GetOSXVersionString();
 #elif defined(TARGET_ANDROID)
   char versionCStr[PROP_VALUE_MAX];
   int propLen = __system_property_get("ro.build.version.release", versionCStr);
@@ -810,7 +810,7 @@ std::string CSysInfo::GetModelName(void)
     int propLen = __system_property_get("ro.product.model", deviceCStr);
     modelName.assign(deviceCStr, (propLen > 0 && propLen <= PROP_VALUE_MAX) ? propLen : 0);
 #elif defined(TARGET_DARWIN_IOS)
-    modelName = getIosPlatformString();
+    modelName = CDarwinUtils::getIosPlatformString();
 #elif defined(TARGET_DARWIN_OSX)
     size_t nameLen = 0; // 'nameLen' should include terminating null
     if (sysctlbyname("hw.model", NULL, &nameLen, NULL, NULL) == 0 && nameLen > 1)
@@ -1220,7 +1220,7 @@ std::string CSysInfo::GetUserAgent()
 bool CSysInfo::IsAppleTV2()
 {
 #if defined(TARGET_DARWIN)
-  return DarwinIsAppleTV2();
+  return CDarwinUtils::IsAppleTV2();
 #else
   return false;
 #endif
@@ -1229,7 +1229,7 @@ bool CSysInfo::IsAppleTV2()
 bool CSysInfo::HasVideoToolBoxDecoder()
 {
 #if defined(HAVE_VIDEOTOOLBOXDECODER)
-  return DarwinHasVideoToolboxDecoder();
+  return CDarwinUtils::HasVideoToolboxDecoder();
 #else
   return false;
 #endif

--- a/xbmc/utils/posix/PosixInterfaceForCLog.cpp
+++ b/xbmc/utils/posix/PosixInterfaceForCLog.cpp
@@ -85,7 +85,7 @@ void CPosixInterfaceForCLog::PrintDebugString(const std::string &debugString)
 {
 #ifdef _DEBUG
 #if defined(TARGET_DARWIN)
-  DarwinPrintDebugString(debugString);
+  CDarwinUtils::PrintDebugString(debugString);
 #elif defined(TARGET_ANDROID)
   //print to adb
   CXBMCApp::android_printf("Debug Print: %s", debugString.c_str());

--- a/xbmc/windowing/osx/WinSystemIOS.mm
+++ b/xbmc/windowing/osx/WinSystemIOS.mm
@@ -385,7 +385,7 @@ void CWinSystemIOS::ShowOSMouse(bool show)
 
 bool CWinSystemIOS::HasCursor()
 {
-  if( DarwinIsAppleTV2() )
+  if( CDarwinUtils::IsAppleTV2() )
   {
     return true;
   }

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -751,7 +751,7 @@ bool CWinSystemOSX::ResizeWindowInternal(int newWidth, int newHeight, int newLef
 {
   bool ret = ResizeWindow(newWidth, newHeight, newLeft, newTop);
 
-  if( DarwinIsMavericks() )
+  if( CDarwinUtils::IsMavericks() )
   {
     NSView * last_view = (NSView *)additional;
     if (last_view && [last_view window])
@@ -921,7 +921,7 @@ bool CWinSystemOSX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
       [newContext setView:blankView];
 
       // Hide the menu bar.
-      if (GetDisplayID(res.iScreen) == kCGDirectMainDisplay || DarwinIsMavericks() )
+      if (GetDisplayID(res.iScreen) == kCGDirectMainDisplay || CDarwinUtils::IsMavericks() )
         SetMenuBarVisible(false);
 
       // Blank other displays if requested.
@@ -955,7 +955,7 @@ bool CWinSystemOSX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
         CGDisplayCapture(GetDisplayID(res.iScreen));
 
       // If we don't hide menu bar, it will get events and interrupt the program.
-      if (GetDisplayID(res.iScreen) == kCGDirectMainDisplay || DarwinIsMavericks() )
+      if (GetDisplayID(res.iScreen) == kCGDirectMainDisplay || CDarwinUtils::IsMavericks() )
         SetMenuBarVisible(false);
     }
 
@@ -983,7 +983,7 @@ bool CWinSystemOSX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
     [NSCursor unhide];
 
     // Show menubar.
-    if (GetDisplayID(res.iScreen) == kCGDirectMainDisplay || DarwinIsMavericks() )
+    if (GetDisplayID(res.iScreen) == kCGDirectMainDisplay || CDarwinUtils::IsMavericks() )
       SetMenuBarVisible(true);
 
     if (CSettings::Get().GetBool("videoscreen.fakefullscreen"))
@@ -1464,7 +1464,7 @@ bool CWinSystemOSX::IsObscured(void)
         if (!obscureLogged)
         {
           std::string appName;
-          if (DarwinCFStringRefToUTF8String(ownerName, appName))
+          if (CDarwinUtils::CFStringRefToUTF8String(ownerName, appName))
             CLog::Log(LOGDEBUG, "WinSystemOSX: Fullscreen window %s obscures XBMC!", appName.c_str());
           obscureLogged = true;
         }
@@ -1523,7 +1523,7 @@ void CWinSystemOSX::NotifyAppFocusChange(bool bGaining)
           // find the screenID
           NSDictionary* screenInfo = [[window screen] deviceDescription];
           NSNumber* screenID = [screenInfo objectForKey:@"NSScreenNumber"];
-          if ((CGDirectDisplayID)[screenID longValue] == kCGDirectMainDisplay || DarwinIsMavericks() )
+          if ((CGDirectDisplayID)[screenID longValue] == kCGDirectMainDisplay || CDarwinUtils::IsMavericks() )
           {
             SetMenuBarVisible(false);
           }


### PR DESCRIPTION
This will:
- reduce spoiling global namespace
- allow c++ objects, like std::string, to be returned
