### PR TITLE
[pvr] fix: remember the wrong selected item path if you close the channel osd

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
@@ -112,17 +112,17 @@ void CGUIDialogPVRChannelsOSD::OnDeinitWindow(int nextWindowID)
 {
   if (m_group)
   {
-    g_PVRManager.SetPlayingGroup(m_group);
-    m_group.reset();
-  }
+    if (m_group != GetPlayingGroup())
+    {
+      CGUIWindowPVRBase::SetSelectedItemPath(g_PVRManager.IsPlayingRadio(), GetLastSelectedItemPath(m_group->GroupID()));
+      g_PVRManager.SetPlayingGroup(m_group);
+    }
+    else
+    {
+      CGUIWindowPVRBase::SetSelectedItemPath(g_PVRManager.IsPlayingRadio(), m_viewControl.GetSelectedItemPath());
+    }
 
-  // set selected item path
-  int selectedItem = m_viewControl.GetSelectedItem();
-  if (selectedItem > -1)
-  {
-    CFileItemPtr fileItem = m_vecItems->Get(selectedItem);
-    if (fileItem)
-      CGUIWindowPVRBase::SetSelectedItemPath(g_PVRManager.IsPlayingRadio(), fileItem->GetPath());
+    m_group.reset();
   }
 
   CGUIDialog::OnDeinitWindow(nextWindowID);
@@ -190,7 +190,7 @@ void CGUIDialogPVRChannelsOSD::Update()
       {
         m_group = group;
         m_viewControl.SetSelectedItem(CGUIWindowPVRBase::GetSelectedItemPath(channel->IsRadio()));
-        SaveSelectedItem(group->GroupID());
+        SaveSelectedItemPath(group->GroupID());
       }
     }
   }
@@ -204,7 +204,7 @@ void CGUIDialogPVRChannelsOSD::SaveControlStates()
 
   CPVRChannelGroupPtr group = GetPlayingGroup();
   if (group)
-    SaveSelectedItem(group->GroupID());
+    SaveSelectedItemPath(group->GroupID());
 }
 
 void CGUIDialogPVRChannelsOSD::RestoreControlStates()
@@ -214,7 +214,7 @@ void CGUIDialogPVRChannelsOSD::RestoreControlStates()
   CPVRChannelGroupPtr group = GetPlayingGroup();
   if (group)
   {
-    m_viewControl.SetSelectedItem(GetLastSelectedItem(group->GroupID()));
+    m_viewControl.SetSelectedItem(GetLastSelectedItemPath(group->GroupID()));
   }
 }
 
@@ -333,15 +333,15 @@ void CGUIDialogPVRChannelsOSD::Notify(const Observable &obs, const ObservableMes
   }
 }
 
-void CGUIDialogPVRChannelsOSD::SaveSelectedItem(int iGroupID)
+void CGUIDialogPVRChannelsOSD::SaveSelectedItemPath(int iGroupID)
 {
-  m_groupSelectedItems[iGroupID] = m_viewControl.GetSelectedItem();
+  m_groupSelectedItemPaths[iGroupID] = m_viewControl.GetSelectedItemPath();
 }
 
-int CGUIDialogPVRChannelsOSD::GetLastSelectedItem(int iGroupID) const
+std::string CGUIDialogPVRChannelsOSD::GetLastSelectedItemPath(int iGroupID) const
 {
-  std::map<int,int>::const_iterator it = m_groupSelectedItems.find(iGroupID);
-  if (it != m_groupSelectedItems.end())
+  std::map<int, std::string>::const_iterator it = m_groupSelectedItemPaths.find(iGroupID);
+  if (it != m_groupSelectedItemPaths.end())
     return it->second;
-  return 0;
+  return "";
 }

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.h
@@ -59,9 +59,9 @@ namespace PVR
 
   private:
     CPVRChannelGroupPtr m_group;
-    std::map<int,int> m_groupSelectedItems;
-    void SaveSelectedItem(int iGroupID);
-    int GetLastSelectedItem(int iGroupID) const;
+    std::map<int, std::string> m_groupSelectedItemPaths;
+    void SaveSelectedItemPath(int iGroupID);
+    std::string GetLastSelectedItemPath(int iGroupID) const;
   };
 }
 

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -715,11 +715,5 @@ void CGUIWindowPVRBase::UpdateButtons(void)
 
 void CGUIWindowPVRBase::UpdateSelectedItemPath()
 {
-  int selectedItem = m_viewControl.GetSelectedItem();
-  if (selectedItem > -1)
-  {
-    CFileItemPtr fileItem = m_vecItems->Get(selectedItem);
-    if (fileItem)
-      m_selectedItemPaths.at(m_bRadio) = fileItem->GetPath();
-  }
+  m_selectedItemPaths.at(m_bRadio) = m_viewControl.GetSelectedItemPath();
 }

--- a/xbmc/view/GUIViewControl.cpp
+++ b/xbmc/view/GUIViewControl.cpp
@@ -175,6 +175,22 @@ int CGUIViewControl::GetSelectedItem() const
   return GetSelectedItem(m_visibleViews[m_currentView]);
 }
 
+std::string CGUIViewControl::GetSelectedItemPath() const
+{
+  if (m_currentView < 0 || (size_t)m_currentView >= m_visibleViews.size())
+    return "";
+
+  int selectedItem = GetSelectedItem(m_visibleViews[m_currentView]);
+  if (selectedItem > -1)
+  {
+    CFileItemPtr fileItem = m_fileItems->Get(selectedItem);
+    if (fileItem)
+      return fileItem->GetPath();
+  }
+
+  return "";
+}
+
 void CGUIViewControl::SetSelectedItem(int item)
 {
   if (!m_fileItems || item < 0 || item >= m_fileItems->Size())

--- a/xbmc/view/GUIViewControl.h
+++ b/xbmc/view/GUIViewControl.h
@@ -46,6 +46,7 @@ public:
   void SetSelectedItem(const std::string &itemPath);
 
   int GetSelectedItem() const;
+  std::string GetSelectedItemPath() const;
   void SetFocused();
 
   bool HasControl(int controlID) const;


### PR DESCRIPTION
If you close the channel osd on a different group than the current playing group without switching to a channel of this group, the wrong selected item path is stored in the global variable. This fix it by setting the proper selected item of the current playing group.
