### PR TITLE
fix hiding component-specific logging when debug logging is enabled and hidden through advancedsettings.xml (fixes #15409)

### DIFF
--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -832,9 +832,6 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
       CSetting *setting = CSettings::Get().GetSetting("debug.showloginfo");
       if (setting != NULL)
         setting->SetVisible(false);
-      setting = CSettings::Get().GetSetting("debug.setextraloglevel");
-      if (setting != NULL)
-        setting->SetVisible(false);
     }
     g_advancedSettings.m_logLevel = std::max(g_advancedSettings.m_logLevel, g_advancedSettings.m_logLevelHint);
     CLog::SetLogLevel(g_advancedSettings.m_logLevel);


### PR DESCRIPTION
This fixes http://trac.xbmc.org/ticket/15409. The problem right now is that when we have the following in advancedsettings.xml

```
<loglevel>1</loglevel>
```

this implicitly triggers the logic that hides the "Enable debug logging" setting in the GUI settings. It however also hides the "Specify component-specific logging..." setting but not the "Enable component specific logging" setting. That leaves the user with the possibility to enable component specific logging in general but doesn't give him a way to actually choose the components. So either we need to hide all three settings or only the "Enable debug logging" setting.

I've chosen to implement the latter since the above advancedsettings.xml snippet only enables debug logging (i.e. it only overwrites the value of the "Enable debug logging" setting) but doesn't touch component specific logging so that should still be possible through the GUI.
