### PR TITLE
CHG: [droid] refactor wake lock; follow our screensaver

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3776,10 +3776,6 @@ void CApplication::ActivateScreenSaver(bool forceType /*= false */)
     m_screenSaver.reset(new CScreenSaver(""));
 
   CAnnouncementManager::Get().Announce(GUI, "xbmc", "OnScreensaverActivated");
-#ifdef TARGET_ANDROID
-  // Screensaver activated -> release wake lock
-  CXBMCApp::EnableWakeLock(false);
-#endif
 
   // disable screensaver lock from the login screen
   m_iScreenSaveLock = g_windowManager.GetActiveWindow() == WINDOW_LOGIN_SCREEN ? 1 : 0;
@@ -3792,11 +3788,18 @@ void CApplication::ActivateScreenSaver(bool forceType /*= false */)
         m_screenSaver.reset(new CScreenSaver(""));
     }
   }
-  if (m_screenSaver->ID() == "screensaver.xbmc.builtin.dim" || m_screenSaver->ID().empty())
+  if (m_screenSaver->ID() == "screensaver.xbmc.builtin.dim"
+      || m_screenSaver->ID() == "screensaver.xbmc.builtin.black")
+  {
+#ifdef TARGET_ANDROID
+    // Default screensaver activated -> release wake lock
+    CXBMCApp::EnableWakeLock(false);
+#endif
     return;
-  else if (m_screenSaver->ID() == "screensaver.xbmc.builtin.black")
+  }
+  else if (m_screenSaver->ID().empty())
     return;
-  else if (!m_screenSaver->ID().empty())
+  else
     g_windowManager.ActivateWindow(WINDOW_SCREENSAVER);
 }
 

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3642,6 +3642,10 @@ bool CApplication::WakeUpScreenSaverAndDPMS(bool bPowerOffKeyPressed /* = false 
     CVariant data(CVariant::VariantTypeObject);
     data["shuttingdown"] = bPowerOffKeyPressed;
     CAnnouncementManager::Get().Announce(GUI, "xbmc", "OnScreensaverDeactivated", data);
+#ifdef TARGET_ANDROID
+    // Screensaver deactivated -> acquire wake lock
+    CXBMCApp::EnableWakeLock(true);
+#endif
   }
 
   return result;
@@ -3772,6 +3776,10 @@ void CApplication::ActivateScreenSaver(bool forceType /*= false */)
     m_screenSaver.reset(new CScreenSaver(""));
 
   CAnnouncementManager::Get().Announce(GUI, "xbmc", "OnScreensaverActivated");
+#ifdef TARGET_ANDROID
+  // Screensaver activated -> release wake lock
+  CXBMCApp::EnableWakeLock(false);
+#endif
 
   // disable screensaver lock from the login screen
   m_iScreenSaveLock = g_windowManager.GetActiveWindow() == WINDOW_LOGIN_SCREEN ? 1 : 0;

--- a/xbmc/android/activity/XBMCApp.cpp
+++ b/xbmc/android/activity/XBMCApp.cpp
@@ -268,7 +268,8 @@ bool CXBMCApp::EnableWakeLock(bool on)
     std::string appName = CCompileInfo::GetAppName();
     StringUtils::ToLower(appName);
     std::string className = "org.xbmc." + appName;
-    m_wakeLock = new CJNIWakeLock(CJNIPowerManager(getSystemService("power")).newWakeLock(className.c_str()));
+    // SCREEN_BRIGHT_WAKE_LOCK is marked as deprecated but there is no real alternatives for now
+    m_wakeLock = new CJNIWakeLock(CJNIPowerManager(getSystemService("power")).newWakeLock(CJNIPowerManager::SCREEN_BRIGHT_WAKE_LOCK, className.c_str()));
     if (m_wakeLock)
       m_wakeLock->setReferenceCounted(false);
     else

--- a/xbmc/android/activity/XBMCApp.cpp
+++ b/xbmc/android/activity/XBMCApp.cpp
@@ -86,9 +86,11 @@ void* thread_run(void* obj)
 }
 CEvent CXBMCApp::m_windowCreated;
 ANativeActivity *CXBMCApp::m_activity = NULL;
+CJNIWakeLock *CXBMCApp::m_wakeLock = NULL;
 ANativeWindow* CXBMCApp::m_window = NULL;
 int CXBMCApp::m_batteryLevel = 0;
 int CXBMCApp::m_initialVolume = 0;
+bool CXBMCApp::m_hasFocus = false;
 CCriticalSection CXBMCApp::m_applicationsMutex;
 std::vector<androidPackage> CXBMCApp::m_applications;
 
@@ -96,7 +98,6 @@ std::vector<androidPackage> CXBMCApp::m_applications;
 CXBMCApp::CXBMCApp(ANativeActivity* nativeActivity)
   : CJNIApplicationMainActivity(nativeActivity)
   , CJNIBroadcastReceiver("org/xbmc/kodi/XBMCBroadcastReceiver")
-  , m_wakeLock(NULL)
 {
   m_activity = nativeActivity;
   m_firstrun = true;
@@ -111,6 +112,7 @@ CXBMCApp::CXBMCApp(ANativeActivity* nativeActivity)
 
 CXBMCApp::~CXBMCApp()
 {
+  delete m_wakeLock;
 }
 
 void CXBMCApp::onStart()
@@ -137,9 +139,16 @@ void CXBMCApp::onStart()
 void CXBMCApp::onResume()
 {
   android_printf("%s: ", __PRETTY_FUNCTION__);
-  CJNIIntentFilter batteryFilter;
-  batteryFilter.addAction("android.intent.action.BATTERY_CHANGED");
-  registerReceiver(*this, batteryFilter);
+  CJNIIntentFilter intentFilter;
+  intentFilter.addAction("android.intent.action.BATTERY_CHANGED");
+  intentFilter.addAction("android.intent.action.DREAMING_STOPPED");
+  intentFilter.addAction("android.intent.action.SCREEN_ON");
+  registerReceiver(*this, intentFilter);
+
+  if (!g_application.IsInScreenSaver())
+    EnableWakeLock(true);
+  else
+    g_application.WakeUpScreenSaverAndDPMS();
 
   // Clear the applications cache. We could have installed/deinstalled apps
   {
@@ -160,6 +169,8 @@ void CXBMCApp::onPause()
   // non-aml boxes will ignore this intent broadcast.
   CJNIIntent intent_aml_video_off = CJNIIntent("android.intent.action.REALVIDEO_OFF");
   sendBroadcast(intent_aml_video_off);
+
+  EnableWakeLock(false);
 }
 
 void CXBMCApp::onStop()
@@ -178,12 +189,6 @@ void CXBMCApp::onDestroy()
     XBMC_Stop();
     pthread_join(m_thread, NULL);
     android_printf(" => XBMC finished");
-  }
-
-  if (m_wakeLock != NULL && m_activity != NULL)
-  {
-    delete m_wakeLock;
-    m_wakeLock = NULL;
   }
 }
 
@@ -215,8 +220,6 @@ void CXBMCApp::onCreateWindow(ANativeWindow* window)
   }
   m_window = window;
   m_windowCreated.Set();
-  if (getWakeLock() &&  m_wakeLock)
-    m_wakeLock->acquire();
   if(!m_firstrun)
   {
     XBMC_SetupDisplay();
@@ -242,33 +245,47 @@ void CXBMCApp::onDestroyWindow()
     XBMC_DestroyDisplay();
     XBMC_Pause(true);
   }
-
-  if (m_wakeLock)
-    m_wakeLock->release();
-
 }
 
 void CXBMCApp::onGainFocus()
 {
   android_printf("%s: ", __PRETTY_FUNCTION__);
+  m_hasFocus = true;
+  g_application.WakeUpScreenSaverAndDPMS();
 }
 
 void CXBMCApp::onLostFocus()
 {
   android_printf("%s: ", __PRETTY_FUNCTION__);
+  m_hasFocus = false;
 }
 
-bool CXBMCApp::getWakeLock()
+bool CXBMCApp::EnableWakeLock(bool on)
 {
-  if (m_wakeLock)
-    return true;
+  android_printf("%s: %s", __PRETTY_FUNCTION__, on ? "true" : "false");
+  if (!m_wakeLock)
+  {
+    std::string appName = CCompileInfo::GetAppName();
+    StringUtils::ToLower(appName);
+    std::string className = "org.xbmc." + appName;
+    m_wakeLock = new CJNIWakeLock(CJNIPowerManager(getSystemService("power")).newWakeLock(className.c_str()));
+    if (m_wakeLock)
+      m_wakeLock->setReferenceCounted(false);
+    else
+      return false;
+  }
 
-  std::string appName = CCompileInfo::GetAppName();
-  StringUtils::ToLower(appName);
-  std::string className = "org.xbmc." + appName;
-  m_wakeLock = new CJNIWakeLock(CJNIPowerManager(getSystemService("power")).newWakeLock(className.c_str()));
+  if (on)
+    m_wakeLock->acquire();
+  else if (m_wakeLock->isHeld())
+    m_wakeLock->release();
 
   return true;
+}
+
+bool CXBMCApp::HasFocus()
+{
+  return m_hasFocus;
 }
 
 void CXBMCApp::run()
@@ -608,6 +625,9 @@ void CXBMCApp::onReceive(CJNIIntent intent)
   android_printf("CXBMCApp::onReceive Got intent. Action: %s", action.c_str());
   if (action == "android.intent.action.BATTERY_CHANGED")
     m_batteryLevel = intent.getIntExtra("level",-1);
+  else if (action == "android.intent.action.DREAMING_STOPPED" || action == "android.intent.action.SCREEN_ON")
+    if (HasFocus())
+      g_application.WakeUpScreenSaverAndDPMS();
 }
 
 void CXBMCApp::onNewIntent(CJNIIntent intent)

--- a/xbmc/android/activity/XBMCApp.cpp
+++ b/xbmc/android/activity/XBMCApp.cpp
@@ -277,9 +277,15 @@ bool CXBMCApp::EnableWakeLock(bool on)
   }
 
   if (on)
-    m_wakeLock->acquire();
-  else if (m_wakeLock->isHeld())
-    m_wakeLock->release();
+  {
+    if (!m_wakeLock->isHeld())
+      m_wakeLock->acquire();
+  }
+  else
+  {
+    if (m_wakeLock->isHeld())
+      m_wakeLock->release();
+  }
 
   return true;
 }

--- a/xbmc/android/activity/XBMCApp.h
+++ b/xbmc/android/activity/XBMCApp.h
@@ -84,6 +84,9 @@ public:
   static int android_printf(const char *format, ...);
   
   static int GetBatteryLevel();
+  static bool EnableWakeLock(bool on);
+  static bool HasFocus();
+
   static bool StartActivity(const std::string &package, const std::string &intent = std::string(), const std::string &dataType = std::string(), const std::string &dataURI = std::string());
   static std::vector <androidPackage> GetApplications();
   static bool GetIconSize(const std::string &packageName, int *width, int *height);
@@ -111,15 +114,15 @@ protected:
 
 private:
   static bool HasLaunchIntent(const std::string &package);
-  bool getWakeLock();
   std::string GetFilenameFromIntent(const CJNIIntent &intent);
   void run();
   void stop();
   void SetupEnv();
   static ANativeActivity *m_activity;
-  CJNIWakeLock *m_wakeLock;
-  static int m_batteryLevel;  
-  static int m_initialVolume;  
+  static CJNIWakeLock *m_wakeLock;
+  static int m_batteryLevel;
+  static int m_initialVolume;
+  static bool m_hasFocus;
   bool m_firstrun;
   bool m_exiting;
   pthread_t m_thread;

--- a/xbmc/android/jni/PowerManager.cpp
+++ b/xbmc/android/jni/PowerManager.cpp
@@ -25,18 +25,20 @@
 using namespace jni;
 
 int CJNIPowerManager::FULL_WAKE_LOCK(0);
+int CJNIPowerManager::SCREEN_BRIGHT_WAKE_LOCK(0xa);
 
 void CJNIPowerManager::PopulateStaticFields()
 {
   jhclass clazz  = find_class("android/os/PowerManager");
   FULL_WAKE_LOCK = (get_static_field<int>(clazz, "FULL_WAKE_LOCK"));
+  SCREEN_BRIGHT_WAKE_LOCK = (get_static_field<int>(clazz, "SCREEN_BRIGHT_WAKE_LOCK"));
 }
 
-CJNIWakeLock CJNIPowerManager::newWakeLock(const std::string &name)
+CJNIWakeLock CJNIPowerManager::newWakeLock(int levelAndFlags, const std::string &tag)
 {
   return call_method<jhobject>(m_object,
     "newWakeLock", "(ILjava/lang/String;)Landroid/os/PowerManager$WakeLock;",
-    FULL_WAKE_LOCK, jcast<jhstring>(name));
+    levelAndFlags, jcast<jhstring>(tag));
 }
 
 void CJNIPowerManager::goToSleep(int64_t timestamp)

--- a/xbmc/android/jni/PowerManager.h
+++ b/xbmc/android/jni/PowerManager.h
@@ -29,14 +29,15 @@ public:
   CJNIPowerManager(const jni::jhobject &object) : CJNIBase(object) {};
   ~CJNIPowerManager() {};
 
-  CJNIWakeLock  newWakeLock(const std::string &name);
+  CJNIWakeLock  newWakeLock(int levelAndFlags, const std::string &name);
   void          reboot(const std::string &reason);
   void          goToSleep(int64_t timestamp);
 
   static void   PopulateStaticFields();
 
+  static int FULL_WAKE_LOCK;
+  static int SCREEN_BRIGHT_WAKE_LOCK;
+
 private:
   CJNIPowerManager();
-
-  static int FULL_WAKE_LOCK;
 };

--- a/xbmc/android/jni/WakeLock.cpp
+++ b/xbmc/android/jni/WakeLock.cpp
@@ -32,6 +32,18 @@ void CJNIWakeLock::acquire()
 void CJNIWakeLock::release()
 {
   call_method<void>(m_object,
-    "release", "()V");
+                    "release", "()V");
+}
+
+bool CJNIWakeLock::isHeld()
+{
+  return call_method<jboolean>(m_object,
+                        "isHeld", "()Z");
+}
+
+void CJNIWakeLock::setReferenceCounted(bool val)
+{
+  call_method<void>(m_object,
+                        "setReferenceCounted", "(Z)V", val);
 }
 

--- a/xbmc/android/jni/WakeLock.h
+++ b/xbmc/android/jni/WakeLock.h
@@ -29,6 +29,8 @@ public:
 
   void acquire();
   void release();
+  bool isHeld();
+  void setReferenceCounted(bool val);
 
 protected:
   CJNIWakeLock();


### PR DESCRIPTION
This refactors the wake lock to release it when our screensaver goes active.

This allows:
- Control on the wake lock via our screensaver settings
- Devices to go to sleep when we are inactive (e.g. Amazon FTV and tablets)

/cc @Montellese @davilla @t-nelson
