### PR TITLE
fix login into password protected profiles

### DIFF
--- a/xbmc/guilib/GUIKeyboardFactory.cpp
+++ b/xbmc/guilib/GUIKeyboardFactory.cpp
@@ -216,7 +216,7 @@ int CGUIKeyboardFactory::ShowAndVerifyPassword(std::string& strPassword, const s
       return 0;
 
     std::string md5pword2 = XBMC::XBMC_MD5::GetMD5(strUserInput);
-    if (strPassword == md5pword2)
+    if (StringUtils::EqualsNoCase(strPassword, md5pword2))
       return 0;     // user entered correct password
     else return 1;  // user must have entered an incorrect password
   }


### PR DESCRIPTION
While hunting down a bug in JSON-RPC's profile handling code I noticed that I wasn't able to log into a password protected profile from the GUI. The reason is that we safe the password as an **all lower-case** MD5 hash. When we ask the user to enter the password, we compute the MD5 hash and compare the two strings but the computed MD5 hash is **all upper-case**. Therefore the comparison needs to be case insensitive. I guess this is a regression from the CStdString removal.

PS: Does anybody know why we allow entering the MD5 hash into the password field? At https://github.com/Montellese/xbmc/blob/master/xbmc/guilib/GUIKeyboardFactory.cpp#L215 we simply compare the input from the password field with the actual password without computing the MD5 hash. If it matches we accept the input as the valid password. This is **very insecure**.
