### PR TITLE
security: do not accept the MD5 hash of a password

### DIFF
--- a/xbmc/guilib/GUIKeyboardFactory.cpp
+++ b/xbmc/guilib/GUIKeyboardFactory.cpp
@@ -212,9 +212,6 @@ int CGUIKeyboardFactory::ShowAndVerifyPassword(std::string& strPassword, const s
 
   if (!strPassword.empty())
   {
-    if (strPassword == strUserInput)
-      return 0;
-
     std::string md5pword2 = XBMC::XBMC_MD5::GetMD5(strUserInput);
     if (StringUtils::EqualsNoCase(strPassword, md5pword2))
       return 0;     // user entered correct password


### PR DESCRIPTION
Right now it is possible to enter the MD5 hash of e.g. a profile password instead of the actual password in the password dialog and the password will be accepted. That is a huge security hole. I guess it was there for backwards compatibility when we used to store profile passwords in plain text (a long time ago).

Follow up of #5455 where I first mentioned this.
