### PR TITLE
[python] add *all* module dependencies to path

### DIFF
--- a/xbmc/interfaces/python/PythonInvoker.h
+++ b/xbmc/interfaces/python/PythonInvoker.h
@@ -66,6 +66,7 @@ private:
   bool initializeModule(PythonModuleInitialization module);
   void addPath(const std::string& path); // add path in UTF-8 encoding
   void addNativePath(const std::string& path); // add path in system/Python encoding
+  void getAddonModuleDeps(const ADDON::AddonPtr& addon, std::set<std::string>& paths);
 
   std::string m_pythonPath;
   void *m_threadState;


### PR DESCRIPTION
Fixes an issue with #5201: dependencies of dependencies are not added to the path. For instance if addon A depends on module B, and module B depends on module C, C would not be added to path when invoking A. Pay attention people!;)
