### PR TITLE
Update fileposition on write in AFPFile

### DIFF
--- a/xbmc/filesystem/AFPFile.cpp
+++ b/xbmc/filesystem/AFPFile.cpp
@@ -633,6 +633,9 @@ int CAFPFile::Write(const void* lpBuf, int64_t uiBufSize)
   numberOfBytesWritten = gAfpConnection.GetImpl()->afp_wrap_write(m_pAfpVol,
     name, (const char *)lpBuf, (size_t)uiBufSize, m_fileOffset, m_pFp, uid, gid);
 
+  if (numberOfBytesWritten > 0)
+    m_fileOffset += numberOfBytesWritten;
+
   return numberOfBytesWritten;
 }
 


### PR DESCRIPTION
Seems like AFPFile doesn't update its internal position on write (which was the old API of CFile) which makes it not behave consistently with the other vfs modules in mixed read/write scenarios.
