### PR TITLE
Better handle Read/Write errors in PosixFile and Win32File

### DIFF
--- a/xbmc/filesystem/posix/PosixFile.cpp
+++ b/xbmc/filesystem/posix/PosixFile.cpp
@@ -122,7 +122,10 @@ unsigned int CPosixFile::Read(void* lpBuf, int64_t uiBufSize)
   
   const ssize_t res = read(m_fd, lpBuf, uiBufSize);
   if (res < 0)
+  {
+    Seek(0, SEEK_CUR); // force update file position
     return 0; // TODO: return -1
+  }
   
   if (m_filePos >= 0)
   {
@@ -158,7 +161,10 @@ int CPosixFile::Write(const void* lpBuf, int64_t uiBufSize)
   
   const ssize_t res = write(m_fd, lpBuf, uiBufSize);
   if (res < 0)
+  {
+    Seek(0, SEEK_CUR); // force update file position
     return -1;
+  }
   
   if (m_filePos >= 0)
     m_filePos += res; // if m_filePos was known - update it

--- a/xbmc/filesystem/win32/Win32File.cpp
+++ b/xbmc/filesystem/win32/Win32File.cpp
@@ -188,7 +188,10 @@ unsigned int CWin32File::Read(void* lpBuf, int64_t uiBufSize)
   {
     DWORD lastRead = 0;
     if (!ReadFile(m_hFile, ((BYTE*)lpBuf) + read, (uiBufSize > DWORD_MAX) ? DWORD_MAX : (DWORD)uiBufSize, &lastRead, NULL))
+    {
+      m_filePos = -1;
       return 0; // TODO: return -1
+    }
     read += lastRead;
     // if m_filePos is set - update it
     if (m_filePos >= 0)
@@ -225,7 +228,10 @@ int CWin32File::Write(const void* lpBuf, int64_t uiBufSize)
     DWORD lastWritten = 0;
     const DWORD toWrite = uiBufSize > DWORD_MAX ? DWORD_MAX : (DWORD)uiBufSize;
     if (!WriteFile(m_hFile, ((const BYTE*)lpBuf) + written, toWrite, &lastWritten, NULL))
+    {
+      m_filePos = -1;
       return -1;
+    }
     written += lastWritten;
     uiBufSize -= lastWritten;
     // if m_filePos is set - update it


### PR DESCRIPTION
Invalidate io pointer on Win32 as it's unknown where read/write was aborted, force update io pointer on Posix for `posix_fadvise`.
