### PR TITLE
[win32] - only allow operating system updates on shutdown/reboot if user has automatic updates configured

### DIFF
--- a/xbmc/win32/WIN32Util.h
+++ b/xbmc/win32/WIN32Util.h
@@ -96,6 +96,7 @@ public:
   static std::string WUSysMsg(DWORD dwError);
 private:
   static DEVINST GetDrivesDevInstByDiskNumber(long DiskNumber);
+  static bool AllowOSUpdatesOnShutdown();
 };
 
 


### PR DESCRIPTION
Follow up to #5466 - not runtime tested yet (will come to it later the day). Someone needs to find out if we need this or if "SHUTDOWN_INSTALL_UPDATES" really does exactly that. If you ask me - the msdn documentation is a bit unclear about the real behavior.

As stated in the other PR - it would be unacceptable if updates are installed during kodi shutdown or reboot if user has automated update installation truned off in windows control panel.
