### PR TITLE
[keyboardlayouts] rename ABC and QWERTY layout 'English'

### DIFF
--- a/system/keyboardlayouts.xml
+++ b/system/keyboardlayouts.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <keyboardlayouts>
-  <layout name="QWERTY">
+  <layout name="English">
     <keyboard>
       <row>1234567890</row>
       <row>qwertyuiop</row>
@@ -40,7 +40,7 @@
       <row>`~éèçà</row>
     </keyboard>
   </layout>
-  <layout name="ABC">
+  <layout name="English ABC">
     <keyboard>
       <row>0123456789</row>
       <row>abcdefghij</row>


### PR DESCRIPTION
I'm assuming the purpose here is to support regional keyboard layouts for the all different languages. In that case it should specify language because [there are lots of different "QWERTY" keyboard layouts](http://en.wikipedia.org/wiki/QWERTY#Diacritical_marks_and_international_variants). The common way to do this is to have the standard named after the language and "English (Dvorak)" etc.
