### PR TITLE
[pvr] fix unnecessary creation of new CPVRChannel instances

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -3723,37 +3723,31 @@ CStdString CGUIInfoManager::GetMusicTagLabel(int info, const CFileItem *item)
     return GetItemLabel(item, LISTITEM_DURATION);
   case MUSICPLAYER_CHANNEL_NAME:
     {
-      CPVRChannel* channeltag = m_currentFile->GetPVRChannelInfoTag();
-      if (channeltag)
-        return channeltag->ChannelName();
+      if (m_currentFile->HasPVRChannelInfoTag())
+        return m_currentFile->GetPVRChannelInfoTag()->ChannelName();
     }
     break;
   case MUSICPLAYER_CHANNEL_NUMBER:
     {
-      CPVRChannel* channeltag = m_currentFile->GetPVRChannelInfoTag();
-      if (channeltag)
-      {
-        return StringUtils::Format("%i", channeltag->ChannelNumber());
-      }
+      if (m_currentFile->HasPVRChannelInfoTag())
+        return StringUtils::Format("%i", m_currentFile->GetPVRChannelInfoTag()->ChannelNumber());
     }
     break;
   case MUSICPLAYER_SUB_CHANNEL_NUMBER:
     {
-      CPVRChannel* channel = m_currentFile->GetPVRChannelInfoTag();
-      if (channel)
-        return StringUtils::Format("%i", channel->SubChannelNumber());
+      if (m_currentFile->HasPVRChannelInfoTag())
+        return StringUtils::Format("%i", m_currentFile->GetPVRChannelInfoTag()->SubChannelNumber());
     }
     break;
   case MUSICPLAYER_CHANNEL_NUMBER_LBL:
     {
-      CPVRChannel* channel = m_currentFile->GetPVRChannelInfoTag();
-      return channel ? channel->FormattedChannelNumber() : "";
+      if (m_currentFile->HasPVRChannelInfoTag())
+        return m_currentFile->GetPVRChannelInfoTag()->FormattedChannelNumber();
     }
     break;
   case MUSICPLAYER_CHANNEL_GROUP:
     {
-      CPVRChannel* channeltag = m_currentFile->GetPVRChannelInfoTag();
-      if (channeltag && channeltag->IsRadio())
+      if (m_currentFile->HasPVRChannelInfoTag() && m_currentFile->GetPVRChannelInfoTag()->IsRadio())
         return g_PVRManager.GetPlayingGroup(true)->GroupName();
     }
     break;


### PR DESCRIPTION
Has seen during integration of Radio RDS in XBMC the music player info generate always the CPVRChannel class new if not present, with this e.g. 
- CPVRChannel\* channel = m_currentFile->GetPVRChannelInfoTag();
- return channel ? channel->FormattedChannelNumber() : "";
  has always then returned a new class "0" string without PVR.

Used this to identify PVR channel on music OSD skin with 
<visible>Player.HasAudio + !IsEmpty(MusicPlayer.ChannelNumberLabel)</visible>
and found it.
