### PR TITLE
Dialog: Don't reset symbol keys after onClickButton

### DIFF
--- a/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
+++ b/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
@@ -303,9 +303,8 @@ void CGUIDialogKeyboardGeneric::OnClickButton(int iButtonControl)
     if (pButton)
     {
       Character(pButton->GetDescription());
-      // reset the shift and symbol keys
+      // reset the shift keys
       if (m_bShift) OnShift();
-      if (m_keyType == SYMBOLS) OnSymbols();
     }
   }
 }


### PR DESCRIPTION
- Resetting the keys makes typing a URL, SMB, FTP or any address
  a longer process than is necessary, especially with a remote.

Signed-off-by: Brandon McAnsh brandonm@matricom.net
