### PR TITLE
[ios8] - bugfixes for ios8 runtime

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecVideoToolBox.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecVideoToolBox.cpp
@@ -66,7 +66,8 @@ enum {
 enum {
   // tells the decoder not to bother returning a CVPixelBuffer
   // in the outputCallback. The output callback will still be called.
-  kVTDecoderDecodeFlags_DontEmitFrame = 1 << 0
+  kVTDecoderDecodeFlags_DontEmitFrame = 1 << 0,
+  kVTDecoderDecodeFlags_DontEmitFrameIOS8 = 1 << 1
 };
 enum {
   // decode and return buffers for all frames currently in flight.
@@ -1375,7 +1376,12 @@ int CDVDVideoCodecVideoToolBox::Decode(uint8_t* pData, int iSize, double dts, do
     frameInfo = CreateDictionaryWithDisplayTime(sort_time - m_sort_time_offset, dts, pts);
 
     if (m_DropPictures)
-      decoderFlags = kVTDecoderDecodeFlags_DontEmitFrame;
+    {
+      if (CDarwinUtils::GetIOSVersion() >= 8.0)
+        decoderFlags = kVTDecoderDecodeFlags_DontEmitFrameIOS8;
+      else
+        decoderFlags = kVTDecoderDecodeFlags_DontEmitFrame;
+    }
 
     // submit for decoding
     status = VTDecompressionSessionDecodeFrame(m_vt_session, sampleBuff, decoderFlags, frameInfo, 0);

--- a/xbmc/osx/IOSScreenManager.mm
+++ b/xbmc/osx/IOSScreenManager.mm
@@ -244,11 +244,17 @@ static CEvent screenChangeEvent;
   res.size = [brwin interfaceFrame].size;
 #endif
 #else
-  //main screen is in portrait mode (physically) so exchange height and width
-  if(screen == [UIScreen mainScreen])
+  #if __IPHONE_8_0
+  if (CDarwinUtils::GetIOSVersion() < 8.0)
+  #endif
   {
-    CGRect frame = res;
-    res.size = CGSizeMake(frame.size.height, frame.size.width);
+    //main screen is in portrait mode (physically) so exchange height and width
+    //at least when compiled with ios sdk < 8.0 (seems to be fixed in later sdks)
+    if(screen == [UIScreen mainScreen])
+    {
+      CGRect frame = res;
+      res.size = CGSizeMake(frame.size.height, frame.size.width);
+    }
   }
 #endif
   return res;

--- a/xbmc/osx/IOSScreenManager.mm
+++ b/xbmc/osx/IOSScreenManager.mm
@@ -30,6 +30,7 @@
 #include "WindowingFactory.h"
 #include "settings/DisplaySettings.h"
 #include "cores/AudioEngine/AEFactory.h"
+#include "osx/DarwinUtils.h"
 #undef BOOL
 
 #import <Foundation/Foundation.h>
@@ -95,10 +96,20 @@ static CEvent screenChangeEvent;
     if (toExternal)
     {
       // portrait on external screen means its landscape for xbmc
-      [g_xbmcController activateScreen:newScreen withOrientation:UIInterfaceOrientationPortrait];// will attach the screen to xbmc mainwindow
+#if __IPHONE_8_0
+      if (CDarwinUtils::GetIOSVersion() >= 8.0)
+        [g_xbmcController activateScreen:newScreen withOrientation:UIInterfaceOrientationLandscapeLeft];// will attach the screen to xbmc mainwindow
+      else
+#endif
+        [g_xbmcController activateScreen:newScreen withOrientation:UIInterfaceOrientationPortrait];// will attach the screen to xbmc mainwindow
     }
     else
     {
+#if __IPHONE_8_0
+      if (CDarwinUtils::GetIOSVersion() >= 8.0)
+        [g_xbmcController activateScreen:newScreen withOrientation:UIInterfaceOrientationPortrait];// will attach the screen to xbmc mainwindow
+      else
+#endif
       // switching back to internal - use same orientation as we used for the touch controller
       [g_xbmcController activateScreen:newScreen withOrientation:_lastTouchControllerOrientation];// will attach the screen to xbmc mainwindow
     }

--- a/xbmc/osx/ios/IOSKeyboard.mm
+++ b/xbmc/osx/ios/IOSKeyboard.mm
@@ -22,6 +22,7 @@
 #include "IOSKeyboard.h"
 #include "IOSKeyboardView.h"
 #include "XBMCDebugHelpers.h"
+#include "osx/DarwinUtils.h"
 
 #import "AutoPool.h"
 
@@ -42,6 +43,10 @@ bool CIOSKeyboard::ShowAndGetInput(char_callback_t pCallback, const std::string 
     // assume we are only drawn on the mainscreen ever!
     UIScreen *pCurrentScreen = [UIScreen mainScreen];
     CGRect keyboardFrame = CGRectMake(0, 0, pCurrentScreen.bounds.size.height, pCurrentScreen.bounds.size.width);
+#if __IPHONE_8_0
+    if (CDarwinUtils::GetIOSVersion() >= 8.0)
+      keyboardFrame = CGRectMake(0, 0, pCurrentScreen.bounds.size.width, pCurrentScreen.bounds.size.height);
+#endif
 //    LOG(@"kb: kb frame: %@", NSStringFromCGRect(keyboardFrame));
     
     //create the keyboardview

--- a/xbmc/osx/ios/IOSKeyboardView.h
+++ b/xbmc/osx/ios/IOSKeyboardView.h
@@ -31,7 +31,7 @@
   UITextField *_textField;
   UITextField *_heading;
   int _keyboardIsShowing; // 0: not, 1: will show, 2: showing
-  CGFloat _kbHeight;
+  CGRect _kbRect;
 }
 
 @property (nonatomic, retain) NSMutableString *text;

--- a/xbmc/osx/ios/IOSKeyboardView.mm
+++ b/xbmc/osx/ios/IOSKeyboardView.mm
@@ -22,6 +22,7 @@
 #include "guilib/GUIKeyboardFactory.h"
 #include "threads/Event.h"
 #include "Application.h"
+#include "osx/DarwinUtils.h"
 #undef BOOL
 
 #import "IOSKeyboardView.h"
@@ -47,7 +48,6 @@ static CEvent keyboardFinishedEvent;
   {
     _iosKeyboard = nil;
     _keyboardIsShowing = 0;
-    _kbHeight = 0;
     _confirmed = NO;
     _canceled = NULL;
     _deactivated = NO;
@@ -112,9 +112,19 @@ static CEvent keyboardFinishedEvent;
     CGSize headingSize = [_heading.text sizeWithFont:[UIFont systemFontOfSize:[UIFont systemFontSize]]];
     headingW = MIN(self.bounds.size.width/2, headingSize.width+30);
   }
-  CGFloat y = _kbHeight <= 0 ? 
+  CGFloat kbHeight = _kbRect.size.width;
+#if __IPHONE_8_0
+  if (CDarwinUtils::GetIOSVersion() >= 8.0)
+    kbHeight =_kbRect.size.height;
+#endif
+
+  CGFloat y = kbHeight <= 0 ?
     _textField.frame.origin.y : 
-    MIN(self.bounds.size.height-_kbHeight, self.bounds.size.height/5*3) - INPUT_BOX_HEIGHT - SPACE_BETWEEN_INPUT_AND_KEYBOARD;
+    MIN(self.bounds.size.height - kbHeight, self.bounds.size.height/5*3) - INPUT_BOX_HEIGHT - SPACE_BETWEEN_INPUT_AND_KEYBOARD;
+
+  if (CDarwinUtils::GetIOSVersion() >= 8.0)
+    y = _kbRect.origin.y - INPUT_BOX_HEIGHT - SPACE_BETWEEN_INPUT_AND_KEYBOARD;
+
   _heading.frame = CGRectMake(0, y, headingW, INPUT_BOX_HEIGHT);
   _textField.frame = CGRectMake(headingW, y, self.bounds.size.width-headingW, INPUT_BOX_HEIGHT);
 }
@@ -123,7 +133,7 @@ static CEvent keyboardFinishedEvent;
   NSDictionary* info = [notification userInfo];
   CGRect kbRect = [[info objectForKey:UIKeyboardFrameEndUserInfoKey] CGRectValue];
   LOG(@"keyboardWillShow: keyboard frame: %@", NSStringFromCGRect(kbRect));
-  _kbHeight = kbRect.size.width;
+  _kbRect = kbRect;
   [self setNeedsLayout];
   _keyboardIsShowing = 1;
 }

--- a/xbmc/osx/ios/XBMCController.mm
+++ b/xbmc/osx/ios/XBMCController.mm
@@ -1013,8 +1013,15 @@ AnnounceReceiver *AnnounceReceiver::g_announceReceiver = NULL;
   }
   // reset the rotation of the view
   view.layer.transform = CATransform3DMakeRotation(angle, 0, 0.0, 1.0);
+#if __IPHONE_8_0
+  view.layer.bounds = view.bounds;
+#else
   [view setFrame:m_window.frame];
+#endif
   m_window.screen = screen;
+#if __IPHONE_8_0
+  [view setFrame:m_window.frame];
+#endif
 }
 //--------------------------------------------------------------
 - (void) remoteControlReceivedWithEvent: (UIEvent *) receivedEvent {

--- a/xbmc/osx/ios/XBMCController.mm
+++ b/xbmc/osx/ios/XBMCController.mm
@@ -48,6 +48,7 @@
 #include "TextureCache.h"
 #undef id
 #include <math.h>
+#include "osx/DarwinUtils.h"
 
 #ifndef M_PI
 #define M_PI 3.1415926535897932384626433832795028842
@@ -326,25 +327,29 @@ AnnounceReceiver *AnnounceReceiver::g_announceReceiver = NULL;
 //--------------------------------------------------------------
 - (void)willRotateToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration
 {
-  orientation = toInterfaceOrientation;
-  CGRect srect = [IOSScreenManager getLandscapeResolution: [m_glView getCurrentScreen]];
-  CGRect rect = srect;;
-  
-
-  switch(toInterfaceOrientation)
+#if __IPHONE_8_0
+  if (CDarwinUtils::GetIOSVersion() < 8.0)
+#endif
   {
-    case UIInterfaceOrientationPortrait:  
-    case UIInterfaceOrientationPortraitUpsideDown:
-      if(![[IOSScreenManager sharedInstance] isExternalScreen]) 
-      {
-        rect.size = CGSizeMake( srect.size.height, srect.size.width );    
-      }
-      break;
-    case UIInterfaceOrientationLandscapeLeft:
-    case UIInterfaceOrientationLandscapeRight:
-      break;//just leave the rect as is
-  }  
-	m_glView.frame = rect;
+    orientation = toInterfaceOrientation;
+    CGRect srect = [IOSScreenManager getLandscapeResolution: [m_glView getCurrentScreen]];
+    CGRect rect = srect;;
+  
+    switch(toInterfaceOrientation)
+    {
+      case UIInterfaceOrientationPortrait:
+      case UIInterfaceOrientationPortraitUpsideDown:
+        if(![[IOSScreenManager sharedInstance] isExternalScreen])
+        {
+          rect.size = CGSizeMake( srect.size.height, srect.size.width );
+        }
+        break;
+      case UIInterfaceOrientationLandscapeLeft:
+      case UIInterfaceOrientationLandscapeRight:
+        break;//just leave the rect as is
+    }
+    m_glView.frame = rect;
+  }
 }
 
 - (UIInterfaceOrientation) getOrientation
@@ -744,22 +749,31 @@ AnnounceReceiver *AnnounceReceiver::g_announceReceiver = NULL;
                  name: nil
                object: nil];
 
-  /* We start in landscape mode */
-  CGRect srect = frame;
-  srect.size = CGSizeMake( frame.size.height, frame.size.width );
   orientation = UIInterfaceOrientationLandscapeLeft;
-  
-  m_glView = [[IOSEAGLView alloc] initWithFrame: srect withScreen:screen];
-  [[IOSScreenManager sharedInstance] setView:m_glView];  
-  [m_glView setMultipleTouchEnabled:YES];
-  
-  /* Check if screen is Retina */
-  screenScale = [m_glView getScreenScale:screen];
 
-  [self.view addSubview: m_glView];
+#if __IPHONE_8_0
+  if (CDarwinUtils::GetIOSVersion() < 8.0)
+#endif
+  {
+    /* We start in landscape mode */
+    CGRect srect = frame;
+    // in ios sdks older then 8.0 the landscape mode is 90 degrees
+    // rotated
+    srect.size = CGSizeMake( frame.size.height, frame.size.width );
   
-  [self createGestureRecognizers];
-  [m_window addSubview: self.view];
+    m_glView = [[IOSEAGLView alloc] initWithFrame: srect withScreen:screen];
+    [[IOSScreenManager sharedInstance] setView:m_glView];
+    [m_glView setMultipleTouchEnabled:YES];
+  
+    /* Check if screen is Retina */
+    screenScale = [m_glView getScreenScale:screen];
+
+    [self.view addSubview: m_glView];
+  
+    [self createGestureRecognizers];
+    [m_window addSubview: self.view];
+  }
+
   [m_window makeKeyAndVisible];
   g_xbmcController = self;  
   
@@ -767,6 +781,29 @@ AnnounceReceiver *AnnounceReceiver::g_announceReceiver = NULL;
 
   return self;
 }
+//--------------------------------------------------------------
+#if __IPHONE_8_0
+- (void)loadView
+{
+  [super loadView];
+  if (CDarwinUtils::GetIOSVersion() >= 8.0)
+  {
+    self.view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    self.view.autoresizesSubviews = YES;
+  
+    m_glView = [[IOSEAGLView alloc] initWithFrame:self.view.bounds withScreen:[UIScreen mainScreen]];
+    [[IOSScreenManager sharedInstance] setView:m_glView];
+    [m_glView setMultipleTouchEnabled:YES];
+  
+    /* Check if screen is Retina */
+    screenScale = [m_glView getScreenScale:[UIScreen mainScreen]];
+  
+    [self.view addSubview: m_glView];
+  
+    [self createGestureRecognizers];
+  }
+}
+#endif
 //--------------------------------------------------------------
 -(void)viewDidLoad
 {


### PR DESCRIPTION
This PR fixes the following bugs we can see when running on ios8
1. Orientation of our layer is borked when compiled against ios8 sdk and running on ios8 runtime (apple finally fixed the 90° based coordinates)
2. Because of 1 orientation on external screen is messed up too when compiling against ios8 sdk and running on ios8 runtime
3. On ios 8 runtime (independend of used SDK) wthe textfield above the native keyboard is hidden
4. On ios 8 runtime (independend of used SDK) VTB hw decoder crashes on seek

This are all problems i have spotted on ios8 and i have tested all those changes on multiple sdk and runtime constellations. Definitly helix material.
