### PR TITLE
Fix episode NFO scraping

### DIFF
--- a/xbmc/NfoFile.cpp
+++ b/xbmc/NfoFile.cpp
@@ -70,9 +70,12 @@ CNfoFile::NFOResult CNfoFile::Create(const CStdString& strPath, const ScraperPtr
     if (episode > -1 && bNfo && m_type == ADDON_SCRAPER_TVSHOWS)
     {
       int infos=0;
-      while (m_headPos!=std::string::npos && details.m_iEpisode != episode)
+      while (m_headPos != std::string::npos && details.m_iEpisode != episode)
       {
         m_headPos = m_doc.find("<episodedetails", m_headPos);
+        if (m_headPos == std::string::npos)
+          break;
+
         bNfo  = GetDetails(details);
         infos++;
         m_headPos++;

--- a/xbmc/NfoFile.cpp
+++ b/xbmc/NfoFile.cpp
@@ -70,13 +70,12 @@ CNfoFile::NFOResult CNfoFile::Create(const CStdString& strPath, const ScraperPtr
     if (episode > -1 && bNfo && m_type == ADDON_SCRAPER_TVSHOWS)
     {
       int infos=0;
-      m_headPos = m_doc.find("<episodedetails", m_headPos);
-      bNfo = GetDetails(details);
       while (m_headPos!=std::string::npos && details.m_iEpisode != episode)
       {
-        m_headPos = m_doc.find("<episodedetails", m_headPos + 1);
+        m_headPos = m_doc.find("<episodedetails", m_headPos);
         bNfo  = GetDetails(details);
         infos++;
+        m_headPos++;
       }
       if (details.m_iEpisode != episode)
       {

--- a/xbmc/NfoFile.h
+++ b/xbmc/NfoFile.h
@@ -49,11 +49,14 @@ public:
   template<class T>
     bool GetDetails(T& details,const char* document=NULL, bool prioritise=false)
   {
+
     CXBMCTinyXML doc;
     if (document)
       doc.Parse(document, TIXML_ENCODING_UNKNOWN);
-    else
+    else if (m_headPos < m_doc.size())
       doc.Parse(m_doc.substr(m_headPos), TIXML_ENCODING_UNKNOWN);
+    else
+      return false;
 
     return details.Load(doc.RootElement(), true, prioritise);
   }


### PR DESCRIPTION
This fixes the problem described in http://trac.xbmc.org/ticket/15472. Basically episode NFO scraping has been completely broken after ca57cc692d86310b4c1f22e01e982c5a256b53ed due to missing range checks before calling std::string::substr().

The old implementation used strstr() which would return NULL in case of no match which then was turned into a CStdString which resulted in an empty string. That was parseable by CXBMCTinyXML.
