### PR TITLE
Remove dependency on weather.wunderground in Confluence skin

### DIFF
--- a/addons/skin.confluence/720p/MyWeather.xml
+++ b/addons/skin.confluence/720p/MyWeather.xml
@@ -334,7 +334,7 @@
 					<shadowcolor>black</shadowcolor>
 				</control>
 				<control type="group">
-					<visible>StringCompare(Weather.Plugin,weather.wunderground) + !IsEmpty(Window.Property(36Hour.IsFetched))</visible>
+					<visible>!IsEmpty(Window.Property(36Hour.IsFetched))</visible>
 					<control type="label">
 						<description>Sunrise Label</description>
 						<left>30</left>
@@ -364,7 +364,7 @@
 				</control>
 			</control>
 			<control type="group">
-				<visible>!StringCompare(Weather.Plugin,weather.wunderground)</visible>
+				<visible>IsEmpty(Window.Property(Today.IsFetched))</visible>
 				<left>580</left>
 				<top>40</top>
 				<control type="image">
@@ -692,7 +692,7 @@
 				</control>
 			</control>
 			<control type="group">
-				<visible>StringCompare(Weather.Plugin,weather.wunderground)</visible>
+				<visible>!IsEmpty(Window.Property(Today.IsFetched))</visible>
 				<left>580</left>
 				<top>40</top>
 				<control type="image">
@@ -717,11 +717,11 @@
 					<texture>dialogheader.png</texture>
 				</control>
 				<control type="group" id="50">
-					<include condition="StringCompare(Weather.Plugin,weather.wunderground)">Weather10DayForcast</include>
-					<include condition="StringCompare(Weather.Plugin,weather.wunderground)">Weather36HourForcast</include>
-					<include condition="StringCompare(Weather.Plugin,weather.wunderground)">WeatherWeekendForcast</include>
-					<include condition="StringCompare(Weather.Plugin,weather.wunderground)">WeatherHourlyForcast</include>
-					<include condition="StringCompare(Weather.Plugin,weather.wunderground)">WeatherMapAlerts</include>
+					<include condition="!IsEmpty(Window.Property(Daily.IsFetched))">Weather10DayForcast</include>
+					<include condition="!IsEmpty(Window.Property(36Hour.IsFetched))">Weather36HourForcast</include>
+					<include condition="!IsEmpty(Window.Property(Weekend.IsFetched))">WeatherWeekendForcast</include>
+					<include condition="!IsEmpty(Window.Property(Hourly.IsFetched))">WeatherHourlyForcast</include>
+					<include condition="!IsEmpty(Window.Property(Alerts.IsFetched)) + !IsEmpty(Window.Property(Map.IsFetched))">WeatherMapAlerts</include>
 				</control>
 			</control>
 		</control>
@@ -783,7 +783,7 @@
 					<include>ButtonCommonValues</include>
 					<label>31904</label>
 					<onfocus>ClearProperty(Weather.CurrentView)</onfocus>
-					<visible>StringCompare(Weather.Plugin,weather.wunderground)</visible>
+					<visible>!IsEmpty(Window.Property(Daily.IsFetched))</visible>
 				</control>
 				<control type="button" id="303">
 					<description>36 hour forcast button</description>
@@ -791,7 +791,7 @@
 					<include>ButtonCommonValues</include>
 					<label>31901</label>
 					<onfocus>SetProperty(Weather.CurrentView,36hour)</onfocus>
-					<visible>StringCompare(Weather.Plugin,weather.wunderground)</visible>
+					<visible>!IsEmpty(Window.Property(36Hour.IsFetched))</visible>
 				</control>
 				<control type="button" id="304">
 					<description>Weekend forcast button</description>
@@ -799,7 +799,7 @@
 					<include>ButtonCommonValues</include>
 					<label>31903</label>
 					<onfocus>SetProperty(Weather.CurrentView,weekend)</onfocus>
-					<visible>StringCompare(Weather.Plugin,weather.wunderground)</visible>
+					<visible>!IsEmpty(Window.Property(Weekend.IsFetched))</visible>
 				</control>
 				<control type="button" id="305">
 					<description>Hourly forcast button</description>
@@ -807,15 +807,15 @@
 					<include>ButtonCommonValues</include>
 					<label>31902</label>
 					<onfocus>SetProperty(Weather.CurrentView,hourly)</onfocus>
-					<visible>StringCompare(Weather.Plugin,weather.wunderground)</visible>
+					<visible>!IsEmpty(Window.Property(Hourly.IsFetched))</visible>
 				</control>
 				<control type="button" id="306">
-					<description>Hourly forcast button</description>
+					<description>Map and alerts button</description>
 					<textwidth>235</textwidth>
 					<include>ButtonCommonValues</include>
 					<label>31910</label>
 					<onfocus>SetProperty(Weather.CurrentView,map)</onfocus>
-					<visible>StringCompare(Weather.Plugin,weather.wunderground)</visible>
+					<visible>!IsEmpty(Window.Property(Alerts.IsFetched)) + !IsEmpty(Window.Property(Map.IsFetched))">WeatherMapAlerts</visible>
 				</control>
 				<control type="label" id="201">
 					<width>250</width>


### PR DESCRIPTION
Hi,

I am currently developing a new weather addon based on the properties that weather.wunderground uses internally, as it is one of the most advanced weather addons so far.During testing, I found that I couldn't display all the weather information I provided using the default Confluence skin. This is becausse the skin has a strong dependency (hardcoded) on the weather.wunderground addon.

A few other weather addons do provide the same "standard" tags as Weather Underground do, for example "36Hour.IsFetched". They work perfectly fine is other skins, for example Ace, MQ5, and Nox.

The following pull request is to convert the visibility conditions in the skin from "StringCompare(Weather.Plugin,weather.wunderground)" to the proper equivalent property provided by the weather addon.

I tested with 2 different weather addons (including mine, in development) and it works great:
- Weather Underground still provides all extra properties
- Yahoo Weather only display the current weather (as before)

Implementation notes:
- For control groups, I used the "Today.IsFetched" property to display the proper group depending on the loaded plugin. Another way could have been to explicitly test all options (Daily.IsFetched, 36Hour.IsFetched, ...)
- I fixed the description on the button 306 (Map and Alerts, bad copy paste from the above button)
- The maps and alerts visibility is a special case, as it combines 2 properties : Alerts.IsFetched and Map.IsFetched

Cheers!
