### PR TITLE
[builtin] fix activatewindow if directory path differs

### DIFF
--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -392,7 +392,17 @@ int CBuiltins::Execute(const std::string& execString)
     int iWindow = CButtonTranslator::TranslateWindow(strWindow);
     if (iWindow != WINDOW_INVALID)
     {
-      if (iWindow != g_windowManager.GetActiveWindow())
+      // compate the given directory param with the current active directory
+      bool bIsSameStartFolder = true;
+      if (!params.empty())
+      {
+        CGUIWindow *activeWindow = g_windowManager.GetWindow(g_windowManager.GetActiveWindow());
+        if (activeWindow && activeWindow->IsMediaWindow())
+          bIsSameStartFolder = ((CGUIMediaWindow*) activeWindow)->IsSameStartFolder(params[0]);
+      }
+
+      // activate window only if window and path differ from the current active window
+      if (iWindow != g_windowManager.GetActiveWindow() || !bIsSameStartFolder)
       {
         // disable the screensaver
         g_application.WakeUpScreenSaverAndDPMS();

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -1928,6 +1928,12 @@ bool CGUIMediaWindow::IsFiltered()
          (m_canFilterAdvanced && !m_filter.IsEmpty());
 }
 
+bool CGUIMediaWindow::IsSameStartFolder(const std::string &dir)
+{
+  const std::string startFolder = GetStartFolder(dir);
+  return StringUtils::StartsWith(m_vecItems->GetPath(), startFolder);
+}
+
 bool CGUIMediaWindow::Filter(bool advanced /* = true */)
 {
   // basic filtering

--- a/xbmc/windows/GUIMediaWindow.h
+++ b/xbmc/windows/GUIMediaWindow.h
@@ -51,6 +51,7 @@ public:
 
   virtual bool CanFilterAdvanced() { return m_canFilterAdvanced; }
   virtual bool IsFiltered();
+  virtual bool IsSameStartFolder(const std::string &dir);
 
 protected:
   virtual void LoadAdditionalTags(TiXmlElement *root);


### PR DESCRIPTION
After #5081 the built-in "activatewindow" does not work if you stay for example in the video window and you want to activate the same window with a different path.
This fixes the issue by comparing the directory path of the current active window with the given directory path of activatewindow.
