### PR TITLE
video library: list UPnP servers among video sources

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -10068,7 +10068,12 @@ msgctxt "#20261"
 msgid "Apple Filing Protocol (AFP)"
 msgstr ""
 
-#empty strings from id 20262 to 20299
+#: xbmc/storage/MediaManager.cpp
+msgctxt "#20262"
+msgid "Zeroconf Browser"
+msgstr ""
+
+#empty strings from id 20263 to 20299
 
 #: xbmc/network/GUIDialogNetworkSetup.cpp
 msgctxt "#20300"

--- a/xbmc/filesystem/SourcesDirectory.cpp
+++ b/xbmc/filesystem/SourcesDirectory.cpp
@@ -49,12 +49,11 @@ bool CSourcesDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 
   VECSOURCES sources;
   VECSOURCES *sourcesFromType = CMediaSourceSettings::Get().GetSources(type);
-  if (sourcesFromType)
-    sources = *sourcesFromType;
-  g_mediaManager.GetRemovableDrives(sources);
-
   if (!sourcesFromType)
     return false;
+
+  sources = *sourcesFromType;
+  g_mediaManager.GetRemovableDrives(sources);
 
   return GetDirectory(sources, items);
 }

--- a/xbmc/filesystem/SourcesDirectory.cpp
+++ b/xbmc/filesystem/SourcesDirectory.cpp
@@ -18,10 +18,12 @@
  *
  */
 
+#include "system.h"
 #include "SourcesDirectory.h"
 #include "utils/URIUtils.h"
 #include "URL.h"
 #include "Util.h"
+#include "Directory.h"
 #include "FileItem.h"
 #include "File.h"
 #include "profiles/ProfilesManager.h"
@@ -55,7 +57,16 @@ bool CSourcesDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   sources = *sourcesFromType;
   g_mediaManager.GetRemovableDrives(sources);
 
-  return GetDirectory(sources, items);
+  if (!GetDirectory(sources, items))
+    return false;
+
+#ifdef HAS_UPNP
+  CFileItemList upnpServers;
+  if (CDirectory::GetDirectory("upnp://", upnpServers))
+    items.Append(upnpServers);
+#endif
+
+  return true;
 }
 
 bool CSourcesDirectory::GetDirectory(const VECSOURCES &sources, CFileItemList &items)

--- a/xbmc/network/upnp/UPnP.cpp
+++ b/xbmc/network/upnp/UPnP.cpp
@@ -184,9 +184,14 @@ public:
     // PLT_MediaBrowser methods
     virtual bool OnMSAdded(PLT_DeviceDataReference& device)
     {
+        // update any open upnp:// path
         CGUIMessage message(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_PATH);
         message.SetStringParam("upnp://");
         g_windowManager.SendThreadMessage(message);
+
+        // update any open source view
+        CGUIMessage updateSourcesMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_SOURCES);
+        g_windowManager.SendThreadMessage(updateSourcesMessage);
 
         return PLT_SyncMediaBrowser::OnMSAdded(device);
     }
@@ -194,9 +199,14 @@ public:
     {
         PLT_SyncMediaBrowser::OnMSRemoved(device);
 
+        // update any open upnp:// path
         CGUIMessage message(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_PATH);
         message.SetStringParam("upnp://");
         g_windowManager.SendThreadMessage(message);
+
+        // update any open source view
+        CGUIMessage updateSourcesMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_SOURCES);
+        g_windowManager.SendThreadMessage(updateSourcesMessage);
 
         PLT_SyncMediaBrowser::OnMSRemoved(device);
     }

--- a/xbmc/storage/MediaManager.cpp
+++ b/xbmc/storage/MediaManager.cpp
@@ -222,7 +222,7 @@ void CMediaManager::GetNetworkLocations(VECSOURCES &locations, bool autolocation
     
 #ifdef HAS_ZEROCONF
     share.strPath = "zeroconf://";
-    share.strName = "Zeroconf Browser";
+    share.strName = g_localizeStrings.Get(20262);
     locations.push_back(share);
 #endif
   }

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -364,7 +364,7 @@ bool CGUIMediaWindow::OnMessage(CGUIMessage& message)
              m_vecItems->IsSourcesPath()) && IsActive())
         {
           int iItem = m_viewControl.GetSelectedItem();
-          Refresh();
+          Refresh(true);
           m_viewControl.SetSelectedItem(iItem);
         }
         return true;


### PR DESCRIPTION
This adds the functionality to list detected UPnP servers among video library sources and removable devices (like USB sticks and removable hard disks). It auto-updates the listing when a new UPnP server is discovered or a UPnP server is shutting down.

Unfortunately it doesn't work for music, picture or program sources because they still use the old logic to retrieve sources. They also don't support listing removable devices. While this is sad it's out of the scope of this PR. But once they use CSourceDirectory somewhere in the future they should benefit from the same functionality.
