### PR TITLE
[WIP] Add hevc support to amlcodec

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/AMLCodec.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/AMLCodec.cpp
@@ -467,6 +467,9 @@ static vformat_t codecid_to_vformat(enum AVCodecID id)
     case AV_CODEC_ID_CAVS:
       format = VFORMAT_AVS;
       break;
+    case AV_CODEC_ID_HEVC:
+      format = VFORMAT_HEVC;
+      break;
 
     default:
       format = VFORMAT_UNSUPPORT;
@@ -575,6 +578,10 @@ static vdec_type_t codec_tag_to_vdec_type(unsigned int codec_tag)
     case AV_CODEC_ID_AVS:
       // avs
       dec_type = VIDEO_DEC_FORMAT_AVS;
+      break;
+    case AV_CODEC_ID_HEVC:
+      // h265
+      dec_type = VIDEO_DEC_FORMAT_HEVC;
       break;
     default:
       dec_type = VIDEO_DEC_FORMAT_UNKNOW;
@@ -950,6 +957,28 @@ static int h264_write_header(am_private_t *para, am_packet_t *pkt)
     return ret;
 }
 
+static int hevc_add_header(unsigned char *buf, int size,  am_packet_t *pkt)
+{
+    memcpy(pkt->hdr->data, buf, size);
+    pkt->hdr->size = size;
+    return PLAYER_SUCCESS;
+}
+
+static int hevc_write_header(am_private_t *para, am_packet_t *pkt)
+{
+    int ret = -1;
+
+    if (para->extradata) {
+      ret = hevc_add_header(para->extradata, para->extrasize, pkt);
+    }
+    if (ret == PLAYER_SUCCESS) {
+      pkt->codec = &para->vcodec;
+      pkt->newflag = 1;
+      ret = write_av_packet(para, pkt);
+    }
+    return ret;
+}
+
 static int wmv3_write_header(am_private_t *para, am_packet_t *pkt)
 {
     CLog::Log(LOGDEBUG, "wmv3_write_header");
@@ -1121,6 +1150,11 @@ int pre_header_feeding(am_private_t *para, am_packet_t *pkt)
         */
         } else if (VFORMAT_MJPEG == para->video_format) {
             ret = mjpeg_write_header(para, pkt);
+            if (ret != PLAYER_SUCCESS) {
+                return ret;
+            }
+        } else if (VFORMAT_HEVC == para->video_format) {
+            ret = hevc_write_header(para, pkt);
             if (ret != PLAYER_SUCCESS) {
                 return ret;
             }
@@ -1618,6 +1652,12 @@ bool CAMLCodec::OpenDecoder(CDVDStreamInfo &hints)
       // vc1 in an avi file
       if (m_hints.ptsinvalid)
         am_private->gcodec.param = (void*)EXTERNAL_PTS;
+      break;
+    case VFORMAT_HEVC:
+      am_private->gcodec.format = VIDEO_DEC_FORMAT_HEVC;
+      am_private->gcodec.param  = (void*)EXTERNAL_PTS;
+      if (m_hints.ptsinvalid)
+        am_private->gcodec.param = (void*)(EXTERNAL_PTS | SYNC_OUTSIDE);
       break;
   }
   am_private->gcodec.param = (void *)((unsigned int)am_private->gcodec.param | (am_private->video_rotation_degree << 16));

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
@@ -24,6 +24,7 @@
 #include "DVDClock.h"
 #include "DVDStreamInfo.h"
 #include "AMLCodec.h"
+#include "utils/AMLUtils.h"
 #include "utils/BitstreamConverter.h"
 #include "utils/log.h"
 
@@ -137,6 +138,26 @@ bool CDVDVideoCodecAmlogic::Open(CDVDStreamInfo &hints, CDVDCodecOptions &option
     case AV_CODEC_ID_AVS:
     case AV_CODEC_ID_CAVS:
       m_pFormatName = "am-avs";
+      break;
+    case AV_CODEC_ID_HEVC:
+      if ((aml_get_device_type() == AML_DEVICE_TYPE_M8B) || (aml_get_device_type() == AML_DEVICE_TYPE_M8M2)) {
+        if ((aml_get_device_type() == AML_DEVICE_TYPE_M8B) && ((m_hints.width > 1920) || (m_hints.height > 1088)))
+        {
+          // 4K HEVC is supported only on Amlogic S812 chip
+          return false;
+        }
+      } else {
+        // HEVC supported only on S805 and S812.
+        return false;
+      }
+      m_pFormatName = "am-h265";
+      m_bitstream = new CBitstreamConverter();
+      m_bitstream->Open(m_hints.codec, (uint8_t*)m_hints.extradata, m_hints.extrasize, true);
+      // make sure we do not leak the existing m_hints.extradata
+      free(m_hints.extradata);
+      m_hints.extrasize = m_bitstream->GetExtraSize();
+      m_hints.extradata = malloc(m_hints.extrasize);
+      memcpy(m_hints.extradata, m_bitstream->GetExtraData(), m_hints.extrasize);
       break;
     default:
       CLog::Log(LOGDEBUG, "%s: Unknown hints.codec(%d", __MODULE_NAME__, m_hints.codec);

--- a/xbmc/utils/AMLUtils.cpp
+++ b/xbmc/utils/AMLUtils.cpp
@@ -159,6 +159,22 @@ void aml_permissions()
   }
 }
 
+bool aml_support_hevc()
+{
+  char valstr[1024];
+  if(aml_get_sysfs_str("/sys/class/amstream/vcodec_profile", valstr, 1024) != 0)
+  {
+    return false;
+  }
+  char* p = strstr(valstr, "hevc:");
+  if(p == NULL)
+  {
+    return false;
+  }
+
+  return true;
+}
+
 enum AML_DEVICE_TYPE aml_get_device_type()
 {
   static enum AML_DEVICE_TYPE aml_device_type = AML_DEVICE_TYPE_UNINIT;
@@ -173,8 +189,14 @@ enum AML_DEVICE_TYPE aml_get_device_type()
       aml_device_type = AML_DEVICE_TYPE_M3;
     else if (cpu_hardware.find("Meson6") != std::string::npos)
       aml_device_type = AML_DEVICE_TYPE_M6;
-    else if (cpu_hardware.find("Meson8") != std::string::npos)
-      aml_device_type = AML_DEVICE_TYPE_M8;
+    else if ((cpu_hardware.find("Meson8") != std::string::npos) && (cpu_hardware.find("Meson8B") == std::string::npos))
+    {
+      if (aml_support_hevc())
+        aml_device_type = AML_DEVICE_TYPE_M8M2;
+      else
+        aml_device_type = AML_DEVICE_TYPE_M8;
+    } else if (cpu_hardware.find("Meson8B") != std::string::npos)
+      aml_device_type = AML_DEVICE_TYPE_M8B;
     else
       aml_device_type = AML_DEVICE_TYPE_UNKNOWN;
   }

--- a/xbmc/utils/AMLUtils.h
+++ b/xbmc/utils/AMLUtils.h
@@ -28,7 +28,9 @@ enum AML_DEVICE_TYPE
   AML_DEVICE_TYPE_M1,
   AML_DEVICE_TYPE_M3,
   AML_DEVICE_TYPE_M6,
-  AML_DEVICE_TYPE_M8
+  AML_DEVICE_TYPE_M8,   // S802
+  AML_DEVICE_TYPE_M8B,  // S805
+  AML_DEVICE_TYPE_M8M2  // S812
 };
 
 int aml_set_sysfs_str(const char *path, const char *val);
@@ -40,6 +42,7 @@ bool aml_present();
 void aml_permissions();
 bool aml_hw3d_present();
 bool aml_wired_present();
+bool aml_support_hevc();
 enum AML_DEVICE_TYPE aml_get_device_type();
 void aml_cpufreq_min(bool limit);
 void aml_cpufreq_max(bool limit);


### PR DESCRIPTION
Test files: http://www.semperpax.be/owncloud/public.php?service=files&t=8c1e200bd98fd7b604c09a1d1c7e9b20

~~\- Should merge the work from https://github.com/xbmc/xbmc/pull/5374 regarding hevc annex-b~~ DONE, a patch to the PR is needed, though.
- Needs 666 on /dev/amstream_hevc
