### PR TITLE
URIUtils::IsInPath needs to check if the base path isn't empty, fixes te...

### DIFF
--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -42,7 +42,8 @@ bool URIUtils::IsInPath(const CStdString &uri, const CStdString &baseURI)
 {
   CStdString uriPath = CSpecialProtocol::TranslatePath(uri);
   CStdString basePath = CSpecialProtocol::TranslatePath(baseURI);
-  return StringUtils::StartsWith(uriPath, basePath);
+
+  return !basePath.empty() && StringUtils::StartsWith(uriPath, basePath);
 }
 
 /* returns filename extension including period of filename */


### PR DESCRIPTION
...xturecache when there is no skin loaded

Basically I noticed that when we run headless the speacial path to skin is "" which means that we did a check against "" which always returned true, meaning we thought that images was cached already and got an infinite loop in the cached file lookup
