### PR TITLE
Don't get the progress handle if we don't have the progress dialog when ...

### DIFF
--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -90,7 +90,8 @@ void CMusicInfoScanner::Process()
     {
       CGUIDialogExtendedProgressBar* dialog =
         (CGUIDialogExtendedProgressBar*)g_windowManager.GetWindow(WINDOW_DIALOG_EXT_PROGRESS);
-      m_handle = dialog->GetHandle(g_localizeStrings.Get(314));
+      if (dialog)
+        m_handle = dialog->GetHandle(g_localizeStrings.Get(314));
     }
 
     m_bCanInterrupt = true;


### PR DESCRIPTION
...scanning music

The MusicInfoScanner fetched the progress dialog, it handles fine without being able to create a handle but it does not check if the progress window is installed. On Headless no windows are installed to the window manager, thus it crashed while scanning.
