### PR TITLE
List keyboard layouts alphabetically

### DIFF
--- a/xbmc/input/KeyboardLayout.cpp
+++ b/xbmc/input/KeyboardLayout.cpp
@@ -164,4 +164,5 @@ void CKeyboardLayout::SettingOptionsKeyboardLayoutsFiller(const CSetting *settin
     std::string name = it->GetName();
     list.push_back(make_pair(name, name));
   }
+  std::sort(list.begin(), list.end());
 }


### PR DESCRIPTION
It's getting crowded, so keyboard layouts should be displayed alphabetically as the other settings in the category are. Cyrillic ones obviously wont sort correctly, but I'm assuming these will be changes to English soon so it wont be an issue.
