### PR TITLE
[ExternalPlayer] - reset m_time on openfile (fixes bad playcount marking

### DIFF
--- a/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
+++ b/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
@@ -106,6 +106,8 @@ bool CExternalPlayer::OpenFile(const CFileItem& file, const CPlayerOptions &opti
   try
   {
     m_bIsPlaying = true;
+    m_time = 0;
+    m_playbackStartTime = XbmcThreads::SystemClockMillis();
     m_launchFilename = file.GetPath();
     CLog::Log(LOGNOTICE, "%s: %s", __FUNCTION__, m_launchFilename.c_str());
     Create();


### PR DESCRIPTION
on successive played movies).

Fix was reported and reported as fixed with this commit here:

http://forum.xbmc.org/showthread.php?tid=184706&page=2

Should be a no brainer ...
