### PR TITLE
Allow named groups on m_videoCleanDateTimeRegExp

### DIFF
--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -201,8 +201,8 @@ void CUtil::CleanString(const std::string& strFileName,
                         bool bRemoveExtension /* = false */,
                         bool bCleanChars /* = true */)
 {
-  CStdString strReTitle;
-  CStdString strReYear;
+  std::string strReTitle;
+  std::string strReYear;
 
   strTitleAndYear = strFileName;
 

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -240,6 +240,7 @@ void CUtil::CleanString(const std::string& strFileName,
       strTitleAndYear = reYear.GetMatch(1);
       strYear = reYear.GetMatch(2);
     }
+    break;
   }
 
   URIUtils::RemoveExtension(strTitleAndYear);

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -210,32 +210,35 @@ void CUtil::CleanString(const std::string& strFileName,
    return;
 
   const std::vector<std::string> &regexps = g_advancedSettings.m_videoCleanStringRegExps;
+  const std::vector<std::string> dateTimeRegExps = g_advancedSettings.m_videoCleanDateTimeRegExps;
 
   CRegExp reTags(true, CRegExp::autoUtf8);
   CRegExp reYear(false, CRegExp::autoUtf8);
 
-  if (!reYear.RegComp(g_advancedSettings.m_videoCleanDateTimeRegExp))
+  for (unsigned int i = 0; i < dateTimeRegExps.size(); i++)
   {
-    CLog::Log(LOGERROR, "%s: Invalid datetime clean RegExp:'%s'", __FUNCTION__, g_advancedSettings.m_videoCleanDateTimeRegExp.c_str());
-  }
-  else
-  {
-    if (reYear.RegFind(strTitleAndYear.c_str()) >= 0)
+    if (!reYear.RegComp(dateTimeRegExps[i].c_str()))
     {
-      strReTitle = reYear.GetMatch("title");
-      strReYear = reYear.GetMatch("year");
-      if (!strReTitle.empty() && !strReYear.empty())
-      {
-        // regex contains named groups, use them
-        // ex: "(?P&lt;year&gt;[0-9]*)[ -]+(?P&lt;title&gt;.*)" on "1999 - Matrix" gives year:"1999", title:"Matrix"
-        strTitleAndYear = strReTitle;
-        strYear = strReYear;
-      }
-      else
-      {
-        strTitleAndYear = reYear.GetMatch(1);
-        strYear = reYear.GetMatch(2);
-      }
+      CLog::Log(LOGERROR, "%s: Invalid datetime clean RegExp:'%s'", __FUNCTION__, dateTimeRegExps[i].c_str());
+      continue;
+    }
+
+    if (reYear.RegFind(strTitleAndYear.c_str()) < 0)
+      continue;
+
+    strReTitle = reYear.GetMatch("title");
+    strReYear = reYear.GetMatch("year");
+    if (!strReTitle.empty() && !strReYear.empty())
+    {
+      // regex contains named groups, use them
+      // ex: "(?P&lt;year&gt;[0-9]*)[ -]+(?P&lt;title&gt;.*)" on "1999 - Matrix" gives year:"1999", title:"Matrix"
+      strTitleAndYear = strReTitle;
+      strYear = strReYear;
+    }
+    else
+    {
+      strTitleAndYear = reYear.GetMatch(1);
+      strYear = reYear.GetMatch(2);
     }
   }
 

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -213,21 +213,21 @@ void CUtil::CleanString(const std::string& strFileName,
   const std::vector<std::string> dateTimeRegExps = g_advancedSettings.m_videoCleanDateTimeRegExps;
 
   CRegExp reTags(true, CRegExp::autoUtf8);
-  CRegExp reYear(false, CRegExp::autoUtf8);
+  CRegExp reTitleAndYear(false, CRegExp::autoUtf8);
 
   for (unsigned int i = 0; i < dateTimeRegExps.size(); i++)
   {
-    if (!reYear.RegComp(dateTimeRegExps[i].c_str()))
+    if (!reTitleAndYear.RegComp(dateTimeRegExps[i].c_str()))
     {
       CLog::Log(LOGERROR, "%s: Invalid datetime clean RegExp:'%s'", __FUNCTION__, dateTimeRegExps[i].c_str());
       continue;
     }
 
-    if (reYear.RegFind(strTitleAndYear.c_str()) < 0)
+    if (reTitleAndYear.RegFind(strTitleAndYear.c_str()) < 0)
       continue;
 
-    strReTitle = reYear.GetMatch("title");
-    strReYear = reYear.GetMatch("year");
+    strReTitle = reTitleAndYear.GetMatch("title");
+    strReYear = reTitleAndYear.GetMatch("year");
     if (!strReTitle.empty() && !strReYear.empty())
     {
       // regex contains named groups, use them
@@ -237,8 +237,8 @@ void CUtil::CleanString(const std::string& strFileName,
     }
     else
     {
-      strTitleAndYear = reYear.GetMatch(1);
-      strYear = reYear.GetMatch(2);
+      strTitleAndYear = reTitleAndYear.GetMatch(1);
+      strYear = reTitleAndYear.GetMatch(2);
     }
     break;
   }

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -201,6 +201,9 @@ void CUtil::CleanString(const std::string& strFileName,
                         bool bRemoveExtension /* = false */,
                         bool bCleanChars /* = true */)
 {
+  CStdString strReTitle;
+  CStdString strReYear;
+
   strTitleAndYear = strFileName;
 
   if (strFileName == "..")
@@ -219,8 +222,20 @@ void CUtil::CleanString(const std::string& strFileName,
   {
     if (reYear.RegFind(strTitleAndYear.c_str()) >= 0)
     {
-      strTitleAndYear = reYear.GetMatch(1);
-      strYear = reYear.GetMatch(2);
+      strReTitle = reYear.GetMatch("title");
+      strReYear = reYear.GetMatch("year");
+      if (!strReTitle.empty() && !strReYear.empty())
+      {
+        // regex contains named groups, use them
+        // ex: "(?P&lt;year&gt;[0-9]*)[ -]+(?P&lt;title&gt;.*)" on "1999 - Matrix" gives year:"1999", title:"Matrix"
+        strTitleAndYear = strReTitle;
+        strYear = strReYear;
+      }
+      else
+      {
+        strTitleAndYear = reYear.GetMatch(1);
+        strYear = reYear.GetMatch(2);
+      }
     }
   }
 

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -189,8 +189,8 @@ void CAdvancedSettings::Initialize()
   m_cachePath = "special://temp/";
 
   m_videoCleanDateTimeRegExps.clear();
-  m_videoCleanDateTimeRegExps.push_back("(?P<title>.+[^ _\\,\\.\\(\\)\\[\\]\\-])[ _\\.\\(\\)\\[\\]\\-]+(?P<year>19[0-9][0-9]|20[0-1][0-9])([ _\\,\\.\\(\\)\\[\\]\\-][^0-9]|$)");
-  m_videoCleanDateTimeRegExps.push_back("(?P<year>19[0-9][0-9]|20[0-1][0-9])[ _\\.\\(\\)\\[\\]\\-]+(?P<title>.+[^ _\\,\\.\\(\\)\\[\\]\\-])([ _\\,\\.\\(\\)\\[\\]\\-][^0-9]|$)");
+  m_videoCleanDateTimeRegExps.push_back("(?P<title>.+[^ _\\,\\.\\(\\)\\[\\]\\-])[ _\\.\\(\\)\\[\\]\\-]+(?P<year>19[0-9][0-9]|20[0-9][0-9])([ _\\,\\.\\(\\)\\[\\]\\-][^0-9]|$)?");
+  m_videoCleanDateTimeRegExps.push_back("(?P<year>19[0-9][0-9]|20[0-9][0-9])[ _\\.\\(\\)\\[\\]\\-]+(?P<title>.+[^ _\\,\\.\\(\\)\\[\\]\\-])([ _\\,\\.\\(\\)\\[\\]\\-][^0-9]|$)?");
 
   m_videoCleanStringRegExps.clear();
   m_videoCleanStringRegExps.push_back("[ _\\,\\.\\(\\)\\[\\]\\-](ac3|dts|custom|dc|remastered|divx|divx5|dsr|dsrip|dutch|dvd|dvd5|dvd9|dvdrip|dvdscr|dvdscreener|screener|dvdivx|cam|fragment|fs|hdtv|hdrip|hdtvrip|internal|limited|multisubs|ntsc|ogg|ogm|pal|pdtv|proper|repack|rerip|retail|r3|r5|bd5|se|svcd|swedish|german|read.nfo|nfofix|unrated|extended|ws|telesync|ts|telecine|tc|brrip|bdrip|480p|480i|576p|576i|720p|720i|1080p|1080i|3d|hrhd|hrhdtv|hddvd|bluray|x264|h264|xvid|xvidvd|xxx|www.www|cd[1-9]|\\[.*\\])([ _\\,\\.\\(\\)\\[\\]\\-]|$)");

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -188,7 +188,7 @@ void CAdvancedSettings::Initialize()
   m_fullScreenOnMovieStart = true;
   m_cachePath = "special://temp/";
 
-  m_videoCleanDateTimeRegExp = "(.*[^ _\\,\\.\\(\\)\\[\\]\\-])[ _\\.\\(\\)\\[\\]\\-]+(19[0-9][0-9]|20[0-9][0-9])([ _\\,\\.\\(\\)\\[\\]\\-]|[^0-9]$)?";
+  m_videoCleanDateTimeRegExp = "(.*[^ _\\,\\.\\(\\)\\[\\]\\-])[ _\\.\\(\\)\\[\\]\\-]+(19[0-9][0-9]|20[0-9][0-9])([ _\\,\\.\\(\\)\\[\\]\\-]|[^0-9]$)?|(?P<year>19[0-9][0-9]|20[0-9][0-9])[ _\\.\\(\\)\\[\\]\\-]+(?P<title>.+[^ _\\,\\.\\(\\)\\[\\]\\-])([ _\\,\\.\\(\\)\\[\\]\\-][^0-9]|$)?";
 
   m_videoCleanStringRegExps.clear();
   m_videoCleanStringRegExps.push_back("[ _\\,\\.\\(\\)\\[\\]\\-](ac3|dts|custom|dc|remastered|divx|divx5|dsr|dsrip|dutch|dvd|dvd5|dvd9|dvdrip|dvdscr|dvdscreener|screener|dvdivx|cam|fragment|fs|hdtv|hdrip|hdtvrip|internal|limited|multisubs|ntsc|ogg|ogm|pal|pdtv|proper|repack|rerip|retail|r3|r5|bd5|se|svcd|swedish|german|read.nfo|nfofix|unrated|extended|ws|telesync|ts|telecine|tc|brrip|bdrip|480p|480i|576p|576i|720p|720i|1080p|1080i|3d|hrhd|hrhdtv|hddvd|bluray|x264|h264|xvid|xvidvd|xxx|www.www|cd[1-9]|\\[.*\\])([ _\\,\\.\\(\\)\\[\\]\\-]|$)");

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -429,7 +429,7 @@ bool CAdvancedSettings::Load()
 void CAdvancedSettings::ParseSettingsFile(const std::string &file)
 {
   CXBMCTinyXML advancedXML;
-  CStdString cleanDateTimeRegExp;
+  std::string cleanDateTimeRegExp;
   if (!CFile::Exists(file))
   {
     CLog::Log(LOGNOTICE, "No settings file to load (%s)", file.c_str());

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -188,7 +188,9 @@ void CAdvancedSettings::Initialize()
   m_fullScreenOnMovieStart = true;
   m_cachePath = "special://temp/";
 
-  m_videoCleanDateTimeRegExp = "(.*[^ _\\,\\.\\(\\)\\[\\]\\-])[ _\\.\\(\\)\\[\\]\\-]+(19[0-9][0-9]|20[0-9][0-9])([ _\\,\\.\\(\\)\\[\\]\\-]|[^0-9]$)?|(?P<year>19[0-9][0-9]|20[0-9][0-9])[ _\\.\\(\\)\\[\\]\\-]+(?P<title>.+[^ _\\,\\.\\(\\)\\[\\]\\-])([ _\\,\\.\\(\\)\\[\\]\\-][^0-9]|$)?";
+  m_videoCleanDateTimeRegExps.clear();
+  m_videoCleanDateTimeRegExps.push_back("(?P<title>.+[^ _\\,\\.\\(\\)\\[\\]\\-])[ _\\.\\(\\)\\[\\]\\-]+(?P<year>19[0-9][0-9]|20[0-1][0-9])([ _\\,\\.\\(\\)\\[\\]\\-][^0-9]|$)");
+  m_videoCleanDateTimeRegExps.push_back("(?P<year>19[0-9][0-9]|20[0-1][0-9])[ _\\.\\(\\)\\[\\]\\-]+(?P<title>.+[^ _\\,\\.\\(\\)\\[\\]\\-])([ _\\,\\.\\(\\)\\[\\]\\-][^0-9]|$)");
 
   m_videoCleanStringRegExps.clear();
   m_videoCleanStringRegExps.push_back("[ _\\,\\.\\(\\)\\[\\]\\-](ac3|dts|custom|dc|remastered|divx|divx5|dsr|dsrip|dutch|dvd|dvd5|dvd9|dvdrip|dvdscr|dvdscreener|screener|dvdivx|cam|fragment|fs|hdtv|hdrip|hdtvrip|internal|limited|multisubs|ntsc|ogg|ogm|pal|pdtv|proper|repack|rerip|retail|r3|r5|bd5|se|svcd|swedish|german|read.nfo|nfofix|unrated|extended|ws|telesync|ts|telecine|tc|brrip|bdrip|480p|480i|576p|576i|720p|720i|1080p|1080i|3d|hrhd|hrhdtv|hddvd|bluray|x264|h264|xvid|xvidvd|xxx|www.www|cd[1-9]|\\[.*\\])([ _\\,\\.\\(\\)\\[\\]\\-]|$)");
@@ -427,6 +429,7 @@ bool CAdvancedSettings::Load()
 void CAdvancedSettings::ParseSettingsFile(const std::string &file)
 {
   CXBMCTinyXML advancedXML;
+  CStdString cleanDateTimeRegExp;
   if (!CFile::Exists(file))
   {
     CLog::Log(LOGNOTICE, "No settings file to load (%s)", file.c_str());
@@ -540,7 +543,23 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     if (pVideoExcludes)
       GetCustomRegexps(pVideoExcludes, m_videoCleanStringRegExps);
 
-    XMLUtils::GetString(pElement,"cleandatetime", m_videoCleanDateTimeRegExp);
+    pVideoExcludes = pElement->FirstChildElement("cleandatetime");
+    if (pVideoExcludes)
+    {
+      if (XMLUtils::HasChild(pVideoExcludes, "regexp"))
+        GetCustomRegexps(pVideoExcludes, m_videoCleanDateTimeRegExps);
+      else
+      {
+        // Support old behavior, only one regexp
+        XMLUtils::GetString(pElement,"cleandatetime", cleanDateTimeRegExp);
+        if (!cleanDateTimeRegExp.empty())
+        {
+          m_videoCleanDateTimeRegExps.clear();
+          m_videoCleanDateTimeRegExps.push_back(cleanDateTimeRegExp.c_str());
+        }
+      }
+    }
+
     XMLUtils::GetString(pElement,"ppffmpegdeinterlacing",m_videoPPFFmpegDeint);
     XMLUtils::GetString(pElement,"ppffmpegpostprocessing",m_videoPPFFmpegPostProc);
     XMLUtils::GetInt(pElement,"vdpauscaling",m_videoVDPAUScaling);
@@ -1136,6 +1155,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
 void CAdvancedSettings::Clear()
 {
   m_videoCleanStringRegExps.clear();
+  m_videoCleanDateTimeRegExps.clear();
   m_moviesExcludeFromScanRegExps.clear();
   m_tvshowExcludeFromScanRegExps.clear();
   m_videoExcludeFromListingRegExps.clear();

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -210,8 +210,8 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
 
     bool m_fullScreenOnMovieStart;
     std::string m_cachePath;
-    std::string m_videoCleanDateTimeRegExp;
     std::vector<std::string> m_videoCleanStringRegExps;
+    std::vector<std::string> m_videoCleanDateTimeRegExps;
     std::vector<std::string> m_videoExcludeFromListingRegExps;
     std::vector<std::string> m_allExcludeFromScanRegExps;
     std::vector<std::string> m_moviesExcludeFromScanRegExps;


### PR DESCRIPTION
Some of my video files are name with the year before the movie title (ie: "1999 - Matrix"). I didn't find a way to only change cleandatetime in advancedsettings.xml to allow this naming (the first group is hardcoded to be the title, the second the year). So here's a patch to use named groups allowing to place year and title in any order.

I defined 2 groups: "year" and "title". To name a group, simply put "?P&lt;group_name&gt;" juste after the opening parenthesis.
As advancedsettings.xml is an XML file, the '<' and '>' characters will have to be escaped "&amp;lt;" and "&amp;gt;" respectively, so a named group will start with "?P&amp;lt;group_name&amp;gt;"

I also change the default value for m_videoCleanDateTimeRegExp to support the actual naming and the one I introduced.

Also, using the named groups "title" and "year" isn't mandatory, the actual regex will still work as expected.
