### PR TITLE
edit control: fix T9/SMS input for INPUT_TYPE_FILTER controls

### DIFF
--- a/xbmc/guilib/GUIEditControl.cpp
+++ b/xbmc/guilib/GUIEditControl.cpp
@@ -289,13 +289,7 @@ bool CGUIEditControl::OnAction(const CAction &action)
     { // input from the remote
       ClearMD5();
       m_edit.clear();
-      if (m_inputType == INPUT_TYPE_FILTER)
-      { // filtering - use single number presses
-        m_text2.insert(m_text2.begin() + m_cursorPos++, L'0' + (action.GetID() - REMOTE_0));
-        UpdateText();
-      }
-      else
-        OnSMSCharacter(action.GetID() - REMOTE_0);
+      OnSMSCharacter(action.GetID() - REMOTE_0);
       return true;
     }
   }


### PR DESCRIPTION
This removes the special casing for T9/SMS input into edit controls of type INPUT_TYPE_FILTER (e.g. the "Filter" control in the side menu of the video files view) to interprete the input as numbers instead of T9/SMS input. I tried to figure out why the special casing was/is there but INPUT_TYPE_FILTER was added before T9/SMS support so maybe it was just a mistake when the latter was introduced.

@uNiversaI please let me know if this works for you.
