### PR TITLE
CGUIDialogSettingsBase: fix default control overriding

### DIFF
--- a/xbmc/settings/dialogs/GUIDialogSettingsBase.cpp
+++ b/xbmc/settings/dialogs/GUIDialogSettingsBase.cpp
@@ -396,7 +396,11 @@ void CGUIDialogSettingsBase::SetupControls(bool createSettings /* = true */)
     CreateSettings();
 
   // set focus correctly depending on whether there are categories visible or not
-  m_defaultControl = m_pOriginalCategoryButton != NULL ? CATEGORY_GROUP_ID : SETTINGS_GROUP_ID;
+  if (m_pOriginalCategoryButton == NULL &&
+     (m_defaultControl <= 0 || m_defaultControl == CATEGORY_GROUP_ID))
+    m_defaultControl = SETTINGS_GROUP_ID;
+  else if (m_pOriginalCategoryButton != NULL && m_defaultControl <= 0)
+    m_defaultControl = CATEGORY_GROUP_ID;
 }
 
 void CGUIDialogSettingsBase::FreeControls()


### PR DESCRIPTION
This fixes the default control definition in windows/dialogs based on CGUIDialogSettingsBase. Without this the default control is always set to either the control ID of the category button group or the settings control group independent of what is set in the skin XML. This works fine in windows/dialogs that only contain categories and settings but fails in other dialogs like CGUIDialogContentSettings where there are also other controls. Therefore right now the "Change scraper" dialog in the music library is completely broken because focus is forced onto the settings control group which is empty and therefore nothing is focused and it becomes impossible to move to any other control (this is a general problem with empty lists in XBMC).

This changes the behaviour to only manually set the default control if it is either not set or e.g. set to the category button control and there are no categories available.

@MilhouseVH: Thanks for reporting this and please let me know if it fixes the problem for you.
