### PR TITLE
winrenderer: fix fallback to pixel shader

### DIFF
--- a/xbmc/cores/VideoRenderers/WinRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/WinRenderer.cpp
@@ -174,6 +174,8 @@ void CWinRenderer::SelectRenderMethod()
           if (shader.Create())
           {
             m_renderMethod = RENDER_PS;
+            if (m_format == RENDER_FMT_DXVA)
+              m_format = RENDER_FMT_NV12;
             break;
           }
           else

--- a/xbmc/cores/dvdplayer/DVDCodecs/DVDCodecUtils.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/DVDCodecUtils.cpp
@@ -25,6 +25,9 @@
 #include "utils/fastmemcpy.h"
 #include "cores/FFmpeg.h"
 #include "Util.h"
+#ifdef HAS_DX
+#include "cores/dvdplayer/DVDCodecs/Video/DXVA.h"
+#endif
 
 #ifdef TARGET_WINDOWS
 #pragma comment(lib, "avcodec.lib")
@@ -362,7 +365,7 @@ bool CDVDCodecUtils::CopyDXVA2Picture(YV12Image* pImage, DVDVideoPicture *pSrc)
   {
     case MAKEFOURCC('N','V','1','2'):
       {
-        IDirect3DSurface9* surface = (IDirect3DSurface9*)pSrc->data[3];
+        IDirect3DSurface9* surface = (IDirect3DSurface9*)(pSrc->dxva->surface);
 
         D3DLOCKED_RECT rectangle;
         if (FAILED(surface->LockRect(&rectangle, NULL, 0)))


### PR DESCRIPTION
system crashed if dxva processor did not support extended format of decoded frames
