### PR TITLE
VAAPI: Set the VAAPI Render to false by default

### DIFF
--- a/language/English (US)/strings.po
+++ b/language/English (US)/strings.po
@@ -5122,8 +5122,8 @@ msgid "Hardware accelerated"
 msgstr "Hardware accelerated"
 
 msgctxt "#13457"
-msgid "Prefer VAAPI render method"
-msgstr "Prefer VAAPI render method"
+msgid "Enable VAAPI render method"
+msgstr "Enable VAAPI render method"
 
 msgctxt "#13458"
 msgid "Allow hardware acceleration (OMXPlayer)"
@@ -12582,8 +12582,8 @@ msgid "Select virtual keyboard layouts."
 msgstr "Select virtual keyboard layouts."
 
 msgctxt "#36433"
-msgid "If enabled VAAPI render method is prefered. This puts less load on the CPU but driver may hang!"
-msgstr "If enabled VAAPI render method is prefered. This puts less load on the CPU but driver may hang!"
+msgid "If enabled VAAPI render method is used and VPP (VAAPI Post Processing) is available. This puts less load on the CPU but driver may hang!"
+msgstr "If enabled VAAPI render method is used and VPP (VAAPI Post Processing) is available. This puts less load on the CPU but driver may hang!"
 
 msgctxt "#36500"
 msgid "Stereoscopic 3D mode (current)"

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -734,7 +734,7 @@
             <dependency type="visible" on="property" name="codecoptionvisible" setting="videoplayer.usevaapivc1" operator="is">true</dependency>
           </dependencies>
           <level>3</level>
-          <default>true</default>
+          <default>false</default>
           <control type="toggle" />
         </setting>
         <setting id="videoplayer.usedxva2" type="boolean" label="13427" help="36158">

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.cpp
@@ -2445,6 +2445,10 @@ bool CVppPostproc::PreInit(CVaapiConfig &config, SDiMethods *methods)
   return false;
 #else
 
+  // When Setting of Prefered VAAPI Render is off don't enumerate VPP methods
+  if (!CSettings::Get().GetBool("videoplayer.prefervaapirender"))
+    return false;
+
   m_config = config;
 
   // create config


### PR DESCRIPTION
This setting still causes GPU hangs on many "Celeron Systems". Also this setting enabled does a Full RGB Conversion and it is not possible for us to do the scaling to e.g. Limited Range afterwards anymore.

Disabling that setting enables a SW Filter that copies the surfaces back to a place we can work with them again.
