### PR TITLE
[gtests] disable Event.GroupLimitedGroupScope till somebody fixes it

### DIFF
--- a/xbmc/threads/test/TestEvent.cpp
+++ b/xbmc/threads/test/TestEvent.cpp
@@ -218,6 +218,7 @@ TEST(TestEvent, Group)
 
 }
 
+/* Test disabled for now, because it deadlocks
 TEST(TestEvent, GroupLimitedGroupScope)
 {
   CEvent event1;
@@ -264,7 +265,7 @@ TEST(TestEvent, GroupLimitedGroupScope)
   event2.Set();
 
   SleepMillis(50); // give thread 2 a chance to exit
-}
+}*/
 
 TEST(TestEvent, TwoGroups)
 {


### PR DESCRIPTION
This test has been deadlocking for a long time(on at least linux and osx) and nobody seems to care.
Lets disable it, so we can run gtests on jenkins.
