### PR TITLE
[confluence] Fix nib not moving on analog seek

### DIFF
--- a/addons/skin.confluence/720p/DialogSeekBar.xml
+++ b/addons/skin.confluence/720p/DialogSeekBar.xml
@@ -328,6 +328,7 @@
 				<textureslidernib>osd_slider_nib.png</textureslidernib>
 				<textureslidernibfocus>osd_slider_nib.png</textureslidernibfocus>
 				<visible>Player.Seeking</visible>
+				<info>Player.seekbar</info>
 			</control>
 		</control>
 	</controls>


### PR DESCRIPTION
Simple fix for the slider nib not moving on analog seek
