### PR TITLE
remove Addon::Enabled()/Disable() - Dead code

### DIFF
--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -260,7 +260,6 @@ CAddon::CAddon(const cp_extension_t *ext)
   Props().libname = m_strLibName;
   BuildProfilePath();
   m_userSettingsPath = URIUtils::AddFileToFolder(Profile(), "settings.xml");
-  m_enabled = true;
   m_hasSettings = true;
   m_hasStrings = false;
   m_checkedStrings = false;
@@ -271,7 +270,6 @@ CAddon::CAddon(const cp_extension_t *ext)
 CAddon::CAddon(const cp_plugin_info_t *plugin)
   : m_props(plugin)
 {
-  m_enabled = true;
   m_hasSettings = false;
   m_hasStrings = false;
   m_checkedStrings = true;
@@ -286,7 +284,6 @@ CAddon::CAddon(const AddonProps &props)
   else m_strLibName = props.libname;
   BuildProfilePath();
   m_userSettingsPath = URIUtils::AddFileToFolder(Profile(), "settings.xml");
-  m_enabled = true;
   m_hasSettings = true;
   m_hasStrings = false;
   m_checkedStrings = false;
@@ -305,7 +302,6 @@ CAddon::CAddon(const CAddon &rhs)
   BuildProfilePath();
   m_userSettingsPath = URIUtils::AddFileToFolder(Profile(), "settings.xml");
   m_strLibName  = rhs.m_strLibName;
-  m_enabled = rhs.Enabled();
   m_hasStrings  = false;
   m_checkedStrings  = false;
 }

--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -145,7 +145,6 @@ public:
   AddonProps& Props() { return m_props; }
   const std::string ID() const { return m_props.id; }
   const std::string Name() const { return m_props.name; }
-  bool Enabled() const { return m_enabled; }
   virtual bool IsInUse() const { return false; };
   const AddonVersion Version() const { return m_props.version; }
   const AddonVersion MinVersion() const { return m_props.minversion; }
@@ -175,8 +174,6 @@ public:
    */
   bool MeetsVersion(const AddonVersion &version) const;
   virtual bool ReloadSettings();
-
-  void MarkAsDisabled() { m_enabled = false; }
 
   /*! \brief callback for when this add-on is disabled.
    Use to perform any needed actions (e.g. stop a service)
@@ -244,8 +241,6 @@ private:
 
   virtual bool IsAddonLibrary() { return false; }
 
-  void Enable() { LoadStrings(); m_enabled = true; }
-  void Disable() { m_enabled = false; ClearStrings();}
 
   virtual bool LoadStrings();
   virtual void ClearStrings();
@@ -254,7 +249,6 @@ private:
   bool m_hasSettings;
 
   std::string m_profile;
-  bool        m_enabled;
   CLocalizeStrings  m_strings;
   std::map<std::string, std::string> m_settings;
 };

--- a/xbmc/addons/IAddon.h
+++ b/xbmc/addons/IAddon.h
@@ -89,7 +89,6 @@ namespace ADDON
     virtual AddonProps& Props() =0;
     virtual const std::string ID() const =0;
     virtual const std::string Name() const =0;
-    virtual bool Enabled() const =0;
     virtual bool IsInUse() const =0;
     virtual const AddonVersion Version() const =0;
     virtual const AddonVersion MinVersion() const =0;
@@ -130,8 +129,6 @@ namespace ADDON
   private:
     friend class CAddonMgr;
     virtual bool IsAddonLibrary() =0;
-    virtual void Enable() =0;
-    virtual void Disable() =0;
     virtual bool LoadStrings() =0;
     virtual void ClearStrings() =0;
   };

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -61,7 +61,7 @@ bool CPVRClients::IsInUse(const std::string& strAddonId) const
   CSingleLock lock(m_critSection);
 
   for (PVR_CLIENTMAP_CITR itr = m_clientMap.begin(); itr != m_clientMap.end(); itr++)
-    if (itr->second->Enabled() && itr->second->ID() == strAddonId)
+    if (itr->second->ID() == strAddonId)
       return true;
   return false;
 }
@@ -173,14 +173,8 @@ int CPVRClients::GetFirstConnectedClientID(void)
 
 int CPVRClients::EnabledClientAmount(void) const
 {
-  int iReturn(0);
   CSingleLock lock(m_critSection);
-
-  for (PVR_CLIENTMAP_CITR itr = m_clientMap.begin(); itr != m_clientMap.end(); itr++)
-    if (itr->second->Enabled())
-      ++iReturn;
-
-  return iReturn;
+  return m_clientMap.size();
 }
 
 bool CPVRClients::HasEnabledClients(void) const
@@ -833,9 +827,6 @@ int CPVRClients::RegisterClient(AddonPtr client, bool* newRegistration/*=NULL*/)
   if (newRegistration)
     *newRegistration = false;
 
-  if (!client->Enabled())
-    return -1;
-
   CLog::Log(LOGDEBUG, "%s - registering add-on '%s'", __FUNCTION__, client->Name().c_str());
 
   CPVRDatabase *database = GetPVRDatabase();
@@ -897,8 +888,7 @@ bool CPVRClients::UpdateAndInitialiseClients(bool bInitialiseAllClients /* = fal
   for (unsigned iClientPtr = 0; iClientPtr < map.size(); iClientPtr++)
   {
     const AddonPtr clientAddon = map.at(iClientPtr);
-    bool bEnabled = clientAddon->Enabled() &&
-        !CAddonMgr::Get().IsAddonDisabled(clientAddon->ID());
+    bool bEnabled = !CAddonMgr::Get().IsAddonDisabled(clientAddon->ID());
 
     if (!bEnabled && IsKnownClient(clientAddon))
     {
@@ -938,7 +928,7 @@ bool CPVRClients::UpdateAndInitialiseClients(bool bInitialiseAllClients /* = fal
         }
 
         // throttle connection attempts, no more than 1 attempt per 5 seconds
-        if (!bDisabled && addon->Enabled())
+        if (!bDisabled)
         {
           time_t now;
           CDateTime::GetCurrentDateTime().GetAsTime(now);
@@ -949,7 +939,7 @@ bool CPVRClients::UpdateAndInitialiseClients(bool bInitialiseAllClients /* = fal
         }
 
         // re-check the enabled status. newly installed clients get disabled when they're added to the db
-        if (!bDisabled && addon->Enabled() && (status = addon->Create(iClientId)) != ADDON_STATUS_OK)
+        if (!bDisabled && (status = addon->Create(iClientId)) != ADDON_STATUS_OK)
         {
           CLog::Log(LOGWARNING, "%s - failed to create add-on %s, status = %d", __FUNCTION__, clientAddon->Name().c_str(), status);
           if (!addon.get() || !addon->DllLoaded() || status == ADDON_STATUS_PERMANENT_FAILURE)

--- a/xbmc/settings/dialogs/GUIDialogContentSettings.cpp
+++ b/xbmc/settings/dialogs/GUIDialogContentSettings.cpp
@@ -196,9 +196,6 @@ bool CGUIDialogContentSettings::Show(ADDON::ScraperPtr& scraper, VIDEO::SScanSet
   {
     dialog->SetContent(content != CONTENT_NONE ? content : scraper->Content());
     dialog->SetScraper(scraper);
-    // toast selected but disabled scrapers
-    if (!scraper->Enabled())
-      CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, g_localizeStrings.Get(24024), scraper->Name(), 2000, true);
   }
 
   dialog->SetScanSettings(settings);
@@ -334,7 +331,7 @@ void CGUIDialogContentSettings::SetupView()
   {
     FillScraperList();
     SET_CONTROL_VISIBLE(CONTROL_SCRAPER_LIST);
-    if (m_scraper != NULL && m_scraper->Enabled())
+    if (m_scraper != NULL)
     {
       m_showScanSettings = true;
       if (m_scraper && m_scraper->Supports(m_content) && m_scraper->HasSettings())


### PR DESCRIPTION
I noticed they're never used, at least on osx I got no compile issues after removing them.
