### PR TITLE
fix: missing bound check on populating context menu

### DIFF
--- a/xbmc/addons/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/GUIWindowAddonBrowser.cpp
@@ -148,9 +148,11 @@ bool CGUIWindowAddonBrowser::OnMessage(CGUIMessage& message)
   return CGUIMediaWindow::OnMessage(message);
 }
 
-void CGUIWindowAddonBrowser::GetContextButtons(int itemNumber,
-                                               CContextButtons& buttons)
+void CGUIWindowAddonBrowser::GetContextButtons(int itemNumber, CContextButtons& buttons)
 {
+  if (itemNumber < 0 || itemNumber >= m_vecItems->Size())
+    return;
+
   CFileItemPtr pItem = m_vecItems->Get(itemNumber);
   if (!pItem->IsPath("addons://enabled/"))
     buttons.Add(CONTEXT_BUTTON_SCAN,24034);


### PR DESCRIPTION
How to reproduce: go to addon browser. Try to open the context menu on something you shouldn't (like on the side bar). It will segfault.

I checked all the other `GetContextButtons` implementations, I think they are fine.
