### PR TITLE
properly deinit visualisation presets dialog (fixes #15478)

### DIFF
--- a/xbmc/music/dialogs/GUIDialogVisualisationPresetList.cpp
+++ b/xbmc/music/dialogs/GUIDialogVisualisationPresetList.cpp
@@ -68,12 +68,9 @@ bool CGUIDialogVisualisationPresetList::OnMessage(CGUIMessage &message)
       }
     }
     break;
-  case GUI_MSG_WINDOW_DEINIT:
   case GUI_MSG_VISUALISATION_UNLOADING:
     {
       m_viz = NULL;
-      CGUIMessage msg(GUI_MSG_LABEL_RESET, GetID(), CONTROL_LIST);
-      OnMessage(msg);
       Update();
     }
     break;
@@ -121,6 +118,15 @@ void CGUIDialogVisualisationPresetList::OnInitWindow()
   CGUIDialog::OnInitWindow();
 }
 
+void CGUIDialogVisualisationPresetList::OnDeinitWindow(int nextWindowID)
+{
+  CGUIDialog::OnDeinitWindow(nextWindowID);
+  CGUIMessage msg(GUI_MSG_LABEL_RESET, GetID(), CONTROL_LIST);
+  OnMessage(msg);
+  SET_CONTROL_LABEL(CONTROL_PRESETS_LABEL, "");
+  m_vecPresets->Clear();
+}
+
 void CGUIDialogVisualisationPresetList::Update()
 {
   m_vecPresets->Clear();
@@ -145,7 +151,7 @@ void CGUIDialogVisualisationPresetList::Update()
         pItem->SetLabel2(" ");
         m_vecPresets->Add(pItem);
       }
-      CGUIMessage msg(GUI_MSG_LABEL_BIND, GetID(), CONTROL_LIST, 0, 0, m_vecPresets);
+      CGUIMessage msg(GUI_MSG_LABEL_BIND, GetID(), CONTROL_LIST, m_currentPreset, 0, m_vecPresets);
       OnMessage(msg);
     }
   }

--- a/xbmc/music/dialogs/GUIDialogVisualisationPresetList.h
+++ b/xbmc/music/dialogs/GUIDialogVisualisationPresetList.h
@@ -39,6 +39,7 @@ public:
 
 protected:
   virtual void OnInitWindow();
+  virtual void OnDeinitWindow(int nextWindowID);
   void SetVisualisation(ADDON::CVisualisation *addon);
   void Update();
   ADDON::CVisualisation* m_viz; //TODO get rid


### PR DESCRIPTION
Properly deinit the visualisation dialog in order to avoid focus and scrollposition changes. I've also added the current preset to GUI_MSG_LABEL_BIND to ensure the actual scrollposition (not just the focus) is preserved after re-opening the dialog.
