### PR TITLE
[keyboard layouts] use English language names

### DIFF
--- a/system/keyboardlayouts.xml
+++ b/system/keyboardlayouts.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+Please use English language names instead.
+Default font lacks support for all characters
+-->
 <keyboardlayouts>
-  <layout name="QWERTY">
+  <layout name="English QWERTY">
     <keyboard>
       <row>1234567890</row>
       <row>qwertyuiop</row>
@@ -20,7 +24,7 @@
       <row>`~</row>
     </keyboard>
   </layout>
-  <layout name="AZERTY">
+  <layout name="English AZERTY">
     <keyboard>
       <row>1234567890</row>
       <row>azertyuiop</row>
@@ -40,7 +44,7 @@
       <row>`~éèçà</row>
     </keyboard>
   </layout>
-  <layout name="ABC">
+  <layout name="English ABC">
     <keyboard>
       <row>0123456789</row>
       <row>abcdefghij</row>
@@ -60,7 +64,7 @@
       <row>`~</row>
    </keyboard>
   </layout>
-  <layout name="Български ЯВЕРТЪ">
+  <layout name="Bulgarian ЯВЕРТЪ">
     <keyboard>
       <row>ч1234567890</row>
       <row>явертъуиопшщ</row>
@@ -80,7 +84,7 @@
       <row>`~</row>
     </keyboard>
   </layout>
-  <layout name="Български АБВ">
+  <layout name="Bulgarian АБВ">
     <keyboard>
       <row>0123456789</row>
       <row>абвгдежзий</row>
@@ -100,7 +104,7 @@
       <row>`~</row>
     </keyboard>
   </layout>
-  <layout name="Русская ЙЦУКЕН">
+  <layout name="Russian ЙЦУКЕН">
     <keyboard>
       <row>ё1234567890</row>
       <row>йцукенгшщзхъ</row>
@@ -120,7 +124,7 @@
       <row>`~</row>
     </keyboard>
   </layout>
-  <layout name="Русская АБВ">
+  <layout name="Russian АБВ">
     <keyboard>
       <row>0123456789</row>
       <row>абвгдеёжзий</row>


### PR DESCRIPTION
This normalizes language names to English and specify English in QWERTY/ABC/AZERTY 

**_Future consideration**_
In future because the OSK Button label is rather limited in length that a **_ID**_ field could be implemented  So that **_layout name**_ would be displayed in selection list and in **_id**_ would show in button label something like.

```
<layout name="English ABC" id=eng abc>
<layout name="English QWERTY" id=eng qwerty>
```

However that last part (implementing the id) I would require assistance in the C++ portion @stefansaraev understands this idea.

@MartijnKaijser hope this helps the author of #5419 make up his mind and rebase/change his PR.
