### PR TITLE
[pvr] fix continue playback of last watched channel on startup if group was deleted or channel was moved

### DIFF
--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -709,10 +709,12 @@ bool CPVRManager::ContinueLastChannel(void)
   if (channel && channel->HasPVRChannelInfoTag())
   {
     CLog::Log(LOGNOTICE, "PVRManager - %s - continue playback on channel '%s'", __FUNCTION__, channel->GetPVRChannelInfoTag()->ChannelName().c_str());
-    SetPlayingGroup(m_channelGroups->GetLastPlayedGroup());
+    SetPlayingGroup(m_channelGroups->GetLastPlayedGroup(channel->GetPVRChannelInfoTag()->ChannelID()));
     StartPlayback(channel->GetPVRChannelInfoTag(), (CSettings::Get().GetInt("pvrplayback.startlast") == CONTINUE_LAST_CHANNEL_IN_BACKGROUND));
     return true;
   }
+
+  CLog::Log(LOGDEBUG, "PVRManager - %s - no last played channel to continue playback found", __FUNCTION__);
 
   return false;
 }

--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -337,14 +337,15 @@ CPVRChannelGroupPtr CPVRChannelGroups::GetLastGroup(void) const
   return empty;
 }
 
-CPVRChannelGroupPtr CPVRChannelGroups::GetLastPlayedGroup() const
+CPVRChannelGroupPtr CPVRChannelGroups::GetLastPlayedGroup(int iChannelID /* = -1 */) const
 {
   CSingleLock lock(m_critSection);
 
   CPVRChannelGroupPtr group;
   for (std::vector<CPVRChannelGroupPtr>::const_iterator it = m_groups.begin(); it != m_groups.end(); it++)
   {
-    if ((*it)->LastWatched() > 0 && (!group || (*it)->LastWatched() > group->LastWatched()))
+    if ((*it)->LastWatched() > 0 && (!group || (*it)->LastWatched() > group->LastWatched()) &&
+        (iChannelID == -1 || (iChannelID >= 0 && (*it)->IsGroupMember(iChannelID))))
       group = (*it);
   }
 

--- a/xbmc/pvr/channels/PVRChannelGroups.h
+++ b/xbmc/pvr/channels/PVRChannelGroups.h
@@ -109,10 +109,11 @@ namespace PVR
     CPVRChannelGroupPtr GetLastGroup(void) const;
     
     /*!
-     * @brief The group that was played last.
+     * @brief The group that was played last and optionally contains the given channel.
+     * @param iChannelID The channel ID
      * @return The last watched group.
      */
-    CPVRChannelGroupPtr GetLastPlayedGroup() const;
+    CPVRChannelGroupPtr GetLastPlayedGroup(int iChannelID = -1) const;
 
     /*!
      * @brief Get the list of groups.

--- a/xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
@@ -265,17 +265,22 @@ void CPVRChannelGroupsContainer::SearchMissingChannelIcons(void)
 
 CFileItemPtr CPVRChannelGroupsContainer::GetLastPlayedChannel(void) const
 {
-  CPVRChannelGroupPtr group = GetLastPlayedGroup();
-  if (group)
-    return group->GetLastPlayedChannel();
+  CFileItemPtr channelTV = m_groupsTV->GetGroupAll()->GetLastPlayedChannel();
+  CFileItemPtr channelRadio = m_groupsRadio->GetGroupAll()->GetLastPlayedChannel();
 
-  return CFileItemPtr(new CFileItem);
+  if (!channelTV ||
+      !channelTV->HasPVRChannelInfoTag() ||
+      (channelRadio && channelRadio->HasPVRChannelInfoTag() &&
+       channelRadio->GetPVRChannelInfoTag()->LastWatched() > channelTV->GetPVRChannelInfoTag()->LastWatched()))
+     return channelRadio;
+
+  return channelTV;
 }
 
-CPVRChannelGroupPtr CPVRChannelGroupsContainer::GetLastPlayedGroup() const
+CPVRChannelGroupPtr CPVRChannelGroupsContainer::GetLastPlayedGroup(int iChannelID /* = -1 */) const
 {
-  CPVRChannelGroupPtr groupTV = m_groupsTV->GetLastPlayedGroup();
-  CPVRChannelGroupPtr groupRadio = m_groupsRadio->GetLastPlayedGroup();
+  CPVRChannelGroupPtr groupTV = m_groupsTV->GetLastPlayedGroup(iChannelID);
+  CPVRChannelGroupPtr groupRadio = m_groupsRadio->GetLastPlayedGroup(iChannelID);
 
   if (!groupTV || (groupRadio && groupTV->LastWatched() < groupRadio->LastWatched()))
     return groupRadio;

--- a/xbmc/pvr/channels/PVRChannelGroupsContainer.h
+++ b/xbmc/pvr/channels/PVRChannelGroupsContainer.h
@@ -181,10 +181,11 @@ namespace PVR
     CFileItemPtr GetLastPlayedChannel(void) const;
 
     /*!
-     * @brief The group that was played last.
+     * @brief The group that was played last and optionally contains the given channel.
+     * @param iChannelID The channel ID
      * @return The last watched group.
      */
-    CPVRChannelGroupPtr GetLastPlayedGroup() const;
+    CPVRChannelGroupPtr GetLastPlayedGroup(int iChannelID = -1) const;
 
     bool CreateChannel(const CPVRChannel &channel);
 


### PR DESCRIPTION
As discussed with @FernetMenta this attempts to fix the issue that the wrong channel is continued at startup if you delete the last played group or move the last played channel to another group, in short if you re-organize your channel setup in the backend.

Here is how this works: first it search for the last watched channel in the "all channels" group and if a channel is found it looks for the last played group which contains this channel. so if you move the last played channel to a new group it would definitely playback the right channel and use the group that was last played and contains the channel which is btw the "all channels" group if no other group contains this channel and will have a greater last watched timestamp. if you delete a group where the last played channel is in the same happens.

I also added a DEBUG output if no channel is found to reproduce the issue described in trac ticket http://trac.xbmc.org/ticket/15397.
