### PR TITLE
[pvr] fix toggle between previous and next channel

### DIFF
--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -1577,8 +1577,10 @@ void CPVRManager::UpdateLastWatched(CPVRChannel &channel)
   CDateTime::GetCurrentDateTime().GetAsTime(tNow);
 
   // update last watched timestamp for channel
-  channel.SetLastWatched(tNow);
-  channel.Persist();
+  // NOTE: method could be called with a fileitem copy as argument so we need to obtain the right channel instance
+  CPVRChannelPtr channelPtr = m_channelGroups->GetChannelById(channel.ChannelID());
+  channelPtr->SetLastWatched(tNow);
+  channelPtr->Persist();
 
   // update last watched timestamp for group
   CPVRChannelGroupPtr group = GetPlayingGroup(channel.IsRadio());

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -267,7 +267,7 @@ namespace PVR
      * @param iCurrentChannel The channelid of the current channel that is playing, or -1 if none
      * @return The requested channel.
      */
-    CFileItemPtr GetLastPlayedChannel(unsigned int iCurrentChannel = -1) const;
+    CFileItemPtr GetLastPlayedChannel(int iCurrentChannel = -1) const;
 
     /*!
      * @brief Get a channel given it's channel number.


### PR DESCRIPTION
After #5400 where I changed the last watched update logic, the update to the channel's last watched property is not reflected to the right channel instance. This only happens if `UpdateLastWatched()` is called from `PerformChannelSwitch()`. This attempts to the fix the issue.

I also rewrite the method `GetLastPlayedChannel()` where we do an unnecessary persist of the current playing channel before we search for the last played one. Previously this was needed because we don't update the last watched of the current channel in `PerformChannelSwitch()`. now we do.

@Jalle19 or @opdenkamp please take a look.
