### PR TITLE
improve handling of unavailable remote sources during library scanning/cleaning

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -6949,11 +6949,13 @@ msgstr ""
 #empty strings from id 14105 to 15011
 
 #: xbmc/video/VideoDatabase.cpp
+#: xbmc/settings/MediaSourceSettings.cpp
 msgctxt "#15012"
 msgid "Unavailable source"
 msgstr ""
 
 #: xbmc/video/VideoDatabase.cpp
+#: xbmc/settings/MediaSourceSettings.cpp
 msgctxt "#15013"
 msgid "What would you like to do with media items from %s"
 msgstr ""
@@ -10929,7 +10931,17 @@ msgctxt "#20469"
 msgid "Keep current set (%s)"
 msgstr ""
 
-#empty strings from id 20470 to 21329
+#: xbmc/video/VideoInfoScanner.cpp
+msgctxt "#20470"
+msgid "Retry"
+msgstr ""
+
+#: xbmc/video/VideoInfoScanner.cpp
+msgctxt "#20471"
+msgid "Skip"
+msgstr ""
+
+#empty strings from id 20472 to 21329
 #up to 21329 is reserved for the video db !! !
 
 #: system/settings/settings.xml

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -39,6 +39,7 @@
 #include "filesystem/File.h"
 #include "filesystem/Directory.h"
 #include "settings/AdvancedSettings.h"
+#include "settings/MediaSourceSettings.h"
 #include "settings/Settings.h"
 #include "FileItem.h"
 #include "guilib/LocalizeStrings.h"
@@ -101,14 +102,40 @@ void CMusicInfoScanner::Process()
       CLog::Log(LOGDEBUG, "%s - Starting scan", __FUNCTION__);
 
       if (m_handle)
+      {
         m_handle->SetTitle(g_localizeStrings.Get(505));
+        m_handle->SetText(g_localizeStrings.Get(314));
+      }
 
       // Reset progress vars
       m_currentItem=0;
       m_itemCount=-1;
 
+      SetPriority(GetMinPriority());
+
+      // get all sources that can be skipped because they are unavailable
+      std::vector<std::string> sourcesToSkip = CMediaSourceSettings::FindSourcesToSkip("music", m_pathsToScan, m_showDialog);
+
+      std::set<std::string> pathsToScan;
+      for (std::set<std::string>::const_iterator it = m_pathsToScan.begin(); it != m_pathsToScan.end(); ++it)
+      {
+        if (URIUtils::IsInPath(*it, sourcesToSkip))
+        {
+          /*
+          * Note that this will skip scanning (if m_bClean is disabled) if the directory really
+          * doesn't exist. Since the music scanner is fed with a list of existing paths from the DB
+          * and cleans out all songs under that path as its first step before re-adding files, if
+          * the entire source is offline we totally empty the music database in one go.
+          */
+          CLog::Log(LOGWARNING, "%s directory '%s' does not exist - skipping scan.", __FUNCTION__, it->c_str());
+        }
+        else
+          pathsToScan.insert(*it);
+      }
+
+      m_pathsToScan = pathsToScan;
+
       // Create the thread to count all files to be scanned
-      SetPriority( GetMinPriority() );
       if (m_handle)
         m_fileCountReader.Create();
 

--- a/xbmc/settings/MediaSourceSettings.cpp
+++ b/xbmc/settings/MediaSourceSettings.cpp
@@ -500,6 +500,57 @@ bool CMediaSourceSettings::SetSources(TiXmlNode *root, const char *section, cons
   return true;
 }
 
+std::map<std::string, std::pair<bool, bool> > CMediaSourceSettings::HandleSourceExistence(const std::string &type, const std::set<std::string> &paths,
+  bool showDialog, int headingLabel /* = 15012 */, int textLabel /* = 15013 */, int okLabel /* = 20470 */, int cancelLabel /* = 20471 */)
+{
+  std::map<std::string, std::pair<bool, bool> > sourcesExistence;
+  if (type.empty() || paths.empty())
+    return sourcesExistence;
+
+  VECSOURCES* sources = Get().GetSources(type);
+  if (sources == NULL || sources->empty())
+    return sourcesExistence;
+
+  // get all paths that are part of a source
+  std::vector<std::string> sourcePaths;
+  for (VECSOURCES::const_iterator source = sources->begin(); source != sources->end(); ++source)
+    sourcePaths.push_back(source->strPath);
+  sourcePaths = URIUtils::ExpandPaths(sourcePaths);
+
+  // go through all paths that are part of a source and are part of the paths to be scanned
+  // and check whether they exist or not (and should be skipped or not)
+  std::vector<std::string> nonExistingSources;
+  for (std::vector<std::string>::const_iterator sourcePath = sourcePaths.begin(); sourcePath != sourcePaths.end(); ++sourcePath)
+  {
+    for (std::set<std::string>::const_iterator pathToScan = paths.begin(); pathToScan != paths.end(); ++pathToScan)
+    {
+      // check if the path to scan is not already marked for skipping
+      // and matches the source path we are processing right now
+      if (!URIUtils::IsInPath(*pathToScan, nonExistingSources) &&
+          URIUtils::IsInPath(*pathToScan, *sourcePath))
+      {
+        // if the path exists everything is fine
+        CLog::Log(LOGDEBUG, "Checking existence of %s", sourcePath->c_str());
+        bool exist = CDirectory::Exists(*sourcePath, false);
+        bool choice = true;
+        if (!exist)
+        {
+          nonExistingSources.push_back(*sourcePath);
+
+          // ask the user what to do with the non-existing item
+          if (showDialog)
+            choice = PromptForSource(*sourcePath, headingLabel, textLabel, okLabel, cancelLabel);
+        }
+
+        sourcesExistence.insert(std::make_pair(*sourcePath, std::make_pair(exist, choice)));
+        break;
+      }
+    }
+  }
+
+  return sourcesExistence;
+}
+
 std::vector<std::string> CMediaSourceSettings::FindSourcesToSkip(const std::string &type, const std::set<std::string> &paths,
   bool showDialog, int headingLabel /* = 15012 */, int textLabel /* = 15013 */, int okLabel /* = 20470 */, int cancelLabel /* = 20471 */)
 {

--- a/xbmc/settings/MediaSourceSettings.h
+++ b/xbmc/settings/MediaSourceSettings.h
@@ -51,6 +51,8 @@ public:
   bool AddShare(const std::string &type, const CMediaSource &share);
   bool UpdateShare(const std::string &type, const std::string &oldName, const CMediaSource &share);
 
+  static bool PromptForSource(const std::string& path, int headingLabel, int textLabel, int okLabel, int cancelLabel);
+
 protected:
   CMediaSourceSettings();
   CMediaSourceSettings(const CMediaSourceSettings&);

--- a/xbmc/settings/MediaSourceSettings.h
+++ b/xbmc/settings/MediaSourceSettings.h
@@ -51,6 +51,9 @@ public:
   bool AddShare(const std::string &type, const CMediaSource &share);
   bool UpdateShare(const std::string &type, const std::string &oldName, const CMediaSource &share);
 
+  static std::map<std::string, std::pair<bool, bool> > HandleSourceExistence(const std::string &type, const std::set<std::string> &paths,
+                                                                             bool showDialog, int headingLabel = 15012, int textLabel = 15013,
+                                                                             int okLabel = 20471, int cancelLabel = 20470);
   static std::vector<std::string> FindSourcesToSkip(const std::string &type, const std::set<std::string> &paths,
                                                     bool showDialog, int headingLabel = 15012, int textLabel = 15013,
                                                     int okLabel = 20471, int cancelLabel = 20470);

--- a/xbmc/settings/MediaSourceSettings.h
+++ b/xbmc/settings/MediaSourceSettings.h
@@ -51,6 +51,9 @@ public:
   bool AddShare(const std::string &type, const CMediaSource &share);
   bool UpdateShare(const std::string &type, const std::string &oldName, const CMediaSource &share);
 
+  static std::vector<std::string> FindSourcesToSkip(const std::string &type, const std::set<std::string> &paths,
+                                                    bool showDialog, int headingLabel = 15012, int textLabel = 15013,
+                                                    int okLabel = 20471, int cancelLabel = 20470);
   static bool PromptForSource(const std::string& path, int headingLabel, int textLabel, int okLabel, int cancelLabel);
 
 protected:

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -46,6 +46,16 @@ bool URIUtils::IsInPath(const CStdString &uri, const CStdString &baseURI)
   return !basePath.empty() && StringUtils::StartsWith(uriPath, basePath);
 }
 
+bool URIUtils::IsInPath(const std::string &uri, const std::vector<std::string> &baseURIs)
+{
+  for (std::vector<std::string>::const_iterator it = baseURIs.begin(); it != baseURIs.end(); ++it)
+  {
+    if (URIUtils::IsInPath(uri, *it))
+      return true;
+  }
+  return false;
+}
+
 /* returns filename extension including period of filename */
 std::string URIUtils::GetExtension(const CURL& url)
 {

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -1333,3 +1333,21 @@ bool URIUtils::IsUsingFastSwitch(const CStdString& strFile)
 {
   return IsUDP(strFile) || IsTCP(strFile) || IsPVRChannel(strFile);
 }
+
+std::vector<std::string> URIUtils::ExpandPaths(const std::vector<std::string> &paths)
+{
+  std::vector<std::string> expandedPaths;
+  for (std::vector<std::string>::const_iterator path = paths.begin(); path != paths.end(); ++path)
+  {
+    if (IsMultiPath(*path))
+    {
+      std::vector<std::string> multiPaths;
+      CMultiPathDirectory::GetPaths(*path, multiPaths);
+      expandedPaths.insert(expandedPaths.end(), multiPaths.begin(), multiPaths.end());
+    }
+    else
+      expandedPaths.push_back(*path);
+  }
+
+  return expandedPaths;
+}

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -29,6 +29,7 @@ public:
   URIUtils(void);
   virtual ~URIUtils(void);
   static bool IsInPath(const CStdString &uri, const CStdString &baseURI);
+  static bool IsInPath(const std::string &uri, const std::vector<std::string> &baseURIs);
 
   static CStdString GetDirectory(const CStdString &strFilePath);
 

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -219,6 +219,8 @@ public:
    */
   static bool UpdateUrlEncoding(std::string &strFilename);
 
+  static std::vector<std::string> ExpandPaths(const std::vector<std::string> &paths);
+
 private:
   static std::string resolvePath(const std::string &path);
 };

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -8376,6 +8376,34 @@ std::vector<int> CVideoDatabase::CleanMediaType(const std::string &mediaType, co
   return cleanedIDs;
 }
 
+void CVideoDatabase::UpdateProgress(CGUIDialogProgressBarHandle *handle, CGUIDialogProgress *progress, int current, int total, bool &canceled)
+{
+  canceled = false;
+  if (handle == NULL && progress == NULL)
+    return;
+
+  int percentage = current * 100 / total;
+  if (handle != NULL)
+    handle->SetPercentage(static_cast<float>(percentage));
+  else
+  {
+    // only update the percentage value if it has changed to avoid constantly
+    // re-drawing the whole progress dialog which is very slow
+    if (percentage != progress->GetPercentage())
+    {
+      progress->SetPercentage(percentage);
+      progress->Progress();
+    }
+
+    // check if the process was canceled
+    if (progress->IsCanceled())
+    {
+      progress->Close();
+      canceled = true;
+    }
+  }
+}
+
 void CVideoDatabase::DumpToDummyFiles(const CStdString &path)
 {
   // get all tvshows

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -7963,7 +7963,11 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const se
 
     int total = m_pDS->num_rows();
     int current = 0;
+    bool canceled = false;
+    UpdateProgress(handle, progress, current, total, canceled);
 
+    std::vector< std::pair<std::string, std::string> > vecFilesToTestForDelete;
+    std::set<std::string> pathsToTestForDelete;
     while (!m_pDS->eof())
     {
       std::string path = m_pDS->fv("path.strPath").get_asString();
@@ -7983,29 +7987,89 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const se
       if (URIUtils::IsOnDVD(fullPath) || !CFile::Exists(fullPath, false))
         filesToTestForDelete += m_pDS->fv("files.idFile").get_asString() + ",";
 
-      if (handle == NULL && progress != NULL)
+      std::string idFile = m_pDS->fv("files.idFile").get_asString();
+      if (URIUtils::IsOnDVD(fullPath))
+        filesToTestForDelete += idFile + ",";
+      else
       {
-        int percentage = current * 100 / total;
-        if (percentage > progress->GetPercentage())
-        {
-          progress->SetPercentage(percentage);
-          progress->Progress();
-        }
-        if (progress->IsCanceled())
-        {
-          progress->Close();
-          m_pDS->close();
-          ANNOUNCEMENT::CAnnouncementManager::Get().Announce(ANNOUNCEMENT::VideoLibrary, "xbmc", "OnCleanFinished");
-          return;
-        }
+        pathsToTestForDelete.insert(path);
+        vecFilesToTestForDelete.push_back(std::make_pair(idFile, std::string(fullPath)));
       }
-      else if (handle != NULL)
-        handle->SetPercentage(current * 100 / (float)total);
 
-      m_pDS->next();
+      UpdateProgress(handle, progress, current, total, canceled);
+      if (canceled)
+      {
+        m_pDS->close();
+        RollbackTransaction();
+        ANNOUNCEMENT::CAnnouncementManager::Get().Announce(ANNOUNCEMENT::VideoLibrary, "xbmc", "OnCleanFinished");
+        return;
+      }
+
       current++;
+      m_pDS->next();
     }
     m_pDS->close();
+
+    std::map<int, std::pair<bool, bool> > pathsExistenceDecisions;
+    std::vector<std::string> sourcesNotToDelete;
+    std::vector<std::string> sourcesToDelete;
+
+    // go through all sources, look for non-exising ones and ask the user whether to remove or keep them
+    std::map<std::string, std::pair<bool, bool> > sourcesExistenceDecisions =
+      CMediaSourceSettings::Get().HandleSourceExistence("videos", pathsToTestForDelete, showProgress, 15012, 15013, 15014, 15015);
+
+    // reset progress to 0%
+    current = 0;
+    total = static_cast<int>(sourcesExistenceDecisions.size());
+    UpdateProgress(handle, progress, 0, 1, canceled);
+
+    // fill the decisions into the map
+    for (std::map<std::string, std::pair<bool, bool> >::const_iterator source = sourcesExistenceDecisions.begin(); source != sourcesExistenceDecisions.end(); ++source)
+    {
+      int sourcePathId = GetPathId(source->first);
+      // only mark a source as to be deleted if it doesn't exist and the user chose to delete it
+      pathsExistenceDecisions.insert(std::make_pair(sourcePathId, source->second));
+
+      if (!source->second.first && !source->second.second)
+        sourcesToDelete.push_back(source->first);
+      else
+        sourcesNotToDelete.push_back(source->first);
+
+      UpdateProgress(handle, progress, current, total, canceled);
+      if (canceled)
+      {
+        m_pDS->close();
+        RollbackTransaction();
+        ANNOUNCEMENT::CAnnouncementManager::Get().Announce(ANNOUNCEMENT::VideoLibrary, "xbmc", "OnCleanFinished");
+        return;
+      }
+
+      current++;
+    }
+
+    // reset progress to 0%
+    current = 0;
+    total = static_cast<int>(vecFilesToTestForDelete.size());
+    UpdateProgress(handle, progress, 0, 1, canceled);
+
+    for (std::vector< std::pair<std::string, std::string> >::const_iterator file = vecFilesToTestForDelete.begin(); file != vecFilesToTestForDelete.end(); ++file)
+    {
+      // remove optical, non-existing files
+      if (!URIUtils::IsInPath(file->second, sourcesNotToDelete) &&
+         (URIUtils::IsInPath(file->second, sourcesToDelete) || !CFile::Exists(file->second, false)))
+         filesToTestForDelete += file->first + ",";
+
+      UpdateProgress(handle, progress, current, total, canceled);
+      if (canceled)
+      {
+        m_pDS->close();
+        RollbackTransaction();
+        ANNOUNCEMENT::CAnnouncementManager::Get().Announce(ANNOUNCEMENT::VideoLibrary, "xbmc", "OnCleanFinished");
+        return;
+      }
+
+      current++;
+    }
 
     std::string filesToDelete;
 
@@ -8021,7 +8085,6 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const se
     }
     m_pDS->close();
 
-    std::map<int, bool> pathsDeleteDecisions;
     std::vector<int> movieIDs;
     std::vector<int> tvshowIDs;
     std::vector<int> episodeIDs;
@@ -8031,15 +8094,9 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const se
     {
       StringUtils::TrimRight(filesToTestForDelete, ",");
 
-      movieIDs = CleanMediaType(MediaTypeMovie, filesToTestForDelete, pathsDeleteDecisions, filesToDelete, !showProgress);
-      episodeIDs = CleanMediaType(MediaTypeEpisode, filesToTestForDelete, pathsDeleteDecisions, filesToDelete, !showProgress);
-      musicVideoIDs = CleanMediaType(MediaTypeMusicVideo, filesToTestForDelete, pathsDeleteDecisions, filesToDelete, !showProgress);
-    }
-
-    if (progress != NULL)
-    {
-      progress->SetPercentage(100);
-      progress->Progress();
+      movieIDs = CleanMediaType(MediaTypeMovie, filesToTestForDelete, pathsExistenceDecisions, filesToDelete, !showProgress);
+      episodeIDs = CleanMediaType(MediaTypeEpisode, filesToTestForDelete, pathsExistenceDecisions, filesToDelete, !showProgress);
+      musicVideoIDs = CleanMediaType(MediaTypeMusicVideo, filesToTestForDelete, pathsExistenceDecisions, filesToDelete, !showProgress);
     }
 
     if (!filesToDelete.empty())
@@ -8095,19 +8152,20 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const se
     sql = "SELECT path.idPath, path.strPath, path.idParentPath FROM path "
             "WHERE NOT ((strContent IS NULL OR strContent = '') "
                    "AND (strSettings IS NULL OR strSettings = '') "
-                   "AND (strHash IS NULL OR strHash = '') "
                    "AND (exclude IS NULL OR exclude != 1))";
     m_pDS->query(sql.c_str());
     std::string strIds;
     while (!m_pDS->eof())
     {
-      std::map<int, bool>::const_iterator pathsDeleteDecision = pathsDeleteDecisions.find(m_pDS->fv(0).get_asInt());
+      std::string strPath = m_pDS->fv(1).get_asString();
+      std::map<int, std::pair<bool, bool> >::const_iterator pathsExistenceDecision = pathsExistenceDecisions.find(m_pDS->fv(0).get_asInt());
       // Check if we have a decision for the parent path
-      std::map<int, bool>::const_iterator pathsDeleteDecisionByParent = pathsDeleteDecisions.find(m_pDS->fv(2).get_asInt());
-      if (((pathsDeleteDecision != pathsDeleteDecisions.end() && pathsDeleteDecision->second) ||
-           (pathsDeleteDecision == pathsDeleteDecisions.end() && !CDirectory::Exists(m_pDS->fv(1).get_asString(), false))) &&
-          ((pathsDeleteDecisionByParent != pathsDeleteDecisions.end() && pathsDeleteDecisionByParent->second) ||
-           (pathsDeleteDecisionByParent == pathsDeleteDecisions.end())))
+      std::map<int, std::pair<bool, bool> >::const_iterator pathsExistenceDecisionByParent = pathsExistenceDecisions.find(m_pDS->fv(2).get_asInt());
+      if (((pathsExistenceDecision != pathsExistenceDecisions.end() && !pathsExistenceDecision->second.first && !pathsExistenceDecision->second.second) ||
+           (pathsExistenceDecision == pathsExistenceDecisions.end() &&
+            (URIUtils::IsInPath(strPath, sourcesToDelete) || !CDirectory::Exists(strPath, false)))) &&
+          ((pathsExistenceDecisionByParent != pathsExistenceDecisions.end() && pathsExistenceDecisionByParent->second.first && !pathsExistenceDecisionByParent->second.second) ||
+           (pathsExistenceDecisionByParent == pathsExistenceDecisions.end())))
         strIds += m_pDS->fv(0).get_asString() + ",";
 
       m_pDS->next();
@@ -8263,7 +8321,7 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const se
 }
 
 std::vector<int> CVideoDatabase::CleanMediaType(const std::string &mediaType, const std::string &cleanableFileIDs,
-                                                std::map<int, bool> &pathsDeleteDecisions, std::string &deletedFileIDs, bool silent)
+                                                std::map<int, std::pair<bool, bool> > &pathsExistenceDecisions, std::string &deletedFileIDs, bool silent)
 {
   std::vector<int> cleanedIDs;
   if (mediaType.empty() || cleanableFileIDs.empty())
@@ -8307,8 +8365,6 @@ std::vector<int> CVideoDatabase::CleanMediaType(const std::string &mediaType, co
                     parentPathIdField.c_str(),
                     table.c_str(), cleanableFileIDs.c_str());
 
-  // map of parent path ID to boolean pair (if not exists and user choice)
-  std::map<int, std::pair<bool, bool> > sourcePathsDeleteDecisions;
   m_pDS2->query(sql.c_str());
   while (!m_pDS2->eof())
   {
@@ -8319,49 +8375,32 @@ std::vector<int> CVideoDatabase::CleanMediaType(const std::string &mediaType, co
     std::string sourcePath;
     GetSourcePath(parentPath, sourcePath, scanSettings);
     int sourcePathID = GetPathId(sourcePath);
-    std::map<int, std::pair<bool, bool> >::const_iterator sourcePathsDeleteDecision = sourcePathsDeleteDecisions.find(sourcePathID);
+    std::map<int, std::pair<bool, bool> >::const_iterator sourcePathsExistenceDecision = pathsExistenceDecisions.find(sourcePathID);
     bool del = true;
-    if (sourcePathsDeleteDecision == sourcePathsDeleteDecisions.end())
+    if (sourcePathsExistenceDecision == pathsExistenceDecisions.end())
     {
-      bool sourcePathNotExists = !CDirectory::Exists(sourcePath, false);
+      bool sourcePathExists = CDirectory::Exists(sourcePath, false);
       // if the parent path exists, the file will be deleted without asking
       // if the parent path doesn't exist, ask the user whether to remove all items it contained
-      if (sourcePathNotExists)
+      if (!sourcePathExists)
       {
         // in silent mode assume that the files are just temporarily missing
         if (silent)
           del = false;
         else
-        {
-          CGUIDialogYesNo* pDialog = (CGUIDialogYesNo*)g_windowManager.GetWindow(WINDOW_DIALOG_YES_NO);
-          if (pDialog != NULL)
-          {
-            CURL sourceUrl(sourcePath);
-            pDialog->SetHeading(15012);
-            pDialog->SetText(StringUtils::Format(g_localizeStrings.Get(15013).c_str(), sourceUrl.GetWithoutUserDetails().c_str()));
-            pDialog->SetChoice(0, 15015);
-            pDialog->SetChoice(1, 15014);
-
-            //send message and wait for user input
-            ThreadMessage tMsg = { TMSG_DIALOG_DOMODAL, WINDOW_DIALOG_YES_NO, g_windowManager.GetActiveWindow() };
-            CApplicationMessenger::Get().SendMessage(tMsg, true);
-
-            del = !pDialog->IsConfirmed();
-          }
-        }
+          del = CMediaSourceSettings::PromptForSource(sourcePath, 15012, 15013, 15015, 15014);
       }
 
-      sourcePathsDeleteDecisions.insert(make_pair(sourcePathID, make_pair(sourcePathNotExists, del)));
-      pathsDeleteDecisions.insert(make_pair(sourcePathID, sourcePathNotExists && del));
+      pathsExistenceDecisions.insert(make_pair(sourcePathID, make_pair(sourcePathExists, !del)));
     }
     // the only reason not to delete the file is if the parent path doesn't
     // exist and the user decided to delete all the items it contained
-    else if (sourcePathsDeleteDecision->second.first &&
-             !sourcePathsDeleteDecision->second.second)
+    else if (!sourcePathsExistenceDecision->second.first &&
+             sourcePathsExistenceDecision->second.second)
       del = false;
 
     if (scanSettings.parent_name)
-      pathsDeleteDecisions.insert(make_pair(m_pDS2->fv(2).get_asInt(), del));
+      pathsExistenceDecisions.insert(make_pair(m_pDS2->fv(2).get_asInt(), make_pair(false, !del)));
 
     if (del)
     {

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -897,7 +897,8 @@ private:
   CStdString GetSafeFile(const CStdString &dir, const CStdString &name) const;
 
   std::vector<int> CleanMediaType(const std::string &mediaType, const std::string &cleanableFileIDs,
-                                  std::map<int, bool> &pathsDeleteDecisions, std::string &deletedFileIDs, bool silent);
+                                  std::map<int, std::pair<bool, bool> > &pathsExistenceDecisions,
+                                  std::string &deletedFileIDs, bool silent);
   static void UpdateProgress(CGUIDialogProgressBarHandle *handle, CGUIDialogProgress *progress, int current, int total, bool &canceled);
 
   static void AnnounceRemove(std::string content, int id, bool scanning = false);

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -898,6 +898,7 @@ private:
 
   std::vector<int> CleanMediaType(const std::string &mediaType, const std::string &cleanableFileIDs,
                                   std::map<int, bool> &pathsDeleteDecisions, std::string &deletedFileIDs, bool silent);
+  static void UpdateProgress(CGUIDialogProgressBarHandle *handle, CGUIDialogProgress *progress, int current, int total, bool &canceled);
 
   static void AnnounceRemove(std::string content, int id, bool scanning = false);
   static void AnnounceUpdate(std::string content, int id);

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -115,7 +115,7 @@ namespace VIDEO
          * reference points to the entry in the set a null reference error
          * occurs.
          */
-        CStdString directory = *m_pathsToScan.begin();
+        std::string directory = *m_pathsToScan.begin();
         if (!CDirectory::Exists(directory))
         {
           /*
@@ -176,7 +176,14 @@ namespace VIDEO
     if (strDirectory.empty())
     { // scan all paths in the database.  We do this by scanning all paths in the db, and crossing them off the list as
       // we go.
-      m_database.GetPaths(m_pathsToScan);
+      std::set<CStdString> pathsToScan;
+      m_database.GetPaths(pathsToScan);
+      m_database.Close();
+
+      // TODO: can be removed once CVideoDatabase::GetPaths() handles an
+      // std::set<std::string> instead of an std::set<CStdString>
+      for (std::set<CStdString>::const_iterator path = pathsToScan.begin(); path != pathsToScan.end(); ++path)
+        m_pathsToScan.insert(*path);
     }
     else
     { // scan all the paths of this subtree that is in the database
@@ -240,7 +247,7 @@ namespace VIDEO
      * the check for file or folder exclusion to prevent an infinite while loop
      * in Process().
      */
-    set<CStdString>::iterator it = m_pathsToScan.find(strDirectory);
+    set<std::string>::iterator it = m_pathsToScan.find(strDirectory);
     if (it != m_pathsToScan.end())
       m_pathsToScan.erase(it);
 
@@ -686,7 +693,7 @@ namespace VIDEO
        * Remove this path from the list we're processing in order to avoid hitting
        * it twice in the main loop.
        */
-      set<CStdString>::iterator it = m_pathsToScan.find(item->GetPath());
+      set<std::string>::iterator it = m_pathsToScan.find(item->GetPath());
       if (it != m_pathsToScan.end())
         m_pathsToScan.erase(it);
 

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -38,6 +38,7 @@
 #include "dialogs/GUIDialogOK.h"
 #include "interfaces/AnnouncementManager.h"
 #include "settings/AdvancedSettings.h"
+#include "settings/MediaSourceSettings.h"
 #include "settings/Settings.h"
 #include "utils/StringUtils.h"
 #include "guilib/LocalizeStrings.h"
@@ -101,6 +102,9 @@ namespace VIDEO
 
       SetPriority(GetMinPriority());
 
+      // get all sources that can be skipped because they are unavailable
+      std::vector<std::string> sourcesToSkip = CMediaSourceSettings::FindSourcesToSkip("video", m_pathsToScan, m_showDialog);
+
       // Database operations should not be canceled
       // using Interupt() while scanning as it could
       // result in unexpected behaviour.
@@ -116,7 +120,7 @@ namespace VIDEO
          * occurs.
          */
         std::string directory = *m_pathsToScan.begin();
-        if (!CDirectory::Exists(directory))
+        if (URIUtils::IsInPath(directory, sourcesToSkip) || !CDirectory::Exists(directory))
         {
           /*
            * Note that this will skip clean (if m_bClean is enabled) if the directory really

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -252,7 +252,7 @@ namespace VIDEO
     bool m_scanAll;
     CStdString m_strStartDir;
     CVideoDatabase m_database;
-    std::set<CStdString> m_pathsToScan;
+    std::set<std::string> m_pathsToScan;
     std::set<int> m_pathsToClean;
     CNfoFile m_nfoReader;
   };

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -253,7 +253,6 @@ namespace VIDEO
     CStdString m_strStartDir;
     CVideoDatabase m_database;
     std::set<CStdString> m_pathsToScan;
-    std::set<CStdString> m_pathsToCount;
     std::set<int> m_pathsToClean;
     CNfoFile m_nfoReader;
   };


### PR DESCRIPTION
This is an improvement of #4304 and it improves the way we handle unavailable remote sources during library scanning and cleaning. Right now if the remote server on which a source is located isn't online we constantly call `CFile::Exists()` and `CDirectory::Exists()` on every path which we know from the remote source and on every call we run into a timeout which slows the whole process down a lot.

The idea here is to first go through all available sources and check if they are available or not. During **library scanning** (both video and music), if one of the sources is not available we ask the user if he wants to retry accessing the source or if he wants to skip it completely. Once skip has been chosen we do not call `CFile::Exists()` or `CDirectory::Exists()` on any sub-path of the skipped source and therefore greatly reduce the number of times we run into the timeout from `X` to `1`. During **library cleaning** (only video) we take the same approach but we ask the user if he wants to keep all the items from that source or if he wants to delete them all. Once again we greatly reduce the number of times we run into the timeout.

I have to admit that `CVideoDatabase::CleanDatabase()` is getting uglier and uglier and it might be best to re-think the process in there and re-write it completely. So if we feel safer with only the library scanning improvements I'd be happy to split the PR into two. Also the library scanning changes almost match the ones from #4304 except that #4304 checked all sources and not just the ones that were actually being scanned.
