### PR TITLE
[AML] HEVC, S805 and S812 board support

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/AMLCodec.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/AMLCodec.cpp
@@ -1580,7 +1580,7 @@ bool CAMLCodec::OpenDecoder(CDVDStreamInfo &hints)
         am_private->gcodec.param = (void*)(EXTERNAL_PTS | SYNC_OUTSIDE);
       break;
     case VFORMAT_H264_4K2K:
-      if (aml_get_device_type() == AML_DEVICE_TYPE_M8) {
+      if ((aml_get_device_type() == AML_DEVICE_TYPE_M8) || (aml_get_device_type() == AML_DEVICE_TYPE_M8M2)) {
         am_private->gcodec.format = VIDEO_DEC_FORMAT_H264_4K2K;
         am_private->gcodec.param  = (void*)EXTERNAL_PTS;
         // h264 in an avi file
@@ -1653,7 +1653,7 @@ bool CAMLCodec::OpenDecoder(CDVDStreamInfo &hints)
   g_renderManager.RegisterRenderFeaturesCallBack((const void*)this, RenderFeaturesCallBack);
 
   m_display_rect = g_graphicsContext.GetViewWindow();
-  if (aml_get_device_type() == AML_DEVICE_TYPE_M8)
+  if ((aml_get_device_type() == AML_DEVICE_TYPE_M8)  || (aml_get_device_type() == AML_DEVICE_TYPE_M8B) || (aml_get_device_type() == AML_DEVICE_TYPE_M8M2))
   {
     char mode[256] = {0};
     aml_get_sysfs_str("/sys/class/display/mode", mode, 255);

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecAmlogic.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecAmlogic.h
@@ -66,8 +66,6 @@ protected:
   mpeg2_sequence *m_mpeg2_sequence;
   double          m_mpeg2_sequence_pts;
 
-  bool            m_convert_bitstream;
   CBitstreamParser *m_bitparser;
   CBitstreamConverter *m_bitstream;
-  bool            m_hevc;
 };

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecAmlogic.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecAmlogic.h
@@ -66,6 +66,8 @@ protected:
   mpeg2_sequence *m_mpeg2_sequence;
   double          m_mpeg2_sequence_pts;
 
+  bool            m_convert_bitstream;
   CBitstreamParser *m_bitparser;
   CBitstreamConverter *m_bitstream;
+  bool            m_hevc;
 };

--- a/xbmc/utils/AMLUtils.cpp
+++ b/xbmc/utils/AMLUtils.cpp
@@ -159,6 +159,21 @@ void aml_permissions()
   }
 }
 
+bool aml_support_hevc()
+{
+    char valstr[1024];
+    if(aml_get_sysfs_str("/sys/class/amstream/vcodec_profile", valstr, 1024) != 0)
+    {
+        return false;
+    }
+    char* p = strstr(valstr, "hevc:");
+    if(p == NULL)
+    {
+        return false;
+    }
+    return true;
+}
+
 enum AML_DEVICE_TYPE aml_get_device_type()
 {
   static enum AML_DEVICE_TYPE aml_device_type = AML_DEVICE_TYPE_UNINIT;
@@ -173,8 +188,14 @@ enum AML_DEVICE_TYPE aml_get_device_type()
       aml_device_type = AML_DEVICE_TYPE_M3;
     else if (cpu_hardware.find("Meson6") != std::string::npos)
       aml_device_type = AML_DEVICE_TYPE_M6;
-    else if (cpu_hardware.find("Meson8") != std::string::npos)
-      aml_device_type = AML_DEVICE_TYPE_M8;
+    else if ((cpu_hardware.find("Meson8") != std::string::npos) && (cpu_hardware.find("Meson8B") == std::string::npos))
+    {
+      if (aml_support_hevc())
+        aml_device_type = AML_DEVICE_TYPE_M8M2;
+      else
+        aml_device_type = AML_DEVICE_TYPE_M8;
+    } else if (cpu_hardware.find("Meson8B") != std::string::npos)
+      aml_device_type = AML_DEVICE_TYPE_M8B;
     else
       aml_device_type = AML_DEVICE_TYPE_UNKNOWN;
   }
@@ -218,7 +239,7 @@ void aml_set_audio_passthrough(bool passthrough)
 {
   if (  aml_present()
     &&  aml_get_device_type() != AML_DEVICE_TYPE_UNKNOWN
-    &&  aml_get_device_type() <= AML_DEVICE_TYPE_M8)
+    &&  aml_get_device_type() <= AML_DEVICE_TYPE_M8M2)
   {
     // m1 uses 1, m3 and above uses 2
     int raw = aml_get_device_type() == AML_DEVICE_TYPE_M1 ? 1:2;

--- a/xbmc/utils/AMLUtils.h
+++ b/xbmc/utils/AMLUtils.h
@@ -28,7 +28,9 @@ enum AML_DEVICE_TYPE
   AML_DEVICE_TYPE_M1,
   AML_DEVICE_TYPE_M3,
   AML_DEVICE_TYPE_M6,
-  AML_DEVICE_TYPE_M8
+  AML_DEVICE_TYPE_M8,
+  AML_DEVICE_TYPE_M8B,
+  AML_DEVICE_TYPE_M8M2
 };
 
 int aml_set_sysfs_str(const char *path, const char *val);
@@ -40,6 +42,7 @@ bool aml_present();
 void aml_permissions();
 bool aml_hw3d_present();
 bool aml_wired_present();
+bool aml_support_hevc();
 enum AML_DEVICE_TYPE aml_get_device_type();
 void aml_cpufreq_min(bool limit);
 void aml_cpufreq_max(bool limit);


### PR DESCRIPTION
This PR depends on #5374 (needs BitstreamConverter patch for HEVC).

HEVC using AMLCodec is working on all sample files I could get. Need more interested testers :)

Also, I did not change h264 way of using bitstreamconverter for now, not to mess anything.

@koying @davilla 
