### PR TITLE
Better emulate system read() and fread() functions, fixes #15490

### DIFF
--- a/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
+++ b/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
@@ -530,7 +530,7 @@ extern "C"
     if (bWrite)
       bResult = pFile->OpenForWrite(CUtil::ValidatePath(str), bOverwrite);
     else
-      bResult = pFile->Open(CUtil::ValidatePath(str));
+      bResult = pFile->Open(CUtil::ValidatePath(str), READ_TRUNCATED);
 
     if (bResult)
     {

--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -745,7 +745,9 @@ bool CFile::ReadString(char *szLine, int iLineLength)
 
 ssize_t CFile::Write(const void* lpBuf, size_t uiBufSize)
 {
-  if (!m_pFile || !lpBuf)
+  if (!m_pFile)
+    return -1;
+  if (lpBuf == NULL && uiBufSize != 0)
     return -1;
 
   try

--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -497,7 +497,9 @@ int CFile::Stat(const CURL& file, struct __stat64* buffer)
 
 ssize_t CFile::Read(void *lpBuf, size_t uiBufSize)
 {
-  if (!m_pFile || !lpBuf)
+  if (!m_pFile)
+    return -1;
+  if (lpBuf == NULL && uiBufSize != 0)
     return -1;
 
   if (uiBufSize > SSIZE_MAX)

--- a/xbmc/filesystem/posix/PosixFile.cpp
+++ b/xbmc/filesystem/posix/PosixFile.cpp
@@ -155,8 +155,11 @@ ssize_t CPosixFile::Read(void* lpBuf, size_t uiBufSize)
 
 ssize_t CPosixFile::Write(const void* lpBuf, size_t uiBufSize)
 {
-  assert(lpBuf != NULL);
-  if (m_fd < 0 || !m_allowWrite || !lpBuf)
+  if (m_fd < 0)
+    return -1;
+
+  assert(lpBuf != NULL || uiBufSize == 0);
+  if ((lpBuf == NULL && uiBufSize != 0) || !m_allowWrite)
     return -1;
 
   if (uiBufSize > SSIZE_MAX)

--- a/xbmc/filesystem/posix/PosixFile.cpp
+++ b/xbmc/filesystem/posix/PosixFile.cpp
@@ -113,10 +113,13 @@ void CPosixFile::Close()
 
 ssize_t CPosixFile::Read(void* lpBuf, size_t uiBufSize)
 {
-  assert(lpBuf != NULL);
-  if (m_fd < 0 || !lpBuf)
+  if (m_fd < 0)
     return -1;
   
+  assert(lpBuf != NULL || uiBufSize == 0);
+  if (lpBuf == NULL && uiBufSize != 0)
+    return -1;
+
   if (uiBufSize > SSIZE_MAX)
     uiBufSize = SSIZE_MAX;
   

--- a/xbmc/filesystem/win32/Win32File.cpp
+++ b/xbmc/filesystem/win32/Win32File.cpp
@@ -173,8 +173,11 @@ void CWin32File::Close()
 
 ssize_t CWin32File::Read(void* lpBuf, size_t uiBufSize)
 {
-  assert(lpBuf != NULL);
-  if (m_hFile == INVALID_HANDLE_VALUE || !lpBuf)
+  if (m_hFile == INVALID_HANDLE_VALUE)
+    return -1;
+
+  assert(lpBuf != NULL || uiBufSize == 0);
+  if (lpBuf == NULL && uiBufSize != 0)
     return -1;
 
   if (uiBufSize > SSIZE_MAX)

--- a/xbmc/filesystem/win32/Win32File.cpp
+++ b/xbmc/filesystem/win32/Win32File.cpp
@@ -214,8 +214,11 @@ ssize_t CWin32File::Read(void* lpBuf, size_t uiBufSize)
 
 ssize_t CWin32File::Write(const void* lpBuf, size_t uiBufSize)
 {
-  assert(lpBuf != NULL);
-  if (m_hFile == INVALID_HANDLE_VALUE || !lpBuf)
+  if (m_hFile == INVALID_HANDLE_VALUE)
+    return -1;
+
+  assert(lpBuf != NULL || uiBufSize == 0);
+  if (lpBuf == NULL && uiBufSize != 0)
     return -1;
 
   if (!m_allowWrite)


### PR DESCRIPTION
libass use test fread() with null pointer and zero count to check for readable file.
I fixed CFile, Win32File and PosixFile to accept null buffer pointer with zero size.
Last commit allow to really call of system file API instead of blindly returning zero for zero size reading.
