### PR TITLE
[fix] keyboard layout default setting

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -144,7 +144,7 @@
         </setting>
         <setting id="locale.keyboardlayouts" type="list[string]" label="310" help="36432">
           <level>1</level>
-          <default>QWERTY</default>
+          <default>English QWERTY</default>
           <constraints>
             <options>keyboardlayouts</options>
             <delimiter>|</delimiter>


### PR DESCRIPTION
This fixes empty OSK since #5525 setting name is now English QWERTY :+1: 
Because default name changed you would get no keys on OSK because list of keyboardlayout is now empty for those who had QWERTY as default and thus a empty OSK

I suppose if your keyboard layout was renamed (for e.g. Bulgarian/Russian) you need to reselect it again since it drops from the guisettings because no match if those were your default you also get empty osk until reselect layout.

But there is a remaining issue I dont know how to fix.

If a user happens to select no layouts at all you still get empty OSK, I would suggest that the fallback requires one otion to be selected in the list and not allow a user no layout selection. 
Idk how to implement that so anyone else may need to step in after this.

@MartijnKaijser 
