### PR TITLE
cmake: support addons without a build step

### DIFF
--- a/project/cmake/addons/CMakeLists.txt
+++ b/project/cmake/addons/CMakeLists.txt
@@ -169,6 +169,7 @@ foreach(addon ${addons})
         list(GET def 1 url)
 
         set(archive_name ${id})
+        set(archive ${id})
         if(ADDON_SRC_PREFIX)
           set(SOURCE_DIR ${ADDON_SRC_PREFIX}/${id})
           set(archive_name "")
@@ -184,6 +185,7 @@ foreach(addon ${addons})
           # if we ever use other repositories, this might need adapting
           set(url ${url}/archive/${revision}.tar.gz)
           set(archive_name ${archive_name}-${revision})
+          set(archive ${archive_name}.tar.gz)
         elseif("${SOURCE_DIR}" STREQUAL "")
           # check if the URL starts with file://
           string(REGEX MATCH "^file://.*$" local_url "${url}")
@@ -204,22 +206,25 @@ foreach(addon ${addons})
                 string(SUBSTRING "${SOURCE_DIR}" 1 -1 SOURCE_DIR)
               endif()
             endif()
+          else()
+            get_filename_component(archive ${url} NAME)
+            set(archive_name ${archive})
           endif()
         endif()
 
         # download the addon if necessary
         if(NOT "${archive_name}" STREQUAL "")
           # download and extract the addon
-          if(NOT EXISTS ${BUILD_DIR}/download/${archive_name}.tar.gz)
+          if(NOT EXISTS ${BUILD_DIR}/download/${archive})
             # cleanup any of the previously downloaded archives of this addon
-            file(GLOB archives "${BUILD_DIR}/download/${id}*.tar.gz")
+            file(GLOB archives "${BUILD_DIR}/download/${id}*.*")
             if(archives)
               message(STATUS "Removing old archives of ${id}: ${archives}")
               file(REMOVE ${archives})
             endif()
 
             # download the addon
-            file(DOWNLOAD "${url}" "${BUILD_DIR}/download/${archive_name}.tar.gz" STATUS dlstatus LOG dllog SHOW_PROGRESS)
+            file(DOWNLOAD "${url}" "${BUILD_DIR}/download/${archive}" STATUS dlstatus LOG dllog SHOW_PROGRESS)
             list(GET dlstatus 0 retcode)
             if(NOT ${retcode} EQUAL 0)
               message(FATAL_ERROR "ERROR downloading ${url} - status: ${dlstatus} log: ${dllog}")
@@ -232,11 +237,11 @@ foreach(addon ${addons})
           endif()
 
           # extract the addon from the archive
-          execute_process(COMMAND ${CMAKE_COMMAND} -E tar xzvf ${BUILD_DIR}/download/${archive_name}.tar.gz
+          execute_process(COMMAND ${CMAKE_COMMAND} -E tar xzvf ${BUILD_DIR}/download/${archive}
                           WORKING_DIRECTORY ${BUILD_DIR})
           file(GLOB extract_dir "${BUILD_DIR}/${archive_name}*")
           if(extract_dir STREQUAL "")
-            message(FATAL_ERROR "${id}: error extracting ${BUILD_DIR}/download/${archive_name}.tar.gz")
+            message(FATAL_ERROR "${id}: error extracting ${BUILD_DIR}/download/${archive}")
           else()
             file(RENAME "${extract_dir}" "${BUILD_DIR}/${id}")
           endif()

--- a/project/cmake/addons/CMakeLists.txt
+++ b/project/cmake/addons/CMakeLists.txt
@@ -145,7 +145,8 @@ add_subdirectory(depends)
 # look for all the addons to be built
 file(GLOB_RECURSE addons ${PROJECT_SOURCE_DIR}/addons/*.txt)
 foreach(addon ${addons})
-  if(NOT (addon MATCHES platforms.txt))
+  if(NOT (addon MATCHES nobuild.txt OR
+          addon MATCHES platforms.txt))
     file(STRINGS ${addon} def)
     separate_arguments(def)
     list(GET def 0 id)
@@ -249,12 +250,22 @@ foreach(addon ${addons})
           set(SOURCE_DIR ${BUILD_DIR}/${id})
         endif()
 
+        set(EXTERNELPROJECT_SETUP "")
+
+        # check if the nobuild.txt file exists
+        if(EXISTS ${dir}/nobuild.txt)
+          # setup a custom install step that simply copies the downloaded repository
+          set(EXTERNELPROJECT_SETUP INSTALL_COMMAND ${CMAKE_COMMAND} -E copy_directory <SOURCE_DIR> <INSTALL_DIR>/${id})
+        else()
+          set(EXTERNALPROJECT_SETUP CMAKE_ARGS ${BUILD_ARGS})
+        endif()
+
         if(NOT "${SOURCE_DIR}" STREQUAL "" AND EXISTS ${SOURCE_DIR})
           # setup the buildsystem for the addon
           externalproject_add(${id}
                               SOURCE_DIR ${SOURCE_DIR}
                               INSTALL_DIR ${CMAKE_INSTALL_PREFIX}
-                              CMAKE_ARGS ${BUILD_ARGS})
+                              ${EXTERNALPROJECT_SETUP})
 
           # add a custom step to the external project between the configure and the build step which will always
           # be executed and therefore forces a re-build of all changed files

--- a/project/cmake/addons/README
+++ b/project/cmake/addons/README
@@ -23,6 +23,9 @@ are:
     also supported to specify negated platforms with a leading exclamation mark
     (i), e.g. "!windows".
     Available platforms are: linux, windows, darwin, ios, android, rbpi
+  * nobuild.txt: there's no configure and build step for an addon resulting in a
+    download and a simple copy of the downloaded directory. In case of a git
+    repository the .git directory is removed before copying the addon directory.
 
 The buildsystem uses the following variables (which can be passed into it when
 executing cmake with the -D<variable-name>=<value> option) to e.g. access


### PR DESCRIPTION
This adds very basic support for addons that don't have a build step to the cmake based binary addons buildsystem. The result is basically a simply download (from URL or from a GIT repository) and a copy of the downloaded directory to the install location for addons.

This allows us to download addons like the Chorus webinterface so that we don't have to use git submodules which are causing problems from time to time.

It might also work for skins but there we'd have to make some adjustements to the platform-specific build scripts that execute TexturePacker etc. Ideally that whole process could be done as part of the binary addon build process (as a build step) but we can look into that later.
