### PR TITLE
Allow moving Android app to SD Card

### DIFF
--- a/tools/android/packaging/xbmc/AndroidManifest.xml.in
+++ b/tools/android/packaging/xbmc/AndroidManifest.xml.in
@@ -2,6 +2,7 @@
 <!-- BEGIN_INCLUDE(manifest) -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.xbmc.@APP_NAME_LC@"
+    android:installLocation="auto"
     android:versionCode="@APP_VERSION_CODE@"
     android:versionName="@APP_VERSION_MAJOR@.@APP_VERSION_MINOR@-@APP_VERSION_TAG@" >
 


### PR DESCRIPTION
Not all devices have enough space on their primary partition to run/upgrade.  Setting this property allows moving the app to the external SD card.  I have been running with this setup for several months without issue.
