### PR TITLE
[pvr] fix call to base class GetContextButtons() to re-add favorite entry

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -105,6 +105,8 @@ void CGUIWindowPVRChannels::GetContextButtons(int itemNumber, CContextButtons &b
     buttons.Add(CONTEXT_BUTTON_FILTER, 19249);                                        /* filter channels */
     buttons.Add(CONTEXT_BUTTON_UPDATE_EPG, 19251);                                    /* update EPG information */
   }
+
+  CGUIWindowPVRBase::GetContextButtons(itemNumber, buttons);
 }
 
 std::string CGUIWindowPVRChannels::GetDirectoryPath(void)

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -100,6 +100,8 @@ void CGUIWindowPVRGuide::GetContextButtons(int itemNumber, CContextButtons &butt
   if (pItem->GetEPGInfoTag()->HasPVRChannel() &&
       g_PVRClients->HasMenuHooks(pItem->GetEPGInfoTag()->ChannelTag()->ClientID(), PVR_MENUHOOK_EPG))
     buttons.Add(CONTEXT_BUTTON_MENU_HOOKS, 19195);      /* PVR client specific action */
+
+  CGUIWindowPVRBase::GetContextButtons(itemNumber, buttons);
 }
 
 void CGUIWindowPVRGuide::UpdateSelectedItemPath()

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -141,6 +141,8 @@ void CGUIWindowPVRRecordings::GetContextButtons(int itemNumber, CContextButtons 
   if (pItem->HasPVRRecordingInfoTag() &&
       g_PVRClients->HasMenuHooks(pItem->GetPVRRecordingInfoTag()->m_iClientId, PVR_MENUHOOK_RECORDING))
     buttons.Add(CONTEXT_BUTTON_MENU_HOOKS, 19195);      /* PVR client specific action */
+
+  CGUIWindowPVRBase::GetContextButtons(itemNumber, buttons);
 }
 
 bool CGUIWindowPVRRecordings::OnAction(const CAction &action)

--- a/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
@@ -74,6 +74,8 @@ void CGUIWindowPVRSearch::GetContextButtons(int itemNumber, CContextButtons &but
   }
 
   buttons.Add(CONTEXT_BUTTON_CLEAR, 19232);             /* Clear search results */
+
+  CGUIWindowPVRBase::GetContextButtons(itemNumber, buttons);
 }
 
 void CGUIWindowPVRSearch::OnWindowLoaded()

--- a/xbmc/pvr/windows/GUIWindowPVRTimers.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRTimers.cpp
@@ -81,6 +81,8 @@ void CGUIWindowPVRTimers::GetContextButtons(int itemNumber, CContextButtons &but
     if (g_PVRClients->HasMenuHooks(pItem->GetPVRTimerInfoTag()->m_iClientId, PVR_MENUHOOK_TIMER))
       buttons.Add(CONTEXT_BUTTON_MENU_HOOKS, 19195);    /* PVR client specific action */
   }
+
+  CGUIWindowPVRBase::GetContextButtons(itemNumber, buttons);
 }
 
 bool CGUIWindowPVRTimers::OnContextButton(int itemNumber, CONTEXT_BUTTON button)


### PR DESCRIPTION
As pointed out by Angelinas in our forum http://forum.xbmc.org/showthread.php?tid=175135&pid=1816726#pid1816726 the base context menu items were lost after PVR rewrite. 

This adds the missing call to the base class which takes care of the favorite context menu entry.
