### PR TITLE
[rebrand] - fixed some labels from strings.po files

### DIFF
--- a/addons/skin.confluence/language/English/strings.po
+++ b/addons/skin.confluence/language/English/strings.po
@@ -534,7 +534,7 @@ msgstr ""
 #empty string with id 31407
 
 msgctxt "#31408"
-msgid "[B]CONFIGURE ADD-ONS[/B][CR][CR]Manage your installed Add-ons · Browse for and install Add-ons from xbmc.org[CR]Modify Add-on settings"
+msgid "[B]CONFIGURE ADD-ONS[/B][CR][CR]Manage your installed Add-ons · Browse for and install Add-ons from kodi.tv[CR]Modify Add-on settings"
 msgstr ""
 
 msgctxt "#31409"


### PR DESCRIPTION
there are still some old references to XBMC(.org) in some strings.po files. (Confluence + script.versioncheck)
Since they still have to be translated it would probably be nice to get those changes in early.
