### PR TITLE
[keyboardlayouts] change from named layout to a locale+variant system

### DIFF
--- a/system/keyboardlayouts.xml
+++ b/system/keyboardlayouts.xml
@@ -4,7 +4,7 @@ Please use English language names instead.
 Default font lacks support for all characters
 -->
 <keyboardlayouts>
-  <layout name="English QWERTY">
+  <layout locale="en" variant="QWERTY">
     <keyboard>
       <row>1234567890</row>
       <row>qwertyuiop</row>
@@ -24,7 +24,7 @@ Default font lacks support for all characters
       <row>`~</row>
     </keyboard>
   </layout>
-  <layout name="English AZERTY">
+  <layout locale="en" variant="AZERTY">
     <keyboard>
       <row>1234567890</row>
       <row>azertyuiop</row>
@@ -44,7 +44,7 @@ Default font lacks support for all characters
       <row>`~éèçà</row>
     </keyboard>
   </layout>
-  <layout name="English ABC">
+  <layout locale="en" variant="ABC">
     <keyboard>
       <row>0123456789</row>
       <row>abcdefghij</row>
@@ -64,7 +64,7 @@ Default font lacks support for all characters
       <row>`~</row>
    </keyboard>
   </layout>
-  <layout name="Bulgarian ЯВЕРТЪ">
+  <layout locale="bg" variant="ЯВЕРТЪ">
     <keyboard>
       <row>ч1234567890</row>
       <row>явертъуиопшщ</row>
@@ -84,7 +84,7 @@ Default font lacks support for all characters
       <row>`~</row>
     </keyboard>
   </layout>
-  <layout name="Bulgarian АБВ">
+  <layout locale="bg" variant="АБВ">
     <keyboard>
       <row>0123456789</row>
       <row>абвгдежзий</row>
@@ -104,7 +104,7 @@ Default font lacks support for all characters
       <row>`~</row>
     </keyboard>
   </layout>
-  <layout name="Russian ЙЦУКЕН">
+  <layout locale="ru" variant="ЙЦУКЕН">
     <keyboard>
       <row>ё1234567890</row>
       <row>йцукенгшщзхъ</row>
@@ -124,7 +124,7 @@ Default font lacks support for all characters
       <row>`~</row>
     </keyboard>
   </layout>
-  <layout name="Russian АБВ">
+  <layout locale="ru" variant="АБВ">
     <keyboard>
       <row>0123456789</row>
       <row>абвгдеёжзий</row>
@@ -144,7 +144,7 @@ Default font lacks support for all characters
       <row>`~</row>
     </keyboard>
   </layout>
-  <layout name="Hebrew QWERTY">
+  <layout locale="he" variant="QWERTY">
     <keyboard>
       <row>1234567890</row>
       <row>קראטוןםפ</row>
@@ -164,7 +164,7 @@ Default font lacks support for all characters
       <row>`~</row>
     </keyboard>
   </layout>
-  <layout name="Hebrew ABC">
+  <layout locale="he" variant="ABC">
     <keyboard>
       <row>0123456789</row>
       <row>יטחזוהדגבא</row>
@@ -184,7 +184,7 @@ Default font lacks support for all characters
       <row>`~</row>
    </keyboard>
   </layout>
-  <layout name="Norwegian QWERTY">
+  <layout locale="no" variant="QWERTY">
     <keyboard>
       <row>1234567890</row>
       <row>qwertyuiopå</row>
@@ -204,7 +204,7 @@ Default font lacks support for all characters
       <row>`~</row>
     </keyboard>
   </layout>
-  <layout name="Danish QWERTY">
+  <layout locale="da" variant="QWERTY">
     <keyboard>
       <row>1234567890</row>
       <row>qwertyuiopå</row>
@@ -224,7 +224,7 @@ Default font lacks support for all characters
       <row>`~</row>
     </keyboard>
   </layout>
-  <layout name="Swedish QWERTY">
+  <layout locale="sv" variant="QWERTY">
     <keyboard>
       <row>1234567890</row>
       <row>qwertyuiopå</row>
@@ -244,7 +244,7 @@ Default font lacks support for all characters
       <row>`~</row>
     </keyboard>
   </layout>
-  <layout name="Turkish QWERTY">
+  <layout locale="tr" variant="QWERTY">
     <keyboard>
       <row>1234567890</row>
       <row>qwertyuıopğü</row>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -144,7 +144,7 @@
         </setting>
         <setting id="locale.keyboardlayouts" type="list[string]" label="310" help="36432">
           <level>1</level>
-          <default>English QWERTY</default>
+          <default>en_QWERTY</default>
           <constraints>
             <options>keyboardlayouts</options>
             <delimiter>|</delimiter>

--- a/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
+++ b/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
@@ -89,16 +89,9 @@ void CGUIDialogKeyboardGeneric::OnInitWindow()
   // fill in the keyboard layouts
   m_currentLayout = 0;
   m_layouts.clear();
-  std::vector<CKeyboardLayout> keyLayouts = CKeyboardLayout::LoadLayouts();
-  const CSetting *setting = CSettings::Get().GetSetting("locale.keyboardlayouts");
-  std::vector<std::string> layouts;
-  if (setting)
-    layouts = StringUtils::Split(setting->ToString(), '|');
-  for (std::vector<CKeyboardLayout>::const_iterator j = keyLayouts.begin(); j != keyLayouts.end(); ++j)
-  {
-    if (std::find(layouts.begin(), layouts.end(), j->GetName()) != layouts.end())
-      m_layouts.push_back(*j);
-  }
+  std::vector<CKeyboardLayout> layouts = CKeyboardLayout::LoadActiveLayouts();
+  for (std::vector<CKeyboardLayout>::const_iterator it = layouts.begin(); it != layouts.end(); ++it)
+    m_layouts.push_back(*it);
 
   // set alphabetic (capitals)
   UpdateButtons();

--- a/xbmc/input/KeyboardLayout.h
+++ b/xbmc/input/KeyboardLayout.h
@@ -41,9 +41,11 @@ class CKeyboardLayout
 {
 public:
   CKeyboardLayout();
-  CKeyboardLayout(const std::string &name, const TiXmlElement& element);
+  CKeyboardLayout(const std::string &localeName, const std::string &variantName, const TiXmlElement& element);
   virtual ~CKeyboardLayout(void);
-  const std::string& GetName() const { return m_name; }
+  std::string GetName() const;
+  const std::string& GetLocale() const { return m_locale; }
+  const std::string& GetVariant() const { return m_variant; }
   std::string GetCharAt(unsigned int row, unsigned int column, unsigned int modifiers = 0) const;
 
   enum MODIFIER_KEYS
@@ -53,16 +55,15 @@ public:
     MODIFIER_KEY_SYMBOL = 0x02
   };
 
-  /*! \brief helper to load a keyboard layout
-   \param layout the layout to load.
-   \return a CKeyboardLayout.
-   */
-  static CKeyboardLayout Load(const std::string &layout);
-
-  /*! \brief helper to list available keyboard layouts
-   \return a vector of CKeyboardLayouts with the layout names.
+  /** \brief helper to list available keyboard layouts
+   *  \return a vector of CKeyboardLayouts with the layout names.
    */
   static std::vector<CKeyboardLayout> LoadLayouts();
+
+  /** \brief load currently selected layout from settings
+   *  \return a vector of CKeyboardLayouts with the layout names.
+   */
+  static std::vector<CKeyboardLayout> LoadActiveLayouts();
 
   static void SettingOptionsKeyboardLayoutsFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void* data);
 
@@ -72,6 +73,7 @@ private:
   typedef std::vector< std::vector<std::string> > KeyboardRows;
   typedef std::map<unsigned int, KeyboardRows> Keyboards;
 
-  std::string m_name;
+  std::string m_locale;
+  std::string m_variant;
   Keyboards   m_keyboards;
 };


### PR DESCRIPTION
This change keyboard layouts from using names by conversions to using locale and variant name.

Allows to:
1. In the future, tie keyboard layout to other locale setting.
2. Display a shorter name in the keyboard dialog. Currently kept unchanged, but it's very easy to change to a lang code (or flag like the original PR) now that display name is decoupled.
