### PR TITLE
[VideoReferenceClock] Add RPi support

### DIFF
--- a/xbmc/linux/RBP.h
+++ b/xbmc/linux/RBP.h
@@ -57,6 +57,7 @@ public:
   // stride can be null for packed output
   unsigned char *CaptureDisplay(int width, int height, int *stride, bool swap_red_blue, bool video_only = true);
   DllOMX *GetDllOMX() { return m_OMX ? m_OMX->GetDll() : NULL; }
+  void WaitVsync();
 
 private:
   DllBcmHost *m_DllBcmHost;
@@ -69,6 +70,8 @@ private:
   bool       m_codec_mpg2_enabled;
   bool       m_codec_wvc1_enabled;
   COMXCore   *m_OMX;
+  DISPMANX_RESOURCE_HANDLE_T m_resource;
+  DISPMANX_ELEMENT_HANDLE_T m_element;
   class DllLibOMXCore;
   CCriticalSection m_critSection;
 };

--- a/xbmc/video/VideoReferenceClock.h
+++ b/xbmc/video/VideoReferenceClock.h
@@ -150,6 +150,12 @@ class CVideoReferenceClock : public CThread
 
     int64_t m_LastVBlankTime;  //timestamp of the last vblank, used for calculating how many vblanks happened
                                //not the same as m_VblankTime
+#elif defined(TARGET_RASPBERRY_PI)
+    bool SetupRPi();
+    void RunRPi();
+    void CleanupRPi();
+    int64_t m_LastVBlankTime;  //timestamp of the last vblank, used for calculating how many vblanks happened
+                               //not the same as m_VblankTime
 #endif
 };
 


### PR DESCRIPTION
Currently the MMAL renderer used by the Pi doesn't support video clock
(for perfect frame rate syncing).

This adds a video clock that counts vsyncs to fix this.
