### PR TITLE
[RFC] Rebranding update: Rename APP_HOME -> KODI_HOME

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -118,6 +118,7 @@ AC_DEFUN([XB_PUSH_FLAGS], [
 # version can be overridden by setting the following as ENV vars when running configure
 APP_NAME=${APP_NAME-$(${AWK} '/APP_NAME/ {print $2}' version.txt)}
 APP_NAME_LC=$(echo $APP_NAME | ${AWK} '{print tolower($0)}')
+APP_NAME_UC=$(echo $APP_NAME | tr '[:lower:]' '[:upper:]')
 APP_VERSION_MAJOR=${APP_VERSION_MAJOR-$(${AWK} '/VERSION_MAJOR/ {print $2}' version.txt)}
 APP_VERSION_MINOR=${APP_VERSION_MINOR-$(${AWK} '/VERSION_MINOR/ {print $2}' version.txt)}
 APP_VERSION_TAG=${APP_VERSION_TAG-$(${AWK} '/VERSION_TAG/ {print $2}' version.txt)}
@@ -129,6 +130,7 @@ if test "$APP_NAME" != "" && test "$APP_VERSION_MAJOR" != "" && test "$APP_VERSI
   final_message="$final_message\n  ${APP_NAME} Version:\t${APP_VERSION_MAJOR}.${APP_VERSION_MINOR}-${APP_VERSION_TAG}"
   AC_SUBST(APP_NAME)
   AC_SUBST(APP_NAME_LC)
+  AC_SUBST(APP_NAME_UC)
   AC_SUBST(APP_VERSION_MAJOR)
   AC_SUBST(APP_VERSION_MINOR)
   AC_SUBST(APP_VERSION_TAG)

--- a/docs/README.osx
+++ b/docs/README.osx
@@ -140,16 +140,16 @@ binaries from git that might cause problems.
 -----------------------------------------------------------------------------
 Start XCode and open the Kodi project (Kodi.xcodeproj) located in $HOME/Kodi.
 For development, Kodi is run from the $HOME/Kodi directory and needs to have
-the APP_HOME environment variable set to know where that directory is located.
-To set APP_HOME environment variable:
+the KODI_HOME environment variable set to know where that directory is located.
+To set KODI_HOME environment variable:
 
 Xcode 3.2.6
  Menu -> Project -> Edit Active Executable "Kodi", click "Arguments" tab and
- add "APP_HOME" as an enviroment variable. Set the value to the path to the
+ add "KODI_HOME" as an enviroment variable. Set the value to the path to the
  Kodi root folder. For example, "/Users/bigdog/Documents/Kodi"
 
 Xcode 4.3.x and later
- Menu -> Product -> Edit Sheme -> "Run Kodi"/"Debug" -> Add APP_HOME into
+ Menu -> Product -> Edit Sheme -> "Run Kodi"/"Debug" -> Add KODI_HOME into
  the List of "Environment Variables". Set the value to the path to the Kodi
  root folder. For example, "/Users/bigdog/Documents/Kodi"	
 
@@ -173,7 +173,7 @@ subsequent builds will be faster.
 
 After the build, you can ether run Kodi for Mac from Xcode or run it from
 the command-line. If you run it from the command-line, make sure your set
-the APP_HOME environment variable (export APP_HOME=$HOME/Kodi). Then, to
+the KODI_HOME environment variable (export KODI_HOME=$HOME/Kodi). Then, to
 run the debug version:
 
 $ ./build/Debug/Kodi
@@ -203,14 +203,14 @@ developers).
 
  a)
  $ cd $HOME/Kodi
- $ export APP_HOME=`pwd`
+ $ export KODI_HOME=`pwd`
  $ make xcode_depends
  $ xcodebuild -sdk macosx10.7 -project Kodi.xcodeproj -target Kodi.app ONLY_ACTIVE_ARCH=YES \
    ARCHS=x86_64 VALID_ARCHS=x86_64  -configuration Release build
 
  b) building via make
  $ cd $HOME/Kodi
- $ export APP_HOME=`pwd`
+ $ export KODI_HOME=`pwd`
  $ make
  $ ./Kodi.bin
 

--- a/project/VS2010Express/XBMC.defaults.props
+++ b/project/VS2010Express/XBMC.defaults.props
@@ -7,7 +7,7 @@
   <PropertyGroup>
     <IncludePath>$(SolutionDir)\..\BuildDependencies\include;$(SolutionDir)\..\BuildDependencies\include\python;$(IncludePath)</IncludePath>
     <ExecutablePath>$(SolutionDir)\..\..\tools\win32buildtools;$(ExecutablePath)</ExecutablePath>
-    <LocalDebuggerEnvironment>APP_HOME=$(SolutionDir)..\..&#xD;&#xA;PATH=$(SolutionDir)..\Win32BuildSetup\dependencies;%PATH%</LocalDebuggerEnvironment>
+    <LocalDebuggerEnvironment>$(ProjectName)_HOME=$(SolutionDir)..\..&#xD;&#xA;PATH=$(SolutionDir)..\Win32BuildSetup\dependencies;%PATH%</LocalDebuggerEnvironment>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/tools/EventClients/Clients/OSXRemote/XBMCHelper.m
+++ b/tools/EventClients/Clients/OSXRemote/XBMCHelper.m
@@ -268,7 +268,7 @@
   NSFileManager *fileManager = [NSFileManager defaultManager];
   if([fileManager fileExistsAtPath:mp_app_path]){
     if(mp_home_path && [mp_home_path length])
-      setenv("APP_HOME", [mp_home_path UTF8String], 1);
+      setenv("KODI_HOME", [mp_home_path UTF8String], 1);
     //launch or activate xbmc
     if(![[NSWorkspace sharedWorkspace] launchApplication:mp_app_path])
       ELOG(@"Error launching %@", mp_app_path);

--- a/tools/Linux/kodi.sh.in
+++ b/tools/Linux/kodi.sh.in
@@ -104,8 +104,8 @@ print_crash_report()
     fi
     single_stacktrace "$PWD" 1
     # Find in plugins directories
-    if [ $APP_HOME ]; then
-      BASEDIR=$APP_HOME
+    if [ $@APP_NAME_UC@_HOME ]; then
+      BASEDIR=$@APP_NAME_UC@_HOME
     else
       BASEDIR="$LIBDIR/${bin_name}/"
     fi

--- a/tools/darwin/runtime/preflight
+++ b/tools/darwin/runtime/preflight
@@ -3,16 +3,16 @@
 die("No HOME set, cannot install defaults.\n")
     if !$ENV{'HOME'};
 
-die("No APP_HOME set, cannot install defaults.\n")
-    if !$ENV{'APP_HOME'};
+die("No KODI_HOME set, cannot install defaults.\n")
+    if !$ENV{'KODI_HOME'};
 
 sub get_home {
     return $ENV{'HOME'} if defined $ENV{'HOME'};
 }
 
 sub get_extras {
-    # APP_HOME is assumed to be always setup
-    return $ENV{'APP_HOME'}."/extras/" if get_os() eq "osx";
+    # KODI_HOME is assumed to be always setup
+    return $ENV{'KODI_HOME'}."/extras/" if get_os() eq "osx";
     return;
 }
 

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -587,7 +587,7 @@ void CApplication::Preflight()
   CStdString install_path;
 
   CUtil::GetHomePath(install_path);
-  setenv("APP_HOME", install_path.c_str(), 0);
+  setenv((CSysInfo::GetAppNameUpperCase() + "_HOME").c_str(), install_path.c_str(), 0);
   install_path += "/tools/darwin/runtime/preflight";
   system(install_path.c_str());
 #endif
@@ -1078,14 +1078,14 @@ bool CApplication::InitDirectoriesLinux()
   std::string appName = CCompileInfo::GetAppName();
   std::string dotLowerAppName = "." + appName;
   StringUtils::ToLower(dotLowerAppName);
-  const char* envAppHome = "APP_HOME";
-  const char* envAppBinHome = "APP_BIN_HOME";
-  const char* envAppTemp = "APP_TEMP";
+  const std::string envAppHome = CSysInfo::GetAppNameUpperCase() + "_HOME";
+  const std::string envAppBinHome = CSysInfo::GetAppNameUpperCase() + "_BIN_HOME";
+  const std::string envAppTemp = CSysInfo::GetAppNameUpperCase() + "_TEMP";
 
 
   CUtil::GetHomePath(appBinPath, envAppBinHome);
-  if (getenv(envAppHome))
-    appPath = getenv(envAppHome);
+  if (getenv(envAppHome.c_str()))
+    appPath = getenv(envAppHome.c_str());
   else
   {
     appPath = appBinPath;
@@ -1104,8 +1104,8 @@ bool CApplication::InitDirectoriesLinux()
   }
 
   /* Set some environment variables */
-  setenv(envAppBinHome, appBinPath.c_str(), 0);
-  setenv(envAppHome, appPath.c_str(), 0);
+  setenv(envAppBinHome.c_str(), appBinPath.c_str(), 0);
+  setenv(envAppHome.c_str(), appPath.c_str(), 0);
 
   if (m_bPlatformDirectories)
   {
@@ -1117,8 +1117,8 @@ bool CApplication::InitDirectoriesLinux()
 
     CStdString strTempPath = userHome;
     strTempPath = URIUtils::AddFileToFolder(strTempPath, dotLowerAppName + "/temp");
-    if (getenv(envAppTemp))
-      strTempPath = getenv(envAppTemp);
+    if (getenv(envAppTemp.c_str()))
+      strTempPath = getenv(envAppTemp.c_str());
     CSpecialProtocol::SetTempPath(strTempPath);
 
     URIUtils::AddSlashAtEnd(strTempPath);
@@ -1171,7 +1171,7 @@ bool CApplication::InitDirectoriesOSX()
 
   std::string appPath;
   CUtil::GetHomePath(appPath);
-  setenv("APP_HOME", appPath.c_str(), 0);
+  setenv((CSysInfo::GetAppNameUpperCase() + "_HOME").c_str(), appPath.c_str(), 0);
 
 #if defined(TARGET_DARWIN_IOS)
   CStdString fontconfigPath;
@@ -1251,7 +1251,7 @@ bool CApplication::InitDirectoriesWin32()
   CStdString xbmcPath;
 
   CUtil::GetHomePath(xbmcPath);
-  CEnvironment::setenv("APP_HOME", xbmcPath);
+  CEnvironment::setenv(CSysInfo::GetAppNameUpperCase() + "_HOME", xbmcPath);
   CSpecialProtocol::SetXBMCBinPath(xbmcPath);
   CSpecialProtocol::SetXBMCPath(xbmcPath);
 
@@ -1262,7 +1262,7 @@ bool CApplication::InitDirectoriesWin32()
   CSpecialProtocol::SetMasterProfilePath(URIUtils::AddFileToFolder(strWin32UserFolder, "userdata"));
   CSpecialProtocol::SetTempPath(URIUtils::AddFileToFolder(strWin32UserFolder,"cache"));
 
-  CEnvironment::setenv("APP_PROFILE_USERDATA", CSpecialProtocol::TranslatePath("special://masterprofile/"));
+  CEnvironment::setenv(CSysInfo::GetAppNameUpperCase() + "_PROFILE_USERDATA", CSpecialProtocol::TranslatePath("special://masterprofile/"));
 
   CreateUserDirs();
 

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -278,7 +278,6 @@
 #include "video/dialogs/GUIDialogSubtitles.h"
 #include "utils/XMLUtils.h"
 #include "addons/AddonInstaller.h"
-#include "CompileInfo.h"
 
 #ifdef HAS_PERFORMANCE_SAMPLE
 #include "utils/PerformanceSample.h"
@@ -643,9 +642,7 @@ bool CApplication::Create()
 
   if (!CLog::Init(CSpecialProtocol::TranslatePath(g_advancedSettings.m_logFolder).c_str()))
   {
-    std::string lcAppName = CCompileInfo::GetAppName();
-    StringUtils::ToLower(lcAppName);
-    fprintf(stderr,"Could not init logging classes. Permission errors on ~/.%s (%s)\n", lcAppName.c_str(),
+    fprintf(stderr,"Could not init logging classes. Permission errors on ~/.%s (%s)\n", CSysInfo::GetAppNameLowerCase().c_str(),
       CSpecialProtocol::TranslatePath(g_advancedSettings.m_logFolder).c_str());
     return false;
   }
@@ -733,9 +730,7 @@ bool CApplication::Create()
   CStdString executable = CUtil::ResolveExecutablePath();
   CLog::Log(LOGNOTICE, "The executable running is: %s", executable.c_str());
   CLog::Log(LOGNOTICE, "Local hostname: %s", m_network->GetHostName().c_str());
-  std::string lowerAppName = CCompileInfo::GetAppName();
-  StringUtils::ToLower(lowerAppName);
-  CLog::Log(LOGNOTICE, "Log File is located: %s%s.log", g_advancedSettings.m_logFolder.c_str(), lowerAppName.c_str());
+  CLog::Log(LOGNOTICE, "Log File is located: %s%s.log", g_advancedSettings.m_logFolder.c_str(), CSysInfo::GetAppNameLowerCase().c_str());
   CRegExp::LogCheckUtf8Support();
   CLog::Log(LOGNOTICE, "-----------------------------------------------------------------------");
 
@@ -1075,9 +1070,8 @@ bool CApplication::InitDirectoriesLinux()
     userHome = "/root";
 
   std::string appBinPath, appPath;
-  std::string appName = CCompileInfo::GetAppName();
-  std::string dotLowerAppName = "." + appName;
-  StringUtils::ToLower(dotLowerAppName);
+  std::string appName = CSysInfo::GetAppName();
+  std::string dotLowerAppName = "." + CSysInfo::GetAppNameLowerCase();;
   const std::string envAppHome = CSysInfo::GetAppNameUpperCase() + "_HOME";
   const std::string envAppBinHome = CSysInfo::GetAppNameUpperCase() + "_BIN_HOME";
   const std::string envAppTemp = CSysInfo::GetAppNameUpperCase() + "_TEMP";
@@ -1189,18 +1183,16 @@ bool CApplication::InitDirectoriesOSX()
     // map our special drives
     CSpecialProtocol::SetXBMCBinPath(appPath);
     CSpecialProtocol::SetXBMCPath(appPath);
+    std::string appName = CSysInfo::GetAppName();
     #if defined(TARGET_DARWIN_IOS)
-      std::string appName = CCompileInfo::GetAppName();
       CSpecialProtocol::SetHomePath(userHome + "/" + CDarwinUtils::GetAppRootFolder() + "/" + appName);
       CSpecialProtocol::SetMasterProfilePath(userHome + "/" + CDarwinUtils::GetAppRootFolder() + "/" + appName + "/userdata");
     #else
-      std::string appName = CCompileInfo::GetAppName();
       CSpecialProtocol::SetHomePath(userHome + "/Library/Application Support/" + appName);
       CSpecialProtocol::SetMasterProfilePath(userHome + "/Library/Application Support/" + appName + "/userdata");
     #endif
 
-    std::string dotLowerAppName = "." + appName;
-    StringUtils::ToLower(dotLowerAppName);
+    std::string dotLowerAppName = "." + CSysInfo::GetAppNameLowerCase();
     // location for temp files
     #if defined(TARGET_DARWIN_IOS)
       std::string strTempPath = URIUtils::AddFileToFolder(userHome,  std::string(CDarwinUtils::GetAppRootFolder()) + "/" + appName + "/temp");

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -97,6 +97,7 @@
 #endif
 
 #include "cores/dvdplayer/DVDDemuxers/DVDDemux.h"
+#include "utils/SystemInfo.h"
 
 using namespace std;
 
@@ -405,7 +406,10 @@ void CUtil::RunShortcut(const char* szShortcutPath)
 
 void CUtil::GetHomePath(std::string& strPath, const std::string& strTarget)
 {
-  strPath = CEnvironment::getenv(strTarget);
+  if (strTarget.empty())
+    strPath = CEnvironment::getenv(CSysInfo::GetAppNameUpperCase() + "_HOME");
+  else
+    strPath = CEnvironment::getenv(strTarget);
 
 #ifdef TARGET_WINDOWS
   if (strPath.find("..") != std::string::npos)
@@ -471,13 +475,13 @@ void CUtil::GetHomePath(std::string& strPath, const std::string& strTarget)
   }
 
 #if defined(TARGET_POSIX) && !defined(TARGET_DARWIN)
-  /* Change strPath accordingly when target is APP_HOME and when INSTALL_PATH
+  /* Change strPath accordingly when target is KODI_HOME and when INSTALL_PATH
    * and BIN_INSTALL_PATH differ
    */
   std::string installPath = INSTALL_PATH;
   std::string binInstallPath = BIN_INSTALL_PATH;
 
-  if (!strTarget.compare("APP_HOME") && installPath.compare(binInstallPath))
+  if (strTarget.empty() && installPath.compare(binInstallPath))
   {
     int pos = strPath.length() - binInstallPath.length();
     CStdString tmp = strPath;

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -20,7 +20,6 @@
 #include "network/Network.h"
 #include "threads/SystemClock.h"
 #include "system.h"
-#include "CompileInfo.h"
 #if defined(TARGET_DARWIN)
 #include <sys/param.h>
 #include <mach-o/dyld.h>
@@ -454,7 +453,7 @@ void CUtil::GetHomePath(std::string& strPath, const std::string& strTarget)
       #else
         // Assume local path inside application bundle.
         strcat(given_path, "../Resources/");
-        strcat(given_path, CCompileInfo::GetAppName());
+        strcat(given_path, CSysInfo::GetAppName().c_str());
         strcat(given_path, "/");
       #endif
 

--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -73,7 +73,7 @@ public:
   static CStdString GetTitleFromPath(const CStdString& strFileNameAndPath, bool bIsFolder = false);
   static void GetQualifiedFilename(const std::string &strBasePath, std::string &strFilename);
   static void RunShortcut(const char* szPath);
-  static void GetHomePath(std::string& strPath, const std::string& strTarget = "APP_HOME");
+  static void GetHomePath(std::string& strPath, const std::string& strTarget = ""); // default target is "@APP_NAME@_HOME"
   static bool IsPVR(const CStdString& strFile);
   static bool IsHTSP(const CStdString& strFile);
   static bool IsLiveTV(const CStdString& strFile);

--- a/xbmc/android/activity/XBMCApp.cpp
+++ b/xbmc/android/activity/XBMCApp.cpp
@@ -72,6 +72,7 @@
 #include "android/jni/ContentResolver.h"
 #include "android/jni/MediaStore.h"
 #include "CompileInfo.h"
+#include "utils/SystemInfo.h"
 
 #define GIGABYTES       1073741824
 
@@ -619,13 +620,13 @@ void CXBMCApp::SetupEnv()
   if (xbmcHome.empty())
   {
     std::string cacheDir = getCacheDir().getAbsolutePath();
-    setenv("APP_BIN_HOME", (cacheDir + "/apk/assets").c_str(), 0);
-    setenv("APP_HOME", (cacheDir + "/apk/assets").c_str(), 0);
+    setenv((CSysInfo::GetAppNameUpperCase() + "_BIN_HOME").c_str(), (cacheDir + "/apk/assets").c_str(), 0);
+    setenv((CSysInfo::GetAppNameUpperCase() + "_HOME").c_str(), (cacheDir + "/apk/assets").c_str(), 0);
   }
   else
   {
-    setenv("APP_BIN_HOME", (xbmcHome + "/assets").c_str(), 0);
-    setenv("APP_HOME", (xbmcHome + "/assets").c_str(), 0);
+    setenv((CSysInfo::GetAppNameUpperCase() + "_BIN_HOME").c_str(), (xbmcHome + "/assets").c_str(), 0);
+    setenv((CSysInfo::GetAppNameUpperCase() + "_HOME").c_str(), (xbmcHome + "/assets").c_str(), 0);
   }
 
   std::string externalDir = CJNISystem::getProperty("xbmc.data", "");
@@ -642,7 +643,7 @@ void CXBMCApp::SetupEnv()
   if (!externalDir.empty())
     setenv("HOME", externalDir.c_str(), 0);
   else
-    setenv("HOME", getenv("APP_TEMP"), 0);
+    setenv("HOME", getenv((CSysInfo::GetAppNameUpperCase() + "_TEMP").c_str()), 0);
 }
 
 std::string CXBMCApp::GetFilenameFromIntent(const CJNIIntent &intent)

--- a/xbmc/android/activity/XBMCApp.cpp
+++ b/xbmc/android/activity/XBMCApp.cpp
@@ -253,9 +253,7 @@ bool CXBMCApp::getWakeLock()
   if (m_wakeLock)
     return true;
 
-  std::string appName = CCompileInfo::GetAppName();
-  StringUtils::ToLower(appName);
-  std::string className = "org.xbmc." + appName;
+  std::string className = "org.xbmc." + CSysInfo::GetAppNameLowerCase();
   m_wakeLock = new CJNIWakeLock(CJNIPowerManager(getSystemService("power")).newWakeLock(className.c_str()));
 
   return true;
@@ -612,9 +610,7 @@ void CXBMCApp::SetupEnv()
   setenv("XBMC_ANDROID_LIBS", getApplicationInfo().nativeLibraryDir.c_str(), 0);
   setenv("XBMC_ANDROID_APK", getPackageResourcePath().c_str(), 0);
 
-  std::string appName = CCompileInfo::GetAppName();
-  StringUtils::ToLower(appName);
-  std::string className = "org.xbmc." + appName;
+  std::string className = "org.xbmc." + CSysInfo::GetAppNameLowerCase();
 
   std::string xbmcHome = CJNISystem::getProperty("xbmc.home", "");
   if (xbmcHome.empty())

--- a/xbmc/android/activity/android_main.cpp
+++ b/xbmc/android/activity/android_main.cpp
@@ -26,6 +26,7 @@
 #include "android/jni/SurfaceTexture.h"
 #include "utils/StringUtils.h"
 #include "CompileInfo.h"
+#include "utils/SystemInfo.h"
 
 // copied from new android_native_app_glue.c
 static void process_input(struct android_app* app, struct android_poll_source* source) {
@@ -84,11 +85,9 @@ extern "C" JNIEXPORT jint JNI_OnLoad(JavaVM *vm, void *reserved)
   if (vm->GetEnv(reinterpret_cast<void**>(&env), version) != JNI_OK)
     return -1;
 
-  std::string appName = CCompileInfo::GetAppName();
-  StringUtils::ToLower(appName);
-  std::string mainClass = "org/xbmc/" + appName + "/Main";
-  std::string bcReceiver = "org/xbmc/" + appName + "/XBMCBroadcastReceiver";
-  std::string frameListener = "org/xbmc/" + appName + "/XBMCOnFrameAvailableListener";
+  std::string mainClass = "org/xbmc/" + CSysInfo::GetAppNameLowerCase() + "/Main";
+  std::string bcReceiver = "org/xbmc/" + CSysInfo::GetAppNameLowerCase() + "/XBMCBroadcastReceiver";
+  std::string frameListener = "org/xbmc/" + CSysInfo::GetAppNameLowerCase() + "/XBMCOnFrameAvailableListener";
 
   jclass cMain = env->FindClass(mainClass.c_str());
   if(cMain)

--- a/xbmc/android/loader/AndroidDyload.cpp
+++ b/xbmc/android/loader/AndroidDyload.cpp
@@ -8,8 +8,7 @@
 #include <fcntl.h>
 #include "android/activity/XBMCApp.h"
 #include "AndroidDyload.h"
-#include "utils/StringUtils.h"
-#include "CompileInfo.h"
+#include "utils/SystemInfo.h"
 using namespace std;
 
 //#define DEBUG_SPEW
@@ -248,9 +247,7 @@ void* CAndroidDyload::Open_Internal(string filename, bool checkSystem)
 
   for (strings::iterator j = deps.begin(); j != deps.end(); ++j)
   {
-    std::string appName = CCompileInfo::GetAppName();
-    std::string libName = "lib" + appName + ".so";
-    StringUtils::ToLower(libName);
+    std::string libName = "lib" + CSysInfo::GetAppNameLowerCase() + ".so";
     // Don't traverse into libkodi's deps, they're guaranteed to be loaded.
     if (*j == libName.c_str())
       continue;

--- a/xbmc/filesystem/AndroidAppDirectory.cpp
+++ b/xbmc/filesystem/AndroidAppDirectory.cpp
@@ -30,7 +30,7 @@
 #include "utils/log.h"
 #include "utils/StringUtils.h"
 #include "URL.h"
-#include "CompileInfo.h"
+#include "utils/SystemInfo.h"
 
 using namespace XFILE;
 using namespace std;
@@ -48,9 +48,7 @@ bool CAndroidAppDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   std::string dirname = url.GetFileName();
   URIUtils::RemoveSlashAtEnd(dirname);
   CLog::Log(LOGDEBUG, "CAndroidAppDirectory::GetDirectory: %s",dirname.c_str()); 
-  std::string appName = CCompileInfo::GetAppName();
-  StringUtils::ToLower(appName);
-  std::string className = "org.xbmc." + appName;
+  std::string className = "org.xbmc." + CSysInfo::GetAppNameLowerCase();
 
   if (dirname == "apps")
   {

--- a/xbmc/filesystem/HTSPSession.cpp
+++ b/xbmc/filesystem/HTSPSession.cpp
@@ -241,7 +241,7 @@ bool CHTSPSession::Connect(const std::string& hostname, int port)
   m = htsmsg_create_map();
   htsmsg_add_str(m, "method", "hello");
   std::string fullAppName = CSysInfo::GetAppName();
-  fullAppName += " Media Center";
+  fullAppName += " Entertainment Center";
   htsmsg_add_str(m, "clientname", fullAppName.c_str());
   htsmsg_add_u32(m, "htspversion", 1);
 

--- a/xbmc/network/cddb.cpp
+++ b/xbmc/network/cddb.cpp
@@ -32,7 +32,6 @@
 
 #include <taglib/id3v1genres.h>
 #include "cddb.h"
-#include "CompileInfo.h"
 #include "network/DNSNameCache.h"
 #include "settings/AdvancedSettings.h"
 #include "utils/StringUtils.h"
@@ -41,6 +40,7 @@
 #include "GUIInfoManager.h"
 #include "utils/CharsetConverter.h"
 #include "utils/log.h"
+#include "utils/SystemInfo.h"
 
 #include <sys/socket.h>
 #include <netinet/in.h>
@@ -873,11 +873,9 @@ bool Xcddb::queryCDinfo(CCdInfo* pInfo)
   //##########################################################
   // Send the Hello message
   std::string version = g_infoManager.GetLabel(SYSTEM_BUILD_VERSION);
-  std::string lcAppName = CCompileInfo::GetAppName();
-  StringUtils::ToLower(lcAppName);
   if (version.find(" ") != std::string::npos)
     version = version.substr(0, version.find(" "));
-  std::string strGreeting = "cddb hello " + lcAppName + " kodi.tv " + CCompileInfo::GetAppName() + " " + version;
+  std::string strGreeting = "cddb hello " + CSysInfo::GetAppNameLowerCase() + " kodi.tv " + CSysInfo::GetAppName() + " " + version;
   if ( ! Send(strGreeting.c_str()) )
   {
     CLog::Log(LOGERROR, "Xcddb::queryCDinfo Error sending \"%s\"", strGreeting.c_str());

--- a/xbmc/osx/XBMCHelper.cpp
+++ b/xbmc/osx/XBMCHelper.cpp
@@ -67,7 +67,7 @@ XBMCHelper::XBMCHelper()
   , m_port(0)
   , m_errorStarting(false)
 {
-  // Compute the APP_HOME path.
+  // Compute the KODI_HOME path.
   CStdString homePath;
   CUtil::GetHomePath(homePath);
   m_homepath = homePath;

--- a/xbmc/osx/XBMCHelper.cpp
+++ b/xbmc/osx/XBMCHelper.cpp
@@ -27,7 +27,6 @@
 #include "XBMCHelper.h"
 #include "PlatformDefs.h"
 #include "Util.h"
-#include "CompileInfo.h"
 
 #include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogYesNo.h"
@@ -88,7 +87,7 @@ XBMCHelper::XBMCHelper()
 
   // Compute the configuration file name.
   m_configFile = getenv("HOME");
-  m_configFile += "/Library/Application Support/" + std::string(CCompileInfo::GetAppName()) + "/XBMCHelper.conf";
+  m_configFile += "/Library/Application Support/" + std::string(CSysInfo::GetAppName()) + "/XBMCHelper.conf";
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -442,6 +442,30 @@ const std::string& CSysInfo::GetAppName(void)
   return appName;
 }
 
+const std::string& CSysInfo::GetAppNameUpperCase(void)
+{
+  static std::string appNameUpperCase;
+  if (appNameUpperCase.empty())
+  {
+    appNameUpperCase = GetAppName();
+    StringUtils::ToUpper(appNameUpperCase);
+  }
+
+  return appNameUpperCase;
+}
+
+const std::string& CSysInfo::GetAppNameLowerCase(void)
+{
+  static std::string appNameLowerCase;
+  if (appNameLowerCase.empty())
+  {
+    appNameLowerCase = GetAppName();
+    StringUtils::ToLower(appNameLowerCase);
+  }
+
+  return appNameLowerCase;
+}
+
 bool CSysInfo::GetDiskSpace(const std::string& drive,int& iTotal, int& iTotalFree, int& iTotalUsed, int& iPercentFree, int& iPercentUsed)
 {
   bool bRet= false;

--- a/xbmc/utils/SystemInfo.h
+++ b/xbmc/utils/SystemInfo.h
@@ -101,6 +101,8 @@ public:
   char MD5_Sign[32 + 1];
 
   static const std::string& GetAppName(void); // the same name as CCompileInfo::GetAppName(), but const ref to std::string
+  static const std::string& GetAppNameUpperCase(void);
+  static const std::string& GetAppNameLowerCase(void);
 
   static std::string GetKernelName(bool emptyIfUnknown = false);
   static std::string GetKernelVersionFull(void); // full version string, including "-generic", "-RELEASE" etc.

--- a/xbmc/utils/log.cpp
+++ b/xbmc/utils/log.cpp
@@ -23,7 +23,7 @@
 #include "threads/SingleLock.h"
 #include "threads/Thread.h"
 #include "utils/StringUtils.h"
-#include "CompileInfo.h"
+#include "utils/SystemInfo.h"
 
 static const char* const levelNames[] =
 {"DEBUG", "INFO", "NOTICE", "WARNING", "ERROR", "SEVERE", "FATAL", "NONE"};
@@ -110,9 +110,8 @@ bool CLog::Init(const std::string& path)
   // the log folder location is initialized in the CAdvancedSettings
   // constructor and changed in CApplication::Create()
 
-  std::string appName = CCompileInfo::GetAppName();
-  StringUtils::ToLower(appName);
-  return s_globals.m_platform.OpenLogFile(path + appName + ".log", path + appName + ".old.log");
+ return s_globals.m_platform.OpenLogFile(path + CSysInfo::GetAppNameLowerCase() + ".log",
+                                         path + CSysInfo::GetAppNameLowerCase() + ".old.log");
 }
 
 void CLog::MemDump(char *pData, int length)

--- a/xbmc/utils/test/TestRegExp.cpp
+++ b/xbmc/utils/test/TestRegExp.cpp
@@ -28,8 +28,7 @@
 #include "utils/StdString.h"
 #include "filesystem/File.h"
 #include "filesystem/SpecialProtocol.h"
-#include "utils/StringUtils.h"
-#include "CompileInfo.h"
+#include "utils/SystemInfo.h"
 
 TEST(TestRegExp, RegFind)
 {
@@ -153,9 +152,7 @@ TEST_F(TestRegExpLog, DumpOvector)
   unsigned int bytesread;
   XFILE::CFile file;
 
-  std::string appName = CCompileInfo::GetAppName();
-  StringUtils::ToLower(appName);
-  logfile = CSpecialProtocol::TranslatePath("special://temp/") + appName + ".log";
+  logfile = CSpecialProtocol::TranslatePath("special://temp/") + CSysInfo::GetAppNameLowerCase() + ".log";
   EXPECT_TRUE(CLog::Init(CSpecialProtocol::TranslatePath("special://temp/").c_str()));
   EXPECT_TRUE(XFILE::CFile::Exists(logfile));
 

--- a/xbmc/utils/test/Testlog.cpp
+++ b/xbmc/utils/test/Testlog.cpp
@@ -23,8 +23,7 @@
 #include "filesystem/File.h"
 #include "filesystem/SpecialProtocol.h"
 #include "utils/StdString.h"
-#include "utils/StringUtils.h"
-#include "CompileInfo.h"
+#include "utils/SystemInfo.h"
 
 #include "test/TestUtils.h"
 
@@ -48,9 +47,7 @@ TEST_F(Testlog, Log)
   XFILE::CFile file;
   CRegExp regex;
 
-  std::string appName = CCompileInfo::GetAppName();
-  StringUtils::ToLower(appName);
-  logfile = CSpecialProtocol::TranslatePath("special://temp/") + appName + ".log";
+  logfile = CSpecialProtocol::TranslatePath("special://temp/") + CSysInfo::GetAppNameLowerCase() + ".log";
   EXPECT_TRUE(CLog::Init(CSpecialProtocol::TranslatePath("special://temp/").c_str()));
   EXPECT_TRUE(XFILE::CFile::Exists(logfile));
 
@@ -104,9 +101,7 @@ TEST_F(Testlog, MemDump)
   CRegExp regex;
   char refdata[] = "0123456789abcdefghijklmnopqrstuvwxyz";
 
-  std::string appName = CCompileInfo::GetAppName();
-  StringUtils::ToLower(appName);
-  logfile = CSpecialProtocol::TranslatePath("special://temp/") + appName + ".log";
+  logfile = CSpecialProtocol::TranslatePath("special://temp/") + CSysInfo::GetAppNameLowerCase() + ".log";
   EXPECT_TRUE(CLog::Init(CSpecialProtocol::TranslatePath("special://temp/").c_str()));
   EXPECT_TRUE(XFILE::CFile::Exists(logfile));
 
@@ -138,9 +133,7 @@ TEST_F(Testlog, SetLogLevel)
 {
   CStdString logfile;
 
-  std::string appName = CCompileInfo::GetAppName();
-  StringUtils::ToLower(appName);
-  logfile = CSpecialProtocol::TranslatePath("special://temp/") + appName + ".log";
+  logfile = CSpecialProtocol::TranslatePath("special://temp/") + CSysInfo::GetAppNameLowerCase() + ".log";
   EXPECT_TRUE(CLog::Init(CSpecialProtocol::TranslatePath("special://temp/").c_str()));
   EXPECT_TRUE(XFILE::CFile::Exists(logfile));
 

--- a/xbmc/windowing/X11/XRandR.cpp
+++ b/xbmc/windowing/X11/XRandR.cpp
@@ -30,7 +30,6 @@
 #include "utils/StringUtils.h"
 #include "../xbmc/utils/log.h"
 #include "threads/SystemClock.h"
-#include "CompileInfo.h"
 #include "utils/SystemInfo.h"
 
 #if defined(TARGET_FREEBSD)
@@ -74,12 +73,10 @@ bool CXRandR::Query(bool force, bool ignoreoff)
 bool CXRandR::Query(bool force, int screennum, bool ignoreoff)
 {
   std::string cmd;
-  std::string appname = CCompileInfo::GetAppName();
-  StringUtils::ToLower(appname);
   if (getenv(std::string(CSysInfo::GetAppNameUpperCase()).append("_BIN_HOME").c_str()))
   {
     cmd  = getenv(std::string(CSysInfo::GetAppNameUpperCase()).append("_BIN_HOME").c_str());
-    cmd += "/" + appname + "-xrandr";
+    cmd += "/" + CSysInfo::GetAppNameLowerCase() + "-xrandr";
     cmd = StringUtils::Format("%s -q --screen %d", cmd.c_str(), screennum);
   }
 
@@ -161,13 +158,11 @@ bool CXRandR::TurnOffOutput(CStdString name)
     return false;
 
   std::string cmd;
-  std::string appname = CCompileInfo::GetAppName();
-  StringUtils::ToLower(appname);
 
   if (getenv(std::string(CSysInfo::GetAppNameUpperCase()).append("_BIN_HOME").c_str()))
   {
     cmd  = getenv(std::string(CSysInfo::GetAppNameUpperCase()).append("_BIN_HOME").c_str());
-    cmd += "/" + appname + "-xrandr";
+    cmd += "/" + CSysInfo::GetAppNameLowerCase() + "-xrandr";
     cmd = StringUtils::Format("%s --screen %d --output %s --off", cmd.c_str(), output->screen, name.c_str());
   }
 
@@ -325,13 +320,12 @@ bool CXRandR::SetMode(XOutput output, XMode mode)
 
   m_currentOutput = outputFound.name;
   m_currentMode = modeFound.id;
-  std::string appname = CCompileInfo::GetAppName();
-  StringUtils::ToLower(appname);
   char cmd[255];
 
   if (getenv(std::string(CSysInfo::GetAppNameUpperCase()).append("_BIN_HOME").c_str()))
     snprintf(cmd, sizeof(cmd), "%s/%s-xrandr --screen %d --output %s --mode %s", 
-               getenv(std::string(CSysInfo::GetAppNameUpperCase()).append("_BIN_HOME").c_str()),appname.c_str(),
+               getenv(std::string(CSysInfo::GetAppNameUpperCase()).append("_BIN_HOME").c_str()),
+               CSysInfo::GetAppNameLowerCase()).c_str(),
                outputFound.screen, outputFound.name.c_str(), modeFound.id.c_str());
   else
     return false;
@@ -419,13 +413,11 @@ void CXRandR::LoadCustomModeLinesToAllOutputs(void)
     StringUtils::Trim(name);
     strModeLine = modeline->FirstChild()->Value();
     StringUtils::Trim(strModeLine);
-    std::string appname = CCompileInfo::GetAppName();
-    StringUtils::ToLower(appname);
 
     if (getenv(std::string(CSysInfo::GetAppNameUpperCase()).append("_BIN_HOME").c_str()))
     {
       snprintf(cmd, sizeof(cmd), "%s/%s-xrandr --newmode \"%s\" %s > /dev/null 2>&1", getenv(std::string(CSysInfo::GetAppNameUpperCase()).append("_BIN_HOME").c_str()),
-               appname.c_str(), name.c_str(), strModeLine.c_str());
+               CSysInfo::GetAppNameLowerCase().c_str(), name.c_str(), strModeLine.c_str());
       if (system(cmd) != 0)
         CLog::Log(LOGERROR, "Unable to create modeline \"%s\"", name.c_str());
     }
@@ -435,7 +427,7 @@ void CXRandR::LoadCustomModeLinesToAllOutputs(void)
       if (getenv(std::string(CSysInfo::GetAppNameUpperCase()).append("_BIN_HOME").c_str()))
       {
         snprintf(cmd, sizeof(cmd), "%s/%s-xrandr --addmode %s \"%s\"  > /dev/null 2>&1", getenv(std::string(CSysInfo::GetAppNameUpperCase()).append("_BIN_HOME").c_str()),
-                 appname.c_str(), m_outputs[i].name.c_str(), name.c_str());
+                 CSysInfo::GetAppNameLowerCase().c_str(), m_outputs[i].name.c_str(), name.c_str());
         if (system(cmd) != 0)
           CLog::Log(LOGERROR, "Unable to add modeline \"%s\"", name.c_str());
       }

--- a/xbmc/windowing/X11/XRandR.cpp
+++ b/xbmc/windowing/X11/XRandR.cpp
@@ -31,6 +31,7 @@
 #include "../xbmc/utils/log.h"
 #include "threads/SystemClock.h"
 #include "CompileInfo.h"
+#include "utils/SystemInfo.h"
 
 #if defined(TARGET_FREEBSD)
 #include <sys/types.h>
@@ -55,7 +56,7 @@ bool CXRandR::Query(bool force, bool ignoreoff)
 
   m_bInit = true;
 
-  if (getenv("APP_BIN_HOME") == NULL)
+  if (getenv(std::string(CSysInfo::GetAppNameUpperCase()).append("_BIN_HOME").c_str()) == NULL)
     return false;
 
   m_outputs.clear();
@@ -75,9 +76,9 @@ bool CXRandR::Query(bool force, int screennum, bool ignoreoff)
   std::string cmd;
   std::string appname = CCompileInfo::GetAppName();
   StringUtils::ToLower(appname);
-  if (getenv("APP_BIN_HOME"))
+  if (getenv(std::string(CSysInfo::GetAppNameUpperCase()).append("_BIN_HOME").c_str()))
   {
-    cmd  = getenv("APP_BIN_HOME");
+    cmd  = getenv(std::string(CSysInfo::GetAppNameUpperCase()).append("_BIN_HOME").c_str());
     cmd += "/" + appname + "-xrandr";
     cmd = StringUtils::Format("%s -q --screen %d", cmd.c_str(), screennum);
   }
@@ -163,9 +164,9 @@ bool CXRandR::TurnOffOutput(CStdString name)
   std::string appname = CCompileInfo::GetAppName();
   StringUtils::ToLower(appname);
 
-  if (getenv("APP_BIN_HOME"))
+  if (getenv(std::string(CSysInfo::GetAppNameUpperCase()).append("_BIN_HOME").c_str()))
   {
-    cmd  = getenv("APP_BIN_HOME");
+    cmd  = getenv(std::string(CSysInfo::GetAppNameUpperCase()).append("_BIN_HOME").c_str());
     cmd += "/" + appname + "-xrandr";
     cmd = StringUtils::Format("%s --screen %d --output %s --off", cmd.c_str(), output->screen, name.c_str());
   }
@@ -328,8 +329,10 @@ bool CXRandR::SetMode(XOutput output, XMode mode)
   StringUtils::ToLower(appname);
   char cmd[255];
 
-  if (getenv("APP_BIN_HOME"))
-    snprintf(cmd, sizeof(cmd), "%s/%s-xrandr --screen %d --output %s --mode %s", getenv("APP_BIN_HOME"),appname.c_str(), outputFound.screen, outputFound.name.c_str(), modeFound.id.c_str());
+  if (getenv(std::string(CSysInfo::GetAppNameUpperCase()).append("_BIN_HOME").c_str()))
+    snprintf(cmd, sizeof(cmd), "%s/%s-xrandr --screen %d --output %s --mode %s", 
+               getenv(std::string(CSysInfo::GetAppNameUpperCase()).append("_BIN_HOME").c_str()),appname.c_str(),
+               outputFound.screen, outputFound.name.c_str(), modeFound.id.c_str());
   else
     return false;
   CLog::Log(LOGINFO, "XRANDR: %s", cmd);
@@ -419,9 +422,9 @@ void CXRandR::LoadCustomModeLinesToAllOutputs(void)
     std::string appname = CCompileInfo::GetAppName();
     StringUtils::ToLower(appname);
 
-    if (getenv("APP_BIN_HOME"))
+    if (getenv(std::string(CSysInfo::GetAppNameUpperCase()).append("_BIN_HOME").c_str()))
     {
-      snprintf(cmd, sizeof(cmd), "%s/%s-xrandr --newmode \"%s\" %s > /dev/null 2>&1", getenv("APP_BIN_HOME"),
+      snprintf(cmd, sizeof(cmd), "%s/%s-xrandr --newmode \"%s\" %s > /dev/null 2>&1", getenv(std::string(CSysInfo::GetAppNameUpperCase()).append("_BIN_HOME").c_str()),
                appname.c_str(), name.c_str(), strModeLine.c_str());
       if (system(cmd) != 0)
         CLog::Log(LOGERROR, "Unable to create modeline \"%s\"", name.c_str());
@@ -429,9 +432,9 @@ void CXRandR::LoadCustomModeLinesToAllOutputs(void)
 
     for (unsigned int i = 0; i < m_outputs.size(); i++)
     {
-      if (getenv("APP_BIN_HOME"))
+      if (getenv(std::string(CSysInfo::GetAppNameUpperCase()).append("_BIN_HOME").c_str()))
       {
-        snprintf(cmd, sizeof(cmd), "%s/%s-xrandr --addmode %s \"%s\"  > /dev/null 2>&1", getenv("APP_BIN_HOME"),
+        snprintf(cmd, sizeof(cmd), "%s/%s-xrandr --addmode %s \"%s\"  > /dev/null 2>&1", getenv(std::string(CSysInfo::GetAppNameUpperCase()).append("_BIN_HOME").c_str()),
                  appname.c_str(), m_outputs[i].name.c_str(), name.c_str());
         if (system(cmd) != 0)
           CLog::Log(LOGERROR, "Unable to add modeline \"%s\"", name.c_str());

--- a/xbmc/windows/GUIWindowDebugInfo.cpp
+++ b/xbmc/windows/GUIWindowDebugInfo.cpp
@@ -24,7 +24,6 @@
 #include "addons/Skin.h"
 #include "utils/CPUInfo.h"
 #include "utils/log.h"
-#include "CompileInfo.h"
 #include "input/ButtonTranslator.h"
 #include "guilib/GUIControlFactory.h"
 #include "guilib/GUIFontManager.h"
@@ -34,6 +33,7 @@
 #include "GUIInfoManager.h"
 #include "utils/Variant.h"
 #include "utils/StringUtils.h"
+#include "utils/SystemInfo.h"
 
 #include <climits>
 
@@ -104,14 +104,12 @@ void CGUIWindowDebugInfo::Process(unsigned int currentTime, CDirtyRegionList &di
     GlobalMemoryStatusEx(&stat);
     CStdString profiling = CGUIControlProfiler::IsRunning() ? " (profiling)" : "";
     CStdString strCores = g_cpuInfo.GetCoresUsageString();
-    std::string lcAppName = CCompileInfo::GetAppName();
-    StringUtils::ToLower(lcAppName);
 #if !defined(TARGET_POSIX)
-    info = StringUtils::Format("LOG: %s%s.log\nMEM: %" PRIu64"/%" PRIu64" KB - FPS: %2.1f fps\nCPU: %s%s", g_advancedSettings.m_logFolder.c_str(), lcAppName.c_str(),
+    info = StringUtils::Format("LOG: %s%s.log\nMEM: %" PRIu64"/%" PRIu64" KB - FPS: %2.1f fps\nCPU: %s%s", g_advancedSettings.m_logFolder.c_str(), CSysInfo::GetAppNameLowerCase().c_str(),
                                stat.ullAvailPhys/1024, stat.ullTotalPhys/1024, g_infoManager.GetFPS(), strCores.c_str(), profiling.c_str());
 #else
     double dCPU = m_resourceCounter.GetCPUUsage();
-    info = StringUtils::Format("LOG: %s%s.log\nMEM: %" PRIu64"/%" PRIu64" KB - FPS: %2.1f fps\nCPU: %s (CPU-XBMC %4.2f%%%s)", g_advancedSettings.m_logFolder.c_str(), lcAppName.c_str(),
+    info = StringUtils::Format("LOG: %s%s.log\nMEM: %" PRIu64"/%" PRIu64" KB - FPS: %2.1f fps\nCPU: %s (CPU-XBMC %4.2f%%%s)", g_advancedSettings.m_logFolder.c_str(), CSysInfo::GetAppNameLowerCase().c_str(),
                                stat.ullAvailPhys/1024, stat.ullTotalPhys/1024, g_infoManager.GetFPS(), strCores.c_str(), dCPU, profiling.c_str());
 #endif
   }


### PR DESCRIPTION
After #5216 Kodi variable for home directory is called `APP_HOME`.
KODI_HOME should be more logical.
`XBMC_HOME` is used widely, but it's not very logical to set variable `APP_HOME` to run Kodi.
And `APP_HOME` can be set by some other app/tool. If Kodi will be run on such system, it will not find libs and other files.
This PR fix it.

@FernetMenta @Memphiz @Montellese @topfs2 your thoughts?
