### PR TITLE
[python] fix video duration infolabel inconsistency (fixes ticket #13904)

### DIFF
--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -250,7 +250,7 @@ namespace XBMCAddon
       if (item->HasVideoInfoTag())
       {
         std::ostringstream oss;
-        oss << item->GetVideoInfoTag()->GetDuration() / 60;
+        oss << item->GetVideoInfoTag()->GetDuration();
         return oss.str();
       }
       return "0";
@@ -354,7 +354,7 @@ namespace XBMCAddon
           else if (key == "sorttitle")
             item->GetVideoInfoTag()->m_strSortTitle = value;
           else if (key == "duration")
-            item->GetVideoInfoTag()->m_duration = CVideoInfoTag::GetDurationFromMinuteString(value);
+            item->GetVideoInfoTag()->m_duration = strtol(value.c_str(), NULL, 10);
           else if (key == "studio")
             item->GetVideoInfoTag()->m_studio = StringUtils::Split(value, g_advancedSettings.m_videoItemSeparator);            
           else if (key == "tagline")

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -211,7 +211,7 @@ namespace XBMCAddon
        *     - title         : string (Big Fan)
        *     - originaltitle : string (Big Fan)
        *     - sorttitle     : string (Big Fan)
-       *     - duration      : string (3:18)
+       *     - duration      : integer (245) - duration in seconds
        *     - studio        : string (Warner Bros.)
        *     - tagline       : string (An awesome movie) - short description of movie
        *     - writer        : string (Robert D. Siegel)


### PR DESCRIPTION
Changes the duration label for from minutes to seconds, for consistency with the rest of the api. No point keeping backwards compatibility for half broken (colon notation never worked) functionality imo.
