### PR TITLE
[buildsystem] posix: add legacy xbmc links for libdir, includedir and da...

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -563,6 +563,7 @@ apk-clean:
 install-binaries: install-scripts
 	@echo "Copying @APP_NAME_LC@ binary to $(DESTDIR)$(libdir)/@APP_NAME_LC@/"
 	@install -d $(DESTDIR)$(libdir)/@APP_NAME_LC@
+	@cd $(DESTDIR)$(libdir); [ -L xbmc ] || [ -d xbmc ] || ln -s @APP_NAME_LC@ xbmc
 ifeq (1,@USE_XRANDR@)
 	@install @APP_NAME_LC@-xrandr $(DESTDIR)$(libdir)/@APP_NAME_LC@/@APP_NAME_LC@-xrandr
 endif
@@ -602,14 +603,15 @@ endif
 install-scripts:
 	@install -d $(DESTDIR)$(bindir)
 	@install tools/Linux/@APP_NAME_LC@.sh $(DESTDIR)$(bindir)/@APP_NAME_LC@
-	@cd $(DESTDIR)$(bindir); [ -L xbmc ] || ln -s @APP_NAME_LC@ xbmc
+	@cd $(DESTDIR)$(bindir); [ -L xbmc ] || [ -f xbmc ] || ln -s @APP_NAME_LC@ xbmc
 	@install tools/Linux/@APP_NAME_LC@-standalone.sh $(DESTDIR)$(bindir)/@APP_NAME_LC@-standalone
-	@cd $(DESTDIR)$(bindir); [ -L xbmc-standalone ] ||  ln -s @APP_NAME_LC@-standalone xbmc-standalone
+	@cd $(DESTDIR)$(bindir); [ -L xbmc-standalone ] || [ -f xbmc-standalone ] ||  ln -s @APP_NAME_LC@-standalone xbmc-standalone
 	@install -d $(DESTDIR)$(datarootdir)/@APP_NAME_LC@
+	@cd $(DESTDIR)$(datarootdir); [ -L xbmc ] || [ -d xbmc ] || ln -s @APP_NAME_LC@ xbmc
 	@install -m 0644 tools/Linux/FEH.py $(DESTDIR)$(datarootdir)/@APP_NAME_LC@/FEH.py
 	@install -d $(DESTDIR)$(datarootdir)/xsessions
 	@install -m 0644 tools/Linux/@APP_NAME_LC@-xsession.desktop $(DESTDIR)$(datarootdir)/xsessions/@APP_NAME_LC@.desktop
-	@cd $(DESTDIR)$(datarootdir)/xsessions; [ -L xbmc.desktop ] || ln -s @APP_NAME_LC@.desktop xbmc.desktop
+	@cd $(DESTDIR)$(datarootdir)/xsessions; [ -L xbmc.desktop ] || [ -f xbmc.desktop ] || ln -s @APP_NAME_LC@.desktop xbmc.desktop
 
 install-datas: install-scripts
 	@echo "Copying support and legal files..."
@@ -660,6 +662,7 @@ endif
 	@for f in project/cmake/scripts/common/*.cmake; do \
 	  install -m 0644 $$f $(DESTDIR)$(libdir)/@APP_NAME_LC@; \
 	done
+	@cd $(DESTDIR)$(includedir); [ -L xbmc ] || [ -d xbmc ] || ln -s @APP_NAME_LC@ xbmc
 
 uninstall:
 	@echo "Removing Kodi..."


### PR DESCRIPTION
...tarootdir

fixes legacy xbmc binary addons, e.g. pvr
