### PR TITLE
Mips port

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -440,7 +440,7 @@ ifeq (@USE_ASAP_CODEC@,1)
   endif
 endif
 	$(MAKE) -C lib/stsound/StSoundLibrary
-ifeq ($(or $(findstring powerpc,@ARCH@),$(findstring x86_64-linux,@ARCH@),$(findstring arm, @ARCH@),$(findstring freebsd,@ARCH@)),)
+ifeq ($(or $(findstring powerpc,@ARCH@),$(findstring x86_64-linux,@ARCH@),$(findstring arm, @ARCH@),$(findstring freebsd,@ARCH@),$(findstring mips,@ARCH@)),)
 	$(MAKE) -C lib/snesapu/SNES/SNESAPU
 endif
 imagelib: dllloader

--- a/addons/library.xbmc.addon/libXBMC_addon.h
+++ b/addons/library.xbmc.addon/libXBMC_addon.h
@@ -55,8 +55,8 @@ typedef intptr_t      ssize_t;
 #define ADDON_HELPER_ARCH       "powerpc64-linux"
 #elif defined(__ARMEL__)
 #define ADDON_HELPER_ARCH       "arm"
-#elif defined(_MIPSEL)
-#define ADDON_HELPER_ARCH       "mipsel-linux"
+#elif defined(__mips__)
+#define ADDON_HELPER_ARCH       "mips"
 #else
 #define ADDON_HELPER_ARCH       "i486-linux"
 #endif

--- a/configure.in
+++ b/configure.in
@@ -691,6 +691,16 @@ case $host in
      use_wayland=no
      build_shared_lib=yes
      ;;
+  mips*-*-linux-gnu*)
+     ARCH="mips"
+     use_arch="mips"
+     use_joystick=no
+     use_gles=no
+     use_gl=yes
+     use_sdl=yes
+     use_wayland=no
+     USE_STATIC_FFMPEG=1
+     ;;
   *)
      AC_MSG_ERROR(unsupported host ($host))
 esac

--- a/m4/xbmc_arch.m4
+++ b/m4/xbmc_arch.m4
@@ -32,6 +32,9 @@ case $host in
   arm*-*-linux-gnu*|arm*-*-linux-uclibc*)
      AC_SUBST(ARCH_DEFINES, "-DTARGET_POSIX -DTARGET_LINUX -D_LINUX")
      ;;
+  mips*-*-linux-gnu*|mips*-*-linux-uclibc*)
+     AC_SUBST(ARCH_DEFINES, "-DTARGET_POSIX -DTARGET_LINUX -D_LINUX")
+     ;;
   *-*linux-android*)
      AC_SUBST(ARCH_DEFINES, "-DTARGET_POSIX -DTARGET_LINUX -D_LINUX -DTARGET_ANDROID")
      ;;

--- a/tools/depends/target/ffmpeg/Makefile
+++ b/tools/depends/target/ffmpeg/Makefile
@@ -47,6 +47,9 @@ endif
 ifeq ($(findstring arm, $(CPU)), arm)
   ffmpg_config += --enable-pic --disable-armv5te --disable-armv6t2
 endif
+ifeq ($(findstring mips, $(CPU)), mips)
+  ffmpg_config += --disable-mips32r2 --disable-mipsdspr1 --disable-mipsdspr2
+endif
 ifeq ($(Configuration), Release)
   ffmpg_config += --disable-debug
 endif

--- a/tools/depends/target/ffmpeg/autobuild.sh
+++ b/tools/depends/target/ffmpeg/autobuild.sh
@@ -154,6 +154,9 @@ CFLAGS="$CFLAGS" CXXFLAGS="$CXXFLAGS" LDFLAGS="$LDFLAGS" \
 	--enable-nonfree \
 	--enable-pthreads \
 	--enable-zlib \
+	--disable-mips32r2 \
+	--disable-mipsdspr1 \
+	--disable-mipsdspr2 \
         ${FLAGS}
 
 make -j ${BUILDTHREADS} 

--- a/xbmc/cores/DllLoader/DllLoader.h
+++ b/xbmc/cores/DllLoader/DllLoader.h
@@ -23,7 +23,7 @@
 #include "coffldr.h"
 #include "LibraryLoader.h"
 
-#if defined(__linux__) && !defined(__powerpc__) && !defined(__arm__)
+#if defined(__linux__) && !defined(__powerpc__) && !defined(__arm__) && !defined(__mips__)
 #define USE_LDT_KEEPER
 #include "ldt_keeper.h"
 #endif

--- a/xbmc/cores/DllLoader/ldt_keeper.c
+++ b/xbmc/cores/DllLoader/ldt_keeper.c
@@ -19,7 +19,7 @@
  */
 
 //#ifndef __powerpc__
-#if !defined(__powerpc__) && !defined(__ppc__) && !defined(__arm__)
+#if !defined(__powerpc__) && !defined(__ppc__) && !defined(__arm__) && !defined(__mips__)
 
 #include "ldt_keeper.h"
 

--- a/xbmc/cores/VideoRenderers/LinuxRendererGL.h
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGL.h
@@ -325,7 +325,7 @@ protected:
 
 
 inline int NP2( unsigned x ) {
-#if defined(TARGET_POSIX) && !defined(__POWERPC__) && !defined(__PPC__) && !defined(__arm__)
+#if defined(TARGET_POSIX) && !defined(__POWERPC__) && !defined(__PPC__) && !defined(__arm__) && !defined(__mips__)
   // If there are any issues compiling this, just append a ' && 0'
   // to the above to make it '#if defined(TARGET_POSIX) && 0'
 

--- a/xbmc/linux/PlatformDefs.h
+++ b/xbmc/linux/PlatformDefs.h
@@ -161,7 +161,7 @@
 #define __int64   long long
 #define __uint64  unsigned long long
 
-#if defined(__x86_64__) || defined(__powerpc__) || defined(__ppc__) || defined (__arm__) // should this be powerpc64 only?
+#if defined(__x86_64__) || defined(__powerpc__) || defined(__ppc__) || defined (__arm__) || defined(__mips__) // should this be powerpc64 only?
 #define __stdcall
 #else /* !__x86_64__ */
 #define __stdcall   __attribute__((__stdcall__))

--- a/xbmc/threads/MipsAtomics.h
+++ b/xbmc/threads/MipsAtomics.h
@@ -1,0 +1,114 @@
+/*
+ *      Copyright (C) 2014 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ * Copyright (C) 2003, 06, 07 by Ralf Baechle (ralf@linux-mips.org)
+ *
+ * Most of this file was borrowed from the linux kernel.
+ */
+
+#ifndef __ATOMIC_MIPS_H_
+#define __ATOMIC_MIPS_H_
+
+#include <inttypes.h>
+#include <pthread.h>
+
+extern pthread_mutex_t cmpxchg_mutex;
+
+static inline long cmpxchg32(volatile long *m, long oldval, long newval)
+{
+	long retval;
+	__asm__ __volatile__(						\
+		"	.set	push				\n"	\
+		"	.set	noat				\n"	\
+		"	.set	mips3				\n"	\
+		"1:	ll	%0, %2		# __cmpxchg_asm	\n"	\
+		"	bne	%0, %z3, 2f			\n"	\
+		"	.set	mips0				\n"	\
+		"	move	$1, %z4				\n"	\
+		"	.set	mips3				\n"	\
+		"	sc	$1, %1				\n"	\
+		"	beqz	$1, 3f				\n"	\
+		"2:						\n"	\
+		"	.subsection 2				\n"	\
+		"3:	b	1b				\n"	\
+		"	.previous				\n"	\
+		"	.set	pop				\n"	\
+		: "=&r" (retval), "=R" (*m)				\
+		: "R" (*m), "Jr" (oldval), "Jr" (newval)			\
+		: "memory");						\
+
+	return retval;
+}
+
+
+static inline long long cmpxchg64(volatile long long *ptr,
+				      long long oldval, long long newval)
+{
+	long long prev;
+
+	pthread_mutex_lock(&cmpxchg_mutex);
+	prev = *(long long *)ptr;
+	if (prev == oldval)
+		*(long long *)ptr = newval;
+	pthread_mutex_unlock(&cmpxchg_mutex);
+	return prev;
+}
+
+
+static __inline__ long atomic_add(int i, volatile long* v)
+{
+	long temp;
+
+	__asm__ __volatile__(
+		"	.set	mips3					\n"
+		"1:	ll	%0, %1		# atomic_add		\n"
+		"	addu	%0, %2					\n"
+		"	sc	%0, %1					\n"
+		"	beqz	%0, 2f					\n"
+		"	.subsection 2					\n"
+		"2:	b	1b					\n"
+		"	.previous					\n"
+		"	.set	mips0					\n"
+		: "=&r" (temp), "=m" (*v)
+		: "Ir" (i), "m" (*v));
+
+	return temp;
+}
+
+static __inline__ long atomic_sub(int i, volatile long* v)
+{
+	long temp;
+
+	__asm__ __volatile__(
+		"	.set	mips3					\n"
+		"1:	ll	%0, %1		# atomic_sub		\n"
+		"	subu	%0, %2					\n"
+		"	sc	%0, %1					\n"
+		"	beqz	%0, 2f					\n"
+		"	.subsection 2					\n"
+		"2:	b	1b					\n"
+		"	.previous					\n"
+		"	.set	mips0					\n"
+		: "=&r" (temp), "=m" (*v)
+		: "Ir" (i), "m" (*v));
+
+	return temp;
+}
+
+
+#endif

--- a/xbmc/threads/MipsAtomics.h
+++ b/xbmc/threads/MipsAtomics.h
@@ -21,8 +21,7 @@
  * Most of this file was borrowed from the linux kernel.
  */
 
-#ifndef __ATOMIC_MIPS_H_
-#define __ATOMIC_MIPS_H_
+#pragma once
 
 #include <inttypes.h>
 #include <pthread.h>
@@ -109,6 +108,3 @@ static __inline__ long atomic_sub(int i, volatile long* v)
 
 	return temp;
 }
-
-
-#endif

--- a/xbmc/utils/MathUtils.h
+++ b/xbmc/utils/MathUtils.h
@@ -34,6 +34,7 @@
 
 #if defined(__ppc__) || \
     defined(__powerpc__) || \
+    defined(__mips__) || \
     defined(__arm__)
   #define DISABLE_MATHUTILS_ASM_ROUND_INT
 #endif

--- a/xbmc/utils/fastmemcpy.c
+++ b/xbmc/utils/fastmemcpy.c
@@ -25,7 +25,7 @@
  *  <http://www.gnu.org/licenses/>.
  *
  */
-#if !defined(TARGET_WINDOWS) && !defined(__ppc__) && !defined(__powerpc__) && !defined(__arm__) 
+#if !defined(TARGET_WINDOWS) && !defined(__ppc__) && !defined(__powerpc__) && !defined(__arm__) && !defined(__mips__)
 #define HAVE_MMX2
 #define HAVE_SSE
 

--- a/xbmc/utils/fastmemcpy.h
+++ b/xbmc/utils/fastmemcpy.h
@@ -23,7 +23,7 @@
 extern "C" {
 #endif
 
-#if !defined(TARGET_WINDOWS) && !defined(__ppc__) && !defined(__powerpc__) && !defined(TARGET_ANDROID) && !defined(TARGET_DARWIN_IOS)
+#if !defined(TARGET_WINDOWS) && !defined(__ppc__) && !defined(__powerpc__) && !defined(__mips__) && !defined(TARGET_ANDROID) && !defined(TARGET_DARWIN_IOS)
 void * fast_memcpy(void * to, const void * from, size_t len);
 //#define fast_memcpy memcpy
 #else


### PR DESCRIPTION
The attached patches makes XBMC build on mipsel (tested on CI20) and the GUI also runs with the patches back-ported to Gotham.
Currently master can't be started on MIPS due to a crash in the internal FFmpeg copy.
