### PR TITLE
[win32] [vfs] Win32SMBDirectory: Do not try to connect with not required.

### DIFF
--- a/xbmc/filesystem/win32/Win32SMBDirectory.cpp
+++ b/xbmc/filesystem/win32/Win32SMBDirectory.cpp
@@ -43,6 +43,14 @@
 
 using namespace XFILE;
 
+// local helper
+static inline bool worthTryToConnect(const DWORD lastErr)
+{
+  return lastErr != ERROR_FILE_NOT_FOUND      && lastErr != ERROR_BAD_NET_NAME  &&
+         lastErr != ERROR_NO_NET_OR_BAD_PATH  && lastErr != ERROR_NO_NETWORK    &&
+         lastErr != ERROR_BAD_NETPATH;
+}
+
 /**
 * Get servers recursively or get shares from specific server
 * @param basePathToScanPtr the pointer to start point for scan
@@ -119,6 +127,9 @@ bool CWin32SMBDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   if (hSearch == INVALID_HANDLE_VALUE)
   {
     DWORD searchErr = GetLastError();
+    if (!worthTryToConnect(searchErr))
+      return false;
+
     if (ConnectAndAuthenticate(authUrl, (m_flags & DIR_FLAG_ALLOW_PROMPT) != 0))
     {
       if (g_sysinfo.IsWindowsVersionAtLeast(CSysInfo::WindowsVersionWin7))
@@ -212,7 +223,7 @@ bool CWin32SMBDirectory::RealCreate(const CURL& url, bool tryToConnect)
       return RealExists(url, false); // is it file or directory?
     else
     {
-      if (tryToConnect)
+      if (tryToConnect && worthTryToConnect(GetLastError()))
       {
         CURL authUrl(url);
         if (ConnectAndAuthenticate(authUrl))
@@ -309,7 +320,7 @@ bool CWin32SMBDirectory::RealExists(const CURL& url, bool tryToConnect)
   if (fileAttrs != INVALID_FILE_ATTRIBUTES)
     return (fileAttrs & FILE_ATTRIBUTE_DIRECTORY) != 0; // is file or directory?
 
-  if (tryToConnect)
+  if (tryToConnect && worthTryToConnect(GetLastError()))
   {
     CURL authUrl(url);
     if (ConnectAndAuthenticate(authUrl))
@@ -328,6 +339,9 @@ bool CWin32SMBDirectory::Remove(const CURL& url)
 
   if (RemoveDirectoryW(nameW.c_str()))
     return true;
+
+  if (!worthTryToConnect(GetLastError()))
+    return false;
 
   CURL authUrl(url);
   if (ConnectAndAuthenticate(authUrl) && RemoveDirectoryW(nameW.c_str()))


### PR DESCRIPTION
Implemented similarly to Win32SMBFile implementation.
This fix remove hundreds of "CWin32SMBDirectory::ConnectAndAuthenticate: Connected to ..." in log during normal scan.
