### PR TITLE
webserver: improved caching control

### DIFF
--- a/xbmc/network/WebServer.cpp
+++ b/xbmc/network/WebServer.cpp
@@ -754,7 +754,7 @@ int CWebServer::ContentReaderCallback(void *cls, size_t pos, char *buf, int max)
     context->file->Seek(context->writePosition);
 
   // read data from the file
-  ssize_t res = context->file->Read(buf, maximum);
+  ssize_t res = context->file->Read(buf, static_cast<size_t>(maximum));
   if (res <= 0)
     return -1;
 

--- a/xbmc/network/WebServer.cpp
+++ b/xbmc/network/WebServer.cpp
@@ -135,17 +135,16 @@ int CWebServer::AskForAuthentication(struct MHD_Connection *connection)
 bool CWebServer::IsAuthenticated(CWebServer *server, struct MHD_Connection *connection)
 {
   CSingleLock lock(server->m_critSection);
+
   if (!server->m_needcredentials)
     return true;
 
-  const char *strbase = "Basic ";
-  const char *headervalue = MHD_lookup_connection_value(connection, MHD_HEADER_KIND, MHD_HTTP_HEADER_AUTHORIZATION);
-  if (NULL == headervalue)
-    return false;
-  if (strncmp(headervalue, strbase, strlen(strbase)))
+  const char *base = "Basic ";
+  string authorization = GetRequestHeaderValue(connection, MHD_HEADER_KIND, MHD_HTTP_HEADER_AUTHORIZATION);
+  if (authorization.empty() || !StringUtils::StartsWith(authorization, base))
     return false;
 
-  return (server->m_Credentials64Encoded.compare(headervalue + strlen(strbase)) == 0);
+  return server->m_Credentials64Encoded.compare(StringUtils::Mid(authorization.c_str(), strlen(base))) == 0;
 }
 
 #if (MHD_VERSION >= 0x00040001)

--- a/xbmc/network/WebServer.cpp
+++ b/xbmc/network/WebServer.cpp
@@ -582,7 +582,8 @@ int CWebServer::CreateFileDownloadResponse(struct MHD_Connection *connection, co
     AddHeader(response, "Last-Modified", lastModified.GetAsRFC1123DateTime());
 
   // set the Expires header
-  CDateTime expiryTime = CDateTime::GetCurrentDateTime();
+  CDateTime now = CDateTime::GetCurrentDateTime();
+  CDateTime expiryTime = now;
   if (StringUtils::EqualsNoCase(mimeType, "text/html") ||
       StringUtils::EqualsNoCase(mimeType, "text/css") ||
       StringUtils::EqualsNoCase(mimeType, "application/javascript"))
@@ -590,6 +591,10 @@ int CWebServer::CreateFileDownloadResponse(struct MHD_Connection *connection, co
   else
     expiryTime += CDateTimeSpan(365, 0, 0, 0);
   AddHeader(response, "Expires", expiryTime.GetAsRFC1123DateTime());
+
+  // set the Cache-Control header
+  int maxAge = (expiryTime - now).GetSecondsTotal();
+  AddHeader(response, "Cache-Control", StringUtils::Format("max-age=%d, public", maxAge));
 
   return MHD_YES;
 }

--- a/xbmc/network/WebServer.h
+++ b/xbmc/network/WebServer.h
@@ -20,6 +20,7 @@
  */
 
 #include "system.h"
+
 #ifdef HAS_WEB_SERVER
 #include <sys/types.h>
 #include <sys/select.h>
@@ -49,14 +50,15 @@ public:
   CWebServer();
   virtual ~CWebServer() { }
 
+  // implementation of JSONRPC::ITransportLayer
+  virtual bool PrepareDownload(const char *path, CVariant &details, std::string &protocol);
+  virtual bool Download(const char *path, CVariant &result);
+  virtual int GetCapabilities();
+
   bool Start(int port, const std::string &username, const std::string &password);
   bool Stop();
   bool IsStarted();
   void SetCredentials(const std::string &username, const std::string &password);
-
-  virtual bool PrepareDownload(const char *path, CVariant &details, std::string &protocol);
-  virtual bool Download(const char *path, CVariant &result);
-  virtual int GetCapabilities();
 
   static void RegisterRequestHandler(IHTTPRequestHandler *handler);
   static void UnregisterRequestHandler(IHTTPRequestHandler *handler);
@@ -121,15 +123,10 @@ private:
 
   struct MHD_Daemon *m_daemon_ip6;
   struct MHD_Daemon *m_daemon_ip4;
-  bool m_running, m_needcredentials;
+  bool m_running;
+  bool m_needcredentials;
   std::string m_Credentials64Encoded;
   CCriticalSection m_critSection;
   static std::vector<IHTTPRequestHandler *> m_requestHandlers;
-
-  typedef struct ConnectionHandler
-  {
-    IHTTPRequestHandler *requestHandler;
-    struct MHD_PostProcessor *postprocessor;
-  } ConnectionHandler;
 };
 #endif

--- a/xbmc/network/httprequesthandler/HTTPJsonRpcHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPJsonRpcHandler.cpp
@@ -79,7 +79,7 @@ int CHTTPJsonRpcHandler::HandleHTTPRequest(const HTTPRequest &request)
     m_response = CJSONVariantWriter::Write(result, false);
   }
 
-  m_responseHeaderFields.insert(pair<string, string>("Content-Type", "application/json"));
+  m_responseHeaderFields.insert(pair<string, string>(MHD_HTTP_HEADER_CONTENT_TYPE, "application/json"));
 
   m_request.clear();
   


### PR DESCRIPTION
The goal of this PR is to improve the caching functionality and control of clients/webbrowsers interacting with our webserver. The first (2c2b7f5) and last (f927927) commit contain pure refactoring to adjust the code in CWebServer to match our coding guidelines. The second to last (072306a) commit silences a simple warning. The other commits add the following functionalities:
- 19dcc76 adds handling of `If-Unmodified-Since` (we already handle `If-Modified-Since`) in HTTP requests
- 7b5816d adds `Cache-Control: max-age=<x> public` to any HTTP responses that contain the content of a file. This extends the existing `Expires` functionality from HTTP/1.0 with the recommended `Cache-Control` functionality from HTTP/1.1
- aff2a39 adds handling of `Cache-Control: no-cache` from HTTP/1.1 and of the deprecated `Pragma: no-cache` in HTTP request
- fa808c3 just changes all hard-coded strings for HTTP header fields and values to custom defines and defines from libmicrohttpd to avoid typos
