### PR TITLE
FFmpeg decoder GUI control

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -488,6 +488,12 @@ AC_ARG_ENABLE([webserver],
   [use_webserver=$enableval],
   [use_webserver=yes])
 
+AC_ARG_ENABLE([ffmpeg-control],
+  [AS_HELP_STRING([--enable-ffmpeg-control],
+  [enable FFmpeg GUI control (default is no)])],
+  [use_ffmpeg_control=$enableval],
+  [use_ffmpeg_control=no])
+
 AC_ARG_ENABLE([optical-drive],
   [AS_HELP_STRING([--disable-optical-drive],
   [disable optical drive])],
@@ -2292,6 +2298,15 @@ if test "$use_webserver" = "yes"; then
 else
   final_message="$final_message\n  Webserver:\tNo"
   USE_WEB_SERVER=0
+fi
+
+if test "$use_ffmpeg_control" = "yes"; then
+  USE_FFMPEG_CONTROL=1
+  AC_DEFINE([USE_FFMPEG_CONTROL], [1], [Define to 1 to enable FFmpeg GUI control.])
+  final_message="$final_message\n  FFMpeg control:\tYes"
+else
+  USE_FFMPEG_CONTROL=0
+  final_message="$final_message\n  FFmpeg control:\tNo"
 fi
 
 if test "$use_libssh" != "no"; then

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -83,6 +83,7 @@ static const ControlMapping controls[] =
     {"fadelabel",         CGUIControl::GUICONTROL_FADELABEL},
     {"image",             CGUIControl::GUICONTROL_IMAGE},
     {"largeimage",        CGUIControl::GUICONTROL_IMAGE},
+    {"ffmpeg",            CGUIControl::GUICONTROL_IMAGE},
     {"image",             CGUIControl::GUICONTROL_BORDEREDIMAGE},
     {"label",             CGUIControl::GUICONTROL_LABEL},
     {"label",             CGUIControl::GUICONTROL_LISTLABEL},
@@ -1299,6 +1300,9 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   {
     if (strType == "largeimage")
       texture.useLarge = true;
+
+    else if (strType == "ffmpeg")
+      texture.useFFmpeg = true;
 
     // use a bordered texture if we have <bordersize> or <bordertexture> specified.
     if (borderTexture.filename.empty() && borderStr.empty())

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -1301,8 +1301,10 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
     if (strType == "largeimage")
       texture.useLarge = true;
 
+#ifdef USE_FFMPEG_CONTROL
     else if (strType == "ffmpeg")
       texture.useFFmpeg = true;
+#endif
 
     // use a bordered texture if we have <bordersize> or <bordertexture> specified.
     if (borderTexture.filename.empty() && borderStr.empty())

--- a/xbmc/guilib/GUITexture.cpp
+++ b/xbmc/guilib/GUITexture.cpp
@@ -24,18 +24,25 @@
 #include "GUILargeTextureManager.h"
 #include "utils/MathUtils.h"
 
+// ffmpeg
+#include "filesystem/SpecialProtocol.h"
+#include "Texture.h"
+#include "utils/log.h"
+
 using namespace std;
 
 CTextureInfo::CTextureInfo()
 {
   orientation = 0;
   useLarge = false;
+  useFFmpeg = false;
 }
 
 CTextureInfo::CTextureInfo(const CStdString &file)
 {
   orientation = 0;
   useLarge = false;
+  useFFmpeg = false;
   filename = file;
 }
 
@@ -46,6 +53,7 @@ CTextureInfo& CTextureInfo::operator=(const CTextureInfo &right)
   diffuse = right.diffuse;
   filename = right.filename;
   useLarge = right.useLarge;
+  useFFmpeg = right.useFFmpeg;
   diffuseColor = right.diffuseColor;
   return *this;
 }
@@ -78,6 +86,9 @@ CGUITextureBase::CGUITextureBase(float posX, float posY, float width, float heig
   m_currentFrame = 0;
   m_frameCounter = (unsigned int) -1;
   m_currentLoop = 0;
+
+  // ffmpeg
+  m_frame = 0;
 
   m_allocateDynamically = false;
   m_isAllocated = NO;
@@ -118,6 +129,9 @@ CGUITextureBase::CGUITextureBase(const CGUITextureBase &right) :
   m_frameCounter = (unsigned int) -1;
   m_currentLoop = 0;
 
+  // ffmpeg
+  m_frame = 0;
+
   m_isAllocated = NO;
   m_invalid = true;
 }
@@ -151,6 +165,9 @@ bool CGUITextureBase::Process(unsigned int currentTime)
   bool changed = false;
   // check if we need to allocate our resources
   changed |= AllocateOnDemand();
+
+  if (m_info.useFFmpeg)
+    changed |= UpdateFFmpeg(currentTime);
 
   if (m_texture.size() > 1)
     changed |= UpdateAnimFrame();
@@ -301,8 +318,37 @@ bool CGUITextureBase::AllocResources()
   m_currentLoop = 0;
 
   bool changed = false;
-  bool useLarge = m_info.useLarge || !g_TextureManager.CanLoad(m_info.filename);
-  if (useLarge)
+
+  if (m_info.useFFmpeg)
+  {
+
+    CStdString realPath = CSpecialProtocol::TranslatePath(m_info.filename);
+    m_decoder = new FFmpegVideoDecoder();
+
+    CLog::Log(LOGDEBUG, "GUITexture::FFmpeg AllocResources %s (%s)", m_info.filename.c_str(), realPath.c_str());
+
+    if (!(m_isAllocated = m_decoder->open(realPath) ? FFMPEG : FFMPEG_FAILED))
+    {
+      CLog::Log(LOGDEBUG, "GUITexture::FFmpeg Failed");
+
+      delete m_decoder;
+      return false;
+    }
+
+    m_lastFrameTime  = 0;
+    m_millisPerFrame = (unsigned int)(1000.0 / m_decoder->getFramesPerSecond());
+
+    unsigned int width  = m_decoder->getWidth();
+    unsigned int height = m_decoder->getHeight();
+
+    m_frame = new CTexture(width, height, XB_FMT_A8R8G8B8);
+    m_texture.Set(m_frame, width, height);
+
+    CLog::Log(LOGDEBUG, "GUITexture::FFmpeg Frame Set");
+
+    changed = true;
+  }
+  else if (m_info.useLarge || !g_TextureManager.CanLoad(m_info.filename))
   { // we want to use the large image loader, but we first check for bundled textures
     if (!IsAllocated())
     {
@@ -345,6 +391,7 @@ bool CGUITextureBase::AllocResources()
     m_texture = texture;
     changed = true;
   }
+
   m_frameWidth = (float)m_texture.m_width;
   m_frameHeight = (float)m_texture.m_height;
 
@@ -459,7 +506,16 @@ bool CGUITextureBase::CalculateSize()
 
 void CGUITextureBase::FreeResources(bool immediately /* = false */)
 {
-  if (m_isAllocated == LARGE || m_isAllocated == LARGE_FAILED)
+  if (m_isAllocated == FFMPEG)
+  {
+    CLog::Log(LOGDEBUG, "GUITexture::FFmpeg FreeResources %s", m_info.filename.c_str());
+
+    m_decoder->close();
+    delete m_decoder;
+    delete m_frame;
+    m_frame = 0;
+  }
+  else if (m_isAllocated == LARGE || m_isAllocated == LARGE_FAILED)
     g_largeTextureManager.ReleaseImage(m_info.filename, immediately || (m_isAllocated == LARGE_FAILED));
   else if (m_isAllocated == NORMAL && m_texture.size())
     g_TextureManager.ReleaseTexture(m_info.filename, immediately);
@@ -489,6 +545,31 @@ void CGUITextureBase::DynamicResourceAlloc(bool allocateDynamically)
 void CGUITextureBase::SetInvalid()
 {
   m_invalid = true;
+}
+
+bool CGUITextureBase::UpdateFFmpeg(unsigned int currentTime)
+{
+//  CLog::Log(LOGDEBUG, "GUITexture::UpdateFFmpeg %d - %d = %d", currentTime, m_lastFrameTime, currentTime - m_lastFrameTime);
+
+  if ((!m_frame) || ((currentTime - m_lastFrameTime) < m_millisPerFrame))
+    return false;
+
+  if (!m_decoder->nextFrame(m_frame))
+  {
+    if ((m_texture.m_loops) && (m_currentLoop + 1 >= m_texture.m_loops))
+      return false;
+
+//    CLog::Log(LOGDEBUG, "GUITexture::UpdateFFmpeg Loop %d", m_currentLoop);
+
+    m_currentLoop++;
+    m_decoder->seek(0.0);
+    m_decoder->nextFrame(m_frame);
+  }
+
+//  CLog::Log(LOGDEBUG, "GUITexture::UpdateFFmpeg Yay");
+
+  m_lastFrameTime = currentTime;
+  return true;
 }
 
 bool CGUITextureBase::UpdateAnimFrame()

--- a/xbmc/guilib/GUITexture.h
+++ b/xbmc/guilib/GUITexture.h
@@ -33,6 +33,9 @@
 #include "system.h" // HAS_GL, HAS_DX, etc
 #include "GUIInfoTypes.h"
 
+// ffmpeg
+#include "video/FFmpegVideoDecoder.h"
+
 typedef uint32_t color_t;
 
 // image alignment for <aspect>keep</aspect>, <aspect>scale</aspect> or <aspect>center</aspect>
@@ -75,6 +78,7 @@ public:
   CTextureInfo(const CStdString &file);
   CTextureInfo& operator=(const CTextureInfo &right);
   bool       useLarge;
+  bool       useFFmpeg;
   CRect      border;          // scaled  - unneeded if we get rid of scale on load
   int        orientation;     // orientation of the texture (0 - 7 == EXIForientation - 1)
   CStdString diffuse;         // diffuse overlay texture
@@ -120,12 +124,13 @@ public:
 
   bool HitTest(const CPoint &point) const { return CRect(m_posX, m_posY, m_posX + m_width, m_posY + m_height).PtInRect(point); };
   bool IsAllocated() const { return m_isAllocated != NO; };
-  bool FailedToAlloc() const { return m_isAllocated == NORMAL_FAILED || m_isAllocated == LARGE_FAILED; };
+  bool FailedToAlloc() const { return m_isAllocated == NORMAL_FAILED || m_isAllocated == LARGE_FAILED || m_isAllocated == FFMPEG_FAILED; };
   bool ReadyToRender() const;
 protected:
   bool CalculateSize();
   void LoadDiffuseImage();
   bool AllocateOnDemand();
+  bool UpdateFFmpeg(unsigned int currentTime);
   bool UpdateAnimFrame();
   void Render(float left, float top, float bottom, float right, float u1, float v1, float u2, float v2, float u3, float v3);
   static void OrientateTexture(CRect &rect, float width, float height, int orientation);
@@ -163,7 +168,7 @@ protected:
   CPoint m_diffuseOffset;                 // offset into the diffuse frame (it's not always the origin)
 
   bool m_allocateDynamically;
-  enum ALLOCATE_TYPE { NO = 0, NORMAL, LARGE, NORMAL_FAILED, LARGE_FAILED };
+  enum ALLOCATE_TYPE { NO = 0, NORMAL, LARGE, FFMPEG, NORMAL_FAILED, LARGE_FAILED, FFMPEG_FAILED };
   ALLOCATE_TYPE m_isAllocated;
 
   CTextureInfo m_info;
@@ -171,6 +176,12 @@ protected:
 
   CTextureArray m_diffuse;
   CTextureArray m_texture;
+
+  // ffmpeg
+  FFmpegVideoDecoder *m_decoder;
+  CBaseTexture *m_frame;
+  unsigned int m_millisPerFrame;
+  unsigned int m_lastFrameTime;
 };
 
 

--- a/xbmc/guilib/GUITexture.h
+++ b/xbmc/guilib/GUITexture.h
@@ -124,13 +124,15 @@ public:
 
   bool HitTest(const CPoint &point) const { return CRect(m_posX, m_posY, m_posX + m_width, m_posY + m_height).PtInRect(point); };
   bool IsAllocated() const { return m_isAllocated != NO; };
-  bool FailedToAlloc() const { return m_isAllocated == NORMAL_FAILED || m_isAllocated == LARGE_FAILED || m_isAllocated == FFMPEG_FAILED; };
+  bool FailedToAlloc() const { return m_isAllocated == NORMAL_FAILED || m_isAllocated == LARGE_FAILED; };
   bool ReadyToRender() const;
 protected:
   bool CalculateSize();
   void LoadDiffuseImage();
   bool AllocateOnDemand();
+#ifdef USE_FFMPEG_CONTROL
   bool UpdateFFmpeg(unsigned int currentTime);
+#endif
   bool UpdateAnimFrame();
   void Render(float left, float top, float bottom, float right, float u1, float v1, float u2, float v2, float u3, float v3);
   static void OrientateTexture(CRect &rect, float width, float height, int orientation);
@@ -168,7 +170,7 @@ protected:
   CPoint m_diffuseOffset;                 // offset into the diffuse frame (it's not always the origin)
 
   bool m_allocateDynamically;
-  enum ALLOCATE_TYPE { NO = 0, NORMAL, LARGE, FFMPEG, NORMAL_FAILED, LARGE_FAILED, FFMPEG_FAILED };
+  enum ALLOCATE_TYPE { NO = 0, NORMAL, LARGE, FFMPEG, NORMAL_FAILED, LARGE_FAILED };
   ALLOCATE_TYPE m_isAllocated;
 
   CTextureInfo m_info;
@@ -177,11 +179,13 @@ protected:
   CTextureArray m_diffuse;
   CTextureArray m_texture;
 
+#ifdef USE_FFMPEG_CONTROL
   // ffmpeg
   FFmpegVideoDecoder *m_decoder;
   CBaseTexture *m_frame;
   unsigned int m_millisPerFrame;
   unsigned int m_lastFrameTime;
+#endif
 };
 
 


### PR DESCRIPTION
Here's a FFmpeg GUI control. It hangs off GUIImage so works exactly the same in a skin like so:

```
<control type="ffmpeg">
  <left>480</left>
  <top>100</top>
  <width>320</width>
  <height>180</height>
  <texture fallback="whateves.jpg">/some/video/file.mp4</texture>
</control>
```

Since it is GUIImage, you should be able to use any tag that works on "image" control (Not that I've tried it)

Here's a demo video (https://vid.me/Suu) showing the Confluence background replaced with 4 "ffmpeg" controls. The background/left/middle videos are .avi/.swf/.mp4 respectively. The right blue is a bad filename to show we get fallback= for free.

It adds ffmpeg support to GUITexture, whos job is to grab a texture from somewhere (currently g_TextureManager or g_largeTextureManager) and put it on screen. Give it one more place to grab from (FFmpegVideoDecoder) and a new flag (useFFmpeg) in CTextureInfo same as useLarge and g_largeTextureManager. Add "ffmpeg" to GUIControlFactory aliased to GUICONTROL_IMAGE same as "largeimage" is aliased. Video is opened in CGUITextureBase::AllocResources() and closed in CGUITextureBase::FreeResources(). GUITexture already handles animated GIFs with UpdateAnimFrame() so add UpdateFFmpeg() to handle decoding.

You get everything "image" can do for free, with a video instead of a picture (fine print: software decode). It should be easy to make a screensaver and a visualization out of this. They might as well be native as going through the addon layer would be silly. Or push it off on the skin guys since they can invoke a video themselves. Put a "ffmpeg" instead of "visualisation", boom done. Plus you can delete 'karaokevideobackground.cpp' (which is twice the size of this commit) because karaoke can already use viz as background. Wheeeeeee
