### PR TITLE
[droid] update Android manifest with <uses-feature>

### DIFF
--- a/tools/android/packaging/xbmc/AndroidManifest.xml.in
+++ b/tools/android/packaging/xbmc/AndroidManifest.xml.in
@@ -13,7 +13,12 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.GET_TASKS" />
 
+    <uses-feature android:name="android.hardware.screen.landscape" android:required="true" />
     <uses-feature android:name="android.hardware.touchscreen" android:required="false" />
+    <uses-feature android:name="android.hardware.touchscreen.multitouch" android:required="false" />
+    <uses-feature android:name="android.hardware.type.television" android:required="false" />
+    <uses-feature android:name="android.hardware.usb.host" android:required="false" />
+    <uses-feature android:name="android.hardware.wifi" android:required="false" />
 	
     <application android:icon="@drawable/ic_launcher" android:label="@string/app_name" android:hasCode="true">
         <activity


### PR DESCRIPTION
As stated on http://developer.android.com/guide/topics/manifest/uses-feature-element.html we should define what we can use.
- hardware.screen.landscape  should be a required feature i think as portrait mode is kinda useless for us (debatable) 
- android.hardware.type.television "designed for a television user experience."
- android.hardware.touchscreen.multitouch  Changed to multitouch as we support that now
- android.hardware.wifi We can use wi-fi if available

@koying @Montellese 

Edit:
Not sure if we also should add 
- android.hardware.bluetooth
- android.hardware.audio.low_latency
