### PR TITLE
[win32] fix some unit tests

### DIFF
--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -69,7 +69,7 @@
     <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Debug Testsuite|Win32'">$(DXSDK_DIR)Lib\x86;$(LibraryPath)</LibraryPath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(DXSDK_DIR)Include;$(IncludePath)</IncludePath>
     <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(DXSDK_DIR)Lib\x86;$(LibraryPath)</LibraryPath>
-    <TargetName Condition="'$(Configuration)|$(Platform)'=='Debug Testsuite|Win32'">xbmc-test</TargetName>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Debug Testsuite|Win32'">$(ProjectName)-test</TargetName>
     <CustomBuildBeforeTargets Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     </CustomBuildBeforeTargets>
   </PropertyGroup>

--- a/xbmc/filesystem/test/TestRarFile.cpp
+++ b/xbmc/filesystem/test/TestRarFile.cpp
@@ -32,6 +32,10 @@
 
 #include "gtest/gtest.h"
 
+#ifndef S_IFLNK
+#define S_IFLNK 0120000
+#endif
+
 TEST(TestRarFile, Read)
 {
   XFILE::CFile file;

--- a/xbmc/test/TestUtils.cpp
+++ b/xbmc/test/TestUtils.cpp
@@ -23,6 +23,7 @@
 #include "filesystem/File.h"
 #include "filesystem/SpecialProtocol.h"
 #include "utils/StringUtils.h"
+#include "utils/URIUtils.h"
 
 #ifdef TARGET_WINDOWS
 #include <windows.h>
@@ -107,7 +108,7 @@ CXBMCTestUtils &CXBMCTestUtils::Instance()
 
 std::string CXBMCTestUtils::ReferenceFilePath(const std::string& path)
 {
-  return CSpecialProtocol::TranslatePath("special://xbmc") + path;
+  return CSpecialProtocol::TranslatePath(URIUtils::AddFileToFolder("special://xbmc", path));
 }
 
 bool CXBMCTestUtils::SetReferenceFileBasePath()

--- a/xbmc/test/TestUtils.cpp
+++ b/xbmc/test/TestUtils.cpp
@@ -43,7 +43,6 @@ public:
   bool Create(const std::string &suffix)
   {
     char tmp[MAX_PATH];
-    int fd;
 
     m_ptempFileDirectory = CSpecialProtocol::TranslatePath("special://temp/");
     m_ptempFilePath = m_ptempFileDirectory + "xbmctempfileXXXXXX";
@@ -64,6 +63,7 @@ public:
     }
     m_ptempFilePath = tmp;
 #else
+    int fd;
     if ((fd = mkstemps(tmp, suffix.length())) < 0)
     {
       m_ptempFilePath = "";


### PR DESCRIPTION
These commits fix the unit test setup and some unit tests on win32.
- The first commit fixes building and running unit tests from Visual Studio. 
- The second commit silences a warning due to an unused variable (only used by non-win32 platforms)
- The third commit fixes CXBMCTestUtils::ReferenceFilePath() which is used in a lot of places to get a valid path to a test file. It probably worked on non-win32 platforms but was broken on win32 due to putting together paths ending with `\` and starting with `/`.
- The last commit excludes TestRarFile from the unit test project for now because compilation fails due to 47f3d83d3daaab638f6dc52a8ecdeb216733cf99 and I don't really know what the proper fix is. On win32 the missing `S_IFLNK` is never used in any core code only in the unit tests.
