### PR TITLE
Remove 'XBMC.' prefix from built-ins

### DIFF
--- a/docs/manpages/kodi-send.1
+++ b/docs/manpages/kodi-send.1
@@ -8,7 +8,7 @@ This program is used for sending actions for Kodi.
 .PP
 Example
 .IP
-kodi\-send \fB\-\-host\fR=\fI192\fR.168.0.1 \fB\-\-port\fR=\fI9777\fR \fB\-\-action=\fR"XBMC.Quit"
+kodi\-send \fB\-\-host\fR=\fI192\fR.168.0.1 \fB\-\-port\fR=\fI9777\fR \fB\-\-action=\fR"Quit"
 .PP
 Options
 .TP

--- a/system/keymaps/appcommand.xml
+++ b/system/keymaps/appcommand.xml
@@ -17,7 +17,7 @@
       <stop>Stop</stop>
       <play_pause>PlayPause</play_pause>
       <launch_mail/>
-      <launch_media_select>XBMC.ActivateWindow(MyMusic)</launch_media_select>
+      <launch_media_select>ActivateWindow(MyMusic)</launch_media_select>
       <launch_app1>ActivateWindow(MyPrograms)</launch_app1>
       <launch_app2>ActivateWindow(MyPrograms)</launch_app2>
       <play>Play</play>

--- a/system/keymaps/gamepad.xml
+++ b/system/keymaps/gamepad.xml
@@ -19,7 +19,7 @@
 <!--    </universalremote>            -->
 
 <!-- Note that the action can be a built-in function.                 -->
-<!--  eg <B>XBMC.ActivateWindow(MyMusic)</B>                         -->
+<!--  eg <B>ActivateWindow(MyMusic)</B>                         -->
 <!-- would automatically go to My Music on the press of the B button. -->
 
 <!-- Joysticks / Gamepads:                                                                    -->
@@ -44,14 +44,14 @@
       <Y>Queue</Y>
       <white>ContextMenu</white>
       <black/>
-      <start>XBMC.ActivateWindow(PlayerControls)</start>
+      <start>ActivateWindow(PlayerControls)</start>
       <back>PreviousMenu</back>
       <dpadleft>Left</dpadleft>
       <dpadright>Right</dpadright>
       <dpadup>Up</dpadup>
       <dpaddown>Down</dpaddown>
       <leftthumbbutton>Screenshot</leftthumbbutton>
-      <rightthumbbutton>XBMC.ActivateWindow(ShutdownMenu)</rightthumbbutton>
+      <rightthumbbutton>ActivateWindow(ShutdownMenu)</rightthumbbutton>
       <leftanalogtrigger>ScrollUp</leftanalogtrigger>
       <rightanalogtrigger>ScrollDown</rightanalogtrigger>
       <rightthumbstickleft>AnalogSeekBack</rightthumbstickleft>
@@ -62,7 +62,7 @@
   </global>
   <Home>
     <gamepad>
-      <black>XBMC.Skin.ToggleSetting(HomeViewToggle)</black>
+      <black>Skin.ToggleSetting(HomeViewToggle)</black>
     </gamepad>
   </Home>
   <MyFiles>
@@ -144,7 +144,7 @@
     <gamepad>
       <A>Pause</A>
       <B>Stop</B>
-      <Y>XBMC.ActivateWindow(VisualisationPresetList)</Y>
+      <Y>ActivateWindow(VisualisationPresetList)</Y>
       <black>CodecInfo</black>
       <white>Info</white>
       <start>OSD</start>

--- a/system/keymaps/joystick.Alienware.Dual.Compatible.Controller.xml
+++ b/system/keymaps/joystick.Alienware.Dual.Compatible.Controller.xml
@@ -19,7 +19,7 @@
 <!--    </universalremote>            -->
 
 <!-- Note that the action can be a built-in function.                 -->
-<!--  eg <B>XBMC.ActivateWindow(MyMusic)</B>                         -->
+<!--  eg <B>ActivateWindow(MyMusic)</B>                         -->
 <!-- would automatically go to My Music on the press of the B button. -->
 
 <!-- Joysticks / Gamepads:                                                                    -->
@@ -50,9 +50,9 @@
       <button id="11">Screenshot</button> <!-- l3 - left analog -->
       <button id="5"></button>    <!-- r1 -->      
       <button id="8"></button>  <!-- r2 -->
-      <button id="12">XBMC.ActivateWindow(ShutdownMenu)</button> <!-- R3 - right analog -->      
+      <button id="12">ActivateWindow(ShutdownMenu)</button> <!-- R3 - right analog -->      
       <button id="9"></button>  <!-- select -->      
-      <button id="10">XBMC.ActivateWindow(PlayerControls)</button>  <!-- start --> 
+      <button id="10">ActivateWindow(PlayerControls)</button>  <!-- start --> 
       <!-- Left Analog Left and Right-->
       <axis limit="-1" id="0">AnalogSeekBack</axis>        
       <axis limit="+1" id="0">AnalogSeekForward</axis>

--- a/system/keymaps/joystick.AppleRemote.xml
+++ b/system/keymaps/joystick.AppleRemote.xml
@@ -19,7 +19,7 @@
 <!--    </universalremote>                                                                       -->
 
 <!-- Note that the action can be a built-in function.                                            -->
-<!--            eg <button id="6">XBMC.ActivateWindow(Favourites)</button>                       -->
+<!--            eg <button id="6">ActivateWindow(Favourites)</button>                       -->
 <!-- would bring up Favourites when the button with the id of 6 is press. In this case, "Menu"   -->
 
 <!--                                                                                             -->
@@ -84,7 +84,7 @@
   </global>
   <Home>
     <joystick name="AppleRemote">
-      <button id="6">XBMC.ActivateWindow(Favourites)</button>
+      <button id="6">ActivateWindow(Favourites)</button>
       <button id="8">ActivateWindow(shutdownmenu)</button>
     </joystick>
   </Home>

--- a/system/keymaps/joystick.Harmony.xml
+++ b/system/keymaps/joystick.Harmony.xml
@@ -19,7 +19,7 @@
 <!--    </universalremote>            -->
 
 <!-- Note that the action can be a built-in function.                 -->
-<!--  eg <B>XBMC.ActivateWindow(MyMusic)</B>                         -->
+<!--  eg <B>ActivateWindow(MyMusic)</B>                         -->
 <!-- would automatically go to My Music on the press of the B button. -->
 
 <!-- Joysticks / Gamepads:                                                                    -->
@@ -84,37 +84,37 @@
       <!-- # enter 	-->      <button id="36">Select</button>
       <!-- Mute		-->      <button id="25">Mute</button>
       <!-- Aspect	-->      <button id="61">AspectRatio</button>
-      <!-- F1		-->      <button id="53">XBMC.ActivateWindow(Music)</button>
-      <!-- F3		-->      <button id="55">XBMC.ActivateWindow(videolibrary,tvshowtitles,return)</button>
-      <!-- F2		-->      <button id="54">XBMC.ActivateWindow(videolibrary,movietitles,return)</button>
-      <!-- F4		-->      <button id="56">XBMC.ActivateWindow(Weather)</button>
+      <!-- F1		-->      <button id="53">ActivateWindow(Music)</button>
+      <!-- F3		-->      <button id="55">ActivateWindow(videolibrary,tvshowtitles,return)</button>
+      <!-- F2		-->      <button id="54">ActivateWindow(videolibrary,movietitles,return)</button>
+      <!-- F4		-->      <button id="56">ActivateWindow(Weather)</button>
       <!-- F5			-->  <button id="93">OSD</button>
-      <!-- F7			-->  <button id="95">XBMC.ActivateWindow(Home)</button>
-      <!-- F6			-->  <button id="94">XBMC.ActivateWindow(Scripts)</button>
-      <!-- F8			-->  <button id="96">XBMC.ActivateWindow(favourites)</button>
+      <!-- F7			-->  <button id="95">ActivateWindow(Home)</button>
+      <!-- F6			-->  <button id="94">ActivateWindow(Scripts)</button>
+      <!-- F8			-->  <button id="96">ActivateWindow(favourites)</button>
       <!-- F9			-->  <button id="73">ShowVideoMenu</button>
       <!-- F10			-->  <button id="74">ShowSubtitles</button>
       <!-- F11			-->  <button id="75">NextSubtitle</button>
-      <!-- F12			-->  <button id="76">XBMC.ActivateWindow(VideoFiles)</button>
+      <!-- F12			-->  <button id="76">ActivateWindow(VideoFiles)</button>
       <!-- F13			-->  <button id="63">Playlist</button>
       <!-- F14			-->  <button id="64">AudioNextLanguage</button>
       <!-- Large Down	-->  <button id="82">PageDown</button>
       <!-- Large Up	-->      <button id="81">PageUp</button>
-      <!-- pwrToggle   -->   <button id="66">XBMC.ShutDown()</button>
+      <!-- pwrToggle   -->   <button id="66">ShutDown()</button>
       <!-- Queue	-->      <button id="62">Queue</button>
-      <!-- Sleep	-->      <button id="46">XBMC.Suspend()</button>
+      <!-- Sleep	-->      <button id="46">Suspend()</button>
       <!-- Red		-->      <button id="83">CodecInfo</button>
-      <!-- Green	-->      <button id="84">XBMC.ActivateWindow(Settings)</button>
+      <!-- Green	-->      <button id="84">ActivateWindow(Settings)</button>
       <!-- Yellow	-->      <button id="85">xbmc.ActivateWindow(SystemSettings)</button>
-      <!-- Blue		-->      <button id="86">XBMC.ActivateWindow(SystemInfo)</button>
+      <!-- Blue		-->      <button id="86">ActivateWindow(SystemInfo)</button>
     </joystick>
   </global>
   <Home>
     <joystick name="Harmony">
-      <!-- menu       	-->      <button id="6">XBMC.ActivateWindow(PlayerControls)</button>
-      <!-- Info  	-->      <button id="31">XBMC.ActivateWindow(Settings)</button>
-      <!-- Exit 	-->      <button id="51">XBMC.ActivateWindow(ShutdownMenu)</button>
-      <!-- #enter	-->      <button id="36">XBMC.ActivateWindow(SystemInfo)</button>
+      <!-- menu       	-->      <button id="6">ActivateWindow(PlayerControls)</button>
+      <!-- Info  	-->      <button id="31">ActivateWindow(Settings)</button>
+      <!-- Exit 	-->      <button id="51">ActivateWindow(ShutdownMenu)</button>
+      <!-- #enter	-->      <button id="36">ActivateWindow(SystemInfo)</button>
       <!-- 1 		-->      <button id="11">ToggleFullScreen</button>
     </joystick>
   </Home>
@@ -208,8 +208,8 @@
       <!-- menu       	-->      <button id="6">OSD</button>
       <!-- Prev		-->      <button id="32">LockPreset</button>
       <!-- Info  	-->      <button id="31">Info</button>
-      <!-- F8		-->      <button id="96">XBMC.ActivateWindow(VisualisationPresetList)</button>
-      <!-- F9		-->      <button id="73">XBMC.ActivateWindow(VisualisationSettings)</button>
+      <!-- F8		-->      <button id="96">ActivateWindow(VisualisationPresetList)</button>
+      <!-- F9		-->      <button id="73">ActivateWindow(VisualisationSettings)</button>
     </joystick>
   </Visualisation>
   <MusicOSD>

--- a/system/keymaps/joystick.Interact.AxisPad.xml
+++ b/system/keymaps/joystick.Interact.AxisPad.xml
@@ -19,7 +19,7 @@
 <!--    </universalremote>            -->
 
 <!-- Note that the action can be a built-in function.                 -->
-<!--  eg <B>XBMC.ActivateWindow(MyMusic)</B>                         -->
+<!--  eg <B>ActivateWindow(MyMusic)</B>                         -->
 <!-- would automatically go to My Music on the press of the B button. -->
 
 <!-- Joysticks / Gamepads:                                                                    -->
@@ -50,7 +50,7 @@
       <button id="8"></button>  <!-- r2 -->
       <button id="10">PreviousMenu</button> <!-- R3 - right analog -->      
       <button id="11"></button>  <!-- select/Escape -->      
-      <button id="12">XBMC.ActivateWindow(PlayerControls)</button>  <!-- start/enter --> 
+      <button id="12">ActivateWindow(PlayerControls)</button>  <!-- start/enter --> 
       <button id="20"></button> <!-- Toggle Switch-->
       <!-- Left Analog Left and Right-->
       <axis limit="-1" id="0">AnalogSeekBack</axis>        

--- a/system/keymaps/joystick.Logitech.RumblePad.2.xml
+++ b/system/keymaps/joystick.Logitech.RumblePad.2.xml
@@ -9,7 +9,7 @@
       <button id="3">Back</button>
       <button id="7">FullScreen</button>
       <button id="8">ContextMenu</button>
-      <button id="10">XBMC.ActivateWindow(Home)</button>
+      <button id="10">ActivateWindow(Home)</button>
       <button id="11">ActivateWindow(shutdownmenu)</button>
       <button id="12">Screenshot</button>
 
@@ -31,7 +31,7 @@
     <joystick name="Logitech Logitech Cordless RumblePad 2">
       <altname>Logitech Cordless RumblePad 2</altname>
       <altname>Logitech RumblePad 2 USB</altname>
-      <button id="3">XBMC.ActivateWindow(Favourites)</button>
+      <button id="3">ActivateWindow(Favourites)</button>
     </joystick>
   </Home>
 
@@ -97,7 +97,7 @@
       <altname>Logitech RumblePad 2 USB</altname>
       <button id="2">Pause</button>
       <button id="3">Stop</button>
-      <button id="4">XBMC.ActivateWindow(VisualisationPresetList)</button>
+      <button id="4">ActivateWindow(VisualisationPresetList)</button>
       <button id="5">Rewind</button>
       <button id="6">FastForward</button>
       <button id="10">OSD</button>

--- a/system/keymaps/joystick.Microsoft.Xbox.360.Controller.xml
+++ b/system/keymaps/joystick.Microsoft.Xbox.360.Controller.xml
@@ -14,7 +14,7 @@
 <!--    </device>                                               -->
 
 <!-- Note that the action can be a built-in function.           -->
-<!-- eg <button id="x">XBMC.ActivateWindow(Home)</button>       -->
+<!-- eg <button id="x">ActivateWindow(Home)</button>       -->
 <!-- would automatically go to Home on the press of button 'x'. -->
 
 <!-- Joystick Name: Xbox 360 Wireless Receiver                  -->
@@ -99,10 +99,10 @@
       <button id="5">Queue</button>
       <button id="6">Playlist</button>
       <button id="7">PreviousMenu</button>
-      <button id="8">XBMC.ActivateWindow(Home)</button>
+      <button id="8">ActivateWindow(Home)</button>
       <!-- Left stick click activates the shutdown menu. -->
-      <button id="9">XBMC.ActivateWindow(ShutdownMenu)</button>
-      <button id="10">XBMC.ActivateWindow(PlayerControls)</button>
+      <button id="9">ActivateWindow(ShutdownMenu)</button>
+      <button id="10">ActivateWindow(PlayerControls)</button>
       <button id="11">Up</button>
       <button id="12">Down</button>
       <button id="13">Left</button>
@@ -141,10 +141,10 @@
       <button id="5">Queue</button>
       <button id="6">Playlist</button>
       <button id="7">PreviousMenu</button>
-      <button id="8">XBMC.ActivateWindow(Home)</button>
-      <button id="9">XBMC.ActivateWindow(Home)</button>
-      <button id="10">XBMC.ActivateWindow(ShutdownMenu)</button>
-      <button id="11">XBMC.ActivateWindow(PlayerControls)</button>
+      <button id="8">ActivateWindow(Home)</button>
+      <button id="9">ActivateWindow(Home)</button>
+      <button id="10">ActivateWindow(ShutdownMenu)</button>
+      <button id="11">ActivateWindow(PlayerControls)</button>
       <button id="12">Left</button>
       <button id="13">Right</button>
       <button id="14">Up</button>
@@ -183,7 +183,7 @@
       <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
       <altname>Xbox wireless receiver for windows (Controller)</altname>
       <altname>Gamepad F310 (Controller)</altname>
-      <button id="8">XBMC.Skin.ToggleSetting(HomeViewToggle)</button>
+      <button id="8">Skin.ToggleSetting(HomeViewToggle)</button>
     </joystick>
     <joystick name="Microsoft X-Box 360 pad">
       <altname>BigBen Interactive XBOX 360 Controller</altname>
@@ -195,7 +195,7 @@
       <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
       <altname>Xbox 360 Wireless Receiver</altname>
       <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
-      <button id="8">XBMC.Skin.ToggleSetting(HomeViewToggle)</button>
+      <button id="8">Skin.ToggleSetting(HomeViewToggle)</button>
     </joystick>
   </Home>
   <MyFiles>
@@ -335,8 +335,8 @@
       <button id="6">ShowSubtitles</button>
       <button id="7">SmallStepBack</button>
       <button id="8">Info</button>
-      <button id="9">XBMC.ActivateWindow(Home)</button>  <!-- guide -->
-      <button id="10">XBMC.ActivateWindow(ShutdownMenu)</button>  <!-- left stick -->
+      <button id="9">ActivateWindow(Home)</button>  <!-- guide -->
+      <button id="10">ActivateWindow(ShutdownMenu)</button>  <!-- left stick -->
       <button id="11">AudioNextLanguage</button>  <!-- right stick -->
       <button id="12">StepBack</button>
       <button id="13">StepForward</button>
@@ -542,10 +542,10 @@
       <altname>Gamepad F310 (Controller)</altname>
       <button id="1">Pause</button>
       <button id="2">Stop</button>
-      <button id="3">XBMC.ActivateWindow(MusicOSD)</button>
-      <button id="5">XBMC.ActivateWindow(VisualisationPresetList)</button>
+      <button id="3">ActivateWindow(MusicOSD)</button>
+      <button id="5">ActivateWindow(VisualisationPresetList)</button>
       <button id="6">Info</button>
-      <button id="10">XBMC.ActivateWindow(MusicOSD)</button>
+      <button id="10">ActivateWindow(MusicOSD)</button>
       <button id="11">SkipNext</button>
       <button id="12">SkipPrevious</button>
       <button id="13">PreviousPreset</button>
@@ -569,10 +569,10 @@
       <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
       <button id="1">Pause</button>
       <button id="2">Stop</button>
-      <button id="3">XBMC.ActivateWindow(MusicOSD)</button>
-      <button id="5">XBMC.ActivateWindow(VisualisationPresetList)</button>
+      <button id="3">ActivateWindow(MusicOSD)</button>
+      <button id="5">ActivateWindow(VisualisationPresetList)</button>
       <button id="6">Info</button>
-      <button id="11">XBMC.ActivateWindow(MusicOSD)</button>
+      <button id="11">ActivateWindow(MusicOSD)</button>
       <button id="12">PreviousPreset</button>
       <button id="13">NextPreset</button>
       <button id="14">SkipPrevious</button>

--- a/system/keymaps/joystick.Microsoft.Xbox.Controller.S.xml
+++ b/system/keymaps/joystick.Microsoft.Xbox.Controller.S.xml
@@ -19,7 +19,7 @@
 <!--    </universalremote>            -->
 
 <!-- Note that the action can be a built-in function.                 -->
-<!--  eg <B>XBMC.ActivateWindow(MyMusic)</B>                         -->
+<!--  eg <B>ActivateWindow(MyMusic)</B>                         -->
 <!-- would automatically go to My Music on the press of the B button. -->
 
 <!-- Joysticks / Gamepads:                                                                    -->
@@ -49,10 +49,10 @@
       <button id="6">ContextMenu</button>
       <button id="7"/>
       <button id="8"/>
-      <button id="9">XBMC.ActivateWindow(PlayerControls)</button>
+      <button id="9">ActivateWindow(PlayerControls)</button>
       <button id="10"/>
       <button id="11">Screenshot</button>
-      <button id="12">XBMC.ActivateWindow(ShutdownMenu)</button>
+      <button id="12">ActivateWindow(ShutdownMenu)</button>
       <button id="13">Up</button>
       <button id="14">Right</button>
       <button id="15">Down</button>
@@ -71,7 +71,7 @@
       <altname>Mad Catz MicroCON</altname>
       <altname>Logitech Xbox Cordless Controller</altname>
       <altname>Microsoft X-Box pad (Japan)</altname> 
-      <button id="3">XBMC.Skin.ToggleSetting(HomeViewToggle)</button>
+      <button id="3">Skin.ToggleSetting(HomeViewToggle)</button>
     </joystick>
   </Home>
   <MyFiles>
@@ -179,7 +179,7 @@
       <button id="1">Pause</button>
       <button id="2">Stop</button>
       <button id="3">CodecInfo</button>
-      <button id="5">XBMC.ActivateWindow(VisualisationPresetList)</button>
+      <button id="5">ActivateWindow(VisualisationPresetList)</button>
       <button id="6">Info</button>
       <button id="9">OSD</button>
       <button id="13">NextPreset</button>

--- a/system/keymaps/joystick.Nintendo.Wii.U.Pro.Controller.xml
+++ b/system/keymaps/joystick.Nintendo.Wii.U.Pro.Controller.xml
@@ -52,11 +52,11 @@
       <button id="8">ScrollDown</button>
 
       <!-- Home -->
-      <button id="11">XBMC.ActivateWindow(Home)</button>
+      <button id="11">ActivateWindow(Home)</button>
 
       <!-- Left/Right stick click -->
-      <button id="12">XBMC.ActivateWindow(ShutdownMenu)</button>
-      <button id="13">XBMC.ActivateWindow(PlayerControls)</button>
+      <button id="12">ActivateWindow(ShutdownMenu)</button>
+      <button id="13">ActivateWindow(PlayerControls)</button>
 
       <!-- D-Pad -->
       <button id="14">Up</button>

--- a/system/keymaps/joystick.PS3.Remote.Keyboard.xml
+++ b/system/keymaps/joystick.PS3.Remote.Keyboard.xml
@@ -19,7 +19,7 @@
 <!--    </universalremote>            -->
 
 <!-- Note that the action can be a built-in function.                 -->
-<!--  eg <B>XBMC.ActivateWindow(MyMusic)</B>                         -->
+<!--  eg <B>ActivateWindow(MyMusic)</B>                         -->
 <!-- would automatically go to My Music on the press of the B button. -->
 
 <!-- Joysticks / Gamepads:                                                                    -->
@@ -50,7 +50,7 @@
       <button id="10">FullScreen</button>
       <button id="12">VolumeUp</button>
       <button id="11">VolumeDown</button>
-      <button id="13">XBMC.ActivateWindow(Home)</button>
+      <button id="13">ActivateWindow(Home)</button>
       <hat    id="1" position="left">Left</hat>
       <hat    id="1" position="right">Right</hat>
       <hat    id="1" position="up">Up</hat>

--- a/system/keymaps/joystick.Sony.PLAYSTATION(R)3.Controller.xml
+++ b/system/keymaps/joystick.Sony.PLAYSTATION(R)3.Controller.xml
@@ -19,7 +19,7 @@
 <!--    </universalremote>            -->
 
 <!-- Note that the action can be a built-in function.                 -->
-<!--  eg <B>XBMC.ActivateWindow(MyMusic)</B>                         -->
+<!--  eg <B>ActivateWindow(MyMusic)</B>                         -->
 <!-- would automatically go to My Music on the press of the B button. -->
 
 <!-- Joysticks / Gamepads:                                                                    -->
@@ -51,8 +51,8 @@
       <button id="5">Up</button>
       <button id="7">Down</button>
       <button id="2">Screenshot</button>
-      <button id="3">XBMC.ActivateWindow(ShutdownMenu)</button>
-      <button id="4">XBMC.ActivateWindow(PlayerControls)</button>
+      <button id="3">ActivateWindow(ShutdownMenu)</button>
+      <button id="4">ActivateWindow(PlayerControls)</button>
       <axis limit="+1" id="4">VolumeDown</axis>
       <axis limit="-1" id="4">VolumeUp</axis>
       <axis limit="+1" id="1">AnalogSeekForward</axis>

--- a/system/keymaps/joystick.WiiRemote.xml
+++ b/system/keymaps/joystick.WiiRemote.xml
@@ -19,7 +19,7 @@
 <!--    </universalremote>            -->
 
 <!-- Note that the action can be a built-in function.                 -->
-<!--  eg <B>XBMC.ActivateWindow(MyMusic)</B>                         -->
+<!--  eg <B>ActivateWindow(MyMusic)</B>                         -->
 <!-- would automatically go to My Music on the press of the B button. -->
 
 <!-- Joysticks / Gamepads:                                                                    -->
@@ -45,17 +45,17 @@
       <button id="5">Select</button>
       <button id="6">Back</button>
       <button id="7">VolumeDown</button>
-      <button id="8">XBMC.ActivateWindow(Home)</button>
+      <button id="8">ActivateWindow(Home)</button>
       <button id="9">VolumeUp</button>
       <button id="10">ContextMenu</button>
-      <button id="11">XBMC.ActivateWindow(PlayerControls)</button>
+      <button id="11">ActivateWindow(PlayerControls)</button>
     </joystick>
   </global>
   <Home>
     <joystick name="WiiRemote">
       <button id="8">Fullscreen</button>
-      <button id="10">XBMC.ActivateWindow(Favourites)</button>
-      <button id="11">XBMC.ActivateWindow(ShutdownMenu)</button>
+      <button id="10">ActivateWindow(Favourites)</button>
+      <button id="11">ActivateWindow(ShutdownMenu)</button>
     </joystick>
   </Home>
   <MyFiles>
@@ -126,7 +126,7 @@
       <button id="4">SkipPrevious</button>
       <button id="5">OSD</button>
       <button id="6">Info</button>
-      <button id="8">XBMC.ActivateWindow(music)</button>
+      <button id="8">ActivateWindow(music)</button>
       <button id="10">IncreaseRating</button>
       <button id="11">DecreaseRating</button>
     </joystick>
@@ -139,8 +139,8 @@
   </MusicOSD>
   <VisualisationSettings>
     <joystick name="WiiRemote">
-      <button id="10">XBMC.ActivateWindow(VisualisationPresetList)</button>
-      <button id="11">XBMC.ActivateWindow(MusicPlaylist)</button>
+      <button id="10">ActivateWindow(VisualisationPresetList)</button>
+      <button id="11">ActivateWindow(MusicPlaylist)</button>
     </joystick>
   </VisualisationSettings>
   <SlideShow>

--- a/system/keymaps/joystick.xml.sample
+++ b/system/keymaps/joystick.xml.sample
@@ -42,10 +42,10 @@
       <button id="5">Queue</button>
       <button id="6">Playlist</button>
       <button id="7">PreviousMenu</button>
-      <button id="8">XBMC.ActivateWindow(Home)</button>
+      <button id="8">ActivateWindow(Home)</button>
       <!-- Left stick click activates the shutdown menu. -->
-      <button id="9">XBMC.ActivateWindow(ShutdownMenu)</button>
-      <button id="10">XBMC.ActivateWindow(PlayerControls)</button>
+      <button id="9">ActivateWindow(ShutdownMenu)</button>
+      <button id="10">ActivateWindow(PlayerControls)</button>
       <button id="11">Up</button>
       <button id="12">Down</button>
       <button id="13">Left</button>
@@ -70,7 +70,7 @@
   </global>
   <Home>
     <joystick>
-      <button id="8">XBMC.Skin.ToggleSetting(HomeViewToggle)</button>
+      <button id="8">Skin.ToggleSetting(HomeViewToggle)</button>
     </joystick>
   </Home>
   <MyFiles>
@@ -166,10 +166,10 @@
     <joystick>
       <button id="1">Pause</button>
       <button id="2">Stop</button>
-      <button id="3">XBMC.ActivateWindow(MusicOSD)</button>
-      <button id="5">XBMC.ActivateWindow(VisualisationPresetList)</button>
+      <button id="3">ActivateWindow(MusicOSD)</button>
+      <button id="5">ActivateWindow(VisualisationPresetList)</button>
       <button id="6">Info</button>
-      <button id="10">XBMC.ActivateWindow(MusicOSD)</button>
+      <button id="10">ActivateWindow(MusicOSD)</button>
       <button id="11">SkipNext</button>
       <button id="12">SkipPrevious</button>
       <button id="13">PreviousPreset</button>

--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -19,7 +19,7 @@
 <!--    </universalremote>            -->
 
 <!-- Note that the action can be a built-in function.                 -->
-<!--  eg <B>XBMC.ActivateWindow(MyMusic)</B>                         -->
+<!--  eg <B>ActivateWindow(MyMusic)</B>                         -->
 <!-- would automatically go to My Music on the press of the B button. -->
 
 <!-- Joysticks / Gamepads:                                                                    -->
@@ -99,11 +99,11 @@
       <power>ActivateWindow(shutdownmenu)</power>
       <sleep>ActivateWindow(shutdownmenu)</sleep>
       <!-- PVR windows -->
-      <e>XBMC.ActivateWindow(TVGuide)</e>
-      <h>XBMC.ActivateWindow(TVChannels)</h>
-      <j>XBMC.ActivateWindow(RadioChannels)</j>
-      <k>XBMC.ActivateWindow(TVRecordings)</k>
-      <b>XBMC.ActivateWindow(TVTimers)</b>
+      <e>ActivateWindow(TVGuide)</e>
+      <h>ActivateWindow(TVChannels)</h>
+      <j>ActivateWindow(RadioChannels)</j>
+      <k>ActivateWindow(TVRecordings)</k>
+      <b>ActivateWindow(TVTimers)</b>
       <!-- Multimedia keyboard keys -->
       <browser_back>Back</browser_back>
       <browser_forward/>
@@ -111,7 +111,7 @@
       <browser_stop/>
       <browser_search/>
       <browser_favorites>ActivateWindow(Favourites)</browser_favorites>
-      <browser_home>XBMC.ActivateWindow(Home)</browser_home>
+      <browser_home>ActivateWindow(Home)</browser_home>
       <volume_mute>Mute</volume_mute>
       <volume_down>VolumeDown</volume_down>
       <volume_up>VolumeUp</volume_up>
@@ -123,7 +123,7 @@
       <rewind>Rewind</rewind>
       <record/>
       <launch_mail></launch_mail>
-      <launch_media_select>XBMC.ActivateWindow(MyMusic)</launch_media_select>
+      <launch_media_select>ActivateWindow(MyMusic)</launch_media_select>
       <launch_app1_pc_icon>ActivateWindow(MyPrograms)</launch_app1_pc_icon>
       <launch_app2_pc_icon>ActivateWindow(MyPrograms)</launch_app2_pc_icon>
       <launch_file_browser/>
@@ -158,13 +158,13 @@
   </global>
   <LoginScreen>
     <keyboard>
-      <end mod="ctrl">XBMC.ShutDown()</end>
+      <end mod="ctrl">ShutDown()</end>
     </keyboard>
   </LoginScreen>
   <Home>
     <keyboard>
       <i>info</i>
-      <end mod="ctrl">XBMC.ShutDown()</end>
+      <end mod="ctrl">ShutDown()</end>
     </keyboard>
   </Home>
   <VirtualKeyboard>
@@ -268,7 +268,7 @@
       <a>AudioDelay</a>
       <escape>Fullscreen</escape>
       <c>Playlist</c>
-      <v>XBMC.ActivateWindow(Teletext)</v>
+      <v>ActivateWindow(Teletext)</v>
       <up mod="ctrl">SubtitleShiftUp</up>
       <down mod="ctrl">SubtitleShiftDown</down>
       <pageup>SkipNext</pageup>
@@ -318,8 +318,8 @@
       <o>CodecInfo</o>
       <l>LockPreset</l>
       <escape>FullScreen</escape>
-      <g>XBMC.ActivateWindow(PVROSDGuide)</g>
-      <c>XBMC.ActivateWindow(PVROSDChannels)</c>
+      <g>ActivateWindow(PVROSDGuide)</g>
+      <c>ActivateWindow(PVROSDChannels)</c>
     </keyboard>
   </Visualisation>
   <MusicOSD>

--- a/system/keymaps/nyxboard/keyboard.xml
+++ b/system/keymaps/nyxboard/keyboard.xml
@@ -3,7 +3,7 @@
 <keymap>
   <global>
     <keyboard>
-      <home>XBMC.ActivateWindow(Home)</home>
+      <home>ActivateWindow(Home)</home>
       <f3>OSD</f3>         <!-- EPG: same as Guide (ctrl-G) on MCE remote -->
       <f3 mod="shift">ActivateWindow(video)</f3>    <!-- Red -->
       <f4 mod="shift">ActivateWindow(music)</f4>    <!-- Green -->

--- a/system/keymaps/remote.xml
+++ b/system/keymaps/remote.xml
@@ -19,7 +19,7 @@
 <!--    </universalremote>            -->
 
 <!-- Note that the action can be a built-in function.                 -->
-<!--  eg <B>XBMC.ActivateWindow(MyMusic)</B>                         -->
+<!--  eg <B>ActivateWindow(MyMusic)</B>                         -->
 <!-- would automatically go to My Music on the press of the B button. -->
 
 <!-- Joysticks / Gamepads:                                                                    -->
@@ -60,24 +60,24 @@
       <display>FullScreen</display>
       <start>PreviousMenu</start>
       <record>Record</record>
-      <eject>XBMC.EjectTray()</eject>
+      <eject>EjectTray()</eject>
       <volumeplus>VolumeUp</volumeplus>
       <volumeminus>VolumeDown</volumeminus>
       <mute>Mute</mute>
-      <power>XBMC.ShutDown()</power>
-      <myvideo>XBMC.ActivateWindow(MyVideos)</myvideo>
-      <mymusic>XBMC.ActivateWindow(MyMusic)</mymusic>
-      <mypictures>XBMC.ActivateWindow(MyPictures)</mypictures>
-      <mytv>XBMC.ActivateWindow(TVChannels)</mytv>
-      <guide>XBMC.ActivateWindow(TVGuide)</guide>
-      <livetv>XBMC.ActivateWindow(TVChannels)</livetv>
-      <liveradio>XBMC.ActivateWindow(RadioChannels)</liveradio>
-      <recordedtv>XBMC.ActivateWindow(TVRecordings)</recordedtv>
-      <epgsearch>XBMC.ActivateWindow(TVSearch)</epgsearch>
-      <red>XBMC.ActivateWindow(TVChannels)</red>
-      <green>XBMC.ActivateWindow(MyVideos)</green>
-      <yellow>XBMC.ActivateWindow(MyMusic)</yellow>
-      <blue>XBMC.ActivateWindow(MyPictures)</blue>
+      <power>ShutDown()</power>
+      <myvideo>ActivateWindow(MyVideos)</myvideo>
+      <mymusic>ActivateWindow(MyMusic)</mymusic>
+      <mypictures>ActivateWindow(MyPictures)</mypictures>
+      <mytv>ActivateWindow(TVChannels)</mytv>
+      <guide>ActivateWindow(TVGuide)</guide>
+      <livetv>ActivateWindow(TVChannels)</livetv>
+      <liveradio>ActivateWindow(RadioChannels)</liveradio>
+      <recordedtv>ActivateWindow(TVRecordings)</recordedtv>
+      <epgsearch>ActivateWindow(TVSearch)</epgsearch>
+      <red>ActivateWindow(TVChannels)</red>
+      <green>ActivateWindow(MyVideos)</green>
+      <yellow>ActivateWindow(MyMusic)</yellow>
+      <blue>ActivateWindow(MyPictures)</blue>
       <zero>Number0</zero>
       <one>Number1</one>
       <two>JumpSMS2</two>
@@ -93,9 +93,9 @@
   </global>
   <Home>
     <remote>
-      <info>XBMC.ActivateWindow(SystemInfo)</info>
-      <clear>XBMC.ActivateWindow(Weather)</clear>
-      <hash>XBMC.ActivateWindow(Settings)</hash>
+      <info>ActivateWindow(SystemInfo)</info>
+      <clear>ActivateWindow(Weather)</clear>
+      <hash>ActivateWindow(Settings)</hash>
     </remote>
   </Home>
   <MyTVRecordings>
@@ -187,8 +187,8 @@
       <select>OSD</select>
       <title>CodecInfo</title>
       <info>Info</info>
-      <guide>XBMC.ActivateWindow(PVROSDGuide)</guide>
-      <teletext>XBMC.ActivateWindow(Teletext)</teletext>
+      <guide>ActivateWindow(PVROSDGuide)</guide>
+      <teletext>ActivateWindow(Teletext)</teletext>
       <subtitle>NextSubtitle</subtitle>
       <star>NextSubtitle</star>
       <language>AudioNextLanguage</language>
@@ -224,12 +224,12 @@
       <down>DecreaseRating</down>
       <back>Back</back>
       <title>CodecInfo</title>
-      <select>XBMC.ActivateWindow(VisualisationPresetList)</select>
+      <select>ActivateWindow(VisualisationPresetList)</select>
       <menu>OSD</menu>
       <start>OSD</start>
       <info>Info</info>
-      <guide>XBMC.ActivateWindow(PVROSDGuide)</guide>
-      <playlist>XBMC.ActivateWindow(PVROSDChannels)</playlist>
+      <guide>ActivateWindow(PVROSDGuide)</guide>
+      <playlist>ActivateWindow(PVROSDChannels)</playlist>
     </remote>
   </Visualisation>
   <MusicOSD>

--- a/system/peripherals.xml
+++ b/system/peripherals.xml
@@ -4,7 +4,7 @@
     <setting key="do_not_use_custom_keymap" type="bool" value="0" label="35009" order="1" />
     <setting key="keymap" value="nyxboard" label="35007" configurable="0" />
     <setting key="enable_flip_commands" type="bool" value="1" label="36005" order="2" />
-    <setting key="flip_keyboard" value="XBMC.VideoLibrary.Search" label="36002" order="3" />
+    <setting key="flip_keyboard" value="VideoLibrary.Search" label="36002" order="3" />
     <setting key="flip_remote" value="Dialog.Close(virtualkeyboard)" label="36003" order="4" />
   </peripheral>
 

--- a/tools/EventClients/Clients/Kodi Send/kodi-send.py
+++ b/tools/EventClients/Clients/Kodi Send/kodi-send.py
@@ -31,7 +31,7 @@ except:
 def usage():
     print "kodi-send [OPTION] --action=ACTION"
     print 'Example'
-    print '\tkodi-send --host=192.168.0.1 --port=9777 --action="XBMC.Quit"'
+    print '\tkodi-send --host=192.168.0.1 --port=9777 --action="Quit"'
     print "Options"
     print "\t-?, --help\t\t\tWill bring up this message"
     print "\t--host=HOST\t\t\tChoose what HOST to connect to (default=localhost)"

--- a/tools/EventClients/examples/python/example_action.py
+++ b/tools/EventClients/examples/python/example_action.py
@@ -27,7 +27,7 @@ def main():
             xbmc.send_action(sys.argv[1], ACTION_EXECBUILTIN)
         except Exception, e:
             print str(e)
-            xbmc.send_action("XBMC.ActivateWindow(ShutdownMenu)")
+            xbmc.send_action("ActivateWindow(ShutdownMenu)")
     
 
     # ok we're done, close the connection

--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -351,7 +351,7 @@ bool CAutorun::RunDisc(IDirectory* pDir, const CStdString& strDrive, int& nAdded
               && (bypassSettings))
         {
           bPlaying = true;
-          CStdString strExec = StringUtils::Format("XBMC.RecursiveSlideShow(%s)", pItem->GetPath().c_str());
+          CStdString strExec = StringUtils::Format("RecursiveSlideShow(%s)", pItem->GetPath().c_str());
           CBuiltins::Execute(strExec);
           return true;
         }
@@ -428,7 +428,7 @@ bool CAutorun::RunDisc(IDirectory* pDir, const CStdString& strDrive, int& nAdded
       if (!pItem->m_bIsFolder && pItem->IsPicture())
       {
         bPlaying = true;
-        CStdString strExec = StringUtils::Format("XBMC.RecursiveSlideShow(%s)", strDrive.c_str());
+        CStdString strExec = StringUtils::Format("RecursiveSlideShow(%s)", strDrive.c_str());
         CBuiltins::Execute(strExec);
         break;
       }

--- a/xbmc/input/ButtonTranslator.h
+++ b/xbmc/input/ButtonTranslator.h
@@ -39,7 +39,7 @@ class TiXmlNode;
 struct CButtonAction
 {
   int id;
-  std::string strID; // needed for "XBMC.ActivateWindow()" type actions
+  std::string strID; // needed for "ActivateWindow()" type actions
 };
 ///
 /// singleton class to map from buttons to actions

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -258,7 +258,7 @@ void CBuiltins::GetHelp(std::string &help)
 
 int CBuiltins::Execute(const std::string& execString)
 {
-  // Get the text after the "XBMC."
+  // Deprecated. Get the text after the "XBMC."
   std::string execute;
   vector<string> params;
   CUtil::SplitExecFunction(execString, execute, params);
@@ -545,7 +545,7 @@ int CBuiltins::Execute(const std::string& execString)
       g_RarManager.ExtractArchive(params[0],strDestDirect);
 #endif
     else
-      CLog::Log(LOGERROR, "XBMC.Extract, No archive given");
+      CLog::Log(LOGERROR, "Extract, No archive given");
   }
   else if (execute == "runplugin")
   {
@@ -560,7 +560,7 @@ int CBuiltins::Execute(const std::string& execString)
     }
     else
     {
-      CLog::Log(LOGERROR, "XBMC.RunPlugin called with no arguments.");
+      CLog::Log(LOGERROR, "RunPlugin called with no arguments.");
     }
   }
   else if (execute == "runaddon")
@@ -614,7 +614,7 @@ int CBuiltins::Execute(const std::string& execString)
     }
     else
     {
-      CLog::Log(LOGERROR, "XBMC.RunAddon called with no arguments.");
+      CLog::Log(LOGERROR, "RunAddon called with no arguments.");
     }
   }
   else if (execute == "notifyall")
@@ -628,13 +628,13 @@ int CBuiltins::Execute(const std::string& execString)
       ANNOUNCEMENT::CAnnouncementManager::Get().Announce(ANNOUNCEMENT::Other, params[0].c_str(), params[1].c_str(), data);
     }
     else
-      CLog::Log(LOGERROR, "XBMC.NotifyAll needs two parameters");
+      CLog::Log(LOGERROR, "NotifyAll needs two parameters");
   }
   else if (execute == "playmedia")
   {
     if (!params.size())
     {
-      CLog::Log(LOGERROR, "XBMC.PlayMedia called with empty parameter");
+      CLog::Log(LOGERROR, "PlayMedia called with empty parameter");
       return -3;
     }
 
@@ -733,7 +733,7 @@ int CBuiltins::Execute(const std::string& execString)
       // play media
       if (!g_application.PlayMedia(item, playlist))
       {
-        CLog::Log(LOGERROR, "XBMC.PlayMedia could not play media: %s", params[0].c_str());
+        CLog::Log(LOGERROR, "PlayMedia could not play media: %s", params[0].c_str());
         return false;
       }
     }
@@ -742,7 +742,7 @@ int CBuiltins::Execute(const std::string& execString)
   {
     if (!params.size())
     {
-      CLog::Log(LOGERROR, "XBMC.ShowPicture called with empty parameter");
+      CLog::Log(LOGERROR, "ShowPicture called with empty parameter");
       return -2;
     }
     CGUIMessage msg(GUI_MSG_SHOW_PICTURE, 0, 0);
@@ -754,7 +754,7 @@ int CBuiltins::Execute(const std::string& execString)
   {
     if (!params.size())
     {
-      CLog::Log(LOGERROR, "XBMC.SlideShow called with empty parameter");
+      CLog::Log(LOGERROR, "SlideShow called with empty parameter");
       return -2;
     }
     std::string beginSlidePath;
@@ -810,7 +810,7 @@ int CBuiltins::Execute(const std::string& execString)
     g_application.WakeUpScreenSaverAndDPMS();
     if (!params.size())
     {
-      CLog::Log(LOGERROR, "XBMC.PlayerControl called with empty parameter");
+      CLog::Log(LOGERROR, "PlayerControl called with empty parameter");
       return -3;
     }
     if (paramlow ==  "play")
@@ -1441,7 +1441,7 @@ int CBuiltins::Execute(const std::string& execString)
       if (!g_application.IsVideoScanning())
          g_application.StartVideoCleanup(userInitiated);
       else
-        CLog::Log(LOGERROR, "XBMC.CleanLibrary is not possible while scanning or cleaning");
+        CLog::Log(LOGERROR, "CleanLibrary is not possible while scanning or cleaning");
     }
     else if (StringUtils::EqualsNoCase(params[0], "music"))
     {
@@ -1454,7 +1454,7 @@ int CBuiltins::Execute(const std::string& execString)
         musicdatabase.Close();
       }
       else
-        CLog::Log(LOGERROR, "XBMC.CleanLibrary is not possible while scanning for media info");
+        CLog::Log(LOGERROR, "CleanLibrary is not possible while scanning for media info");
     }
   }
   else if (execute == "exportlibrary" && !params.empty())

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -288,7 +288,7 @@ namespace XBMCAddon
        *        Once you use a keyword, all following arguments require the keyword.\n
        * \n
        * example:
-       *   - listitem.addContextMenuItems([('Theater Showtimes', 'XBMC.RunScript(special://home/scripts/showtimes/default.py,Iron Man)',)])n
+       *   - listitem.addContextMenuItems([('Theater Showtimes', 'RunScript(special://home/scripts/showtimes/default.py,Iron Man)',)])n
        */
       void addContextMenuItems(const std::vector<Tuple<String,String> >& items, bool replaceItems = false) throw (ListItemException);
 

--- a/xbmc/interfaces/legacy/ModuleXbmc.h
+++ b/xbmc/interfaces/legacy/ModuleXbmc.h
@@ -89,7 +89,7 @@ namespace XBMCAddon
      * List of functions - http://wiki.xbmc.org/?title=List_of_Built_In_Functions 
      * 
      * example:
-     *   - xbmc.executebuiltin('XBMC.RunXBE(c:\\avalaunch.xbe)')
+     *   - xbmc.executebuiltin('RunXBE(c:\\avalaunch.xbe)')
      */
     void executebuiltin(const char* function, bool wait = false);
 

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -129,9 +129,9 @@ void CPVRManager::OnSettingChanged(const CSetting *setting)
   if (settingId == "pvrmanager.enabled")
   {
     if (((CSettingBool*)setting)->GetValue())
-      CApplicationMessenger::Get().ExecBuiltIn("XBMC.StartPVRManager", false);
+      CApplicationMessenger::Get().ExecBuiltIn("StartPVRManager", false);
     else
-      CApplicationMessenger::Get().ExecBuiltIn("XBMC.StopPVRManager", false);
+      CApplicationMessenger::Get().ExecBuiltIn("StopPVRManager", false);
   }
   else if (settingId == "pvrparental.enabled")
   {


### PR DESCRIPTION
The use of the 'XBMC.' prefix has been deprecated ages ago.
In the light of our name change, let's remove it wherever it is still used.
