### PR TITLE
[win32] Dont delete AppData folder

### DIFF
--- a/project/Win32BuildSetup/genNsisInstaller.nsi
+++ b/project/Win32BuildSetup/genNsisInstaller.nsi
@@ -352,15 +352,6 @@ Section "Uninstall"
   ${If} $UnPageProfileCheckbox_State == ${BST_CHECKED}
     RMDir /r "$APPDATA\${APP_NAME}\"
     RMDir /r "$INSTDIR\portable_data\"
-  ${Else}
-    ;Check if %appdata%\${APP_NAME}\userdata and portable_data contain no guisettings.xml
-    ;If that file does not exists, then delete those folders and $INSTDIR
-    IfFileExists $INSTDIR\portable_data\userdata\guisettings.xml +2
-      RMDir /r "$INSTDIR\portable_data\"
-      RMDir "$INSTDIR\"
-    IfFileExists "$APPDATA\${APP_NAME}\userdata\guisettings.xml" +2
-      RMDir /r "$APPDATA\${APP_NAME}\userdata\"
-      RMDir "$APPDATA\${APP_NAME}"
   ${EndIf}
   RMDir "$INSTDIR"
 


### PR DESCRIPTION
As discussed on IRC with @MartijnKaijser.
This removes the check for a guisettings.xml upon uninstall / install and consequential deleting of the install and appdata folder if it wasn't found. Particular use case where this bit caused problems: upon installation of Kodi, it would remove the Kodi folder in AppData if that folder was a symbolic link.
