### PR TITLE
Use "system.playlistspath" setting instead of default library one in CFileUtils

### DIFF
--- a/xbmc/utils/FileUtils.cpp
+++ b/xbmc/utils/FileUtils.cpp
@@ -32,6 +32,7 @@
 #include "Util.h"
 #include "StringUtils.h"
 #include "URL.h"
+#include "settings/Settings.h"
 
 using namespace XFILE;
 using namespace std;
@@ -142,6 +143,13 @@ bool CFileUtils::RemoteAccessAllowed(const CStdString &strPath)
     return true;
   else if (StringUtils::StartsWithNoCase(realPath, "plugin://"))
     return true;
+  else
+  {
+    std::string strPlaylistsPath = CSettings::Get().GetString("system.playlistspath");
+    URIUtils::RemoveSlashAtEnd(strPlaylistsPath);
+    if (StringUtils::StartsWithNoCase(realPath, strPlaylistsPath)) 
+      return true;
+  }
   bool isSource;
   for (unsigned int index = 0; index < SourcesSize; index++)
   {


### PR DESCRIPTION
I find out in two classes "special://profile/playlists" string is used instead of the setting option "system.playlistspath" to check if it's the playlist path.
This pull fixes FileUtils playlists that results as not allowed to access from remote so you can't load playlists with "Files.GetDirectory".
