### PR TITLE
Invalidate path hash on remove so the infoscanner can pick it up again

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -3193,14 +3193,13 @@ void CVideoDatabase::DeleteMovie(int idMovie, bool bKeepId /* = false */)
     // the ancilliary tables are still purged
     if (!bKeepId)
     {
-      strSQL=PrepareSQL("delete from movie where idMovie=%i", idMovie);
-      m_pDS->exec(strSQL.c_str());
-
-      // TODO: Why are we invalidating paths here?
       int idFile = GetDbId(PrepareSQL("SELECT idFile FROM movie WHERE idMovie=%i", idMovie));
       std::string path = GetSingleValue(PrepareSQL("SELECT strPath FROM path JOIN files ON files.idPath=path.idPath WHERE files.idFile=%i", idFile));
       if (!path.empty())
         InvalidatePathHash(path);
+
+      strSQL=PrepareSQL("delete from movie where idMovie=%i", idMovie);
+      m_pDS->exec(strSQL.c_str());
     }
 
     //TODO: move this below CommitTransaction() once UPnP doesn't rely on this anymore

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -3402,14 +3402,13 @@ void CVideoDatabase::DeleteMusicVideo(int idMVideo, bool bKeepId /* = false */)
     // the ancilliary tables are still purged
     if (!bKeepId)
     {
-      strSQL=PrepareSQL("delete from musicvideo where idMVideo=%i", idMVideo);
-      m_pDS->exec(strSQL.c_str());
-
-      // TODO: Why are we invalidating paths here?
       int idFile = GetDbId(PrepareSQL("SELECT idFile FROM musicvideo WHERE idMVideo=%i", idMVideo));
       std::string path = GetSingleValue(PrepareSQL("SELECT strPath FROM path JOIN files ON files.idPath=path.idPath WHERE files.idFile=%i", idFile));
       if (!path.empty())
         InvalidatePathHash(path);
+
+      strSQL=PrepareSQL("delete from musicvideo where idMVideo=%i", idMVideo);
+      m_pDS->exec(strSQL.c_str());
     }
 
     //TODO: move this below CommitTransaction() once UPnP doesn't rely on this anymore


### PR DESCRIPTION
This fixes an issue reported on the forums where a removed movie item is not picked up by the update library routine because you can't query a previously removed fileId :)

Fix for episodes and tvshows has to be done separately as it's a lot more complicated and I don't want to add yet another regression to the upcoming Helix betas at this point.

Bug report @ http://forum.kodi.tv/showthread.php?tid=207452
Regression introduced with a32dcc1933e8568fb6107e634b9e933f96d72864 and some other refactoring (movie vs movieview)

@Montellese, @topfs2 for review please.
