### PR TITLE
[CEC] fixed: re-enable CEC logging by default

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2751,12 +2751,12 @@
         </setting>
         <setting id="debug.extralogging" type="boolean" label="666" help="36394">
           <level>1</level>
-          <default>false</default>
+          <default>true</default>
           <control type="toggle" />
         </setting>
         <setting id="debug.setextraloglevel" type="list[integer]" parent="debug.extralogging" label="668" help="36534">
           <level>1</level>
-          <default></default>
+          <default>32768</default>
           <constraints>
             <options>loggingcomponents</options>
             <delimiter>,</delimiter>

--- a/system/settings/settings.xml~
+++ b/system/settings/settings.xml~
@@ -2756,7 +2756,7 @@
         </setting>
         <setting id="debug.setextraloglevel" type="list[integer]" parent="debug.extralogging" label="668" help="36534">
           <level>1</level>
-          <default>32,64,128,256,512,1024,2048,4096,16384,32768</default>
+          <default>65535</default>
           <constraints>
             <options>loggingcomponents</options>
             <delimiter>,</delimiter>

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -1185,7 +1185,7 @@ int CPeripheralCecAdapter::CecLogMessage(void *cbParam, const cec_log_message me
     break;
   }
 
-  if (iLevel >= CEC_LOG_NOTICE || (iLevel >= 0 && g_advancedSettings.CanLogComponent(LOGCEC)))
+  if (iLevel >= CEC_LOG_NOTICE || (iLevel >= 0 && CLog::IsLogLevelLogged(LOGDEBUG) && g_advancedSettings.CanLogComponent(LOGCEC)))
     CLog::Log(iLevel, "%s - %s", __FUNCTION__, message.message);
 
   return 1;


### PR DESCRIPTION
It can still be disabled for people who don't want to see CEC logging, but it'll now be enabled again by default when debugging is enabled, like it was in Gotham.
