### PR TITLE
[confluence] fix default focus in ProfileSettings.xml (fixes #15507)

### DIFF
--- a/addons/skin.confluence/720p/ProfileSettings.xml
+++ b/addons/skin.confluence/720p/ProfileSettings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
-	<defaultcontrol>1</defaultcontrol>
 	<coordinates>
 		<system>1</system>
 		<left>290</left>


### PR DESCRIPTION
This fixes http://trac.xbmc.org/ticket/15507. Right now no control is focused when opening a CGUIDialogProfileSettings dialog because of an invalid `<defaultcontrol>` definition in Confluence's ProfileSettings.xml. There's no control with ID `1` in CGUIDialogProfileSettings and CGUIDialogSettingsBase (from which CGUIDilaogProfileSettings is derived (indirectly)) already contains logic to automatically set the focus to the first control in the list.

The only thing I'm wondering about is whether it should be possible to focus the image control. But it looks like there's no logic in CGUIDialogProfileSettings that would allow a user to choose a different profile image.

@ronie for review please.
