### PR TITLE
revert b6bec7a

### DIFF
--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -1044,8 +1044,7 @@ bool CPVRClients::UpdateAddons(void)
   for (unsigned iClientPtr = 0; iClientPtr < m_addons.size(); iClientPtr++)
   {
     const AddonPtr clientAddon = m_addons.at(iClientPtr);
-    bool newRegistration = false;
-    if (RegisterClient(clientAddon, &newRegistration) < 0 || newRegistration)
+    if (RegisterClient(clientAddon) < 0)
     {
       CAddonMgr::Get().DisableAddon(clientAddon->ID(), true);
       usableClients--;


### PR DESCRIPTION
this reverts upstream commit b6bec7a (part of xbmc/pull/4761):

> From b6bec7a44fec728c28aa0cedc96288539a71e324 Mon Sep 17 00:00:00 2001
> From: Trent Nelson trent.nelson@pivosgroup.com
> Date: Wed, 21 May 2014 17:16:54 +0800
> Subject: [PATCH] [PVR] Make sure client addons are disabled first time we see
>  them.

xbmc/pull/4761 fixed a bug where newly added pvr clients were automaticaly
enabled and could not be disabled first time an user tries to disable em.

unfortunately, it introduces a regression, now "reset pvr database" is useless
and leaves the user with no pvr clients enabled at all.

however, the "oh-i-can-not-disable-pvr-addons" bug I can not reproduce
anymore, but this commit may re-introduce it for some users.

for details on the regression please look at https://github.com/xbmc/xbmc/pull/4761#issuecomment-52103319

I did not intend to PR this, but I've been asked to. please note that I am not a coder at all, this could be wrong as hell, but it fixes an annoying regression for me, IMO it's better to have an old bug (the annoying part of the old bug I can not reproduce anymore) than introducing new one..

ping @opdenkamp @t-nelson
