### PR TITLE
[rebrand] - change default username of webserver from xbmc to kodi

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2030,10 +2030,13 @@
         </setting>
         <setting id="services.webserverusername" type="string" parent="services.webserver" label="1048" help="36330">
           <level>1</level>
-          <default>xbmc</default>
+          <default>kodi</default>
           <constraints>
             <allowempty>true</allowempty>
           </constraints>
+          <updates>
+            <update type="change" />
+          </updates>
           <dependencies>
             <dependency type="enable" setting="services.webserver">true</dependency>
           </dependencies>

--- a/xbmc/network/NetworkServices.cpp
+++ b/xbmc/network/NetworkServices.cpp
@@ -400,6 +400,27 @@ void CNetworkServices::OnSettingChanged(const CSetting *setting)
   }
 }
 
+bool CNetworkServices::OnSettingUpdate(CSetting* &setting, const char *oldSettingId, const TiXmlNode *oldSettingNode)
+{
+  if (setting == NULL)
+    return false;
+
+  const std::string &settingId = setting->GetId();
+  if (settingId == "services.webserverusername")
+  {
+    CSettingString *webserverusername = (CSettingString*)setting;
+    // if webserverusername is xbmc and pw is empty we treat it as unaltered
+    // and change the username to kodi - part of rebrand
+    if (CSettings::Get().GetString("services.webserverusername") == "xbmc &&
+        CSettings::Get().GetString("services.webserverpassword").empty())
+    {
+      webserverusername->Reset();//reset to default which is kodi atm...
+      return true;
+    }
+  }
+  return false;
+}
+
 void CNetworkServices::Start()
 {
   StartZeroconf();

--- a/xbmc/network/NetworkServices.h
+++ b/xbmc/network/NetworkServices.h
@@ -42,6 +42,7 @@ public:
   
   virtual bool OnSettingChanging(const CSetting *setting);
   virtual void OnSettingChanged(const CSetting *setting);
+  virtual bool OnSettingUpdate(CSetting* &setting, const char *oldSettingId, const TiXmlNode *oldSettingNode);
 
   void Start();
   void Stop(bool bWait);


### PR DESCRIPTION
no brainer (no need for jenkins).

I just realised that when using a plain new install of kodi and adding it to my official xbmc remote (i was like "no" when having to add "xbmc" as username :D).

@Montellese this is your button :)
