### PR TITLE
Change APP_HOME -> KODI_HOME and other APP_* -> KODI_*

### DIFF
--- a/docs/README.osx
+++ b/docs/README.osx
@@ -140,16 +140,16 @@ binaries from git that might cause problems.
 -----------------------------------------------------------------------------
 Start XCode and open the Kodi project (Kodi.xcodeproj) located in $HOME/Kodi.
 For development, Kodi is run from the $HOME/Kodi directory and needs to have
-the APP_HOME environment variable set to know where that directory is located.
-To set APP_HOME environment variable:
+the KODI_HOME environment variable set to know where that directory is located.
+To set KODI_HOME environment variable:
 
 Xcode 3.2.6
  Menu -> Project -> Edit Active Executable "Kodi", click "Arguments" tab and
- add "APP_HOME" as an enviroment variable. Set the value to the path to the
+ add "KODI_HOME" as an enviroment variable. Set the value to the path to the
  Kodi root folder. For example, "/Users/bigdog/Documents/Kodi"
 
 Xcode 4.3.x and later
- Menu -> Product -> Edit Sheme -> "Run Kodi"/"Debug" -> Add APP_HOME into
+ Menu -> Product -> Edit Sheme -> "Run Kodi"/"Debug" -> Add KODI_HOME into
  the List of "Environment Variables". Set the value to the path to the Kodi
  root folder. For example, "/Users/bigdog/Documents/Kodi"	
 
@@ -173,7 +173,7 @@ subsequent builds will be faster.
 
 After the build, you can ether run Kodi for Mac from Xcode or run it from
 the command-line. If you run it from the command-line, make sure your set
-the APP_HOME environment variable (export APP_HOME=$HOME/Kodi). Then, to
+the KODI_HOME environment variable (export KODI_HOME=$HOME/Kodi). Then, to
 run the debug version:
 
 $ ./build/Debug/Kodi
@@ -203,14 +203,14 @@ developers).
 
  a)
  $ cd $HOME/Kodi
- $ export APP_HOME=`pwd`
+ $ export KODI_HOME=`pwd`
  $ make xcode_depends
  $ xcodebuild -sdk macosx10.7 -project Kodi.xcodeproj -target Kodi.app ONLY_ACTIVE_ARCH=YES \
    ARCHS=x86_64 VALID_ARCHS=x86_64  -configuration Release build
 
  b) building via make
  $ cd $HOME/Kodi
- $ export APP_HOME=`pwd`
+ $ export KODI_HOME=`pwd`
  $ make
  $ ./Kodi.bin
 

--- a/project/VS2010Express/XBMC.defaults.props
+++ b/project/VS2010Express/XBMC.defaults.props
@@ -7,7 +7,7 @@
   <PropertyGroup>
     <IncludePath>$(SolutionDir)\..\BuildDependencies\include;$(SolutionDir)\..\BuildDependencies\include\python;$(IncludePath)</IncludePath>
     <ExecutablePath>$(SolutionDir)\..\..\tools\win32buildtools;$(ExecutablePath)</ExecutablePath>
-    <LocalDebuggerEnvironment>APP_HOME=$(SolutionDir)..\..&#xD;&#xA;PATH=$(SolutionDir)..\Win32BuildSetup\dependencies;%PATH%</LocalDebuggerEnvironment>
+    <LocalDebuggerEnvironment>KODI_HOME=$(SolutionDir)..\..&#xD;&#xA;PATH=$(SolutionDir)..\Win32BuildSetup\dependencies;%PATH%</LocalDebuggerEnvironment>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/tools/EventClients/Clients/OSXRemote/XBMCHelper.m
+++ b/tools/EventClients/Clients/OSXRemote/XBMCHelper.m
@@ -268,7 +268,7 @@
   NSFileManager *fileManager = [NSFileManager defaultManager];
   if([fileManager fileExistsAtPath:mp_app_path]){
     if(mp_home_path && [mp_home_path length])
-      setenv("APP_HOME", [mp_home_path UTF8String], 1);
+      setenv("KODI_HOME", [mp_home_path UTF8String], 1);
     //launch or activate xbmc
     if(![[NSWorkspace sharedWorkspace] launchApplication:mp_app_path])
       ELOG(@"Error launching %@", mp_app_path);

--- a/tools/Linux/kodi.sh.in
+++ b/tools/Linux/kodi.sh.in
@@ -104,8 +104,8 @@ print_crash_report()
     fi
     single_stacktrace "$PWD" 1
     # Find in plugins directories
-    if [ $APP_HOME ]; then
-      BASEDIR=$APP_HOME
+    if [ $KODI_HOME ]; then
+      BASEDIR=$KODI_HOME
     else
       BASEDIR="$LIBDIR/${bin_name}/"
     fi

--- a/tools/darwin/runtime/preflight
+++ b/tools/darwin/runtime/preflight
@@ -3,16 +3,16 @@
 die("No HOME set, cannot install defaults.\n")
     if !$ENV{'HOME'};
 
-die("No APP_HOME set, cannot install defaults.\n")
-    if !$ENV{'APP_HOME'};
+die("No KODI_HOME set, cannot install defaults.\n")
+    if !$ENV{'KODI_HOME'};
 
 sub get_home {
     return $ENV{'HOME'} if defined $ENV{'HOME'};
 }
 
 sub get_extras {
-    # APP_HOME is assumed to be always setup
-    return $ENV{'APP_HOME'}."/extras/" if get_os() eq "osx";
+    # KODI_HOME is assumed to be always setup
+    return $ENV{'KODI_HOME'}."/extras/" if get_os() eq "osx";
     return;
 }
 

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -587,7 +587,7 @@ void CApplication::Preflight()
   CStdString install_path;
 
   CUtil::GetHomePath(install_path);
-  setenv("APP_HOME", install_path.c_str(), 0);
+  setenv("KODI_HOME", install_path.c_str(), 0);
   install_path += "/tools/darwin/runtime/preflight";
   system(install_path.c_str());
 #endif
@@ -1078,9 +1078,9 @@ bool CApplication::InitDirectoriesLinux()
   std::string appName = CCompileInfo::GetAppName();
   std::string dotLowerAppName = "." + appName;
   StringUtils::ToLower(dotLowerAppName);
-  const char* envAppHome = "APP_HOME";
-  const char* envAppBinHome = "APP_BIN_HOME";
-  const char* envAppTemp = "APP_TEMP";
+  const char* envAppHome = "KODI_HOME";
+  const char* envAppBinHome = "KODI_BIN_HOME";
+  const char* envAppTemp = "KODI_TEMP";
 
 
   CUtil::GetHomePath(appBinPath, envAppBinHome);
@@ -1171,7 +1171,7 @@ bool CApplication::InitDirectoriesOSX()
 
   std::string appPath;
   CUtil::GetHomePath(appPath);
-  setenv("APP_HOME", appPath.c_str(), 0);
+  setenv("KODI_HOME", appPath.c_str(), 0);
 
 #if defined(TARGET_DARWIN_IOS)
   CStdString fontconfigPath;
@@ -1251,7 +1251,7 @@ bool CApplication::InitDirectoriesWin32()
   CStdString xbmcPath;
 
   CUtil::GetHomePath(xbmcPath);
-  CEnvironment::setenv("APP_HOME", xbmcPath);
+  CEnvironment::setenv("KODI_HOME", xbmcPath);
   CSpecialProtocol::SetXBMCBinPath(xbmcPath);
   CSpecialProtocol::SetXBMCPath(xbmcPath);
 
@@ -1262,7 +1262,7 @@ bool CApplication::InitDirectoriesWin32()
   CSpecialProtocol::SetMasterProfilePath(URIUtils::AddFileToFolder(strWin32UserFolder, "userdata"));
   CSpecialProtocol::SetTempPath(URIUtils::AddFileToFolder(strWin32UserFolder,"cache"));
 
-  CEnvironment::setenv("APP_PROFILE_USERDATA", CSpecialProtocol::TranslatePath("special://masterprofile/"));
+  CEnvironment::setenv("KODI_PROFILE_USERDATA", CSpecialProtocol::TranslatePath("special://masterprofile/"));
 
   CreateUserDirs();
 

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -405,7 +405,10 @@ void CUtil::RunShortcut(const char* szShortcutPath)
 
 void CUtil::GetHomePath(std::string& strPath, const std::string& strTarget)
 {
-  strPath = CEnvironment::getenv(strTarget);
+  if (strTarget.empty())
+    strPath = CEnvironment::getenv("KODI_HOME");
+  else
+    strPath = CEnvironment::getenv(strTarget);
 
 #ifdef TARGET_WINDOWS
   if (strPath.find("..") != std::string::npos)
@@ -471,13 +474,13 @@ void CUtil::GetHomePath(std::string& strPath, const std::string& strTarget)
   }
 
 #if defined(TARGET_POSIX) && !defined(TARGET_DARWIN)
-  /* Change strPath accordingly when target is APP_HOME and when INSTALL_PATH
+  /* Change strPath accordingly when target is KODI_HOME and when INSTALL_PATH
    * and BIN_INSTALL_PATH differ
    */
   std::string installPath = INSTALL_PATH;
   std::string binInstallPath = BIN_INSTALL_PATH;
 
-  if (!strTarget.compare("APP_HOME") && installPath.compare(binInstallPath))
+  if (strTarget.empty() && installPath.compare(binInstallPath))
   {
     int pos = strPath.length() - binInstallPath.length();
     CStdString tmp = strPath;

--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -73,7 +73,7 @@ public:
   static CStdString GetTitleFromPath(const CStdString& strFileNameAndPath, bool bIsFolder = false);
   static void GetQualifiedFilename(const std::string &strBasePath, std::string &strFilename);
   static void RunShortcut(const char* szPath);
-  static void GetHomePath(std::string& strPath, const std::string& strTarget = "APP_HOME");
+  static void GetHomePath(std::string& strPath, const std::string& strTarget = ""); // default target is "KODI_HOME"
   static bool IsPVR(const CStdString& strFile);
   static bool IsHTSP(const CStdString& strFile);
   static bool IsLiveTV(const CStdString& strFile);

--- a/xbmc/android/activity/XBMCApp.cpp
+++ b/xbmc/android/activity/XBMCApp.cpp
@@ -619,13 +619,13 @@ void CXBMCApp::SetupEnv()
   if (xbmcHome.empty())
   {
     std::string cacheDir = getCacheDir().getAbsolutePath();
-    setenv("APP_BIN_HOME", (cacheDir + "/apk/assets").c_str(), 0);
-    setenv("APP_HOME", (cacheDir + "/apk/assets").c_str(), 0);
+    setenv("KODI_BIN_HOME", (cacheDir + "/apk/assets").c_str(), 0);
+    setenv("KODI_HOME", (cacheDir + "/apk/assets").c_str(), 0);
   }
   else
   {
-    setenv("APP_BIN_HOME", (xbmcHome + "/assets").c_str(), 0);
-    setenv("APP_HOME", (xbmcHome + "/assets").c_str(), 0);
+    setenv("KODI_BIN_HOME", (xbmcHome + "/assets").c_str(), 0);
+    setenv("KODI_HOME", (xbmcHome + "/assets").c_str(), 0);
   }
 
   std::string externalDir = CJNISystem::getProperty("xbmc.data", "");
@@ -642,7 +642,7 @@ void CXBMCApp::SetupEnv()
   if (!externalDir.empty())
     setenv("HOME", externalDir.c_str(), 0);
   else
-    setenv("HOME", getenv("APP_TEMP"), 0);
+    setenv("HOME", getenv("KODI_TEMP"), 0);
 }
 
 std::string CXBMCApp::GetFilenameFromIntent(const CJNIIntent &intent)

--- a/xbmc/osx/XBMCHelper.cpp
+++ b/xbmc/osx/XBMCHelper.cpp
@@ -67,7 +67,7 @@ XBMCHelper::XBMCHelper()
   , m_port(0)
   , m_errorStarting(false)
 {
-  // Compute the APP_HOME path.
+  // Compute the KODI_HOME path.
   CStdString homePath;
   CUtil::GetHomePath(homePath);
   m_homepath = homePath;

--- a/xbmc/windowing/X11/XRandR.cpp
+++ b/xbmc/windowing/X11/XRandR.cpp
@@ -55,7 +55,7 @@ bool CXRandR::Query(bool force, bool ignoreoff)
 
   m_bInit = true;
 
-  if (getenv("APP_BIN_HOME") == NULL)
+  if (getenv("KODI_BIN_HOME") == NULL)
     return false;
 
   m_outputs.clear();
@@ -75,9 +75,9 @@ bool CXRandR::Query(bool force, int screennum, bool ignoreoff)
   std::string cmd;
   std::string appname = CCompileInfo::GetAppName();
   StringUtils::ToLower(appname);
-  if (getenv("APP_BIN_HOME"))
+  if (getenv("KODI_BIN_HOME"))
   {
-    cmd  = getenv("APP_BIN_HOME");
+    cmd  = getenv("KODI_BIN_HOME");
     cmd += "/" + appname + "-xrandr";
     cmd = StringUtils::Format("%s -q --screen %d", cmd.c_str(), screennum);
   }
@@ -163,9 +163,9 @@ bool CXRandR::TurnOffOutput(CStdString name)
   std::string appname = CCompileInfo::GetAppName();
   StringUtils::ToLower(appname);
 
-  if (getenv("APP_BIN_HOME"))
+  if (getenv("KODI_BIN_HOME"))
   {
-    cmd  = getenv("APP_BIN_HOME");
+    cmd  = getenv("KODI_BIN_HOME");
     cmd += "/" + appname + "-xrandr";
     cmd = StringUtils::Format("%s --screen %d --output %s --off", cmd.c_str(), output->screen, name.c_str());
   }
@@ -328,8 +328,10 @@ bool CXRandR::SetMode(XOutput output, XMode mode)
   StringUtils::ToLower(appname);
   char cmd[255];
 
-  if (getenv("APP_BIN_HOME"))
-    snprintf(cmd, sizeof(cmd), "%s/%s-xrandr --screen %d --output %s --mode %s", getenv("APP_BIN_HOME"),appname.c_str(), outputFound.screen, outputFound.name.c_str(), modeFound.id.c_str());
+  if (getenv("KODI_BIN_HOME"))
+    snprintf(cmd, sizeof(cmd), "%s/%s-xrandr --screen %d --output %s --mode %s", 
+               getenv("KODI_BIN_HOME"),appname.c_str(),
+               outputFound.screen, outputFound.name.c_str(), modeFound.id.c_str());
   else
     return false;
   CLog::Log(LOGINFO, "XRANDR: %s", cmd);
@@ -419,9 +421,9 @@ void CXRandR::LoadCustomModeLinesToAllOutputs(void)
     std::string appname = CCompileInfo::GetAppName();
     StringUtils::ToLower(appname);
 
-    if (getenv("APP_BIN_HOME"))
+    if (getenv("KODI_BIN_HOME"))
     {
-      snprintf(cmd, sizeof(cmd), "%s/%s-xrandr --newmode \"%s\" %s > /dev/null 2>&1", getenv("APP_BIN_HOME"),
+      snprintf(cmd, sizeof(cmd), "%s/%s-xrandr --newmode \"%s\" %s > /dev/null 2>&1", getenv("KODI_BIN_HOME"),
                appname.c_str(), name.c_str(), strModeLine.c_str());
       if (system(cmd) != 0)
         CLog::Log(LOGERROR, "Unable to create modeline \"%s\"", name.c_str());
@@ -429,9 +431,9 @@ void CXRandR::LoadCustomModeLinesToAllOutputs(void)
 
     for (unsigned int i = 0; i < m_outputs.size(); i++)
     {
-      if (getenv("APP_BIN_HOME"))
+      if (getenv("KODI_BIN_HOME"))
       {
-        snprintf(cmd, sizeof(cmd), "%s/%s-xrandr --addmode %s \"%s\"  > /dev/null 2>&1", getenv("APP_BIN_HOME"),
+        snprintf(cmd, sizeof(cmd), "%s/%s-xrandr --addmode %s \"%s\"  > /dev/null 2>&1", getenv("KODI_BIN_HOME"),
                  appname.c_str(), m_outputs[i].name.c_str(), name.c_str());
         if (system(cmd) != 0)
           CLog::Log(LOGERROR, "Unable to add modeline \"%s\"", name.c_str());


### PR DESCRIPTION
Extracted from #5560

This is the straight forward change from APP_\* env variables to KODI_\* env variables. As pointed out in the other PR the APP_\* might conflict with other apps in the future.

I know this is not generic - but it wasn't in the initial rebrand aswell. Imo we should focus on getting helix out and therefore cleanup the multiple method mess afterwards (i think karlson2k is on the best way - but there is no need to do it for helix).
