### PR TITLE
Fix processing "file://" protocols

### DIFF
--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -71,8 +71,12 @@ void CURL::Reset()
 void CURL::Parse(const std::string& strURL1)
 {
   Reset();
+  std::string strURL(strURL1);
+  if (strURL.compare(0, 7, "file://", 7) == 0)
+    strURL.erase(0, 7); // remove "file://" prefix, all local files are processed without protocol prefix
+
   // start by validating the path
-  std::string strURL = CUtil::ValidatePath(strURL1);
+  strURL = CUtil::ValidatePath(strURL);
 
   // strURL can be one of the following:
   // format 1: protocol://[username:password]@hostname[:port]/directoryandfile

--- a/xbmc/filesystem/posix/PosixFile.cpp
+++ b/xbmc/filesystem/posix/PosixFile.cpp
@@ -54,6 +54,8 @@ CPosixFile::~CPosixFile()
 // local helper
 static std::string getFilename(const CURL& url)
 {
+  assert(url.GetProtocol().empty()); // function suitable only for local files
+  
   std::string filename(url.GetFileName());
   if (IsAliasShortcut(filename))
     TranslateAliasShortcut(filename);

--- a/xbmc/filesystem/posix/PosixFile.cpp
+++ b/xbmc/filesystem/posix/PosixFile.cpp
@@ -54,7 +54,7 @@ CPosixFile::~CPosixFile()
 // local helper
 static std::string getFilename(const CURL& url)
 {
-  assert(url.GetProtocol().empty()); // function suitable only for local files
+  assert(url.GetProtocol().empty() || url.IsProtocol("file")); // function suitable only for local files
   
   std::string filename(url.GetFileName());
   if (IsAliasShortcut(filename))


### PR DESCRIPTION
Fix processing of generated by some addons pathnames in form "file://..."
This fixing handling in PosixFile, Win32File and Win32Directory.
