### PR TITLE
fixup 5f5d8c86490510f49b82d05ff16011bfbf4cbfa8; re-add default joystick map

### DIFF
--- a/tools/android/packaging/Makefile.in
+++ b/tools/android/packaging/Makefile.in
@@ -80,6 +80,7 @@ shared:
 	find `pwd`/assets/system/ -name "*.so" -exec rm {} \;
 	find `pwd`/assets/addons/skin.*/media/* -depth -not -iname "Textures.xbt" -exec rm -rf {} \;
 	find `pwd`/assets/system/keymaps/ -depth -name "joystick*.xml" ! -name "joystick.xml" -exec rm {} \;
+	mv -f `pwd`/assets/system/keymaps/joystick.xml.sample `pwd`/assets/system/keymaps/joystick.xml
 	cd assets; rm -rf $(EXCLUDED_ADDONS)
 
 sharedapk: shared | xbmc/assets


### PR DESCRIPTION
@topfs2 fixup from the obb commit :(
