### PR TITLE
[videodatabase] speed up the video database cleanup for archives

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -7977,6 +7977,10 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const se
       if (URIUtils::IsStack(fullPath))
         fullPath = CStackDirectory::GetFirstStackedFile(fullPath);
 
+      // get the actual archive path
+      if (URIUtils::IsInArchive(fullPath))
+        fullPath = CURL(fullPath).GetHostName();
+
       // remove optical, non-existing files
       if (URIUtils::IsOnDVD(fullPath) || !CFile::Exists(fullPath, false))
         filesToTestForDelete += m_pDS->fv("files.idFile").get_asString() + ",";


### PR DESCRIPTION
Testing the actual archive path is way faster than diving into it and performing the existence check. The actual logic behind the cleanup is not altered as this only changes the path checked by `CFile::Exists`.
This commit speeds up the video database cleanup routine dramatically in case the library contains 'archived' content.

@Montellese, @topfs2 for quick review please. I'd love to see this in Helix ;)
