### PR TITLE
Use APP_NAME_LC for generating the android library

### DIFF
--- a/tools/android/packaging/Makefile.in
+++ b/tools/android/packaging/Makefile.in
@@ -144,7 +144,7 @@ apk-sign:
 	@rm images/@APP_NAME_LC@app-debug-$(CPU)-unaligned.apk
 	@echo "$(XBMCROOT)/@APP_NAME_LC@app-$(CPU)-debug.apk created"
 
-$(PREFIX)/lib/xbmc/libxbmc.so: $(SRCLIBS)
+$(PREFIX)/lib/xbmc/lib@APP_NAME_LC@.so: $(SRCLIBS)
 	$(MAKE) -C ../../depends/target/xbmc
 
 $(SRCLIBS):


### PR DESCRIPTION
- Fix 5f5d8c864

Signed-off-by: Brandon McAnsh brandonm@matricom.net
