### PR TITLE
Fix app signing with certificate 'iPhone Developer'

### DIFF
--- a/tools/darwin/Support/Codesign.command
+++ b/tools/darwin/Support/Codesign.command
@@ -21,7 +21,7 @@ if [ "${PLATFORM_NAME}" == "iphoneos" ]; then
   codesign -v -f -s "iPhone Developer" --entitlements "${BUILT_PRODUCTS_DIR}/${WRAPPER_NAME}/${PROJECT_NAME}.xcent" "${BUILT_PRODUCTS_DIR}/${WRAPPER_NAME}/"
   
   #if user has set a code_sign_identity different from iPhone Developer we do a real codesign (for deployment on non-jailbroken devices)
-  if ! [ -z "${CODE_SIGN_IDENTITY}" ] && [ "${CODE_SIGN_IDENTITY}" != "iPhone Developer" ] && [ "${CODE_SIGN_IDENTITY}" != "Don't Code Sign"  ]; then
+  if ! [ -z "${CODE_SIGN_IDENTITY}" ] && [[ `codesign -s iPhone\ Developer:\  2>&1` != "iPhone Developer: : no identity found" ]] && [ "${CODE_SIGN_IDENTITY}" != "Don't Code Sign"  ]; then
     echo Doing a full bundle sign using genuine identity "${CODE_SIGN_IDENTITY}"
     for binext in $LIST_BINARY_EXTENSIONS
     do


### PR DESCRIPTION
The script now checks if there is a signing identity which looks like an official one inside the Keychain, e.g. `iPhone Developer: John Doe (12A3D5R6T7)`. If yes, let's do some real codesigning.
