### PR TITLE
[droid] set target SDK to 21and add Android 5.0 use-feature leanback

### DIFF
--- a/tools/android/packaging/xbmc/AndroidManifest.xml.in
+++ b/tools/android/packaging/xbmc/AndroidManifest.xml.in
@@ -6,7 +6,7 @@
     android:versionName="@APP_VERSION_MAJOR@.@APP_VERSION_MINOR@-@APP_VERSION_TAG@" >
 
     <!-- This is the platform API where NativeActivity was introduced. -->
-    <uses-sdk android:minSdkVersion="14" />
+    <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="21" />
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.INTERNET" />
@@ -19,6 +19,7 @@
     <uses-feature android:name="android.hardware.type.television" android:required="false" />
     <uses-feature android:name="android.hardware.usb.host" android:required="false" />
     <uses-feature android:name="android.hardware.wifi" android:required="false" />
+    <uses-feature android:name="android.software.leanback" android:required="false" />
 	
     <application android:icon="@drawable/ic_launcher" android:label="@string/app_name" android:hasCode="true">
         <activity


### PR DESCRIPTION
Not sure if this works as documents are quite unclear about this.
Hopefully some one can actually test this on a ADT-1 and other devices (compiled fine using jenkins so doesn't break building).
Could set up a testgroup and upload a alpha version to see if it actually shows up.
@anssih @koying (maybe @Chainfire)

Edit:
triggered jenkins builds for ARM/x86 and they will show up in test-builds on the server
