### PR TITLE
[pvr] fix deleting recording folders

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -610,9 +610,7 @@ bool CGUIWindowPVRBase::ActionDeleteRecording(CFileItem *item)
 {
   bool bReturn = false;
 
-  /* check if the recording tag is valid */
-  CPVRRecording *recTag = (CPVRRecording *) item->GetPVRRecordingInfoTag();
-  if (!recTag || recTag->m_strRecordingId.empty())
+  if (!item->IsPVRRecording() && !item->m_bIsFolder)
     return bReturn;
 
   /* show a confirmation dialog */


### PR DESCRIPTION
The underlying routines perform the recording info tag check so it's
not necessary to do it here at all. This is also why folders couldn't
be deleted earlier.

@xhaggi for sanity checking
