### PR TITLE
[pvr] fix marking recordings as watched or unwatched

### DIFF
--- a/xbmc/pvr/recordings/PVRRecordings.cpp
+++ b/xbmc/pvr/recordings/PVRRecordings.cpp
@@ -117,9 +117,10 @@ void CPVRRecordings::GetSubDirectories(const std::string &strBase, CFileItemList
     else
       strFilePath = StringUtils::Format("pvr://recordings/%s/%s/", strUseBase.c_str(), strCurrent.c_str());
 
+    current->UpdateMetadata();
+    
     if (!results->Contains(strFilePath))
     {
-      current->UpdateMetadata();
       CFileItemPtr pFileItem;
       pFileItem.reset(new CFileItem(strCurrent, true));
       pFileItem->SetPath(strFilePath);

--- a/xbmc/pvr/recordings/PVRRecordings.cpp
+++ b/xbmc/pvr/recordings/PVRRecordings.cpp
@@ -104,8 +104,6 @@ void CPVRRecordings::GetSubDirectories(const std::string &strBase, CFileItemList
 {
   std::string strUseBase = TrimSlashes(strBase);
 
-  std::set<std::string> unwatchedFolders;
-
   for (PVR_RECORDINGMAP_CITR it = m_recordings.begin(); it != m_recordings.end(); it++)
   {
     CPVRRecordingPtr current = it->second;
@@ -132,8 +130,6 @@ void CPVRRecordings::GetSubDirectories(const std::string &strBase, CFileItemList
       // Initialize folder overlay from play count (either directly from client or from video database)
       if (current->m_playCount > 0)
         pFileItem->SetOverlayImage(CGUIListItem::ICON_OVERLAY_WATCHED, false);
-      else
-        unwatchedFolders.insert(strFilePath);
 
       results->Add(pFileItem);
     }
@@ -143,16 +139,6 @@ void CPVRRecordings::GetSubDirectories(const std::string &strBase, CFileItemList
       pFileItem=results->Get(strFilePath);
       if (pFileItem->m_dateTime<current->RecordingTimeAsLocalTime())
         pFileItem->m_dateTime  = current->RecordingTimeAsLocalTime();
-
-      // Unset folder overlay if recording is unwatched
-      if (unwatchedFolders.find(strFilePath) == unwatchedFolders.end())
-      {
-        if (current->m_playCount == 0)
-        {
-          pFileItem->SetOverlayImage(CGUIListItem::ICON_OVERLAY_UNWATCHED, false);
-          unwatchedFolders.insert(strFilePath);
-        }
-      }
     }
   }
 }

--- a/xbmc/pvr/recordings/PVRRecordings.h
+++ b/xbmc/pvr/recordings/PVRRecordings.h
@@ -46,6 +46,7 @@ namespace PVR
     virtual const std::string GetDirectoryFromPath(const std::string &strPath, const std::string &strBase) const;
     virtual bool IsDirectoryMember(const std::string &strDirectory, const std::string &strEntryDirectory) const;
     virtual void GetSubDirectories(const std::string &strBase, CFileItemList *results);
+    CPVRRecordingPtr GetByFileItem(const CFileItem &item) const;
 
     /**
      * @brief recursively deletes all recordings in the specified directory
@@ -85,7 +86,6 @@ namespace PVR
     bool GetDirectory(const std::string& strPath, CFileItemList &items);
     CFileItemPtr GetByPath(const std::string &path);
     CPVRRecordingPtr GetById(int iClientId, const std::string &strRecordingId) const;
-    void SetPlayCount(const CFileItem &item, int iPlayCount);
     void GetAll(CFileItemList &items);
     CFileItemPtr GetById(unsigned int iId) const;
 

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -325,6 +325,8 @@ bool CGUIWindowPVRRecordings::OnContextButtonMarkWatched(const CFileItemPtr &ite
 
     if (g_PVRRecordings->SetRecordingsPlayCount(item, playCount))
     {
+      // Advance the selected item one notch
+      m_viewControl.SetSelectedItem(m_viewControl.GetSelectedItem() + 1);
       Refresh(true);
       bReturn = true;
     }

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -319,24 +319,15 @@ bool CGUIWindowPVRRecordings::OnContextButtonMarkWatched(const CFileItemPtr &ite
 {
   bool bReturn = false;
 
-  if (button == CONTEXT_BUTTON_MARK_WATCHED)
+  if (button == CONTEXT_BUTTON_MARK_WATCHED || button == CONTEXT_BUTTON_MARK_UNWATCHED)
   {
-    bReturn = true;
+    int playCount = button == CONTEXT_BUTTON_MARK_WATCHED ? 1 : 0;
 
-    int newSelection = m_viewControl.GetSelectedItem();
-    g_PVRRecordings->SetRecordingsPlayCount(item, 1);
-    m_viewControl.SetSelectedItem(newSelection);
-
-    Refresh(true);
-  }
-
-  if (button == CONTEXT_BUTTON_MARK_UNWATCHED)
-  {
-    bReturn = true;
-
-    g_PVRRecordings->SetRecordingsPlayCount(item, 0);
-
-    Refresh(true);
+    if (g_PVRRecordings->SetRecordingsPlayCount(item, playCount))
+    {
+      Refresh(true);
+      bReturn = true;
+    }
   }
 
   return bReturn;


### PR DESCRIPTION
This PR fixes there distinct bugs:
- when a recording was marked as watched/unwatched. This is because the change was done on a copy of the actual recording, not the correct instance.
- after marking something as watched/unwatched, the selected item didn't change to the next one in the list (as is done in other windows)
- a folder containing only watched items wasn't marked as watched until the folder had been entered once

Fixes http://trac.xbmc.org/ticket/15118
