### PR TITLE
[android] Add 7.1 PCM playback support

### DIFF
--- a/xbmc/android/jni/AudioFormat.cpp
+++ b/xbmc/android/jni/AudioFormat.cpp
@@ -35,6 +35,8 @@ int CJNIAudioFormat::CHANNEL_OUT_FRONT_CENTER          = 0x00000010;
 int CJNIAudioFormat::CHANNEL_OUT_FRONT_RIGHT_OF_CENTER = 0x00000200;
 int CJNIAudioFormat::CHANNEL_OUT_FRONT_RIGHT           = 0x00000008;
 int CJNIAudioFormat::CHANNEL_OUT_LOW_FREQUENCY         = 0x00000020;
+int CJNIAudioFormat::CHANNEL_OUT_SIDE_LEFT             = 0x00000800;
+int CJNIAudioFormat::CHANNEL_OUT_SIDE_RIGHT            = 0x00001000;
 int CJNIAudioFormat::CHANNEL_OUT_BACK_LEFT             = 0x00000040;
 int CJNIAudioFormat::CHANNEL_OUT_BACK_CENTER           = 0x00000400;
 int CJNIAudioFormat::CHANNEL_OUT_BACK_RIGHT            = 0x00000080;
@@ -49,6 +51,7 @@ void CJNIAudioFormat::PopulateStaticFields()
     jhclass c = find_class("android/media/AudioFormat");
     CJNIAudioFormat::ENCODING_PCM_16BIT = get_static_field<int>(c, "ENCODING_PCM_16BIT");
     if (sdk >= 5)
+    {
       CJNIAudioFormat::CHANNEL_OUT_STEREO = get_static_field<int>(c, "CHANNEL_OUT_STEREO");
       CJNIAudioFormat::CHANNEL_OUT_5POINT1 = get_static_field<int>(c, "CHANNEL_OUT_5POINT1");
       CJNIAudioFormat::CHANNEL_OUT_FRONT_LEFT = get_static_field<int>(c, "CHANNEL_OUT_FRONT_LEFT");
@@ -61,6 +64,12 @@ void CJNIAudioFormat::PopulateStaticFields()
       CJNIAudioFormat::CHANNEL_OUT_BACK_CENTER = get_static_field<int>(c, "CHANNEL_OUT_BACK_CENTER");
       CJNIAudioFormat::CHANNEL_OUT_BACK_RIGHT = get_static_field<int>(c, "CHANNEL_OUT_BACK_RIGHT");
       CJNIAudioFormat::CHANNEL_INVALID = get_static_field<int>(c, "CHANNEL_INVALID");
+      if (sdk >= 21)
+      {
+        CJNIAudioFormat::CHANNEL_OUT_SIDE_LEFT = get_static_field<int>(c, "CHANNEL_OUT_SIDE_LEFT");
+        CJNIAudioFormat::CHANNEL_OUT_SIDE_RIGHT = get_static_field<int>(c, "CHANNEL_OUT_SIDE_RIGHT");
+      }
+    }
   }
 }
 

--- a/xbmc/android/jni/AudioFormat.h
+++ b/xbmc/android/jni/AudioFormat.h
@@ -38,6 +38,8 @@ class CJNIAudioFormat
     static int CHANNEL_OUT_FRONT_RIGHT_OF_CENTER;
     static int CHANNEL_OUT_FRONT_RIGHT;
     static int CHANNEL_OUT_LOW_FREQUENCY;
+    static int CHANNEL_OUT_SIDE_LEFT;
+    static int CHANNEL_OUT_SIDE_RIGHT;
     static int CHANNEL_OUT_BACK_LEFT;
     static int CHANNEL_OUT_BACK_CENTER;
     static int CHANNEL_OUT_BACK_RIGHT;


### PR DESCRIPTION
Add Android 7.1 PCM audio playback support. This support requires
Android 5.0 device.

When support is not available, the code falls back to 5.1 and stereo
playback.

Tested on ADT-1.

The code still restricts channel layout selection to 2.0/5.1/7.1 since
all other layouts seem to still be downmixed to stereo.

TODO: Channel layout is currently messed up on at least ADT-1:
https://code.google.com/p/android-developer-preview/issues/detail?id=1800

So I guess we should hold with this until it is clear if that will be fixed for final and/or whether the issues affect other hardware. I'm making this PR in any case already so that no one does unneeded duplicate work (even though it is quite trivial).
