### PR TITLE
FIX: PGS Subs: Don't read from null ptr

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayCodecFFmpeg.cpp
@@ -165,6 +165,7 @@ int CDVDOverlayCodecFFmpeg::Decode(DemuxPacket *pPacket)
   if (len < 0)
   {
     CLog::Log(LOGERROR, "%s - avcodec_decode_subtitle returned failure", __FUNCTION__);
+    Flush();
     return OC_ERROR;
   }
 
@@ -235,7 +236,10 @@ CDVDOverlay* CDVDOverlayCodecFFmpeg::GetOverlay()
 
     if(m_Subtitle.rects[m_SubtitleIndex] == NULL)
       return NULL;
+
     AVSubtitleRect& rect = *m_Subtitle.rects[m_SubtitleIndex];
+    if (rect.pict.data[0] == NULL)
+      return NULL;
 
     CDVDOverlayImage* overlay = new CDVDOverlayImage();
 


### PR DESCRIPTION
I saw this on the forum: http://pastebin.com/gHEjDrAz basically

```
21:36:03 T:2462055232   ERROR: ffmpeg[92BFFB40]: [pgssub] Subtitle out of video bounds. x = 65509, y = 836, video width = 1920, video height = 1080.
21:36:03 T:2462055232   ERROR: ffmpeg[92BFFB40]: [pgssub] Bitmap dimensions larger than video.
```

In that case 

```
uint8_t* s = rect.pict.data[0];
```

gets NULL and we try to read rect.w from it. 

Please someone with PGS experience (this code is there since the svn to git merge) have a look if this is the correct way to "workaround" it.

@t-nelson: You were the commiter back at that time.
