### PR TITLE
[AE] Allow resampler to indicate when it has too much data buffered

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
@@ -248,8 +248,6 @@ bool CActiveAEBufferPoolResample::ResampleBuffers(int64_t timestamp)
   }
   else if (m_procSample || !m_freeSamples.empty())
   {
-    // GetBufferedSamples is not accurate because of rounding errors
-    int out_samples = m_resampler->GetBufferedSamples();
     int free_samples;
     if (m_procSample)
       free_samples = m_procSample->pkt->max_nb_samples - m_procSample->pkt->nb_samples;
@@ -258,7 +256,7 @@ bool CActiveAEBufferPoolResample::ResampleBuffers(int64_t timestamp)
 
     bool skipInput = false;
     // avoid that ffmpeg resample buffer grows too large
-    if (out_samples > free_samples * 2 && !m_empty)
+    if (!m_resampler->WantsNewSamples(free_samples) && !m_empty)
       skipInput = true;
 
     bool hasInput = !m_inputSamples.empty();
@@ -288,11 +286,11 @@ bool CActiveAEBufferPoolResample::ResampleBuffers(int64_t timestamp)
         m_planes[i] = m_procSample->pkt->data[i] + start;
       }
 
-      out_samples = m_resampler->Resample(m_planes,
-                                          m_procSample->pkt->max_nb_samples - m_procSample->pkt->nb_samples,
-                                          in ? in->pkt->data : NULL,
-                                          in ? in->pkt->nb_samples : 0,
-                                          m_resampleRatio);
+      int out_samples = m_resampler->Resample(m_planes,
+                                              m_procSample->pkt->max_nb_samples - m_procSample->pkt->nb_samples,
+                                              in ? in->pkt->data : NULL,
+                                              in ? in->pkt->nb_samples : 0,
+                                              m_resampleRatio);
       m_procSample->pkt->nb_samples += out_samples;
       busy = true;
       m_empty = (out_samples == 0);

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResampleFFMPEG.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResampleFFMPEG.h
@@ -41,6 +41,7 @@ public:
   int Resample(uint8_t **dst_buffer, int dst_samples, uint8_t **src_buffer, int src_samples, double ratio);
   int64_t GetDelay(int64_t base);
   int GetBufferedSamples();
+  bool WantsNewSamples(int samples) { return GetBufferedSamples() <= samples * 2; }
   int CalcDstSampleCount(int src_samples, int dst_rate, int src_rate);
   int GetSrcBufferSize(int samples);
   int GetDstBufferSize(int samples);

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResamplePi.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResamplePi.h
@@ -35,6 +35,7 @@ public:
   int Resample(uint8_t **dst_buffer, int dst_samples, uint8_t **src_buffer, int src_samples, double ratio);
   int64_t GetDelay(int64_t base);
   int GetBufferedSamples();
+  bool WantsNewSamples(int samples) { return GetBufferedSamples() <= samples; }
   int CalcDstSampleCount(int src_samples, int dst_rate, int src_rate);
   int GetSrcBufferSize(int samples);
   int GetDstBufferSize(int samples);

--- a/xbmc/cores/AudioEngine/Interfaces/AEResample.h
+++ b/xbmc/cores/AudioEngine/Interfaces/AEResample.h
@@ -39,6 +39,7 @@ public:
   virtual int Resample(uint8_t **dst_buffer, int dst_samples, uint8_t **src_buffer, int src_samples, double ratio) = 0;
   virtual int64_t GetDelay(int64_t base) = 0;
   virtual int GetBufferedSamples() = 0;
+  virtual bool WantsNewSamples(int samples) = 0;
   virtual int CalcDstSampleCount(int src_samples, int dst_rate, int src_rate) = 0;
   virtual int GetSrcBufferSize(int samples) = 0;
   virtual int GetDstBufferSize(int samples) = 0;


### PR DESCRIPTION
The Pi resampler doesn't want more samples submitted when it has a whole input buffer queued,
and drops data in this case. This can be triggered when video clock is enabled and audio is resampled.

The FFMPEG resampler buffers more data internally and wants up to two input buffers submitted.

Add a method to query if there is space for more samples, and return approprate values.
