### PR TITLE
[buttontranslator] Group joystick keymaps by family

### DIFF
--- a/system/keymaps/joystick.Microsoft.Xbox.360.Controller.xml
+++ b/system/keymaps/joystick.Microsoft.Xbox.360.Controller.xml
@@ -71,29 +71,90 @@
 <!-- 1   left        D-Pad Left       -->
 <!-- 1   right       D-Pad Right      -->
 
-
-
 <keymap>
+  <joystickFamily name="Xbox 360 Controller (xpad)">
+     <name>Microsoft X-Box 360 pad</name>
+     <name>Xbox 360 Wireless Receiver (XBOX)</name>
+     <name>Xbox 360 Wireless Receiver</name>
+     <name>Thrustmaster Gamepad GP XID</name>
+     <name>Logitech Gamepad F310</name>
+     <name>Logitech Gamepad F510</name>
+     <name>Logitech Gamepad F710</name>
+     <name>Logitech Chillstream Controller</name>
+     <name>Mad Catz Wired Xbox 360 Controller</name>
+     <name>Mad Catz Street Fighter IV FightStick SE</name>
+     <name>Mad Catz Xbox 360 Controller</name>
+     <name>Mad Catz Street Fighter IV FightPad</name>
+     <name>Mad Catz Wired Xbox 360 Controller (SFIV)</name>
+     <name>Mad Catz Beat Pad</name>
+     <name>Mad Catz Xbox controller - MW2</name>
+     <name>Mad Catz JOYTECH NEO SE Advanced GamePad</name>
+     <name>Saitek Cyborg Rumble Pad - PC/Xbox 360</name>
+     <name>Saitek P3200 Rumble Pad - PC/Xbox 360</name>
+     <name>Super SFIV FightStick TE S</name>
+     <name>HSM3 Xbox360 dancepad</name>
+     <name>Afterglow AX.1 Gamepad for Xbox 360</name>
+     <name>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</name>
+     <name>Afterglow Gamepad for Xbox 360</name>
+     <name>Rock Candy Gamepad for Xbox 360</name>
+     <name>Logic3 Controller</name>
+     <name>Logic3 Controller</name>
+     <name>Hori Fighting Stick EX2</name>
+     <name>Hori Real Arcade Pro.EX</name>
+     <name>Honey Bee Xbox360 dancepad</name>
+     <name>PDP AFTERGLOW AX.1</name>
+     <name>RedOctane Guitar Hero X-plorer</name>
+     <name>BigBen Interactive XBOX 360 Controller</name>
+     <name>Razer Sabertooth</name>
+     <name>Power A Mini Pro Elite</name>
+     <name>Xbox Airflo wired controller</name>
+     <name>Batarang Xbox 360 controller</name>
+     <name>Joytech Neo-Se Take2</name>
+     <name>Razer Onza Tournament Edition</name>
+     <name>Razer Onza Classic Edition</name>
+     <name>Razer Sabertooth</name>
+     <name>Harmonix Rock Band Guitar</name>
+     <name>Harmonix Rock Band Drumkit</name>
+     <name>Mad Catz Xbox 360 Controller</name>
+     <name>MLG Pro Circuit Controller (Xbox)</name>
+     <name>Street Fighter IV FightPad</name>
+     <name>Street Fighter IV FightStick TE</name>
+     <name>Harmonix Xbox 360 Controller</name>
+     <name>Gamestop Xbox 360 Controller</name>
+     <name>Tron Xbox 360 controller</name>
+     <name>Razer Atrox Arcade Stick</name>
+     <name>PowerA MINI PROEX Controller</name>
+     <name>Xbox Airflo wired controller</name>
+     <name>Hori XBOX 360 EX 2 with Turbo</name>
+     <name>Hori Real Arcade Pro VX-SA</name>
+     <name>Hori SOULCALIBUR V Stick</name>
+     <name>Thrustmaster, Inc. GPX Controller</name>
+     <name>Thrustmaster Ferrari 458 Racing Wheel</name>
+     <name>Microsoft X-Box One pad</name>  
+  </joystickFamily>
+  <joystickFamily name="Xbox 360 Controller (Windows)">
+     <name>Afterglow Gamepad for Xbox 360 (Controller)</name>
+     <name>Controller (Gamepad F310)</name>
+     <name>Controller (Gamepad for Xbox 360)</name>
+     <name>Controller (Rumble Gamepad F510)</name>
+     <name>Controller (Wireless Gamepad F710)</name>
+     <name>Controller (Xbox 360 Wireless Receiver for Windows)</name>
+     <name>Controller (Xbox wireless receiver for windows)</name>
+     <name>Controller (XBOX360 GAMEPAD)</name>
+     <name>Controller (Batarang wired controller (XBOX))</name>
+     <name>Wireless Gamepad F710 (Controller)</name>
+     <name>XBOX 360 For Windows</name>
+     <name>XBOX 360 For Windows (Controller)</name>
+     <name>Xbox 360 Wireless Controller</name>
+     <name>Xbox Receiver for Windows (Wireless Controller)</name>
+     <name>Xbox wireless receiver for windows (Controller)</name>
+     <name>Gamepad F310 (Controller)</name>
+     <name>Razer Sabertooth Elite (Controller)</name>
+     <name>Controller (Razer Sabertooth Elite)</name>
+     <name>Controller (XBOX One For Windows)</name>
+  </joystickFamily>  
   <global>
-    <joystick name="Controller (XBOX 360 For Windows)">
-      <altname>Afterglow Gamepad for Xbox 360 (Controller)</altname>
-      <altname>Controller (Gamepad F310)</altname>
-      <altname>Controller (Gamepad for Xbox 360)</altname>
-      <altname>Controller (Rumble Gamepad F510)</altname>
-      <altname>Controller (Wireless Gamepad F710)</altname>
-      <altname>Controller (Xbox 360 Wireless Receiver for Windows)</altname>
-      <altname>Controller (Xbox wireless receiver for windows)</altname>
-      <altname>Controller (XBOX360 GAMEPAD)</altname>
-      <altname>Controller (Batarang wired controller (XBOX))</altname>
-      <altname>Wireless Gamepad F710 (Controller)</altname>
-      <altname>XBOX 360 For Windows</altname>
-      <altname>XBOX 360 For Windows (Controller)</altname>
-      <altname>Xbox 360 Wireless Controller</altname>
-      <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
-      <altname>Xbox wireless receiver for windows (Controller)</altname>
-      <altname>Gamepad F310 (Controller)</altname>
-      <altname>Razer Sabertooth Elite (Controller)</altname>
-      <altname>Controller (XBOX One For Windows)</altname>
+    <joystick family="Xbox 360 Controller (Windows)">
       <!-- A selects. B goes back. X gets context menu. Y goes fullscreen and back. -->
       <button id="1">Select</button>
       <button id="2">Back</button>
@@ -128,17 +189,7 @@
       <hat id="1" position="left">Left</hat>
       <hat id="1" position="right">Right</hat>
     </joystick>
-    <joystick name="Microsoft X-Box 360 pad">
-      <altname>BigBen Interactive XBOX 360 Controller</altname>
-      <altname>Generic X-Box pad</altname>
-      <altname>Logitech Chillstream Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller (SFIV)</altname>
-      <altname>Pelican 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Xbox 360 Wireless Receiver</altname>
-      <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
-      <altname>Razer Sabertooth</altname>
+    <joystick family="Xbox 360 Controller (xpad)">
       <button id="1">Select</button>
       <button id="2">Back</button>
       <button id="3">ContextMenu</button>
@@ -171,110 +222,26 @@
     </joystick>
   </global>
   <Home>
-    <joystick name="Controller (XBOX 360 For Windows)">
-      <altname>Afterglow Gamepad for Xbox 360 (Controller)</altname>
-      <altname>Controller (Gamepad F310)</altname>
-      <altname>Controller (Gamepad for Xbox 360)</altname>
-      <altname>Controller (Rumble Gamepad F510)</altname>
-      <altname>Controller (Wireless Gamepad F710)</altname>
-      <altname>Controller (Xbox 360 Wireless Receiver for Windows)</altname>
-      <altname>Controller (Xbox wireless receiver for windows)</altname>
-      <altname>Controller (XBOX360 GAMEPAD)</altname>
-      <altname>Controller (Batarang wired controller (XBOX))</altname>
-      <altname>Wireless Gamepad F710 (Controller)</altname>
-      <altname>XBOX 360 For Windows</altname>
-      <altname>XBOX 360 For Windows (Controller)</altname>
-      <altname>Xbox 360 Wireless Controller</altname>
-      <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
-      <altname>Xbox wireless receiver for windows (Controller)</altname>
-      <altname>Gamepad F310 (Controller)</altname>
-      <altname>Razer Sabertooth Elite (Controller)</altname>
-      <altname>Controller (XBOX One For Windows)</altname>
+    <joystick family="Xbox 360 Controller (Windows)">
       <button id="8">Skin.ToggleSetting(HomeViewToggle)</button>
     </joystick>
-    <joystick name="Microsoft X-Box 360 pad">
-      <altname>BigBen Interactive XBOX 360 Controller</altname>
-      <altname>Generic X-Box pad</altname>
-      <altname>Logitech Chillstream Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller (SFIV)</altname>
-      <altname>Pelican 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Xbox 360 Wireless Receiver</altname>
-      <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
-      <altname>Razer Sabertooth</altname>
+    <joystick family="Xbox 360 Controller (xpad)">
       <button id="8">Skin.ToggleSetting(HomeViewToggle)</button>
     </joystick>
   </Home>
   <MyFiles>
-    <joystick name="Controller (XBOX 360 For Windows)">
-      <altname>Afterglow Gamepad for Xbox 360 (Controller)</altname>
-      <altname>Controller (Gamepad F310)</altname>
-      <altname>Controller (Gamepad for Xbox 360)</altname>
-      <altname>Controller (Rumble Gamepad F510)</altname>
-      <altname>Controller (Wireless Gamepad F710)</altname>
-      <altname>Controller (Xbox 360 Wireless Receiver for Windows)</altname>
-      <altname>Controller (Xbox wireless receiver for windows)</altname>
-      <altname>Controller (XBOX360 GAMEPAD)</altname>
-      <altname>Controller (Batarang wired controller (XBOX))</altname>
-      <altname>Wireless Gamepad F710 (Controller)</altname>
-      <altname>XBOX 360 For Windows</altname>
-      <altname>XBOX 360 For Windows (Controller)</altname>
-      <altname>Xbox 360 Wireless Controller</altname>
-      <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
-      <altname>Xbox wireless receiver for windows (Controller)</altname>
-      <altname>Gamepad F310 (Controller)</altname>
-      <altname>Razer Sabertooth Elite (Controller)</altname>
-      <altname>Controller (XBOX One For Windows)</altname>
+    <joystick family="Xbox 360 Controller (Windows)">
       <button id="6">Highlight</button>
     </joystick>
-    <joystick name="Microsoft X-Box 360 pad">
-      <altname>BigBen Interactive XBOX 360 Controller</altname>
-      <altname>Generic X-Box pad</altname>
-      <altname>Logitech Chillstream Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller (SFIV)</altname>
-      <altname>Pelican 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Xbox 360 Wireless Receiver</altname>
-      <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
-      <altname>Razer Sabertooth</altname>
+    <joystick family="Xbox 360 Controller (xpad)">
       <button id="6">Highlight</button>
     </joystick>
   </MyFiles>
   <MyMusicPlaylist>
-    <joystick name="Controller (XBOX 360 For Windows)">
-      <altname>Afterglow Gamepad for Xbox 360 (Controller)</altname>
-      <altname>Controller (Gamepad F310)</altname>
-      <altname>Controller (Gamepad for Xbox 360)</altname>
-      <altname>Controller (Rumble Gamepad F510)</altname>
-      <altname>Controller (Wireless Gamepad F710)</altname>
-      <altname>Controller (Xbox 360 Wireless Receiver for Windows)</altname>
-      <altname>Controller (Xbox wireless receiver for windows)</altname>
-      <altname>Controller (XBOX360 GAMEPAD)</altname>
-      <altname>Controller (Batarang wired controller (XBOX))</altname>
-      <altname>Wireless Gamepad F710 (Controller)</altname>
-      <altname>XBOX 360 For Windows</altname>
-      <altname>XBOX 360 For Windows (Controller)</altname>
-      <altname>Xbox 360 Wireless Controller</altname>
-      <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
-      <altname>Xbox wireless receiver for windows (Controller)</altname>
-      <altname>Gamepad F310 (Controller)</altname>
-      <altname>Razer Sabertooth Elite (Controller)</altname>
-      <altname>Controller (XBOX One For Windows)</altname>
+    <joystick family="Xbox 360 Controller (Windows)">
       <button id="5">Delete</button>
     </joystick>
-    <joystick name="Microsoft X-Box 360 pad">
-      <altname>BigBen Interactive XBOX 360 Controller</altname>
-      <altname>Generic X-Box pad</altname>
-      <altname>Logitech Chillstream Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller (SFIV)</altname>
-      <altname>Pelican 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Xbox 360 Wireless Receiver</altname>
-      <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
-      <altname>Razer Sabertooth</altname>
+    <joystick family="Xbox 360 Controller (xpad)">
       <button id="5">Delete</button>
     </joystick>
   </MyMusicPlaylist>
@@ -283,25 +250,7 @@
   <MyMusicLibrary>
   </MyMusicLibrary>
   <FullscreenVideo>
-    <joystick name="Controller (XBOX 360 For Windows)">
-      <altname>Afterglow Gamepad for Xbox 360 (Controller)</altname>
-      <altname>Controller (Gamepad F310)</altname>
-      <altname>Controller (Gamepad for Xbox 360)</altname>
-      <altname>Controller (Rumble Gamepad F510)</altname>
-      <altname>Controller (Wireless Gamepad F710)</altname>
-      <altname>Controller (Xbox 360 Wireless Receiver for Windows)</altname>
-      <altname>Controller (Xbox wireless receiver for windows)</altname>
-      <altname>Controller (XBOX360 GAMEPAD)</altname>
-      <altname>Controller (Batarang wired controller (XBOX))</altname>
-      <altname>Wireless Gamepad F710 (Controller)</altname>
-      <altname>XBOX 360 For Windows</altname>
-      <altname>XBOX 360 For Windows (Controller)</altname>
-      <altname>Xbox 360 Wireless Controller</altname>
-      <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
-      <altname>Xbox wireless receiver for windows (Controller)</altname>
-      <altname>Gamepad F310 (Controller)</altname>
-      <altname>Razer Sabertooth Elite (Controller)</altname>
-      <altname>Controller (XBOX One For Windows)</altname>
+    <joystick family="Xbox 360 Controller (Windows)">
       <!--
             A pauses and starts the video.
             B stops the video.
@@ -334,17 +283,7 @@
       <hat id="1" position="left">StepBack</hat>
       <hat id="1" position="right">StepForward</hat>
     </joystick>
-    <joystick name="Microsoft X-Box 360 pad">
-      <altname>BigBen Interactive XBOX 360 Controller</altname>
-      <altname>Generic X-Box pad</altname>
-      <altname>Logitech Chillstream Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller (SFIV)</altname>
-      <altname>Pelican 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Xbox 360 Wireless Receiver</altname>
-      <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
-      <altname>Razer Sabertooth</altname>
+    <joystick family="Xbox 360 Controller (xpad)">
       <button id="1">Pause</button>
       <button id="2">Stop</button>
       <button id="3">OSD</button>
@@ -368,25 +307,7 @@
     </joystick>
   </FullscreenVideo>
   <FullscreenLiveTV>
-    <joystick name="Controller (XBOX 360 For Windows)">
-      <altname>Afterglow Gamepad for Xbox 360 (Controller)</altname>
-      <altname>Controller (Gamepad F310)</altname>
-      <altname>Controller (Gamepad for Xbox 360)</altname>
-      <altname>Controller (Rumble Gamepad F510)</altname>
-      <altname>Controller (Wireless Gamepad F710)</altname>
-      <altname>Controller (Xbox 360 Wireless Receiver for Windows)</altname>
-      <altname>Controller (Xbox wireless receiver for windows)</altname>
-      <altname>Controller (XBOX360 GAMEPAD)</altname>
-      <altname>Controller (Batarang wired controller (XBOX))</altname>
-      <altname>Wireless Gamepad F710 (Controller)</altname>
-      <altname>XBOX 360 For Windows</altname>
-      <altname>XBOX 360 For Windows (Controller)</altname>
-      <altname>Xbox 360 Wireless Controller</altname>
-      <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
-      <altname>Xbox wireless receiver for windows (Controller)</altname>
-      <altname>Gamepad F310 (Controller)</altname>
-      <altname>Razer Sabertooth Elite (Controller)</altname>
-      <altname>Controller (XBOX One For Windows)</altname>
+    <joystick family="Xbox 360 Controller (Windows)">
       <button id="11">ChannelUp</button>
       <button id="12">ChannelDown</button>
       <button id="13">StepBack</button>
@@ -396,17 +317,7 @@
       <hat id="1" position="left">StepBack</hat>
       <hat id="1" position="right">StepForward</hat>
     </joystick>
-    <joystick name="Microsoft X-Box 360 pad">
-      <altname>BigBen Interactive XBOX 360 Controller</altname>
-      <altname>Generic X-Box pad</altname>
-      <altname>Logitech Chillstream Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller (SFIV)</altname>
-      <altname>Pelican 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Xbox 360 Wireless Receiver</altname>
-      <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
-      <altname>Razer Sabertooth</altname>
+    <joystick family="Xbox 360 Controller (xpad)">
       <button id="12">StepBack</button>
       <button id="13">StepForward</button>
       <button id="14">ChannelUp</button>
@@ -418,25 +329,7 @@
     </joystick>
   </FullscreenLiveTV>
   <FullscreenRadio>
-    <joystick name="Controller (XBOX 360 For Windows)">
-      <altname>Afterglow Gamepad for Xbox 360 (Controller)</altname>
-      <altname>Controller (Gamepad F310)</altname>
-      <altname>Controller (Gamepad for Xbox 360)</altname>
-      <altname>Controller (Rumble Gamepad F510)</altname>
-      <altname>Controller (Wireless Gamepad F710)</altname>
-      <altname>Controller (Xbox 360 Wireless Receiver for Windows)</altname>
-      <altname>Controller (Xbox wireless receiver for windows)</altname>
-      <altname>Controller (XBOX360 GAMEPAD)</altname>
-      <altname>Controller (Batarang wired controller (XBOX))</altname>
-      <altname>Wireless Gamepad F710 (Controller)</altname>
-      <altname>XBOX 360 For Windows</altname>
-      <altname>XBOX 360 For Windows (Controller)</altname>
-      <altname>Xbox 360 Wireless Controller</altname>
-      <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
-      <altname>Xbox wireless receiver for windows (Controller)</altname>
-      <altname>Gamepad F310 (Controller)</altname>
-      <altname>Razer Sabertooth Elite (Controller)</altname>
-      <altname>Controller (XBOX One For Windows)</altname>
+    <joystick family="Xbox 360 Controller (Windows)">
       <button id="11">ChannelUp</button>
       <button id="12">ChannelDown</button>
       <button id="13">StepBack</button>
@@ -446,16 +339,7 @@
       <hat id="1" position="left">StepBack</hat>
       <hat id="1" position="right">StepForward</hat>
     </joystick>
-    <joystick name="Microsoft X-Box 360 pad">
-      <altname>BigBen Interactive XBOX 360 Controller</altname>
-      <altname>Generic X-Box pad</altname>
-      <altname>Logitech Chillstream Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller (SFIV)</altname>
-      <altname>Pelican 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Xbox 360 Wireless Receiver</altname>
-      <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
+    <joystick family="Xbox 360 Controller (xpad)">
       <button id="12">StepBack</button>
       <button id="13">StepForward</button>
       <button id="14">ChannelUp</button>
@@ -467,42 +351,14 @@
     </joystick>
   </FullscreenRadio>
   <FullscreenInfo>
-    <joystick name="Controller (XBOX 360 For Windows)">
-      <altname>Afterglow Gamepad for Xbox 360 (Controller)</altname>
-      <altname>Controller (Gamepad F310)</altname>
-      <altname>Controller (Gamepad for Xbox 360)</altname>
-      <altname>Controller (Rumble Gamepad F510)</altname>
-      <altname>Controller (Wireless Gamepad F710)</altname>
-      <altname>Controller (Xbox 360 Wireless Receiver for Windows)</altname>
-      <altname>Controller (Xbox wireless receiver for windows)</altname>
-      <altname>Controller (XBOX360 GAMEPAD)</altname>
-      <altname>Controller (Batarang wired controller (XBOX))</altname>
-      <altname>Wireless Gamepad F710 (Controller)</altname>
-      <altname>XBOX 360 For Windows</altname>
-      <altname>XBOX 360 For Windows (Controller)</altname>
-      <altname>Xbox 360 Wireless Controller</altname>
-      <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
-      <altname>Xbox wireless receiver for windows (Controller)</altname>
-      <altname>Gamepad F310 (Controller)</altname>
-      <altname>Razer Sabertooth Elite (Controller)</altname>
-      <altname>Controller (XBOX One For Windows)</altname>
+    <joystick family="Xbox 360 Controller (Windows)">
       <button id="2">Close</button>
       <button id="3">OSD</button>
       <button id="8">Close</button>
       <axis id="3" limit="+1">AnalogRewind</axis>
       <axis id="3" limit="-1">AnalogFastForward</axis>
     </joystick>
-    <joystick name="Microsoft X-Box 360 pad">
-      <altname>BigBen Interactive XBOX 360 Controller</altname>
-      <altname>Generic X-Box pad</altname>
-      <altname>Logitech Chillstream Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller (SFIV)</altname>
-      <altname>Pelican 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Xbox 360 Wireless Receiver</altname>
-      <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
-      <altname>Razer Sabertooth</altname>
+    <joystick family="Xbox 360 Controller (xpad)">
       <button id="2">Close</button>
       <button id="3">OSD</button>
       <button id="8">Close</button>
@@ -511,65 +367,19 @@
     </joystick>
   </FullscreenInfo>
   <PlayerControls>
-    <joystick name="Controller (XBOX 360 For Windows)">
-      <altname>Afterglow Gamepad for Xbox 360 (Controller)</altname>
-      <altname>Controller (Gamepad F310)</altname>
-      <altname>Controller (Gamepad for Xbox 360)</altname>
-      <altname>Controller (Rumble Gamepad F510)</altname>
-      <altname>Controller (Wireless Gamepad F710)</altname>
-      <altname>Controller (Xbox 360 Wireless Receiver for Windows)</altname>
-      <altname>Controller (Xbox wireless receiver for windows)</altname>
-      <altname>Controller (XBOX360 GAMEPAD)</altname>
-      <altname>Controller (Batarang wired controller (XBOX))</altname>
-      <altname>Wireless Gamepad F710 (Controller)</altname>
-      <altname>XBOX 360 For Windows</altname>
-      <altname>XBOX 360 For Windows (Controller)</altname>
-      <altname>Xbox 360 Wireless Controller</altname>
-      <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
-      <altname>Xbox wireless receiver for windows (Controller)</altname>
-      <altname>Gamepad F310 (Controller)</altname>
-      <altname>Razer Sabertooth Elite (Controller)</altname>
-      <altname>Controller (XBOX One For Windows)</altname>
+    <joystick family="Xbox 360 Controller (Windows)">
       <button id="3">Close</button>
       <button id="9">Close</button>
       <button id="10">Close</button>
     </joystick>
-    <joystick name="Microsoft X-Box 360 pad">
-      <altname>BigBen Interactive XBOX 360 Controller</altname>
-      <altname>Generic X-Box pad</altname>
-      <altname>Logitech Chillstream Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller (SFIV)</altname>
-      <altname>Pelican 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Xbox 360 Wireless Receiver</altname>
-      <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
-      <altname>Razer Sabertooth</altname>
+    <joystick family="Xbox 360 Controller (xpad)">
       <button id="3">Close</button>
       <button id="10">Close</button>
       <button id="11">Close</button>
     </joystick>
   </PlayerControls>
   <Visualisation>
-    <joystick name="Controller (XBOX 360 For Windows)">
-      <altname>Afterglow Gamepad for Xbox 360 (Controller)</altname>
-      <altname>Controller (Gamepad F310)</altname>
-      <altname>Controller (Gamepad for Xbox 360)</altname>
-      <altname>Controller (Rumble Gamepad F510)</altname>
-      <altname>Controller (Wireless Gamepad F710)</altname>
-      <altname>Controller (Xbox 360 Wireless Receiver for Windows)</altname>
-      <altname>Controller (Xbox wireless receiver for windows)</altname>
-      <altname>Controller (XBOX360 GAMEPAD)</altname>
-      <altname>Controller (Batarang wired controller (XBOX))</altname>
-      <altname>Wireless Gamepad F710 (Controller)</altname>
-      <altname>XBOX 360 For Windows</altname>
-      <altname>XBOX 360 For Windows (Controller)</altname>
-      <altname>Xbox 360 Wireless Controller</altname>
-      <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
-      <altname>Xbox wireless receiver for windows (Controller)</altname>
-      <altname>Gamepad F310 (Controller)</altname>
-      <altname>Razer Sabertooth Elite (Controller)</altname>
-      <altname>Controller (XBOX One For Windows)</altname>
+    <joystick family="Xbox 360 Controller (Windows)">
       <button id="1">Pause</button>
       <button id="2">Stop</button>
       <button id="3">ActivateWindow(MusicOSD)</button>
@@ -587,17 +397,7 @@
       <hat id="1" position="left">PreviousPreset</hat>
       <hat id="1" position="right">NextPreset</hat>
     </joystick>
-    <joystick name="Microsoft X-Box 360 pad">
-      <altname>BigBen Interactive XBOX 360 Controller</altname>
-      <altname>Generic X-Box pad</altname>
-      <altname>Logitech Chillstream Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller (SFIV)</altname>
-      <altname>Pelican 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Xbox 360 Wireless Receiver</altname>
-      <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
-      <altname>Razer Sabertooth</altname>
+    <joystick family="Xbox 360 Controller (xpad)">
       <button id="1">Pause</button>
       <button id="2">Stop</button>
       <button id="3">ActivateWindow(MusicOSD)</button>
@@ -617,135 +417,34 @@
     </joystick>
   </Visualisation>
   <MusicOSD>
-    <joystick name="Controller (XBOX 360 For Windows)">
-      <altname>Afterglow Gamepad for Xbox 360 (Controller)</altname>
-      <altname>Controller (Gamepad F310)</altname>
-      <altname>Controller (Gamepad for Xbox 360)</altname>
-      <altname>Controller (Rumble Gamepad F510)</altname>
-      <altname>Controller (Wireless Gamepad F710)</altname>
-      <altname>Controller (Xbox 360 Wireless Receiver for Windows)</altname>
-      <altname>Controller (Xbox wireless receiver for windows)</altname>
-      <altname>Controller (XBOX360 GAMEPAD)</altname>
-      <altname>Controller (Batarang wired controller (XBOX))</altname>
-      <altname>Wireless Gamepad F710 (Controller)</altname>
-      <altname>XBOX 360 For Windows</altname>
-      <altname>XBOX 360 For Windows (Controller)</altname>
-      <altname>Xbox 360 Wireless Controller</altname>
-      <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
-      <altname>Xbox wireless receiver for windows (Controller)</altname>
-      <altname>Gamepad F310 (Controller)</altname>
-      <altname>Razer Sabertooth Elite (Controller)</altname>
-      <altname>Controller (XBOX One For Windows)</altname>
+    <joystick family="Xbox 360 Controller (Windows)">
+
       <button id="3">Close</button>
       <button id="6">Info</button>
     </joystick>
-    <joystick name="Microsoft X-Box 360 pad">
-      <altname>BigBen Interactive XBOX 360 Controller</altname>
-      <altname>Generic X-Box pad</altname>
-      <altname>Logitech Chillstream Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller (SFIV)</altname>
-      <altname>Pelican 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Xbox 360 Wireless Receiver</altname>
-      <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
-      <altname>Razer Sabertooth</altname>
+    <joystick family="Xbox 360 Controller (xpad)">
       <button id="3">Close</button>
       <button id="6">Info</button>
     </joystick>
   </MusicOSD>
   <VisualisationSettings>
-    <joystick name="Controller (XBOX 360 For Windows)">
-      <altname>Afterglow Gamepad for Xbox 360 (Controller)</altname>
-      <altname>Controller (Gamepad F310)</altname>
-      <altname>Controller (Gamepad for Xbox 360)</altname>
-      <altname>Controller (Rumble Gamepad F510)</altname>
-      <altname>Controller (Wireless Gamepad F710)</altname>
-      <altname>Controller (Xbox 360 Wireless Receiver for Windows)</altname>
-      <altname>Controller (Xbox wireless receiver for windows)</altname>
-      <altname>Controller (XBOX360 GAMEPAD)</altname>
-      <altname>Controller (Batarang wired controller (XBOX))</altname>
-      <altname>Wireless Gamepad F710 (Controller)</altname>
-      <altname>XBOX 360 For Windows</altname>
-      <altname>XBOX 360 For Windows (Controller)</altname>
-      <altname>Xbox 360 Wireless Controller</altname>
-      <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
-      <altname>Xbox wireless receiver for windows (Controller)</altname>
-      <altname>Gamepad F310 (Controller)</altname>
-      <altname>Razer Sabertooth Elite (Controller)</altname>
-      <altname>Controller (XBOX One For Windows)</altname>
+    <joystick family="Xbox 360 Controller (Windows)">
       <button id="2">Close</button>
     </joystick>
-    <joystick name="Microsoft X-Box 360 pad">
-      <altname>BigBen Interactive XBOX 360 Controller</altname>
-      <altname>Generic X-Box pad</altname>
-      <altname>Logitech Chillstream Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller (SFIV)</altname>
-      <altname>Pelican 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Xbox 360 Wireless Receiver</altname>
-      <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
-      <altname>Razer Sabertooth</altname>
+    <joystick family="Xbox 360 Controller (xpad)">
       <button id="2">Close</button>
     </joystick>
   </VisualisationSettings>
   <VisualisationPresetList>
-    <joystick name="Controller (XBOX 360 For Windows)">
-      <altname>Afterglow Gamepad for Xbox 360 (Controller)</altname>
-      <altname>Controller (Gamepad F310)</altname>
-      <altname>Controller (Gamepad for Xbox 360)</altname>
-      <altname>Controller (Rumble Gamepad F510)</altname>
-      <altname>Controller (Wireless Gamepad F710)</altname>
-      <altname>Controller (Xbox 360 Wireless Receiver for Windows)</altname>
-      <altname>Controller (Xbox wireless receiver for windows)</altname>
-      <altname>Controller (XBOX360 GAMEPAD)</altname>
-      <altname>Controller (Batarang wired controller (XBOX))</altname>
-      <altname>Wireless Gamepad F710 (Controller)</altname>
-      <altname>XBOX 360 For Windows</altname>
-      <altname>XBOX 360 For Windows (Controller)</altname>
-      <altname>Xbox 360 Wireless Controller</altname>
-      <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
-      <altname>Xbox wireless receiver for windows (Controller)</altname>
-      <altname>Gamepad F310 (Controller)</altname>
-      <altname>Razer Sabertooth Elite (Controller)</altname>
-      <altname>Controller (XBOX One For Windows)</altname>
+    <joystick family="Xbox 360 Controller (Windows)">
       <button id="2">Close</button>
     </joystick>
-    <joystick name="Microsoft X-Box 360 pad">
-      <altname>BigBen Interactive XBOX 360 Controller</altname>
-      <altname>Generic X-Box pad</altname>
-      <altname>Logitech Chillstream Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller (SFIV)</altname>
-      <altname>Pelican 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Xbox 360 Wireless Receiver</altname>
-      <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
-      <altname>Razer Sabertooth</altname>
+    <joystick family="Xbox 360 Controller (xpad)">
       <button id="2">Close</button>
     </joystick>
   </VisualisationPresetList>
   <SlideShow>
-    <joystick name="Controller (XBOX 360 For Windows)">
-      <altname>Afterglow Gamepad for Xbox 360 (Controller)</altname>
-      <altname>Controller (Gamepad F310)</altname>
-      <altname>Controller (Gamepad for Xbox 360)</altname>
-      <altname>Controller (Rumble Gamepad F510)</altname>
-      <altname>Controller (Wireless Gamepad F710)</altname>
-      <altname>Controller (Xbox 360 Wireless Receiver for Windows)</altname>
-      <altname>Controller (Xbox wireless receiver for windows)</altname>
-      <altname>Controller (XBOX360 GAMEPAD)</altname>
-      <altname>Controller (Batarang wired controller (XBOX))</altname>
-      <altname>Wireless Gamepad F710 (Controller)</altname>
-      <altname>XBOX 360 For Windows</altname>
-      <altname>XBOX 360 For Windows (Controller)</altname>
-      <altname>Xbox 360 Wireless Controller</altname>
-      <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
-      <altname>Xbox wireless receiver for windows (Controller)</altname>
-      <altname>Gamepad F310 (Controller)</altname>
-	  <altname>Razer Sabertooth Elite (Controller)</altname>
-      <altname>Controller (XBOX One For Windows)</altname>
+    <joystick family="Xbox 360 Controller (Windows)">
       <button id="1">Pause</button>
       <button id="2">Stop</button>
       <button id="4">ZoomNormal</button>
@@ -764,17 +463,7 @@
       <hat id="1" position="left">PreviousPicture</hat>
       <hat id="1" position="right">NextPicture</hat>
     </joystick>
-    <joystick name="Microsoft X-Box 360 pad">
-      <altname>BigBen Interactive XBOX 360 Controller</altname>
-      <altname>Generic X-Box pad</altname>
-      <altname>Logitech Chillstream Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller (SFIV)</altname>
-      <altname>Pelican 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Xbox 360 Wireless Receiver</altname>
-      <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
-      <altname>Razer Sabertooth</altname>
+    <joystick family="Xbox 360 Controller (xpad)">
       <button id="1">Pause</button>
       <button id="2">Stop</button>
       <button id="4">ZoomNormal</button>
@@ -795,157 +484,45 @@
     </joystick>
   </SlideShow>
   <ScreenCalibration>
-    <joystick name="Controller (XBOX 360 For Windows)">
-      <altname>Afterglow Gamepad for Xbox 360 (Controller)</altname>
-      <altname>Controller (Gamepad F310)</altname>
-      <altname>Controller (Gamepad for Xbox 360)</altname>
-      <altname>Controller (Rumble Gamepad F510)</altname>
-      <altname>Controller (Wireless Gamepad F710)</altname>
-      <altname>Controller (Xbox 360 Wireless Receiver for Windows)</altname>
-      <altname>Controller (Xbox wireless receiver for windows)</altname>
-      <altname>Controller (XBOX360 GAMEPAD)</altname>
-      <altname>Controller (Batarang wired controller (XBOX))</altname>
-      <altname>Wireless Gamepad F710 (Controller)</altname>
-      <altname>XBOX 360 For Windows</altname>
-      <altname>XBOX 360 For Windows (Controller)</altname>
-      <altname>Xbox 360 Wireless Controller</altname>
-      <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
-      <altname>Xbox wireless receiver for windows (Controller)</altname>
-      <altname>Gamepad F310 (Controller)</altname>
-	  <altname>Razer Sabertooth Elite (Controller)</altname>
-      <altname>Controller (XBOX One For Windows)</altname>
+    <joystick family="Xbox 360 Controller (Windows)">
       <button id="3">ResetCalibration</button>
       <button id="5">NextResolution</button>
       <button id="6">NextCalibration</button>
     </joystick>
-    <joystick name="Microsoft X-Box 360 pad">
-      <altname>BigBen Interactive XBOX 360 Controller</altname>
-      <altname>Generic X-Box pad</altname>
-      <altname>Logitech Chillstream Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller (SFIV)</altname>
-      <altname>Pelican 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Xbox 360 Wireless Receiver</altname>
-      <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
-      <altname>Razer Sabertooth</altname>
+    <joystick family="Xbox 360 Controller (xpad)">
       <button id="3">ResetCalibration</button>
       <button id="5">NextResolution</button>
       <button id="6">NextCalibration</button>
     </joystick>
   </ScreenCalibration>
   <GUICalibration>
-    <joystick name="Controller (XBOX 360 For Windows)">
-      <altname>Afterglow Gamepad for Xbox 360 (Controller)</altname>
-      <altname>Controller (Gamepad F310)</altname>
-      <altname>Controller (Gamepad for Xbox 360)</altname>
-      <altname>Controller (Rumble Gamepad F510)</altname>
-      <altname>Controller (Wireless Gamepad F710)</altname>
-      <altname>Controller (Xbox 360 Wireless Receiver for Windows)</altname>
-      <altname>Controller (Xbox wireless receiver for windows)</altname>
-      <altname>Controller (XBOX360 GAMEPAD)</altname>
-      <altname>Controller (Batarang wired controller (XBOX))</altname>
-      <altname>Wireless Gamepad F710 (Controller)</altname>
-      <altname>XBOX 360 For Windows</altname>
-      <altname>XBOX 360 For Windows (Controller)</altname>
-      <altname>Xbox 360 Wireless Controller</altname>
-      <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
-      <altname>Xbox wireless receiver for windows (Controller)</altname>
-      <altname>Gamepad F310 (Controller)</altname>
-	  <altname>Razer Sabertooth Elite (Controller)</altname>
-      <altname>Controller (XBOX One For Windows)</altname>
+    <joystick family="Xbox 360 Controller (Windows)">
       <button id="3">ResetCalibration</button>
       <button id="5">NextResolution</button>
       <button id="6">NextCalibration</button>
     </joystick>
-    <joystick name="Microsoft X-Box 360 pad">
-      <altname>BigBen Interactive XBOX 360 Controller</altname>
-      <altname>Generic X-Box pad</altname>
-      <altname>Logitech Chillstream Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller (SFIV)</altname>
-      <altname>Pelican 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Xbox 360 Wireless Receiver</altname>
-      <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
-      <altname>Razer Sabertooth</altname>
+    <joystick family="Xbox 360 Controller (xpad)">
       <button id="3">ResetCalibration</button>
       <button id="5">NextResolution</button>
       <button id="6">NextCalibration</button>
     </joystick>
   </GUICalibration>
   <VideoOSD>
-    <joystick name="Controller (XBOX 360 For Windows)">
-      <altname>Afterglow Gamepad for Xbox 360 (Controller)</altname>
-      <altname>Controller (Gamepad F310)</altname>
-      <altname>Controller (Gamepad for Xbox 360)</altname>
-      <altname>Controller (Rumble Gamepad F510)</altname>
-      <altname>Controller (Wireless Gamepad F710)</altname>
-      <altname>Controller (Xbox 360 Wireless Receiver for Windows)</altname>
-      <altname>Controller (Xbox wireless receiver for windows)</altname>
-      <altname>Controller (XBOX360 GAMEPAD)</altname>
-      <altname>Controller (Batarang wired controller (XBOX))</altname>
-      <altname>Wireless Gamepad F710 (Controller)</altname>
-      <altname>XBOX 360 For Windows</altname>
-      <altname>XBOX 360 For Windows (Controller)</altname>
-      <altname>Xbox 360 Wireless Controller</altname>
-      <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
-      <altname>Xbox wireless receiver for windows (Controller)</altname>
-      <altname>Gamepad F310 (Controller)</altname>
-	  <altname>Razer Sabertooth Elite (Controller)</altname>
-      <altname>Controller (XBOX One For Windows)</altname>
+    <joystick family="Xbox 360 Controller (Windows)">
       <button id="3">Close</button>
     </joystick>
-    <joystick name="Microsoft X-Box 360 pad">
-      <altname>BigBen Interactive XBOX 360 Controller</altname>
-      <altname>Generic X-Box pad</altname>
-      <altname>Logitech Chillstream Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller (SFIV)</altname>
-      <altname>Pelican 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Xbox 360 Wireless Receiver</altname>
-      <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
-      <altname>Razer Sabertooth</altname>
+    <joystick family="Xbox 360 Controller (xpad)">
       <button id="3">Close</button>
     </joystick>
   </VideoOSD>
   <VideoMenu>
-    <joystick name="Controller (XBOX 360 For Windows)">
-      <altname>Afterglow Gamepad for Xbox 360 (Controller)</altname>
-      <altname>Controller (Gamepad F310)</altname>
-      <altname>Controller (Gamepad for Xbox 360)</altname>
-      <altname>Controller (Rumble Gamepad F510)</altname>
-      <altname>Controller (Wireless Gamepad F710)</altname>
-      <altname>Controller (Xbox 360 Wireless Receiver for Windows)</altname>
-      <altname>Controller (Xbox wireless receiver for windows)</altname>
-      <altname>Controller (XBOX360 GAMEPAD)</altname>
-      <altname>Controller (Batarang wired controller (XBOX))</altname>
-      <altname>Wireless Gamepad F710 (Controller)</altname>
-      <altname>XBOX 360 For Windows</altname>
-      <altname>XBOX 360 For Windows (Controller)</altname>
-      <altname>Xbox 360 Wireless Controller</altname>
-      <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
-      <altname>Xbox wireless receiver for windows (Controller)</altname>
-      <altname>Gamepad F310 (Controller)</altname>
-	  <altname>Razer Sabertooth Elite (Controller)</altname>
-      <altname>Controller (XBOX One For Windows)</altname>
+    <joystick family="Xbox 360 Controller (Windows)">
       <button id="2">Stop</button>
       <button id="3">OSD</button>
       <button id="5">AspectRatio</button>
       <button id="8">Info</button>
     </joystick>
-    <joystick name="Microsoft X-Box 360 pad">
-      <altname>BigBen Interactive XBOX 360 Controller</altname>
-      <altname>Generic X-Box pad</altname>
-      <altname>Logitech Chillstream Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller (SFIV)</altname>
-      <altname>Pelican 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Xbox 360 Wireless Receiver</altname>
-      <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
-      <altname>Razer Sabertooth</altname>
+    <joystick family="Xbox 360 Controller (xpad)">
       <button id="2">Stop</button>
       <button id="3">OSD</button>
       <button id="5">AspectRatio</button>
@@ -953,114 +530,30 @@
     </joystick>
   </VideoMenu>
   <OSDVideoSettings>
-    <joystick name="Controller (XBOX 360 For Windows)">
-      <altname>Afterglow Gamepad for Xbox 360 (Controller)</altname>
-      <altname>Controller (Gamepad F310)</altname>
-      <altname>Controller (Gamepad for Xbox 360)</altname>
-      <altname>Controller (Rumble Gamepad F510)</altname>
-      <altname>Controller (Wireless Gamepad F710)</altname>
-      <altname>Controller (Xbox 360 Wireless Receiver for Windows)</altname>
-      <altname>Controller (Xbox wireless receiver for windows)</altname>
-      <altname>Controller (XBOX360 GAMEPAD)</altname>
-      <altname>Controller (Batarang wired controller (XBOX))</altname>
-      <altname>Wireless Gamepad F710 (Controller)</altname>
-      <altname>XBOX 360 For Windows</altname>
-      <altname>XBOX 360 For Windows (Controller)</altname>
-      <altname>Xbox 360 Wireless Controller</altname>
-      <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
-      <altname>Xbox wireless receiver for windows (Controller)</altname>
-      <altname>Gamepad F310 (Controller)</altname>
-	  <altname>Razer Sabertooth Elite (Controller)</altname>
-      <altname>Controller (XBOX One For Windows)</altname>
+    <joystick family="Xbox 360 Controller (Windows)">
       <button id="5">AspectRatio</button>
       <button id="3">Close</button>
     </joystick>
-    <joystick name="Microsoft X-Box 360 pad">
-      <altname>BigBen Interactive XBOX 360 Controller</altname>
-      <altname>Generic X-Box pad</altname>
-      <altname>Logitech Chillstream Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller (SFIV)</altname>
-      <altname>Pelican 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Xbox 360 Wireless Receiver</altname>
-      <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
-      <altname>Razer Sabertooth</altname>
+    <joystick family="Xbox 360 Controller (xpad)">
       <button id="5">AspectRatio</button>
       <button id="3">Close</button>
     </joystick>
   </OSDVideoSettings>
   <OSDAudioSettings>
-    <joystick name="Controller (XBOX 360 For Windows)">
-      <altname>Afterglow Gamepad for Xbox 360 (Controller)</altname>
-      <altname>Controller (Gamepad F310)</altname>
-      <altname>Controller (Gamepad for Xbox 360)</altname>
-      <altname>Controller (Rumble Gamepad F510)</altname>
-      <altname>Controller (Wireless Gamepad F710)</altname>
-      <altname>Controller (Xbox 360 Wireless Receiver for Windows)</altname>
-      <altname>Controller (Xbox wireless receiver for windows)</altname>
-      <altname>Controller (XBOX360 GAMEPAD)</altname>
-      <altname>Controller (Batarang wired controller (XBOX))</altname>
-      <altname>Wireless Gamepad F710 (Controller)</altname>
-      <altname>XBOX 360 For Windows</altname>
-      <altname>XBOX 360 For Windows (Controller)</altname>
-      <altname>Xbox 360 Wireless Controller</altname>
-      <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
-      <altname>Xbox wireless receiver for windows (Controller)</altname>
-      <altname>Gamepad F310 (Controller)</altname>
-	  <altname>Razer Sabertooth Elite (Controller)</altname>
-      <altname>Controller (XBOX One For Windows)</altname>
+    <joystick family="Xbox 360 Controller (Windows)">
       <button id="5">AspectRatio</button>
       <button id="3">Close</button>
     </joystick>
-    <joystick name="Microsoft X-Box 360 pad">
-      <altname>BigBen Interactive XBOX 360 Controller</altname>
-      <altname>Generic X-Box pad</altname>
-      <altname>Logitech Chillstream Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller (SFIV)</altname>
-      <altname>Pelican 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Xbox 360 Wireless Receiver</altname>
-      <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
-      <altname>Razer Sabertooth</altname>
+    <joystick family="Xbox 360 Controller (xpad)">
       <button id="5">AspectRatio</button>
       <button id="3">Close</button>
     </joystick>
   </OSDAudioSettings>
   <VideoBookmarks>
-    <joystick name="Controller (XBOX 360 For Windows)">
-      <altname>Afterglow Gamepad for Xbox 360 (Controller)</altname>
-      <altname>Controller (Gamepad F310)</altname>
-      <altname>Controller (Gamepad for Xbox 360)</altname>
-      <altname>Controller (Rumble Gamepad F510)</altname>
-      <altname>Controller (Wireless Gamepad F710)</altname>
-      <altname>Controller (Xbox 360 Wireless Receiver for Windows)</altname>
-      <altname>Controller (Xbox wireless receiver for windows)</altname>
-      <altname>Controller (XBOX360 GAMEPAD)</altname>
-      <altname>Controller (Batarang wired controller (XBOX))</altname>
-      <altname>Wireless Gamepad F710 (Controller)</altname>
-      <altname>XBOX 360 For Windows</altname>
-      <altname>XBOX 360 For Windows (Controller)</altname>
-      <altname>Xbox 360 Wireless Controller</altname>
-      <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
-      <altname>Xbox wireless receiver for windows (Controller)</altname>
-      <altname>Gamepad F310 (Controller)</altname>
-	  <altname>Razer Sabertooth Elite (Controller)</altname>
-      <altname>Controller (XBOX One For Windows)</altname>
+    <joystick family="Xbox 360 Controller (Windows)">
       <button id="5">Delete</button>
     </joystick>
-    <joystick name="Microsoft X-Box 360 pad">
-      <altname>BigBen Interactive XBOX 360 Controller</altname>
-      <altname>Generic X-Box pad</altname>
-      <altname>Logitech Chillstream Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller (SFIV)</altname>
-      <altname>Pelican 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Xbox 360 Wireless Receiver</altname>
-      <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
-      <altname>Razer Sabertooth</altname>
+    <joystick family="Xbox 360 Controller (xpad)">
       <button id="5">Delete</button>
     </joystick>
   </VideoBookmarks>
@@ -1069,61 +562,15 @@
   <MyVideoFiles>
   </MyVideoFiles>
   <MyVideoPlaylist>
-    <joystick name="Controller (XBOX 360 For Windows)">
-      <altname>Afterglow Gamepad for Xbox 360 (Controller)</altname>
-      <altname>Controller (Gamepad F310)</altname>
-      <altname>Controller (Gamepad for Xbox 360)</altname>
-      <altname>Controller (Rumble Gamepad F510)</altname>
-      <altname>Controller (Wireless Gamepad F710)</altname>
-      <altname>Controller (Xbox 360 Wireless Receiver for Windows)</altname>
-      <altname>Controller (Xbox wireless receiver for windows)</altname>
-      <altname>Controller (XBOX360 GAMEPAD)</altname>
-      <altname>Controller (Batarang wired controller (XBOX))</altname>
-      <altname>Wireless Gamepad F710 (Controller)</altname>
-      <altname>XBOX 360 For Windows</altname>
-      <altname>XBOX 360 For Windows (Controller)</altname>
-      <altname>Xbox 360 Wireless Controller</altname>
-      <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
-      <altname>Xbox wireless receiver for windows (Controller)</altname>
-      <altname>Gamepad F310 (Controller)</altname>
-	  <altname>Razer Sabertooth Elite (Controller)</altname>
-      <altname>Controller (XBOX One For Windows)</altname>
+    <joystick family="Xbox 360 Controller (Windows)">
       <button id="5">Delete</button>
     </joystick>
-    <joystick name="Microsoft X-Box 360 pad">
-      <altname>BigBen Interactive XBOX 360 Controller</altname>
-      <altname>Generic X-Box pad</altname>
-      <altname>Logitech Chillstream Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller (SFIV)</altname>
-      <altname>Pelican 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Xbox 360 Wireless Receiver</altname>
-      <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
-      <altname>Razer Sabertooth</altname>
+    <joystick family="Xbox 360 Controller (xpad)">
       <button id="5">Delete</button>
     </joystick>
   </MyVideoPlaylist>
   <VirtualKeyboard>
-    <joystick name="Controller (XBOX 360 For Windows)">
-      <altname>Afterglow Gamepad for Xbox 360 (Controller)</altname>
-      <altname>Controller (Gamepad F310)</altname>
-      <altname>Controller (Gamepad for Xbox 360)</altname>
-      <altname>Controller (Rumble Gamepad F510)</altname>
-      <altname>Controller (Wireless Gamepad F710)</altname>
-      <altname>Controller (Xbox 360 Wireless Receiver for Windows)</altname>
-      <altname>Controller (Xbox wireless receiver for windows)</altname>
-      <altname>Controller (XBOX360 GAMEPAD)</altname>
-      <altname>Controller (Batarang wired controller (XBOX))</altname>
-      <altname>Wireless Gamepad F710 (Controller)</altname>
-      <altname>XBOX 360 For Windows</altname>
-      <altname>XBOX 360 For Windows (Controller)</altname>
-      <altname>Xbox 360 Wireless Controller</altname>
-      <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
-      <altname>Xbox wireless receiver for windows (Controller)</altname>
-      <altname>Gamepad F310 (Controller)</altname>
-	  <altname>Razer Sabertooth Elite (Controller)</altname>
-      <altname>Controller (XBOX One For Windows)</altname>
+    <joystick family="Xbox 360 Controller (Windows)">
       <button id="2">BackSpace</button>
       <button id="4">Symbols</button>
       <button id="5">Shift</button>
@@ -1131,17 +578,7 @@
       <axis id="3" limit="+1">CursorLeft</axis>
       <axis id="3" limit="-1">CursorRight</axis>
     </joystick>
-    <joystick name="Microsoft X-Box 360 pad">
-      <altname>BigBen Interactive XBOX 360 Controller</altname>
-      <altname>Generic X-Box pad</altname>
-      <altname>Logitech Chillstream Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller (SFIV)</altname>
-      <altname>Pelican 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Xbox 360 Wireless Receiver</altname>
-      <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
-      <altname>Razer Sabertooth</altname>
+    <joystick family="Xbox 360 Controller (xpad)">
       <button id="2">BackSpace</button>
       <button id="4">Symbols</button>
       <button id="5">Shift</button>
@@ -1151,515 +588,123 @@
     </joystick>
   </VirtualKeyboard>
   <ContextMenu>
-    <joystick name="Controller (XBOX 360 For Windows)">
-      <altname>Afterglow Gamepad for Xbox 360 (Controller)</altname>
-      <altname>Controller (Gamepad F310)</altname>
-      <altname>Controller (Gamepad for Xbox 360)</altname>
-      <altname>Controller (Rumble Gamepad F510)</altname>
-      <altname>Controller (Wireless Gamepad F710)</altname>
-      <altname>Controller (Xbox 360 Wireless Receiver for Windows)</altname>
-      <altname>Controller (Xbox wireless receiver for windows)</altname>
-      <altname>Controller (XBOX360 GAMEPAD)</altname>
-      <altname>Controller (Batarang wired controller (XBOX))</altname>
-      <altname>Wireless Gamepad F710 (Controller)</altname>
-      <altname>XBOX 360 For Windows</altname>
-      <altname>XBOX 360 For Windows (Controller)</altname>
-      <altname>Xbox 360 Wireless Controller</altname>
-      <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
-      <altname>Xbox wireless receiver for windows (Controller)</altname>
-      <altname>Gamepad F310 (Controller)</altname>
-      <altname>Razer Sabertooth Elite (Controller)</altname>
-      <altname>Controller (XBOX One For Windows)</altname>
+    <joystick family="Xbox 360 Controller (Windows)">
       <button id="2">Close</button>
       <button id="3">Close</button>
     </joystick>
-    <joystick name="Microsoft X-Box 360 pad">
-      <altname>BigBen Interactive XBOX 360 Controller</altname>
-      <altname>Generic X-Box pad</altname>
-      <altname>Logitech Chillstream Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller (SFIV)</altname>
-      <altname>Pelican 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Xbox 360 Wireless Receiver</altname>
-      <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
-      <altname>Razer Sabertooth</altname>
+    <joystick family="Xbox 360 Controller (xpad)">
       <button id="2">Close</button>
       <button id="3">Close</button>
     </joystick>
   </ContextMenu>
   <Scripts>
-    <joystick name="Controller (XBOX 360 For Windows)">
-      <altname>Afterglow Gamepad for Xbox 360 (Controller)</altname>
-      <altname>Controller (Gamepad F310)</altname>
-      <altname>Controller (Gamepad for Xbox 360)</altname>
-      <altname>Controller (Rumble Gamepad F510)</altname>
-      <altname>Controller (Wireless Gamepad F710)</altname>
-      <altname>Controller (Xbox 360 Wireless Receiver for Windows)</altname>
-      <altname>Controller (Xbox wireless receiver for windows)</altname>
-      <altname>Controller (XBOX360 GAMEPAD)</altname>
-      <altname>Controller (Batarang wired controller (XBOX))</altname>
-      <altname>Wireless Gamepad F710 (Controller)</altname>
-      <altname>XBOX 360 For Windows</altname>
-      <altname>XBOX 360 For Windows (Controller)</altname>
-      <altname>Xbox 360 Wireless Controller</altname>
-      <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
-      <altname>Xbox wireless receiver for windows (Controller)</altname>
-      <altname>Gamepad F310 (Controller)</altname>
-      <altname>Razer Sabertooth Elite (Controller)</altname>
-      <altname>Controller (XBOX One For Windows)</altname>
+    <joystick family="Xbox 360 Controller (Windows)">
       <button id="3">Info</button>
     </joystick>
-    <joystick name="Microsoft X-Box 360 pad">
-      <altname>BigBen Interactive XBOX 360 Controller</altname>
-      <altname>Generic X-Box pad</altname>
-      <altname>Logitech Chillstream Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller (SFIV)</altname>
-      <altname>Pelican 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Xbox 360 Wireless Receiver</altname>
-      <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
-      <altname>Razer Sabertooth</altname>
+    <joystick family="Xbox 360 Controller (xpad)">
       <button id="3">Info</button>
     </joystick>
   </Scripts>
   <Settings>
-    <joystick name="Controller (XBOX 360 For Windows)">
-      <altname>Afterglow Gamepad for Xbox 360 (Controller)</altname>
-      <altname>Controller (Gamepad F310)</altname>
-      <altname>Controller (Gamepad for Xbox 360)</altname>
-      <altname>Controller (Rumble Gamepad F510)</altname>
-      <altname>Controller (Wireless Gamepad F710)</altname>
-      <altname>Controller (Xbox 360 Wireless Receiver for Windows)</altname>
-      <altname>Controller (Xbox wireless receiver for windows)</altname>
-      <altname>Controller (XBOX360 GAMEPAD)</altname>
-      <altname>Controller (Batarang wired controller (XBOX))</altname>
-      <altname>Wireless Gamepad F710 (Controller)</altname>
-      <altname>XBOX 360 For Windows</altname>
-      <altname>XBOX 360 For Windows (Controller)</altname>
-      <altname>Xbox 360 Wireless Controller</altname>
-      <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
-      <altname>Xbox wireless receiver for windows (Controller)</altname>
-      <altname>Gamepad F310 (Controller)</altname>
-      <altname>Razer Sabertooth Elite (Controller)</altname>
-      <altname>Controller (XBOX One For Windows)</altname>
+    <joystick family="Xbox 360 Controller (Windows)">
       <button id="2">PreviousMenu</button>
     </joystick>
-    <joystick name="Microsoft X-Box 360 pad">
-      <altname>BigBen Interactive XBOX 360 Controller</altname>
-      <altname>Generic X-Box pad</altname>
-      <altname>Logitech Chillstream Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller (SFIV)</altname>
-      <altname>Pelican 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Xbox 360 Wireless Receiver</altname>
-      <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
-      <altname>Razer Sabertooth</altname>
+    <joystick family="Xbox 360 Controller (xpad)">
       <button id="2">PreviousMenu</button>
     </joystick>
   </Settings>
   <AddonInformation>
-    <joystick name="Controller (XBOX 360 For Windows)">
-      <altname>Afterglow Gamepad for Xbox 360 (Controller)</altname>
-      <altname>Controller (Gamepad F310)</altname>
-      <altname>Controller (Gamepad for Xbox 360)</altname>
-      <altname>Controller (Rumble Gamepad F510)</altname>
-      <altname>Controller (Wireless Gamepad F710)</altname>
-      <altname>Controller (Xbox 360 Wireless Receiver for Windows)</altname>
-      <altname>Controller (Xbox wireless receiver for windows)</altname>
-      <altname>Controller (XBOX360 GAMEPAD)</altname>
-      <altname>Controller (Batarang wired controller (XBOX))</altname>
-      <altname>Wireless Gamepad F710 (Controller)</altname>
-      <altname>XBOX 360 For Windows</altname>
-      <altname>XBOX 360 For Windows (Controller)</altname>
-      <altname>Xbox 360 Wireless Controller</altname>
-      <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
-      <altname>Xbox wireless receiver for windows (Controller)</altname>
-      <altname>Gamepad F310 (Controller)</altname>
-      <altname>Razer Sabertooth Elite (Controller)</altname>
-      <altname>Controller (XBOX One For Windows)</altname>
+    <joystick family="Xbox 360 Controller (Windows)">
       <button id="2">Close</button>
     </joystick>
-    <joystick name="Microsoft X-Box 360 pad">
-      <altname>BigBen Interactive XBOX 360 Controller</altname>
-      <altname>Generic X-Box pad</altname>
-      <altname>Logitech Chillstream Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller (SFIV)</altname>
-      <altname>Pelican 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Xbox 360 Wireless Receiver</altname>
-      <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
-      <altname>Razer Sabertooth</altname>
+    <joystick family="Xbox 360 Controller (xpad)">
       <button id="2">Close</button>
     </joystick>
   </AddonInformation>
   <AddonSettings>
-    <joystick name="Controller (XBOX 360 For Windows)">
-      <altname>Afterglow Gamepad for Xbox 360 (Controller)</altname>
-      <altname>Controller (Gamepad F310)</altname>
-      <altname>Controller (Gamepad for Xbox 360)</altname>
-      <altname>Controller (Rumble Gamepad F510)</altname>
-      <altname>Controller (Wireless Gamepad F710)</altname>
-      <altname>Controller (Xbox 360 Wireless Receiver for Windows)</altname>
-      <altname>Controller (Xbox wireless receiver for windows)</altname>
-      <altname>Controller (XBOX360 GAMEPAD)</altname>
-      <altname>Controller (Batarang wired controller (XBOX))</altname>
-      <altname>Wireless Gamepad F710 (Controller)</altname>
-      <altname>XBOX 360 For Windows</altname>
-      <altname>XBOX 360 For Windows (Controller)</altname>
-      <altname>Xbox 360 Wireless Controller</altname>
-      <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
-      <altname>Xbox wireless receiver for windows (Controller)</altname>
-      <altname>Gamepad F310 (Controller)</altname>
-      <altname>Razer Sabertooth Elite (Controller)</altname>
-      <altname>Controller (XBOX One For Windows)</altname>
+    <joystick family="Xbox 360 Controller (Windows)">
       <button id="2">Close</button>
     </joystick>
-    <joystick name="Microsoft X-Box 360 pad">
-      <altname>BigBen Interactive XBOX 360 Controller</altname>
-      <altname>Generic X-Box pad</altname>
-      <altname>Logitech Chillstream Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller (SFIV)</altname>
-      <altname>Pelican 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Xbox 360 Wireless Receiver</altname>
-      <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
-      <altname>Razer Sabertooth</altname>
+    <joystick family="Xbox 360 Controller (xpad)">
       <button id="2">Close</button>
     </joystick>
   </AddonSettings>
   <TextViewer>
-    <joystick name="Controller (XBOX 360 For Windows)">
-      <altname>Afterglow Gamepad for Xbox 360 (Controller)</altname>
-      <altname>Controller (Gamepad F310)</altname>
-      <altname>Controller (Gamepad for Xbox 360)</altname>
-      <altname>Controller (Rumble Gamepad F510)</altname>
-      <altname>Controller (Wireless Gamepad F710)</altname>
-      <altname>Controller (Xbox 360 Wireless Receiver for Windows)</altname>
-      <altname>Controller (Xbox wireless receiver for windows)</altname>
-      <altname>Controller (XBOX360 GAMEPAD)</altname>
-      <altname>Controller (Batarang wired controller (XBOX))</altname>
-      <altname>Wireless Gamepad F710 (Controller)</altname>
-      <altname>XBOX 360 For Windows</altname>
-      <altname>XBOX 360 For Windows (Controller)</altname>
-      <altname>Xbox 360 Wireless Controller</altname>
-      <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
-      <altname>Xbox wireless receiver for windows (Controller)</altname>
-      <altname>Gamepad F310 (Controller)</altname>
-      <altname>Razer Sabertooth Elite (Controller)</altname>
-      <altname>Controller (XBOX One For Windows)</altname>
+    <joystick family="Xbox 360 Controller (Windows)">
       <button id="2">Close</button>
     </joystick>
-    <joystick name="Microsoft X-Box 360 pad">
-      <altname>BigBen Interactive XBOX 360 Controller</altname>
-      <altname>Generic X-Box pad</altname>
-      <altname>Logitech Chillstream Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller (SFIV)</altname>
-      <altname>Pelican 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Xbox 360 Wireless Receiver</altname>
-      <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
-      <altname>Razer Sabertooth</altname>
+    <joystick family="Xbox 360 Controller (xpad)">
       <button id="2">Close</button>
     </joystick>
   </TextViewer>
   <shutdownmenu>
-    <joystick name="Controller (XBOX 360 For Windows)">
-      <altname>Afterglow Gamepad for Xbox 360 (Controller)</altname>
-      <altname>Controller (Gamepad F310)</altname>
-      <altname>Controller (Gamepad for Xbox 360)</altname>
-      <altname>Controller (Rumble Gamepad F510)</altname>
-      <altname>Controller (Wireless Gamepad F710)</altname>
-      <altname>Controller (Xbox 360 Wireless Receiver for Windows)</altname>
-      <altname>Controller (Xbox wireless receiver for windows)</altname>
-      <altname>Controller (XBOX360 GAMEPAD)</altname>
-      <altname>Controller (Batarang wired controller (XBOX))</altname>
-      <altname>Wireless Gamepad F710 (Controller)</altname>
-      <altname>XBOX 360 For Windows</altname>
-      <altname>XBOX 360 For Windows (Controller)</altname>
-      <altname>Xbox 360 Wireless Controller</altname>
-      <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
-      <altname>Xbox wireless receiver for windows (Controller)</altname>
-      <altname>Gamepad F310 (Controller)</altname>
-      <altname>Razer Sabertooth Elite (Controller)</altname>
-      <altname>Controller (XBOX One For Windows)</altname>
+    <joystick family="Xbox 360 Controller (Windows)">
       <button id="2">PreviousMenu</button>
       <button id="9">PreviousMenu</button>
     </joystick>
-    <joystick name="Microsoft X-Box 360 pad">
-      <altname>BigBen Interactive XBOX 360 Controller</altname>
-      <altname>Generic X-Box pad</altname>
-      <altname>Logitech Chillstream Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller (SFIV)</altname>
-      <altname>Pelican 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Xbox 360 Wireless Receiver</altname>
-      <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
-      <altname>Razer Sabertooth</altname>
+    <joystick family="Xbox 360 Controller (xpad)">
       <button id="2">PreviousMenu</button>
       <button id="10">PreviousMenu</button>
     </joystick>
   </shutdownmenu>
   <submenu>
-    <joystick name="Controller (XBOX 360 For Windows)">
-      <altname>Afterglow Gamepad for Xbox 360 (Controller)</altname>
-      <altname>Controller (Gamepad F310)</altname>
-      <altname>Controller (Gamepad for Xbox 360)</altname>
-      <altname>Controller (Rumble Gamepad F510)</altname>
-      <altname>Controller (Wireless Gamepad F710)</altname>
-      <altname>Controller (Xbox 360 Wireless Receiver for Windows)</altname>
-      <altname>Controller (Xbox wireless receiver for windows)</altname>
-      <altname>Controller (XBOX360 GAMEPAD)</altname>
-      <altname>Controller (Batarang wired controller (XBOX))</altname>
-      <altname>Wireless Gamepad F710 (Controller)</altname>
-      <altname>XBOX 360 For Windows</altname>
-      <altname>XBOX 360 For Windows (Controller)</altname>
-      <altname>Xbox 360 Wireless Controller</altname>
-      <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
-      <altname>Xbox wireless receiver for windows (Controller)</altname>
-      <altname>Gamepad F310 (Controller)</altname>
-      <altname>Razer Sabertooth Elite (Controller)</altname>
-      <altname>Controller (XBOX One For Windows)</altname>
+    <joystick family="Xbox 360 Controller (Windows)">
       <button id="2">PreviousMenu</button>
     </joystick>
-    <joystick name="Microsoft X-Box 360 pad">
-      <altname>BigBen Interactive XBOX 360 Controller</altname>
-      <altname>Generic X-Box pad</altname>
-      <altname>Logitech Chillstream Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller (SFIV)</altname>
-      <altname>Pelican 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Xbox 360 Wireless Receiver</altname>
-      <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
-      <altname>Razer Sabertooth</altname>
+    <joystick family="Xbox 360 Controller (xpad)">
       <button id="2">PreviousMenu</button>
     </joystick>
   </submenu>
   <MusicInformation>
-    <joystick name="Controller (XBOX 360 For Windows)">
-      <altname>Afterglow Gamepad for Xbox 360 (Controller)</altname>
-      <altname>Controller (Gamepad F310)</altname>
-      <altname>Controller (Gamepad for Xbox 360)</altname>
-      <altname>Controller (Rumble Gamepad F510)</altname>
-      <altname>Controller (Wireless Gamepad F710)</altname>
-      <altname>Controller (Xbox 360 Wireless Receiver for Windows)</altname>
-      <altname>Controller (Xbox wireless receiver for windows)</altname>
-      <altname>Controller (XBOX360 GAMEPAD)</altname>
-      <altname>Controller (Batarang wired controller (XBOX))</altname>
-      <altname>Wireless Gamepad F710 (Controller)</altname>
-      <altname>XBOX 360 For Windows</altname>
-      <altname>XBOX 360 For Windows (Controller)</altname>
-      <altname>Xbox 360 Wireless Controller</altname>
-      <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
-      <altname>Xbox wireless receiver for windows (Controller)</altname>
-      <altname>Gamepad F310 (Controller)</altname>
-      <altname>Razer Sabertooth Elite (Controller)</altname>
-      <altname>Controller (XBOX One For Windows)</altname>
+    <joystick family="Xbox 360 Controller (Windows)">
       <button id="2">Close</button>
     </joystick>
-    <joystick name="Microsoft X-Box 360 pad">
-      <altname>BigBen Interactive XBOX 360 Controller</altname>
-      <altname>Generic X-Box pad</altname>
-      <altname>Logitech Chillstream Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller (SFIV)</altname>
-      <altname>Pelican 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Xbox 360 Wireless Receiver</altname>
-      <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
-      <altname>Razer Sabertooth</altname>
+    <joystick family="Xbox 360 Controller (xpad)">
       <button id="2">Close</button>
     </joystick>
   </MusicInformation>
   <MovieInformation>
-    <joystick name="Controller (XBOX 360 For Windows)">
-      <altname>Afterglow Gamepad for Xbox 360 (Controller)</altname>
-      <altname>Controller (Gamepad F310)</altname>
-      <altname>Controller (Gamepad for Xbox 360)</altname>
-      <altname>Controller (Rumble Gamepad F510)</altname>
-      <altname>Controller (Wireless Gamepad F710)</altname>
-      <altname>Controller (Xbox 360 Wireless Receiver for Windows)</altname>
-      <altname>Controller (Xbox wireless receiver for windows)</altname>
-      <altname>Controller (XBOX360 GAMEPAD)</altname>
-      <altname>Controller (Batarang wired controller (XBOX))</altname>
-      <altname>Wireless Gamepad F710 (Controller)</altname>
-      <altname>XBOX 360 For Windows</altname>
-      <altname>XBOX 360 For Windows (Controller)</altname>
-      <altname>Xbox 360 Wireless Controller</altname>
-      <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
-      <altname>Xbox wireless receiver for windows (Controller)</altname>
-      <altname>Gamepad F310 (Controller)</altname>
-      <altname>Razer Sabertooth Elite (Controller)</altname>
-      <altname>Controller (XBOX One For Windows)</altname>
+    <joystick family="Xbox 360 Controller (Windows)">
       <button id="2">Close</button>
     </joystick>
-    <joystick name="Microsoft X-Box 360 pad">
-      <altname>BigBen Interactive XBOX 360 Controller</altname>
-      <altname>Generic X-Box pad</altname>
-      <altname>Logitech Chillstream Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller (SFIV)</altname>
-      <altname>Pelican 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Xbox 360 Wireless Receiver</altname>
-      <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
-      <altname>Razer Sabertooth</altname>
+    <joystick family="Xbox 360 Controller (xpad)">
       <button id="2">Close</button>
     </joystick>
   </MovieInformation>
   <NumericInput>
-    <joystick name="Controller (XBOX 360 For Windows)">
-      <altname>Afterglow Gamepad for Xbox 360 (Controller)</altname>
-      <altname>Controller (Gamepad F310)</altname>
-      <altname>Controller (Gamepad for Xbox 360)</altname>
-      <altname>Controller (Rumble Gamepad F510)</altname>
-      <altname>Controller (Wireless Gamepad F710)</altname>
-      <altname>Controller (Xbox 360 Wireless Receiver for Windows)</altname>
-      <altname>Controller (Xbox wireless receiver for windows)</altname>
-      <altname>Controller (XBOX360 GAMEPAD)</altname>
-      <altname>Controller (Batarang wired controller (XBOX))</altname>
-      <altname>Wireless Gamepad F710 (Controller)</altname>
-      <altname>XBOX 360 For Windows</altname>
-      <altname>XBOX 360 For Windows (Controller)</altname>
-      <altname>Xbox 360 Wireless Controller</altname>
-      <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
-      <altname>Xbox wireless receiver for windows (Controller)</altname>
-      <altname>Gamepad F310 (Controller)</altname>
-      <altname>Razer Sabertooth Elite (Controller)</altname>
-      <altname>Controller (XBOX One For Windows)</altname>
+    <joystick family="Xbox 360 Controller (Windows)">
       <button id="2">BackSpace</button>
       <button id="9">Enter</button>
     </joystick>
-    <joystick name="Microsoft X-Box 360 pad">
-      <altname>BigBen Interactive XBOX 360 Controller</altname>
-      <altname>Generic X-Box pad</altname>
-      <altname>Logitech Chillstream Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller (SFIV)</altname>
-      <altname>Pelican 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Xbox 360 Wireless Receiver</altname>
-      <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
-      <altname>Razer Sabertooth</altname>
+    <joystick family="Xbox 360 Controller (xpad)">
       <button id="2">BackSpace</button>
       <button id="10">Enter</button>
     </joystick>
   </NumericInput>
   <GamepadInput>
-    <joystick name="Controller (XBOX 360 For Windows)">
-      <altname>Afterglow Gamepad for Xbox 360 (Controller)</altname>
-      <altname>Controller (Gamepad F310)</altname>
-      <altname>Controller (Gamepad for Xbox 360)</altname>
-      <altname>Controller (Rumble Gamepad F510)</altname>
-      <altname>Controller (Wireless Gamepad F710)</altname>
-      <altname>Controller (Xbox 360 Wireless Receiver for Windows)</altname>
-      <altname>Controller (Xbox wireless receiver for windows)</altname>
-      <altname>Controller (XBOX360 GAMEPAD)</altname>
-      <altname>Controller (Batarang wired controller (XBOX))</altname>
-      <altname>Wireless Gamepad F710 (Controller)</altname>
-      <altname>XBOX 360 For Windows</altname>
-      <altname>XBOX 360 For Windows (Controller)</altname>
-      <altname>Xbox 360 Wireless Controller</altname>
-      <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
-      <altname>Xbox wireless receiver for windows (Controller)</altname>
-      <altname>Gamepad F310 (Controller)</altname>
-      <altname>Razer Sabertooth Elite (Controller)</altname>
-      <altname>Controller (XBOX One For Windows)</altname>
+    <joystick family="Xbox 360 Controller (Windows)">
       <button id="9">Stop</button>
     </joystick>
-    <joystick name="Microsoft X-Box 360 pad">
-      <altname>BigBen Interactive XBOX 360 Controller</altname>
-      <altname>Generic X-Box pad</altname>
-      <altname>Logitech Chillstream Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller (SFIV)</altname>
-      <altname>Pelican 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Xbox 360 Wireless Receiver</altname>
-      <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
-      <altname>Razer Sabertooth</altname>
+    <joystick family="Xbox 360 Controller (xpad)">
       <button id="11">Stop</button>
     </joystick>
   </GamepadInput>
   <LockSettings>
-    <joystick name="Controller (XBOX 360 For Windows)">
-      <altname>Afterglow Gamepad for Xbox 360 (Controller)</altname>
-      <altname>Controller (Gamepad F310)</altname>
-      <altname>Controller (Gamepad for Xbox 360)</altname>
-      <altname>Controller (Rumble Gamepad F510)</altname>
-      <altname>Controller (Wireless Gamepad F710)</altname>
-      <altname>Controller (Xbox 360 Wireless Receiver for Windows)</altname>
-      <altname>Controller (Xbox wireless receiver for windows)</altname>
-      <altname>Controller (XBOX360 GAMEPAD)</altname>
-      <altname>Controller (Batarang wired controller (XBOX))</altname>
-      <altname>Wireless Gamepad F710 (Controller)</altname>
-      <altname>XBOX 360 For Windows</altname>
-      <altname>XBOX 360 For Windows (Controller)</altname>
-      <altname>Xbox 360 Wireless Controller</altname>
-      <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
-      <altname>Xbox wireless receiver for windows (Controller)</altname>
-      <altname>Gamepad F310 (Controller)</altname>
-      <altname>Razer Sabertooth Elite (Controller)</altname>
-      <altname>Controller (XBOX One For Windows)</altname>
+    <joystick family="Xbox 360 Controller (Windows)">
       <button id="2">PreviousMenu</button>
       <button id="9">Close</button>
     </joystick>
-    <joystick name="Microsoft X-Box 360 pad">
-      <altname>BigBen Interactive XBOX 360 Controller</altname>
-      <altname>Generic X-Box pad</altname>
-      <altname>Logitech Chillstream Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller (SFIV)</altname>
-      <altname>Pelican 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Xbox 360 Wireless Receiver</altname>
-      <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
-      <altname>Razer Sabertooth</altname>
+    <joystick family="Xbox 360 Controller (xpad)">
       <button id="2">PreviousMenu</button>
       <button id="11">Close</button>
     </joystick>
   </LockSettings>
   <ProfileSettings>
-    <joystick name="Controller (XBOX 360 For Windows)">
-      <altname>Afterglow Gamepad for Xbox 360 (Controller)</altname>
-      <altname>Controller (Gamepad F310)</altname>
-      <altname>Controller (Gamepad for Xbox 360)</altname>
-      <altname>Controller (Rumble Gamepad F510)</altname>
-      <altname>Controller (Wireless Gamepad F710)</altname>
-      <altname>Controller (Xbox 360 Wireless Receiver for Windows)</altname>
-      <altname>Controller (Xbox wireless receiver for windows)</altname>
-      <altname>Controller (XBOX360 GAMEPAD)</altname>
-      <altname>Controller (Batarang wired controller (XBOX))</altname>
-      <altname>Wireless Gamepad F710 (Controller)</altname>
-      <altname>XBOX 360 For Windows</altname>
-      <altname>XBOX 360 For Windows (Controller)</altname>
-      <altname>Xbox 360 Wireless Controller</altname>
-      <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
-      <altname>Xbox wireless receiver for windows (Controller)</altname>
-      <altname>Gamepad F310 (Controller)</altname>
-      <altname>Razer Sabertooth Elite (Controller)</altname>
-      <altname>Controller (XBOX One For Windows)</altname>
+    <joystick family="Xbox 360 Controller (Windows)">
       <button id="2">PreviousMenu</button>
       <button id="9">Close</button>
     </joystick>
-    <joystick name="Microsoft X-Box 360 pad">
-      <altname>BigBen Interactive XBOX 360 Controller</altname>
-      <altname>Generic X-Box pad</altname>
-      <altname>Logitech Chillstream Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller</altname>
-      <altname>Mad Catz Wired Xbox 360 Controller (SFIV)</altname>
-      <altname>Pelican 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
-      <altname>Xbox 360 Wireless Receiver</altname>
-      <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
-      <altname>Razer Sabertooth</altname>
+    <joystick family="Xbox 360 Controller (xpad)">
       <button id="2">PreviousMenu</button>
       <button id="11">Close</button>
     </joystick>

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -911,9 +911,6 @@ bool CApplication::CreateGUI()
   if (!CButtonTranslator::GetInstance().Load())
     return false;
 
-  //Initialize sdl joystick if available
-  CInputManager::GetInstance().InitializeInputs();
-
   RESOLUTION_INFO info = g_graphicsContext.GetResInfo();
   CLog::Log(LOGINFO, "GUI format %ix%i, Display %s",
             info.iWidth,

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -652,7 +652,9 @@ bool CButtonTranslator::LoadKeymap(const std::string &keymapPath)
       const char *szWindow = pWindow->Value();
       if (szWindow)
       {
-        if (strcmpi(szWindow, "global") == 0)
+        if (strcmpi(szWindow, "joystickFamily") == 0)
+          MapJoystickFamily(pWindow);
+        else if (strcmpi(szWindow, "global") == 0)
           windowID = -1;
         else
           windowID = TranslateWindow(szWindow);
@@ -760,29 +762,84 @@ int CButtonTranslator::TranslateLircRemoteString(const char* szDevice, const cha
 }
 
 #if defined(HAS_SDL_JOYSTICK) || defined(HAS_EVENT_SERVER)
+void CButtonTranslator::MapJoystickFamily(TiXmlNode *pNode)
+{
+  TiXmlElement *pFamily = pNode->ToElement();
+  if (pFamily && pFamily->Attribute("name"))
+  {
+    std::string joyFamilyName = pFamily->Attribute("name");
+    JoystickFamily* joyFamily = &m_joystickFamilies[joyFamilyName];
+
+    TiXmlElement *pMember = pFamily->FirstChildElement();
+    while (pMember)
+    {
+      TiXmlNode* pName = pMember->FirstChild();
+      if (pName && pName->ValueStr() != "") {
+        boost::shared_ptr<CRegExp> re(new CRegExp(true, CRegExp::asciiOnly));
+        std::string joyRe = JoynameToRegex(pName->ValueStr());
+        if (!re->RegComp(joyRe, CRegExp::StudyRegExp))
+        {
+          CLog::Log(LOGNOTICE, "Invalid joystick regex specified: '%s'", pName->Value());
+          continue;
+        }
+        AddFamilyRegex(joyFamily, re);
+      }
+      pMember = pMember->NextSiblingElement();
+    }
+  }
+  else
+  {
+    CLog::Log(LOGNOTICE, "Ignoring nameless joystick family");
+  }
+}
+
 void CButtonTranslator::MapJoystickActions(int windowID, TiXmlNode *pJoystick)
 {
   string joyname = JOYSTICK_DEFAULT_MAP; // default global map name
-  vector<boost::shared_ptr<CRegExp> > joynames;
+  std::string joyFamilyName;
   map<int, string> buttonMap;
   map<int, string> axisMap;
   AxesConfig axesConfig;
   ActionMap hatMap;
 
   TiXmlElement *pJoy = pJoystick->ToElement();
-  if (pJoy && pJoy->Attribute("name"))
-    joyname = pJoy->Attribute("name");
+  if (pJoy && pJoy->Attribute("name")) {
+    // transform loose name to new family, including altnames
+    std::string joyName = pJoy->Attribute("name");
+    joyFamilyName = joyName;    
+    JoystickFamily* joyFamily = &m_joystickFamilies[joyFamilyName];
+
+    boost::shared_ptr<CRegExp> re(new CRegExp(true, CRegExp::asciiOnly));
+    std::string joyRe = JoynameToRegex(joyname);
+    if (!re->RegComp(joyRe, CRegExp::StudyRegExp))
+    {
+      CLog::Log(LOGNOTICE, "Invalid joystick regex specified: '%s'", joyname.c_str());
+      return;
+    }
+    AddFamilyRegex(joyFamily, re);
+
+    // add altnames to family
+    TiXmlElement *pNode = pJoystick->FirstChildElement();
+    while (pNode) {
+      const std::string &type = pNode->ValueStr();
+      if (type == "altname") {
+        std::string altName = pNode->FirstChild()->ValueStr();
+        boost::shared_ptr<CRegExp> altRe(new CRegExp(true, CRegExp::asciiOnly));
+        std::string altReStr = JoynameToRegex(altName);
+        if (!altRe->RegComp(altReStr, CRegExp::StudyRegExp))
+          CLog::Log(LOGNOTICE, "Ignoring invalid joystick altname regex: '%s'", altReStr.c_str());
+        else
+          AddFamilyRegex(joyFamily, altRe);
+      }
+      pNode = pNode->NextSiblingElement();
+    }
+
+  }
+  else if (pJoy && pJoy->Attribute("family"))
+    joyFamilyName = pJoy->Attribute("family");
   else
     CLog::Log(LOGNOTICE, "No Joystick name specified, loading default map");
 
-  boost::shared_ptr<CRegExp> re(new CRegExp(true, CRegExp::asciiOnly));
-  if (!re->RegComp(JoynameToRegex(joyname), CRegExp::StudyRegExp))
-  {
-    CLog::Log(LOGNOTICE, "Invalid joystick regex specified: '%s'", joyname.c_str());
-    return;
-  }
-  else 
-    joynames.push_back(re);
 
   // parse map
   TiXmlElement *pButton = pJoystick->FirstChildElement();
@@ -856,30 +913,16 @@ void CButtonTranslator::MapJoystickActions(int windowID, TiXmlNode *pJoystick)
       else
         CLog::Log(LOGERROR, "Error reading joystick map element, unknown button type: %s", type.c_str());
     }
-    else if (type == "altname")
-    {
-      boost::shared_ptr<CRegExp> altRe(new CRegExp(true, CRegExp::asciiOnly));
-      if (!altRe->RegComp(JoynameToRegex(action), CRegExp::StudyRegExp))
-        CLog::Log(LOGNOTICE, "Ignoring invalid joystick altname regex: '%s'", action.c_str());
-      else
-        joynames.push_back(altRe);
-    }
     else
       CLog::Log(LOGERROR, "Error reading joystick map element, Invalid id: %d", id);
 
     pButton = pButton->NextSiblingElement();
   }
-  vector<boost::shared_ptr<CRegExp> >::iterator it = joynames.begin();
-  while (it!=joynames.end())
-  {
-    MergeMap(*it, &m_joystickButtonMap, windowID, buttonMap);
-    MergeMap(*it, &m_joystickAxisMap, windowID, axisMap);
-    MergeMap(*it, &m_joystickHatMap, windowID, hatMap);
-    if (windowID == -1) 
-      m_joystickAxesConfigs[*it] = axesConfig;
-//    CLog::Log(LOGDEBUG, "Found Joystick map for window %d using %s", windowID, it->c_str());
-    ++it;
-  }
+  m_joystickButtonMap[joyFamilyName][windowID].insert(buttonMap.begin(), buttonMap.end());
+  m_joystickAxisMap[joyFamilyName][windowID].insert(axisMap.begin(), axisMap.end());
+  m_joystickHatMap[joyFamilyName][windowID].insert(hatMap.begin(), hatMap.end());
+  if (windowID == -1) 
+    m_joystickAxesConfigs[joyFamilyName] = axesConfig;
 }
 
 std::string CButtonTranslator::JoynameToRegex(const std::string& joyName) const
@@ -895,34 +938,58 @@ std::string CButtonTranslator::JoynameToRegex(const std::string& joyName) const
   return "\\Q" + joyName + "\\E";
 }
 
-void CButtonTranslator::MergeMap(boost::shared_ptr<CRegExp> joyName, JoystickMap *joystick, int windowID, const ActionMap &map)
+bool CButtonTranslator::AddFamilyRegex(JoystickFamily* family, boost::shared_ptr<CRegExp> regex)
 {
-  // find or create WindowMap entry, match on pattern equality
-  JoystickMap::iterator jit;
-  for (jit = joystick->begin(); jit != joystick->end(); ++jit)
+  // even though family is a set, this does not prevent the same regex 
+  // from being added twice, so we manually match on pattern equality
+  JoystickFamily::iterator it;
+  for (it = family->begin(); it != family->end(); it++)
   {
-    if (jit->first->GetPattern() == joyName->GetPattern())
-      break;
+    if ((*it)->GetPattern() == regex->GetPattern())
+      return false;
   }
-  WindowMap *w = (jit == joystick->end()) ? &(*joystick)[joyName] : &jit->second;
-  
-  // find or create ActionMap, and merge/overwrite new entries
-  ActionMap *a = &(*w)[windowID];
-  for (ActionMap::const_iterator it = map.begin(); it != map.end(); ++it)
-    (*a)[it->first] = it->second;
+  family->insert(regex);
+  return true;
+}
+
+const AxesConfig* CButtonTranslator::GetAxesConfigFor(const std::string& joyName) const
+{
+  JoystickFamilyMap::const_iterator familyIt = FindJoystickFamily(joyName);
+  if (familyIt == m_joystickFamilies.end())
+    return NULL;
+  else {
+    std::map<std::string, AxesConfig>::const_iterator it = m_joystickAxesConfigs.find(familyIt->first);
+    if (it == m_joystickAxesConfigs.end())
+      return NULL;
+    else
+      return &it->second;
+  }
 }
 
 CButtonTranslator::JoystickMap::const_iterator CButtonTranslator::FindWindowMap(const std::string& joyName, const JoystickMap &maps) const
 {
-  JoystickMap::const_iterator it;
-  for (it = maps.begin(); it != maps.end(); ++it)
+  JoystickFamilyMap::const_iterator familyIt = FindJoystickFamily(joyName);
+  if (familyIt == m_joystickFamilies.end())
+    return maps.end();
+  else
+    return maps.find(familyIt->first);
+}
+
+CButtonTranslator::JoystickFamilyMap::const_iterator CButtonTranslator::FindJoystickFamily(const std::string& joyName) const
+{
+  // find the family corresponding to a joystick name
+  JoystickFamilyMap::const_iterator it;
+  for (it = m_joystickFamilies.begin(); it != m_joystickFamilies.end(); it++)
   {
-    if (it->first->RegFind(joyName) >= 0)
+    JoystickFamily::const_iterator regexIt;
+    for (regexIt = it->second.begin(); regexIt != it->second.end(); regexIt++)
     {
-      // CLog::Log(LOGDEBUG, "Regex %s matches joystick %s", it->first->GetPattern().c_str(), joyName.c_str());
-      break;
+      if ((*regexIt)->RegFind(joyName) >= 0)
+      {
+        // CLog::Log(LOGDEBUG, "Regex %s matches joystick %s", it->first->GetPattern().c_str(), joyName.c_str());
+        return it;
+      }
     }
-    // CLog::Log(LOGDEBUG, "No match: %s for joystick %s", it->first->GetPattern().c_str(), joyName.c_str());
   }
   return it;
 }

--- a/xbmc/input/ButtonTranslator.h
+++ b/xbmc/input/ButtonTranslator.h
@@ -26,6 +26,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <set>
 #include "system.h" // for HAS_EVENT_SERVER, HAS_SDL_JOYSTICK
 
 #ifdef HAS_EVENT_SERVER
@@ -99,7 +100,7 @@ public:
                                short inputType, int& action, std::string& strAction,
                                bool &fullrange);
 
-  const std::map<boost::shared_ptr<CRegExp>, AxesConfig>& GetAxesConfigs() { return m_joystickAxesConfigs; };
+  const AxesConfig* GetAxesConfigFor(const std::string& joyName) const;
 #endif
 
   bool TranslateTouchAction(int window, int touchAction, int touchPointers, int &action);
@@ -115,9 +116,11 @@ private:
   int GetActionCode(int window, int action);
   int GetActionCode(int window, const CKey &key, std::string &strAction) const;
 #if defined(HAS_SDL_JOYSTICK) || defined(HAS_EVENT_SERVER)
+  typedef std::set<boost::shared_ptr<CRegExp> > JoystickFamily;
+  typedef std::map<std::string, JoystickFamily> JoystickFamilyMap;
   typedef std::map<int, std::string> ActionMap; // <button/axis, action>
   typedef std::map<int, ActionMap > WindowMap; // <window, actionMap>
-  typedef std::map<boost::shared_ptr<CRegExp>, WindowMap> JoystickMap; // <joystick, windowMap>
+  typedef std::map<std::string, WindowMap> JoystickMap; // <family name, windowMap>
   int GetActionCode(int window, int id, const WindowMap &wmap, std::string &strAction, bool &fullrange) const;
 #endif
   int GetFallbackWindow(int windowID);
@@ -146,14 +149,18 @@ private:
   std::map<std::string, lircButtonMap*> lircRemotesMap;
 
 #if defined(HAS_SDL_JOYSTICK) || defined(HAS_EVENT_SERVER)
+  void MapJoystickFamily(TiXmlNode *pFamily);
   void MapJoystickActions(int windowID, TiXmlNode *pJoystick);
   std::string JoynameToRegex(const std::string& joyName) const;
+  bool AddFamilyRegex(JoystickFamily* family, boost::shared_ptr<CRegExp> regex);
   void MergeMap(boost::shared_ptr<CRegExp> joyName, JoystickMap *joystick, int windowID, const ActionMap &actionMap);
   JoystickMap::const_iterator FindWindowMap(const std::string& joyName, const JoystickMap &maps) const;
-  JoystickMap m_joystickButtonMap;                        // <joy name, button map>
-  JoystickMap m_joystickAxisMap;                          // <joy name, axis map>
-  JoystickMap m_joystickHatMap;                           // <joy name, hat map>
-  std::map<boost::shared_ptr<CRegExp>, AxesConfig> m_joystickAxesConfigs;   // <joy name, axes config>
+  JoystickFamilyMap::const_iterator FindJoystickFamily(const std::string& joyName) const;
+  JoystickFamilyMap m_joystickFamilies;
+  JoystickMap m_joystickButtonMap;                        // <joy family, button map>
+  JoystickMap m_joystickAxisMap;                          // <joy family, axis map>
+  JoystickMap m_joystickHatMap;                           // <joy family, hat map>
+  std::map<std::string, AxesConfig> m_joystickAxesConfigs;   // <joy family, axes config>
 #endif
 
   void MapTouchActions(int windowID, TiXmlNode *pTouch);

--- a/xbmc/input/InputManager.cpp
+++ b/xbmc/input/InputManager.cpp
@@ -73,14 +73,6 @@ CInputManager& CInputManager::GetInstance()
   return inputManager;
 }
 
-void CInputManager::InitializeInputs()
-{
-#ifdef HAS_SDL_JOYSTICK
-  // Pass the mapping of axis to triggers to m_Joystick
-  m_Joystick.LoadAxesConfigs(CButtonTranslator::GetInstance().GetAxesConfigs());
-#endif
-}
-
 void CInputManager::ReInitializeJoystick()
 {
 #ifdef HAS_SDL_JOYSTICK

--- a/xbmc/input/InputManager.h
+++ b/xbmc/input/InputManager.h
@@ -79,11 +79,6 @@ public:
   */
   bool ProcessPeripherals(float frameTime);
 
-  /*!
-   * \brief Call once during application startup to initialize peripherals that need it
-   */
-  void InitializeInputs();
-
   void SetEnabledJoystick(bool enabled = true);
 
   void ReInitializeJoystick();

--- a/xbmc/input/SDLJoystick.cpp
+++ b/xbmc/input/SDLJoystick.cpp
@@ -20,6 +20,7 @@
 
 #include "system.h"
 #include "SDLJoystick.h"
+#include "input/ButtonTranslator.h"
 #include "peripherals/devices/PeripheralImon.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/lib/Setting.h"
@@ -406,12 +407,6 @@ bool CJoystick::Reinitialize()
   return true;
 }
 
-void CJoystick::LoadAxesConfigs(const std::map<boost::shared_ptr<CRegExp>, AxesConfig> &axesConfigs)
-{
-  m_AxesConfigs.clear();
-  m_AxesConfigs.insert(axesConfigs.begin(), axesConfigs.end());
-}
-
 void CJoystick::ApplyAxesConfigs()
 {
   // load axes configuration from keymap
@@ -419,15 +414,10 @@ void CJoystick::ApplyAxesConfigs()
   for (std::map<int, SDL_Joystick*>::const_iterator it = m_Joysticks.begin(); it != m_Joysticks.end(); ++it)
   {
     std::string joyName(SDL_JoystickName(it->second));
-    std::map<boost::shared_ptr<CRegExp>, AxesConfig>::const_iterator axesCfg;
-    for (axesCfg = m_AxesConfigs.begin(); axesCfg != m_AxesConfigs.end(); ++axesCfg)
+    const AxesConfig* axesCfg = CButtonTranslator::GetInstance().GetAxesConfigFor(joyName);
+    if (axesCfg != NULL)
     {
-      if (axesCfg->first->RegFind(joyName) >= 0)
-        break;
-    }
-    if (axesCfg != m_AxesConfigs.end())
-    {
-      for (AxesConfig::const_iterator it = axesCfg->second.begin(); it != axesCfg->second.end(); ++it)
+      for (AxesConfig::const_iterator it = axesCfg->begin(); it != axesCfg->end(); ++it)
       {
         int axis = axesCount + it->axis - 1;
         m_Axes[axis].trigger = it->isTrigger;

--- a/xbmc/input/SDLJoystick.h
+++ b/xbmc/input/SDLJoystick.h
@@ -87,7 +87,6 @@ public:
   float SetDeadzone(float val);
   bool Reinitialize();
   typedef std::vector<AxisConfig> AxesConfig; // [<axis, isTrigger, rest state value>]
-  void LoadAxesConfigs(const std::map<boost::shared_ptr<CRegExp>, AxesConfig>& axesConfigs);
   void ApplyAxesConfigs();
 
 private:
@@ -120,7 +119,6 @@ private:
   uint32_t m_pressTicksButton;
   uint32_t m_pressTicksHat;
   std::map<int, SDL_Joystick*> m_Joysticks;
-  std::map<boost::shared_ptr<CRegExp>, AxesConfig> m_AxesConfigs; // <joy, <axis num, isTrigger, restState> >
 };
 
 #endif

--- a/xbmc/input/windows/WINJoystick.cpp
+++ b/xbmc/input/windows/WINJoystick.cpp
@@ -139,15 +139,10 @@ BOOL CALLBACK CJoystick::EnumJoysticksCallback( const DIDEVICEINSTANCE* pdidInst
           p_this->m_devCaps.push_back(diDevCaps);
 
           // load axes configuration from keymap
-          std::map<boost::shared_ptr<CRegExp>, AxesConfig>::const_iterator axesCfg;
-          for (axesCfg = p_this->m_AxesConfigs.begin(); axesCfg != p_this->m_AxesConfigs.end(); ++axesCfg)
+          const AxesConfig* axesCfg = CButtonTranslator::GetInstance().GetAxesConfigFor(joyName);
+          if (axesCfg != NULL)
           {
-            if (axesCfg->first->RegFind(joyName) >= 0)
-              break;
-          }
-          if (axesCfg != p_this->m_AxesConfigs.end())
-          {
-            for (AxesConfig::const_iterator it = axesCfg->second.begin(); it != axesCfg->second.end(); ++it)
+            for (AxesConfig::const_iterator it = axesCfg->begin(); it != axesCfg->end(); ++it)
             {
               int axis = p_this->MapAxis(pJoystick, it->axis - 1);
               p_this->m_Axes[axis].trigger = it->isTrigger;
@@ -519,12 +514,6 @@ void CJoystick::Acquire()
         (*it)->Acquire();
     }
   }
-}
-
-void CJoystick::LoadAxesConfigs(const std::map<boost::shared_ptr<CRegExp>, AxesConfig> &axesConfigs)
-{
-  m_AxesConfigs.clear();
-  m_AxesConfigs.insert(axesConfigs.begin(), axesConfigs.end());
 }
 
 int CJoystick::JoystickIndex(const std::string &joyName) const

--- a/xbmc/input/windows/WINJoystick.h
+++ b/xbmc/input/windows/WINJoystick.h
@@ -77,7 +77,6 @@ public:
   bool Reinitialize();
   void Acquire();
   typedef std::vector<AxisConfig> AxesConfig; // [<axis, isTrigger, rest state value>]
-  void LoadAxesConfigs(const std::map<boost::shared_ptr<CRegExp>, AxesConfig> &axesConfigs);
 
 private:
   bool IsButtonActive() const { return m_ButtonIdx != -1; }
@@ -115,5 +114,4 @@ private:
   std::vector<LPDIRECTINPUTDEVICE8> m_pJoysticks;
   std::vector<std::string> m_JoystickNames;
   std::vector<DIDEVCAPS> m_devCaps;
-  std::map<boost::shared_ptr<CRegExp>, AxesConfig> m_AxesConfigs; // <joy, <axis num, isTrigger, restState> >
 };


### PR DESCRIPTION
A great amount of clutter in the keymaps is due to having to repeat each controller name for each action window. This is most visible in the Xbox 360 keymap where over 1000 lines are spent on repeating the same list of joystick names.

The first of these patches allows controllers to be grouped by "joystick family". We can replace a keymap extract may have looked like this:

``` xml
    <global>
        <joystick name="joy type 1 vendor A"/>
        <altname>joy type 1 vendor B</altname>
        <altname>joy type 1 vendor C</altname>
        <button id="4">Home</button>
    </global>
    <MyFiles>
        <joystick name="joy type 1 vendor A"/>
        <altname>joy type 1 vendor B</altname>
        <altname>joy type 1 vendor C</altname>
        <button id="6">Highlight</button>
    </MyFiles>
```

With this:

``` xml
    <joystickFamily name="joy type 1">
        <name>joy type 1 vendor A</name>
        <name>joy type 1 vendor B</name>
        <name>joy type 1 vendor C</name>
    </joystickFamily>
    <global>
        <joystick family="joy type 1"/>
        <button id="4">Home</button>
    </global>
    <MyFiles>
        <joystick family="joy type 1"/>
        <button id="6">Highlight</button>
    </MyFiles>
```

I've also made sure that keymaps with the old format are automatically grouped as a family in `CButtonTranslator`. For large keymaps this saves some memory since the the window mapping isn't saved once per altname, but once per family.

db5b10c changes `CJoystick` for the minor change in `CButtonTranslator`'s signature.

ff4dc77 finally uses the new button translator ability to shave about 1000 lines off the xbox 360 keymap, and synchronizes the controller family with the controller names [known to xpad](https://github.com/torvalds/linux/blob/master/drivers/input/joystick/xpad.c#L120).
