### PR TITLE
[PVR] Timeshifting: Fixed EpgInfoTag::[IsActive|WasActive|InTheFuture]

### DIFF
--- a/xbmc/epg/EpgInfoTag.cpp
+++ b/xbmc/epg/EpgInfoTag.cpp
@@ -26,6 +26,7 @@
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/timers/PVRTimers.h"
 #include "pvr/PVRManager.h"
+#include "pvr/addons/PVRClients.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "utils/log.h"
@@ -263,23 +264,41 @@ bool CEpgInfoTag::Changed(void) const
   return m_bChanged;
 }
 
-bool CEpgInfoTag::IsActive(void) const
+CDateTime CEpgInfoTag::GetCurrentTime() const
 {
   CDateTime now = CDateTime::GetUTCDateTime();
+
+  CPVRChannelPtr channel;
+  if (g_PVRClients->GetPlayingChannel(channel))
+  {
+    if (channel == ChannelTag())
+    {
+      // Timeshifting active?
+      time_t time = g_PVRClients->GetPlayingTime();
+      if (time > 0) // returns 0 in case no client is currently playing
+        now = time;
+    }
+  }
+  return now;
+}
+
+bool CEpgInfoTag::IsActive(void) const
+{
+  CDateTime now = GetCurrentTime();
   CSingleLock lock(m_critSection);
   return (m_startTime <= now && m_endTime > now);
 }
 
 bool CEpgInfoTag::WasActive(void) const
 {
-  CDateTime now = CDateTime::GetUTCDateTime();
+  CDateTime now = GetCurrentTime();
   CSingleLock lock(m_critSection);
   return (m_endTime < now);
 }
 
 bool CEpgInfoTag::InTheFuture(void) const
 {
-  CDateTime now = CDateTime::GetUTCDateTime();
+  CDateTime now = GetCurrentTime();
   CSingleLock lock(m_critSection);
   return (m_startTime > now);
 }

--- a/xbmc/epg/EpgInfoTag.h
+++ b/xbmc/epg/EpgInfoTag.h
@@ -470,6 +470,11 @@ namespace EPG
      */
     void UpdatePath(void);
 
+    /*!
+     * @brief Get current time, taking timeshifting into account.
+     */
+    CDateTime GetCurrentTime(void) const;
+
     bool                     m_bNotify;            /*!< notify on start */
     bool                     m_bChanged;           /*!< keep track of changes to this entry */
 


### PR DESCRIPTION
Changed EpgInfoTag::[IsActive|WasActive|InTheFuture] to take timeshifting into account. 
Fixes wrong event info shown at several places in kodi UI when timeshifting (e.g. Video OSD).
