### PR TITLE
[rebrand] change default webserver username from "xbmc" to "kodi"

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2030,10 +2030,13 @@
         </setting>
         <setting id="services.webserverusername" type="string" parent="services.webserver" label="1048" help="36330">
           <level>1</level>
-          <default>xbmc</default>
+          <default>kodi</default>
           <constraints>
             <allowempty>true</allowempty>
           </constraints>
+          <updates>
+            <update type="change" />
+          </updates>
           <dependencies>
             <dependency type="enable" setting="services.webserver">true</dependency>
           </dependencies>

--- a/xbmc/network/NetworkServices.cpp
+++ b/xbmc/network/NetworkServices.cpp
@@ -400,6 +400,24 @@ void CNetworkServices::OnSettingChanged(const CSetting *setting)
   }
 }
 
+bool CNetworkServices::OnSettingUpdate(CSetting* &setting, const char *oldSettingId, const TiXmlNode *oldSettingNode)
+{
+  if (setting == NULL)
+    return false;
+
+  const std::string &settingId = setting->GetId();
+  if (settingId == "services.webserverusername")
+  {
+    CSettingString *webserverusername = (CSettingString*)setting;
+    // if webserverusername is xbmc and pw is not empty we treat it as altered
+    // and don't change the username to kodi - part of rebrand
+    if (CSettings::Get().GetString("services.webserverusername") == "xbmc" &&
+        !CSettings::Get().GetString("services.webserverpassword").empty())
+      return true;
+  }
+  return false;
+}
+
 void CNetworkServices::Start()
 {
   StartZeroconf();

--- a/xbmc/network/NetworkServices.h
+++ b/xbmc/network/NetworkServices.h
@@ -42,6 +42,7 @@ public:
   
   virtual bool OnSettingChanging(const CSetting *setting);
   virtual void OnSettingChanged(const CSetting *setting);
+  virtual bool OnSettingUpdate(CSetting* &setting, const char *oldSettingId, const TiXmlNode *oldSettingNode);
 
   void Start();
   void Stop(bool bWait);

--- a/xbmc/settings/lib/SettingsManager.h
+++ b/xbmc/settings/lib/SettingsManager.h
@@ -104,14 +104,25 @@ public:
   void Clear();
 
   /*!
+  \brief Loads the setting being represented by the given XML node with the
+  given identifier.
+
+  \param node XML node representing the setting to load
+  \param settingId Setting identifier
+  \return True if the setting was successfully loaded from the given XML node, false otherwise
+  */
+  bool LoadSetting(const TiXmlNode *node, const std::string &settingId);
+
+  /*!
    \brief Loads the setting being represented by the given XML node with the
    given identifier.
 
    \param node XML node representing the setting to load
    \param settingId Setting identifier
+   \param updated Set to true if the setting's value was updated
    \return True if the setting was successfully loaded from the given XML node, false otherwise
    */
-  bool LoadSetting(const TiXmlNode *node, const std::string &settingId);
+  bool LoadSetting(const TiXmlNode *node, const std::string &settingId, bool &updated);
 
   /*!
    \brief Tells the settings system that the initialization is complete.
@@ -403,10 +414,9 @@ private:
   virtual bool Load(const TiXmlNode *settings);
 
   bool Serialize(TiXmlNode *parent) const;
-  bool Deserialize(const TiXmlNode *node, std::map<std::string, CSetting*> *loadedSettings = NULL);
+  bool Deserialize(const TiXmlNode *node, bool &updated, std::map<std::string, CSetting*> *loadedSettings = NULL);
 
-  static bool LoadSetting(const TiXmlNode *node, CSetting *setting);
-  bool UpdateSettings(const TiXmlNode *root);
+  bool LoadSetting(const TiXmlNode *node, CSetting *setting, bool &updated);
   bool UpdateSetting(const TiXmlNode *node, CSetting *setting, const CSettingUpdate& update);
   void UpdateSettingByDependency(const std::string &settingId, const CSettingDependency &dependency);
   void UpdateSettingByDependency(const std::string &settingId, SettingDependencyType dependencyType);


### PR DESCRIPTION
This PR superseeds #5596 (thanks @Memphiz for spotting it and doing half the work) and updates the default value of the webserver username setting from `xbmc` to `kodi`.

The tricky part is that the settings system contains logic to automatically update the default value of a setting if the current setting value matches the default. That however means that when someone has set the webserver username to `xbmc` (which is the old default value) but has a non-empty password set (which is not the default value) the username value would be automatically updated to `kodi` and the password would be left untouched. That would mean that users wouldn't be able to connect to the webserver with their known credentials anymore. Therefore we need to catch that case and only update the username from `xbmc` to `kodi` if no password is set.
This however wasn't possible due to the fact that both the update logic and the default value handling logic was added to the settings library afterwards and they didn't work well together. So I've fixed the settings library behaviour to only update the default value if the setting wasn't updated through an update handler. That allows us to use the update handler written by @Memphiz which checks the username and password combination and can therefore force the settings system to not update the default value if the username is `xbmc` and the password is not empty.
