### PR TITLE
videorefclock: fix potential segfault on systems which do not support vi...

### DIFF
--- a/xbmc/video/VideoReferenceClock.cpp
+++ b/xbmc/video/VideoReferenceClock.cpp
@@ -152,9 +152,13 @@ void CVideoReferenceClock::Process()
     SingleLock.Leave();
 
     //clean up the vblank clock
-    m_pVideoSync->Cleanup();
-    delete m_pVideoSync;
-    m_pVideoSync = NULL;
+    if (m_pVideoSync)
+    {
+      m_pVideoSync->Cleanup();
+      delete m_pVideoSync;
+      m_pVideoSync = NULL;
+    }
+
     if (!SetupSuccess)
       break;
   }


### PR DESCRIPTION
see title
@sraue does this fix your issue?
btw: if you get this far there is also another issue. video ref clock should not be started on systems which don't support video sync.
