### PR TITLE
[RFC] replace iconv and fribidi with icu library

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1073,9 +1073,6 @@ PKG_CHECK_MODULES([LIBXML], [libxml-2.0],
 PKG_CHECK_MODULES([LIBXSLT], [libxslt],
   [INCLUDES="$INCLUDES $LIBXSLT_CFLAGS"; LIBS="$LIBS $LIBXSLT_LIBS"],
   AC_MSG_ERROR($missing_library))
-PKG_CHECK_MODULES([FRIBIDI],    [fribidi],
-  [INCLUDES="$INCLUDES $FRIBIDI_CFLAGS"; LIBS="$LIBS $FRIBIDI_LIBS"],
-  AC_MSG_ERROR($missing_library))
 PKG_CHECK_MODULES([SQLITE3],    [sqlite3],
   [INCLUDES="$INCLUDES $SQLITE3_CFLAGS"; LIBS="$LIBS $SQLITE3_LIBS"],
   AC_MSG_ERROR($missing_library))
@@ -1095,6 +1092,9 @@ PKG_CHECK_MODULES([FREETYPE2],  [freetype2],
   AC_MSG_ERROR($missing_library))
 PKG_CHECK_MODULES([TAGLIB],  [taglib >= 1.8],
   [INCLUDES="$INCLUDES $TAGLIB_CFLAGS"; LIBS="$LIBS $TAGLIB_LIBS"],
+  AC_MSG_ERROR($missing_library))
+PKG_CHECK_MODULES([ICU_UC], [icu-uc >= 54.1],
+  [INCLUDES="$INCLUDES $ICU_UC_CFLAGS"; LIBS="$LIBS $ICU_UC_LIBS"],
   AC_MSG_ERROR($missing_library))
 
 if test "$use_optical_drive" = "yes"; then
@@ -1135,7 +1135,6 @@ AS_CASE([x$use_libbluray],
 )
 
 #Check to see if libs are needed for functions that are often built-in to libc
-AC_SEARCH_LIBS([iconv_open],iconv,,AC_SEARCH_LIBS([libiconv_open],iconv,,AC_MSG_ERROR($missing_library)))
 AC_SEARCH_LIBS([dlopen],dl)
 AC_SEARCH_LIBS([clock_gettime],rt)
 AC_SEARCH_LIBS([dn_expand],  resolv)

--- a/tools/depends/native/Makefile
+++ b/tools/depends/native/Makefile
@@ -10,7 +10,7 @@ NATIVE= m4-native gettext-native autoconf-native automake-native \
         pcre-native swig-native rpl-native \
         libpng-native libjpeg-turbo-native liblzo2-native giflib-native \
         distribute-native distutilscross-native JsonSchemaBuilder TexturePacker \
-        google-breakpad-native
+        google-breakpad-native libicu-native
 
 
 ifeq ($(OS),ios)

--- a/tools/depends/native/libicu-native/Makefile
+++ b/tools/depends/native/libicu-native/Makefile
@@ -1,0 +1,47 @@
+include ../../Makefile.include
+PREFIX=$(NATIVEPREFIX)
+PLATFORM=$(NATIVEPLATFORM)
+DEPS= ../../Makefile.include Makefile uconfig_defines.patch
+
+# lib name, version
+LIBNAME=icu
+VERSION=54_1
+SOURCE=$(LIBNAME)4c-$(VERSION)-src
+ARCHIVE=$(SOURCE).tgz
+ICU_PLATFORM=
+
+ifeq ($(findstring linux,$(NATIVEPLATFORM)),linux)
+	ICU_PLATFORM=Linux/GCC
+else ifeq ($(findstring darwin,$(NATIVEPLATFORM)),darwin)
+	ICU_PLATFORM=MacOSX
+endif
+# configuration settings
+CONFIGURE=cp -f $(CONFIG_SUB) $(CONFIG_GUESS) .; \
+        ./runConfigureICU $(ICU_PLATFORM) --prefix=$(PREFIX) --disable-tests --disable-samples
+
+LIBDYLIB=$(PLATFORM)/source/lib/lib$(LIBNAME)uc.so
+
+all: .installed-$(PLATFORM)
+
+$(TARBALLS_LOCATION)/$(ARCHIVE):
+	cd $(TARBALLS_LOCATION); $(RETRIEVE_TOOL) $(RETRIEVE_TOOL_FLAGS) $(BASE_URL)/$(ARCHIVE)
+
+$(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
+	rm -rf $(PLATFORM)/*; mkdir -p $(PLATFORM)
+	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
+	cd $(PLATFORM)/source; patch -p0 < ../../uconfig_defines.patch
+	cd $(PLATFORM)/source; $(CONFIGURE)
+
+$(LIBDYLIB): $(PLATFORM)
+	$(MAKE) -C $(PLATFORM)/source
+
+.installed-$(PLATFORM): $(LIBDYLIB)
+	$(MAKE) -C $(PLATFORM)/source install
+	touch $@
+
+clean:
+	$(MAKE) -C $(PLATFORM)/source clean
+	rm -f .installed-$(PLATFORM)
+
+distclean::
+	rm -rf $(PLATFORM) .installed-$(PLATFORM)

--- a/tools/depends/native/libicu-native/uconfig_defines.patch
+++ b/tools/depends/native/libicu-native/uconfig_defines.patch
@@ -1,0 +1,11 @@
+--- common/unicode/uconfig.h	2014-10-03 18:11:02.000000000 +0200
++++ common/unicode/uconfig2.h	2014-11-15 00:50:25.776535200 +0100
+@@ -15,6 +15,8 @@
+ #ifndef __UCONFIG_H__
+ #define __UCONFIG_H__
+ 
++#define U_USING_ICU_NAMESPACE 1
++#define U_NO_DEFAULT_INCLUDE_UTF_HEADERS 1
+ 
+ /*!
+  * \file

--- a/tools/depends/target/Makefile
+++ b/tools/depends/target/Makefile
@@ -15,7 +15,7 @@ DEPENDS = \
 	libamplayer libssh taglib libusb libnfs \
 	pythonmodule-pil pythonmodule-setuptools \
 	libxslt ffmpeg platform crossguid \
-        libdvdread libdvdnav libdvdcss
+        libdvdread libdvdnav libdvdcss libicu
 
 
 FFMPEG_DEPENDS = gnutls

--- a/tools/depends/target/libicu/Makefile
+++ b/tools/depends/target/libicu/Makefile
@@ -1,0 +1,54 @@
+include ../../Makefile.include
+DEPS= ../../Makefile.include Makefile uconfig_defines.patch
+
+# lib name, version
+LIBNAME=icu
+VERSION=54_1
+SOURCE=$(LIBNAME)4c-$(VERSION)-src
+ARCHIVE=$(SOURCE).tgz
+
+ICU_PLATFORM=
+ICU_CROSS=--with-cross-build=$(XBMCROOT)/tools/depends/native/libicu-native/$(NATIVEPLATFORM)/source
+
+ifeq ($(OS),linux)
+	ICU_PLATFORM=Linux/GCC
+else ifeq ($(OS),android)
+	ICU_PLATFORM=Linux/GCC
+else ifeq ($(OS),osx)
+	ICU_PLATFORM=MacOSX
+else ifeq ($(OS),ios)
+	ICU_PLATFORM=MacOSX
+endif
+
+# configuration settings
+CONFIGURE=cp -f $(CONFIG_SUB) $(CONFIG_GUESS) .; \
+        ./runConfigureICU $(ICU_PLATFORM) --prefix=$(PREFIX) \
+		--disable-tests --disable-samples $(ICU_CROSS) \
+		--disable-shared --enable-static
+
+LIBDYLIB=$(PLATFORM)/source/lib/lib$(LIBNAME)uc.a
+
+all: .installed-$(PLATFORM)
+
+$(TARBALLS_LOCATION)/$(ARCHIVE):
+	cd $(TARBALLS_LOCATION); $(RETRIEVE_TOOL) $(RETRIEVE_TOOL_FLAGS) $(BASE_URL)/$(ARCHIVE)
+
+$(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
+	rm -rf $(PLATFORM)/*; mkdir -p $(PLATFORM)
+	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
+	cd $(PLATFORM)/source; patch -p0 < ../../uconfig_defines.patch
+	cd $(PLATFORM)/source; $(CONFIGURE)
+
+$(LIBDYLIB): $(PLATFORM)
+	$(MAKE) -C $(PLATFORM)/source
+
+.installed-$(PLATFORM): $(LIBDYLIB)
+	$(MAKE) -C $(PLATFORM)/source install
+	touch $@
+
+clean:
+	$(MAKE) -C $(PLATFORM)/source clean
+	rm -f .installed-$(PLATFORM)
+
+distclean::
+	rm -rf $(PLATFORM) .installed-$(PLATFORM)

--- a/tools/depends/target/libicu/uconfig_defines.patch
+++ b/tools/depends/target/libicu/uconfig_defines.patch
@@ -1,0 +1,11 @@
+--- common/unicode/uconfig.h	2014-10-03 18:11:02.000000000 +0200
++++ common/unicode/uconfig2.h	2014-11-15 00:50:25.776535200 +0100
+@@ -15,6 +15,8 @@
+ #ifndef __UCONFIG_H__
+ #define __UCONFIG_H__
+ 
++#define U_USING_ICU_NAMESPACE 1
++#define U_NO_DEFAULT_INCLUDE_UTF_HEADERS 1
+ 
+ /*!
+  * \file

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2760,7 +2760,6 @@ bool CApplication::Cleanup()
 
     g_localizeStrings.Clear();
     g_LangCodeExpander.Clear();
-    g_charsetConverter.clear();
     g_directoryCache.Clear();
     CButtonTranslator::GetInstance().Clear();
 #ifdef HAS_EVENT_SERVER

--- a/xbmc/CueDocument.cpp
+++ b/xbmc/CueDocument.cpp
@@ -425,13 +425,13 @@ std::string CCueDocument::ExtractInfo(const std::string &line)
     if (right != std::string::npos)
     {
       std::string text = line.substr(left + 1, right - left - 1);
-      g_charsetConverter.UnknownToUtf8(text);
+      CCharsetConverter::UnknownToUtf8(text);
       return text;
     }
   }
   std::string text = line;
   StringUtils::Trim(text);
-  g_charsetConverter.UnknownToUtf8(text);
+  CCharsetConverter::UnknownToUtf8(text);
   return text;
 }
 

--- a/xbmc/CueDocument.cpp
+++ b/xbmc/CueDocument.cpp
@@ -425,13 +425,13 @@ std::string CCueDocument::ExtractInfo(const std::string &line)
     if (right != std::string::npos)
     {
       std::string text = line.substr(left + 1, right - left - 1);
-      g_charsetConverter.unknownToUTF8(text);
+      g_charsetConverter.UnknownToUtf8(text);
       return text;
     }
   }
   std::string text = line;
   StringUtils::Trim(text);
-  g_charsetConverter.unknownToUTF8(text);
+  g_charsetConverter.UnknownToUtf8(text);
   return text;
 }
 

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -9806,7 +9806,7 @@ std::string CGUIInfoManager::GetItemLabel(const CFileItem *item, int info, std::
       std::string letter;
       std::wstring character(1, item->GetSortLabel()[0]);
       StringUtils::ToUpper(character);
-      g_charsetConverter.WToUtf8(character, letter);
+      CCharsetConverter::WToUtf8(character, letter);
       return letter;
     }
     break;

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -9806,7 +9806,7 @@ std::string CGUIInfoManager::GetItemLabel(const CFileItem *item, int info, std::
       std::string letter;
       std::wstring character(1, item->GetSortLabel()[0]);
       StringUtils::ToUpper(character);
-      g_charsetConverter.wToUTF8(character, letter);
+      g_charsetConverter.WToUtf8(character, letter);
       return letter;
     }
     break;

--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -115,7 +115,7 @@ static TemperatureInfo temperatureInfo[] = {
 };
 
 #define TEMPERATURE_INFO_SIZE     sizeof(temperatureInfo) / sizeof(TemperatureInfo)
-#define TEMP_UNIT_STRINGS         20027
+#define TEMP_UNIT_STRINGS 20027
 
 typedef struct SpeedInfo {
   CSpeed::Unit unit;
@@ -138,7 +138,7 @@ static SpeedInfo speedInfo[] = {
 };
 
 #define SPEED_INFO_SIZE           sizeof(speedInfo) / sizeof(SpeedInfo)
-#define SPEED_UNIT_STRINGS        20200
+#define SPEED_UNIT_STRINGS 20200
 
 #define SETTING_REGIONAL_DEFAULT  "regional"
 
@@ -313,7 +313,6 @@ void CLangInfo::CRegion::SetGlobalLocale()
   g_langInfo.m_systemLocale = current_locale; // TODO: move to CLangInfo class
   std::locale::global(current_locale);
 #endif
-  g_charsetConverter.resetSystemCharset();
   CLog::Log(LOGINFO, "global locale set to %s", strLocale.c_str());
 }
 
@@ -527,9 +526,8 @@ bool CLangInfo::Load(const std::string& strLanguage)
     }
 
     const std::string& strName = CSettings::GetInstance().GetString(CSettings::SETTING_LOCALE_COUNTRY);
-    SetCurrentRegion(strName);
-  }
-  g_charsetConverter.reinitCharsetsFromSettings();
+      SetCurrentRegion(strName);
+    }
 
   return true;
 }
@@ -757,9 +755,9 @@ bool CLangInfo::SetLanguage(bool& fallback, const std::string &strLanguage /* = 
 
   if (reloadServices)
   {
-    // also tell our weather and skin to reload as these are localized
-    g_weatherManager.Refresh();
-    g_PVRManager.LocalizationChanged();
+  // also tell our weather and skin to reload as these are localized
+  g_weatherManager.Refresh();
+  g_PVRManager.LocalizationChanged();
     CApplicationMessenger::GetInstance().PostMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr, "ReloadSkin");
   }
 
@@ -1148,7 +1146,7 @@ std::string CLangInfo::PrepareTimeFormat(const std::string& timeFormat, bool use
 {
   std::string preparedTimeFormat = timeFormat;
   if (use24HourClock)
-  {
+    {
     // replace all "h" with "H"
     StringUtils::Replace(preparedTimeFormat, 'h', 'H');
 

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -331,7 +331,7 @@ void CUtil::GetHomePath(std::string& strPath, const std::string& strTarget)
   {
     //expand potential relative path to full path
     std::wstring strPathW;
-    g_charsetConverter.Utf8ToW(strPath, strPathW);
+    CCharsetConverter::Utf8ToW(strPath, strPathW);
     CWIN32Util::AddExtraLongPathPrefix(strPathW);
     const unsigned int bufSize = GetFullPathNameW(strPathW.c_str(), 0, NULL, NULL);
     if (bufSize != 0)
@@ -341,7 +341,7 @@ void CUtil::GetHomePath(std::string& strPath, const std::string& strTarget)
       {
         std::wstring expandedPathW(buf);
         CWIN32Util::RemoveExtraLongPathPrefix(expandedPathW);
-        g_charsetConverter.WToUtf8(expandedPathW, strPath);
+        CCharsetConverter::WToUtf8(expandedPathW, strPath);
       }
 
       delete [] buf;
@@ -1647,7 +1647,7 @@ std::string CUtil::ResolveExecutablePath()
   buf[0] = 0;
   ::GetModuleFileNameW(0, buf, bufSize);
   buf[bufSize-1] = 0;
-  g_charsetConverter.WToUtf8(buf,strExecutablePath);
+  CCharsetConverter::WToUtf8(buf,strExecutablePath);
   delete[] buf;
 #elif defined(TARGET_DARWIN)
   char     given_path[2*MAXPATHLEN];

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -331,7 +331,7 @@ void CUtil::GetHomePath(std::string& strPath, const std::string& strTarget)
   {
     //expand potential relative path to full path
     std::wstring strPathW;
-    g_charsetConverter.utf8ToW(strPath, strPathW, false);
+    g_charsetConverter.Utf8ToW(strPath, strPathW);
     CWIN32Util::AddExtraLongPathPrefix(strPathW);
     const unsigned int bufSize = GetFullPathNameW(strPathW.c_str(), 0, NULL, NULL);
     if (bufSize != 0)
@@ -341,7 +341,7 @@ void CUtil::GetHomePath(std::string& strPath, const std::string& strTarget)
       {
         std::wstring expandedPathW(buf);
         CWIN32Util::RemoveExtraLongPathPrefix(expandedPathW);
-        g_charsetConverter.wToUTF8(expandedPathW, strPath);
+        g_charsetConverter.WToUtf8(expandedPathW, strPath);
       }
 
       delete [] buf;
@@ -1647,7 +1647,7 @@ std::string CUtil::ResolveExecutablePath()
   buf[0] = 0;
   ::GetModuleFileNameW(0, buf, bufSize);
   buf[bufSize-1] = 0;
-  g_charsetConverter.wToUTF8(buf,strExecutablePath);
+  g_charsetConverter.WToUtf8(buf,strExecutablePath);
   delete[] buf;
 #elif defined(TARGET_DARWIN)
   char     given_path[2*MAXPATHLEN];

--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -578,7 +578,7 @@ std::vector<CScraperUrl> CScraper::FindMovie(XFILE::CCurlFile &fcurl, const std:
     StringUtils::Replace(sTitle, '-',' ');
 
   std::vector<std::string> vcsIn(1);
-  g_charsetConverter.utf8To(SearchStringEncoding(), sTitle, vcsIn[0]);
+  CCharsetConverter::Utf8To(SearchStringEncoding(), sTitle, vcsIn[0]);
   vcsIn[0] = CURL::Encode(vcsIn[0]);
   if (fFirst && !sYear.empty())
     vcsIn.push_back(sYear);
@@ -703,8 +703,8 @@ std::vector<CMusicAlbumInfo> CScraper::FindAlbum(CCurlFile &fcurl, const std::st
   // scraper function is given the album and artist as parameters and
   // returns an XML <url> element parseable by CScraperUrl
   std::vector<std::string> extras(2);
-  g_charsetConverter.utf8To(SearchStringEncoding(), sAlbum, extras[0]);
-  g_charsetConverter.utf8To(SearchStringEncoding(), sArtist, extras[1]);
+  CCharsetConverter::Utf8To(SearchStringEncoding(), sAlbum, extras[0]);
+  CCharsetConverter::Utf8To(SearchStringEncoding(), sArtist, extras[1]);
   extras[0] = CURL::Encode(extras[0]);
   extras[1] = CURL::Encode(extras[1]);
   CScraperUrl scurl;
@@ -800,7 +800,7 @@ std::vector<CMusicArtistInfo> CScraper::FindArtist(CCurlFile &fcurl,
   // scraper function is given the artist as parameter and
   // returns an XML <url> element parseable by CScraperUrl
   std::vector<std::string> extras(1);
-  g_charsetConverter.utf8To(SearchStringEncoding(), sArtist, extras[0]);
+  CCharsetConverter::Utf8To(SearchStringEncoding(), sArtist, extras[0]);
   extras[0] = CURL::Encode(extras[0]);
   CScraperUrl scurl;
   std::vector<std::string> vcsOut = RunNoThrow("CreateArtistSearchUrl", scurl, fcurl, &extras);

--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -243,8 +243,8 @@ void CScraper::ClearCache()
 // the CCurlFile object is passed in so that URL fetches can be canceled from other threads
 // throws CScraperError abort on internal failures (e.g., parse errors)
 std::vector<std::string> CScraper::Run(const std::string& function,
-                                       const CScraperUrl& scrURL,
-                                       CCurlFile& http,
+                                 const CScraperUrl& scrURL,
+                                 CCurlFile& http,
                                        const std::vector<std::string>* extras)
 {
   if (!Load())

--- a/xbmc/addons/binary/interfaces/api1/Addon/AddonCallbacksAddon.cpp
+++ b/xbmc/addons/binary/interfaces/api1/Addon/AddonCallbacksAddon.cpp
@@ -297,7 +297,7 @@ char* CAddonCallbacksAddon::UnknownToUTF8(const char *strSource)
 {
   std::string string;
   if (strSource != NULL)
-    g_charsetConverter.UnknownToUtf8(strSource, string);
+    CCharsetConverter::UnknownToUtf8(strSource, string);
   else
     string = "";
   char* buffer = strdup(string.c_str());

--- a/xbmc/addons/binary/interfaces/api1/Addon/AddonCallbacksAddon.cpp
+++ b/xbmc/addons/binary/interfaces/api1/Addon/AddonCallbacksAddon.cpp
@@ -297,7 +297,7 @@ char* CAddonCallbacksAddon::UnknownToUTF8(const char *strSource)
 {
   std::string string;
   if (strSource != NULL)
-    g_charsetConverter.unknownToUTF8(strSource, string);
+    g_charsetConverter.UnknownToUtf8(strSource, string);
   else
     string = "";
   char* buffer = strdup(string.c_str());

--- a/xbmc/addons/binary/interfaces/api2/Addon/Addon_General.cpp
+++ b/xbmc/addons/binary/interfaces/api2/Addon/Addon_General.cpp
@@ -374,7 +374,7 @@ char* CAddOnGeneral::unknown_to_utf8(
       throw ADDON::WrongValueException("CAddOnGeneral - %s - invalid data (handle='%p', strSource='%p')", __FUNCTION__, hdl, strSource);
 
     std::string string;
-    ret = g_charsetConverter.unknownToUTF8(strSource, string, failOnBadChar);
+    ret = CCharsetConverter::UnknownToUtf8(strSource, string);
     char* buffer = strdup(string.c_str());
     return buffer;
   }

--- a/xbmc/cores/DllLoader/DllLoader.cpp
+++ b/xbmc/cores/DllLoader/DllLoader.cpp
@@ -827,7 +827,7 @@ void DllLoader::UnloadSymbols()
       try
       {
         std::wstring strNameW;
-        g_charsetConverter.utf8ToW(GetName(), strNameW);
+        g_charsetConverter.Utf8ToW(GetName(), strNameW);
 
         // Get the address of the global struct g_dmi
         // It is located inside the xbdm.dll and

--- a/xbmc/cores/DllLoader/DllLoader.cpp
+++ b/xbmc/cores/DllLoader/DllLoader.cpp
@@ -827,7 +827,7 @@ void DllLoader::UnloadSymbols()
       try
       {
         std::wstring strNameW;
-        g_charsetConverter.Utf8ToW(GetName(), strNameW);
+        CCharsetConverter::Utf8ToW(GetName(), strNameW);
 
         // Get the address of the global struct g_dmi
         // It is located inside the xbdm.dll and

--- a/xbmc/cores/DllLoader/Win32DllLoader.cpp
+++ b/xbmc/cores/DllLoader/Win32DllLoader.cpp
@@ -154,7 +154,7 @@ bool Win32DllLoader::Load()
   std::string strFileName = GetFileName();
 
   std::wstring strDllW;
-  g_charsetConverter.utf8ToW(CSpecialProtocol::TranslatePath(strFileName), strDllW, false, false, false);
+  g_charsetConverter.Utf8ToW(CSpecialProtocol::TranslatePath(strFileName), strDllW);
   m_dllHandle = LoadLibraryExW(strDllW.c_str(), NULL, LOAD_WITH_ALTERED_SEARCH_PATH);
   if (!m_dllHandle)
   {
@@ -167,7 +167,7 @@ bool Win32DllLoader::Load()
     if (strLen != 0)
     {
       std::string strMessage;
-      g_charsetConverter.wToUTF8(std::wstring(lpMsgBuf, strLen), strMessage);
+      g_charsetConverter.WToUtf8(std::wstring(lpMsgBuf, strLen), strMessage);
       CLog::Log(LOGERROR, "%s: Failed to load \"%s\" with error %lu: \"%s\"", __FUNCTION__, CSpecialProtocol::TranslatePath(strFileName).c_str(), dw, strMessage.c_str());
     }
     else
@@ -240,7 +240,7 @@ bool Win32DllLoader::HasSymbols()
 void Win32DllLoader::OverrideImports(const std::string &dll)
 {
   std::wstring strdllW;
-  g_charsetConverter.utf8ToW(CSpecialProtocol::TranslatePath(dll), strdllW, false);
+  g_charsetConverter.Utf8ToWSystemSafe(CSpecialProtocol::TranslatePath(dll), strdllW);
   BYTE* image_base = (BYTE*)GetModuleHandleW(strdllW.c_str());
 
   if (!image_base)
@@ -412,10 +412,10 @@ extern "C" FARPROC __stdcall dllWin32GetProcAddress(HMODULE hModule, LPCSTR func
   // if the high-order word is zero, then lpProcName is the function's ordinal value
   if (reinterpret_cast<uintptr_t>(function) > std::numeric_limits<WORD>::max())
   {
-    // first check whether this function is one of the ones we need to wrap
-    void *fixup = NULL;
-    if (FunctionNeedsWrapping(win32_exports, function, &fixup))
-      return (FARPROC)fixup;
+  // first check whether this function is one of the ones we need to wrap
+  void *fixup = NULL;
+  if (FunctionNeedsWrapping(win32_exports, function, &fixup))
+    return (FARPROC)fixup;
   }
 
   // Nope

--- a/xbmc/cores/DllLoader/Win32DllLoader.cpp
+++ b/xbmc/cores/DllLoader/Win32DllLoader.cpp
@@ -154,7 +154,7 @@ bool Win32DllLoader::Load()
   std::string strFileName = GetFileName();
 
   std::wstring strDllW;
-  g_charsetConverter.Utf8ToW(CSpecialProtocol::TranslatePath(strFileName), strDllW);
+  CCharsetConverter::Utf8ToW(CSpecialProtocol::TranslatePath(strFileName), strDllW);
   m_dllHandle = LoadLibraryExW(strDllW.c_str(), NULL, LOAD_WITH_ALTERED_SEARCH_PATH);
   if (!m_dllHandle)
   {
@@ -167,7 +167,7 @@ bool Win32DllLoader::Load()
     if (strLen != 0)
     {
       std::string strMessage;
-      g_charsetConverter.WToUtf8(std::wstring(lpMsgBuf, strLen), strMessage);
+      CCharsetConverter::WToUtf8(std::wstring(lpMsgBuf, strLen), strMessage);
       CLog::Log(LOGERROR, "%s: Failed to load \"%s\" with error %lu: \"%s\"", __FUNCTION__, CSpecialProtocol::TranslatePath(strFileName).c_str(), dw, strMessage.c_str());
     }
     else
@@ -240,7 +240,7 @@ bool Win32DllLoader::HasSymbols()
 void Win32DllLoader::OverrideImports(const std::string &dll)
 {
   std::wstring strdllW;
-  g_charsetConverter.Utf8ToWSystemSafe(CSpecialProtocol::TranslatePath(dll), strdllW);
+  CCharsetConverter::Utf8ToWSystemSafe(CSpecialProtocol::TranslatePath(dll), strdllW);
   BYTE* image_base = (BYTE*)GetModuleHandleW(strdllW.c_str());
 
   if (!image_base)

--- a/xbmc/cores/DllLoader/exports/emu_kernel32.cpp
+++ b/xbmc/cores/DllLoader/exports/emu_kernel32.cpp
@@ -112,13 +112,13 @@ extern "C" BOOL WINAPI dllFindClose(HANDLE hFile)
 static void to_WIN32_FIND_DATA(LPWIN32_FIND_DATAW wdata, LPWIN32_FIND_DATA data)
 {
   std::string strname;
-  g_charsetConverter.wToUTF8(wdata->cFileName, strname);
+  g_charsetConverter.WToUtf8(wdata->cFileName, strname);
   size_t size = sizeof(data->cFileName) / sizeof(char);
   strncpy(data->cFileName, strname.c_str(), size);
   if (size)
     data->cFileName[size - 1] = '\0';
 
-  g_charsetConverter.wToUTF8(wdata->cAlternateFileName, strname);
+  g_charsetConverter.WToUtf8(wdata->cAlternateFileName, strname);
   size = sizeof(data->cAlternateFileName) / sizeof(char);
   strncpy(data->cAlternateFileName, strname.c_str(), size);
   if (size)
@@ -137,13 +137,13 @@ static void to_WIN32_FIND_DATA(LPWIN32_FIND_DATAW wdata, LPWIN32_FIND_DATA data)
 static void to_WIN32_FIND_DATAW(LPWIN32_FIND_DATA data, LPWIN32_FIND_DATAW wdata)
 {
   std::wstring strwname;
-  g_charsetConverter.utf8ToW(data->cFileName, strwname, false);
+  g_charsetConverter.Utf8ToWSystemSafe(data->cFileName, strwname);
   size_t size = sizeof(wdata->cFileName) / sizeof(wchar_t);
   wcsncpy(wdata->cFileName, strwname.c_str(), size);
   if (size)
     wdata->cFileName[size - 1] = '\0';
 
-  g_charsetConverter.utf8ToW(data->cAlternateFileName, strwname, false);
+  g_charsetConverter.Utf8ToWSystemSafe(data->cAlternateFileName, strwname);
   size = sizeof(wdata->cAlternateFileName) / sizeof(wchar_t);
   wcsncpy(wdata->cAlternateFileName, strwname.c_str(), size);
   if (size)
@@ -174,7 +174,7 @@ extern "C" HANDLE WINAPI dllFindFirstFileA(LPCTSTR lpFileName, LPWIN32_FIND_DATA
 #ifdef TARGET_WINDOWS
   struct _WIN32_FIND_DATAW FindFileDataW;
   std::wstring strwfile;
-  g_charsetConverter.utf8ToW(CSpecialProtocol::TranslatePath(p), strwfile, false);
+  g_charsetConverter.Utf8ToWSystemSafe(CSpecialProtocol::TranslatePath(p), strwfile);
   HANDLE res = FindFirstFileW(strwfile.c_str(), &FindFileDataW);
   if (res != INVALID_HANDLE_VALUE)
     to_WIN32_FIND_DATA(&FindFileDataW, lpFindFileData);

--- a/xbmc/cores/DllLoader/exports/emu_kernel32.cpp
+++ b/xbmc/cores/DllLoader/exports/emu_kernel32.cpp
@@ -112,13 +112,13 @@ extern "C" BOOL WINAPI dllFindClose(HANDLE hFile)
 static void to_WIN32_FIND_DATA(LPWIN32_FIND_DATAW wdata, LPWIN32_FIND_DATA data)
 {
   std::string strname;
-  g_charsetConverter.WToUtf8(wdata->cFileName, strname);
+  CCharsetConverter::WToUtf8(wdata->cFileName, strname);
   size_t size = sizeof(data->cFileName) / sizeof(char);
   strncpy(data->cFileName, strname.c_str(), size);
   if (size)
     data->cFileName[size - 1] = '\0';
 
-  g_charsetConverter.WToUtf8(wdata->cAlternateFileName, strname);
+  CCharsetConverter::WToUtf8(wdata->cAlternateFileName, strname);
   size = sizeof(data->cAlternateFileName) / sizeof(char);
   strncpy(data->cAlternateFileName, strname.c_str(), size);
   if (size)
@@ -137,13 +137,13 @@ static void to_WIN32_FIND_DATA(LPWIN32_FIND_DATAW wdata, LPWIN32_FIND_DATA data)
 static void to_WIN32_FIND_DATAW(LPWIN32_FIND_DATA data, LPWIN32_FIND_DATAW wdata)
 {
   std::wstring strwname;
-  g_charsetConverter.Utf8ToWSystemSafe(data->cFileName, strwname);
+  CCharsetConverter::Utf8ToWSystemSafe(data->cFileName, strwname);
   size_t size = sizeof(wdata->cFileName) / sizeof(wchar_t);
   wcsncpy(wdata->cFileName, strwname.c_str(), size);
   if (size)
     wdata->cFileName[size - 1] = '\0';
 
-  g_charsetConverter.Utf8ToWSystemSafe(data->cAlternateFileName, strwname);
+  CCharsetConverter::Utf8ToWSystemSafe(data->cAlternateFileName, strwname);
   size = sizeof(wdata->cAlternateFileName) / sizeof(wchar_t);
   wcsncpy(wdata->cAlternateFileName, strwname.c_str(), size);
   if (size)
@@ -174,7 +174,7 @@ extern "C" HANDLE WINAPI dllFindFirstFileA(LPCTSTR lpFileName, LPWIN32_FIND_DATA
 #ifdef TARGET_WINDOWS
   struct _WIN32_FIND_DATAW FindFileDataW;
   std::wstring strwfile;
-  g_charsetConverter.Utf8ToWSystemSafe(CSpecialProtocol::TranslatePath(p), strwfile);
+  CCharsetConverter::Utf8ToWSystemSafe(CSpecialProtocol::TranslatePath(p), strwfile);
   HANDLE res = FindFirstFileW(strwfile.c_str(), &FindFileDataW);
   if (res != INVALID_HANDLE_VALUE)
     to_WIN32_FIND_DATA(&FindFileDataW, lpFindFileData);

--- a/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
+++ b/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
@@ -253,7 +253,7 @@ static int convert_fmode(const char* mode)
 static void to_finddata64i32(_wfinddata64i32_t *wdata, _finddata64i32_t *data)
 {
   std::string strname;
-  g_charsetConverter.WToUtf8(wdata->name, strname);
+  CCharsetConverter::WToUtf8(wdata->name, strname);
   size_t size = sizeof(data->name) / sizeof(char);
   strncpy(data->name, strname.c_str(), size);
   if (size)
@@ -268,7 +268,7 @@ static void to_finddata64i32(_wfinddata64i32_t *wdata, _finddata64i32_t *data)
 static void to_wfinddata64i32(_finddata64i32_t *data, _wfinddata64i32_t *wdata)
 {
   std::wstring strwname;
-  g_charsetConverter.Utf8ToWSystemSafe(data->name, strwname);
+  CCharsetConverter::Utf8ToWSystemSafe(data->name, strwname);
   size_t size = sizeof(wdata->name) / sizeof(wchar_t);
   wcsncpy(wdata->name, strwname.c_str(), size);
   if (size)
@@ -847,7 +847,7 @@ extern "C"
       // Make sure the slashes are correct & translate the path
       struct _wfinddata64i32_t wdata;
       std::wstring strwfile;
-      g_charsetConverter.Utf8ToWSystemSafe(CUtil::ValidatePath(CSpecialProtocol::TranslatePath(str)), strwfile);
+      CCharsetConverter::Utf8ToWSystemSafe(CUtil::ValidatePath(CSpecialProtocol::TranslatePath(str)), strwfile);
       intptr_t ret = _wfindfirst64i32(strwfile.c_str(), &wdata);
       if (ret != -1)
         to_finddata64i32(&wdata, data);
@@ -1974,7 +1974,7 @@ extern "C"
     std::string strPath = CUtil::ValidatePath(CSpecialProtocol::TranslatePath(dir));
 #ifndef TARGET_POSIX
     std::wstring strWPath;
-    g_charsetConverter.Utf8ToWSystemSafe(strPath, strWPath);
+    CCharsetConverter::Utf8ToWSystemSafe(strPath, strWPath);
     return _wmkdir(strWPath.c_str());
 #else
     return mkdir(strPath.c_str(), 0755);

--- a/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
+++ b/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
@@ -253,7 +253,7 @@ static int convert_fmode(const char* mode)
 static void to_finddata64i32(_wfinddata64i32_t *wdata, _finddata64i32_t *data)
 {
   std::string strname;
-  g_charsetConverter.wToUTF8(wdata->name, strname);
+  g_charsetConverter.WToUtf8(wdata->name, strname);
   size_t size = sizeof(data->name) / sizeof(char);
   strncpy(data->name, strname.c_str(), size);
   if (size)
@@ -268,7 +268,7 @@ static void to_finddata64i32(_wfinddata64i32_t *wdata, _finddata64i32_t *data)
 static void to_wfinddata64i32(_finddata64i32_t *data, _wfinddata64i32_t *wdata)
 {
   std::wstring strwname;
-  g_charsetConverter.utf8ToW(data->name, strwname, false);
+  g_charsetConverter.Utf8ToWSystemSafe(data->name, strwname);
   size_t size = sizeof(wdata->name) / sizeof(wchar_t);
   wcsncpy(wdata->name, strwname.c_str(), size);
   if (size)
@@ -847,7 +847,7 @@ extern "C"
       // Make sure the slashes are correct & translate the path
       struct _wfinddata64i32_t wdata;
       std::wstring strwfile;
-      g_charsetConverter.utf8ToW(CUtil::ValidatePath(CSpecialProtocol::TranslatePath(str)), strwfile, false);
+      g_charsetConverter.Utf8ToWSystemSafe(CUtil::ValidatePath(CSpecialProtocol::TranslatePath(str)), strwfile);
       intptr_t ret = _wfindfirst64i32(strwfile.c_str(), &wdata);
       if (ret != -1)
         to_finddata64i32(&wdata, data);
@@ -1974,7 +1974,7 @@ extern "C"
     std::string strPath = CUtil::ValidatePath(CSpecialProtocol::TranslatePath(dir));
 #ifndef TARGET_POSIX
     std::wstring strWPath;
-    g_charsetConverter.utf8ToW(strPath, strWPath, false);
+    g_charsetConverter.Utf8ToWSystemSafe(strPath, strWPath);
     return _wmkdir(strWPath.c_str());
 #else
     return mkdir(strPath.c_str(), 0755);

--- a/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
+++ b/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
@@ -411,8 +411,8 @@ BOOL CExternalPlayer::ExecuteAppW32(const char* strPath, const char* strSwitches
   si.wShowWindow = m_hideconsole ? SW_HIDE : SW_SHOW;
 
   std::wstring WstrPath, WstrSwitches;
-  g_charsetConverter.utf8ToW(strPath, WstrPath, false);
-  g_charsetConverter.utf8ToW(strSwitches, WstrSwitches, false);
+  g_charsetConverter.Utf8ToW(strPath, WstrPath);
+  g_charsetConverter.Utf8ToW(strSwitches, WstrSwitches);
 
   if (m_bAbortRequest) return false;
 

--- a/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
+++ b/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
@@ -411,8 +411,8 @@ BOOL CExternalPlayer::ExecuteAppW32(const char* strPath, const char* strSwitches
   si.wShowWindow = m_hideconsole ? SW_HIDE : SW_SHOW;
 
   std::wstring WstrPath, WstrSwitches;
-  g_charsetConverter.Utf8ToW(strPath, WstrPath);
-  g_charsetConverter.Utf8ToW(strSwitches, WstrSwitches);
+  CCharsetConverter::Utf8ToW(strPath, WstrPath);
+  CCharsetConverter::Utf8ToW(strSwitches, WstrSwitches);
 
   if (m_bAbortRequest) return false;
 

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleStream.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleStream.cpp
@@ -84,7 +84,7 @@ bool CDVDSubtitleStream::Open(const std::string& strFile)
     else if (!enc.empty())
     {
       std::string converted;
-      g_charsetConverter.ToUtf8(enc, tmpStr, converted);
+      CCharsetConverter::ToUtf8(enc, tmpStr, converted);
       if (converted.empty())
         return false;
 
@@ -93,7 +93,7 @@ bool CDVDSubtitleStream::Open(const std::string& strFile)
     else
     {
       std::string converted;
-      g_charsetConverter.SubtitleCharsetToUtf8(tmpStr, converted);
+      CCharsetConverter::SubtitleCharsetToUtf8(tmpStr, converted);
       if (converted.empty())
         return false;
 

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleStream.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleStream.cpp
@@ -93,7 +93,7 @@ bool CDVDSubtitleStream::Open(const std::string& strFile)
     else
     {
       std::string converted;
-      g_charsetConverter.subtitleCharsetToUtf8(tmpStr, converted);
+      g_charsetConverter.SubtitleCharsetToUtf8(tmpStr, converted);
       if (converted.empty())
         return false;
 

--- a/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
@@ -1134,7 +1134,7 @@ unsigned int CDVDRadioRDSData::DecodeRT(uint8_t *msgElement, unsigned int len)
 
       std::string rdsline = m_RT_Text[m_RT_Index];
       rtrim_str(rdsline);
-      g_charsetConverter.unknownToUTF8(rdsline);
+      CCharsetConverter::UnknownToUtf8(rdsline);
       m_RT.push_front(StringUtils::Trim(rdsline));
 
       if ((int)m_RT.size() > m_RT_MaxSize)
@@ -1341,7 +1341,7 @@ unsigned int CDVDRadioRDSData::DecodeRTPlus(uint8_t *msgElement, unsigned int le
         case RTPLUS_ITEM_GENRE:
           {
             std::string str = m_RTPlus_Temptext;
-            g_charsetConverter.unknownToUTF8(str);
+            CCharsetConverter::UnknownToUtf8(str);
             m_RTPlus_GenrePresent = true;
             m_currentInfoTag->SetProgStyle(str);
           }
@@ -1505,13 +1505,13 @@ unsigned int CDVDRadioRDSData::DecodeRTPlus(uint8_t *msgElement, unsigned int le
       str = m_currentInfoTag->GetBand();
 
     if (!str.empty())
-      g_charsetConverter.unknownToUTF8(str);
+      CCharsetConverter::UnknownToUtf8(str);
     else if (m_currentChannel)
       str = m_currentChannel->ChannelName();
     currentMusic->SetArtist(str);
 
     str = m_RTPlus_Title;
-    g_charsetConverter.unknownToUTF8(str);
+    CCharsetConverter::UnknownToUtf8(str);
     currentMusic->SetTitle(str);
     m_currentInfoTag->SetTitle(str);
     m_currentFileUpdate = true;

--- a/xbmc/dbwrappers/DatabaseQuery.cpp
+++ b/xbmc/dbwrappers/DatabaseQuery.cpp
@@ -94,7 +94,7 @@ bool CDatabaseQueryRule::Load(const TiXmlNode *node, const std::string &encoding
     if (encoding.empty()) // utf8
       utf8Parameter = parameter->ValueStr();
     else
-      g_charsetConverter.ToUtf8(encoding, parameter->ValueStr(), utf8Parameter);
+      CCharsetConverter::ToUtf8(encoding, parameter->ValueStr(), utf8Parameter);
 
     if (!utf8Parameter.empty())
       m_parameter.push_back(utf8Parameter);
@@ -111,7 +111,7 @@ bool CDatabaseQueryRule::Load(const TiXmlNode *node, const std::string &encoding
         if (encoding.empty()) // utf8
           utf8Parameter = value->ValueStr();
         else
-          g_charsetConverter.ToUtf8(encoding, value->ValueStr(), utf8Parameter);
+          CCharsetConverter::ToUtf8(encoding, value->ValueStr(), utf8Parameter);
 
         if (!utf8Parameter.empty())
           m_parameter.push_back(utf8Parameter);

--- a/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
+++ b/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
@@ -199,7 +199,7 @@ bool CGUIDialogKeyboardGeneric::OnAction(const CAction &action)
     std::wstring wch = L"";
     wch.insert(wch.begin(), action.GetUnicode());
     std::string ch;
-    g_charsetConverter.wToUTF8(wch, ch);
+    CCharsetConverter::WToUtf8(wch, ch);
     handled = CodingCharacter(ch);
     if (!handled)
     {
@@ -374,9 +374,9 @@ void CGUIDialogKeyboardGeneric::Backspace()
   if (m_codingtable && m_hzcode.length() > 0)
   {
     std::wstring tmp;
-    g_charsetConverter.utf8ToW(m_hzcode, tmp);
+    CCharsetConverter::Utf8ToW(m_hzcode, tmp);
     tmp.erase(tmp.length() - 1, 1);
-    g_charsetConverter.wToUTF8(tmp, m_hzcode);
+    CCharsetConverter::WToUtf8(tmp, m_hzcode);
     
     switch (m_codingtable->GetType())
     {
@@ -702,7 +702,7 @@ void CGUIDialogKeyboardGeneric::ShowWordList(int direct)
   if (m_pos + m_num < static_cast<int>(m_words.size()))
     hzlist.insert(hzlist.length(), 1, L'>');
   std::string utf8String;
-  g_charsetConverter.wToUTF8(hzlist, utf8String);
+  CCharsetConverter::WToUtf8(hzlist, utf8String);
   SET_CONTROL_LABEL(CTL_LABEL_HZLIST, utf8String);
 }
 
@@ -738,7 +738,7 @@ bool CGUIDialogKeyboardGeneric::CodingCharacter(const std::string &ch)
         m_hzcode = "";
         SetControlLabel(CTL_LABEL_HZCODE, m_hzcode);
         std::string utf8String;
-        g_charsetConverter.wToUTF8(m_words[i], utf8String);
+        CCharsetConverter::WToUtf8(m_words[i], utf8String);
         NormalCharacter(utf8String);
       }
       return true;

--- a/xbmc/filesystem/APKDirectory.cpp
+++ b/xbmc/filesystem/APKDirectory.cpp
@@ -79,7 +79,7 @@ bool CAPKDirectory::GetDirectory(const CURL& url, CFileItemList &items)
     zip_stat_init(&sb);
     if (zip_stat_index(zip_archive, zip_index, zip_flags, &sb) != -1)
     {
-      g_charsetConverter.unknownToUTF8(test_name);
+      g_charsetConverter.UnknownToUtf8(test_name);
       CFileItemPtr pItem(new CFileItem(test_name));      
       pItem->m_dwSize    = sb.size;
       pItem->m_dateTime  = sb.mtime;    

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -729,7 +729,7 @@ void CCurlFile::ParseAndCorrectUrl(CURL &url2)
 
     // if server sent us the filename in non-utf8, we need send back with same encoding.
     if (url2.GetProtocolOption("utf8") == "0")
-      g_charsetConverter.utf8ToStringCharset(filename);
+      g_charsetConverter.Utf8ToStringCharset(filename);
 
     /* TODO: create a tokenizer that doesn't skip empty's */
     StringUtils::Tokenize(filename, array, "/");

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -729,7 +729,7 @@ void CCurlFile::ParseAndCorrectUrl(CURL &url2)
 
     // if server sent us the filename in non-utf8, we need send back with same encoding.
     if (url2.GetProtocolOption("utf8") == "0")
-      g_charsetConverter.Utf8ToStringCharset(filename);
+      CCharsetConverter::Utf8ToStringCharset(filename);
 
     /* TODO: create a tokenizer that doesn't skip empty's */
     StringUtils::Tokenize(filename, array, "/");

--- a/xbmc/filesystem/Directorization.h
+++ b/xbmc/filesystem/Directorization.h
@@ -129,7 +129,7 @@ namespace XFILE
 
       // determine the entry's filename
       std::string label = pathTokens[filePathTokens.size()];
-      g_charsetConverter.unknownToUTF8(label);
+      CCharsetConverter::UnknownToUtf8(label);
 
       // convert the entry into a CFileItem
       CFileItemPtr item = converter(entry.second, label, itemPath, isFolder);

--- a/xbmc/filesystem/FTPDirectory.cpp
+++ b/xbmc/filesystem/FTPDirectory.cpp
@@ -76,7 +76,7 @@ bool CFTPDirectory::GetDirectory(const CURL& url2, CFileItemList &items)
 
       // server returned filename could in utf8 or non-utf8 encoding
       // we need utf8, so convert it to utf8 anyway
-      g_charsetConverter.UnknownToUtf8(name);
+      CCharsetConverter::UnknownToUtf8(name);
 
       // convert got empty result, ignore it
       if (name.empty())

--- a/xbmc/filesystem/FTPDirectory.cpp
+++ b/xbmc/filesystem/FTPDirectory.cpp
@@ -76,7 +76,7 @@ bool CFTPDirectory::GetDirectory(const CURL& url2, CFileItemList &items)
 
       // server returned filename could in utf8 or non-utf8 encoding
       // we need utf8, so convert it to utf8 anyway
-      g_charsetConverter.unknownToUTF8(name);
+      g_charsetConverter.UnknownToUtf8(name);
 
       // convert got empty result, ignore it
       if (name.empty())

--- a/xbmc/filesystem/HTTPDirectory.cpp
+++ b/xbmc/filesystem/HTTPDirectory.cpp
@@ -79,7 +79,7 @@ bool CHTTPDirectory::GetDirectory(const CURL& url, CFileItemList &items)
     if (!fileCharset.empty() && fileCharset != "UTF-8")
     {
       std::string converted;
-      if (g_charsetConverter.ToUtf8(fileCharset, strBuffer, converted) && !converted.empty())
+      if (CCharsetConverter::ToUtf8(fileCharset, strBuffer, converted) && !converted.empty())
         strBuffer = converted;
     }
 
@@ -97,10 +97,10 @@ bool CHTTPDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 
       std::wstring wName, wLink, wConverted;
       if (fileCharset.empty())
-        g_charsetConverter.UnknownToUtf8(strNameTemp);
-      g_charsetConverter.Utf8ToW(strNameTemp, wName);
+        CCharsetConverter::UnknownToUtf8(strNameTemp);
+      CCharsetConverter::Utf8ToW(strNameTemp, wName);
       HTML::CHTMLUtil::ConvertHTMLToW(wName, wConverted);
-      g_charsetConverter.WToUtf8(wConverted, strNameTemp);
+      CCharsetConverter::WToUtf8(wConverted, strNameTemp);
       URIUtils::RemoveSlashAtEnd(strNameTemp);
 
       std::string strLinkBase = strLink;
@@ -118,10 +118,10 @@ bool CHTTPDirectory::GetDirectory(const CURL& url, CFileItemList &items)
       URIUtils::RemoveSlashAtEnd(strLinkTemp);
       strLinkTemp = CURL::Decode(strLinkTemp);
       if (fileCharset.empty())
-        g_charsetConverter.UnknownToUtf8(strLinkTemp);
-      g_charsetConverter.Utf8ToW(strLinkTemp, wLink);
+        CCharsetConverter::UnknownToUtf8(strLinkTemp);
+      CCharsetConverter::Utf8ToW(strLinkTemp, wLink);
       HTML::CHTMLUtil::ConvertHTMLToW(wLink, wConverted);
-      g_charsetConverter.WToUtf8(wConverted, strLinkTemp);
+      CCharsetConverter::WToUtf8(wConverted, strLinkTemp);
 
       if (StringUtils::EndsWith(strNameTemp, "..>") &&
           StringUtils::StartsWith(strLinkTemp, strNameTemp.substr(0, strNameTemp.length() - 3)))
@@ -139,10 +139,10 @@ bool CHTTPDirectory::GetDirectory(const CURL& url, CFileItemList &items)
          * due to the ; also being allowed as URL option seperator
          */
         if (fileCharset.empty())
-          g_charsetConverter.UnknownToUtf8(strLinkBase);
-        g_charsetConverter.Utf8ToW(strLinkBase, wLink);
+          CCharsetConverter::UnknownToUtf8(strLinkBase);
+        CCharsetConverter::Utf8ToW(strLinkBase, wLink);
         HTML::CHTMLUtil::ConvertHTMLToW(wLink, wConverted);
-        g_charsetConverter.WToUtf8(wConverted, strLinkBase);
+        CCharsetConverter::WToUtf8(wConverted, strLinkBase);
 
         url2.SetFileName(strBasePath + strLinkBase);
         url2.SetOptions(strLinkOptions);

--- a/xbmc/filesystem/HTTPDirectory.cpp
+++ b/xbmc/filesystem/HTTPDirectory.cpp
@@ -97,10 +97,10 @@ bool CHTTPDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 
       std::wstring wName, wLink, wConverted;
       if (fileCharset.empty())
-        g_charsetConverter.unknownToUTF8(strNameTemp);
-      g_charsetConverter.utf8ToW(strNameTemp, wName, false);
+        g_charsetConverter.UnknownToUtf8(strNameTemp);
+      g_charsetConverter.Utf8ToW(strNameTemp, wName);
       HTML::CHTMLUtil::ConvertHTMLToW(wName, wConverted);
-      g_charsetConverter.wToUTF8(wConverted, strNameTemp);
+      g_charsetConverter.WToUtf8(wConverted, strNameTemp);
       URIUtils::RemoveSlashAtEnd(strNameTemp);
 
       std::string strLinkBase = strLink;
@@ -118,10 +118,10 @@ bool CHTTPDirectory::GetDirectory(const CURL& url, CFileItemList &items)
       URIUtils::RemoveSlashAtEnd(strLinkTemp);
       strLinkTemp = CURL::Decode(strLinkTemp);
       if (fileCharset.empty())
-        g_charsetConverter.unknownToUTF8(strLinkTemp);
-      g_charsetConverter.utf8ToW(strLinkTemp, wLink, false);
+        g_charsetConverter.UnknownToUtf8(strLinkTemp);
+      g_charsetConverter.Utf8ToW(strLinkTemp, wLink);
       HTML::CHTMLUtil::ConvertHTMLToW(wLink, wConverted);
-      g_charsetConverter.wToUTF8(wConverted, strLinkTemp);
+      g_charsetConverter.WToUtf8(wConverted, strLinkTemp);
 
       if (StringUtils::EndsWith(strNameTemp, "..>") &&
           StringUtils::StartsWith(strLinkTemp, strNameTemp.substr(0, strNameTemp.length() - 3)))
@@ -139,10 +139,10 @@ bool CHTTPDirectory::GetDirectory(const CURL& url, CFileItemList &items)
          * due to the ; also being allowed as URL option seperator
          */
         if (fileCharset.empty())
-          g_charsetConverter.unknownToUTF8(strLinkBase);
-        g_charsetConverter.utf8ToW(strLinkBase, wLink, false);
+          g_charsetConverter.UnknownToUtf8(strLinkBase);
+        g_charsetConverter.Utf8ToW(strLinkBase, wLink);
         HTML::CHTMLUtil::ConvertHTMLToW(wLink, wConverted);
-        g_charsetConverter.wToUTF8(wConverted, strLinkBase);
+        g_charsetConverter.WToUtf8(wConverted, strLinkBase);
 
         url2.SetFileName(strBasePath + strLinkBase);
         url2.SetOptions(strLinkOptions);

--- a/xbmc/filesystem/RarFile.cpp
+++ b/xbmc/filesystem/RarFile.cpp
@@ -708,11 +708,11 @@ bool CRarFile::OpenInArchive()
 
         if (wcslen(m_pArc->NewLhd.FileNameW) > 0)
         {
-          g_charsetConverter.wToUTF8(m_pArc->NewLhd.FileNameW, strFileName);
+          g_charsetConverter.WToUtf8(m_pArc->NewLhd.FileNameW, strFileName);
         }
         else
         {
-          g_charsetConverter.unknownToUTF8(m_pArc->NewLhd.FileName, strFileName);
+          g_charsetConverter.UnknownToUtf8(m_pArc->NewLhd.FileName, strFileName);
         }
 
         /* replace back slashes into forward slashes */

--- a/xbmc/filesystem/RarFile.cpp
+++ b/xbmc/filesystem/RarFile.cpp
@@ -708,11 +708,11 @@ bool CRarFile::OpenInArchive()
 
         if (wcslen(m_pArc->NewLhd.FileNameW) > 0)
         {
-          g_charsetConverter.WToUtf8(m_pArc->NewLhd.FileNameW, strFileName);
+          CCharsetConverter::WToUtf8(m_pArc->NewLhd.FileNameW, strFileName);
         }
         else
         {
-          g_charsetConverter.UnknownToUtf8(m_pArc->NewLhd.FileName, strFileName);
+          CCharsetConverter::UnknownToUtf8(m_pArc->NewLhd.FileName, strFileName);
         }
 
         /* replace back slashes into forward slashes */

--- a/xbmc/filesystem/RarManager.cpp
+++ b/xbmc/filesystem/RarManager.cpp
@@ -209,7 +209,7 @@ bool CRarManager::CacheRarredFile(std::string& strPathInCache, const std::string
 #ifndef TARGET_POSIX
   StringUtils::Replace(strPath, '/', '\\');
 #endif
-  //g_charsetConverter.UnknownToUtf8(strPath);
+  //CCharsetConverter::UnknownToUtf8(strPath);
   std::string strCachedPath = URIUtils::AddFileToFolder(strDir + "rarfolder%04d",
                                            URIUtils::GetFileName(strPathInRar));
   strCachedPath = CUtil::GetNextPathname(strCachedPath, 9999);
@@ -237,9 +237,9 @@ bool CRarManager::CacheRarredFile(std::string& strPathInCache, const std::string
 
         /* convert to utf8 */
         if( pIterator->item.NameW && wcslen(pIterator->item.NameW) > 0)
-          g_charsetConverter.WToUtf8(pIterator->item.NameW, strName);
+          CCharsetConverter::WToUtf8(pIterator->item.NameW, strName);
         else
-          g_charsetConverter.UnknownToUtf8(pIterator->item.Name, strName);
+          CCharsetConverter::UnknownToUtf8(pIterator->item.Name, strName);
         if (strName == strPath)
         {
           iOffset = pIterator->item.iOffset;
@@ -337,9 +337,9 @@ bool CRarManager::GetFilesInRar(CFileItemList& vecpItems, const std::string& str
 
     /* convert to utf8 */
     if( pIterator->item.NameW && wcslen(pIterator->item.NameW) > 0)
-      g_charsetConverter.WToUtf8(pIterator->item.NameW, strName);
+      CCharsetConverter::WToUtf8(pIterator->item.NameW, strName);
     else
-      g_charsetConverter.UnknownToUtf8(pIterator->item.Name, strName);
+      CCharsetConverter::UnknownToUtf8(pIterator->item.Name, strName);
 
     /* replace back slashes into forward slashes */
     /* this could get us into troubles, file could two different files, one with / and one with \ */

--- a/xbmc/filesystem/RarManager.cpp
+++ b/xbmc/filesystem/RarManager.cpp
@@ -209,7 +209,7 @@ bool CRarManager::CacheRarredFile(std::string& strPathInCache, const std::string
 #ifndef TARGET_POSIX
   StringUtils::Replace(strPath, '/', '\\');
 #endif
-  //g_charsetConverter.unknownToUTF8(strPath);
+  //g_charsetConverter.UnknownToUtf8(strPath);
   std::string strCachedPath = URIUtils::AddFileToFolder(strDir + "rarfolder%04d",
                                            URIUtils::GetFileName(strPathInRar));
   strCachedPath = CUtil::GetNextPathname(strCachedPath, 9999);
@@ -237,9 +237,9 @@ bool CRarManager::CacheRarredFile(std::string& strPathInCache, const std::string
 
         /* convert to utf8 */
         if( pIterator->item.NameW && wcslen(pIterator->item.NameW) > 0)
-          g_charsetConverter.wToUTF8(pIterator->item.NameW, strName);
+          g_charsetConverter.WToUtf8(pIterator->item.NameW, strName);
         else
-          g_charsetConverter.unknownToUTF8(pIterator->item.Name, strName);
+          g_charsetConverter.UnknownToUtf8(pIterator->item.Name, strName);
         if (strName == strPath)
         {
           iOffset = pIterator->item.iOffset;
@@ -337,9 +337,9 @@ bool CRarManager::GetFilesInRar(CFileItemList& vecpItems, const std::string& str
 
     /* convert to utf8 */
     if( pIterator->item.NameW && wcslen(pIterator->item.NameW) > 0)
-      g_charsetConverter.wToUTF8(pIterator->item.NameW, strName);
+      g_charsetConverter.WToUtf8(pIterator->item.NameW, strName);
     else
-      g_charsetConverter.unknownToUTF8(pIterator->item.Name, strName);
+      g_charsetConverter.UnknownToUtf8(pIterator->item.Name, strName);
 
     /* replace back slashes into forward slashes */
     /* this could get us into troubles, file could two different files, one with / and one with \ */

--- a/xbmc/filesystem/ShoutcastFile.cpp
+++ b/xbmc/filesystem/ShoutcastFile.cpp
@@ -148,18 +148,18 @@ bool CShoutcastFile::ExtractTagInfo(const char* buf)
   if (!m_fileCharset.empty())
   {
     std::string converted;
-    g_charsetConverter.ToUtf8(m_fileCharset, strBuffer, converted);
+    CCharsetConverter::ToUtf8(m_fileCharset, strBuffer, converted);
     strBuffer = converted;
   }
   else
-    g_charsetConverter.UnknownToUtf8(strBuffer);
+    CCharsetConverter::UnknownToUtf8(strBuffer);
   
   bool result=false;
 
   std::wstring wBuffer, wConverted;
-  g_charsetConverter.Utf8ToW(strBuffer, wBuffer);
+  CCharsetConverter::Utf8ToW(strBuffer, wBuffer);
   HTML::CHTMLUtil::ConvertHTMLToW(wBuffer, wConverted);
-  g_charsetConverter.WToUtf8(wConverted, strBuffer);
+  CCharsetConverter::WToUtf8(wConverted, strBuffer);
 
   CRegExp reTitle(true);
   reTitle.RegComp("StreamTitle=\'(.*?)\';");

--- a/xbmc/filesystem/ShoutcastFile.cpp
+++ b/xbmc/filesystem/ShoutcastFile.cpp
@@ -152,14 +152,14 @@ bool CShoutcastFile::ExtractTagInfo(const char* buf)
     strBuffer = converted;
   }
   else
-    g_charsetConverter.unknownToUTF8(strBuffer);
+    g_charsetConverter.UnknownToUtf8(strBuffer);
   
   bool result=false;
 
   std::wstring wBuffer, wConverted;
-  g_charsetConverter.utf8ToW(strBuffer, wBuffer, false);
+  g_charsetConverter.Utf8ToW(strBuffer, wBuffer);
   HTML::CHTMLUtil::ConvertHTMLToW(wBuffer, wConverted);
-  g_charsetConverter.wToUTF8(wConverted, strBuffer);
+  g_charsetConverter.WToUtf8(wConverted, strBuffer);
 
   CRegExp reTitle(true);
   reTitle.RegComp("StreamTitle=\'(.*?)\';");

--- a/xbmc/filesystem/ZipManager.cpp
+++ b/xbmc/filesystem/ZipManager.cpp
@@ -192,7 +192,7 @@ bool CZipManager::GetZipList(const CURL& url, std::vector<SZipEntry>& items)
       return false;
     std::string strName(bufName.get(), bufName.size());
     bufName.clear();
-    g_charsetConverter.UnknownToUtf8(strName);
+    CCharsetConverter::UnknownToUtf8(strName);
     ZeroMemory(ze.name, 255);
     strncpy(ze.name, strName.c_str(), strName.size()>254 ? 254 : strName.size());
 

--- a/xbmc/filesystem/ZipManager.cpp
+++ b/xbmc/filesystem/ZipManager.cpp
@@ -192,7 +192,7 @@ bool CZipManager::GetZipList(const CURL& url, std::vector<SZipEntry>& items)
       return false;
     std::string strName(bufName.get(), bufName.size());
     bufName.clear();
-    g_charsetConverter.unknownToUTF8(strName);
+    g_charsetConverter.UnknownToUtf8(strName);
     ZeroMemory(ze.name, 255);
     strncpy(ze.name, strName.c_str(), strName.size()>254 ? 254 : strName.size());
 

--- a/xbmc/filesystem/iso9660.cpp
+++ b/xbmc/filesystem/iso9660.cpp
@@ -703,7 +703,7 @@ std::string iso9660::GetThinText(BYTE* strTxt, int iLen )
   std::u16string strTxtUnicode((char16_t*)strTxt, iLen / 2);
   std::string utf8String;
 
-  g_charsetConverter.Utf16BEToUtf8(strTxtUnicode, utf8String);
+  CCharsetConverter::Utf16BEToUtf8(strTxtUnicode, utf8String);
 
   return utf8String;
 }

--- a/xbmc/filesystem/iso9660.cpp
+++ b/xbmc/filesystem/iso9660.cpp
@@ -703,7 +703,7 @@ std::string iso9660::GetThinText(BYTE* strTxt, int iLen )
   std::u16string strTxtUnicode((char16_t*)strTxt, iLen / 2);
   std::string utf8String;
 
-  g_charsetConverter.utf16BEtoUTF8(strTxtUnicode, utf8String);
+  g_charsetConverter.Utf16BEToUtf8(strTxtUnicode, utf8String);
 
   return utf8String;
 }

--- a/xbmc/filesystem/posix/PosixDirectory.cpp
+++ b/xbmc/filesystem/posix/PosixDirectory.cpp
@@ -58,7 +58,7 @@ bool CPosixDirectory::GetDirectory(const CURL& url, CFileItemList &items)
       continue;
 
     std::string itemLabel(entry->d_name);
-    CCharsetConverter::unknownToUTF8(itemLabel);
+    CCharsetConverter::UnknownToUtf8(itemLabel);
     CFileItemPtr pItem(new CFileItem(itemLabel));
     std::string itemPath(URIUtils::AddFileToFolder(root, entry->d_name));
 

--- a/xbmc/filesystem/win32/Win32Directory.cpp
+++ b/xbmc/filesystem/win32/Win32Directory.cpp
@@ -90,7 +90,7 @@ bool CWin32Directory::GetDirectory(const CURL& url, CFileItemList &items)
       continue;
 
     std::string itemName;
-    if (!g_charsetConverter.wToUTF8(itemNameW, itemName, true) || itemName.empty())
+    if (!g_charsetConverter.WToUtf8SystemSafe(itemNameW, itemName) || itemName.empty())
     {
       CLog::Log(LOGERROR, "%s: Can't convert wide string name to UTF-8 encoding", __FUNCTION__);
       continue;

--- a/xbmc/filesystem/win32/Win32Directory.cpp
+++ b/xbmc/filesystem/win32/Win32Directory.cpp
@@ -90,7 +90,7 @@ bool CWin32Directory::GetDirectory(const CURL& url, CFileItemList &items)
       continue;
 
     std::string itemName;
-    if (!g_charsetConverter.WToUtf8SystemSafe(itemNameW, itemName) || itemName.empty())
+    if (!CCharsetConverter::WToUtf8SystemSafe(itemNameW, itemName) || itemName.empty())
     {
       CLog::Log(LOGERROR, "%s: Can't convert wide string name to UTF-8 encoding", __FUNCTION__);
       continue;

--- a/xbmc/filesystem/win32/Win32SMBDirectory.cpp
+++ b/xbmc/filesystem/win32/Win32SMBDirectory.cpp
@@ -167,7 +167,7 @@ bool CWin32SMBDirectory::GetDirectory(const CURL& url, CFileItemList &items)
       continue;
     
     std::string itemName;
-    if (!g_charsetConverter.WToUtf8SystemSafe(itemNameW, itemName) || itemName.empty())
+    if (!CCharsetConverter::WToUtf8SystemSafe(itemNameW, itemName) || itemName.empty())
     {
       CLog::LogF(LOGERROR, "Can't convert wide string item name to UTF-8");
       continue;
@@ -272,8 +272,8 @@ bool CWin32SMBDirectory::RealExists(const CURL& url, bool tryToConnect)
       std::wstring shareNameW;
       SHARE_INFO_1* info = NULL;
       // try fast way
-      if (g_charsetConverter.Utf8ToWSystemSafe("\\\\" + url.GetHostName(), serverNameW) &&
-          g_charsetConverter.Utf8ToWSystemSafe(url.GetShareName(), shareNameW) &&
+      if (CCharsetConverter::Utf8ToWSystemSafe("\\\\" + url.GetHostName(), serverNameW) &&
+          CCharsetConverter::Utf8ToWSystemSafe(url.GetShareName(), shareNameW) &&
           NetShareGetInfo((LPWSTR)serverNameW.c_str(), (LPWSTR)shareNameW.c_str(), 1, (LPBYTE*)&info) == NERR_Success)
       {
         const bool ret = ((info->shi1_type & STYPE_MASK) == STYPE_DISKTREE);
@@ -368,7 +368,7 @@ bool CWin32SMBDirectory::GetNetworkResources(const CURL& basePath, CFileItemList
     basePathStr.push_back('/');
 
   std::wstring remoteName;
-  if (!basePathStr.empty() && !g_charsetConverter.Utf8ToWSystemSafe("\\\\" + basePath.GetHostName(), remoteName))
+  if (!basePathStr.empty() && !CCharsetConverter::Utf8ToWSystemSafe("\\\\" + basePath.GetHostName(), remoteName))
   {
     CLog::LogF(LOGERROR, "can't convert host name \"%s\" to wide character form", basePath.GetHostName().c_str());
     return false;
@@ -460,7 +460,7 @@ static bool localGetNetworkResources(struct _NETRESOURCEW* basePathToScanPtr, co
             if (remoteName.length() > 2 && remoteName.compare(0, 2, L"\\\\", 2) == 0)
             {
               std::string remoteNameUtf8;
-              if (g_charsetConverter.WToUtf8SystemSafe(remoteName.substr(2), remoteNameUtf8) && !remoteNameUtf8.empty())
+              if (CCharsetConverter::WToUtf8SystemSafe(remoteName.substr(2), remoteNameUtf8) && !remoteNameUtf8.empty())
               {
                 CFileItemPtr pItem(new CFileItem(remoteNameUtf8));
                 pItem->SetPath(urlPrefixForItems + remoteNameUtf8 + '/');
@@ -491,7 +491,7 @@ static bool localGetNetworkResources(struct _NETRESOURCEW* basePathToScanPtr, co
               if (slashPos < serverShareName.length() - 1) // slash must be not on last position
               {
                 std::string shareNameUtf8;
-                if (g_charsetConverter.WToUtf8SystemSafe(serverShareName.substr(slashPos + 1), shareNameUtf8) && !shareNameUtf8.empty())
+                if (CCharsetConverter::WToUtf8SystemSafe(serverShareName.substr(slashPos + 1), shareNameUtf8) && !shareNameUtf8.empty())
                 {
                   CFileItemPtr pItem(new CFileItem(shareNameUtf8));
                   pItem->SetPath(urlPrefixForItems + shareNameUtf8 + '/');
@@ -583,7 +583,7 @@ static bool localGetShares(const std::wstring& serverNameToScan, const std::stri
         {
           std::string shareNameUtf8;
           if (curShare.shi1_netname && curShare.shi1_netname[0] &&
-              g_charsetConverter.WToUtf8SystemSafe(curShare.shi1_netname, shareNameUtf8) && !shareNameUtf8.empty())
+              CCharsetConverter::WToUtf8SystemSafe(curShare.shi1_netname, shareNameUtf8) && !shareNameUtf8.empty())
           {
             CFileItemPtr pItem(new CFileItem(shareNameUtf8));
             pItem->SetPath(urlPrefixForItems + shareNameUtf8 + '/');
@@ -619,7 +619,7 @@ bool CWin32SMBDirectory::ConnectAndAuthenticate(CURL& url, bool allowPromptForCr
 
   /* convert everything to wide strings */
   std::wstring serverNameW;
-  if (!g_charsetConverter.Utf8ToWSystemSafe(url.GetHostName(), serverNameW))
+  if (!CCharsetConverter::Utf8ToWSystemSafe(url.GetHostName(), serverNameW))
   {
     CLog::LogF(LOGERROR, "Can't convert server name \"%s\" to wide string", url.GetHostName().c_str());
     return false;
@@ -631,7 +631,7 @@ bool CWin32SMBDirectory::ConnectAndAuthenticate(CURL& url, bool allowPromptForCr
   if (!url.GetShareName().empty())
   {
     serverShareName = "\\\\" + url.GetHostName() + "\\" + url.GetShareName();
-    if (!g_charsetConverter.Utf8ToWSystemSafe(serverShareName, serverShareNameW))
+    if (!CCharsetConverter::Utf8ToWSystemSafe(serverShareName, serverShareNameW))
     {
       CLog::LogF(LOGERROR, "Can't convert share name \"%s\" to wide string", serverShareName.c_str());
       return false;
@@ -644,12 +644,12 @@ bool CWin32SMBDirectory::ConnectAndAuthenticate(CURL& url, bool allowPromptForCr
   }
 
   std::wstring usernameW;
-  if (!url.GetUserName().empty() && !g_charsetConverter.Utf8ToWSystemSafe(url.GetUserName(), usernameW))
+  if (!url.GetUserName().empty() && !CCharsetConverter::Utf8ToWSystemSafe(url.GetUserName(), usernameW))
   {
     CLog::LogF(LOGERROR, "Can't convert username \"%s\" to wide string", url.GetUserName().c_str());
     return false;
     std::wstring domainW;
-    if (!url.GetDomain().empty() && !g_charsetConverter.Utf8ToWSystemSafe(url.GetDomain(), domainW))
+    if (!url.GetDomain().empty() && !CCharsetConverter::Utf8ToWSystemSafe(url.GetDomain(), domainW))
     {
       CLog::LogF(LOGERROR, "Can't convert domain name \"%s\" to wide string", url.GetDomain().c_str());
       return false;
@@ -659,7 +659,7 @@ bool CWin32SMBDirectory::ConnectAndAuthenticate(CURL& url, bool allowPromptForCr
   }
 
   std::wstring passwordW;
-  if (!url.GetPassWord().empty() && !g_charsetConverter.Utf8ToWSystemSafe(url.GetPassWord(), passwordW))
+  if (!url.GetPassWord().empty() && !CCharsetConverter::Utf8ToWSystemSafe(url.GetPassWord(), passwordW))
   {
     CLog::LogF(LOGERROR, "Can't convert password to wide string");
     return false;

--- a/xbmc/filesystem/win32/Win32SMBDirectory.cpp
+++ b/xbmc/filesystem/win32/Win32SMBDirectory.cpp
@@ -167,7 +167,7 @@ bool CWin32SMBDirectory::GetDirectory(const CURL& url, CFileItemList &items)
       continue;
     
     std::string itemName;
-    if (!g_charsetConverter.wToUTF8(itemNameW, itemName, true) || itemName.empty())
+    if (!g_charsetConverter.WToUtf8SystemSafe(itemNameW, itemName) || itemName.empty())
     {
       CLog::LogF(LOGERROR, "Can't convert wide string item name to UTF-8");
       continue;
@@ -272,8 +272,8 @@ bool CWin32SMBDirectory::RealExists(const CURL& url, bool tryToConnect)
       std::wstring shareNameW;
       SHARE_INFO_1* info = NULL;
       // try fast way
-      if (g_charsetConverter.utf8ToW("\\\\" + url.GetHostName(), serverNameW, false, false, true) &&
-          g_charsetConverter.utf8ToW(url.GetShareName(), shareNameW, false, false, true) &&
+      if (g_charsetConverter.Utf8ToWSystemSafe("\\\\" + url.GetHostName(), serverNameW) &&
+          g_charsetConverter.Utf8ToWSystemSafe(url.GetShareName(), shareNameW) &&
           NetShareGetInfo((LPWSTR)serverNameW.c_str(), (LPWSTR)shareNameW.c_str(), 1, (LPBYTE*)&info) == NERR_Success)
       {
         const bool ret = ((info->shi1_type & STYPE_MASK) == STYPE_DISKTREE);
@@ -368,7 +368,7 @@ bool CWin32SMBDirectory::GetNetworkResources(const CURL& basePath, CFileItemList
     basePathStr.push_back('/');
 
   std::wstring remoteName;
-  if (!basePathStr.empty() && !g_charsetConverter.utf8ToW("\\\\" + basePath.GetHostName(), remoteName, false, false, true))
+  if (!basePathStr.empty() && !g_charsetConverter.Utf8ToWSystemSafe("\\\\" + basePath.GetHostName(), remoteName))
   {
     CLog::LogF(LOGERROR, "can't convert host name \"%s\" to wide character form", basePath.GetHostName().c_str());
     return false;
@@ -460,7 +460,7 @@ static bool localGetNetworkResources(struct _NETRESOURCEW* basePathToScanPtr, co
             if (remoteName.length() > 2 && remoteName.compare(0, 2, L"\\\\", 2) == 0)
             {
               std::string remoteNameUtf8;
-              if (g_charsetConverter.wToUTF8(remoteName.substr(2), remoteNameUtf8, true) && !remoteNameUtf8.empty())
+              if (g_charsetConverter.WToUtf8SystemSafe(remoteName.substr(2), remoteNameUtf8) && !remoteNameUtf8.empty())
               {
                 CFileItemPtr pItem(new CFileItem(remoteNameUtf8));
                 pItem->SetPath(urlPrefixForItems + remoteNameUtf8 + '/');
@@ -491,7 +491,7 @@ static bool localGetNetworkResources(struct _NETRESOURCEW* basePathToScanPtr, co
               if (slashPos < serverShareName.length() - 1) // slash must be not on last position
               {
                 std::string shareNameUtf8;
-                if (g_charsetConverter.wToUTF8(serverShareName.substr(slashPos + 1), shareNameUtf8, true) && !shareNameUtf8.empty())
+                if (g_charsetConverter.WToUtf8SystemSafe(serverShareName.substr(slashPos + 1), shareNameUtf8) && !shareNameUtf8.empty())
                 {
                   CFileItemPtr pItem(new CFileItem(shareNameUtf8));
                   pItem->SetPath(urlPrefixForItems + shareNameUtf8 + '/');
@@ -583,7 +583,7 @@ static bool localGetShares(const std::wstring& serverNameToScan, const std::stri
         {
           std::string shareNameUtf8;
           if (curShare.shi1_netname && curShare.shi1_netname[0] &&
-              g_charsetConverter.wToUTF8(curShare.shi1_netname, shareNameUtf8, true) && !shareNameUtf8.empty())
+              g_charsetConverter.WToUtf8SystemSafe(curShare.shi1_netname, shareNameUtf8) && !shareNameUtf8.empty())
           {
             CFileItemPtr pItem(new CFileItem(shareNameUtf8));
             pItem->SetPath(urlPrefixForItems + shareNameUtf8 + '/');
@@ -619,7 +619,7 @@ bool CWin32SMBDirectory::ConnectAndAuthenticate(CURL& url, bool allowPromptForCr
 
   /* convert everything to wide strings */
   std::wstring serverNameW;
-  if (!g_charsetConverter.utf8ToW(url.GetHostName(), serverNameW, false, false, true))
+  if (!g_charsetConverter.Utf8ToWSystemSafe(url.GetHostName(), serverNameW))
   {
     CLog::LogF(LOGERROR, "Can't convert server name \"%s\" to wide string", url.GetHostName().c_str());
     return false;
@@ -631,7 +631,7 @@ bool CWin32SMBDirectory::ConnectAndAuthenticate(CURL& url, bool allowPromptForCr
   if (!url.GetShareName().empty())
   {
     serverShareName = "\\\\" + url.GetHostName() + "\\" + url.GetShareName();
-    if (!g_charsetConverter.utf8ToW(serverShareName, serverShareNameW, false, false, true))
+    if (!g_charsetConverter.Utf8ToWSystemSafe(serverShareName, serverShareNameW))
     {
       CLog::LogF(LOGERROR, "Can't convert share name \"%s\" to wide string", serverShareName.c_str());
       return false;
@@ -644,12 +644,12 @@ bool CWin32SMBDirectory::ConnectAndAuthenticate(CURL& url, bool allowPromptForCr
   }
 
   std::wstring usernameW;
-  if (!url.GetUserName().empty() && !g_charsetConverter.utf8ToW(url.GetUserName(), usernameW, false, false, true))
+  if (!url.GetUserName().empty() && !g_charsetConverter.Utf8ToWSystemSafe(url.GetUserName(), usernameW))
   {
     CLog::LogF(LOGERROR, "Can't convert username \"%s\" to wide string", url.GetUserName().c_str());
     return false;
     std::wstring domainW;
-    if (!url.GetDomain().empty() && !g_charsetConverter.utf8ToW(url.GetDomain(), domainW, false, false, true))
+    if (!url.GetDomain().empty() && !g_charsetConverter.Utf8ToWSystemSafe(url.GetDomain(), domainW))
     {
       CLog::LogF(LOGERROR, "Can't convert domain name \"%s\" to wide string", url.GetDomain().c_str());
       return false;
@@ -659,7 +659,7 @@ bool CWin32SMBDirectory::ConnectAndAuthenticate(CURL& url, bool allowPromptForCr
   }
 
   std::wstring passwordW;
-  if (!url.GetPassWord().empty() && !g_charsetConverter.utf8ToW(url.GetPassWord(), passwordW, false, false, true))
+  if (!url.GetPassWord().empty() && !g_charsetConverter.Utf8ToWSystemSafe(url.GetPassWord(), passwordW))
   {
     CLog::LogF(LOGERROR, "Can't convert password to wide string");
     return false;

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -975,7 +975,7 @@ void CGUIBaseContainer::UpdateScrollByLetter()
     std::string nextLetter;
     std::wstring character = item->GetSortLabel().substr(0, 1);
     StringUtils::ToUpper(character);
-    g_charsetConverter.WToUtf8(character, nextLetter);
+    CCharsetConverter::WToUtf8(character, nextLetter);
     if (currentMatch != nextLetter)
     {
       currentMatch = nextLetter;

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -975,7 +975,7 @@ void CGUIBaseContainer::UpdateScrollByLetter()
     std::string nextLetter;
     std::wstring character = item->GetSortLabel().substr(0, 1);
     StringUtils::ToUpper(character);
-    g_charsetConverter.wToUTF8(character, nextLetter);
+    g_charsetConverter.WToUtf8(character, nextLetter);
     if (currentMatch != nextLetter)
     {
       currentMatch = nextLetter;

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -587,7 +587,7 @@ bool CGUIControlFactory::GetInfoLabelFromElement(const TiXmlElement *element, CG
   if (StringUtils::IsNaturalNumber(fallback))
     fallback = g_localizeStrings.Get(atoi(fallback.c_str()));
   else
-    g_charsetConverter.unknownToUTF8(fallback);
+    g_charsetConverter.UnknownToUtf8(fallback);
   infoLabel.SetLabel(label, fallback, parentID);
   return true;
 }
@@ -640,7 +640,7 @@ std::string CGUIControlFactory::FilterLabel(const std::string &label)
   if (StringUtils::IsNaturalNumber(viewLabel))
     viewLabel = g_localizeStrings.Get(atoi(label.c_str()));
   else
-    g_charsetConverter.unknownToUTF8(viewLabel);
+    g_charsetConverter.UnknownToUtf8(viewLabel);
   return viewLabel;
 }
 

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -587,7 +587,7 @@ bool CGUIControlFactory::GetInfoLabelFromElement(const TiXmlElement *element, CG
   if (StringUtils::IsNaturalNumber(fallback))
     fallback = g_localizeStrings.Get(atoi(fallback.c_str()));
   else
-    g_charsetConverter.UnknownToUtf8(fallback);
+    CCharsetConverter::UnknownToUtf8(fallback);
   infoLabel.SetLabel(label, fallback, parentID);
   return true;
 }
@@ -640,7 +640,7 @@ std::string CGUIControlFactory::FilterLabel(const std::string &label)
   if (StringUtils::IsNaturalNumber(viewLabel))
     viewLabel = g_localizeStrings.Get(atoi(label.c_str()));
   else
-    g_charsetConverter.UnknownToUtf8(viewLabel);
+    CCharsetConverter::UnknownToUtf8(viewLabel);
   return viewLabel;
 }
 

--- a/xbmc/guilib/GUIEditControl.cpp
+++ b/xbmc/guilib/GUIEditControl.cpp
@@ -104,7 +104,7 @@ bool CGUIEditControl::OnMessage(CGUIMessage &message)
   }
   else if (message.GetMessage() == GUI_MSG_INPUT_TEXT_EDIT && HasFocus())
   {
-    g_charsetConverter.Utf8ToW(message.GetLabel(), m_edit);
+    CCharsetConverter::Utf8ToW(message.GetLabel(), m_edit);
     m_editOffset = message.GetParam1();
     m_editLength = message.GetParam2();
     UpdateText(false);
@@ -284,7 +284,7 @@ bool CGUIEditControl::OnAction(const CAction &action)
     {
       m_edit.clear();
       std::wstring str;
-      g_charsetConverter.Utf8ToW(action.GetText(), str);
+      CCharsetConverter::Utf8ToW(action.GetText(), str);
       m_text2.insert(m_cursorPos, str);
       m_cursorPos += str.size();
       UpdateText();
@@ -302,7 +302,7 @@ void CGUIEditControl::OnClick()
     return;
 
   std::string utf8;
-  g_charsetConverter.WToUtf8(m_text2, utf8);
+  CCharsetConverter::WToUtf8(m_text2, utf8);
   bool textChanged = false;
   switch (m_inputType)
   {
@@ -369,7 +369,7 @@ void CGUIEditControl::OnClick()
   {
     ClearMD5();
     m_edit.clear();
-    g_charsetConverter.Utf8ToW(utf8, m_text2);
+    CCharsetConverter::Utf8ToW(utf8, m_text2);
     m_cursorPos = m_text2.size();
     UpdateText();
     m_cursorPos = m_text2.size();
@@ -610,7 +610,7 @@ void CGUIEditControl::SetLabel2(const std::string &text)
 {
   m_edit.clear();
   std::wstring newText;
-  g_charsetConverter.Utf8ToW(text, newText);
+  CCharsetConverter::Utf8ToW(text, newText);
   if (newText != m_text2)
   {
     m_isMD5 = (m_inputType == INPUT_TYPE_PASSWORD_MD5 || m_inputType == INPUT_TYPE_PASSWORD_NUMBER_VERIFY_NEW);
@@ -624,7 +624,7 @@ void CGUIEditControl::SetLabel2(const std::string &text)
 std::string CGUIEditControl::GetLabel2() const
 {
   std::string text;
-  g_charsetConverter.WToUtf8(m_text2, text);
+  CCharsetConverter::WToUtf8(m_text2, text);
   if (m_inputType == INPUT_TYPE_PASSWORD_MD5 && !m_isMD5)
     return XBMC::XBMC_MD5::GetMD5(text);
   return text;
@@ -690,7 +690,7 @@ void CGUIEditControl::OnPasteClipboard()
 
 // Get text from the clipboard
   utf8_text = g_Windowing.GetClipboardText();
-  g_charsetConverter.Utf8ToW(utf8_text, unicode_text);
+  CCharsetConverter::Utf8ToW(utf8_text, unicode_text);
 
   // Insert the pasted text at the current cursor position.
   if (unicode_text.length() > 0)

--- a/xbmc/guilib/GUIEditControl.cpp
+++ b/xbmc/guilib/GUIEditControl.cpp
@@ -104,7 +104,7 @@ bool CGUIEditControl::OnMessage(CGUIMessage &message)
   }
   else if (message.GetMessage() == GUI_MSG_INPUT_TEXT_EDIT && HasFocus())
   {
-    g_charsetConverter.utf8ToW(message.GetLabel(), m_edit);
+    g_charsetConverter.Utf8ToW(message.GetLabel(), m_edit);
     m_editOffset = message.GetParam1();
     m_editLength = message.GetParam2();
     UpdateText(false);
@@ -284,7 +284,7 @@ bool CGUIEditControl::OnAction(const CAction &action)
     {
       m_edit.clear();
       std::wstring str;
-      g_charsetConverter.utf8ToW(action.GetText(), str);
+      g_charsetConverter.Utf8ToW(action.GetText(), str);
       m_text2.insert(m_cursorPos, str);
       m_cursorPos += str.size();
       UpdateText();
@@ -302,7 +302,7 @@ void CGUIEditControl::OnClick()
     return;
 
   std::string utf8;
-  g_charsetConverter.wToUTF8(m_text2, utf8);
+  g_charsetConverter.WToUtf8(m_text2, utf8);
   bool textChanged = false;
   switch (m_inputType)
   {
@@ -369,7 +369,7 @@ void CGUIEditControl::OnClick()
   {
     ClearMD5();
     m_edit.clear();
-    g_charsetConverter.utf8ToW(utf8, m_text2);
+    g_charsetConverter.Utf8ToW(utf8, m_text2);
     m_cursorPos = m_text2.size();
     UpdateText();
     m_cursorPos = m_text2.size();
@@ -610,7 +610,7 @@ void CGUIEditControl::SetLabel2(const std::string &text)
 {
   m_edit.clear();
   std::wstring newText;
-  g_charsetConverter.utf8ToW(text, newText);
+  g_charsetConverter.Utf8ToW(text, newText);
   if (newText != m_text2)
   {
     m_isMD5 = (m_inputType == INPUT_TYPE_PASSWORD_MD5 || m_inputType == INPUT_TYPE_PASSWORD_NUMBER_VERIFY_NEW);
@@ -624,7 +624,7 @@ void CGUIEditControl::SetLabel2(const std::string &text)
 std::string CGUIEditControl::GetLabel2() const
 {
   std::string text;
-  g_charsetConverter.wToUTF8(m_text2, text);
+  g_charsetConverter.WToUtf8(m_text2, text);
   if (m_inputType == INPUT_TYPE_PASSWORD_MD5 && !m_isMD5)
     return XBMC::XBMC_MD5::GetMD5(text);
   return text;
@@ -690,7 +690,7 @@ void CGUIEditControl::OnPasteClipboard()
 
 // Get text from the clipboard
   utf8_text = g_Windowing.GetClipboardText();
-  g_charsetConverter.utf8ToW(utf8_text, unicode_text);
+  g_charsetConverter.Utf8ToW(utf8_text, unicode_text);
 
   // Insert the pasted text at the current cursor position.
   if (unicode_text.length() > 0)

--- a/xbmc/guilib/GUIFont.cpp
+++ b/xbmc/guilib/GUIFont.cpp
@@ -37,7 +37,7 @@ CScrollInfo::CScrollInfo(unsigned int wait /* = 50 */, float pos /* = 0 */,
     initialPos = pos;
     SetSpeed(speed ? speed : defaultSpeed);
     std::wstring wsuffix;
-    g_charsetConverter.utf8ToW(scrollSuffix, wsuffix);
+    g_charsetConverter.Utf8ToW(scrollSuffix, wsuffix);
     suffix.clear();
     suffix.reserve(wsuffix.size());
     for (vecText::size_type i = 0; i < wsuffix.size(); i++)
@@ -58,7 +58,7 @@ float CScrollInfo::GetPixelsPerFrame()
   m_lastFrameTime = currentTime;
   // do an exponential moving average of the frame time
   if (delta)
-    m_averageFrameTime = m_averageFrameTime + (delta - m_averageFrameTime) * alphaEMA;
+  m_averageFrameTime = m_averageFrameTime + (delta - m_averageFrameTime) * alphaEMA;
   // and multiply by pixel speed (per ms) to get number of pixels to move this frame
   return pixelSpeed * m_averageFrameTime;
 }
@@ -143,7 +143,7 @@ bool CGUIFont::UpdateScrollInfo(const vecText &text, CScrollInfo &scrollInfo)
   float scrollAmount = fabs(scrollInfo.GetPixelsPerFrame() * g_graphicsContext.GetGUIScaleX());
 
   if (!scrollInfo.m_widthValid)
-  {
+        {
     /* Calculate the pixel width of the complete string */
     scrollInfo.m_textWidth = GetTextWidth(text);
     scrollInfo.m_totalWidth = scrollInfo.m_textWidth + GetTextWidth(scrollInfo.suffix);

--- a/xbmc/guilib/GUIFont.cpp
+++ b/xbmc/guilib/GUIFont.cpp
@@ -37,7 +37,7 @@ CScrollInfo::CScrollInfo(unsigned int wait /* = 50 */, float pos /* = 0 */,
     initialPos = pos;
     SetSpeed(speed ? speed : defaultSpeed);
     std::wstring wsuffix;
-    g_charsetConverter.Utf8ToW(scrollSuffix, wsuffix);
+    CCharsetConverter::Utf8ToW(scrollSuffix, wsuffix);
     suffix.clear();
     suffix.reserve(wsuffix.size());
     for (vecText::size_type i = 0; i < wsuffix.size(); i++)

--- a/xbmc/guilib/GUILabelControl.cpp
+++ b/xbmc/guilib/GUILabelControl.cpp
@@ -49,7 +49,7 @@ void CGUILabelControl::SetCursorPos(int iPos)
 {
   std::string labelUTF8 = m_infoLabel.GetLabel(m_parentID);
   std::wstring label;
-  g_charsetConverter.Utf8ToW(labelUTF8, label);
+  CCharsetConverter::Utf8ToW(labelUTF8, label);
   if (iPos > (int)label.length()) iPos = label.length();
   if (iPos < 0) iPos = 0;
 
@@ -80,7 +80,7 @@ void CGUILabelControl::UpdateInfo(const CGUIListItem *item)
   if (m_startHighlight < m_endHighlight || m_startSelection < m_endSelection || m_bShowCursor)
   {
     std::wstring utf16;
-    g_charsetConverter.Utf8ToW(label, utf16);
+    CCharsetConverter::Utf8ToW(label, utf16);
     vecText text; text.reserve(utf16.size()+1);
     vecColors colors;
     colors.push_back(m_label.GetLabelInfo().textColor);

--- a/xbmc/guilib/GUILabelControl.cpp
+++ b/xbmc/guilib/GUILabelControl.cpp
@@ -49,7 +49,7 @@ void CGUILabelControl::SetCursorPos(int iPos)
 {
   std::string labelUTF8 = m_infoLabel.GetLabel(m_parentID);
   std::wstring label;
-  g_charsetConverter.utf8ToW(labelUTF8, label);
+  g_charsetConverter.Utf8ToW(labelUTF8, label);
   if (iPos > (int)label.length()) iPos = label.length();
   if (iPos < 0) iPos = 0;
 
@@ -80,7 +80,7 @@ void CGUILabelControl::UpdateInfo(const CGUIListItem *item)
   if (m_startHighlight < m_endHighlight || m_startSelection < m_endSelection || m_bShowCursor)
   {
     std::wstring utf16;
-    g_charsetConverter.utf8ToW(label, utf16);
+    g_charsetConverter.Utf8ToW(label, utf16);
     vecText text; text.reserve(utf16.size()+1);
     vecColors colors;
     colors.push_back(m_label.GetLabelInfo().textColor);

--- a/xbmc/guilib/GUIListItem.cpp
+++ b/xbmc/guilib/GUIListItem.cpp
@@ -97,7 +97,7 @@ const std::string& CGUIListItem::GetLabel2() const
 
 void CGUIListItem::SetSortLabel(const std::string &label)
 {
-  g_charsetConverter.utf8ToW(label, m_sortLabel, false);
+  g_charsetConverter.Utf8ToW(label, m_sortLabel);
   // no need to invalidate - this is never shown in the UI
 }
 

--- a/xbmc/guilib/GUIListItem.cpp
+++ b/xbmc/guilib/GUIListItem.cpp
@@ -97,7 +97,7 @@ const std::string& CGUIListItem::GetLabel2() const
 
 void CGUIListItem::SetSortLabel(const std::string &label)
 {
-  g_charsetConverter.Utf8ToW(label, m_sortLabel);
+  CCharsetConverter::Utf8ToW(label, m_sortLabel);
   // no need to invalidate - this is never shown in the UI
 }
 

--- a/xbmc/guilib/GUITextLayout.cpp
+++ b/xbmc/guilib/GUITextLayout.cpp
@@ -220,7 +220,7 @@ bool CGUITextLayout::Update(const std::string &text, float maxWidth, bool forceU
   m_lastUtf8Text = text;
   m_lastUpdateW = false;
   std::wstring utf16;
-  g_charsetConverter.Utf8ToW(text, utf16);
+  CCharsetConverter::Utf8ToW(text, utf16);
   UpdateCommon(utf16, maxWidth, forceLTRReadingOrder);
   return true;
 }
@@ -318,11 +318,11 @@ std::wstring CGUITextLayout::BidiFlip(const std::wstring &text, bool forceLTRRea
   std::wstring visualText;
 
   if (forceLTRReadingOrder)
-    g_charsetConverter.LogicalToVisualBiDi(text, visualText, CCharsetConverter::RTL |
+    CCharsetConverter::LogicalToVisualBiDi(text, visualText, CCharsetConverter::RTL |
                                                              CCharsetConverter::REMOVE_CONTROLS |
                                                              CCharsetConverter::WRITE_REVERSE);
   else
-    g_charsetConverter.LogicalToVisualBiDi(text, visualText, CCharsetConverter::LTR |
+    CCharsetConverter::LogicalToVisualBiDi(text, visualText, CCharsetConverter::LTR |
                                                              CCharsetConverter::REMOVE_CONTROLS);
 
   return visualText;
@@ -331,14 +331,14 @@ std::wstring CGUITextLayout::BidiFlip(const std::wstring &text, bool forceLTRRea
 void CGUITextLayout::Filter(std::string &text)
 {
   std::wstring utf16;
-  g_charsetConverter.Utf8ToW(text, utf16);
+  CCharsetConverter::Utf8ToW(text, utf16);
   vecColors colors;
   vecText parsedText;
   ParseText(utf16, 0, 0xffffffff, colors, parsedText);
   utf16.clear();
   for (unsigned int i = 0; i < parsedText.size(); i++)
     utf16 += (wchar_t)(0xffff & parsedText[i]);
-  g_charsetConverter.WToUtf8(utf16, text);
+  CCharsetConverter::WToUtf8(utf16, text);
 }
 
 void CGUITextLayout::ParseText(const std::wstring &text, uint32_t defaultStyle, color_t defaultColor, vecColors &colors, vecText &parsedText)
@@ -430,7 +430,7 @@ void CGUITextLayout::ParseText(const std::wstring &text, uint32_t defaultStyle, 
       if (on && finish != std::string::npos && text.find(L"[/COLOR]",finish) != std::string::npos)
       {
         std::string t;
-        g_charsetConverter.WToUtf8(text.substr(pos + 5, finish - pos - 5), t);
+        CCharsetConverter::WToUtf8(text.substr(pos + 5, finish - pos - 5), t);
         color_t color = g_colorManager.GetColor(t);
         vecColors::const_iterator it = std::find(colors.begin(), colors.end(), color);
         if (it == colors.end())
@@ -653,7 +653,7 @@ std::string CGUITextLayout::GetText() const
   if (m_lastUpdateW)
   {
     std::string utf8;
-    g_charsetConverter.WToUtf8(m_lastText, utf8);
+    CCharsetConverter::WToUtf8(m_lastText, utf8);
     return utf8;
   }
   return m_lastUtf8Text;
@@ -679,7 +679,7 @@ void CGUITextLayout::AppendToUTF32(const std::string &utf8, character_t colStyle
 {
   std::wstring utf16;
   // no need to bidiflip here - it's done in BidiTransform above
-  g_charsetConverter.Utf8ToW(utf8, utf16);
+  CCharsetConverter::Utf8ToW(utf8, utf16);
   AppendToUTF32(utf16, colStyle, utf32);
 }
 

--- a/xbmc/guilib/GUITextLayout.cpp
+++ b/xbmc/guilib/GUITextLayout.cpp
@@ -220,7 +220,7 @@ bool CGUITextLayout::Update(const std::string &text, float maxWidth, bool forceU
   m_lastUtf8Text = text;
   m_lastUpdateW = false;
   std::wstring utf16;
-  g_charsetConverter.utf8ToW(text, utf16, false);
+  g_charsetConverter.Utf8ToW(text, utf16);
   UpdateCommon(utf16, maxWidth, forceLTRReadingOrder);
   return true;
 }
@@ -317,9 +317,13 @@ std::wstring CGUITextLayout::BidiFlip(const std::wstring &text, bool forceLTRRea
   std::string utf8text;
   std::wstring visualText;
 
-  // convert to utf8, and back to utf16 with bidi flipping
-  g_charsetConverter.wToUTF8(text, utf8text);
-  g_charsetConverter.utf8ToW(utf8text, visualText, true, forceLTRReadingOrder);
+  if (forceLTRReadingOrder)
+    g_charsetConverter.LogicalToVisualBiDi(text, visualText, CCharsetConverter::RTL |
+                                                             CCharsetConverter::REMOVE_CONTROLS |
+                                                             CCharsetConverter::WRITE_REVERSE);
+  else
+    g_charsetConverter.LogicalToVisualBiDi(text, visualText, CCharsetConverter::LTR |
+                                                             CCharsetConverter::REMOVE_CONTROLS);
 
   return visualText;
 }
@@ -327,14 +331,14 @@ std::wstring CGUITextLayout::BidiFlip(const std::wstring &text, bool forceLTRRea
 void CGUITextLayout::Filter(std::string &text)
 {
   std::wstring utf16;
-  g_charsetConverter.utf8ToW(text, utf16, false);
+  g_charsetConverter.Utf8ToW(text, utf16);
   vecColors colors;
   vecText parsedText;
   ParseText(utf16, 0, 0xffffffff, colors, parsedText);
   utf16.clear();
   for (unsigned int i = 0; i < parsedText.size(); i++)
     utf16 += (wchar_t)(0xffff & parsedText[i]);
-  g_charsetConverter.wToUTF8(utf16, text);
+  g_charsetConverter.WToUtf8(utf16, text);
 }
 
 void CGUITextLayout::ParseText(const std::wstring &text, uint32_t defaultStyle, color_t defaultColor, vecColors &colors, vecText &parsedText)
@@ -426,7 +430,7 @@ void CGUITextLayout::ParseText(const std::wstring &text, uint32_t defaultStyle, 
       if (on && finish != std::string::npos && text.find(L"[/COLOR]",finish) != std::string::npos)
       {
         std::string t;
-        g_charsetConverter.wToUTF8(text.substr(pos + 5, finish - pos - 5), t);
+        g_charsetConverter.WToUtf8(text.substr(pos + 5, finish - pos - 5), t);
         color_t color = g_colorManager.GetColor(t);
         vecColors::const_iterator it = std::find(colors.begin(), colors.end(), color);
         if (it == colors.end())
@@ -649,7 +653,7 @@ std::string CGUITextLayout::GetText() const
   if (m_lastUpdateW)
   {
     std::string utf8;
-    g_charsetConverter.wToUTF8(m_lastText, utf8);
+    g_charsetConverter.WToUtf8(m_lastText, utf8);
     return utf8;
   }
   return m_lastUtf8Text;
@@ -675,7 +679,7 @@ void CGUITextLayout::AppendToUTF32(const std::string &utf8, character_t colStyle
 {
   std::wstring utf16;
   // no need to bidiflip here - it's done in BidiTransform above
-  g_charsetConverter.utf8ToW(utf8, utf16, false);
+  g_charsetConverter.Utf8ToW(utf8, utf16);
   AppendToUTF32(utf16, colStyle, utf32);
 }
 

--- a/xbmc/guilib/XBTFReader.cpp
+++ b/xbmc/guilib/XBTFReader.cpp
@@ -85,7 +85,7 @@ bool CXBTFReader::Open(const std::string& path)
 
 #ifdef TARGET_WINDOWS
   std::wstring strPathW;
-  g_charsetConverter.Utf8ToWSystemSafe(CSpecialProtocol::TranslatePath(m_fileName), strPathW);
+  CCharsetConverter::Utf8ToWSystemSafe(CSpecialProtocol::TranslatePath(m_path), strPathW);
   m_file = _wfopen(strPathW.c_str(), L"rb");
 #else
   m_file = fopen(m_path.c_str(), "rb");

--- a/xbmc/guilib/XBTFReader.cpp
+++ b/xbmc/guilib/XBTFReader.cpp
@@ -85,7 +85,7 @@ bool CXBTFReader::Open(const std::string& path)
 
 #ifdef TARGET_WINDOWS
   std::wstring strPathW;
-  g_charsetConverter.utf8ToW(CSpecialProtocol::TranslatePath(m_path), strPathW, false);
+  g_charsetConverter.Utf8ToWSystemSafe(CSpecialProtocol::TranslatePath(m_fileName), strPathW);
   m_file = _wfopen(strPathW.c_str(), L"rb");
 #else
   m_file = fopen(m_path.c_str(), "rb");

--- a/xbmc/input/InputCodingTableKorean.cpp
+++ b/xbmc/input/InputCodingTableKorean.cpp
@@ -369,8 +369,8 @@ std::string CInputCodingTableKorean::ConvertString(const std::string& strCode)
 {
   std::wstring input;
   std::string result;
-  g_charsetConverter.utf8ToW(strCode, input);
+  CCharsetConverter::Utf8ToW(strCode, input);
   InputToKorean(input);
-  g_charsetConverter.wToUTF8(InputToKorean(input), result);
+  CCharsetConverter::WToUtf8(InputToKorean(input), result);
   return m_strTextPrev + result;
 }

--- a/xbmc/input/KeyboardLayout.cpp
+++ b/xbmc/input/KeyboardLayout.cpp
@@ -173,7 +173,7 @@ std::vector<std::string> CKeyboardLayout::BreakCharacters(const std::string &cha
   for (std::u32string::const_iterator it = chars32.begin(); it != chars32.end(); ++it)
   {
     std::u32string char32(1, *it);
-    result.push_back(g_charsetConverter.utf32ToUtf8(char32));
+    result.push_back(g_charsetConverter.Utf32ToUtf8(char32));
   }
 
   return result;

--- a/xbmc/input/KeyboardLayout.cpp
+++ b/xbmc/input/KeyboardLayout.cpp
@@ -169,11 +169,11 @@ std::vector<std::string> CKeyboardLayout::BreakCharacters(const std::string &cha
 {
   std::vector<std::string> result;
   // break into utf8 characters
-  std::u32string chars32 = g_charsetConverter.utf8ToUtf32(chars);
+  std::u32string chars32 = CCharsetConverter::Utf8ToUtf32(chars);
   for (std::u32string::const_iterator it = chars32.begin(); it != chars32.end(); ++it)
   {
     std::u32string char32(1, *it);
-    result.push_back(g_charsetConverter.Utf32ToUtf8(char32));
+    result.push_back(CCharsetConverter::Utf32ToUtf8(char32));
   }
 
   return result;

--- a/xbmc/interfaces/python/PythonInvoker.cpp
+++ b/xbmc/interfaces/python/PythonInvoker.cpp
@@ -237,7 +237,7 @@ bool CPythonInvoker::execute(const std::string &script, const std::vector<std::s
 
 #ifdef TARGET_WINDOWS
   std::string pyPathUtf8;
-  g_charsetConverter.systemToUtf8(m_pythonPath, pyPathUtf8, false);
+  g_charsetConverter.SystemToUtf8(m_pythonPath, pyPathUtf8);
   CLog::Log(LOGDEBUG, "CPythonInvoker(%d, %s): setting the Python path to %s", GetId(), m_sourceFile.c_str(), pyPathUtf8.c_str());
 #else // ! TARGET_WINDOWS
   CLog::Log(LOGDEBUG, "CPythonInvoker(%d, %s): setting the Python path to %s", GetId(), m_sourceFile.c_str(), m_pythonPath.c_str());
@@ -274,7 +274,7 @@ bool CPythonInvoker::execute(const std::string &script, const std::vector<std::s
       //  passing a FILE* to python from an fopen has the potential to crash.
       std::string nativeFilename(realFilename); // filename in system encoding
 #ifdef TARGET_WINDOWS
-      if (!g_charsetConverter.utf8ToSystem(nativeFilename, true))
+      if (!g_charsetConverter.Utf8ToSystem(nativeFilename))
       {
         CLog::Log(LOGERROR, "CPythonInvoker(%d, %s): can't convert filename \"%s\" to system encoding", GetId(), m_sourceFile.c_str(), realFilename.c_str());
         return false;
@@ -651,8 +651,8 @@ void CPythonInvoker::addPath(const std::string& path)
   if (path.empty())
     return;
 
-  std::string nativePath(path);
-  if (!g_charsetConverter.utf8ToSystem(nativePath, true))
+  std::string nativePath;
+  if (!g_charsetConverter.Utf8ToSystemSafe(path, nativePath))
   {
     CLog::Log(LOGERROR, "%s: can't convert UTF-8 path \"%s\" to system encoding", __FUNCTION__, path.c_str());
     return;

--- a/xbmc/interfaces/python/PythonInvoker.cpp
+++ b/xbmc/interfaces/python/PythonInvoker.cpp
@@ -237,7 +237,7 @@ bool CPythonInvoker::execute(const std::string &script, const std::vector<std::s
 
 #ifdef TARGET_WINDOWS
   std::string pyPathUtf8;
-  g_charsetConverter.SystemToUtf8(m_pythonPath, pyPathUtf8);
+  CCharsetConverter::SystemToUtf8(m_pythonPath, pyPathUtf8);
   CLog::Log(LOGDEBUG, "CPythonInvoker(%d, %s): setting the Python path to %s", GetId(), m_sourceFile.c_str(), pyPathUtf8.c_str());
 #else // ! TARGET_WINDOWS
   CLog::Log(LOGDEBUG, "CPythonInvoker(%d, %s): setting the Python path to %s", GetId(), m_sourceFile.c_str(), m_pythonPath.c_str());
@@ -274,7 +274,7 @@ bool CPythonInvoker::execute(const std::string &script, const std::vector<std::s
       //  passing a FILE* to python from an fopen has the potential to crash.
       std::string nativeFilename(realFilename); // filename in system encoding
 #ifdef TARGET_WINDOWS
-      if (!g_charsetConverter.Utf8ToSystem(nativeFilename))
+      if (!CCharsetConverter::Utf8ToSystem(nativeFilename))
       {
         CLog::Log(LOGERROR, "CPythonInvoker(%d, %s): can't convert filename \"%s\" to system encoding", GetId(), m_sourceFile.c_str(), realFilename.c_str());
         return false;
@@ -652,7 +652,7 @@ void CPythonInvoker::addPath(const std::string& path)
     return;
 
   std::string nativePath;
-  if (!g_charsetConverter.Utf8ToSystemSafe(path, nativePath))
+  if (!CCharsetConverter::Utf8ToSystemSafe(path, nativePath))
   {
     CLog::Log(LOGERROR, "%s: can't convert UTF-8 path \"%s\" to system encoding", __FUNCTION__, path.c_str());
     return;

--- a/xbmc/music/tags/TagLoaderTagLib.cpp
+++ b/xbmc/music/tags/TagLoaderTagLib.cpp
@@ -115,7 +115,7 @@ void SetFlacArt(FLAC::File *flacFile, EmbeddedArt *art, CMusicInfoTag &tag)
   for (unsigned int i = 0; i < 2; i++)
   {
     if (cover[i])
-    {
+  {
       tag.SetCoverArtInfo(cover[i]->data().size(), cover[i]->mimeType().to8Bit(true));
       if (art)
         art->set(reinterpret_cast<const uint8_t*>(cover[i]->data().data()), cover[i]->data().size(), cover[i]->mimeType().to8Bit(true));

--- a/xbmc/network/Network.cpp
+++ b/xbmc/network/Network.cpp
@@ -169,7 +169,8 @@ bool CNetwork::GetHostName(std::string& hostname)
 
 #ifdef TARGET_WINDOWS
   std::string hostStr;
-  g_charsetConverter.systemToUtf8(hostName, hostStr);
+#ifdef TARGET_WINDOWS
+  g_charsetConverter.SystemToUtf8(hostName, hostStr);
   hostname = hostStr;
 #else
   hostname = hostName;

--- a/xbmc/network/Network.cpp
+++ b/xbmc/network/Network.cpp
@@ -169,8 +169,7 @@ bool CNetwork::GetHostName(std::string& hostname)
 
 #ifdef TARGET_WINDOWS
   std::string hostStr;
-#ifdef TARGET_WINDOWS
-  g_charsetConverter.SystemToUtf8(hostName, hostStr);
+  CCharsetConverter::SystemToUtf8(hostName, hostStr);
   hostname = hostStr;
 #else
   hostname = hostName;

--- a/xbmc/network/cddb.cpp
+++ b/xbmc/network/cddb.cpp
@@ -394,14 +394,14 @@ void Xcddb::addTitle(const char *buffer)
   std::vector<std::string> values = StringUtils::Split(value, " / ");
   if (values.size() > 1)
   {
-    g_charsetConverter.UnknownToUtf8(values[0]);
+    CCharsetConverter::UnknownToUtf8(values[0]);
     m_mapArtists[trk_nr] += values[0];
-    g_charsetConverter.UnknownToUtf8(values[1]);
+    CCharsetConverter::UnknownToUtf8(values[1]);
     m_mapTitles[trk_nr] += values[1];
   }
   else if (!values.empty())
   {
-    g_charsetConverter.UnknownToUtf8(values[0]);
+    CCharsetConverter::UnknownToUtf8(values[0]);
     m_mapTitles[trk_nr] += values[0];
   }
 }
@@ -551,7 +551,7 @@ void Xcddb::parseData(const char *buffer)
         // as a fallback
         size_t iPos = strExtd.find("YEAR: ");
         if (iPos != std::string::npos) // You never know if you really get UTF-8 strings from cddb
-          g_charsetConverter.UnknownToUtf8(strExtd.substr(iPos + 6, 4), m_strYear);
+          CCharsetConverter::UnknownToUtf8(strExtd.substr(iPos + 6, 4), m_strYear);
       }
 
       if (m_strGenre.empty())
@@ -607,7 +607,7 @@ void Xcddb::addExtended(const char *buffer)
   std::string strValue;
   std::string strValueUtf8=value;
   // You never know if you really get UTF-8 strings from cddb
-  g_charsetConverter.UnknownToUtf8(strValueUtf8, strValue);
+  CCharsetConverter::UnknownToUtf8(strValueUtf8, strValue);
   m_mapExtended_track[trk_nr] = strValue;
 }
 
@@ -716,12 +716,12 @@ void Xcddb::addInexactListLine(int line_cnt, const char *line, int len)
 
   std::string strArtist=artist;
   // You never know if you really get UTF-8 strings from cddb
-  g_charsetConverter.UnknownToUtf8(artist, strArtist);
+  CCharsetConverter::UnknownToUtf8(artist, strArtist);
   m_mapInexact_artist_list[line_cnt] = strArtist;
 
   std::string strTitle=title;
   // You never know if you really get UTF-8 strings from cddb
-  g_charsetConverter.UnknownToUtf8(title, strTitle);
+  CCharsetConverter::UnknownToUtf8(title, strTitle);
   m_mapInexact_title_list[line_cnt] = strTitle;
   // char log_string[1024];
   // sprintf(log_string,"%u: %s - %s",line_cnt,artist,title);
@@ -1073,7 +1073,7 @@ std::string Xcddb::TrimToUTF8(const std::string &untrimmedText)
   std::string text(untrimmedText);
   StringUtils::Trim(text);
   // You never know if you really get UTF-8 strings from cddb
-  g_charsetConverter.UnknownToUtf8(text);
+  CCharsetConverter::UnknownToUtf8(text);
   return text;
 }
 

--- a/xbmc/network/cddb.cpp
+++ b/xbmc/network/cddb.cpp
@@ -394,14 +394,14 @@ void Xcddb::addTitle(const char *buffer)
   std::vector<std::string> values = StringUtils::Split(value, " / ");
   if (values.size() > 1)
   {
-    g_charsetConverter.unknownToUTF8(values[0]);
+    g_charsetConverter.UnknownToUtf8(values[0]);
     m_mapArtists[trk_nr] += values[0];
-    g_charsetConverter.unknownToUTF8(values[1]);
+    g_charsetConverter.UnknownToUtf8(values[1]);
     m_mapTitles[trk_nr] += values[1];
   }
   else if (!values.empty())
   {
-    g_charsetConverter.unknownToUTF8(values[0]);
+    g_charsetConverter.UnknownToUtf8(values[0]);
     m_mapTitles[trk_nr] += values[0];
   }
 }
@@ -551,7 +551,7 @@ void Xcddb::parseData(const char *buffer)
         // as a fallback
         size_t iPos = strExtd.find("YEAR: ");
         if (iPos != std::string::npos) // You never know if you really get UTF-8 strings from cddb
-          g_charsetConverter.unknownToUTF8(strExtd.substr(iPos + 6, 4), m_strYear);
+          g_charsetConverter.UnknownToUtf8(strExtd.substr(iPos + 6, 4), m_strYear);
       }
 
       if (m_strGenre.empty())
@@ -607,7 +607,7 @@ void Xcddb::addExtended(const char *buffer)
   std::string strValue;
   std::string strValueUtf8=value;
   // You never know if you really get UTF-8 strings from cddb
-  g_charsetConverter.unknownToUTF8(strValueUtf8, strValue);
+  g_charsetConverter.UnknownToUtf8(strValueUtf8, strValue);
   m_mapExtended_track[trk_nr] = strValue;
 }
 
@@ -716,12 +716,12 @@ void Xcddb::addInexactListLine(int line_cnt, const char *line, int len)
 
   std::string strArtist=artist;
   // You never know if you really get UTF-8 strings from cddb
-  g_charsetConverter.unknownToUTF8(artist, strArtist);
+  g_charsetConverter.UnknownToUtf8(artist, strArtist);
   m_mapInexact_artist_list[line_cnt] = strArtist;
 
   std::string strTitle=title;
   // You never know if you really get UTF-8 strings from cddb
-  g_charsetConverter.unknownToUTF8(title, strTitle);
+  g_charsetConverter.UnknownToUtf8(title, strTitle);
   m_mapInexact_title_list[line_cnt] = strTitle;
   // char log_string[1024];
   // sprintf(log_string,"%u: %s - %s",line_cnt,artist,title);
@@ -1073,7 +1073,7 @@ std::string Xcddb::TrimToUTF8(const std::string &untrimmedText)
   std::string text(untrimmedText);
   StringUtils::Trim(text);
   // You never know if you really get UTF-8 strings from cddb
-  g_charsetConverter.unknownToUTF8(text);
+  g_charsetConverter.UnknownToUtf8(text);
   return text;
 }
 

--- a/xbmc/network/windows/NetworkWin32.cpp
+++ b/xbmc/network/windows/NetworkWin32.cpp
@@ -52,7 +52,7 @@ CNetworkInterfaceWin32::~CNetworkInterfaceWin32(void)
 
 std::string& CNetworkInterfaceWin32::GetName(void)
 {
-  g_charsetConverter.unknownToUTF8(m_adaptername);
+  g_charsetConverter.UnknownToUtf8(m_adaptername);
   return m_adaptername;
 }
 
@@ -120,7 +120,7 @@ std::string CNetworkInterfaceWin32::GetCurrentWirelessEssId(void)
           StringFromGUID2(guid, (LPOLESTR)&wcguid, 64);
           std::wstring strGuid = wcguid;
           std::wstring strAdaptername;
-          g_charsetConverter.utf8ToW(m_adapter.AdapterName, strAdaptername);
+          g_charsetConverter.Utf8ToW(m_adapter.AdapterName, strAdaptername);
           if( strGuid == strAdaptername)
           {
             if(WlanQueryInterface(hClientHdl,&ppInterfaceList->InterfaceInfo[i].InterfaceGuid,wlan_intf_opcode_current_connection, NULL, &dwSize, (PVOID*)&pAttributes, NULL ) == ERROR_SUCCESS)
@@ -347,7 +347,7 @@ std::vector<NetworkAccessPoint> CNetworkInterfaceWin32::GetAccessPoints(void)
     StringFromGUID2(guid, (LPOLESTR)&wcguid, 64);
     std::wstring strGuid = wcguid;
     std::wstring strAdaptername;
-    g_charsetConverter.utf8ToW(m_adapter.AdapterName, strAdaptername);
+    g_charsetConverter.Utf8ToW(m_adapter.AdapterName, strAdaptername);
     if (strGuid == strAdaptername)
     {
       WLAN_BSS_LIST *bss_list;
@@ -461,7 +461,7 @@ void CNetworkInterfaceWin32::GetSettings(NetworkAssignment& assignment, std::str
           StringFromGUID2(guid, (LPOLESTR)&wcguid, 64);
           std::wstring strGuid = wcguid;
           std::wstring strAdaptername;
-          g_charsetConverter.utf8ToW(m_adapter.AdapterName, strAdaptername);
+          g_charsetConverter.Utf8ToW(m_adapter.AdapterName, strAdaptername);
           if( strGuid == strAdaptername)
           {
             if(WlanQueryInterface(hClientHdl,&ppInterfaceList->InterfaceInfo[i].InterfaceGuid,wlan_intf_opcode_current_connection, NULL, &dwSize, (PVOID*)&pAttributes, NULL ) == ERROR_SUCCESS)

--- a/xbmc/network/windows/NetworkWin32.cpp
+++ b/xbmc/network/windows/NetworkWin32.cpp
@@ -52,7 +52,7 @@ CNetworkInterfaceWin32::~CNetworkInterfaceWin32(void)
 
 std::string& CNetworkInterfaceWin32::GetName(void)
 {
-  g_charsetConverter.UnknownToUtf8(m_adaptername);
+  CCharsetConverter::UnknownToUtf8(m_adaptername);
   return m_adaptername;
 }
 
@@ -120,7 +120,7 @@ std::string CNetworkInterfaceWin32::GetCurrentWirelessEssId(void)
           StringFromGUID2(guid, (LPOLESTR)&wcguid, 64);
           std::wstring strGuid = wcguid;
           std::wstring strAdaptername;
-          g_charsetConverter.Utf8ToW(m_adapter.AdapterName, strAdaptername);
+          CCharsetConverter::Utf8ToW(m_adapter.AdapterName, strAdaptername);
           if( strGuid == strAdaptername)
           {
             if(WlanQueryInterface(hClientHdl,&ppInterfaceList->InterfaceInfo[i].InterfaceGuid,wlan_intf_opcode_current_connection, NULL, &dwSize, (PVOID*)&pAttributes, NULL ) == ERROR_SUCCESS)
@@ -347,7 +347,7 @@ std::vector<NetworkAccessPoint> CNetworkInterfaceWin32::GetAccessPoints(void)
     StringFromGUID2(guid, (LPOLESTR)&wcguid, 64);
     std::wstring strGuid = wcguid;
     std::wstring strAdaptername;
-    g_charsetConverter.Utf8ToW(m_adapter.AdapterName, strAdaptername);
+    CCharsetConverter::Utf8ToW(m_adapter.AdapterName, strAdaptername);
     if (strGuid == strAdaptername)
     {
       WLAN_BSS_LIST *bss_list;
@@ -461,7 +461,7 @@ void CNetworkInterfaceWin32::GetSettings(NetworkAssignment& assignment, std::str
           StringFromGUID2(guid, (LPOLESTR)&wcguid, 64);
           std::wstring strGuid = wcguid;
           std::wstring strAdaptername;
-          g_charsetConverter.Utf8ToW(m_adapter.AdapterName, strAdaptername);
+          CCharsetConverter::Utf8ToW(m_adapter.AdapterName, strAdaptername);
           if( strGuid == strAdaptername)
           {
             if(WlanQueryInterface(hClientHdl,&ppInterfaceList->InterfaceInfo[i].InterfaceGuid,wlan_intf_opcode_current_connection, NULL, &dwSize, (PVOID*)&pAttributes, NULL ) == ERROR_SUCCESS)

--- a/xbmc/pictures/PictureInfoTag.cpp
+++ b/xbmc/pictures/PictureInfoTag.cpp
@@ -325,14 +325,14 @@ const std::string CPictureInfoTag::GetInfo(int info) const
     }
     break;
   case SLIDE_COMMENT:
-    g_charsetConverter.unknownToUTF8(m_exifInfo.FileComment, value);
+    CCharsetConverter::UnknownToUtf8(m_exifInfo.FileComment, value);
     break;
   case SLIDE_EXIF_COMMENT:
     // The charset used for the UserComment is stored in CommentsCharset:
     // Ascii, Unicode (UCS2), JIS (X208-1990), Unknown (application specific)
     if (m_exifInfo.CommentsCharset == EXIF_COMMENT_CHARSET_UNICODE)
     {
-      g_charsetConverter.Ucs2ToUtf8(std::u16string((char16_t*)m_exifInfo.Comments), value);
+      CCharsetConverter::Ucs2ToUtf8(std::u16string((char16_t*)m_exifInfo.Comments), value);
     }
     else
     {
@@ -340,13 +340,13 @@ const std::string CPictureInfoTag::GetInfo(int info) const
       // Archived data is already converted (EXIF_COMMENT_CHARSET_CONVERTED)
       // Unknown data can't be converted as it could be any codec (EXIF_COMMENT_CHARSET_UNKNOWN)
       // JIS data can't be converted as CharsetConverter and iconv lacks support (EXIF_COMMENT_CHARSET_JIS)
-      g_charsetConverter.UnknownToUtf8(m_exifInfo.Comments, value);
+      CCharsetConverter::UnknownToUtf8(m_exifInfo.Comments, value);
     }
     break;
   case SLIDE_EXIF_XPCOMMENT:
     if (m_exifInfo.XPCommentsCharset == EXIF_COMMENT_CHARSET_UNICODE)
     {
-      g_charsetConverter.ucs2ToUTF8(std::u16string((char16_t*)m_exifInfo.XPComment), value);
+      CCharsetConverter::Ucs2ToUtf8(std::u16string((char16_t*)m_exifInfo.XPComment), value);
     }
     else
     {

--- a/xbmc/pictures/PictureInfoTag.cpp
+++ b/xbmc/pictures/PictureInfoTag.cpp
@@ -332,7 +332,7 @@ const std::string CPictureInfoTag::GetInfo(int info) const
     // Ascii, Unicode (UCS2), JIS (X208-1990), Unknown (application specific)
     if (m_exifInfo.CommentsCharset == EXIF_COMMENT_CHARSET_UNICODE)
     {
-      g_charsetConverter.ucs2ToUTF8(std::u16string((char16_t*)m_exifInfo.Comments), value);
+      g_charsetConverter.Ucs2ToUtf8(std::u16string((char16_t*)m_exifInfo.Comments), value);
     }
     else
     {
@@ -340,7 +340,7 @@ const std::string CPictureInfoTag::GetInfo(int info) const
       // Archived data is already converted (EXIF_COMMENT_CHARSET_CONVERTED)
       // Unknown data can't be converted as it could be any codec (EXIF_COMMENT_CHARSET_UNKNOWN)
       // JIS data can't be converted as CharsetConverter and iconv lacks support (EXIF_COMMENT_CHARSET_JIS)
-      g_charsetConverter.unknownToUTF8(m_exifInfo.Comments, value);
+      g_charsetConverter.UnknownToUtf8(m_exifInfo.Comments, value);
     }
     break;
   case SLIDE_EXIF_XPCOMMENT:

--- a/xbmc/playlists/PlayListM3U.cpp
+++ b/xbmc/playlists/PlayListM3U.cpp
@@ -111,7 +111,7 @@ bool CPlayListM3U::Load(const std::string& strFileName)
         lDuration = atoi(strLength.c_str());
         iComma++;
         strInfo = strLine.substr(iComma);
-        g_charsetConverter.unknownToUTF8(strInfo);
+        g_charsetConverter.UnknownToUtf8(strInfo);
       }
     }
     else if (StringUtils::StartsWith(strLine, OffsetMarker))
@@ -161,7 +161,7 @@ bool CPlayListM3U::Load(const std::string& strFileName)
 
       if (strFileName.length() > 0)
       {
-        g_charsetConverter.unknownToUTF8(strFileName);
+        g_charsetConverter.UnknownToUtf8(strFileName);
 
         // If no info was read from from the extended tag information, use the file name
         if (strInfo.length() == 0)
@@ -242,7 +242,7 @@ void CPlayListM3U::Save(const std::string& strFileName) const
       file.Write(strLine.c_str(),strLine.size());
     }
     std::string strFileName = ResolveURL(item);
-    g_charsetConverter.utf8ToStringCharset(strFileName);
+    g_charsetConverter.Utf8ToStringCharset(strFileName);
     strLine = StringUtils::Format("%s\n",strFileName.c_str());
     if (file.Write(strLine.c_str(), strLine.size()) != static_cast<ssize_t>(strLine.size()))
       return; // error

--- a/xbmc/playlists/PlayListM3U.cpp
+++ b/xbmc/playlists/PlayListM3U.cpp
@@ -111,7 +111,7 @@ bool CPlayListM3U::Load(const std::string& strFileName)
         lDuration = atoi(strLength.c_str());
         iComma++;
         strInfo = strLine.substr(iComma);
-        g_charsetConverter.UnknownToUtf8(strInfo);
+        CCharsetConverter::UnknownToUtf8(strInfo);
       }
     }
     else if (StringUtils::StartsWith(strLine, OffsetMarker))
@@ -161,7 +161,7 @@ bool CPlayListM3U::Load(const std::string& strFileName)
 
       if (strFileName.length() > 0)
       {
-        g_charsetConverter.UnknownToUtf8(strFileName);
+        CCharsetConverter::UnknownToUtf8(strFileName);
 
         // If no info was read from from the extended tag information, use the file name
         if (strInfo.length() == 0)
@@ -232,7 +232,7 @@ void CPlayListM3U::Save(const std::string& strFileName) const
   {
     CFileItemPtr item = m_vecItems[i];
     std::string strDescription=item->GetLabel();
-    g_charsetConverter.utf8ToStringCharset(strDescription);
+    CCharsetConverter::Utf8ToStringCharset(strDescription);
     strLine = StringUtils::Format( "%s:%i,%s\n", InfoMarker, item->GetMusicInfoTag()->GetDuration() / 1000, strDescription.c_str() );
     if (file.Write(strLine.c_str(), strLine.size()) != static_cast<ssize_t>(strLine.size()))
       return; // error
@@ -242,7 +242,7 @@ void CPlayListM3U::Save(const std::string& strFileName) const
       file.Write(strLine.c_str(),strLine.size());
     }
     std::string strFileName = ResolveURL(item);
-    g_charsetConverter.Utf8ToStringCharset(strFileName);
+    CCharsetConverter::Utf8ToStringCharset(strFileName);
     strLine = StringUtils::Format("%s\n",strFileName.c_str());
     if (file.Write(strLine.c_str(), strLine.size()) != static_cast<ssize_t>(strLine.size()))
       return; // error

--- a/xbmc/playlists/PlayListPLS.cpp
+++ b/xbmc/playlists/PlayListPLS.cpp
@@ -153,7 +153,7 @@ bool CPlayListPLS::Load(const std::string &strFile)
 
         strValue = URIUtils::SubstitutePath(strValue);
         CUtil::GetQualifiedFilename(m_strBasePath, strValue);
-        g_charsetConverter.UnknownToUtf8(strValue);
+        CCharsetConverter::UnknownToUtf8(strValue);
         m_vecItems[idx - 1]->SetPath(strValue);
       }
       else if (StringUtils::StartsWith(strLeft, "title"))
@@ -164,7 +164,7 @@ bool CPlayListPLS::Load(const std::string &strFile)
           bFailed = true;
           break;
         }
-        g_charsetConverter.UnknownToUtf8(strValue);
+        CCharsetConverter::UnknownToUtf8(strValue);
         m_vecItems[idx - 1]->SetLabel(strValue);
       }
       else if (StringUtils::StartsWith(strLeft, "length"))
@@ -180,7 +180,7 @@ bool CPlayListPLS::Load(const std::string &strFile)
       else if (strLeft == "playlistname")
       {
         m_strPlayListName = strValue;
-        g_charsetConverter.UnknownToUtf8(m_strPlayListName);
+        CCharsetConverter::UnknownToUtf8(m_strPlayListName);
       }
     }
   }
@@ -222,16 +222,16 @@ void CPlayListPLS::Save(const std::string& strFileName) const
   std::string write;
   write += StringUtils::Format("%s\n", START_PLAYLIST_MARKER);
   std::string strPlayListName=m_strPlayListName;
-  g_charsetConverter.Utf8ToStringCharset(strPlayListName);
+  CCharsetConverter::Utf8ToStringCharset(strPlayListName);
   write += StringUtils::Format("PlaylistName=%s\n", strPlayListName.c_str() );
 
   for (int i = 0; i < (int)m_vecItems.size(); ++i)
   {
     CFileItemPtr item = m_vecItems[i];
     std::string strFileName=item->GetPath();
-    g_charsetConverter.Utf8ToStringCharset(strFileName);
+    CCharsetConverter::Utf8ToStringCharset(strFileName);
     std::string strDescription=item->GetLabel();
-    g_charsetConverter.Utf8ToStringCharset(strDescription);
+    CCharsetConverter::Utf8ToStringCharset(strDescription);
     write += StringUtils::Format("File%i=%s\n", i + 1, strFileName.c_str() );
     write += StringUtils::Format("Title%i=%s\n", i + 1, strDescription.c_str() );
     write += StringUtils::Format("Length%i=%u\n", i + 1, item->GetMusicInfoTag()->GetDuration() / 1000 );

--- a/xbmc/playlists/PlayListPLS.cpp
+++ b/xbmc/playlists/PlayListPLS.cpp
@@ -153,7 +153,7 @@ bool CPlayListPLS::Load(const std::string &strFile)
 
         strValue = URIUtils::SubstitutePath(strValue);
         CUtil::GetQualifiedFilename(m_strBasePath, strValue);
-        g_charsetConverter.unknownToUTF8(strValue);
+        g_charsetConverter.UnknownToUtf8(strValue);
         m_vecItems[idx - 1]->SetPath(strValue);
       }
       else if (StringUtils::StartsWith(strLeft, "title"))
@@ -164,7 +164,7 @@ bool CPlayListPLS::Load(const std::string &strFile)
           bFailed = true;
           break;
         }
-        g_charsetConverter.unknownToUTF8(strValue);
+        g_charsetConverter.UnknownToUtf8(strValue);
         m_vecItems[idx - 1]->SetLabel(strValue);
       }
       else if (StringUtils::StartsWith(strLeft, "length"))
@@ -180,7 +180,7 @@ bool CPlayListPLS::Load(const std::string &strFile)
       else if (strLeft == "playlistname")
       {
         m_strPlayListName = strValue;
-        g_charsetConverter.unknownToUTF8(m_strPlayListName);
+        g_charsetConverter.UnknownToUtf8(m_strPlayListName);
       }
     }
   }
@@ -222,16 +222,16 @@ void CPlayListPLS::Save(const std::string& strFileName) const
   std::string write;
   write += StringUtils::Format("%s\n", START_PLAYLIST_MARKER);
   std::string strPlayListName=m_strPlayListName;
-  g_charsetConverter.utf8ToStringCharset(strPlayListName);
+  g_charsetConverter.Utf8ToStringCharset(strPlayListName);
   write += StringUtils::Format("PlaylistName=%s\n", strPlayListName.c_str() );
 
   for (int i = 0; i < (int)m_vecItems.size(); ++i)
   {
     CFileItemPtr item = m_vecItems[i];
     std::string strFileName=item->GetPath();
-    g_charsetConverter.utf8ToStringCharset(strFileName);
+    g_charsetConverter.Utf8ToStringCharset(strFileName);
     std::string strDescription=item->GetLabel();
-    g_charsetConverter.utf8ToStringCharset(strDescription);
+    g_charsetConverter.Utf8ToStringCharset(strDescription);
     write += StringUtils::Format("File%i=%s\n", i + 1, strFileName.c_str() );
     write += StringUtils::Format("Title%i=%s\n", i + 1, strDescription.c_str() );
     write += StringUtils::Format("Length%i=%u\n", i + 1, item->GetMusicInfoTag()->GetDuration() / 1000 );

--- a/xbmc/pvr/channels/PVRRadioRDSInfoTag.cpp
+++ b/xbmc/pvr/channels/PVRRadioRDSInfoTag.cpp
@@ -259,25 +259,25 @@ void CPVRRadioRDSInfoTag::SetArtist(const std::string& strArtist)
 void CPVRRadioRDSInfoTag::SetBand(const std::string& strBand)
 {
   m_strBand = Trim(strBand);
-  g_charsetConverter.unknownToUTF8(m_strBand);
+  CCharsetConverter::UnknownToUtf8(m_strBand);
 }
 
 void CPVRRadioRDSInfoTag::SetComposer(const std::string& strComposer)
 {
   m_strComposer = Trim(strComposer);
-  g_charsetConverter.unknownToUTF8(m_strComposer);
+  CCharsetConverter::UnknownToUtf8(m_strComposer);
 }
 
 void CPVRRadioRDSInfoTag::SetConductor(const std::string& strConductor)
 {
   m_strConductor = Trim(strConductor);
-  g_charsetConverter.unknownToUTF8(m_strConductor);
+  CCharsetConverter::UnknownToUtf8(m_strConductor);
 }
 
 void CPVRRadioRDSInfoTag::SetAlbum(const std::string& strAlbum)
 {
   m_strAlbum = Trim(strAlbum);
-  g_charsetConverter.unknownToUTF8(m_strAlbum);
+  CCharsetConverter::UnknownToUtf8(m_strAlbum);
 }
 
 void CPVRRadioRDSInfoTag::SetAlbumTrackNumber(int track)
@@ -288,7 +288,7 @@ void CPVRRadioRDSInfoTag::SetAlbumTrackNumber(int track)
 void CPVRRadioRDSInfoTag::SetComment(const std::string& strComment)
 {
   m_strComment = Trim(strComment);
-  g_charsetConverter.unknownToUTF8(m_strComment);
+  CCharsetConverter::UnknownToUtf8(m_strComment);
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetTitle() const
@@ -334,7 +334,7 @@ const std::string& CPVRRadioRDSInfoTag::GetComment() const
 void CPVRRadioRDSInfoTag::SetInfoNews(const std::string& strNews)
 {
   std::string tmpStr = Trim(strNews);
-  g_charsetConverter.unknownToUTF8(tmpStr);
+  CCharsetConverter::UnknownToUtf8(tmpStr);
 
   for (unsigned i = 0; i < m_strInfoNews.size(); ++i)
   {
@@ -378,7 +378,7 @@ const std::string CPVRRadioRDSInfoTag::GetInfoNews() const
 void CPVRRadioRDSInfoTag::SetInfoNewsLocal(const std::string& strNews)
 {
   std::string tmpStr = Trim(strNews);
-  g_charsetConverter.unknownToUTF8(tmpStr);
+  CCharsetConverter::UnknownToUtf8(tmpStr);
 
   for (unsigned i = 0; i < m_strInfoNewsLocal.size(); ++i)
   {
@@ -422,7 +422,7 @@ const std::string CPVRRadioRDSInfoTag::GetInfoNewsLocal() const
 void CPVRRadioRDSInfoTag::SetInfoSport(const std::string& strSport)
 {
   std::string tmpStr = Trim(strSport);
-  g_charsetConverter.unknownToUTF8(tmpStr);
+  CCharsetConverter::UnknownToUtf8(tmpStr);
 
   for (unsigned i = 0; i < m_strInfoSport.size(); ++i)
   {
@@ -466,7 +466,7 @@ const std::string CPVRRadioRDSInfoTag::GetInfoSport() const
 void CPVRRadioRDSInfoTag::SetInfoStock(const std::string& strStock)
 {
   std::string tmpStr = Trim(strStock);
-  g_charsetConverter.unknownToUTF8(tmpStr);
+  CCharsetConverter::UnknownToUtf8(tmpStr);
 
   for (unsigned i = 0; i < m_strInfoStock.size(); ++i)
   {
@@ -510,7 +510,7 @@ const std::string CPVRRadioRDSInfoTag::GetInfoStock() const
 void CPVRRadioRDSInfoTag::SetInfoWeather(const std::string& strWeather)
 {
   std::string tmpStr = Trim(strWeather);
-  g_charsetConverter.unknownToUTF8(tmpStr);
+  CCharsetConverter::UnknownToUtf8(tmpStr);
 
   for (unsigned i = 0; i < m_strInfoWeather.size(); ++i)
   {
@@ -553,7 +553,7 @@ const std::string CPVRRadioRDSInfoTag::GetInfoWeather() const
 void CPVRRadioRDSInfoTag::SetInfoLottery(const std::string& strLottery)
 {
   std::string tmpStr = Trim(strLottery);
-  g_charsetConverter.unknownToUTF8(tmpStr);
+  CCharsetConverter::UnknownToUtf8(tmpStr);
 
   for (unsigned i = 0; i < m_strInfoLottery.size(); ++i)
   {
@@ -596,7 +596,7 @@ const std::string CPVRRadioRDSInfoTag::GetInfoLottery() const
 void CPVRRadioRDSInfoTag::SetEditorialStaff(const std::string& strEditorialStaff)
 {
   std::string tmpStr = Trim(strEditorialStaff);
-  g_charsetConverter.unknownToUTF8(tmpStr);
+  CCharsetConverter::UnknownToUtf8(tmpStr);
 
   for (unsigned i = 0; i < m_strEditorialStaff.size(); ++i)
   {
@@ -639,7 +639,7 @@ const std::string CPVRRadioRDSInfoTag::GetEditorialStaff() const
 void CPVRRadioRDSInfoTag::SetInfoHoroscope(const std::string& strHoroscope)
 {
   std::string tmpStr = Trim(strHoroscope);
-  g_charsetConverter.unknownToUTF8(tmpStr);
+  CCharsetConverter::UnknownToUtf8(tmpStr);
 
   for (unsigned i = 0; i < m_strInfoHoroscope.size(); ++i)
   {
@@ -682,7 +682,7 @@ const std::string CPVRRadioRDSInfoTag::GetInfoHoroscope() const
 void CPVRRadioRDSInfoTag::SetInfoCinema(const std::string& strCinema)
 {
   std::string tmpStr = Trim(strCinema);
-  g_charsetConverter.unknownToUTF8(tmpStr);
+  CCharsetConverter::UnknownToUtf8(tmpStr);
 
   for (unsigned i = 0; i < m_strInfoCinema.size(); ++i)
   {
@@ -725,7 +725,7 @@ const std::string CPVRRadioRDSInfoTag::GetInfoCinema() const
 void CPVRRadioRDSInfoTag::SetInfoOther(const std::string& strOther)
 {
   std::string tmpStr = Trim(strOther);
-  g_charsetConverter.unknownToUTF8(tmpStr);
+  CCharsetConverter::UnknownToUtf8(tmpStr);
 
   for (unsigned i = 0; i < m_strInfoOther.size(); ++i)
   {
@@ -768,67 +768,67 @@ const std::string CPVRRadioRDSInfoTag::GetInfoOther() const
 void CPVRRadioRDSInfoTag::SetProgStation(const std::string& strProgStation)
 {
   m_strProgStation = Trim(strProgStation);
-  g_charsetConverter.unknownToUTF8(m_strProgStation);
+  CCharsetConverter::UnknownToUtf8(m_strProgStation);
 }
 
 void CPVRRadioRDSInfoTag::SetProgHost(const std::string& strProgHost)
 {
   m_strProgHost = Trim(strProgHost);
-  g_charsetConverter.unknownToUTF8(m_strProgHost);
+  CCharsetConverter::UnknownToUtf8(m_strProgHost);
 }
 
 void CPVRRadioRDSInfoTag::SetProgStyle(const std::string& strProgStyle)
 {
   m_strProgStyle = Trim(strProgStyle);
-  g_charsetConverter.unknownToUTF8(m_strProgStyle);
+  CCharsetConverter::UnknownToUtf8(m_strProgStyle);
 }
 
 void CPVRRadioRDSInfoTag::SetProgWebsite(const std::string& strWebsite)
 {
   m_strProgWebsite = Trim(strWebsite);
-  g_charsetConverter.unknownToUTF8(m_strProgWebsite);
+  CCharsetConverter::UnknownToUtf8(m_strProgWebsite);
 }
 
 void CPVRRadioRDSInfoTag::SetProgNow(const std::string& strNow)
 {
   m_strProgNow = Trim(strNow);
-  g_charsetConverter.unknownToUTF8(m_strProgNow);
+  CCharsetConverter::UnknownToUtf8(m_strProgNow);
 }
 
 void CPVRRadioRDSInfoTag::SetProgNext(const std::string& strNext)
 {
   m_strProgNext = Trim(strNext);
-  g_charsetConverter.unknownToUTF8(m_strProgNext);
+  CCharsetConverter::UnknownToUtf8(m_strProgNext);
 }
 
 void CPVRRadioRDSInfoTag::SetPhoneHotline(const std::string& strHotline)
 {
   m_strPhoneHotline = Trim(strHotline);
-  g_charsetConverter.unknownToUTF8(m_strPhoneHotline);
+  CCharsetConverter::UnknownToUtf8(m_strPhoneHotline);
 }
 
 void CPVRRadioRDSInfoTag::SetEMailHotline(const std::string& strHotline)
 {
   m_strEMailHotline = Trim(strHotline);
-  g_charsetConverter.unknownToUTF8(m_strEMailHotline);
+  CCharsetConverter::UnknownToUtf8(m_strEMailHotline);
 }
 
 void CPVRRadioRDSInfoTag::SetPhoneStudio(const std::string& strPhone)
 {
   m_strPhoneStudio = Trim(strPhone);
-  g_charsetConverter.unknownToUTF8(m_strPhoneStudio);
+  CCharsetConverter::UnknownToUtf8(m_strPhoneStudio);
 }
 
 void CPVRRadioRDSInfoTag::SetEMailStudio(const std::string& strEMail)
 {
   m_strEMailStudio = Trim(strEMail);
-  g_charsetConverter.unknownToUTF8(m_strEMailStudio);
+  CCharsetConverter::UnknownToUtf8(m_strEMailStudio);
 }
 
 void CPVRRadioRDSInfoTag::SetSMSStudio(const std::string& strSMS)
 {
   m_strSMSStudio = Trim(strSMS);
-  g_charsetConverter.unknownToUTF8(m_strSMSStudio);
+  CCharsetConverter::UnknownToUtf8(m_strSMSStudio);
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetProgStyle() const

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -912,7 +912,7 @@ void CSettings::InitializeOptionFillers()
   m_settingsManager->RegisterSettingOptionsFiller("audiodevices", CAEFactory::SettingOptionsAudioDevicesFiller);
   m_settingsManager->RegisterSettingOptionsFiller("audiodevicespassthrough", CAEFactory::SettingOptionsAudioDevicesPassthroughFiller);
   m_settingsManager->RegisterSettingOptionsFiller("audiostreamsilence", CAEFactory::SettingOptionsAudioStreamsilenceFiller);
-  m_settingsManager->RegisterSettingOptionsFiller("charsets", CLangInfo::SettingOptionsCharsetsFiller);
+  //m_settingsManager->RegisterSettingOptionsFiller("charsets", CLangInfo::SettingOptionsCharsetsFiller);
   m_settingsManager->RegisterSettingOptionsFiller("fonts", GUIFontManager::SettingOptionsFontsFiller);
   m_settingsManager->RegisterSettingOptionsFiller("languagenames", CLangInfo::SettingOptionsLanguageNamesFiller);
   m_settingsManager->RegisterSettingOptionsFiller("refreshchangedelays", CDisplaySettings::SettingOptionsRefreshChangeDelaysFiller);
@@ -1089,11 +1089,6 @@ void CSettings::InitializeISettingCallbacks()
   m_settingsManager->RegisterCallback(&g_audioManager, settingSet);
 
   settingSet.clear();
-  settingSet.insert(CSettings::SETTING_SUBTITLES_CHARSET);
-  settingSet.insert(CSettings::SETTING_LOCALE_CHARSET);
-  m_settingsManager->RegisterCallback(&g_charsetConverter, settingSet);
-
-  settingSet.clear();
   settingSet.insert(CSettings::SETTING_VIDEOSCREEN_FAKEFULLSCREEN);
   m_settingsManager->RegisterCallback(&g_graphicsContext, settingSet);
 
@@ -1108,6 +1103,8 @@ void CSettings::InitializeISettingCallbacks()
   settingSet.insert(CSettings::SETTING_LOCALE_USE24HOURCLOCK);
   settingSet.insert(CSettings::SETTING_LOCALE_TEMPERATUREUNIT);
   settingSet.insert(CSettings::SETTING_LOCALE_SPEEDUNIT);
+  settingSet.insert(CSettings::SETTING_SUBTITLES_CHARSET);
+  settingSet.insert(CSettings::SETTING_LOCALE_CHARSET);
   m_settingsManager->RegisterCallback(&g_langInfo, settingSet);
 
   settingSet.clear();

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -602,7 +602,6 @@ void CSettings::Uninitialize()
   m_settingsManager->UnregisterCallback(&CStereoscopicsManager::GetInstance());
   m_settingsManager->UnregisterCallback(&g_application);
   m_settingsManager->UnregisterCallback(&g_audioManager);
-  m_settingsManager->UnregisterCallback(&g_charsetConverter);
   m_settingsManager->UnregisterCallback(&g_graphicsContext);
   m_settingsManager->UnregisterCallback(&g_langInfo);
   m_settingsManager->UnregisterCallback(&CInputManager::GetInstance());
@@ -913,7 +912,7 @@ void CSettings::InitializeOptionFillers()
   m_settingsManager->RegisterSettingOptionsFiller("audiodevices", CAEFactory::SettingOptionsAudioDevicesFiller);
   m_settingsManager->RegisterSettingOptionsFiller("audiodevicespassthrough", CAEFactory::SettingOptionsAudioDevicesPassthroughFiller);
   m_settingsManager->RegisterSettingOptionsFiller("audiostreamsilence", CAEFactory::SettingOptionsAudioStreamsilenceFiller);
-  m_settingsManager->RegisterSettingOptionsFiller("charsets", CCharsetConverter::SettingOptionsCharsetsFiller);
+  m_settingsManager->RegisterSettingOptionsFiller("charsets", CLangInfo::SettingOptionsCharsetsFiller);
   m_settingsManager->RegisterSettingOptionsFiller("fonts", GUIFontManager::SettingOptionsFontsFiller);
   m_settingsManager->RegisterSettingOptionsFiller("languagenames", CLangInfo::SettingOptionsLanguageNamesFiller);
   m_settingsManager->RegisterSettingOptionsFiller("refreshchangedelays", CDisplaySettings::SettingOptionsRefreshChangeDelaysFiller);

--- a/xbmc/storage/MediaManager.cpp
+++ b/xbmc/storage/MediaManager.cpp
@@ -495,10 +495,10 @@ std::string CMediaManager::GetDiskLabel(const std::string& devicePath)
   WCHAR cFSName[128];
   URIUtils::AddSlashAtEnd(strDevice);
   std::wstring strDeviceW;
-  g_charsetConverter.Utf8ToW(strDevice, strDeviceW);
+  CCharsetConverter::Utf8ToW(strDevice, strDeviceW);
   if(GetVolumeInformationW(strDeviceW.c_str(), cVolumenName, 127, NULL, NULL, NULL, cFSName, 127)==0)
     return "";
-  g_charsetConverter.WToUtf8(cVolumenName, strDevice);
+  CCharsetConverter::WToUtf8(cVolumenName, strDevice);
   return StringUtils::TrimRight(strDevice, " ");
 #else
   return MEDIA_DETECT::CDetectDVDMedia::GetDVDLabel();

--- a/xbmc/storage/MediaManager.cpp
+++ b/xbmc/storage/MediaManager.cpp
@@ -495,10 +495,10 @@ std::string CMediaManager::GetDiskLabel(const std::string& devicePath)
   WCHAR cFSName[128];
   URIUtils::AddSlashAtEnd(strDevice);
   std::wstring strDeviceW;
-  g_charsetConverter.utf8ToW(strDevice, strDeviceW);
+  g_charsetConverter.Utf8ToW(strDevice, strDeviceW);
   if(GetVolumeInformationW(strDeviceW.c_str(), cVolumenName, 127, NULL, NULL, NULL, cFSName, 127)==0)
     return "";
-  g_charsetConverter.wToUTF8(cVolumenName, strDevice);
+  g_charsetConverter.WToUtf8(cVolumenName, strDevice);
   return StringUtils::TrimRight(strDevice, " ");
 #else
   return MEDIA_DETECT::CDetectDVDMedia::GetDVDLabel();

--- a/xbmc/threads/platform/win/Win32Exception.cpp
+++ b/xbmc/threads/platform/win/Win32Exception.cpp
@@ -128,7 +128,7 @@ bool win32_exception::write_minidump(EXCEPTION_POINTERS* pEp)
 
   dumpFileName = CWIN32Util::SmbToUnc(URIUtils::AddFileToFolder(CWIN32Util::GetProfilePath(), CUtil::MakeLegalFileName(dumpFileName)));
 
-  g_charsetConverter.utf8ToW(dumpFileName, dumpFileNameW, false);
+  g_charsetConverter.Utf8ToW(dumpFileName, dumpFileNameW);
   HANDLE hDumpFile = CreateFileW(dumpFileNameW.c_str(), GENERIC_WRITE, 0, 0, CREATE_ALWAYS, 0, 0);
 
   if (hDumpFile == INVALID_HANDLE_VALUE)
@@ -199,7 +199,6 @@ bool win32_exception::write_stacktrace(EXCEPTION_POINTERS* pEp)
   STACKFRAME64 frame = { 0 };
   HANDLE hCurProc = GetCurrentProcess();
   IMAGEHLP_SYMBOL64* pSym = NULL;
-  HANDLE hDumpFile = INVALID_HANDLE_VALUE;
   tSC pSC = NULL;
 
   HMODULE hDbgHelpDll = ::LoadLibrary("DBGHELP.DLL");
@@ -231,8 +230,8 @@ bool win32_exception::write_stacktrace(EXCEPTION_POINTERS* pEp)
 
   dumpFileName = CWIN32Util::SmbToUnc(URIUtils::AddFileToFolder(CWIN32Util::GetProfilePath(), CUtil::MakeLegalFileName(dumpFileName)));
 
-  g_charsetConverter.utf8ToW(dumpFileName, dumpFileNameW, false);
-  hDumpFile = CreateFileW(dumpFileNameW.c_str(), GENERIC_WRITE, 0, 0, CREATE_ALWAYS, 0, 0);
+  g_charsetConverter.Utf8ToW(dumpFileName, dumpFileNameW);
+  HANDLE hDumpFile = CreateFileW(dumpFileNameW.c_str(), GENERIC_WRITE, 0, 0, CREATE_ALWAYS, 0, 0);
 
   if (hDumpFile == INVALID_HANDLE_VALUE)
   {

--- a/xbmc/threads/platform/win/Win32Exception.cpp
+++ b/xbmc/threads/platform/win/Win32Exception.cpp
@@ -128,7 +128,7 @@ bool win32_exception::write_minidump(EXCEPTION_POINTERS* pEp)
 
   dumpFileName = CWIN32Util::SmbToUnc(URIUtils::AddFileToFolder(CWIN32Util::GetProfilePath(), CUtil::MakeLegalFileName(dumpFileName)));
 
-  g_charsetConverter.Utf8ToW(dumpFileName, dumpFileNameW);
+  CCharsetConverter::Utf8ToW(dumpFileName, dumpFileNameW);
   HANDLE hDumpFile = CreateFileW(dumpFileNameW.c_str(), GENERIC_WRITE, 0, 0, CREATE_ALWAYS, 0, 0);
 
   if (hDumpFile == INVALID_HANDLE_VALUE)
@@ -230,7 +230,7 @@ bool win32_exception::write_stacktrace(EXCEPTION_POINTERS* pEp)
 
   dumpFileName = CWIN32Util::SmbToUnc(URIUtils::AddFileToFolder(CWIN32Util::GetProfilePath(), CUtil::MakeLegalFileName(dumpFileName)));
 
-  g_charsetConverter.Utf8ToW(dumpFileName, dumpFileNameW);
+  CCharsetConverter::Utf8ToW(dumpFileName, dumpFileNameW);
   HANDLE hDumpFile = CreateFileW(dumpFileNameW.c_str(), GENERIC_WRITE, 0, 0, CREATE_ALWAYS, 0, 0);
 
   if (hDumpFile == INVALID_HANDLE_VALUE)

--- a/xbmc/utils/CPUInfo.cpp
+++ b/xbmc/utils/CPUInfo.cpp
@@ -173,7 +173,7 @@ CCPUInfo::CCPUInfo(void)
         if (RegQueryValueExW(hCpuKey, L"ProcessorNameString", nullptr, &valType, LPBYTE(buf), &bufSize) == ERROR_SUCCESS &&
             valType == REG_SZ)
         {
-          g_charsetConverter.WToUtf8(std::wstring(buf, bufSize / sizeof(wchar_t)), cpuCore.m_strModel);
+          CCharsetConverter::WToUtf8(std::wstring(buf, bufSize / sizeof(wchar_t)), cpuCore.m_strModel);
           cpuCore.m_strModel = cpuCore.m_strModel.substr(0, cpuCore.m_strModel.find(char(0))); // remove extra null terminations
           StringUtils::RemoveDuplicatedSpacesAndTabs(cpuCore.m_strModel);
           StringUtils::Trim(cpuCore.m_strModel);
@@ -182,7 +182,7 @@ CCPUInfo::CCPUInfo(void)
         if (RegQueryValueExW(hCpuKey, L"VendorIdentifier", nullptr, &valType, LPBYTE(buf), &bufSize) == ERROR_SUCCESS &&
             valType == REG_SZ)
         {
-          g_charsetConverter.WToUtf8(std::wstring(buf, bufSize / sizeof(wchar_t)), cpuCore.m_strVendor);
+          CCharsetConverter::WToUtf8(std::wstring(buf, bufSize / sizeof(wchar_t)), cpuCore.m_strVendor);
           cpuCore.m_strVendor = cpuCore.m_strVendor.substr(0, cpuCore.m_strVendor.find(char(0))); // remove extra null terminations
         }
         DWORD mhzVal;

--- a/xbmc/utils/CPUInfo.cpp
+++ b/xbmc/utils/CPUInfo.cpp
@@ -173,7 +173,7 @@ CCPUInfo::CCPUInfo(void)
         if (RegQueryValueExW(hCpuKey, L"ProcessorNameString", nullptr, &valType, LPBYTE(buf), &bufSize) == ERROR_SUCCESS &&
             valType == REG_SZ)
         {
-          g_charsetConverter.wToUTF8(std::wstring(buf, bufSize / sizeof(wchar_t)), cpuCore.m_strModel);
+          g_charsetConverter.WToUtf8(std::wstring(buf, bufSize / sizeof(wchar_t)), cpuCore.m_strModel);
           cpuCore.m_strModel = cpuCore.m_strModel.substr(0, cpuCore.m_strModel.find(char(0))); // remove extra null terminations
           StringUtils::RemoveDuplicatedSpacesAndTabs(cpuCore.m_strModel);
           StringUtils::Trim(cpuCore.m_strModel);
@@ -182,7 +182,7 @@ CCPUInfo::CCPUInfo(void)
         if (RegQueryValueExW(hCpuKey, L"VendorIdentifier", nullptr, &valType, LPBYTE(buf), &bufSize) == ERROR_SUCCESS &&
             valType == REG_SZ)
         {
-          g_charsetConverter.wToUTF8(std::wstring(buf, bufSize / sizeof(wchar_t)), cpuCore.m_strVendor);
+          g_charsetConverter.WToUtf8(std::wstring(buf, bufSize / sizeof(wchar_t)), cpuCore.m_strVendor);
           cpuCore.m_strVendor = cpuCore.m_strVendor.substr(0, cpuCore.m_strVendor.find(char(0))); // remove extra null terminations
         }
         DWORD mhzVal;

--- a/xbmc/utils/CharsetConverter.cpp
+++ b/xbmc/utils/CharsetConverter.cpp
@@ -46,11 +46,7 @@
 #define WCHAR_CHARSET UTF32_CHARSET
 #elif defined(TARGET_WINDOWS)
   #define WCHAR_CHARSET UTF16_CHARSET 
-#ifdef NDEBUG
   #pragma comment(lib, "icuuc.lib")
-#else
-  #pragma comment(lib, "icuucd.lib")
-#endif
 #elif defined(TARGET_ANDROID)
 #define WCHAR_CHARSET UTF32_CHARSET 
 #else

--- a/xbmc/utils/CharsetConverter.cpp
+++ b/xbmc/utils/CharsetConverter.cpp
@@ -19,787 +19,584 @@
  */
 
 #include "CharsetConverter.h"
-
-#include <cerrno>
-#include <algorithm>
-
-#include <iconv.h>
-#include <fribidi/fribidi.h>
-
-#include "guilib/LocalizeStrings.h"
 #include "LangInfo.h"
-#include "log.h"
-#include "settings/lib/Setting.h"
-#include "settings/Settings.h"
-#include "system.h"
-#include "threads/SingleLock.h"
-#include "utils/StringUtils.h"
 #include "utils/Utf8Utils.h"
+#include "utils/log.h"
+
+#include <unicode/ucnv.h>
+#include <unicode/urename.h>
+#include <unicode/ubidi.h>
+#include <unicode/uniset.h>
+#include <unicode/normalizer2.h>
+#include <memory.h>
 
 #if !defined(TARGET_WINDOWS) && defined(HAVE_CONFIG_H)
   #include "config.h"
 #endif
 
-#ifdef WORDS_BIGENDIAN
-  #define ENDIAN_SUFFIX "BE"
-#else
-  #define ENDIAN_SUFFIX "LE"
-#endif
+#define UTF8_CHARSET "UTF-8"
+#define UTF16_CHARSET "UTF16_PlatformEndian"
+#define UTF16LE_CHARSET "UTF-16LE"
+#define UTF16BE_CHARSET "UTF-16BE"
+#define UTF32_CHARSET "UTF32_PlatformEndian"
+#define UTF32LE_CHARSET "UTF-32LE"
+#define UTF32BE_CHARSET "UTF-32BE"
 
 #if defined(TARGET_DARWIN)
-  #define WCHAR_IS_UCS_4 1
-  #define UTF16_CHARSET "UTF-16" ENDIAN_SUFFIX
-  #define UTF32_CHARSET "UTF-32" ENDIAN_SUFFIX
-  #define UTF8_SOURCE "UTF-8-MAC"
-  #define WCHAR_CHARSET UTF32_CHARSET
+#define WCHAR_CHARSET UTF32_CHARSET
 #elif defined(TARGET_WINDOWS)
-  #define WCHAR_IS_UTF16 1
-  #define UTF16_CHARSET "UTF-16" ENDIAN_SUFFIX
-  #define UTF32_CHARSET "UTF-32" ENDIAN_SUFFIX
-  #define UTF8_SOURCE "UTF-8"
   #define WCHAR_CHARSET UTF16_CHARSET 
-#if _DEBUG
-  #pragma comment(lib, "libfribidi.lib")
-  #pragma comment(lib, "libiconvd.lib")
+#ifdef NDEBUG
+  #pragma comment(lib, "icuuc.lib")
 #else
-  #pragma comment(lib, "libfribidi.lib")
-  #pragma comment(lib, "libiconv.lib")
+  #pragma comment(lib, "icuucd.lib")
 #endif
 #elif defined(TARGET_ANDROID)
-  #define WCHAR_IS_UCS_4 1
-  #define UTF16_CHARSET "UTF-16" ENDIAN_SUFFIX
-  #define UTF32_CHARSET "UTF-32" ENDIAN_SUFFIX
-  #define UTF8_SOURCE "UTF-8"
-  #define WCHAR_CHARSET UTF32_CHARSET 
+#define WCHAR_CHARSET UTF32_CHARSET 
 #else
-  #define UTF16_CHARSET "UTF-16" ENDIAN_SUFFIX
-  #define UTF32_CHARSET "UTF-32" ENDIAN_SUFFIX
-  #define UTF8_SOURCE "UTF-8"
-  #define WCHAR_CHARSET "WCHAR_T"
-  #if __STDC_ISO_10646__
-    #ifdef SIZEOF_WCHAR_T
-      #if SIZEOF_WCHAR_T == 4
-        #define WCHAR_IS_UCS_4 1
-      #elif SIZEOF_WCHAR_T == 2
-        #define WCHAR_IS_UCS_2 1
-      #endif
-    #endif
-  #endif
+#define WCHAR_CHARSET UTF16_CHARSET
 #endif
 
-#define NO_ICONV ((iconv_t)-1)
+//specify default normalization, on Darwin we want to compose
+#if defined(TARGET_DARWIN)
+  #define NORMALIZE 1
+#else
+  #define NORMALIZE 0
+#endif
 
-enum SpecialCharset
-{
-  NotSpecialCharset = 0,
-  SystemCharset,
-  UserCharset /* locale.charset */, 
-  SubtitleCharset /* subtitles.charset */,
-};
-
-class CConverterType : public CCriticalSection
-{
-public:
-  CConverterType(const std::string&  sourceCharset,        const std::string&  targetCharset,        unsigned int targetSingleCharMaxLen = 1);
-  CConverterType(enum SpecialCharset sourceSpecialCharset, const std::string&  targetCharset,        unsigned int targetSingleCharMaxLen = 1);
-  CConverterType(const std::string&  sourceCharset,        enum SpecialCharset targetSpecialCharset, unsigned int targetSingleCharMaxLen = 1);
-  CConverterType(enum SpecialCharset sourceSpecialCharset, enum SpecialCharset targetSpecialCharset, unsigned int targetSingleCharMaxLen = 1);
-  CConverterType(const CConverterType& other);
-  ~CConverterType();
-
-  iconv_t GetConverter(CSingleLock& converterLock);
-
-  void Reset(void);
-  void ReinitTo(const std::string& sourceCharset, const std::string& targetCharset, unsigned int targetSingleCharMaxLen = 1);
-  std::string GetSourceCharset(void) const  { return m_sourceCharset; }
-  std::string GetTargetCharset(void) const  { return m_targetCharset; }
-  unsigned int GetTargetSingleCharMaxLen(void) const  { return m_targetSingleCharMaxLen; }
-
-private:
-  static std::string ResolveSpecialCharset(enum SpecialCharset charset);
-
-  enum SpecialCharset m_sourceSpecialCharset;
-  std::string         m_sourceCharset;
-  enum SpecialCharset m_targetSpecialCharset;
-  std::string         m_targetCharset;
-  iconv_t             m_iconv;
-  unsigned int        m_targetSingleCharMaxLen;
-};
-
-CConverterType::CConverterType(const std::string& sourceCharset, const std::string& targetCharset, unsigned int targetSingleCharMaxLen /*= 1*/) : CCriticalSection(),
-  m_sourceSpecialCharset(NotSpecialCharset),
-  m_sourceCharset(sourceCharset),
-  m_targetSpecialCharset(NotSpecialCharset),
-  m_targetCharset(targetCharset),
-  m_iconv(NO_ICONV),
-  m_targetSingleCharMaxLen(targetSingleCharMaxLen)
-{
-}
-
-CConverterType::CConverterType(enum SpecialCharset sourceSpecialCharset, const std::string& targetCharset, unsigned int targetSingleCharMaxLen /*= 1*/) : CCriticalSection(),
-  m_sourceSpecialCharset(sourceSpecialCharset),
-  m_sourceCharset(),
-  m_targetSpecialCharset(NotSpecialCharset),
-  m_targetCharset(targetCharset),
-  m_iconv(NO_ICONV),
-  m_targetSingleCharMaxLen(targetSingleCharMaxLen)
-{
-}
-
-CConverterType::CConverterType(const std::string& sourceCharset, enum SpecialCharset targetSpecialCharset, unsigned int targetSingleCharMaxLen /*= 1*/) : CCriticalSection(),
-  m_sourceSpecialCharset(NotSpecialCharset),
-  m_sourceCharset(sourceCharset),
-  m_targetSpecialCharset(targetSpecialCharset),
-  m_targetCharset(),
-  m_iconv(NO_ICONV),
-  m_targetSingleCharMaxLen(targetSingleCharMaxLen)
-{
-}
-
-CConverterType::CConverterType(enum SpecialCharset sourceSpecialCharset, enum SpecialCharset targetSpecialCharset, unsigned int targetSingleCharMaxLen /*= 1*/) : CCriticalSection(),
-  m_sourceSpecialCharset(sourceSpecialCharset),
-  m_sourceCharset(),
-  m_targetSpecialCharset(targetSpecialCharset),
-  m_targetCharset(),
-  m_iconv(NO_ICONV),
-  m_targetSingleCharMaxLen(targetSingleCharMaxLen)
-{
-}
-
-CConverterType::CConverterType(const CConverterType& other) : CCriticalSection(),
-  m_sourceSpecialCharset(other.m_sourceSpecialCharset),
-  m_sourceCharset(other.m_sourceCharset),
-  m_targetSpecialCharset(other.m_targetSpecialCharset),
-  m_targetCharset(other.m_targetCharset),
-  m_iconv(NO_ICONV),
-  m_targetSingleCharMaxLen(other.m_targetSingleCharMaxLen)
-{
-}
-
-CConverterType::~CConverterType()
-{
-  CSingleLock lock(*this);
-  if (m_iconv != NO_ICONV)
-    iconv_close(m_iconv);
-  lock.Leave(); // ensure unlocking before final destruction
-}
-
-iconv_t CConverterType::GetConverter(CSingleLock& converterLock)
-{
-  // ensure that this unique instance is locked externally
-  if (&converterLock.get_underlying() != this)
-    return NO_ICONV;
-
-  if (m_iconv == NO_ICONV)
-  {
-    if (m_sourceSpecialCharset)
-      m_sourceCharset = ResolveSpecialCharset(m_sourceSpecialCharset);
-    if (m_targetSpecialCharset)
-      m_targetCharset = ResolveSpecialCharset(m_targetSpecialCharset);
-
-    m_iconv = iconv_open(m_targetCharset.c_str(), m_sourceCharset.c_str());
-    
-    if (m_iconv == NO_ICONV)
-      CLog::Log(LOGERROR, "%s: iconv_open() for \"%s\" -> \"%s\" failed, errno = %d (%s)",
-                __FUNCTION__, m_sourceCharset.c_str(), m_targetCharset.c_str(), errno, strerror(errno));
-  }
-
-  return m_iconv;
-}
-
-void CConverterType::Reset(void)
-{
-  CSingleLock lock(*this);
-  if (m_iconv != NO_ICONV)
-  {
-    iconv_close(m_iconv);
-    m_iconv = NO_ICONV;
-  }
-
-  if (m_sourceSpecialCharset)
-    m_sourceCharset.clear();
-  if (m_targetSpecialCharset)
-    m_targetCharset.clear();
-
-}
-
-void CConverterType::ReinitTo(const std::string& sourceCharset, const std::string& targetCharset, unsigned int targetSingleCharMaxLen /*= 1*/)
-{
-  CSingleLock lock(*this);
-  if (sourceCharset != m_sourceCharset || targetCharset != m_targetCharset)
-  {
-    if (m_iconv != NO_ICONV)
-    {
-      iconv_close(m_iconv);
-      m_iconv = NO_ICONV;
-    }
-
-    m_sourceSpecialCharset = NotSpecialCharset;
-    m_sourceCharset = sourceCharset;
-    m_targetSpecialCharset = NotSpecialCharset;
-    m_targetCharset = targetCharset;
-    m_targetSingleCharMaxLen = targetSingleCharMaxLen;
-  }
-}
-
-std::string CConverterType::ResolveSpecialCharset(enum SpecialCharset charset)
-{
-  switch (charset)
-  {
-  case SystemCharset:
-    return "";
-  case UserCharset:
-    return g_langInfo.GetGuiCharSet();
-  case SubtitleCharset:
-    return g_langInfo.GetSubtitleCharSet();
-  case NotSpecialCharset:
-  default:
-    return "UTF-8"; /* dummy value */
-  }
-}
-
-enum StdConversionType /* Keep it in sync with CCharsetConverter::CInnerConverter::m_stdConversion */
-{
-  NoConversion = -1,
-  Utf8ToUtf32 = 0,
-  Utf32ToUtf8,
-  Utf32ToW,
-  WToUtf32,
-  SubtitleCharsetToUtf8,
-  Utf8ToUserCharset,
-  UserCharsetToUtf8,
-  Utf32ToUserCharset,
-  WtoUtf8,
-  Utf16LEtoW,
-  Utf16BEtoUtf8,
-  Utf16LEtoUtf8,
-  Utf8toW,
-  Utf8ToSystem,
-  SystemToUtf8,
-  Ucs2CharsetToUtf8,
-  NumberOfStdConversionTypes /* Dummy sentinel entry */
-};
-
-/* We don't want to pollute header file with many additional includes and definitions, so put 
-   here all staff that require usage of types defined in this file or in additional headers */
+/**
+ * \class CCharsetConverter::CInnerConverter
+ *
+ * We don't want to pollute header file with many additional includes and definitions, so put
+ * here all stuff that require usage of types defined in this file or in additional headers
+ */
 class CCharsetConverter::CInnerConverter
 {
+private:
+  /**
+   * Helper function to perform BiDi flip and reverse hebrew/arabic text
+   *
+   * \param[in]  srcBuffer      array of UChar containing the string to process
+   * \param[in]  srcLength      length in characters of srcBuffer
+   * \param[out] dstBuffer      empty pointer to store result in
+   *                            on success will contain the processed buffer.
+   *                            it's up to the caller to delete buffer on any successful calls.
+   * \param[out] dstLength      length in characters of processed string
+   * \param[in]  bidiOptions    options for logical to visual processing
+   *
+   * \return true on success, false on any error
+   * \sa CCharsetConverter::BiDiOptions
+   */
+  static bool BidiHelper(const UChar* srcBuffer, int32_t srcLength, 
+                                 UChar** dstBuffer, int32_t& dstLength,
+                                 const uint16_t bidiOptions);
+
+  /**
+  * Helper function to perform unicode normalization
+  *
+  * \param[in]  srcBuffer           array of UChar containing the string to process
+  * \param[in]  srcLength           length in characters of srcBuffer
+  * \param[out] dstBuffer           empty pointer to store result in
+  *                                 on success will contain the processed buffer.
+  *                                 it's up to the caller to delete buffer on any successful calls.
+  * \param[out] dstLength           length in characters of processed string
+  * \param[in]  normalizeOptions    options for logical to visual processing
+  *
+  * \return true on success, false on any error
+  * \sa CCharsetConverter::NormalizationOptions
+  */
+  static bool NormalizationHelper(const UChar* srcBuffer, int32_t srcLength,
+                                          UChar** dstBuffer, int32_t& dstLength,
+                                          const uint16_t normalizeOptions);
 public:
-  static bool logicalToVisualBiDi(const std::u32string& stringSrc, std::u32string& stringDst, FriBidiCharType base = FRIBIDI_TYPE_LTR, const bool failOnBadString = false);
-  
-  template<class INPUT,class OUTPUT>
-  static bool stdConvert(StdConversionType convertType, const INPUT& strSource, OUTPUT& strDest, bool failOnInvalidChar = false);
-  template<class INPUT,class OUTPUT>
-  static bool customConvert(const std::string& sourceCharset, const std::string& targetCharset, const INPUT& strSource, OUTPUT& strDest, bool failOnInvalidChar = false);
 
-  template<class INPUT,class OUTPUT>
-  static bool convert(iconv_t type, int multiplier, const INPUT& strSource, OUTPUT& strDest, bool failOnInvalidChar = false);
+  /**
+   * Converts between two encodings and optionally performs normalization and bidi conversion
+   *
+   * Input string is converted to UTF-16 and then normaliztions and
+   * BiDi processing is performed before converting the result
+   * to the specified output encoding
+   *
+   * \param[in]  sourceCharset        charset of source string
+   * \param[in]  targetCharset        charset of destination string
+   * \param[in]  strSource            source string to be processed
+   * \param[out] strDest              output string after processing
+   * \param[in]  bidiOptions          options for logical to visual processing
+   * \param[in]  normalizeOptions     options for normalization
+   * \param[in]  failOnBadString      determines if invalid byte sequences aborts processing
+   *                                  or gets skipped
+   *
+   * \return true on success, false on any error
+   * \sa CCharsetConverter::BiDiOptions
+   * \sa CCharsetConverter::NormalizationOptions
+   */
+  template<class INPUT, class OUTPUT>
+  static bool Convert(const std::string& sourceCharset, const std::string& targetCharset,
+                                  const INPUT& strSource, OUTPUT& strDest,
+                                  const uint16_t bidiOptions, const uint16_t normalizeOptions,
+                                  const bool failOnBadString = false);
 
-  static CConverterType m_stdConversion[NumberOfStdConversionTypes];
-  static CCriticalSection m_critSectionFriBiDi;
 };
 
-/* single symbol sizes in chars */
-const int CCharsetConverter::m_Utf8CharMinSize = 1;
-const int CCharsetConverter::m_Utf8CharMaxSize = 4;
 
-CConverterType CCharsetConverter::CInnerConverter::m_stdConversion[NumberOfStdConversionTypes] = /* keep it in sync with enum StdConversionType */
+class UConverterGuard
 {
-  /* Utf8ToUtf32 */         CConverterType(UTF8_SOURCE,     UTF32_CHARSET),
-  /* Utf32ToUtf8 */         CConverterType(UTF32_CHARSET,   "UTF-8", CCharsetConverter::m_Utf8CharMaxSize),
-  /* Utf32ToW */            CConverterType(UTF32_CHARSET,   WCHAR_CHARSET),
-  /* WToUtf32 */            CConverterType(WCHAR_CHARSET,   UTF32_CHARSET),
-  /* SubtitleCharsetToUtf8*/CConverterType(SubtitleCharset, "UTF-8", CCharsetConverter::m_Utf8CharMaxSize),
-  /* Utf8ToUserCharset */   CConverterType(UTF8_SOURCE,     UserCharset),
-  /* UserCharsetToUtf8 */   CConverterType(UserCharset,     "UTF-8", CCharsetConverter::m_Utf8CharMaxSize),
-  /* Utf32ToUserCharset */  CConverterType(UTF32_CHARSET,   UserCharset),
-  /* WtoUtf8 */             CConverterType(WCHAR_CHARSET,   "UTF-8", CCharsetConverter::m_Utf8CharMaxSize),
-  /* Utf16LEtoW */          CConverterType("UTF-16LE",      WCHAR_CHARSET),
-  /* Utf16BEtoUtf8 */       CConverterType("UTF-16BE",      "UTF-8", CCharsetConverter::m_Utf8CharMaxSize),
-  /* Utf16LEtoUtf8 */       CConverterType("UTF-16LE",      "UTF-8", CCharsetConverter::m_Utf8CharMaxSize),
-  /* Utf8toW */             CConverterType(UTF8_SOURCE,     WCHAR_CHARSET),
-  /* Utf8ToSystem */        CConverterType(UTF8_SOURCE,     SystemCharset),
-  /* SystemToUtf8 */        CConverterType(SystemCharset,   UTF8_SOURCE),
-  /* Ucs2CharsetToUtf8 */   CConverterType("UCS-2LE",       "UTF-8", CCharsetConverter::m_Utf8CharMaxSize)
+  UConverter* converter;
+public:
+  UConverterGuard() : converter(NULL) {};
+  UConverterGuard(UConverter* cnv) : converter(cnv) {};
+  ~UConverterGuard() 
+  {
+    if (converter)
+      ucnv_close(converter);
+  }
+  void Set(UConverter* cnv) { converter = cnv; }
+  operator UConverter*() const
+  {
+    return this->converter;
+  }
 };
 
-CCriticalSection CCharsetConverter::CInnerConverter::m_critSectionFriBiDi;
-
-template<class INPUT,class OUTPUT>
-bool CCharsetConverter::CInnerConverter::stdConvert(StdConversionType convertType, const INPUT& strSource, OUTPUT& strDest, bool failOnInvalidChar /*= false*/)
+template<class INPUT, class OUTPUT>
+bool CCharsetConverter::CInnerConverter::Convert(const std::string& sourceCharset, const std::string& targetCharset,
+                                                            const INPUT& strSource, OUTPUT& strDest,
+                                                            const uint16_t bidiOptions, const uint16_t normalizeOptions,
+                                                            const bool failOnBadString)
 {
   strDest.clear();
   if (strSource.empty())
     return true;
 
-  if (convertType < 0 || convertType >= NumberOfStdConversionTypes)
+  UErrorCode err = U_ZERO_ERROR;
+  UConverterGuard srcConv;
+  UConverterGuard dstConv;
+
+  int32_t srcLength = -1;
+  int32_t srcLengthInBytes = -1;
+  int32_t dstLength = -1;
+  int32_t dstLengthInBytes = -1;
+  int32_t resultLength = -1;
+
+  const char* srcBuffer = NULL;
+  char* dstBuffer = NULL;
+  UChar* conversionBuffer = NULL;
+  UChar* resultBuffer = NULL;
+
+  //if any of the charsets are empty we fall back to the default
+  //encoder
+  if (sourceCharset.empty())
+    srcConv.Set(ucnv_open(NULL, &err));
+  else
+    srcConv.Set(ucnv_open(sourceCharset.c_str(), &err));
+
+  if (U_FAILURE(err))
     return false;
 
-  CConverterType& convType = m_stdConversion[convertType];
-  CSingleLock converterLock(convType);
+  if (targetCharset.empty())
+    dstConv.Set(ucnv_open(NULL, &err));
+  else
+    dstConv.Set(ucnv_open(targetCharset.c_str(), &err));
 
-  return convert(convType.GetConverter(converterLock), convType.GetTargetSingleCharMaxLen(), strSource, strDest, failOnInvalidChar);
-}
+  if (U_FAILURE(err))
+    return false;
 
-template<class INPUT,class OUTPUT>
-bool CCharsetConverter::CInnerConverter::customConvert(const std::string& sourceCharset, const std::string& targetCharset, const INPUT& strSource, OUTPUT& strDest, bool failOnInvalidChar /*= false*/)
-{
-  strDest.clear();
-  if (strSource.empty())
-    return true;
-
-  iconv_t conv = iconv_open(targetCharset.c_str(), sourceCharset.c_str());
-  if (conv == NO_ICONV)
+  if (failOnBadString)
   {
-    CLog::Log(LOGERROR, "%s: iconv_open() for \"%s\" -> \"%s\" failed, errno = %d (%s)",
-              __FUNCTION__, sourceCharset.c_str(), targetCharset.c_str(), errno, strerror(errno));
+    ucnv_setToUCallBack(srcConv, UCNV_TO_U_CALLBACK_STOP, NULL, NULL, NULL, &err);
+    ucnv_setFromUCallBack(dstConv, UCNV_FROM_U_CALLBACK_STOP, NULL, NULL, NULL, &err);
+  }
+  else
+  {
+    ucnv_setFromUCallBack(dstConv, UCNV_FROM_U_CALLBACK_SKIP, NULL, NULL, NULL, &err);
+    ucnv_setToUCallBack(srcConv, UCNV_TO_U_CALLBACK_SKIP, NULL, NULL, NULL, &err);
+  }
+
+  if (U_FAILURE(err))
+    return false;
+
+  srcLength = strSource.length();
+  srcLengthInBytes = strSource.length() * ucnv_getMinCharSize(srcConv);
+  srcBuffer = reinterpret_cast<const char*>(strSource.c_str());
+
+  //Point of no return, remember to free dstBuffer :)
+  dstLengthInBytes = UCNV_GET_MAX_BYTES_FOR_STRING(srcLength, ucnv_getMaxCharSize(srcConv));
+  dstLength = dstLengthInBytes / 2; //we know UChar is always 2 bytes
+  conversionBuffer = new UChar[dstLength];
+
+  do 
+  {
+    err = U_ZERO_ERROR;
+    resultLength = ucnv_toUChars(srcConv, conversionBuffer, dstLength, srcBuffer, srcLengthInBytes, &err);
+
+    if (err == U_BUFFER_OVERFLOW_ERROR)
+    {
+      delete[] conversionBuffer;
+      dstLength = resultLength + 1;
+      conversionBuffer = new UChar[dstLength];
+    } 
+    else if (U_FAILURE(err))
+  {
+      delete[] conversionBuffer;
+      return false;
+  }
+  } while (err == U_BUFFER_OVERFLOW_ERROR);
+  
+#if U_ICU_VERSION_MAJOR_NUM > 48
+  if (normalizeOptions != NO_NORMALIZATION)
+  {
+    if (CInnerConverter::NormalizationHelper(conversionBuffer, resultLength, &resultBuffer, resultLength, normalizeOptions))
+  {
+      //switch the buffers to avoid ifs further down
+      delete[] conversionBuffer;
+      conversionBuffer = resultBuffer;
+      resultBuffer = NULL;
+    }
+    else
+    {
+      delete[] conversionBuffer;
+      return false;
+    }
+  }
+#endif
+  if (bidiOptions != NO_BIDI)
+  {
+    if (CInnerConverter::BidiHelper(conversionBuffer, resultLength, &resultBuffer, resultLength, bidiOptions))
+  {
+      //switch the buffers to avoid ifs further down
+      delete[] conversionBuffer;
+      conversionBuffer = resultBuffer;
+      resultBuffer = NULL;
+    }
+    else
+    {
+      delete[] conversionBuffer;
+      return false;
+    }
+  }
+
+  dstLengthInBytes = UCNV_GET_MAX_BYTES_FOR_STRING(resultLength, ucnv_getMaxCharSize(dstConv));
+  dstBuffer = new char[dstLengthInBytes];
+
+  resultLength = ucnv_fromUChars(dstConv, dstBuffer, dstLengthInBytes, conversionBuffer, resultLength, &err);
+
+  if (U_FAILURE(err))
+  {
+    delete[] conversionBuffer;
+    delete[] resultBuffer;
+    delete[] dstBuffer;
     return false;
   }
-  const int dstMultp = (targetCharset.compare(0, 5, "UTF-8") == 0) ? CCharsetConverter::m_Utf8CharMaxSize : 1;
-  const bool result = convert(conv, dstMultp, strSource, strDest, failOnInvalidChar);
-  iconv_close(conv);
 
+  resultLength /= ucnv_getMinCharSize(dstConv);
+
+  if (U_SUCCESS(err))
+  {
+    uint16_t bom = static_cast<uint16_t>(dstBuffer[0]);
+    //check for a utf-16 or utf-32 bom
+    if (bom == 65535 || bom == 65279)
+      strDest.assign(reinterpret_cast<typename OUTPUT::value_type *>(dstBuffer + 2), resultLength - 1);
+    else
+      strDest.assign(reinterpret_cast<typename OUTPUT::value_type *>(dstBuffer), resultLength);
+  }
+
+  delete[] conversionBuffer;
+  delete[] resultBuffer;
+  delete[] dstBuffer;
+
+  return true;
+}
+
+bool CCharsetConverter::CInnerConverter::BidiHelper(const UChar* srcBuffer, int32_t srcLength,
+                                                            UChar** dstBuffer, int32_t& dstLength,
+                                                            const uint16_t bidiOptions)
+{
+  bool result = false;
+  int32_t outputLength = -1;
+  int32_t requiredLength = -1;
+  UErrorCode err = U_ZERO_ERROR;
+  UBiDiLevel level = 0;
+  UBiDi* bidiConv = ubidi_open();
+  
+  //ubidi_setPara changes the srcBuffer pointer so make it const
+  //and get a local copy of it
+  UChar* inputBuffer = const_cast<UChar*>(srcBuffer);
+  UChar* outputBuffer = NULL;
+
+  if (bidiOptions & LTR)
+    level = UBIDI_DEFAULT_LTR;
+  else if (bidiOptions & RTL)
+    level = UBIDI_DEFAULT_RTL;
+  else
+    level = UBIDI_DEFAULT_LTR;
+
+  ubidi_setPara(bidiConv, inputBuffer, srcLength, level, NULL, &err);
+
+  if (U_SUCCESS(err))
+  {
+    outputLength = ubidi_getProcessedLength(bidiConv) + 1; //allow for null terminator
+    outputBuffer = new UChar[outputLength];
+
+    do
+  {
+      uint16_t options = UBIDI_DO_MIRRORING;
+      if (bidiOptions & REMOVE_CONTROLS)
+        options |= UBIDI_REMOVE_BIDI_CONTROLS;
+      if (bidiOptions & WRITE_REVERSE)
+        options |= UBIDI_OUTPUT_REVERSE;
+
+      requiredLength = ubidi_writeReordered(bidiConv, outputBuffer, outputLength, options, &err);
+
+      if (U_SUCCESS(err))
+        {
+        outputLength = requiredLength;
+        result = true;
+          break;
+        }
+
+      if (err == U_BUFFER_OVERFLOW_ERROR)
+      {
+        delete[] outputBuffer;
+        outputBuffer = new UChar[requiredLength];
+        outputLength = requiredLength;
+
+        //make sure our err is reset, some icu functions fail if it contains
+        //a previous bad result
+        err = U_ZERO_ERROR;
+      }
+
+      //We can't do much for other failures than buffer overflow
+      //clean up and bail out
+      if (U_FAILURE(err))
+      {
+        delete[] outputBuffer;
+    break;
+  }
+    } while (1);
+
+    if (result)
+  {
+      *dstBuffer = outputBuffer;
+      dstLength = outputLength;
+    }
+  }
+
+  ubidi_close(bidiConv);
+  
+  //we don't delete outBuffer, it's returned to caller and
+  //caller is responsible for freeing it
   return result;
 }
 
-/* iconv may declare inbuf to be char** rather than const char** depending on platform and version,
-    so provide a wrapper that handles both */
-struct charPtrPtrAdapter
+bool CCharsetConverter::CInnerConverter::NormalizationHelper(const UChar* srcBuffer, int32_t srcLength,
+                                                             UChar** dstBuffer, int32_t& dstLength,
+                                                             const uint16_t normalizeOptions)
 {
-  const char** pointer;
-  charPtrPtrAdapter(const char** p) :
-    pointer(p) { }
-  operator char**()
-  { return const_cast<char**>(pointer); }
-  operator const char**()
-  { return pointer; }
-};
+#if U_ICU_VERSION_MAJOR_NUM > 48
+  UErrorCode err = U_ZERO_ERROR;
+  UnicodeString src(srcBuffer, srcLength);
+  UnicodeString dst;
 
-template<class INPUT,class OUTPUT>
-bool CCharsetConverter::CInnerConverter::convert(iconv_t type, int multiplier, const INPUT& strSource, OUTPUT& strDest, bool failOnInvalidChar /*= false*/)
-{
-  if (type == NO_ICONV)
-    return false;
-
-  //input buffer for iconv() is the buffer from strSource
-  size_t      inBufSize  = (strSource.length() + 1) * sizeof(typename INPUT::value_type);
-  const char* inBuf      = (const char*)strSource.c_str();
-
-  //allocate output buffer for iconv()
-  size_t      outBufSize = (strSource.length() + 1) * sizeof(typename OUTPUT::value_type) * multiplier;
-  char*       outBuf     = (char*)malloc(outBufSize);
-  if (outBuf == NULL)
+  if (normalizeOptions & COMPOSE)
   {
-      CLog::Log(LOGSEVERE, "%s: malloc failed", __FUNCTION__);
+    //this should not be deleted, it's managed by icu
+    const Normalizer2* norm = Normalizer2::getNFCInstance(err);
+    if (U_FAILURE(err))
+      return false;
+
+    norm->normalize(src, dst, err);
+    if (U_FAILURE(err))
+      return false;
+  }
+  else if (normalizeOptions & DECOMPOSE)
+  {
+    //this should not be deleted, it's managed by icu
+    const Normalizer2* norm = Normalizer2::getNFDInstance(err);
+    if (U_FAILURE(err))
+      return false;
+
+    norm->normalize(src, dst, err);
+    if (U_FAILURE(err))
+      return false;
+    }
+  else if (normalizeOptions & DECOMPOSE_MAC)
+  {
+    //https://developer.apple.com/library/mac/qa/qa1173/_index.html
+    //which U + 2000 through U + 2FFF, U + F900 through U + FAFF, and U + 2F800 through U + 2FAFF
+    //are not decomposed(this avoids problems with round trip conversions from old Mac text encodings).
+    UnicodeString usetString("[[^\\u2000-\\u2fff][^\\uf900-\\ufaff][^\\u2f800-\\u2faff]]");
+    UnicodeSet uSet(usetString, err);
+
+    if (U_FAILURE(err))
+      return false;
+
+    //this should not be deleted, it's managed by icu
+    const Normalizer2* nfd = Normalizer2::getNFDInstance(err);
+
+    if (U_FAILURE(err))
+      return false;
+
+    FilteredNormalizer2 filteredNfd(*nfd, uSet);
+
+    filteredNfd.normalize(src, dst, err);
+
+    if (U_FAILURE(err))
       return false;
   }
 
-  size_t      inBytesAvail  = inBufSize;  //how many bytes iconv() can read
-  size_t      outBytesAvail = outBufSize; //how many bytes iconv() can write
-  const char* inBufStart    = inBuf;      //where in our input buffer iconv() should start reading
-  char*       outBufStart   = outBuf;     //where in out output buffer iconv() should start writing
-
-  size_t returnV;
-  while(1)
-  {
-    //iconv() will update inBufStart, inBytesAvail, outBufStart and outBytesAvail
-    returnV = iconv(type, charPtrPtrAdapter(&inBufStart), &inBytesAvail, &outBufStart, &outBytesAvail);
-
-    if (returnV == (size_t)-1)
-    {
-      if (errno == E2BIG) //output buffer is not big enough
-      {
-        //save where iconv() ended converting, realloc might make outBufStart invalid
-        size_t bytesConverted = outBufSize - outBytesAvail;
-
-        //make buffer twice as big
-        outBufSize   *= 2;
-        char* newBuf  = (char*)realloc(outBuf, outBufSize);
-        if (!newBuf)
-        {
-          CLog::Log(LOGSEVERE, "%s realloc failed with errno=%d(%s)",
-                    __FUNCTION__, errno, strerror(errno));
-          break;
-        }
-        outBuf = newBuf;
-
-        //update the buffer pointer and counter
-        outBufStart   = outBuf + bytesConverted;
-        outBytesAvail = outBufSize - bytesConverted;
-
-        //continue in the loop and convert the rest
-        continue;
-      }
-      else if (errno == EILSEQ) //An invalid multibyte sequence has been encountered in the input
-      {
-        if (failOnInvalidChar)
-          break;
-
-        //skip invalid byte
-        inBufStart++;
-        inBytesAvail--;
-        //continue in the loop and convert the rest
-        continue;
-      }
-      else if (errno == EINVAL) /* Invalid sequence at the end of input buffer */
-      {
-        if (!failOnInvalidChar)
-          returnV = 0; /* reset error status to use converted part */
-
-        break;
-      }
-      else //iconv() had some other error
-      {
-        CLog::Log(LOGERROR, "%s: iconv() failed, errno=%d (%s)",
-                  __FUNCTION__, errno, strerror(errno));
-      }
-    }
-    break;
-  }
-
-  //complete the conversion (reset buffers), otherwise the current data will prefix the data on the next call
-  if (iconv(type, NULL, NULL, &outBufStart, &outBytesAvail) == (size_t)-1)
-    CLog::Log(LOGERROR, "%s failed cleanup errno=%d(%s)", __FUNCTION__, errno, strerror(errno));
-
-  if (returnV == (size_t)-1)
-  {
-    free(outBuf);
-    return false;
-  }
-  //we're done
-
-  const typename OUTPUT::size_type sizeInChars = (typename OUTPUT::size_type) (outBufSize - outBytesAvail) / sizeof(typename OUTPUT::value_type);
-  typename OUTPUT::const_pointer strPtr = (typename OUTPUT::const_pointer) outBuf;
-  /* Make sure that all buffer is assigned and string is stopped at end of buffer */
-  if (strPtr[sizeInChars-1] == 0 && strSource[strSource.length()-1] != 0)
-    strDest.assign(strPtr, sizeInChars-1);
-  else
-    strDest.assign(strPtr, sizeInChars);
-
-  free(outBuf);
-
+  dstLength = dst.length();
+  *dstBuffer = new UChar[dstLength];
+  
+  memcpy(static_cast<void*>(*dstBuffer), static_cast<const void*>(dst.getTerminatedBuffer()), dstLength * 2);
+#endif
   return true;
 }
 
-bool CCharsetConverter::CInnerConverter::logicalToVisualBiDi(const std::u32string& stringSrc, std::u32string& stringDst, FriBidiCharType base /*= FRIBIDI_TYPE_LTR*/, const bool failOnBadString /*= false*/)
+bool CCharsetConverter::Utf8ToUtf32(const std::string& utf8StringSrc, std::u32string& utf32StringDst)
 {
-  stringDst.clear();
-
-  const size_t srcLen = stringSrc.length();
-  if (srcLen == 0)
-    return true;
-
-  stringDst.reserve(srcLen);
-  size_t lineStart = 0;
-
-  // libfribidi is not threadsafe, so make sure we make it so
-  CSingleLock lock(m_critSectionFriBiDi);
-  do
-  {
-    size_t lineEnd = stringSrc.find('\n', lineStart);
-    if (lineEnd >= srcLen) // equal to 'lineEnd == std::string::npos'
-      lineEnd = srcLen;
-    else
-      lineEnd++; // include '\n'
-    
-    const size_t lineLen = lineEnd - lineStart;
-
-    FriBidiChar* visual = (FriBidiChar*) malloc((lineLen + 1) * sizeof(FriBidiChar));
-    if (visual == NULL)
-    {
-      free(visual);
-      CLog::Log(LOGSEVERE, "%s: can't allocate memory", __FUNCTION__);
-      return false;
-    }
-
-    bool bidiFailed = false;
-    FriBidiCharType baseCopy = base; // preserve same value for all lines, required because fribidi_log2vis will modify parameter value
-    if (fribidi_log2vis((const FriBidiChar*)(stringSrc.c_str() + lineStart), lineLen, &baseCopy, visual, NULL, NULL, NULL))
-    {
-      // Removes bidirectional marks
-      const int newLen = fribidi_remove_bidi_marks(visual, lineLen, NULL, NULL, NULL);
-      if (newLen > 0)
-        stringDst.append((const char32_t*)visual, (size_t)newLen);
-      else if (newLen < 0)
-        bidiFailed = failOnBadString;
-    }
-    else
-      bidiFailed = failOnBadString;
-
-    free(visual);
-
-    if (bidiFailed)
-      return false;
-
-    lineStart = lineEnd;
-  } while (lineStart < srcLen);
-
-  return !stringDst.empty();
+  return CInnerConverter::Convert(UTF8_CHARSET, UTF32_CHARSET, utf8StringSrc, utf32StringDst,
+                                  NO_BIDI, NO_NORMALIZATION, false);
 }
 
-static struct SCharsetMapping
-{
-  const char* charset;
-  const char* caption;
-} g_charsets[] = {
-  { "ISO-8859-1", "Western Europe (ISO)" }
-  , { "ISO-8859-2", "Central Europe (ISO)" }
-  , { "ISO-8859-3", "South Europe (ISO)" }
-  , { "ISO-8859-4", "Baltic (ISO)" }
-  , { "ISO-8859-5", "Cyrillic (ISO)" }
-  , { "ISO-8859-6", "Arabic (ISO)" }
-  , { "ISO-8859-7", "Greek (ISO)" }
-  , { "ISO-8859-8", "Hebrew (ISO)" }
-  , { "ISO-8859-9", "Turkish (ISO)" }
-  , { "CP1250", "Central Europe (Windows)" }
-  , { "CP1251", "Cyrillic (Windows)" }
-  , { "CP1252", "Western Europe (Windows)" }
-  , { "CP1253", "Greek (Windows)" }
-  , { "CP1254", "Turkish (Windows)" }
-  , { "CP1255", "Hebrew (Windows)" }
-  , { "CP1256", "Arabic (Windows)" }
-  , { "CP1257", "Baltic (Windows)" }
-  , { "CP1258", "Vietnamesse (Windows)" }
-  , { "CP874", "Thai (Windows)" }
-  , { "BIG5", "Chinese Traditional (Big5)" }
-  , { "GBK", "Chinese Simplified (GBK)" }
-  , { "SHIFT_JIS", "Japanese (Shift-JIS)" }
-  , { "CP949", "Korean" }
-  , { "BIG5-HKSCS", "Hong Kong (Big5-HKSCS)" }
-  , { NULL, NULL }
-};
-
-CCharsetConverter::CCharsetConverter()
-{
-}
-
-void CCharsetConverter::OnSettingChanged(const CSetting* setting)
-{
-  if (setting == NULL)
-    return;
-
-  const std::string& settingId = setting->GetId();
-  if (settingId == CSettings::SETTING_LOCALE_CHARSET)
-    resetUserCharset();
-  else if (settingId == CSettings::SETTING_SUBTITLES_CHARSET)
-    resetSubtitleCharset();
-}
-
-void CCharsetConverter::clear()
-{
-}
-
-std::vector<std::string> CCharsetConverter::getCharsetLabels()
-{
-  std::vector<std::string> lab;
-  for(SCharsetMapping* c = g_charsets; c->charset; c++)
-    lab.push_back(c->caption);
-
-  return lab;
-}
-
-std::string CCharsetConverter::getCharsetLabelByName(const std::string& charsetName)
-{
-  for(SCharsetMapping* c = g_charsets; c->charset; c++)
-  {
-    if (StringUtils::EqualsNoCase(charsetName,c->charset))
-      return c->caption;
-  }
-
-  return "";
-}
-
-std::string CCharsetConverter::getCharsetNameByLabel(const std::string& charsetLabel)
-{
-  for(SCharsetMapping* c = g_charsets; c->charset; c++)
-  {
-    if (StringUtils::EqualsNoCase(charsetLabel, c->caption))
-      return c->charset;
-  }
-
-  return "";
-}
-
-void CCharsetConverter::reset(void)
-{
-  for (int i = 0; i < NumberOfStdConversionTypes; i++)
-    CInnerConverter::m_stdConversion[i].Reset();
-}
-
-void CCharsetConverter::resetSystemCharset(void)
-{
-  CInnerConverter::m_stdConversion[Utf8ToSystem].Reset();
-  CInnerConverter::m_stdConversion[SystemToUtf8].Reset();
-}
-
-void CCharsetConverter::resetUserCharset(void)
-{
-  CInnerConverter::m_stdConversion[UserCharsetToUtf8].Reset();
-  CInnerConverter::m_stdConversion[UserCharsetToUtf8].Reset();
-  CInnerConverter::m_stdConversion[Utf32ToUserCharset].Reset();
-  resetSubtitleCharset();
-}
-
-void CCharsetConverter::resetSubtitleCharset(void)
-{
-  CInnerConverter::m_stdConversion[SubtitleCharsetToUtf8].Reset();
-}
-
-void CCharsetConverter::reinitCharsetsFromSettings(void)
-{
-  resetUserCharset(); // this will also reinit Subtitle charsets
-}
-
-bool CCharsetConverter::utf8ToUtf32(const std::string& utf8StringSrc, std::u32string& utf32StringDst, bool failOnBadChar /*= true*/)
-{
-  return CInnerConverter::stdConvert(Utf8ToUtf32, utf8StringSrc, utf32StringDst, failOnBadChar);
-}
-
-std::u32string CCharsetConverter::utf8ToUtf32(const std::string& utf8StringSrc, bool failOnBadChar /*= true*/)
+std::u32string CCharsetConverter::Utf8ToUtf32(const std::string& utf8StringSrc)
 {
   std::u32string converted;
-  utf8ToUtf32(utf8StringSrc, converted, failOnBadChar);
+  Utf8ToUtf32(utf8StringSrc, converted);
   return converted;
 }
 
-bool CCharsetConverter::utf8ToUtf32Visual(const std::string& utf8StringSrc, std::u32string& utf32StringDst, bool bVisualBiDiFlip /*= false*/, bool forceLTRReadingOrder /*= false*/, bool failOnBadChar /*= false*/)
+bool CCharsetConverter::Utf8ToUtf16(const std::string& utf8StringSrc, std::u16string& utf16StringDst)
 {
-  if (bVisualBiDiFlip)
-  {
-    std::u32string converted;
-    if (!CInnerConverter::stdConvert(Utf8ToUtf32, utf8StringSrc, converted, failOnBadChar))
-      return false;
-
-    return CInnerConverter::logicalToVisualBiDi(converted, utf32StringDst, forceLTRReadingOrder ? FRIBIDI_TYPE_LTR : FRIBIDI_TYPE_PDF, failOnBadChar);
-  }
-  return CInnerConverter::stdConvert(Utf8ToUtf32, utf8StringSrc, utf32StringDst, failOnBadChar);
+  return CInnerConverter::Convert(UTF8_CHARSET, UTF16_CHARSET, utf8StringSrc, utf16StringDst,
+                                  NO_BIDI, NO_NORMALIZATION, false);
 }
 
-bool CCharsetConverter::utf32ToUtf8(const std::u32string& utf32StringSrc, std::string& utf8StringDst, bool failOnBadChar /*= true*/)
+bool CCharsetConverter::TryUtf8ToUtf16(const std::string & utf8StringSrc, std::u16string & utf16StringDst)
 {
-  return CInnerConverter::stdConvert(Utf32ToUtf8, utf32StringSrc, utf8StringDst, failOnBadChar);
+  return CInnerConverter::Convert(UTF8_CHARSET, UTF16_CHARSET, utf8StringSrc, utf16StringDst,
+                                  NO_BIDI, NO_NORMALIZATION, true);
 }
 
-std::string CCharsetConverter::utf32ToUtf8(const std::u32string& utf32StringSrc, bool failOnBadChar /*= false*/)
+std::u16string CCharsetConverter::Utf8ToUtf16(const std::string& utf8StringSrc)
+{
+  std::u16string converted;
+  Utf8ToUtf16(utf8StringSrc, converted);
+  return converted;
+}
+
+bool CCharsetConverter::Utf8ToUtf16BE(const std::string& utf8StringSrc, std::u16string& utf16StringDst)
+{
+  return CInnerConverter::Convert(UTF8_CHARSET, UTF16BE_CHARSET, utf8StringSrc, utf16StringDst,
+                                  NO_BIDI, NO_NORMALIZATION, false);
+}
+
+bool CCharsetConverter::Utf8ToUtf16LE(const std::string& utf8StringSrc, std::u16string& utf16StringDst)
+{
+  return CInnerConverter::Convert(UTF8_CHARSET, UTF16LE_CHARSET, utf8StringSrc, utf16StringDst,
+                                  NO_BIDI, NO_NORMALIZATION, false);
+}
+
+bool CCharsetConverter::Utf8ToUtf32LogicalToVisual(const std::string& utf8StringSrc, std::u32string& utf32StringDst,
+                                                   uint16_t bidiOptions /* = LTR | REMOVE_CONTROLS */)
+{
+  return CInnerConverter::Convert(UTF8_CHARSET, UTF32_CHARSET, utf8StringSrc, utf32StringDst,
+                                                bidiOptions, NO_NORMALIZATION, false);
+}
+
+bool CCharsetConverter::Utf32ToUtf8(const std::u32string& utf32StringSrc, std::string& utf8StringDst)
+{
+  return CInnerConverter::Convert(UTF32_CHARSET, UTF8_CHARSET, utf32StringSrc, utf8StringDst,
+                                  NO_BIDI, NO_NORMALIZATION, false);
+}
+
+std::string CCharsetConverter::Utf32ToUtf8(const std::u32string& utf32StringSrc)
 {
   std::string converted;
-  utf32ToUtf8(utf32StringSrc, converted, failOnBadChar);
+  Utf32ToUtf8(utf32StringSrc, converted);
   return converted;
 }
 
-bool CCharsetConverter::utf32ToW(const std::u32string& utf32StringSrc, std::wstring& wStringDst, bool failOnBadChar /*= true*/)
+bool CCharsetConverter::Utf8ToWLogicalToVisual(const std::string& utf8StringSrc, std::wstring& wStringDst,
+                                               uint16_t bidiOptions /* = LTR | REMOVE_CONTROLS */)
 {
-#ifdef WCHAR_IS_UCS_4
-  wStringDst.assign((const wchar_t*)utf32StringSrc.c_str(), utf32StringSrc.length());
-  return true;
-#else // !WCHAR_IS_UCS_4
-  return CInnerConverter::stdConvert(Utf32ToW, utf32StringSrc, wStringDst, failOnBadChar);
-#endif // !WCHAR_IS_UCS_4
+  return CInnerConverter::Convert(UTF8_CHARSET, WCHAR_CHARSET, utf8StringSrc, wStringDst,
+                                              bidiOptions, NO_NORMALIZATION | NORMALIZE, false);
 }
 
-bool CCharsetConverter::utf32logicalToVisualBiDi(const std::u32string& logicalStringSrc, std::u32string& visualStringDst, bool forceLTRReadingOrder /*= false*/, bool failOnBadString /*= false*/)
+bool CCharsetConverter::Utf8ToW(const std::string& utf8StringSrc, std::wstring& wStringDst)
 {
-  return CInnerConverter::logicalToVisualBiDi(logicalStringSrc, visualStringDst, forceLTRReadingOrder ? FRIBIDI_TYPE_LTR : FRIBIDI_TYPE_PDF, failOnBadString);
+  return CInnerConverter::Convert(UTF8_CHARSET, WCHAR_CHARSET, utf8StringSrc, wStringDst,
+                                  NO_BIDI, NO_NORMALIZATION | NORMALIZE, false);
 }
 
-bool CCharsetConverter::wToUtf32(const std::wstring& wStringSrc, std::u32string& utf32StringDst, bool failOnBadChar /*= true*/)
+bool CCharsetConverter::TryUtf8ToW(const std::string & utf8StringSrc, std::wstring & wStringDst)
 {
-#ifdef WCHAR_IS_UCS_4
-  /* UCS-4 is almost equal to UTF-32, but UTF-32 has strict limits on possible values, while UCS-4 is usually unchecked.
-   * With this "conversion" we ensure that output will be valid UTF-32 string. */
-#endif
-  return CInnerConverter::stdConvert(WToUtf32, wStringSrc, utf32StringDst, failOnBadChar);
+  return CInnerConverter::Convert(UTF8_CHARSET, WCHAR_CHARSET, utf8StringSrc, wStringDst,
+                                  NO_BIDI, NO_NORMALIZATION | NORMALIZE, true);
 }
 
-// The bVisualBiDiFlip forces a flip of characters for hebrew/arabic languages, only set to false if the flipping
-// of the string is already made or the string is not displayed in the GUI
-bool CCharsetConverter::utf8ToW(const std::string& utf8StringSrc, std::wstring& wStringDst, bool bVisualBiDiFlip /*= true*/, 
-                                bool forceLTRReadingOrder /*= false*/, bool failOnBadChar /*= false*/)
+bool CCharsetConverter::TryWToUtf8(const std::wstring & wStringSrc, std::string & utf8StringDst)
 {
-  // Try to flip hebrew/arabic characters, if any
-  if (bVisualBiDiFlip)
-  {
-    wStringDst.clear();
-    std::u32string utf32str;
-    if (!CInnerConverter::stdConvert(Utf8ToUtf32, utf8StringSrc, utf32str, failOnBadChar))
-      return false;
-
-    std::u32string utf32flipped;
-    const bool bidiResult = CInnerConverter::logicalToVisualBiDi(utf32str, utf32flipped, forceLTRReadingOrder ? FRIBIDI_TYPE_LTR : FRIBIDI_TYPE_PDF, failOnBadChar);
-
-    return CInnerConverter::stdConvert(Utf32ToW, utf32flipped, wStringDst, failOnBadChar) && bidiResult;
-  }
-  
-  return CInnerConverter::stdConvert(Utf8toW, utf8StringSrc, wStringDst, failOnBadChar);
+  return CInnerConverter::Convert(WCHAR_CHARSET, UTF8_CHARSET, wStringSrc, utf8StringDst,
+                                  NO_BIDI, NO_NORMALIZATION, true);
 }
 
-bool CCharsetConverter::subtitleCharsetToUtf8(const std::string& stringSrc, std::string& utf8StringDst)
+bool CCharsetConverter::SubtitleCharsetToUtf8(const std::string& stringSrc, std::string& utf8StringDst)
 {
-  return CInnerConverter::stdConvert(SubtitleCharsetToUtf8, stringSrc, utf8StringDst, false);
+  std::string subtitleCharset = g_langInfo.GetSubtitleCharSet();
+  return CInnerConverter::Convert(subtitleCharset, UTF8_CHARSET, stringSrc, utf8StringDst,
+                                  NO_BIDI, NO_NORMALIZATION, false);
 }
 
-bool CCharsetConverter::fromW(const std::wstring& wStringSrc,
-                              std::string& stringDst, const std::string& enc)
+bool CCharsetConverter::Utf8ToStringCharset(const std::string& utf8StringSrc, std::string& stringDst)
 {
-  return CInnerConverter::customConvert(WCHAR_CHARSET, enc, wStringSrc, stringDst);
+  std::string guiCharset = g_langInfo.GetGuiCharSet();
+  return CInnerConverter::Convert(UTF8_CHARSET, guiCharset, utf8StringSrc, stringDst,
+                                  NO_BIDI, NO_NORMALIZATION, false);
 }
 
-bool CCharsetConverter::toW(const std::string& stringSrc,
-                            std::wstring& wStringDst, const std::string& enc)
-{
-  return CInnerConverter::customConvert(enc, WCHAR_CHARSET, stringSrc, wStringDst);
-}
-
-bool CCharsetConverter::utf8ToStringCharset(const std::string& utf8StringSrc, std::string& stringDst)
-{
-  return CInnerConverter::stdConvert(Utf8ToUserCharset, utf8StringSrc, stringDst);
-}
-
-bool CCharsetConverter::utf8ToStringCharset(std::string& stringSrcDst)
+bool CCharsetConverter::Utf8ToStringCharset(std::string& stringSrcDst)
 {
   std::string strSrc(stringSrcDst);
-  return utf8ToStringCharset(strSrc, stringSrcDst);
+  return Utf8ToStringCharset(strSrc, stringSrcDst);
 }
 
-bool CCharsetConverter::ToUtf8(const std::string& strSourceCharset, const std::string& stringSrc, std::string& utf8StringDst, bool failOnBadChar /*= false*/)
+bool CCharsetConverter::ToUtf8(const std::string& strSourceCharset, const std::string& stringSrc, std::string& utf8StringDst)
 {
-  if (strSourceCharset == "UTF-8")
-  { // simple case - no conversion necessary
-    utf8StringDst = stringSrc;
-    return true;
-  }
-  
-  return CInnerConverter::customConvert(strSourceCharset, "UTF-8", stringSrc, utf8StringDst, failOnBadChar);
+  return CInnerConverter::Convert(strSourceCharset, UTF8_CHARSET, stringSrc, utf8StringDst,
+                                  NO_BIDI, NO_NORMALIZATION, false);
 }
 
-bool CCharsetConverter::utf8To(const std::string& strDestCharset, const std::string& utf8StringSrc, std::string& stringDst)
+bool CCharsetConverter::TryToUtf8(const std::string& strSourceCharset, const std::string& stringSrc, std::string& utf8StringDst)
 {
-  if (strDestCharset == "UTF-8")
-  { // simple case - no conversion necessary
-    stringDst = utf8StringSrc;
-    return true;
-  }
-
-  return CInnerConverter::customConvert(UTF8_SOURCE, strDestCharset, utf8StringSrc, stringDst);
+  return CInnerConverter::Convert(strSourceCharset, UTF8_CHARSET, stringSrc, utf8StringDst,
+                                  NO_BIDI, NO_NORMALIZATION, false);
 }
 
-bool CCharsetConverter::utf8To(const std::string& strDestCharset, const std::string& utf8StringSrc, std::u16string& utf16StringDst)
+bool CCharsetConverter::Utf8To(const std::string& strDestCharset, const std::string& utf8StringSrc, std::string& stringDst)
 {
-  return CInnerConverter::customConvert(UTF8_SOURCE, strDestCharset, utf8StringSrc, utf16StringDst);
+  return CInnerConverter::Convert(UTF8_CHARSET, strDestCharset, utf8StringSrc, stringDst,
+                                  NO_BIDI, NO_NORMALIZATION, false);
 }
 
-bool CCharsetConverter::utf8To(const std::string& strDestCharset, const std::string& utf8StringSrc, std::u32string& utf32StringDst)
+bool CCharsetConverter::Utf8To(const std::string& strDestCharset, const std::string& utf8StringSrc, std::u16string& utf16StringDst)
 {
-  return CInnerConverter::customConvert(UTF8_SOURCE, strDestCharset, utf8StringSrc, utf32StringDst);
+  return CInnerConverter::Convert(UTF8_CHARSET, strDestCharset, utf8StringSrc, utf16StringDst,
+                                  NO_BIDI, NO_NORMALIZATION, false);
 }
 
-bool CCharsetConverter::unknownToUTF8(std::string& stringSrcDst)
+bool CCharsetConverter::Utf8To(const std::string& strDestCharset, const std::string& utf8StringSrc, std::u32string& utf32StringDst)
+{
+  return CInnerConverter::Convert(UTF8_CHARSET, strDestCharset, utf8StringSrc, utf32StringDst,
+                                  NO_BIDI, NO_NORMALIZATION, false);
+}
+
+bool CCharsetConverter::UnknownToUtf8(std::string& stringSrcDst)
 {
   std::string source(stringSrcDst);
-  return unknownToUTF8(source, stringSrcDst);
+  return UnknownToUtf8(source, stringSrcDst);
 }
 
-bool CCharsetConverter::unknownToUTF8(const std::string& stringSrc, std::string& utf8StringDst, bool failOnBadChar /*= false*/)
+bool CCharsetConverter::UnknownToUtf8(const std::string& stringSrc, std::string& utf8StringDst)
 {
   // checks whether it's utf8 already, and if not converts using the sourceCharset if given, else the string charset
   if (CUtf8Utils::isValidUtf8(stringSrc))
@@ -807,67 +604,141 @@ bool CCharsetConverter::unknownToUTF8(const std::string& stringSrc, std::string&
     utf8StringDst = stringSrc;
     return true;
   }
-  return CInnerConverter::stdConvert(UserCharsetToUtf8, stringSrc, utf8StringDst, failOnBadChar);
+  std::string guiCharset = g_langInfo.GetGuiCharSet();
+  return CInnerConverter::Convert(guiCharset, UTF8_CHARSET, stringSrc, utf8StringDst,
+                                  NO_BIDI, NO_NORMALIZATION, false);
 }
 
-bool CCharsetConverter::wToUTF8(const std::wstring& wStringSrc, std::string& utf8StringDst, bool failOnBadChar /*= false*/)
+bool CCharsetConverter::WToUtf8(const std::wstring& wStringSrc, std::string& utf8StringDst)
 {
-  return CInnerConverter::stdConvert(WtoUtf8, wStringSrc, utf8StringDst, failOnBadChar);
+  return CInnerConverter::Convert(WCHAR_CHARSET, UTF8_CHARSET, wStringSrc, utf8StringDst,
+                                  NO_BIDI, NO_NORMALIZATION, false);
 }
 
-bool CCharsetConverter::utf16BEtoUTF8(const std::u16string& utf16StringSrc, std::string& utf8StringDst)
+bool CCharsetConverter::Utf16BEToUtf8(const std::u16string& utf16StringSrc, std::string& utf8StringDst)
 {
-  return CInnerConverter::stdConvert(Utf16BEtoUtf8, utf16StringSrc, utf8StringDst);
+  return CInnerConverter::Convert(UTF16BE_CHARSET, UTF8_CHARSET, utf16StringSrc, utf8StringDst,
+                                  NO_BIDI, NO_NORMALIZATION, false);
 }
 
-bool CCharsetConverter::utf16LEtoUTF8(const std::u16string& utf16StringSrc,
-                                      std::string& utf8StringDst)
+bool CCharsetConverter::Utf16LEToUtf8(const std::u16string& utf16StringSrc, std::string& utf8StringDst)
 {
-  return CInnerConverter::stdConvert(Utf16LEtoUtf8, utf16StringSrc, utf8StringDst);
+  return CInnerConverter::Convert(UTF16LE_CHARSET, UTF8_CHARSET, utf16StringSrc, utf8StringDst,
+                                  NO_BIDI, NO_NORMALIZATION, false);
 }
 
-bool CCharsetConverter::ucs2ToUTF8(const std::u16string& ucs2StringSrc, std::string& utf8StringDst)
+bool CCharsetConverter::Utf16ToUtf8(const std::u16string& utf16StringSrc, std::string& utf8StringDst)
 {
-  return CInnerConverter::stdConvert(Ucs2CharsetToUtf8, ucs2StringSrc,utf8StringDst);
+  return CInnerConverter::Convert(UTF16_CHARSET, UTF8_CHARSET, utf16StringSrc, utf8StringDst,
+                                  NO_BIDI, NO_NORMALIZATION, false);
 }
 
-bool CCharsetConverter::utf16LEtoW(const std::u16string& utf16String, std::wstring& wString)
+bool CCharsetConverter::TryUtf16ToUtf8(const std::u16string utf16StringSrc, std::string & utf8StringDst)
 {
-  return CInnerConverter::stdConvert(Utf16LEtoW, utf16String, wString);
+  return CInnerConverter::Convert(UTF16_CHARSET, UTF8_CHARSET, utf16StringSrc, utf8StringDst,
+                                  NO_BIDI, NO_NORMALIZATION, true);
 }
 
-bool CCharsetConverter::utf32ToStringCharset(const std::u32string& utf32StringSrc, std::string& stringDst)
+bool CCharsetConverter::Ucs2ToUtf8(const std::u16string& ucs2StringSrc, std::string& utf8StringDst)
 {
-  return CInnerConverter::stdConvert(Utf32ToUserCharset, utf32StringSrc, stringDst);
+  //UCS2 is technically only BE and ICU includes no LE version converter
+  //Use UTF-16 converter since the only difference are lead bytes that are
+  //illegal to use in UCS2 so should not cause any issues
+  return CInnerConverter::Convert(UTF16LE_CHARSET, UTF8_CHARSET, ucs2StringSrc, utf8StringDst,
+                                  NO_BIDI, NO_NORMALIZATION, false);
 }
 
-bool CCharsetConverter::utf8ToSystem(std::string& stringSrcDst, bool failOnBadChar /*= false*/)
+
+bool CCharsetConverter::Utf8ToSystem(std::string& stringSrcDst)
 {
   std::string strSrc(stringSrcDst);
-  return CInnerConverter::stdConvert(Utf8ToSystem, strSrc, stringSrcDst, failOnBadChar);
+  return CInnerConverter::Convert(UTF8_CHARSET, "", strSrc, stringSrcDst,
+                                  NO_BIDI, NO_NORMALIZATION, false);
 }
 
-bool CCharsetConverter::systemToUtf8(const std::string& sysStringSrc, std::string& utf8StringDst, bool failOnBadChar /*= false*/)
+bool CCharsetConverter::SystemToUtf8(const std::string& sysStringSrc, std::string& utf8StringDst)
 {
-  return CInnerConverter::stdConvert(SystemToUtf8, sysStringSrc, utf8StringDst, failOnBadChar);
+  return CInnerConverter::Convert("", UTF8_CHARSET, sysStringSrc, utf8StringDst,
+                                  NO_BIDI, NO_NORMALIZATION, false);
 }
 
-bool CCharsetConverter::utf8logicalToVisualBiDi(const std::string& utf8StringSrc, std::string& utf8StringDst, bool failOnBadString /*= false*/)
+bool CCharsetConverter::TrySystemToUtf8(const std::string& sysStringSrc, std::string& utf8StringDst)
 {
-  utf8StringDst.clear();
-  std::u32string utf32flipped;
-  if (!utf8ToUtf32Visual(utf8StringSrc, utf32flipped, true, true, failOnBadString))
-    return false;
-
-  return CInnerConverter::stdConvert(Utf32ToUtf8, utf32flipped, utf8StringDst, failOnBadString);
+  return CInnerConverter::Convert("", UTF8_CHARSET, sysStringSrc, utf8StringDst,
+                                  NO_BIDI, NO_NORMALIZATION, true);
 }
 
-void CCharsetConverter::SettingOptionsCharsetsFiller(const CSetting* setting, std::vector< std::pair<std::string, std::string> >& list, std::string& current, void *data)
+bool CCharsetConverter::LogicalToVisualBiDi(const std::string& utf8StringSrc, std::string& utf8StringDst,
+                                            uint16_t bidiOptions /* = LTR | REMOVE_CONTROLS */)
 {
-  std::vector<std::string> vecCharsets = g_charsetConverter.getCharsetLabels();
-  sort(vecCharsets.begin(), vecCharsets.end(), sortstringbyname());
+  return CInnerConverter::Convert(UTF8_CHARSET, UTF8_CHARSET, utf8StringSrc, utf8StringDst,
+                                  bidiOptions, NO_NORMALIZATION, false);
+}
 
-  list.push_back(make_pair(g_localizeStrings.Get(13278), "DEFAULT")); // "Default"
-  for (int i = 0; i < (int) vecCharsets.size(); ++i)
-    list.push_back(make_pair(vecCharsets[i], g_charsetConverter.getCharsetNameByLabel(vecCharsets[i])));
+bool CCharsetConverter::LogicalToVisualBiDi(const std::u16string& utf16StringSrc, std::u16string& utf16StringDst,
+                                            uint16_t bidiOptions /* = LTR | REMOVE_CONTROLS */)
+{
+  return CInnerConverter::Convert(UTF16_CHARSET, UTF16_CHARSET, utf16StringSrc, utf16StringDst,
+                                  bidiOptions, NO_NORMALIZATION, false);
+}
+
+bool CCharsetConverter::LogicalToVisualBiDi(const std::wstring& wStringSrc, std::wstring& wStringDst,
+                                            uint16_t bidiOptions /* = LTR | REMOVE_CONTROLS */)
+{
+  return CInnerConverter::Convert(WCHAR_CHARSET, WCHAR_CHARSET, wStringSrc, wStringDst,
+                                  bidiOptions, NO_NORMALIZATION, false);
+}
+
+bool CCharsetConverter::LogicalToVisualBiDi(const std::u32string& utf32StringSrc, std::u32string& utf32StringDst,
+                                            uint16_t bidiOptions /* = LTR | REMOVE_CONTROLS */)
+{
+  return CInnerConverter::Convert(UTF32_CHARSET, UTF32_CHARSET, utf32StringSrc, utf32StringDst,
+                                  bidiOptions, NO_NORMALIZATION, false);
+}
+
+bool CCharsetConverter::ReverseRTL(const std::string& utf8StringSrc, std::string& utf8StringDst)
+{
+  return CInnerConverter::Convert(UTF8_CHARSET, UTF8_CHARSET, utf8StringSrc, utf8StringDst, 
+                                  RTL | WRITE_REVERSE, NO_NORMALIZATION, false);
+}
+
+bool CCharsetConverter::Utf8ToSystemSafe(const std::string& stringSrc, std::string& stringDst)
+{
+  stringDst = stringSrc;
+
+  return true;
+}
+
+bool CCharsetConverter::Utf8ToWSystemSafe(const std::string& stringSrc, std::wstring& stringDst)
+{
+  //W should be win32 only and requires no special handling, make sure we fail on bad chars
+  //to avoid any weird behavior
+  return CInnerConverter::Convert(UTF8_CHARSET, WCHAR_CHARSET, stringSrc, stringDst,
+                                  NO_BIDI, NO_NORMALIZATION, true);
+}
+
+bool CCharsetConverter::WToUtf8SystemSafe(const std::wstring& wStringSrc, std::string& utf8StringDst)
+{
+  return CInnerConverter::Convert(WCHAR_CHARSET, UTF8_CHARSET, wStringSrc, utf8StringDst,
+                                  NO_BIDI, NO_NORMALIZATION, true);
+}
+
+bool CCharsetConverter::Normalize(const std::string& source, std::string& destination, uint16_t options)
+{
+  return CInnerConverter::Convert(UTF8_CHARSET, UTF8_CHARSET, source, destination, NO_BIDI, options, false);
+}
+
+bool CCharsetConverter::Normalize(const std::u16string & source, std::u16string & destination, uint16_t options)
+{
+  return CInnerConverter::Convert(UTF16_CHARSET, UTF16_CHARSET, source, destination, NO_BIDI, options, false);
+}
+
+bool CCharsetConverter::Normalize(const std::u32string & source, std::u32string & destination, uint16_t options)
+{
+  return CInnerConverter::Convert(UTF32_CHARSET, UTF32_CHARSET, source, destination, NO_BIDI, options, false);
+}
+
+bool CCharsetConverter::Normalize(const std::wstring & source, std::wstring & destination, uint16_t options)
+{
+  return CInnerConverter::Convert(WCHAR_CHARSET, WCHAR_CHARSET, source, destination, NO_BIDI, options, false);
 }

--- a/xbmc/utils/CharsetConverter.h
+++ b/xbmc/utils/CharsetConverter.h
@@ -1,6 +1,4 @@
-#ifndef CCHARSET_CONVERTER
-#define CCHARSET_CONVERTER
-
+#pragma once
 /*
  *      Copyright (C) 2005-2013 Team XBMC
  *      http://xbmc.org
@@ -21,158 +19,659 @@
  *
  */
 
-#include <string>
-#include <utility>
-#include <vector>
-
-#include "settings/lib/ISettingCallback.h"
 #include "utils/GlobalsHandling.h"
 #include "utils/uXstrings.h"
 
-class CSetting;
+#include <string>
+#include <vector>
 
-class CCharsetConverter : public ISettingCallback
+/**
+ * \class CCharsetConverter
+ *
+ * Methods for converting text between different encodings
+ *
+ * There are a few conventions used in the method names that may be
+ * beneficial to know about
+ * Methods starting with Try* will try to convert the text and fail on any invalid byte sequence
+ *
+ * Regular methods will silently ignore invalid byte sequences and skip them,
+ * should only fail on errors like out of memory or completely invalid input
+ *
+ * Methods ending with SystemSafe are meant to be used for file system access,
+ * they provide additional checks to make sure that output is in a valid state
+ * for the platform. They also fail on invalid byte sequences to avoid passing
+ * an unkown filename to the system.
+ * Currently the only platform with special needs are OSX and iOS which require
+ * a special normalization form for it's file names.
+ */
+class CCharsetConverter
 {
 public:
-  CCharsetConverter();
 
-  virtual void OnSettingChanged(const CSetting* setting) override;
+  /** Options to specify BiDi text handling */
+  enum BiDiOptions
+  {
+    NO_BIDI = 0,        /**< No BiDi processing */
+    LTR = 1,            /**< text is mainly left-to-right */
+    RTL = 2,            /**< text is mainly right-to-left */
+    WRITE_REVERSE = 4,  /**< text should be reversed, e.g flip rtl text to ltr */
+    REMOVE_CONTROLS = 8 /**< bidi control characters such as LRE, RLE, PDF should be removed from the output*/
+  };
 
-  static void reset();
-  static void resetSystemCharset();
-  static void reinitCharsetsFromSettings(void);
-
-  static void clear();
+  /** Options to specify if any normalization should be performed and how*/
+  enum NormalizationOptions
+  {
+    NO_NORMALIZATION = 0, /**< no normalization should be performed */
+    COMPOSE = 1,          /**< text should be normalized to NFC e.g. merging ¨a into a single ä */
+    DECOMPOSE = 2,        /**< text should be normalized to NFD e.g. splitting ä into ¨a */
+    DECOMPOSE_MAC = 4     /**< text should be normalized to OSX specific NFD excluding certain ranges */
+  };
 
   /**
    * Convert UTF-8 string to UTF-32 string.
-   * No RTL logical-visual transformation is performed.
-   * @param utf8StringSrc       is source UTF-8 string to convert
-   * @param utf32StringDst      is output UTF-32 string, empty on any error
-   * @param failOnBadChar       if set to true function will fail on invalid character,
-   *                            otherwise invalid character will be skipped
-   * @return true on successful conversion, false on any error
+   *
+   * \param[in]  utf8StringSrc       is source UTF-8 string to convert
+   * \param[out] utf32StringDst      is output UTF-32 string, empty on any error
+   *
+   * \return true on successful conversion, false on any error
    */
-  static bool utf8ToUtf32(const std::string& utf8StringSrc, std::u32string& utf32StringDst, bool failOnBadChar = true);
+  static bool Utf8ToUtf32(const std::string& utf8StringSrc, std::u32string& utf32StringDst);
+  
   /**
    * Convert UTF-8 string to UTF-32 string.
-   * No RTL logical-visual transformation is performed.
-   * @param utf8StringSrc       is source UTF-8 string to convert
-   * @param failOnBadChar       if set to true function will fail on invalid character,
-   *                            otherwise invalid character will be skipped
-   * @return converted string on successful conversion, empty string on any error
+   * 
+   * \param[in] utf8StringSrc       is source UTF-8 string to convert
+   *
+   * \return converted string on successful conversion, empty string on any error
    */
-  static std::u32string utf8ToUtf32(const std::string& utf8StringSrc, bool failOnBadChar = true);
+  static std::u32string Utf8ToUtf32(const std::string& utf8StringSrc);
+
   /**
-   * Convert UTF-8 string to UTF-32 string.
-   * RTL logical-visual transformation is optionally performed.
+  * Convert UTF-8 string to UTF-16 string.
+  * 
+  * \param[in]  utf8StringSrc       is source UTF-8 string to convert
+  * \param[out] utf16StringDst      is output UTF-16 string, empty on any error
+  *
+  * \return true on successful conversion, false on any error
+  */
+  static bool Utf8ToUtf16(const std::string& utf8StringSrc, std::u16string& utf16StringDst);
+
+  /**
+  * Try to convert UTF-8 string to UTF-16.
+  * Will fail on invalid byte sequences.
+  *
+  * \param[in]  utf8StringSrc       is source UTF-8 string to convert
+  * \param[out] utf16StringDst      is output UTF-16 string, empty on any error
+  *
+  * \return true on successful conversion, false on any error
+  * \sa Utf8ToUtf16
+  */
+  static bool TryUtf8ToUtf16(const std::string& utf8StringSrc, std::u16string& utf16StringDst);
+  
+  /**
+  * Convert UTF-8 string to UTF-16 string.
+  * 
+  * \param[in] utf8StringSrc       is source UTF-8 string to convert
+  *
+  * \return converted string on successful conversion, empty string on any error
+  */
+  static std::u16string Utf8ToUtf16(const std::string& utf8StringSrc);
+  
+  /**
+   * Convert UTF-8 string to UTF-32 string and perform logical to visual processing
+   * on the string.
    * Use it for readable text, GUI strings etc.
-   * @param utf8StringSrc       is source UTF-8 string to convert
-   * @param utf32StringDst      is output UTF-32 string, empty on any error
-   * @param bVisualBiDiFlip     allow RTL visual-logical transformation if set to true, must be set
-   *                            to false is logical-visual transformation is already done
-   * @param forceLTRReadingOrder        force LTR reading order
-   * @param failOnBadChar       if set to true function will fail on invalid character,
-   *                            otherwise invalid character will be skipped
-   * @return true on successful conversion, false on any error
+   *
+   * \param[in]  utf8StringSrc        is source UTF-8 string to convert
+   * \param[out] utf32StringDst       is output UTF-32 string, empty on any error
+   * \param[in]  bidiOptions          options for logical to visual transformation
+   *                                  default is LTR | REMOVE_CONTROLS which should be fine
+   *                                  in most cases
+   *
+   * \return true on successful conversion, false on any error
+   * \sa CCharsetConverter::BiDiOptions
+   * \sa Utf8ToUtf32
    */
-  static bool utf8ToUtf32Visual(const std::string& utf8StringSrc, std::u32string& utf32StringDst, bool bVisualBiDiFlip = false, bool forceLTRReadingOrder = false, bool failOnBadChar = false);
+  static bool Utf8ToUtf32LogicalToVisual(const std::string& utf8StringSrc, std::u32string& utf32StringDst, 
+                                         uint16_t bidiOptions = LTR | REMOVE_CONTROLS);
+  
   /**
    * Convert UTF-32 string to UTF-8 string.
-   * No RTL visual-logical transformation is performed.
-   * @param utf32StringSrc      is source UTF-32 string to convert
-   * @param utf8StringDst       is output UTF-8 string, empty on any error
-   * @param failOnBadChar       if set to true function will fail on invalid character,
-   *                            otherwise invalid character will be skipped
-   * @return true on successful conversion, false on any error
+   * 
+   * \param[in]  utf32StringSrc      is source UTF-32 string to convert
+   * \param[out] utf8StringDst       is output UTF-8 string, empty on any error
+   *
+   * \return true on successful conversion, false on any error
+   * \sa Utf32ToUtf8(std::u32string&)
    */
-  static bool utf32ToUtf8(const std::u32string& utf32StringSrc, std::string& utf8StringDst, bool failOnBadChar = false);
+  static bool Utf32ToUtf8(const std::u32string& utf32StringSrc, std::string& utf8StringDst);
+  
   /**
    * Convert UTF-32 string to UTF-8 string.
-   * No RTL visual-logical transformation is performed.
-   * @param utf32StringSrc      is source UTF-32 string to convert
-   * @param failOnBadChar       if set to true function will fail on invalid character,
-   *                            otherwise invalid character will be skipped
-   * @return converted string on successful conversion, empty string on any error
+   * 
+   * \param[in] utf32StringSrc      is source UTF-32 string to convert
+   *
+   * \return converted string on successful conversion, empty string on any error
+   * \sa Utf32ToUtf8(std::u32string&, std::string&)
    */
-  static std::string utf32ToUtf8(const std::u32string& utf32StringSrc, bool failOnBadChar = false);
+  static std::string Utf32ToUtf8(const std::u32string& utf32StringSrc);
+  
   /**
-   * Convert UTF-32 string to wchar_t string (wstring).
-   * No RTL visual-logical transformation is performed.
-   * @param utf32StringSrc      is source UTF-32 string to convert
-   * @param wStringDst          is output wchar_t string, empty on any error
-   * @param failOnBadChar       if set to true function will fail on invalid character,
-   *                            otherwise invalid character will be skipped
-   * @return true on successful conversion, false on any error
+   * Convert UTF-8 string to wide string and perform logical to visual processing
+   * on the string.
+   * Use it for readable text, GUI strings etc.
+   *
+   * \param[in]  utf8StringSrc        is source UTF-8 string to convert
+   * \param[out] wStringDst           is output wide string, empty on any error
+   * \param[in]  bidiOptions          options for logical to visual transformation
+   *                                  default is LTR | REMOVE_CONTROLS which should be fine
+   *                                  in most cases
+   *
+   * \return true on successful conversion, false on any error
+   * \sa CCharsetConverter::BiDiOptions
+   * \sa Utf8ToW
+   * \sa Utf8ToUtf32LogicalToVisual
    */
-  static bool utf32ToW(const std::u32string& utf32StringSrc, std::wstring& wStringDst, bool failOnBadChar = false);
+  static bool Utf8ToWLogicalToVisual(const std::string& utf8StringSrc, std::wstring& wStringDst,
+                                     uint16_t bidiOptions = LTR | REMOVE_CONTROLS);
+
   /**
-   * Perform logical to visual flip.
-   * @param logicalStringSrc    is source string with logical characters order
-   * @param visualStringDst     is output string with visual characters order, empty on any error
-   * @param forceLTRReadingOrder        force LTR reading order
-   * @return true on success, false otherwise
+   * Convert UTF-8 string to wide string.
+   *
+   * \param[in]  utf8StringSrc       is source UTF-8 string to convert
+   * \param[out] wStringDst          is output wide string, empty on any error
+   *
+   * \return true on successful conversion, false on any error
+   * \sa Utf8ToWLogicalToVisual
+   * \sa Utf8ToWSystemSafe
    */
-  static bool utf32logicalToVisualBiDi(const std::u32string& logicalStringSrc, std::u32string& visualStringDst, bool forceLTRReadingOrder = false, bool failOnBadString = false);
+  static bool Utf8ToW(const std::string& utf8StringSrc, std::wstring& wStringDst);
+
   /**
-   * Strictly convert wchar_t string (wstring) to UTF-32 string.
-   * No RTL visual-logical transformation is performed.
-   * @param wStringSrc          is source wchar_t string to convert
-   * @param utf32StringDst      is output UTF-32 string, empty on any error
-   * @param failOnBadChar       if set to true function will fail on invalid character,
-   *                            otherwise invalid character will be skipped
-   * @return true on successful conversion, false on any error
+  * Convert UTF-8 string to wide string.
+  *
+  * \param[in]  utf8StringSrc       is source UTF-8 string to convert
+  * \param[out] wStringDst          is output wide string, empty on any error
+  *
+  * \return true on successful conversion, false on any error
+  * \sa Utf8ToWLogicalToVisual
+  * \sa Utf8ToWSystemSafe
+  * \sa Utf8ToW
    */
-  static bool wToUtf32(const std::wstring& wStringSrc, std::u32string& utf32StringDst, bool failOnBadChar = false);
+  static bool TryUtf8ToW(const std::string& utf8StringSrc, std::wstring& wStringDst);
 
-  static bool utf8ToW(const std::string& utf8StringSrc, std::wstring& wStringDst,
-                bool bVisualBiDiFlip = true, bool forceLTRReadingOrder = false,
-                bool failOnBadChar = false);
+  /**
+   * Convert UTF-8 string to wide string and perform extra processing
+   * to ensure that the string is valid for file system operations.
+   * Fails on invalid byte sequences.
+   *
+   * \param[in]  utf8StringSrc       is source UTF-8 string to convert
+   * \param[out] wStringDst          is output wide string, empty on any error
+   *
+   * \return true on successful conversion, false on any error
+   * \sa Utf8ToWLogicalToVisual
+   * \sa Utf8ToW
+   */
+  static bool Utf8ToWSystemSafe(const std::string& stringSrc, std::wstring& stringDst);
 
-  static bool utf16LEtoW(const std::u16string& utf16String, std::wstring& wString);
+  /**
+   * Convert wide string to UTF-8 string.
+   *
+   * \param[in]  wStringSrc             is source UTF-8 string to convert
+   * \param[out] utf8StringDst          is output wide string, empty on any error
+   *
+   * \return true on successful conversion, false on any error
+   * \sa TryWToUtf8
+   */
+  static bool WToUtf8(const std::wstring& wStringSrc, std::string& utf8StringDst);
 
-  static bool subtitleCharsetToUtf8(const std::string& stringSrc, std::string& utf8StringDst);
+  /**
+  * Convert wide string to UTF-8 string.
+  *
+  * \param[in]  wStringSrc             is source UTF-8 string to convert
+  * \param[out] utf8StringDst          is output wide string, empty on any error
+  *
+  * \return true on successful conversion, false on any error
+  * \sa WToUtf8
+  */
+  static bool TryWToUtf8(const std::wstring& wStringSrc, std::string& utf8StringDst);
 
-  static bool utf8ToStringCharset(const std::string& utf8StringSrc, std::string& stringDst);
+  /**
+   * Convert from the user selected subtitle encoding to UTF-8
+   *
+   * \param[in]  stringSrc             is source UTF-8 string to convert
+   * \param[out] utf8StringDst         is output wide string, empty on any error
+   *
+   * \return true on successful conversion, false on any error
+   */
+  static bool SubtitleCharsetToUtf8(const std::string& stringSrc, std::string& utf8StringDst);
 
-  static bool utf8ToStringCharset(std::string& stringSrcDst);
-  static bool utf8ToSystem(std::string& stringSrcDst, bool failOnBadChar = false);
-  static bool systemToUtf8(const std::string& sysStringSrc, std::string& utf8StringDst, bool failOnBadChar = false);
+  /**
+   * Convert UTF-8 string to the user selected GUI character set
+   *
+   * \param[in]  utf8StringSrc          is source UTF-8 string to convert
+   * \param[out] stringDst              is output wide string, empty on any error
+   *
+   * \return true on successful conversion, false on any error
+   */
+  static bool Utf8ToStringCharset(const std::string& utf8StringSrc, std::string& stringDst);
 
-  static bool utf8To(const std::string& strDestCharset, const std::string& utf8StringSrc, std::string& stringDst);
-  static bool utf8To(const std::string& strDestCharset, const std::string& utf8StringSrc, std::u16string& utf16StringDst);
-  static bool utf8To(const std::string& strDestCharset, const std::string& utf8StringSrc, std::u32string& utf32StringDst);
+  /**
+   * Convert UTF-8 string to the user selected GUI character set
+   *
+   * \param[in,out]  stringSrcDst       is source UTF-8 string to convert
+   *                                    Undefined value of stringSrcDst if conversion fails
+   *
+   * \return true on successful conversion, false on any error
+   */
+  static bool Utf8ToStringCharset(std::string& stringSrcDst);
 
-  static bool ToUtf8(const std::string& strSourceCharset, const std::string& stringSrc, std::string& utf8StringDst, bool failOnBadChar = false);
+  /**
+   * Convert UTF-8 string to UTF-16 big endian string.
+   *
+   * \param[in]  utf8StringSrc          is source UTF-8 string to convert
+   * \param[out] utf16StringDst         is output UTF-16 big endian, empty on any error
+   *
+   * \return true on successful conversion, false on any error
+   * \sa Utf8ToUtf16LE
+   * \sa Utf8ToUtf16
+   */
+  static bool Utf8ToUtf16BE(const std::string& utf8StringSrc, std::u16string& utf16StringDst);
 
-  static bool wToUTF8(const std::wstring& wStringSrc, std::string& utf8StringDst, bool failOnBadChar = false);
-  static bool utf16BEtoUTF8(const std::u16string& utf16StringSrc, std::string& utf8StringDst);
-  static bool utf16LEtoUTF8(const std::u16string& utf16StringSrc, std::string& utf8StringDst);
-  static bool ucs2ToUTF8(const std::u16string& ucs2StringSrc, std::string& utf8StringDst);
+  /**
+   * Convert UTF-8 string to UTF-16 little endian string.
+   * Only for special cases where endianness matters, prefer
+   * Utf8ToUtf16 for general use.
+   *
+   * \param[in]  utf8StringSrc          is source UTF-8 string to convert
+   * \param[out] utf16StringDst         is output UTF-16 little endian, empty on any error
+   *
+   * \return true on successful conversion, false on any error
+   * \sa Utf8ToUtf16BE
+   * \sa Utf8ToUtf16
+   */
+  static bool Utf8ToUtf16LE(const std::string& utf8StringSrc, std::u16string& utf16StringDst);
 
-  static bool utf8logicalToVisualBiDi(const std::string& utf8StringSrc, std::string& utf8StringDst, bool failOnBadString = false);
+  /**
+   * Convert UTF-8 string to system encoding, likely UTF-8 on Linux
+   * and Mac but can be just about anything
+   *
+   * \param[in,out]  utf8StringSrc          is source UTF-8 string to convert
+   *                                        Undefined value on errors
+   *
+   * \return true on successful conversion, false on any error
+   * \sa SystemToUtf8
+   * \sa Utf8To
+   */
+  static bool Utf8ToSystem(std::string& stringSrcDst);
 
-  static bool utf32ToStringCharset(const std::u32string& utf32StringSrc, std::string& stringDst);
+  /**
+   * Convert string in system encoding to UTF-8
+   *
+   * \param[in]  sysStringSrc          is source string in system encoding to convert
+   * \param[out] utf8StringDst         is output UTF-8 string, empty on any error
+   *
+   * \return true on successful conversion, false on any error
+   * \sa Utf8ToSystem
+   * \sa Utf8To
+   * \sa TrySystemToUtf8
+   */
+  static bool SystemToUtf8(const std::string& sysStringSrc, std::string& utf8StringDst);
 
-  static std::vector<std::string> getCharsetLabels();
-  static std::string getCharsetLabelByName(const std::string& charsetName);
-  static std::string getCharsetNameByLabel(const std::string& charsetLabel);
+  /**
+   * Try to convert string in system encoding to UTF-8.
+   * Will fail on invalid byte sequences.
+   *
+   * \param[in]  sysStringSrc         is source string in system encoding to convert
+   * \param[out] utf8StringDst        is output UTF-8 string, empty on any error
+   *
+   * \return true on successful conversion, false on any error
+   * \sa SystemToUtf8
+   * \sa Utf8To
+   */
+  static bool TrySystemToUtf8(const std::string& sysStringSrc, std::string& utf8StringDst);
 
-  static bool unknownToUTF8(std::string& stringSrcDst);
-  static bool unknownToUTF8(const std::string& stringSrc, std::string& utf8StringDst, bool failOnBadChar = false);
+  /**
+   * Convert UTF-8 string to specified 8-bit encoding
+   *
+   * \param[in]  strDestCharset         specify destination encoding
+   *                                    e.g. US-ASCII or CP-1252
+   * \param[in]  utf8StringSrc          is source UTF-8 string to convert
+   * \param[out] stringDst              is output string in specified encoding
+   *
+   * \return true on successful conversion, false on any error
+   * \sa Utf8To(const std::string&, const std::string&, std::u16string&)
+   * \sa Utf8To(const std::string&, const std::string&, std::u32string&)
+   */
+  static bool Utf8To(const std::string& strDestCharset, const std::string& utf8StringSrc, std::string& stringDst);
 
-  static bool toW(const std::string& stringSrc, std::wstring& wStringDst, const std::string& enc);
-  static bool fromW(const std::wstring& wStringSrc, std::string& stringDst, const std::string& enc);
+  /**
+   * Convert UTF-8 string to specified 16-bit encoding
+   *
+   * \param[in]  strDestCharset         specify destination encoding
+   *                                    e.g. UTF-16 or UTF-16LE
+   * \param[in]  utf8StringSrc          is source UTF-8 string to convert
+   * \param[out] utf16StringDst         is output string in specified encoding
+   *
+   * \return true on successful conversion, false on any error
+   * \sa Utf8To(const std::string&, const std::string&, std::string&)
+   * \sa Utf8To(const std::string&, const std::string&, std::u32string&)
+   */
+  static bool Utf8To(const std::string& strDestCharset, const std::string& utf8StringSrc, std::u16string& utf16StringDst);
 
-  static void SettingOptionsCharsetsFiller(const CSetting* setting, std::vector< std::pair<std::string, std::string> >& list, std::string& current, void *data);
+  /**
+   * Convert UTF-8 string to specified 32-bit encoding
+   *
+   * \param[in]  strDestCharset         specify destination encoding
+   *                                    e.g. UTF-32 or UTF-32LE
+   * \param[in]  utf8StringSrc          is source UTF-8 string to convert
+   * \param[out] utf32StringDst         is output string in specified encoding
+   *
+   * \return true on successful conversion, false on any error
+   * \sa Utf8To(const std::string&, const std::string&, std::string&)
+   * \sa Utf8To(const std::string&, const std::string&, std::u16string&)
+   */
+  static bool Utf8To(const std::string& strDestCharset, const std::string& utf8StringSrc, std::u32string& utf32StringDst);
+
+  /**
+   * Convert specified 8-bit encoding to UTF-8
+   *
+   * \param[in]  strSourceCharset         specify source encoding
+   *                                      e.g. US-ASCII or CP-1252
+   * \param[in]  stringSrc                is source 8-bit string to convert
+   * \param[out] utf8StringDst            is output string in UTF-8
+   *
+   * \return true on successful conversion, false on any error
+   * \sa TryToUtf8
+   */
+  static bool ToUtf8(const std::string& strSourceCharset, const std::string& stringSrc, std::string& utf8StringDst);
+
+  /**
+   * Try to convert specified 8-bit encoding to UTF-8.
+   * Fails on any bad byte sequence
+   *
+   * \param[in]  strSourceCharset         specify source encoding
+   *                                      e.g. US-ASCII or CP-1252
+   * \param[in]  stringSrc                is source 8-bit string to convert
+   * \param[out] utf8StringDst            is output string in UTF-8
+   *
+   * \return true on successful conversion, false on any error
+   * \sa ToUtf8
+   */
+  static bool TryToUtf8(const std::string& strSourceCharset, const std::string& stringSrc, std::string& utf8StringDst);
+
+  /**
+   * Convert UTF-16 big endian to UTF-8
+   *
+   * \param[in]  utf16StringSrc           is source UTF-16 big endian string to convert
+   * \param[out] utf8StringDst            is output string in UTF-8
+   *
+   * \return true on successful conversion, false on any error
+   * \sa Utf16ToUtf8
+   * \sa Utf16LEToUtf8
+   */
+  static bool Utf16BEToUtf8(const std::u16string& utf16StringSrc, std::string& utf8StringDst);
+
+  /**
+  * Convert UTF-16 little endian to UTF-8
+  *
+  * \param[in]  utf16StringSrc           is source UTF-16 little endian string to convert
+  * \param[out] utf8StringDst            is output string in UTF-8
+  *
+  * \return true on successful conversion, false on any error
+  * \sa Utf16ToUtf8
+  * \sa Utf16BEToUtf8
+  */
+  static bool Utf16LEToUtf8(const std::u16string& utf16StringSrc, std::string& utf8StringDst);
+
+  /**
+  * Convert UTF-16 to UTF-8
+  *
+  * \param[in]  utf16StringSrc           is source UTF-16 string to convert
+  * \param[out] utf8StringDst            is output string in UTF-8
+  *
+  * \return true on successful conversion, false on any error
+  * \sa Utf16ToUtf8
+  * \sa Utf16LEToUtf8
+  */
+  static bool Utf16ToUtf8(const std::u16string& utf16StringSrc, std::string& utf8StringDst);
+
+/**
+   * Try to convert string in system encoding to UTF-8.
+   * Will fail on invalid byte sequences.
+   *
+   * \param[in]  utf16StringSrc           is source UTF-16 string to convert
+   * \param[out] utf8StringDst            is output string in UTF-8
+   *
+   * \return true on successful conversion, false on any error
+   * \sa Utf16ToUtf8
+   * \sa Utf16LEToUtf8
+   * \sa Utf16BEToUtf8
+   */
+  static bool TryUtf16ToUtf8(const std::u16string utf16StringSrc, std::string& utf8StringDst);
+
+  /**
+   * Convert UCS-2 to UTF-8
+   * This is really another name for Utf16LEToUtf8, technically
+   * UCS-2 is only big endian but our use case requires little endian
+   * conversion
+   *
+   * \param[in]  utf16StringSrc           is source UCS-2 little endian string to convert
+   * \param[out] utf8StringDst            is output string in UTF-8
+   *
+   * \return true on successful conversion, false on any error
+   * \sa Utf16ToUtf8
+   * \sa Utf16LEToUtf8
+   * \sa Utf16BEToUtf8
+   */
+  static bool Ucs2ToUtf8(const std::u16string& ucs2StringSrc, std::string& utf8StringDst);
+
+  /**
+   * Perform logical to visual processing on the string.
+   * Use it for readable text, GUI strings etc.
+   *
+   * \param[in]  utf8StringSrc        is source UTF-8 string to process
+   * \param[out] utf8StringDst        is output UTF-8 string, empty on any error
+   * \param[in]  bidiOptions          options for logical to visual transformation
+   *                                  default is LTR | REMOVE_CONTROLS which should be fine
+   *                                  in most cases
+   *
+   * \return true on successful conversion, false on any error
+   * \sa CCharsetConverter::BiDiOptions
+   * \sa LogicalToVisualBiDi(const std::u16string&, std::u16string&, uint16_t)
+   * \sa LogicalToVisualBiDi(const std::wstring&, std::wstring&, uint16_t)
+   * \sa LogicalToVisualBiDi(const std::u32string, std::u32string&, uint16_t)
+   */
+  static bool LogicalToVisualBiDi(const std::string& utf8StringSrc, std::string& utf8StringDst, 
+                                  uint16_t bidiOptions = LTR | REMOVE_CONTROLS);
+
+  /**
+   * Perform logical to visual processing on the string.
+   * Use it for readable text, GUI strings etc.
+   *
+   * \param[in]  utf16StringSrc       is source UTF-16 string to process
+   * \param[out] utf16StringDst       is output UTF-16 string, empty on any error
+   * \param[in]  bidiOptions          options for logical to visual transformation
+   *                                  default is LTR | REMOVE_CONTROLS which should be fine
+   *                                  in most cases
+   *
+   * \return true on successful conversion, false on any error
+   * \sa CCharsetConverter::BiDiOptions
+   * \sa LogicalToVisualBiDi(const std::string&, std::string&, uint16_t)
+   * \sa LogicalToVisualBiDi(const std::wstring&, std::wstring&, uint16_t)
+   * \sa LogicalToVisualBiDi(const std::u32string, std::u32string&, uint16_t)
+   */
+  static bool LogicalToVisualBiDi(const std::u16string& utf16StringSrc, std::u16string& utf16StringDst,
+                                  uint16_t bidiOptions = LTR | REMOVE_CONTROLS);
+
+  /**
+   * Perform logical to visual processing on the string.
+   * Use it for readable text, GUI strings etc.
+   *
+   * \param[in]  wStringSrc           is source wide string to process
+   * \param[out] wStringDst           is output wide string, empty on any error
+   * \param[in]  bidiOptions          options for logical to visual transformation
+   *                                  default is LTR | REMOVE_CONTROLS which should be fine
+   *                                  in most cases
+   *
+   * \return true on successful conversion, false on any error
+   * \sa CCharsetConverter::BiDiOptions
+   * \sa LogicalToVisualBiDi(const std::string&, std::string&, uint16_t)
+   * \sa LogicalToVisualBiDi(const std::u16string&, std::u16string&, uint16_t)
+   * \sa LogicalToVisualBiDi(const std::u32string, std::u32string&, uint16_t)
+   */
+  static bool LogicalToVisualBiDi(const std::wstring& wStringSrc, std::wstring& wStringDst,
+                                  uint16_t bidiOptions = LTR | REMOVE_CONTROLS);
+
+  /**
+   * Perform logical to visual processing on the string.
+   * Use it for readable text, GUI strings etc.
+   *
+   * \param[in]  utf32StringSrc       is source UTF-32 string to process
+   * \param[out] utf32StringDst       is output UTF-32 string, empty on any error
+   * \param[in]  bidiOptions          options for logical to visual transformation
+   *                                  default is LTR | REMOVE_CONTROLS which should be fine
+   *                                  in most cases
+   *
+   * \return true on successful conversion, false on any error
+   * \sa CCharsetConverter::BiDiOptions
+   * \sa LogicalToVisualBiDi(const std::string&, std::string&, uint16_t)
+   * \sa LogicalToVisualBiDi(const std::u16string&, std::u16string&, uint16_t)
+   * \sa LogicalToVisualBiDi(const std::wstring&, std::wstring&, uint16_t)
+   */
+  static bool LogicalToVisualBiDi(const std::u32string& utf32StringSrc, std::u32string& utf32StringDst,
+                                  uint16_t bidiOptions = LTR | REMOVE_CONTROLS);
+
+  /**
+   * Reverse an RTL string, taking into account encoding
+   *
+   * \param[in]  utf8StringSrc     RTL string to be reversed in utf8 encoding
+   * \param[out] utf8StringDst     Destination for the reversed string
+   *
+   * \return true in success, false otherwise
+   */
+  static bool ReverseRTL(const std::string& utf8StringSrc, std::string& utf8StringDst);
+
+  /**
+   * Convert from unkown encoding to UTF-8
+   *
+   * \param[in,out]  stringSrcDst        is source string to convert and destination string
+   *                                     Undefined value on error
+   *
+   * \return true on successful conversion, false on any error
+   * \sa unkownToUTF8(const std::string&, std::string&)
+   */
+  static bool UnknownToUtf8(std::string& stringSrcDst);
+
+  /**
+   * Convert from unkown encoding to UTF-8
+   *
+   * \param[in]  stringSrcDst       is source string to convert and destination string
+   * \param[out] utf8StringDst      is output UTF-8 string
+   *
+   * \return true on successful conversion, false on any error
+   * \sa unkownToUTF8(std::string&)
+   */
+  static bool UnknownToUtf8(const std::string& stringSrc, std::string& utf8StringDst);
+
+  /**
+   * Convert UTF-8 string to system encoding and perform extra processing
+   * to ensure that the string is valid for file system operations.
+   * Fails on invalid byte sequences.
+   *
+   * \param[in]  stringSrc        is source UTF-8 string to convert
+   * \param[out] stringDst        is output string in system encoding
+   *
+   * \return true on successful conversion, false on any error
+   */
+  static bool Utf8ToSystemSafe(const std::string& stringSrc, std::string& stringDst);
+
+  /**
+   * Convert wide string to UTF-8 string and perform extra processing
+   * to ensure that the string is valid for file system operations.
+   * Fails on invalid byte sequences.
+   *
+   * \param[in]  wStringSrc          is source wide string to convert
+   * \param[out] utf8StringDst       is output UTF-8 string
+   *
+   * \return true on successful conversion, false on any error
+   */
+  static bool WToUtf8SystemSafe(const std::wstring& wStringSrc, std::string& utf8StringDst);
+
+  /**
+   * Normalize a string to composed or decomposed form
+   *
+   * It's also possible to use the special mac decomposed form for any special
+   * needs on darwin platforms
+   *
+   * \param[in]   source        String to normalize
+   * \param[out]  destination   String to store the normalized version
+   * \param[in]   options       Specify which type of normalization to use
+   * \return true on success, false on any failures
+   *
+   * \sa NormalizationOptions
+   * \sa Normalize(const std::u16string&, std::u16string&, uint16_t)
+   * \sa Normalize(const std::u32string&, std::u32string&, uint16_t)
+   * \sa Normalize(const std::wstring&, std::wstring&, uint16_t)
+   */
+  static bool Normalize(const std::string& source, std::string& destination, uint16_t options);
+
+  /**
+  * Normalize a string to composed or decomposed form
+  *
+  * It's also possible to use the special mac decomposed form for any special
+  * needs on darwin platforms
+  *
+  * \param[in]   source        String to normalize
+  * \param[out]  destination   String to store the normalized version
+  * \param[in]   options       Specify which type of normalization to use
+  * \return true on success, false on any failures
+  *
+  * \sa NormalizationOptions
+  * \sa Normalize(const std::string&, std::string&, uint16_t)
+  * \sa Normalize(const std::u32string&, std::u32string&, uint16_t)
+  * \sa Normalize(const std::wstring&, std::wstring&, uint16_t)
+  */
+  static bool Normalize(const std::u16string& source, std::u16string& destination, uint16_t options);
+  
+  /**
+  * Normalize a string to composed or decomposed form
+  *
+  * It's also possible to use the special mac decomposed form for any special
+  * needs on darwin platforms
+  *
+  * \param[in]   source        String to normalize
+  * \param[out]  destination   String to store the normalized version
+  * \param[in]   options       Specify which type of normalization to use
+  * \return true on success, false on any failures
+  *
+  * \sa NormalizationOptions
+  * \sa Normalize(const std::string&, std::string&, uint16_t)
+  * \sa Normalize(const std::u16string&, std::u16string&, uint16_t)
+  * \sa Normalize(const std::wstring&, std::wstring&, uint16_t)
+  */
+  static bool Normalize(const std::u32string& source, std::u32string& destination, uint16_t options);
+  
+  /**
+  * Normalize a string to composed or decomposed form
+  *
+  * It's also possible to use the special mac decomposed form for any special
+  * needs on darwin platforms
+  *
+  * \param[in]   source        String to normalize
+  * \param[out]  destination   String to store the normalized version
+  * \param[in]   options       Specify which type of normalization to use
+  * \return true on success, false on any failures
+  *
+  * \sa NormalizationOptions
+  * \sa Normalize(const std::string&, std::string&, uint16_t)
+  * \sa Normalize(const std::u16string&, std::u16string&, uint16_t)
+  * \sa Normalize(const std::u32string&, std::u32string&, uint16_t)
+  */
+  static bool Normalize(const std::wstring& source, std::wstring& destination, uint16_t options);
 private:
-  static void resetUserCharset(void);
-  static void resetSubtitleCharset(void);
 
-  static const int m_Utf8CharMinSize, m_Utf8CharMaxSize;
   class CInnerConverter;
 };
 
-XBMC_GLOBAL_REF(CCharsetConverter,g_charsetConverter);
-#define g_charsetConverter XBMC_GLOBAL_USE(CCharsetConverter)
-#endif
+XBMC_GLOBAL(CCharsetConverter,g_charsetConverter);

--- a/xbmc/utils/CharsetConverter.h
+++ b/xbmc/utils/CharsetConverter.h
@@ -673,5 +673,3 @@ private:
 
   class CInnerConverter;
 };
-
-XBMC_GLOBAL(CCharsetConverter,g_charsetConverter);

--- a/xbmc/utils/CharsetDetection.cpp
+++ b/xbmc/utils/CharsetDetection.cpp
@@ -350,7 +350,7 @@ bool CCharsetDetection::ConvertHtmlToUtf8(const std::string& htmlContent, std::s
     usedHtmlCharset = "WINDOWS-1252";
 
   CLog::Log(LOGWARNING, "%s: Can't correctly convert to UTF-8 charset, converting as \"%s\"", __FUNCTION__, usedHtmlCharset.c_str());
-  g_charsetConverter.ToUtf8(usedHtmlCharset, htmlContent, converted, false);
+  g_charsetConverter.ToUtf8(usedHtmlCharset, htmlContent, converted);
 
   return false;
 }
@@ -396,7 +396,7 @@ bool CCharsetDetection::ConvertPlainTextToUtf8(const std::string& textContent, s
   }
 
   // try system default charset
-  if (g_charsetConverter.systemToUtf8(textContent, converted, true))
+  if (g_charsetConverter.TrySystemToUtf8(textContent, converted))
   {
     usedCharset = "char"; // synonym to system charset
     return true;
@@ -421,7 +421,7 @@ bool CCharsetDetection::ConvertPlainTextToUtf8(const std::string& textContent, s
     usedCharset = "WINDOWS-1252";
 
   CLog::Log(LOGWARNING, "%s: Can't correctly convert to UTF-8 charset, converting as \"%s\"", __FUNCTION__, usedCharset.c_str());
-  g_charsetConverter.ToUtf8(usedCharset, textContent, converted, false);
+  g_charsetConverter.ToUtf8(usedCharset, textContent, converted);
 
   return false;
 }
@@ -434,7 +434,7 @@ bool CCharsetDetection::checkConversion(const std::string& srcCharset, const std
 
   if (srcCharset != "UTF-8")
   {
-    if (g_charsetConverter.ToUtf8(srcCharset, src, dst, true))
+    if (g_charsetConverter.TryToUtf8(srcCharset, src, dst))
       return true;
   }
   else if (CUtf8Utils::isValidUtf8(src))

--- a/xbmc/utils/CharsetDetection.cpp
+++ b/xbmc/utils/CharsetDetection.cpp
@@ -108,7 +108,7 @@ bool CCharsetDetection::DetectXmlEncoding(const char* const xmlContent, const si
   /* have some guessed encoding, try to use it */
   std::string convertedXml;
   /* use 'm_XmlDeclarationMaxLength * 4' below for UTF-32-like encodings */
-  if (!g_charsetConverter.ToUtf8(guessedEncoding, std::string(xmlContent, std::min(contentLength, m_XmlDeclarationMaxLength * 4)), convertedXml)
+  if (!CCharsetConverter::ToUtf8(guessedEncoding, std::string(xmlContent, std::min(contentLength, m_XmlDeclarationMaxLength * 4)), convertedXml)
       || convertedXml.empty())
     return false;  /* can't convert, guessed encoding is wrong */
 
@@ -350,7 +350,7 @@ bool CCharsetDetection::ConvertHtmlToUtf8(const std::string& htmlContent, std::s
     usedHtmlCharset = "WINDOWS-1252";
 
   CLog::Log(LOGWARNING, "%s: Can't correctly convert to UTF-8 charset, converting as \"%s\"", __FUNCTION__, usedHtmlCharset.c_str());
-  g_charsetConverter.ToUtf8(usedHtmlCharset, htmlContent, converted);
+  CCharsetConverter::ToUtf8(usedHtmlCharset, htmlContent, converted);
 
   return false;
 }
@@ -396,7 +396,7 @@ bool CCharsetDetection::ConvertPlainTextToUtf8(const std::string& textContent, s
   }
 
   // try system default charset
-  if (g_charsetConverter.TrySystemToUtf8(textContent, converted))
+  if (CCharsetConverter::TrySystemToUtf8(textContent, converted))
   {
     usedCharset = "char"; // synonym to system charset
     return true;
@@ -421,7 +421,7 @@ bool CCharsetDetection::ConvertPlainTextToUtf8(const std::string& textContent, s
     usedCharset = "WINDOWS-1252";
 
   CLog::Log(LOGWARNING, "%s: Can't correctly convert to UTF-8 charset, converting as \"%s\"", __FUNCTION__, usedCharset.c_str());
-  g_charsetConverter.ToUtf8(usedCharset, textContent, converted);
+  CCharsetConverter::ToUtf8(usedCharset, textContent, converted);
 
   return false;
 }
@@ -434,7 +434,7 @@ bool CCharsetDetection::checkConversion(const std::string& srcCharset, const std
 
   if (srcCharset != "UTF-8")
   {
-    if (g_charsetConverter.TryToUtf8(srcCharset, src, dst))
+    if (CCharsetConverter::TryToUtf8(srcCharset, src, dst))
       return true;
   }
   else if (CUtf8Utils::isValidUtf8(src))

--- a/xbmc/utils/RssReader.cpp
+++ b/xbmc/utils/RssReader.cpp
@@ -293,7 +293,13 @@ void CRssReader::GetNewsItems(TiXmlElement* channelXmlNode, int iFeed)
 
           std::wstring unicodeText, unicodeText2;
 
-          g_charsetConverter.utf8ToW(htmlText, unicodeText2, m_rtlText);
+          if (m_rtlText)
+          {
+            std::string htmlText2(htmlText);
+            g_charsetConverter.ReverseRTL(htmlText2, htmlText);
+          }
+
+          g_charsetConverter.Utf8ToW(htmlText, unicodeText2);
           html.ConvertHTMLToW(unicodeText2, unicodeText);
 
           mTagElements.insert(StrPair(*i, unicodeText));
@@ -357,7 +363,12 @@ bool CRssReader::Parse(int iFeed)
     {
       std::string strChannel = titleNode->FirstChild()->Value();
       std::wstring strChannelUnicode;
-      g_charsetConverter.utf8ToW(strChannel, strChannelUnicode, m_rtlText);
+      if (m_rtlText)
+      {
+        std::string strChannelTemp(strChannel);
+        g_charsetConverter.ReverseRTL(strChannelTemp, strChannel);
+      }
+      g_charsetConverter.Utf8ToW(strChannel, strChannelUnicode);
       AddString(strChannelUnicode, RSS_COLOR_CHANNEL, iFeed);
 
       AddString(L":", RSS_COLOR_CHANNEL, iFeed);

--- a/xbmc/utils/RssReader.cpp
+++ b/xbmc/utils/RssReader.cpp
@@ -296,10 +296,10 @@ void CRssReader::GetNewsItems(TiXmlElement* channelXmlNode, int iFeed)
           if (m_rtlText)
           {
             std::string htmlText2(htmlText);
-            g_charsetConverter.ReverseRTL(htmlText2, htmlText);
+            CCharsetConverter::ReverseRTL(htmlText2, htmlText);
           }
 
-          g_charsetConverter.Utf8ToW(htmlText, unicodeText2);
+          CCharsetConverter::Utf8ToW(htmlText, unicodeText2);
           html.ConvertHTMLToW(unicodeText2, unicodeText);
 
           mTagElements.insert(StrPair(*i, unicodeText));
@@ -366,9 +366,9 @@ bool CRssReader::Parse(int iFeed)
       if (m_rtlText)
       {
         std::string strChannelTemp(strChannel);
-        g_charsetConverter.ReverseRTL(strChannelTemp, strChannel);
+        CCharsetConverter::ReverseRTL(strChannelTemp, strChannel);
       }
-      g_charsetConverter.Utf8ToW(strChannel, strChannelUnicode);
+      CCharsetConverter::Utf8ToW(strChannel, strChannelUnicode);
       AddString(strChannelUnicode, RSS_COLOR_CHANNEL, iFeed);
 
       AddString(L":", RSS_COLOR_CHANNEL, iFeed);

--- a/xbmc/utils/ScraperParser.cpp
+++ b/xbmc/utils/ScraperParser.cpp
@@ -509,10 +509,10 @@ void CScraperParser::Clean(std::string& strDirty)
     {
       strBuffer = strDirty.substr(i+14,i2-i-14);
       std::wstring wbuffer;
-      g_charsetConverter.Utf8ToW(strBuffer, wbuffer);
+      CCharsetConverter::Utf8ToW(strBuffer, wbuffer);
       std::wstring wConverted;
       HTML::CHTMLUtil::ConvertHTMLToW(wbuffer,wConverted);
-      g_charsetConverter.WToUtf8(wConverted, strBuffer);
+      CCharsetConverter::WToUtf8(wConverted, strBuffer);
       StringUtils::Trim(strBuffer);
       ConvertJSON(strBuffer);
       strDirty.replace(i, i2-i+14, strBuffer);

--- a/xbmc/utils/ScraperParser.cpp
+++ b/xbmc/utils/ScraperParser.cpp
@@ -509,10 +509,10 @@ void CScraperParser::Clean(std::string& strDirty)
     {
       strBuffer = strDirty.substr(i+14,i2-i-14);
       std::wstring wbuffer;
-      g_charsetConverter.utf8ToW(strBuffer, wbuffer, false, false, false);
+      g_charsetConverter.Utf8ToW(strBuffer, wbuffer);
       std::wstring wConverted;
       HTML::CHTMLUtil::ConvertHTMLToW(wbuffer,wConverted);
-      g_charsetConverter.wToUTF8(wConverted, strBuffer, false);
+      g_charsetConverter.WToUtf8(wConverted, strBuffer);
       StringUtils::Trim(strBuffer);
       ConvertJSON(strBuffer);
       strDirty.replace(i, i2-i+14, strBuffer);

--- a/xbmc/utils/ScraperUrl.cpp
+++ b/xbmc/utils/ScraperUrl.cpp
@@ -272,7 +272,7 @@ bool CScraperUrl::Get(const SUrlEntry& scrURL, std::string& strHTML, XFILE::CCur
     {
       CLog::Log(LOGDEBUG, "%s: Using \"%s\" charset for XML \"%s\"", __FUNCTION__, realXmlCharset.c_str(), scrURL.m_url.c_str());
       std::string converted;
-      g_charsetConverter.ToUtf8(realXmlCharset, strHTML, converted);
+      CCharsetConverter::ToUtf8(realXmlCharset, strHTML, converted);
       strHTML = converted;
     }
   }
@@ -292,7 +292,7 @@ bool CScraperUrl::Get(const SUrlEntry& scrURL, std::string& strHTML, XFILE::CCur
     if (reportedCharset != "UTF-8")
     {
       std::string converted;
-      g_charsetConverter.ToUtf8(reportedCharset, strHTML, converted);
+      CCharsetConverter::ToUtf8(reportedCharset, strHTML, converted);
       strHTML = converted;
     }
   }

--- a/xbmc/utils/SortUtils.cpp
+++ b/xbmc/utils/SortUtils.cpp
@@ -710,7 +710,7 @@ void SortUtils::Sort(SortBy sortBy, SortOrder sortOrder, SortAttribute attribute
         }
 
         std::wstring sortLabel;
-        g_charsetConverter.Utf8ToW(preparator(attributes, *item), sortLabel, false);
+        CCharsetConverter::Utf8ToW(preparator(attributes, *item), sortLabel);
         item->insert(std::pair<Field, CVariant>(FieldSort, CVariant(sortLabel)));
       }
 
@@ -749,7 +749,7 @@ void SortUtils::Sort(SortBy sortBy, SortOrder sortOrder, SortAttribute attribute
         }
 
         std::wstring sortLabel;
-        g_charsetConverter.Utf8ToW(preparator(attributes, **item), sortLabel, false);
+        CCharsetConverter::Utf8ToW(preparator(attributes, **item), sortLabel);
         (*item)->insert(std::pair<Field, CVariant>(FieldSort, CVariant(sortLabel)));
       }
 

--- a/xbmc/utils/SortUtils.cpp
+++ b/xbmc/utils/SortUtils.cpp
@@ -710,7 +710,7 @@ void SortUtils::Sort(SortBy sortBy, SortOrder sortOrder, SortAttribute attribute
         }
 
         std::wstring sortLabel;
-        g_charsetConverter.utf8ToW(preparator(attributes, *item), sortLabel, false);
+        g_charsetConverter.Utf8ToW(preparator(attributes, *item), sortLabel, false);
         item->insert(std::pair<Field, CVariant>(FieldSort, CVariant(sortLabel)));
       }
 
@@ -749,7 +749,7 @@ void SortUtils::Sort(SortBy sortBy, SortOrder sortOrder, SortAttribute attribute
         }
 
         std::wstring sortLabel;
-        g_charsetConverter.utf8ToW(preparator(attributes, **item), sortLabel, false);
+        g_charsetConverter.Utf8ToW(preparator(attributes, **item), sortLabel, false);
         (*item)->insert(std::pair<Field, CVariant>(FieldSort, CVariant(sortLabel)));
       }
 

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -376,9 +376,9 @@ void StringUtils::ToLower(std::wstring &str)
 void StringUtils::ToCapitalize(std::string &str)
 {
   std::wstring wstr;
-  g_charsetConverter.utf8ToW(str, wstr);
+  CCharsetConverter::Utf8ToW(str, wstr);
   ToCapitalize(wstr);
-  g_charsetConverter.wToUTF8(wstr, str);
+  CCharsetConverter::WToUtf8(wstr, str);
 }
 
 void StringUtils::ToCapitalize(std::wstring &str)

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -787,7 +787,7 @@ std::string CSysInfo::GetManufacturerName(void)
       DWORD valType;
       if (RegQueryValueExW(hKey, L"SystemManufacturer", NULL, &valType, (LPBYTE)buf, &bufSize) == ERROR_SUCCESS && valType == REG_SZ)
       {
-        g_charsetConverter.WToUtf8(std::wstring(buf, bufSize / sizeof(wchar_t)), manufName);
+        CCharsetConverter::WToUtf8(std::wstring(buf, bufSize / sizeof(wchar_t)), manufName);
         size_t zeroPos = manufName.find(char(0));
         if (zeroPos != std::string::npos)
           manufName.erase(zeroPos); // remove any extra zero-terminations
@@ -835,7 +835,7 @@ std::string CSysInfo::GetModelName(void)
       DWORD valType; 
       if (RegQueryValueExW(hKey, L"SystemProductName", NULL, &valType, (LPBYTE)buf, &bufSize) == ERROR_SUCCESS && valType == REG_SZ)
       {
-        g_charsetConverter.WToUtf8(std::wstring(buf, bufSize / sizeof(wchar_t)), modelName);
+        CCharsetConverter::WToUtf8(std::wstring(buf, bufSize / sizeof(wchar_t)), modelName);
         size_t zeroPos = modelName.find(char(0));
         if (zeroPos != std::string::npos)
           modelName.erase(zeroPos); // remove any extra zero-terminations

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -787,7 +787,7 @@ std::string CSysInfo::GetManufacturerName(void)
       DWORD valType;
       if (RegQueryValueExW(hKey, L"SystemManufacturer", NULL, &valType, (LPBYTE)buf, &bufSize) == ERROR_SUCCESS && valType == REG_SZ)
       {
-        g_charsetConverter.wToUTF8(std::wstring(buf, bufSize / sizeof(wchar_t)), manufName);
+        g_charsetConverter.WToUtf8(std::wstring(buf, bufSize / sizeof(wchar_t)), manufName);
         size_t zeroPos = manufName.find(char(0));
         if (zeroPos != std::string::npos)
           manufName.erase(zeroPos); // remove any extra zero-terminations
@@ -835,7 +835,7 @@ std::string CSysInfo::GetModelName(void)
       DWORD valType; 
       if (RegQueryValueExW(hKey, L"SystemProductName", NULL, &valType, (LPBYTE)buf, &bufSize) == ERROR_SUCCESS && valType == REG_SZ)
       {
-        g_charsetConverter.wToUTF8(std::wstring(buf, bufSize / sizeof(wchar_t)), modelName);
+        g_charsetConverter.WToUtf8(std::wstring(buf, bufSize / sizeof(wchar_t)), modelName);
         size_t zeroPos = modelName.find(char(0));
         if (zeroPos != std::string::npos)
           modelName.erase(zeroPos); // remove any extra zero-terminations

--- a/xbmc/utils/XBMCTinyXML.cpp
+++ b/xbmc/utils/XBMCTinyXML.cpp
@@ -213,7 +213,7 @@ bool CXBMCTinyXML::TryParse(const std::string& data, const std::string& tryDataC
     std::string converted;
     /* some wrong conversions can leave US-ASCII XML header and structure untouched but break non-English data
      * so conversion must fail on wrong character and then other encodings will be tried */
-    if (!g_charsetConverter.TryToUtf8(tryDataCharset, data, converted) || converted.empty())
+    if (!CCharsetConverter::TryToUtf8(tryDataCharset, data, converted) || converted.empty())
       return false; // can't convert data
 
     InternalParse(converted, TIXML_ENCODING_UTF8);

--- a/xbmc/utils/XBMCTinyXML.cpp
+++ b/xbmc/utils/XBMCTinyXML.cpp
@@ -213,7 +213,7 @@ bool CXBMCTinyXML::TryParse(const std::string& data, const std::string& tryDataC
     std::string converted;
     /* some wrong conversions can leave US-ASCII XML header and structure untouched but break non-English data
      * so conversion must fail on wrong character and then other encodings will be tried */
-    if (!g_charsetConverter.ToUtf8(tryDataCharset, data, converted, true) || converted.empty())
+    if (!g_charsetConverter.TryToUtf8(tryDataCharset, data, converted) || converted.empty())
       return false; // can't convert data
 
     InternalParse(converted, TIXML_ENCODING_UTF8);

--- a/xbmc/utils/test/TestCharsetConverter.cpp
+++ b/xbmc/utils/test/TestCharsetConverter.cpp
@@ -641,8 +641,8 @@ TEST_F(TestCharsetConverter, utf8ToSystemSafe_1)
   std::string u8str;
   std::string u8str2;
 
-  g_charsetConverter.Utf16LEToUtf8(cs, u8str);
-  ASSERT_TRUE(g_charsetConverter.Utf8ToSystemSafe(u8str, u8str2));
+  CCharsetConverter::Utf16LEToUtf8(cs, u8str);
+  ASSERT_TRUE(CCharsetConverter::Utf8ToSystemSafe(u8str, u8str2));
 }
 
 TEST_F(TestCharsetConverter, systemToUtf8_CP1251)
@@ -652,7 +652,7 @@ TEST_F(TestCharsetConverter, systemToUtf8_CP1251)
   std::string temp;
   const char* defCodePage = ucnv_getDefaultName();
   ucnv_setDefaultName("CP-1251"); //simulate CP1251 as system codepage
-  g_charsetConverter.SystemToUtf8(data, temp);
+  CCharsetConverter::SystemToUtf8(data, temp);
   ucnv_setDefaultName(defCodePage); //reset codepage to avoid tainting other tests
   EXPECT_STREQ(expected.c_str(), temp.c_str());
 }
@@ -664,7 +664,7 @@ TEST_F(TestCharsetConverter, systemToUtf8_CP1252)
   std::string temp;
   const char* defCodePage = ucnv_getDefaultName();
   ucnv_setDefaultName("CP-1252"); //simulate CP1252 as system codepage
-  g_charsetConverter.SystemToUtf8(data, temp);
+  CCharsetConverter::SystemToUtf8(data, temp);
   ucnv_setDefaultName(defCodePage); //reset codepage to avoid tainting other tests
   EXPECT_STREQ(expected.c_str(), temp.c_str());
 }
@@ -676,7 +676,7 @@ TEST_F(TestCharsetConverter, systemToUtf8_CP1253)
   std::string temp;
   const char* defCodePage = ucnv_getDefaultName();
   ucnv_setDefaultName("CP-1253"); //simulate CP1253 as system codepage
-  g_charsetConverter.SystemToUtf8(data, temp);
+  CCharsetConverter::SystemToUtf8(data, temp);
   ucnv_setDefaultName(defCodePage); //reset codepage to avoid tainting other tests
   EXPECT_STREQ(expected.c_str(), temp.c_str());
 }
@@ -688,7 +688,7 @@ TEST_F(TestCharsetConverter, systemToUtf8_CP1255)
   std::string temp;
   const char* defCodePage = ucnv_getDefaultName();
   ucnv_setDefaultName("CP-1255"); //simulate CP1255 as system codepage
-  g_charsetConverter.SystemToUtf8(data, temp);
+  CCharsetConverter::SystemToUtf8(data, temp);
   ucnv_setDefaultName(defCodePage); //reset codepage to avoid tainting other tests
   EXPECT_STREQ(expected.c_str(), temp.c_str());
 }
@@ -700,7 +700,7 @@ TEST_F(TestCharsetConverter, systemToUtf8_CP1256)
   std::string temp;
   const char* defCodePage = ucnv_getDefaultName();
   ucnv_setDefaultName("CP-1256"); //simulate CP1256 as system codepage
-  g_charsetConverter.SystemToUtf8(data, temp);
+  CCharsetConverter::SystemToUtf8(data, temp);
   ucnv_setDefaultName(defCodePage); //reset codepage to avoid tainting other tests
   EXPECT_STREQ(expected.c_str(), temp.c_str());
 }
@@ -712,7 +712,7 @@ TEST_F(TestCharsetConverter, systemToUtf8_CP874)
   std::string temp;
   const char* defCodePage = ucnv_getDefaultName();
   ucnv_setDefaultName("CP-874"); //simulate CP874 as system codepage
-  g_charsetConverter.SystemToUtf8(data, temp);
+  CCharsetConverter::SystemToUtf8(data, temp);
   ucnv_setDefaultName(defCodePage); //reset codepage to avoid tainting other tests
   EXPECT_STREQ(expected.c_str(), temp.c_str());
 }
@@ -724,7 +724,7 @@ TEST_F(TestCharsetConverter, systemToUtf8_CP932)
   std::string temp;
   const char* defCodePage = ucnv_getDefaultName();
   ucnv_setDefaultName("CP-932"); //simulate CP932 as system codepage
-  g_charsetConverter.SystemToUtf8(data, temp);
+  CCharsetConverter::SystemToUtf8(data, temp);
   ucnv_setDefaultName(defCodePage); //reset codepage to avoid tainting other tests
   EXPECT_STREQ(expected.c_str(), temp.c_str());
 }
@@ -736,7 +736,7 @@ TEST_F(TestCharsetConverter, systemToUtf8_CP932Hiranga)
   std::string temp;
   const char* defCodePage = ucnv_getDefaultName();
   ucnv_setDefaultName("CP-932"); //simulate CP932 as system codepage
-  g_charsetConverter.SystemToUtf8(data, temp);
+  CCharsetConverter::SystemToUtf8(data, temp);
   ucnv_setDefaultName(defCodePage); //reset codepage to avoid tainting other tests
   EXPECT_STREQ(expected.c_str(), temp.c_str());
 }
@@ -748,7 +748,7 @@ TEST_F(TestCharsetConverter, utf8ToSystem_CP1251)
   const char* defCodePage = ucnv_getDefaultName();
 
   ucnv_setDefaultName("CP-1251");
-  g_charsetConverter.Utf8ToSystem(source);
+  CCharsetConverter::Utf8ToSystem(source);
   ucnv_setDefaultName(defCodePage);
   EXPECT_STREQ(expected.c_str(), source.c_str());
 }
@@ -760,7 +760,7 @@ TEST_F(TestCharsetConverter, utf8ToSystem_CP1252)
   const char* defCodePage = ucnv_getDefaultName();
 
   ucnv_setDefaultName("CP-1252");
-  g_charsetConverter.Utf8ToSystem(source);
+  CCharsetConverter::Utf8ToSystem(source);
   ucnv_setDefaultName(defCodePage);
   EXPECT_STREQ(expected.c_str(), source.c_str());
 }
@@ -772,7 +772,7 @@ TEST_F(TestCharsetConverter, utf8ToSystem_CP1253)
   const char* defCodePage = ucnv_getDefaultName();
 
   ucnv_setDefaultName("CP-1253");
-  g_charsetConverter.Utf8ToSystem(source);
+  CCharsetConverter::Utf8ToSystem(source);
   ucnv_setDefaultName(defCodePage);
   EXPECT_STREQ(expected.c_str(), source.c_str());
 }
@@ -784,7 +784,7 @@ TEST_F(TestCharsetConverter, utf8ToSystem_CP1255)
   const char* defCodePage = ucnv_getDefaultName();
 
   ucnv_setDefaultName("CP-1255");
-  g_charsetConverter.Utf8ToSystem(source);
+  CCharsetConverter::Utf8ToSystem(source);
   ucnv_setDefaultName(defCodePage);
   EXPECT_STREQ(expected.c_str(), source.c_str());
 }
@@ -796,7 +796,7 @@ TEST_F(TestCharsetConverter, utf8ToSystem_CP1256)
   const char* defCodePage = ucnv_getDefaultName();
 
   ucnv_setDefaultName("CP-1256");
-  g_charsetConverter.Utf8ToSystem(source);
+  CCharsetConverter::Utf8ToSystem(source);
   ucnv_setDefaultName(defCodePage);
   EXPECT_STREQ(expected.c_str(), source.c_str());
 }
@@ -808,7 +808,7 @@ TEST_F(TestCharsetConverter, utf8ToSystem_CP874)
   const char* defCodePage = ucnv_getDefaultName();
 
   ucnv_setDefaultName("CP-874");
-  g_charsetConverter.Utf8ToSystem(source);
+  CCharsetConverter::Utf8ToSystem(source);
   ucnv_setDefaultName(defCodePage);
   EXPECT_STREQ(expected.c_str(), source.c_str());
 }
@@ -820,7 +820,7 @@ TEST_F(TestCharsetConverter, utf8ToSystem_CP932)
   const char* defCodePage = ucnv_getDefaultName();
 
   ucnv_setDefaultName("CP-932");
-  g_charsetConverter.Utf8ToSystem(source);
+  CCharsetConverter::Utf8ToSystem(source);
   ucnv_setDefaultName(defCodePage);
   EXPECT_STREQ(expected.c_str(), source.c_str());
 }
@@ -832,7 +832,7 @@ TEST_F(TestCharsetConverter, utf8ToSystem_CP932Hiranga)
   const char* defCodePage = ucnv_getDefaultName();
 
   ucnv_setDefaultName("CP-932");
-  g_charsetConverter.Utf8ToSystem(source);
+  CCharsetConverter::Utf8ToSystem(source);
   ucnv_setDefaultName(defCodePage);
   EXPECT_STREQ(expected.c_str(), source.c_str());
 }
@@ -846,9 +846,9 @@ TEST_F(TestCharsetConverter, utf8LogicalToVisual_1)
   std::string expected;
   std::string temp;
 
-  EXPECT_TRUE(g_charsetConverter.Utf16LEToUtf8(u16Source, source));
-  EXPECT_TRUE(g_charsetConverter.Utf16LEToUtf8(u16Expected, expected));
-  EXPECT_TRUE(g_charsetConverter.LogicalToVisualBiDi(source, temp));
+  EXPECT_TRUE(CCharsetConverter::Utf16LEToUtf8(u16Source, source));
+  EXPECT_TRUE(CCharsetConverter::Utf16LEToUtf8(u16Expected, expected));
+  EXPECT_TRUE(CCharsetConverter::LogicalToVisualBiDi(source, temp));
   EXPECT_STREQ(expected.c_str(), temp.c_str());
 }
 
@@ -861,9 +861,9 @@ TEST_F(TestCharsetConverter, utf8LogicalToVisual_2)
   std::string expected;
   std::string temp;
 
-  EXPECT_TRUE(g_charsetConverter.Utf16LEToUtf8(u16Source, source));
-  EXPECT_TRUE(g_charsetConverter.Utf16LEToUtf8(u16Expected, expected));
-  EXPECT_TRUE(g_charsetConverter.LogicalToVisualBiDi(source, temp));
+  EXPECT_TRUE(CCharsetConverter::Utf16LEToUtf8(u16Source, source));
+  EXPECT_TRUE(CCharsetConverter::Utf16LEToUtf8(u16Expected, expected));
+  EXPECT_TRUE(CCharsetConverter::LogicalToVisualBiDi(source, temp));
   EXPECT_STREQ(expected.c_str(), temp.c_str());
 }
 
@@ -876,9 +876,9 @@ TEST_F(TestCharsetConverter, utf8LogicalToVisual_3)
   std::string expected;
   std::string temp;
 
-  EXPECT_TRUE(g_charsetConverter.Utf16LEToUtf8(u16Source, source));
-  EXPECT_TRUE(g_charsetConverter.Utf16LEToUtf8(u16Expected, expected));
-  EXPECT_TRUE(g_charsetConverter.LogicalToVisualBiDi(source, temp));
+  EXPECT_TRUE(CCharsetConverter::Utf16LEToUtf8(u16Source, source));
+  EXPECT_TRUE(CCharsetConverter::Utf16LEToUtf8(u16Expected, expected));
+  EXPECT_TRUE(CCharsetConverter::LogicalToVisualBiDi(source, temp));
   EXPECT_STREQ(expected.c_str(), temp.c_str());
 }
 
@@ -891,9 +891,9 @@ TEST_F(TestCharsetConverter, utf8LogicalToVisual_4)
   std::string expected;
   std::string temp;
 
-  EXPECT_TRUE(g_charsetConverter.Utf16LEToUtf8(u16Source, source));
-  EXPECT_TRUE(g_charsetConverter.Utf16LEToUtf8(u16Expected, expected));
-  EXPECT_TRUE(g_charsetConverter.LogicalToVisualBiDi(source, temp));
+  EXPECT_TRUE(CCharsetConverter::Utf16LEToUtf8(u16Source, source));
+  EXPECT_TRUE(CCharsetConverter::Utf16LEToUtf8(u16Expected, expected));
+  EXPECT_TRUE(CCharsetConverter::LogicalToVisualBiDi(source, temp));
   EXPECT_STREQ(expected.c_str(), temp.c_str());
 }
 
@@ -906,9 +906,9 @@ TEST_F(TestCharsetConverter, utf8LogicalToVisual_5)
   std::string expected;
   std::string temp;
 
-  EXPECT_TRUE(g_charsetConverter.Utf16LEToUtf8(u16Source, source));
-  EXPECT_TRUE(g_charsetConverter.Utf16LEToUtf8(u16Expected, expected));
-  EXPECT_TRUE(g_charsetConverter.LogicalToVisualBiDi(source, temp));
+  EXPECT_TRUE(CCharsetConverter::Utf16LEToUtf8(u16Source, source));
+  EXPECT_TRUE(CCharsetConverter::Utf16LEToUtf8(u16Expected, expected));
+  EXPECT_TRUE(CCharsetConverter::LogicalToVisualBiDi(source, temp));
   EXPECT_STREQ(expected.c_str(), temp.c_str());
 }
 
@@ -918,7 +918,7 @@ TEST_F(TestCharsetConverter, utf16LogicalToVisual_1)
   std::u16string u16Expected((char16_t*)bidiVisualOrder_1_UTF16LE);
   std::u16string result;
 
-  g_charsetConverter.LogicalToVisualBiDi(u16Source, result);
+  CCharsetConverter::LogicalToVisualBiDi(u16Source, result);
   EXPECT_PRED_FORMAT2(AssertStringEquals, u16Expected, result);
 }
 
@@ -928,7 +928,7 @@ TEST_F(TestCharsetConverter, utf16LogicalToVisual_2)
   std::u16string u16Expected((char16_t*)bidiVisualOrder_2_UTF16LE);
   std::u16string result;
 
-  g_charsetConverter.LogicalToVisualBiDi(u16Source, result);
+  CCharsetConverter::LogicalToVisualBiDi(u16Source, result);
   EXPECT_PRED_FORMAT2(AssertStringEquals, u16Expected, result);
 }
 
@@ -938,7 +938,7 @@ TEST_F(TestCharsetConverter, utf16LogicalToVisual_3)
   std::u16string u16Expected((char16_t*)bidiVisualOrder_3_UTF16LE);
   std::u16string result;
 
-  g_charsetConverter.LogicalToVisualBiDi(u16Source, result);
+  CCharsetConverter::LogicalToVisualBiDi(u16Source, result);
   EXPECT_PRED_FORMAT2(AssertStringEquals, u16Expected, result);
 }
 
@@ -948,7 +948,7 @@ TEST_F(TestCharsetConverter, utf16LogicalToVisual_4)
   std::u16string u16Expected((char16_t*)bidiVisualOrder_4_UTF16LE);
   std::u16string result;
 
-  g_charsetConverter.LogicalToVisualBiDi(u16Source, result);
+  CCharsetConverter::LogicalToVisualBiDi(u16Source, result);
   EXPECT_PRED_FORMAT2(AssertStringEquals, u16Expected, result);
 }
 
@@ -958,7 +958,7 @@ TEST_F(TestCharsetConverter, utf16LogicalToVisual_5)
   std::u16string u16Expected((char16_t*)bidiVisualOrder_5_UTF16LE);
   std::u16string result;
 
-  g_charsetConverter.LogicalToVisualBiDi(u16Source, result);
+  CCharsetConverter::LogicalToVisualBiDi(u16Source, result);
   EXPECT_PRED_FORMAT2(AssertStringEquals, u16Expected, result);
 }
 
@@ -968,7 +968,7 @@ TEST_F(TestCharsetConverter, utf16LogicalToVisual_6)
   std::u16string u16Expected((char16_t*)bidiVisualOrder_6_UTF16LE);
   std::u16string result;
 
-  g_charsetConverter.LogicalToVisualBiDi(u16Source, result,
+  CCharsetConverter::LogicalToVisualBiDi(u16Source, result,
                                          CCharsetConverter::LTR |
                                          CCharsetConverter::REMOVE_CONTROLS);
   EXPECT_PRED_FORMAT2(AssertStringEquals, u16Expected, result);
@@ -979,7 +979,7 @@ TEST_F(TestCharsetConverter, utf8ToW)
   refstra1 = "test Utf8ToW";
   refstrw1 = L"test Utf8ToW";
   varstrw1.clear();
-  g_charsetConverter.Utf8ToW(refstra1, varstrw1);
+  CCharsetConverter::Utf8ToW(refstra1, varstrw1);
   EXPECT_STREQ(refstrw1.c_str(), varstrw1.c_str());
 }
 
@@ -987,7 +987,7 @@ TEST_F(TestCharsetConverter, subtitleCharsetToUtf8)
 {
   refstra1 = "test subtitleCharsetToW";
   varstra1.clear();
-  g_charsetConverter.SubtitleCharsetToUtf8(refstra1, varstra1);
+  CCharsetConverter::SubtitleCharsetToUtf8(refstra1, varstra1);
 
   /* Assign refstra1 to refstrw1 so that we can compare */
   EXPECT_STREQ(refstra1.c_str(), varstra1.c_str());
@@ -997,7 +997,7 @@ TEST_F(TestCharsetConverter, utf8ToStringCharset_1)
 {
   refstra1 = "test Utf8ToStringCharset";
   varstra1.clear();
-  g_charsetConverter.Utf8ToStringCharset(refstra1, varstra1);
+  CCharsetConverter::Utf8ToStringCharset(refstra1, varstra1);
   EXPECT_STREQ(refstra1.c_str(), varstra1.c_str());
 }
 
@@ -1005,7 +1005,7 @@ TEST_F(TestCharsetConverter, utf8ToStringCharset_2)
 {
   refstra1 = "test Utf8ToStringCharset";
   varstra1 = "test Utf8ToStringCharset";
-  g_charsetConverter.Utf8ToStringCharset(varstra1);
+  CCharsetConverter::Utf8ToStringCharset(varstra1);
   EXPECT_STREQ(refstra1.c_str(), varstra1.c_str());
 }
 
@@ -1013,7 +1013,7 @@ TEST_F(TestCharsetConverter, utf8ToSystem)
 {
   refstra1 = "test Utf8ToSystem";
   varstra1 = "test Utf8ToSystem";
-  g_charsetConverter.Utf8ToSystem(varstra1);
+  CCharsetConverter::Utf8ToSystem(varstra1);
   EXPECT_STREQ(refstra1.c_str(), varstra1.c_str());
 }
 
@@ -1021,7 +1021,7 @@ TEST_F(TestCharsetConverter, utf8To_ASCII)
 {
   refstra1 = "test Utf8To: charset ASCII, std::string";
   varstra1.clear();
-  g_charsetConverter.Utf8To("ASCII", refstra1, varstra1);
+  CCharsetConverter::Utf8To("ASCII", refstra1, varstra1);
   EXPECT_STREQ(refstra1.c_str(), varstra1.c_str());
 }
 
@@ -1031,7 +1031,7 @@ TEST_F(TestCharsetConverter, utf8ToUtf16_CP1251)
   std::u16string expected((char16_t*)CP1251asUTF16LE);
   std::u16string temp;
 
-  g_charsetConverter.Utf8ToUtf16(source, temp);
+  CCharsetConverter::Utf8ToUtf16(source, temp);
   EXPECT_EQ(expected.length(), temp.length());
   EXPECT_PRED_FORMAT2(AssertStringEquals, expected, temp);
 }
@@ -1042,7 +1042,7 @@ TEST_F(TestCharsetConverter, utf8ToUtf16LE_CP1251)
   std::u16string expected((char16_t*)CP1251asUTF16LE);
   std::u16string temp;
 
-  g_charsetConverter.Utf8ToUtf16LE(source, temp);
+  CCharsetConverter::Utf8ToUtf16LE(source, temp);
   EXPECT_EQ(expected.length(), temp.length());
   EXPECT_PRED_FORMAT2(AssertStringEquals, expected, temp);
 }
@@ -1053,7 +1053,7 @@ TEST_F(TestCharsetConverter, utf8ToUtf16BE_CP1251)
   std::u16string expected((char16_t*)CP1251asUTF16BE);
   std::u16string temp;
 
-  g_charsetConverter.Utf8ToUtf16BE(source, temp);
+  CCharsetConverter::Utf8ToUtf16BE(source, temp);
   EXPECT_EQ(expected.length(), temp.length());
   EXPECT_PRED_FORMAT2(AssertStringEquals, expected, temp);
 }
@@ -1064,7 +1064,7 @@ TEST_F(TestCharsetConverter, utf8ToUtf32_CP1251)
   std::u32string expected((char32_t*)CP1251asUTF32LE);
   std::u32string temp;
 
-  g_charsetConverter.Utf8ToUtf32(source, temp);
+  CCharsetConverter::Utf8ToUtf32(source, temp);
   EXPECT_PRED_FORMAT2(AssertStringEquals, expected, temp);
 }
 
@@ -1074,7 +1074,7 @@ TEST_F(TestCharsetConverter, utf8To_UTF16LE)
              "ＣＳｔｄＳｔｒｉｎｇ１６";
   refstr16_1.assign((char16_t*)refutf16LE2);
   varstr16_1.clear();
-  g_charsetConverter.Utf8To("UTF-16LE", refstra1, varstr16_1);
+  CCharsetConverter::Utf8To("UTF-16LE", refstra1, varstr16_1);
   EXPECT_PRED_FORMAT2(AssertStringEquals, refstr16_1, varstr16_1);
 }
 
@@ -1093,7 +1093,7 @@ TEST_F(TestCharsetConverter, utf8To_UTF32LE)
 #endif
   refstr32_1.assign((char32_t*)refutf32LE1);
   varstr32_1.clear();
-  g_charsetConverter.Utf8To("UTF-32LE", refstra1, varstr32_1);
+  CCharsetConverter::Utf8To("UTF-32LE", refstra1, varstr32_1);
   EXPECT_PRED_FORMAT2(AssertStringEquals, refstr32_1, varstr32_1);
 }
 
@@ -1101,14 +1101,14 @@ TEST_F(TestCharsetConverter, stringCharsetToUtf8)
 {
   refstra1 = "ｔｅｓｔ＿ｓｔｒｉｎｇＣｈａｒｓｅｔＴｏＵｔｆ８";
   varstra1.clear();
-  g_charsetConverter.ToUtf8("UTF-8", refstra1, varstra1);
+  CCharsetConverter::ToUtf8("UTF-8", refstra1, varstra1);
   EXPECT_STREQ(refstra1.c_str(), varstra1.c_str());
 }
 
 TEST_F(TestCharsetConverter, isValidUtf8_1)
 {
   varstra1.clear();
-  g_charsetConverter.ToUtf8("UTF-16LE", refutf16LE3, varstra1);
+  CCharsetConverter::ToUtf8("UTF-16LE", refutf16LE3, varstra1);
   EXPECT_TRUE(CUtf8Utils::isValidUtf8(varstra1.c_str()));
 }
 
@@ -1121,7 +1121,7 @@ TEST_F(TestCharsetConverter, isValidUtf8_2)
 TEST_F(TestCharsetConverter, isValidUtf8_3)
 {
   varstra1.clear();
-  g_charsetConverter.ToUtf8("UTF-16LE", refutf16LE3, varstra1);
+  CCharsetConverter::ToUtf8("UTF-16LE", refutf16LE3, varstra1);
   EXPECT_TRUE(CUtf8Utils::isValidUtf8(varstra1.c_str()));
 }
 
@@ -1135,7 +1135,7 @@ TEST_F(TestCharsetConverter, wToUTF8)
   refstrw1 = L"test Utf8ToW";
   refstra1 = "test Utf8ToW";
   varstra1.clear();
-  g_charsetConverter.WToUtf8(refstrw1, varstra1);
+  CCharsetConverter::WToUtf8(refstrw1, varstra1);
   EXPECT_STREQ(refstra1.c_str(), varstra1.c_str());
 }
 
@@ -1144,7 +1144,7 @@ TEST_F(TestCharsetConverter, utf16BEtoUTF8)
   refstr16_1.assign((char16_t*)refutf16BE);
   refstra1 = "ｔｅｓｔ＿ｕｔｆ１６ＢＥｔｏＵＴＦ８";
   varstra1.clear();
-  g_charsetConverter.Utf16BEToUtf8(refstr16_1, varstra1);
+  CCharsetConverter::Utf16BEToUtf8(refstr16_1, varstra1);
   EXPECT_STREQ(refstra1.c_str(), varstra1.c_str());
 }
 
@@ -1153,7 +1153,7 @@ TEST_F(TestCharsetConverter, ucs2ToUTF8)
   refstr16_1.assign((char16_t*)refucs2);
   refstra1 = "ｔｅｓｔ＿ｕｃｓ２ｔｏＵＴＦ８";
   varstra1.clear();
-  g_charsetConverter.Ucs2ToUtf8(refstr16_1, varstra1);
+  CCharsetConverter::Ucs2ToUtf8(refstr16_1, varstra1);
   EXPECT_STREQ(refstra1.c_str(), varstra1.c_str());
 }
 
@@ -1162,7 +1162,7 @@ TEST_F(TestCharsetConverter, utf8logicalToVisualBiDi)
   refstra1 = "ｔｅｓｔ＿ｕｔｆ８ｌｏｇｉｃａｌＴｏＶｉｓｕａｌＢｉＤｉ";
   refstra2 = "ｔｅｓｔ＿ｕｔｆ８ｌｏｇｉｃａｌＴｏＶｉｓｕａｌＢｉＤｉ";
   varstra1.clear();
-  g_charsetConverter.LogicalToVisualBiDi(refstra1, varstra1);
+  CCharsetConverter::LogicalToVisualBiDi(refstra1, varstra1);
   EXPECT_STREQ(refstra2.c_str(), varstra1.c_str());
 }
 
@@ -1173,9 +1173,9 @@ TEST_F(TestCharsetConverter, NormalizeNFC1)
   std::u16string varstr2((char16_t*)normalizationTestNFD1);
   std::u16string temp;
 
-  g_charsetConverter.Normalize(varstr1, temp, CCharsetConverter::COMPOSE);
+  CCharsetConverter::Normalize(varstr1, temp, CCharsetConverter::COMPOSE);
   EXPECT_PRED_FORMAT2(AssertStringEquals, refstr, temp);
-  g_charsetConverter.Normalize(varstr2, temp, CCharsetConverter::COMPOSE);
+  CCharsetConverter::Normalize(varstr2, temp, CCharsetConverter::COMPOSE);
   EXPECT_PRED_FORMAT2(AssertStringEquals, refstr, temp);
 }
 
@@ -1186,9 +1186,9 @@ TEST_F(TestCharsetConverter, NormalizeNFC2)
   std::u16string varstr2((char16_t*)normalizationTestNFD2);
   std::u16string temp;
 
-  g_charsetConverter.Normalize(varstr1, temp, CCharsetConverter::COMPOSE);
+  CCharsetConverter::Normalize(varstr1, temp, CCharsetConverter::COMPOSE);
   EXPECT_PRED_FORMAT2(AssertStringEquals, refstr, temp);
-  g_charsetConverter.Normalize(varstr2, temp, CCharsetConverter::COMPOSE);
+  CCharsetConverter::Normalize(varstr2, temp, CCharsetConverter::COMPOSE);
   EXPECT_PRED_FORMAT2(AssertStringEquals, refstr, temp);
 }
 
@@ -1199,9 +1199,9 @@ TEST_F(TestCharsetConverter, NormalizeNFC3)
   std::u16string varstr2((char16_t*)normalizationTestNFD3);
   std::u16string temp;
 
-  g_charsetConverter.Normalize(varstr1, temp, CCharsetConverter::COMPOSE);
+  CCharsetConverter::Normalize(varstr1, temp, CCharsetConverter::COMPOSE);
   EXPECT_PRED_FORMAT2(AssertStringEquals, refstr, temp);
-  g_charsetConverter.Normalize(varstr2, temp, CCharsetConverter::COMPOSE);
+  CCharsetConverter::Normalize(varstr2, temp, CCharsetConverter::COMPOSE);
   EXPECT_PRED_FORMAT2(AssertStringEquals, refstr, temp);
 }
 
@@ -1212,9 +1212,9 @@ TEST_F(TestCharsetConverter, NormalizeNFD1)
   std::u16string varstr2((char16_t*)normalizationTestNFC1);
   std::u16string temp;
 
-  g_charsetConverter.Normalize(varstr1, temp, CCharsetConverter::DECOMPOSE);
+  CCharsetConverter::Normalize(varstr1, temp, CCharsetConverter::DECOMPOSE);
   EXPECT_PRED_FORMAT2(AssertStringEquals, refstr, temp);
-  g_charsetConverter.Normalize(varstr2, temp, CCharsetConverter::DECOMPOSE);
+  CCharsetConverter::Normalize(varstr2, temp, CCharsetConverter::DECOMPOSE);
   EXPECT_PRED_FORMAT2(AssertStringEquals, refstr, temp);
 }
 
@@ -1225,9 +1225,9 @@ TEST_F(TestCharsetConverter, NormalizeNFD2)
   std::u16string varstr2((char16_t*)normalizationTestNFD2);
   std::u16string temp;
 
-  g_charsetConverter.Normalize(varstr1, temp, CCharsetConverter::DECOMPOSE);
+  CCharsetConverter::Normalize(varstr1, temp, CCharsetConverter::DECOMPOSE);
   EXPECT_PRED_FORMAT2(AssertStringEquals, refstr, temp);
-  g_charsetConverter.Normalize(varstr2, temp, CCharsetConverter::DECOMPOSE);
+  CCharsetConverter::Normalize(varstr2, temp, CCharsetConverter::DECOMPOSE);
   EXPECT_PRED_FORMAT2(AssertStringEquals, refstr, temp);
 }
 TEST_F(TestCharsetConverter, NormalizeNFD3)
@@ -1237,9 +1237,9 @@ TEST_F(TestCharsetConverter, NormalizeNFD3)
   std::u16string varstr2((char16_t*)normalizationTestNFC3);
   std::u16string temp;
 
-  g_charsetConverter.Normalize(varstr1, temp, CCharsetConverter::DECOMPOSE);
+  CCharsetConverter::Normalize(varstr1, temp, CCharsetConverter::DECOMPOSE);
   EXPECT_PRED_FORMAT2(AssertStringEquals, refstr, temp);
-  g_charsetConverter.Normalize(varstr2, temp, CCharsetConverter::DECOMPOSE);
+  CCharsetConverter::Normalize(varstr2, temp, CCharsetConverter::DECOMPOSE);
   EXPECT_PRED_FORMAT2(AssertStringEquals, refstr, temp);
 }
 
@@ -1249,7 +1249,7 @@ TEST_F(TestCharsetConverter, NormalizeNFDMac1)
   std::u16string varstr1((char16_t*)normalizationTestSource1);
   std::u16string temp;
 
-  g_charsetConverter.Normalize(varstr1, temp, CCharsetConverter::DECOMPOSE_MAC);
+  CCharsetConverter::Normalize(varstr1, temp, CCharsetConverter::DECOMPOSE_MAC);
   EXPECT_PRED_FORMAT2(AssertStringEquals, refstr, temp);
 }
 
@@ -1259,7 +1259,7 @@ TEST_F(TestCharsetConverter, NormalizeNFDMac2)
   std::u16string varstr1((char16_t*)normalizationTestSource2);
   std::u16string temp;
 
-  g_charsetConverter.Normalize(varstr1, temp, CCharsetConverter::DECOMPOSE_MAC);
+  CCharsetConverter::Normalize(varstr1, temp, CCharsetConverter::DECOMPOSE_MAC);
   EXPECT_PRED_FORMAT2(AssertStringEquals, refstr, temp);
 }
 
@@ -1269,7 +1269,7 @@ TEST_F(TestCharsetConverter, NormalizeNFDMac3)
   std::u16string varstr1((char16_t*)normalizationTestSource3);
   std::u16string temp;
 
-  g_charsetConverter.Normalize(varstr1, temp, CCharsetConverter::DECOMPOSE_MAC);
+  CCharsetConverter::Normalize(varstr1, temp, CCharsetConverter::DECOMPOSE_MAC);
   EXPECT_PRED_FORMAT2(AssertStringEquals, refstr, temp);
 }
 //keep it here for now, no CLangInfo test cases?
@@ -1302,7 +1302,7 @@ TEST_F(TestCharsetConverter, NormalizeNFDMac3)
 //  reflabels.push_back("Korean");
 //  reflabels.push_back("Hong Kong (Big5-HKSCS)");
 //
-//  std::vector<std::string> varlabels = g_charsetConverter.getCharsetLabels();
+//  std::vector<std::string> varlabels = CCharsetConverter::getCharsetLabels();
 //  ASSERT_EQ(reflabels.size(), varlabels.size());
 //
 //  std::vector<std::string>::iterator it;
@@ -1315,20 +1315,20 @@ TEST_F(TestCharsetConverter, NormalizeNFDMac3)
 //TEST_F(TestCharsetConverter, getCharsetLabelByName)
 //{
 //  CStdString varstr =
-//    g_charsetConverter.getCharsetLabelByName("ISO-8859-1");
+//    CCharsetConverter::getCharsetLabelByName("ISO-8859-1");
 //  EXPECT_STREQ("Western Europe (ISO)", varstr.c_str());
 //  varstr.clear();
-//  varstr = g_charsetConverter.getCharsetLabelByName("Bogus");
+//  varstr = CCharsetConverter::getCharsetLabelByName("Bogus");
 //  EXPECT_STREQ("", varstr.c_str());
 //}
 //
 //TEST_F(TestCharsetConverter, getCharsetNameByLabel)
 //{
 //  CStdString varstr =
-//    g_charsetConverter.getCharsetNameByLabel("Western Europe (ISO)");
+//    CCharsetConverter::getCharsetNameByLabel("Western Europe (ISO)");
 //  EXPECT_STREQ("ISO-8859-1", varstr.c_str());
 //  varstr.clear();
-//  varstr = g_charsetConverter.getCharsetNameByLabel("Bogus");
+//  varstr = CCharsetConverter::getCharsetNameByLabel("Bogus");
 //  EXPECT_STREQ("", varstr.c_str());
 //}
 
@@ -1336,7 +1336,7 @@ TEST_F(TestCharsetConverter, unknownToUTF8_1)
 {
   refstra1 = "ｔｅｓｔ＿ｕｎｋｎｏｗｎＴｏＵＴＦ８";
   varstra1 = "ｔｅｓｔ＿ｕｎｋｎｏｗｎＴｏＵＴＦ８";
-  g_charsetConverter.UnknownToUtf8(varstra1);
+  CCharsetConverter::UnknownToUtf8(varstra1);
   EXPECT_STREQ(refstra1.c_str(), varstra1.c_str());
 }
 
@@ -1344,7 +1344,7 @@ TEST_F(TestCharsetConverter, unknownToUTF8_2)
 {
   refstra1 = "ｔｅｓｔ＿ｕｎｋｎｏｗｎＴｏＵＴＦ８";
   varstra1.clear();
-  g_charsetConverter.UnknownToUtf8(refstra1, varstra1);
+  CCharsetConverter::UnknownToUtf8(refstra1, varstra1);
   EXPECT_STREQ(refstra1.c_str(), varstra1.c_str());
 }
 
@@ -1376,15 +1376,15 @@ TEST_F(TestCharsetConverter, WToUtf8)
   /* test four bytes UTF-8 sequences */
   /* those tests can fail on some platform with limited wchar_t range and lack of surrogates support */
   std::wstring helperStringW;
-  EXPECT_TRUE(g_charsetConverter.TryUtf8ToW(testLinBIdeoUtf8, helperStringW)) << "Can't prepare source wide string for test";
+  EXPECT_TRUE(CCharsetConverter::TryUtf8ToW(testLinBIdeoUtf8, helperStringW)) << "Can't prepare source wide string for test";
   EXPECT_TRUE(CCharsetConverter::TryWToUtf8(helperStringW, testString));
   EXPECT_STREQ(testLinBIdeoUtf8, testString.c_str());
   helperStringW.clear();
-  EXPECT_TRUE(g_charsetConverter.TryUtf8ToW(testCJKComIdUtf8, helperStringW)) << "Can't prepare source wide string for test";
+  EXPECT_TRUE(CCharsetConverter::TryUtf8ToW(testCJKComIdUtf8, helperStringW)) << "Can't prepare source wide string for test";
   EXPECT_TRUE(CCharsetConverter::TryWToUtf8(helperStringW, testString));
   EXPECT_STREQ(testCJKComIdUtf8, testString.c_str());
   helperStringW.clear();
-  EXPECT_TRUE(g_charsetConverter.TryUtf8ToW(testTagsUtf8, helperStringW)) << "Can't prepare source wide string for test";
+  EXPECT_TRUE(CCharsetConverter::TryUtf8ToW(testTagsUtf8, helperStringW)) << "Can't prepare source wide string for test";
   EXPECT_TRUE(CCharsetConverter::TryWToUtf8(helperStringW, testString));
   EXPECT_STREQ(testTagsUtf8, testString.c_str());
 
@@ -1445,11 +1445,11 @@ TEST_F(TestCharsetConverter, Utf8ToW)
   EXPECT_STREQ(testLinBIdeoUtf8, resultStringUtf8.c_str());
   resultStringUtf8.clear();
   EXPECT_TRUE(CCharsetConverter::Utf8ToW(testCJKComIdUtf8, testStringW));
-  EXPECT_TRUE(g_charsetConverter.TryWToUtf8(testStringW, resultStringUtf8)) << "Can't convert result back to UTF-8 from wide string";
+  EXPECT_TRUE(CCharsetConverter::TryWToUtf8(testStringW, resultStringUtf8)) << "Can't convert result back to UTF-8 from wide string";
   EXPECT_STREQ(testCJKComIdUtf8, resultStringUtf8.c_str());
   resultStringUtf8.clear();
   EXPECT_TRUE(CCharsetConverter::Utf8ToW(testTagsUtf8, testStringW));
-  EXPECT_TRUE(g_charsetConverter.TryWToUtf8(testStringW, resultStringUtf8)) << "Can't convert result back to UTF-8 from wide string";
+  EXPECT_TRUE(CCharsetConverter::TryWToUtf8(testStringW, resultStringUtf8)) << "Can't convert result back to UTF-8 from wide string";
   EXPECT_STREQ(testTagsUtf8, resultStringUtf8.c_str());
 
   /* test invalid sequences */

--- a/xbmc/utils/test/TestCharsetConverter.cpp
+++ b/xbmc/utils/test/TestCharsetConverter.cpp
@@ -23,6 +23,10 @@
 #include "utils/Utf8Utils.h"
 #include "system.h"
 
+#include <string>
+#include <stdio.h>
+#include <unicode/ucnv.h>
+
 #include "gtest/gtest.h"
 
 static const uint16_t refutf16LE1[] = { 0xff54, 0xff45, 0xff53, 0xff54,
@@ -45,7 +49,7 @@ static const uint16_t refutf16LE2[] = { 0xff54, 0xff45, 0xff53, 0xff54,
 static const char refutf16LE3[] = "T\377E\377S\377T\377?\377S\377T\377"
                                   "R\377I\377N\377G\377#\377H\377A\377"
                                   "R\377S\377E\377T\377\064\377O\377\065"
-                                  "\377T\377F\377\030\377";
+                                  "\377T\377F\377\030\377\000";
 
 static const uint16_t refutf16LE4[] = { 0xff54, 0xff45, 0xff53, 0xff54,
                                         0xff3f, 0xff55, 0xff54, 0xff46,
@@ -81,70 +85,909 @@ static const uint16_t refucs2[] = { 0xff54, 0xff45, 0xff53, 0xff54,
                                     0xff12, 0xff54, 0xff4f, 0xff35,
                                     0xff34, 0xff26, 0xff18, 0x0 };
 
-class TestCharsetConverter : public testing::Test
-{
-protected:
-  TestCharsetConverter()
-  {
-    /* Add default settings for locale.
-     * Settings here are taken from CGUISettings::Initialize()
-     */
-    /* TODO
-    CSettingsCategory *loc = CSettings::GetInstance().AddCategory(7, "locale", 14090);
-    CSettings::GetInstance().AddString(loc, CSettings::SETTING_LOCALE_LANGUAGE,248,"english",
-                            SPIN_CONTROL_TEXT);
-    CSettings::GetInstance().AddString(loc, CSettings::SETTING_LOCALE_COUNTRY, 20026, "USA",
-                            SPIN_CONTROL_TEXT);
-    CSettings::GetInstance().AddString(loc, CSettings::SETTING_LOCALE_CHARSET, 14091, "DEFAULT",
-                            SPIN_CONTROL_TEXT); // charset is set by the
-                                                // language file
-
-    // Add default settings for subtitles
-    CSettingsCategory *sub = CSettings::GetInstance().AddCategory(5, "subtitles", 287);
-    CSettings::GetInstance().AddString(sub, CSettings::SETTING_SUBTITLES_CHARSET, 735, "DEFAULT",
-                            SPIN_CONTROL_TEXT);
-    */
-    CSettings::GetInstance().Initialize();
-    g_charsetConverter.reset();
-    g_charsetConverter.clear();
-  }
-
-  ~TestCharsetConverter()
-  {
-    CSettings::GetInstance().Unload();
-  }
-
-  std::string refstra1, refstra2, varstra1;
-  std::wstring refstrw1, varstrw1;
-  std::string refstr1;
+// ftp://ftp.unicode.org/Public/MAPPINGS/VENDORS/MICSFT/WINDOWS/CP1251.TXT
+static const uint8_t refCP1251[] = {
+  //match column width with utf8 version to make it easier to spot any errors
+  //or make changes
+  0xE0, 0xE1, 0xE2, 0xE3, 0xE4,
+  0xE5, 0xE6, 0xE7, 0xE8, 0xE9,
+  0xEA, 0xEB, 0xEC, 0xED, 0xEE,
+  0xEF, 0xF0, 0xF1, 0xF2, 0xF3,
+  0xF4, 0xF5, 0xF6, 0xF7, 0xF8,
+  0xF9, 0xFA, 0xFB, 0xFC, 0xFD,
+  0xFE, 0xFF,
+  0x00
 };
 
-TEST_F(TestCharsetConverter, utf8ToW)
+static const uint8_t CP1251asUTF8[] = {
+  0xD0, 0xB0, 0xD0, 0xB1, 0xD0, 0xB2, 0xD0, 0xB3, 0xD0, 0xB4,
+  0xD0, 0xB5, 0xD0, 0xB6, 0xD0, 0xB7, 0xD0, 0xB8, 0xD0, 0xB9,
+  0xD0, 0xBA, 0xD0, 0xBB, 0xD0, 0xBC, 0xD0, 0xBD, 0xD0, 0xBE,
+  0xD0, 0xBF, 0xD1, 0x80, 0xD1, 0x81, 0xD1, 0x82, 0xD1, 0x83,
+  0xD1, 0x84, 0xD1, 0x85, 0xD1, 0x86, 0xD1, 0x87, 0xD1, 0x88,
+  0xD1, 0x89, 0xD1, 0x8A, 0xD1, 0x8B, 0xD1, 0x8C, 0xD1, 0x8D,
+  0xD1, 0x8E, 0xD1, 0x8F,
+  0x00
+};
+
+static const uint16_t CP1251asUTF16LE[] = {
+  0x0430, 0x0431, 0x0432, 0x0433, 0x0434,
+  0x0435, 0x0436, 0x0437, 0x0438, 0x0439,
+  0x043A, 0x043B, 0x043C, 0x043D, 0x043E,
+  0x043F, 0x0440, 0x0441, 0x0442, 0x0443,
+  0x0444, 0x0445, 0x0446, 0x0447, 0x0448,
+  0x0449, 0x044A, 0x044B, 0x044C, 0x044D,
+  0x044E, 0x044F,
+  0x0000
+};
+
+static const uint16_t CP1251asUTF16BE[] = {
+  0x3004, 0x3104, 0x3204, 0x3304, 0x3404,
+  0x3504, 0x3604, 0x3704, 0x3804, 0x3904,
+  0x3A04, 0x3B04, 0x3C04, 0x3D04, 0x3E04,
+  0x3F04, 0x4004, 0x4104, 0x4204, 0x4304,
+  0x4404, 0x4504, 0x4604, 0x4704, 0x4804,
+  0x4904, 0x4A04, 0x4B04, 0x4C04, 0x4D04,
+  0x4E04, 0x4F04,
+  0x0000
+};
+
+static const uint32_t CP1251asUTF32LE[] = {
+  0x0430, 0x0431, 0x0432, 0x0433, 0x0434,
+  0x0435, 0x0436, 0x0437, 0x0438, 0x0439,
+  0x043A, 0x043B, 0x043C, 0x043D, 0x043E,
+  0x043F, 0x0440, 0x0441, 0x0442, 0x0443,
+  0x0444, 0x0445, 0x0446, 0x0447, 0x0448,
+  0x0449, 0x044A, 0x044B, 0x044C, 0x044D,
+  0x044E, 0x044F,
+  0x0000
+};
+
+// ftp://ftp.unicode.org/Public/MAPPINGS/VENDORS/MICSFT/WINDOWS/CP1252.TXT
+static const uint8_t refCP1252[] = {
+  //match column width with utf8 version to make it easier to spot any errors
+  //or make changes
+  0xE0, 0xE1, 0xE2, 0xE3, 0xE4,
+  0xE5, 0xE6, 0xE7, 0xE8, 0xE9,
+  0xEA, 0xEB, 0xEC, 0xED, 0xEE,
+  0xEF, 0xF0, 0xF1, 0xF2, 0xF3,
+  0xF4, 0xF5, 0xF6, 0xF7, 0xF8,
+  0xF9, 0xFA, 0xFB, 0xFC, 0xFD,
+  0xFE, 0xFF, 0x00
+};
+
+static const uint8_t CP1252asUTF8[] = {
+  0xC3, 0xA0, 0xC3, 0xA1, 0xC3, 0xA2, 0xC3, 0xA3, 0xC3, 0xA4,
+  0xC3, 0xA5, 0xC3, 0xA6, 0xC3, 0xA7, 0xC3, 0xA8, 0xC3, 0xA9,
+  0xC3, 0xAA, 0xC3, 0xAB, 0xC3, 0xAC, 0xC3, 0xAD, 0xC3, 0xAE,
+  0xC3, 0xAF, 0xC3, 0xB0, 0xC3, 0xB1, 0xC3, 0xB2, 0xC3, 0xB3,
+  0xC3, 0xB4, 0xC3, 0xB5, 0xC3, 0xB6, 0xC3, 0xB7, 0xC3, 0xB8,
+  0xC3, 0xB9, 0xC3, 0xBA, 0xC3, 0xBB, 0xC3, 0xBC, 0xC3, 0xBD,
+  0xC3, 0xBE, 0xC3, 0xBF, 0x00
+};
+
+// ftp://ftp.unicode.org/Public/MAPPINGS/VENDORS/MICSFT/WINDOWS/CP1253.TXT
+static const uint8_t refCP1253[] = {
+  //match column width with utf8 version to make it easier to spot any errors
+  //or make changes
+  0xE0, 0xE1, 0xE2, 0xE3, 0xE4,
+  0xE5, 0xE6, 0xE7, 0xE8, 0xE9,
+  0xEA, 0xEB, 0xEC, 0xED, 0xEE,
+  0xEF, 0xF0, 0xF1, 0xF2, 0xF3,
+  0xF4, 0xF5, 0xF6, 0xF7, 0xF8,
+  0xF9, 0xFA, 0xFB, 0xFC, 0xFD,
+  0xFE, 0x00
+};
+
+static const uint8_t CP1253asUTF8[] = {
+  0xCE, 0xB0, 0xCE, 0xB1, 0xCE, 0xB2, 0xCE, 0xB3, 0xCE, 0xB4,
+  0xCE, 0xB5, 0xCE, 0xB6, 0xCE, 0xB7, 0xCE, 0xB8, 0xCE, 0xB9,
+  0xCE, 0xBA, 0xCE, 0xBB, 0xCE, 0xBC, 0xCE, 0xBD, 0xCE, 0xBE,
+  0xCE, 0xBF, 0xCF, 0x80, 0xCF, 0x81, 0xCF, 0x82, 0xCF, 0x83,
+  0xCF, 0x84, 0xCF, 0x85, 0xCF, 0x86, 0xCF, 0x87, 0xCF, 0x88,
+  0xCF, 0x89, 0xCF, 0x8A, 0xCF, 0x8B, 0xCF, 0x8C, 0xCF, 0x8D,
+  0xCF, 0x8E, 0x00
+};
+
+// ftp://ftp.unicode.org/Public/MAPPINGS/VENDORS/MICSFT/WINDOWS/CP1255.TXT
+static const uint8_t refCP1255[] = {
+  //match column width with utf8 version to make it easier to spot any errors
+  //or make changes
+  0xE0, 0xE1, 0xE2, 0xE3, 0xE4,
+  0xE5, 0xE6, 0xE7, 0xE8, 0xE9,
+  0xEA, 0xEB, 0xEC, 0xED, 0xEE,
+  0xEF, 0xF0, 0xF1, 0xF2, 0xF3,
+  0xF4, 0xF5, 0xF6, 0xF7, 0xF8,
+  0xF9, 0xFA, 0x00
+};
+
+static const uint8_t CP1255asUTF8[] = {
+  0xD7, 0x90, 0xD7, 0x91, 0xD7, 0x92, 0xD7, 0x93, 0xD7, 0x94,
+  0xD7, 0x95, 0xD7, 0x96, 0xD7, 0x97, 0xD7, 0x98, 0xD7, 0x99,
+  0xD7, 0x9A, 0xD7, 0x9B, 0xD7, 0x9C, 0xD7, 0x9D, 0xD7, 0x9E,
+  0xD7, 0x9F, 0xD7, 0xA0, 0xD7, 0xA1, 0xD7, 0xA2, 0xD7, 0xA3,
+  0xD7, 0xA4, 0xD7, 0xA5, 0xD7, 0xA6, 0xD7, 0xA7, 0xD7, 0xA8,
+  0xD7, 0xA9, 0xD7, 0xAA, 0x00
+};
+
+// ftp://ftp.unicode.org/Public/MAPPINGS/VENDORS/MICSFT/WINDOWS/CP1256.TXT
+static const uint8_t refCP1256[] = {
+  //match column width with utf8 version to make it easier to spot any errors
+  //or make changes
+  0xC0, 0xC1, 0xC2, 0xC3, 0xC4,
+  0xC5, 0xC6, 0xC7, 0xC8, 0xC9,
+  0xCA, 0xCB, 0xCC, 0xCD, 0xCE,
+  0xCF, 0xD0, 0xD1, 0xD2, 0xD3,
+  0xD4, 0xD5, 0xD6, 0xD8, 0xD9,
+  0xDA, 0xDB, 0xDC, 0xDD, 0xDE,
+  0xDF, 0x00
+};
+
+static const uint8_t CP1256asUTF8[] = {
+  0xDB, 0x81, 0xD8, 0xA1, 0xD8, 0xA2, 0xD8, 0xA3, 0xD8, 0xA4,
+  0xD8, 0xA5, 0xD8, 0xA6, 0xD8, 0xA7, 0xD8, 0xA8, 0xD8, 0xA9,
+  0xD8, 0xAA, 0xD8, 0xAB, 0xD8, 0xAC, 0xD8, 0xAD, 0xD8, 0xAE,
+  0xD8, 0xAF, 0xD8, 0xB0, 0xD8, 0xB1, 0xD8, 0xB2, 0xD8, 0xB3,
+  0xD8, 0xB4, 0xD8, 0xB5, 0xD8, 0xB6, 0xD8, 0xB7, 0xD8, 0xB8,
+  0xD8, 0xB9, 0xD8, 0xBA, 0xD9, 0x80, 0xD9, 0x81, 0xD9, 0x82,
+  0xD9, 0x83, 0x00
+};
+
+// ftp://ftp.unicode.org/Public/MAPPINGS/VENDORS/MICSFT/WINDOWS/CP874.TXT
+static const uint8_t refCP874[] = {
+  //match column width with utf8 version to make it easier to spot any errors
+  //or make changes
+  0xE0, 0xE1, 0xE2, 0xE3,
+  0xE4, 0xE5, 0xE6, 0xE7,
+  0xE8, 0xE9, 0xEA, 0xEB,
+  0xEC, 0xED, 0xEE, 0xEF,
+  0xF0, 0xF1, 0xF2, 0xF3,
+  0xF4, 0xF5, 0xF6, 0xF7,
+  0xF8, 0xF9, 0xFA, 0xFB,
+  0x00
+};
+
+static const uint8_t CP874asUTF8[] = {
+  //uses 3 bytes
+  0xE0, 0xB9, 0x80, 0xE0, 0xB9, 0x81, 0xE0, 0xB9, 0x82, 0xE0, 0xB9, 0x83,
+  0xE0, 0xB9, 0x84, 0xE0, 0xB9, 0x85, 0xE0, 0xB9, 0x86, 0xE0, 0xB9, 0x87,
+  0xE0, 0xB9, 0x88, 0xE0, 0xB9, 0x89, 0xE0, 0xB9, 0x8A, 0xE0, 0xB9, 0x8B,
+  0xE0, 0xB9, 0x8C, 0xE0, 0xB9, 0x8D, 0xE0, 0xB9, 0x8E, 0xE0, 0xB9, 0x8F,
+  0xE0, 0xB9, 0x90, 0xE0, 0xB9, 0x91, 0xE0, 0xB9, 0x92, 0xE0, 0xB9, 0x93,
+  0xE0, 0xB9, 0x94, 0xE0, 0xB9, 0x95, 0xE0, 0xB9, 0x96, 0xE0, 0xB9, 0x97,
+  0xE0, 0xB9, 0x98, 0xE0, 0xB9, 0x99, 0xE0, 0xB9, 0x9A, 0xE0, 0xB9, 0x9B,
+  0x00
+};
+
+// ftp://ftp.unicode.org/Public/MAPPINGS/VENDORS/MICSFT/WINDOWS/CP932.TXT
+static const uint8_t refCP932[] = {
+  //match column width with utf8 version to make it easier to spot any errors
+  //or make changes
+  0xC0, 0xC1, 0xC2, 0xC3,
+  0xC4, 0xC5, 0xC6, 0xC7,
+  0xC8, 0xC9, 0xCA, 0xCB,
+  0xCC, 0xCD, 0xCE, 0xCF,
+  0x00
+};
+
+static const uint8_t CP932asUTF8[] = {
+  //uses 3 bytes
+  0xEF, 0xBE, 0x80, 0xEF, 0xBE, 0x81, 0xEF, 0xBE, 0x82, 0xEF, 0xBE, 0x83,
+  0xEF, 0xBE, 0x84, 0xEF, 0xBE, 0x85, 0xEF, 0xBE, 0x86, 0xEF, 0xBE, 0x87,
+  0xEF, 0xBE, 0x88, 0xEF, 0xBE, 0x89, 0xEF, 0xBE, 0x8A, 0xEF, 0xBE, 0x8B,
+  0xEF, 0xBE, 0x8C, 0xEF, 0xBE, 0x8D, 0xEF, 0xBE, 0x8E, 0xEF, 0xBE, 0x8F,
+  0x00
+};
+
+// ftp://ftp.unicode.org/Public/MAPPINGS/VENDORS/MICSFT/WINDOWS/CP932.TXT
+static const uint8_t refCP932Hiranga[] = {
+  //uses 2 bytes
+  0x82, 0xB0, 0x82, 0xB1, 0x82, 0xB2, 0x82, 0xB3,
+  0x82, 0xB4, 0x82, 0xB5, 0x82, 0xB6, 0x82, 0xB7,
+  0x82, 0xB8, 0x82, 0xB9, 0x82, 0xBA, 0x82, 0xBB,
+  0x82, 0xBC, 0x82, 0xBD, 0x82, 0xBE, 0x82, 0xBF,
+  0x00
+};
+
+static const uint8_t CP932HirangaAsUTF8[] = {
+  //uses 3 bytes
+  0xE3, 0x81, 0x92, 0xE3, 0x81, 0x93, 0xE3, 0x81, 0x94, 0xE3, 0x81, 0x95,
+  0xE3, 0x81, 0x96, 0xE3, 0x81, 0x97, 0xE3, 0x81, 0x98, 0xE3, 0x81, 0x99,
+  0xE3, 0x81, 0x9A, 0xE3, 0x81, 0x9B, 0xE3, 0x81, 0x9C, 0xE3, 0x81, 0x9D,
+  0xE3, 0x81, 0x9E, 0xE3, 0x81, 0x9F, 0xE3, 0x81, 0xA0, 0xE3, 0x81, 0xA1,
+  0x00
+};
+
+static const uint16_t bidiLogicalOrder_1_UTF16LE[] = {
+  /* Arabic mathematical Symbols 0x1EE00 - 0x1EE1B */
+  0xD83B, 0xDE00, 0xD83B, 0xDE01, 0xD83B, 0xDE02, 0xD83B, 0xDE03, 0x20,
+  0xD83B, 0xDE24, 0xD83B, 0xDE05, 0xD83B, 0xDE06, 0x20,
+  0xD83B, 0xDE07, 0xD83B, 0xDE08, 0xD83B, 0xDE09, 0x20,
+  0xD83B, 0xDE0A, 0xD83B, 0xDE0B, 0xD83B, 0xDE0C, 0xD83B, 0xDE0D, 0x20,
+  0xD83B, 0xDE0E, 0xD83B, 0xDE0F, 0xD83B, 0xDE10, 0xD83B, 0xDE11, 0x20,
+  0xD83B, 0xDE12, 0xD83B, 0xDE13, 0xD83B, 0xDE14, 0xD83B, 0xDE15, 0x20,
+  0xD83B, 0xDE16, 0xD83B, 0xDE17, 0xD83B, 0xDE18, 0x20,
+  0xD83B, 0xDE19, 0xD83B, 0xDE1A, 0xD83B, 0xDE1B,
+  0X0
+};
+
+static const uint16_t bidiLogicalOrder_2_UTF16LE[] = {
+  /* Arabic mathematical Symbols - Looped Symbols, 0x1EE80 - 0x1EE9B */
+  0xD83B, 0xDE80, 0xD83B, 0xDE81, 0xD83B, 0xDE82, 0xD83B, 0xDE83, 0x20,
+  0xD83B, 0xDE84, 0xD83B, 0xDE85, 0xD83B, 0xDE86, 0x20,
+  0xD83B, 0xDE87, 0xD83B, 0xDE88, 0xD83B, 0xDE89, 0x20,
+  0xD83B, 0xDE8B, 0xD83B, 0xDE8C, 0xD83B, 0xDE8D, 0x20,
+  0xD83B, 0xDE8E, 0xD83B, 0xDE8F, 0xD83B, 0xDE90, 0xD83B, 0xDE91, 0x20,
+  0xD83B, 0xDE92, 0xD83B, 0xDE93, 0xD83B, 0xDE94, 0xD83B, 0xDE95, 0x20,
+  0xD83B, 0xDE96, 0xD83B, 0xDE97, 0xD83B, 0xDE98, 0x20,
+  0xD83B, 0xDE99, 0xD83B, 0xDE9A, 0xD83B, 0xDE9B,
+  0x00
+};
+
+static const uint16_t bidiLogicalOrder_3_UTF16LE[] = {
+  /* Arabic mathematical Symbols - Double-struck Symbols, 0x1EEA1 - 0x1EEBB */
+  0xD83B, 0xDEA1, 0xD83B, 0xDEA2, 0xD83B, 0xDEA3, 0x20,
+  0xD83B, 0xDEA5, 0xD83B, 0xDEA6, 0x20,
+  0xD83B, 0xDEA7, 0xD83B, 0xDEA8, 0xD83B, 0xDEA9, 0x20,
+  0xD83B, 0xDEAB, 0xD83B, 0xDEAC, 0xD83B, 0xDEAD, 0x20,
+  0xD83B, 0xDEAE, 0xD83B, 0xDEAF, 0xD83B, 0xDEB0, 0xD83B, 0xDEB1, 0x20,
+  0xD83B, 0xDEB2, 0xD83B, 0xDEB3, 0xD83B, 0xDEB4, 0xD83B, 0xDEB5, 0x20,
+  0xD83B, 0xDEB6, 0xD83B, 0xDEB7, 0xD83B, 0xDEB8, 0x20,
+  0xD83B, 0xDEB9, 0xD83B, 0xDEBA, 0xD83B, 0xDEBB,
+  0x00
+};
+
+static const uint16_t bidiLogicalOrder_4_UTF16LE[] = {
+  /* Arabic mathematical Symbols - Initial Symbols, 0x1EE21 - 0x1EE3B */
+  0xD83B, 0xDE21, 0xD83B, 0xDE22, 0x20,
+  0xD83B, 0xDE27, 0xD83B, 0xDE29, 0x20,
+  0xD83B, 0xDE2A, 0xD83B, 0xDE2B, 0xD83B, 0xDE2C, 0xD83B, 0xDE2D, 0x20,
+  0xD83B, 0xDE2E, 0xD83B, 0xDE2F, 0xD83B, 0xDE30, 0xD83B, 0xDE31, 0x20,
+  0xD83B, 0xDE32, 0xD83B, 0xDE34, 0xD83B, 0xDE35, 0x20,
+  0xD83B, 0xDE36, 0xD83B, 0xDE37, 0x20,
+  0xD83B, 0xDE39, 0xD83B, 0xDE3B,
+  0x00
+};
+
+static const uint16_t bidiLogicalOrder_5_UTF16LE[] = {
+  /* Arabic mathematical Symbols - Tailed Symbols */
+  0xD83B, 0xDE42, 0xD83B, 0xDE47, 0xD83B, 0xDE49, 0xD83B, 0xDE4B, 0x20,
+  0xD83B, 0xDE4D, 0xD83B, 0xDE4E, 0xD83B, 0xDE4F, 0x20,
+  0xD83B, 0xDE51, 0xD83B, 0xDE52, 0xD83B, 0xDE54, 0xD83B, 0xDE57, 0x20,
+  0xD83B, 0xDE59, 0xD83B, 0xDE5B, 0xD83B, 0xDE5D, 0xD83B, 0xDE5F,
+  0x00
+};
+
+//using control characters RLE and PDF to reverse text
+static const uint16_t bidiLogicalOrder_6_UTF16LE[] = {
+  //AB \RLEשָׁלוֹם\PDF EF
+  //hebrew word shalom
+  0x41, 0x42, 0x20, 0x202B, 0x05E9, 0x05DC, 0x05D5, 0x05DD, 0x202C,
+  0x20, 0x45, 0x46,
+  0x00
+};
+
+static const uint16_t bidiVisualOrder_1_UTF16LE[] = {
+  /* Arabic mathematical Symbols 0x1EE00 - 0x1EE1B */
+  0xD83B, 0xDE1B, 0xD83B, 0xDE1A, 0xD83B, 0xDE19, 0x20,
+  0xD83B, 0xDE18, 0xD83B, 0xDE17, 0xD83B, 0xDE16, 0x20,
+  0xD83B, 0xDE15, 0xD83B, 0xDE14, 0xD83B, 0xDE13, 0xD83B, 0xDE12, 0x20,
+  0xD83B, 0xDE11, 0xD83B, 0xDE10, 0xD83B, 0xDE0F, 0xD83B, 0xDE0E, 0x20,
+  0xD83B, 0xDE0D, 0xD83B, 0xDE0C, 0xD83B, 0xDE0B, 0xD83B, 0xDE0A, 0x20,
+  0xD83B, 0xDE09, 0xD83B, 0xDE08, 0xD83B, 0xDE07, 0x20,
+  0xD83B, 0xDE06, 0xD83B, 0xDE05, 0xD83B, 0xDE24, 0x20,
+  0xD83B, 0xDE03, 0xD83B, 0xDE02, 0xD83B, 0xDE01, 0xD83B, 0xDE00,
+  0x00
+};
+
+static const uint16_t bidiVisualOrder_2_UTF16LE[] = {
+  /* Arabic mathematical Symbols - Looped Symbols, 0x1EE80 - 0x1EE9B */
+  0xD83B, 0xDE9B, 0xD83B, 0xDE9A, 0xD83B, 0xDE99, 0x20,
+  0xD83B, 0xDE98, 0xD83B, 0xDE97, 0xD83B, 0xDE96, 0x20,
+  0xD83B, 0xDE95, 0xD83B, 0xDE94, 0xD83B, 0xDE93, 0xD83B, 0xDE92, 0x20,
+  0xD83B, 0xDE91, 0xD83B, 0xDE90, 0xD83B, 0xDE8F, 0xD83B, 0xDE8E, 0x20,
+  0xD83B, 0xDE8D, 0xD83B, 0xDE8C, 0xD83B, 0xDE8B, 0x20,
+  0xD83B, 0xDE89, 0xD83B, 0xDE88, 0xD83B, 0xDE87, 0x20,
+  0xD83B, 0xDE86, 0xD83B, 0xDE85, 0xD83B, 0xDE84, 0x20,
+  0xD83B, 0xDE83, 0xD83B, 0xDE82, 0xD83B, 0xDE81, 0xD83B, 0xDE80,
+  0x00
+};
+
+static const uint16_t bidiVisualOrder_3_UTF16LE[] = {
+  /* Arabic mathematical Symbols - Double-struck Symbols, 0x1EEA1 - 0x1EEBB */
+  0xD83B, 0xDEBB, 0xD83B, 0xDEBA, 0xD83B, 0xDEB9, 0x20,
+  0xD83B, 0xDEB8, 0xD83B, 0xDEB7, 0xD83B, 0xDEB6, 0x20,
+  0xD83B, 0xDEB5, 0xD83B, 0xDEB4, 0xD83B, 0xDEB3, 0xD83B, 0xDEB2, 0x20,
+  0xD83B, 0xDEB1, 0xD83B, 0xDEB0, 0xD83B, 0xDEAF, 0xD83B, 0xDEAE, 0x20,
+  0xD83B, 0xDEAD, 0xD83B, 0xDEAC, 0xD83B, 0xDEAB, 0x20,
+  0xD83B, 0xDEA9, 0xD83B, 0xDEA8, 0xD83B, 0xDEA7, 0x20,
+  0xD83B, 0xDEA6, 0xD83B, 0xDEA5, 0x20,
+  0xD83B, 0xDEA3, 0xD83B, 0xDEA2, 0xD83B, 0xDEA1,
+  0x00
+};
+
+static const uint16_t bidiVisualOrder_4_UTF16LE[] = {
+  /* Arabic mathematical Symbols - Initial Symbols, 0x1EE21 - 0x1EE3B */
+  0xD83B, 0xDE3B, 0xD83B, 0xDE39, 0x20,
+  0xD83B, 0xDE37, 0xD83B, 0xDE36, 0x20,
+  0xD83B, 0xDE35, 0xD83B, 0xDE34, 0xD83B, 0xDE32, 0x20,
+  0xD83B, 0xDE31, 0xD83B, 0xDE30, 0xD83B, 0xDE2F, 0xD83B, 0xDE2E, 0x20,
+  0xD83B, 0xDE2D, 0xD83B, 0xDE2C, 0xD83B, 0xDE2B, 0xD83B, 0xDE2A, 0x20,
+  0xD83B, 0xDE29, 0xD83B, 0xDE27, 0x20,
+  0xD83B, 0xDE22, 0xD83B, 0xDE21,
+  0x00
+};
+
+static const uint16_t bidiVisualOrder_5_UTF16LE[] = {
+  /* Arabic mathematical Symbols - Tailed Symbols */
+  0xD83B, 0xDE5F, 0xD83B, 0xDE5D, 0xD83B, 0xDE5B, 0xD83B, 0xDE59, 0x20,
+  0xD83B, 0xDE57, 0xD83B, 0xDE54, 0xD83B, 0xDE52, 0xD83B, 0xDE51, 0x20,
+  0xD83B, 0xDE4F, 0xD83B, 0xDE4E, 0xD83B, 0xDE4D, 0x20,
+  0xD83B, 0xDE4B, 0xD83B, 0xDE49, 0xD83B, 0xDE47, 0xD83B, 0xDE42,
+  0x00
+};
+
+//using control characters RLE and PDF to reverse text
+static const uint16_t bidiVisualOrder_6_UTF16LE[] = {
+  //AB (hebrew word shalom) EF
+  0x41, 0x42, 0x20, 0x05DD, 0x05D5, 0x05DC, 0x05E9,
+  0x20, 0x45, 0x46,
+  0x00
+};
+
+//From normalizationtest.txt in the unicode standard
+static const uint16_t normalizationTestSource1[] = {
+  0x00E5, 0x0000 // (å; å; a◌̊; å; a◌̊; ) LATIN SMALL LETTER A WITH RING ABOVE
+};
+
+static const uint16_t normalizationTestSource2[] = {
+  0xD7A3, 0x0000 // (힣; 힣; 힣; 힣; 힣; ) HANGUL SYLLABLE HIH
+};
+
+static const uint16_t normalizationTestSource3[] = {
+  0xF900, 0x0000 // (豈; 豈; 豈; 豈; 豈; ) CJK COMPATIBILITY IDEOGRAPH - F900
+};
+
+static const uint16_t normalizationTestNFC1[] = {
+  0x00E5, 0x0000 // (å; å; a◌̊; å; a◌̊; ) LATIN SMALL LETTER A WITH RING ABOVE
+};
+
+static const uint16_t normalizationTestNFC2[] = {
+  0xD7A3, 0x0000 //(힣; 힣; 힣; 힣; 힣; ) HANGUL SYLLABLE HIH
+};
+
+static const uint16_t normalizationTestNFC3[] = {
+  0x8C48, 0x0000 //(豈; 豈; 豈; 豈; 豈; ) CJK COMPATIBILITY IDEOGRAPH - F900
+};
+
+static const uint16_t normalizationTestNFD1[] = {
+  0x0061, 0x030A, 0x00 //(å; å; a◌̊; å; a◌̊; ) LATIN SMALL LETTER A WITH RING ABOVE
+};
+
+static const uint16_t normalizationTestNFD2[] = {
+  0x1112, 0x1175, 0x11C2, 0x0000 //(힣; 힣; 힣; 힣; 힣; ) HANGUL SYLLABLE HIH
+};
+
+static const uint16_t normalizationTestNFD3[] = {
+  0x8C48, 0x0000 //(豈; 豈; 豈; 豈; 豈; ) CJK COMPATIBILITY IDEOGRAPH - F900
+};
+
+static const uint16_t normalizationTestNFDMac1[] = {
+  0x0061, 0x030A, 0x00 //(å; å; a◌̊; å; a◌̊; ) LATIN SMALL LETTER A WITH RING ABOVE
+};
+
+static const uint16_t normalizationTestNFDMac2[] = {
+  0x1112, 0x1175, 0x11C2, 0x0000 //(힣; 힣; 힣; 힣; 힣; ) HANGUL SYLLABLE HIH
+};
+
+static const uint16_t normalizationTestNFDMac3[] = {
+  0x8C48, 0x0000 //(豈; 豈; 豈; 豈; 豈; ) CJK COMPATIBILITY IDEOGRAPH - F900
+};
+
+// for realistic test results all characters in the next sequences are real characters from Unicode tables
+
+// two bytes UTF-8 sequences and corresponding wide strings
+static const unsigned char testCyrUtf8u[] = {
+  0xD0, 0x90, 0xD0, 0x91, 0xD0, 0x92, 0xD0, 0x93, 0xD0, 0x94, 0xD0, 0x95, 0xD0, 0x96, 0xD0, 0x97, 0xD0, 0x98, 0xD0, 0x99, 0xD0, 0x9A, 0xD0,
+  0x9B, 0xD0, 0x9C, 0xD0, 0x9D, 0xD0, 0x9E, 0xD0, 0x9F, 0xD0, 0xA0, 0xD0, 0xA1, 0xD0, 0xA2, 0xD0, 0xA3, 0xD0, 0xA4, 0xD0, 0xA5, 0xD0, 0xA6,
+  0xD0, 0xA7, 0xD0, 0xA8, 0xD0, 0xA9, 0xD0, 0xAA, 0xD0, 0xAB, 0xD0, 0xAC, 0xD0, 0xAD, 0xD0, 0xAE, 0xD0, 0xAF, 0xD0, 0xB0, 0xD0, 0xB1, 0xD0,
+  0xB2, 0xD0, 0xB3, 0xD0, 0xB4, 0xD0, 0xB5, 0xD0, 0xB6, 0xD0, 0xB7, 0xD0, 0xB8, 0xD0, 0xB9, 0xD0, 0xBA, 0xD0, 0xBB, 0xD0, 0xBC, 0xD0, 0xBD,
+  0xD0, 0xBE, 0xD0, 0xBF, 0xD1, 0x80, 0xD1, 0x81, 0xD1, 0x82, 0xD1, 0x83, 0xD1, 0x84, 0xD1, 0x85, 0xD1, 0x86, 0xD1, 0x87, 0xD1, 0x88, 0xD1,
+  0x89, 0xD1, 0x8A, 0xD1, 0x8B, 0xD1, 0x8C, 0xD1, 0x8D, 0xD1, 0x8E, 0xD1, 0x8F, 0 
+};
+static const char* const testCyrUtf8 = (const char*)testCyrUtf8u;
+
+static const wchar_t testCyrW[] = {
+  0x410, 0x411, 0x412, 0x413, 0x414, 0x415, 0x416, 0x417, 0x418, 0x419, 0x41A, 0x41B, 0x41C, 0x41D, 0x41E, 0x41F, 0x420, 0x421, 0x422, 0x423,
+  0x424, 0x425, 0x426, 0x427, 0x428, 0x429, 0x42A, 0x42B, 0x42C, 0x42D, 0x42E, 0x42F, 0x430, 0x431, 0x432, 0x433, 0x434, 0x435, 0x436, 0x437,
+  0x438, 0x439, 0x43A, 0x43B, 0x43C, 0x43D, 0x43E, 0x43F, 0x440, 0x441, 0x442, 0x443, 0x444, 0x445, 0x446, 0x447, 0x448, 0x449, 0x44A, 0x44B,
+  0x44C, 0x44D, 0x44E, 0x44F, 0 
+};
+
+static const unsigned char testGreekUtf8u[] = {
+  0xCE, 0x91, 0xCE, 0x92, 0xCE, 0x93, 0xCE, 0x94, 0xCE, 0x95, 0xCE, 0x96, 0xCE, 0x97, 0xCE, 0x98, 0xCE, 0x99, 0xCE, 0x9A, 0xCE, 0x9B, 0xCF,
+  0x80, 0xCF, 0x81, 0xCF, 0x82, 0xCF, 0x83, 0xCF, 0x84, 0xCF, 0x85, 0xCF, 0x86, 0xCF, 0x87, 0xCF, 0x88, 0xCF, 0x89, 0
+};
+static const char* const testGreekUtf8 = (const char*)testGreekUtf8u;
+
+static const wchar_t testGreekW[] ={
+  0x391, 0x392, 0x393, 0x394, 0x395, 0x396, 0x397, 0x398, 0x399, 0x39A, 0x39B, 0x3C0, 0x3C1, 0x3C2, 0x3C3, 0x3C4, 0x3C5, 0x3C6, 0x3C7, 0x3C8,
+  0x3C9, 0
+};
+
+static const unsigned char testArmUtf8u[] = {
+  0xD4, 0xB1, 0xD4, 0xB2, 0xD4, 0xB3, 0xD4, 0xB4, 0xD4, 0xB5, 0xD4, 0xB6, 0xD4, 0xB7, 0xD4, 0xB8, 0xD4, 0xB9, 0xD4, 0xBA, 0xD5, 0xA7, 0xD5,
+  0xA8, 0xD5, 0xA9, 0xD5, 0xAA, 0xD5, 0xAB, 0xD5, 0xAC, 0xD5, 0xAD, 0xD5, 0xAE, 0xD5, 0xAF, 0xD5, 0xB0, 0xD5, 0xB1, 0xD5, 0xB2, 0
+};
+static const char* const testArmUtf8 = (const char*)testArmUtf8u;
+
+static const wchar_t testArmW[] = {
+  0x531, 0x532, 0x533, 0x534, 0x535, 0x536, 0x537, 0x538, 0x539, 0x53A, 0x567, 0x568, 0x569, 0x56A, 0x56B, 0x56C, 0x56D, 0x56E, 0x56F, 0x570,
+  0x571, 0x572, 0
+};
+
+// three bytes UTF-8 sequences and corresponding wide strings
+static const unsigned char testDevnUtf8u[] = {
+  0xE0, 0xA4, 0x84, 0xE0, 0xA4, 0x85, 0xE0, 0xA4, 0x86, 0xE0, 0xA4, 0x87, 0xE0, 0xA4, 0x88, 0xE0, 0xA4, 0x89, 0xE0, 0xA4, 0x8A, 0xE0, 0xA4,
+  0x8B, 0xE0, 0xA4, 0x8C, 0xE0, 0xA4, 0x8D, 0xE0, 0xA4, 0x8E, 0xE0, 0xA5, 0xBB, 0xE0, 0xA5, 0xBC, 0xE0, 0xA5, 0xBD, 0xE0, 0xA5, 0xBE, 0xE0,
+  0xA5, 0xBF, 0
+};
+static const char* const testDevnUtf8 = (const char*)testDevnUtf8u;
+
+static const wchar_t testDevnW[] = {
+  0x904, 0x905, 0x906, 0x907, 0x908, 0x909, 0x90A, 0x90B, 0x90C, 0x90D, 0x90E, 0x97B, 0x97C, 0x97D, 0x97E, 0x97F, 0
+};
+
+static const unsigned char testGeorgUtf8u[] = {
+  0xE1, 0x82, 0xA0, 0xE1, 0x82, 0xA1, 0xE1, 0x82, 0xA2, 0xE1, 0x82, 0xA3, 0xE1, 0x82, 0xA4, 0xE1, 0x82, 0xA5, 0xE1, 0x82, 0xA6, 0xE1, 0x83,
+  0xA8, 0xE1, 0x83, 0xA9, 0xE1, 0x83, 0xAA, 0xE1, 0x83, 0xAB, 0xE1, 0x83, 0xAC, 0xE1, 0x83, 0xAD, 0xE1, 0x83, 0xAE, 0xE1, 0x83, 0xAF, 0
+};
+static const char* const testGeorgUtf8 = (const char*)testGeorgUtf8u;
+
+static const wchar_t testGeorgW[] = {
+  0x10A0, 0x10A1, 0x10A2, 0x10A3, 0x10A4, 0x10A5, 0x10A6, 0x10E8, 0x10E9, 0x10EA, 0x10EB, 0x10EC, 0x10ED, 0x10EE, 0x10EF, 0
+};
+
+static const unsigned char testCJKUtf8u[] = {
+  0xE7, 0x81, 0xB5, 0xE7, 0x81, 0xB6, 0xE7, 0x81, 0xB7, 0xE7, 0x81, 0xB8, 0xE7, 0x81, 0xB9, 0xE7, 0x81, 0xBA, 0xE7, 0x81, 0xBB, 0xE7, 0x83,
+  0xA9, 0xE7, 0x83, 0xAA, 0xE7, 0x83, 0xAB, 0xE7, 0x83, 0xAC, 0xE7, 0x83, 0xAD, 0
+};
+static const char* const testCJKUtf8 = (const char*)testCJKUtf8u;
+
+static const wchar_t testCJKW[] = {
+  0x7075, 0x7076, 0x7077, 0x7078, 0x7079, 0x707A, 0x707B, 0x70E9, 0x70EA, 0x70EB, 0x70EC, 0x70ED, 0
+};
+
+static const unsigned char testArLiUtf8u[] = {
+  0xEF, 0xB5, 0x94, 0xEF, 0xB5, 0x95, 0xEF, 0xB5, 0x96, 0xEF, 0xB5, 0x97, 0xEF, 0xB5, 0x98, 0xEF, 0xB6, 0xA7, 0xEF, 0xB6, 0xA8, 0
+};
+static const char* const testArLiUtf8 = (const char*)testArLiUtf8u;
+
+static const wchar_t testArLiW[] = {
+  0xFD54, 0xFD55, 0xFD56, 0xFD57, 0xFD58, 0xFDA7, 0xFDA8, 0
+};
+
+// four bytes UTF-8 sequences
+static const unsigned char testLinBIdeoUtf8u[] = {
+  0xF0, 0x90, 0x82, 0x82, 0xF0, 0x90, 0x82, 0x83, 0xF0, 0x90, 0x82, 0x84, 0xF0, 0x90, 0x82, 0x85, 0xF0, 0x90, 0x83, 0xA8, 0xF0, 0x90, 0x83,
+  0xA9, 0xF0, 0x90, 0x83, 0xAA, 0xF0, 0x90, 0x83, 0xAB, 0xF0, 0x90, 0x83, 0xAC, 0xF0, 0x90, 0x83, 0xAD, 0
+};
+static const char* const testLinBIdeoUtf8 = (const char*)testLinBIdeoUtf8u;
+
+static const unsigned char testCJKComIdUtf8u[] = {
+  0xF0, 0xAF, 0xA1, 0xA3, 0xF0, 0xAF, 0xA1, 0xA4, 0xF0, 0xAF, 0xA1, 0xA5, 0xF0, 0xAF, 0xA1, 0xA6, 0xF0, 0xAF, 0xA1, 0xA7, 0xF0, 0xAF, 0xA1,
+  0xA8, 0xF0, 0xAF, 0xA3, 0x96, 0xF0, 0xAF, 0xA3, 0x97, 0xF0, 0xAF, 0xA3, 0x98, 0xF0, 0xAF, 0xA3, 0x99, 0xF0, 0xAF, 0xA3, 0x9A, 0
+};
+static const char* const testCJKComIdUtf8 = (const char*)testCJKComIdUtf8u;
+
+static const unsigned char testTagsUtf8u[] = {
+  0xF3, 0xA0, 0x80, 0xA1, 0xF3, 0xA0, 0x80, 0xA2, 0xF3, 0xA0, 0x80, 0xA3, 0xF3, 0xA0, 0x80, 0xA4, 0xF3, 0xA0, 0x80, 0xA5, 0xF3, 0xA0, 0x80,
+  0xA6, 0xF3, 0xA0, 0x80, 0xA7, 0xF3, 0xA0, 0x80, 0xA8, 0xF3, 0xA0, 0x80, 0xA9, 0xF3, 0xA0, 0x80, 0xAA, 0xF3, 0xA0, 0x81, 0xAA, 0xF3, 0xA0,
+  0x81, 0xAB, 0xF3, 0xA0, 0x81, 0xAC, 0xF3, 0xA0, 0x81, 0xAD, 0xF3, 0xA0, 0x81, 0xAE, 0xF3, 0xA0, 0x81, 0xAF, 0
+};
+static const char* const testTagsUtf8 = (const char*)testTagsUtf8u;
+
+
+template<typename T>
+std::string toHex(const T& str)
 {
-  refstra1 = "test utf8ToW";
-  refstrw1 = L"test utf8ToW";
-  varstrw1.clear();
-  g_charsetConverter.utf8ToW(refstra1, varstrw1, true, false, false);
-  EXPECT_STREQ(refstrw1.c_str(), varstrw1.c_str());
+  std::string result = "\"";
+  char buf[16];
+
+  for (size_t i = 0; i < str.length(); ++i)
+  {
+    snprintf(buf, 16, "\\%#X", str[i]);
+    buf[15] = 0;
+    result.append(buf);
+  }
+  result.append("\"");
+
+  return result;
+}
+
+template<typename STR>
+::testing::AssertionResult AssertStringEquals(const char* exp_expr,
+                                              const char* act_expr,
+                                              STR& exp,
+                                              STR& act) 
+{
+  if (exp == act)
+    return ::testing::AssertionSuccess();
+
+  return ::testing::AssertionFailure()
+    << "Value of: " << act_expr << std::endl
+    << "Actual: " << toHex(act) << std::endl
+    << "Expected: " << exp_expr << std::endl
+    << "Which is: " << toHex(exp);
 }
 
 
-//TEST_F(TestCharsetConverter, utf16LEtoW)
-//{
-//  refstrw1 = L"ｔｅｓｔ＿ｕｔｆ１６ＬＥｔｏｗ";
-//  /* TODO: Should be able to use '=' operator instead of assign() */
-//  std::wstring refstr16_1;
-//  refstr16_1.assign(refutf16LE1);
-//  varstrw1.clear();
-//  g_charsetConverter.utf16LEtoW(refstr16_1, varstrw1);
-//  EXPECT_STREQ(refstrw1.c_str(), varstrw1.c_str());
-//}
+class TestCharsetConverter : public testing::Test
+{
+protected:
+
+  std::string refstra1, refstra2, varstra1;
+  std::wstring refstrw1, varstrw1;
+  std::u16string refstr16_1, varstr16_1;
+  std::u32string refstr32_1, varstr32_1;
+  std::string refstr1;
+};
+
+TEST_F(TestCharsetConverter, utf8ToSystemSafe_1)
+{
+  uint16_t c[] = { 0xFA1B, 0x0000 };
+  std::u16string cs((char16_t*)c);
+
+  std::string u8str;
+  std::string u8str2;
+
+  g_charsetConverter.Utf16LEToUtf8(cs, u8str);
+  ASSERT_TRUE(g_charsetConverter.Utf8ToSystemSafe(u8str, u8str2));
+}
+
+TEST_F(TestCharsetConverter, systemToUtf8_CP1251)
+{
+  std::string data((char*)&refCP1251);
+  std::string expected((char*)&CP1251asUTF8);
+  std::string temp;
+  const char* defCodePage = ucnv_getDefaultName();
+  ucnv_setDefaultName("CP-1251"); //simulate CP1251 as system codepage
+  g_charsetConverter.SystemToUtf8(data, temp);
+  ucnv_setDefaultName(defCodePage); //reset codepage to avoid tainting other tests
+  EXPECT_STREQ(expected.c_str(), temp.c_str());
+}
+
+TEST_F(TestCharsetConverter, systemToUtf8_CP1252)
+{
+  std::string data((char*)&refCP1252);
+  std::string expected((char*)&CP1252asUTF8);
+  std::string temp;
+  const char* defCodePage = ucnv_getDefaultName();
+  ucnv_setDefaultName("CP-1252"); //simulate CP1252 as system codepage
+  g_charsetConverter.SystemToUtf8(data, temp);
+  ucnv_setDefaultName(defCodePage); //reset codepage to avoid tainting other tests
+  EXPECT_STREQ(expected.c_str(), temp.c_str());
+}
+
+TEST_F(TestCharsetConverter, systemToUtf8_CP1253)
+{
+  std::string data((char*)&refCP1253);
+  std::string expected((char*)&CP1253asUTF8);
+  std::string temp;
+  const char* defCodePage = ucnv_getDefaultName();
+  ucnv_setDefaultName("CP-1253"); //simulate CP1253 as system codepage
+  g_charsetConverter.SystemToUtf8(data, temp);
+  ucnv_setDefaultName(defCodePage); //reset codepage to avoid tainting other tests
+  EXPECT_STREQ(expected.c_str(), temp.c_str());
+}
+
+TEST_F(TestCharsetConverter, systemToUtf8_CP1255)
+{
+  std::string data((char*)&refCP1255);
+  std::string expected((char*)&CP1255asUTF8);
+  std::string temp;
+  const char* defCodePage = ucnv_getDefaultName();
+  ucnv_setDefaultName("CP-1255"); //simulate CP1255 as system codepage
+  g_charsetConverter.SystemToUtf8(data, temp);
+  ucnv_setDefaultName(defCodePage); //reset codepage to avoid tainting other tests
+  EXPECT_STREQ(expected.c_str(), temp.c_str());
+}
+
+TEST_F(TestCharsetConverter, systemToUtf8_CP1256)
+{
+  std::string data((char*)&refCP1256);
+  std::string expected((char*)&CP1256asUTF8);
+  std::string temp;
+  const char* defCodePage = ucnv_getDefaultName();
+  ucnv_setDefaultName("CP-1256"); //simulate CP1256 as system codepage
+  g_charsetConverter.SystemToUtf8(data, temp);
+  ucnv_setDefaultName(defCodePage); //reset codepage to avoid tainting other tests
+  EXPECT_STREQ(expected.c_str(), temp.c_str());
+}
+
+TEST_F(TestCharsetConverter, systemToUtf8_CP874)
+{
+  std::string data((char*)&refCP874);
+  std::string expected((char*)&CP874asUTF8);
+  std::string temp;
+  const char* defCodePage = ucnv_getDefaultName();
+  ucnv_setDefaultName("CP-874"); //simulate CP874 as system codepage
+  g_charsetConverter.SystemToUtf8(data, temp);
+  ucnv_setDefaultName(defCodePage); //reset codepage to avoid tainting other tests
+  EXPECT_STREQ(expected.c_str(), temp.c_str());
+}
+
+TEST_F(TestCharsetConverter, systemToUtf8_CP932)
+{
+  std::string data((char*)&refCP932);
+  std::string expected((char*)&CP932asUTF8);
+  std::string temp;
+  const char* defCodePage = ucnv_getDefaultName();
+  ucnv_setDefaultName("CP-932"); //simulate CP932 as system codepage
+  g_charsetConverter.SystemToUtf8(data, temp);
+  ucnv_setDefaultName(defCodePage); //reset codepage to avoid tainting other tests
+  EXPECT_STREQ(expected.c_str(), temp.c_str());
+}
+
+TEST_F(TestCharsetConverter, systemToUtf8_CP932Hiranga)
+{
+  std::string data((char*)&refCP932Hiranga);
+  std::string expected((char*)&CP932HirangaAsUTF8);
+  std::string temp;
+  const char* defCodePage = ucnv_getDefaultName();
+  ucnv_setDefaultName("CP-932"); //simulate CP932 as system codepage
+  g_charsetConverter.SystemToUtf8(data, temp);
+  ucnv_setDefaultName(defCodePage); //reset codepage to avoid tainting other tests
+  EXPECT_STREQ(expected.c_str(), temp.c_str());
+}
+
+TEST_F(TestCharsetConverter, utf8ToSystem_CP1251)
+{
+  std::string source((char*)&CP1251asUTF8);
+  std::string expected((char*)&refCP1251);
+  const char* defCodePage = ucnv_getDefaultName();
+
+  ucnv_setDefaultName("CP-1251");
+  g_charsetConverter.Utf8ToSystem(source);
+  ucnv_setDefaultName(defCodePage);
+  EXPECT_STREQ(expected.c_str(), source.c_str());
+}
+
+TEST_F(TestCharsetConverter, utf8ToSystem_CP1252)
+{
+  std::string source((char*)&CP1252asUTF8);
+  std::string expected((char*)&refCP1252);
+  const char* defCodePage = ucnv_getDefaultName();
+
+  ucnv_setDefaultName("CP-1252");
+  g_charsetConverter.Utf8ToSystem(source);
+  ucnv_setDefaultName(defCodePage);
+  EXPECT_STREQ(expected.c_str(), source.c_str());
+}
+
+TEST_F(TestCharsetConverter, utf8ToSystem_CP1253)
+{
+  std::string source((char*)&CP1253asUTF8);
+  std::string expected((char*)&refCP1253);
+  const char* defCodePage = ucnv_getDefaultName();
+
+  ucnv_setDefaultName("CP-1253");
+  g_charsetConverter.Utf8ToSystem(source);
+  ucnv_setDefaultName(defCodePage);
+  EXPECT_STREQ(expected.c_str(), source.c_str());
+}
+
+TEST_F(TestCharsetConverter, utf8ToSystem_CP1255)
+{
+  std::string source((char*)&CP1255asUTF8);
+  std::string expected((char*)&refCP1255);
+  const char* defCodePage = ucnv_getDefaultName();
+
+  ucnv_setDefaultName("CP-1255");
+  g_charsetConverter.Utf8ToSystem(source);
+  ucnv_setDefaultName(defCodePage);
+  EXPECT_STREQ(expected.c_str(), source.c_str());
+}
+
+TEST_F(TestCharsetConverter, utf8ToSystem_CP1256)
+{
+  std::string source((char*)&CP1256asUTF8);
+  std::string expected((char*)&refCP1256);
+  const char* defCodePage = ucnv_getDefaultName();
+
+  ucnv_setDefaultName("CP-1256");
+  g_charsetConverter.Utf8ToSystem(source);
+  ucnv_setDefaultName(defCodePage);
+  EXPECT_STREQ(expected.c_str(), source.c_str());
+}
+
+TEST_F(TestCharsetConverter, utf8ToSystem_CP874)
+{
+  std::string source((char*)&CP874asUTF8);
+  std::string expected((char*)&refCP874);
+  const char* defCodePage = ucnv_getDefaultName();
+
+  ucnv_setDefaultName("CP-874");
+  g_charsetConverter.Utf8ToSystem(source);
+  ucnv_setDefaultName(defCodePage);
+  EXPECT_STREQ(expected.c_str(), source.c_str());
+}
+
+TEST_F(TestCharsetConverter, utf8ToSystem_CP932)
+{
+  std::string source((char*)&CP932asUTF8);
+  std::string expected((char*)&refCP932);
+  const char* defCodePage = ucnv_getDefaultName();
+
+  ucnv_setDefaultName("CP-932");
+  g_charsetConverter.Utf8ToSystem(source);
+  ucnv_setDefaultName(defCodePage);
+  EXPECT_STREQ(expected.c_str(), source.c_str());
+}
+
+TEST_F(TestCharsetConverter, utf8ToSystem_CP932Hiranga)
+{
+  std::string source((char*)&CP932HirangaAsUTF8);
+  std::string expected((char*)&refCP932Hiranga);
+  const char* defCodePage = ucnv_getDefaultName();
+
+  ucnv_setDefaultName("CP-932");
+  g_charsetConverter.Utf8ToSystem(source);
+  ucnv_setDefaultName(defCodePage);
+  EXPECT_STREQ(expected.c_str(), source.c_str());
+}
+
+TEST_F(TestCharsetConverter, utf8LogicalToVisual_1)
+{
+  std::u16string u16Source((char16_t*)bidiLogicalOrder_1_UTF16LE);
+  std::u16string u16Expected((char16_t*)bidiVisualOrder_1_UTF16LE);
+
+  std::string source;
+  std::string expected;
+  std::string temp;
+
+  EXPECT_TRUE(g_charsetConverter.Utf16LEToUtf8(u16Source, source));
+  EXPECT_TRUE(g_charsetConverter.Utf16LEToUtf8(u16Expected, expected));
+  EXPECT_TRUE(g_charsetConverter.LogicalToVisualBiDi(source, temp));
+  EXPECT_STREQ(expected.c_str(), temp.c_str());
+}
+
+TEST_F(TestCharsetConverter, utf8LogicalToVisual_2)
+{
+  std::u16string u16Source((char16_t*)bidiLogicalOrder_2_UTF16LE);
+  std::u16string u16Expected((char16_t*)bidiVisualOrder_2_UTF16LE);
+
+  std::string source;
+  std::string expected;
+  std::string temp;
+
+  EXPECT_TRUE(g_charsetConverter.Utf16LEToUtf8(u16Source, source));
+  EXPECT_TRUE(g_charsetConverter.Utf16LEToUtf8(u16Expected, expected));
+  EXPECT_TRUE(g_charsetConverter.LogicalToVisualBiDi(source, temp));
+  EXPECT_STREQ(expected.c_str(), temp.c_str());
+}
+
+TEST_F(TestCharsetConverter, utf8LogicalToVisual_3)
+{
+  std::u16string u16Source((char16_t*)bidiLogicalOrder_3_UTF16LE);
+  std::u16string u16Expected((char16_t*)bidiVisualOrder_3_UTF16LE);
+
+  std::string source;
+  std::string expected;
+  std::string temp;
+
+  EXPECT_TRUE(g_charsetConverter.Utf16LEToUtf8(u16Source, source));
+  EXPECT_TRUE(g_charsetConverter.Utf16LEToUtf8(u16Expected, expected));
+  EXPECT_TRUE(g_charsetConverter.LogicalToVisualBiDi(source, temp));
+  EXPECT_STREQ(expected.c_str(), temp.c_str());
+}
+
+TEST_F(TestCharsetConverter, utf8LogicalToVisual_4)
+{
+  std::u16string u16Source((char16_t*)bidiLogicalOrder_4_UTF16LE);
+  std::u16string u16Expected((char16_t*)bidiVisualOrder_4_UTF16LE);
+
+  std::string source;
+  std::string expected;
+  std::string temp;
+
+  EXPECT_TRUE(g_charsetConverter.Utf16LEToUtf8(u16Source, source));
+  EXPECT_TRUE(g_charsetConverter.Utf16LEToUtf8(u16Expected, expected));
+  EXPECT_TRUE(g_charsetConverter.LogicalToVisualBiDi(source, temp));
+  EXPECT_STREQ(expected.c_str(), temp.c_str());
+}
+
+TEST_F(TestCharsetConverter, utf8LogicalToVisual_5)
+{
+  std::u16string u16Source((char16_t*)bidiLogicalOrder_5_UTF16LE);
+  std::u16string u16Expected((char16_t*)bidiVisualOrder_5_UTF16LE);
+
+  std::string source;
+  std::string expected;
+  std::string temp;
+
+  EXPECT_TRUE(g_charsetConverter.Utf16LEToUtf8(u16Source, source));
+  EXPECT_TRUE(g_charsetConverter.Utf16LEToUtf8(u16Expected, expected));
+  EXPECT_TRUE(g_charsetConverter.LogicalToVisualBiDi(source, temp));
+  EXPECT_STREQ(expected.c_str(), temp.c_str());
+}
+
+TEST_F(TestCharsetConverter, utf16LogicalToVisual_1)
+{
+  std::u16string u16Source((char16_t*)bidiLogicalOrder_1_UTF16LE);
+  std::u16string u16Expected((char16_t*)bidiVisualOrder_1_UTF16LE);
+  std::u16string result;
+
+  g_charsetConverter.LogicalToVisualBiDi(u16Source, result);
+  EXPECT_PRED_FORMAT2(AssertStringEquals, u16Expected, result);
+}
+
+TEST_F(TestCharsetConverter, utf16LogicalToVisual_2)
+{
+  std::u16string u16Source((char16_t*)bidiLogicalOrder_2_UTF16LE);
+  std::u16string u16Expected((char16_t*)bidiVisualOrder_2_UTF16LE);
+  std::u16string result;
+
+  g_charsetConverter.LogicalToVisualBiDi(u16Source, result);
+  EXPECT_PRED_FORMAT2(AssertStringEquals, u16Expected, result);
+}
+
+TEST_F(TestCharsetConverter, utf16LogicalToVisual_3)
+{
+  std::u16string u16Source((char16_t*)bidiLogicalOrder_3_UTF16LE);
+  std::u16string u16Expected((char16_t*)bidiVisualOrder_3_UTF16LE);
+  std::u16string result;
+
+  g_charsetConverter.LogicalToVisualBiDi(u16Source, result);
+  EXPECT_PRED_FORMAT2(AssertStringEquals, u16Expected, result);
+}
+
+TEST_F(TestCharsetConverter, utf16LogicalToVisual_4)
+{
+  std::u16string u16Source((char16_t*)bidiLogicalOrder_4_UTF16LE);
+  std::u16string u16Expected((char16_t*)bidiVisualOrder_4_UTF16LE);
+  std::u16string result;
+
+  g_charsetConverter.LogicalToVisualBiDi(u16Source, result);
+  EXPECT_PRED_FORMAT2(AssertStringEquals, u16Expected, result);
+}
+
+TEST_F(TestCharsetConverter, utf16LogicalToVisual_5)
+{
+  std::u16string u16Source((char16_t*)bidiLogicalOrder_5_UTF16LE);
+  std::u16string u16Expected((char16_t*)bidiVisualOrder_5_UTF16LE);
+  std::u16string result;
+
+  g_charsetConverter.LogicalToVisualBiDi(u16Source, result);
+  EXPECT_PRED_FORMAT2(AssertStringEquals, u16Expected, result);
+}
+
+TEST_F(TestCharsetConverter, utf16LogicalToVisual_6)
+{
+  std::u16string u16Source((char16_t*)bidiLogicalOrder_6_UTF16LE);
+  std::u16string u16Expected((char16_t*)bidiVisualOrder_6_UTF16LE);
+  std::u16string result;
+
+  g_charsetConverter.LogicalToVisualBiDi(u16Source, result,
+                                         CCharsetConverter::LTR |
+                                         CCharsetConverter::REMOVE_CONTROLS);
+  EXPECT_PRED_FORMAT2(AssertStringEquals, u16Expected, result);
+}
+
+TEST_F(TestCharsetConverter, utf8ToW)
+{
+  refstra1 = "test Utf8ToW";
+  refstrw1 = L"test Utf8ToW";
+  varstrw1.clear();
+  g_charsetConverter.Utf8ToW(refstra1, varstrw1);
+  EXPECT_STREQ(refstrw1.c_str(), varstrw1.c_str());
+}
 
 TEST_F(TestCharsetConverter, subtitleCharsetToUtf8)
 {
   refstra1 = "test subtitleCharsetToW";
   varstra1.clear();
-  g_charsetConverter.subtitleCharsetToUtf8(refstra1, varstra1);
+  g_charsetConverter.SubtitleCharsetToUtf8(refstra1, varstra1);
 
   /* Assign refstra1 to refstrw1 so that we can compare */
   EXPECT_STREQ(refstra1.c_str(), varstra1.c_str());
@@ -152,74 +995,113 @@ TEST_F(TestCharsetConverter, subtitleCharsetToUtf8)
 
 TEST_F(TestCharsetConverter, utf8ToStringCharset_1)
 {
-  refstra1 = "test utf8ToStringCharset";
+  refstra1 = "test Utf8ToStringCharset";
   varstra1.clear();
-  g_charsetConverter.utf8ToStringCharset(refstra1, varstra1);
+  g_charsetConverter.Utf8ToStringCharset(refstra1, varstra1);
   EXPECT_STREQ(refstra1.c_str(), varstra1.c_str());
 }
 
 TEST_F(TestCharsetConverter, utf8ToStringCharset_2)
 {
-  refstra1 = "test utf8ToStringCharset";
-  varstra1 = "test utf8ToStringCharset";
-  g_charsetConverter.utf8ToStringCharset(varstra1);
+  refstra1 = "test Utf8ToStringCharset";
+  varstra1 = "test Utf8ToStringCharset";
+  g_charsetConverter.Utf8ToStringCharset(varstra1);
   EXPECT_STREQ(refstra1.c_str(), varstra1.c_str());
 }
 
 TEST_F(TestCharsetConverter, utf8ToSystem)
 {
-  refstra1 = "test utf8ToSystem";
-  varstra1 = "test utf8ToSystem";
-  g_charsetConverter.utf8ToSystem(varstra1);
+  refstra1 = "test Utf8ToSystem";
+  varstra1 = "test Utf8ToSystem";
+  g_charsetConverter.Utf8ToSystem(varstra1);
   EXPECT_STREQ(refstra1.c_str(), varstra1.c_str());
 }
 
 TEST_F(TestCharsetConverter, utf8To_ASCII)
 {
-  refstra1 = "test utf8To: charset ASCII, std::string";
+  refstra1 = "test Utf8To: charset ASCII, std::string";
   varstra1.clear();
-  g_charsetConverter.utf8To("ASCII", refstra1, varstra1);
+  g_charsetConverter.Utf8To("ASCII", refstra1, varstra1);
   EXPECT_STREQ(refstra1.c_str(), varstra1.c_str());
 }
 
-/*
+TEST_F(TestCharsetConverter, utf8ToUtf16_CP1251)
+{
+  std::string source((char*)&CP1251asUTF8);
+  std::u16string expected((char16_t*)CP1251asUTF16LE);
+  std::u16string temp;
+
+  g_charsetConverter.Utf8ToUtf16(source, temp);
+  EXPECT_EQ(expected.length(), temp.length());
+  EXPECT_PRED_FORMAT2(AssertStringEquals, expected, temp);
+}
+
+TEST_F(TestCharsetConverter, utf8ToUtf16LE_CP1251)
+{
+  std::string source((char*)&CP1251asUTF8);
+  std::u16string expected((char16_t*)CP1251asUTF16LE);
+  std::u16string temp;
+
+  g_charsetConverter.Utf8ToUtf16LE(source, temp);
+  EXPECT_EQ(expected.length(), temp.length());
+  EXPECT_PRED_FORMAT2(AssertStringEquals, expected, temp);
+}
+
+TEST_F(TestCharsetConverter, utf8ToUtf16BE_CP1251)
+{
+  std::string source((char*)&CP1251asUTF8);
+  std::u16string expected((char16_t*)CP1251asUTF16BE);
+  std::u16string temp;
+
+  g_charsetConverter.Utf8ToUtf16BE(source, temp);
+  EXPECT_EQ(expected.length(), temp.length());
+  EXPECT_PRED_FORMAT2(AssertStringEquals, expected, temp);
+}
+
+TEST_F(TestCharsetConverter, utf8ToUtf32_CP1251)
+{
+  std::string source((char*)&CP1251asUTF8);
+  std::u32string expected((char32_t*)CP1251asUTF32LE);
+  std::u32string temp;
+
+  g_charsetConverter.Utf8ToUtf32(source, temp);
+  EXPECT_PRED_FORMAT2(AssertStringEquals, expected, temp);
+}
+
 TEST_F(TestCharsetConverter, utf8To_UTF16LE)
 {
   refstra1 = "ｔｅｓｔ＿ｕｔｆ８Ｔｏ：＿ｃｈａｒｓｅｔ＿ＵＴＦ－１６ＬＥ，＿"
              "ＣＳｔｄＳｔｒｉｎｇ１６";
-  refstr16_1.assign(refutf16LE2);
+  refstr16_1.assign((char16_t*)refutf16LE2);
   varstr16_1.clear();
-  g_charsetConverter.utf8To("UTF-16LE", refstra1, varstr16_1);
-  EXPECT_TRUE(!memcmp(refstr16_1.c_str(), varstr16_1.c_str(),
-                      refstr16_1.length() * sizeof(uint16_t)));
+  g_charsetConverter.Utf8To("UTF-16LE", refstra1, varstr16_1);
+  EXPECT_PRED_FORMAT2(AssertStringEquals, refstr16_1, varstr16_1);
 }
-*/
 
-//TEST_F(TestCharsetConverter, utf8To_UTF32LE)
-//{
-//  refstra1 = "ｔｅｓｔ＿ｕｔｆ８Ｔｏ：＿ｃｈａｒｓｅｔ＿ＵＴＦ－３２ＬＥ，＿"
-//#ifdef TARGET_DARWIN
-///* OSX has it's own 'special' utf-8 charset which we use (see UTF8_SOURCE in CharsetConverter.cpp)
-//   which is basically NFD (decomposed) utf-8.  The trouble is, it fails on the COW FACE and MOUSE FACE
-//   characters for some reason (possibly anything over 0x100000, or maybe there's a decomposed form of these
-//   that I couldn't find???)  If UTF8_SOURCE is switched to UTF-8 then this test would pass as-is, but then
-//   some filenames stored in utf8-mac wouldn't display correctly in the UI. */
-//             "ＣＳｔｄＳｔｒｉｎｇ３２＿";
-//#else
-//             "ＣＳｔｄＳｔｒｉｎｇ３２＿🐭🐮";
-//#endif
-//  refstr32_1.assign(refutf32LE1);
-//  varstr32_1.clear();
-//  g_charsetConverter.utf8To("UTF-32LE", refstra1, varstr32_1);
-//  EXPECT_TRUE(!memcmp(refstr32_1.c_str(), varstr32_1.c_str(),
-//                      sizeof(refutf32LE1)));
-//}
+TEST_F(TestCharsetConverter, utf8To_UTF32LE)
+{
+  refstra1 = "ｔｅｓｔ＿ｕｔｆ８Ｔｏ：＿ｃｈａｒｓｅｔ＿ＵＴＦ－３２ＬＥ，＿"
+#ifdef TARGET_DARWIN
+/* OSX has it's own 'special' utf-8 charset which we use (see UTF8_SOURCE in CharsetConverter.cpp)
+   which is basically NFD (decomposed) utf-8.  The trouble is, it fails on the COW FACE and MOUSE FACE
+   characters for some reason (possibly anything over 0x100000, or maybe there's a decomposed form of these
+   that I couldn't find???)  If UTF8_SOURCE is switched to UTF-8 then this test would pass as-is, but then
+   some filenames stored in utf8-mac wouldn't display correctly in the UI. */
+             "ＣＳｔｄＳｔｒｉｎｇ３２＿";
+#else
+             "ＣＳｔｄＳｔｒｉｎｇ３２＿🐭🐮";
+#endif
+  refstr32_1.assign((char32_t*)refutf32LE1);
+  varstr32_1.clear();
+  g_charsetConverter.Utf8To("UTF-32LE", refstra1, varstr32_1);
+  EXPECT_PRED_FORMAT2(AssertStringEquals, refstr32_1, varstr32_1);
+}
 
 TEST_F(TestCharsetConverter, stringCharsetToUtf8)
 {
   refstra1 = "ｔｅｓｔ＿ｓｔｒｉｎｇＣｈａｒｓｅｔＴｏＵｔｆ８";
   varstra1.clear();
-  g_charsetConverter.ToUtf8("UTF-16LE", refutf16LE3, varstra1);
+  g_charsetConverter.ToUtf8("UTF-8", refstra1, varstra1);
   EXPECT_STREQ(refstra1.c_str(), varstra1.c_str());
 }
 
@@ -248,127 +1130,213 @@ TEST_F(TestCharsetConverter, isValidUtf8_4)
   EXPECT_FALSE(CUtf8Utils::isValidUtf8(refutf16LE3));
 }
 
-/* TODO: Resolve correct input/output for this function */
-// TEST_F(TestCharsetConverter, ucs2CharsetToStringCharset)
-// {
-//   void ucs2CharsetToStringCharset(const std::wstring& strSource,
-//                                   std::string& strDest, bool swap = false);
-// }
-
 TEST_F(TestCharsetConverter, wToUTF8)
 {
-  refstrw1 = L"ｔｅｓｔ＿ｗＴｏＵＴＦ８";
-  refstra1 = "ｔｅｓｔ＿ｗＴｏＵＴＦ８";
+  refstrw1 = L"test Utf8ToW";
+  refstra1 = "test Utf8ToW";
   varstra1.clear();
-  g_charsetConverter.wToUTF8(refstrw1, varstra1);
+  g_charsetConverter.WToUtf8(refstrw1, varstra1);
   EXPECT_STREQ(refstra1.c_str(), varstra1.c_str());
 }
 
-//TEST_F(TestCharsetConverter, utf16BEtoUTF8)
-//{
-//  refstr16_1.assign(refutf16BE);
-//  refstra1 = "ｔｅｓｔ＿ｕｔｆ１６ＢＥｔｏＵＴＦ８";
-//  varstra1.clear();
-//  g_charsetConverter.utf16BEtoUTF8(refstr16_1, varstra1);
-//  EXPECT_STREQ(refstra1.c_str(), varstra1.c_str());
-//}
+TEST_F(TestCharsetConverter, utf16BEtoUTF8)
+{
+  refstr16_1.assign((char16_t*)refutf16BE);
+  refstra1 = "ｔｅｓｔ＿ｕｔｆ１６ＢＥｔｏＵＴＦ８";
+  varstra1.clear();
+  g_charsetConverter.Utf16BEToUtf8(refstr16_1, varstra1);
+  EXPECT_STREQ(refstra1.c_str(), varstra1.c_str());
+}
 
-//TEST_F(TestCharsetConverter, utf16LEtoUTF8)
-//{
-//  refstr16_1.assign(refutf16LE4);
-//  refstra1 = "ｔｅｓｔ＿ｕｔｆ１６ＬＥｔｏＵＴＦ８";
-//  varstra1.clear();
-//  g_charsetConverter.utf16LEtoUTF8(refstr16_1, varstra1);
-//  EXPECT_STREQ(refstra1.c_str(), varstra1.c_str());
-//}
-
-//TEST_F(TestCharsetConverter, ucs2ToUTF8)
-//{
-//  refstr16_1.assign(refucs2);
-//  refstra1 = "ｔｅｓｔ＿ｕｃｓ２ｔｏＵＴＦ８";
-//  varstra1.clear();
-//  g_charsetConverter.ucs2ToUTF8(refstr16_1, varstra1);
-//  EXPECT_STREQ(refstra1.c_str(), varstra1.c_str());
-//}
+TEST_F(TestCharsetConverter, ucs2ToUTF8)
+{
+  refstr16_1.assign((char16_t*)refucs2);
+  refstra1 = "ｔｅｓｔ＿ｕｃｓ２ｔｏＵＴＦ８";
+  varstra1.clear();
+  g_charsetConverter.Ucs2ToUtf8(refstr16_1, varstra1);
+  EXPECT_STREQ(refstra1.c_str(), varstra1.c_str());
+}
 
 TEST_F(TestCharsetConverter, utf8logicalToVisualBiDi)
 {
   refstra1 = "ｔｅｓｔ＿ｕｔｆ８ｌｏｇｉｃａｌＴｏＶｉｓｕａｌＢｉＤｉ";
   refstra2 = "ｔｅｓｔ＿ｕｔｆ８ｌｏｇｉｃａｌＴｏＶｉｓｕａｌＢｉＤｉ";
   varstra1.clear();
-  g_charsetConverter.utf8logicalToVisualBiDi(refstra1, varstra1);
+  g_charsetConverter.LogicalToVisualBiDi(refstra1, varstra1);
   EXPECT_STREQ(refstra2.c_str(), varstra1.c_str());
 }
 
-/* TODO: Resolve correct input/output for this function */
-// TEST_F(TestCharsetConverter, utf32ToStringCharset)
-// {
-//   void utf32ToStringCharset(const unsigned long* strSource, std::string& strDest);
-// }
-
-TEST_F(TestCharsetConverter, getCharsetLabels)
+TEST_F(TestCharsetConverter, NormalizeNFC1)
 {
-  std::vector<std::string> reflabels;
-  reflabels.push_back("Western Europe (ISO)");
-  reflabels.push_back("Central Europe (ISO)");
-  reflabels.push_back("South Europe (ISO)");
-  reflabels.push_back("Baltic (ISO)");
-  reflabels.push_back("Cyrillic (ISO)");
-  reflabels.push_back("Arabic (ISO)");
-  reflabels.push_back("Greek (ISO)");
-  reflabels.push_back("Hebrew (ISO)");
-  reflabels.push_back("Turkish (ISO)");
-  reflabels.push_back("Central Europe (Windows)");
-  reflabels.push_back("Cyrillic (Windows)");
-  reflabels.push_back("Western Europe (Windows)");
-  reflabels.push_back("Greek (Windows)");
-  reflabels.push_back("Turkish (Windows)");
-  reflabels.push_back("Hebrew (Windows)");
-  reflabels.push_back("Arabic (Windows)");
-  reflabels.push_back("Baltic (Windows)");
-  reflabels.push_back("Vietnamesse (Windows)");
-  reflabels.push_back("Thai (Windows)");
-  reflabels.push_back("Chinese Traditional (Big5)");
-  reflabels.push_back("Chinese Simplified (GBK)");
-  reflabels.push_back("Japanese (Shift-JIS)");
-  reflabels.push_back("Korean");
-  reflabels.push_back("Hong Kong (Big5-HKSCS)");
+  std::u16string refstr((char16_t*)normalizationTestNFC1);
+  std::u16string varstr1((char16_t*)normalizationTestSource1);
+  std::u16string varstr2((char16_t*)normalizationTestNFD1);
+  std::u16string temp;
 
-  std::vector<std::string> varlabels = g_charsetConverter.getCharsetLabels();
-  ASSERT_EQ(reflabels.size(), varlabels.size());
-
-  std::vector<std::string>::iterator it;
-  for (it = varlabels.begin(); it < varlabels.end(); ++it)
-  {
-    EXPECT_STREQ((reflabels.at(it - varlabels.begin())).c_str(), (*it).c_str());
-  }
+  g_charsetConverter.Normalize(varstr1, temp, CCharsetConverter::COMPOSE);
+  EXPECT_PRED_FORMAT2(AssertStringEquals, refstr, temp);
+  g_charsetConverter.Normalize(varstr2, temp, CCharsetConverter::COMPOSE);
+  EXPECT_PRED_FORMAT2(AssertStringEquals, refstr, temp);
 }
 
-TEST_F(TestCharsetConverter, getCharsetLabelByName)
+TEST_F(TestCharsetConverter, NormalizeNFC2)
 {
-  std::string varstr =
-    g_charsetConverter.getCharsetLabelByName("ISO-8859-1");
-  EXPECT_STREQ("Western Europe (ISO)", varstr.c_str());
-  varstr.clear();
-  varstr = g_charsetConverter.getCharsetLabelByName("Bogus");
-  EXPECT_STREQ("", varstr.c_str());
+  std::u16string refstr((char16_t*)normalizationTestNFC2);
+  std::u16string varstr1((char16_t*)normalizationTestSource2);
+  std::u16string varstr2((char16_t*)normalizationTestNFD2);
+  std::u16string temp;
+
+  g_charsetConverter.Normalize(varstr1, temp, CCharsetConverter::COMPOSE);
+  EXPECT_PRED_FORMAT2(AssertStringEquals, refstr, temp);
+  g_charsetConverter.Normalize(varstr2, temp, CCharsetConverter::COMPOSE);
+  EXPECT_PRED_FORMAT2(AssertStringEquals, refstr, temp);
 }
 
-TEST_F(TestCharsetConverter, getCharsetNameByLabel)
+TEST_F(TestCharsetConverter, NormalizeNFC3)
 {
-  std::string varstr =
-    g_charsetConverter.getCharsetNameByLabel("Western Europe (ISO)");
-  EXPECT_STREQ("ISO-8859-1", varstr.c_str());
-  varstr.clear();
-  varstr = g_charsetConverter.getCharsetNameByLabel("Bogus");
-  EXPECT_STREQ("", varstr.c_str());
+  std::u16string refstr((char16_t*)normalizationTestNFC3);
+  std::u16string varstr1((char16_t*)normalizationTestSource3);
+  std::u16string varstr2((char16_t*)normalizationTestNFD3);
+  std::u16string temp;
+
+  g_charsetConverter.Normalize(varstr1, temp, CCharsetConverter::COMPOSE);
+  EXPECT_PRED_FORMAT2(AssertStringEquals, refstr, temp);
+  g_charsetConverter.Normalize(varstr2, temp, CCharsetConverter::COMPOSE);
+  EXPECT_PRED_FORMAT2(AssertStringEquals, refstr, temp);
 }
+
+TEST_F(TestCharsetConverter, NormalizeNFD1)
+{
+  std::u16string refstr((char16_t*)normalizationTestNFD1);
+  std::u16string varstr1((char16_t*)normalizationTestSource1);
+  std::u16string varstr2((char16_t*)normalizationTestNFC1);
+  std::u16string temp;
+
+  g_charsetConverter.Normalize(varstr1, temp, CCharsetConverter::DECOMPOSE);
+  EXPECT_PRED_FORMAT2(AssertStringEquals, refstr, temp);
+  g_charsetConverter.Normalize(varstr2, temp, CCharsetConverter::DECOMPOSE);
+  EXPECT_PRED_FORMAT2(AssertStringEquals, refstr, temp);
+}
+
+TEST_F(TestCharsetConverter, NormalizeNFD2)
+{
+  std::u16string refstr((char16_t*)normalizationTestNFD2);
+  std::u16string varstr1((char16_t*)normalizationTestSource2);
+  std::u16string varstr2((char16_t*)normalizationTestNFD2);
+  std::u16string temp;
+
+  g_charsetConverter.Normalize(varstr1, temp, CCharsetConverter::DECOMPOSE);
+  EXPECT_PRED_FORMAT2(AssertStringEquals, refstr, temp);
+  g_charsetConverter.Normalize(varstr2, temp, CCharsetConverter::DECOMPOSE);
+  EXPECT_PRED_FORMAT2(AssertStringEquals, refstr, temp);
+}
+TEST_F(TestCharsetConverter, NormalizeNFD3)
+{
+  std::u16string refstr((char16_t*)normalizationTestNFD3);
+  std::u16string varstr1((char16_t*)normalizationTestSource3);
+  std::u16string varstr2((char16_t*)normalizationTestNFC3);
+  std::u16string temp;
+
+  g_charsetConverter.Normalize(varstr1, temp, CCharsetConverter::DECOMPOSE);
+  EXPECT_PRED_FORMAT2(AssertStringEquals, refstr, temp);
+  g_charsetConverter.Normalize(varstr2, temp, CCharsetConverter::DECOMPOSE);
+  EXPECT_PRED_FORMAT2(AssertStringEquals, refstr, temp);
+}
+
+TEST_F(TestCharsetConverter, NormalizeNFDMac1)
+{
+  std::u16string refstr((char16_t*)normalizationTestNFDMac1);
+  std::u16string varstr1((char16_t*)normalizationTestSource1);
+  std::u16string temp;
+
+  g_charsetConverter.Normalize(varstr1, temp, CCharsetConverter::DECOMPOSE_MAC);
+  EXPECT_PRED_FORMAT2(AssertStringEquals, refstr, temp);
+}
+
+TEST_F(TestCharsetConverter, NormalizeNFDMac2)
+{
+  std::u16string refstr((char16_t*)normalizationTestNFDMac2);
+  std::u16string varstr1((char16_t*)normalizationTestSource2);
+  std::u16string temp;
+
+  g_charsetConverter.Normalize(varstr1, temp, CCharsetConverter::DECOMPOSE_MAC);
+  EXPECT_PRED_FORMAT2(AssertStringEquals, refstr, temp);
+}
+
+TEST_F(TestCharsetConverter, NormalizeNFDMac3)
+{
+  std::u16string refstr((char16_t*)normalizationTestNFDMac3);
+  std::u16string varstr1((char16_t*)normalizationTestSource3);
+  std::u16string temp;
+
+  g_charsetConverter.Normalize(varstr1, temp, CCharsetConverter::DECOMPOSE_MAC);
+  EXPECT_PRED_FORMAT2(AssertStringEquals, refstr, temp);
+}
+//keep it here for now, no CLangInfo test cases?
+
+//TEST_F(TestCharsetConverter, getCharsetLabels)
+//{
+//  std::vector<std::string> reflabels;
+//  reflabels.push_back("Western Europe (ISO)");
+//  reflabels.push_back("Central Europe (ISO)");
+//  reflabels.push_back("South Europe (ISO)");
+//  reflabels.push_back("Baltic (ISO)");
+//  reflabels.push_back("Cyrillic (ISO)");
+//  reflabels.push_back("Arabic (ISO)");
+//  reflabels.push_back("Greek (ISO)");
+//  reflabels.push_back("Hebrew (ISO)");
+//  reflabels.push_back("Turkish (ISO)");
+//  reflabels.push_back("Central Europe (Windows)");
+//  reflabels.push_back("Cyrillic (Windows)");
+//  reflabels.push_back("Western Europe (Windows)");
+//  reflabels.push_back("Greek (Windows)");
+//  reflabels.push_back("Turkish (Windows)");
+//  reflabels.push_back("Hebrew (Windows)");
+//  reflabels.push_back("Arabic (Windows)");
+//  reflabels.push_back("Baltic (Windows)");
+//  reflabels.push_back("Vietnamesse (Windows)");
+//  reflabels.push_back("Thai (Windows)");
+//  reflabels.push_back("Chinese Traditional (Big5)");
+//  reflabels.push_back("Chinese Simplified (GBK)");
+//  reflabels.push_back("Japanese (Shift-JIS)");
+//  reflabels.push_back("Korean");
+//  reflabels.push_back("Hong Kong (Big5-HKSCS)");
+//
+//  std::vector<std::string> varlabels = g_charsetConverter.getCharsetLabels();
+//  ASSERT_EQ(reflabels.size(), varlabels.size());
+//
+//  std::vector<std::string>::iterator it;
+//  for (it = varlabels.begin(); it < varlabels.end(); ++it)
+//  {
+//    EXPECT_STREQ((reflabels.at(it - varlabels.begin())).c_str(), (*it).c_str());
+//  }
+//}
+//
+//TEST_F(TestCharsetConverter, getCharsetLabelByName)
+//{
+//  CStdString varstr =
+//    g_charsetConverter.getCharsetLabelByName("ISO-8859-1");
+//  EXPECT_STREQ("Western Europe (ISO)", varstr.c_str());
+//  varstr.clear();
+//  varstr = g_charsetConverter.getCharsetLabelByName("Bogus");
+//  EXPECT_STREQ("", varstr.c_str());
+//}
+//
+//TEST_F(TestCharsetConverter, getCharsetNameByLabel)
+//{
+//  CStdString varstr =
+//    g_charsetConverter.getCharsetNameByLabel("Western Europe (ISO)");
+//  EXPECT_STREQ("ISO-8859-1", varstr.c_str());
+//  varstr.clear();
+//  varstr = g_charsetConverter.getCharsetNameByLabel("Bogus");
+//  EXPECT_STREQ("", varstr.c_str());
+//}
 
 TEST_F(TestCharsetConverter, unknownToUTF8_1)
 {
   refstra1 = "ｔｅｓｔ＿ｕｎｋｎｏｗｎＴｏＵＴＦ８";
   varstra1 = "ｔｅｓｔ＿ｕｎｋｎｏｗｎＴｏＵＴＦ８";
-  g_charsetConverter.unknownToUTF8(varstra1);
+  g_charsetConverter.UnknownToUtf8(varstra1);
   EXPECT_STREQ(refstra1.c_str(), varstra1.c_str());
 }
 
@@ -376,33 +1344,151 @@ TEST_F(TestCharsetConverter, unknownToUTF8_2)
 {
   refstra1 = "ｔｅｓｔ＿ｕｎｋｎｏｗｎＴｏＵＴＦ８";
   varstra1.clear();
-  g_charsetConverter.unknownToUTF8(refstra1, varstra1);
+  g_charsetConverter.UnknownToUtf8(refstra1, varstra1);
   EXPECT_STREQ(refstra1.c_str(), varstra1.c_str());
 }
 
-TEST_F(TestCharsetConverter, toW)
+TEST_F(TestCharsetConverter, WToUtf8)
 {
-  refstra1 = "ｔｅｓｔ＿ｔｏＷ：＿ｃｈａｒｓｅｔ＿ＵＴＦ－１６ＬＥ";
-  refstrw1 = L"\xBDEF\xEF94\x85BD\xBDEF\xEF93\x94BD\xBCEF\xEFBF"
-             L"\x94BD\xBDEF\xEF8F\xB7BC\xBCEF\xEF9A\xBFBC\xBDEF"
-             L"\xEF83\x88BD\xBDEF\xEF81\x92BD\xBDEF\xEF93\x85BD"
-             L"\xBDEF\xEF94\xBFBC\xBCEF\xEFB5\xB4BC\xBCEF\xEFA6"
-             L"\x8DBC\xBCEF\xEF91\x96BC\xBCEF\xEFAC\xA5BC";
-  varstrw1.clear();
-  g_charsetConverter.toW(refstra1, varstrw1, "UTF-16LE");
-  EXPECT_STREQ(refstrw1.c_str(), varstrw1.c_str());
+  std::string testString;
+   /* test one byte UTF-8 sequences */
+  EXPECT_TRUE(CCharsetConverter::WToUtf8(L"Simple US-ASCII string 1234567890,?./!", testString));
+  EXPECT_STREQ("Simple US-ASCII string 1234567890,?./!", testString.c_str());
+
+  /* test two bytes UTF-8 sequences */
+  EXPECT_TRUE(CCharsetConverter::WToUtf8(testCyrW, testString));
+  EXPECT_STREQ(testCyrUtf8, testString.c_str());
+  EXPECT_TRUE(CCharsetConverter::WToUtf8(testGreekW, testString));
+  EXPECT_STREQ(testGreekUtf8, testString.c_str());
+  EXPECT_TRUE(CCharsetConverter::WToUtf8(testArmW, testString));
+  EXPECT_STREQ(testArmUtf8, testString.c_str());
+
+  /* test three bytes UTF-8 sequences */
+  EXPECT_TRUE(CCharsetConverter::WToUtf8(testDevnW, testString));
+  EXPECT_STREQ(testDevnUtf8, testString.c_str());
+  EXPECT_TRUE(CCharsetConverter::WToUtf8(testGeorgW, testString));
+  EXPECT_STREQ(testGeorgUtf8, testString.c_str());
+  EXPECT_TRUE(CCharsetConverter::WToUtf8(testCJKW, testString));
+  EXPECT_STREQ(testCJKUtf8, testString.c_str());
+  EXPECT_TRUE(CCharsetConverter::WToUtf8(testArLiW, testString));
+  EXPECT_STREQ(testArLiUtf8, testString.c_str());
+
+  /* test four bytes UTF-8 sequences */
+  /* those tests can fail on some platform with limited wchar_t range and lack of surrogates support */
+  std::wstring helperStringW;
+  EXPECT_TRUE(g_charsetConverter.TryUtf8ToW(testLinBIdeoUtf8, helperStringW)) << "Can't prepare source wide string for test";
+  EXPECT_TRUE(CCharsetConverter::TryWToUtf8(helperStringW, testString));
+  EXPECT_STREQ(testLinBIdeoUtf8, testString.c_str());
+  helperStringW.clear();
+  EXPECT_TRUE(g_charsetConverter.TryUtf8ToW(testCJKComIdUtf8, helperStringW)) << "Can't prepare source wide string for test";
+  EXPECT_TRUE(CCharsetConverter::TryWToUtf8(helperStringW, testString));
+  EXPECT_STREQ(testCJKComIdUtf8, testString.c_str());
+  helperStringW.clear();
+  EXPECT_TRUE(g_charsetConverter.TryUtf8ToW(testTagsUtf8, helperStringW)) << "Can't prepare source wide string for test";
+  EXPECT_TRUE(CCharsetConverter::TryWToUtf8(helperStringW, testString));
+  EXPECT_STREQ(testTagsUtf8, testString.c_str());
+
+  /* test invalid chars */
+  static const wchar_t testInvalid1W[] =
+  { L'a', L'b', L'c', 0xD800, 0 }; // invalid char at the end 
+  static const wchar_t testInvalid2W[] =
+  { L'1', L'2', 0xDE00, 0xDF00, L'3', L'4', 0 }; // invalid chars at the middle 
+  static const wchar_t testInvalid3W[] =
+  { 0xD901, L'x', L'y', L'z', 0 }; // invalid char at the beginning 
+  static const wchar_t testInvalid4W[] =
+  { 0xDA11, 0xDBCC, 0 }; // only invalid char 
+  EXPECT_FALSE(CCharsetConverter::TryWToUtf8(testInvalid1W, testString));
+  EXPECT_FALSE(CCharsetConverter::TryWToUtf8(testInvalid2W, testString));
+  EXPECT_FALSE(CCharsetConverter::TryWToUtf8(testInvalid3W, testString));
+  EXPECT_FALSE(CCharsetConverter::TryWToUtf8(testInvalid4W, testString));
+  
+  EXPECT_TRUE(CCharsetConverter::WToUtf8(testInvalid1W, testString));
+  EXPECT_STREQ("abc", testString.c_str());
+  EXPECT_TRUE(CCharsetConverter::WToUtf8(testInvalid2W, testString));
+  EXPECT_STREQ("1234", testString.c_str());
+  EXPECT_TRUE(CCharsetConverter::WToUtf8(testInvalid3W, testString));
+  EXPECT_STREQ("xyz", testString.c_str());
+  EXPECT_TRUE(CCharsetConverter::WToUtf8(testInvalid4W, testString));
+  EXPECT_STREQ("", testString.c_str());
 }
 
-TEST_F(TestCharsetConverter, fromW)
+TEST_F(TestCharsetConverter, Utf8ToW)
 {
-  refstrw1 = L"\xBDEF\xEF94\x85BD\xBDEF\xEF93\x94BD\xBCEF\xEFBF"
-             L"\x86BD\xBDEF\xEF92\x8FBD\xBDEF\xEF8D\xB7BC\xBCEF"
-             L"\xEF9A\xBFBC\xBDEF\xEF83\x88BD\xBDEF\xEF81\x92BD"
-             L"\xBDEF\xEF93\x85BD\xBDEF\xEF94\xBFBC\xBCEF\xEFB5"
-             L"\xB4BC\xBCEF\xEFA6\x8DBC\xBCEF\xEF91\x96BC\xBCEF"
-             L"\xEFAC\xA5BC";
-  refstra1 = "ｔｅｓｔ＿ｆｒｏｍＷ：＿ｃｈａｒｓｅｔ＿ＵＴＦ－１６ＬＥ";
-  varstra1.clear();
-  g_charsetConverter.fromW(refstrw1, varstra1, "UTF-16LE");
-  EXPECT_STREQ(refstra1.c_str(), varstra1.c_str());
+  std::wstring testStringW;
+   /* test one byte UTF-8 sequences */
+  EXPECT_TRUE(CCharsetConverter::Utf8ToW("Simple US-ASCII string 1234567890,?./!", testStringW));
+  EXPECT_STREQ(L"Simple US-ASCII string 1234567890,?./!", testStringW.c_str());
+
+  /* test two bytes UTF-8 sequences */
+  EXPECT_TRUE(CCharsetConverter::Utf8ToW(testCyrUtf8, testStringW));
+  EXPECT_STREQ(testCyrW, testStringW.c_str());
+  EXPECT_TRUE(CCharsetConverter::Utf8ToW(testGreekUtf8, testStringW));
+  EXPECT_STREQ(testGreekW, testStringW.c_str());
+  EXPECT_TRUE(CCharsetConverter::Utf8ToW(testArmUtf8, testStringW));
+  EXPECT_STREQ(testArmW, testStringW.c_str());
+
+  /* test three bytes UTF-8 sequences */
+  EXPECT_TRUE(CCharsetConverter::Utf8ToW(testDevnUtf8, testStringW));
+  EXPECT_STREQ(testDevnW, testStringW.c_str());
+  EXPECT_TRUE(CCharsetConverter::Utf8ToW(testGeorgUtf8, testStringW));
+  EXPECT_STREQ(testGeorgW, testStringW.c_str());
+  EXPECT_TRUE(CCharsetConverter::Utf8ToW(testCJKUtf8, testStringW));
+  EXPECT_STREQ(testCJKW, testStringW.c_str());
+  EXPECT_TRUE(CCharsetConverter::Utf8ToW(testArLiUtf8, testStringW));
+  EXPECT_STREQ(testArLiW, testStringW.c_str());
+
+  /* test four bytes UTF-8 sequences */
+  /* those tests can fail on some platform with limited wchar_t range and lack of surrogates support */
+  std::string resultStringUtf8;
+  EXPECT_TRUE(CCharsetConverter::Utf8ToW(testLinBIdeoUtf8, testStringW));
+  EXPECT_TRUE(CCharsetConverter::TryWToUtf8(testStringW, resultStringUtf8)) << "Can't convert result back to UTF-8 from wide string";
+  EXPECT_STREQ(testLinBIdeoUtf8, resultStringUtf8.c_str());
+  resultStringUtf8.clear();
+  EXPECT_TRUE(CCharsetConverter::Utf8ToW(testCJKComIdUtf8, testStringW));
+  EXPECT_TRUE(g_charsetConverter.TryWToUtf8(testStringW, resultStringUtf8)) << "Can't convert result back to UTF-8 from wide string";
+  EXPECT_STREQ(testCJKComIdUtf8, resultStringUtf8.c_str());
+  resultStringUtf8.clear();
+  EXPECT_TRUE(CCharsetConverter::Utf8ToW(testTagsUtf8, testStringW));
+  EXPECT_TRUE(g_charsetConverter.TryWToUtf8(testStringW, resultStringUtf8)) << "Can't convert result back to UTF-8 from wide string";
+  EXPECT_STREQ(testTagsUtf8, resultStringUtf8.c_str());
+
+  /* test invalid sequences */
+  static const char testInvalid1Utf8[] =
+  { 'a', 'b', 'c', (char)0xC0, 0 }; // invalid sequences at the end 
+  static const char testInvalid2Utf8[] =
+  { '1', '2', (char)0xC1, (char)0xAB, '3', '4', 0 }; // invalid sequences at the middle 
+  static const char testInvalid3Utf8[] =
+  { 'F', 'J', (char)0xC2, 'Q', 'W', 0 }; // incomplete sequences at the middle, 'Q' must be decoded 
+  static const char testInvalid4Utf8[] =
+  { (char)0xF7, 'x', 'y', 'z', 0 }; // invalid sequences at the beginning 
+  static const char testInvalid5Utf8[] =
+  { ' ', (char)0xED, (char)0xA0, (char)0x80, (char)0xED, (char)0xB0, (char)0x82, '?', '!', '*', 0 }; // surrogates in the middle 
+  static const char testInvalid6Utf8[] =
+  { (char)0xF4, (char)0x90, (char)0x80, (char)0x80, 0 }; // only invalid sequences 
+
+  EXPECT_FALSE(CCharsetConverter::TryUtf8ToW(testInvalid1Utf8, testStringW));
+  EXPECT_FALSE(CCharsetConverter::TryUtf8ToW(testInvalid2Utf8, testStringW));
+  EXPECT_FALSE(CCharsetConverter::TryUtf8ToW(testInvalid3Utf8, testStringW));
+  EXPECT_FALSE(CCharsetConverter::TryUtf8ToW(testInvalid4Utf8, testStringW));
+  EXPECT_FALSE(CCharsetConverter::TryUtf8ToW(testInvalid5Utf8, testStringW));
+  EXPECT_FALSE(CCharsetConverter::TryUtf8ToW(testInvalid6Utf8, testStringW));
+
+  EXPECT_TRUE(CCharsetConverter::Utf8ToW(testInvalid1Utf8, testStringW));
+  EXPECT_STREQ(L"abc", testStringW.c_str());
+
+  EXPECT_TRUE(CCharsetConverter::Utf8ToW(testInvalid2Utf8, testStringW));
+  EXPECT_STREQ(L"1234", testStringW.c_str());
+
+  EXPECT_TRUE(CCharsetConverter::Utf8ToW(testInvalid3Utf8, testStringW));
+  EXPECT_STREQ(L"FJQW", testStringW.c_str());
+
+  EXPECT_TRUE(CCharsetConverter::Utf8ToW(testInvalid4Utf8, testStringW));
+  EXPECT_STREQ(L"xyz", testStringW.c_str());
+
+  EXPECT_TRUE(CCharsetConverter::Utf8ToW(testInvalid5Utf8, testStringW));
+  EXPECT_STREQ(L" ?!*", testStringW.c_str());
+
+  EXPECT_TRUE(CCharsetConverter::Utf8ToW(testInvalid6Utf8, testStringW));
+  EXPECT_STREQ(L"", testStringW.c_str());
 }
+

--- a/xbmc/utils/win32/Win32Log.cpp
+++ b/xbmc/utils/win32/Win32Log.cpp
@@ -33,7 +33,7 @@ void CWin32Log::LogW(int loglevel, const wchar_t* format, ...)
     if (!strDataW.empty())
     {
       std::string strDataUtf8;
-      if (g_charsetConverter.wToUTF8(strDataW, strDataUtf8, false) && !strDataUtf8.empty())
+      if (g_charsetConverter.WToUtf8(strDataW, strDataUtf8) && !strDataUtf8.empty())
         LogString(loglevel, strDataUtf8);
       else
         PrintDebugString(__FUNCTION__ ": Can't convert log wide string to UTF-8");
@@ -56,7 +56,7 @@ void CWin32Log::LogFunctionW(int loglevel, const char* functionName, const wchar
         funcNameStr.assign(functionName).append(": ");
 
       std::string strDataUtf8;
-      if (g_charsetConverter.wToUTF8(strDataW, strDataUtf8, false) && !strDataUtf8.empty())
+      if (g_charsetConverter.WToUtf8(strDataW, strDataUtf8) && !strDataUtf8.empty())
         LogString(loglevel, funcNameStr + strDataUtf8);
       else
         PrintDebugString(__FUNCTION__ ": Can't convert log wide string to UTF-8");

--- a/xbmc/utils/win32/Win32Log.cpp
+++ b/xbmc/utils/win32/Win32Log.cpp
@@ -33,7 +33,7 @@ void CWin32Log::LogW(int loglevel, const wchar_t* format, ...)
     if (!strDataW.empty())
     {
       std::string strDataUtf8;
-      if (g_charsetConverter.WToUtf8(strDataW, strDataUtf8) && !strDataUtf8.empty())
+      if (CCharsetConverter::WToUtf8(strDataW, strDataUtf8) && !strDataUtf8.empty())
         LogString(loglevel, strDataUtf8);
       else
         PrintDebugString(__FUNCTION__ ": Can't convert log wide string to UTF-8");
@@ -56,7 +56,7 @@ void CWin32Log::LogFunctionW(int loglevel, const char* functionName, const wchar
         funcNameStr.assign(functionName).append(": ");
 
       std::string strDataUtf8;
-      if (g_charsetConverter.WToUtf8(strDataW, strDataUtf8) && !strDataUtf8.empty())
+      if (CCharsetConverter::WToUtf8(strDataW, strDataUtf8) && !strDataUtf8.empty())
         LogString(loglevel, funcNameStr + strDataUtf8);
       else
         PrintDebugString(__FUNCTION__ ": Can't convert log wide string to UTF-8");

--- a/xbmc/win32/WIN32Util.cpp
+++ b/xbmc/win32/WIN32Util.cpp
@@ -297,9 +297,9 @@ bool CWIN32Util::XBMCShellExecute(const std::string &strPath, bool bWaitForScrip
   }
 
   std::wstring WstrExe, WstrParams, WstrWorkingDir;
-  g_charsetConverter.Utf8ToW(strExe, WstrExe);
-  g_charsetConverter.Utf8ToW(strParams, WstrParams);
-  g_charsetConverter.Utf8ToW(strWorkingDir, WstrWorkingDir);
+  CCharsetConverter::Utf8ToW(strExe, WstrExe);
+  CCharsetConverter::Utf8ToW(strParams, WstrParams);
+  CCharsetConverter::Utf8ToW(strWorkingDir, WstrWorkingDir);
 
   bool ret;
   SHELLEXECUTEINFOW ShExecInfo = {0};
@@ -394,7 +394,7 @@ std::string CWIN32Util::GetSpecialFolder(int csidl)
   if(SUCCEEDED(SHGetFolderPathW(NULL, csidl, NULL, SHGFP_TYPE_CURRENT, buf)))
   {
     buf[bufSize-1] = 0;
-    g_charsetConverter.WToUtf8(buf, strProfilePath);
+    CCharsetConverter::WToUtf8(buf, strProfilePath);
     strProfilePath = UncToSmb(strProfilePath);
   }
   else
@@ -485,25 +485,25 @@ std::wstring CWIN32Util::ConvertPathToWin32Form(const std::string& pathUtf8)
   { // assume local file path in form 'C:\Folder\File.ext'
     std::string formedPath("\\\\?\\"); // insert "\\?\" prefix
     formedPath += URIUtils::CanonicalizePath(URIUtils::FixSlashesAndDups(pathUtf8, '\\'), '\\'); // fix duplicated and forward slashes, resolve relative path
-    convertResult = g_charsetConverter.Utf8ToWSystemSafe(formedPath, result);
+    convertResult = CCharsetConverter::Utf8ToWSystemSafe(formedPath, result);
   }
   else if (pathUtf8.compare(0, 8, "\\\\?\\UNC\\", 8) == 0) // pathUtf8 starts from "\\?\UNC\"
   {
     std::string formedPath("\\\\?\\UNC"); // start from "\\?\UNC" prefix
     formedPath += URIUtils::CanonicalizePath(URIUtils::FixSlashesAndDups(pathUtf8.substr(7), '\\'), '\\'); // fix duplicated and forward slashes, resolve relative path, don't touch "\\?\UNC" prefix,
-    convertResult = g_charsetConverter.Utf8ToWSystemSafe(formedPath, result); 
+    convertResult = CCharsetConverter::Utf8ToWSystemSafe(formedPath, result); 
   }
   else if (pathUtf8.compare(0, 4, "\\\\?\\", 4) == 0) // pathUtf8 starts from "\\?\", but it's not UNC path
   {
     std::string formedPath("\\\\?"); // start from "\\?" prefix
     formedPath += URIUtils::CanonicalizePath(URIUtils::FixSlashesAndDups(pathUtf8.substr(3), '\\'), '\\'); // fix duplicated and forward slashes, resolve relative path, don't touch "\\?" prefix,
-    convertResult = g_charsetConverter.Utf8ToWSystemSafe(formedPath, result);
+    convertResult = CCharsetConverter::Utf8ToWSystemSafe(formedPath, result);
   }
   else // pathUtf8 starts from "\\", but not from "\\?\UNC\"
   { // assume UNC path in form '\\server\share\folder\file.ext'
     std::string formedPath("\\\\?\\UNC"); // append "\\?\UNC" prefix
     formedPath += URIUtils::CanonicalizePath(URIUtils::FixSlashesAndDups(pathUtf8), '\\'); // fix duplicated and forward slashes, resolve relative path, transform "\\" prefix to single "\"
-    convertResult = g_charsetConverter.Utf8ToWSystemSafe(formedPath, result);
+    convertResult = CCharsetConverter::Utf8ToWSystemSafe(formedPath, result);
   }
 
   if (!convertResult)
@@ -525,7 +525,7 @@ std::wstring CWIN32Util::ConvertPathToWin32Form(const CURL& url)
   if (url.GetProtocol().empty())
   {
     std::wstring result;
-    if (g_charsetConverter.Utf8ToWSystemSafe("\\\\?\\" +
+    if (CCharsetConverter::Utf8ToWSystemSafe("\\\\?\\" +
           URIUtils::CanonicalizePath(URIUtils::FixSlashesAndDups(url.GetFileName(), '\\'), '\\'), result))
       return result;
   }
@@ -535,7 +535,7 @@ std::wstring CWIN32Util::ConvertPathToWin32Form(const CURL& url)
       return std::wstring(); // empty string
     
     std::wstring result;
-    if (g_charsetConverter.Utf8ToWSystemSafe("\\\\?\\UNC\\" +
+    if (CCharsetConverter::Utf8ToWSystemSafe("\\\\?\\UNC\\" +
           URIUtils::CanonicalizePath(URIUtils::FixSlashesAndDups(url.GetHostName() + '\\' + url.GetFileName(), '\\'), '\\'),
           result))
       return result;
@@ -578,7 +578,7 @@ void CWIN32Util::ExtendDllPath()
     std::string strPath; std::wstring strPathW;
 
     strPath = CSpecialProtocol::TranslatePath(vecEnv[i]);
-    g_charsetConverter.utf8ToW(strPath, strPathW);
+    CCharsetConverter::Utf8ToW(strPath, strPathW);
 
     strEnv.append(";" + strPath);
     AddDllDirectory(strPathW.c_str());
@@ -910,9 +910,9 @@ void CWIN32Util::GetDrivesByType(VECSOURCES &localDrives, Drive_Types eDriveType
          ( eDriveType == DVD_DRIVES && ( uDriveType == DRIVE_CDROM ))))
       {
         //share.strPath = strWdrive;
-        g_charsetConverter.WToUtf8(strWdrive, share.strPath);
+        CCharsetConverter::WToUtf8(strWdrive, share.strPath);
         if( cVolumeName[0] != L'\0' )
-          g_charsetConverter.WToUtf8(cVolumeName, share.strName);
+          CCharsetConverter::WToUtf8(cVolumeName, share.strName);
         if( uDriveType == DRIVE_CDROM && nResult)
         {
           // Has to be the same as auto mounted devices
@@ -982,7 +982,7 @@ extern "C"
   {
     std::string modetmp = _Mode;
     std::wstring wfilename, wmode(modetmp.begin(), modetmp.end());
-    g_charsetConverter.Utf8ToWSystemSafe(_Filename, wfilename);
+    CCharsetConverter::Utf8ToWSystemSafe(_Filename, wfilename);
     return _wfopen(wfilename.c_str(), wmode.c_str());
   }
 }

--- a/xbmc/win32/WIN32Util.cpp
+++ b/xbmc/win32/WIN32Util.cpp
@@ -297,9 +297,9 @@ bool CWIN32Util::XBMCShellExecute(const std::string &strPath, bool bWaitForScrip
   }
 
   std::wstring WstrExe, WstrParams, WstrWorkingDir;
-  g_charsetConverter.utf8ToW(strExe, WstrExe);
-  g_charsetConverter.utf8ToW(strParams, WstrParams);
-  g_charsetConverter.utf8ToW(strWorkingDir, WstrWorkingDir);
+  g_charsetConverter.Utf8ToW(strExe, WstrExe);
+  g_charsetConverter.Utf8ToW(strParams, WstrParams);
+  g_charsetConverter.Utf8ToW(strWorkingDir, WstrWorkingDir);
 
   bool ret;
   SHELLEXECUTEINFOW ShExecInfo = {0};
@@ -394,7 +394,7 @@ std::string CWIN32Util::GetSpecialFolder(int csidl)
   if(SUCCEEDED(SHGetFolderPathW(NULL, csidl, NULL, SHGFP_TYPE_CURRENT, buf)))
   {
     buf[bufSize-1] = 0;
-    g_charsetConverter.wToUTF8(buf, strProfilePath);
+    g_charsetConverter.WToUtf8(buf, strProfilePath);
     strProfilePath = UncToSmb(strProfilePath);
   }
   else
@@ -485,25 +485,25 @@ std::wstring CWIN32Util::ConvertPathToWin32Form(const std::string& pathUtf8)
   { // assume local file path in form 'C:\Folder\File.ext'
     std::string formedPath("\\\\?\\"); // insert "\\?\" prefix
     formedPath += URIUtils::CanonicalizePath(URIUtils::FixSlashesAndDups(pathUtf8, '\\'), '\\'); // fix duplicated and forward slashes, resolve relative path
-    convertResult = g_charsetConverter.utf8ToW(formedPath, result, false, false, true);
+    convertResult = g_charsetConverter.Utf8ToWSystemSafe(formedPath, result);
   }
   else if (pathUtf8.compare(0, 8, "\\\\?\\UNC\\", 8) == 0) // pathUtf8 starts from "\\?\UNC\"
   {
     std::string formedPath("\\\\?\\UNC"); // start from "\\?\UNC" prefix
     formedPath += URIUtils::CanonicalizePath(URIUtils::FixSlashesAndDups(pathUtf8.substr(7), '\\'), '\\'); // fix duplicated and forward slashes, resolve relative path, don't touch "\\?\UNC" prefix,
-    convertResult = g_charsetConverter.utf8ToW(formedPath, result, false, false, true); 
+    convertResult = g_charsetConverter.Utf8ToWSystemSafe(formedPath, result); 
   }
   else if (pathUtf8.compare(0, 4, "\\\\?\\", 4) == 0) // pathUtf8 starts from "\\?\", but it's not UNC path
   {
     std::string formedPath("\\\\?"); // start from "\\?" prefix
     formedPath += URIUtils::CanonicalizePath(URIUtils::FixSlashesAndDups(pathUtf8.substr(3), '\\'), '\\'); // fix duplicated and forward slashes, resolve relative path, don't touch "\\?" prefix,
-    convertResult = g_charsetConverter.utf8ToW(formedPath, result, false, false, true);
+    convertResult = g_charsetConverter.Utf8ToWSystemSafe(formedPath, result);
   }
   else // pathUtf8 starts from "\\", but not from "\\?\UNC\"
   { // assume UNC path in form '\\server\share\folder\file.ext'
     std::string formedPath("\\\\?\\UNC"); // append "\\?\UNC" prefix
     formedPath += URIUtils::CanonicalizePath(URIUtils::FixSlashesAndDups(pathUtf8), '\\'); // fix duplicated and forward slashes, resolve relative path, transform "\\" prefix to single "\"
-    convertResult = g_charsetConverter.utf8ToW(formedPath, result, false, false, true);
+    convertResult = g_charsetConverter.Utf8ToWSystemSafe(formedPath, result);
   }
 
   if (!convertResult)
@@ -525,8 +525,8 @@ std::wstring CWIN32Util::ConvertPathToWin32Form(const CURL& url)
   if (url.GetProtocol().empty())
   {
     std::wstring result;
-    if (g_charsetConverter.utf8ToW("\\\\?\\" +
-          URIUtils::CanonicalizePath(URIUtils::FixSlashesAndDups(url.GetFileName(), '\\'), '\\'), result, false, false, true))
+    if (g_charsetConverter.Utf8ToWSystemSafe("\\\\?\\" +
+          URIUtils::CanonicalizePath(URIUtils::FixSlashesAndDups(url.GetFileName(), '\\'), '\\'), result))
       return result;
   }
   else if (url.IsProtocol("smb"))
@@ -535,9 +535,9 @@ std::wstring CWIN32Util::ConvertPathToWin32Form(const CURL& url)
       return std::wstring(); // empty string
     
     std::wstring result;
-    if (g_charsetConverter.utf8ToW("\\\\?\\UNC\\" +
+    if (g_charsetConverter.Utf8ToWSystemSafe("\\\\?\\UNC\\" +
           URIUtils::CanonicalizePath(URIUtils::FixSlashesAndDups(url.GetHostName() + '\\' + url.GetFileName(), '\\'), '\\'),
-          result, false, false, true))
+          result))
       return result;
   }
   else
@@ -910,9 +910,9 @@ void CWIN32Util::GetDrivesByType(VECSOURCES &localDrives, Drive_Types eDriveType
          ( eDriveType == DVD_DRIVES && ( uDriveType == DRIVE_CDROM ))))
       {
         //share.strPath = strWdrive;
-        g_charsetConverter.wToUTF8(strWdrive, share.strPath);
+        g_charsetConverter.WToUtf8(strWdrive, share.strPath);
         if( cVolumeName[0] != L'\0' )
-          g_charsetConverter.wToUTF8(cVolumeName, share.strName);
+          g_charsetConverter.WToUtf8(cVolumeName, share.strName);
         if( uDriveType == DRIVE_CDROM && nResult)
         {
           // Has to be the same as auto mounted devices
@@ -982,7 +982,7 @@ extern "C"
   {
     std::string modetmp = _Mode;
     std::wstring wfilename, wmode(modetmp.begin(), modetmp.end());
-    g_charsetConverter.utf8ToW(_Filename, wfilename, false);
+    g_charsetConverter.Utf8ToWSystemSafe(_Filename, wfilename);
     return _wfopen(wfilename.c_str(), wmode.c_str());
   }
 }

--- a/xbmc/win32/stat_utf8.cpp
+++ b/xbmc/win32/stat_utf8.cpp
@@ -24,7 +24,7 @@
 int stat64_utf8(const char* __file, struct stat64* __buf)
 {
   std::wstring fileW;
-  if (!g_charsetConverter.Utf8ToWSystemSafe(__file, fileW))
+  if (!CCharsetConverter::Utf8ToWSystemSafe(__file, fileW))
   {
     errno = EINVAL;
     return -1;

--- a/xbmc/win32/stat_utf8.cpp
+++ b/xbmc/win32/stat_utf8.cpp
@@ -24,7 +24,11 @@
 int stat64_utf8(const char* __file, struct stat64* __buf)
 {
   std::wstring fileW;
-  g_charsetConverter.utf8ToW(__file, fileW, false);
+  if (!g_charsetConverter.Utf8ToWSystemSafe(__file, fileW))
+  {
+    errno = EINVAL;
+    return -1;
+  }
   return _wstat64(fileW.c_str(), __buf);
 }
 

--- a/xbmc/win32/stdio_utf8.cpp
+++ b/xbmc/win32/stdio_utf8.cpp
@@ -24,23 +24,31 @@
 int remove_utf8(const char* __filename)
 {
   std::wstring filenameW;
-  g_charsetConverter.utf8ToW(__filename, filenameW, false);
+  if (!g_charsetConverter.Utf8ToWSystemSafe(__filename, filenameW))
+    return -1;
   return ::DeleteFileW(filenameW.c_str()) ? 0 : -1;
 }
 
 int rename_utf8(const char* __old, const char* __new)
 {
   std::wstring oldW, newW;
-  g_charsetConverter.utf8ToW(__old, oldW, false);
-  g_charsetConverter.utf8ToW(__new, newW, false);
-  return ::MoveFileW(oldW.c_str(), newW.c_str()) ? 0 : -1;
+  if (g_charsetConverter.Utf8ToWSystemSafe(__old, oldW) &&
+      g_charsetConverter.Utf8ToWSystemSafe(__new, newW))
+  {
+    return ::MoveFileW(oldW.c_str(), newW.c_str()) ? 0 : -1;
+  }
+  return -1;
 }
 
 FILE* fopen64_utf8(const char* __filename, const char* __modes)
 {
   std::wstring filenameW, modesW;
-  g_charsetConverter.utf8ToW(__filename, filenameW, false);
-  g_charsetConverter.utf8ToW(__modes, modesW, false);
-  return _wfopen(filenameW.c_str(), modesW.c_str());
+  if (g_charsetConverter.Utf8ToWSystemSafe(__filename, filenameW) &&
+      g_charsetConverter.Utf8ToWSystemSafe(__modes, modesW))
+  {
+    return _wfopen(filenameW.c_str(), modesW.c_str());
+  }
+  errno = EINVAL;
+  return NULL;
 }
 

--- a/xbmc/win32/stdio_utf8.cpp
+++ b/xbmc/win32/stdio_utf8.cpp
@@ -24,7 +24,7 @@
 int remove_utf8(const char* __filename)
 {
   std::wstring filenameW;
-  if (!g_charsetConverter.Utf8ToWSystemSafe(__filename, filenameW))
+  if (!CCharsetConverter::Utf8ToWSystemSafe(__filename, filenameW))
     return -1;
   return ::DeleteFileW(filenameW.c_str()) ? 0 : -1;
 }
@@ -32,8 +32,8 @@ int remove_utf8(const char* __filename)
 int rename_utf8(const char* __old, const char* __new)
 {
   std::wstring oldW, newW;
-  if (g_charsetConverter.Utf8ToWSystemSafe(__old, oldW) &&
-      g_charsetConverter.Utf8ToWSystemSafe(__new, newW))
+  if (CCharsetConverter::Utf8ToWSystemSafe(__old, oldW) &&
+      CCharsetConverter::Utf8ToWSystemSafe(__new, newW))
   {
     return ::MoveFileW(oldW.c_str(), newW.c_str()) ? 0 : -1;
   }
@@ -43,8 +43,8 @@ int rename_utf8(const char* __old, const char* __new)
 FILE* fopen64_utf8(const char* __filename, const char* __modes)
 {
   std::wstring filenameW, modesW;
-  if (g_charsetConverter.Utf8ToWSystemSafe(__filename, filenameW) &&
-      g_charsetConverter.Utf8ToWSystemSafe(__modes, modesW))
+  if (CCharsetConverter::Utf8ToWSystemSafe(__filename, filenameW) &&
+      CCharsetConverter::Utf8ToWSystemSafe(__modes, modesW))
   {
     return _wfopen(filenameW.c_str(), modesW.c_str());
   }

--- a/xbmc/windowing/WinEventsX11.cpp
+++ b/xbmc/windowing/WinEventsX11.cpp
@@ -454,7 +454,7 @@ bool CWinEventsX11Imp::MessagePump()
           {
             std::string data(WinEvents->m_keybuf, len);
             std::wstring keys;
-            g_charsetConverter.utf8ToW(data, keys, false);
+            g_charsetConverter.Utf8ToW(data, keys);
 
             if (keys.length() == 0)
             {

--- a/xbmc/windowing/windows/WinSystemWin32.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32.cpp
@@ -697,8 +697,8 @@ bool CWinSystemWin32::UpdateResolutionsInternal()
       if (foundScreen)
       {
         std::string monitorStr, adapterStr;
-        g_charsetConverter.wToUTF8(ddMon.DeviceString, monitorStr);
-        g_charsetConverter.wToUTF8(ddAdapter.DeviceString, adapterStr);
+        g_charsetConverter.WToUtf8(ddMon.DeviceString, monitorStr);
+        g_charsetConverter.WToUtf8(ddAdapter.DeviceString, adapterStr);
         CLog::Log(LOGNOTICE, "Found screen: %s on %s, adapter %d.", monitorStr.c_str(), adapterStr.c_str(), adapter);
 
         // get information about the display's current position and display mode

--- a/xbmc/windowing/windows/WinSystemWin32.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32.cpp
@@ -697,8 +697,8 @@ bool CWinSystemWin32::UpdateResolutionsInternal()
       if (foundScreen)
       {
         std::string monitorStr, adapterStr;
-        g_charsetConverter.WToUtf8(ddMon.DeviceString, monitorStr);
-        g_charsetConverter.WToUtf8(ddAdapter.DeviceString, adapterStr);
+        CCharsetConverter::WToUtf8(ddMon.DeviceString, monitorStr);
+        CCharsetConverter::WToUtf8(ddAdapter.DeviceString, adapterStr);
         CLog::Log(LOGNOTICE, "Found screen: %s on %s, adapter %d.", monitorStr.c_str(), adapterStr.c_str(), adapter);
 
         // get information about the display's current position and display mode

--- a/xbmc/windowing/windows/WinSystemWin32DX.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32DX.cpp
@@ -171,7 +171,7 @@ std::string CWinSystemWin32DX::GetClipboardText(void)
     CloseClipboard();
   }
 
-  g_charsetConverter.wToUTF8(unicode_text, utf8_text);
+  g_charsetConverter.WToUtf8(unicode_text, utf8_text);
 
   return utf8_text;
 }

--- a/xbmc/windowing/windows/WinSystemWin32DX.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32DX.cpp
@@ -171,7 +171,7 @@ std::string CWinSystemWin32DX::GetClipboardText(void)
     CloseClipboard();
   }
 
-  g_charsetConverter.WToUtf8(unicode_text, utf8_text);
+  CCharsetConverter::WToUtf8(unicode_text, utf8_text);
 
   return utf8_text;
 }


### PR DESCRIPTION
I started a discussion about this in PR #3903 and thought it might be a good idea to create this to have a place to discuss details.

Starting to feel fairly "complete", opinions welcome.
The complete lack of logging is by design, If conversion fails the logging can be handled at a higher level, we loose a bit of error details but avoid circular depencies on CLog.

There's a few design decisions I've not yet decided upon
- Fix all function names to uppercase initial char?
- store subtitle/gui charset in CCharsetConverter, this would add  a need for locking for a few functions but it would remove the dependency on langinfo

Thinking about API design and my current thinking is along the lines of removing the failOnBadChar switch and rather use two different functions, possible naming could be utf8ToUtf16 and utf8ToUtf16SystemSafe. First option would skip bad chars and be the mainly used one, second option would be for syscalls and could include mac specific utf-8 handling and other considerations needed to cater for system specific stuff.
