### PR TITLE
nuke presetlist action. fixes #15518

### DIFF
--- a/xbmc/guilib/Key.h
+++ b/xbmc/guilib/Key.h
@@ -249,7 +249,6 @@
 #define ACTION_ANALOG_SEEK_BACK     125 // seeks backward, and displays the seek bar.
 
 #define ACTION_VIS_PRESET_SHOW        126
-#define ACTION_VIS_PRESET_LIST        127
 #define ACTION_VIS_PRESET_NEXT        128
 #define ACTION_VIS_PRESET_PREV        129
 #define ACTION_VIS_PRESET_LOCK        130

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -179,7 +179,6 @@ static const ActionMapping actions[] =
         {"analogseekforward" , ACTION_ANALOG_SEEK_FORWARD},
         {"analogseekback"    , ACTION_ANALOG_SEEK_BACK},
         {"showpreset"        , ACTION_VIS_PRESET_SHOW},
-        {"presetlist"        , ACTION_VIS_PRESET_LIST},
         {"nextpreset"        , ACTION_VIS_PRESET_NEXT},
         {"previouspreset"    , ACTION_VIS_PRESET_PREV},
         {"lockpreset"        , ACTION_VIS_PRESET_LOCK},


### PR DESCRIPTION
remove dead code. 
people should use visualisationpresetlist instead.
