### PR TITLE
Revert automatically listing UPnP servers among video sources

### DIFF
--- a/xbmc/filesystem/SourcesDirectory.cpp
+++ b/xbmc/filesystem/SourcesDirectory.cpp
@@ -18,12 +18,10 @@
  *
  */
 
-#include "system.h"
 #include "SourcesDirectory.h"
 #include "utils/URIUtils.h"
 #include "URL.h"
 #include "Util.h"
-#include "Directory.h"
 #include "FileItem.h"
 #include "File.h"
 #include "profiles/ProfilesManager.h"
@@ -57,16 +55,7 @@ bool CSourcesDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   sources = *sourcesFromType;
   g_mediaManager.GetRemovableDrives(sources);
 
-  if (!GetDirectory(sources, items))
-    return false;
-
-#ifdef HAS_UPNP
-  CFileItemList upnpServers;
-  if (CDirectory::GetDirectory("upnp://", upnpServers))
-    items.Append(upnpServers);
-#endif
-
-  return true;
+  return GetDirectory(sources, items);
 }
 
 bool CSourcesDirectory::GetDirectory(const VECSOURCES &sources, CFileItemList &items)

--- a/xbmc/network/upnp/UPnP.cpp
+++ b/xbmc/network/upnp/UPnP.cpp
@@ -184,14 +184,9 @@ public:
     // PLT_MediaBrowser methods
     virtual bool OnMSAdded(PLT_DeviceDataReference& device)
     {
-        // update any open upnp:// path
         CGUIMessage message(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_PATH);
         message.SetStringParam("upnp://");
         g_windowManager.SendThreadMessage(message);
-
-        // update any open source view
-        CGUIMessage updateSourcesMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_SOURCES);
-        g_windowManager.SendThreadMessage(updateSourcesMessage);
 
         return PLT_SyncMediaBrowser::OnMSAdded(device);
     }
@@ -199,14 +194,9 @@ public:
     {
         PLT_SyncMediaBrowser::OnMSRemoved(device);
 
-        // update any open upnp:// path
         CGUIMessage message(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_PATH);
         message.SetStringParam("upnp://");
         g_windowManager.SendThreadMessage(message);
-
-        // update any open source view
-        CGUIMessage updateSourcesMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_SOURCES);
-        g_windowManager.SendThreadMessage(updateSourcesMessage);
 
         PLT_SyncMediaBrowser::OnMSRemoved(device);
     }


### PR DESCRIPTION
This reverts two commits from #5492 which automatically add UPnP servers to the list of video sources (not as sources, just like removable devices) upon discovery. Apparently not everyone likes this behaviour. The other three commits from #5492 were fixes so they should be ok.
