### PR TITLE
[Readme] xbmc -> kodi left over

### DIFF
--- a/docs/README.raspberrypi
+++ b/docs/README.raspberrypi
@@ -21,7 +21,7 @@ For example :
 mkdir /opt/kodi-raspberrypi
 cd /opt/kodi-raspberrypi
 
-Checkout xbmc :
+Checkout kodi :
 
 git clone https://github.com/xbmc/xbmc.git kodi
 


### PR DESCRIPTION
I guess its up to huceke to update his buildroot readmes which still all refer to xbmc.
