### PR TITLE
[dvdplayer] Allow dvd menus to work with hardware decoders

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -311,7 +311,8 @@ void CVideoPlayerVideo::Process()
 
   while (!m_bStop)
   {
-    int iQueueTimeOut = (int)(m_stalled ? frametime / 4 : frametime * 10) / 1000;
+    bool bPictureWaiting = m_hints.stills && (m_pVideoCodec->Decode(NULL, 0, DVD_NOPTS_VALUE, DVD_NOPTS_VALUE) & VC_PICTURE);
+    int iQueueTimeOut = (int)(bPictureWaiting ? 0 : (m_hints.stills || m_stalled) ? frametime / 4 : frametime * 10) / 1000;
     int iPriority = (m_speed == DVD_PLAYSPEED_PAUSE && m_syncState == IDVDStreamPlayer::SYNC_INSYNC) ? 1 : 0;
 
     if (m_syncState == IDVDStreamPlayer::SYNC_WAITSYNC)
@@ -331,27 +332,36 @@ void CVideoPlayerVideo::Process()
       if( iPriority )
         continue;
 
-      //Okey, start rendering at stream fps now instead, we are likely in a stillframe
-      if (!m_stalled)
+      // check for picture waiting
+      if (bPictureWaiting)
       {
-        if(m_syncState == IDVDStreamPlayer::SYNC_INSYNC)
-          CLog::Log(LOGINFO, "CVideoPlayerVideo - Stillframe detected, switching to forced %f fps", m_fFrameRate);
-        m_stalled = true;
-        pts+= frametime*4;
+        // create a dummy demuxer packet to prod the decode logic
+        pMsg = new CDVDMsgDemuxerPacket(CDVDDemuxUtils::AllocateDemuxPacket(0), false);
       }
-
-      //Waiting timed out, output last picture
-      if( picture.iFlags & DVP_FLAG_ALLOCATED )
+      else
       {
-        //Remove interlaced flag before outputting
-        //no need to output this as if it was interlaced
-        picture.iFlags &= ~DVP_FLAG_INTERLACED;
-        picture.iFlags |= DVP_FLAG_NOSKIP;
-        OutputPicture(&picture, pts);
-        pts+= frametime;
-      }
+        //Okey, start rendering at stream fps now instead, we are likely in a stillframe
+        if (!m_stalled)
+        {
+          if(m_syncState == IDVDStreamPlayer::SYNC_INSYNC)
+            CLog::Log(LOGINFO, "CVideoPlayerVideo - Stillframe detected, switching to forced %f fps", m_fFrameRate);
+          m_stalled = true;
+          pts+= frametime*4;
+        }
 
-      continue;
+        //Waiting timed out, output last picture
+        if( picture.iFlags & DVP_FLAG_ALLOCATED )
+        {
+          //Remove interlaced flag before outputting
+          //no need to output this as if it was interlaced
+          picture.iFlags &= ~DVP_FLAG_INTERLACED;
+          picture.iFlags |= DVP_FLAG_NOSKIP;
+          OutputPicture(&picture, pts);
+          pts+= frametime;
+        }
+
+        continue;
+      }
     }
 
     if (pMsg->IsType(CDVDMsg::GENERAL_SYNCHRONIZE))


### PR DESCRIPTION
Video from DVD menus (stills) are currently always software decoded (and don't use ffmpeg).
The understanding has been this is due to some custom settings not compatible with ffmpeg and hardware decoders. I don't believe this to be the case.

The real issue is that we only poke the decoder when a new packet arrives. Hardware codecs generally don't return a frame immediately, but on a later call. With dvd stills there may not be a later call, which means the decoded picture never has a chance to be returned.

This PR also prods the decoder when in stills mode from the normal timeouts from message queue to give it a chance to return pictures.

The first two commits just refactor and should have no functional change.
The third (minor) change makes it work.
