### PR TITLE
Honor "ignorethewhensorting" when jumping to letter

### DIFF
--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -32,6 +32,7 @@
 #include "utils/MathUtils.h"
 #include "utils/XBMCTinyXML.h"
 #include "listproviders/IListProvider.h"
+#include "settings/Settings.h"
 
 using namespace std;
 
@@ -561,7 +562,10 @@ void CGUIBaseContainer::OnJumpLetter(char letter, bool skip /*=false*/)
   do
   {
     CGUIListItemPtr item = m_items[i];
-    if (0 == strnicmp(SortUtils::RemoveArticles(item->GetLabel()).c_str(), m_match.c_str(), m_match.size()))
+    std::string label = item->GetLabel();
+    if (CSettings::Get().GetBool("filelists.ignorethewhensorting"))
+      label = SortUtils::RemoveArticles(label);
+    if (0 == strnicmp(label.c_str(), m_match.c_str(), m_match.size()))
     {
       SelectItem(i);
       return;


### PR DESCRIPTION
I always found really confusing that if i have the option "Ignore articles when sorting" disabled, I press shift + h and I'm at letter 'i' it jumps for example to "The Host" instead to the first movie that starts with 'h'.
It could be a new option but IMO if someone disable the option wants to use full name to jump.
IS it just me? If you disagree feel free to drop this pull request ;)
