### PR TITLE
[ios] - get the resolution clamp for > 720p material back in place - the...

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecVideoToolBox.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecVideoToolBox.cpp
@@ -1521,10 +1521,10 @@ CDVDVideoCodecVideoToolBox::CreateVTSession(int width, int height, CMFormatDescr
   if ((width * height) > (1920 * 800))
     width_clamp = 960;
 
-  // allow rendering without scaledown for all
-  // retina devices (which have enough power to handle it)
+  // for retina devices it should be safe [tm] to
+  // loosen the clamp a bit to 1280 pixels width
   if (CDarwinUtils::DeviceHasRetina(scale))
-    width_clamp = 1920;
+    width_clamp = 1280;
 
   int new_width = CheckNP2(width);
   if (width != new_width)


### PR DESCRIPTION
... assumption that retina devices have enough power was wrong.

We now clamp retina devices to 1280 (instead of 960 before) width as this is something which @linusyang did in his branch for all 64bit CPUs - his builds were used by alot of people.

This assumption could be proven wrong again. Users which are still using gotham on ios8 (with my updated cydia versions) will hopefully point it out if there are devices which are retina and to low powered for this. (sorry there is no technically way to determine this limit for me).

This fixes stuttering hw accelerated HD playback on some retina devices (introduced by removing the clamp for those which was way to optimistic by me as proven by the users...).
