### PR TITLE
[NfoFile] fix empty video details for multipart episodes

### DIFF
--- a/xbmc/NfoFile.cpp
+++ b/xbmc/NfoFile.cpp
@@ -72,13 +72,12 @@ CNfoFile::NFOResult CNfoFile::Create(const CStdString& strPath, const ScraperPtr
       int infos=0;
       while (m_headPos != std::string::npos && details.m_iEpisode != episode)
       {
-        m_headPos = m_doc.find("<episodedetails", m_headPos);
+        m_headPos = m_doc.find("<episodedetails", m_headPos + 1);
         if (m_headPos == std::string::npos)
           break;
 
         bNfo  = GetDetails(details);
         infos++;
-        m_headPos++;
       }
       if (details.m_iEpisode != episode)
       {


### PR DESCRIPTION
This commit partially reverts 3bacf68ce3b2ad78a359359d2fcd383a0b6ac74f which introduced a regression for loading multipart episode details as reported on the forums (see http://forum.kodi.tv/showthread.php?tid=207986&pid=1829676)

@Montellese for review.
