### PR TITLE
[jenkins] - fix wrong branchnames at times

### DIFF
--- a/tools/buildsteps/defaultenv
+++ b/tools/buildsteps/defaultenv
@@ -139,7 +139,8 @@ function getBranchName ()
   else
     #if we are in detached head state
     #fetch the first non-pullrequest branch we can find with HEAD
-    git branch -r --contains HEAD | sed "/origin\/pr\//d" | head -n1 | awk '{gsub(".*/","");print $1}'
+    #also only grep in remotes that match current GITHUB_REPO
+    git branch -r --contains HEAD | sed "/origin\/pr\//d" | grep $GITHUB_REPO | head -n1 | awk '{gsub(".*/","");print $1}'
   fi
 }
 


### PR DESCRIPTION
I describe the issue just for documentation purposes here.

As of now in our jenkins jobs all branches where fetched locally to this ref:

remotes/origin/<branchname>

This was done for alle github repos - xbmc and other devs repos. In the end all branches ended up under remoets/origin/\* on the slaves.

When we try to determine the branchname for crafting the resulting filename of the kodi package we use "git branch -r --contains HEAD" end return the first line. Consider following scenario.
1. repo xbmc branch master is at revision 12345
2. repo memphiz branch iosclamp is based on repo xbmc branch master and has revision 54321 on top of it
3. jenkins builds nightly from repo xbmc branch master at revision 12345
4. jenkins gets triggered by me to build repo memphiz branch master(!) - it hereby fetches all branches from repo memphiz including the branch iosclamp
5. jenkins builds the same nightly as in 3. because of no new commits during the day in master
6. For determining the branch name it now issues "git branch -r --contains HEAD" - where HEAD points to revsion 12345
7. the output will now list remotes/origin/iosclamp as the first line because this branch indeed contains 12345 (expected would be master...) - there we have the wrong filename for a nightly build...

This issue is solved by changing the refspec in the jobs so that each repo is tracked in its own subfolder. For example from now on a builds for repo memphiz would fetch the branches into remotes/Memphiz/<branchnames> instead of remotes/origin/<branchnames>. That keeps the branches seperated by repos.

The change for this PR now simply adds a "grep $GITHUB_REPO" after the git branch -r --contains HEAD - leading to the fact that only branches from the built repo are considered for the resulting filename.

@MartijnKaijser i have altered the jobs in a backward compatible way for now. Please ping me 2 weeks after this PR was merged so i can remove the legacy from the jobs then ... ;)
