### PR TITLE
Fix SMB files reading on POSIX platforms

### DIFF
--- a/xbmc/filesystem/SMBFile.cpp
+++ b/xbmc/filesystem/SMBFile.cpp
@@ -596,14 +596,12 @@ void CSMBFile::Close()
 ssize_t CSMBFile::Write(const void* lpBuf, size_t uiBufSize)
 {
   if (m_fd == -1) return -1;
-  DWORD dwNumberOfBytesWritten = 0;
 
   // lpBuf can be safely casted to void* since xbmc_write will only read from it.
   smb.Init();
   CSingleLock lock(smb);
-  dwNumberOfBytesWritten = smbc_write(m_fd, (void*)lpBuf, (DWORD)uiBufSize);
 
-  return dwNumberOfBytesWritten;
+  return  smbc_write(m_fd, (void*)lpBuf, uiBufSize);
 }
 
 bool CSMBFile::Delete(const CURL& url)

--- a/xbmc/filesystem/SMBFile.cpp
+++ b/xbmc/filesystem/SMBFile.cpp
@@ -310,13 +310,11 @@ CSMBFile::~CSMBFile()
 
 int64_t CSMBFile::GetPosition()
 {
-  if (m_fd == -1) return 0;
+  if (m_fd == -1)
+    return -1;
   smb.Init();
   CSingleLock lock(smb);
-  int64_t pos = smbc_lseek(m_fd, 0, SEEK_CUR);
-  if ( pos < 0 )
-    return 0;
-  return pos;
+  return smbc_lseek(m_fd, 0, SEEK_CUR);
 }
 
 int64_t CSMBFile::GetLength()

--- a/xbmc/filesystem/SMBFile.cpp
+++ b/xbmc/filesystem/SMBFile.cpp
@@ -319,7 +319,8 @@ int64_t CSMBFile::GetPosition()
 
 int64_t CSMBFile::GetLength()
 {
-  if (m_fd == -1) return 0;
+  if (m_fd == -1)
+    return -1;
   return m_fileSize;
 }
 

--- a/xbmc/filesystem/SMBFile.cpp
+++ b/xbmc/filesystem/SMBFile.cpp
@@ -516,6 +516,14 @@ ssize_t CSMBFile::Read(void *lpBuf, size_t uiBufSize)
   if (m_fd == -1)
     return -1;
 
+  // Some external libs (libass) use test read with zero size and 
+  // null buffer pointer to check whether file is readable, but 
+  // libsmbclient always return "-1" if called with null buffer 
+  // regardless of buffer size.
+  // To overcome this, force return "0" in that case.
+  if (uiBufSize == 0 && lpBuf == NULL)
+    return 0;
+
   CSingleLock lock(smb); // Init not called since it has to be "inited" by now
   smb.SetActivityTime();
   /* work around stupid bug in samba */


### PR DESCRIPTION
Two fixes for SMB file on POSIX.
First fix is similar to fixes on Win32File and PosixFile.
Second one for bug reported [here](https://github.com/xbmc/xbmc/pull/5534#issuecomment-60687376).
**EDIT:** Added minor fixes.
