### PR TITLE
Add RunScript backwards compatibility

### DIFF
--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -467,6 +467,7 @@ int CBuiltins::Execute(const std::string& execString)
     {
       AddonPtr addon;
       std::string scriptpath;
+      // Test to see if the param is an addon ID
       if (CAddonMgr::Get().GetAddon(params[0], addon))
       {
         //Get the correct extension point to run
@@ -474,9 +475,16 @@ int CBuiltins::Execute(const std::string& execString)
             CAddonMgr::Get().GetAddon(params[0], addon, ADDON_SCRIPT_WEATHER) ||
             CAddonMgr::Get().GetAddon(params[0], addon, ADDON_SCRIPT_LYRICS) ||
             CAddonMgr::Get().GetAddon(params[0], addon, ADDON_SCRIPT_LIBRARY))
+        {
           scriptpath = addon->LibPath();
+        }
         else
-          CLog::Log(LOGERROR, "RunScript called for invalid add-on id '%s'. Not a script.", params[0].c_str());
+        {
+          //Run a random extension point (old behaviour).
+          CAddonMgr::Get().GetAddon(params[0], addon);
+          scriptpath = addon->LibPath();
+          CLog::Log(LOGWARNING, "RunScript called for a non-script addon '%s'. This behaviour is deprecated.", params[0].c_str());
+        }
       }
       else
         scriptpath = params[0];

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -585,8 +585,7 @@ int CBuiltins::Execute(const std::string& execString)
     if (params.size())
     {
       AddonPtr addon;
-      std::string cmd;
-      if (CAddonMgr::Get().GetAddon(params[0],addon,ADDON_PLUGIN))
+      if (CAddonMgr::Get().GetAddon(params[0], addon, ADDON_PLUGIN))
       {
         PluginPtr plugin = boost::dynamic_pointer_cast<CPluginSource>(addon);
         std::string addonid = params[0];
@@ -607,6 +606,7 @@ int CBuiltins::Execute(const std::string& execString)
           urlParameters = "/";
         }
 
+        std::string cmd;
         if (plugin->Provides(CPluginSource::VIDEO))
           cmd = StringUtils::Format("ActivateWindow(Videos,plugin://%s%s,return)", addonid.c_str(), urlParameters.c_str());
         else if (plugin->Provides(CPluginSource::AUDIO))
@@ -619,16 +619,19 @@ int CBuiltins::Execute(const std::string& execString)
           // Pass the script name (params[0]) and all the parameters
           // (params[1] ... params[x]) separated by a comma to RunPlugin
           cmd = StringUtils::Format("RunPlugin(%s)", StringUtils::Join(params, ",").c_str());
+        Execute(cmd);
       }
       else if (CAddonMgr::Get().GetAddon(params[0], addon, ADDON_SCRIPT) ||
                CAddonMgr::Get().GetAddon(params[0], addon, ADDON_SCRIPT_WEATHER) ||
                CAddonMgr::Get().GetAddon(params[0], addon, ADDON_SCRIPT_LYRICS) ||
                CAddonMgr::Get().GetAddon(params[0], addon, ADDON_SCRIPT_LIBRARY))
+      {
         // Pass the script name (params[0]) and all the parameters
         // (params[1] ... params[x]) separated by a comma to RunScript
-        cmd = StringUtils::Format("RunScript(%s)", StringUtils::Join(params, ",").c_str());
-
-      return Execute(cmd);
+        Execute(StringUtils::Format("RunScript(%s)", StringUtils::Join(params, ",").c_str()));
+      }
+      else
+        CLog::Log(LOGERROR, "RunAddon: unknown add-on id '%s', or unexpected add-on type (not a script or plugin).", params[0].c_str());
     }
     else
     {


### PR DESCRIPTION
Fixes regression introduced by #5563. Apparently, many add-ons are using `RunScript` to run other non-script addons. This 'feature' must go if addons are to be allowed to have 'script' as an addition extension points unambiguously. Adds backwards compatibility and warns about this instead. 

Also adds add similar warning to RunAddon: _log_ when addon isn't a script/plugin and nothing will be executed.
