### PR TITLE
fix CApplicationMessenger::SendText() not sending the text to the proper edit control

### DIFF
--- a/xbmc/ApplicationMessenger.cpp
+++ b/xbmc/ApplicationMessenger.cpp
@@ -1281,7 +1281,7 @@ void CApplicationMessenger::SendText(const std::string &aTextString, bool closeK
   if (!window)
     return;
 
-  CGUIMessage msg(GUI_MSG_SET_TEXT, 0, 0);
+  CGUIMessage msg(GUI_MSG_SET_TEXT, 0, window->GetFocusedControlID());
   msg.SetLabel(aTextString);
   msg.SetParam1(closeKeyboard ? 1 : 0);
   SendGUIMessage(msg, window->GetID());


### PR DESCRIPTION
@Tolriq told me that JSON-RPC's `Input.SendText` doesn't work in some dialogs so I tried to reproduce it and realized that it only worked by chance. I always assumed that sending a `CGUIMessage` with a control ID of `0` would simply go to the currently focused control but apparently that's not the case. So we have to get the ID of the currently focused control ourselves.
