### PR TITLE
[infomanager] only call UpdateAVInfo when really needed

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -3617,7 +3617,6 @@ CStdString CGUIInfoManager::GetMusicLabel(int item)
 {
   if (!g_application.m_pPlayer->IsPlaying() || !m_currentFile->HasMusicInfoTag()) return "";
 
-  UpdateAVInfo();
   switch (item)
   {
   case MUSICPLAYER_PLAYLISTLEN:
@@ -3634,6 +3633,7 @@ CStdString CGUIInfoManager::GetMusicLabel(int item)
     break;
   case MUSICPLAYER_BITRATE:
     {
+      UpdateAVInfo();
       CStdString strBitrate = "";
       if (m_audioInfo.bitrate > 0)
         strBitrate = StringUtils::Format("%i", MathUtils::round_int((double)m_audioInfo.bitrate / 1000.0));
@@ -3642,6 +3642,7 @@ CStdString CGUIInfoManager::GetMusicLabel(int item)
     break;
   case MUSICPLAYER_CHANNELS:
     {
+      UpdateAVInfo();
       CStdString strChannels = "";
       if (m_audioInfo.channels > 0)
       {
@@ -3652,6 +3653,7 @@ CStdString CGUIInfoManager::GetMusicLabel(int item)
     break;
   case MUSICPLAYER_BITSPERSAMPLE:
     {
+      UpdateAVInfo();
       CStdString strBitsPerSample = "";
       if (m_audioInfo.bitspersample > 0)
         strBitsPerSample = StringUtils::Format("%i", m_audioInfo.bitspersample);
@@ -3660,6 +3662,7 @@ CStdString CGUIInfoManager::GetMusicLabel(int item)
     break;
   case MUSICPLAYER_SAMPLERATE:
     {
+      UpdateAVInfo();
       CStdString strSampleRate = "";
       if (m_audioInfo.samplerate > 0)
         strSampleRate = StringUtils::Format("%.5g", ((double)m_audioInfo.samplerate / 1000.0));
@@ -3668,6 +3671,7 @@ CStdString CGUIInfoManager::GetMusicLabel(int item)
     break;
   case MUSICPLAYER_CODEC:
     {
+      UpdateAVInfo();
       return StringUtils::Format("%s", m_audioInfo.audioCodecName.c_str());
     }
     break;

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -4333,8 +4333,13 @@ void CGUIInfoManager::UpdateAVInfo()
       g_application.m_pPlayer->GetVideoStreamInfo(video);
       g_application.m_pPlayer->GetAudioStreamInfo(g_application.m_pPlayer->GetAudioStream(), audio);
 
-      m_videoInfo = video;
-      m_audioInfo = audio;
+      {
+        // Gui Thread and Python API can call this
+        // overwriting members will lead to corruption
+        CSingleLock lock(m_critUpdate);
+        m_videoInfo = video;
+        m_audioInfo = audio;
+      }
       m_AVInfoValid = true;
     }
   }

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -958,6 +958,7 @@ protected:
   SPlayerAudioStreamInfo m_audioInfo;
 
   CCriticalSection m_critInfo;
+  CCriticalSection m_critUpdate;
 };
 
 /*!


### PR DESCRIPTION
Currently we´re updating the av information whenever the infomanager is polled for `MUSICPLAYER_*`. This commit makes sure we´re only updating the information when really needed.

Second commit by @fritsch makes sure we´re not running in a race condition where the ui and addon try to update the av information.

@Montellese, @topfs2, @MartijnKaijser for review and Helix approval.
