### PR TITLE
[logging] stop log spam introduced with ba34a62

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2759,7 +2759,7 @@
         </setting>
         <setting id="debug.setextraloglevel" type="list[integer]" parent="debug.extralogging" label="668" help="36534">
           <level>1</level>
-          <default>32,64,128,256,512,1024,2048,4096,16384,32768</default>
+          <default>32768</default>
           <constraints>
             <options>loggingcomponents</options>
             <delimiter>,</delimiter>


### PR DESCRIPTION
This disables the log spam introduced with ba34a62 while retaining CEC logging as only extra component that is enabled by default (as requested by @opdenkamp).
