### PR TITLE
[rbp] Enable optimization on Raspberry Pi

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -771,13 +771,8 @@ CXXFLAGS="$CXXFLAGS $DEBUG_FLAGS"
 
 if test "$use_optimizations" = "yes"; then
   final_message="$final_message\n  Optimization:\tYes"
-  if test "$target_platform" = "target_raspberry_pi"; then
-    CXXFLAGS="$CXXFLAGS"
-    CFLAGS="$CFLAGS"
-  else
-    CXXFLAGS="-O2 $CXXFLAGS"
-    CFLAGS="-O2 $CFLAGS"
-  fi
+  CXXFLAGS="-O2 $CXXFLAGS"
+  CFLAGS="-O2 $CFLAGS"
 else
   final_message="$final_message\n  Optimization:\tNo"
 fi


### PR DESCRIPTION
Originally disabled by commit 177bc0b to work around FFmpeg issue. I believe that is no longer relevant since FFmpeg optimization flags are handled separately now. Building core Kodi code with -O2 does not produce any ill effects on Raspberry Pi and should be a good thing to enable by default since performance is critical on that platform. Tested on Raspbian Jessie with GCC 4.9.1.
