### PR TITLE
videorefclock: fix clock speed for D3D after refactoring

### DIFF
--- a/xbmc/guilib/GraphicContext.cpp
+++ b/xbmc/guilib/GraphicContext.cpp
@@ -454,9 +454,6 @@ void CGraphicContext::SetVideoResolutionInternal(RESOLUTION res, bool forceUpdat
   m_scissors.SetRect(0, 0, (float)m_iScreenWidth, (float)m_iScreenHeight);
   m_Resolution    = res;
 
-  //tell the videoreferenceclock that we're about to change the refreshrate
-  g_VideoReferenceClock.RefreshChanged();
-
   if (g_advancedSettings.m_fullScreen)
   {
 #if defined (TARGET_DARWIN) || defined (TARGET_WINDOWS)
@@ -470,6 +467,9 @@ void CGraphicContext::SetVideoResolutionInternal(RESOLUTION res, bool forceUpdat
     g_Windowing.SetFullScreen(false, info_org, false);
   else
     g_Windowing.ResizeWindow(info_org.iWidth, info_org.iHeight, -1, -1);
+
+  //tell the videoreferenceclock that we changed the refreshrate
+  g_VideoReferenceClock.RefreshChanged();
 
   // make sure all stereo stuff are correctly setup
   SetStereoView(RENDER_STEREO_VIEW_OFF);

--- a/xbmc/video/VideoReferenceClock.cpp
+++ b/xbmc/video/VideoReferenceClock.cpp
@@ -61,7 +61,6 @@ CVideoReferenceClock::CVideoReferenceClock() : CThread("RefClock")
   m_fineadjust = 0.0;
   m_RefreshRate = 0.0;
   m_MissedVblanks = 0;
-  m_RefreshChanged = 0;
   m_VblankTime = 0;
 
   m_pVideoSync = NULL;
@@ -127,7 +126,6 @@ void CVideoReferenceClock::Process()
     m_ClockSpeed = 1.0;
     m_TotalMissedVblanks = 0;
     m_fineadjust = 1.0;
-    m_RefreshChanged = 0;
     m_MissedVblanks = 0;
 
     if (SetupSuccess)
@@ -391,6 +389,15 @@ void CVideoReferenceClock::SetFineAdjust(double fineadjust)
 {
   CSingleLock SingleLock(m_CritSection);
   m_fineadjust = fineadjust;
+}
+
+void CVideoReferenceClock::RefreshChanged()
+{
+  CSingleLock SingleLock(m_CritSection);
+  if (m_pVideoSync)
+  {
+    m_pVideoSync->RefreshChanged();
+  }
 }
 
 CVideoReferenceClock g_VideoReferenceClock;

--- a/xbmc/video/VideoReferenceClock.h
+++ b/xbmc/video/VideoReferenceClock.h
@@ -38,7 +38,7 @@ class CVideoReferenceClock : public CThread
     int64_t Wait(int64_t Target);
     bool    GetClockInfo(int& MissedVblanks, double& ClockSpeed, double& RefreshRate);
     void    SetFineAdjust(double fineadjust);
-    void    RefreshChanged() { m_RefreshChanged = 1; }
+    void    RefreshChanged();
     void    Stop();
 
   private:
@@ -61,7 +61,6 @@ class CVideoReferenceClock : public CThread
     bool    m_UseVblank;         //set to true when vblank is used as clock source
     double  m_RefreshRate;       //current refreshrate
     int     m_MissedVblanks;     //number of clock updates missed by the vblank clock
-    int     m_RefreshChanged;    //1 = we changed the refreshrate, 2 = we should check the refreshrate forced
     int     m_TotalMissedVblanks;//total number of clock updates missed, used by codec information screen
     int64_t m_VblankTime;        //last time the clock was updated when using vblank as clock
 

--- a/xbmc/video/videosync/VideoSync.h
+++ b/xbmc/video/videosync/VideoSync.h
@@ -29,6 +29,7 @@ public:
   virtual void Run(volatile bool& stop) = 0;
   virtual void Cleanup() = 0;
   virtual float GetFps() = 0;
+  virtual void RefreshChanged() {};
 protected:
   PUPDATECLOCK UpdateClock;
   float m_fps;

--- a/xbmc/video/videosync/VideoSyncD3D.cpp
+++ b/xbmc/video/videosync/VideoSyncD3D.cpp
@@ -46,6 +46,11 @@ void CVideoSyncD3D::OnResetDevice()
   m_displayReset = true;
 }
 
+void CVideoSyncD3D::RefreshChanged()
+{
+  m_displayReset = true;
+}
+
 bool CVideoSyncD3D::Setup(PUPDATECLOCK func)
 {
   int ReturnV;

--- a/xbmc/video/videosync/VideoSyncD3D.h
+++ b/xbmc/video/videosync/VideoSyncD3D.h
@@ -34,6 +34,7 @@ public:
   virtual void Run(volatile bool& stop);
   virtual void Cleanup();
   virtual float GetFps();
+  virtual void RefreshChanged();
 
   virtual void OnCreateDevice() {}
   virtual void OnDestroyDevice();


### PR DESCRIPTION
see title. gfx may not fire a display reset event when refresh rate has changed.

http://forum.kodi.tv/showthread.php?tid=208264
