### PR TITLE
binary addons: fix dependency handling for dependencies

### DIFF
--- a/project/cmake/addons/depends/CMakeLists.txt
+++ b/project/cmake/addons/depends/CMakeLists.txt
@@ -107,21 +107,11 @@ foreach(file ${cmake_input_files})
         set(INSTALL_COMMAND "")
       endif()
 
-      # check if there's a deps.txt containing dependencies on other libraries
-      if(EXISTS ${dir}/deps.txt})
-        file(STRINGS ${dir}/deps.txt deps)
-        message(STATUS "${id} dependencies: ${deps}")
-        set(DEPENDS_COMMAND DEPENDS ${deps})
-      else()
-        set(DEPENDS_COMMAND "")
-      endif()
-
       # prepare the setup of the call to externalproject_add()
       set(EXTERNALPROJECT_SETUP PREFIX build/${id}
                                 CMAKE_ARGS ${BUILD_ARGS}
                                 PATCH_COMMAND ${PATCH_COMMAND}
-                                "${INSTALL_COMMAND}"
-                                "${DEPENDS_COMMAND}")
+                                "${INSTALL_COMMAND}")
 
       # if there's an url defined we need to pass that to externalproject_add()
       if(DEFINED url AND NOT "${url}" STREQUAL "")
@@ -146,6 +136,13 @@ foreach(file ${cmake_input_files})
                             SOURCE_DIR ${dir}
                             "${EXTERNALPROJECT_SETUP}"
                            )
+      endif()
+
+      # check if there's a deps.txt containing dependencies on other libraries
+      if(EXISTS ${dir}/deps.txt)
+        file(STRINGS ${dir}/deps.txt deps)
+        message(STATUS "${id} dependencies: ${deps}")
+        add_dependencies(${id} ${deps})
       endif()
     endif()
   endif()


### PR DESCRIPTION
I noticed that there are currently two errors in how we handle dependencies of binary addon dependencies in cmake.
- There's a typo on line 111 i.e. the `}` before the `)` at the end of the line is wrong and results in dependency handling not working.
- Apparently `DEPENDS` of cmake's `externalproject_add()` only works for targets that are already known (i.e. have already been processed by cmake) but this might not always be the case for us so we better use `add_dependencies()` instead.

We are currently not really using this with the audioencoder addons (because linux/osx/android uses depends and win32 uses pre-built dependencies) but we might need it later.
