### PR TITLE
[curl] Avoid busy spinning when socket timeout is too low

### DIFF
--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -1549,7 +1549,7 @@ bool CCurlFile::CReadState::FillBuffer(unsigned int want)
         g_curlInterface.multi_fdset(m_multiHandle, &fdread, &fdwrite, &fdexcep, &maxfd);
 
         long timeout = 0;
-        if (CURLM_OK != g_curlInterface.multi_timeout(m_multiHandle, &timeout) || timeout == -1)
+        if (CURLM_OK != g_curlInterface.multi_timeout(m_multiHandle, &timeout) || timeout == -1 || timeout < 200)
           timeout = 200;
 
         XbmcThreads::EndTime endTime(timeout);


### PR DESCRIPTION
This is an RFC as I don't know this code well, but my investigation may provoke a better fix.
See: http://forum.kodi.tv/showthread.php?tid=201797&pid=1771808#pid1771808

Summary: when streaming audio through http the cpu usage starts low and creeps higher and higher.

For first minute, the CPU usage of FileCache thread is a few percent.
As time goes by the cpu usage for this thread increases until it hits about 60% and we start stuttering.

Disabling the filecache (buffermode=3) avoids the high cpu issue.

I've tracked down where the cpu is occurring.
CCurlFile::CReadState::FillBuffer is called with want=1.
After a while, g_curlInterface.multi_timeout returns smaller and smaller timeouts,
until it it just returning 0 and 1 for timeout. This results in busy spinning in this function.
The small timeouts mean small amounts of data are read and so FillBuffer gets called more often.

My fix just ensures the timeout is never less than 200ms.
Now stream plays for a long time without stuttering and FileCache thread remains at about 1% CPU.
