### PR TITLE
AE: Some fixes for the Cubox hardware

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
@@ -479,7 +479,8 @@ void CAESinkALSA::GetAESParams(AEAudioFormat format, std::string& params)
 
   params += ",AES1=0x82,AES2=0x00";
 
-       if (format.m_sampleRate == 192000) params += ",AES3=0x0e";
+  if (m_passthrough && format.m_channelLayout.Count() == 8) params += ",AES3=0x09";
+  else if (format.m_sampleRate == 192000) params += ",AES3=0x0e";
   else if (format.m_sampleRate == 176400) params += ",AES3=0x0c";
   else if (format.m_sampleRate ==  96000) params += ",AES3=0x0a";
   else if (format.m_sampleRate ==  88200) params += ",AES3=0x08";

--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
@@ -39,6 +39,8 @@
 #include "utils/AMLUtils.h"
 #endif
 
+
+#define AE_MIN_PERIODSIZE 256
 #define ALSA_CHMAP_KERNEL_BLACKLIST
 
 #define ALSA_OPTIONS (SND_PCM_NO_AUTO_FORMAT | SND_PCM_NO_AUTO_CHANNELS | SND_PCM_NO_AUTO_RESAMPLE)
@@ -86,7 +88,9 @@ CAESinkALSA::CAESinkALSA() :
   m_formatSampleRateMul(0.0),
   m_passthrough(false),
   m_pcm(NULL),
-  m_timeout(0)
+  m_timeout(0),
+  m_fragmented(false),
+  m_originalPeriodSize(AE_MIN_PERIODSIZE)
 {
   /* ensure that ALSA has been initialized */
   if (!snd_config)
@@ -807,7 +811,19 @@ bool CAESinkALSA::InitializeHW(const ALSAConfig &inconfig, ALSAConfig &outconfig
 
   /* set the format parameters */
   outconfig.sampleRate   = sampleRate;
-  outconfig.periodSize   = periodSize;
+
+  /* if periodSize is too small Audio Engine might starve */
+  m_fragmented = false;
+  unsigned int fragments = 1;
+  if (periodSize < AE_MIN_PERIODSIZE)
+  {
+    fragments = std::ceil((double) AE_MIN_PERIODSIZE / periodSize);
+    CLog::Log(LOGDEBUG, "Audio Driver reports too low periodSize %d - will use %d fragments", (int) periodSize, (int) fragments);
+    m_fragmented = true;
+  }
+
+  m_originalPeriodSize   = periodSize;
+  outconfig.periodSize   = fragments * periodSize;
   outconfig.frameSize    = snd_pcm_frames_to_bytes(m_pcm, 1);
 
   m_bufferSize = (unsigned int)bufferSize;
@@ -894,27 +910,45 @@ unsigned int CAESinkALSA::AddPackets(uint8_t **data, unsigned int frames, unsign
   }
 
   void *buffer = data[0]+offset*m_format.m_frameSize;
-  int ret = snd_pcm_writei(m_pcm, buffer, frames);
-  if (ret < 0)
+  unsigned int amount = 0;
+  int64_t data_left = (int64_t) frames;
+  int frames_written = 0;
+
+  while (data_left > 0)
   {
-    CLog::Log(LOGERROR, "CAESinkALSA - snd_pcm_writei(%d) %s - trying to recover", ret, snd_strerror(ret));
-    ret = snd_pcm_recover(m_pcm, ret, 1);
-    if(ret < 0)
+    if (m_fragmented)
+      amount = std::min((unsigned int) data_left, m_originalPeriodSize);
+    else // take care as we can come here a second time if the sink does not eat all data
+      amount = (unsigned int) data_left;
+
+    int ret = snd_pcm_writei(m_pcm, buffer, amount);
+    if (ret < 0)
     {
-      HandleError("snd_pcm_writei(1)", ret);
-      ret = snd_pcm_writei(m_pcm, buffer, frames);
-      if (ret < 0)
+      CLog::Log(LOGERROR, "CAESinkALSA - snd_pcm_writei(%d) %s - trying to recover", ret, snd_strerror(ret));
+      ret = snd_pcm_recover(m_pcm, ret, 1);
+      if(ret < 0)
       {
-        HandleError("snd_pcm_writei(2)", ret);
-        ret = 0;
+        HandleError("snd_pcm_writei(1)", ret);
+        ret = snd_pcm_writei(m_pcm, buffer, amount);
+        if (ret < 0)
+        {
+          HandleError("snd_pcm_writei(2)", ret);
+          ret = 0;
+        }
       }
     }
+
+    if ( ret > 0 && snd_pcm_state(m_pcm) == SND_PCM_STATE_PREPARED)
+      snd_pcm_start(m_pcm);
+
+    if (ret <= 0)
+      break;
+
+    frames_written += ret;
+    data_left -= ret;
+    buffer = data[0]+offset*m_format.m_frameSize + frames_written*m_format.m_frameSize;
   }
-
-  if ( ret > 0 && snd_pcm_state(m_pcm) == SND_PCM_STATE_PREPARED)
-    snd_pcm_start(m_pcm);
-
-  return ret;
+  return frames_written;
 }
 
 void CAESinkALSA::HandleError(const char* name, int err)

--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.h
@@ -78,7 +78,9 @@ private:
   std::string       m_device;
   snd_pcm_t        *m_pcm;
   int               m_timeout;
-
+  // support fragmentation, e.g. looping in the sink to get a certain amount of data onto the device
+  bool              m_fragmented;
+  unsigned int      m_originalPeriodSize;
   struct ALSAConfig
   {
     unsigned int sampleRate;


### PR DESCRIPTION
As I am currently starting to get all the needed cubox patches which are wide spread in repositories out there together back to mother xbmc. Those are the first two.

@Anssih: Please check Patch number 2 if it's really spec compliant

The fragmentation patch is a direct result of the kernel driver which only returns such small periodSizes, so we need to add data onto the sink in fragments as we don't want too low values for AE as this will highly increase CPU load.
