### PR TITLE
fix 'action' type addon settings not executed if id attribute is missing

### DIFF
--- a/xbmc/addons/GUIDialogAddonSettings.cpp
+++ b/xbmc/addons/GUIDialogAddonSettings.cpp
@@ -211,7 +211,6 @@ bool CGUIDialogAddonSettings::ShowAndGetInput(const AddonPtr &addon, bool saveTo
     std::string heading = StringUtils::Format("$LOCALIZE[10004] - %s", addon->Name().c_str()); // "Settings - AddonName"
     pDialog->m_strHeading = heading;
 
-    pDialog->m_changed = false;
     pDialog->m_addon = addon;
     pDialog->m_saveToDisk = saveToDisk;
     pDialog->DoModal();

--- a/xbmc/addons/GUIDialogAddonSettings.cpp
+++ b/xbmc/addons/GUIDialogAddonSettings.cpp
@@ -80,6 +80,7 @@ CGUIDialogAddonSettings::CGUIDialogAddonSettings()
 {
   m_currentSection = 0;
   m_totalSections = 1;
+  m_saveToDisk = false;
 }
 
 CGUIDialogAddonSettings::~CGUIDialogAddonSettings(void)

--- a/xbmc/addons/GUIDialogAddonSettings.cpp
+++ b/xbmc/addons/GUIDialogAddonSettings.cpp
@@ -236,8 +236,26 @@ bool CGUIDialogAddonSettings::ShowVirtualKeyboard(int iControl)
     if (controlId == iControl)
     {
       const CGUIControl* control = GetControl(controlId);
-      const std::string   id = XMLUtils::GetAttribute(setting, "id");
+      const std::string id = XMLUtils::GetAttribute(setting, "id");
       const std::string type = XMLUtils::GetAttribute(setting, "type");
+
+      //Special handling for actions: does not require id attribute. TODO: refactor me.
+      if (control && control->GetControlType() == CGUIControl::GUICONTROL_BUTTON && type == "action")
+      {
+        const char *option = setting->Attribute("option");
+        std::string action = XMLUtils::GetAttribute(setting, "action");
+        if (!action.empty())
+        {
+          // replace $CWD with the url of plugin/script
+          StringUtils::Replace(action, "$CWD", m_addon->Path());
+          StringUtils::Replace(action, "$ID", m_addon->ID());
+          if (option)
+            bCloseDialog = (strcmpi(option, "close") == 0);
+          CApplicationMessenger::Get().ExecBuiltIn(action);
+        }
+        break;
+      }
+
       if (control && control->GetControlType() == CGUIControl::GUICONTROL_BUTTON &&
           !id.empty() && !type.empty())
       {
@@ -410,19 +428,6 @@ bool CGUIDialogAddonSettings::ShowVirtualKeyboard(int iControl)
 
             if (CGUIDialogFileBrowser::ShowAndGetFile(localShares, strMask, label, value, bUseThumbs, bUseFileDirectories))
               ((CGUIButtonControl*) control)->SetLabel2(value);
-          }
-        }
-        else if (type == "action")
-        {
-          std::string action = XMLUtils::GetAttribute(setting, "action");
-          if (!action.empty())
-          {
-            // replace $CWD with the url of plugin/script
-            StringUtils::Replace(action, "$CWD", m_addon->Path());
-            StringUtils::Replace(action, "$ID", m_addon->ID());
-            if (option)
-              bCloseDialog = (strcmpi(option, "close") == 0);
-            CApplicationMessenger::Get().ExecBuiltIn(action);
           }
         }
         else if (type == "date")

--- a/xbmc/addons/GUIDialogAddonSettings.h
+++ b/xbmc/addons/GUIDialogAddonSettings.h
@@ -81,7 +81,6 @@ private:
 
   ADDON::AddonPtr m_addon;
   std::map<std::string,std::string> m_buttonValues;
-  bool m_changed;
   bool m_saveToDisk; // whether the addon settings should be saved to disk or just stored locally in the addon
 
   unsigned int m_currentSection;


### PR DESCRIPTION
Fixes regression introduced in 2ce4cccd07f6d9d3a143a. These actions will currently show up in gui even if it does not have an id attribute, but nothing will happen if clicked.
