### PR TITLE
add component logging for video

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -2887,7 +2887,12 @@ msgctxt "#679"
 msgid "Verbose logging for CEC library"
 msgstr ""
 
-#empty strings from id 680 to 699
+#: xbmc/settings/AdvancedSettings.cpp
+msgctxt "#680"
+msgid "Verbose logging for VIDEO component"
+msgstr ""
+
+#empty strings from id 681 to 699
 
 msgctxt "#700"
 msgid "Cleaning up library"

--- a/xbmc/commons/ilog.h
+++ b/xbmc/commons/ilog.h
@@ -53,6 +53,7 @@
 #define LOGAIRTUNES (1 << (LOGMASKBIT + 8))
 #define LOGUPNP     (1 << (LOGMASKBIT + 9))
 #define LOGCEC      (1 << (LOGMASKBIT + 10))
+#define LOGVIDEO    (1 << (LOGMASKBIT + 11))
 
 #include "utils/params_check_macros.h"
 

--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
@@ -1578,7 +1578,8 @@ int CDVDPlayerVideo::CalcDropRequirement(double pts)
   else if (iBufferLevel < 2)
   {
     result |= EOS_BUFFER_LEVEL;
-    CLog::Log(LOGDEBUG,"CDVDPlayerVideo::CalcDropRequirement - hurry: %d", iBufferLevel);
+    if (g_advancedSettings.CanLogComponent(LOGVIDEO))
+      CLog::Log(LOGDEBUG,"CDVDPlayerVideo::CalcDropRequirement - hurry: %d", iBufferLevel);
   }
 
   bNewFrame = iDecoderPts != m_droppingStats.m_lastDecoderPts;
@@ -1599,7 +1600,8 @@ int CDVDPlayerVideo::CalcDropRequirement(double pts)
       m_droppingStats.m_totalGain += gain.gain;
       result |= EOS_DROPPED;
       m_droppingStats.m_dropRequests = 0;
-      CLog::Log(LOGDEBUG,"CDVDPlayerVideo::CalcDropRequirement - dropped pictures, Sleeptime: %f, Bufferlevel: %d, Gain: %f", iSleepTime, iBufferLevel, iGain);
+      if (g_advancedSettings.CanLogComponent(LOGVIDEO))
+        CLog::Log(LOGDEBUG,"CDVDPlayerVideo::CalcDropRequirement - dropped pictures, Sleeptime: %f, Bufferlevel: %d, Gain: %f", iSleepTime, iBufferLevel, iGain);
     }
     else if (iDroppedPics < 0 && iGain > (1/m_fFrameRate + 0.001))
     {
@@ -1610,7 +1612,8 @@ int CDVDPlayerVideo::CalcDropRequirement(double pts)
       m_droppingStats.m_totalGain += iGain;
       result |= EOS_DROPPED;
       m_droppingStats.m_dropRequests = 0;
-      CLog::Log(LOGDEBUG,"CDVDPlayerVideo::CalcDropRequirement - dropped in decoder, Sleeptime: %f, Bufferlevel: %d, Gain: %f", iSleepTime, iBufferLevel, iGain);
+      if (g_advancedSettings.CanLogComponent(LOGVIDEO))
+        CLog::Log(LOGDEBUG,"CDVDPlayerVideo::CalcDropRequirement - dropped in decoder, Sleeptime: %f, Bufferlevel: %d, Gain: %f", iSleepTime, iBufferLevel, iGain);
     }
   }
   m_droppingStats.m_lastDecoderPts = iDecoderPts;

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -1359,6 +1359,8 @@ void CAdvancedSettings::SettingOptionsLoggingComponentsFiller(const CSetting *se
   list.push_back(std::make_pair(g_localizeStrings.Get(670), LOGCURL));
   list.push_back(std::make_pair(g_localizeStrings.Get(671), LOGCMYTH));
   list.push_back(std::make_pair(g_localizeStrings.Get(672), LOGFFMPEG));
+  list.push_back(std::make_pair(g_localizeStrings.Get(676), LOGAUDIO));
+  list.push_back(std::make_pair(g_localizeStrings.Get(676), LOGVIDEO));
 #ifdef HAS_LIBRTMP
   list.push_back(std::make_pair(g_localizeStrings.Get(673), LOGRTMP));
 #endif
@@ -1367,9 +1369,6 @@ void CAdvancedSettings::SettingOptionsLoggingComponentsFiller(const CSetting *se
 #endif
 #ifdef HAS_JSONRPC
   list.push_back(std::make_pair(g_localizeStrings.Get(675), LOGJSONRPC));
-#endif
-#ifdef HAS_ALSA
-  list.push_back(std::make_pair(g_localizeStrings.Get(676), LOGAUDIO));
 #endif
 #ifdef HAS_AIRTUNES
   list.push_back(std::make_pair(g_localizeStrings.Get(677), LOGAIRTUNES));


### PR DESCRIPTION
this should go in right after #4639 (where it is based on) in order not to introduce more logging. in a further step we can move all debug logging of video codecs to component logging. lots of audio logs too.
