### PR TITLE
FIX: must return true after setting update

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1783,7 +1783,7 @@ bool CApplication::OnSettingUpdate(CSetting* &setting, const char *oldSettingId,
     if (!aml_present())
     {
       CSettingBool *useamcodec = (CSettingBool*)setting;
-      useamcodec->SetValue(false);
+      return useamcodec->SetValue(false);
     }
   }
 #endif
@@ -1796,13 +1796,13 @@ bool CApplication::OnSettingUpdate(CSetting* &setting, const char *oldSettingId,
     if (CAndroidFeatures::GetVersion() < 16)
     {
       CSettingBool *usemediacodec = (CSettingBool*)setting;
-      usemediacodec->SetValue(false);
+      return usemediacodec->SetValue(false);
     }
   }
   else if (settingId == "videoplayer.usestagefright")
   {
     CSettingBool *usestagefright = (CSettingBool*)setting;
-    usestagefright->SetValue(false);
+    return usestagefright->SetValue(false);
   }
 #endif
 #if defined(TARGET_DARWIN_OSX)


### PR DESCRIPTION
@Montellese If I understand your recent settings commit, if "true" is not returned from "OnSettingUpdate", the overrides are reset, right?
This apparently fixes at least the fact that android amlcodec is picked up even it's not an amlogic box (and crashes).
