### PR TITLE
[vtb] - fix - use the correct bit for signaling the hw decoder to drop a...

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecVideoToolBox.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecVideoToolBox.cpp
@@ -66,8 +66,7 @@ enum {
 enum {
   // tells the decoder not to bother returning a CVPixelBuffer
   // in the outputCallback. The output callback will still be called.
-  kVTDecoderDecodeFlags_DontEmitFrame = 1 << 0,
-  kVTDecoderDecodeFlags_DontEmitFrameIOS8 = 1 << 1
+  kVTDecoderDecodeFlags_DontEmitFrame = 1 << 1,
 };
 enum {
   // decode and return buffers for all frames currently in flight.
@@ -1377,10 +1376,7 @@ int CDVDVideoCodecVideoToolBox::Decode(uint8_t* pData, int iSize, double dts, do
 
     if (m_DropPictures)
     {
-      if (CDarwinUtils::GetIOSVersion() >= 8.0)
-        decoderFlags = kVTDecoderDecodeFlags_DontEmitFrameIOS8;
-      else
-        decoderFlags = kVTDecoderDecodeFlags_DontEmitFrame;
+      decoderFlags = kVTDecoderDecodeFlags_DontEmitFrame;
     }
 
     // submit for decoding


### PR DESCRIPTION
... frame. This is the bit which is visible in the now public ios 8 headers of vtb. I doubt that apple ever change this till ios4. If they did - we are screwed on older runtimes. At least on ios6 this bit is valid for sure.

Well i discovered that we were off by one in the kVTDecoderDecodeFlags_DontEmitFrame bit. On ios8 our wrong bit crashed the decoder during seek. I firstly ifdefed the new bit define for only beeing effective on ios8.

Now while looking for a problem on h.264 playback on atv2 (ios6) i realised that using the good bit from ios8 fixes my issue.

That means ... from iso6 to ios8 the bit from this PR is the correct one for signaling the hw decoder to drop frames. For ios5 i will varify. Only risk is ios4. Because of the fact that vtb was private till ios8 apple might have theoretically changed the bit meanings for the hw decoder. But i really doubt it - changing bits would be really bad style.

@davilla a comment?

This fixes a/v sync issue on atv2 and other ios devices which need to drop frames for some reasons (after seek e.x.).
