### PR TITLE
[rtmp] fix crash on seek on live streams

### DIFF
--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamRTMP.h
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamRTMP.h
@@ -27,6 +27,7 @@
 class CDVDInputStreamRTMP 
   : public CDVDInputStream
   , public CDVDInputStream::ISeekTime
+  , public CDVDInputStream::ISeekable
 {
 public:
   CDVDInputStreamRTMP();
@@ -36,7 +37,9 @@ public:
   virtual int     Read(uint8_t* buf, int buf_size);
   virtual int64_t Seek(int64_t offset, int whence);
   bool            SeekTime(int iTimeInMsec);
-  virtual bool Pause(double dTime);
+  bool            CanSeek()  { return m_canSeek; }
+  bool            CanPause() { return m_canPause; }
+  virtual bool    Pause(double dTime);
   virtual bool    IsEOF();
   virtual int64_t GetLength();
 
@@ -45,8 +48,9 @@ public:
 protected:
   bool       m_eof;
   bool       m_bPaused;
+  bool       m_canSeek;
+  bool       m_canPause;
   char*      m_sStreamPlaying;
-  std::vector<std::string> m_optionvalues;
 
   RTMP       *m_rtmp;
   DllLibRTMP m_libRTMP;


### PR DESCRIPTION
this fixes issues raised in http://forum.kodi.tv/showthread.php?tid=187840&page=2

This PR does 2 things:
1. implement CanSeek() for RTMP 
2. removes unused protocol options struct, those are parsed from the URL and handled directly in librtmp.
