### PR TITLE
dvdplayer: allow rewinding at end of stream, do a seek after rewind

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -1796,7 +1796,7 @@ void CDVDPlayer::HandlePlaySpeed()
 
     }
     else if (m_CurrentVideo.id >= 0
-          &&  m_CurrentVideo.inited == true
+          &&  (m_CurrentVideo.inited == true || GetPlaySpeed() < 0) // allow rewind at end of file
           &&  m_SpeedState.lastpts  != m_dvdPlayerVideo->GetCurrentPts()
           &&  m_SpeedState.lasttime != GetTime())
     {
@@ -2441,6 +2441,12 @@ void CDVDPlayer::HandleMessages()
         {
           CDVDInputStreamPVRManager* pvrinputstream = static_cast<CDVDInputStreamPVRManager*>(m_pInputStream);
           pvrinputstream->Pause( speed == 0 );
+        }
+
+        // do a seek after rewind, clock is not in sync with current pts
+        if (m_playSpeed < 0 && speed >= 0)
+        {
+          m_messenger.Put(new CDVDMsgPlayerSeek(GetTime(), true, true, true));
         }
 
         // if playspeed is different then DVD_PLAYSPEED_NORMAL or DVD_PLAYSPEED_PAUSE


### PR DESCRIPTION
fix rewind at end of stream when player has already seen eof but there are still a couple of seconds in the buffers.
fixes a/v sync issue after rewind
