### PR TITLE
Handle BlueZ 5.x play/pause evdev scancodes

### DIFF
--- a/xbmc/windowing/WinEventsSDL.cpp
+++ b/xbmc/windowing/WinEventsSDL.cpp
@@ -84,6 +84,8 @@ static uint16_t SymMappingsEvdev[][2] =
 , { 179, XBMCK_LAUNCH_MEDIA_SELECT } // Launch media select
 , { 180, XBMCK_BROWSER_HOME }        // Browser home
 , { 181, XBMCK_BROWSER_REFRESH }     // Browser refresh
+, { 208, XBMCK_MEDIA_PLAY_PAUSE }    // Play_Pause
+, { 209, XBMCK_MEDIA_PLAY_PAUSE }    // Play_Pause
 , { 214, XBMCK_ESCAPE }              // Close
 , { 215, XBMCK_MEDIA_PLAY_PAUSE }    // Play_Pause
 , { 216, 0x66 /* 'f' */}             // Forward


### PR DESCRIPTION
BlueZ 5.x emits [`KEY_PLAYCD`](http://git.kernel.org/cgit/bluetooth/bluez.git/tree/profiles/audio/avctp.c#n266) (kernel: `0xC8`, SDL: `0xD0`) and [`KEY_PAUSECD`](http://git.kernel.org/cgit/bluetooth/bluez.git/tree/profiles/audio/avctp.c#n267) (kernel: `0xC9`, SDL: `0xD1`) evdev key press events for relevant AVRCP button presses instead of `KEY_PLAYPAUSE` (kernel: `0xA4`, SDL: `0xAC`) recognized by XBMC. Thus, two additional SDL scancodes should be mapped to the `XBMCK_MEDIA_PLAY_PAUSE` keysym.

I have successfully tested this pull request with a Dell BH200 headset used with Linux 3.16.5, XBMC 12.2, BlueZ 5.21 and SDL 1.2.15.
