### PR TITLE
[videoinfoscanner] do database clean off main thread

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -5622,17 +5622,15 @@ void CApplication::StartVideoCleanup(bool userInitiated /* = true */)
 {
   if (m_videoInfoScanner->IsScanning())
     return;
-
-  m_videoInfoScanner->CleanDatabase(NULL, NULL, userInitiated);
+  m_videoInfoScanner->ShowDialog(userInitiated);
+  m_videoInfoScanner->StartLibraryClean();
 }
 
 void CApplication::StartVideoScan(const CStdString &strDirectory, bool userInitiated /* = true */, bool scanAll /* = false */)
 {
   if (m_videoInfoScanner->IsScanning())
     return;
-
   m_videoInfoScanner->ShowDialog(userInitiated);
-
   m_videoInfoScanner->Start(strDirectory,scanAll);
 }
 

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -1460,8 +1460,8 @@ int CBuiltins::Execute(const std::string& execString)
     {
       if (!g_application.IsMusicScanning())
       {
+        //FIXME: do this on a seaparate thread
         CMusicDatabase musicdatabase;
-
         musicdatabase.Open();
         musicdatabase.Cleanup(userInitiated);
         musicdatabase.Close();

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -76,9 +76,18 @@ namespace VIDEO
 
   void CVideoInfoScanner::Process()
   {
+    if (m_bClean)
+    {
+      //Only clean, no scanning.
+      CleanDatabase(NULL, NULL, m_showDialog);
+      return;
+    }
+
     try
     {
       unsigned int tick = XbmcThreads::SystemClockMillis();
+
+      m_bClean = g_advancedSettings.m_bVideoLibraryCleanOnUpdate;
 
       m_database.Open();
 
@@ -186,9 +195,18 @@ namespace VIDEO
         m_pathsToScan.insert(it->second);
     }
     m_database.Close();
-    m_bClean = g_advancedSettings.m_bVideoLibraryCleanOnUpdate;
-
     StopThread();
+    m_bClean = false;
+    Create();
+    m_bRunning = true;
+  }
+
+  void CVideoInfoScanner::StartLibraryClean()
+  {
+    m_pathsToScan.clear();
+    m_pathsToClean.clear();
+    StopThread();
+    m_bClean = true;
     Create();
     m_bRunning = true;
   }

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -60,8 +60,8 @@ namespace VIDEO
      */
     void Start(const CStdString& strDirectory, bool scanAll = false);
     bool IsScanning();
-    void CleanDatabase(CGUIDialogProgressBarHandle* handle=NULL, const std::set<int>* paths=NULL, bool showProgress=true);
     void Stop();
+    void StartLibraryClean();
 
     //! \brief Set whether or not to show a progress dialog
     void ShowDialog(bool show) { m_showDialog = show; }
@@ -126,6 +126,7 @@ namespace VIDEO
     virtual void Process();
     bool DoScan(const CStdString& strDirectory);
     bool IsExcluded(const CStdString& strDirectory) const;
+    void CleanDatabase(CGUIDialogProgressBarHandle* handle=NULL, const std::set<int>* paths=NULL, bool showProgress=true);
 
     INFO_RET RetrieveInfoForTvShow(CFileItem *pItem, bool bDirNames, ADDON::ScraperPtr &scraper, bool useLocal, CScraperUrl* pURL, bool fetchEpisodes, CGUIDialogProgress* pDlgProgress);
     INFO_RET RetrieveInfoForMovie(CFileItem *pItem, bool bDirNames, ADDON::ScraperPtr &scraper, bool useLocal, CScraperUrl* pURL, CGUIDialogProgress* pDlgProgress);


### PR DESCRIPTION
Moves it to VideoInfoScanner and changes the modal progress dialog to background one. Fixes freezing issues discussed here: http://forum.kodi.tv/showthread.php?tid=207697  (**Note: does not fix for music.** That is still done in Builtin.cpp)

@mkortstiege if you have time. I'm not going to lie to you: it's not pretty.
