### PR TITLE
Vda fixes

### DIFF
--- a/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
@@ -2693,7 +2693,7 @@ bool CLinuxRendererGL::CreateCVRefTexture(int index)
     // This is necessary for non-power-of-two textures
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-    glTexImage2D(m_textureTarget, 0, GL_RGBA, plane.texwidth, plane.texheight, 0, GL_YCBCR_422_APPLE, GL_UNSIGNED_SHORT_8_8_APPLE, NULL);
+    glTexImage2D(m_textureTarget, 0, GL_RGB, plane.texwidth, plane.texheight, 0, GL_YCBCR_422_APPLE, GL_UNSIGNED_SHORT_8_8_APPLE, NULL);
     glBindTexture(m_textureTarget, 0);
   }
   glDisable(m_textureTarget);

--- a/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
@@ -1481,8 +1481,8 @@ void CLinuxRendererGL::RenderFromFBO()
 
     m_fbo.fbo.SetFiltering(m_textureTarget, filter);
     m_pVideoFilterShader->SetSourceTexture(0);
-    m_pVideoFilterShader->SetWidth(m_sourceWidth);
-    m_pVideoFilterShader->SetHeight(m_sourceHeight);
+    m_pVideoFilterShader->SetWidth(m_fbo.width);
+    m_pVideoFilterShader->SetHeight(m_fbo.height);
 
     //disable non-linear stretch when a dvd menu is shown, parts of the menu are rendered through the overlay renderer
     //having non-linear stretch on breaks the alignment
@@ -1502,8 +1502,8 @@ void CLinuxRendererGL::RenderFromFBO()
 
   VerifyGLState();
 
-  float imgwidth = m_fbo.width / m_sourceWidth;
-  float imgheight = m_fbo.height / m_sourceHeight;
+  float imgwidth  = m_sourceWidth  / m_fbo.width;
+  float imgheight = m_sourceHeight / m_fbo.height;
 
   glBegin(GL_QUADS);
 

--- a/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
@@ -2675,8 +2675,8 @@ bool CLinuxRendererGL::CreateCVRefTexture(int index)
   im.cshift_x = 0;
   im.cshift_y = 0;
 
-  plane.texwidth  = NP2(im.width);
-  plane.texheight = NP2(im.height);
+  plane.texwidth  = im.width;
+  plane.texheight = im.height;
   plane.pixpertex_x = 1;
   plane.pixpertex_y = 1;
 

--- a/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
@@ -2680,6 +2680,12 @@ bool CLinuxRendererGL::CreateCVRefTexture(int index)
   plane.pixpertex_x = 1;
   plane.pixpertex_y = 1;
 
+  if(m_renderMethod & RENDER_POT)
+  {
+    plane.texwidth  = NP2(plane.texwidth);
+    plane.texheight = NP2(plane.texheight);
+  }
+
   glEnable(m_textureTarget);
   glGenTextures(1, &plane.id);
   if (Cocoa_GetOSVersion() >= 0x1074)

--- a/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
@@ -2615,7 +2615,7 @@ bool CLinuxRendererGL::UploadCVRefTexture(int index)
       IOSurfaceRef	surface  = CVPixelBufferGetIOSurface(cvBufferRef);
       GLsizei       texWidth = IOSurfaceGetWidth(surface);
       GLsizei       texHeight= IOSurfaceGetHeight(surface);
-      OSType        format_type = CVPixelBufferGetPixelFormatType(cvBufferRef);
+      OSType        format_type = IOSurfaceGetPixelFormat(surface);
 
       glBindTexture(m_textureTarget, plane.id);
 

--- a/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
@@ -1465,7 +1465,7 @@ void CLinuxRendererGL::RenderToFBO(int index, int field, bool weave /*= false*/)
 
 void CLinuxRendererGL::RenderFromFBO()
 {
-  glEnable(m_textureTarget);
+  glEnable(GL_TEXTURE_2D);
   glActiveTextureARB(GL_TEXTURE0);
   VerifyGLState();
 
@@ -1479,7 +1479,7 @@ void CLinuxRendererGL::RenderFromFBO()
     if (!m_pVideoFilterShader->GetTextureFilter(filter))
       filter = m_scalingMethod == VS_SCALINGMETHOD_NEAREST ? GL_NEAREST : GL_LINEAR;
 
-    m_fbo.fbo.SetFiltering(m_textureTarget, filter);
+    m_fbo.fbo.SetFiltering(GL_TEXTURE_2D, filter);
     m_pVideoFilterShader->SetSourceTexture(0);
     m_pVideoFilterShader->SetWidth(m_fbo.width);
     m_pVideoFilterShader->SetHeight(m_fbo.height);
@@ -1496,7 +1496,7 @@ void CLinuxRendererGL::RenderFromFBO()
   else
   {
     GLint filter = m_scalingMethod == VS_SCALINGMETHOD_NEAREST ? GL_NEAREST : GL_LINEAR;
-    m_fbo.fbo.SetFiltering(m_textureTarget, filter);
+    m_fbo.fbo.SetFiltering(GL_TEXTURE_2D, filter);
     glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE);
   }
 
@@ -1528,8 +1528,8 @@ void CLinuxRendererGL::RenderFromFBO()
 
   VerifyGLState();
 
-  glBindTexture(m_textureTarget, 0);
-  glDisable(m_textureTarget);
+  glBindTexture(GL_TEXTURE_2D, 0);
+  glDisable(GL_TEXTURE_2D);
   VerifyGLState();
 }
 

--- a/xbmc/cores/VideoRenderers/VideoShaders/YUV2RGBShader.cpp
+++ b/xbmc/cores/VideoRenderers/VideoShaders/YUV2RGBShader.cpp
@@ -213,7 +213,7 @@ BaseYUV2RGBGLSLShader::BaseYUV2RGBGLSLShader(bool rect, unsigned flags, ERenderF
     m_defines += "#define XBMC_NV12\n";
   else if (m_format == RENDER_FMT_YUYV422)
     m_defines += "#define XBMC_YUY2\n";
-  else if (m_format == RENDER_FMT_UYVY422)
+  else if (m_format == RENDER_FMT_UYVY422 || m_format == RENDER_FMT_CVBREF)
     m_defines += "#define XBMC_UYVY\n";
   else if (m_format == RENDER_FMT_VDPAU_420)
     m_defines += "#define XBMC_VDPAU_NV12\n";
@@ -376,7 +376,7 @@ YUV2RGBProgressiveShaderARB::YUV2RGBProgressiveShaderARB(bool rect, unsigned fla
     else
       shaderfile = "yuv2rgb_basic_2d_YUY2.arb";
   }
-  else if (m_format == RENDER_FMT_UYVY422)
+  else if (m_format == RENDER_FMT_UYVY422 || m_format == RENDER_FMT_CVBREF)
   {
     if(rect)
       shaderfile = "yuv2rgb_basic_rect_UYVY.arb";

--- a/xbmc/cores/dvdplayer/DVDCodecs/DVDFactoryCodec.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/DVDFactoryCodec.cpp
@@ -58,6 +58,7 @@
 
 
 #include "DVDStreamInfo.h"
+#include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "utils/SystemInfo.h"
 #include "utils/StringUtils.h"
@@ -214,7 +215,7 @@ CDVDVideoCodec* CDVDFactoryCodec::CreateVideoCodec(CDVDStreamInfo &hint, unsigne
 #endif
 
 #if defined(TARGET_DARWIN_OSX)
-  if (!hint.software && CSettings::Get().GetBool("videoplayer.usevda"))
+  if (!hint.software && CSettings::Get().GetBool("videoplayer.usevda") && !g_advancedSettings.m_useFfmpegVda)
   {
     if (hint.codec == AV_CODEC_ID_H264 && !hint.ptsinvalid)
     {

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -128,7 +128,7 @@ enum PixelFormat CDVDVideoCodecFFmpeg::GetFormat( struct AVCodecContext * avctx
 #endif
 
 #ifdef TARGET_DARWIN_OSX
-    if (*cur == AV_PIX_FMT_VDA_VLD && CSettings::Get().GetBool("videoplayer.usevda"))
+    if (*cur == AV_PIX_FMT_VDA && CSettings::Get().GetBool("videoplayer.usevda"))
     {
       VDA::CDecoder* dec = new VDA::CDecoder();
       if(dec->Open(avctx, *cur, ctx->m_uSurfacesCount))

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -128,7 +128,7 @@ enum PixelFormat CDVDVideoCodecFFmpeg::GetFormat( struct AVCodecContext * avctx
 #endif
 
 #ifdef TARGET_DARWIN_OSX
-    if (*cur == AV_PIX_FMT_VDA && CSettings::Get().GetBool("videoplayer.usevda"))
+    if (*cur == AV_PIX_FMT_VDA && CSettings::Get().GetBool("videoplayer.usevda") && g_advancedSettings.m_useFfmpegVda)
     {
       VDA::CDecoder* dec = new VDA::CDecoder();
       if(dec->Open(avctx, *cur, ctx->m_uSurfacesCount))

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -142,6 +142,16 @@ enum PixelFormat CDVDVideoCodecFFmpeg::GetFormat( struct AVCodecContext * avctx
 #endif
     cur++;
   }
+
+  // hardware decoder de-selected, restore standard ffmpeg
+  if (ctx->GetHardware())
+  {
+    ctx->SetHardware(NULL);
+    avctx->get_buffer2     = avcodec_default_get_buffer2;
+    avctx->slice_flags     = 0;
+    avctx->hwaccel_context = 0;
+  }
+
   return avcodec_default_get_format(avctx, fmt);
 }
 

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDA.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDA.cpp
@@ -70,10 +70,15 @@ static void vda_decoder_callback (void *vda_hw_ctx,
 {
   struct vda_context *vda_ctx = (struct vda_context *)vda_hw_ctx;
 
+  vda_ctx->cv_buffer = NULL;
+
   if (!image_buffer)
     return;
 
   if (vda_ctx->cv_pix_fmt_type != CVPixelBufferGetPixelFormatType(image_buffer))
+    return;
+
+  if (infoFlags & kVDADecodeInfo_FrameDropped)
     return;
 
   vda_ctx->cv_buffer = CVPixelBufferRetain(image_buffer);

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDA.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDA.cpp
@@ -36,7 +36,7 @@ static int GetBufferS(AVCodecContext *avctx, AVFrame *pic, int flags)
 {  return ((CDecoder*)((CDVDVideoCodecFFmpeg*)avctx->opaque)->GetHardware())->GetBuffer(avctx, pic, flags); }
 
 CDecoder::CDecoder()
-: m_renderbuffers_count(0)
+: m_renderbuffers_count(3)
 {
   m_ctx = (vda_context*)calloc(1, sizeof(vda_context));
 }

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDA.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDA.cpp
@@ -32,10 +32,6 @@ extern "C" {
 using namespace std;
 using namespace VDA;
 
-
-static void RelBufferS(void *opaque, uint8_t *data)
-{ ((CDecoder*)((CDVDVideoCodecFFmpeg*)opaque)->GetHardware())->RelBuffer(data); }
-
 static int GetBufferS(AVCodecContext *avctx, AVFrame *pic, int flags)
 {  return ((CDecoder*)((CDVDVideoCodecFFmpeg*)avctx->opaque)->GetHardware())->GetBuffer(avctx, pic, flags); }
 
@@ -51,18 +47,11 @@ CDecoder::~CDecoder()
   free(m_ctx);
 }
 
-void CDecoder::RelBuffer(uint8_t *data)
-{
-  CVPixelBufferRef cv_buffer = (CVPixelBufferRef)data;
-  CVPixelBufferRelease(cv_buffer);
-}
-
 int CDecoder::GetBuffer(AVCodecContext *avctx, AVFrame *pic, int flags)
 {
-  pic->data[3] = (uint8_t *)(uintptr_t)1;
-  pic->reordered_opaque = avctx->reordered_opaque;
+  pic->data[0] = (uint8_t *)(uintptr_t)1;
 
-  AVBufferRef *buffer = av_buffer_create(pic->data[3], 0, RelBufferS, avctx->opaque, 0);
+  AVBufferRef *buffer = av_buffer_create(NULL, 0, NULL, avctx->opaque, 0);
   if (!buffer)
   {
     CLog::Log(LOGERROR, "VAAPI::%s - error creating buffer", __FUNCTION__);
@@ -234,6 +223,7 @@ bool CDecoder::Open(AVCodecContext *avctx, enum PixelFormat fmt, unsigned int su
   m_ctx->format = 'avc1';
   m_ctx->use_sync_decoding = 1;
   m_ctx->cv_pix_fmt_type = kCVPixelFormatType_422YpCbCr8;
+  m_ctx->use_ref_buffer = 1;
 
   if (!Create(avctx))
     return false;

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDA.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDA.cpp
@@ -38,50 +38,13 @@ static int GetBufferS(AVCodecContext *avctx, AVFrame *pic, int flags)
 CDecoder::CDecoder()
 : m_renderbuffers_count(3)
 {
-  m_ctx = (vda_context*)calloc(1, sizeof(vda_context));
+  m_ctx = av_vda_alloc_context();
 }
 
 CDecoder::~CDecoder()
 {
   Close();
-  free(m_ctx);
-}
-
-int CDecoder::GetBuffer(AVCodecContext *avctx, AVFrame *pic, int flags)
-{
-  pic->data[0] = (uint8_t *)(uintptr_t)1;
-
-  AVBufferRef *buffer = av_buffer_create(NULL, 0, NULL, avctx->opaque, 0);
-  if (!buffer)
-  {
-    CLog::Log(LOGERROR, "VAAPI::%s - error creating buffer", __FUNCTION__);
-    return -1;
-  }
-  pic->buf[0] = buffer;
-
-  return 0;
-}
-
-static void vda_decoder_callback (void *vda_hw_ctx,
-                                  CFDictionaryRef user_info,
-                                  OSStatus status,
-                                  uint32_t infoFlags,
-                                  CVImageBufferRef image_buffer)
-{
-  struct vda_context *vda_ctx = (struct vda_context *)vda_hw_ctx;
-
-  vda_ctx->cv_buffer = NULL;
-
-  if (!image_buffer)
-    return;
-
-  if (vda_ctx->cv_pix_fmt_type != CVPixelBufferGetPixelFormatType(image_buffer))
-    return;
-
-  if (infoFlags & kVDADecodeInfo_FrameDropped)
-    return;
-
-  vda_ctx->cv_buffer = CVPixelBufferRetain(image_buffer);
+  av_free(m_ctx);
 }
 
 bool CDecoder::Create(AVCodecContext *avctx)
@@ -95,9 +58,7 @@ bool CDecoder::Create(AVCodecContext *avctx)
   CFMutableDictionaryRef buffer_attributes;
   CFMutableDictionaryRef io_surface_properties;
   CFNumberRef cv_pix_fmt;
-
-  m_ctx->priv_bitstream = NULL;
-  m_ctx->priv_allocated_size = 0;
+  int32_t fmt = 'avc1', pix_fmt = kCVPixelFormatType_422YpCbCr8;
 
   /* Each VCL NAL in the bitstream sent to the decoder
    * is preceded by a 4 bytes length header.
@@ -124,9 +85,9 @@ bool CDecoder::Create(AVCodecContext *avctx)
                                           &kCFTypeDictionaryKeyCallBacks,
                                           &kCFTypeDictionaryValueCallBacks);
 
-  height   = CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt32Type, &m_ctx->height);
-  width    = CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt32Type, &m_ctx->width);
-  format   = CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt32Type, &m_ctx->format);
+  height   = CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt32Type, &avctx->height);
+  width    = CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt32Type, &avctx->width);
+  format   = CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt32Type, &fmt);
 
   CFDictionarySetValue(config_info, kVDADecoderConfiguration_Height      , height);
   CFDictionarySetValue(config_info, kVDADecoderConfiguration_Width       , width);
@@ -143,7 +104,7 @@ bool CDecoder::Create(AVCodecContext *avctx)
                                                     &kCFTypeDictionaryValueCallBacks);
   cv_pix_fmt  = CFNumberCreate(kCFAllocatorDefault,
                                kCFNumberSInt32Type,
-                               &m_ctx->cv_pix_fmt_type);
+                               &pix_fmt);
   CFDictionarySetValue(buffer_attributes,
                        kCVPixelBufferPixelFormatTypeKey,
                        cv_pix_fmt);
@@ -153,8 +114,8 @@ bool CDecoder::Create(AVCodecContext *avctx)
 
   status = VDADecoderCreate(config_info,
                             buffer_attributes,
-                            (VDADecoderOutputCallback*)vda_decoder_callback,
-                            m_ctx,
+                            (VDADecoderOutputCallback*)m_ctx->output_callback,
+                            avctx,
                             &m_ctx->decoder);
 
   CFRelease(height);
@@ -181,14 +142,13 @@ void CDecoder::Close()
   if (m_ctx->decoder)
     status = VDADecoderDestroy(m_ctx->decoder);
   m_ctx->decoder = NULL;
-  av_freep(&m_ctx->priv_bitstream);
 }
 
 bool CDecoder::Open(AVCodecContext *avctx, enum PixelFormat fmt, unsigned int surfaces)
 {
   Close();
 
-  if(fmt != AV_PIX_FMT_VDA_VLD)
+  if(fmt != AV_PIX_FMT_VDA)
     return false;
 
   if(avctx->codec_id != AV_CODEC_ID_H264)
@@ -221,21 +181,11 @@ bool CDecoder::Open(AVCodecContext *avctx, enum PixelFormat fmt, unsigned int su
     return false;
   }
 
-  /* init vda */
-  memset(m_ctx, 0, sizeof(struct vda_context));
-  m_ctx->width  = avctx->width;
-  m_ctx->height = avctx->height;
-  m_ctx->format = 'avc1';
-  m_ctx->use_sync_decoding = 1;
-  m_ctx->cv_pix_fmt_type = kCVPixelFormatType_422YpCbCr8;
-  m_ctx->use_ref_buffer = 1;
-
   if (!Create(avctx))
     return false;
 
   avctx->pix_fmt         = fmt;
   avctx->hwaccel_context = m_ctx;
-  avctx->get_buffer2     = GetBufferS;
   return true;
 }
 

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDA.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDA.h
@@ -23,7 +23,7 @@
 
 #include "DVDVideoCodecFFmpeg.h"
 
-struct vda_context;
+struct AVVDAContext;
 
 namespace VDA {
 
@@ -47,7 +47,7 @@ public:
 protected:
   bool                   Create(AVCodecContext* avctx);
   unsigned               m_renderbuffers_count;
-  vda_context*           m_ctx;
+  struct AVVDAContext*   m_ctx;
 };
 
 }

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -159,6 +159,7 @@ void CAdvancedSettings::Initialize()
   m_videoCaptureUseOcclusionQuery = -1; //-1 is auto detect
   m_videoVDPAUtelecine = false;
   m_videoVDPAUdeintSkipChromaHD = false;
+  m_useFfmpegVda = false;
   m_DXVACheckCompatibility = false;
   m_DXVACheckCompatibilityPresent = false;
   m_DXVAForceProcessorRenderer = true;
@@ -590,6 +591,7 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
     XMLUtils::GetInt(pElement, "useocclusionquery", m_videoCaptureUseOcclusionQuery, -1, 1);
     XMLUtils::GetBoolean(pElement,"vdpauInvTelecine",m_videoVDPAUtelecine);
     XMLUtils::GetBoolean(pElement,"vdpauHDdeintSkipChroma",m_videoVDPAUdeintSkipChromaHD);
+    XMLUtils::GetBoolean(pElement,"useffmpegvda", m_useFfmpegVda);
 
     TiXmlElement* pStagefrightElem = pElement->FirstChildElement("stagefright");
     if (pStagefrightElem)

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -177,6 +177,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     int m_videoIgnoreSecondsAtStart;
     float m_videoIgnorePercentAtEnd;
     bool m_audioApplyDrc;
+    bool m_useFfmpegVda;
 
     int   m_videoVDPAUScaling;
     float m_videoNonLinStretchRatio;


### PR DESCRIPTION
Some VDA changes to bring the CVREF usage inline with the normal types of rendering. It avoids usage of the special apple YUV formats that seem bug prone + adds support for limited color range + brightness contrast when rendering using cvref rendering.

I suspect some of these changes should be brought over to the GLES side.
