### PR TITLE
osx: fixed detect of latest sdk after yosemite

### DIFF
--- a/tools/depends/configure.in
+++ b/tools/depends/configure.in
@@ -190,7 +190,7 @@ case $host in
     esac
     case $host in
       *86*-apple-darwin)
-        found_sdk_version=[`$use_xcodebuild -showsdks | grep macosx | sort |  tail -n 1 | grep -oE 'macosx[0-9.0-9]+' | cut -c 7-$NF`]
+        found_sdk_version=[`$use_xcodebuild -showsdks | sed -E -n 's/.*macosx([0-9]+)\.([0-9]+)/\1.\2/p' | sort  -n -t. -k1,1 -k2,2 | tail -n 1`]
         case $use_xcode in
           5.* | 5.*.* )
             use_toolchain="${use_xcodepath}/Toolchains/XcodeDefault.xctoolchain"


### PR DESCRIPTION
This fixes detection of latest OSX sdk for depends when both: 10.9 and 10.10 are installed. Old sorting would prefer 10.9 over 10.10 due to text based sort. This now extracts the version numbers, and sorts by two separate columns in numeric fashion.
