### PR TITLE
Double file cache fix. Fixes ticket #15500

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -2819,10 +2819,10 @@ void CDVDPlayer::GetGeneralInfo(std::string& strGeneralInfo)
       if(m_StateInput.cache_bytes >= 0)
       {
         strBuf += StringUtils::Format(" cache:%s %2.0f%%"
-                                      , StringUtils::SizeToString(m_State.cache_bytes).c_str()
-                                      , m_State.cache_level * 100);
+                                      , StringUtils::SizeToString(m_StateInput.cache_bytes).c_str()
+                                      , m_StateInput.cache_level * 100);
         if(m_playSpeed == 0 || m_caching == CACHESTATE_FULL)
-          strBuf += StringUtils::Format(" %d sec", DVD_TIME_TO_SEC(m_State.cache_delay));
+          strBuf += StringUtils::Format(" %d sec", DVD_TIME_TO_SEC(m_StateInput.cache_delay));
       }
 
       strGeneralInfo = StringUtils::Format("C( ad:% 6.3f, a/v:% 6.3f%s, dcpu:%2i%% acpu:%2i%% vcpu:%2i%%%s af:%d%% vf:%d%% amp:% 5.2f )"
@@ -2855,10 +2855,10 @@ void CDVDPlayer::GetGeneralInfo(std::string& strGeneralInfo)
       if(m_StateInput.cache_bytes >= 0)
       {
         strBuf += StringUtils::Format(" cache:%s %2.0f%%"
-                                      , StringUtils::SizeToString(m_State.cache_bytes).c_str()
-                                      , m_State.cache_level * 100);
+                                      , StringUtils::SizeToString(m_StateInput.cache_bytes).c_str()
+                                      , m_StateInput.cache_level * 100);
         if(m_playSpeed == 0 || m_caching == CACHESTATE_FULL)
-          strBuf += StringUtils::Format(" %d sec", DVD_TIME_TO_SEC(m_State.cache_delay));
+          strBuf += StringUtils::Format(" %d sec", DVD_TIME_TO_SEC(m_StateInput.cache_delay));
       }
 
       strGeneralInfo = StringUtils::Format("C( ad:% 6.3f, a/v:% 6.3f%s, dcpu:%2i%% acpu:%2i%% vcpu:%2i%%%s )"

--- a/xbmc/filesystem/CacheStrategy.cpp
+++ b/xbmc/filesystem/CacheStrategy.cpp
@@ -272,25 +272,25 @@ CCacheStrategy *CSimpleFileCache::CreateNew()
 }
 
 
-CSimpleDoubleCache::CSimpleDoubleCache(CCacheStrategy *impl)
+CDoubleCache::CDoubleCache(CCacheStrategy *impl)
 {
   assert(NULL != impl);
   m_pCache = impl;
   m_pCacheOld = NULL;
 }
 
-CSimpleDoubleCache::~CSimpleDoubleCache()
+CDoubleCache::~CDoubleCache()
 {
   delete m_pCache;
   delete m_pCacheOld;
 }
 
-int CSimpleDoubleCache::Open()
+int CDoubleCache::Open()
 {
   return m_pCache->Open();
 }
 
-void CSimpleDoubleCache::Close()
+void CDoubleCache::Close()
 {
   m_pCache->Close();
   if (m_pCacheOld)
@@ -300,27 +300,27 @@ void CSimpleDoubleCache::Close()
   }
 }
 
-int CSimpleDoubleCache::WriteToCache(const char *pBuffer, size_t iSize)
+int CDoubleCache::WriteToCache(const char *pBuffer, size_t iSize)
 {
   return m_pCache->WriteToCache(pBuffer, iSize);
 }
 
-int CSimpleDoubleCache::ReadFromCache(char *pBuffer, size_t iMaxSize)
+int CDoubleCache::ReadFromCache(char *pBuffer, size_t iMaxSize)
 {
   return m_pCache->ReadFromCache(pBuffer, iMaxSize);
 }
 
-int64_t CSimpleDoubleCache::WaitForData(unsigned int iMinAvail, unsigned int iMillis)
+int64_t CDoubleCache::WaitForData(unsigned int iMinAvail, unsigned int iMillis)
 {
   return m_pCache->WaitForData(iMinAvail, iMillis);
 }
 
-int64_t CSimpleDoubleCache::Seek(int64_t iFilePosition)
+int64_t CDoubleCache::Seek(int64_t iFilePosition)
 {
   return m_pCache->Seek(iFilePosition);
 }
 
-void CSimpleDoubleCache::Reset(int64_t iSourcePosition, bool clearAnyway)
+void CDoubleCache::Reset(int64_t iSourcePosition, bool clearAnyway)
 {
   if (!clearAnyway && m_pCache->IsCachedPosition(iSourcePosition)
       && (!m_pCacheOld || !m_pCacheOld->IsCachedPosition(iSourcePosition)
@@ -349,27 +349,27 @@ void CSimpleDoubleCache::Reset(int64_t iSourcePosition, bool clearAnyway)
   m_pCache = tmp;
 }
 
-void CSimpleDoubleCache::EndOfInput()
+void CDoubleCache::EndOfInput()
 {
   m_pCache->EndOfInput();
 }
 
-bool CSimpleDoubleCache::IsEndOfInput()
+bool CDoubleCache::IsEndOfInput()
 {
   return m_pCache->IsEndOfInput();
 }
 
-void CSimpleDoubleCache::ClearEndOfInput()
+void CDoubleCache::ClearEndOfInput()
 {
   m_pCache->ClearEndOfInput();
 }
 
-int64_t CSimpleDoubleCache::CachedDataEndPos()
+int64_t CDoubleCache::CachedDataEndPos()
 {
   return m_pCache->CachedDataEndPos();
 }
 
-int64_t CSimpleDoubleCache::CachedDataEndPosIfSeekTo(int64_t iFilePosition)
+int64_t CDoubleCache::CachedDataEndPosIfSeekTo(int64_t iFilePosition)
 {
   int64_t ret = m_pCache->CachedDataEndPosIfSeekTo(iFilePosition);
   if (m_pCacheOld)
@@ -377,13 +377,13 @@ int64_t CSimpleDoubleCache::CachedDataEndPosIfSeekTo(int64_t iFilePosition)
   return ret;
 }
 
-bool CSimpleDoubleCache::IsCachedPosition(int64_t iFilePosition)
+bool CDoubleCache::IsCachedPosition(int64_t iFilePosition)
 {
   return m_pCache->IsCachedPosition(iFilePosition) || (m_pCacheOld && m_pCacheOld->IsCachedPosition(iFilePosition));
 }
 
-CCacheStrategy *CSimpleDoubleCache::CreateNew()
+CCacheStrategy *CDoubleCache::CreateNew()
 {
-  return new CSimpleDoubleCache(m_pCache->CreateNew());
+  return new CDoubleCache(m_pCache->CreateNew());
 }
 

--- a/xbmc/filesystem/CacheStrategy.cpp
+++ b/xbmc/filesystem/CacheStrategy.cpp
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2005-2013 Team XBMC
+ *      Copyright (C) 2005-2014 Team XBMC
  *      http://xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify
@@ -124,6 +124,11 @@ void CSimpleFileCache::Close()
     CLog::LogF(LOGWARNING, "failed to delete temporary file \"%s\"", m_filename.c_str());
 
   m_filename.clear();
+}
+
+size_t CSimpleFileCache::GetMaxWriteSize(const size_t& iRequestSize)
+{
+  return iRequestSize; // Can always write since it's on disk
 }
 
 int CSimpleFileCache::WriteToCache(const char *pBuffer, size_t iSize)
@@ -298,6 +303,11 @@ void CDoubleCache::Close()
     delete m_pCacheOld;
     m_pCacheOld = NULL;
   }
+}
+
+size_t CDoubleCache::GetMaxWriteSize(const size_t& iRequestSize)
+{
+  return m_pCache->GetMaxWriteSize(iRequestSize); // NOTE: Check the active cache only
 }
 
 int CDoubleCache::WriteToCache(const char *pBuffer, size_t iSize)

--- a/xbmc/filesystem/CacheStrategy.h
+++ b/xbmc/filesystem/CacheStrategy.h
@@ -102,10 +102,10 @@ protected:
   volatile int64_t m_nReadPosition;
 };
 
-class CSimpleDoubleCache : public CCacheStrategy{
+class CDoubleCache : public CCacheStrategy{
 public:
-  CSimpleDoubleCache(CCacheStrategy *impl);
-  virtual ~CSimpleDoubleCache();
+  CDoubleCache(CCacheStrategy *impl);
+  virtual ~CDoubleCache();
 
   virtual int Open() ;
   virtual void Close() ;

--- a/xbmc/filesystem/CacheStrategy.h
+++ b/xbmc/filesystem/CacheStrategy.h
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2005-2013 Team XBMC
+ *      Copyright (C) 2005-2014 Team XBMC
  *      http://xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify
@@ -44,6 +44,7 @@ public:
   virtual int Open() = 0;
   virtual void Close() = 0;
 
+  virtual size_t GetMaxWriteSize(const size_t& iRequestSize) = 0;
   virtual int WriteToCache(const char *pBuffer, size_t iSize) = 0;
   virtual int ReadFromCache(char *pBuffer, size_t iMaxSize) = 0;
   virtual int64_t WaitForData(unsigned int iMinAvail, unsigned int iMillis) = 0;
@@ -76,6 +77,7 @@ public:
   virtual int Open() ;
   virtual void Close() ;
 
+  virtual size_t GetMaxWriteSize(const size_t& iRequestSize) ;
   virtual int WriteToCache(const char *pBuffer, size_t iSize) ;
   virtual int ReadFromCache(char *pBuffer, size_t iMaxSize) ;
   virtual int64_t WaitForData(unsigned int iMinAvail, unsigned int iMillis) ;
@@ -110,6 +112,7 @@ public:
   virtual int Open() ;
   virtual void Close() ;
 
+  virtual size_t GetMaxWriteSize(const size_t& iRequestSize) ;
   virtual int WriteToCache(const char *pBuffer, size_t iSize) ;
   virtual int ReadFromCache(char *pBuffer, size_t iMaxSize) ;
   virtual int64_t WaitForData(unsigned int iMinAvail, unsigned int iMillis) ;

--- a/xbmc/filesystem/CircularCache.cpp
+++ b/xbmc/filesystem/CircularCache.cpp
@@ -182,7 +182,7 @@ int CCircularCache::ReadFromCache(char *buf, size_t len)
  * Note that caller needs to make sure there's sufficient space in the forward
  * buffer for "minimum" bytes else we may block the full timeout time
  */
-int64_t CCircularCache::WaitForData(unsigned int minumum, unsigned int millis)
+int64_t CCircularCache::WaitForData(unsigned int minimum, unsigned int millis)
 {
   CSingleLock lock(m_sync);
   int64_t avail = m_end - m_cur;
@@ -190,11 +190,11 @@ int64_t CCircularCache::WaitForData(unsigned int minumum, unsigned int millis)
   if(millis == 0 || IsEndOfInput())
     return avail;
 
-  if(minumum > m_size - m_size_back)
-    minumum = m_size - m_size_back;
+  if(minimum > m_size - m_size_back)
+    minimum = m_size - m_size_back;
 
   XbmcThreads::EndTime endtime(millis);
-  while (!IsEndOfInput() && avail < minumum && !endtime.IsTimePast() )
+  while (!IsEndOfInput() && avail < minimum && !endtime.IsTimePast() )
   {
     lock.Leave();
     m_written.WaitMSec(50); // may miss the deadline. shouldn't be a problem.

--- a/xbmc/filesystem/CircularCache.cpp
+++ b/xbmc/filesystem/CircularCache.cpp
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2005-2013 Team XBMC
+ *      Copyright (C) 2005-2014 Team XBMC
  *      http://xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify
@@ -74,6 +74,18 @@ void CCircularCache::Close()
   delete[] m_buf;
 #endif
   m_buf = NULL;
+}
+
+size_t CCircularCache::GetMaxWriteSize(const size_t& iRequestSize)
+{
+  CSingleLock lock(m_sync);
+
+  size_t back  = (size_t)(m_cur - m_beg); // Backbuffer size
+  size_t front = (size_t)(m_end - m_cur); // Frontbuffer size
+  size_t limit = m_size - std::min(back, m_size_back) - front;
+
+  // Never return more than limit and size requested by caller
+  return std::min(iRequestSize, limit);
 }
 
 /**

--- a/xbmc/filesystem/CircularCache.h
+++ b/xbmc/filesystem/CircularCache.h
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2005-2013 Team XBMC
+ *      Copyright (C) 2005-2014 Team XBMC
  *      http://xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify
@@ -36,6 +36,7 @@ public:
     virtual int Open() ;
     virtual void Close();
 
+    virtual size_t GetMaxWriteSize(const size_t& iRequestSize) ;
     virtual int WriteToCache(const char *buf, size_t len) ;
     virtual int ReadFromCache(char *buf, size_t len) ;
     virtual int64_t WaitForData(unsigned int minimum, unsigned int iMillis) ;

--- a/xbmc/filesystem/FileCache.cpp
+++ b/xbmc/filesystem/FileCache.cpp
@@ -100,7 +100,7 @@ CFileCache::CFileCache(bool useDoubleCache) : CThread("FileCache")
    }
    if (useDoubleCache)
    {
-     m_pCache = new CSimpleDoubleCache(m_pCache);
+     m_pCache = new CDoubleCache(m_pCache);
    }
    m_seekPossible = 0;
    m_cacheFull = false;

--- a/xbmc/filesystem/FileCache.cpp
+++ b/xbmc/filesystem/FileCache.cpp
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2005-2013 Team XBMC
+ *      Copyright (C) 2005-2014 Team XBMC
  *      http://xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify
@@ -219,7 +219,7 @@ void CFileCache::Process()
     {
       m_seekEvent.Reset();
       int64_t cacheMaxPos = m_pCache->CachedDataEndPosIfSeekTo(m_seekPos);
-      cacheReachEOF = cacheMaxPos == m_source.GetLength();
+      cacheReachEOF = (cacheMaxPos == m_source.GetLength());
       bool sourceSeekFailed = false;
       if (!cacheReachEOF)
       {
@@ -239,7 +239,7 @@ void CFileCache::Process()
         assert(m_writePos == cacheMaxPos);
         average.Reset(m_writePos);
         limiter.Reset(m_writePos);
-        m_cacheFull = false;
+        m_cacheFull = (m_pCache->GetMaxWriteSize(m_chunkSize) == 0);
         m_nSeekResult = m_seekPos;
       }
 
@@ -263,6 +263,9 @@ void CFileCache::Process()
         break;
       }
     }
+
+    size_t maxWrite = m_pCache->GetMaxWriteSize(m_chunkSize);
+    m_cacheFull = (maxWrite == 0);
 
     ssize_t iRead = 0;
     if (!cacheReachEOF)
@@ -300,13 +303,10 @@ void CFileCache::Process()
       }
       else if (iWrite == 0)
       {
-        m_cacheFull = true;
         average.Pause();
         m_pCache->m_space.WaitMSec(5);
         average.Resume();
       }
-      else
-        m_cacheFull = false;
 
       iTotalWrite += iWrite;
 

--- a/xbmc/filesystem/MemBufferCache.cpp
+++ b/xbmc/filesystem/MemBufferCache.cpp
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2005-2013 Team XBMC
+ *      Copyright (C) 2005-2014 Team XBMC
  *      http://xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify
@@ -65,6 +65,15 @@ void MemBufferCache::Close()
   m_buffer.Clear();
   m_HistoryBuffer.Clear();
   m_forwardBuffer.Clear();
+}
+
+size_t MemBufferCache::GetMaxWriteSize(const size_t& iRequestSize)
+{
+  CSingleLock lock(m_sync);
+
+  // must also check the forward buffer.
+  // if we have leftovers from the previous seek - we need not read anymore until they are utilized
+  return (m_forwardBuffer.getMaxReadSize() == 0 && iRequestSize <= m_buffer.getMaxWriteSize()) ? iRequestSize : 0; 
 }
 
 int MemBufferCache::WriteToCache(const char *pBuffer, size_t iSize)

--- a/xbmc/filesystem/MemBufferCache.h
+++ b/xbmc/filesystem/MemBufferCache.h
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2005-2013 Team XBMC
+ *      Copyright (C) 2005-2014 Team XBMC
  *      http://xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify
@@ -40,6 +40,7 @@ public:
     virtual int Open() ;
     virtual void Close();
 
+    virtual size_t GetMaxWriteSize(const size_t& iRequestSize) ;
     virtual int WriteToCache(const char *pBuffer, size_t iSize) ;
     virtual int ReadFromCache(char *pBuffer, size_t iMaxSize) ;
     virtual int64_t WaitForData(unsigned int iMinAvail, unsigned int iMillis) ;


### PR DESCRIPTION
Double caching for e.g. dvdplayer has been broken for a long time. The actual problem for double cache was that when the cache was full, we still kept reading from the source which get disposed due to seek-requests which in turn also caused seek backs in the stream (which are really slow on e.g. http). This revealed itself while playing mp4 files with high a/v offset but generally this should improve performance (especially on slow systems) for all cached files. Furthmore we would block in WaitForData() when seeking just "over" the cache while it was full.

Would be great if this could be included for Helix.
