### PR TITLE
[AML codec] use codec id if unknow codec tag

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/AMLCodec.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/AMLCodec.cpp
@@ -1530,7 +1530,11 @@ bool CAMLCodec::OpenDecoder(CDVDStreamInfo &hints)
   }
 
   if (am_private->stream_type == AM_STREAM_ES && am_private->video_codec_tag != 0)
+  {
     am_private->video_codec_type = codec_tag_to_vdec_type(am_private->video_codec_tag);
+    if(am_private->video_codec_type == VIDEO_DEC_FORMAT_UNKNOW)
+      am_private->video_codec_type = codec_tag_to_vdec_type(am_private->video_codec_id);
+  }
   else
     am_private->video_codec_type = codec_tag_to_vdec_type(am_private->video_codec_id);
 


### PR DESCRIPTION
Some files can not check codec_type from codec_tag so use codec_id
