### PR TITLE
show correct dialog header text for master lock code. fixes #15543

### DIFF
--- a/xbmc/GUIPassword.cpp
+++ b/xbmc/GUIPassword.cpp
@@ -143,8 +143,8 @@ bool CGUIPassword::CheckStartUpLock()
         int iLeft = g_passwordManager.iMasterLockRetriesLeft-i;
         CStdString strLabel = StringUtils::Format("%i %s", iLeft, strLabel1.c_str());
 
-        // PopUp OK and Display: MasterLock mode has changed but no no Mastercode has been set!
-        CGUIDialogOK::ShowAndGetInput(20076, 12367, 12368, strLabel);
+        // PopUp OK and Display: MasterLock mode has changed but no new Mastercode has been set!
+        CGUIDialogOK::ShowAndGetInput(12360, 12367, 12368, strLabel);
       }
       else
         i=g_passwordManager.iMasterLockRetriesLeft;


### PR DESCRIPTION
old header: "Ask for master lock code on startup"
new header: "Master lock"

note:
is that comment that you see in the diff correct? because the dialog actually shows:

```
"Master code is not valid"
"Please enter a valid master code"
```
