### PR TITLE
DVDDemuxFFmpeg: Fix calculation when increasing buffer

### DIFF
--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -271,7 +271,7 @@ bool CDVDDemuxFFmpeg::Open(CDVDInputStream* pInput, bool streaminfo, bool filein
     unsigned char* buffer = (unsigned char*)av_malloc(FFMPEG_FILE_BUFFER_SIZE);
     m_ioContext = avio_alloc_context(buffer, FFMPEG_FILE_BUFFER_SIZE, 0, this, dvd_file_read, NULL, dvd_file_seek);
     m_ioContext->max_packet_size = m_pInput->GetBlockSize();
-    if(m_ioContext->max_packet_size)
+    if(m_ioContext->max_packet_size > 0 && m_ioContext->max_packet_size < FFMPEG_FILE_BUFFER_SIZE)
       m_ioContext->max_packet_size *= FFMPEG_FILE_BUFFER_SIZE / m_ioContext->max_packet_size;
 
     if(m_pInput->Seek(0, SEEK_POSSIBLE) == 0)


### PR DESCRIPTION
This was here since: https://github.com/xbmc/xbmc/commit/ee6dd202

@FernetMenta what do you think? @elupus: What was the idea behind this? Or rephrase: Why did this fix the homerun issue?

Problem here is, that this wants to workaround the case when FFMPEG_FILE_BUFFER_SIZE is smaller than max_packet_size, but if that is the case the division will result in plain 0 as both are integers. Therefore the max_packet_size is set to 0.

Thx @t-nelson for spotting.
