### PR TITLE
[pvr] go to parent folder after deleting the last item in a subfolder

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -606,47 +606,6 @@ bool CGUIWindowPVRBase::ActionDeleteChannel(CFileItem *item)
   return true;
 }
 
-bool CGUIWindowPVRBase::ActionDeleteRecording(CFileItem *item)
-{
-  bool bReturn = false;
-
-  if (!item->IsPVRRecording() && !item->m_bIsFolder)
-    return bReturn;
-
-  /* show a confirmation dialog */
-  CGUIDialogYesNo* pDialog = (CGUIDialogYesNo*)g_windowManager.GetWindow(WINDOW_DIALOG_YES_NO);
-  if (!pDialog)
-    return bReturn;
-
-  pDialog->SetHeading(122); // Confirm delete
-  pDialog->SetLine(0, item->m_bIsFolder ? 19113 : 19112); // Are you sure?
-  pDialog->SetLine(1, "");
-  pDialog->SetLine(2, item->GetLabel());
-  pDialog->SetChoice(1, 117); // Delete
-
-  /* prompt for the user's confirmation */
-  pDialog->DoModal();
-  if (!pDialog->IsConfirmed())
-    return bReturn;
-
-  /* delete the recording */
-  if (g_PVRRecordings->Delete(*item))
-  {
-    g_PVRManager.TriggerRecordingsUpdate();
-    bReturn = true;
-
-    /* remove the item from the list immediately, otherwise the
-    item count further down may be wrong */
-    m_vecItems->Remove(item);
-
-    /* go to the parent folder if we're in a subdirectory and just deleted the last item */
-    if (m_vecItems->GetPath() != "pvr://recordings/" && m_vecItems->GetObjectCount() == 0)
-      GoParentFolder();
-  }
-
-  return bReturn;
-}
-
 bool CGUIWindowPVRBase::ActionRecord(CFileItem *item)
 {
   bool bReturn = false;

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -634,6 +634,14 @@ bool CGUIWindowPVRBase::ActionDeleteRecording(CFileItem *item)
   {
     g_PVRManager.TriggerRecordingsUpdate();
     bReturn = true;
+
+    /* remove the item from the list immediately, otherwise the
+    item count further down may be wrong */
+    m_vecItems->Remove(item);
+
+    /* go to the parent folder if we're in a subdirectory and just deleted the last item */
+    if (m_vecItems->GetPath() != "pvr://recordings/" && m_vecItems->GetObjectCount() == 0)
+      GoParentFolder();
   }
 
   return bReturn;

--- a/xbmc/pvr/windows/GUIWindowPVRBase.h
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.h
@@ -79,7 +79,6 @@ namespace PVR
     virtual void SetGroup(CPVRChannelGroupPtr group);
 
     virtual bool ActionRecord(CFileItem *item);
-    virtual bool ActionDeleteRecording(CFileItem *item);
     virtual bool ActionPlayChannel(CFileItem *item);
     virtual bool ActionPlayEpg(CFileItem *item);
     virtual bool ActionDeleteChannel(CFileItem *item);

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.h
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.h
@@ -48,6 +48,7 @@ namespace PVR
     void OnPrepareFileItems(CFileItemList &items);
 
   private:
+    bool ActionDeleteRecording(CFileItem *item);
     bool OnContextButtonDelete(CFileItem *item, CONTEXT_BUTTON button);
     bool OnContextButtonInfo(CFileItem *item, CONTEXT_BUTTON button);
     bool OnContextButtonPlay(CFileItem *item, CONTEXT_BUTTON button);


### PR DESCRIPTION
Currently when the last recording is deleted you're left in an empty ghost directory that is gone once you go back to the parent folder. This changes that so that you can't end up in an empty folder.

I also changed the call to `TriggerRecordingsUpdate` to a simple `Refresh`. If the recording was reported as deleted by the backend there's no need to fetch the recordings again, something which can take time.

@xhaggi @opdenkamp for review
