### PR TITLE
[epg] rename GetCurrentTime() to avoid naming collision with Windows-specific macro

### DIFF
--- a/xbmc/epg/EpgInfoTag.cpp
+++ b/xbmc/epg/EpgInfoTag.cpp
@@ -264,7 +264,7 @@ bool CEpgInfoTag::Changed(void) const
   return m_bChanged;
 }
 
-CDateTime CEpgInfoTag::GetCurrentTime() const
+CDateTime CEpgInfoTag::GetCurrentPlayingTime() const
 {
   CDateTime now = CDateTime::GetUTCDateTime();
 
@@ -284,21 +284,21 @@ CDateTime CEpgInfoTag::GetCurrentTime() const
 
 bool CEpgInfoTag::IsActive(void) const
 {
-  CDateTime now = GetCurrentTime();
+  CDateTime now = GetCurrentPlayingTime();
   CSingleLock lock(m_critSection);
   return (m_startTime <= now && m_endTime > now);
 }
 
 bool CEpgInfoTag::WasActive(void) const
 {
-  CDateTime now = GetCurrentTime();
+  CDateTime now = GetCurrentPlayingTime();
   CSingleLock lock(m_critSection);
   return (m_endTime < now);
 }
 
 bool CEpgInfoTag::InTheFuture(void) const
 {
-  CDateTime now = GetCurrentTime();
+  CDateTime now = GetCurrentPlayingTime();
   CSingleLock lock(m_critSection);
   return (m_startTime > now);
 }

--- a/xbmc/epg/EpgInfoTag.h
+++ b/xbmc/epg/EpgInfoTag.h
@@ -473,7 +473,7 @@ namespace EPG
     /*!
      * @brief Get current time, taking timeshifting into account.
      */
-    CDateTime GetCurrentTime(void) const;
+    CDateTime GetCurrentPlayingTime(void) const;
 
     bool                     m_bNotify;            /*!< notify on start */
     bool                     m_bChanged;           /*!< keep track of changes to this entry */


### PR DESCRIPTION
@ksooo @FernetMenta you okay with this name?
