### PR TITLE
[darwin] - fix flicker in sysinfo - querying gateway via pipe needs a sleep

### DIFF
--- a/xbmc/network/linux/NetworkLinux.cpp
+++ b/xbmc/network/linux/NetworkLinux.cpp
@@ -202,6 +202,7 @@ std::string CNetworkInterfaceLinux::GetCurrentDefaultGateway(void)
 
 #if defined(TARGET_DARWIN)
   FILE* pipe = popen("echo \"show State:/Network/Global/IPv4\" | scutil | grep Router", "r");
+  Sleep(100);
   if (pipe)
   {
     std::string tmpStr;


### PR DESCRIPTION
This stops the flicker in the sysinfo dialog / gateway field. We need to sleep after popen (same like we do already in GetNameServers) because there is simply no indicator when the output of a command is available after popen (its async sort of).

cosmetic fix
