### PR TITLE
fix queuing of songs starting playback if something is already playing

### DIFF
--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -558,7 +558,7 @@ void CGUIWindowMusicBase::OnQueueItem(int iItem)
   }
 
   g_playlistPlayer.Add(PLAYLIST_MUSIC, queuedItems);
-  if (g_playlistPlayer.GetPlaylist(PLAYLIST_MUSIC).size() && !g_application.m_pPlayer->IsPlayingAudio())
+  if (g_playlistPlayer.GetPlaylist(PLAYLIST_MUSIC).size() && !g_application.m_pPlayer->IsPlaying())
   {
     if (m_guiState.get())
       m_guiState->SetPlaylistDirectory("playlistmusic://");


### PR DESCRIPTION
Thanks to @da-anda (see http://trac.xbmc.org/ticket/15545) I came across an odd logic when queuing a song for playback. When there is already active playback but it is not music the active playback will be stopped and the song being queued is automatically played. IMO this doesn't make sense as I might want to put together a music playlist while watching a video or music video. The other way around (i.e. queuing a video while listening to music) does not interrupt playback so we should certainly be consistent.

Furthermore this fixes the same issue when playing a song over UPnP on another device because in that case g_application.m_pPlayer->IsPlayingAudio() is always false because there's no audio playing inside Kodi.
