### PR TITLE
[pvr] add missing call to parent's OnPrepareFileItems()

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -364,4 +364,6 @@ void CGUIWindowPVRRecordings::OnPrepareFileItems(CFileItemList& items)
     }
     m_thumbLoader.Load(files);
   }
+
+  CGUIWindowPVRBase::OnPrepareFileItems(items);
 }


### PR DESCRIPTION
@xhaggi @opdenkamp I don't know if this fixes anything but it looks correct to me.
