### PR TITLE
[ResamplePi] Add support for formats that need shifting

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResamplePi.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResamplePi.h
@@ -47,6 +47,7 @@ protected:
   int m_src_channels, m_dst_channels;
   AVSampleFormat m_src_fmt, m_dst_fmt;
   int m_src_bits, m_dst_bits;
+  int m_src_pitch, m_dst_pitch;
   int m_src_dither_bits, m_dst_dither_bits;
 
   OMX_AUDIO_PARAM_PCMMODETYPE m_pcm_input;


### PR DESCRIPTION
This case is triggered by HiFiBerry's 24-bit format.
Requires updated firmware

Lots of reports around for this issue. E.g.
http://openelec.tv/forum/124-raspberry-pi/72837-hifiberry-dac-not-dac-stop-working
and reports of it being fixed:
http://forum.kodi.tv/showthread.php?tid=192380&pid=1836662#pid1836662

It basically implements this code block:
https://github.com/xbmc/xbmc/blob/master/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResampleFFMPEG.cpp#L202-250
on the GPU side.
