### PR TITLE
fix incorrect display of fps when dr kicks in

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2326,10 +2326,11 @@ void CApplication::Render()
     if (frameTime < singleFrameTime)
       Sleep(singleFrameTime - frameTime);
   }
-  m_lastFrameTime = XbmcThreads::SystemClockMillis();
 
   if (flip)
     g_graphicsContext.Flip(dirtyRegions);
+
+  m_lastFrameTime = XbmcThreads::SystemClockMillis();
   CTimeUtils::UpdateFrameTime(flip);
 
   g_renderManager.UpdateResolution();


### PR DESCRIPTION
not mission critical but a fix. (also rested in OE for 1.5 years)
we were tracking down some issue and wondered why fps could get this high when dirty region kicked in. the reason was that last frame time was taken before flipping where the thread blocks.
