### PR TITLE
[pvr] fix selecting last playing group 'All TV/Radio channels'

### DIFF
--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -59,7 +59,7 @@ bool CPVRChannelGroups::GetGroupsFromClients(void)
   return g_PVRClients->GetChannelGroups(this) == PVR_ERROR_NO_ERROR;
 }
 
-bool CPVRChannelGroups::Update(const CPVRChannelGroup &group, bool bSaveInDb /* = false */)
+bool CPVRChannelGroups::Update(const CPVRChannelGroup &group, bool bUpdateFromClient /* = false */)
 {
   if (group.GroupName().empty() && group.GroupID() <= 0)
     return true;
@@ -78,22 +78,23 @@ bool CPVRChannelGroups::Update(const CPVRChannelGroup &group, bool bSaveInDb /* 
     if (!updateGroup)
     {
       // create a new group if none was found
-      updateGroup = CPVRChannelGroupPtr(new CPVRChannelGroup(m_bRadio, group.GroupID(), group.GroupName()));
-      updateGroup->SetGroupType(group.GroupType());
-      updateGroup->SetLastWatched(group.LastWatched());
+      updateGroup = CPVRChannelGroupPtr(new CPVRChannelGroup());
       m_groups.push_back(updateGroup);
     }
-    else
+
+    updateGroup->SetGroupID(group.GroupID());
+    updateGroup->SetGroupName(group.GroupName());
+    updateGroup->SetGroupType(group.GroupType());
+
+    // don't override properties we only store locally in our PVR database
+    if (!bUpdateFromClient)
     {
-      // update existing group
-      updateGroup->SetGroupID(group.GroupID());
-      updateGroup->SetGroupName(group.GroupName());
-      updateGroup->SetGroupType(group.GroupType());
+      updateGroup->SetLastWatched(group.LastWatched());
     }
   }
 
   // persist changes
-  if (bSaveInDb && updateGroup)
+  if (bUpdateFromClient)
     return updateGroup->Persist();
 
   return true;

--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -59,7 +59,7 @@ bool CPVRChannelGroups::GetGroupsFromClients(void)
   return g_PVRClients->GetChannelGroups(this) == PVR_ERROR_NO_ERROR;
 }
 
-bool CPVRChannelGroups::Update(const CPVRChannelGroup &group, bool bSaveInDb)
+bool CPVRChannelGroups::Update(const CPVRChannelGroup &group, bool bSaveInDb /* = false */)
 {
   if (group.GroupName().empty() && group.GroupID() <= 0)
     return true;

--- a/xbmc/pvr/channels/PVRChannelGroups.h
+++ b/xbmc/pvr/channels/PVRChannelGroups.h
@@ -69,7 +69,7 @@ namespace PVR
      * @param group The group to add
      * @return True when updated, false otherwise
      */
-    bool UpdateFromClient(const CPVRChannelGroup &group) { return Update(group, false); }
+    bool UpdateFromClient(const CPVRChannelGroup &group) { return Update(group, true); }
 
     /*!
      * @brief Get a channel given it's path

--- a/xbmc/pvr/channels/PVRChannelGroups.h
+++ b/xbmc/pvr/channels/PVRChannelGroups.h
@@ -59,10 +59,10 @@ namespace PVR
     /*!
      * @brief Update a group or add it if it's not in here yet.
      * @param group The group to update.
-     * @param bSaveInDb True to save the changes in the db.
+     * @param bUpdateFromClient True to save the changes in the db.
      * @return True if the group was added or update successfully, false otherwise.
      */
-    bool Update(const CPVRChannelGroup &group, bool bSaveInDb = false);
+    bool Update(const CPVRChannelGroup &group, bool bUpdateFromClient = false);
 
     /*!
      * @brief Called by the add-on callback to add a new group


### PR DESCRIPTION
As the last watched property of the internal 'All TV/Radio channels' group never gets updated if we fetch it from the database it's impossible to select this group on startup as the last played group.

@FernetMenta  this fix the root cause of http://trac.xbmc.org/ticket/15397 where some users reported that the continue last playing channel option won't work. We attempted to fix it with #5526 but that fixed only the half of the issue. 

@opdenkamp or @Jalle19 for a quick look.
