### PR TITLE
[videoinfoscanner] fix video_ts folder not stacked on movie scan

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -677,7 +677,11 @@ bool CVideoDatabase::GetSubPaths(const CStdString &basepath, vector< pair<int,st
 
     CStdString path(basepath);
     URIUtils::AddSlashAtEnd(path);
-    sql = PrepareSQL("SELECT idPath,strPath FROM path WHERE SUBSTR(strPath,1,%i)='%s'", StringUtils::utf8_strlen(path.c_str()), path.c_str());
+    sql = PrepareSQL("SELECT idPath,strPath FROM path WHERE SUBSTR(strPath,1,%i)='%s'"
+                     " AND idPath NOT IN (SELECT idPath FROM files WHERE strFileName LIKE 'video_ts.ifo')"
+                     " AND idPath NOT IN (SELECT idPath FROM files WHERE strFileName LIKE 'index.bdmv')"
+                     , StringUtils::utf8_strlen(path.c_str()), path.c_str());
+
     m_pDS->query(sql.c_str());
     while (!m_pDS->eof())
     {

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -762,14 +762,16 @@ namespace VIDEO
     while (x < items.Size())
     {
       if (items[x]->m_bIsFolder)
+      {
+        x++;
         continue;
-
+      }
 
       CStdString strPathX, strFileX;
       URIUtils::Split(items[x]->GetPath(), strPathX, strFileX);
       //CLog::Log(LOGDEBUG,"%i:%s:%s", x, strPathX.c_str(), strFileX.c_str());
 
-      int y = x + 1;
+      const int y = x + 1;
       if (strFileX.Equals("VIDEO_TS.IFO"))
       {
         while (y < items.Size())
@@ -790,7 +792,7 @@ namespace VIDEO
             break;
         }
       }
-      x = y;
+      x++;
     }
 
     // enumerate


### PR DESCRIPTION
Fixes issue reported here: http://forum.kodi.tv/showthread.php?tid=208688

From what I can gather, dvd folders were never considered when scanning for movies. It just happened to work because of broken hashing. @mkortstiege ??

also fixes infinite loop (see comment below)
