### PR TITLE
video library: add the possibility to clean the database in the background

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -5643,6 +5643,20 @@ void CApplication::StartVideoScan(const CStdString &strDirectory, bool userIniti
   m_videoInfoScanner->Start(strDirectory,scanAll);
 }
 
+void CApplication::StartMusicCleanup(bool userInitiated /* = true */)
+{
+  if (m_musicInfoScanner->IsScanning())
+    return;
+
+  if (userInitiated)
+    m_musicInfoScanner->CleanDatabase(true);
+  else
+  {
+    m_musicInfoScanner->ShowDialog(false);
+    m_musicInfoScanner->StartCleanDatabase();
+  }
+}
+
 void CApplication::StartMusicScan(const CStdString &strDirectory, bool userInitiated /* = true */, int flags /* = 0 */)
 {
   if (m_musicInfoScanner->IsScanning())

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -5624,7 +5624,13 @@ void CApplication::StartVideoCleanup(bool userInitiated /* = true */)
   if (m_videoInfoScanner->IsScanning())
     return;
 
-  m_videoInfoScanner->CleanDatabase(NULL, NULL, userInitiated);
+  if (userInitiated)
+    m_videoInfoScanner->CleanDatabase(NULL, NULL, true);
+  else
+  {
+    m_videoInfoScanner->ShowDialog(false);
+    m_videoInfoScanner->StartCleanDatabase();
+  }
 }
 
 void CApplication::StartVideoScan(const CStdString &strDirectory, bool userInitiated /* = true */, bool scanAll /* = false */)

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -260,6 +260,12 @@ public:
   void StartVideoScan(const CStdString &path, bool userInitiated = true, bool scanAll = false);
 
   /*!
+  \brief Starts a music library cleanup.
+  \param userInitiated Whether the action was initiated by the user (either via GUI or any other method) or not.  It is meant to hide or show dialogs.
+  */
+  void StartMusicCleanup(bool userInitiated = true);
+
+  /*!
    \brief Starts a music library update.
    \param path The path to scan or "" (empty string) for a global scan.
    \param userInitiated Whether the action was initiated by the user (either via GUI or any other method) or not.  It is meant to hide or show dialogs.

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -1470,13 +1470,7 @@ int CBuiltins::Execute(const std::string& execString)
     else if (StringUtils::EqualsNoCase(params[0], "music"))
     {
       if (!g_application.IsMusicScanning())
-      {
-        CMusicDatabase musicdatabase;
-
-        musicdatabase.Open();
-        musicdatabase.Cleanup(userInitiated);
-        musicdatabase.Close();
-      }
+        g_application.StartMusicCleanup(userInitiated);
       else
         CLog::Log(LOGERROR, "CleanLibrary is not possible while scanning for media info");
     }

--- a/xbmc/music/infoscanner/MusicInfoScanner.h
+++ b/xbmc/music/infoscanner/MusicInfoScanner.h
@@ -55,10 +55,13 @@ public:
   virtual ~CMusicInfoScanner();
 
   void Start(const CStdString& strDirectory, int flags);
+  void StartCleanDatabase();
   void FetchAlbumInfo(const CStdString& strDirectory, bool refresh=false);
   void FetchArtistInfo(const CStdString& strDirectory, bool refresh=false);
   bool IsScanning();
   void Stop();
+
+  void CleanDatabase(bool showProgress = true);
 
   //! \brief Set whether or not to show a progress dialog
   void ShowDialog(bool show) { m_showDialog = show; }

--- a/xbmc/settings/MediaSettings.cpp
+++ b/xbmc/settings/MediaSettings.cpp
@@ -314,9 +314,8 @@ void CMediaSettings::OnSettingAction(const CSetting *setting)
   }
   else if (settingId == "musiclibrary.cleanup")
   {
-    CMusicDatabase musicdatabase;
-    musicdatabase.Clean();
-    CUtil::DeleteMusicDatabaseDirectoryCache();
+    if (CGUIDialogYesNo::ShowAndGetInput(313, 333, 0, 0))
+      g_application.StartMusicCleanup(true);
   }
   else if (settingId == "musiclibrary.export")
     CBuiltins::Execute("exportlibrary(music)");

--- a/xbmc/settings/MediaSettings.cpp
+++ b/xbmc/settings/MediaSettings.cpp
@@ -336,7 +336,7 @@ void CMediaSettings::OnSettingAction(const CSetting *setting)
   else if (settingId == "videolibrary.cleanup")
   {
     if (CGUIDialogYesNo::ShowAndGetInput(313, 333, 0, 0))
-      g_application.StartVideoCleanup();
+      g_application.StartVideoCleanup(true);
   }
   else if (settingId == "videolibrary.export")
     CBuiltins::Execute("exportlibrary(video)");

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -78,10 +78,6 @@ namespace VIDEO
   {
     try
     {
-      unsigned int tick = XbmcThreads::SystemClockMillis();
-
-      m_database.Open();
-
       if (m_showDialog && !CSettings::Get().GetBool("videolibrary.backgroundupdate"))
       {
         CGUIDialogExtendedProgressBar* dialog =
@@ -89,6 +85,24 @@ namespace VIDEO
         if (dialog)
            m_handle = dialog->GetHandle(g_localizeStrings.Get(314));
       }
+
+      // check if we only need to perform a cleaning
+      if (m_bClean && m_pathsToScan.empty())
+      {
+        CleanDatabase(m_handle, NULL, false);
+
+        if (m_handle)
+          m_handle->MarkFinished();
+        m_handle = NULL;
+
+        m_bRunning = false;
+
+        return;
+      }
+
+      unsigned int tick = XbmcThreads::SystemClockMillis();
+
+      m_database.Open();
 
       m_bCanInterrupt = true;
 
@@ -187,6 +201,20 @@ namespace VIDEO
     }
     m_database.Close();
     m_bClean = g_advancedSettings.m_bVideoLibraryCleanOnUpdate;
+
+    StopThread();
+    Create();
+    m_bRunning = true;
+  }
+
+  void CVideoInfoScanner::StartCleanDatabase()
+  {
+    m_strStartDir.clear();
+    m_scanAll = false;
+    m_pathsToScan.clear();
+    m_pathsToClean.clear();
+
+    m_bClean = true;
 
     StopThread();
     Create();

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -59,6 +59,7 @@ namespace VIDEO
      \param scanAll whether to scan everything not already scanned (regardless of whether the user normally doesn't want a folder scanned.) Defaults to false.
      */
     void Start(const CStdString& strDirectory, bool scanAll = false);
+    void StartCleanDatabase();
     bool IsScanning();
     void CleanDatabase(CGUIDialogProgressBarHandle* handle=NULL, const std::set<int>* paths=NULL, bool showProgress=true);
     void Stop();


### PR DESCRIPTION
This is a less intrusive approach to being able to run video library cleaning in the background than #5701. Furthermore it keeps the possibility to run it in-thread (and showing the modal dialog with the cancel button). and it doesn't affect the behaviour of library scanning if `cleanonupdate` is defined.

The result is that if the library cleaning is user initiated it will always show the modal dialog and if it's not user initiated it won't show any progress at all (unless it's part of library scanning with `cleanonupdate`). Another possibility would be to keep user initiated behaviour the same but always show the kai toast progress bar if it's not user initiated.

I'll try to look into the music library cleaning if we can do the same there.
