### PR TITLE
Samba auth and cleanups

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -16116,3 +16116,14 @@ msgstr ""
 msgctxt "#38010"
 msgid "GPU accelerated"
 msgstr ""
+
+#. Description of setting "Services -> SMB Client -> Maximum client version" with label #38012
+#: system/settings/settings.xml
+msgctxt "#38011"
+msgid "Specifies the maximum allowed 'client max protocol' when connecting to samba servers. Higher number can allow higher performance on slow network links. Accepted values NT1, SMB2, SMB3"
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#38012"
+msgid "Maximum client version"
+msgstr ""

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2227,6 +2227,11 @@
           <default>WORKGROUP</default>
           <control type="edit" format="string" />
         </setting>
+        <setting id="smb.maxprotocol" type="string" label="38012" help="38011">
+          <level>2</level>
+	  <default>NT1</default>
+          <control type="edit" format="string" />
+        </setting>
       </group>
     </category>
   </section>

--- a/tools/depends/target/samba-gplv3/Makefile
+++ b/tools/depends/target/samba-gplv3/Makefile
@@ -1,18 +1,33 @@
 include ../../Makefile.include
-DEPS= ../../Makefile.include Makefile
+DEPS= ../../Makefile.include \
+      Makefile \
+      samba_crypto_osx.patch \
+      samba_string_fix.patch \
+
 
 # lib name, version
 LIBNAME=samba
-VERSION=3.6.12
+VERSION=4.1.13
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
 CONFIGURE= cp -f $(CONFIG_SUB) $(CONFIG_GUESS) .; \
           ./configure --prefix=$(PREFIX) \
-          --without-cluster-support --disable-swat --without-ldap \
-          --without-pam --without-pam_smbpass --with-fhs --with-libtalloc=no \
-          --with-libtdb=no --without-winbind --disable-cups --without-ads \
-          --disable-avahi --disable-fam --without-libaddns --without-libnetapi \
-          --without-dnsupdate --without-libsmbsharemodes
+          --without-cluster-support --without-ldap \
+          --without-pam --without-pam_smbpass --enable-fhs \
+          --without-winbind --disable-cups --without-ads \
+          --disable-avahi --without-fam \
+          --without-dnsupdate \
+	  --without-ldap \
+	  --disable-iprint \
+	  --without-sendfile-support \
+	  --without-acl-support \
+	  --without-automount \
+	  --without-aio-support \
+	  --without-dmapi \
+	  --disable-glusterfs \
+	  --without-ad-dc \
+	  --without-systemd
+
 
 LIBDYLIB=$(PLATFORM)/source3/bin/libsmbclient.a
 
@@ -23,24 +38,29 @@ all: .installed-$(PLATFORM)
 $(TARBALLS_LOCATION)/$(ARCHIVE):
 	cd $(TARBALLS_LOCATION); $(RETRIEVE_TOOL) $(RETRIEVE_TOOL_FLAGS) $(BASE_URL)/$(ARCHIVE)
 
-$(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
+.configured-$(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
 	rm -rf $(PLATFORM); mkdir -p $(PLATFORM)
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
-	cd $(PLATFORM)/source3; $(CONFIGURE)
+	cd $(PLATFORM); patch -p1 < ../samba_crypto_osx.patch
+	cd $(PLATFORM); patch -p1 < ../samba_string_fix.patch
+	cd $(PLATFORM); $(CONFIGURE)
+	touch $@
 
-$(LIBDYLIB): $(PLATFORM)
-	$(MAKE) -C $(PLATFORM)/source3 libsmbclient
+$(LIBDYLIB): .configured-$(PLATFORM)
+	$(MAKE) -C $(PLATFORM) bin/shared/libsmbclient.0.dylib
 
 .installed-$(PLATFORM): $(LIBDYLIB)
-	$(MAKE) -C $(PLATFORM)/source3 installlibsmbclient
+	cp $(PLATFORM)/bin/shared/libsmbclient.0.dylib $(PREFIX)/lib/libsmbclient.dylib.0
+	cp $(PLATFORM)/bin/default/include/public/libsmbclient.h $(PREFIX)/include/libsmbclient.h
 ifeq (darwin, $(findstring darwin, $(HOST)))
 	install_name_tool -id $(PREFIX)/lib/libsmbclient.dylib.0 $(PREFIX)/lib/libsmbclient.dylib.0
 endif
 	touch $@
 
 clean:
-	$(MAKE) -C $(PLATFORM)/source3 clean
+	$(MAKE) -C $(PLATFORM) clean
 	rm -f .installed-$(PLATFORM)
+	rm -f .configured-$(PLATFORM)
 
 distclean::
 	rm -rf $(PLATFORM) .installed-$(PLATFORM)

--- a/tools/depends/target/samba-gplv3/samba_crypto_osx.patch
+++ b/tools/depends/target/samba-gplv3/samba_crypto_osx.patch
@@ -1,0 +1,10 @@
+--- a/lib/crypto/md5.h
++++ b/lib/crypto/md5.h
+@@ -18,6 +18,7 @@
+ #elif defined(HAVE_COMMONCRYPTO_COMMONDIGEST_H)
+ #include <CommonCrypto/CommonDigest.h>
+ 
++#define MD5_CTX					CC_MD5_CTX
+ #define MD5Init(c)					CC_MD5_Init(c)
+ #define MD5Update(c,d,l)			CC_MD5_Update(c,d,l)
+ #define MD5Final(m, c)				CC_MD5_Final((unsigned char *)m,c)

--- a/tools/depends/target/samba-gplv3/samba_string_fix.patch
+++ b/tools/depends/target/samba-gplv3/samba_string_fix.patch
@@ -1,0 +1,54 @@
+build: lib/util/string_wrappers.h: fix optimisation check for
+ clang
+
+Building with clang resulted in an error with undefined symbols
+___unsafe_string_function_usage_here_size_t__ etc. Turns out the
+existing check whether the compiler optimizes out functions doesn't
+match the use case, ie the check said yes, but the functions were not
+optimized out.
+
+Signed-off-by: Ralph Boehme <slow at samba.org>
+---
+ source3/wscript | 26 +++++++++++++++++++++-----
+ 1 file changed, 21 insertions(+), 5 deletions(-)
+
+diff --git a/source3/wscript b/source3/wscript
+index 4f182bf..2083f01 100644
+--- a/source3/wscript
++++ b/source3/wscript
+@@ -349,12 +349,28 @@ int main(int argc, char **argv)
+ 
+     # Check if the compiler will optimize out functions
+     conf.CHECK_CODE('''
+-if (0) {
+-    this_function_does_not_exist();
+-} else {
+-    return 1;
++#include <sys/types.h>
++size_t __unsafe_string_function_usage_here_size_t__(void);
++#define CHECK_STRING_SIZE(d, len) (sizeof(d) != (len) && sizeof(d) != sizeof(char *))
++static size_t push_string_check_fn(void *dest, const char *src, size_t dest_len) {
++	return 0;
++}
++
++#define push_string_check(dest, src, dest_len) \
++    (CHECK_STRING_SIZE(dest, dest_len) \
++    ? __unsafe_string_function_usage_here_size_t__()	\
++    : push_string_check_fn(dest, src, dest_len))
++
++int main(int argc, char **argv) {
++    char outbuf[1024];
++    char *p = outbuf;
++    const char *foo = "bar";
++    p += 31 + push_string_check(p + 31, foo, sizeof(outbuf) - (p + 31 - outbuf));
++    return 0;
+ }''', 'HAVE_COMPILER_WILL_OPTIMIZE_OUT_FNS',
+-        msg="Checking if the compiler will optimize out functions")
++            addmain=False,
++            add_headers=False,
++            msg="Checking if the compiler will optimize out functions")
+ 
+     # Check if the compiler supports the LL suffix on long long integers
+     # AIX needs this
+-- 
+1.9.3

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -745,7 +745,7 @@ CStdString CUtil::GetNextPathname(const CStdString &path_template, int max)
   return "";
 }
 
-void CUtil::StatToStatI64(struct _stati64 *result, struct stat *stat)
+void CUtil::StatToStatI64(struct _stati64 *result, const struct stat *stat)
 {
   result->st_dev = stat->st_dev;
   result->st_ino = stat->st_ino;
@@ -767,7 +767,7 @@ void CUtil::StatToStatI64(struct _stati64 *result, struct stat *stat)
 #endif
 }
 
-void CUtil::Stat64ToStatI64(struct _stati64 *result, struct __stat64 *stat)
+void CUtil::Stat64ToStatI64(struct _stati64 *result, const struct __stat64 *stat)
 {
   result->st_dev = stat->st_dev;
   result->st_ino = stat->st_ino;
@@ -788,7 +788,7 @@ void CUtil::Stat64ToStatI64(struct _stati64 *result, struct __stat64 *stat)
 #endif
 }
 
-void CUtil::StatI64ToStat64(struct __stat64 *result, struct _stati64 *stat)
+void CUtil::StatI64ToStat64(struct __stat64 *result, const struct _stati64 *stat)
 {
   result->st_dev = stat->st_dev;
   result->st_ino = stat->st_ino;
@@ -825,7 +825,7 @@ void CUtil::StatToStat64(struct __stat64 *result, const struct stat *stat)
   result->st_ctime = stat->st_ctime;
 }
 
-void CUtil::Stat64ToStat(struct stat *result, struct __stat64 *stat)
+void CUtil::Stat64ToStat(struct stat *result, const struct __stat64 *stat)
 {
   result->st_dev = stat->st_dev;
   result->st_ino = stat->st_ino;
@@ -852,7 +852,7 @@ void CUtil::Stat64ToStat(struct stat *result, struct __stat64 *stat)
 }
 
 #ifdef TARGET_WINDOWS
-void CUtil::Stat64ToStat64i32(struct _stat64i32 *result, struct __stat64 *stat)
+void CUtil::Stat64ToStat64i32(struct _stat64i32 *result, const struct __stat64 *stat)
 {
   result->st_dev = stat->st_dev;
   result->st_ino = stat->st_ino;

--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -105,13 +105,13 @@ public:
   static int64_t ToInt64(uint32_t high, uint32_t low);
   static CStdString GetNextFilename(const CStdString &fn_template, int max);
   static CStdString GetNextPathname(const CStdString &path_template, int max);
-  static void StatToStatI64(struct _stati64 *result, struct stat *stat);
+  static void StatToStatI64(struct _stati64 *result, const struct stat *stat);
   static void StatToStat64(struct __stat64 *result, const struct stat *stat);
-  static void Stat64ToStatI64(struct _stati64 *result, struct __stat64 *stat);
-  static void StatI64ToStat64(struct __stat64 *result, struct _stati64 *stat);
-  static void Stat64ToStat(struct stat *result, struct __stat64 *stat);
+  static void Stat64ToStatI64(struct _stati64 *result, const struct __stat64 *stat);
+  static void StatI64ToStat64(struct __stat64 *result, const struct _stati64 *stat);
+  static void Stat64ToStat(struct stat *result, const struct __stat64 *stat);
 #ifdef TARGET_WINDOWS
-  static void Stat64ToStat64i32(struct _stat64i32 *result, struct __stat64 *stat);
+  static void Stat64ToStat64i32(struct _stat64i32 *result, const struct __stat64 *stat);
 #endif
   static bool CreateDirectoryEx(const CStdString& strPath);
 

--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -88,7 +88,7 @@ bool CFile::Copy(const CURL& url2, const CURL& dest, XFILE::IFileCallback* pCall
   CURL url(url2);
   if (URIUtils::IsInZIP(url.Get()) || URIUtils::IsInAPK(url.Get()))
     url.SetOptions("?cache=no");
-  if (file.Open(url.Get(), READ_TRUNCATED))
+  if (file.Open(url.Get(), READ_TRUNCATED | READ_CHUNKED))
   {
 
     CFile newFile;
@@ -130,7 +130,7 @@ bool CFile::Copy(const CURL& url2, const CURL& dest, XFILE::IFileCallback* pCall
       return false;
     }
 
-    static const int iBufferSize = 128 * 1024;
+    int iBufferSize = GetChunkSize(file.GetChunkSize(), 128 * 1024);
 
     auto_buffer buffer(iBufferSize);
     ssize_t iRead, iWrite;

--- a/xbmc/filesystem/SMBDirectory.cpp
+++ b/xbmc/filesystem/SMBDirectory.cpp
@@ -230,11 +230,7 @@ int CSMBDirectory::OpenDir(const CURL& url, std::string& strAuth)
 {
   int fd = -1;
 
-  /* make a writeable copy */
-  CURL urlIn(url);
-
-  CPasswordManager::GetInstance().AuthenticateURL(urlIn);
-  strAuth = smb.URLEncode(urlIn);
+  strAuth = smb.URLEncode(url);
 
   // remove the / or \ at the end. the samba library does not strip them off
   // don't do this for smb:// !!
@@ -260,7 +256,7 @@ int CSMBDirectory::OpenDir(const CURL& url, std::string& strAuth)
     if (errno == EACCES)
     {
       if (m_flags & DIR_FLAG_ALLOW_PROMPT)
-        RequireAuthentication(urlIn);
+        RequireAuthentication(url);
     }
     else if (errno == ENODEV || errno == ENOENT)
       cError = StringUtils::Format(g_localizeStrings.Get(770).c_str(),errno);
@@ -283,9 +279,7 @@ bool CSMBDirectory::Create(const CURL& url2)
   CSingleLock lock(smb);
   smb.Init();
 
-  CURL url(url2);
-  CPasswordManager::GetInstance().AuthenticateURL(url);
-  std::string strFileName = smb.URLEncode(url);
+  std::string strFileName = smb.URLEncode(url2);
 
   int result = smbc_mkdir(strFileName.c_str(), 0);
   success = (result == 0 || EEXIST == errno);
@@ -300,9 +294,7 @@ bool CSMBDirectory::Remove(const CURL& url2)
   CSingleLock lock(smb);
   smb.Init();
 
-  CURL url(url2);
-  CPasswordManager::GetInstance().AuthenticateURL(url);
-  std::string strFileName = smb.URLEncode(url);
+  std::string strFileName = smb.URLEncode(url2);
 
   int result = smbc_rmdir(strFileName.c_str());
 
@@ -320,9 +312,7 @@ bool CSMBDirectory::Exists(const CURL& url2)
   CSingleLock lock(smb);
   smb.Init();
 
-  CURL url(url2);
-  CPasswordManager::GetInstance().AuthenticateURL(url);
-  std::string strFileName = smb.URLEncode(url);
+  std::string strFileName = smb.URLEncode(url2);
 
   struct stat info;
   if (smbc_stat(strFileName.c_str(), &info) != 0)

--- a/xbmc/filesystem/SMBDirectory.cpp
+++ b/xbmc/filesystem/SMBDirectory.cpp
@@ -80,15 +80,13 @@ bool CSMBDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 
   //Separate roots for the authentication and the containing items to allow browsing to work correctly
   std::string strRoot = url.Get();
-  std::string strAuth;
 
   lock.Leave(); // OpenDir is locked
-  int fd = OpenDir(url, strAuth);
-  if (fd < 0)
+  SMBCFILE* fd = Open(url);
+  if (fd == NULL)
     return false;
 
   URIUtils::AddSlashAtEnd(strRoot);
-  URIUtils::AddSlashAtEnd(strAuth);
 
   std::string strFile;
 
@@ -99,14 +97,14 @@ bool CSMBDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   struct smbc_dirent* dirEnt;
 
   lock.Enter();
-  while ((dirEnt = smbc_readdir(fd)))
+  while ((dirEnt = smb.readdir_fn(smb.GetContext(), fd)))
   {
     CachedDirEntry aDir;
     aDir.type = dirEnt->smbc_type;
     aDir.name = dirEnt->name;
     vecEntries.push_back(aDir);
   }
-  smbc_closedir(fd);
+  smb.closedir_fn(smb.GetContext(), fd);
   lock.Leave();
 
   for (size_t i=0; i<vecEntries.size(); i++)
@@ -139,17 +137,17 @@ bool CSMBDirectory::GetDirectory(const CURL& url, CFileItemList &items)
         if ((m_flags & DIR_FLAG_NO_FILE_INFO)==0 && g_advancedSettings.m_sambastatfiles)
         {
           // make sure we use the authenticated path wich contains any default username
-          const std::string strFullName = strAuth + smb.URLEncode(strFile);
+          const std::string strFullName = strRoot + smb.URLEncode(strFile);
 
           lock.Enter();
 
-          if( smbc_stat(strFullName.c_str(), &info) == 0 )
+          if( smb.stat_fn(smb.GetContext(), strFullName.c_str(), &info) == 0 )
           {
 
             char value[20];
             // We poll for extended attributes which symbolizes bits but split up into a string. Where 0x02 is hidden and 0x12 is hidden directory.
             // According to the libsmbclient.h it's supposed to return 0 if ok, or the length of the string. It seems always to return the length wich is 4
-            if (smbc_getxattr(strFullName.c_str(), "system.dos_attr.mode", value, sizeof(value)) > 0)
+            if (smb.getxattr_fn(smb.GetContext(), strFullName.c_str(), "system.dos_attr.mode", value, sizeof(value)) > 0)
             {
               long longvalue = strtol(value, NULL, 16);
               if (longvalue & SMBC_DOS_MODE_HIDDEN)
@@ -216,40 +214,24 @@ bool CSMBDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   return true;
 }
 
-int CSMBDirectory::Open(const CURL &url)
-{
-  smb.Init();
-  std::string strAuth;
-  return OpenDir(url, strAuth);
-}
-
 /// \brief Checks authentication against SAMBA share and prompts for username and password if needed
 /// \param strAuth The SMB style path
 /// \return SMB file descriptor
-int CSMBDirectory::OpenDir(const CURL& url, std::string& strAuth)
+SMBCFILE* CSMBDirectory::Open(const CURL& url)
 {
-  int fd = -1;
+  SMBCFILE* fd = NULL;
 
-  strAuth = smb.URLEncode(url);
-
-  // remove the / or \ at the end. the samba library does not strip them off
-  // don't do this for smb:// !!
-  std::string s = strAuth;
-  int len = s.length();
-  if (len > 1 && s.at(len - 2) != '/' &&
-      (s.at(len - 1) == '/' || s.at(len - 1) == '\\'))
-  {
-    s.erase(len - 1, 1);
-  }
+  smb.Init();
+  std::string s = smb.URLEncode(url);
 
   if (g_advancedSettings.CanLogComponent(LOGSAMBA))
     CLog::LogFunction(LOGDEBUG, __FUNCTION__, "Using authentication url %s", CURL::GetRedacted(s).c_str());
 
   { CSingleLock lock(smb);
-    fd = smbc_opendir(s.c_str());
+    fd = smb.opendir_fn(smb.GetContext(), s.c_str());
   }
 
-  if (fd < 0) /* only to avoid goto in following code */
+  if (fd == NULL) /* only to avoid goto in following code */
   {
     std::string cError;
 
@@ -267,7 +249,7 @@ int CSMBDirectory::OpenDir(const CURL& url, std::string& strAuth)
       SetErrorDialog(257, cError.c_str());
 
     // write error to logfile
-    CLog::Log(LOGERROR, "SMBDirectory->GetDirectory: Unable to open directory : '%s'\nunix_err:'%x' error : '%s'", CURL::GetRedacted(strAuth).c_str(), errno, strerror(errno));
+    CLog::Log(LOGERROR, "SMBDirectory->GetDirectory: Unable to open directory : '%s'\nunix_err:'%x' error : '%s'", url.GetRedacted().c_str(), errno, strerror(errno));
   }
 
   return fd;
@@ -280,8 +262,7 @@ bool CSMBDirectory::Create(const CURL& url2)
   smb.Init();
 
   std::string strFileName = smb.URLEncode(url2);
-
-  int result = smbc_mkdir(strFileName.c_str(), 0);
+  int result = smb.mkdir_fn(smb.GetContext(), strFileName.c_str(), 0);
   success = (result == 0 || EEXIST == errno);
   if(!success)
     CLog::Log(LOGERROR, "%s - Error( %s )", __FUNCTION__, strerror(errno));
@@ -296,7 +277,7 @@ bool CSMBDirectory::Remove(const CURL& url2)
 
   std::string strFileName = smb.URLEncode(url2);
 
-  int result = smbc_rmdir(strFileName.c_str());
+  int result = smb.rmdir_fn(smb.GetContext(), strFileName.c_str());
 
   if(result != 0 && errno != ENOENT)
   {
@@ -315,7 +296,7 @@ bool CSMBDirectory::Exists(const CURL& url2)
   std::string strFileName = smb.URLEncode(url2);
 
   struct stat info;
-  if (smbc_stat(strFileName.c_str(), &info) != 0)
+  if (smb.stat_fn(smb.GetContext(), strFileName.c_str(), &info) != 0)
     return false;
 
   return S_ISDIR(info.st_mode);

--- a/xbmc/filesystem/SMBDirectory.h
+++ b/xbmc/filesystem/SMBDirectory.h
@@ -36,7 +36,7 @@ public:
   virtual bool Exists(const CURL& url);
   virtual bool Remove(const CURL& url);
 
-  int Open(const CURL &url);
+  SMBCFILE* Open(const CURL &url);
 
   //MountShare will try to mount the smb share and return the path to the mount point (or empty string if failed)
   static std::string MountShare(const std::string &smbPath, const std::string &strType, const std::string &strName,
@@ -46,8 +46,5 @@ public:
   static std::string GetMountPoint(const std::string &strType, const std::string &strName);
 
   static bool MountShare(const std::string &strType, CMediaSource &share);
-
-private:
-  int OpenDir(const CURL &url, std::string& strAuth);
 };
 }

--- a/xbmc/filesystem/SMBFile.cpp
+++ b/xbmc/filesystem/SMBFile.cpp
@@ -157,6 +157,9 @@ void CSMB::Init()
         if (g_advancedSettings.m_sambadoscodepage.length() > 0)
           fprintf(f, "\tdos charset = %s\n", g_advancedSettings.m_sambadoscodepage.c_str());
 
+        // configure allowed client version
+        fprintf(f, "\tclient max protocol = %s\n", CSettings::Get().GetString("smb.maxprotocol").c_str());
+
         fclose(f);
       }
     }

--- a/xbmc/filesystem/SMBFile.cpp
+++ b/xbmc/filesystem/SMBFile.cpp
@@ -369,7 +369,6 @@ bool CSMBFile::Open(const CURL& url)
       CLog::Log(LOGNOTICE,"SMBFile->Open: Bad URL : '%s'",url.GetFileName().c_str());
       return false;
   }
-  m_url = url;
 
   // opening a file to another computer share will create a new session
   // when opening smb://server xbms will try to find folder.jpg in all shares

--- a/xbmc/filesystem/SMBFile.cpp
+++ b/xbmc/filesystem/SMBFile.cpp
@@ -513,12 +513,12 @@ ssize_t CSMBFile::Read(void *lpBuf, size_t uiBufSize)
 
   if ( bytesRead < 0 && errno == EINVAL )
   {
-    CLog::Log(LOGERROR, "%s - Error( %d, %d, %s ) - Retrying", __FUNCTION__, bytesRead, errno, strerror(errno));
+    CLog::Log(LOGERROR, "%s - Error( %"PRIdS", %d, %s ) - Retrying", __FUNCTION__, bytesRead, errno, strerror(errno));
     bytesRead = smbc_read(m_fd, lpBuf, (int)uiBufSize);
   }
 
   if ( bytesRead < 0 )
-    CLog::Log(LOGERROR, "%s - Error( %d, %d, %s )", __FUNCTION__, bytesRead, errno, strerror(errno));
+    CLog::Log(LOGERROR, "%s - Error( %"PRIdS", %d, %s )", __FUNCTION__, bytesRead, errno, strerror(errno));
 
   return bytesRead;
 }

--- a/xbmc/filesystem/SMBFile.h
+++ b/xbmc/filesystem/SMBFile.h
@@ -116,6 +116,7 @@ public:
 protected:
   bool IsValidFile(const std::string& strFileName);
   SMBCFILE* m_fd;
+  size_t    m_limit_len;
 };
 }
 

--- a/xbmc/filesystem/SMBFile.h
+++ b/xbmc/filesystem/SMBFile.h
@@ -93,7 +93,6 @@ public:
 protected:
   CURL m_url;
   bool IsValidFile(const std::string& strFileName);
-  std::string GetAuthenticatedPath(const CURL &url);
   int64_t m_fileSize;
   int m_fd;
 };

--- a/xbmc/filesystem/SMBFile.h
+++ b/xbmc/filesystem/SMBFile.h
@@ -114,7 +114,6 @@ public:
   virtual int  GetChunkSize() {return 1;}
 
 protected:
-  CURL m_url;
   bool IsValidFile(const std::string& strFileName);
   SMBCFILE* m_fd;
 };

--- a/xbmc/filesystem/SMBFile.h
+++ b/xbmc/filesystem/SMBFile.h
@@ -30,6 +30,7 @@
 #include "IFile.h"
 #include "URL.h"
 #include "threads/CriticalSection.h"
+#include <libsmbclient.h>
 
 #define NT_STATUS_CONNECTION_REFUSED long(0xC0000000 | 0x0236)
 #define NT_STATUS_INVALID_HANDLE long(0xC0000000 | 0x0008)
@@ -39,6 +40,9 @@
 
 struct _SMBCCTX;
 typedef _SMBCCTX SMBCCTX;
+
+struct _SMBCFILE;
+typedef _SMBCFILE SMBCFILE;
 
 class CSMB : public CCriticalSection
 {
@@ -53,8 +57,27 @@ public:
   void AddIdleConnection();
   std::string URLEncode(const std::string &value);
   std::string URLEncode(const CURL &url);
+  SMBCCTX* GetContext() { return m_context; }
 
   DWORD ConvertUnixToNT(int error);
+
+  smbc_close_fn    close_fn;
+  smbc_closedir_fn closedir_fn;
+  smbc_creat_fn    creat_fn;
+  smbc_fstat_fn    fstat_fn;
+  smbc_getxattr_fn getxattr_fn;
+  smbc_lseek_fn    lseek_fn;
+  smbc_mkdir_fn    mkdir_fn;
+  smbc_open_fn     open_fn;
+  smbc_opendir_fn  opendir_fn;
+  smbc_read_fn     read_fn;
+  smbc_readdir_fn  readdir_fn;
+  smbc_rename_fn   rename_fn;
+  smbc_rmdir_fn    rmdir_fn;
+  smbc_stat_fn     stat_fn;
+  smbc_unlink_fn   unlink_fn;
+  smbc_write_fn    write_fn;
+
 private:
   SMBCCTX *m_context;
 #ifdef TARGET_POSIX
@@ -94,7 +117,7 @@ protected:
   CURL m_url;
   bool IsValidFile(const std::string& strFileName);
   int64_t m_fileSize;
-  int m_fd;
+  SMBCFILE* m_fd;
 };
 }
 

--- a/xbmc/filesystem/SMBFile.h
+++ b/xbmc/filesystem/SMBFile.h
@@ -116,7 +116,6 @@ public:
 protected:
   CURL m_url;
   bool IsValidFile(const std::string& strFileName);
-  int64_t m_fileSize;
   SMBCFILE* m_fd;
 };
 }

--- a/xbmc/network/NetworkServices.cpp
+++ b/xbmc/network/NetworkServices.cpp
@@ -389,7 +389,7 @@ void CNetworkServices::OnSettingChanged(const CSetting *setting)
 #endif // HAS_WEB_SERVER
   if (settingId == "smb.winsserver" ||
       settingId == "smb.workgroup" ||
-      settingId == "smb.smbprotocol")
+      settingId == "smb.maxrotocol")
   {
     // okey we really don't need to restart, only deinit samba, but that could be damn hard if something is playing
     // TODO - General way of handling setting changes that require restart

--- a/xbmc/network/NetworkServices.cpp
+++ b/xbmc/network/NetworkServices.cpp
@@ -388,7 +388,8 @@ void CNetworkServices::OnSettingChanged(const CSetting *setting)
   else
 #endif // HAS_WEB_SERVER
   if (settingId == "smb.winsserver" ||
-      settingId == "smb.workgroup")
+      settingId == "smb.workgroup" ||
+      settingId == "smb.smbprotocol")
   {
     // okey we really don't need to restart, only deinit samba, but that could be damn hard if something is playing
     // TODO - General way of handling setting changes that require restart

--- a/xbmc/profiles/dialogs/GUIDialogLockSettings.cpp
+++ b/xbmc/profiles/dialogs/GUIDialogLockSettings.cpp
@@ -248,8 +248,8 @@ void CGUIDialogLockSettings::InitializeSettings()
 
   if (m_getUser)
   {
-    AddEdit(group, SETTING_USERNAME, 20142, 0, m_user);
-    AddEdit(group, SETTING_PASSWORD, 12326, 0, m_locks.code, false, true);
+    AddEdit(group, SETTING_USERNAME, 20142, 0, m_user, true);
+    AddEdit(group, SETTING_PASSWORD, 12326, 0, m_locks.code, true, true);
     if (m_saveUserDetails != NULL)
       AddToggle(group, SETTING_PASSWORD_REMEMBER, 13423, 0, *m_saveUserDetails);
 

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -777,6 +777,7 @@ void CSettings::InitializeISettingCallbacks()
   settingSet.insert("services.escontinuousdelay");
   settingSet.insert("smb.winsserver");
   settingSet.insert("smb.workgroup");
+  settingSet.insert("smb.smbprotocol");
   m_settingsManager->RegisterCallback(&CNetworkServices::Get(), settingSet);
 
   settingSet.clear();

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -777,7 +777,7 @@ void CSettings::InitializeISettingCallbacks()
   settingSet.insert("services.escontinuousdelay");
   settingSet.insert("smb.winsserver");
   settingSet.insert("smb.workgroup");
-  settingSet.insert("smb.smbprotocol");
+  settingSet.insert("smb.maxprotocol");
   m_settingsManager->RegisterCallback(&CNetworkServices::Get(), settingSet);
 
   settingSet.clear();


### PR DESCRIPTION
This is a series of commits that build on: https://github.com/xbmc/xbmc/pull/5740 and
- Bumps samba to a version that supports smb2/3 protocol.
- Uses sambas builtin authentication
- Upgrade api usage to the non legacy api
- Uses our own samba config file instead of user global one
