### PR TITLE
[vfs/Pipe] - fix premature close of pipe. It should only be closed if

### DIFF
--- a/xbmc/filesystem/PipesManager.cpp
+++ b/xbmc/filesystem/PipesManager.cpp
@@ -318,9 +318,9 @@ void         PipesManager::ClosePipe(XFILE::Pipe *pipe)
     return ;
   
   pipe->DecRef();
-  pipe->Close();
   if (pipe->RefCount() == 0)
   {
+    pipe->Close();
     m_pipes.erase(pipe->GetName());
     delete pipe;
   }


### PR DESCRIPTION
refcount is zero.

This fixes a long standing interference between airtunes and cu.lyrics addon.

Bug was as follows:
1. AirTunes was playing - the datastream is transfered via our PipeFile and is opened (refcount = 1)
2. cu.lyrics kicks in and opens the file for doing som analyzing (increases refcount of the pipe to 2)
3. cu.lyrics is done and closes the file - pipe got closed with refcount = 1 (this is the bug)
4. AirTunes tries to read from the already closed pipe and gets eof - airtunes stream is stopped.

Basically this PR fixes 3. (only close the pipe if refcount = 0) which fixes this issue. There is a proposal to also make cu.lyrics a bit better here (normally you can't analyse something on a stream). But for now this fixes this (annyoing) bug.

Thx to Mr Hipp who pointed out the solution in the forum here http://forum.kodi.tv/showthread.php?tid=208930

This is safe for helix - no bad impact is to be expected (pipe is only used with airtunes atm and the fix is obvious).
