### PR TITLE
[pvr] Fix recording history (last directory not selected)

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -699,12 +699,6 @@ bool CGUIWindowPVRBase::UpdateEpgForChannel(CFileItem *item)
   return true;
 }
 
-bool CGUIWindowPVRBase::Update(const std::string &strDirectory, bool updateFilterPath /* = true */)
-{
-  m_vecItems->SetPath(strDirectory);
-  return CGUIMediaWindow::Update(strDirectory, updateFilterPath);
-}
-
 void CGUIWindowPVRBase::UpdateButtons(void)
 {
   CGUIMediaWindow::UpdateButtons();

--- a/xbmc/pvr/windows/GUIWindowPVRBase.h
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.h
@@ -59,7 +59,6 @@ namespace PVR
     virtual bool OnMessage(CGUIMessage& message);
     virtual bool OnContextButton(int itemNumber, CONTEXT_BUTTON button);
     virtual bool OnContextButton(const CFileItem &item, CONTEXT_BUTTON button) { return false; };
-    virtual bool Update(const std::string &strDirectory, bool updateFilterPath = true);
     virtual void UpdateButtons(void);
     virtual bool OnAction(const CAction &action);
     virtual bool OnBack(int actionID);

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -678,6 +678,9 @@ bool CGUIMediaWindow::GetDirectory(const std::string &strDirectory, CFileItemLis
       m_history.RemoveParentPath();
   }
 
+  // update the view state's reference to the current items
+  m_guiState.reset(CGUIViewState::GetViewState(GetID(), items));
+
   if (m_guiState.get() && !m_guiState->HideParentDirItems() && !items.GetPath().empty())
   {
     CFileItemPtr pItem(new CFileItem(".."));
@@ -821,8 +824,6 @@ bool CGUIMediaWindow::Update(const std::string &strDirectory, bool updateFilterP
   OnPrepareFileItems(*m_vecItems);
 
   m_vecItems->FillInDefaultIcons();
-
-  m_guiState.reset(CGUIViewState::GetViewState(GetID(), *m_vecItems));
 
   // remember the original (untouched) list of items (for filtering etc)
   m_unfilteredItems->SetPath(m_vecItems->GetPath()); // use the original path - it'll likely be relied on for other things later.


### PR DESCRIPTION
This fixes an ancient bug where the selected item is always the top one in the list after you go back from a recording sub directory. The root cause is two-fold:
- we've called `m_vecItems->SetPath()` manually before updating the window contents. This is wrong since the history manager excepts the item path to be that of the previous window, not the window we are about to enter. The first commit fixes that by removing the `Update()` method override from `CGUIWindowPVRBase`.
- the next issue cropped up after fixing the previous one. The problem now is that the view state which (among other things) controls whether the "go to parent" item should be shown at the top of lists held a reference to the previous directory's items at a time when it should have had the new list. This fixes that by simply moving the call a bit earlier in the chain.

@Montellese regarding the second one, do you know enough about this part to comment on it? I haven't tested all possible scenarios, just that the recordings window works

@xhaggi @opdenkamp for the usual review

@topfs2 for Helix unless someone complains
