### PR TITLE
[Fix] Reading zero bytes from a file should yield zero read bytes.

### DIFF
--- a/xbmc/filesystem/win32/Win32File.cpp
+++ b/xbmc/filesystem/win32/Win32File.cpp
@@ -187,7 +187,7 @@ ssize_t CWin32File::Read(void* lpBuf, size_t uiBufSize)
     if (!ReadFile(m_hFile, dummyBuf.get(), 0, &bytesRead, NULL))
       return -1;
 
-    assert(bytesRead != 0);
+    assert(bytesRead == 0);
     return 0;
   }
 


### PR DESCRIPTION
Fix for 52800a1fa28cd6f9b843b55cfb40820fae2bc9d3.
