### PR TITLE
[osx] - disable ffmpeg vda hw decoder for now - fixes #15432 for helix

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -128,6 +128,7 @@ enum PixelFormat CDVDVideoCodecFFmpeg::GetFormat( struct AVCodecContext * avctx
 #endif
 
 #ifdef TARGET_DARWIN_OSX
+/*  REENABLE this after Helix Release and try to fix http://trac.xbmc.org/ticket/15432
     if (*cur == AV_PIX_FMT_VDA_VLD && CSettings::Get().GetBool("videoplayer.usevda"))
     {
       VDA::CDecoder* dec = new VDA::CDecoder();
@@ -138,7 +139,7 @@ enum PixelFormat CDVDVideoCodecFFmpeg::GetFormat( struct AVCodecContext * avctx
       }
       else
         dec->Release();
-    }
+    }*/
 #endif
     cur++;
   }


### PR DESCRIPTION
The ffmpeg vda is hit when our vda decoder fails to open. Basically we don't fallback to software ffmpeg but the ffmpeg vda hw decoder which is not ready yet.

This behaviour is responsible for this crash reported here:
http://trac.xbmc.org/ticket/15432

and here:

http://forum.kodi.tv/showthread.php?tid=209085

thx to @FernetMenta to seeing this in the logs.

@elupus fyi ping. I think its better to ensure that VDA.cpp is not in action for helix. What do you think?

@MartijnKaijser fyi ping - seems i lied when i said this is never hit in helix (because i was not aware - sorry).
