### PR TITLE
[Confluence] Support recently unwatched items (optional)

### DIFF
--- a/addons/skin.confluence/720p/IncludesHomeRecentlyAdded.xml
+++ b/addons/skin.confluence/720p/IncludesHomeRecentlyAdded.xml
@@ -139,12 +139,28 @@
 					</focusedlayout>
 					<content>
 						<item>
+							<label>$INFO[Window.Property(RecentMovie.1.Title)]</label>
+							<label2/>
+							<onclick>PlayMedia($ESCINFO[Window.Property(RecentMovie.1.File)])</onclick>
+							<icon>$INFO[Window.Property(RecentMovie.1.Art(poster))]</icon>
+							<thumb>-</thumb>
+							<visible>system.hasaddon(service.skin.widgets) + !IsEmpty(Window.Property(RecentMovie.1.Title))</visible>
+						</item>
+						<item>
 							<label>$INFO[Window.Property(LatestMovie.1.Title)]</label>
 							<label2/>
 							<onclick>PlayMedia($ESCINFO[Window.Property(LatestMovie.1.Path)])</onclick>
 							<icon>$INFO[Window.Property(LatestMovie.1.Thumb)]</icon>
 							<thumb>-</thumb>
-							<visible>!IsEmpty(Window.Property(LatestMovie.1.Title))</visible>
+							<visible>!system.hasaddon(service.skin.widgets) + !IsEmpty(Window.Property(LatestMovie.1.Title))</visible>
+						</item>
+						<item>
+							<label>$INFO[Window.Property(RecentMovie.2.Title)]</label>
+							<label2/>
+							<onclick>PlayMedia($ESCINFO[Window.Property(RecentMovie.2.File)])</onclick>
+							<icon>$INFO[Window.Property(RecentMovie.2.Art(poster))]</icon>
+							<thumb>-</thumb>
+							<visible>system.hasaddon(service.skin.widgets) + !IsEmpty(Window.Property(RecentMovie.2.Title))</visible>
 						</item>
 						<item>
 							<label>$INFO[Window.Property(LatestMovie.2.Title)]</label>
@@ -152,7 +168,15 @@
 							<onclick>PlayMedia($ESCINFO[Window.Property(LatestMovie.2.Path)])</onclick>
 							<icon>$INFO[Window.Property(LatestMovie.2.Thumb)]</icon>
 							<thumb>-</thumb>
-							<visible>!IsEmpty(Window.Property(LatestMovie.2.Title))</visible>
+							<visible>!system.hasaddon(service.skin.widgets) + !IsEmpty(Window.Property(LatestMovie.2.Title))</visible>
+						</item>
+						<item>
+							<label>$INFO[Window.Property(RecentMovie.3.Title)]</label>
+							<label2/>
+							<onclick>PlayMedia($ESCINFO[Window.Property(RecentMovie.3.File)])</onclick>
+							<icon>$INFO[Window.Property(RecentMovie.3.Art(poster))]</icon>
+							<thumb>-</thumb>
+							<visible>system.hasaddon(service.skin.widgets) + !IsEmpty(Window.Property(RecentMovie.3.Title))</visible>
 						</item>
 						<item>
 							<label>$INFO[Window.Property(LatestMovie.3.Title)]</label>
@@ -160,7 +184,15 @@
 							<onclick>PlayMedia($ESCINFO[Window.Property(LatestMovie.3.Path)])</onclick>
 							<icon>$INFO[Window.Property(LatestMovie.3.Thumb)]</icon>
 							<thumb>-</thumb>
-							<visible>!IsEmpty(Window.Property(LatestMovie.3.Title))</visible>
+							<visible>!system.hasaddon(service.skin.widgets) + !IsEmpty(Window.Property(LatestMovie.3.Title))</visible>
+						</item>
+						<item>
+							<label>$INFO[Window.Property(RecentMovie.4.Title)]</label>
+							<label2/>
+							<onclick>PlayMedia($ESCINFO[Window.Property(RecentMovie.4.File)])</onclick>
+							<icon>$INFO[Window.Property(RecentMovie.4.Art(poster))]</icon>
+							<thumb>-</thumb>
+							<visible>system.hasaddon(service.skin.widgets) + !IsEmpty(Window.Property(RecentMovie.4.Title))</visible>
 						</item>
 						<item>
 							<label>$INFO[Window.Property(LatestMovie.4.Title)]</label>
@@ -168,7 +200,15 @@
 							<onclick>PlayMedia($ESCINFO[Window.Property(LatestMovie.4.Path)])</onclick>
 							<icon>$INFO[Window.Property(LatestMovie.4.Thumb)]</icon>
 							<thumb>-</thumb>
-							<visible>!IsEmpty(Window.Property(LatestMovie.4.Title))</visible>
+							<visible>!system.hasaddon(service.skin.widgets) + !IsEmpty(Window.Property(LatestMovie.4.Title))</visible>
+						</item>
+												<item>
+							<label>$INFO[Window.Property(RecentMovie.5.Title)]</label>
+							<label2/>
+							<onclick>PlayMedia($ESCINFO[Window.Property(RecentMovie.5.File)])</onclick>
+							<icon>$INFO[Window.Property(RecentMovie.5.Art(poster))]</icon>
+							<thumb>-</thumb>
+							<visible>system.hasaddon(service.skin.widgets) + !IsEmpty(Window.Property(RecentMovie.5.Title))</visible>
 						</item>
 						<item>
 							<label>$INFO[Window.Property(LatestMovie.5.Title)]</label>
@@ -176,7 +216,15 @@
 							<onclick>PlayMedia($ESCINFO[Window.Property(LatestMovie.5.Path)])</onclick>
 							<icon>$INFO[Window.Property(LatestMovie.5.Thumb)]</icon>
 							<thumb>-</thumb>
-							<visible>!IsEmpty(Window.Property(LatestMovie.5.Title))</visible>
+							<visible>!system.hasaddon(service.skin.widgets) + !IsEmpty(Window.Property(LatestMovie.5.Title))</visible>
+						</item>
+						<item>
+							<label>$INFO[Window.Property(RecentMovie.6.Title)]</label>
+							<label2/>
+							<onclick>PlayMedia($ESCINFO[Window.Property(RecentMovie.6.File)])</onclick>
+							<icon>$INFO[Window.Property(RecentMovie.6.Art(poster))]</icon>
+							<thumb>-</thumb>
+							<visible>system.hasaddon(service.skin.widgets) + !IsEmpty(Window.Property(RecentMovie.6.Title))</visible>
 						</item>
 						<item>
 							<label>$INFO[Window.Property(LatestMovie.6.Title)]</label>
@@ -184,7 +232,15 @@
 							<onclick>PlayMedia($ESCINFO[Window.Property(LatestMovie.6.Path)])</onclick>
 							<icon>$INFO[Window.Property(LatestMovie.6.Thumb)]</icon>
 							<thumb>-</thumb>
-							<visible>!IsEmpty(Window.Property(LatestMovie.6.Title))</visible>
+							<visible>!system.hasaddon(service.skin.widgets) + !IsEmpty(Window.Property(LatestMovie.6.Title))</visible>
+						</item>
+						<item>
+							<label>$INFO[Window.Property(RecentMovie.7.Title)]</label>
+							<label2/>
+							<onclick>PlayMedia($ESCINFO[Window.Property(RecentMovie.7.File)])</onclick>
+							<icon>$INFO[Window.Property(RecentMovie.7.Art(poster))]</icon>
+							<thumb>-</thumb>
+							<visible>system.hasaddon(service.skin.widgets) + !IsEmpty(Window.Property(RecentMovie.7.Title))</visible>
 						</item>
 						<item>
 							<label>$INFO[Window.Property(LatestMovie.7.Title)]</label>
@@ -192,7 +248,15 @@
 							<onclick>PlayMedia($ESCINFO[Window.Property(LatestMovie.7.Path)])</onclick>
 							<icon>$INFO[Window.Property(LatestMovie.7.Thumb)]</icon>
 							<thumb>-</thumb>
-							<visible>!IsEmpty(Window.Property(LatestMovie.7.Title))</visible>
+							<visible>!system.hasaddon(service.skin.widgets) + !IsEmpty(Window.Property(LatestMovie.7.Title))</visible>
+						</item>
+						<item>
+							<label>$INFO[Window.Property(RecentMovie.8.Title)]</label>
+							<label2/>
+							<onclick>PlayMedia($ESCINFO[Window.Property(RecentMovie.8.File)])</onclick>
+							<icon>$INFO[Window.Property(RecentMovie.8.Art(poster))]</icon>
+							<thumb>-</thumb>
+							<visible>system.hasaddon(service.skin.widgets) + !IsEmpty(Window.Property(RecentMovie.8.Title))</visible>
 						</item>
 						<item>
 							<label>$INFO[Window.Property(LatestMovie.8.Title)]</label>
@@ -200,7 +264,15 @@
 							<onclick>PlayMedia($ESCINFO[Window.Property(LatestMovie.8.Path)])</onclick>
 							<icon>$INFO[Window.Property(LatestMovie.8.Thumb)]</icon>
 							<thumb>-</thumb>
-							<visible>!IsEmpty(Window.Property(LatestMovie.8.Title))</visible>
+							<visible>!system.hasaddon(service.skin.widgets) + !IsEmpty(Window.Property(LatestMovie.8.Title))</visible>
+						</item>
+						<item>
+							<label>$INFO[Window.Property(RecentMovie.9.Title)]</label>
+							<label2/>
+							<onclick>PlayMedia($ESCINFO[Window.Property(RecentMovie.9.File)])</onclick>
+							<icon>$INFO[Window.Property(RecentMovie.9.Art(poster))]</icon>
+							<thumb>-</thumb>
+							<visible>system.hasaddon(service.skin.widgets) + !IsEmpty(Window.Property(RecentMovie.9.Title))</visible>
 						</item>
 						<item>
 							<label>$INFO[Window.Property(LatestMovie.9.Title)]</label>
@@ -208,7 +280,15 @@
 							<onclick>PlayMedia($ESCINFO[Window.Property(LatestMovie.9.Path)])</onclick>
 							<icon>$INFO[Window.Property(LatestMovie.9.Thumb)]</icon>
 							<thumb>-</thumb>
-							<visible>!IsEmpty(Window.Property(LatestMovie.9.Title))</visible>
+							<visible>!system.hasaddon(service.skin.widgets) + !IsEmpty(Window.Property(LatestMovie.9.Title))</visible>
+						</item>
+						<item>
+							<label>$INFO[Window.Property(RecentMovie.10.Title)]</label>
+							<label2/>
+							<onclick>PlayMedia($ESCINFO[Window.Property(RecentMovie.10.File)])</onclick>
+							<icon>$INFO[Window.Property(RecentMovie.10.Art(poster))]</icon>
+							<thumb>-</thumb>
+							<visible>system.hasaddon(service.skin.widgets) + !IsEmpty(Window.Property(RecentMovie.10.Title))</visible>
 						</item>
 						<item>
 							<label>$INFO[Window.Property(LatestMovie.10.Title)]</label>
@@ -216,7 +296,7 @@
 							<onclick>PlayMedia($ESCINFO[Window.Property(LatestMovie.10.Path)])</onclick>
 							<icon>$INFO[Window.Property(LatestMovie.10.Thumb)]</icon>
 							<thumb>-</thumb>
-							<visible>!IsEmpty(Window.Property(LatestMovie.10.Title))</visible>
+							<visible>!system.hasaddon(service.skin.widgets) + !IsEmpty(Window.Property(LatestMovie.10.Title))</visible>
 						</item>
 					</content>
 				</control>
@@ -402,12 +482,28 @@
 					</focusedlayout>
 					<content>
 						<item>
+							<label>$INFO[Window.Property(RecentEpisode.1.Title)]</label>
+							<label2>$INFO[Window.Property(RecentEpisode.1.TVshowTitle)] - $INFO[Window.Property(RecentEpisode.1.EpisodeNo)]</label2>
+							<onclick>PlayMedia($ESCINFO[Window.Property(RecentEpisode.1.File)])</onclick>
+							<icon>-</icon>
+							<thumb>$INFO[Window.Property(RecentEpisode.1.Art(thumb))]</thumb>
+							<visible>system.hasaddon(service.skin.widgets) + !IsEmpty(Window.Property(RecentEpisode.1.Title))</visible>
+						</item>
+						<item>
 							<label>$INFO[Window.Property(LatestEpisode.1.EpisodeTitle)]</label>
 							<label2>$INFO[Window.Property(LatestEpisode.1.ShowTitle)] - $INFO[Window.Property(LatestEpisode.1.EpisodeNo)]</label2>
 							<onclick>PlayMedia($ESCINFO[Window.Property(LatestEpisode.1.Path)])</onclick>
 							<icon>-</icon>
 							<thumb>$INFO[Window.Property(LatestEpisode.1.Thumb)]</thumb>
-							<visible>!IsEmpty(Window.Property(LatestEpisode.1.EpisodeTitle))</visible>
+							<visible>!system.hasaddon(service.skin.widgets) + !IsEmpty(Window.Property(LatestEpisode.1.EpisodeTitle))</visible>
+						</item>
+						<item>
+							<label>$INFO[Window.Property(RecentEpisode.2.Title)]</label>
+							<label2>$INFO[Window.Property(RecentEpisode.2.TVshowTitle)] - $INFO[Window.Property(RecentEpisode.2.EpisodeNo)]</label2>
+							<onclick>PlayMedia($ESCINFO[Window.Property(RecentEpisode.2.File)])</onclick>
+							<icon>-</icon>
+							<thumb>$INFO[Window.Property(RecentEpisode.2.Art(thumb))]</thumb>
+							<visible>system.hasaddon(service.skin.widgets) + !IsEmpty(Window.Property(RecentEpisode.2.Title))</visible>
 						</item>
 						<item>
 							<label>$INFO[Window.Property(LatestEpisode.2.EpisodeTitle)]</label>
@@ -415,7 +511,15 @@
 							<onclick>PlayMedia($ESCINFO[Window.Property(LatestEpisode.2.Path)])</onclick>
 							<icon>-</icon>
 							<thumb>$INFO[Window.Property(LatestEpisode.2.Thumb)]</thumb>
-							<visible>!IsEmpty(Window.Property(LatestEpisode.2.EpisodeTitle))</visible>
+							<visible>!system.hasaddon(service.skin.widgets) + !IsEmpty(Window.Property(LatestEpisode.2.EpisodeTitle))</visible>
+						</item>
+						<item>
+							<label>$INFO[Window.Property(RecentEpisode.3.Title)]</label>
+							<label2>$INFO[Window.Property(RecentEpisode.3.TVshowTitle)] - $INFO[Window.Property(RecentEpisode.3.EpisodeNo)]</label2>
+							<onclick>PlayMedia($ESCINFO[Window.Property(RecentEpisode.3.File)])</onclick>
+							<icon>-</icon>
+							<thumb>$INFO[Window.Property(RecentEpisode.3.Art(thumb))]</thumb>
+							<visible>system.hasaddon(service.skin.widgets) + !IsEmpty(Window.Property(RecentEpisode.3.Title))</visible>
 						</item>
 						<item>
 							<label>$INFO[Window.Property(LatestEpisode.3.EpisodeTitle)]</label>
@@ -423,7 +527,15 @@
 							<onclick>PlayMedia($ESCINFO[Window.Property(LatestEpisode.3.Path)])</onclick>
 							<icon>-</icon>
 							<thumb>$INFO[Window.Property(LatestEpisode.3.Thumb)]</thumb>
-							<visible>!IsEmpty(Window.Property(LatestEpisode.3.EpisodeTitle))</visible>
+							<visible>!system.hasaddon(service.skin.widgets) + !IsEmpty(Window.Property(LatestEpisode.3.EpisodeTitle))</visible>
+						</item>
+						<item>
+							<label>$INFO[Window.Property(RecentEpisode.4.Title)]</label>
+							<label2>$INFO[Window.Property(RecentEpisode.4.TVshowTitle)] - $INFO[Window.Property(RecentEpisode.4.EpisodeNo)]</label2>
+							<onclick>PlayMedia($ESCINFO[Window.Property(RecentEpisode.4.File)])</onclick>
+							<icon>-</icon>
+							<thumb>$INFO[Window.Property(RecentEpisode.4.Art(thumb))]</thumb>
+							<visible>system.hasaddon(service.skin.widgets) + !IsEmpty(Window.Property(RecentEpisode.4.Title))</visible>
 						</item>
 						<item>
 							<label>$INFO[Window.Property(LatestEpisode.4.EpisodeTitle)]</label>
@@ -431,7 +543,15 @@
 							<onclick>PlayMedia($ESCINFO[Window.Property(LatestEpisode.4.Path)])</onclick>
 							<icon>-</icon>
 							<thumb>$INFO[Window.Property(LatestEpisode.4.Thumb)]</thumb>
-							<visible>!IsEmpty(Window.Property(LatestEpisode.4.EpisodeTitle))</visible>
+							<visible>!system.hasaddon(service.skin.widgets) + !IsEmpty(Window.Property(LatestEpisode.4.EpisodeTitle))</visible>
+						</item>
+						<item>
+							<label>$INFO[Window.Property(RecentEpisode.5.Title)]</label>
+							<label2>$INFO[Window.Property(RecentEpisode.5.TVshowTitle)] - $INFO[Window.Property(RecentEpisode.5.EpisodeNo)]</label2>
+							<onclick>PlayMedia($ESCINFO[Window.Property(RecentEpisode.5.File)])</onclick>
+							<icon>-</icon>
+							<thumb>$INFO[Window.Property(RecentEpisode.5.Art(thumb))]</thumb>
+							<visible>system.hasaddon(service.skin.widgets) + !IsEmpty(Window.Property(RecentEpisode.5.Title))</visible>
 						</item>
 						<item>
 							<label>$INFO[Window.Property(LatestEpisode.5.EpisodeTitle)]</label>
@@ -439,7 +559,15 @@
 							<onclick>PlayMedia($ESCINFO[Window.Property(LatestEpisode.5.Path)])</onclick>
 							<icon>-</icon>
 							<thumb>$INFO[Window.Property(LatestEpisode.5.Thumb)]</thumb>
-							<visible>!IsEmpty(Window.Property(LatestEpisode.5.EpisodeTitle))</visible>
+							<visible>!system.hasaddon(service.skin.widgets) + !IsEmpty(Window.Property(LatestEpisode.5.EpisodeTitle))</visible>
+						</item>
+						<item>
+							<label>$INFO[Window.Property(RecentEpisode.6.Title)]</label>
+							<label2>$INFO[Window.Property(RecentEpisode.6.TVshowTitle)] - $INFO[Window.Property(RecentEpisode.6.EpisodeNo)]</label2>
+							<onclick>PlayMedia($ESCINFO[Window.Property(RecentEpisode.6.File)])</onclick>
+							<icon>-</icon>
+							<thumb>$INFO[Window.Property(RecentEpisode.6.Art(thumb))]</thumb>
+							<visible>system.hasaddon(service.skin.widgets) + !IsEmpty(Window.Property(RecentEpisode.6.Title))</visible>
 						</item>
 						<item>
 							<label>$INFO[Window.Property(LatestEpisode.6.EpisodeTitle)]</label>
@@ -447,7 +575,15 @@
 							<onclick>PlayMedia($ESCINFO[Window.Property(LatestEpisode.6.Path)])</onclick>
 							<icon>-</icon>
 							<thumb>$INFO[Window.Property(LatestEpisode.6.Thumb)]</thumb>
-							<visible>!IsEmpty(Window.Property(LatestEpisode.6.EpisodeTitle))</visible>
+							<visible>!system.hasaddon(service.skin.widgets) + !IsEmpty(Window.Property(LatestEpisode.6.EpisodeTitle))</visible>
+						</item>
+						<item>
+							<label>$INFO[Window.Property(RecentEpisode.7.Title)]</label>
+							<label2>$INFO[Window.Property(RecentEpisode.7.TVshowTitle)] - $INFO[Window.Property(RecentEpisode.7.EpisodeNo)]</label2>
+							<onclick>PlayMedia($ESCINFO[Window.Property(RecentEpisode.7.File)])</onclick>
+							<icon>-</icon>
+							<thumb>$INFO[Window.Property(RecentEpisode.7.Art(thumb))]</thumb>
+							<visible>system.hasaddon(service.skin.widgets) + !IsEmpty(Window.Property(RecentEpisode.7.Title))</visible>
 						</item>
 						<item>
 							<label>$INFO[Window.Property(LatestEpisode.7.EpisodeTitle)]</label>
@@ -455,7 +591,15 @@
 							<onclick>PlayMedia($ESCINFO[Window.Property(LatestEpisode.7.Path)])</onclick>
 							<icon>-</icon>
 							<thumb>$INFO[Window.Property(LatestEpisode.7.Thumb)]</thumb>
-							<visible>!IsEmpty(Window.Property(LatestEpisode.7.EpisodeTitle))</visible>
+							<visible>!system.hasaddon(service.skin.widgets) + !IsEmpty(Window.Property(LatestEpisode.7.EpisodeTitle))</visible>
+						</item>
+						<item>
+							<label>$INFO[Window.Property(RecentEpisode.8.Title)]</label>
+							<label2>$INFO[Window.Property(RecentEpisode.8.TVshowTitle)] - $INFO[Window.Property(RecentEpisode.8.EpisodeNo)]</label2>
+							<onclick>PlayMedia($ESCINFO[Window.Property(RecentEpisode.8.File)])</onclick>
+							<icon>-</icon>
+							<thumb>$INFO[Window.Property(RecentEpisode.8.Art(thumb))]</thumb>
+							<visible>system.hasaddon(service.skin.widgets) + !IsEmpty(Window.Property(RecentEpisode.8.Title))</visible>
 						</item>
 						<item>
 							<label>$INFO[Window.Property(LatestEpisode.8.EpisodeTitle)]</label>
@@ -463,7 +607,15 @@
 							<onclick>PlayMedia($ESCINFO[Window.Property(LatestEpisode.8.Path)])</onclick>
 							<icon>-</icon>
 							<thumb>$INFO[Window.Property(LatestEpisode.8.Thumb)]</thumb>
-							<visible>!IsEmpty(Window.Property(LatestEpisode.8.EpisodeTitle))</visible>
+							<visible>!system.hasaddon(service.skin.widgets) + !IsEmpty(Window.Property(LatestEpisode.8.EpisodeTitle))</visible>
+						</item>
+						<item>
+							<label>$INFO[Window.Property(RecentEpisode.9.Title)]</label>
+							<label2>$INFO[Window.Property(RecentEpisode.9.TVshowTitle)] - $INFO[Window.Property(RecentEpisode.9.EpisodeNo)]</label2>
+							<onclick>PlayMedia($ESCINFO[Window.Property(RecentEpisode.9.File)])</onclick>
+							<icon>-</icon>
+							<thumb>$INFO[Window.Property(RecentEpisode.9.Art(thumb))]</thumb>
+							<visible>system.hasaddon(service.skin.widgets) + !IsEmpty(Window.Property(RecentEpisode.9.Title))</visible>
 						</item>
 						<item>
 							<label>$INFO[Window.Property(LatestEpisode.9.EpisodeTitle)]</label>
@@ -471,7 +623,15 @@
 							<onclick>PlayMedia($ESCINFO[Window.Property(LatestEpisode.9.Path)])</onclick>
 							<icon>-</icon>
 							<thumb>$INFO[Window.Property(LatestEpisode.9.Thumb)]</thumb>
-							<visible>!IsEmpty(Window.Property(LatestEpisode.9.EpisodeTitle))</visible>
+							<visible>!system.hasaddon(service.skin.widgets) + !IsEmpty(Window.Property(LatestEpisode.9.EpisodeTitle))</visible>
+						</item>
+						<item>
+							<label>$INFO[Window.Property(RecentEpisode.10.Title)]</label>
+							<label2>$INFO[Window.Property(RecentEpisode.10.TVshowTitle)] - $INFO[Window.Property(RecentEpisode.10.EpisodeNo)]</label2>
+							<onclick>PlayMedia($ESCINFO[Window.Property(RecentEpisode.10.File)])</onclick>
+							<icon>-</icon>
+							<thumb>$INFO[Window.Property(RecentEpisode.10.Art(thumb))]</thumb>
+							<visible>system.hasaddon(service.skin.widgets) + !IsEmpty(Window.Property(RecentEpisode.10.Title))</visible>
 						</item>
 						<item>
 							<label>$INFO[Window.Property(LatestEpisode.10.EpisodeTitle)]</label>
@@ -479,7 +639,7 @@
 							<onclick>PlayMedia($ESCINFO[Window.Property(LatestEpisode.10.Path)])</onclick>
 							<icon>-</icon>
 							<thumb>$INFO[Window.Property(LatestEpisode.10.Thumb)]</thumb>
-							<visible>!IsEmpty(Window.Property(LatestEpisode.10.EpisodeTitle))</visible>
+							<visible>!system.hasaddon(service.skin.widgets) + !IsEmpty(Window.Property(LatestEpisode.10.EpisodeTitle))</visible>
 						</item>
 					</content>
 				</control>


### PR DESCRIPTION
This is a long requested feature for the Confluence skin that enables
recently unwatched items on the home screen for movies, tv shows and
albums instead of latest items. This does not add a dependency to
service.skin.widgets, but only uses it if its present. Works great.
Should also be ported to re-Touched.
