### PR TITLE
[database] - add setting for hiding watched movies/episodes in recently added lists

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -11176,7 +11176,13 @@ msgctxt "#20469"
 msgid "Keep current set (%s)"
 msgstr ""
 
-#empty strings from id 20470 to 21329
+#. Label of setting "Videos -> Library -> Hide watched videos in recently added list (home screen)"
+#: system/settings/settings.xml
+msgctxt "#20470"
+msgid "Hide watched videos in recently added list (home screen)"
+msgstr ""
+
+#empty strings from id 20471 to 21329
 #up to 21329 is reserved for the video db !! !
 
 #: system/settings/settings.xml
@@ -16012,7 +16018,13 @@ msgctxt "#36435"
 msgid "Use DVDPlayer for decoding of video files with MMAL acceleration."
 msgstr ""
 
-#empty strings from id 36436 to 36499
+#. Description of setting "Videos -> Library -> Hide watched videos in recently added list."
+#: system/settings/settings.xml
+msgctxt "#36436"
+msgid "If enabled all watched items in the recently added list on the home screen will be hidden. This includes movies, episodes and musicvideos. The effect depends on the used skin and its settings."
+msgstr ""
+
+#empty strings from id 36437 to 36499
 #end reservation
 
 #. label of a setting for the stereoscopic 3D mode of the GUI that is/should be applied

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -463,6 +463,11 @@
           <default>false</default>
           <control type="toggle" />
         </setting>
+        <setting id="videolibrary.hiderecentlywatchedvideos" type="boolean" label="20470" help="36436">
+          <level>1</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
       </group>
       <group id="2">
         <setting id="videolibrary.updateonstartup" type="boolean" label="22000" help="36146">

--- a/xbmc/utils/RecentlyAddedJob.cpp
+++ b/xbmc/utils/RecentlyAddedJob.cpp
@@ -31,6 +31,7 @@
 #include "utils/Variant.h"
 #include "utils/StringUtils.h"
 #include "settings/AdvancedSettings.h"
+#include "settings/Settings.h"
 #include "music/MusicThumbLoader.h"
 #include "video/VideoThumbLoader.h"
 
@@ -57,8 +58,8 @@ bool CRecentlyAddedJob::UpdateVideo()
   loader.OnLoaderStart();
   
   videodatabase.Open();
-
-  if (videodatabase.GetRecentlyAddedMoviesNav("videodb://recentlyaddedmovies/", items, NUM_ITEMS))
+  bool hideWatched = CSettings::Get().GetBool("videolibrary.hiderecentlywatchedvideos");
+  if (videodatabase.GetRecentlyAddedMoviesNav("videodb://recentlyaddedmovies/", items, NUM_ITEMS, hideWatched))
   {  
     for (; i < items.Size(); ++i)
     {
@@ -97,8 +98,7 @@ bool CRecentlyAddedJob::UpdateVideo()
  
   i = 0;
   CFileItemList  TVShowItems; 
- 
-  if (videodatabase.GetRecentlyAddedEpisodesNav("videodb://recentlyaddedepisodes/", TVShowItems, NUM_ITEMS))
+  if (videodatabase.GetRecentlyAddedEpisodesNav("videodb://recentlyaddedepisodes/", TVShowItems, NUM_ITEMS, hideWatched))
   {
     for (; i < TVShowItems.Size(); ++i)
     {    
@@ -151,7 +151,7 @@ bool CRecentlyAddedJob::UpdateVideo()
   i = 0;
   CFileItemList MusicVideoItems;
 
-  if (videodatabase.GetRecentlyAddedMusicVideosNav("videodb://recentlyaddedmusicvideos/", MusicVideoItems, NUM_ITEMS))
+  if (videodatabase.GetRecentlyAddedMusicVideosNav("videodb://recentlyaddedmusicvideos/", MusicVideoItems, NUM_ITEMS, hideWatched))
   {
     for (; i < MusicVideoItems.Size(); ++i)
     {

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -6579,27 +6579,48 @@ bool CVideoDatabase::GetMusicVideosNav(const std::string& strBaseDir, CFileItemL
   return GetMusicVideosByWhere(videoUrl.ToString(), filter, items, true, sortDescription);
 }
 
-bool CVideoDatabase::GetRecentlyAddedMoviesNav(const std::string& strBaseDir, CFileItemList& items, unsigned int limit)
+bool CVideoDatabase::GetRecentlyAddedMoviesNav(const std::string& strBaseDir, CFileItemList& items, unsigned int limit, bool hideWatched)
 {
   Filter filter;
   filter.order = "dateAdded desc, idMovie desc";
   filter.limit = PrepareSQL("%u", limit ? limit : g_advancedSettings.m_iVideoLibraryRecentlyAddedItems);
+
+  if (hideWatched)
+  {
+    filter.AppendWhere("playCount <= 0");// only query unwatched items
+    filter.AppendWhere("playCount IS NULL", false);
+  }
+
   return GetMoviesByWhere(strBaseDir, filter, items);
 }
 
-bool CVideoDatabase::GetRecentlyAddedEpisodesNav(const std::string& strBaseDir, CFileItemList& items, unsigned int limit)
+bool CVideoDatabase::GetRecentlyAddedEpisodesNav(const std::string& strBaseDir, CFileItemList& items, unsigned int limit, bool hideWatched)
 {
   Filter filter;
   filter.order = "dateAdded desc, idEpisode desc";
   filter.limit = PrepareSQL("%u", limit ? limit : g_advancedSettings.m_iVideoLibraryRecentlyAddedItems);
+
+  if (hideWatched)
+  {
+    filter.AppendWhere("playCount <= 0");// only query unwatched items
+    filter.AppendWhere("playCount IS NULL", false);
+  }
+
   return GetEpisodesByWhere(strBaseDir, filter, items, false);
 }
 
-bool CVideoDatabase::GetRecentlyAddedMusicVideosNav(const std::string& strBaseDir, CFileItemList& items, unsigned int limit)
+bool CVideoDatabase::GetRecentlyAddedMusicVideosNav(const std::string& strBaseDir, CFileItemList& items, unsigned int limit, bool hideWatched)
 {
   Filter filter;
   filter.order = "dateAdded desc, idMVideo desc";
   filter.limit = PrepareSQL("%u", limit ? limit : g_advancedSettings.m_iVideoLibraryRecentlyAddedItems);
+
+  if (hideWatched)
+  {
+    filter.AppendWhere("playCount <= 0");// only query unwatched items
+    filter.AppendWhere("playCount IS NULL", false);
+  }
+
   return GetMusicVideosByWhere(strBaseDir, filter, items);
 }
 

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -683,9 +683,9 @@ public:
   bool GetEpisodesNav(const std::string& strBaseDir, CFileItemList& items, int idGenre=-1, int idYear=-1, int idActor=-1, int idDirector=-1, int idShow=-1, int idSeason=-1, const SortDescription &sortDescription = SortDescription());
   bool GetMusicVideosNav(const std::string& strBaseDir, CFileItemList& items, int idGenre=-1, int idYear=-1, int idArtist=-1, int idDirector=-1, int idStudio=-1, int idAlbum=-1, int idTag=-1, const SortDescription &sortDescription = SortDescription());
   
-  bool GetRecentlyAddedMoviesNav(const std::string& strBaseDir, CFileItemList& items, unsigned int limit=0);
-  bool GetRecentlyAddedEpisodesNav(const std::string& strBaseDir, CFileItemList& items, unsigned int limit=0);
-  bool GetRecentlyAddedMusicVideosNav(const std::string& strBaseDir, CFileItemList& items, unsigned int limit=0);
+  bool GetRecentlyAddedMoviesNav(const std::string& strBaseDir, CFileItemList& items, unsigned int limit=0, bool hideWatched=false);
+  bool GetRecentlyAddedEpisodesNav(const std::string& strBaseDir, CFileItemList& items, unsigned int limit=0, bool hideWatched=false);
+  bool GetRecentlyAddedMusicVideosNav(const std::string& strBaseDir, CFileItemList& items, unsigned int limit=0, bool hideWatched=false);
 
   bool HasContent();
   bool HasContent(VIDEODB_CONTENT_TYPE type);


### PR DESCRIPTION
This is the c++ alternative to #5745

Not sure if i got the intention right. Not even sure why i joined that party tbh.

This basically adds 2 settings "Hide watched movies in recently added list." and "Hide watched episodes in recently added list." to the videos->Library section which does exactly that (and yes - this setting influences all recently added lists for movies/episodes - not only the ones on the home screen).

@MartijnKaijser let me know if this hits the feature request (i was kinda sick to read it completely and have the feeling that the bikeshedding didn't happen yet - so lets start it).

I\* as its a feature... (this is btw not even compile tested yet ...)
