### PR TITLE
[python] add legacy deps. loading as fallback when running standalone script

### DIFF
--- a/xbmc/interfaces/python/PythonInvoker.cpp
+++ b/xbmc/interfaces/python/PythonInvoker.cpp
@@ -196,6 +196,17 @@ bool CPythonInvoker::execute(const std::string &script, const std::vector<std::s
     for (std::set<std::string>::const_iterator it = paths.begin(); it != paths.end(); ++it)
       addPath(*it);
   }
+  else
+  { // for backwards compatibility.
+    // we don't have any addon so just add all addon modules installed
+    CLog::Log(LOGWARNING, "CPythonInvoker(%d): Script invoked without an addon. Adding all addon "
+        "modules installed to python path as fallback. This behaviour will be removed in future "
+        "version.", GetId());
+    ADDON::VECADDONS addons;
+    ADDON::CAddonMgr::Get().GetAddons(ADDON::ADDON_SCRIPT_MODULE, addons);
+    for (unsigned int i = 0; i < addons.size(); ++i)
+      addPath(CSpecialProtocol::TranslatePath(addons[i]->LibPath()));
+  }
 
   // we want to use sys.path so it includes site-packages
   // if this fails, default to using Py_GetPath


### PR DESCRIPTION
This was always an unintentional side effect of #5201. A couple of addons depends on this old behavior, so no problem adding backwards compatibility and warn instead.
