### PR TITLE
[Fix][win32] Discs that were present at start are not removed from views...

### DIFF
--- a/xbmc/windowing/windows/WinEventsWin32.cpp
+++ b/xbmc/windowing/windows/WinEventsWin32.cpp
@@ -770,7 +770,7 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
               // optical medium
               if (lpdbv -> dbcv_flags & DBTF_MEDIA)
               {
-                CStdString strdrive = StringUtils::Format("%c:\\", CWIN32Util::FirstDriveFromMask(lpdbv ->dbcv_unitmask));
+                CStdString strdrive = StringUtils::Format("%c:", CWIN32Util::FirstDriveFromMask(lpdbv ->dbcv_unitmask));
                 if(wParam == DBT_DEVICEARRIVAL)
                 {
                   CLog::Log(LOGDEBUG, __FUNCTION__": Drive %s Media has arrived.", strdrive.c_str());


### PR DESCRIPTION
... when ejecting them.

This bug annoyed me for quite some time. Today it must die.
Steps to reproduce the following screenshot:
- disc is present at start up
- remove disc
- insert disc

![screenshot000](https://cloud.githubusercontent.com/assets/2150851/5088830/c8659bfa-6f36-11e4-888e-0459aa9e484a.png)

If we prefer to have `x:\` instead of `x:`, this can be fixed by removing 939/940 https://github.com/xbmc/xbmc/blob/master/xbmc/win32/WIN32Util.cpp#L939
