### PR TITLE
[addons] hide broken not installed addons

### DIFF
--- a/xbmc/addons/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/GUIWindowAddonBrowser.cpp
@@ -378,6 +378,17 @@ bool CGUIWindowAddonBrowser::GetDirectory(const std::string& strDirectory,
           items.Remove(i);
       }
     }
+
+    // hide broken
+    for (int i = items.Size() - 1; i >= 0; i--)
+    {
+      if (!items[i]->GetProperty("Addon.Broken").empty())
+      { //check if it's installed
+        AddonPtr addon;
+        if (!CAddonMgr::Get().GetAddon(items[i]->GetProperty("Addon.ID").asString(), addon))
+          items.Remove(i);
+      }
+    }
   }
 
   if (strDirectory.empty() && CAddonInstaller::Get().IsDownloading())


### PR DESCRIPTION
Alternative to #5749. No toggle, just hides broken addons (that isn't installed)
@MartijnKaijser 
