### PR TITLE
library: don't remove the source if the user has changed his mind

### DIFF
--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -371,16 +371,17 @@ bool CGUIDialogContextMenu::OnContextButton(const std::string &type, const CFile
         return false;
     }
     // prompt user if they want to really delete the source
-    if (CGUIDialogYesNo::ShowAndGetInput(751, 0, 750, 0))
-    { // check default before we delete, as deletion will kill the share object
-      std::string defaultSource(GetDefaultShareNameByType(type));
-      if (!defaultSource.empty())
-      {
-        if (share->strName == defaultSource)
-          ClearDefault(type);
-      }
-      CMediaSourceSettings::Get().DeleteSource(type, share->strName, share->strPath);
+    if (!CGUIDialogYesNo::ShowAndGetInput(751, 0, 750, 0))
+      return false;
+
+    // check default before we delete, as deletion will kill the share object
+    std::string defaultSource(GetDefaultShareNameByType(type));
+    if (!defaultSource.empty())
+    {
+      if (share->strName == defaultSource)
+        ClearDefault(type);
     }
+    CMediaSourceSettings::Get().DeleteSource(type, share->strName, share->strPath);
     return true;
   }
   case CONTEXT_BUTTON_SET_DEFAULT:


### PR DESCRIPTION
@MartijnKaijser made me aware of the fact that when a user chooses "Remove source" on a music source but then says "No" in the "Are you sure?" dialog it still asks whether the removed source should be cleaned. After looking into it I noticed that the same problem existed for video sources. Even worse it actually removes the source independent of whether you choose "Yes" or "No".

Hint: use `?w=1` for easier review.
