### PR TITLE
[pvr] Fix recording history (alternative to #5742)

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -666,12 +666,6 @@ bool CGUIWindowPVRBase::UpdateEpgForChannel(CFileItem *item)
   return true;
 }
 
-bool CGUIWindowPVRBase::Update(const std::string &strDirectory, bool updateFilterPath /* = true */)
-{
-  m_vecItems->SetPath(strDirectory);
-  return CGUIMediaWindow::Update(strDirectory, updateFilterPath);
-}
-
 void CGUIWindowPVRBase::UpdateButtons(void)
 {
   CGUIMediaWindow::UpdateButtons();

--- a/xbmc/pvr/windows/GUIWindowPVRBase.h
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.h
@@ -59,7 +59,6 @@ namespace PVR
     virtual bool OnMessage(CGUIMessage& message);
     virtual bool OnContextButton(int itemNumber, CONTEXT_BUTTON button);
     virtual bool OnContextButton(const CFileItem &item, CONTEXT_BUTTON button) { return false; };
-    virtual bool Update(const std::string &strDirectory, bool updateFilterPath = true);
     virtual void UpdateButtons(void);
     virtual bool OnAction(const CAction &action);
     virtual bool OnBack(int actionID);


### PR DESCRIPTION
I had to revert the previous attempt to fix this since it broke other parts of the code that in one way or another relied on the view state. This new attempt fixes the original problem in a more isolated (albeit uglier) way by storing the directory we're about to enter (in `Update()`) in the view state. This directory is then checked by the view state in `HideParentDirItems()`.

@xhaggi @opdenkamp @topfs2 is this okay with you? I'll test this "in production" later today to ensure there are no unexpected side effects.
