### PR TITLE
[Fix] Some manually activated subs were not shown on resume.

### DIFF
--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -510,6 +510,7 @@ void CApplicationPlayer::SetSubtitleVisible(bool bVisible)
   {
     player->SetSubtitleVisible(bVisible);
     CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleOn = bVisible;
+    CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleStream = player->GetSubtitle();
   }
 }
 


### PR DESCRIPTION
As a replacement of #5434
Thx  @Jalle19 for the initial pr.

Manually activated subs, if classified as irrelevant, were not shown on resume.
This is fixed by saving the subtitle's index upon manual activation.
