### PR TITLE
jobs: fixed segmentation fault when thumbnail loader abort

### DIFF
--- a/xbmc/utils/JobManager.h
+++ b/xbmc/utils/JobManager.h
@@ -298,7 +298,7 @@ protected:
    \return true if the job has been cancelled, else returns false.
    \sa IJobCallback, CJob
    */
-  bool  OnJobProgress(unsigned int progress, unsigned int total, const CJob *job) const;
+  bool  OnJobProgress(unsigned int progress, unsigned int total, const CJob *job);
 
 private:
   // private construction, and no assignements; use the provided singleton methods
@@ -330,4 +330,7 @@ private:
   CCriticalSection m_section;
   CEvent           m_jobEvent;
   bool             m_running;
+
+  XbmcThreads::ConditionVariable m_tangle_cond;
+  unsigned int     m_tangle;  /*!< Active callbacks currently running */
 };


### PR DESCRIPTION
JobManager grab a copy of the CWorkItem then release the lock,
if the cancel occurs right then. The callback can be in progress
after the CancelJob finishes.

Several locations assume it's safe to delete the callback target
after having cancelled pending jobs, so make sure we wait for
any in progress job completions or job progress calls.
