### PR TITLE
[AE/CA] - fix regression introduced in the enumeration refactor - handle "hackintosh" audio devices with "digital" in the name as digital devices

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/osx/AEDeviceEnumerationOSX.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/osx/AEDeviceEnumerationOSX.cpp
@@ -97,7 +97,7 @@ bool AEDeviceEnumerationOSX::isDigitalDevice() const
   // ca devices ...
   if (!isDigital)
   {
-    std::string devNameLower = m_deviceName;
+    std::string devNameLower = m_caDevice.GetName();
     StringUtils::ToLower(devNameLower);                       
     isDigital = devNameLower.find("digital") != std::string::npos;
   }

--- a/xbmc/cores/AudioEngine/Sinks/osx/CoreAudioDevice.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/osx/CoreAudioDevice.cpp
@@ -206,7 +206,7 @@ bool CCoreAudioDevice::RemoveIOProc()
   return true;
 }
 
-std::string CCoreAudioDevice::GetName()
+std::string CCoreAudioDevice::GetName() const
 {
   if (!m_DeviceId)
     return "";

--- a/xbmc/cores/AudioEngine/Sinks/osx/CoreAudioDevice.h
+++ b/xbmc/cores/AudioEngine/Sinks/osx/CoreAudioDevice.h
@@ -50,7 +50,7 @@ public:
   bool          SetObjectListenerProc(AudioObjectPropertyListenerProc callback, void *pClientData);
   
   AudioDeviceID GetId() {return m_DeviceId;}
-  std::string   GetName();
+  std::string   GetName() const;
   bool          IsDigital() const;
   UInt32        GetTransportType() const;
   UInt32        GetTotalOutputChannels() const;


### PR DESCRIPTION
As the title says. The IsDigitalDevice relied on the m_devicename member which was not initialised at the point of calling. Use the GetName from the CaDevice directly for this to ensure its always valid.

Waiting for user feedback and should be included into helix afterwards (regression from gotham).

Fixes missing passthrough options for devices which have "digital" in the name but are announced as PCM only on osx.
