### PR TITLE
fixed build for wayland backend. Avoid including X11 headers

### DIFF
--- a/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
@@ -67,6 +67,9 @@ extern "C" {
 #include "osx/DarwinUtils.h"
 #endif
 #if defined(HAS_LIBSTAGEFRIGHT)
+#if defined(HAVE_WAYLAND)
+#include <wayland-egl.h>
+#endif
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
 #include "windowing/egl/EGLWrapper.h"

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/OpenMaxVideo.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/OpenMaxVideo.h
@@ -22,6 +22,9 @@
 #if defined(HAVE_LIBOPENMAX)
 
 #include "OpenMax.h"
+#if defined(HAVE_WAYLAND)
+#include <wayland-egl.h>
+#endif
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
 #include <GLES2/gl2.h>

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/libstagefrightICS/StageFrightVideo.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/libstagefrightICS/StageFrightVideo.cpp
@@ -39,7 +39,9 @@
 #include "android/jni/Build.h"
 
 #include "xbmc/guilib/FrameBufferObject.h"
-
+#if defined(HAVE_WAYLAND)
+#include <wayland-egl.h>
+#endif
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
 #include "windowing/egl/EGLWrapper.h"

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/libstagefrightICS/StageFrightVideoPrivate.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/libstagefrightICS/StageFrightVideoPrivate.cpp
@@ -23,6 +23,9 @@
 
 #include "StageFrightVideoPrivate.h"
 
+#if defined(HAVE_WAYLAND)
+#include <wayland-egl.h>
+#endif
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
 #include <GLES2/gl2.h>

--- a/xbmc/cores/omxplayer/OMXImage.h
+++ b/xbmc/cores/omxplayer/OMXImage.h
@@ -34,6 +34,9 @@
 #include "guilib/XBTF.h"
 #endif
 
+#if defined(HAVE_WAYLAND)
+#include <wayland-egl.h>
+#endif
 #include "system_gl.h"
 #include <EGL/egl.h>
 #include <EGL/eglext.h>

--- a/xbmc/windowing/egl/EGLNativeTypeAmlogic.cpp
+++ b/xbmc/windowing/egl/EGLNativeTypeAmlogic.cpp
@@ -26,6 +26,9 @@
 #include <stdlib.h>
 #include <linux/fb.h>
 #include <sys/ioctl.h>
+#if defined(HAVE_WAYLAND)
+#include <wayland-egl.h>
+#endif
 #include <EGL/egl.h>
 
 CEGLNativeTypeAmlogic::CEGLNativeTypeAmlogic()

--- a/xbmc/windowing/egl/EGLNativeTypeAndroid.cpp
+++ b/xbmc/windowing/egl/EGLNativeTypeAndroid.cpp
@@ -19,6 +19,9 @@
  */
 
 #include "system.h"
+#if defined(HAVE_WAYLAND)
+#include <wayland-egl.h>
+#endif
 #include <EGL/egl.h>
 #include "EGLNativeTypeAndroid.h"
 #include "utils/log.h"

--- a/xbmc/windowing/egl/EGLNativeTypeIMX.cpp
+++ b/xbmc/windowing/egl/EGLNativeTypeIMX.cpp
@@ -19,6 +19,9 @@
  */
 
 #include "system.h"
+#if defined(HAVE_WAYLAND)
+#include <wayland-egl.h>
+#endif
 #include <EGL/egl.h>
 
 #include "EGLNativeTypeIMX.h"

--- a/xbmc/windowing/egl/EGLNativeTypeRaspberryPI.cpp
+++ b/xbmc/windowing/egl/EGLNativeTypeRaspberryPI.cpp
@@ -19,6 +19,9 @@
  */
 #include "system.h"
 
+#if defined(HAVE_WAYLAND)
+#include <wayland-egl.h>
+#endif
 #include <EGL/egl.h>
 #include <math.h>
 #include "EGLNativeTypeRaspberryPI.h"

--- a/xbmc/windowing/egl/EGLNativeTypeWayland.h
+++ b/xbmc/windowing/egl/EGLNativeTypeWayland.h
@@ -22,6 +22,9 @@
 
 #include <boost/scoped_ptr.hpp>
 
+#if defined(HAVE_WAYLAND)
+#include <wayland-egl.h>
+#endif
 #include <EGL/egl.h>
 #include "EGLNativeType.h"
 

--- a/xbmc/windowing/egl/EGLWrapper.h
+++ b/xbmc/windowing/egl/EGLWrapper.h
@@ -21,6 +21,9 @@
  */
 
 #include "guilib/Resolution.h"
+#if defined(HAVE_WAYLAND)
+#include <wayland-egl.h>
+#endif
 #include <EGL/egl.h>
 class CEGLNativeType;
 class CEGLWrapper

--- a/xbmc/windowing/egl/WinSystemEGL.h
+++ b/xbmc/windowing/egl/WinSystemEGL.h
@@ -25,6 +25,9 @@
 
 #include "rendering/gles/RenderSystemGLES.h"
 #include "utils/GlobalsHandling.h"
+#if defined(HAVE_WAYLAND)
+#include <wayland-egl.h>
+#endif
 #include <EGL/egl.h>
 #include "windowing/WinSystem.h"
 


### PR DESCRIPTION
/usr/include/EGL/eglplatform.h:118:22: fatal error: X11/Xlib.h: No such file or directory

Before including <EGL/egl.h> correct egl platform should be defined. Added include for wayland case.

Signed-off-by: Andriy Prystupa andriy.prystupa@globallogic.com
