### PR TITLE
Fix namespace typo

### DIFF
--- a/xbmc/interfaces/json-rpc/PlayerOperations.h
+++ b/xbmc/interfaces/json-rpc/PlayerOperations.h
@@ -22,7 +22,7 @@
 #include "JSONRPC.h"
 #include "FileItemHandler.h"
 
-namespace EGP
+namespace EPG
 {
   class CEpgInfoTag;
 }


### PR DESCRIPTION
Since the namespace was incorrectly spelled, the forward declaration inside it hasn't actually been needed. It's used in the file but I guess the necessary header is included elsewhere. The alternative is to remove this forward declaration completely but I think this is safer.

@topfs2 should be an easy one
