### PR TITLE
[jenkins] - refactor jenkins scripts to centralise the decision for

### DIFF
--- a/tools/buildsteps/android/configure-depends
+++ b/tools/buildsteps/android/configure-depends
@@ -2,7 +2,7 @@ WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
 XBMC_PLATFORM_DIR=android
 . $WORKSPACE/tools/buildsteps/defaultenv
 
-if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
+if [ "$(rebuildDepends)" == "1" ]
 then
   cd $WORKSPACE/tools/depends;./configure \
     --with-tarballs=$TARBALLS \

--- a/tools/buildsteps/android/make-depends
+++ b/tools/buildsteps/android/make-depends
@@ -2,8 +2,8 @@ WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
 XBMC_PLATFORM_DIR=android
 . $WORKSPACE/tools/buildsteps/defaultenv
 
-if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
+if [ "$(rebuildDepends)" == "1" ]
 then
-  cd $WORKSPACE/tools/depends;make -j $BUILDTHREADS && tagSuccessFulBuild .
+  cd $WORKSPACE/tools/depends;make -j $BUILDTHREADS && tagSuccessFulDependsBuild
 fi
 

--- a/tools/buildsteps/android/prepare-depends
+++ b/tools/buildsteps/android/prepare-depends
@@ -3,9 +3,9 @@ XBMC_PLATFORM_DIR=android
 . $WORKSPACE/tools/buildsteps/defaultenv
 
 #clean without depends for skipping depends build if possible
-cd $WORKSPACE;git clean -xfd -e "tools/depends"
+cd $WORKSPACE;git clean -xfd -e "project/cmake/.last_success_revision" -e "tools/depends"
 
-if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
+if [ "$(rebuildDepends)" == "1" ]
 then
   #clean up the rest too
   cd $WORKSPACE;git clean -xffd

--- a/tools/buildsteps/androidx86/configure-depends
+++ b/tools/buildsteps/androidx86/configure-depends
@@ -2,7 +2,7 @@ WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
 XBMC_PLATFORM_DIR=android
 . $WORKSPACE/tools/buildsteps/defaultenv
 
-if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
+if [ "$(rebuildDepends)" == "1" ]
 then
   cd $WORKSPACE/tools/depends;./configure \
     --with-tarballs=$TARBALLS \

--- a/tools/buildsteps/androidx86/make-depends
+++ b/tools/buildsteps/androidx86/make-depends
@@ -2,8 +2,8 @@ WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
 XBMC_PLATFORM_DIR=android
 . $WORKSPACE/tools/buildsteps/defaultenv
 
-if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
+if [ "$(rebuildDepends)" == "1" ]
 then
-  cd $WORKSPACE/tools/depends;make -j $BUILDTHREADS && tagSuccessFulBuild .
+  cd $WORKSPACE/tools/depends;make -j $BUILDTHREADS && tagSuccessFulDependsBuild
 fi
 

--- a/tools/buildsteps/androidx86/prepare-depends
+++ b/tools/buildsteps/androidx86/prepare-depends
@@ -3,9 +3,9 @@ XBMC_PLATFORM_DIR=android
 . $WORKSPACE/tools/buildsteps/defaultenv
 
 #clean without depends for skipping depends build if possible
-cd $WORKSPACE;git clean -xfd -e "tools/depends"
+cd $WORKSPACE;git clean -xfd -e "project/cmake/.last_success_revision" -e "tools/depends"
 
-if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
+if [ "$(rebuildDepends)" == "1" ]
 then
   #clean up the rest too
   cd $WORKSPACE;git clean -xffd

--- a/tools/buildsteps/atv2/configure-depends
+++ b/tools/buildsteps/atv2/configure-depends
@@ -2,7 +2,7 @@ WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
 XBMC_PLATFORM_DIR=atv2
 . $WORKSPACE/tools/buildsteps/defaultenv
 
-if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
+if [ "$(rebuildDepends)" == "1" ]
 then
   cd $WORKSPACE/tools/depends;./configure \
     --with-tarballs=/Users/Shared/xbmc-depends/tarballs \

--- a/tools/buildsteps/atv2/make-depends
+++ b/tools/buildsteps/atv2/make-depends
@@ -2,8 +2,8 @@ WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
 XBMC_PLATFORM_DIR=atv2
 . $WORKSPACE/tools/buildsteps/defaultenv
 
-if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
+if [ "$(rebuildDepends)" == "1" ]
 then
-  cd $WORKSPACE/tools/depends;make -j $BUILDTHREADS && tagSuccessFulBuild .
+  cd $WORKSPACE/tools/depends;make -j $BUILDTHREADS && tagSuccessFulDependsBuild
 fi
 

--- a/tools/buildsteps/atv2/prepare-depends
+++ b/tools/buildsteps/atv2/prepare-depends
@@ -4,9 +4,9 @@ XBMC_PLATFORM_DIR=atv2
 
 #clean without depends for skipping depends build if possible
 #also skip binary addons (pvr, audioencoder) as long as they are deployed in tree
-cd $WORKSPACE;git clean -xfd -e "tools/depends" -e "addons/pvr.*" -e "addons/audioencoder.*"
+cd $WORKSPACE;git clean -xfd -e "project/cmake/.last_success_revision" -e "tools/depends" -e "addons/pvr.*" -e "addons/audioencoder.*"
 
-if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
+if [ "$(rebuildDepends)" == "1" ]
 then
   #clean up the rest too
   cd $WORKSPACE;git clean -xffd

--- a/tools/buildsteps/defaultenv
+++ b/tools/buildsteps/defaultenv
@@ -100,7 +100,7 @@ function pathChanged ()
   checkPath="$1"
   if [ -e $checkPath/$PATH_CHANGE_REV_FILENAME ]
   then
-    if [ "$(cat $checkPath/$PATH_CHANGE_REV_FILENAME)" != "$(getBuildHash $WORKSPACE/tools/depends)" ]
+    if [ "$(cat $checkPath/$PATH_CHANGE_REV_FILENAME)" != "$(getBuildHash $checkPath)" ]
     then
       ret="1"
     fi
@@ -111,11 +111,26 @@ function pathChanged ()
   echo $ret
 }
 
-function tagSuccessFulBuild ()
+function rebuildDepends ()
 {
-  local checkPath
-  checkPath="$1"
-  echo "$(getBuildHash $checkPath)" > $checkPath/$PATH_CHANGE_REV_FILENAME
+  local ret
+  ret="0"
+  # check if depends need to be rebuilt - this is done by checking last
+  # successfull build revision of depends and cmake dir
+  if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ] || [ "$(pathChanged $WORKSPACE/project/cmake)" == "1" ]
+  then
+    ret="1"
+  fi
+
+  echo $ret
+}
+
+function tagSuccessFulDependsBuild ()
+{
+  # tag last successful build of depends by marking the revisions of depends and cmake dir
+  # needs to match the checks in function rebuildDepends
+  echo "$(getBuildHash $WORKSPACE/tools/depends)" > $WORKSPACE/tools/depends/$PATH_CHANGE_REV_FILENAME
+  echo "$(getBuildHash $WORKSPACE/project/cmake)" > $WORKSPACE/project/cmake/$PATH_CHANGE_REV_FILENAME
 }
 
 function getBranchName ()

--- a/tools/buildsteps/ios/configure-depends
+++ b/tools/buildsteps/ios/configure-depends
@@ -2,7 +2,7 @@ WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
 XBMC_PLATFORM_DIR=ios
 . $WORKSPACE/tools/buildsteps/defaultenv
 
-if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
+if [ "$(rebuildDepends)" == "1" ]
 then
   cd $WORKSPACE/tools/depends;./configure \
     --with-tarballs=/Users/Shared/xbmc-depends/tarballs \

--- a/tools/buildsteps/ios/make-depends
+++ b/tools/buildsteps/ios/make-depends
@@ -2,8 +2,8 @@ WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
 XBMC_PLATFORM_DIR=ios
 . $WORKSPACE/tools/buildsteps/defaultenv
 
-if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
+if [ "$(rebuildDepends)" == "1" ]
 then
-  cd $WORKSPACE/tools/depends;make -j $BUILDTHREADS && tagSuccessFulBuild .
+  cd $WORKSPACE/tools/depends;make -j $BUILDTHREADS && tagSuccessFulDependsBuild
 fi
 

--- a/tools/buildsteps/ios/prepare-depends
+++ b/tools/buildsteps/ios/prepare-depends
@@ -4,9 +4,9 @@ XBMC_PLATFORM_DIR=ios
 
 #clean without depends for skipping depends build if possible
 #also skip binary addons (pvr, audioencoder) as long as they are deployed in tree
-cd $WORKSPACE;git clean -xfd -e "tools/depends" -e "addons/pvr.*" -e "addons/audioencoder.*"
+cd $WORKSPACE;git clean -xfd -e "project/cmake/.last_success_revision" -e "tools/depends" -e "addons/pvr.*" -e "addons/audioencoder.*"
 
-if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
+if [ "$(rebuildDepends)" == "1" ]
 then
   #clean up the rest too
   cd $WORKSPACE;git clean -xffd

--- a/tools/buildsteps/linux32/configure-depends
+++ b/tools/buildsteps/linux32/configure-depends
@@ -2,7 +2,7 @@ WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
 XBMC_PLATFORM_DIR=linux32
 . $WORKSPACE/tools/buildsteps/defaultenv
 
-if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
+if [ "$(rebuildDepends)" == "1" ]
 then
   cd $WORKSPACE/tools/depends;./configure \
     --with-toolchain=/usr --prefix=$XBMC_DEPENDS_ROOT --host=i686-linux-gnu --with-tarballs=$TARBALLS

--- a/tools/buildsteps/linux32/make-depends
+++ b/tools/buildsteps/linux32/make-depends
@@ -2,8 +2,8 @@ WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
 XBMC_PLATFORM_DIR=linux32
 . $WORKSPACE/tools/buildsteps/defaultenv
 
-if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
+if [ "$(rebuildDepends)" == "1" ]
 then
-  cd $WORKSPACE/tools/depends;make -j $BUILDTHREADS && tagSuccessFulBuild .
+  cd $WORKSPACE/tools/depends;make -j $BUILDTHREADS && tagSuccessFulDependsBuild
 fi
 

--- a/tools/buildsteps/linux32/prepare-depends
+++ b/tools/buildsteps/linux32/prepare-depends
@@ -3,9 +3,9 @@ XBMC_PLATFORM_DIR=linux32
 . $WORKSPACE/tools/buildsteps/defaultenv
 
 #clean without depends for skipping depends build if possible
-cd $WORKSPACE;git clean -xfd -e "tools/depends"
+cd $WORKSPACE;git clean -xfd -e "project/cmake/.last_success_revision" -e "tools/depends"
 
-if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
+if [ "$(rebuildDepends)" == "1" ]
 then
   #clean up the rest too
   cd $WORKSPACE;git clean -xffd

--- a/tools/buildsteps/linux64/configure-depends
+++ b/tools/buildsteps/linux64/configure-depends
@@ -2,7 +2,7 @@ WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
 XBMC_PLATFORM_DIR=linux64
 . $WORKSPACE/tools/buildsteps/defaultenv
 
-if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
+if [ "$(rebuildDepends)" == "1" ]
 then
   cd $WORKSPACE/tools/depends;./configure \
     --with-toolchain=/usr --prefix=$XBMC_DEPENDS_ROOT --host=x86_64-linux-gnu --with-tarballs=$TARBALLS

--- a/tools/buildsteps/linux64/make-depends
+++ b/tools/buildsteps/linux64/make-depends
@@ -2,8 +2,8 @@ WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
 XBMC_PLATFORM_DIR=linux64
 . $WORKSPACE/tools/buildsteps/defaultenv
 
-if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
+if [ "$(rebuildDepends)" == "1" ]
 then
-  cd $WORKSPACE/tools/depends;make -j $BUILDTHREADS || make && tagSuccessFulBuild .
+  cd $WORKSPACE/tools/depends;make -j $BUILDTHREADS || make && tagSuccessFulDependsBuild
 fi
 

--- a/tools/buildsteps/linux64/prepare-depends
+++ b/tools/buildsteps/linux64/prepare-depends
@@ -3,9 +3,9 @@ XBMC_PLATFORM_DIR=linux64
 . $WORKSPACE/tools/buildsteps/defaultenv
 
 #clean without depends for skipping depends build if possible
-cd $WORKSPACE;git clean -xfd -e "tools/depends"
+cd $WORKSPACE;git clean -xfd -e "project/cmake/.last_success_revision" -e "tools/depends"
 
-if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
+if [ "$(rebuildDepends)" == "1" ]
 then
   #clean up the rest too
   cd $WORKSPACE;git clean -xffd

--- a/tools/buildsteps/osx32/configure-depends
+++ b/tools/buildsteps/osx32/configure-depends
@@ -2,7 +2,7 @@ WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
 XBMC_PLATFORM_DIR=osx32
 . $WORKSPACE/tools/buildsteps/defaultenv
 
-if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
+if [ "$(rebuildDepends)" == "1" ]
 then
   cd $WORKSPACE/tools/depends;./configure \
     --with-tarballs=/Users/Shared/xbmc-depends/tarballs \

--- a/tools/buildsteps/osx32/make-depends
+++ b/tools/buildsteps/osx32/make-depends
@@ -2,8 +2,8 @@ WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
 XBMC_PLATFORM_DIR=osx32
 . $WORKSPACE/tools/buildsteps/defaultenv
 
-if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
+if [ "$(rebuildDepends)" == "1" ]
 then
-  cd $WORKSPACE/tools/depends;make -j $BUILDTHREADS && tagSuccessFulBuild .
+  cd $WORKSPACE/tools/depends;make -j $BUILDTHREADS && tagSuccessFulDependsBuild
 fi
 

--- a/tools/buildsteps/osx32/prepare-depends
+++ b/tools/buildsteps/osx32/prepare-depends
@@ -4,9 +4,9 @@ XBMC_PLATFORM_DIR=osx32
 
 #clean without depends for skipping depends build if possible
 #also skip binary addons (pvr, audioencoder) as long as they are deployed in tree
-cd $WORKSPACE;git clean -xfd -e "tools/depends" -e "addons/pvr.*" -e "addons/audioencoder.*"
+cd $WORKSPACE;git clean -xfd -e "project/cmake/.last_success_revision" -e "tools/depends" -e "addons/pvr.*" -e "addons/audioencoder.*"
 
-if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
+if [ "$(rebuildDepends)" == "1" ]
 then
   #clean up the rest too
   cd $WORKSPACE;git clean -xffd

--- a/tools/buildsteps/osx64/configure-depends
+++ b/tools/buildsteps/osx64/configure-depends
@@ -2,7 +2,7 @@ WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
 XBMC_PLATFORM_DIR=osx64
 . $WORKSPACE/tools/buildsteps/defaultenv
 
-if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
+if [ "$(rebuildDepends)" == "1" ]
 then
   cd $WORKSPACE/tools/depends;./configure \
     --with-tarballs=/Users/Shared/xbmc-depends/tarballs \

--- a/tools/buildsteps/osx64/make-depends
+++ b/tools/buildsteps/osx64/make-depends
@@ -2,8 +2,8 @@ WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
 XBMC_PLATFORM_DIR=osx64
 . $WORKSPACE/tools/buildsteps/defaultenv
 
-if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
+if [ "$(rebuildDepends)" == "1" ]
 then
-  cd $WORKSPACE/tools/depends;make -j $BUILDTHREADS && tagSuccessFulBuild .
+  cd $WORKSPACE/tools/depends;make -j $BUILDTHREADS && tagSuccessFulDependsBuild
 fi
 

--- a/tools/buildsteps/osx64/prepare-depends
+++ b/tools/buildsteps/osx64/prepare-depends
@@ -4,9 +4,9 @@ XBMC_PLATFORM_DIR=osx64
 
 #clean without depends for skipping depends build if possible
 #also skip binary addons (pvr, audioencoder) as long as they are deployed in tree
-cd $WORKSPACE;git clean -xfd -e "tools/depends" -e "addons/pvr.*" -e "addons/audioencoder.*"
+cd $WORKSPACE;git clean -xfd -e "project/cmake/.last_success_revision" -e "tools/depends" -e "addons/pvr.*" -e "addons/audioencoder.*"
 
-if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
+if [ "$(rebuildDepends)" == "1" ]
 then
   #clean up the rest too
   cd $WORKSPACE;git clean -xffd

--- a/tools/buildsteps/rbpi/configure-depends
+++ b/tools/buildsteps/rbpi/configure-depends
@@ -2,7 +2,7 @@ WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
 XBMC_PLATFORM_DIR=rbpi
 . $WORKSPACE/tools/buildsteps/defaultenv
 
-if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
+if [ "$(rebuildDepends)" == "1" ]
 then
   cd $WORKSPACE/tools/depends;
 

--- a/tools/buildsteps/rbpi/make-depends
+++ b/tools/buildsteps/rbpi/make-depends
@@ -2,8 +2,8 @@ WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
 XBMC_PLATFORM_DIR=rbpi
 . $WORKSPACE/tools/buildsteps/defaultenv
 
-if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
+if [ "$(rebuildDepends)" == "1" ]
 then
-  cd $WORKSPACE/tools/depends;make -j $BUILDTHREADS || make && tagSuccessFulBuild .
+  cd $WORKSPACE/tools/depends;make -j $BUILDTHREADS || make && tagSuccessFulDependsBuild
 fi
 

--- a/tools/buildsteps/rbpi/prepare-depends
+++ b/tools/buildsteps/rbpi/prepare-depends
@@ -3,7 +3,7 @@ XBMC_PLATFORM_DIR=rbpi
 . $WORKSPACE/tools/buildsteps/defaultenv
 
 #clean without depends for skipping depends build if possible
-cd $WORKSPACE;git clean -xfd -e "tools/depends"
+cd $WORKSPACE;git clean -xfd -e "project/cmake/.last_success_revision" -e "tools/depends"
 
 if [ -d $JENKINS_RBPI_DEVENV/firmware ]
 then
@@ -12,7 +12,7 @@ else
   cd $JENKINS_RBPI_DEVENV;git clone git://github.com/raspberrypi/firmware.git --depth=1 -b master
 fi
 
-if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
+if [ "$(rebuildDepends)" == "1" ]
 then
   #clean up the rest too
   cd $WORKSPACE;git clean -xffd


### PR DESCRIPTION
rebuilding depends - add project/cmake dir as criterion.

This ensures that jenkins rebuilds depends whenever project/cmake dir changes (for getting binary addons rebuilt).

see http://forum.kodi.tv/showthread.php?tid=208885&pid=1840594#pid1840594
