### PR TITLE
dvdplayer: fix race in UpdateClockMaster

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -4250,6 +4250,8 @@ void CDVDPlayer::UpdatePlayState(double timeout)
   else
     state.cache_bytes = 0;
 
+  UpdateClockMaster();
+
   state.timestamp = CDVDClock::GetAbsoluteClock();
 
   CSingleLock lock(m_StateSection);


### PR DESCRIPTION
at the time UpdateClockMaster is called video ref clock might not be running although it was activated. one reason may be a switch of refresh rate.
@popcornmix observered this

@elupus are you ok with this?
