### PR TITLE
SysInfo: show CPU frequency as "XXXX MHz" instead of "XXXX,00MHz"

### DIFF
--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -265,7 +265,7 @@ const CSysData &CSysInfoJob::GetData() const
 std::string CSysInfoJob::GetCPUFreqInfo()
 {
   double CPUFreq = GetCPUFrequency();
-  return StringUtils::Format("%4.2fMHz", CPUFreq);;
+  return StringUtils::Format("%4.0f MHz", CPUFreq);;
 }
 
 CSysData::INTERNET_STATE CSysInfoJob::GetInternetState()


### PR DESCRIPTION
As title says.
