### PR TITLE
RFC: removal of glGet*

### DIFF
--- a/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
@@ -39,6 +39,7 @@
 #include "windowing/WindowingFactory.h"
 #include "guilib/Texture.h"
 #include "guilib/LocalizeStrings.h"
+#include "guilib/MatrixGLES.h"
 #include "threads/SingleLock.h"
 #include "utils/log.h"
 #include "utils/GLUtils.h"
@@ -1382,21 +1383,22 @@ void CLinuxRendererGL::RenderToFBO(int index, int field, bool weave /*= false*/)
 
   glPushAttrib(GL_VIEWPORT_BIT);
   glPushAttrib(GL_SCISSOR_BIT);
-  glMatrixMode(GL_MODELVIEW);
-  glPushMatrix();
-  glLoadIdentity();
-  VerifyGLState();
+  g_matrices.MatrixMode(MM_MODELVIEW);
+  g_matrices.PushMatrix();
+  g_matrices.LoadIdentity();
 
-  glMatrixMode(GL_PROJECTION);
-  glPushMatrix();
-  glLoadIdentity();
-  VerifyGLState();
-  gluOrtho2D(0, m_sourceWidth, 0, m_sourceHeight);
+  g_matrices.MatrixMode(MM_PROJECTION);
+  g_matrices.PushMatrix();
+  g_matrices.LoadIdentity();
+  g_matrices.Ortho2D(0, m_sourceWidth, 0, m_sourceHeight);
+
   glViewport(0, 0, m_sourceWidth, m_sourceHeight);
   glScissor (0, 0, m_sourceWidth, m_sourceHeight);
-  glMatrixMode(GL_MODELVIEW);
-  VerifyGLState();
 
+  glMatrixMode(GL_PROJECTION);
+  glLoadMatrixf(g_matrices.GetMatrix(MM_PROJECTION));
+  glMatrixMode(GL_MODELVIEW);
+  glLoadMatrixf(g_matrices.GetMatrix(MM_MODELVIEW));
 
   if (!m_pYUVShader->Enable())
   {
@@ -1443,13 +1445,18 @@ void CLinuxRendererGL::RenderToFBO(int index, int field, bool weave /*= false*/)
 
   m_pYUVShader->Disable();
 
-  glMatrixMode(GL_MODELVIEW);
-  glPopMatrix(); // pop modelview
+  g_matrices.MatrixMode(MM_PROJECTION);
+  g_matrices.PopMatrix();
+  g_matrices.MatrixMode(MM_MODELVIEW);
+  g_matrices.PopMatrix();
+
   glMatrixMode(GL_PROJECTION);
-  glPopMatrix(); // pop projection
+  glLoadMatrixf(g_matrices.GetMatrix(MM_PROJECTION));
+  glMatrixMode(GL_MODELVIEW);
+  glLoadMatrixf(g_matrices.GetMatrix(MM_MODELVIEW));
+
   glPopAttrib(); // pop scissor
   glPopAttrib(); // pop viewport
-  glMatrixMode(GL_MODELVIEW);
   VerifyGLState();
 
   m_fbo.fbo.EndRender();
@@ -1683,10 +1690,12 @@ bool CLinuxRendererGL::RenderCapture(CRenderCapture* capture)
   //invert Y axis to get non-inverted image
   glDisable(GL_BLEND);
   glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
+  g_matrices.MatrixMode(MM_MODELVIEW);
+  g_matrices.PushMatrix();
+  g_matrices.Translatef(0, capture->GetHeight(), 0);
+  g_matrices.Scalef(1.0, -1.0f, 1.0f);
   glMatrixMode(GL_MODELVIEW);
-  glPushMatrix();
-  glTranslatef(0, capture->GetHeight(), 0);
-  glScalef(1.0, -1.0f, 1.0f);
+  glLoadMatrixf(g_matrices.GetMatrix(MM_MODELVIEW));
 
   capture->BeginRender();
 
@@ -1698,8 +1707,10 @@ bool CLinuxRendererGL::RenderCapture(CRenderCapture* capture)
   capture->EndRender();
 
   // revert model view matrix
+  g_matrices.MatrixMode(MM_MODELVIEW);
+  g_matrices.PopMatrix();
   glMatrixMode(GL_MODELVIEW);
-  glPopMatrix();
+  glLoadMatrixf(g_matrices.GetMatrix(MM_MODELVIEW));
 
   // restore original video rect
   m_destRect = saveSize;

--- a/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
@@ -1383,22 +1383,18 @@ void CLinuxRendererGL::RenderToFBO(int index, int field, bool weave /*= false*/)
 
   glPushAttrib(GL_VIEWPORT_BIT);
   glPushAttrib(GL_SCISSOR_BIT);
-  g_matrices.MatrixMode(MM_MODELVIEW);
-  g_matrices.PushMatrix();
-  g_matrices.LoadIdentity();
 
-  g_matrices.MatrixMode(MM_PROJECTION);
-  g_matrices.PushMatrix();
-  g_matrices.LoadIdentity();
-  g_matrices.Ortho2D(0, m_sourceWidth, 0, m_sourceHeight);
+  glMatrixModview.Push();
+  glMatrixModview->LoadIdentity();
+  glMatrixModview.Load();
+
+  glMatrixProject.Push();
+  glMatrixProject->LoadIdentity();
+  glMatrixProject->Ortho2D(0, m_sourceWidth, 0, m_sourceHeight);
+  glMatrixProject.Load();
 
   glViewport(0, 0, m_sourceWidth, m_sourceHeight);
   glScissor (0, 0, m_sourceWidth, m_sourceHeight);
-
-  glMatrixMode(GL_PROJECTION);
-  glLoadMatrixf(g_matrices.GetMatrix(MM_PROJECTION));
-  glMatrixMode(GL_MODELVIEW);
-  glLoadMatrixf(g_matrices.GetMatrix(MM_MODELVIEW));
 
   if (!m_pYUVShader->Enable())
   {
@@ -1445,15 +1441,8 @@ void CLinuxRendererGL::RenderToFBO(int index, int field, bool weave /*= false*/)
 
   m_pYUVShader->Disable();
 
-  g_matrices.MatrixMode(MM_PROJECTION);
-  g_matrices.PopMatrix();
-  g_matrices.MatrixMode(MM_MODELVIEW);
-  g_matrices.PopMatrix();
-
-  glMatrixMode(GL_PROJECTION);
-  glLoadMatrixf(g_matrices.GetMatrix(MM_PROJECTION));
-  glMatrixMode(GL_MODELVIEW);
-  glLoadMatrixf(g_matrices.GetMatrix(MM_MODELVIEW));
+  glMatrixModview.PopLoad();
+  glMatrixProject.PopLoad();
 
   glPopAttrib(); // pop scissor
   glPopAttrib(); // pop viewport
@@ -1690,12 +1679,11 @@ bool CLinuxRendererGL::RenderCapture(CRenderCapture* capture)
   //invert Y axis to get non-inverted image
   glDisable(GL_BLEND);
   glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
-  g_matrices.MatrixMode(MM_MODELVIEW);
-  g_matrices.PushMatrix();
-  g_matrices.Translatef(0, capture->GetHeight(), 0);
-  g_matrices.Scalef(1.0, -1.0f, 1.0f);
-  glMatrixMode(GL_MODELVIEW);
-  glLoadMatrixf(g_matrices.GetMatrix(MM_MODELVIEW));
+
+  glMatrixModview.Push();
+  glMatrixModview->Translatef(0.0f, capture->GetHeight(), 0.0f);
+  glMatrixModview->Scalef(1.0f, -1.0f, 1.0f);
+  glMatrixModview.Load();
 
   capture->BeginRender();
 
@@ -1707,10 +1695,7 @@ bool CLinuxRendererGL::RenderCapture(CRenderCapture* capture)
   capture->EndRender();
 
   // revert model view matrix
-  g_matrices.MatrixMode(MM_MODELVIEW);
-  g_matrices.PopMatrix();
-  glMatrixMode(GL_MODELVIEW);
-  glLoadMatrixf(g_matrices.GetMatrix(MM_MODELVIEW));
+  glMatrixModview.PopLoad();
 
   // restore original video rect
   m_destRect = saveSize;

--- a/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
@@ -1080,7 +1080,7 @@ void CLinuxRendererGLES::RenderSinglePass(int index, int field)
   else if(field == FIELD_BOT)
     m_pYUVShader->SetField(0);
 
-  m_pYUVShader->SetMatrices(g_matrices.GetMatrix(MM_PROJECTION), g_matrices.GetMatrix(MM_MODELVIEW));
+  m_pYUVShader->SetMatrices(glMatrixProject.Get(), glMatrixModview.Get());
   m_pYUVShader->Enable();
 
   GLubyte idx[4] = {0, 1, 3, 2};        //determines order of triangle strip
@@ -1139,8 +1139,6 @@ void CLinuxRendererGLES::RenderSinglePass(int index, int field)
 
   glActiveTexture(GL_TEXTURE0);
   glDisable(m_textureTarget);
-
-  g_matrices.MatrixMode(MM_MODELVIEW);
 
   VerifyGLState();
 }
@@ -1206,19 +1204,15 @@ void CLinuxRendererGLES::RenderMultiPass(int index, int field)
 //TODO
 //  glPushAttrib(GL_VIEWPORT_BIT);
 //  glPushAttrib(GL_SCISSOR_BIT);
-  g_matrices.MatrixMode(MM_MODELVIEW);
-  g_matrices.PushMatrix();
-  g_matrices.LoadIdentity();
-  VerifyGLState();
+  glMatrixModview.Push();
+  glMatrixModview.LoadIdentity();
 
-  g_matrices.MatrixMode(MM_PROJECTION);
-  g_matrices.PushMatrix();
-  g_matrices.LoadIdentity();
-  VerifyGLState();
-  g_matrices.Ortho2D(0, m_sourceWidth, 0, m_sourceHeight);
+  glMatrixProject.Push();
+  glMatrixProject.LoadIdentity();
+  glMatrixProject->Ortho2D(0, m_sourceWidth, 0, m_sourceHeight);
+
   CRect viewport(0, 0, m_sourceWidth, m_sourceHeight);
   g_Windowing.SetViewPort(viewport);
-  g_matrices.MatrixMode(MM_MODELVIEW);
   VerifyGLState();
 
 
@@ -1264,14 +1258,12 @@ void CLinuxRendererGLES::RenderMultiPass(int index, int field)
 
   m_pYUVShader->Disable();
 
-  g_matrices.MatrixMode(MM_MODELVIEW);
-  g_matrices.PopMatrix(); // pop modelview
-  g_matrices.MatrixMode(MM_PROJECTION);
-  g_matrices.PopMatrix(); // pop projection
+  glMatrixModview.PopLoad();
+  glMatrixProject.PopLoad();
+
 //TODO
 //  glPopAttrib(); // pop scissor
 //  glPopAttrib(); // pop viewport
-  g_matrices.MatrixMode(MM_MODELVIEW);
   VerifyGLState();
 
   m_fbo.EndRender();
@@ -1775,17 +1767,17 @@ bool CLinuxRendererGLES::RenderCapture(CRenderCapture* capture)
   // clear framebuffer and invert Y axis to get non-inverted image
   glDisable(GL_BLEND);
 
-  g_matrices.MatrixMode(MM_MODELVIEW);
-  g_matrices.PushMatrix();
+  glMatrixModview.Push();
   // fixme - we know that cvref  & eglimg are already flipped in y direction
   // but somehow this also effects the rendercapture here
   // therefore we have to skip the flip here or we get upside down
   // images
   if (m_renderMethod != RENDER_CVREF)
   {
-    g_matrices.Translatef(0.0f, capture->GetHeight(), 0.0f);
-    g_matrices.Scalef(1.0f, -1.0f, 1.0f);
+    glMatrixModview->Translatef(0.0f, capture->GetHeight(), 0.0f);
+    glMatrixModview->Scalef(1.0f, -1.0f, 1.0f);
   }
+  glMatrixModview.Load();
 
   capture->BeginRender();
 
@@ -1805,8 +1797,7 @@ bool CLinuxRendererGLES::RenderCapture(CRenderCapture* capture)
   capture->EndRender();
 
   // revert model view matrix
-  g_matrices.MatrixMode(MM_MODELVIEW);
-  g_matrices.PopMatrix();
+  glMatrixModview.PopLoad();
 
   // restore original video rect
   m_destRect = saveSize;

--- a/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
@@ -1205,10 +1205,10 @@ void CLinuxRendererGLES::RenderMultiPass(int index, int field)
 //  glPushAttrib(GL_VIEWPORT_BIT);
 //  glPushAttrib(GL_SCISSOR_BIT);
   glMatrixModview.Push();
-  glMatrixModview.LoadIdentity();
+  glMatrixModview->LoadIdentity();
 
   glMatrixProject.Push();
-  glMatrixProject.LoadIdentity();
+  glMatrixProject->LoadIdentity();
   glMatrixProject->Ortho2D(0, m_sourceWidth, 0, m_sourceHeight);
 
   CRect viewport(0, 0, m_sourceWidth, m_sourceHeight);

--- a/xbmc/cores/VideoRenderers/OverlayRendererGL.cpp
+++ b/xbmc/cores/VideoRenderers/OverlayRendererGL.cpp
@@ -27,8 +27,8 @@
   #include "LinuxRendererGL.h"
 #elif HAS_GLES == 2
   #include "LinuxRendererGLES.h"
-  #include "guilib/MatrixGLES.h"
 #endif
+#include "guilib/MatrixGLES.h"
 #include "RenderManager.h"
 #include "cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayImage.h"
 #include "cores/dvdplayer/DVDCodecs/Overlay/DVDOverlaySpu.h"
@@ -417,6 +417,11 @@ void COverlayGlyphGL::Render(SRenderState& state)
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 
+  g_matrices.MatrixMode(MM_MODELVIEW);
+  g_matrices.PushMatrix();
+  g_matrices.Translatef(state.x, state.y, 0.0f);
+  g_matrices.Scalef(state.width, state.height, 1.0f);
+
 #ifdef HAS_GL
   glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
   glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_COMBINE);
@@ -431,9 +436,7 @@ void COverlayGlyphGL::Render(SRenderState& state)
   glTexEnvi(GL_TEXTURE_ENV, GL_OPERAND1_ALPHA, GL_SRC_ALPHA);
 
   glMatrixMode(GL_MODELVIEW);
-  glPushMatrix();
-  glTranslatef(state.x    , state.y     , 0.0f);
-  glScalef    (state.width, state.height, 1.0f);
+  glLoadMatrixf(g_matrices.GetMatrix(MM_MODELVIEW));
 
   VerifyGLState();
 
@@ -448,14 +451,9 @@ void COverlayGlyphGL::Render(SRenderState& state)
   glDrawArrays(GL_QUADS, 0, m_count * 4);
   glPopClientAttrib();
 
-  glPopMatrix();
+  g_matrices.PopMatrix();
+  glLoadMatrixf(g_matrices.GetMatrix(MM_MODELVIEW));
 #else
-  g_matrices.MatrixMode(MM_MODELVIEW);
-  g_matrices.PushMatrix();
-  g_matrices.Translatef(state.x, state.y, 0.0f);
-  g_matrices.Scalef(state.width, state.height, 1.0f);
-  VerifyGLState();
-
   g_Windowing.EnableGUIShader(SM_FONTS);
 
   GLint posLoc  = g_Windowing.GUIShaderGetPos();

--- a/xbmc/cores/VideoRenderers/OverlayRendererGL.cpp
+++ b/xbmc/cores/VideoRenderers/OverlayRendererGL.cpp
@@ -417,10 +417,10 @@ void COverlayGlyphGL::Render(SRenderState& state)
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 
-  g_matrices.MatrixMode(MM_MODELVIEW);
-  g_matrices.PushMatrix();
-  g_matrices.Translatef(state.x, state.y, 0.0f);
-  g_matrices.Scalef(state.width, state.height, 1.0f);
+  glMatrixModview.Push();
+  glMatrixModview->Translatef(state.x, state.y, 0.0f);
+  glMatrixModview->Scalef(state.width, state.height, 1.0f);
+  glMatrixModview.Load();
 
 #ifdef HAS_GL
   glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
@@ -435,9 +435,6 @@ void COverlayGlyphGL::Render(SRenderState& state)
   glTexEnvi(GL_TEXTURE_ENV, GL_OPERAND0_ALPHA, GL_SRC_ALPHA);
   glTexEnvi(GL_TEXTURE_ENV, GL_OPERAND1_ALPHA, GL_SRC_ALPHA);
 
-  glMatrixMode(GL_MODELVIEW);
-  glLoadMatrixf(g_matrices.GetMatrix(MM_MODELVIEW));
-
   VerifyGLState();
 
   glPushClientAttrib(GL_CLIENT_VERTEX_ARRAY_BIT);
@@ -451,8 +448,6 @@ void COverlayGlyphGL::Render(SRenderState& state)
   glDrawArrays(GL_QUADS, 0, m_count * 4);
   glPopClientAttrib();
 
-  g_matrices.PopMatrix();
-  glLoadMatrixf(g_matrices.GetMatrix(MM_MODELVIEW));
 #else
   g_Windowing.EnableGUIShader(SM_FONTS);
 
@@ -493,8 +488,9 @@ void COverlayGlyphGL::Render(SRenderState& state)
 
   g_Windowing.DisableGUIShader();
 
-  g_matrices.PopMatrix();
 #endif
+
+  glMatrixModview.PopLoad();
 
   glDisable(GL_BLEND);
   glDisable(GL_TEXTURE_2D);

--- a/xbmc/guilib/GUIShader.cpp
+++ b/xbmc/guilib/GUIShader.cpp
@@ -88,8 +88,8 @@ bool CGUIShader::OnEnabled()
 {
   // This is called after glUseProgram()
 
-  glUniformMatrix4fv(m_hProj,  1, GL_FALSE, g_matrices.GetMatrix(MM_PROJECTION));
-  glUniformMatrix4fv(m_hModel, 1, GL_FALSE, g_matrices.GetMatrix(MM_MODELVIEW));
+  glUniformMatrix4fv(m_hProj,  1, GL_FALSE, glMatrixProject.Get());
+  glUniformMatrix4fv(m_hModel, 1, GL_FALSE, glMatrixModview.Get());
 
   return true;
 }

--- a/xbmc/guilib/Makefile.in
+++ b/xbmc/guilib/Makefile.in
@@ -82,6 +82,7 @@ ifeq (@USE_OPENGL@,1)
 SRCS += TextureGL.cpp
 SRCS += GUIFontTTFGL.cpp
 SRCS += GUITextureGL.cpp
+SRCS += MatrixGLES.cpp
 endif
 
 ifeq (@USE_OPENGLES@,1)

--- a/xbmc/guilib/MatrixGLES.cpp
+++ b/xbmc/guilib/MatrixGLES.cpp
@@ -31,77 +31,18 @@
 #include "utils/CPUInfo.h"
 #endif
 
-CMatrixGLES g_matrices;
 
-#define MODE_WITHIN_RANGE(m)       ((m >= 0) && (m < (int)MM_MATRIXSIZE))
-
-CMatrixGLES::CMatrixGLES()
-{
-  for (unsigned int i=0; i < MM_MATRIXSIZE; i++)
-  {
-    m_matrices[i].push_back(MatrixWrapper());
-    MatrixMode((EMATRIXMODE)i);
-    LoadIdentity();
-  }
-  m_matrixMode = (EMATRIXMODE)-1;
-  m_pMatrix    = NULL;
-#if defined(__ARM_NEON__)
-  m_has_neon = (g_cpuInfo.GetCPUFeatures() & CPU_FEATURE_NEON) == CPU_FEATURE_NEON;
+#ifdef HAS_GL
+CMatrixGLStack glMatrixModview(GL_MODELVIEW);
+CMatrixGLStack glMatrixProject(GL_PROJECTION);
+CMatrixGLStack glMatrixTexture(GL_TEXTURE);
+#else
+CMatrixGLStack glMatrixModview(0);
+CMatrixGLStack glMatrixProject(0);
+CMatrixGLStack glMatrixTexture(0);
 #endif
-}
 
-CMatrixGLES::~CMatrixGLES()
-{
-}
-
-GLfloat* CMatrixGLES::GetMatrix(EMATRIXMODE mode)
-{
-  if (MODE_WITHIN_RANGE(mode))
-  {
-    if (!m_matrices[mode].empty())
-    {
-      return m_matrices[mode].back();
-    }
-  }
-  return NULL;
-}
-
-void CMatrixGLES::MatrixMode(EMATRIXMODE mode)
-{
-  if (MODE_WITHIN_RANGE(mode))
-  {
-    m_matrixMode = mode;
-    m_pMatrix    = m_matrices[mode].back();
-  }
-  else
-  {
-    m_matrixMode = (EMATRIXMODE)-1;
-    m_pMatrix    = NULL;
-  }
-}
-
-void CMatrixGLES::PushMatrix()
-{
-  if (m_pMatrix && MODE_WITHIN_RANGE(m_matrixMode))
-  {
-    m_matrices[m_matrixMode].push_back(MatrixWrapper(m_pMatrix));
-    m_pMatrix =  m_matrices[m_matrixMode].back();
-  }
-}
-
-void CMatrixGLES::PopMatrix()
-{
-  if (MODE_WITHIN_RANGE(m_matrixMode))
-  {
-    if (m_matrices[m_matrixMode].size() > 1)
-    { 
-      m_matrices[m_matrixMode].pop_back();
-    }
-    m_pMatrix = m_matrices[m_matrixMode].back();
-  }
-}
-
-void CMatrixGLES::LoadIdentity()
+void CMatrixGL::LoadIdentity()
 {
   if (m_pMatrix)
   {
@@ -112,7 +53,7 @@ void CMatrixGLES::LoadIdentity()
   }
 }
 
-void CMatrixGLES::Ortho(GLfloat l, GLfloat r, GLfloat b, GLfloat t, GLfloat n, GLfloat f)
+void CMatrixGL::Ortho(GLfloat l, GLfloat r, GLfloat b, GLfloat t, GLfloat n, GLfloat f)
 {
   GLfloat u =  2.0f / (r - l);
   GLfloat v =  2.0f / (t - b);
@@ -127,7 +68,7 @@ void CMatrixGLES::Ortho(GLfloat l, GLfloat r, GLfloat b, GLfloat t, GLfloat n, G
   MultMatrixf(matrix);
 }
 
-void CMatrixGLES::Ortho2D(GLfloat l, GLfloat r, GLfloat b, GLfloat t)
+void CMatrixGL::Ortho2D(GLfloat l, GLfloat r, GLfloat b, GLfloat t)
 {
   GLfloat u =  2.0f / (r - l);
   GLfloat v =  2.0f / (t - b);
@@ -140,7 +81,7 @@ void CMatrixGLES::Ortho2D(GLfloat l, GLfloat r, GLfloat b, GLfloat t)
   MultMatrixf(matrix);
 }
 
-void CMatrixGLES::Frustum(GLfloat l, GLfloat r, GLfloat b, GLfloat t, GLfloat n, GLfloat f)
+void CMatrixGL::Frustum(GLfloat l, GLfloat r, GLfloat b, GLfloat t, GLfloat n, GLfloat f)
 {
   GLfloat u = (2.0f * n) / (r - l);
   GLfloat v = (2.0f * n) / (t - b);
@@ -155,7 +96,7 @@ void CMatrixGLES::Frustum(GLfloat l, GLfloat r, GLfloat b, GLfloat t, GLfloat n,
   MultMatrixf(matrix);
 }
 
-void CMatrixGLES::Translatef(GLfloat x, GLfloat y, GLfloat z)
+void CMatrixGL::Translatef(GLfloat x, GLfloat y, GLfloat z)
 {
   GLfloat matrix[16] = {1.0f, 0.0f, 0.0f, 0.0f,
                         0.0f, 1.0f, 0.0f, 0.0f,
@@ -164,7 +105,7 @@ void CMatrixGLES::Translatef(GLfloat x, GLfloat y, GLfloat z)
   MultMatrixf(matrix);
 }
 
-void CMatrixGLES::Scalef(GLfloat x, GLfloat y, GLfloat z)
+void CMatrixGL::Scalef(GLfloat x, GLfloat y, GLfloat z)
 {
   GLfloat matrix[16] = {   x, 0.0f, 0.0f, 0.0f,
                         0.0f,    y, 0.0f, 0.0f,
@@ -173,7 +114,7 @@ void CMatrixGLES::Scalef(GLfloat x, GLfloat y, GLfloat z)
   MultMatrixf(matrix);
 }
 
-void CMatrixGLES::Rotatef(GLfloat angle, GLfloat x, GLfloat y, GLfloat z)
+void CMatrixGL::Rotatef(GLfloat angle, GLfloat x, GLfloat y, GLfloat z)
 {
   GLfloat modulous = sqrt((x*x)+(y*y)+(z*z));
   if (modulous != 0.0)
@@ -242,12 +183,12 @@ inline void Matrix4Mul(const float* src_mat_1, const float* src_mat_2, float* ds
     );
 }
 #endif
-void CMatrixGLES::MultMatrixf(const GLfloat *matrix)
+void CMatrixGL::MultMatrixf(const GLfloat *matrix)
 {
   if (m_pMatrix)
   {
 #if defined(__ARM_NEON__)
-    if (m_has_neon)
+    if ((g_cpuInfo.GetCPUFeatures() & CPU_FEATURE_NEON) == CPU_FEATURE_NEON)
     {
       GLfloat m[16];
       Matrix4Mul(m_pMatrix, matrix, m);
@@ -278,7 +219,7 @@ void CMatrixGLES::MultMatrixf(const GLfloat *matrix)
 }
 
 // gluLookAt implementation taken from Mesa3D
-void CMatrixGLES::LookAt(GLfloat eyex, GLfloat eyey, GLfloat eyez, GLfloat centerx, GLfloat centery, GLfloat centerz, GLfloat upx, GLfloat upy, GLfloat upz)
+void CMatrixGL::LookAt(GLfloat eyex, GLfloat eyey, GLfloat eyez, GLfloat centerx, GLfloat centery, GLfloat centerz, GLfloat upx, GLfloat upy, GLfloat upz)
 {
   GLfloat forward[3], side[3], up[3];
   GLfloat m[4][4];
@@ -350,7 +291,7 @@ static void __gluMultMatrixVecf(const GLfloat matrix[16], const GLfloat in[4], G
 }
 
 // gluProject implementation taken from Mesa3D
-bool CMatrixGLES::Project(GLfloat objx, GLfloat objy, GLfloat objz, const GLfloat modelMatrix[16], const GLfloat projMatrix[16], const GLint viewport[4], GLfloat* winx, GLfloat* winy, GLfloat* winz)
+bool CMatrixGL::Project(GLfloat objx, GLfloat objy, GLfloat objz, const GLfloat modelMatrix[16], const GLfloat projMatrix[16], const GLint viewport[4], GLfloat* winx, GLfloat* winy, GLfloat* winz)
 {
   GLfloat in[4];
   GLfloat out[4];
@@ -381,17 +322,20 @@ bool CMatrixGLES::Project(GLfloat objx, GLfloat objy, GLfloat objz, const GLfloa
   return true;
 }
 
-void CMatrixGLES::PrintMatrix(void)
+void CMatrixGL::PrintMatrix(void)
 {
-  for (unsigned int i=0; i < MM_MATRIXSIZE; i++)
-  {
-    GLfloat *m = GetMatrix((EMATRIXMODE)i);
-    CLog::Log(LOGDEBUG, "MatrixGLES - Matrix:%d", i);
-    CLog::Log(LOGDEBUG, "%f %f %f %f", m[0], m[4], m[8],  m[12]);
-    CLog::Log(LOGDEBUG, "%f %f %f %f", m[1], m[5], m[9],  m[13]);
-    CLog::Log(LOGDEBUG, "%f %f %f %f", m[2], m[6], m[10], m[14]);
-    CLog::Log(LOGDEBUG, "%f %f %f %f", m[3], m[7], m[11], m[15]);
-  }
+  CLog::Log(LOGDEBUG, "%f %f %f %f", m_pMatrix[0], m_pMatrix[4], m_pMatrix[8],  m_pMatrix[12]);
+  CLog::Log(LOGDEBUG, "%f %f %f %f", m_pMatrix[1], m_pMatrix[5], m_pMatrix[9],  m_pMatrix[13]);
+  CLog::Log(LOGDEBUG, "%f %f %f %f", m_pMatrix[2], m_pMatrix[6], m_pMatrix[10], m_pMatrix[14]);
+  CLog::Log(LOGDEBUG, "%f %f %f %f", m_pMatrix[3], m_pMatrix[7], m_pMatrix[11], m_pMatrix[15]);
+}
+
+void CMatrixGLStack::Load()
+{
+#ifdef HAS_GL
+  glMatrixMode(m_type);
+  glLoadMatrixf(m_current);
+#endif
 }
 
 #endif

--- a/xbmc/guilib/MatrixGLES.cpp
+++ b/xbmc/guilib/MatrixGLES.cpp
@@ -21,7 +21,7 @@
 
 #include "system.h"
 
-#if HAS_GLES == 2
+#if defined(HAS_GL) || HAS_GLES == 2
 #include "system_gl.h"
 
 #include <cmath>

--- a/xbmc/rendering/gl/RenderSystemGL.cpp
+++ b/xbmc/rendering/gl/RenderSystemGL.cpp
@@ -182,8 +182,8 @@ bool CRenderSystemGL::ResetRenderSystem(int width, int height, bool fullScreen, 
 
   CalculateMaxTexturesize();
 
-  glViewport(0, 0, width, height);
-  glScissor(0, 0, width, height);
+  CRect rect( 0, 0, width, height );
+  SetViewPort( rect );
 
   glEnable(GL_TEXTURE_2D);
   glEnable(GL_SCISSOR_TEST);
@@ -393,8 +393,6 @@ void CRenderSystemGL::CaptureStateBlock()
   if (!m_bRenderCreated)
     return;
   
-  glGetIntegerv(GL_VIEWPORT, m_viewPort);
-
   glMatrixMode(GL_PROJECTION);
   glPushMatrix();
   glMatrixMode(GL_TEXTURE);
@@ -438,11 +436,9 @@ void CRenderSystemGL::SetCameraPosition(const CPoint &camera, int screenWidth, i
 
   CPoint offset = camera - CPoint(screenWidth*0.5f, screenHeight*0.5f);
 
-  GLint viewport[4];
-  glGetIntegerv(GL_VIEWPORT, viewport);
 
-  float w = (float)viewport[2]*0.5f;
-  float h = (float)viewport[3]*0.5f;
+  float w = (float)m_viewPort[2]*0.5f;
+  float h = (float)m_viewPort[3]*0.5f;
 
   glMatrixMode(GL_MODELVIEW);
   glLoadIdentity();
@@ -453,7 +449,6 @@ void CRenderSystemGL::SetCameraPosition(const CPoint &camera, int screenWidth, i
   glFrustum( (-w - offset.x)*0.5f, (w - offset.x)*0.5f, (-h + offset.y)*0.5f, (h + offset.y)*0.5f, h, 100*h);
   glMatrixMode(GL_MODELVIEW);
 
-  glGetIntegerv(GL_VIEWPORT, m_viewPort);
   glGetDoublev(GL_MODELVIEW_MATRIX, m_view);
   glGetDoublev(GL_PROJECTION_MATRIX, m_projection);
 
@@ -570,13 +565,10 @@ void CRenderSystemGL::GetViewPort(CRect& viewPort)
   if (!m_bRenderCreated)
     return;
 
-  GLint glvp[4];
-  glGetIntegerv(GL_VIEWPORT, glvp);
-
-  viewPort.x1 = glvp[0];
-  viewPort.y1 = m_height - glvp[1] - glvp[3];
-  viewPort.x2 = glvp[0] + glvp[2];
-  viewPort.y2 = viewPort.y1 + glvp[3];
+  viewPort.x1 = m_viewPort[0];
+  viewPort.y1 = m_height - m_viewPort[1] - m_viewPort[3];
+  viewPort.x2 = m_viewPort[0] + m_viewPort[2];
+  viewPort.y2 = viewPort.y1 + m_viewPort[3];
 }
 
 void CRenderSystemGL::SetViewPort(CRect& viewPort)
@@ -586,6 +578,10 @@ void CRenderSystemGL::SetViewPort(CRect& viewPort)
 
   glScissor((GLint) viewPort.x1, (GLint) (m_height - viewPort.y1 - viewPort.Height()), (GLsizei) viewPort.Width(), (GLsizei) viewPort.Height());
   glViewport((GLint) viewPort.x1, (GLint) (m_height - viewPort.y1 - viewPort.Height()), (GLsizei) viewPort.Width(), (GLsizei) viewPort.Height());
+  m_viewPort[0] = viewPort.x1;
+  m_viewPort[1] = m_height - viewPort.y1 - viewPort.Height();
+  m_viewPort[2] = viewPort.Width();
+  m_viewPort[3] = viewPort.Height();
 }
 
 void CRenderSystemGL::SetScissors(const CRect &rect)

--- a/xbmc/rendering/gl/RenderSystemGL.h
+++ b/xbmc/rendering/gl/RenderSystemGL.h
@@ -91,8 +91,6 @@ protected:
   int        m_glslMajor;
   int        m_glslMinor;
   
-  GLdouble   m_view[16];
-  GLdouble   m_projection[16];
   GLint      m_viewPort[4];
 };
 

--- a/xbmc/rendering/gles/RenderSystemGLES.cpp
+++ b/xbmc/rendering/gles/RenderSystemGLES.cpp
@@ -137,14 +137,19 @@ bool CRenderSystemGLES::ResetRenderSystem(int width, int height, bool fullScreen
 
   glEnable(GL_SCISSOR_TEST); 
 
-  g_matrices.MatrixMode(MM_PROJECTION);
-  g_matrices.LoadIdentity();
+  glMatrixProject.Clear();
+  glMatrixModview->LoadIdentity();
+  glMatrixProject->Ortho(0.0f, width-1, height-1, 0.0f, -1.0f, 1.0f);
+  glMatrixProject.Load();
 
-  g_matrices.Ortho(0.0f, width-1, height-1, 0.0f, -1.0f, 1.0f);
+  glMatrixModview.Clear();
+  glMatrixModview->LoadIdentity();
+  glMatrixModview.Load();
 
-  g_matrices.MatrixMode(MM_MODELVIEW);
-  g_matrices.LoadIdentity();
-  
+  glMatrixTexture.Clear();
+  glMatrixTexture->LoadIdentity();
+  glMatrixTexture.Load();
+
   glBlendFunc(GL_SRC_ALPHA, GL_ONE);
   glEnable(GL_BLEND);          // Turn Blending On
   glDisable(GL_DEPTH_TEST);  
@@ -357,12 +362,10 @@ void CRenderSystemGLES::CaptureStateBlock()
   if (!m_bRenderCreated)
     return;
 
-  g_matrices.MatrixMode(MM_PROJECTION);
-  g_matrices.PushMatrix();
-  g_matrices.MatrixMode(MM_TEXTURE);
-  g_matrices.PushMatrix();
-  g_matrices.MatrixMode(MM_MODELVIEW);
-  g_matrices.PushMatrix();
+  glMatrixProject.Push();
+  glMatrixModview.Push();
+  glMatrixTexture.Push();
+
   glDisable(GL_SCISSOR_TEST); // fixes FBO corruption on Macs
   glActiveTexture(GL_TEXTURE0);
 //TODO - NOTE: Only for Screensavers & Visualisations
@@ -374,12 +377,9 @@ void CRenderSystemGLES::ApplyStateBlock()
   if (!m_bRenderCreated)
     return;
 
-  g_matrices.MatrixMode(MM_PROJECTION);
-  g_matrices.PopMatrix();
-  g_matrices.MatrixMode(MM_TEXTURE);
-  g_matrices.PopMatrix();
-  g_matrices.MatrixMode(MM_MODELVIEW);
-  g_matrices.PopMatrix();
+  glMatrixProject.PopLoad();
+  glMatrixModview.PopLoad();
+  glMatrixTexture.PopLoad();
   glActiveTexture(GL_TEXTURE0);
   glEnable(GL_BLEND);
   glEnable(GL_SCISSOR_TEST);  
@@ -398,20 +398,14 @@ void CRenderSystemGLES::SetCameraPosition(const CPoint &camera, int screenWidth,
   float w = (float)m_viewPort[2]*0.5f;
   float h = (float)m_viewPort[3]*0.5f;
 
-  g_matrices.MatrixMode(MM_MODELVIEW);
-  g_matrices.LoadIdentity();
-  g_matrices.Translatef(-(w + offset.x), +(h + offset.y), 0);
-  g_matrices.LookAt(0.0, 0.0, -2.0*h, 0.0, 0.0, 0.0, 0.0, -1.0, 0.0);
-  g_matrices.MatrixMode(MM_PROJECTION);
-  g_matrices.LoadIdentity();
-  g_matrices.Frustum( (-w - offset.x)*0.5f, (w - offset.x)*0.5f, (-h + offset.y)*0.5f, (h + offset.y)*0.5f, h, 100*h);
-  g_matrices.MatrixMode(MM_MODELVIEW);
+  glMatrixModview->LoadIdentity();
+  glMatrixModview->Translatef(-(w + offset.x), +(h + offset.y), 0);
+  glMatrixModview->LookAt(0.0, 0.0, -2.0*h, 0.0, 0.0, 0.0, 0.0, -1.0, 0.0);
+  glMatrixModview.Load();
 
-  GLfloat* matx;
-  matx = g_matrices.GetMatrix(MM_MODELVIEW);
-  memcpy(m_view, matx, 16 * sizeof(GLfloat));
-  matx = g_matrices.GetMatrix(MM_PROJECTION);
-  memcpy(m_projection, matx, 16 * sizeof(GLfloat));
+  glMatrixProject->LoadIdentity();
+  glMatrixProject->Frustum( (-w - offset.x)*0.5f, (w - offset.x)*0.5f, (-h + offset.y)*0.5f, (h + offset.y)*0.5f, h, 100*h);
+  glMatrixProject.Load();
 
   g_graphicsContext.EndPaint();
 }
@@ -419,7 +413,7 @@ void CRenderSystemGLES::SetCameraPosition(const CPoint &camera, int screenWidth,
 void CRenderSystemGLES::Project(float &x, float &y, float &z)
 {
   GLfloat coordX, coordY, coordZ;
-  if (g_matrices.Project(x, y, z, m_view, m_projection, m_viewPort, &coordX, &coordY, &coordZ))
+  if (CMatrixGL::Project(x, y, z, glMatrixModview.Get(), glMatrixProject.Get(), m_viewPort, &coordX, &coordY, &coordZ))
   {
     x = coordX;
     y = (float)(m_viewPort[1] + m_viewPort[3] - coordY);
@@ -434,8 +428,8 @@ bool CRenderSystemGLES::TestRender()
   //RESOLUTION_INFO resInfo = CDisplaySettings::Get().GetCurrentResolutionInfo();
   //glViewport(0, 0, resInfo.iWidth, resInfo.iHeight);
 
-  g_matrices.PushMatrix();
-  g_matrices.Rotatef( theta, 0.0f, 0.0f, 1.0f );
+  glMatrixModview.Push();
+  glMatrixModview->Rotatef( theta, 0.0f, 0.0f, 1.0f );
 
   EnableGUIShader(SM_DEFAULT);
 
@@ -465,7 +459,7 @@ bool CRenderSystemGLES::TestRender()
 
   DisableGUIShader();
 
-  g_matrices.PopMatrix();
+  glMatrixModview.Pop();
 
   theta += 1.0f;
 
@@ -477,8 +471,7 @@ void CRenderSystemGLES::ApplyHardwareTransform(const TransformMatrix &finalMatri
   if (!m_bRenderCreated)
     return;
 
-  g_matrices.MatrixMode(MM_MODELVIEW);
-  g_matrices.PushMatrix();
+  glMatrixModview.Push();
   GLfloat matrix[4][4];
 
   for(int i = 0; i < 3; i++)
@@ -490,7 +483,8 @@ void CRenderSystemGLES::ApplyHardwareTransform(const TransformMatrix &finalMatri
   matrix[2][3] = 0.0f;
   matrix[3][3] = 1.0f;
 
-  g_matrices.MultMatrixf(&matrix[0][0]);
+  glMatrixModview->MultMatrixf(&matrix[0][0]);
+  glMatrixModview.Load();
 }
 
 void CRenderSystemGLES::RestoreHardwareTransform()
@@ -498,8 +492,7 @@ void CRenderSystemGLES::RestoreHardwareTransform()
   if (!m_bRenderCreated)
     return;
 
-  g_matrices.MatrixMode(MM_MODELVIEW);
-  g_matrices.PopMatrix();
+  glMatrixModview.PopLoad();
 }
 
 void CRenderSystemGLES::CalculateMaxTexturesize()

--- a/xbmc/rendering/gles/RenderSystemGLES.h
+++ b/xbmc/rendering/gles/RenderSystemGLES.h
@@ -109,8 +109,6 @@ protected:
   CGUIShader  **m_pGUIshader;  // One GUI shader for each method
   ESHADERMETHOD m_method;      // Current GUI Shader method
 
-  GLfloat    m_view[16];
-  GLfloat    m_projection[16];
   GLint      m_viewPort[4];
 };
 


### PR DESCRIPTION
This is a series to unify our matrix handling between GL and GLES. It also drops slow glGet calls in the GL pipeline and keep track of that on CPU.

There are some minor glGet for viewport left, but those are not run by default. If you feel advantages, run xbmc on a remote GLX session. It should run quite nicely on ethernet.

I've not tested this on GLES yet, so jenkins build this please.
