### PR TITLE
[metadata.tvdb.com] Added option to use IMDB ratings if it's possible

### DIFF
--- a/addons/metadata.tvdb.com/addon.xml
+++ b/addons/metadata.tvdb.com/addon.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.tvdb.com"
        name="The TVDB"
-       version="1.5.9"
+       version="1.7.0"
        provider-name="XBMC Foundation">
   <requires>
     <import addon="xbmc.metadata" version="2.1.0"/>
+    <import addon="metadata.common.imdb.com" version="2.7.8"/>
   </requires>
   <extension point="xbmc.metadata.scraper.tvshows"
              language="multi"

--- a/addons/metadata.tvdb.com/changelog.txt
+++ b/addons/metadata.tvdb.com/changelog.txt
@@ -1,3 +1,9 @@
+[B]1.7.0[/B]
+- Added: Option to get IMDb episode and series rating when available
+
+[B]1.6.0[/B]
+- Changed: Force selected language even if title on another language is being used for the search query
+
 [B]1.5.9[/B]
 - Updated: language files from Transifex
 

--- a/addons/metadata.tvdb.com/resources/language/English/strings.xml
+++ b/addons/metadata.tvdb.com/resources/language/English/strings.xml
@@ -9,4 +9,6 @@
     <string id="30002">Enable Fanart</string>
     <string id="30003">Prefer Posters</string>
     <string id="30004">Language</string>
+    <string id="30005">Get Rating from</string>
+    <string id="30006">Use TheTVDB Ratings in case IMDb is missing</string>
 </strings>

--- a/addons/metadata.tvdb.com/resources/settings.xml
+++ b/addons/metadata.tvdb.com/resources/settings.xml
@@ -6,4 +6,6 @@
     <setting label="30002" type="bool" id="fanart" default="true" />
     <setting type="sep" />
     <setting label="30004" type="labelenum" id="language" values="da|fi|nl|de|it|es|fr|pl|hu|el|tr|ru|he|ja|pt|zh|cs|sl|hr|ko|en|sv|no" sort="yes" default="en" />
+    <setting label="30005" type="labelenum" values="TheTVDB|IMDb" id="RatingS" default="TheTVDB"/>
+	<setting label="30006" type="bool" id="fallback" subsetting="true" visible="eq(-1,1)" default="true"/>
 </settings>

--- a/addons/metadata.tvdb.com/tvdb.xml
+++ b/addons/metadata.tvdb.com/tvdb.xml
@@ -43,7 +43,7 @@
 	<!-- returns:	results in xml format <results><movie><title>*</title><url>*</url>*#urls<extra>*</extra></movie>*</results> -->
 	<GetSearchResults dest="1">
 		<RegExp input="$$4" output="&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; standalone=&quot;yes&quot;?&gt;&lt;results&gt;\1&lt;/results&gt;" dest="1">
-			<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\3&lt;/title&gt;&lt;language&gt;\2&lt;/language&gt;&lt;url cache=&quot;\1-\2.xml&quot;&gt;http://thetvdb.com/api/1D62F2F90030C444/series/\1/all/\2.zip&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;&lt;/entity&gt;" dest="4">
+			<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\3&lt;/title&gt;&lt;language&gt;\2&lt;/language&gt;&lt;url cache=&quot;\1-$INFO[language].xml&quot;&gt;http://thetvdb.com/api/1D62F2F90030C444/series/\1/all/$INFO[language].zip&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;&lt;/entity&gt;" dest="4">
 				<expression repeat="yes">&lt;seriesid&gt;([0-9]*)&lt;/seriesid&gt;[^&lt;]*&lt;language&gt;([^&lt;]*)&lt;/language&gt;[^&lt;]*&lt;SeriesName&gt;([^&lt;]*)&lt;/SeriesName&gt;</expression>
 			</RegExp>
 			<expression noclean="1"/>
@@ -70,12 +70,33 @@
 			<RegExp input="$$5" output="&lt;premiered&gt;\1&lt;/premiered&gt;" dest="4+">
 				<expression>&lt;FirstAired&gt;([^&lt;]*)&lt;/FirstAired&gt;</expression>
 			</RegExp>
-			<RegExp input="$$5" output="&lt;rating&gt;\1&lt;/rating&gt;" dest="4+">
-				<expression>&lt;Rating&gt;([^&lt;]*)&lt;/Rating&gt;</expression>
+			<RegExp input="$INFO[RatingS]" output="$$12" dest="4+">
+				<RegExp input="$$5" output="&lt;rating&gt;\1&lt;/rating&gt;" dest="12+">
+					<expression>&lt;Rating&gt;([^&lt;]+)&lt;/Rating&gt;</expression>
+				</RegExp>
+				<RegExp input="$$5" output="&lt;votes&gt;\1&lt;/votes&gt;" dest="12+">
+					<expression>&lt;RatingCount&gt;([^&lt;]+)&lt;/RatingCount&gt;</expression>
+				</RegExp>
+				<expression>TheTVDB</expression>
 			</RegExp>
-			<RegExp input="$$5" output="&lt;votes&gt;\1&lt;/votes&gt;" dest="4+">
-				<expression>&lt;RatingCount&gt;([^&lt;]*)&lt;/RatingCount&gt;</expression>
-			</RegExp>
+			<RegExp input="$INFO[RatingS]" output="$$13" dest="4+">
+				<RegExp input="$$5" output="\1" dest="11">
+					<expression clear="yes">&lt;IMDB_ID&gt;([^&lt;]+)&lt;/IMDB_ID&gt;</expression>
+				</RegExp>
+				<RegExp input="$$11">
+					<RegExp conditional="fallback" input="$$5" output="&lt;rating&gt;\1&lt;/rating&gt;" dest="13+">
+						<expression>&lt;Rating&gt;([^&lt;]+)&lt;/Rating&gt;</expression>
+					</RegExp>
+					<RegExp conditional="fallback" input="$$5" output="&lt;votes&gt;\1&lt;/votes&gt;" dest="13+">
+						<expression>&lt;RatingCount&gt;([^&lt;]+)&lt;/RatingCount&gt;</expression>
+					</RegExp>
+					<expression>^$</expression>
+				</RegExp>
+				<RegExp input="$$11" output="&lt;chain function=&quot;GetIMDBRatingById&quot;&gt;$$11&lt;/chain&gt;" dest="13">
+					<expression>(.+)</expression>
+				</RegExp>
+				<expression>IMDb</expression>
+			</RegExp>			
 			<RegExp input="$$5" output="&lt;studio&gt;\1&lt;/studio&gt;" dest="4+">
 				<expression>&lt;Network&gt;([^&lt;]*)&lt;/Network&gt;</expression>
 			</RegExp>
@@ -278,11 +299,32 @@
 			<RegExp input="$$8" output="&lt;displayafterseason&gt;\1&lt;/displayafterseason&gt;" dest="4+">
 				<expression>&lt;airsafter_season&gt;([^&lt;]+)&lt;/airsafter_season&gt;</expression>
 			</RegExp>
-			<RegExp input="$$8" output="&lt;rating&gt;\1&lt;/rating&gt;" dest="4+">
-				<expression>&lt;Rating&gt;([^&lt;]+)&lt;/Rating&gt;</expression>
+			<RegExp input="$INFO[RatingS]" output="$$12" dest="4+">
+				<RegExp input="$$8" output="&lt;rating&gt;\1&lt;/rating&gt;" dest="12+">
+					<expression>&lt;Rating&gt;([^&lt;]+)&lt;/Rating&gt;</expression>
+				</RegExp>
+				<RegExp input="$$8" output="&lt;votes&gt;\1&lt;/votes&gt;" dest="12+">
+					<expression>&lt;RatingCount&gt;([^&lt;]+)&lt;/RatingCount&gt;</expression>
+				</RegExp>
+				<expression>TheTVDB</expression>
 			</RegExp>
-			<RegExp input="$$8" output="&lt;votes&gt;\1&lt;/votes&gt;" dest="4+">
-				<expression>&lt;RatingCount&gt;([^&lt;]+)&lt;/RatingCount&gt;</expression>
+			<RegExp input="$INFO[RatingS]" output="$$13" dest="4+">
+				<RegExp input="$$8" output="\1" dest="11">
+					<expression clear="yes">&lt;IMDB_ID&gt;([^&lt;]+)&lt;/IMDB_ID&gt;</expression>
+				</RegExp>
+				<RegExp input="$$11">
+					<RegExp conditional="fallback" input="$$8" output="&lt;rating&gt;\1&lt;/rating&gt;" dest="13+">
+						<expression>&lt;Rating&gt;([^&lt;]+)&lt;/Rating&gt;</expression>
+					</RegExp>
+					<RegExp conditional="fallback" input="$$8" output="&lt;votes&gt;\1&lt;/votes&gt;" dest="13+">
+						<expression>&lt;RatingCount&gt;([^&lt;]+)&lt;/RatingCount&gt;</expression>
+					</RegExp>
+					<expression>^$</expression>
+				</RegExp>
+				<RegExp input="$$11" output="&lt;chain function=&quot;GetIMDBRatingById&quot;&gt;$$11&lt;/chain&gt;" dest="13">
+					<expression>(.+)</expression>
+				</RegExp>
+				<expression>IMDb</expression>
 			</RegExp>
 			<RegExp input="$$1" output="&lt;runtime&gt;\1&lt;/runtime&gt;" dest="4+">
 				<expression>&lt;Runtime&gt;([^&lt;]+)&lt;/Runtime&gt;</expression>


### PR DESCRIPTION
I don't know if it's the right place to pull for scraper updates. repo-scrapers has no pulls and here i found some old pull for thetvdb like https://github.com/xbmc/xbmc/pull/5272. If you need it in the scraper repo i can create a pull there.
This pull adds an option to allow retrieving IMDB rating if the tag IMDB_ID is present. If there isn't and the option is enabled it falls back to thetvdb rating.
Thetvdb ratings are pretty useless since usually they have less than 20 votes when imdb has hundreds or thousands.
I left the automatic fallback and not an option to chose because not all episodes and series have imdb ratings (especially the old ones).
