### PR TITLE
[osx] - re-enable yadif deinterlacer

### DIFF
--- a/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
@@ -3350,9 +3350,9 @@ bool CLinuxRendererGL::Supports(EINTERLACEMETHOD method)
     return false;
   }
 
-#ifdef TARGET_DARWIN
-  // YADIF too slow for HD but we have no methods to fall back
-  // to something that works so just turn it off.
+#ifdef TARGET_DARWIN_IOS
+  // iOS has not the power for YADIF - TODO evaluate if its
+  // enough to disable it for TARGET_DARWIN_IOS_ATV2
   if(method == VS_INTERLACEMETHOD_DEINTERLACE)
     return false;
 #endif


### PR DESCRIPTION
Users suggested we have year 2014 and macs should be up to the task of using yadif deinterlacer. Since we have this enabled for the other platforms we should get it in sync (i don't trust ios hence the kept exclusion.

Up to the RMs its as safe for helix as adding it ;)

note to myself - needs a rebase before merge (tomorrow evening earliest)
