### PR TITLE
musicdb: fix no songs being shown in years node

### DIFF
--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -3003,7 +3003,7 @@ bool CMusicDatabase::GetAlbumsByYear(const CStdString& strBaseDir, CFileItemList
     return false;
 
   musicUrl.AddOption("year", year);
-  musicUrl.AddOption("singles", true); // allow singles to be listed
+  musicUrl.AddOption("show_singles", true); // allow singles to be listed
   
   Filter filter;
   return GetAlbumsByWhere(musicUrl.ToString(), filter, items);
@@ -5603,7 +5603,7 @@ bool CMusicDatabase::GetFilter(CDbUrl &musicUrl, Filter &filter, SortDescription
       // no artist given, so exclude any single albums (aka empty tagged albums)
       else
       {
-        option = options.find("singles");
+        option = options.find("show_singles");
         if (option == options.end() || !option->second.asBoolean())
           filter.AppendWhere("albumview.strAlbum <> ''");
       }


### PR DESCRIPTION
This resolves the conflicting "singles" filter option introduced by 9fbf13eded5d682d4ae210043e536895c9356c18 and thereby fixes http://trac.xbmc.org/ticket/15539. After that commit there were no songs listed when browsing albums by years.
