### PR TITLE
Improve runtime in video library

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -2014,6 +2014,38 @@ std::string CVideoDatabase::GetValueString(const CVideoInfoTag &details, int min
 }
 
 //********************************************************************************************************************************
+int CVideoDatabase::SetDetailsForItem(const CVideoInfoTag& details, const std::map<std::string, std::string> &artwork)
+{
+  return SetDetailsForItem(details.m_iDbId, details.m_type, details, artwork);
+}
+
+int CVideoDatabase::SetDetailsForItem(int id, const MediaType& mediaType, const CVideoInfoTag& details, const std::map<std::string, std::string> &artwork)
+{
+  if (mediaType == MediaTypeNone)
+    return -1;
+
+  if (mediaType == MediaTypeMovie)
+    return SetDetailsForMovie(details.GetPath(), details, artwork, id);
+  else if (mediaType == MediaTypeVideoCollection)
+    return SetDetailsForMovieSet(details, artwork, id);
+  else if (mediaType == MediaTypeTvShow)
+  {
+    map<int, map<string, string> > seasonArtwork;
+    if (!UpdateDetailsForTvShow(id, details, artwork, seasonArtwork))
+      return -1;
+
+    return id;
+  }
+  else if (mediaType == MediaTypeSeason)
+    return SetDetailsForSeason(details, artwork, details.m_iIdShow, id);
+  else if (mediaType == MediaTypeEpisode)
+    return SetDetailsForEpisode(details.GetPath(), details, artwork, details.m_iIdShow, id);
+  else if (mediaType == MediaTypeMusicVideo)
+    return SetDetailsForMusicVideo(details.GetPath(), details, artwork, id);
+
+  return -1;
+}
+
 int CVideoDatabase::SetDetailsForMovie(const std::string& strFilenameAndPath, const CVideoInfoTag& details, const map<string, string> &artwork, int idMovie /* = -1 */)
 {
   try

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -459,6 +459,9 @@ public:
 
   void GetEpisodesByFile(const std::string& strFilenameAndPath, std::vector<CVideoInfoTag>& episodes);
 
+  int SetDetailsForItem(const CVideoInfoTag& details, const std::map<std::string, std::string> &artwork);
+  int SetDetailsForItem(int id, const MediaType& mediaType, const CVideoInfoTag& details, const std::map<std::string, std::string> &artwork);
+
   int SetDetailsForMovie(const std::string& strFilenameAndPath, const CVideoInfoTag& details, const std::map<std::string, std::string> &artwork, int idMovie = -1);
   int SetDetailsForMovieSet(const CVideoInfoTag& details, const std::map<std::string, std::string> &artwork, int idSet = -1);
 

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -140,7 +140,7 @@ bool CThumbExtractor::DoWork()
       if (URIUtils::IsStack(m_listpath))
       {
         // Don't know the total time of the stack, so set duration to zero to avoid confusion
-        m_item.GetVideoInfoTag()->m_streamDetails.SetVideoDuration(0, 0);
+        info->m_streamDetails.SetVideoDuration(0, 0);
 
         // Restore original stack path
         m_item.SetPath(m_listpath);

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -151,6 +151,15 @@ bool CThumbExtractor::DoWork()
       else
         db.SetStreamDetailsForFileId(info->m_streamDetails, info->m_iFileId);
 
+      // overwrite the runtime value if the one from streamdetails is available
+      if (info->m_iDbId > 0 && info->m_duration != info->GetDuration())
+      {
+        info->m_duration = info->GetDuration();
+
+        // store the updated information in the database
+        db.SetDetailsForItem(info->m_iDbId, info->m_type, *info, m_item.GetArt());
+      }
+
       db.Close();
     }
     return true;


### PR DESCRIPTION
This is based on the discussion in http://trac.xbmc.org/ticket/14524. Right now we always store the scraped runtime of a video in the database but when we also know the stream details of an item (which is not always the case) we replace the scraped runtime with the one from stream details. But stream details are loaded asynchronously to the user interface listing and in JSON-RPC it's possible to not load them at all. In these cases the runtime value is the scraped one which can be off by a lot (often several minutes on episodes).

This adds the logic to overwrite the scraped runtime with the one from stream details when we load stream details. Unfortunately this only works for newly added items and not for items already in the library. But I first wanted to start the discussion and see what people think before looking into adding logic to also handle existing library items.

The problem basically comes from the fact that we don't load/read streamdetails during library scanning (probably to not slow things down) but maybe it would be worth investigating how much impact it would have if we already loaded the stream details during library scanning.
