### PR TITLE
infomanager: fix calls to GetInt() without a valid file item (same as in GetBool())

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -2074,7 +2074,16 @@ bool CGUIInfoManager::GetInt(int &value, int info, int contextWindow, const CGUI
     return GetMultiInfoInt(value, m_multiInfo[info - MULTI_INFO_START], contextWindow);
 
   if (info >= LISTITEM_START && info <= LISTITEM_END)
+  {
+    if (item == NULL)
+    {
+      CGUIWindow *window = GetWindowWithCondition(contextWindow, WINDOW_CONDITION_HAS_LIST_ITEMS); // true for has list items
+      if (window)
+        item = window->GetCurrentListItem().get();
+    }
+
     return GetItemInt(value, item, info);
+  }
 
   value = 0;
   switch( info )


### PR DESCRIPTION
I was looking into the issue brought up by @HitcherUK in http://forum.kodi.tv/showthread.php?tid=209524 and first thought it was a progress control specific issue. The problem basically is that `CGUIProgressControl` doesn't get the `CFileItem` object to be able to make `ListItem.Foo` lookups in `CGUIInfoManager::GetInt()`. But there's no way to pass the item into that code area so I looked at the other `CGUIInfoManager` getters and saw that `CGUIInfoManager::GetBool()` has code that handles the case where a `ListItem.Foo` info value is looked up but no item is provided. So I've copied the code from there and now it works fine.

**Disclaimer**: I don't really know this code very well (probably nobodoy except @jmarshallnz does) so I just fixed the issue at hand. Not sure if that's the right fix or if there's some different problem but from following the code path it looks like this is the proper thing to do.
