### PR TITLE
IMX6: Use correct Method for deletion

### DIFF
--- a/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
@@ -2770,7 +2770,7 @@ bool CLinuxRendererGLES::CreateIMXMAPTexture(int index)
   YUVFIELDS &fields = m_buffers[index].fields;
   YUVPLANE  &plane  = fields[0][0];
 
-  DeleteEGLIMGTexture(index);
+  DeleteIMXMAPTexture(index);
 
   memset(&im    , 0, sizeof(im));
   memset(&fields, 0, sizeof(fields));

--- a/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
@@ -1031,6 +1031,7 @@ void CLinuxRendererGLES::Render(DWORD flags, int index)
   else if (m_renderMethod & RENDER_IMXMAP)
   {
     RenderIMXMAPTexture(index, m_currentField);
+    VerifyGLState();
   }
   else
   {


### PR DESCRIPTION
Call the correct function ptr when deleting IMX textures.
