### PR TITLE
FIX: [aml] no video on newer aml sdk

### DIFF
--- a/tools/android/packaging/xbmc/src/org/xbmc/kodi/Main.java.in
+++ b/tools/android/packaging/xbmc/src/org/xbmc/kodi/Main.java.in
@@ -5,6 +5,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
+import android.graphics.PixelFormat;
 
 public class Main extends NativeActivity 
 {
@@ -19,6 +20,7 @@ public class Main extends NativeActivity
   public void onCreate(Bundle savedInstanceState) 
   {
     super.onCreate(savedInstanceState);
+    getWindow().setFormat(PixelFormat.TRANSPARENT);
   }
 
   @Override


### PR DESCRIPTION
Funnily, amlogic seems to have whitelisted xbmc to use their old way to dig holes in their windows, but not yet kodi.
Symptoms are no apparent video (actually the video plays under kodi).

@topfs2 @MartijnKaijser Waiting from confirmation from http://forum.kodi.tv/showthread.php?tid=209694 then it can go. It's been working for me in spmc for a while.
