### PR TITLE
 [RFC][gui] fix: view state holds wrong file item list while operating with it

### DIFF
--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -678,8 +678,7 @@ bool CGUIMediaWindow::GetDirectory(const std::string &strDirectory, CFileItemLis
       m_history.RemoveParentPath();
   }
 
-  // update the view state to the currently fetched items
-  // TODO we should remove the second call m_guiState.reset() in Update() and pass the right file item ref here
+  // update the view state's reference to the current items
   m_guiState.reset(CGUIViewState::GetViewState(GetID(), items));
 
   if (m_guiState.get() && !m_guiState->HideParentDirItems() && !items.GetPath().empty())
@@ -822,8 +821,6 @@ bool CGUIMediaWindow::Update(const std::string &strDirectory, bool updateFilterP
   OnPrepareFileItems(*m_vecItems);
 
   m_vecItems->FillInDefaultIcons();
-
-  m_guiState.reset(CGUIViewState::GetViewState(GetID(), *m_vecItems));
 
   // remember the original (untouched) list of items (for filtering etc)
   m_unfilteredItems->SetPath(m_vecItems->GetPath()); // use the original path - it'll likely be relied on for other things later.

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -752,8 +752,8 @@ bool CGUIMediaWindow::Update(const std::string &strDirectory, bool updateFilterP
   if (canfilter && url.HasOption("filter"))
     directory = RemoveParameterFromPath(directory, "filter");
 
-  CFileItemList items;
-  if (!GetDirectory(directory, items))
+  ClearFileItems();
+  if (!GetDirectory(directory, *m_vecItems))
   {
     CLog::Log(LOGERROR,"CGUIMediaWindow::GetDirectory(%s) failed", url.GetRedacted().c_str());
     // Try to return to the previous directory, if not the same
@@ -766,14 +766,11 @@ bool CGUIMediaWindow::Update(const std::string &strDirectory, bool updateFilterP
     return false;
   }
 
-  if (items.GetLabel().empty())
-    items.SetLabel(CUtil::GetTitleFromPath(items.GetPath(), true));
-  
-  ClearFileItems();
-  m_vecItems->Copy(items);
+  if (m_vecItems->GetLabel().empty())
+    m_vecItems->SetLabel(CUtil::GetTitleFromPath(m_vecItems->GetPath(), true));
 
   // check the given path for filter data
-  UpdateFilterPath(strDirectory, items, updateFilterPath);
+  UpdateFilterPath(strDirectory, *m_vecItems, updateFilterPath);
     
   // if we're getting the root source listing
   // make sure the path history is clean


### PR DESCRIPTION
As pointed out by #5742 we have an ancient bug where we do some operations on CGUIMediaWindow's m_guiState while it holds the wrong (old) file item list.

This removes the use of a separate CFileItemList object and the copy part to `m_vecItems`. Instead it use `m_vecItems` directly. It also moves the call of `m_guiState.reset()` to `GetDirectory()` directly after items are loaded and before the first operation on `m_guiState` which is `m_guiState->HideParentDirItems()`.

@jmarshallnz it would be very nice if you could take a look and add a comment if it's fine to remove the separate CFileItemList object and the copy part as I don't know why we don't use `m_vecItems` directly.

@Montellese, @Jalle19 ping
