### PR TITLE
[imx] Deinterlacing rework

### DIFF
--- a/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
@@ -2986,7 +2986,7 @@ unsigned int CLinuxRendererGLES::GetOptimalBufferSize()
      m_format == RENDER_FMT_MEDIACODEC)
     return 2;
   else if(m_format == RENDER_FMT_IMXMAP)
-    return 1;
+    return 3;
   else
     return 3;
 }

--- a/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
@@ -2733,16 +2733,16 @@ void CLinuxRendererGLES::UploadIMXMAPTexture(int index)
     glBindTexture(m_textureTarget, plane.id);
 
     GLuint physical = ~0U;
-    GLvoid *virt = (GLvoid*)IMXBuffer->m_VirtAddr;
-    glTexDirectVIVMap(m_textureTarget, IMXBuffer->m_iWidth, IMXBuffer->m_iHeight, GL_VIV_NV12,
+    GLvoid *virt = (GLvoid*)IMXBuffer->pVirtAddr;
+    glTexDirectVIVMap(m_textureTarget, IMXBuffer->iWidth, IMXBuffer->iHeight, GL_VIV_NV12,
                       (GLvoid **)&virt, &physical);
     glTexDirectInvalidateVIV(m_textureTarget);
 
     glBindTexture(m_textureTarget, 0);
 
     plane.flipindex = m_buffers[index].flipindex;
-    plane.texwidth  = IMXBuffer->m_iWidth;
-    plane.texheight = IMXBuffer->m_iHeight;
+    plane.texwidth  = IMXBuffer->iWidth;
+    plane.texheight = IMXBuffer->iHeight;
 
     CalculateTextureSourceRects(index, 1);
 

--- a/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
@@ -2746,8 +2746,14 @@ void CLinuxRendererGLES::UploadIMXMAPTexture(int index)
     if (IMXBuffer->iFormat == 0)
       glTexDirectVIVMap(m_textureTarget, IMXBuffer->iWidth, IMXBuffer->iHeight, GL_VIV_I420,
                         (GLvoid **)&virt, &physical);
-    else
+    else if (IMXBuffer->iFormat == 1)
       glTexDirectVIVMap(m_textureTarget, IMXBuffer->iWidth, IMXBuffer->iHeight, GL_VIV_NV12,
+                        (GLvoid **)&virt, &physical);
+    else if (IMXBuffer->iFormat == 2)
+      glTexDirectVIVMap(m_textureTarget, IMXBuffer->iWidth, IMXBuffer->iHeight, GL_RGB565,
+                        (GLvoid **)&virt, &physical);
+    else if (IMXBuffer->iFormat == 3)
+      glTexDirectVIVMap(m_textureTarget, IMXBuffer->iWidth, IMXBuffer->iHeight, GL_RGBA,
                         (GLvoid **)&virt, &physical);
 
     glTexDirectInvalidateVIV(m_textureTarget);

--- a/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
@@ -1691,7 +1691,7 @@ void CLinuxRendererGLES::RenderIMXMAPTexture(int index, int field)
 #ifdef IMX_PROFILE_BUFFERS
   static unsigned long long last = 0;
   unsigned long long current = XbmcThreads::SystemClockMillis();
-  CLog::Log(LOGNOTICE, "+R  %x  %lld\n", (int)buffer, current-last);
+  CLog::Log(LOGNOTICE, "+R  %f  %lld\n", buffer->GetPts(), current-last);
   last = current;
 #endif
 

--- a/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
@@ -964,13 +964,7 @@ void CLinuxRendererGLES::ReleaseBuffer(int idx)
 #endif
 #ifdef HAS_IMXVPU
   if (m_renderMethod & RENDER_IMXMAP)
-  {
-    if (buf.IMXBuffer)
-    {
-      SAFE_RELEASE(buf.IMXBuffer);
-      buf.IMXBuffer = NULL;
-    }
-  }
+    SAFE_RELEASE(buf.IMXBuffer);
 #endif
 }
 

--- a/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
@@ -89,7 +89,12 @@ static PFNEGLCLIENTWAITSYNCKHRPROC eglClientWaitSyncKHR;
 #include "windowing/egl/EGLWrapper.h"
 #include "DVDCodecs/Video/DVDVideoCodecIMX.h"
 
+#define GL_VIV_YV12 0x8FC0
 #define GL_VIV_NV12 0x8FC1
+#define GL_VIV_YUY2 0x8FC2
+#define GL_VIV_UYVY 0x8FC3
+#define GL_VIV_NV21 0x8FC4
+#define GL_VIV_I420 0x8FC5
 typedef void (GL_APIENTRYP PFNGLTEXDIRECTVIVMAPPROC) (GLenum Target, GLsizei Width, GLsizei Height, GLenum Format, GLvoid ** Logical, const GLuint * Physical);
 typedef void (GL_APIENTRYP PFNGLTEXDIRECTINVALIDATEVIVPROC) (GLenum Target);
 static PFNGLTEXDIRECTVIVMAPPROC glTexDirectVIVMap;
@@ -1237,7 +1242,7 @@ void CLinuxRendererGLES::RenderMultiPass(int index, int field)
 //    imgwidth  *= planes[0].pixpertex_x;
 //    imgheight *= planes[0].pixpertex_y;
 //  }
-//  
+//
 //  glBegin(GL_QUADS);
 //
 //  glMultiTexCoord2fARB(GL_TEXTURE0, planes[0].rect.x1, planes[0].rect.y1);
@@ -1683,18 +1688,23 @@ void CLinuxRendererGLES::RenderIMXMAPTexture(int index, int field)
   YUVPLANE &plane = m_buffers[index].fields[field][0];
   CDVDVideoCodecIMXBuffer *buffer = m_buffers[index].IMXBuffer;
 
-  if(buffer == NULL) return;
+#ifdef IMX_PROFILE_BUFFERS
+  static unsigned long long last = 0;
+  unsigned long long current = XbmcThreads::SystemClockMillis();
+  CLog::Log(LOGNOTICE, "+R  %x  %lld\n", (int)buffer, current-last);
+  last = current;
+#endif
 
-  CDVDVideoCodecIMX::Enter();
+  if(buffer == NULL) return;
 
   if(!buffer->IsValid())
   {
-    CDVDVideoCodecIMX::Leave();
     return;
   }
 
   glDisable(GL_DEPTH_TEST);
 
+  glEnable(m_textureTarget);
   glActiveTexture(GL_TEXTURE0);
   glBindTexture(m_textureTarget, plane.id);
 
@@ -1742,9 +1752,8 @@ void CLinuxRendererGLES::RenderIMXMAPTexture(int index, int field)
   VerifyGLState();
 
   glBindTexture(m_textureTarget, 0);
+  glDisable(m_textureTarget);
   VerifyGLState();
-
-  CDVDVideoCodecIMX::Leave();
 
 #ifdef DEBUG_VERBOSE
   CLog::Log(LOGDEBUG, "RenderIMXMAPTexture %d: tm:%d\n", index, XbmcThreads::SystemClockMillis() - time);
@@ -2719,25 +2728,29 @@ void CLinuxRendererGLES::UploadIMXMAPTexture(int index)
 
   if(IMXBuffer)
   {
-    CDVDVideoCodecIMX::Enter();
-
     if(!IMXBuffer->IsValid())
     {
-      CDVDVideoCodecIMX::Leave();
       return;
     }
 
     YUVPLANE &plane = m_buffers[index].fields[0][0];
 
+    glEnable(m_textureTarget);
     glActiveTexture(GL_TEXTURE0);
+
     glBindTexture(m_textureTarget, plane.id);
 
     GLuint physical = ~0U;
     GLvoid *virt = (GLvoid*)IMXBuffer->pVirtAddr;
-    glTexDirectVIVMap(m_textureTarget, IMXBuffer->iWidth, IMXBuffer->iHeight, GL_VIV_NV12,
-                      (GLvoid **)&virt, &physical);
-    glTexDirectInvalidateVIV(m_textureTarget);
 
+    if (IMXBuffer->iFormat == 0)
+      glTexDirectVIVMap(m_textureTarget, IMXBuffer->iWidth, IMXBuffer->iHeight, GL_VIV_I420,
+                        (GLvoid **)&virt, &physical);
+    else
+      glTexDirectVIVMap(m_textureTarget, IMXBuffer->iWidth, IMXBuffer->iHeight, GL_VIV_NV12,
+                        (GLvoid **)&virt, &physical);
+
+    glTexDirectInvalidateVIV(m_textureTarget);
     glBindTexture(m_textureTarget, 0);
 
     plane.flipindex = m_buffers[index].flipindex;
@@ -2746,7 +2759,7 @@ void CLinuxRendererGLES::UploadIMXMAPTexture(int index)
 
     CalculateTextureSourceRects(index, 1);
 
-    CDVDVideoCodecIMX::Leave();
+    glDisable(m_textureTarget);
   }
 #endif
 }
@@ -2864,9 +2877,6 @@ bool CLinuxRendererGLES::Supports(EDEINTERLACEMODE mode)
   if(m_renderMethod & RENDER_CVREF)
     return false;
 
-  if(m_renderMethod & RENDER_IMXMAP)
-    return false;
-
   if(mode == VS_DEINTERLACEMODE_AUTO
   || mode == VS_DEINTERLACEMODE_FORCE)
     return true;
@@ -2900,6 +2910,15 @@ bool CLinuxRendererGLES::Supports(EINTERLACEMETHOD method)
 
   if(method == VS_INTERLACEMETHOD_AUTO)
     return true;
+
+  if(m_renderMethod & RENDER_IMXMAP)
+  { /*
+    if(method == VS_INTERLACEMETHOD_DEINTERLACE
+    || method == VS_INTERLACEMETHOD_DEINTERLACE_HALF)
+      return true;
+    else*/
+      return false;
+  }
 
 #if defined(__i386__) || defined(__x86_64__)
   if(method == VS_INTERLACEMETHOD_DEINTERLACE
@@ -2966,6 +2985,8 @@ unsigned int CLinuxRendererGLES::GetOptimalBufferSize()
      m_format == RENDER_FMT_EGLIMG ||
      m_format == RENDER_FMT_MEDIACODEC)
     return 2;
+  else if(m_format == RENDER_FMT_IMXMAP)
+    return 1;
   else
     return 3;
 }

--- a/xbmc/cores/VideoRenderers/LinuxRendererGLES.h
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGLES.h
@@ -42,6 +42,9 @@ namespace Shaders { class BaseVideoFilterShader; }
 class COpenMaxVideo;
 class CDVDVideoCodecStageFright;
 class CDVDMediaCodecInfo;
+#ifdef HAS_IMXVPU
+class CDVDVideoCodecIMXBuffer;
+#endif
 typedef std::vector<int>     Features;
 
 

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
@@ -1818,9 +1818,11 @@ CDVDVideoCodecIMXBuffer *CDVDVideoMixerIMX::ProcessFrame(CDVDVideoCodecIMXVPUBuf
     Sleep(35);
     outputBuffer = inputBuffer;
 #else
+    // Enable low motion for buffers that are not split up by the VDIC
+    bool lowMotion = (inputBuffer->iWidth < 1024) && (inputBuffer->iHeight < 1024);
     outputBuffer = m_proc->Process(inputBuffer,
                                    inputBuffer->GetFieldType(),
-                                   false);
+                                   lowMotion);
 #endif
 #ifdef IMX_PROFILE_BUFFERS
     CLog::Log(LOGNOTICE, "+P  %x  %lld\n", (int)outputBuffer,

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
@@ -36,7 +36,7 @@
 #include "utils/log.h"
 #include "DVDClock.h"
 
-#define IMX_MDI_MAX_WIDTH 968
+#define IMX_VDI_MAX_WIDTH 968
 #define FRAME_ALIGN 16
 #define MEDIAINFO 1
 #define _4CC(c1,c2,c3,c4) (((uint32_t)(c4)<<24)|((uint32_t)(c3)<<16)|((uint32_t)(c2)<<8)|(uint32_t)(c1))
@@ -1358,12 +1358,12 @@ bool CDVDVideoCodecIMXIPUBuffer::Process(int fd, CDVDVideoCodecIMXVPUBuffer *buf
 
   /* We do the VDI buffer splitting ourselves since the kernel
    * driver (IPU) is either buggy or it is a feature that it does
-   * not split widths to multiple of 16 to get maximum burst on
-   * on DMA. Since we know that the input and output dimensions are the
+   * not split widths aligned to 16 pixels to get maximum burst on
+   * DMA. Since we know that the input and output dimensions are the
    * same we can implement an easier algorithm that takes care of
    * that.
    */
-  unsigned int nRequiredStripes = (iWidth+IMX_MDI_MAX_WIDTH-1) / IMX_MDI_MAX_WIDTH;
+  unsigned int nRequiredStripes = (iWidth+IMX_VDI_MAX_WIDTH-1) / IMX_VDI_MAX_WIDTH;
   unsigned int iProcWidth = iWidth;
   unsigned int iStripeOffset = 0;
 

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
@@ -189,7 +189,11 @@ bool CDVDVideoCodecIMX::VpuOpen(void)
   VpuAllocBuffers(&memInfo);
 
   m_decOpenParam.nReorderEnable = 1;
+#ifdef IMX_INPUT_FORMAT_I420
+  m_decOpenParam.nChromaInterleave = 0;
+#else
   m_decOpenParam.nChromaInterleave = 1;
+#endif
   m_decOpenParam.nMapType = 0;
   m_decOpenParam.nTiled2LinearEnable = 0;
   m_decOpenParam.nEnableFileMode = 0;
@@ -207,6 +211,24 @@ bool CDVDVideoCodecIMX::VpuOpen(void)
   if (ret != VPU_DEC_RET_SUCCESS)
   {
     CLog::Log(LOGERROR, "%s - iMX VPU set skip mode failed  (%d).\n", __FUNCTION__, ret);
+    goto VpuOpenError;
+  }
+
+  config = VPU_DEC_CONF_BUFDELAY;
+  param = 0;
+  ret = VPU_DecConfig(m_vpuHandle, config, &param);
+  if (ret != VPU_DEC_RET_SUCCESS)
+  {
+    CLog::Log(LOGERROR, "%s - iMX VPU set buffer delay failed  (%d).\n", __FUNCTION__, ret);
+    goto VpuOpenError;
+  }
+
+  config = VPU_DEC_CONF_INPUTTYPE;
+  param = VPU_DEC_IN_NORMAL;
+  ret = VPU_DecConfig(m_vpuHandle, config, &param);
+  if (ret != VPU_DEC_RET_SUCCESS)
+  {
+    CLog::Log(LOGERROR, "%s - iMX VPU configure input type failed  (%d).\n", __FUNCTION__, ret);
     goto VpuOpenError;
   }
 

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
@@ -864,11 +864,7 @@ int CDVDVideoCodecIMX::Decode(BYTE *pData, int iSize, double dts, double pts)
             m_currentBuffer = m_mixer.Process(buffer);
 
           if (m_currentBuffer)
-          {
             retStatus |= VC_PICTURE;
-            //m_currentBuffer->Release();
-            //m_currentBuffer = NULL;
-          }
         }
       } //VPU_DEC_OUTPUT_DIS
 
@@ -1400,7 +1396,7 @@ bool CDVDVideoCodecIMXIPUBuffer::Allocate(int fd, int width, int height, int nAl
   CLog::Log(LOGNOTICE, "IPU: alloc %d bytes for frame of %dx%d at 0x%x\n",
             m_nSize, m_iWidth, m_iHeight, m_pPhyAddr);
 
-  m_pVirtAddr = (uint8_t*)mmap(0, m_nSize, PROT_READ | PROT_WRITE, MAP_SHARED,
+  m_pVirtAddr = (uint8_t*)mmap(0, m_nSize, PROT_READ, MAP_SHARED,
                                fd, m_pPhyAddr);
   if (!m_pVirtAddr)
   {

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
@@ -1373,11 +1373,12 @@ bool CDVDVideoCodecIMXIPUBuffer::Process(int fd, CDVDVideoCodecIMXVPUBuffer *buf
 
   task.input.paddr   = (int)buffer->pPhysAddr;
 
-  bool setupPrevBuffer = lowMotion || (fieldFmt & IPU_DEINTERLACE_RATE_MASK);
-
   // Fill current and next buffer address
-  if (setupPrevBuffer && previousBuffer && previousBuffer->IsValid())
-    task.input.paddr_n = (int)previousBuffer->pPhysAddr;
+  if (lowMotion && previousBuffer && previousBuffer->IsValid())
+  {
+    task.input.paddr_n = task.input.paddr;
+    task.input.paddr   = (int)previousBuffer->pPhysAddr;
+  }
 
   task.input.deinterlace.enable = 1;
   task.input.deinterlace.motion = lowMotion?LOW_MOTION:HIGH_MOTION;

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
@@ -385,16 +385,25 @@ bool CDVDVideoCodecIMX::VpuAllocFrameBuffers(void)
 #endif
   }
 
+  CLog::Log(LOGNOTICE, "IMX: Initialize hardware deinterlacing\n");
+  if (!m_deinterlacer.Init(m_initInfo.nPicWidth, m_initInfo.nPicHeight, GetAllowedReferences()+5, nAlign))
+  {
+    CLog::Log(LOGWARNING, "IMX: Failed to initialize IPU buffers: deinterlacing disabled\n");
+  }
+
+  m_deinterlacer.SetAutoMode(m_initInfo.nInterlace);
+
   return true;
 }
 
-CDVDVideoCodecIMX::CDVDVideoCodecIMX()
+CDVDVideoCodecIMX::CDVDVideoCodecIMX() : m_mixer(&m_deinterlacer)
 {
   m_pFormatName = "iMX-xxx";
   m_vpuHandle = 0;
   m_vpuFrameBuffers = NULL;
   m_outputBuffers = NULL;
   m_lastBuffer = NULL;
+  m_currentBuffer = NULL;
   m_extraMem = NULL;
   m_vpuFrameBufferNum = 0;
   m_dropState = false;
@@ -409,6 +418,7 @@ CDVDVideoCodecIMX::CDVDVideoCodecIMX()
   m_convert_bitstream = false;
   m_bytesToBeConsumed = 0;
   m_previousPts = DVD_NOPTS_VALUE;
+  m_mixer.SetCapacity(3,3);
 }
 
 CDVDVideoCodecIMX::~CDVDVideoCodecIMX()

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
@@ -1281,7 +1281,6 @@ bool CDVDVideoCodecIMXIPUBuffer::Process(int fd, CDVDVideoCodecIMXVPUBuffer *buf
   CDVDVideoCodecIMXVPUBuffer *previousBuffer;
   struct ipu_task task;
   memset(&task, 0, sizeof(task));
-  task.priority = IPU_TASK_PRIORITY_HIGH;
 
   if (lowMotion)
     previousBuffer = buffer->GetPreviousBuffer();

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
@@ -1275,8 +1275,7 @@ bool CDVDVideoCodecIMXIPUBuffer::IsValid()
 }
 
 bool CDVDVideoCodecIMXIPUBuffer::Process(int fd, CDVDVideoCodecIMXVPUBuffer *buffer,
-                                         VpuFieldType fieldType, int fieldFmt,
-                                         bool lowMotion)
+                                         int fieldFmt, bool lowMotion)
 {
   CDVDVideoCodecIMXVPUBuffer *previousBuffer;
   struct ipu_task task;
@@ -1339,7 +1338,7 @@ bool CDVDVideoCodecIMXIPUBuffer::Process(int fd, CDVDVideoCodecIMXVPUBuffer *buf
   task.input.deinterlace.enable = 1;
   task.input.deinterlace.field_fmt = fieldFmt;
 
-  switch (fieldType)
+  switch (buffer->GetFieldType())
   {
   case VPU_FIELD_TOP:
   case VPU_FIELD_TB:
@@ -1597,8 +1596,8 @@ bool CDVDVideoCodecIMXIPUBuffers::Close()
 }
 
 CDVDVideoCodecIMXIPUBuffer *
-CDVDVideoCodecIMXIPUBuffers::Process(CDVDVideoCodecIMXBuffer *sourceBuffer,
-                                     VpuFieldType fieldType, bool lowMotion)
+CDVDVideoCodecIMXIPUBuffers::Process(CDVDVideoCodecIMXVPUBuffer *sourceBuffer,
+                                     bool lowMotion)
 {
   CDVDVideoCodecIMXIPUBuffer *target = NULL;
   bool ret = true;
@@ -1613,8 +1612,7 @@ CDVDVideoCodecIMXIPUBuffers::Process(CDVDVideoCodecIMXBuffer *sourceBuffer,
     // IPU process:
     // SRC: Current VPU physical buffer address + last VPU buffer address
     // DST: IPU buffer[i]
-    ret = m_buffers[i]->Process(m_ipuHandle, (CDVDVideoCodecIMXVPUBuffer*)sourceBuffer,
-                                fieldType, m_currentFieldFmt,
+    ret = m_buffers[i]->Process(m_ipuHandle, sourceBuffer, m_currentFieldFmt,
                                 lowMotion);
     if (ret)
     {
@@ -1865,9 +1863,7 @@ CDVDVideoCodecIMXBuffer *CDVDVideoMixerIMX::ProcessFrame(CDVDVideoCodecIMXVPUBuf
 #else
     // Enable low motion for buffers that are not split up by the VDIC
     bool lowMotion = (inputBuffer->iWidth < 1024) && (inputBuffer->iHeight < 1024);
-    outputBuffer = m_proc->Process(inputBuffer,
-                                   inputBuffer->GetFieldType(),
-                                   lowMotion);
+    outputBuffer = m_proc->Process(inputBuffer, lowMotion);
 #endif
 #ifdef IMX_PROFILE_BUFFERS
     CLog::Log(LOGNOTICE, "+P  %x  %lld\n", (int)outputBuffer,

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
@@ -644,6 +644,8 @@ int CDVDVideoCodecIMX::Decode(BYTE *pData, int iSize, double dts, double pts)
 
 #ifdef IMX_PROFILE
   static unsigned long long previous, current;
+#endif
+#if defined(IMX_PROFILE) || defined(IMX_PROFILE_BUFFERS)
   unsigned long long before_dec;
 #endif
 
@@ -711,12 +713,11 @@ int CDVDVideoCodecIMX::Decode(BYTE *pData, int iSize, double dts, double pts)
 
     while (true) // Decode as long as the VPU consumes data
     {
-#ifdef IMX_PROFILE
+#if defined(IMX_PROFILE) || defined(IMX_PROFILE_BUFFERS)
       before_dec = XbmcThreads::SystemClockMillis();
 #endif
       if (m_frameReported)
         m_bytesToBeConsumed += inData.nSize;
-      unsigned long long before_dec = XbmcThreads::SystemClockMillis();
       ret = VPU_DecDecodeBuf(m_vpuHandle, &inData, &decRet);
 #ifdef IMX_PROFILE_BUFFERS
       dec_time += XbmcThreads::SystemClockMillis()-before_dec;
@@ -1125,7 +1126,7 @@ long CDVDVideoCodecIMXVPUBuffer::Release()
 #endif
   if (count == 2)
   {
-    // Only referenced by the coded and its next frame, release the previous
+    // Only referenced by the codec and its next frame, release the previous
     SAFE_RELEASE(m_previousBuffer);
   }
   if (count == 1)
@@ -1308,7 +1309,7 @@ bool CDVDVideoCodecIMXIPUBuffer::Process(int fd, CDVDVideoCodecIMXVPUBuffer *buf
   task.output.height = iHeight;
 #ifdef IMX_OUTPUT_FORMAT_I420
   task.output.format = IPU_PIX_FMT_YUV420P;
-  format             = 0;
+  iFormat            = 0;
 #else
   task.output.format = IPU_PIX_FMT_NV12;
   iFormat            = 1;

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
@@ -976,18 +976,38 @@ void CDVDVideoCodecIMX::Leave()
 }
 
 /*******************************************/
+#ifdef TRACE_FRAMES
+CDVDVideoCodecIMXBuffer::CDVDVideoCodecIMXBuffer(int idx)
+  : m_idx(idx)
+  , m_refs(1)
+#else
+CDVDVideoCodecIMXBuffer::CDVDVideoCodecIMXBuffer()
+  : m_refs(1)
+#endif
+  , m_pts(DVD_NOPTS_VALUE)
+  , m_dts(DVD_NOPTS_VALUE)
+{
+}
+
+void CDVDVideoCodecIMXBuffer::SetPts(double pts)
+{
+  m_pts = pts;
+}
+
+void CDVDVideoCodecIMXBuffer::SetDts(double dts)
+{
+  m_dts = dts;
+}
 
 #ifdef TRACE_FRAMES
 CDVDVideoCodecIMXVPUBuffer::CDVDVideoCodecIMXVPUBuffer(int idx)
-  : m_refs(1)
-  , m_idx(idx)
+  : CDVDVideoCodecIMXBuffer(idx)
 #else
 CDVDVideoCodecIMXVPUBuffer::CDVDVideoCodecIMXVPUBuffer()
-  : m_refs(1)
+  : CDVDVideoCodecIMXBuffer()
 #endif
   , m_frameBuffer(NULL)
   , m_rendered(false)
-  , m_pts(DVD_NOPTS_VALUE)
   , m_previousBuffer(NULL)
 {
 }
@@ -1078,20 +1098,10 @@ VpuDecRetCode CDVDVideoCodecIMXVPUBuffer::ReleaseFramebuffer(VpuDecHandle *handl
 #endif
   m_rendered = false;
   m_frameBuffer = NULL;
-  m_pts = DVD_NOPTS_VALUE;
+  SetPts(DVD_NOPTS_VALUE);
   SAFE_RELEASE(m_previousBuffer);
 
   return ret;
-}
-
-void CDVDVideoCodecIMXVPUBuffer::SetPts(double pts)
-{
-  m_pts = pts;
-}
-
-double CDVDVideoCodecIMXVPUBuffer::GetPts(void) const
-{
-  return m_pts;
 }
 
 CDVDVideoCodecIMXVPUBuffer *CDVDVideoCodecIMXVPUBuffer::GetPreviousBuffer() const

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
@@ -986,7 +986,7 @@ int CDVDVideoCodecIMX::Decode(BYTE *pData, int iSize, double dts, double pts)
   } //(pData && iSize)
 
   // Reply to flush call only if double rate is active
-  if (m_mixer.DoubleRate() && !retStatus)
+  if ((m_dropState || m_mixer.DoubleRate()) && !retStatus)
   {
     m_currentBuffer = m_mixer.Process(NULL);
     if (m_currentBuffer)

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
@@ -1865,18 +1865,21 @@ void CDVDVideoMixerIMX::Process()
       {
         CDVDVideoCodecIMXBuffer *outputBuffer;
 
+        /*
         bool isSD = (inputBuffer->iWidth < 1024) && (inputBuffer->iHeight < 1024);
         bool hasPreviousBuffer = (inputBuffer->GetPreviousBuffer() != NULL) &&
                                  inputBuffer->GetPreviousBuffer()->IsValid();
+        */
 
         // Disable lowMotion for now due to worse deinterlacing quality
-        bool lowMotion = false && hasPreviousBuffer;
+        bool lowMotion = false;
+        //bool lowMotion = isSD && hasPreviousBuffer;
 
         // Currently double rate introduces oscillating scanlines (either wrong
         // buffer setup or some other kernel issue) so we disable it completely
         // for the time being
-        //bool doubleRate = false;
-        bool doubleRate = isSD && hasPreviousBuffer;
+        bool doubleRate = false;
+        //bool doubleRate = isSD && hasPreviousBuffer;
 
         m_proc->SetDoubleRate(doubleRate);
 

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
@@ -1221,8 +1221,8 @@ void CDVDVideoCodecIMXVPUBuffer::Queue(VpuDecOutFrameInfo *frameInfo,
   iHeight   = frameInfo->pExtInfo->nFrmHeight;
   pVirtAddr = m_frameBuffer->pbufVirtY;
   pPhysAddr = m_frameBuffer->pbufY;
+  fieldType = frameInfo->eFieldType;
 
-  m_fieldType = frameInfo->eFieldType;
   // We decode to I420
 #ifdef IMX_INPUT_FORMAT_I420
   iFormat = 0;
@@ -1338,6 +1338,7 @@ bool CDVDVideoCodecIMXIPUBuffer::Process(int fd, CDVDVideoCodecIMXVPUBuffer *buf
   m_bFree            = true;
   iWidth             = buffer->iWidth;
   iHeight            = buffer->iHeight;
+  fieldType          = VPU_FIELD_NONE;
 
   // Input is the VPU decoded frame
   task.input.width   = iWidth;

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.h
@@ -58,16 +58,16 @@ public:
 #endif
 
   // reference counting
-  virtual void             Lock();
-  virtual long             Release();
-  virtual bool             IsValid();
+  virtual void                Lock();
+  virtual long                Release();
+  virtual bool                IsValid();
 
-  bool                     Rendered() const;
-  void                     Queue(VpuDecOutFrameInfo *frameInfo,
-                                 CDVDVideoCodecIMXVPUBuffer *previous);
-  VpuDecRetCode            ReleaseFramebuffer(VpuDecHandle *handle);
-  void                     SetPts(double pts);
-  double                   GetPts(void) const;
+  bool                        Rendered() const;
+  void                        Queue(VpuDecOutFrameInfo *frameInfo,
+                                    CDVDVideoCodecIMXVPUBuffer *previous);
+  VpuDecRetCode               ReleaseFramebuffer(VpuDecHandle *handle);
+  void                        SetPts(double pts);
+  double                      GetPts(void) const;
   CDVDVideoCodecIMXVPUBuffer *GetPreviousBuffer() const;
 
   uint32_t       m_iWidth;
@@ -77,18 +77,18 @@ public:
 
 private:
   // private because we are reference counted
-  virtual                  ~CDVDVideoCodecIMXVPUBuffer();
+  virtual                     ~CDVDVideoCodecIMXVPUBuffer();
 
 private:
 #ifdef TRACE_FRAMES
-  int                      m_idx;
+  int                         m_idx;
 #endif
-  long                     m_refs;
-  VpuFrameBuffer          *m_frameBuffer;
-  bool                     m_rendered;
-  double                   m_pts;
+  long                        m_refs;
+  VpuFrameBuffer             *m_frameBuffer;
+  bool                        m_rendered;
+  double                      m_pts;
   CDVDVideoCodecIMXVPUBuffer *m_previousBuffer; // Holds a the reference counted
-                                             // previous buffer
+                                                // previous buffer
 };
 
 typedef CDVDVideoCodecIMXVPUBuffer CDVDVideoCodecIMXBuffer;

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.h
@@ -48,13 +48,13 @@ public:
   VpuMemDesc* phyMem;
 };
 
-class CDVDVideoCodecIMXBuffer
+class CDVDVideoCodecIMXVPUBuffer
 {
 public:
 #ifdef TRACE_FRAMES
-  CDVDVideoCodecIMXBuffer(int idx);
+  CDVDVideoCodecIMXVPUBuffer(int idx);
 #else
-  CDVDVideoCodecIMXBuffer();
+  CDVDVideoCodecIMXVPUBuffer();
 #endif
 
   // reference counting
@@ -64,11 +64,11 @@ public:
 
   bool                     Rendered() const;
   void                     Queue(VpuDecOutFrameInfo *frameInfo,
-                                 CDVDVideoCodecIMXBuffer *previous);
+                                 CDVDVideoCodecIMXVPUBuffer *previous);
   VpuDecRetCode            ReleaseFramebuffer(VpuDecHandle *handle);
   void                     SetPts(double pts);
   double                   GetPts(void) const;
-  CDVDVideoCodecIMXBuffer *GetPreviousBuffer() const;
+  CDVDVideoCodecIMXVPUBuffer *GetPreviousBuffer() const;
 
   uint32_t       m_iWidth;
   uint32_t       m_iHeight;
@@ -77,7 +77,7 @@ public:
 
 private:
   // private because we are reference counted
-  virtual                  ~CDVDVideoCodecIMXBuffer();
+  virtual                  ~CDVDVideoCodecIMXVPUBuffer();
 
 private:
 #ifdef TRACE_FRAMES
@@ -87,13 +87,15 @@ private:
   VpuFrameBuffer          *m_frameBuffer;
   bool                     m_rendered;
   double                   m_pts;
-  CDVDVideoCodecIMXBuffer *m_previousBuffer; // Holds a the reference counted
+  CDVDVideoCodecIMXVPUBuffer *m_previousBuffer; // Holds a the reference counted
                                              // previous buffer
 };
 
+typedef CDVDVideoCodecIMXVPUBuffer CDVDVideoCodecIMXBuffer;
+
 class CDVDVideoCodecIMX : public CDVDVideoCodec
 {
-  friend class CDVDVideoCodecIMXBuffer;
+  friend class CDVDVideoCodecIMXVPUBuffer;
   friend class CDVDVideoCodecIPUBuffer;
 
 public:
@@ -122,30 +124,30 @@ protected:
   bool VpuAllocFrameBuffers();
   int  VpuFindBuffer(void *frameAddr);
 
-  static const int          m_extraVpuBuffers;   // Number of additional buffers for VPU
-  static const int          m_maxVpuDecodeLoops; // Maximum iterations in VPU decoding loop
-  static CCriticalSection   m_codecBufferLock;   // Lock to protect buffers handled
-                                                 // by both decoding and rendering threads
+  static const int             m_extraVpuBuffers;   // Number of additional buffers for VPU
+  static const int             m_maxVpuDecodeLoops; // Maximum iterations in VPU decoding loop
+  static CCriticalSection      m_codecBufferLock;   // Lock to protect buffers handled
+                                                    // by both decoding and rendering threads
 
-  CDVDStreamInfo            m_hints;             // Hints from demuxer at stream opening
-  const char               *m_pFormatName;       // Current decoder format name
-  VpuDecOpenParam           m_decOpenParam;      // Parameters required to call VPU_DecOpen
-  CDecMemInfo               m_decMemInfo;        // VPU dedicated memory description
-  VpuDecHandle              m_vpuHandle;         // Handle for VPU library calls
-  VpuDecInitInfo            m_initInfo;          // Initial info returned from VPU at decoding start
-  bool                      m_dropState;         // Current drop state
-  int                       m_vpuFrameBufferNum; // Total number of allocated frame buffers
-  VpuFrameBuffer           *m_vpuFrameBuffers;   // Table of VPU frame buffers description
-  CDVDVideoCodecIMXBuffer **m_outputBuffers;     // Table of VPU output buffers
-  CDVDVideoCodecIMXBuffer  *m_lastBuffer;        // Keep track of previous VPU output buffer (needed by deinterlacing motion engin)
-  VpuMemDesc               *m_extraMem;          // Table of allocated extra Memory
-  int                       m_frameCounter;      // Decoded frames counter
-  bool                      m_usePTS;            // State whether pts out of decoding process should be used
-  VpuDecOutFrameInfo        m_frameInfo;         // Store last VPU output frame info
-  CBitstreamConverter      *m_converter;         // H264 annex B converter
-  bool                      m_convert_bitstream; // State whether bitstream conversion is required
-  int                       m_bytesToBeConsumed; // Remaining bytes in VPU
-  double                    m_previousPts;       // Enable to keep pts when needed
-  bool                      m_frameReported;     // State whether the frame consumed event will be reported by libfslvpu
-  double                    m_dts;               // Current dts
+  CDVDStreamInfo               m_hints;             // Hints from demuxer at stream opening
+  const char                  *m_pFormatName;       // Current decoder format name
+  VpuDecOpenParam              m_decOpenParam;      // Parameters required to call VPU_DecOpen
+  CDecMemInfo                  m_decMemInfo;        // VPU dedicated memory description
+  VpuDecHandle                 m_vpuHandle;         // Handle for VPU library calls
+  VpuDecInitInfo               m_initInfo;          // Initial info returned from VPU at decoding start
+  bool                         m_dropState;         // Current drop state
+  int                          m_vpuFrameBufferNum; // Total number of allocated frame buffers
+  VpuFrameBuffer              *m_vpuFrameBuffers;   // Table of VPU frame buffers description
+  CDVDVideoCodecIMXVPUBuffer **m_outputBuffers;     // Table of VPU output buffers
+  CDVDVideoCodecIMXVPUBuffer  *m_lastBuffer;        // Keep track of previous VPU output buffer (needed by deinterlacing motion engin)
+  VpuMemDesc                  *m_extraMem;          // Table of allocated extra Memory
+  int                          m_frameCounter;      // Decoded frames counter
+  bool                         m_usePTS;            // State whether pts out of decoding process should be used
+  VpuDecOutFrameInfo           m_frameInfo;         // Store last VPU output frame info
+  CBitstreamConverter         *m_converter;         // H264 annex B converter
+  bool                         m_convert_bitstream; // State whether bitstream conversion is required
+  int                          m_bytesToBeConsumed; // Remaining bytes in VPU
+  double                       m_previousPts;       // Enable to keep pts when needed
+  bool                         m_frameReported;     // State whether the frame consumed event will be reported by libfslvpu
+  double                       m_dts;               // Current dts
 };

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.h
@@ -277,9 +277,6 @@ public:
   virtual const char* GetName(void) { return (const char*)m_pFormatName; }
   virtual unsigned GetAllowedReferences();
 
-  static void Enter();
-  static void Leave();
-
 protected:
   bool VpuOpen();
   bool VpuAllocBuffers(VpuMemInfo *);
@@ -289,8 +286,6 @@ protected:
 
   static const int             m_extraVpuBuffers;   // Number of additional buffers for VPU
   static const int             m_maxVpuDecodeLoops; // Maximum iterations in VPU decoding loop
-  static CCriticalSection      m_codecBufferLock;   // Lock to protect buffers handled
-                                                    // by both decoding and rendering threads
 
   CDVDStreamInfo               m_hints;             // Hints from demuxer at stream opening
   const char                  *m_pFormatName;       // Current decoder format name
@@ -315,5 +310,4 @@ protected:
   int                          m_bytesToBeConsumed; // Remaining bytes in VPU
   double                       m_previousPts;       // Enable to keep pts when needed
   bool                         m_frameReported;     // State whether the frame consumed event will be reported by libfslvpu
-  double                       m_dts;               // Current dts
 };

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.h
@@ -38,8 +38,8 @@
 // The IPU works faster when outputting to NV12.
 //#define IMX_OUTPUT_FORMAT_I420
 
-// This enables logging of times for Decode->Decode, Render->Render,
-// Deinterlace->Deinterlace. It helps to profile several stages of
+// This enables logging of times for Decode, Render->Render,
+// Deinterlace. It helps to profile several stages of
 // processing with respect to changed kernels or other configurations.
 // Since we utilize VPU, IPU and GPU at the same time different kernel
 // priorities to those subsystems can result in a very different user

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.h
@@ -330,8 +330,11 @@ protected:
   bool                         m_dropState;         // Current drop state
   int                          m_vpuFrameBufferNum; // Total number of allocated frame buffers
   VpuFrameBuffer              *m_vpuFrameBuffers;   // Table of VPU frame buffers description
+  CDVDVideoCodecIMXIPUBuffers  m_deinterlacer;      // Pool of buffers used for deinterlacing
+  CDVDVideoMixerIMX            m_mixer;
   CDVDVideoCodecIMXVPUBuffer **m_outputBuffers;     // Table of VPU output buffers
   CDVDVideoCodecIMXVPUBuffer  *m_lastBuffer;        // Keep track of previous VPU output buffer (needed by deinterlacing motion engin)
+  CDVDVideoCodecIMXBuffer     *m_currentBuffer;
   VpuMemDesc                  *m_extraMem;          // Table of allocated extra Memory
   int                          m_frameCounter;      // Decoded frames counter
   bool                         m_usePTS;            // State whether pts out of decoding process should be used

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.h
@@ -203,6 +203,9 @@ public:
   // Sets the mode to be used if deinterlacing is set to AUTO
   void SetAutoMode(bool mode) { m_autoMode = mode; }
   bool AutoMode() const { return m_autoMode; }
+  void SetDoubleRate(bool flag);
+  bool DoubleRate() const;
+  void SetInterpolatedFrame(bool flag);
   bool Reset();
   bool Close();
 
@@ -225,6 +228,7 @@ public:
   virtual ~CDVDVideoMixerIMX();
 
   void SetCapacity(int intput, int output);
+  bool DoubleRate() const { return m_proc->DoubleRate(); }
 
   void Start();
   void Reset();
@@ -239,7 +243,8 @@ private:
   CDVDVideoCodecIMXVPUBuffer *GetNextInput();
   void WaitForFreeOutput();
   bool PushOutput(CDVDVideoCodecIMXBuffer *v);
-  CDVDVideoCodecIMXBuffer *ProcessFrame(CDVDVideoCodecIMXVPUBuffer *input);
+  CDVDVideoCodecIMXBuffer *ProcessFrame(CDVDVideoCodecIMXVPUBuffer *input,
+                                        bool lowMotion);
 
   virtual void OnStartup();
   virtual void OnExit();
@@ -317,4 +322,7 @@ protected:
   int                          m_bytesToBeConsumed; // Remaining bytes in VPU
   double                       m_previousPts;       // Enable to keep pts when needed
   bool                         m_frameReported;     // State whether the frame consumed event will be reported by libfslvpu
+#ifdef DUMP_STREAM
+  FILE                        *m_dump;
+#endif
 };

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.h
@@ -127,16 +127,19 @@ public:
                                     CDVDVideoCodecIMXVPUBuffer *previous);
   VpuDecRetCode               ReleaseFramebuffer(VpuDecHandle *handle);
   CDVDVideoCodecIMXVPUBuffer *GetPreviousBuffer() const;
+  VpuFieldType                GetFieldType() const { return m_fieldType; }
 
 private:
   // private because we are reference counted
-  virtual                     ~CDVDVideoCodecIMXVPUBuffer();
+  virtual                    ~CDVDVideoCodecIMXVPUBuffer();
 
 private:
   VpuFrameBuffer             *m_frameBuffer;
+  VpuFieldType                m_fieldType;
+
   bool                        m_rendered;
   CDVDVideoCodecIMXVPUBuffer *m_previousBuffer; // Holds a the reference counted
-                                                // previous buffer
+                                             // previous buffer
 };
 
 

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.h
@@ -26,6 +26,14 @@
 #include "utils/BitstreamConverter.h"
 
 
+// The decoding format of the VPU buffer. Comment this to decode
+// as NV12. The VPU works faster with I420.
+#define IMX_INPUT_FORMAT_I420
+
+// The deinterlacer output and render format. Uncomment to use I420.
+// The IPU works faster when outputting to NV12.
+//#define IMX_OUTPUT_FORMAT_I420
+
 //#define IMX_PROFILE
 //#define TRACE_FRAMES
 
@@ -155,6 +163,35 @@ private:
   uint32_t                 m_iWidth;
   uint32_t                 m_iHeight;
   int                      m_nSize;
+};
+
+
+// Collection class that manages a pool of IPU buffers that are used for
+// deinterlacing. In future they can also serve rotation or color conversion
+// buffers.
+class CDVDVideoCodecIMXIPUBuffers
+{
+  public:
+    CDVDVideoCodecIMXIPUBuffers();
+    ~CDVDVideoCodecIMXIPUBuffers();
+
+    bool Init(int width, int height, int numBuffers, int nAlign);
+    // Sets the mode to be used if deinterlacing is set to AUTO
+    void SetAutoMode(bool mode) { m_autoMode = mode; }
+	bool AutoMode() const { return m_autoMode; }
+    bool Reset();
+    bool Close();
+
+    CDVDVideoCodecIMXIPUBuffer *
+    Process(CDVDVideoCodecIMXBuffer *sourceBuffer,
+            VpuFieldType fieldType, bool lowMotion);
+
+  private:
+    int                          m_ipuHandle;
+	bool                         m_autoMode;
+    int                          m_bufferNum;
+    CDVDVideoCodecIMXIPUBuffer **m_buffers;
+    int                          m_currentFieldFmt;
 };
 
 

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.h
@@ -48,7 +48,44 @@ public:
   VpuMemDesc* phyMem;
 };
 
-class CDVDVideoCodecIMXVPUBuffer
+// Base class of IMXVPU buffer
+class CDVDVideoCodecIMXBuffer {
+public:
+#ifdef TRACE_FRAMES
+  CDVDVideoCodecIMXBuffer(int idx);
+#else
+  CDVDVideoCodecIMXBuffer();
+#endif
+
+  // reference counting
+  virtual void  Lock() = 0;
+  virtual long  Release() = 0;
+  virtual bool  IsValid() = 0;
+
+  void          SetPts(double pts);
+  double        GetPts(void) const { return m_pts; }
+
+  void          SetDts(double dts);
+  double        GetDts(void) const { return m_dts; }
+
+  uint32_t      iWidth;
+  uint32_t      iHeight;
+  uint8_t      *pPhysAddr;
+  uint8_t      *pVirtAddr;
+  uint8_t       iFormat;
+
+protected:
+#ifdef TRACE_FRAMES
+  int           m_idx;
+#endif
+  long          m_refs;
+
+private:
+  double        m_pts;
+  double        m_dts;
+};
+
+class CDVDVideoCodecIMXVPUBuffer : public CDVDVideoCodecIMXBuffer
 {
 public:
 #ifdef TRACE_FRAMES
@@ -66,32 +103,18 @@ public:
   void                        Queue(VpuDecOutFrameInfo *frameInfo,
                                     CDVDVideoCodecIMXVPUBuffer *previous);
   VpuDecRetCode               ReleaseFramebuffer(VpuDecHandle *handle);
-  void                        SetPts(double pts);
-  double                      GetPts(void) const;
   CDVDVideoCodecIMXVPUBuffer *GetPreviousBuffer() const;
-
-  uint32_t       m_iWidth;
-  uint32_t       m_iHeight;
-  uint8_t       *m_phyAddr;
-  uint8_t       *m_VirtAddr;
 
 private:
   // private because we are reference counted
   virtual                     ~CDVDVideoCodecIMXVPUBuffer();
 
 private:
-#ifdef TRACE_FRAMES
-  int                         m_idx;
-#endif
-  long                        m_refs;
   VpuFrameBuffer             *m_frameBuffer;
   bool                        m_rendered;
-  double                      m_pts;
   CDVDVideoCodecIMXVPUBuffer *m_previousBuffer; // Holds a the reference counted
                                                 // previous buffer
 };
-
-typedef CDVDVideoCodecIMXVPUBuffer CDVDVideoCodecIMXBuffer;
 
 class CDVDVideoCodecIMX : public CDVDVideoCodec
 {

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.h
@@ -287,9 +287,6 @@ private:
 
 class CDVDVideoCodecIMX : public CDVDVideoCodec
 {
-  friend class CDVDVideoCodecIMXVPUBuffer;
-  friend class CDVDVideoCodecIPUBuffer;
-
 public:
   CDVDVideoCodecIMX();
   virtual ~CDVDVideoCodecIMX();

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.h
@@ -31,12 +31,16 @@
 
 
 // The decoding format of the VPU buffer. Comment this to decode
-// as NV12. The VPU works faster with I420.
-#define IMX_INPUT_FORMAT_I420
+// as NV12. The VPU works faster with NV12 in combination with
+// deinterlacing.
+//#define IMX_INPUT_FORMAT_I420
 
-// The deinterlacer output and render format. Uncomment to use I420.
-// The IPU works faster when outputting to NV12.
+// The deinterlacer output and render format. Only one format must be active
+// at a time
+#define IMX_OUTPUT_FORMAT_NV12
 //#define IMX_OUTPUT_FORMAT_I420
+//#define IMX_OUTPUT_FORMAT_RGB565
+//#define IMX_OUTPUT_FORMAT_RGB32
 
 // This enables logging of times for Decode, Render->Render,
 // Deinterlace. It helps to profile several stages of
@@ -49,6 +53,11 @@
 
 //#define IMX_PROFILE
 //#define TRACE_FRAMES
+
+// If uncommented a file "stream.dump" will be created in the current
+// directory whenever a new stream is started. This is only for debugging
+// and performance tests. This define must never be active in distributions.
+//#define DUMP_STREAM
 
 class CDecMemInfo
 {

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.h
@@ -187,60 +187,32 @@ private:
 // buffers.
 class CDVDVideoCodecIMXIPUBuffers
 {
-  public:
-    CDVDVideoCodecIMXIPUBuffers();
-    ~CDVDVideoCodecIMXIPUBuffers();
+public:
+  CDVDVideoCodecIMXIPUBuffers();
+  ~CDVDVideoCodecIMXIPUBuffers();
 
-    bool Init(int width, int height, int numBuffers, int nAlign);
-    // Sets the mode to be used if deinterlacing is set to AUTO
-    void SetAutoMode(bool mode) { m_autoMode = mode; }
-	bool AutoMode() const { return m_autoMode; }
-    bool Reset();
-    bool Close();
+  bool Init(int width, int height, int numBuffers, int nAlign);
+  // Sets the mode to be used if deinterlacing is set to AUTO
+  void SetAutoMode(bool mode) { m_autoMode = mode; }
+  bool AutoMode() const { return m_autoMode; }
+  bool Reset();
+  bool Close();
 
-    CDVDVideoCodecIMXIPUBuffer *
-    Process(CDVDVideoCodecIMXBuffer *sourceBuffer,
-            VpuFieldType fieldType, bool lowMotion);
+  CDVDVideoCodecIMXIPUBuffer *
+  Process(CDVDVideoCodecIMXBuffer *sourceBuffer,
+          VpuFieldType fieldType, bool lowMotion);
 
-  private:
-    int                          m_ipuHandle;
-	bool                         m_autoMode;
-    int                          m_bufferNum;
-    CDVDVideoCodecIMXIPUBuffer **m_buffers;
-    int                          m_currentFieldFmt;
+private:
+  int                          m_ipuHandle;
+  bool                         m_autoMode;
+  int                          m_bufferNum;
+  CDVDVideoCodecIMXIPUBuffer **m_buffers;
+  int                          m_currentFieldFmt;
 };
 
 
-// Collection class that manages a pool of IPU buffers that are used for
-// deinterlacing. In future they can also serve rotation or color conversion
-// buffers.
-class CDVDVideoCodecIMXIPUBuffers
+class CDVDVideoMixerIMX : private CThread
 {
-  public:
-    CDVDVideoCodecIMXIPUBuffers();
-    ~CDVDVideoCodecIMXIPUBuffers();
-
-    bool Init(int width, int height, int numBuffers, int nAlign);
-    // Sets the mode to be used if deinterlacing is set to AUTO
-    void SetAutoMode(bool mode) { m_autoMode = mode; }
-	bool AutoMode() const { return m_autoMode; }
-    bool Reset();
-    bool Close();
-
-    CDVDVideoCodecIMXIPUBuffer *
-    Process(CDVDVideoCodecIMXBuffer *sourceBuffer,
-            VpuFieldType fieldType, bool lowMotion);
-
-  private:
-    int                          m_ipuHandle;
-	bool                         m_autoMode;
-    int                          m_bufferNum;
-    CDVDVideoCodecIMXIPUBuffer **m_buffers;
-    int                          m_currentFieldFmt;
-};
-
-
-class CDVDVideoMixerIMX : private CThread {
 public:
   CDVDVideoMixerIMX(CDVDVideoCodecIMXIPUBuffers *proc);
   virtual ~CDVDVideoMixerIMX();
@@ -309,7 +281,6 @@ public:
   static void Leave();
 
 protected:
-
   bool VpuOpen();
   bool VpuAllocBuffers(VpuMemInfo *);
   bool VpuFreeBuffers();

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.h
@@ -171,8 +171,7 @@ public:
   // Returns whether the buffer is ready to be used
   bool                     Rendered() const { return m_bFree; }
   bool                     Process(int fd, CDVDVideoCodecIMXVPUBuffer *buffer,
-                                   VpuFieldType fieldType, int fieldFmt,
-                                   bool lowMotion);
+                                   int fieldFmt, bool lowMotion);
   void                     ReleaseFrameBuffer();
 
   bool                     Allocate(int fd, int width, int height, int nAlign);
@@ -208,8 +207,7 @@ public:
   bool Close();
 
   CDVDVideoCodecIMXIPUBuffer *
-  Process(CDVDVideoCodecIMXBuffer *sourceBuffer,
-          VpuFieldType fieldType, bool lowMotion);
+  Process(CDVDVideoCodecIMXVPUBuffer *sourceBuffer, bool lowMotion);
 
 private:
   int                          m_ipuHandle;

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.h
@@ -99,11 +99,15 @@ public:
   void          SetDts(double dts);
   double        GetDts(void) const { return m_dts; }
 
+  VpuFieldType  GetFieldType() const { return fieldType; }
+
   uint32_t      iWidth;
   uint32_t      iHeight;
   uint8_t      *pPhysAddr;
   uint8_t      *pVirtAddr;
   uint8_t       iFormat;
+  VpuFieldType  fieldType;
+
 
 protected:
 #ifdef TRACE_FRAMES
@@ -136,7 +140,6 @@ public:
                                     CDVDVideoCodecIMXVPUBuffer *previous);
   VpuDecRetCode               ReleaseFramebuffer(VpuDecHandle *handle);
   CDVDVideoCodecIMXVPUBuffer *GetPreviousBuffer() const;
-  VpuFieldType                GetFieldType() const { return m_fieldType; }
 
 private:
   // private because we are reference counted
@@ -144,8 +147,6 @@ private:
 
 private:
   VpuFrameBuffer             *m_frameBuffer;
-  VpuFieldType                m_fieldType;
-
   bool                        m_rendered;
   CDVDVideoCodecIMXVPUBuffer *m_previousBuffer; // Holds a the reference counted
                                              // previous buffer


### PR DESCRIPTION
This is the rework of the HW deinterlacing for IMX6 boards (see xbmc-imx6/xbmc#70). It creates a mixer threads that offloads deinterlacing to the IPU in parallel to VPU decoding and GPU rendering.

What works:
- Selectable deinterlacing modes: None, Auto, Force

What does not work:
- Double rate feature. Can be easily implemented but needs proper settings in the GUI
- Smooth playback for HD streams which needs to be tested. The performance for my test setup increased already compared to Gotham

This PR is for review to be integrated into the current IMX6 Codec implementation.
