### PR TITLE
[libdvdread] - fix out of bound access when playing some iso files

### DIFF
--- a/lib/libdvd/libdvdread/src/dvd_reader.c
+++ b/lib/libdvd/libdvdread/src/dvd_reader.c
@@ -1248,7 +1248,7 @@ int DVDCheckSector(unsigned char *data, int offset)
 {
   int i = 0;
   int32_t *p = (int32_t*)data + (DVD_VIDEO_LB_LEN>>2)*offset;
-  for(;i<(DVD_VIDEO_LB_LEN<<2);i++) {
+  for(;i<(DVD_VIDEO_LB_LEN>>2);i++) {
     if(*(p+i) != 0)
       break;
   }

--- a/lib/libdvd/patches/01-libdvdread.diff
+++ b/lib/libdvd/patches/01-libdvdread.diff
@@ -147,7 +147,7 @@ diff -uwr libdvdread-4.2.1/src/dvd_reader.c xbmc/lib/libdvd/libdvdread/src/dvd_r
 +{
 +  int i = 0;
 +  int32_t *p = (int32_t*)data + (DVD_VIDEO_LB_LEN>>2)*offset;
-+  for(;i<(DVD_VIDEO_LB_LEN<<2);i++) {
++  for(;i<(DVD_VIDEO_LB_LEN>>2);i++) {
 +    if(*(p+i) != 0)
 +      break;
 +  }


### PR DESCRIPTION
ATM playing iso files on ios leads to instant crash. The reason is a bad access because of a typo.

thx to @Karlson2k for finding that one out.

This PR fixes the crash - playback of iso on ios is still broken though - there is still something wrong with the cached reads after e502b0993760b3e8b001f0360755a424bab79086

This is a regression from Gotham and we can hopefully track it down before release...
