### PR TITLE
Script to set up Windows build dir as KODI_HOME

### DIFF
--- a/project/VS2010Express/make_kodi_home_symlinks.bat
+++ b/project/VS2010Express/make_kodi_home_symlinks.bat
@@ -1,0 +1,95 @@
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+::
+:: Creates symbolic links of all Kodi dependencies into the specified directory.
+::
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+@ECHO OFF
+SETLOCAL enabledelayedexpansion enableextensions
+GOTO :Main
+
+
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+:: Helper functions
+
+
+:: Print information about using this script
+:Usage
+(
+   ECHO.
+   ECHO %~nx0: Script for creating symlinks to directories and
+   ECHO files that Kodi depends on (and expects to find via KODI_HOME^), allowing Kodi
+   ECHO to run from the build directory without KODI_HOME being explicitly set.
+   ECHO.
+   ECHO This makes it possible to run/debug Kodi in scenarios where setting KODI_HOME
+   ECHO to point to the build directory is not feasible (e.g., when running as a COM
+   ECHO server^).
+   ECHO.
+   ECHO Usage:
+   ECHO   %~nx0 ^<target^>
+   ECHO.
+   ECHO      ^<target^> The directory into which the DLLs and directories should be
+   ECHO               linked. This should be the directory containing Kodi.exe.
+   EXIT /B
+)
+
+
+:: Helper function to get the absolute path from its second argument, and set
+:: that into the variable named by its first argument
+:SetAbsolutePath <resultVar> <pathVar>
+(
+   SET "%~1=%~f2"
+   EXIT /B
+)
+
+
+:: Checks for the existence of a symbolic link in TARGET_DIR, pointing to
+:: <sourcePath>, and creates it if it does not exist
+:MakeSymlink <sourcePath>
+(
+   SET SOURCE=%1
+   SET TARGET=%TARGET_DIR%\%~nx1
+   IF EXIST "%TARGET%" (
+      ECHO Symlink %TARGET% exists
+   ) ELSE (
+      IF EXIST %SOURCE%\* (
+         ECHO Creating DIR symlink %TARGET%
+         mklink /D "%TARGET%" "%SOURCE%"
+      ) ELSE (
+         ECHO Creating FILE symlink %TARGET%
+         mklink "%TARGET%" "%SOURCE%"
+      )
+   )
+   EXIT /B
+)
+
+
+
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+:: Start of main script body
+:Main
+
+:: Check for a single /? argument...this means "help"
+IF "%1" == "/?" ( Call :Usage && EXIT /B )
+
+:: Where we want to make the symlinks
+IF "%1" == "" ( ECHO No target directory specified. Run %~nx0 /? for help. && EXIT /B )
+IF NOT EXIST %1 ( ECHO Target directory "%1" does not exist. && EXIT /B )
+CALL :SetAbsolutePath TARGET_DIR %1
+ECHO Symlinking DLLs into %TARGET_DIR%
+
+:: Root of the Kodi project repo
+CALL :SetAbsolutePath KODI_ROOT %~dp0\..\..
+ECHO Project root is %KODI_ROOT%
+
+:: Symlink the DLLs in Win32BuildSetup\dependencies into %TARGET_DIR%
+FOR %%f IN (%KODI_ROOT%\project\Win32BuildSetup\dependencies\*.dll) DO CALL :MakeSymlink %%f
+
+:: Symlink "special" directories into %TARGET_DIR%
+CALL :MakeSymlink %KODI_ROOT%\addons
+CALL :MakeSymlink %KODI_ROOT%\language
+CALL :MakeSymlink %KODI_ROOT%\media
+CALL :MakeSymlink %KODI_ROOT%\sounds
+CALL :MakeSymlink %KODI_ROOT%\system
+CALL :MakeSymlink %KODI_ROOT%\userdata
+


### PR DESCRIPTION
This change adds a new batch file, make_kodi_home_symlinks.bat, which accepts one cmdline argument: the path to the build directory (e.g., kodi\project\VS2010Express\XBMC\Debug).

This script creates symbolic links in that directory to all of the directories and DLLs that Kodi expects to find via the KODI_HOME environment variable. This allows Kodi to be run from the build directory without KODI_HOME having been explicitly set.

Being able to run Kodi from the build directory without any special environment variables set is important for debugging Kodi when launched via the Windows shell (e.g., as an auto-play handler for inserted media, such as DVDs).

Unfortunately, due to the default user privileges on WinVista+, normal users cannot create symbolic links, by default, so this script must be run with admin privileges.
