### PR TITLE
More double cache fixes

### DIFF
--- a/xbmc/filesystem/CacheStrategy.h
+++ b/xbmc/filesystem/CacheStrategy.h
@@ -50,7 +50,15 @@ public:
   virtual int64_t WaitForData(unsigned int iMinAvail, unsigned int iMillis) = 0;
 
   virtual int64_t Seek(int64_t iFilePosition) = 0;
-  virtual void Reset(int64_t iSourcePosition, bool clearAnyway=true) = 0;
+
+  /*!
+   \brief Reset cache position
+   \param iSourcePosition position to reset to
+   \param clearAnyway whether to perform a full reset regardless of in cached range already
+   \return Whether a full reset was performed, or not (e.g. only cache swap)
+   \sa CCacheStrategy
+   */
+  virtual bool Reset(int64_t iSourcePosition, bool clearAnyway=true) = 0;
 
   virtual void EndOfInput(); // mark the end of the input stream so that Read will know when to return EOF
   virtual bool IsEndOfInput();
@@ -83,7 +91,7 @@ public:
   virtual int64_t WaitForData(unsigned int iMinAvail, unsigned int iMillis) ;
 
   virtual int64_t Seek(int64_t iFilePosition);
-  virtual void Reset(int64_t iSourcePosition, bool clearAnyway=true);
+  virtual bool Reset(int64_t iSourcePosition, bool clearAnyway=true);
   virtual void EndOfInput();
 
   virtual int64_t CachedDataEndPosIfSeekTo(int64_t iFilePosition);
@@ -118,7 +126,7 @@ public:
   virtual int64_t WaitForData(unsigned int iMinAvail, unsigned int iMillis) ;
 
   virtual int64_t Seek(int64_t iFilePosition);
-  virtual void Reset(int64_t iSourcePosition, bool clearAnyway=true);
+  virtual bool Reset(int64_t iSourcePosition, bool clearAnyway=true);
   virtual void EndOfInput();
   virtual bool IsEndOfInput();
   virtual void ClearEndOfInput();

--- a/xbmc/filesystem/CircularCache.cpp
+++ b/xbmc/filesystem/CircularCache.cpp
@@ -232,17 +232,19 @@ int64_t CCircularCache::Seek(int64_t pos)
   return CACHE_RC_ERROR;
 }
 
-void CCircularCache::Reset(int64_t pos, bool clearAnyway)
+bool CCircularCache::Reset(int64_t pos, bool clearAnyway)
 {
   CSingleLock lock(m_sync);
   if (!clearAnyway && IsCachedPosition(pos))
   {
     m_cur = pos;
-    return;
+    return false;
   }
   m_end = pos;
   m_beg = pos;
   m_cur = pos;
+
+  return true;
 }
 
 int64_t CCircularCache::CachedDataEndPosIfSeekTo(int64_t iFilePosition)

--- a/xbmc/filesystem/CircularCache.h
+++ b/xbmc/filesystem/CircularCache.h
@@ -42,7 +42,7 @@ public:
     virtual int64_t WaitForData(unsigned int minimum, unsigned int iMillis) ;
 
     virtual int64_t Seek(int64_t pos) ;
-    virtual void Reset(int64_t pos, bool clearAnyway=true) ;
+    virtual bool Reset(int64_t pos, bool clearAnyway=true) ;
 
     virtual int64_t CachedDataEndPosIfSeekTo(int64_t iFilePosition);
     virtual int64_t CachedDataEndPos(); 

--- a/xbmc/filesystem/MemBufferCache.cpp
+++ b/xbmc/filesystem/MemBufferCache.cpp
@@ -215,13 +215,14 @@ int64_t MemBufferCache::Seek(int64_t iFilePosition)
   return CACHE_RC_ERROR;
 }
 
-void MemBufferCache::Reset(int64_t iSourcePosition)
+bool MemBufferCache::Reset(int64_t iSourcePosition, bool clearAnyway)
 {
   CSingleLock lock(m_sync);
   m_nStartPosition = iSourcePosition;
   m_buffer.Clear();
   m_HistoryBuffer.Clear();
   m_forwardBuffer.Clear();
+  return true;
 }
 
 

--- a/xbmc/filesystem/MemBufferCache.h
+++ b/xbmc/filesystem/MemBufferCache.h
@@ -46,7 +46,7 @@ public:
     virtual int64_t WaitForData(unsigned int iMinAvail, unsigned int iMillis) ;
 
     virtual int64_t Seek(int64_t iFilePosition) ;
-    virtual void Reset(int64_t iSourcePosition) ;
+    virtual bool Reset(int64_t iSourcePosition, bool clearAnyway) ;
 
 protected:
     int64_t m_nStartPosition;


### PR DESCRIPTION
This PR fixes 2 remaining issues in our double cache implementation:
1) Average calculation with heavy seeking/cache swapping doesn't work properly when the "other" cache is already (almost) full;
2) We would wait for data although the position was already available in our other cache.
