### PR TITLE
Revert "jobs: fixed segmentation fault when thumbnail loader abort"

### DIFF
--- a/xbmc/utils/JobManager.cpp
+++ b/xbmc/utils/JobManager.cpp
@@ -177,7 +177,6 @@ CJobManager::CJobManager()
   m_jobCounter = 0;
   m_running = true;
   m_pauseJobs = false;
-  m_tangle = 0;
 }
 
 void CJobManager::Restart()
@@ -257,13 +256,6 @@ void CJobManager::CancelJob(unsigned int jobID)
   Processing::iterator it = find(m_processing.begin(), m_processing.end(), jobID);
   if (it != m_processing.end())
     it->m_callback = NULL; // job is in progress, so only thing to do is to remove callback
-
-  // wait for tangled callbacks to finish
-  while(m_tangle)
-  {
-    CLog::Log(LOGDEBUG, "CJobManager::CancelJob - waiting for tangled callbacks");
-    m_tangle_cond.wait(m_section);
-  }
 }
 
 void CJobManager::StartWorkers(CJob::PRIORITY priority)
@@ -378,24 +370,18 @@ CJob *CJobManager::GetNextJob(const CJobWorker *worker)
   return NULL;
 }
 
-bool CJobManager::OnJobProgress(unsigned int progress, unsigned int total, const CJob *job)
+bool CJobManager::OnJobProgress(unsigned int progress, unsigned int total, const CJob *job) const
 {
   CSingleLock lock(m_section);
-
   // find the job in the processing queue, and check whether it's cancelled (no callback)
   Processing::const_iterator i = find(m_processing.begin(), m_processing.end(), job);
   if (i != m_processing.end())
   {
     CWorkItem item(*i);
-
+    lock.Leave(); // leave section prior to call
     if (item.m_callback)
     {
-      m_tangle++;
-      lock.Leave(); // leave section prior to call
       item.m_callback->OnJobProgress(item.m_id, progress, total, job);
-      lock.Enter();
-      m_tangle--;
-      m_tangle_cond.notifyAll();
       return false;
     }
   }
@@ -411,8 +397,6 @@ void CJobManager::OnJobComplete(bool success, CJob *job)
   {
     // tell any listeners we're done with the job, then delete it
     CWorkItem item(*i);
-
-    m_tangle++;
     lock.Leave();
     try
     {
@@ -424,9 +408,6 @@ void CJobManager::OnJobComplete(bool success, CJob *job)
       CLog::Log(LOGERROR, "%s error processing job %s", __FUNCTION__, item.m_job->GetType());
     }
     lock.Enter();
-    m_tangle--;
-    m_tangle_cond.notifyAll();
-
     Processing::iterator j = find(m_processing.begin(), m_processing.end(), job);
     if (j != m_processing.end())
       m_processing.erase(j);

--- a/xbmc/utils/JobManager.h
+++ b/xbmc/utils/JobManager.h
@@ -298,7 +298,7 @@ protected:
    \return true if the job has been cancelled, else returns false.
    \sa IJobCallback, CJob
    */
-  bool  OnJobProgress(unsigned int progress, unsigned int total, const CJob *job);
+  bool  OnJobProgress(unsigned int progress, unsigned int total, const CJob *job) const;
 
 private:
   // private construction, and no assignements; use the provided singleton methods
@@ -330,7 +330,4 @@ private:
   CCriticalSection m_section;
   CEvent           m_jobEvent;
   bool             m_running;
-
-  XbmcThreads::ConditionVariable m_tangle_cond;
-  unsigned int     m_tangle;  /*!< Active callbacks currently running */
 };


### PR DESCRIPTION
This reverts commit eb99f7cdc7ef1cd3b707b7b5e788a0dbb2f8189a.

Causes deadlock. See discussion in #5764
