### PR TITLE
[ios] - add support for libdvdcss

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -632,7 +632,7 @@ case $host in
      use_libcec=no
      use_vtbdecoder=yes
      use_optical_drive=no
-     use_dvdcss=no
+     use_dvdcss=yes
      use_gles=yes
      use_cpu=cortex-a8
      ARCH="arm-osx"

--- a/lib/libdvd/libdvdcss/src/device.c
+++ b/lib/libdvd/libdvdcss/src/device.c
@@ -131,6 +131,8 @@ int _dvdcss_use_ioctls( dvdcss_t dvdcss )
         return 1;
 
     return 0;
+#elif defined(__APPLE__) && defined(__arm__)
+    return 0;
 #else
     struct stat fileinfo;
     int ret;

--- a/lib/libdvd/libdvdcss/src/ioctl.c
+++ b/lib/libdvd/libdvdcss/src/ioctl.c
@@ -262,10 +262,11 @@ int ioctl_ReadCopyright( int i_fd, int i_layer, int *pi_copyright )
                         p_buffer, sizeof(p_buffer), &ulDataLen);
 
     *pi_copyright = p_buffer[ 4 ];
-
+#elif defined(__APPLE__) && defined(__arm__)
+    *pi_copyright = 0;
+    i_ret = 0;
 #else
 #   error "DVD ioctls are unavailable on this system"
-
 #endif
     return i_ret;
 }
@@ -429,7 +430,8 @@ int ioctl_ReadDiscKey( int i_fd, int *pi_agid, uint8_t *p_key )
     }
 
     memcpy( p_key, p_buffer + 4, DVD_DISCKEY_SIZE );
-
+#elif defined(__APPLE__) && defined(__arm__)
+// nothing
 #else
 #   error "DVD ioctls are unavailable on this system"
 
@@ -590,6 +592,8 @@ int ioctl_ReadTitleKey( int i_fd, int *pi_agid, int i_pos, uint8_t *p_key )
 
     memcpy( p_key, p_buffer + 5, DVD_KEY_SIZE );
 
+#elif defined(__APPLE__) && defined(__arm__)
+// nothing
 #else
 #   error "DVD ioctls are unavailable on this system"
 
@@ -712,6 +716,8 @@ int ioctl_ReportAgid( int i_fd, int *pi_agid )
 
     *pi_agid = p_buffer[ 7 ] >> 6;
 
+#elif defined(__APPLE__) && defined(__arm__)
+// nothing
 #else
 #   error "DVD ioctls are unavailable on this system"
 
@@ -842,6 +848,8 @@ int ioctl_ReportChallenge( int i_fd, int *pi_agid, uint8_t *p_challenge )
 
     memcpy( p_challenge, p_buffer + 4, DVD_CHALLENGE_SIZE );
 
+#elif defined(__APPLE__) && defined(__arm__)
+// nothing
 #else
 #   error "DVD ioctls are unavailable on this system"
 
@@ -971,6 +979,8 @@ int ioctl_ReportASF( int i_fd, int *pi_remove_me, int *pi_asf )
 
     *pi_asf = p_buffer[ 7 ] & 1;
 
+#elif defined(__APPLE__) && defined(__arm__)
+// nothing
 #else
 #   error "DVD ioctls are unavailable on this system"
 
@@ -1096,6 +1106,8 @@ int ioctl_ReportKey1( int i_fd, int *pi_agid, uint8_t *p_key )
 
     memcpy( p_key, p_buffer + 4, DVD_KEY_SIZE );
 
+#elif defined(__APPLE__) && defined(__arm__)
+// nothing
 #else
 #   error "DVD ioctls are unavailable on this system"
 
@@ -1205,6 +1217,9 @@ int ioctl_InvalidateAgid( int i_fd, int *pi_agid )
     i_ret = DosDevIOCtl(i_fd, IOCTL_CDROMDISK, CDROMDISK_EXECMD,
                         &sdc, sizeof(sdc), &ulParamLen,
                         NULL, 0, &ulDataLen);
+
+#elif defined(__APPLE__) && defined(__arm__)
+// nothing
 #else
 #   error "DVD ioctls are unavailable on this system"
 
@@ -1338,6 +1353,8 @@ int ioctl_SendChallenge( int i_fd, int *pi_agid, uint8_t *p_challenge )
                          &sdc, sizeof(sdc), &ulParamLen,
                          p_buffer, sizeof(p_buffer), &ulDataLen );
 
+#elif defined(__APPLE__) && defined(__arm__)
+// nothing
 #else
 #   error "DVD ioctls are unavailable on this system"
 
@@ -1471,6 +1488,8 @@ int ioctl_SendKey2( int i_fd, int *pi_agid, uint8_t *p_key )
                          &sdc, sizeof(sdc), &ulParamLen,
                          p_buffer, sizeof(p_buffer), &ulDataLen );
 
+#elif defined(__APPLE__) && defined(__arm__)
+// nothing
 #else
 #   error "DVD ioctls are unavailable on this system"
 
@@ -1622,6 +1641,8 @@ int ioctl_ReportRPC( int i_fd, int *p_type, int *p_mask, int *p_scheme )
     *p_mask = p_buffer[ 5 ];
     *p_scheme = p_buffer[ 6 ];
 
+#elif defined(__APPLE__) && defined(__arm__)
+// nothing
 #else
 #   error "DVD ioctls are unavailable on this system"
 

--- a/lib/libdvd/patches/08-libdvdcss-ios-compile-support.diff
+++ b/lib/libdvd/patches/08-libdvdcss-ios-compile-support.diff
@@ -1,0 +1,123 @@
+diff --git a/lib/libdvd/libdvdcss/src/device.c b/lib/libdvd/libdvdcss/src/device.c
+index 53d1fdf..2b96e77 100644
+--- a/lib/libdvd/libdvdcss/src/device.c
++++ b/lib/libdvd/libdvdcss/src/device.c
+@@ -131,6 +131,8 @@ int _dvdcss_use_ioctls( dvdcss_t dvdcss )
+         return 1;
+ 
+     return 0;
++#elif defined(__APPLE__) && defined(__arm__)
++    return 0;
+ #else
+     struct stat fileinfo;
+     int ret;
+diff --git a/lib/libdvd/libdvdcss/src/ioctl.c b/lib/libdvd/libdvdcss/src/ioctl.c
+index 61a924e..f2f5f44 100644
+--- a/lib/libdvd/libdvdcss/src/ioctl.c
++++ b/lib/libdvd/libdvdcss/src/ioctl.c
+@@ -262,10 +262,11 @@ int ioctl_ReadCopyright( int i_fd, int i_layer, int *pi_copyright )
+                         p_buffer, sizeof(p_buffer), &ulDataLen);
+ 
+     *pi_copyright = p_buffer[ 4 ];
+-
++#elif defined(__APPLE__) && defined(__arm__)
++    *pi_copyright = 0;
++    i_ret = 0;
+ #else
+ #   error "DVD ioctls are unavailable on this system"
+-
+ #endif
+     return i_ret;
+ }
+@@ -429,7 +430,8 @@ int ioctl_ReadDiscKey( int i_fd, int *pi_agid, uint8_t *p_key )
+     }
+ 
+     memcpy( p_key, p_buffer + 4, DVD_DISCKEY_SIZE );
+-
++#elif defined(__APPLE__) && defined(__arm__)
++// nothing
+ #else
+ #   error "DVD ioctls are unavailable on this system"
+ 
+@@ -590,6 +592,8 @@ int ioctl_ReadTitleKey( int i_fd, int *pi_agid, int i_pos, uint8_t *p_key )
+ 
+     memcpy( p_key, p_buffer + 5, DVD_KEY_SIZE );
+ 
++#elif defined(__APPLE__) && defined(__arm__)
++// nothing
+ #else
+ #   error "DVD ioctls are unavailable on this system"
+ 
+@@ -712,6 +716,8 @@ int ioctl_ReportAgid( int i_fd, int *pi_agid )
+ 
+     *pi_agid = p_buffer[ 7 ] >> 6;
+ 
++#elif defined(__APPLE__) && defined(__arm__)
++// nothing
+ #else
+ #   error "DVD ioctls are unavailable on this system"
+ 
+@@ -842,6 +848,8 @@ int ioctl_ReportChallenge( int i_fd, int *pi_agid, uint8_t *p_challenge )
+ 
+     memcpy( p_challenge, p_buffer + 4, DVD_CHALLENGE_SIZE );
+ 
++#elif defined(__APPLE__) && defined(__arm__)
++// nothing
+ #else
+ #   error "DVD ioctls are unavailable on this system"
+ 
+@@ -971,6 +979,8 @@ int ioctl_ReportASF( int i_fd, int *pi_remove_me, int *pi_asf )
+ 
+     *pi_asf = p_buffer[ 7 ] & 1;
+ 
++#elif defined(__APPLE__) && defined(__arm__)
++// nothing
+ #else
+ #   error "DVD ioctls are unavailable on this system"
+ 
+@@ -1096,6 +1106,8 @@ int ioctl_ReportKey1( int i_fd, int *pi_agid, uint8_t *p_key )
+ 
+     memcpy( p_key, p_buffer + 4, DVD_KEY_SIZE );
+ 
++#elif defined(__APPLE__) && defined(__arm__)
++// nothing
+ #else
+ #   error "DVD ioctls are unavailable on this system"
+ 
+@@ -1205,6 +1217,9 @@ int ioctl_InvalidateAgid( int i_fd, int *pi_agid )
+     i_ret = DosDevIOCtl(i_fd, IOCTL_CDROMDISK, CDROMDISK_EXECMD,
+                         &sdc, sizeof(sdc), &ulParamLen,
+                         NULL, 0, &ulDataLen);
++
++#elif defined(__APPLE__) && defined(__arm__)
++// nothing
+ #else
+ #   error "DVD ioctls are unavailable on this system"
+ 
+@@ -1338,6 +1353,8 @@ int ioctl_SendChallenge( int i_fd, int *pi_agid, uint8_t *p_challenge )
+                          &sdc, sizeof(sdc), &ulParamLen,
+                          p_buffer, sizeof(p_buffer), &ulDataLen );
+ 
++#elif defined(__APPLE__) && defined(__arm__)
++// nothing
+ #else
+ #   error "DVD ioctls are unavailable on this system"
+ 
+@@ -1471,6 +1488,8 @@ int ioctl_SendKey2( int i_fd, int *pi_agid, uint8_t *p_key )
+                          &sdc, sizeof(sdc), &ulParamLen,
+                          p_buffer, sizeof(p_buffer), &ulDataLen );
+ 
++#elif defined(__APPLE__) && defined(__arm__)
++// nothing
+ #else
+ #   error "DVD ioctls are unavailable on this system"
+ 
+@@ -1622,6 +1641,8 @@ int ioctl_ReportRPC( int i_fd, int *p_type, int *p_mask, int *p_scheme )
+     *p_mask = p_buffer[ 5 ];
+     *p_scheme = p_buffer[ 6 ];
+ 
++#elif defined(__APPLE__) && defined(__arm__)
++// nothing
+ #else
+ #   error "DVD ioctls are unavailable on this system"
+ 


### PR DESCRIPTION
This adds support for using libdvdcss on ios - it allows playback of encrypted iso files.

Its based on a patch mentioned here:

http://forum.kodi.tv/showthread.php?tid=113944&pid=928429#pid928429

Not really sure if we need it (wasn't requested by anyone yet) - but i just didn't want to loose the code. I verified it with an unencrypted ios only so far (it uses libdvdcss for read - startup time is a bit slower because libdvdcss checks each vob file prior playback).

More an RFC and definitly for after Helix.
