### PR TITLE
[emufnc] Disable support for READ_TRUNCATED. To be reverted after Helix release

### DIFF
--- a/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
+++ b/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
@@ -530,7 +530,10 @@ extern "C"
     if (bWrite)
       bResult = pFile->OpenForWrite(CUtil::ValidatePath(str), bOverwrite);
     else
-      bResult = pFile->Open(CUtil::ValidatePath(str), READ_TRUNCATED);
+      bResult = pFile->Open(CUtil::ValidatePath(str), 0 /* READ_TRUNCATED */); // Disabled READ_TRUNCATED for release
+    /* Looks that libdvdnav / libdvdread / libdvdcss have bugs and do not process correctly partial reads */
+    /* All found bug were eliminated but for safety READ_TRUNCATED is disabled for Helix release */
+    /* TODO: enable READ_TRUNCATED after release of Helix */
 
     if (bResult)
     {


### PR DESCRIPTION
Temporarily revert https://github.com/xbmc/xbmc/commit/e502b0993760b3e8b001f0360755a424bab79086  for release .
@topfs2 @MartijnKaijser 
