### PR TITLE
[win32] [vfs] Win32SMBFile::Stat(): fix wrong error code check

### DIFF
--- a/xbmc/filesystem/win32/Win32SMBFile.cpp
+++ b/xbmc/filesystem/win32/Win32SMBFile.cpp
@@ -151,7 +151,7 @@ int CWin32SMBFile::Stat(const CURL& url, struct __stat64* statData)
   if (CWin32File::Stat(url, statData) == 0)
     return 0;
 
-  if (!worthTryToConnect(GetLastError()) || !ConnectAndAuthenticate(url))
+  if (!worthTryToConnect(m_lastSMBFileErr) || !ConnectAndAuthenticate(url))
     return -1;
 
   return CWin32File::Stat(url, statData);


### PR DESCRIPTION
Simple fix of copy-paste error.
