### PR TITLE
VAAPI: Print driver vendor string (which includes version) when opening context

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.cpp
@@ -146,6 +146,8 @@ bool CVAAPIContext::CreateContext()
   if (g_advancedSettings.CanLogComponent(LOGVIDEO))
     CLog::Log(LOGDEBUG, "VAAPI - initialize version %d.%d", major_version, minor_version);
 
+  if (g_advancedSettings.CanLogComponent(LOGVIDEO))
+    CLog::Log(LOGDEBUG, "VAAPI - driver in use: %s", vaQueryVendorString(m_display));
 
   QueryCaps();
   if (!m_profileCount || !m_attributeCount)


### PR DESCRIPTION
Realized that we don't log the driver vendor string (including version) when opening the context. This makes it hard to debug issues like: http://forum.kodi.tv/showthread.php?tid=209649&pid=1845879#pid1845879
