### PR TITLE
[pvr] always use last played group as current group on startup

### DIFF
--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -111,7 +111,13 @@ void CPVRManager::Announce(AnnouncementFlag flag, const char *sender, const char
    return;
 
   if (strcmp(message, "OnWake") == 0)
-    ContinueLastChannel();
+  {
+    {
+      CSingleLock lock(m_critSection);
+      m_bFirstStart = true;
+    }
+    Start(true);
+  }
 }
 
 CPVRManager &CPVRManager::Get(void)

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -503,8 +503,9 @@ void CPVRManager::Process(void)
       /* start job to search for missing channel icons */
       TriggerSearchMissingChannelIcons();
       
-      /* continue last watched channel */
-      ContinueLastChannel();
+      /* try to continue last watched channel otherwise set group to last played group */
+      if (!ContinueLastChannel())
+        SetPlayingGroup(m_channelGroups->GetLastPlayedGroup());
     }
     /* execute the next pending jobs if there are any */
     try


### PR DESCRIPTION
This PR adds two new improvements for the PVR section:
- Always use the last played group as current group on startup whether or not you enabled the option 'continue last channel on startup'. With it we'll have no difference in behavior.
- Trigger job to search for missing channel icons also on wake up

Maybe something for a 14.x release?

@opdenkamp, @Jalle19 mind taking a look please
