### PR TITLE
[audioencoders] bump to their latest master

### DIFF
--- a/project/cmake/addons/addons/audioencoder.flac/audioencoder.flac.txt
+++ b/project/cmake/addons/addons/audioencoder.flac/audioencoder.flac.txt
@@ -1,1 +1,1 @@
-audioencoder.flac https://github.com/xbmc/audioencoder.flac 84bdf32
+audioencoder.flac https://github.com/xbmc/audioencoder.flac a960eba

--- a/project/cmake/addons/addons/audioencoder.lame/audioencoder.lame.txt
+++ b/project/cmake/addons/addons/audioencoder.lame/audioencoder.lame.txt
@@ -1,1 +1,1 @@
-audioencoder.lame https://github.com/xbmc/audioencoder.lame 90fb99b
+audioencoder.lame https://github.com/xbmc/audioencoder.lame 6f8384f

--- a/project/cmake/addons/addons/audioencoder.vorbis/audioencoder.vorbis.txt
+++ b/project/cmake/addons/addons/audioencoder.vorbis/audioencoder.vorbis.txt
@@ -1,1 +1,1 @@
-audioencoder.vorbis https://github.com/xbmc/audioencoder.vorbis a73ef7e
+audioencoder.vorbis https://github.com/xbmc/audioencoder.vorbis fa0de15

--- a/project/cmake/addons/addons/audioencoder.wav/audioencoder.wav.txt
+++ b/project/cmake/addons/addons/audioencoder.wav/audioencoder.wav.txt
@@ -1,1 +1,1 @@
-audioencoder.wav https://github.com/xbmc/audioencoder.wav b28ab95
+audioencoder.wav https://github.com/xbmc/audioencoder.wav 40aaedf


### PR DESCRIPTION
Audio encoders flac, vorbis, lame, wav wont compile because failure.

http://pastebin.com/kKfEYHZq
per IRC conversation with wsnipex

^^ That is resolved by **deleting** the /usr/include/xbmc/ symlink to /usr/include/kodi/ and then applying this patch and running

```
sudo make -C tools/depends/target/xbmc-audioencoder-addons PREFIX=/usr
```

Where then it creates  /usr/include/xbmc/ with same contents as /usr/include/kodi/
so the legacy symlinks seem to be at fault as @wsnipex suspected.

**_These need bumping in any case**_ irrespective of issue.

@wsnipex @topfs2 
