### PR TITLE
Revert "linux: Check for Logind first, then *Kit-s with UPower when detecting PM framework"

### DIFF
--- a/xbmc/powermanagement/PowerManager.cpp
+++ b/xbmc/powermanagement/PowerManager.cpp
@@ -75,12 +75,12 @@ void CPowerManager::Initialize()
   m_instance = new CAndroidPowerSyscall();
 #elif defined(TARGET_POSIX)
 #if defined(HAS_DBUS)
-  if (CLogindUPowerSyscall::HasLogind())
-    m_instance = new CLogindUPowerSyscall();
-  else if (CConsoleUPowerSyscall::HasConsoleKitAndUPower())
+  if (CConsoleUPowerSyscall::HasConsoleKitAndUPower())
     m_instance = new CConsoleUPowerSyscall();
   else if (CConsoleDeviceKitPowerSyscall::HasDeviceConsoleKit())
     m_instance = new CConsoleDeviceKitPowerSyscall();
+  else if (CLogindUPowerSyscall::HasLogind())
+    m_instance = new CLogindUPowerSyscall();
   else if (CUPowerSyscall::HasUPower())
     m_instance = new CUPowerSyscall();
   else


### PR DESCRIPTION
This reverts commit c70fa349c0a5c2392045dd00751f64391fbef2e2.

It was not wrong but it seems distributions are not yet ready and the logind
path for e.g. suspending is not as well implemented as the scripts called by
upower initiated power operations.
