### PR TITLE
[infomanager] container.pluginname returns an empty string (fixes #15566)

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1758,10 +1758,7 @@ CStdString CGUIInfoManager::GetLabel(int info, int contextWindow, std::string *f
       {
         CURL url(((CGUIMediaWindow*)window)->CurrentDirectory().GetPath());
         if (url.IsProtocol("plugin"))
-        {
-          strLabel = url.GetFileName();
-          URIUtils::RemoveSlashAtEnd(strLabel);
-        }
+          strLabel = URIUtils::GetFileName(url.GetHostName());
       }
       break;
     }


### PR DESCRIPTION
This fixes an issue reported @ http://trac.kodi.tv/ticket/15566.

Since we're calling it on a container, the paths is a folder (ends with a slash). In that case the usage of `url.GetFileName()` is wrong and leads to an empty label.

I am not entirely sure if the behavior is like intended. It will now return `plugin.video.youtube` for the container path `plugin://plugin.video.youtube/`

@Montellese, @ronie for review please.
