### PR TITLE
fix: [linux] include ffmpeg tarball in mk-debian-package.sh

### DIFF
--- a/tools/Linux/packaging/mk-debian-package.sh
+++ b/tools/Linux/packaging/mk-debian-package.sh
@@ -99,6 +99,7 @@ function archiveRepo {
     cd $REPO_DIR || exit 1
     git clean -xfd
     echo $REV > VERSION
+    tools/depends/target/ffmpeg/autobuild.sh -d
     DEST="kodi-${RELEASEV}~git$(date '+%Y%m%d.%H%M')-${TAG}"
     [[ -d debian ]] && rm -rf debian
     cd ..


### PR DESCRIPTION
needed because we cannot download anything during debuild stage

only touches a script that is solely used for manual deb-package building, totally safe for helix.
