### PR TITLE
Revert "gl: multipass renderer would use wrong source pixels sizes"

### DIFF
--- a/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
@@ -1481,8 +1481,8 @@ void CLinuxRendererGL::RenderFromFBO()
 
     m_fbo.fbo.SetFiltering(GL_TEXTURE_2D, filter);
     m_pVideoFilterShader->SetSourceTexture(0);
-    m_pVideoFilterShader->SetWidth(m_fbo.width);
-    m_pVideoFilterShader->SetHeight(m_fbo.height);
+    m_pVideoFilterShader->SetWidth(m_sourceWidth);
+    m_pVideoFilterShader->SetHeight(m_sourceHeight);
 
     //disable non-linear stretch when a dvd menu is shown, parts of the menu are rendered through the overlay renderer
     //having non-linear stretch on breaks the alignment
@@ -1502,8 +1502,8 @@ void CLinuxRendererGL::RenderFromFBO()
 
   VerifyGLState();
 
-  float imgwidth  = m_sourceWidth  / m_fbo.width;
-  float imgheight = m_sourceHeight / m_fbo.height;
+  float imgwidth = m_fbo.width / m_sourceWidth;
+  float imgheight = m_fbo.height / m_sourceHeight;
 
   glBegin(GL_QUADS);
 


### PR DESCRIPTION
This reverts commit 9255204c264b25969558035deeae4a6d2d7f2842.

breaks HQ scaling for sw decoding on Linux

see title. A change like this should really not be hidden in a PR named vdr_fixes. Note that this is the 3rd commit of a series of elupus patches we have to revert. I would have expected a little more testing in this phase.
