### PR TITLE
[depends] - add boblight to depends but don't install it (used for compi...

### DIFF
--- a/tools/depends/target/boblight/01-fix_fpermissive.patch
+++ b/tools/depends/target/boblight/01-fix_fpermissive.patch
@@ -1,0 +1,11 @@
+--- src/util/miscorig.cpp	2014-11-27 18:31:54.778680630 +0000
++++ src/util/misc.cpp	2014-11-27 18:32:21.986680437 +0000
+@@ -64,7 +64,7 @@
+ //convert . or , to the current locale for correct conversion of ascii float
+ void ConvertFloatLocale(std::string& strfloat)
+ {
+-  static struct lconv* locale = localeconv();
++  static const struct lconv* locale = localeconv();
+   
+   size_t pos = strfloat.find_first_of(",.");
+ 

--- a/tools/depends/target/boblight/02-fixandroid.patch
+++ b/tools/depends/target/boblight/02-fixandroid.patch
@@ -1,0 +1,35 @@
+--- src/util/daemonizeorig.cpp	2014-11-27 18:36:30.474678137 +0000
++++ src/util/daemonize.cpp	2014-11-27 18:36:44.226678082 +0000
+@@ -35,10 +35,12 @@
+   if (setsid() < 0)
+     fprintf(stderr, "setsid(): %s", GetErrno().c_str());
+ 
++#if !defined(__ANDROID__)
+   //route stdout and stderr to /dev/null
+   fclose(stdout);
+   stdout = fopen("/dev/null", "w");
+   fclose(stderr);
+   stderr = fopen("/dev/null", "w");
++#endif
+ }
+ 
+--- src/lib/boblightorig.h	2014-11-27 18:38:37.174677063 +0000
++++ src/lib/boblight.h	2014-11-27 18:40:14.810676123 +0000
+@@ -61,7 +61,7 @@
+     //gets a functionpointer from dlsym, and returns char* from dlerror if it didn't work
+     #define BOBLIGHT_FUNCTION(returnvalue, name, arguments) \
+     name = BOBLIGHT_CAST(returnvalue (*) arguments)(dlsym(p_boblight, #name)); \
+-                        { char* error = dlerror(); if (error) return error; }
++                        { char* error = (char *)dlerror(); if (error) return error; }
+ 
+     void* p_boblight = NULL; //where we put the lib
+ 
+@@ -79,7 +79,7 @@
+ 
+       p_boblight = dlopen(filename, RTLD_NOW);
+       if (p_boblight == NULL)
+-        return dlerror();
++        return (char *)dlerror();
+ 
+       //generate dlsym lines
+       #include "boblight-functions.h"

--- a/tools/depends/target/boblight/Makefile
+++ b/tools/depends/target/boblight/Makefile
@@ -1,0 +1,53 @@
+include ../../Makefile.include
+DEPS= ../../Makefile.include Makefile
+
+#hint for building a fat lib - "lipo -arch i386 libboblight-i386.dylib -arch x86_64 libboblight-x86_64.dylib -output libboblight-fat.dylib"
+
+# lib name, version
+LIBNAME=libboblight
+VERSION=r478
+SOURCE=$(LIBNAME)-$(VERSION)
+ARCHIVE=$(SOURCE).tar.gz
+
+# configuration settings
+CONFIGURE=./configure --prefix=$(PREFIX) \
+  --without-opengl \
+  --without-portaudio \
+  --without-x11 \
+  --without-libusb
+
+LIBDYLIB=$(PLATFORM)/src/.libs/$(LIBNAME).a
+
+CLEAN_FILES=$(ARCHIVE) $(PLATFORM)
+
+all: $(LIBDYLIB) .installed-$(PLATFORM)
+
+$(TARBALLS_LOCATION)/$(ARCHIVE):
+	cd $(TARBALLS_LOCATION); $(RETRIEVE_TOOL) $(RETRIEVE_TOOL_FLAGS) $(BASE_URL)/$(ARCHIVE)
+
+$(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
+	rm -rf $(PLATFORM)/*; mkdir -p $(PLATFORM)
+	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
+	cd $(PLATFORM); patch -p0 < ../01-fix_fpermissive.patch
+	cd $(PLATFORM); patch -p0 < ../02-fixandroid.patch
+	cd $(PLATFORM); autoreconf -vif
+	cd $(PLATFORM); $(CONFIGURE)
+
+$(LIBDYLIB): $(PLATFORM)
+	$(MAKE) -C $(PLATFORM)
+
+.installed-$(PLATFORM): $(LIBDYLIB)
+ifeq ($(OS),android)
+	rm -f $(PLATFORM)/src/.libs/libboblight.la $(PLATFORM)/src/.libs/libboblight.so $(PLATFORM)/src/.libs/libboblight.so.0
+	mv -f $(PLATFORM)/src/.libs/libboblight.so.0.0.0 $(PLATFORM)/src/.libs/libboblight.so
+	$(RPL) -e "libboblight.so.0" "libboblight.so\x00\x00" $(PLATFORM)/src/.libs/libboblight.so
+	-$(READELF) --dynamic $(PLATFORM)/src/.libs/libboblight.so | grep ibrary
+endif
+	echo "libboblight isn't a dependency of XBMC and won't be installed"
+	touch $@
+clean:
+	$(MAKE) -C $(PLATFORM) clean
+	rm -r .installed-$(PLATFORM)
+
+distclean::
+	rm -rf $(PLATFORM) .installed-$(PLATFORM)


### PR DESCRIPTION
...ling the needed libboblight binary for the boblight addon) - seems this was lost since frodo ...

Well we had it in our depends at frodo times but it got lost during unified deps. I used that for compiling the libboblight dylib/so files for our boblight python addon. Since this is not hooked up to anything we can savly apply this to helix to have it (just in case we need to compile the lib for new platforms - e.x. android-x86 soon).
