### PR TITLE
[platform] - add info bools to determine the arch of the compilation

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1278,6 +1278,24 @@ int CGUIInfoManager::TranslateSingleString(const CStdString &strCondition, bool 
       else if (platform == "atv2") return SYSTEM_PLATFORM_DARWIN_ATV2;
       else if (platform == "android") return SYSTEM_PLATFORM_ANDROID;
     }
+
+    if (info[0].name == "system" && info[1].name == "arch")
+    {
+      CStdString arch = info[2].name;
+      if (arch == "x86_32")
+        return SYSTEM_ARCH_X86_32;
+      else if (arch == "x86_64")
+        return SYSTEM_ARCH_X86_64;
+      else if (arch == "arm_32")
+        return SYSTEM_ARCH_ARM_32;
+      else if (arch == "arm_64")
+        return SYSTEM_ARCH_ARM_64;
+      else if (arch == "mips_32")
+        return SYSTEM_ARCH_MIPS_32;
+      else if (arch == "mips_64")
+        return SYSTEM_ARCH_MIPS_64;
+    }
+
     if (info[0].name == "musicplayer")
     { // TODO: these two don't allow duration(foo) and also don't allow more than this number of levels...
       if (info[1].name == "position")
@@ -2310,6 +2328,48 @@ bool CGUIInfoManager::GetBool(int condition1, int contextWindow, const CGUIListI
 #else
     bReturn = false;
 #endif
+  else if (condition == SYSTEM_ARCH_X86_32)
+  {
+    if (g_sysinfo.GetKernelCpuFamily() == KERNEL_CPU_FAMILY_X86 && g_sysinfo.GetXbmcBitness() == 32)
+      bReturn = true;
+    else
+      bReturn = false;
+  }
+  else if (condition == SYSTEM_ARCH_X86_64)
+  {
+    if (g_sysinfo.GetKernelCpuFamily() == KERNEL_CPU_FAMILY_X86 && g_sysinfo.GetXbmcBitness() == 64)
+      bReturn = true;
+    else
+      bReturn = false;
+  }
+  else if (condition == SYSTEM_ARCH_ARM_32)
+  {
+    if (g_sysinfo.GetKernelCpuFamily() == KERNEL_CPU_FAMILY_ARM && g_sysinfo.GetXbmcBitness() == 32)
+      bReturn = true;
+    else
+      bReturn = false;
+  }
+  else if (condition == SYSTEM_ARCH_ARM_64)
+  {
+    if (g_sysinfo.GetKernelCpuFamily() == KERNEL_CPU_FAMILY_ARM && g_sysinfo.GetXbmcBitness() == 64)
+      bReturn = true;
+    else
+      bReturn = false;
+  }
+  else if (condition == SYSTEM_ARCH_MIPS_32)
+  {
+    if (g_sysinfo.GetKernelCpuFamily() == KERNEL_CPU_FAMILY_MIPS && g_sysinfo.GetXbmcBitness() == 32)
+      bReturn = true;
+    else
+      bReturn = false;
+  }
+  else if (condition == SYSTEM_ARCH_MIPS_64)
+  {
+    if (g_sysinfo.GetKernelCpuFamily() == KERNEL_CPU_FAMILY_MIPS && g_sysinfo.GetXbmcBitness() == 64)
+      bReturn = true;
+    else
+      bReturn = false;
+  }
   else if (condition == SYSTEM_MEDIA_DVD)
     bReturn = g_mediaManager.IsDiscInDrive();
 #ifdef HAS_DVD_DRIVE

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -420,6 +420,13 @@ namespace INFO
 #define SYSTEM_CAN_HIBERNATE        752
 #define SYSTEM_CAN_REBOOT           753
 
+#define SYSTEM_ARCH_X86_32          760
+#define SYSTEM_ARCH_X86_64          761
+#define SYSTEM_ARCH_ARM_32          762
+#define SYSTEM_ARCH_ARM_64          763
+#define SYSTEM_ARCH_MIPS_32         764
+#define SYSTEM_ARCH_MIPS_64         765
+
 #define SLIDESHOW_ISPAUSED          800
 #define SLIDESHOW_ISRANDOM          801
 #define SLIDESHOW_ISACTIVE          802

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -960,23 +960,23 @@ const std::string& CSysInfo::GetKernelCpuFamily(void)
     GetNativeSystemInfo(&si);
     if (si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_INTEL ||
         si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_AMD64)
-        kernelCpuFamily = "x86";
+        kernelCpuFamily = KERNEL_CPU_FAMILY_X86;
     else if (si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_ARM)
-      kernelCpuFamily = "ARM";
+      kernelCpuFamily = KERNEL_CPU_FAMILY_ARM;
 #elif defined(TARGET_DARWIN)
     const NXArchInfo* archInfo = NXGetLocalArchInfo();
     if (archInfo)
     {
       const cpu_type_t cpuType = (archInfo->cputype & ~CPU_ARCH_ABI64); // get CPU family without 64-bit ABI flag
       if (cpuType == CPU_TYPE_I386)
-        kernelCpuFamily = "x86";
+        kernelCpuFamily = KERNEL_CPU_FAMILY_X86;
       else if (cpuType == CPU_TYPE_ARM)
-        kernelCpuFamily = "ARM";
+        kernelCpuFamily = KERNEL_CPU_FAMILY_ARM;
       else if (cpuType == CPU_TYPE_POWERPC)
         kernelCpuFamily = "PowerPC";
 #ifdef CPU_TYPE_MIPS
       else if (cpuType == CPU_TYPE_MIPS)
-        kernelCpuFamily = "MIPS";
+        kernelCpuFamily = KERNEL_CPU_FAMILY_MIPS;
 #endif // CPU_TYPE_MIPS
     }
 #elif defined(TARGET_POSIX)
@@ -985,11 +985,11 @@ const std::string& CSysInfo::GetKernelCpuFamily(void)
     {
       std::string machine(un.machine);
       if (machine.compare(0, 3, "arm", 3) == 0)
-        kernelCpuFamily = "ARM";
+        kernelCpuFamily = KERNEL_CPU_FAMILY_ARM;
       else if (machine.compare(0, 4, "mips", 4) == 0)
-        kernelCpuFamily = "MIPS";
+        kernelCpuFamily = KERNEL_CPU_FAMILY_MIPS;
       else if (machine.compare(0, 4, "i686", 4) == 0 || machine == "i386" || machine == "amd64" ||  machine.compare(0, 3, "x86", 3) == 0)
-        kernelCpuFamily = "x86";
+        kernelCpuFamily = KERNEL_CPU_FAMILY_X86;
       else if (machine.compare(0, 3, "ppc", 3) == 0 || machine.compare(0, 5, "power", 5) == 0)
         kernelCpuFamily = "PowerPC";
     }

--- a/xbmc/utils/SystemInfo.h
+++ b/xbmc/utils/SystemInfo.h
@@ -31,6 +31,9 @@
 #define TB  (1024*GB)       // 1 TerraByte (1TB)  1024 GB (2^10 GB)
 
 #define MAX_KNOWN_ATTRIBUTES  46
+#define KERNEL_CPU_FAMILY_X86 "x86"
+#define KERNEL_CPU_FAMILY_ARM "ARM"
+#define KERNEL_CPU_FAMILY_MIPS "MIPS"
 
 
 class CSysData


### PR DESCRIPTION
Basically as RFC. This adds the bool conditions:

system.arch.x86_32, x86_64, arm_32, arm_64, mips_32, mips_64

I added this to determine which libboblight.so i need to download (atm i only can determine android which defaults to arm atm - but at one point i need to distinguish between android-arm and android-x86) in the boblight addon.

This allows a python script to determine the compiled arch by something like

if xbmc.getCondVisibility('system.arch.mips_64'):
  downloadmips64lib()
