### PR TITLE
[rebrand] android: log to logcat with "Kodi" prefix instead of "XBMC"

### DIFF
--- a/xbmc/android/activity/XBMCApp.cpp
+++ b/xbmc/android/activity/XBMCApp.cpp
@@ -343,7 +343,7 @@ int CXBMCApp::android_printf(const char *format, ...)
   // For use before CLog is setup by XBMC_Run()
   va_list args;
   va_start(args, format);
-  int result = __android_log_vprint(ANDROID_LOG_VERBOSE, "XBMC", format, args);
+  int result = __android_log_vprint(ANDROID_LOG_VERBOSE, "Kodi", format, args);
   va_end(args);
   return result;
 }


### PR DESCRIPTION
I just noticed that we are still using the `XBMC` prefix when logging to logcat on android and this changes it to `Kodi`.

@koying @anssih for commenting.
