### PR TITLE
[imx6] Fix VP8 timestamping

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
@@ -732,6 +732,13 @@ int CDVDVideoCodecIMX::Decode(BYTE *pData, int iSize, double dts, double pts)
         m_frameInfo.pExtInfo->nFrmWidth  = (((m_frameInfo.pExtInfo->nFrmWidth) + 15) & ~15);
         m_frameInfo.pExtInfo->nFrmHeight = (((m_frameInfo.pExtInfo->nFrmHeight) + 15) & ~15);
 
+        /* quick & dirty fix to get proper timestamping for VP8 codec */
+        if (m_decOpenParam.CodecFormat == VPU_V_VP8)
+        {
+          idx = VpuFindBuffer(m_frameInfo.pDisplayFrameBuf->pbufY);
+          m_outputBuffers[idx]->SetPts(pts);
+        }
+
         retStatus |= VC_PICTURE;
       } //VPU_DEC_OUTPUT_DIS
 


### PR DESCRIPTION
Hi,

I had a look at the remaining patches that may have been forgotten from the old xbmc-imx6 repo with helix release in approach.

That one comes from https://github.com/xbmc-imx6/xbmc/issues/52.
It is not so clean because I think the proper way would be to include the library libfslvpuwrap in kodi repo to be able to solve a few annoying bugs, or at least inconsistent behavior, this library exhibits.
Moreover it would be easier to build for android don't you think @koying ?
So if you agree, I can begin to prepare this library inclusion and then we will push in it the few fixes that may be useful to have a cleaner generic imx6 decode function...

By the time, this 3 lines patch is likely to avoid some reports from users who are not so happy with imx6 and VP8 codec for helix release...
