### PR TITLE
fix content dialog settings not being properly reset

### DIFF
--- a/xbmc/settings/dialogs/GUIDialogContentSettings.cpp
+++ b/xbmc/settings/dialogs/GUIDialogContentSettings.cpp
@@ -77,6 +77,7 @@ bool CGUIDialogContentSettings::OnMessage(CGUIMessage &message)
     {
       m_scrapers.clear();
       m_vecItems->Clear();
+      m_content = CONTENT_NONE;
 
       break;
     }


### PR DESCRIPTION
I just noticed that when you open the "Set content" dialog for a music/video source that has no content set yet, the dialog will have the content and scraper from the source set that was previously used in this dialog. So opening the dialog for an existing source and then for a new one showed the content settings of the existing source instead of starting with the "(None)" content.

This is a regression from Gotham introduced by my settings dialog refactor (specifically 4f109dde3e149b6899b13bba605da1035a05cf92) and should go into Helix.
