### PR TITLE
[win32] add nopvraddons and nobinaryaddons options to BuildSetup.bat

### DIFF
--- a/project/Win32BuildSetup/BuildSetup.bat
+++ b/project/Win32BuildSetup/BuildSetup.bat
@@ -26,7 +26,7 @@ rem -------------------------------------------------------------
 rem Config
 rem If you get an error that Visual studio was not found, SET your path for VSNET main executable.
 rem -------------------------------------------------------------
-rem	CONFIG START
+rem  CONFIG START
 SET buildmode=ask
 SET promptlevel=prompt
 SET buildmingwlibs=true
@@ -34,11 +34,11 @@ SET exitcode=0
 SET useshell=rxvt
 SET BRANCH=na
 FOR %%b in (%1, %2, %3, %4, %5) DO (
-	IF %%b==clean SET buildmode=clean
-	IF %%b==noclean SET buildmode=noclean
-	IF %%b==noprompt SET promptlevel=noprompt
-	IF %%b==nomingwlibs SET buildmingwlibs=false
-	IF %%b==sh SET useshell=sh
+  IF %%b==clean SET buildmode=clean
+  IF %%b==noclean SET buildmode=noclean
+  IF %%b==noprompt SET promptlevel=noprompt
+  IF %%b==nomingwlibs SET buildmingwlibs=false
+  IF %%b==sh SET useshell=sh
 )
 
 SET buildconfig=Release
@@ -50,14 +50,14 @@ set WORKSPACE=%CD%\..\..
   SET NET="%MSBUILDROOT%12.0\bin\MSBuild.exe"
 
   IF EXIST "!NET!" (
-	set msbuildemitsolution=1
-	set OPTS_EXE="..\VS2010Express\XBMC for Windows.sln" /t:Build /p:Configuration="%buildconfig%" /property:VCTargetsPath="%MSBUILDROOT%Microsoft.Cpp\v4.0\V120" /m
-	set CLEAN_EXE="..\VS2010Express\XBMC for Windows.sln" /t:Clean /p:Configuration="%buildconfig%" /property:VCTargetsPath="%MSBUILDROOT%Microsoft.Cpp\v4.0\V120"
+    set msbuildemitsolution=1
+    set OPTS_EXE="..\VS2010Express\XBMC for Windows.sln" /t:Build /p:Configuration="%buildconfig%" /property:VCTargetsPath="%MSBUILDROOT%Microsoft.Cpp\v4.0\V120" /m
+    set CLEAN_EXE="..\VS2010Express\XBMC for Windows.sln" /t:Clean /p:Configuration="%buildconfig%" /property:VCTargetsPath="%MSBUILDROOT%Microsoft.Cpp\v4.0\V120"
   )
 
   IF NOT EXIST %NET% (
     set DIETEXT=MSBuild was not found.
-	goto DIE
+    goto DIE
   )
   
   set EXE= "..\VS2010Express\XBMC\%buildconfig%\%APP_NAME%.exe"
@@ -66,7 +66,7 @@ set WORKSPACE=%CD%\..\..
   :: sets the BRANCH env var
   call getbranch.bat
 
-  rem	CONFIG END
+  rem  CONFIG END
   rem -------------------------------------------------------------
   goto EXE_COMPILE
 
@@ -75,7 +75,7 @@ set WORKSPACE=%CD%\..\..
   IF NOT %buildmode%==ask goto COMPILE_MINGW
   IF %promptlevel%==noprompt goto COMPILE_MINGW
   rem ---------------------------------------------
-  rem	check for existing exe
+  rem  check for existing exe
   rem ---------------------------------------------
   set buildmode=clean
   
@@ -99,9 +99,9 @@ set WORKSPACE=%CD%\..\..
     ECHO Compiling mingw libs
     ECHO bla>noprompt
     IF EXIST errormingw del errormingw > NUL
-	IF %buildmode%==clean (
-	  ECHO bla>makeclean
-	)
+    IF %buildmode%==clean (
+      ECHO bla>makeclean
+    )
     rem only use sh to please jenkins
     IF %useshell%==sh (
       call ..\..\tools\buildsteps\win32\make-mingwlibs.bat sh noprompt
@@ -109,8 +109,8 @@ set WORKSPACE=%CD%\..\..
       call ..\..\tools\buildsteps\win32\make-mingwlibs.bat noprompt
     )
     IF EXIST errormingw (
-    	set DIETEXT="failed to build mingw libs"
-    	goto DIE
+      set DIETEXT="failed to build mingw libs"
+      goto DIE
     )
   )
   IF %buildmode%==clean goto COMPILE_EXE
@@ -125,11 +125,11 @@ set WORKSPACE=%CD%\..\..
   ECHO Compiling %APP_NAME% branch %BRANCH%...
   %NET% %OPTS_EXE%
   IF %errorlevel%==1 (
-  	set DIETEXT="%APP_NAME%.EXE failed to build!  See %CD%\..\vs2010express\XBMC\%buildconfig%\objs\XBMC.log"
-	IF %promptlevel%==noprompt (
-		type "%CD%\..\vs2010express\XBMC\%buildconfig%\objs\XBMC.log"
-	)
-  	goto DIE
+    set DIETEXT="%APP_NAME%.EXE failed to build!  See %CD%\..\vs2010express\XBMC\%buildconfig%\objs\XBMC.log"
+    IF %promptlevel%==noprompt (
+      type "%CD%\..\vs2010express\XBMC\%buildconfig%\objs\XBMC.log"
+    )
+    goto DIE
   )
   ECHO Done!
   ECHO ------------------------------------------------------------
@@ -142,11 +142,11 @@ set WORKSPACE=%CD%\..\..
   ECHO Compiling %APP_NAME% branch %BRANCH%...
   %NET% %OPTS_EXE%
   IF %errorlevel%==1 (
-  	set DIETEXT="%APP_NAME%.EXE failed to build!  See %CD%\..\vs2010express\XBMC\%buildconfig%\objs\XBMC.log"
-	IF %promptlevel%==noprompt (
-		type "%CD%\..\vs2010express\XBMC\%buildconfig%\objs\XBMC.log"
-	)
-  	goto DIE
+    set DIETEXT="%APP_NAME%.EXE failed to build!  See %CD%\..\vs2010express\XBMC\%buildconfig%\objs\XBMC.log"
+    IF %promptlevel%==noprompt (
+      type "%CD%\..\vs2010express\XBMC\%buildconfig%\objs\XBMC.log"
+    )
+    goto DIE
   )
   ECHO Done!
   ECHO ------------------------------------------------------------
@@ -271,7 +271,7 @@ set WORKSPACE=%CD%\..\..
   ECHO Creating installer %APP_SETUPFILE%...
   IF EXIST %APP_SETUPFILE% del %APP_SETUPFILE% > NUL
   rem get path to makensis.exe from registry, first try tab delim
-  FOR /F "tokens=2* delims=	" %%A IN ('REG QUERY "HKLM\Software\NSIS" /ve') DO SET NSISExePath=%%B
+  FOR /F "tokens=2* delims=  " %%A IN ('REG QUERY "HKLM\Software\NSIS" /ve') DO SET NSISExePath=%%B
 
   IF NOT EXIST "%NSISExePath%" (
     rem try with space delim instead of tab
@@ -280,7 +280,7 @@ set WORKSPACE=%CD%\..\..
       
   IF NOT EXIST "%NSISExePath%" (
     rem fails on localized windows (Default) becomes (Par D�faut)
-    FOR /F "tokens=3* delims=	" %%A IN ('REG QUERY "HKLM\Software\NSIS" /ve') DO SET NSISExePath=%%B
+    FOR /F "tokens=3* delims=  " %%A IN ('REG QUERY "HKLM\Software\NSIS" /ve') DO SET NSISExePath=%%B
   )
 
   IF NOT EXIST "%NSISExePath%" (
@@ -290,7 +290,7 @@ set WORKSPACE=%CD%\..\..
   rem proper x64 registry checks
   IF NOT EXIST "%NSISExePath%" (
     ECHO using x64 registry entries
-    FOR /F "tokens=2* delims=	" %%A IN ('REG QUERY "HKLM\Software\Wow6432Node\NSIS" /ve') DO SET NSISExePath=%%B
+    FOR /F "tokens=2* delims=  " %%A IN ('REG QUERY "HKLM\Software\Wow6432Node\NSIS" /ve') DO SET NSISExePath=%%B
   )
   IF NOT EXIST "%NSISExePath%" (
     rem try with space delim instead of tab
@@ -298,7 +298,7 @@ set WORKSPACE=%CD%\..\..
   )
   IF NOT EXIST "%NSISExePath%" (
     rem on win 7 x64, the previous fails
-    FOR /F "tokens=3* delims=	" %%A IN ('REG QUERY "HKLM\Software\Wow6432Node\NSIS" /ve') DO SET NSISExePath=%%B
+    FOR /F "tokens=3* delims=  " %%A IN ('REG QUERY "HKLM\Software\Wow6432Node\NSIS" /ve') DO SET NSISExePath=%%B
   )
   IF NOT EXIST "%NSISExePath%" (
     rem try with space delim instead of tab
@@ -308,8 +308,8 @@ set WORKSPACE=%CD%\..\..
   SET NSISExe=%NSISExePath%\makensis.exe
   "%NSISExe%" /V1 /X"SetCompressor /FINAL lzma" /Dapp_root="%CD%\BUILD_WIN32" /DAPP_NAME="%APP_NAME%" /DCOMPANY="%COMPANY%" /DWEBSITE="%WEBSITE%" /Dapp_revision="%GIT_REV%" /Dapp_target="%target%" /Dapp_branch="%BRANCH%" "genNsisInstaller.nsi"
   IF NOT EXIST "%APP_SETUPFILE%" (
-	  set DIETEXT=Failed to create %APP_SETUPFILE%. NSIS installed?
-	  goto DIE
+    set DIETEXT=Failed to create %APP_SETUPFILE%. NSIS installed?
+    goto DIE
   )
   copy %PDB% %APP_PDBFILE% > nul
   ECHO ------------------------------------------------------------
@@ -336,7 +336,7 @@ set WORKSPACE=%CD%\..\..
   copy %log% ./buildlog.html > NUL
 
   IF %promptlevel%==noprompt (
-  goto END
+    goto END
   )
 
   set /P APP_BUILD_ANSWER=View the build log in your HTML browser? [y/n]
@@ -349,7 +349,7 @@ set WORKSPACE=%CD%\..\..
 
 :END
   IF %promptlevel% NEQ noprompt (
-  ECHO Press any key to exit...
-  pause > NUL
+    ECHO Press any key to exit...
+    pause > NUL
   )
   EXIT /B %exitcode%

--- a/project/Win32BuildSetup/BuildSetup.bat
+++ b/project/Win32BuildSetup/BuildSetup.bat
@@ -30,6 +30,8 @@ rem  CONFIG START
 SET buildmode=ask
 SET promptlevel=prompt
 SET buildmingwlibs=true
+SET buildpvraddons=true
+SET buildbinaryaddons=true
 SET exitcode=0
 SET useshell=rxvt
 SET BRANCH=na
@@ -38,6 +40,8 @@ FOR %%b in (%1, %2, %3, %4, %5) DO (
   IF %%b==noclean SET buildmode=noclean
   IF %%b==noprompt SET promptlevel=noprompt
   IF %%b==nomingwlibs SET buildmingwlibs=false
+  IF %%b==nopvraddons SET buildpvraddons=false
+  IF %%b==nobinaryaddons SET buildbinaryaddons=false
   IF %%b==sh SET useshell=sh
 )
 
@@ -210,27 +214,34 @@ set WORKSPACE=%CD%\..\..
   xcopy ..\..\media BUILD_WIN32\application\media /E /Q /I /Y /EXCLUDE:exclude.txt  > NUL
   xcopy ..\..\sounds BUILD_WIN32\application\sounds /E /Q /I /Y /EXCLUDE:exclude.txt  > NUL
   
-  ECHO ------------------------------------------------------------
-  call buildpvraddons.bat
-  IF %errorlevel%==1 (
-    set DIETEXT="failed to build pvr addons"
-    goto DIE
-  )
-    
-  IF EXIST error.log del error.log > NUL
   SET build_path=%CD%
-  ECHO ------------------------------------------------------------
-  ECHO Building addons...
-  cd ..\..\tools\buildsteps\win32
-  call make-addons.bat
-  IF %errorlevel%==1 (
-    set DIETEXT="failed to build addons"
-    cd %build_path%
-    goto DIE
+  IF %buildpvraddons%==true (
+    ECHO ------------------------------------------------------------
+    ECHO Building pvr addons...
+    call buildpvraddons.bat
+    IF %errorlevel%==1 (
+      set DIETEXT="failed to build pvr addons"
+      goto DIE
+    )
+      
+    IF EXIST error.log del error.log > NUL
   )
 
-  cd %build_path%
-  IF EXIST error.log del error.log > NUL
+  IF %buildbinaryaddons%==true (
+    ECHO ------------------------------------------------------------
+    ECHO Building addons...
+    cd ..\..\tools\buildsteps\win32
+    call make-addons.bat
+    IF %errorlevel%==1 (
+      set DIETEXT="failed to build addons"
+      cd %build_path%
+      goto DIE
+    )
+
+    cd %build_path%
+    IF EXIST error.log del error.log > NUL
+  )
+
   ECHO ------------------------------------------------------------
   ECHO Building Confluence Skin...
   cd ..\..\addons\skin.confluence


### PR DESCRIPTION
- The first commit replaces all tabs with two spaces and cleans up the indentation where it is wrong.
- The second commit adds the `nopvraddons` and `nobinaryaddons` options to BuildSetup.bat (similar to the existing `nomingwlibs` option) to make it possible to create very fast builds without having to rebuild PVR or binary addons.
