### PR TITLE
[pvr] fix: select the first item if we don't have a stored last selected item path

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
@@ -214,7 +214,11 @@ void CGUIDialogPVRChannelsOSD::RestoreControlStates()
   CPVRChannelGroupPtr group = GetPlayingGroup();
   if (group)
   {
-    m_viewControl.SetSelectedItem(GetLastSelectedItemPath(group->GroupID()));
+    std::string path = GetLastSelectedItemPath(group->GroupID());
+    if (!path.empty())
+      m_viewControl.SetSelectedItem(path);
+    else
+      m_viewControl.SetSelectedItem(0);
   }
 }
 


### PR DESCRIPTION
If you stay in the channel osd and select a different group, you never selected before, the selected item will be the same (group A = 22, group B = 22). This will fix the issue as it selects the first item instead of the same if we don't have a stored last selected item path.

@opdenkamp @Jalle19 mind taking a look
