### PR TITLE
Addon manager improvements

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -12392,7 +12392,7 @@ msgctxt "#24031"
 msgid "Error loading settings"
 msgstr ""
 
-#: xbmc/filesystem/AddonsDirectory.cpp
+#: xbmc/pvr/addons/PVRClients.cpp
 msgctxt "#24032"
 msgid "All Add-ons"
 msgstr ""
@@ -12400,7 +12400,7 @@ msgstr ""
 #: xbmc/addons/GUIViewStateAddonBrowser.cpp
 #: xbmc/filesystem/AddonsDirectory.cpp
 msgctxt "#24033"
-msgid "Get Add-ons"
+msgid "Install from repository"
 msgstr ""
 
 msgctxt "#24034"
@@ -12669,7 +12669,13 @@ msgctxt "#24086"
 msgid "Installing add-on..."
 msgstr ""
 
-#empty strings from id 24087 to 24088
+#. Used in add-on browser
+#: xbmc/filesystem/AddonsDirectory.cpp
+msgctxt "#24087"
+msgid "All repositories"
+msgstr ""
+
+#empty strings id 24088
 
 msgctxt "#24089"
 msgid "Add-on restarts"
@@ -12900,16 +12906,49 @@ msgctxt "#24134"
 msgid "We were unable to load your configured language. Please check your language settings."
 msgstr ""
 
-#empty strings from id 24135 to 24998
+#empty strings from id 24135 to 24993
 
+#: xbmc/addons/CGUIViewStateAddonBrowser.cpp
+#: xbmc/filesystem/AddonsDirectory.cpp
+msgctxt "#24994"
+msgid "Running"
+msgstr ""
+
+#: xbmc/addons/CGUIViewStateAddonBrowser.cpp
+#: xbmc/filesystem/AddonsDirectory.cpp
+msgctxt "#24995"
+msgid "Orphaned Dependencies"
+msgstr ""
+
+#: xbmc/addons/CGUIViewStateAddonBrowser.cpp
+#: xbmc/filesystem/AddonsDirectory.cpp
+msgctxt "#24996"
+msgid "Required Dependencies"
+msgstr ""
+
+#: xbmc/addons/CGUIViewStateAddonBrowser.cpp
+#: xbmc/filesystem/AddonsDirectory.cpp
+msgctxt "#24997"
+msgid "System Add-ons"
+msgstr ""
+
+#: xbmc/addons/CGUIViewStateAddonBrowser.cpp
+#: xbmc/filesystem/AddonsDirectory.cpp
+msgctxt "#24998"
+msgid "My Add-ons"
+msgstr ""
+
+#. Used in add-on browser
 msgctxt "#24999"
 msgid "Hide incompatible"
 msgstr ""
 
+#. Used in add-on browser
 msgctxt "#25000"
 msgid "Notifications"
 msgstr ""
 
+#. Used in add-on browser
 msgctxt "#25001"
 msgid "Hide foreign"
 msgstr ""

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -12906,7 +12906,13 @@ msgctxt "#24134"
 msgid "We were unable to load your configured language. Please check your language settings."
 msgstr ""
 
-#empty strings from id 24135 to 24993
+#empty strings from id 24135 to 24992
+
+#: xbmc/addons/CGUIViewStateAddonBrowser.cpp
+#: xbmc/filesystem/AddonsDirectory.cpp
+msgctxt "#24993"
+msgid "Information Providers"
+msgstr ""
 
 #: xbmc/addons/CGUIViewStateAddonBrowser.cpp
 #: xbmc/filesystem/AddonsDirectory.cpp

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -466,7 +466,6 @@ bool CAddonMgr::HasOutdatedAddons()
 bool CAddonMgr::GetAddons(const TYPE &type, VECADDONS &addons, bool enabled /* = true */)
 {
   CSingleLock lock(m_critSection);
-  addons.clear();
   if (!m_cp_context)
     return false;
   cp_status_t status;

--- a/xbmc/addons/GUIViewStateAddonBrowser.cpp
+++ b/xbmc/addons/GUIViewStateAddonBrowser.cpp
@@ -64,16 +64,11 @@ std::string CGUIViewStateAddonBrowser::GetExtensions()
 VECSOURCES& CGUIViewStateAddonBrowser::GetSources()
 {
   m_sources.clear();
-
-  { // check for updates
+  {
     CMediaSource share;
-    share.strPath = "addons://check/";
-    share.m_iDriveType = CMediaSource::SOURCE_TYPE_REMOTE; // hack for sorting
-    share.strName = g_localizeStrings.Get(24055); // "Check for updates"
-    CDateTime lastChecked = CAddonInstaller::Get().LastRepoUpdate();
-    if (lastChecked.IsValid())
-      share.strStatus = StringUtils::Format(g_localizeStrings.Get(24056).c_str(),
-                                            lastChecked.GetAsLocalizedDateTime(false, false).c_str());
+    share.strPath = "addons://user/";
+    share.m_iDriveType = CMediaSource::SOURCE_TYPE_LOCAL;
+    share.strName = g_localizeStrings.Get(24998);
     m_sources.push_back(share);
   }
   if (CAddonMgr::Get().HasOutdatedAddons())
@@ -84,24 +79,35 @@ VECSOURCES& CGUIViewStateAddonBrowser::GetSources()
     share.strName = g_localizeStrings.Get(24043); // "Available updates"
     m_sources.push_back(share);
   }
-  CAddonDatabase db;
-  if (db.Open() && db.HasDisabledAddons())
   {
     CMediaSource share;
-    share.strPath = "addons://disabled/";
+    share.strPath = "addons://dependencies/";
     share.m_iDriveType = CMediaSource::SOURCE_TYPE_LOCAL;
-    share.strName = g_localizeStrings.Get(24039);
+    share.strName = g_localizeStrings.Get(24996);
     m_sources.push_back(share);
   }
-  // we always have some enabled addons
   {
     CMediaSource share;
-    share.strPath = "addons://enabled/";
+    share.strPath = "addons://orphaned/";
     share.m_iDriveType = CMediaSource::SOURCE_TYPE_LOCAL;
-    share.strName = g_localizeStrings.Get(24062);
+    share.strName = g_localizeStrings.Get(24995);
     m_sources.push_back(share);
   }
-  if (CAddonMgr::Get().HasAddons(ADDON_REPOSITORY,true))
+  {
+    CMediaSource share;
+    share.strPath = "addons://system/";
+    share.m_iDriveType = CMediaSource::SOURCE_TYPE_LOCAL;
+    share.strName = g_localizeStrings.Get(24997);
+    m_sources.push_back(share);
+  }
+  {
+    CMediaSource share;
+    share.strPath = "addons://running/";
+    share.m_iDriveType = CMediaSource::SOURCE_TYPE_LOCAL;
+    share.strName = g_localizeStrings.Get(24994);
+    m_sources.push_back(share);
+  }
+  if (CAddonMgr::Get().HasAddons(ADDON_REPOSITORY, true))
   {
     CMediaSource share;
     share.strPath = "addons://repos/";
@@ -109,7 +115,6 @@ VECSOURCES& CGUIViewStateAddonBrowser::GetSources()
     share.strName = g_localizeStrings.Get(24033);
     m_sources.push_back(share);
   }
-  // add "install from zip"
   {
     CMediaSource share;
     share.strPath = "addons://install/";
@@ -117,7 +122,6 @@ VECSOURCES& CGUIViewStateAddonBrowser::GetSources()
     share.strName = g_localizeStrings.Get(24041);
     m_sources.push_back(share);
   }
-  // add "search"
   {
     CMediaSource share;
     share.strPath = "addons://search/";

--- a/xbmc/addons/GUIViewStateAddonBrowser.cpp
+++ b/xbmc/addons/GUIViewStateAddonBrowser.cpp
@@ -43,7 +43,6 @@ CGUIViewStateAddonBrowser::CGUIViewStateAddonBrowser(const CFileItemList& items)
   else
   {
     AddSortMethod(SortByLabel, SortAttributeIgnoreFolders, 551, LABEL_MASKS("%L", "%I", "%L", ""));  // Filename, Size | Foldername, empty
-    AddSortMethod(SortByDate, 552, LABEL_MASKS("%L", "%J", "%L", "%J"));  // Filename, Date | Foldername, Date
     SetSortMethod(SortByLabel);
   }
   SetViewAsControl(DEFAULT_VIEW_AUTO);

--- a/xbmc/addons/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/GUIWindowAddonBrowser.cpp
@@ -329,9 +329,8 @@ bool CGUIWindowAddonBrowser::GetDirectory(const std::string& strDirectory,
     CAddonInstaller::Get().GetInstallList(addons);
 
     CURL url(strDirectory);
-    CAddonsDirectory::GenerateListing(url,addons,items);
+    CAddonsDirectory::GenerateAddonListing(url, addons, items, g_localizeStrings.Get(24067));
     result = true;
-    items.SetProperty("reponame",g_localizeStrings.Get(24067));
     items.SetPath(strDirectory);
 
     if (m_guiState.get() && !m_guiState->HideParentDirItems())
@@ -546,7 +545,7 @@ int CGUIWindowAddonBrowser::SelectAddonID(const vector<ADDON::TYPE> &types, vect
   CFileItemList items;
   for (ADDON::IVECADDONS addon = addons.begin(); addon != addons.end(); ++addon)
   {
-    CFileItemPtr item(CAddonsDirectory::FileItemFromAddon(*addon, ""));
+    CFileItemPtr item(CAddonsDirectory::FileItemFromAddon(*addon, (*addon)->ID()));
     if (!items.Contains(item->GetPath()))
     {
       items.Add(item);

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -18,7 +18,9 @@
  *
  */
 
-
+#include <array>
+#include <algorithm>
+#include <functional>
 #include "AddonsDirectory.h"
 #include "addons/AddonDatabase.h"
 #include "DirectoryFactory.h"
@@ -47,187 +49,336 @@ CAddonsDirectory::CAddonsDirectory(void)
 CAddonsDirectory::~CAddonsDirectory(void)
 {}
 
-bool CAddonsDirectory::GetDirectory(const CURL& url, CFileItemList &items)
+
+const std::array<TYPE, 4> dependencyTypes = {
+    ADDON_VIZ_LIBRARY,
+    ADDON_SCRAPER_LIBRARY,
+    ADDON_SCRIPT_LIBRARY,
+    ADDON_SCRIPT_MODULE,
+};
+
+
+bool IsSystemAddon(const AddonPtr& addon)
 {
-  const std::string strPath(url.Get());
-  std::string path1(strPath);
-  URIUtils::RemoveSlashAtEnd(path1);
-  CURL path(path1);
-  items.ClearProperties();
+  return StringUtils::StartsWith(addon->Path(), CSpecialProtocol::TranslatePath("special://xbmc/addons"));
+}
 
-  items.SetContent("addons");
 
-  VECADDONS addons;
-  // get info from repository
-  bool groupAddons = true;
-  bool reposAsFolders = true;
-  if (path.GetHostName() == "enabled")
-  { // grab all enabled addons, including enabled repositories
-    reposAsFolders = false;
-    CAddonMgr::Get().GetAllAddons(addons, true);
-    items.SetProperty("reponame",g_localizeStrings.Get(24062));
-    items.SetLabel(g_localizeStrings.Get(24062));
-  }
-  else if (path.GetHostName() == "disabled")
-  { // grab all disabled addons, including disabled repositories
-    reposAsFolders = false;
-    groupAddons = false;
-    CAddonMgr::Get().GetAllAddons(addons, false);
-    items.SetProperty("reponame",g_localizeStrings.Get(24039));
-    items.SetLabel(g_localizeStrings.Get(24039));
-  }
-  else if (path.GetHostName() == "outdated")
+bool IsUserInstalled(const AddonPtr& addon)
+{
+  if (IsSystemAddon(addon))
+    return false;
+
+  auto res = std::find_if(dependencyTypes.begin(), dependencyTypes.end(),
+    [&addon](TYPE type){ return addon->IsType(type); });
+  return res == dependencyTypes.end();
+}
+
+
+bool IsOrphaned(const AddonPtr& addon)
+{
+  if (IsSystemAddon(addon) || IsUserInstalled(addon))
+    return false;
+
+  // Check if it's required by an installed addon
+  VECADDONS allAddons;
+  CAddonMgr::Get().GetAllAddons(allAddons, true);
+  CAddonMgr::Get().GetAllAddons(allAddons, false);
+  for (const AddonPtr& other : allAddons)
   {
-    reposAsFolders = false;
-    groupAddons = false;
-    // ensure our repos are up to date
-    CAddonInstaller::Get().UpdateRepos(false, true);
-    CAddonMgr::Get().GetAllOutdatedAddons(addons);
-    items.SetProperty("reponame",g_localizeStrings.Get(24043));
-    items.SetLabel(g_localizeStrings.Get(24043));
-  }
-  else if (path.GetHostName() == "repos")
-  {
-    groupAddons = false;
-    CAddonMgr::Get().GetAddons(ADDON_REPOSITORY,addons,true);
-    items.SetLabel(g_localizeStrings.Get(24033)); // Get Add-ons
-  }
-  else if (path.GetHostName() == "sources")
-  {
-    return GetScriptsAndPlugins(path.GetFileName(), items);
-  }
-  else if (path.GetHostName() == "all")
-  {
-    CAddonDatabase database;
-    database.Open();
-    database.GetAddons(addons);
-    items.SetProperty("reponame",g_localizeStrings.Get(24032));
-    items.SetLabel(g_localizeStrings.Get(24032));
-  }
-  else if (path.GetHostName() == "search")
-  {
-    std::string search(path.GetFileName());
-    if (search.empty() && !GetKeyboardInput(16017, search))
+    const auto& deps = other->GetDeps();
+    if (deps.find(addon->ID()) != deps.end())
       return false;
-
-    items.SetProperty("reponame",g_localizeStrings.Get(283));
-    items.SetLabel(g_localizeStrings.Get(283));
-
-    CAddonDatabase database;
-    database.Open();
-    database.Search(search, addons);
-    GenerateListing(path, addons, items, true);
-
-    path.SetFileName(search);
-    items.SetPath(path.Get());
-    return true;
   }
-  else
-  {
-    reposAsFolders = false;
-    AddonPtr addon;
-    CAddonMgr::Get().GetAddon(path.GetHostName(),addon);
-    if (!addon)
-      return false;
+  return true;
+}
 
-    // ensure our repos are up to date
-    CAddonInstaller::Get().UpdateRepos(false, true);
-    CAddonDatabase database;
-    database.Open();
-    database.GetRepository(addon->ID(),addons);
-    items.SetProperty("reponame",addon->Name());
-    items.SetLabel(addon->Name());
-  }
 
-  if (path.GetFileName().empty())
+void SetUpdateAvailProperties(CFileItemList &items)
+{
+  CAddonDatabase database;
+  database.Open();
+  for (int i = 0; i < items.Size(); ++i)
   {
-    if (groupAddons)
+    const std::string addonId = items[i]->GetProperty("Addon.ID").asString();
+    if (!CAddonMgr::Get().IsAddonDisabled(addonId))
     {
-      for (int i=ADDON_UNKNOWN+1;i<ADDON_MAX;++i)
+      const AddonVersion installedVersion = AddonVersion(items[i]->GetProperty("Addon.Version").asString());
+      AddonPtr repoAddon;
+      database.GetAddon(addonId, repoAddon);
+      if (repoAddon && repoAddon->Version() > installedVersion &&
+          !database.IsAddonBlacklisted(addonId, repoAddon->Version().asString()))
       {
-        for (unsigned int j=0;j<addons.size();++j)
-        {
-          if (addons[j]->IsType((TYPE)i))
-          {
-            CFileItemPtr item(new CFileItem(TranslateType((TYPE)i,true)));
-            item->SetPath(URIUtils::AddFileToFolder(strPath,TranslateType((TYPE)i,false)));
-            item->m_bIsFolder = true;
-            std::string thumb = GetIcon((TYPE)i);
-            if (!thumb.empty() && g_TextureManager.HasTexture(thumb))
-              item->SetArt("thumb", thumb);
-            items.Add(item);
-            break;
-          }
-        }
-      }
-      items.SetPath(strPath);
-      return true;
-    }
-  }
-  else
-  {
-    TYPE type = TranslateType(path.GetFileName());
-    items.SetProperty("addoncategory",TranslateType(type, true));
-    items.SetLabel(TranslateType(type, true));
-    items.SetPath(strPath);
-
-    // FIXME: Categorisation of addons needs adding here
-    for (unsigned int j=0;j<addons.size();++j)
-    {
-      if (!addons[j]->IsType(type))
-        addons.erase(addons.begin()+j--);
-    }
-  }
-
-  items.SetPath(strPath);
-  GenerateListing(path, addons, items, reposAsFolders);
-  // check for available updates
-  if (path.GetHostName() == "enabled")
-  {
-    CAddonDatabase database;
-    database.Open();
-    for (int i=0;i<items.Size();++i)
-    {
-      AddonPtr addon2;
-      database.GetAddon(items[i]->GetProperty("Addon.ID").asString(),addon2);
-      if (addon2 && addon2->Version() > AddonVersion(items[i]->GetProperty("Addon.Version").asString())
-                 && !database.IsAddonBlacklisted(addon2->ID(),addon2->Version().asString()))
-      {
-        items[i]->SetProperty("Addon.Status",g_localizeStrings.Get(24068));
+        items[i]->SetProperty("Addon.Status", g_localizeStrings.Get(24068));
         items[i]->SetProperty("Addon.UpdateAvail", true);
       }
     }
   }
-  if (path.GetHostName() == "repos" && items.Size() > 1)
-  {
-    CFileItemPtr item(new CFileItem("addons://all/",true));
-    item->SetLabel(g_localizeStrings.Get(24032));
-    items.Add(item);
-  }
-  else if (path.GetHostName() == "outdated" && items.Size() > 1)
+}
+
+bool CAddonsDirectory::GetSearchResults(const CURL& path, CFileItemList &items)
+{
+  std::string search(path.GetFileName());
+  if (search.empty() && !GetKeyboardInput(16017, search))
+    return false;
+
+  CAddonDatabase database;
+  database.Open();
+
+  VECADDONS addons;
+  database.Search(search, addons);
+  CAddonsDirectory::GenerateAddonListing(path, addons, items, g_localizeStrings.Get(283));
+  CURL searchPath(path);
+  searchPath.SetFileName(search);
+  items.SetPath(searchPath.Get());
+  return true;
+}
+
+void UserInstalledAddons(const CURL& path, CFileItemList &items)
+{
+  VECADDONS addons;
+  CAddonMgr::Get().GetAllAddons(addons, true);
+  CAddonMgr::Get().GetAllAddons(addons, false);
+  addons.erase(std::remove_if(addons.begin(), addons.end(),
+                              std::not1(std::ptr_fun(IsUserInstalled))), addons.end());
+  CAddonsDirectory::GenerateAddonListing(path, addons, items, g_localizeStrings.Get(24998));
+  SetUpdateAvailProperties(items);
+}
+
+void SystemAddons(const CURL& path, CFileItemList &items)
+{
+  VECADDONS addons;
+  CAddonMgr::Get().GetAllAddons(addons, true);
+  CAddonMgr::Get().GetAllAddons(addons, false);
+  addons.erase(std::remove_if(addons.begin(), addons.end(),
+                              std::not1(std::ptr_fun(IsSystemAddon))), addons.end());
+  CAddonsDirectory::GenerateAddonListing(path, addons, items, g_localizeStrings.Get(24997));
+}
+
+void DependencyAddons(const CURL& path, CFileItemList &items)
+{
+  VECADDONS addons;
+  CAddonMgr::Get().GetAllAddons(addons, true);
+  CAddonMgr::Get().GetAllAddons(addons, false);
+  addons.erase(std::remove_if(addons.begin(), addons.end(), IsSystemAddon), addons.end());
+  addons.erase(std::remove_if(addons.begin(), addons.end(), IsUserInstalled), addons.end());
+  addons.erase(std::remove_if(addons.begin(), addons.end(), IsOrphaned), addons.end());
+  CAddonsDirectory::GenerateAddonListing(path, addons, items, g_localizeStrings.Get(24996));
+  SetUpdateAvailProperties(items);
+}
+
+void OrphanedAddons(const CURL& path, CFileItemList &items)
+{
+  VECADDONS addons;
+  CAddonMgr::Get().GetAllAddons(addons, true);
+  CAddonMgr::Get().GetAllAddons(addons, false);
+  addons.erase(std::remove_if(addons.begin(), addons.end(),
+                              std::not1(std::ptr_fun(IsOrphaned))), addons.end());
+  CAddonsDirectory::GenerateAddonListing(path, addons, items, g_localizeStrings.Get(24995));
+}
+
+void OutdatedAddons(const CURL& path, CFileItemList &items)
+{
+  VECADDONS addons;
+  // Wait for running update to complete
+  CAddonInstaller::Get().UpdateRepos(false, true);
+  CAddonMgr::Get().GetAllOutdatedAddons(addons);
+  CAddonsDirectory::GenerateAddonListing(path, addons, items, g_localizeStrings.Get(24043));
+
+  if (items.Size() > 1)
   {
     CFileItemPtr item(new CFileItem("addons://update_all/", true));
     item->SetLabel(g_localizeStrings.Get(24122));
     item->SetSpecialSort(SortSpecialOnTop);
     items.Add(item);
   }
+}
 
+void RunningAddons(const CURL& path, CFileItemList &items)
+{
+  VECADDONS addons;
+  CAddonMgr::Get().GetAddons(ADDON_SERVICE, addons, true);
+  CAddonsDirectory::GenerateAddonListing(path, addons, items, g_localizeStrings.Get(24994));
+  //TODO: include web interfaces if web server is running
+}
+
+bool Browse(const CURL& path, CFileItemList &items)
+{
+  const std::string repo = path.GetHostName();
+  const std::string category = path.GetFileName();
+
+  VECADDONS addons;
+  if (repo == "all")
+  {
+    CAddonDatabase database;
+    database.Open();
+    database.GetAddons(addons);
+    items.SetProperty("reponame", g_localizeStrings.Get(24087));
+    items.SetLabel(g_localizeStrings.Get(24087));
+  }
+  else
+  {
+    AddonPtr addon;
+    if (!CAddonMgr::Get().GetAddon(repo, addon, ADDON_REPOSITORY))
+      return false;
+    //Wait for runnig update to complete
+    CAddonInstaller::Get().UpdateRepos(false, true);
+    CAddonDatabase database;
+    database.Open();
+    if (!database.GetRepository(addon->ID(), addons))
+      return false;
+    items.SetProperty("reponame", addon->Name());
+    items.SetLabel(addon->Name());
+  }
+
+  if (category.empty())
+  {
+    for (unsigned int i = ADDON_UNKNOWN + 1; i < ADDON_MAX - 1; ++i)
+    {
+      const TYPE type = (TYPE)i;
+      if (std::find(dependencyTypes.begin(), dependencyTypes.end(), type) != dependencyTypes.end())
+        continue;
+
+      for (unsigned int j = 0; j < addons.size(); ++j)
+      {
+        if (addons[j]->IsType(type))
+        {
+          CFileItemPtr item(new CFileItem(TranslateType(type, true)));
+          item->SetPath(URIUtils::AddFileToFolder(path.Get(), TranslateType(type, false)));
+          item->m_bIsFolder = true;
+          std::string thumb = GetIcon(type);
+          if (!thumb.empty() && g_TextureManager.HasTexture(thumb))
+            item->SetArt("thumb", thumb);
+          items.Add(item);
+          break;
+        }
+      }
+    }
+  }
+  else
+  {
+    TYPE type = TranslateType(category);
+    items.SetProperty("addoncategory",TranslateType(type, true));
+    addons.erase(std::remove_if(addons.begin(), addons.end(),
+        [=](const AddonPtr& addon){ return !addon->IsType(type); })  , addons.end());
+    CAddonsDirectory::GenerateAddonListing(path, addons, items, TranslateType(type, true));
+  }
   return true;
 }
 
-void CAddonsDirectory::GenerateListing(CURL &path, VECADDONS& addons, CFileItemList &items, bool reposAsFolders)
+
+bool Repos(const CURL& path, CFileItemList &items)
+{
+  items.SetLabel(g_localizeStrings.Get(24033));
+
+  VECADDONS addons;
+  CAddonMgr::Get().GetAddons(ADDON_REPOSITORY, addons, true);
+  if (addons.empty())
+    return true;
+  else if (addons.size() == 1)
+    return Browse(CURL("addons://" + addons[0]->ID()), items);
+  else
+  {
+    CFileItemPtr item(new CFileItem("addons://all/", true));
+    item->SetLabel(g_localizeStrings.Get(24087));
+    items.Add(item);
+  }
+
+  for (const auto& repo : addons)
+  {
+    CFileItemPtr item = CAddonsDirectory::FileItemFromAddon(repo, "addons://" + repo->ID(), true);
+    CAddonDatabase::SetPropertiesFromAddon(repo, item);
+    items.Add(item);
+  }
+  return true;
+}
+
+
+bool CAddonsDirectory::GetDirectory(const CURL& url, CFileItemList &items)
+{
+  std::string tmp(url.Get());
+  URIUtils::RemoveSlashAtEnd(tmp);
+  CURL path(tmp);
+  const std::string endpoint = path.GetHostName();
+  items.ClearProperties();
+  items.SetContent("addons");
+  items.SetPath(path.Get());
+
+  if (endpoint == "user")
+  {
+    UserInstalledAddons(path, items);
+    return true;
+  }
+  else if (endpoint == "dependencies")
+  {
+    DependencyAddons(path, items);
+    return true;
+  }
+  else if (endpoint == "orphaned")
+  {
+    OrphanedAddons(path, items);
+    return true;
+  }
+  else if (endpoint == "system")
+  {
+    SystemAddons(path, items);
+    return true;
+  }
+  //Pvr hardcodes this view so keep for compatibility
+  else if (endpoint == "disabled" && path.GetFileName() == "xbmc.pvrclient")
+  {
+    VECADDONS addons;
+    if (CAddonMgr::Get().GetAddons(ADDON_PVRDLL, addons, false))
+    {
+      CAddonsDirectory::GenerateAddonListing(path, addons, items, TranslateType(ADDON_PVRDLL, true));
+      return true;
+    }
+    return false;
+  }
+  else if (endpoint == "outdated")
+  {
+    OutdatedAddons(path, items);
+    return true;
+  }
+  else if (endpoint == "running")
+  {
+    RunningAddons(path, items);
+    return true;
+  }
+  else if (endpoint == "repos")
+  {
+    return Repos(path, items);
+  }
+  else if (endpoint == "sources")
+  {
+    return GetScriptsAndPlugins(path.GetFileName(), items);
+  }
+  else if (endpoint == "search")
+  {
+    return GetSearchResults(path, items);
+  }
+  else
+  {
+    return Browse(path, items);
+  }
+}
+
+
+void CAddonsDirectory::GenerateAddonListing(const CURL &path,
+                                            const VECADDONS& addons,
+                                            CFileItemList &items,
+                                            const std::string label)
 {
   items.ClearItems();
-  for (unsigned i=0; i < addons.size(); i++)
+  items.SetLabel(label);
+  for (const auto& addon : addons)
   {
-    AddonPtr addon = addons[i];
-    CFileItemPtr pItem;
-    if (reposAsFolders && addon->Type() == ADDON_REPOSITORY)
-      pItem = FileItemFromAddon(addon, "addons://", true);
-    else
-      pItem = FileItemFromAddon(addon, path.Get(), false);
-    AddonPtr addon2;
-    if (CAddonMgr::Get().GetAddon(addon->ID(),addon2))
+    CURL itemPath = path;
+    itemPath.SetFileName(addon->ID());
+    CFileItemPtr pItem = FileItemFromAddon(addon, itemPath.Get(), false);
+
+    AddonPtr installedAddon;
+    if (CAddonMgr::Get().GetAddon(addon->ID(), installedAddon))
       pItem->SetProperty("Addon.Status",g_localizeStrings.Get(305));
     else if (CAddonMgr::Get().IsAddonDisabled(addon->ID()))
       pItem->SetProperty("Addon.Status",g_localizeStrings.Get(24023));
@@ -236,7 +387,7 @@ void CAddonsDirectory::GenerateListing(CURL &path, VECADDONS& addons, CFileItemL
       pItem->SetProperty("Addon.Status",g_localizeStrings.Get(24049));
     else if (!addon->Props().broken.empty())
       pItem->SetProperty("Addon.Status",g_localizeStrings.Get(24098));
-    if (addon2 && addon2->Version() < addon->Version())
+    if (installedAddon && installedAddon->Version() < addon->Version())
     {
       pItem->SetProperty("Addon.Status",g_localizeStrings.Get(24068));
       pItem->SetProperty("Addon.UpdateAvail", true);
@@ -246,28 +397,17 @@ void CAddonsDirectory::GenerateListing(CURL &path, VECADDONS& addons, CFileItemL
   }
 }
 
-CFileItemPtr CAddonsDirectory::FileItemFromAddon(const AddonPtr &addon, const std::string &basePath, bool folder)
+CFileItemPtr CAddonsDirectory::FileItemFromAddon(const AddonPtr &addon, const std::string& path, bool folder)
 {
   if (!addon)
     return CFileItemPtr();
 
-  // TODO: This can probably be done more efficiently
-  CURL url(basePath);
-  url.SetFileName(addon->ID());
-  std::string path(url.Get());
-  if (folder)
-    URIUtils::AddSlashAtEnd(path);
-
   CFileItemPtr item(new CFileItem(path, folder));
 
   std::string strLabel(addon->Name());
-  if (url.GetHostName() == "search")
+  if (CURL(path).GetHostName() == "search")
     strLabel = StringUtils::Format("%s - %s", TranslateType(addon->Type(), true).c_str(), addon->Name().c_str());
-
   item->SetLabel(strLabel);
-
-  if (!URIUtils::PathEquals(basePath, "addons://") && addon->Type() == ADDON_REPOSITORY)
-    item->SetLabel2(addon->Version().asString());
   item->SetArt("thumb", addon->Icon());
   item->SetLabelPreformated(true);
   item->SetIconImage("DefaultAddon.png");
@@ -310,12 +450,12 @@ bool CAddonsDirectory::GetScriptsAndPlugins(const std::string &content, CFileIte
   if (!GetScriptsAndPlugins(content, addons))
     return false;
 
-  for (unsigned i=0; i<addons.size(); i++)
+  for (VECADDONS::const_iterator it = addons.begin(); it != addons.end(); ++it)
   {
-    CFileItemPtr item(FileItemFromAddon(addons[i], 
-                      addons[i]->Type()==ADDON_PLUGIN?"plugin://":"script://",
-                      addons[i]->Type() == ADDON_PLUGIN));
-    PluginPtr plugin = std::dynamic_pointer_cast<CPluginSource>(addons[i]);
+    const AddonPtr addon = *it;
+    const std::string prot = addon->Type() == ADDON_PLUGIN ? "plugin://" : "script://";
+    CFileItemPtr item(FileItemFromAddon(addon, prot + addon->ID(), addon->Type() == ADDON_PLUGIN));
+    PluginPtr plugin = std::dynamic_pointer_cast<CPluginSource>(addon);
     if (plugin->ProvidesSeveral())
     {
       CURL url = item->GetURL();

--- a/xbmc/filesystem/AddonsDirectory.h
+++ b/xbmc/filesystem/AddonsDirectory.h
@@ -62,7 +62,10 @@ namespace XFILE
      */
     static CFileItemPtr GetMoreItem(const std::string &content);
 
-    static void GenerateListing(CURL &path, ADDON::VECADDONS& addons, CFileItemList &items, bool reposAsFolders = true);
-    static CFileItemPtr FileItemFromAddon(const ADDON::AddonPtr &addon, const std::string &basePath, bool folder = false);
+    static void GenerateAddonListing(const CURL &path, const ADDON::VECADDONS& addons, CFileItemList &items, const std::string label);
+    static CFileItemPtr FileItemFromAddon(const ADDON::AddonPtr &addon, const std::string& path, bool folder = false);
+  
+  private:
+    bool GetSearchResults(const CURL& path, CFileItemList &items);
   };
 }

--- a/xbmc/video/dialogs/GUIDialogSubtitles.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitles.cpp
@@ -257,7 +257,7 @@ void CGUIDialogSubtitles::FillServices()
   std::string service = addons.front()->ID();
   for (VECADDONS::const_iterator addonIt = addons.begin(); addonIt != addons.end(); ++addonIt)
   {
-    CFileItemPtr item(CAddonsDirectory::FileItemFromAddon(*addonIt, "plugin://", false));
+    CFileItemPtr item(CAddonsDirectory::FileItemFromAddon(*addonIt, "plugin://" + (*addonIt)->ID(), false));
     m_serviceItems->Add(item);
     if ((*addonIt)->ID() == defaultService)
       service = (*addonIt)->ID();


### PR DESCRIPTION
- [x] This mainly removes the enabled/disabled nodes and replaces them with 'My addon'. And for the sake of keeping all installed addons visible, adds a 'dependencies' and 'system' addons node for uninstallable- and addons user shouldn't uninstall.
- [x] Adds 'Orphaned addons' for quick access to dependencies that can be removed.
- [x] Several fixes and UI improvements.
- [x] Adds support for categorization separate from addon type. Currently only moves 'information providers' type addons in a new category.
