### PR TITLE
[pvr] fix: separate sort orders for each directory in recordings window

### DIFF
--- a/xbmc/pvr/windows/GUIViewStatePVR.cpp
+++ b/xbmc/pvr/windows/GUIViewStatePVR.cpp
@@ -45,15 +45,15 @@ void CGUIViewStateWindowPVRChannels::SaveViewState(void)
 
 CGUIViewStateWindowPVRRecordings::CGUIViewStateWindowPVRRecordings(const int windowId, const CFileItemList& items) : CGUIViewStatePVR(windowId, items)
 {
-    AddSortMethod(SortByLabel, 551, LABEL_MASKS("%L", "%I", "%L", ""), CSettings::Get().GetBool("filelists.ignorethewhensorting") ? SortAttributeIgnoreArticle : SortAttributeNone);  // FileName, Size | Foldername, empty
-    AddSortMethod(SortByDate, 552, LABEL_MASKS("%L", "%J", "%L", "%J"));  // FileName, Date | Foldername, Date
-    AddSortMethod(SortByTime, 180, LABEL_MASKS("%T", "%D"));
-    AddSortMethod(SortByFile, 561, LABEL_MASKS("%L", "%I", "%L", ""));  // Filename, Size | FolderName, empty
+  AddSortMethod(SortByLabel, 551, LABEL_MASKS("%L", "%I", "%L", ""), CSettings::Get().GetBool("filelists.ignorethewhensorting") ? SortAttributeIgnoreArticle : SortAttributeNone);  // FileName, Size | Foldername, empty
+  AddSortMethod(SortByDate, 552, LABEL_MASKS("%L", "%J", "%L", "%J"));  // FileName, Date | Foldername, Date
+  AddSortMethod(SortByTime, 180, LABEL_MASKS("%T", "%D"));
+  AddSortMethod(SortByFile, 561, LABEL_MASKS("%L", "%I", "%L", ""));  // Filename, Size | FolderName, empty
 
-    // Default sorting
-    SetSortMethod(SortByDate);
+  // Default sorting
+  SetSortMethod(SortByDate);
 
-    LoadViewState(items.GetPath(), m_windowId);
+  LoadViewState(items.GetPath(), m_windowId);
 }
 
 void CGUIViewStateWindowPVRRecordings::SaveViewState(void)

--- a/xbmc/pvr/windows/GUIViewStatePVR.cpp
+++ b/xbmc/pvr/windows/GUIViewStatePVR.cpp
@@ -53,12 +53,12 @@ CGUIViewStateWindowPVRRecordings::CGUIViewStateWindowPVRRecordings(const int win
     // Default sorting
     SetSortMethod(SortByDate);
 
-    LoadViewState("pvr://recordings/", m_windowId);
+    LoadViewState(items.GetPath(), m_windowId);
 }
 
 void CGUIViewStateWindowPVRRecordings::SaveViewState(void)
 {
-  SaveViewToDb("pvr://recordings/", m_windowId, CViewStateSettings::Get().Get("pvrrecordings"));
+  SaveViewToDb(m_items.GetPath(), m_windowId, CViewStateSettings::Get().Get("pvrrecordings"));
 }
 
 bool CGUIViewStateWindowPVRRecordings::HideParentDirItems(void)


### PR DESCRIPTION
As reported in our forum http://forum.kodi.tv/showthread.php?tid=210142 it's currently impossible to select and store a different sort order (in general different view state options) for each directory in the recordings window.

We've changed the view state handling to be global for all PVR windows, which makes sense for the channel, guide and timer window, but I understand the need for a more flexible handling in the recordings window. So this re-adds a view state handling on a per directory-level basis in favor of a per directory basis.

Let me explain what's possible after we merge this. Imagine you have a recordings directory structure like below:

```
root
\__ channels 
        \__ episodes
```

With this PR it's possible to set the view state options (sort order, view etc.) for each directory level. For example you could sort all channels by name and episodes by date.

@Jalle19 and @opdenkamp if you look at the forum thread did you think we should handle this as a bugfix?
