### PR TITLE
[keymap] fix guide button for kernel-based mceusb remotes (closes #15374)

### DIFF
--- a/system/Lircmap.xml
+++ b/system/Lircmap.xml
@@ -87,6 +87,7 @@
 		<myvideo>KEY_VIDEO</myvideo>
 		<mymusic>KEY_AUDIO</mymusic>
 		<mytv>LiveTV</mytv>
+		<guide>KEY_EPG</guide>
 		<one>KEY_1</one>
 		<two>KEY_2</two>
 		<three>KEY_3</three>


### PR DESCRIPTION
Copied from trac, not tested in any way but seems valid.

@xhaggi right?
@topfs2 @MartijnKaijser should be pretty harmless, though I guess it can wait until a point release too since this is not a regression introduced by us.
