### PR TITLE
[pvr] don't reset internal group channel numbers if reset channel number cache

### DIFF
--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -967,10 +967,6 @@ void CPVRChannelGroup::ResetChannelNumberCache(void)
   if (!m_bSelectedGroup)
     return;
 
-  /* reset the channel number cache */
-  if (!IsInternalGroup())
-    g_PVRChannelGroups->GetGroupAll(m_bRadio)->ResetChannelNumbers();
-
   /* set all channel numbers on members of this group */
   for (unsigned int iChannelPtr = 0; iChannelPtr < m_members.size(); iChannelPtr++)
   {
@@ -1017,13 +1013,6 @@ bool CPVRChannelGroup::HasChanges(void) const
 {
   CSingleLock lock(m_critSection);
   return m_bChanged || HasNewChannels() || HasChangedChannels();
-}
-
-void CPVRChannelGroup::ResetChannelNumbers(void)
-{
-  CSingleLock lock(m_critSection);
-  for (unsigned int iChannelPtr = 0; iChannelPtr < m_members.size(); iChannelPtr++)
-    m_members.at(iChannelPtr).channel->SetCachedChannelNumber(0);
 }
 
 void CPVRChannelGroup::OnSettingChanged(const CSetting *setting)

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -518,8 +518,6 @@ namespace PVR
      */
     CFileItemPtr GetByChannelUpDown(const CFileItem &channel, bool bChannelUp) const;
 
-    void ResetChannelNumbers(void);
-
     /*!
      * @brief Get a channel given it's channel ID.
      * @param iChannelID The channel ID.


### PR DESCRIPTION
Should fix the issue reported in Trac http://trac.kodi.tv/ticket/15563

> When "use backend channel number" is selected in settings/live tv/general (using pvr.wmc client) infolabel Listitem.ChannelNumberLabel returns labels in the form "0.y" (y = minor channel number for US ATSC virtual channels) for all channels which are not members of the selected channel group (when "use backend channel number" is not selected, the infolabel returns "0"). Observed in Confluence Dialog PVRGroupManager.
> Expected result would either be "0" for channels not in current channel group or "x.y" with the actual major.minor virtual channel number. Assumed source is PVRChannelGroupInternal.cpp.
