### PR TITLE
[translation] Fixed Polish translation

### DIFF
--- a/language/Polish/strings.po
+++ b/language/Polish/strings.po
@@ -2827,7 +2827,7 @@ msgstr "Chciałbyś przeskanować teraz?"
 
 msgctxt "#802"
 msgid "%s of %s available"
-msgstr "%s z &s dostępne"
+msgstr "%s z %s dostępne"
 
 msgctxt "#850"
 msgid "Invalid port number entered"


### PR DESCRIPTION
This fixes Polish translation of "%s of %s available" (the second value was displayed as "&s")
