### PR TITLE
[pvr] fix async selected item behavior

### DIFF
--- a/xbmc/epg/GUIEPGGridContainer.cpp
+++ b/xbmc/epg/GUIEPGGridContainer.cpp
@@ -1289,8 +1289,13 @@ void CGUIEPGGridContainer::SetSelectedChannel(int channelIndex)
 {
   if (channelIndex < 0)
     return;
-
-  if (channelIndex - m_channelOffset < m_channelsPerPage && channelIndex - m_channelOffset >= 0)
+  
+  if (channelIndex - m_channelOffset <= 0)
+  {
+    ScrollToChannelOffset(0);
+    SetChannel(channelIndex);
+  }
+  else if (channelIndex - m_channelOffset < m_channelsPerPage && channelIndex - m_channelOffset >= 0)
   {
     SetChannel(channelIndex - m_channelOffset);
   }

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -113,7 +113,7 @@ void CGUIWindowPVRGuide::UpdateSelectedItemPath()
     {
       CPVRChannel* channel = epgGridContainer->GetChannel(epgGridContainer->GetSelectedChannel());
       if (channel != NULL)
-        m_selectedItemPaths.at(m_bRadio) = channel->Path();
+        SetSelectedItemPath(m_bRadio, channel->Path());
     }
   }
   else
@@ -295,7 +295,7 @@ void CGUIWindowPVRGuide::UpdateViewNow()
   }
 
   m_viewControl.SetItems(*m_vecItems);
-  m_viewControl.SetSelectedItem(m_selectedItemPaths.at(m_bRadio));
+  m_viewControl.SetSelectedItem(GetSelectedItemPath(m_bRadio));
 }
 
 void CGUIWindowPVRGuide::UpdateViewNext()
@@ -316,7 +316,7 @@ void CGUIWindowPVRGuide::UpdateViewNext()
   }
 
   m_viewControl.SetItems(*m_vecItems);
-  m_viewControl.SetSelectedItem(m_selectedItemPaths.at(m_bRadio));
+  m_viewControl.SetSelectedItem(GetSelectedItemPath(m_bRadio));
 }
 
 void CGUIWindowPVRGuide::UpdateViewTimeline()
@@ -362,7 +362,7 @@ void CGUIWindowPVRGuide::UpdateViewTimeline()
   
   m_viewControl.SetItems(*m_vecItems);
 
-  epgGridContainer->SetChannel(m_selectedItemPaths.at(m_bRadio));
+  epgGridContainer->SetChannel(GetSelectedItemPath(m_bRadio));
 }
 
 bool CGUIWindowPVRGuide::Update(const std::string &strDirectory, bool updateFilterPath /* = true */)


### PR DESCRIPTION
This is an attempt to fix the async selected item behavior reported at http://trac.kodi.tv/ticket/15522

The root cause is related to an issue in CGUIEPGGridContainer::SetSelectedChannel() where we calculate the channel offset and relative channel index. If the index is less than the stored channel offset the wrong calculation is done and the wrong item is selected. This adds a new condition to fix that issue.

Furthermore i've changed CGUIWindowPVRGuide to use the getter/setter instead of access m_selectedItemPaths directly.
