### PR TITLE
fix - not really proper fix for #15501

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayCodecFFmpeg.cpp
@@ -190,7 +190,7 @@ int CDVDOverlayCodecFFmpeg::Decode(DemuxPacket *pPacket)
   }
 
   m_StartTime   = DVD_MSEC_TO_TIME(m_Subtitle.start_display_time);
-  m_StopTime    = DVD_MSEC_TO_TIME(m_Subtitle.end_display_time);
+  m_StopTime    = DVD_MSEC_TO_TIME(m_Subtitle.end_display_time + 5000);
 
   //adapt start and stop time to our packet pts
   bool dummy = false;


### PR DESCRIPTION
@topfs2 

see http://trac.kodi.tv/ticket/15501

:warning: this PR is not really meant to be merged as is but it is indeed beyond me its a totall botch but works for this case.

The issue is that  m_Subtitle.end_display_time seems to be some insane value of  **_4294967295**_

that was observed by adding to line 194+

```
CLog::Log(LOGNOTICE, "Insane EndTime: %ld", (unsigned int) m_Subtitle.end_display_time);
```

This crude solution fixes the symptom but not the cause please close this PR and submit a proper fix.

@fritsch  tried to guide me on IRC to a better solution like https://github.com/uNiversaI/xbmc/commit/c24947dc99b5b3abbb025c52fa41f91c94a3216a but that doesn't even compile and I utterly lack the skills to do better.
