### PR TITLE
fix: internal pgs subtitles handling trac #15501

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayCodecFFmpeg.cpp
@@ -188,7 +188,12 @@ int CDVDOverlayCodecFFmpeg::Decode(DemuxPacket *pPacket)
       pts_offset = m_Subtitle.pts - pPacket->pts ;
     }
   }
-
+  // Workaround m_Subtitle.end_display_time being UINT32_MAX.
+  // That would keep last spoken line on sub always on screen.
+  // cause: m_Subtitle.end_display_time is not always UINT32_MAX only in error case.
+  if (m_Subtitle.end_display_time == 0xffffffffU)
+    m_Subtitle.end_display_time = m_Subtitle.start_display_time + 5000;
+  
   m_StartTime   = DVD_MSEC_TO_TIME(m_Subtitle.start_display_time);
   m_StopTime    = DVD_MSEC_TO_TIME(m_Subtitle.end_display_time);
 


### PR DESCRIPTION
Fixes really insane long value for  m_Subtitle.end_display_time

Now... after comments on #5874 and fairly extensive help from @fritsch managed to get all his instructions compiled and tested.

Ive tested against http://trac.kodi.tv/ticket/15501 foreign part only pgs subs which are problematic ones.
the issue never existed with similar SRT counterparts I dont have similar ass or sub/idx to test but the issue on track is indeed resolved by this.

thank you @fritsch for actually solving it on both counts. I can say I have indeed learned something more today.
