### PR TITLE
FIX: [json;build] include the proper Makefile.include

### DIFF
--- a/xbmc/interfaces/json-rpc/Makefile
+++ b/xbmc/interfaces/json-rpc/Makefile
@@ -27,7 +27,7 @@ JSON_SRC =  $(JSON_VERSION_SRC) schema/license.txt schema/methods.json schema/ty
 
 all: $(GENERATED_JSON) $(GENERATED_ADDON_JSON) $(LIB)
 
--include ../../../Makefile.include
+-include ../../../tools/depends/Makefile.include
 ifeq ($(wildcard $(JSON_BUILDER)),)
   JSON_BUILDER = $(shell which JsonSchemaBuilder)
 ifeq ($(JSON_BUILDER),)


### PR DESCRIPTION
Build-only issue. JsonSchemaBuilder is not found.
/cc @Montellese @Memphiz 
