### PR TITLE
Revert "[airplay] - merge the binary plist and xml plist pathes in airpl...

### DIFF
--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -877,7 +877,7 @@ int CAirPlayServer::CTCPClient::ProcessRequest( std::string& responseHeader,
     {
       status = AIRPLAY_STATUS_NEED_AUTH;
     }
-    else
+    else if (contentType == "application/x-apple-binary-plist")
     {
       CAirPlayServer::m_isPlaying++;    
       
@@ -888,11 +888,7 @@ int CAirPlayServer::CTCPClient::ProcessRequest( std::string& responseHeader,
         const char* bodyChr = m_httpParser->getBody();
 
         plist_t dict = NULL;
-        if (contentType == "application/x-apple-binary-plist")
-          m_pLibPlist->plist_from_bin(bodyChr, m_httpParser->getContentLength(), &dict);
-        else
-          m_pLibPlist->plist_from_xml(bodyChr, m_httpParser->getContentLength(), &dict);
-
+        m_pLibPlist->plist_from_bin(bodyChr, m_httpParser->getContentLength(), &dict);
 
         if (m_pLibPlist->plist_dict_get_size(dict))
         {
@@ -949,6 +945,28 @@ int CAirPlayServer::CTCPClient::ProcessRequest( std::string& responseHeader,
           CLog::Log(LOGERROR, "Error parsing plist");
         }
         m_pLibPlist->Unload();
+      }
+    }
+    else
+    {
+      CAirPlayServer::m_isPlaying++;        
+      // Get URL to play
+      std::string contentLocation = "Content-Location: ";
+      size_t start = body.find(contentLocation);
+      if (start == std::string::npos)
+        return AIRPLAY_STATUS_NOT_IMPLEMENTED;
+      start += contentLocation.size();
+      int end = body.find('\n', start);
+      location = body.substr(start, end - start);
+
+      std::string startPosition = "Start-Position: ";
+      start = body.find(startPosition);
+      if (start != std::string::npos)
+      {
+        start += startPosition.size();
+        int end = body.find('\n', start);
+        std::string positionStr = body.substr(start, end - start);
+        position = (float)atof(positionStr.c_str());
       }
     }
 

--- a/xbmc/network/DllLibPlist.h
+++ b/xbmc/network/DllLibPlist.h
@@ -30,7 +30,6 @@ public:
   virtual ~DllLibPlistInterface() {}
 
   virtual void        plist_from_bin        (const char *plist_bin,   uint32_t length, plist_t * plist  )=0;
-  virtual void        plist_from_xml        (const char *plist_xml,   uint32_t length, plist_t * plist  )=0;
   virtual plist_t     plist_new_dict        (void                                                       )=0;
   virtual uint32_t    plist_dict_get_size   (plist_t node                                               )=0;
   virtual void        plist_get_string_val  (plist_t node,            char **val                        )=0;
@@ -57,7 +56,6 @@ class DllLibPlist : public DllDynamic, DllLibPlistInterface
   DEFINE_METHOD2(void,          plist_dict_new_iter,  (plist_t p1,      plist_dict_iter* p2))
   DEFINE_METHOD2(plist_t,       plist_dict_get_item,  (plist_t p1,      const char* p2))
   DEFINE_METHOD3(void,          plist_from_bin,       (const char *p1,  uint32_t p2, plist_t *p3))
-  DEFINE_METHOD3(void,          plist_from_xml,       (const char *p1,  uint32_t p2, plist_t *p3))
   DEFINE_METHOD3(void,          plist_to_xml,         (plist_t p1,      char **p2, uint32_t *p3));
   DEFINE_METHOD4(void,          plist_dict_next_item, (plist_t p1, plist_dict_iter p2, char **p3, plist_t *p4))
 #ifdef TARGET_WINDOWS
@@ -70,7 +68,6 @@ class DllLibPlist : public DllDynamic, DllLibPlistInterface
     RESOLVE_METHOD_RENAME(plist_free,             plist_free)
     RESOLVE_METHOD_RENAME(plist_dict_get_size,    plist_dict_get_size)
     RESOLVE_METHOD_RENAME(plist_from_bin,         plist_from_bin)
-    RESOLVE_METHOD_RENAME(plist_from_xml,         plist_from_xml)
     RESOLVE_METHOD_RENAME(plist_get_real_val,     plist_get_real_val)
     RESOLVE_METHOD_RENAME(plist_get_string_val,   plist_get_string_val)
     RESOLVE_METHOD_RENAME(plist_dict_get_item,    plist_dict_get_item)


### PR DESCRIPTION
...ay (which already diverged) by using libplist for parsing in both cases - not only the binary case"

This reverts commit 392babec96915939f416efa6888e1379140ad725. Because it
was plain wrong - the text version of the airplay protocol is not even
XML.

I had a brainfart here and luckily there are still apps out there which don't use plist airplay format so this was discovered and can be fixed for helix right in time :) - confirmed by the user who noticed the regression.
