### PR TITLE
[win32] SystemInfo: support Windows 10 detection

### DIFF
--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -712,6 +712,12 @@ std::string CSysInfo::GetOsPrettyNameWithVersion(void)
       else
         osNameVer.append("Server 2012 R2");
       break;
+    case WindowsVersionWin10:
+      if (osvi.wProductType == VER_NT_WORKSTATION)
+        osNameVer.append("10");
+      else
+        osNameVer.append("Server vNext"); /* FIXME: Correct name if required */
+      break;
     case WindowsVersionFuture:
       osNameVer.append("Unknown Future Version");
       break;
@@ -899,8 +905,10 @@ CSysInfo::WindowsVersion CSysInfo::GetWindowsVersion()
         m_WinVer = WindowsVersionWin8;
       else if (osvi.dwMajorVersion == 6 && osvi.dwMinorVersion == 3) 
         m_WinVer = WindowsVersionWin8_1;
+      else if (osvi.dwMajorVersion == 6 && osvi.dwMinorVersion == 4)
+        m_WinVer = WindowsVersionWin10;
       /* Insert checks for new Windows versions here */
-      else if ( (osvi.dwMajorVersion == 6 && osvi.dwMinorVersion > 3) || osvi.dwMajorVersion > 6)
+      else if (osvi.dwMajorVersion >= 6)
         m_WinVer = WindowsVersionFuture;
     }
   }

--- a/xbmc/utils/SystemInfo.h
+++ b/xbmc/utils/SystemInfo.h
@@ -87,7 +87,8 @@ public:
     WindowsVersionVista,        // Windows Vista, Windows Server 2008
     WindowsVersionWin7,         // Windows 7, Windows Server 2008 R2
     WindowsVersionWin8,         // Windows 8, Windows Server 2012
-    WindowsVersionWin8_1,       // Windows 8.1
+    WindowsVersionWin8_1,       // Windows 8.1, Windows Server 2012 R2
+    WindowsVersionWin10,        // Windows 10, Windows Server vNext
     /* Insert new Windows versions here, when they'll be known */
     WindowsVersionFuture = 100  // Future Windows version, not known to code
   };


### PR DESCRIPTION
Simple patch, shouldn't break anything.
I believe that Helix release will be used with next version of Windows, which should be much more popular than 8/8.1.
With this patch Helix will write correct info to the log instead of "Unknown Windows future version".
