### PR TITLE
[input/linux] - map KEY_BACK to xbmckey backspace - same like we do for ...

### DIFF
--- a/xbmc/input/linux/LinuxInputDevices.cpp
+++ b/xbmc/input/linux/LinuxInputDevices.cpp
@@ -249,6 +249,7 @@ KeyMap keyMap[] = {
   { KEY_FASTFORWARD   , XBMCK_FASTFORWARD },
   { KEY_PRINT         , XBMCK_PRINT       },
   { KEY_QUESTION      , XBMCK_HELP        },
+  { KEY_BACK          , XBMCK_BACKSPACE   },
   // The Little Black Box Remote Additions
   { 384               , XBMCK_LEFT        }, // Red
   { 378               , XBMCK_RIGHT       }, // Green


### PR DESCRIPTION
...android (key back as found on the wetek remote sends KEY_BACK keycode which is not mapped on linux and so isn't usable in openelec on that box).

Well this is a nobrainer imo and fixes the back key on the wetek remote :)
