### PR TITLE
[aml] Do not disable keyboard auto-repeat for Meson6 and higher

### DIFF
--- a/xbmc/input/linux/LinuxInputDevices.cpp
+++ b/xbmc/input/linux/LinuxInputDevices.cpp
@@ -748,7 +748,7 @@ void CLinuxInputDevice::SetupKeyboardAutoRepeat(int fd)
   bool enable = true;
 
 #if defined(HAS_LIBAMCODEC)
-  if (aml_present())
+  if (aml_get_device_type() == AML_DEVICE_TYPE_M1 || aml_get_device_type() == AML_DEVICE_TYPE_M3)
   {
     // ignore the native aml driver named 'key_input',
     //  it is the dedicated power key handler (am_key_input)


### PR DESCRIPTION
Amlogic Meson6 and higher SoCs don't suffer anymore from the
kernel bug mentioned in comments as they predecessors,
so there's no need to disable the keyboard auto-repeat.
