### PR TITLE
[addons] display a more helpful message on python script error

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -4221,17 +4221,31 @@ msgctxt "#2081"
 msgid "Went back to parent list because the active list has been emptied"
 msgstr ""
 
-#empty strings from id 2082 to 2099
-
-msgctxt "#2100"
-msgid "Script failed! : %s"
-msgstr ""
+#empty strings from id 2082 to 2100
 
 msgctxt "#2101"
 msgid "Newer version needed - See log"
 msgstr ""
 
-#empty strings from id 2102 to 9999
+#. Notification message indicating an add-on error. "<Add-on name> error".
+#: xbmc/interfaces/python/PythonInvoker.cpp
+msgctxt "#2102"
+msgid "%s error"
+msgstr ""
+
+#. Fallback message indicating an add-on error.
+#: xbmc/interfaces/python/PythonInvoker.cpp
+msgctxt "#2103"
+msgid "Add-on error"
+msgstr ""
+
+#. Used for add-on error kaitoast.
+#: xbmc/interfaces/python/PythonInvoker.cpp
+msgctxt "#2104"
+msgid "See log for more info."
+msgstr ""
+
+#empty strings from id 2105 to 9999
 
 #: xbmc/guilib/WindowIDs.h
 msgctxt "#10000"

--- a/xbmc/interfaces/python/PythonInvoker.cpp
+++ b/xbmc/interfaces/python/PythonInvoker.cpp
@@ -573,24 +573,14 @@ void CPythonInvoker::onError()
   CGUIDialogKaiToast *pDlgToast = (CGUIDialogKaiToast*)g_windowManager.GetWindow(WINDOW_DIALOG_KAI_TOAST);
   if (pDlgToast != NULL)
   {
-    std::string desc;
-    std::string script;
-    if (m_addon.get() != NULL)
-      script = m_addon->Name();
+    std::string message;
+    if (m_addon && !m_addon->Name().empty())
+      message = StringUtils::Format(g_localizeStrings.Get(2102).c_str(), m_addon->Name().c_str());
+    else if (m_sourceFile == CSpecialProtocol::TranslatePath("special://profile/autoexec.py"))
+      message = StringUtils::Format(g_localizeStrings.Get(2102).c_str(), "autoexec.py");
     else
-    {
-      std::string path;
-      URIUtils::Split(m_sourceFile.c_str(), path, script);
-      if (script == "default.py")
-      {
-        std::string path2;
-        URIUtils::RemoveSlashAtEnd(path);
-        URIUtils::Split(path, path2, script);
-      }
-    }
-
-    desc = StringUtils::Format(g_localizeStrings.Get(2100).c_str(), script.c_str());
-    pDlgToast->QueueNotification(CGUIDialogKaiToast::Error, g_localizeStrings.Get(257), desc);
+       message = g_localizeStrings.Get(2103);
+    pDlgToast->QueueNotification(CGUIDialogKaiToast::Error, message, g_localizeStrings.Get(2104));
   }
 }
 


### PR DESCRIPTION
Clearly people are unable to read beyond "script error". This makes it more clear it's an addon error and displays the addon name first if available.
