### PR TITLE
[Android-5.0] fix playback getting progressively slower and memory filling up until cr...

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -782,7 +782,7 @@ int CDVDVideoCodecAndroidMediaCodec::GetOutputPicture(void)
 {
   int rtn = 0;
 
-  int64_t timeout_us = 5000;
+  int64_t timeout_us = 50000;
   CJNIMediaCodecBufferInfo bufferInfo;
   int index = m_codec->dequeueOutputBuffer(bufferInfo, timeout_us);
   if (index >= 0)


### PR DESCRIPTION
...ash

The timeout in dequeueOutputBuffer has been increased to 50ms (from 5ms), to ensure a buffer will be available. While it appears this is not an issue on 4.4 and older, on Android 5.0 dequeueOutputBuffer with a 5ms timeout will usually fail, releaseOutputBuffer will not be called, and this will lead to most dequeueInputBuffer calls failing as well (far fewer than wanted fps calls will succeed). This in turn leads to the m_demux queue quickly filling up with the raw frame data, consuming all system memory, until a crash results.
