### PR TITLE
Fix bashisms in shell scripts

### DIFF
--- a/tools/Linux/kodi.sh.in
+++ b/tools/Linux/kodi.sh.in
@@ -57,7 +57,7 @@ migrate_home()
 
 command_exists()
 {
-  command -v $1 >/dev/null 2>&1
+  command -pv $1 >/dev/null 2>&1
 }
 
 single_stacktrace()


### PR DESCRIPTION
Bashisms in scripts may cause problems on systems where the default
shell is not Bash.

I could not test the changes on Darwin lacking the development environment.
