### PR TITLE
AESinkFactory: Allow selection of ALSA devices even when running Pulseaudio

### DIFF
--- a/xbmc/cores/AudioEngine/AESinkFactory.cpp
+++ b/xbmc/cores/AudioEngine/AESinkFactory.cpp
@@ -260,7 +260,9 @@ void CAESinkFactory::EnumerateEx(AESinkInfoList &list, bool force)
   if(!info.m_deviceInfoList.empty())
   {
     list.push_back(info);
-    return;
+    // Not returning here will allow to also add
+    // ALSA devices into the enumeration
+    //return;
   }
   #endif
 


### PR DESCRIPTION
After the 100ts time having to cope with pure idi***, that just don't want to understand why we hide ALSA devices when a pulseaudio server is up and running, I give in ...

I documented it in the wiki but I am constantly blamed in the forum for breaking user setups, cause it "just worked in gotham".
- We will plain segfault when we open alsa devices while PA server is initializing.
- We will loose audio devices on every situation we don't hogg the device, e.g. when switching from menu to video, from idle to menu sounds, from passthrough to menu playback.

Here, enable everything on any broken, random setup. Just let people run into constant segfaults, they really, really want it like this.
