### PR TITLE
VAAPI: Don't return false when vlVaQueryDisplayAttributes returns empty

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.cpp
@@ -2480,6 +2480,9 @@ bool CVppPostproc::PreInit(CVaapiConfig &config, SDiMethods *methods)
   // create config
   if (!CheckSuccess(vaCreateConfig(m_config.dpy, VAProfileNone, VAEntrypointVideoProc, NULL, 0, &m_configId)))
   {
+    if (g_advancedSettings.CanLogComponent(LOGVIDEO))
+      CLog::Log(LOGDEBUG, "CVppPostproc::PreInit  - VPP init failed");
+
     return false;
   }
 
@@ -2494,6 +2497,9 @@ bool CVppPostproc::PreInit(CVaapiConfig &config, SDiMethods *methods)
                                      nb_surfaces,
                                      NULL, 0)))
   {
+    if (g_advancedSettings.CanLogComponent(LOGVIDEO))
+      CLog::Log(LOGDEBUG, "CVppPostproc::PreInit  - VPP init failed");
+
     return false;
   }
   for (int i=0; i<nb_surfaces; i++)
@@ -2512,6 +2518,9 @@ bool CVppPostproc::PreInit(CVaapiConfig &config, SDiMethods *methods)
                                     &m_contextId)))
   {
     m_contextId = VA_INVALID_ID;
+    if (g_advancedSettings.CanLogComponent(LOGVIDEO))
+      CLog::Log(LOGDEBUG, "CVppPostproc::PreInit  - VPP init failed");
+
     return false;
   }
 
@@ -2522,6 +2531,9 @@ bool CVppPostproc::PreInit(CVaapiConfig &config, SDiMethods *methods)
 
   if (!CheckSuccess(vaQueryVideoProcFilters(m_config.dpy, m_contextId, filters, &numFilters)))
   {
+    if (g_advancedSettings.CanLogComponent(LOGVIDEO))
+      CLog::Log(LOGDEBUG, "CVppPostproc::PreInit  - VPP init failed");
+
     return false;
   }
 
@@ -2531,6 +2543,9 @@ bool CVppPostproc::PreInit(CVaapiConfig &config, SDiMethods *methods)
                                                deinterlacingCaps,
                                                &numDeinterlacingCaps)))
   {
+    if (g_advancedSettings.CanLogComponent(LOGVIDEO))
+      CLog::Log(LOGDEBUG, "CVppPostproc::PreInit  - VPP init failed");
+
     return false;
   }
 

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.cpp
@@ -243,7 +243,7 @@ bool CVAAPIContext::CheckSuccess(VAStatus status)
 {
   if (status != VA_STATUS_SUCCESS)
   {
-    CLog::Log(LOGERROR, "VAAPI error: %s", vaErrorStr(status));
+    CLog::Log(LOGERROR, "VAAPI::%s error: %s", __FUNCTION__, vaErrorStr(status));
     return false;
   }
   return true;
@@ -943,7 +943,7 @@ bool CDecoder::CheckSuccess(VAStatus status)
 {
   if (status != VA_STATUS_SUCCESS)
   {
-    CLog::Log(LOGERROR, "VAAPI - error: %s", vaErrorStr(status));
+    CLog::Log(LOGERROR, "VAAPI::%s - error: %s", __FUNCTION__, vaErrorStr(status));
     m_ErrorCount++;
 
     if(m_DisplayState == VAAPI_OPEN)
@@ -2309,7 +2309,7 @@ bool COutput::CheckSuccess(VAStatus status)
 {
   if (status != VA_STATUS_SUCCESS)
   {
-    CLog::Log(LOGERROR, "VAAPI - Error: %s(%d)", vaErrorStr(status), status);
+    CLog::Log(LOGERROR, "VAAPI::%s - Error: %s(%d)", __FUNCTION__, vaErrorStr(status), status);
     m_vaError = true;
     return false;
   }
@@ -2930,7 +2930,7 @@ bool CVppPostproc::CheckSuccess(VAStatus status)
 {
   if (status != VA_STATUS_SUCCESS)
   {
-    CLog::Log(LOGERROR, "VAAPI - Error: %s(%d)", vaErrorStr(status), status);
+    CLog::Log(LOGERROR, "VAAPI::%s - Error: %s(%d)", __FUNCTION__, vaErrorStr(status), status);
     return false;
   }
   return true;

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.cpp
@@ -150,8 +150,11 @@ bool CVAAPIContext::CreateContext()
     CLog::Log(LOGDEBUG, "VAAPI - driver in use: %s", vaQueryVendorString(m_display));
 
   QueryCaps();
-  if (!m_profileCount || !m_attributeCount)
+  if (!m_profileCount)
     return false;
+
+  if (!m_attributeCount)
+    CLog::Log(LOGWARNING, "VAAPI - driver did not return anything from vlVaQueryDisplayAttributes");
 
   return true;
 }


### PR DESCRIPTION
Mesa tracker does not implement VaQueryDisplayAttributes and returns zero attributes. As we only use m_attributes for enumeration purposes, we should not return false at this point.

@FernetMenta What do you think? It's a "Starthilfe" for mesa devs, wrapper devs and so on.

Besides that the status of mesa vaapi tracker is shown here: 
![bildschirmfoto-07 12 mkjmj](https://cloud.githubusercontent.com/assets/1089309/5332501/eb052ad2-7e58-11e4-9133-c457a9ed45c2.png)

Here is the mesa implementation: http://cgit.freedesktop.org/mesa/mesa/tree/src/gallium/state_trackers/va/display.c#n31
