### PR TITLE
update keyboard keymap. "P" to playpause for consistent behavior

### DIFF
--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -38,7 +38,7 @@
 <keymap>
   <global>
     <keyboard>
-      <p>Play</p>
+      <p>PlayPause</p>
       <q>Queue</q>
       <f>FastForward</f>
       <r>Rewind</r>


### PR DESCRIPTION
User pointed out that P got overlooked when updating things from "Play" to "PlayPause": http://forum.kodi.tv/showthread.php?tid=210811

In other words: 

v13's Play = v14's PlayPause
