### PR TITLE
[Builtins] Fix for ReloadSkin() while dialogs are opened.

### DIFF
--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -818,10 +818,12 @@ int CBuiltins::Execute(const std::string& execString)
   else if (execute == "reloadskin")
   {
     //  Reload the skin
+    g_windowManager.CloseDialogs(true);
     g_application.ReloadSkin(!params.empty() && StringUtils::EqualsNoCase(params[0], "confirm"));
   }
   else if (execute == "unloadskin")
   {
+    g_windowManager.CloseDialogs(true);
     g_application.UnloadSkin(true); // we're reloading the skin after this
   }
   else if (execute == "refreshrss")


### PR DESCRIPTION
If you reload the skin while the context menu is open for example, then that dialog won´t work anymore until you restart Kodi.
This almost exclusively happens for skinners while debugging, but could also be triggered in real-world cases. (some skins and add-ons use that builtin for different stuff)
This PR makes kodi force-close all dialogs before reloading / unloading the skin.
