### PR TITLE
Update of Power Management functions

### DIFF
--- a/xbmc/powermanagement/PowerManager.cpp
+++ b/xbmc/powermanagement/PowerManager.cpp
@@ -139,59 +139,87 @@ void CPowerManager::SetDefaults()
 
 bool CPowerManager::Powerdown()
 {
-  if (CanPowerdown() && m_instance->Powerdown())
+  if (CanPowerdown())
   {
-    CGUIDialogBusy* dialog = (CGUIDialogBusy*)g_windowManager.GetWindow(WINDOW_DIALOG_BUSY);
-    if (dialog)
-      dialog->Show();
+    if (m_instance->Powerdown())
+    {
+      CGUIDialogBusy* dialog = (CGUIDialogBusy*)g_windowManager.GetWindow(WINDOW_DIALOG_BUSY);
+      if (dialog)
+        dialog->Show();
 
-    return true;
+      return true;
+    }
+    else
+      CLog::LogF(LOGERROR, "System powerdown failed");
   }
+  else
+    CLog::LogF(LOGERROR, "System doesn't support powerdown");
 
   return false;
 }
 
 bool CPowerManager::Suspend()
 {
-  if (CanSuspend() && m_instance->Suspend())
+  if (CanSuspend())
   {
-    CGUIDialogBusy* dialog = (CGUIDialogBusy*)g_windowManager.GetWindow(WINDOW_DIALOG_BUSY);
-    if (dialog)
-      dialog->Show();
+    if (m_instance->Suspend())
+    {
+      CGUIDialogBusy* dialog = (CGUIDialogBusy*)g_windowManager.GetWindow(WINDOW_DIALOG_BUSY);
+      if (dialog)
+        dialog->Show();
 
-    return true;
+      return true;
+    }
+    else
+      CLog::LogF(LOGERROR, "System suspend failed");
   }
+  else
+    CLog::LogF(LOGERROR, "System doesn't support suspend");
 
   return false;
 }
 
 bool CPowerManager::Hibernate()
 {
-  if (CanHibernate() && m_instance->Hibernate())
+  if (CanHibernate())
   {
-    CGUIDialogBusy* dialog = (CGUIDialogBusy*)g_windowManager.GetWindow(WINDOW_DIALOG_BUSY);
-    if (dialog)
-      dialog->Show();
+    if (m_instance->Hibernate())
+    {
+      CGUIDialogBusy* dialog = (CGUIDialogBusy*)g_windowManager.GetWindow(WINDOW_DIALOG_BUSY);
+      if (dialog)
+        dialog->Show();
 
-    return true;
+      return true;
+    }
+    else
+      CLog::LogF(LOGERROR, "System hibernate failed");
   }
+  else
+    CLog::LogF(LOGERROR, "System doesn't support hibernate");
 
   return false;
 }
 bool CPowerManager::Reboot()
 {
-  bool success = CanReboot() ? m_instance->Reboot() : false;
-
-  if (success)
+  if (CanReboot())
   {
-    CAnnouncementManager::Get().Announce(System, "xbmc", "OnRestart");
+    if (m_instance->Reboot())
+    {
+      CAnnouncementManager::Get().Announce(System, "xbmc", "OnRestart");
 
-    CGUIDialogBusy* dialog = (CGUIDialogBusy*)g_windowManager.GetWindow(WINDOW_DIALOG_BUSY);
-    if (dialog)
-      dialog->Show();
+      CGUIDialogBusy* dialog = (CGUIDialogBusy*)g_windowManager.GetWindow(WINDOW_DIALOG_BUSY);
+      if (dialog)
+        dialog->Show();
+
+      return true;
+    }
+    else
+      CLog::LogF(LOGERROR, "System reboot failed");
   }
+  else
+    CLog::LogF(LOGERROR, "System doesn't support reboot");
 
-  return success;
+  return false;
 }
 
 bool CPowerManager::CanPowerdown()

--- a/xbmc/powermanagement/PowerManager.cpp
+++ b/xbmc/powermanagement/PowerManager.cpp
@@ -57,9 +57,8 @@ using namespace ANNOUNCEMENT;
 
 CPowerManager g_powerManager;
 
-CPowerManager::CPowerManager()
+CPowerManager::CPowerManager() : m_instance(NULL), m_appIsSleeping(false)
 {
-  m_instance = NULL;
 }
 
 CPowerManager::~CPowerManager()
@@ -227,6 +226,12 @@ void CPowerManager::ProcessEvents()
 
 void CPowerManager::OnSleep()
 {
+  if (m_appIsSleeping)
+  {
+    CLog::LogF(LOGDEBUG, "Application is in sleeping state, ignoring \"OnSleep()\"");
+    return;
+  }
+  m_appIsSleeping = true;
   CAnnouncementManager::Get().Announce(System, "xbmc", "OnSleep");
   CLog::Log(LOGNOTICE, "%s: Running sleep jobs", __FUNCTION__);
 
@@ -246,6 +251,12 @@ void CPowerManager::OnSleep()
 
 void CPowerManager::OnWake()
 {
+  if (!m_appIsSleeping)
+  {
+    CLog::LogF(LOGDEBUG, "Application isn't in sleeping state, ignoring \"OnWake()\"");
+    return;
+  }
+  m_appIsSleeping = false;
   CLog::Log(LOGNOTICE, "%s: Running resume jobs", __FUNCTION__);
 
   // reset out timers

--- a/xbmc/powermanagement/PowerManager.cpp
+++ b/xbmc/powermanagement/PowerManager.cpp
@@ -142,7 +142,7 @@ bool CPowerManager::Powerdown()
   if (CanPowerdown())
   {
     CLog::LogF(LOGINFO, "Requesting system powerdown");
-    if (m_instance->Powerdown())
+    if (m_instance && m_instance->Powerdown())
     {
       CGUIDialogBusy* dialog = (CGUIDialogBusy*)g_windowManager.GetWindow(WINDOW_DIALOG_BUSY);
       if (dialog)
@@ -164,7 +164,7 @@ bool CPowerManager::Suspend()
   if (CanSuspend())
   {
     CLog::LogF(LOGINFO, "Requesting system suspend");
-    if (m_instance->Suspend())
+    if (m_instance && m_instance->Suspend())
     {
       CGUIDialogBusy* dialog = (CGUIDialogBusy*)g_windowManager.GetWindow(WINDOW_DIALOG_BUSY);
       if (dialog)
@@ -186,7 +186,7 @@ bool CPowerManager::Hibernate()
   if (CanHibernate())
   {
     CLog::LogF(LOGINFO, "Requesting system hibernate");
-    if (m_instance->Hibernate())
+    if (m_instance && m_instance->Hibernate())
     {
       CGUIDialogBusy* dialog = (CGUIDialogBusy*)g_windowManager.GetWindow(WINDOW_DIALOG_BUSY);
       if (dialog)
@@ -207,7 +207,7 @@ bool CPowerManager::Reboot()
   if (CanReboot())
   {
     CLog::LogF(LOGINFO, "Requesting system reboot");
-    if (m_instance->Reboot())
+    if (m_instance && m_instance->Reboot())
     {
       CAnnouncementManager::Get().Announce(System, "xbmc", "OnRestart");
 
@@ -228,32 +228,35 @@ bool CPowerManager::Reboot()
 
 bool CPowerManager::CanPowerdown()
 {
-  return m_instance->CanPowerdown();
+  return m_instance && m_instance->CanPowerdown();
 }
 bool CPowerManager::CanSuspend()
 {
-  return m_instance->CanSuspend();
+  return m_instance && m_instance->CanSuspend();
 }
 bool CPowerManager::CanHibernate()
 {
-  return m_instance->CanHibernate();
+  return m_instance && m_instance->CanHibernate();
 }
 bool CPowerManager::CanReboot()
 {
-  return m_instance->CanReboot();
+  return m_instance && m_instance->CanReboot();
 }
 int CPowerManager::BatteryLevel()
 {
-  return m_instance->BatteryLevel();
+  return m_instance && m_instance->BatteryLevel();
 }
 void CPowerManager::ProcessEvents()
 {
   static int nesting = 0;
 
-  if (++nesting == 1)
-    m_instance->PumpPowerEvents(this);
+  if (m_instance)
+  {
+    if (++nesting == 1)
+      m_instance->PumpPowerEvents(this);
 
-  nesting--;
+    nesting--;
+  }
 }
 
 void CPowerManager::OnSleep()

--- a/xbmc/powermanagement/PowerManager.cpp
+++ b/xbmc/powermanagement/PowerManager.cpp
@@ -141,6 +141,7 @@ bool CPowerManager::Powerdown()
 {
   if (CanPowerdown())
   {
+    CLog::LogF(LOGINFO, "Requesting system powerdown");
     if (m_instance->Powerdown())
     {
       CGUIDialogBusy* dialog = (CGUIDialogBusy*)g_windowManager.GetWindow(WINDOW_DIALOG_BUSY);
@@ -162,6 +163,7 @@ bool CPowerManager::Suspend()
 {
   if (CanSuspend())
   {
+    CLog::LogF(LOGINFO, "Requesting system suspend");
     if (m_instance->Suspend())
     {
       CGUIDialogBusy* dialog = (CGUIDialogBusy*)g_windowManager.GetWindow(WINDOW_DIALOG_BUSY);
@@ -183,6 +185,7 @@ bool CPowerManager::Hibernate()
 {
   if (CanHibernate())
   {
+    CLog::LogF(LOGINFO, "Requesting system hibernate");
     if (m_instance->Hibernate())
     {
       CGUIDialogBusy* dialog = (CGUIDialogBusy*)g_windowManager.GetWindow(WINDOW_DIALOG_BUSY);
@@ -203,6 +206,7 @@ bool CPowerManager::Reboot()
 {
   if (CanReboot())
   {
+    CLog::LogF(LOGINFO, "Requesting system reboot");
     if (m_instance->Reboot())
     {
       CAnnouncementManager::Get().Announce(System, "xbmc", "OnRestart");

--- a/xbmc/powermanagement/PowerManager.h
+++ b/xbmc/powermanagement/PowerManager.h
@@ -94,6 +94,7 @@ private:
   void OnLowBattery();
 
   IPowerSyscall *m_instance;
+  bool m_appIsSleeping;
 };
 
 extern CPowerManager g_powerManager;

--- a/xbmc/powermanagement/windows/Win32PowerSyscall.cpp
+++ b/xbmc/powermanagement/windows/Win32PowerSyscall.cpp
@@ -47,9 +47,6 @@ bool CWin32PowerSyscall::Suspend()
     CLog::LogF(LOGERROR, "Can't suspend: suspend is not supported by system");
     return false;
   }
-  // On Vista+, we don't receive the PBT_APMSUSPEND message as we have fired the suspend mode
-  // Set the flag manually
-  CWin32PowerSyscall::SetOnSuspend();
 
   return CWIN32Util::PowerManagement(POWERSTATE_SUSPEND);
 }
@@ -61,9 +58,6 @@ bool CWin32PowerSyscall::Hibernate()
     CLog::LogF(LOGERROR, "Can't hibernate: hibernate is not supported by system");
     return false;
   }
-  // On Vista+, we don't receive the PBT_APMSUSPEND message as we have fired the suspend mode
-  // Set the flag manually
-  CWin32PowerSyscall::SetOnSuspend();
 
   return CWIN32Util::PowerManagement(POWERSTATE_HIBERNATE);
 }

--- a/xbmc/powermanagement/windows/Win32PowerSyscall.cpp
+++ b/xbmc/powermanagement/windows/Win32PowerSyscall.cpp
@@ -38,22 +38,35 @@ bool CWin32PowerSyscall::Powerdown()
 {
   return CWIN32Util::PowerManagement(POWERSTATE_SHUTDOWN);
 }
+
 bool CWin32PowerSyscall::Suspend()
 {
+  if (!CanSuspend())
+  {
+    CLog::LogF(LOGERROR, "Can't suspend: suspend is not supported by system");
+    return false;
+  }
   // On Vista+, we don't receive the PBT_APMSUSPEND message as we have fired the suspend mode
   // Set the flag manually
   CWin32PowerSyscall::SetOnSuspend();
 
   return CWIN32Util::PowerManagement(POWERSTATE_SUSPEND);
 }
+
 bool CWin32PowerSyscall::Hibernate()
 {
+  if (!CanHibernate())
+  {
+    CLog::LogF(LOGERROR, "Can't hibernate: hibernate is not supported by system");
+    return false;
+  }
   // On Vista+, we don't receive the PBT_APMSUSPEND message as we have fired the suspend mode
   // Set the flag manually
   CWin32PowerSyscall::SetOnSuspend();
 
   return CWIN32Util::PowerManagement(POWERSTATE_HIBERNATE);
 }
+
 bool CWin32PowerSyscall::Reboot()
 {
   return CWIN32Util::PowerManagement(POWERSTATE_REBOOT);

--- a/xbmc/powermanagement/windows/Win32PowerSyscall.cpp
+++ b/xbmc/powermanagement/windows/Win32PowerSyscall.cpp
@@ -18,18 +18,84 @@
  *
  */
 
+#ifdef TARGET_WINDOWS
 #include "Win32PowerSyscall.h"
 #include "powermanagement/PowerManager.h"
-#ifdef TARGET_WINDOWS
-#include "WIN32Util.h"
 #include "utils/log.h"
+#include "utils/SystemInfo.h"
+
 #include <powrprof.h>
 #pragma comment(lib, "PowrProf")
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN 1
+#endif // WIN32_LEAN_AND_MEAN 
+#include <Windows.h>
+
 
 bool CWin32PowerSyscall::m_OnResume = false;
 bool CWin32PowerSyscall::m_OnSuspend = false;
 bool CWin32PowerSyscall::m_sleeping = false;
 
+
+// local helpers
+static DWORD WINAPI threadForHibernateOs(_In_ LPVOID ignored)
+{
+  CLog::LogF(LOGNOTICE, "Requesting OS to hibernate");
+  if (SetSuspendState(true, true, false) != FALSE) // may be blocked until resume
+  {
+    CLog::LogF(LOGDEBUG, "OS was hibernated successfully");
+    return TRUE;
+  }
+  CLog::LogF(LOGERROR, "Can't hibernate system, error code: %lu", GetLastError());
+  return FALSE;
+}
+
+static DWORD WINAPI threadForSuspendOs(_In_ LPVOID ignored)
+{
+  CLog::LogF(LOGNOTICE, "Requesting OS to suspend");
+  if (SetSuspendState(false, true, false) != FALSE) // may be blocked until resume
+  {
+    CLog::LogF(LOGDEBUG, "OS was suspended successfully");
+    return TRUE;
+  }
+  CLog::LogF(LOGERROR, "Can't suspend system, error code: %lu", GetLastError());
+  return FALSE;
+}
+
+bool CWin32PowerSyscall::AdjustPrivileges()
+{
+  static bool gotShutdownPrivileges = false;
+  if (!gotShutdownPrivileges)
+  {
+    HANDLE hToken;
+    // Get a token for this process.
+    if (OpenProcessToken(GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY, &hToken))
+    {
+      // Get the LUID for the shutdown privilege.
+      TOKEN_PRIVILEGES tkp = {};
+      if (LookupPrivilegeValue(NULL, SE_SHUTDOWN_NAME, &tkp.Privileges[0].Luid))
+      {
+        tkp.PrivilegeCount = 1;  // one privilege to set
+        tkp.Privileges[0].Attributes = SE_PRIVILEGE_ENABLED;
+        // Get the shutdown privilege for this process.
+        if (AdjustTokenPrivileges(hToken, FALSE, &tkp, 0, (PTOKEN_PRIVILEGES)NULL, 0))
+          gotShutdownPrivileges = true;
+      }
+      CloseHandle(hToken);
+    }
+
+    if (!gotShutdownPrivileges)
+    {
+      CLog::LogF(LOGERROR, "Can't get shutdown privileges");
+      return false;
+    }
+    CLog::LogF(LOGDEBUG, "Got shutdown privileges");
+  }
+  else
+    CLog::LogF(LOGDEBUG, "Already have shutdown privileges");
+
+  return true;
+}
 
 CWin32PowerSyscall::CWin32PowerSyscall()
 {
@@ -37,7 +103,16 @@ CWin32PowerSyscall::CWin32PowerSyscall()
 
 bool CWin32PowerSyscall::Powerdown()
 {
-  return CWIN32Util::PowerManagement(POWERSTATE_SHUTDOWN);
+  if (!AdjustPrivileges())
+    return false;
+
+  CLog::LogF(LOGINFO, "Requesting OS shutdown");
+
+  if (g_sysinfo.IsWindowsVersionAtLeast(CSysInfo::WindowsVersionWin8))
+    return InitiateShutdownW(NULL, NULL, 0, SHUTDOWN_HYBRID | SHUTDOWN_INSTALL_UPDATES | SHUTDOWN_POWEROFF,
+                             SHTDN_REASON_MAJOR_APPLICATION | SHTDN_REASON_MINOR_OTHER | SHTDN_REASON_FLAG_PLANNED) == ERROR_SUCCESS;
+  return InitiateShutdownW(NULL, NULL, 0, SHUTDOWN_INSTALL_UPDATES | SHUTDOWN_POWEROFF,
+                           SHTDN_REASON_MAJOR_APPLICATION | SHTDN_REASON_MINOR_OTHER | SHTDN_REASON_FLAG_PLANNED) == ERROR_SUCCESS;
 }
 
 bool CWin32PowerSyscall::Suspend()
@@ -47,8 +122,20 @@ bool CWin32PowerSyscall::Suspend()
     CLog::LogF(LOGERROR, "Can't suspend: suspend is not supported by system");
     return false;
   }
+  if (!AdjustPrivileges())
+    return false;
 
-  return CWIN32Util::PowerManagement(POWERSTATE_SUSPEND);
+  CWin32PowerSyscall::SetOnSuspend();
+  // process OnSleep() events. This is called in main thread.
+  g_powerManager.ProcessEvents();
+  HANDLE threadHandle = CreateThread(NULL, 0, threadForSuspendOs, NULL, 0, NULL); // use separate thread, so main thread stay unblocked
+  if (threadHandle == NULL)
+  {
+    CLog::LogF(LOGERROR, "Can't create thread for switching power mode");
+    return false;
+  }
+  CloseHandle(threadHandle); // thread is one-shot, no need to track it
+  return true;
 }
 
 bool CWin32PowerSyscall::Hibernate()
@@ -58,13 +145,34 @@ bool CWin32PowerSyscall::Hibernate()
     CLog::LogF(LOGERROR, "Can't hibernate: hibernate is not supported by system");
     return false;
   }
+  if (!AdjustPrivileges())
+    return false;
 
-  return CWIN32Util::PowerManagement(POWERSTATE_HIBERNATE);
+  CWin32PowerSyscall::SetOnSuspend();
+  // process OnSleep() events. This is called in main thread.
+  g_powerManager.ProcessEvents();
+  HANDLE threadHandle = CreateThread(NULL, 0, threadForHibernateOs, NULL, 0, NULL); // use separate thread, so main thread stay unblocked
+  if (threadHandle == NULL)
+  {
+    CLog::LogF(LOGERROR, "Can't create thread for switching power mode");
+    return false;
+  }
+  CloseHandle(threadHandle); // thread is one-shot, no need to track it
+  return true;
 }
 
 bool CWin32PowerSyscall::Reboot()
 {
-  return CWIN32Util::PowerManagement(POWERSTATE_REBOOT);
+  if (!AdjustPrivileges())
+    return false;
+
+  CLog::LogF(LOGINFO, "Requesting OS reboot");
+
+  if (g_sysinfo.IsWindowsVersionAtLeast(CSysInfo::WindowsVersionWin8))
+    return InitiateShutdownW(NULL, NULL, 0, SHUTDOWN_INSTALL_UPDATES | SHUTDOWN_RESTART,
+                             SHTDN_REASON_MAJOR_APPLICATION | SHTDN_REASON_MINOR_OTHER | SHTDN_REASON_FLAG_PLANNED) == ERROR_SUCCESS;
+  return InitiateShutdownW(NULL, NULL, 0, SHUTDOWN_INSTALL_UPDATES | SHUTDOWN_RESTART,
+                           SHTDN_REASON_MAJOR_APPLICATION | SHTDN_REASON_MINOR_OTHER | SHTDN_REASON_FLAG_PLANNED) == ERROR_SUCCESS;
 }
 
 bool CWin32PowerSyscall::CanPowerdown()
@@ -138,7 +246,12 @@ bool CWin32PowerSyscall::CanReboot()
 
 int CWin32PowerSyscall::BatteryLevel()
 {
-  return CWIN32Util::BatteryLevel();
+  SYSTEM_POWER_STATUS SystemPowerStatus;
+
+  if (GetSystemPowerStatus(&SystemPowerStatus) && SystemPowerStatus.BatteryLifePercent != 255)
+    return SystemPowerStatus.BatteryLifePercent;
+
+  return -1;
 }
 
 bool CWin32PowerSyscall::PumpPowerEvents(IPowerEventsCallback *callback)

--- a/xbmc/powermanagement/windows/Win32PowerSyscall.h
+++ b/xbmc/powermanagement/windows/Win32PowerSyscall.h
@@ -51,6 +51,7 @@ private:
 
   static bool m_OnResume;
   static bool m_OnSuspend;
+  static bool m_sleeping;
 
 };
 #endif

--- a/xbmc/powermanagement/windows/Win32PowerSyscall.h
+++ b/xbmc/powermanagement/windows/Win32PowerSyscall.h
@@ -49,6 +49,8 @@ public:
 
 private:
 
+  static bool AdjustPrivileges();
+
   static bool m_OnResume;
   static bool m_OnSuspend;
   static bool m_sleeping;

--- a/xbmc/win32/WIN32Util.cpp
+++ b/xbmc/win32/WIN32Util.cpp
@@ -22,7 +22,6 @@
 #include "Util.h"
 #include "utils/URIUtils.h"
 #include "storage/cdioSupport.h"
-#include "PowrProf.h"
 #include "WindowHelper.h"
 #include "Application.h"
 #include <shlobj.h>
@@ -37,12 +36,10 @@
 #include "DllPaths_win32.h"
 #include "FileSystem/File.h"
 #include "utils/URIUtils.h"
-#include "powermanagement\PowerManager.h"
 #include "utils/SystemInfo.h"
 #include "utils/Environment.h"
 #include "utils/URIUtils.h"
 #include "utils/StringUtils.h"
-#include "powermanagement/windows/Win32PowerSyscall.h"
 
 #define DLL_ENV_PATH "special://xbmc/system/;" \
                      "special://xbmc/system/players/dvdplayer/;" \
@@ -189,123 +186,6 @@ char CWIN32Util::FirstDriveFromMask (ULONG unitmask)
         unitmask = unitmask >> 1;
     }
     return (i + 'A');
-}
-
-static DWORD WINAPI threadForSetPowerState(_In_ LPVOID powerState)
-{
-  switch (PowerState(intptr_t(powerState)))
-  {
-  case POWERSTATE_HIBERNATE:
-    CLog::LogF(LOGNOTICE, "Requesting OS to hibernate");
-    if (SetSuspendState(true, true, false) != FALSE) // may be blocked until resume
-    {
-      CLog::LogF(LOGDEBUG, "OS was hibernated successfully");
-      return TRUE;
-    }
-    else
-    {
-      CLog::LogF(LOGERROR, "Can't hibernate system, error code: %lu", GetLastError());
-      return FALSE;
-    }
-    break;
-  case POWERSTATE_SUSPEND:
-    CLog::LogF(LOGNOTICE, "Requesting OS to suspend");
-    if (SetSuspendState(false, true, false) != FALSE) // may be blocked until resume
-    {
-      CLog::LogF(LOGDEBUG, "OS was suspended successfully");
-      return TRUE;
-    }
-    else
-    {
-      CLog::LogF(LOGERROR, "Can't suspend system, error code: %lu", GetLastError());
-      return FALSE;
-    }
-    break;
-  }
-  CLog::LogF(LOGERROR, "Unknown powerstate requested");
-  return FALSE;
-}
-
-bool CWIN32Util::PowerManagement(PowerState State)
-{
-  static bool gotShutdownPrivileges = false;
-  if (!gotShutdownPrivileges)
-  {
-    HANDLE hToken;
-    // Get a token for this process.
-    if (OpenProcessToken(GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY, &hToken))
-    {
-      // Get the LUID for the shutdown privilege.
-      TOKEN_PRIVILEGES tkp = {};
-      if (LookupPrivilegeValue(NULL, SE_SHUTDOWN_NAME, &tkp.Privileges[0].Luid))
-      {
-        tkp.PrivilegeCount = 1;  // one privilege to set
-        tkp.Privileges[0].Attributes = SE_PRIVILEGE_ENABLED;
-        // Get the shutdown privilege for this process.
-        if (AdjustTokenPrivileges(hToken, FALSE, &tkp, 0, (PTOKEN_PRIVILEGES)NULL, 0))
-          gotShutdownPrivileges = true;
-      }
-      CloseHandle(hToken);
-    }
-
-    if (!gotShutdownPrivileges)
-    {
-      CLog::LogF(LOGERROR, "Can't get shutdown privileges");
-      return false;
-    }
-    CLog::LogF(LOGDEBUG, "Got shutdown privileges");
-  }
-  else
-    CLog::LogF(LOGDEBUG, "Already have shutdown privileges");
-
-  switch (State)
-  {
-  case POWERSTATE_HIBERNATE:
-  case POWERSTATE_SUSPEND:
-    {
-      CWin32PowerSyscall::SetOnSuspend();
-      // process OnSleep() events. This is called in main thread.
-      g_powerManager.ProcessEvents();
-      HANDLE threadHandle = CreateThread(NULL, 0, threadForSetPowerState, PVOID(intptr_t(State)), 0, NULL); // use separate thread, so main thread stay unblocked
-      if (threadHandle == NULL)
-      {
-        CLog::LogF(LOGERROR, "Can't create thread for switching power mode");
-        return false;
-      }
-      CloseHandle(threadHandle); // thread is one-shot, no need to track it
-    }
-    return true;
-  case POWERSTATE_SHUTDOWN:
-    CLog::Log(LOGINFO, "Shutdown Windows...");
-    if (g_sysinfo.IsWindowsVersionAtLeast(CSysInfo::WindowsVersionWin8))
-      return InitiateShutdownW(NULL, NULL, 0, SHUTDOWN_HYBRID | SHUTDOWN_INSTALL_UPDATES | SHUTDOWN_POWEROFF,
-                               SHTDN_REASON_MAJOR_APPLICATION | SHTDN_REASON_MINOR_OTHER | SHTDN_REASON_FLAG_PLANNED) == ERROR_SUCCESS;
-    return InitiateShutdownW(NULL, NULL, 0, SHUTDOWN_INSTALL_UPDATES | SHUTDOWN_POWEROFF,
-                             SHTDN_REASON_MAJOR_APPLICATION | SHTDN_REASON_MINOR_OTHER | SHTDN_REASON_FLAG_PLANNED) == ERROR_SUCCESS;
-    break;
-  case POWERSTATE_REBOOT:
-    CLog::Log(LOGINFO, "Rebooting Windows...");
-    if (g_sysinfo.IsWindowsVersionAtLeast(CSysInfo::WindowsVersionWin8))
-      return InitiateShutdownW(NULL, NULL, 0, SHUTDOWN_INSTALL_UPDATES | SHUTDOWN_RESTART,
-                               SHTDN_REASON_MAJOR_APPLICATION | SHTDN_REASON_MINOR_OTHER | SHTDN_REASON_FLAG_PLANNED) == ERROR_SUCCESS;
-    return InitiateShutdownW(NULL, NULL, 0, SHUTDOWN_INSTALL_UPDATES | SHUTDOWN_RESTART,
-                             SHTDN_REASON_MAJOR_APPLICATION | SHTDN_REASON_MINOR_OTHER | SHTDN_REASON_FLAG_PLANNED) == ERROR_SUCCESS;
-    break;
-  default:
-    CLog::Log(LOGERROR, "Unknown PowerState called.");
-    return false;
-    break;
-  }
-}
-
-int CWIN32Util::BatteryLevel()
-{
-  SYSTEM_POWER_STATUS SystemPowerStatus;
-
-  if (GetSystemPowerStatus(&SystemPowerStatus) && SystemPowerStatus.BatteryLifePercent != 255)
-      return SystemPowerStatus.BatteryLifePercent;
-
-  return 0;
 }
 
 bool CWIN32Util::XBMCShellExecute(const std::string &strPath, bool bWaitForScriptExit)

--- a/xbmc/win32/WIN32Util.cpp
+++ b/xbmc/win32/WIN32Util.cpp
@@ -42,6 +42,7 @@
 #include "utils/Environment.h"
 #include "utils/URIUtils.h"
 #include "utils/StringUtils.h"
+#include "powermanagement/windows/Win32PowerSyscall.h"
 
 #define DLL_ENV_PATH "special://xbmc/system/;" \
                      "special://xbmc/system/players/dvdplayer/;" \
@@ -257,14 +258,14 @@ bool CWIN32Util::PowerManagement(PowerState State)
   else
     CLog::LogF(LOGDEBUG, "Already have shutdown privileges");
 
-  // process OnSleep() events. This is called in main thread.
-  g_powerManager.ProcessEvents();
-
   switch (State)
   {
   case POWERSTATE_HIBERNATE:
   case POWERSTATE_SUSPEND:
     {
+      CWin32PowerSyscall::SetOnSuspend();
+      // process OnSleep() events. This is called in main thread.
+      g_powerManager.ProcessEvents();
       HANDLE threadHandle = CreateThread(NULL, 0, threadForSetPowerState, PVOID(intptr_t(State)), 0, NULL); // use separate thread, so main thread stay unblocked
       if (threadHandle == NULL)
       {

--- a/xbmc/win32/WIN32Util.cpp
+++ b/xbmc/win32/WIN32Util.cpp
@@ -213,8 +213,14 @@ bool CWIN32Util::PowerManagement(PowerState State)
     }
 
     if (!gotShutdownPrivileges)
+    {
+      CLog::LogF(LOGERROR, "Can't get shutdown privileges");
       return false;
+    }
+    CLog::LogF(LOGDEBUG, "Got shutdown privileges");
   }
+  else
+    CLog::LogF(LOGDEBUG, "Already have shutdown privileges");
 
   // process OnSleep() events. This is called in main thread.
   g_powerManager.ProcessEvents();

--- a/xbmc/win32/WIN32Util.h
+++ b/xbmc/win32/WIN32Util.h
@@ -24,7 +24,6 @@
 #include "Cfgmgr32.h"
 #include "MediaSource.h"
 #include "guilib/Geometry.h"
-#include "powermanagement/PowerManager.h"
 #include "utils/Stopwatch.h"
 
 enum Drive_Types
@@ -48,8 +47,6 @@ public:
 
   static char FirstDriveFromMask (ULONG unitmask);
   static int GetDriveStatus(const std::string &strPath, bool bStatusEx=false);
-  static bool PowerManagement(PowerState State);
-  static int BatteryLevel();
   static bool XBMCShellExecute(const std::string &strPath, bool bWaitForScriptExit=false);
   static std::vector<std::string> GetDiskUsage();
   static std::string GetResInfoString();


### PR DESCRIPTION
For all platforms: 
- put more information to the log in PowerManager (currently it log minimal information, sometimes it's hard to track processes before Suspend/Shutdown), 
- prevent possible crashes if PowerManager functions called Initialize()

For win32:
- prevent lock of main thread on Suspend/Hibernate
- add more error and debug logging
- move all power management functions from Win32Utils to Win32PowerSyscall
