### PR TITLE
BaseRender: Allow 1px wrong in aspect ratio to not do completeley refit the image

### DIFF
--- a/xbmc/cores/VideoRenderers/BaseRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/BaseRenderer.cpp
@@ -443,6 +443,12 @@ void CBaseRenderer::CalcNormalDisplayRect(float offsetX, float offsetY, float sc
   newWidth *= zoomAmount;
   newHeight *= zoomAmount;
 
+  // if we are less than one pixel off use the complete screen instead
+  if (std::abs(newWidth - screenWidth) < 1.0f)
+    newWidth = screenWidth;
+  if (std::abs(newHeight - screenHeight) < 1.0f)
+    newHeight = screenHeight;
+
   // Centre the movie
   float posY = (screenHeight - newHeight) / 2;
   float posX = (screenWidth - newWidth) / 2;


### PR DESCRIPTION
This fixes off by 1 errors when running on systems with broken pixel Ratio.

Basically with a pixel Ratio of: 1.000512 as seen here: http://forum.kodi.tv/showthread.php?tid=210815 You end up with 1919 pixels instead of 1920 pixels. This patch prefers to better have 1 px wrong in ratio than using a scaler to resort all the pixels.
