### PR TITLE
[linux] fix building libkodi.so (closes #14914)

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -496,13 +496,11 @@ LIBS+= @GNUTLS_ALL_LIBS@ @VORBISENC_ALL_LIBS@
 $(FFMPEGOBJS): dvdpcodecs
 endif
 
-ifneq (@USE_LIBXBMC@,1)
-MAINOBJS+=xbmc/main/main.a
-else
 ifeq (@USE_ANDROID@,1)
 MAINOBJS+=xbmc/android/activity/activity.a
+else
+MAINOBJS+=xbmc/main/main.a
 endif # USE_ANDROID
-endif # USE_LIBXBMC
 
 
 OBJSXBMC =$(DIRECTORY_ARCHIVES)
@@ -523,7 +521,7 @@ lib@APP_NAME_LC@.so: $(OBJSXBMC) $(DYNOBJSXBMC) $(NWAOBJSXBMC) $(MAINOBJS)
 ifeq ($(findstring osx,@ARCH@), osx)
 	$(SILENT_LD) $(CXX) $(LDFLAGS) -bundle -o $@ $(MAINOBJS) -Wl,-all_load,-ObjC $(MAINOBJS) $(DYNOBJSXBMC) $(NWAOBJSXBMC) $(OBJSXBMC) $(LIBS) -read_only_relocs suppress
 else
-	$(SILENT_LD) $(CXX) $(CXXFLAGS) $(LDFLAGS) -shared -o $@ -Wl,--whole-archive $(MAINOBJS) -Wl,--no-whole-archive,--start-group $(MAINOBJS) $(DYNOBJSXBMC) $(OBJSXBMC) -Wl,--end-group -Wl,--no-undefined $(NWAOBJSXBMC) $(LIBS)
+	$(SILENT_LD) $(CXX) $(CXXFLAGS) $(LDFLAGS) -shared -o $@ -Wl,--whole-archive $(MAINOBJS) -Wl,--no-whole-archive,--start-group $(MAINOBJS) $(DYNOBJSXBMC) $(OBJSXBMC) -Wl,--end-group -Wl,--no-undefined $(NWAOBJSXBMC) $(LIBS) -Wl,-Bsymbolic
 endif
 
 @APP_NAME_LC@.bin: $(OBJSXBMC) $(DYNOBJSXBMC) $(NWAOBJSXBMC) $(MAINOBJS)


### PR DESCRIPTION
this issue goes back to pre-gotham.
Building libkodi on at least linux is broken. It builds without errors, but the resulting lib is essentially emtpy.

This PR takes a non-intrusive way to remedy it, by using the Bsymbolic compiler switch that is even default in many linux distros. Its probably possible to fix it without that, but that would require significant changes without any gain.

@topfs2 this should have been in gotham already ;)
