### PR TITLE
Fix FFmpeg component-specific logging to hide other log levels

### DIFF
--- a/xbmc/cores/FFmpeg.cpp
+++ b/xbmc/cores/FFmpeg.cpp
@@ -87,7 +87,9 @@ void ff_avutil_log(void* ptr, int level, const char* format, va_list va)
 
   AVClass* avc= ptr ? *(AVClass**)ptr : NULL;
 
-  if(level >= AV_LOG_DEBUG &&
+  if((level == AV_LOG_DEBUG ||
+      level == AV_LOG_WARNING ||
+      level == AV_LOG_VERBOSE) &&
      !g_advancedSettings.CanLogComponent(LOGFFMPEG))
     return;
   else if(g_advancedSettings.m_logLevel <= LOG_LEVEL_NORMAL)
@@ -99,6 +101,8 @@ void ff_avutil_log(void* ptr, int level, const char* format, va_list va)
     case AV_LOG_INFO   : type = LOGINFO;    break;
     case AV_LOG_ERROR  : type = LOGERROR;   break;
     case AV_LOG_DEBUG  :
+    case AV_LOG_WARNING:
+    case AV_LOG_VERBOSE:
     default            : type = LOGDEBUG;   break;
   }
 


### PR DESCRIPTION
Currently only log messages at AV_LOG_DEBUG level are hidden by disabling component-specific logging for FFmpeg.

This change makes it so that unless FFmpeg component-specific logging is turned on, log messages at AV_LOG_WARNING and AV_LOG_VERBOSE levels will also be hidden.

Fixes [#15537](http://trac.kodi.tv/ticket/15537).
