### PR TITLE
[android] Conditionally use IMMERSIVE sticky flag

### DIFF
--- a/tools/android/packaging/xbmc/src/org/xbmc/kodi/Main.java.in
+++ b/tools/android/packaging/xbmc/src/org/xbmc/kodi/Main.java.in
@@ -1,7 +1,10 @@
 package org.xbmc.@APP_NAME_LC@;
 
 import android.app.NativeActivity;
+import android.app.UiModeManager;
+import android.content.Context;
 import android.content.Intent;
+import android.content.res.Configuration;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
@@ -45,6 +48,9 @@ public class Main extends NativeActivity
   {
     super.onResume();
 
+    UiModeManager uiModeManager = (UiModeManager) getSystemService(Context.UI_MODE_SERVICE);
+    boolean isTelevision = uiModeManager.getCurrentModeType() == Configuration.UI_MODE_TYPE_TELEVISION;
+
     if (android.os.Build.VERSION.SDK_INT >= 19) {
       // Immersive mode
 
@@ -55,14 +61,18 @@ public class Main extends NativeActivity
       final int API_SYSTEM_UI_FLAG_FULLSCREEN = 0x00000004;
       final int API_SYSTEM_UI_FLAG_IMMERSIVE_STICKY = 0x00001000;
 
-      View thisView = getWindow().getDecorView();
-      thisView.setSystemUiVisibility(
-                API_SYSTEM_UI_FLAG_LAYOUT_STABLE
+      int flags = API_SYSTEM_UI_FLAG_LAYOUT_STABLE
               | API_SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
               | API_SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
               | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
-              | API_SYSTEM_UI_FLAG_FULLSCREEN
-              | API_SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
+              | API_SYSTEM_UI_FLAG_FULLSCREEN;
+
+      if (!isTelevision) {
+          flags += API_SYSTEM_UI_FLAG_IMMERSIVE_STICKY;
+      }
+
+      View thisView = getWindow().getDecorView();
+      thisView.setSystemUiVisibility(flags);
     }
   }
 


### PR DESCRIPTION
- If using kodi on a TV with an IR remote, the immersive mode confirmation is not easily dismissable

Signed-off-by: Brandon McAnsh brandonm@matricom.net
