### PR TITLE
[keymap] Make XB360 DPads consistent

### DIFF
--- a/system/keymaps/joystick.Microsoft.Xbox.360.Controller.xml
+++ b/system/keymaps/joystick.Microsoft.Xbox.360.Controller.xml
@@ -329,8 +329,8 @@
       <!-- D-pad does what you'd expect. Triggers fast forward and rewind. Left stick scans forward and back. -->
       <axis id="3" limit="+1">AnalogRewind</axis>
       <axis id="3" limit="-1">AnalogFastForward</axis>
-      <hat id="1" position="up">BigStepForward</hat>
-      <hat id="1" position="down">BigStepBack</hat>
+      <hat id="1" position="up">ChapterOrBigStepForward</hat>
+      <hat id="1" position="down">ChapterOrBigStepBack</hat>
       <hat id="1" position="left">StepBack</hat>
       <hat id="1" position="right">StepForward</hat>
     </joystick>
@@ -361,8 +361,8 @@
       <button id="15">ChapterOrBigStepBack</button>
       <axis id="3">AnalogRewind</axis>
       <axis id="6">AnalogFastForward</axis>
-      <hat id="1" position="up">BigStepForward</hat>
-      <hat id="1" position="down">BigStepBack</hat>
+      <hat id="1" position="up">ChapterOrBigStepForward</hat>
+      <hat id="1" position="down">ChapterOrBigStepBack</hat>
       <hat id="1" position="left">StepBack</hat>
       <hat id="1" position="right">StepForward</hat>
     </joystick>


### PR DESCRIPTION
According to the top of the file different drivers send different codes for DPad buttons.
Button-IDs were already changed, but the `<hat>` sections were not.
This change makes it consistent across drivers (and consistent with the Keyboards Cursor-Buttons).

Non-360 Gamepads seem to be adjusted already
