### PR TITLE
[osx] - replace alias shortcut resolving with non-deprecated API

### DIFF
--- a/xbmc/osx/DarwinUtils.h
+++ b/xbmc/osx/DarwinUtils.h
@@ -51,6 +51,8 @@ public:
   static bool        CFStringRefToString(CFStringRef source, std::string& destination);
   static bool        CFStringRefToUTF8String(CFStringRef source, std::string& destination);
   static const std::string&  GetManufacturer(void);
+  static bool        IsAliasShortcut(const std::string& path);
+  static void        TranslateAliasShortcut(std::string& path);
 };
 
 #endif

--- a/xbmc/osx/DarwinUtils.h
+++ b/xbmc/osx/DarwinUtils.h
@@ -53,6 +53,7 @@ public:
   static const std::string&  GetManufacturer(void);
   static bool        IsAliasShortcut(const std::string& path);
   static void        TranslateAliasShortcut(std::string& path);
+  static bool        CreateAliasShortcut(const std::string& fromPath, const std::string& toPath);
 };
 
 #endif

--- a/xbmc/osx/DarwinUtils.mm
+++ b/xbmc/osx/DarwinUtils.mm
@@ -699,4 +699,26 @@ void CDarwinUtils::TranslateAliasShortcut(std::string& path)
 #endif
 }
 
+bool CDarwinUtils::CreateAliasShortcut(const std::string& fromPath, const std::string& toPath)
+{
+  bool ret = false;
+#if defined(TARGET_DARWIN_OSX)
+  NSString *nsToPath = [NSString stringWithUTF8String:toPath.c_str()];
+  NSURL *toUrl = [NSURL fileURLWithPath:nsToPath];
+  NSString *nsFromPath = [NSString stringWithUTF8String:fromPath.c_str()];
+  NSURL *fromUrl = [NSURL fileURLWithPath:nsFromPath];
+  NSError *error = nil;
+  NSData *bookmarkData = [toUrl bookmarkDataWithOptions: NSURLBookmarkCreationSuitableForBookmarkFile includingResourceValuesForKeys:nil relativeToURL:nil error:&error];
+
+  if(bookmarkData != nil && fromUrl != nil && toUrl != nil) 
+  {
+    if([NSURL writeBookmarkData:bookmarkData toURL:fromUrl options:NSURLBookmarkCreationSuitableForBookmarkFile error:&error])
+    {
+      ret = true;
+    }
+  }
+#endif
+  return ret;
+}
+
 #endif

--- a/xbmc/utils/test/TestAliasShortcutUtils.cpp
+++ b/xbmc/utils/test/TestAliasShortcutUtils.cpp
@@ -19,26 +19,85 @@
  */
 
 #include "utils/AliasShortcutUtils.h"
+#include "filesystem/File.h"
+#include "test/TestUtils.h"
 
+#if defined(TARGET_DARWIN_OSX)
+#include "osx/DarwinUtils.h"
+#endif
 #include "gtest/gtest.h"
 
 TEST(TestAliasShortcutUtils, IsAliasShortcut)
 {
-  std::string a;
+  XFILE::CFile *tmpFile = XBMC_CREATETEMPFILE("noaliastest");
+  std::string noalias = XBMC_TEMPFILEPATH(tmpFile);
+
 #if defined(TARGET_DARWIN_OSX)
-  /* TODO: Write test case for OSX */
-#else
-  EXPECT_FALSE(IsAliasShortcut(a));
+  XFILE::CFile *aliasDestFile = XBMC_CREATETEMPFILE("aliastest");
+  std::string alias = XBMC_TEMPFILEPATH(aliasDestFile);
+
+  //we only need the path here so delete the alias file
+  //which will be recreated as shortcut later:
+  XBMC_DELETETEMPFILE(aliasDestFile);
+
+  // create alias from a pointing to /Volumes
+  CDarwinUtils::CreateAliasShortcut(alias, "/Volumes");
+  EXPECT_TRUE(IsAliasShortcut(alias));
+  XFILE::CFile::Delete(alias);
+
+  // volumes is not a shortcut but a dir
+  EXPECT_FALSE(IsAliasShortcut("/Volumes"));
 #endif
+
+  // a regular file is not a shortcut
+  EXPECT_FALSE(IsAliasShortcut(noalias));
+  XBMC_DELETETEMPFILE(tmpFile);
+
+  // empty string is not an alias
+  std::string emptyString;
+  EXPECT_FALSE(IsAliasShortcut(emptyString));
+
+  // non-existent file is no alias
+  std::string nonExistingFile="/IDontExistsNormally/somefile.txt";
+  EXPECT_FALSE(IsAliasShortcut(nonExistingFile));
 }
 
 TEST(TestAliasShortcutUtils, TranslateAliasShortcut)
 {
-  std::string a;
-  TranslateAliasShortcut(a);
+  XFILE::CFile *tmpFile = XBMC_CREATETEMPFILE("noaliastest");
+  std::string noalias = XBMC_TEMPFILEPATH(tmpFile);
+  std::string noaliastemp = noalias;
+
 #if defined(TARGET_DARWIN_OSX)
-  /* TODO: Write test case for OSX */
-#else
-  EXPECT_STREQ("", a.c_str());
+  XFILE::CFile *aliasDestFile = XBMC_CREATETEMPFILE("aliastest");
+  std::string alias = XBMC_TEMPFILEPATH(aliasDestFile);
+
+  //we only need the path here so delete the alias file
+  //which will be recreated as shortcut later:
+  XBMC_DELETETEMPFILE(aliasDestFile);
+
+  // create alias from a pointing to /Volumes
+  CDarwinUtils::CreateAliasShortcut(alias, "/Volumes");
+
+  // resolve the shortcut
+  TranslateAliasShortcut(alias);
+  EXPECT_STREQ("/Volumes", alias.c_str());
+  XFILE::CFile::Delete(alias);
 #endif
+
+  // translating a non-shortcut url should result in no change...
+  TranslateAliasShortcut(noaliastemp);
+  EXPECT_STREQ(noaliastemp.c_str(), noalias.c_str());
+  XBMC_DELETETEMPFILE(tmpFile);
+
+  //translate empty should stay empty
+  std::string emptyString;
+  TranslateAliasShortcut(emptyString);
+  EXPECT_STREQ("", emptyString.c_str());
+
+  // translate non-existent file should result in no change...
+  std::string nonExistingFile="/IDontExistsNormally/somefile.txt";
+  std::string resolvedNonExistingFile=nonExistingFile;
+  TranslateAliasShortcut(resolvedNonExistingFile);
+  EXPECT_STREQ(resolvedNonExistingFile.c_str(), nonExistingFile.c_str());
 }


### PR DESCRIPTION
We were using an outdated API for resolving osx alias / shortcuts. This PR uses the currently suggested API.

This fixes a regression we hit on OSX 10.10 yosemite. The API used in this PR is save down to 10.6 which is our lowest supported OSX Version.

It was confirmed working by @Karlson2k and the user who reported the issue. I will do another sanity check on osx 10.9.

I consider this save for helix because its a path which isn't hit very often and the API is pretty clear.

I also finally implemented the unit tests for this (which were there but only with a comment "TODO implement unit test") :D - the test run already on jenkins which means the shortcut resolving worked on osx 10.8 (this is what the jenkins slave runs).

Up to the RMs @MartijnKaijser && @topfs2 
