### PR TITLE
[infoscanner] remove whitespaces from sample scan exclude regexs (fixes #15605)

### DIFF
--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -211,9 +211,9 @@ void CAdvancedSettings::Initialize()
 
   m_moviesExcludeFromScanRegExps.clear();
   m_moviesExcludeFromScanRegExps.push_back("-trailer");
-  m_moviesExcludeFromScanRegExps.push_back("[!-._ \\\\/]sample[-._ \\\\/]");
+  m_moviesExcludeFromScanRegExps.push_back("[!-._\\/]sample[-._\\/]");
   m_moviesExcludeFromScanRegExps.push_back("[\\/](proof|subs)[\\/]");
-  m_tvshowExcludeFromScanRegExps.push_back("[!-._ \\\\/]sample[-._ \\\\/]");
+  m_tvshowExcludeFromScanRegExps.push_back("[!-._\\/]sample[-._\\/]");
 
   m_folderStackRegExps.clear();
   m_folderStackRegExps.push_back("((cd|dvd|dis[ck])[0-9]+)$");


### PR DESCRIPTION
This commit removes leading and trailing whitespaces from the movies and tvshows
exclude from scan regular expressions. Impact - if any - should be pretty low as
samples usually reside in a dedicated samples folder or are following naming
conventions where the word sample is either pre- or postfixed to the actual media.

Not sure how non-scene handles though. Might raise yet other regressions in case
someone thinks separating with space is a good idea. Even though i put up this PR,
i'd vote for not including it ;)

@topfs2, @MartijnKaijser for decision whether to include or not.
