### PR TITLE
media library: fix path history for items with a real path differing from the requested path

### DIFF
--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -1472,7 +1472,13 @@ void CGUIMediaWindow::OnInitWindow()
   bool updateStartDirectory = (m_startDirectory == m_vecItems->GetPath());
   Refresh();
   if (updateStartDirectory)
+  {
+    // reset the start directory to the path of the items
     m_startDirectory = m_vecItems->GetPath();
+
+    // reset the history based on the path of the items
+    SetHistoryForPath(m_startDirectory);
+  }
 
   m_rootDir.SetAllowThreads(true);
 


### PR DESCRIPTION
This fixes a problem in media library navigation brought to my attention by @mkortstiege as described in http://forum.kodi.tv/showthread.php?tid=211165. Basically the problem is that when using a `library://` based URL to access media library items from the home screen the `return` statement in the `ActivateWindow()` builtin doesn't have the expected effect.

The reason for this is that `CGUIMediaWindow` is opened with a `library://` based URL but that URL is changed to a `videodb://` based URL during `GetDirectory` which is required for proper filtering etc. Due to the change of the URL during `GetDirectory` the navigation history in `CGUIMediaWindow` is wrong and still contains `library://` based URLs instead of `videodb://` based URL.

There is already some handling for this case for `CGUIMediaWindow::m_startDirectory` but it doesn't cover the navigation history yet which is added by this commit.

This approach is not a 100% clean solution but I'm not very familiar with the navigation history stuff (@jmarshallnz is probably the only one that was) and this is the best I could come up with. The problem I have with changing things in `CGUIMediaWindow` is that it's impossible to test all use cases to be sure that there are no regressions.
