### PR TITLE
[pvr] Fix epg strIconPath transfer and store in EPG database

### DIFF
--- a/xbmc/epg/EpgDatabase.cpp
+++ b/xbmc/epg/EpgDatabase.cpp
@@ -60,6 +60,7 @@ void CEpgDatabase::CreateTables(void)
         "sTitle          varchar(128), "
         "sPlotOutline    text, "
         "sPlot           text, "
+        "sIconPath       varchar(255), "
         "iStartTime      integer, "
         "iEndTime        integer, "
         "iGenreType      integer, "
@@ -98,6 +99,9 @@ void CEpgDatabase::UpdateTables(int iVersion)
 
   if (iVersion < 8)
     m_pDS->exec("ALTER TABLE epgtags ADD sRecordingId varchar(128);");
+
+  if (iVersion < 9)
+    m_pDS->exec("ALTER TABLE epgtags ADD sIconPath varchar(255);");
 }
 
 bool CEpgDatabase::DeleteEpg(void)
@@ -227,6 +231,7 @@ int CEpgDatabase::Get(CEpg &epg)
         newTag.m_strEpisodeName     = m_pDS->fv("sEpisodeName").get_asString().c_str();
         newTag.m_iSeriesNumber      = m_pDS->fv("iSeriesId").get_asInt();
         newTag.m_strRecordingId     = m_pDS->fv("sRecordingId").get_asString().c_str();
+        newTag.m_strIconPath        = m_pDS->fv("sIconPath").get_asString().c_str();
 
         epg.AddEntry(newTag);
         ++iReturn;
@@ -332,12 +337,12 @@ int CEpgDatabase::Persist(const CEpgInfoTag &tag, bool bSingleUpdate /* = true *
   if (iBroadcastId < 0)
   {
     strQuery = PrepareSQL("REPLACE INTO epgtags (idEpg, iStartTime, "
-        "iEndTime, sTitle, sPlotOutline, sPlot, iGenreType, iGenreSubType, sGenre, "
+        "iEndTime, sTitle, sPlotOutline, sPlot, sIconPath, iGenreType, iGenreSubType, sGenre, "
         "iFirstAired, iParentalRating, iStarRating, bNotify, iSeriesId, "
         "iEpisodeId, iEpisodePart, sEpisodeName, iBroadcastUid, sRecordingId) "
-        "VALUES (%u, %u, %u, '%s', '%s', '%s', %i, %i, '%s', %u, %i, %i, %i, %i, %i, %i, '%s', %i, '%s');",
+        "VALUES (%u, %u, %u, '%s', '%s', '%s', '%s', %i, %i, '%s', %u, %i, %i, %i, %i, %i, %i, '%s', %i, '%s');",
         tag.EpgID(), iStartTime, iEndTime,
-        tag.Title(true).c_str(), tag.PlotOutline(true).c_str(), tag.Plot(true).c_str(), tag.GenreType(), tag.GenreSubType(), strGenre.c_str(),
+        tag.Title(true).c_str(), tag.PlotOutline(true).c_str(), tag.Plot(true).c_str(), tag.Icon().c_str(), tag.GenreType(), tag.GenreSubType(), strGenre.c_str(),
         iFirstAired, tag.ParentalRating(), tag.StarRating(), tag.Notify(),
         tag.SeriesNum(), tag.EpisodeNum(), tag.EpisodePart(), tag.EpisodeName().c_str(),
         tag.UniqueBroadcastID(), tag.RecordingId().c_str());
@@ -345,12 +350,12 @@ int CEpgDatabase::Persist(const CEpgInfoTag &tag, bool bSingleUpdate /* = true *
   else
   {
     strQuery = PrepareSQL("REPLACE INTO epgtags (idEpg, iStartTime, "
-        "iEndTime, sTitle, sPlotOutline, sPlot, iGenreType, iGenreSubType, sGenre, "
+        "iEndTime, sTitle, sPlotOutline, sPlot, sIconPath, iGenreType, iGenreSubType, sGenre, "
         "iFirstAired, iParentalRating, iStarRating, bNotify, iSeriesId, "
         "iEpisodeId, iEpisodePart, sEpisodeName, iBroadcastUid, idBroadcast, sRecordingId) "
-        "VALUES (%u, %u, %u, '%s', '%s', '%s', %i, %i, '%s', %u, %i, %i, %i, %i, %i, %i, '%s', %i, %i, '%s');",
+        "VALUES (%u, %u, %u, '%s', '%s', '%s', '%s', %i, %i, '%s', %u, %i, %i, %i, %i, %i, %i, '%s', %i, %i, '%s');",
         tag.EpgID(), iStartTime, iEndTime,
-        tag.Title(true).c_str(), tag.PlotOutline(true).c_str(), tag.Plot(true).c_str(), tag.GenreType(), tag.GenreSubType(), strGenre.c_str(),
+        tag.Title(true).c_str(), tag.PlotOutline(true).c_str(), tag.Plot(true).c_str(), tag.Icon().c_str(), tag.GenreType(), tag.GenreSubType(), strGenre.c_str(),
         iFirstAired, tag.ParentalRating(), tag.StarRating(), tag.Notify(),
         tag.SeriesNum(), tag.EpisodeNum(), tag.EpisodePart(), tag.EpisodeName().c_str(),
         tag.UniqueBroadcastID(), iBroadcastId, tag.RecordingId().c_str());

--- a/xbmc/epg/EpgDatabase.h
+++ b/xbmc/epg/EpgDatabase.h
@@ -54,7 +54,7 @@ namespace EPG
      * @brief Get the minimal database version that is required to operate correctly.
      * @return The minimal database version.
      */
-    virtual int GetSchemaVersion(void) const { return 8; };
+    virtual int GetSchemaVersion(void) const { return 9; };
 
     /*!
      * @brief Get the default sqlite database filename.

--- a/xbmc/epg/EpgInfoTag.cpp
+++ b/xbmc/epg/EpgInfoTag.cpp
@@ -950,7 +950,8 @@ bool CEpgInfoTag::Update(const CEpgInfoTag &tag, bool bUpdateBroadcastId /* = tr
         EpgID()              != tag.EpgID() ||
         m_pvrChannel         != tag.m_pvrChannel ||
         m_genre              != tag.m_genre ||
-        m_strRecordingId     != tag.m_strRecordingId
+        m_strRecordingId     != tag.m_strRecordingId ||
+        m_strIconPath        != tag.m_strIconPath
     );
     if (bUpdateBroadcastId)
       bChanged = bChanged || m_iBroadcastId != tag.m_iBroadcastId;
@@ -989,6 +990,7 @@ bool CEpgInfoTag::Update(const CEpgInfoTag &tag, bool bUpdateBroadcastId /* = tr
       m_strEpisodeName     = tag.m_strEpisodeName;
       m_iUniqueBroadcastID = tag.m_iUniqueBroadcastID;
       m_strRecordingId     = tag.m_strRecordingId;
+      m_strIconPath        = tag.m_strIconPath;
 
       m_bChanged = true;
     }


### PR DESCRIPTION
Existing field "strIconPath" on EPG_INFO tag is not transferred from PVR Addon manager to Kodi (field missing from Update() function) nor is it stored in the EPG database.  This leads to the episode images provided by some PVR backend not being available to be shown in Kodi.

Forum topic here: http://forum.kodi.tv/showthread.php?tid=186486

This PR fixes both issues.  Note that the EPG database version has been incremented to 9.

This is the first Kodi side PVR change ive done so please advise if I have missed anything.
