### PR TITLE
[vfs] CFile::Open: don't use buffered io for VFS with ChunkSize == 1

### DIFF
--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -298,7 +298,7 @@ bool CFile::Open(const CURL& file, const unsigned int flags)
       return false;
     }
 
-    if (m_pFile->GetChunkSize() && !(m_flags & READ_CHUNKED))
+    if (m_pFile->GetChunkSize() > 1 && !(m_flags & READ_CHUNKED))
     {
       m_pBuffer = new CFileStreamBuffer(0);
       m_pBuffer->Attach(m_pFile);


### PR DESCRIPTION
This fix a [crash on OpenELEC](https://github.com/OpenELEC/OpenELEC.tv/issues/3692) , but while this is a real fix, for mentioned crash it's only a workaround. 
We need to review code of CFileStreamBuffer to find crash point.

More explanations: GetChunkSize() should return minimal size that VFS can read. Most VFSes could read any size (no limits) so GetChunkSize() for such VFSes should return 0 (no limits). But NFSFile return "1" instead of "0" for some reason. Instead of patching NFSFile I decided to patch CFile to prevent any similar errors in future, as for ChunkSize "1" we don't need internal buffering.
