### PR TITLE
fixed: Try to recache image in case cached texture loading fails

### DIFF
--- a/xbmc/TextureCache.cpp
+++ b/xbmc/TextureCache.cpp
@@ -133,16 +133,7 @@ void CTextureCache::BackgroundCacheImage(const std::string &url)
   AddJob(new CTextureCacheJob(CTextureUtils::UnwrapImageURL(url), details.hash));
 }
 
-bool CTextureCache::CacheImage(const std::string &image, CTextureDetails &details)
-{
-  std::string path = GetCachedImage(image, details);
-  if (path.empty()) // not cached
-    path = CacheImage(image, NULL, &details);
-
-  return !path.empty();
-}
-
-std::string CTextureCache::CacheImage(const std::string &image, CBaseTexture **texture, CTextureDetails *details)
+std::string CTextureCache::CacheImage(const std::string &image, CBaseTexture **texture /* = NULL */, CTextureDetails *details /* = NULL */)
 {
   std::string url = CTextureUtils::UnwrapImageURL(image);
   CSingleLock lock(m_processingSection);
@@ -174,6 +165,15 @@ std::string CTextureCache::CacheImage(const std::string &image, CBaseTexture **t
   if (!details)
     details = &tempDetails;
   return GetCachedImage(url, *details, true);
+}
+
+bool CTextureCache::CacheImage(const std::string &image, CTextureDetails &details)
+{
+  std::string path = GetCachedImage(image, details);
+  if (path.empty()) // not cached
+    path = CacheImage(image, NULL, &details);
+
+  return !path.empty();
 }
 
 void CTextureCache::ClearCachedImage(const std::string &url, bool deleteSource /*= false */)

--- a/xbmc/TextureCache.h
+++ b/xbmc/TextureCache.h
@@ -92,7 +92,7 @@ public:
    \return cached url of this image
    \sa CTextureCacheJob::CacheTexture
    */
-  std::string CacheImage(const std::string &url, CBaseTexture **texture = NULL, CTextureDetails *details = NULL);
+  std::string CacheImage(const std::string &image, CBaseTexture **texture = NULL, CTextureDetails *details = NULL);
 
   /*! \brief Cache an image to image cache if not already cached, returning the image details.
    \param image url of the image to cache.


### PR DESCRIPTION
Up till now we didn't handle failed texture loading for cached images. This could occur in cases where the locally cached file is missing (or corrupt) and possibly other scenarios. 
