### PR TITLE
Separate actor name and role

### DIFF
--- a/addons/skin.confluence/720p/DialogVideoInfo.xml
+++ b/addons/skin.confluence/720p/DialogVideoInfo.xml
@@ -892,6 +892,7 @@
 							<texture border="5">button-nofocus.png</texture>
 						</control>
 						<control type="label">
+							<description>Actor and Role</description>
 							<left>10</left>
 							<top>0</top>
 							<width>410</width>
@@ -900,7 +901,7 @@
 							<align>left</align>
 							<aligny>center</aligny>
 							<selectedcolor>white</selectedcolor>
-							<info>ListItem.Label</info>
+							<label>$INFO[ListItem.Label]$INFO[ListItem.Label2, $LOCALIZE[20347] ,]</label>
 						</control>
 					</itemlayout>
 					<focusedlayout height="40" width="430">
@@ -921,6 +922,7 @@
 							<texture border="5">button-focus2.png</texture>
 						</control>
 						<control type="label">
+							<description>Actor and Role</description>
 							<left>10</left>
 							<top>0</top>
 							<width>410</width>
@@ -929,7 +931,7 @@
 							<align>left</align>
 							<aligny>center</aligny>
 							<selectedcolor>white</selectedcolor>
-							<info>ListItem.Label</info>
+							<label>$INFO[ListItem.Label]$INFO[ListItem.Label2, $LOCALIZE[20347] ,]</label>
 						</control>
 					</focusedlayout>
 				</control>

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -177,12 +177,7 @@ bool CGUIDialogVideoInfo::OnMessage(CGUIMessage& message)
           if (iItem < 0 || iItem >= m_castList->Size())
             break;
           std::string strItem = m_castList->Get(iItem)->GetLabel();
-          std::string strFind = StringUtils::Format(" %s ",g_localizeStrings.Get(20347).c_str());
-          size_t iPos = strItem.find(strFind);
-          if (iPos == std::string::npos)
-            iPos = strItem.size();
-          std::string tmp = strItem.substr(0, iPos);
-          OnSearch(tmp);
+          OnSearch(strItem);
         }
       }
     }
@@ -276,11 +271,6 @@ void CGUIDialogVideoInfo::SetMovie(const CFileItem *item)
   { // movie/show/episode
     for (CVideoInfoTag::iCast it = m_movieItem->GetVideoInfoTag()->m_cast.begin(); it != m_movieItem->GetVideoInfoTag()->m_cast.end(); ++it)
     {
-      std::string character;
-      if (it->strRole.empty())
-        character = it->strName;
-      else
-        character = StringUtils::Format("%s %s %s", it->strName.c_str(), g_localizeStrings.Get(20347).c_str(), it->strRole.c_str());
       CFileItemPtr item(new CFileItem(it->strName));
       if (!it->thumb.empty())
         item->SetArt("thumb", it->thumb);
@@ -294,7 +284,8 @@ void CGUIDialogVideoInfo::SetMovie(const CFileItem *item)
         }
       }
       item->SetIconImage("DefaultActor.png");
-      item->SetLabel(character);
+      item->SetLabel(it->strName);
+      item->SetLabel2(it->strRole);
       m_castList->Add(item);
     }
     // determine type:


### PR DESCRIPTION
Moved actor role to label2. Simplifies code and gives skinners greater
flexibility.
