### PR TITLE
Avoid compiling cdrip when build with --disable-optical-drive

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -29,7 +29,6 @@ DVDPLAYER_ARCHIVES=xbmc/cores/dvdplayer/DVDPlayer.a \
 DIRECTORY_ARCHIVES=$(DVDPLAYER_ARCHIVES) \
                    lib/SlingboxLib/SlingboxLib.a \
                    xbmc/addons/addons.a \
-                   xbmc/cdrip/cdrip.a \
                    xbmc/cores/AudioEngine/audioengine.a \
                    xbmc/cores/DllLoader/dllloader.a \
                    xbmc/cores/DllLoader/exports/exports.a \
@@ -101,6 +100,9 @@ DIRECTORY_ARCHIVES=$(DVDPLAYER_ARCHIVES) \
 NWAOBJSXBMC=	xbmc/threads/threads.a \
 		xbmc/commons/commons.a
 
+ifeq (@USE_OPTICAL_DRIVE@,1)
+DIRECTORY_ARCHIVES += xbmc/cdrip/cdrip.a 
+endif
 
 ifeq (@USE_WEB_SERVER@,1)
 DIRECTORY_ARCHIVES += xbmc/network/httprequesthandler/httprequesthandlers.a

--- a/configure.ac
+++ b/configure.ac
@@ -1310,6 +1310,9 @@ fi
 # Optical
 if test "$use_optical_drive" = "yes"; then
   AC_DEFINE([HAS_DVD_DRIVE], [1], [Define to 1 to have optical drive support])
+  USE_OPTICAL_DRIVE=1
+else
+  USE_OPTICAL_DRIVE=0
 fi
 
 # Alsa
@@ -2661,6 +2664,7 @@ AC_SUBST(UPNP_DEFINES)
 AC_SUBST(USE_SSE4)
 AC_SUBST(USE_MMAL)
 AC_SUBST(USE_X11)
+AC_SUBST(USE_OPTICAL_DRIVE)
 AC_SUBST(USE_BREAKPAD)
 
 # pushd and popd are not available in other shells besides bash, so implement


### PR DESCRIPTION
Avoid compiling unnecessary files (EncoderFFmpeg, CDDARipJob) when configure with --disable-optical-drive option.
