### PR TITLE
sorting: cleanup and refactor to allow different sort orders for the different sort methods

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1954,7 +1954,7 @@ void CFileItemList::Archive(CArchive& ar)
     ar << (int)m_sortDetails.size();
     for (unsigned int j = 0; j < m_sortDetails.size(); ++j)
     {
-      const SORT_METHOD_DETAILS &details = m_sortDetails[j];
+      const GUIViewSortDetails &details = m_sortDetails[j];
       ar << (int)details.m_sortDescription.sortBy;
       ar << (int)details.m_sortDescription.sortOrder;
       ar << (int)details.m_sortDescription.sortAttributes;
@@ -2020,7 +2020,7 @@ void CFileItemList::Archive(CArchive& ar)
     ar >> detailSize;
     for (unsigned int j = 0; j < detailSize; ++j)
     {
-      SORT_METHOD_DETAILS details;
+      GUIViewSortDetails details;
       ar >> (int&)tempint;
       details.m_sortDescription.sortBy = (SortBy)tempint;
       ar >> (int&)tempint;
@@ -3084,7 +3084,7 @@ void CFileItemList::AddSortMethod(SortBy sortBy, SortAttribute sortAttributes, i
 
 void CFileItemList::AddSortMethod(SortDescription sortDescription, int buttonLabel, const LABEL_MASKS &labelMasks)
 {
-  SORT_METHOD_DETAILS sort;
+  GUIViewSortDetails sort;
   sort.m_sortDescription = sortDescription;
   sort.m_buttonLabel = buttonLabel;
   sort.m_labelMasks = labelMasks;

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -638,8 +638,8 @@ public:
   void AddSortMethod(SortBy sortBy, int buttonLabel, const LABEL_MASKS &labelMasks, SortAttribute sortAttributes = SortAttributeNone);
   void AddSortMethod(SortBy sortBy, SortAttribute sortAttributes, int buttonLabel, const LABEL_MASKS &labelMasks);
   void AddSortMethod(SortDescription sortDescription, int buttonLabel, const LABEL_MASKS &labelMasks);
-  bool HasSortDetails() const { return m_sortDetails.size() != 0; };
-  const std::vector<SORT_METHOD_DETAILS> &GetSortDetails() const { return m_sortDetails; };
+  bool HasSortDetails() const { return m_sortDetails.size() != 0; }
+  const std::vector<GUIViewSortDetails> &GetSortDetails() const { return m_sortDetails; }
 
   /*! \brief Specify whether this list should be sorted with folders separate from files
    By default we sort with folders listed (and sorted separately) except for those sort modes
@@ -680,7 +680,7 @@ private:
   bool m_replaceListing;
   std::string m_content;
 
-  std::vector<SORT_METHOD_DETAILS> m_sortDetails;
+  std::vector<GUIViewSortDetails> m_sortDetails;
 
   CCriticalSection m_lock;
 };

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -3024,7 +3024,7 @@ bool CGUIInfoManager::GetMultiInfoBool(const GUIInfo &info, int contextWindow, c
         {
           const CGUIViewState *viewState = ((CGUIMediaWindow*)window)->GetViewState();
           if (viewState)
-            bReturn = ((unsigned int)viewState->GetDisplaySortOrder() == info.GetData1());
+            bReturn = ((unsigned int)viewState->GetSortOrder() == info.GetData1());
         }
         break;
       }

--- a/xbmc/utils/SortUtils.h
+++ b/xbmc/utils/SortUtils.h
@@ -108,12 +108,12 @@ typedef struct SortDescription {
   { }
 } SortDescription;
 
-typedef struct
+typedef struct GUIViewSortDetails
 {
   SortDescription m_sortDescription;
   int m_buttonLabel;
   LABEL_MASKS m_labelMasks;
-} SORT_METHOD_DETAILS;
+} GUIViewSortDetails;
 
 typedef DatabaseResult SortItem;
 typedef boost::shared_ptr<SortItem> SortItemPtr;

--- a/xbmc/view/GUIViewControl.cpp
+++ b/xbmc/view/GUIViewControl.cpp
@@ -37,8 +37,7 @@ CGUIViewControl::CGUIViewControl(void)
 }
 
 CGUIViewControl::~CGUIViewControl(void)
-{
-}
+{ }
 
 void CGUIViewControl::Reset()
 {
@@ -157,13 +156,16 @@ void CGUIViewControl::UpdateView()
 
 int CGUIViewControl::GetSelectedItem(const CGUIControl *control) const
 {
-  if (!control || !m_fileItems) return -1;
+  if (!control || !m_fileItems)
+    return -1;
+
   CGUIMessage msg(GUI_MSG_ITEM_SELECTED, m_parentWindow, control->GetID());
   g_windowManager.SendMessage(msg, m_parentWindow);
 
   int iItem = msg.GetParam1();
   if (iItem >= m_fileItems->Size())
     return -1;
+
   return iItem;
 }
 
@@ -349,4 +351,3 @@ void CGUIViewControl::UpdateViewVisibility()
       m_visibleViews.push_back(view);
   }
 }
-

--- a/xbmc/view/GUIViewControl.h
+++ b/xbmc/view/GUIViewControl.h
@@ -30,8 +30,8 @@ class CFileItemList;
 class CGUIViewControl
 {
 public:
-  CGUIViewControl(void);
-  virtual ~CGUIViewControl(void);
+  CGUIViewControl();
+  virtual ~CGUIViewControl();
 
   void Reset();
   void SetParentWindow(int window);
@@ -66,12 +66,12 @@ protected:
   void UpdateViewVisibility();
   int GetView(VIEW_TYPE type, int id) const;
 
-  std::vector<CGUIControl *> m_allViews;
-  std::vector<CGUIControl *> m_visibleViews;
-  typedef std::vector<CGUIControl *>::const_iterator ciViews;
+  std::vector<CGUIControl*> m_allViews;
+  std::vector<CGUIControl*> m_visibleViews;
+  typedef std::vector<CGUIControl*>::const_iterator ciViews;
 
-  CFileItemList*        m_fileItems;
-  int                   m_viewAsControl;
-  int                   m_parentWindow;
-  int                   m_currentView;
+  CFileItemList* m_fileItems;
+  int m_viewAsControl;
+  int m_parentWindow;
+  int m_currentView;
 };

--- a/xbmc/view/GUIViewState.cpp
+++ b/xbmc/view/GUIViewState.cpp
@@ -285,7 +285,7 @@ void CGUIViewState::AddSortMethod(SortBy sortBy, SortAttribute sortAttributes, i
     if (m_sortMethods[i].m_sortDescription.sortBy == sortBy)
       return;
 
-  SORT_METHOD_DETAILS sort;
+  GUIViewSortDetails sort;
   sort.m_sortDescription.sortBy = sortBy;
   sort.m_sortDescription.sortAttributes = sortAttributes;
   sort.m_buttonLabel = buttonLabel;
@@ -543,10 +543,10 @@ CGUIViewStateGeneral::CGUIViewStateGeneral(const CFileItemList& items) : CGUIVie
 
 CGUIViewStateFromItems::CGUIViewStateFromItems(const CFileItemList &items) : CGUIViewState(items)
 {
-  const vector<SORT_METHOD_DETAILS> &details = items.GetSortDetails();
+  const vector<GUIViewSortDetails> &details = items.GetSortDetails();
   for (unsigned int i = 0; i < details.size(); i++)
   {
-    const SORT_METHOD_DETAILS sort = details[i];
+    const GUIViewSortDetails sort = details[i];
     AddSortMethod(sort.m_sortDescription, sort.m_buttonLabel, sort.m_labelMasks);
   }
   // TODO: Should default sort/view mode be specified?

--- a/xbmc/view/GUIViewState.cpp
+++ b/xbmc/view/GUIViewState.cpp
@@ -110,64 +110,64 @@ CGUIViewState* CGUIViewState::GetViewState(int windowId, const CFileItemList& it
   if (url.IsProtocol("androidapp"))
     return new CGUIViewStateWindowPrograms(items);
 
-  if (windowId==WINDOW_MUSIC_NAV)
+  if (windowId == WINDOW_MUSIC_NAV)
     return new CGUIViewStateWindowMusicNav(items);
 
-  if (windowId==WINDOW_MUSIC_FILES)
+  if (windowId == WINDOW_MUSIC_FILES)
     return new CGUIViewStateWindowMusicSongs(items);
 
-  if (windowId==WINDOW_MUSIC_PLAYLIST)
+  if (windowId == WINDOW_MUSIC_PLAYLIST)
     return new CGUIViewStateWindowMusicPlaylist(items);
 
-  if (windowId==WINDOW_MUSIC_PLAYLIST_EDITOR)
+  if (windowId == WINDOW_MUSIC_PLAYLIST_EDITOR)
     return new CGUIViewStateWindowMusicSongs(items);
 
-  if (windowId==WINDOW_VIDEO_FILES)
+  if (windowId == WINDOW_VIDEO_FILES)
     return new CGUIViewStateWindowVideoFiles(items);
 
-  if (windowId==WINDOW_VIDEO_NAV)
+  if (windowId == WINDOW_VIDEO_NAV)
     return new CGUIViewStateWindowVideoNav(items);
 
-  if (windowId==WINDOW_VIDEO_PLAYLIST)
+  if (windowId == WINDOW_VIDEO_PLAYLIST)
     return new CGUIViewStateWindowVideoPlaylist(items);
 
-  if (windowId==WINDOW_TV_CHANNELS)
+  if (windowId == WINDOW_TV_CHANNELS)
     return new CGUIViewStateWindowPVRChannels(windowId, items);
 
-  if (windowId==WINDOW_TV_RECORDINGS)
+  if (windowId == WINDOW_TV_RECORDINGS)
     return new CGUIViewStateWindowPVRRecordings(windowId, items);
 
-  if (windowId==WINDOW_TV_GUIDE)
+  if (windowId == WINDOW_TV_GUIDE)
     return new CGUIViewStateWindowPVRGuide(windowId, items);
 
-  if (windowId==WINDOW_TV_TIMERS)
+  if (windowId == WINDOW_TV_TIMERS)
     return new CGUIViewStateWindowPVRTimers(windowId, items);
 
-  if (windowId==WINDOW_TV_SEARCH)
+  if (windowId == WINDOW_TV_SEARCH)
     return new CGUIViewStateWindowPVRSearch(windowId, items);
 
-  if (windowId==WINDOW_RADIO_CHANNELS)
+  if (windowId == WINDOW_RADIO_CHANNELS)
       return new CGUIViewStateWindowPVRChannels(windowId, items);
 
-  if (windowId==WINDOW_RADIO_RECORDINGS)
+  if (windowId == WINDOW_RADIO_RECORDINGS)
     return new CGUIViewStateWindowPVRRecordings(windowId, items);
 
-  if (windowId==WINDOW_RADIO_GUIDE)
+  if (windowId == WINDOW_RADIO_GUIDE)
     return new CGUIViewStateWindowPVRGuide(windowId, items);
 
-  if (windowId==WINDOW_RADIO_TIMERS)
+  if (windowId == WINDOW_RADIO_TIMERS)
     return new CGUIViewStateWindowPVRTimers(windowId, items);
 
-  if (windowId==WINDOW_RADIO_SEARCH)
+  if (windowId == WINDOW_RADIO_SEARCH)
     return new CGUIViewStateWindowPVRSearch(windowId, items);
 
-  if (windowId==WINDOW_PICTURES)
+  if (windowId == WINDOW_PICTURES)
     return new CGUIViewStateWindowPictures(items);
 
-  if (windowId==WINDOW_PROGRAMS)
+  if (windowId == WINDOW_PROGRAMS)
     return new CGUIViewStateWindowPrograms(items);
   
-  if (windowId==WINDOW_ADDON_BROWSER)
+  if (windowId == WINDOW_ADDON_BROWSER)
     return new CGUIViewStateAddonBrowser(items);
 
   //  Use as fallback/default
@@ -176,15 +176,14 @@ CGUIViewState* CGUIViewState::GetViewState(int windowId, const CFileItemList& it
 
 CGUIViewState::CGUIViewState(const CFileItemList& items) : m_items(items)
 {
-  m_currentViewAsControl=0;
-  m_currentSortMethod=0;
+  m_currentViewAsControl = 0;
+  m_currentSortMethod = 0;
   m_playlist = PLAYLIST_NONE;
   m_sortOrder = SortOrderAscending;
 }
 
 CGUIViewState::~CGUIViewState()
-{
-}
+{ }
 
 SortOrder CGUIViewState::GetDisplaySortOrder() const
 {
@@ -240,7 +239,7 @@ void CGUIViewState::SaveViewAsControl(int viewAsControl)
 SortDescription CGUIViewState::GetSortMethod() const
 {
   SortDescription sorting;
-  if (m_currentSortMethod>=0 && m_currentSortMethod<(int)m_sortMethods.size())
+  if (m_currentSortMethod >= 0 && m_currentSortMethod < (int)m_sortMethods.size())
     sorting = m_sortMethods[m_currentSortMethod].m_sortDescription;
   sorting.sortOrder = m_sortOrder;
 
@@ -254,7 +253,7 @@ bool CGUIViewState::HasMultipleSortMethods() const
 
 int CGUIViewState::GetSortMethodLabel() const
 {
-  if (m_currentSortMethod>=0 && m_currentSortMethod<(int)m_sortMethods.size())
+  if (m_currentSortMethod >= 0 && m_currentSortMethod < (int)m_sortMethods.size())
     return m_sortMethods[m_currentSortMethod].m_buttonLabel;
 
   return 551; // default sort method label 'Name'
@@ -262,9 +261,9 @@ int CGUIViewState::GetSortMethodLabel() const
 
 void CGUIViewState::GetSortMethodLabelMasks(LABEL_MASKS& masks) const
 {
-  if (m_currentSortMethod>=0 && m_currentSortMethod<(int)m_sortMethods.size())
+  if (m_currentSortMethod >= 0 && m_currentSortMethod < (int)m_sortMethods.size())
   {
-    masks=m_sortMethods[m_currentSortMethod].m_labelMasks;
+    masks = m_sortMethods[m_currentSortMethod].m_labelMasks;
     return;
   }
 
@@ -376,7 +375,7 @@ const std::string& CGUIViewState::GetPlaylistDirectory()
 
 void CGUIViewState::SetPlaylistDirectory(const std::string& strDirectory)
 {
-  m_strPlaylistDirectory=strDirectory;
+  m_strPlaylistDirectory = strDirectory;
   URIUtils::RemoveSlashAtEnd(m_strPlaylistDirectory);
 }
 
@@ -385,10 +384,10 @@ bool CGUIViewState::IsCurrentPlaylistDirectory(const std::string& strDirectory)
   if (g_playlistPlayer.GetCurrentPlaylist()!=GetPlaylist())
     return false;
 
-  std::string strDir=strDirectory;
+  std::string strDir = strDirectory;
   URIUtils::RemoveSlashAtEnd(strDir);
 
-  return (m_strPlaylistDirectory==strDir);
+  return m_strPlaylistDirectory == strDir;
 }
 
 bool CGUIViewState::AutoPlayNextItem()
@@ -468,16 +467,6 @@ void CGUIViewState::AddLiveTVSources()
   }
 }
 
-CGUIViewStateGeneral::CGUIViewStateGeneral(const CFileItemList& items) : CGUIViewState(items)
-{
-  AddSortMethod(SortByLabel, 551, LABEL_MASKS("%F", "%I", "%L", ""));  // Filename, size | Foldername, empty
-  SetSortMethod(SortByLabel);
-
-  SetViewAsControl(DEFAULT_VIEW_LIST);
-
-  SetSortOrder(SortOrderAscending);
-}
-
 void CGUIViewState::SetSortOrder(SortOrder sortOrder)
 {
   if (GetSortMethod().sortBy == SortByNone)
@@ -491,41 +480,42 @@ void CGUIViewState::SetSortOrder(SortOrder sortOrder)
 void CGUIViewState::LoadViewState(const std::string &path, int windowID)
 { // get our view state from the db
   CViewDatabase db;
-  if (db.Open())
+  if (!db.Open())
+    return;
+
+  CViewState state;
+  if (db.GetViewState(path, windowID, state, CSettings::Get().GetString("lookandfeel.skin")) ||
+      db.GetViewState(path, windowID, state, ""))
   {
-    CViewState state;
-    if (db.GetViewState(path, windowID, state, CSettings::Get().GetString("lookandfeel.skin")) ||
-        db.GetViewState(path, windowID, state, ""))
-    {
-      SetViewAsControl(state.m_viewMode);
-      SetSortMethod(state.m_sortDescription);
-      SetSortOrder(state.m_sortDescription.sortOrder);
-    }
-    db.Close();
+    SetViewAsControl(state.m_viewMode);
+    SetSortMethod(state.m_sortDescription);
+    SetSortOrder(state.m_sortDescription.sortOrder);
   }
 }
 
 void CGUIViewState::SaveViewToDb(const std::string &path, int windowID, CViewState *viewState)
 {
   CViewDatabase db;
-  if (db.Open())
-  {
-    SortDescription sorting = GetSortMethod();
-    CViewState state(m_currentViewAsControl, sorting.sortBy, m_sortOrder, sorting.sortAttributes);
-    if (viewState)
-      *viewState = state;
-    db.SetViewState(path, windowID, state, CSettings::Get().GetString("lookandfeel.skin"));
-    db.Close();
-    if (viewState)
-      CSettings::Get().Save();
-  }
+  if (!db.Open())
+    return;
+
+  SortDescription sorting = GetSortMethod();
+  CViewState state(m_currentViewAsControl, sorting.sortBy, m_sortOrder, sorting.sortAttributes);
+  if (viewState != NULL)
+    *viewState = state;
+
+  db.SetViewState(path, windowID, state, CSettings::Get().GetString("lookandfeel.skin"));
+  db.Close();
+
+  if (viewState != NULL)
+    CSettings::Get().Save();
 }
 
 void CGUIViewState::AddPlaylistOrder(const CFileItemList &items, LABEL_MASKS label_masks)
 {
   SortBy sortBy = SortByPlaylistOrder;
-  int         sortLabel = 559;
-  SortOrder   sortOrder = SortOrderAscending;
+  int sortLabel = 559;
+  SortOrder sortOrder = SortOrderAscending;
   if (items.HasProperty(PROPERTY_SORT_ORDER))
   {
     sortBy = (SortBy)items.GetProperty(PROPERTY_SORT_ORDER).asInteger();
@@ -535,11 +525,21 @@ void CGUIViewState::AddPlaylistOrder(const CFileItemList &items, LABEL_MASKS lab
       sortOrder = items.GetProperty(PROPERTY_SORT_ASCENDING).asBoolean() ? SortOrderAscending : SortOrderDescending;
     }
   }
+
   AddSortMethod(sortBy, sortLabel, label_masks);
   SetSortMethod(sortBy);
   SetSortOrder(sortOrder);
 }
 
+CGUIViewStateGeneral::CGUIViewStateGeneral(const CFileItemList& items) : CGUIViewState(items)
+{
+  AddSortMethod(SortByLabel, 551, LABEL_MASKS("%F", "%I", "%L", ""));  // Filename, size | Foldername, empty
+  SetSortMethod(SortByLabel);
+
+  SetViewAsControl(DEFAULT_VIEW_LIST);
+
+  SetSortOrder(SortOrderAscending);
+}
 
 CGUIViewStateFromItems::CGUIViewStateFromItems(const CFileItemList &items) : CGUIViewState(items)
 {
@@ -568,6 +568,7 @@ CGUIViewStateFromItems::CGUIViewStateFromItems(const CFileItemList &items) : CGU
         m_playlist = PLAYLIST_VIDEO;
     }
   }
+
   LoadViewState(items.GetPath(), g_windowManager.GetActiveWindow());
 }
 
@@ -591,4 +592,3 @@ void CGUIViewStateLibrary::SaveViewState()
 {
   SaveViewToDb(m_items.GetPath(), g_windowManager.GetActiveWindow());
 }
-

--- a/xbmc/view/GUIViewState.h
+++ b/xbmc/view/GUIViewState.h
@@ -99,7 +99,7 @@ protected:
   int m_currentViewAsControl;
   int m_playlist;
 
-  std::vector<SORT_METHOD_DETAILS> m_sortMethods;
+  std::vector<GUIViewSortDetails> m_sortMethods;
   int m_currentSortMethod;
   SortOrder m_sortOrder;
 

--- a/xbmc/view/GUIViewState.h
+++ b/xbmc/view/GUIViewState.h
@@ -47,21 +47,25 @@ public:
   SortOrder SetNextSortOrder();
   SortOrder GetSortOrder() const { return m_sortOrder; };
   SortOrder GetDisplaySortOrder() const;
+
   virtual bool HideExtensions();
   virtual bool HideParentDirItems();
   virtual bool DisableAddSourceButtons();
+
   virtual int GetPlaylist();
   const std::string& GetPlaylistDirectory();
   void SetPlaylistDirectory(const std::string& strDirectory);
   bool IsCurrentPlaylistDirectory(const std::string& strDirectory);
   virtual bool AutoPlayNextItem();
+
   virtual std::string GetLockType();
   virtual std::string GetExtensions();
   virtual VECSOURCES& GetSources();
 
 protected:
   CGUIViewState(const CFileItemList& items);  // no direct object creation, use GetViewState()
-  virtual void SaveViewState()=0;
+
+  virtual void SaveViewState() = 0;
   virtual void SaveViewToDb(const std::string &path, int windowID, CViewState *viewState = NULL);
   void LoadViewState(const std::string &path, int windowID);
   
@@ -89,18 +93,17 @@ protected:
   void SetSortMethod(SortBy sortBy);
   void SetSortMethod(SortDescription sortDescription);
   void SetSortOrder(SortOrder sortOrder);
-  const CFileItemList& m_items;
 
-  static VECSOURCES m_sources;
+  const CFileItemList& m_items;
 
   int m_currentViewAsControl;
   int m_playlist;
 
   std::vector<SORT_METHOD_DETAILS> m_sortMethods;
   int m_currentSortMethod;
-
   SortOrder m_sortOrder;
 
+  static VECSOURCES m_sources;
   static std::string m_strPlaylistDirectory;
 };
 
@@ -110,7 +113,7 @@ public:
   CGUIViewStateGeneral(const CFileItemList& items);
 
 protected:
-  virtual void SaveViewState() {};
+  virtual void SaveViewState() { }
 };
 
 class CGUIViewStateFromItems : public CGUIViewState

--- a/xbmc/view/GUIViewState.h
+++ b/xbmc/view/GUIViewState.h
@@ -45,8 +45,7 @@ public:
   void GetSortMethodLabelMasks(LABEL_MASKS& masks) const;
 
   SortOrder SetNextSortOrder();
-  SortOrder GetSortOrder() const { return m_sortOrder; };
-  SortOrder GetDisplaySortOrder() const;
+  SortOrder GetSortOrder() const;
 
   virtual bool HideExtensions();
   virtual bool HideParentDirItems();
@@ -87,10 +86,10 @@ protected:
    */
   void AddPlaylistOrder(const CFileItemList &items, LABEL_MASKS label_masks);
 
-  void AddSortMethod(SortBy sortBy, int buttonLabel, const LABEL_MASKS &labelMasks, SortAttribute sortAttributes = SortAttributeNone);
-  void AddSortMethod(SortBy sortBy, SortAttribute sortAttributes, int buttonLabel, const LABEL_MASKS &labelMasks);
+  void AddSortMethod(SortBy sortBy, int buttonLabel, const LABEL_MASKS &labelMasks, SortAttribute sortAttributes = SortAttributeNone, SortOrder sortOrder = SortOrderNone);
+  void AddSortMethod(SortBy sortBy, SortAttribute sortAttributes, int buttonLabel, const LABEL_MASKS &labelMasks, SortOrder sortOrder = SortOrderNone);
   void AddSortMethod(SortDescription sortDescription, int buttonLabel, const LABEL_MASKS &labelMasks);
-  void SetSortMethod(SortBy sortBy);
+  void SetSortMethod(SortBy sortBy, SortOrder sortOrder = SortOrderNone);
   void SetSortMethod(SortDescription sortDescription);
   void SetSortOrder(SortOrder sortOrder);
 
@@ -101,7 +100,6 @@ protected:
 
   std::vector<GUIViewSortDetails> m_sortMethods;
   int m_currentSortMethod;
-  SortOrder m_sortOrder;
 
   static VECSOURCES m_sources;
   static std::string m_strPlaylistDirectory;

--- a/xbmc/view/ViewDatabase.cpp
+++ b/xbmc/view/ViewDatabase.cpp
@@ -30,19 +30,12 @@
 #include "dbwrappers/dataset.h"
 #include "SortFileItem.h"
 
-
-//********************************************************************************************************************************
 CViewDatabase::CViewDatabase(void)
-{
-}
+{ }
 
-//********************************************************************************************************************************
 CViewDatabase::~CViewDatabase(void)
-{
+{ }
 
-}
-
-//********************************************************************************************************************************
 bool CViewDatabase::Open()
 {
   return CDatabase::Open();
@@ -52,14 +45,14 @@ void CViewDatabase::CreateTables()
 {
   CLog::Log(LOGINFO, "create view table");
   m_pDS->exec("CREATE TABLE view ("
-                "idView integer primary key,"
-                "window integer,"
-                "path text,"
-                "viewMode integer,"
-                "sortMethod integer,"
-                "sortOrder integer,"
-                "sortAttributes integer,"
-                "skin text)\n");
+              "idView integer primary key,"
+              "window integer,"
+              "path text,"
+              "viewMode integer,"
+              "sortMethod integer,"
+              "sortOrder integer,"
+              "sortAttributes integer,"
+              "skin text)");
 }
 
 void CViewDatabase::CreateAnalytics()

--- a/xbmc/view/ViewDatabase.h
+++ b/xbmc/view/ViewDatabase.h
@@ -26,8 +26,8 @@ class CViewState;
 class CViewDatabase : public CDatabase
 {
 public:
-  CViewDatabase(void);
-  virtual ~CViewDatabase(void);
+  CViewDatabase();
+  virtual ~CViewDatabase();
   virtual bool Open();
 
   bool GetViewState(const std::string &path, int windowID, CViewState &state, const std::string &skin);
@@ -38,6 +38,6 @@ protected:
   virtual void CreateTables();
   virtual void CreateAnalytics();
   virtual void UpdateTables(int version);
-  virtual int GetSchemaVersion() const { return 6; };
-  const char *GetBaseDBName() const { return "ViewModes"; };
+  virtual int GetSchemaVersion() const { return 6; }
+  const char *GetBaseDBName() const { return "ViewModes"; }
 };

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -526,14 +526,14 @@ void CGUIMediaWindow::UpdateButtons()
   if (m_guiState.get())
   {
     // Update sorting controls
-    if (m_guiState->GetDisplaySortOrder() == SortOrderNone)
+    if (m_guiState->GetSortOrder() == SortOrderNone)
     {
       CONTROL_DISABLE(CONTROL_BTNSORTASC);
     }
     else
     {
       CONTROL_ENABLE(CONTROL_BTNSORTASC);
-      SET_CONTROL_SELECTED(GetID(), CONTROL_BTNSORTASC, m_guiState->GetDisplaySortOrder() != SortOrderAscending);
+      SET_CONTROL_SELECTED(GetID(), CONTROL_BTNSORTASC, m_guiState->GetSortOrder() != SortOrderAscending);
     }
 
     // Update list/thumb control
@@ -571,7 +571,7 @@ void CGUIMediaWindow::SortItems(CFileItemList &items)
   if (guiState.get())
   {
     SortDescription sorting = guiState->GetSortMethod();
-    sorting.sortOrder = guiState->GetDisplaySortOrder();
+    sorting.sortOrder = guiState->GetSortOrder();
     // If the sort method is "sort by playlist" and we have a specific
     // sort order available we can use the specified sort order to do the sorting
     // We do this as the new SortBy methods are a superset of the SORT_METHOD methods, thus
@@ -588,7 +588,7 @@ void CGUIMediaWindow::SortItems(CFileItemList &items)
 
         // if the sort order is descending, we need to switch the original sort order, as we assume
         // in CGUIViewState::AddPlaylistOrder that SortByPlaylistOrder is ascending.
-        if (guiState->GetDisplaySortOrder() == SortOrderDescending)
+        if (guiState->GetSortOrder() == SortOrderDescending)
           sorting.sortOrder = sorting.sortOrder == SortOrderDescending ? SortOrderAscending : SortOrderDescending;
       }
     }
@@ -630,7 +630,7 @@ void CGUIMediaWindow::FormatAndSort(CFileItemList &items)
     viewState->GetSortMethodLabelMasks(labelMasks);
     FormatItemLabels(items, labelMasks);
 
-    items.Sort(viewState->GetSortMethod().sortBy, viewState->GetDisplaySortOrder(), viewState->GetSortMethod().sortAttributes);
+    items.Sort(viewState->GetSortMethod().sortBy, viewState->GetSortOrder(), viewState->GetSortMethod().sortAttributes);
   }
 }
 


### PR DESCRIPTION
The first two commits are merely cosmetics and clean up the GUI view related code to better follow our coding style guidelines.
The last commit changes the behaviour of sorting in GUI listings from using a single sort order for all available sort methods to using a separate sort order for every available sort method.

Right now when a user sorts a list of items by title in descending order and moves on to sorting by year the list will also be sorted in descending order. While that doesn't sound completely wrong (even though it feels unintuitive to me) when moving on to sorting by rating the list will be sorted in ascending order. The reason for this is that there's some code that inverts the sort order for specific sort methods which make better sense with a descending sort order by default.

With this change when a user sorts a a list of items by title in descending order and moves on to sorting by year the list will be sorted in ascending order. And when he moves on to sorting by rating the list will be sorted in descending order (because that makes more sense by default).

Apart from changing the IMO ackward behaviour when switching between sort methods this also fixes an issue with smartplaylists. There a user can define a default sort method and order. If that sort method is e.g. set to sorting by rating and the sort order is set to descending the resulting GUI list will be sorted by rating in ascending order because the above mentioned logic inverts the sort order of certain sort methods.
