### PR TITLE
dvdplayer: allow skipping streaminfo only for mpegts streams

### DIFF
--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -415,6 +415,10 @@ bool CDVDDemuxFFmpeg::Open(CDVDInputStream* pInput, bool streaminfo, bool filein
     m_checkvideo = true;
     skipCreateStreams = true;
   }
+  else if (iformat && (strcmp(iformat->name, "mpegts") != 0))
+  {
+    m_streaminfo = true;
+  }
 
   // we need to know if this is matroska or avi later
   m_bMatroska = strncmp(m_pFormatContext->iformat->name, "matroska", 8) == 0;	// for "matroska.webm"


### PR DESCRIPTION
not sure if addons like IPTV ever were supposed to play anything other then mpegts. obviously it is used with flv streams.
fixes http://forum.kodi.tv/showthread.php?tid=211249&pid=1860413#pid1860413
