### PR TITLE
Revert "Disable extra logging by default"

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2754,12 +2754,12 @@
         </setting>
         <setting id="debug.extralogging" type="boolean" label="666" help="36394">
           <level>1</level>
-          <default>false</default>
+          <default>true</default>
           <control type="toggle" />
         </setting>
         <setting id="debug.setextraloglevel" type="list[integer]" parent="debug.extralogging" label="668" help="36534">
           <level>1</level>
-          <default></default>
+          <default>32768</default>
           <constraints>
             <options>loggingcomponents</options>
             <delimiter>,</delimiter>


### PR DESCRIPTION
stupid revert button on github creates branches...
now that master is free again and the insanity of helix seems to be over here, this is reverted back to how it was.
