### PR TITLE
IMX: Fix changing resolutions

### DIFF
--- a/xbmc/windowing/egl/EGLNativeTypeIMX.h
+++ b/xbmc/windowing/egl/EGLNativeTypeIMX.h
@@ -31,7 +31,7 @@ public:
   virtual bool  CheckCompatibility();
   virtual void  Initialize();
   virtual void  Destroy();
-  virtual int   GetQuirks() { return EGL_QUIRK_NONE; }
+  virtual int   GetQuirks() { return EGL_QUIRK_RECREATE_DISPLAY_ON_CREATE_WINDOW; }
 
   virtual bool  CreateNativeDisplay();
   virtual bool  CreateNativeWindow();

--- a/xbmc/windowing/egl/EGLQuirks.h
+++ b/xbmc/windowing/egl/EGLQuirks.h
@@ -39,3 +39,9 @@
            size of -1, -1. Work around it for now
 */
 #define EGL_QUIRK_DONT_TRUST_SURFACE_SIZE (1 << 2)
+
+/*! \brief Some drivers destroy the native display on resolution change. xbmc's EGL
+    implementation is not aware of this change. In that case a Reinit of the display
+    needs to be done.
+*/
+#define EGL_QUIRK_RECREATE_DISPLAY_ON_CREATE_WINDOW (1 << 3)

--- a/xbmc/windowing/egl/WinSystemEGL.cpp
+++ b/xbmc/windowing/egl/WinSystemEGL.cpp
@@ -151,6 +151,18 @@ bool CWinSystemEGL::CreateWindow(RESOLUTION_INFO &res)
   if(m_egl)
     m_egl->SetNativeResolution(res);
 
+  int quirks;
+  m_egl->GetQuirks(&quirks);
+  if (quirks & EGL_QUIRK_RECREATE_DISPLAY_ON_CREATE_WINDOW)
+  {
+    if (m_context != EGL_NO_CONTEXT)
+      if (!m_egl->InitDisplay(&m_display))
+      {
+        CLog::Log(LOGERROR, "%s: Could not reinit display",__FUNCTION__);
+        return false;
+      }
+  }
+
   if (!m_egl->CreateSurface(m_display, m_config, &m_surface))
   {
     CLog::Log(LOGNOTICE, "%s: Could not create a surface. Trying with a fresh Native Window.",__FUNCTION__);


### PR DESCRIPTION
Background:
- imx6 as only egl driver is destroying nativedisplay on resolution change
- xbmc's EGL code is not aware of this change (pointer to EGLDisplay can change but xbmc uses old pointer  which was obtained on EGL init. in such case EGL properly  throws error 300b - bad window - which comes from recreating new window on BAD display)
- InitDisplay() is refreshing display pointer (and running eglInitialize() has no effect on already initialised display)

Special thanks to Matus Kral @mk01 from the xbian project for debugging and finding this fix. Highly appreciated.

@smallint @wolfgar For review please.
