### PR TITLE
[imx6] Revert to software decoding for AVC profile 578

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
@@ -418,9 +418,12 @@ bool CDVDVideoCodecIMX::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
     m_pFormatName = "iMX-h263";
     break;
   case CODEC_ID_H264:
-    if (m_hints.profile == 110)
+  {
+    // Test for VPU unsupported profiles to revert to sw decoding
+    if ((m_hints.profile == 110) || //hi10p
+        (m_hints.profile == 578))   //quite uncommon h264 profile
     {
-      CLog::Log(LOGNOTICE, "i.MX6 VPU is not able to decode AVC high 10 profile\n");
+      CLog::Log(LOGNOTICE, "i.MX6 VPU is not able to decode AVC profile %d", m_hints.profile);
       return false;
     }
     m_decOpenParam.CodecFormat = VPU_V_AVC;
@@ -434,6 +437,7 @@ bool CDVDVideoCodecIMX::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
       }
     }
     break;
+  }
   case CODEC_ID_VC1:
     m_decOpenParam.CodecFormat = VPU_V_VC1_AP;
     m_pFormatName = "iMX-vc1";


### PR DESCRIPTION
Following a sample submitted by @fritsch 
Here is a quick fix to revert to sw decoding faced to this unsupported profile
@MartijnKaijser @topfs2 : Could this still be merged for helix ?
