### PR TITLE
[keyboardlayout] Add Greek QWERTY

### DIFF
--- a/system/keyboardlayouts.xml
+++ b/system/keyboardlayouts.xml
@@ -384,4 +384,24 @@ Default font lacks support for all characters
       <row>`~</row>
     </keyboard>
   </layout>
+  <layout name="Greek QWERTY">
+    <keyboard>
+      <row>1234567890</row>
+      <row>ςερτυθιοπ</row>
+      <row>ασδφγηξκλ</row>
+      <row>ζχψωβνμ</row>
+    </keyboard>
+    <keyboard modifiers="shift">
+      <row>1234567890</row>
+      <row>ΕΡΤΥΘΙΟΠ</row>
+      <row>ΑΣΔΦΓΗΞΚΛ</row>
+      <row>ΖΧΨΩΒΝΜ</row>
+    </keyboard>
+    <keyboard modifiers="symbol,shift+symbol">
+      <row>)!@#$%^&amp;*(€</row>
+      <row>[]{}-_=+;:~</row>
+      <row>'",.&lt;&gt;/?\|`</row>
+      <row>έύίόάήώϋϊΰΐ</row>
+    </keyboard>
+  </layout>
 </keyboardlayouts>


### PR DESCRIPTION
Greek QWERTY keyboard layout. All accented characters are under "symbol,shift+symbol". No space for the capital accented characters though.
(Sorry I submitted the same change (#5965) to the master branch a few hours earlier, when I really wanted to submit it to the Helix branch...).
