### PR TITLE
media library: fix path history for items with a real path differing from the requested path

### DIFF
--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -1472,7 +1472,13 @@ void CGUIMediaWindow::OnInitWindow()
   bool updateStartDirectory = (m_startDirectory == m_vecItems->GetPath());
   Refresh();
   if (updateStartDirectory)
+  {
+    // reset the start directory to the path of the items
     m_startDirectory = m_vecItems->GetPath();
+
+    // reset the history based on the path of the items
+    SetHistoryForPath(m_startDirectory);
+  }
 
   m_rootDir.SetAllowThreads(true);
 


### PR DESCRIPTION
Same as #5941 but for Helix.
