### PR TITLE
sorting: fix Container.SetSortMethod (fixes #15627)

### DIFF
--- a/xbmc/addons/GUIViewStateAddonBrowser.cpp
+++ b/xbmc/addons/GUIViewStateAddonBrowser.cpp
@@ -44,7 +44,7 @@ CGUIViewStateAddonBrowser::CGUIViewStateAddonBrowser(const CFileItemList& items)
   {
     AddSortMethod(SortByLabel, SortAttributeIgnoreFolders, 551, LABEL_MASKS("%L", "%I", "%L", ""));  // Filename, Size | Foldername, empty
     AddSortMethod(SortByDate, 552, LABEL_MASKS("%L", "%J", "%L", "%J"));  // Filename, Date | Foldername, Date
-    SetSortMethod(SortByLabel, SortAttributeIgnoreFolders);
+    SetSortMethod(SortByLabel);
   }
   SetViewAsControl(DEFAULT_VIEW_AUTO);
 

--- a/xbmc/music/GUIViewStateMusic.cpp
+++ b/xbmc/music/GUIViewStateMusic.cpp
@@ -87,7 +87,7 @@ CGUIViewStateMusicSearch::CGUIViewStateMusicSearch(const CFileItemList& items) :
     sortAttribute = SortAttributeIgnoreArticle;
 
   AddSortMethod(SortByTitle, sortAttribute, 556, LABEL_MASKS("%T - %A", "%D", "%L", "%A"));  // Title, Artist, Duration| empty, empty
-  SetSortMethod(SortByTitle, sortAttribute);
+  SetSortMethod(SortByTitle);
 
   const CViewState *viewState = CViewStateSettings::Get().Get("musicnavsongs");
   SetViewAsControl(viewState->m_viewMode);
@@ -172,7 +172,7 @@ CGUIViewStateMusicDatabase::CGUIViewStateMusicDatabase(const CFileItemList& item
   case NODE_TYPE_ARTIST:
     {
       AddSortMethod(SortByArtist, sortAttribute, 557, LABEL_MASKS("%F", "", "%A", ""));  // Filename, empty | Artist, empty
-      SetSortMethod(SortByArtist, sortAttribute);
+      SetSortMethod(SortByArtist);
 
       const CViewState *viewState = CViewStateSettings::Get().Get("musicnavartists");
       SetViewAsControl(viewState->m_viewMode);
@@ -277,7 +277,7 @@ CGUIViewStateMusicDatabase::CGUIViewStateMusicDatabase(const CFileItemList& item
       // the "All Albums" entries always default to SortByAlbum as this is most logical - user can always
       // change it and the change will be saved for this particular path
       if (dir.IsAllItem(items.GetPath()))
-        SetSortMethod(SortByAlbum, sortAttribute);
+        SetSortMethod(SortByAlbum);
       else
         SetSortMethod(viewState->m_sortDescription);
 
@@ -560,7 +560,7 @@ CGUIViewStateWindowMusicSongs::CGUIViewStateWindowMusicSongs(const CFileItemList
   else if (items.GetPath() == "special://musicplaylists/")
   { // playlists list sorts by label only, ignoring folders
     AddSortMethod(SortByLabel, SortAttributeIgnoreFolders, 551, LABEL_MASKS("%F", "%D", "%L", ""));  // Filename, Duration | Foldername, empty
-    SetSortMethod(SortByLabel, SortAttributeIgnoreFolders);
+    SetSortMethod(SortByLabel);
   }
   else
   {

--- a/xbmc/video/GUIViewStateVideo.cpp
+++ b/xbmc/video/GUIViewStateVideo.cpp
@@ -206,7 +206,7 @@ CGUIViewStateWindowVideoNav::CGUIViewStateWindowVideoNav(const CFileItemList& it
         if (CMediaSettings::Get().GetWatchedMode(items.GetContent()) == WatchedModeAll)
           AddSortMethod(SortByPlaycount, 567, LABEL_MASKS("%T", "%V", "%T", "%V"));  // Title, Playcount | Title, Playcount
 
-        SetSortMethod(SortByLabel, SortAttributeIgnoreArticle);
+        SetSortMethod(SortByLabel);
 
         const CViewState *viewState = CViewStateSettings::Get().Get("videonavgenres");
         SetViewAsControl(viewState->m_viewMode);
@@ -216,7 +216,7 @@ CGUIViewStateWindowVideoNav::CGUIViewStateWindowVideoNav(const CFileItemList& it
     case NODE_TYPE_TAGS:
       {
         AddSortMethod(SortByLabel, sortAttributes, 551, LABEL_MASKS("%T","", "%T",""));  // Title, empty | Title, empty
-        SetSortMethod(SortByLabel, sortAttributes);
+        SetSortMethod(SortByLabel);
         
         const CViewState *viewState = CViewStateSettings::Get().Get("videonavgenres");
         SetViewAsControl(viewState->m_viewMode);

--- a/xbmc/view/GUIViewState.cpp
+++ b/xbmc/view/GUIViewState.cpp
@@ -309,17 +309,15 @@ void CGUIViewState::SetCurrentSortMethod(int method)
   if (sortBy < SortByNone || sortBy > SortByRandom)
     return; // invalid
 
-  SetSortMethod(sortBy, sortAttributes);
+  SetSortMethod(sortBy);
   SaveViewState();
 }
 
-void CGUIViewState::SetSortMethod(SortBy sortBy, SortAttribute sortAttributes /* = SortAttributeNone */)
+void CGUIViewState::SetSortMethod(SortBy sortBy)
 {
   for (int i = 0; i < (int)m_sortMethods.size(); ++i)
   {
-    if (m_sortMethods[i].m_sortDescription.sortBy == sortBy &&
-       // don't care about SortAttributeIgnoreFolders as it wasn't part of the old sorting comparison
-       (m_sortMethods[i].m_sortDescription.sortAttributes & ~SortAttributeIgnoreFolders) == (sortAttributes & ~SortAttributeIgnoreFolders))
+    if (m_sortMethods[i].m_sortDescription.sortBy == sortBy)
     {
       m_currentSortMethod = i;
       break;
@@ -330,7 +328,7 @@ void CGUIViewState::SetSortMethod(SortBy sortBy, SortAttribute sortAttributes /*
 
 void CGUIViewState::SetSortMethod(SortDescription sortDescription)
 {
-  return SetSortMethod(sortDescription.sortBy, sortDescription.sortAttributes);
+  return SetSortMethod(sortDescription.sortBy);
 }
 
 SortDescription CGUIViewState::SetNextSortMethod(int direction /* = 1 */)

--- a/xbmc/view/GUIViewState.h
+++ b/xbmc/view/GUIViewState.h
@@ -86,7 +86,7 @@ protected:
   void AddSortMethod(SortBy sortBy, int buttonLabel, const LABEL_MASKS &labelMasks, SortAttribute sortAttributes = SortAttributeNone);
   void AddSortMethod(SortBy sortBy, SortAttribute sortAttributes, int buttonLabel, const LABEL_MASKS &labelMasks);
   void AddSortMethod(SortDescription sortDescription, int buttonLabel, const LABEL_MASKS &labelMasks);
-  void SetSortMethod(SortBy sortBy, SortAttribute sortAttributes = SortAttributeNone);
+  void SetSortMethod(SortBy sortBy);
   void SetSortMethod(SortDescription sortDescription);
   void SetSortOrder(SortOrder sortOrder);
   const CFileItemList& m_items;


### PR DESCRIPTION
This fixes the builtin `Container.SetSortMethod()` (see http://trac.kodi.tv/ticket/15627). When I wrote the sorting refactor we switched from sort methods like `SORT_METHOD_TITLE_IGNORE_THE` to a combination of `SortByTitle` and `SortAttributesIgnoreArticle`. Therefore I changed all the logic in `CGUIViewState` to take a `SortBy` and a `SortAttributes` parameter.
But we don't always know the `SortAttributes` parameter (e.g. in the mentioned `Container.SetSortMethod()` builtin. Furthermore there's no case where we use the same `SortBy` value with different `SortAttributes` values in the same view. So knowing the `SortBy` value is enough to identify the sort method to be used.

This is broken since the sorting refactor so certainly also in Gotham. It could go into a Helix point release.
