### PR TITLE
woa - use profile path

### DIFF
--- a/xbmc/network/WakeOnAccess.cpp
+++ b/xbmc/network/WakeOnAccess.cpp
@@ -637,7 +637,7 @@ void CWakeOnAccess::OnJobComplete(unsigned int jobID, bool success, CJob *job)
 
 std::string CWakeOnAccess::GetSettingFile()
 {
-  return CSpecialProtocol::TranslatePath("special://masterprofile/wakeonlan.xml");
+  return CSpecialProtocol::TranslatePath("special://profile/wakeonlan.xml");
 }
 
 void CWakeOnAccess::OnSettingsLoaded()


### PR DESCRIPTION
I am not very familiar with profiles but believe it is better to use "profile"-folder for settings-storage and the current 'hard'-link to "masterprofile" is bad. 
