### PR TITLE
FIX: [aml;pivos] Fix 1080 on MX

### DIFF
--- a/xbmc/android/activity/XBMCApp.cpp
+++ b/xbmc/android/activity/XBMCApp.cpp
@@ -116,6 +116,12 @@ CXBMCApp::~CXBMCApp()
 void CXBMCApp::onStart()
 {
   android_printf("%s: ", __PRETTY_FUNCTION__);
+
+  // non-aml boxes will ignore this intent broadcast.
+  // setup aml scalers to play video as is, unscaled.
+  CJNIIntent intent_aml_video_on = CJNIIntent("android.intent.action.REALVIDEO_ON");
+  sendBroadcast(intent_aml_video_on);
+
   if (!m_firstrun)
   {
     android_printf("%s: Already running, ignoring request to start", __PRETTY_FUNCTION__);
@@ -150,6 +156,10 @@ void CXBMCApp::onPause()
   SetSystemVolume(m_initialVolume);
 
   unregisterReceiver(*this);
+
+  // non-aml boxes will ignore this intent broadcast.
+  CJNIIntent intent_aml_video_off = CJNIIntent("android.intent.action.REALVIDEO_OFF");
+  sendBroadcast(intent_aml_video_off);
 }
 
 void CXBMCApp::onStop()

--- a/xbmc/windowing/egl/EGLNativeTypeAmlogic.h
+++ b/xbmc/windowing/egl/EGLNativeTypeAmlogic.h
@@ -49,6 +49,7 @@ public:
 
 protected:
   bool SetDisplayResolution(const char *resolution);
+  void SetupVideoScaling(const char *mode);
   void EnableFreeScale();
   void DisableFreeScale();
 


### PR DESCRIPTION
From Pivos.
Ref: http://forum.kodi.tv/showthread.php?tid=211227&pid=1866798#pid1866798

This solves issues on amlogic where video is not fullscreen when fb size is different than hdmi size, e.g. fb 720p on HDMI 1080p on MX.
This require the standard amlogic "com.aml.settings" package to be enabled in firmware.
