### PR TITLE
[art] fix missing container art for album paths

### DIFF
--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -1102,13 +1102,12 @@ bool CGUIWindowMusicBase::GetDirectory(const std::string &strDirectory, CFileIte
   CQueryParams params;
   map<string, string> art;
   CDirectoryNode::GetDatabaseInfo(items.GetPath(), params);
-  if (m_musicdatabase.GetArtForItem(params.GetArtistId(), MediaTypeArtist, art));
-  {
-    // set container art
+
+  if (params.GetAlbumId() && m_musicdatabase.GetArtistArtForItem(params.GetAlbumId(), MediaTypeAlbum, art))
+    items.AppendArt(art, MediaTypeAlbum);
+
+  if (params.GetArtistId() && m_musicdatabase.GetArtForItem(params.GetArtistId(), MediaTypeArtist, art));
     items.AppendArt(art, MediaTypeArtist);
-    items.SetArtFallback("fanart", "artist.fanart");
-    items.SetArtFallback("fanart", "albumartist.fanart");
-  }
 
   // add in the "New Playlist" item if we're in the playlists folder
   if ((items.GetPath() == "special://musicplaylists/") && !items.Contains("newplaylist://"))


### PR DESCRIPTION
Adds missing Container.Art() on album nodes.

@BigNoid, @ronie for testing please.
