### PR TITLE
CFile::Open: don't use buffered io for VFS with ChunkSize == 1

### DIFF
--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -298,7 +298,7 @@ bool CFile::Open(const CURL& file, const unsigned int flags)
       return false;
     }
 
-    if (m_pFile->GetChunkSize() && !(m_flags & READ_CHUNKED))
+    if (m_pFile->GetChunkSize() > 1 && !(m_flags & READ_CHUNKED))
     {
       m_pBuffer = new CFileStreamBuffer(0);
       m_pBuffer->Attach(m_pFile);


### PR DESCRIPTION
Helix Version of: https://github.com/xbmc/xbmc/pull/5947
