### PR TITLE
addons: fix <extension> XSDs

### DIFF
--- a/addons/xbmc.addon/metadata.xsd
+++ b/addons/xbmc.addon/metadata.xsd
@@ -41,7 +41,6 @@
       <xs:enumeration value="osx64"/>
       <xs:enumeration value="osx32"/>
       <xs:enumeration value="ios"/>
-      <xs:enumeration value="wingl"/>
       <xs:enumeration value="windx"/>
       <xs:enumeration value="android"/>
     </xs:restriction>

--- a/addons/xbmc.addon/repository.xsd
+++ b/addons/xbmc.addon/repository.xsd
@@ -3,19 +3,43 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <xs:element name="extension">
     <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="repositorydirectory">
+          <xs:sequence>
+            <xs:element name="dir" type="repositorydirectory" minOccurs="1" maxOccurs="unbounded"/>
+          </xs:sequence>
+          <xs:attribute name="point" type="xs:string" use="required"/>
+          <xs:attribute name="id" type="simpleIdentifier"/>
+          <xs:attribute name="name" type="xs:string"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:complexType name="repositorydirectory">
+    <xs:sequence>
       <xs:element name="info">
         <xs:complexType>
-          <xs:attribute name="compressed" type="xs:boolean"/>
+          <xs:simpleContent>
+            <xs:extension base="xs:string">
+              <xs:attribute name="compressed" type="xs:boolean"/>
+            </xs:extension>
+          </xs:simpleContent>
         </xs:complexType>
       </xs:element>
       <xs:element name="checksum" type="xs:string"/>
       <xs:element name="datadir">
         <xs:complexType>
-          <xs:attribute name="zip" type="xs:boolean"/>
+          <xs:simpleContent>
+            <xs:extension base="xs:string">
+              <xs:attribute name="zip" type="xs:boolean"/>
+            </xs:extension>
+          </xs:simpleContent>
         </xs:complexType>
       </xs:element>
-    </xs:complexType>
-  </xs:element>
+      <xs:element name="hashes" type="xs:boolean"/>
+    </xs:sequence>
+    <xs:attribute name="minversion" type="xs:string"/>
+  </xs:complexType>
   <xs:simpleType name="simpleIdentifier">
     <xs:restriction base="xs:string">
       <xs:pattern value="[^.]+"/>

--- a/addons/xbmc.gui/skin.xsd
+++ b/addons/xbmc.gui/skin.xsd
@@ -17,7 +17,7 @@
       <xs:attribute name="point" type="xs:string" use="required"/>
       <xs:attribute name="id" type="simpleIdentifier"/>
       <xs:attribute name="name" type="xs:string"/>
-      <xs:attribute name="defaultresolution" type="xs:string" use="required"/>
+      <xs:attribute name="defaultresolution" type="xs:string"/>
       <xs:attribute name="defaultwideresolution" type="xs:string"/>
       <xs:attribute name="effectslowdown" type="xs:float"/>
       <xs:attribute name="debugging" type="xs:boolean"/>

--- a/addons/xbmc.gui/skin.xsd
+++ b/addons/xbmc.gui/skin.xsd
@@ -3,6 +3,17 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <xs:element name="extension">
     <xs:complexType>
+      <xs:sequence>
+        <xs:element name="res" minOccurs="0" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:attribute name="width" type="xs:unsignedInt" use="required"/>
+            <xs:attribute name="height" type="xs:unsignedInt" use="required"/>
+            <xs:attribute name="default" type="xs:boolean"/>
+            <xs:attribute name="folder" type="xs:string"/>
+            <xs:attribute name="aspect" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
       <xs:attribute name="point" type="xs:string" use="required"/>
       <xs:attribute name="id" type="simpleIdentifier"/>
       <xs:attribute name="name" type="xs:string"/>

--- a/addons/xbmc.gui/skin.xsd
+++ b/addons/xbmc.gui/skin.xsd
@@ -18,7 +18,7 @@
       <xs:attribute name="id" type="simpleIdentifier"/>
       <xs:attribute name="name" type="xs:string"/>
       <xs:attribute name="defaultresolution" type="xs:string" use="required"/>
-      <xs:attribute name="defaultresolutionwide" type="xs:string" use="required"/>
+      <xs:attribute name="defaultwideresolution" type="xs:string"/>
       <xs:attribute name="effectslowdown" type="xs:float"/>
       <xs:attribute name="debugging" type="xs:boolean"/>
     </xs:complexType>

--- a/addons/xbmc.gui/skin.xsd
+++ b/addons/xbmc.gui/skin.xsd
@@ -19,7 +19,6 @@
       <xs:attribute name="name" type="xs:string"/>
       <xs:attribute name="defaultresolution" type="xs:string" use="required"/>
       <xs:attribute name="defaultresolutionwide" type="xs:string" use="required"/>
-      <xs:attribute name="defaultthemename" type="xs:string" use="required"/>
       <xs:attribute name="effectslowdown" type="xs:float"/>
       <xs:attribute name="debugging" type="xs:boolean"/>
     </xs:complexType>

--- a/addons/xbmc.metadata/scraper.xsd
+++ b/addons/xbmc.metadata/scraper.xsd
@@ -9,6 +9,7 @@
       <xs:attribute name="library" type="xs:string"/>
       <xs:attribute name="language" type="xs:string"/>
       <xs:attribute name="requiressetting" type="xs:boolean"/>
+      <xs:attribute name="cachepersistence" type="xs:string"/>
     </xs:complexType>
   </xs:element>
   <xs:simpleType name="simpleIdentifier">

--- a/addons/xbmc.python/pluginsource.xsd
+++ b/addons/xbmc.python/pluginsource.xsd
@@ -3,7 +3,9 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <xs:element name="extension">
     <xs:complexType>
-      <xs:element name="provides" type="providesList"/>
+      <xs:sequence>
+        <xs:element name="provides" type="providesList"/>
+      </xs:sequence>
       <xs:attribute name="point" type="xs:string" use="required"/>
       <xs:attribute name="id" type="simpleIdentifier"/>
       <xs:attribute name="name" type="xs:string"/>

--- a/addons/xbmc.python/pluginsource.xsd
+++ b/addons/xbmc.python/pluginsource.xsd
@@ -12,11 +12,6 @@
       <xs:attribute name="library" type="xs:string" use="required"/>
     </xs:complexType>
   </xs:element>
-  <xs:element name="content">
-    <xs:complexType>
-      <xs:attribute name="type" type="xs:string" use="required"/>
-    </xs:complexType>
-  </xs:element>
   <xs:simpleType name="simpleIdentifier">
     <xs:restriction base="xs:string">
       <xs:pattern value="[^.]+"/>

--- a/addons/xbmc.python/service.xsd
+++ b/addons/xbmc.python/service.xsd
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE schema PUBLIC "-//W3C//DTD XMLSCHEMA 200102//EN" "http://www.w3.org/2001/XMLSchema.dtd">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="extension">
+    <xs:complexType>
+      <xs:attribute name="point" type="xs:string" use="required"/>
+      <xs:attribute name="id" type="simpleIdentifier"/>
+      <xs:attribute name="name" type="xs:string"/>
+      <xs:attribute name="library" type="xs:string" use="required"/>
+      <xs:attribute name="start" type="xs:string"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:simpleType name="simpleIdentifier">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[^.]+"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>


### PR DESCRIPTION
I noticed that some of the XSDs describing the different addon types' `<extension>` tag are outdated, missing elements or are plain wrong. So I went through them and fixed them and brought them up to date with what the code expects and supports.
