### PR TITLE
show chapters in bookmark dialog

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -12759,7 +12759,12 @@ msgctxt "#25009"
 msgid "The menu of this Blu-ray is not supported"
 msgstr ""
 
-#empty strings from id 25010 to 29799
+#: xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
+msgctxt "#25010"
+msgid "Chapter %u"
+msgstr ""
+
+#empty strings from id 25011 to 29799
 #strings 29800 thru 29998 reserved strings used only in the default Project Mayhem III skin and not c++ code
 
 #: skin.confluence

--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -138,6 +138,15 @@ void CApplicationPlayer::GetChapterName(std::string& strChapterName)
     player->GetChapterName(strChapterName);
 }
 
+int64_t CApplicationPlayer::GetChapterPos(int chapterIdx)
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    return player->GetChapterPos(chapterIdx);
+
+  return -1;
+}
+
 bool CApplicationPlayer::HasAudio() const
 {
   boost::shared_ptr<IPlayer> player = GetInternal();

--- a/xbmc/ApplicationPlayer.h
+++ b/xbmc/ApplicationPlayer.h
@@ -95,6 +95,7 @@ public:
   int   GetChapterCount();
   int   GetChapter();  
   void  GetChapterName(std::string& strChapterName);
+  int64_t GetChapterPos(int chapterIdx=-1);
   void  GetDeinterlaceMethods(std::vector<int> &deinterlaceMethods);
   void  GetDeinterlaceModes(std::vector<int> &deinterlaceModes);
   void  GetGeneralInfo(std::string& strVideoInfo);

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -180,8 +180,8 @@ public:
   virtual int  GetChapterCount()                               { return 0; }
   virtual int  GetChapter()                                    { return -1; }
   virtual void GetChapterName(std::string& strChapterName)     { return; }
+  virtual int64_t GetChapterPos(int chapterIdx=-1)             { return 0; }
   virtual int  SeekChapter(int iChapter)                       { return -1; }
-//  virtual bool GetChapterInfo(int chapter, SChapterInfo &info) { return false; }
 
   virtual float GetActualFPS() { return 0.0f; };
   virtual void SeekTime(int64_t iTime = 0){};

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemux.h
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemux.h
@@ -277,6 +277,12 @@ public:
   virtual void GetChapterName(std::string& strChapterName) {}
 
   /*
+   * Get the position of a chapter
+   * \param chapterIdx -1 for current chapter, else a chapter index
+   */
+  virtual int64_t GetChapterPos(int chapterIdx=-1) { return 0; }
+
+  /*
    * Set the playspeed, if demuxer can handle different
    * speeds of playback
    */

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1400,7 +1400,7 @@ int CDVDDemuxFFmpeg::GetChapter()
 void CDVDDemuxFFmpeg::GetChapterName(std::string& strChapterName)
 {
   CDVDInputStream::IChapter* ich = dynamic_cast<CDVDInputStream::IChapter*>(m_pInput);
-  if(ich)  
+  if(ich)
     ich->GetChapterName(strChapterName);
   else
   {
@@ -1413,6 +1413,20 @@ void CDVDDemuxFFmpeg::GetChapterName(std::string& strChapterName)
     if (titleTag)
       strChapterName = titleTag->value;
   }
+}
+
+int64_t CDVDDemuxFFmpeg::GetChapterPos(int chapterIdx)
+{
+  if (chapterIdx <= 0 || chapterIdx > GetChapterCount())
+    chapterIdx = GetChapter();
+  if(chapterIdx <= 0)
+    return 0;
+
+  CDVDInputStream::IChapter* ich = dynamic_cast<CDVDInputStream::IChapter*>(m_pInput);
+  if(ich)  
+    return ich->GetChapterPos(chapterIdx);
+
+  return m_pFormatContext->chapters[chapterIdx-1]->start*av_q2d(m_pFormatContext->chapters[chapterIdx-1]->time_base);
 }
 
 bool CDVDDemuxFFmpeg::SeekChapter(int chapter, double* startpts)

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.h
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.h
@@ -111,6 +111,7 @@ public:
   int GetChapterCount();
   int GetChapter();
   void GetChapterName(std::string& strChapterName);
+  int64_t GetChapterPos(int chapterIdx=-1);
   virtual void GetStreamCodecName(int iStreamId, std::string &strName);
 
   bool Aborted();

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStream.h
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStream.h
@@ -102,6 +102,7 @@ public:
     virtual int  GetChapter() = 0;
     virtual int  GetChapterCount() = 0;
     virtual void GetChapterName(std::string& name) = 0;
+    virtual int64_t GetChapterPos(int ch=-1) = 0;
     virtual bool SeekChapter(int ch) = 0;
   };
 

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -558,7 +558,7 @@ void CDVDInputStreamBluray::ProcessEvent() {
     m_player->OnDVDNavResult((void*) &pid, 3);
     break;
 
-#if (BLURAY_VERSION >= BLURAY_VERSION_CODE(0,2,2))
+#if (BLURAY_VERSION > BLURAY_VERSION_CODE(0,2,2))
   case BD_EVENT_MENU:
     CLog::Log(LOGDEBUG, "CDVDInputStreamBluray - BD_EVENT_MENU %d",
         m_event.param);
@@ -927,6 +927,14 @@ bool CDVDInputStreamBluray::SeekChapter(int ch)
     return false;
   else
     return true;
+}
+
+int64_t CDVDInputStreamBluray::GetChapterPos(int ch)
+{
+  if (ch == -1 || ch > GetChapterCount())
+    ch = GetChapter();
+
+  return m_title->chapters[ch-1].start;
 }
 
 int64_t CDVDInputStreamBluray::Seek(int64_t offset, int whence)

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.h
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.h
@@ -97,6 +97,7 @@ public:
   int GetChapter();
   int GetChapterCount();
   void GetChapterName(std::string& name) {};
+  int64_t GetChapterPos(int ch);
   bool SeekChapter(int ch);
 
   int GetTotalTime();

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -1455,3 +1455,18 @@ bool CDVDInputStreamNavigator::GetDVDSerialString(std::string& serialStr)
   serialStr.assign(str);
   return true;
 }
+
+int64_t CDVDInputStreamNavigator::GetChapterPos(int ch)
+{
+  if (ch == -1 || ch > GetChapterCount())
+    ch = GetChapter();
+
+  uint64_t* times, duration;
+
+  m_dll.dvdnav_describe_title_chapters(m_dvdnav, m_iTitle, &times, &duration);
+
+  int64_t result = ch==1?0.0:times[ch-2]/90000;
+  free(times);
+
+  return result;
+}

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.h
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.h
@@ -128,6 +128,7 @@ public:
   int GetChapter()      { return m_iPart; }      // the current part in the current title
   int GetChapterCount() { return m_iPartCount; } // the number of parts in the current title
   void GetChapterName(std::string& name) {};
+  int64_t GetChapterPos(int ch=-1);
   bool SeekChapter(int iChapter);
 
   int GetTotalTime(); // the total time in milli seconds

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DllDvdNav.h
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DllDvdNav.h
@@ -106,6 +106,7 @@ public:
   virtual dvdnav_status_t dvdnav_mouse_select(dvdnav_t *self, pci_t *pci, int32_t x, int32_t y)=0;
   virtual dvdnav_status_t dvdnav_get_title_string(dvdnav_t *self, const char **title_str)=0;
   virtual dvdnav_status_t dvdnav_get_serial_string(dvdnav_t *self, const char **serial_str)=0;
+  virtual uint32_t dvdnav_describe_title_chapters(dvdnav_t* self, uint32_t title, uint64_t** times, uint64_t* duration)=0;
 };
 
 #if (defined USE_STATIC_LIBDVDNAV)
@@ -231,6 +232,8 @@ public:
         { return ::dvdnav_get_title_string(self, title_str); }
     virtual dvdnav_status_t dvdnav_get_serial_string(dvdnav_t *self, const char **serial_str)
         { return ::dvdnav_get_serial_string(self, serial_str); }
+    virtual uint32_t dvdnav_describe_title_chapters(dvdnav_t* self, uint32_t title, uint64_t** times, uint64_t* duration)
+        { return ::dvdnav_describe_title_chapters(self, title, times, duration); }
 
     // DLL faking.
     virtual bool ResolveExports() { return true; }
@@ -303,6 +306,7 @@ class DllDvdNav : public DllDynamic, DllDvdNavInterface
   DEFINE_METHOD4(dvdnav_status_t, dvdnav_mouse_select, (dvdnav_t *p1, pci_t *p2, int32_t p3, int32_t p4))
   DEFINE_METHOD2(dvdnav_status_t, dvdnav_get_title_string, (dvdnav_t *p1, const char **p2))
   DEFINE_METHOD2(dvdnav_status_t, dvdnav_get_serial_string, (dvdnav_t *p1, const char **p2))
+  DEFINE_METHOD4(uint32_t, dvdnav_describe_title_chapters, (dvdnav_t* p1, uint32_t p2, uint64_t** p3, uint64_t* p4))
   BEGIN_METHOD_RESOLVE()
     RESOLVE_METHOD(dvdnav_open)
     RESOLVE_METHOD(dvdnav_close)
@@ -363,6 +367,7 @@ class DllDvdNav : public DllDynamic, DllDvdNavInterface
     RESOLVE_METHOD(dvdnav_mouse_select)
     RESOLVE_METHOD(dvdnav_get_title_string)
     RESOLVE_METHOD(dvdnav_get_serial_string)
+    RESOLVE_METHOD(dvdnav_describe_title_chapters)
 END_METHOD_RESOLVE()
 };
 

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -3989,6 +3989,15 @@ int CDVDPlayer::SeekChapter(int iChapter)
   return 0;
 }
 
+int64_t CDVDPlayer::GetChapterPos(int chapterIdx)
+{
+  CSingleLock lock(m_StateSection);
+  if (m_pDemuxer)
+    return m_pDemuxer->GetChapterPos(chapterIdx);
+
+  return -1;
+}
+
 int CDVDPlayer::AddSubtitle(const std::string& strSubPath)
 {
   return AddSubtitleFile(strSubPath);

--- a/xbmc/cores/dvdplayer/DVDPlayer.h
+++ b/xbmc/cores/dvdplayer/DVDPlayer.h
@@ -265,6 +265,7 @@ public:
   virtual int  GetChapterCount();
   virtual int  GetChapter();
   virtual void GetChapterName(std::string& strChapterName);
+  virtual int64_t GetChapterPos(int chapterIdx=-1);
   virtual int  SeekChapter(int iChapter);
 
   virtual void SeekTime(int64_t iTime);


### PR DESCRIPTION
This is a stripped down port of @notspiff chapter menu. Removed:
- Thumbs. It's too buggy and extremely slow in its current state. 
- Chapter names. On every file/dvd I could find, chapter name was the time of the chapter (i.e it shows two timestamps in GUI). Changed it to using generic "Chapter i" until a better solution can be found.

I'd prefer this to be done properly in a new window/menu as a simple list, but until somebody does that, this is a working alternative.
