### PR TITLE
AESinkPULSE: Use const ref when finding the channel map

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
@@ -319,7 +319,7 @@ static pa_channel_position_t AEChannelToPAChannel(AEChannel ae_channel)
   return pa_channel;
 }
 
-static pa_channel_map AEChannelMapToPAChannel(CAEChannelInfo info)
+static pa_channel_map AEChannelMapToPAChannel(const CAEChannelInfo& info)
 {
   pa_channel_map map;
   pa_channel_map_init(&map);


### PR DESCRIPTION
Fixes coverity issue. Not sure why it appeared after this scan ... but yeah can be a const ref.
