### PR TITLE
VAAPI: Enable VC1 by default - not much interlaced content there

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -719,7 +719,7 @@
             <dependency type="visible" on="property" name="codecoptionvisible" setting="videoplayer.usevaapivc1" operator="is">true</dependency>
           </dependencies>
           <level>3</level>
-          <default>false</default>
+          <default>true</default>
           <control type="toggle" />
         </setting>
         <setting id="videoplayer.prefervaapirender" type="boolean" parent="videoplayer.usevaapi" label="13457" help="36433">


### PR DESCRIPTION
It always confuses users, cause VC-1 interlaced content is really rarely available. Newer intel drivers don't segfault anymore, but rather blacken the screen.
