### PR TITLE
videodb: avoid an empty entry in string arrays

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -3197,8 +3197,12 @@ void CVideoDatabase::GetDetailsFromDB(const dbiplus::sql_record* const record, i
       *(float*)(((char*)&details)+offsets[i].offset) = record->at(i+idxOffset).get_asFloat();
       break;
     case VIDEODB_TYPE_STRINGARRAY:
-      *(std::vector<std::string>*)(((char*)&details)+offsets[i].offset) = StringUtils::Split(record->at(i+idxOffset).get_asString(), g_advancedSettings.m_videoItemSeparator);
+    {
+      std::string value = record->at(i+idxOffset).get_asString();
+      if (!value.empty())
+        *(std::vector<std::string>*)(((char*)&details)+offsets[i].offset) = StringUtils::Split(value, g_advancedSettings.m_videoItemSeparator);
       break;
+    }
     case VIDEODB_TYPE_DATE:
       ((CDateTime*)(((char*)&details)+offsets[i].offset))->SetFromDBDate(record->at(i+idxOffset).get_asString());
       break;


### PR DESCRIPTION
When working on my media import stuff I noticed that we fill in `std::vector<std::string>` members of `CVideoInfoTag` with an empty string element instead of nothing if the value of the members is empty. So if we retrieve a movie without any genres the result will be that `CVideoInfoTag::m_genre` will contain a single empty string in the vector instead of simply being empty.

I've been using this since the very beginning of my media import work and haven't seen any fallout but it's very difficult to determine if something is relying on the vector not being empty.
