### PR TITLE
videodb: add update/cleanup logic for version 91 in case of duplicate actors

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -1425,13 +1425,18 @@ int CVideoDatabase::AddActor(const std::string& name, const std::string& thumbUR
     if (NULL == m_pDB.get()) return -1;
     if (NULL == m_pDS.get()) return -1;
     int idActor = -1;
-    std::string strSQL=PrepareSQL("select actor_id from actor where name like '%s'", name.c_str());
+
+    // ATTENTION: the trimming of actor names should really not be done here but after the scraping / NFO-parsing
+    std::string trimmedName = name.c_str();
+    StringUtils::Trim(trimmedName);
+
+    std::string strSQL=PrepareSQL("select actor_id from actor where name = '%s'", trimmedName.c_str());
     m_pDS->query(strSQL.c_str());
     if (m_pDS->num_rows() == 0)
     {
       m_pDS->close();
       // doesnt exists, add it
-      strSQL=PrepareSQL("insert into actor (actor_id, name, art_urls) values( NULL, '%s','%s')", name.c_str(),thumbURLs.c_str());
+      strSQL=PrepareSQL("insert into actor (actor_id, name, art_urls) values(NULL, '%s', '%s')", trimmedName.c_str(), thumbURLs.c_str());
       m_pDS->exec(strSQL.c_str());
       idActor = (int)m_pDS->lastinsertid();
     }

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -4462,7 +4462,71 @@ void CVideoDatabase::UpdateTables(int iVersion)
     m_pDS->exec("DELETE from art WHERE media_type='season' AND NOT EXISTS (SELECT 1 FROM seasons WHERE seasons.idSeason = art.media_id)");
   }
   if (iVersion < 91)
-  { // create actor link table
+  {
+    // handle corrupted databases with multiple actors with the same name
+    std::map<std::string, std::vector<int> > duplicateActors;
+    m_pDS->query("SELECT TRIM(strActor) as strActor FROM actors GROUP BY TRIM(strActor) HAVING COUNT(1) > 1");
+    while (!m_pDS->eof())
+    {
+      std::string strActor = m_pDS->fv(0).get_asString();
+      std::vector<int> ids;
+
+      m_pDS2->query(PrepareSQL("SELECT idActor FROM actors WHERE TRIM(strActor) = '%s' ORDER BY strThumb DESC", strActor.c_str()));
+      while (!m_pDS2->eof())
+      {
+        ids.push_back(m_pDS2->fv(0).get_asInt());
+        m_pDS2->next();
+      }
+      m_pDS2->close();
+
+      duplicateActors.insert(std::make_pair(strActor, ids));
+
+      m_pDS->next();
+    }
+    m_pDS->close();
+
+    // now go through all duplicate actors and adjust all link tables to use the first actor entry
+    for (std::map<std::string, std::vector<int> >::const_iterator actor = duplicateActors.begin(); actor != duplicateActors.end(); ++actor)
+    {
+      // we are only interested in duplicate actors
+      if (actor->second.size() < 2)
+        continue;
+
+      int newActorId = *actor->second.begin();
+
+      // cleanup all duplicate actor references in the link tables
+      CleanupActorLinkTablePre91("actorlinkmovie", "idActor", "idMovie", newActorId, actor->first);
+      CleanupActorLinkTablePre91("actorlinktvshow", "idActor", "idShow", newActorId, actor->first);
+      CleanupActorLinkTablePre91("actorlinkepisode", "idActor", "idEpisode", newActorId, actor->first);
+      CleanupActorLinkTablePre91("directorlinkmovie", "idDirector", "idMovie", newActorId, actor->first);
+      CleanupActorLinkTablePre91("directorlinktvshow", "idDirector", "idShow", newActorId, actor->first);
+      CleanupActorLinkTablePre91("directorlinkepisode", "idDirector", "idEpisode", newActorId, actor->first);
+      CleanupActorLinkTablePre91("directorlinkmusicvideo", "idDirector", "idMVideo", newActorId, actor->first);
+      CleanupActorLinkTablePre91("writerlinkmovie", "idWriter", "idMovie", newActorId, actor->first);
+      CleanupActorLinkTablePre91("writerlinkepisode", "idWriter", "idEpisode", newActorId, actor->first);
+      CleanupActorLinkTablePre91("artistlinkmusicvideo", "idArtist", "idMVideo", newActorId, actor->first);
+
+      for (std::vector<int>::const_iterator actorId = actor->second.begin() + 1; actorId != actor->second.end(); ++actorId)
+      {
+        // update all the link tables refering to the actors table
+        m_pDS->exec(PrepareSQL("UPDATE actorlinkmovie SET idActor = %d WHERE idActor = %d", newActorId, *actorId));
+        m_pDS->exec(PrepareSQL("UPDATE actorlinktvshow SET idActor = %d WHERE idActor = %d", newActorId, *actorId));
+        m_pDS->exec(PrepareSQL("UPDATE actorlinkepisode SET idActor = %d WHERE idActor = %d", newActorId, *actorId));
+        m_pDS->exec(PrepareSQL("UPDATE directorlinkmovie SET idDirector = %d WHERE idDirector = %d", newActorId, *actorId));
+        m_pDS->exec(PrepareSQL("UPDATE directorlinktvshow SET idDirector = %d WHERE idDirector = %d", newActorId, *actorId));
+        m_pDS->exec(PrepareSQL("UPDATE directorlinkepisode SET idDirector = %d WHERE idDirector = %d", newActorId, *actorId));
+        m_pDS->exec(PrepareSQL("UPDATE directorlinkmusicvideo SET idDirector = %d WHERE idDirector = %d", newActorId, *actorId));
+        m_pDS->exec(PrepareSQL("UPDATE writerlinkmovie SET idWriter = %d WHERE idWriter = %d", newActorId, *actorId));
+        m_pDS->exec(PrepareSQL("UPDATE writerlinkepisode SET idWriter = %d WHERE idWriter = %d", newActorId, *actorId));
+        m_pDS->exec(PrepareSQL("UPDATE artistlinkmusicvideo SET idArtist = %d WHERE idArtist = %d", newActorId, *actorId));
+
+        // remove the duplicate entry from the actors table
+        m_pDS->exec(PrepareSQL("DELETE FROM actors WHERE idActor = %d", *actorId));
+      }
+    }
+    m_pDS->exec("UPDATE actors set strActor = TRIM(strActor)");
+
+    // create actor link table
     m_pDS->exec("CREATE TABLE actor_link(actor_id INT, media_id INT, media_type TEXT, role TEXT, cast_order INT)");
     m_pDS->exec("INSERT INTO actor_link(actor_id, media_id, media_type, role, cast_order) SELECT idActor,idMovie,'movie',strRole,iOrder from actorlinkmovie");
     m_pDS->exec("INSERT INTO actor_link(actor_id, media_id, media_type, role, cast_order) SELECT idActor,idShow,'tvshow',strRole,iOrder from actorlinktvshow");
@@ -4545,6 +4609,37 @@ void CVideoDatabase::UpdateTables(int iVersion)
 int CVideoDatabase::GetSchemaVersion() const
 {
   return 91;
+}
+
+void CVideoDatabase::CleanupActorLinkTablePre91(const std::string &linkTable, const std::string &linkTableIdActor, const std::string &linkTableIdMedia, int idActor, const std::string &strActor)
+{
+  if (linkTable.empty() || linkTableIdActor.empty() || linkTableIdMedia.empty() ||
+    idActor <= 0 || strActor.empty())
+    return;
+
+  // get all duplicate actors linked to the same media item
+  m_pDS->query(PrepareSQL("SELECT actors.idActor, l1.%s FROM actors "
+    "JOIN %s AS l1 ON "
+    "  l1.%s = actors.idActor "
+    "JOIN %s AS l2 ON "
+    "  l2.%s = l1.%s "
+    "WHERE TRIM(actors.strActor) = '%s' AND l1.%s != %d AND l2.%s = %d",
+    linkTableIdMedia.c_str(),
+    linkTable.c_str(), linkTableIdActor.c_str(),
+    linkTable.c_str(), linkTableIdMedia.c_str(), linkTableIdMedia.c_str(),
+    strActor.c_str(), linkTableIdActor.c_str(), idActor, linkTableIdActor.c_str(), idActor));
+
+  // and delete the duplicates
+  while (!m_pDS->eof())
+  {
+    int idActor = m_pDS->fv(0).get_asInt();
+    int idLink = m_pDS->fv(1).get_asInt();
+    m_pDS2->exec(PrepareSQL("DELETE FROM %s WHERE %s = %d AND %s = %d",
+      linkTable.c_str(), linkTableIdMedia.c_str(), idLink, linkTableIdActor.c_str(), idActor));
+
+    m_pDS->next();
+  }
+  m_pDS->close();
 }
 
 bool CVideoDatabase::LookupByFolders(const std::string &path, bool shows)

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -870,6 +870,8 @@ private:
   virtual int GetExportVersion() const { return 1; };
   const char *GetBaseDBName() const { return "MyVideos"; };
 
+  void CleanupActorLinkTablePre91(const std::string &linkTable, const std::string &linkTableIdActor, const std::string &linkTableIdMedia, int idActor, const std::string &strActor);
+
   void ConstructPath(std::string& strDest, const std::string& strPath, const std::string& strFileName);
   void SplitPath(const std::string& strFileNameAndPath, std::string& strPath, std::string& strFileName);
   void InvalidatePathHash(const std::string& strPath);


### PR DESCRIPTION
This is a fix for the videodb update procedure introduced in #5653. There seem to be videodb's out there with multiple entries in the `actors` table that have the exact same name. I have no idea how that is possible because our code basically prevents that. A possibility would be an external tool that writes directly into our database (@MilhouseVH: any chance you are or have been using such a tool?).

I tested this with manually messing up my database and then updating from version 90 to 91 and it worked fine. But it's terribly slow (several seconds on my i7 with SQLite) because the `actors` table is so huge. So this will significantly slow down first start after upgrading from Helix to I***\* for every user.

The question is whether we should/need to do the same thing for the `country`, `genre`, `studio` and `tag` tables.

And I hope MySQL is not too stupid to handle that SQL query to retrieve all duplicate actors.
