### PR TITLE
Remove string initialization

### DIFF
--- a/xbmc/android/jni/JNIBase.cpp
+++ b/xbmc/android/jni/JNIBase.cpp
@@ -29,7 +29,6 @@ CJNIBase::CJNIBase(std::string classname):
 }
 
 CJNIBase::CJNIBase(const jhobject &object):
-    m_className(""),
     m_object(object)
 {
   m_object.setGlobal();


### PR DESCRIPTION
We learned that strings are initialized to an empty string anyway. Therefore, initializing it explicitly doesn't really do anything other than waste time. 
