### PR TITLE
cppcheck performance fixes in dbwrappers/

### DIFF
--- a/xbmc/dbwrappers/DatabaseQuery.cpp
+++ b/xbmc/dbwrappers/DatabaseQuery.cpp
@@ -172,7 +172,7 @@ bool CDatabaseQueryRule::Save(TiXmlNode *parent) const
   rule.SetAttribute("field", TranslateField(m_field).c_str());
   rule.SetAttribute("operator", TranslateOperator(m_operator).c_str());
 
-  for (vector<std::string>::const_iterator it = m_parameter.begin(); it != m_parameter.end(); it++)
+  for (vector<std::string>::const_iterator it = m_parameter.begin(); it != m_parameter.end(); ++it)
   {
     TiXmlElement value("value");
     TiXmlText text(*it);
@@ -513,7 +513,7 @@ bool CDatabaseQueryRuleCombination::Save(CVariant &obj) const
   CVariant comboArray(CVariant::VariantTypeArray);
   if (!m_combinations.empty())
   {
-    for (CDatabaseQueryRuleCombinations::const_iterator combo = m_combinations.begin(); combo != m_combinations.end(); combo++)
+    for (CDatabaseQueryRuleCombinations::const_iterator combo = m_combinations.begin(); combo != m_combinations.end(); ++combo)
     {
       CVariant comboObj(CVariant::VariantTypeObject);
       if ((*combo)->Save(comboObj))
@@ -523,7 +523,7 @@ bool CDatabaseQueryRuleCombination::Save(CVariant &obj) const
   }
   if (!m_rules.empty())
   {
-    for (CDatabaseQueryRules::const_iterator rule = m_rules.begin(); rule != m_rules.end(); rule++)
+    for (CDatabaseQueryRules::const_iterator rule = m_rules.begin(); rule != m_rules.end(); ++rule)
     {
       CVariant ruleObj(CVariant::VariantTypeObject);
       if ((*rule)->Save(ruleObj))

--- a/xbmc/dbwrappers/dataset.cpp
+++ b/xbmc/dbwrappers/dataset.cpp
@@ -39,15 +39,16 @@ using namespace std;
 namespace dbiplus {
 //************* Database implementation ***************
 
-Database::Database() {
+Database::Database():
+  error(), //S_NO_CONNECTION,
+  host(),
+  port(),
+  db(),
+  login(),
+  passwd(),
+  sequence_table("db_sequence")
+{
   active = false;	// No connection yet
-  error = "";//S_NO_CONNECTION;
-  host = "";
-  port = "";
-  db = "";
-  login = "";
-  passwd = "";
-  sequence_table = "db_sequence";
 }
 
 Database::~Database() {
@@ -71,11 +72,9 @@ int Database::connectFull(const char *newHost, const char *newPort, const char *
 
 string Database::prepare(const char *format, ...)
 {
-  string result = "";
-
   va_list args;
   va_start(args, format);
-  result = vprepare(format, args);
+  string result = vprepare(format, args);
   va_end(args);
 
   return result;
@@ -83,15 +82,15 @@ string Database::prepare(const char *format, ...)
 
 //************* Dataset implementation ***************
 
-Dataset::Dataset() {
+Dataset::Dataset():
+  select_sql("")
+{
 
   db = NULL;
   haveError = active = false;
   frecno = 0;
   fbof = feof = true;
   autocommit = true;
-
-  select_sql = "";
 
   fields_object = new Fields();
 
@@ -100,15 +99,15 @@ Dataset::Dataset() {
 
 
 
-Dataset::Dataset(Database *newDb) {
+Dataset::Dataset(Database *newDb):
+  select_sql("")
+{
 
   db = newDb;
   haveError = active = false;
   frecno = 0;
   fbof = feof = true;
   autocommit = true;
-
-  select_sql = "";
 
   fields_object = new Fields();
 
@@ -514,8 +513,9 @@ for (unsigned int i=0; i < fields_object->size(); i++)
 
 //************* DbErrors implementation ***************
 
-DbErrors::DbErrors() {
-  msg_ = "Unknown Database Error";
+DbErrors::DbErrors():
+  msg_("Unknown Database Error")
+{
 }
 
 

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -1320,7 +1320,7 @@ void MysqlDataset::make_query(StringList &_sql) {
   {
     if (autocommit) db->start_transaction();
 
-    for (list<string>::iterator i =_sql.begin(); i!=_sql.end(); i++)
+    for (list<string>::iterator i =_sql.begin(); i!=_sql.end(); ++i)
     {
       query = *i;
       Dataset::parse_sql(query);

--- a/xbmc/dbwrappers/qry_dat.cpp
+++ b/xbmc/dbwrappers/qry_dat.cpp
@@ -46,14 +46,15 @@ using namespace std;
 namespace dbiplus {
 
 //Constructors 
-field_value::field_value(){
-  str_value = "";
+field_value::field_value()
+{
   field_type = ft_String;
   is_null = false;
-  }
+}
 
-field_value::field_value(const char *s) {
-  str_value = s;
+field_value::field_value(const char *s):
+  str_value(s)
+{
   field_type = ft_String;
   is_null = false;
 }
@@ -276,11 +277,10 @@ char field_value::get_asChar() const {
       return str_value[0];
     }
     case ft_Boolean:{
-      char c;
       if (bool_value) 
-	return c='T';
+	return 'T';
       else
-	return c='F';
+	return 'F';
     }
     case ft_Char: {
       return  char_value;

--- a/xbmc/dbwrappers/sqlitedataset.cpp
+++ b/xbmc/dbwrappers/sqlitedataset.cpp
@@ -491,7 +491,7 @@ void SqliteDataset::make_query(StringList &_sql) {
   if (autocommit) db->start_transaction();
 
 
-  for (list<string>::iterator i =_sql.begin(); i!=_sql.end(); i++) {
+  for (list<string>::iterator i =_sql.begin(); i!=_sql.end(); ++i) {
   query = *i;
   char* err=NULL; 
   Dataset::parse_sql(query);


### PR DESCRIPTION
This is another round of fixes for the files under dbwrappers/

I hope you are okay with me removing string initializations. But since strings do default to an empty string when not initialized, I assume that it's redundant to initialize them again.
