### PR TITLE
[Mediacodec] Fix media codec surface memory leak

### DIFF
--- a/xbmc/android/jni/SurfaceTexture.cpp
+++ b/xbmc/android/jni/SurfaceTexture.cpp
@@ -87,6 +87,11 @@ void CJNISurfaceTexture::updateTexImage()
     "updateTexImage", "()V");
 }
 
+void CJNISurfaceTexture::releaseTexImage()
+{
+  call_method<void>(m_object,
+    "releaseTexImage", "()V");
+}
 void CJNISurfaceTexture::detachFromGLContext()
 {
   call_method<void>(m_object,

--- a/xbmc/android/jni/SurfaceTexture.h
+++ b/xbmc/android/jni/SurfaceTexture.h
@@ -50,6 +50,7 @@ public:
   void    setOnFrameAvailableListener(const CJNISurfaceTextureOnFrameAvailableListener &listener);
   void    setDefaultBufferSize(int width, int height);
   void    updateTexImage();
+  void    releaseTexImage();
   void    detachFromGLContext();
   void    attachToGLContext(int texName);
   void    getTransformMatrix(float* mtx); // mtx MUST BE a preallocated 4x4 float array

--- a/xbmc/cores/VideoRenderers/BaseRenderer.h
+++ b/xbmc/cores/VideoRenderers/BaseRenderer.h
@@ -85,6 +85,7 @@ public:
 
   virtual bool AddVideoPicture(DVDVideoPicture* picture, int index) { return false; }
   virtual void Flush() {};
+  virtual void releaseTexImage() {};
 
   /**
    * Returns number of references a single buffer can retain when rendering a single frame

--- a/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
@@ -916,6 +916,12 @@ void CLinuxRendererGLES::UnInit()
   m_RenderFeaturesCallBackCtx = NULL;
 }
 
+void CLinuxRendererGLES::releaseTexImage()
+{
+  CLog::Log(LOGDEBUG, "CLinuxRendererGLES::releaseTexImage");
+  ReleaseBuffer_1(0);
+  ReleaseBuffer_1(1);
+}
 inline void CLinuxRendererGLES::ReorderDrawPoints()
 {
 
@@ -953,7 +959,7 @@ void CLinuxRendererGLES::ReleaseBuffer(int idx)
       // The media buffer has been queued to the SurfaceView but we didn't render it
       // We have to do to the updateTexImage or it will get stuck
       buf.mediacodec->UpdateTexImage();
-      SAFE_RELEASE(buf.mediacodec);
+      //SAFE_RELEASE(buf.mediacodec);
     }
   }
 #endif
@@ -967,6 +973,18 @@ void CLinuxRendererGLES::ReleaseBuffer(int idx)
     }
   }
 #endif
+}
+void CLinuxRendererGLES::ReleaseBuffer_1(int idx)
+{
+  YUVBUFFER &buf = m_buffers[idx];
+  if ( m_renderMethod & RENDER_MEDIACODEC )
+  {
+    if (buf.mediacodec)
+    {
+      buf.mediacodec->releaseTexImage();
+      SAFE_RELEASE(buf.mediacodec);
+    }
+  }
 }
 
 void CLinuxRendererGLES::Render(DWORD flags, int index)
@@ -2610,7 +2628,7 @@ void CLinuxRendererGLES::UploadSurfaceTexture(int index)
     buf.fields[0][0].id = buf.mediacodec->GetTextureID();
     buf.mediacodec->UpdateTexImage();
     buf.mediacodec->GetTransformMatrix(m_textureMatrix);
-    SAFE_RELEASE(buf.mediacodec);
+    //SAFE_RELEASE(buf.mediacodec);
   }
 
   CalculateTextureSourceRects(index, 1);

--- a/xbmc/cores/VideoRenderers/LinuxRendererGLES.h
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGLES.h
@@ -137,10 +137,12 @@ public:
   virtual void         FlipPage(int source);
   virtual unsigned int PreInit();
   virtual void         UnInit();
+  virtual void         releaseTexImage();
   virtual void         Reset(); /* resets renderer after seek for example */
   virtual void         Flush();
   virtual void         ReorderDrawPoints();
   virtual void         ReleaseBuffer(int idx);
+  virtual void         ReleaseBuffer_1(int idx);
   virtual void         SetBufferSize(int numBuffers) { m_NumYV12Buffers = numBuffers; }
   virtual unsigned int GetMaxBufferSize() { return NUM_BUFFERS; }
   virtual unsigned int GetOptimalBufferSize();

--- a/xbmc/cores/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoRenderers/RenderManager.cpp
@@ -458,6 +458,14 @@ void CXBMCRenderManager::UnInit()
     m_pRenderer->UnInit();
 }
 
+void CXBMCRenderManager::releaseTexImage()
+{
+#if defined(TARGET_ANDROID)
+  if (m_pRenderer)
+    m_pRenderer->releaseTexImage();
+#endif
+}
+
 bool CXBMCRenderManager::Flush()
 {
   if (!m_pRenderer)

--- a/xbmc/cores/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoRenderers/RenderManager.h
@@ -105,6 +105,7 @@ public:
   void FlipPage(volatile bool& bStop, double timestamp = 0.0, int source = -1, EFIELDSYNC sync = FS_NONE);
   unsigned int PreInit();
   void UnInit();
+  void releaseTexImage();
   bool Flush();
 
   void AddOverlay(CDVDOverlay* o, double pts)

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
@@ -66,7 +66,7 @@ public:
   int                 GetTextureID() const;
   void                GetTransformMatrix(float *textureMatrix);
   void                UpdateTexImage();
-
+  void                releaseTexImage();
 private:
   // private because we are reference counted
   virtual            ~CDVDMediaCodecInfo();

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -624,6 +624,9 @@ bool CDVDPlayer::CloseFile(bool reopen)
 
   // set the abort request so that other threads can finish up
   m_bAbortRequest = true;
+#if defined(HAS_VIDEO_PLAYBACK)
+  g_renderManager.releaseTexImage();
+#endif
 
   // tell demuxer to abort
   if(m_pDemuxer)


### PR DESCRIPTION
I use Amlogic platform. When I increase ION buffer，It can play use mediacodec. But I found the problem of memory leak. when play video it has 6 buffers, but after played it has one buffer not released. Every play video it always has more one buffer not released.  So when I play some times, the log show out of memory.
This patch fixed this problem.
