### PR TITLE
fix GUISpinControl process

### DIFF
--- a/xbmc/guilib/GUISpinControl.cpp
+++ b/xbmc/guilib/GUISpinControl.cpp
@@ -438,6 +438,7 @@ void CGUISpinControl::Process(unsigned int currentTime, CDirtyRegionList &dirtyr
   changed |= m_imgspinDown.Process(currentTime);
   changed |= m_imgspinUp.Process(currentTime);
   changed |= m_imgspinUpFocus.Process(currentTime);
+  changed |= m_label.Process(currentTime);
 
   if (changed)
     MarkDirtyRegion();


### PR DESCRIPTION
- Call Process methos on m_label too
- Now label is scrolling if need (e.g. when audio stream name is too long in audio osd settings window) 
