### PR TITLE
dvdplayer: drop silly setting sync to audio when video reference clock i...

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -6339,27 +6339,7 @@ msgctxt "#13459"
 msgid "Use OMXPlayer for decoding of video files."
 msgstr ""
 
-#empty strings from id 13460 to 13499
-
-#: system/settings/settings.xml
-msgctxt "#13500"
-msgid "A/V sync method"
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#13501"
-msgid "Audio clock"
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#13502"
-msgid "Video clock (Drop/Dupe audio)"
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#13503"
-msgid "Video clock (Resample audio)"
-msgstr ""
+#empty strings from id 13460 to 13503
 
 #: system/settings/settings.xml
 msgctxt "#13504"
@@ -14115,11 +14095,7 @@ msgctxt "#36166"
 msgid "Synchronise the video to the refresh rate of the monitor."
 msgstr ""
 
-#. Description of setting "Videos -> Playback -> A/V sync method" with label #13500
-#: system/settings/settings.xml
-msgctxt "#36167"
-msgid "Audio has to stay in sync, this can either be done by resampling, skipping/duplicating packets, or adjusting the clock if it gets out of sync too far."
-msgstr ""
+#empty string with id 36167
 
 #. Description of setting "Videos -> Playback -> Maximum speedup/slowdown amount (%)" with label #13504
 #: system/settings/settings.xml

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -428,21 +428,6 @@
           <default>false</default>
           <control type="toggle" />
         </setting>
-        <setting id="videoplayer.synctype" type="integer" parent="videoplayer.usedisplayasclock" label="13500" help="36167">
-          <level>2</level>
-          <default>2</default> <!-- SYNC_RESAMPLE -->
-          <constraints>
-            <options>
-              <option label="13501">0</option> <!-- SYNC_DISCON -->
-              <option label="13502">1</option> <!-- SYNC_SKIPDUP -->
-              <option label="13503">2</option> <!-- SYNC_RESAMPLE -->
-            </options>
-          </constraints>
-          <dependencies>
-            <dependency type="enable" setting="videoplayer.usedisplayasclock" operator="is">true</dependency>
-          </dependencies>
-          <control type="spinner" format="string" />
-        </setting>
         <setting id="videoplayer.maxspeedadjust" type="number" label="13504" help="36168">
           <level>4</level>
           <default>5.0</default>
@@ -455,7 +440,6 @@
             <dependency type="enable">
               <and>
                 <condition setting="videoplayer.usedisplayasclock" operator="is">true</condition>
-                <condition setting="videoplayer.synctype" operator="is">2</condition> <!-- SYNC_RESAMPLE -->
               </and>
             </dependency>
           </dependencies>

--- a/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
@@ -186,7 +186,7 @@ void CDVDPlayerAudio::OpenStream( CDVDStreamInfo &hints, CDVDAudioCodec* codec )
   m_synctype = SYNC_DISCON;
   m_setsynctype = SYNC_DISCON;
   if (CSettings::Get().GetBool("videoplayer.usedisplayasclock"))
-    m_setsynctype = CSettings::Get().GetInt("videoplayer.synctype");
+    m_setsynctype = SYNC_RESAMPLE;
   m_prevsynctype = -1;
 
   m_error = 0;


### PR DESCRIPTION
...s active

see title. It makes no sense settings the clock source to display and then sync to audio stream. I keep the internal code for completeness and testing purposes.
