### PR TITLE
[Confluence] labels in PVR Search could overlap

### DIFF
--- a/addons/skin.confluence/720p/MyPVRSearch.xml
+++ b/addons/skin.confluence/720p/MyPVRSearch.xml
@@ -195,9 +195,9 @@
 								<info>ListItem.Label</info>
 							</control>
 							<control type="label">
-								<left>700</left>
+								<left>750</left>
 								<top>0</top>
-								<width>270</width>
+								<width>230</width>
 								<height>40</height>
 								<font>font12</font>
 								<aligny>center</aligny>
@@ -332,9 +332,9 @@
 								<info>ListItem.Label</info>
 							</control>
 							<control type="label">
-								<left>700</left>
+								<left>750</left>
 								<top>0</top>
-								<width>270</width>
+								<width>230</width>
 								<height>40</height>
 								<font>font12</font>
 								<aligny>center</aligny>


### PR DESCRIPTION
backport of https://github.com/xbmc/xbmc/pull/6040 for Helix.
