### PR TITLE
[pvr] Fix segfault due wrong increment of iterator.

### DIFF
--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -220,7 +220,7 @@ bool CPVRTimers::UpdateEntries(const CPVRTimers &timers)
       }
     }
     if (it->second->size() == 0)
-      m_tags.erase(++it);
+      m_tags.erase(it++);
     else
       ++it;
   }


### PR DESCRIPTION
Introduced in 841fb09f0d2f31e5bf9b3cb5df05c7dbfcae0300 .
