### PR TITLE
configure.in: Check for taglib headers

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -1062,6 +1062,9 @@ AC_CHECK_HEADER([mpeg2dec/mpeg2convert.h],, AC_MSG_ERROR($missing_library),
   [#include <mpeg2dec/mpeg2.h>])
 AC_CHECK_HEADER([jpeglib.h],,        AC_MSG_ERROR($missing_library))
 AC_CHECK_HEADER([ogg/ogg.h],,        AC_MSG_ERROR($missing_library))
+AC_LANG_PUSH([C++])
+AC_CHECK_HEADER([taglib/taglib.h],, AC_MSG_ERROR($missing_library))
+AC_LANG_POP([C++])
 AC_CHECK_HEADER([vorbis/vorbisfile.h],, AC_MSG_ERROR($missing_library))
 AC_CHECK_HEADER([libmodplug/modplug.h],, AC_MSG_ERROR($missing_library))
 


### PR DESCRIPTION
Configure.in already asks pkg-config, but this is fooled at least on ubuntu. There is another taglib package (libtagc0-dev), that provides taglib to pkg-config, but does not provide the required headers. Those are provided by libtag1-dev.

Thus we have to check specifically for the availability of the required headers.
