### PR TITLE
dvdplayer: fix potential segfault when silencing audio

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
@@ -564,7 +564,7 @@ void CDVDPlayerAudio::Process()
     // Zero out the frame data if we are supposed to silence the audio
     if (m_silence)
     {
-      int size = audioframe.nb_frames * audioframe.framesize * audioframe.channel_count / audioframe.planes;
+      int size = audioframe.nb_frames * audioframe.framesize / audioframe.planes;
       for (unsigned int i=0; i<audioframe.planes; i++)
         memset(audioframe.data[i], 0, size);
     }


### PR DESCRIPTION
fix potential segfault if EDL is used
