### PR TITLE
Fix coverity: Some Reverts

### DIFF
--- a/xbmc/filesystem/iso9660.cpp
+++ b/xbmc/filesystem/iso9660.cpp
@@ -722,12 +722,7 @@ HANDLE iso9660::OpenFile(const char *filename)
   while ( strpbrk( pointer, "\\/" ) )
     pointer = strpbrk( pointer, "\\/" ) + 1;
 
-  if (sizeof(filename) > sizeof(work) -1)
-    CLog::Log(LOGWARNING, "iso9660::OpenFile supplied path length too large");
-
-  strncpy(work, filename, sizeof(work) - 1 );
-  work[sizeof(work) - 1] = 0;
-
+  strcpy(work, filename );
   pointer2 = work;
 
   while ( strpbrk(pointer2 + 1, "\\" ) )

--- a/xbmc/filesystem/iso9660.cpp
+++ b/xbmc/filesystem/iso9660.cpp
@@ -628,11 +628,7 @@ HANDLE iso9660::FindFirstFile( char *szLocalFolder, WIN32_FIND_DATA *wfdFile )
 
     if ( m_searchpointer )
     {
-      if (sizeof(m_searchpointer->name) > sizeof(wfdFile->cFileName) -1)
-        CLog::Log(LOGWARNING, "iso9660::FindFirstFile length of search pattern too large");
-
-      strncpy(wfdFile->cFileName, m_searchpointer->name, sizeof(wfdFile->cFileName) - 1 );
-      wfdFile->cFileName[sizeof(wfdFile->cFileName) - 1] = 0;
+      strcpy(wfdFile->cFileName, m_searchpointer->name );
 
       if ( m_searchpointer->type == 2 )
         wfdFile->dwFileAttributes |= FILE_ATTRIBUTE_DIRECTORY;

--- a/xbmc/filesystem/iso9660.cpp
+++ b/xbmc/filesystem/iso9660.cpp
@@ -658,11 +658,7 @@ int iso9660::FindNextFile( HANDLE szLocalFolder, WIN32_FIND_DATA *wfdFile )
 
   if ( m_searchpointer )
   {
-    if (sizeof(m_searchpointer->name) > sizeof(wfdFile->cFileName) -1)
-      CLog::Log(LOGWARNING, "iso9660::FindNextFile Search pattern too large");
-
-    strncpy(wfdFile->cFileName, m_searchpointer->name, sizeof(wfdFile->cFileName) - 1 );
-    wfdFile->cFileName[sizeof(wfdFile->cFileName) - 1] = 0;
+    strcpy(wfdFile->cFileName, m_searchpointer->name );
 
     if ( m_searchpointer->type == 2 )
       wfdFile->dwFileAttributes |= FILE_ATTRIBUTE_DIRECTORY;


### PR DESCRIPTION
When taking over the the fixes I did not check every usage of sizeof, using sizeof the ptr is of course bs when the strlen is of interest.
