### PR TITLE
[pvr] properly select the hovered channel in the channel manager

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -80,7 +80,8 @@ bool CGUIDialogPVRChannelManager::OnActionMove(const CAction &action)
   int iActionId = action.GetID();
   if (GetFocusedControlID() == CONTROL_LIST_CHANNELS &&
       (iActionId == ACTION_MOVE_DOWN || iActionId == ACTION_MOVE_UP ||
-       iActionId == ACTION_PAGE_DOWN || iActionId == ACTION_PAGE_UP))
+       iActionId == ACTION_PAGE_DOWN || iActionId == ACTION_PAGE_UP ||
+       iActionId == ACTION_MOUSE_MOVE)) // item should be selected on hover
   {
     bReturn = true;
     if (!m_bMovingMode)


### PR DESCRIPTION
Fixes #15473. The issue is that we don't consider an item in the list selected unless the arrow keys or page up/down is used. We don't recognize click events so without this it's not possible to use the channel manager dialog with a mouse.

The only question is if `ACTION_MOUSE_MOVE` is the best event to listen on? The original bug report mentioned that some other input methods are broken too, not just regular mouses.
