### PR TITLE
[pvr] Improve PVR channel context menu

### DIFF
--- a/addons/library.xbmc.gui/libXBMC_gui.h
+++ b/addons/library.xbmc.gui/libXBMC_gui.h
@@ -36,7 +36,7 @@ typedef void* GUIHANDLE;
 #endif
 
 /* current ADDONGUI API version */
-#define XBMC_GUI_API_VERSION "5.5.0"
+#define XBMC_GUI_API_VERSION "5.6.0"
 
 /* min. ADDONGUI API version */
 #define XBMC_GUI_MIN_API_VERSION "5.3.0"

--- a/addons/skin.confluence/720p/IncludesPVR.xml
+++ b/addons/skin.confluence/720p/IncludesPVR.xml
@@ -79,7 +79,6 @@
 				<left>0</left>
 				<top>60</top>
 				<width>250</width>
-				<height>600</height>
 				<onleft>9000</onleft>
 				<onright>50</onright>
 				<onup>9000</onup>

--- a/addons/skin.confluence/720p/IncludesPVR.xml
+++ b/addons/skin.confluence/720p/IncludesPVR.xml
@@ -162,15 +162,6 @@
 					<include>ButtonCommonValues</include>
 					<label>-</label>
 				</control>
-				<control type="radiobutton" id="5">
-					<description>Group recording items by folder structure</description>
-					<left>0</left>
-					<right>40</right>
-					<textwidth>235</textwidth>
-					<include>ButtonCommonValues</include>
-					<label>19270</label>
-					<visible>Window.IsActive(TVRecordings) | Window.IsActive(RadioRecordings)</visible>
-				</control>
 				<control type="button" id="2">
 					<description>View As button</description>
 					<left>0</left>
@@ -214,6 +205,15 @@
 					<textcolor>blue</textcolor>
 					<align>center</align>
 					<aligny>center</aligny>
+				</control>
+				<control type="radiobutton" id="5">
+					<description>Group recording items by folder structure</description>
+					<left>0</left>
+					<right>40</right>
+					<textwidth>235</textwidth>
+					<include>ButtonCommonValues</include>
+					<label>19270</label>
+					<visible>Window.IsActive(TVRecordings) | Window.IsActive(RadioRecordings)</visible>
 				</control>
 				<control type="radiobutton" id="6">
 					<description>Show hidden channels</description>

--- a/addons/skin.confluence/720p/IncludesPVR.xml
+++ b/addons/skin.confluence/720p/IncludesPVR.xml
@@ -195,6 +195,37 @@
 					<altlabel>31050</altlabel>
 					<usealttexture>Container.SortDirection(Ascending)</usealttexture>
 				</control>
+				<control type="radiobutton" id="31">
+					<description>Filter</description>
+					<left>0</left>
+					<right>40</right>
+					<textwidth>235</textwidth>
+					<include>ButtonCommonValues</include>
+					<label>587</label>
+					<selected>Container.Filtered</selected>
+					<onclick>right</onclick>
+					<visible>Window.IsActive(TVChannels) | Window.IsActive(RadioChannels)</visible>
+				</control>
+				<!-- Misc Options (ID is completely arbitrary) -->
+				<control type="label" id="205">
+					<width>250</width>
+					<height>35</height>
+					<font>font12</font>
+					<label>31026</label>
+					<textcolor>blue</textcolor>
+					<align>center</align>
+					<aligny>center</aligny>
+				</control>
+				<control type="radiobutton" id="6">
+					<description>Show hidden channels</description>
+					<left>0</left>
+					<right>40</right>
+					<textwidth>235</textwidth>
+					<include>ButtonCommonValues</include>
+					<label>19051</label>
+					<visible>Window.IsActive(TVChannels) | Window.IsActive(RadioChannels)</visible>
+				</control>
+				<!-- Playback controls -->
 				<include>CommonNowPlaying_Controls</include>
 			</control>
 		</control>

--- a/addons/skin.confluence/addon.xml
+++ b/addons/skin.confluence/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="skin.confluence"
-  version="2.5.8"
+  version="2.6.0"
   name="Confluence"
   provider-name="Jezz_X, Team Kodi">
   <requires>

--- a/addons/skin.confluence/changelog.txt
+++ b/addons/skin.confluence/changelog.txt
@@ -1,3 +1,7 @@
+[B]2.6.0[/B]
+
+- Moved some context menu functionality for PVR channels to the sideblade
+
 [B]2.5.8[/B]
 
 - Updated language files from Transifex

--- a/addons/xbmc.gui/addon.xml
+++ b/addons/xbmc.gui/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="xbmc.gui" version="5.5.0" provider-name="Team-Kodi">
+<addon id="xbmc.gui" version="5.6.0" provider-name="Team-Kodi">
   <backwards-compatibility abi="5.3.0"/>
   <requires>
     <import addon="xbmc.core" version="0.1.0"/>

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -7784,7 +7784,7 @@ msgid "Programme info"
 msgstr ""
 
 msgctxt "#19048"
-msgid "Group management"
+msgid "Group manager"
 msgstr ""
 
 msgctxt "#19049"

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -14360,7 +14360,10 @@ msgctxt "#36212"
 msgid "Display programming information when changing channels, such as the current TV show."
 msgstr ""
 
-#empty string with id 36213
+#: system/settings/settings.xml
+msgctxt "#36213"
+msgid "Open the group manager, which allows modification of groups and their respective channels"
+msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#36214"

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1099,6 +1099,13 @@
           </dependencies>
           <control type="button" format="action" />
         </setting>
+        <setting id="pvrmanager.groupmanager" type="action" label="19048" help="36213">
+          <level>1</level>
+          <dependencies>
+            <dependency type="enable" setting="pvrmanager.enabled">true</dependency>
+          </dependencies>
+          <control type="button" format="action" />
+        </setting>
         <setting id="pvrmanager.channelscan" type="action" label="19117" help="36208">
           <level>1</level>
           <dependencies>

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -59,6 +59,7 @@
 #include "addons/AddonInstaller.h"
 #include "guilib/Key.h"
 #include "dialogs/GUIDialogPVRChannelManager.h"
+#include "dialogs/GUIDialogPVRGroupManager.h"
 
 using namespace MUSIC_INFO;
 using namespace PVR;
@@ -199,6 +200,15 @@ void CPVRManager::OnSettingAction(const CSetting *setting)
     if (IsStarted())
     {
       CGUIDialogPVRChannelManager *dialog = (CGUIDialogPVRChannelManager *)g_windowManager.GetWindow(WINDOW_DIALOG_PVR_CHANNEL_MANAGER);
+      if (dialog)
+        dialog->DoModal();
+    }
+  }
+  else if (settingId == "pvrmanager.groupmanager")
+  {
+    if (IsStarted())
+    {
+      CGUIDialogPVRGroupManager *dialog = (CGUIDialogPVRGroupManager *)g_windowManager.GetWindow(WINDOW_DIALOG_PVR_GROUP_MANAGER);
       if (dialog)
         dialog->DoModal();
     }

--- a/xbmc/pvr/windows/GUIWindowPVRBase.h
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.h
@@ -27,7 +27,9 @@
 #define CONTROL_BTNSORTBY                 3
 #define CONTROL_BTNSORTASC                4
 #define CONTROL_BTNGROUPITEMS             5
+#define CONTROL_BTNSHOWHIDDEN             6
 #define CONTROL_BTNCHANNELGROUPS          28
+#define CONTROL_BTNFILTERCHANNELS         31
 
 #define CONTROL_LABEL_HEADER1             29
 #define CONTROL_LABEL_HEADER2             30

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -88,11 +88,12 @@ void CGUIWindowPVRChannels::GetContextButtons(int itemNumber, CContextButtons &b
 
     if (g_PVRClients->HasMenuHooks(pItem->GetPVRChannelInfoTag()->ClientID(), PVR_MENUHOOK_CHANNEL))
       buttons.Add(CONTEXT_BUTTON_MENU_HOOKS, 19195);                                  /* PVR client specific action */
+
+    // Add parent buttons before the Manage button
+    CGUIWindowPVRBase::GetContextButtons(itemNumber, buttons);
     
     buttons.Add(CONTEXT_BUTTON_EDIT, 16106);                                          /* "Manage" submenu */
   }
-
-  CGUIWindowPVRBase::GetContextButtons(itemNumber, buttons);
 }
 
 std::string CGUIWindowPVRChannels::GetDirectoryPath(void)

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -26,18 +26,18 @@
 #include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogYesNo.h"
 #include "guilib/GUIKeyboardFactory.h"
+#include "guilib/GUIRadioButtonControl.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/Key.h"
 #include "GUIInfoManager.h"
-#include "profiles/ProfilesManager.h"
 #include "pvr/PVRManager.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/dialogs/GUIDialogPVRGroupManager.h"
+#include "pvr/dialogs/GUIDialogPVRChannelManager.h"
 #include "pvr/addons/PVRClients.h"
 #include "pvr/timers/PVRTimers.h"
 #include "epg/EpgContainer.h"
 #include "settings/Settings.h"
-#include "storage/MediaManager.h"
 #include "utils/log.h"
 #include "threads/SingleLock.h"
 
@@ -84,26 +84,12 @@ void CGUIWindowPVRChannels::GetContextButtons(int itemNumber, CContextButtons &b
   {
     buttons.Add(CONTEXT_BUTTON_INFO, 19047);                                          /* channel info */
     buttons.Add(CONTEXT_BUTTON_FIND, 19003);                                          /* find similar program */
-    buttons.Add(CONTEXT_BUTTON_PLAY_ITEM, 19000);                                     /* switch to channel */
     buttons.Add(CONTEXT_BUTTON_RECORD_ITEM, channel->IsRecording() ? 19256 : 19255);  /* start/stop recording on channel */
-    buttons.Add(CONTEXT_BUTTON_SET_THUMB, 19284);                                     /* change icon */
-    buttons.Add(CONTEXT_BUTTON_GROUP_MANAGER, 19048);                                 /* group manager */
-    buttons.Add(CONTEXT_BUTTON_HIDE, m_bShowHiddenChannels ? 19049 : 19054);          /* show/hide channel */
-
-    if (m_vecItems->Size() > 1 && !m_bShowHiddenChannels)
-      buttons.Add(CONTEXT_BUTTON_MOVE, 116);                                          /* move channel up or down */
-
-    if (m_bShowHiddenChannels || g_PVRChannelGroups->GetGroupAllTV()->GetNumHiddenChannels() > 0)
-      buttons.Add(CONTEXT_BUTTON_SHOW_HIDDEN, m_bShowHiddenChannels ? 19050 : 19051); /* show hidden/visible channels */
 
     if (g_PVRClients->HasMenuHooks(pItem->GetPVRChannelInfoTag()->ClientID(), PVR_MENUHOOK_CHANNEL))
       buttons.Add(CONTEXT_BUTTON_MENU_HOOKS, 19195);                                  /* PVR client specific action */
-
-    CPVRChannel *channel = pItem->GetPVRChannelInfoTag();
-    buttons.Add(CONTEXT_BUTTON_ADD_LOCK, channel->IsLocked() ? 19258 : 19257);        /* show lock/unlock channel */
-
-    buttons.Add(CONTEXT_BUTTON_FILTER, 19249);                                        /* filter channels */
-    buttons.Add(CONTEXT_BUTTON_UPDATE_EPG, 19251);                                    /* update EPG information */
+    
+    buttons.Add(CONTEXT_BUTTON_EDIT, 16106);                                          /* "Manage" submenu */
   }
 
   CGUIWindowPVRBase::GetContextButtons(itemNumber, buttons);
@@ -122,18 +108,12 @@ bool CGUIWindowPVRChannels::OnContextButton(int itemNumber, CONTEXT_BUTTON butto
     return false;
   CFileItemPtr pItem = m_vecItems->Get(itemNumber);
 
-  return OnContextButtonPlay(pItem.get(), button) ||
-      OnContextButtonMove(pItem.get(), button) ||
-      OnContextButtonHide(pItem.get(), button) ||
-      OnContextButtonShowHidden(pItem.get(), button) ||
-      OnContextButtonSetThumb(pItem.get(), button) ||
-      OnContextButtonAdd(pItem.get(), button) ||
+  return OnContextButtonAdd(pItem.get(), button) ||
       OnContextButtonInfo(pItem.get(), button) ||
       OnContextButtonGroupManager(pItem.get(), button) ||
-      OnContextButtonFilter(pItem.get(), button) ||
       OnContextButtonUpdateEpg(pItem.get(), button) ||
       OnContextButtonRecord(pItem.get(), button) ||
-      OnContextButtonLock(pItem.get(), button) ||
+      OnContextButtonManage(pItem.get(), button) ||
       CGUIWindowPVRBase::OnContextButton(itemNumber, button);
 }
 
@@ -215,6 +195,25 @@ bool CGUIWindowPVRChannels::OnMessage(CGUIMessage& message)
           }
         }
       }
+      else if (message.GetSenderId() == CONTROL_BTNSHOWHIDDEN)
+      {
+        CGUIRadioButtonControl *radioButton = (CGUIRadioButtonControl*)GetControl(CONTROL_BTNSHOWHIDDEN);
+        if (radioButton)
+        {
+          m_bShowHiddenChannels = radioButton->IsSelected();
+          Update(GetDirectoryPath());
+        }
+
+        bReturn = true;
+      }
+      else if (message.GetSenderId() == CONTROL_BTNFILTERCHANNELS)
+      {
+        std::string filter = GetProperty("filter").asString();
+        CGUIKeyboardFactory::ShowAndGetFilter(filter, false);
+        OnFilterItems(filter);
+
+        bReturn = true;
+      }
       break;
     case GUI_MSG_REFRESH_LIST:
       switch(message.GetParam1())
@@ -269,61 +268,6 @@ bool CGUIWindowPVRChannels::OnContextButtonGroupManager(CFileItem *item, CONTEXT
   return bReturn;
 }
 
-bool CGUIWindowPVRChannels::OnContextButtonHide(CFileItem *item, CONTEXT_BUTTON button)
-{
-  bool bReturn = false;
-
-  if (button == CONTEXT_BUTTON_HIDE)
-  {
-    CPVRChannel *channel = item->GetPVRChannelInfoTag();
-    if (!channel || channel->IsRadio() != m_bRadio)
-      return bReturn;
-
-    CGUIDialogYesNo* pDialog = (CGUIDialogYesNo*)g_windowManager.GetWindow(WINDOW_DIALOG_YES_NO);
-    if (!pDialog)
-      return bReturn;
-
-    pDialog->SetHeading(19039);
-    pDialog->SetLine(0, "");
-    pDialog->SetLine(1, channel->ChannelName());
-    pDialog->SetLine(2, "");
-    pDialog->DoModal();
-
-    if (!pDialog->IsConfirmed())
-      return bReturn;
-
-    g_PVRManager.GetPlayingGroup(m_bRadio)->RemoveFromGroup(*channel);
-    Refresh(true);
-
-    bReturn = true;
-  }
-
-  return bReturn;
-}
-
-bool CGUIWindowPVRChannels::OnContextButtonLock(CFileItem *item, CONTEXT_BUTTON button)
-{
-  bool bReturn = false;
-
-  if (button == CONTEXT_BUTTON_ADD_LOCK)
-  {
-    // ask for PIN first
-    if (!g_PVRManager.CheckParentalPIN(g_localizeStrings.Get(19262).c_str()))
-      return bReturn;
-
-    CPVRChannelGroupPtr group = g_PVRChannelGroups->GetGroupAll(m_bRadio);
-    if (!group)
-      return bReturn;
-
-    group->ToggleChannelLocked(*item);
-    Refresh(true);
-
-    bReturn = true;
-  }
-
-  return bReturn;
-}
-
 bool CGUIWindowPVRChannels::OnContextButtonInfo(CFileItem *item, CONTEXT_BUTTON button)
 {
   bool bReturn = false;
@@ -337,139 +281,38 @@ bool CGUIWindowPVRChannels::OnContextButtonInfo(CFileItem *item, CONTEXT_BUTTON 
   return bReturn;
 }
 
-bool CGUIWindowPVRChannels::OnContextButtonMove(CFileItem *item, CONTEXT_BUTTON button)
+bool CGUIWindowPVRChannels::OnContextButtonManage(CFileItem *item, CONTEXT_BUTTON button)
 {
   bool bReturn = false;
 
-  if (button == CONTEXT_BUTTON_MOVE)
+  if (button == CONTEXT_BUTTON_EDIT)
   {
-    CPVRChannel *channel = item->GetPVRChannelInfoTag();
-    if (!channel || channel->IsRadio() != m_bRadio)
-      return bReturn;
+    // Create context sub menu
+    CContextButtons buttons;
+    buttons.Add(CONTEXT_BUTTON_GROUP_MANAGER, 19048);
+    buttons.Add(CONTEXT_BUTTON_CHANNEL_MANAGER, 19199);
+    buttons.Add(CONTEXT_BUTTON_UPDATE_EPG, 19251);
 
-    std::string strIndex;
-    strIndex = StringUtils::Format("%i", channel->ChannelNumber());
-    CGUIDialogNumeric::ShowAndGetNumber(strIndex, g_localizeStrings.Get(19052));
-    int newIndex = atoi(strIndex.c_str());
-
-    if (newIndex != channel->ChannelNumber())
+    // Get the response
+    int button = CGUIDialogContextMenu::ShowAndGetChoice(buttons);
+    if (button >= 0)
     {
-      g_PVRManager.GetPlayingGroup()->MoveChannel(channel->ChannelNumber(), newIndex);
+      switch ((CONTEXT_BUTTON)button)
+      {
+        case CONTEXT_BUTTON_GROUP_MANAGER:
+          ShowGroupManager();
+          break;
+        case CONTEXT_BUTTON_CHANNEL_MANAGER:
+          ShowChannelManager();
+          break;
+        case CONTEXT_BUTTON_UPDATE_EPG:
+          OnContextButtonUpdateEpg(item, (CONTEXT_BUTTON)button);
+          break;
+      }
+
+      // Refresh the list in case anything was changed
       Refresh(true);
     }
-
-    bReturn = true;
-  }
-
-  return bReturn;
-}
-
-bool CGUIWindowPVRChannels::OnContextButtonPlay(CFileItem *item, CONTEXT_BUTTON button)
-{
-  bool bReturn = false;
-
-  if (button == CONTEXT_BUTTON_PLAY_ITEM)
-  {
-    /* play channel */
-    bReturn = PlayFile(item, CSettings::Get().GetBool("pvrplayback.playminimized"));
-  }
-
-  return bReturn;
-}
-
-bool CGUIWindowPVRChannels::OnContextButtonSetThumb(CFileItem *item, CONTEXT_BUTTON button)
-{
-  bool bReturn = false;
-
-  if (button == CONTEXT_BUTTON_SET_THUMB)
-  {
-    if (CProfilesManager::Get().GetCurrentProfile().canWriteSources() && !g_passwordManager.IsProfileLockUnlocked())
-      return bReturn;
-    else if (!g_passwordManager.IsMasterLockUnlocked(true))
-      return bReturn;
-
-    /* setup our thumb list */
-    CFileItemList items;
-    CPVRChannel *channel = item->GetPVRChannelInfoTag();
-
-    if (!channel->IconPath().empty())
-    {
-      /* add the current icon, if available */
-      CFileItemPtr current(new CFileItem("thumb://Current", false));
-      current->SetArt("thumb", channel->IconPath());
-      current->SetLabel(g_localizeStrings.Get(19282));
-      items.Add(current);
-    }
-    else if (item->HasArt("thumb"))
-    {
-      /* already have a thumb that the share doesn't know about - must be a local one, so we may as well reuse it */
-      CFileItemPtr current(new CFileItem("thumb://Current", false));
-      current->SetArt("thumb", item->GetArt("thumb"));
-      current->SetLabel(g_localizeStrings.Get(19282));
-      items.Add(current);
-    }
-
-    /* and add a "no thumb" entry as well */
-    CFileItemPtr nothumb(new CFileItem("thumb://None", false));
-    nothumb->SetIconImage(item->GetIconImage());
-    nothumb->SetLabel(g_localizeStrings.Get(19283));
-    items.Add(nothumb);
-
-    std::string strThumb;
-    VECSOURCES shares;
-    if (CSettings::Get().GetString("pvrmenu.iconpath") != "")
-    {
-      CMediaSource share1;
-      share1.strPath = CSettings::Get().GetString("pvrmenu.iconpath");
-      share1.strName = g_localizeStrings.Get(19066);
-      shares.push_back(share1);
-    }
-    g_mediaManager.GetLocalDrives(shares);
-    if (!CGUIDialogFileBrowser::ShowAndGetImage(items, shares, g_localizeStrings.Get(19285), strThumb, NULL, 19285))
-      return bReturn;
-
-    if (strThumb != "thumb://Current")
-    {
-      if (strThumb == "thumb://None")
-        strThumb = "";
-
-      CPVRChannelGroupPtr group = g_PVRChannelGroups->GetGroupAll(channel->IsRadio());
-      CPVRChannelPtr channelPtr = group->GetByUniqueID(channel->UniqueID());
-
-      channelPtr->SetIconPath(strThumb, true);
-      channelPtr->Persist();
-      Refresh(true);
-    }
-
-    bReturn = true;
-  }
-
-  return bReturn;
-}
-
-bool CGUIWindowPVRChannels::OnContextButtonShowHidden(CFileItem *item, CONTEXT_BUTTON button)
-{
-  bool bReturn = false;
-
-  if (button == CONTEXT_BUTTON_SHOW_HIDDEN)
-  {
-    m_bShowHiddenChannels = !m_bShowHiddenChannels;
-    Update(GetDirectoryPath());
-    bReturn = true;
-  }
-
-  return bReturn;
-}
-
-bool CGUIWindowPVRChannels::OnContextButtonFilter(CFileItem *item, CONTEXT_BUTTON button)
-{
-  bool bReturn = false;
-
-  if (button == CONTEXT_BUTTON_FILTER)
-  {
-    std::string filter = GetProperty("filter").asString();
-    CGUIKeyboardFactory::ShowAndGetFilter(filter, false);
-    OnFilterItems(filter);
 
     bReturn = true;
   }
@@ -521,6 +364,13 @@ bool CGUIWindowPVRChannels::OnContextButtonUpdateEpg(CFileItem *item, CONTEXT_BU
   }
 
   return bReturn;
+}
+
+void CGUIWindowPVRChannels::ShowChannelManager()
+{
+  CGUIDialogPVRChannelManager *dialog = (CGUIDialogPVRChannelManager *)g_windowManager.GetWindow(WINDOW_DIALOG_PVR_CHANNEL_MANAGER);
+  if (dialog)
+    dialog->DoModal();
 }
 
 void CGUIWindowPVRChannels::ShowGroupManager(void)

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.h
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.h
@@ -45,17 +45,12 @@ namespace PVR
   private:
     bool OnContextButtonAdd(CFileItem *item, CONTEXT_BUTTON button);
     bool OnContextButtonGroupManager(CFileItem *item, CONTEXT_BUTTON button);
-    bool OnContextButtonHide(CFileItem *item, CONTEXT_BUTTON button);
     bool OnContextButtonInfo(CFileItem *item, CONTEXT_BUTTON button);
-    bool OnContextButtonMove(CFileItem *item, CONTEXT_BUTTON button);
-    bool OnContextButtonPlay(CFileItem *item, CONTEXT_BUTTON button);
-    bool OnContextButtonSetThumb(CFileItem *item, CONTEXT_BUTTON button);
-    bool OnContextButtonShowHidden(CFileItem *item, CONTEXT_BUTTON button);
-    bool OnContextButtonFilter(CFileItem *item, CONTEXT_BUTTON button);
+    bool OnContextButtonManage(CFileItem *item, CONTEXT_BUTTON button);
     bool OnContextButtonUpdateEpg(CFileItem *item, CONTEXT_BUTTON button);
     bool OnContextButtonRecord(CFileItem *item, CONTEXT_BUTTON button);
-    bool OnContextButtonLock(CFileItem *item, CONTEXT_BUTTON button);
 
+    void ShowChannelManager();
     void ShowGroupManager(void);
 
     bool m_bShowHiddenChannels;

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -42,7 +42,6 @@ CGUIWindowPVRGuide::CGUIWindowPVRGuide(bool bRadio) :
   CGUIWindowPVRBase(bRadio, bRadio ? WINDOW_RADIO_GUIDE : WINDOW_TV_GUIDE, "MyPVRGuide.xml")
 {
   m_bUpdateRequired = false;
-  m_bShowHiddenChannels = false;
   m_cachedTimeline = new CFileItemList;
   m_cachedChannelGroup = CPVRChannelGroupPtr(new CPVRChannelGroup);
 }

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.h
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.h
@@ -65,7 +65,6 @@ namespace PVR
     CFileItemList      *m_cachedTimeline;
     CPVRChannelGroupPtr m_cachedChannelGroup;
 
-    bool m_bShowHiddenChannels;
     bool m_bUpdateRequired;
   };
 }

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -786,6 +786,7 @@ void CSettings::InitializeISettingCallbacks()
   settingSet.clear();
   settingSet.insert("pvrmanager.enabled");
   settingSet.insert("pvrmanager.channelmanager");
+  settingSet.insert("pvrmanager.groupmanager");
   settingSet.insert("pvrmanager.channelscan");
   settingSet.insert("pvrmanager.resetdb");
   settingSet.insert("pvrclient.menuhook");


### PR DESCRIPTION
This started out pretty small scale but grew a bit once I started working on it, sorry about that. The issues this PR tries to fix are:
- the context menu for PVR channels is absolutely massive. A lot of the things available through it are already implemented in the channel manager dialog, which until now has been accessible only by going all the way to the settings window. This also meant that the functionality has been duplicated in `CGUIWindowPVRChannels`.
- some functionality is expected to be in the side blade but has been implemented as context menu actions instead

This PR does the following:
- removes the "Add to favourites" context menu item for PVR channels. I don't even know what this is supposed to do. The "Switch to channel" menu item has been removed too since if you don't have a way of pressing "Select" you're screwed anyway.
- replaces the functionality duplicated from the channel manager and adds a "Manage" item which contains links to the group and channel manager, as well as the "Update EPG information" item.
- moves "Show hidden channels" and the filtering functionality to the side blade
- makes the group manager accessible through settings as well

@xhaggi @opdenkamp for review.
