### PR TITLE
FIX: [aml] only use screen size if ppscaler is disabled

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/AMLCodec.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/AMLCodec.cpp
@@ -1687,11 +1687,18 @@ bool CAMLCodec::OpenDecoder(CDVDStreamInfo &hints)
   g_renderManager.RegisterRenderFeaturesCallBack((const void*)this, RenderFeaturesCallBack);
 
   m_display_rect = CRect(0, 0, CDisplaySettings::Get().GetCurrentResolutionInfo().iWidth, CDisplaySettings::Get().GetCurrentResolutionInfo().iHeight);
-  char mode[256] = {0};
-  aml_get_sysfs_str("/sys/class/display/mode", mode, 255);
-  RESOLUTION_INFO res;
-  if (aml_mode_to_resolution(mode, &res))
-    m_display_rect = CRect(0, 0, res.iScreenWidth, res.iScreenHeight);
+
+  char buffer[256] = {0};
+  aml_get_sysfs_str("/sys/class/ppmgr/ppscaler", buffer, 255);
+  if (!strstr(buffer, "enabled"))     // Scaler not enabled, use screen size
+  {
+    CLog::Log(LOGDEBUG, "ppscaler not enabled");
+    memset(buffer, 0, 256);
+    aml_get_sysfs_str("/sys/class/display/mode", buffer, 255);
+    RESOLUTION_INFO res;
+    if (aml_mode_to_resolution(buffer, &res))
+      m_display_rect = CRect(0, 0, res.iScreenWidth, res.iScreenHeight);
+  }
 
 /*
   // if display is set to 1080xxx, then disable deinterlacer for HD content


### PR DESCRIPTION
If the h/w scaler is enabled and we use the HDMI size while the fb size is different, picture is "zoomed".
On most aml devices, the scaler is disabled with the "android.intent.action.REALVIDEO_ON" intent we send when starting, but not all devices handle this correctly.
