### PR TITLE
[airtunes] - feed audio data to the pipe in one chunk instead of splitting into 64 byte buffers - reduces audio stuttering

### DIFF
--- a/xbmc/cores/VideoRenderers/WinRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/WinRenderer.cpp
@@ -63,6 +63,7 @@ static RenderMethodDetail *FindRenderMethod(RenderMethod m)
 
 CWinRenderer::CWinRenderer()
 {
+  m_use10bitTexture = g_advancedSettings.m_Force10BitRgbOutput;
   m_iYV12RenderBuffer = 0;
   m_NumYV12Buffers = 0;
 
@@ -506,7 +507,8 @@ bool CWinRenderer::CreateIntermediateRenderTarget(unsigned int width, unsigned i
   LPDIRECT3DDEVICE9 pD3DDevice = g_Windowing.Get3DDevice();
   D3DFORMAT format = D3DFMT_X8R8G8B8;
   DWORD usage = D3DUSAGE_RENDERTARGET;
-
+  if (m_use10bitTexture && g_Windowing.IsTextureFormatOk(D3DFMT_A2R10G10B10, usage))
+    format = D3DFMT_A2R10G10B10;
   if      (m_renderMethod == RENDER_DXVA)                            format = D3DFMT_X8R8G8B8;
   else if (g_Windowing.IsTextureFormatOk(D3DFMT_A2R10G10B10, usage)) format = D3DFMT_A2R10G10B10;
   else if (g_Windowing.IsTextureFormatOk(D3DFMT_A2B10G10R10, usage)) format = D3DFMT_A2B10G10R10;

--- a/xbmc/cores/VideoRenderers/WinRenderer.h
+++ b/xbmc/cores/VideoRenderers/WinRenderer.h
@@ -204,6 +204,7 @@ protected:
   void RenderProcessor(DWORD flags);
   int  m_iYV12RenderBuffer;
   int  m_NumYV12Buffers;
+  bool                 m_use10bitTexture;
 
   bool                 m_bConfigured;
   SVideoBuffer        *m_VideoBuffers[NUM_BUFFERS];

--- a/xbmc/network/AirTunesServer.cpp
+++ b/xbmc/network/AirTunesServer.cpp
@@ -262,21 +262,8 @@ void  CAirTunesServer::AudioOutputFunctions::audio_set_volume(void *cls, void *s
 
 void  CAirTunesServer::AudioOutputFunctions::audio_process(void *cls, void *session, const void *buffer, int buflen)
 {
-  #define NUM_OF_BYTES 64
   XFILE::CPipeFile *pipe=(XFILE::CPipeFile *)cls;
-  int sentBytes = 0;
-  unsigned char buf[NUM_OF_BYTES];
-
-  while (sentBytes < buflen)
-  {
-    int n = (buflen - sentBytes < NUM_OF_BYTES ? buflen - sentBytes : NUM_OF_BYTES);
-    memcpy(buf, (char*) buffer + sentBytes, n);
-
-    if (pipe->Write(buf, n) == 0)
-      return;
-
-    sentBytes += n;
-  }
+  pipe->Write(buffer, buflen);
 }
 
 void  CAirTunesServer::AudioOutputFunctions::audio_destroy(void *cls, void *session)

--- a/xbmc/rendering/dx/RenderSystemDX.h
+++ b/xbmc/rendering/dx/RenderSystemDX.h
@@ -122,6 +122,7 @@ protected:
   void SetMonitor(HMONITOR monitor);
   void SetRenderParams(unsigned int width, unsigned int height, bool fullScreen, float refreshRate);
   void BuildPresentParameters();
+  void DwmEnableDisableComposition(bool beforeReset);
   virtual void UpdateMonitor() {};
   BOOL IsDepthFormatOk(D3DFORMAT DepthFormat, D3DFORMAT RenderTargetFormat);
   void OnMove();
@@ -148,6 +149,7 @@ protected:
   IDirect3DStateBlock9*       m_stateBlock;
   int64_t                     m_systemFreq;
   bool                        m_useD3D9Ex;
+  bool                        m_use10bitTexture;
   DWORD                       m_defaultD3DUsage;
   D3DPOOL                     m_defaultD3DPool;
   bool                        m_useWindowedDX;

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -340,6 +340,9 @@ void CAdvancedSettings::Initialize()
   m_sleepBeforeFlip = 0;
   m_bVirtualShares = true;
   m_Force10BitRgbOutput = false;
+  m_skipSteps = { 15, 30, 60, 180, 300, 600, 900, 1800, 3600, 7200 };
+  m_skipTimeout = 2500;
+
 //caused lots of jerks
 //#ifdef TARGET_WINDOWS
 //  m_ForcedSwapTime = 2.0;
@@ -847,7 +850,17 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
   }
 
   XMLUtils::GetString(pRootElement, "cddbaddress", m_cddbAddress);
+  
+  // Transform into vector of ints
+  string skipSteps;
+  XMLUtils::GetString(pRootElement, "skipsteps", skipSteps);
+  for (auto step : StringUtils::Split(skipSteps, ','))
+  {
+    m_skipSteps.push_back(atoi(step.c_str()));
+  }
 
+  XMLUtils::GetUInt(pRootElement, "skiptimeout", m_skipTimeout);
+  
   //airtunes + airplay
   XMLUtils::GetInt(pRootElement,     "airtunesport", m_airTunesPort);
   XMLUtils::GetInt(pRootElement,     "airplayport", m_airPlayPort);  

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -341,7 +341,6 @@ void CAdvancedSettings::Initialize()
   m_bVirtualShares = true;
   m_Force10BitRgbOutput = false;
   m_skipSteps = { 15, 30, 60, 180, 300, 600, 900, 1800, 3600, 7200 };
-  m_skipTimeout = 2500;
 
 //caused lots of jerks
 //#ifdef TARGET_WINDOWS
@@ -854,12 +853,12 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
   // Transform into vector of ints
   string skipSteps;
   XMLUtils::GetString(pRootElement, "skipsteps", skipSteps);
-  for (auto step : StringUtils::Split(skipSteps, ','))
+  if (skipSteps.length() > 0)
   {
-    m_skipSteps.push_back(atoi(step.c_str()));
+    m_skipSteps.clear();
+    for (auto step : StringUtils::Split(skipSteps, ','))
+      m_skipSteps.push_back(atoi(step.c_str()));
   }
-
-  XMLUtils::GetUInt(pRootElement, "skiptimeout", m_skipTimeout);
   
   //airtunes + airplay
   XMLUtils::GetInt(pRootElement,     "airtunesport", m_airTunesPort);

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -339,7 +339,7 @@ void CAdvancedSettings::Initialize()
   m_RestrictCapsMask = 0;
   m_sleepBeforeFlip = 0;
   m_bVirtualShares = true;
-
+  m_Force10BitRgbOutput = false;
 //caused lots of jerks
 //#ifdef TARGET_WINDOWS
 //  m_ForcedSwapTime = 2.0;
@@ -869,6 +869,7 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
   XMLUtils::GetInt(pRootElement,"skiploopfilter", m_iSkipLoopFilter, -16, 48);
   XMLUtils::GetFloat(pRootElement, "forcedswaptime", m_ForcedSwapTime, 0.0, 100.0);
 
+  XMLUtils::GetBoolean(pRootElement, "force10BitRbgOutput", m_Force10BitRgbOutput);
   XMLUtils::GetBoolean(pRootElement,"allowd3d9ex", m_AllowD3D9Ex);
   XMLUtils::GetBoolean(pRootElement,"forced3d9ex", m_ForceD3D9Ex);
   XMLUtils::GetBoolean(pRootElement,"allowdynamictextures", m_AllowDynamicTextures);

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -215,7 +215,6 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     int m_extraLogLevels;
     CStdString m_cddbAddress;
 
-    unsigned int m_skipTimeout;
     std::vector<int> m_skipSteps;
 
     //airtunes + airplay

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -340,6 +340,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
 
     bool m_AllowD3D9Ex;
     bool m_ForceD3D9Ex;
+    bool m_Force10BitRgbOutput;
     bool m_AllowDynamicTextures;
     unsigned int m_RestrictCapsMask;
     float m_sleepBeforeFlip; ///< if greather than zero, XBMC waits for raster to be this amount through the frame prior to calling the flip

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -215,6 +215,9 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     int m_extraLogLevels;
     CStdString m_cddbAddress;
 
+    unsigned int m_skipTimeout;
+    std::vector<int> m_skipSteps;
+
     //airtunes + airplay
     int m_airTunesPort;
     int m_airPlayPort;

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -61,6 +61,7 @@
 
 #include <stdio.h>
 #include <algorithm>
+#include <boost/format.hpp>
 #if defined(TARGET_DARWIN)
 #include "linux/LinuxResourceCounter.h"
 #endif
@@ -91,9 +92,7 @@ static CLinuxResourceCounter m_resourceCounter;
 CGUIWindowFullScreen::CGUIWindowFullScreen(void)
     : CGUIWindow(WINDOW_FULLSCREEN_VIDEO, "VideoFullScreen.xml")
 {
-  m_timeCodeStamp[0] = 0;
-  m_timeCodePosition = 0;
-  m_timeCodeShow = false;
+  m_timeCode = 0;
   m_timeCodeTimeout = 0;
   m_bShowViewModeInfo = false;
   m_dwShowViewModeTimeout = 0;
@@ -124,7 +123,7 @@ CGUIWindowFullScreen::~CGUIWindowFullScreen(void)
 
 bool CGUIWindowFullScreen::OnAction(const CAction &action)
 {
-  if (m_timeCodePosition > 0 && action.GetButtonCode())
+  if (m_timeCode > 0 && action.GetButtonCode())
   { // check whether we have a mapping in our virtual videotimeseek "window" and have a select action
     CKey key(action.GetButtonCode());
     CAction timeSeek = CButtonTranslator::GetInstance().GetAction(WINDOW_VIDEO_TIME_SEEK, key, false);
@@ -155,7 +154,7 @@ bool CGUIWindowFullScreen::OnAction(const CAction &action)
 
   case ACTION_PLAYER_PLAY:
   case ACTION_PAUSE:
-    if (m_timeCodePosition > 0)
+    if (m_timeCode > 0)
     {
       SeekToTimeCodeStamp(SEEK_ABSOLUTE);
       return true;
@@ -163,14 +162,14 @@ bool CGUIWindowFullScreen::OnAction(const CAction &action)
     break;
 
   case ACTION_STEP_BACK:
-    if (m_timeCodePosition > 0)
+    if (m_timeCode > 0)
       SeekToTimeCodeStamp(SEEK_RELATIVE, SEEK_BACKWARD);
     else
       g_application.m_pPlayer->Seek(false, false);
     return true;
 
   case ACTION_STEP_FORWARD:
-    if (m_timeCodePosition > 0)
+    if (m_timeCode > 0)
       SeekToTimeCodeStamp(SEEK_RELATIVE, SEEK_FORWARD);
     else
       g_application.m_pPlayer->Seek(true, false);
@@ -178,7 +177,7 @@ bool CGUIWindowFullScreen::OnAction(const CAction &action)
 
   case ACTION_BIG_STEP_BACK:
   case ACTION_CHAPTER_OR_BIG_STEP_BACK:
-    if (m_timeCodePosition > 0)
+    if (m_timeCode > 0)
       SeekToTimeCodeStamp(SEEK_RELATIVE, SEEK_BACKWARD);
     else
       g_application.m_pPlayer->Seek(false, true, action.GetID() == ACTION_CHAPTER_OR_BIG_STEP_BACK);
@@ -186,7 +185,7 @@ bool CGUIWindowFullScreen::OnAction(const CAction &action)
 
   case ACTION_BIG_STEP_FORWARD:
   case ACTION_CHAPTER_OR_BIG_STEP_FORWARD:
-    if (m_timeCodePosition > 0)
+    if (m_timeCode > 0)
       SeekToTimeCodeStamp(SEEK_RELATIVE, SEEK_FORWARD);
     else
       g_application.m_pPlayer->Seek(true, true, action.GetID() == ACTION_CHAPTER_OR_BIG_STEP_FORWARD);
@@ -311,7 +310,7 @@ bool CGUIWindowFullScreen::OnAction(const CAction &action)
     return true;
     break;
   case ACTION_SMALL_STEP_BACK:
-    if (m_timeCodePosition > 0)
+    if (m_timeCode > 0)
       SeekToTimeCodeStamp(SEEK_RELATIVE, SEEK_BACKWARD);
     else
     {
@@ -673,26 +672,15 @@ void CGUIWindowFullScreen::FrameMove()
     }
   }
 
-  if (m_timeCodeShow && m_timeCodePosition != 0)
+  if (m_timeCode != 0)
   {
     if ( (XbmcThreads::SystemClockMillis() - m_timeCodeTimeout) >= 2500)
     {
-      m_timeCodeShow = false;
-      m_timeCodePosition = 0;
+      m_timeCode = 0;
     }
-    CStdString strDispTime = "00:00:00";
 
     CGUIMessage msg(GUI_MSG_LABEL_SET, GetID(), LABEL_ROW1);
-
-    for (int pos = 7, i = m_timeCodePosition; pos >= 0 && i > 0; pos--)
-    {
-      if (strDispTime[pos] != ':')
-      {
-        i -= 1;
-        strDispTime[pos] = (char)m_timeCodeStamp[i] + '0';
-      }
-    }
-
+    std::string  strDispTime = GetTimeCodeAsString();
     strDispTime += "/" + g_infoManager.GetDuration(TIME_FORMAT_HH_MM_SS) + " [" + g_infoManager.GetCurrentPlayTime(TIME_FORMAT_HH_MM_SS) + "]"; // duration [ time ]
     msg.SetLabel(strDispTime);
     OnMessage(msg);
@@ -706,7 +694,7 @@ void CGUIWindowFullScreen::FrameMove()
     SET_CONTROL_VISIBLE(BLUE_BAR);
     SET_CONTROL_HIDDEN(CONTROL_GROUP_CHOOSER);
   }
-  else if (m_timeCodeShow)
+  else if (m_timeCode != 0)
   {
     SET_CONTROL_VISIBLE(LABEL_ROW1);
     SET_CONTROL_HIDDEN(LABEL_ROW2);
@@ -750,46 +738,46 @@ void CGUIWindowFullScreen::ChangetheTimeCode(int remote)
 {
   if (remote >= REMOTE_0 && remote <= REMOTE_9)
   {
-    m_timeCodeShow = true;
     m_timeCodeTimeout = XbmcThreads::SystemClockMillis();
 
-    if (m_timeCodePosition < 6)
-      m_timeCodeStamp[m_timeCodePosition++] = remote - REMOTE_0;
-    else
-    {
-      // rotate around
-      for (int i = 0; i < 5; i++)
-        m_timeCodeStamp[i] = m_timeCodeStamp[i+1];
-      m_timeCodeStamp[5] = remote - REMOTE_0;
-    }
+    m_timeCode = m_timeCode * 10 + remote - REMOTE_0;
   }
 }
 
 void CGUIWindowFullScreen::SeekToTimeCodeStamp(SEEK_TYPE type, SEEK_DIRECTION direction)
 {
-  double total = GetTimeCodeStamp();
+  double total = GetTimeCodeAsSeconds();
   if (type == SEEK_RELATIVE)
     total = g_application.GetTime() + (((direction == SEEK_FORWARD) ? 1 : -1) * total);
 
   if (total < g_application.GetTotalTime())
     g_application.SeekTime(total);
 
-  m_timeCodePosition = 0;
-  m_timeCodeShow = false;
+  m_timeCode = 0;
 }
 
-double CGUIWindowFullScreen::GetTimeCodeStamp()
+double CGUIWindowFullScreen::GetTimeCodeAsSeconds()
 {
-  // Convert the timestamp into an integer
-  int tot = 0;
-  for (int i = 0; i < m_timeCodePosition; i++)
-    tot = tot * 10 + m_timeCodeStamp[i];
-
+  int t = m_timeCode;
   // Interpret result as HHMMSS
-  int s = tot % 100; tot /= 100;
-  int m = tot % 100; tot /= 100;
-  int h = tot % 100;
+  int s = t % 100; t /= 100;
+  int m = t % 100; t /= 100;
+  int h = t % 100;
   return h * 3600 + m * 60 + s;
+}
+
+std::string CGUIWindowFullScreen::GetTimeCodeAsString()
+{
+  int t = m_timeCode;
+  int s = t % 100; t /= 100;
+  int m = t % 100; t /= 100;
+  int h = t % 100;
+
+  boost::format fmt("%02i:%02i:%02i");
+  fmt % h;
+  fmt % m;
+  fmt % s;
+  return fmt.str();
 }
 
 void CGUIWindowFullScreen::SeekChapter(int iChapter)

--- a/xbmc/video/windows/GUIWindowFullScreen.h
+++ b/xbmc/video/windows/GUIWindowFullScreen.h
@@ -57,8 +57,8 @@ private:
 
   /*! \brief Convert the current timecode into a time in seconds to seek
    */
-  double GetTimeCodeStamp();
-
+  double GetTimeCodeAsSeconds();
+  std::string GetTimeCodeAsString();
   bool m_bShowViewModeInfo;
   unsigned int m_dwShowViewModeTimeout;
   CGUIInfoBool m_showCodec;
@@ -66,8 +66,6 @@ private:
   bool m_bShowCurrentTime;
 
   bool m_bGroupSelectShow;
-  bool m_timeCodeShow;
   unsigned int m_timeCodeTimeout;
-  int m_timeCodeStamp[6];
-  int m_timeCodePosition;
+  int m_timeCode;
 };

--- a/xbmc/video/windows/GUIWindowFullScreen.h
+++ b/xbmc/video/windows/GUIWindowFullScreen.h
@@ -58,7 +58,19 @@ private:
   /*! \brief Convert the current timecode into a time in seconds to seek
    */
   double GetTimeCodeAsSeconds();
-  std::string GetTimeCodeAsString();
+
+  /*! \brief Returns timecode as "HH:MM:SS" formated string
+  */
+  std::string GetTimeCodeAsString(int timeCode, int base);
+
+  /*! \brief Seeks to content of Skip Step array
+  */
+  void SeekToSkipStep();
+  
+  /*! \brief converts skip step klicks to seconds
+  */
+  int GetSkipStepTimeCode();
+
   bool m_bShowViewModeInfo;
   unsigned int m_dwShowViewModeTimeout;
   CGUIInfoBool m_showCodec;
@@ -66,6 +78,7 @@ private:
   bool m_bShowCurrentTime;
 
   bool m_bGroupSelectShow;
-  unsigned int m_timeCodeTimeout;
+  unsigned int m_userTimeout;
   int m_timeCode;
+  int m_skipStepCount;
 };


### PR DESCRIPTION
Pipe can handle large packets. Splitting into 64 byte chunks makes no sense.
