### PR TITLE
ffmpeg: bump to 2.5.2

### DIFF
--- a/tools/depends/target/ffmpeg/FFMPEG-VERSION
+++ b/tools/depends/target/ffmpeg/FFMPEG-VERSION
@@ -1,5 +1,5 @@
 LIBNAME=ffmpeg
 BASE_URL=https://github.com/xbmc/FFmpeg/archive
-VERSION=2.4.4-Helix
+VERSION=2.5.2-Isengard-alpha
 ARCHIVE=$(LIBNAME)-$(VERSION).tar.gz
 

--- a/tools/depends/target/ffmpeg/Makefile
+++ b/tools/depends/target/ffmpeg/Makefile
@@ -10,7 +10,7 @@ APPLY_PATCHES=no
 ffmpg_config = --prefix=$(PREFIX) --extra-version="xbmc-$(VERSION)"
 ffmpg_config += --cc=$(CC) --cxx=$(CXX)
 ffmpg_config += --disable-devices --disable-doc
-ffmpg_config += --disable-ffplay --disable-ffmpeg
+ffmpg_config += --disable-ffplay --disable-ffmpeg --disable-sdl
 ffmpg_config += --disable-ffprobe --disable-ffserver
 ffmpg_config += --enable-gpl --enable-runtime-cpudetect
 ffmpg_config += --enable-postproc --enable-pthreads

--- a/tools/depends/target/ffmpeg/autobuild.sh
+++ b/tools/depends/target/ffmpeg/autobuild.sh
@@ -131,6 +131,7 @@ CFLAGS="$CFLAGS" CXXFLAGS="$CXXFLAGS" LDFLAGS="$LDFLAGS" \
 	--disable-devices \
 	--disable-ffplay \
 	--disable-ffmpeg \
+	--disable-sdl \
 	--disable-ffprobe \
 	--disable-ffserver \
 	--disable-doc \


### PR DESCRIPTION
dropped patch due to merge conflict: https://github.com/xbmc/FFmpeg/commit/084fc1406c0deeab826517f53600a54779b99f75
I doubt that is was still needed anyway.

according to @Memphiz suggestion SDL for ffmpeg is explicitly disabled now
