### PR TITLE
[pvr] don't disable addons when database is reset

### DIFF
--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -650,14 +650,6 @@ bool CPVRDatabase::PersistGroupMembers(CPVRChannelGroup &group)
 
 /********** Client methods **********/
 
-bool CPVRDatabase::DeleteClients()
-{
-  CLog::Log(LOGDEBUG, "PVR - %s - deleting all clients from the database", __FUNCTION__);
-
-  return DeleteValues("clients");
-      //TODO && DeleteValues("map_channels_clients");
-}
-
 bool CPVRDatabase::Delete(const CPVRClient &client)
 {
   /* invalid client uid */

--- a/xbmc/pvr/PVRDatabase.h
+++ b/xbmc/pvr/PVRDatabase.h
@@ -154,11 +154,6 @@ namespace PVR
 
     /*! @name Client methods */
     //@{
-    /*!
-     * @brief Remove all client information from the database.
-     * @return True if all clients were removed successfully.
-     */
-    bool DeleteClients();
 
     /*!
      * @brief Add a client to the database if it's not already in there.

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -798,11 +798,6 @@ void CPVRManager::ResetDatabase(bool bResetEPGOnly /* = false */)
       
       pDlgProgress->SetPercentage(80);
       pDlgProgress->Progress();
-
-      /* delete all client information */
-      m_database->DeleteClients();
-      pDlgProgress->SetPercentage(90);
-      pDlgProgress->Progress();
     }
 
     m_database->Close();


### PR DESCRIPTION
This is yet another attempt at fixing bug 15583. Earlier discussed here:

https://github.com/xbmc/xbmc/pull/4761 (introduced the change in behavior)
https://github.com/xbmc/xbmc/pull/5595 (fix, never accepted)
https://github.com/OpenELEC/OpenELEC.tv/pull/3673 (revert of #4761, in OpenELEC since about three weeks)

@opdenkamp AFAICT this introduces no regressions. Disabled addons remain disabled after the database is reset, enabled addons will remain enabled.
