### PR TITLE
AESinkALSA: Workaround alsa-lib buffer overflow in snd_pcm_chmap_print

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
@@ -338,8 +338,10 @@ snd_pcm_chmap_t* CAESinkALSA::CopyALSAchmap(snd_pcm_chmap_t* alsaMap)
 
 std::string CAESinkALSA::ALSAchmapToString(snd_pcm_chmap_t* alsaMap)
 {
-  char buf[64] = { 0 };
-  int err = snd_pcm_chmap_print(alsaMap, sizeof(buf), buf);
+  char buf[128] = { 0 };
+  // ALSA bug - buffer overflow by a factor of 2 is possible
+  // http://mailman.alsa-project.org/pipermail/alsa-devel/2014-December/085815.html
+  int err = snd_pcm_chmap_print(alsaMap, sizeof(buf) / 2, buf);
   if (err < 0)
     return "Error";
   return std::string(buf);


### PR DESCRIPTION
snd_pcm_chmap_print() seems to contain a bug that can cause it to overrun the buffer provided to it in certainc cases. Provide a double-length buffer for it, which the buggy versions cannot overflow.

There might be some other bug in there as well since the channel map string is suspiciously long (64+ chars) if this buffer overflow was indeed actually triggered, but that would be a separate issue.

http://trac.kodi.tv/ticket/15641
http://mailman.alsa-project.org/pipermail/alsa-devel/2014-December/085815.html
