### PR TITLE
[pvr] fix crash when adding video source after disabling live TV

### DIFF
--- a/xbmc/filesystem/PVRDirectory.cpp
+++ b/xbmc/filesystem/PVRDirectory.cpp
@@ -118,5 +118,6 @@ bool CPVRDirectory::IsLiveTV(const std::string& strPath)
 
 bool CPVRDirectory::HasRecordings()
 {
-  return g_PVRRecordings->GetNumRecordings() > 0;
+  return g_PVRManager.IsStarted() ? 
+    g_PVRRecordings->GetNumRecordings() > 0 : false;
 }


### PR DESCRIPTION
Fixes #15591

@opdenkamp don't know if this is the best way to fix it, but at least it works.
