### PR TITLE
[gui] correct the logic for checking whether we have a sort method

### DIFF
--- a/xbmc/view/GUIViewState.cpp
+++ b/xbmc/view/GUIViewState.cpp
@@ -472,7 +472,7 @@ void CGUIViewState::SetSortOrder(SortOrder sortOrder)
   if (sortOrder == SortOrderNone)
     return;
 
-  if (m_currentSortMethod < 0 && m_currentSortMethod >= (int)m_sortMethods.size())
+  if (m_currentSortMethod < 0 || m_currentSortMethod >= (int)m_sortMethods.size())
     return;
 
   m_sortMethods[m_currentSortMethod].m_sortDescription.sortOrder = sortOrder;


### PR DESCRIPTION
Without this, if you go to Live TV -> Guide and change view mode, Kodi will crash and will continue to crash on startup for all eternity.

@Montellese for review. If this turns out to be valid the backported fix will need fixing as well.
