### PR TITLE
configure.in: Fix final_message without PulseAudio

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -1285,6 +1285,7 @@ if test "x$use_pulse" != "xno"; then
       if test "x$use_pulse" = "xyes"; then
         AC_MSG_ERROR($pulse_not_found)
       else
+        use_pulse="no"
         AC_MSG_RESULT($pulse_disabled)
       fi
     fi


### PR DESCRIPTION
Currently, when pulseaudio is not installed,
./configure shows:

```
checking for PULSE... no
== PulseAudio support disabled. ==
```

but at the end

```
------------------------
  Kodi Configuration:
------------------------
...
  PulseAudio:   Yes
```
