### PR TITLE
[fixed] DXVA flickering on AMD

### DIFF
--- a/xbmc/cores/VideoRenderers/DXVA.cpp
+++ b/xbmc/cores/VideoRenderers/DXVA.cpp
@@ -664,6 +664,7 @@ bool CProcessor::Render(CRect src, CRect dst, IDirect3DSurface9* target, IDirect
     vs.Start = frameIdx + (sampIdx - pastFrames) * 2;
     vs.End = vs.Start + 2;
     vs.PlanarAlpha = DXVA2_Fixed32OpaqueAlpha();
+    vs.SampleFormat = m_desc.SampleFormat;
     vs.SampleFormat.SampleFormat = sampleFormat;
     
     // Override the sample format when the processor doesn't need to deinterlace or when deinterlacing is forced and flags are missing.


### PR DESCRIPTION
Though my only qualifying system is a bit odd (Windows 10 with mobility radeon 4xxx). This seems to fix for me the AMD flickering issue: http://forum.kodi.tv/showthread.php?tid=208314. Either way, a fully populated DXVA2_ExtendedFormat for every video sample should not hurt.
