### PR TITLE
AESinkALSA: Workaround alsa-lib buffer overflow in snd_pcm_chmap_print

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
@@ -338,8 +338,10 @@ snd_pcm_chmap_t* CAESinkALSA::CopyALSAchmap(snd_pcm_chmap_t* alsaMap)
 
 std::string CAESinkALSA::ALSAchmapToString(snd_pcm_chmap_t* alsaMap)
 {
-  char buf[64] = { 0 };
-  int err = snd_pcm_chmap_print(alsaMap, sizeof(buf), buf);
+  char buf[128] = { 0 };
+  // ALSA bug - buffer overflow by a factor of 2 is possible
+  // http://mailman.alsa-project.org/pipermail/alsa-devel/2014-December/085815.html
+  int err = snd_pcm_chmap_print(alsaMap, sizeof(buf) / 2, buf);
   if (err < 0)
     return "Error";
   return std::string(buf);


### PR DESCRIPTION
Backport of PR #6065.

Provide a double-length buffer for snd_pcm_chmap_print(), which the
buggy versions cannot overflow.

We are not yet sure if this patch fixes ticket#15641, but this should go in regardless.

http://trac.kodi.tv/ticket/15641
http://mailman.alsa-project.org/pipermail/alsa-devel/2014-December/085815.html
(cherry picked from commit 957f8e2474ce733d9d05cb67b62721e9b3b1c389)
