### PR TITLE
Fix default web interface when not default

### DIFF
--- a/addons/webinterface.default/js/xbmc.core.js
+++ b/addons/webinterface.default/js/xbmc.core.js
@@ -25,7 +25,7 @@
     xbmc.core = {
         'DEFAULT_ALBUM_COVER': 'images/DefaultAlbumCover.png',
         'DEFAULT_VIDEO_COVER': 'images/DefaultVideo.png',
-        'JSON_RPC': 'jsonrpc',
+        'JSON_RPC': '/jsonrpc',
         'applyDeviceFixes': function () {
             window.document.addEventListener('touchmove', function (e) {
                 e.preventDefault();


### PR DESCRIPTION
When the default interface is not default, the user can access it
via http://ip:8080/addons/webinterface.default/
But it won't work, with the error message 'Connection to server lost'.
The reason is that the interface tries to call the rpc at:
http://ip:8080/addons/webinterface.default/jsonrpc
which is clearly incorrect. This one character commit fixes it.
