### PR TITLE
AE: make stream more robust against frequent calls to flush

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
@@ -53,6 +53,7 @@ CActiveAEStream::CActiveAEStream(AEAudioFormat *format)
   m_streamFading = false;
   m_streamFreeBuffers = 0;
   m_streamIsBuffering = false;
+  m_streamIsFlushed = false;
   m_streamSlave = NULL;
   m_leftoverBuffer = new uint8_t[m_format.m_frameSize];
   m_leftoverBytes = 0;
@@ -199,6 +200,8 @@ unsigned int CActiveAEStream::AddData(uint8_t* const *data, unsigned int offset,
   unsigned int copied = 0;
   int sourceFrames = frames;
   uint8_t* const *buf = data;
+
+  m_streamIsFlushed = false;
 
   while(copied < frames)
   {
@@ -385,10 +388,14 @@ bool CActiveAEStream::IsDrained()
 
 void CActiveAEStream::Flush()
 {
-  m_currentBuffer = NULL;
-  m_leftoverBytes = 0;
-  AE.FlushStream(this);
-  ResetFreeBuffers();
+  if (!m_streamIsFlushed)
+  {
+    m_currentBuffer = NULL;
+    m_leftoverBytes = 0;
+    AE.FlushStream(this);
+    ResetFreeBuffers();
+    m_streamIsFlushed = true;
+  }
 }
 
 float CActiveAEStream::GetAmplification()

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.h
@@ -92,6 +92,7 @@ protected:
   bool m_streamFading;
   int m_streamFreeBuffers;
   bool m_streamIsBuffering;
+  bool m_streamIsFlushed;
   IAEStream *m_streamSlave;
   CCriticalSection m_streamLock;
   uint8_t *m_leftoverBuffer;


### PR DESCRIPTION
pvr may be broken after 46373a0afbd72da0902e9cf970d8e53491a1e9d1 because it calls PAUSE on every packet when buffering. every call to pause triggered a call to flush which is a rather heavy operation.
