### PR TITLE
[osx/ios] - enable gnutls

### DIFF
--- a/tools/darwin/Configurations/App.xcconfig.in
+++ b/tools/darwin/Configurations/App.xcconfig.in
@@ -25,6 +25,6 @@ HEADER_SEARCH_PATHS = $(inherited) $SRCROOT xbmc xbmc/linux xbmc/osx xbmc/cores/
 LIBRARY_SEARCH_PATHS = $(inherited) $(SRCROOT) $(SRCROOT)/lib/libRTV $(SRCROOT)/lib/libXDAAP $(SRCROOT)/lib/cmyth/libcmyth $(SRCROOT)/lib/cmyth/librefmem $(SRCROOT)/lib/libsquish $(SRCROOT)/lib/SlingboxLib $(SRCROOT)/xbmc/interfaces/json-rpc "$(SRCROOT)/xbmc/interfaces/python" "$(SRCROOT)/xbmc/interfaces/legacy"
 FRAMEWORK_SEARCH_PATHS = $(inherited) "$(SDKROOT)/System/Library/PrivateFrameworks/" "$(SDKROOT)/System/Library/Frameworks/"
 
-XBMC_OTHER_LDFLAGS_COMMON = $(inherited) -Wl,-headerpad_max_install_names -Wl,-all_load -L$XBMC_DEPENDS/lib -lbz2 -lintl -lexpat -lssl -lgpg-error -lresolv -lffi -lssh -llzo2 -lpcre -lpcrecpp -lfribidi -lfreetype -lfontconfig -lsqlite3 -ltinyxml -lmicrohttpd -lsmbclient -lpython2.6 -lyajl -ljpeg -lcrypto -lgcrypt -lavdevice -lavfilter -lavcodec -lavformat -lpostproc -lavutil -lswresample -lswscale -ltag -L$XBMC_DEPENDS/lib/mysql -lmysqlclient -lxml2 -lxslt
+XBMC_OTHER_LDFLAGS_COMMON = $(inherited) -Wl,-headerpad_max_install_names -Wl,-all_load -L$XBMC_DEPENDS/lib -lbz2 -lintl -lexpat -lssl -lgpg-error -lresolv -lffi -lssh -llzo2 -lpcre -lpcrecpp -lfribidi -lfreetype -lfontconfig -lsqlite3 -ltinyxml -lmicrohttpd -lsmbclient -lpython2.6 -lyajl -ljpeg -lcrypto -lgcrypt -lavdevice -lavfilter -lavcodec -lavformat -lpostproc -lavutil -lswresample -lswscale -ltag -L$XBMC_DEPENDS/lib/mysql -lmysqlclient -lxml2 -lxslt -lnettle -lgmp -lhogweed -lgnutls
 
 

--- a/tools/depends/target/Makefile
+++ b/tools/depends/target/Makefile
@@ -18,6 +18,8 @@ DEPENDS = \
 	xbmc-pvr-addons xbmc-audioencoder-addons \
 	pythonmodule-pil libxslt ffmpeg
 
+FFMPEG_DEPENDS = gnutls
+
 ifeq ($(ENABLE_GPLV3),1)
   DEPENDS+=samba-gplv3 libcdio-gplv3
 else
@@ -26,17 +28,16 @@ endif
 
 ifeq ($(OS),ios)
   DEPENDS += Backrow
-  EXCLUDED_DEPENDS = libcec libusb gmp nettle gnutls
+  EXCLUDED_DEPENDS = libcec libusb
 endif
 
 ifeq ($(OS),osx)
   DEPENDS += libGLEW libsdl
-  EXCLUDED_DEPENDS = libusb gmp nettle gnutls
+  EXCLUDED_DEPENDS = libusb
 endif
 
 ifeq ($(OS),android)
   DEPENDS += mdnsresponder android-sources-ics
-  FFMPEG_DEPENDS = gnutls
 endif
 
 DEPENDS := $(filter-out $(EXCLUDED_DEPENDS),$(DEPENDS))
@@ -63,7 +64,6 @@ ifeq ($(OS),linux)
   endif
   DEPENDS += alsa-lib
   ALSA_LIB = alsa-lib
-  FFMPEG_DEPENDS = gnutls
 endif
 
 .PHONY: $(DEPENDS)

--- a/tools/depends/target/ffmpeg/Makefile
+++ b/tools/depends/target/ffmpeg/Makefile
@@ -18,12 +18,14 @@ ffmpg_config += --enable-muxer=spdif --enable-muxer=adts
 ffmpg_config += --enable-muxer=asf --enable-muxer=ipod
 ffmpg_config += --enable-encoder=ac3 --enable-encoder=aac
 ffmpg_config += --enable-encoder=wmav2 --enable-protocol=http
+ffmpg_config += --enable-gnutls
+
 ifeq ($(CROSS_COMPILING), yes)
   ffmpg_config += --arch=$(CPU) --enable-cross-compile
 endif
 ifeq ($(OS), linux)
   ffmpg_config += --target-os=$(OS) --cpu=$(CPU)
-  ffmpg_config += --enable-vdpau --enable-vaapi --enable-gnutls
+  ffmpg_config += --enable-vdpau --enable-vaapi
   ffmpg_config += --enable-libvorbis --enable-muxer=ogg --enable-encoder=libvorbis
 endif
 ifeq ($(OS), android)
@@ -32,7 +34,7 @@ ifeq ($(OS), android)
   else
     ffmpg_config += --cpu=i686 --disable-mmx
   endif
-  ffmpg_config += --target-os=linux --enable-gnutls
+  ffmpg_config += --target-os=linux
 endif
 ifeq ($(OS), ios)
   ffmpg_config += --cpu=cortex-a8 --yasmexe=$(NATIVEPREFIX)/bin/yasm

--- a/tools/depends/target/gmp/Makefile
+++ b/tools/depends/target/gmp/Makefile
@@ -18,9 +18,14 @@ ifeq ($(OS),linux)
   endif
 endif
 
+ifeq ($(OS),ios)
+CONFIGURE_FLAGS=CC_FOR_BUILD=llvm-gcc CPP_FOR_BUILD="llvm-gcc -E" --disable-assembly
+endif
+
 # configuration settings
 CONFIGURE=cp -f $(CONFIG_SUB) $(CONFIG_GUESS) .; \
-          ./configure --prefix=$(PREFIX) --disable-shared $(ABI)
+          ./configure --prefix=$(PREFIX) --disable-shared $(ABI) $(CONFIGURE_FLAGS)
+
 
 LIBDYLIB=$(PLATFORM)/.libs/lib$(LIBNAME).a
 

--- a/tools/depends/target/nettle/Makefile
+++ b/tools/depends/target/nettle/Makefile
@@ -7,9 +7,15 @@ VERSION=2.7.1
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
 
+ifeq ($(OS),ios)
+  ifneq (,$(findstring 3.,$(XCODE_VERSION)))
+    CONFIGURE_FLAGS=-disable-assembler
+  endif
+endif
+
 # configuration settings
 CONFIGURE=cp -f $(CONFIG_SUB) $(CONFIG_GUESS) .; \
-          ./configure --prefix=$(PREFIX) --disable-shared --disable-openssl
+          ./configure --prefix=$(PREFIX) --disable-shared --disable-openssl $(CONFIGURE_FLAGS)
 
 LIBDYLIB=$(PLATFORM)/lib$(LIBNAME).a
 


### PR DESCRIPTION
This enables gnutls for ios and osx. This means all platforms have gnutls support (so instead of excluding it - we have gnutls enabled by default with this PR for all platforms).

The issues we had might still be there on osx but only show on osx 10.6 which we will drop soon (because of C++11 compatibility for example). So lets enable it and see what users report.

The iOS was never enabled because the dependencies didn't compile - i fixed it now (the asm code of gmp will not compile with the ios assambler - so i had to disable it - i also found that this is the "official" way of compiling gmp for ios).

I tested it on osx and ios with the test https streams from the forum thread here:

http://forum.kodi.tv/showthread.php?tid=209569

@wsnipex for a pair of eyes.
