### PR TITLE
[PVR] Fix for slow metadata updates of recordings

### DIFF
--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -221,7 +221,7 @@ bool CPVRRecording::SetPlayCount(int count)
   return true;
 }
 
-void CPVRRecording::UpdateMetadata(void)
+void CPVRRecording::UpdateMetadata(CVideoDatabase &db)
 {
   if (m_bGotMetaData)
     return;
@@ -231,20 +231,14 @@ void CPVRRecording::UpdateMetadata(void)
   
   if (!supportsPlayCount || !supportsLastPlayed)
   {
-    CVideoDatabase db;
-    if (db.Open())
+    if (!supportsPlayCount)
     {
-      if (!supportsPlayCount)
-      {
-        CFileItem pFileItem(*this);
-        m_playCount = db.GetPlayCount(pFileItem);
-      }
-
-      if (!supportsLastPlayed)
-        db.GetResumeBookMark(m_strFileNameAndPath, m_resumePoint);
-
-      db.Close();
+       CFileItem pFileItem(*this);
+       m_playCount = db.GetPlayCount(pFileItem);
     }
+
+    if (!supportsLastPlayed)
+      db.GetResumeBookMark(m_strFileNameAndPath, m_resumePoint);
   }
   
   m_bGotMetaData = true;

--- a/xbmc/pvr/recordings/PVRRecording.h
+++ b/xbmc/pvr/recordings/PVRRecording.h
@@ -39,6 +39,8 @@
 #include "video/VideoInfoTag.h"
 #include "XBDateTime.h"
 
+class CVideoDatabase;
+
 namespace PVR
 {
   class CPVRRecording;
@@ -149,7 +151,7 @@ namespace PVR
      * @brief Get the resume point and play count from the database if the 
      * client doesn't handle it itself.
      */
-    void UpdateMetadata(void);
+    void UpdateMetadata(CVideoDatabase &db);
 
     /*!
      * @brief Update this tag with the contents of the given tag.

--- a/xbmc/pvr/recordings/PVRRecordings.cpp
+++ b/xbmc/pvr/recordings/PVRRecordings.cpp
@@ -43,14 +43,14 @@ CPVRRecordings::CPVRRecordings(void) :
     m_iLastId(0),
     m_bGroupItems(true)
 {
-  m_dbLoaded = m_db.Open();
+  m_database.Open();
 }
 
 CPVRRecordings::~CPVRRecordings()
 {
   Clear();
-  if (m_dbLoaded)
-    m_db.Close();
+  if (m_database.IsOpen())
+    m_database.Close();
 }
 
 void CPVRRecordings::UpdateFromClients(void)
@@ -126,8 +126,8 @@ void CPVRRecordings::GetSubDirectories(const std::string &strBase, CFileItemList
       strFilePath = StringUtils::Format("pvr://recordings/%s/%s/", strUseBase.c_str(), strCurrent.c_str());
 
     CFileItemPtr pFileItem;
-    if (m_dbLoaded)
-      current->UpdateMetadata(m_db);
+    if (m_database.IsOpen())
+      current->UpdateMetadata(m_database);
 
     if (!results->Contains(strFilePath))
     {
@@ -256,7 +256,7 @@ bool CPVRRecordings::SetRecordingsPlayCount(const CFileItemPtr &item, int count)
 {
   bool bResult = false;
 
-  if (m_dbLoaded)
+  if (m_database.IsOpen())
   {
     bResult = true;
 
@@ -296,11 +296,11 @@ bool CPVRRecordings::SetRecordingsPlayCount(const CFileItemPtr &item, int count)
         // Clear resume bookmark
         if (count > 0)
         {
-          m_db.ClearBookMarksOfFile(pItem->GetPath(), CBookmark::RESUME);
+          m_database.ClearBookMarksOfFile(pItem->GetPath(), CBookmark::RESUME);
           recording->SetLastPlayedPosition(0);
         }
 
-        m_db.SetPlayCount(*pItem, count);
+        m_database.SetPlayCount(*pItem, count);
       }
     }
   }
@@ -333,8 +333,8 @@ bool CPVRRecordings::GetDirectory(const std::string& strPath, CFileItemList &ite
       if (!IsDirectoryMember(strDirectoryPath, current->m_strDirectory))
         continue;
 
-      if (m_dbLoaded)
-        current->UpdateMetadata(m_db);
+      if (m_database.IsOpen())
+        current->UpdateMetadata(m_database);
       CFileItemPtr pFileItem(new CFileItem(*current));
       pFileItem->SetLabel2(current->RecordingTimeAsLocalTime().GetAsLocalizedDateTime(true, false));
       pFileItem->m_dateTime = current->RecordingTimeAsLocalTime();
@@ -373,8 +373,8 @@ void CPVRRecordings::GetAll(CFileItemList &items)
   for (PVR_RECORDINGMAP_CITR it = m_recordings.begin(); it != m_recordings.end(); it++)
   {
     CPVRRecordingPtr current = it->second;
-    if (m_dbLoaded)
-      current->UpdateMetadata(m_db);
+    if (m_database.IsOpen())
+      current->UpdateMetadata(m_database);
 
     CFileItemPtr pFileItem(new CFileItem(*current));
     pFileItem->SetLabel2(current->RecordingTimeAsLocalTime().GetAsLocalizedDateTime(true, false));

--- a/xbmc/pvr/recordings/PVRRecordings.cpp
+++ b/xbmc/pvr/recordings/PVRRecordings.cpp
@@ -43,7 +43,14 @@ CPVRRecordings::CPVRRecordings(void) :
     m_iLastId(0),
     m_bGroupItems(true)
 {
+  m_dbLoaded = m_db.Open();
+}
 
+CPVRRecordings::~CPVRRecordings()
+{
+  Clear();
+  if (m_dbLoaded)
+    m_db.Close();
 }
 
 void CPVRRecordings::UpdateFromClients(void)
@@ -119,8 +126,9 @@ void CPVRRecordings::GetSubDirectories(const std::string &strBase, CFileItemList
       strFilePath = StringUtils::Format("pvr://recordings/%s/%s/", strUseBase.c_str(), strCurrent.c_str());
 
     CFileItemPtr pFileItem;
-    current->UpdateMetadata();
-    
+    if (m_dbLoaded)
+      current->UpdateMetadata(m_db);
+
     if (!results->Contains(strFilePath))
     {
       pFileItem.reset(new CFileItem(strCurrent, true));
@@ -248,8 +256,7 @@ bool CPVRRecordings::SetRecordingsPlayCount(const CFileItemPtr &item, int count)
 {
   bool bResult = false;
 
-  CVideoDatabase database;
-  if (database.Open())
+  if (m_dbLoaded)
   {
     bResult = true;
 
@@ -289,15 +296,13 @@ bool CPVRRecordings::SetRecordingsPlayCount(const CFileItemPtr &item, int count)
         // Clear resume bookmark
         if (count > 0)
         {
-          database.ClearBookMarksOfFile(pItem->GetPath(), CBookmark::RESUME);
+          m_db.ClearBookMarksOfFile(pItem->GetPath(), CBookmark::RESUME);
           recording->SetLastPlayedPosition(0);
         }
 
-        database.SetPlayCount(*pItem, count);
+        m_db.SetPlayCount(*pItem, count);
       }
     }
-
-    database.Close();
   }
 
   return bResult;
@@ -328,7 +333,8 @@ bool CPVRRecordings::GetDirectory(const std::string& strPath, CFileItemList &ite
       if (!IsDirectoryMember(strDirectoryPath, current->m_strDirectory))
         continue;
 
-      current->UpdateMetadata();
+      if (m_dbLoaded)
+        current->UpdateMetadata(m_db);
       CFileItemPtr pFileItem(new CFileItem(*current));
       pFileItem->SetLabel2(current->RecordingTimeAsLocalTime().GetAsLocalizedDateTime(true, false));
       pFileItem->m_dateTime = current->RecordingTimeAsLocalTime();
@@ -367,7 +373,8 @@ void CPVRRecordings::GetAll(CFileItemList &items)
   for (PVR_RECORDINGMAP_CITR it = m_recordings.begin(); it != m_recordings.end(); it++)
   {
     CPVRRecordingPtr current = it->second;
-    current->UpdateMetadata();
+    if (m_dbLoaded)
+      current->UpdateMetadata(m_db);
 
     CFileItemPtr pFileItem(new CFileItem(*current));
     pFileItem->SetLabel2(current->RecordingTimeAsLocalTime().GetAsLocalizedDateTime(true, false));

--- a/xbmc/pvr/recordings/PVRRecordings.h
+++ b/xbmc/pvr/recordings/PVRRecordings.h
@@ -24,6 +24,7 @@
 #include "threads/Thread.h"
 #include "utils/Observer.h"
 #include "video/VideoThumbLoader.h"
+#include "video/VideoDatabase.h"
 
 #define PVR_ALL_RECORDINGS_PATH_EXTENSION "-1"
 
@@ -40,6 +41,8 @@ namespace PVR
     PVR_RECORDINGMAP             m_recordings;
     unsigned int                 m_iLastId;
     bool                         m_bGroupItems;
+    CVideoDatabase               m_db;
+    bool                         m_dbLoaded;
 
     virtual void UpdateFromClients(void);
     virtual std::string TrimSlashes(const std::string &strOrig) const;
@@ -58,7 +61,7 @@ namespace PVR
 
   public:
     CPVRRecordings(void);
-    virtual ~CPVRRecordings(void) { Clear(); };
+    virtual ~CPVRRecordings(void);
 
     int Load();
     void Unload();

--- a/xbmc/pvr/recordings/PVRRecordings.h
+++ b/xbmc/pvr/recordings/PVRRecordings.h
@@ -41,8 +41,7 @@ namespace PVR
     PVR_RECORDINGMAP             m_recordings;
     unsigned int                 m_iLastId;
     bool                         m_bGroupItems;
-    CVideoDatabase               m_db;
-    bool                         m_dbLoaded;
+    CVideoDatabase               m_database;
 
     virtual void UpdateFromClients(void);
     virtual std::string TrimSlashes(const std::string &strOrig) const;


### PR DESCRIPTION
See: http://forum.kodi.tv/showthread.php?tid=210774

metaron identified that entering the recordings screen wih 850 recordings on a Pi
was taking about 40 seconds. The database is opened and closed for every recording,
and this dominates the time taken. With the database open/close pulled out of the loop
it now takes 1.4 seconds.
