### PR TITLE
Samsung CEC return key 0x91 mapping fix

### DIFF
--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -875,6 +875,7 @@ void CPeripheralCecAdapter::PushCecKeypress(const cec_keypress &key)
     PushCecKeypress(xbmcKey);
     break;
   case CEC_USER_CONTROL_CODE_EXIT:
+  case CEC_USER_CONTROL_CODE_AN_RETURN:
     xbmcKey.iButton = XINPUT_IR_REMOTE_BACK;
     PushCecKeypress(xbmcKey);
     break;
@@ -1032,7 +1033,6 @@ void CPeripheralCecAdapter::PushCecKeypress(const cec_keypress &key)
     break;
   case CEC_USER_CONTROL_CODE_NEXT_FAVORITE:
   case CEC_USER_CONTROL_CODE_DOT:
-  case CEC_USER_CONTROL_CODE_AN_RETURN:
     xbmcKey.iButton = XINPUT_IR_REMOTE_TITLE; // context menu
     PushCecKeypress(xbmcKey);
     break;


### PR DESCRIPTION
Samsung uses non-standard CEC code for "return" key. 

Code 0x91 - CEC_USER_CONTROL_CODE_AN_RETURN   is currently wrongly  mapped to ContextMenu.

This is picture of Samsung remote. (see key labelled as "return" )
http://cnet3.cbsistatic.com/hub/i/r/2014/04/18/87d5c07d-f256-4afd-908e-d13534a3e9ee/resize/770x578/d01f7a66d77a53060a46b8dc8a5f7c5d/samsung-un55h6400-product-photos03.jpg

Mapping it to context menu is clearly wrong.

This request fixes this mapping.
