### PR TITLE
dvdplayer: do not wait for buffers when closing subs or teletext in Open...

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -861,7 +861,7 @@ void CDVDPlayer::OpenDefaultStreams(bool reset)
     }
   }
   if(!valid)
-    CloseStream(m_CurrentSubtitle, true);
+    CloseStream(m_CurrentSubtitle, false);
 
   if (!dynamic_cast<CDVDInputStreamNavigator*>(m_pInputStream) || m_PlayerOptions.state.size() == 0)
     SetSubtitleVisibleInternal(visible); // only set subtitle visibility if state not stored by dvd navigator, because navigator will restore it (if visible)
@@ -875,7 +875,7 @@ void CDVDPlayer::OpenDefaultStreams(bool reset)
       valid = true;
   }
   if(!valid)
-    CloseStream(m_CurrentTeletext, true);
+    CloseStream(m_CurrentTeletext, false);
 }
 
 bool CDVDPlayer::ReadPacket(DemuxPacket*& packet, CDemuxStream*& stream)


### PR DESCRIPTION
...DefaultStreams

1) leaving any subtitles in overaycontainer when closing the stream is wrong at this place
2) closing a stream with "waitforbuffers" set causes caching state to to be set to done. we don't want this on a channel switch during caching.
