### PR TITLE
enable dirty regions for full screen video

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2175,9 +2175,6 @@ bool CApplication::RenderNoPresent()
   // dont show GUI when playing full screen video
   if (g_graphicsContext.IsFullScreenVideo())
   {
-    g_graphicsContext.SetRenderingResolution(g_graphicsContext.GetVideoResolution(), false);
-    g_renderManager.Render(true, 0, 255);
-
     // close window overlays
     CGUIDialog *overlay = (CGUIDialog *)g_windowManager.GetWindow(WINDOW_DIALOG_VIDEO_OVERLAY);
     if (overlay) overlay->Close(true);
@@ -2230,7 +2227,6 @@ void CApplication::Render()
     if (!extPlayerActive && g_graphicsContext.IsFullScreenVideo() && !m_pPlayer->IsPausedPlayback())
     {
       m_bPresentFrame = g_renderManager.FrameWait(100);
-      hasRendered = true;
     }
     else
     {
@@ -2273,8 +2269,6 @@ void CApplication::Render()
   if(!g_Windowing.BeginRender())
     return;
 
-  g_renderManager.FrameMove();
-
   CDirtyRegionList dirtyRegions = g_windowManager.GetDirty();
   if(g_graphicsContext.GetStereoMode())
   {
@@ -2295,8 +2289,6 @@ void CApplication::Render()
     if(RenderNoPresent())
       hasRendered = true;
   }
-
-  g_renderManager.FrameFinish();
 
   g_Windowing.EndRender();
 
@@ -2322,7 +2314,7 @@ void CApplication::Render()
     flip = true;
 
   //fps limiter, make sure each frame lasts at least singleFrameTime milliseconds
-  if (limitFrames || !flip)
+  if (limitFrames || !(flip || m_bPresentFrame))
   {
     if (!limitFrames)
       singleFrameTime = 40; //if not flipping, loop at 25 fps

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2217,16 +2217,17 @@ void CApplication::Render()
   bool limitFrames = false;
   unsigned int singleFrameTime = 10; // default limit 100 fps
 
+  // Whether externalplayer is playing and we're unfocused
+  bool extPlayerActive = m_pPlayer->GetCurrentPlayer() == EPC_EXTPLAYER && m_pPlayer->IsPlaying() && !m_AppFocused;
+
   {
     // Less fps in DPMS
     bool lowfps = m_dpmsIsActive || g_Windowing.EnableFrameLimiter();
-    // Whether externalplayer is playing and we're unfocused
-    bool extPlayerActive = m_pPlayer->GetCurrentPlayer() == EPC_EXTPLAYER && m_pPlayer->IsPlaying() && !m_AppFocused;
 
     m_bPresentFrame = false;
     if (!extPlayerActive && g_graphicsContext.IsFullScreenVideo() && !m_pPlayer->IsPausedPlayback())
     {
-      m_bPresentFrame = g_renderManager.FrameWait(100);
+      m_bPresentFrame = g_renderManager.HasFrame();
     }
     else
     {
@@ -2326,6 +2327,11 @@ void CApplication::Render()
 
   if (flip)
     g_graphicsContext.Flip(dirtyRegions);
+
+  if (!extPlayerActive && g_graphicsContext.IsFullScreenVideo() && !m_pPlayer->IsPausedPlayback())
+  {
+    g_renderManager.FrameWait(100);
+  }
 
   m_lastFrameTime = XbmcThreads::SystemClockMillis();
   CTimeUtils::UpdateFrameTime(flip);

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2227,7 +2227,7 @@ void CApplication::Render()
     bool extPlayerActive = m_pPlayer->GetCurrentPlayer() == EPC_EXTPLAYER && m_pPlayer->IsPlaying() && !m_AppFocused;
 
     m_bPresentFrame = false;
-    if (!extPlayerActive && g_graphicsContext.IsFullScreenVideo() && !m_pPlayer->IsPausedPlayback() && g_renderManager.RendererHandlesPresent())
+    if (!extPlayerActive && g_graphicsContext.IsFullScreenVideo() && !m_pPlayer->IsPausedPlayback())
     {
       m_bPresentFrame = g_renderManager.FrameWait(100);
       hasRendered = true;

--- a/xbmc/cores/VideoRenderers/BaseRenderer.h
+++ b/xbmc/cores/VideoRenderers/BaseRenderer.h
@@ -94,6 +94,7 @@ public:
   virtual void         SetBufferSize(int numBuffers) { }
   virtual void         ReleaseBuffer(int idx) { }
   virtual bool         NeedBufferForRef(int idx) { return false; }
+  virtual bool         IsGuiLayer() { return true; }
 
   virtual bool Supports(ERENDERFEATURE feature) { return false; }
 

--- a/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
@@ -522,32 +522,16 @@ void CLinuxRendererGLES::Update()
 
 void CLinuxRendererGLES::RenderUpdate(bool clear, DWORD flags, DWORD alpha)
 {
-  if (!m_bConfigured) return;
+  if (!m_bConfigured)
+    return;
 
   // if its first pass, just init textures and return
   if (ValidateRenderTarget())
     return;
 
-  if (m_renderMethod & RENDER_BYPASS)
+  if (!IsGuiLayer())
   {
-    ManageDisplay();
-    // if running bypass, then the player might need the src/dst rects
-    // for sizing video playback on a layer other than the gles layer.
-    if (m_RenderUpdateCallBackFn)
-      (*m_RenderUpdateCallBackFn)(m_RenderUpdateCallBackCtx, m_sourceRect, m_destRect);
-
-    CRect old = g_graphicsContext.GetScissors();
-
-    g_graphicsContext.BeginPaint();
-    g_graphicsContext.SetScissors(m_destRect);
-
-    glEnable(GL_BLEND);
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-    glClearColor(0, 0, 0, 0);
-    glClear(GL_COLOR_BUFFER_BIT);
-
-    g_graphicsContext.SetScissors(old);
-    g_graphicsContext.EndPaint();
+    RenderUpdateVideo(clear, flags, alpha);
     return;
   }
 
@@ -604,6 +588,26 @@ void CLinuxRendererGLES::RenderUpdate(bool clear, DWORD flags, DWORD alpha)
   glEnable(GL_BLEND);
 
   g_graphicsContext.EndPaint();
+}
+
+void CLinuxRendererGLES::RenderUpdateVideo(bool clear, DWORD flags, DWORD alpha)
+{
+  if (!m_bConfigured)
+    return;
+
+  if (IsGuiLayer())
+    return;
+
+  if (m_renderMethod & RENDER_BYPASS)
+  {
+    ManageDisplay();
+    // if running bypass, then the player might need the src/dst rects
+    // for sizing video playback on a layer other than the gles layer.
+    if (m_RenderUpdateCallBackFn)
+      (*m_RenderUpdateCallBackFn)(m_RenderUpdateCallBackCtx, m_sourceRect, m_destRect);
+
+    return;
+  }
 }
 
 void CLinuxRendererGLES::FlipPage(int source)
@@ -3129,6 +3133,14 @@ void CLinuxRendererGLES::AddProcessor(CDVDVideoCodecIMXBuffer *buffer, int index
     buffer->Lock();
 }
 #endif
+
+bool CLinuxRendererGLES::IsGuiLayer()
+{
+  if (m_format == RENDER_FMT_BYPASS)
+    return false;
+  else
+    return true;
+}
 
 #endif
 

--- a/xbmc/cores/VideoRenderers/LinuxRendererGLES.h
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGLES.h
@@ -144,6 +144,7 @@ public:
   virtual void         SetBufferSize(int numBuffers) { m_NumYV12Buffers = numBuffers; }
   virtual unsigned int GetMaxBufferSize() { return NUM_BUFFERS; }
   virtual unsigned int GetOptimalBufferSize();
+  virtual bool         IsGuiLayer();
 
   virtual void RenderUpdate(bool clear, DWORD flags = 0, DWORD alpha = 255);
 
@@ -177,6 +178,7 @@ public:
 
 protected:
   virtual void Render(DWORD flags, int index);
+  void RenderUpdateVideo(bool clear, DWORD flags = 0, DWORD alpha = 255);
 
   int  NextYV12Texture();
   virtual bool ValidateRenderTarget();

--- a/xbmc/cores/VideoRenderers/MMALRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/MMALRenderer.cpp
@@ -347,21 +347,6 @@ void CMMALRenderer::RenderUpdate(bool clear, DWORD flags, DWORD alpha)
   // for sizing video playback on a layer other than the gles layer.
   if (m_RenderUpdateCallBackFn)
     (*m_RenderUpdateCallBackFn)(m_RenderUpdateCallBackCtx, m_sourceRect, m_destRect);
-
-  SetVideoRect(m_sourceRect, m_destRect);
-
-  CRect old = g_graphicsContext.GetScissors();
-
-  g_graphicsContext.BeginPaint();
-  g_graphicsContext.SetScissors(m_destRect);
-
-  glEnable(GL_BLEND);
-  glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-  glClearColor(0, 0, 0, 0);
-  glClear(GL_COLOR_BUFFER_BIT);
-
-  g_graphicsContext.SetScissors(old);
-  g_graphicsContext.EndPaint();
 }
 
 void CMMALRenderer::FlipPage(int source)

--- a/xbmc/cores/VideoRenderers/MMALRenderer.h
+++ b/xbmc/cores/VideoRenderers/MMALRenderer.h
@@ -90,6 +90,7 @@ public:
   virtual unsigned int GetMaxBufferSize() { return NUM_BUFFERS; }
   virtual unsigned int GetOptimalBufferSize() { return NUM_BUFFERS; }
   virtual void SetVideoRect(const CRect& SrcRect, const CRect& DestRect);
+  virtual bool         IsGuiLayer() { return false; }
 
   void vout_input_port_cb(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer);
 protected:

--- a/xbmc/cores/VideoRenderers/OverlayRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/OverlayRenderer.cpp
@@ -306,6 +306,24 @@ void CRenderer::Render(COverlay* o, float adjust_height)
   o->Render(state);
 }
 
+bool CRenderer::HasOverlay(int idx)
+{
+  bool hasOverlay = false;
+
+  CSingleLock lock(m_section);
+
+  SElementV& list = m_buffers[idx];
+  for(SElementV::iterator it = list.begin(); it != list.end(); ++it)
+  {
+    if (it->overlay || it->overlay_dvd)
+    {
+      hasOverlay = true;
+      break;
+    }
+  }
+  return hasOverlay;
+}
+
 COverlay* CRenderer::Convert(CDVDOverlaySSA* o, double pts)
 {
   CRect src, dst;

--- a/xbmc/cores/VideoRenderers/OverlayRenderer.h
+++ b/xbmc/cores/VideoRenderers/OverlayRenderer.h
@@ -100,6 +100,7 @@ namespace OVERLAY {
     void Render(int idx);
     void Flush();
     void Release(int idx);
+    bool HasOverlay(int idx);
 
   protected:
 

--- a/xbmc/cores/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoRenderers/RenderManager.cpp
@@ -293,17 +293,10 @@ bool CXBMCRenderManager::Configure(unsigned int width, unsigned int height, unsi
     m_sleeptime = 1.0;
     m_presentevent.notifyAll();
 
-    m_firstFlipPage = false;  // tempfix
-
     CLog::Log(LOGDEBUG, "CXBMCRenderManager::Configure - %d", m_QueueSize);
   }
 
   return result;
-}
-
-bool CXBMCRenderManager::RendererHandlesPresent() const
-{
-  return IsConfigured() && (m_firstFlipPage || m_format != RENDER_FMT_BYPASS);
 }
 
 bool CXBMCRenderManager::IsConfigured() const
@@ -660,8 +653,6 @@ void CXBMCRenderManager::FlipPage(volatile bool& bStop, double timestamp /* = 0L
       return;
 
     if(!m_pRenderer) return;
-
-    m_firstFlipPage = true;              // tempfix
 
     EPRESENTMETHOD presentmethod;
 

--- a/xbmc/cores/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoRenderers/RenderManager.cpp
@@ -381,7 +381,10 @@ void CXBMCRenderManager::FrameFinish()
   SPresent& m = m_Queue[m_presentsource];
 
   if(g_graphicsContext.IsFullScreenVideo())
+  {
+    CSingleExit lock(g_graphicsContext);
     WaitPresentTime(m.timestamp);
+  }
 
   m_clock_framefinish = GetPresentTime();
 

--- a/xbmc/cores/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoRenderers/RenderManager.cpp
@@ -316,13 +316,21 @@ void CXBMCRenderManager::Update()
     m_pRenderer->Update();
 }
 
-bool CXBMCRenderManager::FrameWait(int ms)
+void CXBMCRenderManager::FrameWait(int ms)
 {
   XbmcThreads::EndTime timeout(ms);
   CSingleLock lock(m_presentlock);
   while(m_presentstep == PRESENT_IDLE && !timeout.IsTimePast())
     m_presentevent.wait(lock, timeout.MillisLeft());
-  return m_presentstep != PRESENT_IDLE;
+}
+
+bool CXBMCRenderManager::HasFrame()
+{
+  CSingleLock lock(m_presentlock);
+  if (m_presentstep == PRESENT_FRAME || m_presentstep == PRESENT_FRAME2)
+    return true;
+  else
+    return false;
 }
 
 void CXBMCRenderManager::FrameMove()

--- a/xbmc/cores/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoRenderers/RenderManager.cpp
@@ -120,6 +120,7 @@ CXBMCRenderManager::CXBMCRenderManager()
   m_QueueSize   = 2;
   m_QueueSkip   = 0;
   m_format      = RENDER_FMT_NONE;
+  m_renderedOverlay = false;
 }
 
 CXBMCRenderManager::~CXBMCRenderManager()
@@ -233,7 +234,7 @@ bool CXBMCRenderManager::Configure(unsigned int width, unsigned int height, unsi
 
   /* make sure any queued frame was fully presented */
   XbmcThreads::EndTime endtime(5000);
-  while(m_presentstep != PRESENT_IDLE)
+  while(m_presentstep != PRESENT_IDLE && m_presentstep != PRESENT_READY)
   {
     if(endtime.IsTimePast())
     {
@@ -292,6 +293,7 @@ bool CXBMCRenderManager::Configure(unsigned int width, unsigned int height, unsi
     m_presentpts = DVD_NOPTS_VALUE;
     m_sleeptime = 1.0;
     m_presentevent.notifyAll();
+    m_renderedOverlay = false;
 
     CLog::Log(LOGDEBUG, "CXBMCRenderManager::Configure - %d", m_QueueSize);
   }
@@ -766,22 +768,58 @@ void CXBMCRenderManager::RegisterRenderFeaturesCallBack(const void *ctx, RenderF
     m_pRenderer->RegisterRenderFeaturesCallBack(ctx, fn);
 }
 
-void CXBMCRenderManager::Render(bool clear, DWORD flags, DWORD alpha)
+void CXBMCRenderManager::Render(bool clear, DWORD flags, DWORD alpha, bool gui)
 {
   CSharedLock lock(m_sharedSection);
 
-  SPresent& m = m_Queue[m_presentsource];
+  if (!gui && m_pRenderer->IsGuiLayer())
+    return;
 
-  if( m.presentmethod == PRESENT_METHOD_BOB )
-    PresentFields(clear, flags, alpha);
-  else if( m.presentmethod == PRESENT_METHOD_WEAVE )
-    PresentFields(clear, flags | RENDER_FLAG_WEAVE, alpha);
-  else if( m.presentmethod == PRESENT_METHOD_BLEND )
-    PresentBlend(clear, flags, alpha);
-  else
-    PresentSingle(clear, flags, alpha);
+  if (!gui || m_pRenderer->IsGuiLayer())
+  {
+    SPresent& m = m_Queue[m_presentsource];
 
-  m_overlays.Render(m_presentsource);
+    if( m.presentmethod == PRESENT_METHOD_BOB )
+      PresentFields(clear, flags, alpha);
+    else if( m.presentmethod == PRESENT_METHOD_WEAVE )
+      PresentFields(clear, flags | RENDER_FLAG_WEAVE, alpha);
+    else if( m.presentmethod == PRESENT_METHOD_BLEND )
+      PresentBlend(clear, flags, alpha);
+    else
+      PresentSingle(clear, flags, alpha);
+  }
+
+  if (gui)
+  {
+    m_renderedOverlay = m_overlays.HasOverlay(m_presentsource);
+    m_overlays.Render(m_presentsource);
+  }
+}
+
+bool CXBMCRenderManager::IsGuiLayer()
+{
+  { CSingleLock lock(m_presentlock);
+
+    if (!m_pRenderer)
+      return false;
+
+    if (m_pRenderer->IsGuiLayer() || m_renderedOverlay || m_overlays.HasOverlay(m_presentsource))
+      return true;
+  }
+  return false;
+}
+
+bool CXBMCRenderManager::IsVideoLayer()
+{
+  { CSingleLock lock(m_presentlock);
+
+    if (!m_pRenderer)
+      return false;
+
+    if (!m_pRenderer->IsGuiLayer())
+      return true;
+  }
+  return false;
 }
 
 /* simple present method */

--- a/xbmc/cores/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoRenderers/RenderManager.h
@@ -143,8 +143,6 @@ public:
 
   void UpdateResolution();
 
-  bool RendererHandlesPresent() const;
-
 #ifdef HAS_GL
   CLinuxRendererGL    *m_pRenderer;
 #elif defined(HAS_MMAL)
@@ -267,9 +265,6 @@ protected:
   //set to true when adding something to m_captures, set to false when m_captures is made empty
   //std::list::empty() isn't thread safe, using an extra bool will save a lock per render when no captures are requested
   bool                       m_hasCaptures; 
-
-  // temporary fix for RendererHandlesPresent after #2811
-  bool m_firstFlipPage;
 };
 
 extern CXBMCRenderManager g_renderManager;

--- a/xbmc/cores/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoRenderers/RenderManager.h
@@ -59,7 +59,8 @@ public:
   void Update();
   void FrameMove();
   void FrameFinish();
-  bool FrameWait(int ms);
+  void FrameWait(int ms);
+  bool HasFrame();
   void Render(bool clear, DWORD flags = 0, DWORD alpha = 255, bool gui = true);
   bool IsGuiLayer();
   bool IsVideoLayer();

--- a/xbmc/cores/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoRenderers/RenderManager.h
@@ -60,7 +60,9 @@ public:
   void FrameMove();
   void FrameFinish();
   bool FrameWait(int ms);
-  void Render(bool clear, DWORD flags = 0, DWORD alpha = 255);
+  void Render(bool clear, DWORD flags = 0, DWORD alpha = 255, bool gui = true);
+  bool IsGuiLayer();
+  bool IsVideoLayer();
   void SetupScreenshot();
 
   CRenderCapture* AllocRenderCapture();
@@ -257,6 +259,7 @@ protected:
 
 
   OVERLAY::CRenderer m_overlays;
+  bool m_renderedOverlay;
 
   void RenderCapture(CRenderCapture* capture);
   void RemoveCapture(CRenderCapture* capture);

--- a/xbmc/guilib/GUIControl.cpp
+++ b/xbmc/guilib/GUIControl.cpp
@@ -511,6 +511,8 @@ void CGUIControl::SetVisible(bool bVisible, bool setVisState)
   {
     m_forceHidden = !bVisible;
     SetInvalid();
+    if (m_forceHidden)
+      MarkDirtyRegion();
   }
   if (m_forceHidden)
   { // reset any visible animations that are in process

--- a/xbmc/guilib/GUIControl.h
+++ b/xbmc/guilib/GUIControl.h
@@ -83,6 +83,9 @@ public:
   virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
   virtual void DoRender();
   virtual void Render() {};
+  // Called after the actual rendering is completed to trigger additional
+  // non GUI rendering operations
+  virtual void RenderEx() {};
 
   /*! \brief Returns whether or not we have processed */
   bool HasProcessed() const { return m_hasProcessed; };

--- a/xbmc/guilib/GUIControlGroup.cpp
+++ b/xbmc/guilib/GUIControlGroup.cpp
@@ -133,6 +133,13 @@ void CGUIControlGroup::Render()
   g_graphicsContext.RestoreOrigin();
 }
 
+void CGUIControlGroup::RenderEx()
+{
+  for (iControls it = m_children.begin(); it != m_children.end(); ++it)
+    (*it)->RenderEx();
+  CGUIControl::RenderEx();
+}
+
 bool CGUIControlGroup::OnAction(const CAction &action)
 {
   assert(false);  // unimplemented

--- a/xbmc/guilib/GUIControlGroup.h
+++ b/xbmc/guilib/GUIControlGroup.h
@@ -42,6 +42,7 @@ public:
 
   virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
   virtual void Render();
+  virtual void RenderEx();
   virtual bool OnAction(const CAction &action);
   virtual bool OnMessage(CGUIMessage& message);
   virtual bool SendControlMessage(CGUIMessage& message);

--- a/xbmc/guilib/GUIVideoControl.cpp
+++ b/xbmc/guilib/GUIVideoControl.cpp
@@ -43,8 +43,7 @@ CGUIVideoControl::~CGUIVideoControl(void)
 void CGUIVideoControl::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
   // TODO Proper processing which marks when its actually changed. Just mark always for now.
-  if (g_renderManager.RendererHandlesPresent())
-    MarkDirtyRegion();
+  MarkDirtyRegion();
 
   CGUIControl::Process(currentTime, dirtyregions);
 }

--- a/xbmc/guilib/GUIVideoControl.cpp
+++ b/xbmc/guilib/GUIVideoControl.cpp
@@ -42,8 +42,11 @@ CGUIVideoControl::~CGUIVideoControl(void)
 
 void CGUIVideoControl::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
+  g_renderManager.FrameMove();
+
   // TODO Proper processing which marks when its actually changed. Just mark always for now.
-  MarkDirtyRegion();
+  if (g_renderManager.IsGuiLayer())
+    MarkDirtyRegion();
 
   CGUIControl::Process(currentTime, dirtyregions);
 }
@@ -67,12 +70,36 @@ void CGUIVideoControl::Render()
 
 #ifdef HAS_VIDEO_PLAYBACK
     color_t alpha = g_graphicsContext.MergeAlpha(0xFF000000) >> 24;
-    g_renderManager.Render(false, 0, alpha);
+    if (g_renderManager.IsVideoLayer())
+    {
+      CRect old = g_graphicsContext.GetScissors();
+      CRect region = GetRenderRegion();
+      region.Intersect(old);
+      g_graphicsContext.BeginPaint();
+      g_graphicsContext.SetScissors(region);
+      g_graphicsContext.Clear(0);
+      g_graphicsContext.SetScissors(old);
+      g_graphicsContext.EndPaint();
+    }
+    else
+      g_renderManager.Render(false, 0, alpha);
 #else
     ((CDummyVideoPlayer *)g_application.m_pPlayer->GetInternal())->Render();
 #endif
   }
+  // TODO: remove this crap: HAS_VIDEO_PLAYBACK
+  // instantiateing a vidio control having no playback is complete nonsense
   CGUIControl::Render();
+}
+
+void CGUIVideoControl::RenderEx()
+{
+#ifdef HAS_VIDEO_PLAYBACK
+  if (g_application.m_pPlayer->IsPlayingVideo() && g_renderManager.IsStarted())
+    g_renderManager.Render(false, 0, 255, false);
+  g_renderManager.FrameFinish();
+#endif
+  CGUIControl::RenderEx();
 }
 
 EVENT_RESULT CGUIVideoControl::OnMouseEvent(const CPoint &point, const CMouseEvent &event)

--- a/xbmc/guilib/GUIVideoControl.h
+++ b/xbmc/guilib/GUIVideoControl.h
@@ -44,6 +44,7 @@ public:
 
   virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
   virtual void Render();
+  virtual void RenderEx();
   virtual EVENT_RESULT OnMouseEvent(const CPoint &point, const CMouseEvent &event);
   virtual bool CanFocus() const;
   virtual bool CanFocusFromPoint(const CPoint &point) const;

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -548,6 +548,24 @@ void CGUIWindowManager::RenderPass() const
   }
 }
 
+void CGUIWindowManager::RenderEx() const
+{
+  CGUIWindow* pWindow = GetWindow(GetActiveWindow());
+  if (pWindow)
+    pWindow->RenderEx();
+
+  // We don't call RenderEx for now on dialogs since it is used
+  // to trigger non gui video rendering. We can activate it later at any time.
+  /*
+  vector<CGUIWindow *> &activeDialogs = m_activeDialogs;
+  for (iDialog it = activeDialogs.begin(); it != activeDialogs.end(); ++it)
+  {
+    if ((*it)->IsDialogRunning())
+      (*it)->RenderEx();
+  }
+  */
+}
+
 bool CGUIWindowManager::Render()
 {
   assert(g_application.IsCurrentThread());
@@ -587,12 +605,14 @@ bool CGUIWindowManager::Render()
   if (g_advancedSettings.m_guiVisualizeDirtyRegions)
   {
     g_graphicsContext.SetRenderingResolution(g_graphicsContext.GetResInfo(), false);
-    const CDirtyRegionList &markedRegions  = m_tracker.GetMarkedRegions(); 
+    const CDirtyRegionList &markedRegions  = m_tracker.GetMarkedRegions();
     for (CDirtyRegionList::const_iterator i = markedRegions.begin(); i != markedRegions.end(); ++i)
       CGUITexture::DrawQuad(*i, 0x0fff0000);
     for (CDirtyRegionList::const_iterator i = dirtyRegions.begin(); i != dirtyRegions.end(); ++i)
       CGUITexture::DrawQuad(*i, 0x4c00ff00);
   }
+
+  RenderEx();
 
   return hasRendered;
 }

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -144,6 +144,7 @@ public:
 #endif
 private:
   void RenderPass() const;
+  void RenderEx() const;
 
   void LoadNotOnDemandWindows();
   void UnloadNotOnDemandWindows();

--- a/xbmc/video/dialogs/GUIDialogTeletext.cpp
+++ b/xbmc/video/dialogs/GUIDialogTeletext.cpp
@@ -46,7 +46,10 @@ CGUIDialogTeletext::~CGUIDialogTeletext()
 bool CGUIDialogTeletext::OnAction(const CAction& action)
 {
   if (m_TextDecoder.HandleAction(action))
+  {
+    MarkDirtyRegion();
     return true;
+  }
 
   return CGUIDialog::OnAction(action);
 }
@@ -54,6 +57,7 @@ bool CGUIDialogTeletext::OnAction(const CAction& action)
 bool CGUIDialogTeletext::OnBack(int actionID)
 {
   m_bClose = true;
+  MarkDirtyRegion();
   return true;
 }
 
@@ -79,6 +83,12 @@ bool CGUIDialogTeletext::OnMessage(CGUIMessage& message)
   return CGUIDialog::OnMessage(message);
 }
 
+void CGUIDialogTeletext::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
+{
+  CGUIDialog::Process(currentTime, dirtyregions);
+  m_renderRegion = m_vertCoords;
+}
+
 void CGUIDialogTeletext::Render()
 {
   // Do not render if we have no texture
@@ -93,12 +103,18 @@ void CGUIDialogTeletext::Render()
   if (!m_bClose)
   {
     if (teletextFadeAmount < 100)
+    {
       teletextFadeAmount = std::min(100, teletextFadeAmount + 5);
+      MarkDirtyRegion();
+    }
   }
   else
   {
     if (teletextFadeAmount > 0)
+    {
       teletextFadeAmount = std::max(0, teletextFadeAmount - 10);
+      MarkDirtyRegion();
+    }
 
     if (teletextFadeAmount == 0)
       Close();
@@ -109,6 +125,7 @@ void CGUIDialogTeletext::Render()
   {
     m_pTxtTexture->Update(m_TextDecoder.GetWidth(), m_TextDecoder.GetHeight(), m_TextDecoder.GetWidth()*4, XB_FMT_A8R8G8B8, textureBuffer, false);
     m_TextDecoder.RenderingDone();
+    MarkDirtyRegion();
   }
 
   color_t color = ((color_t)(teletextFadeAmount * 2.55f) & 0xff) << 24 | 0xFFFFFF;
@@ -184,4 +201,6 @@ void CGUIDialogTeletext::SetCoordinates()
     top,
     right,
     bottom);
+
+  MarkDirtyRegion();
 }

--- a/xbmc/video/dialogs/GUIDialogTeletext.h
+++ b/xbmc/video/dialogs/GUIDialogTeletext.h
@@ -32,6 +32,7 @@ public:
   virtual bool OnMessage(CGUIMessage& message);
   virtual bool OnAction(const CAction& action);
   virtual bool OnBack(int actionID);
+  virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
   virtual void Render();
   virtual void OnInitWindow();
   virtual void OnDeinitWindow(int nextWindowID);

--- a/xbmc/video/windows/GUIWindowFullScreen.h
+++ b/xbmc/video/windows/GUIWindowFullScreen.h
@@ -30,9 +30,11 @@ public:
   virtual ~CGUIWindowFullScreen(void);
   virtual bool OnMessage(CGUIMessage& message);
   virtual bool OnAction(const CAction &action);
+  virtual void ClearBackground();
   virtual void FrameMove();
   virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregion);
   virtual void Render();
+  virtual void RenderEx();
   virtual void OnWindowLoaded();
   void ChangetheTimeCode(int remote);
 


### PR DESCRIPTION
Moves video rendering (fullscreen) from application to GUIWindowFullScreen. By doing this dirty regions work on fullscreen mode and the platform has separate layers for video and ui.

@popcornmix iirc you still need some options to limit fps of gui, right?
