### PR TITLE
[pvr] attempt to fix occasional crash when persisting channels

### DIFF
--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -193,25 +193,6 @@ void CPVRDatabase::UpdateTables(int iVersion)
     m_pDS->exec("ALTER TABLE channelgroups ADD bIsHidden bool");
 }
 
-int CPVRDatabase::GetLastChannelId(void)
-{
-  int iReturn(0);
-
-  std::string strQuery = PrepareSQL("SELECT MAX(idChannel) as iMaxChannel FROM channels");
-  if (ResultQuery(strQuery))
-  {
-    try
-    {
-      if (!m_pDS->eof())
-        iReturn = m_pDS->fv("iMaxChannel").get_asInt();
-      m_pDS->close();
-    }
-    catch (...) {}
-  }
-
-  return iReturn;
-}
-
 /********** Channel methods **********/
 
 bool CPVRDatabase::DeleteChannels(void)
@@ -591,21 +572,13 @@ int CPVRDatabase::Get(CPVRChannelGroup &group)
 bool CPVRDatabase::PersistChannels(CPVRChannelGroup &group)
 {
   bool bReturn(true);
-  int iLastChannel(0);
-
-  /* we can only safely get this from a local db */
-  if (m_sqlite)
-    iLastChannel = GetLastChannelId();
 
   for (unsigned int iChannelPtr = 0; iChannelPtr < group.m_members.size(); iChannelPtr++)
   {
     PVRChannelGroupMember member = group.m_members.at(iChannelPtr);
+    
     if (member.channel->IsChanged() || member.channel->IsNew())
-    {
-      if (m_sqlite && member.channel->IsNew())
-        member.channel->SetChannelID(++iLastChannel);
-      bReturn &= Persist(*member.channel, m_sqlite || !member.channel->IsNew());
-    }
+      bReturn &= Persist(*member.channel);
   }
 
   bReturn &= CommitInsertQueries();
@@ -750,7 +723,7 @@ int CPVRDatabase::Persist(const AddonPtr client)
   return iReturn;
 }
 
-bool CPVRDatabase::Persist(CPVRChannel &channel, bool bQueueWrite /* = false */)
+bool CPVRDatabase::Persist(CPVRChannel &channel)
 {
   bool bReturn(false);
 
@@ -789,16 +762,12 @@ bool CPVRDatabase::Persist(CPVRChannel &channel, bool bQueueWrite /* = false */)
         channel.EpgID());
   }
 
-  if (bQueueWrite)
+  if (ExecuteQuery(strQuery))
   {
-    QueueInsertQuery(strQuery);
-    bReturn = true;
-  }
-  else if (ExecuteQuery(strQuery))
-  {
-    CSingleLock lock(channel.m_critSection);
-    if (channel.m_iChannelId <= 0)
-      channel.m_iChannelId = (int)m_pDS->lastinsertid();
+    /* update the channel ID for new channels */
+    if (channel.ChannelID() <= 0)
+      channel.SetChannelID((int)m_pDS->lastinsertid());
+
     bReturn = true;
   }
 

--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -773,3 +773,19 @@ bool CPVRDatabase::Persist(CPVRChannel &channel)
 
   return bReturn;
 }
+
+bool CPVRDatabase::UpdateLastWatched(const CPVRChannel &channel)
+{
+  std::string strQuery = PrepareSQL("UPDATE channels SET iLastWatched = %d WHERE idChannel = %d",
+    channel.LastWatched(), channel.ChannelID());
+
+  return ExecuteQuery(strQuery);
+}
+
+bool CPVRDatabase::UpdateLastWatched(const CPVRChannelGroup &group)
+{
+  std::string strQuery = PrepareSQL("UPDATE channelgroups SET iLastWatched = %d WHERE idGroup = %d",
+    group.LastWatched(), group.GroupID());
+
+  return ExecuteQuery(strQuery);
+}

--- a/xbmc/pvr/PVRDatabase.h
+++ b/xbmc/pvr/PVRDatabase.h
@@ -86,10 +86,9 @@ namespace PVR
     /*!
      * @brief Add or update a channel entry in the database
      * @param channel The channel to persist.
-     * @param bQueueWrite If true, don't write immediately
      * @return True when persisted or queued, false otherwise.
      */
-    bool Persist(CPVRChannel &channel, bool bQueueWrite = false);
+    bool Persist(CPVRChannel &channel);
 
     /*!
      * @brief Remove a channel entry from the database
@@ -195,7 +194,6 @@ namespace PVR
     bool DeleteChannelsFromGroup(const CPVRChannelGroup &group, const std::vector<int> &channelsToDelete);
 
     bool GetCurrentGroupMembers(const CPVRChannelGroup &group, std::vector<int> &members);
-    int GetLastChannelId(void);
     bool RemoveStaleChannelsFromGroup(const CPVRChannelGroup &group);
 
     /*!

--- a/xbmc/pvr/PVRDatabase.h
+++ b/xbmc/pvr/PVRDatabase.h
@@ -180,6 +180,20 @@ namespace PVR
      * @return The database ID of the client or -1 if it wasn't found.
      */
     int GetClientId(const std::string &strClientUid);
+
+    /*!
+    * @brief Updates the last watched timestamp for the channel
+    * @param channel the channel
+    * @return whether the update was successful
+    */
+    bool UpdateLastWatched(const CPVRChannel &channel);
+
+    /*!
+    * @brief Updates the last watched timestamp for the channel group
+    * @param group the group
+    * @return whether the update was successful
+    */
+    bool UpdateLastWatched(const CPVRChannelGroup &group);
     //@}
 
   private:

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -1655,12 +1655,10 @@ void CPVRManager::UpdateLastWatched(CPVRChannel &channel)
   // NOTE: method could be called with a fileitem copy as argument so we need to obtain the right channel instance
   CPVRChannelPtr channelPtr = m_channelGroups->GetChannelById(channel.ChannelID());
   channelPtr->SetLastWatched(tNow);
-  channelPtr->Persist();
 
   // update last watched timestamp for group
   CPVRChannelGroupPtr group = GetPlayingGroup(channel.IsRadio());
   group->SetLastWatched(tNow);
-  group->Persist();
 
   /* update last played group */
   m_channelGroups->SetLastPlayedGroup(group);

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -244,7 +244,7 @@ bool CPVRChannel::UpdateFromClient(const CPVRChannel &channel)
   return m_bChanged;
 }
 
-bool CPVRChannel::Persist(bool bQueueWrite /* = false */)
+bool CPVRChannel::Persist()
 {
   {
     // not changed
@@ -255,7 +255,7 @@ bool CPVRChannel::Persist(bool bQueueWrite /* = false */)
 
   if (CPVRDatabase *database = GetPVRDatabase())
   {
-    bool bReturn = database->Persist(*this, bQueueWrite);
+    bool bReturn = database->Persist(*this);
     CSingleLock lock(m_critSection);
     m_bChanged = !bReturn;
     return bReturn;

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -399,17 +399,15 @@ bool CPVRChannel::SetVirtual(bool bIsVirtual)
 
 bool CPVRChannel::SetLastWatched(time_t iLastWatched)
 {
-  CSingleLock lock(m_critSection);
-
-  if (m_iLastWatched != iLastWatched)
   {
-    /* update last watched  */
-    m_iLastWatched = iLastWatched;
-    SetChanged();
-    m_bChanged = true;
+    CSingleLock lock(m_critSection);
 
-    return true;
+    if (m_iLastWatched != iLastWatched)
+      m_iLastWatched = iLastWatched;
   }
+
+  if (CPVRDatabase *database = GetPVRDatabase())
+    return database->UpdateLastWatched(*this);
 
   return false;
 }

--- a/xbmc/pvr/channels/PVRChannel.h
+++ b/xbmc/pvr/channels/PVRChannel.h
@@ -88,10 +88,9 @@ namespace PVR
 
     /*!
      * @brief Persists the changes in the database.
-     * @param bQueueWrite Queue the change and write changes later.
      * @return True if the changes were saved succesfully, false otherwise.
      */
-    bool Persist(bool bQueueWrite = false);
+    bool Persist();
 
     /*!
      * @return The identifier given to this channel by the TV database.

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -1244,17 +1244,16 @@ time_t CPVRChannelGroup::LastWatched(void) const
 
 bool CPVRChannelGroup::SetLastWatched(time_t iLastWatched)
 {
-  CSingleLock lock(m_critSection);
-
-  if (m_iLastWatched != iLastWatched)
   {
-    /* update last watched  */
-    m_iLastWatched = iLastWatched;
-    SetChanged();
-    m_bChanged = true;
+    CSingleLock lock(m_critSection);
 
-    return true;
+    if (m_iLastWatched != iLastWatched)
+      m_iLastWatched = iLastWatched;
   }
+  
+  /* update the database immediately */
+  if (CPVRDatabase *database = GetPVRDatabase())
+    return database->UpdateLastWatched(*this);
 
   return false;
 }

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
@@ -270,23 +270,6 @@ bool CPVRChannelGroupInternal::IsGroupMember(const CPVRChannel &channel) const
   return !channel.IsHidden();
 }
 
-bool CPVRChannelGroupInternal::UpdateChannel(const CPVRChannel &channel)
-{
-  CSingleLock lock(m_critSection);
-  CPVRChannelPtr updateChannel = GetByUniqueID(channel.UniqueID());
-
-  if (!updateChannel)
-  {
-    updateChannel = CPVRChannelPtr(new CPVRChannel(channel.IsRadio()));
-    PVRChannelGroupMember newMember = { updateChannel, 0 };
-    m_members.push_back(newMember);
-    updateChannel->SetUniqueID(channel.UniqueID());
-  }
-  updateChannel->UpdateFromClient(channel);
-
-  return updateChannel->Persist(!m_bLoaded);
-}
-
 bool CPVRChannelGroupInternal::AddAndUpdateChannels(const CPVRChannelGroup &channels, bool bUseBackendChannelNumbers)
 {
   bool bReturn(false);

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.h
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.h
@@ -55,13 +55,6 @@ namespace PVR
     int GetNumHiddenChannels() const { return m_iHiddenChannels; }
 
     /*!
-     * @brief Add or update a channel in this table.
-     * @param channel The channel to update.
-     * @return True if the channel was updated and persisted.
-     */
-    bool UpdateChannel(const CPVRChannel &channel);
-
-    /*!
      * @brief Add a channel to this internal group.
      * @param iChannelNumber The channel number to use for this channel or 0 to add it to the back.
      */


### PR DESCRIPTION
This tries to fix the crash reported at http://forum.kodi.tv/showthread.php?tid=213283 (has been mentioned on IRC as well).

I'm not sure what the exact problem is, only that the crash happens in `GetLastChannelID()` which is a method we don't even need. I hope that removing this method either fixes the problem (I can't reproduce it so it's hard to say) or moves the crash somewhere else where the cause is more apparent.

@opdenkamp @xhaggi for review. See the commit messages for more justification.
