### PR TITLE
[pvr] don't persist channel groups (includes members) unless the group is fully loaded

### DIFF
--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -900,7 +900,8 @@ bool CPVRChannelGroup::Persist(void)
   bool bReturn(true);
   CSingleLock lock(m_critSection);
 
-  if (!HasChanges())
+  /* don't persist until the group is fully loaded and has changes */
+  if (!HasChanges() || !m_bLoaded)
     return bReturn;
 
   if (CPVRDatabase *database = GetPVRDatabase())


### PR DESCRIPTION
While working on #6091 I noticed that we persist everything to database quite a few times while starting the PVR manager. I've changed it so it only attempts to persist things after they've been fully loaded. At least when running in Visual Studio this speeds up the manager startup time a bit.

@opdenkamp do you think this is correct?
