### PR TITLE
[pvr] Drop support for virtual channels

### DIFF
--- a/addons/library.xbmc.gui/libXBMC_gui.h
+++ b/addons/library.xbmc.gui/libXBMC_gui.h
@@ -36,7 +36,7 @@ typedef void* GUIHANDLE;
 #endif
 
 /* current ADDONGUI API version */
-#define XBMC_GUI_API_VERSION "5.6.0"
+#define XBMC_GUI_API_VERSION "5.7.0"
 
 /* min. ADDONGUI API version */
 #define XBMC_GUI_MIN_API_VERSION "5.3.0"

--- a/addons/skin.confluence/720p/DialogPVRChannelManager.xml
+++ b/addons/skin.confluence/720p/DialogPVRChannelManager.xml
@@ -280,7 +280,7 @@
 					<label>19074</label>
 					<onleft>20</onleft>
 					<onright>9000</onright>
-					<onup>33</onup>
+					<onup>30</onup>
 					<ondown>8</ondown>
 				</control>
 				<control type="edit" id="8">
@@ -413,7 +413,7 @@
 					<onleft>20</onleft>
 					<onright>34</onright>
 					<onup>14</onup>
-					<ondown>31</ondown>
+					<ondown>7</ondown>
 				</control>
 				<control type="button" id="34">
 					<description>TV/Radio Button</description>
@@ -430,7 +430,7 @@
 					<onleft>30</onleft>
 					<onright>9000</onright>
 					<onup>14</onup>
-					<ondown>31</ondown>
+					<ondown>7</ondown>
 				</control>
 				<control type="button" id="34">
 					<description>TV/Radio Button</description>
@@ -447,7 +447,7 @@
 					<onleft>30</onleft>
 					<onright>9000</onright>
 					<onup>14</onup>
-					<ondown>31</ondown>
+					<ondown>7</ondown>
 				</control>
 				<control type="button" id="31">
 					<description>Edit channel Button</description>
@@ -480,22 +480,6 @@
 					<onright>9000</onright>
 					<onup>31</onup>
 					<ondown>33</ondown>
-				</control>
-				<control type="button" id="33">
-					<description>New channel Button</description>
-					<left>0</left>
-					<top>145</top>
-					<width>380</width>
-					<height>35</height>
-					<font>font12</font>
-					<texturefocus border="5">button-focus2.png</texturefocus>
-					<texturenofocus border="5">button-nofocus.png</texturenofocus>
-					<align>center</align>
-					<label>19204</label>
-					<onleft>20</onleft>
-					<onright>9000</onright>
-					<onup>32</onup>
-					<ondown>7</ondown>
 				</control>
 			</control>
 		</control>

--- a/addons/skin.confluence/720p/DialogPVRChannelManager.xml
+++ b/addons/skin.confluence/720p/DialogPVRChannelManager.xml
@@ -449,38 +449,6 @@
 					<onup>14</onup>
 					<ondown>7</ondown>
 				</control>
-				<control type="button" id="31">
-					<description>Edit channel Button</description>
-					<left>0</left>
-					<top>65</top>
-					<width>380</width>
-					<height>35</height>
-					<font>font12</font>
-					<texturefocus border="5">button-focus2.png</texturefocus>
-					<texturenofocus border="5">button-nofocus.png</texturenofocus>
-					<align>center</align>
-					<label>19203</label>
-					<onleft>20</onleft>
-					<onright>9000</onright>
-					<onup>30</onup>
-					<ondown>32</ondown>
-				</control>
-				<control type="button" id="32">
-					<description>Delete channel Button</description>
-					<left>0</left>
-					<top>105</top>
-					<width>380</width>
-					<height>35</height>
-					<font>font12</font>
-					<texturefocus border="5">button-focus2.png</texturefocus>
-					<texturenofocus border="5">button-nofocus.png</texturenofocus>
-					<align>center</align>
-					<label>19211</label>
-					<onleft>20</onleft>
-					<onright>9000</onright>
-					<onup>31</onup>
-					<ondown>33</ondown>
-				</control>
 			</control>
 		</control>
 		<control type="group" id="9000">

--- a/addons/skin.confluence/addon.xml
+++ b/addons/skin.confluence/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="skin.confluence"
-  version="2.6.0"
+  version="2.7.0"
   name="Confluence"
   provider-name="Jezz_X, Team Kodi">
   <requires>

--- a/addons/skin.confluence/changelog.txt
+++ b/addons/skin.confluence/changelog.txt
@@ -1,3 +1,7 @@
+[B]2.7.0[/B]
+
+- Removed new/edit/delete buttons from the channel manager dialog
+
 [B]2.6.0[/B]
 
 - Moved some context menu functionality for PVR channels to the sideblade

--- a/addons/xbmc.gui/addon.xml
+++ b/addons/xbmc.gui/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="xbmc.gui" version="5.6.0" provider-name="Team-Kodi">
+<addon id="xbmc.gui" version="5.7.0" provider-name="Team-Kodi">
   <backwards-compatibility abi="5.3.0"/>
   <requires>
     <import addon="xbmc.core" version="0.1.0"/>

--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -279,7 +279,6 @@ int CPVRDatabase::Get(CPVRChannelGroupInternal &results)
         channel->m_bIsLocked               = m_pDS->fv("bIsLocked").get_asBool();
         channel->m_strIconPath             = m_pDS->fv("sIconPath").get_asString();
         channel->m_strChannelName          = m_pDS->fv("sChannelName").get_asString();
-        channel->m_bIsVirtual              = m_pDS->fv("bIsVirtual").get_asBool();
         channel->m_bEPGEnabled             = m_pDS->fv("bEPGEnabled").get_asBool();
         channel->m_strEPGScraper           = m_pDS->fv("sEPGScraper").get_asString();
         channel->m_iLastWatched            = (time_t) m_pDS->fv("iLastWatched").get_asInt();
@@ -771,7 +770,7 @@ bool CPVRDatabase::Persist(CPVRChannel &channel, bool bQueueWrite /* = false */)
         "iClientChannelNumber, iClientSubChannelNumber, sInputFormat, sStreamURL, iEncryptionSystem, idEpg) "
         "VALUES (%i, %i, %i, %i, %i, %i, '%s', '%s', %i, %i, '%s', %u, %i, %i, %i, '%s', '%s', %i, %i)",
         channel.UniqueID(), (channel.IsRadio() ? 1 :0), (channel.IsHidden() ? 1 : 0), (channel.IsUserSetIcon() ? 1 : 0), (channel.IsUserSetName() ? 1 : 0), (channel.IsLocked() ? 1 : 0),
-        channel.IconPath().c_str(), channel.ChannelName().c_str(), (channel.IsVirtual() ? 1 : 0), (channel.EPGEnabled() ? 1 : 0), channel.EPGScraper().c_str(), channel.LastWatched(), channel.ClientID(),
+        channel.IconPath().c_str(), channel.ChannelName().c_str(), 0, (channel.EPGEnabled() ? 1 : 0), channel.EPGScraper().c_str(), channel.LastWatched(), channel.ClientID(),
         channel.ClientChannelNumber(), channel.ClientSubChannelNumber(), channel.InputFormat().c_str(), channel.StreamURL().c_str(), channel.EncryptionSystem(),
         channel.EpgID());
   }
@@ -784,7 +783,7 @@ bool CPVRDatabase::Persist(CPVRChannel &channel, bool bQueueWrite /* = false */)
         "iClientChannelNumber, iClientSubChannelNumber, sInputFormat, sStreamURL, iEncryptionSystem, idChannel, idEpg) "
         "VALUES (%i, %i, %i, %i, %i, %i, '%s', '%s', %i, %i, '%s', %u, %i, %i, %i, '%s', '%s', %i, %i, %i)",
         channel.UniqueID(), (channel.IsRadio() ? 1 :0), (channel.IsHidden() ? 1 : 0), (channel.IsUserSetIcon() ? 1 : 0), (channel.IsUserSetName() ? 1 : 0), (channel.IsLocked() ? 1 : 0),
-        channel.IconPath().c_str(), channel.ChannelName().c_str(), (channel.IsVirtual() ? 1 : 0), (channel.EPGEnabled() ? 1 : 0), channel.EPGScraper().c_str(), channel.LastWatched(), channel.ClientID(),
+        channel.IconPath().c_str(), channel.ChannelName().c_str(), 0, (channel.EPGEnabled() ? 1 : 0), channel.EPGScraper().c_str(), channel.LastWatched(), channel.ClientID(),
         channel.ClientChannelNumber(), channel.ClientSubChannelNumber(), channel.InputFormat().c_str(), channel.StreamURL().c_str(), channel.EncryptionSystem(), channel.ChannelID(),
         channel.EpgID());
   }

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -142,7 +142,7 @@ void CPVRClient::ResetProperties(int iClientId /* = PVR_INVALID_CLIENT_ID */)
 ADDON_STATUS CPVRClient::Create(int iClientId)
 {
   ADDON_STATUS status(ADDON_STATUS_UNKNOWN);
-  if (iClientId <= PVR_INVALID_CLIENT_ID || iClientId == PVR_VIRTUAL_CLIENT_ID)
+  if (iClientId <= PVR_INVALID_CLIENT_ID)
     return status;
 
   /* ensure that a previous instance is destroyed */

--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -44,7 +44,6 @@ namespace PVR
   typedef std::vector<PVR_MENUHOOK> PVR_MENUHOOKS;
   typedef boost::shared_ptr<CPVRClient> PVR_CLIENT;
   #define PVR_INVALID_CLIENT_ID (-2)
-  #define PVR_VIRTUAL_CLIENT_ID (-1)
 
   /*!
    * Interface from XBMC to a PVR add-on.

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -109,7 +109,7 @@ int CPVRClients::GetClientId(const AddonPtr client) const
 bool CPVRClients::GetClient(int iClientId, PVR_CLIENT &addon) const
 {
   bool bReturn(false);
-  if (iClientId <= PVR_INVALID_CLIENT_ID || iClientId == PVR_VIRTUAL_CLIENT_ID)
+  if (iClientId <= PVR_INVALID_CLIENT_ID)
     return bReturn;
 
   CSingleLock lock(m_critSection);
@@ -1184,9 +1184,7 @@ bool CPVRClients::OpenStream(const CPVRChannel &tag, bool bIsSwitchingChannel)
     m_playingClientId = tag.ClientID();
     m_bIsPlayingLiveTV = true;
 
-    if (tag.ClientID() == PVR_VIRTUAL_CLIENT_ID)
-      m_strPlayingClientName = g_localizeStrings.Get(19209);
-    else if (!tag.IsVirtual() && client.get())
+    if (client.get())
       m_strPlayingClientName = client->GetFriendlyName();
     else
       m_strPlayingClientName = g_localizeStrings.Get(13205);

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -56,7 +56,6 @@ CPVRChannel::CPVRChannel(bool bRadio /* = false */)
   m_bIsUserSetIcon          = false;
   m_bIsUserSetName          = false;
   m_bIsLocked               = false;
-  m_bIsVirtual              = false;
   m_iLastWatched            = 0;
   m_bChanged                = false;
   m_iCachedChannelNumber    = 0;
@@ -95,7 +94,6 @@ CPVRChannel::CPVRChannel(const PVR_CHANNEL &channel, unsigned int iClientId)
   m_iCachedChannelNumber    = 0;
   m_iCachedSubChannelNumber = 0;
   m_iClientId               = iClientId;
-  m_bIsVirtual              = false;
   m_iLastWatched            = 0;
   m_bEPGEnabled             = !channel.bIsHidden;
   m_strEPGScraper           = "client";
@@ -124,7 +122,6 @@ CPVRChannel &CPVRChannel::operator=(const CPVRChannel &channel)
   m_bIsLocked               = channel.m_bIsLocked;
   m_strIconPath             = channel.m_strIconPath;
   m_strChannelName          = channel.m_strChannelName;
-  m_bIsVirtual              = channel.m_bIsVirtual;
   m_iLastWatched            = channel.m_iLastWatched;
   m_bEPGEnabled             = channel.m_bEPGEnabled;
   m_strEPGScraper           = channel.m_strEPGScraper;
@@ -370,23 +367,6 @@ bool CPVRChannel::SetChannelName(const std::string &strChannelName, bool bIsUser
       m_strChannelName = ClientChannelName();
     }
     
-    SetChanged();
-    m_bChanged = true;
-
-    return true;
-  }
-
-  return false;
-}
-
-bool CPVRChannel::SetVirtual(bool bIsVirtual)
-{
-  CSingleLock lock(m_critSection);
-
-  if (m_bIsVirtual != bIsVirtual)
-  {
-    /* update the virtual flag */
-    m_bIsVirtual = bIsVirtual;
     SetChanged();
     m_bChanged = true;
 
@@ -762,12 +742,6 @@ std::string CPVRChannel::ChannelName(void) const
 {
   CSingleLock lock(m_critSection);
   return m_strChannelName;
-}
-
-bool CPVRChannel::IsVirtual(void) const
-{
-  CSingleLock lock(m_critSection);
-  return m_bIsVirtual;
 }
 
 time_t CPVRChannel::LastWatched(void) const

--- a/xbmc/pvr/channels/PVRChannel.h
+++ b/xbmc/pvr/channels/PVRChannel.h
@@ -29,6 +29,8 @@
 
 #include <boost/shared_ptr.hpp>
 
+#define PVR_INVALID_CHANNEL_UID -1
+
 namespace EPG
 {
   class CEpg;
@@ -212,18 +214,6 @@ namespace PVR
      * @return True if the something changed, false otherwise.
      */
     bool SetChannelName(const std::string &strChannelName, bool bIsUserSetName = false);
-
-    /*!
-     * @return True if this channel is marked as virtual. False if not.
-     */
-    bool IsVirtual(void) const;
-
-    /*!
-     * @brief True if this channel is marked as virtual. False if not.
-     * @param bIsVirtual The new value.
-     * @return True if the something changed, false otherwise.
-     */
-    bool SetVirtual(bool bIsVirtual);
 
     /*!
      * @return Time channel has been watched last.
@@ -478,7 +468,6 @@ namespace PVR
     bool             m_bIsLocked;               /*!< true if channel is locked, false if not */
     std::string      m_strIconPath;             /*!< the path to the icon for this channel */
     std::string      m_strChannelName;          /*!< the name for this channel used by XBMC */
-    bool             m_bIsVirtual;              /*!< true if this channel is marked as virtual, false if not */
     time_t           m_iLastWatched;            /*!< last time channel has been watched */
     bool             m_bChanged;                /*!< true if anything in this entry was changed that needs to be persisted */
     unsigned int     m_iCachedChannelNumber;    /*!< the cached channel number in the selected group */

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -752,8 +752,6 @@ void CPVRChannelGroup::RemoveInvalidChannels(void)
   {
     bool bDelete = false;
     CPVRChannelPtr channel = m_members.at(ptr).channel;
-    if (channel->IsVirtual())
-      continue;
 
     if (m_members.at(ptr).channel->ClientChannelNumber() <= 0)
     {
@@ -1281,7 +1279,7 @@ void CPVRChannelGroup::SetPreventSortAndRenumber(bool bPreventSortAndRenumber /*
   m_bPreventSortAndRenumber = bPreventSortAndRenumber;
 }
 
-bool CPVRChannelGroup::UpdateChannel(const CFileItem &item, bool bHidden, bool bVirtual, bool bEPGEnabled, bool bParentalLocked, int iEPGSource, int iChannelNumber, const std::string &strChannelName, const std::string &strIconPath, const std::string &strStreamURL, bool bUserSetIcon)
+bool CPVRChannelGroup::UpdateChannel(const CFileItem &item, bool bHidden, bool bEPGEnabled, bool bParentalLocked, int iEPGSource, int iChannelNumber, const std::string &strChannelName, const std::string &strIconPath, const std::string &strStreamURL, bool bUserSetIcon)
 {
   if (!item.HasPVRChannelInfoTag())
     return false;
@@ -1298,8 +1296,6 @@ bool CPVRChannelGroup::UpdateChannel(const CFileItem &item, bool bHidden, bool b
   channel->SetLocked(bParentalLocked);
   channel->SetIconPath(strIconPath, bUserSetIcon);
 
-  if (bVirtual)
-    channel->SetStreamURL(strStreamURL);
   if (iEPGSource == 0)
     channel->SetEPGScraper("client");
 

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -418,11 +418,9 @@ namespace PVR
      */
     CDateTime GetLastEPGDate(void) const;
 
-    bool UpdateChannel(const CFileItem &channel, bool bHidden, bool bVirtual, bool bEPGEnabled, bool bParentalLocked, int iEPGSource, int iChannelNumber, const std::string &strChannelName, const std::string &strIconPath, const std::string &strStreamURL, bool bUserSetIcon = false);
+    bool UpdateChannel(const CFileItem &channel, bool bHidden, bool bEPGEnabled, bool bParentalLocked, int iEPGSource, int iChannelNumber, const std::string &strChannelName, const std::string &strIconPath, const std::string &strStreamURL, bool bUserSetIcon = false);
 
     bool ToggleChannelLocked(const CFileItem &channel);
-
-    virtual bool AddNewChannel(const CPVRChannel &channel, unsigned int iChannelNumber = 0) { return false; }
 
     /*!
      * @brief Get a channel given the channel number on the client.

--- a/xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
@@ -289,12 +289,6 @@ CPVRChannelGroupPtr CPVRChannelGroupsContainer::GetLastPlayedGroup(int iChannelI
   return groupTV;
 }
 
-bool CPVRChannelGroupsContainer::CreateChannel(const CPVRChannel &channel) const
-{
-  return GetGroupAll(channel.IsRadio())->AddNewChannel(channel);
-}
-
-
 bool CPVRChannelGroupsContainer::CreateChannelEpgs(void)
 {
   return m_groupsRadio->CreateChannelEpgs() &&

--- a/xbmc/pvr/channels/PVRChannelGroupsContainer.h
+++ b/xbmc/pvr/channels/PVRChannelGroupsContainer.h
@@ -187,8 +187,6 @@ namespace PVR
      */
     CPVRChannelGroupPtr GetLastPlayedGroup(int iChannelID = -1) const;
 
-    bool CreateChannel(const CPVRChannel &channel) const;
-
     /*!
      * @brief Create EPG tags for channels in all internal channel groups.
      * @return True if EPG tags were created succesfully.

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -54,7 +54,6 @@
 #define BUTTON_GROUP_MANAGER      30
 #define BUTTON_EDIT_CHANNEL       31
 #define BUTTON_DELETE_CHANNEL     32
-#define BUTTON_NEW_CHANNEL        33
 #define BUTTON_RADIO_TV           34
 
 using namespace PVR;
@@ -466,76 +465,6 @@ bool CGUIDialogPVRChannelManager::OnClickButtonDeleteChannel(CGUIMessage &messag
   return true;
 }
 
-bool CGUIDialogPVRChannelManager::OnClickButtonNewChannel(CGUIMessage &message)
-{
-  std::vector<long> clients;
-
-  CGUIDialogSelect* pDlgSelect = (CGUIDialogSelect*)g_windowManager.GetWindow(WINDOW_DIALOG_SELECT);
-  if (!pDlgSelect)
-    return false;
-
-  pDlgSelect->SetHeading(19213); // Select Client
-  pDlgSelect->Add(g_localizeStrings.Get(19209));
-  clients.push_back(PVR_VIRTUAL_CLIENT_ID);
-
-  PVR_CLIENTMAP clientMap;
-  if (g_PVRClients->GetConnectedClients(clientMap) > 0)
-  {
-    PVR_CLIENTMAP_ITR itr;
-    for (itr = clientMap.begin() ; itr != clientMap.end(); itr++)
-    {
-      clients.push_back((*itr).first);
-      pDlgSelect->Add((*itr).second->Name());
-    }
-  }
-  pDlgSelect->DoModal();
-
-  int selection = pDlgSelect->GetSelectedLabel();
-  if (selection >= 0 && selection <= (int) clients.size())
-  {
-    int clientID = clients[selection];
-    if (clientID == PVR_VIRTUAL_CLIENT_ID)
-    {
-      std::string strURL = "";
-      if (CGUIKeyboardFactory::ShowAndGetInput(strURL, g_localizeStrings.Get(19214), false))
-      {
-        if (!strURL.empty())
-        {
-          CPVRChannel *newchannel = new CPVRChannel(m_bIsRadio);
-          newchannel->SetChannelName(g_localizeStrings.Get(19204));
-          newchannel->SetEPGEnabled(false);
-          newchannel->SetVirtual(true);
-          newchannel->SetStreamURL(strURL);
-          newchannel->SetClientID(PVR_VIRTUAL_CLIENT_ID);
-          if (g_PVRChannelGroups->CreateChannel(*newchannel))
-            g_PVRChannelGroups->GetGroupAll(m_bIsRadio)->Persist();
-
-          CFileItemPtr channel(new CFileItem(*newchannel));
-          if (channel)
-          {
-            channel->SetProperty("ActiveChannel", true);
-            channel->SetProperty("Name", g_localizeStrings.Get(19204));
-            channel->SetProperty("UseEPG", false);
-            channel->SetProperty("Icon", newchannel->IconPath());
-            channel->SetProperty("EPGSource", (int)0);
-            channel->SetProperty("ClientName", g_localizeStrings.Get(19209));
-            channel->SetProperty("ParentalLocked", false);
-
-            m_channelItems->AddFront(channel, m_iSelected);
-            m_viewControl.SetItems(*m_channelItems);
-            Renumber();
-          }
-        }
-      }
-    }
-    else
-    {
-      CGUIDialogOK::ShowAndGetInput(19033,19038,0,0);
-    }
-  }
-  return true;
-}
-
 bool CGUIDialogPVRChannelManager::OnMessageClick(CGUIMessage &message)
 {
   int iControl = message.GetSenderId();
@@ -569,8 +498,6 @@ bool CGUIDialogPVRChannelManager::OnMessageClick(CGUIMessage &message)
     return OnClickButtonEditChannel(message);
   case BUTTON_DELETE_CHANNEL:
     return OnClickButtonDeleteChannel(message);
-  case BUTTON_NEW_CHANNEL:
-    return OnClickButtonNewChannel(message);
   default:
     return false;
   }
@@ -626,8 +553,6 @@ bool CGUIDialogPVRChannelManager::OnPopupMenu(int iItem)
     return false;
 
   buttons.Add(CONTEXT_BUTTON_MOVE, 116);              /* Move channel up or down */
-  if (pItem->GetProperty("Virtual").asBoolean())
-    buttons.Add(CONTEXT_BUTTON_EDIT_SOURCE, 1027);    /* Edit virtual channel URL */
 
   int choice = CGUIDialogContextMenu::ShowAndGetChoice(buttons);
 
@@ -712,17 +637,8 @@ void CGUIDialogPVRChannelManager::Update()
     channelFile->SetProperty("ParentalLocked", channel->IsLocked());
     channelFile->SetProperty("Number", StringUtils::Format("%i", channel->ChannelNumber()));
 
-    if (channel->IsVirtual())
-    {
-      channelFile->SetProperty("Virtual", true);
-      channelFile->SetProperty("StreamURL", channel->StreamURL());
-    }
-
     std::string clientName;
-    if (channel->ClientID() == PVR_VIRTUAL_CLIENT_ID) /* XBMC internal */
-      clientName = g_localizeStrings.Get(19209);
-    else
-      g_PVRClients->GetClientName(channel->ClientID(), clientName);
+    g_PVRClients->GetClientName(channel->ClientID(), clientName);
     channelFile->SetProperty("ClientName", clientName);
 
     m_channelItems->Add(channelFile);
@@ -755,7 +671,6 @@ bool CGUIDialogPVRChannelManager::PersistChannel(CFileItemPtr pItem, CPVRChannel
 
   /* get values from the form */
   bool bHidden              = !pItem->GetProperty("ActiveChannel").asBoolean();
-  bool bVirtual             = pItem->GetProperty("Virtual").asBoolean();
   bool bEPGEnabled          = pItem->GetProperty("UseEPG").asBoolean();
   bool bParentalLocked      = pItem->GetProperty("ParentalLocked").asBoolean();
   int iEPGSource            = (int)pItem->GetProperty("EPGSource").asInteger();
@@ -764,7 +679,7 @@ bool CGUIDialogPVRChannelManager::PersistChannel(CFileItemPtr pItem, CPVRChannel
   std::string strStreamURL  = pItem->GetProperty("StreamURL").asString();
   bool bUserSetIcon         = pItem->GetProperty("UserSetIcon").asBoolean();
 
-  return group->UpdateChannel(*pItem, bHidden, bVirtual, bEPGEnabled, bParentalLocked, iEPGSource, ++(*iChannelNumber), strChannelName, strIconPath, strStreamURL, bUserSetIcon);
+  return group->UpdateChannel(*pItem, bHidden, bEPGEnabled, bParentalLocked, iEPGSource, ++(*iChannelNumber), strChannelName, strIconPath, strStreamURL, bUserSetIcon);
 }
 
 void CGUIDialogPVRChannelManager::SaveList(void)

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -52,8 +52,6 @@
 #define RADIOBUTTON_PARENTAL_LOCK 14
 #define CONTROL_LIST_CHANNELS     20
 #define BUTTON_GROUP_MANAGER      30
-#define BUTTON_EDIT_CHANNEL       31
-#define BUTTON_DELETE_CHANNEL     32
 #define BUTTON_RADIO_TV           34
 
 using namespace PVR;
@@ -416,55 +414,6 @@ bool CGUIDialogPVRChannelManager::OnClickButtonGroupManager(CGUIMessage &message
   return true;
 }
 
-bool CGUIDialogPVRChannelManager::OnClickButtonEditChannel(CGUIMessage &message)
-{
-  CFileItemPtr pItem = m_channelItems->Get(m_iSelected);
-  if (!pItem)
-    return false;
-
-  if (pItem->GetProperty("Virtual").asBoolean())
-  {
-    std::string strURL = pItem->GetProperty("StreamURL").asString();
-    if (CGUIKeyboardFactory::ShowAndGetInput(strURL, g_localizeStrings.Get(19214), false))
-      pItem->SetProperty("StreamURL", strURL);
-    return true;
-  }
-
-  CGUIDialogOK::ShowAndGetInput(19033,19038,0,0);
-  return true;
-}
-
-bool CGUIDialogPVRChannelManager::OnClickButtonDeleteChannel(CGUIMessage &message)
-{
-  CFileItemPtr pItem = m_channelItems->Get(m_iSelected);
-  if (!pItem)
-    return false;
-
-  CGUIDialogYesNo* pDialog = (CGUIDialogYesNo*)g_windowManager.GetWindow(WINDOW_DIALOG_YES_NO);
-  if (!pDialog)
-    return true;
-
-  pDialog->SetHeading(19211);
-  pDialog->SetLine(0, "");
-  pDialog->SetLine(1, 750);
-  pDialog->SetLine(2, "");
-  pDialog->DoModal();
-
-  if (pDialog->IsConfirmed())
-  {
-    if (pItem->GetProperty("Virtual").asBoolean())
-    {
-      pItem->GetPVRChannelInfoTag()->SetVirtual(true);
-      m_channelItems->Remove(m_iSelected);
-      m_viewControl.SetItems(*m_channelItems);
-      Renumber();
-      return true;
-    }
-    CGUIDialogOK::ShowAndGetInput(19033,19038,0,0);
-  }
-  return true;
-}
-
 bool CGUIDialogPVRChannelManager::OnMessageClick(CGUIMessage &message)
 {
   int iControl = message.GetSenderId();
@@ -494,10 +443,6 @@ bool CGUIDialogPVRChannelManager::OnMessageClick(CGUIMessage &message)
     return OnClickEPGSourceSpin(message);
   case BUTTON_GROUP_MANAGER:
     return OnClickButtonGroupManager(message);
-  case BUTTON_EDIT_CHANNEL:
-    return OnClickButtonEditChannel(message);
-  case BUTTON_DELETE_CHANNEL:
-    return OnClickButtonDeleteChannel(message);
   default:
     return false;
   }

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.h
@@ -61,8 +61,6 @@ namespace PVR
     virtual bool OnClickButtonUseEPG(CGUIMessage &message);
     virtual bool OnClickEPGSourceSpin(CGUIMessage &message);
     virtual bool OnClickButtonGroupManager(CGUIMessage &message);
-    virtual bool OnClickButtonEditChannel(CGUIMessage &message);
-    virtual bool OnClickButtonDeleteChannel(CGUIMessage &message);
 
     virtual bool PersistChannel(CFileItemPtr pItem, CPVRChannelGroupPtr group, unsigned int *iChannelNumber);
     virtual void SetItemsUnchanged(void);

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.h
@@ -63,7 +63,6 @@ namespace PVR
     virtual bool OnClickButtonGroupManager(CGUIMessage &message);
     virtual bool OnClickButtonEditChannel(CGUIMessage &message);
     virtual bool OnClickButtonDeleteChannel(CGUIMessage &message);
-    virtual bool OnClickButtonNewChannel(CGUIMessage &message);
 
     virtual bool PersistChannel(CFileItemPtr pItem, CPVRChannelGroupPtr group, unsigned int *iChannelNumber);
     virtual void SetItemsUnchanged(void);

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -105,15 +105,10 @@ void CGUIDialogPVRTimerSettings::OnSettingChanged(const CSetting *setting)
         tag->m_iClientId         = channel->ClientID();
         tag->m_bIsRadio          = channel->IsRadio();
         tag->m_iChannelNumber    = channel->ChannelNumber();
+       
+        // Update channel pointer from above values
+        tag->UpdateChannel();
       }
-      else
-      {
-        tag->m_iClientChannelUid = PVR_VIRTUAL_CHANNEL_UID;
-        tag->m_iClientId         = PVR_VIRTUAL_CLIENT_ID;
-        tag->m_iChannelNumber    = 0;
-      }
-      // Update channel pointer from above values
-      tag->UpdateChannel();
     }
   }
   else if (settingId == SETTING_TMR_DAY)
@@ -353,11 +348,10 @@ CSetting* CGUIDialogPVRTimerSettings::AddChannelNames(CSettingGroup *group, bool
   std::vector< std::pair<std::string, int> > options;
   getChannelNames(bRadio, options, m_selectedChannelEntry, true);
   
-  int timerChannelID;
+  // select the correct channel
+  int timerChannelID = 0;
   if (m_timerItem->GetPVRTimerInfoTag()->ChannelTag())
     timerChannelID = m_timerItem->GetPVRTimerInfoTag()->ChannelTag()->ChannelID();
-  else
-    timerChannelID = PVR_VIRTUAL_CHANNEL_UID;
 
   for (std::vector< std::pair<std::string, int> >::const_iterator option = options.begin(); option != options.end(); ++option)
   {
@@ -449,10 +443,6 @@ void CGUIDialogPVRTimerSettings::getChannelNames(bool bRadio, std::vector< std::
   g_PVRChannelGroups->GetGroupAll(bRadio)->GetMembers(channelsList);
   
   int entry = 0;
-  list.push_back(std::make_pair("0 dummy", entry));
-  if (updateChannelEntries)
-    m_channelEntries.insert(std::make_pair(std::make_pair(bRadio, entry), PVR_VIRTUAL_CHANNEL_UID));
-  ++entry;
 
   for (int i = 0; i < channelsList.Size(); i++)
   {

--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -34,7 +34,7 @@ using namespace PVR;
 using namespace EPG;
 
 CPVRRecordingUid::CPVRRecordingUid() :
-    m_iClientId(PVR_VIRTUAL_CLIENT_ID)
+    m_iClientId(PVR_INVALID_CLIENT_ID)
 {
 }
 

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -44,7 +44,7 @@ CPVRTimerInfoTag::CPVRTimerInfoTag(void) :
 {
   m_iClientId          = g_PVRClients->GetFirstConnectedClientID();
   m_iClientIndex       = -1;
-  m_iClientChannelUid  = PVR_VIRTUAL_CHANNEL_UID;
+  m_iClientChannelUid  = PVR_INVALID_CHANNEL_UID;
   m_iPriority          = CSettings::Get().GetInt("pvrrecord.defaultpriority");
   m_iLifetime          = CSettings::Get().GetInt("pvrrecord.defaultlifetime");
   m_bIsRepeating       = false;

--- a/xbmc/pvr/timers/PVRTimerInfoTag.h
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.h
@@ -62,7 +62,6 @@ namespace PVR
 
   class CPVRTimerInfoTag;
   typedef boost::shared_ptr<PVR::CPVRTimerInfoTag> CPVRTimerInfoTagPtr;
-  #define PVR_VIRTUAL_CHANNEL_UID (-1)
 
   class CPVRTimerInfoTag : public ISerializable
   {

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -529,21 +529,7 @@ bool CGUIWindowPVRBase::ActionInputChannelNumber(int input)
 
 bool CGUIWindowPVRBase::ActionPlayChannel(CFileItem *item)
 {
-  bool bReturn = false;
-
-  if (item->GetPath() == "pvr://channels/.add.channel")
-  {
-    /* show "add channel" dialog */
-    CGUIDialogOK::ShowAndGetInput(19033,0,19038,0);
-    bReturn = true;
-  }
-  else
-  {
-    /* open channel */
-    bReturn = PlayFile(item, CSettings::Get().GetBool("pvrplayback.playminimized"));
-  }
-
-  return bReturn;
+  return PlayFile(item, CSettings::Get().GetBool("pvrplayback.playminimized"));
 }
 
 bool CGUIWindowPVRBase::ActionPlayEpg(CFileItem *item)

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -75,25 +75,17 @@ void CGUIWindowPVRChannels::GetContextButtons(int itemNumber, CContextButtons &b
   CFileItemPtr pItem = m_vecItems->Get(itemNumber);
   CPVRChannel *channel = pItem->GetPVRChannelInfoTag();
 
-  if (pItem->GetPath() == "pvr://channels/.add.channel")
-  {
-    /* If yes show only "New Channel" on context menu */
-    buttons.Add(CONTEXT_BUTTON_ADD, 19046);                                           /* add new channel */
-  }
-  else
-  {
-    buttons.Add(CONTEXT_BUTTON_INFO, 19047);                                          /* channel info */
-    buttons.Add(CONTEXT_BUTTON_FIND, 19003);                                          /* find similar program */
-    buttons.Add(CONTEXT_BUTTON_RECORD_ITEM, channel->IsRecording() ? 19256 : 19255);  /* start/stop recording on channel */
+  buttons.Add(CONTEXT_BUTTON_INFO, 19047);                                          /* channel info */
+  buttons.Add(CONTEXT_BUTTON_FIND, 19003);                                          /* find similar program */
+  buttons.Add(CONTEXT_BUTTON_RECORD_ITEM, channel->IsRecording() ? 19256 : 19255);  /* start/stop recording on channel */
 
-    if (g_PVRClients->HasMenuHooks(pItem->GetPVRChannelInfoTag()->ClientID(), PVR_MENUHOOK_CHANNEL))
-      buttons.Add(CONTEXT_BUTTON_MENU_HOOKS, 19195);                                  /* PVR client specific action */
+  if (g_PVRClients->HasMenuHooks(pItem->GetPVRChannelInfoTag()->ClientID(), PVR_MENUHOOK_CHANNEL))
+    buttons.Add(CONTEXT_BUTTON_MENU_HOOKS, 19195);                                  /* PVR client specific action */
 
-    // Add parent buttons before the Manage button
-    CGUIWindowPVRBase::GetContextButtons(itemNumber, buttons);
+  // Add parent buttons before the Manage button
+  CGUIWindowPVRBase::GetContextButtons(itemNumber, buttons);
     
-    buttons.Add(CONTEXT_BUTTON_EDIT, 16106);                                          /* "Manage" submenu */
-  }
+  buttons.Add(CONTEXT_BUTTON_EDIT, 16106);                                          /* "Manage" submenu */
 }
 
 std::string CGUIWindowPVRChannels::GetDirectoryPath(void)


### PR DESCRIPTION
This drops support for what is probably the least used PVR feature (and also least useful). A virtual channel is a fake channel that you could add from the channel manager dialog. All it takes is a URL to a stream. This kind of functionality is simply not needed, the idea has all along been that the backend provides the channels.

This also means that the edit/delete buttons in the channel manager had to go since they were never implemented for normal addons (they'd just display a "Not supported by your backend" dialog without even consulting it).

If anyone can come up with a good use case for why we still need this, please speak up.

This PR doesn't touch the database at all since AFAICT you can't drop columns from an SQLite database without some wizardry.

@opdenkamp @xhaggi thoughts?
