### PR TITLE
[CONFLUENCE] fix spacer image width in VideoOSD

### DIFF
--- a/addons/skin.confluence/720p/VideoOSD.xml
+++ b/addons/skin.confluence/720p/VideoOSD.xml
@@ -114,7 +114,7 @@
 				<animation effect="fade" start="100" end="0" time="100" condition="!IntegerGreaterThan(Playlist.Length(video),1)">Conditional</animation>
 			</control>
 			<control type="image" id="2200">
-				<width>380</width>
+				<width>270</width>
 				<texture>-</texture>
 			</control>
 			<control type="button" id="255">


### PR DESCRIPTION
fix positioning of VideoOSD buttons introduced with https://github.com/xbmc/xbmc/pull/6088
Thx to @FernetMenta for pointing this out.
