### PR TITLE
[addoninstaller] - prevent recursion on addons with circular dependecies...

### DIFF
--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -359,9 +359,9 @@ bool CAddonInstaller::CheckDependencies(const AddonPtr &addon,
       if (!CheckDependencies(dep, preDeps, database))
       {
         database.Close();
+        preDeps.push_back(dep->ID());
         return false;
       }
-      preDeps.push_back(dep->ID());
     }
   }
   database.Close();


### PR DESCRIPTION
... - fixes stackoverflow crash with xunity repo

thx @jmarshallnz for the suggestion. Waiting for confirmation from the user who posted the recursion stacktrace here:

http://forum.kodi.tv/showthread.php?tid=213036

@koying ping - in case you can reproduce the crash or something :D - once it is confirmed - i will do a PR to helix.
