### PR TITLE
Revert "Moved userdata to XDG_DATA_HOME"

### DIFF
--- a/tools/Linux/kodi.sh.in
+++ b/tools/Linux/kodi.sh.in
@@ -26,7 +26,7 @@ exec_prefix="@exec_prefix@"
 datarootdir="@datarootdir@"
 LIBDIR="@libdir@"
 CRASHLOG_DIR=${CRASHLOG_DIR:-$HOME}
-USERDATA_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/${bin_name}"
+USERDATA_DIR="${HOME}/.${bin_name}"
 
 
 # Check for some options used by this script
@@ -50,13 +50,7 @@ migrate_home()
   #check if data migration is needed
   if [ -d "${HOME}/.xbmc" ] && [ ! -d "${USERDATA_DIR}" ]; then
       echo "INFO: migrating userdata folder. Renaming ${HOME}/.xbmc to $USERDATA_DIR"
-      mv ${HOME}/.xbmc ${USERDATA_DIR}
-      ln -s $USERDATA_DIR ${HOME}/.xbmc
-      touch ${USERDATA_DIR}/.kodi_data_was_migrated
-  elif [ -d "${HOME}/.kodi" ] && [ ! -d "${USERDATA_DIR}" ]; then
-      echo "INFO: migrating userdata folder. Renaming ${HOME}/.kodi to $USERDATA_DIR"
-      mv ${HOME}/.kodi ${USERDATA_DIR}
-      ln -s $USERDATA_DIR ${HOME}/.kodi
+      mv ${HOME}/.xbmc $USERDATA_DIR
       touch ${USERDATA_DIR}/.kodi_data_was_migrated
   fi
 }

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -647,7 +647,7 @@ bool CApplication::Create()
   {
     std::string lcAppName = CCompileInfo::GetAppName();
     StringUtils::ToLower(lcAppName);
-    fprintf(stderr,"Could not init logging classes. Permission errors on $XDG_CACHE_HOME/%s (%s)\n", lcAppName.c_str(),
+    fprintf(stderr,"Could not init logging classes. Permission errors on ~/.%s (%s)\n", lcAppName.c_str(),
       CSpecialProtocol::TranslatePath(g_advancedSettings.m_logFolder).c_str());
     return false;
   }
@@ -1056,10 +1056,10 @@ bool CApplication::InitDirectoriesLinux()
    special://xbmc/          => [read-only] system directory (/usr/share/kodi)
    special://home/          => [read-write] user's directory that will override special://kodi/ system-wide
                                installations like skins, screensavers, etc.
-                               ($XDG_DATA_HOME/kodi)
+                               ($HOME/.kodi)
                                NOTE: XBMC will look in both special://xbmc/addons and special://home/addons for addons.
    special://masterprofile/ => [read-write] userdata of master profile. It will by default be
-                               mapped to special://home/userdata ($XDG_DATA_HOME/kodi/userdata)
+                               mapped to special://home/userdata ($HOME/.kodi/userdata)
    special://profile/       => [read-write] current profile's userdata directory.
                                Generally special://masterprofile for the master profile or
                                special://masterprofile/profiles/<profile_name> for other profiles.
@@ -1081,15 +1081,14 @@ bool CApplication::InitDirectoriesLinux()
   else
     userHome = "/root";
 
-  std::string appBinPath, appPath, xdgDataPath, xdgCachePath;
+  std::string appBinPath, appPath;
   std::string appName = CCompileInfo::GetAppName();
-  std::string lowerAppName = appName;
-  StringUtils::ToLower(lowerAppName);
+  std::string dotLowerAppName = "." + appName;
+  StringUtils::ToLower(dotLowerAppName);
   const char* envAppHome = "KODI_HOME";
   const char* envAppBinHome = "KODI_BIN_HOME";
   const char* envAppTemp = "KODI_TEMP";
-  const char* xdgDataHome = "XDG_DATA_HOME";
-  const char* xdgCacheHome = "XDG_CACHE_HOME";
+
 
   CUtil::GetHomePath(appBinPath, envAppBinHome);
   if (getenv(envAppHome))
@@ -1111,31 +1110,20 @@ bool CApplication::InitDirectoriesLinux()
     }
   }
 
-  if (getenv(xdgDataHome))
-    xdgDataPath = getenv(xdgDataHome);
-  else
-    xdgDataPath = userHome + "/.local/share/";
-
-  if (getenv(xdgCacheHome))
-    xdgCachePath = getenv(xdgCacheHome);
-  else
-    xdgCachePath = userHome + "/.cache/";
-
   /* Set some environment variables */
   setenv(envAppBinHome, appBinPath.c_str(), 0);
   setenv(envAppHome, appPath.c_str(), 0);
 
   if (m_bPlatformDirectories)
   {
-    /* map our special drives */
+    // map our special drives
     CSpecialProtocol::SetXBMCBinPath(appBinPath);
     CSpecialProtocol::SetXBMCPath(appPath);
-    CSpecialProtocol::SetHomePath(xdgDataPath + lowerAppName);
-    CSpecialProtocol::SetMasterProfilePath(xdgDataPath + lowerAppName + "/userdata");
+    CSpecialProtocol::SetHomePath(userHome + "/" + dotLowerAppName);
+    CSpecialProtocol::SetMasterProfilePath(userHome + "/" + dotLowerAppName + "/userdata");
 
-    CStdString strTempPath = URIUtils::AddFileToFolder(xdgCachePath, lowerAppName + "/");
-    CDirectory::Create(strTempPath);
-    strTempPath = URIUtils::AddFileToFolder(xdgCachePath, lowerAppName + "/temp");
+    CStdString strTempPath = userHome;
+    strTempPath = URIUtils::AddFileToFolder(strTempPath, dotLowerAppName + "/temp");
     if (getenv(envAppTemp))
       strTempPath = getenv(envAppTemp);
     CSpecialProtocol::SetTempPath(strTempPath);
@@ -1144,6 +1132,7 @@ bool CApplication::InitDirectoriesLinux()
     g_advancedSettings.m_logFolder = strTempPath;
 
     CreateUserDirs();
+
   }
   else
   {

--- a/xbmc/filesystem/SpecialProtocol.h
+++ b/xbmc/filesystem/SpecialProtocol.h
@@ -28,24 +28,23 @@
 
  special://xbmc/          - the main XBMC folder (i.e. where the app resides).
  special://home/          - a writeable version of the main XBMC folder
-                             Linux: $XDG_DATA_HOME/kodi/ (defaults to ~/.local/share)
+                             Linux: ~/.kodi/
                              OS X:  ~/Library/Application Support/Kodi/
                              Win32: ~/Application Data/XBMC/
  special://userhome/      - a writable version of the user home directory
-                             Linux: $XDG_DATA_HOME/kodi/ (defaults to ~/.local/share)
-                             OS X: ~/.kodi
+                             Linux, OS X: ~/.kodi
                              Win32: home directory of user
  special://masterprofile/ - the master users userdata folder - usually special://home/userdata
-                             Linux: $XDG_DATA_HOME/kodi/userdata/ (defaults to ~/.local/share)
+                             Linux: ~/.kodi/userdata/
                              OS X:  ~/Library/Application Support/Kodi/UserData/
                              Win32: ~/Application Data/XBMC/UserData/
  special://profile/       - the current users userdata folder - usually special://masterprofile/profiles/<current_profile>
-                             Linux: $XDG_DATA_HOME/kodi/userdata/profiles/<current_profile> (defaults to ~/.local/share)
+                             Linux: ~/.kodi/userdata/profiles/<current_profile>
                              OS X:  ~/Library/Application Support/Kodi/UserData/profiles/<current_profile>
                              Win32: ~/Application Data/XBMC/UserData/profiles/<current_profile>
 
  special://temp/          - the temporary directory.
-                             Linux: $XDG_CACHE_HOME/kodi/temp (defaults to ~/.cache)
+                             Linux: ~/.kodi/temp
                              OS X:  ~/
                              Win32: ~/Application Data/XBMC/cache
 */


### PR DESCRIPTION
Reverts xbmc/xbmc#5895

this was incomplete in numerous ways:
1.) existence on ~/.local/share was not tested -> migration fails, kodi doesn't start
2.) crashes all over, kodi doesn't create a clean userdata folder anymore
