### PR TITLE
[Feature] Support external audio tracks (part III)

### DIFF
--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -2341,6 +2341,34 @@ std::string CUtil::GetVobSubIdxFromSub(const std::string& vobSub)
   return std::string();
 }
 
+
+void CUtil::ScanForExternalAudio(const std::string& videoPath, std::vector<std::string>& vecAudio)
+{
+  unsigned int startTimer = XbmcThreads::SystemClockMillis();
+
+  // new array for commons audio sub dirs
+  const char * common_audio_dirs[] = {"audio",
+    "tracks",
+    NULL};
+
+  CFileItem item(videoPath, false);
+  if ( item.IsInternetStream()
+   ||  item.IsHDHomeRun()
+   ||  item.IsSlingbox()
+   ||  item.IsPlayList()
+   ||  item.IsLiveTV()
+   || !item.IsVideo()) 
+    return;
+
+  std::vector<std::string> strLookInPaths;
+  GetPathsToLookForAssociatedItems(videoPath, common_audio_dirs, strLookInPaths);
+
+  std::vector<std::string> audio_exts = StringUtils::Split(g_advancedSettings.m_musicExtensions, "|");
+  ScanPathsForAssociatedItems(videoPath, strLookInPaths, audio_exts, vecAudio);
+
+  CLog::Log(LOGDEBUG,"%s: END (total time: %i ms)", __FUNCTION__, (int)(XbmcThreads::SystemClockMillis() - startTimer));
+}
+
 bool CUtil::CanBindPrivileged()
 {
 #ifdef TARGET_POSIX

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -1834,6 +1834,234 @@ CStdString CUtil::GetFrameworksPath(bool forPython)
   return strFrameworksPath;
 }
 
+void CUtil::GetPathsToLookForAssociatedItems(const std::string& videoPath,
+  const char* common_sub_dirs[],
+  std::vector<std::string>& paths)
+{
+  std::string videoFileName;
+  std::string strPath;
+
+  URIUtils::Split(videoPath, strPath, videoFileName);
+  std::string videoFileNameNoExt(URIUtils::ReplaceExtension(videoFileName, ""));
+  paths.push_back(strPath);
+
+  if (StringUtils::StartsWithNoCase(videoPath, "rar://")) // <--- if this is found in main path then ignore it!
+  {
+    CURL url(videoPath);
+    std::string strArchive = url.GetHostName();
+    URIUtils::Split(strArchive, strPath, videoFileName);
+    paths.push_back(strPath);
+  }
+
+  int iSize = paths.size();
+  for (int i=0; i<iSize; ++i)
+  {
+    std::vector<std::string> directories = StringUtils::Split(paths[i], "/");
+    if (directories.size() == 1)
+      directories = StringUtils::Split(paths[i], "\\");
+
+    // if it's inside a cdX dir, add parent path
+    if (directories.size() >= 2 && directories[directories.size()-2].size() == 3 
+      && StringUtils::StartsWithNoCase(directories[directories.size()-2], "cd")) // SplitString returns empty token as last item, hence size-2
+    {
+      std::string strPath2;
+      URIUtils::GetParentPath(paths[i], strPath2);
+      paths.push_back(strPath2);
+    }
+  }
+
+  // checking if any of the common subdirs exist ..
+  iSize = paths.size();
+  for (int i=0;i<iSize;++i)
+  {
+    for (int j=0; common_sub_dirs[j]; j++)
+    {
+      std::string strPath2 = URIUtils::AddFileToFolder(paths[i], common_sub_dirs[j]);
+      URIUtils::AddSlashAtEnd(strPath2);
+      if (CDirectory::Exists(strPath2))
+        paths.push_back(strPath2);
+    }
+  }
+  // .. done checking for common subdirs
+
+  // check if there any cd-directories in the paths we have added so far
+  iSize = paths.size();
+  for (int i=0;i<9;++i) // 9 cd's
+  {
+    std::string cdDir = StringUtils::Format("cd%i",i+1);
+    for (int i=0;i<iSize;++i)
+    {
+      std::string strPath2 = URIUtils::AddFileToFolder(paths[i], cdDir);
+      URIUtils::AddSlashAtEnd(strPath2);
+      bool pathAlreadyAdded = false;
+      for (unsigned int i=0; i<paths.size(); i++)
+      {
+        // if movie file is inside cd-dir, this directory can exist in vector already
+        if (StringUtils::EqualsNoCase(paths[i], strPath2))
+          pathAlreadyAdded = true;
+      }
+      if (CDirectory::Exists(strPath2) && !pathAlreadyAdded) 
+        paths.push_back(strPath2);
+    }
+  }
+  // .. done checking for cd-dirs
+}
+
+void CUtil::ScanPathsForAssociatedItems(const std::string& videoPath,
+  std::vector<std::string>& paths,
+  const std::vector<std::string>& item_exts,
+  std::vector<std::string>& itemPaths)
+{
+  std::string videoFileName;
+  std::string strPath;
+
+  URIUtils::Split(videoPath, strPath, videoFileName);
+  std::string videoFileNameNoExt(URIUtils::ReplaceExtension(videoFileName, ""));
+
+  CURL url(videoPath);
+  std::string isoFileNameNoExt;
+  if (url.IsProtocol("bluray"))
+    url = CURL(url.GetHostName());
+  //a path inside an iso
+  if (url.IsProtocol("udf"))
+  {
+    std::string isoPath = url.GetHostName();
+    URIUtils::RemoveSlashAtEnd(isoPath);
+    CFileItem iso(isoPath, false);
+
+    if (iso.IsDiscImage())
+    {
+      std::string isoFileName;
+      URIUtils::Split(iso.GetPath(), isoPath, isoFileName);
+      isoFileNameNoExt = URIUtils::ReplaceExtension(isoFileName, "");
+      paths.push_back(isoPath);
+    }
+  }
+
+  std::string strItem;
+
+  CLog::Log(LOGDEBUG,"%s: Searching for associated items...", __FUNCTION__);
+  for (unsigned int step = 0; step < paths.size(); step++)
+  {
+    if (paths[step].length() != 0)
+    {
+      CFileItemList items;
+      std::string exts = StringUtils::Join(item_exts, "|");
+      CDirectory::GetDirectory(paths[step], items, exts ,DIR_FLAG_NO_FILE_DIRS);
+
+      for (int j = 0; j < items.Size(); j++)
+      {
+        URIUtils::Split(items[j]->GetPath(), strPath, strItem);
+
+        if (StringUtils::StartsWithNoCase(strItem, videoFileNameNoExt)
+          || (!isoFileNameNoExt.empty() && StringUtils::StartsWithNoCase(strItem, isoFileNameNoExt)))
+        {
+          // is this a rar or zip-file
+          if (URIUtils::IsRAR(strItem) || URIUtils::IsZIP(strItem))
+          {
+            // zip-file name equals videoFileNameNoExt, don't check in zip-file
+            ScanArchiveForAssociatedItems( items[j]->GetPath(), "", item_exts, itemPaths );
+          }
+          else    // not a rar/zip file
+          {
+            for (unsigned int i = 0; i < item_exts.size(); i++)
+            {
+              if (URIUtils::HasExtension(strItem, item_exts[i]))
+              {
+                itemPaths.push_back( items[j]->GetPath() ); 
+                CLog::Log(LOGINFO, "%s: found associated file %s\n", __FUNCTION__, items[j]->GetPath().c_str() );
+              }
+            }
+          }
+        }
+        else
+        {
+          // is this a rar or zip-file
+          if (URIUtils::IsRAR(strItem) || URIUtils::IsZIP(strItem))
+          {
+            // check videoFileNameNoExt in zip-file
+            ScanArchiveForAssociatedItems( items[j]->GetPath(), videoFileNameNoExt, item_exts, itemPaths );
+          }
+        }
+      }
+    }
+  }
+}
+
+int CUtil::ScanArchiveForAssociatedItems(const std::string& strArchivePath,
+  const std::string& videoNameNoExt,
+  const std::vector<std::string>& item_exts,
+  std::vector<std::string>& itemPaths)
+{
+  int nItemsAdded = 0;
+  CFileItemList ItemList;
+
+  // zip only gets the root dir
+  if (URIUtils::HasExtension(strArchivePath, ".zip"))
+  {
+    CURL pathToUrl(strArchivePath);
+    CURL zipURL = URIUtils::CreateArchivePath("zip", pathToUrl, "");
+    if (!CDirectory::GetDirectory(zipURL, ItemList, "", DIR_FLAG_NO_FILE_DIRS))
+      return false;
+  }
+  else
+  {
+#ifdef HAS_FILESYSTEM_RAR
+    // get _ALL_files in the rar, even those located in subdirectories because we set the bMask to false.
+    // so now we dont have to find any subdirs anymore, all files in the rar is checked.
+    if( !g_RarManager.GetFilesInRar(ItemList, strArchivePath, false, "") )
+      return false;
+#else
+    return false;
+#endif
+  }
+  for (int it= 0 ; it <ItemList.Size();++it)
+  {
+    std::string strPathInRar = ItemList[it]->GetPath();
+    std::string strExt = URIUtils::GetExtension(strPathInRar);
+
+    CLog::Log(LOGDEBUG, "ScanArchiveForAssociatedItems:: Found file %s", strPathInRar.c_str());
+    // always check any embedded rar archives
+    // checking for embedded rars, moved this outside the item_exts[] loop. We only need to check this once for each file.
+    if (URIUtils::IsRAR(strPathInRar) || URIUtils::IsZIP(strPathInRar))
+    {
+      CURL urlRar;
+      CURL pathToUrl(strArchivePath);
+      if (strExt == ".rar")
+        urlRar = URIUtils::CreateArchivePath("rar", pathToUrl, strPathInRar);
+      else
+        urlRar = URIUtils::CreateArchivePath("zip", pathToUrl, strPathInRar);
+      ScanArchiveForAssociatedItems(urlRar.Get(), videoNameNoExt, item_exts, itemPaths);
+    }
+    // done checking if this is a rar-in-rar
+
+    // check that the found filename matches the video filename
+    int fnl = videoNameNoExt.size();
+    if (fnl && !StringUtils::StartsWithNoCase(URIUtils::GetFileName(strPathInRar), videoNameNoExt))
+      continue;
+
+    unsigned int iPos=0;
+    while (iPos < item_exts.size())
+    {
+      if (StringUtils::EqualsNoCase(strExt, item_exts[iPos]))
+      {
+        CURL pathToURL(strArchivePath);
+        std::string strSourceUrl;
+        if (URIUtils::HasExtension(strArchivePath, ".rar"))
+          strSourceUrl = URIUtils::CreateArchivePath("rar", pathToURL, strPathInRar).Get();
+        else
+          strSourceUrl = strPathInRar;
+
+        CLog::Log(LOGINFO, "%s: found associated file %s\n", __FUNCTION__, strSourceUrl.c_str() );
+        itemPaths.push_back( strSourceUrl );
+        nItemsAdded++;
+      }
+      iPos++;
+    }
+  }
+  return nItemsAdded;
+}
+
 void CUtil::ScanForExternalSubtitles(const std::string& strMovie, std::vector<std::string>& vecSubtitles )
 {
   unsigned int startTimer = XbmcThreads::SystemClockMillis();

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -697,8 +697,6 @@ void CUtil::ClearTempFonts()
   }
 }
 
-static const char * sub_exts[] = { ".utf", ".utf8", ".utf-8", ".sub", ".srt", ".smi", ".rt", ".txt", ".ssa", ".aqt", ".jss", ".ass", ".idx", NULL};
-
 int64_t CUtil::ToInt64(uint32_t high, uint32_t low)
 {
   int64_t n;
@@ -2089,36 +2087,7 @@ void CUtil::ScanForExternalSubtitles(const std::string& strMovie, std::vector<st
     || item.IsLiveTV()
     || !item.IsVideo())
     return;
-  
-  vector<std::string> strLookInPaths;
-  
-  std::string strMovieFileName;
-  std::string strPath;
-  
-  URIUtils::Split(strMovie, strPath, strMovieFileName);
-  std::string strMovieFileNameNoExt(URIUtils::ReplaceExtension(strMovieFileName, ""));
-  strLookInPaths.push_back(strPath);
-  
-  CURL url(strMovie);
-  std::string isoFileNameNoExt;
-  if (url.IsProtocol("bluray"))
-      url = CURL(url.GetHostName());
-  //a path inside an iso
-  if (url.IsProtocol("udf"))
-  {
-    std::string isoPath = url.GetHostName();
-    URIUtils::RemoveSlashAtEnd(isoPath);
-    CFileItem iso(isoPath, false);
 
-    if (iso.IsDiscImage())
-    {
-      std::string isoFileName;
-      URIUtils::Split(iso.GetPath(), isoPath, isoFileName);
-      isoFileNameNoExt = URIUtils::ReplaceExtension(isoFileName, "");
-      strLookInPaths.push_back(isoPath);
-    }
-  }
-  
   if (!CMediaSettings::Get().GetAdditionalSubtitleDirectoryChecked() && !CSettings::Get().GetString("subtitles.custompath").empty()) // to avoid checking non-existent directories (network) every time..
   {
     if (!g_application.getNetwork().IsAvailable() && !URIUtils::IsHD(CSettings::Get().GetString("subtitles.custompath")))
@@ -2134,129 +2103,25 @@ void CUtil::ScanForExternalSubtitles(const std::string& strMovie, std::vector<st
     
     CMediaSettings::Get().SetAdditionalSubtitleDirectoryChecked(1);
   }
-  
-  if (StringUtils::StartsWith(strMovie, "rar://")) // <--- if this is found in main path then ignore it!
-  {
-    CURL url(strMovie);
-    std::string strArchive = url.GetHostName();
-    URIUtils::Split(strArchive, strPath, strMovieFileName);
-    strLookInPaths.push_back(strPath);
-  }
-  
-  int iSize = strLookInPaths.size();
-  for (int i=0; i<iSize; ++i)
-  {
-    vector<string> directories = StringUtils::Split( strLookInPaths[i], "/" );
-    if (directories.size() == 1)
-      directories = StringUtils::Split( strLookInPaths[i], "\\" );
 
-    // if it's inside a cdX dir, add parent path
-    if (directories.size() >= 2 && directories[directories.size()-2].size() == 3 && StringUtils::StartsWithNoCase(directories[directories.size()-2], "cd")) // SplitString returns empty token as last item, hence size-2
-    {
-      std::string strPath2;
-      URIUtils::GetParentPath(strLookInPaths[i], strPath2);
-      strLookInPaths.push_back(strPath2);
-    }
-  }
+  std::vector<std::string> strLookInPaths;
+  GetPathsToLookForAssociatedItems(strMovie, common_sub_dirs, strLookInPaths);
 
-  // checking if any of the common subdirs exist ..
-  iSize = strLookInPaths.size();
-  for (int i=0;i<iSize;++i)
-  {
-    for (int j=0; common_sub_dirs[j]; j++)
-    {
-      std::string strPath2 = URIUtils::AddFileToFolder(strLookInPaths[i],common_sub_dirs[j]);
-      URIUtils::AddSlashAtEnd(strPath2);
-      if (CDirectory::Exists(strPath2))
-        strLookInPaths.push_back(strPath2);
-    }
-  }
-  // .. done checking for common subdirs
-  
-  // check if there any cd-directories in the paths we have added so far
-  iSize = strLookInPaths.size();
-  for (int i=0;i<9;++i) // 9 cd's
-  {
-    std::string cdDir = StringUtils::Format("cd%i",i+1);
-    for (int i=0;i<iSize;++i)
-    {
-      std::string strPath2 = URIUtils::AddFileToFolder(strLookInPaths[i],cdDir);
-      URIUtils::AddSlashAtEnd(strPath2);
-      bool pathAlreadyAdded = false;
-      for (unsigned int i=0; i<strLookInPaths.size(); i++)
-      {
-        // if movie file is inside cd-dir, this directory can exist in vector already
-        if (StringUtils::EqualsNoCase(strLookInPaths[i], strPath2))
-          pathAlreadyAdded = true;
-      }
-      if (CDirectory::Exists(strPath2) && !pathAlreadyAdded) 
-        strLookInPaths.push_back(strPath2);
-    }
-  }
-  // .. done checking for cd-dirs
-  
   // this is last because we dont want to check any common subdirs or cd-dirs in the alternate <subtitles> dir.
   if (CMediaSettings::Get().GetAdditionalSubtitleDirectoryChecked() == 1)
   {
-    strPath = CSettings::Get().GetString("subtitles.custompath");
+    std::string strPath = CSettings::Get().GetString("subtitles.custompath");
     URIUtils::AddSlashAtEnd(strPath);
     strLookInPaths.push_back(strPath);
   }
-  
-  std::string strDest;
-  std::string strItem;
-  
-  // 2 steps for movie directory and alternate subtitles directory
-  CLog::Log(LOGDEBUG,"%s: Searching for subtitles...", __FUNCTION__);
-  for (unsigned int step = 0; step < strLookInPaths.size(); step++)
-  {
-    if (strLookInPaths[step].length() != 0)
-    {
-      CFileItemList items;
-      
-      CDirectory::GetDirectory(strLookInPaths[step], items, g_advancedSettings.m_subtitlesExtensions, DIR_FLAG_NO_FILE_DIRS);
-      
-      for (int j = 0; j < items.Size(); j++)
-      {
-        URIUtils::Split(items[j]->GetPath(), strPath, strItem);
-        
-        if (StringUtils::StartsWithNoCase(strItem, strMovieFileNameNoExt)
-          || (!isoFileNameNoExt.empty() && StringUtils::StartsWithNoCase(strItem, isoFileNameNoExt)))
-        {
-          // is this a rar or zip-file
-          if (URIUtils::IsRAR(strItem) || URIUtils::IsZIP(strItem))
-          {
-            // zip-file name equals strMovieFileNameNoExt, don't check in zip-file
-            ScanArchiveForSubtitles( items[j]->GetPath(), "", vecSubtitles );
-          }
-          else    // not a rar/zip file
-          {
-            for (int i = 0; sub_exts[i]; i++)
-            {
-              //Cache subtitle with same name as movie
-              if (URIUtils::HasExtension(strItem, sub_exts[i]))
-              {
-                vecSubtitles.push_back( items[j]->GetPath() ); 
-                CLog::Log(LOGINFO, "%s: found subtitle file %s\n", __FUNCTION__, CURL::GetRedacted(items[j]->GetPath()).c_str() );
-              }
-            }
-          }
-        }
-        else
-        {
-          // is this a rar or zip-file
-          if (URIUtils::IsRAR(strItem) || URIUtils::IsZIP(strItem))
-          {
-            // check strMovieFileNameNoExt in zip-file
-            ScanArchiveForSubtitles( items[j]->GetPath(), strMovieFileNameNoExt, vecSubtitles );
-          }
-        }
-      }
-    }
-  }
 
-  iSize = vecSubtitles.size();
-  for (int i = 0; i < iSize; i++)
+  std::vector<std::string> sub_exts = StringUtils::Split(g_advancedSettings.m_subtitlesExtensions, "|");
+
+  ScanPathsForAssociatedItems(strMovie, strLookInPaths, sub_exts, vecSubtitles);
+
+  unsigned int iSize = vecSubtitles.size();
+  std::string strDest;
+  for (unsigned int i = 0; i < iSize; i++)
   {
     if (URIUtils::HasExtension(vecSubtitles[i], ".smi"))
     {
@@ -2285,78 +2150,6 @@ void CUtil::ScanForExternalSubtitles(const std::string& strMovie, std::vector<st
   CLog::Log(LOGDEBUG,"%s: END (total time: %i ms)", __FUNCTION__, (int)(XbmcThreads::SystemClockMillis() - startTimer));
 }
 
-int CUtil::ScanArchiveForSubtitles( const std::string& strArchivePath, const std::string& strMovieFileNameNoExt, std::vector<std::string>& vecSubtitles )
-{
-  int nSubtitlesAdded = 0;
-  CFileItemList ItemList;
- 
-  // zip only gets the root dir
-  if (URIUtils::HasExtension(strArchivePath, ".zip"))
-  {
-   CURL pathToUrl(strArchivePath);
-   CURL zipURL = URIUtils::CreateArchivePath("zip", pathToUrl, "");
-   if (!CDirectory::GetDirectory(zipURL, ItemList, "", DIR_FLAG_NO_FILE_DIRS))
-    return false;
-  }
-  else
-  {
- #ifdef HAS_FILESYSTEM_RAR
-   // get _ALL_files in the rar, even those located in subdirectories because we set the bMask to false.
-   // so now we dont have to find any subdirs anymore, all files in the rar is checked.
-   if( !g_RarManager.GetFilesInRar(ItemList, strArchivePath, false, "") )
-    return false;
- #else
-   return false;
- #endif
-  }
-  for (int it= 0 ; it <ItemList.Size();++it)
-  {
-   std::string strPathInRar = ItemList[it]->GetPath();
-   std::string strExt = URIUtils::GetExtension(strPathInRar);
-   
-   CLog::Log(LOGDEBUG, "ScanArchiveForSubtitles:: Found file %s", strPathInRar.c_str());
-   // always check any embedded rar archives
-   // checking for embedded rars, I moved this outside the sub_ext[] loop. We only need to check this once for each file.
-   if (URIUtils::IsRAR(strPathInRar) || URIUtils::IsZIP(strPathInRar))
-   {
-    CURL urlRar;
-    CURL pathToUrl(strArchivePath);
-    if (strExt == ".rar")
-      urlRar = URIUtils::CreateArchivePath("rar", pathToUrl, strPathInRar);
-    else
-      urlRar = URIUtils::CreateArchivePath("zip", pathToUrl, strPathInRar);
-    ScanArchiveForSubtitles(urlRar.Get(), strMovieFileNameNoExt, vecSubtitles);
-   }
-   // done checking if this is a rar-in-rar
-
-   // check that the found filename matches the movie filename
-   int fnl = strMovieFileNameNoExt.size();
-   if (fnl && !StringUtils::StartsWithNoCase(URIUtils::GetFileName(strPathInRar), strMovieFileNameNoExt))
-     continue;
-
-   int iPos=0;
-    while (sub_exts[iPos])
-    {
-     if (StringUtils::EqualsNoCase(strExt, sub_exts[iPos]))
-     {
-       CURL pathToURL(strArchivePath);
-      CStdString strSourceUrl;
-      if (URIUtils::HasExtension(strArchivePath, ".rar"))
-       strSourceUrl = URIUtils::CreateArchivePath("rar", pathToURL, strPathInRar).Get();
-      else
-       strSourceUrl = strPathInRar;
-      
-       CLog::Log(LOGINFO, "%s: found subtitle file %s\n", __FUNCTION__, strSourceUrl.c_str() );
-       vecSubtitles.push_back( strSourceUrl );
-       nSubtitlesAdded++;
-     }
-     
-     iPos++;
-    }
-  }
-
-  return nSubtitlesAdded;
-}
 
 void CUtil::GetExternalStreamDetailsFromFilename(const CStdString& strVideo, const CStdString& strStream, ExternalStreamInfo& info)
 {

--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -133,6 +133,12 @@ public:
   static bool IsVobSub(const std::vector<std::string>& vecSubtitles, const std::string& strSubPath);
   static std::string GetVobSubSubFromIdx(const std::string& vobSubIdx);
   static std::string GetVobSubIdxFromSub(const std::string& vobSub);
+  
+  /** \brief Retrieves paths of external audio files for a given video.
+  *   \param[in] videoPath The full path of the video file.
+  *   \param[out] vecAudio A vector containing the full paths of all found external audio files.
+  */
+  static void ScanForExternalAudio(const std::string& videoPath, std::vector<std::string>& vecAudio);
   static int64_t ToInt64(uint32_t high, uint32_t low);
   static CStdString GetNextFilename(const CStdString &fn_template, int max);
   static CStdString GetNextPathname(const CStdString &path_template, int max);

--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -128,7 +128,6 @@ public:
     std::vector<std::string>& itemPaths);
 
   static void ScanForExternalSubtitles(const std::string& strMovie, std::vector<std::string>& vecSubtitles );
-  static int ScanArchiveForSubtitles( const std::string& strArchivePath, const std::string& strMovieFileNameNoExt, std::vector<std::string>& vecSubtitles );
   static void GetExternalStreamDetailsFromFilename(const CStdString& strMovie, const CStdString& strSubtitles, ExternalStreamInfo& info); 
   static bool FindVobSubPair( const std::vector<std::string>& vecSubtitles, const std::string& strIdxPath, std::string& strSubPath );
   static bool IsVobSub(const std::vector<std::string>& vecSubtitles, const std::string& strSubPath);

--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -95,6 +95,38 @@ public:
   static void ClearTempFonts();
 
   static void ClearSubtitles();
+
+  /** \brief Retrieves paths that could contain associated files of a given video.
+  *   \param[in] videoPath The full path of the video file.
+  *   \param[in] common_sub_dirs[] An array of sub directory names to look for.
+  *   \param[out] paths A vector of found paths to look for associated files.
+  */
+  static void GetPathsToLookForAssociatedItems(const std::string& videoPath,
+    const char* common_sub_dirs[],
+    std::vector<std::string>& paths);
+
+  /** \brief Searches for associated files of a given video.
+  *   \param[in] videoPath The full path of the video file.
+  *   \param[in] paths A vector of paths to look for associated files.
+  *   \param[in] item_exts An array of extensions specifying the associated files.
+  *   \param[out] itemPaths A vector containing the full paths of all found associated files.
+  */
+  static void ScanPathsForAssociatedItems(const std::string& videoPath,
+    std::vector<std::string>& paths,
+    const std::vector<std::string>& item_exts,
+    std::vector<std::string>& itemPaths);
+
+  /** \brief Searches in an archive for associated files of a given video.
+  *   \param[in] strArchivePath The full path of the archive.
+  *   \param[in] videoNameNoExt The filename of the video without extension for which associated files should be retrieved.
+  *   \param[in] item_exts An array of extensions specifying the associated files.
+  *   \param[out] itemPaths A vector containing the full paths of all found associated files.
+  */
+  static int ScanArchiveForAssociatedItems(const std::string& strArchivePath,
+    const std::string& videoNameNoExt,
+    const std::vector<std::string>& item_exts,
+    std::vector<std::string>& itemPaths);
+
   static void ScanForExternalSubtitles(const std::string& strMovie, std::vector<std::string>& vecSubtitles );
   static int ScanArchiveForSubtitles( const std::string& strArchivePath, const std::string& strMovieFileNameNoExt, std::vector<std::string>& vecSubtitles );
   static void GetExternalStreamDetailsFromFilename(const CStdString& strMovie, const CStdString& strSubtitles, ExternalStreamInfo& info); 

--- a/xbmc/cores/dvdplayer/DVDFileInfo.cpp
+++ b/xbmc/cores/dvdplayer/DVDFileInfo.cpp
@@ -145,7 +145,7 @@ bool CDVDFileInfo::ExtractThumb(const std::string &strPath,
 
   if (pStreamDetails)
   {
-    DemuxerToStreamDetails(pInputStream, pDemuxer, *pStreamDetails, strPath);
+    DemuxerToStreamDetails(pInputStream, pDemuxer, *pStreamDetails, true, strPath);
 
     //extern subtitles
     std::vector<std::string> filenames;
@@ -349,7 +349,7 @@ bool CDVDFileInfo::GetFileStreamDetails(CFileItem *pItem)
   CDVDDemux *pDemuxer = CDVDFactoryDemuxer::CreateDemuxer(pInputStream, true);
   if (pDemuxer)
   {
-    bool retVal = DemuxerToStreamDetails(pInputStream, pDemuxer, pItem->GetVideoInfoTag()->m_streamDetails, strFileNameAndPath);
+    bool retVal = DemuxerToStreamDetails(pInputStream, pDemuxer, pItem->GetVideoInfoTag()->m_streamDetails, true, strFileNameAndPath);
     delete pDemuxer;
     delete pInputStream;
     return retVal;
@@ -361,9 +361,43 @@ bool CDVDFileInfo::GetFileStreamDetails(CFileItem *pItem)
   }
 }
 
-bool CDVDFileInfo::DemuxerToStreamDetails(CDVDInputStream *pInputStream, CDVDDemux *pDemuxer, const std::vector<CStreamDetailSubtitle> &subs, CStreamDetails &details)
+bool CDVDFileInfo::DemuxerToStreamDetails(CDVDInputStream *pInputStream, CDVDDemux *pDemux, const std::map<int, DemuxPtr>& pDemuxers, CStreamDetails &details, const std::string &path)
 {
-  bool result = DemuxerToStreamDetails(pInputStream, pDemuxer, details);
+  bool retVal = false;
+  details.Reset();
+  retVal = DemuxerToStreamDetails(pInputStream, pDemux, details, false, path);
+
+  if(! retVal)
+    return false;
+
+  // process external audio streams, the first one is the master demuxer pDemux
+  for (std::map<int, DemuxPtr>::const_iterator iter = ++pDemuxers.begin(); iter != pDemuxers.end(); ++iter)
+  {
+    if (iter->second.get())
+    {
+      for (int i = 0; i < iter->second->GetNrOfStreams(); i++)
+      {
+        CDemuxStream *stream = iter->second->GetStream(i);
+
+        if (stream->type == STREAM_AUDIO)
+        {
+          CStreamDetailAudio *p = new CStreamDetailAudio();
+          p->m_iChannels = ((CDemuxStreamAudio *)stream)->iChannels;
+          p->m_strLanguage = stream->language;
+          iter->second->GetStreamCodecName(i, p->m_strCodec);
+          details.AddStream(p);
+          retVal = true;
+        }
+      }
+    }
+  }
+
+  details.DetermineBestStreams();
+  return retVal;
+}
+bool CDVDFileInfo::DemuxerToStreamDetails(CDVDInputStream *pInputStream, CDVDDemux *pDemuxer, const std::map<int, DemuxPtr>& pDemuxers, const std::vector<CStreamDetailSubtitle>& subs, CStreamDetails &details)
+{
+  bool result = DemuxerToStreamDetails(pInputStream, pDemuxer, pDemuxers, details);
   for (unsigned int i = 0; i < subs.size(); i++)
   {
     CStreamDetailSubtitle* sub = new CStreamDetailSubtitle();
@@ -375,7 +409,7 @@ bool CDVDFileInfo::DemuxerToStreamDetails(CDVDInputStream *pInputStream, CDVDDem
 }
 
 /* returns true if details have been added */
-bool CDVDFileInfo::DemuxerToStreamDetails(CDVDInputStream *pInputStream, CDVDDemux *pDemux, CStreamDetails &details, const std::string &path)
+bool CDVDFileInfo::DemuxerToStreamDetails(CDVDInputStream *pInputStream, CDVDDemux *pDemux, CStreamDetails &details, bool handleExternalAudio, const std::string &path)
 {
   bool retVal = false;
   details.Reset();
@@ -439,6 +473,16 @@ bool CDVDFileInfo::DemuxerToStreamDetails(CDVDInputStream *pInputStream, CDVDDem
     }
   }  /* for iStream */
 
+  std::string video_path;
+  if (path.empty())
+    video_path = pInputStream->GetFileName();
+  else
+    video_path = path;
+
+  // include external audio tracks
+  if (handleExternalAudio)
+    retVal |= AddExternalAudioToDetails(video_path, details);
+
   details.DetermineBestStreams();
 #ifdef HAVE_LIBBLURAY
   // correct bluray runtime. we need the duration from the input stream, not the demuxer.
@@ -452,6 +496,78 @@ bool CDVDFileInfo::DemuxerToStreamDetails(CDVDInputStream *pInputStream, CDVDDem
     }
   }
 #endif
+  return retVal;
+}
+
+bool CDVDFileInfo::AddExternalAudioToDetails(const std::string &path, CStreamDetails &details)
+{
+  bool retVal = false;
+  // find any available external audio track
+  std::vector<std::string> filenames;
+  CUtil::ScanForExternalAudio( path, filenames );
+  for(unsigned int i = 0; i < filenames.size();i++)
+  {
+    CDVDInputStream* ext_pInputStream;
+    CFileItem ext_item = CFileItem(filenames[i]);
+    std::string ext_mimeType = ext_item.GetMimeType();
+    ext_pInputStream = CDVDFactoryInputStream::CreateInputStream(NULL, filenames[i], ext_mimeType);
+    if(ext_pInputStream == NULL)
+    {
+      CLog::Log(LOGERROR, "CDVDPlayer::OpenInputStream - unable to create input stream for external audio file [%s]", filenames[i].c_str());
+      continue;
+    }
+    else
+      ext_pInputStream->SetFileItem(ext_item);
+
+    if (!ext_pInputStream->Open(filenames[i].c_str(), ext_mimeType))
+    {
+      CLog::Log(LOGERROR, "CDVDPlayer::OpenInputStream - error opening  external audio file [%s]", filenames[i].c_str());
+      continue;
+    }
+    CDVDDemux* extDemuxer = NULL;
+    try
+    {
+      int attempts = 10;
+      while(attempts-- > 0)
+      {
+        extDemuxer = CDVDFactoryDemuxer::CreateDemuxer(ext_pInputStream);
+        if(!extDemuxer && ext_pInputStream->NextStream() != CDVDInputStream::NEXTSTREAM_NONE)
+        {
+          CLog::Log(LOGDEBUG, "%s - New stream available from input, retry open", __FUNCTION__);
+          continue;
+        }
+        break;
+      }
+
+      if(!extDemuxer)
+      {
+        CLog::Log(LOGERROR, "%s - Error creating external audio demuxer for file %s", __FUNCTION__, ext_pInputStream->GetFileName().c_str());
+        continue;
+      }
+
+    }
+    catch(...)
+    {
+      CLog::Log(LOGERROR, "%s - Exception thrown when opening external audio demuxer for file %s", __FUNCTION__, ext_pInputStream->GetFileName().c_str());
+      continue;
+    }
+    if(extDemuxer)
+    {
+      for (int i = 0; i < extDemuxer->GetNrOfStreams(); i++)
+      {
+        CDemuxStream *stream = extDemuxer->GetStream(i);
+        if (stream->type == STREAM_AUDIO)
+        {
+          CStreamDetailAudio *p = new CStreamDetailAudio();
+          p->m_iChannels = ((CDemuxStreamAudio *)stream)->iChannels;
+          p->m_strLanguage = stream->language;
+          extDemuxer->GetStreamCodecName(i, p->m_strCodec);
+          details.AddStream(p);
+          retVal = true;
+        }
+      }
+    }
+  }
   return retVal;
 }
 

--- a/xbmc/cores/dvdplayer/DVDFileInfo.h
+++ b/xbmc/cores/dvdplayer/DVDFileInfo.h
@@ -22,9 +22,12 @@
 
 #include <string>
 #include <vector>
+#include "boost/shared_ptr.hpp"
+#include <map>
 
 class CFileItem;
 class CDVDDemux;
+typedef boost::shared_ptr<CDVDDemux> DemuxPtr;
 class CStreamDetails;
 class CStreamDetailSubtitle;
 class CDVDInputStream;
@@ -42,12 +45,16 @@ public:
   static bool GetFileStreamDetails(CFileItem *pItem);
   static bool DemuxerToStreamDetails(CDVDInputStream* pInputStream, CDVDDemux *pDemux, CStreamDetails &details, const std::string &path = "");
 
+  static bool DemuxerToStreamDetails(CDVDInputStream* pInputStream, CDVDDemux *pDemux, const std::map<int, DemuxPtr>& m_extDemuxer, CStreamDetails &details, const std::string &path = "");
+  static bool DemuxerToStreamDetails(CDVDInputStream* pInputStream, CDVDDemux *pDemux, CStreamDetails &details, bool handleExternalAudio, const std::string &path = "");
+
   /** \brief Probe the file's internal and external streams and store the info in the StreamDetails parameter.
   *   \param[out] details The file's StreamDetails consisting of internal streams and external subtitle streams.
   */
-  static bool DemuxerToStreamDetails(CDVDInputStream *pInputStream, CDVDDemux *pDemuxer, const std::vector<CStreamDetailSubtitle> &subs, CStreamDetails &details);
+  static bool DemuxerToStreamDetails(CDVDInputStream *pInputStream, CDVDDemux *pDemuxer, const std::map<int, DemuxPtr>& pDemuxers, const std::vector<CStreamDetailSubtitle>& subs, CStreamDetails &details);
 
   static bool GetFileDuration(const std::string &path, int &duration);
+  static bool AddExternalAudioToDetails(const std::string &path, CStreamDetails &details);
 
   /** \brief Probe the streams of an external subtitle file and store the info in the StreamDetails parameter.
   *   \param[out] details The external subtitle file's StreamDetails.

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -4486,7 +4486,7 @@ bool CDVDPlayer::GetStreamDetails(CStreamDetails &details)
       extSubDetails.push_back(p);
     }
     
-    bool result = CDVDFileInfo::DemuxerToStreamDetails(m_pInputStream, m_pDemuxer, extSubDetails, details);
+    bool result = CDVDFileInfo::DemuxerToStreamDetails(m_pInputStream, m_pDemuxer, m_pDemuxers, extSubDetails, details);
     if (result && details.GetStreamCount(CStreamDetail::VIDEO) > 0) // this is more correct (dvds in particular)
     {
       /* 

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -111,6 +111,21 @@ void CSelectionStreams::Clear(StreamType type, StreamSource source)
   }
 }
 
+void CSelectionStreams::Clear(StreamType type, int source)
+{
+  CSingleLock lock(m_section);
+  for(int i = m_Streams.size()-1; i >= 0; i--)
+  {
+    if(type && m_Streams[i].type != type)
+      continue;
+
+    if(source && m_Streams[i].source != source)
+      continue;
+
+    m_Streams.erase(m_Streams.begin() + i);
+  }
+}
+
 SelectionStream& CSelectionStreams::Get(StreamType type, int index)
 {
   CSingleLock lock(m_section);
@@ -967,8 +982,23 @@ bool CDVDPlayer::ReadPacket(DemuxPacket*& packet, CDemuxStream*& stream)
     }
   }
 
-  if(m_pDemuxers[source])
-    packet = m_pDemuxers[source]->Read();
+  do
+  {
+    if(source > 0 && m_pDemuxers[source])
+      packet = m_pDemuxers[source]->Read();
+
+    // no packet could be read form external file, e.g. eof or not a valid audio file
+    if (!packet && source > 0 && (source != m_CurrentVideo.source))
+    {
+      m_SelectionStreams.Clear(STREAM_NONE, source);
+      m_pDemuxers.erase(source);
+      CloseStream(m_CurrentAudio, false);
+      OpenDefaultStreams(false);
+      source = m_CurrentAudio.source;
+      if(source > 0 && m_pDemuxers[source])
+        packet = m_pDemuxers[source]->Read();
+    }
+  }while (!packet && source > 0 && (source != m_CurrentVideo.source));
 
   if(packet)
   {

--- a/xbmc/cores/dvdplayer/DVDPlayer.h
+++ b/xbmc/cores/dvdplayer/DVDPlayer.h
@@ -204,6 +204,7 @@ public:
   }
 
   void             Clear   (StreamType type, StreamSource source);
+  void             Clear   (StreamType type, int source);
   int              Source  (StreamSource source, std::string filename);
 
   void             Update  (SelectionStream& s);

--- a/xbmc/cores/dvdplayer/DVDPlayer.h
+++ b/xbmc/cores/dvdplayer/DVDPlayer.h
@@ -87,6 +87,7 @@ struct SOmxPlayerState
 };
 
 class CDVDInputStream;
+typedef boost::shared_ptr<CDVDInputStream> InputStreamPtr;
 
 class CDVDDemux;
 class CDemuxStreamVideo;
@@ -426,8 +427,9 @@ protected:
   CDVDClock m_clock;                // master clock
   CDVDOverlayContainer m_overlayContainer;
 
-  CDVDInputStream* m_pInputStream;  // input stream for current playing file
-  CDVDDemux* m_pDemuxer;            // demuxer for current playing file
+  CDVDInputStream* m_pInputStream;                  // master input stream for current playing file
+  std::map<int, InputStreamPtr> m_pInputStreams;    // input streams for current playing file
+  CDVDDemux* m_pDemuxer;                            // demuxer for current playing file
   CDVDDemux* m_pSubtitleDemuxer;
   CDVDDemuxCC* m_pCCDemuxer;
 

--- a/xbmc/cores/dvdplayer/DVDPlayer.h
+++ b/xbmc/cores/dvdplayer/DVDPlayer.h
@@ -90,6 +90,8 @@ class CDVDInputStream;
 typedef boost::shared_ptr<CDVDInputStream> InputStreamPtr;
 
 class CDVDDemux;
+typedef boost::shared_ptr<CDVDDemux> DemuxPtr;
+
 class CDemuxStreamVideo;
 class CDemuxStreamAudio;
 class CStreamInfo;
@@ -205,7 +207,7 @@ public:
   int              Source  (StreamSource source, std::string filename);
 
   void             Update  (SelectionStream& s);
-  void             Update  (CDVDInputStream* input, CDVDDemux* demuxer, std::string filename2 = "");
+  int              Update  (CDVDInputStream* input, CDVDDemux* demuxer, std::string filename2 = "");
 };
 
 
@@ -381,6 +383,7 @@ protected:
 
   bool OpenInputStream();
   bool OpenDemuxStream();
+  bool OpenDemuxStream(InputStreamPtr& input);
   void OpenDefaultStreams(bool reset = true);
 
   void UpdateApplication(double timeout);
@@ -429,7 +432,8 @@ protected:
 
   CDVDInputStream* m_pInputStream;                  // master input stream for current playing file
   std::map<int, InputStreamPtr> m_pInputStreams;    // input streams for current playing file
-  CDVDDemux* m_pDemuxer;                            // demuxer for current playing file
+  CDVDDemux* m_pDemuxer;                            // master demuxer for current playing file
+  std::map<int, DemuxPtr> m_pDemuxers;              // demuxers for current playing file
   CDVDDemux* m_pSubtitleDemuxer;
   CDVDDemuxCC* m_pCCDemuxer;
 


### PR DESCRIPTION
This PR adds the possibility to play external audio tracks together with video files.
The original PR is here:#2562 (and #1337). Currently there is no support for language/type extraction from the filename. It can be added easily. The first 3 commits are also available as separate pr: #6096.
