### PR TITLE
[backport] videodb: fix GetRandomMusicVideo() with empty WHERE clause (fixes mixed party mode)

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -7457,7 +7457,9 @@ bool CVideoDatabase::GetRandomMusicVideo(CFileItem* item, int& idSong, const CSt
     if (NULL == m_pDS.get()) return false;
 
     // We don't use PrepareSQL here, as the WHERE clause is already formatted.
-    CStdString strSQL = StringUtils::Format("select * from musicvideoview where %s", strWhere.c_str());
+    CStdString strSQL = "select * from musicvideoview";
+    if (!strWhere.empty())
+      strSQL += PrepareSQL(" where %s", strWhere.c_str());
     strSQL += PrepareSQL(" order by RANDOM() limit 1");
     CLog::Log(LOGDEBUG, "%s query = %s", __FUNCTION__, strSQL.c_str());
     // run query


### PR DESCRIPTION
This is a backport of c5ebee0f7009d531d9584eec7ad724b2b15e7df9 and fixes an issue that has long been reported in the forums at http://forum.kodi.tv/showthread.php?tid=200938&pid=1880181 but I hadn't seen it until the bump a few days ago.

Apart from the obvious fix where the passed in WHERE clause is empty and the SQL query becomes invalid it is also wrong to use `StringUtils::Format()?  because it doesn't handle SQL specific escaping like`PrepareSQL()` does.
