### PR TITLE
media library: fix path history navigation

### DIFF
--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -497,9 +497,17 @@ bool URIUtils::PathStarts(const std::string& url, const char *start)
   return StringUtils::StartsWith(url, start);
 }
 
-bool URIUtils::PathEquals(const std::string& url, const std::string &start)
+bool URIUtils::PathEquals(const std::string& url, const std::string &start, bool ignoreTrailingSlash /* = false */)
 {
-  return url == start;
+  std::string path1 = url;
+  std::string path2 = start;
+  if (ignoreTrailingSlash)
+  {
+    RemoveSlashAtEnd(path1);
+    RemoveSlashAtEnd(path2);
+  }
+
+  return path1 == path2;
 }
 
 bool URIUtils::IsRemote(const CStdString& strFile)

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -106,10 +106,11 @@ public:
    Comparison is case-sensitive.
    \param path1 a std::string path.
    \param path2 the second path the path should be compared against.
+   \param ignoreTrailingSlash ignore any trailing slashes in both paths
    \return true if the paths are equal, false otherwise.
    \sa IsProtocol, PathStarts
    */
-  static bool PathEquals(const std::string& path1, const std::string &path2);
+  static bool PathEquals(const std::string& path1, const std::string &path2, bool ignoreTrailingSlash = false);
 
   static bool IsAddonsPath(const CStdString& strFile);
   static bool IsSourcesPath(const CStdString& strFile);

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -218,7 +218,7 @@ bool CGUIMediaWindow::OnBack(int actionID)
 {
   CURL filterUrl(m_strFilterPath);
   if (actionID == ACTION_NAV_BACK && !m_vecItems->IsVirtualDirectoryRoot() &&
-     (m_vecItems->GetPath() != m_startDirectory || (m_canFilterAdvanced && filterUrl.HasOption("filter"))))
+     (!URIUtils::PathEquals(m_vecItems->GetPath(), m_startDirectory, true) || (m_canFilterAdvanced && filterUrl.HasOption("filter"))))
   {
     GoParentFolder();
     return true;
@@ -1458,7 +1458,7 @@ void CGUIMediaWindow::OnInitWindow()
   m_rootDir.SetAllowThreads(false);
 
   // the start directory may change during Refresh
-  bool updateStartDirectory = (m_startDirectory == m_vecItems->GetPath());
+  bool updateStartDirectory = URIUtils::PathEquals(m_vecItems->GetPath(), m_startDirectory, true);
   Refresh();
   if (updateStartDirectory)
   {

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -1276,7 +1276,12 @@ void CGUIMediaWindow::SetHistoryForPath(const std::string& strDirectory)
         strParentPath = url.Get();
       }
 
-      URIUtils::AddSlashAtEnd(strPath);
+      // set the original path exactly as it was passed in
+      if (URIUtils::PathEquals(strPath, strDirectory, true))
+        strPath = strDirectory;
+      else
+        URIUtils::AddSlashAtEnd(strPath);
+
       m_history.AddPathFront(strPath);
       m_history.SetSelectedItem(strPath, strParentPath);
       strPath = strParentPath;


### PR DESCRIPTION
This fixes an issue introduced by #5941 (actually we were just lucky that it didn't hit us before) which broke path history navigation when e.g. jumping into a tvshow smartplaylist directly from the home screen as described by @HitcherUK in http://forum.kodi.tv/showthread.php?tid=211165&pid=1876847#pid1876847.

The issue basically is/was that we compared the original start path with the determined parent path and the determined parent path had a trailing slash whereas the original start path didn't. Furthermore the logic in `CGUIMediaWindow::SetHistoryForPath()` always adds a trailing slash to all paths being stored in the path history. But that can result in invalid paths if the path was pointing to a file that is evaluated as a directory (e.g. XSP paths). We don't do that in `CDirectoryHistory::AddPath()` either so I fixed that as well.
