### PR TITLE
Fix memory leak in paplayer/OGGcodec.cpp

### DIFF
--- a/xbmc/cores/paplayer/OGGcodec.cpp
+++ b/xbmc/cores/paplayer/OGGcodec.cpp
@@ -92,7 +92,10 @@ bool OGGCodec::Init(const std::string &strFile1, unsigned int filecache)
   if (iStreams>1)
   {
     if (m_CurrentStream > iStreams)
+    {
+      DeInit();
       return false;
+    }
   }
 
   //  Calculate the offset in secs where the bitstream starts
@@ -104,6 +107,7 @@ bool OGGCodec::Init(const std::string &strFile1, unsigned int filecache)
   if (!pInfo)
   {
     CLog::Log(LOGERROR, "OGGCodec: Can't get stream info from %s", strFile1.c_str());
+    DeInit();
     return false;
   }
 
@@ -122,6 +126,7 @@ bool OGGCodec::Init(const std::string &strFile1, unsigned int filecache)
   if (m_SampleRate==0 || m_Channels==0 || m_BitsPerSample==0 || m_TotalTime==0)
   {
     CLog::Log(LOGERROR, "OGGCodec: incomplete stream info from %s, SampleRate=%i, Channels=%i, BitsPerSample=%i, TotalTime=%" PRIu64, strFile1.c_str(), m_SampleRate, m_Channels, m_BitsPerSample, m_TotalTime);
+    DeInit();
     return false;
   }
 
@@ -139,9 +144,12 @@ bool OGGCodec::Init(const std::string &strFile1, unsigned int filecache)
     if (m_dll.ov_time_seek(&m_VorbisFile, m_TimeOffset)!=0)
     {
       CLog::Log(LOGERROR, "OGGCodec: Can't seek to the bitstream start time (%s)", strFile1.c_str());
+      DeInit();
       return false;
     }
   }
+
+  m_inited = true;
 
   return true;
 }


### PR DESCRIPTION
m_inited is checked in OGGCodec::Init() but was never set to true and inialization was done always causing a memory leak. A few MB's of memory is eaten for every ogg file that is played.
