### PR TITLE
[confluence] Chapter foward always hidden by broken condition

### DIFF
--- a/addons/skin.confluence/720p/VideoOSD.xml
+++ b/addons/skin.confluence/720p/VideoOSD.xml
@@ -110,8 +110,6 @@
 				<texturefocus>OSDNextTrackFO.png</texturefocus>
 				<texturenofocus>OSDNextTrackNF.png</texturenofocus>
 				<onclick>PlayerControl(Next)</onclick>
-				<enable>IntegerGreaterThan(Playlist.Length(video),1)</enable>
-				<animation effect="fade" start="100" end="0" time="100" condition="!IntegerGreaterThan(Playlist.Length(video),1)">Conditional</animation>
 			</control>
 			<control type="image" id="2200">
 				<width>270</width>


### PR DESCRIPTION
I dont understand this condition nor why the **chapter forward button is always hidden even when a file has chapters.**

Further makes no sense whatsoever because chapter back is possible/visible but not chapter forward.

 If we hiding buttons conditionally then hide correct ones properly.
