### PR TITLE
[pvr] fix channel switch with numpad for radio channels

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2659,7 +2659,7 @@ bool CApplication::OnAction(const CAction &action)
   }
 
   // Now check with the player if action can be handled.
-  if (g_windowManager.GetActiveWindow() == WINDOW_FULLSCREEN_VIDEO ||
+  if (g_windowManager.GetActiveWindow() == WINDOW_FULLSCREEN_VIDEO || g_windowManager.GetActiveWindow() == WINDOW_VISUALISATION ||
       (g_windowManager.GetActiveWindow() == WINDOW_DIALOG_VIDEO_OSD && (action.GetID() == ACTION_NEXT_ITEM || action.GetID() == ACTION_PREV_ITEM || action.GetID() == ACTION_CHANNEL_UP || action.GetID() == ACTION_CHANNEL_DOWN)) ||
       action.GetID() == ACTION_STOP)
   {

--- a/xbmc/music/windows/GUIWindowVisualisation.cpp
+++ b/xbmc/music/windows/GUIWindowVisualisation.cpp
@@ -20,16 +20,24 @@
 
 #include "GUIWindowVisualisation.h"
 #include "Application.h"
+#include "FileItem.h"
 #include "music/dialogs/GUIDialogMusicOSD.h"
 #include "GUIUserMessages.h"
 #include "GUIInfoManager.h"
 #include "music/dialogs/GUIDialogVisualisationPresetList.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/Key.h"
+#include "guilib/LocalizeStrings.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
+#include "utils/log.h"
+#include "utils/StringUtils.h"
+#include "dialogs/GUIDialogNumeric.h"
+#include "pvr/PVRManager.h"
+#include "pvr/channels/PVRChannelGroupsContainer.h"
 
 using namespace MUSIC_INFO;
+using namespace PVR;
 
 #define START_FADE_LENGTH  2.0f // 2 seconds on startup
 
@@ -118,6 +126,61 @@ bool CGUIWindowVisualisation::OnAction(const CAction &action)
       return true;
     }
     break;*/
+
+    case REMOTE_0:
+    case REMOTE_1:
+    case REMOTE_2:
+    case REMOTE_3:
+    case REMOTE_4:
+    case REMOTE_5:
+    case REMOTE_6:
+    case REMOTE_7:
+    case REMOTE_8:
+    case REMOTE_9:
+      {
+        if (g_application.CurrentFileItem().IsLiveTV() && g_PVRManager.IsPlaying())
+        {
+          // pvr client addon
+          CPVRChannelPtr playingChannel;
+          if(!g_PVRManager.GetCurrentChannel(playingChannel))
+            return false;
+
+          if (action.GetID() == REMOTE_0)
+          {
+            CPVRChannelGroupPtr group = g_PVRChannelGroups->GetPreviousPlayedGroup();
+            if (group)
+            {
+              g_PVRManager.SetPlayingGroup(group);
+              CFileItemPtr fileItem = group->GetLastPlayedChannel(playingChannel->ChannelID());
+              if (fileItem && fileItem->HasPVRChannelInfoTag())
+              {
+                CLog::Log(LOGDEBUG, "%s - switch to channel number %d", __FUNCTION__, fileItem->GetPVRChannelInfoTag()->ChannelNumber());
+                g_application.OnAction(CAction(ACTION_CHANNEL_SWITCH, (float) fileItem->GetPVRChannelInfoTag()->ChannelNumber()));
+              }
+            }
+          }
+          else
+          {
+            int autoCloseTime = CSettings::Get().GetBool("pvrplayback.confirmchannelswitch") ? 0 : g_advancedSettings.m_iPVRNumericChannelSwitchTimeout;
+            CStdString strChannel = StringUtils::Format("%i", action.GetID() - REMOTE_0);
+            if (CGUIDialogNumeric::ShowAndGetNumber(strChannel, g_localizeStrings.Get(19000), autoCloseTime) || autoCloseTime)
+            {
+              int iChannelNumber = atoi(strChannel.c_str());
+              if (iChannelNumber > 0 && iChannelNumber != playingChannel->ChannelNumber())
+              {
+                CPVRChannelGroupPtr selectedGroup = g_PVRManager.GetPlayingGroup(playingChannel->IsRadio());
+                CFileItemPtr channel = selectedGroup->GetByChannelNumber(iChannelNumber);
+                if (!channel || !channel->HasPVRChannelInfoTag())
+                  return false;
+
+                g_application.OnAction(CAction(ACTION_CHANNEL_SWITCH, (float)iChannelNumber));
+              }
+            }
+          }
+        }
+        return true;
+      }
+      break;
   }
 
   if (passToVis)

--- a/xbmc/pvr/windows/GUIWindowPVRFullScreen.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRFullScreen.cpp
@@ -1,0 +1,117 @@
+/*
+ *      Copyright (C) 2005-2015 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "GUIWindowPVRFullScreen.h"
+
+#include "Application.h"
+#include "ApplicationMessenger.h"
+#include "guilib/Key.h"
+#include "utils/log.h"
+#include "utils/log.h"
+#include "utils/StringUtils.h"
+#include "settings/Settings.h"
+#include "settings/AdvancedSettings.h"
+#include "dialogs/GUIDialogNumeric.h"
+#include "guilib/LocalizeStrings.h"
+#include "guilib/GUIControlGroup.h"
+#include "pvr/PVRManager.h"
+#include "pvr/windows/GUIWindowPVRFullScreen.h"
+#include "pvr/channels/PVRChannelGroupsContainer.h"
+
+using namespace PVR;
+
+CGUIWindowPVRFullScreen::CGUIWindowPVRFullScreen()
+{
+}
+
+bool CGUIWindowPVRFullScreen::OnAction(const CAction &action)
+{
+  switch (action.GetID())
+  {
+    case REMOTE_0:
+    case REMOTE_1:
+    case REMOTE_2:
+    case REMOTE_3:
+    case REMOTE_4:
+    case REMOTE_5:
+    case REMOTE_6:
+    case REMOTE_7:
+    case REMOTE_8:
+    case REMOTE_9:
+      {
+        if(g_PVRManager.IsPlaying())
+        {
+          // pvr client addon
+          CPVRChannelPtr playingChannel;
+          if(!g_PVRManager.GetCurrentChannel(playingChannel))
+            return false;
+
+          if (action.GetID() == REMOTE_0)
+          {
+            CPVRChannelGroupPtr group = g_PVRChannelGroups->GetPreviousPlayedGroup();
+            if (group)
+            {
+              g_PVRManager.SetPlayingGroup(group);
+              CFileItemPtr fileItem = group->GetLastPlayedChannel(playingChannel->ChannelID());
+              if (fileItem && fileItem->HasPVRChannelInfoTag())
+              {
+                CLog::Log(LOGDEBUG, "%s - switch to channel number %d", __FUNCTION__, fileItem->GetPVRChannelInfoTag()->ChannelNumber());
+                g_application.OnAction(CAction(ACTION_CHANNEL_SWITCH, (float) fileItem->GetPVRChannelInfoTag()->ChannelNumber()));
+              }
+            }
+          }
+          else
+          {
+            int autoCloseTime = CSettings::Get().GetBool("pvrplayback.confirmchannelswitch") ? 0 : g_advancedSettings.m_iPVRNumericChannelSwitchTimeout;
+            CStdString strChannel = StringUtils::Format("%i", action.GetID() - REMOTE_0);
+            if (CGUIDialogNumeric::ShowAndGetNumber(strChannel, g_localizeStrings.Get(19000), autoCloseTime) || autoCloseTime)
+            {
+              int iChannelNumber = atoi(strChannel.c_str());
+              if (iChannelNumber > 0 && iChannelNumber != playingChannel->ChannelNumber())
+              {
+                CPVRChannelGroupPtr selectedGroup = g_PVRManager.GetPlayingGroup(playingChannel->IsRadio());
+                CFileItemPtr channel = selectedGroup->GetByChannelNumber(iChannelNumber);
+                if (!channel || !channel->HasPVRChannelInfoTag())
+                  return false;
+
+                g_application.OnAction(CAction(ACTION_CHANNEL_SWITCH, (float)iChannelNumber));
+              }
+            }
+          }
+          return true;
+        }
+        else
+        {
+          // filesystem provider like slingbox, cmyth, etc
+          int iChannelNumber = -1;
+          CStdString strChannel = StringUtils::Format("%i", action.GetID() - REMOTE_0);
+          if (CGUIDialogNumeric::ShowAndGetNumber(strChannel, g_localizeStrings.Get(19000)))
+            iChannelNumber = atoi(strChannel.c_str());
+
+          if (iChannelNumber > 0)
+            g_application.OnAction(CAction(ACTION_CHANNEL_SWITCH, (float)iChannelNumber));
+          return true;
+        }
+      }
+      break;
+    }
+
+  return false;
+}

--- a/xbmc/pvr/windows/GUIWindowPVRFullScreen.h
+++ b/xbmc/pvr/windows/GUIWindowPVRFullScreen.h
@@ -1,6 +1,7 @@
 #pragma once
+
 /*
- *      Copyright (C) 2005-2013 Team XBMC
+ *      Copyright (C) 2005-2015 Team XBMC
  *      http://xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify
@@ -19,26 +20,14 @@
  *
  */
 
-#include "guilib/GUIWindow.h"
-#include "music/tags/MusicInfoTag.h"
-#include "utils/Stopwatch.h"
+#include "guilib/Key.h"
 
-#include "windows/GUIWindowFullScreenBase.h"
-
-class CGUIWindowVisualisation :
-      public CGUIWindowFullScreenBase
+class CGUIWindowPVRFullScreen
 {
 public:
-  CGUIWindowVisualisation(void);
-  virtual bool OnMessage(CGUIMessage& message);
+  CGUIWindowPVRFullScreen(void);
+  virtual ~CGUIWindowPVRFullScreen(void) {};
+
   virtual bool OnAction(const CAction &action);
-  virtual void FrameMove();
-protected:
-  virtual EVENT_RESULT OnMouseEvent(const CPoint &point, const CMouseEvent &event);
 
-  CStopWatch m_initTimer;
-  CStopWatch m_lockedTimer;
-  bool m_bShowPreset;
-  MUSIC_INFO::CMusicInfoTag m_tag;    // current tag info, for finding when the info manager updates
 };
-

--- a/xbmc/video/windows/GUIWindowFullScreen.h
+++ b/xbmc/video/windows/GUIWindowFullScreen.h
@@ -20,10 +20,10 @@
  *
  */
 
-#include "guilib/GUIWindow.h"
+#include "windows/GUIWindowFullScreenBase.h"
 #include "threads/CriticalSection.h"
 
-class CGUIWindowFullScreen : public CGUIWindow
+class CGUIWindowFullScreen : public CGUIWindowFullScreenBase
 {
 public:
   CGUIWindowFullScreen(void);

--- a/xbmc/windows/GUIWindowFullScreenBase.cpp
+++ b/xbmc/windows/GUIWindowFullScreenBase.cpp
@@ -1,0 +1,42 @@
+/*
+ *      Copyright (C) 2005-2015 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "GUIWindowFullScreenBase.h"
+
+#include "Application.h"
+#include "FileItem.h"
+#include "guilib/Key.h"
+#include "pvr/windows/GUIWindowPVRFullScreen.h"
+
+CGUIWindowFullScreenBase::CGUIWindowFullScreenBase(int id, const CStdString &xmlFile)
+  : CGUIWindow(id, xmlFile), CGUIWindowPVRFullScreen()
+{
+}
+
+bool CGUIWindowFullScreenBase::OnAction(const CAction &action)
+{
+  bool bReturn = false;
+
+  // delegate to PVR fullscreen
+  if (g_application.CurrentFileItem().IsLiveTV())
+    bReturn = CGUIWindowPVRFullScreen::OnAction(action);
+
+  return bReturn || CGUIWindow::OnAction(action);
+}

--- a/xbmc/windows/GUIWindowFullScreenBase.h
+++ b/xbmc/windows/GUIWindowFullScreenBase.h
@@ -1,6 +1,7 @@
 #pragma once
+
 /*
- *      Copyright (C) 2005-2013 Team XBMC
+ *      Copyright (C) 2005-2015 Team XBMC
  *      http://xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify
@@ -20,25 +21,14 @@
  */
 
 #include "guilib/GUIWindow.h"
-#include "music/tags/MusicInfoTag.h"
-#include "utils/Stopwatch.h"
+#include "threads/CriticalSection.h"
+#include "pvr/windows/GUIWindowPVRFullScreen.h"
 
-#include "windows/GUIWindowFullScreenBase.h"
-
-class CGUIWindowVisualisation :
-      public CGUIWindowFullScreenBase
+class CGUIWindowFullScreenBase : public CGUIWindow, public CGUIWindowPVRFullScreen
 {
 public:
-  CGUIWindowVisualisation(void);
-  virtual bool OnMessage(CGUIMessage& message);
+  CGUIWindowFullScreenBase(int id, const CStdString &xmlFile);
+  virtual ~CGUIWindowFullScreenBase(void) {};
+
   virtual bool OnAction(const CAction &action);
-  virtual void FrameMove();
-protected:
-  virtual EVENT_RESULT OnMouseEvent(const CPoint &point, const CMouseEvent &event);
-
-  CStopWatch m_initTimer;
-  CStopWatch m_lockedTimer;
-  bool m_bShowPreset;
-  MUSIC_INFO::CMusicInfoTag m_tag;    // current tag info, for finding when the info manager updates
 };
-


### PR DESCRIPTION
This will fixes the issue that you can't switch a radio channel by entering its channel number in fullscreen mode like you can do for tv channels.

Related trac ticket http://trac.kodi.tv/ticket/15345
