### PR TITLE
[confluence] fix cosmetic scrollbar shwing for half setting height

### DIFF
--- a/addons/skin.confluence/720p/VideoOSDSettings.xml
+++ b/addons/skin.confluence/720p/VideoOSDSettings.xml
@@ -76,7 +76,7 @@
 				<left>40</left>
 				<top>65</top>
 				<width>720</width>
-				<height>490</height>
+				<height>505</height>
 				<itemgap>5</itemgap>
 				<pagecontrol>60</pagecontrol>
 				<onleft>60</onleft>


### PR DESCRIPTION
This is both cosmetic and functional.

When pulling AudioOSDsettings (ignore the fact this is videoOSDSettings as both share same xml.) the audio settings the scrollbar is present only for half a height of the last field

So really to see all settings fully you need to scroll some minimal amount for no reason.

This fixes that minor yet annoying thing.

before/after crude screenshots

![vvrrdwx9](https://cloud.githubusercontent.com/assets/3521959/5617709/819d3900-9509-11e4-936f-514c66fb7646.png)

@ronie for review etc.
