### PR TITLE
[cosmetic] initialize members in the order they were declared

### DIFF
--- a/xbmc/dialogs/GUIDialogCache.h
+++ b/xbmc/dialogs/GUIDialogCache.h
@@ -50,9 +50,9 @@ protected:
 
   XbmcThreads::EndTime m_endtime;
   CGUIDialogProgress* m_pDlg;
+  std::string m_strHeader;
   std::string m_strLinePrev;
   std::string m_strLinePrev2;
-  std::string m_strHeader;
   bool bSentCancel;
   bool m_bOpenTried;
 };


### PR DESCRIPTION
Fix compiler warning introduced with b85413cc267b9765849902b6a21eb2bd1f39946f
