### PR TITLE
[confluence] left align addon descriptions

### DIFF
--- a/addons/skin.confluence/720p/DialogAddonInfo.xml
+++ b/addons/skin.confluence/720p/DialogAddonInfo.xml
@@ -287,7 +287,7 @@
 						<width>600</width>
 						<height>260</height>
 						<font>font13</font>
-						<align>justify</align>
+						<align>left</align>
 						<textcolor>white</textcolor>
 						<label>$INFO[ListItem.Property(Addon.Description)]</label>
 						<pagecontrol>61</pagecontrol>

--- a/addons/skin.confluence/720p/ViewsAddonBrowser.xml
+++ b/addons/skin.confluence/720p/ViewsAddonBrowser.xml
@@ -213,7 +213,7 @@
 						<width>490</width>
 						<height>215</height>
 						<font>font13</font>
-						<align>justify</align>
+						<align>left</align>
 						<textcolor>white</textcolor>
 						<label>$INFO[ListItem.Property(Addon.Description)]</label>
 						<autoscroll time="2000" delay="3000" repeat="5000">Skin.HasSetting(AutoScroll)</autoscroll>
@@ -445,7 +445,7 @@
 						<width>290</width>
 						<height>445</height>
 						<font>font13</font>
-						<align>justify</align>
+						<align>left</align>
 						<textcolor>white</textcolor>
 						<label>$INFO[ListItem.Property(Addon.Description)]</label>
 						<autoscroll time="2000" delay="3000" repeat="5000">Skin.HasSetting(AutoScroll)</autoscroll>


### PR DESCRIPTION
This is causing a lot of weird stretching as people put long links etc. in the descriptions. See for instance info dialog for Rom Collection Browser and KinoPoisk in Info 2 view. 
