### PR TITLE
don't force skins to use a panel container

### DIFF
--- a/xbmc/dialogs/GUIDialogFileBrowser.cpp
+++ b/xbmc/dialogs/GUIDialogFileBrowser.cpp
@@ -444,7 +444,7 @@ void CGUIDialogFileBrowser::Update(const std::string &strDirectory)
   }
 
   m_viewControl.SetItems(*m_vecItems);
-  m_viewControl.SetCurrentView((m_browsingForImages && CAutoSwitch::ByFileCount(*m_vecItems)) ? DEFAULT_VIEW_ICONS : DEFAULT_VIEW_LIST);
+  m_viewControl.SetCurrentView((m_browsingForImages && CAutoSwitch::ByFileCount(*m_vecItems)) ? CONTROL_THUMBS : CONTROL_LIST);
 
   std::string strPath2 = m_Directory->GetPath();
   URIUtils::RemoveSlashAtEnd(strPath2);


### PR DESCRIPTION
currently Kodi forces skins to use a panel container in the filebrowser for container id=451
(this is the container that's used when browsing for images).
in case container 451 is not a panel container, Kodi will use container id=450 instead
(this container is normally used when browsing for files/folders)

this limits the skinner in the way they want to present the layout of the filebrowser.

the patch fixes that. (tested and it works as expected).
please review if this change is correct (c++ n00b here). 

see: http://forum.kodi.tv/showthread.php?tid=121568
