### PR TITLE
Fix Refresh Rate Adjustment on OSX.

### DIFF
--- a/xbmc/video/VideoReferenceClock.h
+++ b/xbmc/video/VideoReferenceClock.h
@@ -39,11 +39,11 @@ class CVideoReferenceClock : public CThread
     bool    GetClockInfo(int& MissedVblanks, double& ClockSpeed, double& RefreshRate);
     void    SetFineAdjust(double fineadjust);
     void    RefreshChanged();
+    void    UpdateRefreshrate();
     void    Stop();
 
   private:
     void    Process();
-    void    UpdateRefreshrate();
     void    SendVblankSignal();
     void    UpdateClock(int NrVBlanks, bool CheckMissed);
     double  UpdateInterval();

--- a/xbmc/video/videosync/VideoSyncCocoa.cpp
+++ b/xbmc/video/videosync/VideoSyncCocoa.cpp
@@ -101,7 +101,7 @@ bool CVideoSyncCocoa::Setup(PUPDATECLOCK func)
   else
 #endif
   {
-    GetFps();//UpdateRefreshrate(true); - FIXME?NEEDED?
+    GetFps();
     return true;
   }
 }
@@ -133,6 +133,7 @@ void CVideoSyncCocoa::UpdateFPS(double fps)
   {
     CLog::Log(LOGDEBUG, "CVideoSyncCocoa: Detected refreshrate: %i hertz", fpsInt);
     m_fps = fpsInt;
+    g_VideoReferenceClock.UpdateRefreshrate();
   }
 }
 


### PR DESCRIPTION
m_RefreshRate variable was not updated on resolution change, so the display
would be at, e.g., 24Hz, but Kodi thought it was still at 60Hz.

Audio is still out of sync at start of playback unless the option to pause the playback is selected and given enough time for the display to actually switch.  That is unrelated to this fix, however.

See the following for details:
http://forum.kodi.tv/showthread.php?tid=212849
http://forum.kodi.tv/showthread.php?tid=212855
http://trac.kodi.tv/ticket/15612 (possibly/probably)
