### PR TITLE
[video] seek in video window: skip now operates in two ways

### DIFF
--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -339,6 +339,7 @@ void CAdvancedSettings::Initialize()
   m_RestrictCapsMask = 0;
   m_sleepBeforeFlip = 0;
   m_bVirtualShares = true;
+  m_skipSteps = { 15, 30, 60, 180, 300, 600, 900, 1800, 3600, 7200 };
 
 //caused lots of jerks
 //#ifdef TARGET_WINDOWS
@@ -847,7 +848,15 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
   }
 
   XMLUtils::GetString(pRootElement, "cddbaddress", m_cddbAddress);
-
+  // Transform into vector of ints
+  string skipSteps;
+  XMLUtils::GetString(pRootElement, "skipsteps", skipSteps);
+  if (skipSteps.length() > 0)
+  {
+    m_skipSteps.clear();
+    for (auto step : StringUtils::Split(skipSteps, ','))
+      m_skipSteps.push_back(atoi(step.c_str()));
+  }
   //airtunes + airplay
   XMLUtils::GetInt(pRootElement,     "airtunesport", m_airTunesPort);
   XMLUtils::GetInt(pRootElement,     "airplayport", m_airPlayPort);  

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -215,6 +215,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     int m_extraLogLevels;
     std::string m_cddbAddress;
 
+    std::vector<int> m_skipSteps;
     //airtunes + airplay
     int m_airTunesPort;
     int m_airPlayPort;

--- a/xbmc/video/windows/GUIWindowFullScreen.h
+++ b/xbmc/video/windows/GUIWindowFullScreen.h
@@ -57,7 +57,19 @@ private:
 
   /*! \brief Convert the current timecode into a time in seconds to seek
    */
-  double GetTimeCodeStamp();
+  double GetTimeCodeAsSeconds();
+
+  /*! \brief Returns timecode as "HH:MM:SS" formated string
+  */
+  std::string GetTimeCodeAsString(int timeCode, int base);
+
+  /*! \brief Seeks to content of Skip Step array
+  */
+  void SeekToSkipStep();
+  
+  /*! \brief converts skip step klicks to seconds
+  */
+  int GetSkipStepTimeCode();
 
   bool m_bShowViewModeInfo;
   unsigned int m_dwShowViewModeTimeout;
@@ -66,8 +78,7 @@ private:
   bool m_bShowCurrentTime;
 
   bool m_bGroupSelectShow;
-  bool m_timeCodeShow;
-  unsigned int m_timeCodeTimeout;
-  int m_timeCodeStamp[6];
-  int m_timeCodePosition;
+  unsigned int m_userTimeout;
+  int m_timeCode;
+  int m_skipStepCount;
 };


### PR DESCRIPTION
1) (Old behavior - keyboard friendly) User enters a time code (digits 0-9) and presses left (or right) arrow key. When arrow key is pressed the
entered time code is executed. i.e. user presses 100 and right arrow key => A one minute forward skip step is performed.
2) (New feature - remote friendly) User presses an arrow key one or more times, each time key is pressed skip step counter is increased. The final
skip is determined by the skip step array, If the array is { 15, 30, 60, 180, 300, 600, 900, 1800, 3600, 7200 }
and the user presses skip step twice, a 30 sec skip is performed. Note - skip step array is a configuration property.
