### PR TITLE
dvdplayer: limit ff/rw to 16x of normal speed

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2744,7 +2744,7 @@ bool CApplication::OnAction(const CAction &action)
 
         if (action.GetID() == ACTION_PLAYER_FORWARD && iPlaySpeed == -1) //sets iSpeed back to 1 if -1 (didn't plan for a -1)
           iPlaySpeed = 1;
-        if (iPlaySpeed > 32 || iPlaySpeed < -32)
+        if (iPlaySpeed > 16 || iPlaySpeed < -16)
           iPlaySpeed = 1;
 
         m_pPlayer->SetPlaySpeed(iPlaySpeed, g_application.m_muted);

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -869,7 +869,7 @@ int CBuiltins::Execute(const std::string& execString)
         else
           iPlaySpeed *= 2;
 
-        if (iPlaySpeed > 32 || iPlaySpeed < -32)
+        if (iPlaySpeed > 16 || iPlaySpeed < -16)
           iPlaySpeed = 1;
 
         g_application.m_pPlayer->SetPlaySpeed(iPlaySpeed, g_application.IsMutedInternal());


### PR DESCRIPTION
there is only a very small number of systems which can do 32x of normal speed. for all others this does more harm than any good.
