### PR TITLE
Allow up to 31 days to display in the EPG

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1196,7 +1196,7 @@
           <constraints>
             <minimum>1</minimum>
             <step>1</step>
-            <maximum>14</maximum>
+            <maximum>31</maximum>
           </constraints>
           <control type="spinner" format="string">
             <formatlabel>17999</formatlabel>

--- a/xbmc/epg/GUIEPGGridContainer.h
+++ b/xbmc/epg/GUIEPGGridContainer.h
@@ -30,7 +30,7 @@
 namespace EPG
 {
   #define MAXCHANNELS 20
-  #define MAXBLOCKS   (16 * 24 * 60 / 5) //! 16 days of 5 minute blocks (14 days for upcoming data + 1 day for past data + 1 day for fillers)
+  #define MAXBLOCKS   (33 * 24 * 60 / 5) //! 33 days of 5 minute blocks (31 days for upcoming data + 1 day for past data + 1 day for fillers)
 
   struct GridItemsPtr
   {


### PR DESCRIPTION
Public German TV channels offer up to 28 days of EPG.

This is a follow-up PR (including MAXBLOCKS change) for https://github.com/xbmc/xbmc/pull/5946, where I successfully managed to break my branch ;)
