### PR TITLE
fix - unhandled render format did not reset crop values

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
@@ -1193,7 +1193,7 @@ void CDVDPlayerVideo::AutoCrop(DVDVideoPicture *pPicture)
 {
     RECT crop;
 
-    if (!(CMediaSettings::Get().GetCurrentVideoSettings().m_Crop && AutoCrop(pPicture, crop)))
+    if (!AutoCrop(pPicture, crop))
     { // reset to defaults
       crop.left   = 0;
       crop.right  = 0;
@@ -1229,6 +1229,9 @@ void CDVDPlayerVideo::AutoCrop(DVDVideoPicture *pPicture)
 
 bool CDVDPlayerVideo::AutoCrop(DVDVideoPicture *pPicture, RECT &crop)
 {
+  if (!CMediaSettings::Get().GetCurrentVideoSettings().m_Crop)
+    return false;
+
   if ((pPicture->format != RENDER_FMT_YUV420P) &&
     (pPicture->format != RENDER_FMT_NV12) &&
     (pPicture->format != RENDER_FMT_YUYV422) &&

--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
@@ -1191,16 +1191,9 @@ int CDVDPlayerVideo::OutputPicture(const DVDVideoPicture* src, double pts)
 
 void CDVDPlayerVideo::AutoCrop(DVDVideoPicture *pPicture)
 {
-  if ((pPicture->format == RENDER_FMT_YUV420P) ||
-     (pPicture->format == RENDER_FMT_NV12) ||
-     (pPicture->format == RENDER_FMT_YUYV422) ||
-     (pPicture->format == RENDER_FMT_UYVY422))
-  {
     RECT crop;
 
-    if (CMediaSettings::Get().GetCurrentVideoSettings().m_Crop)
-      AutoCrop(pPicture, crop);
-    else
+    if (!(CMediaSettings::Get().GetCurrentVideoSettings().m_Crop && AutoCrop(pPicture, crop)))
     { // reset to defaults
       crop.left   = 0;
       crop.right  = 0;
@@ -1232,11 +1225,16 @@ void CDVDPlayerVideo::AutoCrop(DVDVideoPicture *pPicture)
       g_renderManager.SetViewMode(CMediaSettings::Get().GetCurrentVideoSettings().m_ViewMode);
     }
 # undef HYST
-  }
 }
 
-void CDVDPlayerVideo::AutoCrop(DVDVideoPicture *pPicture, RECT &crop)
+bool CDVDPlayerVideo::AutoCrop(DVDVideoPicture *pPicture, RECT &crop)
 {
+  if ((pPicture->format != RENDER_FMT_YUV420P) &&
+    (pPicture->format != RENDER_FMT_NV12) &&
+    (pPicture->format != RENDER_FMT_YUYV422) &&
+    (pPicture->format != RENDER_FMT_UYVY422))
+    return false;
+
   crop.left   = CMediaSettings::Get().GetCurrentVideoSettings().m_CropLeft;
   crop.right  = CMediaSettings::Get().GetCurrentVideoSettings().m_CropRight;
   crop.top    = CMediaSettings::Get().GetCurrentVideoSettings().m_CropTop;
@@ -1363,6 +1361,7 @@ void CDVDPlayerVideo::AutoCrop(DVDVideoPicture *pPicture, RECT &crop)
     crop.top = crop.bottom = max;
   else
     crop.top = crop.bottom = min;
+  return true;
 }
 
 std::string CDVDPlayerVideo::GetPlayerInfo()

--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.h
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.h
@@ -124,7 +124,7 @@ protected:
 #define EOS_BUFFER_LEVEL 8
 
   void AutoCrop(DVDVideoPicture* pPicture);
-  void AutoCrop(DVDVideoPicture *pPicture, RECT &crop);
+  bool AutoCrop(DVDVideoPicture *pPicture, RECT &crop);
   CRect m_crop;
 
   int OutputPicture(const DVDVideoPicture* src, double pts);


### PR DESCRIPTION
fix - unhandled render format (e.g. RENDER_FMT_DXVA) did not reset crop  values
