### PR TITLE
[osx] - fix broken keyboard input

### DIFF
--- a/xbmc/GUIUserMessages.h
+++ b/xbmc/GUIUserMessages.h
@@ -134,5 +134,4 @@
 #define GUI_MSG_SHOW_PICTURE          GUI_MSG_USER + 36
 
 // Sent to text field to support 'input method'
-#define GUI_MSG_INPUT_TEXT            GUI_MSG_USER + 37
 #define GUI_MSG_INPUT_TEXT_EDIT       GUI_MSG_USER + 38

--- a/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
+++ b/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
@@ -219,7 +219,6 @@ bool CGUIDialogKeyboardGeneric::OnMessage(CGUIMessage& message)
     break;
 
   case GUI_MSG_SET_TEXT:
-  case GUI_MSG_INPUT_TEXT:
   case GUI_MSG_INPUT_TEXT_EDIT:
     {
       // the edit control only handles these messages if it is either focues
@@ -270,9 +269,9 @@ void CGUIDialogKeyboardGeneric::Character(const std::string &ch)
   CGUIControl *edit = GetControl(CTL_EDIT);
   if (edit)
   {
-    CGUIMessage msg(GUI_MSG_INPUT_TEXT, GetID(), CTL_EDIT);
-    msg.SetLabel(ch);
-    edit->OnMessage(msg);
+    CAction action(ACTION_INPUT_TEXT);
+    action.SetText(ch);
+    edit->OnAction(action);
   }
 }
 

--- a/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
+++ b/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
@@ -32,6 +32,7 @@
 #include "utils/RegExp.h"
 #include "utils/StringUtils.h"
 #include "ApplicationMessenger.h"
+#include "windowing/WindowingFactory.h"
 
 #define BUTTON_ID_OFFSET      100
 #define BUTTONS_PER_ROW        20
@@ -75,6 +76,7 @@ void CGUIDialogKeyboardGeneric::OnWindowLoaded()
   CGUIEditControl *edit = (CGUIEditControl *)GetControl(CTL_EDIT);
   if (edit)
     edit->SetShowCursorAlways(true);
+  g_Windowing.EnableTextInput(false);
 
   CGUIDialog::OnWindowLoaded();
 }

--- a/xbmc/guilib/GUIEditControl.cpp
+++ b/xbmc/guilib/GUIEditControl.cpp
@@ -103,17 +103,6 @@ bool CGUIEditControl::OnMessage(CGUIMessage &message)
     SetLabel2(message.GetLabel());
     UpdateText();
   }
-  else if (message.GetMessage() == GUI_MSG_INPUT_TEXT && !message.GetLabel().empty()
-        && (HasFocus() || message.GetControlId() == GetID()))
-  {
-    m_edit.clear();
-    std::wstring str;
-    g_charsetConverter.utf8ToW(message.GetLabel(), str);
-    m_text2.insert(m_cursorPos, str);
-    m_cursorPos += str.size();
-    UpdateText();
-    return true;
-  }
   else if (message.GetMessage() == GUI_MSG_INPUT_TEXT_EDIT && HasFocus())
   {
     g_charsetConverter.utf8ToW(message.GetLabel(), m_edit);
@@ -290,6 +279,16 @@ bool CGUIEditControl::OnAction(const CAction &action)
       ClearMD5();
       m_edit.clear();
       OnSMSCharacter(action.GetID() - REMOTE_0);
+      return true;
+    }
+    else if (action.GetID() == ACTION_INPUT_TEXT)
+    {
+      m_edit.clear();
+      std::wstring str;
+      g_charsetConverter.utf8ToW(action.GetText(), str);
+      m_text2.insert(m_cursorPos, str);
+      m_cursorPos += str.size();
+      UpdateText();
       return true;
     }
   }

--- a/xbmc/guilib/Key.h
+++ b/xbmc/guilib/Key.h
@@ -347,6 +347,7 @@
 #define ACTION_SETTINGS_LEVEL_CHANGE  242
 
 #define ACTION_TRIGGER_OSD            243 // show autoclosing OSD. Can b used in videoFullScreen.xml window id=2005
+#define ACTION_INPUT_TEXT             244
 
 // touch actions
 #define ACTION_TOUCH_TAP              401
@@ -418,6 +419,16 @@ public:
    \return name of the action
    */
   const std::string &GetName() const { return m_name; };
+  
+  /*! \brief Text of the action if any
+   \return text payload of this action.
+   */
+  const std::string &GetText() const { return m_text; };
+  
+  /*! \brief Set the text payload of the action
+   \param text to be set
+   */
+  void SetText(const std::string &text) { m_text = text; };
 
   /*! \brief Get an amount associated with this action
    \param zero-based index of amount to retrieve, defaults to 0
@@ -456,6 +467,7 @@ private:
   unsigned int m_holdTime;
   unsigned int m_buttonCode;
   wchar_t      m_unicode;
+  std::string  m_text;
 };
 
 /*!

--- a/xbmc/osx/OSXTextInputResponder.mm
+++ b/xbmc/osx/OSXTextInputResponder.mm
@@ -27,6 +27,8 @@
 #include "guilib/GUIWindowManager.h"
 #include "GUIUserMessages.h"
 #include "utils/log.h"
+#include "ApplicationMessenger.h"
+#include "guilib/key.h"
 #undef BOOL
 
 void SendKeyboardText(const char *text)
@@ -37,9 +39,12 @@ void SendKeyboardText(const char *text)
   if ((unsigned char)*text < ' ' || *text == 127)
     return;
 
-  CGUIMessage msg(GUI_MSG_INPUT_TEXT, 0, 0);
-  msg.SetLabel(text);
-  g_windowManager.SendThreadMessage(msg, g_windowManager.GetFocusedWindow());
+  ThreadMessage tMsg = {TMSG_GUI_ACTION};
+  tMsg.param1 = WINDOW_INVALID;
+  CAction *action = new CAction(ACTION_INPUT_TEXT);
+  action->SetText(text);
+  tMsg.lpVoid = action;
+  CApplicationMessenger::Get().SendMessage(tMsg, false);
 }
 
 void SendEditingText(const char *text, unsigned int location, unsigned int length)

--- a/xbmc/windowing/WinEventsSDL.cpp
+++ b/xbmc/windowing/WinEventsSDL.cpp
@@ -457,19 +457,6 @@ bool CWinEventsSDL::ProcessOSXShortcuts(SDL_Event& event)
       CApplicationMessenger::Get().Minimize();
       return true;
 
-    case SDLK_v: // CMD-v to paste clipboard text
-      if (g_Windowing.IsTextInputEnabled())
-      {
-        const char *szStr = Cocoa_Paste();
-        if (szStr)
-        {
-          CGUIMessage msg(GUI_MSG_INPUT_TEXT, 0, 0);
-          msg.SetLabel(szStr);
-          g_windowManager.SendMessage(msg, g_windowManager.GetFocusedWindow());
-        }
-      }
-      return true;
-
     default:
       return false;
     }


### PR DESCRIPTION
In helix and mainline the direct keyboard input on osx is broken.
1. Paste via cmd+v only worked in the keyboard dialog and only if user explicitly clicked into the textfield before pressing cmd+v
2. Direct keyboard input only worked in the keyboard dialog. When a textfield somewhere else had the focus there as no direct keyboard input possible. User had to click into the textfield which in result opened the onscreen keyboard where the user could type then.

The first commit is pretty straight forward - at one point the paste behavior was transfered to the application in a generic way - we forgot to remove the shortcut in sdl input handling which resulted in application never seeing this shortcut.

The second commit is a bit more tricky. Basically we need to allow the guieditcontrol to handle character key presses even if the input is enabled (it is enabled as soon as the textfield gets the focus - so basically almost always when a user wants to type into it).

But on the other hand we don't want to have the key presses to be evaluated twice (once in the editcontrol onaction and once via GUI_MSG_INPUT_TEXT) when we are in the keyboard dialog.

@jmarshallnz the second commit looks not correct to me (it fixes the problem but its hard to understand). Can you maybe by any chance suggest a correct fix?

This is helix 14.1 material if you ask me (and if a proper fix can be found soon).
