### PR TITLE
[osx] - fixed vsync for osx - notify reference clock when refresh rate h...

### DIFF
--- a/xbmc/video/videosync/VideoSyncCocoa.h
+++ b/xbmc/video/videosync/VideoSyncCocoa.h
@@ -21,7 +21,9 @@
 
 #if defined(TARGET_DARWIN)
 #include "VideoSync.h"
-class CVideoSyncCocoa : public CVideoSync
+#include "guilib/DispResource.h"
+
+class CVideoSyncCocoa : public CVideoSync, IDispResource
 {
 public:
   virtual bool Setup(PUPDATECLOCK func);
@@ -29,9 +31,11 @@ public:
   virtual void Cleanup();
   virtual float GetFps();
   void VblankHandler(int64_t nowtime, double fps);
+  virtual void OnResetDevice();
 private:
   void UpdateFPS(double fps);
   int64_t m_LastVBlankTime;  //timestamp of the last vblank, used for calculating how many vblanks happened
+  volatile bool m_abort;
 };
 
 #endif


### PR DESCRIPTION
...as

fixes #15612

m_RefreshRate variable was not updated on resolution change, so the display
would be at, e.g., 24Hz, but Kodi thought it was still at 60Hz.

See the following for details:
http://forum.kodi.tv/showthread.php?tid=212849
http://forum.kodi.tv/showthread.php?tid=212855

superseeds #6126
