### PR TITLE
fix(scraper-tadb): escape apostrophes in names

### DIFF
--- a/addons/metadata.musicvideos.theaudiodb.com/tadb.xml
+++ b/addons/metadata.musicvideos.theaudiodb.com/tadb.xml
@@ -7,6 +7,9 @@
 	</NfoUrl>
 	<CreateSearchUrl dest="3">
 		<RegExp input="$$5" output="\1" dest="3">
+			<RegExp input="$$1" output="\1\\&apos;\2" dest="1">
+				<expression repeat="yes">(.*[^\\])%27(.*)</expression>
+			</RegExp>
 			<RegExp input="$$1" output="&lt;url&gt;http://www.theaudiodb.com/api/v1/json/58424d43204d6564696120/searchtrack.php?s=\1&amp;amp;t=\2&lt;/url&gt;" dest="6">
 				<expression trim="1,2">(.+)%20(?:%20|-)%20(.+)</expression>
 			</RegExp>

--- a/addons/metadata.musicvideos.theaudiodb.com/tadb.xml
+++ b/addons/metadata.musicvideos.theaudiodb.com/tadb.xml
@@ -8,17 +8,17 @@
 	<CreateSearchUrl dest="3">
 		<RegExp input="$$5" output="\1" dest="3">
 			<RegExp input="$$1" output="\1\\&apos;\2" dest="1">
-				<expression repeat="yes">(.*[^\\])%27(.*)</expression>
+				<expression repeat="yes">((?:[^%]*(?:%20))*[^%]*)(?:%27)((?:[^%]*(?:%20))*[^%]*)</expression>
 			</RegExp>
-			<RegExp input="$$1" output="&lt;url&gt;http://www.theaudiodb.com/api/v1/json/58424d43204d6564696120/searchtrack.php?s=\1&amp;amp;t=\2&lt;/url&gt;" dest="6">
+			<RegExp input="$$1" output="&lt;url&gt;http://www.theaudiodb.com/api/v1/json/58424d43204d6564696120/searchtrack.php?s=\1&amp;amp;t=\2&lt;/url&gt;" dest="5">
 				<expression trim="1,2">(.+)%20(?:%20|-)%20(.+)</expression>
 			</RegExp>
-			<RegExp input="$$6" output="\1" dest="5">
+			<!--<RegExp input="$$6" output="\1" dest="5">
 				<expression noclean="1" />
 			</RegExp>
 			<RegExp input="$$6" output="&lt;url&gt;http://www.theaudiodb.com/api/v1/json/58424d43204d6564696120/searchtrack.php?s=$$1&amp;amp;t=&lt;/url&gt;" dest="5">
 				<expression>^$</expression>
-			</RegExp>
+			</RegExp>-->
 			<expression noclean="1" />
 		</RegExp>
 	</CreateSearchUrl>


### PR DESCRIPTION
Properly escape apostrophes in file names when scraping music videos from theaudiodb.com.

See [this issue in the forum](http://forum.kodi.tv/showthread.php?pid=1809327#pid1809327)

> I used this addon recently for the first time, and it had trouble finding matches for artists/titles that contained an apostrophe ( ' ).
> I found that this could be fixed by replacing the apostrophe ( ' ) with backslash+apostrophe ( \' ) when adding manually the files to the library from within XMBC.
> e.g.: The Weather Girls - It's Raining Men ---> The Weather Girls - It\'s Raining Men
> Actually, the search field of TheAudioDB.com is doing this substitution. Just try searching for something and then in the results page see the text chain after "Search Results for...".

So how does this work? Find a non escaped apostrophe; %27 with a character other than '\' before it. Then take the string in front (\1), the escaped apostrophe(\&apos;), then the string in back (\2) and override the value in register 1. If no match is found leave register 1 as is.

Assuming repeat does what I think it does, this should work on names with multiple apostrophe; however, I have not found a real world example to test this on. If anyone knows of a song title with multiple apostrophe, let me know!
