### PR TITLE
[wayland] fixed wrong current/preferred modes in Output

### DIFF
--- a/xbmc/windowing/egl/wayland/Output.cpp
+++ b/xbmc/windowing/egl/wayland/Output.cpp
@@ -42,8 +42,8 @@ xw::Output::Output(IDllWaylandClient &clientLibrary,
   m_clientLibrary(clientLibrary),
   m_output(output),
   m_scaleFactor(1.0),
-  m_current(NULL),
-  m_preferred(NULL)
+  m_currentValid(false),
+  m_preferredValid(false)
 {
   protocol::AddListenerOnWaylandObject(m_clientLibrary,
                                        m_output,
@@ -69,21 +69,21 @@ xw::Output::GetWlOutput()
 const xw::Output::ModeGeometry &
 xw::Output::CurrentMode()
 {
-  if (!m_current)
+  if (!m_currentValid)
     throw std::logic_error("No current mode has been set by the server"
                            " yet");
   
-  return *m_current;
+  return m_current;
 }
 
 const xw::Output::ModeGeometry &
 xw::Output::PreferredMode()
 {
-  if (!m_preferred)
+  if (!m_preferredValid)
     throw std::logic_error("No preferred mode has been set by the "
                            " server yet");
 
-  return *m_preferred;
+  return m_preferred;
 }
 
 const std::vector <xw::Output::ModeGeometry> &
@@ -229,9 +229,15 @@ xw::Output::Mode(uint32_t flags,
    * or existing mode. In both cases we need to
    * update the current and preferred modes */
   if (outputFlags & WL_OUTPUT_MODE_CURRENT)
-    m_current = update;
+  {
+    m_current = *update;
+    m_currentValid = true;
+  }
   if (outputFlags & WL_OUTPUT_MODE_PREFERRED)
-    m_preferred = update;
+  {
+    m_preferred = *update;
+    m_preferredValid = true;
+  }
 }
 
 void

--- a/xbmc/windowing/egl/wayland/Output.h
+++ b/xbmc/windowing/egl/wayland/Output.h
@@ -143,8 +143,10 @@ private:
 
   /* Only one mode at a time can have the current or preferred
    * flags set, so only one pointer is set here */
-  ModeGeometry *m_current;
-  ModeGeometry *m_preferred;
+  ModeGeometry m_current;
+  ModeGeometry m_preferred;
+  bool m_currentValid;
+  bool m_preferredValid;
 };
 }
 }


### PR DESCRIPTION
Output class stores m_current mode as raw pointer to element
of std::vector. During vector resize there is memory realocations
and pointer becames invalid. As result retrieving current mode
can give some garbage.  Replaced by storing real values
instead of pointers.
