### PR TITLE
upnp: do not block upnp renderer on start of playback

### DIFF
--- a/xbmc/ApplicationMessenger.cpp
+++ b/xbmc/ApplicationMessenger.cpp
@@ -921,15 +921,15 @@ void CApplicationMessenger::MediaPlay(string filename)
   MediaPlay(item);
 }
 
-void CApplicationMessenger::MediaPlay(const CFileItem &item)
+void CApplicationMessenger::MediaPlay(const CFileItem &item, bool wait)
 {
   CFileItemList list;
   list.Add(CFileItemPtr(new CFileItem(item)));
 
-  MediaPlay(list);
+  MediaPlay(list, 0, wait);
 }
 
-void CApplicationMessenger::MediaPlay(const CFileItemList &list, int song)
+void CApplicationMessenger::MediaPlay(const CFileItemList &list, int song, bool wait)
 {
   ThreadMessage tMsg = {TMSG_MEDIA_PLAY};
   CFileItemList* listcopy = new CFileItemList();
@@ -937,7 +937,7 @@ void CApplicationMessenger::MediaPlay(const CFileItemList &list, int song)
   tMsg.lpVoid = (void*)listcopy;
   tMsg.param1 = song;
   tMsg.param2 = 1;
-  SendMessage(tMsg, true);
+  SendMessage(tMsg, wait);
 }
 
 void CApplicationMessenger::MediaPlay(int playlistid, int song /* = -1 */)

--- a/xbmc/ApplicationMessenger.h
+++ b/xbmc/ApplicationMessenger.h
@@ -166,8 +166,8 @@ public:
 
 
   void MediaPlay(std::string filename);
-  void MediaPlay(const CFileItem &item);
-  void MediaPlay(const CFileItemList &item, int song = 0);
+  void MediaPlay(const CFileItem &item, bool wait = true);
+  void MediaPlay(const CFileItemList &item, int song = 0, bool wait = true);
   void MediaPlay(int playlistid, int song = -1);
   void MediaStop(bool bWait = true, int playlistid = -1);
   void MediaPause();

--- a/xbmc/network/upnp/UPnPRenderer.cpp
+++ b/xbmc/network/upnp/UPnPRenderer.cpp
@@ -625,7 +625,7 @@ CUPnPRenderer::PlayMedia(const NPT_String& uri, const NPT_String& meta, PLT_Acti
     if (item->IsPicture()) {
         CApplicationMessenger::Get().PictureShow(item->GetPath());
     } else {
-        CApplicationMessenger::Get().MediaPlay(*item);
+        CApplicationMessenger::Get().MediaPlay(*item, false);
     }
 
     if (g_application.m_pPlayer->IsPlaying() || g_windowManager.GetActiveWindow() == WINDOW_SLIDESHOW) {


### PR DESCRIPTION
fixes http://trac.xbmc.org/ticket/15636
This was used to work in Gotham but only by chance. We must not block the upnp call while calling back and opening the stream.
