### PR TITLE
ActiveAE - Wait 60 seconds for init

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -2176,7 +2176,7 @@ bool CActiveAE::Initialize()
   Message *reply;
   if (m_controlPort.SendOutMessageSync(CActiveAEControlProtocol::INIT,
                                                  &reply,
-                                                 10000))
+                                                 60000))
   {
     bool success = reply->signal == CActiveAEControlProtocol::ACC;
     reply->Release();


### PR DESCRIPTION
This fixes issues on Windows Systems that need much longer than our 10 seconds.

See: http://forum.kodi.tv/showthread.php?tid=205904&pid=1885594#pid1885594

I vote to include it in Helix backports, as we have no idea why it needs that long.
