### PR TITLE
cppcheck performance fixes in peripherals/

### DIFF
--- a/xbmc/peripherals/bus/osx/PeripheralBusUSB.cpp
+++ b/xbmc/peripherals/bus/osx/PeripheralBusUSB.cpp
@@ -121,8 +121,6 @@ void CPeripheralBusUSB::DeviceDetachCallback(void *refCon, io_service_t service,
 { 
   if (messageType == kIOMessageServiceIsTerminated)
   {
-    IOReturn result;
-
     USBDevicePrivateData *privateDataRef = (USBDevicePrivateData*)refCon;
 
     std::vector<PeripheralScanResult>::iterator it = privateDataRef->refCon->m_scan_results.m_results.begin();
@@ -137,10 +135,10 @@ void CPeripheralBusUSB::DeviceDetachCallback(void *refCon, io_service_t service,
     
     CLog::Log(LOGDEBUG, "USB Device Detach:%s, %s\n",
       privateDataRef->deviceName.c_str(), privateDataRef->result.m_strLocation.c_str());
-    result = IOObjectRelease(privateDataRef->notification);
+    IOObjectRelease(privateDataRef->notification);
     delete privateDataRef;
     //release the service
-    result = IOObjectRelease(service);
+    IOObjectRelease(service);
   }
 }
 
@@ -183,10 +181,10 @@ void CPeripheralBusUSB::DeviceAttachCallback(CPeripheralBusUSB* refCon, io_itera
     UInt32  locationId;
     UInt8   bDeviceClass;
 
-    result = (*deviceInterface)->GetDeviceVendor( deviceInterface, &vendorId);
-    result = (*deviceInterface)->GetDeviceProduct(deviceInterface, &productId);
-    result = (*deviceInterface)->GetLocationID(   deviceInterface, &locationId);
-    result = (*deviceInterface)->GetDeviceClass(  deviceInterface, &bDeviceClass);
+    (*deviceInterface)->GetDeviceVendor( deviceInterface, &vendorId);
+    (*deviceInterface)->GetDeviceProduct(deviceInterface, &productId);
+    (*deviceInterface)->GetLocationID(   deviceInterface, &locationId);
+    (*deviceInterface)->GetDeviceClass(  deviceInterface, &bDeviceClass);
 
     io_service_t usbInterface;
     io_iterator_t interface_iterator;


### PR DESCRIPTION
Simple ones. Removing assign to a variable that we don't check
