### PR TITLE
CGUIDialogAudioSubtitleSettings: enable volume and volume amplification settings when passthrough is enabled but playback is not using passthrough

### DIFF
--- a/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
@@ -293,9 +293,13 @@ void CGUIDialogAudioSubtitleSettings::InitializeSettings()
     g_application.m_pPlayer->GetSubtitleCapabilities(m_subCaps);
   }
 
+  // register IsPlayingPassthrough condition
+  m_settingsManager->AddCondition("IsPlayingPassthrough", IsPlayingPassthrough);
+
   CSettingDependency dependencyAudioOutputPassthroughDisabled(SettingDependencyTypeEnable, m_settingsManager);
-  dependencyAudioOutputPassthroughDisabled.And()
-    ->Add(CSettingDependencyConditionPtr(new CSettingDependencyCondition(SETTING_AUDIO_PASSTHROUGH, "false", SettingDependencyOperatorEquals, false, m_settingsManager)));
+  dependencyAudioOutputPassthroughDisabled.Or()
+    ->Add(CSettingDependencyConditionPtr(new CSettingDependencyCondition(SETTING_AUDIO_PASSTHROUGH, "false", SettingDependencyOperatorEquals, false, m_settingsManager)))
+    ->Add(CSettingDependencyConditionPtr(new CSettingDependencyCondition("IsPlayingPassthrough", "", "", true, m_settingsManager)));
   SettingDependencies depsAudioOutputPassthroughDisabled;
   depsAudioOutputPassthroughDisabled.push_back(dependencyAudioOutputPassthroughDisabled);
   
@@ -404,6 +408,11 @@ void CGUIDialogAudioSubtitleSettings::AddSubtitleStreams(CSettingGroup *group, c
     m_subtitleStream = 0;
 
   AddSpinner(group, settingId, 462, 0, m_subtitleStream, SubtitleStreamsOptionFiller);
+}
+
+bool CGUIDialogAudioSubtitleSettings::IsPlayingPassthrough(const std::string &condition, const std::string &value, const CSetting *setting)
+{
+  return g_application.m_pPlayer->IsPassthrough();
 }
 
 void CGUIDialogAudioSubtitleSettings::AudioStreamsOptionFiller(const CSetting *setting, std::vector< std::pair<std::string, int> > &list, int &current, void *data)

--- a/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.h
+++ b/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.h
@@ -53,6 +53,8 @@ protected:
   void AddAudioStreams(CSettingGroup *group, const std::string &settingId);
   void AddSubtitleStreams(CSettingGroup *group, const std::string &settingId);
 
+  static bool IsPlayingPassthrough(const std::string &condition, const std::string &value, const CSetting *setting);
+
   static void AudioStreamsOptionFiller(const CSetting *setting, std::vector< std::pair<std::string, int> > &list, int &current, void *data);
   static void SubtitleStreamsOptionFiller(const CSetting *setting, std::vector< std::pair<std::string, int> > &list, int &current, void *data);
   


### PR DESCRIPTION
@notspiff made me aware of the fact that since my settings dialog refactor the "volume" and "volume amplification" settings in the audio settings dialog were only enabled when the passthrough setting was disabled. But they should also be enabled when the passthrough setting was enabled but we weren't using passthrough (e.g. because the user configured that his receiver wasn't able to handle that audio format).

This should also be backported to Helix.
