### PR TITLE
CApplication: fix loading of custom windows

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2099,7 +2099,7 @@ bool CApplication::LoadUserWindows()
           // Root element should be <window>
           TiXmlElement* pRootElement = xmlDoc.RootElement();
           std::string strValue = pRootElement->Value();
-          if (!StringUtils::CompareNoCase(strValue, "window"))
+          if (!StringUtils::EqualsNoCase(strValue, "window"))
           {
             CLog::Log(LOGERROR, "file: %s doesnt contain <window>", skinFile.c_str());
             continue;


### PR DESCRIPTION
https://github.com/xbmc/xbmc/commit/ec3f48cafccc4a7f4ba97368b02d838c2b6799a5#diff-63246197ac0f0ac89358c1155ad21d5bR2102 causes errors in log:
ERROR: file: custom_1118_OSDVideoInfo.xml doesnt contain <window>

Unable to locate window with id 1118.  Check skin files

@Montellese 
