### PR TITLE
configure.in: Make SDL depend on joystick

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -214,6 +214,7 @@ libplist_not_found="== Could not find libplist. AirPlay support disabled. =="
 libplist_disabled="== AirPlay support disabled. =="
 alsa_not_found="== Could not find ALSA. ALSA support disabled. =="
 dbus_not_found="== Could not find DBUS. DBUS support disabled. =="
+sdl_joystick_not_found="== Could not find SDL2. Joystick support disabled. =="
 libcap_disabled="== Capabilities detection support disabled. =="
 libcap_not_found="== Could not find libcap. Capabilities detection support disabled. =="
 gtest_enabled="== Google Test Framework will be configured. =="
@@ -273,12 +274,6 @@ AC_ARG_ENABLE([gles],
   [use_gles=$enableval],
   [use_gles=no])
 
-AC_ARG_ENABLE([sdl],
-  [AS_HELP_STRING([--enable-sdl],
-  [enable SDL (default is auto)])],
-  [use_sdl=$enableval],
-  [use_sdl=auto])
-
 AC_ARG_ENABLE([vdpau],
   [AS_HELP_STRING([--enable-vdpau],
   [enable VDPAU decoding (default is auto)])],
@@ -317,9 +312,9 @@ AC_ARG_ENABLE([profiling],
 
 AC_ARG_ENABLE([joystick],
   [AS_HELP_STRING([--enable-joystick],
-  [enable SDL joystick support (default is yes)])],
+  [enable SDL joystick support (default is auto)])],
   [use_joystick=$enableval],
-  [use_joystick=yes])
+  [use_joystick=auto])
 
 AC_ARG_ENABLE([xrandr],
   [AS_HELP_STRING([--enable-xrandr],
@@ -509,7 +504,7 @@ AC_ARG_ENABLE([libbluray],
 
 AC_ARG_ENABLE([texturepacker],
   [AS_HELP_STRING([--enable-texturepacker],
-  [enable texturepacker support (default is yes)])],
+  [enable texturepacker support (default is auto)])],
   [use_texturepacker=$enableval],
   [use_texturepacker=auto])
 
@@ -605,7 +600,6 @@ case $host in
      use_joystick=no
      use_gles=yes
      use_optical_drive=no
-     use_sdl=no
      use_x11=no
      build_shared_lib=yes    
      ;;
@@ -680,7 +674,6 @@ case $host in
      use_neon=yes
      use_gles=yes
      use_gl=no
-     use_sdl=no
      use_wayland=no
      USE_STATIC_FFMPEG=1
      ;;
@@ -693,7 +686,6 @@ case $host in
      use_neon=yes
      use_gles=yes
      use_optical_drive=no
-     use_sdl=no
      use_x11=no
      use_wayland=no
      build_shared_lib=yes
@@ -991,7 +983,6 @@ if test "$use_wayland" = "yes" && test "$host_vendor" != "apple"; then
   fi
 
   # Disable SDL and X11 builds
-  use_sdl=no
   use_joystick=no
   use_x11=no
 
@@ -1222,18 +1213,22 @@ if test "x$use_dbus" != "xno"; then
 else
   AC_MSG_NOTICE($dbus_disabled)
 fi
-  if test "x$use_sdl" != "xno"; then
-    PKG_CHECK_MODULES([SDL2],   [sdl2], 
+  #case "$host_vendor" != "apple"; determine availability of SDL or SDL2
+  # joystick
+  if test "$use_joystick" != "no"; then
+    PKG_CHECK_MODULES([SDL2], [sdl2],
       [AC_DEFINE([SDL_VERSION],[2],["SDL major version"])
-       INCLUDES="$INCLUDES $SDL2_CFLAGS"; LIBS="$LIBS $SDL2_LIBS";],
-      [PKG_CHECK_MODULES([SDL],   [sdl],
-        [AC_DEFINE([SDL_VERSION],[1],["SDL major version"])
-         INCLUDES="$INCLUDES $SDL_CFLAGS"; LIBS="$LIBS $SDL_LIBS"; use_joystick=no],
-        [AC_MSG_ERROR($missing_library)])
-      ]
-    )
-    AC_CHECK_LIB([SDL_image],  [main],, AC_MSG_ERROR($missing_library))
-    AC_DEFINE([HAVE_SDL],[1],["Define to 1 if using sdl"])
+       AC_DEFINE([HAVE_SDL],[1],["Define to 1 if using sdl"])
+       INCLUDES="$INCLUDES $SDL2_CFLAGS"; LIBS="$LIBS $SDL2_LIBS"; use_joystick="yes"],
+      [if test "$use_joystick" = "yes"; then
+        AC_MSG_ERROR($sdl_joystick_not_found)
+      elif test "$use_joystick" != "no"; then
+        AC_MSG_NOTICE($sdl_joystick_not_found)
+        use_joystick="no"
+      fi
+     ])
+  else
+    AC_MSG_RESULT($sdl_joystick_not_found)
   fi
 fi
 


### PR DESCRIPTION
Currently, when using --disable-sdl, the Joystick support is still enabled by default. This leads to

```
CPP     xbmc/input/ButtonTranslator.o
In file included from ButtonTranslator.cpp:44:0:
SDLJoystick.h:51:31: fatal error: SDL2/SDL_joystick.h: No such file or directory
```

This patch remove the disable-sdl switch. Instead, SDL2 is required
whenever joystick support is enabled.
If joystick support is left on auto (as it is the
default), they it is enabled when SDL2 is detected and disabled if no SDL2
is detected.
