### PR TITLE
Add actions for mouse drag start and end

### DIFF
--- a/xbmc/guilib/Key.h
+++ b/xbmc/guilib/Key.h
@@ -89,8 +89,10 @@
 #define KEY_MOUSE_LONG_CLICK       0xE020
 #define KEY_MOUSE_WHEEL_UP         0xE101
 #define KEY_MOUSE_WHEEL_DOWN       0xE102
-#define KEY_MOUSE_DRAG             0xE103
-#define KEY_MOUSE_MOVE             0xE104
+#define KEY_MOUSE_MOVE             0xE103
+#define KEY_MOUSE_DRAG             0xE104
+#define KEY_MOUSE_DRAG_START       0xE105
+#define KEY_MOUSE_DRAG_END         0xE106
 #define KEY_MOUSE_NOOP             0xEFFF
 #define KEY_MOUSE_END              0xEFFF
 

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -411,8 +411,10 @@ static const ActionMapping mousekeys[] =
   { "longclick",   KEY_MOUSE_LONG_CLICK },
   { "wheelup",     KEY_MOUSE_WHEEL_UP },
   { "wheeldown",   KEY_MOUSE_WHEEL_DOWN },
+  { "mousemove",   KEY_MOUSE_MOVE },
   { "mousedrag",   KEY_MOUSE_DRAG },
-  { "mousemove",   KEY_MOUSE_MOVE }
+  { "mousedragstart", KEY_MOUSE_DRAG_START },
+  { "mousedragend",   KEY_MOUSE_DRAG_END }
 };
 
 static const ActionMapping touchcommands[] =

--- a/xbmc/input/MouseStat.cpp
+++ b/xbmc/input/MouseStat.cpp
@@ -23,6 +23,7 @@
 #include "settings/lib/Setting.h"
 #include "utils/TimeUtils.h"
 #include "windowing/WindowingFactory.h"
+#include "utils/log.h"
 
 CMouseStat::CMouseStat()
 {
@@ -129,9 +130,15 @@ void CMouseStat::HandleEvent(XBMC_Event& newEvent)
       bNothingDown = false;
       break;
     case CButtonState::MB_DRAG_START:
+      bHold[i] = CButtonState::MB_DRAG_START;
+      bNothingDown = false;
+      break;
     case CButtonState::MB_DRAG:
+      bHold[i] = CButtonState::MB_DRAG;
+      bNothingDown = false;
+      break;
     case CButtonState::MB_DRAG_END:
-      bHold[i] = action - CButtonState::MB_DRAG_START + 1;
+      bHold[i] = CButtonState::MB_DRAG_END;
       bNothingDown = false;
       break;
     default:
@@ -163,9 +170,22 @@ void CMouseStat::HandleEvent(XBMC_Event& newEvent)
 
   if (m_Key == KEY_MOUSE_NOOP)
   {
-    // The bHold array is set true if CButtonState::Update spots a mouse drag
-    if (bHold[MOUSE_LEFT_BUTTON])
-      m_Key = KEY_MOUSE_DRAG;
+    // The bHold array is set to the drag action
+    if (bHold[MOUSE_LEFT_BUTTON] != 0)
+    {
+      switch (bHold[MOUSE_LEFT_BUTTON])
+      {
+        case CButtonState::MB_DRAG:
+          m_Key = KEY_MOUSE_DRAG;
+          break;
+        case CButtonState::MB_DRAG_START:
+          m_Key = KEY_MOUSE_DRAG_START;
+          break;
+        case CButtonState::MB_DRAG_END:
+          m_Key = KEY_MOUSE_DRAG_END;
+          break;
+      }
+    }
 
     // dz is +1 on wheel up and -1 on wheel down
     else if (m_mouseState.dz > 0)

--- a/xbmc/input/MouseStat.cpp
+++ b/xbmc/input/MouseStat.cpp
@@ -23,7 +23,6 @@
 #include "settings/lib/Setting.h"
 #include "utils/TimeUtils.h"
 #include "windowing/WindowingFactory.h"
-#include "utils/log.h"
 
 CMouseStat::CMouseStat()
 {


### PR DESCRIPTION
This is partly to address ticket http://trac.kodi.tv/ticket/15670 and partly OCD. It adds mappable actions in mouse.xml for the start and end of a mouse drag.

This addresses the ticket because the user can map Select to a mousedragend, then clicking the mouse will always execute the Select action even if the user moves the mouse during the click and unintentionally converts it into a drag.
