### PR TITLE
[New feature] User custom UPnP mime types

### DIFF
--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -650,6 +650,7 @@
     <ClCompile Include="..\..\xbmc\network\UdpClient.cpp" />
     <ClCompile Include="..\..\xbmc\network\upnp\UPnP.cpp" />
     <ClCompile Include="..\..\xbmc\network\upnp\UPnPInternal.cpp" />
+    <ClCompile Include="..\..\xbmc\network\upnp\UPnPMimeSettings.cpp" />
     <ClCompile Include="..\..\xbmc\network\upnp\UPnPPlayer.cpp" />
     <ClCompile Include="..\..\xbmc\network\upnp\UPnPRenderer.cpp" />
     <ClCompile Include="..\..\xbmc\network\upnp\UPnPServer.cpp" />
@@ -936,6 +937,7 @@
     <ClInclude Include="..\..\xbmc\media\MediaType.h" />
     <ClInclude Include="..\..\xbmc\music\karaoke\karaokevideobackground.h" />
     <ClInclude Include="..\..\xbmc\network\NetworkServices.h" />
+    <ClInclude Include="..\..\xbmc\network\upnp\UPnPMimeSettings.h" />
     <ClInclude Include="..\..\xbmc\peripherals\bus\virtual\PeripheralBusCEC.h" />
     <ClInclude Include="..\..\xbmc\network\upnp\UPnPSettings.h" />
     <ClInclude Include="..\..\xbmc\playlists\SmartPlaylistFileItemListModifier.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -3089,6 +3089,9 @@
     <ClCompile Include="..\..\xbmc\cores\dvdplayer\DVDDemuxers\DVDDemuxCC.cpp">
       <Filter>cores\dvdplayer\DVDDemuxers</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\network\upnp\UPnPMimeSettings.cpp">
+      <Filter>network\upnp</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\xbmc\win32\pch.h">
@@ -6014,6 +6017,9 @@
     </ClInclude>
     <ClInclude Include="..\..\xbmc\cores\dvdplayer\DVDDemuxers\DVDDemuxCC.h">
       <Filter>cores\dvdplayer\DVDDemuxers</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\network\upnp\UPnPMimeSettings.h">
+      <Filter>network\upnp</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/xbmc/network/upnp/UPnP.cpp
+++ b/xbmc/network/upnp/UPnP.cpp
@@ -31,6 +31,7 @@
 #include "UPnPRenderer.h"
 #include "UPnPServer.h"
 #include "UPnPSettings.h"
+#include "UPnPMimeSettings.h"
 #include "utils/URIUtils.h"
 #include "Application.h"
 #include "ApplicationMessenger.h"
@@ -610,6 +611,10 @@ CUPnP::StartServer()
     // load upnpserver.xml
     CStdString filename = URIUtils::AddFileToFolder(CProfilesManager::Get().GetUserDataFolder(), "upnpserver.xml");
     CUPnPSettings::Get().Load(filename);
+
+    // load upnpmime.xml
+    CStdString mimefilename = URIUtils::AddFileToFolder(CProfilesManager::Get().GetUserDataFolder(), "upnpmime.xml");
+    CUPnPMimeSettings::Get().Load(mimefilename);
 
     // create the server with a XBox compatible friendlyname and UUID from upnpserver.xml if found
     m_ServerHolder->m_Device = CreateServer(CUPnPSettings::Get().GetServerPort());

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -40,6 +40,7 @@
 #include "TextureDatabase.h"
 #include "ThumbLoader.h"
 #include "utils/URIUtils.h"
+#include "UPnPMimeSettings.h"
 
 using namespace MUSIC_INFO;
 using namespace XFILE;
@@ -129,10 +130,19 @@ GetMimeType(const CFileItem& item,
 
     NPT_String mime;
 
+    /* Use user custom mime type first for better compatibility
+    with devices that expect different mime type than
+    DLNA/UPnP standard specified */
+    if (!ext.IsEmpty())
+    {
+        mime = CUPnPMimeSettings::Get().GetMimeTypeForExtension(ext);
+        if (mime == "application/octet-stream") mime = "";
+    }
+
     /* We always use Platinum mime type first
        as it is defined to map extension to DLNA compliant mime type
        or custom according to context (who asked for it) */
-    if (!ext.IsEmpty()) {
+	if (!ext.IsEmpty() && mime.IsEmpty()) {
         mime = PLT_MimeType::GetMimeTypeFromExtension(ext, context);
         if (mime == "application/octet-stream") mime = "";
     }

--- a/xbmc/network/upnp/UPnPMimeSettings.cpp
+++ b/xbmc/network/upnp/UPnPMimeSettings.cpp
@@ -1,0 +1,180 @@
+/*
+*      Copyright (C) 2013 Team XBMC
+*      http://xbmc.org
+*
+*  This Program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2, or (at your option)
+*  any later version.
+*
+*  This Program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with XBMC; see the file COPYING.  If not, see
+*  <http://www.gnu.org/licenses/>.
+*
+*/
+
+#include "UPnPMimeSettings.h"
+#include "filesystem/File.h"
+#include "threads/SingleLock.h"
+#include "utils/log.h"
+#include "utils/StringUtils.h"
+#include "utils/XBMCTinyXML.h"
+#include "utils/XMLUtils.h"
+
+#define XML_UPNP_MIME "upnpmime"
+
+using namespace std;
+using namespace XFILE;
+
+CUPnPMimeSettings::CUPnPMimeSettings()
+{
+	Clear();
+}
+
+CUPnPMimeSettings::~CUPnPMimeSettings()
+{
+	Clear();
+}
+
+CUPnPMimeSettings& CUPnPMimeSettings::Get()
+{
+	static CUPnPMimeSettings sUPnPMimeSettings;
+	return sUPnPMimeSettings;
+}
+
+void CUPnPMimeSettings::OnSettingsUnloaded()
+{
+	Clear();
+}
+
+bool CUPnPMimeSettings::Load(const std::string &file)
+{
+	CSingleLock lock(m_critical);
+
+	Clear();
+
+	if (!CFile::Exists(file))
+		return false;
+
+	CXBMCTinyXML doc;
+	if (!doc.LoadFile(file))
+	{
+		CLog::Log(LOGERROR, "CUPnPMimeSettings: error loading %s, Line %d\n%s", file.c_str(), doc.ErrorRow(), doc.ErrorDesc());
+		return false;
+	}
+
+	TiXmlElement *pRootElement = doc.RootElement();
+	if (pRootElement == NULL || !StringUtils::EqualsNoCase(pRootElement->Value(), XML_UPNP_MIME))
+	{
+		CLog::Log(LOGERROR, "CUPnPMimeSettings: error loading %s, no <upnpmime> node", file.c_str());
+		return false;
+	}
+
+	// load settings
+	CUPnPMimeProfile *pMimeProfile;
+	TiXmlElement *pProfile = pRootElement->FirstChildElement("profile");
+	if (pProfile == NULL) return false;
+	while (pProfile)
+	{
+		pMimeProfile = new CUPnPMimeProfile();
+
+		pMimeProfile->m_id = XMLUtils::GetAttribute(pProfile, "id");
+		pMimeProfile->m_profileType = GetProfileType(XMLUtils::GetAttribute(pProfile, "type"));
+		if (pMimeProfile->m_profileType == UPNP_PROFILE_UNKNOWN || pMimeProfile->m_id == "")
+		{
+			CLog::Log(LOGERROR, "CUPnPMimeSettings: unknown profile type or id");
+			delete pMimeProfile;
+			Clear();
+			return false;
+		}
+
+		TiXmlElement* pMime = pProfile->FirstChildElement("mime");
+		std::string ext = "";
+		std::string mimetype = "";
+		while (pMime)
+		{
+			ext = XMLUtils::GetAttribute(pMime, "ext");
+			mimetype = XMLUtils::GetAttribute(pMime, "mimetype");
+
+			if (ext == "" || mimetype == "")
+			{
+				CLog::Log(LOGERROR, "CUPnPMimeSettings: unknown extension or mime type");
+				delete pMimeProfile;
+				Clear();
+				return false;
+			}
+
+			pMimeProfile->m_mimeTypes[ext] = mimetype;
+			pMime = pMime->NextSiblingElement("mime");
+		}
+
+		m_profiles.push_back(pMimeProfile);
+		pProfile = pProfile->NextSiblingElement("profile");
+	}
+
+	return true;
+}
+
+bool CUPnPMimeSettings::Save(const std::string &file) const
+{
+	CLog::Log(LOGINFO, "CUPnPMimeSettings: saving not implemented");
+	return false;
+}
+
+void CUPnPMimeSettings::Clear()
+{
+	CSingleLock lock(m_critical);
+
+	std::vector<CUPnPMimeProfile *>::iterator iter = m_profiles.begin();
+	for (iter = m_profiles.begin(); iter != m_profiles.end(); ++iter)
+	{
+		delete *iter;
+	}
+	m_profiles.clear();
+
+	m_deviceName = "";
+	m_deviceUUID = "";
+}
+
+ProfileType CUPnPMimeSettings::GetProfileType(std::string profileType)
+{
+	if (profileType == "name") return UPNP_PROFILE_NAME;
+	else if (profileType == "uuid") return UPNP_PROFILE_UUID;
+	else return UPNP_PROFILE_UNKNOWN;
+}
+
+const char* CUPnPMimeSettings::GetMimeTypeForExtension(const NPT_String& extension)
+{
+	std::vector<CUPnPMimeProfile *>::iterator iter = m_profiles.begin();
+	for (iter = m_profiles.begin(); iter != m_profiles.end(); ++iter)
+	{
+		ProfileType profileType = (*iter)->m_profileType;
+		std::string deviceID;
+
+		if (profileType == UPNP_PROFILE_NAME) deviceID = m_deviceName;
+		else if (profileType == UPNP_PROFILE_UUID) deviceID = m_deviceUUID;
+		else return NULL;
+
+		if (deviceID != (*iter)->m_id) continue;
+
+		std::map<std::string, std::string>::iterator iter_map = (*iter)->m_mimeTypes.find(extension.GetChars());
+		if (iter_map != (*iter)->m_mimeTypes.end())
+		{
+			CLog::Log(LOGINFO, "using type from user list for extension: %s", (*iter_map).second.c_str());
+			return (*iter_map).second.c_str();
+		}
+	}
+
+	return NULL;
+}
+
+void CUPnPMimeSettings::SetUPnPDevice(const PLT_DeviceData *device)
+{
+	m_deviceName = device->GetFriendlyName();
+	m_deviceUUID = device->GetUUID();
+}

--- a/xbmc/network/upnp/UPnPMimeSettings.h
+++ b/xbmc/network/upnp/UPnPMimeSettings.h
@@ -1,0 +1,69 @@
+/*
+*      Copyright (C) 2013 Team XBMC
+*      http://xbmc.org
+*
+*  This Program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2, or (at your option)
+*  any later version.
+*
+*  This Program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with XBMC; see the file COPYING.  If not, see
+*  <http://www.gnu.org/licenses/>.
+*
+*/
+#pragma once
+#include <string>
+
+#include "settings/lib/ISettingsHandler.h"
+#include "threads/CriticalSection.h"
+#include "Neptune/Source/Core/NptStrings.h"
+#include "Platinum/Source/Platinum/Platinum.h"
+
+
+enum ProfileType
+{
+	UPNP_PROFILE_NAME,
+	UPNP_PROFILE_UUID,
+	UPNP_PROFILE_UNKNOWN
+};
+
+struct CUPnPMimeProfile
+{
+	std::string m_id;
+	ProfileType m_profileType;
+	std::map <std::string, std::string> m_mimeTypes;
+};
+
+class CUPnPMimeSettings : public ISettingsHandler
+{
+public:
+	static CUPnPMimeSettings& Get();
+
+	virtual void OnSettingsUnloaded();
+
+	bool Load(const std::string &file);
+	bool Save(const std::string &file) const;
+	void Clear();
+	const char* GetMimeTypeForExtension(const NPT_String& extension);
+	void SetUPnPDevice(const PLT_DeviceData *device);
+
+protected:
+	CUPnPMimeSettings();
+	CUPnPMimeSettings(const CUPnPMimeSettings&);
+	CUPnPMimeSettings const& operator=(CUPnPMimeSettings const&);
+	virtual ~CUPnPMimeSettings();
+
+private:
+	std::vector <CUPnPMimeProfile *> m_profiles;
+	CCriticalSection m_critical;
+	std::string m_deviceUUID;
+	std::string m_deviceName;
+
+	ProfileType GetProfileType(std::string profileType);
+};

--- a/xbmc/network/upnp/UPnPPlayer.cpp
+++ b/xbmc/network/upnp/UPnPPlayer.cpp
@@ -39,6 +39,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "guilib/Key.h"
 #include "dialogs/GUIDialogYesNo.h"
+#include "UPnPMimeSettings.h"
 
 
 NPT_SET_LOCAL_LOGGER("xbmc.upnp.player")
@@ -225,6 +226,10 @@ int CUPnPPlayer::PlayFile(const CFileItem& file, const CPlayerOptions& options, 
     thumb_loader = NPT_Reference<CThumbLoader>(new CVideoThumbLoader());
   else if (item.IsMusicDb())
     thumb_loader = NPT_Reference<CThumbLoader>(new CMusicThumbLoader());
+
+  /*  setting device data for CUPnPMimeSettings this way, to avoid adding another
+      parameter to BuildObject function */
+  CUPnPMimeSettings::Get().SetUPnPDevice(m_delegate->m_device.AsPointer());
 
   obj = BuildObject(item, path, false, thumb_loader, NULL, CUPnP::GetServer());
   if(obj.IsNull()) goto failed;


### PR DESCRIPTION
You could add your own mime-types for streaming file if your TV (or another device) expect different one than DLNA/UPnP standard specified (like mine TV). For example mime type standard for AVI file is video/x-msvideo but my TV (LG) expect video/avi and won't play streaming avi movies from Kodi (XBMC). To add custom mime types (only for streaming) just add file named "upnpmime.xml" to "userdata" directory (%APPDATA%\Kodi\userdata on Windows).

Structure of upnpmime.xml file:

&lt;upnpmime&gt;
&nbsp;&nbsp;&lt;profile id="name_of_device" type="name" &gt;
&nbsp;&nbsp;&nbsp;&nbsp;&lt;mime ext="movie_file_extension" mimetype="new_mimetype" /&gt;
&nbsp;&nbsp;&lt;/profile&gt;
&lt;/upnpmime&gt;
- name_of_device - friendly name of device in DLNA\UPnP (KODI shows it in logs or in "Play Using..." function)
- "id" could be UUID of device in Kodi, but you have to change type to "uuid"
- you could add as many profiles as you want, and so mime entries in profile

for example:

&lt;upnpmime&gt;
&nbsp;&nbsp;&lt;profile id="[TV]47LM660S-ZA" type="name" &gt;
&nbsp;&nbsp;&nbsp;&nbsp;&lt;mime ext="avi" mimetype="video/avi" /&gt;
&nbsp;&nbsp;&lt;/profile&gt;
&lt;/upnpmime&gt;
