### PR TITLE
[build] Fix python when cross compiled with unified build

### DIFF
--- a/xbmc/interfaces/python/XBPython.cpp
+++ b/xbmc/interfaces/python/XBPython.cpp
@@ -564,7 +564,8 @@ bool XBPython::OnScriptInitialized(ILanguageInvoker *invoker)
 
 
     // Darwin packs .pyo files, we need PYTHONOPTIMIZE on in order to load them.
-#if defined(TARGET_DARWIN)
+    // linux built with unified builds only packages the pyo files so need it
+#if defined(TARGET_DARWIN) || defined(TARGET_LINUX)
     setenv("PYTHONOPTIMIZE", "1", 1);
 #endif
     // Info about interesting python envvars available


### PR DESCRIPTION
If I build for Pi on Ubuntu, then python doesn't work
This directory contins the required .py files:
/opt/xbmc-bcm/xbmc-dbg/arm-linux-gnueabihf/i686-linux-gnu-native/lib/python2.6
But the directory the Pi runs from has them deleted:
/opt/xbmc-bcm/xbmc-dbg/arm-linux-gnueabihf/arm-linux-gnueabihf/lib/python2.6

Not sure why the .py files are deleted, but it's not good for running python add-ons.
