### PR TITLE
[New feature] External subtitles over UPnP

### DIFF
--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.cpp
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.cpp
@@ -48,6 +48,7 @@ const char* didl_header         = "<DIDL-Lite xmlns=\"urn:schemas-upnp-org:metad
                                             " xmlns:dc=\"http://purl.org/dc/elements/1.1/\""
                                             " xmlns:upnp=\"urn:schemas-upnp-org:metadata-1-0/upnp/\""
                                             " xmlns:dlna=\"urn:schemas-dlna-org:metadata-1-0/\""
+                                            " xmlns:sec=\"http://www.sec.co.kr/\""
                                             " xmlns:xbmc=\"urn:schemas-xbmc-org:metadata-1-0/\">";
 const char* didl_footer         = "</DIDL-Lite>";
 const char* didl_namespace_dc   = "http://purl.org/dc/elements/1.1/";

--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp
@@ -528,10 +528,49 @@ PLT_MediaObject::ToDidl(NPT_UInt64 mask, NPT_String& didl)
             
             didl += " protocolInfo=\"";
             PLT_Didl::AppendXmlEscape(didl, m_Resources[i].m_ProtocolInfo.ToString());
-            didl += "\">";
+            didl += "\"";
+            /* adding custom data */
+            NPT_List<NPT_Map<NPT_String, NPT_String>::Entry*>::Iterator entry = m_Resources[i].m_CustomData.GetEntries().GetFirstItem();
+            while (entry)
+            {
+                didl += " ";
+                PLT_Didl::AppendXmlEscape(didl, (*entry)->GetKey());
+                didl += "=\"";
+                PLT_Didl::AppendXmlEscape(didl, (*entry)->GetValue());
+                didl += "\"";
+
+                entry++;
+            }
+
+            didl += ">";
             PLT_Didl::AppendXmlEscape(didl, m_Resources[i].m_Uri);
             didl += "</res>";
         }
+    }
+
+    //sec resources related
+    for (NPT_Cardinal i = 0; i < m_SecResources.GetItemCount(); i++) {
+        didl += "<sec:";
+        PLT_Didl::AppendXmlEscape(didl, m_SecResources[i].name);
+
+        NPT_List<NPT_Map<NPT_String, NPT_String>::Entry*>::Iterator entry = m_SecResources[i].attributes.GetEntries().GetFirstItem();
+        while (entry)
+        {
+            didl += " sec:";
+            PLT_Didl::AppendXmlEscape(didl, (*entry)->GetKey());
+            didl += "=\"";
+            PLT_Didl::AppendXmlEscape(didl, (*entry)->GetValue());
+            didl += "\"";
+
+            entry++;
+        }
+
+        didl += ">";
+        PLT_Didl::AppendXmlEscape(didl, m_SecResources[i].value);
+
+        didl += "</sec:";
+        PLT_Didl::AppendXmlEscape(didl, m_SecResources[i].name);
+        didl += ">";
     }
 
     // xbmc dateadded

--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.h
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.h
@@ -172,6 +172,12 @@ typedef struct {
   NPT_String unique_identifier;
 } PLT_XbmcInfo;
 
+typedef struct {
+  NPT_String name;
+  NPT_Map<NPT_String, NPT_String> attributes;
+  NPT_String value;
+} PLT_SecResource;
+
 /*----------------------------------------------------------------------
 |   PLT_MediaItemResource
 +---------------------------------------------------------------------*/
@@ -192,6 +198,9 @@ public:
     NPT_UInt32       m_NbAudioChannels;
     NPT_String       m_Resolution;
     NPT_UInt32       m_ColorDepth;
+    /* to add custom data to resource, that are not standard one, or are only
+    proper for some type of devices (UPnP)*/
+    NPT_Map<NPT_String, NPT_String> m_CustomData;
 };
 
 /*----------------------------------------------------------------------
@@ -249,6 +258,9 @@ public:
 
     /* resources related */
     NPT_Array<PLT_MediaItemResource> m_Resources;
+
+    /* sec resources related */
+    NPT_Array<PLT_SecResource> m_SecResources;
 
     /* XBMC specific */
     PLT_XbmcInfo m_XbmcInfo;

--- a/lib/libUPnP/patches/0035-platinum-Changes-to-external-subtitles-over-UPnP-wor.patch
+++ b/lib/libUPnP/patches/0035-platinum-Changes-to-external-subtitles-over-UPnP-wor.patch
@@ -1,0 +1,122 @@
+From ec171eae6aad8bbf51fdf52c97446db6418c96a1 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Rafa=C5=82=20Chwia=C5=82a?= <rchwiala@gmail.com>
+Date: Sat, 17 Jan 2015 15:55:52 +0100
+Subject: [PATCH] platinum Changes to external subtitles over UPnP works
+
+Added custom data to resources field - needed to add some attributes to res.
+Added new struct PLK_SecResource - needed by Somasung devices. It's not specialized struct (just general one), because I can't find any "sec" specification.
+---
+ .../Source/Devices/MediaServer/PltDidl.cpp         |  1 +
+ .../Source/Devices/MediaServer/PltMediaItem.cpp    | 41 +++++++++++++++++++++-
+ .../Source/Devices/MediaServer/PltMediaItem.h      | 12 +++++++
+ 3 files changed, 53 insertions(+), 1 deletion(-)
+
+diff --git a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.cpp b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.cpp
+index 7b853c8..b58aa50 100644
+--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.cpp
++++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.cpp
+@@ -48,6 +48,7 @@ const char* didl_header         = "<DIDL-Lite xmlns=\"urn:schemas-upnp-org:metad
+                                             " xmlns:dc=\"http://purl.org/dc/elements/1.1/\""
+                                             " xmlns:upnp=\"urn:schemas-upnp-org:metadata-1-0/upnp/\""
+                                             " xmlns:dlna=\"urn:schemas-dlna-org:metadata-1-0/\""
++                                            " xmlns:sec=\"http://www.sec.co.kr/\""
+                                             " xmlns:xbmc=\"urn:schemas-xbmc-org:metadata-1-0/\">";
+ const char* didl_footer         = "</DIDL-Lite>";
+ const char* didl_namespace_dc   = "http://purl.org/dc/elements/1.1/";
+diff --git a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp
+index 4db2d45..f937df2 100644
+--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp
++++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp
+@@ -528,12 +528,51 @@ PLT_MediaObject::ToDidl(NPT_UInt64 mask, NPT_String& didl)
+             
+             didl += " protocolInfo=\"";
+             PLT_Didl::AppendXmlEscape(didl, m_Resources[i].m_ProtocolInfo.ToString());
+-            didl += "\">";
++            didl += "\"";
++            /* adding custom data */
++            NPT_List<NPT_Map<NPT_String, NPT_String>::Entry*>::Iterator entry = m_Resources[i].m_CustomData.GetEntries().GetFirstItem();
++            while (entry)
++            {
++                didl += " ";
++                PLT_Didl::AppendXmlEscape(didl, (*entry)->GetKey());
++                didl += "=\"";
++                PLT_Didl::AppendXmlEscape(didl, (*entry)->GetValue());
++                didl += "\"";
++
++                entry++;
++            }
++
++            didl += ">";
+             PLT_Didl::AppendXmlEscape(didl, m_Resources[i].m_Uri);
+             didl += "</res>";
+         }
+     }
+ 
++    //sec resources related
++    for (NPT_Cardinal i = 0; i < m_SecResources.GetItemCount(); i++) {
++        didl += "<sec:";
++        PLT_Didl::AppendXmlEscape(didl, m_SecResources[i].name);
++
++        NPT_List<NPT_Map<NPT_String, NPT_String>::Entry*>::Iterator entry = m_SecResources[i].attributes.GetEntries().GetFirstItem();
++        while (entry)
++        {
++            didl += " sec:";
++            PLT_Didl::AppendXmlEscape(didl, (*entry)->GetKey());
++            didl += "=\"";
++            PLT_Didl::AppendXmlEscape(didl, (*entry)->GetValue());
++            didl += "\"";
++
++            entry++;
++        }
++
++        didl += ">";
++        PLT_Didl::AppendXmlEscape(didl, m_SecResources[i].value);
++
++        didl += "</sec:";
++        PLT_Didl::AppendXmlEscape(didl, m_SecResources[i].name);
++        didl += ">";
++    }
++
+     // xbmc dateadded
+     if ((mask & PLT_FILTER_MASK_XBMC_DATEADDED) && !m_XbmcInfo.date_added.IsEmpty()) {
+         didl += "<xbmc:dateadded>";
+diff --git a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.h b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.h
+index deb4961..6461b81 100644
+--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.h
++++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.h
+@@ -172,6 +172,12 @@ typedef struct {
+   NPT_String unique_identifier;
+ } PLT_XbmcInfo;
+ 
++typedef struct {
++  NPT_String name;
++  NPT_Map<NPT_String, NPT_String> attributes;
++  NPT_String value;
++} PLT_SecResource;
++
+ /*----------------------------------------------------------------------
+ |   PLT_MediaItemResource
+ +---------------------------------------------------------------------*/
+@@ -192,6 +198,9 @@ public:
+     NPT_UInt32       m_NbAudioChannels;
+     NPT_String       m_Resolution;
+     NPT_UInt32       m_ColorDepth;
++    /* to add custom data to resource, that are not standard one, or are only
++    proper for some type of devices (UPnP)*/
++    NPT_Map<NPT_String, NPT_String> m_CustomData;
+ };
+ 
+ /*----------------------------------------------------------------------
+@@ -250,6 +259,9 @@ public:
+     /* resources related */
+     NPT_Array<PLT_MediaItemResource> m_Resources;
+ 
++    /* sec resources related */
++    NPT_Array<PLT_SecResource> m_SecResources;
++
+     /* XBMC specific */
+     PLT_XbmcInfo m_XbmcInfo;
+ 
+-- 
+1.8.3.msysgit.0
+

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -823,6 +823,11 @@ bool CFileItem::IsLyrics() const
   return URIUtils::HasExtension(m_strPath, ".cdg|.lrc");
 }
 
+bool CFileItem::IsSubtitle() const
+{
+  return URIUtils::HasExtension(m_strPath, g_advancedSettings.m_subtitlesExtensions);
+}
+
 bool CFileItem::IsCUESheet() const
 {
   return URIUtils::HasExtension(m_strPath, ".cue");

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -152,6 +152,7 @@ public:
    */
   bool IsPicture() const;
   bool IsLyrics() const;
+  bool IsSubtitle() const;
 
   /*!
    \brief Check whether an item is an audio item. Note that this returns true for

--- a/xbmc/network/upnp/UPnPServer.cpp
+++ b/xbmc/network/upnp/UPnPServer.cpp
@@ -1194,6 +1194,20 @@ CUPnPServer::ServeFile(const NPT_HttpRequest&              request,
       response.GetHeaders().SetHeader("Content-Disposition", disp.c_str());
     }
 
+    // set getCaptionInfo.sec - sets subtitle uri for Samsung devices
+    const NPT_String* captionInfoHeader = request.GetHeaders().GetHeaderValue("getCaptionInfo.sec");
+    if (captionInfoHeader) 
+    {
+      NPT_String *sub_uri, movie;
+      movie = "subtitle://" + md5;
+
+      NPT_AutoLock lock(m_FileMutex);
+      if (NPT_SUCCEEDED(m_FileMap.Get(movie, sub_uri))) 
+      {
+        response.GetHeaders().SetHeader("CaptionInfo.sec", sub_uri->GetChars(), false);
+      }
+    }
+
     return PLT_HttpServer::ServeFile(request,
                                        context,
                                        response,
@@ -1288,6 +1302,19 @@ CUPnPServer::DefaultSortItems(CFileItemList& items)
     items.Sort(sorting.sortBy, sorting.sortOrder, sorting.sortAttributes);
     delete viewState;
   }
+}
+
+NPT_Result
+CUPnPServer::AddSubtitleUriForSecResponse(NPT_String movie_md5, NPT_String subtitle_uri)
+{
+  /* using existing m_FileMap to store subtitle uri for movie,
+     adding subtitle:// prefix, because there is already entry for movie md5 with movie path */
+  NPT_String movie = "subtitle://" + movie_md5;
+
+  NPT_AutoLock lock(m_FileMutex);
+  NPT_CHECK(m_FileMap.Put(movie, subtitle_uri));
+
+  return NPT_SUCCESS;
 }
 
 } /* namespace UPNP */

--- a/xbmc/network/upnp/UPnPServer.h
+++ b/xbmc/network/upnp/UPnPServer.h
@@ -97,6 +97,10 @@ public:
         }
     }
 
+    /* Samsungs devices get subtitles from header in response (for movie file), not from didl.
+       It's a way to store subtitle uri generated when building didl, to use later in http response*/
+    NPT_Result AddSubtitleUriForSecResponse(NPT_String movie_md5, NPT_String subtitle_uri);
+
 
 private:
     void OnScanCompleted(int type);


### PR DESCRIPTION
Like in title, it allows to play video with external subtitle over UPnP.

Supported subtitle file extensions: txt, srt, ssa, ass, sub, smi. (most
popular ones)

Subtitle files are searched like in internal player (in video file
folder and in folders specified in options). If more than one subtitle
file are found (multiple language versions), Kodi takes the one with
language choosed in options (prefered language for subtitles), otherwise
first found.

Subtitles are added as 2 resources, 2 sec resources and 3 attributes added to
video file resource, for greater compatibility with more UPnP devices.
Device take the last one it could handle, and skip ones it can't
"understand":

&lt;res protocolInfo="http-get:_:video/mp4:_" xmlns:pv="http://www.pv.com/pvns/" pv:subtitleFileUri="http://192.168.1.13:1722/video.srt" pv:subtitleFileType="SRT"&gt;http://192.168.1.13:1722/video.mp4 &lt;/res&gt;
&lt;res protocolInfo="http-get:_:text/srt:_"&gt; http://192.168.1.13:1722/video.srt &lt;/res&gt;
&lt;res protocolInfo="http-get:_:smi/caption:_"&gt; http://192.168.1.13:1722/video.srt &lt;/res&gt;
&lt;sec:CaptionInfoEx sec:type="srt"&gt;http://192.168.1.13:1722/video.srt&lt;/sec:CaptionInfoEx&gt;
&lt;sec:CaptionInfo sec:type="srt"&gt;http://192.168.1.13:1722/video.srt&lt;/sec:CaptionInfo&gt;

Samsung devices get subtitles uri from "CaptionInfo.sec" field in http response header for movie file request (it contains "getCaptionInfo.sec" field).

This all should be (and probably it would be) changed, when Profile Manager (for DLNA devices) will be available in Kodi.
