### PR TITLE
[pvr] support EPG item type for "ListItem.Premiered" GUI label

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -4571,6 +4571,16 @@ std::string CGUIInfoManager::GetItemLabel(const CFileItem *item, int info, std::
         return dateTime.GetAsLocalizedDate();
       break;
     }
+    if (item->HasEPGInfoTag())
+    {
+      if (item->GetEPGInfoTag()->FirstAiredAsLocalTime().IsValid())
+      {
+        CDateTime dateTime;
+        dateTime = item->GetEPGInfoTag()->FirstAiredAsLocalTime();
+        return dateTime.GetAsLocalizedDate(true);
+        break;
+      }
+    }
     break;
   case LISTITEM_GENRE:
     if (item->HasVideoInfoTag())


### PR DESCRIPTION
PVR EPG items have a "FirstAired" property which was not able to be shown on skins due to being missing in GUIManager.  Expanded the existing "Premiered" label type to handle EPG items in addition to the existing Video items
