### PR TITLE
Add support for right mouse drag

### DIFF
--- a/xbmc/guilib/Key.h
+++ b/xbmc/guilib/Key.h
@@ -93,6 +93,9 @@
 #define KEY_MOUSE_DRAG             0xE104
 #define KEY_MOUSE_DRAG_START       0xE105
 #define KEY_MOUSE_DRAG_END         0xE106
+#define KEY_MOUSE_RDRAG            0xE107
+#define KEY_MOUSE_RDRAG_START      0xE108
+#define KEY_MOUSE_RDRAG_END        0xE109
 #define KEY_MOUSE_NOOP             0xEFFF
 #define KEY_MOUSE_END              0xEFFF
 

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -414,7 +414,10 @@ static const ActionMapping mousekeys[] =
   { "mousemove",   KEY_MOUSE_MOVE },
   { "mousedrag",   KEY_MOUSE_DRAG },
   { "mousedragstart", KEY_MOUSE_DRAG_START },
-  { "mousedragend",   KEY_MOUSE_DRAG_END }
+  { "mousedragend",   KEY_MOUSE_DRAG_END },
+  { "mouserdrag", KEY_MOUSE_RDRAG },
+  { "mouserdragstart", KEY_MOUSE_RDRAG_START },
+  { "mouserdragend", KEY_MOUSE_RDRAG_END }
 };
 
 static const ActionMapping touchcommands[] =

--- a/xbmc/input/MouseStat.cpp
+++ b/xbmc/input/MouseStat.cpp
@@ -185,6 +185,21 @@ void CMouseStat::HandleEvent(XBMC_Event& newEvent)
           break;
       }
     }
+    else if (bHold[MOUSE_RIGHT_BUTTON] != 0)
+    {
+      switch (bHold[MOUSE_RIGHT_BUTTON])
+      {
+      case CButtonState::MB_DRAG:
+        m_Key = KEY_MOUSE_RDRAG;
+        break;
+      case CButtonState::MB_DRAG_START:
+        m_Key = KEY_MOUSE_RDRAG_START;
+        break;
+      case CButtonState::MB_DRAG_END:
+        m_Key = KEY_MOUSE_RDRAG_END;
+        break;
+      }
+    }
 
     // dz is +1 on wheel up and -1 on wheel down
     else if (m_mouseState.dz > 0)


### PR DESCRIPTION
This is the obvious follow up to https://github.com/xbmc/xbmc/pull/6171. It allows actions to be mapped to a right drag when using air mice, where it's easy to accidentally drag instead of click.
