### PR TITLE
[depends] fix building audio encoders on non unified depends platforms

### DIFF
--- a/tools/depends/target/xbmc-audioencoder-addons/Makefile
+++ b/tools/depends/target/xbmc-audioencoder-addons/Makefile
@@ -1,4 +1,5 @@
 BUILDDIR := $(shell pwd)
 ADDONS = "audioencoder.flac audioencoder.lame audioencoder.vorbis audioencoder.wav"
 
-include ../../Makefile.include ../../xbmc-addons.include
+-include ../../Makefile.include
+include ../../xbmc-addons.include


### PR DESCRIPTION
we can't require the Makefile.include on non unified deps platforms.
fixed building via the Makefile on linux
