### PR TITLE
Add path option to Skin.SetImage()

### DIFF
--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -1285,6 +1285,19 @@ int CBuiltins::Execute(const std::string& execString)
     }
     else if (execute == "skin.setimage")
     {
+      if (params.size() > 2)
+      {
+        value = params[2];
+        URIUtils::AddSlashAtEnd(value);
+        bool bIsSource;
+        if (CUtil::GetMatchingSource(value,localShares,bIsSource) < 0) // path is outside shares - add it as a separate one
+        {
+          CMediaSource share;
+          share.strName = g_localizeStrings.Get(13278);
+          share.strPath = value;
+          localShares.push_back(share);
+        }
+      }
       if (CGUIDialogFileBrowser::ShowAndGetImage(localShares, g_localizeStrings.Get(1030), value))
         CSkinSettings::Get().SetString(string, value);
     }


### PR DESCRIPTION
this allows skinners to specify the path that should be opened by the filebrowser:
Skin.SetImage(string[,value,path])

the code is a c&p from the skin.setfile() builtin, where this option was already available.
