### PR TITLE
webserver: image resizing

### DIFF
--- a/Kodi.xcodeproj/project.pbxproj
+++ b/Kodi.xcodeproj/project.pbxproj
@@ -182,6 +182,9 @@
 		3802709A13D5A653009493DD /* SystemClock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3802709813D5A653009493DD /* SystemClock.cpp */; };
 		384718D81325BA04000486D6 /* XBDateTime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 384718D61325BA04000486D6 /* XBDateTime.cpp */; };
 		38F4E57013CCCB3B00664821 /* Implementation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 38F4E56C13CCCB3B00664821 /* Implementation.cpp */; };
+		395F6DE21A81FACF0088CC74 /* HTTPImageTransformationHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 395F6DE01A81FACF0088CC74 /* HTTPImageTransformationHandler.cpp */; };
+		395F6DE31A81FACF0088CC74 /* HTTPImageTransformationHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 395F6DE01A81FACF0088CC74 /* HTTPImageTransformationHandler.cpp */; };
+		395F6DE41A81FACF0088CC74 /* HTTPImageTransformationHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 395F6DE01A81FACF0088CC74 /* HTTPImageTransformationHandler.cpp */; };
 		42DAC16E1A6E789E0066B4C8 /* PVRActionListener.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 42DAC16C1A6E789E0066B4C8 /* PVRActionListener.cpp */; };
 		42DAC16F1A6E789E0066B4C8 /* PVRActionListener.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 42DAC16C1A6E789E0066B4C8 /* PVRActionListener.cpp */; };
 		42DAC1701A6E789E0066B4C8 /* PVRActionListener.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 42DAC16C1A6E789E0066B4C8 /* PVRActionListener.cpp */; };
@@ -4070,6 +4073,8 @@
 		38F4E56C13CCCB3B00664821 /* Implementation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Implementation.cpp; sourceTree = "<group>"; };
 		38F4E56D13CCCB3B00664821 /* README.platform */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = README.platform; sourceTree = "<group>"; };
 		38F4E56E13CCCB3B00664821 /* ThreadLocal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ThreadLocal.h; sourceTree = "<group>"; };
+		395F6DE01A81FACF0088CC74 /* HTTPImageTransformationHandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = HTTPImageTransformationHandler.cpp; sourceTree = "<group>"; };
+		395F6DE11A81FACF0088CC74 /* HTTPImageTransformationHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HTTPImageTransformationHandler.h; sourceTree = "<group>"; };
 		42DAC16B1A6E780C0066B4C8 /* IActionListener.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IActionListener.h; sourceTree = "<group>"; };
 		42DAC16C1A6E789E0066B4C8 /* PVRActionListener.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PVRActionListener.cpp; sourceTree = "<group>"; };
 		42DAC16D1A6E789E0066B4C8 /* PVRActionListener.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PVRActionListener.h; sourceTree = "<group>"; };
@@ -8454,6 +8459,8 @@
 				DF56EF1E1A798A3F00CAAEFB /* HTTPFileHandler.h */,
 				7C6EB6F8155F32C30080368A /* HTTPImageHandler.cpp */,
 				7C6EB6F9155F32C30080368A /* HTTPImageHandler.h */,
+				395F6DE01A81FACF0088CC74 /* HTTPImageTransformationHandler.cpp */,
+				395F6DE11A81FACF0088CC74 /* HTTPImageTransformationHandler.h */,
 				DFCA6ABB152245CD000BFAAE /* HTTPJsonRpcHandler.cpp */,
 				DFCA6ABC152245CD000BFAAE /* HTTPJsonRpcHandler.h */,
 				DFCA6ABD152245CD000BFAAE /* HTTPVfsHandler.cpp */,
@@ -11560,6 +11567,7 @@
 				DFB02DEA16629DBA00F37752 /* PyContext.cpp in Sources */,
 				DF07252E168734D7008DCAAD /* karaokevideobackground.cpp in Sources */,
 				DF072534168734ED008DCAAD /* FFmpegVideoDecoder.cpp in Sources */,
+				395F6DE21A81FACF0088CC74 /* HTTPImageTransformationHandler.cpp in Sources */,
 				DF64FE3D16C07AAA00D028FB /* GUIViewControl.cpp in Sources */,
 				DF64FE3E16C07AAA00D028FB /* GUIViewState.cpp in Sources */,
 				DF64FE4016C07AAA00D028FB /* ViewDatabase.cpp in Sources */,
@@ -12181,6 +12189,7 @@
 				DFF0F20017528350002DA3A4 /* FTPParse.cpp in Sources */,
 				DFF0F20317528350002DA3A4 /* HDHomeRunDirectory.cpp in Sources */,
 				DFF0F20417528350002DA3A4 /* HDHomeRunFile.cpp in Sources */,
+				395F6DE41A81FACF0088CC74 /* HTTPImageTransformationHandler.cpp in Sources */,
 				DFF0F20517528350002DA3A4 /* HTSPDirectory.cpp in Sources */,
 				DFF0F20617528350002DA3A4 /* HTSPSession.cpp in Sources */,
 				DFF0F20717528350002DA3A4 /* HTTPDirectory.cpp in Sources */,
@@ -13882,6 +13891,7 @@
 				E499147F174E605900741B6D /* Variant.cpp in Sources */,
 				E4991480174E605900741B6D /* Weather.cpp in Sources */,
 				E4991481174E605900741B6D /* XBMCTinyXML.cpp in Sources */,
+				395F6DE31A81FACF0088CC74 /* HTTPImageTransformationHandler.cpp in Sources */,
 				E4991482174E605900741B6D /* XMLUtils.cpp in Sources */,
 				E4991483174E606500741B6D /* GUIDialogAudioSubtitleSettings.cpp in Sources */,
 				E4991484174E606500741B6D /* GUIDialogFileStacking.cpp in Sources */,

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -639,6 +639,7 @@
     <ClCompile Include="..\..\xbmc\network\GUIDialogNetworkSetup.cpp" />
     <ClCompile Include="..\..\xbmc\network\httprequesthandler\HTTPFileHandler.cpp" />
     <ClCompile Include="..\..\xbmc\network\httprequesthandler\HTTPImageHandler.cpp" />
+    <ClCompile Include="..\..\xbmc\network\httprequesthandler\HTTPImageTransformationHandler.cpp" />
     <ClCompile Include="..\..\xbmc\network\httprequesthandler\HTTPJsonRpcHandler.cpp" />
     <ClCompile Include="..\..\xbmc\network\httprequesthandler\HTTPVfsHandler.cpp" />
     <ClCompile Include="..\..\xbmc\network\httprequesthandler\HTTPWebinterfaceAddonsHandler.cpp" />
@@ -944,6 +945,7 @@
     <ClInclude Include="..\..\xbmc\media\MediaType.h" />
     <ClInclude Include="..\..\xbmc\music\karaoke\karaokevideobackground.h" />
     <ClInclude Include="..\..\xbmc\network\httprequesthandler\HTTPFileHandler.h" />
+    <ClInclude Include="..\..\xbmc\network\httprequesthandler\HTTPImageTransformationHandler.h" />
     <ClInclude Include="..\..\xbmc\network\NetworkServices.h" />
     <ClInclude Include="..\..\xbmc\peripherals\bus\virtual\PeripheralBusCEC.h" />
     <ClInclude Include="..\..\xbmc\network\upnp\UPnPSettings.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -3104,6 +3104,9 @@
     <ClCompile Include="..\..\xbmc\input\InputManager.cpp">
       <Filter>input</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\network\httprequesthandler\HTTPImageTransformationHandler.cpp">
+      <Filter>network\httprequesthandler</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\xbmc\win32\pch.h">
@@ -6038,6 +6041,9 @@
     </ClInclude>
     <ClInclude Include="..\..\xbmc\input\InputManager.h">
       <Filter>input</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\network\httprequesthandler\HTTPImageTransformationHandler.h">
+      <Filter>network\httprequesthandler</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/xbmc/TextureCacheJob.cpp
+++ b/xbmc/TextureCacheJob.cpp
@@ -127,6 +127,31 @@ bool CTextureCacheJob::CacheTexture(CBaseTexture **out_texture)
   return false;
 }
 
+bool CTextureCacheJob::ResizeTexture(const std::string &url, uint8_t* &result, size_t &result_size)
+{
+  result = NULL;
+  result_size = 0;
+
+  if (url.empty())
+    return false;
+
+  // unwrap the URL as required
+  std::string additional_info;
+  unsigned int width, height;
+  std::string image = DecodeImageURL(url, width, height, additional_info);
+  if (image.empty())
+    return false;
+
+  CBaseTexture *texture = LoadImage(image, width, height, additional_info, true);
+  if (texture == NULL)
+    return false;
+
+  bool success = CPicture::ResizeTexture(image, texture, width, height, result, result_size);
+  delete texture;
+
+  return success;
+}
+
 std::string CTextureCacheJob::DecodeImageURL(const std::string &url, unsigned int &width, unsigned int &height, std::string &additional_info)
 {
   // unwrap the URL as required
@@ -150,6 +175,13 @@ std::string CTextureCacheJob::DecodeImageURL(const std::string &url, unsigned in
 
     if (thumbURL.GetOption("size") == "thumb")
       width = height = g_advancedSettings.GetThumbSize();
+    else
+    {
+      if (thumbURL.HasOption("width") && StringUtils::IsInteger(thumbURL.GetOption("width")))
+        width = strtol(thumbURL.GetOption("width").c_str(), NULL, 0);
+      if (thumbURL.HasOption("height") && StringUtils::IsInteger(thumbURL.GetOption("height")))
+        height = strtol(thumbURL.GetOption("height").c_str(), NULL, 0);
+    }
   }
   return image;
 }

--- a/xbmc/TextureCacheJob.h
+++ b/xbmc/TextureCacheJob.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <stdint.h>
 #include <string>
 #include <vector>
 #include "utils/Job.h"
@@ -75,6 +76,8 @@ public:
    \return a hash string for this image
    */
   bool CacheTexture(CBaseTexture **texture = NULL);
+
+  static bool ResizeTexture(const std::string &url, uint8_t* &result, size_t &result_size);
 
   std::string m_url;
   std::string m_oldHash;

--- a/xbmc/network/NetworkServices.cpp
+++ b/xbmc/network/NetworkServices.cpp
@@ -59,6 +59,7 @@
 #ifdef HAS_WEB_SERVER
 #include "network/WebServer.h"
 #include "network/httprequesthandler/HTTPImageHandler.h"
+#include "network/httprequesthandler/HTTPImageTransformationHandler.h"
 #include "network/httprequesthandler/HTTPVfsHandler.h"
 #ifdef HAS_JSONRPC
 #include "network/httprequesthandler/HTTPJsonRpcHandler.h"
@@ -95,6 +96,7 @@ CNetworkServices::CNetworkServices()
   :
   m_webserver(*new CWebServer),
   m_httpImageHandler(*new CHTTPImageHandler),
+  m_httpImageTransformationHandler(*new CHTTPImageTransformationHandler),
   m_httpVfsHandler(*new CHTTPVfsHandler)
 #ifdef HAS_JSONRPC
   , m_httpJsonRpcHandler(*new CHTTPJsonRpcHandler)
@@ -107,6 +109,7 @@ CNetworkServices::CNetworkServices()
 {
 #ifdef HAS_WEB_SERVER
   CWebServer::RegisterRequestHandler(&m_httpImageHandler);
+  CWebServer::RegisterRequestHandler(&m_httpImageTransformationHandler);
   CWebServer::RegisterRequestHandler(&m_httpVfsHandler);
 #ifdef HAS_JSONRPC
   CWebServer::RegisterRequestHandler(&m_httpJsonRpcHandler);
@@ -123,6 +126,8 @@ CNetworkServices::~CNetworkServices()
 #ifdef HAS_WEB_SERVER
   CWebServer::UnregisterRequestHandler(&m_httpImageHandler);
   delete &m_httpImageHandler;
+  CWebServer::UnregisterRequestHandler(&m_httpImageTransformationHandler);
+  delete &m_httpImageTransformationHandler;
   CWebServer::UnregisterRequestHandler(&m_httpVfsHandler);
   delete &m_httpVfsHandler;
 #ifdef HAS_JSONRPC

--- a/xbmc/network/NetworkServices.h
+++ b/xbmc/network/NetworkServices.h
@@ -25,6 +25,7 @@
 #ifdef HAS_WEB_SERVER
 class CWebServer;
 class CHTTPImageHandler;
+class CHTTPImageTransformationHandler;
 class CHTTPVfsHandler;
 #ifdef HAS_JSONRPC
 class CHTTPJsonRpcHandler;
@@ -98,6 +99,7 @@ private:
 #ifdef HAS_WEB_SERVER
   CWebServer& m_webserver;
   CHTTPImageHandler& m_httpImageHandler;
+  CHTTPImageTransformationHandler& m_httpImageTransformationHandler;
   CHTTPVfsHandler& m_httpVfsHandler;
 #ifdef HAS_JSONRPC
   CHTTPJsonRpcHandler& m_httpJsonRpcHandler;

--- a/xbmc/network/httprequesthandler/HTTPImageTransformationHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPImageTransformationHandler.cpp
@@ -1,0 +1,184 @@
+/*
+ *      Copyright (C) 2012-2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <map>
+
+#include "HTTPImageTransformationHandler.h"
+#include "TextureCacheJob.h"
+#include "URL.h"
+#include "filesystem/ImageFile.h"
+#include "network/WebServer.h"
+#include "utils/Mime.h"
+#include "utils/StringUtils.h"
+#include "utils/URIUtils.h"
+
+#define TRANSFORMATION_OPTION_WIDTH   "width"
+#define TRANSFORMATION_OPTION_HEIGHT  "height"
+
+static const std::string ImageBasePath = "/image/";
+
+CHTTPImageTransformationHandler::CHTTPImageTransformationHandler()
+  : m_url(),
+    m_lastModified(),
+    m_buffer(NULL),
+    m_responseData()
+{ }
+
+CHTTPImageTransformationHandler::CHTTPImageTransformationHandler(const HTTPRequest &request)
+  : IHTTPRequestHandler(request),
+    m_url(),
+    m_lastModified(),
+    m_buffer(NULL),
+    m_responseData()
+{
+  m_url = m_request.url.substr(ImageBasePath.size());
+  if (m_url.empty())
+  {
+    m_response.status = MHD_HTTP_BAD_REQUEST;
+    m_response.type = HTTPError;
+    return;
+  }
+
+  XFILE::CImageFile imageFile;
+  const CURL pathToUrl(m_url);
+  if (!imageFile.Exists(pathToUrl))
+  {
+    m_response.status = MHD_HTTP_NOT_FOUND;
+    m_response.type = HTTPError;
+    return;
+  }
+
+  m_response.type = HTTPMemoryDownloadNoFreeCopy;
+  m_response.status = MHD_HTTP_OK;
+
+  // determine the content type
+  std::string ext = URIUtils::GetExtension(pathToUrl.GetHostName());
+  StringUtils::ToLower(ext);
+  m_response.contentType = CMime::GetMimeType(ext);
+
+  // TODO: determine the maximum age
+
+  // determine the last modified date
+  struct __stat64 statBuffer;
+  if (imageFile.Stat(pathToUrl, &statBuffer) != 0)
+    return;
+
+  struct tm *time;
+#ifdef HAVE_LOCALTIME_R
+  struct tm result = {};
+  time = localtime_r((time_t*)&statBuffer.st_mtime, &result);
+#else
+  time = localtime((time_t *)&statBuffer.st_mtime);
+#endif
+  if (time == NULL)
+    return;
+
+  m_lastModified = *time;
+}
+
+CHTTPImageTransformationHandler::~CHTTPImageTransformationHandler()
+{
+  m_responseData.clear();
+  delete m_buffer;
+  m_buffer = NULL;
+}
+
+bool CHTTPImageTransformationHandler::CanHandleRequest(const HTTPRequest &request)
+{
+  if ((request.method != GET && request.method != HEAD) ||
+      request.url.find(ImageBasePath) != 0 || request.url.size() <= ImageBasePath.size())
+    return false;
+
+  // get the transformation options
+  std::map<std::string, std::string> options;
+  CWebServer::GetRequestHeaderValues(request.connection, MHD_GET_ARGUMENT_KIND, options);
+
+  return (options.find(TRANSFORMATION_OPTION_WIDTH) != options.end() ||
+          options.find(TRANSFORMATION_OPTION_HEIGHT) != options.end());
+}
+
+int CHTTPImageTransformationHandler::HandleRequest()
+{
+  if (m_response.type == HTTPError)
+    return MHD_YES;
+
+  // nothing else to do if this is a HEAD request
+  if (m_request.method == HEAD)
+  {
+    m_response.status = MHD_HTTP_OK;
+    m_response.type = HTTPMemoryDownloadNoFreeNoCopy;
+
+    return MHD_YES;
+  }
+
+  // get the transformation options
+  std::map<std::string, std::string> options;
+  CWebServer::GetRequestHeaderValues(m_request.connection, MHD_GET_ARGUMENT_KIND, options);
+
+  std::vector<std::string> urlOptions;
+  std::map<std::string, std::string>::const_iterator option = options.find(TRANSFORMATION_OPTION_WIDTH);
+  if (option != options.end())
+    urlOptions.push_back(TRANSFORMATION_OPTION_WIDTH "=" + option->second);
+
+  option = options.find(TRANSFORMATION_OPTION_HEIGHT);
+  if (option != options.end())
+    urlOptions.push_back(TRANSFORMATION_OPTION_HEIGHT "=" + option->second);
+
+  std::string imagePath = m_url;
+  if (!urlOptions.empty())
+  {
+    imagePath += "?";
+    imagePath += StringUtils::Join(urlOptions, "&");
+  }
+
+  // resize the image into the local buffer
+  size_t bufferSize;
+  if (!CTextureCacheJob::ResizeTexture(imagePath, m_buffer, bufferSize))
+  {
+    m_response.status = MHD_HTTP_INTERNAL_SERVER_ERROR;
+    m_response.type = HTTPError;
+
+    return MHD_YES;
+  }
+
+  // store the size of the image
+  m_response.totalLength = bufferSize;
+
+  // nothing else to do if the request is not ranged
+  if (!GetRequestedRanges(m_response.totalLength))
+  {
+    m_responseData.push_back(CHttpResponseRange(m_buffer, 0, m_response.totalLength - 1));
+    return MHD_YES;
+  }
+
+  for (HttpRanges::const_iterator range = m_request.ranges.Begin(); range != m_request.ranges.End(); ++range)
+    m_responseData.push_back(CHttpResponseRange(m_buffer + range->GetFirstPosition(), range->GetFirstPosition(), range->GetLastPosition()));
+
+  return MHD_YES;
+}
+
+bool CHTTPImageTransformationHandler::GetLastModifiedDate(CDateTime &lastModified) const
+{
+  if (!m_lastModified.IsValid())
+    return false;
+
+  lastModified = m_lastModified;
+  return true;
+}

--- a/xbmc/network/httprequesthandler/HTTPImageTransformationHandler.h
+++ b/xbmc/network/httprequesthandler/HTTPImageTransformationHandler.h
@@ -1,0 +1,57 @@
+#pragma once
+/*
+ *      Copyright (C) 2015 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <stdint.h>
+#include <string>
+
+#include "XBDateTime.h"
+#include "network/httprequesthandler/IHTTPRequestHandler.h"
+
+class CHTTPImageTransformationHandler : public IHTTPRequestHandler
+{
+public:
+  CHTTPImageTransformationHandler();
+  virtual ~CHTTPImageTransformationHandler();
+
+  virtual IHTTPRequestHandler* Create(const HTTPRequest &request) { return new CHTTPImageTransformationHandler(request); }
+  virtual bool CanHandleRequest(const HTTPRequest &request);
+
+  virtual int HandleRequest();
+
+  virtual bool CanHandleRanges() const { return true; }
+  virtual bool CanBeCached() const { return true; }
+  virtual bool GetLastModifiedDate(CDateTime &lastModified) const;
+
+  virtual HttpResponseRanges GetResponseData() const { return m_responseData; }
+
+  // priority must be higher than the one of CHTTPImageHandler
+  virtual int GetPriority() const { return 3; }
+
+protected:
+  explicit CHTTPImageTransformationHandler(const HTTPRequest &request);
+
+private:
+  std::string m_url;
+  CDateTime m_lastModified;
+
+  uint8_t* m_buffer;
+  HttpResponseRanges m_responseData;
+};

--- a/xbmc/network/httprequesthandler/Makefile
+++ b/xbmc/network/httprequesthandler/Makefile
@@ -1,5 +1,6 @@
 SRCS=HTTPFileHandler.cpp \
      HTTPImageHandler.cpp \
+     HTTPImageTransformationHandler.cpp \
      HTTPJsonRpcHandler.cpp \
      HTTPVfsHandler.cpp \
      HTTPWebinterfaceAddonsHandler.cpp \

--- a/xbmc/pictures/Picture.cpp
+++ b/xbmc/pictures/Picture.cpp
@@ -43,6 +43,31 @@ extern "C" {
 
 using namespace XFILE;
 
+bool CPicture::GetThumbnailFromSurface(const unsigned char* buffer, int width, int height, int stride, const std::string &thumbFile, uint8_t* &result, size_t& result_size)
+{
+  unsigned char *thumb = NULL;
+  unsigned int thumbsize = 0;
+
+  // get an image handler
+  IImage* image = ImageFactory::CreateLoader(thumbFile);
+  if (image == NULL || !image->CreateThumbnailFromSurface((BYTE *)buffer, width, height, XB_FMT_A8R8G8B8, stride, thumbFile.c_str(), thumb, thumbsize))
+  {
+    delete image;
+    return false;
+  }
+
+  // copy the resulting buffer
+  result_size = thumbsize;
+  result = new uint8_t[result_size];
+  memcpy(result, thumb, result_size);
+
+  // release the image buffer and the image handler
+  image->ReleaseThumbnailBuffer();
+  delete image;
+
+  return true;
+}
+
 bool CPicture::CreateThumbnailFromSurface(const unsigned char *buffer, int width, int height, int stride, const std::string &thumbFile)
 {
   CLog::Log(LOGDEBUG, "cached image '%s' size %dx%d", thumbFile.c_str(), width, height);
@@ -98,6 +123,75 @@ bool CThumbnailWriter::DoWork()
 
   delete [] m_buffer;
   m_buffer = NULL;
+
+  return success;
+}
+
+bool CPicture::ResizeTexture(const std::string &image, CBaseTexture *texture, uint32_t &dest_width, uint32_t &dest_height, uint8_t* &result, size_t& result_size)
+{
+  if (image.empty() || texture == NULL)
+    return false;
+
+  return ResizeTexture(image, texture->GetPixels(), texture->GetWidth(), texture->GetHeight(), texture->GetPitch(),
+                       dest_width, dest_height, result, result_size);
+}
+
+bool CPicture::ResizeTexture(const std::string &image, uint8_t *pixels, uint32_t width, uint32_t height, uint32_t pitch, uint32_t &dest_width, uint32_t &dest_height, uint8_t* &result, size_t& result_size)
+{
+  if (image.empty() || pixels == NULL)
+    return false;
+
+  dest_width = std::min(width, dest_width);
+  dest_height = std::min(height, dest_height);
+
+  // if no max width or height is specified, don't resize
+  if (dest_width == 0 && dest_height == 0)
+  {
+    dest_width = width;
+    dest_height = height;
+  }
+  else if (dest_width == 0)
+  {
+    double factor = (double)dest_height / (double)height;
+    dest_width = (uint32_t)(width * factor);
+  }
+  else if (dest_height == 0)
+  {
+    double factor = (double)dest_width / (double)width;
+    dest_height = (uint32_t)(height * factor);
+  }
+
+  // nothing special to do if the dimensions already match
+  if (dest_width >= width || dest_height >= height)
+    return GetThumbnailFromSurface(pixels, dest_width, dest_height, pitch, image, result, result_size);
+
+  // create a buffer large enough for the resulting image
+  GetScale(width, height, dest_width, dest_height);
+
+  uint8_t *buffer = new uint8_t[dest_width * dest_height * sizeof(uint32_t)];
+  if (buffer == NULL)
+  {
+    result = NULL;
+    result_size = 0;
+    return false;
+  }
+
+  if (!ScaleImage(pixels, width, height, pitch, buffer, dest_width, dest_height, dest_width * sizeof(uint32_t)))
+  {
+    delete[] buffer;
+    result = NULL;
+    result_size = 0;
+    return false;
+  }
+
+  bool success = GetThumbnailFromSurface(buffer, dest_width, dest_height, dest_width * sizeof(uint32_t), image, result, result_size);
+  delete[] buffer;
+
+  if (!success)
+  {
+    result = NULL;
+    result_size = 0;
+  }
 
   return success;
 }

--- a/xbmc/pictures/Picture.h
+++ b/xbmc/pictures/Picture.h
@@ -27,6 +27,7 @@ class CBaseTexture;
 class CPicture
 {
 public:
+  static bool GetThumbnailFromSurface(const unsigned char* buffer, int width, int height, int stride, const std::string &thumbFile, uint8_t* &result, size_t& result_size);
   static bool CreateThumbnailFromSurface(const unsigned char* buffer, int width, int height, int stride, const std::string &thumbFile);
 
   /*! \brief Create a tiled thumb of the given files
@@ -34,6 +35,9 @@ public:
    \param thumb the filename of the thumb
    */
   static bool CreateTiledThumb(const std::vector<std::string> &files, const std::string &thumb);
+
+  static bool ResizeTexture(const std::string &image, CBaseTexture *texture, uint32_t &dest_width, uint32_t &dest_height, uint8_t* &result, size_t& result_size);
+  static bool ResizeTexture(const std::string &image, uint8_t *pixels, uint32_t width, uint32_t height, uint32_t pitch, uint32_t &dest_width, uint32_t &dest_height, uint8_t* &result, size_t& result_size);
 
   /*! \brief Cache a texture, resizing, rotating and flipping as needed, and saving as a JPG or PNG
    \param texture a pointer to a CBaseTexture


### PR DESCRIPTION
This work is based on #6201 and I'm only putting it up as a PR already because I would like to get feedback on how best to implement the image resizing. What I/we want to be able to do is let people call a URL on our webserver like
`http://localhost/transformation/image/<some urlencoded image:// path>?width=720`
to retrieve an image (whose `image://` URL has been exposed by JSON-RPC) in a specific size. This is mainly helpful for webinterfaces and remote applications which have limited screen size and can't make any use of a Full HD fanart image.

The webserver implementation side is pretty straight forward and supports all features like `Last-Modified`,  `Content-Type`, cache and range handling (thanks to the refactor in #6201).

The image resizing implementation is the simplest I came across when looking into the texture cache but it e.g. doesn't support the special `OMXImage` implementation and I have no idea if it's the right/best way to go and how fast/slow it is. So any feedback on that is very welcome.
