### PR TITLE
Optimize CPVRRecording. No more copies, just shared pointers.

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -62,6 +62,8 @@
 #include "cores/paplayer/ASAPCodec.h"
 #endif
 
+#include <assert.h>
+
 using namespace std;
 using namespace XFILE;
 using namespace PLAYLIST;
@@ -173,16 +175,17 @@ CFileItem::CFileItem(const CPVRChannel& channel)
   FillInMimeType(false);
 }
 
-CFileItem::CFileItem(const CPVRRecording& record)
+CFileItem::CFileItem(const CPVRRecordingPtr& record)
 {
+  assert(record.get());
+
   Initialize();
 
-  m_strPath = record.m_strFileNameAndPath;
   m_bIsFolder = false;
-  *GetPVRRecordingInfoTag() = record;
-  SetLabel(record.m_strTitle);
-  m_strLabel2 = record.m_strPlot;
-
+  m_pvrRecordingInfoTag = record;
+  m_strPath = record->m_strFileNameAndPath;
+  SetLabel(record->m_strTitle);
+  m_strLabel2 = record->m_strPlot;
   FillInMimeType(false);
 }
 
@@ -230,7 +233,6 @@ CFileItem::CFileItem(const CFileItem& item): CGUIListItem()
   m_musicInfoTag = NULL;
   m_videoInfoTag = NULL;
   m_pvrChannelInfoTag = NULL;
-  m_pvrRecordingInfoTag = NULL;
   m_pvrTimerInfoTag = NULL;
   m_pictureInfoTag = NULL;
   *this = item;
@@ -315,14 +317,12 @@ CFileItem::~CFileItem(void)
   delete m_musicInfoTag;
   delete m_videoInfoTag;
   delete m_pvrChannelInfoTag;
-  delete m_pvrRecordingInfoTag;
   delete m_pvrTimerInfoTag;
   delete m_pictureInfoTag;
 
   m_musicInfoTag = NULL;
   m_videoInfoTag = NULL;
   m_pvrChannelInfoTag = NULL;
-  m_pvrRecordingInfoTag = NULL;
   m_pvrTimerInfoTag = NULL;
   m_pictureInfoTag = NULL;
 }
@@ -382,19 +382,10 @@ const CFileItem& CFileItem::operator=(const CFileItem& item)
     m_pvrChannelInfoTag = NULL;
   }
 
-  if (item.HasPVRRecordingInfoTag())
-  {
-    m_pvrRecordingInfoTag = GetPVRRecordingInfoTag();
-    if (m_pvrRecordingInfoTag)
-      *m_pvrRecordingInfoTag = *item.m_pvrRecordingInfoTag;
-  }
+  if (item.m_pvrRecordingInfoTag)
+    m_pvrRecordingInfoTag = item.m_pvrRecordingInfoTag;
   else
-  {
-    if (m_pvrRecordingInfoTag)
-      delete m_pvrRecordingInfoTag;
-
-    m_pvrRecordingInfoTag = NULL;
-  }
+    m_pvrRecordingInfoTag.reset();
 
   if (item.HasPVRTimerInfoTag())
   {
@@ -446,7 +437,6 @@ void CFileItem::Initialize()
   m_musicInfoTag = NULL;
   m_videoInfoTag = NULL;
   m_pvrChannelInfoTag = NULL;
-  m_pvrRecordingInfoTag = NULL;
   m_pvrTimerInfoTag = NULL;
   m_pictureInfoTag = NULL;
   m_bLabelPreformated=false;
@@ -490,8 +480,7 @@ void CFileItem::Reset()
   m_epgInfoTag.reset();
   delete m_pvrChannelInfoTag;
   m_pvrChannelInfoTag=NULL;
-  delete m_pvrRecordingInfoTag;
-  m_pvrRecordingInfoTag=NULL;
+  m_pvrRecordingInfoTag.reset();
   delete m_pvrTimerInfoTag;
   m_pvrTimerInfoTag=NULL;
   delete m_pictureInfoTag;
@@ -1394,8 +1383,8 @@ void CFileItem::UpdateInfo(const CFileItem &item, bool replaceLabels /*=true*/)
   { // copy info across (TODO: premiered info is normally stored in m_dateTime by the db)
     *GetVideoInfoTag() = *item.GetVideoInfoTag();
     // preferably use some information from PVR info tag if available
-    if (HasPVRRecordingInfoTag())
-      GetPVRRecordingInfoTag()->CopyClientInfo(GetVideoInfoTag());
+    if (m_pvrRecordingInfoTag)
+      m_pvrRecordingInfoTag->CopyClientInfo(GetVideoInfoTag());
     SetOverlayImage(ICON_OVERLAY_UNWATCHED, GetVideoInfoTag()->m_playCount > 0);
     SetInvalid();
   }
@@ -3114,14 +3103,6 @@ CPVRChannel* CFileItem::GetPVRChannelInfoTag()
   return m_pvrChannelInfoTag;
 }
 
-CPVRRecording* CFileItem::GetPVRRecordingInfoTag()
-{
-  if (!m_pvrRecordingInfoTag)
-    m_pvrRecordingInfoTag = new CPVRRecording;
-
-  return m_pvrRecordingInfoTag;
-}
-
 CPVRTimerInfoTag* CFileItem::GetPVRTimerInfoTag()
 {
   if (!m_pvrTimerInfoTag)
@@ -3255,15 +3236,15 @@ int CFileItem::GetVideoContentType() const
 bool CFileItem::IsResumePointSet() const
 {
   return (HasVideoInfoTag() && GetVideoInfoTag()->m_resumePoint.IsSet()) ||
-      (HasPVRRecordingInfoTag() && GetPVRRecordingInfoTag()->GetLastPlayedPosition() > 0);
+      (m_pvrRecordingInfoTag && m_pvrRecordingInfoTag->GetLastPlayedPosition() > 0);
 }
 
 double CFileItem::GetCurrentResumeTime() const
 {
-  if (HasPVRRecordingInfoTag())
+  if (m_pvrRecordingInfoTag)
   {
     // This will retrieve 'fresh' resume information from the PVR server
-    int rc = GetPVRRecordingInfoTag()->GetLastPlayedPosition();
+    int rc = m_pvrRecordingInfoTag->GetLastPlayedPosition();
     if (rc > 0)
       return rc;
     // Fall through to default value

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -51,6 +51,7 @@ namespace PVR
   class CPVRChannel;
   class CPVRRecording;
   class CPVRTimerInfoTag;
+  typedef boost::shared_ptr<PVR::CPVRRecording> CPVRRecordingPtr;
 }
 class CPictureInfoTag;
 
@@ -103,7 +104,7 @@ public:
   CFileItem(const CVideoInfoTag& movie);
   CFileItem(const EPG::CEpgInfoTagPtr& tag);
   CFileItem(const PVR::CPVRChannel& channel);
-  CFileItem(const PVR::CPVRRecording& record);
+  CFileItem(const PVR::CPVRRecordingPtr& record);
   CFileItem(const PVR::CPVRTimerInfoTag& timer);
   CFileItem(const CMediaSource& share);
   virtual ~CFileItem(void);
@@ -286,12 +287,10 @@ public:
 
   inline bool HasPVRRecordingInfoTag() const
   {
-    return m_pvrRecordingInfoTag != NULL;
+    return m_pvrRecordingInfoTag.get() != NULL;
   }
 
-  PVR::CPVRRecording* GetPVRRecordingInfoTag();
-
-  inline const PVR::CPVRRecording* GetPVRRecordingInfoTag() const
+  inline const PVR::CPVRRecordingPtr GetPVRRecordingInfoTag() const
   {
     return m_pvrRecordingInfoTag;
   }
@@ -485,7 +484,7 @@ private:
   CVideoInfoTag* m_videoInfoTag;
   EPG::CEpgInfoTagPtr m_epgInfoTag;
   PVR::CPVRChannel* m_pvrChannelInfoTag;
-  PVR::CPVRRecording* m_pvrRecordingInfoTag;
+  PVR::CPVRRecordingPtr m_pvrRecordingInfoTag;
   PVR::CPVRTimerInfoTag * m_pvrTimerInfoTag;
   CPictureInfoTag* m_pictureInfoTag;
   bool m_bIsAlbum;

--- a/xbmc/addons/AddonCallbacksPVR.cpp
+++ b/xbmc/addons/AddonCallbacksPVR.cpp
@@ -191,7 +191,7 @@ void CAddonCallbacksPVR::PVRTransferRecordingEntry(void *addonData, const ADDON_
   }
 
   /* transfer this entry to the recordings container */
-  CPVRRecording transferRecording(*recording, client->GetID());
+  CPVRRecordingPtr transferRecording(new CPVRRecording(*recording, client->GetID()));
   xbmcRecordings->UpdateFromClient(transferRecording);
 }
 

--- a/xbmc/epg/EpgSearchFilter.cpp
+++ b/xbmc/epg/EpgSearchFilter.cpp
@@ -205,9 +205,10 @@ int EpgSearchFilter::FilterRecordings(CFileItemList &results)
   g_PVRRecordings->GetAll(recordings);
 
   // TODO inefficient!
+  CPVRRecordingPtr recording;
   for (int iRecordingPtr = 0; iRecordingPtr < recordings.Size(); iRecordingPtr++)
   {
-    CPVRRecording *recording = recordings.Get(iRecordingPtr)->GetPVRRecordingInfoTag();
+    recording = recordings.Get(iRecordingPtr)->GetPVRRecordingInfoTag();
     if (!recording)
       continue;
 

--- a/xbmc/filesystem/PVRFile.cpp
+++ b/xbmc/filesystem/PVRFile.cpp
@@ -75,7 +75,7 @@ bool CPVRFile::Open(const CURL& url)
     CFileItemPtr tag = g_PVRRecordings->GetByPath(strURL);
     if (tag && tag->HasPVRRecordingInfoTag())
     {
-      if (!g_PVRManager.OpenRecordedStream(*tag->GetPVRRecordingInfoTag()))
+      if (!g_PVRManager.OpenRecordedStream(tag->GetPVRRecordingInfoTag()))
         return false;
 
       m_isPlayRecording = true;

--- a/xbmc/interfaces/json-rpc/FileItemHandler.cpp
+++ b/xbmc/interfaces/json-rpc/FileItemHandler.cpp
@@ -359,7 +359,7 @@ void CFileItemHandler::HandleFileItem(const char *ID, bool allowFile, const char
     if (item->HasEPGInfoTag())
       FillDetails(item->GetEPGInfoTag().get(), item, fields, object, thumbLoader);
     if (item->HasPVRRecordingInfoTag())
-      FillDetails(item->GetPVRRecordingInfoTag(), item, fields, object, thumbLoader);
+      FillDetails(item->GetPVRRecordingInfoTag().get(), item, fields, object, thumbLoader);
     if (item->HasPVRTimerInfoTag())
       FillDetails(item->GetPVRTimerInfoTag(), item, fields, object, thumbLoader);
     if (item->HasVideoInfoTag())

--- a/xbmc/pvr/PVRGUIInfo.cpp
+++ b/xbmc/pvr/PVRGUIInfo.cpp
@@ -872,7 +872,6 @@ CEpgInfoTagPtr CPVRGUIInfo::GetPlayingTag() const
 void CPVRGUIInfo::UpdatePlayingTag(void)
 {
   CPVRChannelPtr currentChannel;
-  CPVRRecording recording;
   if (g_PVRManager.GetCurrentChannel(currentChannel))
   {
     CEpgInfoTagPtr epgTag(GetPlayingTag());
@@ -896,10 +895,14 @@ void CPVRGUIInfo::UpdatePlayingTag(void)
       g_PVRManager.UpdateCurrentFile();
     }
   }
-  else if (g_PVRClients->GetPlayingRecording(recording))
+  else
   {
-    ResetPlayingTag();
-    m_iDuration = recording.GetDuration() * 1000;
+    CPVRRecordingPtr recording(g_PVRClients->GetPlayingRecording());
+    if (recording)
+    {
+      ResetPlayingTag();
+      m_iDuration = recording->GetDuration() * 1000;
+    }
   }
 }
 

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -1048,7 +1048,7 @@ bool CPVRManager::OpenLiveStream(const CFileItem &channel)
   return bReturn;
 }
 
-bool CPVRManager::OpenRecordedStream(const CPVRRecording &tag)
+bool CPVRManager::OpenRecordedStream(const CPVRRecordingPtr &tag)
 {
   bool bReturn = false;
   CSingleLock lock(m_critSection);

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -28,6 +28,7 @@
 #include "utils/JobManager.h"
 #include "utils/Observer.h"
 #include "interfaces/IAnnouncer.h"
+#include "pvr/recordings/PVRRecording.h"
 
 class CGUIDialogProgressBarHandle;
 class CStopWatch;
@@ -46,7 +47,6 @@ namespace PVR
   typedef boost::shared_ptr<PVR::CPVRChannel> CPVRChannelPtr;
   class CPVRChannelGroupsContainer;
   class CPVRChannelGroup;
-  class CPVRRecording;
   class CPVRRecordings;
   class CPVRTimers;
   class CPVRGUIInfo;
@@ -319,7 +319,7 @@ namespace PVR
      * @param tag The recording to open.
      * @return True if the stream was opened, false otherwise.
      */
-    bool OpenRecordedStream(const CPVRRecording &tag);
+    bool OpenRecordedStream(const CPVRRecordingPtr &tag);
 
     /*!
     * @brief Try to playback the given file item

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -1365,15 +1365,13 @@ bool CPVRClient::GetPlayingChannel(CPVRChannelPtr &channel) const
   return false;
 }
 
-bool CPVRClient::GetPlayingRecording(CPVRRecording &recording) const
+CPVRRecordingPtr CPVRClient::GetPlayingRecording(void) const
 {
   CSingleLock lock(m_critSection);
   if (m_bReadyToUse && m_bIsPlayingRecording)
-  {
-    recording = m_playingRecording;
-    return true;
-  }
-  return false;
+    return m_playingRecording;
+
+  return CPVRRecordingPtr();
 }
 
 bool CPVRClient::OpenStream(const CPVRChannel &channel, bool bIsSwitchingChannel)
@@ -1426,7 +1424,7 @@ bool CPVRClient::OpenStream(const CPVRChannel &channel, bool bIsSwitchingChannel
   return bReturn;
 }
 
-bool CPVRClient::OpenStream(const CPVRRecording &recording)
+bool CPVRClient::OpenStream(const CPVRRecordingPtr &recording)
 {
   bool bReturn(false);
   CloseStream();
@@ -1434,7 +1432,7 @@ bool CPVRClient::OpenStream(const CPVRRecording &recording)
   if (m_bReadyToUse && m_addonCapabilities.bSupportsRecordings)
   {
     PVR_RECORDING tag;
-    WriteClientRecordingInfo(recording, tag);
+    WriteClientRecordingInfo(*recording, tag);
 
     try
     {

--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -444,7 +444,7 @@ namespace PVR
      * @param recording The recording to open.
      * @return True if the stream has been opened succesfully, false otherwise.
      */
-    bool OpenStream(const CPVRRecording &recording);
+    bool OpenStream(const CPVRRecordingPtr &recording);
 
     //@}
     /** @name PVR demultiplexer methods */
@@ -494,7 +494,7 @@ namespace PVR
     bool IsPlayingRecording(void) const;
     bool IsPlaying(void) const;
     bool GetPlayingChannel(CPVRChannelPtr &channel) const;
-    bool GetPlayingRecording(CPVRRecording &recording) const;
+    CPVRRecordingPtr GetPlayingRecording(void) const;
 
     static const char *ToString(const PVR_ERROR error);
 
@@ -605,10 +605,10 @@ namespace PVR
 
     CCriticalSection m_critSection;
 
-    bool           m_bIsPlayingTV;
-    CPVRChannelPtr m_playingChannel;
-    bool           m_bIsPlayingRecording;
-    CPVRRecording  m_playingRecording;
+    bool                m_bIsPlayingTV;
+    CPVRChannelPtr      m_playingChannel;
+    bool                m_bIsPlayingRecording;
+    CPVRRecordingPtr    m_playingRecording;
     ADDON::AddonVersion m_apiVersion;
   };
 }

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -288,14 +288,13 @@ namespace PVR
      * @param tag The recording to start playing.
      * @return True if the stream was opened successfully, false otherwise.
      */
-    bool OpenStream(const CPVRRecording &tag);
+    bool OpenStream(const CPVRRecordingPtr &tag);
 
     /*!
      * @brief Get the recordings that is currently playing.
-     * @param recording A copy of the recording that is currently playing.
-     * @return True if a recording is playing, false otherwise.
+     * @return The recording that is currently playing, NULL otherwise.
      */
-    bool GetPlayingRecording(CPVRRecording &recording) const;
+    CPVRRecordingPtr GetPlayingRecording(void) const;
 
     //@}
 

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
@@ -176,7 +176,7 @@ bool CGUIDialogPVRGuideInfo::OnClickButtonSwitch(CGUIMessage &message)
     if (epgTag)
     {
       if (epgTag->HasRecording())
-        ret = g_application.PlayFile(CFileItem(*epgTag->Recording()));
+        ret = g_application.PlayFile(CFileItem(epgTag->Recording()));
       else if (epgTag->HasPVRChannel())
         ret = g_application.PlayFile(CFileItem(*epgTag->ChannelTag()));
     }

--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -232,10 +232,7 @@ void CPVRRecording::UpdateMetadata(CVideoDatabase &db)
   if (!supportsPlayCount || !supportsLastPlayed)
   {
     if (!supportsPlayCount)
-    {
-       CFileItem pFileItem(*this);
-       m_playCount = db.GetPlayCount(pFileItem);
-    }
+      m_playCount = db.GetPlayCount(m_strFileNameAndPath);
 
     if (!supportsLastPlayed)
       db.GetResumeBookMark(m_strFileNameAndPath, m_resumePoint);

--- a/xbmc/pvr/recordings/PVRRecording.h
+++ b/xbmc/pvr/recordings/PVRRecording.h
@@ -84,6 +84,12 @@ namespace PVR
 
     CPVRRecording(void);
     CPVRRecording(const PVR_RECORDING &recording, unsigned int iClientId);
+
+  private:
+    CPVRRecording(const CPVRRecording &tag); // intentionally not implemented.
+    CPVRRecording &operator =(const CPVRRecording &other); // intentionally not implemented.
+
+  public:
     virtual ~CPVRRecording() {};
 
     bool operator ==(const CPVRRecording& right) const;

--- a/xbmc/pvr/recordings/PVRRecordings.h
+++ b/xbmc/pvr/recordings/PVRRecordings.h
@@ -48,7 +48,6 @@ namespace PVR
     virtual const std::string GetDirectoryFromPath(const std::string &strPath, const std::string &strBase) const;
     virtual bool IsDirectoryMember(const std::string &strDirectory, const std::string &strEntryDirectory) const;
     virtual void GetSubDirectories(const std::string &strBase, CFileItemList *results);
-    CPVRRecordingPtr GetByFileItem(const CFileItem &item) const;
 
     /**
      * @brief recursively deletes all recordings in the specified directory
@@ -65,7 +64,7 @@ namespace PVR
     int Load();
     void Unload();
     void Clear();
-    void UpdateFromClient(const CPVRRecording &tag);
+    void UpdateFromClient(const CPVRRecordingPtr &tag);
 
     /**
      * @brief refresh the recordings list from the clients.

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -549,7 +549,7 @@ bool CGUIWindowPVRBase::ActionPlayEpg(CFileItem *item)
 
   CFileItem fileItem;
   if (epgTag->HasRecording())
-    fileItem = CFileItem(*epgTag->Recording());
+    fileItem = CFileItem(epgTag->Recording());
   else
     fileItem = CFileItem(*channel);
 

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -342,14 +342,17 @@ bool CGUIWindowPVRRecordings::OnContextButtonRename(CFileItem *item, CONTEXT_BUT
 
   if (button == CONTEXT_BUTTON_RENAME)
   {
-    bReturn = true;
-
-    CPVRRecording *recording = item->GetPVRRecordingInfoTag();
-    std::string strNewName = recording->m_strTitle;
-    if (CGUIKeyboardFactory::ShowAndGetInput(strNewName, g_localizeStrings.Get(19041), false))
+    CPVRRecordingPtr recording = item->GetPVRRecordingInfoTag();
+    if (recording)
     {
-      if (g_PVRRecordings->RenameRecording(*item, strNewName))
-        Refresh(true);
+      bReturn = true;
+
+      std::string strNewName = recording->m_strTitle;
+      if (CGUIKeyboardFactory::ShowAndGetInput(strNewName, g_localizeStrings.Get(19041), false))
+      {
+        if (g_PVRRecordings->RenameRecording(*item, strNewName))
+          Refresh(true);
+      }
     }
   }
 

--- a/xbmc/utils/SaveFileStateJob.cpp
+++ b/xbmc/utils/SaveFileStateJob.cpp
@@ -105,7 +105,7 @@ bool CSaveFileStateJob::DoWork()
             // PVR: Set/clear recording's resume bookmark on the backend (if supported)
             if (m_item.HasPVRRecordingInfoTag())
             {
-              PVR::CPVRRecording *recording = m_item.GetPVRRecordingInfoTag();
+              PVR::CPVRRecordingPtr recording = m_item.GetPVRRecordingInfoTag();
               recording->SetLastPlayedPosition(m_bookmark.timeInSeconds <= 0.0f ? 0 : (int)m_bookmark.timeInSeconds);
               recording->m_resumePoint = m_bookmark;
             }

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -4727,10 +4727,9 @@ bool CVideoDatabase::GetPlayCounts(const std::string &strPath, CFileItemList &it
   return false;
 }
 
-int CVideoDatabase::GetPlayCount(const CFileItem &item)
+int CVideoDatabase::GetPlayCount(int iFileId)
 {
-  int id = GetFileId(item);
-  if (id < 0)
+  if (iFileId < 0)
     return 0;  // not in db, so not watched
 
   try
@@ -4739,7 +4738,7 @@ int CVideoDatabase::GetPlayCount(const CFileItem &item)
     if (NULL == m_pDB.get()) return -1;
     if (NULL == m_pDS.get()) return -1;
 
-    std::string strSQL = PrepareSQL("select playCount from files WHERE idFile=%i", id);
+    std::string strSQL = PrepareSQL("select playCount from files WHERE idFile=%i", iFileId);
     int count = 0;
     if (m_pDS->query(strSQL.c_str()))
     {
@@ -4755,6 +4754,16 @@ int CVideoDatabase::GetPlayCount(const CFileItem &item)
     CLog::Log(LOGERROR, "%s failed", __FUNCTION__);
   }
   return -1;
+}
+
+int CVideoDatabase::GetPlayCount(const std::string& strFilenameAndPath)
+{
+  return GetPlayCount(GetFileId(strFilenameAndPath));
+}
+
+int CVideoDatabase::GetPlayCount(const CFileItem &item)
+{
+  return GetPlayCount(GetFileId(item));
 }
 
 void CVideoDatabase::UpdateFanart(const CFileItem &item, VIDEODB_CONTENT_TYPE type)

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -408,6 +408,13 @@ public:
    */
   int GetPlayCount(const CFileItem &item);
 
+  /*! \brief Get the playcount of a filename and path
+   \param strFilenameAndPath filename and path to get the playcount for
+   \return the playcount of the item, or -1 on error
+   \sa SetPlayCount, IncrementPlayCount, GetPlayCounts
+   */
+  int GetPlayCount(const std::string& strFilenameAndPath);
+
   /*! \brief Update the last played time of an item
    Updates the last played date
    \param item CFileItem to update the last played time for
@@ -864,6 +871,13 @@ private:
    \param shows whether this path is from a tvshow (defaults to false)
    */
   bool LookupByFolders(const std::string &path, bool shows = false);
+
+  /*! \brief Get the playcount for a file id
+   \param iFileId file id to get the playcount for
+   \return the playcount of the item, or -1 on error
+   \sa SetPlayCount, IncrementPlayCount, GetPlayCounts
+   */
+  int GetPlayCount(int iFileId);
 
   virtual int GetMinSchemaVersion() const { return 60; };
   virtual int GetSchemaVersion() const;


### PR DESCRIPTION
Followup to #5763. Same implementation approach...

Citing myself from #5763: "Next after this PR got merged will be optimization of CPVRRecording, which will by the way fix the issues with watched/unwatched state in recording window. @Jalle19 recently introduced a hack (#5613) that fixes immediate display of watched/unwatched in the recording window after changing the state via the respective context menu entries but that does not fix immediate display of watched state after a recording has been watched completely. The state will be set correctly, but it gets not displayed in the recording window, because the state is set at the wrong CPVRRecording instance. Eleminating all CPVRRecording copies will make Sam's hack obsolete (Recently introduced CPVRRecording::GetByFileItem which obtains the original PVRRecording belonging to a copy no longer needed than)."
