### PR TITLE
Fix unit tests using URIUtils::IsRemote() in one way or another

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -595,7 +595,7 @@ void CApplication::Preflight()
 #endif
 }
 
-bool CApplication::Create()
+bool CApplication::SetupNetwork()
 {
 #if defined(HAS_LINUX_NETWORK)
   m_network = new CNetworkLinux();
@@ -605,6 +605,12 @@ bool CApplication::Create()
   m_network = new CNetwork();
 #endif
 
+  return m_network != NULL;
+}
+
+bool CApplication::Create()
+{
+  SetupNetwork();
   Preflight();
 
   for (int i = RES_HDTV_1080i; i <= RES_PAL60_16x9; i++)

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -196,6 +196,7 @@ public:
   void CheckScreenSaverAndDPMS();
   void CheckPlayingProgress();
   void ActivateScreenSaver(bool forceType = false);
+  bool SetupNetwork();
   void CloseNetworkShares();
 
   void ShowAppMigrationMessage();

--- a/xbmc/test/TestBasicEnvironment.cpp
+++ b/xbmc/test/TestBasicEnvironment.cpp
@@ -27,6 +27,7 @@
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "Util.h"
+#include "Application.h"
 
 #include <cstdio>
 #include <cstdlib>
@@ -42,6 +43,9 @@ void TestBasicEnvironment::SetUp()
    * in xbmcutil::GlobalsSingleton<CAdvancedSettings>::getInstance().
    */
   g_advancedSettings.Initialize();
+
+  // Need to configure the network as some tests access the network member
+  g_application.SetupNetwork();
 
   if (!CXBMCTestUtils::Instance().SetReferenceFileBasePath())
     SetUpError();


### PR DESCRIPTION
@notspiff noticed that a lot of our unit tests were broken since `URIUtils::IsRemote()` has been changed to interact with the network manager. Since the network manager wasn't setup when running unit tests `URIUtils::IsRemote()` didn't work properly anymore and this remedies the situation.

A big thank you to @notspiff and an even bigger reminder to everyone to (please) run the unit tests during development (and to write unit tests for stuff you add).
