### PR TITLE
Remove xrandr from application

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -292,9 +292,6 @@
 #include <shlobj.h>
 #include "win32util.h"
 #endif
-#ifdef HAS_XRANDR
-#include "windowing/X11/XRandR.h"
-#endif
 
 #ifdef TARGET_DARWIN_OSX
 #include "osx/CocoaInterface.h"
@@ -745,10 +742,6 @@ bool CApplication::Create()
 
   std::string strExecutablePath;
   CUtil::GetHomePath(strExecutablePath);
-
-#ifdef HAS_XRANDR
-  g_xrandr.LoadCustomModeLinesToAllOutputs();
-#endif
 
   // for python scripts that check the OS
 #if defined(TARGET_DARWIN)


### PR DESCRIPTION
Headless does not start X11, so querying xrandr outside of windowing is wrong. And according to e0026f0fe3aada179d487c2530e4554b328144a6 the function seems to be old and non-working, so remove?
