### PR TITLE
[mediawindow] let CGUIMediaWindow::OnMessage handle ACTION_SWITCH_PLAYER

### DIFF
--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -307,6 +307,15 @@ bool CGUIMediaWindow::OnMessage(CGUIMessage& message)
           OnPopupMenu(iItem);
           return true;
         }
+        else if (iAction == ACTION_SWITCH_PLAYER)
+        {
+          VECPLAYERCORES cores;
+          CPlayerCoreFactory::Get().GetPlayers(*GetCurrentListItem(), cores);
+          g_application.m_eForcedNextPlayer = CPlayerCoreFactory::Get().SelectPlayerDialog(cores);
+          if( g_application.m_eForcedNextPlayer != EPC_NONE )
+            OnPlayMedia(iItem);
+          return true;
+        }
       }
     }
     break;


### PR DESCRIPTION
This tries to fix an issue reported on the forums where the SwitchPlayer action (ACTION_SWITCH_PLAYER) is not working when fired from a custom context menu. Issue @ http://forum.kodi.tv/showthread.php?tid=215052

@FernetMenta and @Montellese for review please.
