### PR TITLE
python: add multi-selection support to Dialog.select() (thanks notspiff)

### DIFF
--- a/xbmc/interfaces/legacy/Dialog.cpp
+++ b/xbmc/interfaces/legacy/Dialog.cpp
@@ -18,7 +18,7 @@
  *
  */
 #include "LanguageHook.h"
-
+#include "FileItem.h"
 #include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogYesNo.h"
 #include "dialogs/GUIDialogSelect.h"
@@ -82,7 +82,7 @@ namespace XBMCAddon
       return pDialog->IsConfirmed();
     }
 
-    int Dialog::select(const String& heading, const std::vector<String>& list, int autoclose) throw (WindowException)
+    Alternative<int, std::vector<String> > Dialog::select(const String& heading, const std::vector<String>& list, int autoclose, bool multi /* = false */) throw (WindowException)
     {
       DelayedCallGuard dcguard(languageHook);
       const int window = WINDOW_DIALOG_SELECT;
@@ -98,15 +98,26 @@ namespace XBMCAddon
       for(unsigned int i = 0; i < list.size(); i++)
       {
         listLine = list[i];
-          pDialog->Add(listLine);
+        pDialog->Add(listLine);
       }
       if (autoclose > 0)
         pDialog->SetAutoClose(autoclose);
 
+      pDialog->SetMultiSelection(multi);
+
       //send message and wait for user input
       XBMCWaitForThreadMessage(TMSG_DIALOG_DOMODAL, window, ACTIVE_WINDOW);
+      Alternative<int, std::vector<String> > ret;
+      if (multi)
+      {
+        const CFileItemList& items = pDialog->GetSelectedItems();
+        for (int i = 0; i < items.Size(); ++i)
+          ret.later().push_back(items[i]->GetLabel());
+      }
+      else
+        ret.former() = pDialog->GetSelectedLabel();
 
-      return pDialog->GetSelectedLabel();
+      return ret;
     }
 
     bool Dialog::ok(const String& heading, const String& line1, 

--- a/xbmc/interfaces/legacy/Dialog.h
+++ b/xbmc/interfaces/legacy/Dialog.h
@@ -85,14 +85,15 @@ namespace XBMCAddon
        * heading        : string or unicode - dialog heading.\n
        * list           : string list - list of items.\n
        * autoclose      : [opt] integer - milliseconds to autoclose dialog. (default=do not autoclose)\n
+       * multiselect    : [opt] boolean - True to enable multiselection. (default=off)\n
        * \n
-       * *Note, Returns the position of the highlighted item as an integer.\n
+       * Note, Returns the position of the highlighted item as an integer but list of strings of selection for multiselect.\n
        * \n
        * example:\n
        *   - dialog = xbmcgui.Dialog()\n
        *   - ret = dialog.select('Choose a playlist', ['Playlist #1', 'Playlist #2, 'Playlist #3'])n\n
        */
-      int select(const String& heading, const std::vector<String>& list, int autoclose=0) throw (WindowException);
+      Alternative<int,std::vector<String> > select(const String& heading, const std::vector<String>& list, int autoclose=0, bool multiselect=false) throw (WindowException);
 
       /**
        * ok(heading, line1[, line2, line3]) -- Show a dialog 'OK'.\n


### PR DESCRIPTION
This is a backport of https://github.com/notspiff/kodi-cmake/commit/02dcc4b3d42e32f32b0cc6f5b09ff0f4fe45d10f from @notspiff's fork and adds the possibility to use `Dialog.select()` as a multi-selection dialog.
