### PR TITLE
python: add ControlTextBox.autoScroll()

### DIFF
--- a/xbmc/guilib/GUITextBox.cpp
+++ b/xbmc/guilib/GUITextBox.cpp
@@ -351,6 +351,15 @@ void CGUITextBox::SetAutoScrolling(const TiXmlNode *node)
   }
 }
 
+void CGUITextBox::SetAutoScrolling(int delay, int time, int repeatTime, const std::string &condition /* = "" */)
+{
+  m_autoScrollDelay = delay;
+  m_autoScrollTime = time;
+  if (!condition.empty())
+    m_autoScrollCondition = g_infoManager.Register(condition, GetParentID());
+  m_autoScrollRepeatAnim = new CAnimation(CAnimation::CreateFader(100, 0, repeatTime, 1000));
+}
+
 void CGUITextBox::ResetAutoScrolling()
 {
   m_autoScrollDelayTime = 0;

--- a/xbmc/guilib/GUITextBox.h
+++ b/xbmc/guilib/GUITextBox.h
@@ -60,6 +60,7 @@ public:
   virtual bool CanFocus() const;
   void SetInfo(const CGUIInfoLabel &info);
   void SetAutoScrolling(const TiXmlNode *node);
+  void SetAutoScrolling(int delay, int time, int repeatTime, const std::string &condition = "");
   void ResetAutoScrolling();
   std::string GetLabel(int info) const;
   std::string GetDescription() const;

--- a/xbmc/interfaces/legacy/Control.cpp
+++ b/xbmc/interfaces/legacy/Control.cpp
@@ -161,6 +161,11 @@ namespace XBMCAddon
       static_cast<CGUITextBox*>(pGUIControl)->Scroll((int)position);
     }
 
+    void ControlTextBox::autoScroll(int delay, int time, int repeat) throw(UnimplementedException)
+    {
+      static_cast<CGUITextBox*>(pGUIControl)->SetAutoScrolling(delay, time, repeat);
+    }
+
     CGUIControl* ControlTextBox::Create() throw (WindowException)
     {
       // create textbox

--- a/xbmc/interfaces/legacy/Control.h
+++ b/xbmc/interfaces/legacy/Control.h
@@ -920,6 +920,19 @@ namespace XBMCAddon
        */
       virtual void scroll(long id) throw(UnimplementedException);
 
+      // autoScroll() Method
+      /**
+       * autoScroll(delay, time, repeat) -- Set autoscrolling times.
+       *
+       * delay           : integer - Scroll delay (in ms)
+       * time            : integer - Scroll time (in ms)
+       * repeat          : integer - Repeat time
+       *
+       * example:
+       *   - self.textbox.autoScroll(1, 2, 1)
+       */
+      virtual void autoScroll(int delay, int time, int repeat) throw(UnimplementedException);
+
 #ifndef SWIG
       std::string strFont;
       color_t textColor;


### PR DESCRIPTION
This is an adjusted backport of https://github.com/notspiff/kodi-cmake/commit/24d8388d93c55c0061e534e2f6667b47a25652ec from @notspiff's fork.

@notspiff: Instead of putting together an XML file I added an overloaded `CGUITextBox::SetAutoScrolling()` method which takes the actual parameters. Any reason you used `float` in the python API? The members of `CGUITextBox` are integers (in milliseconds).
