### PR TITLE
fix heading labels of CGUIDialogPeripheralSettings, CGUIDialogSmartPlaylistEditor and CGUIDialogVideoSettings

### DIFF
--- a/addons/skin.confluence/720p/DialogPeripheralSettings.xml
+++ b/addons/skin.confluence/720p/DialogPeripheralSettings.xml
@@ -31,7 +31,6 @@
 			<width>620</width>
 			<height>30</height>
 			<font>font13_title</font>
-			<label>$LOCALIZE[5]</label>
 			<align>center</align>
 			<aligny>center</aligny>
 			<textcolor>selected</textcolor>

--- a/addons/skin.confluence/720p/SmartPlaylistEditor.xml
+++ b/addons/skin.confluence/720p/SmartPlaylistEditor.xml
@@ -35,7 +35,6 @@
 				<width>720</width>
 				<height>30</height>
 				<font>font13_title</font>
-				<label>$LOCALIZE[21432]</label>
 				<align>center</align>
 				<aligny>center</aligny>
 				<textcolor>selected</textcolor>

--- a/addons/skin.confluence/720p/VideoOSDSettings.xml
+++ b/addons/skin.confluence/720p/VideoOSDSettings.xml
@@ -26,33 +26,17 @@
 				<height>40</height>
 				<texture>dialogheader.png</texture>
 			</control>
-			<control type="label">
+			<control type="label" id="2">
 				<description>header label</description>
 				<left>40</left>
 				<top>20</top>
 				<width>720</width>
 				<height>30</height>
 				<font>font13_title</font>
-				<label>$LOCALIZE[3] - $LOCALIZE[5]</label>
 				<align>center</align>
 				<aligny>center</aligny>
 				<textcolor>selected</textcolor>
 				<shadowcolor>black</shadowcolor>
-				<visible>Window.IsVisible(123)</visible>
-			</control>
-			<control type="label">
-				<description>header label</description>
-				<left>40</left>
-				<top>20</top>
-				<width>720</width>
-				<height>30</height>
-				<font>font13_title</font>
-				<label>$LOCALIZE[292] - $LOCALIZE[5]</label>
-				<align>center</align>
-				<aligny>center</aligny>
-				<textcolor>selected</textcolor>
-				<shadowcolor>black</shadowcolor>
-				<visible>Window.IsVisible(124)</visible>
 			</control>
 			<control type="button">
 				<description>Close Window button</description>

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -6022,6 +6022,7 @@ msgctxt "#13395"
 msgid "Video settings"
 msgstr ""
 
+#: xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
 msgctxt "#13396"
 msgid "Audio and subtitle settings"
 msgstr ""

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -6017,6 +6017,7 @@ msgctxt "#13394"
 msgid "Calculating folder size"
 msgstr ""
 
+#: xbmc/video/dialogs/GUIDialogVideoSettings.cpp
 msgctxt "#13395"
 msgid "Video settings"
 msgstr ""

--- a/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
@@ -429,6 +429,8 @@ void CGUIDialogSmartPlaylistEditor::OnInitWindow()
   m_playlist.SetType(ConvertType(type));
   UpdateButtons();
 
+  SET_CONTROL_LABEL(CONTROL_HEADING, 21432);
+
   CGUIDialog::OnInitWindow();
 }
 

--- a/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.cpp
+++ b/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.cpp
@@ -116,6 +116,13 @@ void CGUIDialogPeripheralSettings::OnResetSettings()
   SetupView();
 }
 
+void CGUIDialogPeripheralSettings::SetupView()
+{
+  CGUIDialogSettingsManualBase::SetupView();
+
+  SetHeading(5);
+}
+
 void CGUIDialogPeripheralSettings::InitializeSettings()
 {
   if (m_item == NULL)

--- a/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.h
+++ b/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.h
@@ -44,6 +44,7 @@ protected:
   virtual bool AllowResettingSettings() const { return false; }
   virtual void Save();
   virtual void OnResetSettings();
+  virtual void SetupView();
 
   // specialization of CGUIDialogSettingsManualBase
   virtual void InitializeSettings();

--- a/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
@@ -252,6 +252,13 @@ void CGUIDialogAudioSubtitleSettings::Save()
   CSettings::Get().Save();
 }
 
+void CGUIDialogAudioSubtitleSettings::SetupView()
+{
+  CGUIDialogSettingsManualBase::SetupView();
+
+  SetHeading(13396);
+}
+
 void CGUIDialogAudioSubtitleSettings::InitializeSettings()
 {
   CGUIDialogSettingsManualBase::InitializeSettings();

--- a/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.h
+++ b/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.h
@@ -43,6 +43,7 @@ protected:
   // specialization of CGUIDialogSettingsBase
   virtual bool AllowResettingSettings() const { return false; }
   virtual void Save();
+  virtual void SetupView();
 
   // specialization of CGUIDialogSettingsManualBase
   virtual void InitializeSettings();

--- a/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
@@ -185,6 +185,13 @@ void CGUIDialogVideoSettings::Save()
   }
 }
 
+void CGUIDialogVideoSettings::SetupView()
+{
+  CGUIDialogSettingsManualBase::SetupView();
+
+  SetHeading(13395);
+}
+
 void CGUIDialogVideoSettings::InitializeSettings()
 {
   CGUIDialogSettingsManualBase::InitializeSettings();

--- a/xbmc/video/dialogs/GUIDialogVideoSettings.h
+++ b/xbmc/video/dialogs/GUIDialogVideoSettings.h
@@ -36,6 +36,7 @@ protected:
   // specialization of CGUIDialogSettingsBase
   virtual bool AllowResettingSettings() const { return false; }
   virtual void Save();
+  virtual void SetupView();
 
   // specialization of CGUIDialogSettingsManualBase
   virtual void InitializeSettings();


### PR DESCRIPTION
Some skinners noticed that a few dialogs didn't have a heading label set by default, see http://forum.kodi.tv/showthread.php?tid=214100&pid=1896191. These commits fix CGUIDialogPeripheralSettings, CGUIDialogSmartPlaylistEditor  and CGUIDialogVideoSettings based on the labels currently set by Confluence and removes those labels from Confluence.

The thread also mentions CGUIDialogVisualisationPresetList but that one has a label but it uses ID 3 because ID 2 is used for the list of presets (which obviously doesn't match the other dialogs but I don't want to break backwards compatibility).
