### PR TITLE
renderer: exit gfx lock when waiting for present time

### DIFF
--- a/xbmc/cores/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoRenderers/RenderManager.cpp
@@ -386,7 +386,10 @@ void CXBMCRenderManager::FrameFinish()
   SPresent& m = m_Queue[m_presentsource];
 
   if(g_graphicsContext.IsFullScreenVideo())
+  {
+    CSingleExit lock(g_graphicsContext);
     WaitPresentTime(m.timestamp);
+  }
 
   m_clock_framefinish = GetPresentTime();
 


### PR DESCRIPTION
holding a lock while waiting is no-go. we may wait here up to 40ms when playing 23.976 content.

@popcornmix this bug affects all platforms so I submit it as separate PR.
