### PR TITLE
[pvr] separates/removes PVR specific stuff from CGUIWindowFullScreen

### DIFF
--- a/Kodi.xcodeproj/project.pbxproj
+++ b/Kodi.xcodeproj/project.pbxproj
@@ -4053,6 +4053,7 @@
 		38F4E56C13CCCB3B00664821 /* Implementation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Implementation.cpp; sourceTree = "<group>"; };
 		38F4E56D13CCCB3B00664821 /* README.platform */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = README.platform; sourceTree = "<group>"; };
 		38F4E56E13CCCB3B00664821 /* ThreadLocal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ThreadLocal.h; sourceTree = "<group>"; };
+		42DAC16B1A6E780C0066B4C8 /* IActionListener.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IActionListener.h; sourceTree = "<group>"; };
 		430C881312D64A730098821A /* IPowerSyscall.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IPowerSyscall.h; sourceTree = "<group>"; };
 		431376FF12D6455C00680C15 /* GUIDialogCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GUIDialogCache.h; sourceTree = "<group>"; };
 		431AE5D7109C1A63007428C3 /* OverlayRendererUtil.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = OverlayRendererUtil.cpp; sourceTree = "<group>"; };
@@ -7126,6 +7127,7 @@
 		4367217312D6640E002508E6 /* interfaces */ = {
 			isa = PBXGroup;
 			children = (
+				42DAC16B1A6E780C0066B4C8 /* IActionListener.h */,
 				DF40BC21178B4C07009DB567 /* generic */,
 				7C89674213C03B21003631FE /* info */,
 				F5AE407F13415D9E0004BD79 /* json-rpc */,

--- a/Kodi.xcodeproj/project.pbxproj
+++ b/Kodi.xcodeproj/project.pbxproj
@@ -179,6 +179,9 @@
 		3802709A13D5A653009493DD /* SystemClock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3802709813D5A653009493DD /* SystemClock.cpp */; };
 		384718D81325BA04000486D6 /* XBDateTime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 384718D61325BA04000486D6 /* XBDateTime.cpp */; };
 		38F4E57013CCCB3B00664821 /* Implementation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 38F4E56C13CCCB3B00664821 /* Implementation.cpp */; };
+		42DAC16E1A6E789E0066B4C8 /* PVRActionListener.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 42DAC16C1A6E789E0066B4C8 /* PVRActionListener.cpp */; };
+		42DAC16F1A6E789E0066B4C8 /* PVRActionListener.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 42DAC16C1A6E789E0066B4C8 /* PVRActionListener.cpp */; };
+		42DAC1701A6E789E0066B4C8 /* PVRActionListener.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 42DAC16C1A6E789E0066B4C8 /* PVRActionListener.cpp */; };
 		431AE5DA109C1A63007428C3 /* OverlayRendererUtil.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 431AE5D7109C1A63007428C3 /* OverlayRendererUtil.cpp */; };
 		432D7CE412D86DA500CE4C49 /* NetworkLinux.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 432D7CE312D86DA500CE4C49 /* NetworkLinux.cpp */; };
 		432D7CF712D870E800CE4C49 /* TCPServer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 432D7CF612D870E800CE4C49 /* TCPServer.cpp */; };
@@ -4054,6 +4057,8 @@
 		38F4E56D13CCCB3B00664821 /* README.platform */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = README.platform; sourceTree = "<group>"; };
 		38F4E56E13CCCB3B00664821 /* ThreadLocal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ThreadLocal.h; sourceTree = "<group>"; };
 		42DAC16B1A6E780C0066B4C8 /* IActionListener.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IActionListener.h; sourceTree = "<group>"; };
+		42DAC16C1A6E789E0066B4C8 /* PVRActionListener.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PVRActionListener.cpp; sourceTree = "<group>"; };
+		42DAC16D1A6E789E0066B4C8 /* PVRActionListener.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PVRActionListener.h; sourceTree = "<group>"; };
 		430C881312D64A730098821A /* IPowerSyscall.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IPowerSyscall.h; sourceTree = "<group>"; };
 		431376FF12D6455C00680C15 /* GUIDialogCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GUIDialogCache.h; sourceTree = "<group>"; };
 		431AE5D7109C1A63007428C3 /* OverlayRendererUtil.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = OverlayRendererUtil.cpp; sourceTree = "<group>"; };
@@ -7983,6 +7988,8 @@
 		C8482871156CFCD8005A996F /* pvr */ = {
 			isa = PBXGroup;
 			children = (
+				42DAC16C1A6E789E0066B4C8 /* PVRActionListener.cpp */,
+				42DAC16D1A6E789E0066B4C8 /* PVRActionListener.h */,
 				C8482872156CFCD8005A996F /* addons */,
 				C8482878156CFCD8005A996F /* channels */,
 				C8482884156CFCD8005A996F /* dialogs */,
@@ -11873,6 +11880,7 @@
 				7CCDACC119275D790074CF51 /* NptAppleAutoreleasePool.mm in Sources */,
 				7CCDACCA19275D790074CF51 /* NptAppleLogConfig.mm in Sources */,
 				7CAA469019427AED00008885 /* PosixDirectory.cpp in Sources */,
+				42DAC16E1A6E789E0066B4C8 /* PVRActionListener.cpp in Sources */,
 				DF033D381946612400BFC82E /* AEDeviceEnumerationOSX.cpp in Sources */,
 				7C525DF5195E2D8100BE3482 /* SaveFileStateJob.cpp in Sources */,
 				7C908894196358A8003D0619 /* auto_buffer.cpp in Sources */,
@@ -11963,6 +11971,7 @@
 				DFF0F14417528350002DA3A4 /* AEPackIEC61937.cpp in Sources */,
 				DFF0F14617528350002DA3A4 /* AEStreamInfo.cpp in Sources */,
 				DFF0F14717528350002DA3A4 /* AEUtil.cpp in Sources */,
+				42DAC1701A6E789E0066B4C8 /* PVRActionListener.cpp in Sources */,
 				DFF0F14917528350002DA3A4 /* AEFactory.cpp in Sources */,
 				DFF0F14A17528350002DA3A4 /* EmuFileWrapper.cpp in Sources */,
 				DFF0F14B17528350002DA3A4 /* emu_dummy.cpp in Sources */,
@@ -13817,6 +13826,7 @@
 				E499146F174E605900741B6D /* ScraperUrl.cpp in Sources */,
 				E4991470174E605900741B6D /* Screenshot.cpp in Sources */,
 				E4991471174E605900741B6D /* SeekHandler.cpp in Sources */,
+				42DAC16F1A6E789E0066B4C8 /* PVRActionListener.cpp in Sources */,
 				E4991472174E605900741B6D /* SortUtils.cpp in Sources */,
 				E4991473174E605900741B6D /* Splash.cpp in Sources */,
 				E4991474174E605900741B6D /* Stopwatch.cpp in Sources */,

--- a/addons/skin.confluence/720p/VideoFullScreen.xml
+++ b/addons/skin.confluence/720p/VideoFullScreen.xml
@@ -405,20 +405,6 @@
 				<label>-</label>
 			</control>
 		</control>
-		<control type="selectbutton" id="503">
-			<left>440</left>
-			<top>100</top>
-			<width>400</width>
-			<height>100</height>
-			<font>font13caps</font>
-			<description>TV Channel Group Select Button</description>
-			<texturebg border="20">OverlayDialogBackground.png</texturebg>
-			<onleft>503</onleft>
-			<onright>503</onright>
-			<onup>500</onup>
-			<ondown>500</ondown>
-			<include>VisibleFadeEffect</include>
-		</control>
 		<control type="group">
 			<visible>Player.ShowCodec + VideoPlayer.Content(LiveTV) + system.getbool(pvrplayback.signalquality)</visible>
 			<top>185</top>

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -726,6 +726,7 @@
     <ClCompile Include="..\..\xbmc\pvr\dialogs\GUIDialogPVRGuideSearch.cpp" />
     <ClCompile Include="..\..\xbmc\pvr\dialogs\GUIDialogPVRRecordingInfo.cpp" />
     <ClCompile Include="..\..\xbmc\pvr\dialogs\GUIDialogPVRTimerSettings.cpp" />
+    <ClCompile Include="..\..\xbmc\pvr\PVRActionListener.cpp" />
     <ClCompile Include="..\..\xbmc\pvr\PVRDatabase.cpp" />
     <ClCompile Include="..\..\xbmc\pvr\PVRGUIInfo.cpp" />
     <ClCompile Include="..\..\xbmc\pvr\PVRManager.cpp" />
@@ -1971,6 +1972,7 @@
     <ClInclude Include="..\..\xbmc\pvr\dialogs\GUIDialogPVRGuideSearch.h" />
     <ClInclude Include="..\..\xbmc\pvr\dialogs\GUIDialogPVRRecordingInfo.h" />
     <ClInclude Include="..\..\xbmc\pvr\dialogs\GUIDialogPVRTimerSettings.h" />
+    <ClInclude Include="..\..\xbmc\pvr\PVRActionListener.h" />
     <ClInclude Include="..\..\xbmc\pvr\PVRDatabase.h" />
     <ClInclude Include="..\..\xbmc\pvr\PVRGUIInfo.h" />
     <ClInclude Include="..\..\xbmc\pvr\PVRManager.h" />

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -1822,6 +1822,7 @@
     <ClInclude Include="..\..\xbmc\input\XBMC_vkeys.h" />
     <ClInclude Include="..\..\xbmc\interfaces\AnnouncementManager.h" />
     <ClInclude Include="..\..\xbmc\interfaces\Builtins.h" />
+    <ClInclude Include="..\..\xbmc\interfaces\IActionListener.h" />
     <ClInclude Include="..\..\xbmc\interfaces\IAnnouncer.h" />
     <ClInclude Include="..\..\xbmc\interfaces\info\InfoBool.h" />
     <ClInclude Include="..\..\xbmc\interfaces\info\InfoExpression.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -1759,6 +1759,9 @@
     <ClCompile Include="..\..\xbmc\dialogs\GUIDialogExtendedProgressBar.cpp">
       <Filter>dialogs</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\pvr\PVRActionListener.cpp">
+      <Filter>pvr</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\xbmc\pvr\PVRDatabase.cpp">
       <Filter>pvr</Filter>
     </ClCompile>
@@ -4721,6 +4724,9 @@
     </ClInclude>
     <ClInclude Include="..\..\xbmc\dialogs\GUIDialogExtendedProgressBar.h">
       <Filter>dialogs</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\pvr\PVRActionListener.h">
+      <Filter>pvr</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\pvr\PVRDatabase.h">
       <Filter>pvr</Filter>

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -4569,6 +4569,9 @@
     <ClInclude Include="..\..\xbmc\interfaces\Builtins.h">
       <Filter>interfaces</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\xbmc\interfaces\IActionListener.h">
+      <Filter>interfaces</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\xbmc\interfaces\IAnnouncer.h">
       <Filter>interfaces</Filter>
     </ClInclude>

--- a/system/keymaps/gamepad.xml
+++ b/system/keymaps/gamepad.xml
@@ -112,16 +112,16 @@
   </FullscreenVideo>
   <FullscreenLiveTV>
     <gamepad>
-      <dpadleft>PreviousChannelGroup</dpadleft>
-      <dpadright>NextChannelGroup</dpadright>
+      <dpadleft>StepBack</dpadleft>
+      <dpadright>StepForward</dpadright>
       <dpadup>ChannelUp</dpadup>
       <dpaddown>ChannelDown</dpaddown>
     </gamepad>
   </FullscreenLiveTV>
   <FullscreenRadio>
     <gamepad>
-      <dpadleft>PreviousChannelGroup</dpadleft>
-      <dpadright>NextChannelGroup</dpadright>
+      <dpadleft>StepBack</dpadleft>
+      <dpadright>StepForward</dpadright>
       <dpadup>ChannelUp</dpadup>
       <dpaddown>ChannelDown</dpaddown>
     </gamepad>

--- a/system/keymaps/joystick.Harmony.xml
+++ b/system/keymaps/joystick.Harmony.xml
@@ -177,16 +177,16 @@
     <joystick name="Harmony">
       <!-- up       	-->      <button id="1">ChannelUp</button>
       <!-- down      	-->      <button id="2">ChannelDown</button>
-      <!-- left       	-->      <button id="3">PreviousChannelGroup</button>
-      <!-- right      	-->      <button id="4">NextChannelGroup</button>
+      <!-- left       	-->      <button id="3">StepBack</button>
+      <!-- right      	-->      <button id="4">StepForward</button>
     </joystick>
   </FullscreenLiveTV>
   <FullscreenRadio>
     <joystick name="Harmony">
       <!-- up       	-->      <button id="1">ChannelUp</button>
       <!-- down      	-->      <button id="2">ChannelDown</button>
-      <!-- left       	-->      <button id="3">PreviousChannelGroup</button>
-      <!-- right      	-->      <button id="4">NextChannelGroup</button>
+      <!-- left       	-->      <button id="3">StepBack</button>
+      <!-- right      	-->      <button id="4">StepForward</button>
     </joystick>
   </FullscreenRadio>
   <FullscreenInfo>

--- a/system/keymaps/joystick.Logitech.RumblePad.2.xml
+++ b/system/keymaps/joystick.Logitech.RumblePad.2.xml
@@ -73,8 +73,8 @@
     <joystick name="Logitech Logitech Cordless RumblePad 2">
       <altname>Logitech Cordless RumblePad 2</altname>
       <altname>Logitech RumblePad 2 USB</altname>
-      <hat    id="1" position="left">PreviousChannelGroup</hat>
-      <hat    id="1" position="right">NextChannelGroup</hat>
+      <hat    id="1" position="left">StepBack</hat>
+      <hat    id="1" position="right">StepForward</hat>
       <hat    id="1" position="up">ChannelUp</hat>
       <hat    id="1" position="down">ChannelDown</hat>
     </joystick>
@@ -84,8 +84,8 @@
     <joystick name="Logitech Logitech Cordless RumblePad 2">
       <altname>Logitech Cordless RumblePad 2</altname>
       <altname>Logitech RumblePad 2 USB</altname>
-      <hat    id="1" position="left">PreviousChannelGroup</hat>
-      <hat    id="1" position="right">NextChannelGroup</hat>
+      <hat    id="1" position="left">StepBack</hat>
+      <hat    id="1" position="right">StepForward</hat>
       <hat    id="1" position="up">ChannelUp</hat>
       <hat    id="1" position="down">ChannelDown</hat>
     </joystick>

--- a/system/keymaps/joystick.Microsoft.Xbox.360.Controller.xml
+++ b/system/keymaps/joystick.Microsoft.Xbox.360.Controller.xml
@@ -389,12 +389,12 @@
       <altname>Controller (XBOX One For Windows)</altname>
       <button id="11">ChannelUp</button>
       <button id="12">ChannelDown</button>
-      <button id="13">PreviousChannelGroup</button>
-      <button id="14">NextChannelGroup</button>
+      <button id="13">StepBack</button>
+      <button id="14">StepForward</button>
       <hat id="1" position="up">ChannelUp</hat>
       <hat id="1" position="down">ChannelDown</hat>
-      <hat id="1" position="left">PreviousChannelGroup</hat>
-      <hat id="1" position="right">NextChannelGroup</hat>
+      <hat id="1" position="left">StepBack</hat>
+      <hat id="1" position="right">StepForward</hat>
     </joystick>
     <joystick name="Microsoft X-Box 360 pad">
       <altname>BigBen Interactive XBOX 360 Controller</altname>
@@ -407,14 +407,14 @@
       <altname>Xbox 360 Wireless Receiver</altname>
       <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
       <altname>Razer Sabertooth</altname>
-      <button id="12">PreviousChannelGroup</button>
-      <button id="13">NextChannelGroup</button>
+      <button id="12">StepBack</button>
+      <button id="13">StepForward</button>
       <button id="14">ChannelUp</button>
       <button id="15">ChannelDown</button>
       <hat id="1" position="up">ChannelUp</hat>
       <hat id="1" position="down">ChannelDown</hat>
-      <hat id="1" position="left">PreviousChannelGroup</hat>
-      <hat id="1" position="right">NextChannelGroup</hat>
+      <hat id="1" position="left">StepBack</hat>
+      <hat id="1" position="right">StepForward</hat>
     </joystick>
   </FullscreenLiveTV>
   <FullscreenRadio>
@@ -439,12 +439,12 @@
       <altname>Controller (XBOX One For Windows)</altname>
       <button id="11">ChannelUp</button>
       <button id="12">ChannelDown</button>
-      <button id="13">PreviousChannelGroup</button>
-      <button id="14">NextChannelGroup</button>
+      <button id="13">StepBack</button>
+      <button id="14">StepForward</button>
       <hat id="1" position="up">ChannelUp</hat>
       <hat id="1" position="down">ChannelDown</hat>
-      <hat id="1" position="left">PreviousChannelGroup</hat>
-      <hat id="1" position="right">NextChannelGroup</hat>
+      <hat id="1" position="left">StepBack</hat>
+      <hat id="1" position="right">StepForward</hat>
     </joystick>
     <joystick name="Microsoft X-Box 360 pad">
       <altname>BigBen Interactive XBOX 360 Controller</altname>
@@ -456,14 +456,14 @@
       <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
       <altname>Xbox 360 Wireless Receiver</altname>
       <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
-      <button id="12">PreviousChannelGroup</button>
-      <button id="13">NextChannelGroup</button>
+      <button id="12">StepBack</button>
+      <button id="13">StepForward</button>
       <button id="14">ChannelUp</button>
       <button id="15">ChannelDown</button>
       <hat id="1" position="up">ChannelUp</hat>
       <hat id="1" position="down">ChannelDown</hat>
-      <hat id="1" position="left">PreviousChannelGroup</hat>
-      <hat id="1" position="right">NextChannelGroup</hat>
+      <hat id="1" position="left">StepBack</hat>
+      <hat id="1" position="right">StepForward</hat>
     </joystick>
   </FullscreenRadio>
   <FullscreenInfo>

--- a/system/keymaps/joystick.Microsoft.Xbox.Controller.S.xml
+++ b/system/keymaps/joystick.Microsoft.Xbox.Controller.S.xml
@@ -135,9 +135,9 @@
       <altname>Logitech Xbox Cordless Controller</altname>
       <altname>Microsoft X-Box pad (Japan)</altname> 
       <button id="13">ChannelUp</button>
-      <button id="14">NextChannelGroup</button>
+      <button id="14">StepForward</button>
       <button id="15">ChannelDown</button>
-      <button id="16">PreviousChannelGroup</button>
+      <button id="16">StepBack</button>
     </joystick>
   </FullscreenLiveTV>
   <FullscreenRadio>
@@ -146,9 +146,9 @@
       <altname>Logitech Xbox Cordless Controller</altname>
       <altname>Microsoft X-Box pad (Japan)</altname> 
       <button id="13">ChannelUp</button>
-      <button id="14">NextChannelGroup</button>
+      <button id="14">StepForward</button>
       <button id="15">ChannelDown</button>
-      <button id="16">PreviousChannelGroup</button>
+      <button id="16">StepBack</button>
     </joystick>
   </FullscreenRadio>
   <FullscreenInfo>

--- a/system/keymaps/joystick.PS3.Remote.Keyboard.xml
+++ b/system/keymaps/joystick.PS3.Remote.Keyboard.xml
@@ -105,8 +105,8 @@
 
   <FullscreenLiveTV>
     <joystick name="PLAYSTATION(R)3 Remote Keyboard">
-      <hat    id="1" position="left">PreviousChannelGroup</hat>
-      <hat    id="1" position="right">NextChannelGroup</hat>
+      <hat    id="1" position="left">StepBack</hat>
+      <hat    id="1" position="right">StepForward</hat>
       <hat    id="1" position="up">ChannelUp</hat>
       <hat    id="1" position="down">ChannelDown</hat>
     </joystick>
@@ -114,8 +114,8 @@
 
   <FullscreenRadio>
     <joystick name="PLAYSTATION(R)3 Remote Keyboard">
-      <hat    id="1" position="left">PreviousChannelGroup</hat>
-      <hat    id="1" position="right">NextChannelGroup</hat>
+      <hat    id="1" position="left">StepBack</hat>
+      <hat    id="1" position="right">StepForward</hat>
       <hat    id="1" position="up">ChannelUp</hat>
       <hat    id="1" position="down">ChannelDown</hat>
     </joystick>

--- a/system/keymaps/joystick.Sony.PLAYSTATION(R)3.Controller.xml
+++ b/system/keymaps/joystick.Sony.PLAYSTATION(R)3.Controller.xml
@@ -177,8 +177,8 @@
       <altname>Sony Computer Entertainment Wireless Controller</altname>      
       <button id="5">ChannelUp</button>
       <button id="7">ChannelDown</button>
-      <button id="8">PreviousChannelGroup</button>
-      <button id="6">NextChannelGroup</button>
+      <button id="8">StepBack</button>
+      <button id="6">StepForward</button>
     </joystick>
   </FullscreenLiveTV>
   <FullscreenRadio>
@@ -188,8 +188,8 @@
       <altname>Sony Computer Entertainment Wireless Controller</altname>      
       <button id="5">ChannelUp</button>
       <button id="7">ChannelDown</button>
-      <button id="8">PreviousChannelGroup</button>
-      <button id="6">NextChannelGroup</button>
+      <button id="8">StepBack</button>
+      <button id="6">StepForward</button>
     </joystick>
   </FullscreenRadio>
   <FullscreenInfo>

--- a/system/keymaps/joystick.xml.sample
+++ b/system/keymaps/joystick.xml.sample
@@ -126,24 +126,24 @@
     <joystick>
       <button id="11">ChannelUp</button>
       <button id="12">ChannelDown</button>
-      <button id="13">PreviousChannelGroup</button>
-      <button id="14">NextChannelGroup</button>
+      <button id="13">StepBack</button>
+      <button id="14">StepForward</button>
       <hat id="1" position="up">ChannelUp</hat>
       <hat id="1" position="down">ChannelDown</hat>
-      <hat id="1" position="left">PreviousChannelGroup</hat>
-      <hat id="1" position="right">NextChannelGroup</hat>
+      <hat id="1" position="left">StepBack</hat>
+      <hat id="1" position="right">StepForward</hat>
     </joystick>
   </FullscreenLiveTV>
   <FullscreenRadio>
     <joystick>
       <button id="11">ChannelUp</button>
       <button id="12">ChannelDown</button>
-      <button id="13">PreviousChannelGroup</button>
-      <button id="14">NextChannelGroup</button>
+      <button id="13">StepBack</button>
+      <button id="14">StepForward</button>
       <hat id="1" position="up">ChannelUp</hat>
       <hat id="1" position="down">ChannelDown</hat>
-      <hat id="1" position="left">PreviousChannelGroup</hat>
-      <hat id="1" position="right">NextChannelGroup</hat>
+      <hat id="1" position="left">StepBack</hat>
+      <hat id="1" position="right">StepForward</hat>
     </joystick>
   </FullscreenRadio>
   <FullscreenInfo>

--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -523,16 +523,16 @@
   </NumericInput>
   <FullscreenLiveTV>
     <keyboard>
-      <left>PreviousChannelGroup</left>
-      <right>NextChannelGroup</right>
+      <left>StepBack</left>
+      <right>StepForward</right>
       <up>ChannelUp</up>
       <down>ChannelDown</down>
     </keyboard>
   </FullscreenLiveTV>
   <FullscreenRadio>
     <keyboard>
-      <left>PreviousChannelGroup</left>
-      <right>NextChannelGroup</right>
+      <left>StepBack</left>
+      <right>StepForward</right>
       <up>ChannelUp</up>
       <down>ChannelDown</down>
     </keyboard>

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2700,10 +2700,6 @@ bool CApplication::OnAction(const CAction &action)
     return true;
   }
 
-  // forward action to g_PVRManager and break if it was able to handle it
-  if (g_PVRManager.OnAction(action))
-    return true;
-
   // forward action to graphic context and see if it can handle it
   if (CStereoscopicsManager::Get().OnAction(action))
     return true;

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -459,6 +459,8 @@ CApplication::~CApplication(void)
   delete m_playerController;
   delete m_pInertialScrollingHandler;
   delete m_pPlayer;
+
+  m_actionListeners.clear();
 }
 
 bool CApplication::OnEvent(XBMC_Event& newEvent)
@@ -2583,7 +2585,11 @@ bool CApplication::OnAction(const CAction &action)
   }
 
   // handle extra global presses
-
+  
+  // notify action listeners
+  if (NotifyActionListeners(action))
+    return true;
+  
   // screenshot : take a screenshot :)
   if (action.GetID() == ACTION_TAKE_SCREENSHOT)
   {
@@ -5888,4 +5894,32 @@ void CApplication::CloseNetworkShares()
 #ifdef HAS_FILESYSTEM_SFTP
   CSFTPSessionManager::DisconnectAllSessions();
 #endif
+}
+
+void CApplication::RegisterActionListener(IActionListener *listener)
+{
+  CSingleLock lock(m_critSection);
+  std::vector<IActionListener *>::iterator it = std::find(m_actionListeners.begin(), m_actionListeners.end(), listener);
+  if (it == m_actionListeners.end())
+    m_actionListeners.push_back(listener);
+}
+
+void CApplication::UnregisterActionListener(IActionListener *listener)
+{
+  CSingleLock lock(m_critSection);
+  std::vector<IActionListener *>::iterator it = std::find(m_actionListeners.begin(), m_actionListeners.end(), listener);
+  if (it != m_actionListeners.end())
+    m_actionListeners.erase(it);
+}
+
+bool CApplication::NotifyActionListeners(const CAction &action) const
+{
+  CSingleLock lock(m_critSection);
+  for (std::vector<IActionListener *>::const_iterator it = m_actionListeners.begin(); it != m_actionListeners.end(); ++it)
+  {
+    if ((*it)->OnAction(action))
+      return true;
+  }
+  
+  return false;
 }

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -66,6 +66,7 @@ class CPlayerController;
 #include "threads/Thread.h"
 
 #include "ApplicationPlayer.h"
+#include "interfaces/IActionListener.h"
 
 class CSeekHandler;
 class CKaraokeLyricsManager;
@@ -380,6 +381,17 @@ public:
   ReplayGainSettings& GetReplayGainSettings() { return m_replayGainSettings; }
 
   void SetLoggingIn(bool loggingIn) { m_loggingIn = loggingIn; }
+  
+  /*!
+   \brief Register an action listener.
+   \param listener The listener to register
+   */
+  void RegisterActionListener(IActionListener *listener);
+  /*!
+   \brief Unregister an action listener.
+   \param listener The listener to unregister
+   */
+  void UnregisterActionListener(IActionListener *listener);
 
 protected:
   virtual bool OnSettingsSaving() const;
@@ -393,6 +405,13 @@ protected:
 
   bool LoadSkin(const std::string& skinID);
   bool LoadSkin(const boost::shared_ptr<ADDON::CSkinInfo>& skin);
+  
+  /*!
+   \brief Delegates the action to all registered action handlers.
+   \param action The action
+   \return true, if the action was taken by one of the action listener.
+   */
+  bool NotifyActionListeners(const CAction &action) const;
 
   bool m_skinReverting;
 
@@ -498,6 +517,11 @@ protected:
 #endif
 
   ReplayGainSettings m_replayGainSettings;
+  
+  std::vector<IActionListener *> m_actionListeners;
+  
+private:
+  CCriticalSection                m_critSection;                 /*!< critical section for all changes to this class, except for changes to triggers */
 };
 
 XBMC_GLOBAL_REF(CApplication,g_application);

--- a/xbmc/interfaces/IActionListener.h
+++ b/xbmc/interfaces/IActionListener.h
@@ -1,0 +1,31 @@
+#pragma once
+
+/*
+ *      Copyright (C) 2005-2015 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "guilib/Key.h"
+
+class IActionListener
+{
+public:
+  virtual ~IActionListener() {};
+  
+  virtual bool OnAction(const CAction &action) = 0;
+};

--- a/xbmc/pvr/Makefile
+++ b/xbmc/pvr/Makefile
@@ -1,6 +1,7 @@
 SRCS=PVRGUIInfo.cpp \
      PVRManager.cpp \
-     PVRDatabase.cpp
+     PVRDatabase.cpp \
+     PVRActionListener.cpp
 
 LIB=pvr.a
 

--- a/xbmc/pvr/PVRActionListener.cpp
+++ b/xbmc/pvr/PVRActionListener.cpp
@@ -27,6 +27,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "guilib/GUIWindowManager.h"
 #include "dialogs/GUIDialogNumeric.h"
+#include "dialogs/GUIDialogKaiToast.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "utils/log.h"
@@ -51,6 +52,30 @@ bool CPVRActionListener::OnAction(const CAction &action)
 {
   switch (action.GetID())
   {
+    case ACTION_PVR_PLAY:
+    case ACTION_PVR_PLAY_TV:
+    case ACTION_PVR_PLAY_RADIO:
+    {
+      // see if we're already playing a PVR stream and if not or the stream type
+      // doesn't match the demanded type, start playback of according type
+      bool isPlayingPvr(g_PVRManager.IsPlaying() && g_application.CurrentFileItem().HasPVRChannelInfoTag());
+      switch (action.GetID())
+      {
+        case ACTION_PVR_PLAY:
+          if (!isPlayingPvr)
+            g_PVRManager.StartPlayback(PlaybackTypeAny);
+          break;
+        case ACTION_PVR_PLAY_TV:
+          if (!isPlayingPvr || g_application.CurrentFileItem().GetPVRChannelInfoTag()->IsRadio())
+            g_PVRManager.StartPlayback(PlaybackTypeTv);
+          break;
+        case ACTION_PVR_PLAY_RADIO:
+          if (!isPlayingPvr || !g_application.CurrentFileItem().GetPVRChannelInfoTag()->IsRadio())
+            g_PVRManager.StartPlayback(PlaybackTypeRadio);
+          break;
+      }
+      return true;
+    }
     case REMOTE_0:
     case REMOTE_1:
     case REMOTE_2:

--- a/xbmc/pvr/PVRActionListener.cpp
+++ b/xbmc/pvr/PVRActionListener.cpp
@@ -1,0 +1,125 @@
+/*
+ *      Copyright (C) 2005-2015 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "PVRActionListener.h"
+
+#include "Application.h"
+#include "ApplicationMessenger.h"
+#include "guilib/Key.h"
+#include "guilib/GUIWindow.h"
+#include "guilib/LocalizeStrings.h"
+#include "guilib/GUIWindowManager.h"
+#include "dialogs/GUIDialogNumeric.h"
+#include "settings/AdvancedSettings.h"
+#include "settings/Settings.h"
+#include "utils/log.h"
+#include "utils/StringUtils.h"
+
+#include "pvr/PVRManager.h"
+#include "pvr/channels/PVRChannelGroupsContainer.h"
+
+using namespace PVR;
+
+CPVRActionListener::CPVRActionListener()
+{
+}
+
+CPVRActionListener &CPVRActionListener::Get()
+{
+  static CPVRActionListener instance;
+  return instance;
+}
+
+bool CPVRActionListener::OnAction(const CAction &action)
+{
+  switch (action.GetID())
+  {
+    case REMOTE_0:
+    case REMOTE_1:
+    case REMOTE_2:
+    case REMOTE_3:
+    case REMOTE_4:
+    case REMOTE_5:
+    case REMOTE_6:
+    case REMOTE_7:
+    case REMOTE_8:
+    case REMOTE_9:
+    {
+      if (g_application.IsFullScreen() && g_application.CurrentFileItem().IsLiveTV())
+      {
+        if(g_PVRManager.IsPlaying())
+        {
+          // pvr client addon
+          CPVRChannelPtr playingChannel;
+          if(!g_PVRManager.GetCurrentChannel(playingChannel))
+            return false;
+          
+          if (action.GetID() == REMOTE_0)
+          {
+            CPVRChannelGroupPtr group = g_PVRChannelGroups->GetPreviousPlayedGroup();
+            if (group)
+            {
+              g_PVRManager.SetPlayingGroup(group);
+              CFileItemPtr fileItem = group->GetLastPlayedChannel(playingChannel->ChannelID());
+              if (fileItem && fileItem->HasPVRChannelInfoTag())
+              {
+                CLog::Log(LOGDEBUG, "%s - switch to channel number %d", __FUNCTION__, fileItem->GetPVRChannelInfoTag()->ChannelNumber());
+                CApplicationMessenger::Get().SendAction(CAction(ACTION_CHANNEL_SWITCH, (float) fileItem->GetPVRChannelInfoTag()->ChannelNumber()), WINDOW_INVALID, false);
+              }
+            }
+          }
+          else
+          {
+            int autoCloseTime = CSettings::Get().GetBool("pvrplayback.confirmchannelswitch") ? 0 : g_advancedSettings.m_iPVRNumericChannelSwitchTimeout;
+            std::string strChannel = StringUtils::Format("%i", action.GetID() - REMOTE_0);
+            if (CGUIDialogNumeric::ShowAndGetNumber(strChannel, g_localizeStrings.Get(19000), autoCloseTime) || autoCloseTime)
+            {
+              int iChannelNumber = atoi(strChannel.c_str());
+              if (iChannelNumber > 0 && iChannelNumber != playingChannel->ChannelNumber())
+              {
+                CPVRChannelGroupPtr selectedGroup = g_PVRManager.GetPlayingGroup(playingChannel->IsRadio());
+                CFileItemPtr channel = selectedGroup->GetByChannelNumber(iChannelNumber);
+                if (!channel || !channel->HasPVRChannelInfoTag())
+                  return false;
+                
+                CApplicationMessenger::Get().SendAction(CAction(ACTION_CHANNEL_SWITCH, (float)iChannelNumber), WINDOW_INVALID, false);
+              }
+            }
+          }
+        }
+        else
+        {
+          // filesystem provider like slingbox, cmyth, etc
+          int iChannelNumber = -1;
+          std::string strChannel = StringUtils::Format("%i", action.GetID() - REMOTE_0);
+          if (CGUIDialogNumeric::ShowAndGetNumber(strChannel, g_localizeStrings.Get(19000)))
+            iChannelNumber = atoi(strChannel.c_str());
+          
+          if (iChannelNumber > 0)
+            CApplicationMessenger::Get().SendAction(CAction(ACTION_CHANNEL_SWITCH, (float)iChannelNumber), WINDOW_INVALID, false);
+        }
+      }
+      return true;
+    }
+    break;
+  }
+  
+  return false;
+}

--- a/xbmc/pvr/PVRActionListener.h
+++ b/xbmc/pvr/PVRActionListener.h
@@ -1,0 +1,38 @@
+#pragma once
+
+/*
+ *      Copyright (C) 2005-2015 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "interfaces/IActionListener.h"
+
+class CPVRActionListener : public IActionListener
+{
+public:
+  
+  static CPVRActionListener &Get();
+  
+  bool OnAction(const CAction &action);
+  
+private:
+  CPVRActionListener();
+  CPVRActionListener(const CPVRActionListener&);
+  CPVRActionListener& operator=(const CPVRActionListener&);
+  ~CPVRActionListener() {};
+};

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -1558,42 +1558,6 @@ void CPVRManager::ExecutePendingJobs(void)
   m_triggerEvent.Reset();
 }
 
-bool CPVRManager::OnAction(const CAction &action)
-{
-  // process PVR specific play actions
-  if (action.GetID() == ACTION_PVR_PLAY || action.GetID() == ACTION_PVR_PLAY_TV || action.GetID() == ACTION_PVR_PLAY_RADIO)
-  {
-    // pvr not active yet, show error message
-    if (!IsStarted())
-    {
-      CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Warning, g_localizeStrings.Get(19045), g_localizeStrings.Get(19044));
-    }
-    else
-    {
-      // see if we're already playing a PVR stream and if not or the stream type
-      // doesn't match the demanded type, start playback of according type
-      bool isPlayingPvr(IsPlaying() && g_application.CurrentFileItem().HasPVRChannelInfoTag());
-      switch (action.GetID())
-      {
-        case ACTION_PVR_PLAY:
-          if (!isPlayingPvr)
-            StartPlayback(PlaybackTypeAny);
-          break;
-        case ACTION_PVR_PLAY_TV:
-          if (!isPlayingPvr || g_application.CurrentFileItem().GetPVRChannelInfoTag()->IsRadio())
-            StartPlayback(PlaybackTypeTv);
-          break;
-        case ACTION_PVR_PLAY_RADIO:
-          if (!isPlayingPvr || !g_application.CurrentFileItem().GetPVRChannelInfoTag()->IsRadio())
-            StartPlayback(PlaybackTypeRadio);
-          break;
-      }
-    }
-    return true;
-  }
-  return false;
-}
-
 bool CPVRChannelSwitchJob::DoWork(void)
 {
   // announce OnStop and delete m_previous when done

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -48,6 +48,7 @@
 #include "PVRManager.h"
 #include "PVRDatabase.h"
 #include "PVRGUIInfo.h"
+#include "PVRActionListener.h"
 #include "addons/PVRClients.h"
 #include "channels/PVRChannel.h"
 #include "channels/PVRChannelGroupsContainer.h"
@@ -354,6 +355,9 @@ void CPVRManager::Cleanup(void)
   for (unsigned int iJobPtr = 0; iJobPtr < m_pendingUpdates.size(); iJobPtr++)
     delete m_pendingUpdates.at(iJobPtr);
   m_pendingUpdates.clear();
+  
+  /* unregister application action listener */
+  g_application.UnregisterActionListener(&CPVRActionListener::Get());
 
   HideProgressDialog();
 
@@ -418,6 +422,9 @@ void CPVRManager::Start(bool bAsync /* = false */, int openWindowId /* = 0 */)
   if (!m_database)
     m_database = new CPVRDatabase;
   m_database->Open();
+  
+  /* register application action listener */
+  g_application.RegisterActionListener(&CPVRActionListener::Get());
 
   /* create the supervisor thread to do all background activities */
   StartUpdateThreads();

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -544,11 +544,10 @@ namespace PVR
     bool SetWakeupCommand(void);
 
     /*!
-     * @brief Handle PVR specific cActions
-     * @param action The action to process
-     * @return True if action could be handled, false otherwise.
+     * @brief Wait until the pvr manager is loaded
+     * @return True when loaded, false otherwise
      */
-    bool OnAction(const CAction &action);
+    bool WaitUntilInitialised(void);
 
     /*!
      * @brief Create EPG tags for all channels in internal channel groups

--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -525,35 +525,6 @@ bool CPVRChannelGroups::DeleteGroup(const CPVRChannelGroup &group)
   return bFound;
 }
 
-void CPVRChannelGroups::FillGroupsGUI(int iWindowId, int iControlId) const
-{
-  int iListGroupPtr(0);
-  int iSelectedGroupPtr(0);
-  CPVRChannelGroupPtr selectedGroup = g_PVRManager.GetPlayingGroup(false);
-  std::vector< std::pair<std::string, int> > labels;
-
-  // fetch all groups
-  {
-    CSingleLock lock(m_critSection);
-    for (std::vector<CPVRChannelGroupPtr>::const_iterator it = m_groups.begin(); it != m_groups.end(); ++it)
-    {
-      // skip empty groups
-      if ((*it)->Size() == 0)
-        continue;
-
-      if ((*it)->GroupID() == selectedGroup->GroupID())
-        iSelectedGroupPtr = iListGroupPtr;
-
-      labels.push_back(make_pair((*it)->GroupName(), iListGroupPtr++));
-    }
-  }
-
-  // selected group
-  CGUIMessage msgSel(GUI_MSG_SET_LABELS, iWindowId, iControlId, iSelectedGroupPtr);
-  msgSel.SetPointer(&labels);
-  g_windowManager.SendMessage(msgSel);
-}
-
 bool CPVRChannelGroups::CreateChannelEpgs(void)
 {
   bool bReturn(false);

--- a/xbmc/pvr/channels/PVRChannelGroups.h
+++ b/xbmc/pvr/channels/PVRChannelGroups.h
@@ -194,13 +194,6 @@ namespace PVR
     bool IsRadio(void) const { return m_bRadio; }
 
     /*!
-     * @brief Call by a guiwindow/dialog to add the groups to a control
-     * @param iWindowId The window to add the groups to.
-     * @param iControlId The control to add the groups to
-     */
-    void FillGroupsGUI(int iWindowId, int iControlId) const;
-
-    /*!
      * @brief Update the contents of the groups in this container.
      * @param bChannelsOnly Set to true to only update channels, not the groups themselves.
      * @return True if the update was successful, false otherwise.

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -235,65 +235,11 @@ bool CGUIWindowFullScreen::OnAction(const CAction &action)
   case REMOTE_8:
   case REMOTE_9:
     {
-      if (g_application.CurrentFileItem().IsLiveTV())
-      {
-        if(CPVRManager::Get().IsPlaying())
-        {
-          // pvr client addon
-          CPVRChannelPtr playingChannel;
-          if(!g_PVRManager.GetCurrentChannel(playingChannel))
-            return false;
-
-          if (action.GetID() == REMOTE_0)
-          {
-            CPVRChannelGroupPtr group = g_PVRChannelGroups->GetPreviousPlayedGroup();
-            if (group)
-            {
-              g_PVRManager.SetPlayingGroup(group);
-              CFileItemPtr fileItem = group->GetLastPlayedChannel(playingChannel->ChannelID());
-              if (fileItem && fileItem->HasPVRChannelInfoTag())
-              {
-                CLog::Log(LOGDEBUG, "%s - switch to channel number %d", __FUNCTION__, fileItem->GetPVRChannelInfoTag()->ChannelNumber());
-                g_application.OnAction(CAction(ACTION_CHANNEL_SWITCH, (float) fileItem->GetPVRChannelInfoTag()->ChannelNumber()));
-              }
-            }
-          }
-          else
-          {
-            int autoCloseTime = CSettings::Get().GetBool("pvrplayback.confirmchannelswitch") ? 0 : g_advancedSettings.m_iPVRNumericChannelSwitchTimeout;
-            std::string strChannel = StringUtils::Format("%i", action.GetID() - REMOTE_0);
-            if (CGUIDialogNumeric::ShowAndGetNumber(strChannel, g_localizeStrings.Get(19000), autoCloseTime) || autoCloseTime)
-            {
-              int iChannelNumber = atoi(strChannel.c_str());
-              if (iChannelNumber > 0 && iChannelNumber != playingChannel->ChannelNumber())
-              {
-                CPVRChannelGroupPtr selectedGroup = g_PVRManager.GetPlayingGroup(playingChannel->IsRadio());
-                CFileItemPtr channel = selectedGroup->GetByChannelNumber(iChannelNumber);
-                if (!channel || !channel->HasPVRChannelInfoTag())
-                  return false;
-
-                g_application.OnAction(CAction(ACTION_CHANNEL_SWITCH, (float)iChannelNumber));
-              }
-            }
-          }
-        }
-        else
-        {
-          // filesystem provider like slingbox, cmyth, etc
-          int iChannelNumber = -1;
-          std::string strChannel = StringUtils::Format("%i", action.GetID() - REMOTE_0);
-          if (CGUIDialogNumeric::ShowAndGetNumber(strChannel, g_localizeStrings.Get(19000)))
-            iChannelNumber = atoi(strChannel.c_str());
-            
-          if (iChannelNumber > 0)
-            g_application.OnAction(CAction(ACTION_CHANNEL_SWITCH, (float)iChannelNumber));
-        }
-      }
-      else
+      if (!g_application.CurrentFileItem().IsLiveTV())
       {
         ChangetheTimeCode(action.GetID());
+        return true;
       }
-      return true;
     }
     break;
 

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -53,8 +53,6 @@
 #include "utils/StringUtils.h"
 #include "XBDateTime.h"
 #include "input/ButtonTranslator.h"
-#include "pvr/PVRManager.h"
-#include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "windowing/WindowingFactory.h"
 #include "cores/IPlayer.h"
 #include "filesystem/File.h"
@@ -65,13 +63,10 @@
 #include "linux/LinuxResourceCounter.h"
 #endif
 
-using namespace PVR;
-
 #define BLUE_BAR                          0
 #define LABEL_ROW1                       10
 #define LABEL_ROW2                       11
 #define LABEL_ROW3                       12
-#define CONTROL_GROUP_CHOOSER            503
 
 //Displays current position, visible after seek or when forced
 //Alt, use conditional visibility Player.DisplayAfterSeek
@@ -98,7 +93,6 @@ CGUIWindowFullScreen::CGUIWindowFullScreen(void)
   m_bShowViewModeInfo = false;
   m_dwShowViewModeTimeout = 0;
   m_bShowCurrentTime = false;
-  m_bGroupSelectShow = false;
   m_loadType = KEEP_IN_MEMORY;
   // audio
   //  - language
@@ -280,18 +274,6 @@ bool CGUIWindowFullScreen::OnAction(const CAction &action)
     }
     return true;
     break;
-  case ACTION_PREVIOUS_CHANNELGROUP:
-    {
-      if (g_application.CurrentFileItem().HasPVRChannelInfoTag())
-        ChangetheTVGroup(false);
-      return true;
-    }
-  case ACTION_NEXT_CHANNELGROUP:
-    {
-      if (g_application.CurrentFileItem().HasPVRChannelInfoTag())
-        ChangetheTVGroup(true);
-      return true;
-    }
   default:
       break;
   }
@@ -332,8 +314,6 @@ void CGUIWindowFullScreen::OnWindowLoaded()
   }
 
   m_showCodec.Parse("player.showcodec", GetID());
-
-  FillInTVGroups();
 }
 
 bool CGUIWindowFullScreen::OnMessage(CGUIMessage& message)
@@ -352,7 +332,6 @@ bool CGUIWindowFullScreen::OnMessage(CGUIMessage& message)
       g_infoManager.SetShowInfo(false);
       g_infoManager.SetShowCodec(false);
       m_bShowCurrentTime = false;
-      m_bGroupSelectShow = false;
       g_infoManager.SetDisplayAfterSeek(0); // Make sure display after seek is off.
 
       // switch resolution
@@ -399,61 +378,6 @@ bool CGUIWindowFullScreen::OnMessage(CGUIMessage& message)
       g_renderManager.Update();
 #endif
       return true;
-    }
-  case GUI_MSG_CLICKED:
-    {
-      unsigned int iControl = message.GetSenderId();
-      if (iControl == CONTROL_GROUP_CHOOSER && g_PVRManager.IsStarted())
-      {
-        // Get the currently selected label of the Select button
-        CGUIMessage msg(GUI_MSG_ITEM_SELECTED, GetID(), iControl);
-        OnMessage(msg);
-        std::string strLabel = msg.GetLabel();
-
-        CPVRChannelPtr playingChannel;
-        if (g_PVRManager.GetCurrentChannel(playingChannel))
-        {
-          CPVRChannelGroupPtr selectedGroup = g_PVRChannelGroups->Get(playingChannel->IsRadio())->GetByName(strLabel);
-          if (selectedGroup)
-          {
-            g_PVRManager.SetPlayingGroup(selectedGroup);
-            CLog::Log(LOGDEBUG, "%s - switched to group '%s'", __FUNCTION__, selectedGroup->GroupName().c_str());
-
-            if (!selectedGroup->IsGroupMember(*playingChannel))
-            {
-              CLog::Log(LOGDEBUG, "%s - channel '%s' is not a member of '%s', switching to channel 1 of the new group",
-                  __FUNCTION__, playingChannel->ChannelName().c_str(), selectedGroup->GroupName().c_str());
-              CFileItemPtr switchChannel = selectedGroup->GetByChannelNumber(1);
-
-              if (switchChannel && switchChannel->HasPVRChannelInfoTag())
-                g_application.OnAction(CAction(ACTION_CHANNEL_SWITCH, (float) switchChannel->GetPVRChannelInfoTag()->ChannelNumber()));
-              else
-              {
-                CLog::Log(LOGERROR, "%s - cannot find channel '1' in group %s", __FUNCTION__, selectedGroup->GroupName().c_str());
-                CApplicationMessenger::Get().MediaStop(false);
-              }
-            }
-          }
-          else
-          {
-            CLog::Log(LOGERROR, "%s - could not switch to group '%s'", __FUNCTION__, selectedGroup->GroupName().c_str());
-            CApplicationMessenger::Get().MediaStop(false);
-          }
-        }
-        else
-        {
-          CLog::Log(LOGERROR, "%s - cannot find the current channel", __FUNCTION__);
-          CApplicationMessenger::Get().MediaStop(false);
-        }
-
-        // hide the control and reset focus
-        m_bGroupSelectShow = false;
-        SET_CONTROL_HIDDEN(CONTROL_GROUP_CHOOSER);
-//      SET_CONTROL_FOCUS(0, 0);
-
-        return true;
-      }
-      break;
     }
   case GUI_MSG_SETFOCUS:
   case GUI_MSG_LOSTFOCUS:
@@ -646,7 +570,6 @@ void CGUIWindowFullScreen::FrameMove()
     SET_CONTROL_VISIBLE(LABEL_ROW2);
     SET_CONTROL_VISIBLE(LABEL_ROW3);
     SET_CONTROL_VISIBLE(BLUE_BAR);
-    SET_CONTROL_HIDDEN(CONTROL_GROUP_CHOOSER);
   }
   else if (m_timeCodeShow)
   {
@@ -654,15 +577,6 @@ void CGUIWindowFullScreen::FrameMove()
     SET_CONTROL_HIDDEN(LABEL_ROW2);
     SET_CONTROL_HIDDEN(LABEL_ROW3);
     SET_CONTROL_VISIBLE(BLUE_BAR);
-    SET_CONTROL_HIDDEN(CONTROL_GROUP_CHOOSER);
-  }
-  else if (m_bGroupSelectShow)
-  {
-    SET_CONTROL_HIDDEN(LABEL_ROW1);
-    SET_CONTROL_HIDDEN(LABEL_ROW2);
-    SET_CONTROL_HIDDEN(LABEL_ROW3);
-    SET_CONTROL_HIDDEN(BLUE_BAR);
-    SET_CONTROL_VISIBLE(CONTROL_GROUP_CHOOSER);
   }
   else
   {
@@ -670,7 +584,6 @@ void CGUIWindowFullScreen::FrameMove()
     SET_CONTROL_HIDDEN(LABEL_ROW2);
     SET_CONTROL_HIDDEN(LABEL_ROW3);
     SET_CONTROL_HIDDEN(BLUE_BAR);
-    SET_CONTROL_HIDDEN(CONTROL_GROUP_CHOOSER);
   }
 }
 
@@ -740,47 +653,6 @@ void CGUIWindowFullScreen::SeekChapter(int iChapter)
 
   // Make sure gui items are visible.
   g_infoManager.SetDisplayAfterSeek();
-}
-
-void CGUIWindowFullScreen::FillInTVGroups()
-{
-  if (!g_PVRManager.IsStarted())
-    return;
-
-  CGUIMessage msgReset(GUI_MSG_LABEL_RESET, GetID(), CONTROL_GROUP_CHOOSER);
-  g_windowManager.SendMessage(msgReset);
-
-  const CPVRChannelGroups *groups = g_PVRChannelGroups->Get(g_PVRManager.IsPlayingRadio());
-  if (groups)
-    groups->FillGroupsGUI(GetID(), CONTROL_GROUP_CHOOSER);
-}
-
-void CGUIWindowFullScreen::ChangetheTVGroup(bool next)
-{
-  if (!g_PVRManager.IsStarted())
-    return;
-
-  CGUIControl* pButton = GetControl(CONTROL_GROUP_CHOOSER);
-  if (!pButton)
-    return;
-
-  if (!m_bGroupSelectShow)
-  {
-    SET_CONTROL_VISIBLE(CONTROL_GROUP_CHOOSER);
-    SET_CONTROL_FOCUS(CONTROL_GROUP_CHOOSER, 0);
-
-    // fire off an event that we've pressed this button...
-    OnAction(CAction(ACTION_SELECT_ITEM));
-
-    m_bGroupSelectShow = true;
-  }
-  else
-  {
-    if (next)
-      pButton->OnRight();
-    else
-      pButton->OnLeft();
-  }
 }
 
 void CGUIWindowFullScreen::ToggleOSD()

--- a/xbmc/video/windows/GUIWindowFullScreen.h
+++ b/xbmc/video/windows/GUIWindowFullScreen.h
@@ -35,14 +35,12 @@ public:
   virtual void Render();
   virtual void OnWindowLoaded();
   void ChangetheTimeCode(int remote);
-  void ChangetheTVGroup(bool next);
 
 protected:
   virtual EVENT_RESULT OnMouseEvent(const CPoint &point, const CMouseEvent &event);
 
 private:
   void SeekChapter(int iChapter);
-  void FillInTVGroups();
   void ToggleOSD();
   void TriggerOSD();
 
@@ -65,7 +63,6 @@ private:
 
   bool m_bShowCurrentTime;
 
-  bool m_bGroupSelectShow;
   bool m_timeCodeShow;
   unsigned int m_timeCodeTimeout;
   int m_timeCodeStamp[6];


### PR DESCRIPTION
This is the follow-up for #6116 which introduce a new action listener pattern to separate for example PVR specific action handling out of GUIWindow's or CApplication.

@FernetMenta @Jalle19 ping
