### PR TITLE
panning with gamepad in slideshow fixed

### DIFF
--- a/system/keymaps/joystick.Microsoft.Xbox.360.Controller.xml
+++ b/system/keymaps/joystick.Microsoft.Xbox.360.Controller.xml
@@ -80,6 +80,7 @@
      <name>Logitech Gamepad F310</name>
      <name>Logitech Gamepad F510</name>
      <name>Logitech Gamepad F710</name>
+     <name>Generic X-Box pad</name>
      <name>Logitech Chillstream Controller</name>
      <name>Mad Catz Wired Xbox 360 Controller</name>
      <name>Mad Catz Street Fighter IV FightStick SE</name>
@@ -454,8 +455,8 @@
       <button id="12">ZoomOut</button>
       <button id="13">PreviousPicture</button>
       <button id="14">NextPicture</button>
-      <axis id="1">AnalogMove</axis>
-      <axis id="2">AnalogMove</axis>
+      <axis id="1">AnalogMoveX</axis>
+      <axis id="2">AnalogMoveY</axis>
       <axis id="3" limit="+1">ZoomOut</axis>
       <axis id="3" limit="-1">ZoomIn</axis>
       <hat id="1" position="up">ZoomIn</hat>
@@ -473,8 +474,8 @@
       <button id="13">NextPicture</button>
       <button id="14">ZoomIn</button>
       <button id="15">ZoomOut</button>
-      <axis id="1">AnalogMove</axis>
-      <axis id="2">AnalogMove</axis>
+      <axis id="1">AnalogMoveX</axis>
+      <axis id="2">AnalogMoveY</axis>
       <axis id="3">ZoomOut</axis>
       <axis id="6">ZoomIn</axis>
       <hat id="1" position="up">ZoomIn</hat>

--- a/system/keymaps/joystick.Sony.PLAYSTATION(R)3.Controller.xml
+++ b/system/keymaps/joystick.Sony.PLAYSTATION(R)3.Controller.xml
@@ -268,8 +268,8 @@
       <button id="13">ZoomNormal</button>
       <button id="11">Rotate</button>
       <button id="12">CodecInfo</button>
-      <axis id="1">AnalogMove</axis>
-      <axis id="2">AnalogMove</axis>
+      <axis id="1">AnalogMoveX</axis>
+      <axis id="2">AnalogMoveY</axis>
       <axis id="13">ZoomOut</axis>
       <axis id="14">ZoomIn</axis>
       <button id="5">ZoomIn</button>

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -114,6 +114,8 @@ static const ActionMapping actions[] =
         {"nextcalibration"   , ACTION_CALIBRATE_SWAP_ARROWS},
         {"resetcalibration"  , ACTION_CALIBRATE_RESET},
         {"analogmove"        , ACTION_ANALOG_MOVE},
+        {"analogmovex"       , ACTION_ANALOG_MOVE_X},
+        {"analogmovey"       , ACTION_ANALOG_MOVE_Y},
         {"rotate"            , ACTION_ROTATE_PICTURE_CW},
         {"rotateccw"         , ACTION_ROTATE_PICTURE_CCW},
         {"close"             , ACTION_NAV_BACK}, // backwards compatibility

--- a/xbmc/input/Key.h
+++ b/xbmc/input/Key.h
@@ -157,6 +157,7 @@
 #define ACTION_CALIBRATE_SWAP_ARROWS  47 // select next arrow. Can b used in: settingsScreenCalibration.xml windowid=11
 #define ACTION_CALIBRATE_RESET        48 // reset calibration to defaults. Can b used in: settingsScreenCalibration.xml windowid=11/settingsUICalibration.xml windowid=10
 #define ACTION_ANALOG_MOVE            49 // analog thumbstick move. Can b used in: slideshow.xml window id=2007/settingsScreenCalibration.xml windowid=11/settingsUICalibration.xml windowid=10
+// see also ACTION_ANALOG_MOVE_X, ACTION_ANALOG_MOVE_Y
 #define ACTION_ROTATE_PICTURE_CW      50 // rotate current picture clockwise during slideshow. Can be used in slideshow.xml window id=2007
 #define ACTION_ROTATE_PICTURE_CCW     51 // rotate current picture counterclockwise during slideshow. Can be used in slideshow.xml window id=2007
 
@@ -372,6 +373,11 @@
 #define ACTION_GESTURE_SWIPE_DOWN_TEN   550
 // 5xx is reserved for additional gesture actions
 #define ACTION_GESTURE_END            599
+
+// other, non-gesture actions
+#define ACTION_ANALOG_MOVE_X            601 // analog thumbstick move, horizontal axis; see ACTION_ANALOG_MOVE
+#define ACTION_ANALOG_MOVE_Y            602 // analog thumbstick move, vertical axis; see ACTION_ANALOG_MOVE
+
 
 // The NOOP action can be specified to disable an input event. This is
 // useful in user keyboard.xml etc to disable actions specified in the

--- a/xbmc/input/SDLJoystick.cpp
+++ b/xbmc/input/SDLJoystick.cpp
@@ -306,6 +306,29 @@ bool CJoystick::GetAxis(std::string &joyName, int& id) const
   return true;
 }
 
+bool CJoystick::GetAxes(std::list<std::pair<std::string, int> >& axes, bool consider_still)
+{
+  std::list<std::pair<std::string, int> > ret;
+  if (!IsEnabled() || !IsAxisActive())
+    return false;
+
+  SDL_Joystick *joy;
+  int axisId;
+
+  for (size_t i = 0; i < m_Axes.size(); ++i)
+  {
+    int deadzone = m_Axes[i].trigger ? 0 : m_DeadzoneRange;
+    int amount = m_Axes[i].val - m_Axes[i].rest;
+    if (consider_still || abs(amount) > deadzone)
+    {
+      MapAxis(i, joy, axisId);
+      ret.push_back(std::pair<std::string, int>(SDL_JoystickName(joy), axisId));
+    }
+  }
+  axes = ret;
+  return true;
+}
+
 int CJoystick::GetAxisWithMaxAmount() const
 {
   int maxAmount= 0, axis = -1;

--- a/xbmc/input/SDLJoystick.h
+++ b/xbmc/input/SDLJoystick.h
@@ -23,6 +23,8 @@
 
 #include "system.h" // for HAS_SDL_JOYSTICK
 #include <vector>
+#include <list>
+#include <utility>
 #include <string>
 #include <map>
 #include <memory>
@@ -78,6 +80,7 @@ public:
   bool GetAxis(std::string &joyName, int &id) const;
   bool GetButton(std::string &joyName, int &id, bool consider_repeat = true);
   bool GetHat(std::string &joyName, int &id, int &position, bool consider_repeat = true);
+  bool GetAxes(std::list<std::pair<std::string, int> >& axes, bool consider_still = false);
   float GetAmount(std::string &joyName, int axisNum) const;
   bool IsEnabled() const { return m_joystickEnabled; }
   void SetEnabled(bool enabled = true);

--- a/xbmc/input/windows/WINJoystick.cpp
+++ b/xbmc/input/windows/WINJoystick.cpp
@@ -427,6 +427,33 @@ bool CJoystick::GetAxis(std::string &joyName, int &id)
   return true;
 }
 
+bool CJoystick::GetAxes(std::list<std::pair<std::string, int> >& axes, bool consider_still)
+{
+  std::list<std::pair<std::string, int> > ret;
+  if (!IsEnabled() || !IsAxisActive())
+    return false;
+
+  LPDIRECTINPUTDEVICE8 joy;
+  int axisId;
+
+  for (size_t i = 0; i < m_Axes.size(); ++i)
+  {
+    int deadzone = m_Axes[i].trigger ? 0 : m_DeadzoneRange;
+    int amount = m_Axes[i].val - m_Axes[i].rest;
+    CLog::LogF(LOGDEBUG, "checking axis %d/%d; amount %d (deadzone %d)", i, m_Axes.size(), amount, deadzone);
+    CLog::LogF(LOGDEBUG, "axis %d: trigger:%s, val:%d, rest:%d", i,m_Axes[i].trigger?"yes":"no", m_Axes[i].val, m_Axes[i].rest);
+    if (consider_still || abs(amount) > deadzone)
+    {
+      CLog::LogF(LOGDEBUG, "adding axis %d (%d)", i, axisId);
+      MapAxis(i, joy, axisId);
+      ret.push_back(std::pair<std::string, int>(m_JoystickNames[JoystickIndex(joy)], axisId));
+    }
+  }
+  axes = ret;
+
+  return true;
+}
+
 int CJoystick::GetAxisWithMaxAmount() const
 {
   int maxAmount = 0, axis = -1;

--- a/xbmc/input/windows/WINJoystick.h
+++ b/xbmc/input/windows/WINJoystick.h
@@ -22,6 +22,7 @@
 #include <vector>
 #include <string>
 #include <map>
+#include <list>
 #include <memory>
 #include <stdint.h>
 #include "threads/CriticalSection.h"
@@ -66,6 +67,7 @@ public:
 
   bool GetButton(std::string &joyName, int &id, bool consider_repeat = true);
   bool GetAxis(std::string &joyName, int &id);
+  bool GetAxes(std::list<std::pair<std::string, int> >& axes, bool consider_still = false);
   bool GetHat(std::string &joyName, int &id, int &position, bool consider_repeat = true);
   float GetAmount(const std::string &joyName, int axisNum) const;
 

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -887,7 +887,15 @@ bool CGUIWindowSlideShow::OnAction(const CAction &action)
     break;
 
   case ACTION_ANALOG_MOVE:
+    // this action is used and works, when CAction object provides both x and y coordinates
     Move(action.GetAmount()*PICTURE_MOVE_AMOUNT_ANALOG, -action.GetAmount(1)*PICTURE_MOVE_AMOUNT_ANALOG);
+    break;
+  case ACTION_ANALOG_MOVE_X:
+    // this and following action are used and work, when CAction object provides either x of y coordinate
+    Move(action.GetAmount()*PICTURE_MOVE_AMOUNT_ANALOG, 0.0f);
+    break;
+  case ACTION_ANALOG_MOVE_Y:
+    Move(0.0f, action.GetAmount(0)*PICTURE_MOVE_AMOUNT_ANALOG);
     break;
 
   default:


### PR DESCRIPTION
It is now possible to pann zoomed pictures using gamepad analog axis.
(fixes http://forum.kodi.tv/showthread.php?tid=135871 3rd issue)

Input from several axes is now handled at the same time.
A side-effect of this is possibility to pan images diagonally.

Minor bugfix was done with handling volume up/down globally.

I needed to create new actions in Key.h, so I added them to the end of list in order to not change all values after 49.
