### PR TITLE
Silence a lot of warnings

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResampleFFMPEG.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResampleFFMPEG.cpp
@@ -184,7 +184,7 @@ int CActiveAEResampleFFMPEG::Resample(uint8_t **dst_buffer, int dst_samples, uin
   if (ratio != 1.0)
   {
     if (swr_set_compensation(m_pContext,
-                                            (dst_samples*ratio-dst_samples)*m_dst_rate/m_src_rate,
+                                            static_cast<int>((dst_samples*ratio-dst_samples)*m_dst_rate/m_src_rate),
                                              dst_samples*m_dst_rate/m_src_rate) < 0)
     {
       CLog::Log(LOGERROR, "CActiveAEResampleFFMPEG::Resample - set compensation failed");
@@ -259,13 +259,13 @@ int64_t CActiveAEResampleFFMPEG::GetDelay(int64_t base)
 
 int CActiveAEResampleFFMPEG::GetBufferedSamples()
 {
-  return av_rescale_rnd(swr_get_delay(m_pContext, m_src_rate),
-                                    m_dst_rate, m_src_rate, AV_ROUND_UP);
+  return static_cast<int>(av_rescale_rnd(swr_get_delay(m_pContext, m_src_rate),
+                                    m_dst_rate, m_src_rate, AV_ROUND_UP));
 }
 
 int CActiveAEResampleFFMPEG::CalcDstSampleCount(int src_samples, int dst_rate, int src_rate)
 {
-  return av_rescale_rnd(src_samples, dst_rate, src_rate, AV_ROUND_UP);
+  return static_cast<int>(av_rescale_rnd(src_samples, dst_rate, src_rate, AV_ROUND_UP));
 }
 
 int CActiveAEResampleFFMPEG::GetSrcBufferSize(int samples)

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -188,8 +188,8 @@ void CActiveAESink::StateMachine(int signal, Protocol *port, Message *msg)
           {
             SinkReply reply;
             reply.format = m_sinkFormat;
-            reply.cacheTotal = m_sink->GetCacheTotal();
-            reply.latency = m_sink->GetLatency();
+            reply.cacheTotal = static_cast<float>(m_sink->GetCacheTotal());
+            reply.latency = static_cast<float>(m_sink->GetLatency());
             reply.hasVolume = m_sink->HasVolume();
             m_state = S_TOP_CONFIGURED_IDLE;
             m_extTimeout = 10000;
@@ -856,7 +856,7 @@ unsigned int CActiveAESink::OutputSamples(CSampleBuffer* samples)
     }
     m_stats->UpdateSinkDelay(status, samples->pool ? written : 0, pts, samples->clockId);
   }
-  return status.delay * 1000;
+  return static_cast<unsigned int>(status.delay * 1000);
 }
 
 void CActiveAESink::SwapInit(CSampleBuffer* samples)

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
@@ -96,7 +96,7 @@ void CActiveAEStream::InitRemapper()
   for(unsigned int i=0; i<m_format.m_channelLayout.Count(); i++)
   {
     avLast = avCur;
-    avCur = CAEUtil::GetAVChannel(m_format.m_channelLayout[i]);
+    avCur = static_cast<unsigned int>(CAEUtil::GetAVChannel(m_format.m_channelLayout[i]));
     if(avCur < avLast)
     {
       needRemap = true;
@@ -221,7 +221,7 @@ unsigned int CActiveAEStream::AddData(uint8_t* const *data, unsigned int offset,
 
       if (!copied)
       {
-        m_currentBuffer->timestamp = pts;
+        m_currentBuffer->timestamp = static_cast<int64_t>(pts);
         m_currentBuffer->clockId = m_clockId;
         m_currentBuffer->pkt_start_offset = m_currentBuffer->pkt->nb_samples;
       }
@@ -235,7 +235,7 @@ unsigned int CActiveAEStream::AddData(uint8_t* const *data, unsigned int offset,
       {
         CSingleLock lock(*m_statsLock);
         m_currentBuffer->pkt->nb_samples += minFrames;
-        m_bufferedTime += (double)minFrames / m_currentBuffer->pkt->config.sample_rate;
+        m_bufferedTime += static_cast<float>(minFrames) / m_currentBuffer->pkt->config.sample_rate;
       }
 
       if (m_currentBuffer->pkt->nb_samples == m_currentBuffer->pkt->max_nb_samples)

--- a/xbmc/cores/VideoRenderers/DXVA.cpp
+++ b/xbmc/cores/VideoRenderers/DXVA.cpp
@@ -493,7 +493,7 @@ bool CProcessor::CreateSurfaces()
   }
 
   m_context = new CSurfaceContext();
-  for (int i = 0; i < m_size; i++)
+  for (uint32_t i = 0; i < m_size; i++)
   {
     m_context->AddSurface(surfaces[i]);
   }
@@ -609,10 +609,12 @@ bool CProcessor::Render(CRect src, CRect dst, IDirect3DSurface9* target, IDirect
   
   D3DSURFACE_DESC desc;
   CHECK(target->GetDesc(&desc));
-  CRect rectTarget(0, 0, desc.Width, desc.Height);
+  CRect rectTarget(0, 0, static_cast<float>(desc.Width), static_cast<float>(desc.Height));
   CWIN32Util::CropSource(src, dst, rectTarget);
-  RECT sourceRECT = { src.x1, src.y1, src.x2, src.y2 };
-  RECT dstRECT    = { dst.x1, dst.y1, dst.x2, dst.y2 };
+  RECT sourceRECT = { static_cast<LONG>(src.x1), static_cast<LONG>(src.y1),
+                      static_cast<LONG>(src.x2), static_cast<LONG>(src.y2) };
+  RECT dstRECT    = { static_cast<LONG>(dst.x1), static_cast<LONG>(dst.y1),
+                      static_cast<LONG>(dst.x2), static_cast<LONG>(dst.y2) };
 
   // set sample format for progressive and interlaced
   UINT sampleFormat = DXVA2_SampleProgressiveFrame;
@@ -693,9 +695,9 @@ bool CProcessor::Render(CRect src, CRect dst, IDirect3DSurface9* target, IDirect
     blt.DestFormat.NominalRange          = DXVA2_NominalRange_0_255;
   blt.Alpha = DXVA2_Fixed32OpaqueAlpha();
 
-  blt.ProcAmpValues.Brightness = ConvertRange( m_brightness, CMediaSettings::Get().GetCurrentVideoSettings().m_Brightness
+  blt.ProcAmpValues.Brightness = ConvertRange( m_brightness, static_cast<int>(CMediaSettings::Get().GetCurrentVideoSettings().m_Brightness)
                                              , 0, 100, 50);
-  blt.ProcAmpValues.Contrast   = ConvertRange( m_contrast, CMediaSettings::Get().GetCurrentVideoSettings().m_Contrast
+  blt.ProcAmpValues.Contrast   = ConvertRange( m_contrast, static_cast<int>(CMediaSettings::Get().GetCurrentVideoSettings().m_Contrast)
                                              , 0, 100, 50);
   blt.ProcAmpValues.Hue        = m_hue.DefaultValue;
   blt.ProcAmpValues.Saturation = m_saturation.DefaultValue;

--- a/xbmc/cores/VideoRenderers/DXVAHD.cpp
+++ b/xbmc/cores/VideoRenderers/DXVAHD.cpp
@@ -49,16 +49,6 @@ using namespace DXVA;
 using namespace AUTOPTR;
 using namespace std;
 
-#define CHECK(a) \
-do { \
-  HRESULT res = a; \
-  if(FAILED(res)) \
-  { \
-    CLog::Log(LOGERROR, __FUNCTION__" - failed executing "#a" at line %d with error %x", __LINE__, res); \
-    return false; \
-  } \
-} while(0);
-
 #define LOGIFERROR(a) \
 do { \
   HRESULT res = a; \
@@ -309,7 +299,7 @@ bool CProcessorHD::CreateSurfaces()
 {
   LPDIRECT3DDEVICE9 pD3DDevice = g_Windowing.Get3DDevice();
   LPDIRECT3DSURFACE9 surfaces[32];
-  for (unsigned idx = 0; idx < m_size; idx++)
+  for (uint32_t idx = 0; idx < m_size; idx++)
   {
     CHECK(pD3DDevice->CreateOffscreenPlainSurface(
       (m_width + 15) & ~15,
@@ -321,7 +311,7 @@ bool CProcessorHD::CreateSurfaces()
   }
 
   m_context = new CSurfaceContext();
-  for (int i = 0; i < m_size; i++)
+  for (uint32_t i = 0; i < m_size; i++)
   {
     m_context->AddSurface(surfaces[i]);
   }
@@ -386,10 +376,12 @@ bool CProcessorHD::Render(CRect src, CRect dst, IDirect3DSurface9* target, IDire
 
   D3DSURFACE_DESC desc;
   CHECK(target->GetDesc(&desc));
-  CRect rectTarget(0, 0, desc.Width, desc.Height);
+  CRect rectTarget(0, 0, static_cast<float>(desc.Width), static_cast<float>(desc.Height));
   CWIN32Util::CropSource(src, dst, rectTarget);
-  RECT sourceRECT = { src.x1, src.y1, src.x2, src.y2 };
-  RECT dstRECT    = { dst.x1, dst.y1, dst.x2, dst.y2 };
+  RECT sourceRECT = { static_cast<LONG>(src.x1), static_cast<LONG>(src.y1),
+                      static_cast<LONG>(src.x2), static_cast<LONG>(src.y2) };
+  RECT dstRECT = { static_cast<LONG>(dst.x1), static_cast<LONG>(dst.y1),
+                   static_cast<LONG>(dst.x2), static_cast<LONG>(dst.y2) };
 
   DXVAHD_FRAME_FORMAT dxvaFrameFormat = DXVAHD_FRAME_FORMAT_PROGRESSIVE;
 
@@ -477,9 +469,9 @@ bool CProcessorHD::Render(CRect src, CRect dst, IDirect3DSurface9* target, IDire
   LOGIFERROR( m_pDXVAVP->SetVideoProcessStreamState( 0, DXVAHD_STREAM_STATE_SOURCE_RECT
                                                    , sizeof(srcRect), &srcRect));
 
-  ApplyFilter( DXVAHD_FILTER_BRIGHTNESS, CMediaSettings::Get().GetCurrentVideoSettings().m_Brightness
+  ApplyFilter( DXVAHD_FILTER_BRIGHTNESS, static_cast<int>(CMediaSettings::Get().GetCurrentVideoSettings().m_Brightness)
                                              , 0, 100, 50);
-  ApplyFilter( DXVAHD_FILTER_CONTRAST, CMediaSettings::Get().GetCurrentVideoSettings().m_Contrast
+  ApplyFilter( DXVAHD_FILTER_CONTRAST, static_cast<int>(CMediaSettings::Get().GetCurrentVideoSettings().m_Contrast)
                                              , 0, 100, 50);
 
   unsigned int uiRange = g_Windowing.UseLimitedColor() ? 1 : 0;

--- a/xbmc/cores/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoRenderers/RenderManager.cpp
@@ -1073,7 +1073,7 @@ void CXBMCRenderManager::PrepareNextRender()
   double clocktime = GetPresentTime();
   double frametime = 1.0 / GetMaximumFPS();
   double correction = 0.0;
-  int fps = g_VideoReferenceClock.GetRefreshRate();
+  int fps = static_cast<int>(g_VideoReferenceClock.GetRefreshRate());
   if((fps > 0) && g_graphicsContext.IsFullScreenVideo() && (clocktime != m_clock_framefinish))
   {
     correction = frametime;

--- a/xbmc/cores/VideoRenderers/VideoShaders/WinVideoFilter.cpp
+++ b/xbmc/cores/VideoRenderers/VideoShaders/WinVideoFilter.cpp
@@ -808,7 +808,7 @@ void CConvolutionShaderSeparable::PrepareParameters(unsigned int sourceWidth, un
 
     // Alter rectangles the destination rectangle exceeds the intermediate target width when zooming and causes artifacts.
     // Work on the parameters rather than the members to avoid disturbing the parameter change detection the next time the function is called
-    CRect tgtRect(0, 0, destWidth, destHeight);
+    CRect tgtRect(0, 0, static_cast<float>(destWidth), static_cast<float>(destHeight));
     CWIN32Util::CropSource(sourceRect, destRect, tgtRect);
 
     // Manipulate the coordinates to work only on the active parts of the textures,

--- a/xbmc/cores/VideoRenderers/WinRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/WinRenderer.cpp
@@ -978,8 +978,8 @@ void CWinRenderer::Stage1()
     pD3DDevice->GetRenderTarget(0, &oldRT);
     pD3DDevice->SetRenderTarget(0, newRT);
 
-    CRect srcRect(0.0f, 0.0f, m_sourceWidth, m_sourceHeight);
-    CRect rtRect(0.0f, 0.0f, m_sourceWidth, m_sourceHeight);
+    CRect srcRect(0.0f, 0.0f, static_cast<float>(m_sourceWidth), static_cast<float>(m_sourceHeight));
+    CRect rtRect(0.0f, 0.0f, static_cast<float>(m_sourceWidth), static_cast<float>(m_sourceHeight));
 
     m_colorShader->Render(srcRect, rtRect,
                           CMediaSettings::Get().GetCurrentVideoSettings().m_Contrast,
@@ -1008,9 +1008,9 @@ void CWinRenderer::Stage2()
   if (m_renderMethod == RENDER_DXVA)
   {
     sourceRect.y1 = 0.0f;
-    sourceRect.y2 = m_sourceHeight;
+    sourceRect.y2 = static_cast<float>(m_sourceHeight);
     sourceRect.x1 = 0.0f;
-    sourceRect.x2 = m_sourceWidth;
+    sourceRect.x2 = static_cast<float>(m_sourceWidth);
   }
   else
     sourceRect = m_sourceRect;
@@ -1027,9 +1027,9 @@ void CWinRenderer::RenderProcessor(DWORD flags)
   if (m_bUseHQScaler)
   {
     destRect.y1 = 0.0f;
-    destRect.y2 = m_sourceHeight;
+    destRect.y2 = static_cast<float>(m_sourceHeight);
     destRect.x1 = 0.0f;
-    destRect.x2 = m_sourceWidth;
+    destRect.x2 = static_cast<float>(m_sourceWidth);
   }
   else
     destRect = g_graphicsContext.StereoCorrection(m_destRect);

--- a/xbmc/cores/dvdplayer/DVDClock.cpp
+++ b/xbmc/cores/dvdplayer/DVDClock.cpp
@@ -232,7 +232,7 @@ int CDVDClock::UpdateFramerate(double fps, double* interval /*= NULL*/)
 
   g_VideoReferenceClock.SetSpeed(speed);
 
-  return rate;
+  return static_cast<int>(rate);
 }
 
 void CDVDClock::CheckSystemClock()

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -481,14 +481,17 @@ int CDVDVideoCodecFFmpeg::Decode(uint8_t* pData, int iSize, double dts, double p
   av_init_packet(&avpkt);
   avpkt.data = pData;
   avpkt.size = iSize;
-#define SET_PKT_TS(ts) \
-  if(ts != DVD_NOPTS_VALUE)\
-    avpkt.ts = (ts / DVD_TIME_BASE) * AV_TIME_BASE;\
-  else\
-    avpkt.ts = AV_NOPTS_VALUE
-  SET_PKT_TS(pts);
-  SET_PKT_TS(dts);
-#undef SET_PKT_TS
+  
+  if (pts != DVD_NOPTS_VALUE)
+    avpkt.pts = static_cast<int64_t>((pts / DVD_TIME_BASE) * AV_TIME_BASE);
+  else
+    avpkt.pts = AV_NOPTS_VALUE;
+
+  if (dts != DVD_NOPTS_VALUE)
+    avpkt.dts = static_cast<int64_t>((dts / DVD_TIME_BASE) * AV_TIME_BASE);
+  else
+    avpkt.dts = AV_NOPTS_VALUE;
+
   /* We lie, but this flag is only used by pngdec.c.
    * Setting it correctly would allow CorePNG decoding. */
   avpkt.flags = AV_PKT_FLAG_KEY;

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DXVA.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DXVA.h
@@ -37,10 +37,10 @@ namespace DXVA {
 do { \
   HRESULT res = a; \
   if(FAILED(res)) \
-  { \
-    CLog::Log(LOGERROR, "DXVA - failed executing "#a" at line %d with error %x", __LINE__, res); \
+    { \
+    CLog::Log(LOGERROR, __FUNCTION__" - failed executing "#a" at line %d with error %x", __LINE__, res); \
     return false; \
-  } \
+    } \
 } while(0);
 
 class CSurfaceContext

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -775,7 +775,7 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
 
         // we need to get duration slightly different for matroska embedded text subtitels
         if(m_bMatroska && stream->codec && stream->codec->codec_id == AV_CODEC_ID_TEXT && m_pkt.pkt.convergence_duration != 0)
-          m_pkt.pkt.duration = m_pkt.pkt.convergence_duration;
+          m_pkt.pkt.duration = static_cast<int>(m_pkt.pkt.convergence_duration);
 
         if(m_bAVI && stream->codec && stream->codec->codec_type == AVMEDIA_TYPE_VIDEO)
         {
@@ -1165,7 +1165,8 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int iId)
 
         st->iWidth = pStream->codec->width;
         st->iHeight = pStream->codec->height;
-        st->fAspect = SelectAspect(pStream, &st->bForcedAspect) * pStream->codec->width / pStream->codec->height;
+        st->fAspect = static_cast<float>(SelectAspect(pStream, &st->bForcedAspect) *
+                                         pStream->codec->width / pStream->codec->height);
         st->iOrientation = 0;
         st->iBitsPerPixel = pStream->codec->bits_per_coded_sample;
 

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -73,7 +73,7 @@ int DllLibbluray::file_eof(BD_FILE_H *file)
 
 int64_t DllLibbluray::file_read(BD_FILE_H *file, uint8_t *buf, int64_t size)
 {
-  return static_cast<CFile*>(file->internal)->Read(buf, size); // TODO: fix size cast
+  return static_cast<CFile*>(file->internal)->Read(buf, static_cast<size_t>(size));
 }
 
 int64_t DllLibbluray::file_write(BD_FILE_H *file, const uint8_t *buf, int64_t size)

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -1172,7 +1172,7 @@ void CDVDPlayer::Process()
     }
     else
     {
-      starttime = m_Edl.RestoreCutTime(m_PlayerOptions.starttime * 1000); // s to ms
+      starttime = m_Edl.RestoreCutTime(static_cast<int>(m_PlayerOptions.starttime * 1000)); // s to ms
     }
     CLog::Log(LOGDEBUG, "%s - Start position set to last stopped position: %d", __FUNCTION__, starttime);
   }
@@ -2094,7 +2094,7 @@ void CDVDPlayer::CheckAutoSceneSkip()
   const int64_t clock = m_omxplayer_mode ? GetTime() : DVD_TIME_TO_MSEC(min(m_CurrentAudio.dts, m_CurrentVideo.dts) + m_offset_pts);
 
   CEdl::Cut cut;
-  if(!m_Edl.InCut(clock, &cut))
+  if(!m_Edl.InCut(static_cast<int>(clock), &cut))
     return;
 
   if(cut.action == CEdl::CUT
@@ -2102,7 +2102,8 @@ void CDVDPlayer::CheckAutoSceneSkip()
   {
     CLog::Log(LOGDEBUG, "%s - Clock in EDL cut [%s - %s]: %s. Automatically skipping over.",
               __FUNCTION__, CEdl::MillisecondsToTimeString(cut.start).c_str(),
-              CEdl::MillisecondsToTimeString(cut.end).c_str(), CEdl::MillisecondsToTimeString(clock).c_str());
+              CEdl::MillisecondsToTimeString(cut.end).c_str(),
+              CEdl::MillisecondsToTimeString(static_cast<int>(clock)).c_str());
     /*
      * Seeking either goes to the start or the end of the cut depending on the play direction.
      */
@@ -2124,7 +2125,7 @@ void CDVDPlayer::CheckAutoSceneSkip()
   {
     CLog::Log(LOGDEBUG, "%s - Clock in commercial break [%s - %s]: %s. Automatically skipping to end of commercial break (only done once per break)",
               __FUNCTION__, CEdl::MillisecondsToTimeString(cut.start).c_str(), CEdl::MillisecondsToTimeString(cut.end).c_str(),
-              CEdl::MillisecondsToTimeString(clock).c_str());
+              CEdl::MillisecondsToTimeString(static_cast<int>(clock)).c_str());
     /*
      * Seeking is NOT flushed so any content up to the demux point is retained when playing forwards.
      */
@@ -2322,11 +2323,11 @@ void CDVDPlayer::HandleMessages()
         if(m_pDemuxer && m_pDemuxer->SeekChapter(msg.GetChapter(), &start))
         {
           FlushBuffers(false, start, true);
-          offset = DVD_TIME_TO_MSEC(start) - beforeSeek;
+          offset = static_cast<double>(DVD_TIME_TO_MSEC(start) - beforeSeek);
           m_callback.OnPlayBackSeekChapter(msg.GetChapter());
         }
 
-        g_infoManager.SetDisplayAfterSeek(2500, offset);
+        g_infoManager.SetDisplayAfterSeek(2500, static_cast<int>(offset));
       }
       else if (pMsg->IsType(CDVDMsg::DEMUXER_RESET))
       {
@@ -2457,7 +2458,7 @@ void CDVDPlayer::HandleMessages()
           if ( (speed != DVD_PLAYSPEED_PAUSE && speed != DVD_PLAYSPEED_NORMAL) ||
                (m_playSpeed != DVD_PLAYSPEED_PAUSE && m_playSpeed != DVD_PLAYSPEED_NORMAL) )
           {
-            m_messenger.Put(new CDVDMsgPlayerSeek(GetTime(), (speed < 0), true, true, false, true));
+            m_messenger.Put(new CDVDMsgPlayerSeek(static_cast<int>(GetTime()), (speed < 0), true, true, false, true));
           }
           else
           {
@@ -2469,7 +2470,7 @@ void CDVDPlayer::HandleMessages()
         }
         else if (m_playSpeed < 0 && speed >= 0)
         {
-          int64_t iTime = (int64_t)DVD_TIME_TO_MSEC(m_clock.GetClock() + m_State.time_offset);
+          int iTime = static_cast<int>(DVD_TIME_TO_MSEC(m_clock.GetClock() + m_State.time_offset));
           m_messenger.Put(new CDVDMsgPlayerSeek(iTime, true, true, false, false, true));
         }
 
@@ -2849,7 +2850,7 @@ bool CDVDPlayer::SeekScene(bool bPlus)
    * There is a 5 second grace period applied when seeking for scenes backwards. If there is no
    * grace period applied it is impossible to go backwards past a scene marker.
    */
-  int64_t clock = GetTime();
+  int clock = static_cast<int>(GetTime());
   if (!bPlus && clock > 5 * 1000) // 5 seconds
     clock -= 5 * 1000;
 
@@ -4303,8 +4304,8 @@ void CDVDPlayer::UpdatePlayState(double timeout)
 
   if (m_Edl.HasCut())
   {
-    state.time        = (double) m_Edl.RemoveCutTime(llrint(state.time));
-    state.time_total  = (double) m_Edl.RemoveCutTime(llrint(state.time_total));
+    state.time        = (double) m_Edl.RemoveCutTime(static_cast<int>(llrint(state.time)));
+    state.time_total  = (double) m_Edl.RemoveCutTime(static_cast<int>(llrint(state.time_total)));
   }
 
   if(state.time_total <= 0)

--- a/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
@@ -423,7 +423,7 @@ int CDVDPlayerAudio::DecodeFrame(DVDAudioFrame &audioframe)
     }
     else if (pMsg->IsType(CDVDMsg::PLAYER_SETSPEED))
     {
-      double speed = static_cast<CDVDMsgInt*>(pMsg)->m_value;
+      int speed = static_cast<CDVDMsgInt*>(pMsg)->m_value;
 
       if (speed == DVD_PLAYSPEED_NORMAL)
       {
@@ -712,7 +712,7 @@ bool CDVDPlayerAudio::OutputPacket(DVDAudioFrame &audioframe)
     m_dvdAudio.SetResampleRatio(1.0);
     if (error > 0)
     {
-      int dups = std::min(DVD_MSEC_TO_TIME(100), error) / audioframe.duration;
+      int dups = static_cast<int>(std::min(DVD_MSEC_TO_TIME(100), error) / audioframe.duration);
       for (int i = 0; i < dups; i++)
       {
         m_dvdAudio.AddPackets(audioframe);

--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
@@ -421,7 +421,7 @@ void CDVDPlayerVideo::Process()
     else if (pMsg->IsType(CDVDMsg::VIDEO_SET_ASPECT))
     {
       CLog::Log(LOGDEBUG, "CDVDPlayerVideo - CDVDMsg::VIDEO_SET_ASPECT");
-      m_fForcedAspectRatio = *((CDVDMsgDouble*)pMsg);
+      m_fForcedAspectRatio = static_cast<float>(*((CDVDMsgDouble*)pMsg));
     }
     else if (pMsg->IsType(CDVDMsg::GENERAL_RESET))
     {
@@ -1032,7 +1032,7 @@ int CDVDPlayerVideo::OutputPicture(const DVDVideoPicture* src, double pts)
                                 , pPicture->iHeight
                                 , pPicture->iDisplayWidth
                                 , pPicture->iDisplayHeight
-                                , config_framerate
+                                , static_cast<float>(config_framerate)
                                 , flags
                                 , pPicture->format
                                 , pPicture->extended_format

--- a/xbmc/cores/dvdplayer/Edl.cpp
+++ b/xbmc/cores/dvdplayer/Edl.cpp
@@ -270,8 +270,8 @@ bool CEdl::ReadEdl(const std::string& strMovie, const float fFramesPerSecond)
       continue;
 
     Cut cut;
-    cut.start = iCutStartEnd[0];
-    cut.end = iCutStartEnd[1];
+    cut.start = static_cast<int>(iCutStartEnd[0]);
+    cut.end = static_cast<int>(iCutStartEnd[1]);
 
     switch (iAction)
     {
@@ -386,8 +386,8 @@ bool CEdl::ReadComskip(const std::string& strMovie, const float fFramesPerSecond
     if (sscanf(szBuffer, "%lf %lf", &dStartFrame, &dEndFrame) == 2)
     {
       Cut cut;
-      cut.start = (int64_t)(dStartFrame / fFrameRate * 1000);
-      cut.end = (int64_t)(dEndFrame / fFrameRate * 1000);
+      cut.start = static_cast<int>(dStartFrame / fFrameRate * 1000);
+      cut.end = static_cast<int>(dEndFrame / fFrameRate * 1000);
       cut.action = COMM_BREAK;
       bValid = AddCut(cut);
     }
@@ -463,8 +463,8 @@ bool CEdl::ReadVideoReDo(const std::string& strMovie)
          *  Times need adjusting by 1/10,000 to get ms.
          */
         Cut cut;
-        cut.start = (int64_t)(dStart / 10000);
-        cut.end = (int64_t)(dEnd / 10000);
+        cut.start = static_cast<int>(dStart / 10000);
+        cut.end = static_cast<int>(dEnd / 10000);
         cut.action = CUT;
         bValid = AddCut(cut);
       }
@@ -476,7 +476,7 @@ bool CEdl::ReadVideoReDo(const std::string& strMovie)
       int iScene;
       double dSceneMarker;
       if (sscanf(szBuffer + strlen(VIDEOREDO_TAG_SCENE), " %i>%lf", &iScene, &dSceneMarker) == 2)
-        bValid = AddSceneMarker((int64_t)(dSceneMarker / 10000)); // Times need adjusting by 1/10,000 to get ms.
+        bValid = AddSceneMarker(static_cast<int>(dSceneMarker / 10000)); // Times need adjusting by 1/10,000 to get ms.
       else
         bValid = false;
     }
@@ -559,8 +559,8 @@ bool CEdl::ReadBeyondTV(const std::string& strMovie)
        * atof() returns 0 if there were any problems and will subsequently be rejected in AddCut().
        */
       Cut cut;
-      cut.start = (int64_t)(atof(pStart->FirstChild()->Value()) / 10000);
-      cut.end = (int64_t)(atof(pEnd->FirstChild()->Value()) / 10000);
+      cut.start = static_cast<int>(atof(pStart->FirstChild()->Value()) / 10000);
+      cut.end = static_cast<int>(atof(pEnd->FirstChild()->Value()) / 10000);
       cut.action = COMM_BREAK;
       bValid = AddCut(cut);
     }
@@ -614,8 +614,8 @@ bool CEdl::ReadPvr(const std::string &strMovie)
   for (it = edl.begin(); it != edl.end(); ++it)
   {
     Cut cut;
-    cut.start = it->start;
-    cut.end = it->end;
+    cut.start = static_cast<int>(it->start);
+    cut.end = static_cast<int>(it->end);
 
     switch (it->type)
     {

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -163,11 +163,11 @@ size_t CCurlFile::CReadState::ReadCallback(char *buffer, size_t size, size_t nit
     return CURL_READFUNC_PAUSE;
   }
 
-  int64_t retSize = XMIN(m_fileSize - m_filePos, int64_t(nitems * size));
-  memcpy(buffer, m_readBuffer + m_filePos, retSize);
+  int64_t retSize = std::min(m_fileSize - m_filePos, int64_t(nitems * size));
+  memcpy(buffer, m_readBuffer + m_filePos, static_cast<size_t>(retSize));
   m_filePos += retSize;
 
-  return retSize;
+  return static_cast<size_t>(retSize);
 }
 
 size_t CCurlFile::CReadState::WriteCallback(char *buffer, size_t size, size_t nitems)
@@ -1061,7 +1061,7 @@ ssize_t CCurlFile::Write(const void* lpBuf, size_t uiBufSize)
   }
 
   m_writeOffset += m_state->m_filePos;
-  return m_state->m_filePos;
+  return static_cast<ssize_t>(m_state->m_filePos);
 }
 
 bool CCurlFile::CReadState::ReadString(char *szLine, int iLineLength)

--- a/xbmc/filesystem/ISOFile.cpp
+++ b/xbmc/filesystem/ISOFile.cpp
@@ -85,7 +85,8 @@ ssize_t CISOFile::Read(void *lpBuf, size_t uiBufSize)
       if (m_cache.getMaxReadSize() )
       {
         long lBytes2Read = m_cache.getMaxReadSize();
-        if (lBytes2Read > uiBufSize) lBytes2Read = (long)uiBufSize;
+        if (static_cast<size_t>(lBytes2Read) > uiBufSize)
+          lBytes2Read = (long)uiBufSize;
         m_cache.ReadData(pData, lBytes2Read );
         uiBufSize -= lBytes2Read ;
         pData += lBytes2Read;

--- a/xbmc/filesystem/RTVFile.cpp
+++ b/xbmc/filesystem/RTVFile.cpp
@@ -142,7 +142,7 @@ ssize_t CRTVFile::Read(void *lpBuf, size_t uiBufSize)
   if(m_filePos + lenread > m_fileSize)
   {
     CLog::Log(LOGWARNING, "%s - RTV library read passed filesize, returning last chunk", __FUNCTION__);
-    lenread = (m_fileSize - m_filePos);
+    lenread = static_cast<ssize_t>(m_fileSize - m_filePos);
     m_filePos = m_fileSize;
     return lenread;
   }

--- a/xbmc/filesystem/ZipFile.cpp
+++ b/xbmc/filesystem/ZipFile.cpp
@@ -346,7 +346,7 @@ ssize_t CZipFile::Read(void* lpBuf, size_t uiBufSize)
   else if (mZipItem.method == 0) // uncompressed. just read from file, but mind our boundaries.
   {
     if (uiBufSize+m_iFilePos > mZipItem.csize)
-      uiBufSize = mZipItem.csize-m_iFilePos;
+      uiBufSize = static_cast<size_t>(mZipItem.csize-m_iFilePos);
 
     if (uiBufSize == 0)
       return 0; // we are past eof, this shouldn't happen but test anyway
@@ -444,7 +444,7 @@ bool CZipFile::FillBuffer()
 {
   ssize_t sToRead = 65535;
   if (m_iZipFilePos+65535 > mZipItem.csize)
-    sToRead = mZipItem.csize-m_iZipFilePos;
+    sToRead = static_cast<ssize_t>(mZipItem.csize-m_iZipFilePos);
 
   if (sToRead <= 0)
     return false; // eof!

--- a/xbmc/filesystem/test/TestFile.cpp
+++ b/xbmc/filesystem/test/TestFile.cpp
@@ -53,7 +53,7 @@ TEST(TestFile, Read)
   currentPos = firstBuf.length();
   EXPECT_EQ(currentPos, file.GetPosition());
   EXPECT_TRUE(memcmp(firstBuf.c_str(), buf, firstBuf.length()) == 0);
-  EXPECT_TRUE(file.Read(buf, secondBuf.length()));
+  EXPECT_GT(0, file.Read(buf, secondBuf.length()));
   currentPos += secondBuf.length();
   EXPECT_EQ(currentPos, file.GetPosition());
   EXPECT_TRUE(memcmp(secondBuf.c_str(), buf, secondBuf.length()) == 0);
@@ -142,7 +142,7 @@ TEST(TestFile, Stat)
   ASSERT_TRUE((file = XBMC_CREATETEMPFILE("")) != NULL);
   EXPECT_EQ(0, file->Stat(&buffer));
   file->Close();
-  EXPECT_TRUE(buffer.st_mode | _S_IFREG);
+  EXPECT_NE(0, buffer.st_mode | _S_IFREG);
   EXPECT_EQ(-1, XFILE::CFile::Stat("", &buffer));
   EXPECT_EQ(ENOENT, errno);
   EXPECT_TRUE(XBMC_DELETETEMPFILE(file));

--- a/xbmc/filesystem/test/TestRarFile.cpp
+++ b/xbmc/filesystem/test/TestRarFile.cpp
@@ -22,6 +22,7 @@
 #ifdef HAS_FILESYSTEM_RAR
 #include "filesystem/Directory.h"
 #include "filesystem/File.h"
+#include "filesystem/NFSFile.h"
 #include "URL.h"
 #include "utils/URIUtils.h"
 #include "FileItem.h"
@@ -116,7 +117,7 @@ TEST(TestRarFile, Stat)
   strpathinrar = itemlist[0]->GetPath();
 
   EXPECT_EQ(0, XFILE::CFile::Stat(strpathinrar, &buffer));
-  EXPECT_TRUE(buffer.st_mode | _S_IFREG);
+  EXPECT_NE(0, buffer.st_mode | _S_IFREG);
 }
 
 /* Test case to test for graceful handling of corrupted input.
@@ -216,7 +217,7 @@ TEST(TestRarFile, StoredRAR)
   strpathinrar = itemlist[1]->GetPath();
   ASSERT_TRUE(StringUtils::EndsWith(strpathinrar, "/reffile.txt"));
   EXPECT_EQ(0, XFILE::CFile::Stat(strpathinrar, &stat_buffer));
-  EXPECT_TRUE((stat_buffer.st_mode & S_IFMT) | S_IFREG);
+  EXPECT_NE(0, (stat_buffer.st_mode & S_IFMT) | S_IFREG);
 
   ASSERT_TRUE(file.Open(strpathinrar));
   EXPECT_EQ(0, file.GetPosition());
@@ -261,7 +262,7 @@ TEST(TestRarFile, StoredRAR)
   strpathinrar = itemlist[2]->GetPath();
   ASSERT_TRUE(StringUtils::EndsWith(strpathinrar, "/testsymlink"));
   EXPECT_EQ(0, XFILE::CFile::Stat(strpathinrar, &stat_buffer));
-  EXPECT_TRUE((stat_buffer.st_mode & S_IFMT) | S_IFLNK);
+  EXPECT_NE(0, (stat_buffer.st_mode & S_IFMT) | S_IFLNK);
 
   /*
    * FIXME: Reading symlinks in RARs is currently broken. It takes a long time
@@ -276,7 +277,7 @@ TEST(TestRarFile, StoredRAR)
   strpathinrar = itemlist[3]->GetPath();
   ASSERT_TRUE(StringUtils::EndsWith(strpathinrar, "/testsymlinksubdir"));
   EXPECT_EQ(0, XFILE::CFile::Stat(strpathinrar, &stat_buffer));
-  EXPECT_TRUE((stat_buffer.st_mode & S_IFMT) | S_IFLNK);
+  EXPECT_NE(0, (stat_buffer.st_mode & S_IFMT) | S_IFLNK);
 
   ASSERT_TRUE(file.Open(strpathinrar));
   EXPECT_EQ(30, file.GetLength());
@@ -286,7 +287,7 @@ TEST(TestRarFile, StoredRAR)
   strpathinrar = itemlist[0]->GetPath();
   ASSERT_TRUE(StringUtils::EndsWith(strpathinrar, "/testdir/"));
   EXPECT_EQ(0, XFILE::CFile::Stat(strpathinrar, &stat_buffer));
-  EXPECT_TRUE((stat_buffer.st_mode & S_IFMT) | S_IFDIR);
+  EXPECT_NE(0, (stat_buffer.st_mode & S_IFMT) | S_IFDIR);
 
   itemlist.Clear();
   ASSERT_TRUE(XFILE::CDirectory::GetDirectory(strpathinrar, itemlist));
@@ -296,7 +297,7 @@ TEST(TestRarFile, StoredRAR)
   strpathinrar = itemlist[1]->GetPath();
   ASSERT_TRUE(StringUtils::EndsWith(strpathinrar, "/testdir/reffile.txt"));
   EXPECT_EQ(0, XFILE::CFile::Stat(strpathinrar, &stat_buffer));
-  EXPECT_TRUE((stat_buffer.st_mode & S_IFMT) | S_IFREG);
+  EXPECT_NE(0, (stat_buffer.st_mode & S_IFMT) | S_IFREG);
 
   ASSERT_TRUE(file.Open(strpathinrar));
   EXPECT_EQ(0, file.GetPosition());
@@ -343,7 +344,7 @@ TEST(TestRarFile, StoredRAR)
   /* TODO: Should this set the itemlist to an empty list instead? */
   EXPECT_FALSE(XFILE::CDirectory::GetDirectory(strpathinrar, itemlistemptydir));
   EXPECT_EQ(0, XFILE::CFile::Stat(strpathinrar, &stat_buffer));
-  EXPECT_TRUE((stat_buffer.st_mode & S_IFMT) | S_IFDIR);
+  EXPECT_NE(0, (stat_buffer.st_mode & S_IFMT) | S_IFDIR);
 
   /* FIXME: This directory appears a second time as a file */
   strpathinrar = itemlist[3]->GetPath();
@@ -353,7 +354,7 @@ TEST(TestRarFile, StoredRAR)
   strpathinrar = itemlist[4]->GetPath();
   ASSERT_TRUE(StringUtils::EndsWith(strpathinrar, "/testdir/testsymlink"));
   EXPECT_EQ(0, XFILE::CFile::Stat(strpathinrar, &stat_buffer));
-  EXPECT_TRUE((stat_buffer.st_mode & S_IFMT) | S_IFLNK);
+  EXPECT_NE(0, (stat_buffer.st_mode & S_IFMT) | S_IFLNK);
 
   ASSERT_TRUE(file.Open(strpathinrar));
   EXPECT_EQ(22, file.GetLength());
@@ -363,7 +364,7 @@ TEST(TestRarFile, StoredRAR)
   strpathinrar = itemlist[0]->GetPath();
   ASSERT_TRUE(StringUtils::EndsWith(strpathinrar, "/testdir/testsubdir/"));
   EXPECT_EQ(0, XFILE::CFile::Stat(strpathinrar, &stat_buffer));
-  EXPECT_TRUE((stat_buffer.st_mode & S_IFMT) | S_IFDIR);
+  EXPECT_NE(0, (stat_buffer.st_mode & S_IFMT) | S_IFDIR);
 
   itemlist.Clear();
   ASSERT_TRUE(XFILE::CDirectory::GetDirectory(strpathinrar, itemlist));
@@ -374,7 +375,7 @@ TEST(TestRarFile, StoredRAR)
   ASSERT_TRUE(StringUtils::EndsWith(strpathinrar,
                                     "/testdir/testsubdir/reffile.txt"));
   EXPECT_EQ(0, XFILE::CFile::Stat(strpathinrar, &stat_buffer));
-  EXPECT_TRUE((stat_buffer.st_mode & S_IFMT) | S_IFREG);
+  EXPECT_NE(0, (stat_buffer.st_mode & S_IFMT) | S_IFREG);
 
   ASSERT_TRUE(file.Open(strpathinrar));
   EXPECT_EQ(0, file.GetPosition());
@@ -434,7 +435,7 @@ TEST(TestRarFile, NormalRAR)
   strpathinrar = itemlist[1]->GetPath();
   ASSERT_TRUE(StringUtils::EndsWith(strpathinrar, "/reffile.txt"));
   EXPECT_EQ(0, XFILE::CFile::Stat(strpathinrar, &stat_buffer));
-  EXPECT_TRUE((stat_buffer.st_mode & S_IFMT) | S_IFREG);
+  EXPECT_NE(0, (stat_buffer.st_mode & S_IFMT) | S_IFREG);
 
   ASSERT_TRUE(file.Open(strpathinrar));
   EXPECT_EQ(0, file.GetPosition());
@@ -479,7 +480,7 @@ TEST(TestRarFile, NormalRAR)
   strpathinrar = itemlist[2]->GetPath();
   ASSERT_TRUE(StringUtils::EndsWith(strpathinrar, "/testsymlink"));
   EXPECT_EQ(0, XFILE::CFile::Stat(strpathinrar, &stat_buffer));
-  EXPECT_TRUE((stat_buffer.st_mode & S_IFMT) | S_IFLNK);
+  EXPECT_NE(0, (stat_buffer.st_mode & S_IFMT) | S_IFLNK);
 
   /*
    * FIXME: Reading symlinks in RARs is currently broken. It takes a long time
@@ -494,7 +495,7 @@ TEST(TestRarFile, NormalRAR)
   strpathinrar = itemlist[3]->GetPath();
   ASSERT_TRUE(StringUtils::EndsWith(strpathinrar, "/testsymlinksubdir"));
   EXPECT_EQ(0, XFILE::CFile::Stat(strpathinrar, &stat_buffer));
-  EXPECT_TRUE((stat_buffer.st_mode & S_IFMT) | S_IFLNK);
+  EXPECT_NE(0, (stat_buffer.st_mode & S_IFMT) | S_IFLNK);
 
   ASSERT_TRUE(file.Open(strpathinrar));
   EXPECT_EQ(30, file.GetLength());
@@ -504,7 +505,7 @@ TEST(TestRarFile, NormalRAR)
   strpathinrar = itemlist[0]->GetPath();
   ASSERT_TRUE(StringUtils::EndsWith(strpathinrar, "/testdir/"));
   EXPECT_EQ(0, XFILE::CFile::Stat(strpathinrar, &stat_buffer));
-  EXPECT_TRUE((stat_buffer.st_mode & S_IFMT) | S_IFDIR);
+  EXPECT_NE(0, (stat_buffer.st_mode & S_IFMT) | S_IFDIR);
 
   itemlist.Clear();
   ASSERT_TRUE(XFILE::CDirectory::GetDirectory(strpathinrar, itemlist));
@@ -514,7 +515,7 @@ TEST(TestRarFile, NormalRAR)
   strpathinrar = itemlist[1]->GetPath();
   ASSERT_TRUE(StringUtils::EndsWith(strpathinrar, "/testdir/reffile.txt"));
   EXPECT_EQ(0, XFILE::CFile::Stat(strpathinrar, &stat_buffer));
-  EXPECT_TRUE((stat_buffer.st_mode & S_IFMT) | S_IFREG);
+  EXPECT_NE(0, (stat_buffer.st_mode & S_IFMT) | S_IFREG);
 
   ASSERT_TRUE(file.Open(strpathinrar));
   EXPECT_EQ(0, file.GetPosition());
@@ -561,7 +562,7 @@ TEST(TestRarFile, NormalRAR)
   /* TODO: Should this set the itemlist to an empty list instead? */
   EXPECT_FALSE(XFILE::CDirectory::GetDirectory(strpathinrar, itemlistemptydir));
   EXPECT_EQ(0, XFILE::CFile::Stat(strpathinrar, &stat_buffer));
-  EXPECT_TRUE((stat_buffer.st_mode & S_IFMT) | S_IFDIR);
+  EXPECT_NE(0, (stat_buffer.st_mode & S_IFMT) | S_IFDIR);
 
   /* FIXME: This directory appears a second time as a file */
   strpathinrar = itemlist[3]->GetPath();
@@ -571,7 +572,7 @@ TEST(TestRarFile, NormalRAR)
   strpathinrar = itemlist[4]->GetPath();
   ASSERT_TRUE(StringUtils::EndsWith(strpathinrar, "/testdir/testsymlink"));
   EXPECT_EQ(0, XFILE::CFile::Stat(strpathinrar, &stat_buffer));
-  EXPECT_TRUE((stat_buffer.st_mode & S_IFMT) | S_IFLNK);
+  EXPECT_NE(0, (stat_buffer.st_mode & S_IFMT) | S_IFLNK);
 
   ASSERT_TRUE(file.Open(strpathinrar));
   EXPECT_EQ(22, file.GetLength());
@@ -581,7 +582,7 @@ TEST(TestRarFile, NormalRAR)
   strpathinrar = itemlist[0]->GetPath();
   ASSERT_TRUE(StringUtils::EndsWith(strpathinrar, "/testdir/testsubdir/"));
   EXPECT_EQ(0, XFILE::CFile::Stat(strpathinrar, &stat_buffer));
-  EXPECT_TRUE((stat_buffer.st_mode & S_IFMT) | S_IFDIR);
+  EXPECT_NE(0, (stat_buffer.st_mode & S_IFMT) | S_IFDIR);
 
   itemlist.Clear();
   ASSERT_TRUE(XFILE::CDirectory::GetDirectory(strpathinrar, itemlist));
@@ -592,7 +593,7 @@ TEST(TestRarFile, NormalRAR)
   ASSERT_TRUE(StringUtils::EndsWith(strpathinrar,
                                     "/testdir/testsubdir/reffile.txt"));
   EXPECT_EQ(0, XFILE::CFile::Stat(strpathinrar, &stat_buffer));
-  EXPECT_TRUE((stat_buffer.st_mode & S_IFMT) | S_IFREG);
+  EXPECT_NE(0, (stat_buffer.st_mode & S_IFMT) | S_IFREG);
 
   ASSERT_TRUE(file.Open(strpathinrar));
   EXPECT_EQ(0, file.GetPosition());

--- a/xbmc/filesystem/test/TestZipFile.cpp
+++ b/xbmc/filesystem/test/TestZipFile.cpp
@@ -139,7 +139,7 @@ TEST_F(TestZipFile, Stat)
   strpathinzip = itemlist[0]->GetPath();
 
   EXPECT_EQ(0, XFILE::CFile::Stat(strpathinzip, &buffer));
-  EXPECT_TRUE(buffer.st_mode | _S_IFREG);
+  EXPECT_NE(0, buffer.st_mode | _S_IFREG);
 }
 
 /* Test case to test for graceful handling of corrupted input.

--- a/xbmc/input/windows/WINJoystick.cpp
+++ b/xbmc/input/windows/WINJoystick.cpp
@@ -285,7 +285,7 @@ void CJoystick::Update()
     }
 
     // get button states first, they take priority over axis
-    for (int b = 0; b < caps.dwButtons; b++)
+    for (int b = 0; b < static_cast<int>(caps.dwButtons); b++)
     {
       if (js.rgbButtons[b] & 0x80)
       {
@@ -296,7 +296,7 @@ void CJoystick::Update()
     }
 
     // get hat position
-    for (int h = 0; h < caps.dwPOVs; h++)
+    for (int h = 0; h < static_cast<int>(caps.dwPOVs); h++)
     {
       if ((LOWORD(js.rgdwPOV[h]) == 0xFFFF) != true)
       {
@@ -563,7 +563,7 @@ void CJoystick::MapAxis(int axisIdx, LPDIRECTINPUTDEVICE8 &joy, int &axisNum) co
 {
   int axisCount = 0;
   size_t i;
-  for (i = 0; i != m_pJoysticks.size() && m_pJoysticks[i] != joy && axisCount + m_devCaps[i].dwAxes <= axisIdx; ++i)
+  for (i = 0; i != m_pJoysticks.size() && m_pJoysticks[i] != joy && axisCount + static_cast<int>(m_devCaps[i].dwAxes) <= axisIdx; ++i)
     axisCount += m_devCaps[i].dwAxes;
   if (i != m_pJoysticks.size())
   {
@@ -593,7 +593,7 @@ void CJoystick::MapButton(int buttonIdx, LPDIRECTINPUTDEVICE8 &joy, int &buttonN
 {
   int buttonCount = 0;
   size_t i;
-  for (i = 0; i != m_pJoysticks.size() && m_pJoysticks[i] != joy && buttonCount + m_devCaps[i].dwButtons <= buttonIdx; ++i)
+  for (i = 0; i != m_pJoysticks.size() && m_pJoysticks[i] != joy && buttonCount + static_cast<int>(m_devCaps[i].dwButtons) <= buttonIdx; ++i)
     buttonCount += m_devCaps[i].dwButtons;
   if (i != m_pJoysticks.size())
   {
@@ -623,7 +623,7 @@ void CJoystick::MapHat(int hatIdx, LPDIRECTINPUTDEVICE8 &joy, int &hatNum) const
 {
   int hatCount = 0;
   size_t i;
-  for (i = 0; i != m_pJoysticks.size() && m_pJoysticks[i] != joy && hatCount + m_devCaps[i].dwPOVs <= hatIdx; ++i)
+  for (i = 0; i != m_pJoysticks.size() && m_pJoysticks[i] != joy && hatCount + static_cast<int>(m_devCaps[i].dwPOVs) <= hatIdx; ++i)
     hatCount += m_devCaps[i].dwPOVs;
   if (i != m_pJoysticks.size())
   {

--- a/xbmc/interfaces/legacy/Monitor.cpp
+++ b/xbmc/interfaces/legacy/Monitor.cpp
@@ -45,7 +45,7 @@ namespace XBMCAddon
     bool Monitor::waitForAbort(double timeout)
     {
       XBMC_TRACE;
-      int timeoutMS = ceil(timeout * 1000);
+      int timeoutMS = static_cast<int>(ceil(timeout * 1000));
       XbmcThreads::EndTime endTime(timeoutMS > 0 ? timeoutMS : XbmcThreads::EndTime::InfiniteValue);
       while (!endTime.IsTimePast())
       {

--- a/xbmc/utils/MathUtils.h
+++ b/xbmc/utils/MathUtils.h
@@ -158,7 +158,7 @@ namespace MathUtils
   {
     assert(x > static_cast<double>(INT_MIN / 2) - 1.0);
     assert(x < static_cast<double>(INT_MAX / 2) + 1.0);
-    return x;
+    return static_cast<int>(x);
   }
 
   inline int64_t abs(int64_t a)

--- a/xbmc/utils/test/TestArchive.cpp
+++ b/xbmc/utils/test/TestArchive.cpp
@@ -42,7 +42,7 @@ protected:
 
 TEST_F(TestArchive, IsStoring)
 {
-  ASSERT_TRUE(file);
+  ASSERT_TRUE(file != NULL);
   CArchive arstore(file, CArchive::store);
   EXPECT_TRUE(arstore.IsStoring());
   EXPECT_FALSE(arstore.IsLoading());
@@ -51,7 +51,7 @@ TEST_F(TestArchive, IsStoring)
 
 TEST_F(TestArchive, IsLoading)
 {
-  ASSERT_TRUE(file);
+  ASSERT_TRUE(file != NULL);
   CArchive arload(file, CArchive::load);
   EXPECT_TRUE(arload.IsLoading());
   EXPECT_FALSE(arload.IsStoring());
@@ -60,7 +60,7 @@ TEST_F(TestArchive, IsLoading)
 
 TEST_F(TestArchive, FloatArchive)
 {
-  ASSERT_TRUE(file);
+  ASSERT_TRUE(file != NULL);
   float float_ref = 1, float_var = 0;
 
   CArchive arstore(file, CArchive::store);
@@ -77,7 +77,7 @@ TEST_F(TestArchive, FloatArchive)
 
 TEST_F(TestArchive, DoubleArchive)
 {
-  ASSERT_TRUE(file);
+  ASSERT_TRUE(file != NULL);
   double double_ref = 2, double_var = 0;
 
   CArchive arstore(file, CArchive::store);
@@ -94,7 +94,7 @@ TEST_F(TestArchive, DoubleArchive)
 
 TEST_F(TestArchive, IntegerArchive)
 {
-  ASSERT_TRUE(file);
+  ASSERT_TRUE(file != NULL);
   int int_ref = 3, int_var = 0;
 
   CArchive arstore(file, CArchive::store);
@@ -111,7 +111,7 @@ TEST_F(TestArchive, IntegerArchive)
 
 TEST_F(TestArchive, UnsignedIntegerArchive)
 {
-  ASSERT_TRUE(file);
+  ASSERT_TRUE(file != NULL);
   unsigned int unsigned_int_ref = 4, unsigned_int_var = 0;
 
   CArchive arstore(file, CArchive::store);
@@ -128,7 +128,7 @@ TEST_F(TestArchive, UnsignedIntegerArchive)
 
 TEST_F(TestArchive, Int64tArchive)
 {
-  ASSERT_TRUE(file);
+  ASSERT_TRUE(file != NULL);
   int64_t int64_t_ref = 5, int64_t_var = 0;
 
   CArchive arstore(file, CArchive::store);
@@ -145,7 +145,7 @@ TEST_F(TestArchive, Int64tArchive)
 
 TEST_F(TestArchive, UInt64tArchive)
 {
-  ASSERT_TRUE(file);
+  ASSERT_TRUE(file != NULL);
   uint64_t uint64_t_ref = 6, uint64_t_var = 0;
 
   CArchive arstore(file, CArchive::store);
@@ -162,7 +162,7 @@ TEST_F(TestArchive, UInt64tArchive)
 
 TEST_F(TestArchive, BoolArchive)
 {
-  ASSERT_TRUE(file);
+  ASSERT_TRUE(file != NULL);
   bool bool_ref = true, bool_var = false;
 
   CArchive arstore(file, CArchive::store);
@@ -179,7 +179,7 @@ TEST_F(TestArchive, BoolArchive)
 
 TEST_F(TestArchive, CharArchive)
 {
-  ASSERT_TRUE(file);
+  ASSERT_TRUE(file != NULL);
   char char_ref = 'A', char_var = '\0';
 
   CArchive arstore(file, CArchive::store);
@@ -196,7 +196,7 @@ TEST_F(TestArchive, CharArchive)
 
 TEST_F(TestArchive, WStringArchive)
 {
-  ASSERT_TRUE(file);
+  ASSERT_TRUE(file != NULL);
   std::wstring wstring_ref = L"test wstring", wstring_var;
 
   CArchive arstore(file, CArchive::store);
@@ -213,7 +213,7 @@ TEST_F(TestArchive, WStringArchive)
 
 TEST_F(TestArchive, StringArchive)
 {
-  ASSERT_TRUE(file);
+  ASSERT_TRUE(file != NULL);
   std::string string_ref = "test string", string_var;
 
   CArchive arstore(file, CArchive::store);
@@ -230,7 +230,7 @@ TEST_F(TestArchive, StringArchive)
 
 TEST_F(TestArchive, SYSTEMTIMEArchive)
 {
-  ASSERT_TRUE(file);
+  ASSERT_TRUE(file != NULL);
   SYSTEMTIME SYSTEMTIME_ref = { 1, 2, 3, 4, 5, 6, 7, 8 };
   SYSTEMTIME SYSTEMTIME_var = { 0, 0, 0, 0, 0, 0, 0, 0 };
 
@@ -248,7 +248,7 @@ TEST_F(TestArchive, SYSTEMTIMEArchive)
 
 TEST_F(TestArchive, CVariantArchive)
 {
-  ASSERT_TRUE(file);
+  ASSERT_TRUE(file != NULL);
   CVariant CVariant_ref((int)1), CVariant_var;
 
   CArchive arstore(file, CArchive::store);
@@ -266,7 +266,7 @@ TEST_F(TestArchive, CVariantArchive)
 
 TEST_F(TestArchive, CVariantArchiveString)
 {
-  ASSERT_TRUE(file);
+  ASSERT_TRUE(file != NULL);
   CVariant CVariant_ref("teststring"), CVariant_var;
 
   CArchive arstore(file, CArchive::store);
@@ -284,7 +284,7 @@ TEST_F(TestArchive, CVariantArchiveString)
 
 TEST_F(TestArchive, StringVectorArchive)
 {
-  ASSERT_TRUE(file);
+  ASSERT_TRUE(file != NULL);
   std::vector<std::string> strArray_ref, strArray_var;
   strArray_ref.push_back("test strArray_ref 0");
   strArray_ref.push_back("test strArray_ref 1");
@@ -308,7 +308,7 @@ TEST_F(TestArchive, StringVectorArchive)
 
 TEST_F(TestArchive, IntegerVectorArchive)
 {
-  ASSERT_TRUE(file);
+  ASSERT_TRUE(file != NULL);
   std::vector<int> iArray_ref, iArray_var;
   iArray_ref.push_back(0);
   iArray_ref.push_back(1);
@@ -332,7 +332,7 @@ TEST_F(TestArchive, IntegerVectorArchive)
 
 TEST_F(TestArchive, MultiTypeArchive)
 {
-  ASSERT_TRUE(file);
+  ASSERT_TRUE(file != NULL);
   float float_ref = 1, float_var = 0;
   double double_ref = 2, double_var = 0;
   int int_ref = 3, int_var = 0;

--- a/xbmc/utils/test/TestAsyncFileCopy.cpp
+++ b/xbmc/utils/test/TestAsyncFileCopy.cpp
@@ -38,8 +38,8 @@ TEST(TestAsyncFileCopy, General)
   XFILE::CFile *f1, *f2;
   char vardata[sizeof(refdata)];
 
-  ASSERT_TRUE((f1 = XBMC_CREATETEMPFILE("")));
-  ASSERT_TRUE((f2 = XBMC_CREATETEMPFILE(".copy")));
+  ASSERT_TRUE((f1 = XBMC_CREATETEMPFILE("")) != NULL);
+  ASSERT_TRUE((f2 = XBMC_CREATETEMPFILE(".copy")) != NULL);
 
   EXPECT_EQ((int)sizeof(refdata), f1->Write(refdata, sizeof(refdata)));
   f1->Close();

--- a/xbmc/utils/test/TestFileOperationJob.cpp
+++ b/xbmc/utils/test/TestFileOperationJob.cpp
@@ -34,7 +34,7 @@ TEST(TestFileOperationJob, ActionCopy)
   CFileItemList items;
   CFileOperationJob job;
 
-  ASSERT_TRUE((tmpfile = XBMC_CREATETEMPFILE("")));
+  ASSERT_TRUE((tmpfile = XBMC_CREATETEMPFILE("")) != NULL);
   tmpfilepath = XBMC_TEMPFILEPATH(tmpfile);
   tmpfile->Close();
 
@@ -68,7 +68,7 @@ TEST(TestFileOperationJob, ActionMove)
   CFileItemList items;
   CFileOperationJob job;
 
-  ASSERT_TRUE((tmpfile = XBMC_CREATETEMPFILE("")));
+  ASSERT_TRUE((tmpfile = XBMC_CREATETEMPFILE("")) != NULL);
   tmpfilepath = XBMC_TEMPFILEPATH(tmpfile);
   tmpfile->Close();
 
@@ -102,7 +102,7 @@ TEST(TestFileOperationJob, ActionDelete)
   CFileItemList items;
   CFileOperationJob job;
 
-  ASSERT_TRUE((tmpfile = XBMC_CREATETEMPFILE("")));
+  ASSERT_TRUE((tmpfile = XBMC_CREATETEMPFILE("")) != NULL);
   tmpfilepath = XBMC_TEMPFILEPATH(tmpfile);
   tmpfile->Close();
 
@@ -152,7 +152,7 @@ TEST(TestFileOperationJob, ActionReplace)
   CFileItemList items;
   CFileOperationJob job;
 
-  ASSERT_TRUE((tmpfile = XBMC_CREATETEMPFILE("")));
+  ASSERT_TRUE((tmpfile = XBMC_CREATETEMPFILE("")) != NULL);
   tmpfilepath = XBMC_TEMPFILEPATH(tmpfile);
   tmpfile->Close();
 
@@ -192,7 +192,7 @@ TEST(TestFileOperationJob, ActionCreateFolder)
   CFileItemList items;
   CFileOperationJob job;
 
-  ASSERT_TRUE((tmpfile = XBMC_CREATETEMPFILE("")));
+  ASSERT_TRUE((tmpfile = XBMC_CREATETEMPFILE("")) != NULL);
   tmpfilepath = XBMC_TEMPFILEPATH(tmpfile);
 
   std::string tmpfiledirectory =
@@ -228,7 +228,7 @@ TEST(TestFileOperationJob, ActionDeleteFolder)
   CFileItemList items;
   CFileOperationJob job;
 
-  ASSERT_TRUE((tmpfile = XBMC_CREATETEMPFILE("")));
+  ASSERT_TRUE((tmpfile = XBMC_CREATETEMPFILE("")) != NULL);
   tmpfilepath = XBMC_TEMPFILEPATH(tmpfile);
 
   std::string tmpfiledirectory =
@@ -268,7 +268,7 @@ TEST(TestFileOperationJob, GetFunctions)
   CFileItemList items;
   CFileOperationJob job;
 
-  ASSERT_TRUE((tmpfile = XBMC_CREATETEMPFILE("")));
+  ASSERT_TRUE((tmpfile = XBMC_CREATETEMPFILE("")) != NULL);
   tmpfilepath = XBMC_TEMPFILEPATH(tmpfile);
   tmpfile->Close();
 

--- a/xbmc/utils/test/TestFileUtils.cpp
+++ b/xbmc/utils/test/TestFileUtils.cpp
@@ -30,7 +30,7 @@ TEST(TestFileUtils, DeleteItem_CFileItemPtr)
   XFILE::CFile *tmpfile;
   std::string tmpfilepath;
 
-  ASSERT_TRUE((tmpfile = XBMC_CREATETEMPFILE("")));
+  ASSERT_TRUE((tmpfile = XBMC_CREATETEMPFILE("")) != NULL);
   tmpfilepath = XBMC_TEMPFILEPATH(tmpfile);
 
   CFileItemPtr item(new CFileItem(tmpfilepath));
@@ -45,7 +45,7 @@ TEST(TestFileUtils, DeleteItemString)
 {
   XFILE::CFile *tmpfile;
 
-  ASSERT_TRUE((tmpfile = XBMC_CREATETEMPFILE("")));
+  ASSERT_TRUE((tmpfile = XBMC_CREATETEMPFILE("")) != NULL);
   EXPECT_TRUE(CFileUtils::DeleteItem(XBMC_TEMPFILEPATH(tmpfile)));
 }
 

--- a/xbmc/utils/test/TestLabelFormatter.cpp
+++ b/xbmc/utils/test/TestLabelFormatter.cpp
@@ -57,7 +57,7 @@ TEST_F(TestLabelFormatter, FormatLabel)
   LABEL_MASKS labelMasks;
   CLabelFormatter formatter("", labelMasks.m_strLabel2File);
 
-  ASSERT_TRUE((tmpfile = XBMC_CREATETEMPFILE("")));
+  ASSERT_TRUE((tmpfile = XBMC_CREATETEMPFILE("")) != NULL);
   tmpfilepath = XBMC_TEMPFILEPATH(tmpfile);
 
   CFileItemPtr item(new CFileItem(tmpfilepath));
@@ -77,7 +77,7 @@ TEST_F(TestLabelFormatter, FormatLabel2)
   LABEL_MASKS labelMasks;
   CLabelFormatter formatter("", labelMasks.m_strLabel2File);
 
-  ASSERT_TRUE((tmpfile = XBMC_CREATETEMPFILE("")));
+  ASSERT_TRUE((tmpfile = XBMC_CREATETEMPFILE("")) != NULL);
   tmpfilepath = XBMC_TEMPFILEPATH(tmpfile);
 
   CFileItemPtr item(new CFileItem(tmpfilepath));

--- a/xbmc/utils/test/TestXBMCTinyXML.cpp
+++ b/xbmc/utils/test/TestXBMCTinyXML.cpp
@@ -53,7 +53,7 @@ TEST(TestXBMCTinyXML, ParseFromFileHandle)
   // scraper results with unescaped &
   CXBMCTinyXML doc;
   FILE *f = fopen(XBMC_REF_FILE_PATH("/xbmc/utils/test/CXBMCTinyXML-test.xml").c_str(), "r");
-  ASSERT_TRUE(f);
+  ASSERT_TRUE(f != NULL);
   doc.LoadFile(f);
   fclose(f);
   TiXmlNode *root = doc.RootElement();

--- a/xbmc/utils/test/Testfastmemcpy.cpp
+++ b/xbmc/utils/test/Testfastmemcpy.cpp
@@ -34,6 +34,6 @@ TEST(Testfastmemcpy, General)
 {
   char vardata[sizeof(refdata)];
   memset(vardata, 0, sizeof(vardata));
-  EXPECT_TRUE(fast_memcpy(vardata, refdata, sizeof(refdata)));
+  EXPECT_TRUE(fast_memcpy(vardata, refdata, sizeof(refdata)) != NULL);
   EXPECT_TRUE(!memcmp(refdata, vardata, sizeof(refdata)));
 }


### PR DESCRIPTION
Not much to add, silenced a lot of conversion warnings and some others mainly in VS but should probably silence other compilers as well. Tested on Win32 and Ubuntu 14.04
