### PR TITLE
[3D] don't back out from 3D handling on resolution changes

### DIFF
--- a/xbmc/guilib/GraphicContext.cpp
+++ b/xbmc/guilib/GraphicContext.cpp
@@ -438,14 +438,17 @@ void CGraphicContext::SetVideoResolutionInternal(RESOLUTION res, bool forceUpdat
 
   RENDER_STEREO_MODE stereo_mode = m_stereoMode;
 
-  // if the new mode is an actual stereo mode, switch to that
-  // if the old mode was an actual stereo mode, switch to no 3d mode
+  // if the new resolution is an actual stereo mode, switch to that
+  // if the old resolution was an actual stereo mode and renderer is still in old 3D mode, switch to no 3d mode
   if (info_org.dwFlags & D3DPRESENTFLAG_MODE3DTB)
     stereo_mode = RENDER_STEREO_MODE_SPLIT_HORIZONTAL;
   else if (info_org.dwFlags & D3DPRESENTFLAG_MODE3DSBS)
     stereo_mode = RENDER_STEREO_MODE_SPLIT_VERTICAL;
-  else if ((info_last.dwFlags & D3DPRESENTFLAG_MODE3DSBS) != 0
-        || (info_last.dwFlags & D3DPRESENTFLAG_MODE3DTB)  != 0)
+  else if ((info_last.dwFlags & D3DPRESENTFLAG_MODE3DTB)
+        && m_stereoMode == RENDER_STEREO_MODE_SPLIT_HORIZONTAL)
+    stereo_mode = RENDER_STEREO_MODE_OFF;
+  else if ((info_last.dwFlags & D3DPRESENTFLAG_MODE3DSBS)
+        && m_stereoMode == RENDER_STEREO_MODE_SPLIT_VERTICAL)
     stereo_mode = RENDER_STEREO_MODE_OFF;
 
   if(stereo_mode != m_stereoMode)


### PR DESCRIPTION
Our codebase has a logic in place to adjust the GUI rendering according to the resolution - so if a "real" 3D resolution is applied (SBS/OU), we detect it and adjust everything accordingly. Problem now is that when switching from a 3D resolution into a 3D mode that didn't require a special resolution (anaglyph, line interlaced or monoscopic) this logic overruled the target mode and set the 3D mode to "none". By validating that the internal m_stereoMode stil matches the mode of the previous resolution, we ensure this logic only kicks in on pure resolution changes (like if one is manually changing the resolution in settings) and not on "active" changes to the 3D mode.

Thanks to @anaconda for finding this spot and pointing me to it.
