### PR TITLE
[PVR] Fix CGUIWindowPVRChannels::Update (back from hidden can not work)

### DIFF
--- a/addons/skin.confluence/720p/IncludesPVR.xml
+++ b/addons/skin.confluence/720p/IncludesPVR.xml
@@ -205,6 +205,7 @@
 					<textcolor>blue</textcolor>
 					<align>center</align>
 					<aligny>center</aligny>
+					<visible>Control.IsVisible(5) | Control.IsVisible(6)</visible>
 				</control>
 				<control type="radiobutton" id="5">
 					<description>Group recording items by folder structure</description>

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -124,12 +124,12 @@ bool CGUIWindowPVRChannels::Update(const std::string &strDirectory, bool updateF
   bool bReturn = CGUIWindowPVRBase::Update(strDirectory);
 
   /* empty list for hidden channels */
-  if (m_vecItems->Size() == 0 && m_bShowHiddenChannels)
+  if (m_vecItems->GetObjectCount() == 0 && m_bShowHiddenChannels)
   {
-      /* show the visible channels instead */
-      m_bShowHiddenChannels = false;
-      lock.Leave();
-      Update(GetDirectoryPath());
+    /* show the visible channels instead */
+    m_bShowHiddenChannels = false;
+    lock.Leave();
+    Update(GetDirectoryPath());
   }
 
   return bReturn;
@@ -137,6 +137,13 @@ bool CGUIWindowPVRChannels::Update(const std::string &strDirectory, bool updateF
 
 void CGUIWindowPVRChannels::UpdateButtons(void)
 {
+  CGUIRadioButtonControl *btnShowHidden = (CGUIRadioButtonControl*) GetControl(CONTROL_BTNSHOWHIDDEN);
+  if (btnShowHidden)
+  {
+    btnShowHidden->SetVisible(g_PVRChannelGroups->GetGroupAll(m_bRadio)->GetNumHiddenChannels() > 0);
+    btnShowHidden->SetSelected(m_bShowHiddenChannels);
+  }
+
   CGUIWindowPVRBase::UpdateButtons();
   SET_CONTROL_LABEL(CONTROL_LABEL_HEADER1, m_bShowHiddenChannels ? g_localizeStrings.Get(19022) : GetGroup()->GroupName());
 }


### PR DESCRIPTION
Found during creation from indication of deleted recordings and undelete of them a fault on the PVR channel window, the "m_vecItems->Size()" return always minimum one (folder back as last) this changed to "m_vecItems->GetObjectCount() == 0" works and go back to normal channels if no hidden is present.
