### PR TITLE
Fix for coverity #1194431

### DIFF
--- a/lib/timidity/timidity/timidity.c
+++ b/lib/timidity/timidity/timidity.c
@@ -974,7 +974,13 @@ static int set_gus_patchconf(char *name, int line,
     {
 	int err;
 	if((err = set_gus_patchconf_opts(name, line, opts[j], tone)) != 0)
+    {
+#ifdef SET_GUS_PATCHCONF_COMMENT
+        if(old_name != NULL)
+            free(old_name);
+#endif
 	    return err;
+    }
     }
 #ifdef SET_GUS_PATCHCONF_COMMENT
 		if(tone->comment == NULL ||


### PR DESCRIPTION
CID 1194431 (#3 of 3): Resource leak (RESOURCE_LEAK)
leaked_storage: Variable old_name going out of scope leaks the storage it points to
