### PR TITLE
Fix for Coverity #1126044

### DIFF
--- a/xbmc/pictures/Picture.cpp
+++ b/xbmc/pictures/Picture.cpp
@@ -210,8 +210,8 @@ bool CPicture::CreateTiledThumb(const std::vector<std::string> &files, const std
         }
       }
       delete[] scaled;
-      delete texture;
     }
+    delete texture;
   }
   // now save to a file
   if (success)


### PR DESCRIPTION
CID 1126044 (2-1 of 2): Resource leak (RESOURCE_LEAK)

leaked_storage: Variable texture going out of scope leaks the storage it points to.

This should fix this (and not make any practical difference, I think.
