### PR TITLE
Fix for coverity #719001

### DIFF
--- a/xbmc/filesystem/iso9660.cpp
+++ b/xbmc/filesystem/iso9660.cpp
@@ -392,7 +392,10 @@ struct iso_dirtree *iso9660::ReadRecursiveDirFromSector( DWORD sector, const cha
           pFile_Pointer->name = (char *)malloc( temp_text.length() + 1);
 
           if (!pFile_Pointer->name)
+          {
+            free(pCurr_dir_cache);
             return NULL;
+          }
 
           strcpy( pFile_Pointer->name , temp_text.c_str());
 


### PR DESCRIPTION
CID 719001 (1 of 2): Resource leak (RESOURCE_LEAK)
61. leaked_storage: Variable pCurr_dir_cache going out of scope leaks the storage it points to.
