### PR TITLE
cmake: fix addon tarball download

### DIFF
--- a/project/cmake/addons/CMakeLists.txt
+++ b/project/cmake/addons/CMakeLists.txt
@@ -143,30 +143,47 @@ foreach(addon ${addons})
         # get the URL and revision of the addon
         list(LENGTH def deflength)
         list(GET def 1 url)
-        list(GET def 2 revision)
 
-        # download and extract all addons
-        if(deflength GREATER 2)
+        set(archive_name ${id})
+
           # if there is a 3rd parameter in the file, we consider it a git revision
+        if(deflength GREATER 2)
+          list(GET def 2 revision)
+
           # Note: downloading specific revisions via http in the format below is probably github specific
           # if we ever use other repositories, this might need adapting
           set(url ${url}/archive/${revision}.tar.gz)
+          set(archive_name ${archive_name}-${revision})
         endif()
-        if(NOT EXISTS ${BUILD_DIR}/download/${id}.tar.gz)
-          file(DOWNLOAD "${url}" "${BUILD_DIR}/download/${id}.tar.gz" STATUS dlstatus LOG dllog SHOW_PROGRESS)
+
+        # download and extract the addon
+        if(NOT EXISTS ${BUILD_DIR}/download/${archive_name}.tar.gz)
+          # cleanup any of the previously downloaded archives of this addon
+          file(GLOB archives "${BUILD_DIR}/download/${id}*.tar.gz")
+          if(archives)
+            message(STATUS "Removing old archives of ${id}: ${archives}")
+            file(REMOVE ${archives})
+          endif()
+
+          # download the addon
+          file(DOWNLOAD "${url}" "${BUILD_DIR}/download/${archive_name}.tar.gz" STATUS dlstatus LOG dllog SHOW_PROGRESS)
           list(GET dlstatus 0 retcode)
           if(NOT ${retcode} EQUAL 0)
             message(FATAL_ERROR "ERROR downloading ${url} - status: ${dlstatus} log: ${dllog}")
           endif()
         endif()
+
+        # remove any previously extracted version of the addon
         if(EXISTS "${BUILD_DIR}/${id}")
           file(REMOVE_RECURSE "${BUILD_DIR}/${id}")
         endif()
-        execute_process(COMMAND ${CMAKE_COMMAND} -E tar xzvf ${BUILD_DIR}/download/${id}.tar.gz
+
+        # extract the addon from the archive
+        execute_process(COMMAND ${CMAKE_COMMAND} -E tar xzvf ${BUILD_DIR}/download/${archive_name}.tar.gz
                         WORKING_DIRECTORY ${BUILD_DIR})
-        file(GLOB extract_dir "${BUILD_DIR}/${id}-${revision}*")
+        file(GLOB extract_dir "${BUILD_DIR}/${archive_name}*")
         if(extract_dir STREQUAL "")
-          message(FATAL_ERROR "Error extracting ${BUILD_DIR}/download/${id}.tar.gz")
+          message(FATAL_ERROR "Error extracting ${BUILD_DIR}/download/${archive_name}.tar.gz")
         else()
           file(RENAME "${extract_dir}" "${BUILD_DIR}/${id}")
         endif()

--- a/project/cmake/scripts/common/handle-depends.cmake
+++ b/project/cmake/scripts/common/handle-depends.cmake
@@ -42,11 +42,11 @@ function(add_addon_depends addon searchpath)
         endif()
 
         set(BUILD_ARGS -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}
-                       -DOUTPUT_DIR=${DEPENDS_PATH}
+                       -DOUTPUT_DIR=${OUTPUT_DIR}
                        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
                        -DCMAKE_USER_MAKE_RULES_OVERRIDE=${CMAKE_USER_MAKE_RULES_OVERRIDE}
                        -DCMAKE_USER_MAKE_RULES_OVERRIDE_CXX=${CMAKE_USER_MAKE_RULES_OVERRIDE_CXX}
-                       -DCMAKE_INSTALL_PREFIX=${DEPENDS_PATH}
+                       -DCMAKE_INSTALL_PREFIX=${OUTPUT_DIR}
                        -DARCH_DEFINES=${ARCH_DEFINES}
                        -DENABLE_STATIC=1
                        -DBUILD_SHARED_LIBS=0)
@@ -82,7 +82,7 @@ function(add_addon_depends addon searchpath)
           set(INSTALL_COMMAND INSTALL_COMMAND ${CMAKE_COMMAND}
                                               -DINPUTDIR=${BUILD_DIR}/${id}/src/${id}-build/
                                               -DINPUTFILE=${dir}/install.txt
-                                              -DDESTDIR=${DEPENDS_PATH}
+                                              -DDESTDIR=${OUTPUT_DIR}
                                               -DENABLE_STATIC=1
                                               "${extraflags}"
                                               -P ${PROJECT_SOURCE_DIR}/install.cmake)


### PR DESCRIPTION
While working on PVR binary addons @wsnipex noticed that the logic that decided whether to download the tarball of a binary addon from github was bugged and once a tarball had been downloaded we never downloaded a new tarball even if the revision/hash of the binary addon had changed. The first commit remedies this situation and also includes logic to remove any "old" downloaded tarballs of a binary addon before downloading a new one.
It also fixes support for addons not downloaded from github which currently fails because we extract the `revision` part from the binary addon definition file before checking if it's actually there.

The second commit is a simple cleanup to keep things consistent in the `add_addon_depends()` cmake helper function.
