### PR TITLE
[pvr] Improve PVR startup time

### DIFF
--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -77,8 +77,9 @@ bool CPVRChannelGroups::Update(const CPVRChannelGroup &group, bool bUpdateFromCl
 
     if (!updateGroup)
     {
-      // create a new group if none was found
-      updateGroup = CPVRChannelGroupPtr(new CPVRChannelGroup());
+      // create a new group if none was found. Copy the properties immediately 
+      // so the group doesn't get flagged as "changed" further down.
+      updateGroup = CPVRChannelGroupPtr(new CPVRChannelGroup(group.IsRadio(), group.GroupID(), group.GroupName()));
       m_groups.push_back(updateGroup);
     }
 


### PR DESCRIPTION
People have been complaining that starting the PVR manager takes too long. The reason for this is partly that we've done some unnecessary persisting of channels, groups and group members during every startup. With these changes, not a single group or channel is being persisted during startup.

Walkthrough:
- In `CPVRChannel::UpdateFromClient`, we check if the client channel name has changed. This check has always evaluated to true because we've never stored that field in the database. This means that we've always persisted every channel at least once on every startup. Thanks @FernetMenta for spotting it.
- I can't remember the reason for 98d4a4c
- we've always loaded group members into a temporary group, which means the code has always thought that every group we've loaded from the database has been empty, even when that's not the case. @opdenkamp do you know why this has been done like this? `git blame` doesn't go far enough.
- when loading groups from the database we've created an empty group first, then updated it with the data from the database. This update has caused `m_bChanged` to be set to true for every group loaded from the database, which has lead to _surprise_ all groups being persisted once more during startup.
- we've added every EPG tag to `m_changedTags` on startup. This vector is then looped over and tags are persisted if they've been changed. We can make the loop shorter by only considering tags that have actually changed. The gain here is most likely negligible on most devices, but still.

I've only tested this in VS so far on a reasonably fast machine and I can't even see the "Loading channels from clients" anymore. Next up is to have a look through the EPG loading, I'm sure there's something that can be optimized there as well.

@xhaggi pinging you too
