### PR TITLE
[pvr] fix: refresh container after view mode is changed in guide window

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -21,6 +21,7 @@
 #include "GUIWindowPVRGuide.h"
 
 #include "Application.h"
+#include "GUIUserMessages.h"
 #include "dialogs/GUIDialogOK.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/Key.h"
@@ -207,6 +208,14 @@ bool CGUIWindowPVRGuide::OnMessage(CGUIMessage& message)
         Refresh(true);
         bReturn = true;
       }
+      break;
+    }
+    case GUI_MSG_CHANGE_VIEW_MODE:
+    {
+      // let's set the view mode first before update
+      CGUIWindowPVRBase::OnMessage(message);
+      Refresh(true);
+      bReturn = true;
       break;
     }
     case GUI_MSG_REFRESH_LIST:


### PR DESCRIPTION
Attempt to fix the reported issue http://trac.kodi.tv/ticket/15706

As we use the view modes in CGUIWindowPVRGuide to populate the different EPG views (Now, Next, Timeline etc.) which relates on different items, we need to update the items list after the view mode is changed. In a normal window we only change the presentation of the same items so there is no need to update the items list.
