### PR TITLE
[coverity] fix for #1262429

### DIFF
--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxCC.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxCC.cpp
@@ -96,6 +96,7 @@ bool reorder_sort (CCaptionBlock *lhs, CCaptionBlock *rhs)
 CDVDDemuxCC::CDVDDemuxCC(AVCodecID codec)
 {
   m_hasData = false;
+  m_curPts = 0;
   m_ccDecoder = NULL;
   m_codec = codec;
 }


### PR DESCRIPTION
CID 1262429 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)2. uninit_member: Non-static class member m_curPts is not initialized in this constructor nor in any functions that it calls.
