### PR TITLE
[PVR] Hide "Channels" in Guide when no channel is playing

### DIFF
--- a/addons/skin.confluence/720p/ViewsPVRGuide.xml
+++ b/addons/skin.confluence/720p/ViewsPVRGuide.xml
@@ -1108,6 +1108,7 @@
 					<onright>75</onright>
 					<pagecontrol>75</pagecontrol>
 					<scrolltime>200</scrolltime>
+					<visible>Pvr.IsPlayingTv | Pvr.IsPlayingRadio</visible>
 					<itemlayout height="40">
 						<control type="image">
 							<left>0</left>


### PR DESCRIPTION
The "Channels" view mode in the PVR Guide only has content when a tv or radio channel is playing. When the user switches through the view modes, "Channels" shows up regardless of whether the PVR has a channel active. It makes sense to me not letting the user navigate to an empty window, as it only confuses / makes it seem malfunctioning.

Another option would be to showing a message explaining why there's nothing to see. But I think this proposal is more elegant.

P.S. I am not a PVR user myself, so if I am missing something obvious not to do this, my apologies :)
