### PR TITLE
[jenkins/droid] - allow to select the ndk version through jenkins jobs a...

### DIFF
--- a/tools/buildsteps/android/configure-depends
+++ b/tools/buildsteps/android/configure-depends
@@ -2,15 +2,20 @@ WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
 XBMC_PLATFORM_DIR=android
 . $WORKSPACE/tools/buildsteps/defaultenv
 
+NDK_ARCH="arm"
+#the following pathes must exist on the slave and use the defined scheme here!
+CURRENT_NDK_PATH=$ANDROID_DEV_ROOT/android-ndk-r$NDK_VERSION
+CURRENT_TOOLCHAIN=$ANDROID_DEV_ROOT/android-toolchain-$NDK_ARCH-$SDK_VERSION-r$NDK_VERSION
+
 if [ "$(rebuildDepends)" == "1" ]
 then
   cd $WORKSPACE/tools/depends;./configure \
     --with-tarballs=$TARBALLS \
     --host=arm-linux-androideabi \
     --with-sdk-path=$SDK_PATH \
-    --with-ndk=$NDK_PATH \
+    --with-ndk=$CURRENT_NDK_PATH \
     $(if [ "$SDK_VERSION" != "Default" ]; then echo --with-sdk=android-$SDK_VERSION;fi) \
-    --with-toolchain=$TOOLCHAIN \
+    --with-toolchain=$CURRENT_TOOLCHAIN \
     --prefix=$XBMC_DEPENDS_ROOT \
     --enable-neon
 fi

--- a/tools/buildsteps/androidx86/configure-depends
+++ b/tools/buildsteps/androidx86/configure-depends
@@ -2,14 +2,19 @@ WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
 XBMC_PLATFORM_DIR=android
 . $WORKSPACE/tools/buildsteps/defaultenv
 
+NDK_ARCH=x86
+#the following pathes must exist on the slave and use the defined scheme here!
+CURRENT_NDK_PATH=$ANDROID_DEV_ROOT/android-ndk-r$NDK_VERSION
+CURRENT_TOOLCHAIN=$ANDROID_DEV_ROOT/android-toolchain-$NDK_ARCH-$SDK_VERSION-r$NDK_VERSION
+
 if [ "$(rebuildDepends)" == "1" ]
 then
   cd $WORKSPACE/tools/depends;./configure \
     --with-tarballs=$TARBALLS \
     --host=i686-linux-android \
     --with-sdk-path=$SDK_PATH \
-    --with-ndk=$NDK_PATH \
+    --with-ndk=$CURRENT_NDK_PATH \
     $(if [ "$SDK_VERSION" != "Default" ]; then echo --with-sdk=android-$SDK_VERSION;fi) \
-    --with-toolchain=$TOOLCHAIN_X86 \
+    --with-toolchain=$CURRENT_TOOLCHAIN \
     --prefix=$XBMC_DEPENDS_ROOT
 fi

--- a/tools/buildsteps/defaultenv
+++ b/tools/buildsteps/defaultenv
@@ -1,5 +1,6 @@
 BUILDTHREADS=${BUILDTHREADS:-1}
 SDK_VERSION=${SDK_VERSION:-"Default"}
+NDK_VERSION=${NDK_VERSION:-"Default"}
 Configuration=${Configuration:-"Default"}
 XBMC_DEPENDS_ROOT=${XBMC_DEPENDS_ROOT:-"Default"}
 PATH_CHANGE_REV_FILENAME=".last_success_revision"
@@ -34,7 +35,8 @@ case $XBMC_PLATFORM_DIR in
     ;;
 
   android)
-    DEFAULT_SDK_VERSION="Default"
+    DEFAULT_SDK_VERSION="14"
+    DEFAULT_NDK_VERSION="10d"
     DEFAULT_XBMC_DEPENDS_ROOT=$WORKSPACE/tools/depends/xbmc-depends
     DEFAULT_CONFIGURATION="Debug"
     ;;
@@ -56,6 +58,11 @@ then
   SDK_VERSION=$DEFAULT_SDK_VERSION
 fi
 
+if [ "$NDK_VERSION" == "Default" ]
+then
+  NDK_VERSION=$DEFAULT_NDK_VERSION
+fi 
+
 if [ "$XBMC_DEPENDS_ROOT" == "Default" ]
 then
   XBMC_DEPENDS_ROOT=$DEFAULT_XBMC_DEPENDS_ROOT
@@ -74,14 +81,14 @@ fi
 
 #helper functions
 
-#hash a dir based on the git revision, SDK_PATH, NDK_PATH, SDK_VERSION, TOOLCHAIN TOOLCHAIN_X86 (for droidx86) and XBMC_DEPENDS_ROOT
+#hash a dir based on the git revision, SDK_PATH, NDK_PATH, NDK_VERSION, SDK_VERSION, TOOLCHAIN TOOLCHAIN_X86 (for droidx86) and XBMC_DEPENDS_ROOT
 function getBuildHash ()
 {
   local checkPath
   checkPath="$1"
   local hashStr
   hashStr="$(git rev-list HEAD --max-count=1  -- $checkPath)"
-  hashStr="$hashStr $SDK_PATH $NDK_PATH $SDK_VERSION $TOOLCHAIN $TOOLCHAIN_X86 $XBMC_DEPENDS_ROOT"
+  hashStr="$hashStr $SDK_PATH $NDK_PATH $NDK_VERSION $SDK_VERSION $TOOLCHAIN $TOOLCHAIN_X86 $XBMC_DEPENDS_ROOT"
   echo $hashStr
 }
 


### PR DESCRIPTION
...nd bump to ndk r10d

this is your button @koying 

testbuilds where successful:

http://jenkins.kodi.tv/job/Android-ARM/3027/
http://jenkins.kodi.tv/job/Android-X86/2881/ - still building but have a crystal ball ;)

default sdk is 14 default ndk is r10d - for helix branch it defaults to 14/r9 - if you want to bump sdk at some point it will be easy from now on...
