### PR TITLE
windowing/egl: add Mali support (for Allwinner / Cubieboard)

### DIFF
--- a/xbmc/windowing/egl/EGLNativeTypeMali.cpp
+++ b/xbmc/windowing/egl/EGLNativeTypeMali.cpp
@@ -1,0 +1,153 @@
+/*
+ *      Copyright (C) 2011-2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "EGLNativeTypeMali.h"
+#include "system.h"
+#include "guilib/gui3d.h"
+#include "utils/StringUtils.h"
+
+#include <EGL/egl.h>
+
+#include <math.h>
+
+CEGLNativeTypeMali::CEGLNativeTypeMali()
+{
+}
+
+CEGLNativeTypeMali::~CEGLNativeTypeMali()
+{
+}
+
+bool CEGLNativeTypeMali::CheckCompatibility()
+{
+#if defined(TARGET_MALI)
+  return true;
+#else
+  return false;
+#endif
+}
+
+void CEGLNativeTypeMali::Initialize()
+{
+}
+
+void CEGLNativeTypeMali::Destroy()
+{
+}
+
+bool CEGLNativeTypeMali::CreateNativeDisplay()
+{
+  m_nativeDisplay = EGL_DEFAULT_DISPLAY;
+  return true;
+}
+
+bool CEGLNativeTypeMali::CreateNativeWindow()
+{
+#if defined(TARGET_MALI)
+  // TODO: detect full-screen resolution
+  mali_native_window.width = 1280;
+  mali_native_window.height = 1024;
+  m_nativeWindow = &mali_native_window;
+  return true;
+#else
+  return false;
+#endif
+}
+
+bool CEGLNativeTypeMali::GetNativeDisplay(XBNativeDisplayType **nativeDisplay) const
+{
+  if (!nativeDisplay)
+    return false;
+  *nativeDisplay = (XBNativeDisplayType*) &m_nativeDisplay;
+  return true;
+}
+
+bool CEGLNativeTypeMali::GetNativeWindow(XBNativeWindowType **nativeWindow) const
+{
+  if (!nativeWindow || !m_nativeWindow)
+    return false;
+  *nativeWindow = (XBNativeWindowType*) &m_nativeWindow;
+  return true;
+}
+
+bool CEGLNativeTypeMali::DestroyNativeDisplay()
+{
+  return true;
+}
+
+bool CEGLNativeTypeMali::DestroyNativeWindow()
+{
+#if defined(TARGET_MALI)
+  return true;
+#else
+  return false;
+#endif
+}
+
+bool CEGLNativeTypeMali::GetNativeResolution(RESOLUTION_INFO *res) const
+{
+#if defined(TARGET_MALI)
+  // TODO: detect full-screen resolution
+  res->iWidth = 1280;
+  res->iHeight= 1024;
+
+  res->fRefreshRate = 60;
+  res->dwFlags= D3DPRESENTFLAG_PROGRESSIVE;
+  res->iScreen       = 0;
+  res->bFullScreen   = true;
+  res->iSubtitles    = (int)(0.965 * res->iHeight);
+  res->fPixelRatio   = 1.0f;
+  res->iScreenWidth  = res->iWidth;
+  res->iScreenHeight = res->iHeight;
+  res->strMode       = StringUtils::Format("%dx%d @ %.2f%s - Full Screen", res->iScreenWidth, res->iScreenHeight, res->fRefreshRate,
+  res->dwFlags & D3DPRESENTFLAG_INTERLACED ? "i" : "");
+
+  return true;
+#else
+  return false;
+#endif
+}
+
+bool CEGLNativeTypeMali::SetNativeResolution(const RESOLUTION_INFO &res)
+{
+  return false;
+}
+
+bool CEGLNativeTypeMali::ProbeResolutions(std::vector<RESOLUTION_INFO> &resolutions)
+{
+  RESOLUTION_INFO res;
+  bool ret = GetNativeResolution(&res);
+  if (ret && res.iWidth > 1 && res.iHeight > 1)
+  {
+    resolutions.push_back(res);
+    return true;
+  }
+  return false;
+}
+
+bool CEGLNativeTypeMali::GetPreferredResolution(RESOLUTION_INFO *res) const
+{
+  return false;
+}
+
+bool CEGLNativeTypeMali::ShowWindow(bool show)
+{
+  return false;
+}

--- a/xbmc/windowing/egl/EGLNativeTypeMali.h
+++ b/xbmc/windowing/egl/EGLNativeTypeMali.h
@@ -1,0 +1,59 @@
+#pragma once
+
+/*
+ *      Copyright (C) 2011-2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "EGLNativeType.h"
+
+#define TARGET_MALI // TODO: define somewhere else?
+#if defined(TARGET_MALI)
+#include <EGL/eglplatform.h>
+#endif
+
+class CEGLNativeTypeMali : public CEGLNativeType
+{
+public:
+  CEGLNativeTypeMali();
+  virtual ~CEGLNativeTypeMali();
+  virtual std::string GetNativeName() const { return "mali"; };
+  virtual bool  CheckCompatibility();
+  virtual void  Initialize();
+  virtual void  Destroy();
+  virtual int   GetQuirks() { return EGL_QUIRK_NONE; };
+
+  virtual bool  CreateNativeDisplay();
+  virtual bool  CreateNativeWindow();
+  virtual bool  GetNativeDisplay(XBNativeDisplayType **nativeDisplay) const;
+  virtual bool  GetNativeWindow(XBNativeWindowType **nativeWindow) const;
+
+  virtual bool  DestroyNativeWindow();
+  virtual bool  DestroyNativeDisplay();
+
+  virtual bool  GetNativeResolution(RESOLUTION_INFO *res) const;
+  virtual bool  SetNativeResolution(const RESOLUTION_INFO &res);
+  virtual bool  ProbeResolutions(std::vector<RESOLUTION_INFO> &resolutions);
+  virtual bool  GetPreferredResolution(RESOLUTION_INFO *res) const;
+
+  virtual bool  ShowWindow(bool show);
+#if defined(TARGET_MALI)
+private:
+  struct mali_native_window mali_native_window;
+#endif
+};

--- a/xbmc/windowing/egl/EGLWrapper.cpp
+++ b/xbmc/windowing/egl/EGLWrapper.cpp
@@ -24,6 +24,7 @@
 #include "EGLNativeTypeAndroid.h"
 #include "EGLNativeTypeAmlogic.h"
 #include "EGLNativeTypeRaspberryPI.h"
+#include "EGLNativeTypeMali.h"
 #include "EGLNativeTypeWayland.h"
 #include "EGLNativeTypeIMX.h"
 #include "EGLWrapper.h"
@@ -83,6 +84,7 @@ bool CEGLWrapper::Initialize(const std::string &implementation)
       (nativeGuess = CreateEGLNativeType<CEGLNativeTypeAndroid>(implementation)) ||
       (nativeGuess = CreateEGLNativeType<CEGLNativeTypeAmlogic>(implementation)) ||
       (nativeGuess = CreateEGLNativeType<CEGLNativeTypeRaspberryPI>(implementation)) ||
+      (nativeGuess = CreateEGLNativeType<CEGLNativeTypeMali>(implementation)) ||
       (nativeGuess = CreateEGLNativeType<CEGLNativeTypeIMX>(implementation))
       )
   {

--- a/xbmc/windowing/egl/Makefile.in
+++ b/xbmc/windowing/egl/Makefile.in
@@ -4,6 +4,7 @@ SRCS = WinSystemEGL.cpp
 SRCS+= EGLNativeTypeAmlogic.cpp
 SRCS+= EGLNativeTypeAndroid.cpp
 SRCS+= EGLNativeTypeRaspberryPI.cpp
+SRCS+= EGLNativeTypeMali.cpp
 SRCS+= EGLNativeTypeWayland.cpp
 SRCS+= EGLNativeTypeIMX.cpp
 SRCS+= EGLWrapper.cpp


### PR DESCRIPTION
Add the class CEGLNativeTypeMali which uses the Mali binary driver
(https://github.com/linux-sunxi/sunxi-mali) to initialize an EGL
context.

This was tested successfully on a CubieTruck and a Cubieboard.

The screen resolution is currently hard-coded to the size of my TFT
monitor.  This part will need to be rewritten.
