### PR TITLE
cmake: fix backwards compatibility logic

### DIFF
--- a/project/cmake/scripts/common/prepare-env.cmake
+++ b/project/cmake/scripts/common/prepare-env.cmake
@@ -64,8 +64,10 @@ foreach(binding ${bindings})
   file(COPY ${APP_ROOT}/${header} DESTINATION ${KODI_INCLUDE_DIR})
 
   # auto-generate header files for backwards compatibility to xbmc with deprecation warning
+  # but only do it if the file doesn't already exist
   get_filename_component(headerfile ${header} NAME)
-  file(WRITE ${XBMC_INCLUDE_DIR}/${headerfile}
+  if (NOT EXISTS "${XBMC_INCLUDE_DIR}/${headerfile}")
+    file(WRITE ${XBMC_INCLUDE_DIR}/${headerfile}
 "#pragma once
 #define DEPRECATION_WARNING \"Including xbmc/${headerfile} has been deprecated, please use kodi/${headerfile}\"
 #ifdef _MSC_VER
@@ -74,4 +76,5 @@ foreach(binding ${bindings})
   #warning DEPRECATION_WARNING
 #endif
 #include \"kodi/${headerfile}\"")
+  endif()
 endforeach()

--- a/project/cmake/scripts/common/prepare-env.cmake
+++ b/project/cmake/scripts/common/prepare-env.cmake
@@ -63,7 +63,7 @@ foreach(binding ${bindings})
   # copy the header file to include/kodi
   file(COPY ${APP_ROOT}/${header} DESTINATION ${KODI_INCLUDE_DIR})
 
-  # auto-generate header files for backwards comaptibility to xbmc with deprecation warning
+  # auto-generate header files for backwards compatibility to xbmc with deprecation warning
   get_filename_component(headerfile ${header} NAME)
   file(WRITE ${XBMC_INCLUDE_DIR}/${headerfile}
 "#pragma once


### PR DESCRIPTION
After a comment from @garbear at https://github.com/garbear/peripheral.joystick/tree/cmake I realized that I never PR'ed this fix for the backwards compatibility logic in our cmake buildsystem which is intended to take care of being able to still build binary addons that use "xbmc" include paths instead of "kodi" ones.

The problem is that the logic overwrites the actual "kodi" header files with ones that only contain a warning and a forwarded include if the buildsystem is set up so that the "xbmc" include directory is a symlink to the "kodi" include directory.

This changes the logic to only write the forwarding header files if they don't already exist (which is the case when using a symlink).
