### PR TITLE
[pvr] only update a group's last watched timestamp if the timestamp has actually changed

### DIFF
--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -1244,16 +1244,17 @@ time_t CPVRChannelGroup::LastWatched(void) const
 
 bool CPVRChannelGroup::SetLastWatched(time_t iLastWatched)
 {
-  {
-    CSingleLock lock(m_critSection);
+  CSingleLock lock(m_critSection);
 
-    if (m_iLastWatched != iLastWatched)
-      m_iLastWatched = iLastWatched;
+  if (m_iLastWatched != iLastWatched)
+  {
+    m_iLastWatched = iLastWatched;
+    lock.Leave();
+
+    /* update the database immediately */
+    if (CPVRDatabase *database = GetPVRDatabase())
+      return database->UpdateLastWatched(*this);
   }
-  
-  /* update the database immediately */
-  if (CPVRDatabase *database = GetPVRDatabase())
-    return database->UpdateLastWatched(*this);
 
   return false;
 }


### PR DESCRIPTION
@xhaggi this is a fix for what you mentioned in https://github.com/xbmc/xbmc/pull/6246
