### PR TITLE
[gui] fix font cutting in auto height textboxes

### DIFF
--- a/xbmc/guilib/GUITextBox.cpp
+++ b/xbmc/guilib/GUITextBox.cpp
@@ -227,7 +227,7 @@ void CGUITextBox::Render()
         uint32_t align = m_label.align;
         if (m_lines[current].m_text.size() && m_lines[current].m_carriageReturn)
           align &= ~XBFONT_JUSTIFIED; // last line of a paragraph shouldn't be justified
-        m_font->DrawText(posX, posY + 2, m_colors, m_label.shadowColor, m_lines[current].m_text, align, m_width);
+        m_font->DrawText(posX, posY, m_colors, m_label.shadowColor, m_lines[current].m_text, align, m_width);
         posY += m_itemHeight;
         current++;
       }


### PR DESCRIPTION
This fixes an issue reported on the forums (http://forum.kodi.tv/showthread.php?tid=215193) where auto height textboxes are cutting of char tails (eg. g,y,j ..). Thanks @jmarshallnz for the hint! ;)
