### PR TITLE
[AML] - add support for screenshot and video bookmarks

### DIFF
--- a/xbmc/utils/Makefile.in
+++ b/xbmc/utils/Makefile.in
@@ -85,6 +85,10 @@ ifeq (@USE_OPENGLES@,1)
 SRCS += AMLUtils.cpp
 endif
 
+ifeq (@USE_LIBAMCODEC@,1)
+SRCS += ScreenshotAML.cpp
+endif
+
 LIB   = utils.a
 
 include @abs_top_srcdir@/Makefile.include

--- a/xbmc/utils/Screenshot.cpp
+++ b/xbmc/utils/Screenshot.cpp
@@ -47,6 +47,10 @@
 #include "settings/Settings.h"
 #include "settings/windows/GUIControlSettings.h"
 
+#if defined(HAS_LIBAMCODEC)
+#include "utils/ScreenshotAML.h"
+#endif
+
 using namespace std;
 using namespace XFILE;
 
@@ -162,6 +166,11 @@ bool CScreenshotSurface::capture()
   }
 
   delete [] surface;
+  
+#if defined(HAS_LIBAMCODEC)
+  // Captures the current visible videobuffer and blend it into m_buffer (captured overlay)
+  CScreenshotAML::CaptureVideoFrame(m_buffer, m_width, m_height);
+#endif
 
 #else
   //nothing to take a screenshot from

--- a/xbmc/utils/ScreenshotAML.cpp
+++ b/xbmc/utils/ScreenshotAML.cpp
@@ -1,0 +1,95 @@
+/*
+ *      Copyright (C) 2015 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "system.h"
+#if defined(HAS_LIBAMCODEC)
+#include "utils/ScreenshotAML.h"
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+#include <sys/ioctl.h>
+
+// taken from linux/amlogic/amports/amvideocap.h - needs to be synced - no changes expected though
+#define AMVIDEOCAP_IOC_MAGIC  'V'
+#define AMVIDEOCAP_IOW_SET_WANTFRAME_WIDTH      _IOW(AMVIDEOCAP_IOC_MAGIC, 0x02, int)
+#define AMVIDEOCAP_IOW_SET_WANTFRAME_HEIGHT     _IOW(AMVIDEOCAP_IOC_MAGIC, 0x03, int)
+#define AMVIDEOCAP_IOW_SET_CANCEL_CAPTURE       _IOW(AMVIDEOCAP_IOC_MAGIC, 0x33, int)
+
+// capture format already defaults to GE2D_FORMAT_S24_RGB - no need to pull in all the ge2d headers :)
+
+#define CAPTURE_DEVICEPATH "/dev/amvideocap0"
+
+//the buffer format is BGRA (4 byte)
+void CScreenshotAML::CaptureVideoFrame(unsigned char *buffer, int iWidth, int iHeight, bool bBlendToBuffer)
+{
+  int captureFd = open(CAPTURE_DEVICEPATH, O_RDWR, 0);
+  if (captureFd >= 0)
+  {
+    int buffSize = iWidth * iHeight * 3;
+    int readSize = 0;
+    // videobuffer should be rgb according to docu - but it is bgr ...
+    unsigned char *videoBuffer = new unsigned char[buffSize];
+
+    if (videoBuffer != NULL)
+    {
+      // configure destination
+      ioctl(captureFd, AMVIDEOCAP_IOW_SET_WANTFRAME_WIDTH, iWidth);
+      ioctl(captureFd, AMVIDEOCAP_IOW_SET_WANTFRAME_HEIGHT, iHeight);
+      readSize = pread(captureFd, videoBuffer, buffSize, 0);
+    }
+
+    close(captureFd);
+
+    if (readSize == buffSize)
+    {
+      unsigned char *videoPtr = videoBuffer;
+
+      if (!bBlendToBuffer)
+      {
+        memset(buffer, 0xff, buffSize);
+      }
+
+      for (int processedBytes = 0; processedBytes < buffSize; processedBytes += 3, buffer+=4)
+      {
+        float alpha = buffer[3] / (float)255;
+
+        if (bBlendToBuffer)
+        {
+          //B
+          buffer[0] = alpha * (float)buffer[0] + (1 - alpha) * (float)videoPtr[0];
+          //G
+          buffer[1] = alpha * (float)buffer[1] + (1 - alpha) * (float)videoPtr[1];
+          //R
+          buffer[2] = alpha * (float)buffer[2] + (1 - alpha) * (float)videoPtr[2];
+          //A
+          buffer[3] = 0xff;// we are solid now
+        }
+        else
+        {
+          memcpy(buffer, videoPtr, 3);
+        }
+        videoPtr += 3;
+      }
+    }
+    delete [] videoBuffer;
+  }
+}
+#endif //defined(HAS_LIBAMCODEC)

--- a/xbmc/utils/ScreenshotAML.h
+++ b/xbmc/utils/ScreenshotAML.h
@@ -1,0 +1,30 @@
+#pragma once
+/*
+ *      Copyright (C) 2015 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#if defined(HAS_LIBAMCODEC)
+class CScreenshotAML
+{
+  public:
+    // Captures the current visible video framebuffer and blends it into
+    // the passed overlay. The buffer format is BGRA (4 byte)
+    static void CaptureVideoFrame(unsigned char *buffer, int iWidth, int iHeight, bool bBlendToBuffer = true);
+};
+#endif//HAS_LIBAMCODEC

--- a/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
@@ -25,7 +25,10 @@
 #ifdef HAS_VIDEO_PLAYBACK
 #include "cores/VideoRenderers/RenderManager.h"
 #include "cores/VideoRenderers/RenderCapture.h"
-#endif
+#if defined(HAS_LIBAMCODEC)
+#include "utils/ScreenshotAML.h"
+#endif//HAS_LIBAMCODEC
+#endif//HAS_VIDEO_PLAYBACK
 #include "pictures/Picture.h"
 #include "dialogs/GUIDialogContextMenu.h"
 #include "view/ViewState.h"
@@ -339,8 +342,13 @@ bool CGUIDialogVideoBookmarks::AddBookmark(CVideoInfoTag* tag)
     {
       g_renderManager.Capture(thumbnail, width, height, CAPTUREFLAG_IMMEDIATELY);
 
+#if !defined(HAS_LIBAMCODEC)
       if (thumbnail->GetUserState() == CAPTURESTATE_DONE)
       {
+#else//HAS_LIBAMCODEC
+      {
+        CScreenshotAML::CaptureVideoFrame(thumbnail->GetPixels(), width, height, false);
+#endif
         Crc32 crc;
         crc.ComputeFromLowerCase(g_application.CurrentFile());
         bookmark.thumbNailImage = StringUtils::Format("%08x_%i.jpg", (unsigned __int32) crc, (int)bookmark.timeInSeconds);
@@ -349,8 +357,10 @@ bool CGUIDialogVideoBookmarks::AddBookmark(CVideoInfoTag* tag)
                                             bookmark.thumbNailImage))
           bookmark.thumbNailImage.clear();
       }
+#if !defined(HAS_LIBAMCODEC)
       else
         CLog::Log(LOGERROR,"CGUIDialogVideoBookmarks: failed to create thumbnail");
+#endif
 
       g_renderManager.ReleaseRenderCapture(thumbnail);
     }


### PR DESCRIPTION
As the title says this allows to capture screenshot and video bookmarks when using amlcodec. It makes use of the amvideocap driver in the amlogic kernels (and therefore needs support for those).

Tested it on WeTek.Play with OE...

@stefansaraev fyi :)
