### PR TITLE
[depends/TexturePacker] - fix extraction of delay and disposal from anim...

### DIFF
--- a/tools/depends/native/TexturePacker/src/TexturePacker.cpp
+++ b/tools/depends/native/TexturePacker/src/TexturePacker.cpp
@@ -385,7 +385,7 @@ int createBundle(const std::string& InputDir, const std::string& OutputFile, dou
     {
       for (unsigned int j = 0; j < frames.frameList.size(); j++)
       {
-        printf("    frame %4i                                ", j);
+        printf("    frame %4i (delay:%4i)                         ", j, frames.frameList[j].delay);
         CXBTFFrame frame = createXBTFFrame(frames.frameList[j].rgbaImage, writer, maxMSE, flags);
         frame.SetDuration(frames.frameList[j].delay);
         file.GetFrames().push_back(frame);

--- a/tools/depends/native/TexturePacker/src/decoder/GifHelper.cpp
+++ b/tools/depends/native/TexturePacker/src/decoder/GifHelper.cpp
@@ -294,7 +294,7 @@ bool GifHelper::gcbToFrame(GifFrame &frame, unsigned int imgIdx)
   frame.m_delay = 0;
   frame.m_disposal = 0;
 #if GIFLIB_MAJOR >= 5
-  if (m_gif->ExtensionBlockCount > 0)
+  if (m_gif->ImageCount > 0)
   {
     GraphicsControlBlock gcb;
     if (!DGifSavedExtensionToGCB(m_gif, imgIdx, &gcb))


### PR DESCRIPTION
...ated gifs (wrong assumption what ExtensionBlockCount was ...) - add delay as printout too.

This fixes extraction of animated gifs which missed the delay and disposal settings of each frame because i had a wrong assumption on what ExtensionBlockCount did (its the number of extension blocks after the last image - not the number of blocks of each image). Checking number of images in the gif seems to be the right thing to do here.

@MilhouseVH - sry ... :)
