### PR TITLE
[core] Support mixed media types in playlists

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4865,6 +4865,10 @@ bool CApplication::OnMessage(CGUIMessage& message)
       if (url.IsProtocol("plugin"))
         XFILE::CPluginDirectory::GetPluginResult(url.Get(), file);
 
+      // Don't queue if next media type is different from current one
+      if (!file.IsVideo() && m_pPlayer->IsPlayingVideo()) return true;
+      if (!file.IsAudio() && m_pPlayer->IsPlayingAudio()) return true;
+
 #ifdef HAS_UPNP
       if (URIUtils::IsUPnP(file.GetPath()))
       {


### PR DESCRIPTION
Ignore GUI_MSG_QUEUE_NEXT_ITEM messages when the incoming item
is not playable by current player, giving a chance to be reproduced
by a different one, instead of skipping it.
