### PR TITLE
[gui] remove eventual context menu items for the "go to parent" item

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -328,7 +328,7 @@ bool CGUIWindowPVRRecordings::ActionDeleteRecording(CFileItem *item)
 {
   bool bReturn = false;
 
-  if (!item->IsPVRRecording() && !item->m_bIsFolder)
+  if (!item->IsPVRRecording() && !item->m_bIsFolder || item->IsParentFolder())
     return bReturn;
 
   /* show a confirmation dialog */

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -1523,8 +1523,12 @@ void CGUIMediaWindow::GetContextButtons(int itemNumber, CContextButtons &buttons
 {
   CFileItemPtr item = (itemNumber >= 0 && itemNumber < m_vecItems->Size()) ? m_vecItems->Get(itemNumber) : CFileItemPtr();
 
-  if (!item)
+  // ensure that the "go to parent" item doesn't have any context menu items
+  if (!item || item->IsParentFolder())
+  {
+    buttons.clear();
     return;
+  }
 
   // user added buttons
   std::string label;


### PR DESCRIPTION
Fixes  #15732

@xhaggi should be pretty straight-forward
