### PR TITLE
dvdplayer: fix calculation of level when data based

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
@@ -811,7 +811,7 @@ int CDVDPlayerVideo::GetLevel() const
     int datasize = m_messageQueue.GetDataSize();
     if (m_pVideoCodec)
       datasize += m_pVideoCodec->GetDataSize();
-    return min(100, (int)(100 * datasize / (m_messageQueue.GetMaxDataSize() * m_messageQueue.GetMaxTimeSize())));
+    return min(100, MathUtils::round_int((100.0 * datasize) / m_messageQueue.GetMaxDataSize()));
   }
   else
   {


### PR DESCRIPTION
After reading the code together with @adamsutton we found that the databased method is quite strange and would end up with bytes^2 / seconds which makes no sense for a percentage value at all. It seems GetMaxTimeSize() went wrongly in there.
