### PR TITLE
[confluence] show the subtitles OSD button in live TV too

### DIFF
--- a/addons/skin.confluence/720p/VideoOSD.xml
+++ b/addons/skin.confluence/720p/VideoOSD.xml
@@ -417,6 +417,8 @@
 				<onclick>Close</onclick>
 				<onclick>Dialog.Close(VideoOSD)</onclick>
 				<onclick>ActivateWindow(SubtitleSearch)</onclick>
+				<!-- no point in downloading subtitles for live programs -->
+				<enable>!VideoPlayer.Content(LiveTV)</enable>
 			</control>
 			<control type="button" id="402">
 				<height>40</height>

--- a/addons/skin.confluence/720p/VideoOSD.xml
+++ b/addons/skin.confluence/720p/VideoOSD.xml
@@ -290,7 +290,7 @@
 				<onclick>ActivateWindow(Teletext)</onclick>
 			</control>
 			<control type="image" id="2300">
-				<width>215</width>
+				<width>165</width>
 				<texture>-</texture>
 			</control>
 			<control type="button" id="354">
@@ -303,6 +303,16 @@
 				<texturefocus>OSDStereoscopicFO.png</texturefocus>
 				<texturenofocus>OSDStereoscopicNF.png</texturenofocus>
 				<onup>551</onup>
+			</control>
+			<control type="button" id="250">
+				<width>55</width>
+				<height>55</height>
+				<label>31356</label>
+				<font>-</font>
+				<texturefocus>OSDSubtitlesFO.png</texturefocus>
+				<texturenofocus>OSDSubtitlesNF.png</texturenofocus>
+				<onup>404</onup>
+				<ondown>1000</ondown>
 			</control>
 			<control type="button" id="351">
 				<width>55</width>

--- a/addons/skin.confluence/720p/VideoOSD.xml
+++ b/addons/skin.confluence/720p/VideoOSD.xml
@@ -280,6 +280,15 @@
 				<onclick>ActivateWindow(PVROSDGuide)</onclick>
 				<onclick>Dialog.Close(VideoOSD)</onclick>
 			</control>
+			<control type="button" id="350">
+				<width>55</width>
+				<height>55</height>
+				<label>31356</label>
+				<font>-</font>
+				<texturefocus>OSDTeleTextFO.png</texturefocus>
+				<texturenofocus>OSDTeleTextNF.png</texturenofocus>
+				<onclick>ActivateWindow(Teletext)</onclick>
+			</control>
 			<control type="image" id="2300">
 				<width>215</width>
 				<texture>-</texture>
@@ -294,15 +303,6 @@
 				<texturefocus>OSDStereoscopicFO.png</texturefocus>
 				<texturenofocus>OSDStereoscopicNF.png</texturenofocus>
 				<onup>551</onup>
-			</control>
-			<control type="button" id="350">
-				<width>55</width>
-				<height>55</height>
-				<label>31356</label>
-				<font>-</font>
-				<texturefocus>OSDTeleTextFO.png</texturefocus>
-				<texturenofocus>OSDTeleTextNF.png</texturenofocus>
-				<onclick>ActivateWindow(Teletext)</onclick>
 			</control>
 			<control type="button" id="351">
 				<width>55</width>


### PR DESCRIPTION
Fixes #15688

@ronie can you take a brief look? I don't like the amount of duplication in the skin, is there a better way to do this? The button IDs are also just random, things seem to work though.

@FernetMenta can you test this with closed captions in a live TV context somehow? I'll tell the guy who reported the bug to test as well.
