### PR TITLE
Add missing initialization for m_forceUnicodeFont

### DIFF
--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -53,6 +53,7 @@ CLangInfo::CRegion::CRegion(const CRegion& region):
   m_strLangLocaleName(region.m_strLangLocaleName),
   m_strLangLocaleCodeTwoChar(region.m_strLangLocaleCodeTwoChar),
   m_strRegionLocaleName(region.m_strRegionLocaleName),
+  m_forceUnicodeFont(region.m_forceUnicodeFont),
   m_strName(region.m_strName),
   m_strDateFormatLong(region.m_strDateFormatLong),
   m_strDateFormatShort(region.m_strDateFormatShort),


### PR DESCRIPTION
I accidentally removed that initialization when doing the cppcheck fixes (#6253)
