### PR TITLE
Fix TexturePacker segfault with grayscale PNGs.

### DIFF
--- a/tools/depends/native/TexturePacker/src/decoder/PNGDecoder.cpp
+++ b/tools/depends/native/TexturePacker/src/decoder/PNGDecoder.cpp
@@ -165,7 +165,14 @@ bool PNGDecoder::LoadFile(const std::string &filename, DecodedFrames &frames)
   /* swap the RGBA or GA data to ARGB or AG (or BGRA to ABGR) */
   //png_set_swap_alpha(png_ptr);
   
-  
+  //libsquish only eats 32bit RGBA, must convert grayscale into this format
+  if (color_type == PNG_COLOR_TYPE_GRAY ||
+      color_type == PNG_COLOR_TYPE_GRAY_ALPHA)
+  {
+    png_set_expand_gray_1_2_4_to_8(png_ptr);
+    png_set_gray_to_rgb(png_ptr);
+  }
+
   // Update the png info struct.
   png_read_update_info(png_ptr, info_ptr);
   


### PR DESCRIPTION
I have a segfault with a PNG file from aeon.nox.5 skin ( https://github.com/BigNoid/Aeon-Nox/raw/master/media/thumbs/boxes/poster_shadow.png )

I use Kodi git version Commit:576ac98 on Ubuntu 14.04.1 LTS x86_64.

The segfault is in squish::CopyRGBA(), and is caused by grayscale PNG files, libsquish only takes data in 32bit ARGB format, however TexturePacker's PNGDecoder::LoadFile() does not convert grayscale data correctly.

 see http://forum.kodi.tv/showthread.php?tid=216503
