### PR TITLE
[update] use real support website link

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ(2.59)
-AC_INIT([kodi], [14.9.701], [http://issues.kodi.tv])
+AC_INIT([kodi], [14.9.701], [http://trac.kodi.tv])
 AC_CONFIG_HEADERS([xbmc/config.h])
 AH_TOP([#pragma once])
 m4_include([m4/ax_prog_cc_for_build.m4])


### PR DESCRIPTION
http://issues.kodi.tv is not really used doesnt even work as its http://issues.xbmc.org and from what @kib mentioned this site didnt work as expected., afaik issues/bugs are at http://trac.kodi.tv so lets use that here.
