### PR TITLE
dvdplayer: avoid ffmpeg hw decoder reset on recoverable error

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodec.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodec.h
@@ -171,6 +171,7 @@ class CDVDCodecOptions;
 #define VC_USERDATA 0x00000008  // the decoder found some userdata,  call Decode(NULL, 0) again to parse the rest of the data
 #define VC_FLUSHED  0x00000010  // the decoder lost it's state, we need to restart decoding again
 #define VC_DROPPED  0x00000020  // needed to identify if a picture was dropped
+#define VC_NOBUFFER 0x00000040  // last FFmpeg GetBuffer failed
 
 class CDVDVideoCodec
 {

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -495,6 +495,15 @@ int CDVDVideoCodecFFmpeg::Decode(uint8_t* pData, int iSize, double dts, double p
 
   if (len < 0)
   {
+    if(m_pHardware)
+    {
+      int result = m_pHardware->Check(m_pCodecContext);
+      if (result & VC_NOBUFFER)
+      {
+        result = m_pHardware->Decode(m_pCodecContext, NULL);
+        return result;
+      }
+    }
     CLog::Log(LOGERROR, "%s - avcodec_decode_video returned failure", __FUNCTION__);
     return VC_ERROR;
   }

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -451,10 +451,6 @@ int CDVDVideoCodecFFmpeg::Decode(uint8_t* pData, int iSize, double dts, double p
   shared_ptr<CSingleLock> lock;
   if(m_pHardware)
   {
-    CCriticalSection* section = m_pHardware->Section();
-    if(section)
-      lock = shared_ptr<CSingleLock>(new CSingleLock(*section));
-
     int result;
     if(pData)
       result = m_pHardware->Check(m_pCodecContext);

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.h
@@ -52,7 +52,6 @@ public:
     virtual unsigned GetAllowedReferences() { return 0; }
     virtual bool CanSkipDeint() {return false; }
     virtual const std::string Name() = 0;
-    virtual CCriticalSection* Section() { return NULL; }
   };
 
   CDVDVideoCodecFFmpeg();

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.cpp
@@ -471,6 +471,7 @@ CDecoder::CDecoder() : m_vaapiOutput(&m_inMsgEvent)
   m_vaapiConfig.contextId = VA_INVALID_ID;
   m_vaapiConfig.configId = VA_INVALID_ID;
   m_avctx = NULL;
+  m_getBufferError = false;
 }
 
 CDecoder::~CDecoder()
@@ -697,9 +698,9 @@ int CDecoder::FFGetBuffer(AVCodecContext *avctx, AVFrame *pic, int flags)
     uint16_t decoded, processed, render;
     bool vpp;
     va->m_bufferStats.Get(decoded, processed, render, vpp);
-    CLog::Log(LOGERROR, "VAAPI::FFGetBuffer - no surface available - dec: %d, render: %d",
+    CLog::Log(LOGWARNING, "VAAPI::FFGetBuffer - no surface available - dec: %d, render: %d",
                          decoded, render);
-    va->m_DisplayState = VAAPI_ERROR;
+    va->m_getBufferError = true;
     return -1;
   }
 
@@ -734,6 +735,8 @@ void CDecoder::FFReleaseBuffer(uint8_t *data)
 
 int CDecoder::Decode(AVCodecContext* avctx, AVFrame* pFrame)
 {
+  m_getBufferError = false;
+
   int result = Check(avctx);
   if (result)
     return result;
@@ -850,6 +853,7 @@ int CDecoder::Decode(AVCodecContext* avctx, AVFrame* pFrame)
 
 int CDecoder::Check(AVCodecContext* avctx)
 {
+  int ret = 0;
   EDisplayState state;
 
   { CSingleLock lock(m_DecoderSection);
@@ -891,7 +895,12 @@ int CDecoder::Check(AVCodecContext* avctx)
     else
       return VC_ERROR;
   }
-  return 0;
+
+  if (m_getBufferError)
+    ret |= VC_NOBUFFER;
+
+  m_getBufferError = false;
+  return ret;
 }
 
 bool CDecoder::GetPicture(AVCodecContext* avctx, AVFrame* frame, DVDVideoPicture* picture)

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.h
@@ -449,6 +449,7 @@ protected:
   CVideoSurfaces m_videoSurfaces;
   vaapi_context m_hwContext;
   AVCodecContext* m_avctx;
+  bool m_getBufferError;
 
   COutput m_vaapiOutput;
   CVaapiBufferStats m_bufferStats;

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDA.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDA.h
@@ -39,7 +39,6 @@ public:
   virtual int  Check     (AVCodecContext* avctx);
   virtual void Close();
   virtual const std::string Name() { return "vda"; }
-  virtual CCriticalSection* Section() {  return NULL; }
   virtual unsigned GetAllowedReferences();
 
   int   GetBuffer(AVCodecContext *avctx, AVFrame *pic, int flags);


### PR DESCRIPTION
should fix TRAC #15741
faulty material my require more decoder buffers than max_refs for h264. if ffmpeg requests a buffer and we have none available this error is recoverable without resetting the decoder.
