### PR TITLE
[confluence] fix: On play/pause default control for play/pause

### DIFF
--- a/addons/skin.confluence/720p/VideoOSD.xml
+++ b/addons/skin.confluence/720p/VideoOSD.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
-	<defaultcontrol always="true">202</defaultcontrol>
+	<defaultcontrol always="false">100</defaultcontrol>
 	<include>dialogeffect</include>
 	<coordinates>
 		<system>1</system>
@@ -188,7 +188,6 @@
 		<control type="grouplist" id="100">
 			<left>325</left>
 			<top>60r</top>
-			<defaultcontrol always="true">301</defaultcontrol>
 			<animation effect="fade" time="200">VisibleChange</animation>
 			<visible>![Window.IsVisible(SliderDialog) | Window.IsVisible(OSDVideoSettings) | Window.IsVisible(OSDAudioSettings) | Window.IsVisible(VideoBookmarks) | Window.IsVisible(PVROSDChannels) | Window.IsVisible(PVROSDGuide)]</visible>
 			<visible>VideoPlayer.Content(LiveTV)</visible>

--- a/addons/skin.confluence/720p/VideoOSD.xml
+++ b/addons/skin.confluence/720p/VideoOSD.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
-	<defaultcontrol always="true">100</defaultcontrol>
+	<defaultcontrol always="true">202</defaultcontrol>
 	<include>dialogeffect</include>
 	<coordinates>
 		<system>1</system>


### PR DESCRIPTION
This is a bit odd, the default control https://github.com/xbmc/xbmc/blob/8abac52b32e220a12da0fd2dafd1fb6de8d24eb7/addons/skin.confluence/720p/VideoOSD.xml#L49 was removed with latest changes, re adding it back made no difference to behaviour.

But setting default control here restored it to how it use to work.

Essentially if you hit **_play/pause**_ on remote you dont want the default control to be **_chapter back  <id=100>**_ else if you press ok, instead of resuming you end up at beginning of file or previous chapter depending.

This restores this and therefore restores  WAF Factor on this, as I was getting annoyed that wife moaning this went back to beginning of file or previous chapter. Two weeks of listening to grief was my limit and therefore hence this PR.

@ronie 
