### PR TITLE
[Confluence] Focus OSD play/pause button by default

### DIFF
--- a/addons/skin.confluence/720p/MusicOSD.xml
+++ b/addons/skin.confluence/720p/MusicOSD.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
 	<defaultcontrol always="true">100</defaultcontrol>
+	<onload condition="!MusicPlayer.Content(LiveTV)">SetFocus(602)</onload>
 	<include>dialogeffect</include>
 	<coordinates>
 		<system>1</system>

--- a/addons/skin.confluence/720p/VideoOSD.xml
+++ b/addons/skin.confluence/720p/VideoOSD.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
 	<defaultcontrol always="true">100</defaultcontrol>
+	<onload condition="!VideoPlayer.Content(LiveTV)">SetFocus(202)</onload>
 	<include>dialogeffect</include>
 	<coordinates>
 		<system>1</system>


### PR DESCRIPTION
ever since https://github.com/xbmc/xbmc/commit/d43d8f053987c9bfdd9d20e0c14a5afa9a1f202b and https://github.com/xbmc/xbmc/commit/6f0284adcd52325f075228cd7240239c02689076 we don't focus the play/pause button by default anymore.

this commit fixes it for situations where livetv is not playing.
for livetv, the situation doesn't change and the channelup button will be focussed.

ping @phil65 / @BigNoid
