### PR TITLE
[osx/ios] - bump sdk on jenkins

### DIFF
--- a/Kodi.xcodeproj/project.pbxproj
+++ b/Kodi.xcodeproj/project.pbxproj
@@ -14539,7 +14539,7 @@
 					"\"$(SDKROOT)$(SYSTEM_LIBRARY_DIR)/PrivateFrameworks\"",
 				);
 				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_VERSION = 4.2;
+				GCC_VERSION = "";
 				HEADER_SEARCH_PATHS = (
 					$SRCROOT,
 					xbmc,
@@ -14600,7 +14600,6 @@
 				);
 				GCC_ENABLE_FIX_AND_CONTINUE = NO;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
-				GCC_VERSION = 4.2;
 				HEADER_SEARCH_PATHS = (
 					$SRCROOT,
 					xbmc,

--- a/tools/buildsteps/defaultenv
+++ b/tools/buildsteps/defaultenv
@@ -11,25 +11,25 @@ TARBALLS=${TARBALLS:-"/opt/xbmc-tarballs"}
 #$XBMC_PLATFORM_DIR matches the platform subdirs!
 case $XBMC_PLATFORM_DIR in
   atv2)
-    DEFAULT_SDK_VERSION=4.2
+    DEFAULT_SDK_VERSION=8.1
     DEFAULT_XBMC_DEPENDS_ROOT=$WORKSPACE/tools/depends/xbmc-depends
     DEFAULT_CONFIGURATION="Debug"
     ;;
 
   ios)
-    DEFAULT_SDK_VERSION=4.2
+    DEFAULT_SDK_VERSION=8.1
     DEFAULT_XBMC_DEPENDS_ROOT=$WORKSPACE/tools/depends/xbmc-depends
     DEFAULT_CONFIGURATION="Debug"
     ;;
 
   osx32)
-    DEFAULT_SDK_VERSION=10.8
+    DEFAULT_SDK_VERSION=10.10
     DEFAULT_XBMC_DEPENDS_ROOT=$WORKSPACE/tools/depends/xbmc-depends
     DEFAULT_CONFIGURATION="Debug"
     ;;
 
   osx64)
-    DEFAULT_SDK_VERSION=10.8
+    DEFAULT_SDK_VERSION=10.10
     DEFAULT_XBMC_DEPENDS_ROOT=$WORKSPACE/tools/depends/xbmc-depends
     DEFAULT_CONFIGURATION="Debug"
     ;;


### PR DESCRIPTION
This bumps the SDKs used for building on jenkins to:

iOS 8.1 SDK
MacOSX 10.10 SDK

I will update the second macmini builder the next days. For all who build manually from their branches - once this PR is in you need to rebase before beeing able to build your own branch on jenkins. (as the updated builders are not able to build against the older SDKs we used till now).
