### PR TITLE
[PVR] Optimized CPVRManager::CanSystemPowerdown not to do expensive backend calls

### DIFF
--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -631,6 +631,11 @@ namespace PVR
     ManagerState GetState(void) const;
 
     void SetState(ManagerState state);
+
+    bool AllLocalBackendsIdle(void) const;
+    bool EventOccursOnLocalBackend(const CFileItemPtr& item) const;
+    bool IsNextEventWithinBackendIdleTime(void) const;
+
     /** @name containers */
     //@{
     CPVRChannelGroupsContainer *    m_channelGroups;               /*!< pointer to the channel groups container */

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -34,7 +34,6 @@
 #include "pvr/recordings/PVRRecordings.h"
 #include "pvr/timers/PVRTimers.h"
 #include "cores/IPlayer.h"
-#include "network/Network.h"
 
 using namespace ADDON;
 using namespace PVR;
@@ -1317,6 +1316,19 @@ bool CPVRClients::IsEncrypted(void) const
   return false;
 }
 
+std::string CPVRClients::GetBackendHostnameByClientId(int iClientId) const
+{
+  PVR_CLIENT client;
+  std::string name;
+
+  if (GetConnectedClient(iClientId, client))
+  {
+    name = client->GetBackendHostname();
+  }
+
+  return name;
+}
+
 time_t CPVRClients::GetPlayingTime() const
 {
   PVR_CLIENT client;
@@ -1356,32 +1368,3 @@ time_t CPVRClients::GetBufferTimeEnd() const
   return time;
 }
 
-bool CPVRClients::NextEventWithinBackendIdleTime(const CPVRTimers& timers)
-{
-    // timers going off soon?
-    const CDateTime now(CDateTime::GetUTCDateTime());
-    const CDateTimeSpan idle(
-      0, 0, CSettings::Get().GetInt("pvrpowermanagement.backendidletime"), 0);
-    const CDateTime next(timers.GetNextEventTime());
-    const CDateTimeSpan delta(next - now);
-
-    return (delta <= idle);
-}
-
-bool CPVRClients::AllLocalBackendsIdle() const
-{
-  PVR_CLIENTMAP clients;
-  GetConnectedClients(clients);
-  for (PVR_CLIENTMAP_CITR itr = clients.begin(); itr != clients.end(); itr++)
-  {
-    CPVRTimers timers;
-    PVR_ERROR ret = itr->second->GetTimers(&timers);
-    if (ret == PVR_ERROR_NOT_IMPLEMENTED || ret != PVR_ERROR_NO_ERROR)
-      continue;
-
-    if (((timers.AmountActiveRecordings() > 0) || NextEventWithinBackendIdleTime(timers))
-        && g_application.getNetwork().IsLocalHost(itr->second->GetBackendHostname()))
-      return false;
-  }
-  return true;
-}

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -546,11 +546,7 @@ namespace PVR
 
     bool GetPlayingClient(PVR_CLIENT &client) const;
 
-    /*!
-     * @brief Checks whether all local pvr backends (if any) are idle (no recording active, ...).
-     * @return True if all local backends are idle or no local backends are connected, false otherwise.
-     */
-    bool AllLocalBackendsIdle() const;
+    std::string GetBackendHostnameByClientId(int iClientId) const;
 
     time_t GetPlayingTime() const;
     time_t GetBufferTimeStart() const;
@@ -620,8 +616,6 @@ namespace PVR
     int RegisterClient(ADDON::AddonPtr client, bool* newRegistration = NULL);
 
     int GetClientId(const ADDON::AddonPtr client) const;
-
-    static bool NextEventWithinBackendIdleTime(const CPVRTimers& timers);
 
     bool                  m_bChannelScanRunning;      /*!< true when a channel scan is currently running, false otherwise */
     bool                  m_bIsSwitchingChannels;        /*!< true while switching channels */


### PR DESCRIPTION
Optimized CPVRManager::CanSystemPowerdown not to do expensive backend calls but to act 100% on local data.

This is a followup to #4342. Implementation seems to work fine wrt functionality but has ugly performance implications. If Kodi feature "automatic shutdown after xyz minutes" is active, CPVRManager::CanSystemPowerdown gets called frequently on a regular base (once a second, not quite sure though). CPVRManager::CanSystemPowerdown calls CPVRClients::AllLocalBackendsIdle which calls CPVRClient::GetTimers. The latter causes a PVR backend call every time!

This PR reimplements the existing functionality 100%, but does not do any PVR backends calls any more.
