### PR TITLE
fixed: External subtitles in custom folder did not work with url encoded files

### DIFF
--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -1898,11 +1898,11 @@ void CUtil::ScanForExternalSubtitles(const std::string& strMovie, std::vector<st
   vector<std::string> strLookInPaths;
   
   std::string strMovieFileName;
-  std::string strPath;
+  std::string strMoviePath;
   
-  URIUtils::Split(strMovie, strPath, strMovieFileName);
+  URIUtils::Split(strMovie, strMoviePath, strMovieFileName);
   std::string strMovieFileNameNoExt(URIUtils::ReplaceExtension(strMovieFileName, ""));
-  strLookInPaths.push_back(strPath);
+  strLookInPaths.push_back(strMoviePath);
   
   CURL url(strMovie);
   std::string isoFileNameNoExt;
@@ -1944,8 +1944,8 @@ void CUtil::ScanForExternalSubtitles(const std::string& strMovie, std::vector<st
   {
     CURL url(strMovie);
     std::string strArchive = url.GetHostName();
-    URIUtils::Split(strArchive, strPath, strMovieFileName);
-    strLookInPaths.push_back(strPath);
+    URIUtils::Split(strArchive, strMoviePath, strMovieFileName);
+    strLookInPaths.push_back(strMoviePath);
   }
   
   int iSize = strLookInPaths.size();
@@ -2003,9 +2003,9 @@ void CUtil::ScanForExternalSubtitles(const std::string& strMovie, std::vector<st
   // this is last because we dont want to check any common subdirs or cd-dirs in the alternate <subtitles> dir.
   if (CMediaSettings::Get().GetAdditionalSubtitleDirectoryChecked() == 1)
   {
-    strPath = CSettings::Get().GetString("subtitles.custompath");
-    URIUtils::AddSlashAtEnd(strPath);
-    strLookInPaths.push_back(strPath);
+    std::string strPath2 = CSettings::Get().GetString("subtitles.custompath");
+    URIUtils::AddSlashAtEnd(strPath2);
+    strLookInPaths.push_back(strPath2);
   }
   
   std::string strDest;
@@ -2023,7 +2023,8 @@ void CUtil::ScanForExternalSubtitles(const std::string& strMovie, std::vector<st
       
       for (int j = 0; j < items.Size(); j++)
       {
-        URIUtils::Split(items[j]->GetPath(), strPath, strItem);
+        std::string strSubtitlePath;
+        URIUtils::Split(items[j]->GetPath(), strSubtitlePath, strItem);
         
         if (StringUtils::StartsWithNoCase(strItem, strMovieFileNameNoExt)
           || (!isoFileNameNoExt.empty() && StringUtils::StartsWithNoCase(strItem, isoFileNameNoExt)))

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -2025,8 +2025,11 @@ void CUtil::ScanForExternalSubtitles(const std::string& strMovie, std::vector<st
       {
         std::string strSubtitlePath;
         URIUtils::Split(items[j]->GetPath(), strSubtitlePath, strItem);
+
+        // Make sure filename uses the correct encoding
+        std::string strMovieFileNameNoExt2 = URIUtils::ChangeBasePath(strMoviePath, strMovieFileNameNoExt, strSubtitlePath, false);
         
-        if (StringUtils::StartsWithNoCase(strItem, strMovieFileNameNoExt)
+        if (StringUtils::StartsWithNoCase(strItem, strMovieFileNameNoExt2)
           || (!isoFileNameNoExt.empty() && StringUtils::StartsWithNoCase(strItem, isoFileNameNoExt)))
         {
           // is this a rar or zip-file
@@ -2053,8 +2056,11 @@ void CUtil::ScanForExternalSubtitles(const std::string& strMovie, std::vector<st
           // is this a rar or zip-file
           if (URIUtils::IsRAR(strItem) || URIUtils::IsZIP(strItem))
           {
+            // Make sure filename uses the correct encoding
+            std::string strMovieFileNameNoExt2 = URIUtils::ChangeBasePath(strMoviePath, strMovieFileNameNoExt, "", false);
+
             // check strMovieFileNameNoExt in zip-file
-            ScanArchiveForSubtitles( items[j]->GetPath(), strMovieFileNameNoExt, vecSubtitles );
+            ScanArchiveForSubtitles(items[j]->GetPath(), strMovieFileNameNoExt2, vecSubtitles );
           }
         }
       }

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -419,7 +419,7 @@ std::string URLDecodePath(const std::string& strPath)
   return StringUtils::Join(segments, "/");
 }
 
-std::string URIUtils::ChangeBasePath(const std::string &fromPath, const std::string &fromFile, const std::string &toPath)
+std::string URIUtils::ChangeBasePath(const std::string &fromPath, const std::string &fromFile, const std::string &toPath, const bool &bAddPath /* = true */)
 {
   std::string toFile = fromFile;
 
@@ -443,7 +443,10 @@ std::string URIUtils::ChangeBasePath(const std::string &fromPath, const std::str
   if (!IsDOSPath(fromPath) && IsDOSPath(toPath))
     StringUtils::Replace(toFile, "/", "\\");
 
-  return AddFileToFolder(toPath, toFile);
+  if (bAddPath)
+    return AddFileToFolder(toPath, toFile);
+
+  return toFile;
 }
 
 CURL URIUtils::SubstitutePath(const CURL& url, bool reverse /* = false */)

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -78,7 +78,7 @@ public:
     \param toPath the base path of the resulting URL
     \return the full path.
    */
-  static std::string ChangeBasePath(const std::string &fromPath, const std::string &fromFile, const std::string &toPath);
+  static std::string ChangeBasePath(const std::string &fromPath, const std::string &fromFile, const std::string &toPath, const bool &bAddPath = true);
 
   static CURL SubstitutePath(const CURL& url, bool reverse = false);
   static CStdString SubstitutePath(const CStdString& strPath, bool reverse = false);


### PR DESCRIPTION
Apparently this has always been broken but never been noticed: Playing URL-encoded movie from eg. http + autoloading an external subtitle stored in the custom sub folder on hd.
