### PR TITLE
Add optional .index() to Control.GetLabel() allowing access to secondary...

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1314,6 +1314,20 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
         return AddMultiInfo(GUIInfo(TranslateListItem(info[2]), id, offset, INFOFLAG_LISTITEM_WRAP));
       }
     }
+    else if (info[0].name == "control")
+    {
+      const Property &prop = info[1];
+      for (size_t i = 0; i < sizeof(control_labels) / sizeof(infomap); i++)
+      {
+        if (prop.name == control_labels[i].str)
+        { // TODO: The parameter for these should really be on the first not the second property
+          int controlID = atoi(prop.param().c_str());
+          if (controlID)
+            return AddMultiInfo(GUIInfo(control_labels[i].val, controlID, atoi(info[2].param(0).c_str())));
+          return 0;
+        }
+      }
+    }
   }
 
   return 0;
@@ -3312,7 +3326,13 @@ std::string CGUIInfoManager::GetMultiInfoLabel(const GUIInfo &info, int contextW
     {
       const CGUIControl *control = window->GetControl(info.GetData1());
       if (control)
-        return control->GetDescription();
+      {
+        int data2 = info.GetData2();
+        if (data2)
+          return control->GetDescriptionByIndex(data2);
+        else
+          return control->GetDescription();
+      }
     }
   }
   else if (info.m_info == WINDOW_PROPERTY)

--- a/xbmc/guilib/GUIControl.h
+++ b/xbmc/guilib/GUIControl.h
@@ -219,6 +219,7 @@ public:
   virtual void SetInvalid() { m_bInvalidated = true; };
   virtual void SetPulseOnSelect(bool pulse) { m_pulseOnSelect = pulse; };
   virtual std::string GetDescription() const { return ""; };
+  virtual std::string GetDescriptionByIndex(int index) const { return ""; };
 
   void SetAnimations(const std::vector<CAnimation> &animations);
   const std::vector<CAnimation> &GetAnimations() const { return m_animations; };

--- a/xbmc/guilib/GUIEditControl.cpp
+++ b/xbmc/guilib/GUIEditControl.cpp
@@ -747,3 +747,13 @@ void CGUIEditControl::SetFocus(bool focus)
   g_Windowing.EnableTextInput(focus);
   CGUIControl::SetFocus(focus);
 }
+
+std::string CGUIEditControl::GetDescriptionByIndex(int index) const
+{
+  if (index == 0)
+    return GetDescription();
+  else if(index == 1)
+    return GetLabel2();
+  
+  return "";
+}

--- a/xbmc/guilib/GUIEditControl.h
+++ b/xbmc/guilib/GUIEditControl.h
@@ -92,6 +92,7 @@ protected:
   virtual void RenderText();
   virtual CGUILabel::COLOR GetTextColor() const;
   std::wstring GetDisplayedText() const;
+  std::string GetDescriptionByIndex(int index) const;
   bool SetStyledText(const std::wstring &text);
   void RecalcLabelPosition();
   void ValidateCursor();


### PR DESCRIPTION
This change allows adding .index() to the Control.GetLabel() infolabel. This allows retrieval of secondary labels such as the text of an edit control (which is also implemented by this change) but in the future could be used to access all the labels of a fade label control, etc. My main reason for adding this is because Kodi's changes to the keyboard dialog made the keyboard unusable to blind users using the Speech addon, although it will help later for implementing access to other control's text that the Speech addon currently cannot access.

Example usage:

```
<info>Control.GetLabel(300).index(1)</info>
```

I don't claim to be confident with C++, so please let me know if I've done something stupid or if my implementation should be changed somehow.
