### PR TITLE
Update FileItem.cpp

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1487,7 +1487,7 @@ std::string CFileItem::GetOpticalMediaPath() const
   {
     dvdPath = URIUtils::AddFileToFolder(GetPath(), "VIDEO_TS");
     path = URIUtils::AddFileToFolder(dvdPath, "VIDEO_TS.IFO");
-    if (CFile::Exists(dvdPath) && CFile::Exists(path))
+    if (CDirectory::Exists(dvdPath) && CFile::Exists(path))
       dvdPath = path;
     else
       dvdPath.clear();
@@ -1502,7 +1502,7 @@ std::string CFileItem::GetOpticalMediaPath() const
     {
       dvdPath = URIUtils::AddFileToFolder(GetPath(), "BDMV");
       path = URIUtils::AddFileToFolder(dvdPath, "index.bdmv");
-      if (CFile::Exists(dvdPath) && CFile::Exists(path))
+      if (CDirectory::Exists(dvdPath) && CFile::Exists(path))
 	dvdPath = path;
       else
 	dvdPath.clear();

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1487,9 +1487,10 @@ std::string CFileItem::GetOpticalMediaPath() const
   {
     dvdPath = URIUtils::AddFileToFolder(GetPath(), "VIDEO_TS");
     path = URIUtils::AddFileToFolder(dvdPath, "VIDEO_TS.IFO");
-    dvdPath.clear();
-    if (CFile::Exists(path))
+    if (CFile::Exists(dvdPath) && CFile::Exists(path))
       dvdPath = path;
+    else
+      dvdPath.clear();
   }
 #ifdef HAVE_LIBBLURAY
   if (dvdPath.empty())
@@ -1501,9 +1502,10 @@ std::string CFileItem::GetOpticalMediaPath() const
     {
       dvdPath = URIUtils::AddFileToFolder(GetPath(), "BDMV");
       path = URIUtils::AddFileToFolder(dvdPath, "index.bdmv");
-      dvdPath.clear();
-      if (CFile::Exists(path))
-        dvdPath = path;
+      if (CFile::Exists(dvdPath) && CFile::Exists(path))
+	dvdPath = path;
+      else
+	dvdPath.clear();
     }
   }
 #endif


### PR DESCRIPTION
Added check to CFileItem::GetOpticalMedia to avoid calling CFile::Exists on files in non-existing directories causing a crash in smbclient with some servers

See Bug described in this post: http://forum.kodi.tv/showthread.php?tid=207416
