### PR TITLE
[infomanager] Added System.ScreenSaverName infolabel

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -249,6 +249,7 @@ const infomap system_labels[] =  {{ "hasnetwork",       SYSTEM_ETHERNET_LINK_ACT
                                   { "canhibernate",     SYSTEM_CAN_HIBERNATE },
                                   { "canreboot",        SYSTEM_CAN_REBOOT },
                                   { "screensaveractive",SYSTEM_SCREENSAVER_ACTIVE },
+                                  { "screensaver",      SYSTEM_SCREENSAVER },
                                   { "dpmsactive",       SYSTEM_DPMS_ACTIVE },
                                   { "cputemperature",   SYSTEM_CPU_TEMPERATURE },     // labels from here
                                   { "cpuusage",         SYSTEM_CPU_USAGE },
@@ -1459,6 +1460,9 @@ std::string CGUIInfoManager::GetLabel(int info, int contextWindow, std::string *
   case WEATHER_PLUGIN:
     strLabel = CSettings::Get().GetString("weather.addon");
     break;
+  case SYSTEM_SCREENSAVER:
+    strLabel = CSettings::Get().GetString("screensaver.mode");
+    break;
   case SYSTEM_DATE:
     strLabel = GetDate();
     break;
@@ -1737,7 +1741,6 @@ std::string CGUIInfoManager::GetLabel(int info, int contextWindow, std::string *
         GetFPS());
     return strLabel;
     break;
-
   case CONTAINER_FOLDERPATH:
   case CONTAINER_FOLDERNAME:
     {

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -360,6 +360,7 @@ namespace INFO
 #define SKIN_HAS_THEME              606
 #define SKIN_ASPECT_RATIO           607
 
+#define SYSTEM_SCREENSAVER          643
 #define SYSTEM_TOTAL_MEMORY         644
 #define SYSTEM_CPU_USAGE            645
 #define SYSTEM_USED_MEMORY_PERCENT  646


### PR DESCRIPTION
This adds the infolabel `Sytem.ScreenSaverName`. Request on forums @ http://forum.kodi.tv/showthread.php?tid=217125

@BigNoid, @ronie for comments on how much useful this is. I wonder if it should return the addon name or id.
