### PR TITLE
[core] Support mixed media types in playlists

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4237,6 +4237,14 @@ bool CApplication::OnMessage(CGUIMessage& message)
       if (url.IsProtocol("plugin"))
         XFILE::CPluginDirectory::GetPluginResult(url.Get(), file);
 
+      // Don't queue if next media type is different from current one
+      if ((!file.IsVideo() && m_pPlayer->IsPlayingVideo())
+          || (!file.IsAudio() && m_pPlayer->IsPlayingAudio()))
+      {
+        m_pPlayer->OnNothingToQueueNotify();
+        return true;
+      }
+
 #ifdef HAS_UPNP
       if (URIUtils::IsUPnP(file.GetPath()))
       {


### PR DESCRIPTION
Ignore GUI_MSG_QUEUE_NEXT_ITEM messages when the incoming item is not playable by current player, giving a chance to be reproduced by a different one, instead of skipping it.

@FernetMenta, I accidentally closed #6291, but this is a re-implementation doing a graceful shutdown of the current player.
