### PR TITLE
[gui] fix list control couldn't get the focus after introducing #5804

### DIFF
--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -751,7 +751,6 @@ bool CGUIMediaWindow::Update(const std::string &strDirectory, bool updateFilterP
   if (canfilter && url.HasOption("filter"))
     directory = RemoveParameterFromPath(directory, "filter");
 
-  ClearFileItems();
   if (!GetDirectory(directory, *m_vecItems))
   {
     CLog::Log(LOGERROR,"CGUIMediaWindow::GetDirectory(%s) failed", url.GetRedacted().c_str());
@@ -823,8 +822,7 @@ bool CGUIMediaWindow::Update(const std::string &strDirectory, bool updateFilterP
   m_vecItems->FillInDefaultIcons();
 
   // remember the original (untouched) list of items (for filtering etc)
-  m_unfilteredItems->SetPath(m_vecItems->GetPath()); // use the original path - it'll likely be relied on for other things later.
-  m_unfilteredItems->Append(*m_vecItems);
+  m_unfilteredItems->Assign(*m_vecItems);
 
   // Cache the list of items if possible
   OnCacheFileItems(*m_vecItems);


### PR DESCRIPTION
This is an attempt to fix the reported issues after introducing PR #5804.

> Start YouTube addon
>     Click on "What to watch"
>     Wait for items to be listed ("List" view)
>     Press a button - any button - and nothing happens, although you hear the GUI "click" sound
>     Press more buttons, and now the buttons are processed correctly
> 
> So it seems that the first input is being "swallowed" somehow, but only in certain views/pages. I thought it might be an issue with "Show parent folder items" (I have it disabled) but it's not, same behaviour with it enabled.

and

> The blue selection bar appears for half a second then disappears as screenshot above shows, only comes back when pressing any key on remote.

@mkortstiege as we have discussed this at IRC could you please take a look.

@MilhouseVH, @uNiversaI could please do some test on top of this PR.
