### PR TITLE
[readme update] libyajl-dev >= 2.0

### DIFF
--- a/docs/README.linux
+++ b/docs/README.linux
@@ -55,8 +55,9 @@ Build-Depends: autoconf, automake, autopoint, autotools-dev, cmake, curl,
   librtmp-dev, libsdl2-dev, libshairplay-dev, libsmbclient-dev, libsqlite3-dev, libssh-dev,
   libssl-dev, libswscale-dev, libtag1-dev (>= 1.8), libtiff-dev, libtinyxml-dev, libtool,
   libudev-dev, libusb-dev, libva-dev, libvdpau-dev, libvorbis-dev, libxinerama-dev,
-  libxml2-dev, libxmu-dev, libxrandr-dev, libxslt1-dev, libxt-dev, libyajl-dev, lsb-release,
-  nasm [!amd64], python-dev, python-imaging, python-support, swig, unzip, yasm, zip, zlib1g-dev
+  libxml2-dev, libxmu-dev, libxrandr-dev, libxslt1-dev, libxt-dev, libyajl-dev (>=2.0),
+  lsb-release, nasm [!amd64], python-dev, python-imaging, python-support, swig, unzip,
+  yasm, zip, zlib1g-dev
   
 Note: For developers and anyone else who compiles frequently it is recommended to use ccache.
 

--- a/docs/README.ubuntu
+++ b/docs/README.ubuntu
@@ -78,6 +78,10 @@ For Ubuntu (all versions >= 7.04):
 
 For >= 10.10:
     $ sudo apt-get install autopoint libltdl-dev
+
+For >= 12.04 lts: Backport for Precise of libyajl2
+	& sudo-add-apt-repository ppa:team-xbmc/xbmc-nightly
+	& sudo apt-get install libyajl-dev
 	
 For >= 12.10:
 	$ sudo apt-get install libtag1-dev


### PR DESCRIPTION
This adds information about current nightly requirements for this
library.

added nightly ppa which has backport of this library to readme.ubuntu
readme linux only has a bump in minimal required version.

@wsnipex
