### PR TITLE
slideshow: fix not considering videos when started through builtin

### DIFF
--- a/xbmc/pictures/GUIViewStatePictures.cpp
+++ b/xbmc/pictures/GUIViewStatePictures.cpp
@@ -73,10 +73,11 @@ std::string CGUIViewStateWindowPictures::GetLockType()
 
 std::string CGUIViewStateWindowPictures::GetExtensions()
 {
+  std::string extensions = g_advancedSettings.m_pictureExtensions;
   if (CSettings::Get().GetBool("pictures.showvideos"))
-    return g_advancedSettings.m_pictureExtensions+"|"+g_advancedSettings.m_videoExtensions;
+    extensions += "|" + g_advancedSettings.m_videoExtensions;
 
-  return g_advancedSettings.m_pictureExtensions;
+  return extensions;
 }
 
 VECSOURCES& CGUIViewStateWindowPictures::GetSources()

--- a/xbmc/pictures/GUIViewStatePictures.h
+++ b/xbmc/pictures/GUIViewStatePictures.h
@@ -27,10 +27,11 @@ class CGUIViewStateWindowPictures : public CGUIViewState
 public:
   CGUIViewStateWindowPictures(const CFileItemList& items);
 
-protected:
-  virtual void SaveViewState();
   virtual std::string GetLockType();
   virtual std::string GetExtensions();
   virtual VECSOURCES& GetSources();
+
+protected:
+  virtual void SaveViewState();
 };
 

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -45,6 +45,7 @@
 #include "utils/log.h"
 #include "utils/TimeUtils.h"
 #include "interfaces/AnnouncementManager.h"
+#include "pictures/GUIViewStatePictures.h"
 #include "pictures/PictureInfoTag.h"
 #include "pictures/PictureThumbLoader.h"
 
@@ -1261,9 +1262,11 @@ void CGUIWindowSlideShow::AddItems(const std::string &strPath, path_set *recursi
     recursivePaths->insert(path);
   }
 
-  // fetch directory and sort accordingly
   CFileItemList items;
-  if (!CDirectory::GetDirectory(strPath, items, m_strExtensions.empty()?g_advancedSettings.m_pictureExtensions:m_strExtensions,DIR_FLAG_NO_FILE_DIRS,true))
+  CGUIViewStateWindowPictures viewState(items);
+
+  // fetch directory and sort accordingly
+  if (!CDirectory::GetDirectory(strPath, items, viewState.GetExtensions(), DIR_FLAG_NO_FILE_DIRS, true))
     return;
 
   items.Sort(method, order, sortAttributes);


### PR DESCRIPTION
The first two commits are merely cleanup but the third commit fixes the fact that starting a slideshow through builtins current behaves differently than when starting it from the pictures view in the GUI because the latter also considers files with video extensions (if enabled in the settings). This moves the general code to start a slideshow without specifying any file extensions in line with that behaviour.
