### PR TITLE
dvdplayer: discard render buffers if gui is not active

### DIFF
--- a/xbmc/cores/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoRenderers/RenderManager.h
@@ -201,10 +201,11 @@ protected:
 
   EINTERLACEMETHOD AutoInterlaceMethodInternal(EINTERLACEMETHOD mInt);
 
-  bool m_bIsStarted;
   CSharedSection m_sharedSection;
 
+  bool m_bIsStarted;
   bool m_bReconfigured;
+  bool m_bRenderGUI;
 
   int m_rendermethod;
 


### PR DESCRIPTION
fixes http://trac.kodi.tv/ticket/15762

don't let player jam if GUI is not active
