### PR TITLE
[osx] Force reset in VideoSyncCocoa when refresh rate changes

### DIFF
--- a/xbmc/video/videosync/VideoSyncCocoa.cpp
+++ b/xbmc/video/videosync/VideoSyncCocoa.cpp
@@ -126,12 +126,7 @@ void CVideoSyncCocoa::OnResetDevice()
 float CVideoSyncCocoa::GetFps()
 {
 #if defined(TARGET_DARWIN_IOS)
-  int fpsInt = MathUtils::round_int(g_Windowing.GetDisplayLinkFPS() + 0.5);
-
-  if (fpsInt != MathUtils::round_int(m_fps))
-  {
-    m_fps = fpsInt;
-  }
+  m_fps = g_Windowing.GetDisplayLinkFPS();
 #else
   m_fps = g_graphicsContext.GetFPS();
 #endif

--- a/xbmc/video/videosync/VideoSyncCocoa.cpp
+++ b/xbmc/video/videosync/VideoSyncCocoa.cpp
@@ -53,6 +53,7 @@ static CVReturn DisplayLinkCallBack(CVDisplayLinkRef displayLink, const CVTimeSt
   
   return kCVReturnSuccess;
 }
+#endif
 
 void CVideoSyncCocoa::VblankHandler(int64_t nowtime, double fps)
 {
@@ -69,7 +70,6 @@ void CVideoSyncCocoa::VblankHandler(int64_t nowtime, double fps)
   //update the vblank timestamp, update the clock and send a signal that we got a vblank
   UpdateClock(NrVBlanks, nowtime);
 }
-#endif
 
 bool CVideoSyncCocoa::Setup(PUPDATECLOCK func)
 {

--- a/xbmc/video/videosync/VideoSyncCocoa.cpp
+++ b/xbmc/video/videosync/VideoSyncCocoa.cpp
@@ -28,6 +28,7 @@
 #include "utils/TimeUtils.h"
 
 #include "windowing/WindowingFactory.h"
+#include "guilib/GraphicContext.h"
 
 //osx specifics
 #if defined(TARGET_DARWIN_OSX)
@@ -52,19 +53,11 @@ static CVReturn DisplayLinkCallBack(CVDisplayLinkRef displayLink, const CVTimeSt
   
   return kCVReturnSuccess;
 }
-#endif
 
 void CVideoSyncCocoa::VblankHandler(int64_t nowtime, double fps)
 {
   int           NrVBlanks;
   double        VBlankTime;
-  int           RefreshRate = MathUtils::round_int(fps);
-  
-  if (RefreshRate != MathUtils::round_int(m_fps))
-  {
-    CLog::Log(LOGDEBUG, "CVideoSyncCocoa: Detected refreshrate: %f hertz, rounding to %i hertz", fps, RefreshRate);
-    UpdateFPS(fps);
-  }
   
   //calculate how many vblanks happened
   VBlankTime = (double)(nowtime - m_LastVBlankTime) / (double)g_VideoReferenceClock.GetFrequency();
@@ -76,10 +69,11 @@ void CVideoSyncCocoa::VblankHandler(int64_t nowtime, double fps)
   //update the vblank timestamp, update the clock and send a signal that we got a vblank
   UpdateClock(NrVBlanks, nowtime);
 }
+#endif
 
 bool CVideoSyncCocoa::Setup(PUPDATECLOCK func)
 {
-  CLog::Log(LOGDEBUG, "CVideoSyncCocoa: setting up Cocoa");
+  CLog::Log(LOGDEBUG, "CVideoSyncCocoa::%s - setting up Cocoa", __FUNCTION__);
   bool setupOk = false;
 
   //init the vblank timestamp
@@ -95,7 +89,7 @@ bool CVideoSyncCocoa::Setup(PUPDATECLOCK func)
   if (setupOk)
     g_Windowing.Register(this);
   else
-    CLog::Log(LOGDEBUG, "CVideoSyncCocoa: Cocoa_CVDisplayLinkCreate failed");
+    CLog::Log(LOGDEBUG, "CVideoSyncCocoa::%s Cocoa_CVDisplayLinkCreate failed", __FUNCTION__);
 #endif
 
   if (setupOk)
@@ -115,24 +109,13 @@ void CVideoSyncCocoa::Run(volatile bool& stop)
 
 void CVideoSyncCocoa::Cleanup()
 {
-  CLog::Log(LOGDEBUG, "CVideoSyncCocoa: cleaning up Cocoa");
+  CLog::Log(LOGDEBUG, "CVideoSyncCocoa::%s cleaning up Cocoa", __FUNCTION__);
 #if defined(TARGET_DARWIN_IOS)
   g_Windowing.DeinitDisplayLink();
 #else
   Cocoa_CVDisplayLinkRelease();
   g_Windowing.Unregister(this);
 #endif
-}
-
-void CVideoSyncCocoa::UpdateFPS(double fps)
-{
-  int fpsInt = MathUtils::round_int(fps);
-
-  if (fpsInt != MathUtils::round_int(m_fps))
-  {
-    CLog::Log(LOGDEBUG, "CVideoSyncCocoa: Detected refreshrate: %i hertz", fpsInt);
-    m_fps = fpsInt;
-  }
 }
 
 void CVideoSyncCocoa::OnResetDevice()
@@ -142,12 +125,19 @@ void CVideoSyncCocoa::OnResetDevice()
 
 float CVideoSyncCocoa::GetFps()
 {
+  int fpsInt;
 #if defined(TARGET_DARWIN_IOS)
-  UpdateFPS(g_Windowing.GetDisplayLinkFPS() + 0.5);
-#else
-  UpdateFPS(Cocoa_GetCVDisplayLinkRefreshPeriod());
-#endif
+  fpsInt = MathUtils::round_int(g_Windowing.GetDisplayLinkFPS() + 0.5);
 
+  if (fpsInt != MathUtils::round_int(m_fps))
+  {
+    m_fps = fpsInt;
+  }
+#else
+  m_fps = g_graphicsContext.GetFPS();
+  fpsInt = MathUtils::round_int(m_fps);
+#endif
+  CLog::Log(LOGDEBUG, "CVideoSyncCocoa::%s Detected refreshrate: %i hertz", __FUNCTION__, fpsInt);
   return m_fps;
 }
 

--- a/xbmc/video/videosync/VideoSyncCocoa.cpp
+++ b/xbmc/video/videosync/VideoSyncCocoa.cpp
@@ -125,9 +125,8 @@ void CVideoSyncCocoa::OnResetDevice()
 
 float CVideoSyncCocoa::GetFps()
 {
-  int fpsInt;
 #if defined(TARGET_DARWIN_IOS)
-  fpsInt = MathUtils::round_int(g_Windowing.GetDisplayLinkFPS() + 0.5);
+  int fpsInt = MathUtils::round_int(g_Windowing.GetDisplayLinkFPS() + 0.5);
 
   if (fpsInt != MathUtils::round_int(m_fps))
   {
@@ -135,9 +134,8 @@ float CVideoSyncCocoa::GetFps()
   }
 #else
   m_fps = g_graphicsContext.GetFPS();
-  fpsInt = MathUtils::round_int(m_fps);
 #endif
-  CLog::Log(LOGDEBUG, "CVideoSyncCocoa::%s Detected refreshrate: %i hertz", __FUNCTION__, fpsInt);
+  CLog::Log(LOGDEBUG, "CVideoSyncCocoa::%s Detected refreshrate: %f hertz", __FUNCTION__, m_fps);
   return m_fps;
 }
 

--- a/xbmc/video/videosync/VideoSyncCocoa.h
+++ b/xbmc/video/videosync/VideoSyncCocoa.h
@@ -33,7 +33,6 @@ public:
   void VblankHandler(int64_t nowtime, double fps);
   virtual void OnResetDevice();
 private:
-  void UpdateFPS(double fps);
   int64_t m_LastVBlankTime;  //timestamp of the last vblank, used for calculating how many vblanks happened
   volatile bool m_abort;
 };


### PR DESCRIPTION
The existing implementation just updates m_fps, but nothing is fed back to the reference clock.  Instead of calling UpdateFPS(), just force a reset, as it does in VideoSyncD3D.

This PR makes refresh rate adjustment work on OSX, which was the intended fix in PR #6146 / #6147.

However, it's a little suboptimal because the first time it goes to set things up, the call to CVDisplayLinkGetActualOutputVideoRefreshPeriod() in Cocoa_GetCVDisplayLinkRefreshPeriod() returns 0.0, which makes Cocoa_GetCVDisplayLinkRefreshPeriod() default to a return value of 60.0.  So the video reference clock is set to 60.0 right off the bat.

In reality, the display is just in the process of switching over (which can take seconds on some TVs), so this means for every video played where refresh rate adjustment is required, it has to create the device, destroy it, and create it again.

Additionally, the audio is out of sync even after it does figure things out.  Pressing 'm' to bring up VideoOSD forces it to sync up, but it's a little annoying to have to do that every time.  [side note:  what function is called to force-sync things when VideoOSD is brought up?]

I'm soliciting some discussion about how this should really be handled properly.  Ideally, I think it should only set things up after the resolution change has completed (that is, CVDisplayLinkGetActualOutputVideoRefreshPeriod() returns > 0.0) to avoid creating and destroying things more than necessary (to speed up the start of playback).  But it also needs to handle refresh rate/resolution changes on-the-fly as well (i.e., getting audio and video back in sync if the user just changes the refresh rate outside of Kodi, without requiring the user to bring up VideoOSD or some other UI element that forces a resync).
