### PR TITLE
[rtmp] re-add rtmp options

### DIFF
--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamRTMP.h
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamRTMP.h
@@ -51,6 +51,7 @@ protected:
   bool       m_canSeek;
   bool       m_canPause;
   char*      m_sStreamPlaying;
+  std::vector<std::string> m_optionvalues;
 
   RTMP       *m_rtmp;
   DllLibRTMP m_libRTMP;


### PR DESCRIPTION
partially reverts 0339c8cdf564d056fc307c04d12370ccdc75499b
fixes (#15756)

turns out, some plugins/streams actually use those options.
