### PR TITLE
[videodatabase] include tvshows base dir in GetPathsForTvShow

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -574,6 +574,13 @@ bool CVideoDatabase::GetPathsForTvShow(int idShow, set<int>& paths)
   {
     if (NULL == m_pDB.get()) return false;
     if (NULL == m_pDS.get()) return false;
+
+    // add base path
+    strSQL = PrepareSQL("SELECT strPath FROM tvshow_view WHERE idShow=%i", idShow);
+    if (m_pDS->query(strSQL.c_str()))
+      paths.insert(GetPathId(m_pDS->fv(0).get_asString()));
+
+    // add all other known paths
     strSQL = PrepareSQL("SELECT DISTINCT idPath FROM files JOIN episode ON episode.idFile=files.idFile WHERE episode.idShow=%i",idShow);
     m_pDS->query(strSQL.c_str());
     while (!m_pDS->eof())


### PR DESCRIPTION
Make sure we´re adding the actual base path of the tvshow when fetching paths so it´s properly invalided on remove. This fixes an issue where previously removed tvshows are not picked by the videoinfoscanner.
