### PR TITLE
[jenkins] - don't clamp release builds to 1 thread -

### DIFF
--- a/tools/buildsteps/defaultenv
+++ b/tools/buildsteps/defaultenv
@@ -66,12 +66,6 @@ then
   Configuration=$DEFAULT_CONFIGURATION
 fi
 
-#clamp release builds to 1 thread only
-if [ "$Configuration" == "Release" ]
-then
-  BUILDTHREADS=1
-fi
-
 #helper functions
 
 #hash a dir based on the git revision, SDK_PATH, NDK_PATH, SDK_VERSION, TOOLCHAIN TOOLCHAIN_X86 (for droidx86) and XBMC_DEPENDS_ROOT


### PR DESCRIPTION
 parallel building seems working ok on the builders [tm]
