### PR TITLE
[guilib] fix hint text vanish on unfocus

### DIFF
--- a/xbmc/guilib/GUIEditControl.cpp
+++ b/xbmc/guilib/GUIEditControl.cpp
@@ -746,4 +746,5 @@ void CGUIEditControl::SetFocus(bool focus)
   m_smsTimer.Stop();
   g_Windowing.EnableTextInput(focus);
   CGUIControl::SetFocus(focus);
+  SetInvalid();
 }


### PR DESCRIPTION
Backport of https://github.com/xbmc/xbmc/pull/6366
