### PR TITLE
[curl] don't return 0 in the write callback, it causes ftp content lengh...

### DIFF
--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -100,7 +100,7 @@ extern "C" size_t write_callback(char *buffer,
                size_t nitems,
                void *userp)
 {
-  if(userp == NULL) return 0;
+  if(userp == NULL) return size * nitems;
 
   CCurlFile::CReadState *state = (CCurlFile::CReadState *)userp;
   return state->WriteCallback(buffer, size, nitems);


### PR DESCRIPTION
...t requests to fail

fixes issues raised in https://github.com/OpenELEC/OpenELEC.tv/issues/3866#issuecomment-73482469
Curl always expects the number of bytes written in the callback to be equal to the input.

Some more testing would be welcome
