### PR TITLE
[configure] tinyxml upstream does not provide a pkg-config file,

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -1117,9 +1117,21 @@ if test "$use_mysql" = "yes"; then
 fi
 AC_CHECK_LIB([bluetooth],   [hci_devid],, AC_MSG_RESULT([Could not find suitable version of libbluetooth]))
 
+AC_LANG_PUSH([C++])
 PKG_CHECK_MODULES([TINYXML], [tinyxml >= 2.6.2],
   [INCLUDES="$INCLUDES $TINYXML_CFLAGS"; LIBS="$LIBS $TINYXML_LIBS"],
-  AC_MSG_ERROR("libtinyxml >= 2.6.2 not found"))
+  [AC_RUN_IFELSE(
+   [AC_LANG_SOURCE([[
+#include <stdlib.h>
+#include <tinyxml.h>
+
+int main() {
+  if (TIXML_MAJOR_VERSION < 2) exit(1);
+  if (TIXML_MAJOR_VERSION == 2 && ( TIXML_MINOR_VERSION < 6 || ( TIXML_MINOR_VERSION == 6 && TIXML_PATCH_VERSION < 2 ))) exit(1);
+}
+    ]])],[AC_CHECK_LIB([tinyxml], [main],, AC_MSG_ERROR("tinyxml >= 2.6.2 not found"))], [AC_MSG_ERROR([tinyxml >= 2.6.2 not found])]
+  )])
+AC_LANG_POP([C++])
 
 PKG_CHECK_MODULES([YAJL], [yajl >= 2],
   [INCLUDES="$INCLUDES $YAJL_CFLAGS"; LIBS="$LIBS $YAJL_LIBS"; YAJL_FOUND="true"],


### PR DESCRIPTION
so we must fallback to checking the header :/
closes (#15771)
