### PR TITLE
[gui] adds new info label Player.SeekStepSize

### DIFF
--- a/addons/skin.confluence/720p/DialogSeekBar.xml
+++ b/addons/skin.confluence/720p/DialogSeekBar.xml
@@ -231,21 +231,7 @@
 				<aligny>center</aligny>
 				<font>font10_title</font>
 				<textcolor>blue</textcolor>
-				<label>$LOCALIZE[31046]</label>
-				<visible>Player.Seeking</visible>
-			</control>
-			<control type="label">
-				<description>Final Seek amount Label</description>
-				<left>20</left>
-				<top>7</top>
-				<width>240</width>
-				<height>20</height>
-				<align>left</align>
-				<aligny>center</aligny>
-				<font>font10_title</font>
-				<textcolor>blue</textcolor>
-				<label>$LOCALIZE[31046][COLOR=grey] $INFO[Player.SeekOffset][/COLOR]</label>
-				<visible>Player.DisplayAfterSeek + ![player.forwarding | player.rewinding]</visible>
+				<label>$VAR[SeekLabel]</label>
 			</control>
 			<control type="label">
 				<description>FF Label</description>

--- a/addons/skin.confluence/720p/includes.xml
+++ b/addons/skin.confluence/720p/includes.xml
@@ -59,6 +59,11 @@
 		<value condition="[substring(ListItem.VideoCodec,div,left) | stringcompare(ListItem.VideoCodec,dx50)]">divx</value>
 		<value>$INFO[ListItem.VideoCodec]</value>
 	</variable>
+	<variable name="SeekLabel">
+		<value condition="!IsEmpty(Player.SeekStepSize) + ![player.forwarding | player.rewinding]">$LOCALIZE[31046][COLOR=grey] $INFO[Player.SeekStepSize][/COLOR]</value>
+		<value condition="Player.DisplayAfterSeek + ![player.forwarding | player.rewinding]">$LOCALIZE[31046][COLOR=grey] $INFO[Player.SeekOffset][/COLOR]</value>
+		<value condition="!Player.DisplayAfterSeek + Player.Seeking">$LOCALIZE[31046]</value>
+	</variable>
 
 	<include name="BehindDialogFadeOut">
 		<control type="image">

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -219,6 +219,7 @@ const infomap player_param[] =   {{ "art",              PLAYER_ITEM_ART }};
 
 const infomap player_times[] =   {{ "seektime",         PLAYER_SEEKTIME },
                                   { "seekoffset",       PLAYER_SEEKOFFSET },
+                                  { "seekstepsize",     PLAYER_SEEKSTEPSIZE },
                                   { "timeremaining",    PLAYER_TIME_REMAINING },
                                   { "timespeed",        PLAYER_TIME_SPEED },
                                   { "time",             PLAYER_TIME },
@@ -3238,6 +3239,14 @@ std::string CGUIInfoManager::GetMultiInfoLabel(const GUIInfo &info, int contextW
     if (m_seekOffset < 0)
       return "-" + seekOffset;
     if (m_seekOffset > 0)
+      return "+" + seekOffset;
+  }
+  else if (info.m_info == PLAYER_SEEKSTEPSIZE)
+  {
+    std::string seekOffset = StringUtils::SecondsToTimeString(abs(m_seekStepSize), (TIME_FORMAT)info.GetData1());
+    if (m_seekStepSize < 0)
+      return "-" + seekOffset;
+    if (m_seekStepSize > 0)
       return "+" + seekOffset;
   }
   else if (info.m_info == PLAYER_ITEM_ART)

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -111,6 +111,7 @@ namespace INFO
 #define PLAYER_TITLE                 53
 #define PLAYER_ISINTERNETSTREAM      54
 #define PLAYER_FILENAME              55
+#define PLAYER_SEEKSTEPSIZE          56
 
 #define WEATHER_CONDITIONS          100
 #define WEATHER_TEMPERATURE         101
@@ -801,6 +802,7 @@ public:
 
   bool GetDisplayAfterSeek();
   void SetDisplayAfterSeek(unsigned int timeOut = 2500, int seekOffset = 0);
+  void SetSeekStepSize(int seekStepSize) { m_seekStepSize = seekStepSize; };
   void SetSeeking(bool seeking) { m_playerSeeking = seeking; };
   void SetShowTime(bool showtime) { m_playerShowTime = showtime; };
   void SetShowCodec(bool showcodec) { m_playerShowCodec = showcodec; };
@@ -931,6 +933,7 @@ protected:
   //Fullscreen OSD Stuff
   unsigned int m_AfterSeekTimeout;
   int m_seekOffset;
+  int m_seekStepSize;
   bool m_playerSeeking;
   bool m_playerShowTime;
   bool m_playerShowCodec;

--- a/xbmc/utils/SeekHandler.cpp
+++ b/xbmc/utils/SeekHandler.cpp
@@ -141,7 +141,10 @@ void CSeekHandler::Seek(bool forward, float amount, float duration /* = 0 */, bo
       if (g_infoManager.GetTotalPlayTime())
         percentPerSecond = 100.0f / (float)g_infoManager.GetTotalPlayTime();
 
-      m_percent = m_percentPlayTime + percentPerSecond * GetSeekSeconds(forward);
+      int seekSeconds = GetSeekSeconds(forward);
+      g_infoManager.SetSeekStepSize(seekSeconds);
+
+      m_percent = m_percentPlayTime + percentPerSecond * seekSeconds;
     }
 
     if (m_percent > 100.0f) m_percent = 100.0f;
@@ -171,6 +174,9 @@ void CSeekHandler::Process()
     if (m_requireSeek)
     {
       g_infoManager.m_performingSeek = true;
+
+      // reset seek step size
+      g_infoManager.SetSeekStepSize(0);
 
       // calculate the seek time
       double time = g_infoManager.GetTotalPlayTime() * m_percent * 0.01;


### PR DESCRIPTION
This will updates the seek offset in CGUIInfoManager for every call to CSeekHandler::Seek() if using smart seeking which gives us the possibility to output the seek step size before the seek is processed. 

@da-anda mind taking a look .. might we use a different GUI info var as `Player.SeekOffset` e.g. `Player.SeekStepSize`?
