### PR TITLE
[darwin/depends/tar-native] - force fdopendir to no because we don't have it wh...

### DIFF
--- a/tools/depends/native/tar-native/Makefile
+++ b/tools/depends/native/tar-native/Makefile
@@ -12,7 +12,7 @@ ARCHIVE=$(SOURCE).tar.gz
 export LIBTOOL=builds/unix/libtool
 export PATH:=$(PREFIX)/bin:$(PATH)
 CONFIGURE=./configure --prefix=$(PREFIX) \
---program-transform-name=s/tar/gtar/ --disable-dependency-tracking
+--program-transform-name=s/tar/gtar/ --disable-dependency-tracking ac_cv_func_fdopendir=no
 
 APP=$(SOURCE)/src/tar
 APPBIN=$(PREFIX)/bin/tar


### PR DESCRIPTION
...en compiling native on 10.9 with 10.10 sdk installed (it would pick fdopendir from 10.10 sdk which is not available at runtime on 10.9 later on when tar is used for packaging the ios deb files).

This is an ugly side effect. Basically our nativetools for osx are crosscompile aswell. (in my case i compile on osx 10.9 but have 10.10 sdk installed - native tools would be built against 10.10 sdk and linking symbols which are not available during runtime on 10.9 later on).

The fact that this is the only tool which we build which exposes issues is the reason i do this "quick" fix here. The proper way (defining all the -isystem -iroot -mmacos-version-min -arch tschenga tschonga) wouldn't even help in this particular case because the used fdopendir.m4 file doesn't obey the cross flags anyway.

This only affects darwin builds (we don't build tar for any others...)
