### PR TITLE
[ios/atv2/packaging] - switch back to the hardcoded dsym dir - fixes dsy...

### DIFF
--- a/tools/darwin/packaging/atv2/mkdeb-atv2.sh.in
+++ b/tools/darwin/packaging/atv2/mkdeb-atv2.sh.in
@@ -4,7 +4,7 @@
 XBMC_DEPENDS_ROOT=@DEPENDS_ROOT_FOR_XCODE@
 SWITCH=`echo $1 | tr [A-Z] [a-z]`
 DIRNAME=`dirname $0`
-DSYM_TARGET_DIR=${XBMC_DEPENDS_ROOT}/dSyms
+DSYM_TARGET_DIR=/Users/Shared/xbmc-depends/dSyms
 DSYM_FILENAME=@APP_NAME@.frappliance.dSYM
 
 if [ ${SWITCH:-""} = "debug" ]; then

--- a/tools/darwin/packaging/ios/mkdeb-ios.sh.in
+++ b/tools/darwin/packaging/ios/mkdeb-ios.sh.in
@@ -5,7 +5,7 @@
 XBMC_DEPENDS_ROOT=@DEPENDS_ROOT_FOR_XCODE@
 SWITCH=`echo $1 | tr [A-Z] [a-z]`
 DIRNAME=`dirname $0`
-DSYM_TARGET_DIR=${XBMC_DEPENDS_ROOT}/dSyms
+DSYM_TARGET_DIR=/Users/Shared/xbmc-depends/dSyms
 DSYM_FILENAME=@APP_NAME@.app.dSYM
 
 if [ ${SWITCH:-""} = "debug" ]; then


### PR DESCRIPTION
...m backups on jenkins which were broken in a0a6e40a6299ff004353603201e6d60f569c1a2c

This restores our ability to backup dsyms for beeing able to symbolicate crash logs. Sadly i only happened to realise now that it was broken - we don't have the dsyms for 14.0 and 14.1 no sadly :(

This is nothing which would reveil in a jenkins build (it will for sure light up green here in the PR)  - thats why i will merge it directly in some mins.

backport of #6389 

@MartijnKaijser no brainer in case we wanna do 14.2 it would be great to have the dsyms backed up ;)
