### PR TITLE
[python] remove leftover xbmc.python 1.0 compat code

### DIFF
--- a/xbmc/interfaces/legacy/Addon.cpp
+++ b/xbmc/interfaces/legacy/Addon.cpp
@@ -50,30 +50,8 @@ namespace XBMCAddon
       if (id.empty())
         throw AddonException("No valid addon id could be obtained. None was passed and the script wasn't executed in a normal xbmc manner.");
 
-      // if we still fail we MAY be able to recover.
       if (!ADDON::CAddonMgr::Get().GetAddon(id.c_str(), pAddon))
-      {
-        // we need to check the version prior to trying a bw compatibility trick
-        ADDON::AddonVersion version(getAddonVersion());
-        ADDON::AddonVersion allowable("1.0");
-
-        if (version <= allowable)
-        {
-          // try the default ...
-          id = getDefaultId();
-
-          if (id.empty() || !ADDON::CAddonMgr::Get().GetAddon(id.c_str(), pAddon))
-            throw AddonException("Could not get AddonPtr!");
-          else
-            CLog::Log(LOGERROR,"Use of deprecated functionality. Please to not assume that \"os.getcwd\" will return the script directory.");
-        }
-        else
-        {
-          throw AddonException("Could not get AddonPtr given a script id of %s."
-                               "If you are trying to use 'os.getcwd' to set the path, you cannot do that in a version %s plugin.", 
-                               id.c_str(), version.asString().c_str());
-        }
-      }
+        throw AddonException("Unknown addon id '%s'.", id.c_str());
 
       CAddonMgr::Get().AddToUpdateableAddons(pAddon);
     }

--- a/xbmc/interfaces/python/AddonPythonInvoker.cpp
+++ b/xbmc/interfaces/python/AddonPythonInvoker.cpp
@@ -50,27 +50,6 @@
         "sys.stderr = xbmcout(" MODULE ".LOGERROR)\n" \
         ""
 
-#define RUNSCRIPT_OVERRIDE_HACK \
-        "" \
-        "import os\n" \
-        "def getcwd_xbmc():\n" \
-        "  import __main__\n" \
-        "  import warnings\n" \
-        "  if hasattr(__main__, \"__file__\"):\n" \
-        "    warnings.warn(\"os.getcwd() currently lies to you so please use addon.getAddonInfo('path') to find the script's root directory and DO NOT make relative path accesses based on the results of 'os.getcwd.' \", DeprecationWarning, stacklevel=2)\n" \
-        "    return os.path.dirname(__main__.__file__)\n" \
-        "  else:\n" \
-        "    return os.getcwd_original()\n" \
-        "" \
-        "def chdir_xbmc(dir):\n" \
-        "  raise RuntimeError(\"os.chdir not supported in xbmc\")\n" \
-        "" \
-        "os_getcwd_original = os.getcwd\n" \
-        "os.getcwd          = getcwd_xbmc\n" \
-        "os.chdir_orignal   = os.chdir\n" \
-        "os.chdir           = chdir_xbmc\n" \
-        ""
-
 #define RUNSCRIPT_SETUPTOOLS_HACK \
   "" \
   "import imp,sys\n" \
@@ -90,16 +69,10 @@
 
 #if defined(TARGET_ANDROID)
 
-#define RUNSCRIPT_BWCOMPATIBLE \
-  RUNSCRIPT_PRAMBLE RUNSCRIPT_OVERRIDE_HACK RUNSCRIPT_SETUPTOOLS_HACK RUNSCRIPT_POSTSCRIPT
-
 #define RUNSCRIPT_COMPLIANT \
   RUNSCRIPT_PRAMBLE RUNSCRIPT_SETUPTOOLS_HACK RUNSCRIPT_POSTSCRIPT
 
 #else
-
-#define RUNSCRIPT_BWCOMPATIBLE \
-  RUNSCRIPT_PRAMBLE RUNSCRIPT_OVERRIDE_HACK RUNSCRIPT_POSTSCRIPT
 
 #define RUNSCRIPT_COMPLIANT \
   RUNSCRIPT_PRAMBLE RUNSCRIPT_POSTSCRIPT
@@ -155,7 +128,5 @@ std::map<std::string, CPythonInvoker::PythonModuleInitialization> CAddonPythonIn
 
 const char* CAddonPythonInvoker::getInitializationScript() const
 {
-  bool bwcompatMode = (m_addon.get() == NULL ||
-                       m_addon->GetDependencyVersion("xbmc.python") <= ADDON::AddonVersion("1.0"));
-  return bwcompatMode ? RUNSCRIPT_BWCOMPATIBLE : RUNSCRIPT_COMPLIANT;
+  return RUNSCRIPT_COMPLIANT;
 }


### PR DESCRIPTION
According to https://github.com/xbmc/xbmc/blob/master/addons/xbmc.python/addon.xml any compatibility with 1.0 was dropped long ago, so there should be no point keeping these old hacks.
