### PR TITLE
addons: rename xbmc.gui.webinterface extension point to xbmc.webinterface

### DIFF
--- a/addons/webinterface.default/addon.xml
+++ b/addons/webinterface.default/addon.xml
@@ -8,7 +8,7 @@
     <import addon="xbmc.json" version="6.0.0"/>
   </requires>
   <extension
-    point="xbmc.gui.webinterface"/>
+    point="xbmc.webinterface"/>
   <extension point="xbmc.addon.metadata">
     <summary lang="af">Span Kodi Web Koppelvlak. (Kodi se verstek web koppelvlak)</summary>
     <summary lang="am">የ Kodi የዌብ ገጽታዎች (የ Kodi ነባር የዌብ ገጽታዎች)</summary>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2111,7 +2111,7 @@
           <level>1</level>
           <default>webinterface.default</default>
           <constraints>
-            <addontype>xbmc.gui.webinterface</addontype>
+            <addontype>xbmc.webinterface</addontype>
           </constraints>
           <control type="button" format="addon" />
         </setting>

--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -81,7 +81,7 @@ static const TypeMapping types[] =
    {"xbmc.python.module",                ADDON_SCRIPT_MODULE,       24082, "DefaultAddonLibrary.png" },
    {"xbmc.subtitle.module",              ADDON_SUBTITLE_MODULE,     24012, "DefaultAddonSubtitles.png" },
    {"xbmc.gui.skin",                     ADDON_SKIN,                  166, "DefaultAddonSkin.png" },
-   {"xbmc.gui.webinterface",             ADDON_WEB_INTERFACE,         199, "DefaultAddonWebSkin.png" },
+   {"xbmc.webinterface",                 ADDON_WEB_INTERFACE,         199, "DefaultAddonWebSkin.png" },
    {"xbmc.addon.repository",             ADDON_REPOSITORY,          24011, "DefaultAddonRepository.png" },
    {"xbmc.pvrclient",                    ADDON_PVRDLL,              24019, "DefaultAddonPVRClient.png" },
    {"xbmc.addon.video",                  ADDON_VIDEO,                1037, "DefaultAddonVideo.png" },
@@ -115,6 +115,7 @@ TYPE TranslateType(const std::string &string)
     if (string == map.name)
       return map.type;
   }
+
   return ADDON_UNKNOWN;
 }
 

--- a/xbmc/interfaces/json-rpc/schema/types.json
+++ b/xbmc/interfaces/json-rpc/schema/types.json
@@ -1306,7 +1306,7 @@
     "enum": [ "unknown", "xbmc.metadata.scraper.albums", "xbmc.metadata.scraper.artists", "xbmc.metadata.scraper.movies",
               "xbmc.metadata.scraper.musicvideos", "xbmc.metadata.scraper.tvshows", "xbmc.ui.screensaver",
               "xbmc.player.musicviz", "xbmc.python.pluginsource", "xbmc.python.script", "xbmc.python.weather",
-              "xbmc.python.subtitles", "xbmc.python.lyrics", "xbmc.gui.skin", "xbmc.gui.webinterface",
+              "xbmc.python.subtitles", "xbmc.python.lyrics", "xbmc.gui.skin", "xbmc.webinterface",
               "xbmc.pvrclient", "xbmc.addon.video", "xbmc.addon.audio", "xbmc.addon.image", "xbmc.addon.executable",
               "xbmc.service", "xbmc.subtitle.module" ],
     "default": "unknown"


### PR DESCRIPTION
This renames the existing `xbmc.gui.webinterface` adon extension point for webinterfaces to `xbmc.webinterface` as it doesn't really have anything to do with the `xbmc.gui` extension point for skins.
