### PR TITLE
[seek] adds smart seek support for music

### DIFF
--- a/system/keymaps/gamepad.xml
+++ b/system/keymaps/gamepad.xml
@@ -151,10 +151,10 @@
       <back>LockPreset</back>
       <leftanalogtrigger>AnalogRewind</leftanalogtrigger>
       <rightanalogtrigger>AnalogFastForward</rightanalogtrigger>
-      <dpadleft>SkipPrevious</dpadleft>
-      <dpadright>SkipNext</dpadright>
-      <dpadup>NextPreset</dpadup>
-      <dpaddown>PreviousPreset</dpaddown>
+      <dpadleft>StepBack</dpadleft>
+      <dpadright>StepForward</dpadright>
+      <dpadup>SkipNext</dpadup>
+      <dpaddown>SkipPrevious</dpaddown>
     </gamepad>
   </Visualisation>
   <MusicOSD>

--- a/system/keymaps/joystick.Harmony.xml
+++ b/system/keymaps/joystick.Harmony.xml
@@ -203,8 +203,8 @@
     <joystick name="Harmony">
       <!-- up       	-->      <button id="1">IncreaseRating</button>
       <!-- minus      	-->      <button id="2">DecreaseRating</button>
-      <!-- left       	-->      <button id="3">PreviousPreset</button>
-      <!-- right      	-->      <button id="4">NextPreset</button>
+      <!-- left       	-->      <button id="3">StepBack</button>
+      <!-- right      	-->      <button id="4">StepForward</button>
       <!-- menu       	-->      <button id="6">OSD</button>
       <!-- Prev		-->      <button id="32">LockPreset</button>
       <!-- Info  	-->      <button id="31">Info</button>

--- a/system/keymaps/joystick.Logitech.RumblePad.2.xml
+++ b/system/keymaps/joystick.Logitech.RumblePad.2.xml
@@ -102,10 +102,10 @@
       <button id="6">FastForward</button>
       <button id="10">OSD</button>
 
-      <hat    id="1" position="left">SkipPrevious</hat>
-      <hat    id="1" position="right">SkipNext</hat>
-      <hat    id="1" position="up">NextPreset</hat>
-      <hat    id="1" position="left">PreviousPreset</hat>
+      <hat    id="1" position="left">StepBack</hat>
+      <hat    id="1" position="right">StepForward</hat>
+      <hat    id="1" position="up">SkipNext</hat>
+      <hat    id="1" position="down">SkipPrevious</hat>
     </joystick>
   </Visualisation>
 

--- a/system/keymaps/joystick.Microsoft.Xbox.360.Controller.xml
+++ b/system/keymaps/joystick.Microsoft.Xbox.360.Controller.xml
@@ -394,8 +394,8 @@
       <axis id="3" limit="-1">AnalogFastForward</axis>
       <hat id="1" position="up">SkipNext</hat>
       <hat id="1" position="down">SkipPrevious</hat>
-      <hat id="1" position="left">PreviousPreset</hat>
-      <hat id="1" position="right">NextPreset</hat>
+      <hat id="1" position="left">StepBack</hat>
+      <hat id="1" position="right">StepForward</hat>
     </joystick>
     <joystick family="Xbox 360 Controller (xpad)">
       <button id="1">Pause</button>

--- a/system/keymaps/joystick.PS3.Remote.Keyboard.xml
+++ b/system/keymaps/joystick.PS3.Remote.Keyboard.xml
@@ -72,8 +72,8 @@
       <button id="1">Info</button>
       <button id="2">Pause</button>
       <button id="3">Stop</button>
-      <hat    id="1" position="left">SkipPrevious</hat>
-      <hat    id="1" position="right">SkipNext</hat>
+      <hat    id="1" position="left">StepBack</hat>
+      <hat    id="1" position="right">StepForward</hat>
       <hat    id="1" position="up">IncreaseRating</hat>
       <hat    id="1" position="down">DecreaseRating</hat>
     </joystick>

--- a/system/keymaps/joystick.WiiRemote.xml
+++ b/system/keymaps/joystick.WiiRemote.xml
@@ -122,13 +122,13 @@
     <joystick name="WiiRemote">
       <button id="1">Pause</button>
       <button id="2">Stop</button>
-      <button id="3">SkipNext</button>
-      <button id="4">SkipPrevious</button>
+      <button id="3">StepForward</button>
+      <button id="4">StepBack</button>
       <button id="5">OSD</button>
       <button id="6">Info</button>
       <button id="8">ActivateWindow(music)</button>
-      <button id="10">IncreaseRating</button>
-      <button id="11">DecreaseRating</button>
+      <button id="10">SkipNext</button>
+      <button id="11">SkipPrevious</button>
     </joystick>
   </Visualisation>
   <MusicOSD>

--- a/system/keymaps/joystick.xml.sample
+++ b/system/keymaps/joystick.xml.sample
@@ -178,8 +178,8 @@
       <axis id="3" limit="-1">AnalogFastForward</axis>
       <hat id="1" position="up">SkipNext</hat>
       <hat id="1" position="down">SkipPrevious</hat>
-      <hat id="1" position="left">PreviousPreset</hat>
-      <hat id="1" position="right">NextPreset</hat>
+      <hat id="1" position="left">StepBack</hat>
+      <hat id="1" position="right">StepForward</hat>
     </joystick>
   </Visualisation>
   <MusicOSD>

--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -311,10 +311,10 @@
       <p>ActivateWindow(VisualisationPresetList)</p>
       <v>ActivateWindow(VisualisationSettings)</v>
       <n>ActivateWindow(MusicPlaylist)</n>
-      <left>SkipPrevious</left>
-      <right>SkipNext</right>
-      <up>IncreaseRating</up>
-      <down>DecreaseRating</down>      <!--<back>NextPreset</back>!-->
+      <left>StepBack</left>
+      <right>StepForward</right>
+      <up>SkipNext</up>
+      <down>SkipPrevious</down>
       <o>CodecInfo</o>
       <l>LockPreset</l>
       <escape>FullScreen</escape>

--- a/system/keymaps/remote.xml
+++ b/system/keymaps/remote.xml
@@ -226,10 +226,10 @@
   </PlayerControls>
   <Visualisation>
     <remote>
-      <left>PreviousPreset</left>
-      <right>NextPreset</right>
-      <up>IncreaseRating</up>
-      <down>DecreaseRating</down>
+      <left>StepBack</left>
+      <right>StepForward</right>
+      <up>SkipNext</up>
+      <down>SkipPrevious</down>
       <back>Back</back>
       <title>CodecInfo</title>
       <select>ActivateWindow(VisualisationPresetList)</select>

--- a/system/keymaps/touchscreen.xml
+++ b/system/keymaps/touchscreen.xml
@@ -22,6 +22,14 @@
       <swipe direction="left" pointers="2">SmallStepBack</swipe>
     </touch>
   </FullScreenVideo>
+  <Visualisation>
+    <touch>
+      <swipe direction="left">StepBack</swipe>
+      <swipe direction="right">StepForward</swipe>
+      <swipe direction="up">SkipNext</swipe>
+      <swipe direction="down">SkipPrevious</swipe>
+    </touch>
+  </Visualisation>
   <SlideShow>
     <touch>
       <zoom>ZoomGesture</zoom>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1578,6 +1578,32 @@
         </setting>
       </group>
       <group id="2">
+        <setting id="musicplayer.seeksteps" type="list[integer]" label="13556" help="37042">
+          <level>2</level>
+          <default>-60,-30,-15,-7,7,15,30,60</default>
+          <constraints>
+            <options>videoseeksteps</options>
+            <delimiter>,</delimiter>
+            <minimumItems>2</minimumItems>
+          </constraints>
+          <control type="list" format="string">
+            <multiselect>true</multiselect>
+          </control>
+        </setting>
+        <setting id="musicplayer.seekdelay" type="integer" label="13557" help="37043">
+          <level>2</level>
+          <default>1000</default>
+          <constraints>
+            <minimum label="231">0</minimum> <!-- None -->
+            <step>250</step>
+            <maximum>3000</maximum>
+          </constraints>
+          <control type="spinner" format="string">
+            <formatlabel>14046</formatlabel>
+          </control>
+        </setting>
+      </group>
+      <group id="3">
         <setting id="musicplayer.replaygaintype" type="integer" label="638" help="36267">
           <level>2</level>
           <default>1</default> <!-- REPLAY_GAIN_ALBUM -->
@@ -1629,7 +1655,7 @@
           </dependencies>
         </setting>
       </group>
-      <group id="3">
+      <group id="4">
         <setting id="musicplayer.crossfade" type="integer" label="13314" help="36271">
           <level>1</level>
           <default>0</default>
@@ -1651,7 +1677,7 @@
           <control type="toggle" />
         </setting>
       </group>
-      <group id="4">
+      <group id="5">
         <setting id="musicplayer.visualisation" type="addon" label="250" help="36273">
           <level>0</level>
           <default>visualization.glspectrum</default>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -416,7 +416,7 @@
           <level>2</level>
           <default>1000</default>
           <constraints>
-            <minimum>500</minimum>
+            <minimum label="231">0</minimum> <!-- None -->
             <step>250</step>
             <maximum>3000</maximum>
           </constraints>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -414,7 +414,7 @@
         </setting>
         <setting id="videoplayer.seekdelay" type="integer" label="13557" help="37043">
           <level>2</level>
-          <default>1000</default>
+          <default>750</default>
           <constraints>
             <minimum label="231">0</minimum> <!-- None -->
             <step>250</step>
@@ -1592,7 +1592,7 @@
         </setting>
         <setting id="musicplayer.seekdelay" type="integer" label="13557" help="37043">
           <level>2</level>
-          <default>1000</default>
+          <default>750</default>
           <constraints>
             <minimum label="231">0</minimum> <!-- None -->
             <step>250</step>

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -296,7 +296,6 @@ CApplication::CApplication(void)
   , m_progressTrackingItem(new CFileItem)
   , m_videoInfoScanner(new CVideoInfoScanner)
   , m_musicInfoScanner(new CMusicInfoScanner)
-  , m_seekHandler(&CSeekHandler::Get())
   , m_playerController(new CPlayerController)
 {
   m_network = NULL;
@@ -2721,7 +2720,7 @@ void CApplication::FrameMove(bool processEvents, bool processGUI)
     if (processGUI && m_renderGUI)
     {
       m_pInertialScrollingHandler->ProcessInertialScroll(frameTime);
-      m_seekHandler->Process();
+      CSeekHandler::Get().Process();
     }
   }
   if (processGUI && m_renderGUI)
@@ -4141,7 +4140,7 @@ bool CApplication::OnMessage(CGUIMessage& message)
       CDarwinUtils::SetScheduling(message.GetMessage());
 #endif
       // reset the seek handler
-      m_seekHandler->Reset();
+      CSeekHandler::Get().Reset();
       CPlayList playList = g_playlistPlayer.GetPlaylist(g_playlistPlayer.GetCurrentPlaylist());
 
       // Update our infoManager with the new details etc.

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2662,13 +2662,6 @@ bool CApplication::OnAction(const CAction &action)
     ShowVolumeBar(&action);
     return true;
   }
-  // Check for global seek control
-  if (m_pPlayer->IsPlaying() && action.GetAmount() && (action.GetID() == ACTION_ANALOG_SEEK_FORWARD || action.GetID() == ACTION_ANALOG_SEEK_BACK))
-  {
-    if (!m_pPlayer->CanSeek()) return false;
-    m_seekHandler->Seek(action.GetID() == ACTION_ANALOG_SEEK_FORWARD, action.GetAmount(), action.GetRepeat(), true);
-    return true;
-  }
   if (action.GetID() == ACTION_GUIPROFILE_BEGIN)
   {
     CGUIControlProfiler::Instance().SetOutputFile(CSpecialProtocol::TranslatePath("special://home/guiprofiler.xml"));

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1305,6 +1305,9 @@ bool CApplication::Initialize()
 
   CAddonMgr::Get().StartServices(true);
 
+  // register action listeners
+  RegisterActionListener(&CSeekHandler::Get());
+
   CLog::Log(LOGNOTICE, "initialize done");
 
   m_bInitializing = false;
@@ -2921,6 +2924,9 @@ void CApplication::Stop(int exitCode)
 
     // Stop services before unloading Python
     CAddonMgr::Get().StopServices(false);
+
+    // unregister action listeners
+    UnregisterActionListener(&CSeekHandler::Get());
 
     // stop all remaining scripts; must be done after skin has been unloaded,
     // not before some windows still need it when deinitializing during skin

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -368,12 +368,6 @@ public:
 
   float GetDimScreenSaverLevel() const;
 
-  /*! \brief Retrieve the applications seek handler.
-   \return a constant pointer to the seek handler.
-   \sa CSeekHandler
-   */
-  CSeekHandler* const GetSeekHandler() const { return m_seekHandler; };
-
   bool SwitchToFullScreen();
 
   CSplash* GetSplash() { return m_splash; }
@@ -502,7 +496,6 @@ protected:
   bool InitDirectoriesWin32();
   void CreateUserDirs();
 
-  CSeekHandler *m_seekHandler;
   CPlayerController *m_playerController;
   CInertialScrollingHandler *m_pInertialScrollingHandler;
   CNetwork    *m_network;

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -2119,7 +2119,7 @@ bool CGUIInfoManager::GetInt(int &value, int info, int contextWindow, const CGUI
             value = (int)(g_application.GetCachePercentage());
             break;
           case PLAYER_SEEKBAR:
-            value = (int)g_application.GetSeekHandler()->GetPercent();
+            value = (int)CSeekHandler::Get().GetPercent();
             break;
           case PLAYER_CACHELEVEL:
             value = (int)(g_application.m_pPlayer->GetCacheLevel());
@@ -4032,7 +4032,7 @@ std::string CGUIInfoManager::GetCurrentSeekTime(TIME_FORMAT format) const
 {
   if (format == TIME_FORMAT_GUESS && GetTotalPlayTime() >= 3600)
     format = TIME_FORMAT_HH_MM_SS;
-  float time = GetTotalPlayTime() * g_application.GetSeekHandler()->GetPercent() * 0.01f;
+  float time = GetTotalPlayTime() * CSeekHandler::Get().GetPercent() * 0.01f;
   return StringUtils::SecondsToTimeString((int)time, format);
 }
 

--- a/xbmc/dialogs/GUIDialogSeekBar.cpp
+++ b/xbmc/dialogs/GUIDialogSeekBar.cpp
@@ -68,7 +68,7 @@ void CGUIDialogSeekBar::FrameMove()
   }
 
   // update controls
-  if (!g_application.GetSeekHandler()->InProgress() && !g_infoManager.m_performingSeek
+  if (!CSeekHandler::Get().InProgress() && !g_infoManager.m_performingSeek
     && g_infoManager.GetTotalPlayTime())
   { // position the bar at our current time
     CONTROL_SELECT_ITEM(POPUP_SEEK_PROGRESS, (unsigned int)(g_infoManager.GetPlayTime()/g_infoManager.GetTotalPlayTime() * 0.1f));
@@ -76,7 +76,7 @@ void CGUIDialogSeekBar::FrameMove()
   }
   else
   {
-    CONTROL_SELECT_ITEM(POPUP_SEEK_PROGRESS, (unsigned int)g_application.GetSeekHandler()->GetPercent());
+    CONTROL_SELECT_ITEM(POPUP_SEEK_PROGRESS, (unsigned int)CSeekHandler::Get().GetPercent());
     SET_CONTROL_LABEL(POPUP_SEEK_LABEL, g_infoManager.GetCurrentSeekTime());
   }
 

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -131,9 +131,6 @@ void CAdvancedSettings::Initialize()
 
   m_videoSubsDelayRange = 60;
   m_videoAudioDelayRange = 10;
-  m_videoSmallStepBackSeconds = 7;
-  m_videoSmallStepBackTries = 3;
-  m_videoSmallStepBackDelay = 300;
   m_videoUseTimeSeeking = true;
   m_videoTimeSeekForward = 30;
   m_videoTimeSeekBackward = -30;
@@ -562,10 +559,6 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetFloat(pElement, "playcountminimumpercent", m_videoPlayCountMinimumPercent, 0.0f, 101.0f);
     XMLUtils::GetInt(pElement, "ignoresecondsatstart", m_videoIgnoreSecondsAtStart, 0, 900);
     XMLUtils::GetFloat(pElement, "ignorepercentatend", m_videoIgnorePercentAtEnd, 0, 100.0f);
-
-    XMLUtils::GetInt(pElement, "smallstepbackseconds", m_videoSmallStepBackSeconds, 1, INT_MAX);
-    XMLUtils::GetInt(pElement, "smallstepbacktries", m_videoSmallStepBackTries, 1, 10);
-    XMLUtils::GetInt(pElement, "smallstepbackdelay", m_videoSmallStepBackDelay, 100, 5000); //MS
 
     XMLUtils::GetBoolean(pElement, "usetimeseeking", m_videoUseTimeSeeking);
     XMLUtils::GetInt(pElement, "timeseekforward", m_videoTimeSeekForward, 0, 6000);

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -115,6 +115,8 @@ void CAdvancedSettings::Initialize()
   m_limiterHold = 0.025f;
   m_limiterRelease = 0.1f;
 
+  m_seekSteps = { 7, 15, 30, 60, 180, 300, 600, 900, 1800 };
+
   m_omxHWAudioDecode = false;
   m_omxDecodeStartWithValidFrame = false;
 
@@ -140,18 +142,7 @@ void CAdvancedSettings::Initialize()
   m_videoPercentSeekBackward = -2;
   m_videoPercentSeekForwardBig = 10;
   m_videoPercentSeekBackwardBig = -10;
-  
-  m_videoSeekSteps.clear();
-  m_videoSeekSteps.push_back(7);
-  m_videoSeekSteps.push_back(15);
-  m_videoSeekSteps.push_back(30);
-  m_videoSeekSteps.push_back(60);
-  m_videoSeekSteps.push_back(180);
-  m_videoSeekSteps.push_back(300);
-  m_videoSeekSteps.push_back(600);
-  m_videoSeekSteps.push_back(900);
-  m_videoSeekSteps.push_back(1800);
-  
+
   m_videoBlackBarColour = 0;
   m_videoPPFFmpegDeint = "linblenddeint";
   m_videoPPFFmpegPostProc = "ha:128:7,va,dr";
@@ -565,16 +556,6 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetInt(pElement, "timeseekbackward", m_videoTimeSeekBackward, -6000, 0);
     XMLUtils::GetInt(pElement, "timeseekforwardbig", m_videoTimeSeekForwardBig, 0, 6000);
     XMLUtils::GetInt(pElement, "timeseekbackwardbig", m_videoTimeSeekBackwardBig, -6000, 0);
-    
-    std::string seekSteps;
-    XMLUtils::GetString(pRootElement, "seeksteps", seekSteps);
-    if (!seekSteps.empty())
-    {
-      m_videoSeekSteps.clear();
-      std::vector<string> steps = StringUtils::Split(seekSteps, ',');
-      for(std::vector<string>::iterator it = steps.begin(); it != steps.end(); ++it)
-        m_videoSeekSteps.push_back(atoi((*it).c_str()));
-    }
 
     XMLUtils::GetInt(pElement, "percentseekforward", m_videoPercentSeekForward, 0, 100);
     XMLUtils::GetInt(pElement, "percentseekbackward", m_videoPercentSeekBackward, -100, 0);
@@ -1191,6 +1172,16 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetBoolean(pElement, "visualizedirtyregions", m_guiVisualizeDirtyRegions);
     XMLUtils::GetInt(pElement, "algorithmdirtyregions",     m_guiAlgorithmDirtyRegions);
     XMLUtils::GetInt(pElement, "nofliptimeout",             m_guiDirtyRegionNoFlipTimeout);
+  }
+
+  std::string seekSteps;
+  XMLUtils::GetString(pRootElement, "seeksteps", seekSteps);
+  if (!seekSteps.empty())
+  {
+    m_seekSteps.clear();
+    std::vector<string> steps = StringUtils::Split(seekSteps, ',');
+    for(std::vector<string>::iterator it = steps.begin(); it != steps.end(); ++it)
+      m_seekSteps.push_back(atoi((*it).c_str()));
   }
 
   // load in the settings overrides

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -149,9 +149,6 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
 
     float m_videoSubsDelayRange;
     float m_videoAudioDelayRange;
-    int m_videoSmallStepBackSeconds;
-    int m_videoSmallStepBackTries;
-    int m_videoSmallStepBackDelay;
     bool m_videoUseTimeSeeking;
     int m_videoTimeSeekForward;
     int m_videoTimeSeekBackward;

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -158,7 +158,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     int m_videoPercentSeekBackward;
     int m_videoPercentSeekForwardBig;
     int m_videoPercentSeekBackwardBig;
-    std::vector<int> m_videoSeekSteps;
+    std::vector<int> m_seekSteps;
     std::string m_videoPPFFmpegDeint;
     std::string m_videoPPFFmpegPostProc;
     bool m_videoVDPAUtelecine;

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -691,6 +691,8 @@ void CSettings::InitializeISettingCallbacks()
   settingSet.clear();
   settingSet.insert("videoplayer.seekdelay");
   settingSet.insert("videoplayer.seeksteps");
+  settingSet.insert("musicplayer.seekdelay");
+  settingSet.insert("musicplayer.seeksteps");
   m_settingsManager->RegisterCallback(&CSeekHandler::Get(), settingSet);
 
   settingSet.clear();

--- a/xbmc/utils/SeekHandler.cpp
+++ b/xbmc/utils/SeekHandler.cpp
@@ -219,6 +219,7 @@ bool CSeekHandler::OnAction(const CAction &action)
 
   switch (action.GetID())
   {
+    case ACTION_SMALL_STEP_BACK:
     case ACTION_STEP_BACK:
     {
       Seek(false, action.GetAmount(), action.GetRepeat());
@@ -251,14 +252,6 @@ bool CSeekHandler::OnAction(const CAction &action)
     {
       if (g_application.m_pPlayer->SeekScene(false))
         g_infoManager.SetDisplayAfterSeek();
-      return true;
-    }
-    case ACTION_SMALL_STEP_BACK:
-    {
-      int orgpos = (int)g_application.GetTime();
-      int jumpsize = g_advancedSettings.m_videoSmallStepBackSeconds; // secs
-      int setpos = (orgpos > jumpsize) ? orgpos - jumpsize : 0;
-      g_application.SeekTime((double)setpos);
       return true;
     }
     case ACTION_ANALOG_SEEK_FORWARD:

--- a/xbmc/utils/SeekHandler.cpp
+++ b/xbmc/utils/SeekHandler.cpp
@@ -108,14 +108,6 @@ void CSeekHandler::Seek(bool forward, float amount, float duration /* = 0 */, bo
     g_infoManager.SetSeeking(true);
     m_seekStep = 0;
     m_analogSeek = analogSeek;
-
-    if (!analogSeek)
-    {
-      // don't apply a seek delay if only one seek step for the given direction exists
-      if ((m_backwardSeekSteps.size() == 1 && forward == false) ||
-          (m_forwardSeekSteps.size() == 1 && forward == true))
-        m_seekDelay = 0;
-    }
   }
 
   // calculate our seek amount

--- a/xbmc/utils/SeekHandler.cpp
+++ b/xbmc/utils/SeekHandler.cpp
@@ -261,6 +261,13 @@ bool CSeekHandler::OnAction(const CAction &action)
       g_application.SeekTime((double)setpos);
       return true;
     }
+    case ACTION_ANALOG_SEEK_FORWARD:
+    case ACTION_ANALOG_SEEK_BACK:
+    {
+      if (action.GetAmount())
+        Seek(action.GetID() == ACTION_ANALOG_SEEK_FORWARD, action.GetAmount(), action.GetRepeat(), true);
+      return true;
+    }
     default:
       break;
   }

--- a/xbmc/utils/SeekHandler.cpp
+++ b/xbmc/utils/SeekHandler.cpp
@@ -133,7 +133,7 @@ void CSeekHandler::Seek(bool forward, float amount, float duration /* = 0 */, bo
     g_infoManager.SetSeeking(true);
     m_seekStep = 0;
     m_analogSeek = analogSeek;
-    m_seekDelay = m_seekDelays.at(type);
+    m_seekDelay = analogSeek ? analogSeekDelay : m_seekDelays.at(type);
   }
 
   // calculate our seek amount

--- a/xbmc/utils/SeekHandler.cpp
+++ b/xbmc/utils/SeekHandler.cpp
@@ -211,3 +211,59 @@ void CSeekHandler::OnSettingChanged(const CSetting *setting)
       setting->GetId() == "videoplayer.seeksteps")
     Reset();
 }
+
+bool CSeekHandler::OnAction(const CAction &action)
+{
+  if (!g_application.m_pPlayer->IsPlaying() || !g_application.m_pPlayer->CanSeek())
+    return false;
+
+  switch (action.GetID())
+  {
+    case ACTION_STEP_BACK:
+    {
+      Seek(false, action.GetAmount(), action.GetRepeat());
+      return true;
+    }
+    case ACTION_STEP_FORWARD:
+    {
+      Seek(true, action.GetAmount(), action.GetRepeat());
+      return true;
+    }
+    case ACTION_BIG_STEP_BACK:
+    case ACTION_CHAPTER_OR_BIG_STEP_BACK:
+    {
+      g_application.m_pPlayer->Seek(false, true, action.GetID() == ACTION_CHAPTER_OR_BIG_STEP_BACK);
+      return true;
+    }
+    case ACTION_BIG_STEP_FORWARD:
+    case ACTION_CHAPTER_OR_BIG_STEP_FORWARD:
+    {
+      g_application.m_pPlayer->Seek(true, true, action.GetID() == ACTION_CHAPTER_OR_BIG_STEP_FORWARD);
+      return true;
+    }
+    case ACTION_NEXT_SCENE:
+    {
+      if (g_application.m_pPlayer->SeekScene(true))
+        g_infoManager.SetDisplayAfterSeek();
+      return true;
+    }
+    case ACTION_PREV_SCENE:
+    {
+      if (g_application.m_pPlayer->SeekScene(false))
+        g_infoManager.SetDisplayAfterSeek();
+      return true;
+    }
+    case ACTION_SMALL_STEP_BACK:
+    {
+      int orgpos = (int)g_application.GetTime();
+      int jumpsize = g_advancedSettings.m_videoSmallStepBackSeconds; // secs
+      int setpos = (orgpos > jumpsize) ? orgpos - jumpsize : 0;
+      g_application.SeekTime((double)setpos);
+      return true;
+    }
+    default:
+      break;
+  }
+
+  return false;
+}

--- a/xbmc/utils/SeekHandler.cpp
+++ b/xbmc/utils/SeekHandler.cpp
@@ -184,24 +184,19 @@ bool CSeekHandler::InProgress() const
 
 void CSeekHandler::Process()
 {
-  if (m_timer.GetElapsedMilliseconds() > m_seekDelay)
+  if (m_timer.GetElapsedMilliseconds() > m_seekDelay && m_requireSeek)
   {
-    if (!g_infoManager.m_performingSeek && m_timer.GetElapsedMilliseconds() > time_for_display) // TODO: Why?
-      g_infoManager.SetSeeking(false);
+    g_infoManager.m_performingSeek = true;
 
-    if (m_requireSeek)
-    {
-      g_infoManager.m_performingSeek = true;
+    // reset seek step size
+    g_infoManager.SetSeekStepSize(0);
 
-      // reset seek step size
-      g_infoManager.SetSeekStepSize(0);
+    // calculate the seek time
+    double time = g_infoManager.GetTotalPlayTime() * m_percent * 0.01;
 
-      // calculate the seek time
-      double time = g_infoManager.GetTotalPlayTime() * m_percent * 0.01;
-
-      g_application.SeekTime(time);
-      m_requireSeek = false;
-    }
+    g_application.SeekTime(time);
+    m_requireSeek = false;
+    g_infoManager.SetSeeking(false);
   }
 }
 

--- a/xbmc/utils/SeekHandler.h
+++ b/xbmc/utils/SeekHandler.h
@@ -57,6 +57,8 @@ protected:
 
 private:
   static const int time_for_display = 2000; // TODO: WTF?
+  static const int analogSeekDelay = 500;
+  
   int        GetSeekSeconds(bool forward, SeekType type);
   int        m_seekDelay;
   std::map<SeekType, int > m_seekDelays;

--- a/xbmc/utils/SeekHandler.h
+++ b/xbmc/utils/SeekHandler.h
@@ -56,7 +56,6 @@ protected:
   virtual ~CSeekHandler();
 
 private:
-  static const int time_for_display = 2000; // TODO: WTF?
   static const int analogSeekDelay = 500;
   
   int        GetSeekSeconds(bool forward, SeekType type);

--- a/xbmc/utils/SeekHandler.h
+++ b/xbmc/utils/SeekHandler.h
@@ -20,11 +20,13 @@
  */
 
 #include <vector>
+#include "guilib/Key.h"
+#include "interfaces/IActionListener.h"
 #include "settings/Settings.h"
 #include "settings/lib/ISettingCallback.h"
 #include "utils/Stopwatch.h"
 
-class CSeekHandler : public ISettingCallback
+class CSeekHandler : public ISettingCallback, public IActionListener
 {
 public:
   static CSeekHandler& Get();
@@ -32,6 +34,7 @@ public:
   static void SettingOptionsSeekStepsFiller(const CSetting *setting, std::vector< std::pair<std::string, int> > &list, int &current, void *data);
   
   virtual void OnSettingChanged(const CSetting *setting);
+  virtual bool OnAction(const CAction &action);
 
   void Seek(bool forward, float amount, float duration = 0, bool analogSeek = false);
   void Process();

--- a/xbmc/utils/SeekHandler.h
+++ b/xbmc/utils/SeekHandler.h
@@ -26,6 +26,12 @@
 #include "settings/lib/ISettingCallback.h"
 #include "utils/Stopwatch.h"
 
+enum SeekType
+{
+  SEEK_TYPE_VIDEO = 0,
+  SEEK_TYPE_MUSIC = 1
+};
+
 class CSeekHandler : public ISettingCallback, public IActionListener
 {
 public:
@@ -36,7 +42,7 @@ public:
   virtual void OnSettingChanged(const CSetting *setting);
   virtual bool OnAction(const CAction &action);
 
-  void Seek(bool forward, float amount, float duration = 0, bool analogSeek = false);
+  void Seek(bool forward, float amount, float duration = 0, bool analogSeek = false, SeekType type = SEEK_TYPE_VIDEO);
   void Process();
   void Reset();
 
@@ -51,14 +57,15 @@ protected:
 
 private:
   static const int time_for_display = 2000; // TODO: WTF?
-  int        GetSeekSeconds(bool forward);
+  int        GetSeekSeconds(bool forward, SeekType type);
   int        m_seekDelay;
+  std::map<SeekType, int > m_seekDelays;
   bool       m_requireSeek;
   float      m_percent;
   float      m_percentPlayTime;
   bool       m_analogSeek;
   int        m_seekStep;
-  std::vector<int> m_forwardSeekSteps;
-  std::vector<int> m_backwardSeekSteps;
+  std::map<SeekType, std::vector<int> > m_forwardSeekSteps;
+  std::map<SeekType, std::vector<int> > m_backwardSeekSteps;
   CStopWatch m_timer;
 };

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -157,46 +157,24 @@ bool CGUIWindowFullScreen::OnAction(const CAction &action)
     }
     break;
 
+  case ACTION_SMALL_STEP_BACK:
   case ACTION_STEP_BACK:
-    if (m_timeCodePosition > 0)
-      SeekToTimeCodeStamp(SEEK_RELATIVE, SEEK_BACKWARD);
-    else
-      g_application.GetSeekHandler()->Seek(false, action.GetAmount(), action.GetRepeat());
-    return true;
-
-  case ACTION_STEP_FORWARD:
-    if (m_timeCodePosition > 0)
-      SeekToTimeCodeStamp(SEEK_RELATIVE, SEEK_FORWARD);
-    else
-      g_application.GetSeekHandler()->Seek(true, action.GetAmount(), action.GetRepeat());
-    return true;
-
   case ACTION_BIG_STEP_BACK:
   case ACTION_CHAPTER_OR_BIG_STEP_BACK:
     if (m_timeCodePosition > 0)
+    {
       SeekToTimeCodeStamp(SEEK_RELATIVE, SEEK_BACKWARD);
-    else
-      g_application.m_pPlayer->Seek(false, true, action.GetID() == ACTION_CHAPTER_OR_BIG_STEP_BACK);
-    return true;
-
+      return true;
+    }
+    break;
+  case ACTION_STEP_FORWARD:
   case ACTION_BIG_STEP_FORWARD:
   case ACTION_CHAPTER_OR_BIG_STEP_FORWARD:
     if (m_timeCodePosition > 0)
+    {
       SeekToTimeCodeStamp(SEEK_RELATIVE, SEEK_FORWARD);
-    else
-      g_application.m_pPlayer->Seek(true, true, action.GetID() == ACTION_CHAPTER_OR_BIG_STEP_FORWARD);
-    return true;
-
-  case ACTION_NEXT_SCENE:
-    if (g_application.m_pPlayer->SeekScene(true))
-      g_infoManager.SetDisplayAfterSeek();
-    return true;
-    break;
-
-  case ACTION_PREV_SCENE:
-    if (g_application.m_pPlayer->SeekScene(false))
-      g_infoManager.SetDisplayAfterSeek();
-    return true;
+      return true;
+    }
     break;
 
   case ACTION_SHOW_OSD_TIME:
@@ -248,18 +226,6 @@ bool CGUIWindowFullScreen::OnAction(const CAction &action)
       }
       m_bShowViewModeInfo = true;
       m_dwShowViewModeTimeout = XbmcThreads::SystemClockMillis();
-    }
-    return true;
-    break;
-  case ACTION_SMALL_STEP_BACK:
-    if (m_timeCodePosition > 0)
-      SeekToTimeCodeStamp(SEEK_RELATIVE, SEEK_BACKWARD);
-    else
-    {
-      int orgpos = (int)g_application.GetTime();
-      int jumpsize = g_advancedSettings.m_videoSmallStepBackSeconds; // secs
-      int setpos = (orgpos > jumpsize) ? orgpos - jumpsize : 0;
-      g_application.SeekTime((double)setpos);
     }
     return true;
     break;


### PR DESCRIPTION
This PR does the following:
- refactor seek handling out of CGUIWindowFullScreen + CApplication and put it in CSeekHandler (done with the action listener pattern)
- drop the AS to configure small step back and forward it to our new smart seeking
- unify seek/skip keys for FullscreenVideo and Visualisation in most of our keymaps
- extends the delay setting to be turned off and drop the validation if only one seek step is enabled to turn off the delay
- adds the seek settings (delay, steps) also to music and differ between in SeekHandler depending on the content (video/audio)

@da-anda @mkortstiege it would be nice if you might take a look.
