### PR TITLE
[configure.in] use pkgconfig to detect curl and force the distros to use...

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -1065,7 +1065,7 @@ AC_CHECK_HEADER([ogg/ogg.h],,        AC_MSG_ERROR($missing_library))
 AC_CHECK_HEADER([vorbis/vorbisfile.h],, AC_MSG_ERROR($missing_library))
 AC_CHECK_HEADER([libmodplug/modplug.h],, AC_MSG_ERROR($missing_library))
 
-AC_CHECK_HEADER([curl/curl.h],, AC_MSG_ERROR($missing_library))
+PKG_CHECK_MODULES([LIBCURL], [libcurl],, AC_MSG_ERROR([libcurl not found]))
 XB_FIND_SONAME([CURL], [curl])
 AC_MSG_CHECKING([for CRYPTO_set_locking_callback(0) in $CURL_SONAME])
 if test "$host_vendor" = "apple" ; then


### PR DESCRIPTION
... what ubuntu is using, this workarounds a issue with ftp thumbs, see also
https://github.com/xbmc/xbmc/pull/6376
https://github.com/OpenELEC/OpenELEC.tv/issues/3866
https://github.com/OpenELEC/OpenELEC.tv/pull/3905/

this should be added to Helix too
