### PR TITLE
[tests] - move atomics tests from shared_ptr of thread array to vector o...

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -718,14 +718,14 @@ testframework: $(GTEST_LIBS)
 $(GTEST_LIBS): $(GTEST_DIR)/Makefile
 
 $(GTEST_DIR)/Makefile: force
-	$(MAKE) -C $(GTEST_DIR)
+	$(MAKE) CXXFLAGS="$(CXXFLAGS) -DGTEST_USE_OWN_TR1_TUPLE=1" -C $(GTEST_DIR)
 
 $(CHECK_LIBS): force
-	@$(MAKE) $(if $(V),,-s) -C $(@D)
+	@$(MAKE) CXXFLAGS="$(CXXFLAGS) -DGTEST_USE_OWN_TR1_TUPLE=1" $(if $(V),,-s) -C $(@D)
 
 @APP_NAME_LC@-test: $(CHECK_LIBS) $(OBJSXBMC) $(DYNOBJSXBMC) $(NWAOBJSXBMC) $(GTEST_LIBS)
 ifeq ($(findstring osx,@ARCH@), osx)
-	$(SILENT_LD) $(CXX) $(LDFLAGS) $(GTEST_INCLUDES) -o $@ -Wl,-all_load,-ObjC $(DYNOBJSXBMC) $(NWAOBJSXBMC) $(OBJSXBMC) $(GTEST_LIBS) $(CHECK_LIBS) $(LIBS) $(CHECK_LIBADD) -rdynamic
+	$(SILENT_LD) $(CXX) $(CXXFLAGS) $(LDFLAGS) $(GTEST_INCLUDES) -o $@ -Wl,-all_load,-ObjC $(DYNOBJSXBMC) $(NWAOBJSXBMC) $(OBJSXBMC) $(GTEST_LIBS) $(CHECK_LIBS) $(LIBS) $(CHECK_LIBADD) -rdynamic
 else
 	$(SILENT_LD) $(CXX) $(CXXFLAGS) $(LDFLAGS) $(GTEST_INCLUDES) -o $@ -Wl,--whole-archive $(DYNOBJSXBMC) $(OBJSXBMC) $(GTEST_LIBS) $(CHECK_LIBS) -Wl,--no-whole-archive $(NWAOBJSXBMC) $(LIBS) $(CHECK_LIBADD) -rdynamic
 endif

--- a/Makefile.include.in
+++ b/Makefile.include.in
@@ -119,7 +119,7 @@ GEN_DEPS=\
 
 %.o: %.m
 	@rm -f $@
-	$(SILENT_MM) $(CXX) -MF $*.d -MD -c $(CXXFLAGS) $(DEFINES) $(INCLUDES) $< -o $@ \
+	$(SILENT_MM) $(CC) -MF $*.d -MD -c $(CFLAGS) $(DEFINES) $(INCLUDES) $< -o $@ \
 	&& $(GEN_DEPS)
 
 %.o: %.mm

--- a/configure.in
+++ b/configure.in
@@ -2854,6 +2854,7 @@ XB_CONFIG_MODULE([lib/gtest], [
     CC="$CC" \
     CXX="$CXX" \
     CFLAGS="$CFLAGS" \
+    CXXFLAGS="$CXXFLAGS" \
     --prefix="${prefix}" --includedir="${includedir}" --libdir="${libdir}" --datadir="${datadir}" \
     --host=$host_alias \
     --build=$build_alias \

--- a/xbmc/cores/AudioEngine/Utils/AEELDParser.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEELDParser.cpp
@@ -23,6 +23,7 @@
 #include "utils/EndianSwap.h"
 #include <string.h>
 #include <algorithm>
+#include <functional>
 
 #include <stdio.h>
 

--- a/xbmc/network/test/TestWebServer.cpp
+++ b/xbmc/network/test/TestWebServer.cpp
@@ -19,9 +19,9 @@
  */
 
 #include <errno.h>
+#include <stdlib.h>
 
 #include <gtest/gtest.h>
-
 #include "system.h"
 #include "URL.h"
 #include "filesystem/CurlFile.h"

--- a/xbmc/threads/test/TestAtomics.cpp
+++ b/xbmc/threads/test/TestAtomics.cpp
@@ -85,14 +85,14 @@ public:
 TEST(TestMassAtomic, Increment)
 {
   long lNumber = 0;
-  std::shared_ptr<thread> t;
-  t.reset(new thread[NUMTHREADS], std::default_delete<thread[]>());
   DoIncrement di(&lNumber);
-  for(size_t i=0; i<NUMTHREADS; i++)
-    t[i] = thread(di);
+
+  std::vector<std::shared_ptr<thread>> t(NUMTHREADS);
+  for (size_t i=0;i<NUMTHREADS;++i)
+    t[i].reset(new thread(di));
 
   for(size_t i=0; i<NUMTHREADS; i++)
-    t[i].join();
+    t[i]->join();
 
   EXPECT_EQ((NUMTHREADS * TESTNUM), lNumber);
  }
@@ -100,14 +100,14 @@ TEST(TestMassAtomic, Increment)
 TEST(TestMassAtomic, Decrement)
 {
   long lNumber = (NUMTHREADS * TESTNUM);
-  std::shared_ptr<thread> t;
-  t.reset(new thread[NUMTHREADS], std::default_delete<thread[]>());
   DoDecrement dd(&lNumber);
-  for(size_t i=0; i<NUMTHREADS; i++)
-    t[i] = thread(dd);
+
+  std::vector<std::shared_ptr<thread>> t(NUMTHREADS);
+  for (size_t i=0;i<NUMTHREADS;++i)
+    t[i].reset(new thread(dd));
 
   for(size_t i=0; i<NUMTHREADS; i++)
-    t[i].join();
+    t[i]->join();
 
   EXPECT_EQ(0, lNumber);
  }
@@ -116,14 +116,14 @@ TEST(TestMassAtomic, Add)
 {
   long lNumber = 0;
   long toAdd = 10;
-  std::shared_ptr<thread> t;
-  t.reset(new thread[NUMTHREADS], std::default_delete<thread[]>());
   DoAdd da(&lNumber,toAdd);
+
+  std::vector<std::shared_ptr<thread>> t(NUMTHREADS);
   for(size_t i=0; i<NUMTHREADS; i++)
-    t[i] = thread(da);
+    t[i].reset(new thread(da));
 
   for(size_t i=0; i<NUMTHREADS; i++)
-    t[i].join();
+    t[i]->join();
 
   EXPECT_EQ((NUMTHREADS * TESTNUM) * toAdd, lNumber);
  }
@@ -132,14 +132,14 @@ TEST(TestMassAtomic, Subtract)
 {
   long toSubtract = 10;
   long lNumber = (NUMTHREADS * TESTNUM) * toSubtract;
-  std::shared_ptr<thread> t;
-  t.reset(new thread[NUMTHREADS], std::default_delete<thread[]>());
   DoSubtract ds(&lNumber,toSubtract);
+
+  std::vector<std::shared_ptr<thread>> t(NUMTHREADS);
   for(size_t i=0; i<NUMTHREADS; i++)
-    t[i] = thread(ds);
+    t[i].reset(new thread(ds));
 
   for(size_t i=0; i<NUMTHREADS; i++)
-    t[i].join();
+    t[i]->join();
 
   EXPECT_EQ(0, lNumber);
  }

--- a/xbmc/utils/test/TestHttpHeader.cpp
+++ b/xbmc/utils/test/TestHttpHeader.cpp
@@ -479,7 +479,7 @@ TEST(TestHttpHeader, GetMimeType)
   EXPECT_STREQ(CHECK_CONTENT_TYPE_TEXT, testHdr.GetMimeType().c_str()) << "MIME-type was not overwritten by \"AddParam\"";
 
   /* Correct trimming */
-  testHdr.AddParam(CHECK_CNT_TYPE_NAME, "  "CHECK_CONTENT_TYPE_TEXT " \t ;foo=bar");
+  testHdr.AddParam(CHECK_CNT_TYPE_NAME, "  " CHECK_CONTENT_TYPE_TEXT " \t ;foo=bar");
   EXPECT_STREQ(CHECK_CONTENT_TYPE_TEXT, testHdr.GetMimeType().c_str()) << "MIME-type is not trimmed correctly";
 }
 

--- a/xbmc/utils/test/Testlog.cpp
+++ b/xbmc/utils/test/Testlog.cpp
@@ -18,6 +18,7 @@
  *
  */
 
+#include <stdlib.h>
 #include "utils/log.h"
 #include "utils/RegExp.h"
 #include "filesystem/File.h"


### PR DESCRIPTION
...f shared_ptr of thread - fixes tests broken by change to c++11 shared pointers for clang 3.5

once unit tests on jenkins are ok we can merge this:

http://jenkins.kodi.tv/view/Helpers/job/TestMulti-All/123/

thx @notspiff
