### PR TITLE
Fix AnnouncementManager::Announce().

### DIFF
--- a/xbmc/interfaces/AnnouncementManager.cpp
+++ b/xbmc/interfaces/AnnouncementManager.cpp
@@ -90,9 +90,13 @@ void CAnnouncementManager::Announce(AnnouncementFlag flag, const char *sender, c
 void CAnnouncementManager::Announce(AnnouncementFlag flag, const char *sender, const char *message, CVariant &data)
 {
   CLog::Log(LOGDEBUG, "CAnnouncementManager - Announcement: %s from %s", message, sender);
+
   CSingleLock lock (m_critSection);
-  for (unsigned int i = 0; i < m_announcers.size(); i++)
-    m_announcers[i]->Announce(flag, sender, message, data);
+
+  // Make a copy of announers. They may be removed or even remove themselves during execution of IAnnouncer::Announce()!
+  std::vector<IAnnouncer *> announcers(m_announcers); 
+  for (unsigned int i = 0; i < announcers.size(); i++)
+    announcers[i]->Announce(flag, sender, message, data);
 }
 
 void CAnnouncementManager::Announce(AnnouncementFlag flag, const char *sender, const char *message, CFileItemPtr item)


### PR DESCRIPTION
Fix AnnouncementManager::Announce(). Announcers may be removed while iterating announcers vector.

Examples: 
- https://github.com/xbmc/xbmc/blob/master/xbmc/peripherals/devices/PeripheralCecAdapter.cpp#L153
- https://github.com/xbmc/xbmc/blob/master/xbmc/peripherals/devices/PeripheralCecAdapter.cpp#L1661 (called from CPeripheralCecAdapter::Announce() => "OnWake")

Consequence is that not all announcers will be called. For instance, if an anonuncer not located at the end of the vector gets removed during iteration, the last announcer staying in the vector will not be called.
