### PR TITLE
fixes for a few coverity  issues

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Overlay/contrib/cc_decoder.c
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Overlay/contrib/cc_decoder.c
@@ -258,7 +258,7 @@ void ccmem_tobuf(cc_decoder_t *dec)
         if (buf->rows[i].cells[f].c != ' ')
           break;
       for (l = CC_COLUMNS-1; l>0; l--)
-        if (buf->rows[i].cells[f].c != ' ')
+        if (buf->rows[i].cells[l].c != ' ')
           break;
       for (j = f; j <= l; j++)
         dec->text[dec->textlen++] = buf->rows[i].cells[j].c;

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamPVRManager.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamPVRManager.cpp
@@ -294,7 +294,7 @@ bool CDVDInputStreamPVRManager::SelectChannel(const CPVRChannel &channel)
   return false;
 }
 
-bool CDVDInputStreamPVRManager::GetSelectedChannel(CPVRChannelPtr& channel) const
+bool CDVDInputStreamPVRManager::GetSelectedChannel(CPVRChannelPtr& channel)
 {
   return g_PVRManager.GetCurrentChannel(channel);
 }

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamPVRManager.h
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamPVRManager.h
@@ -59,7 +59,7 @@ public:
   bool            SelectChannel(const PVR::CPVRChannel &channel);
   bool            NextChannel(bool preview = false);
   bool            PrevChannel(bool preview = false);
-  bool            GetSelectedChannel(PVR::CPVRChannelPtr& channel) const;
+  bool            GetSelectedChannel(PVR::CPVRChannelPtr& channel);
 
   int             GetTotalTime();
   int             GetTime();

--- a/xbmc/filesystem/SAPFile.cpp
+++ b/xbmc/filesystem/SAPFile.cpp
@@ -115,12 +115,10 @@ int CSAPFile::Stat(const CURL& url, struct __stat64* buffer)
 
 ssize_t CSAPFile::Read(void *lpBuf, size_t uiBufSize)
 {
-  if (uiBufSize > SSIZE_MAX)
-    uiBufSize = SSIZE_MAX;
   if (uiBufSize > std::numeric_limits<std::streamsize>::max())
-    uiBufSize = (size_t)std::numeric_limits<std::streamsize>::max();
+    uiBufSize = static_cast<size_t>(std::numeric_limits<std::streamsize>::max());
 
-  return (ssize_t)m_stream.readsome((char*)lpBuf, (streamsize)uiBufSize);
+  return static_cast<ssize_t>(m_stream.readsome((char*)lpBuf, static_cast<std::streamsize>(uiBufSize)));
 }
 
 void CSAPFile::Close()

--- a/xbmc/guilib/XBTFReader.cpp
+++ b/xbmc/guilib/XBTFReader.cpp
@@ -31,16 +31,16 @@
 #include "PlatformDefs.h"
 
 #define READ_STR(str, size, file) \
-  if (!fread(str, size, 1, file)) \
+  if (1 != fread(str, size, 1, file)) \
     return false;
 
 #define READ_U32(i, file) \
-  if (!fread(&i, 4, 1, file)) \
+  if (1 != fread(&i, 4, 1, file)) \
     return false; \
   i = Endian_SwapLE32(i);
 
 #define READ_U64(i, file) \
-  if (!fread(&i, 8, 1, file)) \
+  if (1 != fread(&i, 8, 1, file)) \
     return false; \
   i = Endian_SwapLE64(i);
 

--- a/xbmc/network/httprequesthandler/HTTPWebinterfaceHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPWebinterfaceHandler.cpp
@@ -89,8 +89,8 @@ int CHTTPWebinterfaceHandler::ResolveUrl(const std::string &url, std::string &pa
 
   if (useDefaultWebInterface)
   {
-    ADDON::CAddonMgr::Get().GetDefault(ADDON::ADDON_WEB_INTERFACE, addon);
-    if (addon)
+    
+    if (ADDON::CAddonMgr::Get().GetDefault(ADDON::ADDON_WEB_INTERFACE, addon) && addon)
       addonPath = addon->Path();
   }
 

--- a/xbmc/network/upnp/UPnPServer.cpp
+++ b/xbmc/network/upnp/UPnPServer.cpp
@@ -278,9 +278,11 @@ CUPnPServer::Build(CFileItemPtr                  item,
             object->m_ObjectID = "0";
             object->m_ParentID = "-1";
             // root has 5 children
-            if (with_count) {
-                ((PLT_MediaContainer*)object)->m_ChildrenCount = 5;
-            }
+            
+            //This is dead code because of the HACK a few lines up setting with_count to false
+            //if (with_count) {
+            //    ((PLT_MediaContainer*)object)->m_ChildrenCount = 5;
+            //}
         } else {
             goto failure;
         }

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -276,7 +276,7 @@ void CGUIWindowVideoBase::UpdateButtons()
   CGUIMediaWindow::UpdateButtons();
 }
 
-void CGUIWindowVideoBase::OnInfo(CFileItem* pItem, const ADDON::ScraperPtr& scraper)
+void CGUIWindowVideoBase::OnInfo(CFileItem* pItem, ADDON::ScraperPtr& scraper)
 {
   if (!pItem)
     return;

--- a/xbmc/video/windows/GUIWindowVideoBase.h
+++ b/xbmc/video/windows/GUIWindowVideoBase.h
@@ -49,7 +49,7 @@ public:
   static bool HasResumeItemOffset(const CFileItem *item);
 
   void AddToDatabase(int iItem);
-  virtual void OnInfo(CFileItem* pItem, const ADDON::ScraperPtr& scraper);
+  virtual void OnInfo(CFileItem* pItem, ADDON::ScraperPtr& scraper);
 
 
   /*! \brief Show the resume menu for this item (if it has a resume bookmark)


### PR DESCRIPTION
Most of these should be harmless and fix the newest warnings that has popped up in coverity.

I'm not sure about cc_decoder.c though, it's been wrong for a long time so it may break something and maybe should be skipped?
