### PR TITLE
FFmpeg: Bump version to 2.5.4-Isengard-alpha

### DIFF
--- a/tools/depends/target/ffmpeg/FFMPEG-VERSION
+++ b/tools/depends/target/ffmpeg/FFMPEG-VERSION
@@ -1,5 +1,5 @@
 LIBNAME=ffmpeg
 BASE_URL=https://github.com/xbmc/FFmpeg/archive
-VERSION=2.5.2-Isengard-alpha
+VERSION=2.5.4-Isengard-alpha
 ARCHIVE=$(LIBNAME)-$(VERSION).tar.gz
 


### PR DESCRIPTION
Kodi part of: https://github.com/xbmc/FFmpeg/releases/tag/2.5.4-Isengard-alpha
