### PR TITLE
[AE] clean up - drop enumeration for vanished engines

### DIFF
--- a/xbmc/cores/AudioEngine/AEFactory.cpp
+++ b/xbmc/cores/AudioEngine/AEFactory.cpp
@@ -40,22 +40,11 @@ IAE *CAEFactory::GetEngine()
 
 bool CAEFactory::LoadEngine()
 {
-  return CAEFactory::LoadEngine(AE_ENGINE_ACTIVE);
-}
-
-bool CAEFactory::LoadEngine(enum AEEngine engine)
-{
   /* can only load the engine once, XBMC restart is required to change it */
   if (AE)
     return false;
 
-  switch(engine)
-  {
-    case AE_ENGINE_NULL     :
-    case AE_ENGINE_ACTIVE   : AE = new ActiveAE::CActiveAE(); break;
-    default:
-      return false;
-  }
+  AE = new ActiveAE::CActiveAE();
 
   if (AE && !AE->CanInit())
   {

--- a/xbmc/cores/AudioEngine/AEFactory.h
+++ b/xbmc/cores/AudioEngine/AEFactory.h
@@ -26,14 +26,6 @@
 
 class CSetting;
 
-enum AEEngine
-{
-  AE_ENGINE_NULL,
-  AE_ENGINE_COREAUDIO,
-  AE_ENGINE_ACTIVE,
-  AE_ENGINE_PIAUDIO
-};
-
 class CAEFactory
 {
 public:
@@ -84,7 +76,6 @@ public:
   static void UnregisterAudioCallback();
 
 private:
-  static bool LoadEngine(enum AEEngine engine);
   static IAE *AE;
 
   static void SettingOptionsAudioDevicesFillerGeneral(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, bool passthrough);


### PR DESCRIPTION
see title
g++ 4.9 with c++11 seem to complain about typed enum in case switch - > launchpad build fails for Ubuntu 14.10
