### PR TITLE
CHG: [aml] remove su hacks

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
@@ -60,6 +60,12 @@ CDVDVideoCodecAmlogic::~CDVDVideoCodecAmlogic()
 
 bool CDVDVideoCodecAmlogic::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
 {
+  if (!aml_permissions())
+  {
+    CLog::Log(LOGERROR, "AML: no proper permission, please contact the device vendor. Skipping codec...");
+    return false;
+  }
+
   m_hints = hints;
 
   switch(m_hints.codec)

--- a/xbmc/utils/AMLUtils.cpp
+++ b/xbmc/utils/AMLUtils.cpp
@@ -77,33 +77,71 @@ bool aml_wired_present()
   return has_wired == 1;
 }
 
-void aml_permissions()
-{
+bool aml_permissions()
+{  
   if (!aml_present())
-    return;
-  
-  // most all aml devices are already rooted.
-  int ret = system("ls /system/xbin/su");
-  if (ret != 0)
+    return false;
+
+  static int permissions_ok = -1;
+  if (permissions_ok == -1)
   {
-    CLog::Log(LOGWARNING, "aml_permissions: missing su, playback might fail");
+    permissions_ok = 1;
+
+    if (!SysfsUtils::HasRW("/dev/amvideo"))
+    {
+      CLog::Log(LOGERROR, "AML: no rw on /dev/amvideo");
+      permissions_ok = 0;
+    }
+    if (!SysfsUtils::HasRW("/dev/amstream_mpts"))
+    {
+      CLog::Log(LOGERROR, "AML: no rw on /dev/amstream*");
+      permissions_ok = 0;
+    }
+    if (!SysfsUtils::HasRW("/sys/class/video/axis"))
+    {
+      CLog::Log(LOGERROR, "AML: no rw on /sys/class/video/axis");
+      permissions_ok = 0;
+    }
+    if (!SysfsUtils::HasRW("/sys/class/video/screen_mode"))
+    {
+      CLog::Log(LOGERROR, "AML: no rw on /sys/class/video/screen_mode");
+      permissions_ok = 0;
+    }
+    if (!SysfsUtils::HasRW("/sys/class/video/disable_video"))
+    {
+      CLog::Log(LOGERROR, "AML: no rw on /sys/class/video/disable_video");
+      permissions_ok = 0;
+    }
+    if (!SysfsUtils::HasRW("/sys/class/tsync/pts_pcrscr"))
+    {
+      CLog::Log(LOGERROR, "AML: no rw on /sys/class/tsync/pts_pcrscr");
+      permissions_ok = 0;
+    }
+    if (!SysfsUtils::HasRW("/sys/class/audiodsp/digital_raw"))
+    {
+      CLog::Log(LOGERROR, "AML: no rw on /sys/class/audiodsp/digital_raw");
+    }
+    if (!SysfsUtils::HasRW("/sys/class/ppmgr/ppmgr_3d_mode"))
+    {
+      CLog::Log(LOGERROR, "AML: no rw on /sys/class/ppmgr/ppmgr_3d_mode");
+    }
+#ifndef TARGET_ANDROID
+    if (!SysfsUtils::HasRW("/sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq"))
+    {
+      CLog::Log(LOGERROR, "AML: no rw on /sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq");
+    }
+    if (!SysfsUtils::HasRW("/sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq"))
+    {
+      CLog::Log(LOGERROR, "AML: no rw on /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq");
+    }
+    if (!SysfsUtils::HasRW("/sys/devices/cpu/cpu/cpu0/cpufreq/scaling_governor"))
+    {
+      CLog::Log(LOGERROR, "AML: no rw on /sys/devices/cpu/cpu/cpu0/cpufreq/scaling_governor");
+    }
+#endif
   }
-  else
-  {
-    // certain aml devices have 664 permission, we need 666.
-    system("su -c chmod 666 /dev/amvideo");
-    system("su -c chmod 666 /dev/amstream*");
-    system("su -c chmod 666 /sys/class/video/axis");
-    system("su -c chmod 666 /sys/class/video/screen_mode");
-    system("su -c chmod 666 /sys/class/video/disable_video");
-    system("su -c chmod 666 /sys/class/tsync/pts_pcrscr");
-    system("su -c chmod 666 /sys/class/audiodsp/digital_raw");
-    system("su -c chmod 666 /sys/class/ppmgr/ppmgr_3d_mode");
-    system("su -c chmod 666 /sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq");
-    system("su -c chmod 666 /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq");
-    system("su -c chmod 666 /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor");
-    CLog::Log(LOGINFO, "aml_permissions: permissions changed");
-  }
+
+  return permissions_ok == 1;
 }
 
 bool aml_support_hevc()

--- a/xbmc/utils/AMLUtils.h
+++ b/xbmc/utils/AMLUtils.h
@@ -42,7 +42,7 @@ enum AML_DISPLAY_AXIS_PARAM
 };
 
 bool aml_present();
-void aml_permissions();
+bool aml_permissions();
 bool aml_hw3d_present();
 bool aml_wired_present();
 bool aml_support_hevc();

--- a/xbmc/utils/SysfsUtils.cpp
+++ b/xbmc/utils/SysfsUtils.cpp
@@ -102,3 +102,14 @@ bool SysfsUtils::Has(const std::string &path)
   }
   return false;
 }
+
+bool SysfsUtils::HasRW(const std::string &path)
+{
+  int fd = open(path.c_str(), O_CREAT | O_RDWR | O_TRUNC, 0644);
+  if (fd >= 0)
+  {
+    close(fd);
+    return true;
+  }
+  return false;
+}

--- a/xbmc/utils/SysfsUtils.h
+++ b/xbmc/utils/SysfsUtils.h
@@ -29,4 +29,5 @@ public:
   static int SetInt(const std::string& path, const int val);
   static int GetInt(const std::string& path, int& val);
   static bool Has(const std::string& path);
+  static bool HasRW(const std::string &path);
 };

--- a/xbmc/windowing/egl/EGLNativeTypeAndroid.cpp
+++ b/xbmc/windowing/egl/EGLNativeTypeAndroid.cpp
@@ -25,9 +25,6 @@
 #include "guilib/gui3d.h"
 #if defined(TARGET_ANDROID)
   #include "android/activity/XBMCApp.h"
-  #if defined(HAS_AMLPLAYER) || defined(HAS_LIBAMCODEC)
-    #include "utils/AMLUtils.h"
-  #endif
 #endif
 #include "utils/StringUtils.h"
 
@@ -49,21 +46,10 @@ bool CEGLNativeTypeAndroid::CheckCompatibility()
 
 void CEGLNativeTypeAndroid::Initialize()
 {
-#if defined(TARGET_ANDROID) && (defined(HAS_AMLPLAYER) || defined(HAS_LIBAMCODEC))
-  aml_permissions();
-  aml_cpufreq_min(true);
-  aml_cpufreq_max(true);
-#endif
-
   return;
 }
 void CEGLNativeTypeAndroid::Destroy()
 {
-#if defined(TARGET_ANDROID) && (defined(HAS_AMLPLAYER) || defined(HAS_LIBAMCODEC))
-  aml_cpufreq_min(false);
-  aml_cpufreq_max(false);
-#endif
-
   return;
 }
 


### PR DESCRIPTION
This removes the ugly su hacks for android amlogic.
Up to the box vendors to have their permissions right, not us ;)

After this, we'll bypass amlogic if the permissions are not right, rather than the dreaded "black video" effect, which will actually save on support, as most amlogic support mediacodec those days.

/cc @MartijnKaijser @wsnipex @Montellese @davilla 
