### PR TITLE
[Win32] Fix occasional build errors related to unclean binary addons build

### DIFF
--- a/project/Win32BuildSetup/BuildSetup.bat
+++ b/project/Win32BuildSetup/BuildSetup.bat
@@ -231,6 +231,9 @@ set WORKSPACE=%CD%\..\..
     ECHO ------------------------------------------------------------
     ECHO Building addons...
     cd ..\..\tools\buildsteps\win32
+    IF %buildmode%==clean (
+      call make-addons.bat clean
+    )
     call make-addons.bat
     IF %errorlevel%==1 (
       set DIETEXT="failed to build addons"


### PR DESCRIPTION
as title says: also call "clean" on the binary addons build to ensure the remnants of a previous build don't cause trouble.
