### PR TITLE
[settings] Allow coded settings dialogs to define label (needed to pass addon strings)

### DIFF
--- a/xbmc/settings/dialogs/GUIDialogSettingsBase.cpp
+++ b/xbmc/settings/dialogs/GUIDialogSettingsBase.cpp
@@ -539,6 +539,11 @@ std::set<std::string> CGUIDialogSettingsBase::CreateSettings()
   return settingMap;
 }
 
+std::string CGUIDialogSettingsBase::GetSettingsLabel(CSetting *pSetting)
+{
+  return GetLocalizedString(pSetting->GetLabel());
+}
+
 void CGUIDialogSettingsBase::UpdateSettings()
 {
   for (vector<BaseSettingControlPtr>::iterator it = m_settingControls.begin(); it != m_settingControls.end(); ++it)
@@ -562,7 +567,7 @@ CGUIControl* CGUIDialogSettingsBase::AddSetting(CSetting *pSetting, float width,
   CGUIControl *pControl = NULL;
 
   // determine the label and any possible indentation in case of sub settings
-  string label = GetLocalizedString(pSetting->GetLabel());
+  std::string label = GetSettingsLabel(pSetting);
   int parentLevels = 0;
   CSetting *parentSetting = GetSetting(pSetting->GetParent());
   while (parentSetting != NULL)

--- a/xbmc/settings/dialogs/GUIDialogSettingsBase.h
+++ b/xbmc/settings/dialogs/GUIDialogSettingsBase.h
@@ -101,7 +101,19 @@ protected:
   virtual void SetupView();
   virtual std::set<std::string> CreateSettings();
   virtual void UpdateSettings();
-  
+
+  /*!
+    \brief Get the name for the setting entry
+
+    Used as virtual to allow related settings dialog to give a std::string name of the setting.
+    If not used on own dialog class it handle the string from int CSetting::GetLabel(),
+    This must also be used if on related dialog no special entry is wanted.
+
+    \param pSetting Base settings class which need the name
+    \return Name used on settings dialog
+   */
+  virtual std::string GetSettingsLabel(CSetting *pSetting);
+
   virtual CGUIControl* AddSetting(CSetting *pSetting, float width, int &iControlID);
   virtual CGUIControl* AddSettingControl(CGUIControl *pControl, BaseSettingControlPtr pSettingControl, float width, int &iControlID);
   


### PR DESCRIPTION
With this change it become possible to change the settings item name from Dialog.

Is needed to pass std::string names to the entry in settings. This is required for addons where the usage of string id's is not possible.
