### PR TITLE
[settings] Add coded settings button with updateable label

### DIFF
--- a/xbmc/settings/SettingControl.cpp
+++ b/xbmc/settings/SettingControl.cpp
@@ -201,7 +201,8 @@ bool CSettingControlButton::SetFormat(const std::string &format)
 {
   if (!StringUtils::EqualsNoCase(format, "path") &&
       !StringUtils::EqualsNoCase(format, "addon") &&
-      !StringUtils::EqualsNoCase(format, "action"))
+      !StringUtils::EqualsNoCase(format, "action") &&
+      !StringUtils::EqualsNoCase(format, "infolabel"))
     return false;
 
   m_format = format;

--- a/xbmc/settings/dialogs/GUIDialogSettingsManualBase.cpp
+++ b/xbmc/settings/dialogs/GUIDialogSettingsManualBase.cpp
@@ -239,6 +239,24 @@ CSettingAction* CGUIDialogSettingsManualBase::AddButton(CSettingGroup *group, co
   return setting;
 }
 
+CSettingString* CGUIDialogSettingsManualBase::AddInfoLabelButton(CSettingGroup *group, const std::string &id, int label, int level, std::string info,
+                                                                 bool visible /* = true */, int help /* = -1 */)
+{
+  if (group == NULL || id.empty() || label < 0 ||
+      GetSetting(id) != NULL)
+    return NULL;
+
+  CSettingString *setting = new CSettingString(id, label, info, m_settingsManager);
+  if (setting == NULL)
+    return NULL;
+
+  setting->SetControl(GetButtonControl("infolabel", false));
+  setSettingDetails(setting, level, visible, help);
+
+  group->AddSetting(setting);
+  return setting;
+}
+
 CSettingAddon* CGUIDialogSettingsManualBase::AddAddon(CSettingGroup *group, const std::string &id, int label, int level, std::string value, ADDON::TYPE addonType,
                                                       bool allowEmpty /* = false */, int heading /* = -1 */, bool hideValue /* = false */, bool showInstalledAddons /* = true */,
                                                       bool showInstallableAddons /* = false */, bool showMoreAddons /* = true */, bool delayed /* = false */,

--- a/xbmc/settings/dialogs/GUIDialogSettingsManualBase.h
+++ b/xbmc/settings/dialogs/GUIDialogSettingsManualBase.h
@@ -70,6 +70,7 @@ protected:
                                  int heading = -1, bool delayed = false, bool visible = true, int help = -1);
   // button controls
   CSettingAction* AddButton(CSettingGroup *group, const std::string &id, int label, int level, bool delayed = false, bool visible = true, int help = -1);
+  CSettingString* AddInfoLabelButton(CSettingGroup *group, const std::string &id, int label, int level, std::string info, bool visible = true, int help = -1);
   CSettingAddon* AddAddon(CSettingGroup *group, const std::string &id, int label, int level, std::string value, ADDON::TYPE addonType,
                           bool allowEmpty = false, int heading = -1, bool hideValue = false, bool showInstalledAddons = true, bool showInstallableAddons = false,
                           bool showMoreAddons = true, bool delayed = false, bool visible = true, int help = -1);

--- a/xbmc/settings/windows/GUIControlSettings.cpp
+++ b/xbmc/settings/windows/GUIControlSettings.cpp
@@ -617,6 +617,12 @@ void CGUIControlButtonSetting::Update(bool updateDisplayOnly /* = false */)
         if (CUtil::MakeShortenPath(strValue, shortPath, 30))
           strText = shortPath;
       }
+      else if (controlFormat == "infolabel")
+      {
+        strText = strValue;
+        if (strText.empty())
+          strText = g_localizeStrings.Get(231); // None
+      }
     }
   }
   else if (controlType == "slider")


### PR DESCRIPTION
With this it become possible to use a button where the label can continuous updated.

as example:
<code>m_settingsManager->SetString(SETTING_STREAM_INFO_CPU_USAGE, m_CPUUsage); </code>
