### PR TITLE
Part 2 of input refactoring

### DIFF
--- a/Kodi.xcodeproj/project.pbxproj
+++ b/Kodi.xcodeproj/project.pbxproj
@@ -116,7 +116,6 @@
 		18B7C7ED1294222E009E7A26 /* GUIWindowManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7981294222E009E7A26 /* GUIWindowManager.cpp */; };
 		18B7C7EE1294222E009E7A26 /* GUIWrappingListContainer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7991294222E009E7A26 /* GUIWrappingListContainer.cpp */; };
 		18B7C7EF1294222E009E7A26 /* IWindowManagerCallback.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C79A1294222E009E7A26 /* IWindowManagerCallback.cpp */; };
-		18B7C7F01294222E009E7A26 /* Key.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C79B1294222E009E7A26 /* Key.cpp */; };
 		18B7C7F11294222E009E7A26 /* LocalizeStrings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C79C1294222E009E7A26 /* LocalizeStrings.cpp */; };
 		18B7C7F21294222E009E7A26 /* MatrixGLES.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C79D1294222E009E7A26 /* MatrixGLES.cpp */; };
 		18B7C7F31294222E009E7A26 /* Shader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C79E1294222E009E7A26 /* Shader.cpp */; };
@@ -182,6 +181,9 @@
 		3802709A13D5A653009493DD /* SystemClock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3802709813D5A653009493DD /* SystemClock.cpp */; };
 		384718D81325BA04000486D6 /* XBDateTime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 384718D61325BA04000486D6 /* XBDateTime.cpp */; };
 		38F4E57013CCCB3B00664821 /* Implementation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 38F4E56C13CCCB3B00664821 /* Implementation.cpp */; };
+		395C29BC1A94733100EBC7AD /* Key.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 395C29BA1A94733100EBC7AD /* Key.cpp */; };
+		395C29BD1A94733100EBC7AD /* Key.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 395C29BA1A94733100EBC7AD /* Key.cpp */; };
+		395C29BE1A94733100EBC7AD /* Key.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 395C29BA1A94733100EBC7AD /* Key.cpp */; };
 		395C29C11A98A0A000EBC7AD /* Webinterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 395C29BF1A98A0A000EBC7AD /* Webinterface.cpp */; };
 		395C29C21A98A0A000EBC7AD /* Webinterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 395C29BF1A98A0A000EBC7AD /* Webinterface.cpp */; };
 		395C29C31A98A0A000EBC7AD /* Webinterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 395C29BF1A98A0A000EBC7AD /* Webinterface.cpp */; };
@@ -1452,7 +1454,6 @@
 		DFF0F2B817528350002DA3A4 /* imagefactory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF404A3716B9896C00D8023E /* imagefactory.cpp */; };
 		DFF0F2B917528350002DA3A4 /* IWindowManagerCallback.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C79A1294222E009E7A26 /* IWindowManagerCallback.cpp */; };
 		DFF0F2BA17528350002DA3A4 /* JpegIO.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 32C631261423A90F00F18420 /* JpegIO.cpp */; };
-		DFF0F2BB17528350002DA3A4 /* Key.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C79B1294222E009E7A26 /* Key.cpp */; };
 		DFF0F2BC17528350002DA3A4 /* LocalizeStrings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C79C1294222E009E7A26 /* LocalizeStrings.cpp */; };
 		DFF0F2BD17528350002DA3A4 /* MatrixGLES.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C79D1294222E009E7A26 /* MatrixGLES.cpp */; };
 		DFF0F2BE17528350002DA3A4 /* Shader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C79E1294222E009E7A26 /* Shader.cpp */; };
@@ -2704,7 +2705,6 @@
 		E4991321174E5DAD00741B6D /* imagefactory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF404A3716B9896C00D8023E /* imagefactory.cpp */; };
 		E4991322174E5DAD00741B6D /* IWindowManagerCallback.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C79A1294222E009E7A26 /* IWindowManagerCallback.cpp */; };
 		E4991323174E5DAD00741B6D /* JpegIO.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 32C631261423A90F00F18420 /* JpegIO.cpp */; };
-		E4991324174E5DAD00741B6D /* Key.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C79B1294222E009E7A26 /* Key.cpp */; };
 		E4991325174E5DAD00741B6D /* LocalizeStrings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C79C1294222E009E7A26 /* LocalizeStrings.cpp */; };
 		E4991326174E5DAD00741B6D /* MatrixGLES.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C79D1294222E009E7A26 /* MatrixGLES.cpp */; };
 		E4991327174E5DAD00741B6D /* Shader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C79E1294222E009E7A26 /* Shader.cpp */; };
@@ -3459,7 +3459,6 @@
 		18B7C7401294222D009E7A26 /* IAudioDeviceChangedCallback.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IAudioDeviceChangedCallback.h; sourceTree = "<group>"; };
 		18B7C7411294222D009E7A26 /* IMsgTargetCallback.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IMsgTargetCallback.h; sourceTree = "<group>"; };
 		18B7C7421294222D009E7A26 /* IWindowManagerCallback.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IWindowManagerCallback.h; sourceTree = "<group>"; };
-		18B7C7431294222D009E7A26 /* Key.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Key.h; sourceTree = "<group>"; };
 		18B7C7441294222D009E7A26 /* LocalizeStrings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LocalizeStrings.h; sourceTree = "<group>"; };
 		18B7C7451294222E009E7A26 /* MatrixGLES.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MatrixGLES.h; sourceTree = "<group>"; };
 		18B7C7461294222E009E7A26 /* Resolution.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Resolution.h; sourceTree = "<group>"; };
@@ -3543,7 +3542,6 @@
 		18B7C7981294222E009E7A26 /* GUIWindowManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GUIWindowManager.cpp; sourceTree = "<group>"; };
 		18B7C7991294222E009E7A26 /* GUIWrappingListContainer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GUIWrappingListContainer.cpp; sourceTree = "<group>"; };
 		18B7C79A1294222E009E7A26 /* IWindowManagerCallback.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = IWindowManagerCallback.cpp; sourceTree = "<group>"; };
-		18B7C79B1294222E009E7A26 /* Key.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Key.cpp; sourceTree = "<group>"; };
 		18B7C79C1294222E009E7A26 /* LocalizeStrings.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LocalizeStrings.cpp; sourceTree = "<group>"; };
 		18B7C79D1294222E009E7A26 /* MatrixGLES.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MatrixGLES.cpp; sourceTree = "<group>"; };
 		18B7C79E1294222E009E7A26 /* Shader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Shader.cpp; sourceTree = "<group>"; };
@@ -3671,6 +3669,8 @@
 		38F4E56C13CCCB3B00664821 /* Implementation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Implementation.cpp; sourceTree = "<group>"; };
 		38F4E56D13CCCB3B00664821 /* README.platform */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = README.platform; sourceTree = "<group>"; };
 		38F4E56E13CCCB3B00664821 /* ThreadLocal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ThreadLocal.h; sourceTree = "<group>"; };
+		395C29BA1A94733100EBC7AD /* Key.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Key.cpp; sourceTree = "<group>"; };
+		395C29BB1A94733100EBC7AD /* Key.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Key.h; sourceTree = "<group>"; };
 		395C29BF1A98A0A000EBC7AD /* Webinterface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Webinterface.cpp; sourceTree = "<group>"; };
 		395C29C01A98A0A000EBC7AD /* Webinterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Webinterface.h; sourceTree = "<group>"; };
 		395C29C41A98A0E100EBC7AD /* ILanguageInvoker.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ILanguageInvoker.cpp; sourceTree = "<group>"; };
@@ -6308,8 +6308,6 @@
 				18B7C7421294222D009E7A26 /* IWindowManagerCallback.h */,
 				32C631261423A90F00F18420 /* JpegIO.cpp */,
 				32C631271423A90F00F18420 /* JpegIO.h */,
-				18B7C79B1294222E009E7A26 /* Key.cpp */,
-				18B7C7431294222D009E7A26 /* Key.h */,
 				18B7C79C1294222E009E7A26 /* LocalizeStrings.cpp */,
 				18B7C7441294222D009E7A26 /* LocalizeStrings.h */,
 				18B7C79D1294222E009E7A26 /* MatrixGLES.cpp */,
@@ -6415,6 +6413,8 @@
 				DFAB049713F8376700B70BFB /* InertialScrollingHandler.h */,
 				DF14CF7C1A77782E00396CC9 /* InputManager.cpp */,
 				DF14CF7D1A77782E00396CC9 /* InputManager.h */,
+				395C29BA1A94733100EBC7AD /* Key.cpp */,
+				395C29BB1A94733100EBC7AD /* Key.h */,
 				7CF80DC719710DC2003B2B34 /* KeyboardLayout.cpp */,
 				7CF80DC819710DC2003B2B34 /* KeyboardLayout.h */,
 				18B7C8CD12942546009E7A26 /* KeyboardLayoutConfiguration.cpp */,
@@ -10651,6 +10651,7 @@
 				E38E22490D25F9FE00618676 /* log.cpp in Sources */,
 				E38E224B0D25F9FE00618676 /* match.cpp in Sources */,
 				E38E224D0D25F9FE00618676 /* options.cpp in Sources */,
+				395C29BC1A94733100EBC7AD /* Key.cpp in Sources */,
 				E38E224E0D25F9FE00618676 /* pathfn.cpp in Sources */,
 				395C29F01A98A16300EBC7AD /* HTTPPythonWsgiInvoker.cpp in Sources */,
 				E38E22500D25F9FE00618676 /* rarvm.cpp in Sources */,
@@ -10970,7 +10971,6 @@
 				18B7C7ED1294222E009E7A26 /* GUIWindowManager.cpp in Sources */,
 				18B7C7EE1294222E009E7A26 /* GUIWrappingListContainer.cpp in Sources */,
 				18B7C7EF1294222E009E7A26 /* IWindowManagerCallback.cpp in Sources */,
-				18B7C7F01294222E009E7A26 /* Key.cpp in Sources */,
 				18B7C7F11294222E009E7A26 /* LocalizeStrings.cpp in Sources */,
 				18B7C7F21294222E009E7A26 /* MatrixGLES.cpp in Sources */,
 				18B7C7F31294222E009E7A26 /* Shader.cpp in Sources */,
@@ -11935,7 +11935,6 @@
 				DFF0F2B817528350002DA3A4 /* imagefactory.cpp in Sources */,
 				DFF0F2B917528350002DA3A4 /* IWindowManagerCallback.cpp in Sources */,
 				DFF0F2BA17528350002DA3A4 /* JpegIO.cpp in Sources */,
-				DFF0F2BB17528350002DA3A4 /* Key.cpp in Sources */,
 				DFF0F2BC17528350002DA3A4 /* LocalizeStrings.cpp in Sources */,
 				DFF0F2BD17528350002DA3A4 /* MatrixGLES.cpp in Sources */,
 				DFF0F2BE17528350002DA3A4 /* Shader.cpp in Sources */,
@@ -12105,6 +12104,7 @@
 				DFF0F35E17528350002DA3A4 /* PlayList.cpp in Sources */,
 				DFF0F35F17528350002DA3A4 /* PlayListB4S.cpp in Sources */,
 				DFF0F36017528350002DA3A4 /* PlayListFactory.cpp in Sources */,
+				395C29BE1A94733100EBC7AD /* Key.cpp in Sources */,
 				DFF0F36117528350002DA3A4 /* PlayListM3U.cpp in Sources */,
 				DF4BF0191A4EF31F0053AC56 /* cc_decoder.c in Sources */,
 				DFF0F36217528350002DA3A4 /* PlayListPLS.cpp in Sources */,
@@ -12666,6 +12666,7 @@
 				E49911CB174E5D2500741B6D /* DVDOverlayCodecTX3G.cpp in Sources */,
 				E49911CE174E5D2500741B6D /* DVDVideoCodecFFmpeg.cpp in Sources */,
 				E49911CF174E5D2500741B6D /* DVDVideoCodecLibMpeg2.cpp in Sources */,
+				395C29BD1A94733100EBC7AD /* Key.cpp in Sources */,
 				E49911D0174E5D2500741B6D /* DVDVideoCodecVDA.cpp in Sources */,
 				E49911D1174E5D2500741B6D /* DVDVideoPPFFmpeg.cpp in Sources */,
 				E49911D2174E5D2E00741B6D /* DVDDemux.cpp in Sources */,
@@ -13015,7 +13016,6 @@
 				E4991321174E5DAD00741B6D /* imagefactory.cpp in Sources */,
 				E4991322174E5DAD00741B6D /* IWindowManagerCallback.cpp in Sources */,
 				E4991323174E5DAD00741B6D /* JpegIO.cpp in Sources */,
-				E4991324174E5DAD00741B6D /* Key.cpp in Sources */,
 				E4991325174E5DAD00741B6D /* LocalizeStrings.cpp in Sources */,
 				E4991326174E5DAD00741B6D /* MatrixGLES.cpp in Sources */,
 				E4991327174E5DAD00741B6D /* Shader.cpp in Sources */,

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -484,7 +484,6 @@
     <ClCompile Include="..\..\xbmc\guilib\imagefactory.cpp" />
     <ClCompile Include="..\..\xbmc\guilib\IWindowManagerCallback.cpp" />
     <ClCompile Include="..\..\xbmc\guilib\JpegIO.cpp" />
-    <ClCompile Include="..\..\xbmc\guilib\Key.cpp" />
     <ClCompile Include="..\..\xbmc\guilib\LocalizeStrings.cpp" />
     <ClCompile Include="..\..\xbmc\guilib\MatrixGLES.cpp" />
     <ClCompile Include="..\..\xbmc\guilib\StereoscopicsManager.cpp" />
@@ -501,6 +500,7 @@
     <ClCompile Include="..\..\xbmc\input\ButtonTranslator.cpp" />
     <ClCompile Include="..\..\xbmc\input\InertialScrollingHandler.cpp" />
     <ClCompile Include="..\..\xbmc\input\InputManager.cpp" />
+    <ClCompile Include="..\..\xbmc\input\Key.cpp" />
     <ClCompile Include="..\..\xbmc\input\KeyboardLayout.cpp" />
     <ClCompile Include="..\..\xbmc\input\KeyboardLayoutConfiguration.cpp" />
     <ClCompile Include="..\..\xbmc\input\KeyboardStat.cpp" />
@@ -900,6 +900,7 @@
     <ClInclude Include="..\..\xbmc\guilib\ISliderCallback.h" />
     <ClInclude Include="..\..\xbmc\IFileItemListModifier.h" />
     <ClInclude Include="..\..\xbmc\input\InputManager.h" />
+    <ClInclude Include="..\..\xbmc\input\Key.h" />
     <ClInclude Include="..\..\xbmc\input\touch\generic\GenericTouchActionHandler.h" />
     <ClInclude Include="..\..\xbmc\input\touch\generic\GenericTouchSwipeDetector.h" />
     <ClInclude Include="..\..\xbmc\input\touch\generic\IGenericTouchGestureDetector.h" />
@@ -1842,7 +1843,6 @@
     <ClInclude Include="..\..\xbmc\guilib\IMsgTargetCallback.h" />
     <ClInclude Include="..\..\xbmc\guilib\IWindowManagerCallback.h" />
     <ClInclude Include="..\..\xbmc\guilib\JpegIO.h" />
-    <ClInclude Include="..\..\xbmc\guilib\Key.h" />
     <ClInclude Include="..\..\xbmc\guilib\LocalizeStrings.h" />
     <ClInclude Include="..\..\xbmc\guilib\MatrixGLES.h" />
     <ClInclude Include="..\..\xbmc\guilib\Resolution.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -1120,9 +1120,6 @@
     <ClCompile Include="..\..\xbmc\guilib\IWindowManagerCallback.cpp">
       <Filter>guilib</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\xbmc\guilib\Key.cpp">
-      <Filter>guilib</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\xbmc\guilib\LocalizeStrings.cpp">
       <Filter>guilib</Filter>
     </ClCompile>
@@ -3146,6 +3143,9 @@
     </ClCompile>
     <ClCompile Include="..\..\xbmc\video\jobs\VideoLibraryProgressJob.cpp">
       <Filter>video\jobs</Filter>
+	</ClCompile>
+    <ClCompile Include="..\..\xbmc\input\Key.cpp">
+      <Filter>input</Filter>
     </ClCompile>
     <ClCompile Include="..\..\xbmc\network\httprequesthandler\python\HTTPPythonInvoker.cpp">
       <Filter>network\httprequesthandler\python</Filter>
@@ -4085,9 +4085,6 @@
       <Filter>guilib</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\guilib\IWindowManagerCallback.h">
-      <Filter>guilib</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\xbmc\guilib\Key.h">
       <Filter>guilib</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\guilib\LocalizeStrings.h">
@@ -6145,6 +6142,9 @@
     </ClInclude>
     <ClInclude Include="..\..\xbmc\video\jobs\VideoLibraryProgressJob.h">
       <Filter>video\jobs</Filter>
+	</ClInclude>
+    <ClInclude Include="..\..\xbmc\input\Key.h">
+      <Filter>input</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\network\httprequesthandler\python\HTTPPythonRequest.h">
       <Filter>network\httprequesthandler\python</Filter>

--- a/xbmc/AppParamParser.cpp
+++ b/xbmc/AppParamParser.cpp
@@ -26,11 +26,9 @@
 #include "settings/AdvancedSettings.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
+#include "input/InputManager.h"
 #ifdef TARGET_WINDOWS
 #include "WIN32Util.h"
-#endif
-#ifdef HAS_LIRC
-#include "input/linux/LIRC.h"
 #endif
 #ifndef TARGET_WINDOWS
 #include "linux/XTimeUtils.h"
@@ -49,23 +47,22 @@ void CAppParamParser::Parse(const char* argv[], int nArgs)
     for (int i = 1; i < nArgs; i++)
     {
       ParseArg(argv[i]);
-#ifdef HAS_LIRC
       if (strnicmp(argv[i], "-l", 2) == 0 || strnicmp(argv[i], "--lircdev", 9) == 0)
       {
         // check the next arg with the proper value.
-        int next=i+1;
+        int next = i + 1;
         if (next < nArgs)
         {
-          if ((argv[next][0] != '-' ) && (argv[next][0] == '/' ))
+          if ((argv[next][0] != '-') && (argv[next][0] == '/'))
           {
-            g_RemoteControl.setDeviceName(argv[next]);
+            CInputManager::Get().SetRemoteControlName(argv[next]);
             i++;
           }
         }
       }
       else if (strnicmp(argv[i], "-n", 2) == 0 || strnicmp(argv[i], "--nolirc", 8) == 0)
-         g_RemoteControl.setUsed(false);
-#endif
+        CInputManager::Get().DisableRemoteControl();
+
       if (stricmp(argv[i], "-d") == 0)
       {
         if (i + 1 < nArgs)

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -738,7 +738,7 @@ bool CApplication::Create()
   g_Mouse.Initialize();
   g_Mouse.SetEnabled(CSettings::Get().GetBool("input.enablemouse"));
 
-  g_Keyboard.Initialize();
+  CInputManager::Get().InitializeInputs();
 
 #if defined(TARGET_DARWIN_OSX)
   // Configure and possible manually start the helper.

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -388,7 +388,7 @@ bool CApplication::OnEvent(XBMC_Event& newEvent)
     case XBMC_MOUSEBUTTONUP:
     case XBMC_MOUSEMOTION:
       g_Mouse.HandleEvent(newEvent);
-      CInputManager::GetInstance().ProcessMouse(g_windowManager.GetActiveWindowID());
+      CInputManager::Get().ProcessMouse(g_windowManager.GetActiveWindowID());
       break;
     case XBMC_VIDEORESIZE:
       if (!g_application.m_bInitializing &&
@@ -913,6 +913,7 @@ bool CApplication::CreateGUI()
   if (!CButtonTranslator::GetInstance().Load())
     return false;
 
+
   RESOLUTION_INFO info = g_graphicsContext.GetResInfo();
   CLog::Log(LOGINFO, "GUI format %ix%i, Display %s",
             info.iWidth,
@@ -1318,7 +1319,7 @@ bool CApplication::Initialize()
   ResetScreenSaver();
 
 #ifdef HAS_SDL_JOYSTICK
-  CInputManager::GetInstance().SetEnabledJoystick(CSettings::Get().GetBool("input.enablejoystick") &&
+  CInputManager::Get().SetEnabledJoystick(CSettings::Get().GetBool("input.enablejoystick") &&
                     CPeripheralImon::GetCountOfImonsConflictWithDInput() == 0 );
 #endif
 
@@ -2670,10 +2671,10 @@ void CApplication::FrameMove(bool processEvents, bool processGUI)
 #endif
 
     // process input actions
-    CInputManager::GetInstance().ProcessRemote(g_windowManager.GetActiveWindowID());
-    CInputManager::GetInstance().ProcessGamepad(g_windowManager.GetActiveWindowID());
-    CInputManager::GetInstance().ProcessEventServer(g_windowManager.GetActiveWindowID(), frameTime);
-    CInputManager::GetInstance().ProcessPeripherals(frameTime);
+    CInputManager::Get().ProcessRemote(g_windowManager.GetActiveWindowID());
+    CInputManager::Get().ProcessGamepad(g_windowManager.GetActiveWindowID());
+    CInputManager::Get().ProcessEventServer(g_windowManager.GetActiveWindowID(), frameTime);
+    CInputManager::Get().ProcessPeripherals(frameTime);
     if (processGUI && m_renderGUI)
     {
       m_pInertialScrollingHandler->ProcessInertialScroll(frameTime);

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -735,8 +735,7 @@ bool CApplication::Create()
 
   // Create the Mouse, Keyboard, Remote, and Joystick devices
   // Initialize after loading settings to get joystick deadzone setting
-  g_Mouse.Initialize();
-  g_Mouse.SetEnabled(CSettings::Get().GetBool("input.enablemouse"));
+  
 
   CInputManager::Get().InitializeInputs();
 
@@ -2097,7 +2096,7 @@ bool CApplication::OnAction(const CAction &action)
   }
 
   if (action.IsMouse())
-    g_Mouse.SetActive(true);
+    CInputManager::Get().SetMouseActive(true);
 
   
   if (action.GetID() == ACTION_CREATE_EPISODE_BOOKMARK)   

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -75,7 +75,6 @@ class DPMSSupport;
 class CSplash;
 class CBookmark;
 class CNetwork;
-class CInputManager;
 
 namespace VIDEO
 {
@@ -117,7 +116,6 @@ class CApplication : public CXBApplicationEx, public IPlayerCallback, public IMs
                      public ISettingCallback, public ISettingsHandler, public ISubSettings
 {
   friend class CApplicationPlayer;
-  friend class CInputManager;
 public:
 
   enum ESERVERS
@@ -189,7 +187,6 @@ public:
   bool IsPlayingFullScreenVideo() const;
   bool IsStartingPlayback() const { return m_bPlaybackStarting; }
   bool IsFullScreen();
-  bool OnKey(const CKey& key);
   bool OnAppCommand(const CAction &action);
   bool OnAction(const CAction &action);
   void CheckShutdown();
@@ -484,11 +481,9 @@ protected:
   void VolumeChanged() const;
 
   PlayBackRet PlayStack(const CFileItem& item, bool bRestart);
-  bool ExecuteInputAction(const CAction &action);
-  
+  int  GetActiveWindowID(void);
 
   float NavigationIdleTime();
-  static bool AlwaysProcess(const CAction& action);
 
   bool InitDirectoriesLinux();
   bool InitDirectoriesOSX();

--- a/xbmc/ApplicationMessenger.cpp
+++ b/xbmc/ApplicationMessenger.cpp
@@ -37,7 +37,7 @@
 #include "settings/Settings.h"
 #include "FileItem.h"
 #include "guilib/GUIDialog.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "guilib/Resolution.h"
 #include "GUIInfoManager.h"

--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -35,7 +35,7 @@
 #include "dialogs/GUIDialogKaiToast.h"
 #include "guilib/LocalizeStrings.h"
 #include "interfaces/AnnouncementManager.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "URL.h"
 
 using namespace PLAYLIST;

--- a/xbmc/SystemGlobals.cpp
+++ b/xbmc/SystemGlobals.cpp
@@ -56,7 +56,6 @@
 
   CGUITextureManager g_TextureManager;
   CGUILargeTextureManager g_largeTextureManager;
-  CMouseStat         g_Mouse;
 
   CGUIPassword       g_passwordManager;
   CGUIInfoManager    g_infoManager;

--- a/xbmc/addons/AddonCallbacksGUI.cpp
+++ b/xbmc/addons/AddonCallbacksGUI.cpp
@@ -30,7 +30,7 @@
 #include "utils/TimeUtils.h"
 #include "utils/StringUtils.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "guilib/TextureManager.h"
 #include "guilib/GUISpinControlEx.h"
 #include "guilib/GUIRadioButtonControl.h"

--- a/xbmc/addons/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/GUIDialogAddonInfo.cpp
@@ -31,7 +31,7 @@
 #include "dialogs/GUIDialogTextViewer.h"
 #include "GUIUserMessages.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "utils/JobManager.h"
 #include "utils/FileOperationJob.h"
 #include "utils/StringUtils.h"

--- a/xbmc/addons/GUIDialogAddonSettings.cpp
+++ b/xbmc/addons/GUIDialogAddonSettings.cpp
@@ -34,7 +34,7 @@
 #include "guilib/GUIRadioButtonControl.h"
 #include "guilib/GUISpinControlEx.h"
 #include "guilib/GUIImage.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "filesystem/Directory.h"
 #include "video/VideoInfoScanner.h"
 #include "addons/Scraper.h"

--- a/xbmc/addons/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/GUIWindowAddonBrowser.cpp
@@ -47,7 +47,7 @@
 #include "settings/AdvancedSettings.h"
 #include "storage/MediaManager.h"
 #include "LangInfo.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "ContextMenuManager.h"
 
 #define CONTROL_AUTOUPDATE    5
@@ -201,28 +201,28 @@ bool CGUIWindowAddonBrowser::OnContextButton(int itemNumber,
   AddonPtr addon;
   if (CAddonMgr::Get().GetAddon(pItem->GetProperty("Addon.ID").asString(), addon, ADDON_UNKNOWN, false))
   {
-    if (button == CONTEXT_BUTTON_SETTINGS)
-      return CGUIDialogAddonSettings::ShowAndGetInput(addon);
+  if (button == CONTEXT_BUTTON_SETTINGS)
+    return CGUIDialogAddonSettings::ShowAndGetInput(addon);
 
-    if (button == CONTEXT_BUTTON_REFRESH)
-    {
-      CAddonDatabase database;
-      database.Open();
-      database.DeleteRepository(addon->ID());
-      button = CONTEXT_BUTTON_SCAN;
-    }
+  if (button == CONTEXT_BUTTON_REFRESH)
+  {
+    CAddonDatabase database;
+    database.Open();
+    database.DeleteRepository(addon->ID());
+    button = CONTEXT_BUTTON_SCAN;
+  }
 
-    if (button == CONTEXT_BUTTON_SCAN)
-    {
-      CAddonInstaller::Get().UpdateRepos(true);
-      return true;
-    }
+  if (button == CONTEXT_BUTTON_SCAN)
+  {
+    CAddonInstaller::Get().UpdateRepos(true);
+    return true;
+  }
 
-    if (button == CONTEXT_BUTTON_INFO)
-    {
-      CGUIDialogAddonInfo::ShowForItem(pItem);
-      return true;
-    }
+  if (button == CONTEXT_BUTTON_INFO)
+  {
+    CGUIDialogAddonInfo::ShowForItem(pItem);
+    return true;
+  }
   }
 
   return CGUIMediaWindow::OnContextButton(itemNumber, button);
@@ -548,9 +548,9 @@ int CGUIWindowAddonBrowser::SelectAddonID(const vector<ADDON::TYPE> &types, vect
 
           // check if the addon is installed or can be installed
           if ((showInstallable || showMore) && !isInstalled && CAddonMgr::Get().CanAddonBeInstalled(pAddon))
-          {
+  {
             ++addon;
-            continue;
+      continue;
           }
         }
 
@@ -571,11 +571,11 @@ int CGUIWindowAddonBrowser::SelectAddonID(const vector<ADDON::TYPE> &types, vect
   std::map<std::string, AddonPtr> addonMap;
   CFileItemList items;
   for (ADDON::IVECADDONS addon = addons.begin(); addon != addons.end(); ++addon)
-  {
-    CFileItemPtr item(CAddonsDirectory::FileItemFromAddon(*addon, ""));
-    if (!items.Contains(item->GetPath()))
     {
-      items.Add(item);
+    CFileItemPtr item(CAddonsDirectory::FileItemFromAddon(*addon, ""));
+      if (!items.Contains(item->GetPath()))
+    {
+        items.Add(item);
       addonMap.insert(std::make_pair(item->GetPath(), *addon));
     }
   }
@@ -638,7 +638,7 @@ int CGUIWindowAddonBrowser::SelectAddonID(const vector<ADDON::TYPE> &types, vect
 
   addonIDs.clear();
   const CFileItemList& list = dialog->GetSelectedItems();
-  for (int i = 0; i < list.Size(); i++)
+  for (int i = 0 ; i < list.Size() ; i++)
   {
     const CFileItemPtr& item = list.Get(i);
 

--- a/xbmc/android/activity/AndroidKey.cpp
+++ b/xbmc/android/activity/AndroidKey.cpp
@@ -21,7 +21,7 @@
 #include "AndroidKey.h"
 #include "AndroidExtra.h"
 #include "XBMCApp.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "windowing/WinEvents.h"
 #include "android/jni/KeyCharacterMap.h"
 

--- a/xbmc/android/activity/XBMCApp.cpp
+++ b/xbmc/android/activity/XBMCApp.cpp
@@ -33,7 +33,7 @@
 
 #include "input/MouseStat.h"
 #include "input/XBMC_keysym.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "windowing/XBMC_events.h"
 #include <android/log.h>
 

--- a/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
+++ b/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
@@ -39,15 +39,10 @@
 #include "utils/TimeUtils.h"
 #include "utils/log.h"
 #include "cores/AudioEngine/AEFactory.h"
+#include "input/InputManager.h"
 #if defined(TARGET_WINDOWS)
   #include "utils/CharsetConverter.h"
   #include "Windows.h"
-  #ifdef HAS_IRSERVERSUITE
-    #include "input/windows/IRServerSuite.h"
-  #endif
-#endif
-#if defined(HAS_LIRC)
-  #include "input/linux/LIRC.h"
 #endif
 #if defined(TARGET_ANDROID)
   #include "android/activity/XBMCApp.h"
@@ -466,18 +461,14 @@ BOOL CExternalPlayer::ExecuteAppW32(const char* strPath, const char* strSwitches
 BOOL CExternalPlayer::ExecuteAppLinux(const char* strSwitches)
 {
   CLog::Log(LOGNOTICE, "%s: %s", __FUNCTION__, strSwitches);
-#ifdef HAS_LIRC
-  bool remoteused = g_RemoteControl.IsInUse();
-  g_RemoteControl.Disconnect();
-  g_RemoteControl.setUsed(false);
-#endif
+
+  bool remoteUsed = CInputManager::Get().IsRemoteControlEnabled();
+  CInputManager::Get().DisableRemoteControl();
 
   int ret = system(strSwitches);
 
-#ifdef HAS_LIRC
-  g_RemoteControl.setUsed(remoteused);
-  g_RemoteControl.Initialize();
-#endif
+  if (remoteUsed)
+    CInputManager::Get().EnableRemoteControl();
 
   if (ret != 0)
   {

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -39,7 +39,7 @@
 #include "DVDFileInfo.h"
 
 #include "utils/LangCodeExpander.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
 
 #include "utils/URIUtils.h"

--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -35,7 +35,7 @@
 #include "profiles/dialogs/GUIDialogLockSettings.h"
 #include "storage/MediaManager.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "GUIDialogYesNo.h"
 #include "addons/AddonManager.h"
 #include "FileItem.h"

--- a/xbmc/dialogs/GUIDialogFavourites.cpp
+++ b/xbmc/dialogs/GUIDialogFavourites.cpp
@@ -25,7 +25,7 @@
 #include "filesystem/FavouritesDirectory.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/GUIKeyboardFactory.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "filesystem/File.h"
 #include "FileItem.h"
 #include "guilib/LocalizeStrings.h"

--- a/xbmc/dialogs/GUIDialogFileBrowser.cpp
+++ b/xbmc/dialogs/GUIDialogFileBrowser.cpp
@@ -42,7 +42,7 @@
 #include "settings/AdvancedSettings.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/Settings.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
 #include "utils/log.h"
 #include "URL.h"

--- a/xbmc/dialogs/GUIDialogGamepad.cpp
+++ b/xbmc/dialogs/GUIDialogGamepad.cpp
@@ -25,7 +25,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "GUIDialogOK.h"
 #include "utils/StringUtils.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
 
 CGUIDialogGamepad::CGUIDialogGamepad(void)

--- a/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
+++ b/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
@@ -22,7 +22,7 @@
 #include "input/XBMC_vkeys.h"
 #include "guilib/GUIEditControl.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
 #include "GUIUserMessages.h"
 #include "GUIDialogNumeric.h"

--- a/xbmc/dialogs/GUIDialogMediaSource.cpp
+++ b/xbmc/dialogs/GUIDialogMediaSource.cpp
@@ -23,7 +23,7 @@
 #include "GUIDialogFileBrowser.h"
 #include "video/windows/GUIWindowVideoBase.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "Util.h"
 #include "utils/URIUtils.h"
 #include "utils/StringUtils.h"

--- a/xbmc/dialogs/GUIDialogNumeric.cpp
+++ b/xbmc/dialogs/GUIDialogNumeric.cpp
@@ -25,7 +25,7 @@
 #include "GUIDialogOK.h"
 #include "input/XBMC_vkeys.h"
 #include "utils/StringUtils.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
 #include "interfaces/AnnouncementManager.h"
 

--- a/xbmc/dialogs/GUIDialogSelect.cpp
+++ b/xbmc/dialogs/GUIDialogSelect.cpp
@@ -21,7 +21,7 @@
 #include "GUIDialogSelect.h"
 #include "guilib/GUIWindowManager.h"
 #include "FileItem.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
 #include "utils/StringUtils.h"
 

--- a/xbmc/dialogs/GUIDialogSlider.cpp
+++ b/xbmc/dialogs/GUIDialogSlider.cpp
@@ -21,7 +21,7 @@
 #include "GUIDialogSlider.h"
 #include "guilib/GUISliderControl.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
 
 #define CONTROL_HEADING 10

--- a/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
@@ -29,7 +29,7 @@
 #include "profiles/ProfilesManager.h"
 #include "settings/Settings.h"
 #include "FileItem.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
 
 using namespace std;

--- a/xbmc/dialogs/GUIDialogVolumeBar.cpp
+++ b/xbmc/dialogs/GUIDialogVolumeBar.cpp
@@ -19,7 +19,7 @@
  */
 
 #include "GUIDialogVolumeBar.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "utils/TimeUtils.h"
 
 #define VOLUME_BAR_DISPLAY_TIME 1000L

--- a/xbmc/dialogs/GUIDialogYesNo.cpp
+++ b/xbmc/dialogs/GUIDialogYesNo.cpp
@@ -20,7 +20,7 @@
 
 #include "GUIDialogYesNo.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 
 #define CONTROL_NO_BUTTON 10
 #define CONTROL_YES_BUTTON 11

--- a/xbmc/epg/GUIEPGGridContainer.cpp
+++ b/xbmc/epg/GUIEPGGridContainer.cpp
@@ -18,7 +18,7 @@
  *
  */
 
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "guilib/GUIControlFactory.h"
 #include "guilib/GUIListItem.h"
 #include "guilib/LocalizeStrings.h"

--- a/xbmc/guilib/GUIAudioManager.cpp
+++ b/xbmc/guilib/GUIAudioManager.cpp
@@ -20,7 +20,7 @@
 
 #include "system.h"
 #include "GUIAudioManager.h"
-#include "Key.h"
+#include "input/Key.h"
 #include "input/ButtonTranslator.h"
 #include "settings/lib/Setting.h"
 #include "threads/SingleLock.h"

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -28,7 +28,7 @@
 #include "utils/SortUtils.h"
 #include "utils/StringUtils.h"
 #include "FileItem.h"
-#include "Key.h"
+#include "input/Key.h"
 #include "utils/MathUtils.h"
 #include "utils/XBMCTinyXML.h"
 #include "listproviders/IListProvider.h"

--- a/xbmc/guilib/GUIButtonControl.cpp
+++ b/xbmc/guilib/GUIButtonControl.cpp
@@ -22,7 +22,7 @@
 #include "GUIWindowManager.h"
 #include "GUIDialog.h"
 #include "GUIFontManager.h"
-#include "Key.h"
+#include "input/Key.h"
 
 using namespace std;
 

--- a/xbmc/guilib/GUICheckMarkControl.cpp
+++ b/xbmc/guilib/GUICheckMarkControl.cpp
@@ -20,7 +20,7 @@
 
 #include "GUICheckMarkControl.h"
 #include "GUIFontManager.h"
-#include "Key.h"
+#include "input/Key.h"
 
 using namespace std;
 

--- a/xbmc/guilib/GUIControl.cpp
+++ b/xbmc/guilib/GUIControl.cpp
@@ -27,7 +27,7 @@
 #include "GUIControlProfiler.h"
 #include "input/MouseStat.h"
 #include "input/InputManager.h"
-#include "Key.h"
+#include "input/Key.h"
 
 using namespace std;
 

--- a/xbmc/guilib/GUIControl.cpp
+++ b/xbmc/guilib/GUIControl.cpp
@@ -26,6 +26,7 @@
 #include "GUIWindowManager.h"
 #include "GUIControlProfiler.h"
 #include "input/MouseStat.h"
+#include "input/InputManager.h"
 #include "Key.h"
 
 using namespace std;
@@ -547,8 +548,8 @@ EVENT_RESULT CGUIControl::SendMouseEvent(const CPoint &point, const CMouseEvent 
 // override this function to implement custom mouse behaviour
 bool CGUIControl::OnMouseOver(const CPoint &point)
 {
-  if (g_Mouse.GetState() != MOUSE_STATE_DRAG)
-    g_Mouse.SetState(MOUSE_STATE_FOCUS);
+  if (CInputManager::Get().GetMouseState() != MOUSE_STATE_DRAG)
+    CInputManager::Get().SetMouseState(MOUSE_STATE_FOCUS);
   if (!CanFocus()) return false;
   if (!HasFocus())
   {

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -55,7 +55,7 @@
 #include "GUIListLabel.h"
 #include "GUIListGroup.h"
 #include "GUIInfoManager.h"
-#include "Key.h"
+#include "input/Key.h"
 #include "addons/Skin.h"
 #include "utils/CharsetConverter.h"
 #include "utils/log.h"

--- a/xbmc/guilib/GUIControlGroupList.cpp
+++ b/xbmc/guilib/GUIControlGroupList.cpp
@@ -19,7 +19,7 @@
  */
 
 #include "GUIControlGroupList.h"
-#include "Key.h"
+#include "input/Key.h"
 #include "GUIInfoManager.h"
 #include "GUIControlProfiler.h"
 #include "GUIFont.h" // for XBFONT_* definitions

--- a/xbmc/guilib/GUIDialog.cpp
+++ b/xbmc/guilib/GUIDialog.cpp
@@ -26,7 +26,7 @@
 #include "utils/TimeUtils.h"
 #include "Application.h"
 #include "ApplicationMessenger.h"
-#include "Key.h"
+#include "input/Key.h"
 
 CGUIDialog::CGUIDialog(int id, const std::string &xmlFile)
     : CGUIWindow(id, xmlFile)

--- a/xbmc/guilib/GUIEditControl.cpp
+++ b/xbmc/guilib/GUIEditControl.cpp
@@ -24,7 +24,7 @@
 #include "GUIKeyboardFactory.h"
 #include "dialogs/GUIDialogNumeric.h"
 #include "input/XBMC_vkeys.h"
-#include "Key.h"
+#include "input/Key.h"
 #include "LocalizeStrings.h"
 #include "XBDateTime.h"
 #include "windowing/WindowingFactory.h"

--- a/xbmc/guilib/GUIFixedListContainer.cpp
+++ b/xbmc/guilib/GUIFixedListContainer.cpp
@@ -20,7 +20,7 @@
 
 #include "GUIFixedListContainer.h"
 #include "GUIListItem.h"
-#include "Key.h"
+#include "input/Key.h"
 
 CGUIFixedListContainer::CGUIFixedListContainer(int parentID, int controlID, float posX, float posY, float width, float height, ORIENTATION orientation, const CScroller& scroller, int preloadItems, int fixedPosition, int cursorRange)
     : CGUIBaseContainer(parentID, controlID, posX, posY, width, height, orientation, scroller, preloadItems)

--- a/xbmc/guilib/GUIListContainer.cpp
+++ b/xbmc/guilib/GUIListContainer.cpp
@@ -21,7 +21,7 @@
 #include "system.h"
 #include "GUIListContainer.h"
 #include "GUIListItem.h"
-#include "Key.h"
+#include "input/Key.h"
 #include "utils/StringUtils.h"
 
 CGUIListContainer::CGUIListContainer(int parentID, int controlID, float posX, float posY, float width, float height, ORIENTATION orientation, const CScroller& scroller, int preloadItems)

--- a/xbmc/guilib/GUIMoverControl.cpp
+++ b/xbmc/guilib/GUIMoverControl.cpp
@@ -20,7 +20,7 @@
 
 #include "GUIMoverControl.h"
 #include "GUIWindowManager.h"
-#include "Key.h"
+#include "input/Key.h"
 #include "utils/TimeUtils.h"
 
 // time to reset accelerated cursors (digital movement)

--- a/xbmc/guilib/GUIMultiImage.cpp
+++ b/xbmc/guilib/GUIMultiImage.cpp
@@ -25,7 +25,7 @@
 #include "utils/JobManager.h"
 #include "FileItem.h"
 #include "settings/AdvancedSettings.h"
-#include "Key.h"
+#include "input/Key.h"
 #include "TextureCache.h"
 #include "WindowIDs.h"
 #include "utils/StringUtils.h"

--- a/xbmc/guilib/GUIMultiSelectText.cpp
+++ b/xbmc/guilib/GUIMultiSelectText.cpp
@@ -20,7 +20,7 @@
 
 #include "GUIMultiSelectText.h"
 #include "GUIWindowManager.h"
-#include "Key.h"
+#include "input/Key.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
 

--- a/xbmc/guilib/GUIPanelContainer.cpp
+++ b/xbmc/guilib/GUIPanelContainer.cpp
@@ -21,7 +21,7 @@
 #include "GUIPanelContainer.h"
 #include "GUIListItem.h"
 #include "GUIInfoManager.h"
-#include "Key.h"
+#include "input/Key.h"
 
 #include <cassert>
 

--- a/xbmc/guilib/GUIRadioButtonControl.cpp
+++ b/xbmc/guilib/GUIRadioButtonControl.cpp
@@ -21,7 +21,7 @@
 #include "GUIRadioButtonControl.h"
 #include "GUIInfoManager.h"
 #include "GUIFontManager.h"
-#include "Key.h"
+#include "input/Key.h"
 
 CGUIRadioButtonControl::CGUIRadioButtonControl(int parentID, int controlID, float posX, float posY, float width, float height,
     const CTextureInfo& textureFocus, const CTextureInfo& textureNoFocus,

--- a/xbmc/guilib/GUIResizeControl.cpp
+++ b/xbmc/guilib/GUIResizeControl.cpp
@@ -20,7 +20,7 @@
 
 #include "GUIResizeControl.h"
 #include "GUIWindowManager.h"
-#include "Key.h"
+#include "input/Key.h"
 #include "utils/TimeUtils.h"
 
 // time to reset accelerated cursors (digital movement)

--- a/xbmc/guilib/GUIScrollBarControl.cpp
+++ b/xbmc/guilib/GUIScrollBarControl.cpp
@@ -19,7 +19,7 @@
  */
 
 #include "GUIScrollBarControl.h"
-#include "Key.h"
+#include "input/Key.h"
 #include "utils/StringUtils.h"
 
 #define MIN_NIB_SIZE 4.0f

--- a/xbmc/guilib/GUISelectButtonControl.cpp
+++ b/xbmc/guilib/GUISelectButtonControl.cpp
@@ -21,7 +21,7 @@
 #include "GUISelectButtonControl.h"
 #include "GUIWindowManager.h"
 #include "utils/TimeUtils.h"
-#include "Key.h"
+#include "input/Key.h"
 
 CGUISelectButtonControl::CGUISelectButtonControl(int parentID, int controlID,
     float posX, float posY,

--- a/xbmc/guilib/GUISliderControl.cpp
+++ b/xbmc/guilib/GUISliderControl.cpp
@@ -20,7 +20,7 @@
 
 #include "GUISliderControl.h"
 #include "GUIInfoManager.h"
-#include "Key.h"
+#include "input/Key.h"
 #include "utils/MathUtils.h"
 #include "utils/StringUtils.h"
 #include "GUIWindowManager.h"

--- a/xbmc/guilib/GUISpinControl.cpp
+++ b/xbmc/guilib/GUISpinControl.cpp
@@ -19,7 +19,7 @@
  */
 
 #include "GUISpinControl.h"
-#include "Key.h"
+#include "input/Key.h"
 #include "utils/StringUtils.h"
 #include <stdio.h>
 

--- a/xbmc/guilib/GUIToggleButtonControl.cpp
+++ b/xbmc/guilib/GUIToggleButtonControl.cpp
@@ -22,7 +22,7 @@
 #include "GUIWindowManager.h"
 #include "GUIDialog.h"
 #include "GUIInfoManager.h"
-#include "Key.h"
+#include "input/Key.h"
 
 using namespace std;
 

--- a/xbmc/guilib/GUIVideoControl.cpp
+++ b/xbmc/guilib/GUIVideoControl.cpp
@@ -22,7 +22,7 @@
 #include "GUIVideoControl.h"
 #include "GUIWindowManager.h"
 #include "Application.h"
-#include "Key.h"
+#include "input/Key.h"
 #include "WindowIDs.h"
 #include "cores/IPlayer.h"
 #ifdef HAS_VIDEO_PLAYBACK

--- a/xbmc/guilib/GUIVisualisationControl.cpp
+++ b/xbmc/guilib/GUIVisualisationControl.cpp
@@ -26,7 +26,7 @@
 #include "addons/Visualisation.h"
 #include "utils/log.h"
 #include "guilib/IRenderingCallback.h"
-#include "Key.h"
+#include "input/Key.h"
 
 using namespace std;
 using namespace ADDON;

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -21,7 +21,7 @@
 #include "system.h"
 #include "GUIWindow.h"
 #include "GUIWindowManager.h"
-#include "Key.h"
+#include "input/Key.h"
 #include "LocalizeStrings.h"
 #include "GUIControlFactory.h"
 #include "GUIControlGroup.h"

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -33,7 +33,7 @@
 #include "GUITexture.h"
 #include "windowing/WindowingFactory.h"
 #include "utils/Variant.h"
-#include "Key.h"
+#include "input/Key.h"
 #include "utils/StringUtils.h"
 
 #include "windows/GUIWindowHome.h"

--- a/xbmc/guilib/GUIWrappingListContainer.cpp
+++ b/xbmc/guilib/GUIWrappingListContainer.cpp
@@ -20,7 +20,7 @@
 
 #include "GUIWrappingListContainer.h"
 #include "FileItem.h"
-#include "Key.h"
+#include "input/Key.h"
 #include "utils/log.h"
 
 CGUIWrappingListContainer::CGUIWrappingListContainer(int parentID, int controlID, float posX, float posY, float width, float height, ORIENTATION orientation, const CScroller& scroller, int preloadItems, int fixedPosition)

--- a/xbmc/guilib/GraphicContext.cpp
+++ b/xbmc/guilib/GraphicContext.cpp
@@ -30,7 +30,7 @@
 #include "cores/VideoRenderers/RenderManager.h"
 #include "windowing/WindowingFactory.h"
 #include "TextureManager.h"
-#include "input/MouseStat.h"
+#include "input/InputManager.h"
 #include "GUIWindowManager.h"
 #include "utils/JobManager.h"
 #include "video/VideoReferenceClock.h"
@@ -489,7 +489,7 @@ void CGraphicContext::SetVideoResolutionInternal(RESOLUTION res, bool forceUpdat
 
   // update anyone that relies on sizing information
   g_renderManager.Recover();
-  g_Mouse.SetResolution(info_org.iWidth, info_org.iHeight, 1, 1);
+  CInputManager::Get().SetMouseResolution(info_org.iWidth, info_org.iHeight, 1, 1);
   g_windowManager.SendMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_WINDOW_RESIZE);
 
   Unlock();

--- a/xbmc/guilib/Makefile.in
+++ b/xbmc/guilib/Makefile.in
@@ -66,7 +66,6 @@ SRCS += GUIWrappingListContainer.cpp
 SRCS += imagefactory.cpp
 SRCS += IWindowManagerCallback.cpp
 SRCS += JpegIO.cpp
-SRCS += Key.cpp
 SRCS += LocalizeStrings.cpp
 SRCS += Shader.cpp
 SRCS += StereoscopicsManager.cpp

--- a/xbmc/guilib/StereoscopicsManager.cpp
+++ b/xbmc/guilib/StereoscopicsManager.cpp
@@ -34,7 +34,7 @@
 #include "GUIInfoManager.h"
 #include "GUIUserMessages.h"
 #include "guilib/LocalizeStrings.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "guilib/GUIWindowManager.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/lib/ISettingCallback.h"

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -23,7 +23,7 @@
 #include "ButtonTranslator.h"
 #include "profiles/ProfilesManager.h"
 #include "utils/URIUtils.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "guilib/WindowIDs.h"
 #include "input/XBMC_keysym.h"
 #include "input/XBMC_keytable.h"

--- a/xbmc/input/InertialScrollingHandler.cpp
+++ b/xbmc/input/InertialScrollingHandler.cpp
@@ -23,7 +23,7 @@
 #include "InertialScrollingHandler.h"
 #include "Application.h"
 #include "utils/TimeUtils.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "guilib/GUIWindowManager.h"
 #include "windowing/WindowingFactory.h"
 

--- a/xbmc/input/InputManager.cpp
+++ b/xbmc/input/InputManager.cpp
@@ -57,6 +57,7 @@
 #endif
 #include "ButtonTranslator.h"
 #include "peripherals/Peripherals.h"
+#include "peripherals/devices/PeripheralImon.h"
 #include "XBMC_vkeys.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
@@ -70,10 +71,10 @@
 #endif
 
 #ifdef HAS_EVENT_SERVER
-using namespace EVENTSERVER;
+using EVENTSERVER::CEventServer;
 #endif
 
-using namespace PERIPHERALS;
+using PERIPHERALS::CPeripherals;
 
 CInputManager& CInputManager::Get()
 {
@@ -781,5 +782,21 @@ void CInputManager::SetRemoteControlName(const std::string& name)
 {
 #if defined(HAS_LIRC)
   m_RemoteControl.setDeviceName(name);
+#endif
+}
+
+void CInputManager::OnSettingChanged(const CSetting *setting)
+{
+  if (setting == nullptr)
+    return;
+
+  const std::string &settingId = setting->GetId();
+  if (settingId == "input.enablemouse")
+    m_Mouse.SetEnabled(dynamic_cast<const CSettingBool*>(setting)->GetValue());
+
+#if defined(HAS_SDL_JOYSTICK)
+  if (settingId == "input.enablejoystick")
+    m_Joystick.SetEnabled(dynamic_cast<const CSettingBool*>(setting)->GetValue() &&
+    PERIPHERALS::CPeripheralImon::GetCountOfImonsConflictWithDInput() == 0);
 #endif
 }

--- a/xbmc/input/InputManager.cpp
+++ b/xbmc/input/InputManager.cpp
@@ -67,7 +67,7 @@ using namespace EVENTSERVER;
 
 using namespace PERIPHERALS;
 
-CInputManager& CInputManager::GetInstance()
+CInputManager& CInputManager::Get()
 {
   static CInputManager inputManager;
   return inputManager;

--- a/xbmc/input/InputManager.cpp
+++ b/xbmc/input/InputManager.cpp
@@ -18,12 +18,11 @@
 *
 */
 
-#include <map>
-#include <string>
 #include <math.h>
 
 #include "Application.h"
 #include "InputManager.h"
+#include "input/Key.h"
 #include "ApplicationMessenger.h"
 #include "guilib/Geometry.h"
 #include "guilib/GUIAudioManager.h"
@@ -89,7 +88,7 @@ void CInputManager::InitializeInputs()
 #endif
 
 #ifdef HAS_SDL_JOYSTICK
-  // Pass the mapping of axis to triggers to m_Joystick 
+  // Pass the mapping of axis to triggers to m_Joystick
   m_Joystick.Initialize();
 #endif
 

--- a/xbmc/input/InputManager.cpp
+++ b/xbmc/input/InputManager.cpp
@@ -58,7 +58,6 @@
 #include "ButtonTranslator.h"
 #include "input/MouseStat.h"
 #include "peripherals/Peripherals.h"
-#include "input/KeyboardStat.h"
 #include "XBMC_vkeys.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
@@ -88,8 +87,9 @@ void CInputManager::InitializeInputs()
   // Pass the mapping of axis to triggers to m_Joystick 
   m_Joystick.Initialize();
 #endif
-}
 
+  m_Keyboard.Initialize();
+}
 
 void CInputManager::ReInitializeJoystick()
 {
@@ -420,10 +420,10 @@ bool CInputManager::OnEvent(XBMC_Event& newEvent)
   switch (newEvent.type)
   {
   case XBMC_KEYDOWN:
-    OnKey(g_Keyboard.ProcessKeyDown(newEvent.key.keysym));
+    OnKey(m_Keyboard.ProcessKeyDown(newEvent.key.keysym));
     break;
   case XBMC_KEYUP:
-    g_Keyboard.ProcessKeyUp();
+    m_Keyboard.ProcessKeyUp();
     break;
   case XBMC_MOUSEBUTTONDOWN:
   case XBMC_MOUSEBUTTONUP:
@@ -512,7 +512,7 @@ bool CInputManager::OnKey(const CKey& key)
   // allow some keys to be processed while the screensaver is active
   if (g_application.WakeUpScreenSaverAndDPMS(processKey) && !processKey)
   {
-    CLog::LogF(LOGDEBUG, "%s pressed, screen saver/dpms woken up", g_Keyboard.GetKeyName((int)key.GetButtonCode()).c_str());
+    CLog::LogF(LOGDEBUG, "%s pressed, screen saver/dpms woken up", m_Keyboard.GetKeyName((int)key.GetButtonCode()).c_str());
     return true;
   }
 
@@ -596,7 +596,7 @@ bool CInputManager::OnKey(const CKey& key)
         }
       }
 
-      CLog::LogF(LOGDEBUG, "%s pressed, trying keyboard action %x", g_Keyboard.GetKeyName((int)key.GetButtonCode()).c_str(), action.GetID());
+      CLog::LogF(LOGDEBUG, "%s pressed, trying keyboard action %x", m_Keyboard.GetKeyName((int)key.GetButtonCode()).c_str(), action.GetID());
 
       if (g_application.OnAction(action))
         return true;
@@ -611,7 +611,7 @@ bool CInputManager::OnKey(const CKey& key)
       action = CButtonTranslator::GetInstance().GetAction(iWin, key);
   }
   if (!key.IsAnalogButton())
-    CLog::LogF(LOGDEBUG, "%s pressed, action is %s", g_Keyboard.GetKeyName((int)key.GetButtonCode()).c_str(), action.GetName().c_str());
+    CLog::LogF(LOGDEBUG, "%s pressed, action is %s", m_Keyboard.GetKeyName((int)key.GetButtonCode()).c_str(), action.GetName().c_str());
 
   return ExecuteInputAction(action);
 }

--- a/xbmc/input/InputManager.h
+++ b/xbmc/input/InputManager.h
@@ -29,6 +29,7 @@
 #endif
 #include "windowing/XBMC_events.h"
 #include "guilib/Key.h"
+#include "input/KeyboardStat.h"
 
 class CInputManager
 {
@@ -140,6 +141,8 @@ private:
   * \sa CAction
   */
   bool ExecuteInputAction(const CAction &action);
+
+  CKeyboardStat m_Keyboard;
 
 #ifdef HAS_EVENT_SERVER
   std::map<std::string, std::map<int, float> > m_lastAxisMap;

--- a/xbmc/input/InputManager.h
+++ b/xbmc/input/InputManager.h
@@ -21,12 +21,20 @@
 
 #include <map>
 #include <string>
+#include <vector>
 
 #if defined(TARGET_WINDOWS)
 #include "input/windows/WINJoystick.h"
 #elif defined(HAS_SDL_JOYSTICK) || defined(HAS_EVENT_SERVER)
 #include "input/SDLJoystick.h"
 #endif
+#if defined(HAS_LIRC)
+#include "input/linux/LIRC.h"
+#endif
+#if defined(HAS_IRSERVERSUITE)
+#include "input/windows/IRServerSuite.h"
+#endif
+
 #include "windowing/XBMC_events.h"
 #include "guilib/Key.h"
 #include "input/KeyboardStat.h"
@@ -82,6 +90,14 @@ public:
   \return true if event is handled, false otherwise
   */
   bool ProcessPeripherals(float frameTime);
+
+  /*! \brief Process all inputs
+   *
+   * \param windowId Currently active window
+   * \param frameTime Time in seconds since last call
+   * \return true on success, false otherwise
+   */
+  bool Process(int windowId, float frameTime);
 
   /*!
    * \brief Call once during application startup to initialize peripherals that need it
@@ -164,6 +180,38 @@ public:
    */
   void SetMouseResolution(int maxX, int maxY, float speedX, float speedY);
 
+  /*! \brief Enable the remote control
+   *
+   */
+  void EnableRemoteControl();
+
+  /*! \brief Disable the remote control
+   *
+   */
+  void DisableRemoteControl();
+
+  /*! \brief Check if the remote control is enabled
+   *
+   * \return true if remote control is enabled, false otherwise 
+   */
+  bool IsRemoteControlEnabled();
+
+  /*! \brief Set the device name to use with LIRC, does nothing 
+   *   if IRServerSuite is used
+   *
+   * \param[in] name Name of the device to use with LIRC
+   */
+  void SetRemoteControlName(const std::string& name);
+
+  /*! \brief Parse a builtin command and execute any input action
+   *  currently only LIRC commands implemented
+   *
+   * \param[in] execute Command to execute
+   * \param[in] params  parameters that was passed to the command
+   * \return 0 on success, -1 on failure
+   */
+  int ExecuteBuiltin(const std::string& execute, const std::vector<std::string>& params);
+
 private:
 
   /*! \brief Process keyboard event and translate into an action
@@ -194,6 +242,10 @@ private:
 
   CKeyboardStat m_Keyboard;
   CMouseStat m_Mouse;
+
+#if defined(HAS_LIRC) || defined(HAS_IRSERVERSUITE)
+  CRemoteControl m_RemoteControl;
+#endif
 
 #ifdef HAS_EVENT_SERVER
   std::map<std::string, std::map<int, float> > m_lastAxisMap;

--- a/xbmc/input/InputManager.h
+++ b/xbmc/input/InputManager.h
@@ -30,6 +30,7 @@
 #include "windowing/XBMC_events.h"
 #include "guilib/Key.h"
 #include "input/KeyboardStat.h"
+#include "input/MouseStat.h"
 
 class CInputManager
 {
@@ -114,6 +115,55 @@ public:
    */
   bool OnEvent(XBMC_Event& newEvent);
 
+  /*! \brief Control if the mouse is actively used or not
+   *
+   * \param[in] active sets mouse active or inactive
+   */
+  void SetMouseActive(bool active = true);
+
+  /*! \brief Control if we should use a mouse or not
+   *
+   * \param[in] mouseEnabled sets mouse enabled or disabled
+   */
+  void SetMouseEnabled(bool mouseEnabled = true);
+
+  /*! \brief Set the current state of the mouse such as click, drag operation
+   *
+   * \param[in] mouseState which state the mouse should be set to
+   * \sa MOUSE_STATE
+   */
+  void SetMouseState(MOUSE_STATE mouseState);
+
+  /*! \brief Check if the mouse is currently active
+   *
+   * \return true if active, false otherwise 
+   */
+  bool IsMouseActive();
+
+  /*! \brief Get the current state of the mouse, such as click or drag operation
+   *
+   * \return the current state of the mouse as a value from MOUSE_STATE
+   * \sa MOUSE_STATE
+   */
+  MOUSE_STATE GetMouseState();
+
+  /*! \brief Get the current mouse positions x and y coordinates
+   *
+   * \return a struct containing the x and y coordinates
+   * \sa MousePosition
+   */
+  MousePosition GetMousePosition();
+
+  /*! \brief Set the current screen resolution and pointer speed
+   *
+   * \param[in] maxX    screen width
+   * \param[in] maxY    screen height
+   * \param[in] speedX  mouse speed in x dimension
+   * \param[in] speedY  mouse speed in y dimension
+   * \return 
+   */
+  void SetMouseResolution(int maxX, int maxY, float speedX, float speedY);
+
 private:
 
   /*! \brief Process keyboard event and translate into an action
@@ -143,6 +193,7 @@ private:
   bool ExecuteInputAction(const CAction &action);
 
   CKeyboardStat m_Keyboard;
+  CMouseStat m_Mouse;
 
 #ifdef HAS_EVENT_SERVER
   std::map<std::string, std::map<int, float> > m_lastAxisMap;

--- a/xbmc/input/InputManager.h
+++ b/xbmc/input/InputManager.h
@@ -41,7 +41,7 @@ private:
 public:
   /*! \brief static method to get the current instance of the class. Creates a new instance the first time it's called.
   */
-  static CInputManager& GetInstance();
+  static CInputManager& Get();
 
   /*! \brief decode an input event from remote controls.
 

--- a/xbmc/input/InputManager.h
+++ b/xbmc/input/InputManager.h
@@ -27,6 +27,8 @@
 #elif defined(HAS_SDL_JOYSTICK) || defined(HAS_EVENT_SERVER)
 #include "input/SDLJoystick.h"
 #endif
+#include "windowing/XBMC_events.h"
+#include "guilib/Key.h"
 
 class CInputManager
 {
@@ -79,8 +81,22 @@ public:
   */
   bool ProcessPeripherals(float frameTime);
 
+  /*!
+   * \brief Call once during application startup to initialize peripherals that need it
+   */
+  void InitializeInputs();
+
+  /*! \brief Enable or disable the joystick
+   *
+   * \param enabled true to enable joystick, false to disable
+   * \return void
+   */
   void SetEnabledJoystick(bool enabled = true);
 
+  /*! \brief Run joystick initialization again, e.g. a new device is connected
+  *
+  * \return void
+  */
   void ReInitializeJoystick();
 
   bool ProcessJoystickEvent(int windowId, const std::string& joystickName, int wKeyID, short inputType, float fAmount, unsigned int holdTime = 0);
@@ -89,7 +105,42 @@ public:
   void UpdateJoystick(SDL_Event& joyEvent);
 #endif
 
+  /*! \brief Handle an input event
+   * 
+   * \param newEvent event details
+   * \return true on succesfully handled event
+   * \sa XBMC_Event
+   */
+  bool OnEvent(XBMC_Event& newEvent);
+
 private:
+
+  /*! \brief Process keyboard event and translate into an action
+  *
+  * \param CKey keypress details
+  * \return true on succesfully handled event
+  * \sa CKey
+  */
+  bool OnKey(const CKey& key);
+
+  /*! \brief Determine if an action should be processed or just
+  *   cancel the screensaver
+  *
+  * \param action Action that is about to be processed
+  * \return true on any poweractions such as shutdown/reboot/sleep/suspend, false otherwise
+  * \sa CAction
+  */
+  bool AlwaysProcess(const CAction& action);
+
+  /*! \brief Send the Action to CApplication for further handling,
+  *   play a sound before or after sending the action.
+  *
+  * \param action Action to send to CApplication
+  * \return result from CApplication::OnAction
+  * \sa CAction
+  */
+  bool ExecuteInputAction(const CAction &action);
+
 #ifdef HAS_EVENT_SERVER
   std::map<std::string, std::map<int, float> > m_lastAxisMap;
 #endif

--- a/xbmc/input/InputManager.h
+++ b/xbmc/input/InputManager.h
@@ -39,16 +39,15 @@
 #include "guilib/Key.h"
 #include "input/KeyboardStat.h"
 #include "input/MouseStat.h"
+#include "settings/lib/ISettingCallback.h"
 
-class CInputManager
+class CInputManager : public ISettingCallback
 {
 private:
   CInputManager() { }
   CInputManager(const CInputManager&);
   CInputManager const& operator=(CInputManager const&);
   virtual ~CInputManager() { };
-
-  friend class CSettings;
 
 public:
   /*! \brief static method to get the current instance of the class. Creates a new instance the first time it's called.
@@ -211,6 +210,8 @@ public:
    * \return 0 on success, -1 on failure
    */
   int ExecuteBuiltin(const std::string& execute, const std::vector<std::string>& params);
+
+  virtual void OnSettingChanged(const CSetting *setting);
 
 private:
 

--- a/xbmc/input/InputManager.h
+++ b/xbmc/input/InputManager.h
@@ -36,10 +36,11 @@
 #endif
 
 #include "windowing/XBMC_events.h"
-#include "guilib/Key.h"
 #include "input/KeyboardStat.h"
 #include "input/MouseStat.h"
 #include "settings/lib/ISettingCallback.h"
+
+class CKey;
 
 class CInputManager : public ISettingCallback
 {
@@ -248,7 +249,7 @@ private:
   CRemoteControl m_RemoteControl;
 #endif
 
-#ifdef HAS_EVENT_SERVER
+#if defined(HAS_EVENT_SERVER)
   std::map<std::string, std::map<int, float> > m_lastAxisMap;
 #endif
 

--- a/xbmc/input/Key.cpp
+++ b/xbmc/input/Key.cpp
@@ -19,7 +19,7 @@
  */
 
 #include "system.h"
-#include "Key.h"
+#include "input/Key.h"
 
 CKey::CKey(void)
 {

--- a/xbmc/input/Key.h
+++ b/xbmc/input/Key.h
@@ -2,10 +2,6 @@
  \file Key.h
  \brief
  */
-
-#ifndef GUILIB_KEY
-#define GUILIB_KEY
-
 #pragma once
 
 /*
@@ -560,6 +556,4 @@ private:
   bool m_fromService;
 };
 #endif //undef SWIG
-
-#endif
 

--- a/xbmc/input/KeyboardStat.cpp
+++ b/xbmc/input/KeyboardStat.cpp
@@ -35,7 +35,6 @@
 using namespace std;
 using namespace PERIPHERALS;
 
-CKeyboardStat g_Keyboard;
 
 CKeyboardStat::CKeyboardStat()
 {

--- a/xbmc/input/KeyboardStat.h
+++ b/xbmc/input/KeyboardStat.h
@@ -40,7 +40,7 @@
 #include <string>
 
 #include "windowing/XBMC_events.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "input/XBMC_keyboard.h"
 
 class CKeyboardStat

--- a/xbmc/input/KeyboardStat.h
+++ b/xbmc/input/KeyboardStat.h
@@ -37,8 +37,11 @@
 // but this allows for double/redundant or ambiguous mapping definition, e.g.
 // ASCII/unicode could be derived from scancodes, virtual keys, modifiers and/or other ASCII/unicode.
 
+#include <string>
+
 #include "windowing/XBMC_events.h"
 #include "guilib/Key.h"
+#include "input/XBMC_keyboard.h"
 
 class CKeyboardStat
 {
@@ -59,7 +62,5 @@ private:
   XBMC_keysym m_lastKeysym;
   unsigned int m_lastKeyTime;
 };
-
-extern CKeyboardStat g_Keyboard;
 
 #endif

--- a/xbmc/input/Makefile
+++ b/xbmc/input/Makefile
@@ -7,6 +7,7 @@ SRCS=ButtonTranslator.cpp \
      SDLJoystick.cpp \
      XBMC_keytable.cpp \
      InputManager.cpp \
+     Key.cpp
      
 LIB=input.a
 

--- a/xbmc/input/MouseStat.cpp
+++ b/xbmc/input/MouseStat.cpp
@@ -19,7 +19,7 @@
  */
 
 #include "MouseStat.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "settings/lib/Setting.h"
 #include "utils/TimeUtils.h"
 #include "windowing/WindowingFactory.h"

--- a/xbmc/input/MouseStat.cpp
+++ b/xbmc/input/MouseStat.cpp
@@ -38,16 +38,6 @@ CMouseStat::~CMouseStat()
 {
 }
 
-void CMouseStat::OnSettingChanged(const CSetting *setting)
-{
-  if (setting == NULL)
-    return;
-
-  const std::string &settingId = setting->GetId();
-  if (settingId == "input.enablemouse")
-    SetEnabled(((CSettingBool*)setting)->GetValue());
-}
-
 void CMouseStat::Initialize()
 {
   // Set the default resolution (PAL)

--- a/xbmc/input/MouseStat.h
+++ b/xbmc/input/MouseStat.h
@@ -21,7 +21,6 @@
  *
  */
 
-#include "settings/lib/ISettingCallback.h"
 #include "windowing/XBMC_events.h"
 
 #define XBMC_BUTTON(X)		(1 << ((X)-1))
@@ -73,13 +72,11 @@ struct MousePosition
 
 class CAction;
 
-class CMouseStat : public ISettingCallback
+class CMouseStat
 {
 public:
   CMouseStat();
   virtual ~CMouseStat();
-
-  virtual void OnSettingChanged(const CSetting *setting);
 
   void Initialize();
   void HandleEvent(XBMC_Event& newEvent);

--- a/xbmc/input/MouseStat.h
+++ b/xbmc/input/MouseStat.h
@@ -44,7 +44,13 @@
 
 #define MOUSE_MAX_BUTTON 5
 
-enum MOUSE_STATE { MOUSE_STATE_NORMAL = 1, MOUSE_STATE_FOCUS, MOUSE_STATE_DRAG, MOUSE_STATE_CLICK };
+enum MOUSE_STATE 
+{ 
+  MOUSE_STATE_NORMAL = 1, /*! < Normal state */
+  MOUSE_STATE_FOCUS,      /*! < Control below the mouse is currently in focus */
+  MOUSE_STATE_DRAG,       /*! < A drag operation is being performed */
+  MOUSE_STATE_CLICK       /*! < A mousebutton is being clicked */
+};
 enum MOUSE_BUTTON { MOUSE_LEFT_BUTTON = 0, MOUSE_RIGHT_BUTTON, MOUSE_MIDDLE_BUTTON, MOUSE_EXTRA_BUTTON1, MOUSE_EXTRA_BUTTON2 };
 
 // this holds everything we know about the current state of the mouse
@@ -57,6 +63,12 @@ struct MouseState
   int8_t dz;          // change in z (wheel)
   bool button[MOUSE_MAX_BUTTON];     // current state of the buttons
   bool active;        // true if the mouse is active
+};
+
+struct MousePosition
+{
+  int x;
+  int y;
 };
 
 class CAction;
@@ -86,6 +98,7 @@ public:
   inline int GetY(void) const { return m_mouseState.y; }
   inline int GetDX(void) const { return m_mouseState.dx; }
   inline int GetDY(void) const { return m_mouseState.dy; }
+  MousePosition GetPosition() { return MousePosition{ m_mouseState.x, m_mouseState.y }; }
 
 private:
   /*! \brief Holds information regarding a particular mouse button state
@@ -174,8 +187,6 @@ private:
 
   uint32_t m_Key;
 };
-
-extern CMouseStat g_Mouse;
 
 #endif
 

--- a/xbmc/input/SDLJoystick.cpp
+++ b/xbmc/input/SDLJoystick.cpp
@@ -21,7 +21,6 @@
 #include "system.h"
 #include "SDLJoystick.h"
 #include "input/ButtonTranslator.h"
-#include "peripherals/devices/PeripheralImon.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/lib/Setting.h"
 #include "utils/log.h"
@@ -40,16 +39,6 @@ CJoystick::CJoystick()
   m_joystickEnabled = false;
   SetDeadzone(0);
   Reset();
-}
-
-void CJoystick::OnSettingChanged(const CSetting *setting)
-{
-  if (setting == NULL)
-    return;
-
-  const std::string &settingId = setting->GetId();
-  if (settingId == "input.enablejoystick")
-    SetEnabled(((CSettingBool*)setting)->GetValue() && PERIPHERALS::CPeripheralImon::GetCountOfImonsConflictWithDInput() == 0);
 }
 
 void CJoystick::Reset()

--- a/xbmc/input/SDLJoystick.h
+++ b/xbmc/input/SDLJoystick.h
@@ -22,7 +22,6 @@
 #define SDL_JOYSTICK_H
 
 #include "system.h" // for HAS_SDL_JOYSTICK
-#include "settings/lib/ISettingCallback.h"
 #include <vector>
 #include <string>
 #include <map>
@@ -67,12 +66,10 @@ class CRegExp;
 // Class to manage all connected joysticks
 // Note: 'index' always refers to indices specific to this class,
 //       whereas 'ids' always refer to SDL instance id's
-class CJoystick : public ISettingCallback
+class CJoystick
 {
 public:
   CJoystick();
-
-  virtual void OnSettingChanged(const CSetting *setting);
 
   void Initialize();
   void Reset();

--- a/xbmc/input/linux/LIRC.cpp
+++ b/xbmc/input/linux/LIRC.cpp
@@ -37,8 +37,6 @@
 #include "settings/AdvancedSettings.h"
 #include "utils/TimeUtils.h"
 
-CRemoteControl g_RemoteControl;
-
 CRemoteControl::CRemoteControl():
   m_deviceName(LIRC_DEVICE)
 {

--- a/xbmc/input/linux/LIRC.h
+++ b/xbmc/input/linux/LIRC.h
@@ -65,6 +65,4 @@ private:
   int         m_nrSending;
 };
 
-extern CRemoteControl g_RemoteControl;
-
 #endif

--- a/xbmc/input/touch/generic/GenericTouchActionHandler.cpp
+++ b/xbmc/input/touch/generic/GenericTouchActionHandler.cpp
@@ -21,7 +21,7 @@
 #include "GenericTouchActionHandler.h"
 #include "ApplicationMessenger.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "windowing/WinEvents.h"
 
 CGenericTouchActionHandler &CGenericTouchActionHandler::Get()

--- a/xbmc/input/windows/IRServerSuite.cpp
+++ b/xbmc/input/windows/IRServerSuite.cpp
@@ -29,8 +29,6 @@
 
 #define IRSS_PORT 24000
 
-CRemoteControl g_RemoteControl;
-
 CRemoteControl::CRemoteControl() : CThread("RemoteControl")
 {
   m_socket = INVALID_SOCKET;
@@ -75,7 +73,8 @@ void CRemoteControl::Reset()
 
 void CRemoteControl::Initialize()
 {
-  if (m_isConnecting || m_bInitialized) return;
+  if (m_isConnecting || m_bInitialized || IsRunning())
+    return;
   //trying to connect when there is nothing to connect to is kinda slow so kick it off in a thread.
   Create();
 }

--- a/xbmc/input/windows/IRServerSuite.h
+++ b/xbmc/input/windows/IRServerSuite.h
@@ -62,5 +62,3 @@ private:
 
   bool HandleRemoteEvent(CIrssMessage& message);
 };
-
-extern CRemoteControl g_RemoteControl;

--- a/xbmc/input/windows/WINJoystick.cpp
+++ b/xbmc/input/windows/WINJoystick.cpp
@@ -65,16 +65,6 @@ CJoystick::~CJoystick()
   ReleaseJoysticks();
 }
 
-void CJoystick::OnSettingChanged(const CSetting *setting)
-{
-  if (setting == NULL)
-    return;
-
-  const std::string &settingId = setting->GetId();
-  if (settingId == "input.enablejoystick")
-    SetEnabled(((CSettingBool*)setting)->GetValue() && PERIPHERALS::CPeripheralImon::GetCountOfImonsConflictWithDInput() == 0);
-}
-
 void CJoystick::Reset()
 {
   m_AxisIdx = -1;

--- a/xbmc/input/windows/WINJoystick.cpp
+++ b/xbmc/input/windows/WINJoystick.cpp
@@ -20,7 +20,6 @@
 
 #include "WINJoystick.h"
 #include "input/ButtonTranslator.h"
-#include "peripherals/devices/PeripheralImon.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/lib/Setting.h"
 #include "utils/log.h"

--- a/xbmc/input/windows/WINJoystick.h
+++ b/xbmc/input/windows/WINJoystick.h
@@ -24,7 +24,6 @@
 #include <map>
 #include <memory>
 #include <stdint.h>
-#include "settings/lib/ISettingCallback.h"
 #include "threads/CriticalSection.h"
 
 #define JACTIVE_BUTTON 0x00000001
@@ -55,13 +54,12 @@ typedef std::vector<AxisConfig> AxesConfig; // [<axis, isTrigger, rest state val
 class CRegExp;
 
 // Class to manage all connected joysticks
-class CJoystick : public ISettingCallback
+class CJoystick
 {
 public:
   CJoystick();
   ~CJoystick();
 
-  virtual void OnSettingChanged(const CSetting *setting);
   void Initialize();
   void Reset();
   void Update();

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -27,6 +27,7 @@
 #include "Autorun.h"
 #include "Builtins.h"
 #include "input/ButtonTranslator.h"
+#include "input/InputManager.h"
 #include "FileItem.h"
 #include "addons/GUIDialogAddonSettings.h"
 #include "dialogs/GUIDialogFileBrowser.h"
@@ -1772,29 +1773,6 @@ int CBuiltins::Execute(const std::string& execString)
   {
     CApplicationMessenger::Get().CECStandby();
   }
-#if defined(HAS_LIRC) || defined(HAS_IRSERVERSUITE)
-  else if (execute == "lirc.stop")
-  {
-    g_RemoteControl.Disconnect();
-    g_RemoteControl.setUsed(false);
-  }
-  else if (execute == "lirc.start")
-  {
-    g_RemoteControl.setUsed(true);
-    g_RemoteControl.Initialize();
-  }
-  else if (execute == "lirc.send")
-  {
-    std::string command;
-    for (int i = 0; i < (int)params.size(); i++)
-    {
-      command += params[i];
-      if (i < (int)params.size() - 1)
-        command += ' ';
-    }
-    g_RemoteControl.AddSendCommand(command);
-  }
-#endif
   else if (execute == "weather.locationset" && !params.empty())
   {
     int loc = atoi(params[0].c_str());
@@ -1851,6 +1829,6 @@ int CBuiltins::Execute(const std::string& execString)
     }
   }
   else
-    return -1;
+    return CInputManager::Get().ExecuteBuiltin(execute, params);
   return 0;
 }

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -32,7 +32,7 @@
 #include "addons/GUIDialogAddonSettings.h"
 #include "dialogs/GUIDialogFileBrowser.h"
 #include "guilib/GUIKeyboardFactory.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "guilib/StereoscopicsManager.h"
 #include "dialogs/GUIDialogKaiToast.h"
 #include "dialogs/GUIDialogNumeric.h"

--- a/xbmc/interfaces/IActionListener.h
+++ b/xbmc/interfaces/IActionListener.h
@@ -20,7 +20,7 @@
  *
  */
 
-#include "guilib/Key.h"
+#include "input/Key.h"
 
 class IActionListener
 {

--- a/xbmc/interfaces/json-rpc/GUIOperations.cpp
+++ b/xbmc/interfaces/json-rpc/GUIOperations.cpp
@@ -23,7 +23,7 @@
 #include "ApplicationMessenger.h"
 #include "GUIInfoManager.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "interfaces/Builtins.h"
 #include "dialogs/GUIDialogKaiToast.h"
 #include "addons/AddonManager.h"

--- a/xbmc/interfaces/json-rpc/InputOperations.h
+++ b/xbmc/interfaces/json-rpc/InputOperations.h
@@ -20,7 +20,7 @@
  */
 
 #include "JSONRPC.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "threads/CriticalSection.h"
 
 namespace JSONRPC

--- a/xbmc/interfaces/json-rpc/PlayerOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlayerOperations.cpp
@@ -24,7 +24,7 @@
 #include "PlayListPlayer.h"
 #include "playlists/PlayList.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "GUIUserMessages.h"
 #include "pictures/GUIWindowSlideShow.h"
 #include "interfaces/Builtins.h"

--- a/xbmc/interfaces/json-rpc/PlaylistOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlaylistOperations.cpp
@@ -23,7 +23,7 @@
 #include "PlayListPlayer.h"
 #include "Util.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "GUIUserMessages.h"
 #include "ApplicationMessenger.h"
 #include "pictures/GUIWindowSlideShow.h"

--- a/xbmc/interfaces/legacy/Control.h
+++ b/xbmc/interfaces/legacy/Control.h
@@ -22,7 +22,7 @@
 
 #include "guilib/GUIControl.h"
 #include "guilib/GUIFont.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 
 #include "Alternative.h"
 #include "Tuple.h"

--- a/xbmc/interfaces/swig/AddonModuleXbmcgui.i
+++ b/xbmc/interfaces/swig/AddonModuleXbmcgui.i
@@ -28,7 +28,7 @@
 #include "interfaces/legacy/WindowDialog.h"
 #include "interfaces/legacy/Dialog.h"
 #include "interfaces/legacy/WindowXML.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 
 using namespace XBMCAddon;
 using namespace xbmcgui;
@@ -116,4 +116,4 @@ using namespace xbmcgui;
 
 %include "interfaces/legacy/WindowXML.h"
 
-%include "guilib/Key.h"
+%include "input/Key.h"

--- a/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
@@ -34,7 +34,7 @@
 #include "settings/AdvancedSettings.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/Settings.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
 #include "utils/log.h"
 #include "utils/URIUtils.h"

--- a/xbmc/music/dialogs/GUIDialogMusicOSD.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicOSD.cpp
@@ -21,7 +21,7 @@
 #include "GUIDialogMusicOSD.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/Key.h"
-#include "input/MouseStat.h"
+#include "input/InputManager.h"
 #include "GUIUserMessages.h"
 #include "settings/Settings.h"
 #include "addons/GUIWindowAddonBrowser.h"
@@ -88,8 +88,9 @@ void CGUIDialogMusicOSD::FrameMove()
   if (m_autoClosing)
   {
     // check for movement of mouse or a submenu open
-    if (g_Mouse.IsActive() || g_windowManager.IsWindowActive(WINDOW_DIALOG_VIS_SETTINGS)
-                           || g_windowManager.IsWindowActive(WINDOW_DIALOG_VIS_PRESET_LIST))
+    if (CInputManager::Get().IsMouseActive() ||
+        g_windowManager.IsWindowActive(WINDOW_DIALOG_VIS_SETTINGS) ||
+        g_windowManager.IsWindowActive(WINDOW_DIALOG_VIS_PRESET_LIST))
       // extend show time by original value
       SetAutoClose(m_showDuration);
   }

--- a/xbmc/music/dialogs/GUIDialogMusicOSD.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicOSD.cpp
@@ -20,7 +20,7 @@
 
 #include "GUIDialogMusicOSD.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "input/InputManager.h"
 #include "GUIUserMessages.h"
 #include "settings/Settings.h"

--- a/xbmc/music/dialogs/GUIDialogMusicOverlay.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicOverlay.cpp
@@ -20,7 +20,7 @@
 
 #include "GUIDialogMusicOverlay.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "input/MouseStat.h"
 #include "input/InputManager.h"
 

--- a/xbmc/music/dialogs/GUIDialogMusicOverlay.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicOverlay.cpp
@@ -22,6 +22,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "guilib/Key.h"
 #include "input/MouseStat.h"
+#include "input/InputManager.h"
 
 #define CONTROL_LOGO_PIC    1
 
@@ -58,7 +59,7 @@ EVENT_RESULT CGUIDialogMusicOverlay::OnMouseEvent(const CPoint &point, const CMo
   if (pControl && pControl->HitTest(point))
   {
     // send highlight message
-    g_Mouse.SetState(MOUSE_STATE_FOCUS);
+    CInputManager::Get().SetMouseState(MOUSE_STATE_FOCUS);
     if (event.m_id == ACTION_MOUSE_LEFT_CLICK)
     { // send mouse message
       CGUIMessage message(GUI_MSG_FULLSCREEN, CONTROL_LOGO_PIC, GetID());

--- a/xbmc/music/dialogs/GUIDialogSongInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogSongInfo.cpp
@@ -28,7 +28,7 @@
 #include "music/windows/GUIWindowMusicBase.h"
 #include "music/tags/MusicInfoTag.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "filesystem/File.h"
 #include "filesystem/CurlFile.h"
 #include "FileItem.h"

--- a/xbmc/music/dialogs/GUIDialogVisualisationPresetList.cpp
+++ b/xbmc/music/dialogs/GUIDialogVisualisationPresetList.cpp
@@ -23,7 +23,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "GUIUserMessages.h"
 #include "FileItem.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
 #include "utils/StringUtils.h"
 

--- a/xbmc/music/karaoke/GUIDialogKaraokeSongSelector.cpp
+++ b/xbmc/music/karaoke/GUIDialogKaraokeSongSelector.cpp
@@ -21,7 +21,7 @@
 #include "GUIDialogKaraokeSongSelector.h"
 #include "PlayListPlayer.h"
 #include "playlists/PlayList.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"

--- a/xbmc/music/karaoke/GUIWindowKaraokeLyrics.cpp
+++ b/xbmc/music/karaoke/GUIWindowKaraokeLyrics.cpp
@@ -20,7 +20,7 @@
 
 #include "Application.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "settings/AdvancedSettings.h"
 
 #include "GUIDialogKaraokeSongSelector.h"

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -46,7 +46,7 @@
 #include "dialogs/GUIDialogSmartPlaylistEditor.h"
 #include "music/tags/MusicInfoTag.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogYesNo.h"
 #include "guilib/GUIKeyboardFactory.h"

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -38,7 +38,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "dialogs/GUIDialogOK.h"
 #include "guilib/GUIKeyboardFactory.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "dialogs/GUIDialogYesNo.h"
 #include "guilib/GUIEditControl.h"
 #include "GUIUserMessages.h"

--- a/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
@@ -29,7 +29,7 @@
 #include "music/tags/MusicInfoTag.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/GUIKeyboardFactory.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "GUIUserMessages.h"
 #include "ContextMenuManager.h"
 #include "filesystem/FavouritesDirectory.h"

--- a/xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
@@ -35,7 +35,7 @@
 #include "FileItem.h"
 #include "settings/Settings.h"
 #include "GUIUserMessages.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
 #include "ContextMenuManager.h"
 

--- a/xbmc/music/windows/GUIWindowMusicSongs.cpp
+++ b/xbmc/music/windows/GUIWindowMusicSongs.cpp
@@ -33,7 +33,7 @@
 #include "storage/MediaManager.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/Settings.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
 #include "utils/log.h"
 #include "utils/URIUtils.h"

--- a/xbmc/music/windows/GUIWindowVisualisation.cpp
+++ b/xbmc/music/windows/GUIWindowVisualisation.cpp
@@ -25,7 +25,7 @@
 #include "GUIInfoManager.h"
 #include "music/dialogs/GUIDialogVisualisationPresetList.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 

--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -40,7 +40,7 @@
 #include "utils/md5.h"
 #include "utils/Variant.h"
 #include "settings/Settings.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "URL.h"
 #include "cores/IPlayer.h"
 #include "interfaces/AnnouncementManager.h"

--- a/xbmc/network/EventClient.cpp
+++ b/xbmc/network/EventClient.cpp
@@ -34,7 +34,7 @@
 #include "utils/TimeUtils.h"
 #include "dialogs/GUIDialogKaiToast.h"
 #include "guilib/GraphicContext.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
 #include "utils/StringUtils.h"
 

--- a/xbmc/network/EventServer.cpp
+++ b/xbmc/network/EventServer.cpp
@@ -34,7 +34,7 @@
 #include "threads/SingleLock.h"
 #include "Zeroconf.h"
 #include "guilib/GUIAudioManager.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include <map>
 #include <queue>
 #include <cassert>

--- a/xbmc/network/GUIDialogAccessPoints.cpp
+++ b/xbmc/network/GUIDialogAccessPoints.cpp
@@ -25,7 +25,7 @@
 #endif
 #include "Application.h"
 #include "FileItem.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
 
 #define CONTROL_ACCESS_POINTS 3

--- a/xbmc/network/upnp/UPnP.cpp
+++ b/xbmc/network/upnp/UPnP.cpp
@@ -46,7 +46,7 @@
 #include "GUIInfoManager.h"
 #include "utils/TimeUtils.h"
 #include "video/VideoInfoTag.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "Util.h"
 
 using namespace std;

--- a/xbmc/network/upnp/UPnPPlayer.cpp
+++ b/xbmc/network/upnp/UPnPPlayer.cpp
@@ -37,7 +37,7 @@
 #include "Application.h"
 #include "dialogs/GUIDialogBusy.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "dialogs/GUIDialogYesNo.h"
 
 

--- a/xbmc/network/upnp/UPnPRenderer.cpp
+++ b/xbmc/network/upnp/UPnPRenderer.cpp
@@ -29,7 +29,7 @@
 #include "filesystem/SpecialProtocol.h"
 #include "GUIInfoManager.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "pictures/GUIWindowSlideShow.h"
 #include "pictures/PictureInfoTag.h"
 #include "interfaces/AnnouncementManager.h"

--- a/xbmc/osx/OSXTextInputResponder.mm
+++ b/xbmc/osx/OSXTextInputResponder.mm
@@ -28,7 +28,7 @@
 #include "GUIUserMessages.h"
 #include "utils/log.h"
 #include "ApplicationMessenger.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #undef BOOL
 
 void SendKeyboardText(const char *text)

--- a/xbmc/osx/atv2/KodiController.mm
+++ b/xbmc/osx/atv2/KodiController.mm
@@ -57,7 +57,7 @@
 #include "osx/DarwinUtils.h"
 #include "threads/Event.h"
 #include "Application.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #undef BOOL
 
 #import <Foundation/Foundation.h>

--- a/xbmc/osx/ios/XBMCController.mm
+++ b/xbmc/osx/ios/XBMCController.mm
@@ -36,7 +36,7 @@
 #include "interfaces/AnnouncementManager.h"
 #include "input/touch/generic/GenericTouchActionHandler.h"
 #include "guilib/GUIControl.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "windowing/WindowingFactory.h"
 #include "video/VideoReferenceClock.h"
 #include "utils/log.h"

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -46,7 +46,7 @@
 #include "GUIUserMessages.h"
 #include "utils/StringUtils.h"
 #include "Util.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "settings/lib/Setting.h"
 
 using namespace PERIPHERALS;

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -28,7 +28,7 @@
 #include "threads/SingleLock.h"
 #include "dialogs/GUIDialogKaiToast.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
 #include "peripherals/Peripherals.h"
 #include "peripherals/bus/PeripheralBus.h"

--- a/xbmc/peripherals/devices/PeripheralImon.cpp
+++ b/xbmc/peripherals/devices/PeripheralImon.cpp
@@ -111,7 +111,7 @@ void CPeripheralImon::ActionOnImonConflict(bool deviceInserted /*= true*/)
     bool enableJoystickNow = !deviceInserted && CSettings::Get().GetBool("input.enablejoystick");
     CLog::Log(LOGNOTICE, "Problematic iMON hardware %s. Joystick usage: %s", (deviceInserted ? "detected" : "was removed"),
         (enableJoystickNow) ? "enabled." : "disabled." );
-    CInputManager::GetInstance().SetEnabledJoystick(enableJoystickNow);
+    CInputManager::Get().SetEnabledJoystick(enableJoystickNow);
 #endif
   }
 }

--- a/xbmc/peripherals/devices/PeripheralNyxboard.cpp
+++ b/xbmc/peripherals/devices/PeripheralNyxboard.cpp
@@ -20,7 +20,7 @@
 
 #include "PeripheralNyxboard.h"
 #include "PeripheralHID.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "utils/log.h"
 #include "Application.h"
 

--- a/xbmc/peripherals/dialogs/GUIDialogPeripheralManager.cpp
+++ b/xbmc/peripherals/dialogs/GUIDialogPeripheralManager.cpp
@@ -23,7 +23,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "peripherals/Peripherals.h"
 #include "FileItem.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "utils/log.h"
 
 #define BUTTON_CLOSE     10

--- a/xbmc/pictures/GUIDialogPictureInfo.cpp
+++ b/xbmc/pictures/GUIDialogPictureInfo.cpp
@@ -22,7 +22,7 @@
 #include "GUIInfoManager.h"
 #include "guilib/GUIWindowManager.h"
 #include "FileItem.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
 #include "PictureInfoTag.h"
 

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -32,7 +32,7 @@
 #include "playlists/PlayListFactory.h"
 #include "PictureInfoLoader.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogYesNo.h"
 #include "playlists/PlayList.h"

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -27,7 +27,7 @@
 #include "URL.h"
 #include "guilib/TextureManager.h"
 #include "guilib/GUILabelControl.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "GUIInfoManager.h"
 #include "filesystem/Directory.h"
 #include "GUIDialogPictureInfo.h"

--- a/xbmc/profiles/ProfilesManager.cpp
+++ b/xbmc/profiles/ProfilesManager.cpp
@@ -35,7 +35,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "input/ButtonTranslator.h"
-#include "input/MouseStat.h"
+#include "input/InputManager.h"
 #include "settings/Settings.h"
 #if !defined(TARGET_WINDOWS) && defined(HAS_DVD_DRIVE)
 #include "storage/DetectDVDType.h"
@@ -262,7 +262,7 @@ bool CProfilesManager::LoadProfile(size_t index)
 
   CDatabaseManager::Get().Initialize();
 
-  g_Mouse.SetEnabled(CSettings::Get().GetBool("input.enablemouse"));
+  CInputManager::Get().SetMouseEnabled(CSettings::Get().GetBool("input.enablemouse"));
 
   g_infoManager.ResetCache();
   g_infoManager.ResetLibraryBools();

--- a/xbmc/profiles/windows/GUIWindowSettingsProfile.cpp
+++ b/xbmc/profiles/windows/GUIWindowSettingsProfile.cpp
@@ -34,7 +34,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "filesystem/Directory.h"
 #include "FileItem.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
 
 using namespace XFILE;

--- a/xbmc/programs/GUIWindowPrograms.cpp
+++ b/xbmc/programs/GUIWindowPrograms.cpp
@@ -26,7 +26,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "FileItem.h"
 #include "settings/MediaSourceSettings.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"

--- a/xbmc/pvr/PVRActionListener.cpp
+++ b/xbmc/pvr/PVRActionListener.cpp
@@ -22,7 +22,7 @@
 
 #include "Application.h"
 #include "ApplicationMessenger.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "guilib/GUIWindow.h"
 #include "guilib/LocalizeStrings.h"
 #include "guilib/GUIWindowManager.h"

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -59,7 +59,7 @@
 #include "timers/PVRTimers.h"
 #include "interfaces/AnnouncementManager.h"
 #include "addons/AddonInstaller.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "dialogs/GUIDialogPVRChannelManager.h"
 #include "dialogs/GUIDialogPVRGroupManager.h"
 

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -30,7 +30,7 @@
 #include "dialogs/GUIDialogYesNo.h"
 #include "guilib/GUIEditControl.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
 #include "profiles/ProfilesManager.h"
 #include "pvr/PVRManager.h"

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
@@ -23,7 +23,7 @@
 #include "ApplicationMessenger.h"
 #include "FileItem.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
 #include "dialogs/GUIDialogKaiToast.h"
 #include "dialogs/GUIDialogOK.h"

--- a/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
@@ -24,7 +24,7 @@
 #include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogYesNo.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
 #include "guilib/GUIRadioButtonControl.h"
 #include "utils/StringUtils.h"

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideOSD.cpp
@@ -22,7 +22,7 @@
 #include "FileItem.h"
 #include "GUIDialogPVRGuideInfo.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "view/ViewState.h"
 #include "epg/Epg.h"
 

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -28,7 +28,7 @@
 #include "dialogs/GUIDialogYesNo.h"
 #include "dialogs/GUIDialogSelect.h"
 #include "filesystem/StackDirectory.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "guilib/GUIMessage.h"
 #include "guilib/GUIWindowManager.h"
 #include "pvr/PVRManager.h"

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -29,7 +29,7 @@
 #include "guilib/GUIKeyboardFactory.h"
 #include "guilib/GUIRadioButtonControl.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "GUIInfoManager.h"
 #include "pvr/PVRManager.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -25,7 +25,7 @@
 #include "GUIUserMessages.h"
 #include "dialogs/GUIDialogOK.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "pvr/PVRManager.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "epg/EpgContainer.h"

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -25,7 +25,7 @@
 #include "dialogs/GUIDialogYesNo.h"
 #include "guilib/GUIRadioButtonControl.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
 #include "GUIInfoManager.h"
 #include "pvr/PVRManager.h"

--- a/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
@@ -24,7 +24,7 @@
 #include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogProgress.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "pvr/PVRManager.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/dialogs/GUIDialogPVRGuideSearch.h"

--- a/xbmc/pvr/windows/GUIWindowPVRTimers.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRTimers.cpp
@@ -25,7 +25,7 @@
 #include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogYesNo.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "pvr/PVRManager.h"
 #include "pvr/dialogs/GUIDialogPVRTimerSettings.h"
 #include "pvr/timers/PVRTimers.h"

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -37,12 +37,6 @@
 #include "guilib/LocalizeStrings.h"
 #include "guilib/StereoscopicsManager.h"
 #include "input/KeyboardLayout.h"
-#include "input/MouseStat.h"
-#if defined(TARGET_WINDOWS)
-#include "input/windows/WINJoystick.h"
-#elif defined(HAS_SDL_JOYSTICK)
-#include "input/SDLJoystick.h"
-#endif // defined(HAS_SDL_JOYSTICK)
 #if defined(TARGET_POSIX)
 #include "linux/LinuxTimezone.h"
 #endif // defined(TARGET_POSIX)

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -274,7 +274,7 @@ void CSettings::Uninitialize()
 #if defined(TARGET_WINDOWS) || defined(HAS_SDL_JOYSTICK)
   m_settingsManager->UnregisterCallback(&CInputManager::Get().m_Joystick);
 #endif
-  m_settingsManager->UnregisterCallback(&g_Mouse);
+  m_settingsManager->UnregisterCallback(&CInputManager::Get().m_Mouse);
   m_settingsManager->UnregisterCallback(&CNetworkServices::Get());
   m_settingsManager->UnregisterCallback(&g_passwordManager);
   m_settingsManager->UnregisterCallback(&PVR::g_PVRManager);
@@ -767,7 +767,7 @@ void CSettings::InitializeISettingCallbacks()
 
   settingSet.clear();
   settingSet.insert("input.enablemouse");
-  m_settingsManager->RegisterCallback(&g_Mouse, settingSet);
+  m_settingsManager->RegisterCallback(&CInputManager::Get().m_Mouse, settingSet);
 
   settingSet.clear();
   settingSet.insert("services.webserver");

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -271,10 +271,7 @@ void CSettings::Uninitialize()
   m_settingsManager->UnregisterCallback(&g_charsetConverter);
   m_settingsManager->UnregisterCallback(&g_graphicsContext);
   m_settingsManager->UnregisterCallback(&g_langInfo);
-#if defined(TARGET_WINDOWS) || defined(HAS_SDL_JOYSTICK)
-  m_settingsManager->UnregisterCallback(&CInputManager::Get().m_Joystick);
-#endif
-  m_settingsManager->UnregisterCallback(&CInputManager::Get().m_Mouse);
+  m_settingsManager->UnregisterCallback(&CInputManager::Get());
   m_settingsManager->UnregisterCallback(&CNetworkServices::Get());
   m_settingsManager->UnregisterCallback(&g_passwordManager);
   m_settingsManager->UnregisterCallback(&PVR::g_PVRManager);
@@ -759,15 +756,10 @@ void CSettings::InitializeISettingCallbacks()
   settingSet.insert("locale.country");
   m_settingsManager->RegisterCallback(&g_langInfo, settingSet);
 
-#if defined(HAS_SDL_JOYSTICK)
   settingSet.clear();
   settingSet.insert("input.enablejoystick");
-  m_settingsManager->RegisterCallback(&CInputManager::Get().m_Joystick, settingSet);
-#endif
-
-  settingSet.clear();
   settingSet.insert("input.enablemouse");
-  m_settingsManager->RegisterCallback(&CInputManager::Get().m_Mouse, settingSet);
+  m_settingsManager->RegisterCallback(&CInputManager::Get(), settingSet);
 
   settingSet.clear();
   settingSet.insert("services.webserver");

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -272,7 +272,7 @@ void CSettings::Uninitialize()
   m_settingsManager->UnregisterCallback(&g_graphicsContext);
   m_settingsManager->UnregisterCallback(&g_langInfo);
 #if defined(TARGET_WINDOWS) || defined(HAS_SDL_JOYSTICK)
-  m_settingsManager->UnregisterCallback(&CInputManager::GetInstance().m_Joystick);
+  m_settingsManager->UnregisterCallback(&CInputManager::Get().m_Joystick);
 #endif
   m_settingsManager->UnregisterCallback(&g_Mouse);
   m_settingsManager->UnregisterCallback(&CNetworkServices::Get());
@@ -762,7 +762,7 @@ void CSettings::InitializeISettingCallbacks()
 #if defined(HAS_SDL_JOYSTICK)
   settingSet.clear();
   settingSet.insert("input.enablejoystick");
-  m_settingsManager->RegisterCallback(&CInputManager::GetInstance().m_Joystick, settingSet);
+  m_settingsManager->RegisterCallback(&CInputManager::Get().m_Joystick, settingSet);
 #endif
 
   settingSet.clear();

--- a/xbmc/settings/dialogs/GUIDialogContentSettings.cpp
+++ b/xbmc/settings/dialogs/GUIDialogContentSettings.cpp
@@ -27,7 +27,7 @@
 #include "filesystem/AddonsDirectory.h"
 #include "dialogs/GUIDialogKaiToast.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "interfaces/Builtins.h"
 #include "settings/lib/Setting.h"
 #include "settings/lib/SettingDependency.h"

--- a/xbmc/settings/dialogs/GUIDialogSettingsBase.cpp
+++ b/xbmc/settings/dialogs/GUIDialogSettingsBase.cpp
@@ -31,7 +31,7 @@
 #include "guilib/GUISpinControlEx.h"
 #include "guilib/GUIToggleButtonControl.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
 #include "settings/SettingControl.h"
 #include "settings/lib/SettingSection.h"

--- a/xbmc/settings/windows/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/windows/GUIWindowSettingsCategory.cpp
@@ -21,7 +21,7 @@
 #include "GUIWindowSettingsCategory.h"
 #include "GUIPassword.h"
 #include "GUIUserMessages.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "settings/DisplaySettings.h"
 #include "settings/Settings.h"
 #include "settings/lib/SettingSection.h"

--- a/xbmc/settings/windows/GUIWindowSettingsScreenCalibration.cpp
+++ b/xbmc/settings/windows/GUIWindowSettingsScreenCalibration.cpp
@@ -30,7 +30,7 @@
 #include "settings/Settings.h"
 #include "guilib/GUIWindowManager.h"
 #include "dialogs/GUIDialogYesNo.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"

--- a/xbmc/settings/windows/GUIWindowTestPattern.cpp
+++ b/xbmc/settings/windows/GUIWindowTestPattern.cpp
@@ -21,7 +21,7 @@
 #include "GUIWindowTestPattern.h"
 #include "settings/DisplaySettings.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "guilib/WindowIDs.h"
 #include "windowing/WindowingFactory.h"
 

--- a/xbmc/storage/AutorunMediaJob.cpp
+++ b/xbmc/storage/AutorunMediaJob.cpp
@@ -22,7 +22,7 @@
 #include "interfaces/Builtins.h"
 #include "guilib/GUIWindowManager.h"
 #include "dialogs/GUIDialogSelect.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "utils/StringUtils.h"
 
 CAutorunMediaJob::CAutorunMediaJob(const std::string &label, const std::string &path):

--- a/xbmc/utils/SeekHandler.h
+++ b/xbmc/utils/SeekHandler.h
@@ -20,7 +20,7 @@
  */
 
 #include <vector>
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "interfaces/IActionListener.h"
 #include "settings/Settings.h"
 #include "settings/lib/ISettingCallback.h"

--- a/xbmc/video/PlayerController.cpp
+++ b/xbmc/video/PlayerController.cpp
@@ -25,7 +25,7 @@
 #include "settings/MediaSettings.h"
 #include "settings/Settings.h"
 #include "cores/IPlayer.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
 #include "guilib/GUISliderControl.h"
 #include "dialogs/GUIDialogKaiToast.h"

--- a/xbmc/video/PlayerController.h
+++ b/xbmc/video/PlayerController.h
@@ -21,7 +21,7 @@
  */
 
 #include "guilib/ISliderCallback.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 
 /*! \brief Player controller class to handle user actions.
 

--- a/xbmc/video/Teletext.h
+++ b/xbmc/video/Teletext.h
@@ -21,7 +21,7 @@
  */
 
 #include "TeletextDefines.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "guilib/GUITexture.h"
 
 // stuff for freetype

--- a/xbmc/video/dialogs/GUIDialogFileStacking.cpp
+++ b/xbmc/video/dialogs/GUIDialogFileStacking.cpp
@@ -19,7 +19,7 @@
  */
 
 #include "GUIDialogFileStacking.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
 #include "FileItem.h"
 #include "utils/StringUtils.h"

--- a/xbmc/video/dialogs/GUIDialogFullScreenInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogFullScreenInfo.cpp
@@ -19,7 +19,7 @@
  */
 
 #include "GUIDialogFullScreenInfo.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 
 CGUIDialogFullScreenInfo::CGUIDialogFullScreenInfo(void)
     : CGUIDialog(WINDOW_DIALOG_FULLSCREEN_INFO, "DialogFullScreenInfo.xml")

--- a/xbmc/video/dialogs/GUIDialogSubtitles.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitles.cpp
@@ -31,7 +31,7 @@
 #include "filesystem/SpecialProtocol.h"
 #include "filesystem/StackDirectory.h"
 #include "guilib/GUIKeyboardFactory.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "settings/MediaSettings.h"
 #include "settings/Settings.h"
 #include "settings/VideoSettings.h"

--- a/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
@@ -39,7 +39,7 @@
 #include "guilib/Texture.h"
 #include "guilib/GUIWindowManager.h"
 #include "utils/Crc32.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -44,7 +44,7 @@
 #include "settings/AdvancedSettings.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/Settings.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
 #include "ContextMenuManager.h"
 #include "GUIUserMessages.h"

--- a/xbmc/video/dialogs/GUIDialogVideoOSD.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoOSD.cpp
@@ -24,7 +24,7 @@
 #include "GUIUserMessages.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/Key.h"
-#include "input/MouseStat.h"
+#include "input/InputManager.h"
 #include "cores/IPlayer.h"
 
 #include "pvr/PVRManager.h"
@@ -47,7 +47,8 @@ void CGUIDialogVideoOSD::FrameMove()
   if (m_autoClosing)
   {
     // check for movement of mouse or a submenu open
-    if (g_Mouse.IsActive() || g_windowManager.IsWindowActive(WINDOW_DIALOG_AUDIO_OSD_SETTINGS)
+    if (CInputManager::Get().IsMouseActive()
+                           || g_windowManager.IsWindowActive(WINDOW_DIALOG_AUDIO_OSD_SETTINGS)
                            || g_windowManager.IsWindowActive(WINDOW_DIALOG_VIDEO_OSD_SETTINGS)
                            || g_windowManager.IsWindowActive(WINDOW_DIALOG_VIDEO_BOOKMARKS)
                            || g_windowManager.IsWindowActive(WINDOW_DIALOG_PVR_OSD_CHANNELS)

--- a/xbmc/video/dialogs/GUIDialogVideoOSD.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoOSD.cpp
@@ -23,7 +23,7 @@
 #include "FileItem.h"
 #include "GUIUserMessages.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "input/InputManager.h"
 #include "cores/IPlayer.h"
 

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -35,7 +35,7 @@
 #include "guilib/GUIFontManager.h"
 #include "guilib/GUITextLayout.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "video/dialogs/GUIDialogFullScreenInfo.h"
 #include "dialogs/GUIDialogNumeric.h"
 #include "settings/DisplaySettings.h"

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -57,7 +57,7 @@
 #include "settings/AdvancedSettings.h"
 #include "settings/MediaSettings.h"
 #include "settings/dialogs/GUIDialogContentSettings.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -47,7 +47,7 @@
 #include "settings/MediaSettings.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/Settings.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
 #include "storage/MediaManager.h"
 #include "utils/LegacyPathTranslation.h"

--- a/xbmc/video/windows/GUIWindowVideoPlaylist.cpp
+++ b/xbmc/video/windows/GUIWindowVideoPlaylist.cpp
@@ -32,7 +32,7 @@
 #include "filesystem/FavouritesDirectory.h"
 #include "settings/Settings.h"
 #include "settings/MediaSettings.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
 #include "utils/log.h"
 #include "utils/URIUtils.h"

--- a/xbmc/view/GUIViewState.cpp
+++ b/xbmc/view/GUIViewState.cpp
@@ -41,7 +41,7 @@
 #include "settings/MediaSourceSettings.h"
 #include "settings/Settings.h"
 #include "FileItem.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "filesystem/AddonsDirectory.h"
 #include "guilib/TextureManager.h"
 

--- a/xbmc/windowing/WinEventsSDL.cpp
+++ b/xbmc/windowing/WinEventsSDL.cpp
@@ -238,7 +238,7 @@ bool CWinEventsSDL::MessagePump()
       case SDL_JOYHATMOTION:
       case SDL_JOYDEVICEADDED:
       case SDL_JOYDEVICEREMOVED:
-        CInputManager::GetInstance().UpdateJoystick(event);
+        CInputManager::Get().UpdateJoystick(event);
         ret = true;
         break;
 #endif

--- a/xbmc/windowing/WinEventsSDL.cpp
+++ b/xbmc/windowing/WinEventsSDL.cpp
@@ -28,7 +28,7 @@
 #include "GUIUserMessages.h"
 #include "settings/DisplaySettings.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #ifdef HAS_SDL_JOYSTICK
 #include "input/SDLJoystick.h"
 #endif

--- a/xbmc/windowing/WinEventsSDL.cpp
+++ b/xbmc/windowing/WinEventsSDL.cpp
@@ -346,7 +346,7 @@ bool CWinEventsSDL::MessagePump()
       {
         if (0 == (SDL_GetAppState() & SDL_APPMOUSEFOCUS))
         {
-          g_Mouse.SetActive(false);
+          CInputManager::Get().SetMouseActive(false);
 #if defined(TARGET_DARWIN_OSX)
           // See CApplication::ProcessSlow() for a description as to why we call Cocoa_HideMouse.
           // this is here to restore the pointer when toggling back to window mode from fullscreen.

--- a/xbmc/windowing/WinEventsX11.cpp
+++ b/xbmc/windowing/WinEventsX11.cpp
@@ -616,7 +616,7 @@ bool CWinEventsX11Imp::MessagePump()
       case SDL_JOYHATMOTION:
       case SDL_JOYDEVICEADDED:
       case SDL_JOYDEVICEREMOVED:
-        CInputManager::GetInstance().UpdateJoystick(event);
+        CInputManager::Get().UpdateJoystick(event);
         ret = true;
         break;
 

--- a/xbmc/windowing/WinEventsX11.cpp
+++ b/xbmc/windowing/WinEventsX11.cpp
@@ -542,7 +542,7 @@ bool CWinEventsX11Imp::MessagePump()
       // lose mouse coverage
       case LeaveNotify:
       {
-        g_Mouse.SetActive(false);
+        CInputManager::Get().SetMouseActive(false);
         break;
       }
 

--- a/xbmc/windowing/X11/WinSystemX11.cpp
+++ b/xbmc/windowing/X11/WinSystemX11.cpp
@@ -46,7 +46,7 @@
 #endif
 
 #include "../WinEventsX11.h"
-#include "input/MouseStat.h"
+#include "input/InputManager.h"
 
 using namespace std;
 
@@ -993,7 +993,7 @@ bool CWinSystemX11::SetWindow(int width, int height, bool fullscreen, const std:
 
   if (!m_mainWindow)
   {
-    g_Mouse.SetActive(false);
+    CInputManager::Get().SetMouseActive(false);
   }
 
   if (m_mainWindow && ((m_bFullScreen != fullscreen) || m_currentOutput.compare(output) != 0 || m_windowDirty))
@@ -1023,7 +1023,7 @@ bool CWinSystemX11::SetWindow(int width, int height, bool fullscreen, const std:
       }
     }
 
-    g_Mouse.SetActive(false);
+    CInputManager::Get().SetMouseActive(false);
     OnLostDevice();
     DestroyWindow();
     m_windowDirty = true;

--- a/xbmc/windowing/android/WinEventsAndroid.cpp
+++ b/xbmc/windowing/android/WinEventsAndroid.cpp
@@ -220,7 +220,7 @@ bool CWinEventsAndroid::MessagePump()
 
       if (fabs(amount) >= ALMOST_ZERO)
       {
-        ret |= CInputManager::GetInstance().ProcessJoystickEvent(g_windowManager.GetActiveWindowID(),
+        ret |= CInputManager::Get().ProcessJoystickEvent(g_windowManager.GetActiveWindowID(),
             input_device.name, item, input_type, amount, holdTime);
       }
     }

--- a/xbmc/windowing/osx/WinEventsIOS.mm
+++ b/xbmc/windowing/osx/WinEventsIOS.mm
@@ -71,7 +71,7 @@ bool CWinEventsIOS::MessagePump()
       unsigned int holdTime = pumpEvent.jbutton.holdTime;
 
       CLog::Log(LOGDEBUG,"CWinEventsIOS: Button press keyID = %i", wKeyID);
-      ret |= CInputManager::GetInstance().ProcessJoystickEvent(g_windowManager.GetActiveWindowID(), joystickName, wKeyID, JACTIVE_BUTTON, fAmount, holdTime);
+      ret |= CInputManager::Get().ProcessJoystickEvent(g_windowManager.GetActiveWindowID(), joystickName, wKeyID, JACTIVE_BUTTON, fAmount, holdTime);
     }
     else
       ret |= g_application.OnEvent(pumpEvent);

--- a/xbmc/windowing/windows/WinEventsWin32.cpp
+++ b/xbmc/windowing/windows/WinEventsWin32.cpp
@@ -455,7 +455,7 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
     case WM_ACTIVATE:
       {
         if( WA_INACTIVE != wParam )
-          CInputManager::GetInstance().ReInitializeJoystick();
+          CInputManager::Get().ReInitializeJoystick();
 
         bool active = g_application.GetRenderGUI();
         if (HIWORD(wParam))
@@ -761,7 +761,7 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
             if (((_DEV_BROADCAST_HEADER*) lParam)->dbcd_devicetype == DBT_DEVTYP_DEVICEINTERFACE)
             {
               g_peripherals.TriggerDeviceScan(PERIPHERAL_BUS_USB);
-              CInputManager::GetInstance().ReInitializeJoystick();
+              CInputManager::Get().ReInitializeJoystick();
             }
             // check if an usb or optical media was inserted or removed
             if (((_DEV_BROADCAST_HEADER*) lParam)->dbcd_devicetype == DBT_DEVTYP_VOLUME)

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -53,7 +53,7 @@
 #include "video/VideoLibraryQueue.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
 #include "utils/TimeUtils.h"
 #include "filesystem/File.h"

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -35,7 +35,7 @@
 #include "playlists/PlayListFactory.h"
 #include "network/Network.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogYesNo.h"
 #include "guilib/GUIKeyboardFactory.h"

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -48,7 +48,7 @@
 #include "settings/AdvancedSettings.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/Settings.h"
-#include "input/MouseStat.h"
+#include "input/InputManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
@@ -293,7 +293,7 @@ bool CGUIWindowFileManager::OnMessage(CGUIMessage& message)
         if (iAction == ACTION_HIGHLIGHT_ITEM || iAction == ACTION_MOUSE_LEFT_CLICK)
         {
           OnMark(list, iItem);
-          if (!g_Mouse.IsActive())
+          if (!CInputManager::Get().IsMouseActive())
           {
             //move to next item
             CGUIMessage msg(GUI_MSG_ITEM_SELECT, GetID(), iControl, iItem + 1);

--- a/xbmc/windows/GUIWindowHome.cpp
+++ b/xbmc/windows/GUIWindowHome.cpp
@@ -19,7 +19,7 @@
  */
 
 #include "GUIWindowHome.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "guilib/WindowIDs.h"
 #include "utils/JobManager.h"
 #include "utils/RecentlyAddedJob.h"

--- a/xbmc/windows/GUIWindowLoginScreen.cpp
+++ b/xbmc/windows/GUIWindowLoginScreen.cpp
@@ -43,7 +43,7 @@
 #include "dialogs/GUIDialogOK.h"
 #include "settings/Settings.h"
 #include "FileItem.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
 #include "addons/AddonManager.h"
 #include "view/ViewState.h"

--- a/xbmc/windows/GUIWindowPointer.cpp
+++ b/xbmc/windows/GUIWindowPointer.cpp
@@ -20,6 +20,7 @@
 
 #include "GUIWindowPointer.h"
 #include "input/MouseStat.h"
+#include "input/InputManager.h"
 #include "windowing/WindowingFactory.h"
 #include <climits>
 #define ID_POINTER 10
@@ -58,7 +59,7 @@ void CGUIWindowPointer::UpdateVisibility()
 {
   if(g_Windowing.HasCursor())
   {
-    if (g_Mouse.IsActive())
+    if (CInputManager::Get().IsMouseActive())
       Show();
     else
       Close();
@@ -80,13 +81,14 @@ void CGUIWindowPointer::OnWindowLoaded()
 
 void CGUIWindowPointer::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
-  bool active = g_Mouse.IsActive();
+  bool active = CInputManager::Get().IsMouseActive();
   if (active != m_active)
   {
     MarkDirtyRegion();
     m_active = active;
   }
-  SetPosition((float)g_Mouse.GetX(), (float)g_Mouse.GetY());
-  SetPointer(g_Mouse.GetState());
+  MousePosition pos = CInputManager::Get().GetMousePosition();
+  SetPosition((float)pos.x, (float)pos.y);
+  SetPointer(CInputManager::Get().GetMouseState());
   return CGUIWindow::Process(currentTime, dirtyregions);
 }

--- a/xbmc/windows/GUIWindowStartup.cpp
+++ b/xbmc/windows/GUIWindowStartup.cpp
@@ -19,7 +19,7 @@
  */
 
 #include "GUIWindowStartup.h"
-#include "guilib/Key.h"
+#include "input/Key.h"
 #include "guilib/WindowIDs.h"
 
 CGUIWindowStartup::CGUIWindowStartup(void)


### PR DESCRIPTION
As the title says, this is a continuation of the refactoring I started. More input handling functions are moved from CApplication and globals have been moved into CInputManager as private members instead.

I've tried to hide implementation details to make calling code cleaner, ifdefs are hidden in inputmanager instead of callers having to be aware of this.

The last commit moving key.h/cpp requires some xcode person to fix the project file I assume, make files are sorted.
