### PR TITLE
[linux] fix building with gcc 4.9 on i386

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -843,15 +843,20 @@ fi
 
 use_sse4=no
 if test "$ARCH" = "x86_64-linux" || test "$ARCH" = "i486-linux"; then
-    SAVE_CFLAGS="$CFLAGS"
-    CFLAGS="-msse4.1"
-    AC_COMPILE_IFELSE(
-      [AC_LANG_SOURCE([int foo;])],
-      [ use_sse4=yes
-        USE_SSE4=1],
-      [ use_sse=no
-        USE_SSE4=0])
-    CFLAGS="$SAVE_CFLAGS"
+  SAVE_CFLAGS="$CFLAGS"
+  CFLAGS="-msse4.1"
+  AC_COMPILE_IFELSE(
+    [AC_LANG_SOURCE([int foo;])],
+    [ use_sse4=yes
+      USE_SSE4=1],
+    [ use_sse=no
+      USE_SSE4=0])
+  CFLAGS="$SAVE_CFLAGS"
+
+  if test "$use_sse4" = "yes"; then
+    CFLAGS="${CFLAGS} -msse4.1"
+    CXXFLAGS="${CXXFLAGS} -msse4.1"
+  fi
 fi
 
 # Checks for library functions.


### PR DESCRIPTION
fixes building on linux i386 after https://github.com/xbmc/xbmc/pull/6412
