### PR TITLE
Fix for UI not showing both extractflags and extractthumb

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -12863,7 +12863,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#20433"
-msgid "Extract thumbnails and video information"
+msgid "Extract video information from files"
 msgstr ""
 
 #: xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
@@ -17694,7 +17694,7 @@ msgstr ""
 #. Description of setting with label #20433 "Extract thumbnails and video information"
 #: system/settings/settings.xml
 msgctxt "#36178"
-msgid "Extract thumbnails and metadata information such as codec and aspect ratio from videos."
+msgid "Extract metadata information such as codec and aspect ratio from videos."
 msgstr ""
 
 #. Description of setting with label #20419 "Replace file names with library titles"
@@ -17706,7 +17706,7 @@ msgstr ""
 #. Description of setting with label #20433 "Extract thumbnails and video information"
 #: system/settings/settings.xml
 msgctxt "#36180"
-msgid "Extract thumbnails and information, such as codecs and aspect ratio, to display in library mode."
+msgid "Extract thumbnails to display in library mode."
 msgstr ""
 
 #: system/settings/settings.xml
@@ -20433,4 +20433,8 @@ msgstr ""
 #: xbmc/music/windows/GUIWindowMusicBase.cpp
 msgctxt "#39016"
 msgid "Resume audiobook"
+msgstr ""
+
+msgctxt "#38190"
+msgid "Extract thumbnails from video files"
 msgstr ""

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -969,8 +969,8 @@
           <default>true</default>
           <control type="toggle" />
         </setting>
-        <setting id="myvideos.extractthumb" type="boolean" label="20433" help="36180">
-          <level>4</level>
+        <setting id="myvideos.extractthumb" type="boolean" label="38190" help="36180">
+          <level>1</level>
           <default>true</default>
           <control type="toggle" />
         </setting>


### PR DESCRIPTION
Before this PR, extractthumb was a level 4 setting (which doesn't show in gui) and had no way of being set. It also had the same label as extractflags.

However it is useful to be set independently of extractflags.
Extracting flags (codec info) is relatively cheap for indexed files (not quite so cheap for mpegts).
Extracting thumbnails is pretty expensive on a low powered device.

So this allows either to be set in gui.
