### PR TITLE
[keymap] show OSD when pressing SELECT on remotes in Visualisation

### DIFF
--- a/system/keymaps/remote.xml
+++ b/system/keymaps/remote.xml
@@ -232,7 +232,7 @@
       <down>SkipPrevious</down>
       <back>Back</back>
       <title>CodecInfo</title>
-      <select>ActivateWindow(VisualisationPresetList)</select>
+      <select>OSD</select>
       <menu>OSD</menu>
       <contentsmenu>OSD</contentsmenu>
       <rootmenu>OSD</rootmenu>


### PR DESCRIPTION
Currently the behavior when pressing SELECT/OK on remotes in FullscreenVideo and Visualisation window differs. While on FullscreenVideo you get the OSD menu you get some visualisation preset list for music. IMO this should be consistent and always trigger the OSD menu (do we really need a shortcut to visualisation presets on limited remotes?). This is especially useful when using CEC (which is using the remote keymap) with a limited set of buttons forwarded (like on LG TVs).
