### PR TITLE
[CDDAFile]- allow reads < CDIO_CD_FRAMESIZE_RAW by using a buffer - fixe...

### DIFF
--- a/xbmc/filesystem/CDDAFile.cpp
+++ b/xbmc/filesystem/CDDAFile.cpp
@@ -43,16 +43,23 @@ CFileCDDA::CFileCDDA(void)
   m_lsnEnd = CDIO_INVALID_LSN;
   m_cdio = CLibcdio::GetInstance();
   m_iSectorCount = 52;
+  m_TrackBuf = (uint8_t *) malloc(CDIO_CD_FRAMESIZE_RAW);
+  p_TrackBuf = 0;
+  f_TrackBuf = 0;
 }
 
 CFileCDDA::~CFileCDDA(void)
 {
+  free(m_TrackBuf);
   Close();
 }
 
 bool CFileCDDA::Open(const CURL& url)
 {
   std::string strURL = url.GetWithoutFilename();
+
+  // Flag TrackBuffer = FALSE, TrackBuffer is empty
+  f_TrackBuf = 0;
 
   if (!g_mediaManager.IsDiscInDrive(strURL) || !IsValidFile(url))
     return false;
@@ -118,50 +125,98 @@ int CFileCDDA::Stat(const CURL& url, struct __stat64* buffer)
 
 ssize_t CFileCDDA::Read(void* lpBuf, size_t uiBufSize)
 {
+
+  ssize_t returnValue;
+  int iSectorCount;
+  void *destBuf;
+
+
   if (!m_pCdIo || !g_mediaManager.IsDiscInDrive())
-    return -1;
-
-  if (uiBufSize > SSIZE_MAX)
-    uiBufSize = SSIZE_MAX;
-
-  // limit number of sectors that fits in buffer by m_iSectorCount
-  int iSectorCount = std::min((int)uiBufSize / CDIO_CD_FRAMESIZE_RAW, m_iSectorCount);
-
-  if (iSectorCount <= 0)
-    return -1;
-
-  // Are there enough sectors left to read
-  if (m_lsnCurrent + iSectorCount > m_lsnEnd)
-    iSectorCount = m_lsnEnd - m_lsnCurrent;
-
-  // The loop tries to solve read error problem by lowering number of sectors to read (iSectorCount).
-  // When problem is solved the proper number of sectors is stored in m_iSectorCount
-  int big_iSectorCount = iSectorCount;
-  while (iSectorCount > 0)
   {
-    int iret = m_cdio->cdio_read_audio_sectors(m_pCdIo, lpBuf, m_lsnCurrent, iSectorCount);
-
-    if (iret == DRIVER_OP_SUCCESS)
-    {
-      // If lower iSectorCount solved the problem limit it's value
-      if (iSectorCount < big_iSectorCount)
-      {
-        m_iSectorCount = iSectorCount;
-      }
-      break;
-    }
-
-    // iSectorCount is low so it cannot solve read problem
-    if (iSectorCount <= 10)
-    {
-      CLog::Log(LOGERROR, "file cdda: Reading %d sectors of audio data starting at lsn %d failed with error code %i", iSectorCount, m_lsnCurrent, iret);
-      return -1;
-    }
-
-    iSectorCount = 10;
+    CLog::Log(LOGERROR, "file cdda: Aborted because no disc in drive or no m_pCdIo");
+    return -1;
   }
+
+  uiBufSize = std::min( uiBufSize, (size_t)SSIZE_MAX );
+
+  // If we have data in the TrackBuffer, they must be used first
+  if (f_TrackBuf)
+  {
+    // Get at most the remaining data in m_TrackBuf
+    uiBufSize = std::min(uiBufSize, CDIO_CD_FRAMESIZE_RAW - p_TrackBuf);
+    memcpy(lpBuf, m_TrackBuf + p_TrackBuf, uiBufSize);
+    // Update the data offset
+    p_TrackBuf += uiBufSize;
+    // Is m_TrackBuf empty?
+    f_TrackBuf = (CDIO_CD_FRAMESIZE_RAW == p_TrackBuf);
+    // All done, return read bytes
+    return uiBufSize;
+  }
+
+  // No data left in buffer
+
+  // Is this a short read?
+  if (uiBufSize < CDIO_CD_FRAMESIZE_RAW)
+  {
+    // short request, buffer one full sector
+    iSectorCount = 1;
+    destBuf = m_TrackBuf;
+  }
+  else // normal request
+  {
+    // limit number of sectors that fits in buffer by m_iSectorCount
+    iSectorCount = std::min((int)uiBufSize / CDIO_CD_FRAMESIZE_RAW, m_iSectorCount);
+    destBuf = lpBuf;
+  }
+  
+  // Are there enough sectors left to read?
+  iSectorCount = std::min(iSectorCount, m_lsnEnd - m_lsnCurrent);
+
+  // Have we reached EOF?
+  if (iSectorCount == 0)
+  {
+    CLog::Log(LOGNOTICE, "file cdda: Read EoF");
+    return 0; // Success, but nothing read
+  } // Reached EoF
+
+  // At leat one sector to read
+  int retries;
+  int iret;
+  // Try reading a decresing number of sectors, then 3 times with 1 sector
+  for (retries = 3; retries > 0; iSectorCount>1 ? iSectorCount-- : retries--)
+  {
+    iret = m_cdio->cdio_read_audio_sectors(m_pCdIo, destBuf, m_lsnCurrent, iSectorCount);
+    if (iret == DRIVER_OP_SUCCESS)
+      break; // Get out from the loop
+    else
+    {
+      CLog::Log(LOGERROR, "file cdda: Read cdio error when reading track ");
+    } // Errors when reading file
+  }
+  // retries == 0 only if failed reading at least one sector
+  if (retries == 0)
+  {
+    CLog::Log(LOGERROR, "file cdda: Reading %d sectors of audio data starting at lsn %d failed with error code %i", iSectorCount, m_lsnCurrent, iret);
+    return -1;
+  }
+
+  // Update position in file
   m_lsnCurrent += iSectorCount;
 
+  // Was it a short request?
+  if (uiBufSize < CDIO_CD_FRAMESIZE_RAW)
+  {
+    // We copy the amount if requested data into the destination buffer
+    memcpy(lpBuf, m_TrackBuf, uiBufSize);
+    // and keep track of the first available data
+    p_TrackBuf = uiBufSize;
+    // Finally, we set the buffer flag as TRUE
+    f_TrackBuf = true;
+    // We will return uiBufSize
+    return uiBufSize;
+  }
+
+  // Otherwise, just return the size of read data
   return iSectorCount*CDIO_CD_FRAMESIZE_RAW;
 }
 
@@ -195,6 +250,9 @@ int64_t CFileCDDA::Seek(int64_t iFilePosition, int iWhence /*=SEEK_SET*/)
 
 void CFileCDDA::Close()
 {
+  // Flag TrackBuffer = FALSE, TrackBuffer is empty
+  f_TrackBuf = 0;
+
   if (m_pCdIo)
   {
     m_cdio->cdio_destroy(m_pCdIo);

--- a/xbmc/filesystem/CDDAFile.h
+++ b/xbmc/filesystem/CDDAFile.h
@@ -50,6 +50,9 @@ protected:
 
 protected:
   CdIo_t* m_pCdIo;
+  uint8_t *m_TrackBuf;
+  size_t   p_TrackBuf;
+  int      f_TrackBuf;
   lsn_t m_lsnStart;  // Start of m_iTrack in logical sector number
   lsn_t m_lsnCurrent; // Position inside the track in logical sector number
   lsn_t m_lsnEnd;   // End of m_iTrack in logical sector number


### PR DESCRIPTION
...s #15794
monkeywork for @Claudio-Sjo

----------------snip-----------------------
Hi XBMC Team,
 I found the following issue: the Audio files are accessed via FileCache that exploits CDDAFile.
 FileCache::Process expects to fill out the cache by requesting data to the Read method, in the general case it requests a value that is 52 \* CDIO_CD_FRAMESIZE_RAW
 This is fine until FileCache reaches the end of the buffer, when it starts requesting sizes that are less than that value, until it can request data size that is less than CDIO_CD_FRAMESIZE_RAW.
 CDDAFile::Read was designed in a way that it can only handle requests that are grater than CDIO_CD_FRAMESIZE_RAW, otherwise it returns a fault code.
 In order to trigger a fault, it's just enough that a user of a cached file is slower than the process of reading the file.
 An example is trying to rip an Audio CD and compress it in FLAC by using Raspberry Pi.
 I've written a patch towards CDDAFile that implements a correction, it uses a local buffer of CDIO_CD_FRAMESIZE_RAW size within CDDAFile to cope with the problem.
 The patchfile is here
http://paste.ubuntu.com/10223199/
 it applies to kodi in the directory
 OpenELEC.tv/packages/mediacenter/kodi/patches
 I tested the patch with some CD that couldn't be ripped earlier, and now they are read properly.

There are other problems when dealing with cache and CD Audio, I'm trying to figure out why when ripping the CD #2 of "Monty Alexander - Steaming Hot" I get the errors
 16:34:02 T:1948365888 ERROR: CCurlFile::FillBuffer - Failed: Timeout was reached(28)
 16:34:02 T:1948365888 ERROR: CCurlFile::CReadState::Connect, didn't get any data from stream.
 16:34:28 T:1799353408 ERROR: CDDARipper: Error ripping cdda://local/02.cdda

Regards,
 Claudio
------------snip------------------
