### PR TITLE
Revert changes in addon lib and bump versions

### DIFF
--- a/project/Win32BuildSetup/buildpvraddons.bat
+++ b/project/Win32BuildSetup/buildpvraddons.bat
@@ -9,7 +9,7 @@ SET DEPS_DIR=..\BuildDependencies
 SET TMP_DIR=%DEPS_DIR%\tmp
 
 SET LIBNAME=xbmc-pvr-addons
-SET VERSION=225afcfa9dad2ca8d0f62ec248d2d29734bcaa3c
+SET VERSION=2fb0fc22668b1efdec05e66161d6c419844ee9cd
 SET SOURCE=%LIBNAME%
 SET GIT_URL=git://github.com/opdenkamp/%LIBNAME%.git
 SET SOURCE_DIR=%TMP_DIR%\%SOURCE%

--- a/tools/depends/target/xbmc-pvr-addons/Makefile
+++ b/tools/depends/target/xbmc-pvr-addons/Makefile
@@ -2,7 +2,7 @@ include ../../Makefile.include
 #DEPS= ../../Makefile.include Makefile
 
 LIBNAME=xbmc-pvr-addons
-VERSION=225afcfa9dad2ca8d0f62ec248d2d29734bcaa3c
+VERSION=2fb0fc22668b1efdec05e66161d6c419844ee9cd
 GIT_DIR=$(TARBALLS_LOCATION)/$(LIBNAME).git
 BASE_URL=git://github.com/opdenkamp/$(LIBNAME).git
 DYLIB=$(PLATFORM)/addons/pvr.demo/.libs/libpvrdemo-addon.so

--- a/xbmc/addons/AddonCallbacks.h
+++ b/xbmc/addons/AddonCallbacks.h
@@ -36,10 +36,10 @@ typedef void (*AddOnLogCallback)(void *addonData, const ADDON::addon_log_t logle
 typedef void (*AddOnQueueNotification)(void *addonData, const ADDON::queue_msg_t type, const char *msg);
 typedef bool (*AddOnWakeOnLan)(const char* mac);
 typedef bool (*AddOnGetSetting)(void *addonData, const char *settingName, void *settingValue);
-typedef const char* (*AddOnUnknownToUTF8)(const char *sourceDest);
-typedef const char* (*AddOnGetLocalizedString)(const void* addonData, long dwCode);
-typedef const char* (*AddOnGetDVDMenuLanguage)(const void* addonData);
-typedef void (*AddOnFreeString)(const void* addonData, const char* str);
+typedef char* (*AddOnUnknownToUTF8)(const char *sourceDest);
+typedef char* (*AddOnGetLocalizedString)(const void* addonData, long dwCode);
+typedef char* (*AddOnGetDVDMenuLanguage)(const void* addonData);
+typedef void (*AddOnFreeString)(const void* addonData, char* str);
 
 typedef void* (*AddOnOpenFile)(const void* addonData, const char* strFileName, unsigned int flags);
 typedef void* (*AddOnOpenFileForWrite)(const void* addonData, const char* strFileName, bool bOverWrite);

--- a/xbmc/addons/AddonCallbacksAddon.cpp
+++ b/xbmc/addons/AddonCallbacksAddon.cpp
@@ -297,7 +297,7 @@ char* CAddonCallbacksAddon::GetDVDMenuLanguage(const void* addonData)
 
 void CAddonCallbacksAddon::FreeString(const void* addonData, char* str)
 {
-  delete[] str;
+  free(str);
 }
 
 void* CAddonCallbacksAddon::OpenFile(const void* addonData, const char* strFileName, unsigned int flags)

--- a/xbmc/addons/AddonCallbacksAddon.cpp
+++ b/xbmc/addons/AddonCallbacksAddon.cpp
@@ -252,7 +252,7 @@ bool CAddonCallbacksAddon::GetAddonSetting(void *addonData, const char *strSetti
   return false;
 }
 
-const char* CAddonCallbacksAddon::UnknownToUTF8(const char *strSource)
+char* CAddonCallbacksAddon::UnknownToUTF8(const char *strSource)
 {
   std::string string;
   if (strSource != NULL)
@@ -263,7 +263,7 @@ const char* CAddonCallbacksAddon::UnknownToUTF8(const char *strSource)
   return buffer;
 }
 
-const char* CAddonCallbacksAddon::GetLocalizedString(const void* addonData, long dwCode)
+char* CAddonCallbacksAddon::GetLocalizedString(const void* addonData, long dwCode)
 {
   CAddonCallbacks* helper = (CAddonCallbacks*) addonData;
   if (!helper || g_application.m_bStop)
@@ -283,7 +283,7 @@ const char* CAddonCallbacksAddon::GetLocalizedString(const void* addonData, long
   return buffer;
 }
 
-const char* CAddonCallbacksAddon::GetDVDMenuLanguage(const void* addonData)
+char* CAddonCallbacksAddon::GetDVDMenuLanguage(const void* addonData)
 {
   CAddonCallbacks* helper = (CAddonCallbacks*) addonData;
   if (!helper)
@@ -295,7 +295,7 @@ const char* CAddonCallbacksAddon::GetDVDMenuLanguage(const void* addonData)
   return buffer;
 }
 
-void CAddonCallbacksAddon::FreeString(const void* addonData, const char* str)
+void CAddonCallbacksAddon::FreeString(const void* addonData, char* str)
 {
   delete[] str;
 }

--- a/xbmc/addons/AddonCallbacksAddon.h
+++ b/xbmc/addons/AddonCallbacksAddon.h
@@ -39,10 +39,10 @@ public:
   static bool GetAddonSetting(void *addonData, const char *strSettingName, void *settingValue);
   static void QueueNotification(void *addonData, const queue_msg_t type, const char *strMessage);
   static bool WakeOnLan(const char *mac);
-  static const char* UnknownToUTF8(const char *strSource);
-  static const char* GetLocalizedString(const void* addonData, long dwCode);
-  static const char* GetDVDMenuLanguage(const void* addonData);
-  static void FreeString(const void* addonData, const char* str);
+  static char* UnknownToUTF8(const char *strSource);
+  static char* GetLocalizedString(const void* addonData, long dwCode);
+  static char* GetDVDMenuLanguage(const void* addonData);
+  static void FreeString(const void* addonData, char* str);
 
   // file operations
   static void* OpenFile(const void* addonData, const char* strFileName, unsigned int flags);


### PR DESCRIPTION
fix FreeString

related to https://github.com/opdenkamp/xbmc-pvr-addons/pull/441
