### PR TITLE
[mysql] fix transaction handling

### DIFF
--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -443,6 +443,7 @@ long MysqlDatabase::nextid(const char* sname) {
 void MysqlDatabase::start_transaction() {
   if (active)
   {
+    mysql_autocommit(conn, false);
     CLog::Log(LOGDEBUG,"Mysql Start transaction");
     _in_transaction = true;
   }


### PR DESCRIPTION
This commit adds the missing bit for mysql transaction handling. MySQL as backend for the music and/or video library should now suck less performance wise ;)

This has to be thoroughly tested before it get's merged.
