### PR TITLE
[configure] fix sse4 typo

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -849,7 +849,7 @@ if test "$ARCH" = "x86_64-linux" || test "$ARCH" = "i486-linux"; then
     [AC_LANG_SOURCE([int foo;])],
     [ use_sse4=yes
       USE_SSE4=1],
-    [ use_sse=no
+    [ use_sse4=no
       USE_SSE4=0])
   CFLAGS="$SAVE_CFLAGS"
 


### PR DESCRIPTION
Fixes typo Introduced with b13d84764883aed9805d2670b21211dde6bdc826

@wsnipex your button.
