### PR TITLE
[win32] - add inapp update feature via winsparkle

### DIFF
--- a/project/BuildDependencies/scripts/0_package.list
+++ b/project/BuildDependencies/scripts/0_package.list
@@ -50,3 +50,4 @@ swig-2.0.7-win32-1.7z
 taglib-1.9.1-win32-vc120.7z
 texturepacker-1.0.1-win32.7z
 tinyxml-2.6.2_3-win32-vc120.7z
+winsparkle-0.4-win32.7z

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -91,7 +91,7 @@
       <IgnoreSpecificDefaultLibraries>libcpmt;libc;msvcrt;libcmt;msvcrtd;msvcprtd;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
       <ModuleDefinitionFile>
       </ModuleDefinitionFile>
-      <DelayLoadDLLs>libxslt.dll;dnssd.dll;dwmapi.dll;libmicrohttpd-5.dll;ssh.dll;sqlite3.dll;avcodec-56.dll;avfilter-5.dll;avformat-56.dll;avutil-54.dll;postproc-53.dll;swresample-1.dll;swscale-3.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
+      <DelayLoadDLLs>libxslt.dll;dnssd.dll;dwmapi.dll;libmicrohttpd-5.dll;ssh.dll;sqlite3.dll;avcodec-56.dll;avfilter-5.dll;avformat-56.dll;avutil-54.dll;postproc-53.dll;swresample-1.dll;swscale-3.dll;WinSparkle.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
       <ProgramDatabaseFile>$(OutDir)$(ProjectName).pdb</ProgramDatabaseFile>
       <EntryPointSymbol>
       </EntryPointSymbol>
@@ -155,7 +155,7 @@
       <AdditionalDependencies>D3dx9.lib;DInput8.lib;DSound.lib;winmm.lib;Mpr.lib;Iphlpapi.lib;PowrProf.lib;setupapi.lib;dwmapi.lib;yajl.lib;dxguid.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(ProjectName).exe</OutputFile>
       <IgnoreSpecificDefaultLibraries>libc;msvcrt;libci;msvcprt;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
-      <DelayLoadDLLs>libxslt.dll;dnssd.dll;dwmapi.dll;libmicrohttpd-5.dll;ssh.dll;sqlite3.dll;avcodec-56.dll;avfilter-5.dll;avformat-56.dll;avutil-54.dll;postproc-53.dll;swresample-1.dll;swscale-3.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
+      <DelayLoadDLLs>libxslt.dll;dnssd.dll;dwmapi.dll;libmicrohttpd-5.dll;ssh.dll;sqlite3.dll;avcodec-56.dll;avfilter-5.dll;avformat-56.dll;avutil-54.dll;postproc-53.dll;swresample-1.dll;swscale-3.dll;WinSparkle.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>$(OutDir)$(ProjectName).pdb</ProgramDatabaseFile>
       <RandomizedBaseAddress>true</RandomizedBaseAddress>

--- a/tools/windows/CompileInfo.bat
+++ b/tools/windows/CompileInfo.bat
@@ -14,6 +14,7 @@ FOR /f %%i IN ('%msys_bin_dir%\awk.exe "/VERSION_MAJOR/ {print $2}" %base_dir%\v
 FOR /f %%i IN ('%msys_bin_dir%\awk.exe "/VERSION_MINOR/ {print $2}" %base_dir%\version.txt') DO SET minor=%%i
 FOR /f %%i IN ('%msys_bin_dir%\awk.exe "/VERSION_TAG/ {print $2}" %base_dir%\version.txt') DO SET tag=%%i
 FOR /f %%i IN ('%msys_bin_dir%\awk.exe "/ADDON_API/ {print $2}" %base_dir%\version.txt') DO SET addon_api=%%i
+FOR /f %%i IN ('%msys_bin_dir%\awk.exe "/SPARKLE_UPDATE_SCHEME_URL/ {print $2}" %base_dir%\version.txt') DO SET sparkle_update_scheme_url=%%i
 
 SET app_version=%major%.%minor%
 IF NOT [%tag%] == [] (
@@ -27,5 +28,5 @@ CALL SET file_version=%%addon_api:.=%separator%%%%separator%0
 REM create the files with the proper version information
 "%msys_bin_dir%\sed.exe" -e s/@APP_NAME@/%app_name%/g -e s/@APP_VERSION_MAJOR@/%major%/g -e s/@APP_VERSION_MINOR@/%minor%/g -e s/@APP_VERSION_TAG@/%tag%/g "%base_dir%\xbmc\CompileInfo.cpp.in" > "%base_dir%\xbmc\CompileInfo.cpp"
 "%msys_bin_dir%\sed.exe" s/@APP_ADDON_API@/%addon_api%/g "%base_dir%\addons\xbmc.addon\addon.xml.in" > "%base_dir%\addons\xbmc.addon\addon.xml"
-"%msys_bin_dir%\sed.exe" -e s/@APP_NAME@/%app_name%/g -e s/@COMPANY_NAME@/%company_name%/g -e s/@APP_VERSION_MAJOR@/%major%/g -e s/@APP_VERSION_MINOR@/%minor%/g -e s/@APP_VERSION_TAG@/%tag%/g -e s/@FILE_VERSION@/%file_version%/g -e s/@APP_VERSION@/%app_version%/g "%base_dir%\xbmc\win32\XBMC_PC.rc.in" > "%base_dir%\xbmc\win32\XBMC_PC.rc"
+"%msys_bin_dir%\sed.exe" -e s/@APP_NAME@/%app_name%/g -e s/@COMPANY_NAME@/%company_name%/g -e s/@APP_VERSION_MAJOR@/%major%/g -e s/@APP_VERSION_MINOR@/%minor%/g -e s/@APP_VERSION_TAG@/%tag%/g -e s/@FILE_VERSION@/%file_version%/g -e s/@APP_VERSION@/%app_version%/g -e s#@SPARKLE_UPDATE_SCHEME_URL@#%sparkle_update_scheme_url%#g "%base_dir%\xbmc\win32\XBMC_PC.rc.in" > "%base_dir%\xbmc\win32\XBMC_PC.rc"
 

--- a/version.txt
+++ b/version.txt
@@ -6,6 +6,7 @@ VERSION_MINOR 0
 VERSION_TAG ALPHA1
 VERSION_CODE 149701
 ADDON_API 14.9.701
+SPARKLE_UPDATE_SCHEME_URL http://mirrors.kodi.tv/releases/sparkleupdate.xml
 
 # Notes:
 # Change AC_INIT in configure.in

--- a/xbmc/win32/Win32DelayedDllLoad.cpp
+++ b/xbmc/win32/Win32DelayedDllLoad.cpp
@@ -60,6 +60,12 @@ FARPROC WINAPI delayHookNotifyFunc (unsigned dliNotify, PDelayLoadInfo pdli)
         HMODULE hMod = LoadLibraryEx(strDll.c_str(), 0, LOAD_WITH_ALTERED_SEARCH_PATH);
         return (FARPROC)hMod;
       }
+      if (stricmp(pdli->szDll, "winsparkle.dll") == 0)
+      {
+        std::string strDll = CSpecialProtocol::TranslatePath("special://xbmcbin/system/winsparkle.dll");
+        HMODULE hMod = LoadLibraryEx(strDll.c_str(), 0, LOAD_WITH_ALTERED_SEARCH_PATH);
+        return (FARPROC)hMod;
+      }
       if (stricmp(pdli->szDll, "avcodec-56.dll") == 0)
       {
         std::string strDll = CSpecialProtocol::TranslatePath("special://xbmcbin/system/players/dvdplayer/avcodec-56.dll");

--- a/xbmc/win32/XBMC_PC.cpp
+++ b/xbmc/win32/XBMC_PC.cpp
@@ -35,10 +35,20 @@
 #include "utils/CPUInfo.h"
 #include <mmdeviceapi.h>
 #include "win32/IMMNotificationClient.h"
+#include <winsparkle.h>
 
 #ifndef _DEBUG
 #define XBMC_TRACK_EXCEPTIONS
 #endif
+
+// callback for the sparkle updater
+void win_sparkle_shutdown_request_callback()
+{
+  // shutdown kodi...
+  g_application.Stop(EXITCODE_QUIT);
+}
+
+
 
 // Minidump creation function
 LONG WINAPI CreateMiniDump( EXCEPTION_POINTERS* pEp )
@@ -236,7 +246,15 @@ INT WINAPI WinMain( HINSTANCE hInst, HINSTANCE, LPSTR commandLine, INT )
     SAFE_RELEASE(pEnumerator);
   }
 
+  // init win_sparkle inapp updater
+  win_sparkle_set_shutdown_request_callback(win_sparkle_shutdown_request_callback);
+  win_sparkle_init();
+
+
   g_application.Run();
+
+  // shutdown the updater
+  win_sparkle_cleanup();
 
   // clear previously set timer resolution
   timeEndPeriod(1);		

--- a/xbmc/win32/XBMC_PC.rc.in
+++ b/xbmc/win32/XBMC_PC.rc.in
@@ -21,6 +21,11 @@ LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
 #pragma code_page(1252)
 #endif //_WIN32
 
+// Get updates from this appcast feed:
+FeedURL     APPCAST     {"@SPARKLE_UPDATE_SCHEME_URL@"}
+
+
+
 #ifdef APSTUDIO_INVOKED
 /////////////////////////////////////////////////////////////////////////////
 //


### PR DESCRIPTION
Well basically the same like #6474 just for windows. Need to upload the package once home and verify how to adapt the xml to serve both - win32 and osx at the same time. Windows version has no signing support (and so its not forced and needed of course).

Screenshots (didn't came further due to firewall restrictions):

https://dl.dropboxusercontent.com/u/30371861/sparkle/01-winsparkle-update.png
https://dl.dropboxusercontent.com/u/30371861/sparkle/02-winsparkle-update.png
