### PR TITLE
Add support for jumping to the first unwatched tv show season/episode

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -11322,7 +11322,10 @@ msgctxt "#21415"
 msgid "Default music video scraper"
 msgstr ""
 
-#empty string with id 21416
+#: system/settings/settings.xml
+msgctxt "#21416"
+msgid "Jump to first unwatched TV show season/episode"
+msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#21417"
@@ -11545,7 +11548,11 @@ msgctxt "#21465"
 msgid "Above video"
 msgstr ""
 
-#empty string with id 21466
+#. Description of setting "Videos -> Library -> Jump to first unwatched TV show season/episode" with label #21416
+#: system/settings/settings.xml
+msgctxt "#21466"
+msgid "When entering a TV show season or episode view automatically jump to the first unwatched season or episode."
+msgstr ""
 
 #. Filter (media data) from float value to float value
 #: xbmc/dialogs/GUIDialogMediaFilter.cpp

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -345,6 +345,11 @@
           </constraints>
           <control type="spinner" format="string" />
         </setting>
+        <setting id="videolibrary.jumptofirstunplayeditem" type="boolean" label="21416" help="21466">
+          <level>1</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
         <setting id="videolibrary.groupmoviesets" type="boolean" label="20458" help="36145">
           <level>0</level>
           <default>false</default>

--- a/xbmc/video/GUIViewStateVideo.cpp
+++ b/xbmc/video/GUIViewStateVideo.cpp
@@ -436,6 +436,31 @@ bool CGUIViewStateWindowVideoNav::AutoPlayNextItem()
   return CSettings::Get().GetBool("videoplayer.autoplaynextitem");
 }
 
+bool CGUIViewStateWindowVideoNav::JumpToFirstUnplayedItem()
+{
+  if (m_items.IsVideoDb())
+  {
+    NODE_TYPE NodeType = CVideoDatabaseDirectory::GetDirectoryChildType(m_items.GetPath());
+    switch (NodeType)
+    {
+    case NODE_TYPE_EPISODES:
+      if (GetSortMethod().sortBy == SortBy::SortByEpisodeNumber)
+        return CSettings::Get().GetBool("videolibrary.jumptofirstunplayeditem");
+      else
+        return false;
+
+    case NODE_TYPE_SEASONS:
+      return CSettings::Get().GetBool("videolibrary.jumptofirstunplayeditem");
+
+    default:
+      return false;
+      break;
+    }
+  }
+
+  return CGUIViewStateWindowVideo::JumpToFirstUnplayedItem();
+}
+
 CGUIViewStateWindowVideoPlaylist::CGUIViewStateWindowVideoPlaylist(const CFileItemList& items) : CGUIViewStateWindowVideo(items)
 {
   AddSortMethod(SortByNone, 551, LABEL_MASKS("%L", "", "%L", ""));  // Label, empty | Label, empty

--- a/xbmc/video/GUIViewStateVideo.h
+++ b/xbmc/video/GUIViewStateVideo.h
@@ -49,6 +49,7 @@ class CGUIViewStateWindowVideoNav : public CGUIViewStateWindowVideo
 public:
   CGUIViewStateWindowVideoNav(const CFileItemList& items);
   virtual bool AutoPlayNextItem();
+  virtual bool JumpToFirstUnplayedItem();
 
 protected:
   virtual void SaveViewState();

--- a/xbmc/view/GUIViewState.cpp
+++ b/xbmc/view/GUIViewState.cpp
@@ -395,6 +395,11 @@ bool CGUIViewState::AutoPlayNextItem()
   return false;
 }
 
+bool CGUIViewState::JumpToFirstUnplayedItem()
+{
+  return false;
+}
+
 std::string CGUIViewState::GetLockType()
 {
   return "";

--- a/xbmc/view/GUIViewState.h
+++ b/xbmc/view/GUIViewState.h
@@ -56,6 +56,7 @@ public:
   void SetPlaylistDirectory(const std::string& strDirectory);
   bool IsCurrentPlaylistDirectory(const std::string& strDirectory);
   virtual bool AutoPlayNextItem();
+  virtual bool JumpToFirstUnplayedItem();
 
   virtual std::string GetLockType();
   virtual std::string GetExtensions();

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -71,6 +71,7 @@
 #include "xbmc/android/activity/XBMCApp.h"
 #endif
 #include "FileItemListModification.h"
+#include "video/VideoInfoTag.h"
 
 #define CONTROL_BTNVIEWASICONS       2
 #define CONTROL_BTNSORTBY            3
@@ -851,9 +852,35 @@ bool CGUIMediaWindow::Update(const std::string &strDirectory, bool updateFilterP
     }
   }
 
-  // if we haven't found the selected item, select the first item
+  // if we haven't found the selected item, see if we should select the first unplayed item
+  // if yes, find the first unplayed item and select it
+  // if no, select the first item
   if (!bSelectedFound)
-    m_viewControl.SetSelectedItem(0);
+  {
+    int iIndex = 0; // index of the item to select, default to the first item
+
+    // Check if we should select the first unplayed item
+    if (m_guiState.get()->JumpToFirstUnplayedItem())
+    {
+      // Find the index of the 
+      for (int i = 0; i < m_vecItems->Size(); ++i)
+      {
+        CFileItemPtr pItem = m_vecItems->Get(i);
+        // We don't want to jump to the parent folder item or an All Seasons item
+        if (pItem->IsParentFolder() || !pItem->HasVideoInfoTag() || 
+          (pItem->GetVideoInfoTag()->m_type == MediaTypeSeason && pItem->GetVideoInfoTag()->m_iSeason < 0))
+          continue;
+
+        if (pItem->GetVideoInfoTag()->m_playCount == 0)
+        {
+          iIndex = i;
+          break;
+        }
+      }
+    }
+
+    m_viewControl.SetSelectedItem(iIndex);
+  }
 
   m_history.AddPath(m_vecItems->GetPath(), m_strFilterPath);
 


### PR DESCRIPTION
My first PR - please be gentle :)

This is a pull request to add support for automatically selecting the first unwatched item when viewing tv show seasons or episodes from the library.

It adds a setting (Videos -> Library -> Jump to first unwatched TV show season/episode) which can be used to toggle the functionality on/off.

This is my first foray into the Kodi code so I may not have implemented it in the right place, so comments and suggestions are welcome :)
