### PR TITLE
Add optional .index() to Control.GetLabel() allowing access to secondary labels

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1313,6 +1313,20 @@ int CGUIInfoManager::TranslateSingleString(const CStdString &strCondition, bool 
         return AddMultiInfo(GUIInfo(TranslateListItem(info[2]), id, offset, INFOFLAG_LISTITEM_WRAP));
       }
     }
+    else if (info[0].name == "control")
+    {
+      const Property &prop = info[1];
+      for (size_t i = 0; i < sizeof(control_labels) / sizeof(infomap); i++)
+      {
+        if (prop.name == control_labels[i].str)
+        { // TODO: The parameter for these should really be on the first not the second property
+          int controlID = atoi(prop.param().c_str());
+          if (controlID)
+            return AddMultiInfo(GUIInfo(control_labels[i].val, controlID, atoi(info[2].param(0).c_str())));
+          return 0;
+        }
+      }
+    }
   }
 
   return 0;
@@ -3295,7 +3309,13 @@ CStdString CGUIInfoManager::GetMultiInfoLabel(const GUIInfo &info, int contextWi
     {
       const CGUIControl *control = window->GetControl(info.GetData1());
       if (control)
-        return control->GetDescription();
+      {
+        int data2 = info.GetData2();
+        if (data2)
+          return control->GetDescriptionByIndex(data2);
+        else
+          return control->GetDescription();
+      }
     }
   }
   else if (info.m_info == WINDOW_PROPERTY)

--- a/xbmc/guilib/GUIControl.h
+++ b/xbmc/guilib/GUIControl.h
@@ -216,6 +216,7 @@ public:
   virtual void SetInvalid() { m_bInvalidated = true; };
   virtual void SetPulseOnSelect(bool pulse) { m_pulseOnSelect = pulse; };
   virtual std::string GetDescription() const { return ""; };
+  virtual std::string GetDescriptionByIndex(int index) const { return ""; };
 
   void SetAnimations(const std::vector<CAnimation> &animations);
   const std::vector<CAnimation> &GetAnimations() const { return m_animations; };

--- a/xbmc/guilib/GUIEditControl.cpp
+++ b/xbmc/guilib/GUIEditControl.cpp
@@ -748,3 +748,13 @@ void CGUIEditControl::SetFocus(bool focus)
   CGUIControl::SetFocus(focus);
   SetInvalid();
 }
+
+std::string CGUIEditControl::GetDescriptionByIndex(int index) const
+{
+  if (index == 0)
+    return GetDescription();
+  else if(index == 1)
+    return GetLabel2();
+
+  return "";
+}

--- a/xbmc/guilib/GUIEditControl.h
+++ b/xbmc/guilib/GUIEditControl.h
@@ -92,6 +92,7 @@ protected:
   virtual void RenderText();
   virtual CGUILabel::COLOR GetTextColor() const;
   CStdStringW GetDisplayedText() const;
+  std::string GetDescriptionByIndex(int index) const;
   bool SetStyledText(const CStdStringW &text);
   void RecalcLabelPosition();
   void ValidateCursor();


### PR DESCRIPTION
This is the pull request from master #6327 

In Gotham, the text that was entered in the keyboard dialog was displayed on a label control which was accessible from skins and scripts. Helix moved this to using an edit control, which is not accessible. This broke speech for the dialog, making it nearly impossible for the blind to change settings that required it, enter passwords etc.

This pull request was created to fix that. While it necessitates adding a feature, that is a byproduct of the nature of the fix. It is impossible to fix this issue without adding a feature.
Ultimately for the blind users, this fixes something that is broken.

Anyway, here it is for the powers that be to decide if it belongs in the Helix point release.
