### PR TITLE
[jenkins/addons] - fix error detection during addons build

### DIFF
--- a/tools/buildsteps/android/make-binary-addons
+++ b/tools/buildsteps/android/make-binary-addons
@@ -4,17 +4,18 @@ XBMC_PLATFORM_DIR=android
 
 . $WORKSPACE/tools/buildsteps/$XBMC_PLATFORM_DIR/make-native-depends 
 
-for addon in $BINARY_ADDONS
-do
-  ALL_BINARY_ADDONS_BUILT="1"
-  #only build binary addons if something in the addons metadata changed
-  if [ "$(pathChanged $WORKSPACE/project/cmake)" == "1" ]
-  then
+ALL_BINARY_ADDONS_BUILT="1"
+#only build binary addons if something in the addons metadata changed
+if [ "$(pathChanged $WORKSPACE/project/cmake)" == "1" ]
+then
+  for addon in $BINARY_ADDONS
+  do
     echo "building $addon"
     git clean -xffd $WORKSPACE/$BINARY_ADDONS_ROOT/$addon
     cd $WORKSPACE/$BINARY_ADDONS_ROOT/$addon;make -j $BUILDTHREADS || ALL_BINARY_ADDONS_BUILT="0"
-  fi
-done
+  done
+fi
+
 if [ "$ALL_BINARY_ADDONS_BUILT" == "1" ]
 then
   tagSuccessFulBuild $WORKSPACE/project/cmake

--- a/tools/buildsteps/androidx86/make-binary-addons
+++ b/tools/buildsteps/androidx86/make-binary-addons
@@ -4,17 +4,18 @@ XBMC_PLATFORM_DIR=android
 
 . $WORKSPACE/tools/buildsteps/$XBMC_PLATFORM_DIR/make-native-depends
 
-for addon in $BINARY_ADDONS
-do
-  ALL_BINARY_ADDONS_BUILT="1"
-  #only build binary addons if something in the addons metadata changed
-  if [ "$(pathChanged $WORKSPACE/project/cmake)" == "1" ]
-  then
+ALL_BINARY_ADDONS_BUILT="1"
+#only build binary addons if something in the addons metadata changed
+if [ "$(pathChanged $WORKSPACE/project/cmake)" == "1" ]
+then
+  for addon in $BINARY_ADDONS
+  do
     echo "building $addon"
     git clean -xffd $WORKSPACE/$BINARY_ADDONS_ROOT/$addon
     cd $WORKSPACE/$BINARY_ADDONS_ROOT/$addon;make -j $BUILDTHREADS || ALL_BINARY_ADDONS_BUILT="0"
-  fi
-done
+  done
+fi
+
 if [ "$ALL_BINARY_ADDONS_BUILT" == "1" ]
 then
   tagSuccessFulBuild $WORKSPACE/project/cmake

--- a/tools/buildsteps/atv2/make-binary-addons
+++ b/tools/buildsteps/atv2/make-binary-addons
@@ -4,17 +4,18 @@ XBMC_PLATFORM_DIR=atv2
 
 . $WORKSPACE/tools/buildsteps/$XBMC_PLATFORM_DIR/make-native-depends
 
-for addon in $BINARY_ADDONS
-do
-  ALL_BINARY_ADDONS_BUILT="1"
-  #only build binary addons if something in the addons metadata changed
-  if [ "$(pathChanged $WORKSPACE/project/cmake)" == "1" ]
-  then
+ALL_BINARY_ADDONS_BUILT="1"
+#only build binary addons if something in the addons metadata changed
+if [ "$(pathChanged $WORKSPACE/project/cmake)" == "1" ]
+then
+  for addon in $BINARY_ADDONS
+  do
     echo "building $addon"
     git clean -xffd $WORKSPACE/$BINARY_ADDONS_ROOT/$addon
     cd $WORKSPACE/$BINARY_ADDONS_ROOT/$addon;make -j $BUILDTHREADS || ALL_BINARY_ADDONS_BUILT="0"
-  fi
-done
+  done
+fi
+
 if [ "$ALL_BINARY_ADDONS_BUILT" == "1" ]
 then
   tagSuccessFulBuild $WORKSPACE/project/cmake

--- a/tools/buildsteps/ios/make-binary-addons
+++ b/tools/buildsteps/ios/make-binary-addons
@@ -4,17 +4,18 @@ XBMC_PLATFORM_DIR=ios
 
 . $WORKSPACE/tools/buildsteps/$XBMC_PLATFORM_DIR/make-native-depends
 
-for addon in $BINARY_ADDONS
-do
-  ALL_BINARY_ADDONS_BUILT="1"
-  #only build binary addons if something in the addons metadata changed
-  if [ "$(pathChanged $WORKSPACE/project/cmake)" == "1" ]
-  then
+ALL_BINARY_ADDONS_BUILT="1"
+#only build binary addons if something in the addons metadata changed
+if [ "$(pathChanged $WORKSPACE/project/cmake)" == "1" ]
+then
+  for addon in $BINARY_ADDONS
+  do
     echo "building $addon"
     git clean -xffd $WORKSPACE/$BINARY_ADDONS_ROOT/$addon
     cd $WORKSPACE/$BINARY_ADDONS_ROOT/$addon;make -j $BUILDTHREADS || ALL_BINARY_ADDONS_BUILT="0"
-  fi
-done
+  done
+fi
+
 if [ "$ALL_BINARY_ADDONS_BUILT" == "1" ]
 then
   tagSuccessFulBuild $WORKSPACE/project/cmake

--- a/tools/buildsteps/linux32/make-binary-addons
+++ b/tools/buildsteps/linux32/make-binary-addons
@@ -4,17 +4,18 @@ XBMC_PLATFORM_DIR=linux32
 
 . $WORKSPACE/tools/buildsteps/$XBMC_PLATFORM_DIR/make-native-depends
 
-for addon in $BINARY_ADDONS
-do
-  ALL_BINARY_ADDONS_BUILT="1"
-  #only build binary addons if something in the addons metadata changed
-  if [ "$(pathChanged $WORKSPACE/project/cmake)" == "1" ]
-  then
+ALL_BINARY_ADDONS_BUILT="1"
+#only build binary addons if something in the addons metadata changed
+if [ "$(pathChanged $WORKSPACE/project/cmake)" == "1" ]
+then
+  for addon in $BINARY_ADDONS
+  do
     echo "building $addon"
     git clean -xffd $WORKSPACE/$BINARY_ADDONS_ROOT/$addon
     cd $WORKSPACE/$BINARY_ADDONS_ROOT/$addon;make -j $BUILDTHREADS || ALL_BINARY_ADDONS_BUILT="0"
-  fi
-done
+  done
+fi
+
 if [ "$ALL_BINARY_ADDONS_BUILT" == "1" ]
 then
   tagSuccessFulBuild $WORKSPACE/project/cmake

--- a/tools/buildsteps/linux64/make-binary-addons
+++ b/tools/buildsteps/linux64/make-binary-addons
@@ -4,17 +4,18 @@ XBMC_PLATFORM_DIR=linux64
 
 . $WORKSPACE/tools/buildsteps/$XBMC_PLATFORM_DIR/make-native-depends
 
-for addon in $BINARY_ADDONS
-do
-  ALL_BINARY_ADDONS_BUILT="1"
-  #only build binary addons if something in the addons metadata changed
-  if [ "$(pathChanged $WORKSPACE/project/cmake)" == "1" ]
-  then
+ALL_BINARY_ADDONS_BUILT="1"
+#only build binary addons if something in the addons metadata changed
+if [ "$(pathChanged $WORKSPACE/project/cmake)" == "1" ]
+then
+  for addon in $BINARY_ADDONS
+  do
     echo "building $addon"
     git clean -xffd $WORKSPACE/$BINARY_ADDONS_ROOT/$addon
     cd $WORKSPACE/$BINARY_ADDONS_ROOT/$addon;make -j $BUILDTHREADS || ALL_BINARY_ADDONS_BUILT="0"
-  fi
-done
+  done
+fi
+
 if [ "$ALL_BINARY_ADDONS_BUILT" == "1" ]
 then
   tagSuccessFulBuild $WORKSPACE/project/cmake

--- a/tools/buildsteps/osx32/make-binary-addons
+++ b/tools/buildsteps/osx32/make-binary-addons
@@ -4,17 +4,18 @@ XBMC_PLATFORM_DIR=osx32
 
 . $WORKSPACE/tools/buildsteps/$XBMC_PLATFORM_DIR/make-native-depends
 
-for addon in $BINARY_ADDONS
-do
-  ALL_BINARY_ADDONS_BUILT="1"
-  #only build binary addons if something in the addons metadata changed
-  if [ "$(pathChanged $WORKSPACE/project/cmake)" == "1" ]
-  then
+ALL_BINARY_ADDONS_BUILT="1"
+#only build binary addons if something in the addons metadata changed
+if [ "$(pathChanged $WORKSPACE/project/cmake)" == "1" ]
+then
+  for addon in $BINARY_ADDONS
+  do
     echo "building $addon"
     git clean -xffd $WORKSPACE/$BINARY_ADDONS_ROOT/$addon
     cd $WORKSPACE/$BINARY_ADDONS_ROOT/$addon;make -j $BUILDTHREADS || ALL_BINARY_ADDONS_BUILT="0"
-  fi
-done
+  done
+fi
+
 if [ "$ALL_BINARY_ADDONS_BUILT" == "1" ]
 then
   tagSuccessFulBuild $WORKSPACE/project/cmake

--- a/tools/buildsteps/osx64/make-binary-addons
+++ b/tools/buildsteps/osx64/make-binary-addons
@@ -4,17 +4,18 @@ XBMC_PLATFORM_DIR=osx64
 
 . $WORKSPACE/tools/buildsteps/$XBMC_PLATFORM_DIR/make-native-depends
 
-for addon in $BINARY_ADDONS
-do
-  ALL_BINARY_ADDONS_BUILT="1"
-  #only build binary addons if something in the addons metadata changed
-  if [ "$(pathChanged $WORKSPACE/project/cmake)" == "1" ]
-  then
+ALL_BINARY_ADDONS_BUILT="1"
+#only build binary addons if something in the addons metadata changed
+if [ "$(pathChanged $WORKSPACE/project/cmake)" == "1" ]
+then
+  for addon in $BINARY_ADDONS
+  do
     echo "building $addon"
     git clean -xffd $WORKSPACE/$BINARY_ADDONS_ROOT/$addon
     cd $WORKSPACE/$BINARY_ADDONS_ROOT/$addon;make -j $BUILDTHREADS || ALL_BINARY_ADDONS_BUILT="0"
-  fi
-done
+  done
+fi
+
 if [ "$ALL_BINARY_ADDONS_BUILT" == "1" ]
 then
   tagSuccessFulBuild $WORKSPACE/project/cmake

--- a/tools/buildsteps/rbpi/make-binary-addons
+++ b/tools/buildsteps/rbpi/make-binary-addons
@@ -4,17 +4,18 @@ XBMC_PLATFORM_DIR=rbpi
 
 . $WORKSPACE/tools/buildsteps/$XBMC_PLATFORM_DIR/make-native-depends
 
-for addon in $BINARY_ADDONS
-do
-  ALL_BINARY_ADDONS_BUILT="1"
-  #only build binary addons if something in the addons metadata changed
-  if [ "$(pathChanged $WORKSPACE/project/cmake)" == "1" ]
-  then
+ALL_BINARY_ADDONS_BUILT="1"
+#only build binary addons if something in the addons metadata changed
+if [ "$(pathChanged $WORKSPACE/project/cmake)" == "1" ]
+then
+  for addon in $BINARY_ADDONS
+  do
     echo "building $addon"
     git clean -xffd $WORKSPACE/$BINARY_ADDONS_ROOT/$addon
     cd $WORKSPACE/$BINARY_ADDONS_ROOT/$addon;make -j $BUILDTHREADS || ALL_BINARY_ADDONS_BUILT="0"
-  fi
-done
+  done
+fi
+
 if [ "$ALL_BINARY_ADDONS_BUILT" == "1" ]
 then
   tagSuccessFulBuild $WORKSPACE/project/cmake


### PR DESCRIPTION
"Allgood" Flag was always reset to 1 - basically the if and the for loop where switched.

@Montellese could you try this in your branch?
