### PR TITLE
[linux] prepend -Wall so it doesn't override flags from environment

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -789,8 +789,8 @@ else
     DEBUG_FLAGS="-DNDEBUG=1"
   fi
 fi
-CFLAGS="$CFLAGS $DEBUG_FLAGS"
-CXXFLAGS="$CXXFLAGS $DEBUG_FLAGS"
+CFLAGS="$DEBUG_FLAGS $CFLAGS"
+CXXFLAGS="$DEBUG_FLAGS $CXXFLAGS"
 
 
 if test "$use_optimizations" = "yes"; then


### PR DESCRIPTION
With clang order matters apparently and setting -Wall last will toggle any previously disabled warnings on.
