### PR TITLE
revert xbmc.gui bw-compatibility change

### DIFF
--- a/addons/xbmc.gui/addon.xml
+++ b/addons/xbmc.gui/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="xbmc.gui" version="5.8.0" provider-name="Team-Kodi">
-  <backwards-compatibility abi="5.8.0"/>
+  <backwards-compatibility abi="5.3.0"/>
   <requires>
     <import addon="xbmc.core" version="0.1.0"/>
   </requires>


### PR DESCRIPTION
this sets the api compatibility for skins back to 5.3.0

the change in https://github.com/xbmc/xbmc/commit/6e3f59b48270b2979d513e7407359774a7895cd0#diff-79505cb5dc0792bd934ba7de1a0c9cd3L2 is incorrect and basically breaks every skin in the book.
