### PR TITLE
Refactor #6489 JumpToFirstUnplayedItem to SelectFirstUnwatchedItem

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -11338,7 +11338,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#21416"
-msgid "Jump to first unwatched TV show season/episode"
+msgid "Select the first unwatched TV show season/episode"
 msgstr ""
 
 #: system/settings/settings.xml
@@ -11562,10 +11562,10 @@ msgctxt "#21465"
 msgid "Above video"
 msgstr ""
 
-#. Description of setting "Videos -> Library -> Jump to first unwatched TV show season/episode" with label #21416
+#. Description of setting "Videos -> Library -> Select first unwatched TV show season/episode" with label #21416
 #: system/settings/settings.xml
 msgctxt "#21466"
-msgid "When entering a TV show season or episode view automatically jump to the first unwatched season or episode."
+msgid "When entering a TV show season or episode view automatically select the first unwatched season or episode. [On first entry] the first unwatched item will be selected only when a view is entered for the first time. [Always] the first unwatched item will be selected every time a view is entered."
 msgstr ""
 
 #. Filter (media data) from float value to float value
@@ -11593,7 +11593,48 @@ msgctxt "#21470"
 msgid "%s [%d]"
 msgstr ""
 
-#empty strings from id 21471 to 21601
+#. One of the values valid for "Videos -> Library -> Select first unwatched TV show season/episode" with label #21416
+#: system/settings/settings.xml
+msgctxt "#21471"
+msgid "On first entry"
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#21472"
+msgid "Include All Seasons and Specials"
+msgstr ""
+
+#. Description of setting "Videos -> Library -> Include All Seasons and Specials" with label #21472
+#: system/settings/settings.xml
+msgctxt "#21473"
+msgid "Whether or not to consider All Seasons and Special items in the unwatched item selection."
+msgstr ""
+
+#. One of the values valid for "Videos -> Library -> Include All Seasons and Specials" with label #21472
+#: system/settings/settings.xml
+msgctxt "#21474"
+msgid "Neither"
+msgstr ""
+
+#. One of the values valid for "Videos -> Library -> Include All Seasons and Specials" with label #21472
+#: system/settings/settings.xml
+msgctxt "#21475"
+msgid "Both"
+msgstr ""
+
+#. One of the values valid for "Videos -> Library -> Include All Seasons and Specials" with label #21472
+#: system/settings/settings.xml
+msgctxt "#21476"
+msgid "Just All Seasons"
+msgstr ""
+
+#. One of the values valid for "Videos -> Library -> Include All Seasons and Specials" with label #21472
+#: system/settings/settings.xml
+msgctxt "#21477"
+msgid "Just Specials"
+msgstr ""
+
+#empty strings from id 21478 to 21601
 
 #: xbmc/Util.cpp
 msgctxt "#21602"

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -349,10 +349,33 @@
           </constraints>
           <control type="list" format="string" />
         </setting>
-        <setting id="videolibrary.jumptofirstunplayeditem" type="boolean" label="21416" help="21466">
+        <setting id="videolibrary.tvshowsselectfirstunwatcheditem" type="integer" label="21416" help="21466">
           <level>1</level>
-          <default>false</default>
-          <control type="toggle" />
+          <default>0</default> <!-- Never -->
+          <constraints>
+            <options>
+              <option label="20420">0</option> <!-- Never -->
+              <option label="21471">1</option> <!-- On first entry -->
+              <option label="20422">2</option> <!-- Always -->
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="videolibrary.tvshowsincludeallseasonsandspecials" type="integer" parent="videolibrary.tvshowsselectfirstunwatcheditem" label="21472" help="21473">
+          <level>2</level>
+          <default>0</default> <!-- Neither -->
+          <constraints>
+            <options>
+              <option label="21474">0</option> <!-- Neither -->
+              <option label="21475">1</option> <!-- Both -->
+              <option label="21476">2</option> <!-- Just All Seasons -->
+              <option label="21477">3</option> <!-- Just Specials -->
+            </options>
+          </constraints>
+          <dependencies>
+            <dependency type="enable" setting="videolibrary.tvshowsselectfirstunwatcheditem" operator="!is">0</dependency> <!-- Never -->
+          </dependencies>
+          <control type="spinner" format="string" />
         </setting>
         <setting id="videolibrary.hideallitems" type="boolean" label="38011" help="38012">
           <level>2</level>

--- a/xbmc/video/GUIViewStateVideo.cpp
+++ b/xbmc/video/GUIViewStateVideo.cpp
@@ -436,31 +436,6 @@ bool CGUIViewStateWindowVideoNav::AutoPlayNextItem()
   return CSettings::Get().GetBool("videoplayer.autoplaynextitem");
 }
 
-bool CGUIViewStateWindowVideoNav::JumpToFirstUnplayedItem()
-{
-  if (m_items.IsVideoDb())
-  {
-    NODE_TYPE NodeType = CVideoDatabaseDirectory::GetDirectoryChildType(m_items.GetPath());
-    switch (NodeType)
-    {
-    case NODE_TYPE_EPISODES:
-      if (GetSortMethod().sortBy == SortBy::SortByEpisodeNumber)
-        return CSettings::Get().GetBool("videolibrary.jumptofirstunplayeditem");
-      else
-        return false;
-
-    case NODE_TYPE_SEASONS:
-      return CSettings::Get().GetBool("videolibrary.jumptofirstunplayeditem");
-
-    default:
-      return false;
-      break;
-    }
-  }
-
-  return CGUIViewStateWindowVideo::JumpToFirstUnplayedItem();
-}
-
 CGUIViewStateWindowVideoPlaylist::CGUIViewStateWindowVideoPlaylist(const CFileItemList& items) : CGUIViewStateWindowVideo(items)
 {
   AddSortMethod(SortByNone, 551, LABEL_MASKS("%L", "", "%L", ""));  // Label, empty | Label, empty

--- a/xbmc/video/GUIViewStateVideo.h
+++ b/xbmc/video/GUIViewStateVideo.h
@@ -49,7 +49,6 @@ class CGUIViewStateWindowVideoNav : public CGUIViewStateWindowVideo
 public:
   CGUIViewStateWindowVideoNav(const CFileItemList& items);
   virtual bool AutoPlayNextItem();
-  virtual bool JumpToFirstUnplayedItem();
 
 protected:
   virtual void SaveViewState();

--- a/xbmc/video/windows/GUIWindowVideoNav.h
+++ b/xbmc/video/windows/GUIWindowVideoNav.h
@@ -24,6 +24,21 @@
 
 class CFileItemList;
 
+enum SelectFirstUnwatchedItem
+{
+  NEVER = 0,
+  ON_FIRST_ENTRY = 1,
+  ALWAYS = 2
+};
+
+enum IncludeAllSeasonsAndSpecials
+{
+  NEITHER = 0,
+  BOTH = 1,
+  ALL_SEASONS = 2,
+  SPECIALS = 3
+};
+
 class CGUIWindowVideoNav : public CGUIWindowVideoBase
 {
 public:
@@ -55,7 +70,9 @@ protected:
   virtual bool GetFilteredItems(const std::string &filter, CFileItemList &items);
 
   virtual void OnItemLoaded(CFileItem* pItem) {};
+
   // override base class methods
+  virtual bool Update(const std::string &strDirectory, bool updateFilterPath = true);
   virtual bool GetDirectory(const std::string &strDirectory, CFileItemList &items);
   virtual void UpdateButtons();
   virtual void DoSearch(const std::string& strSearch, CFileItemList& items);
@@ -69,4 +86,9 @@ protected:
   virtual std::string GetQuickpathName(const std::string& strPath) const;
 
   VECSOURCES m_shares;
+
+private:
+  virtual SelectFirstUnwatchedItem GetSettingSelectFirstUnwatchedItem();
+  virtual IncludeAllSeasonsAndSpecials GetSettingIncludeAllSeasonsAndSpecials();
+  virtual int GetFirstUnwatchedItemIndex(bool includeAllSeasons, bool includeSpecials);
 };

--- a/xbmc/view/GUIViewState.cpp
+++ b/xbmc/view/GUIViewState.cpp
@@ -395,11 +395,6 @@ bool CGUIViewState::AutoPlayNextItem()
   return false;
 }
 
-bool CGUIViewState::JumpToFirstUnplayedItem()
-{
-  return false;
-}
-
 std::string CGUIViewState::GetLockType()
 {
   return "";

--- a/xbmc/view/GUIViewState.h
+++ b/xbmc/view/GUIViewState.h
@@ -56,7 +56,6 @@ public:
   void SetPlaylistDirectory(const std::string& strDirectory);
   bool IsCurrentPlaylistDirectory(const std::string& strDirectory);
   virtual bool AutoPlayNextItem();
-  virtual bool JumpToFirstUnplayedItem();
 
   virtual std::string GetLockType();
   virtual std::string GetExtensions();

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -853,35 +853,9 @@ bool CGUIMediaWindow::Update(const std::string &strDirectory, bool updateFilterP
     }
   }
 
-  // if we haven't found the selected item, see if we should select the first unplayed item
-  // if yes, find the first unplayed item and select it
-  // if no, select the first item
+  // if we haven't found the selected item, select the first item
   if (!bSelectedFound)
-  {
-    int iIndex = 0; // index of the item to select, default to the first item
-
-    // Check if we should select the first unplayed item
-    if (m_guiState.get()->JumpToFirstUnplayedItem())
-    {
-      // Find the index of the 
-      for (int i = 0; i < m_vecItems->Size(); ++i)
-      {
-        CFileItemPtr pItem = m_vecItems->Get(i);
-        // We don't want to jump to the parent folder item or an All Seasons item
-        if (pItem->IsParentFolder() || !pItem->HasVideoInfoTag() || 
-          (pItem->GetVideoInfoTag()->m_type == MediaTypeSeason && pItem->GetVideoInfoTag()->m_iSeason < 0))
-          continue;
-
-        if (pItem->GetVideoInfoTag()->m_playCount == 0)
-        {
-          iIndex = i;
-          break;
-        }
-      }
-    }
-
-    m_viewControl.SetSelectedItem(iIndex);
-  }
+    m_viewControl.SetSelectedItem(0);
 
   m_history.AddPath(m_vecItems->GetPath(), m_strFilterPath);
 


### PR DESCRIPTION
As per @xhaggi request in comments for #6489 the first commit changes the settings and method names from videolibrary.jumptofirstunplayeditem and JumpToFirstUnplayedItem to videolibrary.selectfirstunplayeditem and SelectFirstUnplayedItem.

The second commit changes the setting from a boolean to an integer in order to allow future extension of the setting options to allow finer grained control of how the item should be selected e.g. whether to skip over the All Seasons or Specials items.

**UPDATE**
Following discussion with @xhaggi  and @mkortstiege and other comments I have amended the changes as follows:
- I've backed out the previous changes to CGUIMediaWindow and CGUIViewState (and derivatives).
- I've reimplemented as part of CGUIWindowVideoNav
- It is no longer applicable just when episodes are sorted by episode number. It now works by finding the lowest unwatched episode number (or season number if at season level), no matter what the sort type is.
