### PR TITLE
[pvr] Fix compiler warning in CGUIWindowPVRRecordings

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -328,7 +328,7 @@ bool CGUIWindowPVRRecordings::ActionDeleteRecording(CFileItem *item)
 {
   bool bReturn = false;
 
-  if (!item->IsPVRRecording() && !item->m_bIsFolder || item->IsParentFolder())
+  if ((!item->IsPVRRecording() && !item->m_bIsFolder) || item->IsParentFolder())
     return bReturn;
 
   /* show a confirmation dialog */


### PR DESCRIPTION
With this becomes following compiler warning fixed.

<code>  GUIWindowPVRRecordings.cpp: In member function ‘bool PVR::CGUIWindowPVRRecordings::ActionDeleteRecording(CFileItem*)’:</code>
<code>GUIWindowPVRRecordings.cpp:331:31: warning: suggest parentheses around ‘&&’ within ‘||’ [-Wparentheses]</code>
<code>   if (!item->IsPVRRecording() && !item->m_bIsFolder || item->IsParentFolder())</code>
