### PR TITLE
[videoinfoscanner] reset library bools only once - fixes #15805

### DIFF
--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -159,6 +159,7 @@ namespace VIDEO
         }
       }
 
+      g_infoManager.ResetLibraryBools();
       m_database.Close();
 
       tick = XbmcThreads::SystemClockMillis() - tick;
@@ -491,7 +492,6 @@ namespace VIDEO
     if(pDlgProgress)
       pDlgProgress->ShowProgressBar(false);
 
-    g_infoManager.ResetLibraryBools();
     m_database.Close();
     return FoundSomeInfo;
   }


### PR DESCRIPTION
Reset library bools only once. Same is already done in the musicinfoscanner.
This fixes the issue reported in http://trac.kodi.tv/ticket/15805.

@MartijnKaijser, please test again.
