### PR TITLE
[addon] Allow version check also for addon names start with 'kodi.'

### DIFF
--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -318,10 +318,10 @@ AddonPtr CAddon::Clone() const
 
 bool CAddon::MeetsVersion(const AddonVersion &version) const
 {
-  // if the addon is one of xbmc's extension point definitions (addonid starts with "xbmc.")
+  // if the addon is one of kodi's extension point definitions (addonid starts with "kodi." or "xbmc.")
   // and the minversion is "0.0.0" i.e. no <backwards-compatibility> tag has been specified
   // we need to assume that the current version is not backwards-compatible and therefore check against the actual version
-  if (StringUtils::StartsWithNoCase(m_props.id, "xbmc.") && m_props.minversion.empty())
+  if ((StringUtils::StartsWithNoCase(m_props.id, "kodi.") || StringUtils::StartsWithNoCase(m_props.id, "xbmc.")) && m_props.minversion.empty())
     return m_props.version == version;
 
   return m_props.minversion <= version && version <= m_props.version;


### PR DESCRIPTION
With this also the version check becomes performed for add-ons where name starts with "kodi."
