### PR TITLE
Add native artifacts to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -465,11 +465,11 @@ lib/cpluff/stamp-h1
 /tools/android/packaging/xbmc/strings.xml
 
 #/tools/depends
+/tools/depends/native/*/*native/
 /tools/depends/native/JsonSchemaBuilder/bin/
-/tools/depends/native/JsonSchemaBuilder/native/
 /tools/depends/target/ffmpeg/.ffmpeg-installed
-/tools/depends/target/ffmpeg/ffmpeg-2.4-Helix-alpha4.tar.gz
-/tools/depends/target/ffmpeg/ffmpeg-2.4-Helix-alpha4/
+/tools/depends/target/ffmpeg/ffmpeg-*-*.tar.gz
+/tools/depends/target/ffmpeg/ffmpeg-*-*/
 /tools/depends/target/ffmpeg/ffmpeg-install/
 
 # /tools/EventClients/
@@ -488,6 +488,7 @@ lib/cpluff/stamp-h1
 /tools/darwin/packaging/osx/VolumeIcon.icns
 /tools/darwin/packaging/migrate_to_kodi_ios.sh
 /tools/darwin/packaging/seatbeltunlock/mkdeb-seatbeltunlock.sh
+/tools/darwin/runtime/XBMCHelper
 
 # /tools/Linux/
 /tools/Linux/kodi.sh


### PR DESCRIPTION
When building tools/depends we get a whole bunch of artifacts that should be ignored from the git repository, add those to the list.
