### PR TITLE
dvdplayer: fix missing audio info

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1680,7 +1680,7 @@ std::string CGUIInfoManager::GetLabel(int info, int contextWindow, std::string *
     if(g_application.m_pPlayer->IsPlaying())
     {
       SPlayerAudioStreamInfo info;
-      g_application.m_pPlayer->GetAudioStreamInfo(g_application.m_pPlayer->GetAudioStream(), info);
+      g_application.m_pPlayer->GetAudioStreamInfo(CURRENT_STREAM, info);
       strLabel = info.language;
     }
     break;
@@ -4368,7 +4368,7 @@ void CGUIInfoManager::UpdateAVInfo()
       SPlayerAudioStreamInfo audio;
 
       g_application.m_pPlayer->GetVideoStreamInfo(video);
-      g_application.m_pPlayer->GetAudioStreamInfo(g_application.m_pPlayer->GetAudioStream(), audio);
+      g_application.m_pPlayer->GetAudioStreamInfo(CURRENT_STREAM, audio);
 
       m_videoInfo = video;
       m_audioInfo = audio;

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -26,6 +26,8 @@
 #include "guilib/Geometry.h"
 #include <string>
 
+#define CURRENT_STREAM -1
+
 struct TextCacheStruct_t;
 class TiXmlElement;
 class CStreamDetails;

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -4156,6 +4156,9 @@ int CDVDPlayer::GetSourceBitrate()
 
 void CDVDPlayer::GetAudioStreamInfo(int index, SPlayerAudioStreamInfo &info)
 {
+  if (index == CURRENT_STREAM)
+    index = GetAudioStream();
+
   if (index < 0 || index > GetAudioStreamCount() - 1 )
     return;
 

--- a/xbmc/video/dialogs/GUIDialogSubtitles.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitles.cpp
@@ -341,8 +341,7 @@ void CGUIDialogSubtitles::Search(const std::string &search/*=""*/)
     SPlayerAudioStreamInfo info;
     std::string strLanguage;
 
-    int currentAudio = g_application.m_pPlayer->GetAudioStream();
-    g_application.m_pPlayer->GetAudioStreamInfo(currentAudio, info);
+    g_application.m_pPlayer->GetAudioStreamInfo(CURRENT_STREAM, info);
 
     if (!g_LangCodeExpander.Lookup(strLanguage, info.language))
       strLanguage = "Unknown";


### PR DESCRIPTION
Now -1 indicates current stream. No need to bother player with 2 function calls.

@Voyager1 does this fix the issue?
