### PR TITLE
[addons] remove legacy backwards compatibility behaviour

### DIFF
--- a/addons/xbmc.codec/addon.xml
+++ b/addons/xbmc.codec/addon.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="xbmc.codec" version="1.0.1" provider-name="Team-Kodi">
+  <backwards-compatibility abi="1.0.1"/>
   <requires>
     <import addon="xbmc.core" version="0.1.0"/>
   </requires>

--- a/addons/xbmc.pvr/addon.xml
+++ b/addons/xbmc.pvr/addon.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="xbmc.pvr" version="1.9.4" provider-name="Team-Kodi">
+  <backwards-compatibility abi="1.9.4"/>
   <requires>
     <import addon="xbmc.core" version="0.1.0"/>
   </requires>

--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -318,12 +318,6 @@ AddonPtr CAddon::Clone() const
 
 bool CAddon::MeetsVersion(const AddonVersion &version) const
 {
-  // if the addon is one of xbmc's extension point definitions (addonid starts with "xbmc.")
-  // and the minversion is "0.0.0" i.e. no <backwards-compatibility> tag has been specified
-  // we need to assume that the current version is not backwards-compatible and therefore check against the actual version
-  if (StringUtils::StartsWithNoCase(m_props.id, "xbmc.") && m_props.minversion.empty())
-    return m_props.version == version;
-
   return m_props.minversion <= version && version <= m_props.version;
 }
 


### PR DESCRIPTION
This changes the backwards-compatible tag to be consistent for extension point definitions and addons. I.e no backwards-compatible specified now means compatible with 0.0.0

@notspiff this was brought up before. Do you remember why this was added in the first place? (besides not having to add the backwards-compatible tag for everything?) Also, is it correct that xbmc.codec is not backwards compatible?
