### PR TITLE
dvdplayer: audio sync patches

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -1819,6 +1819,7 @@ void CDVDPlayer::HandlePlaySpeed()
         {
           CLog::Log(LOGDEBUG, "CDVDPlayer::Process - Seeking to catch up");
           m_SpeedState.lastseekpts = (int)DVD_TIME_TO_MSEC(m_clock.GetClock());
+          m_SpeedState.needsync = true;
           int iTime = DVD_TIME_TO_MSEC(m_clock.GetClock() + m_State.time_offset + 500000.0 * m_playSpeed / DVD_PLAYSPEED_NORMAL);
           m_messenger.Put(new CDVDMsgPlayerSeek(iTime, (GetPlaySpeed() < 0), true, false, false, true, false));
         }
@@ -2474,10 +2475,11 @@ void CDVDPlayer::HandleMessages()
           m_OmxPlayerState.av_clock.OMXSetSpeed(speed);
           CLog::Log(LOGDEBUG, "%s::%s CDVDMsg::PLAYER_SETSPEED speed : %d (%d)", "CDVDPlayer", __FUNCTION__, speed, m_playSpeed);
         }
-        else if (m_playSpeed < 0 && speed >= 0)
+        else if ((speed == DVD_PLAYSPEED_NORMAL) && m_SpeedState.needsync)
         {
           int64_t iTime = (int64_t)DVD_TIME_TO_MSEC(m_clock.GetClock() + m_State.time_offset);
           m_messenger.Put(new CDVDMsgPlayerSeek(iTime, true, true, false, false, true));
+          m_SpeedState.needsync = false;
         }
 
         // if playspeed is different then DVD_PLAYSPEED_NORMAL or DVD_PLAYSPEED_PAUSE

--- a/xbmc/cores/dvdplayer/DVDPlayer.h
+++ b/xbmc/cores/dvdplayer/DVDPlayer.h
@@ -412,6 +412,7 @@ protected:
     int64_t lasttime;
     int lastseekpts;
     double  lastabstime;
+    bool needsync;
   } m_SpeedState;
 
   int m_errorCount;

--- a/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
@@ -587,8 +587,9 @@ void CDVDPlayerAudio::Process()
       // add any packets play
       packetadded = OutputPacket(audioframe);
 
-      // we are not running until something is cached in output device
-      if(m_stalled && m_dvdAudio.GetCacheTime() > 0.0)
+      // we are not running until something is cached in output device and
+      // we still have a minimum level in the message queue
+      if(m_stalled && m_dvdAudio.GetCacheTime() > 0.0 && m_messageQueue.GetLevel() > 5)
         m_stalled = false;
     }
 


### PR DESCRIPTION
- consider audio stalled if msg queue is empty. audio can't sync with an empty queue
- when rw/ff dvdplayer can do seeks without sync of av players. as a result msg queues may have different levels with different timestamps. do a sync if that happened and we go back to normal speed.

should fix http://trac.kodi.tv/ticket/15806
