### PR TITLE
[pvr] Improve pvr manager start/stop way

### DIFF
--- a/xbmc/ApplicationMessenger.cpp
+++ b/xbmc/ApplicationMessenger.cpp
@@ -864,6 +864,13 @@ void CApplicationMessenger::ProcessMessage(ThreadMessage *pMsg)
 #endif
       break;
     }
+    case TMSG_SETPVRMANAGER:
+    {
+      if (pMsg->param1 != 0)
+        g_application.StartPVRManager();
+      else
+        g_application.StopPVRManager();
+    }
   }
 }
 
@@ -1410,5 +1417,12 @@ void CApplicationMessenger::CECActivateSource()
 void CApplicationMessenger::CECStandby()
 {
   ThreadMessage tMsg = {TMSG_CECSTANDBY};
+  SendMessage(tMsg, false);
+}
+
+void CApplicationMessenger::SetPVRManager(bool onOff)
+{
+  ThreadMessage tMsg = {TMSG_SETPVRMANAGER};
+  tMsg.param1 = onOff ? 1 : 0;
   SendMessage(tMsg, false);
 }

--- a/xbmc/ApplicationMessenger.h
+++ b/xbmc/ApplicationMessenger.h
@@ -91,6 +91,7 @@ namespace MUSIC_INFO
 #define TMSG_CECACTIVATESOURCE    317
 #define TMSG_CECSTANDBY           318
 #define TMSG_SETVIDEORESOLUTION   319
+#define TMSG_SETPVRMANAGER        320
 
 #define TMSG_NETWORKMESSAGE         500
 
@@ -251,6 +252,11 @@ public:
 
   void SetSplashMessage(const std::string& message);
   void SetSplashMessage(int stringID);
+
+  /*! \brief Used to enable/disable PVR system without waiting.
+   \param onOff if true it becomes switched on otherwise off
+   */
+  void SetPVRManager(bool onOff);
   
   bool SetupDisplay();
   bool DestroyDisplay();

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -225,8 +225,6 @@ const BUILT_IN commands[] = {
 #endif
   { "VideoLibrary.Search",        false,  "Brings up a search dialog which will search the library" },
   { "ToggleDebug",                false,  "Enables/disables debug mode" },
-  { "StartPVRManager",            false,  "(Re)Starts the PVR manager" },
-  { "StopPVRManager",             false,  "Stops the PVR manager" },
 #if defined(TARGET_ANDROID)
   { "StartAndroidActivity",       true,   "Launch an Android native app with the given package name.  Optional parms (in order): intent, dataType, dataURI." },
 #endif
@@ -1826,14 +1824,6 @@ int CBuiltins::Execute(const std::string& execString)
     bool debug = CSettings::Get().GetBool("debug.showloginfo");
     CSettings::Get().SetBool("debug.showloginfo", !debug);
     g_advancedSettings.SetDebugMode(!debug);
-  }
-  else if (execute == "startpvrmanager")
-  {
-    g_application.StartPVRManager();
-  }
-  else if (execute == "stoppvrmanager")
-  {
-    g_application.StopPVRManager();
   }
   else if (execute == "startandroidactivity" && !params.empty())
   {

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -144,10 +144,7 @@ void CPVRManager::OnSettingChanged(const CSetting *setting)
   const std::string &settingId = setting->GetId();
   if (settingId == "pvrmanager.enabled")
   {
-    if (((CSettingBool*)setting)->GetValue())
-      CApplicationMessenger::Get().ExecBuiltIn("StartPVRManager", false);
-    else
-      CApplicationMessenger::Get().ExecBuiltIn("StopPVRManager", false);
+    CApplicationMessenger::Get().SetPVRManager(((CSettingBool*)setting)->GetValue());
   }
   else if (settingId == "pvrparental.enabled")
   {
@@ -553,7 +550,7 @@ void CPVRManager::Process(void)
   if (IsStarted())
   {
     CLog::Log(LOGNOTICE, "PVRManager - %s - no add-ons enabled anymore. restarting the pvrmanager", __FUNCTION__);
-    CApplicationMessenger::Get().ExecBuiltIn("StartPVRManager", false);
+    CApplicationMessenger::Get().SetPVRManager(true);
   }
   else
   {


### PR DESCRIPTION
During the creation of dsp system I become the info that the usage from "CBuiltins::Execute" way is not good to use for things like this. Here is also the correction of PVR to use another way.

Have checked the pvr addons and confluence skin that the "StartPVRManager" or "StopPVRManager" text message is not used, but need also recheck from others to make sure that no problems come.
