### PR TITLE
Decouple Util and StringUtil

### DIFF
--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -24,7 +24,6 @@
 #include <vector>
 #include <string.h>
 #include <stdint.h>
-#include "utils/StringUtils.h"
 #include "MediaSource.h"
 
 #define ARRAY_SIZE(X)         (sizeof(X)/sizeof((X)[0]))
@@ -36,18 +35,6 @@
 
 class CFileItemList;
 class CURL;
-
-struct sortstringbyname
-{
-  bool operator()(const std::string& strItem1, const std::string& strItem2)
-  {
-    std::string strLine1 = strItem1;
-    std::string strLine2 = strItem2;
-    StringUtils::ToLower(strLine1);
-    StringUtils::ToLower(strLine2);
-    return strcmp(strLine1.c_str(), strLine2.c_str()) < 0;
-  }
-};
 
 struct ExternalStreamInfo
 {

--- a/xbmc/addons/AddonCallbacksPVR.cpp
+++ b/xbmc/addons/AddonCallbacksPVR.cpp
@@ -22,6 +22,7 @@
 #include "AddonCallbacksPVR.h"
 #include "settings/AdvancedSettings.h"
 #include "utils/log.h"
+#include "utils/StringUtils.h"
 #include "dialogs/GUIDialogKaiToast.h"
 
 #include "epg/EpgContainer.h"

--- a/xbmc/dialogs/GUIDialogFileBrowser.cpp
+++ b/xbmc/dialogs/GUIDialogFileBrowser.cpp
@@ -21,6 +21,7 @@
 #include "GUIDialogFileBrowser.h"
 #include "Util.h"
 #include "utils/URIUtils.h"
+#include "utils/StringUtils.h"
 #include "network/GUIDialogNetworkSetup.h"
 #include "GUIDialogMediaSource.h"
 #include "GUIDialogContextMenu.h"

--- a/xbmc/filesystem/AFPFile.cpp
+++ b/xbmc/filesystem/AFPFile.cpp
@@ -32,6 +32,7 @@
 #include "settings/AdvancedSettings.h"
 #include "threads/SingleLock.h"
 #include "utils/log.h"
+#include "utils/StringUtils.h"
 #include "utils/TimeUtils.h"
 
 using namespace XFILE;

--- a/xbmc/filesystem/HDHomeRunFile.cpp
+++ b/xbmc/filesystem/HDHomeRunFile.cpp
@@ -25,6 +25,7 @@
 #include "HDHomeRunFile.h"
 #include "utils/TimeUtils.h"
 #include "utils/log.h"
+#include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "Util.h"
 #include "DllHDHomeRun.h"

--- a/xbmc/filesystem/IDirectory.cpp
+++ b/xbmc/filesystem/IDirectory.cpp
@@ -25,6 +25,7 @@
 #include "URL.h"
 #include "PasswordManager.h"
 #include "utils/URIUtils.h"
+#include "utils/StringUtils.h"
 
 using namespace XFILE;
 

--- a/xbmc/filesystem/PVRDirectory.cpp
+++ b/xbmc/filesystem/PVRDirectory.cpp
@@ -23,6 +23,7 @@
 #include "Util.h"
 #include "URL.h"
 #include "utils/log.h"
+#include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "guilib/LocalizeStrings.h"
 

--- a/xbmc/playlists/PlayListB4S.cpp
+++ b/xbmc/playlists/PlayListB4S.cpp
@@ -25,6 +25,7 @@
 #include "music/tags/MusicInfoTag.h"
 #include "filesystem/File.h"
 #include "utils/log.h"
+#include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/XMLUtils.h"
 

--- a/xbmc/playlists/PlayListWPL.cpp
+++ b/xbmc/playlists/PlayListWPL.cpp
@@ -24,6 +24,7 @@
 #include "settings/AdvancedSettings.h"
 #include "filesystem/File.h"
 #include "utils/log.h"
+#include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/XMLUtils.h"
 

--- a/xbmc/playlists/PlayListXML.cpp
+++ b/xbmc/playlists/PlayListXML.cpp
@@ -23,6 +23,7 @@
 #include "Util.h"
 #include "utils/RegExp.h"
 #include "utils/log.h"
+#include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/XMLUtils.h"
 #include "utils/Variant.h"

--- a/xbmc/profiles/dialogs/GUIDialogProfileSettings.cpp
+++ b/xbmc/profiles/dialogs/GUIDialogProfileSettings.cpp
@@ -34,6 +34,7 @@
 #include "settings/lib/Setting.h"
 #include "storage/MediaManager.h"
 #include "utils/log.h"
+#include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 
 #define CONTROL_PROFILE_IMAGE         CONTROL_SETTINGS_CUSTOM + 1

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -30,6 +30,7 @@
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "utils/log.h"
+#include "utils/StringUtils.h"
 
 using namespace ADDON;
 using namespace PVR;

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -39,6 +39,7 @@
 #include "epg/EpgContainer.h"
 #include "settings/Settings.h"
 #include "utils/log.h"
+#include "utils/StringUtils.h"
 #include "threads/SingleLock.h"
 
 using namespace PVR;

--- a/xbmc/utils/HttpRangeUtils.cpp
+++ b/xbmc/utils/HttpRangeUtils.cpp
@@ -21,6 +21,7 @@
 #include "HttpRangeUtils.h"
 #include "Util.h"
 #include "network/httprequesthandler/IHTTPRequestHandler.h"
+#include "utils/StringUtils.h"
 #include "utils/Variant.h"
 
 #include <algorithm>

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -194,3 +194,11 @@ public:
 private:
   static std::string m_lastUUID;
 };
+
+struct sortstringbyname
+{
+  bool operator()(const std::string& strItem1, const std::string& strItem2)
+  {
+    return StringUtils::CompareNoCase(strItem1, strItem2) < 0;
+  }
+};

--- a/xbmc/utils/test/TestStringUtils.cpp
+++ b/xbmc/utils/test/TestStringUtils.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "utils/StringUtils.h"
+#include <algorithm>
 
 #include "gtest/gtest.h"
 
@@ -477,4 +478,17 @@ TEST(TestStringUtils, Paramify)
 
   std::string result = StringUtils::Paramify(input);
   EXPECT_STREQ(ref, result.c_str());
+}
+
+TEST(TestStringUtils, sortstringbyname)
+{
+  std::vector<std::string> strarray;
+  strarray.push_back("B");
+  strarray.push_back("c");
+  strarray.push_back("a");
+  std::sort(strarray.begin(), strarray.end(), sortstringbyname());
+
+  EXPECT_STREQ("a", strarray[0].c_str());
+  EXPECT_STREQ("B", strarray[1].c_str());
+  EXPECT_STREQ("c", strarray[2].c_str());
 }


### PR DESCRIPTION
Util included StringUtil which lead to many classes relying on it, decouple it instead and make it explicit to include StringUtils.

This was achieved by moving the sortstringbyname from Util class to a better fit, StringUtil. The method was also optimized to avoid copying of the string and use the method from the StringUtil instead.
