### PR TITLE
[pvr] Improve pvr manager start/stop way

### DIFF
--- a/xbmc/ApplicationMessenger.cpp
+++ b/xbmc/ApplicationMessenger.cpp
@@ -864,6 +864,13 @@ void CApplicationMessenger::ProcessMessage(ThreadMessage *pMsg)
 #endif
       break;
     }
+    case TMSG_SETPVRMANAGERSTATE:
+    {
+      if (pMsg->param1 != 0)
+        g_application.StartPVRManager();
+      else
+        g_application.StopPVRManager();
+    }
   }
 }
 
@@ -1410,5 +1417,12 @@ void CApplicationMessenger::CECActivateSource()
 void CApplicationMessenger::CECStandby()
 {
   ThreadMessage tMsg = {TMSG_CECSTANDBY};
+  SendMessage(tMsg, false);
+}
+
+void CApplicationMessenger::SetPVRManagerState(bool onOff)
+{
+  ThreadMessage tMsg = {TMSG_SETPVRMANAGERSTATE};
+  tMsg.param1 = onOff ? 1 : 0;
   SendMessage(tMsg, false);
 }

--- a/xbmc/ApplicationMessenger.h
+++ b/xbmc/ApplicationMessenger.h
@@ -91,6 +91,7 @@ namespace MUSIC_INFO
 #define TMSG_CECACTIVATESOURCE    317
 #define TMSG_CECSTANDBY           318
 #define TMSG_SETVIDEORESOLUTION   319
+#define TMSG_SETPVRMANAGERSTATE   320
 
 #define TMSG_NETWORKMESSAGE         500
 
@@ -251,6 +252,11 @@ public:
 
   void SetSplashMessage(const std::string& message);
   void SetSplashMessage(int stringID);
+
+  /*! \brief Used to enable/disable PVR system without waiting.
+   \param onOff if true it becomes switched on otherwise off
+   */
+  void SetPVRManagerState(bool onOff);
   
   bool SetupDisplay();
   bool DestroyDisplay();

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -144,10 +144,7 @@ void CPVRManager::OnSettingChanged(const CSetting *setting)
   const std::string &settingId = setting->GetId();
   if (settingId == "pvrmanager.enabled")
   {
-    if (((CSettingBool*)setting)->GetValue())
-      CApplicationMessenger::Get().ExecBuiltIn("StartPVRManager", false);
-    else
-      CApplicationMessenger::Get().ExecBuiltIn("StopPVRManager", false);
+    CApplicationMessenger::Get().SetPVRManagerState(((CSettingBool*)setting)->GetValue());
   }
   else if (settingId == "pvrparental.enabled")
   {
@@ -553,7 +550,7 @@ void CPVRManager::Process(void)
   if (IsStarted())
   {
     CLog::Log(LOGNOTICE, "PVRManager - %s - no add-ons enabled anymore. restarting the pvrmanager", __FUNCTION__);
-    CApplicationMessenger::Get().ExecBuiltIn("StartPVRManager", false);
+    CApplicationMessenger::Get().SetPVRManagerState(true);
   }
   else
   {


### PR DESCRIPTION
This is a updated request related to #6517, there is still possible to use string function for the skins and add-ons, but internal the string compare is removed.
