### PR TITLE
[videodatabase] getvideosettings refactor

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3042,7 +3042,7 @@ PlayBackRet CApplication::PlayStack(const CFileItem& item, bool bRestart)
   // case 2: all other stacks
   else
   {
-    LoadVideoSettings(item.GetPath());
+    LoadVideoSettings(item);
     
     // see if we have the info in the database
     // TODO: If user changes the time speed (FPS via framerate conversion stuff)
@@ -3269,7 +3269,7 @@ PlayBackRet CApplication::PlayFile(const CFileItem& item, bool bRestart)
   else
   {
     options.starttime = item.m_lStartOffset / 75.0;
-    LoadVideoSettings(item.GetPath());
+    LoadVideoSettings(item);
 
     if (item.IsVideo())
     {
@@ -3771,15 +3771,15 @@ void CApplication::UpdateFileState()
   }
 }
 
-void CApplication::LoadVideoSettings(const std::string &path)
+void CApplication::LoadVideoSettings(const CFileItem& item)
 {
   CVideoDatabase dbs;
   if (dbs.Open())
   {
-    CLog::Log(LOGDEBUG, "Loading settings for %s", path.c_str());
+    CLog::Log(LOGDEBUG, "Loading settings for %s", item.GetPath().c_str());
     
     // Load stored settings if they exist, otherwise use default
-    if (!dbs.GetVideoSettings(path, CMediaSettings::Get().GetCurrentVideoSettings()))
+    if (!dbs.GetVideoSettings(item, CMediaSettings::Get().GetCurrentVideoSettings()))
       CMediaSettings::Get().GetCurrentVideoSettings() = CMediaSettings::Get().GetDefaultVideoSettings();
     
     dbs.Close();

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -181,7 +181,7 @@ public:
   PlayBackRet PlayFile(const CFileItem& item, bool bRestart = false);
   void SaveFileState(bool bForeground = false);
   void UpdateFileState();
-  void LoadVideoSettings(const std::string &path);
+  void LoadVideoSettings(const CFileItem& item);
   void StopPlaying();
   void Restart(bool bSamePosition = true);
   void DelayedPlayerRestart();

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -1329,7 +1329,7 @@ bool CPVRManager::PerformChannelSwitch(const CPVRChannelPtr &channel, bool bPrev
     // save previous and load new channel's settings (view mode is updated in 
     // the player)
     g_application.SaveFileState();
-    g_application.LoadVideoSettings(channel->Path());
+    g_application.LoadVideoSettings(channel);
     
     // set channel as selected item
     CGUIWindowPVRBase::SetSelectedItemPath(channel->IsRadio(), channel->Path());

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -3721,9 +3721,19 @@ void CVideoDatabase::GetTags(int media_id, const std::string &media_type, std::v
   }
 }
 
+bool CVideoDatabase::GetVideoSettings(const CFileItem &item, CVideoSettings &settings)
+{
+  return GetVideoSettings(GetFileId(item), settings);
+}
+
 /// \brief GetVideoSettings() obtains any saved video settings for the current file.
 /// \retval Returns true if the settings exist, false otherwise.
-bool CVideoDatabase::GetVideoSettings(const std::string &strFilenameAndPath, CVideoSettings &settings)
+bool CVideoDatabase::GetVideoSettings(const std::string &filePath, CVideoSettings &settings)
+{
+  return GetVideoSettings(GetFileId(filePath), settings);
+}
+
+bool CVideoDatabase::GetVideoSettings(int idFile, CVideoSettings &settings)
 {
   try
   {
@@ -3735,7 +3745,6 @@ bool CVideoDatabase::GetVideoSettings(const std::string &strFilenameAndPath, CVi
     URIUtils::Split(strFilenameAndPath, strPath, strFileName);
     std::string strSQL=PrepareSQL("select * from settings, files, path where settings.idFile=files.idFile and path.idPath=files.idPath and path.strPath='%s' and files.strFileName='%s'", strPath.c_str() , strFileName.c_str());
 #else
-    int idFile = GetFileId(strFilenameAndPath);
     if (idFile < 0) return false;
     if (NULL == m_pDB.get()) return false;
     if (NULL == m_pDS.get()) return false;

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -3737,21 +3737,13 @@ bool CVideoDatabase::GetVideoSettings(int idFile, CVideoSettings &settings)
 {
   try
   {
-    // obtain the FileID (if it exists)
-#ifdef NEW_VIDEODB_METHODS
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
-    std::string strPath, strFileName;
-    URIUtils::Split(strFilenameAndPath, strPath, strFileName);
-    std::string strSQL=PrepareSQL("select * from settings, files, path where settings.idFile=files.idFile and path.idPath=files.idPath and path.strPath='%s' and files.strFileName='%s'", strPath.c_str() , strFileName.c_str());
-#else
     if (idFile < 0) return false;
     if (NULL == m_pDB.get()) return false;
     if (NULL == m_pDS.get()) return false;
-    // ok, now obtain the settings for this file
+
     std::string strSQL=PrepareSQL("select * from settings where settings.idFile = '%i'", idFile);
-#endif
     m_pDS->query( strSQL.c_str() );
+
     if (m_pDS->num_rows() > 0)
     { // get the video settings info
       settings.m_AudioDelay = m_pDS->fv("AudioDelay").get_asFloat();

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -514,8 +514,10 @@ public:
   void DeleteTag(int idTag, VIDEODB_CONTENT_TYPE mediaType);
 
   // per-file video settings
-  bool GetVideoSettings(const std::string &strFilenameAndPath, CVideoSettings &settings);
-  void SetVideoSettings(const std::string &strFilenameAndPath, const CVideoSettings &settings);
+  bool GetVideoSettings(int idFile, CVideoSettings &settings);
+  bool GetVideoSettings(const CFileItem &item, CVideoSettings &settings);
+  bool GetVideoSettings(const std::string &filePath, CVideoSettings &settings);
+  void SetVideoSettings(const std::string &filePath, const CVideoSettings &settings);
 
   /**
    * Erases settings for all files beginning with the specified path. Defaults 

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -513,10 +513,31 @@ public:
   void DeleteSet(int idSet);
   void DeleteTag(int idTag, VIDEODB_CONTENT_TYPE mediaType);
 
-  // per-file video settings
+  /*! \brief Get video settings for the specified file id
+   \param idFile file id to get the settings for
+   \return true if video settings found, false otherwise
+   \sa SetVideoSettings
+   */
   bool GetVideoSettings(int idFile, CVideoSettings &settings);
+
+  /*! \brief Get video settings for the specified file item
+   \param item item to get the settings for
+   \return true if video settings found, false otherwise
+   \sa SetVideoSettings
+   */
   bool GetVideoSettings(const CFileItem &item, CVideoSettings &settings);
+
+  /*! \brief Get video settings for the specified file path
+   \param filePath filepath to get the settings for
+   \return true if video settings found, false otherwise
+   \sa SetVideoSettings
+   */
   bool GetVideoSettings(const std::string &filePath, CVideoSettings &settings);
+
+  /*! \brief Set video settings for the specified file path
+   \param filePath filepath to set the settings for
+   \sa GetVideoSettings
+   */
   void SetVideoSettings(const std::string &filePath, const CVideoSettings &settings);
 
   /**

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -567,7 +567,7 @@ void CVideoThumbLoader::DetectAndAddMissingItemData(CFileItem &item)
     // check for custom stereomode setting in video settings
     CVideoSettings itemVideoSettings;
     m_videoDatabase->Open();
-    if (m_videoDatabase->GetVideoSettings(path, itemVideoSettings) && itemVideoSettings.m_StereoMode != RENDER_STEREO_MODE_OFF)
+    if (m_videoDatabase->GetVideoSettings(item, itemVideoSettings) && itemVideoSettings.m_StereoMode != RENDER_STEREO_MODE_OFF)
       stereoMode = CStereoscopicsManager::Get().ConvertGuiStereoModeToString( (RENDER_STEREO_MODE) itemVideoSettings.m_StereoMode );
     m_videoDatabase->Close();
 


### PR DESCRIPTION
Just a small `GetVideoSettings()` refactor to make it retrieve settings by `CFileItem` rather than a file path. Saves us doing a few `GetFileId` queries in case we´re calling it for videodb items. While at it i added doxy blocks to the Get-/SetVideoSettings functions and removed dead code.

@Montellese, @xhaggi for review please. I am not entirely sure about the PVR one.
