### PR TITLE
[win32] addons: fix filtering foreign language addons

### DIFF
--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -535,12 +535,9 @@ const std::string CLangInfo::GetDVDSubtitleLanguage() const
   return code;
 }
 
-const std::string CLangInfo::GetLanguageLocale(bool twochar /* = false */) const
+const std::string& CLangInfo::GetLanguageLocale() const
 {
-  if (twochar)
-    return m_currentRegion->m_strLangLocaleCodeTwoChar;
-
-  return m_currentRegion->m_strLangLocaleName;
+  return m_currentRegion->m_strLangLocaleCodeTwoChar;
 }
 
 const std::string& CLangInfo::GetRegionLocale() const

--- a/xbmc/LangInfo.h
+++ b/xbmc/LangInfo.h
@@ -76,7 +76,11 @@ public:
   const std::string& GetTimeZone() const;
 
   const std::string& GetRegionLocale() const;
-  const std::string GetLanguageLocale(bool twochar = false) const;
+
+  /*!
+   \brief Returns the two character ISO 639-1 language code of the current language.
+   */
+  const std::string& GetLanguageLocale() const;
 
   bool ForceUnicodeFont() const { return m_currentRegion->m_forceUnicodeFont; }
 

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -631,7 +631,7 @@ std::string CAddonMgr::GetTranslatedString(const cp_cfg_element_t *root, const c
     if (strcmp(tag, child.name) == 0)
     { // see if we have a "lang" attribute
       const char *lang = m_cpluff->lookup_cfg_value((cp_cfg_element_t*)&child, "@lang");
-      if (lang && 0 == strcmp(lang,g_langInfo.GetLanguageLocale(true).c_str()))
+      if (lang && 0 == strcmp(lang,g_langInfo.GetLanguageLocale().c_str()))
         return child.value ? child.value : "";
       if (!lang || 0 == strcmp(lang, "en"))
         eng = &child;

--- a/xbmc/addons/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/GUIWindowAddonBrowser.cpp
@@ -375,11 +375,8 @@ bool CGUIWindowAddonBrowser::GetDirectory(const std::string& strDirectory,
       int i=0;
       while (i < items.Size())
       {
-        if (!FilterVar(CSettings::Get().GetBool("general.addonforeignfilter"),
-                      items[i]->GetProperty("Addon.Language"), "en") ||
-            !FilterVar(CSettings::Get().GetBool("general.addonforeignfilter"),
-                      items[i]->GetProperty("Addon.Language"),
-                      g_langInfo.GetLanguageLocale()))
+        if (!FilterVar(true, items[i]->GetProperty("Addon.Language"), "en") ||
+            !FilterVar(true, items[i]->GetProperty("Addon.Language"), g_langInfo.GetLanguageLocale()))
         {
           i++;
         }

--- a/xbmc/addons/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/GUIWindowAddonBrowser.cpp
@@ -376,7 +376,7 @@ bool CGUIWindowAddonBrowser::GetDirectory(const std::string& strDirectory,
       while (i < items.Size())
       {
         if (!FilterVar(true, items[i]->GetProperty("Addon.Language"), "en") ||
-            !FilterVar(true, items[i]->GetProperty("Addon.Language"), g_langInfo.GetLanguageLocale(true)))
+            !FilterVar(true, items[i]->GetProperty("Addon.Language"), g_langInfo.GetLanguageLocale()))
         {
           i++;
         }

--- a/xbmc/addons/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/GUIWindowAddonBrowser.cpp
@@ -376,7 +376,7 @@ bool CGUIWindowAddonBrowser::GetDirectory(const std::string& strDirectory,
       while (i < items.Size())
       {
         if (!FilterVar(true, items[i]->GetProperty("Addon.Language"), "en") ||
-            !FilterVar(true, items[i]->GetProperty("Addon.Language"), g_langInfo.GetLanguageLocale()))
+            !FilterVar(true, items[i]->GetProperty("Addon.Language"), g_langInfo.GetLanguageLocale(true)))
         {
           i++;
         }


### PR DESCRIPTION
While working on the language addons (see #5561) I noticed that the logic that filters foreign languages looks a bit odd.
- The logic is only executed if the `general.addonforeignfilter` is set but we still retrieve its value (at worst) twice more. This is "fixed" by the first commit.
- On WIN32 `g_langInfo.GetLanguageLocale()` returns a three char language code by default (on all other platforms it should be a two char language code). We have to explicitly set the optional `twochar` parameter to `true` to get a two character language code. Without this we try to compare strings like `en` with `eng` or `de` with `deu` which obviously fails. I'm wondering why nobody ever noticed this. This is fixed by the second commit.
- After the change in the second commit there is no code using `g_langInfo.GetLanguageLocale()` with the `twochar` parameter set to false so I removed it completely to avoid any future confusion and added a short documentation to the method in the third commit.

I also noticed that the language comparison is done as a substring comparison and I'm not sure if that's what we actually want. It shouldn't be an issue as long as both values are ISO 639-1 language codes but if an `addon.xml` would contain an odd value in `<language>` this might lead to unexpected behaviour.
