### PR TITLE
[PVR] fix deleted recordings view

### DIFF
--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -91,7 +91,8 @@ CPVRRecording::CPVRRecording(const PVR_RECORDING &recording, unsigned int iClien
   m_duration                       = CDateTimeSpan(0, 0, recording.iDuration / 60, recording.iDuration % 60);
   m_iPriority                      = recording.iPriority;
   m_iLifetime                      = recording.iLifetime;
-  m_strDirectory                   = recording.strDirectory;
+  // Deleted recording is placed at the root of the deleted view
+  m_strDirectory                   = recording.bIsDeleted ? "" : recording.strDirectory;
   m_strPlot                        = recording.strPlot;
   m_strPlotOutline                 = recording.strPlotOutline;
   m_strStreamURL                   = recording.strStreamURL;
@@ -377,7 +378,7 @@ void CPVRRecording::UpdatePath(void)
       strDirectory = StringUtils::Format("%s/", m_strDirectory.c_str());
     if (!m_strChannelName.empty())
       strChannel = StringUtils::Format(" (%s)", m_strChannelName.c_str());
-    m_strFileNameAndPath = StringUtils::Format("pvr://recordings/%s/%s%s, TV%s, %s.pvr", (m_bIsDeleted ? "deleted" : "active"),  strDirectory.c_str(), strTitle.c_str(), strChannel.c_str(), strDatetime.c_str());
+    m_strFileNameAndPath = StringUtils::Format("pvr://" PVR_RECORDING_BASE_PATH "/%s/%s%s, TV%s, %s.pvr", m_bIsDeleted ? PVR_RECORDING_DELETED_PATH : PVR_RECORDING_ACTIVE_PATH,  strDirectory.c_str(), strTitle.c_str(), strChannel.c_str(), strDatetime.c_str());
   }
 }
 
@@ -392,7 +393,7 @@ const CDateTime &CPVRRecording::RecordingTimeAsLocalTime(void) const
 std::string CPVRRecording::GetTitleFromURL(const std::string &url)
 {
   CRegExp reg(true);
-  if (reg.RegComp("pvr://recordings/(.*/)*(.*), TV( \\(.*\\))?, "
+  if (reg.RegComp("pvr://" PVR_RECORDING_BASE_PATH "/(.*/)*(.*), TV( \\(.*\\))?, "
       "(19[0-9][0-9]|20[0-9][0-9])[0-9][0-9][0-9][0-9]_[0-9][0-9][0-9][0-9][0-9][0-9].pvr"))
   {
     if (reg.RegFind(url.c_str()) >= 0)

--- a/xbmc/pvr/recordings/PVRRecording.h
+++ b/xbmc/pvr/recordings/PVRRecording.h
@@ -39,6 +39,10 @@
 #include "video/VideoInfoTag.h"
 #include "XBDateTime.h"
 
+#define PVR_RECORDING_BASE_PATH     "recordings"
+#define PVR_RECORDING_DELETED_PATH  "deleted"
+#define PVR_RECORDING_ACTIVE_PATH   "active"
+
 class CVideoDatabase;
 
 namespace PVR

--- a/xbmc/pvr/recordings/PVRRecordings.h
+++ b/xbmc/pvr/recordings/PVRRecordings.h
@@ -48,7 +48,7 @@ namespace PVR
     virtual std::string TrimSlashes(const std::string &strOrig) const;
     virtual const std::string GetDirectoryFromPath(const std::string &strPath, const std::string &strBase) const;
     virtual bool IsDirectoryMember(const std::string &strDirectory, const std::string &strEntryDirectory) const;
-    virtual void GetSubDirectories(const std::string &strBase, CFileItemList *results, bool bDeleted = false);
+    virtual void GetSubDirectories(const std::string &strBase, CFileItemList *results);
 
     /**
      * @brief recursively deletes all recordings in the specified directory


### PR DESCRIPTION
Upgrade feature "Add support of deleted and reproducable recordings" #6367.
This commit fix deleted recordings view by removing unwanted empty sub-folder
and to become usable with all PVR addons using sub-path for recordings view.
It Doesn't requires any API changes.
Constant strings are now defined in the PVRRecording header:
"recordings" , "deleted" , "active"
