### PR TITLE
[ActiveAE] - ActiveAESink: Change several LOGNOTICE to LOGDEBUG

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -570,13 +570,13 @@ void CActiveAESink::EnumerateSinkList(bool force)
   CAESinkFactory::EnumerateEx(m_sinkInfoList);
   while(m_sinkInfoList.size() == 0 && c_retry > 0)
   {
-    CLog::Log(LOGNOTICE, "No Devices found - retry: %d", c_retry);
+    CLog::Log(LOGDEBUG, "No Devices found - retry: %d", c_retry);
     Sleep(1500);
     c_retry--;
     // retry the enumeration
     CAESinkFactory::EnumerateEx(m_sinkInfoList, true);
   }
-  CLog::Log(LOGNOTICE, "Found %lu Lists of Devices", m_sinkInfoList.size());
+  CLog::Log(LOGDEBUG, "Found %lu Lists of Devices", m_sinkInfoList.size());
   PrintSinks();
 }
 
@@ -584,16 +584,16 @@ void CActiveAESink::PrintSinks()
 {
   for (AESinkInfoList::iterator itt = m_sinkInfoList.begin(); itt != m_sinkInfoList.end(); ++itt)
   {
-    CLog::Log(LOGNOTICE, "Enumerated %s devices:", itt->m_sinkName.c_str());
+    CLog::Log(LOGDEBUG, "Enumerated %s devices:", itt->m_sinkName.c_str());
     int count = 0;
     for (AEDeviceInfoList::iterator itt2 = itt->m_deviceInfoList.begin(); itt2 != itt->m_deviceInfoList.end(); ++itt2)
     {
-      CLog::Log(LOGNOTICE, "    Device %d", ++count);
+      CLog::Log(LOGDEBUG, "    Device %d", ++count);
       CAEDeviceInfo& info = *itt2;
       std::stringstream ss((std::string)info);
       std::string line;
       while(std::getline(ss, line, '\n'))
-        CLog::Log(LOGNOTICE, "        %s", line.c_str());
+        CLog::Log(LOGDEBUG, "        %s", line.c_str());
     }
   }
 }


### PR DESCRIPTION
ActiveAESink: Change several LOGNOTICE to LOGDEBUG to reduce kodi.log "spamming".

My kodi.log contains long lists like

14:20:47 T:140533781100288  NOTICE: Found 1 Lists of Devices
14:20:47 T:140533781100288  NOTICE: Enumerated ALSA devices:
14:20:47 T:140533781100288  NOTICE:     Device 1
14:20:47 T:140533781100288  NOTICE:         m_deviceName      : @
...
14:20:47 T:140533781100288  NOTICE:     Device 2
14:20:47 T:140533781100288  NOTICE:         m_deviceName      : @:CARD=Generic,DEV=0
...
14:20:47 T:140533781100288  NOTICE:     Device 5
14:20:47 T:140533781100288  NOTICE:         m_deviceName      : hdmi:CARD=NVidia,DEV=0
....

for every startup and resume of kodi (running on OpenELEC).

My feeling is that this stuff should be logged as DEBUG, not NOTICE. Opinions?
