### PR TITLE
[rss] CRssReader::Process: Sleep 5 secs before retrying CCurlFile::Get().

### DIFF
--- a/xbmc/utils/RssReader.cpp
+++ b/xbmc/utils/RssReader.cpp
@@ -159,8 +159,7 @@ void CRssReader::Process()
       {
         if (timeout.IsTimePast())
         {
-          CLog::Log(LOGERROR, "Timeout whilst retrieving %s", strUrl.c_str());
-          http.Cancel();
+          CLog::Log(LOGERROR, "Timeout while retrieving rss feed: %s", strUrl.c_str());
           break;
         }
         nRetries--;
@@ -176,12 +175,18 @@ void CRssReader::Process()
           }
         }
         else
+        {
           if (http.Get(strUrl, strXML))
           {
             fileCharset = http.GetServerReportedCharset();
             CLog::Log(LOGDEBUG, "Got rss feed: %s", strUrl.c_str());
             break;
           }
+          else if (nRetries > 0)
+            Sleep(5000); // Network problems? Retry, but not immediately.
+          else
+            CLog::Log(LOGERROR, "Unable to obtain rss feed: %s", strUrl.c_str());
+        }
       }
       http.Cancel();
     }


### PR DESCRIPTION
CRssReader::Process may be called very early during resume of Kodi (running an OpenELEC here). In this case, for me CCurlFile::Get() fails quite often. Visual effect is an empty rss ticker after resume of Kodi.

kodi.log:
06:50:25 T:140506940049152   ERROR: CCurlFile::CReadState::Connect, didn't get any data from stream.
06:50:28 T:140506940049152   ERROR: CCurlFile::FillBuffer - Failed: Couldn't resolve host name(6)
06:50:28 T:140506940049152   ERROR: CCurlFile::CReadState::Connect, didn't get any data from stream.
06:50:29 T:140506940049152   ERROR: CCurlFile::FillBuffer - Failed: Couldn't resolve host name(6)
06:50:29 T:140506940049152   ERROR: CCurlFile::CReadState::Connect, didn't get any data from stream.
06:50:29 T:140506940049152   ERROR: CCurlFile::FillBuffer - Failed: Couldn't resolve host name(6)

Problem is that the existing retry mechanism retries immediately.

Waiting 5 secs between the retries fixes this as for me the second try (after 5 secs) always works.
