### PR TITLE
[smbdirectory] mark dot files and folders hidden (fixes #15680)

### DIFF
--- a/xbmc/filesystem/SMBDirectory.cpp
+++ b/xbmc/filesystem/SMBDirectory.cpp
@@ -122,6 +122,9 @@ bool CSMBDirectory::GetDirectory(const CURL& url, CFileItemList &items)
       if(StringUtils::EndsWith(strFile, "$") && aDir.type == SMBC_FILE_SHARE )
         continue;
 
+      if (StringUtils::StartsWith(strFile, "."))
+        hidden = true;
+
       // only stat files that can give proper responses
       if ( aDir.type == SMBC_FILE ||
            aDir.type == SMBC_DIR )


### PR DESCRIPTION
Mark dot files and folders hidden just as we do in all the other directory implementations.
