### PR TITLE
[scraper] retry without appending year after first fail

### DIFF
--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -576,7 +576,7 @@ std::vector<CScraperUrl> CScraper::FindMovie(XFILE::CCurlFile &fcurl, const std:
   vector<string> vcsIn(1);
   g_charsetConverter.utf8To(SearchStringEncoding(), sTitle, vcsIn[0]);
   vcsIn[0] = CURL::Encode(vcsIn[0]);
-  if (!sYear.empty())
+  if (fFirst && !sYear.empty())
     vcsIn.push_back(sYear);
 
   // request a search URL from the title/filename/etc.


### PR DESCRIPTION
Whenever we fail to scrape on first run we retry without cleaning chars. This commit changes the behavior to also exclude the year on second run. This comes handy whenever the year that is extracted from the file or folder name is wrong or the backend simply doesn't accept it.

Issue @ http://forum.kodi.tv/showthread.php?tid=219403 and most likely in a lot of other places.

Another solution for the issue reported would be to not append the year for thetvdb at all. Comments?
