### PR TITLE
[win32] addons: fix filtering foreign language addons

### DIFF
--- a/xbmc/addons/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/GUIWindowAddonBrowser.cpp
@@ -379,7 +379,7 @@ bool CGUIWindowAddonBrowser::GetDirectory(const std::string& strDirectory,
                       items[i]->GetProperty("Addon.Language"), "en") ||
             !FilterVar(CSettings::Get().GetBool("general.addonforeignfilter"),
                       items[i]->GetProperty("Addon.Language"),
-                      g_langInfo.GetLanguageLocale()))
+                      g_langInfo.GetLanguageLocale(true)))
         {
           i++;
         }


### PR DESCRIPTION
This is a minimized backport of #6524 without the cosmetics and cleanup.
