### PR TITLE
 [gui] fix activating of context menu after skin reload while context menu was active

### DIFF
--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -679,9 +679,6 @@ int CGUIDialogContextMenu::ShowAndGetChoice(const CContextButtons &choices)
   CGUIDialogContextMenu *pMenu = (CGUIDialogContextMenu *)g_windowManager.GetWindow(WINDOW_DIALOG_CONTEXT_MENU);
   if (pMenu)
   {
-    if (pMenu->IsDialogRunning())
-      return -1;
-
     pMenu->m_buttons = choices;
     pMenu->Initialize();
     pMenu->SetInitialVisibility();


### PR DESCRIPTION
This is another approach to #5912 which fix the issue that you can't re-open the context menu after you reload the skin while you have the context menu open/active.

The root cause is that CGUIDialogContextMenu is not recognized as currently active window while we deinitialize the windows, therefor we do not call `pWindow->Close(true)` and `m_active` remains `true` after reload is done which means the dialog stays active.
https://github.com/xbmc/xbmc/blob/master/xbmc/dialogs/GUIDialogContextMenu.cpp#L682 checks if the dialog is active/open before open the dialog and return -1 if true.
