### PR TITLE
[gui] Fix/cleanup osd dialogs to close PVR related if media is stopped

### DIFF
--- a/xbmc/music/dialogs/GUIDialogMusicOSD.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicOSD.cpp
@@ -64,6 +64,21 @@ bool CGUIDialogMusicOSD::OnMessage(CGUIMessage &message)
       return true;
     }
     break;
+  case GUI_MSG_WINDOW_DEINIT:  // fired when OSD is hidden
+    {
+      CGUIDialog *pDialog;
+
+      pDialog = (CGUIDialog *)g_windowManager.GetWindow(WINDOW_DIALOG_PVR_OSD_CHANNELS);
+      if (pDialog && pDialog->IsDialogRunning())
+        pDialog->Close(true);
+      pDialog = (CGUIDialog *)g_windowManager.GetWindow(WINDOW_DIALOG_PVR_OSD_GUIDE);
+      if (pDialog && pDialog->IsDialogRunning())
+        pDialog->Close(true);
+      pDialog = (CGUIDialog *)g_windowManager.GetWindow(WINDOW_DIALOG_OSD_TELETEXT);
+      if (pDialog && pDialog->IsDialogRunning())
+        pDialog->Close(true);
+    }
+    break;
   }
   return CGUIDialog::OnMessage(message);
 }

--- a/xbmc/video/dialogs/GUIDialogVideoOSD.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoOSD.cpp
@@ -102,15 +102,20 @@ bool CGUIDialogVideoOSD::OnMessage(CGUIMessage& message)
       if (pDialog && pDialog->IsDialogRunning())
         pDialog->Close(true);
       pDialog = (CGUIDialog *)g_windowManager.GetWindow(WINDOW_DIALOG_AUDIO_OSD_SETTINGS);
-      if (pDialog && pDialog->IsDialogRunning()) pDialog->Close(true);
+      if (pDialog && pDialog->IsDialogRunning())
+        pDialog->Close(true);
       pDialog = (CGUIDialog *)g_windowManager.GetWindow(WINDOW_DIALOG_VIDEO_BOOKMARKS);
-      if (pDialog && pDialog->IsDialogRunning()) pDialog->Close(true);
+      if (pDialog && pDialog->IsDialogRunning())
+        pDialog->Close(true);
       pDialog = (CGUIDialog *)g_windowManager.GetWindow(WINDOW_DIALOG_PVR_OSD_CHANNELS);
-      if (pDialog && pDialog->IsDialogRunning()) pDialog->Close(true);
+      if (pDialog && pDialog->IsDialogRunning())
+        pDialog->Close(true);
       pDialog = (CGUIDialog *)g_windowManager.GetWindow(WINDOW_DIALOG_PVR_OSD_GUIDE);
-      if (pDialog && pDialog->IsDialogRunning()) pDialog->Close(true);
+      if (pDialog && pDialog->IsDialogRunning())
+        pDialog->Close(true);
       pDialog = (CGUIDialog *)g_windowManager.GetWindow(WINDOW_DIALOG_OSD_TELETEXT);
-      if (pDialog && pDialog->IsDialogRunning()) pDialog->Close(true);
+      if (pDialog && pDialog->IsDialogRunning())
+        pDialog->Close(true);
     }
     break;
   }

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -237,9 +237,9 @@ bool CGUIMediaWindow::OnMessage(CGUIMessage& message)
       m_iSelectedItem = m_viewControl.GetSelectedItem();
       m_iLastControl = GetFocusedControlID();
       CGUIWindow::OnMessage(message);
-      CGUIDialogContextMenu* pDlg = (CGUIDialogContextMenu*)g_windowManager.GetWindow(WINDOW_DIALOG_CONTEXT_MENU);
-      if (pDlg && pDlg->IsActive())
-        pDlg->Close();
+
+      // Close all open dialogs
+      g_windowManager.CloseDialogs(true);
 
       // get rid of any active filtering
       if (m_canFilterAdvanced)


### PR DESCRIPTION
This request fix a failure if on playback of radio channel and a opened PVR dialog the playback becomes stopped, before was the dialog leaved open.

Also the others perform a cleanup to match the code style strategy and one to base class to allow usage of value pointer also for other dialogs (dsp related)
