### PR TITLE
Fix trac 12016, 15790

### DIFF
--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -160,6 +160,17 @@ bool CApplicationPlayer::HasVideo() const
   return (player && player->HasVideo());
 }
 
+int CApplicationPlayer::GetPreferredPlaylist() const
+{
+  if (IsPlayingVideo())
+    return PLAYLIST_VIDEO;
+
+  if (IsPlayingAudio())
+    return PLAYLIST_MUSIC;
+
+  return PLAYLIST_NONE;
+}
+
 bool CApplicationPlayer::IsPaused() const
 {
   std::shared_ptr<IPlayer> player = GetInternal();

--- a/xbmc/ApplicationPlayer.h
+++ b/xbmc/ApplicationPlayer.h
@@ -103,6 +103,7 @@ public:
   float GetPercentage() const;
   std::string GetPlayerState();
   std::string GetPlayingTitle();
+  int   GetPreferredPlaylist() const;
   void  GetRenderFeatures(std::vector<int> &renderFeatures);
   void  GetScalingMethods(std::vector<int> &scalingMethods);
   bool  GetStreamDetails(CStreamDetails &details);

--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -350,6 +350,7 @@ void CPlayListPlayer::SetCurrentSong(int iSong)
 {
   if (iSong >= -1 && iSong < GetPlaylist(m_iCurrentPlayList).size())
     m_iCurrentSong = iSong;
+
 }
 
 int CPlayListPlayer::GetCurrentSong() const
@@ -360,6 +361,17 @@ int CPlayListPlayer::GetCurrentSong() const
 int CPlayListPlayer::GetCurrentPlaylist() const
 {
   return m_iCurrentPlayList;
+}
+
+int CPlayListPlayer::GetCurrentPlaylist(int iPlaylist) const
+{
+  if (GetCurrentPlaylist() != PLAYLIST_NONE)
+    return GetCurrentPlaylist();
+
+  if (g_application.m_pPlayer->GetPreferredPlaylist() != PLAYLIST_NONE)
+    return g_application.m_pPlayer->GetPreferredPlaylist();
+
+  return iPlaylist;
 }
 
 void CPlayListPlayer::SetCurrentPlaylist(int iPlaylist)
@@ -709,9 +721,7 @@ void CPlayListPlayer::Swap(int iPlaylist, int indexItem1, int indexItem2)
 
 void CPlayListPlayer::AnnouncePropertyChanged(int iPlaylist, const std::string &strProperty, const CVariant &value)
 {
-  if (strProperty.empty() || value.isNull() ||
-     (iPlaylist == PLAYLIST_VIDEO && !g_application.m_pPlayer->IsPlayingVideo()) ||
-     (iPlaylist == PLAYLIST_MUSIC && !g_application.m_pPlayer->IsPlayingAudio()))
+  if (strProperty.empty() || value.isNull())
     return;
 
   CVariant data;

--- a/xbmc/PlayListPlayer.h
+++ b/xbmc/PlayListPlayer.h
@@ -103,6 +103,11 @@ public:
    */
   int GetCurrentPlaylist() const;
 
+  /*! \brief Get currently active playlist or a default for current player
+   \return PLAYLIST_MUSIC or PLAYLIST_VIDEO
+   */
+  int GetCurrentPlaylist(int iPlaylist) const;
+
   /*! \brief Get a particular playlist object
    \param playList Values can be PLAYLIST_MUSIC or PLAYLIST_VIDEO
    \return A reference to the CPlayList object.

--- a/xbmc/interfaces/json-rpc/PlayerOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlayerOperations.cpp
@@ -1033,10 +1033,10 @@ int CPlayerOperations::GetActivePlayers()
 
 PlayerType CPlayerOperations::GetPlayer(const CVariant &player)
 {
-  int activePlayers = GetActivePlayers();
-  int playerID;
+  int iPlayer = (int)player.asInteger();
+  PlayerType playerID;
 
-  switch ((int)player.asInteger())
+  switch (iPlayer)
   {
     case PLAYLIST_VIDEO:
       playerID = Video;
@@ -1051,19 +1051,12 @@ PlayerType CPlayerOperations::GetPlayer(const CVariant &player)
       break;
 
     default:
-      playerID = PlayerImplicit;
+      playerID = None;
       break;
   }
 
-  int choosenPlayer = playerID & activePlayers;
-
-  // Implicit order
-  if (choosenPlayer & Video)
-    return Video;
-  else if (choosenPlayer & Audio)
-    return Audio;
-  else if (choosenPlayer & Picture)
-    return Picture;
+  if (GetPlaylist(playerID) == iPlayer)
+    return playerID;
   else
     return None;
 }
@@ -1073,16 +1066,16 @@ int CPlayerOperations::GetPlaylist(PlayerType player)
   switch (player)
   {
     case Video:
-      return PLAYLIST_VIDEO;
+      return g_playlistPlayer.GetCurrentPlaylist(PLAYLIST_VIDEO);
 
     case Audio:
-      return PLAYLIST_MUSIC;
+      return g_playlistPlayer.GetCurrentPlaylist(PLAYLIST_MUSIC);
 
     case Picture:
       return PLAYLIST_PICTURE;
 
     default:
-      return PLAYLIST_NONE;
+      return g_playlistPlayer.GetCurrentPlaylist(PLAYLIST_NONE);
   }
 }
 
@@ -1292,7 +1285,7 @@ JSONRPC_STATUS CPlayerOperations::GetPropertyValue(PlayerType player, const std:
     switch (player)
     {
       case Video:
-      case Audio:
+      case Audio: /* Return the position of current item if there is an active playlist */
         if (!IsPVRChannel() && g_playlistPlayer.GetCurrentPlaylist() == playlist)
           result = g_playlistPlayer.GetCurrentSong();
         else


### PR DESCRIPTION
Alternative solution for [TR 15790](http://trac.kodi.tv/ticket/15790) & [TR 12016](http://trac.kodi.tv/ticket/12016). It has a different focus than PR #6418, and solves the inconsistency in JSON answers by making playerid=playlistid.

Advantages:
- Requires less changes.
- Addresses @Montellese concerns about remotes that assume playerid=playistid
- Fixes some paper-cuts in chorous webinterface with mixed playlists, and hopefully some other remotes.

Possible problems:
- Playerid doesn't represent the kind of media being played any more. I don't know if any remote worked under such assumption.
- Not sure if some spurious notifications might be triggered. Yatse seems to work fine but some unit testing would be nice.
