### PR TITLE
[confluence, core] String Fixes: TV settings

### DIFF
--- a/addons/skin.confluence/language/English/strings.po
+++ b/addons/skin.confluence/language/English/strings.po
@@ -582,7 +582,7 @@ msgid "Scheduled Time"
 msgstr ""
 
 msgctxt "#31502"
-msgid "Live TV"
+msgid "TV"
 msgstr ""
 
 msgctxt "#31503"

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -4358,7 +4358,7 @@ msgid "Scripts"
 msgstr ""
 
 msgctxt "#10021"
-msgid "Web Browser"
+msgid "Settings - TV"
 msgstr ""
 
 #empty strings from id 10022 to 10024


### PR DESCRIPTION
10021 "Web Browser" => "Settings - TV". This one was semantically completely wrong.
      String gets displayed on VFDs/LCDs when navigating through the items of the
      left side of the TV settings dialog.
31502 "Live TV" => "TV". Confluence. Seems this one got forgotten the time the
      resp. core changes were made.
