### PR TITLE
addons: support selecting installable addons for settings

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -12458,7 +12458,17 @@ msgctxt "#24056"
 msgid "Last updated %s"
 msgstr ""
 
-#empty strings from id 24057 to 24058
+#. Used as a title in the progress dialog when installing an add-on
+#: xbmc/addons/AddonInstaller.cpp
+msgctxt "#24057"
+msgid "Installing %s..."
+msgstr ""
+
+#. Used as a text in the progress dialog when installing an add-on
+#: xbmc/addons/AddonInstaller.cpp
+msgctxt "#24058"
+msgid "Checking dependencies..."
+msgstr ""
 
 msgctxt "#24059"
 msgid "Would you like to enable this Add-on?"
@@ -12542,7 +12552,23 @@ msgctxt "#24076"
 msgid "Add-on Required"
 msgstr ""
 
-#empty strings from id 24077 to 24079
+#. Used as a text in the progress dialog when installing an add-on
+#: xbmc/addons/AddonInstaller.cpp
+msgctxt "#24077"
+msgid "Verifying downloaded add-on..."
+msgstr ""
+
+#. Used as a text in the progress dialog when installing an add-on
+#: xbmc/addons/AddonInstaller.cpp
+msgctxt "#24078"
+msgid "Downloading add-on..."
+msgstr ""
+
+#. Used as a text in the progress dialog when installing an add-on
+#: xbmc/addons/AddonInstaller.cpp
+msgctxt "#24079"
+msgid "Installing add-on dependencies..."
+msgstr ""
 
 msgctxt "#24080"
 msgid "Try to reconnect?"
@@ -12572,7 +12598,19 @@ msgctxt "#24084"
 msgid "Visualisation libraries"
 msgstr ""
 
-#empty strings from id 24085 to 24088
+#. Used as a text in the progress dialog when installing an add-on
+#: xbmc/addons/AddonInstaller.cpp
+msgctxt "#24085"
+msgid "Failed to install a dependency"
+msgstr ""
+
+#. Used as a text in the progress dialog when installing an add-on
+#: xbmc/addons/AddonInstaller.cpp
+msgctxt "#24086"
+msgid "Installing add-on..."
+msgstr ""
+
+#empty strings from id 24087 to 24088
 
 msgctxt "#24089"
 msgid "Add-on restarts"

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -9,7 +9,9 @@
           <constraints>
             <addontype>xbmc.gui.skin</addontype>
           </constraints>
-          <control type="button" format="addon" />
+          <control type="button" format="addon">
+            <show more="true" details="true">installed</show>
+          </control>
         </setting>
         <setting id="lookandfeel.skinsettings" type="action" parent="lookandfeel.skin" label="21417" help="36104">
           <level>0</level>
@@ -240,7 +242,9 @@
           <updates>
             <update type="change" />
           </updates>
-          <control type="button" format="addon" />
+          <control type="button" format="addon">
+            <show more="true" details="true">installed</show>
+          </control>
         </setting>
         <setting id="screensaver.settings" parent="screensaver.mode" type="action" label="21417" help="36131">
           <level>0</level>
@@ -975,7 +979,9 @@
           <constraints>
             <addontype>xbmc.subtitle.module</addontype>
           </constraints>
-          <control type="button" format="addon" />
+          <control type="button" format="addon">
+            <show more="true" details="true">installed</show>
+          </control>
         </setting>
         <setting id="subtitles.movie" type="addon" label="24118" help="24119">
           <level>1</level>
@@ -983,7 +989,9 @@
           <constraints>
             <addontype>xbmc.subtitle.module</addontype>
           </constraints>
-          <control type="button" format="addon" />
+          <control type="button" format="addon">
+            <show more="true" details="true">installed</show>
+          </control>
         </setting>
       </group>
     </category>
@@ -1526,7 +1534,9 @@
           <constraints>
             <addontype>xbmc.metadata.scraper.albums</addontype>
           </constraints>
-          <control type="button" format="addon" />
+          <control type="button" format="addon">
+            <show more="true" details="true">installed</show>
+          </control>
         </setting>
         <setting id="musiclibrary.artistsscraper" type="addon" label="20194" help="36258">
           <level>1</level>
@@ -1534,7 +1544,9 @@
           <constraints>
             <addontype>xbmc.metadata.scraper.artists</addontype>
           </constraints>
-          <control type="button" format="addon" />
+          <control type="button" format="addon">
+            <show more="true" details="true">installed</show>
+          </control>
         </setting>
         <setting id="musiclibrary.overridetags" type="boolean" label="20220" help="20221">
           <level>1</level>
@@ -1690,7 +1702,9 @@
             <addontype>xbmc.player.musicviz</addontype>
             <allowempty>true</allowempty>
           </constraints>
-          <control type="button" format="addon" />
+          <control type="button" format="addon">
+            <show more="true" details="true">installed</show>
+          </control>
         </setting>
       </group>
     </category>
@@ -1802,7 +1816,9 @@
           <constraints>
             <addontype>xbmc.audioencoder</addontype>
           </constraints>
-          <control type="button" format="addon" />
+          <control type="button" format="addon">
+            <show more="true" details="true">installed</show>
+          </control>
         </setting>
         <setting id="audiocds.settings" parent="audiocds.encoder" type="action" label="21417" help="37025">
           <level>1</level>
@@ -2004,7 +2020,9 @@
             <addontype>xbmc.python.weather</addontype>
             <allowempty>true</allowempty>
           </constraints>
-          <control type="button" format="addon" />
+          <control type="button" format="addon">
+            <show more="true" details="true">installed</show>
+          </control>
         </setting>
         <setting id="weather.addonsettings" type="action" parent="weather.addon" label="21417" help="36419">
           <level>0</level>
@@ -2108,7 +2126,9 @@
           <constraints>
             <addontype>xbmc.webinterface</addontype>
           </constraints>
-          <control type="button" format="addon" />
+          <control type="button" format="addon">
+            <show more="true" details="true">installed</show>
+          </control>
         </setting>
       </group>
     </category>

--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -194,7 +194,7 @@ public:
 
   /*! \brief callbacks for special install/uninstall behaviour */
   virtual bool OnPreInstall() { return false; };
-  virtual void OnPostInstall(bool restart, bool update) {};
+  virtual void OnPostInstall(bool restart, bool update, bool modal) {};
   virtual void OnPreUnInstall() {};
   virtual void OnPostUnInstall() {};
   virtual bool CanInstall(const std::string& referer) { return true; }

--- a/xbmc/addons/AddonInstaller.h
+++ b/xbmc/addons/AddonInstaller.h
@@ -118,7 +118,7 @@ public:
     unsigned int progress;
   };
 
-  typedef std::map<std::string,CDownloadJob> JobMap;
+  typedef std::map<std::string, CDownloadJob> JobMap;
 
 private:
   // private construction, and no assignements; use the provided singleton methods
@@ -145,8 +145,7 @@ private:
    \param database database instance to update
    \return true if dependencies are available, false otherwise.
    */
-  bool CheckDependencies(const ADDON::AddonPtr &addon,
-                         std::vector<std::string>& preDeps, CAddonDatabase &database);
+  bool CheckDependencies(const ADDON::AddonPtr &addon, std::vector<std::string>& preDeps, CAddonDatabase &database);
 
   void PrunePackageCache();
   int64_t EnumeratePackageFolder(std::map<std::string,CFileItemList*>& result);
@@ -180,10 +179,11 @@ public:
    *  \return The hosting repository
    */
   static ADDON::AddonPtr GetRepoForAddon(const ADDON::AddonPtr& addon);
+
 private:
   bool OnPreInstall();
   void OnPostInstall(bool reloadAddon);
-  bool Install(const std::string &installFrom, const ADDON::AddonPtr& repo=ADDON::AddonPtr());
+  bool Install(const std::string &installFrom, const ADDON::AddonPtr& repo = ADDON::AddonPtr());
   bool DownloadPackage(const std::string &path, const std::string &dest);
 
   /*! \brief Queue a notification for addon installation/update failure
@@ -204,6 +204,7 @@ public:
   CAddonUnInstallJob(const ADDON::AddonPtr &addon);
 
   virtual bool DoWork();
+
 private:
   void OnPostUnInstall();
 

--- a/xbmc/addons/AddonInstaller.h
+++ b/xbmc/addons/AddonInstaller.h
@@ -57,10 +57,11 @@ public:
    \param force whether to force the install even if the addon is already installed (eg for updating). Defaults to false.
    \param referer string to use for referer for http fetch. Set to previous version when updating, parent when fetching a dependency
    \param background whether to install in the background or not. Defaults to true.
+   \param modal whether to show a modal dialog when not installing in background
    \return true on successful install, false on failure.
    \sa DoInstall
    */
-  bool Install(const std::string &addonID, bool force = false, const std::string &referer="", bool background = true);
+  bool Install(const std::string &addonID, bool force = false, const std::string &referer="", bool background = true, bool modal = false);
 
   /*! \brief Install an addon from the given zip path
    \param path the zip file to install from
@@ -135,7 +136,7 @@ private:
    \param background whether to install in the background or not. Defaults to true.
    \return true on successful install, false on failure.
    */
-  bool DoInstall(const ADDON::AddonPtr &addon, const std::string &hash = "", bool update = false, const std::string &referer = "", bool background = true);
+  bool DoInstall(const ADDON::AddonPtr &addon, const std::string &hash = "", bool update = false, const std::string &referer = "", bool background = true, bool modal = false);
 
   /*! \brief Check whether dependencies of an addon exist or are installable.
    Iterates through the addon's dependencies, checking they're installed or installable.
@@ -169,16 +170,19 @@ public:
    */
   std::string AddonID() const;
 
-  /*! \brief Delete an addon following install failure
-   \param addonFolder - the folder to delete
-   */
-  static bool DeleteAddon(const std::string &addonFolder);
-
   /*! \brief Find which repository hosts an add-on
    *  \param addon The add-on to find the repository for
    *  \return The hosting repository
    */
   static ADDON::AddonPtr GetRepoForAddon(const ADDON::AddonPtr& addon);
+
+  /*! \brief Find the add-on and itshash for the given add-on ID
+   *  \param addonID ID of the add-on to find
+   *  \param addon Add-on with the given add-on ID
+   *  \param hash Hash of the add-on
+   *  \return True if the add-on and its hash were found, false otherwise.
+   */
+  static bool GetAddonWithHash(const std::string& addonID, ADDON::AddonPtr& addon, std::string& hash);
 
 private:
   bool OnPreInstall();
@@ -186,11 +190,19 @@ private:
   bool Install(const std::string &installFrom, const ADDON::AddonPtr& repo = ADDON::AddonPtr());
   bool DownloadPackage(const std::string &path, const std::string &dest);
 
+  /*! \brief Delete an addon following install failure
+   \param addonFolder - the folder to delete
+   */
+  bool DeleteAddon(const std::string &addonFolder);
+
+  bool DoFileOperation(FileAction action, CFileItemList &items, const std::string &file, bool useSameJob = true);
+
   /*! \brief Queue a notification for addon installation/update failure
    \param addonID - addon id
    \param fileName - filename which is shown in case the addon id is unknown
+   \param message - error message to be displayed
    */
-  void ReportInstallError(const std::string& addonID, const std::string& fileName);
+  void ReportInstallError(const std::string& addonID, const std::string& fileName, const std::string& message = "");
 
   ADDON::AddonPtr m_addon;
   std::string m_hash;
@@ -206,6 +218,11 @@ public:
   virtual bool DoWork();
 
 private:
+  /*! \brief Delete an addon following install failure
+   \param addonFolder - the folder to delete
+   */
+  bool DeleteAddon(const std::string &addonFolder);
+
   void OnPostUnInstall();
 
   ADDON::AddonPtr m_addon;

--- a/xbmc/addons/AddonInstaller.h
+++ b/xbmc/addons/AddonInstaller.h
@@ -43,13 +43,14 @@ public:
   bool GetProgress(const std::string &addonID, unsigned int &percent) const;
   bool Cancel(const std::string &addonID);
 
-  /*! \brief Prompt the user as to whether they wish to install an addon.
+  /*! \brief Installs the addon while showing a modal progress dialog
    \param addonID the addon ID of the item to install.
    \param addon [out] the installed addon for later use.
+   \param promptForInstall Whether or not to prompt the user before installing the addon.
    \return true on successful install, false otherwise.
    \sa Install
    */
-  bool PromptForInstall(const std::string &addonID, ADDON::AddonPtr &addon);
+  bool InstallModal(const std::string &addonID, ADDON::AddonPtr &addon, bool promptForInstall = true);
 
   /*! \brief Install an addon if it is available in a repository
    \param addonID the addon ID of the item to install

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -129,6 +129,33 @@ namespace ADDON
      */
     bool IsAddonDisabled(const std::string& ID);
 
+    /* \brief Checks whether an addon can be disabled via DisableAddon.
+     \param ID id of the addon
+     \sa DisableAddon
+     */
+    bool CanAddonBeDisabled(const std::string& ID);
+
+    /* \brief Checks whether an addon is installed.
+     \param ID id of the addon
+    */
+    bool IsAddonInstalled(const std::string& ID);
+
+    /* \brief Checks whether an addon is installed.
+     \param ID id of the addon
+     \param addon Installed addon
+     */
+    bool IsAddonInstalled(const std::string& ID, AddonPtr& addon);
+
+    /* \brief Checks whether an addon can be installed. Broken addons can't be installed.
+     \param ID id of the addon
+     */
+    bool CanAddonBeInstalled(const std::string& ID);
+
+    /* \brief Checks whether an addon can be installed. Broken addons can't be installed.
+    \param addon addon to be checked
+    */
+    bool CanAddonBeInstalled(const AddonPtr& addon);
+
     /* libcpluff */
     std::string GetExtValue(cp_cfg_element_t *base, const char *path);
 

--- a/xbmc/addons/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/GUIDialogAddonInfo.cpp
@@ -150,18 +150,14 @@ void CGUIDialogAddonInfo::OnInitWindow()
 
 void CGUIDialogAddonInfo::UpdateControls()
 {
-  std::string xbmcPath = CSpecialProtocol::TranslatePath("special://xbmc/addons");
   bool isInstalled = NULL != m_localAddon.get();
-  bool isSystem = isInstalled && StringUtils::StartsWith(m_localAddon->Path(), xbmcPath);
   bool isEnabled = isInstalled && m_item->GetProperty("Addon.Enabled").asBoolean();
   bool isUpdatable = isInstalled && m_item->GetProperty("Addon.UpdateAvail").asBoolean();
   bool isExecutable = isInstalled && (m_localAddon->Type() == ADDON_PLUGIN || m_localAddon->Type() == ADDON_SCRIPT);
   if (isInstalled)
     GrabRollbackVersions();
 
-  // TODO: System addons should be able to be disabled
-  bool isPVR = isInstalled && m_localAddon->Type() == ADDON_PVRDLL;
-  bool canDisable = isInstalled && (!isSystem || isPVR) && !m_localAddon->IsInUse();
+  bool canDisable = isInstalled && CAddonMgr::Get().CanAddonBeDisabled(m_localAddon->ID());
   bool canInstall = !isInstalled && m_item->GetProperty("Addon.Broken").empty();
   bool isRepo = (isInstalled && m_localAddon->Type() == ADDON_REPOSITORY) || (m_addon && m_addon->Type() == ADDON_REPOSITORY);
 

--- a/xbmc/addons/GUIWindowAddonBrowser.h
+++ b/xbmc/addons/GUIWindowAddonBrowser.h
@@ -38,19 +38,27 @@ public:
    \param type the type of addon wanted
    \param addonID [out] the addon ID of the selected item
    \param showNone whether there should be a "None" item in the list (defaults to false)
+   \param showDetails whether to show details of the addons or not
+   \param showInstalled whether installed addons should be in the list
+   \param showInstallable whether installable addons should be in the list
+   \param showMore whether to show the "Get More" button (only makes sense if showInstalled is true and showInstallable is false)
    \return 1 if an addon was selected, 2 if "Get More" was chosen, or 0 if an error occurred or if the selection process was cancelled
    */
-  static int SelectAddonID(ADDON::TYPE type, std::string &addonID, bool showNone = false);
-  static int SelectAddonID(const std::vector<ADDON::TYPE> &types, std::string &addonID, bool showNone = false);
+  static int SelectAddonID(ADDON::TYPE type, std::string &addonID, bool showNone = false, bool showDetails = true, bool showInstalled = true, bool showInstallable = false, bool showMore = true);
+  static int SelectAddonID(const std::vector<ADDON::TYPE> &types, std::string &addonID, bool showNone = false, bool showDetails = true, bool showInstalled = true, bool showInstallable = false, bool showMore = true);
   /*! \brief Popup a selection dialog with a list of addons of the given type
    \param type the type of addon wanted
    \param addonIDs [out] array of selected addon IDs
    \param showNone whether there should be a "None" item in the list (defaults to false)
+   \param showDetails whether to show details of the addons or not
    \param multipleSelection allow selection of multiple addons, if set to true showNone will automaticly switch to false
+   \param showInstalled whether installed addons should be in the list
+   \param showInstallable whether installable addons should be in the list
+   \param showMore whether to show the "Get More" button (only makes sense if showInstalled is true and showInstallable is false)
    \return 1 if an addon was selected or multiple selection was specified, 2 if "Get More" was chosen, or 0 if an error occurred or if the selection process was cancelled
    */
-  static int SelectAddonID(ADDON::TYPE type, std::vector<std::string> &addonIDs, bool showNone = false, bool multipleSelection = true);
-  static int SelectAddonID(const std::vector<ADDON::TYPE> &types, std::vector<std::string> &addonIDs, bool showNone = false, bool multipleSelection = true);
+  static int SelectAddonID(ADDON::TYPE type, std::vector<std::string> &addonIDs, bool showNone = false, bool showDetails = true, bool multipleSelection = true, bool showInstalled = true, bool showInstallable = false, bool showMore = true);
+  static int SelectAddonID(const std::vector<ADDON::TYPE> &types, std::vector<std::string> &addonIDs, bool showNone = false, bool showDetails = true, bool multipleSelection = true, bool showInstalled = true, bool showInstallable = false, bool showMore = true);
   
 protected:
   /* \brief set label2 of an item based on the Addon.Status property

--- a/xbmc/addons/IAddon.h
+++ b/xbmc/addons/IAddon.h
@@ -117,7 +117,7 @@ namespace ADDON
     virtual void OnEnabled() =0;
     virtual AddonPtr GetRunningInstance() const=0;
     virtual bool OnPreInstall() =0;
-    virtual void OnPostInstall(bool restart, bool update) =0;
+    virtual void OnPostInstall(bool restart, bool update, bool modal) =0;
     virtual void OnPreUnInstall() =0;
     virtual void OnPostUnInstall() =0;
     virtual bool CanInstall(const std::string& referer) =0;

--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -193,7 +193,7 @@ bool CRepository::Parse(const DirInfo& dir, VECADDONS &result)
   return false;
 }
 
-void CRepository::OnPostInstall(bool restart, bool update)
+void CRepository::OnPostInstall(bool restart, bool update, bool modal)
 {
   VECADDONS addons;
   AddonPtr repo(new CRepository(*this));

--- a/xbmc/addons/Repository.h
+++ b/xbmc/addons/Repository.h
@@ -58,7 +58,7 @@ namespace ADDON
     static bool Parse(const DirInfo& dir, VECADDONS& addons);
     static std::string FetchChecksum(const std::string& url);
 
-    virtual void OnPostInstall(bool restart, bool update);
+    virtual void OnPostInstall(bool restart, bool update, bool modal);
     virtual void OnPostUnInstall();
 
   private:

--- a/xbmc/addons/Service.cpp
+++ b/xbmc/addons/Service.cpp
@@ -136,7 +136,7 @@ bool CService::OnPreInstall()
   return !CAddonMgr::Get().IsAddonDisabled(ID());
 }
 
-void CService::OnPostInstall(bool restart, bool update)
+void CService::OnPostInstall(bool restart, bool update, bool modal)
 {
   if (restart) // reload/start it if it was running
   {

--- a/xbmc/addons/Service.h
+++ b/xbmc/addons/Service.h
@@ -50,7 +50,7 @@ namespace ADDON
     virtual void OnDisabled();
     virtual void OnEnabled();
     virtual bool OnPreInstall();
-    virtual void OnPostInstall(bool restart, bool update);
+    virtual void OnPostInstall(bool restart, bool update, bool modal);
     virtual void OnPreUnInstall();
 
   protected:

--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -289,7 +289,7 @@ bool CSkinInfo::OnPreInstall()
 
 void CSkinInfo::OnPostInstall(bool restart, bool update, bool modal)
 {
-  if (restart || (!update && CGUIDialogYesNo::ShowAndGetInput(Name(), g_localizeStrings.Get(24099),"","")))
+  if (restart || (!update && !modal && CGUIDialogYesNo::ShowAndGetInput(Name(), g_localizeStrings.Get(24099),"","")))
   {
     CGUIDialogKaiToast *toast = (CGUIDialogKaiToast *)g_windowManager.GetWindow(WINDOW_DIALOG_KAI_TOAST);
     if (toast)

--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -287,7 +287,7 @@ bool CSkinInfo::OnPreInstall()
   return false;
 }
 
-void CSkinInfo::OnPostInstall(bool restart, bool update)
+void CSkinInfo::OnPostInstall(bool restart, bool update, bool modal)
 {
   if (restart || (!update && CGUIDialogYesNo::ShowAndGetInput(Name(), g_localizeStrings.Get(24099),"","")))
   {

--- a/xbmc/addons/Skin.h
+++ b/xbmc/addons/Skin.h
@@ -119,7 +119,7 @@ public:
   static void SettingOptionsStartupWindowsFiller(const CSetting *setting, std::vector< std::pair<std::string, int> > &list, int &current, void *data);
 
   virtual bool OnPreInstall();
-  virtual void OnPostInstall(bool restart, bool update);
+  virtual void OnPostInstall(bool restart, bool update, bool modal);
 protected:
   /*! \brief Given a resolution, retrieve the corresponding directory name
    \param res RESOLUTION to translate

--- a/xbmc/filesystem/PluginDirectory.cpp
+++ b/xbmc/filesystem/PluginDirectory.cpp
@@ -96,7 +96,7 @@ bool CPluginDirectory::StartScript(const std::string& strPath, bool retrievingDi
   // try the plugin type first, and if not found, try an unknown type
   if (!CAddonMgr::Get().GetAddon(url.GetHostName(), m_addon, ADDON_PLUGIN) &&
       !CAddonMgr::Get().GetAddon(url.GetHostName(), m_addon, ADDON_UNKNOWN) &&
-      !CAddonInstaller::Get().PromptForInstall(url.GetHostName(), m_addon))
+      !CAddonInstaller::Get().InstallModal(url.GetHostName(), m_addon))
   {
     CLog::Log(LOGERROR, "Unable to find plugin %s", url.GetHostName().c_str());
     return false;
@@ -424,7 +424,7 @@ bool CPluginDirectory::RunScriptWithParams(const std::string& strPath)
     return false;
 
   AddonPtr addon;
-  if (!CAddonMgr::Get().GetAddon(url.GetHostName(), addon, ADDON_PLUGIN) && !CAddonInstaller::Get().PromptForInstall(url.GetHostName(), addon))
+  if (!CAddonMgr::Get().GetAddon(url.GetHostName(), addon, ADDON_PLUGIN) && !CAddonInstaller::Get().InstallModal(url.GetHostName(), addon))
   {
     CLog::Log(LOGERROR, "Unable to find plugin %s", url.GetHostName().c_str());
     return false;

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -1068,7 +1068,7 @@ void CGUIWindowManager::DeInitialize()
   for (WindowMap::iterator it = m_mapWindows.begin(); it != m_mapWindows.end(); ++it)
   {
     CGUIWindow* pWindow = (*it).second;
-    if (IsWindowActive(it->first))
+    if (IsWindowActive(it->first, false))
     {
       pWindow->DisableAnimations();
       pWindow->Close(true);

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -90,7 +90,7 @@ bool CPVRClient::OnPreInstall()
   return false;
 }
 
-void CPVRClient::OnPostInstall(bool restart, bool update)
+void CPVRClient::OnPostInstall(bool restart, bool update, bool modal)
 {
   // (re)start the pvr manager
   PVR::CPVRManager::Get().Start(true);

--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -61,7 +61,7 @@ namespace PVR
     virtual void OnEnabled();
     virtual ADDON::AddonPtr GetRunningInstance() const;
     virtual bool OnPreInstall();
-    virtual void OnPostInstall(bool restart, bool update);
+    virtual void OnPostInstall(bool restart, bool update, bool modal);
     virtual void OnPreUnInstall();
     virtual void OnPostUnInstall();
     virtual bool CanInstall(const std::string &referer);

--- a/xbmc/settings/SettingControl.cpp
+++ b/xbmc/settings/SettingControl.cpp
@@ -27,6 +27,10 @@
 #include "utils/XBMCTinyXML.h"
 #include "utils/XMLUtils.h"
 
+#define SHOW_ADDONS_ALL               "all"
+#define SHOW_ADDONS_INSTALLED         "installed"
+#define SHOW_ADDONS_INSTALLABLE       "installable"
+
 ISettingControl* CSettingControlCreator::CreateControl(const std::string &controlType) const
 {
   if (StringUtils::EqualsNoCase(controlType, "toggle"))
@@ -139,6 +143,56 @@ bool CSettingControlButton::Deserialize(const TiXmlNode *node, bool update /* = 
   
   XMLUtils::GetInt(node, SETTING_XML_ELM_CONTROL_HEADING, m_heading);
   XMLUtils::GetBoolean(node, SETTING_XML_ELM_CONTROL_HIDEVALUE, m_hideValue);
+
+  if (m_format == "addon")
+  {
+    std::string strShowAddons;
+    if (XMLUtils::GetString(node, "show", strShowAddons) && !strShowAddons.empty())
+    {
+      if (StringUtils::EqualsNoCase(strShowAddons, SHOW_ADDONS_ALL))
+      {
+        m_showInstalledAddons = true;
+        m_showInstallableAddons = true;
+      }
+      else if (StringUtils::EqualsNoCase(strShowAddons, SHOW_ADDONS_INSTALLED))
+      {
+        m_showInstalledAddons = true;
+        m_showInstallableAddons = false;
+      }
+      else if (StringUtils::EqualsNoCase(strShowAddons, SHOW_ADDONS_INSTALLABLE))
+      {
+        m_showInstalledAddons = false;
+        m_showInstallableAddons = true;
+      }
+      else
+        CLog::Log(LOGWARNING, "CSettingControlButton: invalid <show>");
+
+      const TiXmlElement *show = node->FirstChildElement("show");
+      if (show != NULL)
+      {
+        const char *strShowDetails = NULL;
+        if ((strShowDetails = show->Attribute(SETTING_XML_ATTR_SHOW_DETAILS)) != NULL)
+        {
+          if (StringUtils::EqualsNoCase(strShowDetails, "false") || StringUtils::EqualsNoCase(strShowDetails, "true"))
+            m_showAddonDetails = StringUtils::EqualsNoCase(strShowDetails, "true");
+          else
+            CLog::Log(LOGWARNING, "CSettingControlButton: error reading \"details\" attribute of <show>");
+        }
+
+        if (!m_showInstallableAddons)
+        {
+          const char *strShowMore = NULL;
+          if ((strShowMore = show->Attribute(SETTING_XML_ATTR_SHOW_MORE)) != NULL)
+          {
+            if (StringUtils::EqualsNoCase(strShowMore, "false") || StringUtils::EqualsNoCase(strShowMore, "true"))
+              m_showMoreAddons = StringUtils::EqualsNoCase(strShowMore, "true");
+            else
+              CLog::Log(LOGWARNING, "CSettingControlButton: error reading \"more\" attribute of <show>");
+          }
+        }
+      }
+    }
+  }
 
   return true;
 }

--- a/xbmc/settings/SettingControl.h
+++ b/xbmc/settings/SettingControl.h
@@ -30,6 +30,8 @@
 #define SETTING_XML_ELM_CONTROL_MULTISELECT  "multiselect"
 #define SETTING_XML_ELM_CONTROL_POPUP        "popup"
 #define SETTING_XML_ELM_CONTROL_FORMATVALUE  "value"
+#define SETTING_XML_ATTR_SHOW_MORE           "more"
+#define SETTING_XML_ATTR_SHOW_DETAILS        "details"
 
 class CVariant;
 
@@ -120,7 +122,11 @@ class CSettingControlButton : public ISettingControl
 public:
   CSettingControlButton()
     : m_heading(-1),
-      m_hideValue(false)
+      m_hideValue(false),
+      m_showAddonDetails(true),
+      m_showInstalledAddons(true),
+      m_showInstallableAddons(false),
+      m_showMoreAddons(true)
   { }
   virtual ~CSettingControlButton() { }
 
@@ -134,9 +140,23 @@ public:
   bool HideValue() const { return m_hideValue; }
   void SetHideValue(bool hideValue) { m_hideValue = hideValue; }
 
+  bool ShowAddonDetails() const { return m_showAddonDetails; }
+  void SetShowAddonDetails(bool showAddonDetails) { m_showAddonDetails = showAddonDetails; }
+  bool ShowInstalledAddons() const { return m_showInstalledAddons; }
+  void SetShowInstalledAddons(bool showInstalledAddons) { m_showInstalledAddons = showInstalledAddons; }
+  bool ShowInstallableAddons() const { return m_showInstallableAddons; }
+  void SetShowInstallableAddons(bool showInstallableAddons) { m_showInstallableAddons = showInstallableAddons; }
+  bool ShowMoreAddons() const { return !m_showInstallableAddons && m_showMoreAddons; }
+  void SetShowMoreAddons(bool showMoreAddons) { m_showMoreAddons = showMoreAddons; }
+
 protected:
   int m_heading;
   bool m_hideValue;
+
+  bool m_showAddonDetails;
+  bool m_showInstalledAddons;
+  bool m_showInstallableAddons;
+  bool m_showMoreAddons;
 };
 
 class CSettingControlList : public ISettingControl

--- a/xbmc/settings/dialogs/GUIDialogSettingsManualBase.cpp
+++ b/xbmc/settings/dialogs/GUIDialogSettingsManualBase.cpp
@@ -240,7 +240,8 @@ CSettingAction* CGUIDialogSettingsManualBase::AddButton(CSettingGroup *group, co
 }
 
 CSettingAddon* CGUIDialogSettingsManualBase::AddAddon(CSettingGroup *group, const std::string &id, int label, int level, std::string value, ADDON::TYPE addonType,
-                                                      bool allowEmpty /* = false */, int heading /* = -1 */, bool hideValue /* = false */, bool delayed /* = false */,
+                                                      bool allowEmpty /* = false */, int heading /* = -1 */, bool hideValue /* = false */, bool showInstalledAddons /* = true */,
+                                                      bool showInstallableAddons /* = false */, bool showMoreAddons /* = true */, bool delayed /* = false */,
                                                       bool visible /* = true */, int help /* = -1 */)
 {
   if (group == NULL || id.empty() || label < 0 ||
@@ -251,7 +252,7 @@ CSettingAddon* CGUIDialogSettingsManualBase::AddAddon(CSettingGroup *group, cons
   if (setting == NULL)
     return NULL;
 
-  setting->SetControl(GetButtonControl("addon", delayed, heading, hideValue));
+  setting->SetControl(GetButtonControl("addon", delayed, heading, hideValue, showInstalledAddons, showInstallableAddons, showMoreAddons));
   setting->SetAddonType(addonType);
   setting->SetAllowEmpty(allowEmpty);
   setSettingDetails(setting, level, visible, help);
@@ -950,7 +951,8 @@ ISettingControl* CGUIDialogSettingsManualBase::GetEditControl(const std::string 
   return control;
 }
 
-ISettingControl* CGUIDialogSettingsManualBase::GetButtonControl(const std::string &format, bool delayed /* = false */, int heading /* = -1 */, bool hideValue /* = false */)
+ISettingControl* CGUIDialogSettingsManualBase::GetButtonControl(const std::string &format, bool delayed /* = false */, int heading /* = -1 */, bool hideValue /* = false */,
+                                                                bool showInstalledAddons /* = true */, bool showInstallableAddons /* = false */, bool showMoreAddons /* = true */)
 {
   CSettingControlButton *control = new CSettingControlButton();
   if (!control->SetFormat(format))
@@ -962,6 +964,9 @@ ISettingControl* CGUIDialogSettingsManualBase::GetButtonControl(const std::strin
   control->SetDelayed(delayed);
   control->SetHeading(heading);
   control->SetHideValue(hideValue);
+  control->SetShowInstalledAddons(showInstalledAddons);
+  control->SetShowInstallableAddons(showInstallableAddons);
+  control->SetShowMoreAddons(showMoreAddons);
 
   return control;
 }

--- a/xbmc/settings/dialogs/GUIDialogSettingsManualBase.h
+++ b/xbmc/settings/dialogs/GUIDialogSettingsManualBase.h
@@ -71,7 +71,8 @@ protected:
   // button controls
   CSettingAction* AddButton(CSettingGroup *group, const std::string &id, int label, int level, bool delayed = false, bool visible = true, int help = -1);
   CSettingAddon* AddAddon(CSettingGroup *group, const std::string &id, int label, int level, std::string value, ADDON::TYPE addonType,
-                          bool allowEmpty = false, int heading = -1, bool hideValue = false, bool delayed = false, bool visible = true, int help = -1);
+                          bool allowEmpty = false, int heading = -1, bool hideValue = false, bool showInstalledAddons = true, bool showInstallableAddons = false,
+                          bool showMoreAddons = true, bool delayed = false, bool visible = true, int help = -1);
   CSettingPath* AddPath(CSettingGroup *group, const std::string &id, int label, int level, std::string value, bool writable = true,
                         const std::vector<std::string> &sources = std::vector<std::string>(), bool allowEmpty = false, int heading = -1, bool hideValue = false,
                         bool delayed = false, bool visible = true, int help = -1);
@@ -145,7 +146,8 @@ protected:
 
   ISettingControl* GetCheckmarkControl(bool delayed = false);
   ISettingControl* GetEditControl(const std::string &format, bool delayed = false, bool hidden = false, bool verifyNewValue = false, int heading = -1);
-  ISettingControl* GetButtonControl(const std::string &format, bool delayed = false, int heading = -1, bool hideValue = false);
+  ISettingControl* GetButtonControl(const std::string &format, bool delayed = false, int heading = -1, bool hideValue = false, bool showInstalledAddons = true,
+                                    bool showInstallableAddons = false, bool showMoreAddons = true);
   ISettingControl* GetSpinnerControl(const std::string &format, bool delayed = false, int minimumLabel = -1, int formatLabel = -1, const std::string &formatString = "");
   ISettingControl* GetListControl(const std::string &format, bool delayed = false, int heading = -1, bool multiselect = false);
   ISettingControl* GetSliderControl(const std::string &format, bool delayed = false, int heading = -1, bool usePopup = false, int formatLabel = -1, const std::string &formatString = "");

--- a/xbmc/settings/windows/GUIControlSettings.cpp
+++ b/xbmc/settings/windows/GUIControlSettings.cpp
@@ -531,12 +531,15 @@ bool CGUIControlButtonSetting::OnClick()
   const std::string &controlFormat = control->GetFormat();
   if (controlType == "button")
   {
+    const CSettingControlButton *buttonControl = static_cast<const CSettingControlButton*>(control);
     if (controlFormat == "addon")
     {
       // prompt for the addon
       CSettingAddon *setting = (CSettingAddon *)m_pSetting;
       std::string addonID = setting->GetValue();
-      if (CGUIWindowAddonBrowser::SelectAddonID(setting->GetAddonType(), addonID, setting->AllowEmpty()) != 1)
+      if (CGUIWindowAddonBrowser::SelectAddonID(setting->GetAddonType(), addonID, setting->AllowEmpty(),
+                                                buttonControl->ShowAddonDetails(), buttonControl->ShowInstalledAddons(),
+                                                buttonControl->ShowInstallableAddons(), buttonControl->ShowMoreAddons()) != 1)
         return false;
 
       SetValid(setting->SetValue(addonID));

--- a/xbmc/utils/FileOperationJob.cpp
+++ b/xbmc/utils/FileOperationJob.cpp
@@ -18,47 +18,52 @@
  *
  */
 
+#include "system.h"
+
 #include "FileOperationJob.h"
-#include "filesystem/File.h"
-#include "filesystem/Directory.h"
-#include "filesystem/ZipManager.h"
-#include "filesystem/FileDirectoryFactory.h"
-#include "filesystem/MultiPathDirectory.h"
-#include "filesystem/SpecialProtocol.h"
-#include "log.h"
-#include "Util.h"
-#include "URIUtils.h"
-#include "utils/StringUtils.h"
 #include "URL.h"
+#include "Util.h"
+#include "dialogs/GUIDialogExtendedProgressBar.h"
 #include "guilib/LocalizeStrings.h"
 #include "guilib/GUIWindowManager.h"
-#include "dialogs/GUIDialogExtendedProgressBar.h"
-
-#ifdef HAS_FILESYSTEM_RAR
-#include "filesystem/RarManager.h"
-#endif
+#include "filesystem/Directory.h"
+#include "filesystem/File.h"
+#include "filesystem/FileDirectoryFactory.h"
+#include "utils/log.h"
+#include "utils/StringUtils.h"
+#include "utils/URIUtils.h"
 
 using namespace std;
 using namespace XFILE;
 
 CFileOperationJob::CFileOperationJob()
-{
-  m_action = ActionCopy;
-  m_heading = 0;
-  m_line = 0;
-  m_handle = NULL;
-  m_displayProgress = false;
-}
+  : m_action(ActionCopy),
+    m_items(),
+    m_strDestFile(),
+    m_avgSpeed(),
+    m_currentOperation(),
+    m_currentFile(),
+    m_handle(NULL),
+    m_displayProgress(false),
+    m_heading(0),
+    m_line(0)
+{ }
 
 CFileOperationJob::CFileOperationJob(FileAction action, CFileItemList & items,
                                     const std::string& strDestFile,
-                                    bool displayProgress,
-                                    int heading, int line)
+                                    bool displayProgress /* = false */,
+                                    int heading /* = 0 */, int line /* = 0 */)
+  : m_action(action),
+    m_items(),
+    m_strDestFile(strDestFile),
+    m_avgSpeed(),
+    m_currentOperation(),
+    m_currentFile(),
+    m_handle(NULL),
+    m_displayProgress(displayProgress),
+    m_heading(heading),
+    m_line(line)
 {
-  m_handle = NULL;
-  m_displayProgress = displayProgress;
-  m_heading = heading;
-  m_line = line;
   SetFileOperation(action, items, strDestFile);
 }
 
@@ -107,7 +112,7 @@ bool CFileOperationJob::DoProcessFile(FileAction action, const std::string& strF
   if (action == ActionCopy || action == ActionReplace || (action == ActionMove && !CanBeRenamed(strFileA, strFileB)))
   {
     struct __stat64 data;
-    if(CFile::Stat(strFileA, &data) == 0)
+    if (CFile::Stat(strFileA, &data) == 0)
       time += data.st_size;
   }
 
@@ -128,9 +133,9 @@ bool CFileOperationJob::DoProcessFolder(FileAction action, const std::string& st
     delete file;
     return true;
   }
+
   CLog::Log(LOGDEBUG,"FileManager, processing folder: %s",strPath.c_str());
   CFileItemList items;
-  //m_rootDir.GetDirectory(strPath, items);
   CDirectory::GetDirectory(strPath, items, "", DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_GET_HIDDEN);
   for (int i = 0; i < items.Size(); i++)
   {
@@ -139,7 +144,8 @@ bool CFileOperationJob::DoProcessFolder(FileAction action, const std::string& st
     CLog::Log(LOGDEBUG,"  -- %s",pItem->GetPath().c_str());
   }
 
-  if (!DoProcess(action, items, strDestFile, fileOperations, totalTime)) return false;
+  if (!DoProcess(action, items, strDestFile, fileOperations, totalTime))
+    return false;
 
   if (action == ActionMove)
   {
@@ -167,7 +173,7 @@ bool CFileOperationJob::DoProcess(FileAction action, CFileItemList & items, cons
         // get filename from label instead of path
         strFileName = pItem->GetLabel();
 
-        if(!pItem->m_bIsFolder && !URIUtils::HasExtension(strFileName))
+        if (!pItem->m_bIsFolder && !URIUtils::HasExtension(strFileName))
         {
           // FIXME: for now we only work well if the url has the extension
           // we should map the content type to the extension otherwise
@@ -178,7 +184,7 @@ bool CFileOperationJob::DoProcess(FileAction action, CFileItemList & items, cons
       }
 
       std::string strnewDestFile;
-      if(!strDestFile.empty()) // only do this if we have a destination
+      if (!strDestFile.empty()) // only do this if we have a destination
         strnewDestFile = URIUtils::ChangeBasePath(pItem->GetPath(), strFileName, strDestFile); // Convert (URL) encoding + slashes (if source / target differ)
 
       if (pItem->m_bIsFolder)
@@ -190,10 +196,13 @@ bool CFileOperationJob::DoProcess(FileAction action, CFileItemList & items, cons
         // create folder on dest. drive
         if (action != ActionDelete && action != ActionDeleteFolder)
           DoProcessFile(ActionCreateFolder, strnewDestFile, "", fileOperations, totalTime);
+
         if (action == ActionReplace && CDirectory::Exists(strnewDestFile))
           DoProcessFolder(ActionDelete, strnewDestFile, "", fileOperations, totalTime);
+
         if (!DoProcessFolder(subdirAction, pItem->GetPath(), strnewDestFile, fileOperations, totalTime))
           return false;
+
         if (action == ActionDelete || action == ActionDeleteFolder)
           DoProcessFile(ActionDeleteFolder, pItem->GetPath(), "", fileOperations, totalTime);
       }
@@ -201,12 +210,16 @@ bool CFileOperationJob::DoProcess(FileAction action, CFileItemList & items, cons
         DoProcessFile(action, pItem->GetPath(), strnewDestFile, fileOperations, totalTime);
     }
   }
+
   return true;
 }
 
-CFileOperationJob::CFileOperation::CFileOperation(FileAction action, const std::string &strFileA, const std::string &strFileB, int64_t time) : m_action(action), m_strFileA(strFileA), m_strFileB(strFileB), m_time(time)
-{
-}
+CFileOperationJob::CFileOperation::CFileOperation(FileAction action, const std::string &strFileA, const std::string &strFileB, int64_t time)
+  : m_action(action),
+    m_strFileA(strFileA),
+    m_strFileB(strFileB),
+    m_time(time)
+{ }
 
 struct DataHolder
 {
@@ -224,16 +237,20 @@ std::string CFileOperationJob::GetActionString(FileAction action)
     case ActionReplace:
       result = g_localizeStrings.Get(115);
       break;
+
     case ActionMove:
       result = g_localizeStrings.Get(116);
       break;
+
     case ActionDelete:
     case ActionDeleteFolder:
       result = g_localizeStrings.Get(117);
       break;
+
     case ActionCreateFolder:
       result = g_localizeStrings.Get(119);
       break;
+
     default:
       break;
   }
@@ -248,7 +265,7 @@ bool CFileOperationJob::CFileOperation::ExecuteOperation(CFileOperationJob *base
   base->m_currentFile = CURL(m_strFileA).GetFileNameWithoutPath();
   base->m_currentOperation = GetActionString(m_action);
 
-  if (base->ShouldCancel((unsigned)current, 100))
+  if (base->ShouldCancel((unsigned int)current, 100))
     return false;
 
   if (base->m_handle)
@@ -269,6 +286,7 @@ bool CFileOperationJob::CFileOperation::ExecuteOperation(CFileOperationJob *base
       bResult = CFile::Copy(m_strFileA, m_strFileB, this, &data);
     }
     break;
+
     case ActionMove:
     {
       CLog::Log(LOGDEBUG,"FileManager: move %s -> %s\n", m_strFileA.c_str(), m_strFileB.c_str());
@@ -281,6 +299,7 @@ bool CFileOperationJob::CFileOperation::ExecuteOperation(CFileOperationJob *base
         bResult = false;
     }
     break;
+
     case ActionDelete:
     {
       CLog::Log(LOGDEBUG,"FileManager: delete %s\n", m_strFileA.c_str());
@@ -288,6 +307,7 @@ bool CFileOperationJob::CFileOperation::ExecuteOperation(CFileOperationJob *base
       bResult = CFile::Delete(m_strFileA);
     }
     break;
+
     case ActionDeleteFolder:
     {
       CLog::Log(LOGDEBUG,"FileManager: delete folder %s\n", m_strFileA.c_str());
@@ -295,6 +315,7 @@ bool CFileOperationJob::CFileOperation::ExecuteOperation(CFileOperationJob *base
       bResult = CDirectory::Remove(m_strFileA);
     }
     break;
+
     case ActionCreateFolder:
     {
       CLog::Log(LOGDEBUG,"FileManager: create folder %s\n", m_strFileA.c_str());
@@ -351,24 +372,24 @@ bool CFileOperationJob::CFileOperation::OnFileCallback(void* pContext, int iperc
 
 bool CFileOperationJob::operator==(const CJob* job) const
 {
-  if (strcmp(job->GetType(),GetType()) == 0)
+  if (strcmp(job->GetType(), GetType()) != 0)
+    return false;
+
+  const CFileOperationJob* rjob = dynamic_cast<const CFileOperationJob*>(job);
+  if (rjob == NULL)
+    return false;
+
+  if (GetAction() != rjob->GetAction() ||
+      m_strDestFile != rjob->m_strDestFile ||
+      m_items.Size() != rjob->m_items.Size())
+    return false;
+
+  for (int i = 0; i < m_items.Size(); i++)
   {
-    const CFileOperationJob* rjob = dynamic_cast<const CFileOperationJob*>(job);
-    if (rjob)
-    {
-      if (GetAction() == rjob->GetAction() &&
-          m_strDestFile == rjob->m_strDestFile &&
-          m_items.Size() == rjob->m_items.Size())
-      {
-        for (int i=0;i<m_items.Size();++i)
-        {
-          if (m_items[i]->GetPath() != rjob->m_items[i]->GetPath() ||
-              m_items[i]->IsSelected() != rjob->m_items[i]->IsSelected())
-            return false;
-        }
-        return true;
-      }
-    }
+    if (m_items[i]->GetPath() != rjob->m_items[i]->GetPath() ||
+        m_items[i]->IsSelected() != rjob->m_items[i]->IsSelected())
+      return false;
   }
-  return false;
+
+  return true;
 }

--- a/xbmc/utils/FileOperationJob.h
+++ b/xbmc/utils/FileOperationJob.h
@@ -19,12 +19,12 @@
  *
  */
 
-#include "system.h"
-#include "FileItem.h"
-#include "Job.h"
-#include "filesystem/File.h"
 #include <string>
 #include <vector>
+
+#include "FileItem.h"
+#include "filesystem/File.h"
+#include "utils/Job.h"
 
 class CGUIDialogProgressBarHandle;
 
@@ -44,39 +44,44 @@ public:
   CFileOperationJob();
   CFileOperationJob(FileAction action, CFileItemList & items,
                     const std::string& strDestFile,
-                    bool displayProgress=false,
-                    int errorHeading=0, int errorLine=0);
-
-  void SetFileOperation(FileAction action, CFileItemList &items, const std::string &strDestFile);
-
-  virtual bool operator==(const CJob *job) const;
+                    bool displayProgress = false,
+                    int errorHeading = 0, int errorLine = 0);
 
   static std::string GetActionString(FileAction action);
 
-  const char* GetType() const { return m_displayProgress?"filemanager":""; }
-
+  // implementations of CJob
   virtual bool DoWork();
-  const std::string &GetAverageSpeed()     const { return m_avgSpeed; }
+  virtual const char* GetType() const { return m_displayProgress ? "filemanager" : ""; }
+  virtual bool operator==(const CJob *job) const;
+
+  void SetFileOperation(FileAction action, CFileItemList &items, const std::string &strDestFile);
+
+  const std::string &GetAverageSpeed() const { return m_avgSpeed; }
   const std::string &GetCurrentOperation() const { return m_currentOperation; }
-  const std::string &GetCurrentFile()      const { return m_currentFile; }
-  const CFileItemList &GetItems()         const { return m_items; }
-  FileAction GetAction() const            { return m_action; }
-  int GetHeading() const                  { return m_heading; }
-  int GetLine() const                     { return m_line; }
+  const std::string &GetCurrentFile() const { return m_currentFile; }
+  const CFileItemList &GetItems() const { return m_items; }
+  FileAction GetAction() const { return m_action; }
+  int GetHeading() const { return m_heading; }
+  int GetLine() const { return m_line; }
+
 private:
   class CFileOperation : public XFILE::IFileCallback
   {
   public:
     CFileOperation(FileAction action, const std::string &strFileA, const std::string &strFileB, int64_t time);
+
+    virtual bool OnFileCallback(void* pContext, int ipercent, float avgSpeed);
+
     bool ExecuteOperation(CFileOperationJob *base, double &current, double opWeight);
     void Debug();
-    virtual bool OnFileCallback(void* pContext, int ipercent, float avgSpeed);
+
   private:
     FileAction m_action;
     std::string m_strFileA, m_strFileB;
     int64_t m_time;
   };
   friend class CFileOperation;
+
   typedef std::vector<CFileOperation> FileOperationList;
   bool DoProcess(FileAction action, CFileItemList & items, const std::string& strDestFile, FileOperationList &fileOperations, double &totalTime);
   bool DoProcessFolder(FileAction action, const std::string& strPath, const std::string& strDestFile, FileOperationList &fileOperations, double &totalTime);

--- a/xbmc/utils/FileOperationJob.h
+++ b/xbmc/utils/FileOperationJob.h
@@ -24,11 +24,9 @@
 
 #include "FileItem.h"
 #include "filesystem/File.h"
-#include "utils/Job.h"
+#include "utils/ProgressJob.h"
 
-class CGUIDialogProgressBarHandle;
-
-class CFileOperationJob : public CJob
+class CFileOperationJob : public CProgressJob
 {
 public:
   enum FileAction
@@ -93,7 +91,6 @@ private:
   CFileItemList m_items;
   std::string m_strDestFile;
   std::string m_avgSpeed, m_currentOperation, m_currentFile;
-  CGUIDialogProgressBarHandle* m_handle;
   bool m_displayProgress;
   int m_heading;
   int m_line;

--- a/xbmc/utils/Job.h
+++ b/xbmc/utils/Job.h
@@ -163,7 +163,7 @@ public:
    
    \sa IJobCallback::OnJobProgress()
    */
-  bool ShouldCancel(unsigned int progress, unsigned int total) const;
+  virtual bool ShouldCancel(unsigned int progress, unsigned int total) const;
 private:
   friend class CJobManager;
   CJobManager *m_callback;

--- a/xbmc/utils/ProgressJob.h
+++ b/xbmc/utils/ProgressJob.h
@@ -23,6 +23,7 @@
 
 #include "utils/Job.h"
 
+class CGUIDialogProgress;
 class CGUIDialogProgressBarHandle;
 
 /*!
@@ -37,14 +38,90 @@ public:
   // implementation of CJob
   virtual const char *GetType() const { return "ProgressJob"; }
   virtual bool operator==(const CJob* job) const { return false; }
+  virtual bool ShouldCancel(unsigned int progress, unsigned int total) const;
+
+  /*!
+   \brief Executes the job showing a modal progress dialog.
+   */
+  bool DoModal();
+
+  /*!
+   \brief Sets the given progress indicators to be used during execution of
+   the job.
+
+   \details This automatically disables auto-closing the given progress
+   indicators once the job has been finished.
+
+   \param progressBar Progress bar handle to be used.
+   \param progressDialog Progress dialog to be used.
+   \param updateProgress (optional) Whether to show progress updates.
+   \param updateInformation (optional) Whether to show progress information.
+   */
+  void SetProgressIndicators(CGUIDialogProgressBarHandle* progressBar, CGUIDialogProgress* progressDialog, bool updateProgress = true, bool updateInformation = true);
 
 protected:
+  CProgressJob();
   CProgressJob(CGUIDialogProgressBarHandle* progressBar);
+
+  /*!
+   \brief Whether the job is being run modally or in the background.
+   */
+  bool IsModal() const { return m_modal; }
 
   /*!
    \brief Returns the progress bar indicating the progress of the job.
    */
-  CGUIDialogProgressBarHandle* GetProgressBar() { return m_progress; }
+  CGUIDialogProgressBarHandle* GetProgressBar() const { return m_progress; }
+
+  /*!
+   \brief Sets the progress bar indicating the progress of the job.
+   */
+  void SetProgressBar(CGUIDialogProgressBarHandle* progress) { m_progress = progress; }
+
+  /*!
+   \brief Returns the progress dialog indicating the progress of the job.
+   */
+  CGUIDialogProgress* GetProgressDialog() const { return m_progressDialog; }
+
+  /*!
+   \brief Sets the progress bar indicating the progress of the job.
+   */
+  void SetProgressDialog(CGUIDialogProgress* progressDialog) { m_progressDialog = progressDialog; }
+
+  /*!
+   \brief Whether to automatically close the progress indicator in MarkFinished().
+   */
+  bool GetAutoClose() { return m_autoClose; }
+
+  /*!
+   \brief Set whether to automatically close the progress indicator in MarkFinished().
+   */
+  void SetAutoClose(bool autoClose) { m_autoClose = autoClose; }
+
+  /*!
+   \brief Whether to update the progress bar or not.
+   */
+  bool GetUpdateProgress() { return m_updateProgress; }
+
+  /*!
+   \brief Set whether to update the progress bar or not.
+   */
+  void SetUpdateProgress(bool updateProgress) { m_updateProgress = updateProgress; }
+
+  /*!
+  \brief Whether to update the progress information or not.
+  */
+  bool GetUpdateInformation() { return m_updateInformation; }
+
+  /*!
+  \brief Set whether to update the progress information or not.
+  */
+  void SetUpdateInformation(bool updateInformation) { m_updateInformation = updateInformation; }
+
+  /*!
+   \brief Makes sure that the modal dialog is being shown.
+   */
+  void ShowProgressDialog() const;
 
   /*!
    \brief Sets the given title as the title of the progress bar.
@@ -65,7 +142,7 @@ protected:
 
    \param[in] percentage Percentage to be set as the current progress
   */
-  void SetProgress(float percentage);
+  void SetProgress(float percentage) const;
 
   /*!
    \brief Sets the progress of the progress bar to the given value.
@@ -73,13 +150,23 @@ protected:
    \param[in] currentStep Current step being processed
    \param[in] totalSteps Total steps to be processed
   */
-  void SetProgress(int currentStep, int totalSteps);
+  void SetProgress(int currentStep, int totalSteps) const;
 
   /*!
    \brief Marks the progress as finished by setting it to 100%.
    */
   void MarkFinished();
 
+  /*!
+   \brief Checks if the progress dialog has been cancelled.
+   */
+  bool IsCancelled() const;
+
 private:
-  CGUIDialogProgressBarHandle* m_progress;
+  bool m_modal;
+  bool m_autoClose;
+  bool m_updateProgress;
+  bool m_updateInformation;
+  mutable CGUIDialogProgressBarHandle* m_progress;
+  mutable CGUIDialogProgress* m_progressDialog;
 };


### PR DESCRIPTION
This is an approach at implementing what I've brought up in http://forum.kodi.tv/showthread.php?tid=219504. For those too lazy to follow the link:
It has always bugged me how we let users choose addons for a setting. The user gets to see a select dialog with all installed and enabled addons. If the user wants to take a look at all the available (i.e. not necessarily locally installed) addons he presses the "Get more..." button. But instead of showing all the addons available for installation in the same (or a new) select dialog he gets thrown out of the dialog and into the addon browser. Then when he has either downloaded an addon or done nothing he presses Back/Esc and lands back in the settings window but not in the previously open select dialog. Therefore the user has to activate the same setting again to get into the select dialog and choose the addon he wants (and may have previously installed). Last but not least when the user then goes out of the settings and into the addon browser he is thrown directly into the list that he was redirected to from the settings window. All of this seems very unideal to me.

Therefore I've started looking into extending CGUIWindowAddonBrowser::SelectAddonID() to automatically handle the "Get more..." functionality by opening another select dialog with all the addons available for installation.

Apart from a few cosmetic and cleanup commits I've done the following changes:
- I have extended `CProgressJob` to support either a non-modal progress bar dialog (the small one in the top right corner) or a modal one (the big one in the center of the screen with the "Cancel" button).
- I have adjusted `CFileOperationJob` to derive from `CProgressJob` to make use of its progress handling.
- I have added some helper methods to `CAddonMgr`: `CanAddonBeDisabled`, `IsAddonInstalled` and `CanAddonBeInstalled`
- I have refactored `CAddonInstaller` and especially `CAddonInstallerJob` (which derives from `CFileOperationJob` and therefore from `CProgressJob`) to make use of the progress functionality provided by `CProgressJob`. It now sets titles and texts based on the current work being done, updates the progress bar and on errors either shows a kai toast (when run in the background) or a modal dialog (when run in the foreground).
- I have extended `CGUIWindowAddonBrowser::SelectAddonID()` to be able to show either only installed or all available addons of a (list of) addon type(s). The "Get more..." button automatically re-opens the select dialog but with a list of all available addons instead of throwing the user into the addons window. Furthermore selecting an addon automatically starts installing it and shows a modal progress dialog.

There's one thing I don't like in this implementation and that's the last commit. The problem is that when the user selects a skin to be used that isn't already installed the skin is automatically downloaded and then the user gets the "Would you like to change to this skin?" dialog which simply doesn't make any sense as the user has already chosen that skin. What I did is that I forwarded the modal flag of the installation process to `CSkinInfo::OnPostInstall` and disabled showing the dialog when the installation has been performed with a modal dialog. But it's not really a clean/neat solution. So any ideas on this are welcome.

I've made a short video demonstrating how the process looks and works by selecting Aeon Nox (which wasn't installed) as the skin to be used, see https://www.youtube.com/watch?v=aeOQRXNCPm4.

PS: Even though I listed a lot of reasons why I don't like the current behaviour I actually started working on this because of the language addons (see #5561) in case we don't want to distribute all of them but allow users to choose a language from the list of all available language addons.
