### PR TITLE
[video] fix mark watched/unwatched from manage sub menu

### DIFF
--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -50,6 +50,7 @@
 #include "TextureCache.h"
 #include "music/MusicDatabase.h"
 #include "URL.h"
+#include "video/VideoLibraryQueue.h"
 #include "video/VideoThumbLoader.h"
 #include "filesystem/Directory.h"
 #include "filesystem/VideoDatabaseDirectory.h"
@@ -1064,6 +1065,12 @@ int CGUIDialogVideoInfo::ManageVideoItem(const CFileItemPtr &item)
 
       case CONTEXT_BUTTON_TAGS_REMOVE_ITEMS:
         result = RemoveItemsFromTag(item);
+        break;
+
+      case CONTEXT_BUTTON_MARK_WATCHED:
+      case CONTEXT_BUTTON_MARK_UNWATCHED:
+        CVideoLibraryQueue::Get().MarkAsWatched(item, (button == (CONTEXT_BUTTON)CONTEXT_BUTTON_MARK_WATCHED));
+        result = true;
         break;
 
       default:


### PR DESCRIPTION
This fixes marking watched from the item's manage sub menu. Discussion @ https://github.com/xbmc/xbmc/commit/c9efbe72f9386c77bb4b4a6e25851c67974ab6cf#commitcomment-9925967

@Montellese for review please.
