### PR TITLE
Bump python to 2.7.9 built with VS2013

### DIFF
--- a/project/BuildDependencies/scripts/0_package.list
+++ b/project/BuildDependencies/scripts/0_package.list
@@ -44,7 +44,7 @@ libzlib-vc100-1.2.5-win32.7z
 mysqlclient-6.1.3-win32-vc120.7z
 pcre-8.34-win32-vc120.7z
 PIL-1.1.7p-win32.7z
-python-2.7.8-win32.7z
+python-2.7.9-win32.7z
 sqlite-3.8.6-win32-vc120.7z
 swig-2.0.7-win32-1.7z
 taglib-1.9.1-win32-vc120.7z


### PR DESCRIPTION
With our previous issues around different msvcrt versions I thought we might as well build our own python to get away from similar things in the future. The one difference is that this is lacking the msi module because it's using features no longer available in the Windows SDK.

Pre-built package can be found at http://delusional.nu/python-2.7.9-win32.7z in the correct package format.
