### PR TITLE
[backport] Fix playback of mixed SmartPlaylists

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4848,6 +4848,14 @@ bool CApplication::OnMessage(CGUIMessage& message)
       if (url.IsProtocol("plugin"))
         XFILE::CPluginDirectory::GetPluginResult(url.Get(), file);
 
+      // Don't queue if next media type is different from current one
+      if ((!file.IsVideo() && m_pPlayer->IsPlayingVideo())
+          || ((!file.IsAudio() || file.IsVideo()) && m_pPlayer->IsPlayingAudio()))
+      {
+        m_pPlayer->OnNothingToQueueNotify();
+        return true;
+      }
+
 #ifdef HAS_UPNP
       if (URIUtils::IsUPnP(file.GetPath()))
       {


### PR DESCRIPTION
Ignore GUI_MSG_QUEUE_NEXT_ITEM messages when the incoming item is not playable by current player, giving a chance to be reproduced by a different one, instead of skipping it.

backport
(cherry picked from commit d09993ea7c840b632f75a0090fd6fe4b4f1f9722)
(cherry picked from commit 15b22b44fb84f29c7fc5f9832e1d7c87c3ed41b5)
