### PR TITLE
Fix for coverity #1261754

### DIFF
--- a/lib/libXDAAP/httpClient.c
+++ b/lib/libXDAAP/httpClient.c
@@ -104,6 +104,7 @@ static void bind_socket(int sockfd)
         int res;
 
         saddrBindingSocket.sin_port = htons(port);
+        memset(&saddrBindingSocket.sin_zero, 0, sizeof(saddrBindingSocket.sin_zero));
         res = bind(sockfd, (struct sockaddr *)&saddrBindingSocket,
                    sizeof(saddrBindingSocket));
         if (res == 0) bound = 1;


### PR DESCRIPTION
This commit should fix coverity #1261754 

I didn't compile this but used https://silviocesare.wordpress.com/2007/10/22/setting-sin_zero-to-0-in-struct-sockaddr_in/ as a reference.
