### PR TITLE
CTextureCacheJob: add fallback hash in case neither mtime/ctime nor size of an image are known

### DIFF
--- a/xbmc/TextureCacheJob.cpp
+++ b/xbmc/TextureCacheJob.cpp
@@ -235,6 +235,9 @@ std::string CTextureCacheJob::GetImageHash(const std::string &url)
     if (time || st.st_size)
       return StringUtils::Format("d%" PRId64"s%" PRId64, time, st.st_size);;
 
+    // the image exists but we couldn't determine the mtime/ctime and/or size
+    // so set an obviously bad hash
+    return "BADHASH";
   }
   CLog::Log(LOGDEBUG, "%s - unable to stat url %s", __FUNCTION__, url.c_str());
   return "";


### PR DESCRIPTION
This fixes caching images from a HTTP server that doesn't provide neither the `Last-Modified` nor the `Content-Length` header in the response to our HTTP HEAD request (through `CCurlFile::Stat()`). The image obviously exists (otherwise the HTTP HEAD request would have failed) but we don't have enough information to be able to determine in the future whether the image has changed. Therefore we fall back to an obviously bad hash `BADHASH` instead of a combination of last modified date and file size.

This was reported by @bromix in the forum with an example HTTP response, see http://forum.kodi.tv/showthread.php?tid=219802.
