### PR TITLE
Invalidate repo data on version change

### DIFF
--- a/xbmc/addons/AddonDatabase.h
+++ b/xbmc/addons/AddonDatabase.h
@@ -44,19 +44,21 @@ public:
    \return true if a repo was found, false otherwise.
    */
   bool GetRepoForAddon(const std::string& addonID, std::string& repo);
-  int AddRepository(const std::string& id, const ADDON::VECADDONS& addons, const std::string& checksum);
+  int AddRepository(const std::string& id, const ADDON::VECADDONS& addons, const std::string& checksum, const ADDON::AddonVersion& version);
   void DeleteRepository(const std::string& id);
   void DeleteRepository(int id);
   int GetRepoChecksum(const std::string& id, std::string& checksum);
   bool GetRepository(const std::string& id, ADDON::VECADDONS& addons);
   bool GetRepository(int id, ADDON::VECADDONS& addons);
-  bool SetRepoTimestamp(const std::string& id, const std::string& timestamp);
+  bool SetRepoTimestamp(const std::string& id, const std::string& timestamp, const ADDON::AddonVersion& version);
 
   /*! \brief Retrieve the time a repository was last checked
    \param id id of the repo
    \return last time the repo was checked, current time if not available
    \sa SetRepoTimestamp */
   CDateTime GetRepoTimestamp(const std::string& id);
+
+  ADDON::AddonVersion GetRepoVersion(const std::string& id);
 
   bool Search(const std::string& search, ADDON::VECADDONS& items);
   static void SetPropertiesFromAddon(const ADDON::AddonPtr& addon, CFileItemPtr& item); 
@@ -139,7 +141,7 @@ protected:
   virtual void CreateAnalytics();
   virtual void UpdateTables(int version);
   virtual int GetMinSchemaVersion() const { return 15; }
-  virtual int GetSchemaVersion() const { return 16; }
+  virtual int GetSchemaVersion() const { return 17; }
   const char *GetBaseDBName() const { return "Addons"; }
 
   bool GetAddon(int id, ADDON::AddonPtr& addon);

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -414,7 +414,8 @@ void CAddonInstaller::UpdateRepos(bool force, bool wait)
     for (const auto& repo : addons)
     {
       CDateTime lastUpdate = database.GetRepoTimestamp(repo->ID());
-      if (force || !lastUpdate.IsValid() || lastUpdate + CDateTimeSpan(0,24,0,0) < CDateTime::GetCurrentDateTime())
+      if (force || !lastUpdate.IsValid() || lastUpdate + CDateTimeSpan(0,24,0,0) < CDateTime::GetCurrentDateTime()
+        || repo->Version() != database.GetRepoVersion(repo->ID()))
       {
         CLog::Log(LOGDEBUG,"Checking repositories for updates (triggered by %s)",repo->Name().c_str());
         m_repoUpdateJob = CJobManager::GetInstance().AddJob(new CRepositoryUpdateJob(addons), this);

--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -381,14 +381,14 @@ bool CRepositoryUpdateJob::GrabAddons(const RepositoryPtr& repo, VECADDONS& addo
     {
       for (map<string, AddonPtr>::const_iterator i = uniqueAddons.begin(); i != uniqueAddons.end(); ++i)
         addons.push_back(i->second);
-      database.AddRepository(repo->ID(),addons,reposum);
+      database.AddRepository(repo->ID(), addons, reposum, repo->Version());
     }
   }
   else
   {
     CLog::Log(LOGDEBUG, "Checksum for repository %s not changed.", repo->ID().c_str());
     database.GetRepository(repo->ID(), addons);
-    database.SetRepoTimestamp(repo->ID(), CDateTime::GetCurrentDateTime().GetAsDBDateTime());
+    database.SetRepoTimestamp(repo->ID(), CDateTime::GetCurrentDateTime().GetAsDBDateTime(), repo->Version());
   }
   return true;
 }


### PR DESCRIPTION
This changes the addon DB to store the repo version the info was fetched from. This is to ensure that the repo we are comparing against is actually the same. For instance if the `dir` entires in the addon have changed, the checksum is invalid and the repo should be checked for updates immediately.

@MartijnKaijser Let me be very clear that this **incidentally** fixes your ABI problem. It only works because the current repo updater force re-check dependencies, even if nothing changed in the repo (which is a quite broken behavior).
