### PR TITLE
[video] Only allow delete from library if user has DB write permission

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -1090,6 +1090,7 @@ msgid "Fetching CD information"
 msgstr ""
 
 #: xbmc/dialogs/GUIDialogFileBrowser.cpp
+#: xbmc/video/windows/GUIWindowVideoNav.cpp
 msgctxt "#257"
 msgid "Error"
 msgstr ""
@@ -2806,6 +2807,7 @@ msgctxt "#661"
 msgid "Choose export folder"
 msgstr ""
 
+#: xbmc/video/windows/GUIWindowVideoNav.cpp
 msgctxt "#662"
 msgid "This file is no longer available."
 msgstr ""

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -1046,13 +1046,21 @@ bool CGUIWindowVideoNav::OnClick(int iItem)
   if (!item->m_bIsFolder && item->IsVideoDb() && !item->Exists())
   {
     CLog::Log(LOGDEBUG, "%s called on '%s' but file doesn't exist", __FUNCTION__, item->GetPath().c_str());
-    if (!CGUIDialogVideoInfo::DeleteVideoItemFromDatabase(item, true))
-      return true;
+    if (CProfilesManager::Get().GetCurrentProfile().canWriteDatabases())
+    {
+      if (!CGUIDialogVideoInfo::DeleteVideoItemFromDatabase(item, true))
+        return true;
 
-    // update list
-    Refresh(true);
-    m_viewControl.SetSelectedItem(iItem);
-    return true;
+      // update list
+      Refresh(true);
+      m_viewControl.SetSelectedItem(iItem);
+      return true;
+    }
+    else
+    {
+      CGUIDialogOK::ShowAndGetInput(257, 0, 662, 0);
+      return true;
+    }	  
   }
   else if (StringUtils::StartsWithNoCase(item->GetPath(), "newtag://"))
   {


### PR DESCRIPTION
This will fix issue [15784](http://trac.kodi.tv/ticket/15784)

The code will check if the user is allowed to remove from database before prompting the delete from library dialog. If the user is not allowed to remove from database he gets a prompt with file is no longer available.
