### PR TITLE
CTextureCacheJob: add fallback hash in case neither mtime/ctime nor size of an image are known

### DIFF
--- a/xbmc/TextureCacheJob.cpp
+++ b/xbmc/TextureCacheJob.cpp
@@ -203,6 +203,9 @@ CStdString CTextureCacheJob::GetImageHash(const CStdString &url)
     if (time || st.st_size)
       return StringUtils::Format("d%" PRId64"s%" PRId64, time, st.st_size);;
 
+    // the image exists but we couldn't determine the mtime/ctime and/or size
+    // so set an obviously bad hash
+    return "BADHASH";
   }
   CLog::Log(LOGDEBUG, "%s - unable to stat url %s", __FUNCTION__, url.c_str());
   return "";


### PR DESCRIPTION
This is the backport of #6562 for Helix.
