### PR TITLE
[omxplayer] Fix for volume being treated as a linear scale

### DIFF
--- a/xbmc/cores/omxplayer/OMXAudio.cpp
+++ b/xbmc/cores/omxplayer/OMXAudio.cpp
@@ -1050,6 +1050,8 @@ bool COMXAudio::ApplyVolume(void)
     return false;
 
   float fVolume = m_Mute ? VOLUME_MINIMUM : m_CurrentVolume;
+  // need to convert a log scale of 0.0=-60dB, 1.0=0dB to a linear scale (0.0=silence, 1.0=full)
+  fVolume = CAEUtil::GainToScale(CAEUtil::PercentToGain(fVolume));
 
   // the analogue volume is too quiet for some. Allow use of an advancedsetting to boost this (at risk of distortion) (deprecated)
   double gain = pow(10, (g_advancedSettings.m_ac3Gain - 12.0f) / 20.0);


### PR DESCRIPTION
The volume in kodi is actually 0.0=-60dB to 1.0=0dB. omxplayer was treating this as a linear scale.
That's correct for 0.0 and 1.0, but too loud for 0.5.

The fix has been tested with white noise sample and decibel meter smartphone app,
and now omxplayer and dvdplayer produce the same output.
