### PR TITLE
[mmalrenderer] Fix for hang on shutdown

### DIFF
--- a/xbmc/cores/VideoRenderers/MMALRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/MMALRenderer.cpp
@@ -132,7 +132,7 @@ bool CMMALRenderer::init_vout(MMAL_ES_FORMAT_T *format)
 void CMMALRenderer::Process()
 {
   MMAL_BUFFER_HEADER_T *buffer;
-  while (buffer = mmal_queue_wait(m_release_queue), buffer)
+  while (buffer = mmal_queue_wait(m_release_queue), buffer && buffer != &m_quit_packet)
   {
     CMMALVideoBuffer *omvb = (CMMALVideoBuffer *)buffer->user_data;
     omvb->Release();
@@ -148,6 +148,7 @@ CMMALRenderer::CMMALRenderer()
   m_vout_input = NULL;
   m_vout_input_pool = NULL;
   memset(m_buffers, 0, sizeof m_buffers);
+  mmal_buffer_header_reset(&m_quit_packet);
   m_release_queue = mmal_queue_create();
   m_iYV12RenderBuffer = 0;
   Create();
@@ -157,7 +158,7 @@ CMMALRenderer::~CMMALRenderer()
 {
   CLog::Log(LOGDEBUG, "%s::%s", CLASSNAME, __func__);
   // shutdown thread
-  mmal_queue_put(m_release_queue, NULL);
+  mmal_queue_put(m_release_queue, &m_quit_packet);
   m_sync.Wait();
   mmal_queue_destroy(m_release_queue);
   UnInit();

--- a/xbmc/cores/VideoRenderers/MMALRenderer.h
+++ b/xbmc/cores/VideoRenderers/MMALRenderer.h
@@ -118,6 +118,8 @@ protected:
 
   MMAL_QUEUE_T     *m_release_queue;
   CEvent            m_sync;
+  MMAL_BUFFER_HEADER_T m_quit_packet;
+
   bool init_vout(MMAL_ES_FORMAT_T *m_format);
   void ReleaseBuffers();
   void UnInitMMAL();


### PR DESCRIPTION
mmal_queue_push doesn't allow null pointers, so use a unique packet for signalling quit
