### PR TITLE
Optimize CPVRTimerInfoTag. No more copies, just shared pointers.

### DIFF
--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -53,6 +53,7 @@ namespace PVR
   class CPVRTimerInfoTag;
   typedef std::shared_ptr<PVR::CPVRRecording> CPVRRecordingPtr;
   typedef std::shared_ptr<PVR::CPVRChannel> CPVRChannelPtr;
+  typedef std::shared_ptr<PVR::CPVRTimerInfoTag> CPVRTimerInfoTagPtr;
 }
 class CPictureInfoTag;
 
@@ -110,7 +111,7 @@ public:
   CFileItem(const EPG::CEpgInfoTagPtr& tag);
   CFileItem(const PVR::CPVRChannelPtr& channel);
   CFileItem(const PVR::CPVRRecordingPtr& record);
-  CFileItem(const PVR::CPVRTimerInfoTag& timer);
+  CFileItem(const PVR::CPVRTimerInfoTagPtr& timer);
   CFileItem(const CMediaSource& share);
   virtual ~CFileItem(void);
   virtual CGUIListItem *Clone() const { return new CFileItem(*this); };
@@ -306,9 +307,7 @@ public:
     return m_pvrTimerInfoTag != NULL;
   }
 
-  PVR::CPVRTimerInfoTag* GetPVRTimerInfoTag();
-
-  inline const PVR::CPVRTimerInfoTag* GetPVRTimerInfoTag() const
+  inline const PVR::CPVRTimerInfoTagPtr GetPVRTimerInfoTag() const
   {
     return m_pvrTimerInfoTag;
   }
@@ -495,7 +494,7 @@ private:
   EPG::CEpgInfoTagPtr m_epgInfoTag;
   PVR::CPVRChannelPtr m_pvrChannelInfoTag;
   PVR::CPVRRecordingPtr m_pvrRecordingInfoTag;
-  PVR::CPVRTimerInfoTag * m_pvrTimerInfoTag;
+  PVR::CPVRTimerInfoTagPtr m_pvrTimerInfoTag;
   CPictureInfoTag* m_pictureInfoTag;
   bool m_bIsAlbum;
 

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -5249,7 +5249,7 @@ bool CGUIInfoManager::GetItemBool(const CGUIListItem *item, int condition) const
       }
       else if (pItem->HasPVRTimerInfoTag())
       {
-        const CPVRTimerInfoTag *timer = pItem->GetPVRTimerInfoTag();
+        const CPVRTimerInfoTagPtr timer = pItem->GetPVRTimerInfoTag();
         if (timer)
           return timer->IsRecording();
       }

--- a/xbmc/addons/AddonCallbacksPVR.cpp
+++ b/xbmc/addons/AddonCallbacksPVR.cpp
@@ -219,7 +219,7 @@ void CAddonCallbacksPVR::PVRTransferTimerEntry(void *addonData, const ADDON_HAND
   }
 
   /* transfer this entry to the timers container */
-  CPVRTimerInfoTag transferTimer(*timer, channel, client->GetID());
+  CPVRTimerInfoTagPtr transferTimer(new CPVRTimerInfoTag(*timer, channel, client->GetID()));
   xbmcTimers->UpdateFromClient(transferTimer);
 }
 

--- a/xbmc/epg/EpgSearchFilter.cpp
+++ b/xbmc/epg/EpgSearchFilter.cpp
@@ -245,7 +245,7 @@ int EpgSearchFilter::FilterTimers(CFileItemList &results)
     if (!fileItem || !fileItem->HasPVRTimerInfoTag())
       continue;
 
-    CPVRTimerInfoTag *timer = fileItem->GetPVRTimerInfoTag();
+    CPVRTimerInfoTagPtr timer = fileItem->GetPVRTimerInfoTag();
     if (!timer)
       continue;
 

--- a/xbmc/interfaces/json-rpc/FileItemHandler.cpp
+++ b/xbmc/interfaces/json-rpc/FileItemHandler.cpp
@@ -361,7 +361,7 @@ void CFileItemHandler::HandleFileItem(const char *ID, bool allowFile, const char
     if (item->HasPVRRecordingInfoTag())
       FillDetails(item->GetPVRRecordingInfoTag().get(), item, fields, object, thumbLoader);
     if (item->HasPVRTimerInfoTag())
-      FillDetails(item->GetPVRTimerInfoTag(), item, fields, object, thumbLoader);
+      FillDetails(item->GetPVRTimerInfoTag().get(), item, fields, object, thumbLoader);
     if (item->HasVideoInfoTag())
       FillDetails(item->GetVideoInfoTag(), item, fields, object, thumbLoader);
     if (item->HasMusicInfoTag())

--- a/xbmc/interfaces/json-rpc/PVROperations.cpp
+++ b/xbmc/interfaces/json-rpc/PVROperations.cpp
@@ -334,7 +334,7 @@ JSONRPC_STATUS CPVROperations::GetTimerDetails(const std::string &method, ITrans
   if (!timer)
     return InvalidParams;
 
-  HandleFileItem("timerid", false, "timerdetails", CFileItemPtr(new CFileItem(*timer)), parameterObject, parameterObject["properties"], result, false);
+  HandleFileItem("timerid", false, "timerdetails", CFileItemPtr(new CFileItem(timer)), parameterObject, parameterObject["properties"], result, false);
 
   return OK;
 }

--- a/xbmc/pvr/PVRGUIInfo.cpp
+++ b/xbmc/pvr/PVRGUIInfo.cpp
@@ -796,7 +796,7 @@ void CPVRGUIInfo::UpdateNextTimer(void)
   CFileItemPtr tag = g_PVRTimers->GetNextActiveTimer();
   if (tag && tag->HasPVRTimerInfoTag())
   {
-    CPVRTimerInfoTag *timer = tag->GetPVRTimerInfoTag();
+    CPVRTimerInfoTagPtr timer = tag->GetPVRTimerInfoTag();
     strNextRecordingTitle = StringUtils::Format("%s",       timer->Title().c_str());
     strNextRecordingChannelName = StringUtils::Format("%s", timer->ChannelName().c_str());
     strNextRecordingChannelIcon = StringUtils::Format("%s", timer->ChannelIcon().c_str());
@@ -833,7 +833,7 @@ void CPVRGUIInfo::UpdateTimersToggle(void)
     std::vector<CFileItemPtr> activeTags = g_PVRTimers->GetActiveRecordings();
     if (m_iTimerInfoToggleCurrent < activeTags.size() && activeTags.at(m_iTimerInfoToggleCurrent)->HasPVRTimerInfoTag())
     {
-      CPVRTimerInfoTag *tag = activeTags.at(m_iTimerInfoToggleCurrent)->GetPVRTimerInfoTag();
+      CPVRTimerInfoTagPtr tag = activeTags.at(m_iTimerInfoToggleCurrent)->GetPVRTimerInfoTag();
       strActiveTimerTitle = StringUtils::Format("%s",       tag->Title().c_str());
       strActiveTimerChannelName = StringUtils::Format("%s", tag->ChannelName().c_str());
       strActiveTimerChannelIcon = StringUtils::Format("%s", tag->ChannelIcon().c_str());

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -1454,13 +1454,10 @@ bool CPVRManager::EventOccursOnLocalBackend(const CFileItemPtr& item) const
 {
   if (item && item->HasPVRTimerInfoTag())
   {
-    CPVRTimerInfoTag* tag = item->GetPVRTimerInfoTag();
-    if (tag)
-    {
-      std::string hostname(m_addons->GetBackendHostnameByClientId(tag->m_iClientId));
-      if (!hostname.empty() && g_application.getNetwork().IsLocalHost(hostname))
-        return true;
-    }
+    CPVRTimerInfoTagPtr tag(item->GetPVRTimerInfoTag());
+    std::string hostname(m_addons->GetBackendHostnameByClientId(tag->m_iClientId));
+    if (!hostname.empty() && g_application.getNetwork().IsLocalHost(hostname))
+      return true;
   }
   return false;
 }

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
@@ -76,11 +76,10 @@ bool CGUIDialogPVRGuideInfo::ActionStartTimer(const CEpgInfoTagPtr &tag)
     if (pDialog->IsConfirmed())
     {
       Close();
-      CPVRTimerInfoTag *newTimer = CPVRTimerInfoTag::CreateFromEpg(*tag);
+      CPVRTimerInfoTagPtr newTimer = CPVRTimerInfoTag::CreateFromEpg(tag);
       if (newTimer)
       {
-        bReturn = CPVRTimers::AddTimer(*newTimer);
-        delete newTimer;
+        bReturn = CPVRTimers::AddTimer(newTimer);
       }
       else
       {

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -78,7 +78,7 @@ void CGUIDialogPVRTimerSettings::OnSettingChanged(const CSetting *setting)
 
   CGUIDialogSettingsManualBase::OnSettingChanged(setting);
 
-  CPVRTimerInfoTag* tag = m_timerItem->GetPVRTimerInfoTag();
+  CPVRTimerInfoTagPtr tag = m_timerItem->GetPVRTimerInfoTag();
   if (tag == NULL)
     return;
 
@@ -176,7 +176,7 @@ void CGUIDialogPVRTimerSettings::OnSettingAction(const CSetting *setting)
 
   CGUIDialogSettingsManualBase::OnSettingAction(setting);
 
-  CPVRTimerInfoTag* tag = m_timerItem->GetPVRTimerInfoTag();
+  CPVRTimerInfoTagPtr tag = m_timerItem->GetPVRTimerInfoTag();
   if (tag == NULL)
     return;
 
@@ -228,7 +228,7 @@ void CGUIDialogPVRTimerSettings::OnSettingAction(const CSetting *setting)
 
 void CGUIDialogPVRTimerSettings::Save()
 {
-  CPVRTimerInfoTag* tag = m_timerItem->GetPVRTimerInfoTag();
+  CPVRTimerInfoTagPtr tag = m_timerItem->GetPVRTimerInfoTag();
 
   // Set the timer's title to the channel name if it's 'New Timer' or empty
   if (tag->m_strTitle == g_localizeStrings.Get(19056) || tag->m_strTitle.empty())
@@ -272,7 +272,7 @@ void CGUIDialogPVRTimerSettings::InitializeSettings()
   // add a condition
   m_settingsManager->AddCondition("IsTimerDayRepeating", IsTimerDayRepeating);
 
-  CPVRTimerInfoTag* tag = m_timerItem->GetPVRTimerInfoTag();
+  CPVRTimerInfoTagPtr tag = m_timerItem->GetPVRTimerInfoTag();
 
   m_selectedChannelEntry = 0;
   m_channelEntries.clear();
@@ -498,7 +498,7 @@ void CGUIDialogPVRTimerSettings::DaysOptionsFiller(const CSetting *setting, std:
   if (dialog == NULL)
     return;
 
-  const CPVRTimerInfoTag *tag = dialog->m_timerItem->GetPVRTimerInfoTag();
+  const CPVRTimerInfoTagPtr tag = dialog->m_timerItem->GetPVRTimerInfoTag();
   if (tag == NULL)
     return;
 

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -38,7 +38,7 @@
 using namespace PVR;
 using namespace EPG;
 
-CPVRTimerInfoTag::CPVRTimerInfoTag(void) :
+CPVRTimerInfoTag::CPVRTimerInfoTag(bool bRadio /* = false */) :
   m_strTitle(g_localizeStrings.Get(19056)), // New Timer
   m_strDirectory("/")
 {
@@ -50,7 +50,7 @@ CPVRTimerInfoTag::CPVRTimerInfoTag(void) :
   m_bIsRepeating       = false;
   m_iWeekdays          = 0;
   m_iChannelNumber     = 0;
-  m_bIsRadio           = false;
+  m_bIsRadio           = bRadio;
   CEpgInfoTagPtr emptyTag;
   m_epgTag             = emptyTag;
   m_iMarginStart       = CSettings::Get().GetInt("pvrrecord.marginstart");
@@ -64,10 +64,10 @@ CPVRTimerInfoTag::CPVRTimerInfoTag(void) :
   m_iTimerId           = 0;
 }
 
-CPVRTimerInfoTag::CPVRTimerInfoTag(const PVR_TIMER &timer, CPVRChannelPtr channel, unsigned int iClientId) :
+CPVRTimerInfoTag::CPVRTimerInfoTag(const PVR_TIMER &timer, const CPVRChannelPtr &channel, unsigned int iClientId) :
   m_strTitle(timer.strTitle),
   m_strDirectory(timer.strDirectory)
-{  
+{
   m_iClientId          = iClientId;
   m_iClientIndex       = timer.iClientIndex;
   m_iClientChannelUid  = channel ? channel->UniqueID() : timer.iClientChannelUid;
@@ -123,37 +123,6 @@ bool CPVRTimerInfoTag::operator ==(const CPVRTimerInfoTag& right) const
           m_iMarginEnd         == right.m_iMarginEnd &&
           m_state              == right.m_state &&
           m_iTimerId           == right.m_iTimerId);
-}
-
-CPVRTimerInfoTag &CPVRTimerInfoTag::operator=(const CPVRTimerInfoTag &orig)
-{
-  m_channel            = orig.m_channel;
-  m_iClientIndex       = orig.m_iClientIndex;
-  m_strSummary         = orig.m_strSummary;
-  m_iClientChannelUid  = orig.m_iClientChannelUid;
-  m_bIsRadio           = orig.m_bIsRadio;
-  m_bIsRepeating       = orig.m_bIsRepeating;
-  m_StartTime          = orig.m_StartTime;
-  m_StopTime           = orig.m_StopTime;
-  m_FirstDay           = orig.m_FirstDay;
-  m_iWeekdays          = orig.m_iWeekdays;
-  m_iPriority          = orig.m_iPriority;
-  m_iLifetime          = orig.m_iLifetime;
-  m_strFileNameAndPath = orig.m_strFileNameAndPath;
-  m_strTitle           = orig.m_strTitle;
-  m_strDirectory       = orig.m_strDirectory;
-  m_iClientId          = orig.m_iClientId;
-  m_iMarginStart       = orig.m_iMarginStart;
-  m_iMarginEnd         = orig.m_iMarginEnd;
-  m_state              = orig.m_state;
-  m_iChannelNumber     = orig.m_iChannelNumber;
-  m_iTimerId           = orig.m_iTimerId;
-  m_iGenreType         = orig.m_iGenreType;
-  m_iGenreSubType      = orig.m_iGenreSubType;
-  m_epgTag             = orig.m_epgTag;
-  m_genre              = orig.m_genre;
-
-  return *this;
 }
 
 CPVRTimerInfoTag::~CPVRTimerInfoTag(void)
@@ -382,32 +351,32 @@ bool CPVRTimerInfoTag::RenameOnClient(const std::string &strNewName)
   return true;
 }
 
-bool CPVRTimerInfoTag::UpdateEntry(const CPVRTimerInfoTag &tag)
+bool CPVRTimerInfoTag::UpdateEntry(const CPVRTimerInfoTagPtr &tag)
 {
   CSingleLock lock(m_critSection);
 
-  m_iClientId         = tag.m_iClientId;
-  m_iClientIndex      = tag.m_iClientIndex;
-  m_strTitle          = tag.m_strTitle;
-  m_strDirectory      = tag.m_strDirectory;
-  m_iClientChannelUid = tag.m_iClientChannelUid;
-  m_StartTime         = tag.m_StartTime;
-  m_StopTime          = tag.m_StopTime;
-  m_FirstDay          = tag.m_FirstDay;
-  m_iPriority         = tag.m_iPriority;
-  m_iLifetime         = tag.m_iLifetime;
-  m_state             = tag.m_state;
-  m_bIsRepeating      = tag.m_bIsRepeating;
-  m_iWeekdays         = tag.m_iWeekdays;
-  m_iChannelNumber    = tag.m_iChannelNumber;
-  m_bIsRadio          = tag.m_bIsRadio;
-  m_iMarginStart      = tag.m_iMarginStart;
-  m_iMarginEnd        = tag.m_iMarginEnd;
-  m_epgTag            = tag.m_epgTag;
-  m_genre             = tag.m_genre;
-  m_iGenreType        = tag.m_iGenreType;
-  m_iGenreSubType     = tag.m_iGenreSubType;
-  m_strSummary        = tag.m_strSummary;
+  m_iClientId         = tag->m_iClientId;
+  m_iClientIndex      = tag->m_iClientIndex;
+  m_strTitle          = tag->m_strTitle;
+  m_strDirectory      = tag->m_strDirectory;
+  m_iClientChannelUid = tag->m_iClientChannelUid;
+  m_StartTime         = tag->m_StartTime;
+  m_StopTime          = tag->m_StopTime;
+  m_FirstDay          = tag->m_FirstDay;
+  m_iPriority         = tag->m_iPriority;
+  m_iLifetime         = tag->m_iLifetime;
+  m_state             = tag->m_state;
+  m_bIsRepeating      = tag->m_bIsRepeating;
+  m_iWeekdays         = tag->m_iWeekdays;
+  m_iChannelNumber    = tag->m_iChannelNumber;
+  m_bIsRadio          = tag->m_bIsRadio;
+  m_iMarginStart      = tag->m_iMarginStart;
+  m_iMarginEnd        = tag->m_iMarginEnd;
+  m_epgTag            = tag->m_epgTag;
+  m_genre             = tag->m_genre;
+  m_iGenreType        = tag->m_iGenreType;
+  m_iGenreSubType     = tag->m_iGenreSubType;
+  m_strSummary        = tag->m_strSummary;
 
   if (m_strSummary.empty())
     UpdateSummary();
@@ -485,49 +454,47 @@ bool CPVRTimerInfoTag::SetDuration(int iDuration)
   return false;
 }
 
-CPVRTimerInfoTag *CPVRTimerInfoTag::CreateFromEpg(const CEpgInfoTag &tag)
+CPVRTimerInfoTagPtr CPVRTimerInfoTag::CreateFromEpg(const CEpgInfoTagPtr &tag)
 {
   /* create a new timer */
-  CPVRTimerInfoTag *newTag = new CPVRTimerInfoTag();
+  CPVRTimerInfoTagPtr newTag(new CPVRTimerInfoTag());
   if (!newTag)
   {
     CLog::Log(LOGERROR, "%s - couldn't create new timer", __FUNCTION__);
-    return NULL;
+    return CPVRTimerInfoTagPtr();
   }
 
   /* check if a valid channel is set */
-  CPVRChannelPtr channel = tag.ChannelTag();
+  CPVRChannelPtr channel = tag->ChannelTag();
   if (!channel)
   {
     CLog::Log(LOGERROR, "%s - no channel set", __FUNCTION__);
-    delete newTag;
-    return NULL;
+    return CPVRTimerInfoTagPtr();
   }
 
   /* check if the epg end date is in the future */
-  if (tag.EndAsLocalTime() < CDateTime::GetCurrentDateTime())
+  if (tag->EndAsLocalTime() < CDateTime::GetCurrentDateTime())
   {
     CLog::Log(LOGERROR, "%s - end time is in the past", __FUNCTION__);
-    delete newTag;
-    return NULL;
+    return CPVRTimerInfoTagPtr();
   }
 
   /* set the timer data */
-  CDateTime newStart = tag.StartAsUTC();
-  CDateTime newEnd = tag.EndAsUTC();
+  CDateTime newStart = tag->StartAsUTC();
+  CDateTime newEnd = tag->EndAsUTC();
   newTag->m_iClientIndex      = -1;
-  newTag->m_strTitle          = tag.Title().empty() ? channel->ChannelName() : tag.Title();
+  newTag->m_strTitle          = tag->Title().empty() ? channel->ChannelName() : tag->Title();
   newTag->m_iChannelNumber    = channel->ChannelNumber();
   newTag->m_iClientChannelUid = channel->UniqueID();
   newTag->m_iClientId         = channel->ClientID();
   newTag->m_bIsRadio          = channel->IsRadio();
-  newTag->m_iGenreType        = tag.GenreType();
-  newTag->m_iGenreSubType     = tag.GenreSubType();
+  newTag->m_iGenreType        = tag->GenreType();
+  newTag->m_iGenreSubType     = tag->GenreSubType();
   newTag->m_channel           = channel;
   newTag->SetStartFromUTC(newStart);
   newTag->SetEndFromUTC(newEnd);
 
-  if (tag.Plot().empty())
+  if (tag->Plot().empty())
   {
     newTag->m_strSummary= StringUtils::Format("%s %s %s %s %s",
                                               newTag->StartAsLocalTime().GetAsLocalizedDate().c_str(),
@@ -538,10 +505,10 @@ CPVRTimerInfoTag *CPVRTimerInfoTag::CreateFromEpg(const CEpgInfoTag &tag)
   }
   else
   {
-    newTag->m_strSummary = tag.Plot();
+    newTag->m_strSummary = tag->Plot();
   }
 
-  newTag->m_epgTag = g_EpgContainer.GetById(tag.EpgID())->GetTag(tag.StartAsUTC());
+  newTag->m_epgTag = g_EpgContainer.GetById(tag->EpgID())->GetTag(tag->StartAsUTC());
 
   /* unused only for reference */
   newTag->m_strFileNameAndPath = "pvr://timers/new";

--- a/xbmc/pvr/timers/PVRTimerInfoTag.h
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.h
@@ -66,16 +66,20 @@ namespace PVR
   class CPVRTimerInfoTag : public ISerializable
   {
     friend class CPVRTimers;
-    friend class CGUIDialogPVRTimerSettings;
 
   public:
-    CPVRTimerInfoTag(void);
-    CPVRTimerInfoTag(const PVR_TIMER &timer, CPVRChannelPtr channel, unsigned int iClientId);
+    CPVRTimerInfoTag(bool bRadio = false);
+    CPVRTimerInfoTag(const PVR_TIMER &timer, const CPVRChannelPtr &channel, unsigned int iClientId);
+
+  private:
+    CPVRTimerInfoTag(const CPVRTimerInfoTag &tag); // intentionally not implemented.
+    CPVRTimerInfoTag &operator=(const CPVRTimerInfoTag &orig); // intentionally not implemented.
+
+  public:
     virtual ~CPVRTimerInfoTag(void);
 
     bool operator ==(const CPVRTimerInfoTag& right) const;
     bool operator !=(const CPVRTimerInfoTag& right) const;
-    CPVRTimerInfoTag &operator=(const CPVRTimerInfoTag &orig);
 
     virtual void Serialize(CVariant &value) const;
 
@@ -89,7 +93,7 @@ namespace PVR
 
     bool SetDuration(int iDuration);
 
-    static CPVRTimerInfoTag *CreateFromEpg(const EPG::CEpgInfoTag &tag);
+    static CPVRTimerInfoTagPtr CreateFromEpg(const EPG::CEpgInfoTagPtr &tag);
     EPG::CEpgInfoTagPtr GetEpgInfoTag(void) const;
 
     int ChannelNumber(void) const;
@@ -97,7 +101,7 @@ namespace PVR
     std::string ChannelIcon(void) const;
     CPVRChannelPtr ChannelTag(void) const;
 
-    bool UpdateEntry(const CPVRTimerInfoTag &tag);
+    bool UpdateEntry(const CPVRTimerInfoTagPtr &tag);
 
     void UpdateEpgEvent(bool bClear = false);
 

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -118,7 +118,7 @@ bool CPVRTimers::UpdateEntries(const CPVRTimers &timers)
       {
         /* if it's present, update the current tag */
         bool bStateChanged(existingTimer->m_state != (*timerIt)->m_state);
-        if (existingTimer->UpdateEntry(*(*timerIt)))
+        if (existingTimer->UpdateEntry(*timerIt))
         {
           bChanged = true;
           UpdateEpgEvent(existingTimer);
@@ -138,7 +138,7 @@ bool CPVRTimers::UpdateEntries(const CPVRTimers &timers)
       {
         /* new timer */
         CPVRTimerInfoTagPtr newTimer = CPVRTimerInfoTagPtr(new CPVRTimerInfoTag);
-        newTimer->UpdateEntry(*(*timerIt));
+        newTimer->UpdateEntry(*timerIt);
         UpdateEpgEvent(newTimer);
 
         VecTimerInfoTag* addEntry = NULL;
@@ -270,19 +270,19 @@ bool CPVRTimers::UpdateEntries(const CPVRTimers &timers)
   return bChanged;
 }
 
-bool CPVRTimers::UpdateFromClient(const CPVRTimerInfoTag &timer)
+bool CPVRTimers::UpdateFromClient(const CPVRTimerInfoTagPtr &timer)
 {
   CSingleLock lock(m_critSection);
-  CPVRTimerInfoTagPtr tag = GetByClient(timer.m_iClientId, timer.m_iClientIndex);
+  CPVRTimerInfoTagPtr tag = GetByClient(timer->m_iClientId, timer->m_iClientIndex);
   if (!tag)
   {
     tag = CPVRTimerInfoTagPtr(new CPVRTimerInfoTag());
     VecTimerInfoTag* addEntry = NULL;
-    MapTags::iterator itr = m_tags.find(timer.StartAsUTC());
+    MapTags::iterator itr = m_tags.find(timer->StartAsUTC());
     if (itr == m_tags.end())
     {
       addEntry = new VecTimerInfoTag;
-      m_tags.insert(std::make_pair(timer.StartAsUTC(), addEntry));
+      m_tags.insert(std::make_pair(timer->StartAsUTC(), addEntry));
     }
     else
     {
@@ -309,7 +309,7 @@ CFileItemPtr CPVRTimers::GetNextActiveTimer(void) const
       CPVRTimerInfoTagPtr current = *timerIt;
       if (current->IsActive() && !current->IsRecording())
       {
-        CFileItemPtr fileItem(new CFileItem(*current));
+        CFileItemPtr fileItem(new CFileItem(current));
         return fileItem;
       }
     }
@@ -331,7 +331,7 @@ std::vector<CFileItemPtr> CPVRTimers::GetActiveTimers(void) const
       CPVRTimerInfoTagPtr current = *timerIt;
       if (current->IsActive())
       {
-        CFileItemPtr fileItem(new CFileItem(*current));
+        CFileItemPtr fileItem(new CFileItem(current));
         tags.push_back(fileItem);
       }
     }
@@ -365,7 +365,7 @@ std::vector<CFileItemPtr> CPVRTimers::GetActiveRecordings(void) const
       CPVRTimerInfoTagPtr current = *timerIt;
       if (current->IsRecording())
       {
-        CFileItemPtr fileItem(new CFileItem(*current));
+        CFileItemPtr fileItem(new CFileItem(current));
         tags.push_back(fileItem);
       }
     }
@@ -419,7 +419,7 @@ bool CPVRTimers::GetDirectory(const std::string& strPath, CFileItemList &items) 
         CPVRTimerInfoTagPtr current = *timerIt;
         if (bRadio == current->m_bIsRadio)
         {
-          item.reset(new CFileItem(*current));
+          item.reset(new CFileItem(current));
           items.Add(item);
         }
       }
@@ -474,10 +474,13 @@ bool CPVRTimers::InstantTimer(const CPVRChannelPtr &channel)
     return false;
 
   CEpgInfoTagPtr epgTag(channel->GetEPGNow());
-  CPVRTimerInfoTag *newTimer = epgTag ? CPVRTimerInfoTag::CreateFromEpg(*epgTag) : NULL;
+  CPVRTimerInfoTagPtr newTimer;
+  if (epgTag)
+    newTimer = CPVRTimerInfoTag::CreateFromEpg(epgTag);
+
   if (!newTimer)
   {
-    newTimer = new CPVRTimerInfoTag;
+    newTimer.reset(new CPVRTimerInfoTag);
     /* set the timer data */
     newTimer->m_iClientIndex      = -1;
     newTimer->m_strTitle          = channel->ChannelName();
@@ -511,32 +514,30 @@ bool CPVRTimers::InstantTimer(const CPVRChannelPtr &channel)
   if (!bReturn)
     CLog::Log(LOGERROR, "PVRTimers - %s - unable to add an instant timer on the client", __FUNCTION__);
 
-  delete newTimer;
-
   return bReturn;
 }
 
 /********** static methods **********/
 
-bool CPVRTimers::AddTimer(const CPVRTimerInfoTag &item)
+bool CPVRTimers::AddTimer(const CPVRTimerInfoTagPtr &item)
 {
-  if (!item.m_channel)
+  if (!item->m_channel)
   {
     CLog::Log(LOGERROR, "PVRTimers - %s - no channel given", __FUNCTION__);
     CGUIDialogOK::ShowAndGetInput(19033,0,19109,0); // Couldn't save timer
     return false;
   }
 
-  if (!g_PVRClients->SupportsTimers(item.m_iClientId))
+  if (!g_PVRClients->SupportsTimers(item->m_iClientId))
   {
     CGUIDialogOK::ShowAndGetInput(19033,0,19215,0);
     return false;
   }
 
-  if (!g_PVRManager.CheckParentalLock(item.m_channel))
+  if (!g_PVRManager.CheckParentalLock(item->m_channel))
     return false;
 
-  return item.AddToClient();
+  return item->AddToClient();
 }
 
 bool CPVRTimers::DeleteTimer(const CFileItem &item, bool bForce /* = false */)
@@ -548,7 +549,7 @@ bool CPVRTimers::DeleteTimer(const CFileItem &item, bool bForce /* = false */)
     return false;
   }
 
-  const CPVRTimerInfoTag *tag = item.GetPVRTimerInfoTag();
+  const CPVRTimerInfoTagPtr tag = item.GetPVRTimerInfoTag();
   if (!tag)
     return false;
 
@@ -564,7 +565,7 @@ bool CPVRTimers::RenameTimer(CFileItem &item, const std::string &strNewName)
     return false;
   }
 
-  CPVRTimerInfoTag *tag = item.GetPVRTimerInfoTag();
+  CPVRTimerInfoTagPtr tag = item.GetPVRTimerInfoTag();
   if (!tag)
     return false;
 
@@ -580,7 +581,7 @@ bool CPVRTimers::UpdateTimer(CFileItem &item)
     return false;
   }
 
-  CPVRTimerInfoTag *tag = item.GetPVRTimerInfoTag();
+  CPVRTimerInfoTagPtr tag = item.GetPVRTimerInfoTag();
   if (!tag)
     return false;
 
@@ -641,7 +642,7 @@ CFileItemPtr CPVRTimers::GetTimerForEpgTag(const CFileItem *item) const
             timer->StartAsUTC() <= epgTag->StartAsUTC() &&
             timer->EndAsUTC() >= epgTag->EndAsUTC())
         {
-          CFileItemPtr fileItem(new CFileItem(*timer));
+          CFileItemPtr fileItem(new CFileItem(timer));
           return fileItem;
         }
       }
@@ -754,7 +755,7 @@ void CPVRTimers::GetAll(CFileItemList& items) const
   {
     for (VecTimerInfoTag::const_iterator timerIt = it->second->begin(); timerIt != it->second->end(); ++timerIt)
     {
-      item.reset(new CFileItem(**timerIt));
+      item.reset(new CFileItem(*timerIt));
       items.Add(item);
     }
   }

--- a/xbmc/pvr/timers/PVRTimers.h
+++ b/xbmc/pvr/timers/PVRTimers.h
@@ -55,7 +55,7 @@ namespace PVR
     /**
      * Add a timer entry to this container, called by the client callback.
      */
-    bool UpdateFromClient(const CPVRTimerInfoTag &timer);
+    bool UpdateFromClient(const CPVRTimerInfoTagPtr &timer);
 
     /*!
      * @return The timer that will be active next (state scheduled), or an empty fileitemptr if none.
@@ -138,7 +138,7 @@ namespace PVR
      * @brief Add a timer to the client. Doesn't add the timer to the container. The backend will do this.
      * @return True if it was sent correctly, false if not.
      */
-    static bool AddTimer(const CPVRTimerInfoTag &item);
+    static bool AddTimer(const CPVRTimerInfoTagPtr &item);
 
     /*!
      * @brief Delete a timer on the client. Doesn't delete the timer from the container. The backend will do this.

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -357,12 +357,11 @@ bool CGUIWindowPVRBase::StartRecordFile(const CFileItem &item)
   if (!pDialog->IsConfirmed())
     return false;
 
-  CPVRTimerInfoTag *newTimer = CPVRTimerInfoTag::CreateFromEpg(*tag);
+  CPVRTimerInfoTagPtr newTimer = CPVRTimerInfoTag::CreateFromEpg(tag);
   bool bReturn(false);
   if (newTimer)
   {
-    bReturn = g_PVRTimers->AddTimer(*newTimer);
-    delete newTimer;
+    bReturn = g_PVRTimers->AddTimer(newTimer);
   }
   return bReturn;
 }
@@ -623,11 +622,10 @@ bool CGUIWindowPVRBase::ActionRecord(CFileItem *item)
     if (!pDialog->IsConfirmed())
       return bReturn;
 
-    CPVRTimerInfoTag *newTimer = CPVRTimerInfoTag::CreateFromEpg(*epgTag);
+    CPVRTimerInfoTagPtr newTimer = CPVRTimerInfoTag::CreateFromEpg(epgTag);
     if (newTimer)
     {
-      bReturn = g_PVRTimers->AddTimer(*newTimer);
-      delete newTimer;
+      bReturn = g_PVRTimers->AddTimer(newTimer);
     }
     else
     {

--- a/xbmc/pvr/windows/GUIWindowPVRTimers.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRTimers.cpp
@@ -170,7 +170,7 @@ bool CGUIWindowPVRTimers::OnContextButtonActivate(CFileItem *item, CONTEXT_BUTTO
     if (!item->HasPVRTimerInfoTag())
       return bReturn;
 
-    CPVRTimerInfoTag *timer = item->GetPVRTimerInfoTag();
+    CPVRTimerInfoTagPtr timer = item->GetPVRTimerInfoTag();
     int iLabelId;
     if (timer->IsActive())
     {
@@ -254,7 +254,7 @@ bool CGUIWindowPVRTimers::OnContextButtonRename(CFileItem *item, CONTEXT_BUTTON 
     bReturn = true;
     if (!item->HasPVRTimerInfoTag())
       return bReturn;
-    CPVRTimerInfoTag *timer = item->GetPVRTimerInfoTag();
+    CPVRTimerInfoTagPtr timer = item->GetPVRTimerInfoTag();
 
     std::string strNewName(timer->m_strTitle);
     if (CGUIKeyboardFactory::ShowAndGetInput(strNewName, g_localizeStrings.Get(19042), false))
@@ -267,7 +267,7 @@ bool CGUIWindowPVRTimers::OnContextButtonRename(CFileItem *item, CONTEXT_BUTTON 
 bool CGUIWindowPVRTimers::ActionDeleteTimer(CFileItem *item)
 {
   /* check if the timer tag is valid */
-  CPVRTimerInfoTag *timerTag = item->GetPVRTimerInfoTag();
+  CPVRTimerInfoTagPtr timerTag = item->GetPVRTimerInfoTag();
   if (!timerTag || timerTag->m_iClientIndex < 0)
     return false;
 
@@ -317,18 +317,16 @@ bool CGUIWindowPVRTimers::ShowNewTimerDialog(void)
 {
   bool bReturn(false);
 
-  CPVRTimerInfoTag *newTimer = new CPVRTimerInfoTag;
-  CFileItem *newItem = new CFileItem(*newTimer);
-  newItem->GetPVRTimerInfoTag()->m_bIsRadio = m_bRadio;
+  CPVRTimerInfoTagPtr newTimer(new CPVRTimerInfoTag(m_bRadio));
+  CFileItem *newItem = new CFileItem(newTimer);
 
   if (ShowTimerSettings(newItem))
   {
     /* Add timer to backend */
-    bReturn = g_PVRTimers->AddTimer(*newItem->GetPVRTimerInfoTag());
+    bReturn = g_PVRTimers->AddTimer(newItem->GetPVRTimerInfoTag());
   }
 
   delete newItem;
-  delete newTimer;
 
   return bReturn;
 }


### PR DESCRIPTION
Followup to #5763, #6207 and #6404 . Same implementation approach.

@opdenkamp This one should be straight forward.
