### PR TITLE
[videoinfoscanner] add season art when new season are added

### DIFF
--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -778,6 +778,7 @@ public:
   std::string GetArtForItem(int mediaId, const MediaType &mediaType, const std::string &artType);
   bool RemoveArtForItem(int mediaId, const MediaType &mediaType, const std::string &artType);
   bool RemoveArtForItem(int mediaId, const MediaType &mediaType, const std::set<std::string> &artTypes);
+  bool GetTvShowSeasons(int showId, std::map<int, int> &seasons);
   bool GetTvShowSeasonArt(int mediaId, std::map<int, std::map<std::string, std::string> > &seasonArt);
   bool GetArtTypes(const MediaType &mediaType, std::vector<std::string> &artTypes);
 

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -789,6 +789,7 @@ public:
 
   virtual bool GetFilter(CDbUrl &videoUrl, Filter &filter, SortDescription &sorting);
 
+  int AddSeason(int showID, int season);
   int AddSet(const std::string& strSet);
   void ClearMovieSet(int idMovie);
   void SetMovieSet(int idMovie, int idSet);
@@ -816,7 +817,6 @@ protected:
 
   int AddTvShow();
   int AddMusicVideo(const std::string& strFilenameAndPath);
-  int AddSeason(int showID, int season);
 
   /*! \brief Adds a path to the tvshow link table.
    \param idShow the id of the show.

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -223,11 +223,12 @@ namespace VIDEO
      \param files the episode files to process.
      \param scraper scraper to use for finding online info
      \param showInfo information for the show.
+     \param updatedSeasons returns true in case a new season was found
      \param pDlgProcess progress dialog to update during processing.  Defaults to NULL.
      \return INFO_ERROR on failure, INFO_CANCELLED on cancellation,
      INFO_NOT_FOUND if an episode isn't found, or INFO_ADDED if all episodes are added.
      */
-    INFO_RET OnProcessSeriesFolder(EPISODELIST& files, const ADDON::ScraperPtr &scraper, bool useLocal, const CVideoInfoTag& showInfo, CGUIDialogProgress* pDlgProgress = NULL);
+    INFO_RET OnProcessSeriesFolder(EPISODELIST& files, const ADDON::ScraperPtr &scraper, bool useLocal, const CVideoInfoTag& showInfo, bool& updatedSeasons, CGUIDialogProgress* pDlgProgress = NULL);
 
     bool EnumerateSeriesFolder(CFileItem* item, EPISODELIST& episodeList);
     bool ProcessItemByVideoInfoTag(const CFileItem *item, EPISODELIST &episodeList);


### PR DESCRIPTION
This is an alternative to https://github.com/xbmc/xbmc/pull/3546 without scraper modifications. Fixes an issue where local season art is not properly updated/imported when new seasons are added. Issue @ http://trac.kodi.tv/ticket/14339

/cc @Montellese, @MilhouseVH
