### PR TITLE
No Warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,6 +126,7 @@ config.log
 /addons/xbmc.addon/addon.xml
 /addons/xbmc.json/addon.xml
 /addons/kodi.guilib/addon.xml
+/addons/audiodecoder.*
 
 # /lib/
 /lib/Makefile
@@ -434,6 +435,8 @@ lib/cpluff/stamp-h1
 /tools/depends/target/ffmpeg/ffmpeg-*-*.tar.gz
 /tools/depends/target/ffmpeg/ffmpeg-*-*/
 /tools/depends/target/ffmpeg/ffmpeg-install/
+/tools/depends/target/Toolchain_binaddons.cmake
+/tools/depends/target/config-binaddons.site
 
 # /tools/EventClients/
 /tools/EventClients/*.pyc

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1868,15 +1868,15 @@ std::string CGUIInfoManager::GetLabel(int info, int contextWindow, std::string *
       int iMemPercentUsed = 100 - iMemPercentFree;
 
       if (info == SYSTEM_FREE_MEMORY)
-        strLabel = StringUtils::Format("%luMB", (ULONG)(stat.ullAvailPhys/MB));
+        strLabel = StringUtils::Format("%uMB", (unsigned int)(stat.ullAvailPhys/MB));
       else if (info == SYSTEM_FREE_MEMORY_PERCENT)
         strLabel = StringUtils::Format("%i%%", iMemPercentFree);
       else if (info == SYSTEM_USED_MEMORY)
-        strLabel = StringUtils::Format("%luMB", (ULONG)((stat.ullTotalPhys - stat.ullAvailPhys)/MB));
+        strLabel = StringUtils::Format("%uMB", (unsigned int)((stat.ullTotalPhys - stat.ullAvailPhys)/MB));
       else if (info == SYSTEM_USED_MEMORY_PERCENT)
         strLabel = StringUtils::Format("%i%%", iMemPercentUsed);
       else if (info == SYSTEM_TOTAL_MEMORY)
-        strLabel = StringUtils::Format("%luMB", (ULONG)(stat.ullTotalPhys/MB));
+        strLabel = StringUtils::Format("%uMB", (unsigned int)(stat.ullTotalPhys/MB));
     }
     break;
   case SYSTEM_SCREEN_MODE:

--- a/xbmc/cores/dvdplayer/DVDCodecs/Overlay/contrib/cc_decoder.c
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Overlay/contrib/cc_decoder.c
@@ -575,8 +575,6 @@ void decode_cc(cc_decoder_t *dec, uint8_t *buffer, uint32_t buf_len)
   uint32_t i;
   for (i = 0; i<buf_len; i += 3)
   {
-    
-    unsigned char cc_valid = buffer[i] & 0x04;
     unsigned char cc_type = buffer[i] & 0x03;
 
     uint8_t data1 = buffer[i + 1];

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -476,7 +476,8 @@ int CDVDInputStreamNavigator::ProcessBlock(uint8_t* dest_buffer, int* read)
         {
           uint64_t* times = NULL;
           uint64_t duration;
-          int entries = static_cast<int>(m_dll.dvdnav_describe_title_chapters(m_dvdnav, m_iTitle, &times, &duration));
+          //dvdnav_describe_title_chapters returns 0 on failure and NULL for times
+          int entries = m_dll.dvdnav_describe_title_chapters(m_dvdnav, m_iTitle, &times, &duration);
 
           if (entries != m_iPartCount)
             CLog::Log(LOGDEBUG, "%s - Number of chapters/positions differ: Chapters %d, positions %d\n", __FUNCTION__, m_iPartCount, entries);

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -918,8 +918,8 @@ void MysqlDatabase::mysqlVXPrintf(
         }
         bufpt = &buf[etBUFSIZE-1];
         {
-          register const char *cset;      /* Use registers for speed */
-          register int base;
+          const char *cset;
+          int base;
           cset = &aDigits[infop->charset];
           base = infop->base;
           do{                                           /* Convert to ascii */
@@ -1167,7 +1167,7 @@ void MysqlDatabase::mysqlVXPrintf(
     ** the output.
     */
     if( !flag_leftjustify ){
-      register int nspace;
+      int nspace;
       nspace = width-length;
       if( nspace>0 ){
         appendSpace(pAccum, nspace);
@@ -1177,7 +1177,7 @@ void MysqlDatabase::mysqlVXPrintf(
       mysqlStrAccumAppend(pAccum, bufpt, length);
     }
     if( flag_leftjustify ){
-      register int nspace;
+      int nspace;
       nspace = width-length;
       if( nspace>0 ){
         appendSpace(pAccum, nspace);

--- a/xbmc/filesystem/HTTPFile.cpp
+++ b/xbmc/filesystem/HTTPFile.cpp
@@ -46,7 +46,7 @@ ssize_t CHTTPFile::Write(const void* lpBuf, size_t uiBufSize)
   if (!m_openedforwrite)
     return -1;
 
-  std::string myPostData((char*) lpBuf);
+  std::string myPostData(static_cast<const char*>(lpBuf));
   if (myPostData.length() != uiBufSize)
     return -1;
 

--- a/xbmc/filesystem/ISOFile.cpp
+++ b/xbmc/filesystem/ISOFile.cpp
@@ -24,6 +24,7 @@
 #include "URL.h"
 #include "iso9660.h"
 
+#include <algorithm>
 #include <sys/stat.h>
 
 using namespace std;
@@ -84,10 +85,7 @@ ssize_t CISOFile::Read(void *lpBuf, size_t uiBufSize)
     {
       if (m_cache.getMaxReadSize() )
       {
-        long lBytes2Read = m_cache.getMaxReadSize();
-        if (lBytes2Read > static_cast<long>(uiBufSize))
-          lBytes2Read = static_cast<long>(uiBufSize);
-
+        unsigned int lBytes2Read = std::min(m_cache.getMaxReadSize(), static_cast<unsigned int>(uiBufSize));
         m_cache.ReadData(pData, lBytes2Read );
         uiBufSize -= lBytes2Read ;
         pData += lBytes2Read;

--- a/xbmc/filesystem/RarFile.cpp
+++ b/xbmc/filesystem/RarFile.cpp
@@ -20,6 +20,7 @@
 
 #include "system.h"
 #include "RarFile.h"
+#include <algorithm>
 #include <sys/stat.h>
 #include "Util.h"
 #include "utils/CharsetConverter.h"
@@ -302,7 +303,7 @@ ssize_t CRarFile::Read(void *lpBuf, size_t uiBufSize)
   int64_t uicBufSize = uiBufSize;
   if (m_iDataInBuffer > 0)
   {
-    int64_t iCopy = (uiBufSize < static_cast<size_t>(m_iDataInBuffer)) ? uiBufSize : m_iDataInBuffer;
+    int64_t iCopy = std::min(static_cast<int64_t>(uiBufSize), m_iDataInBuffer);
     memcpy(lpBuf,m_szStartOfBuffer,size_t(iCopy));
     m_szStartOfBuffer += iCopy;
     m_iDataInBuffer -= int(iCopy);

--- a/xbmc/filesystem/ZipFile.cpp
+++ b/xbmc/filesystem/ZipFile.cpp
@@ -306,7 +306,7 @@ ssize_t CZipFile::Read(void* lpBuf, size_t uiBufSize)
   {
     uLong iDecompressed = 0;
     uLong prevOut = m_ZStream.total_out;
-    while ((static_cast<size_t>(iDecompressed) < uiBufSize) && ((m_iZipFilePos < mZipItem.csize) || (m_bFlush)))
+    while ((iDecompressed < uiBufSize) && ((m_iZipFilePos < mZipItem.csize) || (m_bFlush)))
     {
       m_ZStream.next_out = (Bytef*)(lpBuf)+iDecompressed;
       m_ZStream.avail_out = static_cast<uInt>(uiBufSize-iDecompressed);

--- a/xbmc/filesystem/udf25.cpp
+++ b/xbmc/filesystem/udf25.cpp
@@ -592,7 +592,7 @@ int udf25::ReadAt( int64_t pos, size_t len, unsigned char *data )
     return -1;
 
   ssize_t ret = m_fp->Read(data, len);
-  if (static_cast<size_t>(ret) < len)
+  if ( ret > 0 && static_cast<size_t>(ret) < len)
   {
     CLog::Log(LOGERROR, "udf25::ReadFile - less data than requested available!" );
     return (int)ret;

--- a/xbmc/network/TCPServer.cpp
+++ b/xbmc/network/TCPServer.cpp
@@ -34,10 +34,12 @@
 #include "websocket/WebSocketManager.h"
 #include "Network.h"
 
+#if defined(TARGET_WINDOWS) || defined(HAVE_LIBBLUETOOTH)
 static const char     bt_service_name[] = "XBMC JSON-RPC";
 static const char     bt_service_desc[] = "Interface for XBMC remote control over bluetooth";
 static const char     bt_service_prov[] = "XBMC JSON-RPC Provider";
 static const uint32_t bt_service_guid[] = {0x65AE4CC0, 0x775D11E0, 0xBE16CE28, 0x4824019B};
+#endif
 
 #ifdef HAVE_LIBBLUETOOTH
 #include <bluetooth/bluetooth.h>

--- a/xbmc/peripherals/devices/Peripheral.cpp
+++ b/xbmc/peripherals/devices/Peripheral.cpp
@@ -53,10 +53,19 @@ CPeripheral::CPeripheral(const PeripheralScanResult& scanResult) :
 {
   PeripheralTypeTranslator::FormatHexString(scanResult.m_iVendorId, m_strVendorId);
   PeripheralTypeTranslator::FormatHexString(scanResult.m_iProductId, m_strProductId);
-  m_strFileLocation = StringUtils::Format(scanResult.m_iSequence > 0 ? "peripherals://%s/%s_%d.dev" : "peripherals://%s/%s.dev",
-                                          PeripheralTypeTranslator::BusTypeToString(scanResult.m_busType),
-                                          scanResult.m_strLocation.c_str(),
-                                          scanResult.m_iSequence);
+  if (scanResult.m_iSequence > 0)
+  {
+    m_strFileLocation = StringUtils::Format("peripherals://%s/%s_%d.dev",
+                                            PeripheralTypeTranslator::BusTypeToString(scanResult.m_busType),
+                                            scanResult.m_strLocation.c_str(),
+                                            scanResult.m_iSequence);
+  }
+  else
+  {
+    m_strFileLocation = StringUtils::Format("peripherals://%s/%s.dev",
+                                            PeripheralTypeTranslator::BusTypeToString(scanResult.m_busType),
+                                            scanResult.m_strLocation.c_str());
+  }
 }
 
 CPeripheral::~CPeripheral(void)

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -156,7 +156,9 @@ bool CThumbExtractor::DoWork()
         db.SetStreamDetailsForFileId(info->m_streamDetails, info->m_iFileId);
 
       // overwrite the runtime value if the one from streamdetails is available
-      if (info->m_iDbId > 0 && info->m_duration != static_cast<int>(info->GetDuration()))
+      if (info->m_iDbId > 0
+          && info->m_duration > 0
+          && static_cast<size_t>(info->m_duration) != info->GetDuration())
       {
         info->m_duration = info->GetDuration();
 


### PR DESCRIPTION
To improve the development and get more help from the tools (and for the sake of correctness) I started a series of patches to remove all warnings on OSX. The patches also affects other platforms but I am only testing the OS X path I work on. This reduces the warnings down to 6 with the aim to go all the way down to 0 and enable -Werror.

The commit messages can use some re-wording and so could some of the commits, I wanted to gather them in this PR so I can follow them up quicker.
