### PR TITLE
[mysql] properly toggle mysql transactions automode

### DIFF
--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -459,6 +459,7 @@ void MysqlDatabase::commit_transaction() {
   if (active)
   {
     mysql_commit(conn);
+    mysql_autocommit(conn, true);
     CLog::Log(LOGDEBUG,"Mysql commit transaction");
     _in_transaction = false;
   }
@@ -468,6 +469,7 @@ void MysqlDatabase::rollback_transaction() {
   if (active)
   {
     mysql_rollback(conn);
+    mysql_autocommit(conn, true);
     CLog::Log(LOGDEBUG,"Mysql rollback transaction");
     _in_transaction = false;
   }


### PR DESCRIPTION
Fixes stale inserts after https://github.com/xbmc/xbmc/pull/6467 due to a wrong assumption that mysql reverts to regular commit mode after commit/rollback just like sqlite does.
