### PR TITLE
[mmalrenderer] Fix for HAS_MMAL being set by chance

### DIFF
--- a/xbmc/cores/VideoRenderers/MMALRenderer.h
+++ b/xbmc/cores/VideoRenderers/MMALRenderer.h
@@ -20,8 +20,6 @@
  *
  */
 
-#ifdef HAS_MMAL
-
 #include "guilib/GraphicContext.h"
 #include "RenderFlags.h"
 #include "RenderFormats.h"
@@ -124,7 +122,3 @@ protected:
   void ReleaseBuffers();
   void UnInitMMAL();
 };
-
-#else
-#include "LinuxRenderer.h"
-#endif


### PR DESCRIPTION
HAS_MMAL is being tested without an explicit include of config.h
It works by chance but a header file refactor in PR6518 breaks the Pi build.

MMALRenderer.h is only included twice, once already inside a HAS_MMAL ifdef
and once from MMALRenderer.cpp which also must have HAS_MMAL defined.

So remove the ifdef in header.
