### PR TITLE
CVideoLibraryQueue: fix segfault in CancelJob() if CJobQueue::CancelJob() deletes the job to be cancelled

### DIFF
--- a/xbmc/video/VideoLibraryQueue.cpp
+++ b/xbmc/video/VideoLibraryQueue.cpp
@@ -152,13 +152,21 @@ void CVideoLibraryQueue::CancelJob(CVideoLibraryJob *job)
     return;
 
   CSingleLock lock(m_critical);
+  // remember the job type needed later because the job might be deleted
+  // in the call to CJobQueue::CancelJob()
+  std::string jobType;
+  if (job->GetType() != NULL)
+    jobType = job->GetType();
+
+  // check if the job supports cancellation and cancel it
   if (job->CanBeCancelled())
     job->Cancel();
 
+  // remove the job from the job queue
   CJobQueue::CancelJob(job);
 
   // remove the job from our list of queued/running jobs
-  VideoLibraryJobMap::iterator jobsIt = m_jobs.find(job->GetType());
+  VideoLibraryJobMap::iterator jobsIt = m_jobs.find(jobType);
   if (jobsIt != m_jobs.end())
     jobsIt->second.erase(job);
 }


### PR DESCRIPTION
This should take care of a segfault in the newly introduced CVideoLibraryQueue reported by @MartijnKaijser in #6406. I haven't had the time to reproduce but since `CJobQueue::CancelJob()` can delete the job to be cancelled (depending on whether the job is still waiting in the queue or is already being processed) the following call to `job->GetType()` can segfault.

I guess the proper solution to avoid such issues would be to re-write the job manager/queue to use shared pointers to jobs but that's out of the scope of this.
