### PR TITLE
[dvdplayer] Fix CDVDPlayer::SwitchChannel signature to match IPlayer::SwitchChannel signature.

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -4488,7 +4488,7 @@ std::string CDVDPlayer::GetPlayingTitle()
   return "";
 }
 
-bool CDVDPlayer::SwitchChannel(CPVRChannelPtr &channel)
+bool CDVDPlayer::SwitchChannel(const CPVRChannelPtr &channel)
 {
   if (!g_PVRManager.CheckParentalLock(channel))
     return false;

--- a/xbmc/cores/dvdplayer/DVDPlayer.h
+++ b/xbmc/cores/dvdplayer/DVDPlayer.h
@@ -286,7 +286,7 @@ public:
 
   virtual std::string GetPlayingTitle();
 
-  virtual bool SwitchChannel(PVR::CPVRChannelPtr &channel);
+  virtual bool SwitchChannel(const PVR::CPVRChannelPtr &channel);
   virtual bool CachePVRStream(void) const;
 
   enum ECacheState


### PR DESCRIPTION
[dvdplayer] Fix CDVDPlayer::SwitchChannel signature to match IPlayer::SwitchChannel signature.

Fix for regression intrdoduced by #6404. See the bug description there.

Mismatch of signature led to call to IPlayer::SwitchChannel (which always returns false) instead of call to overridden CDVDPlayer::SwitchChannel. :-/
