### PR TITLE
[pvr] added: attempt to auto-configure pvr clients via avahi

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -9378,7 +9378,22 @@ msgctxt "#19686"
 msgid "The PVR backend is busy. Shutdown anyway?"
 msgstr ""
 
-#empty strings from id 19687 to 19999
+#: xbmc/pvr/addons/PVRClients.cpp
+msgctxt "#19688"
+msgid "Scanning for PVR services"
+msgstr ""
+
+#: xbmc/pvr/addons/PVRClients.cpp
+msgctxt "#19689"
+msgid "%s service found at %s"
+msgstr ""
+
+#: xbmc/pvr/addons/PVRClient.cpp
+msgctxt "#19690"
+msgid "Do you want to use this service?"
+msgstr ""
+
+#empty strings from id 19691 to 19999
 
 #: system/settings/settings.xml
 msgctxt "#20000"

--- a/xbmc/network/ZeroconfBrowser.h
+++ b/xbmc/network/ZeroconfBrowser.h
@@ -127,20 +127,6 @@ public:
 
   virtual void ProcessResults() {}
 
-protected:
-  // pure virtual methods to implement for OS specific implementations
-  virtual bool doAddServiceType(const std::string& fcr_service_type) = 0;
-  virtual bool doRemoveServiceType(const std::string& fcr_service_type) = 0;
-  virtual std::vector<ZeroconfService> doGetFoundServices() = 0;
-  virtual bool doResolveService(ZeroconfService& fr_service, double f_timeout) = 0;
-
-protected:
-  //singleton: we don't want to get instantiated nor copied or deleted from outside
-  CZeroconfBrowser();
-  CZeroconfBrowser(const CZeroconfBrowser&);
-  virtual ~CZeroconfBrowser();
-
-private:
   /// methods for browsing and getting results of it
   ///@{
   /// adds a service type for browsing
@@ -153,6 +139,19 @@ private:
   /// @return if it was not found
   bool RemoveServiceType(const std::string& fcr_service_type);
 
+protected:
+  //singleton: we don't want to get instantiated nor copied or deleted from outside
+  CZeroconfBrowser();
+  CZeroconfBrowser(const CZeroconfBrowser&);
+  virtual ~CZeroconfBrowser();
+
+  // pure virtual methods to implement for OS specific implementations
+  virtual bool doAddServiceType(const std::string& fcr_service_type) = 0;
+  virtual bool doRemoveServiceType(const std::string& fcr_service_type) = 0;
+  virtual std::vector<ZeroconfService> doGetFoundServices() = 0;
+  virtual bool doResolveService(ZeroconfService& fr_service, double f_timeout) = 0;
+
+private:
   struct ServiceInfo
   {
     std::string type;

--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -22,6 +22,7 @@
 #include "addons/Addon.h"
 #include "addons/AddonDll.h"
 #include "addons/DllPVRClient.h"
+#include "network/ZeroconfBrowser.h"
 #include "pvr/channels/PVRChannel.h"
 #include "pvr/recordings/PVRRecordings.h"
 
@@ -662,11 +663,12 @@ namespace PVR
     std::string            m_strBackendHostname;    /*!< the cached backend hostname */
 
     /* stored strings to make sure const char* members in PVR_PROPERTIES stay valid */
-    std::string m_strUserPath;    /*!< @brief translated path to the user profile */
-    std::string m_strClientPath;  /*!< @brief translated path to this add-on */
-    std::string m_strAvahiType;
-    std::string m_strAvahiIpSetting;
-    std::string m_strAvahiPortSetting;
+    std::string                                    m_strUserPath;         /*!< @brief translated path to the user profile */
+    std::string                                    m_strClientPath;       /*!< @brief translated path to this add-on */
+    std::string                                    m_strAvahiType;        /*!< avahi service type */
+    std::string                                    m_strAvahiIpSetting;   /*!< add-on setting name to change to the found ip address */
+    std::string                                    m_strAvahiPortSetting; /*!< add-on setting name to change to the found port number */
+    std::vector<CZeroconfBrowser::ZeroconfService> m_rejectedAvahiHosts;  /*!< hosts that were rejected by the user */
 
     CCriticalSection m_critSection;
 

--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -558,6 +558,17 @@ namespace PVR
      */
     time_t GetBufferTimeEnd() const;
 
+    /*!
+     * @return True when this add-on can be auto-configured via avahi, false otherwise
+     */
+    bool CanAutoconfigure(void) const;
+
+    /*!
+     * Try to auto-configure this add-on via avahi
+     * @return True when auto-configured and the configured was accepted by the user, false otherwise
+     */
+    bool Autoconfigure(void);
+
   private:
     /*!
      * @brief Checks whether the provided API version is compatible with XBMC
@@ -647,6 +658,9 @@ namespace PVR
     /* stored strings to make sure const char* members in PVR_PROPERTIES stay valid */
     std::string m_strUserPath;    /*!< @brief translated path to the user profile */
     std::string m_strClientPath;  /*!< @brief translated path to this add-on */
+    std::string m_strAvahiType;
+    std::string m_strAvahiIpSetting;
+    std::string m_strAvahiPortSetting;
 
     CCriticalSection m_critSection;
 

--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -559,13 +559,19 @@ namespace PVR
     time_t GetBufferTimeEnd() const;
 
     /*!
-     * @return True when this add-on can be auto-configured via avahi, false otherwise
+     * @return True if this add-on can be auto-configured via avahi, false otherwise
      */
     bool CanAutoconfigure(void) const;
 
     /*!
+     * Registers the avahi type for this add-on
+     * @return True if registered, false if not.
+     */
+    bool AutoconfigureRegisterType(void);
+
+    /*!
      * Try to auto-configure this add-on via avahi
-     * @return True when auto-configured and the configured was accepted by the user, false otherwise
+     * @return True if auto-configured and the configured was accepted by the user, false otherwise
      */
     bool Autoconfigure(void);
 
@@ -669,5 +675,6 @@ namespace PVR
     bool                m_bIsPlayingRecording;
     CPVRRecordingPtr    m_playingRecording;
     ADDON::AddonVersion m_apiVersion;
+    bool                m_bAvahiServiceAdded;
   };
 }

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -1212,6 +1212,8 @@ bool CPVRClients::AutoconfigureClients(void)
 
   /** start zeroconf and wait a second to get some responses */
   CZeroconfBrowser::GetInstance()->Start();
+  for (std::vector<PVR_CLIENT>::iterator it = autoConfigAddons.begin(); !bReturn && it != autoConfigAddons.end(); ++it)
+    (*it)->AutoconfigureRegisterType();
   Sleep(1000);
   float percentage = 20.0f;
   float percentageStep = 80.0f / autoConfigAddons.size();

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -676,6 +676,12 @@ namespace PVR
 
     int GetClientId(const ADDON::AddonPtr client) const;
 
+    /*!
+     * Try to automatically configure clients
+     * @return True when at least one was configured
+     */
+    bool AutoconfigureClients(void);
+
     bool                  m_bChannelScanRunning;      /*!< true when a channel scan is currently running, false otherwise */
     bool                  m_bIsSwitchingChannels;        /*!< true while switching channels */
     int                   m_playingClientId;          /*!< the ID of the client that is currently playing */


### PR DESCRIPTION
add these to the `xbmc.pvrclient` extension point in the `addon.xml` of the add-on to configure:
- avahi_type="(avahi type)"
- avahi_ip_setting="(name of the ip/address setting)"
- avahi_port_setting="(name of the port setting)"

e.g. for pvr.hts (only one that supports avahi afaik):

``` XML
  <extension
    point="xbmc.pvrclient"
    avahi_type="_htsp._tcp."
    avahi_ip_setting="host"
    avahi_port_setting="htsp_port" />
```

When the PVR manager is started without any add-ons being enabled, and when disabled add-ons were found with the entries from above in `addon.xml`, then it will start the avahi browser, search for the service, and display this dialog:
![avahi-addons](https://cloud.githubusercontent.com/assets/441806/6476232/ba063fda-c213-11e4-982f-8f285bf1ac9b.png)

Currently only supports services already included in `CZeroconfBrowser`. `CZeroconfBrowser::AddServiceType()` has to be made public and implemented so services can be added dynamically.

And only supports the ip address and port, no username/password.
