### PR TITLE
fix video library cleaning not initiated by a user blocking the main thread

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4748,7 +4748,7 @@ void CApplication::StartVideoCleanup(bool userInitiated /* = true */)
   if (userInitiated)
     CVideoLibraryQueue::Get().CleanLibraryModal(paths);
   else
-    CVideoLibraryQueue::Get().CleanLibrary(paths, false);
+    CVideoLibraryQueue::Get().CleanLibrary(paths, true);
 }
 
 void CApplication::StartVideoScan(const std::string &strDirectory, bool userInitiated /* = true */, bool scanAll /* = false */)

--- a/xbmc/video/VideoLibraryQueue.cpp
+++ b/xbmc/video/VideoLibraryQueue.cpp
@@ -32,7 +32,7 @@
 using namespace std;
 
 CVideoLibraryQueue::CVideoLibraryQueue()
-  : CJobQueue(false, 1, CJob::PRIORITY_LOW_PAUSABLE),
+  : CJobQueue(false, 1, CJob::PRIORITY_LOW),
     m_jobs(),
     m_cleaning(false)
 { }


### PR DESCRIPTION
This should fix an issue reported by @MilhouseVH in #6406 that initiating a video library cleaning through JSON-RPC makes the GUI unresponsive and blocks input events from being handled.
The issue is that if the library cleaning initiated through JSON-RPC and without a dialog is performed in the main thread and not as a job. Therefore anything handled by the main thread (including input processing) is blocked by the video library cleaning task.

@MilhouseVH: Please let me know if this solves the issue(s) for you. And thanks again for the detailed analysis.
