### PR TITLE
[fonts] ability to capitalize the first letter of each word

### DIFF
--- a/xbmc/guilib/GUIFont.h
+++ b/xbmc/guilib/GUIFont.h
@@ -53,6 +53,7 @@ class CGUIFontTTFBase;
 #define FONT_STYLE_ITALICS      2
 #define FONT_STYLE_UPPERCASE    4
 #define FONT_STYLE_LOWERCASE    8
+#define FONT_STYLE_CAPITALIZE  16
 #define FONT_STYLE_MASK       0xF
 
 class CScrollInfo

--- a/xbmc/guilib/GUIFontManager.cpp
+++ b/xbmc/guilib/GUIFontManager.cpp
@@ -440,6 +440,8 @@ void GUIFontManager::GetStyle(const TiXmlNode *fontNode, int &iStyle)
         iStyle |= FONT_STYLE_UPPERCASE;
       else if (*i == "lowercase")
         iStyle |= FONT_STYLE_LOWERCASE;
+      else if (*i == "capitalize")
+        iStyle |= FONT_STYLE_CAPITALIZE;
     }
   }
 }

--- a/xbmc/guilib/GUITextLayout.cpp
+++ b/xbmc/guilib/GUITextLayout.cpp
@@ -403,6 +403,13 @@ void CGUITextLayout::ParseText(const std::wstring &text, uint32_t defaultStyle, 
          (!on && (currentStyle & FONT_STYLE_LOWERCASE)))  // or matching start point
         newStyle = FONT_STYLE_LOWERCASE;
     }
+    else if (text.compare(pos, 11, L"CAPITALIZE]") == 0)
+    {
+      pos += 11;
+      if ((on && text.find(L"[/CAPITALIZE]", pos) != std::string::npos) ||  // check for a matching end point
+         (!on && (currentStyle & FONT_STYLE_CAPITALIZE)))  // or matching start point
+        newStyle = FONT_STYLE_CAPITALIZE;
+    }
     else if (text.compare(pos, 3, L"CR]") == 0 && on)
     {
       newLine = true;
@@ -450,6 +457,8 @@ void CGUITextLayout::ParseText(const std::wstring &text, uint32_t defaultStyle, 
         StringUtils::ToUpper(subText);
       if (currentStyle & FONT_STYLE_LOWERCASE)
         StringUtils::ToLower(subText);
+      if (currentStyle & FONT_STYLE_CAPITALIZE)
+        StringUtils::ToCapitalize(subText);
       AppendToUTF32(subText, ((currentStyle & 3) << 24) | (currentColor << 16), parsedText);
       if (newLine)
         parsedText.push_back(L'\n');
@@ -470,6 +479,8 @@ void CGUITextLayout::ParseText(const std::wstring &text, uint32_t defaultStyle, 
     StringUtils::ToUpper(subText);
   if (currentStyle & FONT_STYLE_LOWERCASE)
     StringUtils::ToLower(subText);
+  if (currentStyle & FONT_STYLE_CAPITALIZE)
+    StringUtils::ToCapitalize(subText);
   AppendToUTF32(subText, ((currentStyle & 3) << 24) | (currentColor << 16), parsedText);
 }
 

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -30,6 +30,7 @@
 
 
 #include "StringUtils.h"
+#include "CharsetConverter.h"
 #include "utils/fstrcmp.h"
 #include "Util.h"
 #include "LangInfo.h"
@@ -372,6 +373,30 @@ void StringUtils::ToLower(string &str)
 void StringUtils::ToLower(wstring &str)
 {
   transform(str.begin(), str.end(), str.begin(), tolowerUnicode);
+}
+
+void StringUtils::ToCapitalize(string &str)
+{
+  std::wstring wstr;
+  g_charsetConverter.utf8ToW(str, wstr);
+  ToCapitalize(wstr);
+  g_charsetConverter.wToUTF8(wstr, str);
+}
+
+void StringUtils::ToCapitalize(std::wstring &str)
+{
+  const std::locale& loc = g_langInfo.GetSystemLocale();
+  bool isFirstLetter = true;
+  for (std::wstring::iterator it = str.begin(); it < str.end(); ++it)
+  {
+    if (std::isspace(*it, loc))
+      isFirstLetter = true;
+    else if (isFirstLetter)
+    {
+      *it = std::toupper(*it, loc);
+      isFirstLetter = false;
+    }
+  }
 }
 
 bool StringUtils::EqualsNoCase(const std::string &str1, const std::string &str2)

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -59,6 +59,8 @@ public:
   static void ToUpper(std::wstring &str);
   static void ToLower(std::string &str);
   static void ToLower(std::wstring &str);
+  static void ToCapitalize(std::string &str);
+  static void ToCapitalize(std::wstring &str);
   static bool EqualsNoCase(const std::string &str1, const std::string &str2);
   static bool EqualsNoCase(const std::string &str1, const char *s2);
   static bool EqualsNoCase(const char *s1, const char *s2);

--- a/xbmc/utils/test/TestStringUtils.cpp
+++ b/xbmc/utils/test/TestStringUtils.cpp
@@ -52,6 +52,29 @@ TEST(TestStringUtils, ToLower)
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 }
 
+TEST(TestStringUtils, ToCapitalize)
+{
+  std::string refstr = "Test";
+  std::string varstr = "test";
+  StringUtils::ToCapitalize(varstr);
+  EXPECT_STREQ(refstr.c_str(), varstr.c_str());
+
+  refstr = "Just A Test";
+  varstr = "just a test";
+  StringUtils::ToCapitalize(varstr);
+  EXPECT_STREQ(refstr.c_str(), varstr.c_str());
+
+  refstr = "Test -1;2:3, String For Case";
+  varstr = "test -1;2:3, string for Case";
+  StringUtils::ToCapitalize(varstr);
+  EXPECT_STREQ(refstr.c_str(), varstr.c_str());
+
+  refstr = "  JuST Another\t\tTEst:\nWoRKs ";
+  varstr = "  juST another\t\ttEst:\nwoRKs ";
+  StringUtils::ToCapitalize(varstr);
+  EXPECT_STREQ(refstr.c_str(), varstr.c_str());
+}
+
 TEST(TestStringUtils, EqualsNoCase)
 {
   std::string refstr = "TeSt";


### PR DESCRIPTION
This adds the ability to capitalize the first letter of each word.
Usage: Same as upper-/lowercase by using `[CAPIZALIZE]` or `capitalize` in the font.xml style tag.

Request at forums: http://forum.kodi.tv/showthread.php?tid=220249
