### PR TITLE
Cleanup context menus in addon window

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -12445,9 +12445,7 @@ msgctxt "#24034"
 msgid "Check for updates"
 msgstr ""
 
-msgctxt "#24035"
-msgid "Force refresh"
-msgstr ""
+#empty string id 24035
 
 msgctxt "#24036"
 msgid "Change log"

--- a/addons/skin.confluence/720p/AddonBrowser.xml
+++ b/addons/skin.confluence/720p/AddonBrowser.xml
@@ -123,6 +123,11 @@
 					<include>ButtonCommonValues</include>
 					<label>24999</label>
 				</control>
+				<control type="button" id="9">
+					<description>Check for updates</description>
+					<include>ButtonCommonValues</include>
+					<label>24034</label>
+				</control>
 				<include>CommonNowPlaying_Controls</include>
 			</control>
 		</control>

--- a/addons/skin.confluence/addon.xml
+++ b/addons/skin.confluence/addon.xml
@@ -5,7 +5,7 @@
   name="Confluence"
   provider-name="Jezz_X, Team Kodi">
   <requires>
-    <import addon="xbmc.gui" version="5.8.0"/>
+    <import addon="xbmc.gui" version="5.9.0"/>
   </requires>
   <extension
     point="xbmc.gui.skin"

--- a/addons/xbmc.gui/addon.xml
+++ b/addons/xbmc.gui/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="xbmc.gui" version="5.8.0" provider-name="Team-Kodi">
+<addon id="xbmc.gui" version="5.9.0" provider-name="Team-Kodi">
   <backwards-compatibility abi="5.3.0"/>
   <requires>
     <import addon="xbmc.core" version="0.1.0"/>


### PR DESCRIPTION
I don't think a single button works properly in this window.. 'Check for updates' does two completely different things depending on window and item. For some items it doesn't show, for others it shows but does nothing. 
This changes that so 'check for updates' now does a repo update in all windows on all items.

Also removes 'force refresh' which should never be necessary. If it is, there is a bug in the repo updating procedure, which should be fixed properly without forcefully clearing the database.
