### PR TITLE
[addons] cleanup pre/post-install hooks

### DIFF
--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -192,9 +192,11 @@ public:
    */
   virtual AddonPtr GetRunningInstance() const { return AddonPtr(); }
 
-  /*! \brief callbacks for special install/uninstall behaviour */
-  virtual bool OnPreInstall() { return false; };
-  virtual void OnPostInstall(bool restart, bool update, bool modal) {};
+  /*! \brief Called before add-on is installed. Return true on success, otherwise false.*/
+  virtual bool OnPreInstall() { return true; };
+
+  /*! \brief Called if pre-install and install succeeded.*/
+  virtual void OnPostInstall(bool update, bool modal) {};
   virtual void OnPreUnInstall() {};
   virtual void OnPostUnInstall() {};
   virtual bool CanInstall(const std::string& referer) { return true; }

--- a/xbmc/addons/AddonInstaller.h
+++ b/xbmc/addons/AddonInstaller.h
@@ -185,8 +185,6 @@ public:
   static bool GetAddonWithHash(const std::string& addonID, ADDON::AddonPtr& addon, std::string& hash);
 
 private:
-  bool OnPreInstall();
-  void OnPostInstall(bool reloadAddon);
   bool Install(const std::string &installFrom, const ADDON::AddonPtr& repo = ADDON::AddonPtr());
   bool DownloadPackage(const std::string &path, const std::string &dest);
 

--- a/xbmc/addons/ContextItemAddon.cpp
+++ b/xbmc/addons/ContextItemAddon.cpp
@@ -68,12 +68,13 @@ CContextItemAddon::CContextItemAddon(const cp_extension_t *ext)
 
 bool CContextItemAddon::OnPreInstall()
 {
-  return CContextMenuManager::Get().Unregister(std::dynamic_pointer_cast<CContextItemAddon>(shared_from_this()));
+  CContextMenuManager::Get().Unregister(std::dynamic_pointer_cast<CContextItemAddon>(shared_from_this()));
+  return true;
 }
 
-void CContextItemAddon::OnPostInstall(bool restart, bool update, bool modal)
+void CContextItemAddon::OnPostInstall(bool update, bool modal)
 {
-  if (restart)
+  if (!CAddonMgr::Get().IsAddonDisabled(ID()))
   {
     // need to grab the local addon so we have the correct library path to run
     AddonPtr localAddon;

--- a/xbmc/addons/ContextItemAddon.h
+++ b/xbmc/addons/ContextItemAddon.h
@@ -57,7 +57,7 @@ namespace ADDON
     bool IsVisible(const CFileItemPtr& item) const;
 
     virtual bool OnPreInstall();
-    virtual void OnPostInstall(bool restart, bool update, bool modal);
+    virtual void OnPostInstall(bool update, bool modal);
     virtual void OnPreUnInstall();
     virtual void OnDisabled();
     virtual void OnEnabled();

--- a/xbmc/addons/IAddon.h
+++ b/xbmc/addons/IAddon.h
@@ -119,7 +119,7 @@ namespace ADDON
     virtual void OnEnabled() =0;
     virtual AddonPtr GetRunningInstance() const=0;
     virtual bool OnPreInstall() =0;
-    virtual void OnPostInstall(bool restart, bool update, bool modal) =0;
+    virtual void OnPostInstall(bool update, bool modal) =0;
     virtual void OnPreUnInstall() =0;
     virtual void OnPostUnInstall() =0;
     virtual bool CanInstall(const std::string& referer) =0;

--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -193,7 +193,7 @@ bool CRepository::Parse(const DirInfo& dir, VECADDONS &result)
   return false;
 }
 
-void CRepository::OnPostInstall(bool restart, bool update, bool modal)
+void CRepository::OnPostInstall(bool update, bool modal)
 {
   VECADDONS addons;
   AddonPtr repo(new CRepository(*this));

--- a/xbmc/addons/Repository.h
+++ b/xbmc/addons/Repository.h
@@ -58,7 +58,7 @@ namespace ADDON
     static bool Parse(const DirInfo& dir, VECADDONS& addons);
     static std::string FetchChecksum(const std::string& url);
 
-    virtual void OnPostInstall(bool restart, bool update, bool modal);
+    virtual void OnPostInstall(bool update, bool modal);
     virtual void OnPostUnInstall();
 
   private:

--- a/xbmc/addons/Service.cpp
+++ b/xbmc/addons/Service.cpp
@@ -133,12 +133,12 @@ bool CService::OnPreInstall()
     if (service)
       service->Stop();
   }
-  return !CAddonMgr::Get().IsAddonDisabled(ID());
+  return true;
 }
 
-void CService::OnPostInstall(bool restart, bool update, bool modal)
+void CService::OnPostInstall(bool update, bool modal)
 {
-  if (restart) // reload/start it if it was running
+  if (!CAddonMgr::Get().IsAddonDisabled(ID())) // reload/start it if it was running
   {
     AddonPtr localAddon; // need to grab the local addon so we have the correct library path to stop
     if (CAddonMgr::Get().GetAddon(ID(), localAddon, ADDON_SERVICE, false))

--- a/xbmc/addons/Service.h
+++ b/xbmc/addons/Service.h
@@ -50,7 +50,7 @@ namespace ADDON
     virtual void OnDisabled();
     virtual void OnEnabled();
     virtual bool OnPreInstall();
-    virtual void OnPostInstall(bool restart, bool update, bool modal);
+    virtual void OnPostInstall(bool update, bool modal);
     virtual void OnPreUnInstall();
 
   protected:

--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -278,18 +278,14 @@ const INFO::CSkinVariableString* CSkinInfo::CreateSkinVariable(const std::string
 
 bool CSkinInfo::OnPreInstall()
 {
-  // check whether this is an active skin - we need to unload it if so
   if (IsInUse())
-  {
     CApplicationMessenger::Get().ExecBuiltIn("UnloadSkin", true);
-    return true;
-  }
-  return false;
+  return true;
 }
 
-void CSkinInfo::OnPostInstall(bool restart, bool update, bool modal)
+void CSkinInfo::OnPostInstall(bool update, bool modal)
 {
-  if (restart || (!update && !modal && CGUIDialogYesNo::ShowAndGetInput(Name(), g_localizeStrings.Get(24099),"","")))
+  if (IsInUse() || (!update && !modal && CGUIDialogYesNo::ShowAndGetInput(Name(), g_localizeStrings.Get(24099),"","")))
   {
     CGUIDialogKaiToast *toast = (CGUIDialogKaiToast *)g_windowManager.GetWindow(WINDOW_DIALOG_KAI_TOAST);
     if (toast)

--- a/xbmc/addons/Skin.h
+++ b/xbmc/addons/Skin.h
@@ -119,7 +119,7 @@ public:
   static void SettingOptionsStartupWindowsFiller(const CSetting *setting, std::vector< std::pair<std::string, int> > &list, int &current, void *data);
 
   virtual bool OnPreInstall();
-  virtual void OnPostInstall(bool restart, bool update, bool modal);
+  virtual void OnPostInstall(bool update, bool modal);
 protected:
   /*! \brief Given a resolution, retrieve the corresponding directory name
    \param res RESOLUTION to translate

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -88,10 +88,10 @@ bool CPVRClient::OnPreInstall()
 {
   // stop the pvr manager, so running pvr add-ons are stopped and closed
   PVR::CPVRManager::Get().Stop();
-  return false;
+  return true;
 }
 
-void CPVRClient::OnPostInstall(bool restart, bool update, bool modal)
+void CPVRClient::OnPostInstall(bool update, bool modal)
 {
   // (re)start the pvr manager
   PVR::CPVRManager::Get().Start(true);

--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -61,7 +61,7 @@ namespace PVR
     virtual void OnEnabled();
     virtual ADDON::AddonPtr GetRunningInstance() const;
     virtual bool OnPreInstall();
-    virtual void OnPostInstall(bool restart, bool update, bool modal);
+    virtual void OnPostInstall(bool update, bool modal);
     virtual void OnPreUnInstall();
     virtual void OnPostUnInstall();
     virtual bool CanInstall(const std::string &referer);


### PR DESCRIPTION
Slightly. Currently `OnPreInstall`returns whether or not `OnPostInstall` should restart the add-on or not, which sounds very weird to me. Changed that to return success/failure (though it isn't used by any of the current ones) 
