### PR TITLE
[improvement] Include MusicVideos when creating playlists

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -6593,6 +6593,9 @@ msgid "Change area code 3"
 msgstr ""
 
 #: system/settings/settings.xml
+#: xbmc/music/windows/GUIWindowMusicBase.cpp
+#: xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
+#: xbmc/vide/windows/GUIWindowVideoBase.cpp
 msgctxt "#14022"
 msgid "Library"
 msgstr ""

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -713,7 +713,10 @@ void CGUIWindowMusicBase::UpdateButtons()
   msg2.SetLabel(g_localizeStrings.Get(744)); // Files
   g_windowManager.SendMessage(msg2);
 
-  msg2.SetLabel(g_localizeStrings.Get(15100)); // Library
+  msg2.SetLabel(g_localizeStrings.Get(14022)); // Library
+  g_windowManager.SendMessage(msg2);
+
+  msg2.SetLabel(g_localizeStrings.Get(20389)); // Music Videos
   g_windowManager.SendMessage(msg2);
 
   // Select the current window as default item

--- a/xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
@@ -149,12 +149,21 @@ bool CGUIWindowMusicPlaylistEditor::GetDirectory(const std::string &strDirectory
     files->SetLabelPreformated(true);
     files->m_bIsShareOrDrive = true;
     items.Add(files);
-    CFileItemPtr db(new CFileItem("musicdb://", true));
-    db->SetLabel(g_localizeStrings.Get(14022));
-    db->SetLabelPreformated(true);
-    db->m_bIsShareOrDrive = true;
+
+    CFileItemPtr mdb(new CFileItem("musicdb://", true));
+    mdb->SetLabel(g_localizeStrings.Get(14022));
+    mdb->SetLabelPreformated(true);
+    mdb->m_bIsShareOrDrive = true;
     items.SetPath("");
-    items.Add(db);
+    items.Add(mdb);
+
+    CFileItemPtr vdb(new CFileItem("videodb://musicvideos/", true));
+    vdb->SetLabel(g_localizeStrings.Get(20389));
+    vdb->SetLabelPreformated(true);
+    vdb->m_bIsShareOrDrive = true;
+    items.SetPath("");
+    items.Add(vdb);
+
     return true;
   }
 


### PR DESCRIPTION
Show videodb://musicvideos/ as a source for items in playlists.

Right now only songs can be added into playlists. This patch allows adding music videos as well.
