### PR TITLE
[pvr] fix deleting timers

### DIFF
--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -440,7 +440,7 @@ bool CPVRTimers::DeleteTimersOnChannel(const CPVRChannelPtr &channel, bool bDele
 
     for (MapTags::reverse_iterator it = m_tags.rbegin(); it != m_tags.rend(); ++it)
     {
-      for (VecTimerInfoTag::iterator timerIt = it->second->begin(); timerIt != it->second->end(); )
+      for (VecTimerInfoTag::iterator timerIt = it->second->begin(); timerIt != it->second->end(); ++timerIt)
       {
         bool bDeleteActiveItem = !bCurrentlyActiveOnly || (*timerIt)->IsRecording();
         bool bDeleteRepeatingItem = bDeleteRepeating || !(*timerIt)->m_bIsRepeating;
@@ -450,12 +450,7 @@ bool CPVRTimers::DeleteTimersOnChannel(const CPVRChannelPtr &channel, bool bDele
         {
           CLog::Log(LOGDEBUG,"PVRTimers - %s - deleted timer %d on client %d", __FUNCTION__, (*timerIt)->m_iClientIndex, (*timerIt)->m_iClientId);
           bReturn = (*timerIt)->DeleteFromClient(true) || bReturn;
-          timerIt = it->second->erase(timerIt);
           SetChanged();
-        }
-        else
-        {
-          ++timerIt;
         }
       }
     }

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -198,6 +198,8 @@ bool CPVRTimers::UpdateEntries(const CPVRTimers &timers)
           timerNotifications.push_back(strMessage);
         }
 
+        /** clear the EPG tag explicitly here, because it no longer happens automatically with shared pointers */
+        timer->ClearEpgTag();
         it->second->erase(it->second->begin() + iTimerPtr);
 
         bChanged = true;


### PR DESCRIPTION
- don't delete timers directly in `CPVRTimers::DeleteTimersOnChannel()` but wait for the backend to trigger an update
- timer tags weren't cleared from epg tags after 8f3260726b6a9a5fde842e9e7159f55bcfbfcf60 when they were deleted. this leads to a segfault when stopping a timer and restarting it on the same channel, when the active epg tag didn't change in the meantime 
