### PR TITLE
[Fix] fixed broken dvd playback after pr #6415

### DIFF
--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.h
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.h
@@ -194,5 +194,7 @@ protected:
 
   uint8_t m_lastblock[DVD_VIDEO_BLOCKSIZE];
   int     m_lastevent;
+
+  std::map<int, std::map<int, int64_t>> m_mapTitleChapters;
 };
 


### PR DESCRIPTION
Frequently asking dvdnav for chapter timestamps leads to buffering issues.
This is fixed by adding an appropriate cache which is only updated when a new title is started.
