### PR TITLE
Fix for lirc message spam

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4301,8 +4301,6 @@ void CApplication::ProcessSlow()
 
   g_mediaManager.ProcessEvents();
 
-  CInputManager::Get().EnableRemoteControl();
-
   if (!m_pPlayer->IsPlayingVideo() &&
       CSettings::Get().GetInt("general.addonupdates") != AUTO_UPDATES_NEVER)
     CAddonInstaller::Get().UpdateRepos();

--- a/xbmc/input/InputManager.cpp
+++ b/xbmc/input/InputManager.cpp
@@ -84,6 +84,7 @@ CInputManager& CInputManager::Get()
 void CInputManager::InitializeInputs()
 {
 #if defined(HAS_LIRC) || defined(HAS_IRSERVERSUITE)
+  m_RemoteControl.setUsed(true);
   m_RemoteControl.Initialize();
 #endif
 
@@ -760,12 +761,23 @@ bool CInputManager::IsRemoteControlEnabled()
 #endif
 }
 
+bool CInputManager::IsRemoteControlInitialized()
+{
+#if defined(HAS_LIRC) || defined(HAS_IRSERVERSUITE)
+  return m_RemoteControl.IsInitialized();
+#else
+  return false;
+#endif
+}
+
 void CInputManager::EnableRemoteControl()
 {
 #if defined(HAS_LIRC) || defined(HAS_IRSERVERSUITE)
   m_RemoteControl.setUsed(true);
   if (!m_RemoteControl.IsInitialized())
+  {
     m_RemoteControl.Initialize();
+  }
 #endif
 }
 
@@ -777,10 +789,18 @@ void CInputManager::DisableRemoteControl()
 #endif
 }
 
+void CInputManager::InitializeRemoteControl()
+{
+#if defined(HAS_LIRC) || defined(HAS_IRSERVERSUITE)
+  if (!m_RemoteControl.IsInitialized())
+    m_RemoteControl.Initialize();
+#endif
+}
+
 void CInputManager::SetRemoteControlName(const std::string& name)
 {
 #if defined(HAS_LIRC)
-  m_RemoteControl.setDeviceName(name);
+  m_RemoteControl.SetDeviceName(name);
 #endif
 }
 

--- a/xbmc/input/InputManager.cpp
+++ b/xbmc/input/InputManager.cpp
@@ -84,7 +84,7 @@ CInputManager& CInputManager::Get()
 void CInputManager::InitializeInputs()
 {
 #if defined(HAS_LIRC) || defined(HAS_IRSERVERSUITE)
-  m_RemoteControl.setUsed(true);
+  m_RemoteControl.SetEnabled(true);
   m_RemoteControl.Initialize();
 #endif
 
@@ -693,11 +693,11 @@ int CInputManager::ExecuteBuiltin(const std::string& execute, const std::vector<
   if (execute == "lirc.stop")
   {
     m_RemoteControl.Disconnect();
-    m_RemoteControl.setUsed(false);
+    m_RemoteControl.SetEnabled(false);
   }
   else if (execute == "lirc.start")
   {
-    m_RemoteControl.setUsed(true);
+    m_RemoteControl.SetEnabled(true);
     m_RemoteControl.Initialize();
   }
   else if (execute == "lirc.send")
@@ -773,7 +773,7 @@ bool CInputManager::IsRemoteControlInitialized()
 void CInputManager::EnableRemoteControl()
 {
 #if defined(HAS_LIRC) || defined(HAS_IRSERVERSUITE)
-  m_RemoteControl.setUsed(true);
+  m_RemoteControl.SetEnabled(true);
   if (!m_RemoteControl.IsInitialized())
   {
     m_RemoteControl.Initialize();
@@ -785,7 +785,7 @@ void CInputManager::DisableRemoteControl()
 {
 #if defined(HAS_LIRC) || defined(HAS_IRSERVERSUITE)
   m_RemoteControl.Disconnect();
-  m_RemoteControl.setUsed(false);
+  m_RemoteControl.SetEnabled(false);
 #endif
 }
 
@@ -799,7 +799,7 @@ void CInputManager::InitializeRemoteControl()
 
 void CInputManager::SetRemoteControlName(const std::string& name)
 {
-#if defined(HAS_LIRC)
+#if defined(HAS_LIRC) || defined(HAS_IRSERVERSUITE)
   m_RemoteControl.SetDeviceName(name);
 #endif
 }

--- a/xbmc/input/InputManager.h
+++ b/xbmc/input/InputManager.h
@@ -190,11 +190,22 @@ public:
    */
   void DisableRemoteControl();
 
+  /*! \brief Try to connect to a remote control to listen for commands
+   *
+   */
+  void InitializeRemoteControl();
+
   /*! \brief Check if the remote control is enabled
    *
    * \return true if remote control is enabled, false otherwise 
    */
   bool IsRemoteControlEnabled();
+
+  /*! \brief Check if the remote control is initialized
+   *
+   * \return true if initialized, false otherwise 
+   */
+  bool IsRemoteControlInitialized();
 
   /*! \brief Set the device name to use with LIRC, does nothing 
    *   if IRServerSuite is used

--- a/xbmc/input/linux/LIRC.cpp
+++ b/xbmc/input/linux/LIRC.cpp
@@ -74,8 +74,8 @@ void CRemoteControl::Reset()
 
 void CRemoteControl::Disconnect()
 {
-  if (!m_used)
-    return;
+  if (IsRunning())
+    StopThread();
 
   if (m_fd != -1) 
   {

--- a/xbmc/input/linux/LIRC.cpp
+++ b/xbmc/input/linux/LIRC.cpp
@@ -59,7 +59,7 @@ CRemoteControl::~CRemoteControl()
     fclose(m_file);
 }
 
-void CRemoteControl::setUsed(bool value)
+void CRemoteControl::SetEnabled(bool value)
 {
   m_used=value;
   if (!value)

--- a/xbmc/input/linux/LIRC.cpp
+++ b/xbmc/input/linux/LIRC.cpp
@@ -37,7 +37,8 @@
 #include "settings/AdvancedSettings.h"
 #include "utils/TimeUtils.h"
 
-CRemoteControl::CRemoteControl():
+CRemoteControl::CRemoteControl() :
+  CThread("RemoteControl"),
   m_deviceName(LIRC_DEVICE)
 {
   m_fd = -1;
@@ -48,12 +49,8 @@ CRemoteControl::CRemoteControl():
   m_used = true;
   m_inotify_fd = -1;
   m_inotify_wd = -1;
-  m_bLogConnectFailure = true;
-  m_lastInitAttempt = -5000;
-  m_initRetryPeriod = 5000;
   m_inReply = false;
   m_nrSending = 0;
-  Reset();
 }
 
 CRemoteControl::~CRemoteControl()
@@ -67,11 +64,6 @@ void CRemoteControl::setUsed(bool value)
   m_used=value;
   if (!value)
     CLog::Log(LOGINFO, "LIRC %s: disabled", __FUNCTION__);
-  else
-  {
-    m_lastInitAttempt = -5000;
-    m_initRetryPeriod = 5000;
-  }
 }
 
 void CRemoteControl::Reset()
@@ -109,109 +101,55 @@ void CRemoteControl::Disconnect()
   }
 }
 
-void CRemoteControl::setDeviceName(const std::string& value)
+void CRemoteControl::SetDeviceName(const std::string& value)
 {
   if (value.length()>0)
     m_deviceName=value;
   else
     m_deviceName=LIRC_DEVICE;
-  if (m_bInitialized)
-  {
-    Disconnect();
-    Initialize();
-  }
 }
 
 void CRemoteControl::Initialize()
 {
-  struct sockaddr_un addr;
-  unsigned int now = XbmcThreads::SystemClockMillis();
-
-  if (m_bInitialized || !m_used || (now - m_lastInitAttempt) < (unsigned int)m_initRetryPeriod)
+  if (m_bInitialized || !m_used || IsRunning())
     return;
-  
-  m_lastInitAttempt = now;
+
+  Create();
+}
+void CRemoteControl::Process()
+{
+  struct sockaddr_un addr;
   addr.sun_family = AF_UNIX;
   strcpy(addr.sun_path, m_deviceName.c_str());
 
   CLog::Log(LOGINFO, "LIRC %s: using: %s", __FUNCTION__, addr.sun_path);
 
-  // Open the socket from which we will receive the remote commands
-  if ((m_fd = socket(AF_UNIX, SOCK_STREAM, 0)) != -1)
+  int iAttempt = 0;
+  unsigned int iMsRetryDelay = 5000;
+  unsigned int time = XbmcThreads::SystemClockMillis() - iMsRetryDelay;
+
+  // try to connect 60 times @ a 5 second interval (5 minutes)
+  // multiple tries because LIRC service might be up and running a little later then xbmc on boot.
+  while (!m_bStop && iAttempt <= 60)
   {
-    // Connect to the socket
-    if (connect(m_fd, (struct sockaddr *)&addr, sizeof(addr)) != -1)
+    if (XbmcThreads::SystemClockMillis() - time >= iMsRetryDelay)
     {
-      int opts;
-      m_bLogConnectFailure = true;
-      if ((opts = fcntl(m_fd,F_GETFL)) != -1)
-      {
-        // Set the socket to non-blocking
-        opts = (opts | O_NONBLOCK);
-        if (fcntl(m_fd,F_SETFL,opts) != -1)
-        {
-          if ((m_file = fdopen(m_fd, "r+")) != NULL)
-          {
-#ifdef HAVE_INOTIFY
-            // Setup inotify so we can disconnect if lircd is restarted
-            if ((m_inotify_fd = inotify_init()) >= 0)
-            {
-              // Set the fd non-blocking
-              if ((opts = fcntl(m_inotify_fd, F_GETFL)) != -1)
-              {
-                opts |= O_NONBLOCK;
-                if (fcntl(m_inotify_fd, F_SETFL, opts) != -1)
-                {
-                  // Set an inotify watch on the lirc device
-                  if ((m_inotify_wd = inotify_add_watch(m_inotify_fd, m_deviceName.c_str(), IN_DELETE_SELF)) != -1)
-                  {
-                    m_bInitialized = true;
-                    CLog::Log(LOGINFO, "LIRC %s: successfully started", __FUNCTION__);
-                  }
-                  else
-                    CLog::Log(LOGDEBUG, "LIRC: Failed to initialize Inotify. LIRC device will not be monitored.");
-                }
-              }
-            }
-#else
-            m_bInitialized = true;
-            CLog::Log(LOGINFO, "LIRC %s: successfully started", __FUNCTION__);
-#endif
-          }
-          else
-            CLog::Log(LOGERROR, "LIRC %s: fdopen failed: %s", __FUNCTION__, strerror(errno));
-        }
-        else
-          CLog::Log(LOGERROR, "LIRC %s: fcntl(F_SETFL) failed: %s", __FUNCTION__, strerror(errno));
-      }
-      else
-        CLog::Log(LOGERROR, "LIRC %s: fcntl(F_GETFL) failed: %s", __FUNCTION__, strerror(errno));
+      time = XbmcThreads::SystemClockMillis();
+      if (Connect(addr))
+        break;
+
+      if (iAttempt == 0)
+        CLog::Log(LOGINFO, "CRemoteControl::Process - failed to connect to LIRC, will keep retrying every %d seconds", iMsRetryDelay / 1000);
+
+      ++iAttempt;
     }
-    else
-    {
-      if (m_bLogConnectFailure)
-      {
-        CLog::Log(LOGINFO, "LIRC %s: connect failed: %s", __FUNCTION__, strerror(errno));
-        m_bLogConnectFailure = false;
-      }
-    }
+    Sleep(1000);
   }
-  else
-    CLog::Log(LOGINFO, "LIRC %s: socket failed: %s", __FUNCTION__, strerror(errno));
+  
   if (!m_bInitialized)
   {
-    Disconnect();
-    m_initRetryPeriod *= 2;
-    if (m_initRetryPeriod > 60000)
-    {
-      m_used = false;
-      CLog::Log(LOGDEBUG, "Failed to connect to LIRC. Giving up.");
-    }
-    else
-      CLog::Log(LOGDEBUG, "Failed to connect to LIRC. Retry in %ds.", m_initRetryPeriod/1000);
+    CLog::Log(LOGDEBUG, "Failed to connect to LIRC. Giving up.");
   }
-  else
-    m_initRetryPeriod = 5000;
 }
 
 bool CRemoteControl::CheckDevice() {
@@ -351,6 +289,67 @@ void CRemoteControl::AddSendCommand(const std::string& command)
 
   m_sendData += command;
   m_sendData += '\n';
+}
+
+bool CRemoteControl::Connect(struct sockaddr_un addr)
+{
+  // Open the socket from which we will receive the remote commands
+  if ((m_fd = socket(AF_UNIX, SOCK_STREAM, 0)) != -1)
+  {
+    // Connect to the socket
+    if (connect(m_fd, (struct sockaddr *)&addr, sizeof(addr)) != -1)
+    {
+      int opts;
+      if ((opts = fcntl(m_fd, F_GETFL)) != -1)
+      {
+        // Set the socket to non-blocking
+        opts = (opts | O_NONBLOCK);
+        if (fcntl(m_fd, F_SETFL, opts) != -1)
+        {
+          if ((m_file = fdopen(m_fd, "r+")) != NULL)
+          {
+#ifdef HAVE_INOTIFY
+            // Setup inotify so we can disconnect if lircd is restarted
+            if ((m_inotify_fd = inotify_init()) >= 0)
+            {
+              // Set the fd non-blocking
+              if ((opts = fcntl(m_inotify_fd, F_GETFL)) != -1)
+              {
+                opts |= O_NONBLOCK;
+                if (fcntl(m_inotify_fd, F_SETFL, opts) != -1)
+                {
+                  // Set an inotify watch on the lirc device
+                  if ((m_inotify_wd = inotify_add_watch(m_inotify_fd, m_deviceName.c_str(), IN_DELETE_SELF)) != -1)
+                  {
+                    m_bInitialized = true;
+                    CLog::Log(LOGINFO, "LIRC %s: successfully started", __FUNCTION__);
+                  }
+                  else
+                    CLog::Log(LOGDEBUG, "LIRC: Failed to initialize Inotify. LIRC device will not be monitored.");
+                }
+              }
+            }
+#else
+            m_bInitialized = true;
+            CLog::Log(LOGINFO, "LIRC %s: successfully started", __FUNCTION__);
+#endif
+          }
+          else
+            CLog::Log(LOGERROR, "LIRC %s: fdopen failed: %s", __FUNCTION__, strerror(errno));
+        }
+        else
+          CLog::Log(LOGERROR, "LIRC %s: fcntl(F_SETFL) failed: %s", __FUNCTION__, strerror(errno));
+      }
+      else
+        CLog::Log(LOGERROR, "LIRC %s: fcntl(F_GETFL) failed: %s", __FUNCTION__, strerror(errno));
+    }
+    else
+      CLog::Log(LOGINFO, "LIRC %s: connect failed: %s", __FUNCTION__, strerror(errno));
+  }
+  else
+    CLog::Log(LOGINFO, "LIRC %s: socket failed: %s", __FUNCTION__, strerror(errno));
+
+  return m_bInitialized;
 }
 
 #endif

--- a/xbmc/input/linux/LIRC.h
+++ b/xbmc/input/linux/LIRC.h
@@ -41,7 +41,7 @@ public:
    */
   unsigned int GetHoldTime() const;
   void SetDeviceName(const std::string& value);
-  void setUsed(bool value);
+  void SetEnabled(bool value);
   bool IsInUse() const { return m_used; }
   bool IsInitialized() const { return m_bInitialized; }
   void AddSendCommand(const std::string& command);

--- a/xbmc/input/linux/LIRC.h
+++ b/xbmc/input/linux/LIRC.h
@@ -25,6 +25,7 @@
 
 #include "system.h"
 #include "threads/Thread.h"
+#include "threads/Event.h"
 
 class CRemoteControl :  CThread
 {
@@ -67,6 +68,7 @@ private:
   std::string  m_sendData;
   bool        m_inReply;
   int         m_nrSending;
+  CEvent      m_event;
 };
 
 #endif

--- a/xbmc/input/linux/LIRC.h
+++ b/xbmc/input/linux/LIRC.h
@@ -21,14 +21,16 @@
 #ifndef LIRC_H
 #define LIRC_H
 
-#include "system.h"
 #include <string>
 
-class CRemoteControl
+#include "system.h"
+#include "threads/Thread.h"
+
+class CRemoteControl :  CThread
 {
 public:
   CRemoteControl();
-  ~CRemoteControl();
+  virtual ~CRemoteControl();
   void Initialize();
   void Disconnect();
   void Reset();
@@ -38,25 +40,27 @@ public:
    \return time in milliseconds the button has been down
    */
   unsigned int GetHoldTime() const;
-  void setDeviceName(const std::string& value);
+  void SetDeviceName(const std::string& value);
   void setUsed(bool value);
   bool IsInUse() const { return m_used; }
   bool IsInitialized() const { return m_bInitialized; }
   void AddSendCommand(const std::string& command);
 
+protected:
+  virtual void Process();
+
+  bool Connect(struct sockaddr_un addr);
+
 private:
   int     m_fd;
   int     m_inotify_fd;
   int     m_inotify_wd;
-  int     m_lastInitAttempt;
-  int     m_initRetryPeriod;
   FILE*   m_file;
   unsigned int m_holdTime;
   int32_t m_button;
   char    m_buf[128];
   bool    m_bInitialized;
   bool    m_used;
-  bool    m_bLogConnectFailure;
   uint32_t    m_firstClickTime;
   std::string  m_deviceName;
   bool        CheckDevice();

--- a/xbmc/input/windows/IRServerSuite.cpp
+++ b/xbmc/input/windows/IRServerSuite.cpp
@@ -483,7 +483,3 @@ unsigned int CRemoteControl::GetHoldTime() const
 {
   return 0;
 }
-
-void CRemoteControl::setUsed(bool value)
-{
-}

--- a/xbmc/input/windows/IRServerSuite.cpp
+++ b/xbmc/input/windows/IRServerSuite.cpp
@@ -18,13 +18,10 @@
  *
  */
 
-#include "threads/SystemClock.h"
 #include "IRServerSuite.h"
 #include "IrssMessage.h"
 #include "input/ButtonTranslator.h"
 #include "utils/log.h"
-#include "settings/AdvancedSettings.h"
-#include "utils/TimeUtils.h"
 #include <Ws2tcpip.h>
 
 #define IRSS_PORT 24000
@@ -34,7 +31,6 @@ CRemoteControl::CRemoteControl() : CThread("RemoteControl")
   m_socket = INVALID_SOCKET;
   m_bInitialized = false;
   m_isConnecting = false;
-  m_iAttempt     = 0;
   Reset();
 }
 
@@ -45,6 +41,8 @@ CRemoteControl::~CRemoteControl()
 
 void CRemoteControl::Disconnect()
 {
+  m_event.Set();
+
   StopThread();
   Close();
 }
@@ -82,25 +80,22 @@ void CRemoteControl::Initialize()
 void CRemoteControl::Process()
 {
   unsigned int iMsRetryDelay = 5000;
-  unsigned int time = XbmcThreads::SystemClockMillis() - iMsRetryDelay;
+  int iAttempt = 0;
   // try to connect 60 times @ a 5 second interval (5 minutes)
   // multiple tries because irss service might be up and running a little later then xbmc on boot.
-  while (!m_bStop && m_iAttempt <= 60)
+  while (!m_bStop && iAttempt <= 60)
   {
-    if (XbmcThreads::SystemClockMillis() - time >= iMsRetryDelay)
-    {
-      time = XbmcThreads::SystemClockMillis();
-      if (Connect())
-        break;
+    if (Connect())
+      break;
 
-      if(m_iAttempt == 0)
-        CLog::Log(LOGINFO, "CRemoteControl::Process - failed to connect to irss, will keep retrying every %d seconds", iMsRetryDelay / 1000);
+    if(iAttempt == 0)
+      CLog::Log(LOGINFO, "CRemoteControl::Process - failed to connect to irss, will keep retrying every %d seconds", iMsRetryDelay / 1000);
 
-      m_iAttempt++;
-    }
-    Sleep(1000);
+    ++iAttempt;
+    
+    if (AbortableWait(m_event, iMsRetryDelay) == WAIT_INTERRUPTED)
+      break;
   }
-  m_iAttempt     = 0;
 }
 
 bool CRemoteControl::Connect()
@@ -119,8 +114,7 @@ bool CRemoteControl::Connect()
   res = getaddrinfo("localhost", service, &hints, &result);
   if(res)
   {
-    if(m_iAttempt == 0)
-      CLog::Log(LOGDEBUG, "CRemoteControl::Connect - getaddrinfo failed: %s", gai_strerror(res));
+    CLog::Log(LOGDEBUG, "CRemoteControl::Connect - getaddrinfo failed: %s", gai_strerror(res));
     return false;
   }
 
@@ -132,8 +126,7 @@ bool CRemoteControl::Connect()
       strcpy(portbuf, "[unknown]");
     }
 
-    if(m_iAttempt == 0)
-      CLog::Log(LOGDEBUG, "CRemoteControl::Connect - connecting to: %s:%s ...", namebuf, portbuf);
+    CLog::Log(LOGDEBUG, "CRemoteControl::Connect - connecting to: %s:%s ...", namebuf, portbuf);
 
     m_socket = socket(addr->ai_family, addr->ai_socktype, addr->ai_protocol);
     if(m_socket == INVALID_SOCKET)
@@ -149,8 +142,7 @@ bool CRemoteControl::Connect()
   freeaddrinfo(result);
   if(m_socket == INVALID_SOCKET)
   {
-    if(m_iAttempt == 0)
-      CLog::Log(LOGDEBUG, "CRemoteControl::Connect - failed to connect");
+    CLog::Log(LOGDEBUG, "CRemoteControl::Connect - failed to connect");
     Close();
     return false;
   }
@@ -158,8 +150,7 @@ bool CRemoteControl::Connect()
   u_long iMode = 1; //non-blocking
   if (ioctlsocket(m_socket, FIONBIO, &iMode) == SOCKET_ERROR)
   {
-    if(m_iAttempt == 0)
-      CLog::Log(LOGERROR, "IRServerSuite: failed to set socket to non-blocking.");
+    CLog::Log(LOGERROR, "IRServerSuite: failed to set socket to non-blocking.");
     Close();
     return false;
   }
@@ -168,8 +159,7 @@ bool CRemoteControl::Connect()
   CIrssMessage mess(IRSSMT_RegisterClient, IRSSMF_Request);
   if (!SendPacket(mess))
   {
-    if(m_iAttempt == 0)
-      CLog::Log(LOGERROR, "IRServerSuite: failed to send RegisterClient packet.");
+    CLog::Log(LOGERROR, "IRServerSuite: failed to send RegisterClient packet.");
     return false;
   }
   m_isConnecting = true;
@@ -362,10 +352,8 @@ bool CRemoteControl::HandleRemoteEvent(CIrssMessage& message)
     keycode[keycodelength] = '\0';
     //translate to a buttoncode xbmc understands
     m_button = CButtonTranslator::GetInstance().TranslateLircRemoteString(deviceName, keycode);
-    if (g_advancedSettings.m_logLevel == LOG_LEVEL_DEBUG_FREEMEM)
-    {
-      CLog::Log(LOGINFO, "IRServerSuite, RemoteEvent: %s %s", deviceName, keycode);
-    }
+    CLog::Log(LOGDEBUG, "IRServerSuite, RemoteEvent: %s %s", deviceName, keycode);
+    
     delete[] deviceName;
     delete[] keycode;
     return true;

--- a/xbmc/input/windows/IRServerSuite.h
+++ b/xbmc/input/windows/IRServerSuite.h
@@ -20,8 +20,11 @@
  */
 
 #include <winsock2.h>
+#include <string>
+
 #include "IrssMessage.h"
 #include "threads/Thread.h"
+#include "threads/Event.h"
 
 class CRemoteControl : CThread
 {
@@ -50,9 +53,9 @@ private:
   bool  m_bInitialized;
   SOCKET m_socket;
   bool m_isConnecting;
-  int  m_iAttempt;
   std::string m_deviceName;
   std::string m_keyCode;
+  CEvent m_event;
 
   bool SendPacket(CIrssMessage& message);
   bool ReadPacket(CIrssMessage& message);

--- a/xbmc/input/windows/IRServerSuite.h
+++ b/xbmc/input/windows/IRServerSuite.h
@@ -27,7 +27,7 @@ class CRemoteControl : CThread
 {
 public:
   CRemoteControl();
-  ~CRemoteControl();
+  virtual ~CRemoteControl();
   void Initialize();
   void Disconnect();
   void Reset();
@@ -38,7 +38,8 @@ public:
 
   //lirc stuff, not implemented
   bool IsInUse() {return false;}
-  void setUsed(bool value);
+  void SetEnabled(bool) { }
+  void SetDeviceName(const std::string&) { }
   void AddSendCommand(const std::string& command) {}
 
 protected:


### PR DESCRIPTION
I reworked the LIRC code to match the one in IRSS for Windows and removed the calls to Init in our slow loop. New behvaiour is that it will try to connect 60 times at launch, every 5 seconds, after that it gives up and won't be used.
I've tried this on OpenElec and it works fine with a remote at least.
