### PR TITLE
CActiveAEResamplePi: remove usage of videoplayer.synctype

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResamplePi.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResamplePi.cpp
@@ -280,7 +280,7 @@ bool CActiveAEResamplePi::Init(uint64_t dst_chan_layout, int dst_channels, int d
 
   LOGTIME(3);
 
-  if (CSettings::Get().GetBool("videoplayer.usedisplayasclock") && CSettings::Get().GetInt("videoplayer.synctype") == SYNC_RESAMPLE)
+  if (CSettings::Get().GetBool("videoplayer.usedisplayasclock"))
   {
     OMX_PARAM_U32TYPE scaleType;
     OMX_INIT_STRUCTURE(scaleType);


### PR DESCRIPTION
This removes the usage of the `videoplayer.synctype` after df1c1b8d25f8ae227ee76399f6ef7b6b98f34201.

I can't build/test this and I don't know this code. @FernetMenta: Let me know if this is ok.
