### PR TITLE
Index the entire collection's fanart when building the "fanart://Remote%i" strings

### DIFF
--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -1917,6 +1917,7 @@ bool CGUIDialogVideoInfo::OnGetFanart(const CFileItemPtr &videoItem)
     CStdString baseDir = StringUtils::Format("videodb://movies/sets/%d", videoItem->GetVideoInfoTag()->m_iDbId);
     if (videodb.GetMoviesNav(baseDir, movies))
     {
+      int iFanart = 0;
       for (int i=0; i < movies.Size(); i++)
       {
         // ensure the fanart is unpacked
@@ -1925,7 +1926,7 @@ bool CGUIDialogVideoInfo::OnGetFanart(const CFileItemPtr &videoItem)
         // Grab the thumbnails from the web
         for (unsigned int j = 0; j < movies[i]->GetVideoInfoTag()->m_fanart.GetNumFanarts(); j++)
         {
-          CStdString strItemPath = StringUtils::Format("fanart://Remote%i",j);
+          CStdString strItemPath = StringUtils::Format("fanart://Remote%i",iFanart++);
           CFileItemPtr item(new CFileItem(strItemPath, false));
           CStdString thumb = movies[i]->GetVideoInfoTag()->m_fanart.GetPreviewURL(j);
           item->SetArt("thumb", CTextureUtils::GetWrappedThumbURL(thumb));


### PR DESCRIPTION
When I group movies into collections, I can not always change the collection fanart to the one I want. The problem is "fanart://RemoteN" text is not counting all the remote fanarts for every movie. It goes back to 0 when the fanart for the next movie in the collection starts. This patch adds another index to count all fanart to fix it.

This patch is for Helix branch. Same issue on master can be fixed in a similar way.

ref: http://forum.kodi.tv/showthread.php?tid=220345
