### PR TITLE
[pvr.hts] bump to https://github.com/kodi-pvr/pvr.hts/commit/f11a84f6deb8609fa47a39b49c2b729d50a9b5b0

### DIFF
--- a/project/cmake/addons/addons/pvr.hts/pvr.hts.txt
+++ b/project/cmake/addons/addons/pvr.hts/pvr.hts.txt
@@ -1,1 +1,1 @@
-pvr.hts https://github.com/kodi-pvr/pvr.hts 3bc77ae
+pvr.hts https://github.com/kodi-pvr/pvr.hts f11a84f


### PR DESCRIPTION
instead of building from a commit while in development, until branched off
