### PR TITLE
fixed: tinyxml linkage on x64 hosts

### DIFF
--- a/project/cmake/addons/depends/common/tinyxml/CMakeLists.txt
+++ b/project/cmake/addons/depends/common/tinyxml/CMakeLists.txt
@@ -14,6 +14,11 @@ add_definitions(-DTIXML_USE_STL)
 
 add_library(tinyxml ${SOURCES})
 
+
+IF(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+  SET_TARGET_PROPERTIES(tinyxml PROPERTIES COMPILE_FLAGS "-fPIC")
+ENDIF(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+
 include_directories(${PROJECT_SOURCE_DIR}/include)
 
 set(HEADERS ${PROJECT_SOURCE_DIR}/include/tinystr.h


### PR DESCRIPTION
without this, the linker complains: `relocation R_X86_64_32 against .rodata' can not be used when making a shared object; recompile with -fPIC`

ping @montellese @notspiff
