### PR TITLE
[pvr.hts] bump to https://github.com/kodi-pvr/pvr.hts/commit/abceaf8

### DIFF
--- a/project/cmake/addons/addons/pvr.demo/pvr.demo.txt
+++ b/project/cmake/addons/addons/pvr.demo/pvr.demo.txt
@@ -1,1 +1,1 @@
-pvr.demo https://github.com/kodi-pvr/pvr.demo e457cf4
+pvr.demo https://github.com/kodi-pvr/pvr.demo b4b7de1

--- a/project/cmake/addons/addons/pvr.hts/pvr.hts.txt
+++ b/project/cmake/addons/addons/pvr.hts/pvr.hts.txt
@@ -1,1 +1,1 @@
-pvr.hts https://github.com/kodi-pvr/pvr.hts f11a84f
+pvr.hts https://github.com/kodi-pvr/pvr.hts abceaf8


### PR DESCRIPTION
[pvr.demo] bump to https://github.com/kodi-pvr/pvr.demo/commit/b4b7de1

and this time it not just builds but also runs after this api changes. pvr.demo needs https://github.com/xbmc/xbmc/pull/6618 or it won't build on my x64 host
