### PR TITLE
[pvr] fix add-ons new being disabled

### DIFF
--- a/xbmc/addons/AddonDatabase.cpp
+++ b/xbmc/addons/AddonDatabase.cpp
@@ -105,6 +105,12 @@ void CAddonDatabase::UpdateTables(int version)
   }
 }
 
+int CAddonDatabase::GetAddonId(const ADDON::AddonPtr& item)
+{
+  std::string value = GetSingleValue("addon", "id", StringUtils::Format("name = '%s'", item->Name().c_str()), "id desc");
+  return value.empty() || !StringUtils::IsInteger(value) ? -1 : atoi(value.c_str());
+}
+
 int CAddonDatabase::AddAddon(const AddonPtr& addon,
                              int idRepo)
 {

--- a/xbmc/addons/AddonDatabase.h
+++ b/xbmc/addons/AddonDatabase.h
@@ -31,6 +31,7 @@ public:
   virtual ~CAddonDatabase();
   virtual bool Open();
 
+  int GetAddonId(const ADDON::AddonPtr& item);
   int AddAddon(const ADDON::AddonPtr& item, int idRepo);
   bool GetAddon(const std::string& addonID, ADDON::AddonPtr& addon);
   bool GetAddons(ADDON::VECADDONS& addons);

--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -91,16 +91,6 @@ void CPVRDatabase::CreateTables()
         "iSubChannelNumber integer"
       ")"
   );
-
-  // disable all PVR add-on when started the first time
-  ADDON::VECADDONS addons;
-  if (!CAddonMgr::Get().GetAddons(ADDON_PVRDLL, addons, true))
-    CLog::Log(LOGERROR, "PVR - %s - failed to get add-ons from the add-on manager", __FUNCTION__);
-  else
-  {
-    for (IVECADDONS it = addons.begin(); it != addons.end(); it++)
-      CAddonMgr::Get().DisableAddon(it->get()->ID());
-  }
 }
 
 void CPVRDatabase::CreateAnalytics()
@@ -116,24 +106,6 @@ void CPVRDatabase::UpdateTables(int iVersion)
   if (iVersion < 13)
     m_pDS->exec("ALTER TABLE channels ADD idEpg integer;");
 
-  if (iVersion < 19)
-  {
-    // bit of a hack, but we need to keep the version/contents of the non-pvr databases the same to allow clean upgrades
-    ADDON::VECADDONS addons;
-    if (!CAddonMgr::Get().GetAddons(ADDON_PVRDLL, addons, true))
-      CLog::Log(LOGERROR, "PVR - %s - failed to get add-ons from the add-on manager", __FUNCTION__);
-    else
-    {
-      CAddonDatabase database;
-      database.Open();
-      for (IVECADDONS it = addons.begin(); it != addons.end(); it++)
-      {
-        if (!database.IsSystemPVRAddonEnabled(it->get()->ID()))
-          CAddonMgr::Get().DisableAddon(it->get()->ID());
-      }
-      database.Close();
-    }
-  }
   if (iVersion < 20)
     m_pDS->exec("ALTER TABLE channels ADD bIsUserSetIcon bool");
 

--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -134,6 +134,49 @@ void CPVRDatabase::UpdateTables(int iVersion)
 
   if (iVersion < 27)
     m_pDS->exec("ALTER TABLE channelgroups ADD bIsHidden bool");
+
+  if (iVersion < 28)
+  {
+    VECADDONS addons;
+    int iAddonId;
+    CAddonDatabase database;
+    if (!database.Open() || !CAddonMgr::Get().GetAddons(ADDON_PVRDLL, addons, true))
+      return;
+
+    /** find all old client IDs */
+    std::string strQuery(PrepareSQL("SELECT idClient, sUid FROM clients"));
+    m_pDS->query(strQuery);
+    while (!m_pDS->eof() && !addons.empty())
+    {
+      /** try to find an add-on that matches the sUid */
+      iAddonId = -1;
+      for (VECADDONS::iterator it = addons.begin(); iAddonId <= 0 && it != addons.end(); ++it)
+      {
+        if ((*it)->ID() == m_pDS->fv(1).get_asString())
+        {
+          /** try to get the current ID from the database */
+          iAddonId = database.GetAddonId(*it);
+          /** register a new id if it didn't exist */
+          if (iAddonId <= 0)
+            iAddonId = database.AddAddon(*it, 0);
+          if (iAddonId > 0)
+          {
+            // this fails when an id becomes the id of one that's being replaced next iteration
+            // but since almost everyone only has 1 add-on enabled...
+            /** update the iClientId in the channels table */
+            strQuery = PrepareSQL("UPDATE channels SET iClientId = %u WHERE iClientId = %u", iAddonId, m_pDS->fv(0).get_asInt());
+            m_pDS->exec(strQuery);
+
+            /** no need to check this add-on again */
+            addons.erase(it);
+          }
+        }
+      }
+    }
+
+    strQuery = PrepareSQL("DROP TABLE clients");
+    m_pDS->exec(strQuery);
+  }
 }
 
 /********** Channel methods **********/

--- a/xbmc/pvr/PVRDatabase.h
+++ b/xbmc/pvr/PVRDatabase.h
@@ -153,32 +153,6 @@ namespace PVR
 
     /*! @name Client methods */
     //@{
-    /*!
-     * @brief Remove all client information from the database.
-     * @return True if all clients were removed successfully.
-     */
-    bool DeleteClients();
-
-    /*!
-     * @brief Add a client to the database if it's not already in there.
-     * @param addon The pointer to related addon
-     * @return The database ID of the client.
-     */
-    int Persist(const ADDON::AddonPtr addon);
-
-    /*!
-     * @brief Remove a client from the database
-     * @param client The related PVR client to remove from Database.
-     * @return True if the client was removed successfully, false otherwise.
-     */
-    bool Delete(const CPVRClient &client);
-
-    /*!
-     * @brief Get the database ID of a client.
-     * @param strClientUid The unique ID of the client.
-     * @return The database ID of the client or -1 if it wasn't found.
-     */
-    int GetClientId(const std::string &strClientUid);
 
     /*!
     * @brief Updates the last watched timestamp for the channel

--- a/xbmc/pvr/PVRDatabase.h
+++ b/xbmc/pvr/PVRDatabase.h
@@ -59,7 +59,7 @@ namespace PVR
      * @brief Get the minimal database version that is required to operate correctly.
      * @return The minimal database version.
      */
-    virtual int GetSchemaVersion() const { return 27; };
+    virtual int GetSchemaVersion() const { return 28; };
 
     /*!
      * @brief Get the default sqlite database filename.

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -138,6 +138,16 @@ CPVRManager &CPVRManager::Get(void)
   return pvrManagerInstance;
 }
 
+bool CPVRManager::RestartManagerOnAddonDisabled(void) const
+{
+  ManagerState ms(GetState());
+  if (ms == ManagerStateStarting)
+    return false;
+  else if (ms == ManagerStateStarted)
+    return m_addons->RestartManagerOnAddonDisabled();
+  return true;
+}
+
 void CPVRManager::OnSettingChanged(const CSetting *setting)
 {
   if (setting == NULL)

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -818,7 +818,6 @@ void CPVRManager::ResetDatabase(bool bResetEPGOnly /* = false */)
       pDlgProgress->Progress();
 
       /* delete all client information */
-      m_database->DeleteClients();
       pDlgProgress->SetPercentage(90);
       pDlgProgress->Progress();
     }

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -250,6 +250,12 @@ namespace PVR
     {
       return GetState() == ManagerStateStarted;
     }
+
+    /**
+     * Called by OnEnable() and OnDisable() to check if the manager should be restarted
+     * @return True if it should be restarted, false otherwise
+     */
+    bool RestartManagerOnAddonDisabled(void) const;
     
     /*!
      * @brief Check whether the PVRManager is stopping

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -59,6 +59,7 @@ CPVRClient::CPVRClient(const cp_extension_t *ext) :
   m_strAvahiType = CAddonMgr::Get().GetExtValue(ext->configuration, "@avahi_type");
   m_strAvahiIpSetting = CAddonMgr::Get().GetExtValue(ext->configuration, "@avahi_ip_setting");
   m_strAvahiPortSetting = CAddonMgr::Get().GetExtValue(ext->configuration, "@avahi_port_setting");
+  m_bNeedsConfiguration = !(CAddonMgr::Get().GetExtValue(ext->configuration, "@needs_configuration") == "false");
 }
 
 CPVRClient::~CPVRClient(void)

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -73,14 +73,15 @@ CPVRClient::~CPVRClient(void)
 void CPVRClient::OnDisabled()
 {
   // restart the PVR manager if we're disabling a client
-  if (CPVRManager::Get().IsStarted())
+  if (CPVRManager::Get().IsStarted() && CPVRManager::Get().RestartManagerOnAddonDisabled())
     CPVRManager::Get().Start(true);
 }
 
 void CPVRClient::OnEnabled()
 {
   // restart the PVR manager if we're enabling a client
-  CPVRManager::Get().Start(true);
+  if (CPVRManager::Get().RestartManagerOnAddonDisabled())
+    CPVRManager::Get().Start(true);
 }
 
 AddonPtr CPVRClient::GetRunningInstance() const

--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -66,6 +66,7 @@ namespace PVR
     virtual void OnPreUnInstall();
     virtual void OnPostUnInstall();
     virtual bool CanInstall(const std::string &referer);
+    bool NeedsConfiguration(void) const { return m_bNeedsConfiguration; }
 
     /** @name PVR add-on methods */
     //@{
@@ -668,6 +669,7 @@ namespace PVR
     std::string                                    m_strAvahiType;        /*!< avahi service type */
     std::string                                    m_strAvahiIpSetting;   /*!< add-on setting name to change to the found ip address */
     std::string                                    m_strAvahiPortSetting; /*!< add-on setting name to change to the found port number */
+    bool                                           m_bNeedsConfiguration; /*!< add-on needs a user set configuration */
     std::vector<CZeroconfBrowser::ZeroconfService> m_rejectedAvahiHosts;  /*!< hosts that were rejected by the user */
 
     CCriticalSection m_critSection;

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -1273,6 +1273,7 @@ void CPVRClients::ShowDialogNoClientsEnabled(void)
 bool CPVRClients::UpdateAddons(void)
 {
   VECADDONS addons;
+  PVR_CLIENT addon;
   bool bReturn(CAddonMgr::Get().GetAddons(ADDON_PVRDLL, addons, true));
   size_t usableClients;
 
@@ -1291,8 +1292,12 @@ bool CPVRClients::UpdateAddons(void)
     bool newRegistration = false;
     if (RegisterClient(clientAddon, &newRegistration) < 0 || newRegistration)
     {
-      CAddonMgr::Get().DisableAddon(clientAddon->ID(), true);
-      usableClients--;
+      addon = std::dynamic_pointer_cast<CPVRClient>(clientAddon);
+      if (addon && addon->NeedsConfiguration() && addon->HasSettings() && !addon->HasUserSettings())
+      {
+        CAddonMgr::Get().DisableAddon(clientAddon->ID(), true);
+        usableClients--;
+      }
     }
   }
 

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -1008,17 +1008,17 @@ int CPVRClients::RegisterClient(AddonPtr client, bool* newRegistration/*=NULL*/)
 
   CLog::Log(LOGDEBUG, "%s - registering add-on '%s'", __FUNCTION__, client->Name().c_str());
 
-  CPVRDatabase *database = GetPVRDatabase();
-  if (!database)
+  CAddonDatabase database;
+  if (!database.Open())
     return -1;
 
   // check whether we already know this client
-  iClientId = database->GetClientId(client->ID());
+  iClientId = database.GetAddonId(client); //database->GetClientId(client->ID());
 
   // try to register the new client in the db
   if (iClientId < 0)
   {
-    if ((iClientId = database->Persist(client)) < 0)
+    if ((iClientId = database.AddAddon(client, 0)) < 0)
     {
       CLog::Log(LOGERROR, "PVR - %s - can't add client '%s' to the database", __FUNCTION__, client->Name().c_str());
       return -1;

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -669,10 +669,9 @@ namespace PVR
     /*!
      * @brief Initialise and connect a client.
      * @param client The client to initialise.
-     * @param newRegistration pass in pointer to bool to return whether the client was newly registered.
      * @return The id of the client if it was created or found in the existing client map, -1 otherwise.
      */
-    int RegisterClient(ADDON::AddonPtr client, bool* newRegistration = NULL);
+    int RegisterClient(ADDON::AddonPtr client);
 
     int GetClientId(const ADDON::AddonPtr client) const;
 

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -611,6 +611,12 @@ namespace PVR
     time_t GetBufferTimeStart() const;
     time_t GetBufferTimeEnd() const;
 
+    /**
+     * Called by OnEnable() and OnDisable() to check if the manager should be restarted
+     * @return True if it should be restarted, false otherwise
+     */
+    bool RestartManagerOnAddonDisabled(void) const { return m_bRestartManagerOnAddonDisabled; }
+
   private:
     /*!
      * @brief Update add-ons from the AddonManager
@@ -694,5 +700,6 @@ namespace PVR
     bool                  m_bNoAddonWarningDisplayed; /*!< true when a warning was displayed that no add-ons were found, false otherwise */
     CCriticalSection      m_critSection;
     std::map<int, time_t> m_connectionAttempts;       /*!< last connection attempt per add-on */
+    bool                  m_bRestartManagerOnAddonDisabled; /*!< true to restart the manager when an add-on is enabled/disabled */
   };
 }


### PR DESCRIPTION
this attempts to fix the annoying new add-ons being disabled thing in pvr.

it removes the clients table from pvr, and uses the standard add-ons table for IDs now instead, and only disables new add-ons when they don't have a user set configuration.

add-ons won't be disabled when they have the following in addon.xml in the pvr extension point (this only applies to pvr add-ons): `needs_configuration=false`

it also stops the add-ons from being disabled when the database is reset.

ping @Jalle19 you had another PR for this some time ago, can you test this please
