### PR TITLE
[video] Allow master mode to remove from library

### DIFF
--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -1159,7 +1159,7 @@ bool CGUIWindowVideoNav::OnClick(int iItem)
   if (!item->m_bIsFolder && item->IsVideoDb() && !item->Exists())
   {
     CLog::Log(LOGDEBUG, "%s called on '%s' but file doesn't exist", __FUNCTION__, item->GetPath().c_str());
-    if (CProfilesManager::Get().GetCurrentProfile().canWriteDatabases())
+    if (CProfilesManager::Get().GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser)
     {
       if (!CGUIDialogVideoInfo::DeleteVideoItemFromDatabase(item, true))
         return true;


### PR DESCRIPTION
This is a fixup of issue [#15784](http://trac.kodi.tv/ticket/15784).
Now if the RO user is in master mode he will be able to remove items from the library.

I noticed that this check is commonly used. Therefor wouldn't it be better to wrap this in the `canWriteDatabases()` fuction? So the following [line](https://github.com/delftswa2014/xbmc/blob/master/xbmc/profiles/Profile.h#L66) will become:
 `bool canWriteDatabases() const { return (m_bCanWrite || g_passwordManager.bMasterUser); }`

please let me know what you guys think.
