### PR TITLE
[linux] fix home path detection

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -933,11 +933,11 @@ bool CApplication::InitDirectoriesLinux()
     appPath = appBinPath;
     /* Check if binaries and arch independent data files are being kept in
      * separate locations. */
-    if (!CDirectory::Exists(URIUtils::AddFileToFolder(appPath, "system")))
+    if (!CDirectory::Exists(URIUtils::AddFileToFolder(appPath, "userdata")))
     {
       /* Attempt to locate arch independent data files. */
       CUtil::GetHomePath(appPath);
-      if (!CDirectory::Exists(URIUtils::AddFileToFolder(appPath, "system")))
+      if (!CDirectory::Exists(URIUtils::AddFileToFolder(appPath, "userdata")))
       {
         fprintf(stderr, "Unable to find path to %s data files!\n", appName.c_str());
         exit(1);


### PR DESCRIPTION
According to @wsnipex this fixes the home path detection on linux after #5561 which is currently pointing to the `lib` instead of the `share` directory of Kodi (thanks @notspiff for the investigation).
