### PR TITLE
[linux] use userdata dir to check for arch independent files(KODI_HOME)

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -933,11 +933,11 @@ bool CApplication::InitDirectoriesLinux()
     appPath = appBinPath;
     /* Check if binaries and arch independent data files are being kept in
      * separate locations. */
-    if (!CDirectory::Exists(URIUtils::AddFileToFolder(appPath, "system")))
+    if (!CDirectory::Exists(URIUtils::AddFileToFolder(appPath, "userdata")))
     {
       /* Attempt to locate arch independent data files. */
       CUtil::GetHomePath(appPath);
-      if (!CDirectory::Exists(URIUtils::AddFileToFolder(appPath, "system")))
+      if (!CDirectory::Exists(URIUtils::AddFileToFolder(appPath, "userdata")))
       {
         fprintf(stderr, "Unable to find path to %s data files!\n", appName.c_str());
         exit(1);


### PR DESCRIPTION
fixes special://xbmc/ being wrongly mapped to $prefix/lib/kodi

Since it was my fault :)
@mkortstiege mind giving this a try?
@Montellese fyi
