### PR TITLE
Add short/long date formats, time formats, temperature and speed unit settings

### DIFF
--- a/Kodi.xcodeproj/project.pbxproj
+++ b/Kodi.xcodeproj/project.pbxproj
@@ -244,6 +244,9 @@
 		395F6DE21A81FACF0088CC74 /* HTTPImageTransformationHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 395F6DE01A81FACF0088CC74 /* HTTPImageTransformationHandler.cpp */; };
 		395F6DE31A81FACF0088CC74 /* HTTPImageTransformationHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 395F6DE01A81FACF0088CC74 /* HTTPImageTransformationHandler.cpp */; };
 		395F6DE41A81FACF0088CC74 /* HTTPImageTransformationHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 395F6DE01A81FACF0088CC74 /* HTTPImageTransformationHandler.cpp */; };
+		397877D81AAAF87700F98A45 /* Temperature.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 397877D31AAAF87700F98A45 /* Temperature.cpp */; };
+		397877D91AAAF87700F98A45 /* Temperature.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 397877D31AAAF87700F98A45 /* Temperature.cpp */; };
+		397877DA1AAAF87700F98A45 /* Temperature.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 397877D31AAAF87700F98A45 /* Temperature.cpp */; };
 		3994425B1A8DD8D0006C39E9 /* ProgressJob.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 399442591A8DD8D0006C39E9 /* ProgressJob.cpp */; };
 		3994425C1A8DD8D0006C39E9 /* ProgressJob.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 399442591A8DD8D0006C39E9 /* ProgressJob.cpp */; };
 		3994425D1A8DD8D0006C39E9 /* ProgressJob.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 399442591A8DD8D0006C39E9 /* ProgressJob.cpp */; };
@@ -1828,7 +1831,6 @@
 		DFF0F44517528350002DA3A4 /* PlayListPlayer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1DE90D25F9FD00618676 /* PlayListPlayer.cpp */; };
 		DFF0F44617528350002DA3A4 /* SectionLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1DFE0D25F9FD00618676 /* SectionLoader.cpp */; };
 		DFF0F44717528350002DA3A4 /* SystemGlobals.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C8D0B2AE1265A9A800F0C0AC /* SystemGlobals.cpp */; };
-		DFF0F44817528350002DA3A4 /* Temperature.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E160D25F9FD00618676 /* Temperature.cpp */; };
 		DFF0F44917528350002DA3A4 /* TextureCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C8A14541154CB2600E5FCFA /* TextureCache.cpp */; };
 		DFF0F44A17528350002DA3A4 /* TextureCacheJob.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C1A85631520522500C63311 /* TextureCacheJob.cpp */; };
 		DFF0F44B17528350002DA3A4 /* TextureDatabase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C8A187A115B2A8200E5FCFA /* TextureDatabase.cpp */; };
@@ -2192,7 +2194,6 @@
 		E38E22B40D25F9FE00618676 /* VideoSettings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E010D25F9FD00618676 /* VideoSettings.cpp */; };
 		E38E22B80D25F9FE00618676 /* SlideShowPicture.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E090D25F9FD00618676 /* SlideShowPicture.cpp */; };
 		E38E22BA0D25F9FE00618676 /* Song.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E0D0D25F9FD00618676 /* Song.cpp */; };
-		E38E22BE0D25F9FE00618676 /* Temperature.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E160D25F9FD00618676 /* Temperature.cpp */; };
 		E38E22BF0D25F9FE00618676 /* ThumbLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E180D25F9FD00618676 /* ThumbLoader.cpp */; };
 		E38E22C00D25F9FE00618676 /* ThumbnailCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E1A0D25F9FD00618676 /* ThumbnailCache.cpp */; };
 		E38E22C20D25F9FE00618676 /* URL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E1E0D25F9FD00618676 /* URL.cpp */; };
@@ -3071,7 +3072,6 @@
 		E4991540174E642900741B6D /* PlayListPlayer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1DE90D25F9FD00618676 /* PlayListPlayer.cpp */; };
 		E4991541174E642900741B6D /* SectionLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1DFE0D25F9FD00618676 /* SectionLoader.cpp */; };
 		E4991542174E642900741B6D /* SystemGlobals.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C8D0B2AE1265A9A800F0C0AC /* SystemGlobals.cpp */; };
-		E4991543174E642900741B6D /* Temperature.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E160D25F9FD00618676 /* Temperature.cpp */; };
 		E4991544174E642900741B6D /* TextureCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C8A14541154CB2600E5FCFA /* TextureCache.cpp */; };
 		E4991545174E642900741B6D /* TextureCacheJob.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C1A85631520522500C63311 /* TextureCacheJob.cpp */; };
 		E4991546174E642900741B6D /* TextureDatabase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C8A187A115B2A8200E5FCFA /* TextureDatabase.cpp */; };
@@ -3708,6 +3708,8 @@
 		395F6DDC1A8133360088CC74 /* GUIDialogSimpleMenu.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GUIDialogSimpleMenu.h; sourceTree = "<group>"; };
 		395F6DE01A81FACF0088CC74 /* HTTPImageTransformationHandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = HTTPImageTransformationHandler.cpp; sourceTree = "<group>"; };
 		395F6DE11A81FACF0088CC74 /* HTTPImageTransformationHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HTTPImageTransformationHandler.h; sourceTree = "<group>"; };
+		397877D31AAAF87700F98A45 /* Temperature.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Temperature.cpp; sourceTree = "<group>"; };
+		397877D41AAAF87700F98A45 /* Temperature.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Temperature.h; sourceTree = "<group>"; };
 		399442591A8DD8D0006C39E9 /* ProgressJob.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ProgressJob.cpp; sourceTree = "<group>"; };
 		3994425A1A8DD8D0006C39E9 /* ProgressJob.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ProgressJob.h; sourceTree = "<group>"; };
 		399442611A8DD920006C39E9 /* VideoLibraryCleaningJob.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VideoLibraryCleaningJob.cpp; sourceTree = "<group>"; };
@@ -5488,8 +5490,6 @@
 		E38E1E0D0D25F9FD00618676 /* Song.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Song.cpp; sourceTree = "<group>"; };
 		E38E1E0E0D25F9FD00618676 /* Song.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Song.h; sourceTree = "<group>"; };
 		E38E1E100D25F9FD00618676 /* SortFileItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SortFileItem.h; sourceTree = "<group>"; };
-		E38E1E160D25F9FD00618676 /* Temperature.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Temperature.cpp; sourceTree = "<group>"; };
-		E38E1E170D25F9FD00618676 /* Temperature.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Temperature.h; sourceTree = "<group>"; };
 		E38E1E180D25F9FD00618676 /* ThumbLoader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ThumbLoader.cpp; sourceTree = "<group>"; };
 		E38E1E190D25F9FD00618676 /* ThumbLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ThumbLoader.h; sourceTree = "<group>"; };
 		E38E1E1A0D25F9FD00618676 /* ThumbnailCache.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ThumbnailCache.cpp; sourceTree = "<group>"; };
@@ -8421,8 +8421,6 @@
 				E38E1DFF0D25F9FD00618676 /* SectionLoader.h */,
 				E38E1E100D25F9FD00618676 /* SortFileItem.h */,
 				C8D0B2AE1265A9A800F0C0AC /* SystemGlobals.cpp */,
-				E38E1E160D25F9FD00618676 /* Temperature.cpp */,
-				E38E1E170D25F9FD00618676 /* Temperature.h */,
 				7C8A14541154CB2600E5FCFA /* TextureCache.cpp */,
 				7C8A14551154CB2600E5FCFA /* TextureCache.h */,
 				7C1A85631520522500C63311 /* TextureCacheJob.cpp */,
@@ -9582,6 +9580,8 @@
 				DFD882E617DD189E001516FE /* StringValidation.h */,
 				E38E1E830D25F9FD00618676 /* SystemInfo.cpp */,
 				E38E1E840D25F9FD00618676 /* SystemInfo.h */,
+				397877D31AAAF87700F98A45 /* Temperature.cpp */,
+				397877D41AAAF87700F98A45 /* Temperature.h */,
 				C848291D156D003E005A996F /* TextSearch.cpp */,
 				C848291E156D003E005A996F /* TextSearch.h */,
 				7CEE2E5913D6B71E000ABF2A /* TimeSmoother.cpp */,
@@ -10692,7 +10692,6 @@
 				E38E22B40D25F9FE00618676 /* VideoSettings.cpp in Sources */,
 				E38E22B80D25F9FE00618676 /* SlideShowPicture.cpp in Sources */,
 				E38E22BA0D25F9FE00618676 /* Song.cpp in Sources */,
-				E38E22BE0D25F9FE00618676 /* Temperature.cpp in Sources */,
 				E38E22BF0D25F9FE00618676 /* ThumbLoader.cpp in Sources */,
 				E38E22C00D25F9FE00618676 /* ThumbnailCache.cpp in Sources */,
 				E38E22C20D25F9FE00618676 /* URL.cpp in Sources */,
@@ -10912,6 +10911,7 @@
 				18B7C7B51294222E009E7A26 /* GUICheckMarkControl.cpp in Sources */,
 				18B7C7B61294222E009E7A26 /* GUIColorManager.cpp in Sources */,
 				18B7C7B71294222E009E7A26 /* GUIControl.cpp in Sources */,
+				397877D81AAAF87700F98A45 /* Temperature.cpp in Sources */,
 				18B7C7B81294222E009E7A26 /* GUIControlFactory.cpp in Sources */,
 				18B7C7B91294222E009E7A26 /* GUIControlGroup.cpp in Sources */,
 				18B7C7BA1294222E009E7A26 /* GUIControlGroupList.cpp in Sources */,
@@ -12081,6 +12081,7 @@
 				DFF0F34D17528350002DA3A4 /* PeripheralHID.cpp in Sources */,
 				DFF0F34E17528350002DA3A4 /* PeripheralImon.cpp in Sources */,
 				DFF0F34F17528350002DA3A4 /* PeripheralNIC.cpp in Sources */,
+				397877DA1AAAF87700F98A45 /* Temperature.cpp in Sources */,
 				DFF0F35017528350002DA3A4 /* PeripheralNyxboard.cpp in Sources */,
 				DFF0F35117528350002DA3A4 /* PeripheralTuner.cpp in Sources */,
 				DFF0F35217528350002DA3A4 /* GUIDialogPeripheralManager.cpp in Sources */,
@@ -12313,7 +12314,6 @@
 				DFF0F44517528350002DA3A4 /* PlayListPlayer.cpp in Sources */,
 				DFF0F44617528350002DA3A4 /* SectionLoader.cpp in Sources */,
 				DFF0F44717528350002DA3A4 /* SystemGlobals.cpp in Sources */,
-				DFF0F44817528350002DA3A4 /* Temperature.cpp in Sources */,
 				DFF0F44917528350002DA3A4 /* TextureCache.cpp in Sources */,
 				DFF0F44A17528350002DA3A4 /* TextureCacheJob.cpp in Sources */,
 				DFF0F44B17528350002DA3A4 /* TextureDatabase.cpp in Sources */,
@@ -12641,6 +12641,7 @@
 				E49911B5174E5D0A00741B6D /* emu_msvcrt.cpp in Sources */,
 				E49911B6174E5D0A00741B6D /* coff.cpp in Sources */,
 				E49911B7174E5D0A00741B6D /* dll.cpp in Sources */,
+				397877D91AAAF87700F98A45 /* Temperature.cpp in Sources */,
 				E49911B8174E5D0A00741B6D /* dll_tracker.cpp in Sources */,
 				E49911B9174E5D0A00741B6D /* dll_tracker_file.cpp in Sources */,
 				DF4BF0171A4EF31E0053AC56 /* cc_decoder.c in Sources */,
@@ -13390,7 +13391,6 @@
 				E4991540174E642900741B6D /* PlayListPlayer.cpp in Sources */,
 				E4991541174E642900741B6D /* SectionLoader.cpp in Sources */,
 				E4991542174E642900741B6D /* SystemGlobals.cpp in Sources */,
-				E4991543174E642900741B6D /* Temperature.cpp in Sources */,
 				E4991544174E642900741B6D /* TextureCache.cpp in Sources */,
 				E4991545174E642900741B6D /* TextureCacheJob.cpp in Sources */,
 				E4991546174E642900741B6D /* TextureDatabase.cpp in Sources */,

--- a/Kodi.xcodeproj/project.pbxproj
+++ b/Kodi.xcodeproj/project.pbxproj
@@ -244,6 +244,9 @@
 		395F6DE21A81FACF0088CC74 /* HTTPImageTransformationHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 395F6DE01A81FACF0088CC74 /* HTTPImageTransformationHandler.cpp */; };
 		395F6DE31A81FACF0088CC74 /* HTTPImageTransformationHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 395F6DE01A81FACF0088CC74 /* HTTPImageTransformationHandler.cpp */; };
 		395F6DE41A81FACF0088CC74 /* HTTPImageTransformationHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 395F6DE01A81FACF0088CC74 /* HTTPImageTransformationHandler.cpp */; };
+		397877D51AAAF87700F98A45 /* Speed.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 397877D11AAAF87700F98A45 /* Speed.cpp */; };
+		397877D61AAAF87700F98A45 /* Speed.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 397877D11AAAF87700F98A45 /* Speed.cpp */; };
+		397877D71AAAF87700F98A45 /* Speed.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 397877D11AAAF87700F98A45 /* Speed.cpp */; };
 		397877D81AAAF87700F98A45 /* Temperature.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 397877D31AAAF87700F98A45 /* Temperature.cpp */; };
 		397877D91AAAF87700F98A45 /* Temperature.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 397877D31AAAF87700F98A45 /* Temperature.cpp */; };
 		397877DA1AAAF87700F98A45 /* Temperature.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 397877D31AAAF87700F98A45 /* Temperature.cpp */; };
@@ -3708,6 +3711,8 @@
 		395F6DDC1A8133360088CC74 /* GUIDialogSimpleMenu.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GUIDialogSimpleMenu.h; sourceTree = "<group>"; };
 		395F6DE01A81FACF0088CC74 /* HTTPImageTransformationHandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = HTTPImageTransformationHandler.cpp; sourceTree = "<group>"; };
 		395F6DE11A81FACF0088CC74 /* HTTPImageTransformationHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HTTPImageTransformationHandler.h; sourceTree = "<group>"; };
+		397877D11AAAF87700F98A45 /* Speed.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Speed.cpp; sourceTree = "<group>"; };
+		397877D21AAAF87700F98A45 /* Speed.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Speed.h; sourceTree = "<group>"; };
 		397877D31AAAF87700F98A45 /* Temperature.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Temperature.cpp; sourceTree = "<group>"; };
 		397877D41AAAF87700F98A45 /* Temperature.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Temperature.h; sourceTree = "<group>"; };
 		399442591A8DD8D0006C39E9 /* ProgressJob.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ProgressJob.cpp; sourceTree = "<group>"; };
@@ -9566,6 +9571,8 @@
 				7C1A492215A962EE004AF4A4 /* SeekHandler.h */,
 				36A9443F15821E7C00727135 /* SortUtils.cpp */,
 				36A9444015821E7C00727135 /* SortUtils.h */,
+				397877D11AAAF87700F98A45 /* Speed.cpp */,
+				397877D21AAAF87700F98A45 /* Speed.h */,
 				E38E1E7F0D25F9FD00618676 /* Splash.cpp */,
 				E38E1E800D25F9FD00618676 /* Splash.h */,
 				E38E1E810D25F9FD00618676 /* Stopwatch.cpp */,
@@ -10779,6 +10786,7 @@
 				F5FAB07A0EFABE4A00BAD4AE /* VTPSession.cpp in Sources */,
 				7C5608C70F1754930056433A /* ExternalPlayer.cpp in Sources */,
 				F584E12E0F257C5100DB26A5 /* HTTPDirectory.cpp in Sources */,
+				397877D51AAAF87700F98A45 /* Speed.cpp in Sources */,
 				F54C51D20F1E783200D46E3C /* GUIDialogKaraokeSongSelector.cpp in Sources */,
 				2F4564D51970129A00396109 /* GUIFontCache.cpp in Sources */,
 				F54C51D50F1E784800D46E3C /* karaokelyricscdg.cpp in Sources */,
@@ -11586,6 +11594,7 @@
 				DFF0F16217528350002DA3A4 /* DVDOverlayCodecText.cpp in Sources */,
 				DFF0F16317528350002DA3A4 /* DVDOverlayCodecTX3G.cpp in Sources */,
 				DFF0F16617528350002DA3A4 /* DVDVideoCodecFFmpeg.cpp in Sources */,
+				397877D71AAAF87700F98A45 /* Speed.cpp in Sources */,
 				DFF0F16717528350002DA3A4 /* DVDVideoCodecLibMpeg2.cpp in Sources */,
 				DFF0F16817528350002DA3A4 /* DVDVideoCodecVDA.cpp in Sources */,
 				DFF0F16917528350002DA3A4 /* DVDVideoPPFFmpeg.cpp in Sources */,
@@ -13014,6 +13023,7 @@
 				E4991327174E5DAD00741B6D /* Shader.cpp in Sources */,
 				E4991328174E5DAD00741B6D /* Texture.cpp in Sources */,
 				E4991329174E5DAD00741B6D /* TextureBundle.cpp in Sources */,
+				397877D61AAAF87700F98A45 /* Speed.cpp in Sources */,
 				E499132A174E5DAD00741B6D /* TextureBundleXBT.cpp in Sources */,
 				E499132B174E5DAD00741B6D /* TextureBundleXPR.cpp in Sources */,
 				E499132C174E5DAD00741B6D /* TextureDX.cpp in Sources */,

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -6964,7 +6964,12 @@ msgctxt "#14105"
 msgid "Temperature unit"
 msgstr ""
 
-#empty strings from id 14106 to 15011
+#: system/settings/settings.xml
+msgctxt "#14106"
+msgid "Speed unit"
+msgstr ""
+
+#empty strings from id 14107 to 15011
 
 #: xbmc/video/VideoDatabase.cpp
 msgctxt "#15012"
@@ -14176,7 +14181,11 @@ msgctxt "#36141"
 msgid "Show plot information for unwatched media in the Video Library."
 msgstr ""
 
-#empty string with id 36142
+#.  Description of setting "Appearance -> International -> Speed unit" with label #14106
+#: system/settings/settings.xml
+msgctxt "#36142"
+msgid "Choose which speed unit is used for displaying speeds in the user interface."
+msgstr ""
 
 #. Description of setting "Videos -> Library -> Download actor thumbnails when adding to library" with label #20402
 #: system/settings/settings.xml

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -6959,7 +6959,12 @@ msgctxt "#14104"
 msgid "Show simplified menu"
 msgstr ""
 
-#empty strings from id 14105 to 15011
+#: system/settings/settings.xml
+msgctxt "#14105"
+msgid "Temperature unit"
+msgstr ""
+
+#empty strings from id 14106 to 15011
 
 #: xbmc/video/VideoDatabase.cpp
 msgctxt "#15012"
@@ -9516,6 +9521,13 @@ msgstr ""
 
 #empty strings from id 20027 to 20036
 #string id's 20027 thru 20034 are reserved for temperature strings (LocalizeStrings.cpp)
+
+#: xbmc/LangInfo.cpp
+msgctxt "#20035"
+msgid "Regional (%s)"
+msgstr ""
+
+#empty string with id 20036
 
 msgctxt "#20037"
 msgid "Summary"
@@ -14152,7 +14164,11 @@ msgctxt "#36139"
 msgid "Category containing the settings for how the video library is handled."
 msgstr ""
 
-#empty string with id 36140
+#.  Description of setting "Appearance -> International -> Temperature unit" with label #14105
+#: system/settings/settings.xml
+msgctxt "#36140"
+msgid "Choose which temperature unit is used for displaying temperatures in the user interface."
+msgstr ""
 
 #. Description of setting "Videos -> Library -> Show plot for unwatched items" with label #20369
 #: system/settings/settings.xml

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -1620,11 +1620,13 @@ msgid "Light"
 msgstr ""
 
 #. Weather token
+#: xbmc/LangInfo.cpp
 msgctxt "#378"
 msgid "AM"
 msgstr ""
 
 #. Weather token
+#: xbmc/LangInfo.cpp
 msgctxt "#379"
 msgid "PM"
 msgstr ""
@@ -5018,16 +5020,22 @@ msgctxt "#12379"
 msgid "Use pan and zoom effects"
 msgstr ""
 
-#empty strings from id 12380 to 12382
+#empty strings from id 12380 to 12381
 
-#: unknown
-msgctxt "#12383"
-msgid "12 hour clock"
+#. time format with meridiem (xx) e.g. "HH:mm:ss xx"
+#: xbmc/LangInfo.cpp
+msgctxt "#12382"
+msgid "%s xx"
 msgstr ""
 
-#: unknown
+#: system/settings/settings.xml
+msgctxt "#12383"
+msgid "12-hour clock"
+msgstr ""
+
+#: system/settings/settings.xml
 msgctxt "#12384"
-msgid "24 hour clock"
+msgid "24-hour clock"
 msgstr ""
 
 #: unknown
@@ -6969,7 +6977,17 @@ msgctxt "#14106"
 msgid "Speed unit"
 msgstr ""
 
-#empty strings from id 14107 to 15011
+#: system/settings/settings.xml
+msgctxt "#14107"
+msgid "Time format"
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#14108"
+msgid "Use 12/24-hour format"
+msgstr ""
+
+#empty strings from id 14109 to 15011
 
 #: xbmc/video/VideoDatabase.cpp
 msgctxt "#15012"
@@ -9532,7 +9550,11 @@ msgctxt "#20035"
 msgid "Regional (%s)"
 msgstr ""
 
-#empty string with id 20036
+#. Used for date/time format settings like "10:00:00 (HH:mm:ss)"
+#: xbmc/LangInfo.cpp
+msgctxt "#20036"
+msgid "%s (%s)"
+msgstr ""
 
 msgctxt "#20037"
 msgid "Summary"
@@ -14325,7 +14347,17 @@ msgctxt "#36166"
 msgid "Synchronise the video to the refresh rate of the monitor."
 msgstr ""
 
-#empty strings from id 36167 to 36168
+#. Description of setting "Appearance -> International -> Time format" with label #14107
+#: system/settings/settings.xml
+msgctxt "#36167"
+msgid "Choose which time format is used for displaying the time in the user interface."
+msgstr ""
+
+#. Description of setting "Appearance -> International -> Use 12/24-hour format" with label #14108
+#: system/settings/settings.xml
+msgctxt "#36168"
+msgid "Choose whether to use 12-hour or 24-hour format for displaying the time in the user interface."
+msgstr ""
 
 #. Description of setting "System -> Audio output -> Resample quality" with label #13505
 #: system/settings/settings.xml

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -6987,7 +6987,17 @@ msgctxt "#14108"
 msgid "Use 12/24-hour format"
 msgstr ""
 
-#empty strings from id 14109 to 15011
+#: system/settings/settings.xml
+msgctxt "#14109"
+msgid "Short date format"
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#14110"
+msgid "Long date format"
+msgstr ""
+
+#empty strings from id 14111 to 15011
 
 #: xbmc/video/VideoDatabase.cpp
 msgctxt "#15012"
@@ -14383,7 +14393,11 @@ msgctxt "#36172"
 msgid "VDPAU studio level conversion provides a way for advanced applications like Kodi to influence the colour space conversion."
 msgstr ""
 
-#empty string with id 36173
+#. Description of setting "Appearance -> International -> Short date format" with label #14109
+#: system/settings/settings.xml
+msgctxt "#36173"
+msgid "Choose which short date format is used for displaying the date in the user interface."
+msgstr ""
 
 #. Description of setting "Videos -> Playback -> Activate Teletext" with label #23050
 #: system/settings/settings.xml
@@ -14612,7 +14626,11 @@ msgctxt "#36214"
 msgid "Close the on screen display controls after switching channels."
 msgstr ""
 
-#empty string with id 36215
+#. Description of setting "Appearance -> International -> Long date format" with label #14110
+#: system/settings/settings.xml
+msgctxt "#36215"
+msgid "Choose which long date format is used for displaying the date in the user interface."
+msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#36216"

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -806,7 +806,6 @@
     <ClCompile Include="..\..\xbmc\storage\MediaManager.cpp" />
     <ClCompile Include="..\..\xbmc\storage\windows\Win32StorageProvider.cpp" />
     <ClCompile Include="..\..\xbmc\SystemGlobals.cpp" />
-    <ClCompile Include="..\..\xbmc\Temperature.cpp" />
     <ClCompile Include="..\..\xbmc\test\TestBasicEnvironment.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
@@ -1036,6 +1035,7 @@
     <ClInclude Include="..\..\xbmc\utils\ProgressJob.h" />
     <ClInclude Include="..\..\xbmc\utils\RssManager.h" />
     <ClInclude Include="..\..\xbmc\utils\StringValidation.h" />
+    <ClInclude Include="..\..\xbmc\utils\Temperature.h" />
     <ClInclude Include="..\..\xbmc\utils\Utf8Utils.h" />
     <ClInclude Include="..\..\xbmc\utils\uXstrings.h" />
     <ClInclude Include="..\..\xbmc\utils\Vector.h" />
@@ -1175,6 +1175,7 @@
     <ClCompile Include="..\..\xbmc\utils\ProgressJob.cpp" />
     <ClCompile Include="..\..\xbmc\utils\RssManager.cpp" />
     <ClCompile Include="..\..\xbmc\utils\StringValidation.cpp" />
+    <ClCompile Include="..\..\xbmc\utils\Temperature.cpp" />
     <ClCompile Include="..\..\xbmc\utils\test\TestHttpRangeUtils.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
@@ -2055,7 +2056,6 @@
     <ClInclude Include="..\..\xbmc\storage\MediaManager.h" />
     <ClInclude Include="..\..\xbmc\storage\windows\Win32StorageProvider.h" />
     <ClInclude Include="..\..\xbmc\system.h" />
-    <ClInclude Include="..\..\xbmc\Temperature.h" />
     <ClInclude Include="..\..\xbmc\test\TestBasicEnvironment.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -1034,6 +1034,7 @@
     <ClInclude Include="..\..\xbmc\utils\params_check_macros.h" />
     <ClInclude Include="..\..\xbmc\utils\ProgressJob.h" />
     <ClInclude Include="..\..\xbmc\utils\RssManager.h" />
+    <ClInclude Include="..\..\xbmc\utils\Speed.h" />
     <ClInclude Include="..\..\xbmc\utils\StringValidation.h" />
     <ClInclude Include="..\..\xbmc\utils\Temperature.h" />
     <ClInclude Include="..\..\xbmc\utils\Utf8Utils.h" />
@@ -1174,6 +1175,7 @@
     <ClCompile Include="..\..\xbmc\utils\Locale.cpp" />
     <ClCompile Include="..\..\xbmc\utils\ProgressJob.cpp" />
     <ClCompile Include="..\..\xbmc\utils\RssManager.cpp" />
+    <ClCompile Include="..\..\xbmc\utils\Speed.cpp" />
     <ClCompile Include="..\..\xbmc\utils\StringValidation.cpp" />
     <ClCompile Include="..\..\xbmc\utils\Temperature.cpp" />
     <ClCompile Include="..\..\xbmc\utils\test\TestHttpRangeUtils.cpp">

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -2342,7 +2342,6 @@
     <ClCompile Include="..\..\xbmc\PartyModeManager.cpp" />
     <ClCompile Include="..\..\xbmc\PasswordManager.cpp" />
     <ClCompile Include="..\..\xbmc\SectionLoader.cpp" />
-    <ClCompile Include="..\..\xbmc\Temperature.cpp" />
     <ClCompile Include="..\..\xbmc\TextureCache.cpp" />
     <ClCompile Include="..\..\xbmc\TextureCacheJob.cpp" />
     <ClCompile Include="..\..\xbmc\TextureDatabase.cpp" />
@@ -3173,6 +3172,9 @@
     </ClCompile>
     <ClCompile Include="..\..\xbmc\utils\test\TestLocale.cpp">
       <Filter>utils\test</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\xbmc\utils\Temperature.cpp">
+      <Filter>utils</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -5432,7 +5434,6 @@
     <ClInclude Include="..\..\xbmc\PasswordManager.h" />
     <ClInclude Include="..\..\xbmc\SortFileItem.h" />
     <ClInclude Include="..\..\xbmc\SectionLoader.h" />
-    <ClInclude Include="..\..\xbmc\Temperature.h" />
     <ClInclude Include="..\..\xbmc\TextureCache.h" />
     <ClInclude Include="..\..\xbmc\TextureCacheJob.h" />
     <ClInclude Include="..\..\xbmc\TextureDatabase.h" />
@@ -6166,6 +6167,9 @@
     </ClInclude>
     <ClInclude Include="..\..\xbmc\addons\AudioDecoder.h">
       <Filter>addons</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\utils\Temperature.h">
+      <Filter>utils</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -3176,6 +3176,9 @@
     <ClCompile Include="..\..\xbmc\utils\Temperature.cpp">
       <Filter>utils</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\utils\Speed.cpp">
+      <Filter>utils</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\xbmc\win32\pch.h">
@@ -6169,6 +6172,9 @@
       <Filter>addons</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\utils\Temperature.h">
+      <Filter>utils</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\utils\Speed.h">
       <Filter>utils</Filter>
     </ClInclude>
   </ItemGroup>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -193,6 +193,17 @@
           </dependencies>
           <control type="list" format="string" />
         </setting>
+        <setting id="locale.speedunit" type="string" label="14106" help="36142">
+          <level>1</level>
+          <default>regional</default>
+          <constraints>
+            <options>speedunits</options>
+          </constraints>
+          <dependencies>
+            <dependency type="update" setting="locale.country" />
+          </dependencies>
+          <control type="list" format="string" />
+        </setting>
       </group>
     </category>
     <category id="filelists" label="14081" help="36121">

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -182,6 +182,28 @@
         </setting>
       </group>
       <group id="3">
+        <setting id="locale.shortdateformat" type="string" label="14109" help="36173">
+          <level>1</level>
+          <default>regional</default>
+          <constraints>
+            <options>shortdateformats</options>
+          </constraints>
+          <dependencies>
+            <dependency type="update" setting="locale.country" />
+          </dependencies>
+          <control type="list" format="string" />
+        </setting>
+        <setting id="locale.longdateformat" type="string" label="14110" help="36215">
+          <level>1</level>
+          <default>regional</default>
+          <constraints>
+            <options>longdateformats</options>
+          </constraints>
+          <dependencies>
+            <dependency type="update" setting="locale.country" />
+          </dependencies>
+          <control type="list" format="string" />
+        </setting>
         <setting id="locale.timeformat" type="string" label="14107" help="36167">
           <level>1</level>
           <default>regional</default>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -182,6 +182,31 @@
         </setting>
       </group>
       <group id="3">
+        <setting id="locale.timeformat" type="string" label="14107" help="36167">
+          <level>1</level>
+          <default>regional</default>
+          <constraints>
+            <options>timeformats</options>
+          </constraints>
+          <dependencies>
+            <dependency type="update" setting="locale.country" />
+            <dependency type="update" setting="locale.use24hourclock" />
+          </dependencies>
+          <control type="list" format="string" />
+        </setting>
+        <setting id="locale.use24hourclock" type="string" label="14108" help="36168">
+          <level>1</level>
+          <default>regional</default>
+          <constraints>
+            <options>24hourclockformats</options>
+          </constraints>
+          <dependencies>
+            <dependency type="update" setting="locale.country" />
+          </dependencies>
+          <control type="spinner" format="string" />
+        </setting>
+      </group>
+      <group id="4">
         <setting id="locale.temperatureunit" type="string" label="14105" help="36140">
           <level>1</level>
           <default>regional</default>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -181,6 +181,19 @@
           <control type="list" format="string" />
         </setting>
       </group>
+      <group id="3">
+        <setting id="locale.temperatureunit" type="string" label="14105" help="36140">
+          <level>1</level>
+          <default>regional</default>
+          <constraints>
+            <options>temperatureunits</options>
+          </constraints>
+          <dependencies>
+            <dependency type="update" setting="locale.country" />
+          </dependencies>
+          <control type="list" format="string" />
+        </setting>
+      </group>
     </category>
     <category id="filelists" label="14081" help="36121">
       <group id="1">

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1465,7 +1465,7 @@ std::string CGUIInfoManager::GetLabel(int info, int contextWindow, std::string *
   case WEATHER_TEMPERATURE:
     strLabel = StringUtils::Format("%s%s",
                                    g_weatherManager.GetInfo(WEATHER_LABEL_CURRENT_TEMP).c_str(),
-                                   g_langInfo.GetTempUnitString().c_str());
+                                   g_langInfo.GetTemperatureUnitString().c_str());
     break;
   case WEATHER_LOCATION:
     strLabel = g_weatherManager.GetInfo(WEATHER_LABEL_LOCATION);
@@ -1928,7 +1928,7 @@ std::string CGUIInfoManager::GetLabel(int info, int contextWindow, std::string *
     strLabel = g_langInfo.GetEnglishLanguageName();
     break;
   case SYSTEM_TEMPERATURE_UNITS:
-    strLabel = g_langInfo.GetTempUnitString();
+    strLabel = g_langInfo.GetTemperatureUnitString();
     break;
   case SYSTEM_PROGRESS_BAR:
     {
@@ -4232,10 +4232,10 @@ string CGUIInfoManager::GetSystemHeatInfo(int info)
   switch(info)
   {
     case SYSTEM_CPU_TEMPERATURE:
-      return m_cpuTemp.IsValid() ? m_cpuTemp.ToString() : "?";
+      return m_cpuTemp.IsValid() ? g_langInfo.GetTemperatureAsString(m_cpuTemp) : "?";
       break;
     case SYSTEM_GPU_TEMPERATURE:
-      return m_gpuTemp.IsValid() ? m_gpuTemp.ToString() : "?";
+      return m_gpuTemp.IsValid() ? g_langInfo.GetTemperatureAsString(m_gpuTemp) : "?";
       break;
     case SYSTEM_FAN_SPEED:
       text = StringUtils::Format("%i%%", m_fanSpeed * 2);

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -26,12 +26,12 @@
  *
  */
 
-#include "Temperature.h"
 #include "threads/CriticalSection.h"
 #include "guilib/IMsgTargetCallback.h"
 #include "inttypes.h"
 #include "XBDateTime.h"
 #include "utils/Observer.h"
+#include "utils/Temperature.h"
 #include "interfaces/info/InfoBool.h"
 #include "interfaces/info/SkinVariable.h"
 #include "cores/IPlayer.h"

--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -98,30 +98,30 @@ void CLangInfo::CRegion::SetDefaults()
   m_strDateFormatShort="DD/MM/YYYY";
   m_strDateFormatLong="DDDD, D MMMM YYYY";
   m_strTimeFormat="HH:mm:ss";
-  m_tempUnit=TEMP_UNIT_CELSIUS;
+  m_tempUnit = CTemperature::UnitCelsius;
   m_speedUnit=SPEED_UNIT_KMH;
   m_strTimeZone.clear();
 }
 
-void CLangInfo::CRegion::SetTempUnit(const std::string& strUnit)
+void CLangInfo::CRegion::SetTemperatureUnit(const std::string& strUnit)
 {
   std::string unit(strUnit); StringUtils::ToLower(unit);
   if (unit == "f")
-    m_tempUnit=TEMP_UNIT_FAHRENHEIT;
+    m_tempUnit = CTemperature::UnitFahrenheit;
   else if (unit == "k")
-    m_tempUnit=TEMP_UNIT_KELVIN;
+    m_tempUnit = CTemperature::UnitKelvin;
   else if (unit == "c")
-    m_tempUnit=TEMP_UNIT_CELSIUS;
+    m_tempUnit = CTemperature::UnitCelsius;
   else if (unit == "re")
-    m_tempUnit=TEMP_UNIT_REAUMUR;
+    m_tempUnit = CTemperature::UnitReaumur;
   else if (unit == "ra")
-    m_tempUnit=TEMP_UNIT_RANKINE;
+    m_tempUnit = CTemperature::UnitRankine;
   else if (unit == "ro")
-    m_tempUnit=TEMP_UNIT_ROMER;
+    m_tempUnit = CTemperature::UnitRomer;
   else if (unit == "de")
-    m_tempUnit=TEMP_UNIT_DELISLE;
+    m_tempUnit = CTemperature::UnitDelisle;
   else if (unit == "n")
-    m_tempUnit=TEMP_UNIT_NEWTON;
+    m_tempUnit = CTemperature::UnitNewton;
 }
 
 void CLangInfo::CRegion::SetSpeedUnit(const std::string& strUnit)
@@ -351,7 +351,7 @@ bool CLangInfo::Load(const std::string& strLanguage, bool onlyCheckLanguage /*= 
 
       const TiXmlNode *pTempUnit=pRegion->FirstChild("tempunit");
       if (pTempUnit && !pTempUnit->NoChildren())
-        region.SetTempUnit(pTempUnit->FirstChild()->ValueStr());
+        region.SetTemperatureUnit(pTempUnit->FirstChild()->ValueStr());
 
       const TiXmlNode *pSpeedUnit=pRegion->FirstChild("speedunit");
       if (pSpeedUnit && !pSpeedUnit->NoChildren())
@@ -741,15 +741,29 @@ const std::string& CLangInfo::GetCurrentRegion() const
   return m_currentRegion->m_strName;
 }
 
-CLangInfo::TEMP_UNIT CLangInfo::GetTempUnit() const
+CTemperature::Unit CLangInfo::GetTemperatureUnit() const
 {
   return m_currentRegion->m_tempUnit;
 }
 
-// Returns the temperature unit string for the current language
-const std::string& CLangInfo::GetTempUnitString() const
+std::string CLangInfo::GetTemperatureAsString(const CTemperature& temperature) const
 {
-  return g_localizeStrings.Get(TEMP_UNIT_STRINGS+m_currentRegion->m_tempUnit);
+  if (!temperature.IsValid())
+    return g_localizeStrings.Get(13205); // "Unknown"
+
+  CTemperature::Unit temperatureUnit = GetTemperatureUnit();
+  return StringUtils::Format("%s%s", temperature.ToString(temperatureUnit).c_str(), GetTemperatureUnitString().c_str());
+}
+
+// Returns the temperature unit string for the current language
+const std::string& CLangInfo::GetTemperatureUnitString() const
+{
+  return GetTemperatureUnitString(m_currentRegion->m_tempUnit);
+}
+
+const std::string& CLangInfo::GetTemperatureUnitString(CTemperature::Unit temperatureUnit)
+{
+  return g_localizeStrings.Get(TEMP_UNIT_STRINGS + temperatureUnit);
 }
 
 CLangInfo::SPEED_UNIT CLangInfo::GetSpeedUnit() const

--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -962,3 +962,31 @@ void CLangInfo::SettingOptionsTemperatureUnitsFiller(const CSetting *setting, st
   if (!match && !list.empty())
     current = list[0].second;
 }
+
+void CLangInfo::SettingOptionsSpeedUnitsFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data)
+{
+  bool match = false;
+  const std::string& speedUnitSetting = static_cast<const CSettingString*>(setting)->GetValue();
+
+  list.push_back(std::make_pair(StringUtils::Format(g_localizeStrings.Get(20035).c_str(), GetSpeedUnitString(g_langInfo.m_currentRegion->m_speedUnit).c_str()), SETTING_REGIONAL_DEFAULT));
+  if (speedUnitSetting == SETTING_REGIONAL_DEFAULT)
+  {
+    match = true;
+    current = SETTING_REGIONAL_DEFAULT;
+  }
+
+  for (size_t i = 0; i < SPEED_INFO_SIZE; i++)
+  {
+    const SpeedInfo& info = speedInfo[i];
+    list.push_back(std::make_pair(GetSpeedUnitString(info.unit), info.name));
+
+    if (!match && speedUnitSetting == info.name)
+    {
+      match = true;
+      current = info.name;
+    }
+  }
+
+  if (!match && !list.empty())
+    current = list[0].second;
+}

--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -314,16 +314,16 @@ bool CLangInfo::Load(const std::string& strLanguage, bool onlyCheckLanguage /*= 
   // Windows need 3 chars isolang code
   if (m_defaultRegion.m_strLangLocaleName.length() == 2)
   {
-    if (! g_LangCodeExpander.ConvertTwoToThreeCharCode(m_defaultRegion.m_strLangLocaleName, m_defaultRegion.m_strLangLocaleName, true))
+    if (!g_LangCodeExpander.ConvertISO6391ToISO6392T(m_defaultRegion.m_strLangLocaleName, m_defaultRegion.m_strLangLocaleName, true))
       m_defaultRegion.m_strLangLocaleName = "";
   }
 
-  if (!g_LangCodeExpander.ConvertWindowsToGeneralCharCode(m_defaultRegion.m_strLangLocaleName, m_languageCodeGeneral))
+  if (!g_LangCodeExpander.ConvertWindowsLanguageCodeToISO6392T(m_defaultRegion.m_strLangLocaleName, m_languageCodeGeneral))
     m_languageCodeGeneral = "";
 #else
   if (m_defaultRegion.m_strLangLocaleName.length() != 3)
   {
-    if (!g_LangCodeExpander.ConvertToThreeCharCode(m_languageCodeGeneral, m_defaultRegion.m_strLangLocaleName, !onlyCheckLanguage))
+    if (!g_LangCodeExpander.ConvertToISO6392T(m_defaultRegion.m_strLangLocaleName, m_languageCodeGeneral, !onlyCheckLanguage))
       m_languageCodeGeneral = "";
   }
   else
@@ -331,7 +331,7 @@ bool CLangInfo::Load(const std::string& strLanguage, bool onlyCheckLanguage /*= 
 #endif
 
   std::string tmp;
-  if (g_LangCodeExpander.ConvertToTwoCharCode(tmp, m_defaultRegion.m_strLangLocaleName))
+  if (g_LangCodeExpander.ConvertToISO6391(m_defaultRegion.m_strLangLocaleName, tmp))
     m_defaultRegion.m_strLangLocaleCodeTwoChar = tmp;
 
   const TiXmlNode *pRegions = pRootElement->FirstChild("regions");
@@ -352,7 +352,7 @@ bool CLangInfo::Load(const std::string& strLanguage, bool onlyCheckLanguage /*= 
       // Windows need 3 chars regions code
       if (region.m_strRegionLocaleName.length() == 2)
       {
-        if (! g_LangCodeExpander.ConvertLinuxToWindowsRegionCodes(region.m_strRegionLocaleName, region.m_strRegionLocaleName))
+        if (!g_LangCodeExpander.ConvertISO36111Alpha2ToISO36111Alpha3(region.m_strRegionLocaleName, region.m_strRegionLocaleName))
           region.m_strRegionLocaleName = "";
       }
 #endif
@@ -640,7 +640,7 @@ void CLangInfo::SetAudioLanguage(const std::string& language)
   if (language.empty()
     || StringUtils::EqualsNoCase(language, "default")
     || StringUtils::EqualsNoCase(language, "original")
-    || !g_LangCodeExpander.ConvertToThreeCharCode(m_audioLanguage, language))
+    || !g_LangCodeExpander.ConvertToISO6392T(language, m_audioLanguage))
     m_audioLanguage.clear();
 }
 
@@ -658,7 +658,7 @@ void CLangInfo::SetSubtitleLanguage(const std::string& language)
   if (language.empty()
     || StringUtils::EqualsNoCase(language, "default")
     || StringUtils::EqualsNoCase(language, "original")
-    || !g_LangCodeExpander.ConvertToThreeCharCode(m_subtitleLanguage, language))
+    || !g_LangCodeExpander.ConvertToISO6392T(language, m_subtitleLanguage))
     m_subtitleLanguage.clear();
 }
 
@@ -666,7 +666,7 @@ void CLangInfo::SetSubtitleLanguage(const std::string& language)
 const std::string CLangInfo::GetDVDMenuLanguage() const
 {
   std::string code;
-  if (!g_LangCodeExpander.ConvertToTwoCharCode(code, m_currentRegion->m_strLangLocaleName))
+  if (!g_LangCodeExpander.ConvertToISO6391(m_currentRegion->m_strLangLocaleName, code))
     code = m_strDVDMenuLanguage;
   
   return code;
@@ -676,7 +676,7 @@ const std::string CLangInfo::GetDVDMenuLanguage() const
 const std::string CLangInfo::GetDVDAudioLanguage() const
 {
   std::string code;
-  if (!g_LangCodeExpander.ConvertToTwoCharCode(code, m_audioLanguage))
+  if (!g_LangCodeExpander.ConvertToISO6391(m_audioLanguage, code))
     code = m_strDVDAudioLanguage;
   
   return code;
@@ -686,7 +686,7 @@ const std::string CLangInfo::GetDVDAudioLanguage() const
 const std::string CLangInfo::GetDVDSubtitleLanguage() const
 {
   std::string code;
-  if (!g_LangCodeExpander.ConvertToTwoCharCode(code, m_subtitleLanguage))
+  if (!g_LangCodeExpander.ConvertToISO6391(m_subtitleLanguage, code))
     code = m_strDVDSubtitleLanguage;
   
   return code;

--- a/xbmc/LangInfo.h
+++ b/xbmc/LangInfo.h
@@ -142,7 +142,12 @@ public:
 
   bool ForceUnicodeFont() const { return m_forceUnicodeFont; }
 
-  const std::string& GetDateFormat(bool bLongDate=false) const;
+  const std::string& GetDateFormat(bool bLongDate = false) const;
+  void SetDateFormat(const std::string& dateFormat, bool bLongDate = false);
+  const std::string& GetShortDateFormat() const;
+  void SetShortDateFormat(const std::string& shortDateFormat);
+  const std::string& GetLongDateFormat() const;
+  void SetLongDateFormat(const std::string& longDateFormat);
 
   const std::string& GetTimeFormat() const;
   void SetTimeFormat(const std::string& timeFormat);
@@ -182,6 +187,8 @@ public:
   static void SettingOptionsLanguageNamesFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data);
   static void SettingOptionsStreamLanguagesFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data);
   static void SettingOptionsRegionsFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data);
+  static void SettingOptionsShortDateFormatsFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data);
+  static void SettingOptionsLongDateFormatsFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data);
   static void SettingOptionsTimeFormatsFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data);
   static void SettingOptions24HourClockFormatsFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data);
   static void SettingOptionsTemperatureUnitsFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data);
@@ -238,6 +245,8 @@ protected:
   std::string m_strDVDSubtitleLanguage;
   std::set<std::string> m_sortTokens;
 
+  std::string m_shortDateFormat;
+  std::string m_longDateFormat;
   std::string m_timeFormat;
   bool m_use24HourClock;
   CTemperature::Unit m_temperatureUnit;

--- a/xbmc/LangInfo.h
+++ b/xbmc/LangInfo.h
@@ -50,6 +50,12 @@ namespace ADDON
 }
 typedef std::shared_ptr<ADDON::CLanguageResource> LanguageResourcePtr;
 
+typedef enum MeridiemSymbol
+{
+  MeridiemSymbolPM = 0,
+  MeridiemSymbolAM
+} MeridiemSymbol;
+
 class CLangInfo : public ISettingCallback, public ISettingsHandler
 {
 public:
@@ -138,15 +144,12 @@ public:
 
   const std::string& GetDateFormat(bool bLongDate=false) const;
 
-  typedef enum _MERIDIEM_SYMBOL
-  {
-    MERIDIEM_SYMBOL_PM=0,
-    MERIDIEM_SYMBOL_AM,
-    MERIDIEM_SYMBOL_MAX
-  } MERIDIEM_SYMBOL;
-
   const std::string& GetTimeFormat() const;
-  const std::string& GetMeridiemSymbol(MERIDIEM_SYMBOL symbol) const;
+  void SetTimeFormat(const std::string& timeFormat);
+  bool Use24HourClock() const;
+  void Set24HourClock(bool use24HourClock);
+  void Set24HourClock(const std::string& str24HourClock);
+  const std::string& GetMeridiemSymbol(MeridiemSymbol symbol) const;
 
   CTemperature::Unit GetTemperatureUnit() const;
   void SetTemperatureUnit(CTemperature::Unit temperatureUnit);
@@ -179,11 +182,17 @@ public:
   static void SettingOptionsLanguageNamesFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data);
   static void SettingOptionsStreamLanguagesFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data);
   static void SettingOptionsRegionsFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data);
+  static void SettingOptionsTimeFormatsFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data);
+  static void SettingOptions24HourClockFormatsFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data);
   static void SettingOptionsTemperatureUnitsFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data);
   static void SettingOptionsSpeedUnitsFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data);
 
 protected:
   void SetDefaults();
+
+  static bool DetermineUse24HourClockFromTimeFormat(const std::string& timeFormat);
+  static bool DetermineUseMeridiemFromTimeFormat(const std::string& timeFormat);
+  static std::string PrepareTimeFormat(const std::string& timeFormat, bool use24HourClock);
 
   class CRegion
   {
@@ -203,7 +212,7 @@ protected:
     std::string m_strDateFormatLong;
     std::string m_strDateFormatShort;
     std::string m_strTimeFormat;
-    std::string m_strMeridiemSymbols[MERIDIEM_SYMBOL_MAX];
+    std::string m_strMeridiemSymbols[2];
     std::string m_strTimeZone;
 
     CTemperature::Unit m_tempUnit;
@@ -229,6 +238,8 @@ protected:
   std::string m_strDVDSubtitleLanguage;
   std::set<std::string> m_sortTokens;
 
+  std::string m_timeFormat;
+  bool m_use24HourClock;
   CTemperature::Unit m_temperatureUnit;
   CSpeed::Unit m_speedUnit;
 

--- a/xbmc/LangInfo.h
+++ b/xbmc/LangInfo.h
@@ -23,6 +23,7 @@
 #include "settings/lib/ISettingsHandler.h"
 #include "utils/GlobalsHandling.h"
 #include "utils/Locale.h"
+#include "utils/Speed.h"
 #include "utils/Temperature.h"
 
 #include <map>
@@ -154,24 +155,12 @@ public:
   static const std::string& GetTemperatureUnitString(CTemperature::Unit temperatureUnit);
   std::string GetTemperatureAsString(const CTemperature& temperature) const;
 
-  typedef enum _SPEED_UNIT
-  {
-    SPEED_UNIT_KMH=0, // kilemetre per hour
-    SPEED_UNIT_MPMIN, // metres per minute
-    SPEED_UNIT_MPS, // metres per second
-    SPEED_UNIT_FTH, // feet per hour
-    SPEED_UNIT_FTMIN, // feet per minute
-    SPEED_UNIT_FTS, // feet per second
-    SPEED_UNIT_MPH, // miles per hour
-    SPEED_UNIT_KTS, // knots
-    SPEED_UNIT_BEAUFORT, // beaufort
-    SPEED_UNIT_INCHPS, // inch per second
-    SPEED_UNIT_YARDPS, // yard per second
-    SPEED_UNIT_FPF // Furlong per Fortnight
-  } SPEED_UNIT;
-
+  CSpeed::Unit GetSpeedUnit() const;
+  void SetSpeedUnit(CSpeed::Unit speedUnit);
+  void SetSpeedUnit(const std::string& speedUnit);
   const std::string& GetSpeedUnitString() const;
-  CLangInfo::SPEED_UNIT GetSpeedUnit() const;
+  static const std::string& GetSpeedUnitString(CSpeed::Unit speedUnit);
+  std::string GetSpeedAsString(const CSpeed& speed) const;
 
   void GetRegionNames(std::vector<std::string>& array);
   void SetCurrentRegion(const std::string& strName);
@@ -217,7 +206,7 @@ protected:
     std::string m_strTimeZone;
 
     CTemperature::Unit m_tempUnit;
-    SPEED_UNIT m_speedUnit;
+    CSpeed::Unit m_speedUnit;
   };
 
 
@@ -240,6 +229,7 @@ protected:
   std::set<std::string> m_sortTokens;
 
   CTemperature::Unit m_temperatureUnit;
+  CSpeed::Unit m_speedUnit;
 
   std::string m_audioLanguage;
   std::string m_subtitleLanguage;

--- a/xbmc/LangInfo.h
+++ b/xbmc/LangInfo.h
@@ -22,6 +22,7 @@
 #include "settings/lib/ISettingCallback.h"
 #include "utils/GlobalsHandling.h"
 #include "utils/Locale.h"
+#include "utils/Temperature.h"
 
 #include <map>
 #include <memory>
@@ -141,21 +142,10 @@ public:
   const std::string& GetTimeFormat() const;
   const std::string& GetMeridiemSymbol(MERIDIEM_SYMBOL symbol) const;
 
-  typedef enum _TEMP_UNIT
-  {
-    TEMP_UNIT_FAHRENHEIT=0,
-    TEMP_UNIT_KELVIN,
-    TEMP_UNIT_CELSIUS,
-    TEMP_UNIT_REAUMUR,
-    TEMP_UNIT_RANKINE,
-    TEMP_UNIT_ROMER,
-    TEMP_UNIT_DELISLE,
-    TEMP_UNIT_NEWTON
-  } TEMP_UNIT;
-
-  const std::string& GetTempUnitString() const;
-  CLangInfo::TEMP_UNIT GetTempUnit() const;
-
+  CTemperature::Unit GetTemperatureUnit() const;
+  const std::string& GetTemperatureUnitString() const;
+  static const std::string& GetTemperatureUnitString(CTemperature::Unit temperatureUnit);
+  std::string GetTemperatureAsString(const CTemperature& temperature) const;
 
   typedef enum _SPEED_UNIT
   {
@@ -204,7 +194,7 @@ protected:
     CRegion();
     virtual ~CRegion();
     void SetDefaults();
-    void SetTempUnit(const std::string& strUnit);
+    void SetTemperatureUnit(const std::string& strUnit);
     void SetSpeedUnit(const std::string& strUnit);
     void SetTimeZone(const std::string& strTimeZone);
     void SetGlobalLocale();
@@ -218,7 +208,7 @@ protected:
     std::string m_strMeridiemSymbols[MERIDIEM_SYMBOL_MAX];
     std::string m_strTimeZone;
 
-    TEMP_UNIT m_tempUnit;
+    CTemperature::Unit m_tempUnit;
     SPEED_UNIT m_speedUnit;
   };
 

--- a/xbmc/LangInfo.h
+++ b/xbmc/LangInfo.h
@@ -180,6 +180,7 @@ public:
   static void SettingOptionsStreamLanguagesFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data);
   static void SettingOptionsRegionsFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data);
   static void SettingOptionsTemperatureUnitsFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data);
+  static void SettingOptionsSpeedUnitsFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data);
 
 protected:
   void SetDefaults();

--- a/xbmc/LangInfo.h
+++ b/xbmc/LangInfo.h
@@ -20,6 +20,7 @@
  */
 
 #include "settings/lib/ISettingCallback.h"
+#include "settings/lib/ISettingsHandler.h"
 #include "utils/GlobalsHandling.h"
 #include "utils/Locale.h"
 #include "utils/Temperature.h"
@@ -48,13 +49,17 @@ namespace ADDON
 }
 typedef std::shared_ptr<ADDON::CLanguageResource> LanguageResourcePtr;
 
-class CLangInfo : public ISettingCallback
+class CLangInfo : public ISettingCallback, public ISettingsHandler
 {
 public:
   CLangInfo();
   virtual ~CLangInfo();
 
+  // implementation of ISettingCallback
   virtual void OnSettingChanged(const CSetting *setting);
+
+  // implementation of ISettingsHandler
+  virtual void OnSettingsLoaded();
 
   bool Load(const std::string& strLanguage, bool onlyCheckLanguage = false);
 
@@ -143,6 +148,8 @@ public:
   const std::string& GetMeridiemSymbol(MERIDIEM_SYMBOL symbol) const;
 
   CTemperature::Unit GetTemperatureUnit() const;
+  void SetTemperatureUnit(CTemperature::Unit temperatureUnit);
+  void SetTemperatureUnit(const std::string& temperatureUnit);
   const std::string& GetTemperatureUnitString() const;
   static const std::string& GetTemperatureUnitString(CTemperature::Unit temperatureUnit);
   std::string GetTemperatureAsString(const CTemperature& temperature) const;
@@ -183,6 +190,7 @@ public:
   static void SettingOptionsLanguageNamesFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data);
   static void SettingOptionsStreamLanguagesFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data);
   static void SettingOptionsRegionsFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data);
+  static void SettingOptionsTemperatureUnitsFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data);
 
 protected:
   void SetDefaults();
@@ -230,6 +238,8 @@ protected:
   std::string m_strDVDAudioLanguage;
   std::string m_strDVDSubtitleLanguage;
   std::set<std::string> m_sortTokens;
+
+  CTemperature::Unit m_temperatureUnit;
 
   std::string m_audioLanguage;
   std::string m_subtitleLanguage;

--- a/xbmc/Makefile.in
+++ b/xbmc/Makefile.in
@@ -25,7 +25,6 @@ SRCS=Application.cpp \
      PartyModeManager.cpp \
      SectionLoader.cpp \
      SystemGlobals.cpp \
-     Temperature.cpp \
      TextureCache.cpp \
      TextureCacheJob.cpp \
      TextureDatabase.cpp \

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -2168,7 +2168,7 @@ void CUtil::GetExternalStreamDetailsFromFilename(const std::string& strVideo, co
         std::string langTmp(*it);
         std::string langCode;
         // try to recognize language
-        if (g_LangCodeExpander.ConvertToThreeCharCode(langCode, langTmp))
+        if (g_LangCodeExpander.ConvertToISO6392T(langTmp, langCode))
         {
           info.language = langCode;
           continue;

--- a/xbmc/XBDateTime.cpp
+++ b/xbmc/XBDateTime.cpp
@@ -1115,7 +1115,7 @@ std::string CDateTime::GetAsLocalizedTime(const std::string &format, bool withSe
   GetAsSystemTime(dateTime);
 
   // Prefetch meridiem symbol
-  const std::string& strMeridiem=g_langInfo.GetMeridiemSymbol(dateTime.wHour > 11 ? CLangInfo::MERIDIEM_SYMBOL_PM : CLangInfo::MERIDIEM_SYMBOL_AM);
+  const std::string& strMeridiem = g_langInfo.GetMeridiemSymbol(dateTime.wHour > 11 ? MeridiemSymbolPM : MeridiemSymbolAM);
 
   size_t length = strFormat.size();
   for (size_t i=0; i < length; ++i)

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -882,10 +882,7 @@ bool CDVDInputStreamNavigator::GetSubtitleStreamInfo(const int iId, DVDNavStream
     lang[1] = (subp_attributes.lang_code & 255);
     lang[0] = (subp_attributes.lang_code >> 8) & 255;
 
-    std::string temp;
-    g_LangCodeExpander.ConvertToThreeCharCode(temp, lang);
-    info.language = temp;
-
+    g_LangCodeExpander.ConvertToISO6392T(lang, info.language);
     return true;
   }
   return false;
@@ -1068,9 +1065,7 @@ bool CDVDInputStreamNavigator::GetAudioStreamInfo(const int iId, DVDNavStreamInf
     lang[1] = (audio_attributes.lang_code & 255);
     lang[0] = (audio_attributes.lang_code >> 8) & 255;
 
-    std::string temp;
-    g_LangCodeExpander.ConvertToThreeCharCode(temp, lang);
-    info.language = temp;
+    g_LangCodeExpander.ConvertToISO6392T(lang, info.language);
 
     info.channels = audio_attributes.channels + 1;
 

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -174,7 +174,7 @@ public:
     if(STREAM_SOURCE_MASK(ss.source) == STREAM_SOURCE_DEMUX_SUB || STREAM_SOURCE_MASK(ss.source) == STREAM_SOURCE_TEXT)
       return false;
 
-    if ((ss.flags & CDemuxStream::FLAG_FORCED) && (original || g_LangCodeExpander.CompareLangCodes(ss.language, audiolang)))
+    if ((ss.flags & CDemuxStream::FLAG_FORCED) && (original || g_LangCodeExpander.CompareISO639Codes(ss.language, audiolang)))
       return false;
 
     if ((ss.flags & CDemuxStream::FLAG_DEFAULT))
@@ -183,7 +183,7 @@ public:
     if(!original)
     {
       std::string subtitle_language = g_langInfo.GetSubtitleLanguage();
-      if (g_LangCodeExpander.CompareLangCodes(subtitle_language, ss.language))
+      if (g_LangCodeExpander.CompareISO639Codes(subtitle_language, ss.language))
         return false;
     }
 
@@ -199,8 +199,8 @@ static bool PredicateAudioPriority(const SelectionStream& lh, const SelectionStr
   if(!StringUtils::EqualsNoCase(CSettings::Get().GetString("locale.audiolanguage"), "original"))
   {
     std::string audio_language = g_langInfo.GetAudioLanguage();
-    PREDICATE_RETURN(g_LangCodeExpander.CompareLangCodes(audio_language, lh.language)
-                   , g_LangCodeExpander.CompareLangCodes(audio_language, rh.language));
+    PREDICATE_RETURN(g_LangCodeExpander.CompareISO639Codes(audio_language, lh.language)
+                   , g_LangCodeExpander.CompareISO639Codes(audio_language, rh.language));
 
     bool hearingimp = CSettings::Get().GetBool("accessibility.audiohearing");
     PREDICATE_RETURN(!hearingimp ? !(lh.flags & CDemuxStream::FLAG_HEARING_IMPAIRED) : lh.flags & CDemuxStream::FLAG_HEARING_IMPAIRED
@@ -275,8 +275,8 @@ public:
 
     if(!subson || original)
     {
-      PREDICATE_RETURN(lh.flags & CDemuxStream::FLAG_FORCED && g_LangCodeExpander.CompareLangCodes(lh.language, audiolang)
-                     , rh.flags & CDemuxStream::FLAG_FORCED && g_LangCodeExpander.CompareLangCodes(rh.language, audiolang));
+      PREDICATE_RETURN(lh.flags & CDemuxStream::FLAG_FORCED && g_LangCodeExpander.CompareISO639Codes(lh.language, audiolang)
+                     , rh.flags & CDemuxStream::FLAG_FORCED && g_LangCodeExpander.CompareISO639Codes(rh.language, audiolang));
 
       PREDICATE_RETURN(lh.flags & CDemuxStream::FLAG_FORCED
                      , rh.flags & CDemuxStream::FLAG_FORCED);
@@ -285,14 +285,14 @@ public:
     std::string subtitle_language = g_langInfo.GetSubtitleLanguage();
     if(!original)
     {
-      PREDICATE_RETURN((STREAM_SOURCE_MASK(lh.source) == STREAM_SOURCE_DEMUX_SUB || STREAM_SOURCE_MASK(lh.source) == STREAM_SOURCE_TEXT) && g_LangCodeExpander.CompareLangCodes(subtitle_language, lh.language)
-                     , (STREAM_SOURCE_MASK(rh.source) == STREAM_SOURCE_DEMUX_SUB || STREAM_SOURCE_MASK(rh.source) == STREAM_SOURCE_TEXT) && g_LangCodeExpander.CompareLangCodes(subtitle_language, rh.language));
+      PREDICATE_RETURN((STREAM_SOURCE_MASK(lh.source) == STREAM_SOURCE_DEMUX_SUB || STREAM_SOURCE_MASK(lh.source) == STREAM_SOURCE_TEXT) && g_LangCodeExpander.CompareISO639Codes(subtitle_language, lh.language)
+                     , (STREAM_SOURCE_MASK(rh.source) == STREAM_SOURCE_DEMUX_SUB || STREAM_SOURCE_MASK(rh.source) == STREAM_SOURCE_TEXT) && g_LangCodeExpander.CompareISO639Codes(subtitle_language, rh.language));
     }
 
     if(!original)
     {
-      PREDICATE_RETURN(g_LangCodeExpander.CompareLangCodes(subtitle_language, lh.language)
-                     , g_LangCodeExpander.CompareLangCodes(subtitle_language, rh.language));
+      PREDICATE_RETURN(g_LangCodeExpander.CompareISO639Codes(subtitle_language, lh.language)
+                     , g_LangCodeExpander.CompareISO639Codes(subtitle_language, rh.language));
 
       bool hearingimp = CSettings::Get().GetBool("accessibility.subhearing");
       PREDICATE_RETURN(!hearingimp ? !(lh.flags & CDemuxStream::FLAG_HEARING_IMPAIRED) : lh.flags & CDemuxStream::FLAG_HEARING_IMPAIRED
@@ -3404,7 +3404,7 @@ bool CDVDPlayer::AdaptForcedSubtitles()
 
     for(SelectionStreams::iterator it = streams.begin(); it != streams.end() && !valid; ++it)
     {
-      if (it->flags & CDemuxStream::FLAG_FORCED && g_LangCodeExpander.CompareLangCodes(it->language, as.language))
+      if (it->flags & CDemuxStream::FLAG_FORCED && g_LangCodeExpander.CompareISO639Codes(it->language, as.language))
       {
         if(OpenStream(m_CurrentSubtitle, it->id, it->source))
         {

--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -425,7 +425,7 @@ namespace XBMCAddon
           StringUtils::Replace(result, "YYYY", "%Y");
         }
       else if (strcmpi(id, "tempunit") == 0)
-        result = g_langInfo.GetTempUnitString();
+        result = g_langInfo.GetTemperatureUnitString();
       else if (strcmpi(id, "speedunit") == 0)
         result = g_langInfo.GetSpeedUnitString();
       else if (strcmpi(id, "time") == 0)

--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -439,8 +439,8 @@ namespace XBMCAddon
         }
       else if (strcmpi(id, "meridiem") == 0)
         result = StringUtils::Format("%s/%s",
-                                     g_langInfo.GetMeridiemSymbol(CLangInfo::MERIDIEM_SYMBOL_AM).c_str(),
-                                     g_langInfo.GetMeridiemSymbol(CLangInfo::MERIDIEM_SYMBOL_PM).c_str());
+                                     g_langInfo.GetMeridiemSymbol(MeridiemSymbolAM).c_str(),
+                                     g_langInfo.GetMeridiemSymbol(MeridiemSymbolPM).c_str());
 
       return result;
     }

--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -194,12 +194,12 @@ namespace XBMCAddon
       case CLangCodeExpander::ISO_639_1:
         {
           std::string langCode;
-          g_LangCodeExpander.ConvertToTwoCharCode(langCode, lang);
+          g_LangCodeExpander.ConvertToISO6391(lang, langCode);
           if (region)
           {
             std::string region = g_langInfo.GetRegionLocale();
             std::string region2Code;
-            g_LangCodeExpander.ConvertToTwoCharCode(region2Code, region);
+            g_LangCodeExpander.ConvertToISO6391(region, region2Code);
             region2Code = "-" + region2Code;
             return (langCode += region2Code);
           }
@@ -208,12 +208,12 @@ namespace XBMCAddon
       case CLangCodeExpander::ISO_639_2:
         {
           std::string langCode;
-          g_LangCodeExpander.ConvertToThreeCharCode(langCode, lang);
+          g_LangCodeExpander.ConvertToISO6392T(lang, langCode);
           if (region)
           {
             std::string region = g_langInfo.GetRegionLocale();
             std::string region3Code;
-            g_LangCodeExpander.ConvertToThreeCharCode(region3Code, region);
+            g_LangCodeExpander.ConvertToISO6392T(region, region3Code);
             region3Code = "-" + region3Code;
             return (langCode += region3Code);
           }
@@ -495,20 +495,20 @@ namespace XBMCAddon
       {
       case CLangCodeExpander::ENGLISH_NAME:
         {
-          g_LangCodeExpander.Lookup(convertedLanguage, language);
+          g_LangCodeExpander.Lookup(language, convertedLanguage);
           // maybe it's a check whether the language exists or not
           if (convertedLanguage.empty())
           {
-            g_LangCodeExpander.ConvertToThreeCharCode(convertedLanguage, language);
+            g_LangCodeExpander.ConvertToISO6392T(language, convertedLanguage);
             g_LangCodeExpander.Lookup(convertedLanguage, convertedLanguage);
           }
           break;
         }
       case CLangCodeExpander::ISO_639_1:
-        g_LangCodeExpander.ConvertToTwoCharCode(convertedLanguage, language);
+        g_LangCodeExpander.ConvertToISO6391(language, convertedLanguage);
         break;
       case CLangCodeExpander::ISO_639_2:
-        g_LangCodeExpander.ConvertToThreeCharCode(convertedLanguage, language);
+        g_LangCodeExpander.ConvertToISO6392T(language, convertedLanguage);
         break;
       default:
         return "";

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -645,7 +645,7 @@ BuildObject(CFileItem&                    item,
             /* trying to find subtitle with prefered language settings */
             std::string preferredLanguage = (CSettings::Get().GetSetting("locale.subtitlelanguage"))->ToString();
             std::string preferredLanguageCode;
-            CLangCodeExpander::ConvertToThreeCharCode(preferredLanguageCode, preferredLanguage);
+            CLangCodeExpander::ConvertToISO6392T(preferredLanguage, preferredLanguageCode);
 
             for (unsigned int i = 0; i < subtitles.size(); i++)
             {

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -145,7 +145,7 @@ bool CSettings::Load(const std::string &file)
   if (!XFILE::CFile::Exists(file) || !xmlDoc.LoadFile(file) ||
       !m_settingsManager->Load(xmlDoc.RootElement(), updated))
   {
-    CLog::Log(LOGERROR, "CSettingsManager: unable to load settings from %s, creating new default settings", file.c_str());
+    CLog::Log(LOGERROR, "CSettings: unable to load settings from %s, creating new default settings", file.c_str());
     if (!Reset())
       return false;
 
@@ -233,6 +233,8 @@ void CSettings::Uninitialize()
   m_settingsManager->UnregisterSettingOptionsFiller("refreshchangedelays");
   m_settingsManager->UnregisterSettingOptionsFiller("refreshrates");
   m_settingsManager->UnregisterSettingOptionsFiller("regions");
+  m_settingsManager->UnregisterSettingOptionsFiller("timeformats");
+  m_settingsManager->UnregisterSettingOptionsFiller("24hourclockformats");
   m_settingsManager->UnregisterSettingOptionsFiller("speedunits");
   m_settingsManager->UnregisterSettingOptionsFiller("temperatureunits");
   m_settingsManager->UnregisterSettingOptionsFiller("rendermethods");
@@ -579,6 +581,8 @@ void CSettings::InitializeOptionFillers()
   m_settingsManager->RegisterSettingOptionsFiller("refreshchangedelays", CDisplaySettings::SettingOptionsRefreshChangeDelaysFiller);
   m_settingsManager->RegisterSettingOptionsFiller("refreshrates", CDisplaySettings::SettingOptionsRefreshRatesFiller);
   m_settingsManager->RegisterSettingOptionsFiller("regions", CLangInfo::SettingOptionsRegionsFiller);
+  m_settingsManager->RegisterSettingOptionsFiller("timeformats", CLangInfo::SettingOptionsTimeFormatsFiller);
+  m_settingsManager->RegisterSettingOptionsFiller("24hourclockformats", CLangInfo::SettingOptions24HourClockFormatsFiller);
   m_settingsManager->RegisterSettingOptionsFiller("speedunits", CLangInfo::SettingOptionsSpeedUnitsFiller);
   m_settingsManager->RegisterSettingOptionsFiller("temperatureunits", CLangInfo::SettingOptionsTemperatureUnitsFiller);
   m_settingsManager->RegisterSettingOptionsFiller("rendermethods", CBaseRenderer::SettingOptionsRenderMethodsFiller);
@@ -754,6 +758,8 @@ void CSettings::InitializeISettingCallbacks()
   settingSet.insert("locale.subtitlelanguage");
   settingSet.insert("locale.language");
   settingSet.insert("locale.country");
+  settingSet.insert("locale.timeformat");
+  settingSet.insert("locale.use24hourclock");
   settingSet.insert("locale.temperatureunit");
   settingSet.insert("locale.speedunit");
   m_settingsManager->RegisterCallback(&g_langInfo, settingSet);

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -233,6 +233,8 @@ void CSettings::Uninitialize()
   m_settingsManager->UnregisterSettingOptionsFiller("refreshchangedelays");
   m_settingsManager->UnregisterSettingOptionsFiller("refreshrates");
   m_settingsManager->UnregisterSettingOptionsFiller("regions");
+  m_settingsManager->UnregisterSettingOptionsFiller("shortdateformats");
+  m_settingsManager->UnregisterSettingOptionsFiller("longdateformats");
   m_settingsManager->UnregisterSettingOptionsFiller("timeformats");
   m_settingsManager->UnregisterSettingOptionsFiller("24hourclockformats");
   m_settingsManager->UnregisterSettingOptionsFiller("speedunits");
@@ -581,6 +583,8 @@ void CSettings::InitializeOptionFillers()
   m_settingsManager->RegisterSettingOptionsFiller("refreshchangedelays", CDisplaySettings::SettingOptionsRefreshChangeDelaysFiller);
   m_settingsManager->RegisterSettingOptionsFiller("refreshrates", CDisplaySettings::SettingOptionsRefreshRatesFiller);
   m_settingsManager->RegisterSettingOptionsFiller("regions", CLangInfo::SettingOptionsRegionsFiller);
+  m_settingsManager->RegisterSettingOptionsFiller("shortdateformats", CLangInfo::SettingOptionsShortDateFormatsFiller);
+  m_settingsManager->RegisterSettingOptionsFiller("longdateformats", CLangInfo::SettingOptionsLongDateFormatsFiller);
   m_settingsManager->RegisterSettingOptionsFiller("timeformats", CLangInfo::SettingOptionsTimeFormatsFiller);
   m_settingsManager->RegisterSettingOptionsFiller("24hourclockformats", CLangInfo::SettingOptions24HourClockFormatsFiller);
   m_settingsManager->RegisterSettingOptionsFiller("speedunits", CLangInfo::SettingOptionsSpeedUnitsFiller);
@@ -758,6 +762,8 @@ void CSettings::InitializeISettingCallbacks()
   settingSet.insert("locale.subtitlelanguage");
   settingSet.insert("locale.language");
   settingSet.insert("locale.country");
+  settingSet.insert("locale.shortdateformat");
+  settingSet.insert("locale.longdateformat");
   settingSet.insert("locale.timeformat");
   settingSet.insert("locale.use24hourclock");
   settingSet.insert("locale.temperatureunit");

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -233,6 +233,7 @@ void CSettings::Uninitialize()
   m_settingsManager->UnregisterSettingOptionsFiller("refreshchangedelays");
   m_settingsManager->UnregisterSettingOptionsFiller("refreshrates");
   m_settingsManager->UnregisterSettingOptionsFiller("regions");
+  m_settingsManager->UnregisterSettingOptionsFiller("speedunits");
   m_settingsManager->UnregisterSettingOptionsFiller("temperatureunits");
   m_settingsManager->UnregisterSettingOptionsFiller("rendermethods");
   m_settingsManager->UnregisterSettingOptionsFiller("resolutions");
@@ -578,6 +579,7 @@ void CSettings::InitializeOptionFillers()
   m_settingsManager->RegisterSettingOptionsFiller("refreshchangedelays", CDisplaySettings::SettingOptionsRefreshChangeDelaysFiller);
   m_settingsManager->RegisterSettingOptionsFiller("refreshrates", CDisplaySettings::SettingOptionsRefreshRatesFiller);
   m_settingsManager->RegisterSettingOptionsFiller("regions", CLangInfo::SettingOptionsRegionsFiller);
+  m_settingsManager->RegisterSettingOptionsFiller("speedunits", CLangInfo::SettingOptionsSpeedUnitsFiller);
   m_settingsManager->RegisterSettingOptionsFiller("temperatureunits", CLangInfo::SettingOptionsTemperatureUnitsFiller);
   m_settingsManager->RegisterSettingOptionsFiller("rendermethods", CBaseRenderer::SettingOptionsRenderMethodsFiller);
   m_settingsManager->RegisterSettingOptionsFiller("resolutions", CDisplaySettings::SettingOptionsResolutionsFiller);
@@ -753,6 +755,7 @@ void CSettings::InitializeISettingCallbacks()
   settingSet.insert("locale.language");
   settingSet.insert("locale.country");
   settingSet.insert("locale.temperatureunit");
+  settingSet.insert("locale.speedunit");
   m_settingsManager->RegisterCallback(&g_langInfo, settingSet);
 
   settingSet.clear();

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -233,6 +233,7 @@ void CSettings::Uninitialize()
   m_settingsManager->UnregisterSettingOptionsFiller("refreshchangedelays");
   m_settingsManager->UnregisterSettingOptionsFiller("refreshrates");
   m_settingsManager->UnregisterSettingOptionsFiller("regions");
+  m_settingsManager->UnregisterSettingOptionsFiller("temperatureunits");
   m_settingsManager->UnregisterSettingOptionsFiller("rendermethods");
   m_settingsManager->UnregisterSettingOptionsFiller("resolutions");
   m_settingsManager->UnregisterSettingOptionsFiller("screens");
@@ -300,6 +301,7 @@ void CSettings::Uninitialize()
 #endif
   m_settingsManager->UnregisterSettingsHandler(&CWakeOnAccess::Get());
   m_settingsManager->UnregisterSettingsHandler(&CRssManager::Get());
+  m_settingsManager->UnregisterSettingsHandler(&g_langInfo);
   m_settingsManager->UnregisterSettingsHandler(&g_application);
 #if defined(TARGET_LINUX) && !defined(TARGET_ANDROID) && !defined(__UCLIBC__)
   m_settingsManager->UnregisterSettingsHandler(&g_timezone);
@@ -576,6 +578,7 @@ void CSettings::InitializeOptionFillers()
   m_settingsManager->RegisterSettingOptionsFiller("refreshchangedelays", CDisplaySettings::SettingOptionsRefreshChangeDelaysFiller);
   m_settingsManager->RegisterSettingOptionsFiller("refreshrates", CDisplaySettings::SettingOptionsRefreshRatesFiller);
   m_settingsManager->RegisterSettingOptionsFiller("regions", CLangInfo::SettingOptionsRegionsFiller);
+  m_settingsManager->RegisterSettingOptionsFiller("temperatureunits", CLangInfo::SettingOptionsTemperatureUnitsFiller);
   m_settingsManager->RegisterSettingOptionsFiller("rendermethods", CBaseRenderer::SettingOptionsRenderMethodsFiller);
   m_settingsManager->RegisterSettingOptionsFiller("resolutions", CDisplaySettings::SettingOptionsResolutionsFiller);
   m_settingsManager->RegisterSettingOptionsFiller("screens", CDisplaySettings::SettingOptionsScreensFiller);
@@ -627,6 +630,7 @@ void CSettings::InitializeISettingsHandlers()
 #endif
   m_settingsManager->RegisterSettingsHandler(&CWakeOnAccess::Get());
   m_settingsManager->RegisterSettingsHandler(&CRssManager::Get());
+  m_settingsManager->RegisterSettingsHandler(&g_langInfo);
   m_settingsManager->RegisterSettingsHandler(&g_application);
 #if defined(TARGET_LINUX) && !defined(TARGET_ANDROID) && !defined(__UCLIBC__)
   m_settingsManager->RegisterSettingsHandler(&g_timezone);
@@ -748,6 +752,7 @@ void CSettings::InitializeISettingCallbacks()
   settingSet.insert("locale.subtitlelanguage");
   settingSet.insert("locale.language");
   settingSet.insert("locale.country");
+  settingSet.insert("locale.temperatureunit");
   m_settingsManager->RegisterCallback(&g_langInfo, settingSet);
 
   settingSet.clear();

--- a/xbmc/utils/CPUInfo.cpp
+++ b/xbmc/utils/CPUInfo.cpp
@@ -581,7 +581,7 @@ bool CCPUInfo::getTemperature(CTemperature& temperature)
   FILE        *p    = NULL;
   std::string  cmd   = g_advancedSettings.m_cpuTempCmd;
 
-  temperature.SetState(CTemperature::invalid);
+  temperature.SetValid(false);
 
   if (cmd.empty() && m_fProcTemperature == NULL)
     return false;

--- a/xbmc/utils/CPUInfo.cpp
+++ b/xbmc/utils/CPUInfo.cpp
@@ -21,7 +21,7 @@
 #include <cstdlib>
 
 #include "CPUInfo.h"
-#include "Temperature.h"
+#include "utils/Temperature.h"
 #include <string>
 #include <string.h>
 

--- a/xbmc/utils/LangCodeExpander.cpp
+++ b/xbmc/utils/LangCodeExpander.cpp
@@ -19,14 +19,14 @@
  */
 
 #include "LangCodeExpander.h"
-#include "utils/XBMCTinyXML.h"
 #include "LangInfo.h"
+#include "Util.h"
 #include "utils/log.h" 
 #include "utils/StringUtils.h"
-#include "Util.h"
+#include "utils/XBMCTinyXML.h"
 
-#define MAKECODE(a, b, c, d)  ((((long)(a))<<24) | (((long)(b))<<16) | (((long)(c))<<8) | (long)(d))
-#define MAKETWOCHARCODE(a, b) ((((long)(a))<<8) | (long)(b)) 
+#define MAKECODE(a, b, c, d)  ((((long)(a)) << 24) | (((long)(b)) << 16) | (((long)(c)) << 8) | (long)(d))
+#define MAKETWOCHARCODE(a, b) ((((long)(a)) << 8) | (long)(b)) 
 
 typedef struct LCENTRY
 {
@@ -37,29 +37,28 @@ typedef struct LCENTRY
 extern const struct LCENTRY g_iso639_1[186];
 extern const struct LCENTRY g_iso639_2[538];
 
-struct CharCodeConvertionWithHack
+struct ISO639
 {
-  const char* old;
-  const char* id;
+  const char* iso639_1;
+  const char* iso639_2;
   const char* win_id;
 };
 
-struct CharCodeConvertion
+struct ISO3166_1
 {
-  const char* old;
-  const char* id;
+  const char* alpha2;
+  const char* alpha3;
 };
 
 // declared as extern to allow forward declaration
-extern const CharCodeConvertionWithHack CharCode2To3[189];
-extern const CharCodeConvertion RegionCode2To3[246];
+extern const ISO639 LanguageCodes[189];
+extern const ISO3166_1 RegionCodes[246];
 
-CLangCodeExpander::CLangCodeExpander(void)
-{}
+CLangCodeExpander::CLangCodeExpander()
+{ }
 
-CLangCodeExpander::~CLangCodeExpander(void)
-{
-}
+CLangCodeExpander::~CLangCodeExpander()
+{ }
 
 void CLangCodeExpander::Clear()
 {
@@ -68,37 +67,39 @@ void CLangCodeExpander::Clear()
 
 void CLangCodeExpander::LoadUserCodes(const TiXmlElement* pRootElement)
 {
-  if (pRootElement)
+  if (pRootElement != NULL)
   {
     m_mapUser.clear();
 
     std::string sShort, sLong;
 
     const TiXmlNode* pLangCode = pRootElement->FirstChild("code");
-    while (pLangCode)
+    while (pLangCode != NULL)
     {
       const TiXmlNode* pShort = pLangCode->FirstChildElement("short");
       const TiXmlNode* pLong = pLangCode->FirstChildElement("long");
-      if (pShort && pLong)
+      if (pShort != NULL && pLong != NULL)
       {
         sShort = pShort->FirstChild()->Value();
         sLong = pLong->FirstChild()->Value();
         StringUtils::ToLower(sShort);
+
         m_mapUser[sShort] = sLong;
       }
+
       pLangCode = pLangCode->NextSibling();
     }
   }
 }
 
-bool CLangCodeExpander::Lookup(std::string& desc, const std::string& code)
+bool CLangCodeExpander::Lookup(const std::string& code, std::string& desc)
 {
   int iSplit = code.find("-");
   if (iSplit > 0)
   {
     std::string strLeft, strRight;
-    const bool bLeft = Lookup(strLeft, code.substr(0, iSplit));
-    const bool bRight = Lookup(strRight, code.substr(iSplit + 1));
+    const bool bLeft = Lookup(code.substr(0, iSplit), strLeft);
+    const bool bRight = Lookup(code.substr(iSplit + 1), strRight);
     if (bLeft || bRight)
     {
       desc = "";
@@ -117,91 +118,94 @@ bool CLangCodeExpander::Lookup(std::string& desc, const std::string& code)
         desc += " - ";
         desc += code.substr(iSplit + 1);
       }
+
       return true;
     }
+
     return false;
   }
-  else
-  {
-    if( LookupInMap(desc, code) )
-      return true;
 
-    if( LookupInDb(desc, code) )
-      return true;
-  }
+  if (LookupInUserMap(code, desc))
+    return true;
+
+  if (LookupInISO639Tables(code, desc))
+    return true;
+
   return false;
 }
 
-bool CLangCodeExpander::Lookup(std::string& desc, const int code)
+bool CLangCodeExpander::Lookup(const int code, std::string& desc)
 {
-
   char lang[3];
   lang[2] = 0;
-  lang[1] = (code & 255);
-  lang[0] = (code >> 8) & 255;
+  lang[1] = (code & 0xFF);
+  lang[0] = (code >> 8) & 0xFF;
 
-  return Lookup(desc, lang);
+  return Lookup(lang, desc);
 }
 
-bool CLangCodeExpander::ConvertTwoToThreeCharCode(std::string& strThreeCharCode, const std::string& strTwoCharCode, bool checkWin32Locales /*= false*/)
-{       
-  if ( strTwoCharCode.length() == 2 )
-  {
-    std::string strTwoCharCodeLower( strTwoCharCode );
-    StringUtils::ToLower(strTwoCharCodeLower);
-    StringUtils::Trim(strTwoCharCodeLower);
+bool CLangCodeExpander::ConvertISO6391ToISO6392T(const std::string& strISO6391, std::string& strISO6392T, bool checkWin32Locales /* = false */)
+{
+  // not a 2 char code
+  if (strISO6391.length() != 2)
+    return false;
 
-    for (unsigned int index = 0; index < ARRAY_SIZE(CharCode2To3); ++index)
+  std::string strISO6391Lower(strISO6391);
+  StringUtils::ToLower(strISO6391Lower);
+  StringUtils::Trim(strISO6391Lower);
+
+  for (unsigned int index = 0; index < ARRAY_SIZE(LanguageCodes); ++index)
+  {
+    if (strISO6391Lower == LanguageCodes[index].iso639_1)
     {
-      if (strTwoCharCodeLower == CharCode2To3[index].old)
+      if (checkWin32Locales && LanguageCodes[index].win_id)
       {
-        if (checkWin32Locales && CharCode2To3[index].win_id)
-        {
-          strThreeCharCode = CharCode2To3[index].win_id;
-          return true;
-        }
-        strThreeCharCode = CharCode2To3[index].id;
+        strISO6392T = LanguageCodes[index].win_id;
         return true;
       }
+
+      strISO6392T = LanguageCodes[index].iso639_2;
+      return true;
     }
   }
 
-  // not a 2 char code
   return false;
 }
 
-bool CLangCodeExpander::ConvertToThreeCharCode(std::string& strThreeCharCode, const std::string& strCharCode, bool checkXbmcLocales /*= true*/, bool checkWin32Locales /*= false*/)
+bool CLangCodeExpander::ConvertToISO6392T(const std::string& strCharCode, std::string& strISO6392T, bool checkXbmcLocales /* = true */, bool checkWin32Locales /* = false */)
 {
   if (strCharCode.size() == 2)
-    return g_LangCodeExpander.ConvertTwoToThreeCharCode(strThreeCharCode, strCharCode, checkWin32Locales);
-  else if (strCharCode.size() == 3)
+    return g_LangCodeExpander.ConvertISO6391ToISO6392T(strCharCode, strISO6392T, checkWin32Locales);
+
+  if (strCharCode.size() == 3)
   {
     std::string charCode(strCharCode); StringUtils::ToLower(charCode);
-    for (unsigned int index = 0; index < ARRAY_SIZE(CharCode2To3); ++index)
+    for (unsigned int index = 0; index < ARRAY_SIZE(LanguageCodes); ++index)
     {
-      if (charCode == CharCode2To3[index].id ||
-           (checkWin32Locales && CharCode2To3[index].win_id != NULL && charCode == CharCode2To3[index].win_id) )
+      if (charCode == LanguageCodes[index].iso639_2 ||
+         (checkWin32Locales && LanguageCodes[index].win_id != NULL && charCode == LanguageCodes[index].win_id))
       {
-        strThreeCharCode = charCode;
+        strISO6392T = charCode;
         return true;
       }
     }
-    for (unsigned int index = 0; index < ARRAY_SIZE(RegionCode2To3); ++index)
+
+    for (unsigned int index = 0; index < ARRAY_SIZE(RegionCodes); ++index)
     {
-      if (charCode == RegionCode2To3[index].id)
+      if (charCode == RegionCodes[index].alpha3)
       {
-        strThreeCharCode = charCode;
+        strISO6392T = charCode;
         return true;
       }
     }
   }
   else if (strCharCode.size() > 3)
   {
-    for(unsigned int i = 0; i < sizeof(g_iso639_2) / sizeof(LCENTRY); i++)
+    for (unsigned int i = 0; i < sizeof(g_iso639_2) / sizeof(LCENTRY); i++)
     {
       if (StringUtils::EqualsNoCase(strCharCode, g_iso639_2[i].name))
       {
-        CodeToString(g_iso639_2[i].code, strThreeCharCode);
+        CodeToString(g_iso639_2[i].code, strISO6392T);
         return true;
       }
     }
@@ -212,8 +216,8 @@ bool CLangCodeExpander::ConvertToThreeCharCode(std::string& strThreeCharCode, co
       if (!langInfo.CheckLoadLanguage(strCharCode))
         return false;
 
-      strThreeCharCode = langInfo.GetLanguageCode();
-      return !strThreeCharCode.empty();
+      strISO6392T = langInfo.GetLanguageCode();
+      return !strISO6392T.empty();
     }
   }
 
@@ -221,19 +225,19 @@ bool CLangCodeExpander::ConvertToThreeCharCode(std::string& strThreeCharCode, co
 }
 
 #ifdef TARGET_WINDOWS
-bool CLangCodeExpander::ConvertLinuxToWindowsRegionCodes(const std::string& strTwoCharCode, std::string& strThreeCharCode)
+bool CLangCodeExpander::ConvertISO36111Alpha2ToISO36111Alpha3(const std::string& strISO36111Alpha2, std::string& strISO36111Alpha3)
 {
-  if (strTwoCharCode.length() != 2)
+  if (strISO36111Alpha2.length() != 2)
     return false;
 
-  std::string strLower( strTwoCharCode );
+  std::string strLower(strISO36111Alpha2);
   StringUtils::ToLower(strLower);
   StringUtils::Trim(strLower);
-  for (unsigned int index = 0; index < ARRAY_SIZE(RegionCode2To3); ++index)
+  for (unsigned int index = 0; index < ARRAY_SIZE(RegionCodes); ++index)
   {
-    if (strLower == RegionCode2To3[index].old)
+    if (strLower == RegionCodes[index].alpha2)
     {
-      strThreeCharCode = RegionCode2To3[index].id;
+      strISO36111Alpha3 = RegionCodes[index].alpha3;
       return true;
     }
   }
@@ -241,28 +245,28 @@ bool CLangCodeExpander::ConvertLinuxToWindowsRegionCodes(const std::string& strT
   return true;
 }
 
-bool CLangCodeExpander::ConvertWindowsToGeneralCharCode(const std::string& strWindowsCharCode, std::string& strThreeCharCode)
+bool CLangCodeExpander::ConvertWindowsLanguageCodeToISO6392T(const std::string& strWindowsLanguageCode, std::string& strISO6392T)
 {
-  if (strWindowsCharCode.length() != 3)
+  if (strWindowsLanguageCode.length() != 3)
     return false;
 
-  std::string strLower(strWindowsCharCode);
+  std::string strLower(strWindowsLanguageCode);
   StringUtils::ToLower(strLower);
-  for (unsigned int index = 0; index < ARRAY_SIZE(CharCode2To3); ++index)
+  for (unsigned int index = 0; index < ARRAY_SIZE(LanguageCodes); ++index)
   {
-    if ((CharCode2To3[index].win_id && strLower == CharCode2To3[index].win_id) ||
-         strLower == CharCode2To3[index].id)
+    if ((LanguageCodes[index].win_id && strLower == LanguageCodes[index].win_id) ||
+         strLower == LanguageCodes[index].iso639_2)
     {
-      strThreeCharCode = CharCode2To3[index].id;
+      strISO6392T = LanguageCodes[index].iso639_2;
       return true;
     }
   }
 
-  return true;
+  return false;
 }
 #endif
 
-bool CLangCodeExpander::ConvertToTwoCharCode(std::string& code, const std::string& lang, bool checkXbmcLocales /*= true*/)
+bool CLangCodeExpander::ConvertToISO6391(const std::string& lang, std::string& code, bool checkXbmcLocales /*= true*/)
 {
   if (lang.empty())
     return false;
@@ -270,7 +274,7 @@ bool CLangCodeExpander::ConvertToTwoCharCode(std::string& code, const std::strin
   if (lang.length() == 2)
   {
     std::string tmp;
-    if (Lookup(tmp, lang))
+    if (Lookup(lang, tmp))
     {
       code = lang;
       return true;
@@ -279,20 +283,20 @@ bool CLangCodeExpander::ConvertToTwoCharCode(std::string& code, const std::strin
   else if (lang.length() == 3)
   {
     std::string lower(lang); StringUtils::ToLower(lower);
-    for (unsigned int index = 0; index < ARRAY_SIZE(CharCode2To3); ++index)
+    for (unsigned int index = 0; index < ARRAY_SIZE(LanguageCodes); ++index)
     {
-      if (lower == CharCode2To3[index].id || (CharCode2To3[index].win_id && lower == CharCode2To3[index].win_id))
+      if (lower == LanguageCodes[index].iso639_2 || (LanguageCodes[index].win_id && lower == LanguageCodes[index].win_id))
       {
-        code = CharCode2To3[index].old;
+        code = LanguageCodes[index].iso639_1;
         return true;
       }
     }
 
-    for (unsigned int index = 0; index < ARRAY_SIZE(RegionCode2To3); ++index)
+    for (unsigned int index = 0; index < ARRAY_SIZE(RegionCodes); ++index)
     {
-      if (lower == RegionCode2To3[index].id)
+      if (lower == RegionCodes[index].alpha3)
       {
-        code = RegionCode2To3[index].old;
+        code = RegionCodes[index].alpha2;
         return true;
       }
     }
@@ -307,8 +311,9 @@ bool CLangCodeExpander::ConvertToTwoCharCode(std::string& code, const std::strin
       code = tmp;
       return true;
     }
-    else if (tmp.length() == 3)
-      return ConvertToTwoCharCode(code, tmp);
+
+    if (tmp.length() == 3)
+      return ConvertToISO6391(tmp, code);
   }
 
   if (!checkXbmcLocales)
@@ -319,7 +324,7 @@ bool CLangCodeExpander::ConvertToTwoCharCode(std::string& code, const std::strin
   if (!langInfo.CheckLoadLanguage(lang))
     return false;
 
-  return ConvertToTwoCharCode(code, langInfo.GetLanguageCode(), false);
+  return ConvertToISO6391(langInfo.GetLanguageCode(), code, false);
 }
 
 bool CLangCodeExpander::ReverseLookup(const std::string& desc, std::string& code)
@@ -330,8 +335,7 @@ bool CLangCodeExpander::ReverseLookup(const std::string& desc, std::string& code
   std::string descTmp(desc);
   StringUtils::Trim(descTmp);
   StringUtils::ToLower(descTmp);
-  STRINGLOOKUPTABLE::iterator it;
-  for (it = m_mapUser.begin(); it != m_mapUser.end() ; ++it)
+  for (STRINGLOOKUPTABLE::const_iterator it = m_mapUser.begin(); it != m_mapUser.end(); ++it)
   {
     if (StringUtils::EqualsNoCase(descTmp, it->second))
     {
@@ -339,7 +343,8 @@ bool CLangCodeExpander::ReverseLookup(const std::string& desc, std::string& code
       return true;
     }
   }
-  for(unsigned int i = 0; i < sizeof(g_iso639_1) / sizeof(LCENTRY); i++)
+
+  for (unsigned int i = 0; i < sizeof(g_iso639_1) / sizeof(LCENTRY); i++)
   {
     if (descTmp == g_iso639_1[i].name)
     {
@@ -347,7 +352,8 @@ bool CLangCodeExpander::ReverseLookup(const std::string& desc, std::string& code
       return true;
     }
   }
-  for(unsigned int i = 0; i < sizeof(g_iso639_2) / sizeof(LCENTRY); i++)
+
+  for (unsigned int i = 0; i < sizeof(g_iso639_2) / sizeof(LCENTRY); i++)
   {
     if (descTmp == g_iso639_2[i].name)
     {
@@ -355,30 +361,31 @@ bool CLangCodeExpander::ReverseLookup(const std::string& desc, std::string& code
       return true;
     }
   }
+
   return false;
 }
 
-bool CLangCodeExpander::LookupInMap(std::string& desc, const std::string& code)
+bool CLangCodeExpander::LookupInUserMap(const std::string& code, std::string& desc)
 {
   if (code.empty())
     return false;
 
-  STRINGLOOKUPTABLE::iterator it;
-  //Make sure we convert to lowercase before trying to find it
+  // make sure we convert to lowercase before trying to find it
   std::string sCode(code);
   StringUtils::ToLower(sCode);
   StringUtils::Trim(sCode);
 
-  it = m_mapUser.find(sCode);
+  STRINGLOOKUPTABLE::iterator it = m_mapUser.find(sCode);
   if (it != m_mapUser.end())
   {
     desc = it->second;
     return true;
   }
+
   return false;
 }
 
-bool CLangCodeExpander::LookupInDb(std::string& desc, const std::string& code)
+bool CLangCodeExpander::LookupInISO639Tables(const std::string& code, std::string& desc)
 {
   if (code.empty())
     return false;
@@ -388,24 +395,24 @@ bool CLangCodeExpander::LookupInDb(std::string& desc, const std::string& code)
   StringUtils::ToLower(sCode);
   StringUtils::Trim(sCode);
 
-  if(sCode.length() == 2)
+  if (sCode.length() == 2)
   {
     longcode = MAKECODE('\0', '\0', sCode[0], sCode[1]);
-    for(unsigned int i = 0; i < sizeof(g_iso639_1) / sizeof(LCENTRY); i++)
+    for (unsigned int i = 0; i < sizeof(g_iso639_1) / sizeof(LCENTRY); i++)
     {
-      if(g_iso639_1[i].code == longcode)
+      if (g_iso639_1[i].code == longcode)
       {
         desc = g_iso639_1[i].name;
         return true;
       }
     }
   }
-  else if(code.length() == 3)
+  else if (code.length() == 3)
   {
     longcode = MAKECODE('\0', sCode[0], sCode[1], sCode[2]);
-    for(unsigned int i = 0; i < sizeof(g_iso639_2) / sizeof(LCENTRY); i++)
+    for (unsigned int i = 0; i < sizeof(g_iso639_2) / sizeof(LCENTRY); i++)
     {
-      if(g_iso639_2[i].code == longcode)
+      if (g_iso639_2[i].code == longcode)
       {
         desc = g_iso639_2[i].name;
         return true;
@@ -418,17 +425,18 @@ bool CLangCodeExpander::LookupInDb(std::string& desc, const std::string& code)
 void CLangCodeExpander::CodeToString(long code, std::string& ret)
 {
   ret.clear();
-  for (unsigned int j = 0 ; j < 4 ; j++)
+  for (unsigned int j = 0; j < 4; j++)
   {
-    char c = (char) code & 0xFF;
+    char c = (char)code & 0xFF;
     if (c == '\0')
       return;
+
     ret.insert(0, 1, c);
     code >>= 8;
   }
 }
 
-bool CLangCodeExpander::CompareFullLangNames(const std::string& lang1, const std::string& lang2)
+bool CLangCodeExpander::CompareFullLanguageNames(const std::string& lang1, const std::string& lang2)
 {
   if (StringUtils::EqualsNoCase(lang1, lang2))
     return true;
@@ -437,16 +445,15 @@ bool CLangCodeExpander::CompareFullLangNames(const std::string& lang1, const std
 
   if (!ReverseLookup(lang1, code1))
     return false;
-  else
-    code1 = lang1;
 
+  code1 = lang1;
   if (!ReverseLookup(lang2, code2))
     return false;
-  else
-    code2 = lang2;
 
+  code2 = lang2;
   Lookup(expandedLang1, code1);
   Lookup(expandedLang2, code2);
+
   return StringUtils::EqualsNoCase(expandedLang1, expandedLang2);
 }
 
@@ -471,17 +478,17 @@ std::vector<std::string> CLangCodeExpander::GetLanguageNames(LANGFORMATS format 
   return languages;
 }
 
-bool CLangCodeExpander::CompareLangCodes(const std::string& code1, const std::string& code2)
+bool CLangCodeExpander::CompareISO639Codes(const std::string& code1, const std::string& code2)
 {
   if (StringUtils::EqualsNoCase(code1, code2))
     return true;
 
-  std::string expandedLang1, expandedLang2;
-
-  if (!Lookup(expandedLang1, code1))
+  std::string expandedLang1;
+  if (!Lookup(code1, expandedLang1))
     return false;
 
-  if (!Lookup(expandedLang2, code2))
+  std::string expandedLang2;
+  if (!Lookup(code2, expandedLang2))
     return false;
 
   return StringUtils::EqualsNoCase(expandedLang1, expandedLang2);
@@ -493,11 +500,12 @@ std::string CLangCodeExpander::ConvertToISO6392T(const std::string& lang)
     return lang;
 
   std::string two, three;
-  if (ConvertToTwoCharCode(two, lang))
+  if (ConvertToISO6391(lang, two))
   {
-    if (ConvertToThreeCharCode(three, two))
+    if (ConvertToISO6392T(two, three))
       return three;
   }
+
   return lang;
 }
 
@@ -1234,7 +1242,7 @@ extern const LCENTRY g_iso639_2[538] =
   { MAKECODE('\0','z','u','n'), "Zuni" },
 };
 
-const CharCodeConvertionWithHack CharCode2To3[189] =
+const ISO639 LanguageCodes[189] =
 {
   { "aa", "aar", NULL },
   { "ab", "abk", NULL },
@@ -1428,7 +1436,7 @@ const CharCodeConvertionWithHack CharCode2To3[189] =
 };
 
 // Based on ISO 3166
-const CharCodeConvertion RegionCode2To3[246] =
+const ISO3166_1 RegionCodes[246] =
 {
   { "af", "afg" },
   { "ax", "ala" },

--- a/xbmc/utils/LangCodeExpander.h
+++ b/xbmc/utils/LangCodeExpander.h
@@ -28,6 +28,8 @@ class TiXmlElement;
 class CLangCodeExpander
 {
 public:
+  CLangCodeExpander();
+  ~CLangCodeExpander();
 
   enum LANGFORMATS
   {
@@ -36,11 +38,11 @@ public:
     ENGLISH_NAME
   };
 
-  CLangCodeExpander(void);
-  ~CLangCodeExpander(void);
+  void LoadUserCodes(const TiXmlElement* pRootElement);
+  void Clear();
 
-  bool Lookup(std::string& desc, const std::string& code);
-  bool Lookup(std::string& desc, const int code);
+  bool Lookup(const std::string& code, std::string& desc);
+  bool Lookup(const int code, std::string& desc);
 
   /** \brief Determines if two english language names represent the same language.
   *   \param[in] lang1 The first language string to compare given as english language name.
@@ -48,7 +50,7 @@ public:
   *   \return true if the two language strings represent the same language, false otherwise.
   *   For example "Abkhaz" and "Abkhazian" represent the same language.
   */ 
-  bool CompareFullLangNames(const std::string& lang1, const std::string& lang2);
+  bool CompareFullLanguageNames(const std::string& lang1, const std::string& lang2);
 
   /** \brief Determines if two languages given as ISO 639-1, ISO 639-2/T, or ISO 639-2/B codes represent the same language.
   *   \param[in] code1 The first language to compare given as ISO 639-1, ISO 639-2/T, or ISO 639-2/B code.
@@ -56,7 +58,7 @@ public:
   *   \return true if the two language codes represent the same language, false otherwise.
   *   For example "ger", "deu" and "de" represent the same language.
   */ 
-  bool CompareLangCodes(const std::string& code1, const std::string& code2);
+  bool CompareISO639Codes(const std::string& code1, const std::string& code2);
 
   /** \brief Converts a language given as 2-Char (ISO 639-1),
   *          3-Char (ISO 639-2/T or ISO 639-2/B),
@@ -66,7 +68,7 @@ public:
   *   \param[in] checkXbmcLocales Try to find in XBMC specific locales
   *   \return true if the conversion succeeded, false otherwise. 
   */ 
-  bool ConvertToTwoCharCode(std::string& code, const std::string& lang, bool checkXbmcLocales = true);
+  bool ConvertToISO6391(const std::string& lang, std::string& code, bool checkXbmcLocales = true);
 
   /** \brief Converts a language given as 2-Char (ISO 639-1),
   *          3-Char (ISO 639-2/T or ISO 639-2/B),
@@ -75,16 +77,30 @@ public:
   *   \return The 3-Char ISO 639-2/T code of lang if that code exists, lang otherwise.
   */
   std::string ConvertToISO6392T(const std::string& lang);
-  static bool ConvertTwoToThreeCharCode(std::string& strThreeCharCode, const std::string& strTwoCharCode, bool checkWin32Locales = false);
-  static bool ConvertToThreeCharCode(std::string& strThreeCharCode, const std::string& strCharCode, bool checkXbmcLocales = true, bool checkWin32Locales = false);
+
+  /** \brief Converts a language given as 2-Char (ISO 639-1) to a 3-Char (ISO 639-2/T) code.
+  *   \param[in] strISO6391 The language that should be converted.
+  *   \param[out] strISO6392T The 3-Char (ISO 639-2/T) language code of the given language strISO6391.
+  *   \param[in] checkWin32Locales Whether to also check WIN32 specific language codes.
+  *   \return true if the conversion succeeded, false otherwise.
+  */
+  static bool ConvertISO6391ToISO6392T(const std::string& strISO6391, std::string& strISO6392T, bool checkWin32Locales = false);
+
+  /** \brief Converts a language given as 2-Char (ISO 639-1),
+  *          3-Char (ISO 639-2/T or ISO 639-2/B),
+  *          or full english name string to a 3-Char ISO 639-2/T code.
+  *   \param[in] strCharCode The language that should be converted.
+  *   \param[out] strISO6392T The 3-Char (ISO 639-2/T) language code of the given language strISO6391.
+  *   \param[in] checkXbmcLocales Try to find in XBMC specific locales
+  *   \param[in] checkWin32Locales Whether to also check WIN32 specific language codes.
+  *   \return true if the conversion succeeded, false otherwise.
+  */
+  static bool ConvertToISO6392T(const std::string& strCharCode, std::string& strISO6392T, bool checkXbmcLocales = true, bool checkWin32Locales = false);
 
 #ifdef TARGET_WINDOWS
-  static bool ConvertLinuxToWindowsRegionCodes(const std::string& strTwoCharCode, std::string& strThreeCharCode);
-  static bool ConvertWindowsToGeneralCharCode(const std::string& strWindowsCharCode, std::string& strThreeCharCode);
+  static bool ConvertISO36111Alpha2ToISO36111Alpha3(const std::string& strISO36111Alpha2, std::string& strISO36111Alpha3);
+  static bool ConvertWindowsLanguageCodeToISO6392T(const std::string& strWindowsLanguageCode, std::string& strISO6392T);
 #endif
-
-  void LoadUserCodes(const TiXmlElement* pRootElement);
-  void Clear();
 
   static std::vector<std::string> GetLanguageNames(LANGFORMATS format = ISO_639_1);
 protected:
@@ -96,11 +112,8 @@ protected:
   */ 
   static void CodeToString(long code, std::string& ret);
 
-  typedef std::map<std::string, std::string> STRINGLOOKUPTABLE;
-  STRINGLOOKUPTABLE m_mapUser;
-
-  static bool LookupInDb(std::string& desc, const std::string& code);
-  bool LookupInMap(std::string& desc, const std::string& code);
+  static bool LookupInISO639Tables(const std::string& code, std::string& desc);
+  bool LookupInUserMap(const std::string& code, std::string& desc);
 
   /** \brief Looks up the ISO 639-1, ISO 639-2/T, or ISO 639-2/B, whichever it finds first,
   *          code of the given english language name.
@@ -109,6 +122,9 @@ protected:
   *   \return true if the a code was found, false otherwise.
   */ 
   bool ReverseLookup(const std::string& desc, std::string& code);
+
+  typedef std::map<std::string, std::string> STRINGLOOKUPTABLE;
+  STRINGLOOKUPTABLE m_mapUser;
 };
 
 extern CLangCodeExpander g_LangCodeExpander;

--- a/xbmc/utils/Makefile.in
+++ b/xbmc/utils/Makefile.in
@@ -66,6 +66,7 @@ SRCS += StreamUtils.cpp
 SRCS += StringUtils.cpp
 SRCS += StringValidation.cpp
 SRCS += SystemInfo.cpp
+SRCS += Temperature.cpp
 SRCS += TextSearch.cpp
 SRCS += TimeSmoother.cpp
 SRCS += TimeUtils.cpp

--- a/xbmc/utils/Makefile.in
+++ b/xbmc/utils/Makefile.in
@@ -59,6 +59,7 @@ SRCS += ScraperUrl.cpp
 SRCS += Screenshot.cpp
 SRCS += SeekHandler.cpp
 SRCS += SortUtils.cpp
+SRCS += Speed.cpp
 SRCS += Splash.cpp
 SRCS += Stopwatch.cpp
 SRCS += StreamDetails.cpp

--- a/xbmc/utils/Speed.cpp
+++ b/xbmc/utils/Speed.cpp
@@ -1,0 +1,593 @@
+/*
+ *      Copyright (C) 2005-2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <assert.h>
+
+#include "Speed.h"
+#include "utils/Archive.h"
+#include "utils/StringUtils.h"
+
+CSpeed::CSpeed()
+{
+  m_value = 0.0;
+  m_valid = false;
+}
+
+CSpeed::CSpeed(const CSpeed& speed)
+{
+  m_value = speed.m_value;
+  m_valid = speed.m_valid;
+}
+
+CSpeed::CSpeed(double value)
+{
+  m_value = value;
+  m_valid = true;
+}
+
+bool CSpeed::operator >(const CSpeed& right) const
+{
+  assert(IsValid());
+  assert(right.IsValid());
+
+  if (!IsValid() || !right.IsValid())
+    return false;
+
+  if (this == &right)
+    return false;
+
+  return (m_value > right.m_value);
+}
+
+bool CSpeed::operator >=(const CSpeed& right) const
+{
+  return operator >(right) || operator ==(right);
+}
+
+bool CSpeed::operator <(const CSpeed& right) const
+{
+  assert(IsValid());
+  assert(right.IsValid());
+
+  if (!IsValid() || !right.IsValid())
+    return false;
+
+  if (this == &right)
+    return false;
+
+  return (m_value < right.m_value);
+}
+
+bool CSpeed::operator <=(const CSpeed& right) const
+{
+  return operator <(right) || operator ==(right);
+}
+
+bool CSpeed::operator ==(const CSpeed& right) const
+{
+  assert(IsValid());
+  assert(right.IsValid());
+
+  if (!IsValid() || !right.IsValid())
+    return false;
+
+  if (this == &right)
+    return true;
+
+  return (m_value == right.m_value);
+}
+
+bool CSpeed::operator !=(const CSpeed& right) const
+{
+  return !operator ==(right.m_value);
+}
+
+const CSpeed& CSpeed::operator =(const CSpeed& right)
+{
+  m_valid = right.m_valid;
+  m_value = right.m_value;
+  return *this;
+}
+
+const CSpeed& CSpeed::operator +=(const CSpeed& right)
+{
+  assert(IsValid());
+  assert(right.IsValid());
+
+  m_value += right.m_value;
+  return *this;
+}
+
+const CSpeed& CSpeed::operator -=(const CSpeed& right)
+{
+  assert(IsValid());
+  assert(right.IsValid());
+
+  m_value -= right.m_value;
+  return *this;
+}
+
+const CSpeed& CSpeed::operator *=(const CSpeed& right)
+{
+  assert(IsValid());
+  assert(right.IsValid());
+
+  m_value *= right.m_value;
+  return *this;
+}
+
+const CSpeed& CSpeed::operator /=(const CSpeed& right)
+{
+  assert(IsValid());
+  assert(right.IsValid());
+
+  m_value /= right.m_value;
+  return *this;
+}
+
+CSpeed CSpeed::operator +(const CSpeed& right) const
+{
+  assert(IsValid());
+  assert(right.IsValid());
+
+  CSpeed temp(*this);
+
+  if (!IsValid() || !right.IsValid())
+    temp.SetValid(false);
+  else
+    temp.m_value += right.m_value;
+
+  return temp;
+}
+
+CSpeed CSpeed::operator -(const CSpeed& right) const
+{
+  assert(IsValid());
+  assert(right.IsValid());
+
+  CSpeed temp(*this);
+  if (!IsValid() || !right.IsValid())
+    temp.SetValid(false);
+  else
+    temp.m_value -= right.m_value;
+
+  return temp;
+}
+
+CSpeed CSpeed::operator *(const CSpeed& right) const
+{
+  assert(IsValid());
+  assert(right.IsValid());
+
+  CSpeed temp(*this);
+  if (!IsValid() || !right.IsValid())
+    temp.SetValid(false);
+  else
+    temp.m_value *= right.m_value;
+  return temp;
+}
+
+CSpeed CSpeed::operator /(const CSpeed& right) const
+{
+  assert(IsValid());
+  assert(right.IsValid());
+
+  CSpeed temp(*this);
+  if (!IsValid() || !right.IsValid())
+    temp.SetValid(false);
+  else
+    temp.m_value /= right.m_value;
+  return temp;
+}
+
+CSpeed& CSpeed::operator ++()
+{
+  assert(IsValid());
+
+  m_value++;
+  return *this;
+}
+
+CSpeed& CSpeed::operator --()
+{
+  assert(IsValid());
+
+  m_value--;
+  return *this;
+}
+
+CSpeed CSpeed::operator ++(int)
+{
+  assert(IsValid());
+
+  CSpeed temp(*this);
+  m_value++;
+  return temp;
+}
+
+CSpeed CSpeed::operator --(int)
+{
+  assert(IsValid());
+
+  CSpeed temp(*this);
+  m_value--;
+  return temp;
+}
+
+bool CSpeed::operator >(double right) const
+{
+  assert(IsValid());
+
+  if (!IsValid())
+    return false;
+
+  return (m_value > right);
+}
+
+bool CSpeed::operator >=(double right) const
+{
+  return operator >(right) || operator ==(right);
+}
+
+bool CSpeed::operator <(double right) const
+{
+  assert(IsValid());
+
+  if (!IsValid())
+    return false;
+
+  return (m_value < right);
+}
+
+bool CSpeed::operator <=(double right) const
+{
+  return operator <(right) || operator ==(right);
+}
+
+bool CSpeed::operator ==(double right) const
+{
+  if (!IsValid())
+    return false;
+
+  return (m_value == right);
+}
+
+bool CSpeed::operator !=(double right) const
+{
+  return !operator ==(right);
+}
+
+const CSpeed& CSpeed::operator +=(double right)
+{
+  assert(IsValid());
+
+  m_value += right;
+  return *this;
+}
+
+const CSpeed& CSpeed::operator -=(double right)
+{
+  assert(IsValid());
+
+  m_value -= right;
+  return *this;
+}
+
+const CSpeed& CSpeed::operator *=(double right)
+{
+  assert(IsValid());
+
+  m_value *= right;
+  return *this;
+}
+
+const CSpeed& CSpeed::operator /=(double right)
+{
+  assert(IsValid());
+
+  m_value /= right;
+  return *this;
+}
+
+CSpeed CSpeed::operator +(double right) const
+{
+  assert(IsValid());
+
+  CSpeed temp(*this);
+  temp.m_value += right;
+  return temp;
+}
+
+CSpeed CSpeed::operator -(double right) const
+{
+  assert(IsValid());
+
+  CSpeed temp(*this);
+  temp.m_value -= right;
+  return temp;
+}
+
+CSpeed CSpeed::operator *(double right) const
+{
+  assert(IsValid());
+
+  CSpeed temp(*this);
+  temp.m_value *= right;
+  return temp;
+}
+
+CSpeed CSpeed::operator /(double right) const
+{
+  assert(IsValid());
+
+  CSpeed temp(*this);
+  temp.m_value /= right;
+  return temp;
+}
+
+CSpeed CSpeed::CreateFromKilometresPerHour(double value)
+{
+  return CSpeed(value / 3.6);
+}
+
+CSpeed CSpeed::CreateFromMetresPerMinute(double value)
+{
+  return CSpeed(value / 60.0);
+}
+
+CSpeed CSpeed::CreateFromMetresPerSecond(double value)
+{
+  return CSpeed(value);
+}
+
+CSpeed CSpeed::CreateFromFeetPerHour(double value)
+{
+  return CreateFromFeetPerMinute(value / 60.0);
+}
+
+CSpeed CSpeed::CreateFromFeetPerMinute(double value)
+{
+  return CreateFromFeetPerSecond(value / 60.0);
+}
+
+CSpeed CSpeed::CreateFromFeetPerSecond(double value)
+{
+  return CSpeed(value / 3.280839895);
+}
+
+CSpeed CSpeed::CreateFromMilesPerHour(double value)
+{
+  return CSpeed(value / 2.236936292);
+}
+
+CSpeed CSpeed::CreateFromKnots(double value)
+{
+  return CSpeed(value / 1.943846172);
+}
+
+CSpeed CSpeed::CreateFromBeaufort(unsigned int value)
+{
+  if (value == 0)
+    return CSpeed(0.15);
+  if (value == 1)
+    return CSpeed(0.9);
+  if (value == 2)
+    return CSpeed(2.4);
+  if (value == 3)
+    return CSpeed(4.4);
+  if (value == 4)
+    return CSpeed(6.75);
+  if (value == 5)
+    return CSpeed(9.4);
+  if (value == 6)
+    return CSpeed(12.35);
+  if (value == 7)
+    return CSpeed(15.55);
+  if (value == 8)
+    return CSpeed(18.95);
+  if (value == 9)
+    return CSpeed(22.6);
+  if (value == 10)
+    return CSpeed(26.45);
+  if (value == 11)
+    return CSpeed(30.5);
+
+  return CSpeed(32.6);
+}
+
+CSpeed CSpeed::CreateFromInchPerSecond(double value)
+{
+  return CSpeed(value / 39.37007874);
+}
+
+CSpeed CSpeed::CreateFromYardPerSecond(double value)
+{
+  return CSpeed(value / 1.093613298);
+}
+
+CSpeed CSpeed::CreateFromFurlongPerFortnight(double value)
+{
+  return CSpeed(value / 6012.885613871);
+}
+
+void CSpeed::Archive(CArchive& ar)
+{
+  if (ar.IsStoring())
+  {
+    ar << m_value;
+    ar << m_valid;
+  }
+  else
+  {
+    ar >> m_value;
+    ar >> m_valid;
+  }
+}
+
+bool CSpeed::IsValid() const
+{
+  return m_valid;
+}
+
+double CSpeed::ToKilometresPerHour() const
+{
+  return m_value * 3.6;
+}
+
+double CSpeed::ToMetresPerMinute() const
+{
+  return m_value * 60.0;
+}
+
+double CSpeed::ToMetresPerSecond() const
+{
+  return m_value;
+}
+
+double CSpeed::ToFeetPerHour() const
+{
+  return ToFeetPerMinute() * 60.0;
+}
+
+double CSpeed::ToFeetPerMinute() const
+{
+  return ToFeetPerSecond() * 60.0;
+}
+
+double CSpeed::ToFeetPerSecond() const
+{
+  return m_value * 3.280839895;
+}
+
+double CSpeed::ToMilesPerHour() const
+{
+  return m_value * 2.236936292;
+}
+
+double CSpeed::ToKnots() const
+{
+  return m_value * 1.943846172;
+}
+
+double CSpeed::ToBeaufort() const
+{
+  if (m_value < 0.3)
+    return 0;
+  if (m_value >= 0.3 && m_value < 1.5)
+    return 1;
+  if (m_value >= 1.5 && m_value < 3.3)
+    return 2;
+  if (m_value >= 3.3 && m_value < 5.5)
+    return 3;
+  if (m_value >= 5.5 && m_value < 8.0)
+    return 4;
+  if (m_value >= 8.0 && m_value < 10.8)
+    return 5;
+  if (m_value >= 10.8 && m_value < 13.9)
+    return 6;
+  if (m_value >= 13.9 && m_value < 17.2)
+    return 7;
+  if (m_value >= 17.2 && m_value < 20.7)
+    return 8;
+  if (m_value >= 20.7 && m_value < 24.5)
+    return 9;
+  if (m_value >= 24.5 && m_value < 28.4)
+    return 10;
+  if (m_value >= 28.4 && m_value < 32.6)
+    return 11;
+
+  return 12;
+}
+
+double CSpeed::ToInchPerSecond() const
+{
+  return m_value * 39.37007874;
+}
+
+double CSpeed::ToYardPerSecond() const
+{
+  return m_value * 1.093613298;
+}
+
+double CSpeed::ToFurlongPerFortnight() const
+{
+  return m_value * 6012.885613871;
+}
+
+double CSpeed::To(Unit speedUnit) const
+{
+  if (!IsValid())
+    return 0;
+
+  double value = 0.0;
+
+  switch (speedUnit)
+  {
+  case UnitKilometresPerHour:
+    value = ToKilometresPerHour();
+    break;
+  case UnitMetresPerMinute:
+    value = ToMetresPerMinute();
+    break;
+  case UnitMetresPerSecond:
+    value = ToMetresPerSecond();
+    break;
+  case UnitFeetPerHour:
+    value = ToFeetPerHour();
+    break;
+  case UnitFeetPerMinute:
+    value = ToFeetPerMinute();
+    break;
+  case UnitFeetPerSecond:
+    value = ToFeetPerSecond();
+    break;
+  case UnitMilesPerHour:
+    value = ToMilesPerHour();
+    break;
+  case UnitKnots:
+    value = ToKnots();
+    break;
+  case UnitBeaufort:
+    value = ToBeaufort();
+    break;
+  case UnitInchPerSecond:
+    value = ToInchPerSecond();
+    break;
+  case UnitYardPerSecond:
+    value = ToYardPerSecond();
+    break;
+  case UnitFurlongPerFortnight:
+    value = ToFurlongPerFortnight();
+    break;
+  default:
+    assert(false);
+    break;
+  }
+  return value;
+}
+
+// Returns temperature as localized string
+std::string CSpeed::ToString(Unit speedUnit) const
+{
+  if (!IsValid())
+    return "";
+
+  return StringUtils::Format("%2.0f", To(speedUnit));
+}

--- a/xbmc/utils/Speed.h
+++ b/xbmc/utils/Speed.h
@@ -1,0 +1,127 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <string>
+
+#include "utils/IArchivable.h"
+
+class CSpeed : public IArchivable
+{
+public:
+  CSpeed();
+  CSpeed(const CSpeed& speed);
+
+  typedef enum Unit
+  {
+    UnitKilometresPerHour = 0,
+    UnitMetresPerMinute,
+    UnitMetresPerSecond,
+    UnitFeetPerHour,
+    UnitFeetPerMinute,
+    UnitFeetPerSecond,
+    UnitMilesPerHour,
+    UnitKnots,
+    UnitBeaufort,
+    UnitInchPerSecond,
+    UnitYardPerSecond,
+    UnitFurlongPerFortnight
+  } Unit;
+
+  static CSpeed CreateFromKilometresPerHour(double value);
+  static CSpeed CreateFromMetresPerMinute(double value);
+  static CSpeed CreateFromMetresPerSecond(double value);
+  static CSpeed CreateFromFeetPerHour(double value);
+  static CSpeed CreateFromFeetPerMinute(double value);
+  static CSpeed CreateFromFeetPerSecond(double value);
+  static CSpeed CreateFromMilesPerHour(double value);
+  static CSpeed CreateFromKnots(double value);
+  static CSpeed CreateFromBeaufort(unsigned int value);
+  static CSpeed CreateFromInchPerSecond(double value);
+  static CSpeed CreateFromYardPerSecond(double value);
+  static CSpeed CreateFromFurlongPerFortnight(double value);
+
+  bool operator >(const CSpeed& right) const;
+  bool operator >=(const CSpeed& right) const;
+  bool operator <(const CSpeed& right) const;
+  bool operator <=(const CSpeed& right) const;
+  bool operator ==(const CSpeed& right) const;
+  bool operator !=(const CSpeed& right) const;
+
+  const CSpeed& operator =(const CSpeed& right);
+  const CSpeed& operator +=(const CSpeed& right);
+  const CSpeed& operator -=(const CSpeed& right);
+  const CSpeed& operator *=(const CSpeed& right);
+  const CSpeed& operator /=(const CSpeed& right);
+  CSpeed operator +(const CSpeed& right) const;
+  CSpeed operator -(const CSpeed& right) const;
+  CSpeed operator *(const CSpeed& right) const;
+  CSpeed operator /(const CSpeed& right) const;
+
+  bool operator >(double right) const;
+  bool operator >=(double right) const;
+  bool operator <(double right) const;
+  bool operator <=(double right) const;
+  bool operator ==(double right) const;
+  bool operator !=(double right) const;
+
+  const CSpeed& operator +=(double right);
+  const CSpeed& operator -=(double right);
+  const CSpeed& operator *=(double right);
+  const CSpeed& operator /=(double right);
+  CSpeed operator +(double right) const;
+  CSpeed operator -(double right) const;
+  CSpeed operator *(double right) const;
+  CSpeed operator /(double right) const;
+
+  CSpeed& operator ++();
+  CSpeed& operator --();
+  CSpeed operator ++(int);
+  CSpeed operator --(int);
+
+  virtual void Archive(CArchive& ar);
+
+  bool IsValid() const;
+
+  double ToKilometresPerHour() const;
+  double ToMetresPerMinute() const;
+  double ToMetresPerSecond() const;
+  double ToFeetPerHour() const;
+  double ToFeetPerMinute() const;
+  double ToFeetPerSecond() const;
+  double ToMilesPerHour() const;
+  double ToKnots() const;
+  double ToBeaufort() const;
+  double ToInchPerSecond() const;
+  double ToYardPerSecond() const;
+  double ToFurlongPerFortnight() const;
+
+  double To(Unit speedUnit) const;
+  std::string ToString(Unit speedUnit) const;
+
+protected:
+  CSpeed(double value);
+
+  void SetValid(bool valid) { m_valid = valid; }
+
+  double m_value; // we store in m/s
+  bool m_valid;
+};
+

--- a/xbmc/utils/StreamDetails.cpp
+++ b/xbmc/utils/StreamDetails.cpp
@@ -155,13 +155,13 @@ bool CStreamDetailSubtitle::IsWorseThan(CStreamDetail *that)
   if (that->m_eType != CStreamDetail::SUBTITLE)
     return true;
 
-  if (g_LangCodeExpander.CompareLangCodes(m_strLanguage, ((CStreamDetailSubtitle *)that)->m_strLanguage))
+  if (g_LangCodeExpander.CompareISO639Codes(m_strLanguage, ((CStreamDetailSubtitle *)that)->m_strLanguage))
     return false;
 
   // the best subtitle should be the one in the user's preferred language
   // If preferred language is set to "original" this is "eng"
   return m_strLanguage.empty() ||
-    g_LangCodeExpander.CompareLangCodes(((CStreamDetailSubtitle *)that)->m_strLanguage, g_langInfo.GetSubtitleLanguage());
+    g_LangCodeExpander.CompareISO639Codes(((CStreamDetailSubtitle *)that)->m_strLanguage, g_langInfo.GetSubtitleLanguage());
 }
 
 CStreamDetailSubtitle& CStreamDetailSubtitle::operator=(const CStreamDetailSubtitle &that)

--- a/xbmc/utils/Temperature.cpp
+++ b/xbmc/utils/Temperature.cpp
@@ -21,8 +21,6 @@
 #include <assert.h>
 
 #include "Temperature.h"
-#include "LangInfo.h"
-#include "guilib/LocalizeStrings.h"
 #include "utils/Archive.h"
 #include "utils/StringUtils.h"
 
@@ -439,36 +437,37 @@ double CTemperature::ToNewton() const
   return (m_value-32.0f)*11.0f/60.0f;
 }
 
-double CTemperature::ToLocale() const
+double CTemperature::To(Unit temperatureUnit) const
 {
   if (!IsValid())
     return 0;
+
   double value = 0.0;
 
-  switch(g_langInfo.GetTempUnit())
+  switch (temperatureUnit)
   {
-  case CLangInfo::TEMP_UNIT_FAHRENHEIT:
+  case UnitFahrenheit:
     value=ToFahrenheit();
     break;
-  case CLangInfo::TEMP_UNIT_KELVIN:
+  case UnitKelvin:
     value=ToKelvin();
     break;
-  case CLangInfo::TEMP_UNIT_CELSIUS:
+  case UnitCelsius:
     value=ToCelsius();
     break;
-  case CLangInfo::TEMP_UNIT_REAUMUR:
+  case UnitReaumur:
     value=ToReaumur();
     break;
-  case CLangInfo::TEMP_UNIT_RANKINE:
+  case UnitRankine:
     value=ToRankine();
     break;
-  case CLangInfo::TEMP_UNIT_ROMER:
+  case UnitRomer:
     value=ToRomer();
     break;
-  case CLangInfo::TEMP_UNIT_DELISLE:
+  case UnitDelisle:
     value=ToDelisle();
     break;
-  case CLangInfo::TEMP_UNIT_NEWTON:
+  case UnitNewton:
     value=ToNewton();
     break;
   default:
@@ -479,10 +478,10 @@ double CTemperature::ToLocale() const
 }
 
 // Returns temperature as localized string
-std::string CTemperature::ToString() const
+std::string CTemperature::ToString(Unit temperatureUnit) const
 {
   if (!IsValid())
-    return g_localizeStrings.Get(13205); // "Unknown"
+    return "";
 
-  return StringUtils::Format("%2.0f%s", ToLocale(), g_langInfo.GetTempUnitString().c_str());
+  return StringUtils::Format("%2.0f", To(temperatureUnit));
 }

--- a/xbmc/utils/Temperature.cpp
+++ b/xbmc/utils/Temperature.cpp
@@ -18,29 +18,30 @@
  *
  */
 
+#include <assert.h>
+
+#include "Temperature.h"
 #include "LangInfo.h"
 #include "guilib/LocalizeStrings.h"
-#include "Temperature.h"
-#include "utils/StringUtils.h"
 #include "utils/Archive.h"
-#include <assert.h>
+#include "utils/StringUtils.h"
 
 CTemperature::CTemperature()
 {
   m_value=0.0f;
-  m_state=invalid;
+  m_valid=false;
 }
 
 CTemperature::CTemperature(const CTemperature& temperature)
 {
   m_value=temperature.m_value;
-  m_state=temperature.m_state;
+  m_valid=temperature.m_valid;
 }
 
 CTemperature::CTemperature(double value)
 {
   m_value=value;
-  m_state=valid;
+  m_valid=true;
 }
 
 bool CTemperature::operator >(const CTemperature& right) const
@@ -102,7 +103,7 @@ bool CTemperature::operator !=(const CTemperature& right) const
 
 const CTemperature& CTemperature::operator =(const CTemperature& right)
 {
-  m_state=right.m_state;
+  m_valid=right.m_valid;
   m_value=right.m_value;
   return *this;
 }
@@ -151,7 +152,7 @@ CTemperature CTemperature::operator +(const CTemperature& right) const
   CTemperature temp(*this);
 
   if (!IsValid() || !right.IsValid())
-    temp.SetState(invalid);
+    temp.SetValid(false);
   else
     temp.m_value+=right.m_value;
 
@@ -165,7 +166,7 @@ CTemperature CTemperature::operator -(const CTemperature& right) const
 
   CTemperature temp(*this);
   if (!IsValid() || !right.IsValid())
-    temp.SetState(invalid);
+    temp.SetValid(false);
   else
     temp.m_value-=right.m_value;
 
@@ -179,7 +180,7 @@ CTemperature CTemperature::operator *(const CTemperature& right) const
 
   CTemperature temp(*this);
   if (!IsValid() || !right.IsValid())
-    temp.SetState(invalid);
+    temp.SetValid(false);
   else
     temp.m_value*=right.m_value;
   return temp;
@@ -192,7 +193,7 @@ CTemperature CTemperature::operator /(const CTemperature& right) const
 
   CTemperature temp(*this);
   if (!IsValid() || !right.IsValid())
-    temp.SetState(invalid);
+    temp.SetValid(false);
   else
     temp.m_value/=right.m_value;
   return temp;
@@ -384,25 +385,18 @@ void CTemperature::Archive(CArchive& ar)
   if (ar.IsStoring())
   {
     ar<<m_value;
-    ar<<(int)m_state;
+    ar<<m_valid;
   }
   else
   {
     ar>>m_value;
-    int state;
-    ar>>(int&)state;
-    m_state = CTemperature::STATE(state);
+    ar>>m_valid;
   }
-}
-
-void CTemperature::SetState(CTemperature::STATE state)
-{
-  m_state=state;
 }
 
 bool CTemperature::IsValid() const
 {
-  return (m_state==valid);
+  return m_valid;
 }
 
 double CTemperature::ToFahrenheit() const

--- a/xbmc/utils/Temperature.h
+++ b/xbmc/utils/Temperature.h
@@ -20,6 +20,7 @@
  */
 
 #include <string>
+
 #include "utils/IArchivable.h"
 
 class CTemperature : public IArchivable
@@ -77,13 +78,6 @@ public:
 
   virtual void Archive(CArchive& ar);
 
-  typedef enum _STATE
-  {
-    invalid=0,
-    valid
-  } STATE;
-
-  void SetState(CTemperature::STATE state);
   bool IsValid() const;
 
   double ToFahrenheit() const;
@@ -101,8 +95,9 @@ public:
 protected:
   CTemperature(double value);
 
-protected:
+  void SetValid(bool valid) { m_valid = valid; }
+
   double m_value; // we store as fahrenheit
-  STATE m_state;
+  bool m_valid;
 };
 

--- a/xbmc/utils/Temperature.h
+++ b/xbmc/utils/Temperature.h
@@ -29,6 +29,18 @@ public:
   CTemperature();
   CTemperature(const CTemperature& temperature);
 
+  typedef enum Unit
+  {
+    UnitFahrenheit = 0,
+    UnitKelvin,
+    UnitCelsius,
+    UnitReaumur,
+    UnitRankine,
+    UnitRomer,
+    UnitDelisle,
+    UnitNewton
+  } Unit;
+
   static CTemperature CreateFromFahrenheit(double value);
   static CTemperature CreateFromKelvin(double value);
   static CTemperature CreateFromCelsius(double value);
@@ -79,6 +91,7 @@ public:
   virtual void Archive(CArchive& ar);
 
   bool IsValid() const;
+  void SetValid(bool valid) { m_valid = valid; }
 
   double ToFahrenheit() const;
   double ToKelvin() const;
@@ -89,13 +102,11 @@ public:
   double ToDelisle() const;
   double ToNewton() const;
 
-  double ToLocale() const;
-  std::string ToString() const;
+  double To(Unit temperatureUnit) const;
+  std::string ToString(Unit temperatureUnit) const;
 
 protected:
   CTemperature(double value);
-
-  void SetValid(bool valid) { m_valid = valid; }
 
   double m_value; // we store as fahrenheit
   bool m_valid;

--- a/xbmc/utils/Weather.cpp
+++ b/xbmc/utils/Weather.cpp
@@ -221,7 +221,7 @@ int CWeatherJob::ConvertSpeed(int curSpeed)
 void CWeatherJob::FormatTemperature(std::string &text, int temp)
 {
   CTemperature temperature = CTemperature::CreateFromCelsius(temp);
-  text = StringUtils::Format("%.0f", temperature.ToLocale());
+  text = StringUtils::Format("%.0f", temperature.To(g_langInfo.GetTempUnit()));
 }
 
 void CWeatherJob::LoadLocalizedToken()

--- a/xbmc/utils/Weather.cpp
+++ b/xbmc/utils/Weather.cpp
@@ -153,71 +153,6 @@ void CWeatherJob::LocalizeOverview(std::string &str)
   str = StringUtils::Join(words, " ");
 }
 
-// input param must be kmh
-int CWeatherJob::ConvertSpeed(int curSpeed)
-{
-  switch (g_langInfo.GetSpeedUnit())
-  {
-  case CLangInfo::SPEED_UNIT_KMH:
-    break;
-  case CLangInfo::SPEED_UNIT_MPS:
-    curSpeed=(int)(curSpeed * (1000.0 / 3600.0) + 0.5);
-    break;
-  case CLangInfo::SPEED_UNIT_MPH:
-    curSpeed=(int)(curSpeed / (8.0 / 5.0));
-    break;
-  case CLangInfo::SPEED_UNIT_MPMIN:
-    curSpeed=(int)(curSpeed * (1000.0 / 3600.0) + 0.5*60);
-    break;
-  case CLangInfo::SPEED_UNIT_FTH:
-    curSpeed=(int)(curSpeed * 3280.8398888889f);
-    break;
-  case CLangInfo::SPEED_UNIT_FTMIN:
-    curSpeed=(int)(curSpeed * 54.6805555556f);
-    break;
-  case CLangInfo::SPEED_UNIT_FTS:
-    curSpeed=(int)(curSpeed * 0.911344f);
-    break;
-  case CLangInfo::SPEED_UNIT_KTS:
-    curSpeed=(int)(curSpeed * 0.5399568f);
-    break;
-  case CLangInfo::SPEED_UNIT_INCHPS:
-    curSpeed=(int)(curSpeed * 10.9361388889f);
-    break;
-  case CLangInfo::SPEED_UNIT_YARDPS:
-    curSpeed=(int)(curSpeed * 0.3037814722f);
-    break;
-  case CLangInfo::SPEED_UNIT_FPF:
-    curSpeed=(int)(curSpeed * 1670.25f);
-    break;
-  case CLangInfo::SPEED_UNIT_BEAUFORT:
-    {
-      float knot=(float)curSpeed * 0.5399568f; // to kts first
-      if(knot<=1.0) curSpeed=0;
-      if(knot>1.0 && knot<3.5) curSpeed=1;
-      if(knot>=3.5 && knot<6.5) curSpeed=2;
-      if(knot>=6.5 && knot<10.5) curSpeed=3;
-      if(knot>=10.5 && knot<16.5) curSpeed=4;
-      if(knot>=16.5 && knot<21.5) curSpeed=5;
-      if(knot>=21.5 && knot<27.5) curSpeed=6;
-      if(knot>=27.5 && knot<33.5) curSpeed=7;
-      if(knot>=33.5 && knot<40.5) curSpeed=8;
-      if(knot>=40.5 && knot<47.5) curSpeed=9;
-      if(knot>=47.5 && knot<55.5) curSpeed=10;
-      if(knot>=55.5 && knot<63.5) curSpeed=11;
-      if(knot>=63.5 && knot<74.5) curSpeed=12;
-      if(knot>=74.5 && knot<80.5) curSpeed=13;
-      if(knot>=80.5 && knot<89.5) curSpeed=14;
-      if(knot>=89.5) curSpeed=15;
-    }
-    break;
-  default:
-    assert(false);
-  }
-
-  return curSpeed;
-}
-
 void CWeatherJob::FormatTemperature(std::string &text, int temp)
 {
   CTemperature temperature = CTemperature::CreateFromCelsius(temp);
@@ -337,7 +272,7 @@ void CWeatherJob::SetFromProperties()
         strtol(window->GetProperty("Current.FeelsLike").asString().c_str(),0,10));
     m_info.currentUVIndex = window->GetProperty("Current.UVIndex").asString();
     LocalizeOverview(m_info.currentUVIndex);
-    int speed = ConvertSpeed(strtol(window->GetProperty("Current.Wind").asString().c_str(),0,10));
+    CSpeed speed = CSpeed::CreateFromKilometresPerHour(strtol(window->GetProperty("Current.Wind").asString().c_str(),0,10));
     std::string direction = window->GetProperty("Current.WindDirection").asString();
     if (direction == "CALM")
       m_info.currentWind = g_localizeStrings.Get(1410);
@@ -345,9 +280,9 @@ void CWeatherJob::SetFromProperties()
     {
       LocalizeOverviewToken(direction);
       m_info.currentWind = StringUtils::Format(g_localizeStrings.Get(434).c_str(),
-          direction.c_str(), speed, g_langInfo.GetSpeedUnitString().c_str());
+          direction.c_str(), (int)speed.To(g_langInfo.GetSpeedUnit()), g_langInfo.GetSpeedUnitString().c_str());
     }
-    std::string windspeed = StringUtils::Format("%i %s",speed,g_langInfo.GetSpeedUnitString().c_str());
+    std::string windspeed = StringUtils::Format("%i %s", (int)speed.To(g_langInfo.GetSpeedUnit()), g_langInfo.GetSpeedUnitString().c_str());
     window->SetProperty("Current.WindSpeed",windspeed);
     FormatTemperature(m_info.currentDewPoint,
         strtol(window->GetProperty("Current.DewPoint").asString().c_str(),0,10));

--- a/xbmc/utils/Weather.cpp
+++ b/xbmc/utils/Weather.cpp
@@ -221,7 +221,7 @@ int CWeatherJob::ConvertSpeed(int curSpeed)
 void CWeatherJob::FormatTemperature(std::string &text, int temp)
 {
   CTemperature temperature = CTemperature::CreateFromCelsius(temp);
-  text = StringUtils::Format("%.0f", temperature.To(g_langInfo.GetTempUnit()));
+  text = StringUtils::Format("%.0f", temperature.To(g_langInfo.GetTemperatureUnit()));
 }
 
 void CWeatherJob::LoadLocalizedToken()

--- a/xbmc/utils/Weather.cpp
+++ b/xbmc/utils/Weather.cpp
@@ -25,7 +25,7 @@
 #include "filesystem/ZipManager.h"
 #include "XMLUtils.h"
 #include "utils/POUtils.h"
-#include "Temperature.h"
+#include "utils/Temperature.h"
 #include "network/Network.h"
 #include "Application.h"
 #include "settings/lib/Setting.h"

--- a/xbmc/utils/test/TestCPUInfo.cpp
+++ b/xbmc/utils/test/TestCPUInfo.cpp
@@ -19,7 +19,7 @@
  */
 
 #include "utils/CPUInfo.h"
-#include "Temperature.h"
+#include "utils/Temperature.h"
 #include "settings/AdvancedSettings.h"
 
 #ifdef TARGET_POSIX

--- a/xbmc/utils/test/TestLangCodeExpander.cpp
+++ b/xbmc/utils/test/TestLangCodeExpander.cpp
@@ -22,20 +22,20 @@
 
 #include "gtest/gtest.h"
 
-TEST(TestLangCodeExpander, ConvertTwoToThreeCharCode)
+TEST(TestLangCodeExpander, ConvertISO6391ToISO6392T)
 {
   std::string refstr, varstr;
 
   refstr = "eng";
-  g_LangCodeExpander.ConvertTwoToThreeCharCode(varstr, "en");
+  g_LangCodeExpander.ConvertISO6391ToISO6392T("en", varstr);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 }
 
-TEST(TestLangCodeExpander, ConvertToThreeCharCode)
+TEST(TestLangCodeExpander, ConvertToISO6392T)
 {
   std::string refstr, varstr;
 
   refstr = "eng";
-  g_LangCodeExpander.ConvertToThreeCharCode(varstr, "en");
+  g_LangCodeExpander.ConvertToISO6392T("en", varstr);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 }

--- a/xbmc/video/PlayerController.cpp
+++ b/xbmc/video/PlayerController.cpp
@@ -69,7 +69,7 @@ bool CPlayerController::OnAction(const CAction &action)
         {
           SPlayerSubtitleStreamInfo info;
           g_application.m_pPlayer->GetSubtitleStreamInfo(g_application.m_pPlayer->GetSubtitle(), info);
-          if (!g_LangCodeExpander.Lookup(lang, info.language))
+          if (!g_LangCodeExpander.Lookup(info.language, lang))
             lang = g_localizeStrings.Get(13205); // Unknown
 
           if (info.name.length() == 0)
@@ -116,7 +116,7 @@ bool CPlayerController::OnAction(const CAction &action)
         {
           SPlayerSubtitleStreamInfo info;
           g_application.m_pPlayer->GetSubtitleStreamInfo(currentSub, info);
-          if (!g_LangCodeExpander.Lookup(lang, info.language))
+          if (!g_LangCodeExpander.Lookup(info.language, lang))
             lang = g_localizeStrings.Get(13205); // Unknown
 
           if (info.name.length() == 0)
@@ -212,7 +212,7 @@ bool CPlayerController::OnAction(const CAction &action)
         std::string lan;
         SPlayerAudioStreamInfo info;
         g_application.m_pPlayer->GetAudioStreamInfo(currentAudio, info);
-        if (!g_LangCodeExpander.Lookup(lan, info.language))
+        if (!g_LangCodeExpander.Lookup(info.language, lan))
           lan = g_localizeStrings.Get(13205); // Unknown
         if (info.name.empty())
           aud = lan;

--- a/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
@@ -435,7 +435,7 @@ void CGUIDialogAudioSubtitleSettings::AudioStreamsOptionFiller(const CSetting *s
     SPlayerAudioStreamInfo info;
     g_application.m_pPlayer->GetAudioStreamInfo(i, info);
 
-    if (!g_LangCodeExpander.Lookup(strLanguage, info.language))
+    if (!g_LangCodeExpander.Lookup(info.language, strLanguage))
       strLanguage = g_localizeStrings.Get(13205); // Unknown
 
     if (info.name.length() == 0)
@@ -467,7 +467,7 @@ void CGUIDialogAudioSubtitleSettings::SubtitleStreamsOptionFiller(const CSetting
     std::string strItem;
     std::string strLanguage;
 
-    if (!g_LangCodeExpander.Lookup(strLanguage, info.language))
+    if (!g_LangCodeExpander.Lookup(info.language, strLanguage))
       strLanguage = g_localizeStrings.Get(13205); // Unknown
 
     if (info.name.length() == 0)

--- a/xbmc/video/dialogs/GUIDialogSubtitles.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitles.cpp
@@ -344,7 +344,7 @@ void CGUIDialogSubtitles::Search(const std::string &search/*=""*/)
 
     g_application.m_pPlayer->GetAudioStreamInfo(CURRENT_STREAM, info);
 
-    if (!g_LangCodeExpander.Lookup(strLanguage, info.language))
+    if (!g_LangCodeExpander.Lookup(info.language, strLanguage))
       strLanguage = "Unknown";
 
     preferredLanguage = strLanguage;
@@ -502,7 +502,7 @@ void CGUIDialogSubtitles::OnDownloadComplete(const CFileItemList *items, const s
 
   // Extract the language and appropriate extension
   std::string strSubLang;
-  g_LangCodeExpander.ConvertToTwoCharCode(strSubLang, language);
+  g_LangCodeExpander.ConvertToISO6391(language, strSubLang);
 
   // Iterate over all items to transfer
   for (unsigned int i = 0; i < vecFiles.size() && i < (unsigned int) items->Size(); i++)

--- a/xbmc/windows/GUIWindowWeather.cpp
+++ b/xbmc/windows/GUIWindowWeather.cpp
@@ -192,11 +192,11 @@ void CGUIWindowWeather::UpdateButtons()
   SET_CONTROL_LABEL(CONTROL_LABELUPDATED, g_weatherManager.GetLastUpdateTime());
 
   SET_CONTROL_LABEL(WEATHER_LABEL_CURRENT_COND, g_weatherManager.GetInfo(WEATHER_LABEL_CURRENT_COND));
-  SET_CONTROL_LABEL(WEATHER_LABEL_CURRENT_TEMP, g_weatherManager.GetInfo(WEATHER_LABEL_CURRENT_TEMP) + g_langInfo.GetTempUnitString());
-  SET_CONTROL_LABEL(WEATHER_LABEL_CURRENT_FEEL, g_weatherManager.GetInfo(WEATHER_LABEL_CURRENT_FEEL) + g_langInfo.GetTempUnitString());
+  SET_CONTROL_LABEL(WEATHER_LABEL_CURRENT_TEMP, g_weatherManager.GetInfo(WEATHER_LABEL_CURRENT_TEMP) + g_langInfo.GetTemperatureUnitString());
+  SET_CONTROL_LABEL(WEATHER_LABEL_CURRENT_FEEL, g_weatherManager.GetInfo(WEATHER_LABEL_CURRENT_FEEL) + g_langInfo.GetTemperatureUnitString());
   SET_CONTROL_LABEL(WEATHER_LABEL_CURRENT_UVID, g_weatherManager.GetInfo(WEATHER_LABEL_CURRENT_UVID));
   SET_CONTROL_LABEL(WEATHER_LABEL_CURRENT_WIND, g_weatherManager.GetInfo(WEATHER_LABEL_CURRENT_WIND));
-  SET_CONTROL_LABEL(WEATHER_LABEL_CURRENT_DEWP, g_weatherManager.GetInfo(WEATHER_LABEL_CURRENT_DEWP) + g_langInfo.GetTempUnitString());
+  SET_CONTROL_LABEL(WEATHER_LABEL_CURRENT_DEWP, g_weatherManager.GetInfo(WEATHER_LABEL_CURRENT_DEWP) + g_langInfo.GetTemperatureUnitString());
   SET_CONTROL_LABEL(WEATHER_LABEL_CURRENT_HUMI, g_weatherManager.GetInfo(WEATHER_LABEL_CURRENT_HUMI));
   SET_CONTROL_FILENAME(WEATHER_IMAGE_CURRENT_ICON, g_weatherManager.GetInfo(WEATHER_IMAGE_CURRENT_ICON));
 
@@ -211,8 +211,8 @@ void CGUIWindowWeather::UpdateButtons()
   for (int i = 0; i < NUM_DAYS; i++)
   {
     SET_CONTROL_LABEL(CONTROL_LABELD0DAY + (i*10), g_weatherManager.GetForecast(i).m_day);
-    SET_CONTROL_LABEL(CONTROL_LABELD0HI + (i*10), g_weatherManager.GetForecast(i).m_high + g_langInfo.GetTempUnitString());
-    SET_CONTROL_LABEL(CONTROL_LABELD0LOW + (i*10), g_weatherManager.GetForecast(i).m_low + g_langInfo.GetTempUnitString());
+    SET_CONTROL_LABEL(CONTROL_LABELD0HI + (i*10), g_weatherManager.GetForecast(i).m_high + g_langInfo.GetTemperatureUnitString());
+    SET_CONTROL_LABEL(CONTROL_LABELD0LOW + (i*10), g_weatherManager.GetForecast(i).m_low + g_langInfo.GetTemperatureUnitString());
     SET_CONTROL_LABEL(CONTROL_LABELD0GEN + (i*10), g_weatherManager.GetForecast(i).m_overview);
     SET_CONTROL_FILENAME(CONTROL_IMAGED0IMG + (i*10), g_weatherManager.GetForecast(i).m_icon);
   }


### PR DESCRIPTION
These commits basically add temperature and speed unit settings to `Appearance` -> `International` which can be set independently of the `Region` setting. The idea is that the default setting is `regional` which will pick whatever is specified in the configured region but it is also possible to choose another unit from a list of supported units.

Here's a screenshot of the new settings:
![Screenshot](https://www.dropbox.com/s/90tt1ctgywpomup/Screenshot%202015-03-08%2002.15.37.png?dl=1)

Apart from the commits adding/improving `CTemperature`, `CSpeed`, `CLangInfo` and the settings logic I also added a commit (see 588e5c233b28191cc5d210f7b029a8013e45857f) that refactors `CLangCodeExpander` by basically renaming most of the methods to something more obvious using the proper ISO 639-X names.
