### PR TITLE
[CONFLUENCE] get rid of 0.75 effectslowdown

### DIFF
--- a/addons/skin.confluence/720p/AddonBrowser.xml
+++ b/addons/skin.confluence/720p/AddonBrowser.xml
@@ -8,11 +8,15 @@
 		<include>CommonBackground</include>
 		<include>ContentPanelBackgrounds</include>
 		<control type="group">
-			<include>Window_OpenClose_Animation</include>		
-			<include>CommonRootView</include> <!-- view id = 50 -->
-			<include>FullWidthList</include> <!-- view id = 51 -->
-			<include>AddonInfoListView1</include> <!-- view id = 550 -->
-			<include>AddonInfoThumbView1</include> <!-- view id = 551 -->
+			<include>Window_OpenClose_Animation</include>
+			<include>CommonRootView</include>
+			<!-- view id = 50 -->
+			<include>FullWidthList</include>
+			<!-- view id = 51 -->
+			<include>AddonInfoListView1</include>
+			<!-- view id = 550 -->
+			<include>AddonInfoThumbView1</include>
+			<!-- view id = 551 -->
 		</control>
 		<include>CommonPageCount</include>
 		<include>CommonNowPlaying</include>

--- a/addons/skin.confluence/720p/DialogAddonSettings.xml
+++ b/addons/skin.confluence/720p/DialogAddonSettings.xml
@@ -173,7 +173,6 @@
 				<ondown>2</ondown>
 			</control>
 		</control>
-
 		<control type="button" id="13">
 			<description>Default Category Button</description>
 			<height>40</height>

--- a/addons/skin.confluence/720p/DialogAlbumInfo.xml
+++ b/addons/skin.confluence/720p/DialogAlbumInfo.xml
@@ -5,8 +5,8 @@
 	<controls>
 		<control type="group">
 			<visible>!Window.IsVisible(FileBrowser)</visible>
-			<animation effect="slide" start="1100,0" end="0,0" time="400" tween="quadratic" easing="out">WindowOpen</animation>
-			<animation effect="slide" start="0,0" end="1100,0" time="400" tween="quadratic" easing="out">WindowClose</animation>
+			<animation effect="slide" start="1100,0" end="0,0" time="300" tween="quadratic" easing="out">WindowOpen</animation>
+			<animation effect="slide" start="0,0" end="1100,0" time="300" tween="quadratic" easing="out">WindowClose</animation>
 			<control type="image">
 				<left>180</left>
 				<top>0</top>
@@ -32,8 +32,8 @@
 				<visible>system.getbool(input.enablemouse)</visible>
 			</control>
 			<control type="group">
-				<animation effect="fade" delay="400" start="0" end="100" time="200">WindowOpen</animation>
-				<animation effect="fade" start="100" end="0" time="200">WindowClose</animation>
+				<animation effect="fade" delay="300" start="0" end="100" time="150">WindowOpen</animation>
+				<animation effect="fade" start="100" end="0" time="150">WindowClose</animation>
 				<control type="label">
 					<description>Album header label</description>
 					<left>210</left>

--- a/addons/skin.confluence/720p/DialogBusy.xml
+++ b/addons/skin.confluence/720p/DialogBusy.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
-	<animation effect="fade" time="100">WindowOpen</animation>
-	<animation effect="fade" time="200">WindowClose</animation>
+	<animation effect="fade" time="75">WindowOpen</animation>
+	<animation effect="fade" time="150">WindowClose</animation>
 	<coordinates>
 		<system>1</system>
 		<left>0</left>
@@ -27,7 +27,7 @@
 				<height>32</height>
 				<texture>busy.png</texture>
 				<aspectratio>keep</aspectratio>
-				<animation effect="rotate" start="0" end="360" center="36,36" time="1200" loop="true" condition="true">conditional</animation>
+				<animation effect="rotate" start="0" end="360" center="36,36" time="900" loop="true" condition="true">conditional</animation>
 			</control>
 			<control type="label">
 				<description>Busy label</description>

--- a/addons/skin.confluence/720p/DialogContentSettings.xml
+++ b/addons/skin.confluence/720p/DialogContentSettings.xml
@@ -9,7 +9,7 @@
 	<include>dialogeffect</include>
 	<controls>
 		<control type="group">
-			<animation effect="fade" start="100" end="0" time="200" condition="Window.IsActive(AddonSettings)">Conditional</animation>
+			<animation effect="fade" start="100" end="0" time="150" condition="Window.IsActive(AddonSettings)">Conditional</animation>
 			<control type="image">
 				<description>background image</description>
 				<left>0</left>

--- a/addons/skin.confluence/720p/DialogExtendedProgressBar.xml
+++ b/addons/skin.confluence/720p/DialogExtendedProgressBar.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
-	<defaultcontrol/>
+	<defaultcontrol />
 	<animation effect="slide" start="0,-70" end="0,0" time="100">WindowOpen</animation>
 	<animation effect="slide" start="0,0" end="0,-70" delay="400" time="100">WindowClose</animation>
 	<controls>

--- a/addons/skin.confluence/720p/DialogExtendedProgressBar.xml
+++ b/addons/skin.confluence/720p/DialogExtendedProgressBar.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
 	<defaultcontrol />
-	<animation effect="slide" start="0,-70" end="0,0" time="100">WindowOpen</animation>
-	<animation effect="slide" start="0,0" end="0,-70" delay="400" time="100">WindowClose</animation>
+	<animation effect="slide" start="0,-70" end="0,0" time="75">WindowOpen</animation>
+	<animation effect="slide" start="0,0" end="0,-70" delay="300" time="75">WindowClose</animation>
 	<controls>
 		<control type="group">
 			<left>720</left>
 			<top>0</top>
-			<animation effect="slide" end="0,-80" time="200" condition="Window.IsVisible(FullscreenVideo) | Window.IsVisible(Visualisation)">conditional</animation>
+			<animation effect="slide" end="0,-80" time="150" condition="Window.IsVisible(FullscreenVideo) | Window.IsVisible(Visualisation)">conditional</animation>
 			<control type="image">
 				<left>0</left>
 				<top>-10</top>

--- a/addons/skin.confluence/720p/DialogFavourites.xml
+++ b/addons/skin.confluence/720p/DialogFavourites.xml
@@ -8,8 +8,8 @@
 	</coordinates>
 	<controls>
 		<control type="group">
-			<animation effect="slide" start="400,0" end="0,0" time="400" tween="quadratic" easing="out">WindowOpen</animation>
-			<animation effect="slide" start="0,0" end="400,0" time="400" tween="quadratic" easing="out">WindowClose</animation>
+			<animation effect="slide" start="400,0" end="0,0" time="300" tween="quadratic" easing="out">WindowOpen</animation>
+			<animation effect="slide" start="0,0" end="400,0" time="300" tween="quadratic" easing="out">WindowClose</animation>
 			<control type="image">
 				<left>400r</left>
 				<top>0</top>

--- a/addons/skin.confluence/720p/DialogKaiToast.xml
+++ b/addons/skin.confluence/720p/DialogKaiToast.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
-	<animation effect="fade" start="0" end="100" time="200">WindowOpen</animation>
-	<animation effect="fade" start="100" end="0" time="200">WindowClose</animation>
+	<animation effect="fade" start="0" end="100" time="150">WindowOpen</animation>
+	<animation effect="fade" start="100" end="0" time="150">WindowClose</animation>
 	<coordinates>
 		<left>860</left>
 		<top>640</top>
 	</coordinates>
 	<controls>
 		<control type="group">
-			<animation effect="slide" start="0,0" end="-190,0" time="200" condition="Window.IsVisible(BusyDialog)">conditional</animation>
+			<animation effect="slide" start="0,0" end="-190,0" time="150" condition="Window.IsVisible(BusyDialog)">conditional</animation>
 			<control type="image">
 				<left>0</left>
 				<top>0</top>

--- a/addons/skin.confluence/720p/DialogKaraokeSongSelector.xml
+++ b/addons/skin.confluence/720p/DialogKaraokeSongSelector.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window type="dialog">
-	<animation effect="slide" start="0,-40" end="0,0" time="100">WindowOpen</animation>
-	<animation effect="slide" start="0,0" end="0,-40" delay="400" time="100">WindowClose</animation>
+	<animation effect="slide" start="0,-40" end="0,0" time="75">WindowOpen</animation>
+	<animation effect="slide" start="0,0" end="0,-40" delay="300" time="75">WindowClose</animation>
 	<controls>
 		<control type="group">
 			<left>100</left>

--- a/addons/skin.confluence/720p/DialogKeyboard.xml
+++ b/addons/skin.confluence/720p/DialogKeyboard.xml
@@ -179,7 +179,7 @@
 						<include>KeyboardButton</include>
 					</control>
 				</control>
-					<!-- 2nd row -->
+				<!-- 2nd row -->
 				<control type="grouplist">
 					<orientation>horizontal</orientation>
 					<top>50</top>
@@ -274,7 +274,7 @@
 						<include>KeyboardButton</include>
 					</control>
 				</control>
-					<!-- 3rd row -->
+				<!-- 3rd row -->
 				<control type="grouplist">
 					<top>100</top>
 					<orientation>horizontal</orientation>
@@ -369,7 +369,7 @@
 						<include>KeyboardButton</include>
 					</control>
 				</control>
-					<!-- 4th row -->
+				<!-- 4th row -->
 				<control type="grouplist">
 					<top>150</top>
 					<itemgap>0</itemgap>
@@ -478,7 +478,7 @@
 						<include>KeyboardButton</include>
 					</control>
 				</control>
-					<!-- 5th row -->
+				<!-- 5th row -->
 				<control type="grouplist">
 					<top>200</top>
 					<itemgap>0</itemgap>

--- a/addons/skin.confluence/720p/DialogMediaFilter.xml
+++ b/addons/skin.confluence/720p/DialogMediaFilter.xml
@@ -54,7 +54,6 @@
 			<ondown>10</ondown>
 			<visible>system.getbool(input.enablemouse)</visible>
 		</control>
-
 		<control type="grouplist" id="5">
 			<description>control area</description>
 			<left>30</left>
@@ -83,7 +82,6 @@
 			<showonepage>false</showonepage>
 			<orientation>vertical</orientation>
 		</control>
-
 		<control type="button" id="7">
 			<description>Default Button</description>
 			<left>0</left>
@@ -143,7 +141,6 @@
 			<texturenofocus border="5">button-nofocus.png</texturenofocus>
 			<texturefocus border="5">button-focus2.png</texturefocus>
 		</control>
-
 		<control type="group" id="9001">
 			<left>190</left>
 			<top>435</top>

--- a/addons/skin.confluence/720p/DialogPVRChannelManager.xml
+++ b/addons/skin.confluence/720p/DialogPVRChannelManager.xml
@@ -8,7 +8,6 @@
 		<top>65</top>
 	</coordinates>
 	<include>dialogeffect</include>
-
 	<controls>
 		<control type="image">
 			<left>0</left>
@@ -504,7 +503,7 @@
 					<height>200</height>
 					<aspectratio>keep</aspectratio>
 					<texture background="true">$INFO[Container(20).ListItem.Icon]</texture>
-				</control> 
+				</control>
 			</control>
 			<control type="label">
 				<description>Page Count Label</description>

--- a/addons/skin.confluence/720p/DialogPVRGroupManager.xml
+++ b/addons/skin.confluence/720p/DialogPVRGroupManager.xml
@@ -480,7 +480,6 @@
 			</control>
 		</control>
 		<include>Clock</include>
-
 		<control type="label" id="20">
 			<description>Fake Label used to pass on name label</description>
 			<visible>false</visible>

--- a/addons/skin.confluence/720p/DialogPVRGroupManager.xml
+++ b/addons/skin.confluence/720p/DialogPVRGroupManager.xml
@@ -4,8 +4,8 @@
 	<controls>
 		<control type="group">
 			<visible>!Window.IsVisible(FileBrowser)</visible>
-			<animation effect="slide" start="1150,0" end="0,0" time="400" tween="quadratic" easing="out">WindowOpen</animation>
-			<animation effect="slide" start="0,0" end="1150,0" time="400" tween="quadratic" easing="out">WindowClose</animation>
+			<animation effect="slide" start="1150,0" end="0,0" time="300" tween="quadratic" easing="out">WindowOpen</animation>
+			<animation effect="slide" start="0,0" end="1150,0" time="300" tween="quadratic" easing="out">WindowClose</animation>
 			<control type="image">
 				<left>50</left>
 				<top>0</top>
@@ -48,8 +48,8 @@
 				<visible>system.getbool(input.enablemouse)</visible>
 			</control>
 			<control type="group">
-				<animation effect="fade" delay="400" start="0" end="100" time="200">WindowOpen</animation>
-				<animation effect="fade" start="100" end="0" time="200">WindowClose</animation>
+				<animation effect="fade" delay="300" start="0" end="100" time="150">WindowOpen</animation>
+				<animation effect="fade" start="100" end="0" time="150">WindowClose</animation>
 				<control type="label">
 					<description>header label</description>
 					<left>90</left>

--- a/addons/skin.confluence/720p/DialogPVRGuideOSD.xml
+++ b/addons/skin.confluence/720p/DialogPVRGuideOSD.xml
@@ -263,7 +263,7 @@
 				<align>right</align>
 				<aligny>center</aligny>
 				<label>([COLOR=blue]$INFO[Container(11).NumItems][/COLOR]) $LOCALIZE[31025] - $LOCALIZE[31024] ([COLOR=blue]$INFO[Container(11).CurrentPage]/$INFO[Container(11).NumPages][/COLOR])</label>
-				<include>Window_OpenClose_Animation</include>		
+				<include>Window_OpenClose_Animation</include>
 			</control>
 		</control>
 	</controls>

--- a/addons/skin.confluence/720p/DialogPeripheralManager.xml
+++ b/addons/skin.confluence/720p/DialogPeripheralManager.xml
@@ -67,7 +67,6 @@
 				<ondown>10</ondown>
 				<visible>system.getbool(input.enablemouse)</visible>
 			</control>
-
 			<control type="list" id="20">
 				<left>20</left>
 				<top>65</top>
@@ -182,7 +181,6 @@
 					</control>
 				</focusedlayout>
 			</control>
-
 			<control type="scrollbar" id="61">
 				<left>570</left>
 				<top>65</top>

--- a/addons/skin.confluence/720p/DialogPeripheralSettings.xml
+++ b/addons/skin.confluence/720p/DialogPeripheralSettings.xml
@@ -131,7 +131,6 @@
 			<height>2</height>
 			<texture>separator2.png</texture>
 		</control>
-
 		<control type="group" id="9000">
 			<left>40</left>
 			<top>505</top>

--- a/addons/skin.confluence/720p/DialogSeekBar.xml
+++ b/addons/skin.confluence/720p/DialogSeekBar.xml
@@ -2,8 +2,8 @@
 <window>
 	<defaultcontrol>1</defaultcontrol>
 	<visible>Player.Seeking | Player.DisplayAfterSeek | Player.Paused | Player.Forwarding | Player.Rewinding</visible>
-	<animation effect="fade" start="0" end="100" time="200">WindowOpen</animation>
-	<animation effect="fade" start="100" end="0" time="200">WindowClose</animation>
+	<animation effect="fade" start="0" end="100" time="150">WindowOpen</animation>
+	<animation effect="fade" start="100" end="0" time="150">WindowClose</animation>
 	<controls>
 		<control type="group">
 			<visible>player.chaptercount + Window.IsVisible(FullScreenVideo)</visible>

--- a/addons/skin.confluence/720p/DialogSeekBar.xml
+++ b/addons/skin.confluence/720p/DialogSeekBar.xml
@@ -98,7 +98,6 @@
 					<texture>OSDPlay.png</texture>
 					<visible>Player.Playing</visible>
 				</control>
-
 				<control type="image">
 					<left>28</left>
 					<top>4</top>
@@ -139,7 +138,6 @@
 					<texture>OSD32x.png</texture>
 					<visible>Player.Rewinding32x</visible>
 				</control>
-
 				<control type="image">
 					<left>34</left>
 					<top>4</top>

--- a/addons/skin.confluence/720p/DialogSlider.xml
+++ b/addons/skin.confluence/720p/DialogSlider.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
 	<defaultcontrol>11</defaultcontrol>
-	<animation effect="slide" start="0,-80" end="0,0" time="100">WindowOpen</animation>
-	<animation effect="slide" start="0,0" end="0,-80" time="100">WindowClose</animation>
+	<animation effect="slide" start="0,-80" end="0,0" time="75">WindowOpen</animation>
+	<animation effect="slide" start="0,0" end="0,-80" time="75">WindowClose</animation>
 	<coordinates>
 		<system>1</system>
 		<left>405</left>

--- a/addons/skin.confluence/720p/DialogSubtitles.xml
+++ b/addons/skin.confluence/720p/DialogSubtitles.xml
@@ -7,9 +7,9 @@
 	</coordinates>
 	<controls>
 		<control type="group" id="250">
-			<animation effect="slide" start="0,0" end="900,0" time="500" tween="quadratic" easing="out">WindowClose</animation> 
+			<animation effect="slide" start="0,0" end="900,0" time="500" tween="quadratic" easing="out">WindowClose</animation>
 			<animation type="Conditional" condition="Control.HasFocus(150) | Control.HasFocus(160)" reversible="true">
-				<effect type="slide" end="-250,0" time="400"/>
+				<effect type="slide" end="-250,0" time="400" />
 			</animation>
 			<control type="button" id="8999">
 				<description>Fake button for mouse control</description>
@@ -326,7 +326,7 @@
 					<width>720</width>
 					<height>4</height>
 					<texture>separator.png</texture>
-					<animation effect="rotate" start="0" end="90" center="auto" time="0" condition="true">Conditional</animation>		
+					<animation effect="rotate" start="0" end="90" center="auto" time="0" condition="true">Conditional</animation>
 				</control>
 				<control type="label">
 					<left>905</left>

--- a/addons/skin.confluence/720p/DialogSubtitles.xml
+++ b/addons/skin.confluence/720p/DialogSubtitles.xml
@@ -7,9 +7,9 @@
 	</coordinates>
 	<controls>
 		<control type="group" id="250">
-			<animation effect="slide" start="0,0" end="900,0" time="500" tween="quadratic" easing="out">WindowClose</animation>
+			<animation effect="slide" start="0,0" end="900,0" time="375" tween="quadratic" easing="out">WindowClose</animation>
 			<animation type="Conditional" condition="Control.HasFocus(150) | Control.HasFocus(160)" reversible="true">
-				<effect type="slide" end="-250,0" time="400" />
+				<effect type="slide" end="-250,0" time="300" />
 			</animation>
 			<control type="button" id="8999">
 				<description>Fake button for mouse control</description>

--- a/addons/skin.confluence/720p/DialogTextViewer.xml
+++ b/addons/skin.confluence/720p/DialogTextViewer.xml
@@ -3,8 +3,8 @@
 	<defaultcontrol>61</defaultcontrol>
 	<controls>
 		<control type="group">
-			<animation effect="slide" start="1100,0" end="0,0" time="400" tween="quadratic" easing="out">WindowOpen</animation>
-			<animation effect="slide" start="0,0" end="1100,0" time="400" tween="quadratic" easing="out">WindowClose</animation>
+			<animation effect="slide" start="1100,0" end="0,0" time="300" tween="quadratic" easing="out">WindowOpen</animation>
+			<animation effect="slide" start="0,0" end="1100,0" time="300" tween="quadratic" easing="out">WindowClose</animation>
 			<control type="image">
 				<left>180</left>
 				<top>0</top>
@@ -30,8 +30,8 @@
 				<visible>system.getbool(input.enablemouse)</visible>
 			</control>
 			<control type="group">
-				<animation effect="fade" delay="400" start="0" end="100" time="200">WindowOpen</animation>
-				<animation effect="fade" start="100" end="0" time="200">WindowClose</animation>
+				<animation effect="fade" delay="300" start="0" end="100" time="150">WindowOpen</animation>
+				<animation effect="fade" start="100" end="0" time="150">WindowClose</animation>
 				<control type="label" id="1">
 					<description>header label</description>
 					<left>210</left>

--- a/addons/skin.confluence/720p/DialogVideoInfo.xml
+++ b/addons/skin.confluence/720p/DialogVideoInfo.xml
@@ -6,8 +6,8 @@
 	<controls>
 		<control type="group">
 			<visible>!Window.IsVisible(FileBrowser)</visible>
-			<animation effect="slide" start="1100,0" end="0,0" time="400" tween="quadratic" easing="out">WindowOpen</animation>
-			<animation effect="slide" start="0,0" end="1100,0" time="400" tween="quadratic" easing="out">WindowClose</animation>
+			<animation effect="slide" start="1100,0" end="0,0" time="300" tween="quadratic" easing="out">WindowOpen</animation>
+			<animation effect="slide" start="0,0" end="1100,0" time="300" tween="quadratic" easing="out">WindowClose</animation>
 			<control type="image">
 				<left>180</left>
 				<top>0</top>
@@ -33,8 +33,8 @@
 				<visible>system.getbool(input.enablemouse)</visible>
 			</control>
 			<control type="group">
-				<animation effect="fade" delay="400" start="0" end="100" time="200">WindowOpen</animation>
-				<animation effect="fade" start="100" end="0" time="200">WindowClose</animation>
+				<animation effect="fade" delay="300" start="0" end="100" time="150">WindowOpen</animation>
+				<animation effect="fade" start="100" end="0" time="150">WindowClose</animation>
 				<control type="label">
 					<description>header label</description>
 					<left>210</left>

--- a/addons/skin.confluence/720p/DialogVolumeBar.xml
+++ b/addons/skin.confluence/720p/DialogVolumeBar.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
 	<defaultcontrol>1</defaultcontrol>
-	<animation effect="slide" start="0,-40" end="0,0" time="100">WindowOpen</animation>
-	<animation effect="slide" start="0,0" end="0,-40" delay="400" time="100">WindowClose</animation>
+	<animation effect="slide" start="0,-40" end="0,0" time="75">WindowOpen</animation>
+	<animation effect="slide" start="0,0" end="0,-40" delay="300" time="75">WindowClose</animation>
 	<controls>
 		<control type="group">
 			<left>820</left>

--- a/addons/skin.confluence/720p/FileBrowser.xml
+++ b/addons/skin.confluence/720p/FileBrowser.xml
@@ -131,23 +131,23 @@
 					<height>221</height>
 					<texture border="5">button-nofocus.png</texture>
 				</control>
-				<control type="image"> 
-					<left>690</left> 
-					<top>405</top> 
-					<width>211</width> 
-					<height>211</height> 
-					<aspectratio>keep</aspectratio> 
-					<texture background="true">$INFO[ListItem.Icon]</texture> 
-					<visible>!SubString(Control.GetLabel(416),*)</visible> 
-				</control> 
-				<control type="image"> 
-					<left>250</left> 
-					<top>465</top> 
-					<width>410</width> 
-					<height>200</height> 
-					<aspectratio>keep</aspectratio> 
-					<texture background="true" flipx="true">$INFO[ListItem.Icon]</texture> 
-					<visible>SubString(Control.GetLabel(416),*)</visible> 
+				<control type="image">
+					<left>690</left>
+					<top>405</top>
+					<width>211</width>
+					<height>211</height>
+					<aspectratio>keep</aspectratio>
+					<texture background="true">$INFO[ListItem.Icon]</texture>
+					<visible>!SubString(Control.GetLabel(416),*)</visible>
+				</control>
+				<control type="image">
+					<left>250</left>
+					<top>465</top>
+					<width>410</width>
+					<height>200</height>
+					<aspectratio>keep</aspectratio>
+					<texture background="true" flipx="true">$INFO[ListItem.Icon]</texture>
+					<visible>SubString(Control.GetLabel(416),*)</visible>
 				</control>
 				<control type="panel" id="450">
 					<left>20</left>
@@ -303,7 +303,6 @@
 						</control>
 					</focusedlayout>
 				</control>
-
 				<control type="scrollbar" id="60">
 					<left>640</left>
 					<top>90</top>

--- a/addons/skin.confluence/720p/FileBrowser.xml
+++ b/addons/skin.confluence/720p/FileBrowser.xml
@@ -10,10 +10,10 @@
 	<controls>
 		<control type="group">
 			<left>360</left>
-			<animation effect="slide" start="700,0" end="0,0" time="400" tween="quadratic" easing="out" condition="![Window.IsVisible(MovieInformation) | Window.IsVisible(MusicInformation)]">WindowOpen</animation>
-			<animation effect="slide" start="-180,0" end="0,0" time="400" tween="quadratic" easing="out" condition="[Window.IsVisible(MovieInformation) | Window.IsVisible(MusicInformation)]">WindowOpen</animation>
-			<animation effect="slide" start="0,0" end="700,0" time="400" tween="quadratic" easing="out" condition="![Window.IsVisible(MovieInformation) | Window.IsVisible(MusicInformation)]">WindowClose</animation>
-			<animation effect="slide" start="0,0" end="-400,0" time="400" tween="quadratic" easing="out" condition="[Window.IsVisible(MovieInformation) | Window.IsVisible(MusicInformation)]">WindowClose</animation>
+			<animation effect="slide" start="700,0" end="0,0" time="300" tween="quadratic" easing="out" condition="![Window.IsVisible(MovieInformation) | Window.IsVisible(MusicInformation)]">WindowOpen</animation>
+			<animation effect="slide" start="-180,0" end="0,0" time="300" tween="quadratic" easing="out" condition="[Window.IsVisible(MovieInformation) | Window.IsVisible(MusicInformation)]">WindowOpen</animation>
+			<animation effect="slide" start="0,0" end="700,0" time="300" tween="quadratic" easing="out" condition="![Window.IsVisible(MovieInformation) | Window.IsVisible(MusicInformation)]">WindowClose</animation>
+			<animation effect="slide" start="0,0" end="-400,0" time="300" tween="quadratic" easing="out" condition="[Window.IsVisible(MovieInformation) | Window.IsVisible(MusicInformation)]">WindowClose</animation>
 			<control type="image">
 				<left>0</left>
 				<top>0</top>
@@ -56,8 +56,8 @@
 				<visible>system.getbool(input.enablemouse)</visible>
 			</control>
 			<control type="group">
-				<animation effect="fade" delay="400" start="0" end="100" time="200">WindowOpen</animation>
-				<animation effect="fade" start="100" end="0" time="200">WindowClose</animation>
+				<animation effect="fade" delay="300" start="0" end="100" time="150">WindowOpen</animation>
+				<animation effect="fade" start="100" end="0" time="150">WindowClose</animation>
 				<control type="label" id="411">
 					<description>header label</description>
 					<left>40</left>

--- a/addons/skin.confluence/720p/FileManager.xml
+++ b/addons/skin.confluence/720p/FileManager.xml
@@ -39,12 +39,12 @@
 			<left>30</left>
 			<top>40</top>
 			<animation type="WindowOpen" reversible="false">
-				<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="300"/>
-				<effect type="fade" start="0" end="100" time="300"/>
+				<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="300" />
+				<effect type="fade" start="0" end="100" time="300" />
 			</animation>
 			<animation type="WindowClose" reversible="false">
-				<effect type="zoom" start="100" end="80" center="640,360" easing="in" tween="back" time="300"/>
-				<effect type="fade" start="100" end="0" time="300"/>
+				<effect type="zoom" start="100" end="80" center="640,360" easing="in" tween="back" time="300" />
+				<effect type="fade" start="100" end="0" time="300" />
 			</animation>
 			<control type="image">
 				<left>0</left>
@@ -213,12 +213,12 @@
 			<left>650</left>
 			<top>40</top>
 			<animation type="WindowOpen" reversible="false">
-				<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="300"/>
-				<effect type="fade" start="0" end="100" time="300"/>
+				<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="300" />
+				<effect type="fade" start="0" end="100" time="300" />
 			</animation>
 			<animation type="WindowClose" reversible="false">
-				<effect type="zoom" start="100" end="80" center="640,360" easing="in" tween="back" time="300"/>
-				<effect type="fade" start="100" end="0" time="300"/>
+				<effect type="zoom" start="100" end="80" center="640,360" easing="in" tween="back" time="300" />
+				<effect type="fade" start="100" end="0" time="300" />
 			</animation>
 			<control type="image">
 				<left>0</left>

--- a/addons/skin.confluence/720p/FileManager.xml
+++ b/addons/skin.confluence/720p/FileManager.xml
@@ -10,8 +10,8 @@
 			<width>1280</width>
 			<height>100</height>
 			<texture>floor.png</texture>
-			<animation effect="slide" start="0,10" end="0,0" time="200" condition="Window.Previous(Home)">WindowOpen</animation>
-			<animation effect="slide" start="0,0" end="0,10" time="200" condition="Window.Next(Home)">WindowClose</animation>
+			<animation effect="slide" start="0,10" end="0,0" time="150" condition="Window.Previous(Home)">WindowOpen</animation>
+			<animation effect="slide" start="0,0" end="0,10" time="150" condition="Window.Next(Home)">WindowClose</animation>
 		</control>
 		<control type="image">
 			<description>Section header image</description>
@@ -39,12 +39,12 @@
 			<left>30</left>
 			<top>40</top>
 			<animation type="WindowOpen" reversible="false">
-				<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="300" />
-				<effect type="fade" start="0" end="100" time="300" />
+				<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="225" />
+				<effect type="fade" start="0" end="100" time="225" />
 			</animation>
 			<animation type="WindowClose" reversible="false">
-				<effect type="zoom" start="100" end="80" center="640,360" easing="in" tween="back" time="300" />
-				<effect type="fade" start="100" end="0" time="300" />
+				<effect type="zoom" start="100" end="80" center="640,360" easing="in" tween="back" time="225" />
+				<effect type="fade" start="100" end="0" time="225" />
 			</animation>
 			<control type="image">
 				<left>0</left>
@@ -213,12 +213,12 @@
 			<left>650</left>
 			<top>40</top>
 			<animation type="WindowOpen" reversible="false">
-				<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="300" />
-				<effect type="fade" start="0" end="100" time="300" />
+				<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="225" />
+				<effect type="fade" start="0" end="100" time="225" />
 			</animation>
 			<animation type="WindowClose" reversible="false">
-				<effect type="zoom" start="100" end="80" center="640,360" easing="in" tween="back" time="300" />
-				<effect type="fade" start="100" end="0" time="300" />
+				<effect type="zoom" start="100" end="80" center="640,360" easing="in" tween="back" time="225" />
+				<effect type="fade" start="100" end="0" time="225" />
 			</animation>
 			<control type="image">
 				<left>0</left>

--- a/addons/skin.confluence/720p/Font.xml
+++ b/addons/skin.confluence/720p/Font.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <fonts>
-	<fontset id="Default" idloc="31390"> 
+	<fontset id="Default" idloc="31390">
 		<!-- Normal Fonts -->
 		<font>
 			<name>font10</name>
@@ -37,8 +37,6 @@
 			<filename>Roboto-Regular.ttf</filename>
 			<size>18</size>
 		</font>
-
-
 		<!-- Title Fonts -->
 		<font>
 			<name>font10_title</name>
@@ -75,7 +73,6 @@
 			<filename>Roboto-Bold.ttf</filename>
 			<size>35</size>
 		</font>
-
 		<font>
 			<name>font_MainMenu</name>
 			<filename>Roboto-Bold.ttf</filename>
@@ -87,7 +84,6 @@
 			<size>80</size>
 		</font>
 	</fontset>
-
 	<fontset id="Massive" idloc="15110">
 		<!-- Normal Fonts -->
 		<font>
@@ -125,8 +121,6 @@
 			<filename>Roboto-Regular.ttf</filename>
 			<size>25</size>
 		</font>
-		
-		
 		<!-- Title Fonts -->
 		<font>
 			<name>font10_title</name>
@@ -174,8 +168,7 @@
 			<size>80</size>
 		</font>
 	</fontset>
-	
-	<fontset id="DefaultNoCaps" idloc="31391"> 
+	<fontset id="DefaultNoCaps" idloc="31391">
 		<!-- Normal Fonts -->
 		<font>
 			<name>font10</name>
@@ -212,8 +205,6 @@
 			<filename>Roboto-Regular.ttf</filename>
 			<size>18</size>
 		</font>
-
-
 		<!-- Title Fonts -->
 		<font>
 			<name>font10_title</name>
@@ -250,7 +241,6 @@
 			<filename>Roboto-Bold.ttf</filename>
 			<size>35</size>
 		</font>
-
 		<font>
 			<name>font_MainMenu</name>
 			<filename>Roboto-Bold.ttf</filename>
@@ -262,8 +252,7 @@
 			<size>80</size>
 		</font>
 	</fontset>
-
-	<fontset id="Arial" idloc="31392"> 
+	<fontset id="Arial" idloc="31392">
 		<!-- Arial Font better for non English -->
 		<font>
 			<name>font10</name>
@@ -300,8 +289,6 @@
 			<filename>arial.ttf</filename>
 			<size>16</size>
 		</font>
-
-
 		<!-- Title Fonts -->
 		<font>
 			<name>font10_title</name>
@@ -345,7 +332,6 @@
 			<size>33</size>
 			<style>bold</style>
 		</font>
-
 		<font>
 			<name>font_MainMenu</name>
 			<filename>arial.ttf</filename>

--- a/addons/skin.confluence/720p/Home.xml
+++ b/addons/skin.confluence/720p/Home.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
 	<defaultcontrol always="true">9000</defaultcontrol>
-	<allowoverlay>no</allowoverlay>	
+	<allowoverlay>no</allowoverlay>
 	<onunload condition="Container(9000).Hasfocus(10) | Container(9000).Hasfocus(11) | ControlGroup(9010).HasFocus | ControlGroup(9016).HasFocus | ControlGroup(9017).HasFocus">SetProperty(VideosDirectLink,True)</onunload>
 	<onunload condition="Control.HasFocus(9000) + Container(9000).Hasfocus(2)">ClearProperty(VideosDirectLink)</onunload>
 	<controls>
@@ -459,12 +459,12 @@
 			<top>370</top>
 			<animation effect="slide" start="0,0" end="365,0" time="300" condition="!Player.HasMedia">conditional</animation>
 			<animation type="WindowOpen" reversible="false">
-				<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="300"/>
-				<effect type="fade" start="0" end="100" time="300"/>
+				<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="300" />
+				<effect type="fade" start="0" end="100" time="300" />
 			</animation>
 			<animation type="WindowClose" reversible="false">
-				<effect type="zoom" start="100" end="80" center="640,360" easing="in" tween="back" time="300"/>
-				<effect type="fade" start="100" end="0" time="300"/>
+				<effect type="zoom" start="100" end="80" center="640,360" easing="in" tween="back" time="300" />
+				<effect type="fade" start="100" end="0" time="300" />
 			</animation>
 			<control type="image">
 				<description>Background End image</description>
@@ -724,12 +724,12 @@
 		<control type="group">
 			<top>400</top>
 			<animation type="WindowOpen" reversible="false">
-				<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="300"/>
-				<effect type="fade" start="0" end="100" time="300"/>
+				<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="300" />
+				<effect type="fade" start="0" end="100" time="300" />
 			</animation>
 			<animation type="WindowClose" reversible="false">
-				<effect type="zoom" start="100" end="80" center="640,360" easing="in" tween="back" time="300"/>
-				<effect type="fade" start="100" end="0" time="300"/>
+				<effect type="zoom" start="100" end="80" center="640,360" easing="in" tween="back" time="300" />
+				<effect type="fade" start="100" end="0" time="300" />
 			</animation>
 			<control type="group" id="9001">
 				<left>0</left>
@@ -741,63 +741,72 @@
 					<onleft>9010</onleft>
 					<onright>9010</onright>
 					<visible>Container(9000).HasFocus(2)</visible>
-					<include>HomeSubMenuVideos</include> <!-- Buttons for the grouplist -->
+					<include>HomeSubMenuVideos</include>
+					<!-- Buttons for the grouplist -->
 				</control>
 				<control type="grouplist" id="9016">
 					<include>HomeSubMenuCommonValues</include>
 					<onleft>9016</onleft>
 					<onright>9016</onright>
 					<visible>Container(9000).HasFocus(10)</visible>
-					<include>HomeSubMenuMovies</include> <!-- Buttons for the grouplist -->
+					<include>HomeSubMenuMovies</include>
+					<!-- Buttons for the grouplist -->
 				</control>
 				<control type="grouplist" id="9017">
 					<include>HomeSubMenuCommonValues</include>
 					<onleft>9017</onleft>
 					<onright>9017</onright>
 					<visible>Container(9000).HasFocus(11)</visible>
-					<include>HomeSubMenuTVShows</include> <!-- Buttons for the grouplist -->
+					<include>HomeSubMenuTVShows</include>
+					<!-- Buttons for the grouplist -->
 				</control>
 				<control type="grouplist" id="9011">
 					<include>HomeSubMenuCommonValues</include>
 					<onleft>9011</onleft>
 					<onright>9011</onright>
 					<visible>Container(9000).HasFocus(3)</visible>
-					<include>HomeSubMenuMusic</include> <!-- Buttons for the grouplist -->
+					<include>HomeSubMenuMusic</include>
+					<!-- Buttons for the grouplist -->
 				</control>
 				<control type="grouplist" id="9012">
 					<include>HomeSubMenuCommonValues</include>
 					<onleft>9012</onleft>
 					<onright>9012</onright>
 					<visible>Container(9000).HasFocus(5)</visible>
-					<include>HomeSubMenuSystem</include> <!-- Buttons for the grouplist -->
+					<include>HomeSubMenuSystem</include>
+					<!-- Buttons for the grouplist -->
 				</control>
 				<control type="grouplist" id="9013">
 					<include>HomeSubMenuCommonValues</include>
 					<onleft>9013</onleft>
 					<onright>9013</onright>
 					<visible>Container(9000).HasFocus(6)</visible>
-					<include>HomeSubMenuPlayDisc</include> <!-- Buttons for the grouplist -->
+					<include>HomeSubMenuPlayDisc</include>
+					<!-- Buttons for the grouplist -->
 				</control>
 				<control type="grouplist" id="9014">
 					<include>HomeSubMenuCommonValues</include>
 					<onleft>9014</onleft>
 					<onright>9014</onright>
 					<visible>Container(9000).HasFocus(12)</visible>
-					<include>HomeSubMenuTV</include> <!-- Buttons for the grouplist -->
+					<include>HomeSubMenuTV</include>
+					<!-- Buttons for the grouplist -->
 				</control>
 				<control type="grouplist" id="9015">
 					<include>HomeSubMenuCommonValues</include>
 					<onleft>9013</onleft>
 					<onright>9013</onright>
 					<visible>Container(9000).HasFocus(4)</visible>
-					<include>HomeSubMenuPictures</include> <!-- Buttons for the grouplist -->
+					<include>HomeSubMenuPictures</include>
+					<!-- Buttons for the grouplist -->
 				</control>
 				<control type="grouplist" id="9016">
 					<include>HomeSubMenuCommonValues</include>
 					<onleft>9014</onleft>
 					<onright>9014</onright>
 					<visible>Container(9000).HasFocus(13)</visible>
-					<include>HomeSubMenuRadio</include> <!-- Buttons for the grouplist -->
+					<include>HomeSubMenuRadio</include>
+					<!-- Buttons for the grouplist -->
 				</control>
 			</control>
 			<control type="image">
@@ -1210,5 +1219,5 @@
 			<include>Window_OpenClose_Animation</include>
 			<animation effect="slide" start="0,0" end="-40,0" time="100" condition="Window.IsVisible(Mutebug)">conditional</animation>
 		</control>
-	</controls>	
+	</controls>
 </window>

--- a/addons/skin.confluence/720p/Home.xml
+++ b/addons/skin.confluence/720p/Home.xml
@@ -12,8 +12,8 @@
 			<width>1280</width>
 			<height>90</height>
 			<texture>floor.png</texture>
-			<animation effect="fade" time="250" condition="Window.Previous(Home)">WindowOpen</animation>
-			<animation effect="fade" time="250" condition="Window.Next(Home)">WindowClose</animation>
+			<animation effect="fade" time="200" condition="Window.Previous(Home)">WindowOpen</animation>
+			<animation effect="fade" time="200" condition="Window.Next(Home)">WindowClose</animation>
 		</control>
 		<control type="image">
 			<description>LOGO</description>
@@ -92,7 +92,7 @@
 			<visible>Container(9000).HasFocus(12) + [PVR.IsRecording | PVR.HasNonRecordingTimer]</visible>
 			<include>VisibleFadeEffect</include>
 			<include>Window_OpenClose_Animation</include>
-			<animation effect="fade" start="100" end="0" time="200" condition="Window.IsActive(Favourites)">conditional</animation>
+			<animation effect="fade" start="100" end="0" time="150" condition="Window.IsActive(Favourites)">conditional</animation>
 			<control type="group">
 				<animation effect="slide" start="0,0" end="0,100" time="0" condition="PVR.IsRecording">conditional</animation>
 				<visible>PVR.HasNonRecordingTimer</visible>
@@ -457,14 +457,14 @@
 			<description>Controls for currently playing media</description>
 			<left>545r</left>
 			<top>370</top>
-			<animation effect="slide" start="0,0" end="365,0" time="300" condition="!Player.HasMedia">conditional</animation>
+			<animation effect="slide" start="0,0" end="365,0" time="225" condition="!Player.HasMedia">conditional</animation>
 			<animation type="WindowOpen" reversible="false">
-				<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="300" />
-				<effect type="fade" start="0" end="100" time="300" />
+				<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="225" />
+				<effect type="fade" start="0" end="100" time="225" />
 			</animation>
 			<animation type="WindowClose" reversible="false">
-				<effect type="zoom" start="100" end="80" center="640,360" easing="in" tween="back" time="300" />
-				<effect type="fade" start="100" end="0" time="300" />
+				<effect type="zoom" start="100" end="80" center="640,360" easing="in" tween="back" time="225" />
+				<effect type="fade" start="100" end="0" time="225" />
 			</animation>
 			<control type="image">
 				<description>Background End image</description>
@@ -673,7 +673,7 @@
 						<ondown>9000</ondown>
 						<onclick>PlayerControl(Play)</onclick>
 						<enable>Player.PauseEnabled</enable>
-						<animation effect="fade" start="100" end="30" time="100" condition="!Player.PauseEnabled">Conditional</animation>
+						<animation effect="fade" start="100" end="30" time="75" condition="!Player.PauseEnabled">Conditional</animation>
 					</control>
 					<control type="button" id="606">
 						<left>160</left>
@@ -724,12 +724,12 @@
 		<control type="group">
 			<top>400</top>
 			<animation type="WindowOpen" reversible="false">
-				<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="300" />
-				<effect type="fade" start="0" end="100" time="300" />
+				<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="225" />
+				<effect type="fade" start="0" end="100" time="225" />
 			</animation>
 			<animation type="WindowClose" reversible="false">
-				<effect type="zoom" start="100" end="80" center="640,360" easing="in" tween="back" time="300" />
-				<effect type="fade" start="100" end="0" time="300" />
+				<effect type="zoom" start="100" end="80" center="640,360" easing="in" tween="back" time="225" />
+				<effect type="fade" start="100" end="0" time="225" />
 			</animation>
 			<control type="group" id="9001">
 				<left>0</left>
@@ -1217,7 +1217,7 @@
 			<shadowcolor>black</shadowcolor>
 			<label>$INFO[System.Date]</label>
 			<include>Window_OpenClose_Animation</include>
-			<animation effect="slide" start="0,0" end="-40,0" time="100" condition="Window.IsVisible(Mutebug)">conditional</animation>
+			<animation effect="slide" start="0,0" end="-40,0" time="75" condition="Window.IsVisible(Mutebug)">conditional</animation>
 		</control>
 	</controls>
 </window>

--- a/addons/skin.confluence/720p/IncludesBackgroundBuilding.xml
+++ b/addons/skin.confluence/720p/IncludesBackgroundBuilding.xml
@@ -77,8 +77,8 @@
 			<width>1280</width>
 			<height>100</height>
 			<texture>floor.png</texture>
-			<animation effect="slide" start="0,10" end="0,0" time="200" condition="Window.Previous(Home)">WindowOpen</animation>
-			<animation effect="slide" start="0,0" end="0,10" time="200" condition="Window.Next(Home)">WindowClose</animation>
+			<animation effect="slide" start="0,10" end="0,0" time="150" condition="Window.Previous(Home)">WindowOpen</animation>
+			<animation effect="slide" start="0,0" end="0,10" time="150" condition="Window.Next(Home)">WindowClose</animation>
 		</control>
 		<control type="group">
 			<include>Window_OpenClose_Animation</include>

--- a/addons/skin.confluence/720p/IncludesHomeRecentlyAdded.xml
+++ b/addons/skin.confluence/720p/IncludesHomeRecentlyAdded.xml
@@ -7,8 +7,8 @@
 			<ondown condition="!System.HasAddon(script.globalsearch)">603</ondown>
 			<visible>!Window.IsVisible(Favourites)</visible>
 			<include>VisibleFadeEffect</include>
-			<animation effect="fade" time="300" delay="1000">WindowOpen</animation>
-			<animation effect="fade" time="200">WindowClose</animation>
+			<animation effect="fade" time="225" delay="750">WindowOpen</animation>
+			<animation effect="fade" time="150">WindowClose</animation>
 			<control type="group">
 				<left>190</left>
 				<top>50</top>

--- a/addons/skin.confluence/720p/IncludesHomeRecentlyAdded.xml
+++ b/addons/skin.confluence/720p/IncludesHomeRecentlyAdded.xml
@@ -140,7 +140,7 @@
 					<content>
 						<item>
 							<label>$INFO[Window.Property(LatestMovie.1.Title)]</label>
-							<label2/>
+							<label2 />
 							<onclick>PlayMedia($ESCINFO[Window.Property(LatestMovie.1.Path)])</onclick>
 							<icon>$INFO[Window.Property(LatestMovie.1.Thumb)]</icon>
 							<thumb>-</thumb>
@@ -148,7 +148,7 @@
 						</item>
 						<item>
 							<label>$INFO[Window.Property(LatestMovie.2.Title)]</label>
-							<label2/>
+							<label2 />
 							<onclick>PlayMedia($ESCINFO[Window.Property(LatestMovie.2.Path)])</onclick>
 							<icon>$INFO[Window.Property(LatestMovie.2.Thumb)]</icon>
 							<thumb>-</thumb>
@@ -156,7 +156,7 @@
 						</item>
 						<item>
 							<label>$INFO[Window.Property(LatestMovie.3.Title)]</label>
-							<label2/>
+							<label2 />
 							<onclick>PlayMedia($ESCINFO[Window.Property(LatestMovie.3.Path)])</onclick>
 							<icon>$INFO[Window.Property(LatestMovie.3.Thumb)]</icon>
 							<thumb>-</thumb>
@@ -164,7 +164,7 @@
 						</item>
 						<item>
 							<label>$INFO[Window.Property(LatestMovie.4.Title)]</label>
-							<label2/>
+							<label2 />
 							<onclick>PlayMedia($ESCINFO[Window.Property(LatestMovie.4.Path)])</onclick>
 							<icon>$INFO[Window.Property(LatestMovie.4.Thumb)]</icon>
 							<thumb>-</thumb>
@@ -172,7 +172,7 @@
 						</item>
 						<item>
 							<label>$INFO[Window.Property(LatestMovie.5.Title)]</label>
-							<label2/>
+							<label2 />
 							<onclick>PlayMedia($ESCINFO[Window.Property(LatestMovie.5.Path)])</onclick>
 							<icon>$INFO[Window.Property(LatestMovie.5.Thumb)]</icon>
 							<thumb>-</thumb>
@@ -180,7 +180,7 @@
 						</item>
 						<item>
 							<label>$INFO[Window.Property(LatestMovie.6.Title)]</label>
-							<label2/>
+							<label2 />
 							<onclick>PlayMedia($ESCINFO[Window.Property(LatestMovie.6.Path)])</onclick>
 							<icon>$INFO[Window.Property(LatestMovie.6.Thumb)]</icon>
 							<thumb>-</thumb>
@@ -188,7 +188,7 @@
 						</item>
 						<item>
 							<label>$INFO[Window.Property(LatestMovie.7.Title)]</label>
-							<label2/>
+							<label2 />
 							<onclick>PlayMedia($ESCINFO[Window.Property(LatestMovie.7.Path)])</onclick>
 							<icon>$INFO[Window.Property(LatestMovie.7.Thumb)]</icon>
 							<thumb>-</thumb>
@@ -196,7 +196,7 @@
 						</item>
 						<item>
 							<label>$INFO[Window.Property(LatestMovie.8.Title)]</label>
-							<label2/>
+							<label2 />
 							<onclick>PlayMedia($ESCINFO[Window.Property(LatestMovie.8.Path)])</onclick>
 							<icon>$INFO[Window.Property(LatestMovie.8.Thumb)]</icon>
 							<thumb>-</thumb>
@@ -204,7 +204,7 @@
 						</item>
 						<item>
 							<label>$INFO[Window.Property(LatestMovie.9.Title)]</label>
-							<label2/>
+							<label2 />
 							<onclick>PlayMedia($ESCINFO[Window.Property(LatestMovie.9.Path)])</onclick>
 							<icon>$INFO[Window.Property(LatestMovie.9.Thumb)]</icon>
 							<thumb>-</thumb>
@@ -212,7 +212,7 @@
 						</item>
 						<item>
 							<label>$INFO[Window.Property(LatestMovie.10.Title)]</label>
-							<label2/>
+							<label2 />
 							<onclick>PlayMedia($ESCINFO[Window.Property(LatestMovie.10.Path)])</onclick>
 							<icon>$INFO[Window.Property(LatestMovie.10.Thumb)]</icon>
 							<thumb>-</thumb>

--- a/addons/skin.confluence/720p/LoginScreen.xml
+++ b/addons/skin.confluence/720p/LoginScreen.xml
@@ -10,7 +10,7 @@
 	<controls>
 		<include>CommonBackground</include>
 		<control type="group">
-			<include>Window_OpenClose_Animation</include>		
+			<include>Window_OpenClose_Animation</include>
 			<control type="image">
 				<left>0</left>
 				<top>100r</top>

--- a/addons/skin.confluence/720p/LoginScreen.xml
+++ b/addons/skin.confluence/720p/LoginScreen.xml
@@ -17,8 +17,8 @@
 				<width>1280</width>
 				<height>100</height>
 				<texture>floor.png</texture>
-				<animation effect="slide" start="0,10" end="0,0" time="200" condition="Window.Previous(Home)">WindowOpen</animation>
-				<animation effect="slide" start="0,0" end="0,10" time="200" condition="Window.Next(Home)">WindowClose</animation>
+				<animation effect="slide" start="0,10" end="0,0" time="150" condition="Window.Previous(Home)">WindowOpen</animation>
+				<animation effect="slide" start="0,0" end="0,10" time="150" condition="Window.Next(Home)">WindowClose</animation>
 			</control>
 			<control type="image">
 				<description>LOGO</description>
@@ -226,7 +226,7 @@
 			<shadowcolor>black</shadowcolor>
 			<label>$INFO[System.Date]</label>
 			<include>Window_OpenClose_Animation</include>
-			<animation effect="slide" start="0,0" end="-40,0" time="100" condition="Window.IsVisible(Mutebug)">conditional</animation>
+			<animation effect="slide" start="0,0" end="-40,0" time="75" condition="Window.IsVisible(Mutebug)">conditional</animation>
 		</control>
 	</controls>
 </window>

--- a/addons/skin.confluence/720p/MusicKaraokeLyrics.xml
+++ b/addons/skin.confluence/720p/MusicKaraokeLyrics.xml
@@ -19,7 +19,7 @@
 		</control>
 		<control type="group">
 			<visible>MusicPlayer.Offset(number).Exists + !IntegerGreaterThan(Player.TimeRemaining,20)</visible>
-			<animation effect="slide" start="0,-40" end="0,0" time="100">Visible</animation>
+			<animation effect="slide" start="0,-40" end="0,0" time="75">Visible</animation>
 			<left>420</left>
 			<top>0</top>
 			<control type="image">

--- a/addons/skin.confluence/720p/MusicOSD.xml
+++ b/addons/skin.confluence/720p/MusicOSD.xml
@@ -25,7 +25,7 @@
 			<onright>1000</onright>
 			<onup>100</onup>
 			<ondown>100</ondown>
-			<animation effect="fade" time="200">VisibleChange</animation>
+			<animation effect="fade" time="150">VisibleChange</animation>
 			<visible>![Window.IsVisible(AddonSettings) | Window.IsVisible(SelectDialog) | Window.IsVisible(VisualisationPresetList) | Window.IsVisible(PVROSDChannels) | Window.IsVisible(PVROSDGuide)]</visible>
 		</control>
 		<control type="slider" id="87">
@@ -40,7 +40,7 @@
 			<texturesliderbar>seekslider2.png</texturesliderbar>
 			<textureslidernib>osd_slider_nibNF.png</textureslidernib>
 			<textureslidernibfocus>osd_slider_nib.png</textureslidernibfocus>
-			<animation effect="fade" time="200">VisibleChange</animation>
+			<animation effect="fade" time="150">VisibleChange</animation>
 			<visible>![Window.IsVisible(AddonSettings) | Window.IsVisible(SelectDialog) | Window.IsVisible(VisualisationPresetList) | Window.IsVisible(PVROSDChannels) | Window.IsVisible(PVROSDGuide)]</visible>
 		</control>
 		<control type="grouplist" id="100">
@@ -50,7 +50,7 @@
 			<ondown>1000</ondown>
 			<orientation>horizontal</orientation>
 			<itemgap>0</itemgap>
-			<animation effect="fade" time="200">VisibleChange</animation>
+			<animation effect="fade" time="150">VisibleChange</animation>
 			<visible>![Window.IsVisible(AddonSettings) | Window.IsVisible(SelectDialog) | Window.IsVisible(VisualisationPresetList) | Window.IsVisible(PVROSDChannels) | Window.IsVisible(PVROSDGuide)]</visible>
 			<control type="button" id="300">
 				<width>55</width>
@@ -89,7 +89,7 @@
 				<font>-</font>
 				<texturefocus>OSDRewindFO.png</texturefocus>
 				<texturenofocus>OSDRewindNF.png</texturenofocus>
-				<animation effect="fade" start="100" end="50" time="100" condition="!Player.SeekEnabled">Conditional</animation>
+				<animation effect="fade" start="100" end="50" time="75" condition="!Player.SeekEnabled">Conditional</animation>
 				<onclick>PlayerControl(Rewind)</onclick>
 				<enable>Player.SeekEnabled</enable>
 			</control>
@@ -104,7 +104,7 @@
 				<usealttexture>Player.Paused | Player.Forwarding | Player.Rewinding</usealttexture>
 				<alttexturefocus>OSDPlayFO.png</alttexturefocus>
 				<alttexturenofocus>OSDPlayNF.png</alttexturenofocus>
-				<animation effect="fade" start="100" end="50" time="100" condition="!Player.PauseEnabled">Conditional</animation>
+				<animation effect="fade" start="100" end="50" time="75" condition="!Player.PauseEnabled">Conditional</animation>
 				<onclick>PlayerControl(Play)</onclick>
 				<enable>Player.PauseEnabled</enable>
 			</control>
@@ -124,7 +124,7 @@
 				<font>-</font>
 				<texturefocus>OSDForwardFO.png</texturefocus>
 				<texturenofocus>OSDForwardNF.png</texturenofocus>
-				<animation effect="fade" start="100" end="50" time="100" condition="!Player.SeekEnabled">Conditional</animation>
+				<animation effect="fade" start="100" end="50" time="75" condition="!Player.SeekEnabled">Conditional</animation>
 				<onclick>PlayerControl(Forward)</onclick>
 				<enable>Player.SeekEnabled</enable>
 			</control>
@@ -308,7 +308,7 @@
 				<texturenofocus>OSDRecordOffNF.png</texturenofocus>
 				<onclick>PlayerControl(record)</onclick>
 				<enable>Player.CanRecord</enable>
-				<animation effect="fade" start="100" end="50" time="100" condition="!Player.CanRecord">Conditional</animation>
+				<animation effect="fade" start="100" end="50" time="75" condition="!Player.CanRecord">Conditional</animation>
 			</control>
 		</control>
 	</controls>

--- a/addons/skin.confluence/720p/MusicOverlay.xml
+++ b/addons/skin.confluence/720p/MusicOverlay.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
 	<defaultcontrol>-</defaultcontrol>
-	<controls>
-	</controls>
+	<controls></controls>
 </window>

--- a/addons/skin.confluence/720p/MusicVisualisation.xml
+++ b/addons/skin.confluence/720p/MusicVisualisation.xml
@@ -24,7 +24,7 @@
 		</control>
 		<!-- media infos -->
 		<control type="group">
-			<animation effect="fade" time="200">VisibleChange</animation>
+			<animation effect="fade" time="150">VisibleChange</animation>
 			<visible>[Player.ShowInfo | Window.IsActive(MusicOSD)] + ![Window.IsVisible(AddonSettings) | Window.IsVisible(SelectDialog) | Window.IsVisible(VisualisationPresetList) | Window.IsVisible(PVROSDChannels) | Window.IsVisible(PVROSDGuide)]</visible>
 			<control type="image">
 				<left>0</left>
@@ -181,7 +181,7 @@
 					<textcolor>grey</textcolor>
 					<scroll>true</scroll>
 					<visible>MusicPlayer.HasNext + !Window.IsVisible(MusicOSD)</visible>
-					<animation effect="fade" time="200">VisibleChange</animation>
+					<animation effect="fade" time="150">VisibleChange</animation>
 				</control>
 			</control>
 			<control type="group">
@@ -222,7 +222,7 @@
 			<left>0</left>
 			<top>50</top>
 			<visible>Player.ShowCodec + ![Window.IsVisible(script-cu-lrclyrics-main.xml) | Window.IsVisible(VisualisationSettings) | Window.IsVisible(VisualisationPresetList) | Window.IsVisible(PVROSDChannels) | Window.IsVisible(PVROSDGuide)]</visible>
-			<animation effect="fade" time="200">VisibleChange</animation>
+			<animation effect="fade" time="150">VisibleChange</animation>
 			<control type="image">
 				<description>media info background image</description>
 				<left>0</left>

--- a/addons/skin.confluence/720p/MyMusicNav.xml
+++ b/addons/skin.confluence/720p/MyMusicNav.xml
@@ -8,17 +8,27 @@
 		<include>CommonBackground</include>
 		<include>ContentPanelBackgrounds</include>
 		<control type="group">
-			<include>Window_OpenClose_Animation</include>		
-			<include>CommonRootView</include> <!-- view id = 50 -->
-			<include>FullWidthList</include> <!-- view id = 51 -->
-			<include>ThumbnailView</include> <!-- view id = 500 -->
-			<include>MusicInfoListView</include> <!-- view id = 506 -->
-			<include>AlbumWrapView2_Fanart</include> <!-- view id = 509 -->
-			<include>MusicVideoInfoListView</include> <!-- view id = 511 -->
-			<include>ArtistMediaListView</include> <!-- view id = 512 -->
-			<include>AlbumInfoListView</include> <!-- view id = 513 -->
-			<include>AddonInfoListView1</include> <!-- view id = 550 -->
-			<include>AddonInfoThumbView1</include> <!-- view id = 551 -->
+			<include>Window_OpenClose_Animation</include>
+			<include>CommonRootView</include>
+			<!-- view id = 50 -->
+			<include>FullWidthList</include>
+			<!-- view id = 51 -->
+			<include>ThumbnailView</include>
+			<!-- view id = 500 -->
+			<include>MusicInfoListView</include>
+			<!-- view id = 506 -->
+			<include>AlbumWrapView2_Fanart</include>
+			<!-- view id = 509 -->
+			<include>MusicVideoInfoListView</include>
+			<!-- view id = 511 -->
+			<include>ArtistMediaListView</include>
+			<!-- view id = 512 -->
+			<include>AlbumInfoListView</include>
+			<!-- view id = 513 -->
+			<include>AddonInfoListView1</include>
+			<!-- view id = 550 -->
+			<include>AddonInfoThumbView1</include>
+			<!-- view id = 551 -->
 		</control>
 		<include>CommonPageCount</include>
 		<include>CommonNowPlaying</include>

--- a/addons/skin.confluence/720p/MyMusicPlaylist.xml
+++ b/addons/skin.confluence/720p/MyMusicPlaylist.xml
@@ -8,10 +8,13 @@
 		<include>CommonBackground</include>
 		<include>ContentPanelBackgrounds</include>
 		<control type="group">
-			<include>Window_OpenClose_Animation</include>		
-			<include>CommonRootView</include> <!-- view id = 50 -->
-			<include>FullWidthList</include> <!-- view id = 51 -->
-			<include>MusicInfoListView</include> <!-- view id = 506 -->
+			<include>Window_OpenClose_Animation</include>
+			<include>CommonRootView</include>
+			<!-- view id = 50 -->
+			<include>FullWidthList</include>
+			<!-- view id = 51 -->
+			<include>MusicInfoListView</include>
+			<!-- view id = 506 -->
 		</control>
 		<include>CommonPageCount</include>
 		<include>CommonNowPlaying</include>

--- a/addons/skin.confluence/720p/MyMusicPlaylistEditor.xml
+++ b/addons/skin.confluence/720p/MyMusicPlaylistEditor.xml
@@ -119,8 +119,8 @@
 			</control>
 		</control>
 		<control type="group">
-			<animation effect="slide" start="-480,0" end="0,0" time="500" tween="quadratic" easing="out">WindowOpen</animation>
-			<animation effect="slide" end="-480,0" start="0,0" time="500" tween="quadratic" easing="out">WindowClose</animation>
+			<animation effect="slide" start="-480,0" end="0,0" time="375" tween="quadratic" easing="out">WindowOpen</animation>
+			<animation effect="slide" end="-480,0" start="0,0" time="375" tween="quadratic" easing="out">WindowClose</animation>
 			<control type="image">
 				<left>0</left>
 				<top>0</top>
@@ -257,8 +257,8 @@
 			</control>
 		</control>
 		<control type="group">
-			<animation effect="slide" start="480,0" end="0,0" time="500" tween="quadratic" easing="out">WindowOpen</animation>
-			<animation effect="slide" end="480,0" start="0,0" time="500" tween="quadratic" easing="out">WindowClose</animation>
+			<animation effect="slide" start="480,0" end="0,0" time="375" tween="quadratic" easing="out">WindowOpen</animation>
+			<animation effect="slide" end="480,0" start="0,0" time="375" tween="quadratic" easing="out">WindowClose</animation>
 			<left>800</left>
 			<control type="image">
 				<left>0</left>

--- a/addons/skin.confluence/720p/MyMusicSongs.xml
+++ b/addons/skin.confluence/720p/MyMusicSongs.xml
@@ -8,13 +8,19 @@
 		<include>CommonBackground</include>
 		<include>ContentPanelBackgrounds</include>
 		<control type="group">
-			<include>Window_OpenClose_Animation</include>		
-			<include>CommonRootView</include> <!-- view id = 50 -->
-			<include>FullWidthList</include> <!-- view id = 51 -->
-			<include>ThumbnailView</include> <!-- view id = 500 -->
-			<include>MusicInfoListView</include> <!-- view id = 506 -->
-			<include>AddonInfoListView1</include> <!-- view id = 550 -->
-			<include>AddonInfoThumbView1</include> <!-- view id = 551 -->
+			<include>Window_OpenClose_Animation</include>
+			<include>CommonRootView</include>
+			<!-- view id = 50 -->
+			<include>FullWidthList</include>
+			<!-- view id = 51 -->
+			<include>ThumbnailView</include>
+			<!-- view id = 500 -->
+			<include>MusicInfoListView</include>
+			<!-- view id = 506 -->
+			<include>AddonInfoListView1</include>
+			<!-- view id = 550 -->
+			<include>AddonInfoThumbView1</include>
+			<!-- view id = 551 -->
 		</control>
 		<include>CommonPageCount</include>
 		<include>CommonNowPlaying</include>

--- a/addons/skin.confluence/720p/MyPVRChannels.xml
+++ b/addons/skin.confluence/720p/MyPVRChannels.xml
@@ -15,7 +15,7 @@
 			<animation effect="fade" time="250" condition="Window.Next(Home)">WindowClose</animation>
 		</control>
 		<control type="group">
-			<include>Window_OpenClose_Animation</include>		
+			<include>Window_OpenClose_Animation</include>
 			<control type="group">
 				<include>VisibleFadeEffect</include>
 				<control type="image">
@@ -56,7 +56,7 @@
 			<top>80</top>
 			<visible>Control.IsVisible(50)</visible>
 			<include>VisibleFadeEffect</include>
-			<include>Window_OpenClose_Animation</include>		
+			<include>Window_OpenClose_Animation</include>
 			<control type="image">
 				<left>0</left>
 				<top>0</top>
@@ -104,7 +104,6 @@
 				<visible>Player.HasVideo</visible>
 			</control>
 		</control>
-		
 		<control type="group">
 			<include>Window_OpenClose_Animation</include>
 			<description>TV Channels group</description>
@@ -413,11 +412,9 @@
 				<include>Window_OpenClose_Animation</include>
 			</control>
 		</control>
-
 		<include>CommonNowPlaying</include>
 		<include>BehindDialogFadeOut</include>
 		<include>ScrollOffsetLabel</include>
-
 		<control type="image">
 			<left>0</left>
 			<top>0</top>
@@ -428,7 +425,6 @@
 			<animation effect="fade" time="200">Hidden</animation>
 			<visible>Window.IsActive(FileBrowser) | Window.IsActive(PVRGuideInfo) | Window.IsActive(PVRRecordingInfo) | Window.IsActive(PVRTimerSetting) | Window.IsActive(PVRGroupManager) | Window.IsActive(PVRGuideSearch)</visible>
 		</control>
-
 		<include>PVRSideBlade</include>
 		<include>Clock</include>
 	</controls>

--- a/addons/skin.confluence/720p/MyPVRChannels.xml
+++ b/addons/skin.confluence/720p/MyPVRChannels.xml
@@ -11,8 +11,8 @@
 			<width>1280</width>
 			<height>100</height>
 			<texture>floor.png</texture>
-			<animation effect="fade" time="250" condition="Window.Previous(Home)">WindowOpen</animation>
-			<animation effect="fade" time="250" condition="Window.Next(Home)">WindowClose</animation>
+			<animation effect="fade" time="200" condition="Window.Previous(Home)">WindowOpen</animation>
+			<animation effect="fade" time="200" condition="Window.Next(Home)">WindowClose</animation>
 		</control>
 		<control type="group">
 			<include>Window_OpenClose_Animation</include>
@@ -421,8 +421,8 @@
 			<width>1280</width>
 			<height>720</height>
 			<texture>black-back.png</texture>
-			<animation effect="fade" time="400">Visible</animation>
-			<animation effect="fade" time="200">Hidden</animation>
+			<animation effect="fade" time="300">Visible</animation>
+			<animation effect="fade" time="150">Hidden</animation>
 			<visible>Window.IsActive(FileBrowser) | Window.IsActive(PVRGuideInfo) | Window.IsActive(PVRRecordingInfo) | Window.IsActive(PVRTimerSetting) | Window.IsActive(PVRGroupManager) | Window.IsActive(PVRGuideSearch)</visible>
 		</control>
 		<include>PVRSideBlade</include>

--- a/addons/skin.confluence/720p/MyPVRGuide.xml
+++ b/addons/skin.confluence/720p/MyPVRGuide.xml
@@ -15,7 +15,7 @@
 			<animation effect="fade" time="250" condition="Window.Next(Home)">WindowClose</animation>
 		</control>
 		<control type="group">
-			<include>Window_OpenClose_Animation</include>		
+			<include>Window_OpenClose_Animation</include>
 			<control type="image">
 				<left>0</left>
 				<top>100r</top>
@@ -26,7 +26,7 @@
 				<animation effect="fade" time="250" condition="Window.Next(Home)">WindowClose</animation>
 			</control>
 			<control type="group">
-				<include>Window_OpenClose_Animation</include>		
+				<include>Window_OpenClose_Animation</include>
 				<control type="group">
 					<include>VisibleFadeEffect</include>
 					<control type="image">
@@ -48,7 +48,6 @@
 		</control>
 		<include>MainWindowMouseButtons</include>
 		<include>PVRHeader</include>
-		
 		<control type="group" id="50">
 			<include>Window_OpenClose_Animation</include>
 			<include>PVRGuideViewTimeline</include>
@@ -59,7 +58,6 @@
 		<include>CommonNowPlaying</include>
 		<include>BehindDialogFadeOut</include>
 		<include>ScrollOffsetLabel</include>
-
 		<control type="image">
 			<left>0</left>
 			<top>0</top>
@@ -70,7 +68,6 @@
 			<animation effect="fade" time="200">Hidden</animation>
 			<visible>Window.IsActive(FileBrowser) | Window.IsActive(PVRGuideInfo) | Window.IsActive(PVRRecordingInfo) | Window.IsActive(PVRTimerSetting) | Window.IsActive(PVRGroupManager) | Window.IsActive(PVRGuideSearch)</visible>
 		</control>
-
 		<include>PVRSideBlade</include>
 		<include>Clock</include>
 	</controls>

--- a/addons/skin.confluence/720p/MyPVRGuide.xml
+++ b/addons/skin.confluence/720p/MyPVRGuide.xml
@@ -11,8 +11,8 @@
 			<width>1280</width>
 			<height>100</height>
 			<texture>floor.png</texture>
-			<animation effect="fade" time="250" condition="Window.Previous(Home)">WindowOpen</animation>
-			<animation effect="fade" time="250" condition="Window.Next(Home)">WindowClose</animation>
+			<animation effect="fade" time="200" condition="Window.Previous(Home)">WindowOpen</animation>
+			<animation effect="fade" time="200" condition="Window.Next(Home)">WindowClose</animation>
 		</control>
 		<control type="group">
 			<include>Window_OpenClose_Animation</include>
@@ -22,8 +22,8 @@
 				<width>1280</width>
 				<height>100</height>
 				<texture>floor.png</texture>
-				<animation effect="fade" time="250" condition="Window.Previous(Home)">WindowOpen</animation>
-				<animation effect="fade" time="250" condition="Window.Next(Home)">WindowClose</animation>
+				<animation effect="fade" time="200" condition="Window.Previous(Home)">WindowOpen</animation>
+				<animation effect="fade" time="200" condition="Window.Next(Home)">WindowClose</animation>
 			</control>
 			<control type="group">
 				<include>Window_OpenClose_Animation</include>
@@ -64,8 +64,8 @@
 			<width>1280</width>
 			<height>720</height>
 			<texture>black-back.png</texture>
-			<animation effect="fade" time="400">Visible</animation>
-			<animation effect="fade" time="200">Hidden</animation>
+			<animation effect="fade" time="300">Visible</animation>
+			<animation effect="fade" time="150">Hidden</animation>
 			<visible>Window.IsActive(FileBrowser) | Window.IsActive(PVRGuideInfo) | Window.IsActive(PVRRecordingInfo) | Window.IsActive(PVRTimerSetting) | Window.IsActive(PVRGroupManager) | Window.IsActive(PVRGuideSearch)</visible>
 		</control>
 		<include>PVRSideBlade</include>

--- a/addons/skin.confluence/720p/MyPVRRecordings.xml
+++ b/addons/skin.confluence/720p/MyPVRRecordings.xml
@@ -15,7 +15,7 @@
 			<animation effect="fade" time="250" condition="Window.Next(Home)">WindowClose</animation>
 		</control>
 		<control type="group">
-			<include>Window_OpenClose_Animation</include>		
+			<include>Window_OpenClose_Animation</include>
 			<control type="group">
 				<include>VisibleFadeEffect</include>
 				<visible>Control.IsVisible(50)</visible>
@@ -51,8 +51,6 @@
 		</control>
 		<include>MainWindowMouseButtons</include>
 		<include>PVRHeader</include>
-
-			
 		<control type="group">
 			<include>Window_OpenClose_Animation</include>
 			<description>Recordings group</description>
@@ -235,7 +233,7 @@
 				<align>right</align>
 				<aligny>center</aligny>
 				<label>([COLOR=blue]$INFO[Container(50).NumItems][/COLOR]) $LOCALIZE[19163] - $LOCALIZE[31024] ([COLOR=blue]$INFO[Container(50).CurrentPage]/$INFO[Container(50).NumPages][/COLOR])</label>
-				<include>Window_OpenClose_Animation</include>		
+				<include>Window_OpenClose_Animation</include>
 			</control>
 			<control type="group">
 				<left>910</left>
@@ -296,17 +294,13 @@
 					<left>10</left>
 					<top>548</top>
 					<width>290</width>
-					<height>12</height>>
-					<info>PVR.backenddiskspaceprogr</info>
-					<visible>!IntegerGreaterThan(PVR.backenddiskspaceprogr,100)</visible>
-				</control>
+					<height>12</height>&gt;
+					<info>PVR.backenddiskspaceprogr</info><visible>!IntegerGreaterThan(PVR.backenddiskspaceprogr,100)</visible></control>
 			</control>
 		</control>
-
 		<include>CommonNowPlaying</include>
 		<include>BehindDialogFadeOut</include>
 		<include>ScrollOffsetLabel</include>
-
 		<control type="image">
 			<left>0</left>
 			<top>0</top>
@@ -317,7 +311,6 @@
 			<animation effect="fade" time="200">Hidden</animation>
 			<visible>Window.IsActive(FileBrowser) | Window.IsActive(PVRGuideInfo) | Window.IsActive(PVRRecordingInfo) | Window.IsActive(PVRTimerSetting) | Window.IsActive(PVRGroupManager) | Window.IsActive(PVRGuideSearch)</visible>
 		</control>
-
 		<include>PVRSideBlade</include>
 		<include>Clock</include>
 	</controls>

--- a/addons/skin.confluence/720p/MyPVRRecordings.xml
+++ b/addons/skin.confluence/720p/MyPVRRecordings.xml
@@ -11,8 +11,8 @@
 			<width>1280</width>
 			<height>100</height>
 			<texture>floor.png</texture>
-			<animation effect="fade" time="250" condition="Window.Previous(Home)">WindowOpen</animation>
-			<animation effect="fade" time="250" condition="Window.Next(Home)">WindowClose</animation>
+			<animation effect="fade" time="200" condition="Window.Previous(Home)">WindowOpen</animation>
+			<animation effect="fade" time="200" condition="Window.Next(Home)">WindowClose</animation>
 		</control>
 		<control type="group">
 			<include>Window_OpenClose_Animation</include>
@@ -294,7 +294,7 @@
 					<left>10</left>
 					<top>548</top>
 					<width>290</width>
-					<height>12</height>&gt;
+					<height>12</height>
 					<info>PVR.backenddiskspaceprogr</info><visible>!IntegerGreaterThan(PVR.backenddiskspaceprogr,100)</visible></control>
 			</control>
 		</control>
@@ -307,8 +307,8 @@
 			<width>1280</width>
 			<height>720</height>
 			<texture>black-back.png</texture>
-			<animation effect="fade" time="400">Visible</animation>
-			<animation effect="fade" time="200">Hidden</animation>
+			<animation effect="fade" time="300">Visible</animation>
+			<animation effect="fade" time="150">Hidden</animation>
 			<visible>Window.IsActive(FileBrowser) | Window.IsActive(PVRGuideInfo) | Window.IsActive(PVRRecordingInfo) | Window.IsActive(PVRTimerSetting) | Window.IsActive(PVRGroupManager) | Window.IsActive(PVRGuideSearch)</visible>
 		</control>
 		<include>PVRSideBlade</include>

--- a/addons/skin.confluence/720p/MyPVRSearch.xml
+++ b/addons/skin.confluence/720p/MyPVRSearch.xml
@@ -15,7 +15,7 @@
 			<animation effect="fade" time="250" condition="Window.Next(Home)">WindowClose</animation>
 		</control>
 		<control type="group">
-			<include>Window_OpenClose_Animation</include>		
+			<include>Window_OpenClose_Animation</include>
 			<control type="image">
 				<left>0</left>
 				<top>100r</top>
@@ -26,7 +26,7 @@
 				<animation effect="fade" time="250" condition="Window.Next(Home)">WindowClose</animation>
 			</control>
 			<control type="group">
-				<include>Window_OpenClose_Animation</include>		
+				<include>Window_OpenClose_Animation</include>
 				<control type="group">
 					<include>VisibleFadeEffect</include>
 					<control type="image">
@@ -48,8 +48,6 @@
 		</control>
 		<include>MainWindowMouseButtons</include>
 		<include>PVRHeader</include>
-
-			
 		<control type="group">
 			<include>Window_OpenClose_Animation</include>
 			<description>TV Search group</description>
@@ -146,7 +144,7 @@
 								<textcolor>grey2</textcolor>
 								<selectedcolor>selected</selectedcolor>
 								<info>ListItem.Label</info>
-							</control>	
+							</control>
 						</control>
 						<control type="group">
 							<visible>!IsEmpty(ListItem.Date)</visible>
@@ -283,7 +281,7 @@
 								<textcolor>grey2</textcolor>
 								<selectedcolor>selected</selectedcolor>
 								<info>ListItem.Label</info>
-							</control>	
+							</control>
 						</control>
 						<control type="group">
 							<visible>!IsEmpty(ListItem.Date)</visible>
@@ -424,11 +422,9 @@
 				<label>([COLOR=blue]$INFO[Container(50).NumItems][/COLOR]) $LOCALIZE[31025] - $LOCALIZE[31024] ([COLOR=blue]$INFO[Container(50).CurrentPage]/$INFO[Container(50).NumPages][/COLOR])</label>
 			</control>
 		</control>
-
 		<include>CommonNowPlaying</include>
 		<include>BehindDialogFadeOut</include>
 		<include>ScrollOffsetLabel</include>
-
 		<control type="image">
 			<left>0</left>
 			<top>0</top>
@@ -439,7 +435,6 @@
 			<animation effect="fade" time="200">Hidden</animation>
 			<visible>Window.IsActive(FileBrowser) | Window.IsActive(PVRGuideInfo) | Window.IsActive(PVRRecordingInfo) | Window.IsActive(PVRTimerSetting) | Window.IsActive(PVRGroupManager) | Window.IsActive(PVRGuideSearch)</visible>
 		</control>
-
 		<include>PVRSideBlade</include>
 		<include>Clock</include>
 	</controls>

--- a/addons/skin.confluence/720p/MyPVRSearch.xml
+++ b/addons/skin.confluence/720p/MyPVRSearch.xml
@@ -11,8 +11,8 @@
 			<width>1280</width>
 			<height>100</height>
 			<texture>floor.png</texture>
-			<animation effect="fade" time="250" condition="Window.Previous(Home)">WindowOpen</animation>
-			<animation effect="fade" time="250" condition="Window.Next(Home)">WindowClose</animation>
+			<animation effect="fade" time="200" condition="Window.Previous(Home)">WindowOpen</animation>
+			<animation effect="fade" time="200" condition="Window.Next(Home)">WindowClose</animation>
 		</control>
 		<control type="group">
 			<include>Window_OpenClose_Animation</include>
@@ -22,8 +22,8 @@
 				<width>1280</width>
 				<height>100</height>
 				<texture>floor.png</texture>
-				<animation effect="fade" time="250" condition="Window.Previous(Home)">WindowOpen</animation>
-				<animation effect="fade" time="250" condition="Window.Next(Home)">WindowClose</animation>
+				<animation effect="fade" time="200" condition="Window.Previous(Home)">WindowOpen</animation>
+				<animation effect="fade" time="200" condition="Window.Next(Home)">WindowClose</animation>
 			</control>
 			<control type="group">
 				<include>Window_OpenClose_Animation</include>
@@ -431,8 +431,8 @@
 			<width>1280</width>
 			<height>720</height>
 			<texture>black-back.png</texture>
-			<animation effect="fade" time="400">Visible</animation>
-			<animation effect="fade" time="200">Hidden</animation>
+			<animation effect="fade" time="300">Visible</animation>
+			<animation effect="fade" time="150">Hidden</animation>
 			<visible>Window.IsActive(FileBrowser) | Window.IsActive(PVRGuideInfo) | Window.IsActive(PVRRecordingInfo) | Window.IsActive(PVRTimerSetting) | Window.IsActive(PVRGroupManager) | Window.IsActive(PVRGuideSearch)</visible>
 		</control>
 		<include>PVRSideBlade</include>

--- a/addons/skin.confluence/720p/MyPVRTimers.xml
+++ b/addons/skin.confluence/720p/MyPVRTimers.xml
@@ -15,7 +15,7 @@
 			<animation effect="fade" time="250" condition="Window.Next(Home)">WindowClose</animation>
 		</control>
 		<control type="group">
-			<include>Window_OpenClose_Animation</include>		
+			<include>Window_OpenClose_Animation</include>
 			<control type="image">
 				<left>0</left>
 				<top>100r</top>
@@ -26,7 +26,7 @@
 				<animation effect="fade" time="250" condition="Window.Next(Home)">WindowClose</animation>
 			</control>
 			<control type="group">
-				<include>Window_OpenClose_Animation</include>		
+				<include>Window_OpenClose_Animation</include>
 				<control type="group">
 					<include>VisibleFadeEffect</include>
 					<control type="image">
@@ -48,8 +48,6 @@
 		</control>
 		<include>MainWindowMouseButtons</include>
 		<include>PVRHeader</include>
-	
-			
 		<control type="group">
 			<include>Window_OpenClose_Animation</include>
 			<description>Timers group</description>
@@ -334,14 +332,12 @@
 				<align>right</align>
 				<aligny>center</aligny>
 				<label>([COLOR=blue]$INFO[Container(50).NumItems][/COLOR]) $LOCALIZE[19040] - $LOCALIZE[31024] ([COLOR=blue]$INFO[Container(50).CurrentPage]/$INFO[Container(50).NumPages][/COLOR])</label>
-				<include>Window_OpenClose_Animation</include>		
+				<include>Window_OpenClose_Animation</include>
 			</control>
 		</control>
-
 		<include>CommonNowPlaying</include>
 		<include>BehindDialogFadeOut</include>
 		<include>ScrollOffsetLabel</include>
-
 		<control type="image">
 			<left>0</left>
 			<top>0</top>
@@ -352,7 +348,6 @@
 			<animation effect="fade" time="200">Hidden</animation>
 			<visible>Window.IsActive(FileBrowser) | Window.IsActive(PVRGuideInfo) | Window.IsActive(PVRRecordingInfo) | Window.IsActive(PVRTimerSetting) | Window.IsActive(PVRGroupManager) | Window.IsActive(PVRGuideSearch)</visible>
 		</control>
-
 		<include>PVRSideBlade</include>
 		<include>Clock</include>
 	</controls>

--- a/addons/skin.confluence/720p/MyPVRTimers.xml
+++ b/addons/skin.confluence/720p/MyPVRTimers.xml
@@ -11,8 +11,8 @@
 			<width>1280</width>
 			<height>100</height>
 			<texture>floor.png</texture>
-			<animation effect="fade" time="250" condition="Window.Previous(Home)">WindowOpen</animation>
-			<animation effect="fade" time="250" condition="Window.Next(Home)">WindowClose</animation>
+			<animation effect="fade" time="200" condition="Window.Previous(Home)">WindowOpen</animation>
+			<animation effect="fade" time="200" condition="Window.Next(Home)">WindowClose</animation>
 		</control>
 		<control type="group">
 			<include>Window_OpenClose_Animation</include>
@@ -22,8 +22,8 @@
 				<width>1280</width>
 				<height>100</height>
 				<texture>floor.png</texture>
-				<animation effect="fade" time="250" condition="Window.Previous(Home)">WindowOpen</animation>
-				<animation effect="fade" time="250" condition="Window.Next(Home)">WindowClose</animation>
+				<animation effect="fade" time="200" condition="Window.Previous(Home)">WindowOpen</animation>
+				<animation effect="fade" time="200" condition="Window.Next(Home)">WindowClose</animation>
 			</control>
 			<control type="group">
 				<include>Window_OpenClose_Animation</include>
@@ -344,8 +344,8 @@
 			<width>1280</width>
 			<height>720</height>
 			<texture>black-back.png</texture>
-			<animation effect="fade" time="400">Visible</animation>
-			<animation effect="fade" time="200">Hidden</animation>
+			<animation effect="fade" time="300">Visible</animation>
+			<animation effect="fade" time="150">Hidden</animation>
 			<visible>Window.IsActive(FileBrowser) | Window.IsActive(PVRGuideInfo) | Window.IsActive(PVRRecordingInfo) | Window.IsActive(PVRTimerSetting) | Window.IsActive(PVRGroupManager) | Window.IsActive(PVRGuideSearch)</visible>
 		</control>
 		<include>PVRSideBlade</include>

--- a/addons/skin.confluence/720p/MyPics.xml
+++ b/addons/skin.confluence/720p/MyPics.xml
@@ -16,18 +16,25 @@
 			<aspectratio>keep</aspectratio>
 			<include>VisibleFadeEffect</include>
 			<visible>Control.IsVisible(510)</visible>
-			<include>Window_OpenClose_Animation</include>		
+			<include>Window_OpenClose_Animation</include>
 		</control>
 		<include>ContentPanelBackgrounds</include>
 		<control type="group">
-			<include>Window_OpenClose_Animation</include>		
-			<include>CommonRootView</include> <!-- view id = 50 -->
-			<include>FullWidthList</include> <!-- view id = 51 -->
-			<include>ThumbnailView</include> <!-- view id = 500 -->
-			<include>PictureWrapView</include> <!-- view id = 510 -->
-			<include>PictureThumbView</include> <!-- view id = 514 -->
-			<include>AddonInfoListView1</include> <!-- view id = 550 -->
-			<include>AddonInfoThumbView1</include> <!-- view id = 551 -->
+			<include>Window_OpenClose_Animation</include>
+			<include>CommonRootView</include>
+			<!-- view id = 50 -->
+			<include>FullWidthList</include>
+			<!-- view id = 51 -->
+			<include>ThumbnailView</include>
+			<!-- view id = 500 -->
+			<include>PictureWrapView</include>
+			<!-- view id = 510 -->
+			<include>PictureThumbView</include>
+			<!-- view id = 514 -->
+			<include>AddonInfoListView1</include>
+			<!-- view id = 550 -->
+			<include>AddonInfoThumbView1</include>
+			<!-- view id = 551 -->
 		</control>
 		<include>CommonPageCount</include>
 		<include>CommonNowPlaying</include>

--- a/addons/skin.confluence/720p/MyPrograms.xml
+++ b/addons/skin.confluence/720p/MyPrograms.xml
@@ -8,12 +8,17 @@
 		<include>CommonBackground</include>
 		<include>ContentPanelBackgrounds</include>
 		<control type="group">
-			<include>Window_OpenClose_Animation</include>		
-			<include>CommonRootView</include> <!-- view id = 50 -->
-			<include>FullWidthList</include> <!-- view id = 51 -->
-			<include>ThumbnailView</include> <!-- view id = 500 -->
-			<include>AddonInfoListView1</include> <!-- view id = 550 -->
-			<include>AddonInfoThumbView1</include> <!-- view id = 551 -->
+			<include>Window_OpenClose_Animation</include>
+			<include>CommonRootView</include>
+			<!-- view id = 50 -->
+			<include>FullWidthList</include>
+			<!-- view id = 51 -->
+			<include>ThumbnailView</include>
+			<!-- view id = 500 -->
+			<include>AddonInfoListView1</include>
+			<!-- view id = 550 -->
+			<include>AddonInfoThumbView1</include>
+			<!-- view id = 551 -->
 		</control>
 		<include>CommonPageCount</include>
 		<include>CommonNowPlaying</include>

--- a/addons/skin.confluence/720p/MyVideoNav.xml
+++ b/addons/skin.confluence/720p/MyVideoNav.xml
@@ -9,20 +9,33 @@
 		<include>CommonBackground</include>
 		<include>ContentPanelBackgrounds</include>
 		<control type="group">
-			<include>Window_OpenClose_Animation</include>		
-			<include>CommonRootView</include> <!-- view id = 50 -->
-			<include>FullWidthList</include> <!-- view id = 51 -->
-			<include>ThumbnailView</include> <!-- view id = 500 -->
-			<include>PosterWrapView</include> <!-- view id = 501 -->
-			<include>PosterWrapView2_Fanart</include> <!-- view id = 508 -->
-			<include>MediaListView3</include> <!-- view id = 503 -->
-			<include>MediaListView2</include> <!-- view id = 504 -->
-			<include>MediaListView4</include> <!-- view id = 515 -->
-			<include>WideIconView</include> <!-- view id = 505 -->
-			<include>MusicVideoInfoListView</include> <!-- view id = 511 -->
-			<include>AddonInfoListView1</include> <!-- view id = 550 -->
-			<include>AddonInfoThumbView1</include> <!-- view id = 551 -->
-			<include>LiveTVView1</include> <!-- view id = 560 -->
+			<include>Window_OpenClose_Animation</include>
+			<include>CommonRootView</include>
+			<!-- view id = 50 -->
+			<include>FullWidthList</include>
+			<!-- view id = 51 -->
+			<include>ThumbnailView</include>
+			<!-- view id = 500 -->
+			<include>PosterWrapView</include>
+			<!-- view id = 501 -->
+			<include>PosterWrapView2_Fanart</include>
+			<!-- view id = 508 -->
+			<include>MediaListView3</include>
+			<!-- view id = 503 -->
+			<include>MediaListView2</include>
+			<!-- view id = 504 -->
+			<include>MediaListView4</include>
+			<!-- view id = 515 -->
+			<include>WideIconView</include>
+			<!-- view id = 505 -->
+			<include>MusicVideoInfoListView</include>
+			<!-- view id = 511 -->
+			<include>AddonInfoListView1</include>
+			<!-- view id = 550 -->
+			<include>AddonInfoThumbView1</include>
+			<!-- view id = 551 -->
+			<include>LiveTVView1</include>
+			<!-- view id = 560 -->
 		</control>
 		<include>CommonPageCount</include>
 		<include>CommonNowPlaying</include>

--- a/addons/skin.confluence/720p/MyVideoPlaylist.xml
+++ b/addons/skin.confluence/720p/MyVideoPlaylist.xml
@@ -8,9 +8,11 @@
 		<include>CommonBackground</include>
 		<include>ContentPanelBackgrounds</include>
 		<control type="group">
-			<include>Window_OpenClose_Animation</include>		
-			<include>CommonRootView</include> <!-- view id = 50 -->
-			<include>FullWidthList</include> <!-- view id = 51 -->
+			<include>Window_OpenClose_Animation</include>
+			<include>CommonRootView</include>
+			<!-- view id = 50 -->
+			<include>FullWidthList</include>
+			<!-- view id = 51 -->
 		</control>
 		<include>CommonPageCount</include>
 		<include>CommonNowPlaying</include>

--- a/addons/skin.confluence/720p/MyWeather.xml
+++ b/addons/skin.confluence/720p/MyWeather.xml
@@ -52,12 +52,12 @@
 		</control>
 		<control type="group">
 			<animation type="WindowOpen" reversible="false">
-				<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="300"/>
-				<effect type="fade" start="0" end="100" time="300"/>
+				<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="300" />
+				<effect type="fade" start="0" end="100" time="300" />
 			</animation>
 			<animation type="WindowClose" reversible="false">
-				<effect type="zoom" start="100" end="80" center="640,360" easing="in" tween="back" time="300"/>
-				<effect type="fade" start="100" end="0" time="300"/>
+				<effect type="zoom" start="100" end="80" center="640,360" easing="in" tween="back" time="300" />
+				<effect type="fade" start="100" end="0" time="300" />
 			</animation>
 			<include>VisibleFadeEffect</include>
 			<control type="group">

--- a/addons/skin.confluence/720p/MyWeather.xml
+++ b/addons/skin.confluence/720p/MyWeather.xml
@@ -16,7 +16,7 @@
 			<fadetime>1000</fadetime>
 			<include>VisibleFadeEffect</include>
 			<visible>Skin.HasSetting(ShowWeatherFanart) + !IsEmpty(Skin.String(WeatherFanartDir))</visible>
-			<animation effect="fade" time="200">WindowClose</animation>
+			<animation effect="fade" time="150">WindowClose</animation>
 		</control>
 		<control type="image">
 			<description>Section header image</description>
@@ -47,17 +47,17 @@
 			<height>100</height>
 			<texture>floor.png</texture>
 			<include>VisibleFadeEffect</include>
-			<animation effect="slide" start="0,10" end="0,0" time="200" condition="Window.Previous(Home)">WindowOpen</animation>
-			<animation effect="slide" start="0,0" end="0,10" time="200" condition="Window.Next(Home)">WindowClose</animation>
+			<animation effect="slide" start="0,10" end="0,0" time="150" condition="Window.Previous(Home)">WindowOpen</animation>
+			<animation effect="slide" start="0,0" end="0,10" time="150" condition="Window.Next(Home)">WindowClose</animation>
 		</control>
 		<control type="group">
 			<animation type="WindowOpen" reversible="false">
-				<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="300" />
-				<effect type="fade" start="0" end="100" time="300" />
+				<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="225" />
+				<effect type="fade" start="0" end="100" time="225" />
 			</animation>
 			<animation type="WindowClose" reversible="false">
-				<effect type="zoom" start="100" end="80" center="640,360" easing="in" tween="back" time="300" />
-				<effect type="fade" start="100" end="0" time="300" />
+				<effect type="zoom" start="100" end="80" center="640,360" easing="in" tween="back" time="225" />
+				<effect type="fade" start="100" end="0" time="225" />
 			</animation>
 			<include>VisibleFadeEffect</include>
 			<control type="group">

--- a/addons/skin.confluence/720p/PlayerControls.xml
+++ b/addons/skin.confluence/720p/PlayerControls.xml
@@ -129,7 +129,7 @@
 				<ondown>200</ondown>
 				<onclick>PlayerControl(record)</onclick>
 				<enable>Player.CanRecord</enable>
-				<animation effect="fade" start="100" end="30" time="100" condition="!Player.CanRecord">Conditional</animation>
+				<animation effect="fade" start="100" end="30" time="75" condition="!Player.CanRecord">Conditional</animation>
 				<visible>!VideoPlayer.Content(LiveTV)</visible>
 			</control>
 			<control type="group">
@@ -274,7 +274,7 @@
 				<onclick>PlayerControl(Rewind)</onclick>
 				<visible>VideoPlayer.Content(LiveTV)</visible>
 				<enable>Player.SeekEnabled</enable>
-				<animation effect="fade" start="100" end="50" time="100" condition="true">Conditional</animation>
+				<animation effect="fade" start="100" end="50" time="75" condition="true">Conditional</animation>
 			</control>
 			<control type="button" id="702">
 				<left>40</left>
@@ -311,7 +311,7 @@
 				<visible>VideoPlayer.Content(LiveTV)</visible>
 				<enable>false</enable>
 				<enable>Player.PauseEnabled</enable>
-				<animation effect="fade" start="100" end="50" time="100" condition="true">Conditional</animation>
+				<animation effect="fade" start="100" end="50" time="75" condition="true">Conditional</animation>
 			</control>
 			<control type="button" id="704">
 				<left>120</left>
@@ -328,7 +328,7 @@
 				<onclick>PlayerControl(Forward)</onclick>
 				<visible>VideoPlayer.Content(LiveTV)</visible>
 				<enable>Player.SeekEnabled</enable>
-				<animation effect="fade" start="100" end="50" time="100" condition="true">Conditional</animation>
+				<animation effect="fade" start="100" end="50" time="75" condition="true">Conditional</animation>
 			</control>
 			<control type="button" id="700">
 				<left>200</left>
@@ -374,7 +374,7 @@
 				<ondown>200</ondown>
 				<onclick>PlayerControl(record)</onclick>
 				<enable>Player.CanRecord</enable>
-				<animation effect="fade" start="100" end="30" time="100" condition="!Player.CanRecord">Conditional</animation>
+				<animation effect="fade" start="100" end="30" time="75" condition="!Player.CanRecord">Conditional</animation>
 				<visible>VideoPlayer.Content(LiveTV)</visible>
 			</control>
 		</control>

--- a/addons/skin.confluence/720p/Settings.xml
+++ b/addons/skin.confluence/720p/Settings.xml
@@ -17,12 +17,12 @@
 			<left>90</left>
 			<top>30</top>
 			<animation type="WindowOpen" reversible="false">
-				<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="300"/>
-				<effect type="fade" start="0" end="100" time="300"/>
+				<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="300" />
+				<effect type="fade" start="0" end="100" time="300" />
 			</animation>
 			<animation type="WindowClose" reversible="false">
-				<effect type="zoom" start="100" end="80" center="640,360" easing="in" tween="back" time="300"/>
-				<effect type="fade" start="100" end="0" time="300"/>
+				<effect type="zoom" start="100" end="80" center="640,360" easing="in" tween="back" time="300" />
+				<effect type="fade" start="100" end="0" time="300" />
 			</animation>
 			<control type="image">
 				<left>5</left>

--- a/addons/skin.confluence/720p/Settings.xml
+++ b/addons/skin.confluence/720p/Settings.xml
@@ -10,19 +10,19 @@
 			<width>1280</width>
 			<height>100</height>
 			<texture>floor.png</texture>
-			<animation effect="slide" start="0,10" end="0,0" time="200" condition="Window.Previous(Home)">WindowOpen</animation>
-			<animation effect="slide" start="0,0" end="0,10" time="200" condition="Window.Next(Home)">WindowClose</animation>
+			<animation effect="slide" start="0,10" end="0,0" time="150" condition="Window.Previous(Home)">WindowOpen</animation>
+			<animation effect="slide" start="0,0" end="0,10" time="150" condition="Window.Next(Home)">WindowClose</animation>
 		</control>
 		<control type="group">
 			<left>90</left>
 			<top>30</top>
 			<animation type="WindowOpen" reversible="false">
-				<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="300" />
-				<effect type="fade" start="0" end="100" time="300" />
+				<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="225" />
+				<effect type="fade" start="0" end="100" time="225" />
 			</animation>
 			<animation type="WindowClose" reversible="false">
-				<effect type="zoom" start="100" end="80" center="640,360" easing="in" tween="back" time="300" />
-				<effect type="fade" start="100" end="0" time="300" />
+				<effect type="zoom" start="100" end="80" center="640,360" easing="in" tween="back" time="225" />
+				<effect type="fade" start="100" end="0" time="225" />
 			</animation>
 			<control type="image">
 				<left>5</left>

--- a/addons/skin.confluence/720p/SettingsCategory.xml
+++ b/addons/skin.confluence/720p/SettingsCategory.xml
@@ -16,12 +16,12 @@
 			<left>90</left>
 			<top>30</top>
 			<animation type="WindowOpen" reversible="false">
-				<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="300"/>
-				<effect type="fade" start="0" end="100" time="300"/>
+				<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="300" />
+				<effect type="fade" start="0" end="100" time="300" />
 			</animation>
 			<animation type="WindowClose" reversible="false">
-				<effect type="zoom" start="100" end="80" center="640,360" easing="in" tween="back" time="300"/>
-				<effect type="fade" start="100" end="0" time="300"/>
+				<effect type="zoom" start="100" end="80" center="640,360" easing="in" tween="back" time="300" />
+				<effect type="fade" start="100" end="0" time="300" />
 			</animation>
 			<control type="image">
 				<left>5</left>
@@ -103,11 +103,11 @@
 				<left>20</left>
 				<top>566</top>
 				<height>25</height>
-				<width>230</width> 
-				<label>31142</label> 
-				<font>font13_title</font> 
-				<textcolor>white</textcolor> 
-				<align>right</align> 
+				<width>230</width>
+				<label>31142</label>
+				<font>font13_title</font>
+				<textcolor>white</textcolor>
+				<align>right</align>
 				<aligny>center</aligny>
 			</control>
 			<control type="image">
@@ -187,7 +187,6 @@
 			</control>
 		</control>
 		<include>BehindDialogFadeOut</include>
-
 		<control type="button" id="10">
 			<description>Default Category Button</description>
 			<height>60</height>

--- a/addons/skin.confluence/720p/SettingsCategory.xml
+++ b/addons/skin.confluence/720p/SettingsCategory.xml
@@ -16,12 +16,12 @@
 			<left>90</left>
 			<top>30</top>
 			<animation type="WindowOpen" reversible="false">
-				<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="300" />
-				<effect type="fade" start="0" end="100" time="300" />
+				<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="225" />
+				<effect type="fade" start="0" end="100" time="225" />
 			</animation>
 			<animation type="WindowClose" reversible="false">
-				<effect type="zoom" start="100" end="80" center="640,360" easing="in" tween="back" time="300" />
-				<effect type="fade" start="100" end="0" time="300" />
+				<effect type="zoom" start="100" end="80" center="640,360" easing="in" tween="back" time="225" />
+				<effect type="fade" start="100" end="0" time="225" />
 			</animation>
 			<control type="image">
 				<left>5</left>

--- a/addons/skin.confluence/720p/SettingsProfile.xml
+++ b/addons/skin.confluence/720p/SettingsProfile.xml
@@ -17,12 +17,12 @@
 			<left>90</left>
 			<top>30</top>
 			<animation type="WindowOpen" reversible="false">
-				<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="300"/>
-				<effect type="fade" start="0" end="100" time="300"/>
+				<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="300" />
+				<effect type="fade" start="0" end="100" time="300" />
 			</animation>
 			<animation type="WindowClose" reversible="false">
-				<effect type="zoom" start="100" end="80" center="640,360" easing="in" tween="back" time="300"/>
-				<effect type="fade" start="100" end="0" time="300"/>
+				<effect type="zoom" start="100" end="80" center="640,360" easing="in" tween="back" time="300" />
+				<effect type="fade" start="100" end="0" time="300" />
 			</animation>
 			<control type="image">
 				<left>5</left>

--- a/addons/skin.confluence/720p/SettingsProfile.xml
+++ b/addons/skin.confluence/720p/SettingsProfile.xml
@@ -10,19 +10,19 @@
 			<width>1280</width>
 			<height>100</height>
 			<texture>floor.png</texture>
-			<animation effect="slide" start="0,10" end="0,0" time="200" condition="Window.Previous(Home)">WindowOpen</animation>
-			<animation effect="slide" start="0,0" end="0,10" time="200" condition="Window.Next(Home)">WindowClose</animation>
+			<animation effect="slide" start="0,10" end="0,0" time="150" condition="Window.Previous(Home)">WindowOpen</animation>
+			<animation effect="slide" start="0,0" end="0,10" time="150" condition="Window.Next(Home)">WindowClose</animation>
 		</control>
 		<control type="group">
 			<left>90</left>
 			<top>30</top>
 			<animation type="WindowOpen" reversible="false">
-				<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="300" />
-				<effect type="fade" start="0" end="100" time="300" />
+				<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="225" />
+				<effect type="fade" start="0" end="100" time="225" />
 			</animation>
 			<animation type="WindowClose" reversible="false">
-				<effect type="zoom" start="100" end="80" center="640,360" easing="in" tween="back" time="300" />
-				<effect type="fade" start="100" end="0" time="300" />
+				<effect type="zoom" start="100" end="80" center="640,360" easing="in" tween="back" time="225" />
+				<effect type="fade" start="100" end="0" time="225" />
 			</animation>
 			<control type="image">
 				<left>5</left>
@@ -102,7 +102,7 @@
 						<width>260</width>
 						<height>55</height>
 						<texture border="5">MenuItemFO.png</texture>
-						<animation effect="fade" start="100" end="30" time="100" condition="!Control.HasFocus(9000)">Conditional</animation>
+						<animation effect="fade" start="100" end="30" time="75" condition="!Control.HasFocus(9000)">Conditional</animation>
 					</control>
 					<control type="label">
 						<left>10</left>

--- a/addons/skin.confluence/720p/SettingsSystemInfo.xml
+++ b/addons/skin.confluence/720p/SettingsSystemInfo.xml
@@ -17,12 +17,12 @@
 			<left>90</left>
 			<top>30</top>
 			<animation type="WindowOpen" reversible="false">
-				<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="300"/>
-				<effect type="fade" start="0" end="100" time="300"/>
+				<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="300" />
+				<effect type="fade" start="0" end="100" time="300" />
 			</animation>
 			<animation type="WindowClose" reversible="false">
-				<effect type="zoom" start="100" end="80" center="640,360" easing="in" tween="back" time="300"/>
-				<effect type="fade" start="100" end="0" time="300"/>
+				<effect type="zoom" start="100" end="80" center="640,360" easing="in" tween="back" time="300" />
+				<effect type="fade" start="100" end="0" time="300" />
 			</animation>
 			<control type="image">
 				<left>5</left>

--- a/addons/skin.confluence/720p/SettingsSystemInfo.xml
+++ b/addons/skin.confluence/720p/SettingsSystemInfo.xml
@@ -10,19 +10,19 @@
 			<width>1280</width>
 			<height>100</height>
 			<texture>floor.png</texture>
-			<animation effect="slide" start="0,10" end="0,0" time="200" condition="Window.Previous(Home)">WindowOpen</animation>
-			<animation effect="slide" start="0,0" end="0,10" time="200" condition="Window.Next(Home)">WindowClose</animation>
+			<animation effect="slide" start="0,10" end="0,0" time="150" condition="Window.Previous(Home)">WindowOpen</animation>
+			<animation effect="slide" start="0,0" end="0,10" time="150" condition="Window.Next(Home)">WindowClose</animation>
 		</control>
 		<control type="group">
 			<left>90</left>
 			<top>30</top>
 			<animation type="WindowOpen" reversible="false">
-				<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="300" />
-				<effect type="fade" start="0" end="100" time="300" />
+				<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="225" />
+				<effect type="fade" start="0" end="100" time="225" />
 			</animation>
 			<animation type="WindowClose" reversible="false">
-				<effect type="zoom" start="100" end="80" center="640,360" easing="in" tween="back" time="300" />
-				<effect type="fade" start="100" end="0" time="300" />
+				<effect type="zoom" start="100" end="80" center="640,360" easing="in" tween="back" time="225" />
+				<effect type="fade" start="100" end="0" time="225" />
 			</animation>
 			<control type="image">
 				<left>5</left>

--- a/addons/skin.confluence/720p/SkinSettings.xml
+++ b/addons/skin.confluence/720p/SkinSettings.xml
@@ -42,12 +42,12 @@
 			<left>90</left>
 			<top>30</top>
 			<animation type="WindowOpen" reversible="false">
-				<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="300"/>
-				<effect type="fade" start="0" end="100" time="300"/>
+				<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="300" />
+				<effect type="fade" start="0" end="100" time="300" />
 			</animation>
 			<animation type="WindowClose" reversible="false">
-				<effect type="zoom" start="100" end="80" center="640,360" easing="in" tween="back" time="300"/>
-				<effect type="fade" start="100" end="0" time="300"/>
+				<effect type="zoom" start="100" end="80" center="640,360" easing="in" tween="back" time="300" />
+				<effect type="fade" start="100" end="0" time="300" />
 			</animation>
 			<control type="image">
 				<left>5</left>
@@ -721,8 +721,7 @@
 							<texturenofocus>MenuItemNF.png</texturenofocus>
 							<enable>!IsEmpty(Skin.String(LyricScript_Path))</enable>
 							<onclick>Addon.OpenSettings($INFO[Skin.String(LyricScript_Path)])</onclick>
-						</control> 
-
+						</control>
 						<control type="label" id="410">
 							<width>750</width>
 							<height>45</height>
@@ -793,7 +792,6 @@
 							<texturenofocus>MenuItemNF.png</texturenofocus>
 							<onclick>Skin.SetAddon(HomeVideosButton5,xbmc.addon.video,xbmc.addon.executable)</onclick>
 						</control>
-
 						<control type="label" id="420">
 							<width>750</width>
 							<height>45</height>
@@ -864,7 +862,6 @@
 							<texturenofocus>MenuItemNF.png</texturenofocus>
 							<onclick>Skin.SetAddon(HomeMusicButton5,xbmc.addon.audio,xbmc.addon.executable)</onclick>
 						</control>
-
 						<control type="label" id="430">
 							<width>750</width>
 							<height>45</height>
@@ -935,7 +932,6 @@
 							<texturenofocus>MenuItemNF.png</texturenofocus>
 							<onclick>Skin.SetAddon(HomePictureButton5,xbmc.addon.image,xbmc.addon.executable)</onclick>
 						</control>
-
 						<control type="label" id="440">
 							<width>750</width>
 							<height>45</height>

--- a/addons/skin.confluence/720p/SkinSettings.xml
+++ b/addons/skin.confluence/720p/SkinSettings.xml
@@ -42,12 +42,12 @@
 			<left>90</left>
 			<top>30</top>
 			<animation type="WindowOpen" reversible="false">
-				<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="300" />
-				<effect type="fade" start="0" end="100" time="300" />
+				<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="225" />
+				<effect type="fade" start="0" end="100" time="225" />
 			</animation>
 			<animation type="WindowClose" reversible="false">
-				<effect type="zoom" start="100" end="80" center="640,360" easing="in" tween="back" time="300" />
-				<effect type="fade" start="100" end="0" time="300" />
+				<effect type="zoom" start="100" end="80" center="640,360" easing="in" tween="back" time="225" />
+				<effect type="fade" start="100" end="0" time="225" />
 			</animation>
 			<control type="image">
 				<left>5</left>
@@ -138,7 +138,7 @@
 						<width>260</width>
 						<height>81</height>
 						<texture border="5">MenuItemFO.png</texture>
-						<animation effect="fade" start="100" end="30" time="100" condition="!Control.HasFocus(9000)">Conditional</animation>
+						<animation effect="fade" start="100" end="30" time="75" condition="!Control.HasFocus(9000)">Conditional</animation>
 					</control>
 					<control type="label">
 						<left>10</left>

--- a/addons/skin.confluence/720p/SmartPlaylistEditor.xml
+++ b/addons/skin.confluence/720p/SmartPlaylistEditor.xml
@@ -217,7 +217,6 @@
 					<ondown>16</ondown>
 				</control>
 			</control>
-
 			<control type="label">
 				<description>Name Label</description>
 				<left>30</left>
@@ -242,7 +241,6 @@
 				<onup>10</onup>
 				<ondown>17</ondown>
 			</control>
-
 			<control type="spincontrolex" id="17">
 				<left>30</left>
 				<top>440</top>
@@ -257,7 +255,6 @@
 				<onup>16</onup>
 				<ondown>18</ondown>
 			</control>
-
 			<control type="spincontrolex" id="18">
 				<left>30</left>
 				<top>485</top>
@@ -272,7 +269,6 @@
 				<onup>17</onup>
 				<ondown>23</ondown>
 			</control>
-
 			<control type="togglebutton" id="19">
 				<left>590</left>
 				<top>485</top>
@@ -292,7 +288,6 @@
 				<onup>17</onup>
 				<ondown>24</ondown>
 			</control>
-
 			<control type="spincontrolex" id="23">
 				<left>30</left>
 				<top>530</top>
@@ -307,7 +302,6 @@
 				<onup>18</onup>
 				<ondown>9001</ondown>
 			</control>
-
 			<control type="radiobutton" id="24">
 				<left>590</left>
 				<top>530</top>
@@ -324,7 +318,6 @@
 				<onup>19</onup>
 				<ondown>9001</ondown>
 			</control>
-
 			<control type="group" id="9001">
 				<control type="button" id="20">
 					<description>Ok Button</description>

--- a/addons/skin.confluence/720p/VideoFullScreen.xml
+++ b/addons/skin.confluence/720p/VideoFullScreen.xml
@@ -5,7 +5,7 @@
 		<!-- media infos -->
 		<control type="group" id="1">
 			<visible>[Player.ShowInfo | Window.IsActive(VideoOSD)] + ![Window.IsVisible(OSDVideoSettings) | Window.IsVisible(OSDAudioSettings) | Window.IsVisible(VideoBookmarks) | Window.IsVisible(PVROSDChannels) | Window.IsVisible(PVROSDGuide) | Window.IsVisible(SliderDialog)]</visible>
-			<animation effect="fade" time="200">VisibleChange</animation>
+			<animation effect="fade" time="150">VisibleChange</animation>
 			<control type="image" id="1">
 				<left>0</left>
 				<top>-150</top>
@@ -274,7 +274,7 @@
 					<textcolor>grey</textcolor>
 					<scroll>true</scroll>
 					<visible>!Window.IsVisible(VideoOSD) + !VideoPlayer.Content(LiveTV)</visible>
-					<animation effect="fade" time="200">VisibleChange</animation>
+					<animation effect="fade" time="150">VisibleChange</animation>
 				</control>
 				<control type="label" id="1">
 					<left>0</left>
@@ -288,7 +288,7 @@
 					<textcolor>grey</textcolor>
 					<scroll>true</scroll>
 					<visible>!Window.IsVisible(VideoOSD) + VideoPlayer.Content(LiveTV)</visible>
-					<animation effect="fade" time="200">VisibleChange</animation>
+					<animation effect="fade" time="150">VisibleChange</animation>
 				</control>
 			</control>
 			<control type="group" id="1">
@@ -362,7 +362,7 @@
 		<control type="group" id="0">
 			<left>0</left>
 			<top>20</top>
-			<animation effect="fade" time="200">VisibleChange</animation>
+			<animation effect="fade" time="150">VisibleChange</animation>
 			<control type="image">
 				<description>media info background image</description>
 				<left>0</left>

--- a/addons/skin.confluence/720p/VideoOSD.xml
+++ b/addons/skin.confluence/720p/VideoOSD.xml
@@ -25,7 +25,7 @@
 			<onright>1000</onright>
 			<onup>100</onup>
 			<ondown>100</ondown>
-			<animation effect="fade" time="200">VisibleChange</animation>
+			<animation effect="fade" time="150">VisibleChange</animation>
 			<visible>![Window.IsVisible(SliderDialog) | Window.IsVisible(OSDVideoSettings) | Window.IsVisible(OSDAudioSettings) | Window.IsVisible(VideoBookmarks)]</visible>
 		</control>
 		<control type="slider" id="87">
@@ -40,7 +40,7 @@
 			<texturesliderbar>seekslider2.png</texturesliderbar>
 			<textureslidernib>osd_slider_nibNF.png</textureslidernib>
 			<textureslidernibfocus>osd_slider_nib.png</textureslidernibfocus>
-			<animation effect="fade" time="200">VisibleChange</animation>
+			<animation effect="fade" time="150">VisibleChange</animation>
 			<visible>![Window.IsVisible(SliderDialog) | Window.IsVisible(OSDVideoSettings) | Window.IsVisible(OSDAudioSettings) | Window.IsVisible(VideoBookmarks) | VideoPlayer.Content(LiveTV)]</visible>
 		</control>
 		<control type="grouplist" id="100">
@@ -48,7 +48,7 @@
 			<top>60r</top>
 			<orientation>horizontal</orientation>
 			<itemgap>0</itemgap>
-			<animation effect="fade" time="200">VisibleChange</animation>
+			<animation effect="fade" time="150">VisibleChange</animation>
 			<visible>![Window.IsVisible(SliderDialog) | Window.IsVisible(OSDVideoSettings) | Window.IsVisible(OSDAudioSettings) | Window.IsVisible(VideoBookmarks) | Window.IsVisible(PVROSDChannels) | Window.IsVisible(PVROSDGuide)]</visible>
 			<onup>1000</onup>
 			<control type="button" id="300">
@@ -89,7 +89,7 @@
 				<texturefocus>OSDRewindFO.png</texturefocus>
 				<texturenofocus>OSDRewindNF.png</texturenofocus>
 				<enable>Player.SeekEnabled</enable>
-				<animation effect="fade" start="100" end="50" time="100" condition="!Player.SeekEnabled">Conditional</animation>
+				<animation effect="fade" start="100" end="50" time="75" condition="!Player.SeekEnabled">Conditional</animation>
 				<onclick>PlayerControl(Rewind)</onclick>
 			</control>
 			<control type="togglebutton" id="202">
@@ -105,7 +105,7 @@
 				<alttexturenofocus>OSDPlayNF.png</alttexturenofocus>
 				<onclick>PlayerControl(Play)</onclick>
 				<enable>Player.PauseEnabled</enable>
-				<animation effect="fade" start="100" end="50" time="100" condition="!Player.PauseEnabled">Conditional</animation>
+				<animation effect="fade" start="100" end="50" time="75" condition="!Player.PauseEnabled">Conditional</animation>
 			</control>
 			<control type="button" id="203">
 				<width>55</width>
@@ -124,7 +124,7 @@
 				<texturefocus>OSDForwardFO.png</texturefocus>
 				<texturenofocus>OSDForwardNF.png</texturenofocus>
 				<enable>Player.SeekEnabled</enable>
-				<animation effect="fade" start="100" end="50" time="100" condition="!Player.SeekEnabled">Conditional</animation>
+				<animation effect="fade" start="100" end="50" time="75" condition="!Player.SeekEnabled">Conditional</animation>
 				<onclick>PlayerControl(Forward)</onclick>
 			</control>
 			<control type="button" id="205">
@@ -181,7 +181,7 @@
 			</control>
 			<control type="button" id="255">
 				<enable>VideoPlayer.IsStereoscopic</enable>
-				<animation effect="fade" start="100" end="0" time="100" condition="!VideoPlayer.IsStereoscopic">Conditional</animation>
+				<animation effect="fade" start="100" end="0" time="75" condition="!VideoPlayer.IsStereoscopic">Conditional</animation>
 				<width>55</width>
 				<height>55</height>
 				<label>36501</label>
@@ -246,7 +246,7 @@
 				<ondown>1000</ondown>
 				<onclick>PlayerControl(ShowVideoMenu)</onclick>
 				<enable>VideoPlayer.HasMenu</enable>
-				<animation effect="fade" start="100" end="50" time="100" condition="!VideoPlayer.HasMenu">Conditional</animation>
+				<animation effect="fade" start="100" end="50" time="75" condition="!VideoPlayer.HasMenu">Conditional</animation>
 				<visible>!VideoPlayer.Content(LiveTV)</visible>
 			</control>
 			<control type="togglebutton" id="353">
@@ -262,7 +262,7 @@
 				<alttexturenofocus>OSDRecordOnNF.png</alttexturenofocus>
 				<onclick>PlayerControl(Record)</onclick>
 				<enable>Player.CanRecord</enable>
-				<animation effect="fade" start="100" end="50" time="100" condition="!Player.CanRecord">Conditional</animation>
+				<animation effect="fade" start="100" end="50" time="75" condition="!Player.CanRecord">Conditional</animation>
 				<visible>VideoPlayer.Content(LiveTV)</visible>
 			</control>
 		</control>
@@ -281,7 +281,7 @@
 		</control>
 		<control type="grouplist" id="400">
 			<visible>![Window.IsVisible(SliderDialog) | Window.IsVisible(OSDVideoSettings) | Window.IsVisible(OSDAudioSettings) | Window.IsVisible(VideoBookmarks)]</visible>
-			<animation effect="fade" time="200">VisibleChange</animation>
+			<animation effect="fade" time="150">VisibleChange</animation>
 			<animation effect="slide" start="0,0" end="0,80" time="0" condition="![VideoPlayer.HasSubtitles + VideoPlayer.SubtitlesEnabled]">Conditional</animation>
 			<animation effect="slide" start="0,0" end="0,40" time="0" condition="!VideoPlayer.HasSubtitles">Conditional</animation>
 			<animation effect="slide" start="0,0" end="55,0" time="0" condition="VideoPlayer.Content(LiveTV)">Conditional</animation>
@@ -403,7 +403,7 @@
 		</control>
 		<control type="grouplist" id="500">
 			<visible>videoplayer.isstereoscopic + ![Window.IsVisible(SliderDialog) | Window.IsVisible(OSDVideoSettings) | Window.IsVisible(OSDAudioSettings) | Window.IsVisible(VideoBookmarks) | Window.IsVisible(PVROSDChannels) | Window.IsVisible(PVROSDGuide)] + [Control.HasFocus(255) | ControlGroup(500).HasFocus | Control.HasFocus(520)]</visible>
-			<animation effect="fade" time="200">VisibleChange</animation>
+			<animation effect="fade" time="150">VisibleChange</animation>
 			<animation effect="slide" start="0,0" end="55,0" time="0" condition="VideoPlayer.Content(LiveTV)">Conditional</animation>
 			<right>200</right>
 			<bottom>45</bottom>

--- a/addons/skin.confluence/720p/VideoOSDSettings.xml
+++ b/addons/skin.confluence/720p/VideoOSDSettings.xml
@@ -9,7 +9,7 @@
 	<include>dialogeffect</include>
 	<controls>
 		<control type="group">
-			<animation effect="fade" start="100" end="0" time="400" condition="Window.IsVisible(SliderDialog) | Window.IsVisible(FileBrowser)">Conditional</animation>
+			<animation effect="fade" start="100" end="0" time="300" condition="Window.IsVisible(SliderDialog) | Window.IsVisible(FileBrowser)">Conditional</animation>
 			<control type="image">
 				<description>background image</description>
 				<left>0</left>

--- a/addons/skin.confluence/720p/VideoOverlay.xml
+++ b/addons/skin.confluence/720p/VideoOverlay.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
 	<defaultcontrol>-</defaultcontrol>
-	<controls>
-	</controls>
+	<controls></controls>
 </window>

--- a/addons/skin.confluence/720p/ViewsFileMode.xml
+++ b/addons/skin.confluence/720p/ViewsFileMode.xml
@@ -5,7 +5,7 @@
 			<visible>Control.IsVisible(50)</visible>
 			<include>VisibleFadeEffect</include>
 			<control type="list" id="50">
-			<left>70</left>
+				<left>70</left>
 				<top>78</top>
 				<width>690</width>
 				<height>561</height>

--- a/addons/skin.confluence/720p/ViewsMusicLibrary.xml
+++ b/addons/skin.confluence/720p/ViewsMusicLibrary.xml
@@ -262,7 +262,7 @@
 			<top>450</top>
 			<control type="fixedlist" id="509">
 				<visible>Container.Content(Albums)</visible>
-				<hitrect x="0" y="-10" w="1280" h="190"/>
+				<hitrect x="0" y="-10" w="1280" h="190" />
 				<left>-80</left>
 				<top>0</top>
 				<width>1360</width>
@@ -333,12 +333,12 @@
 						<aspectratio>keep</aspectratio>
 						<texture>$INFO[ListItem.Overlay]</texture>
 						<animation type="focus">
-							<effect type="fade" start="0" end="100" time="200"/>
-							<effect type="slide" start="0,0" end="40,40" time="200"/>
+							<effect type="fade" start="0" end="100" time="200" />
+							<effect type="slide" start="0,0" end="40,40" time="200" />
 						</animation>
 						<animation type="unfocus">
-							<effect type="fade" start="100" end="0" time="200"/>
-							<effect type="slide" end="0,0" start="40,40" time="200"/>
+							<effect type="fade" start="100" end="0" time="200" />
+							<effect type="slide" end="0,0" start="40,40" time="200" />
 						</animation>
 					</control>
 				</focusedlayout>

--- a/addons/skin.confluence/720p/ViewsMusicLibrary.xml
+++ b/addons/skin.confluence/720p/ViewsMusicLibrary.xml
@@ -252,7 +252,7 @@
 				<align>center</align>
 				<aligny>center</aligny>
 				<label>$INFO[ListItem.Label]</label>
-				<animation effect="slide" start="0,0" end="0,20" time="200" condition="!Control.HasFocus(509)">conditional</animation>
+				<animation effect="slide" start="0,0" end="0,20" time="150" condition="!Control.HasFocus(509)">conditional</animation>
 			</control>
 		</control>
 		<control type="group">
@@ -322,8 +322,8 @@
 						<bordersize>8</bordersize>
 						<fadetime>200</fadetime>
 						<texture background="true">$INFO[ListItem.Icon]</texture>
-						<animation reversible="false" effect="zoom" start="-2,16,168,168" end="-12,-4,198,198" time="200">focus</animation>
-						<animation reversible="false" effect="zoom" end="-2,16,168,168" start="-12,-4,198,198" time="200">unfocus</animation>
+						<animation reversible="false" effect="zoom" start="-2,16,168,168" end="-12,-4,198,198" time="150">focus</animation>
+						<animation reversible="false" effect="zoom" end="-2,16,168,168" start="-12,-4,198,198" time="150">unfocus</animation>
 					</control>
 					<control type="image">
 						<left>180</left>
@@ -333,12 +333,12 @@
 						<aspectratio>keep</aspectratio>
 						<texture>$INFO[ListItem.Overlay]</texture>
 						<animation type="focus">
-							<effect type="fade" start="0" end="100" time="200" />
-							<effect type="slide" start="0,0" end="40,40" time="200" />
+							<effect type="fade" start="0" end="100" time="150" />
+							<effect type="slide" start="0,0" end="40,40" time="150" />
 						</animation>
 						<animation type="unfocus">
-							<effect type="fade" start="100" end="0" time="200" />
-							<effect type="slide" end="0,0" start="40,40" time="200" />
+							<effect type="fade" start="100" end="0" time="150" />
+							<effect type="slide" end="0,0" start="40,40" time="150" />
 						</animation>
 					</control>
 				</focusedlayout>

--- a/addons/skin.confluence/720p/ViewsPVRGuide.xml
+++ b/addons/skin.confluence/720p/ViewsPVRGuide.xml
@@ -31,7 +31,7 @@
 				<onright>101</onright>
 				<onup>10</onup>
 				<ondown>10</ondown>
-				<onback>101</onback> 
+				<onback>101</onback>
 				<rulerlayout height="35" width="40">
 					<control type="label" id="2">
 						<left>0</left>
@@ -280,7 +280,6 @@
 			</control>
 		</control>
 	</include>
-	
 	<!-- ID: 11 -->
 	<include name="PVRGuideViewNow">
 		<control type="group">
@@ -659,7 +658,6 @@
 			</control>
 		</control>
 	</include>
-	
 	<!-- ID: 12 -->
 	<include name="PVRGuideViewNext">
 		<control type="group">
@@ -1038,7 +1036,6 @@
 			</control>
 		</control>
 	</include>
-	
 	<!-- ID: 13 -->
 	<include name="PVRGuideViewChannel">
 		<control type="group">

--- a/addons/skin.confluence/720p/ViewsPictures.xml
+++ b/addons/skin.confluence/720p/ViewsPictures.xml
@@ -53,8 +53,8 @@
 						<bordersize>8</bordersize>
 						<fadetime>200</fadetime>
 						<texture border="2">ThumbBG.png</texture>
-						<animation reversible="false" effect="zoom" start="15,40,160,160" end="-10,-5,210,210" time="200">focus</animation>
-						<animation reversible="false" effect="zoom" end="15,40,160,160" start="-10,-5,210,210" time="200">unfocus</animation>
+						<animation reversible="false" effect="zoom" start="15,40,160,160" end="-10,-5,210,210" time="150">focus</animation>
+						<animation reversible="false" effect="zoom" end="15,40,160,160" start="-10,-5,210,210" time="150">unfocus</animation>
 					</control>
 					<control type="image">
 						<left>25</left>
@@ -63,8 +63,8 @@
 						<height>140</height>
 						<aspectratio>keep</aspectratio>
 						<texture background="true">$INFO[ListItem.Icon]</texture>
-						<animation reversible="false" effect="zoom" start="25,50,140,140" end="5,10,180,180" time="200">focus</animation>
-						<animation reversible="false" effect="zoom" end="25,50,140,140" start="5,10,180,180" time="200">unfocus</animation>
+						<animation reversible="false" effect="zoom" start="25,50,140,140" end="5,10,180,180" time="150">focus</animation>
+						<animation reversible="false" effect="zoom" end="25,50,140,140" start="5,10,180,180" time="150">unfocus</animation>
 					</control>
 				</focusedlayout>
 			</control>

--- a/addons/skin.confluence/720p/ViewsVideoLibrary.xml
+++ b/addons/skin.confluence/720p/ViewsVideoLibrary.xml
@@ -71,12 +71,12 @@
 						<aspectratio>keep</aspectratio>
 						<texture>$INFO[ListItem.Overlay]</texture>
 						<animation type="focus">
-							<effect type="fade" start="0" end="100" time="200"/>
-							<effect type="slide" start="0,0" end="40,40" time="200"/>
+							<effect type="fade" start="0" end="100" time="200" />
+							<effect type="slide" start="0,0" end="40,40" time="200" />
 						</animation>
 						<animation type="unfocus">
-							<effect type="fade" start="100" end="0" time="200"/>
-							<effect type="slide" end="0,0" start="40,40" time="200"/>
+							<effect type="fade" start="100" end="0" time="200" />
+							<effect type="slide" end="0,0" start="40,40" time="200" />
 						</animation>
 					</control>
 				</focusedlayout>
@@ -310,7 +310,7 @@
 			<top>460</top>
 			<control type="fixedlist" id="508">
 				<visible>Container.Content(Movies) | Container.Content(TVShows) | Container.Content(Sets)</visible>
-				<hitrect x="0" y="-10" w="1280" h="190"/>
+				<hitrect x="0" y="-10" w="1280" h="190" />
 				<left>-20</left>
 				<top>0</top>
 				<width>1320</width>
@@ -392,12 +392,12 @@
 						<aspectratio>keep</aspectratio>
 						<texture>$INFO[ListItem.Overlay]</texture>
 						<animation type="focus">
-							<effect type="fade" start="0" end="100" time="200"/>
-							<effect type="slide" start="0,0" end="10,5" time="200"/>
+							<effect type="fade" start="0" end="100" time="200" />
+							<effect type="slide" start="0,0" end="10,5" time="200" />
 						</animation>
 						<animation type="unfocus">
-							<effect type="fade" start="100" end="0" time="200"/>
-							<effect type="slide" end="0,0" start="10,5" time="200"/>
+							<effect type="fade" start="100" end="0" time="200" />
+							<effect type="slide" end="0,0" start="10,5" time="200" />
 						</animation>
 					</control>
 				</focusedlayout>

--- a/addons/skin.confluence/720p/ViewsVideoLibrary.xml
+++ b/addons/skin.confluence/720p/ViewsVideoLibrary.xml
@@ -50,8 +50,8 @@
 						<bordertexture border="8">ThumbBorder.png</bordertexture>
 						<bordersize>8</bordersize>
 						<texture background="true">$VAR[PosterThumb]</texture>
-						<animation reversible="false" effect="zoom" start="-2,36,222,318" end="-28,0,284,390" time="200">focus</animation>
-						<animation reversible="false" effect="zoom" end="-2,36,222,318" start="-28,0,284,390" time="200">unfocus</animation>
+						<animation reversible="false" effect="zoom" start="-2,36,222,318" end="-28,0,284,390" time="150">focus</animation>
+						<animation reversible="false" effect="zoom" end="-2,36,222,318" start="-28,0,284,390" time="150">unfocus</animation>
 					</control>
 					<control type="image">
 						<left>6</left>
@@ -60,8 +60,8 @@
 						<height>180</height>
 						<aspectratio>stretch</aspectratio>
 						<texture>GlassOverlay.png</texture>
-						<animation reversible="false" effect="zoom" start="6,44,170,180" end="-24,4,240,250" time="200">focus</animation>
-						<animation reversible="false" effect="zoom" end="6,44,170,180" start="-24,4,240,250" time="200">unfocus</animation>
+						<animation reversible="false" effect="zoom" start="6,44,170,180" end="-24,4,240,250" time="150">focus</animation>
+						<animation reversible="false" effect="zoom" end="6,44,170,180" start="-24,4,240,250" time="150">unfocus</animation>
 					</control>
 					<control type="image">
 						<left>185</left>
@@ -71,12 +71,12 @@
 						<aspectratio>keep</aspectratio>
 						<texture>$INFO[ListItem.Overlay]</texture>
 						<animation type="focus">
-							<effect type="fade" start="0" end="100" time="200" />
-							<effect type="slide" start="0,0" end="40,40" time="200" />
+							<effect type="fade" start="0" end="100" time="150" />
+							<effect type="slide" start="0,0" end="40,40" time="150" />
 						</animation>
 						<animation type="unfocus">
-							<effect type="fade" start="100" end="0" time="200" />
-							<effect type="slide" end="0,0" start="40,40" time="200" />
+							<effect type="fade" start="100" end="0" time="150" />
+							<effect type="slide" end="0,0" start="40,40" time="150" />
 						</animation>
 					</control>
 				</focusedlayout>
@@ -300,7 +300,7 @@
 				<align>center</align>
 				<aligny>center</aligny>
 				<label>$INFO[ListItem.Label]</label>
-				<animation effect="slide" start="0,0" end="0,25" time="200" condition="!Control.HasFocus(508)">conditional</animation>
+				<animation effect="slide" start="0,0" end="0,25" time="150" condition="!Control.HasFocus(508)">conditional</animation>
 			</control>
 		</control>
 		<control type="group">
@@ -370,8 +370,8 @@
 						<bordersize>8</bordersize>
 						<fadetime>200</fadetime>
 						<texture background="true">$VAR[PosterThumb]</texture>
-						<animation reversible="false" effect="zoom" start="-2,16,128,168" end="-12,-10,148,198" time="200">focus</animation>
-						<animation reversible="false" effect="zoom" end="-2,16,128,168" start="-12,-10,148,198" time="200">unfocus</animation>
+						<animation reversible="false" effect="zoom" start="-2,16,128,168" end="-12,-10,148,198" time="150">focus</animation>
+						<animation reversible="false" effect="zoom" end="-2,16,128,168" start="-12,-10,148,198" time="150">unfocus</animation>
 					</control>
 					<control type="image">
 						<left>2</left>
@@ -392,12 +392,12 @@
 						<aspectratio>keep</aspectratio>
 						<texture>$INFO[ListItem.Overlay]</texture>
 						<animation type="focus">
-							<effect type="fade" start="0" end="100" time="200" />
-							<effect type="slide" start="0,0" end="10,5" time="200" />
+							<effect type="fade" start="0" end="100" time="150" />
+							<effect type="slide" start="0,0" end="10,5" time="150" />
 						</animation>
 						<animation type="unfocus">
-							<effect type="fade" start="100" end="0" time="200" />
-							<effect type="slide" end="0,0" start="10,5" time="200" />
+							<effect type="fade" start="100" end="0" time="150" />
+							<effect type="slide" end="0,0" start="10,5" time="150" />
 						</animation>
 					</control>
 				</focusedlayout>

--- a/addons/skin.confluence/720p/includes.xml
+++ b/addons/skin.confluence/720p/includes.xml
@@ -1,20 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <includes>
-	<include file="defaults.xml"/>
-	<include file="ViewsVideoLibrary.xml"/>
-	<include file="ViewsMusicLibrary.xml"/>
-	<include file="ViewsFileMode.xml"/>
-	<include file="ViewsPictures.xml"/>
-	<include file="ViewsAddonBrowser.xml"/>
-	<include file="ViewsLiveTV.xml"/>
-	<include file="ViewsPVRGuide.xml"/>
-	<include file="ViewsWeather.xml"/>
-	<include file="IncludesCodecFlagging.xml"/>
-	<include file="IncludesHomeRecentlyAdded.xml"/>
-	<include file="IncludesHomeMenuItems.xml"/>
-	<include file="IncludesPVR.xml"/>
-	<include file="IncludesBackgroundBuilding.xml"/>
-
+	<include file="defaults.xml" />
+	<include file="ViewsVideoLibrary.xml" />
+	<include file="ViewsMusicLibrary.xml" />
+	<include file="ViewsFileMode.xml" />
+	<include file="ViewsPictures.xml" />
+	<include file="ViewsAddonBrowser.xml" />
+	<include file="ViewsLiveTV.xml" />
+	<include file="ViewsPVRGuide.xml" />
+	<include file="ViewsWeather.xml" />
+	<include file="IncludesCodecFlagging.xml" />
+	<include file="IncludesHomeRecentlyAdded.xml" />
+	<include file="IncludesHomeMenuItems.xml" />
+	<include file="IncludesPVR.xml" />
+	<include file="IncludesBackgroundBuilding.xml" />
 	<constant name="FanartCrossfadeTime">500</constant>
 	<constant name="IconCrossfadeTime">400</constant>
 	<variable name="ResolutionOverlayVar">
@@ -69,7 +68,6 @@
 		<value condition="Player.Forwarding">$LOCALIZE[31044]</value>
 		<value condition="Player.Rewinding">$LOCALIZE[31045]</value>
 	</variable>
-
 	<include name="BehindDialogFadeOut">
 		<control type="image">
 			<left>0</left>
@@ -981,14 +979,14 @@
 	<include name="HomeAddonsCommonLayout">
 		<include>Window_OpenClose_Animation</include>
 		<animation type="Visible">
-			<effect type="slide" start="0,30" end="0,0" delay="200" easing="out" tween="quadratic" time="200"/>
-			<effect type="fade" start="0" end="100" delay="200" time="200"/>
+			<effect type="slide" start="0,30" end="0,0" delay="200" easing="out" tween="quadratic" time="200" />
+			<effect type="fade" start="0" end="100" delay="200" time="200" />
 		</animation>
 		<animation type="Hidden">
-			<effect type="zoom" start="100" end="70" center="auto" easing="in" tween="quadratic" time="300"/>
-			<effect type="fade" start="100" end="0" time="300"/>
+			<effect type="zoom" start="100" end="70" center="auto" easing="in" tween="quadratic" time="300" />
+			<effect type="fade" start="100" end="0" time="300" />
 		</animation>
-		<hitrect x="0" y="530" w="1280" h="120"/>
+		<hitrect x="0" y="530" w="1280" h="120" />
 		<left>0</left>
 		<top>190r</top>
 		<width>1280</width>

--- a/addons/skin.confluence/720p/includes.xml
+++ b/addons/skin.confluence/720p/includes.xml
@@ -75,8 +75,8 @@
 			<width>1280</width>
 			<height>720</height>
 			<texture>black-back.png</texture>
-			<animation effect="fade" time="400">Visible</animation>
-			<animation effect="fade" time="200">Hidden</animation>
+			<animation effect="fade" time="300">Visible</animation>
+			<animation effect="fade" time="150">Hidden</animation>
 			<visible>Window.IsActive(MovieInformation) | Window.IsActive(MusicInformation) | Window.IsActive(SongInformation) | Window.IsActive(FileBrowser) | Window.IsActive(TextViewer) | Window.IsActive(AddonSettings) | Window.IsActive(ContentSettings) | Window.IsActive(SelectDialog) | Window.IsActive(FileStackingDialog) | Window.IsActive(MediaSource) | Window.IsActive(PictureInfo) | Window.IsActive(PlayerControls) | Window.IsActive(VirtualKeyboard) | Window.IsActive(NumericInput) | Window.IsActive(ProfileSettings) | Window.IsActive(LockSettings) | Window.IsActive(SmartPlaylistEditor) | Window.IsActive(SmartPlaylistRule) | Window.IsActive(script-RSS_Editor-rssEditor.xml) | Window.IsActive(script-RSS_Editor-setEditor.xml) | Window.IsActive(AddonInformation) | Window.IsActive(Peripherals) | Window.IsActive(PeripheralSettings) | Window.IsActive(script-cu-lrclyrics-main.xml) | Window.IsActive(MediaFilter)</visible>
 		</control>
 	</include>
@@ -137,8 +137,8 @@
 		<ondown>9002</ondown>
 		<itemgap>0</itemgap>
 		<orientation>Horizontal</orientation>
-		<animation effect="slide" start="0,-40" end="0,0" delay="200" time="200" tween="quadratic" easing="out">Visible</animation>
-		<animation effect="slide" start="0,0" end="0,-40" time="200" tween="quadratic" easing="out">Hidden</animation>
+		<animation effect="slide" start="0,-40" end="0,0" delay="150" time="150" tween="quadratic" easing="out">Visible</animation>
+		<animation effect="slide" start="0,0" end="0,-40" time="150" tween="quadratic" easing="out">Hidden</animation>
 	</include>
 	<include name="ButtonInfoDialogsCommonValues">
 		<height>40</height>
@@ -152,10 +152,10 @@
 		<pulseonselect>false</pulseonselect>
 	</include>
 	<include name="SideBladeLeft">
-		<animation effect="slide" start="0,0" end="250,0" time="400" tween="quadratic" easing="out" condition="ControlGroup(9000).HasFocus | Control.HasFocus(9001) | Control.HasFocus(8999)">Conditional</animation>
-		<animation effect="slide" start="0,0" end="-300,0" time="400" tween="quadratic" easing="out" condition="ControlGroup(9000).HasFocus | Control.HasFocus(9001)">WindowClose</animation>
-		<animation effect="slide" start="0,0" end="-50,0" time="300" tween="quadratic" easing="out" condition="![ControlGroup(9000).HasFocus | Control.HasFocus(9001)]">WindowClose</animation>
-		<animation effect="slide" start="-50,0" end="0,0" time="300" tween="quadratic" easing="out">WindowOpen</animation>
+		<animation effect="slide" start="0,0" end="250,0" time="300" tween="quadratic" easing="out" condition="ControlGroup(9000).HasFocus | Control.HasFocus(9001) | Control.HasFocus(8999)">Conditional</animation>
+		<animation effect="slide" start="0,0" end="-300,0" time="300" tween="quadratic" easing="out" condition="ControlGroup(9000).HasFocus | Control.HasFocus(9001)">WindowClose</animation>
+		<animation effect="slide" start="0,0" end="-50,0" time="225" tween="quadratic" easing="out" condition="![ControlGroup(9000).HasFocus | Control.HasFocus(9001)]">WindowClose</animation>
+		<animation effect="slide" start="-50,0" end="0,0" time="225" tween="quadratic" easing="out">WindowOpen</animation>
 		<control type="button" id="8999">
 			<description>Fake button for mouse control</description>
 			<left>0</left>
@@ -198,8 +198,8 @@
 		<control type="group">
 			<left>120r</left>
 			<top>55r</top>
-			<animation effect="fade" time="250" condition="Window.Previous(Home)">WindowOpen</animation>
-			<animation effect="fade" time="250" condition="Window.Next(Home)">WindowClose</animation>
+			<animation effect="fade" time="200" condition="Window.Previous(Home)">WindowOpen</animation>
+			<animation effect="fade" time="200" condition="Window.Next(Home)">WindowClose</animation>
 			<visible>system.getbool(input.enablemouse)</visible>
 			<control type="button">
 				<description>Back push button</description>
@@ -257,8 +257,8 @@
 		<control type="group">
 			<visible>Player.HasMedia + !SubString(Window(videolibrary).Property(TvTunesIsAlive),TRUE)</visible>
 			<include>VisibleFadeEffect</include>
-			<animation effect="fade" time="250" condition="Window.Previous(Home)">WindowOpen</animation>
-			<animation effect="fade" time="250" condition="Window.Next(Home)">WindowClose</animation>
+			<animation effect="fade" time="200" condition="Window.Previous(Home)">WindowOpen</animation>
+			<animation effect="fade" time="200" condition="Window.Next(Home)">WindowClose</animation>
 			<control type="button">
 				<description>push button</description>
 				<left>30</left>
@@ -697,7 +697,7 @@
 				<onback>50</onback>
 				<onclick>PlayerControl(Play)</onclick>
 				<enable>Player.PauseEnabled</enable>
-				<animation effect="fade" start="100" end="30" time="100" condition="!Player.PauseEnabled">Conditional</animation>
+				<animation effect="fade" start="100" end="30" time="75" condition="!Player.PauseEnabled">Conditional</animation>
 			</control>
 			<control type="button" id="605">
 				<left>180</left>
@@ -713,7 +713,7 @@
 				<ondown>611</ondown>
 				<onclick>PlayerControl(record)</onclick>
 				<enable>Player.CanRecord</enable>
-				<animation effect="fade" start="100" end="30" time="100" condition="!Player.CanRecord">Conditional</animation>
+				<animation effect="fade" start="100" end="30" time="75" condition="!Player.CanRecord">Conditional</animation>
 			</control>
 		</control>
 		<control type="group" id="9005">
@@ -936,8 +936,8 @@
 	<include name="ScrollOffsetLabel">
 		<control type="group">
 			<visible>Container.Scrolling + [StringCompare(Container.SortMethod,$LOCALIZE[551]) | StringCompare(Container.SortMethod,$LOCALIZE[561]) | StringCompare(Container.SortMethod,$LOCALIZE[558]) | StringCompare(Container.SortMethod,$LOCALIZE[557]) | StringCompare(Container.SortMethod,$LOCALIZE[556])]</visible>
-			<animation effect="slide" start="0,0" end="0,-60" time="100">Visible</animation>
-			<animation effect="slide" start="0,-60" end="0,0" delay="400" time="100">Hidden</animation>
+			<animation effect="slide" start="0,0" end="0,-60" time="75">Visible</animation>
+			<animation effect="slide" start="0,-60" end="0,0" delay="300" time="75">Hidden</animation>
 			<left>300r</left>
 			<top>720</top>
 			<control type="image">
@@ -973,18 +973,18 @@
 			<textcolor>white</textcolor>
 			<shadowcolor>black</shadowcolor>
 			<label>$INFO[System.Time]</label>
-			<animation effect="slide" start="0,0" end="-40,0" time="100" condition="Window.IsVisible(Mutebug)">conditional</animation>
+			<animation effect="slide" start="0,0" end="-40,0" time="75" condition="Window.IsVisible(Mutebug)">conditional</animation>
 		</control>
 	</include>
 	<include name="HomeAddonsCommonLayout">
 		<include>Window_OpenClose_Animation</include>
 		<animation type="Visible">
-			<effect type="slide" start="0,30" end="0,0" delay="200" easing="out" tween="quadratic" time="200" />
-			<effect type="fade" start="0" end="100" delay="200" time="200" />
+			<effect type="slide" start="0,30" end="0,0" delay="150" easing="out" tween="quadratic" time="150" />
+			<effect type="fade" start="0" end="100" delay="150" time="150" />
 		</animation>
 		<animation type="Hidden">
-			<effect type="zoom" start="100" end="70" center="auto" easing="in" tween="quadratic" time="300" />
-			<effect type="fade" start="100" end="0" time="300" />
+			<effect type="zoom" start="100" end="70" center="auto" easing="in" tween="quadratic" time="225" />
+			<effect type="fade" start="100" end="0" time="225" />
 		</animation>
 		<hitrect x="0" y="530" w="1280" h="120" />
 		<left>0</left>
@@ -1253,20 +1253,20 @@
 		</focusedlayout>
 	</include>
 	<include name="backgroundfade">
-		<animation effect="fade" time="600">Visible</animation>
-		<animation effect="fade" time="600">Hidden</animation>
+		<animation effect="fade" time="450">Visible</animation>
+		<animation effect="fade" time="450">Hidden</animation>
 	</include>
 	<include name="Window_OpenClose_Animation">
-		<animation effect="fade" time="250">WindowOpen</animation>
-		<animation effect="fade" time="250">WindowClose</animation>
+		<animation effect="fade" time="200">WindowOpen</animation>
+		<animation effect="fade" time="200">WindowClose</animation>
 	</include>
 	<include name="dialogeffect">
-		<animation effect="fade" time="250">WindowOpen</animation>
-		<animation effect="fade" time="250">WindowClose</animation>
+		<animation effect="fade" time="200">WindowOpen</animation>
+		<animation effect="fade" time="200">WindowClose</animation>
 	</include>
 	<include name="VisibleFadeEffect">
-		<animation effect="fade" time="300">Visible</animation>
-		<animation effect="fade" time="300">Hidden</animation>
+		<animation effect="fade" time="225">Visible</animation>
+		<animation effect="fade" time="225">Hidden</animation>
 	</include>
 	<include name="KeyboardButton">
 		<width>50</width>

--- a/addons/skin.confluence/720p/script-NextAired-TVGuide.xml
+++ b/addons/skin.confluence/720p/script-NextAired-TVGuide.xml
@@ -134,7 +134,7 @@
 			</control>
 		</control>
 		<control type="grouplist" id="2000">
-			<include>Window_OpenClose_Animation</include>		
+			<include>Window_OpenClose_Animation</include>
 			<left>40</left>
 			<top>60</top>
 			<width>1200</width>
@@ -445,7 +445,7 @@
 			</control>
 		</control>
 		<control type="group">
-			<include>Window_OpenClose_Animation</include>		
+			<include>Window_OpenClose_Animation</include>
 			<control type="image">
 				<description>left Arrow</description>
 				<left>10</left>

--- a/addons/skin.confluence/720p/script-NextAired-TVGuide.xml
+++ b/addons/skin.confluence/720p/script-NextAired-TVGuide.xml
@@ -21,8 +21,8 @@
 				<texture background="true">$INFO[Container(200).ListItem.Property(Fanart)]</texture>
 				<visible>Control.HasFocus(200)</visible>
 				<fadetime>600</fadetime>
-				<animation effect="fade" time="600">Visible</animation>
-				<animation effect="fade" time="600">Hidden</animation>
+				<animation effect="fade" time="450">Visible</animation>
+				<animation effect="fade" time="450">Hidden</animation>
 			</control>
 			<control type="image">
 				<left>0</left>
@@ -33,8 +33,8 @@
 				<texture background="true">$INFO[Container(201).ListItem.Property(Fanart)]</texture>
 				<visible>Control.HasFocus(201)</visible>
 				<fadetime>600</fadetime>
-				<animation effect="fade" time="600">Visible</animation>
-				<animation effect="fade" time="600">Hidden</animation>
+				<animation effect="fade" time="450">Visible</animation>
+				<animation effect="fade" time="450">Hidden</animation>
 			</control>
 			<control type="image">
 				<left>0</left>
@@ -45,8 +45,8 @@
 				<texture background="true">$INFO[Container(202).ListItem.Property(Fanart)]</texture>
 				<visible>Control.HasFocus(202)</visible>
 				<fadetime>600</fadetime>
-				<animation effect="fade" time="600">Visible</animation>
-				<animation effect="fade" time="600">Hidden</animation>
+				<animation effect="fade" time="450">Visible</animation>
+				<animation effect="fade" time="450">Hidden</animation>
 			</control>
 			<control type="image">
 				<left>0</left>
@@ -57,8 +57,8 @@
 				<texture background="true">$INFO[Container(203).ListItem.Property(Fanart)]</texture>
 				<visible>Control.HasFocus(203)</visible>
 				<fadetime>600</fadetime>
-				<animation effect="fade" time="600">Visible</animation>
-				<animation effect="fade" time="600">Hidden</animation>
+				<animation effect="fade" time="450">Visible</animation>
+				<animation effect="fade" time="450">Hidden</animation>
 			</control>
 			<control type="image">
 				<left>0</left>
@@ -69,8 +69,8 @@
 				<texture background="true">$INFO[Container(204).ListItem.Property(Fanart)]</texture>
 				<visible>Control.HasFocus(204)</visible>
 				<fadetime>600</fadetime>
-				<animation effect="fade" time="600">Visible</animation>
-				<animation effect="fade" time="600">Hidden</animation>
+				<animation effect="fade" time="450">Visible</animation>
+				<animation effect="fade" time="450">Hidden</animation>
 			</control>
 			<control type="image">
 				<left>0</left>
@@ -81,8 +81,8 @@
 				<texture background="true">$INFO[Container(205).ListItem.Property(Fanart)]</texture>
 				<visible>Control.HasFocus(205)</visible>
 				<fadetime>600</fadetime>
-				<animation effect="fade" time="600">Visible</animation>
-				<animation effect="fade" time="600">Hidden</animation>
+				<animation effect="fade" time="450">Visible</animation>
+				<animation effect="fade" time="450">Hidden</animation>
 			</control>
 			<control type="image">
 				<left>0</left>
@@ -93,8 +93,8 @@
 				<texture background="true">$INFO[Container(206).ListItem.Property(Fanart)]</texture>
 				<visible>Control.HasFocus(206)</visible>
 				<fadetime>600</fadetime>
-				<animation effect="fade" time="600">Visible</animation>
-				<animation effect="fade" time="600">Hidden</animation>
+				<animation effect="fade" time="450">Visible</animation>
+				<animation effect="fade" time="450">Hidden</animation>
 			</control>
 		</control>
 		<control type="image">
@@ -104,8 +104,8 @@
 			<height>100</height>
 			<texture>floor.png</texture>
 			<aspectratio>stretch</aspectratio>
-			<animation effect="slide" start="0,10" end="0,0" time="200" condition="Window.Previous(Home)">WindowOpen</animation>
-			<animation effect="slide" start="0,0" end="0,10" time="200" condition="Window.Next(Home)">WindowClose</animation>
+			<animation effect="slide" start="0,10" end="0,0" time="150" condition="Window.Previous(Home)">WindowOpen</animation>
+			<animation effect="slide" start="0,0" end="0,10" time="150" condition="Window.Next(Home)">WindowClose</animation>
 		</control>
 		<control type="image">
 			<description>Section header image</description>

--- a/addons/skin.confluence/720p/script-cu-lrclyrics-main.xml
+++ b/addons/skin.confluence/720p/script-cu-lrclyrics-main.xml
@@ -8,9 +8,9 @@
 	</coordinates>
 	<controls>
 		<control type="group">
-			<animation effect="slide" start="600,0" end="0,0" time="400" tween="quadratic" easing="out" condition="!Player.ShowCodec">WindowOpen</animation>
-			<animation effect="slide" start="600,0" end="0,0" time="400" delay="400" tween="quadratic" easing="out" condition="Player.ShowCodec">WindowOpen</animation>
-			<animation effect="slide" start="0,0" end="600,0" time="200" tween="quadratic" easing="out">WindowClose</animation>
+			<animation effect="slide" start="600,0" end="0,0" time="300" tween="quadratic" easing="out" condition="!Player.ShowCodec">WindowOpen</animation>
+			<animation effect="slide" start="600,0" end="0,0" time="300" delay="300" tween="quadratic" easing="out" condition="Player.ShowCodec">WindowOpen</animation>
+			<animation effect="slide" start="0,0" end="600,0" time="150" tween="quadratic" easing="out">WindowClose</animation>
 			<control type="image">
 				<description>media info background image</description>
 				<left>0</left>

--- a/addons/skin.confluence/720p/script-globalsearch-main.xml
+++ b/addons/skin.confluence/720p/script-globalsearch-main.xml
@@ -118,12 +118,12 @@
 				<left>90</left>
 				<top>30</top>
 				<animation type="WindowOpen" reversible="false">
-					<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="300"/>
-					<effect type="fade" start="0" end="100" time="300"/>
+					<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="300" />
+					<effect type="fade" start="0" end="100" time="300" />
 				</animation>
 				<animation type="WindowClose" reversible="false">
-					<effect type="zoom" start="100" end="80" center="640,360" easing="in" tween="back" time="300"/>
-					<effect type="fade" start="100" end="0" time="300"/>
+					<effect type="zoom" start="100" end="80" center="640,360" easing="in" tween="back" time="300" />
+					<effect type="fade" start="100" end="0" time="300" />
 				</animation>
 				<control type="image">
 					<left>5</left>
@@ -378,12 +378,12 @@
 			</control>
 			<control type="group">
 				<animation type="WindowOpen" reversible="false">
-					<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="300"/>
-					<effect type="fade" start="0" end="100" time="300"/>
+					<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="300" />
+					<effect type="fade" start="0" end="100" time="300" />
 				</animation>
 				<animation type="WindowClose" reversible="false">
-					<effect type="zoom" start="100" end="80" center="640,360" easing="in" tween="back" time="300"/>
-					<effect type="fade" start="100" end="0" time="300"/>
+					<effect type="zoom" start="100" end="80" center="640,360" easing="in" tween="back" time="300" />
+					<effect type="fade" start="100" end="0" time="300" />
 				</animation>
 				<left>380</left>
 				<top>90</top>

--- a/addons/skin.confluence/720p/script-globalsearch-main.xml
+++ b/addons/skin.confluence/720p/script-globalsearch-main.xml
@@ -111,19 +111,19 @@
 				<width>1280</width>
 				<height>720</height>
 				<texture>black-back.png</texture>
-				<animation effect="fade" time="400">WindowOpen</animation>
-				<animation effect="fade" time="200">WindowClose</animation>
+				<animation effect="fade" time="300">WindowOpen</animation>
+				<animation effect="fade" time="150">WindowClose</animation>
 			</control>
 			<control type="group">
 				<left>90</left>
 				<top>30</top>
 				<animation type="WindowOpen" reversible="false">
-					<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="300" />
-					<effect type="fade" start="0" end="100" time="300" />
+					<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="225" />
+					<effect type="fade" start="0" end="100" time="225" />
 				</animation>
 				<animation type="WindowClose" reversible="false">
-					<effect type="zoom" start="100" end="80" center="640,360" easing="in" tween="back" time="300" />
-					<effect type="fade" start="100" end="0" time="300" />
+					<effect type="zoom" start="100" end="80" center="640,360" easing="in" tween="back" time="225" />
+					<effect type="fade" start="100" end="0" time="225" />
 				</animation>
 				<control type="image">
 					<left>5</left>
@@ -214,7 +214,7 @@
 							<width>260</width>
 							<height>61</height>
 							<texture border="5">MenuItemFO.png</texture>
-							<animation effect="fade" start="100" end="50" time="100" condition="!Control.HasFocus(9000)">Conditional</animation>
+							<animation effect="fade" start="100" end="50" time="75" condition="!Control.HasFocus(9000)">Conditional</animation>
 						</control>
 						<control type="label">
 							<left>10</left>
@@ -378,12 +378,12 @@
 			</control>
 			<control type="group">
 				<animation type="WindowOpen" reversible="false">
-					<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="300" />
-					<effect type="fade" start="0" end="100" time="300" />
+					<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="225" />
+					<effect type="fade" start="0" end="100" time="225" />
 				</animation>
 				<animation type="WindowClose" reversible="false">
-					<effect type="zoom" start="100" end="80" center="640,360" easing="in" tween="back" time="300" />
-					<effect type="fade" start="100" end="0" time="300" />
+					<effect type="zoom" start="100" end="80" center="640,360" easing="in" tween="back" time="225" />
+					<effect type="fade" start="100" end="0" time="225" />
 				</animation>
 				<left>380</left>
 				<top>90</top>

--- a/addons/skin.confluence/addon.xml
+++ b/addons/skin.confluence/addon.xml
@@ -10,7 +10,7 @@
   <extension
     point="xbmc.gui.skin"
     debugging="false"
-    effectslowdown="0.75">
+    effectslowdown="1.0">
     <res width="1280" height="720" aspect="16:9" default="true" folder="720p" />
   </extension>
   <extension point="xbmc.addon.metadata">


### PR DESCRIPTION
This PR aims to get rid of the effectmultiplier used by Confluence. That one is a real pain and we should get rid of it sooner than later because it also applies to python scripts which provide their own XMLs for example.  Also, a lot of other skinners base their work on confluence and a lot of them never notice that they don´t work with the "real" time values and never change it back. In fact we should "disallow" using any other value than 1.0 for repo skins (can still get used for debug purposes of course).
Atm I am scaling:
- attributes "time", "delay", "repeat" for elements "animation", "effect" and "scrolltime"
- "autoscroll" element

I´m using my XML tool to do this, so adding other values is easy. Please let me know if I got everything. :)
Downside is that we do not have round values anymore. If wanted then I could round it to 100ms steps, 10ms steps whatever. Up to you guys.
@ronie, @BigNoid for review, please.
