### PR TITLE
[gui] fix for textbox vertical centering

### DIFF
--- a/xbmc/guilib/GUITextBox.cpp
+++ b/xbmc/guilib/GUITextBox.cpp
@@ -24,6 +24,8 @@
 #include "utils/MathUtils.h"
 #include "utils/StringUtils.h"
 
+#include <algorithm>
+
 using namespace std;
 
 CGUITextBox::CGUITextBox(int parentID, int controlID, float posX, float posY, float width, float height,
@@ -212,10 +214,25 @@ void CGUITextBox::Render()
     float posX = m_posX;
     float posY = m_posY + offset * m_itemHeight - m_scrollOffset;
 
+    uint32_t alignment = m_label.align;
+
+    if (alignment & XBFONT_CENTER_Y)
+    {
+      if (m_font)
+      {
+        float textHeight = m_font->GetTextHeight(std::min((unsigned int)m_lines.size(), m_itemsPerPage));
+
+        if (textHeight <= m_renderHeight)
+          posY += (m_renderHeight - textHeight) * 0.5f;
+      }
+
+      alignment &= ~XBFONT_CENTER_Y;
+    }
+
     // alignment correction
-    if (m_label.align & XBFONT_CENTER_X)
+    if (alignment & XBFONT_CENTER_X)
       posX += m_width * 0.5f;
-    if (m_label.align & XBFONT_RIGHT)
+    if (alignment & XBFONT_RIGHT)
       posX += m_width;
 
     if (m_font)
@@ -224,7 +241,7 @@ void CGUITextBox::Render()
       int current = offset;
       while (posY < m_posY + m_renderHeight && current < (int)m_lines.size())
       {
-        uint32_t align = m_label.align;
+        uint32_t align = alignment;
         if (m_lines[current].m_text.size() && m_lines[current].m_carriageReturn)
           align &= ~XBFONT_JUSTIFIED; // last line of a paragraph shouldn't be justified
         m_font->DrawText(posX, posY, m_colors, m_label.shadowColor, m_lines[current].m_text, align, m_width);


### PR DESCRIPTION
This PR fix missing textbox vertical centering described on forum (http://forum.kodi.tv/showthread.php?tid=220150). Current code completely ignore XBFONT_CENTER_Y and so it's passed to m_font->DrawText(...) which causes that first line upper half is cut (it's vertically centered around 0).
My code touches only situations when vertical centering is used so it shouldn't cause any compatibility problems with existing skins. I assume no one really used vertical centering till now because how bad it works.
