### PR TITLE
Fixed issue 15831 by checking for the password after the choice have been made. Also included the delete function again.

### DIFF
--- a/xbmc/windows/GUIWindowLoginScreen.cpp
+++ b/xbmc/windows/GUIWindowLoginScreen.cpp
@@ -228,15 +228,14 @@ bool CGUIWindowLoginScreen::OnPopupMenu(int iItem)
 
   CContextButtons choices;
   choices.Add(1, 20067);
-/*  if (m_viewControl.GetSelectedItem() != 0) // no deleting the default profile
-    choices.Add(2, 117); */
+
   if (iItem == 0 && g_passwordManager.iMasterLockRetriesLeft == 0)
-    choices.Add(3, 12334);
+    choices.Add(2, 12334);
 
   CContextMenuManager::Get().AddVisibleItems(pItem, choices);
 
   int choice = CGUIDialogContextMenu::ShowAndGetChoice(choices);
-  if (choice == 3)
+  if (choice == 2)
   {
     if (g_passwordManager.CheckLock(CProfilesManager::Get().GetMasterProfile().getLockMode(),CProfilesManager::Get().GetMasterProfile().getLockCode(),20075))
       g_passwordManager.iMasterLockRetriesLeft = CSettings::Get().GetInt("masterlock.maxretries");
@@ -245,21 +244,11 @@ bool CGUIWindowLoginScreen::OnPopupMenu(int iItem)
 
     return true;
   }
-  
-  if (!g_passwordManager.IsMasterLockUnlocked(true))
-    return false;
 
-  if (choice == 1)
+  // Edit the profile after checking if the correct master lock password was given.
+  if (choice == 1 && g_passwordManager.IsMasterLockUnlocked(true))
     CGUIDialogProfileSettings::ShowForProfile(m_viewControl.GetSelectedItem());
-  if (choice == 2)
-  {
-    int iDelete = m_viewControl.GetSelectedItem();
-    m_viewControl.Clear();
-    if (iDelete >= 0)
-      CProfilesManager::Get().DeleteProfile((size_t)iDelete);
-    Update();
-    m_viewControl.SetSelectedItem(0);
-  }
+  
   //NOTE: this can potentially (de)select the wrong item if the filelisting has changed because of an action above.
   if (iItem < (int)CProfilesManager::Get().GetNumberOfProfiles())
     m_vecItems->Get(iItem)->Select(bSelect);


### PR DESCRIPTION
fixes [issue 15831](http://trac.kodi.tv/ticket/15831).

It fixes that when a user right button clicks on a non-master profile and then click [x] it will not ask for the master lock password. 
Also uncommented the delete button again and made sure that when it was clicked the master lock password would be asked.

See [link](https://www.youtube.com/watch?v=NaMEow80dpg) for the bug. 
