### PR TITLE
[pvr] fixed: slow channels import

### DIFF
--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -217,7 +217,7 @@ bool CPVRChannel::Persist()
 
   if (CPVRDatabase *database = GetPVRDatabase())
   {
-    bool bReturn = database->Persist(*this);
+    bool bReturn = database->Persist(*this) && database->CommitInsertQueries();
     CSingleLock lock(m_critSection);
     m_bChanged = !bReturn;
     return bReturn;


### PR DESCRIPTION
initial channel import takes ages because of how it's persisted, depending on how many channels there are. this speeds it up (greatly)
@Jalle19 this isn't the same as your https://github.com/xbmc/xbmc/pull/6246 , that one is still relevant (half ;-))
