### PR TITLE
[ffmpeg] bump to 2.6

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -1724,12 +1724,12 @@ else
 fi
 
 # FFmpeg
-FFMPEG_LIBNAMES="libavcodec >= 56.1.100
-                 libavfilter >= 5.1.100
-                 libavformat >= 56.4.101
-                 libavutil >= 54.7.100
-                 libpostproc >= 53.0.100
-                 libswscale >= 3.0.100
+FFMPEG_LIBNAMES="libavcodec >= 56.26.100
+                 libavfilter >= 5.11.102
+                 libavformat >= 56.25.101
+                 libavutil >= 54.20.100
+                 libpostproc >= 53.3.100
+                 libswscale >= 3.1.101
                  libswresample >= 1.1.100"
 
 ffmpeg_build="${abs_top_srcdir}/tools/depends/target/ffmpeg"

--- a/tools/depends/target/ffmpeg/FFMPEG-VERSION
+++ b/tools/depends/target/ffmpeg/FFMPEG-VERSION
@@ -1,5 +1,5 @@
 LIBNAME=ffmpeg
 BASE_URL=https://github.com/xbmc/FFmpeg/archive
-VERSION=2.5.4-Isengard-alpha
+VERSION=2.6.0-Isengard-alpha
 ARCHIVE=$(LIBNAME)-$(VERSION).tar.gz
 

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -542,7 +542,7 @@ void CDVDDemuxFFmpeg::Flush()
 {
   // naughty usage of an internal ffmpeg function
   if (m_pFormatContext)
-    av_read_frame_flush(m_pFormatContext);
+    avformat_flush(m_pFormatContext);
 
   m_currentPts = DVD_NOPTS_VALUE;
 


### PR DESCRIPTION
Noteworthy:
- drop two of our ffmpeg patches
- DXVA support for HEVC

see ffmpeg change log https://github.com/xbmc/FFmpeg/blob/release/2.6-xbmc/Changelog
