### PR TITLE
[uclibc] Fix compilation error in xbmc/cores/DllLoader/exports/emu_msvcr...

### DIFF
--- a/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
+++ b/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
@@ -20,6 +20,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <stdarg.h>
 #include <math.h>
 #ifndef TARGET_POSIX
 #include <io.h>


### PR DESCRIPTION
...t.cpp

Fixes compile error:

CPP     xbmc/cores/DllLoader/exports/emu_msvcrt.o
In file included from emu_msvcrt.cpp:63:0:
emu_msvcrt.h:84:38: error: 'va_list' has not been declared
   int dllvprintf(const char _format, va_list va);
                                      ^
emu_msvcrt.h:129:54: error: 'va_list' has not been declared
   int dll_vfprintf(FILE *stream, const char *format, va_list va);
                                                      ^
emu_msvcrt.cpp: In function 'int dllvprintf(const char_, va_list)':
emu_msvcrt.cpp:1547:48: error: declaration of C function 'int dllvprintf(const char_, va_list)' conflicts with
   int dllvprintf(const char *format, va_list va)
                                                ^
In file included from emu_msvcrt.cpp:63:0:
emu_msvcrt.h:84:7: error: previous declaration 'int dllvprintf(const char_, int)' here
   int dllvprintf(const char _format, va_list va);
       ^
emu_msvcrt.cpp: In function 'int dll_vfprintf(FILE_, const char_, va_list)':
emu_msvcrt.cpp:1554:64: error: declaration of C function 'int dll_vfprintf(FILE_, const char_, va_list)' conflicts with
   int dll_vfprintf(FILE *stream, const char *format, va_list va)
                                                                ^
In file included from emu_msvcrt.cpp:63:0:
emu_msvcrt.h:129:7: error: previous declaration 'int dll_vfprintf(FILE_, const char_, int)' here
   int dll_vfprintf(FILE *stream, const char *format, va_list va);
       ^
make[1]: *_\* [emu_msvcrt.o] Error 1
