### PR TITLE
fix uninit warnings in coverity

### DIFF
--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -834,6 +834,7 @@
     <ClCompile Include="..\..\xbmc\TextureDatabase.cpp" />
     <ClCompile Include="..\..\xbmc\DatabaseManager.cpp" />
     <ClInclude Include="..\..\xbmc\addons\AddonCallbacksCodec.h" />
+    <ClInclude Include="..\..\xbmc\addons\AudioDecoder.h" />
     <ClInclude Include="..\..\xbmc\addons\ContextItemAddon.h" />
     <ClInclude Include="..\..\xbmc\addons\Webinterface.h" />
     <ClInclude Include="..\..\xbmc\addons\LanguageResource.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -3134,7 +3134,7 @@
     </ClCompile>
     <ClCompile Include="..\..\xbmc\video\jobs\VideoLibraryProgressJob.cpp">
       <Filter>video\jobs</Filter>
-	</ClCompile>
+    </ClCompile>
     <ClCompile Include="..\..\xbmc\input\Key.cpp">
       <Filter>input</Filter>
     </ClCompile>
@@ -6142,7 +6142,7 @@
     </ClInclude>
     <ClInclude Include="..\..\xbmc\video\jobs\VideoLibraryProgressJob.h">
       <Filter>video\jobs</Filter>
-	</ClInclude>
+    </ClInclude>
     <ClInclude Include="..\..\xbmc\input\Key.h">
       <Filter>input</Filter>
     </ClInclude>
@@ -6187,6 +6187,9 @@
     </ClInclude>
     <ClInclude Include="..\..\xbmc\utils\Locale.h">
       <Filter>utils</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\addons\AudioDecoder.h">
+      <Filter>addons</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/xbmc/addons/AddonCallbacksGUI.cpp
+++ b/xbmc/addons/AddonCallbacksGUI.cpp
@@ -1915,12 +1915,14 @@ CGUIAddonWindow::CGUIAddonWindow(int id, const std::string& strXML, CAddon* addo
  , m_bIsDialog(false)
  , m_actionEvent(true)
  , m_addon(addon)
+ , m_clientHandle{nullptr}
+ , CBOnAction{nullptr}
+ , CBOnClick{nullptr}
+ , CBOnFocus{nullptr}
+ , CBOnInit{nullptr}
+
 {
   m_loadType = LOAD_ON_GUI_INIT;
-  CBOnInit        = NULL;
-  CBOnFocus       = NULL;
-  CBOnClick       = NULL;
-  CBOnAction      = NULL;
 }
 
 CGUIAddonWindow::~CGUIAddonWindow(void)

--- a/xbmc/addons/AddonCallbacksGUI.cpp
+++ b/xbmc/addons/AddonCallbacksGUI.cpp
@@ -2222,10 +2222,14 @@ void CGUIAddonWindowDialog::Show_Internal(bool show /* = true */)
 }
 
 CGUIAddonRenderingControl::CGUIAddonRenderingControl(CGUIRenderingControl *pControl)
-{
-  m_pControl = pControl;
-  m_refCount = 1;
-}
+  : m_pControl{pControl},
+  m_clientHandle{nullptr},
+  m_refCount{1},
+  CBCreate{nullptr},
+  CBDirty{nullptr},
+  CBRender{nullptr},
+  CBStop{nullptr}
+{ }
 
 bool CGUIAddonRenderingControl::Create(int x, int y, int w, int h, void *device)
 {

--- a/xbmc/addons/AddonDatabase.h
+++ b/xbmc/addons/AddonDatabase.h
@@ -148,7 +148,7 @@ protected:
   bool GetAddon(int id, ADDON::AddonPtr& addon);
 
   /* keep in sync with the select in GetAddon */
-  enum _AddonFields
+  enum AddonFields
   {
     addon_id=0,
     addon_type,
@@ -171,6 +171,6 @@ protected:
     dependencies_addon,
     dependencies_version,
     dependencies_optional
-  } AddonFields;
+  };
 };
 

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -218,9 +218,9 @@ bool CAddonMgr::CheckUserDirs(const cp_cfg_element_t *settings)
 }
 
 CAddonMgr::CAddonMgr()
-{
-  m_cpluff = NULL;
-}
+  : m_cpluff(nullptr),
+  m_cp_context(nullptr)
+{ }
 
 CAddonMgr::~CAddonMgr()
 {

--- a/xbmc/addons/AudioDecoder.h
+++ b/xbmc/addons/AudioDecoder.h
@@ -42,7 +42,13 @@ namespace ADDON
                         public XFILE::CMusicFileDirectory
   {
   public:
-    CAudioDecoder(const AddonProps &props) : AudioDecoderDll(props) {};
+    CAudioDecoder(const AddonProps &props) 
+      : AudioDecoderDll(props)
+      , m_context{nullptr}
+      , m_channel{nullptr}
+      , m_tags{false}
+      , m_tracks{false}
+    {};
     CAudioDecoder(const cp_extension_t *ext);
     virtual ~CAudioDecoder() {}
     virtual AddonPtr Clone() const;

--- a/xbmc/addons/AudioEncoder.h
+++ b/xbmc/addons/AudioEncoder.h
@@ -31,7 +31,7 @@ namespace ADDON
   class CAudioEncoder : public AudioEncoderDll, public IEncoder
   {
   public:
-    CAudioEncoder(const AddonProps &props) : AudioEncoderDll(props) {};
+    CAudioEncoder(const AddonProps &props) : AudioEncoderDll(props), m_context{nullptr} {};
     CAudioEncoder(const cp_extension_t *ext);
     virtual ~CAudioEncoder() {}
     virtual AddonPtr Clone() const;

--- a/xbmc/addons/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/GUIDialogAddonInfo.cpp
@@ -55,7 +55,9 @@ using namespace ADDON;
 using namespace XFILE;
 
 CGUIDialogAddonInfo::CGUIDialogAddonInfo(void)
-  : CGUIDialog(WINDOW_DIALOG_ADDON_INFO, "DialogAddonInfo.xml"), m_jobid(0)
+  : CGUIDialog(WINDOW_DIALOG_ADDON_INFO, "DialogAddonInfo.xml"),
+  m_jobid(0),
+  m_changelog(false)
 {
   m_item = CFileItemPtr(new CFileItem);
   m_loadType = KEEP_IN_MEMORY;

--- a/xbmc/addons/LanguageResource.cpp
+++ b/xbmc/addons/LanguageResource.cpp
@@ -35,9 +35,9 @@ namespace ADDON
 {
 
 CLanguageResource::CLanguageResource(const cp_extension_t *ext)
-  : CResource(ext)
+  : CResource(ext),
+  m_forceUnicodeFont(false)
 {
-  m_forceUnicodeFont = false;
   if (ext != NULL)
   {
     // parse <extension> attributes
@@ -94,7 +94,8 @@ CLanguageResource::CLanguageResource(const cp_extension_t *ext)
 
 CLanguageResource::CLanguageResource(const CLanguageResource &rhs)
   : CResource(rhs),
-    m_locale(rhs.m_locale)
+    m_locale(rhs.m_locale),
+    m_forceUnicodeFont(rhs.m_forceUnicodeFont)
 { }
 
 AddonPtr CLanguageResource::Clone() const

--- a/xbmc/addons/LanguageResource.h
+++ b/xbmc/addons/LanguageResource.h
@@ -30,7 +30,8 @@ class CLanguageResource : public CResource
 {
 public:
   CLanguageResource(const AddonProps &props)
-    : CResource(props)
+    : CResource(props),
+    m_forceUnicodeFont(false)
   { }
   CLanguageResource(const cp_extension_t *ext);
   virtual ~CLanguageResource() { }

--- a/xbmc/addons/Scraper.h
+++ b/xbmc/addons/Scraper.h
@@ -81,7 +81,10 @@ private:
 class CScraper : public CAddon
 {
 public:
-  CScraper(const AddonProps &props) : CAddon(props), m_fLoaded(false) {}
+  CScraper(const AddonProps &props) :
+    CAddon(props), m_fLoaded(false), m_requiressettings(false),
+    m_pathContent(CONTENT_NONE) {}
+
   CScraper(const cp_extension_t *ext);
   virtual ~CScraper() {}
   virtual AddonPtr Clone() const;


### PR DESCRIPTION
Fix all except one uninitialized variable warnings in addons module as reported by coverity.
