### PR TITLE
[videoinfoscanner] shows not picked up after initial scan abort

### DIFF
--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -340,10 +340,7 @@ namespace VIDEO
         GetPathHash(items, hash);
         bSkip = true;
         if (!m_database.GetPathHash(strDirectory, dbHash) || dbHash != hash)
-        {
-          m_database.SetPathHash(strDirectory, hash);
           bSkip = false;
-        }
         else
           items.Clear();
       }


### PR DESCRIPTION
Do not set the path hash on the actual tvshow source. Due to this the infoscanner skips further processing of the actual tvshow source (parent folder where content was set on) in case the initial scan was aborted and so fails to enumerate and add the underlying tvshow folders.

Fixes the issue reported in http://forum.kodi.tv/showthread.php?tid=210661&pid=1948818#pid1948818 and other places.

@Montellese, @tamland for review, please.
