### PR TITLE
[dxva] Added dxva hevc decoding.

### DIFF
--- a/lib/win32/ffmpeg_dxva2/dxva.h
+++ b/lib/win32/ffmpeg_dxva2/dxva.h
@@ -1,0 +1,150 @@
+//------------------------------------------------------------------------------
+// Copyright (c) 1999 - 2002, Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------------------------
+
+#ifndef __DIRECTX_VA_HEVC__
+#define __DIRECTX_VA_HEVC__
+
+/****************STRUCTURES******************/
+#pragma pack(push, 1)
+
+/* HEVC Picture Entry structure */
+typedef struct _DXVA_PicEntry_HEVC
+{
+    union
+    {
+       struct
+       {
+            UCHAR Index7Bits : 7;
+            UCHAR AssociatedFlag : 1;
+       };
+       UCHAR bPicEntry;
+    };
+} DXVA_PicEntry_HEVC, *LPDXVA_PicEntry_HEVC;
+
+/* HEVC Picture Parameter structure */
+typedef struct _DXVA_PicParams_HEVC {
+    USHORT      PicWidthInMinCbsY;
+    USHORT      PicHeightInMinCbsY;
+    union {
+        struct {
+            USHORT  chroma_format_idc                       : 2;
+            USHORT  separate_colour_plane_flag              : 1;
+            USHORT  bit_depth_luma_minus8                   : 3;
+            USHORT  bit_depth_chroma_minus8                 : 3;
+            USHORT  log2_max_pic_order_cnt_lsb_minus4       : 4;
+            USHORT  NoPicReorderingFlag                     : 1;
+            USHORT  NoBiPredFlag                            : 1;
+            USHORT  ReservedBits1                            : 1;
+        };
+        USHORT wFormatAndSequenceInfoFlags;
+    };
+    DXVA_PicEntry_HEVC  CurrPic;
+    UCHAR   sps_max_dec_pic_buffering_minus1;
+    UCHAR   log2_min_luma_coding_block_size_minus3;
+    UCHAR   log2_diff_max_min_luma_coding_block_size;
+    UCHAR   log2_min_transform_block_size_minus2;
+    UCHAR   log2_diff_max_min_transform_block_size;
+    UCHAR   max_transform_hierarchy_depth_inter;
+    UCHAR   max_transform_hierarchy_depth_intra;
+    UCHAR   num_short_term_ref_pic_sets;
+    UCHAR   num_long_term_ref_pics_sps;
+    UCHAR   num_ref_idx_l0_default_active_minus1;
+    UCHAR   num_ref_idx_l1_default_active_minus1;
+    CHAR    init_qp_minus26;
+    UCHAR   ucNumDeltaPocsOfRefRpsIdx;
+    USHORT  wNumBitsForShortTermRPSInSlice;
+    USHORT  ReservedBits2;
+
+    union {
+        struct {
+            UINT32  scaling_list_enabled_flag                    : 1;
+            UINT32  amp_enabled_flag                            : 1;
+            UINT32  sample_adaptive_offset_enabled_flag         : 1;
+            UINT32  pcm_enabled_flag                            : 1;
+            UINT32  pcm_sample_bit_depth_luma_minus1            : 4;
+            UINT32  pcm_sample_bit_depth_chroma_minus1          : 4;
+            UINT32  log2_min_pcm_luma_coding_block_size_minus3  : 2;
+            UINT32  log2_diff_max_min_pcm_luma_coding_block_size : 2;
+            UINT32  pcm_loop_filter_disabled_flag                : 1;
+            UINT32  long_term_ref_pics_present_flag             : 1;
+            UINT32  sps_temporal_mvp_enabled_flag               : 1;
+            UINT32  strong_intra_smoothing_enabled_flag         : 1;
+            UINT32  dependent_slice_segments_enabled_flag       : 1;
+            UINT32  output_flag_present_flag                    : 1;
+            UINT32  num_extra_slice_header_bits                 : 3;
+            UINT32  sign_data_hiding_enabled_flag               : 1;
+            UINT32  cabac_init_present_flag                     : 1;
+            UINT32  ReservedBits3                               : 5;
+        };
+        UINT32 dwCodingParamToolFlags;
+    };
+
+    union {
+       struct {
+            UINT32  constrained_intra_pred_flag                 : 1;
+            UINT32  transform_skip_enabled_flag                 : 1;
+            UINT32  cu_qp_delta_enabled_flag                    : 1;
+            UINT32  pps_slice_chroma_qp_offsets_present_flag    : 1;
+            UINT32  weighted_pred_flag                          : 1;
+            UINT32  weighted_bipred_flag                        : 1;
+            UINT32  transquant_bypass_enabled_flag              : 1;
+            UINT32  tiles_enabled_flag                          : 1;
+            UINT32  entropy_coding_sync_enabled_flag            : 1;
+            UINT32  uniform_spacing_flag                        : 1;
+            UINT32  loop_filter_across_tiles_enabled_flag       : 1;
+            UINT32  pps_loop_filter_across_slices_enabled_flag  : 1;
+            UINT32  deblocking_filter_override_enabled_flag     : 1;
+            UINT32  pps_deblocking_filter_disabled_flag         : 1;
+            UINT32  lists_modification_present_flag             : 1;
+            UINT32  slice_segment_header_extension_present_flag : 1;
+            UINT32  IrapPicFlag                                 : 1;
+            UINT32  IdrPicFlag                                  : 1;
+            UINT32  IntraPicFlag                                : 1;
+            UINT32  ReservedBits4                               : 13;
+        };
+        UINT32 dwCodingSettingPicturePropertyFlags;
+    };
+    CHAR    pps_cb_qp_offset;
+    CHAR    pps_cr_qp_offset;
+    UCHAR   num_tile_columns_minus1;
+    UCHAR   num_tile_rows_minus1;
+    USHORT  column_width_minus1[19];
+    USHORT  row_height_minus1[21];
+    UCHAR   diff_cu_qp_delta_depth;
+    CHAR    pps_beta_offset_div2;
+    CHAR    pps_tc_offset_div2;
+    UCHAR   log2_parallel_merge_level_minus2;
+    INT     CurrPicOrderCntVal;
+    DXVA_PicEntry_HEVC  RefPicList[15];
+    UCHAR   ReservedBits5;
+    INT     PicOrderCntValList[15];
+    UCHAR   RefPicSetStCurrBefore[8];
+    UCHAR   RefPicSetStCurrAfter[8];
+    UCHAR   RefPicSetLtCurr[8];
+    USHORT  ReservedBits6;
+    USHORT  ReservedBits7;
+    UINT    StatusReportFeedbackNumber;
+} DXVA_PicParams_HEVC, *LPDXVA_PicParams_HEVC;
+
+/* HEVC Quantizatiuon Matrix structure */
+typedef struct _DXVA_Qmatrix_HEVC
+{
+    UCHAR ucScalingLists0[6][16];
+    UCHAR ucScalingLists1[6][64];
+    UCHAR ucScalingLists2[6][64];
+    UCHAR ucScalingLists3[2][64];
+    UCHAR ucScalingListDCCoefSizeID2[6];
+    UCHAR ucScalingListDCCoefSizeID3[2];
+} DXVA_Qmatrix_HEVC, *LPDXVA_Qmatrix_HEVC;
+
+/* HEVC Slice Control Structure */
+typedef struct _DXVA_Slice_HEVC_Short
+{
+    UINT    BSNALunitDataLocation;
+    UINT    SliceBytesInBuffer;
+    USHORT  wBadSliceChopping;
+} DXVA_Slice_HEVC_Short, *LPDXVA_Slice_HEVC_Short;
+
+#pragma pack(pop)
+#endif //__DIRECTX_VA_HEVC__

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DXVA.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DXVA.cpp
@@ -113,6 +113,10 @@ static const dxva2_mode_t dxva2_modes[] = {
     { "VC-1 MoComp",          &DXVA2_ModeVC1_B,    0 },
     { "VC-1 post processing", &DXVA2_ModeVC1_A,    0 },
 
+    /* HEVC / H.265 */
+    { "HEVC / H.265 variable-length decoder, main",   &DXVA_ModeHEVC_VLD_Main,   AV_CODEC_ID_HEVC },
+    { "HEVC / H.265 variable-length decoder, main10", &DXVA_ModeHEVC_VLD_Main10, 0 },
+
 #ifdef FF_DXVA2_WORKAROUND_INTEL_CLEARVIDEO
     /* Intel specific modes (only useful on older GPUs) */
     { "Intel H.264 VLD, no FGT",                                      &DXVADDI_Intel_ModeH264_E, AV_CODEC_ID_H264 },
@@ -820,8 +824,8 @@ bool CDecoder::Open(AVCodecContext *avctx, enum PixelFormat fmt, unsigned int su
 
   m_format.SampleWidth  = avctx->coded_width;
   m_format.SampleHeight = avctx->coded_height;
-  m_format.SampleFormat.SampleFormat           = DXVA2_SampleProgressiveFrame;
-  m_format.SampleFormat.VideoLighting          = DXVA2_VideoLighting_dim;
+  m_format.SampleFormat.SampleFormat  = DXVA2_SampleProgressiveFrame;
+  m_format.SampleFormat.VideoLighting = DXVA2_VideoLighting_dim;
 
   if     (avctx->color_range == AVCOL_RANGE_JPEG)
     m_format.SampleFormat.NominalRange = DXVA2_NominalRange_0_255;
@@ -918,10 +922,13 @@ bool CDecoder::Open(AVCodecContext *avctx, enum PixelFormat fmt, unsigned int su
 
   if(avctx->refs > m_refs)
     m_refs = avctx->refs+2;
+  if (avctx->codec_id == AV_CODEC_ID_HEVC)
+    m_refs = 16;
 
   if(m_refs == 0)
   {
-    if(avctx->codec_id == AV_CODEC_ID_H264)
+    if( avctx->codec_id == AV_CODEC_ID_H264
+     || avctx->codec_id == AV_CODEC_ID_HEVC)
       m_refs = 16;
     else
       m_refs = 2;
@@ -1101,7 +1108,7 @@ bool CDecoder::OpenDecoder()
   CLog::Log(LOGDEBUG, "DXVA - allocating %d surfaces", m_context->surface_count);
 
   if (!m_dxva_context->CreateSurfaces(m_format.SampleWidth, m_format.SampleHeight, m_format.Format,
-                                      m_context->surface_count - 1, m_context->surface))
+                                      m_context->surface_count, m_context->surface))
     return false;
 
   for(unsigned i = 0; i < m_context->surface_count; i++)


### PR DESCRIPTION
WIP because something went wrong in ffmpeg. Decoding starts fine and after a couple seconds I got 

```
ffmpeg[9C0]: Assertion rpl->nb_refs <= (sizeof(pp->RefPicSetStCurrBefore) / sizeof((pp->RefPicSetStCurrBefore)[0])) failed at libavcodec/dxva2_hevc.c:186
```

ping @FernetMenta 
@MartijnKaijser can you try this on your Intel hw (I know it supports dxva hevc :))
