### PR TITLE
fixed: all add-ons got duplicated in the addon table

### DIFF
--- a/xbmc/addons/AddonDatabase.cpp
+++ b/xbmc/addons/AddonDatabase.cpp
@@ -328,7 +328,7 @@ bool CAddonDatabase::GetAddons(VECADDONS& addons, const ADDON::TYPE &type /* = A
     if (NULL == m_pDB.get()) return false;
     if (NULL == m_pDS2.get()) return false;
 
-    std::string sql = PrepareSQL("select distinct addonID from addon");
+    std::string sql = PrepareSQL("SELECT DISTINCT a.addonID FROM addon a, addonlinkrepo b WHERE b.idRepo > 0 AND a.id = b.idAddon");
     if (type != ADDON_UNKNOWN)
     {
       std::string strType;

--- a/xbmc/addons/AddonDatabase.cpp
+++ b/xbmc/addons/AddonDatabase.cpp
@@ -100,8 +100,12 @@ void CAddonDatabase::UpdateTables(int version)
   }
   if (version < 17)
   {
-    m_pDS->exec("DELETE FROM repo");
-    m_pDS->exec("ALTER TABLE repo ADD version text");
+    m_pDS->exec("ALTER TABLE repo ADD version text DEFAULT '0.0.0'");
+  }
+  if (version == 17)
+  {
+    /** remove all add-ons because the previous upgrade created dupes in it's first version */
+    m_pDS->exec("DELETE FROM addon");
   }
 }
 

--- a/xbmc/addons/AddonDatabase.h
+++ b/xbmc/addons/AddonDatabase.h
@@ -142,7 +142,7 @@ protected:
   virtual void CreateAnalytics();
   virtual void UpdateTables(int version);
   virtual int GetMinSchemaVersion() const { return 15; }
-  virtual int GetSchemaVersion() const { return 17; }
+  virtual int GetSchemaVersion() const { return 18; }
   const char *GetBaseDBName() const { return "Addons"; }
 
   bool GetAddon(int id, ADDON::AddonPtr& addon);


### PR DESCRIPTION
PR https://github.com/xbmc/xbmc/pull/6568 deleted all repo entries from the db, but didn't delete the add-ons. This leads to a dupe of each add-on when upgrading from an older version, as the repo gets inserted another time, including all it's add-ons.

Fixed by defaulting to version 0.0.0, which just triggers an update.

ping @tamland @mkortstiege @MartijnKaijser 
