### PR TITLE
ActiveAE: Wait 60 seconds max for init

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -2176,7 +2176,7 @@ bool CActiveAE::Initialize()
   Message *reply;
   if (m_controlPort.SendOutMessageSync(CActiveAEControlProtocol::INIT,
                                                  &reply,
-                                                 10000))
+                                                 60000))
   {
     bool success = reply->signal == CActiveAEControlProtocol::ACC;
     reply->Release();


### PR DESCRIPTION
Via: http://trac.kodi.tv/ticket/15842 it was shown that one device approximately needs 2 seconds for enumeration. With users having 5 or 6 devices installed - AE initialization might fail. This increases the timeout to max 30 seconds.
