### PR TITLE
[audioencoders] add xbmc.audioencoder

### DIFF
--- a/addons/xbmc.audioencoder/addon.xml
+++ b/addons/xbmc.audioencoder/addon.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<addon id="xbmc.audioencoder" version="1.0.0" provider-name="Team-Kodi">
+  <backwards-compatibility abi="1.0.0"/>
+  <requires>
+    <import addon="xbmc.core" version="0.1.0"/>
+  </requires>
+</addon>


### PR DESCRIPTION
all audio encoder addons depend on xbmc.audioencoder but it was never added

ref 0ccd9106
//cc @notspiff
