### PR TITLE
FIX: [droid] properly save addon settings even if the control is not focused (fixes #13913)

### DIFF
--- a/xbmc/addons/GUIDialogAddonSettings.cpp
+++ b/xbmc/addons/GUIDialogAddonSettings.cpp
@@ -143,6 +143,8 @@ bool CGUIDialogAddonSettings::OnMessage(CGUIMessage& message)
         CGUIMessage msg(GUI_MSG_SETFOCUS,GetID(),iControl);
         OnMessage(msg);
       }
+      else
+        CreateControls();
       return true;
     }
   }


### PR DESCRIPTION
@Montellese Could not find the root cause of the control not being focused with a tap, but not having a focused control shouldn't prevent the apply of the changed setting ;)
