### PR TITLE
FIX: [droid] properly save addon settings even if the control is not focused (fixes #13913)

### DIFF
--- a/xbmc/addons/GUIDialogAddonSettings.cpp
+++ b/xbmc/addons/GUIDialogAddonSettings.cpp
@@ -143,6 +143,8 @@ bool CGUIDialogAddonSettings::OnMessage(CGUIMessage& message)
         CGUIMessage msg(GUI_MSG_SETFOCUS,GetID(),iControl);
         OnMessage(msg);
       }
+      else
+        CreateControls();
       return true;
     }
   }


### PR DESCRIPTION
/cc @MartijnKaijser 
