### PR TITLE
add logic to wait for the startup window to finish before showing information dialogs during startup

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1252,7 +1252,12 @@ bool CApplication::Initialize()
 #endif
 
   if (fallbackLanguage)
+  {
+    // make sure the startup window doesn't replace our dialog
+    WaitForStartWindow();
+
     CGUIDialogOK::ShowAndGetInput(24133, 24134);
+  }
 
   // show info dialog about moved configuration files if needed
   ShowAppMigrationMessage();
@@ -1746,6 +1751,22 @@ void CApplication::UnloadSkin(bool forReload /* = false */)
 //  The g_SkinInfo shared_ptr ought to be reset here
 // but there are too many places it's used without checking for NULL
 // and as a result a race condition on exit can cause a crash.
+}
+
+void CApplication::WaitForStartWindow()
+{
+  int windowId;
+  while (true)
+  {
+    // get the ID of the currently active window
+    windowId = g_windowManager.GetActiveWindowID();
+
+    // if it's not the startup window we're good
+    if (windowId != WINDOW_STARTUP_ANIM)
+      return;
+
+    Process();
+  }
 }
 
 bool CApplication::LoadUserWindows()
@@ -4114,6 +4135,9 @@ void CApplication::ShowAppMigrationMessage()
   if (CFile::Exists("special://home/.kodi_data_was_migrated") &&
       !CFile::Exists("special://home/.kodi_migration_info_shown"))
   {
+    // make sure the startup window doesn't replace our dialog
+    WaitForStartWindow();
+
     CGUIDialogOK::ShowAndGetInput(24128, 0, 24129, 0);
     CFile tmpFile;
     // create the file which will prevent this dialog from appearing in the future

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -389,6 +389,12 @@ public:
    */
   void UnregisterActionListener(IActionListener *listener);
 
+  /*!
+   \brief Wait for the startup window to complete and move on to the real
+          start window.
+   */
+  void WaitForStartWindow();
+
 protected:
   virtual bool OnSettingsSaving() const;
 

--- a/xbmc/windows/GUIWindowLoginScreen.cpp
+++ b/xbmc/windows/GUIWindowLoginScreen.cpp
@@ -324,9 +324,6 @@ void CGUIWindowLoginScreen::LoadProfile(unsigned int profile)
   g_weatherManager.Refresh();
   g_application.SetLoggingIn(true);
 
-  if (fallbackLanguage)
-    CGUIDialogOK::ShowAndGetInput("Failed to load language", "We were unable to load your configured language. Please check your language settings.");
-
 #ifdef HAS_JSONRPC
   JSONRPC::CJSONRPC::Initialize();
 #endif
@@ -341,4 +338,12 @@ void CGUIWindowLoginScreen::LoadProfile(unsigned int profile)
 
   g_application.UpdateLibraries();
   CStereoscopicsManager::Get().Initialize();
+
+  if (fallbackLanguage)
+  {
+    // make sure the startup window doesn't replace our dialog
+    g_application.WaitForStartWindow();
+
+    CGUIDialogOK::ShowAndGetInput("Failed to load language", "We were unable to load your configured language. Please check your language settings.");
+  }
 }


### PR DESCRIPTION
This is an attempt at solving the problem that when we try to show a modal dialog during startup to provide the user with some information, the dialog isn't really shown to the user most of the time because by the time the dialog becomes visible, Confluence's `Startup.xml` kicks in and executes a `ReplaceWindow()` call to go to the home window. That `ReplaceWindow()` call changes the active window and basically hides the modal dialog in the background.

What this does is that when we want to show a modal dialog with some information we first wait until the `Startup.xml` has been processed and the actual start screen has been reached. Then we show the dialog.

TBH I don't really like this approach but I'm not sure how else to do it. Should `ReplaceWindow()` (and `ActivateWindow()` for that matter) be blocked while a modal dialog is active instead?
