### PR TITLE
[win32file] use LastWriteTime instead of ChangeTime (fixes #15590)

### DIFF
--- a/xbmc/filesystem/win32/Win32File.cpp
+++ b/xbmc/filesystem/win32/Win32File.cpp
@@ -534,9 +534,7 @@ int CWin32File::Stat(const CURL& url, struct __stat64* statData)
     FILE_BASIC_INFO basicInfo;
     if (GetFileInformationByHandleEx(hFile, FileBasicInfo, &basicInfo, sizeof(basicInfo)) != 0)
     {
-      statData->st_mtime = CWIN32Util::fileTimeToTimeT(basicInfo.ChangeTime); // most accurate value
-      if (statData->st_mtime == 0)
-        statData->st_mtime = CWIN32Util::fileTimeToTimeT(basicInfo.LastWriteTime); // less accurate value
+      statData->st_mtime = CWIN32Util::fileTimeToTimeT(basicInfo.LastWriteTime);
       statData->st_atime = CWIN32Util::fileTimeToTimeT(basicInfo.LastAccessTime);
       statData->st_ctime = CWIN32Util::fileTimeToTimeT(basicInfo.CreationTime);
     }
@@ -639,9 +637,7 @@ int CWin32File::Stat(struct __stat64* statData)
   if (GetFileInformationByHandleEx(m_hFile, FileBasicInfo, &basicInfo, sizeof(basicInfo)) == 0)
     return -1; // can't get basic file information
 
-  statData->st_mtime = CWIN32Util::fileTimeToTimeT(basicInfo.ChangeTime); // most accurate value
-  if (statData->st_mtime == 0)
-    statData->st_mtime = CWIN32Util::fileTimeToTimeT(basicInfo.LastWriteTime); // less accurate value
+  statData->st_mtime = CWIN32Util::fileTimeToTimeT(basicInfo.LastWriteTime);
 
   statData->st_atime = CWIN32Util::fileTimeToTimeT(basicInfo.LastAccessTime);
   if (statData->st_atime == 0)


### PR DESCRIPTION
Fixes issue described in http://trac.kodi.tv/ticket/15590 and restores old behavior.

@Karlson2k for review.
