### PR TITLE
Disable desktop compositing for KDE, when Kodi is in full-screen mode

### DIFF
--- a/xbmc/windowing/X11/WinSystemX11.cpp
+++ b/xbmc/windowing/X11/WinSystemX11.cpp
@@ -1125,6 +1125,10 @@ bool CWinSystemX11::SetWindow(int width, int height, bool fullscreen, const std:
     {
       Atom fs = XInternAtom(m_dpy, "_NET_WM_STATE_FULLSCREEN", True);
       XChangeProperty(m_dpy, m_mainWindow, XInternAtom(m_dpy, "_NET_WM_STATE", True), XA_ATOM, 32, PropModeReplace, (unsigned char *) &fs, 1);
+      // disable desktop compositing for KDE, when Kodi is in full-screen mode
+      int one = 1;
+      XChangeProperty(m_dpy, m_mainWindow, XInternAtom(m_dpy, "_KDE_NET_WM_BLOCK_COMPOSITING", True), XA_CARDINAL, 32,
+                      PropModeReplace, (unsigned char*) &one,  1);
     }
 
     // define invisible cursor


### PR DESCRIPTION
On KDE desktop, disable of desktop compositing is supported.
See kwin developer Martin's [blog](http://blog.martin-graesslin.com/blog/2011/04/turning-compositing-off-in-the-right-way) about the subject.

When we are in full-screen mode, we absolutely don't need compositing. So it must be turned off if possible.
With this PR, the performance and power efficiency of kodi in full screen mode, will be in par with a kodi running on bare X11. BTW the qt5 based KDE5 looks absolutely great and it is really fast and responsive.

I tested this on KDE and on Gnome (obviously in Gnome it has no effect)

Maybe @FernetMenta could look at this, to check if the code is ok.

Also here is my [discussion](https://bugs.kde.org/show_bug.cgi?id=344319#c3) on the subject with Martin.
