### PR TITLE
[win32] improvements to make-addons.bat

### DIFF
--- a/tools/buildsteps/win32/make-addons.bat
+++ b/tools/buildsteps/win32/make-addons.bat
@@ -38,7 +38,14 @@ SET ADDON_DEPENDS_PATH=%ADDONS_PATH%\output
 SET ADDONS_BUILD_PATH=%ADDONS_PATH%\build
 SET ADDONS_DEFINITION_PATH=%ADDONS_PATH%\addons
 
-SET ERRORFILE=%BASE_PATH%\make-addons.error
+SET ADDONS_SUCCESS_FILE=%ADDONS_PATH%\.success
+SET ADDONS_FAILURE_FILE=%ADDONS_PATH%\.failure
+
+SET ERRORFILE=%ADDONS_PATH%\make-addons.error
+
+rem remove the success and failure files from a previous build
+DEL /F %ADDONS_SUCCESS_FILE% > NUL 2>&1
+DEL /F %ADDONS_FAILURE_FILE% > NUL 2>&1
 
 IF %clean% == true (
   rem remove the build directory if it exists
@@ -108,7 +115,9 @@ FOR %%a IN (%ADDONS_TO_BUILD%) DO (
   nmake %%a
   IF ERRORLEVEL 1 (
     ECHO nmake %%a error level: %ERRORLEVEL% > %ERRORFILE%
-    GOTO ERROR
+    ECHO %%a >> %ADDONS_FAILURE_FILE%
+  ) ELSE (
+    ECHO %%a >> %ADDONS_SUCCESS_FILE%
   )
 )
 
@@ -117,6 +126,9 @@ GOTO END
 
 :ERROR
 rem something went wrong
+FOR %%a IN (%ADDONS_TO_BUILD%) DO (
+  ECHO %%a >> %ADDONS_FAILURE_FILE%
+)
 ECHO Failed to build addons
 ECHO See %ERRORFILE% for more details
 SET EXITCODE=1

--- a/tools/buildsteps/win32/make-addons.bat
+++ b/tools/buildsteps/win32/make-addons.bat
@@ -36,6 +36,7 @@ SET SCRIPTS_PATH=%BASE_PATH%\scripts\windows
 SET ADDONS_PATH=%BASE_PATH%\addons
 SET ADDON_DEPENDS_PATH=%ADDONS_PATH%\output
 SET ADDONS_BUILD_PATH=%ADDONS_PATH%\build
+SET ADDONS_DEFINITION_PATH=%ADDONS_PATH%\addons
 
 SET ERRORFILE=%BASE_PATH%\make-addons.error
 
@@ -73,9 +74,15 @@ ECHO --------------------------------------------------
 ECHO Building addons
 ECHO --------------------------------------------------
 
-SET ADDONS_TO_BUILD="all"
+SET ADDONS_TO_BUILD=
 IF "%addon%" NEQ "" (
   SET ADDONS_TO_BUILD=%addon%
+) ELSE (
+  SETLOCAL EnableDelayedExpansion
+  FOR /D %%a IN (%ADDONS_DEFINITION_PATH%\*) DO (
+    SET ADDONS_TO_BUILD=!ADDONS_TO_BUILD! %%~nxa
+  )
+  SETLOCAL DisableDelayedExpansion
 )
 
 rem execute cmake to generate makefiles processable by nmake
@@ -94,11 +101,15 @@ IF ERRORLEVEL 1 (
   GOTO ERROR
 )
 
-rem execute nmake to build the addons
-nmake %addon%
-IF ERRORLEVEL 1 (
-  ECHO nmake error level: %ERRORLEVEL% > %ERRORFILE%
-  GOTO ERROR
+rem loop over all addons to build
+FOR %%a IN (%ADDONS_TO_BUILD%) DO (
+  ECHO Building %%a...
+  rem execute nmake to build the addons
+  nmake %%a
+  IF ERRORLEVEL 1 (
+    ECHO nmake %%a error level: %ERRORLEVEL% > %ERRORFILE%
+    GOTO ERROR
+  )
 )
 
 rem everything was fine

--- a/tools/buildsteps/win32/make-addons.bat
+++ b/tools/buildsteps/win32/make-addons.bat
@@ -7,15 +7,18 @@ SET EXITCODE=0
 SET install=false
 SET clean=false
 SET addon=
-FOR %%b in (%1, %2, %3, %4) DO (
+
+SETLOCAL EnableDelayedExpansion
+FOR %%b IN (%*) DO (
   IF %%b == install (
     SET install=true
   ) ELSE ( IF %%b == clean (
     SET clean=true
   ) ELSE (
-    SET addon=%%b
+    SET addon=!addon! %%b
   ))
 )
+SETLOCAL DisableDelayedExpansion
 
 rem set Visual C++ build environment
 call "%VS120COMNTOOLS%..\..\VC\bin\vcvars32.bat"
@@ -72,7 +75,7 @@ ECHO --------------------------------------------------
 
 SET ADDONS_TO_BUILD="all"
 IF "%addon%" NEQ "" (
-  SET ADDONS_TO_BUILD="%addon%"
+  SET ADDONS_TO_BUILD=%addon%
 )
 
 rem execute cmake to generate makefiles processable by nmake


### PR DESCRIPTION
These three commits add a few improvements to WIN32's buildstep script `make-addons.bat` which we use to build binary addons.
- Possibility to call `make-addons.bat` and pass in the names of multiple binary addons to be built (e.g. `make-addons.bat pvr.demo pvr.vdr.vnsi`). Right now it's only possible to specify a single binary addon to be built.
- `make-addons.bat` doesn't abort anymore if building a single binary addon fails. This is only true for the actual build process. If there's a problem in our (not the binary addon's) buildsystem it will fail completely.
- Successfully built binary addons are written into `project/cmake/addons/.success` and failed ones are written into `project/cmake/addons/.failure`.

@Memphiz: Let me know if the `.success` and `.failure` file-based approach with one binary addon name/ID per line works for you on jenkins. The files are deleted with every call to `make-addons.bat` and then created when building the addons. If all addons fail to build there's no `.success` and if all addons build fine there's no `.failure` but that could be adjusted that the files always exist but are empty if that's easier for you.
