### PR TITLE
[Fix][settings] Fix min/max constraints and language list for subs download

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -922,7 +922,6 @@
             <options>iso6391languages</options>
             <delimiter>,</delimiter>
             <minimumitems>1</minimumitems>
-            <maximumitems>3</maximumitems>
           </constraints>
           <control type="list" format="string">
             <multiselect>true</multiselect>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -152,8 +152,8 @@
           <constraints>
             <options>keyboardlayouts</options>
             <delimiter>|</delimiter>
-            <minimumItems>1</minimumItems>
-            <maximumItems>3</maximumItems>
+            <minimumitems>1</minimumitems>
+            <maximumitems>3</maximumitems>
           </constraints>
           <control type="list" format="string">
             <multiselect>true</multiselect>
@@ -516,7 +516,7 @@
           <constraints>
             <options>videoseeksteps</options>
             <delimiter>,</delimiter>
-            <minimumItems>2</minimumItems>
+            <minimumitems>2</minimumitems>
           </constraints>
           <control type="list" format="string">
             <multiselect>true</multiselect>
@@ -921,8 +921,8 @@
           <constraints>
             <options>languagenames</options>
             <delimiter>,</delimiter>
-            <minimumItems>1</minimumItems>
-            <maximumItems>3</maximumItems>
+            <minimumitems>1</minimumitems>
+            <maximumitems>3</maximumitems>
           </constraints>
           <control type="list" format="string">
             <multiselect>true</multiselect>
@@ -1712,7 +1712,7 @@
           <constraints>
             <options>videoseeksteps</options>
             <delimiter>,</delimiter>
-            <minimumItems>2</minimumItems>
+            <minimumitems>2</minimumitems>
           </constraints>
           <control type="list" format="string">
             <multiselect>true</multiselect>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -919,7 +919,7 @@
           <level>1</level>
           <default>English</default>
           <constraints>
-            <options>languagenames</options>
+            <options>iso6391languages</options>
             <delimiter>,</delimiter>
             <minimumitems>1</minimumitems>
             <maximumitems>3</maximumitems>

--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -1126,16 +1126,22 @@ void CLangInfo::SettingOptionsLanguageNamesFiller(const CSetting *setting, std::
   sort(list.begin(), list.end(), SortLanguage());
 }
 
-void CLangInfo::SettingOptionsStreamLanguagesFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data)
+void CLangInfo::SettingOptionsISO6391LanguagesFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data)
 {
-  list.push_back(make_pair(g_localizeStrings.Get(308), "original"));
-  list.push_back(make_pair(g_localizeStrings.Get(309), "default"));
-
   // get a list of language names
   vector<string> languages = g_LangCodeExpander.GetLanguageNames();
   sort(languages.begin(), languages.end(), sortstringbyname());
   for (std::vector<std::string>::const_iterator language = languages.begin(); language != languages.end(); ++language)
     list.push_back(make_pair(*language, *language));
+}
+
+void CLangInfo::SettingOptionsStreamLanguagesFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data)
+{
+  list.push_back(make_pair(g_localizeStrings.Get(308), "original"));
+  list.push_back(make_pair(g_localizeStrings.Get(309), "default"));
+
+  std::string dummy;
+  SettingOptionsISO6391LanguagesFiller(NULL, list, dummy, NULL);
 }
 
 void CLangInfo::SettingOptionsRegionsFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data)

--- a/xbmc/LangInfo.h
+++ b/xbmc/LangInfo.h
@@ -186,6 +186,7 @@ public:
 
   static void SettingOptionsLanguageNamesFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data);
   static void SettingOptionsStreamLanguagesFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data);
+  static void SettingOptionsISO6391LanguagesFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data);
   static void SettingOptionsRegionsFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data);
   static void SettingOptionsShortDateFormatsFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data);
   static void SettingOptionsLongDateFormatsFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data);

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -249,6 +249,7 @@ void CSettings::Uninitialize()
   m_settingsManager->UnregisterSettingOptionsFiller("shutdownstates");
   m_settingsManager->UnregisterSettingOptionsFiller("startupwindows");
   m_settingsManager->UnregisterSettingOptionsFiller("streamlanguages");
+  m_settingsManager->UnregisterSettingOptionsFiller("iso6391languages");
   m_settingsManager->UnregisterSettingOptionsFiller("skincolors");
   m_settingsManager->UnregisterSettingOptionsFiller("skinfonts");
   m_settingsManager->UnregisterSettingOptionsFiller("skinsounds");
@@ -599,6 +600,7 @@ void CSettings::InitializeOptionFillers()
   m_settingsManager->RegisterSettingOptionsFiller("shutdownstates", CPowerManager::SettingOptionsShutdownStatesFiller);
   m_settingsManager->RegisterSettingOptionsFiller("startupwindows", ADDON::CSkinInfo::SettingOptionsStartupWindowsFiller);
   m_settingsManager->RegisterSettingOptionsFiller("streamlanguages", CLangInfo::SettingOptionsStreamLanguagesFiller);
+  m_settingsManager->RegisterSettingOptionsFiller("iso6391languages", CLangInfo::SettingOptionsISO6391LanguagesFiller);
   m_settingsManager->RegisterSettingOptionsFiller("skincolors", ADDON::CSkinInfo::SettingOptionsSkinColorsFiller);
   m_settingsManager->RegisterSettingOptionsFiller("skinfonts", ADDON::CSkinInfo::SettingOptionsSkinFontsFiller);
   m_settingsManager->RegisterSettingOptionsFiller("skinsounds", ADDON::CSkinInfo::SettingOptionsSkinSoundFiller);


### PR DESCRIPTION
@Montellese for review. https://github.com/xbmc/xbmc/commit/a09a0bd42fd8000125435df4c3626ed07e0c4a0e leads to a almost complete rebuild. I could also change the xml file, but I wasn't sure about the naming conventions.

Also the maximum constraints that exist are rather arbitrary, imo.
