### PR TITLE
[depends/binaddons] - unify binary addons and add build result tracking

### DIFF
--- a/docs/README.android
+++ b/docs/README.android
@@ -200,8 +200,10 @@ on with the Android toolchain and creating an Android Application Package
    having to input these with each configure. 
 
    # make -j <jobs>
-   # make -j <jobs> -C target/xbmc-pvr-addons
-   # make -j <jobs> -C target/xbmc-audioencoder-addons
+   # make -j <jobs> -C target/binary-addons
+
+   NOTE: if you only want to build specific addons you can specify like this:
+   # make -C target/binary-addons ADDONS="pvr.hts pvr.dvblink"
 
    This build was designed to be massively parallel. Don't be afraid to
    give it a 'make -j20' or so.

--- a/docs/README.ios
+++ b/docs/README.ios
@@ -80,9 +80,11 @@ constellations of Xcode and osx versions (to be updated once we know more):
  $ ./bootstrap
  $ ./configure --host=arm-apple-darwin
  $ make
- $ make -C target/xbmc-pvr-addons
- $ make -C target/xbmc-audioencoder-addons
+ $ make -C target/binary-addons
  
+ NOTE: if you only want to build specific addons you can specify like this:
+  $ make -C target/binary-addons ADDONS="pvr.hts pvr.dvblink"
+
  NOTE: You can speedup compilation on multicore systems by doing 
  "make -j<number of cores>" instead of "make". For a dualcore this would read:
  "make -j2"

--- a/docs/README.linux
+++ b/docs/README.linux
@@ -99,10 +99,12 @@ Tip: By adding -j<number> to the make command, you describe how many
 
 Note: From v14 with commit 4090a5f a new API for binary audio encoder and pvr addons is available, if you need to compile them do:
     
-    $ make -C tools/depends/target/xbmc-audioencoder-addons PREFIX=/<system prefix you added on step 4.1>
-    $ make -C tools/depends/target/xbmc-pvr-addons PREFIX=/<system prefix you added on step 4.1>
+    $ make -C tools/depends/target/binary-addons PREFIX=/<system prefix you added on step 4.1>
 
 .3  $ make install
+
+Note: if you only want to build specific addons you can specify like this:
+  $ make -C tools/depends/target/binary-addons PREFIX=/<system prefix you added on step 4.1> ADDONS="pvr.hts pvr.dvblink"
 
 This will install Kodi in the prefix provided in 4.1 as well as a launcher script.
 

--- a/docs/README.osx
+++ b/docs/README.osx
@@ -86,8 +86,10 @@ constellations of Xcode and osx versions (to be updated once we know more):
  $ make
 
 3.2.3 Compile binary addons
- $ make -C target/xbmc-pvr-addons
- $ make -C target/xbmc-audioencoder-addons
+ $ make -C target/binary-addons
+
+ NOTE: if you only want to build specific addons you can specify like this:
+  $ make -C target/binary-addons ADDONS="pvr.hts pvr.dvblink"
 
  NOTE: You can speedup compilation on multicore systems by doing
  "make -j<number of cores>" instead of "make". For a dualcore this would read:

--- a/tools/buildsteps/defaultenv
+++ b/tools/buildsteps/defaultenv
@@ -9,7 +9,7 @@ FAILED_BUILD_FILENAME=".last_failed_revision"
 TARBALLS=${TARBALLS:-"/opt/xbmc-tarballs"}
 
 BINARY_ADDONS_ROOT=tools/depends/target
-BINARY_ADDONS="xbmc-audioencoder-addons xbmc-pvr-addons"
+BINARY_ADDONS="binary-addons"
 DEPLOYED_BINARY_ADDONS="-e addons"
 
 #set platform defaults

--- a/tools/depends/target/binary-addons/Makefile
+++ b/tools/depends/target/binary-addons/Makefile
@@ -1,5 +1,5 @@
 BUILDDIR := $(shell pwd)
-ADDONS = "pvr.argustv pvr.demo pvr.dvblink pvr.dvbviewer pvr.filmon pvr.hts pvr.iptvsimple pvr.mediaportal.tvserver pvr.mythtv pvr.nextpvr pvr.njoy pvr.vdr.vnsi pvr.vuplus pvr.wmc audioencoder.flac audioencoder.lame audioencoder.vorbis audioencoder.wav"
+ADDONS := "$(shell cd $(BUILDDIR)/../../../../project/cmake/addons/addons/; echo *)"
 
 -include ../../Makefile.include
 include ../../xbmc-addons.include

--- a/tools/depends/target/binary-addons/Makefile
+++ b/tools/depends/target/binary-addons/Makefile
@@ -1,0 +1,5 @@
+BUILDDIR := $(shell pwd)
+ADDONS = "pvr.argustv pvr.demo pvr.dvblink pvr.dvbviewer pvr.filmon pvr.hts pvr.iptvsimple pvr.mediaportal.tvserver pvr.mythtv pvr.nextpvr pvr.njoy pvr.vdr.vnsi pvr.vuplus pvr.wmc audioencoder.flac audioencoder.lame audioencoder.vorbis audioencoder.wav"
+
+-include ../../Makefile.include
+include ../../xbmc-addons.include

--- a/tools/depends/target/xbmc-audioencoder-addons/Makefile
+++ b/tools/depends/target/xbmc-audioencoder-addons/Makefile
@@ -1,5 +1,0 @@
-BUILDDIR := $(shell pwd)
-ADDONS = "audioencoder.flac audioencoder.lame audioencoder.vorbis audioencoder.wav"
-
--include ../../Makefile.include
-include ../../xbmc-addons.include

--- a/tools/depends/target/xbmc-pvr-addons/Makefile
+++ b/tools/depends/target/xbmc-pvr-addons/Makefile
@@ -1,5 +1,0 @@
-BUILDDIR := $(shell pwd)
-ADDONS = "pvr.argustv pvr.demo pvr.dvblink pvr.dvbviewer pvr.filmon pvr.hts pvr.iptvsimple pvr.mediaportal.tvserver pvr.mythtv pvr.nextpvr pvr.njoy pvr.vdr.vnsi pvr.vuplus pvr.wmc"
-
--include ../../Makefile.include
-include ../../xbmc-addons.include

--- a/tools/depends/xbmc-addons.include
+++ b/tools/depends/xbmc-addons.include
@@ -1,5 +1,6 @@
 ADDON_DEPS_DIR := $(BUILDDIR)/$(PLATFORM)/build/depends
 TOOLCHAIN_FILE = $(ADDON_DEPS_DIR)/share/Toolchain_binaddons.cmake
+ADDON_PROJECT_DIR = $(BUILDDIR)/../../../../project/cmake/addons
 
 ifeq ($(CROSS_COMPILING),yes)
   DEPS = $(TOOLCHAIN_FILE) $(abs_top_srcdir)/target/config-binaddons.site $(abs_top_srcdir)/target/Toolchain_binaddons.cmake $(CONFIG_SUB) $(CONFIG_GUESS)
@@ -43,7 +44,7 @@ distclean:
 	rm -rf $(PLATFORM) .installed-$(PLATFORM) native
 
 .installed-$(PLATFORM): $(DEPS)
-	cd ../../../../project/cmake/addons/ && (git clean -xfd || rm -rf CMakeCache.txt CMakeFiles cmake_install.cmake build/*)
+	cd $(ADDON_PROJECT_DIR) && (git clean -xfd || rm -rf CMakeCache.txt CMakeFiles cmake_install.cmake build/*)
 	mkdir -p $(PLATFORM)
 ifeq ($(PREFIX),)
 	@echo
@@ -57,9 +58,12 @@ endif
 	cd $(PLATFORM); \
          $(CMAKE) -DCMAKE_INSTALL_PREFIX=$(INSTALL_PREFIX) $(CMAKE_EXTRA) \
          $(TOOLCHAIN) \
-         -DADDONS_TO_BUILD=$(ADDONS) ../../../../../project/cmake/addons/ -DBUILD_DIR=$(BUILDDIR)/$(PLATFORM)/build ;\
-         $(MAKE);
+         -DADDONS_TO_BUILD=$(ADDONS) $(ADDON_PROJECT_DIR) -DBUILD_DIR=$(BUILDDIR)/$(PLATFORM)/build ;\
+         for addon in "$(ADDONS)"; do \
+           $(MAKE) $$addon && echo $$addon >> $(ADDON_PROJECT_DIR)/.success || echo $$addon >> $(ADDON_PROJECT_DIR)/.failure ;\
+         done
 ifneq ($(CROSS_COMPILING),yes)
+	@[ -f $(ADDON_PROJECT_DIR)/.failure ] && echo "Following Addons failed to build: $(shell cat $(ADDON_PROJECT_DIR)/.failure)"
 	@[ -w $(INSTALL_PREFIX) ] || $(MAKE) -C $(PLATFORM) install
 endif
 	touch $@


### PR DESCRIPTION
This is basically the brother of #6673 

It:
- combines the depends wrappers for binary addons into a single one in tools/depends/target/binary-addons
- gets rid of the hardcoded addons lists but instead builds all addons that have a description in project/cmake/addons/addons
- tracks build results of individual addons in project/cmake/addons/{.success,.failure}
- builds all bin addons even if a couple of them failed to build.

Result on jenkins looks like this then:

http://jenkins.kodi.tv/job/BINARY-ADDONS/platform_label=linux64/106/

(showing the successful and failed builds).

@wsnipex and @Montellese for review
