### PR TITLE
[UPower] Update logind/upower power management to 0.99 changes

### DIFF
--- a/xbmc/powermanagement/linux/LogindUPowerSyscall.cpp
+++ b/xbmc/powermanagement/linux/LogindUPowerSyscall.cpp
@@ -59,7 +59,12 @@ CLogindUPowerSyscall::CLogindUPowerSyscall()
 
   m_batteryLevel = 0;
   if (m_hasUPower)
+  {
+    m_upower99 = UPower99();
+    CLog::Log(LOGINFO, "UPower version 0.99 or higher %s", m_upower99 ? "true" : "false");
+
     UpdateBatteryLevel();
+  }
 
   DBusError error;
   dbus_error_init(&error);
@@ -307,4 +312,16 @@ void CLogindUPowerSyscall::ReleaseDelayLock()
   }
 }
 
+bool CLogindUPowerSyscall::UPower99()
+{
+  std::string version = CDBusUtil::GetVariant("org.freedesktop.UPower", "/org/freedesktop/UPower", "org.freedesktop.UPower","DaemonVersion").asString();
+
+  if(version.size()>=4)
+  {
+    if(version.substr(0,4).compare("0.9.") == 0)
+     return false;
+  }
+
+  return true;
+}
 #endif

--- a/xbmc/powermanagement/linux/LogindUPowerSyscall.cpp
+++ b/xbmc/powermanagement/linux/LogindUPowerSyscall.cpp
@@ -302,7 +302,18 @@ bool CLogindUPowerSyscall::PumpPowerEvents(IPowerEventsCallback *callback)
         }
         else if(m_warnLevel == UP_DEVICE_LEVEL_ACTION)
         {
-          Powerdown();
+          if (CanPowerdown())
+          {
+            Powerdown();
+          }
+          else if (CanHibernate())
+          {
+            Hibernate();
+          }
+          else if (CanSuspend())
+          {
+            Suspend();
+          }
         }
 
         CLog::Log(LOGDEBUG, "LogindUPowerSyscall - UPower warning level %i", m_warnLevel);

--- a/xbmc/powermanagement/linux/LogindUPowerSyscall.cpp
+++ b/xbmc/powermanagement/linux/LogindUPowerSyscall.cpp
@@ -84,7 +84,16 @@ CLogindUPowerSyscall::CLogindUPowerSyscall()
   dbus_bus_add_match(m_connection, "type='signal',interface='org.freedesktop.login1.Manager',member='PrepareForSleep'", NULL);
 
   if (m_hasUPower)
-    dbus_bus_add_match(m_connection, "type='signal',interface='org.freedesktop.UPower',member='DeviceChanged'", NULL);
+  {
+    if(m_upower99)
+    {
+      dbus_bus_add_match(m_connection, "type='signal',sender='org.freedesktop.UPower',interface='org.freedesktop.DBus.Properties',member='PropertiesChanged'", NULL);
+    }
+    else
+    {
+      dbus_bus_add_match(m_connection, "type='signal',interface='org.freedesktop.UPower',member='DeviceChanged'", NULL);
+    }
+  }
 
   dbus_connection_flush(m_connection);
   dbus_error_free(&error);
@@ -248,6 +257,9 @@ bool CLogindUPowerSyscall::PumpPowerEvents(IPowerEventsCallback *callback)
         }
 
         result = true;
+      }
+      else if (dbus_message_is_signal(msg, "org.freedesktop.DBus.Properties", "PropertiesChanged"))
+      {
       }
       else if (dbus_message_is_signal(msg, "org.freedesktop.UPower", "DeviceChanged"))
       {

--- a/xbmc/powermanagement/linux/LogindUPowerSyscall.h
+++ b/xbmc/powermanagement/linux/LogindUPowerSyscall.h
@@ -49,6 +49,7 @@ private:
   bool m_canReboot;
   bool m_hasUPower;
   bool m_lowBattery;
+  bool m_upower99;
   int m_batteryLevel;
   int m_delayLockFd; // file descriptor for the logind sleep delay lock
   void UpdateBatteryLevel();
@@ -56,6 +57,7 @@ private:
   void ReleaseDelayLock();
   static bool LogindSetPowerState(const char *state);
   static bool LogindCheckCapability(const char *capability);
+  static bool UPower99();
 };
 
 #endif

--- a/xbmc/powermanagement/linux/LogindUPowerSyscall.h
+++ b/xbmc/powermanagement/linux/LogindUPowerSyscall.h
@@ -50,6 +50,7 @@ private:
   bool m_hasUPower;
   bool m_lowBattery;
   bool m_upower99;
+  int m_warnLevel;
   int m_batteryLevel;
   int m_delayLockFd; // file descriptor for the logind sleep delay lock
   void UpdateBatteryLevel();


### PR DESCRIPTION
The UPower DBus handling changed with version 0.99 .

There is no longer an onLowBattery overall indicator of powerlevel and all battery devices now have a a per-device warning level indicating the power state.

http://cgit.freedesktop.org/upower/commit/?id=9b28dac1a1e764593532628b31342dad813ad013

Incorporated these changes into the logind/upower powermanager for linux. It now supports both versions.
