### PR TITLE
add helper for dealing with video dimensions

### DIFF
--- a/Kodi.xcodeproj/project.pbxproj
+++ b/Kodi.xcodeproj/project.pbxproj
@@ -178,6 +178,9 @@
 		395897151AAD94F00033D27C /* KeyboardLayoutManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 395897131AAD94F00033D27C /* KeyboardLayoutManager.cpp */; };
 		395897161AAD94F00033D27C /* KeyboardLayoutManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 395897131AAD94F00033D27C /* KeyboardLayoutManager.cpp */; };
 		395897171AAD94F00033D27C /* KeyboardLayoutManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 395897131AAD94F00033D27C /* KeyboardLayoutManager.cpp */; };
+		395938701AC163800053A590 /* VideoDimensions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3959386E1AC163800053A590 /* VideoDimensions.cpp */; };
+		395938711AC163800053A590 /* VideoDimensions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3959386E1AC163800053A590 /* VideoDimensions.cpp */; };
+		395938721AC163800053A590 /* VideoDimensions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3959386E1AC163800053A590 /* VideoDimensions.cpp */; };
 		395C29BC1A94733100EBC7AD /* Key.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 395C29BA1A94733100EBC7AD /* Key.cpp */; };
 		395C29BD1A94733100EBC7AD /* Key.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 395C29BA1A94733100EBC7AD /* Key.cpp */; };
 		395C29BE1A94733100EBC7AD /* Key.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 395C29BA1A94733100EBC7AD /* Key.cpp */; };
@@ -3537,6 +3540,8 @@
 		395897131AAD94F00033D27C /* KeyboardLayoutManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = KeyboardLayoutManager.cpp; sourceTree = "<group>"; };
 		395897141AAD94F00033D27C /* KeyboardLayoutManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KeyboardLayoutManager.h; sourceTree = "<group>"; };
 		395938731AC28F5A0053A590 /* EmbeddedArt.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EmbeddedArt.h; sourceTree = "<group>"; };
+		3959386E1AC163800053A590 /* VideoDimensions.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VideoDimensions.cpp; sourceTree = "<group>"; };
+		3959386F1AC163800053A590 /* VideoDimensions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VideoDimensions.h; sourceTree = "<group>"; };
 		395C29BA1A94733100EBC7AD /* Key.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Key.cpp; sourceTree = "<group>"; };
 		395C29BB1A94733100EBC7AD /* Key.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Key.h; sourceTree = "<group>"; };
 		395C29BF1A98A0A000EBC7AD /* Webinterface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Webinterface.cpp; sourceTree = "<group>"; };
@@ -6744,6 +6749,8 @@
 				E38E1E940D25F9FD00618676 /* VideoDatabase.h */,
 				36A9466B15CF201F00727135 /* VideoDbUrl.cpp */,
 				36A9466C15CF201F00727135 /* VideoDbUrl.h */,
+				3959386E1AC163800053A590 /* VideoDimensions.cpp */,
+				3959386F1AC163800053A590 /* VideoDimensions.h */,
 				E38E1E4A0D25F9FD00618676 /* VideoInfoDownloader.cpp */,
 				E38E1E4B0D25F9FD00618676 /* VideoInfoDownloader.h */,
 				E38E1E950D25F9FD00618676 /* VideoInfoScanner.cpp */,
@@ -10665,6 +10672,7 @@
 				F5AE40A513415D9E0004BD79 /* PlaylistOperations.cpp in Sources */,
 				F5AE40A613415D9E0004BD79 /* SystemOperations.cpp in Sources */,
 				F5AE40A713415D9E0004BD79 /* VideoLibrary.cpp in Sources */,
+				395938701AC163800053A590 /* VideoDimensions.cpp in Sources */,
 				F5AE40A813415D9E0004BD79 /* XBMCOperations.cpp in Sources */,
 				C84BF7341349BB74006D6FC9 /* JSONServiceDescription.cpp in Sources */,
 				384718D81325BA04000486D6 /* XBDateTime.cpp in Sources */,
@@ -11721,6 +11729,7 @@
 				DFF0F37217528350002DA3A4 /* PVRClients.cpp in Sources */,
 				DFF0F37317528350002DA3A4 /* PVRChannel.cpp in Sources */,
 				DFF0F37417528350002DA3A4 /* PVRChannelGroup.cpp in Sources */,
+				395938721AC163800053A590 /* VideoDimensions.cpp in Sources */,
 				395C29F81A98B44B00EBC7AD /* AddonModuleXbmcwsgi.cpp in Sources */,
 				DFF0F37517528350002DA3A4 /* PVRChannelGroupInternal.cpp in Sources */,
 				DFF0F37617528350002DA3A4 /* PVRChannelGroups.cpp in Sources */,
@@ -12155,6 +12164,7 @@
 				E4991154174E5CC300741B6D /* crypt.cpp in Sources */,
 				E4991155174E5CC300741B6D /* encname.cpp in Sources */,
 				E4991156174E5CC300741B6D /* errhnd.cpp in Sources */,
+				395938711AC163800053A590 /* VideoDimensions.cpp in Sources */,
 				E4991157174E5CC300741B6D /* extinfo.cpp in Sources */,
 				E4991158174E5CC300741B6D /* extract.cpp in Sources */,
 				E4991159174E5CC300741B6D /* filcreat.cpp in Sources */,

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -1168,6 +1168,7 @@
     <ClCompile Include="..\..\xbmc\video\jobs\VideoLibraryProgressJob.cpp" />
     <ClCompile Include="..\..\xbmc\video\jobs\VideoLibraryScanningJob.cpp" />
     <ClCompile Include="..\..\xbmc\video\PlayerController.cpp" />
+    <ClCompile Include="..\..\xbmc\video\VideoDimensions.cpp" />
     <ClCompile Include="..\..\xbmc\video\videosync\VideoSyncD3D.cpp" />
     <ClCompile Include="..\..\xbmc\video\VideoLibraryQueue.cpp" />
     <ClCompile Include="..\..\xbmc\video\VideoThumbLoader.cpp" />
@@ -2025,6 +2026,7 @@
     <ClInclude Include="..\..\xbmc\video\jobs\VideoLibraryProgressJob.h" />
     <ClInclude Include="..\..\xbmc\video\jobs\VideoLibraryScanningJob.h" />
     <ClInclude Include="..\..\xbmc\video\PlayerController.h" />
+    <ClInclude Include="..\..\xbmc\video\VideoDimensions.h" />
     <ClInclude Include="..\..\xbmc\video\videosync\VideoSync.h" />
     <ClInclude Include="..\..\xbmc\video\videosync\VideoSyncD3D.h" />
     <ClInclude Include="..\..\xbmc\video\VideoLibraryQueue.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -3076,6 +3076,9 @@
     </ClCompile>
     <ClCompile Include="..\..\xbmc\input\KeyboardLayoutManager.cpp">
       <Filter>input</Filter>
+	</ClCompile>
+    <ClCompile Include="..\..\xbmc\video\VideoDimensions.cpp">
+      <Filter>video</Filter>
     </ClCompile>
     <ClCompile Include="..\..\xbmc\music\CueInfoLoader.cpp">
       <Filter>music</Filter>
@@ -5961,6 +5964,9 @@
     </ClInclude>
     <ClInclude Include="..\..\xbmc\music\EmbeddedArt.h">
       <Filter>music</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\video\VideoDimensions.h">
+      <Filter>video</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -84,6 +84,7 @@
 #include "video/VideoThumbLoader.h"
 #include "music/MusicThumbLoader.h"
 #include "video/VideoDatabase.h"
+#include "video/VideoDimensions.h"
 #include "cores/IPlayer.h"
 #include "cores/AudioEngine/Utils/AEUtil.h"
 #include "cores/VideoRenderers/BaseRenderer.h"
@@ -1661,7 +1662,8 @@ std::string CGUIInfoManager::GetLabel(int info, int contextWindow, std::string *
   case VIDEOPLAYER_VIDEO_RESOLUTION:
     if(g_application.m_pPlayer->IsPlaying())
     {
-      return CStreamDetails::VideoDimsToResolutionDescription(m_videoInfo.width, m_videoInfo.height);
+      CVideoDimensions dimensions(m_videoInfo.width, m_videoInfo.height);
+      return dimensions.GetQuality();
     }
     break;
   case VIDEOPLAYER_AUDIO_CODEC:
@@ -5017,7 +5019,13 @@ std::string CGUIInfoManager::GetItemLabel(const CFileItem *item, int info, std::
     break;
   case LISTITEM_VIDEO_RESOLUTION:
     if (item->HasVideoInfoTag())
-      return CStreamDetails::VideoDimsToResolutionDescription(item->GetVideoInfoTag()->m_streamDetails.GetVideoWidth(), item->GetVideoInfoTag()->m_streamDetails.GetVideoHeight());
+    {
+      CVideoDimensions dimensions(
+        item->GetVideoInfoTag()->m_streamDetails.GetVideoWidth(),
+        item->GetVideoInfoTag()->m_streamDetails.GetVideoHeight());
+
+      return dimensions.GetQuality();
+    }
     break;
   case LISTITEM_VIDEO_ASPECT:
     if (item->HasVideoInfoTag())

--- a/xbmc/cores/playercorefactory/PlayerSelectionRule.cpp
+++ b/xbmc/cores/playercorefactory/PlayerSelectionRule.cpp
@@ -21,6 +21,7 @@
 #include "URL.h"
 #include "PlayerSelectionRule.h"
 #include "video/VideoInfoTag.h"
+#include "video/VideoDimensions.h"
 #include "utils/StreamDetails.h"
 #include "settings/Settings.h"
 #include "utils/log.h"
@@ -147,8 +148,12 @@ void CPlayerSelectionRule::GetPlayers(const CFileItem& item, VECPLAYERCORES &vec
 
     if (CompileRegExp(m_videoCodec, regExp) && !MatchesRegExp(streamDetails.GetVideoCodec(), regExp)) return;
 
+    CVideoDimensions dimensions(
+      streamDetails.GetVideoWidth(),
+      streamDetails.GetVideoHeight());
+
     if (CompileRegExp(m_videoResolution, regExp) &&
-        !MatchesRegExp(CStreamDetails::VideoDimsToResolutionDescription(streamDetails.GetVideoWidth(), streamDetails.GetVideoHeight()), regExp)) return;
+        !MatchesRegExp(dimensions.GetQuality(), regExp)) return;
 
     if (CompileRegExp(m_videoAspect, regExp) &&
         !MatchesRegExp(CStreamDetails::VideoAspectToAspectDescription(streamDetails.GetVideoAspect()),  regExp)) return;

--- a/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
@@ -22,6 +22,7 @@
 #include "GUIDialogFileBrowser.h"
 #include "music/MusicDatabase.h"
 #include "video/VideoDatabase.h"
+#include "video/VideoDimensions.h"
 #include "guilib/GUIWindowManager.h"
 #include "GUIDialogSelect.h"
 #include "filesystem/Directory.h"
@@ -330,6 +331,11 @@ void CGUIDialogSmartPlaylistRule::OnBrowse()
 
     videodatabase.GetTagsNav(basePath + "tags/", items, type);
     iLabel = 20459;
+  }
+  else if (m_rule.m_field == FieldVideoResolution)
+  {
+    for (const auto &quality : CVideoDimensions::GetQualities())
+      items.Add(CFileItemPtr(new CFileItem(quality.c_str())));
   }
   else
   { // TODO: Add browseability in here.

--- a/xbmc/playlists/SmartPlayList.h
+++ b/xbmc/playlists/SmartPlayList.h
@@ -27,6 +27,7 @@
 #include "dbwrappers/DatabaseQuery.h"
 #include "utils/SortUtils.h"
 #include "utils/XBMCTinyXML.h"
+#include "video/VideoDimensions.h"
 
 class CURL;
 class CVariant;
@@ -76,6 +77,7 @@ protected:
 
 private:
   std::string GetVideoResolutionQuery(const std::string &parameter) const;
+  std::string GetVideoDimensionsQuery(SResolutionBoundaries &boundaries) const;
   static std::string FormatLinkQuery(const char *field, const char *table, const MediaType& mediaType, const std::string& mediaField, const std::string& parameter);
 };
 

--- a/xbmc/utils/StreamDetails.cpp
+++ b/xbmc/utils/StreamDetails.cpp
@@ -541,32 +541,6 @@ void CStreamDetails::DetermineBestStreams(void)
   }  /* for each */
 }
 
-std::string CStreamDetails::VideoDimsToResolutionDescription(int iWidth, int iHeight)
-{
-  if (iWidth == 0 || iHeight == 0)
-    return "";
-
-  else if (iWidth <= 720 && iHeight <= 480)
-    return "480";
-  // 720x576 (PAL) (768 when rescaled for square pixels)
-  else if (iWidth <= 768 && iHeight <= 576)
-    return "576";
-  // 960x540 (sometimes 544 which is multiple of 16)
-  else if (iWidth <= 960 && iHeight <= 544)
-    return "540";
-  // 1280x720
-  else if (iWidth <= 1280 && iHeight <= 720)
-    return "720";
-  // 1920x1080
-  else if (iWidth <= 1920 && iHeight <= 1080)
-    return "1080";
-  // 4K
-  else if (iWidth * iHeight >= 6000000)
-    return "4K";
-  else
-    return "";
-}
-
 std::string CStreamDetails::VideoAspectToAspectDescription(float fAspect)
 {
   if (fAspect == 0.0f)

--- a/xbmc/utils/StreamDetails.h
+++ b/xbmc/utils/StreamDetails.h
@@ -98,7 +98,6 @@ public:
   bool operator ==(const CStreamDetails &that) const;
   bool operator !=(const CStreamDetails &that) const;
 
-  static std::string VideoDimsToResolutionDescription(int iWidth, int iHeight);
   static std::string VideoAspectToAspectDescription(float fAspect);
 
   bool HasItems(void) const { return m_vecItems.size() > 0; };

--- a/xbmc/utils/test/TestStreamDetails.cpp
+++ b/xbmc/utils/test/TestStreamDetails.cpp
@@ -18,7 +18,10 @@
  *
  */
 
+#include <tuple>
+#include <vector>
 #include "utils/StreamDetails.h"
+#include "video/VideoDimensions.h"
 
 #include "gtest/gtest.h"
 
@@ -75,10 +78,153 @@ TEST(TestStreamDetails, General)
   EXPECT_STREQ("left_right", a.GetStereoMode().c_str());
 }
 
-TEST(TestStreamDetails, VideoDimsToResolutionDescription)
+TEST(TestStreamDetails, VideoDimensionsToFidelityAndQuality)
 {
-  EXPECT_STREQ("1080",
-               CStreamDetails::VideoDimsToResolutionDescription(1920, 1080).c_str());
+  // Test data assembled from several different libraries using mediainfo
+  std::vector<std::tuple<std::string, std::string, int, int>> dataProvider =
+  {
+    { std::make_tuple("480", "SD", 528, 224) },
+    { std::make_tuple("480", "SD", 448, 256) },
+    { std::make_tuple("480", "SD", 608, 256) },
+    { std::make_tuple("480", "SD", 640, 256) },
+    { std::make_tuple("480", "SD", 640, 272) },
+    { std::make_tuple("480", "SD", 656, 272) },
+    { std::make_tuple("480", "SD", 512, 288) },
+    { std::make_tuple("480", "SD", 560, 304) },
+    { std::make_tuple("480", "SD", 576, 304) },
+    { std::make_tuple("480", "SD", 704, 304) },
+    { std::make_tuple("480", "SD", 720, 304) },
+    { std::make_tuple("480", "SD", 576, 320) },
+    { std::make_tuple("480", "SD", 592, 320) },
+    { std::make_tuple("480", "SD", 608, 320) },
+    { std::make_tuple("480", "SD", 708, 328) },
+    { std::make_tuple("480", "SD", 576, 336) },
+    { std::make_tuple("480", "SD", 608, 336) },
+    { std::make_tuple("480", "SD", 624, 336) },
+    { std::make_tuple("480", "SD", 640, 336) },
+    { std::make_tuple("480", "SD", 672, 336) },
+    { std::make_tuple("480", "SD", 706, 344) },
+    { std::make_tuple("480", "SD", 464, 352) },
+    { std::make_tuple("480", "SD", 624, 352) },
+    { std::make_tuple("480", "SD", 640, 352) },
+    { std::make_tuple("480", "SD", 704, 352) },
+    { std::make_tuple("480", "SD", 704, 358) },
+    { std::make_tuple("480", "SD", 718, 360) },
+    { std::make_tuple("480", "SD", 640, 368) },
+    { std::make_tuple("480", "SD", 720, 368) },
+    { std::make_tuple("480", "SD", 512, 384) },
+    { std::make_tuple("480", "SD", 688, 384) },
+    { std::make_tuple("480", "SD", 720, 384) },
+    { std::make_tuple("480", "SD", 716, 396) },
+    { std::make_tuple("480", "SD", 608, 400) },
+    { std::make_tuple("480", "SD", 720, 400) },
+    { std::make_tuple("480", "SD", 720, 416) },
+    { std::make_tuple("480", "SD", 648, 428) },
+    { std::make_tuple("480", "SD", 576, 432) },
+    { std::make_tuple("480", "SD", 708, 444) },
+    { std::make_tuple("480", "SD", 712, 460) },
+    { std::make_tuple("480", "SD", 720, 462) },
+    { std::make_tuple("480", "SD", 720, 464) },
+    { std::make_tuple("480", "SD", 708, 468) },
+    { std::make_tuple("480", "SD", 714, 470) },
+    { std::make_tuple("480", "SD", 696, 472) },
+    { std::make_tuple("480", "SD", 640, 480) },
+    { std::make_tuple("480", "SD", 672, 480) },
+    { std::make_tuple("480", "SD", 704, 480) },
+    { std::make_tuple("480", "SD", 716, 480) },
+    { std::make_tuple("480", "SD", 720, 480) },
+    { std::make_tuple("576", "SD", 704, 528) },
+    { std::make_tuple("576", "SD", 716, 548) },
+    { std::make_tuple("576", "SD", 720, 552) },
+    { std::make_tuple("576", "SD", 716, 560) },
+    { std::make_tuple("576", "SD", 720, 566) },
+    { std::make_tuple("576", "SD", 697, 576) },
+    { std::make_tuple("576", "SD", 698, 576) },
+    { std::make_tuple("576", "SD", 716, 576) },
+    { std::make_tuple("576", "SD", 720, 576) },
+    { std::make_tuple("576", "SD", 720, 592) },
+    { std::make_tuple("720", "HD", 1280, 464) },
+    { std::make_tuple("720", "HD", 1280, 528) },
+    { std::make_tuple("720", "HD", 1280, 532) },
+    { std::make_tuple("720", "HD", 1280, 534) },
+    { std::make_tuple("720", "HD", 1280, 536) },
+    { std::make_tuple("720", "HD", 1280, 538) },
+    { std::make_tuple("720", "HD", 1280, 542) },
+    { std::make_tuple("720", "HD", 1272, 544) },
+    { std::make_tuple("720", "HD", 1280, 544) },
+    { std::make_tuple("720", "HD", 1280, 546) },
+    { std::make_tuple("720", "HD", 1280, 568) },
+    { std::make_tuple("720", "HD", 1280, 572) },
+    { std::make_tuple("720", "HD", 1280, 688) },
+    { std::make_tuple("720", "HD", 1280, 690) },
+    { std::make_tuple("720", "HD", 1280, 692) },
+    { std::make_tuple("720", "HD", 1280, 694) },
+    { std::make_tuple("720", "HD", 1280, 696) },
+    { std::make_tuple("720", "HD", 1280, 714) },
+    { std::make_tuple("720", "HD", 1280, 716) },
+    { std::make_tuple("720", "HD", 1280, 718) },
+    { std::make_tuple("720", "HD", 960, 720) },
+    { std::make_tuple("720", "HD", 964, 720) },
+    { std::make_tuple("720", "HD", 992, 720) },
+    { std::make_tuple("720", "HD", 1194, 720) },
+    { std::make_tuple("720", "HD", 1200, 720) },
+    { std::make_tuple("720", "HD", 1264, 720) },
+    { std::make_tuple("720", "HD", 1274, 720) },
+    { std::make_tuple("720", "HD", 1280, 720) },
+    { std::make_tuple("1080", "HD", 1920, 752) },
+    { std::make_tuple("1080", "HD", 1920, 784) },
+    { std::make_tuple("1080", "HD", 1916, 796) },
+    { std::make_tuple("1080", "HD", 1920, 798) },
+    { std::make_tuple("1080", "HD", 1918, 800) },
+    { std::make_tuple("1080", "HD", 1920, 800) },
+    { std::make_tuple("1080", "HD", 1920, 802) },
+    { std::make_tuple("1080", "HD", 1920, 804) },
+    { std::make_tuple("1080", "HD", 1920, 808) },
+    { std::make_tuple("1080", "HD", 1920, 814) },
+    { std::make_tuple("1080", "HD", 1920, 816) },
+    { std::make_tuple("1080", "HD", 1920, 818) },
+    { std::make_tuple("1080", "HD", 1916, 820) },
+    { std::make_tuple("1080", "HD", 1920, 824) },
+    { std::make_tuple("1080", "HD", 1920, 856) },
+    { std::make_tuple("1080", "HD", 1844, 992) },
+    { std::make_tuple("1080", "HD", 1920, 1032) },
+    { std::make_tuple("1080", "HD", 1920, 1036) },
+    { std::make_tuple("1080", "HD", 1920, 1038) },
+    { std::make_tuple("1080", "HD", 1920, 1040) },
+    { std::make_tuple("1080", "HD", 1080, 1040) },
+    { std::make_tuple("1080", "HD", 1920, 1056) },
+    { std::make_tuple("1080", "HD", 1920, 1072) },
+    { std::make_tuple("1080", "HD", 1392, 1080) },
+    { std::make_tuple("1080", "HD", 1424, 1080) },
+    { std::make_tuple("1080", "HD", 1440, 1080) },
+    { std::make_tuple("1080", "HD", 1488, 1080) },
+    { std::make_tuple("1080", "HD", 1712, 1080) },
+    { std::make_tuple("1080", "HD", 1792, 1080) },
+    { std::make_tuple("1080", "HD", 1808, 1080) },
+    { std::make_tuple("1080", "HD", 1824, 1080) },
+    { std::make_tuple("1080", "HD", 1884, 1080) },
+    { std::make_tuple("1080", "HD", 1920, 1080) },
+    { std::make_tuple("1080", "HD", 3840, 1080) },
+    { std::make_tuple("4K", "HD", 4096, 1714) },
+    { std::make_tuple("4K", "HD", 4096, 1744) },
+    { std::make_tuple("4K", "HD", 3840, 2076) },
+    { std::make_tuple("4K", "HD", 3840, 2076) }
+  };
+
+  // Unpack each data set and check that the quality/fidelity matches
+  for (const auto &tuple : dataProvider)
+  {
+    std::string quality;
+    std::string fidelity;
+    int width;
+    int height;
+
+    std::tie(quality, fidelity, width, height) = tuple;
+
+    CVideoDimensions dimensions(width, height);
+    EXPECT_STREQ(quality.c_str(), dimensions.GetQuality().c_str());
+    EXPECT_STREQ(fidelity.c_str(), dimensions.GetFidelity().c_str());
+  }
 }
 
 TEST(TestStreamDetails, VideoAspectToAspectDescription)

--- a/xbmc/video/Makefile
+++ b/xbmc/video/Makefile
@@ -5,6 +5,7 @@ SRCS=Bookmark.cpp \
      Teletext.cpp \
      VideoDatabase.cpp \
      VideoDbUrl.cpp \
+     VideoDimensions.cpp \
      VideoInfoDownloader.cpp \
      VideoInfoScanner.cpp \
      VideoInfoTag.cpp \

--- a/xbmc/video/VideoDimensions.cpp
+++ b/xbmc/video/VideoDimensions.cpp
@@ -20,7 +20,7 @@
 
 #include "VideoDimensions.h"
 #include <algorithm>
-#include <limits>
+#include <climits>
 
 std::vector<SResolution> CVideoDimensions::resolutions =
 {

--- a/xbmc/video/VideoDimensions.cpp
+++ b/xbmc/video/VideoDimensions.cpp
@@ -27,10 +27,10 @@ std::vector<SResolution> CVideoDimensions::resolutions =
   { "480", "SD", { { 0, 720 }, { 0, 480 } } },
   // With invalid settings it's possible to end up with e.g. a 720x592 DVD rip
   { "576", "SD", { { 0, 768 }, { 480, 600 } } },
-  // 720p can be anything from 960x720 (1.33:1) to 1280x474 (2.70:1, e.g. Ben Hur)
-  { "720", "HD", { { 768, 1280 }, { 474, 720 } } },
-  // Full-SBS 3D can be 3840x1080
-  { "1080", "HD", { { 1280, 3840 }, { 540, 1080 } } },
+  // 720p can be anything from 960x720 (1.33:1) to 1280x464 (2.70:1, e.g. Ben Hur)
+  { "720", "HD", { { 768, 1280 }, { 460, 720 } } },
+  // Full-SBS 3D can be 3840x1080, some weird shit can be 1080x1040
+  { "1080", "HD", { { 1079, 3840 }, { 540, 1080 } } },
   // Full-SBS 4K 3D could be 8192x2160
   { "4K", "HD", { { 2048, 8192 }, { 1080, 2160 } } }
 };

--- a/xbmc/video/VideoDimensions.cpp
+++ b/xbmc/video/VideoDimensions.cpp
@@ -1,0 +1,118 @@
+/*
+ *      Copyright (C) 2005-2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "VideoDimensions.h"
+#include <algorithm>
+#include <limits>
+
+std::vector<SResolution> CVideoDimensions::resolutions =
+{
+  { "480", "SD", { { 0, 720 }, { 0, 480 } } },
+  // With invalid settings it's possible to end up with e.g. a 720x592 DVD rip
+  { "576", "SD", { { 0, 768 }, { 480, 600 } } },
+  // 720p can be anything from 960x720 (1.33:1) to 1280x474 (2.70:1, e.g. Ben Hur)
+  { "720", "HD", { { 768, 1280 }, { 474, 720 } } },
+  // Full-SBS 3D can be 3840x1080
+  { "1080", "HD", { { 1280, 3840 }, { 540, 1080 } } },
+  // Full-SBS 4K 3D could be 8192x2160
+  { "4K", "HD", { { 2048, 8192 }, { 1080, 2160 } } }
+};
+
+CVideoDimensions::CVideoDimensions(int width, int height) :
+  m_width(width),
+  m_height(height)
+{
+  // Find the resolution that matches these dimensions
+  auto it = std::find_if(
+    resolutions.cbegin(),
+    resolutions.cend(),
+    [this](const SResolution &resolution)
+  {
+    auto width = resolution.boundaries.width;
+    auto height = resolution.boundaries.height;
+
+    return m_width > width.min && m_width <= width.max &&
+      m_height > height.min && m_height <= height.max;
+  });
+
+  if (it != resolutions.cend())
+    m_resolution = *it;
+  else
+    m_resolution = SResolution();
+}
+
+std::string CVideoDimensions::GetQuality() const
+{
+  return m_resolution.quality;
+}
+
+std::string CVideoDimensions::GetFidelity() const
+{
+  return m_resolution.fidelity;
+}
+
+SResolutionBoundaries CVideoDimensions::GetBoundaries() const
+{
+  return m_resolution.boundaries;
+}
+
+SResolutionBoundaries CVideoDimensions::GetQualityBoundaries(const std::string &quality)
+{
+  auto it = std::find_if(
+    resolutions.cbegin(),
+    resolutions.cend(),
+    [&quality](const SResolution &resolution)
+  {
+    return resolution.quality == quality;
+  });
+
+  if (it != resolutions.cend())
+    return it->boundaries;
+
+  return SResolutionBoundaries();
+}
+
+SResolutionBoundaries CVideoDimensions::GetFidelityBoundaries(const std::string &fidelity)
+{
+  SResolutionBoundaries boundaries = { { INT_MAX, INT_MIN }, { INT_MAX, INT_MIN } };
+
+  for (const auto &resolution : resolutions)
+  {
+    if (resolution.fidelity != fidelity)
+      continue;
+
+    boundaries.width.min = std::min(boundaries.width.min, resolution.boundaries.width.min);
+    boundaries.width.max = std::max(boundaries.width.max, resolution.boundaries.width.max);
+    boundaries.height.min = std::min(boundaries.height.min, resolution.boundaries.height.min);
+    boundaries.height.max = std::max(boundaries.height.max, resolution.boundaries.height.max);
+  }
+
+  return boundaries;
+}
+
+const std::vector<std::string> CVideoDimensions::GetQualities()
+{
+  return { "480", "576", "720", "1080", "4K" };
+}
+
+const std::vector<std::string> CVideoDimensions::GetFidelities()
+{
+  return { "SD", "HD" };
+}

--- a/xbmc/video/VideoDimensions.h
+++ b/xbmc/video/VideoDimensions.h
@@ -1,0 +1,101 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <string>
+#include <vector>
+
+/*
+ * Represents the boundaries for a specific resolution, i.e. the limits that
+ * each dimension has
+ */
+struct SResolutionBoundaries
+{
+  struct SLimits
+  {
+    int min;
+    int max;
+  };
+
+  SLimits width;
+  SLimits height;
+};
+
+/*
+ * Represents a resolution, identified mainly by a quality, e.g. "720"
+ */
+struct SResolution
+{
+  std::string quality;
+  std::string fidelity;
+  SResolutionBoundaries boundaries;
+};
+
+class CVideoDimensions
+{
+public:
+  CVideoDimensions(int width, int height);
+  ~CVideoDimensions() {};
+
+  /*
+   * @return the quality for the resolution, e.g. "720"
+   */
+  std::string GetQuality() const;
+
+  /*
+   * @return the fidelity of the resolution, e.g. "SD" or "HD"
+   */
+  std::string GetFidelity() const;
+
+  /*
+   * @return the dimensional boundaries for this resolution
+   */
+  SResolutionBoundaries GetBoundaries() const;
+
+  /*
+   * @return the dimensional boundaries for the specified resolution quality
+   */
+  static SResolutionBoundaries GetQualityBoundaries(const std::string &quality);
+
+  /*
+   * @return the dimensional boundaries for the specified fidelity
+   */
+  static SResolutionBoundaries GetFidelityBoundaries(const std::string &fidelity);
+
+  /*
+   * @return a list of all possible qualities
+   */
+  static const std::vector<std::string> GetQualities();
+
+  /*
+   * @return a list of all possible fidelities
+   */
+  static const std::vector<std::string> GetFidelities();
+
+private:
+  int m_width;
+  int m_height;
+  SResolution m_resolution;
+
+  /*
+   * Resolution data for mapping a width and a height to a specific resolution
+   */
+  static std::vector<SResolution> resolutions;
+};


### PR DESCRIPTION
This is a first attempt at hopefully consolidating the logic behind determining whether a video is SD or HD etc. It replaces `CStreamDetails::VideoDimsToResolutionDescription` with a new helper class `CVideoDimensions` which provides the same functionality and more.

This also changes the logic for converting width and height to e.g. "720" to use a list of boundaries that each "descriptor" can have, e.g. for a file to be "720" its width must be between 960 and 1280 while its height must be between 540, 720. The way this is implemented means it should be easy to create unit tests to make sure this crap doesn't keep breaking everyone someone so much as looks at the code.

The use of boundaries to specify what "descriptor" a video item has can also be used backwards, e.g. in order to find all videos having a resolution matching "720". Before that was not possible because the boundaries weren't defined anywhere. This is needed in order to implement some of the suggestions in https://github.com/xbmc/xbmc/pull/6611

RFC:
- should we try to bake this into e.g. `CStreamDetailsVideo` instead? Somewhere else? There are lots of classes that have just two members (widht and height) so there's probably more room for consolidation
- The naming scheme could probably be more descriptive (no pun intended)

TODO:
- Not sure where `GetFidelity` could be used at the moment, I need to check the code for the lists (where the SD/HD icon is shown).

@mkortstiege @Montellese @topfs2 @fritsch 
