### PR TITLE
Cleanup addon (un)installing and enabling/disabling

### DIFF
--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -20,6 +20,8 @@
 
 #include "Addon.h"
 #include "AddonManager.h"
+#include "addons/Service.h"
+#include "ContextMenuManager.h"
 #include "settings/Settings.h"
 #include "filesystem/Directory.h"
 #include "filesystem/File.h"
@@ -618,6 +620,33 @@ AddonVersion CAddon::GetDependencyVersion(const std::string &dependencyID) const
   if (it != deps.end())
     return it->second.first;
   return AddonVersion("0.0.0");
+}
+
+void OnEnabled(const std::string& id)
+{
+  // If the addon is a special, call enabled handler
+  AddonPtr addon;
+  if (CAddonMgr::Get().GetAddon(id, addon, ADDON_PVRDLL))
+    return addon->OnEnabled();
+
+  if (CAddonMgr::Get().GetAddon(id, addon, ADDON_SERVICE))
+    std::static_pointer_cast<CService>(addon)->Start();
+
+  if (CAddonMgr::Get().GetAddon(id, addon, ADDON_CONTEXT_ITEM))
+    CContextMenuManager::Get().Register(std::static_pointer_cast<CContextItemAddon>(addon));
+}
+
+void OnDisabled(const std::string& id)
+{
+  AddonPtr addon;
+  if (CAddonMgr::Get().GetAddon(id, addon, ADDON_PVRDLL, false))
+    return addon->OnDisabled();
+
+  if (CAddonMgr::Get().GetAddon(id, addon, ADDON_SERVICE, false))
+    std::static_pointer_cast<CService>(addon)->Stop();
+
+  if (CAddonMgr::Get().GetAddon(id, addon, ADDON_CONTEXT_ITEM, false))
+    CContextMenuManager::Get().Unregister(std::static_pointer_cast<CContextItemAddon>(addon));
 }
 
 /**

--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -268,7 +268,6 @@ CAddon::CAddon(const cp_extension_t *ext)
   Props().libname = m_strLibName;
   BuildProfilePath();
   m_userSettingsPath = URIUtils::AddFileToFolder(Profile(), "settings.xml");
-  m_enabled = true;
   m_hasSettings = true;
   m_hasStrings = false;
   m_checkedStrings = false;
@@ -279,7 +278,6 @@ CAddon::CAddon(const cp_extension_t *ext)
 CAddon::CAddon(const cp_plugin_info_t *plugin)
   : m_props(plugin)
 {
-  m_enabled = true;
   m_hasSettings = false;
   m_hasStrings = false;
   m_checkedStrings = true;
@@ -294,7 +292,6 @@ CAddon::CAddon(const AddonProps &props)
   else m_strLibName = props.libname;
   BuildProfilePath();
   m_userSettingsPath = URIUtils::AddFileToFolder(Profile(), "settings.xml");
-  m_enabled = true;
   m_hasSettings = true;
   m_hasStrings = false;
   m_checkedStrings = false;
@@ -313,7 +310,6 @@ CAddon::CAddon(const CAddon &rhs)
   BuildProfilePath();
   m_userSettingsPath = URIUtils::AddFileToFolder(Profile(), "settings.xml");
   m_strLibName  = rhs.m_strLibName;
-  m_enabled = rhs.Enabled();
   m_hasStrings  = false;
   m_checkedStrings  = false;
 }

--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -44,6 +44,10 @@ const std::string   GetIcon(const TYPE &type);
 
 void OnEnabled(const std::string& id);
 void OnDisabled(const std::string& id);
+void OnPreInstall(const AddonPtr& addon);
+void OnPostInstall(const AddonPtr& addon, bool update, bool modal);
+void OnPreUnInstall(const AddonPtr& addon);
+void OnPostUnInstall(const AddonPtr& addon);
 
 class AddonProps : public ISerializable
 {
@@ -194,9 +198,8 @@ public:
    */
   virtual AddonPtr GetRunningInstance() const { return AddonPtr(); }
 
-  /*! \brief callbacks for special install/uninstall behaviour */
-  virtual bool OnPreInstall() { return false; };
-  virtual void OnPostInstall(bool restart, bool update, bool modal) {};
+  virtual void OnPreInstall() {};
+  virtual void OnPostInstall(bool update, bool modal) {};
   virtual void OnPreUnInstall() {};
   virtual void OnPostUnInstall() {};
   virtual bool CanInstall(const std::string& referer) { return true; }

--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -42,6 +42,9 @@ const std::string   TranslateType(const TYPE &type, bool pretty=false);
 const std::string   GetIcon(const TYPE &type);
       TYPE          TranslateType(const std::string &string);
 
+void OnEnabled(const std::string& id);
+void OnDisabled(const std::string& id);
+
 class AddonProps : public ISerializable
 {
 public:

--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -145,7 +145,8 @@ public:
   AddonProps& Props() { return m_props; }
   const std::string ID() const { return m_props.id; }
   const std::string Name() const { return m_props.name; }
-  bool Enabled() const { return m_enabled; }
+  /*! This lies. Ask CAddonMgr */
+  bool Enabled() const { return true; }
   virtual bool IsInUse() const { return false; };
   const AddonVersion Version() const { return m_props.version; }
   const AddonVersion MinVersion() const { return m_props.minversion; }
@@ -175,8 +176,6 @@ public:
    */
   bool MeetsVersion(const AddonVersion &version) const;
   virtual bool ReloadSettings();
-
-  void MarkAsDisabled() { m_enabled = false; }
 
   /*! \brief callback for when this add-on is disabled.
    Use to perform any needed actions (e.g. stop a service)
@@ -242,11 +241,6 @@ private:
   std::string        m_userSettingsPath;
   void BuildProfilePath();
 
-  virtual bool IsAddonLibrary() { return false; }
-
-  void Enable() { LoadStrings(); m_enabled = true; }
-  void Disable() { m_enabled = false; ClearStrings();}
-
   virtual bool LoadStrings();
   virtual void ClearStrings();
 
@@ -255,7 +249,6 @@ private:
   bool m_hasSettings;
 
   std::string m_profile;
-  bool        m_enabled;
   CLocalizeStrings  m_strings;
   std::map<std::string, std::string> m_settings;
 };
@@ -269,7 +262,6 @@ public:
   virtual AddonPtr Clone() const;
 
 private:
-  virtual bool IsAddonLibrary() { return true; }
   TYPE SetAddonType();
   const TYPE m_addonType; // addon type this library enhances
 };

--- a/xbmc/addons/AddonDatabase.h
+++ b/xbmc/addons/AddonDatabase.h
@@ -36,6 +36,9 @@ public:
   bool GetAddon(const std::string& addonID, ADDON::AddonPtr& addon);
   bool GetAddons(ADDON::VECADDONS& addons, const ADDON::TYPE &type = ADDON::ADDON_UNKNOWN);
 
+  /*! Get the addon IDs that has been set to disabled */
+  bool GetDisabled(std::vector<std::string>& addons);
+
   /*! \brief grab the (largest) add-on version for an add-on */
   ADDON::AddonVersion GetAddonVersion(const std::string &id);
 

--- a/xbmc/addons/AddonInstaller.h
+++ b/xbmc/addons/AddonInstaller.h
@@ -185,8 +185,8 @@ public:
   static bool GetAddonWithHash(const std::string& addonID, ADDON::AddonPtr& addon, std::string& hash);
 
 private:
-  bool OnPreInstall();
-  void OnPostInstall(bool reloadAddon);
+  void OnPreInstall();
+  void OnPostInstall();
   bool Install(const std::string &installFrom, const ADDON::AddonPtr& repo = ADDON::AddonPtr());
   bool DownloadPackage(const std::string &path, const std::string &dest);
 
@@ -223,7 +223,7 @@ private:
    */
   bool DeleteAddon(const std::string &addonFolder);
 
-  void OnPostUnInstall();
+  void ClearFavourites();
 
   ADDON::AddonPtr m_addon;
 };

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -666,7 +666,7 @@ bool CAddonMgr::CanAddonBeDisabled(const std::string& ID)
   CSingleLock lock(m_critSection);
   AddonPtr localAddon;
   // can't disable an addon that isn't installed
-  if (!IsAddonInstalled(ID, localAddon))
+  if (!GetAddon(ID, localAddon, ADDON_UNKNOWN, false))
     return false;
 
   // can't disable an addon that is in use
@@ -688,12 +688,7 @@ bool CAddonMgr::CanAddonBeDisabled(const std::string& ID)
 bool CAddonMgr::IsAddonInstalled(const std::string& ID)
 {
   AddonPtr tmp;
-  return IsAddonInstalled(ID, tmp);
-}
-
-bool CAddonMgr::IsAddonInstalled(const std::string& ID, AddonPtr& addon)
-{
-  return GetAddon(ID, addon, ADDON_UNKNOWN, false);
+  return GetAddon(ID, tmp, ADDON_UNKNOWN, false);
 }
 
 bool CAddonMgr::CanAddonBeInstalled(const std::string& ID)

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -629,12 +629,15 @@ void CAddonMgr::FindAddons()
   NotifyObservers(ObservableMessageAddons);
 }
 
-void CAddonMgr::RemoveAddon(const std::string& ID)
+void CAddonMgr::UnregisterAddon(const std::string& ID)
 {
+  CSingleLock lock(m_critSection);
+  m_disabled.erase(ID);
   if (m_cpluff && m_cp_context)
   {
-    m_cpluff->uninstall_plugin(m_cp_context,ID.c_str());
+    m_cpluff->uninstall_plugin(m_cp_context, ID.c_str());
     SetChanged();
+    lock.Leave();
     NotifyObservers(ObservableMessageAddons);
   }
 }

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -114,13 +114,11 @@ namespace ADDON
     void FindAddons();
     void RemoveAddon(const std::string& ID);
 
-    /* \brief Disable an addon
-     Triggers the database routine and saves the current addon state to cache.
-     \param ID id of the addon
-     \param disable whether to enable or disable. Defaults to true (disable)
-     \sa IsAddonDisabled,
-     */
-    bool DisableAddon(const std::string& ID, bool disable = true);
+    /*! \brief Disable an addon. Returns true on success, false on failure. */
+    bool DisableAddon(const std::string& ID);
+
+    /*! \brief Enable an addon. Returns true on success, false on failure. */
+    bool EnableAddon(const std::string& ID);
 
     /* \brief Check whether an addon has been disabled via DisableAddon.
      In case the disabled cache does not know about the current state the database routine will be used.
@@ -245,7 +243,7 @@ namespace ADDON
     CAddonMgr const& operator=(CAddonMgr const&);
     virtual ~CAddonMgr();
 
-    std::map<std::string, bool> m_disabled;
+    std::set<std::string> m_disabled;
     static std::map<TYPE, IAddonMgrCallback*> m_managers;
     CCriticalSection m_critSection;
     CAddonDatabase m_database;

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -112,7 +112,7 @@ namespace ADDON
     std::string GetTranslatedString(const cp_cfg_element_t *root, const char *tag);
     static AddonPtr AddonFromProps(AddonProps& props);
     void FindAddons();
-    void RemoveAddon(const std::string& ID);
+    void UnregisterAddon(const std::string& ID);
 
     /*! \brief Disable an addon. Returns true on success, false on failure. */
     bool DisableAddon(const std::string& ID);

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -140,12 +140,6 @@ namespace ADDON
     */
     bool IsAddonInstalled(const std::string& ID);
 
-    /* \brief Checks whether an addon is installed.
-     \param ID id of the addon
-     \param addon Installed addon
-     */
-    bool IsAddonInstalled(const std::string& ID, AddonPtr& addon);
-
     /* \brief Checks whether an addon can be installed. Broken addons can't be installed.
      \param ID id of the addon
      */

--- a/xbmc/addons/AddonStatusHandler.cpp
+++ b/xbmc/addons/AddonStatusHandler.cpp
@@ -155,7 +155,6 @@ void CAddonStatusHandler::Process()
   /* A unknown event has occurred */
   else if (m_status == ADDON_STATUS_UNKNOWN)
   {
-    //CAddonMgr::Get().DisableAddon(m_addon->ID());
     CGUIDialogOK* pDialog = (CGUIDialogOK*)g_windowManager.GetWindow(WINDOW_DIALOG_OK);
     if (!pDialog) return;
 

--- a/xbmc/addons/ContextItemAddon.cpp
+++ b/xbmc/addons/ContextItemAddon.cpp
@@ -88,15 +88,6 @@ void CContextItemAddon::OnPreUnInstall()
   CContextMenuManager::Get().Unregister(std::dynamic_pointer_cast<CContextItemAddon>(shared_from_this()));
 }
 
-void CContextItemAddon::OnDisabled()
-{
-  CContextMenuManager::Get().Unregister(std::dynamic_pointer_cast<CContextItemAddon>(shared_from_this()));
-}
-void CContextItemAddon::OnEnabled()
-{
-  CContextMenuManager::Get().Register(std::dynamic_pointer_cast<CContextItemAddon>(shared_from_this()));
-}
-
 bool CContextItemAddon::IsVisible(const CFileItemPtr& item) const
 {
   return item && m_visCondition->Get(item.get());

--- a/xbmc/addons/ContextItemAddon.cpp
+++ b/xbmc/addons/ContextItemAddon.cpp
@@ -63,31 +63,6 @@ CContextItemAddon::CContextItemAddon(const cp_extension_t *ext)
   }
 }
 
-bool CContextItemAddon::OnPreInstall()
-{
-  return CContextMenuManager::Get().Unregister(std::dynamic_pointer_cast<CContextItemAddon>(shared_from_this()));
-}
-
-void CContextItemAddon::OnPostInstall(bool restart, bool update, bool modal)
-{
-  if (restart)
-  {
-    // need to grab the local addon so we have the correct library path to run
-    AddonPtr localAddon;
-    if (CAddonMgr::Get().GetAddon(ID(), localAddon, ADDON_CONTEXT_ITEM))
-    {
-      ContextItemAddonPtr contextItem = std::dynamic_pointer_cast<CContextItemAddon>(localAddon);
-      if (contextItem)
-        CContextMenuManager::Get().Register(contextItem);
-    }
-  }
-}
-
-void CContextItemAddon::OnPreUnInstall()
-{
-  CContextMenuManager::Get().Unregister(std::dynamic_pointer_cast<CContextItemAddon>(shared_from_this()));
-}
-
 bool CContextItemAddon::IsVisible(const CFileItemPtr& item) const
 {
   return item && m_visCondition->Get(item.get());

--- a/xbmc/addons/ContextItemAddon.h
+++ b/xbmc/addons/ContextItemAddon.h
@@ -56,10 +56,6 @@ namespace ADDON
      */
     bool IsVisible(const CFileItemPtr& item) const;
 
-    virtual bool OnPreInstall();
-    virtual void OnPostInstall(bool restart, bool update, bool modal);
-    virtual void OnPreUnInstall();
-
   private:
     std::string m_label;
     std::string m_parent;

--- a/xbmc/addons/ContextItemAddon.h
+++ b/xbmc/addons/ContextItemAddon.h
@@ -59,8 +59,6 @@ namespace ADDON
     virtual bool OnPreInstall();
     virtual void OnPostInstall(bool restart, bool update, bool modal);
     virtual void OnPreUnInstall();
-    virtual void OnDisabled();
-    virtual void OnEnabled();
 
   private:
     std::string m_label;

--- a/xbmc/addons/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/GUIDialogAddonInfo.cpp
@@ -260,7 +260,10 @@ void CGUIDialogAddonInfo::OnEnable(bool enable)
   if (!enable && PromptIfDependency(24075, 24091))
     return;
 
-  CAddonMgr::Get().DisableAddon(m_localAddon->ID(), !enable);
+  if (enable)
+    CAddonMgr::Get().EnableAddon(m_localAddon->ID());
+  else
+    CAddonMgr::Get().DisableAddon(m_localAddon->ID());
   SetItem(m_item);
   UpdateControls();
   g_windowManager.SendMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE);

--- a/xbmc/addons/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/GUIDialogAddonInfo.cpp
@@ -240,12 +240,8 @@ void CGUIDialogAddonInfo::OnUninstall()
   if (!CGUIDialogYesNo::ShowAndGetInput(24037, 750, 0, 0))
     return;
 
-  // ensure the addon isn't disabled in our database
-  CAddonMgr::Get().DisableAddon(m_localAddon->ID(), false);
-
   CJobManager::GetInstance().AddJob(new CAddonUnInstallJob(m_localAddon),
                                     &CAddonInstaller::Get());
-  CAddonMgr::Get().RemoveAddon(m_localAddon->ID());
   Close();
 }
 
@@ -335,10 +331,12 @@ void CGUIDialogAddonInfo::OnRollback()
       database.BlacklistAddon(m_localAddon->ID(),m_rollbackVersions[j]);
     std::string path = "special://home/addons/packages/";
     path += m_localAddon->ID()+"-"+m_rollbackVersions[choice]+".zip";
+
+    //FIXME: this is probably broken
     // needed as cpluff won't downgrade
     if (!m_localAddon->IsType(ADDON_SERVICE))
       //we will handle this for service addons in CAddonInstallJob::OnPostInstall
-      CAddonMgr::Get().RemoveAddon(m_localAddon->ID());
+      CAddonMgr::Get().UnregisterAddon(m_localAddon->ID());
     CAddonInstaller::Get().InstallFromZip(path);
     database.RemoveAddonFromBlacklist(m_localAddon->ID(),m_rollbackVersions[choice]);
     Close();

--- a/xbmc/addons/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/GUIWindowAddonBrowser.cpp
@@ -653,7 +653,7 @@ int CGUIWindowAddonBrowser::SelectAddonID(const vector<ADDON::TYPE> &types, vect
 
         // if the addon is disabled we need to enable it
         if (CAddonMgr::Get().IsAddonDisabled(addon->ID()))
-          CAddonMgr::Get().DisableAddon(addon->ID(), false);
+          CAddonMgr::Get().EnableAddon(addon->ID());
       }
     }
 

--- a/xbmc/addons/IAddon.h
+++ b/xbmc/addons/IAddon.h
@@ -131,9 +131,6 @@ namespace ADDON
 
   private:
     friend class CAddonMgr;
-    virtual bool IsAddonLibrary() =0;
-    virtual void Enable() =0;
-    virtual void Disable() =0;
     virtual bool LoadStrings() =0;
     virtual void ClearStrings() =0;
   };

--- a/xbmc/addons/IAddon.h
+++ b/xbmc/addons/IAddon.h
@@ -120,8 +120,8 @@ namespace ADDON
     virtual void OnDisabled() =0;
     virtual void OnEnabled() =0;
     virtual AddonPtr GetRunningInstance() const=0;
-    virtual bool OnPreInstall() =0;
-    virtual void OnPostInstall(bool restart, bool update, bool modal) =0;
+    virtual void OnPreInstall() =0;
+    virtual void OnPostInstall(bool update, bool modal) =0;
     virtual void OnPreUnInstall() =0;
     virtual void OnPostUnInstall() =0;
     virtual bool CanInstall(const std::string& referer) =0;

--- a/xbmc/addons/LanguageResource.cpp
+++ b/xbmc/addons/LanguageResource.cpp
@@ -108,14 +108,9 @@ bool CLanguageResource::IsInUse() const
   return StringUtils::EqualsNoCase(CSettings::Get().GetString(LANGUAGE_SETTING), ID());
 }
 
-bool CLanguageResource::OnPreInstall()
+void CLanguageResource::OnPostInstall(bool update, bool modal)
 {
-  return IsInUse();
-}
-
-void CLanguageResource::OnPostInstall(bool restart, bool update, bool modal)
-{
-  if (restart ||
+  if (IsInUse() ||
      (!update && !modal && CGUIDialogYesNo::ShowAndGetInput(Name(), g_localizeStrings.Get(24132), "", "")))
   {
     CGUIDialogKaiToast *toast = (CGUIDialogKaiToast *)g_windowManager.GetWindow(WINDOW_DIALOG_KAI_TOAST);

--- a/xbmc/addons/LanguageResource.h
+++ b/xbmc/addons/LanguageResource.h
@@ -40,8 +40,7 @@ public:
 
   virtual bool IsInUse() const;
 
-  virtual bool OnPreInstall();
-  virtual void OnPostInstall(bool restart, bool update, bool modal);
+  virtual void OnPostInstall(bool update, bool modal);
 
   virtual bool IsAllowed(const std::string &file) const;
 

--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -193,14 +193,6 @@ bool CRepository::Parse(const DirInfo& dir, VECADDONS &result)
   return false;
 }
 
-void CRepository::OnPostInstall(bool restart, bool update, bool modal)
-{
-  VECADDONS addons;
-  AddonPtr repo(new CRepository(*this));
-  addons.push_back(repo);
-  CJobManager::GetInstance().AddJob(new CRepositoryUpdateJob(addons), &CAddonInstaller::Get());
-}
-
 void CRepository::OnPostUnInstall()
 {
   CAddonDatabase database;

--- a/xbmc/addons/Repository.h
+++ b/xbmc/addons/Repository.h
@@ -58,7 +58,6 @@ namespace ADDON
     static bool Parse(const DirInfo& dir, VECADDONS& addons);
     static std::string FetchChecksum(const std::string& url);
 
-    virtual void OnPostInstall(bool restart, bool update, bool modal);
     virtual void OnPostUnInstall();
 
   private:

--- a/xbmc/addons/Service.cpp
+++ b/xbmc/addons/Service.cpp
@@ -113,16 +113,6 @@ void CService::BuildServiceType()
   }
 }
 
-void CService::OnDisabled()
-{
-  Stop();
-}
-
-void CService::OnEnabled()
-{
-  Start();
-}
-
 bool CService::OnPreInstall()
 {
   // make sure the addon is stopped

--- a/xbmc/addons/Service.cpp
+++ b/xbmc/addons/Service.cpp
@@ -113,36 +113,4 @@ void CService::BuildServiceType()
   }
 }
 
-bool CService::OnPreInstall()
-{
-  // make sure the addon is stopped
-  AddonPtr localAddon; // need to grab the local addon so we have the correct library path to stop
-  if (CAddonMgr::Get().GetAddon(ID(), localAddon, ADDON_SERVICE, false))
-  {
-    std::shared_ptr<CService> service = std::dynamic_pointer_cast<CService>(localAddon);
-    if (service)
-      service->Stop();
-  }
-  return !CAddonMgr::Get().IsAddonDisabled(ID());
-}
-
-void CService::OnPostInstall(bool restart, bool update, bool modal)
-{
-  if (restart) // reload/start it if it was running
-  {
-    AddonPtr localAddon; // need to grab the local addon so we have the correct library path to stop
-    if (CAddonMgr::Get().GetAddon(ID(), localAddon, ADDON_SERVICE, false))
-    {
-      std::shared_ptr<CService> service = std::dynamic_pointer_cast<CService>(localAddon);
-      if (service)
-        service->Start();
-    }
-  }
-}
-
-void CService::OnPreUnInstall()
-{
-  Stop();
-}
-
 }

--- a/xbmc/addons/Service.h
+++ b/xbmc/addons/Service.h
@@ -47,9 +47,6 @@ namespace ADDON
     bool Stop();
     TYPE GetServiceType() { return m_type; }
     START_OPTION GetStartOption() { return m_startOption; }
-    virtual bool OnPreInstall();
-    virtual void OnPostInstall(bool restart, bool update, bool modal);
-    virtual void OnPreUnInstall();
 
   protected:
     void BuildServiceType();

--- a/xbmc/addons/Service.h
+++ b/xbmc/addons/Service.h
@@ -47,8 +47,6 @@ namespace ADDON
     bool Stop();
     TYPE GetServiceType() { return m_type; }
     START_OPTION GetStartOption() { return m_startOption; }
-    virtual void OnDisabled();
-    virtual void OnEnabled();
     virtual bool OnPreInstall();
     virtual void OnPostInstall(bool restart, bool update, bool modal);
     virtual void OnPreUnInstall();

--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -276,20 +276,15 @@ const INFO::CSkinVariableString* CSkinInfo::CreateSkinVariable(const std::string
   return m_includes.CreateSkinVariable(name, context);
 }
 
-bool CSkinInfo::OnPreInstall()
+void CSkinInfo::OnPreInstall()
 {
-  // check whether this is an active skin - we need to unload it if so
   if (IsInUse())
-  {
     CApplicationMessenger::Get().ExecBuiltIn("UnloadSkin", true);
-    return true;
-  }
-  return false;
 }
 
-void CSkinInfo::OnPostInstall(bool restart, bool update, bool modal)
+void CSkinInfo::OnPostInstall(bool update, bool modal)
 {
-  if (restart || (!update && !modal && CGUIDialogYesNo::ShowAndGetInput(Name(), g_localizeStrings.Get(24099),"","")))
+  if (IsInUse() || (!update && !modal && CGUIDialogYesNo::ShowAndGetInput(Name(), g_localizeStrings.Get(24099),"","")))
   {
     CGUIDialogKaiToast *toast = (CGUIDialogKaiToast *)g_windowManager.GetWindow(WINDOW_DIALOG_KAI_TOAST);
     if (toast)

--- a/xbmc/addons/Skin.h
+++ b/xbmc/addons/Skin.h
@@ -118,8 +118,8 @@ public:
   static void SettingOptionsSkinThemesFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data);
   static void SettingOptionsStartupWindowsFiller(const CSetting *setting, std::vector< std::pair<std::string, int> > &list, int &current, void *data);
 
-  virtual bool OnPreInstall();
-  virtual void OnPostInstall(bool restart, bool update, bool modal);
+  virtual void OnPreInstall();
+  virtual void OnPostInstall(bool update, bool modal);
 protected:
   /*! \brief Given a resolution, retrieve the corresponding directory name
    \param res RESOLUTION to translate

--- a/xbmc/addons/UISoundsResource.cpp
+++ b/xbmc/addons/UISoundsResource.cpp
@@ -43,7 +43,7 @@ bool CUISoundsResource::IsInUse() const
   return CSettings::Get().GetString("lookandfeel.soundskin") == ID();
 }
 
-void CUISoundsResource::OnPostInstall(bool restart, bool update, bool modal)
+void CUISoundsResource::OnPostInstall(bool update, bool modal)
 {
   if (IsInUse())
     g_audioManager.Load();

--- a/xbmc/addons/UISoundsResource.h
+++ b/xbmc/addons/UISoundsResource.h
@@ -35,7 +35,7 @@ public:
   virtual bool IsAllowed(const std::string &file) const;
 
   virtual bool IsInUse() const;
-  virtual void OnPostInstall(bool restart, bool update, bool modal);
+  virtual void OnPostInstall(bool update, bool modal);
 
 private:
   CUISoundsResource(const CUISoundsResource &rhs) : CResource(rhs) {}

--- a/xbmc/interfaces/json-rpc/AddonsOperations.cpp
+++ b/xbmc/interfaces/json-rpc/AddonsOperations.cpp
@@ -152,10 +152,8 @@ JSONRPC_STATUS CAddonsOperations::SetAddonEnabled(const std::string &method, ITr
   else
     return InvalidParams;
 
-  if (!CAddonMgr::Get().DisableAddon(id, disabled))
-      return InvalidParams;
-
-  return ACK;
+  bool success = disabled ? CAddonMgr::Get().DisableAddon(id) : CAddonMgr::Get().EnableAddon(id);
+  return success ? ACK : InvalidParams;
 }
 
 JSONRPC_STATUS CAddonsOperations::ExecuteAddon(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -95,14 +95,13 @@ AddonPtr CPVRClient::GetRunningInstance() const
   return CAddon::GetRunningInstance();
 }
 
-bool CPVRClient::OnPreInstall()
+void CPVRClient::OnPreInstall()
 {
   // stop the pvr manager, so running pvr add-ons are stopped and closed
   PVR::CPVRManager::Get().Stop();
-  return false;
 }
 
-void CPVRClient::OnPostInstall(bool restart, bool update, bool modal)
+void CPVRClient::OnPostInstall(bool update, bool modal)
 {
   // (re)start the pvr manager
   PVR::CPVRManager::Get().Start(true);

--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -61,8 +61,8 @@ namespace PVR
     virtual void OnDisabled();
     virtual void OnEnabled();
     virtual ADDON::AddonPtr GetRunningInstance() const;
-    virtual bool OnPreInstall();
-    virtual void OnPostInstall(bool restart, bool update, bool modal);
+    virtual void OnPreInstall();
+    virtual void OnPostInstall(bool update, bool modal);
     virtual void OnPreUnInstall();
     virtual void OnPostUnInstall();
     virtual bool CanInstall(const std::string &referer);

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -1150,7 +1150,7 @@ bool CPVRClients::UpdateAndInitialiseClients(bool bInitialiseAllClients /* = fal
     for (VECADDONS::iterator it = disableAddons.begin(); it != disableAddons.end(); ++it)
     {
       // disable in the add-on db
-      CAddonMgr::Get().DisableAddon((*it)->ID(), true);
+      CAddonMgr::Get().DisableAddon((*it)->ID());
 
       // remove from the pvr add-on list
       VECADDONS::iterator addonPtr = std::find(m_addons.begin(), m_addons.end(), *it);
@@ -1245,7 +1245,7 @@ bool CPVRClients::AutoconfigureClients(void)
         progressHandle->MarkFinished();
 
         /** enable the add-on */
-        CAddonMgr::Get().DisableAddon((*it)->ID(), false);
+        CAddonMgr::Get().EnableAddon((*it)->ID());
         CSingleLock lock(m_critSection);
         m_addons.push_back(*it);
         bReturn = true;
@@ -1312,7 +1312,7 @@ bool CPVRClients::UpdateAddons(void)
     if (bDisable)
     {
       CLog::Log(LOGDEBUG, "%s - disabling add-on '%s'", __FUNCTION__, (*it)->Name().c_str());
-      CAddonMgr::Get().DisableAddon((*it)->ID(), true);
+      CAddonMgr::Get().DisableAddon((*it)->ID());
       usableClients--;
     }
   }


### PR DESCRIPTION
Sorry for the one big 'fix things' commit, but I lost track. It mainly moves all the On\* functions to central place because that polymorphic stuff isn't going to work. Another problem with that is that they may get called on the "wrong" instance leading to weird hacks as seen in Service.cpp
- Fixes OnPre(Post)Install never getting called for secondary extension points. Same for enable/disable.
- Fixes race conditions caused by the uninstaller enabling the addon right before it uninstalls it; possibly leading to all kinds of weird issues. E.g uninstalling a disabled service addon will currently start and run it while files are being deleted from the file system.
- And cleans up bookkeeping of disabled addon in the manager; changing it to only keep track of the ones disabled and query db _only_ when status change. Currently `IsAddonDisabled` keeps every parameter called for it in a map indefinite, which can grow quite large. E.g by browsing the repo this function will be called for every single addon in the repo.
