### PR TITLE
[EPG] Fix CEpgInfoTag::Title() regression

### DIFF
--- a/xbmc/epg/EpgInfoTag.cpp
+++ b/xbmc/epg/EpgInfoTag.cpp
@@ -322,7 +322,7 @@ std::string CEpgInfoTag::Title(bool bOverrideParental /* = false */) const
 
   if (!bOverrideParental && bParentalLocked)
     strTitle = g_localizeStrings.Get(19266); // parental locked
-  else if (strTitle.empty() && !CSettings::Get().GetBool("epg.hidenoinfoavailable"))
+  else if (m_strTitle.empty() && !CSettings::Get().GetBool("epg.hidenoinfoavailable"))
     strTitle = g_localizeStrings.Get(19055); // no information available
   else
     strTitle = m_strTitle;


### PR DESCRIPTION
Fixes a regression introduced by https://github.com/xbmc/xbmc/commit/cdbca43e46a3126bbf124e6b3b281fbdd988526c

"No information available" for all EPG items (except for those with parental lock) was displayed instead of real title.
