### PR TITLE
[pvr] various optimisations and fixes for CPVRChannelGroup

### DIFF
--- a/xbmc/epg/Epg.cpp
+++ b/xbmc/epg/Epg.cpp
@@ -163,7 +163,7 @@ void CEpg::Cleanup(void)
 void CEpg::Cleanup(const CDateTime &Time)
 {
   CSingleLock lock(m_critSection);
-  for (map<CDateTime, CEpgInfoTagPtr>::iterator it = m_tags.begin(); it != m_tags.end(); it != m_tags.end() ? it++ : it)
+  for (map<CDateTime, CEpgInfoTagPtr>::iterator it = m_tags.begin(); it != m_tags.end();)
   {
     if (it->second->EndAsUTC() < Time)
     {
@@ -171,7 +171,11 @@ void CEpg::Cleanup(const CDateTime &Time)
         m_nowActiveStart.SetValid(false);
 
       it->second->ClearTimer();
-      m_tags.erase(it++);
+      it = m_tags.erase(it);
+    }
+    else
+    {
+      ++it;
     }
   }
 }

--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -260,7 +260,8 @@ int CPVRDatabase::Get(CPVRChannelGroupInternal &results)
         CLog::Log(LOGDEBUG, "PVR - %s - channel '%s' loaded from the database", __FUNCTION__, channel->m_strChannelName.c_str());
 #endif
         PVRChannelGroupMember newMember = { channel, (unsigned int)m_pDS->fv("iChannelNumber").get_asInt() };
-        results.m_members.push_back(newMember);
+        results.m_sortedMembers.push_back(newMember);
+        results.m_members.insert(std::make_pair(channel->StorageId(), newMember));
 
         m_pDS->next();
         ++iReturn;
@@ -407,7 +408,7 @@ bool CPVRDatabase::RemoveStaleChannelsFromGroup(const CPVRChannelGroup &group)
     }
   }
 
-  if (group.m_members.size() > 0)
+  if (group.HasChannels())
   {
     std::vector<int> currentMembers;
     if (GetCurrentGroupMembers(group, currentMembers))
@@ -520,7 +521,8 @@ int CPVRDatabase::Get(CPVRChannelGroup &group)
           CLog::Log(LOGDEBUG, "PVR - %s - channel '%s' loaded from the database", __FUNCTION__, channel->m_strChannelName.c_str());
 #endif
           PVRChannelGroupMember newMember = { channel, (unsigned int)iChannelNumber };
-          group.m_members.push_back(newMember);
+          group.m_sortedMembers.push_back(newMember);
+          group.m_members.insert(std::make_pair(channel->StorageId(), newMember));
           iReturn++;
         }
         else
@@ -553,10 +555,10 @@ bool CPVRDatabase::PersistChannels(CPVRChannelGroup &group)
 {
   bool bReturn(true);
 
-  for (std::vector<PVRChannelGroupMember>::iterator it = group.m_members.begin(); it != group.m_members.end(); ++it)
+  for (PVR_CHANNEL_GROUP_MEMBERS::iterator it = group.m_members.begin(); it != group.m_members.end(); ++it)
   {
-    if ((*it).channel->IsChanged() || (*it).channel->IsNew())
-      bReturn &= Persist(*(*it).channel);
+    if (it->second.channel->IsChanged() || it->second.channel->IsNew())
+      bReturn &= Persist(*it->second.channel);
   }
 
   bReturn &= CommitInsertQueries();
@@ -565,33 +567,31 @@ bool CPVRDatabase::PersistChannels(CPVRChannelGroup &group)
   {
     std::string strQuery;
     std::string strValue;
-    for (std::vector<PVRChannelGroupMember>::iterator it = group.m_members.begin(); it != group.m_members.end(); ++it)
+    for (PVR_CHANNEL_GROUP_MEMBERS::iterator it = group.m_members.begin(); it != group.m_members.end(); ++it)
     {
-      strQuery = PrepareSQL("iUniqueId = %u AND iClientId = %u", (*it).channel->UniqueID(), (*it).channel->ClientID());
+      strQuery = PrepareSQL("iUniqueId = %u AND iClientId = %u", it->second.channel->UniqueID(), it->second.channel->ClientID());
       strValue = GetSingleValue("channels", "idChannel", strQuery);
       if (!strValue.empty() && StringUtils::IsInteger(strValue))
-        (*it).channel->SetChannelID(atoi(strValue.c_str()));
+        it->second.channel->SetChannelID(atoi(strValue.c_str()));
     }
   }
 
   return bReturn;
 }
 
-bool CPVRDatabase::PersistGroupMembers(CPVRChannelGroup &group)
+bool CPVRDatabase::PersistGroupMembers(const CPVRChannelGroup &group)
 {
   bool bReturn = true;
   bool bRemoveChannels = true;
   std::string strQuery;
   CSingleLock lock(group.m_critSection);
 
-  if (group.m_members.size() > 0)
+  if (group.HasChannels())
   {
-    for (unsigned int iChannelPtr = 0; iChannelPtr < group.m_members.size(); iChannelPtr++)
+    for (PVR_CHANNEL_GROUP_SORTED_MEMBERS::const_iterator it = group.m_sortedMembers.begin(); it != group.m_sortedMembers.end(); ++it)
     {
-      PVRChannelGroupMember member = group.m_members.at(iChannelPtr);
-
       std::string strWhereClause = PrepareSQL("idChannel = %u AND idGroup = %u AND iChannelNumber = %u AND iSubChannelNumber = %u",
-          member.channel->ChannelID(), group.GroupID(), member.iChannelNumber, member.iSubChannelNumber);
+          (*it).channel->ChannelID(), group.GroupID(), (*it).iChannelNumber, (*it).iSubChannelNumber);
 
       std::string strValue = GetSingleValue("map_channelgroups_channels", "idChannel", strWhereClause);
       if (strValue.empty())
@@ -599,7 +599,7 @@ bool CPVRDatabase::PersistGroupMembers(CPVRChannelGroup &group)
         strQuery = PrepareSQL("REPLACE INTO map_channelgroups_channels ("
             "idGroup, idChannel, iChannelNumber, iSubChannelNumber) "
             "VALUES (%i, %i, %i, %i);",
-            group.GroupID(), member.channel->ChannelID(), member.iChannelNumber, member.iSubChannelNumber);
+            group.GroupID(), (*it).channel->ChannelID(), (*it).iChannelNumber, (*it).iSubChannelNumber);
         QueueInsertQuery(strQuery);
       }
     }

--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -150,7 +150,7 @@ void CPVRDatabase::UpdateTables(int iVersion)
     {
       /** try to find an add-on that matches the sUid */
       iAddonId = -1;
-      for (VECADDONS::iterator it = addons.begin(); iAddonId <= 0 && it != addons.end(); ++it)
+      for (VECADDONS::iterator it = addons.begin(); iAddonId <= 0 && it != addons.end();)
       {
         if ((*it)->ID() == m_pDS->fv(1).get_asString())
         {
@@ -168,8 +168,16 @@ void CPVRDatabase::UpdateTables(int iVersion)
             m_pDS->exec(strQuery);
 
             /** no need to check this add-on again */
-            addons.erase(it);
+            it = addons.erase(it);
           }
+          else
+          {
+            ++it;
+          }
+        }
+        else
+        {
+          ++it;
         }
       }
     }

--- a/xbmc/pvr/PVRDatabase.h
+++ b/xbmc/pvr/PVRDatabase.h
@@ -189,7 +189,7 @@ namespace PVR
     void UpdateTables(int version);
     virtual int GetMinSchemaVersion() const { return 11; }
 
-    bool PersistGroupMembers(CPVRChannelGroup &group);
+    bool PersistGroupMembers(const CPVRChannelGroup &group);
 
     bool PersistChannels(CPVRChannelGroup &group);
 

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -1252,9 +1252,9 @@ bool CPVRManager::StartPlayback(PlaybackType type /* = PlaybackTypeAny */)
     if (channelGroup)
     {
       // try to start playback of first channel in this group
-      CFileItemPtr channel = channelGroup->GetByIndex(0);
-      if (channel && channel->HasPVRChannelInfoTag())
-        bReturn = StartPlayback(channel->GetPVRChannelInfoTag(), false);
+      std::vector<PVRChannelGroupMember> groupMembers(channelGroup->GetMembers());
+      if (!groupMembers.empty())
+        bReturn = StartPlayback((*groupMembers.begin()).channel, false);
     }
   }
 

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -115,6 +115,15 @@ int CPVRClients::GetClientId(const AddonPtr client) const
   return -1;
 }
 
+int CPVRClients::GetClientId(const std::string& strId) const
+{
+  CSingleLock lock(m_critSection);
+  std::map<std::string, int>::const_iterator it = m_addonNameIds.find(strId);
+  return it != m_addonNameIds.end() ?
+      it->second :
+      -1;
+}
+
 bool CPVRClients::GetClient(int iClientId, PVR_CLIENT &addon) const
 {
   bool bReturn(false);
@@ -249,6 +258,14 @@ bool CPVRClients::GetClientName(int iClientId, std::string &strName) const
     strName = client->GetFriendlyName();
 
   return bReturn;
+}
+
+std::string CPVRClients::GetClientAddonId(int iClientId) const
+{
+  PVR_CLIENT client;
+  return GetClient(iClientId, client) ?
+      client->ID() :
+      "";;
 }
 
 int CPVRClients::GetConnectedClients(PVR_CLIENTMAP &clients) const
@@ -1033,6 +1050,7 @@ int CPVRClients::RegisterClient(AddonPtr client)
       // create a new client instance
       addon = std::dynamic_pointer_cast<CPVRClient>(client);
       m_clientMap.insert(std::make_pair(iClientId, addon));
+      m_addonNameIds.insert(make_pair(addon->ID(), iClientId));
     }
   }
 

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -265,7 +265,7 @@ std::string CPVRClients::GetClientAddonId(int iClientId) const
   PVR_CLIENT client;
   return GetClient(iClientId, client) ?
       client->ID() :
-      "";;
+      "";
 }
 
 int CPVRClients::GetConnectedClients(PVR_CLIENTMAP &clients) const

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -147,6 +147,13 @@ namespace PVR
     bool GetClientName(int iClientId, std::string &strName) const;
 
     /*!
+     * Get the add-on ID of the client
+     * @param iClientId The db id of the client
+     * @return The add-on id
+     */
+    std::string GetClientAddonId(int iClientId) const;
+
+    /*!
      * @bried Get all connected clients.
      * @param clients Store the active clients in this map.
      * @return The amount of added clients.
@@ -617,6 +624,8 @@ namespace PVR
      */
     bool RestartManagerOnAddonDisabled(void) const { return m_bRestartManagerOnAddonDisabled; }
 
+    int GetClientId(const std::string& strId) const;
+
   private:
     /*!
      * @brief Update add-ons from the AddonManager
@@ -701,5 +710,6 @@ namespace PVR
     CCriticalSection      m_critSection;
     std::map<int, time_t> m_connectionAttempts;       /*!< last connection attempt per add-on */
     bool                  m_bRestartManagerOnAddonDisabled; /*!< true to restart the manager when an add-on is enabled/disabled */
+    std::map<std::string, int> m_addonNameIds; /*!< map add-on names to IDs */
   };
 }

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -380,23 +380,6 @@ bool CPVRChannel::IsEmpty() const
 
 /********** Client related channel methods **********/
 
-bool CPVRChannel::SetUniqueID(int iUniqueId)
-{
-  CSingleLock lock(m_critSection);
-
-  if (m_iUniqueId != iUniqueId)
-  {
-    /* update the unique ID */
-    m_iUniqueId = iUniqueId;
-    SetChanged();
-    m_bChanged = true;
-
-    return true;
-  }
-
-  return false;
-}
-
 bool CPVRChannel::SetClientID(int iClientId)
 {
   CSingleLock lock(m_critSection);
@@ -431,13 +414,16 @@ bool CPVRChannel::SetStreamURL(const std::string &strStreamURL)
   return false;
 }
 
-void CPVRChannel::UpdatePath(CPVRChannelGroupInternal* group, unsigned int iNewChannelGroupPosition)
+void CPVRChannel::UpdatePath(CPVRChannelGroupInternal* group)
 {
   if (!group) return;
 
   std::string strFileNameAndPath;
   CSingleLock lock(m_critSection);
-  strFileNameAndPath = StringUtils::Format("pvr://channels/%s/%s/%i.pvr", (m_bIsRadio ? "radio" : "tv"), group->GroupName().c_str(), iNewChannelGroupPosition);
+  strFileNameAndPath = StringUtils::Format("pvr://channels/%s/%s/%lu.pvr",
+                                           (m_bIsRadio ? "radio" : "tv"),
+                                           group->GroupName().c_str(),
+                                           ((uint64_t)m_iClientId) << 32 | (uint64_t)m_iUniqueId);
   if (m_strFileNameAndPath != strFileNameAndPath)
   {
     m_strFileNameAndPath = strFileNameAndPath;
@@ -744,7 +730,6 @@ bool CPVRChannel::IsChanged() const
 
 int CPVRChannel::UniqueID(void) const
 {
-  CSingleLock lock(m_critSection);
   return m_iUniqueId;
 }
 

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -420,10 +420,11 @@ void CPVRChannel::UpdatePath(CPVRChannelGroupInternal* group)
 
   std::string strFileNameAndPath;
   CSingleLock lock(m_critSection);
-  strFileNameAndPath = StringUtils::Format("pvr://channels/%s/%s/%lu.pvr",
+  strFileNameAndPath = StringUtils::Format("pvr://channels/%s/%s/%s_%d.pvr",
                                            (m_bIsRadio ? "radio" : "tv"),
                                            group->GroupName().c_str(),
-                                           ((uint64_t)m_iClientId) << 32 | (uint64_t)m_iUniqueId);
+                                           g_PVRClients->GetClientAddonId(m_iClientId).c_str(),
+                                           m_iUniqueId);
   if (m_strFileNameAndPath != strFileNameAndPath)
   {
     m_strFileNameAndPath = strFileNameAndPath;

--- a/xbmc/pvr/channels/PVRChannel.h
+++ b/xbmc/pvr/channels/PVRChannel.h
@@ -266,13 +266,6 @@ namespace PVR
     int UniqueID(void) const;
 
     /*!
-     * @brief Change the unique identifier for this channel.
-     * @param iUniqueId The new unique ID.
-     * @return True if the something changed, false otherwise.
-     */
-    bool SetUniqueID(int iUniqueId);
-
-    /*!
      * @return The identifier of the client that serves this channel.
      */
     int ClientID(void) const;
@@ -341,11 +334,15 @@ namespace PVR
     virtual void ToSortable(SortItem& sortable, Field field) const;
 
     /*!
-     * @brief Update the path after the channel number in the internal group changed.
+     * @brief Update the path this channel got added to the internal group
      * @param group The internal group that contains this channel
-     * @param iNewChannelGroupPosition The new channel number in the group
      */
-    void UpdatePath(CPVRChannelGroupInternal* group, unsigned int iNewChannelGroupPosition);
+    void UpdatePath(CPVRChannelGroupInternal* group);
+
+    /*!
+     * @return Storage id for this channel in CPVRChannelGroup
+     */
+    std::pair<int, int> StorageId(void) const { return std::make_pair(m_iClientId, m_iUniqueId); }
 
     /*!
      * @brief Return true if this channel is encrypted.

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -1022,9 +1022,6 @@ int CPVRChannelGroup::GetEPGNowOrNext(CFileItemList &results, bool bGetNext) con
     epg = (*it).channel->GetEPG();
     if (epg && !(*it).channel->IsHidden())
     {
-      // XXX channel pointers aren't set in some occasions. this works around the issue, but is not very nice
-      epg->SetChannel((*it).channel);
-
       epgNext = bGetNext ? epg->GetTagNext() : epg->GetTagNow();
       if (epgNext)
       {

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -374,7 +374,7 @@ void CPVRChannelGroup::SortByChannelNumber(void)
 
 /********** getters **********/
 
-CPVRChannelPtr CPVRChannelGroup::GetByClient(int iUniqueChannelId, int iClientID) const
+CPVRChannelPtr CPVRChannelGroup::GetByUniqueID(int iUniqueChannelId, int iClientID) const
 {
   CPVRChannelPtr retval;
   CSingleLock lock(m_critSection);
@@ -616,7 +616,7 @@ bool CPVRChannelGroup::AddAndUpdateChannels(const CPVRChannelGroup &channels, bo
   for (std::vector<PVRChannelGroupMember>::const_iterator it = channels.m_members.begin(); it != channels.m_members.end(); ++it)
   {
     /* check whether this channel is known in the internal group */
-    CPVRChannelPtr existingChannel = g_PVRChannelGroups->GetGroupAll(m_bRadio)->GetByClient((*it).channel->UniqueID(), (*it).channel->ClientID());
+    CPVRChannelPtr existingChannel = g_PVRChannelGroups->GetGroupAll(m_bRadio)->GetByUniqueID((*it).channel->UniqueID(), (*it).channel->ClientID());
     if (!existingChannel)
       continue;
 
@@ -646,7 +646,7 @@ bool CPVRChannelGroup::RemoveDeletedChannels(const CPVRChannelGroup &channels)
   /* check for deleted channels */
   for (std::vector<PVRChannelGroupMember>::iterator it = m_members.begin(); it != m_members.end();)
   {
-    if (channels.GetByClient((*it).channel->UniqueID(), (*it).channel->ClientID()) == NULL)
+    if (channels.GetByUniqueID((*it).channel->UniqueID(), (*it).channel->ClientID()) == NULL)
     {
       /* channel was not found */
       CLog::Log(LOGINFO,"PVRChannelGroup - %s - deleted %s channel '%s' from group '%s'",
@@ -788,8 +788,8 @@ bool CPVRChannelGroup::AddToGroup(const CPVRChannelPtr &channel, int iChannelNum
       iChannelNumber = m_members.size() + 1;
 
     CPVRChannelPtr realChannel = (IsInternalGroup()) ?
-        GetByClient(channel->UniqueID(), channel->ClientID()) :
-        g_PVRChannelGroups->GetGroupAll(m_bRadio)->GetByClient(channel->UniqueID(), channel->ClientID());
+        GetByUniqueID(channel->UniqueID(), channel->ClientID()) :
+        g_PVRChannelGroups->GetGroupAll(m_bRadio)->GetByUniqueID(channel->UniqueID(), channel->ClientID());
 
     if (realChannel)
     {
@@ -1224,7 +1224,7 @@ bool CPVRChannelGroup::UpdateChannel(const CFileItem &item, bool bHidden, bool b
   CSingleLock lock(m_critSection);
 
   /* get the real channel from the group */
-  CPVRChannelPtr channel = GetByClient(item.GetPVRChannelInfoTag()->UniqueID(), item.GetPVRChannelInfoTag()->ClientID());
+  CPVRChannelPtr channel = GetByUniqueID(item.GetPVRChannelInfoTag()->UniqueID(), item.GetPVRChannelInfoTag()->ClientID());
   if (!channel)
     return false;
 
@@ -1271,7 +1271,7 @@ bool CPVRChannelGroup::ToggleChannelLocked(const CFileItem &item)
   CSingleLock lock(m_critSection);
 
   /* get the real channel from the group */
-  CPVRChannelPtr channel = GetByClient(item.GetPVRChannelInfoTag()->UniqueID(), item.GetPVRChannelInfoTag()->ClientID());
+  CPVRChannelPtr channel = GetByUniqueID(item.GetPVRChannelInfoTag()->UniqueID(), item.GetPVRChannelInfoTag()->ClientID());
   if (!channel)
     return false;
 

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -511,12 +511,11 @@ CFileItemPtr CPVRChannelGroup::GetByChannelUpDown(const CFileItem &channel, bool
       else if (iChannelIndex < 0)
         iChannelIndex = m_members.size() - 1;
 
-      CFileItemPtr current = GetByIndex(iChannelIndex);
-      if (!current || *current->GetPVRChannelInfoTag() == *channel.GetPVRChannelInfoTag())
-        break;
-
-      if (!current->GetPVRChannelInfoTag()->IsHidden())
-        return current;
+      CPVRChannelPtr current = m_members.at(iChannelIndex).channel;
+      if (current &&
+          *current != *channel.GetPVRChannelInfoTag() &&
+          !current->IsHidden())
+        return CFileItemPtr(new CFileItem(current));
     }
   }
 
@@ -524,17 +523,19 @@ CFileItemPtr CPVRChannelGroup::GetByChannelUpDown(const CFileItem &channel, bool
   return retVal;
 }
 
-CFileItemPtr CPVRChannelGroup::GetByIndex(unsigned int iIndex) const
+std::vector<PVRChannelGroupMember> CPVRChannelGroup::GetMembers(void) const
+{
+  CSingleLock lock(m_critSection);
+  return m_members;
+}
+
+CPVRChannelPtr CPVRChannelGroup::GetByIndex(unsigned int iIndex) const
 {
   CSingleLock lock(m_critSection);
   if (iIndex < m_members.size())
-  {
-    CFileItemPtr retVal = CFileItemPtr(new CFileItem(m_members.at(iIndex).channel));
-    return retVal;
-  }
+    return m_members.at(iIndex).channel;
 
-  CFileItemPtr retVal = CFileItemPtr(new CFileItem);
-  return retVal;
+  return CPVRChannelPtr();
 }
 
 int CPVRChannelGroup::GetIndex(const CPVRChannelPtr &channel) const

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -417,20 +417,6 @@ CPVRChannelPtr CPVRChannelGroup::GetByChannelEpgID(int iEpgID) const
   return retval;
 }
 
-CPVRChannelPtr CPVRChannelGroup::GetByUniqueID(int iUniqueID) const
-{
-  CPVRChannelPtr retval;
-  CSingleLock lock(m_critSection);
-
-  for (std::vector<PVRChannelGroupMember>::const_iterator it = m_members.begin(); !retval && it != m_members.end(); ++it)
-  {
-    if ((*it).channel->UniqueID() == iUniqueID)
-      retval = (*it).channel;
-  }
-
-  return retval;
-}
-
 CFileItemPtr CPVRChannelGroup::GetLastPlayedChannel(int iCurrentChannel /* = -1 */) const
 {
   CSingleLock lock(m_critSection);
@@ -1238,7 +1224,7 @@ bool CPVRChannelGroup::UpdateChannel(const CFileItem &item, bool bHidden, bool b
   CSingleLock lock(m_critSection);
 
   /* get the real channel from the group */
-  CPVRChannelPtr channel = GetByUniqueID(item.GetPVRChannelInfoTag()->UniqueID());
+  CPVRChannelPtr channel = GetByClient(item.GetPVRChannelInfoTag()->UniqueID(), item.GetPVRChannelInfoTag()->ClientID());
   if (!channel)
     return false;
 
@@ -1285,7 +1271,7 @@ bool CPVRChannelGroup::ToggleChannelLocked(const CFileItem &item)
   CSingleLock lock(m_critSection);
 
   /* get the real channel from the group */
-  CPVRChannelPtr channel = GetByUniqueID(item.GetPVRChannelInfoTag()->UniqueID());
+  CPVRChannelPtr channel = GetByClient(item.GetPVRChannelInfoTag()->UniqueID(), item.GetPVRChannelInfoTag()->ClientID());
   if (!channel)
     return false;
 

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -306,11 +306,10 @@ namespace PVR
     CFileItemPtr GetByChannelDown(const CFileItem &channel) const { return GetByChannelUpDown(channel, false); }
 
     /*!
-     * @brief Get a channel given it's index in this container.
-     * @param index The index in this container.
-     * @return The channel or NULL if it wasn't found.
+     * Get the current members of this group
+     * @return The group members
      */
-    CFileItemPtr GetByIndex(unsigned int index) const;
+    std::vector<PVRChannelGroupMember> GetMembers(void) const;
 
     /*!
      * @brief Get the current index in this group of a channel.
@@ -437,6 +436,13 @@ namespace PVR
     bool IsHidden(void) const;
 
   protected:
+    /*!
+     * @brief Get a channel given it's index in this container.
+     * @param index The index in this container.
+     * @return The channel or an empty channel if it wasn't found.
+     */
+    CPVRChannelPtr GetByIndex(unsigned int index) const;
+
     /*!
      * @brief Load the channels stored in the database.
      * @param bCompress If true, compress the database after storing the channels.

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -51,7 +51,10 @@ namespace PVR
     unsigned int   iChannelNumber;
     unsigned int   iSubChannelNumber;
   } PVRChannelGroupMember;
-  
+
+  typedef std::vector<PVRChannelGroupMember> PVR_CHANNEL_GROUP_SORTED_MEMBERS;
+  typedef std::map<std::pair<int, int>, PVRChannelGroupMember> PVR_CHANNEL_GROUP_MEMBERS;
+
   enum EpgDateType
   {
     EPG_FIRST_DATE = 0,
@@ -100,10 +103,22 @@ namespace PVR
     bool operator ==(const CPVRChannelGroup &right) const;
     bool operator !=(const CPVRChannelGroup &right) const;
 
+    /**
+     * Empty group member
+     */
+    static PVRChannelGroupMember EmptyMember;
+
+    /*!
+     * Translate an id used in the path to a client id + unique channel id pair
+     * @param pathId Id in the path to translate
+     * @return The requested pair
+     */
+    static std::pair<int, int> PathIdToStorageId(uint64_t pathId);
+
     /*!
      * @return The amount of group members
      */
-    int Size(void) const;
+    size_t Size(void) const;
 
     /*!
      * @brief Refresh the channel list from the clients.
@@ -296,27 +311,20 @@ namespace PVR
      * @param channel The current channel.
      * @return The channel or NULL if it wasn't found.
      */
-    CFileItemPtr GetByChannelUp(const CFileItem &channel) const { return GetByChannelUpDown(channel, true); }
+    CFileItemPtr GetByChannelUp(const CFileItem &channel) const;
 
     /*!
      * @brief Get the previous channel in this group.
      * @param channel The current channel.
      * @return The channel or NULL if it wasn't found.
      */
-    CFileItemPtr GetByChannelDown(const CFileItem &channel) const { return GetByChannelUpDown(channel, false); }
+    CFileItemPtr GetByChannelDown(const CFileItem &channel) const;
 
     /*!
      * Get the current members of this group
      * @return The group members
      */
-    std::vector<PVRChannelGroupMember> GetMembers(void) const;
-
-    /*!
-     * @brief Get the current index in this group of a channel.
-     * @param channel The channel to get the index for.
-     * @return The index or -1 if it wasn't found.
-     */
-    int GetIndex(const CPVRChannelPtr &channel) const;
+    PVR_CHANNEL_GROUP_SORTED_MEMBERS GetMembers(void) const;
 
     /*!
      * @brief Get the list of channels in a group.
@@ -340,13 +348,7 @@ namespace PVR
      * @brief The amount of hidden channels in this container.
      * @return The amount of hidden channels in this container.
      */
-    virtual int GetNumHiddenChannels(void) const { return 0; }
-    
-    /*!
-     * @brief The amount of channels in this container.
-     * @return The amount of channels in this container.
-     */
-    int GetNumChannels(void) const;
+    virtual size_t GetNumHiddenChannels(void) const { return 0; }
 
     /*!
      * @brief Does this container holds channels.
@@ -396,14 +398,14 @@ namespace PVR
      * @param results The fileitem list to store the results in.
      * @return The amount of entries that were added.
      */
-    int GetEPGNow(CFileItemList &results) const;
+    int GetEPGNow(CFileItemList &results) const { return GetEPGNowOrNext(results, false); }
 
     /*!
      * @brief Get all entries that will be active next.
      * @param results The fileitem list to store the results in.
      * @return The amount of entries that were added.
      */
-    int GetEPGNext(CFileItemList &results) const;
+    int GetEPGNext(CFileItemList &results) const { return GetEPGNowOrNext(results, true); }
     
     /*!
      * @brief Get the start time of the first entry.
@@ -428,6 +430,7 @@ namespace PVR
      * @return The channel or NULL if it wasn't found.
      */
     CPVRChannelPtr GetByUniqueID(int iUniqueChannelId, int iClientID) const;
+    const PVRChannelGroupMember& GetByUniqueID(const std::pair<int, int>& id) const;
 
     void SetSelectedGroup(bool bSetTo);
     bool IsSelectedGroup(void) const;
@@ -436,13 +439,6 @@ namespace PVR
     bool IsHidden(void) const;
 
   protected:
-    /*!
-     * @brief Get a channel given it's index in this container.
-     * @param index The index in this container.
-     * @return The channel or an empty channel if it wasn't found.
-     */
-    CPVRChannelPtr GetByIndex(unsigned int index) const;
-
     /*!
      * @brief Load the channels stored in the database.
      * @param bCompress If true, compress the database after storing the channels.
@@ -511,14 +507,6 @@ namespace PVR
     void SortByChannelNumber(void);
 
     /*!
-     * @brief Get the previous or next channel in this group.
-     * @param channel The current channel.
-     * @param bChannelUp True to get the next channel, false to get the previous one.
-     * @return The requested channel or NULL if there is none.
-     */
-    CFileItemPtr GetByChannelUpDown(const CFileItem &channel, bool bChannelUp) const;
-
-    /*!
      * @brief Get a channel given it's channel ID.
      * @param iChannelID The channel ID.
      * @return The channel or NULL if it wasn't found.
@@ -537,12 +525,19 @@ namespace PVR
     bool             m_bPreventSortAndRenumber;     /*!< true when sorting and renumbering should not be done after adding/updating channels to the group */
     time_t           m_iLastWatched;                /*!< last time group has been watched */
     bool             m_bHidden;                     /*!< true if this group is hidden, false otherwise */
-    std::vector<PVRChannelGroupMember> m_members;
+    PVR_CHANNEL_GROUP_SORTED_MEMBERS m_sortedMembers; /*!< members sorted by channel number */
+    PVR_CHANNEL_GROUP_MEMBERS        m_members;       /*!< members with key clientid+uniqueid */
     CCriticalSection m_critSection;
     
   private:
     CDateTime GetEPGDate(EpgDateType epgDateType) const;
-    
+    /*!
+     * @brief Get all entries that will be active next.
+     * @param results The fileitem list to store the results in.
+     * @param bGetNext True to get the next item, false to get the current one
+     * @return The amount of entries that were added.
+     */
+    int GetEPGNowOrNext(CFileItemList &results, bool bGetNext) const;
   };
 
   class CPVRPersistGroupJob : public CJob

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -430,13 +430,6 @@ namespace PVR
      */
     CPVRChannelPtr GetByClient(int iUniqueChannelId, int iClientID) const;
 
-    /*!
-     * @brief Get a channel given it's unique ID.
-     * @param iUniqueID The unique ID.
-     * @return The channel or NULL if it wasn't found.
-     */
-    CPVRChannelPtr GetByUniqueID(int iUniqueID) const;
-
     void SetSelectedGroup(bool bSetTo);
     bool IsSelectedGroup(void) const;
 

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -428,7 +428,7 @@ namespace PVR
      * @param iClientID The ID of the client.
      * @return The channel or NULL if it wasn't found.
      */
-    CPVRChannelPtr GetByClient(int iUniqueChannelId, int iClientID) const;
+    CPVRChannelPtr GetByUniqueID(int iUniqueChannelId, int iClientID) const;
 
     void SetSelectedGroup(bool bSetTo);
     bool IsSelectedGroup(void) const;

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
@@ -128,7 +128,7 @@ bool CPVRChannelGroupInternal::Update(void)
   return PVRChannels_tmp.LoadFromClients() && UpdateGroupEntries(PVRChannels_tmp);
 }
 
-bool CPVRChannelGroupInternal::AddToGroup(CPVRChannelPtr &channel, int iChannelNumber /* = 0 */)
+bool CPVRChannelGroupInternal::AddToGroup(const CPVRChannelPtr &channel, int iChannelNumber /* = 0 */)
 {
   CSingleLock lock(m_critSection);
 

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
@@ -98,7 +98,7 @@ CPVRChannelPtr CPVRChannelGroupInternal::UpdateFromClient(const CPVRChannelPtr &
   assert(channel.get());
 
   CSingleLock lock(m_critSection);
-  CPVRChannelPtr realChannel(GetByClient(channel->UniqueID(), channel->ClientID()));
+  CPVRChannelPtr realChannel(GetByUniqueID(channel->UniqueID(), channel->ClientID()));
   if (realChannel)
   {
     realChannel->UpdateFromClient(channel);
@@ -295,7 +295,7 @@ bool CPVRChannelGroupInternal::AddAndUpdateChannels(const CPVRChannelGroup &chan
       continue;
 
     /* check whether this channel is present in this container */
-    CPVRChannelPtr existingChannel = GetByClient(member.channel->UniqueID(), member.channel->ClientID());
+    CPVRChannelPtr existingChannel = GetByUniqueID(member.channel->UniqueID(), member.channel->ClientID());
     if (existingChannel)
     {
       /* if it's present, update the current tag */

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
@@ -135,7 +135,7 @@ bool CPVRChannelGroupInternal::AddToGroup(CPVRChannelPtr &channel, int iChannelN
   bool bReturn(false);
 
   /* get the actual channel since this is called from a fileitemlist copy */
-  CPVRChannelPtr realChannel = GetByChannelID(channel->ChannelID());
+  CPVRChannelPtr realChannel = GetByUniqueID(channel->UniqueID(), channel->ClientID());
   if (!realChannel)
     return bReturn;
 
@@ -173,7 +173,7 @@ bool CPVRChannelGroupInternal::RemoveFromGroup(const CPVRChannelPtr &channel)
   assert(channel.get());
 
   /* get the actual channel since this is called from a fileitemlist copy */
-  CPVRChannelPtr realChannel(GetByChannelID(channel->ChannelID()));
+  CPVRChannelPtr realChannel(GetByUniqueID(channel->UniqueID(), channel->ClientID()));
   if (!realChannel)
     return false;
 

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.h
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.h
@@ -52,13 +52,7 @@ namespace PVR
      * @brief The amount of channels in this container.
      * @return The amount of channels in this container.
      */
-    int GetNumHiddenChannels() const { return m_iHiddenChannels; }
-
-    /*!
-     * @brief Add a channel to this internal group.
-     * @param iChannelNumber The channel number to use for this channel or 0 to add it to the back.
-     */
-    bool InsertInGroup(CPVRChannelPtr &channel, int iChannelNumber = 0);
+    size_t GetNumHiddenChannels() const { return m_iHiddenChannels; }
 
     /*!
      * @brief Callback for add-ons to update a channel.
@@ -143,11 +137,6 @@ namespace PVR
     bool Update(void);
 
     /*!
-     * @brief Remove invalid channels and updates the channel numbers.
-     */
-    bool Renumber(void);
-
-    /*!
      * @brief Load the channels from the database.
      *
      * Load the channels from the database.
@@ -164,6 +153,6 @@ namespace PVR
 
     void CreateChannelEpg(CPVRChannelPtr channel, bool bForce = false);
 
-    int m_iHiddenChannels; /*!< the amount of hidden channels in this container */
+    size_t m_iHiddenChannels; /*!< the amount of hidden channels in this container */
   };
 }

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.h
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.h
@@ -75,7 +75,7 @@ namespace PVR
     /*!
      * @see CPVRChannelGroup::AddToGroup
      */
-    bool AddToGroup(CPVRChannelPtr &channel, int iChannelNumber = 0);
+    bool AddToGroup(const CPVRChannelPtr &channel, int iChannelNumber = 0);
 
     /*!
      * @see CPVRChannelGroup::RemoveFromGroup

--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -117,7 +117,7 @@ CFileItemPtr CPVRChannelGroups::GetByPath(const std::string &strPath) const
     if (StringUtils::StartsWith(strFileName, strCheckPath))
     {
       strFileName.erase(0, strCheckPath.length());
-      CPVRChannelPtr channel((*it)->GetByIndex(atoi(strFileName.c_str())));
+      CPVRChannelPtr channel((*it)->GetByUniqueID(CPVRChannelGroup::PathIdToStorageId(strtoul(strFileName.c_str(), NULL, 10))).channel);
       if (channel)
         return CFileItemPtr(new CFileItem(channel));
     }

--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -503,7 +503,7 @@ bool CPVRChannelGroups::DeleteGroup(const CPVRChannelGroup &group)
   // delete the group in this container
   {
     CSingleLock lock(m_critSection);
-    for (std::vector<CPVRChannelGroupPtr>::iterator it = m_groups.begin(); !bFound && it != m_groups.end(); ++it)
+    for (std::vector<CPVRChannelGroupPtr>::iterator it = m_groups.begin(); !bFound && it != m_groups.end();)
     {
       if ((*it)->GroupID() == group.GroupID())
       {
@@ -512,8 +512,12 @@ bool CPVRChannelGroups::DeleteGroup(const CPVRChannelGroup &group)
         if (selectedGroup && *selectedGroup == group)
           g_PVRManager.SetPlayingGroup(GetGroupAll());
 
-        m_groups.erase(it);
+        it = m_groups.erase(it);
         bFound = true;
+      }
+      else
+      {
+        ++it;
       }
     }
   }

--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -117,9 +117,13 @@ CFileItemPtr CPVRChannelGroups::GetByPath(const std::string &strPath) const
     if (StringUtils::StartsWith(strFileName, strCheckPath))
     {
       strFileName.erase(0, strCheckPath.length());
-      CPVRChannelPtr channel((*it)->GetByUniqueID(CPVRChannelGroup::PathIdToStorageId(strtoul(strFileName.c_str(), NULL, 10))).channel);
-      if (channel)
-        return CFileItemPtr(new CFileItem(channel));
+      std::vector<std::string> split(StringUtils::Split(strFileName, '_', 2));
+      if (split.size() == 2)
+      {
+        CPVRChannelPtr channel((*it)->GetByUniqueID(atoi(split[1].c_str()), g_PVRClients->GetClientId(split[0])));
+        if (channel)
+          return CFileItemPtr(new CFileItem(channel));
+      }
     }
   }
 

--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -117,7 +117,9 @@ CFileItemPtr CPVRChannelGroups::GetByPath(const std::string &strPath) const
     if (StringUtils::StartsWith(strFileName, strCheckPath))
     {
       strFileName.erase(0, strCheckPath.length());
-      return (*it)->GetByIndex(atoi(strFileName.c_str()));
+      CPVRChannelPtr channel((*it)->GetByIndex(atoi(strFileName.c_str())));
+      if (channel)
+        return CFileItemPtr(new CFileItem(channel));
     }
   }
 

--- a/xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
@@ -227,30 +227,6 @@ CPVRChannelPtr CPVRChannelGroupsContainer::GetByUniqueID(int iUniqueChannelId, i
   return channel;
 }
 
-CFileItemPtr CPVRChannelGroupsContainer::GetByChannelIDFromAll(int iChannelID) const
-{
-  CPVRChannelPtr channel;
-  CPVRChannelGroupPtr channelgroup = GetGroupAllTV();
-  if (channelgroup)
-    channel = channelgroup->GetByChannelID(iChannelID);
-
-  if (!channel)
-  {
-    channelgroup = GetGroupAllRadio();
-    if (channelgroup)
-      channel = channelgroup->GetByChannelID(iChannelID);
-  }
-
-  if (channel)
-  {
-    CFileItemPtr retVal = CFileItemPtr(new CFileItem(channel));
-    return retVal;
-  }
-
-  CFileItemPtr retVal = CFileItemPtr(new CFileItem);
-  return retVal;
-}
-
 void CPVRChannelGroupsContainer::SearchMissingChannelIcons(void) const
 {
   CLog::Log(LOGINFO, "PVRChannelGroupsContainer - %s - starting channel icon search", __FUNCTION__);

--- a/xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
@@ -217,12 +217,12 @@ CPVRChannelPtr CPVRChannelGroupsContainer::GetByUniqueID(int iUniqueChannelId, i
   CPVRChannelPtr channel;
   CPVRChannelGroupPtr channelgroup = GetGroupAllTV();
   if (channelgroup)
-    channel = channelgroup->GetByClient(iUniqueChannelId, iClientID);
+    channel = channelgroup->GetByUniqueID(iUniqueChannelId, iClientID);
 
   if (!channelgroup || !channel)
     channelgroup = GetGroupAllRadio();
   if (channelgroup)
-    channel = channelgroup->GetByClient(iUniqueChannelId, iClientID);
+    channel = channelgroup->GetByUniqueID(iUniqueChannelId, iClientID);
 
   return channel;
 }

--- a/xbmc/pvr/channels/PVRChannelGroupsContainer.h
+++ b/xbmc/pvr/channels/PVRChannelGroupsContainer.h
@@ -163,13 +163,6 @@ namespace PVR
     CPVRChannelPtr GetByUniqueID(int iUniqueChannelId, int iClientID) const;
 
     /*!
-     * @brief Get a channel given it's channel ID from all containers.
-     * @param iChannelID The channel ID.
-     * @return The channel or NULL if it wasn't found.
-     */
-    CFileItemPtr GetByChannelIDFromAll(int iChannelID) const;
-
-    /*!
      * @brief Try to find missing channel icons automatically
      */
     void SearchMissingChannelIcons(void) const;

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -664,9 +664,11 @@ void CGUIDialogPVRChannelManager::Update()
   if(!channels)
     return;
 
-  for (int iChannelPtr = 0; iChannelPtr < channels->Size(); iChannelPtr++)
+  std::vector<PVRChannelGroupMember> groupMembers(channels->GetMembers());
+  CFileItemPtr channelFile;
+  for (std::vector<PVRChannelGroupMember>::const_iterator it = groupMembers.begin(); it != groupMembers.end(); ++it)
   {
-    CFileItemPtr channelFile = channels->GetByIndex(iChannelPtr);
+    channelFile = CFileItemPtr(new CFileItem((*it).channel));
     if (!channelFile || !channelFile->HasPVRChannelInfoTag())
       continue;
     const CPVRChannelPtr channel(channelFile->GetPVRChannelInfoTag());

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
@@ -77,14 +77,11 @@ void CGUIDialogPVRGuideSearch::UpdateChannelSpin(void)
   if (!group)
     group = g_PVRChannelGroups->GetGroupAll(m_searchFilter->m_bIsRadio);
 
-  for (int iChannelPtr = 0; iChannelPtr < group->Size(); iChannelPtr++)
+  std::vector<PVRChannelGroupMember> groupMembers(group->GetMembers());
+  for (std::vector<PVRChannelGroupMember>::const_iterator it = groupMembers.begin(); it != groupMembers.end(); ++it)
   {
-    CFileItemPtr channel = group->GetByIndex(iChannelPtr);
-    if (!channel || !channel->HasPVRChannelInfoTag())
-      continue;
-
-    int iChannelNumber = group->GetChannelNumber(channel->GetPVRChannelInfoTag());
-    labels.push_back(std::make_pair(channel->GetPVRChannelInfoTag()->ChannelName(), iChannelNumber));
+    if ((*it).channel)
+      labels.push_back(std::make_pair((*it).channel->ChannelName(), (*it).iChannelNumber));
   }
 
   SET_CONTROL_LABELS(CONTROL_SPIN_CHANNELS, m_searchFilter->m_iChannelNumber, &labels);

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -631,7 +631,7 @@ CPVRChannelPtr CPVRTimerInfoTag::ChannelTag(void) const
 void CPVRTimerInfoTag::UpdateChannel(void)
 {
   CSingleLock lock(m_critSection);
-  m_channel = g_PVRChannelGroups->Get(m_bIsRadio)->GetGroupAll()->GetByClient(m_iClientChannelUid, m_iClientId);
+  m_channel = g_PVRChannelGroups->Get(m_bIsRadio)->GetGroupAll()->GetByUniqueID(m_iClientChannelUid, m_iClientId);
 }
 
 const std::string& CPVRTimerInfoTag::Title(void) const

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -178,9 +178,9 @@ bool CPVRTimers::UpdateEntries(const CPVRTimers &timers)
   /* check for deleted timers */
   for (MapTags::iterator it = m_tags.begin(); it != m_tags.end();)
   {
-    for (int iTimerPtr = it->second->size() - 1; iTimerPtr >= 0; iTimerPtr--)
+    for (std::vector<CPVRTimerInfoTagPtr>::iterator it2 = it->second->begin(); it2 != it->second->end();)
     {
-      CPVRTimerInfoTagPtr timer = it->second->at(iTimerPtr);
+      CPVRTimerInfoTagPtr timer(*it2);
       if (!timers.GetByClient(timer->m_iClientId, timer->m_iClientIndex))
       {
         /* timer was not found */
@@ -200,7 +200,7 @@ bool CPVRTimers::UpdateEntries(const CPVRTimers &timers)
 
         /** clear the EPG tag explicitly here, because it no longer happens automatically with shared pointers */
         timer->ClearEpgTag();
-        it->second->erase(it->second->begin() + iTimerPtr);
+        it2 = it->second->erase(it2);
 
         bChanged = true;
         bAddedOrDeleted = true;
@@ -217,14 +217,18 @@ bool CPVRTimers::UpdateEntries(const CPVRTimers &timers)
         timersToMove.push_back(timer);
         
         /* remove timer for now, reinsert later */
-        it->second->erase(it->second->begin() + iTimerPtr);
+        it2 = it->second->erase(it2);
 
         bChanged = true;
         bAddedOrDeleted = true;
       }
+      else
+      {
+        ++it2;
+      }
     }
-    if (it->second->size() == 0)
-      m_tags.erase(it++);
+    if (it->second->empty())
+      it = m_tags.erase(it);
     else
       ++it;
   }


### PR DESCRIPTION
- use a vector sorted by channel number and a map with the client id+unique id as key for accessing channels in a group, and use the latter one where possible
- changed channel vfs paths to use the client id+unique id instead of using the group position, so we don't have to write all channels each time the group changes, and so we can use the sorted map rather than an iterator over the whole group when searching for a channel
- removed dead code
- fix crash caused by https://github.com/xbmc/xbmc/pull/6635
- various small optimisations (const, `empty()` instead of `size() > 0`, that sort of things)
