### PR TITLE
[pvr] adds capability for sorted channel groups

### DIFF
--- a/xbmc/addons/include/xbmc_pvr_types.h
+++ b/xbmc/addons/include/xbmc_pvr_types.h
@@ -244,6 +244,7 @@ extern "C" {
   {
     char         strGroupName[PVR_ADDON_NAME_STRING_LENGTH]; /*!< @brief (required) name of this channel group */
     bool         bIsRadio;                                   /*!< @brief (required) true if this is a radio channel group, false otherwise. */
+    unsigned int iPosition;                                  /*!< @brief (optional) sort position of the group (0 indicates that the backend doesn't support sorting of groups) */
   } ATTRIBUTE_PACKED PVR_CHANNEL_GROUP;
 
   typedef struct PVR_CHANNEL_GROUP_MEMBER

--- a/xbmc/pvr/PVRDatabase.h
+++ b/xbmc/pvr/PVRDatabase.h
@@ -59,7 +59,7 @@ namespace PVR
      * @brief Get the minimal database version that is required to operate correctly.
      * @return The minimal database version.
      */
-    virtual int GetSchemaVersion() const { return 28; };
+    virtual int GetSchemaVersion() const { return 29; };
 
     /*!
      * @brief Get the default sqlite database filename.

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -56,7 +56,8 @@ CPVRChannelGroup::CPVRChannelGroup(void) :
     m_bSelectedGroup(false),
     m_bPreventSortAndRenumber(false),
     m_iLastWatched(0),
-    m_bHidden(false)
+    m_bHidden(false),
+    m_iPosition(0)
 {
 }
 
@@ -72,7 +73,8 @@ CPVRChannelGroup::CPVRChannelGroup(bool bRadio, unsigned int iGroupId, const std
     m_bSelectedGroup(false),
     m_bPreventSortAndRenumber(false),
     m_iLastWatched(0),
-    m_bHidden(false)
+    m_bHidden(false),
+    m_iPosition(0)
 {
 }
 
@@ -88,7 +90,8 @@ CPVRChannelGroup::CPVRChannelGroup(const PVR_CHANNEL_GROUP &group) :
     m_bSelectedGroup(false),
     m_bPreventSortAndRenumber(false),
     m_iLastWatched(0),
-    m_bHidden(false)
+    m_bHidden(false),
+    m_iPosition(group.iPosition)
 {
 }
 
@@ -102,7 +105,8 @@ bool CPVRChannelGroup::operator==(const CPVRChannelGroup& right) const
   return (m_bRadio == right.m_bRadio &&
       m_iGroupType == right.m_iGroupType &&
       m_iGroupId == right.m_iGroupId &&
-      m_strGroupName == right.m_strGroupName);
+      m_strGroupName == right.m_strGroupName &&
+      m_iPosition == right.m_iPosition);
 }
 
 bool CPVRChannelGroup::operator!=(const CPVRChannelGroup &right) const
@@ -133,6 +137,7 @@ CPVRChannelGroup::CPVRChannelGroup(const CPVRChannelGroup &group) :
   m_bPreventSortAndRenumber     = group.m_bPreventSortAndRenumber;
   m_members                     = group.m_members;
   m_sortedMembers               = group.m_sortedMembers;
+  m_iPosition                   = group.m_iPosition;
 }
 
 bool CPVRChannelGroup::Load(void)
@@ -1275,4 +1280,21 @@ bool CPVRChannelGroup::IsHidden(void) const
 {
   CSingleLock lock(m_critSection);
   return m_bHidden;
+}
+
+int CPVRChannelGroup::GetPosition(void) const
+{
+  CSingleLock lock(m_critSection);
+  return m_iPosition;
+}
+
+void CPVRChannelGroup::SetPosition(int iPosition)
+{
+  CSingleLock lock(m_critSection);
+
+  if (m_iPosition != iPosition)
+  {
+    m_iPosition = iPosition;
+    m_bChanged = true;
+  }
 }

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -438,6 +438,9 @@ namespace PVR
     void SetHidden(bool bHidden);
     bool IsHidden(void) const;
 
+    int GetPosition(void) const;
+    void SetPosition(int iPosition);
+
   protected:
     /*!
      * @brief Load the channels stored in the database.
@@ -525,6 +528,7 @@ namespace PVR
     bool             m_bPreventSortAndRenumber;     /*!< true when sorting and renumbering should not be done after adding/updating channels to the group */
     time_t           m_iLastWatched;                /*!< last time group has been watched */
     bool             m_bHidden;                     /*!< true if this group is hidden, false otherwise */
+    bool             m_iPosition;                   /*!< the position of this group within the group list */
     PVR_CHANNEL_GROUP_SORTED_MEMBERS m_sortedMembers; /*!< members sorted by channel number */
     PVR_CHANNEL_GROUP_MEMBERS        m_members;       /*!< members with key clientid+uniqueid */
     CCriticalSection m_critSection;

--- a/xbmc/pvr/channels/PVRChannelGroups.h
+++ b/xbmc/pvr/channels/PVRChannelGroups.h
@@ -204,6 +204,7 @@ namespace PVR
     bool UpdateGroupsEntries(const CPVRChannelGroups &groups);
     bool LoadUserDefinedChannelGroups(void);
     bool GetGroupsFromClients(void);
+    void SortGroups(void);
 
     bool                             m_bRadio;         /*!< true if this is a container for radio channels, false if it is for tv channels */
     CPVRChannelGroupPtr              m_selectedGroup;  /*!< the group that's currently selected in the UI */


### PR DESCRIPTION
This will adds the capability to import the sort position of channel groups from the backends.
One known backend which supports sorting of groups is TVHeadend, but i think there are more.

@Jalle19, @opdenkamp mind taking a look.
