### PR TITLE
Advanced setting for GUI refresh rate

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1994,7 +1994,7 @@ void CApplication::Render()
   if (limitFrames || !(flip || m_bPresentFrame))
   {
     if (!limitFrames)
-      singleFrameTime = 40; //if not flipping, loop at 25 fps
+      singleFrameTime = (unsigned int)g_advancedSettings.m_guiFrameTime; //if not flipping, loop at fixed fps
 
     unsigned int frameTime = now - m_lastFrameTime;
     if (frameTime < singleFrameTime)

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -370,6 +370,7 @@ void CAdvancedSettings::Initialize()
   m_guiVisualizeDirtyRegions = false;
   m_guiAlgorithmDirtyRegions = 3;
   m_guiDirtyRegionNoFlipTimeout = 0;
+  m_guiFrameTime = 40; // Default GUI refresh rate at 25 fps
   m_airTunesPort = 36666;
   m_airPlayPort = 36667;
 
@@ -1146,6 +1147,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetBoolean(pElement, "visualizedirtyregions", m_guiVisualizeDirtyRegions);
     XMLUtils::GetInt(pElement, "algorithmdirtyregions",     m_guiAlgorithmDirtyRegions);
     XMLUtils::GetInt(pElement, "nofliptimeout",             m_guiDirtyRegionNoFlipTimeout);
+    XMLUtils::GetInt(pElement, "frametime",                 m_guiFrameTime);
   }
 
   std::string seekSteps;

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -364,6 +364,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     bool m_guiVisualizeDirtyRegions;
     int  m_guiAlgorithmDirtyRegions;
     int  m_guiDirtyRegionNoFlipTimeout;
+    int  m_guiFrameTime;
     unsigned int m_addonPackageFolderSize;
 
     unsigned int m_cacheMemBufferSize;


### PR DESCRIPTION
Create a new GUI tag <frametime> in advanced settings to let the userdecide the refresh rate when not fliping. It will give the user better control over the responsiveness/cpu-usage trade off and provide integrators with a way to optimize their packages for small systems (e.g. OpenELEC for Raspberry Pi or AppleTV).

Default is kept at current 40 ms (25 fps).
