### PR TITLE
[Fix][GUIDialogSelect] Reset members buttonString and ButtonPressed on Reset()

### DIFF
--- a/xbmc/dialogs/GUIDialogSelect.cpp
+++ b/xbmc/dialogs/GUIDialogSelect.cpp
@@ -163,6 +163,8 @@ bool CGUIDialogSelect::OnBack(int actionID)
 void CGUIDialogSelect::Reset()
 {
   m_bButtonEnabled = false;
+  m_buttonString = -1;
+  m_bButtonPressed = false;
   m_useDetails = false;
   m_multiSelection = false;
   m_iSelected = -1;


### PR DESCRIPTION
If the "get more" button was pressed and the dialog was reopened (reused) any selection/click opened the "get more dialog" again.
