### PR TITLE
binary addons: don't try to build unsupported addons

### DIFF
--- a/project/cmake/addons/CMakeLists.txt
+++ b/project/cmake/addons/CMakeLists.txt
@@ -245,6 +245,9 @@ foreach(addon ${addons})
         endif()
 
         if(NOT "${SOURCE_DIR}" STREQUAL "" AND EXISTS ${SOURCE_DIR})
+          # create a list of addons we are building
+          list(APPEND ALL_ADDONS_BUILDING ${id})
+
           # setup the buildsystem for the addon
           externalproject_add(${id}
                               SOURCE_DIR ${SOURCE_DIR}
@@ -275,6 +278,9 @@ foreach(addon ${addons})
         else()
           message(FATAL_ERROR "${id}: invalid or missing addon source directory at ${SOURCE_DIR}")
         endif()
+      else()
+        # add a dummy target for addons that are unsupported on this platform
+        add_custom_target(${id} COMMAND ${CMAKE_COMMAND} -E echo "IGNORED ${id} - not supported on ${CORE_SYSTEM_NAME}\n")
       endif()
     endif()
   endif()
@@ -288,3 +294,7 @@ if(NEED_SUDO)
                     COMMAND sudo ${CMAKE_COMMAND} -E remove_directory ${ADDON_INSTALL_DIR}/
                     COMMAND sudo -k)
 endif()
+
+# add custom target "supported_addons" that returns all addons that are supported on this platform
+string(REPLACE ";" " " ALL_ADDONS_BUILDING "${ALL_ADDONS_BUILDING}")
+add_custom_target(supported_addons COMMAND ${CMAKE_COMMAND} -E echo "ALL_ADDONS_BUILDING: ${ALL_ADDONS_BUILDING}" VERBATIM)

--- a/project/cmake/addons/CMakeLists.txt
+++ b/project/cmake/addons/CMakeLists.txt
@@ -248,7 +248,7 @@ foreach(addon ${addons})
           # setup the buildsystem for the addon
           externalproject_add(${id}
                               SOURCE_DIR ${SOURCE_DIR}
-                              INSTALL_DIR ${CMAKE_INSTALL_PREFIX}
+                              INSTALL_DIR ${ADDON_INSTALL_DIR}
                               CMAKE_ARGS ${BUILD_ARGS})
 
           # add a custom step to the external project between the configure and the build step which will always

--- a/tools/buildsteps/win32/make-addons.bat
+++ b/tools/buildsteps/win32/make-addons.bat
@@ -108,8 +108,20 @@ IF ERRORLEVEL 1 (
   GOTO ERROR
 )
 
+rem get the list of addons that can actually be built
+SET ADDONS_TO_MAKE=
+SETLOCAL EnableDelayedExpansion
+FOR /f "delims=" %%i IN ('nmake supported_addons') DO (
+  SET line="%%i"
+  SET addons=!line:ALL_ADDONS_BUILDING=!
+  IF NOT "!addons!" == "!line!" (
+    SET ADDONS_TO_MAKE=!addons:~3,-1!
+  )
+)
+SETLOCAL DisableDelayedExpansion
+
 rem loop over all addons to build
-FOR %%a IN (%ADDONS_TO_BUILD%) DO (
+FOR %%a IN (%ADDONS_TO_MAKE%) DO (
   ECHO Building %%a...
   rem execute nmake to build the addons
   nmake %%a

--- a/tools/depends/xbmc-addons.include
+++ b/tools/depends/xbmc-addons.include
@@ -59,11 +59,11 @@ endif
          $(CMAKE) -DCMAKE_INSTALL_PREFIX=$(INSTALL_PREFIX) $(CMAKE_EXTRA) \
          $(TOOLCHAIN) \
          -DADDONS_TO_BUILD=$(ADDONS) $(ADDON_PROJECT_DIR) -DBUILD_DIR=$(BUILDDIR)/$(PLATFORM)/build ;\
-         for addon in "$(ADDONS)"; do \
+         for addon in $$(make supported_addons | awk '/^ALL_ADDONS_BUILDING: .*$$/ { first = $$1; $$1 = ""; print $$0 }'); do \
            $(MAKE) $$addon && echo $$addon >> $(ADDON_PROJECT_DIR)/.success || echo $$addon >> $(ADDON_PROJECT_DIR)/.failure ;\
          done
 ifneq ($(CROSS_COMPILING),yes)
-	@[ -f $(ADDON_PROJECT_DIR)/.failure ] && echo "Following Addons failed to build: $(shell cat $(ADDON_PROJECT_DIR)/.failure)"
+	@[ -f $(ADDON_PROJECT_DIR)/.failure ] && echo "Following Addons failed to build:" $(shell cat $(ADDON_PROJECT_DIR)/.failure)
 	@[ -w $(INSTALL_PREFIX) ] || $(MAKE) -C $(PLATFORM) install
 endif
 	touch $@


### PR DESCRIPTION
@Montellese @Memphiz as discussed.
fixes issues introduced with #6678

This add a custom target "supported_addons" that can be used to retrieve all addons that cmake considers supported on this platform.
We then use this list in the depends Makefile.
Not sure whats needed on win32.

I've also slipped in a fix for linux standalone sudo install, as that got broken again somehow.
