### PR TITLE
Add more native artifacts to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -466,6 +466,8 @@ lib/cpluff/stamp-h1
 #/tools/depends
 /tools/depends/native/*/*native/
 /tools/depends/native/JsonSchemaBuilder/bin/
+/tools/depends/native/libsquish-native/squish-install/
+/tools/depends/native/TexturePacker/bin/
 /tools/depends/target/ffmpeg/.ffmpeg-installed
 /tools/depends/target/ffmpeg/ffmpeg-*-*.tar.gz
 /tools/depends/target/ffmpeg/ffmpeg-*-*/


### PR DESCRIPTION
Add TexturePacker and libsquish-native artifacts to .gitignore.
On a related note, why is 
`xbmc/visualizations/Goom/goom2k4-0/mkinstalldirs`
modified during build time?

After a build one has to git checkout the file every time.
