### PR TITLE
[subtitles] refactor - fetch based on media basepath

### DIFF
--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -402,6 +402,28 @@ bool URIUtils::GetParentPath(const std::string& strPath, std::string& strParent)
   return true;
 }
 
+std::string URIUtils::GetBasePath(const std::string& strPath)
+{
+  std::string strCheck(strPath);
+  if (IsStack(strPath))
+    strCheck = CStackDirectory::GetFirstStackedFile(strPath);
+
+  std::string strDirectory = GetDirectory(strCheck);
+  if (IsInRAR(strCheck))
+  {
+    std::string strPath=strDirectory;
+    GetParentPath(strPath, strDirectory);
+  }
+  if (IsStack(strPath))
+  {
+    strCheck = strDirectory;
+    RemoveSlashAtEnd(strCheck);
+    if (GetFileName(strCheck).size() == 3 && StringUtils::StartsWithNoCase(GetFileName(strCheck), "cd"))
+      strDirectory = GetDirectory(strCheck);
+  }
+  return strDirectory;
+}
+
 std::string URLEncodePath(const std::string& strPath)
 {
   vector<string> segments = StringUtils::Split(strPath, "/");

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -72,6 +72,12 @@ public:
   static std::string GetParentPath(const std::string& strPath);
   static bool GetParentPath(const std::string& strPath, std::string& strParent);
 
+  /*! \brief Retrieve the base path, accounting for stacks and files in rars.
+   \param strPath path.
+   \return the folder that contains the item.
+   */
+  static std::string GetBasePath(const std::string& strPath);
+
   /* \brief Change the base path of a URL: fromPath/fromFile -> toPath/toFile
     Handles changes in path separator and filename URL encoding if necessary to derive toFile.
     \param fromPath the base path of the original URL

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1343,7 +1343,7 @@ namespace VIDEO
     pItem->SetArt(art);
 
     // parent folder to apply the thumb to and to search for local actor thumbs
-    std::string parentDir = GetParentDir(*pItem);
+    std::string parentDir = URIUtils::GetBasePath(pItem->GetPath());
     if (CSettings::Get().GetBool("videolibrary.actorthumbs"))
       FetchActorThumbs(movieDetails.m_cast, actorArtPath.empty() ? parentDir : actorArtPath);
     if (bApplyToDir)
@@ -2058,27 +2058,4 @@ namespace VIDEO
     }
     return 0;    // didn't find anything
   }
-
-  std::string CVideoInfoScanner::GetParentDir(const CFileItem &item) const
-  {
-    std::string strCheck = item.GetPath();
-    if (item.IsStack())
-      strCheck = CStackDirectory::GetFirstStackedFile(item.GetPath());
-
-    std::string strDirectory = URIUtils::GetDirectory(strCheck);
-    if (URIUtils::IsInRAR(strCheck))
-    {
-      std::string strPath=strDirectory;
-      URIUtils::GetParentPath(strPath, strDirectory);
-    }
-    if (item.IsStack())
-    {
-      strCheck = strDirectory;
-      URIUtils::RemoveSlashAtEnd(strCheck);
-      if (URIUtils::GetFileName(strCheck).size() == 3 && StringUtils::StartsWithNoCase(URIUtils::GetFileName(strCheck), "cd"))
-        strDirectory = URIUtils::GetDirectory(strCheck);
-    }
-    return strDirectory;
-  }
-
 }

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -235,12 +235,6 @@ namespace VIDEO
 
     std::string GetnfoFile(CFileItem *item, bool bGrabAny=false) const;
 
-    /*! \brief Retrieve the parent folder of an item, accounting for stacks and files in rars.
-     \param item a media item.
-     \return the folder that contains the item.
-     */
-    std::string GetParentDir(const CFileItem &item) const;
-
     bool m_showDialog;
     CGUIDialogProgressBarHandle* m_handle;
     int m_currentItem;


### PR DESCRIPTION
This is a refactor for `ScanForExternalSubtitles` that's in my tree for too long now. Instead of wildly and blindly stating around for possible subtitle directories, this one tries to determine the external subtitle by doing one listing of the media's basepath and other related paths if needed. This reduces the amount of useless stats to a minimum.

@ace20022, @arnova, @Montellese for review please. 
@MilhouseVH can we get this one in your RPI builds to get some testers on it?
