### PR TITLE
[savefilestate] notify the list to update - not just the item

### DIFF
--- a/xbmc/utils/SaveFileStateJob.cpp
+++ b/xbmc/utils/SaveFileStateJob.cpp
@@ -155,7 +155,7 @@ bool CSaveFileStateJob::DoWork()
           CFileItemPtr msgItem(new CFileItem(m_item));
           if (m_item.HasProperty("original_listitem_url"))
             msgItem->SetPath(m_item.GetProperty("original_listitem_url").asString());
-          CGUIMessage message(GUI_MSG_NOTIFY_ALL, g_windowManager.GetActiveWindow(), 0, GUI_MSG_UPDATE_ITEM, 1, msgItem); // 1 to update the listing as well
+          CGUIMessage message(GUI_MSG_NOTIFY_ALL, g_windowManager.GetActiveWindow(), 0, GUI_MSG_UPDATE);
           g_windowManager.SendThreadMessage(message);
         }
       }


### PR DESCRIPTION
This is needed in order to update the entire list so other functions are able to actually use the
updated playcount without having to re-fetch the list and enables skip to next unwatched after
playback ended in case the option "Select the first unwatched TV show season/episode" is set to always.

@Montellese, @xhaggi for review please.
