### PR TITLE
[confluence] Consistent usage of same string resource for "EPG".

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -7936,7 +7936,7 @@ msgctxt "#19068"
 msgid "This recording could not be deleted. Check the log for details."
 msgstr ""
 
-#: system/settings/settings.xml
+#. Electronic program guide. used by ?
 msgctxt "#19069"
 msgid "EPG"
 msgstr ""
@@ -12099,8 +12099,10 @@ msgctxt "#22019"
 msgid "Recordings by title"
 msgstr ""
 
-#. Electronic program guide, used as label in the menu of the PVR section
-#: addons/skin/confluence
+#. Electronic program guide, used as label in the menu of the PVR settings section and by confluence and other skins
+#: system/settings/settings.xml
+#: addons/skin.confluence/720p/IncludesPVR.xml
+#: addons/skin.confluence/720p/IncludesHomeMenuItems.xml
 msgctxt "#22020"
 msgid "Guide"
 msgstr ""

--- a/addons/skin.confluence/720p/IncludesHomeMenuItems.xml
+++ b/addons/skin.confluence/720p/IncludesHomeMenuItems.xml
@@ -259,7 +259,7 @@
 		</control>
 		<control type="button" id="90144">
 			<include>ButtonHomeSubCommonValues</include>
-			<label>19069</label>
+			<label>22020</label>
 			<onclick>ActivateWindow(TVGuide)</onclick>
 		</control>
 		<control type="button" id="90145">
@@ -296,7 +296,7 @@
 		</control>
 		<control type="button" id="90244">
 			<include>ButtonHomeSubCommonValues</include>
-			<label>19069</label>
+			<label>22020</label>
 			<onclick>ActivateWindow(RadioGuide)</onclick>
 		</control>
 		<control type="button" id="90245">

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1298,7 +1298,7 @@
         </setting>
       </group>
     </category>
-    <category id="epg" label="19069" help="36218">
+    <category id="epg" label="22020" help="36218">
       <group id="1">
         <setting id="epg.daystodisplay" type="integer" label="19182" help="36220">
           <level>2</level>


### PR DESCRIPTION
Currently Electronic Program Guide at some places appears as "EPG", at other places as "Guide"

Guide:
https://github.com/xbmc/xbmc/blob/master/addons/skin.confluence/720p/IncludesPVR.xml#L38
https://github.com/xbmc/xbmc/blob/master/addons/skin.confluence/720p/IncludesPVR.xml#L109

vs. "EPG":
https://github.com/xbmc/xbmc/blob/master/addons/skin.confluence/720p/IncludesHomeMenuItems.xml#L263
https://github.com/xbmc/xbmc/blob/master/addons/skin.confluence/720p/IncludesHomeMenuItems.xml#L299

This PR changes this inconsistency in favour to consequent usage of "EPG".

@ronie mind taking a look
