### PR TITLE
Remove throw() specifications since they're not used anymore in C++11

### DIFF
--- a/xbmc/commons/Buffer.h
+++ b/xbmc/commons/Buffer.h
@@ -94,7 +94,7 @@ namespace XbmcCommons
     size_t mcapacity;
     size_t mlimit;
 
-    inline void check(int count) const throw(BufferException)
+    inline void check(int count) const
     { 
       if ((mposition + count) > mlimit) 
         throw BufferException("Buffer buffer overflow: Cannot add more data to the Buffer's buffer.");
@@ -219,15 +219,15 @@ namespace XbmcCommons
      */
     inline size_t remaining() { return mlimit - mposition; }
 
-    inline Buffer& put(const void* src, size_t bytes) throw(BufferException)
+    inline Buffer& put(const void* src, size_t bytes)
     { check(bytes); memcpy( buffer + mposition, src, bytes); mposition += bytes; return *this; }
-    inline Buffer& get(void* dest, size_t bytes) throw(BufferException) 
+    inline Buffer& get(void* dest, size_t bytes)
     { check(bytes); memcpy( dest, buffer + mposition, bytes); mposition += bytes; return *this; }
 
     inline unsigned char* array() { return buffer; }
     inline unsigned char* curPosition() { return buffer + mposition; }
     inline Buffer& setPosition(size_t position) { mposition = position; return *this; }
-    inline Buffer& forward(size_t positionIncrement) throw(BufferException)
+    inline Buffer& forward(size_t positionIncrement)
     { check(positionIncrement); mposition += positionIncrement; return *this; }
 
     inline size_t limit() const { return mlimit; }
@@ -235,8 +235,8 @@ namespace XbmcCommons
     inline size_t position() const { return mposition; }
 
 #define DEFAULTBUFFERRELATIVERW(name,type) \
-    inline Buffer& put##name(const type & val) throw(BufferException) { return put(&val, sizeof(type)); } \
-    inline type get##name() throw(BufferException) { type ret; get(&ret, sizeof(type)); return ret; }
+    inline Buffer& put##name(const type & val) { return put(&val, sizeof(type)); } \
+    inline type get##name() { type ret; get(&ret, sizeof(type)); return ret; }
 
     DEFAULTBUFFERRELATIVERW(Bool,bool);
     DEFAULTBUFFERRELATIVERW(Int,int);
@@ -248,18 +248,18 @@ namespace XbmcCommons
     DEFAULTBUFFERRELATIVERW(LongLong,long long);
 #undef DEFAULTBUFFERRELATIVERW
 
-    inline Buffer& putString(const char* str) throw (BufferException) { size_t len = strlen(str) + 1; check(len); put(str, len); return (*this); }
-    inline Buffer& putString(const std::string& str) throw (BufferException) { size_t len = str.length() + 1; check(len); put(str.c_str(), len); return (*this); }
+    inline Buffer& putString(const char* str) { size_t len = strlen(str) + 1; check(len); put(str, len); return (*this); }
+    inline Buffer& putString(const std::string& str) { size_t len = str.length() + 1; check(len); put(str.c_str(), len); return (*this); }
 
-    inline std::string getString() throw (BufferException) { std::string ret((const char*)(buffer + mposition)); size_t len = ret.length() + 1; check(len); mposition += len; return ret; }
-    inline std::string getString(size_t length) throw (BufferException) 
+    inline std::string getString() { std::string ret((const char*)(buffer + mposition)); size_t len = ret.length() + 1; check(len); mposition += len; return ret; }
+    inline std::string getString(size_t length)
     { 
       check(length); 
       std::string ret((const char*)(buffer + mposition),length);
       mposition += length;
       return ret;
     }
-    inline char* getCharPointerDirect() throw (BufferException) { char* ret = (char*)(buffer + mposition); size_t len = strlen(ret) + 1; check(len); mposition += len; return ret; }
+    inline char* getCharPointerDirect() { char* ret = (char*)(buffer + mposition); size_t len = strlen(ret) + 1; check(len); mposition += len; return ret; }
 
   };
 

--- a/xbmc/interfaces/legacy/Addon.cpp
+++ b/xbmc/interfaces/legacy/Addon.cpp
@@ -37,7 +37,7 @@ namespace XBMCAddon
 
     String Addon::getAddonVersion() { return languageHook == NULL ? emptyString : languageHook->GetAddonVersion(); }
 
-    Addon::Addon(const char* cid) throw (AddonException)
+    Addon::Addon(const char* cid)
     {
       String id(cid ? cid : emptyString);
 
@@ -105,7 +105,7 @@ namespace XBMCAddon
       CGUIDialogAddonSettings::ShowAndGetInput(addon);
     }
 
-    String Addon::getAddonInfo(const char* id) throw (AddonException)
+    String Addon::getAddonInfo(const char* id)
     {
       if (strcmpi(id, "author") == 0)
         return pAddon->Author();

--- a/xbmc/interfaces/legacy/Addon.h
+++ b/xbmc/interfaces/legacy/Addon.h
@@ -72,7 +72,7 @@ namespace XBMCAddon
        *  - self.Addon = xbmcaddon.Addon()
        *  - self.Addon = xbmcaddon.Addon('script.foo.bar')
        */
-      Addon(const char* id = NULL) throw (AddonException);
+      Addon(const char* id = NULL);
 
       virtual ~Addon();
 
@@ -128,7 +128,7 @@ namespace XBMCAddon
        * example:
        *   - version = self.Addon.getAddonInfo('version')
        */
-      String getAddonInfo(const char* id) throw (AddonException);
+      String getAddonInfo(const char* id);
     };
   }
 }

--- a/xbmc/interfaces/legacy/Alternative.h
+++ b/xbmc/interfaces/legacy/Alternative.h
@@ -47,7 +47,7 @@ namespace XBMCAddon
 
     inline WhichAlternative which() const { return pos; }
 
-    inline T1& former() throw (WrongTypeException)
+    inline T1& former()
     {
       unsigned char* data = m_data;
       if (pos == second)// first and none is ok
@@ -58,7 +58,7 @@ namespace XBMCAddon
       return *((T1*)data);
     }
 
-    inline const T1& former() const throw (WrongTypeException)
+    inline const T1& former() const
     {
       const unsigned char* data = m_data;
       if (pos != first)
@@ -66,7 +66,7 @@ namespace XBMCAddon
       return *((T1*)data);
     }
 
-    inline T2& later() throw (WrongTypeException)
+    inline T2& later()
     {
       unsigned char* data = m_data;
       if (pos == first)
@@ -77,7 +77,7 @@ namespace XBMCAddon
       return *((T2*)data);
     }
 
-    inline const T2& later() const throw (WrongTypeException)
+    inline const T2& later() const
     {
       const unsigned char* data = m_data;
       if (pos != second)
@@ -85,10 +85,10 @@ namespace XBMCAddon
       return *((T2*)data);
     }
 
-    inline operator T1& () throw (WrongTypeException) { return former(); }
-    inline operator const T1& () const throw (WrongTypeException) { return former(); }
-    inline operator T2& () throw (WrongTypeException) { return later(); }
-    inline operator const T2& () const throw (WrongTypeException) { return later(); }
+    inline operator T1& () { return former(); }
+    inline operator const T1& () const { return former(); }
+    inline operator T2& () { return later(); }
+    inline operator const T2& () const { return later(); }
   };
 }
 

--- a/xbmc/interfaces/legacy/Control.cpp
+++ b/xbmc/interfaces/legacy/Control.cpp
@@ -71,7 +71,7 @@ namespace XBMCAddon
       pGUIControl = NULL;
     }
 
-    void ControlFadeLabel::addLabel(const String& label) throw (UnimplementedException)
+    void ControlFadeLabel::addLabel(const String& label)
     {
       CGUIMessage msg(GUI_MSG_LABEL_ADD, iParentId, iControlId);
       msg.SetLabel(label);
@@ -79,7 +79,7 @@ namespace XBMCAddon
       g_windowManager.SendThreadMessage(msg, iParentId);
     }
 
-    void ControlFadeLabel::reset() throw (UnimplementedException)
+    void ControlFadeLabel::reset()
     {
       CGUIMessage msg(GUI_MSG_LABEL_RESET, iParentId, iControlId);
 
@@ -87,7 +87,7 @@ namespace XBMCAddon
       g_windowManager.SendThreadMessage(msg, iParentId);
     }
 
-    CGUIControl* ControlFadeLabel::Create() throw (WindowException)
+    CGUIControl* ControlFadeLabel::Create()
     {
       CLabelInfo label;
       label.font = g_fontManager.GetFont(strFont);
@@ -131,7 +131,7 @@ namespace XBMCAddon
         sscanf(_textColor, "%x", &textColor);
     }
 
-    void ControlTextBox::setText(const String& text) throw(UnimplementedException)
+    void ControlTextBox::setText(const String& text)
     {
       // create message
       CGUIMessage msg(GUI_MSG_LABEL_SET, iParentId, iControlId);
@@ -141,7 +141,7 @@ namespace XBMCAddon
       g_windowManager.SendThreadMessage(msg, iParentId);
     }
 
-    String ControlTextBox::getText() throw (UnimplementedException)
+    String ControlTextBox::getText()
     {
       if (!pGUIControl) return NULL;
 
@@ -149,24 +149,24 @@ namespace XBMCAddon
       return ((CGUITextBox*) pGUIControl)->GetDescription();
     }
 
-    void ControlTextBox::reset() throw(UnimplementedException)
+    void ControlTextBox::reset()
     {
       // create message
       CGUIMessage msg(GUI_MSG_LABEL_RESET, iParentId, iControlId);
       g_windowManager.SendThreadMessage(msg, iParentId);
     }
 
-    void ControlTextBox::scroll(long position) throw(UnimplementedException)
+    void ControlTextBox::scroll(long position)
     {
       static_cast<CGUITextBox*>(pGUIControl)->Scroll((int)position);
     }
 
-    void ControlTextBox::autoScroll(int delay, int time, int repeat) throw(UnimplementedException)
+    void ControlTextBox::autoScroll(int delay, int time, int repeat)
     {
       static_cast<CGUITextBox*>(pGUIControl)->SetAutoScrolling(delay, time, repeat);
     }
 
-    CGUIControl* ControlTextBox::Create() throw (WindowException)
+    CGUIControl* ControlTextBox::Create()
     {
       // create textbox
       CLabelInfo label;
@@ -224,7 +224,7 @@ namespace XBMCAddon
                                  const char* _disabledColor,
                                  const char* _shadowColor,
                                  const char* _focusedColor,
-                                 const String& label2) throw (UnimplementedException)
+                                 const String& label2)
     {
       if (!label.empty()) strText = label;
       if (!label2.empty()) strText2 = label2;
@@ -243,7 +243,7 @@ namespace XBMCAddon
       }
     }
 
-    void ControlButton::setDisabledColor(const char* color) throw (UnimplementedException)
+    void ControlButton::setDisabledColor(const char* color)
     { 
       if (color) sscanf(color, "%x", &disabledColor);
 
@@ -254,7 +254,7 @@ namespace XBMCAddon
       }
     }
 
-    String ControlButton::getLabel() throw (UnimplementedException)
+    String ControlButton::getLabel()
     {
       if (!pGUIControl) return NULL;
 
@@ -262,7 +262,7 @@ namespace XBMCAddon
       return ((CGUIButtonControl*) pGUIControl)->GetLabel();
     }
 
-    String ControlButton::getLabel2() throw (UnimplementedException)
+    String ControlButton::getLabel2()
     {
       if (!pGUIControl) return NULL;
 
@@ -270,7 +270,7 @@ namespace XBMCAddon
       return ((CGUIButtonControl*) pGUIControl)->GetLabel2();
     }
 
-    CGUIControl* ControlButton::Create() throw (WindowException)
+    CGUIControl* ControlButton::Create()
     {
       CLabelInfo label;
       label.font = g_fontManager.GetFont(strFont);
@@ -330,7 +330,7 @@ namespace XBMCAddon
         XBMCAddonUtils::getDefaultImage((char*)"checkmark", (char*)"texturenofocus", (char*)"check-boxNF.png");
     }
 
-    bool ControlCheckMark::getSelected() throw (UnimplementedException)
+    bool ControlCheckMark::getSelected()
     {
       bool isSelected = false;
 
@@ -343,7 +343,7 @@ namespace XBMCAddon
       return isSelected;
     }
 
-    void ControlCheckMark::setSelected(bool selected) throw (UnimplementedException)
+    void ControlCheckMark::setSelected(bool selected)
     {
       if (pGUIControl)
       {
@@ -358,7 +358,7 @@ namespace XBMCAddon
                                     const char* _disabledColor,
                                     const char* _shadowColor,
                                     const char* _focusedColor,
-                                    const String& label2) throw (UnimplementedException)
+                                    const String& label2)
     {
 
       if (font) strFont = font;
@@ -373,7 +373,7 @@ namespace XBMCAddon
       }
     }
 
-    void ControlCheckMark::setDisabledColor(const char* color) throw (UnimplementedException)
+    void ControlCheckMark::setDisabledColor(const char* color)
     {
       if (color) sscanf(color, "%x", &disabledColor);
 
@@ -384,7 +384,7 @@ namespace XBMCAddon
       }
     }
 
-    CGUIControl* ControlCheckMark::Create() throw (WindowException)
+    CGUIControl* ControlCheckMark::Create()
     {
       CLabelInfo label;
       label.disabledColor = disabledColor;
@@ -431,7 +431,7 @@ namespace XBMCAddon
         sscanf(_colorDiffuse, "%x", &colorDiffuse);
     }
 
-    void ControlImage::setImage(const char* imageFilename, const bool useCache) throw (UnimplementedException)
+    void ControlImage::setImage(const char* imageFilename, const bool useCache)
     {
       strFileName = imageFilename;
 
@@ -440,7 +440,7 @@ namespace XBMCAddon
         ((CGUIImage*)pGUIControl)->SetFileName(strFileName, false, useCache);
     }
 
-    void ControlImage::setColorDiffuse(const char* cColorDiffuse) throw (UnimplementedException)
+    void ControlImage::setColorDiffuse(const char* cColorDiffuse)
     {
       if (cColorDiffuse) sscanf(cColorDiffuse, "%x", &colorDiffuse);
       else colorDiffuse = 0;
@@ -450,7 +450,7 @@ namespace XBMCAddon
         ((CGUIImage *)pGUIControl)->SetColorDiffuse(colorDiffuse);
     }
     
-    CGUIControl* ControlImage::Create() throw (WindowException)
+    CGUIControl* ControlImage::Create()
     {
       pGUIControl = new CGUIImage(iParentId, iControlId,
             (float)dwPosX, (float)dwPosY, (float)dwWidth, (float)dwHeight,
@@ -494,18 +494,18 @@ namespace XBMCAddon
         XBMCAddonUtils::getDefaultImage((char*)"progress", (char*)"overlaytexture", (char*)"progress_over.png");
     }
 
-    void ControlProgress::setPercent(float pct) throw (UnimplementedException)
+    void ControlProgress::setPercent(float pct)
     {
       if (pGUIControl)
         ((CGUIProgressControl*)pGUIControl)->SetPercentage(pct);
     }
 
-    float ControlProgress::getPercent() throw (UnimplementedException)
+    float ControlProgress::getPercent()
     {
       return (pGUIControl) ? ((CGUIProgressControl*)pGUIControl)->GetPercentage() : 0.0f;
     }
 
-    CGUIControl* ControlProgress::Create() throw (WindowException)
+    CGUIControl* ControlProgress::Create()
     {
       pGUIControl = new CGUIProgressControl(iParentId, iControlId,
          (float)dwPosX, (float)dwPosY,
@@ -543,18 +543,18 @@ namespace XBMCAddon
         XBMCAddonUtils::getDefaultImage((char*)"slider", (char*)"textureslidernibfocus", (char*)"osd_slider_nib.png");
     }
 
-    float ControlSlider::getPercent() throw (UnimplementedException)
+    float ControlSlider::getPercent()
     {
       return (pGUIControl) ? ((CGUISliderControl*)pGUIControl)->GetPercentage() : 0.0f;
     }
 
-    void ControlSlider::setPercent(float pct) throw (UnimplementedException)
+    void ControlSlider::setPercent(float pct)
     {
       if (pGUIControl)
         ((CGUISliderControl*)pGUIControl)->SetPercentage(pct);
     }
 
-    CGUIControl* ControlSlider::Create () throw (WindowException)
+    CGUIControl* ControlSlider::Create ()
     {
       pGUIControl = new CGUISliderControl(iParentId, iControlId,(float)dwPosX, (float)dwPosY,
                                           (float)dwWidth,(float)dwHeight,
@@ -576,7 +576,7 @@ namespace XBMCAddon
       dwHeight = height;
     }
 
-    CGUIControl* ControlGroup::Create() throw (WindowException)
+    CGUIControl* ControlGroup::Create()
     {
       pGUIControl = new CGUIControlGroup(iParentId,
                                          iControlId,
@@ -645,7 +645,7 @@ namespace XBMCAddon
       if (_focusedColor) sscanf( _focusedColor, "%x", &focusedColor );
     }
 
-    void ControlRadioButton::setSelected(bool selected) throw (UnimplementedException)
+    void ControlRadioButton::setSelected(bool selected)
     {
       if (pGUIControl)
       {
@@ -654,7 +654,7 @@ namespace XBMCAddon
       }
     }
 
-    bool ControlRadioButton::isSelected() throw (UnimplementedException)
+    bool ControlRadioButton::isSelected()
     {
       bool isSelected = false;
 
@@ -672,7 +672,7 @@ namespace XBMCAddon
                                       const char* _disabledColor,
                                       const char* _shadowColor,
                                       const char* _focusedColor,
-                                      const String& label2) throw (UnimplementedException)
+                                      const String& label2)
     {
       if (!label.empty()) strText = label;
       if (font) strFont = font;
@@ -690,7 +690,6 @@ namespace XBMCAddon
     }
 
     void ControlRadioButton::setRadioDimension(long x, long y, long width, long height) 
-      throw (UnimplementedException)
     {
       dwPosX = x;
       dwPosY = y;
@@ -703,7 +702,7 @@ namespace XBMCAddon
       }
     }
 
-    CGUIControl* ControlRadioButton::Create() throw (WindowException)
+    CGUIControl* ControlRadioButton::Create()
     {
       CLabelInfo label;
       label.font = g_fontManager.GetFont(strFont);
@@ -744,7 +743,7 @@ namespace XBMCAddon
     // ============================================================
     Control::~Control() { deallocating(); }
 
-    CGUIControl* Control::Create() throw (WindowException)
+    CGUIControl* Control::Create()
     {
       throw WindowException("Object is a Control, but can't be added to a window");
     }
@@ -791,7 +790,7 @@ namespace XBMCAddon
         pGUIControl->SetEnableCondition(enable);
     }
 
-    void Control::setAnimations(const std::vector< Tuple<String,String> >& eventAttr) throw (WindowException)
+    void Control::setAnimations(const std::vector< Tuple<String,String> >& eventAttr)
     {
       CXBMCTinyXML xmlDoc;
       TiXmlElement xmlRootElement("control");
@@ -863,7 +862,6 @@ namespace XBMCAddon
 
     void Control::setNavigation(const Control* up, const Control* down,
                                 const Control* left, const Control* right) 
-      throw (WindowException)
     {
       if(iControlId == 0)
         throw WindowException("Control has to be added to a window first");
@@ -880,7 +878,7 @@ namespace XBMCAddon
       }
     }
 
-    void Control::controlUp(const Control* control) throw (WindowException)
+    void Control::controlUp(const Control* control)
     {
       if(iControlId == 0)
         throw WindowException("Control has to be added to a window first");
@@ -892,7 +890,7 @@ namespace XBMCAddon
       }
     }
 
-    void Control::controlDown(const Control* control) throw (WindowException)
+    void Control::controlDown(const Control* control)
     {
       if(iControlId == 0)
         throw WindowException("Control has to be added to a window first");
@@ -904,7 +902,7 @@ namespace XBMCAddon
       }
     }
 
-    void Control::controlLeft(const Control* control) throw (WindowException)
+    void Control::controlLeft(const Control* control)
     {
       if(iControlId == 0)
         throw WindowException("Control has to be added to a window first");
@@ -916,7 +914,7 @@ namespace XBMCAddon
       }
     }
 
-    void Control::controlRight(const Control* control) throw (WindowException)
+    void Control::controlRight(const Control* control)
     {
       if(iControlId == 0)
         throw WindowException("Control has to be added to a window first");
@@ -949,7 +947,7 @@ namespace XBMCAddon
 
     void ControlSpin::setTextures(const char* up, const char* down, 
                                   const char* upFocus, 
-                                  const char* downFocus) throw(UnimplementedException)
+                                  const char* downFocus)
     {
       strTextureUp = up;
       strTextureDown = down;
@@ -999,7 +997,7 @@ namespace XBMCAddon
 
     ControlLabel::~ControlLabel() {}
 
-    CGUIControl* ControlLabel::Create()  throw (WindowException)
+    CGUIControl* ControlLabel::Create() 
     {
       CLabelInfo label;
       label.font = g_fontManager.GetFont(strFont);
@@ -1024,7 +1022,7 @@ namespace XBMCAddon
     void ControlLabel::setLabel(const String& label, const char* font,
                                 const char* textColor, const char* disabledColor,
                                 const char* shadowColor, const char* focusedColor,
-                                const String& label2) throw(UnimplementedException)
+                                const String& label2)
     {
       strText = label;
       CGUIMessage msg(GUI_MSG_LABEL_SET, iParentId, iControlId);
@@ -1032,7 +1030,7 @@ namespace XBMCAddon
       g_windowManager.SendThreadMessage(msg, iParentId);
     }
 
-    String ControlLabel::getLabel() throw(UnimplementedException)
+    String ControlLabel::getLabel()
     {
       if (!pGUIControl) 
         return NULL;
@@ -1063,7 +1061,7 @@ namespace XBMCAddon
       if (_disabledColor) sscanf( _disabledColor, "%x", &disabledColor );
     }
 
-    CGUIControl* ControlEdit::Create()  throw (WindowException)
+    CGUIControl* ControlEdit::Create() 
     {
       CLabelInfo label;
       label.font = g_fontManager.GetFont(strFont);
@@ -1090,7 +1088,7 @@ namespace XBMCAddon
     void ControlEdit::setLabel(const String& label, const char* font,
                                 const char* textColor, const char* disabledColor,
                                 const char* shadowColor, const char* focusedColor,
-                                const String& label2) throw(UnimplementedException)
+                                const String& label2)
     {
       strText = label;
       CGUIMessage msg(GUI_MSG_LABEL_SET, iParentId, iControlId);
@@ -1098,14 +1096,14 @@ namespace XBMCAddon
       g_windowManager.SendThreadMessage(msg, iParentId);
     }
 
-    String ControlEdit::getLabel() throw(UnimplementedException)
+    String ControlEdit::getLabel()
     {
       if (!pGUIControl) 
         return NULL;
       return strText;
     }
 
-    void ControlEdit::setText(const String& text) throw(UnimplementedException)
+    void ControlEdit::setText(const String& text)
     {
       // create message
       CGUIMessage msg(GUI_MSG_LABEL2_SET, iParentId, iControlId);
@@ -1115,7 +1113,7 @@ namespace XBMCAddon
       g_windowManager.SendThreadMessage(msg, iParentId);
     }
 
-    String ControlEdit::getText() throw(UnimplementedException)
+    String ControlEdit::getText()
     {
       CGUIMessage msg(GUI_MSG_ITEM_SELECTED, iParentId, iControlId);
       g_windowManager.SendMessage(msg, iParentId);
@@ -1170,7 +1168,7 @@ namespace XBMCAddon
 
     ControlList::~ControlList() { }
 
-    CGUIControl* ControlList::Create() throw (WindowException)
+    CGUIControl* ControlList::Create()
     {
       CLabelInfo label;
       label.align = alignmentY;
@@ -1222,7 +1220,7 @@ namespace XBMCAddon
       sendLabelBind(items.size());
     }
 
-    void ControlList::internAddListItem(AddonClass::Ref<ListItem> pListItem, bool sendMessage) throw (WindowException)
+    void ControlList::internAddListItem(AddonClass::Ref<ListItem> pListItem, bool sendMessage)
     {
       if (pListItem.isNull())
         throw WindowException("NULL ListItem passed to ControlList::addListItem");
@@ -1247,7 +1245,7 @@ namespace XBMCAddon
       g_windowManager.SendThreadMessage(msg, iParentId);
     }
 
-    void ControlList::selectItem(long item) throw(UnimplementedException)
+    void ControlList::selectItem(long item)
     {
       // create message
       CGUIMessage msg(GUI_MSG_ITEM_SELECT, iParentId, iControlId, item);
@@ -1256,7 +1254,7 @@ namespace XBMCAddon
       g_windowManager.SendThreadMessage(msg, iParentId);
     }
 
-    void ControlList::removeItem(int index) throw(UnimplementedException,WindowException)
+    void ControlList::removeItem(int index)
     {
       if (index < 0 || index >= (int)vecItems.size())
         throw WindowException("Index out of range");
@@ -1266,7 +1264,7 @@ namespace XBMCAddon
       sendLabelBind(vecItems.size());
     }
 
-    void ControlList::reset() throw(UnimplementedException)
+    void ControlList::reset()
     {
       CGUIMessage msg(GUI_MSG_LABEL_RESET, iParentId, iControlId);
 
@@ -1277,12 +1275,12 @@ namespace XBMCAddon
       vecItems.clear(); // this should delete all of the objects
     }
 
-    Control* ControlList::getSpinControl() throw (UnimplementedException)
+    Control* ControlList::getSpinControl()
     {
       return pControlSpin;
     }
 
-    long ControlList::getSelectedPosition() throw(UnimplementedException)
+    long ControlList::getSelectedPosition()
     {
       DelayedCallGuard dcguard(languageHook);
       LOCKGUI;
@@ -1301,7 +1299,7 @@ namespace XBMCAddon
       return pos;
     }
 
-    XBMCAddon::xbmcgui::ListItem* ControlList::getSelectedItem() throw (UnimplementedException)
+    XBMCAddon::xbmcgui::ListItem* ControlList::getSelectedItem()
     {
       DelayedCallGuard dcguard(languageHook);
       LOCKGUI;
@@ -1321,7 +1319,7 @@ namespace XBMCAddon
       return pListItem.get();
     }
 
-    void ControlList::setImageDimensions(long imageWidth,long imageHeight) throw (UnimplementedException)
+    void ControlList::setImageDimensions(long imageWidth,long imageHeight)
     {
       CLog::Log(LOGWARNING,"ControlList::setImageDimensions was called but ... it currently isn't defined to do anything.");
       /*
@@ -1335,7 +1333,7 @@ namespace XBMCAddon
       */
     }
 
-    void ControlList::setItemHeight(long height) throw (UnimplementedException)
+    void ControlList::setItemHeight(long height)
     {
       CLog::Log(LOGWARNING,"ControlList::setItemHeight was called but ... it currently isn't defined to do anything.");
       /*
@@ -1349,7 +1347,7 @@ namespace XBMCAddon
       */
     }
 
-    void ControlList::setSpace(int space) throw (UnimplementedException)
+    void ControlList::setSpace(int space)
     {
       CLog::Log(LOGWARNING,"ControlList::setSpace was called but ... it currently isn't defined to do anything.");
       /*
@@ -1363,7 +1361,7 @@ namespace XBMCAddon
       */
     }
 
-    void ControlList::setPageControlVisible(bool visible) throw (UnimplementedException)
+    void ControlList::setPageControlVisible(bool visible)
     {
       CLog::Log(LOGWARNING,"ControlList::setPageControlVisible was called but ... it currently isn't defined to do anything.");
 
@@ -1379,22 +1377,22 @@ namespace XBMCAddon
       */
     }
 
-    long ControlList::size() throw (UnimplementedException)
+    long ControlList::size()
     {
       return (long)vecItems.size();
     }
 
-    long ControlList::getItemHeight() throw(UnimplementedException)
+    long ControlList::getItemHeight()
     {
       return (long)itemHeight;
     }
 
-    long ControlList::getSpace() throw (UnimplementedException)
+    long ControlList::getSpace()
     {
       return (long)space;
     }
 
-    XBMCAddon::xbmcgui::ListItem* ControlList::getListItem(int index) throw (UnimplementedException,WindowException)
+    XBMCAddon::xbmcgui::ListItem* ControlList::getListItem(int index)
     {
       if (index < 0 || index >= (int)vecItems.size())
         throw WindowException("Index out of range");
@@ -1403,7 +1401,7 @@ namespace XBMCAddon
       return pListItem.get();
     }
 
-    void ControlList::setStaticContent(const ListItemList* pitems) throw (UnimplementedException)
+    void ControlList::setStaticContent(const ListItemList* pitems)
     {
       const ListItemList& vecItems = *pitems;
 

--- a/xbmc/interfaces/legacy/Control.h
+++ b/xbmc/interfaces/legacy/Control.h
@@ -56,7 +56,7 @@ namespace XBMCAddon
       virtual ~Control();
 
 #ifndef SWIG
-      virtual CGUIControl* Create() throw (WindowException);
+      virtual CGUIControl* Create();
 #endif
 
       // currently we only accept messages from a button or controllist with a select action
@@ -166,7 +166,7 @@ namespace XBMCAddon
        * example:
        *   - self.button.setAnimations([('focus', 'effect=zoom end=90,247,220,56 time=0',)])
        */
-      virtual void setAnimations(const std::vector< Tuple<String,String> >& eventAttr) throw (WindowException);
+      virtual void setAnimations(const std::vector< Tuple<String,String> >& eventAttr);
 
       // setPosition() Method
       /**
@@ -224,8 +224,7 @@ namespace XBMCAddon
        *   - self.button.setNavigation(self.button1, self.button2, self.button3, self.button4)
        */
       virtual void setNavigation(const Control* up, const Control* down,
-                                 const Control* left, const Control* right) 
-        throw (WindowException);
+                                 const Control* left, const Control* right);
 
       // controlUp() Method
       /**
@@ -242,7 +241,7 @@ namespace XBMCAddon
        * example:
        *   - self.button.controlUp(self.button1)
        */
-      virtual void controlUp(const Control* up) throw (WindowException);
+      virtual void controlUp(const Control* up);
 
       // controlDown() Method
       /**
@@ -259,7 +258,7 @@ namespace XBMCAddon
        * example:
        *   - self.button.controlDown(self.button1)
        */
-      virtual void controlDown(const Control* control) throw (WindowException);
+      virtual void controlDown(const Control* control);
 
       // controlLeft() Method
       /**
@@ -276,7 +275,7 @@ namespace XBMCAddon
        * example:
        *   - self.button.controlLeft(self.button1)
        */
-      virtual void controlLeft(const Control* control) throw (WindowException);
+      virtual void controlLeft(const Control* control);
 
       // controlRight() Method
       /**
@@ -293,7 +292,7 @@ namespace XBMCAddon
        * example:
        *   - self.button.controlRight(self.button1)
        */
-      virtual void controlRight(const Control* control) throw (WindowException);
+      virtual void controlRight(const Control* control);
 
 #ifndef SWIG
       int iControlId;
@@ -330,7 +329,7 @@ namespace XBMCAddon
        */
       virtual void setTextures(const char* up, const char* down, 
                                const char* upFocus, 
-                               const char* downFocus) throw(UnimplementedException);
+                               const char* downFocus);
 #ifndef SWIG
       color_t color;
       std::string strTextureUp;
@@ -385,7 +384,7 @@ namespace XBMCAddon
        * example:
        *   - label = self.label.getLabel()
        */
-      virtual String getLabel() throw(UnimplementedException);
+      virtual String getLabel();
 
       /**
        * setLabel(label) -- Set's text for this label.
@@ -401,7 +400,7 @@ namespace XBMCAddon
                             const char* disabledColor = NULL,
                             const char* shadowColor = NULL,
                             const char* focusedColor = NULL,
-                            const String& label2 = emptyString) throw(UnimplementedException);
+                            const String& label2 = emptyString);
 #ifndef SWIG
       ControlLabel() : 
         bHasPath(false),
@@ -416,7 +415,7 @@ namespace XBMCAddon
       bool bHasPath;
       int iAngle;
 
-      SWIGHIDDENVIRTUAL CGUIControl* Create() throw (WindowException);
+      SWIGHIDDENVIRTUAL CGUIControl* Create();
 
 #endif
     };
@@ -473,7 +472,7 @@ namespace XBMCAddon
                             const char* disabledColor = NULL,
                             const char* shadowColor = NULL,
                             const char* focusedColor = NULL,
-                            const String& label2 = emptyString) throw(UnimplementedException);
+                            const String& label2 = emptyString);
 
       // getLabel() Method
       /**
@@ -482,7 +481,7 @@ namespace XBMCAddon
        * example:
        *   - label = self.edit.getLabel()
        */
-      virtual String getLabel() throw(UnimplementedException);
+      virtual String getLabel();
 
       // setText() Method
       /**
@@ -493,7 +492,7 @@ namespace XBMCAddon
        * example:
        *   - self.edit.setText('online')
        */
-      virtual void setText(const String& text) throw(UnimplementedException);
+      virtual void setText(const String& text);
 
       // getText() Method
       /**
@@ -502,7 +501,7 @@ namespace XBMCAddon
        * example:
        *   - value = self.edit.getText()
        */
-      virtual String getText() throw(UnimplementedException);
+      virtual String getText();
 
 #ifndef SWIG
       ControlEdit() :
@@ -518,7 +517,7 @@ namespace XBMCAddon
       uint32_t align;
       bool bIsPassword;
 
-      SWIGHIDDENVIRTUAL CGUIControl* Create() throw (WindowException);
+      SWIGHIDDENVIRTUAL CGUIControl* Create();
 #endif
     };
 
@@ -556,7 +555,7 @@ namespace XBMCAddon
      */
     class ControlList : public Control 
     {
-      void internAddListItem(AddonClass::Ref<ListItem> listitem, bool sendMessage) throw(WindowException);
+      void internAddListItem(AddonClass::Ref<ListItem> listitem, bool sendMessage);
 
     public:
       ControlList(long x, long y, long width, long height, const char* font = NULL,
@@ -601,7 +600,7 @@ namespace XBMCAddon
        * example:
        *   - cList.selectItem(12)
        */
-      virtual void selectItem(long item) throw(UnimplementedException);
+      virtual void selectItem(long item);
 
       /**
        * removeItem(index) -- Remove an item by index number.
@@ -611,7 +610,7 @@ namespace XBMCAddon
        * example:
        *   - cList.removeItem(12)
        */
-      virtual void removeItem(int index) throw (UnimplementedException,WindowException);
+      virtual void removeItem(int index);
 
       /**
        * reset() -- Clear all ListItems in this control list.
@@ -619,7 +618,7 @@ namespace XBMCAddon
        * example:
        *   - cList.reset()
        */
-      virtual void reset() throw (UnimplementedException);
+      virtual void reset();
 
       /**
        * getSpinControl() -- returns the associated ControlSpin object.
@@ -631,7 +630,7 @@ namespace XBMCAddon
        * example:
        *   - ctl = cList.getSpinControl()
        */
-      virtual Control* getSpinControl() throw (UnimplementedException);
+      virtual Control* getSpinControl();
 
       /**
        * getSelectedPosition() -- Returns the position of the selected item as an integer.
@@ -641,7 +640,7 @@ namespace XBMCAddon
        * example:
        *   - pos = cList.getSelectedPosition()
        */
-      virtual long getSelectedPosition() throw (UnimplementedException);
+      virtual long getSelectedPosition();
 
       /**
        * getSelectedItem() -- Returns the selected item as a ListItem object.
@@ -653,7 +652,7 @@ namespace XBMCAddon
        * example:
        *   - item = cList.getSelectedItem()
        */
-      virtual XBMCAddon::xbmcgui::ListItem* getSelectedItem() throw (UnimplementedException);
+      virtual XBMCAddon::xbmcgui::ListItem* getSelectedItem();
 
 
       // setImageDimensions() method
@@ -666,7 +665,7 @@ namespace XBMCAddon
        * example:
        *   - cList.setImageDimensions(18, 18)
        */
-      virtual void setImageDimensions(long imageWidth,long imageHeight) throw (UnimplementedException);
+      virtual void setImageDimensions(long imageWidth,long imageHeight);
 
       // setItemHeight() method
       /**
@@ -677,7 +676,7 @@ namespace XBMCAddon
        * example:
        *   - cList.setItemHeight(25)
        */
-      virtual void setItemHeight(long height) throw (UnimplementedException);
+      virtual void setItemHeight(long height);
 
       // setSpace() method
       /**
@@ -688,7 +687,7 @@ namespace XBMCAddon
        * example:
        *   - cList.setSpace(5)
        */
-      virtual void setSpace(int space) throw (UnimplementedException);
+      virtual void setSpace(int space);
 
       // setPageControlVisible() method
       /**
@@ -699,7 +698,7 @@ namespace XBMCAddon
        * example:
        *   - cList.setPageControlVisible(True)
        */
-      virtual void setPageControlVisible(bool visible) throw(UnimplementedException);
+      virtual void setPageControlVisible(bool visible);
 
       // size() method
       /**
@@ -708,7 +707,7 @@ namespace XBMCAddon
        * example:
        *   - cnt = cList.size()
        */
-      virtual long size() throw (UnimplementedException);
+      virtual long size();
 
 
       // getItemHeight() Method
@@ -718,7 +717,7 @@ namespace XBMCAddon
        * example:
        *   - item_height = self.cList.getItemHeight()
        */
-      virtual long getItemHeight() throw(UnimplementedException);
+      virtual long getItemHeight();
 
       // getSpace() Method
       /**
@@ -727,7 +726,7 @@ namespace XBMCAddon
        * example:
        *   - gap = self.cList.getSpace()
        */
-      virtual long getSpace() throw (UnimplementedException);
+      virtual long getSpace();
 
       // getListItem() method
       /**
@@ -740,7 +739,7 @@ namespace XBMCAddon
        * example:
        *   - listitem = cList.getListItem(6)
        */
-      virtual XBMCAddon::xbmcgui::ListItem* getListItem(int index) throw (UnimplementedException,WindowException);
+      virtual XBMCAddon::xbmcgui::ListItem* getListItem(int index);
 
       /**
        * setStaticContent(items) -- Fills a static list with a list of listitems.
@@ -752,7 +751,7 @@ namespace XBMCAddon
        * example:
        *   - cList.setStaticContent(items=listitems)
        */
-      virtual void setStaticContent(const ListItemList* items) throw (UnimplementedException);
+      virtual void setStaticContent(const ListItemList* items);
 
 #ifndef SWIG
       void sendLabelBind(int tail);
@@ -789,7 +788,7 @@ namespace XBMCAddon
       int itemTextOffsetY;
       uint32_t alignmentY;
 
-      SWIGHIDDENVIRTUAL CGUIControl* Create() throw (WindowException);
+      SWIGHIDDENVIRTUAL CGUIControl* Create();
 #endif
     };
 
@@ -832,7 +831,7 @@ namespace XBMCAddon
        * example:
        *   - self.fadelabel.addLabel('This is a line of text that can scroll.')
        */
-       virtual void addLabel(const String& label) throw (UnimplementedException);
+       virtual void addLabel(const String& label);
 
       /**
        * reset() -- Clear this fade label.
@@ -840,7 +839,7 @@ namespace XBMCAddon
        * example:
        *   - self.fadelabel.reset()
        */
-      virtual void reset() throw (UnimplementedException);
+      virtual void reset();
 
 #ifndef SWIG
       std::string strFont;
@@ -848,7 +847,7 @@ namespace XBMCAddon
       std::vector<std::string> vecLabels;
       uint32_t align;
 
-      SWIGHIDDENVIRTUAL CGUIControl* Create() throw (WindowException);
+      SWIGHIDDENVIRTUAL CGUIControl* Create();
 
       ControlFadeLabel() {}
 #endif
@@ -889,7 +888,7 @@ namespace XBMCAddon
        * example:
        *   - self.textbox.setText('This is a line of text that can wrap.')
        */
-      virtual void setText(const String& text) throw(UnimplementedException);
+      virtual void setText(const String& text);
 
       // getText() Method
       /**
@@ -898,7 +897,7 @@ namespace XBMCAddon
        * example:
        *   - text = self.text.getText()
        */
-      virtual String getText() throw(UnimplementedException);
+      virtual String getText();
 
       // reset() Method
       /**
@@ -907,7 +906,7 @@ namespace XBMCAddon
        * example:
        *   - self.textbox.reset()
        */
-      virtual void reset() throw(UnimplementedException);
+      virtual void reset();
 
       // scroll() Method
       /**
@@ -918,7 +917,7 @@ namespace XBMCAddon
        * example:
        *   - self.textbox.scroll(10)
        */
-      virtual void scroll(long id) throw(UnimplementedException);
+      virtual void scroll(long id);
 
       // autoScroll() Method
       /**
@@ -931,13 +930,13 @@ namespace XBMCAddon
        * example:
        *   - self.textbox.autoScroll(1, 2, 1)
        */
-      virtual void autoScroll(int delay, int time, int repeat) throw(UnimplementedException);
+      virtual void autoScroll(int delay, int time, int repeat);
 
 #ifndef SWIG
       std::string strFont;
       color_t textColor;
 
-      SWIGHIDDENVIRTUAL CGUIControl* Create() throw (WindowException);
+      SWIGHIDDENVIRTUAL CGUIControl* Create();
 
       ControlTextBox() {}
 #endif
@@ -980,7 +979,7 @@ namespace XBMCAddon
        * example:
        *   - self.image.setImage('special://home/scripts/test.png')
        */
-      virtual void setImage(const char* imageFilename, const bool useCache = true) throw (UnimplementedException);
+      virtual void setImage(const char* imageFilename, const bool useCache = true);
 
       /**
        * setColorDiffuse(colorDiffuse) -- Changes the images color.
@@ -990,7 +989,7 @@ namespace XBMCAddon
        * example:
        *   - self.image.setColorDiffuse('0xC0FF0000')
        */
-      virtual void setColorDiffuse(const char* hexString) throw (UnimplementedException);
+      virtual void setColorDiffuse(const char* hexString);
 
 #ifndef SWIG
       ControlImage() :
@@ -1001,7 +1000,7 @@ namespace XBMCAddon
       int aspectRatio;
       color_t colorDiffuse;
 
-      SWIGHIDDENVIRTUAL CGUIControl* Create() throw (WindowException);
+      SWIGHIDDENVIRTUAL CGUIControl* Create();
 #endif
     };
 
@@ -1025,7 +1024,7 @@ namespace XBMCAddon
        * example:
        *   - self.progress.setPercent(60)
        */
-      virtual void setPercent(float pct) throw (UnimplementedException);
+      virtual void setPercent(float pct);
 
       /**
        * getPercent() -- Returns a float of the percent of the progress.
@@ -1033,7 +1032,7 @@ namespace XBMCAddon
        * example:
        *   - print self.progress.getValue()
        */
-       virtual float getPercent() throw (UnimplementedException);
+       virtual float getPercent();
 
 #ifndef SWIG
       std::string strTextureLeft;
@@ -1044,7 +1043,7 @@ namespace XBMCAddon
       int aspectRatio;
       color_t colorDiffuse;
 
-      SWIGHIDDENVIRTUAL CGUIControl* Create() throw (WindowException);
+      SWIGHIDDENVIRTUAL CGUIControl* Create();
       ControlProgress() :
         aspectRatio (0)
       {}
@@ -1118,7 +1117,7 @@ namespace XBMCAddon
                             const char* disabledColor = NULL,
                             const char* shadowColor = NULL,
                             const char* focusedColor = NULL,
-                            const String& label2 = emptyString) throw (UnimplementedException);
+                            const String& label2 = emptyString);
 
       // setDisabledColor() Method
       /**
@@ -1129,7 +1128,7 @@ namespace XBMCAddon
        * example:
        *   - self.button.setDisabledColor('0xFFFF3300')
        */
-      virtual void setDisabledColor(const char* color) throw (UnimplementedException);
+      virtual void setDisabledColor(const char* color);
 
       // getLabel() Method
       /**
@@ -1138,7 +1137,7 @@ namespace XBMCAddon
        * example:
        *   - label = self.button.getLabel()
        */
-      virtual String getLabel() throw (UnimplementedException);
+      virtual String getLabel();
 
       // getLabel2() Method
       /**
@@ -1147,7 +1146,7 @@ namespace XBMCAddon
        * example:
        *   - label = self.button.getLabel2()
        */
-      virtual String getLabel2() throw (UnimplementedException);
+      virtual String getLabel2();
 #ifndef SWIG
       SWIGHIDDENVIRTUAL bool canAcceptMessages(int actionId) { return true; }
 
@@ -1165,7 +1164,7 @@ namespace XBMCAddon
       std::string strTextureFocus;
       std::string strTextureNoFocus;
 
-      SWIGHIDDENVIRTUAL CGUIControl* Create() throw (WindowException);
+      SWIGHIDDENVIRTUAL CGUIControl* Create();
 
       ControlButton() :
         textOffsetX (0),
@@ -1222,7 +1221,7 @@ namespace XBMCAddon
        * example:
        *   - selected = self.checkmark.getSelected()
        */
-      virtual bool getSelected() throw (UnimplementedException);
+      virtual bool getSelected();
 
       // setSelected() Method
       /**
@@ -1233,7 +1232,7 @@ namespace XBMCAddon
        * example:
        *   - self.checkmark.setSelected(True)
        */
-      virtual void setSelected(bool selected) throw (UnimplementedException);
+      virtual void setSelected(bool selected);
 
       // setLabel() Method
       /**
@@ -1253,7 +1252,7 @@ namespace XBMCAddon
                             const char* disabledColor = NULL,
                             const char* shadowColor = NULL,
                             const char* focusedColor = NULL,
-                            const String& label2 = emptyString) throw (UnimplementedException);
+                            const String& label2 = emptyString);
 
       // setDisabledColor() Method
       /**
@@ -1264,7 +1263,7 @@ namespace XBMCAddon
        * example:
        *   - self.checkmark.setDisabledColor('0xFFFF3300')
        */
-      virtual void setDisabledColor(const char* color) throw (UnimplementedException);
+      virtual void setDisabledColor(const char* color);
 
 #ifndef SWIG
       SWIGHIDDENVIRTUAL bool canAcceptMessages(int actionId) { return true; }
@@ -1279,7 +1278,7 @@ namespace XBMCAddon
       std::string strTextureNoFocus;
       std::string strText;
 
-      SWIGHIDDENVIRTUAL CGUIControl* Create() throw (WindowException);
+      SWIGHIDDENVIRTUAL CGUIControl* Create();
 
       ControlCheckMark() :
         checkWidth  (0),
@@ -1307,7 +1306,7 @@ namespace XBMCAddon
       ControlGroup(long x, long y, long width, long height);
 
 #ifndef SWIG
-      SWIGHIDDENVIRTUAL CGUIControl* Create() throw (WindowException);
+      SWIGHIDDENVIRTUAL CGUIControl* Create();
 
       inline ControlGroup() {}
 #endif
@@ -1372,7 +1371,7 @@ namespace XBMCAddon
        * example:
        *   - self.radiobutton.setSelected(True)
        */
-      virtual void setSelected(bool selected) throw (UnimplementedException);
+      virtual void setSelected(bool selected);
 
       // isSelected() Method
       /**
@@ -1381,7 +1380,7 @@ namespace XBMCAddon
        * example:
        *   - is = self.radiobutton.isSelected()
        */
-      virtual bool isSelected() throw (UnimplementedException);
+      virtual bool isSelected();
 
       // setLabel() Method
       /**
@@ -1406,7 +1405,7 @@ namespace XBMCAddon
                             const char* disabledColor = NULL,
                             const char* shadowColor = NULL,
                             const char* focusedColor = NULL,
-                            const String& label2 = emptyString) throw (UnimplementedException);
+                            const String& label2 = emptyString);
 
       // setRadioDimension() Method
       /**
@@ -1423,7 +1422,7 @@ namespace XBMCAddon
        * example:
        *   - self.radiobutton.setRadioDimension(x=100, y=5, width=20, height=20)
        */
-      virtual void setRadioDimension(long x, long y, long width, long height) throw (UnimplementedException);
+      virtual void setRadioDimension(long x, long y, long width, long height);
 
 #ifndef SWIG
       SWIGHIDDENVIRTUAL bool canAcceptMessages(int actionId) { return true; }
@@ -1445,7 +1444,7 @@ namespace XBMCAddon
       color_t shadowColor;
       color_t focusedColor;
 
-      SWIGHIDDENVIRTUAL CGUIControl* Create() throw (WindowException);
+      SWIGHIDDENVIRTUAL CGUIControl* Create();
 
       ControlRadioButton() :
         textOffsetX (0),
@@ -1489,7 +1488,7 @@ namespace XBMCAddon
        * example:
        *   - print self.slider.getPercent()
        */
-      virtual float getPercent() throw (UnimplementedException);
+      virtual float getPercent();
 
       /**
        * setPercent(50) -- Sets the percent of the slider.
@@ -1497,14 +1496,14 @@ namespace XBMCAddon
        * example:
        *   - self.slider.setPercent(50)
        */
-      virtual void setPercent(float pct) throw (UnimplementedException);
+      virtual void setPercent(float pct);
 
 #ifndef SWIG
       std::string strTextureBack;
       std::string strTexture;
       std::string strTextureFoc;    
 
-      SWIGHIDDENVIRTUAL CGUIControl* Create() throw (WindowException);
+      SWIGHIDDENVIRTUAL CGUIControl* Create();
 
       inline ControlSlider() {}
 #endif

--- a/xbmc/interfaces/legacy/Dialog.cpp
+++ b/xbmc/interfaces/legacy/Dialog.cpp
@@ -50,7 +50,7 @@ namespace XBMCAddon
                        const String& line3,
                        const String& nolabel,
                        const String& yeslabel,
-                       int autoclose) throw (WindowException)
+                       int autoclose)
     {
       DelayedCallGuard dcguard(languageHook);
       const int window = WINDOW_DIALOG_YES_NO;
@@ -82,7 +82,7 @@ namespace XBMCAddon
       return pDialog->IsConfirmed();
     }
 
-    int Dialog::select(const String& heading, const std::vector<String>& list, int autoclose) throw (WindowException)
+    int Dialog::select(const String& heading, const std::vector<String>& list, int autoclose)
     {
       DelayedCallGuard dcguard(languageHook);
       const int window = WINDOW_DIALOG_SELECT;
@@ -111,7 +111,7 @@ namespace XBMCAddon
 
     bool Dialog::ok(const String& heading, const String& line1, 
                     const String& line2,
-                    const String& line3) throw (WindowException)
+                    const String& line3)
     {
       DelayedCallGuard dcguard(languageHook);
       const int window = WINDOW_DIALOG_OK;
@@ -138,7 +138,7 @@ namespace XBMCAddon
     Alternative<String, std::vector<String> > Dialog::browse(int type, const String& heading, 
                                 const String& s_shares, const String& maskparam, bool useThumbs, 
                                 bool useFileDirectories, const String& defaultt,
-                                bool enableMultiple) throw (WindowException)
+                                bool enableMultiple)
     {
       Alternative<String, std::vector<String> > ret;
       if (enableMultiple)
@@ -151,7 +151,7 @@ namespace XBMCAddon
     String Dialog::browseSingle(int type, const String& heading, const String& s_shares,
                                 const String& maskparam, bool useThumbs, 
                                 bool useFileDirectories, 
-                                const String& defaultt ) throw (WindowException)
+                                const String& defaultt )
     {
       DelayedCallGuard dcguard(languageHook);
       std::string value;
@@ -175,7 +175,7 @@ namespace XBMCAddon
 
     std::vector<String> Dialog::browseMultiple(int type, const String& heading, const String& s_shares,
                           const String& mask, bool useThumbs, 
-                          bool useFileDirectories, const String& defaultt ) throw (WindowException)
+                          bool useFileDirectories, const String& defaultt )
     {
       DelayedCallGuard dcguard(languageHook);
       VECSOURCES *shares = CMediaSourceSettings::Get().GetSources(s_shares);
@@ -271,7 +271,7 @@ namespace XBMCAddon
         CGUIDialogKaiToast::QueueNotification(strIcon, heading, message, iTime, sound);
     }
     
-    String Dialog::input(const String& heading, const String& defaultt, int type, int option, int autoclose) throw (WindowException)
+    String Dialog::input(const String& heading, const String& defaultt, int type, int option, int autoclose)
     {
       DelayedCallGuard dcguard(languageHook);
       std::string value(defaultt);
@@ -364,7 +364,7 @@ namespace XBMCAddon
 
     void DialogProgress::create(const String& heading, const String& line1, 
                                 const String& line2,
-                                const String& line3) throw (WindowException)
+                                const String& line3)
     {
       DelayedCallGuard dcguard(languageHook);
       CGUIDialogProgress* pDialog= (CGUIDialogProgress*)g_windowManager.GetWindow(WINDOW_DIALOG_PROGRESS);
@@ -389,7 +389,7 @@ namespace XBMCAddon
 
     void DialogProgress::update(int percent, const String& line1, 
                                 const String& line2,
-                                const String& line3) throw (WindowException)
+                                const String& line3)
     {
       DelayedCallGuard dcguard(languageHook);
       CGUIDialogProgress* pDialog = dlg;
@@ -444,7 +444,7 @@ namespace XBMCAddon
       }
     }
 
-    void DialogProgressBG::create(const String& heading, const String& message) throw (WindowException)
+    void DialogProgressBG::create(const String& heading, const String& message)
     {
       DelayedCallGuard dcguard(languageHook);
       CGUIDialogExtendedProgressBar* pDialog = 
@@ -464,7 +464,7 @@ namespace XBMCAddon
         pHandle->SetText(message);
     }
 
-    void DialogProgressBG::update(int percent, const String& heading, const String& message) throw (WindowException)
+    void DialogProgressBG::update(int percent, const String& heading, const String& message)
     {
       DelayedCallGuard dcguard(languageHook);
       CGUIDialogProgressBarHandle* pHandle = handle;

--- a/xbmc/interfaces/legacy/Dialog.h
+++ b/xbmc/interfaces/legacy/Dialog.h
@@ -77,7 +77,7 @@ namespace XBMCAddon
                  const String& line3 = emptyString,
                  const String& nolabel = emptyString,
                  const String& yeslabel = emptyString,
-                 int autoclose = 0) throw (WindowException);
+                 int autoclose = 0);
 
       /**
        * select(heading, list) -- Show a select dialog.\n
@@ -92,7 +92,7 @@ namespace XBMCAddon
        *   - dialog = xbmcgui.Dialog()\n
        *   - ret = dialog.select('Choose a playlist', ['Playlist #1', 'Playlist #2, 'Playlist #3'])n\n
        */
-      int select(const String& heading, const std::vector<String>& list, int autoclose=0) throw (WindowException);
+      int select(const String& heading, const std::vector<String>& list, int autoclose=0);
 
       /**
        * ok(heading, line1[, line2, line3]) -- Show a dialog 'OK'.\n
@@ -111,7 +111,7 @@ namespace XBMCAddon
        */
       bool ok(const String& heading, const String& line1, 
               const String& line2 = emptyString,
-              const String& line3 = emptyString) throw (WindowException);
+              const String& line3 = emptyString);
 
       /**
        * browse(type, heading, shares[, mask, useThumbs, treatAsFolder, default, enableMultiple]) -- Show a 'Browse' dialog.\n
@@ -147,7 +147,7 @@ namespace XBMCAddon
       Alternative<String, std::vector<String> > browse(int type, const String& heading, const String& s_shares,
                           const String& mask = emptyString, bool useThumbs = false, 
                           bool treatAsFolder = false, const String& defaultt = emptyString,
-                          bool enableMultiple = false) throw (WindowException);
+                          bool enableMultiple = false);
  
       /**
        * browse(type, heading, shares[, mask, useThumbs, treatAsFolder, default]) -- Show a 'Browse' dialog.\n
@@ -177,7 +177,7 @@ namespace XBMCAddon
       String browseSingle(int type, const String& heading, const String& shares,
                           const String& mask = emptyString, bool useThumbs = false, 
                           bool treatAsFolder = false, 
-                          const String& defaultt = emptyString ) throw (WindowException);
+                          const String& defaultt = emptyString );
 
       /**
        * browse(type, heading, shares[, mask, useThumbs, treatAsFolder, default]) -- Show a 'Browse' dialog.\n
@@ -205,7 +205,7 @@ namespace XBMCAddon
       std::vector<String> browseMultiple(int type, const String& heading, const String& shares,
                                          const String& mask = emptyString, bool useThumbs = false, 
                                          bool treatAsFolder = false, 
-                                         const String& defaultt = emptyString ) throw (WindowException);
+                                         const String& defaultt = emptyString );
 
 
       /**
@@ -284,7 +284,7 @@ namespace XBMCAddon
                    const String& defaultt = emptyString,
                    int type = INPUT_ALPHANUM,
                    int option = 0,
-                   int autoclose = 0) throw (WindowException);
+                   int autoclose = 0);
     };
 
     /**
@@ -321,7 +321,7 @@ namespace XBMCAddon
        */
       void create(const String& heading, const String& line1 = emptyString, 
                   const String& line2 = emptyString,
-                  const String& line3 = emptyString) throw (WindowException);
+                  const String& line3 = emptyString);
 
       /**
        * update(percent[, line1, line2, line3]) -- Updates the progress dialog.\n
@@ -339,7 +339,7 @@ namespace XBMCAddon
        */
       void update(int percent, const String& line1 = emptyString, 
                   const String& line2 = emptyString,
-                  const String& line3 = emptyString) throw (WindowException);
+                  const String& line3 = emptyString);
 
       /**
        * close() -- Close the progress dialog.\n
@@ -389,7 +389,7 @@ namespace XBMCAddon
        * - pDialog = xbmcgui.DialogProgressBG()
        * - pDialog.create('Movie Trailers', 'Downloading Monsters Inc. ...')
        */
-      void create(const String& heading, const String& message = emptyString) throw (WindowException);
+      void create(const String& heading, const String& message = emptyString);
 
       /**
        * update([percent, heading, message]) -- Updates the background progress dialog.
@@ -403,7 +403,7 @@ namespace XBMCAddon
        * example:
        * - pDialog.update(25, message='Downloading Finding Nemo ...')
        */
-      void update(int percent = 0, const String& heading = emptyString, const String& message = emptyString) throw (WindowException);
+      void update(int percent = 0, const String& heading = emptyString, const String& message = emptyString);
 
       /**
        * close() -- Close the background progress dialog

--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -262,7 +262,7 @@ namespace XBMCAddon
       return item->GetPath();
     }
 
-    void ListItem::setInfo(const char* type, const InfoLabelDict& infoLabels) throw (WrongTypeException)
+    void ListItem::setInfo(const char* type, const InfoLabelDict& infoLabels)
     {
       LOCKGUI;
 
@@ -587,7 +587,6 @@ namespace XBMCAddon
     } // end ListItem::addStreamInfo
 
     void ListItem::addContextMenuItems(const std::vector<Tuple<String,String> >& items, bool replaceItems /* = false */)
-      throw (ListItemException)
     {
       int itemCount = 0;
       for (std::vector<Tuple<String,String> >::const_iterator iter = items.begin(); iter < items.end(); ++iter, ++itemCount)

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -250,7 +250,7 @@ namespace XBMCAddon
        * example:\n
        *   - self.list.getSelectedItem().setInfo('video', { 'Genre': 'Comedy' })n\n
        */
-      void setInfo(const char* type, const InfoLabelDict& infoLabels) throw (WrongTypeException);
+      void setInfo(const char* type, const InfoLabelDict& infoLabels);
 
       /**
        * addStreamInfo(type, values) -- Add a stream with details.\n
@@ -292,7 +292,7 @@ namespace XBMCAddon
        * example:
        *   - listitem.addContextMenuItems([('Theater Showtimes', 'RunScript(special://home/scripts/showtimes/default.py,Iron Man)',)])n
        */
-      void addContextMenuItems(const std::vector<Tuple<String,String> >& items, bool replaceItems = false) throw (ListItemException);
+      void addContextMenuItems(const std::vector<Tuple<String,String> >& items, bool replaceItems = false);
 
       /**
        * setProperty(key, value) -- Sets a listitem property, similar to an infolabel.\n

--- a/xbmc/interfaces/legacy/PlayList.cpp
+++ b/xbmc/interfaces/legacy/PlayList.cpp
@@ -32,7 +32,7 @@ namespace XBMCAddon
   {
     // TODO: need a means to check for a valid construction
     //  either by throwing an exception or by an "isValid" check
-    PlayList::PlayList(int playList) throw (PlayListException) : 
+    PlayList::PlayList(int playList) : 
       refs(1), iPlayList(playList), pPlayList(NULL)
     {
       // we do not create our own playlist, just using the ones from playlistplayer
@@ -69,7 +69,7 @@ namespace XBMCAddon
       pPlayList->Insert(items, index);
     }
 
-    bool PlayList::load(const char* cFileName) throw (PlayListException)
+    bool PlayList::load(const char* cFileName)
     {
       CFileItem item(cFileName);
       item.SetPath(cFileName);
@@ -139,7 +139,7 @@ namespace XBMCAddon
       return g_playlistPlayer.GetCurrentSong();
     }
 
-    XBMCAddon::xbmcgui::ListItem* PlayList::operator [](long i) throw (PlayListException)
+    XBMCAddon::xbmcgui::ListItem* PlayList::operator [](long i)
     {
       int iPlayListSize = size();
 

--- a/xbmc/interfaces/legacy/PlayList.h
+++ b/xbmc/interfaces/legacy/PlayList.h
@@ -39,7 +39,7 @@ namespace XBMCAddon
       PLAYLIST::CPlayList *pPlayList;
 
     public:
-      PlayList(int playList) throw (PlayListException);
+      PlayList(int playList);
       virtual ~PlayList();
 
       /**
@@ -73,7 +73,7 @@ namespace XBMCAddon
        * filename can be like .pls or .m3u ...\n
        * returns False if unable to load playlist
        */
-      bool load(const char* filename) throw (PlayListException);
+      bool load(const char* filename);
 
       /**
        * remove(filename) -- remove an item with this filename from the playlist.
@@ -109,7 +109,7 @@ namespace XBMCAddon
        * retrieve the item at the given position. A negative index means from the ending 
        * rather than from the start.
        */
-      XBMCAddon::xbmcgui::ListItem* operator[](long i) throw (PlayListException);
+      XBMCAddon::xbmcgui::ListItem* operator[](long i);
     };
   }
 }

--- a/xbmc/interfaces/legacy/Player.cpp
+++ b/xbmc/interfaces/legacy/Player.cpp
@@ -317,7 +317,7 @@ namespace XBMCAddon
       return g_application.m_pPlayer->IsPlayingVideo();
     }
 
-    String Player::getPlayingFile() throw (PlayerException)
+    String Player::getPlayingFile()
     {
       XBMC_TRACE;
       if (!g_application.m_pPlayer->IsPlaying())
@@ -326,7 +326,7 @@ namespace XBMCAddon
       return g_application.CurrentFile();
     }
 
-    InfoTagVideo* Player::getVideoInfoTag() throw (PlayerException)
+    InfoTagVideo* Player::getVideoInfoTag()
     {
       XBMC_TRACE;
       if (!g_application.m_pPlayer->IsPlayingVideo())
@@ -339,7 +339,7 @@ namespace XBMCAddon
       return new InfoTagVideo();
     }
 
-    InfoTagMusic* Player::getMusicInfoTag() throw (PlayerException)
+    InfoTagMusic* Player::getMusicInfoTag()
     {
       XBMC_TRACE;
       if (g_application.m_pPlayer->IsPlayingVideo() || !g_application.m_pPlayer->IsPlayingAudio())
@@ -352,7 +352,7 @@ namespace XBMCAddon
       return new InfoTagMusic();
     }
 
-    double Player::getTotalTime() throw (PlayerException)
+    double Player::getTotalTime()
     {
       XBMC_TRACE;
       if (!g_application.m_pPlayer->IsPlaying())
@@ -361,7 +361,7 @@ namespace XBMCAddon
       return g_application.GetTotalTime();
     }
 
-    double Player::getTime() throw (PlayerException)
+    double Player::getTime()
     {
       XBMC_TRACE;
       if (!g_application.m_pPlayer->IsPlaying())
@@ -370,7 +370,7 @@ namespace XBMCAddon
       return g_application.GetTime();
     }
 
-    void Player::seekTime(double pTime) throw (PlayerException)
+    void Player::seekTime(double pTime)
     {
       XBMC_TRACE;
       if (!g_application.m_pPlayer->IsPlaying())

--- a/xbmc/interfaces/legacy/Player.h
+++ b/xbmc/interfaces/legacy/Player.h
@@ -225,7 +225,7 @@ namespace XBMCAddon
        * Throws: Exception, if player is not playing a file.\n
        */
       // Player_GetPlayingFile
-      String getPlayingFile() throw (PlayerException);
+      String getPlayingFile();
 
       /**
        * getTime() -- Returns the current time of the current playing media as fractional seconds.
@@ -233,7 +233,7 @@ namespace XBMCAddon
        * Throws: Exception, if player is not playing a file.
        */
       // Player_GetTime
-      double getTime() throw(PlayerException);
+      double getTime();
 
       /**
        * seekTime() -- Seeks the specified amount of time as fractional seconds.
@@ -243,7 +243,7 @@ namespace XBMCAddon
        * Throws: Exception, if player is not playing a file.
        */
       // Player_SeekTime
-      void seekTime(double seekTime) throw(PlayerException);
+      void seekTime(double seekTime);
 
       /**
        * setSubtitles() -- set subtitle file and enable subtitlesn
@@ -296,7 +296,7 @@ namespace XBMCAddon
        * 
        * Throws: Exception, if player is not playing a file or current file is not a movie file.
        */
-      InfoTagVideo* getVideoInfoTag() throw (PlayerException);
+      InfoTagVideo* getVideoInfoTag();
 
       /**
        * getMusicInfoTag() -- returns the MusicInfoTag of the current playing 'Song'.
@@ -304,7 +304,7 @@ namespace XBMCAddon
        * Throws: Exception, if player is not playing a file or current file is not a music file.
        */
       // Player_GetMusicInfoTag
-      InfoTagMusic* getMusicInfoTag() throw (PlayerException);
+      InfoTagMusic* getMusicInfoTag();
 
       /**
        * getTotalTime() -- Returns the total time of the current playing media in
@@ -312,7 +312,7 @@ namespace XBMCAddon
        *
        * Throws: Exception, if player is not playing a file.
        */
-      double getTotalTime() throw (PlayerException);
+      double getTotalTime();
 
       // Player_getAvailableAudioStreams
       /**

--- a/xbmc/interfaces/legacy/RenderCapture.h
+++ b/xbmc/interfaces/legacy/RenderCapture.h
@@ -83,7 +83,7 @@ namespace XBMCAddon
        * 
        * The size of the image is getWidth() * getHeight() * 4
        */
-      inline XbmcCommons::Buffer getImage() throw(RenderCaptureException)
+      inline XbmcCommons::Buffer getImage()
       {
         if (GetUserState() != CAPTURESTATE_DONE)
           throw RenderCaptureException("illegal user state");

--- a/xbmc/interfaces/legacy/Window.cpp
+++ b/xbmc/interfaces/legacy/Window.cpp
@@ -83,7 +83,7 @@ namespace XBMCAddon
 
     CGUIWindow* ProxyExistingWindowInterceptor::get() { XBMC_TRACE; return cguiwindow; }
 
-    Window::Window(bool discrim) throw (WindowException): 
+    Window::Window(bool discrim): 
       isDisposed(false), window(NULL), iWindowId(-1),
       iOldWindowId(0), iCurrentControlId(3000), bModal(false), m_actionEvent(true),
       canPulse(true), existingWindow(false), destroyAfterDeInit(false)
@@ -94,7 +94,7 @@ namespace XBMCAddon
     /**
      * This just creates a default window.
      */
-    Window::Window(int existingWindowId) throw (WindowException) : 
+    Window::Window(int existingWindowId) : 
       isDisposed(false), window(NULL), iWindowId(-1),
       iOldWindowId(0), iCurrentControlId(3000), bModal(false), m_actionEvent(true),
       canPulse(false), existingWindow(true), destroyAfterDeInit(false)
@@ -214,7 +214,7 @@ namespace XBMCAddon
         g_windowManager.Add(window->get());
     }
 
-    int Window::getNextAvailalbeWindowId() throw (WindowException)
+    int Window::getNextAvailalbeWindowId()
     {
       XBMC_TRACE;
       // window id's 13000 - 13100 are reserved for python
@@ -241,7 +241,7 @@ namespace XBMCAddon
      * If we can't find any but the window has the controlId (in case of a not python window)
      * we create a new control with basic functionality
      */
-    Control* Window::GetControlById(int iControlId, CCriticalSection* gc) throw (WindowException)
+    Control* Window::GetControlById(int iControlId, CCriticalSection* gc)
     {
       XBMC_TRACE;
 
@@ -519,7 +519,7 @@ namespace XBMCAddon
       CApplicationMessenger::Get().ActivateWindow(iWindowId, params, false);
     }
 
-    void Window::setFocus(Control* pControl) throw (WindowException)
+    void Window::setFocus(Control* pControl)
     {
       XBMC_TRACE;
       if(pControl == NULL)
@@ -536,7 +536,7 @@ namespace XBMCAddon
       g_windowManager.SendThreadMessage(msg, iWindowId);
     }
 
-    Control* Window::getFocus() throw (WindowException)
+    Control* Window::getFocus()
     {
       XBMC_TRACE;
       SingleLockWithDelayGuard gslock(g_graphicsContext,languageHook);
@@ -548,7 +548,7 @@ namespace XBMCAddon
       return GetControlById(iControlId,NULL);
     }
 
-    long Window::getFocusId() throw (WindowException)
+    long Window::getFocusId()
     {
       XBMC_TRACE;
       SingleLockWithDelayGuard gslock(g_graphicsContext,languageHook);
@@ -558,14 +558,14 @@ namespace XBMCAddon
       return (long)iControlId;
     }
 
-    void Window::removeControl(Control* pControl) throw (WindowException)
+    void Window::removeControl(Control* pControl)
     {
       XBMC_TRACE;
       DelayedCallGuard dg(languageHook);
       doRemoveControl(pControl,&g_graphicsContext,true);
     }
 
-    void Window::doRemoveControl(Control* pControl, CCriticalSection* gcontext, bool wait) throw (WindowException)
+    void Window::doRemoveControl(Control* pControl, CCriticalSection* gcontext, bool wait)
     {
       XBMC_TRACE;
       // type checking, object should be of type Control
@@ -599,7 +599,7 @@ namespace XBMCAddon
       pControl->iParentId = 0;
     }
 
-    void Window::removeControls(std::vector<Control*> pControls) throw (WindowException)
+    void Window::removeControls(std::vector<Control*> pControls)
     {
       XBMC_TRACE;
       DelayedCallGuard dg(languageHook);
@@ -626,7 +626,7 @@ namespace XBMCAddon
       return (long)g_graphicsContext.GetVideoResolution();
     }
 
-    void Window::setCoordinateResolution(long res) throw (WindowException)
+    void Window::setCoordinateResolution(long res)
     {
       XBMC_TRACE;
       if (res < RES_HDTV_1080i || res > RES_AUTORES)
@@ -728,14 +728,14 @@ namespace XBMCAddon
       }
     }
 
-    void Window::addControl(Control* pControl) throw (WindowException)
+    void Window::addControl(Control* pControl)
     {
       XBMC_TRACE;
       DelayedCallGuard dg(languageHook);
       doAddControl(pControl,&g_graphicsContext,true);
     }
 
-    void Window::doAddControl(Control* pControl, CCriticalSection* gcontext, bool wait) throw (WindowException)
+    void Window::doAddControl(Control* pControl, CCriticalSection* gcontext, bool wait)
     {
       XBMC_TRACE;
       if(pControl == NULL)
@@ -777,7 +777,7 @@ namespace XBMCAddon
       CApplicationMessenger::Get().SendGUIMessage(msg, iWindowId, wait);
     }
 
-    void Window::addControls(std::vector<Control*> pControls) throw (WindowException)
+    void Window::addControls(std::vector<Control*> pControls)
     {
       XBMC_TRACE;
       SingleLockWithDelayGuard gslock(g_graphicsContext,languageHook);
@@ -786,7 +786,7 @@ namespace XBMCAddon
         doAddControl(*iter,NULL, count == size);
     }
 
-    Control* Window::getControl(int iControlId) throw (WindowException)
+    Control* Window::getControl(int iControlId)
     {
       XBMC_TRACE;
       DelayedCallGuard dg(languageHook);

--- a/xbmc/interfaces/legacy/Window.h
+++ b/xbmc/interfaces/legacy/Window.h
@@ -114,8 +114,8 @@ namespace XBMCAddon
       friend class WindowDialogMixin;
       bool isDisposed;
 
-      void doAddControl(Control* pControl, CCriticalSection* gcontext, bool wait) throw (WindowException);
-      void doRemoveControl(Control* pControl, CCriticalSection* gcontext, bool wait) throw (WindowException);
+      void doAddControl(Control* pControl, CCriticalSection* gcontext, bool wait);
+      void doRemoveControl(Control* pControl, CCriticalSection* gcontext, bool wait);
 
     protected:
 #ifndef SWIG
@@ -137,7 +137,7 @@ namespace XBMCAddon
       // This only takes a boolean to allow subclasses to explicitly use it. A default
       //  constructor can be used as a concrete class and we need to tell the difference.
       //  subclasses should use this constructor and not the other.
-      Window(bool discrim) throw (WindowException);
+      Window(bool discrim);
 
       virtual void deallocating();
 
@@ -145,7 +145,7 @@ namespace XBMCAddon
        * This helper retrieves the next available id. It is assumed 
        *  that the global lock is already being held.
        */
-      static int getNextAvailalbeWindowId() throw (WindowException);
+      static int getNextAvailalbeWindowId();
 
       /**
        * Child classes MUST call this in their constructors. It should
@@ -165,14 +165,14 @@ namespace XBMCAddon
        * This is a helper method since getting
        *  a control by it's id is a common function
        */
-      Control* GetControlById(int iControlId, CCriticalSection* gc) throw (WindowException);
+      Control* GetControlById(int iControlId, CCriticalSection* gc);
 
       SWIGHIDDENVIRTUAL void PulseActionEvent();
       SWIGHIDDENVIRTUAL bool WaitForActionEvent(unsigned int milliseconds);
 #endif
 
     public:
-      Window(int existingWindowId = -1) throw (WindowException);
+      Window(int existingWindowId = -1);
 
       virtual ~Window();
 
@@ -267,7 +267,7 @@ namespace XBMCAddon
        *         - SystemError, on Internal error
        *         - RuntimeError, if control is not added to a window
        */
-      SWIGHIDDENVIRTUAL void setFocus(Control* pControl) throw (WindowException);
+      SWIGHIDDENVIRTUAL void setFocus(Control* pControl);
 
       /**
        * setFocusId(self, int) -- Gives the control with the supplied focus.
@@ -285,7 +285,7 @@ namespace XBMCAddon
        *         - SystemError, on Internal error
        *         - RuntimeError, if no control has focus
        */
-      SWIGHIDDENVIRTUAL Control* getFocus() throw (WindowException);
+      SWIGHIDDENVIRTUAL Control* getFocus();
 
       /**
        * getFocusId(self, int) -- returns the id of the control which is focused.
@@ -293,7 +293,7 @@ namespace XBMCAddon
        *         - SystemError, on Internal error
        *         - RuntimeError, if no control has focus
        */
-      SWIGHIDDENVIRTUAL long getFocusId() throw (WindowException);
+      SWIGHIDDENVIRTUAL long getFocusId();
 
       /**
        * removeControl(self, Control) -- Removes the control from this window.
@@ -304,7 +304,7 @@ namespace XBMCAddon
        * 
        * This will not delete the control. It is only removed from the window.
        */
-      SWIGHIDDENVIRTUAL void removeControl(Control* pControl) throw (WindowException);
+      SWIGHIDDENVIRTUAL void removeControl(Control* pControl);
 
       /**
        * removeControls(self, List) -- Removes a list of controls from this window.
@@ -315,7 +315,7 @@ namespace XBMCAddon
        *
        * This will not delete the controls. They are only removed from the window.
        */
-      SWIGHIDDENVIRTUAL void removeControls(std::vector<Control*> pControls) throw (WindowException);
+      SWIGHIDDENVIRTUAL void removeControls(std::vector<Control*> pControls);
 
       /**
        * getHeight(self) -- Returns the height of this screen.
@@ -361,7 +361,7 @@ namespace XBMCAddon
        *    - 8 - PAL60 4:3  (720x480)
        *    - 9 - PAL60 16:9 (720x480)n
        */
-      SWIGHIDDENVIRTUAL void setCoordinateResolution(long res) throw (WindowException);
+      SWIGHIDDENVIRTUAL void setCoordinateResolution(long res);
 
       /**
        * setProperty(key, value) -- Sets a window property, similar to an infolabel.
@@ -452,7 +452,7 @@ namespace XBMCAddon
        *   -ControlRadioButton
        *   -ControlProgressn
        */
-      SWIGHIDDENVIRTUAL void addControl(Control* pControl) throw (WindowException);
+      SWIGHIDDENVIRTUAL void addControl(Control* pControl);
 
       /**
        * addControls(self, List) -- Add a list of Controls to this window.
@@ -462,7 +462,7 @@ namespace XBMCAddon
        *        - ReferenceError, if control is already used in another window
        *        - RuntimeError, should not happen :-)
        */
-      SWIGHIDDENVIRTUAL void addControls(std::vector<Control*> pControls) throw (WindowException);
+      SWIGHIDDENVIRTUAL void addControls(std::vector<Control*> pControls);
 
       /**
        * getControl(self, int controlId) -- Get's the control from this window.
@@ -475,7 +475,7 @@ namespace XBMCAddon
        * Note, not python controls are not completely usable yet
        * You can only use the Control functions
        */
-      SWIGHIDDENVIRTUAL Control* getControl(int iControlId) throw (WindowException);
+      SWIGHIDDENVIRTUAL Control* getControl(int iControlId);
     };
   }
 }

--- a/xbmc/interfaces/legacy/WindowDialog.cpp
+++ b/xbmc/interfaces/legacy/WindowDialog.cpp
@@ -27,7 +27,7 @@ namespace XBMCAddon
 {
   namespace xbmcgui
   {
-    WindowDialog::WindowDialog() throw(WindowException) :
+    WindowDialog::WindowDialog() :
       Window(true), WindowDialogMixin(this)
     {
       CSingleLock lock(g_graphicsContext);

--- a/xbmc/interfaces/legacy/WindowDialog.h
+++ b/xbmc/interfaces/legacy/WindowDialog.h
@@ -35,7 +35,7 @@ namespace XBMCAddon
     {
 
     public:
-      WindowDialog() throw(WindowException);
+      WindowDialog();
       virtual ~WindowDialog();
 
 #ifndef SWIG

--- a/xbmc/interfaces/legacy/WindowXML.cpp
+++ b/xbmc/interfaces/legacy/WindowXML.cpp
@@ -97,7 +97,7 @@ namespace XBMCAddon
     WindowXML::WindowXML(const String& xmlFilename,
                          const String& scriptPath,
                          const String& defaultSkin,
-                         const String& defaultRes) throw(WindowException) :
+                         const String& defaultRes) :
       Window(true)
     {
       XBMC_TRACE;
@@ -147,7 +147,7 @@ namespace XBMCAddon
       interceptor->SetCoordsRes(res);
     }
 
-    int WindowXML::lockingGetNextAvailalbeWindowId() throw (WindowException)
+    int WindowXML::lockingGetNextAvailalbeWindowId()
     {
       XBMC_TRACE;
       CSingleLock lock(g_graphicsContext);
@@ -216,7 +216,7 @@ namespace XBMCAddon
       A(m_viewControl).SetSelectedItem(position);
     }
 
-    ListItem* WindowXML::getListItem(int position) throw (WindowException)
+    ListItem* WindowXML::getListItem(int position)
     {
       LOCKGUI;
       //CFileItemPtr fi = pwx->GetListItem(listPos);
@@ -462,7 +462,7 @@ namespace XBMCAddon
 
     WindowXMLDialog::WindowXMLDialog(const String& xmlFilename, const String& scriptPath,
                                      const String& defaultSkin,
-                                     const String& defaultRes) throw(WindowException) :
+                                     const String& defaultRes) :
       WindowXML(xmlFilename, scriptPath, defaultSkin, defaultRes),
       WindowDialogMixin(this)
     { XBMC_TRACE; }

--- a/xbmc/interfaces/legacy/WindowXML.h
+++ b/xbmc/interfaces/legacy/WindowXML.h
@@ -66,7 +66,7 @@ namespace XBMCAddon
        * This helper retrieves the next available id. It is doesn't
        *  assume that the global lock is already being held.
        */
-      static int lockingGetNextAvailalbeWindowId() throw (WindowException);
+      static int lockingGetNextAvailalbeWindowId();
 
       WindowXMLInterceptor* interceptor;
 #endif
@@ -74,7 +74,7 @@ namespace XBMCAddon
      public:
       WindowXML(const String& xmlFilename, const String& scriptPath,
                 const String& defaultSkin = "Default",
-                const String& defaultRes = "720p") throw(WindowException);
+                const String& defaultRes = "720p");
       virtual ~WindowXML();
 
       /**
@@ -126,7 +126,7 @@ namespace XBMCAddon
        * example:\n
        *   - listitem = self.getListItem(6)
        */
-      SWIGHIDDENVIRTUAL ListItem* getListItem(int position) throw (WindowException);
+      SWIGHIDDENVIRTUAL ListItem* getListItem(int position);
 
       /**
        * getListSize() -- Returns the number of items in this Window List.
@@ -230,7 +230,7 @@ namespace XBMCAddon
     public:
       WindowXMLDialog(const String& xmlFilename, const String& scriptPath,
                       const String& defaultSkin = "Default",
-                      const String& defaultRes = "720p") throw(WindowException);
+                      const String& defaultRes = "720p");
 
       virtual ~WindowXMLDialog();
 

--- a/xbmc/interfaces/python/swig.cpp
+++ b/xbmc/interfaces/python/swig.cpp
@@ -45,7 +45,7 @@ namespace PythonBindings
   };
 
   void PyXBMCGetUnicodeString(std::string& buf, PyObject* pObject, bool coerceToString,
-                              const char* argumentName, const char* methodname) throw (XBMCAddon::WrongTypeException)
+                              const char* argumentName, const char* methodname)
   {
     // It's okay for a string to be "None". In this case the buf returned
     // will be the emptyString.
@@ -243,7 +243,7 @@ namespace PythonBindings
   }
   
   XBMCAddon::AddonClass* doretrieveApiInstance(const PyHolder* pythonObj, const TypeInfo* typeInfo, const char* expectedType, 
-                              const char* methodNamespacePrefix, const char* methodNameForErrorString) throw (XBMCAddon::WrongTypeException)
+                              const char* methodNamespacePrefix, const char* methodNameForErrorString)
   {
     if (pythonObj->magicNumber != XBMC_PYTHON_TYPE_MAGIC_NUMBER)
       throw XBMCAddon::WrongTypeException("Non api type passed to \"%s\" in place of the expected type \"%s.\"",

--- a/xbmc/interfaces/python/swig.h
+++ b/xbmc/interfaces/python/swig.h
@@ -44,7 +44,7 @@ namespace PythonBindings
    */
   void PyXBMCGetUnicodeString(std::string& buf, PyObject* pObject, bool coerceToString = false,
                               const char* pos = "unknown", 
-                              const char* methodname = "unknown") throw (XBMCAddon::WrongTypeException);
+                              const char* methodname = "unknown");
 
   struct TypeInfo
   {
@@ -75,7 +75,7 @@ namespace PythonBindings
    */
   inline XBMCAddon::AddonClass* retrieveApiInstance(PyObject* pythonObj, const TypeInfo* typeToCheck, 
                                    const char* methodNameForErrorString, 
-                                   const char* typenameForErrorString) throw (XBMCAddon::WrongTypeException)
+                                   const char* typenameForErrorString)
   {
     if (pythonObj == NULL || pythonObj == Py_None)
       return NULL;
@@ -87,7 +87,7 @@ namespace PythonBindings
   bool isParameterRightType(const char* passedType, const char* expectedType, const char* methodNamespacePrefix, bool tryReverse = true);
 
   XBMCAddon::AddonClass* doretrieveApiInstance(const PyHolder* pythonObj, const TypeInfo* typeInfo, const char* expectedType, 
-                              const char* methodNamespacePrefix, const char* methodNameForErrorString) throw (XBMCAddon::WrongTypeException);
+                              const char* methodNamespacePrefix, const char* methodNameForErrorString);
 
   /**
    * This method retrieves the pointer from the PyHolder. The return value should
@@ -99,7 +99,7 @@ namespace PythonBindings
    * pythonObj is Py_None.
    */
   inline XBMCAddon::AddonClass* retrieveApiInstance(const PyObject* pythonObj, const char* expectedType, const char* methodNamespacePrefix,
-                                   const char* methodNameForErrorString) throw (XBMCAddon::WrongTypeException)
+                                   const char* methodNameForErrorString)
   {
     return (pythonObj == NULL || pythonObj == Py_None) ? NULL :
       doretrieveApiInstance(((PyHolder*)pythonObj),((PyHolder*)pythonObj)->typeInfo, expectedType, methodNamespacePrefix, methodNameForErrorString);
@@ -191,7 +191,6 @@ namespace PythonBindings
   template<class T> struct PythonCompare
   {
     static inline int compare(PyObject* obj1, PyObject* obj2, const char* swigType, const char* methodNamespacePrefix, const char* methodNameForErrorString)
-      throw(XBMCAddon::WrongTypeException)
     {
       XBMC_TRACE;
       try


### PR DESCRIPTION
Get rid of about 1500 warnings on win32.
