### PR TITLE
ffmpeg: fixes for 2.6.0

### DIFF
--- a/tools/depends/target/ffmpeg/FFMPEG-VERSION
+++ b/tools/depends/target/ffmpeg/FFMPEG-VERSION
@@ -1,5 +1,5 @@
 LIBNAME=ffmpeg
 BASE_URL=https://github.com/xbmc/FFmpeg/archive
-VERSION=2.6.0-Isengard-alpha
+VERSION=2.6.0-fix-Isengard-alpha
 ARCHIVE=$(LIBNAME)-$(VERSION).tar.gz
 


### PR DESCRIPTION
lots of fixes for 2.6.0 and 2 preliminary patches for DXVA hevc
