### PR TITLE
fix frametime for active vsync

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1888,6 +1888,7 @@ void CApplication::Render()
   bool hasRendered = false;
   bool limitFrames = false;
   unsigned int singleFrameTime = 10; // default limit 100 fps
+  bool vsync = true;
 
   // Whether externalplayer is playing and we're unfocused
   bool extPlayerActive = m_pPlayer->GetCurrentPlayer() == EPC_EXTPLAYER && m_pPlayer->IsPlaying() && !m_AppFocused;
@@ -1900,6 +1901,8 @@ void CApplication::Render()
     if (!extPlayerActive && g_graphicsContext.IsFullScreenVideo() && !m_pPlayer->IsPausedPlayback())
     {
       m_bPresentFrame = g_renderManager.HasFrame();
+      if (vsync_mode == VSYNC_DISABLED)
+        vsync = false;
     }
     else
     {
@@ -1908,9 +1911,15 @@ void CApplication::Render()
       // DXMERGE - we checked for g_videoConfig.GetVSyncMode() before this
       //           perhaps allowing it to be set differently than the UI option??
       if (vsync_mode == VSYNC_DISABLED || vsync_mode == VSYNC_VIDEO)
+      {
         limitFrames = true; // not using vsync.
+        vsync = false;
+      }
       else if ((g_infoManager.GetFPS() > g_graphicsContext.GetFPS() + 10) && g_infoManager.GetFPS() > 1000 / singleFrameTime)
+      {
         limitFrames = true; // using vsync, but it isn't working.
+        vsync = false;
+      }
 
       if (limitFrames)
       {
@@ -2006,7 +2015,7 @@ void CApplication::Render()
   }
 
   m_lastFrameTime = XbmcThreads::SystemClockMillis();
-  CTimeUtils::UpdateFrameTime(flip);
+  CTimeUtils::UpdateFrameTime(flip, vsync);
 
   g_renderManager.UpdateResolution();
   g_renderManager.ManageCaptures();

--- a/xbmc/guilib/GUIFont.cpp
+++ b/xbmc/guilib/GUIFont.cpp
@@ -57,7 +57,8 @@ float CScrollInfo::GetPixelsPerFrame()
     delta = 100; // assume a minimum of 10 fps
   m_lastFrameTime = currentTime;
   // do an exponential moving average of the frame time
-  m_averageFrameTime = m_averageFrameTime + (delta - m_averageFrameTime) * alphaEMA;
+  if (delta)
+    m_averageFrameTime = m_averageFrameTime + (delta - m_averageFrameTime) * alphaEMA;
   // and multiply by pixel speed (per ms) to get number of pixels to move this frame
   return pixelSpeed * m_averageFrameTime;
 }

--- a/xbmc/utils/TimeUtils.cpp
+++ b/xbmc/utils/TimeUtils.cpp
@@ -21,6 +21,7 @@
 #include "TimeUtils.h"
 #include "XBDateTime.h"
 #include "threads/SystemClock.h"
+#include "guilib/GraphicContext.h"
 
 #if (defined HAVE_CONFIG_H) && (!defined TARGET_WINDOWS)
   #include "config.h"
@@ -72,12 +73,26 @@ int64_t CurrentHostFrequency(void)
 CTimeSmoother CTimeUtils::frameTimer;
 unsigned int CTimeUtils::frameTime = 0;
 
-void CTimeUtils::UpdateFrameTime(bool flip)
+void CTimeUtils::UpdateFrameTime(bool flip, bool vsync)
 {
   unsigned int currentTime = XbmcThreads::SystemClockMillis();
-  if (flip)
-    frameTimer.AddTimeStamp(currentTime);
-  frameTime = frameTimer.GetNextFrameTime(currentTime);
+  if (vsync)
+  {
+    unsigned int last = frameTime;
+    while (frameTime < currentTime)
+    {
+      frameTime += (unsigned int)(1000 / g_graphicsContext.GetFPS());
+      // observe wrap around
+      if (frameTime < last)
+        break;
+    }
+  }
+  else
+  {
+    if (flip)
+      frameTimer.AddTimeStamp(currentTime);
+    frameTime = frameTimer.GetNextFrameTime(currentTime);
+  }
 }
 
 unsigned int CTimeUtils::GetFrameTime()

--- a/xbmc/utils/TimeUtils.h
+++ b/xbmc/utils/TimeUtils.h
@@ -32,7 +32,7 @@ int64_t CurrentHostFrequency(void);
 class CTimeUtils
 {
 public:
-  static void UpdateFrameTime(bool flip); ///< update the frame time.  Not threadsafe
+  static void UpdateFrameTime(bool flip, bool vsync); ///< update the frame time.  Not threadsafe
   static unsigned int GetFrameTime(); ///< returns the frame time in MS.  Not threadsafe
   static CDateTime GetLocalTime(time_t time);
 


### PR DESCRIPTION
fix incorrect calculation of frametime which leads to faulty behavior of i.e. scrolling text of display of fps

@popcornmix could you test this please
