### PR TITLE
[cleanup] Remove check for language (codes) from language addons.

### DIFF
--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -373,18 +373,16 @@ void CLangInfo::OnSettingsLoaded()
   SetSpeedUnit(CSettings::Get().GetString("locale.speedunit"));
 }
 
-bool CLangInfo::Load(const std::string& strLanguage, bool onlyCheckLanguage /*= false*/)
+bool CLangInfo::Load(const std::string& strLanguage)
 {
   SetDefaults();
 
   string strFileName = GetLanguageInfoPath(strLanguage);
-  if (!onlyCheckLanguage)
-    CLog::Log(LOGINFO, "CLangInfo: load language info file: %s", strFileName.c_str());
 
   CXBMCTinyXML xmlDoc;
   if (!xmlDoc.LoadFile(strFileName))
   {
-    CLog::Log(onlyCheckLanguage ? LOGDEBUG : LOGERROR, "unable to load %s: %s at line %d", strFileName.c_str(), xmlDoc.ErrorDesc(), xmlDoc.ErrorRow());
+    CLog::Log(LOGERROR, "unable to load %s: %s at line %d", strFileName.c_str(), xmlDoc.ErrorDesc(), xmlDoc.ErrorRow());
     return false;
   }
 
@@ -392,26 +390,24 @@ bool CLangInfo::Load(const std::string& strLanguage, bool onlyCheckLanguage /*= 
   m_languageAddon = GetLanguageAddon(strLanguage);
   if (m_languageAddon == NULL)
   {
-    CLog::Log(onlyCheckLanguage ? LOGDEBUG : LOGERROR, "Unknown language %s", strLanguage.c_str());
+    CLog::Log(LOGERROR, "Unknown language %s", strLanguage.c_str());
     return false;
   }
 
-  if (!onlyCheckLanguage)
-  {
-    // get some language-specific information from the language addon
-    m_strGuiCharSet = m_languageAddon->GetGuiCharset();
-    m_forceUnicodeFont = m_languageAddon->ForceUnicodeFont();
-    m_strSubtitleCharSet = m_languageAddon->GetSubtitleCharset();
-    m_strDVDMenuLanguage = m_languageAddon->GetDvdMenuLanguage();
-    m_strDVDAudioLanguage = m_languageAddon->GetDvdAudioLanguage();
-    m_strDVDSubtitleLanguage = m_languageAddon->GetDvdSubtitleLanguage();
-    m_sortTokens = m_languageAddon->GetSortTokens();
-  }
+  // get some language-specific information from the language addon
+  m_strGuiCharSet = m_languageAddon->GetGuiCharset();
+  m_forceUnicodeFont = m_languageAddon->ForceUnicodeFont();
+  m_strSubtitleCharSet = m_languageAddon->GetSubtitleCharset();
+  m_strDVDMenuLanguage = m_languageAddon->GetDvdMenuLanguage();
+  m_strDVDAudioLanguage = m_languageAddon->GetDvdAudioLanguage();
+  m_strDVDSubtitleLanguage = m_languageAddon->GetDvdSubtitleLanguage();
+  m_sortTokens = m_languageAddon->GetSortTokens();
+
 
   TiXmlElement* pRootElement = xmlDoc.RootElement();
   if (pRootElement->ValueStr() != "language")
   {
-    CLog::Log(onlyCheckLanguage ? LOGDEBUG : LOGERROR, "%s Doesn't contain <language>", strFileName.c_str());
+    CLog::Log(LOGERROR, "%s Doesn't contain <language>", strFileName.c_str());
     return false;
   }
 
@@ -498,11 +494,8 @@ bool CLangInfo::Load(const std::string& strLanguage, bool onlyCheckLanguage /*= 
       pRegion=pRegion->NextSiblingElement("region");
     }
 
-    if (!onlyCheckLanguage)
-    {
-      const std::string& strName = CSettings::Get().GetString("locale.country");
-      SetCurrentRegion(strName);
-    }
+    const std::string& strName = CSettings::Get().GetString("locale.country");
+    SetCurrentRegion(strName);
   }
   g_charsetConverter.reinitCharsetsFromSettings();
 
@@ -528,12 +521,6 @@ std::string CLangInfo::GetLanguageInfoPath(const std::string &language)
     return "";
 
   return URIUtils::AddFileToFolder(GetLanguagePath(language), "langinfo.xml");
-}
-
-bool CLangInfo::CheckLanguage(const std::string& language)
-{
-  CLangInfo li;
-  return li.Load(language, true);
 }
 
 void CLangInfo::LoadTokens(const TiXmlNode* pTokens, set<std::string>& vecTokens)
@@ -727,11 +714,6 @@ bool CLangInfo::SetLanguage(bool& fallback, const std::string &strLanguage /* = 
   }
 
   return true;
-}
-
-bool CLangInfo::CheckLoadLanguage(const std::string &language)
-{
-  return Load(language, true);
 }
 
 // three char language code (not win32 specific)

--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -431,7 +431,7 @@ bool CLangInfo::Load(const std::string& strLanguage, bool onlyCheckLanguage /*= 
 #else
   if (m_defaultRegion.m_strLangLocaleName.length() != 3)
   {
-    if (!g_LangCodeExpander.ConvertToISO6392T(m_defaultRegion.m_strLangLocaleName, m_languageCodeGeneral, !onlyCheckLanguage))
+    if (!g_LangCodeExpander.ConvertToISO6392T(m_defaultRegion.m_strLangLocaleName, m_languageCodeGeneral))
       m_languageCodeGeneral = "";
   }
   else

--- a/xbmc/LangInfo.h
+++ b/xbmc/LangInfo.h
@@ -68,7 +68,7 @@ public:
   // implementation of ISettingsHandler
   virtual void OnSettingsLoaded();
 
-  bool Load(const std::string& strLanguage, bool onlyCheckLanguage = false);
+  bool Load(const std::string& strLanguage);
 
   /*!
    \brief Returns the language addon for the given locale (or the current one).
@@ -108,7 +108,6 @@ public:
    \return True if the language has been successfully loaded, false otherwise.
    */
   bool SetLanguage(bool& fallback, const std::string &strLanguage = "", bool reloadServices = true);
-  bool CheckLoadLanguage(const std::string &language);
 
   const std::string& GetAudioLanguage() const;
   // language can either be a two char language code as defined in ISO639
@@ -179,8 +178,6 @@ public:
   static std::string GetLanguagePath() { return "resource://"; }
   static std::string GetLanguagePath(const std::string &language);
   static std::string GetLanguageInfoPath(const std::string &language);
-
-  static bool CheckLanguage(const std::string& language);
 
   static void LoadTokens(const TiXmlNode* pTokens, std::set<std::string>& vecTokens);
 

--- a/xbmc/utils/LangCodeExpander.cpp
+++ b/xbmc/utils/LangCodeExpander.cpp
@@ -172,7 +172,7 @@ bool CLangCodeExpander::ConvertISO6391ToISO6392T(const std::string& strISO6391, 
   return false;
 }
 
-bool CLangCodeExpander::ConvertToISO6392T(const std::string& strCharCode, std::string& strISO6392T, bool checkXbmcLocales /* = true */, bool checkWin32Locales /* = false */)
+bool CLangCodeExpander::ConvertToISO6392T(const std::string& strCharCode, std::string& strISO6392T, bool checkWin32Locales /* = false */)
 {
   if (strCharCode.size() == 2)
     return g_LangCodeExpander.ConvertISO6391ToISO6392T(strCharCode, strISO6392T, checkWin32Locales);
@@ -208,16 +208,6 @@ bool CLangCodeExpander::ConvertToISO6392T(const std::string& strCharCode, std::s
         CodeToString(g_iso639_2[i].code, strISO6392T);
         return true;
       }
-    }
-
-    if (checkXbmcLocales)
-    {
-      CLangInfo langInfo;
-      if (!langInfo.CheckLoadLanguage(strCharCode))
-        return false;
-
-      strISO6392T = langInfo.GetLanguageCode();
-      return !strISO6392T.empty();
     }
   }
 
@@ -266,7 +256,7 @@ bool CLangCodeExpander::ConvertWindowsLanguageCodeToISO6392T(const std::string& 
 }
 #endif
 
-bool CLangCodeExpander::ConvertToISO6391(const std::string& lang, std::string& code, bool checkXbmcLocales /*= true*/)
+bool CLangCodeExpander::ConvertToISO6391(const std::string& lang, std::string& code)
 {
   if (lang.empty())
     return false;
@@ -316,15 +306,7 @@ bool CLangCodeExpander::ConvertToISO6391(const std::string& lang, std::string& c
       return ConvertToISO6391(tmp, code);
   }
 
-  if (!checkXbmcLocales)
-    return false;
-
-  // try xbmc specific language names
-  CLangInfo langInfo;
-  if (!langInfo.CheckLoadLanguage(lang))
-    return false;
-
-  return ConvertToISO6391(langInfo.GetLanguageCode(), code, false);
+  return false;
 }
 
 bool CLangCodeExpander::ReverseLookup(const std::string& desc, std::string& code)

--- a/xbmc/utils/LangCodeExpander.h
+++ b/xbmc/utils/LangCodeExpander.h
@@ -65,10 +65,9 @@ public:
   *          or full english name string to a 2-Char (ISO 639-1) code.  
   *   \param[out] code The 2-Char language code of the given language lang.
   *   \param[in] lang The language that should be converted.
-  *   \param[in] checkXbmcLocales Try to find in XBMC specific locales
   *   \return true if the conversion succeeded, false otherwise. 
   */ 
-  bool ConvertToISO6391(const std::string& lang, std::string& code, bool checkXbmcLocales = true);
+  bool ConvertToISO6391(const std::string& lang, std::string& code);
 
   /** \brief Converts a language given as 2-Char (ISO 639-1),
   *          3-Char (ISO 639-2/T or ISO 639-2/B),
@@ -91,11 +90,10 @@ public:
   *          or full english name string to a 3-Char ISO 639-2/T code.
   *   \param[in] strCharCode The language that should be converted.
   *   \param[out] strISO6392T The 3-Char (ISO 639-2/T) language code of the given language strISO6391.
-  *   \param[in] checkXbmcLocales Try to find in XBMC specific locales
   *   \param[in] checkWin32Locales Whether to also check WIN32 specific language codes.
   *   \return true if the conversion succeeded, false otherwise.
   */
-  static bool ConvertToISO6392T(const std::string& strCharCode, std::string& strISO6392T, bool checkXbmcLocales = true, bool checkWin32Locales = false);
+  static bool ConvertToISO6392T(const std::string& strCharCode, std::string& strISO6392T, bool checkWin32Locales = false);
 
 #ifdef TARGET_WINDOWS
   static bool ConvertISO36111Alpha2ToISO36111Alpha3(const std::string& strISO36111Alpha2, std::string& strISO36111Alpha3);


### PR DESCRIPTION
This was quite useless before the language addons were introduced, but now it's really useless with only one pre-installed addon.

I'm not sure about the second commit, it might be useful to check load a language.
@Montellese for review.
