### PR TITLE
Allow smaller minimal subtitle size in settings.xml

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -975,7 +975,7 @@
           <level>1</level>
           <default>28</default>
           <constraints>
-            <minimum>16</minimum>
+            <minimum>12</minimum>
             <step>2</step>
             <maximum>74</maximum>
           </constraints>


### PR DESCRIPTION
A user requested this change and made a convincing argument for it. I'm not even sure why we force a minimal on a setting like this. If the user wants smaller subs, that seems reasonable to me and doesn't complicate anything.
