### PR TITLE
[depends] binary-addons: fix building only selected addons

### DIFF
--- a/tools/depends/xbmc-addons.include
+++ b/tools/depends/xbmc-addons.include
@@ -58,12 +58,12 @@ endif
 	cd $(PLATFORM); \
          $(CMAKE) -DCMAKE_INSTALL_PREFIX=$(INSTALL_PREFIX) $(CMAKE_EXTRA) \
          $(TOOLCHAIN) \
-         -DADDONS_TO_BUILD=$(ADDONS) $(ADDON_PROJECT_DIR) -DBUILD_DIR=$(BUILDDIR)/$(PLATFORM)/build ;\
+         -DADDONS_TO_BUILD="$(ADDONS)" $(ADDON_PROJECT_DIR) -DBUILD_DIR=$(BUILDDIR)/$(PLATFORM)/build ;\
          for addon in $$(make supported_addons | awk '/^ALL_ADDONS_BUILDING: .*$$/ { first = $$1; $$1 = ""; print $$0 }'); do \
            $(MAKE) $$addon && echo $$addon >> $(ADDON_PROJECT_DIR)/.success || echo $$addon >> $(ADDON_PROJECT_DIR)/.failure ;\
          done
 ifneq ($(CROSS_COMPILING),yes)
-	@[ -f $(ADDON_PROJECT_DIR)/.failure ] && echo "Following Addons failed to build:" $(shell cat $(ADDON_PROJECT_DIR)/.failure)
+	@[ -f $(ADDON_PROJECT_DIR)/.failure ] && echo "Following Addons failed to build:" $(shell cat $(ADDON_PROJECT_DIR)/.failure) || :
 	@[ -w $(INSTALL_PREFIX) ] || $(MAKE) -C $(PLATFORM) install
 endif
 	touch $@


### PR DESCRIPTION
Properly quote the list of addons to build, fixes doing something like:
make -C tools/depends/target/binary-addons ADDONS="audioencoder.flac audioencoder.lame audioencoder.vorbis audioencoder.wav" PREFIX=/tmp/1

Also fixes make exiting with error when all addons built ok :)
