### PR TITLE
--enable-static seems to require a lot of static library

### DIFF
--- a/tools/depends/native/TexturePacker/Makefile
+++ b/tools/depends/native/TexturePacker/Makefile
@@ -9,14 +9,10 @@ endif
 
 ifeq ($(NATIVEPLATFORM),)
   PLATFORM = native
-  EXTRA_CONFIGURE = --enable-static
 else
   PLATFORM = $(NATIVEPLATFORM)
 endif
 
-ifeq ($(NATIVE_OS), linux)
-  EXTRA_CONFIGURE = --enable-static
-endif
 ifeq ($(NATIVE_OS), android)
   EXTRA_CONFIGURE = --enable-static
 endif


### PR DESCRIPTION
Don't know where TexturePacker is used, but here it does not build. It require linking with static library (eg. libjpeg.a) that I don't have here. I removed the --enable-static things and the build proceeds
