### PR TITLE
[pvr] fix group member assignment

### DIFF
--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -786,6 +786,7 @@ bool CPVRChannelGroup::AddToGroup(const CPVRChannelPtr &channel, int iChannelNum
     {
       PVRChannelGroupMember newMember(realChannel);
       newMember.iChannelNumber = (unsigned int)iChannelNumber;
+      m_sortedMembers.push_back(newMember);
       m_members.insert(std::make_pair(realChannel.channel->StorageId(), newMember));
       m_bChanged = true;
 


### PR DESCRIPTION
As pointed out by @FernetMenta at https://github.com/xbmc/xbmc/commit/08528edd6fa6680757084e7ec5bea373d47adf3d#commitcomment-10200052 this will fix the group member assignment for user-defined groups.

@opdenkamp ping
