### PR TITLE
[pvr] fix unable to open grouped recordings/folders (closes #15848)

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -251,8 +251,7 @@ bool CGUIWindowPVRRecordings::OnMessage(CGUIMessage &message)
             case ACTION_MOUSE_LEFT_CLICK:
             case ACTION_PLAY:
             {
-              PlayFile(m_vecItems->Get(iItem).get());
-              bReturn = true;
+              bReturn = PlayFile(m_vecItems->Get(iItem).get());
               break;
             }
             case ACTION_CONTEXT_MENU:


### PR DESCRIPTION
Fixes entering grouped recordings folders after 989c853f7acd0b8c4ff5ccb5bd4b17c2fbc1c968.
Issue @ http://trac.kodi.tv/ticket/15848

@opdenkamp, @xhaggi your button.
