### PR TITLE
Enables SSL for MySQL in Mac OS X builds

### DIFF
--- a/tools/depends/target/Makefile
+++ b/tools/depends/target/Makefile
@@ -89,7 +89,7 @@ libcdio: $(ICONV)
 libplist: libxml2 $(ZLIB)
 libbluray: $(ICONV) libxml2
 libssh: libgcrypt openssl $(ZLIB)
-mysql: openssl
+mysql: openssl $(ZLIB)
 libzip: $(ZLIB)
 libpng: $(ZLIB)
 openssl: $(ZLIB)

--- a/tools/depends/target/mysql/06-fixsslcheck.patch
+++ b/tools/depends/target/mysql/06-fixsslcheck.patch
@@ -1,0 +1,11 @@
+--- config/ac-macros/ssl.m4.orig	2016-02-14 13:47:23.792296242 +0000
++++ config/ac-macros/ssl.m4	2016-02-14 13:47:05.464296846 +0000
+@@ -111,7 +111,7 @@
+   #
+   # Try to link with openSSL libs in <location>
+   #
+-  openssl_libs="-L$location/lib/ -lssl -lcrypto"
++  openssl_libs="-L$location/lib/ -lssl -lcrypto -lz -ldl"
+   MYSQL_CHECK_SSL_DIR([$openssl_includes], [$openssl_libs])
+ 
+   if test "$mysql_ssl_found" == "no"

--- a/tools/depends/target/mysql/Makefile
+++ b/tools/depends/target/mysql/Makefile
@@ -33,6 +33,7 @@ $(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
 	cd $(PLATFORM); patch -Np1 -i ../03-mysqlclient-android.patch
 	cd $(PLATFORM); patch -p0 < ../04-strnlen.patch
 	cd $(PLATFORM); patch -p1 < ../05-mysqlclient-ios64.patch
+	cd $(PLATFORM); patch -p0 < ../06-fixsslcheck.patch
 	cd $(PLATFORM); autoconf
 	cd $(PLATFORM); $(CONFIGURE) 
 

--- a/tools/depends/target/mysql/Makefile
+++ b/tools/depends/target/mysql/Makefile
@@ -13,7 +13,8 @@ CONFIGURE=cp -f $(CONFIG_SUB) $(CONFIG_GUESS) .; \
 	--enable-thread-safe-client --with-extra-charsets=complex \
 	--with-named-thread-libs=-lc --with-named-curses-libs=-lncurses \
 	--with-libedit \
-	--without-server --without-bench --without-docs --without-man --disable-shared
+	--without-server --without-bench --without-docs --without-man --disable-shared \
+	--with-ssl=$(PREFIX) LIBS="-ldl -lz"
 
 LIBDYLIB=$(PLATFORM)/lib$(LIBNAME)/.libs/lib$(LIBNAME)client.a
 


### PR DESCRIPTION
MySQL connections using SSL do not work for Mac OS X builds. This PR makes the necessary changes to the MySQL Makefile to enable SSL in Mac OS X builds.

I have built and tested this on Mac OS X 10.10, 10.9, Windows 7 x86_64, and Fedora 20 x86_64.
