### PR TITLE
renderer: eat video frames properly if there is no consumer - fix crash ...

### DIFF
--- a/xbmc/cores/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoRenderers/RenderManager.h
@@ -113,6 +113,10 @@ public:
 
   void AddOverlay(CDVDOverlay* o, double pts)
   {
+    { CSingleLock lock(m_presentlock);
+      if (m_free.empty())
+        return;
+    }
     CSharedLock lock(m_sharedSection);
     m_overlays.AddOverlay(o, pts, m_free.front());
   }


### PR DESCRIPTION
@MartijnKaijser does this fix the issue
