### PR TITLE
[pvr] Improved content of pvr shutdown warning dialog.

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -9383,16 +9383,12 @@ msgid "Adult"
 msgstr ""
 
 #. Title for shutdown confirmation dialog
-#: xbmc/ApplicationMessenger.cpp
+#: xbmc/pvr/PVRManager.cpp
 msgctxt "#19685"
 msgid "Confirm shutdown"
 msgstr ""
 
-#. Text for shutdown confirmation dialog
-#: xbmc/ApplicationMessenger.cpp
-msgctxt "#19686"
-msgid "The PVR backend is busy. Shutdown anyway?"
-msgstr ""
+#empty string with id 19686
 
 #: xbmc/pvr/windows/GUIWindowPVRGuide.cpp
 msgctxt "#19687"
@@ -9414,7 +9410,43 @@ msgctxt "#19690"
 msgid "Do you want to use this service?"
 msgstr ""
 
-#empty strings from id 19691 to 19999
+#. Text for shutdown confirmation dialog.
+#: xbmc/pvr/PVRManager.cpp
+msgctxt "#19691"
+msgid "PVR is currently recording '%s' on channel '%s'."
+msgstr ""
+
+#. Text for shutdown confirmation dialog
+#: xbmc/pvr/PVRManager.cpp
+msgctxt "#19692"
+msgid "PVR will start recording '%s' on channel '%s' in %s."
+msgstr ""
+
+#. Text for shutdown confirmation dialog
+#: xbmc/pvr/PVRManager.cpp
+msgctxt "#19693"
+msgid "Daily wakeup is due in %s."
+msgstr ""
+
+#. Text for shutdown confirmation dialog
+#: xbmc/pvr/PVRManager.cpp
+msgctxt "#19694"
+msgid "%d minutes"
+msgstr ""
+
+#. Text for shutdown confirmation dialog
+#: xbmc/pvr/PVRManager.cpp
+msgctxt "#19695"
+msgid "about a minute"
+msgstr ""
+
+#. Yes button label for shutdown confirmation dialog
+#: xbmc/pvr/PVRManager.cpp
+msgctxt "#19696"
+msgid "Shutdown anyway"
+msgstr ""
+
+#empty strings from id 19697 to 19999
 
 #: system/settings/settings.xml
 msgctxt "#20000"

--- a/xbmc/dialogs/GUIDialogYesNo.cpp
+++ b/xbmc/dialogs/GUIDialogYesNo.cpp
@@ -115,12 +115,14 @@ bool CGUIDialogYesNo::ShowAndGetInput(const std::string& heading, const std::str
   return ShowAndGetInput(heading,line0,line1,line2,bDummy,noLabel,yesLabel);
 }
 
-bool CGUIDialogYesNo::ShowAndGetInput(const std::string& heading, const std::string& text, bool& bCanceled, const std::string& noLabel, const std::string& yesLabel)
+bool CGUIDialogYesNo::ShowAndGetInput(const std::string& heading, const std::string& text, bool& bCanceled, const std::string& noLabel, const std::string& yesLabel, unsigned int autoCloseTime)
 {
   CGUIDialogYesNo *dialog = (CGUIDialogYesNo *)g_windowManager.GetWindow(WINDOW_DIALOG_YES_NO);
   if (!dialog) return false;
   dialog->SetHeading(heading);
   dialog->SetText(text);
+  if (autoCloseTime)
+    dialog->SetAutoClose(autoCloseTime);
   dialog->m_bCanceled = false;
   if (!noLabel.empty())
     dialog->SetChoice(0,noLabel);
@@ -135,10 +137,10 @@ bool CGUIDialogYesNo::ShowAndGetInput(const std::string& heading, const std::str
   return (dialog->IsConfirmed()) ? true : false;
 }
 
-bool CGUIDialogYesNo::ShowAndGetInput(const std::string& heading, const std::string& line0, const std::string& line1, const std::string& line2, bool& bCanceled, const std::string& noLabel, const std::string& yesLabel)
+bool CGUIDialogYesNo::ShowAndGetInput(const std::string& heading, const std::string& line0, const std::string& line1, const std::string& line2, bool& bCanceled, const std::string& noLabel, const std::string& yesLabel, unsigned int autoCloseTime)
 {
   std::string text = line0 + "\n" + line1 + "\n" + line2;
-  return ShowAndGetInput(heading, text, bCanceled, noLabel, yesLabel);
+  return ShowAndGetInput(heading, text, bCanceled, noLabel, yesLabel, autoCloseTime);
 }
 
 int CGUIDialogYesNo::GetDefaultLabelID(int controlId) const

--- a/xbmc/dialogs/GUIDialogYesNo.h
+++ b/xbmc/dialogs/GUIDialogYesNo.h
@@ -36,8 +36,8 @@ public:
   static bool ShowAndGetInput(int heading, int line0, int line1, int line2, bool& bCanceled);
   static bool ShowAndGetInput(int heading, int line0, int line1, int line2, int iNoLabel, int iYesLabel, bool& bCanceled, unsigned int autoCloseTime = 0);
   static bool ShowAndGetInput(const std::string& heading, const std::string& line0, const std::string& line1, const std::string& line2, const std::string& noLabel="", const std::string& yesLabel="");
-  static bool ShowAndGetInput(const std::string& heading, const std::string& text, bool& bCanceled, const std::string& noLabel, const std::string& yesLabel);
-  static bool ShowAndGetInput(const std::string& heading, const std::string& line0, const std::string& line1, const std::string& line2, bool &bCanceled, const std::string& noLabel="", const std::string& yesLabel="");
+  static bool ShowAndGetInput(const std::string& heading, const std::string& text, bool& bCanceled, const std::string& noLabel, const std::string& yesLabel, unsigned int autoCloseTime = 0);
+  static bool ShowAndGetInput(const std::string& heading, const std::string& line0, const std::string& line1, const std::string& line2, bool &bCanceled, const std::string& noLabel="", const std::string& yesLabel="", unsigned int autoCloseTime = 0);
 protected:
   virtual int GetDefaultLabelID(int controlId) const;
 

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -44,11 +44,13 @@ namespace PVR
 {
   class CPVRClients;
   class CPVRChannel;
-  typedef std::shared_ptr<PVR::CPVRChannel> CPVRChannelPtr;
+  typedef std::shared_ptr<CPVRChannel> CPVRChannelPtr;
   class CPVRChannelGroupsContainer;
   class CPVRChannelGroup;
   class CPVRRecordings;
   class CPVRTimers;
+  class CPVRTimerInfoTag;
+  typedef std::shared_ptr<CPVRTimerInfoTag> CPVRTimerInfoTagPtr;
   class CPVRGUIInfo;
   class CPVRDatabase;
   class CGUIWindowPVRCommon;
@@ -369,7 +371,7 @@ namespace PVR
      * @brief Check whether the system Kodi is running on can be powered down
      *        (shutdown/reboot/suspend/hibernate) without stopping any active
      *        recordings and/or without preventing the start of recordings
-     *        sheduled for now + pvrpowermanagement.backendidletime.
+     *        scheduled for now + pvrpowermanagement.backendidletime.
      * @param bAskUser True to informs user in case of potential
      *        data loss. User can decide to allow powerdown anyway. False to
      *        not to ask user and to not confirm power down.
@@ -637,7 +639,7 @@ namespace PVR
 
     void SetState(ManagerState state);
 
-    bool AllLocalBackendsIdle(void) const;
+    bool AllLocalBackendsIdle(CPVRTimerInfoTagPtr& causingEvent) const;
     bool EventOccursOnLocalBackend(const CFileItemPtr& item) const;
     bool IsNextEventWithinBackendIdleTime(void) const;
 

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -675,7 +675,7 @@ CDateTime CPVRTimers::GetNextEventTime(void) const
   {
     const CDateTimeSpan prestart(0, 0, item->GetPVRTimerInfoTag()->MarginStart(), 0);
     const CDateTime start = item->GetPVRTimerInfoTag()->StartAsUTC();
-    wakeuptime = ((start - idle) > now) ?
+    wakeuptime = ((start - prestart - prewakeup - idle) > now) ?
         start - prestart - prewakeup :
         now + idle;
   }


### PR DESCRIPTION
This is an enhancement for #4342.

Today, the shutdown warning dialog is quite simple:

Heading: "Confirm Shutdown"
Content: "The PVR backend is busy. Shutdown anyway?"
Buttons: Yes | No (defaulted to No)

This PR extends this dialog to display the reason for the shutdown warning, which can be one of:
1) "PVR is currently recording."
2) "Next recording will start in \* minutes." or "Next recording will start in about a minute."
3) "Daily wakeup is due in \* minutes." or "Daily wakeup is due in about a minute."

For 1) and 2), the line after the reason contains channel name and title of the current or next recording.

Thus, the new dialog layout is:

Heading: "Confirm Shutdown"
Line 1: Reason 1) to 3)
Line 2: for 1) and 2) channel name and title
Line 3: "Shutdown anyway?"
Buttons: Yes | No (defaulted to No)

I thought, the additional information might be quite useful for the user... ;-)

@opdenkamp, @jalle19 mind taking a look.
