### PR TITLE
[gui] Use a list instead of a spinner for the audio and subtitle selection

### DIFF
--- a/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
@@ -402,7 +402,7 @@ void CGUIDialogAudioSubtitleSettings::AddAudioStreams(CSettingGroup *group, cons
   if (m_audioStream < 0)
     m_audioStream = 0;
 
-  AddSpinner(group, settingId, 460, 0, m_audioStream, AudioStreamsOptionFiller);
+  AddList(group, settingId, 460, 0, m_audioStream, AudioStreamsOptionFiller, 460);
 }
 
 void CGUIDialogAudioSubtitleSettings::AddSubtitleStreams(CSettingGroup *group, const std::string &settingId)
@@ -414,7 +414,7 @@ void CGUIDialogAudioSubtitleSettings::AddSubtitleStreams(CSettingGroup *group, c
   if (m_subtitleStream < 0)
     m_subtitleStream = 0;
 
-  AddSpinner(group, settingId, 462, 0, m_subtitleStream, SubtitleStreamsOptionFiller);
+  AddList(group, settingId, 462, 0, m_subtitleStream, SubtitleStreamsOptionFiller, 462);
 }
 
 bool CGUIDialogAudioSubtitleSettings::IsPlayingPassthrough(const std::string &condition, const std::string &value, const CSetting *setting)


### PR DESCRIPTION
 via the video osd dialog.

Blu-rays and DVDs can have quite a lot of streams, so a list is clearer and better suited imo.
