### PR TITLE
[lang] Add proper support for custom languages

### DIFF
--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -1111,7 +1111,7 @@ void CLangInfo::SettingOptionsLanguageNamesFiller(const CSetting *setting, std::
 void CLangInfo::SettingOptionsISO6391LanguagesFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data)
 {
   // get a list of language names
-  vector<string> languages = g_LangCodeExpander.GetLanguageNames();
+  vector<string> languages = g_LangCodeExpander.GetLanguageNames(CLangCodeExpander::ISO_639_1, true);
   sort(languages.begin(), languages.end(), sortstringbyname());
   for (std::vector<std::string>::const_iterator language = languages.begin(); language != languages.end(); ++language)
     list.push_back(make_pair(*language, *language));

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -645,7 +645,7 @@ BuildObject(CFileItem&                    item,
             /* trying to find subtitle with prefered language settings */
             std::string preferredLanguage = (CSettings::Get().GetSetting("locale.subtitlelanguage"))->ToString();
             std::string preferredLanguageCode;
-            CLangCodeExpander::ConvertToISO6392T(preferredLanguage, preferredLanguageCode);
+            g_LangCodeExpander.ConvertToISO6392T(preferredLanguage, preferredLanguageCode);
 
             for (unsigned int i = 0; i < subtitles.size(); i++)
             {

--- a/xbmc/utils/LangCodeExpander.cpp
+++ b/xbmc/utils/LangCodeExpander.cpp
@@ -174,6 +174,11 @@ bool CLangCodeExpander::ConvertISO6391ToISO6392T(const std::string& strISO6391, 
 
 bool CLangCodeExpander::ConvertToISO6392T(const std::string& strCharCode, std::string& strISO6392T, bool checkWin32Locales /* = false */)
 {
+
+  //first search in the user defined map
+  if (LookupUserCode(strCharCode, strISO6392T))
+    return true;
+
   if (strCharCode.size() == 2)
     return g_LangCodeExpander.ConvertISO6391ToISO6392T(strCharCode, strISO6392T, checkWin32Locales);
 
@@ -210,7 +215,19 @@ bool CLangCodeExpander::ConvertToISO6392T(const std::string& strCharCode, std::s
       }
     }
   }
+  return false;
+}
 
+bool CLangCodeExpander::LookupUserCode(const std::string& desc, std::string &userCode)
+{
+  for (STRINGLOOKUPTABLE::const_iterator it = m_mapUser.begin(); it != m_mapUser.end(); ++it)
+  {
+    if (StringUtils::EqualsNoCase(desc, it->first) || StringUtils::EqualsNoCase(desc, it->second))
+    {
+      userCode = it->first;
+      return true;
+    }
+  }
   return false;
 }
 
@@ -260,6 +277,10 @@ bool CLangCodeExpander::ConvertToISO6391(const std::string& lang, std::string& c
 {
   if (lang.empty())
     return false;
+
+  //first search in the user defined map
+  if (LookupUserCode(lang, code))
+    return true;
 
   if (lang.length() == 2)
   {

--- a/xbmc/utils/LangCodeExpander.cpp
+++ b/xbmc/utils/LangCodeExpander.cpp
@@ -438,7 +438,7 @@ bool CLangCodeExpander::CompareFullLanguageNames(const std::string& lang1, const
   return StringUtils::EqualsNoCase(expandedLang1, expandedLang2);
 }
 
-std::vector<std::string> CLangCodeExpander::GetLanguageNames(LANGFORMATS format /* = CLangCodeExpander::ISO_639_1 */)
+std::vector<std::string> CLangCodeExpander::GetLanguageNames(LANGFORMATS format /* = CLangCodeExpander::ISO_639_1 */, bool customNames /* = false */)
 {
   std::vector<std::string> languages;
   const LCENTRY *lang = g_iso639_1;
@@ -454,6 +454,12 @@ std::vector<std::string> CLangCodeExpander::GetLanguageNames(LANGFORMATS format 
   {
     languages.push_back(lang->name);
     ++lang;
+  }
+
+  if (customNames)
+  {
+    for (STRINGLOOKUPTABLE::const_iterator it = m_mapUser.begin(); it != m_mapUser.end(); ++it)
+      languages.push_back(it->second);
   }
 
   return languages;

--- a/xbmc/utils/LangCodeExpander.h
+++ b/xbmc/utils/LangCodeExpander.h
@@ -93,7 +93,7 @@ public:
   *   \param[in] checkWin32Locales Whether to also check WIN32 specific language codes.
   *   \return true if the conversion succeeded, false otherwise.
   */
-  static bool ConvertToISO6392T(const std::string& strCharCode, std::string& strISO6392T, bool checkWin32Locales = false);
+  bool ConvertToISO6392T(const std::string& strCharCode, std::string& strISO6392T, bool checkWin32Locales = false);
 
 #ifdef TARGET_WINDOWS
   static bool ConvertISO36111Alpha2ToISO36111Alpha3(const std::string& strISO36111Alpha2, std::string& strISO36111Alpha3);
@@ -120,6 +120,14 @@ protected:
   *   \return true if the a code was found, false otherwise.
   */ 
   bool ReverseLookup(const std::string& desc, std::string& code);
+
+
+  /** \brief Looks up the user defined code of the given code or language name.
+  *   \param[in] desc The language code or name that should be converted.
+  *   \param[out] userCode The user defined language code of the given language desc.
+  *   \return true if desc was found, false otherwise.
+  */
+  bool LookupUserCode(const std::string& desc, std::string &userCode);
 
   typedef std::map<std::string, std::string> STRINGLOOKUPTABLE;
   STRINGLOOKUPTABLE m_mapUser;

--- a/xbmc/utils/LangCodeExpander.h
+++ b/xbmc/utils/LangCodeExpander.h
@@ -100,7 +100,7 @@ public:
   static bool ConvertWindowsLanguageCodeToISO6392T(const std::string& strWindowsLanguageCode, std::string& strISO6392T);
 #endif
 
-  static std::vector<std::string> GetLanguageNames(LANGFORMATS format = ISO_639_1);
+  std::vector<std::string> GetLanguageNames(LANGFORMATS format = ISO_639_1, bool customNames = false);
 protected:
 
   /** \brief Converts a language code given as a long, see #MAKECODE(a, b, c, d)


### PR DESCRIPTION
The first commit adds custom languages to our language lists, e.g., preferred subtitle language.
The second one adds support of custom languages to our conversion methods and therefore support for preferred selection and presentation of the name in the gui.

For example Portuguese (Brazil) can be added via:

```
<advancedsettings>
<languagecodes>
  <code>
    <short>ptbr</short>
    <long>Portuguese (Brazil)</long>
  </code>
</languagecodes>
</advancedsettings>
```
