### PR TITLE
Changed FONT_CACHE_DIST_LIMIT to float to silence a bunch of warnings. f...

### DIFF
--- a/xbmc/guilib/GUIFontCache.h
+++ b/xbmc/guilib/GUIFontCache.h
@@ -39,7 +39,7 @@
 #include "TransformMatrix.h"
 
 #define FONT_CACHE_TIME_LIMIT (1000)
-#define FONT_CACHE_DIST_LIMIT (0.01)
+#define FONT_CACHE_DIST_LIMIT (0.01f)
 
 template<class Position, class Value> class CGUIFontCache;
 class CGUIFontTTFBase;


### PR DESCRIPTION
...loats are used everywhere in the calculations so this was most likely an oversight and not intended behaviour

@mkortstiege you've been active in guilib, what do you say?
