### PR TITLE
[depends] binary-addons: fix building all addons

### DIFF
--- a/tools/depends/target/binary-addons/Makefile
+++ b/tools/depends/target/binary-addons/Makefile
@@ -1,5 +1,5 @@
 BUILDDIR := $(shell pwd)
-ADDONS := "$(shell cd $(BUILDDIR)/../../../../project/cmake/addons/addons/; echo *)"
+ADDONS := all
 
 -include ../../Makefile.include
 include ../../xbmc-addons.include


### PR DESCRIPTION
due to double quoting(2nd pair of quotes is in xbmc-addons.include), currently only the 1st addon in the list is built.
While we are at it, lets just use the "all" alias for every addon available.
