### PR TITLE
[remote] [keyboard] restore track rating functionality

### DIFF
--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -303,6 +303,8 @@
       <r>Rewind</r>
       <period>SkipNext</period>
       <comma>SkipPrevious</comma>
+      <pageup>IncreaseRating</pageup>
+      <pagedown>DecreaseRating</pagedown>
       <backspace>Fullscreen</backspace>
       <return>OSD</return>
       <enter>OSD</enter>

--- a/system/keymaps/remote.xml
+++ b/system/keymaps/remote.xml
@@ -230,6 +230,8 @@
       <right>StepForward</right>
       <up>SkipNext</up>
       <down>SkipPrevious</down>
+      <pageplus>IncreaseRating</pageplus>
+      <pageminus>DecreaseRating</pageminus>
       <back>Back</back>
       <title>CodecInfo</title>
       <select>OSD</select>


### PR DESCRIPTION
This restores music track rating functionality after video/music controls were
normalized previous mapped keys have been repurposed, this assigns new mappings that have been suggested by da-anda and xhaggi is also ok with. 

As discussed in
http://forum.kodi.tv/showthread.php?tid=217616&pid=1957016#pid1957016

@jjd-uk @xhaggi @da-anda 
