### PR TITLE
[pvr] Fix radio channelgroup support. Take over 'radio' group property s...

### DIFF
--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -204,6 +204,12 @@ namespace PVR
     bool IsRadio(void) const { return m_bRadio; }
 
     /*!
+     * @brief Set 'radio' property of this group.
+     * @param bIsRadio The new value for the 'radio' property.
+     */
+    void SetRadio(bool bIsRadio) { m_bRadio = bIsRadio; }
+
+    /*!
      * @brief True if sorting should be prevented when adding/updating channels to the group.
      * @return True if sorting should be prevented when adding/updating channels to the group.
      */

--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -82,6 +82,7 @@ bool CPVRChannelGroups::Update(const CPVRChannelGroup &group, bool bUpdateFromCl
       m_groups.push_back(updateGroup);
     }
 
+    updateGroup->SetRadio(group.IsRadio());
     updateGroup->SetGroupID(group.GroupID());
     updateGroup->SetGroupName(group.GroupName());
     updateGroup->SetGroupType(group.GroupType());


### PR DESCRIPTION
Fix radio channelgroup support. Take over 'radio' group property supplied by client.

BTW: IMO, radio channel groups never can have worked without this patch as the "isRadio" flag supplied by clients never was taken into account. Thus, all channel groups were treated as TV groups.
