### PR TITLE
[omxplayer] Allow HDMI output to work when ALSA card is selected

### DIFF
--- a/xbmc/cores/omxplayer/OMXAudio.cpp
+++ b/xbmc/cores/omxplayer/OMXAudio.cpp
@@ -129,7 +129,7 @@ bool COMXAudio::PortSettingsChanged()
     if(!m_omx_render_analog.Initialize("OMX.broadcom.audio_render", OMX_IndexParamAudioInit))
       return false;
   }
-  if (CSettings::Get().GetString("audiooutput.audiodevice") == "PI:Both" || CSettings::Get().GetString("audiooutput.audiodevice") == "PI:HDMI")
+  if (CSettings::Get().GetString("audiooutput.audiodevice") == "PI:Both" || CSettings::Get().GetString("audiooutput.audiodevice") != "PI:Analogue")
   {
     if(!m_omx_render_hdmi.Initialize("OMX.broadcom.audio_render", OMX_IndexParamAudioInit))
       return false;


### PR DESCRIPTION
See: http://forum.kodi.tv/showthread.php?tid=221118&pid=1958062#pid1958062

Basically omxplayer doesn't support ALSA and can only drive HDMI or the analogue output.
In the past users have made use of this fact to effectively get HDMI output for videos,
and ALSA output for music.

In some of the code restructuring using omxplayer with ALSA enabled no longer works at all -
you just get openmax errors in the log as an inconsistent set of components are created.

A trivial change allows this to work again.
