### PR TITLE
alsalib: Build with enable-shared

### DIFF
--- a/tools/depends/target/alsa-lib/Makefile
+++ b/tools/depends/target/alsa-lib/Makefile
@@ -19,9 +19,9 @@ CONFIGURE=cp -f $(CONFIG_SUB) $(CONFIG_GUESS) .; \
           --with-ctl-plugins=ext \
           --with-pcm-plugins="copy,linear,route,mulaw,alaw,adpcm,rate,plug,multi,file,null,empty,share,meter,hooks,lfloat,ladspa,asym,iec958,softvol,extplug,ioplug,mmap_emul" \
           --disable-resmgr --enable-aload --enable-mixer  --enable-pcm  --disable-rawmidi  --enable-hwdep  --disable-seq  --disable-alisp  --disable-old-symbols --disable-python \
-          --with-softfloat=yes --with-libdl=yes --with-pthread=yes --with-librt=no --disable-shared \
+          --with-softfloat=yes --with-libdl=yes --with-pthread=yes --with-librt=no --enable-shared \
 
-LIBDYLIB=$(PLATFORM)/src/.libs/$(LIBNAME).a
+LIBDYLIB=$(PLATFORM)/src/.libs/$(LIBNAME).so
 
 CLEAN_FILES=$(ARCHIVE) $(PLATFORM)
 


### PR DESCRIPTION
On the Pi, building with unified builds, alsa doesn't work.
Changing to enabled-shared makes it work.
