### PR TITLE
[resampler] Use ffmpeg for quiet noise generation

### DIFF
--- a/xbmc/cores/AudioEngine/AEResampleFactory.cpp
+++ b/xbmc/cores/AudioEngine/AEResampleFactory.cpp
@@ -28,10 +28,10 @@
 namespace ActiveAE
 {
 
-IAEResample *CAEResampleFactory::Create()
+IAEResample *CAEResampleFactory::Create(uint32_t flags /* = 0 */)
 {
 #if defined(TARGET_RASPBERRY_PI)
-  if (CSettings::Get().GetInt("audiooutput.processquality") == AE_QUALITY_GPU)
+  if (!(flags & AERESAMPLEFACTORY_QUICK_RESAMPLE) && CSettings::Get().GetInt("audiooutput.processquality") == AE_QUALITY_GPU)
     return new CActiveAEResamplePi();
 #endif
   return new CActiveAEResampleFFMPEG();

--- a/xbmc/cores/AudioEngine/AEResampleFactory.h
+++ b/xbmc/cores/AudioEngine/AEResampleFactory.h
@@ -26,10 +26,19 @@ class IAEResample;
 namespace ActiveAE
 {
 
+/**
+ * Bit options to pass to CAEResampleFactory::Create
+ */
+enum AEResampleFactoryOptions
+{
+  /* This is a quick resample job (e.g. resample a single noise packet) and may not be worth using GPU acceleration */
+  AERESAMPLEFACTORY_QUICK_RESAMPLE = 0x01
+};
+
 class CAEResampleFactory
 {
 public:
-  static IAEResample *Create();
+  static IAEResample *Create(uint32_t flags = 0U);
 };
 
 }

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -2684,7 +2684,7 @@ bool CActiveAE::ResampleSound(CActiveAESound *sound)
   dst_config.bits_per_sample = CAEUtil::DataFormatToUsedBits(m_internalFormat.m_dataFormat);
   dst_config.dither_bits = CAEUtil::DataFormatToDitherBits(m_internalFormat.m_dataFormat);
 
-  IAEResample *resampler = CAEResampleFactory::Create();
+  IAEResample *resampler = CAEResampleFactory::Create(AERESAMPLEFACTORY_QUICK_RESAMPLE);
   resampler->Init(dst_config.channel_layout,
                   dst_config.channels,
                   dst_config.sample_rate,

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -895,7 +895,7 @@ void CActiveAESink::GenerateNoise()
   }
 
   SampleConfig config = m_sampleOfSilence.pkt->config;
-  IAEResample *resampler = CAEResampleFactory::Create();
+  IAEResample *resampler = CAEResampleFactory::Create(AERESAMPLEFACTORY_QUICK_RESAMPLE);
   resampler->Init(config.channel_layout,
                  config.channels,
                  config.sample_rate,

--- a/xbmc/cores/AudioEngine/Interfaces/AEStream.h
+++ b/xbmc/cores/AudioEngine/Interfaces/AEStream.h
@@ -26,7 +26,8 @@
 /**
  * Bit options to pass to IAE::GetStream
  */
-enum AEStreamOptions {
+enum AEStreamOptions
+{
   AESTREAM_FORCE_RESAMPLE = 0x01, /* force resample even if rates match */
   AESTREAM_PAUSED         = 0x02, /* create the stream paused */
   AESTREAM_AUTOSTART      = 0x04  /* autostart the stream when enough data is buffered */


### PR DESCRIPTION
Opening the GPU resampler is relatively expensive compared to the small amount of work done here.
This function takes ~110ms when using GPU resampler and about 14ms with ffmpeg resample on Pi 2.

Provide a way of flagging that GPU acceleration is not required
