### PR TITLE
[art] container.art() fixes

### DIFF
--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -1141,14 +1141,18 @@ bool CGUIWindowMusicBase::GetDirectory(const std::string &strDirectory, CFileIte
   }
 
   CQueryParams params;
-  map<string, string> art;
   CDirectoryNode::GetDatabaseInfo(items.GetPath(), params);
 
-  if (params.GetAlbumId() && m_musicdatabase.GetArtistArtForItem(params.GetAlbumId(), MediaTypeAlbum, art))
-    items.AppendArt(art, MediaTypeAlbum);
+  if (params.GetAlbumId())
+  {
+    map<string, string> artistArt;
+    if (m_musicdatabase.GetArtistArtForItem(params.GetAlbumId(), MediaTypeAlbum, artistArt))
+      items.AppendArt(artistArt, MediaTypeArtist);
 
-  if (params.GetArtistId() && m_musicdatabase.GetArtForItem(params.GetArtistId(), MediaTypeArtist, art))
-    items.AppendArt(art, MediaTypeArtist);
+    map<string, string> albumArt;
+    if (m_musicdatabase.GetArtForItem(params.GetAlbumId(), MediaTypeAlbum, albumArt))
+      items.AppendArt(albumArt, MediaTypeAlbum);
+  }
 
   // add in the "New Playlist" item if we're in the playlists folder
   if ((items.GetPath() == "special://musicplaylists/") && !items.Contains("newplaylist://"))

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -1132,7 +1132,7 @@ void CGUIWindowMusicBase::OnRetrieveMusicInfo(CFileItemList& items)
 
 bool CGUIWindowMusicBase::GetDirectory(const std::string &strDirectory, CFileItemList &items)
 {
-  items.SetArt("thumb", "");
+  items.ClearArt();
   bool bResult = CGUIMediaWindow::GetDirectory(strDirectory, items);
   if (bResult)
   {

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -313,6 +313,7 @@ bool CGUIWindowVideoNav::GetDirectory(const std::string &strDirectory, CFileItem
   if (m_thumbLoader.IsLoading())
     m_thumbLoader.StopThread();
 
+  items.ClearArt();
   items.ClearProperties();
 
   bool bResult = CGUIWindowVideoBase::GetDirectory(strDirectory, items);
@@ -365,7 +366,6 @@ bool CGUIWindowVideoNav::GetDirectory(const std::string &strDirectory, CFileItem
         }
       }
 
-      items.SetArt("thumb", "");
       if (node == VIDEODATABASEDIRECTORY::NODE_TYPE_EPISODES ||
           node == NODE_TYPE_SEASONS                          ||
           node == NODE_TYPE_RECENTLY_ADDED_EPISODES)


### PR DESCRIPTION
First one ensure we're clearing the entire artwork for the container, not just the `simple` thumb.
Second one fixes an issue reported on the forums where album.thumb and artist.thumb holds the same artwork.

@BigNoid, @HitcherUK, is there anything else that's not working as intended?
