### PR TITLE
[pvr] fix type of CPVRChannelGroup's m_iPosition

### DIFF
--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -528,7 +528,7 @@ namespace PVR
     bool             m_bPreventSortAndRenumber;     /*!< true when sorting and renumbering should not be done after adding/updating channels to the group */
     time_t           m_iLastWatched;                /*!< last time group has been watched */
     bool             m_bHidden;                     /*!< true if this group is hidden, false otherwise */
-    bool             m_iPosition;                   /*!< the position of this group within the group list */
+    int              m_iPosition;                   /*!< the position of this group within the group list */
     PVR_CHANNEL_GROUP_SORTED_MEMBERS m_sortedMembers; /*!< members sorted by channel number */
     PVR_CHANNEL_GROUP_MEMBERS        m_members;       /*!< members with key clientid+uniqueid */
     CCriticalSection m_critSection;


### PR DESCRIPTION
Yet another stupid mistake I did in #6738.
