### PR TITLE
fix TV language detection with HDMI-CEC

### DIFF
--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -636,6 +636,7 @@ void CPeripheralCecAdapter::SetMenuLanguage(const char *strLanguage)
 
   if (!strGuiLanguage.empty())
   {
+    strGuiLanguage = "resource.language." + strGuiLanguage;
     CApplicationMessenger::Get().SetGUILanguage(strGuiLanguage);
     CLog::Log(LOGDEBUG, "%s - language set to '%s'", __FUNCTION__, strGuiLanguage.c_str());
   }


### PR DESCRIPTION
@da-anda has told me that something is wrong with the GUI language selection on his WeTek Play and from the log file I've seen that it tries to set `en_gb` instead of `resource.language.en_gb` as a value for `locale.language`. I changed this in my language addons work (and added support for using e.g.`en_gb` instead of `resource.language.en_gb`) but then refactored all the logic that sets the GUI language to go through the same path by setting the value of `locale.language` which in turn would trigger the `OnSettingChanged()` callback which would then change the displayed GUI language. Unfortunately that path doesn't suppor the short language value version.
