### PR TITLE
addons: find and use the best matching translation for summary/description/disclaimer

### DIFF
--- a/xbmc/utils/Locale.h
+++ b/xbmc/utils/Locale.h
@@ -19,6 +19,7 @@
  *
  */
 
+#include <set>
 #include <string>
 
 /*!
@@ -131,11 +132,22 @@ public:
   */
   bool Matches(const std::string& locale) const;
 
+  /*!
+  \brief Tries to find the locale in the given list that matches this locale
+         best.
+
+  \param locales List of string representations of locales
+  \return Best matching locale from the given list or empty string.
+  */
+  std::string FindBestMatch(const std::set<std::string>& locales) const;
+
 private:
   static bool CheckValidity(const std::string& language, const std::string& territory, const std::string& codeset, const std::string& modifier);
   static bool ParseLocale(const std::string &locale, std::string &language, std::string &territory, std::string &codeset, std::string &modifier);
 
   void Initialize();
+
+  int GetMatchRank(const std::string& locale) const;
 
   bool m_valid;
   std::string m_language;


### PR DESCRIPTION
@alanwww1 made me aware of the fact that when a user has `Portuguese (Brazilian)` set as his GUI language and an addon has a summary/description/disclaimer for both `pt` as well as `pt_BR` it depends on the order of the tags in the XML whether we choose the translated strings for `pt` or `pt_BR` but it's usually the one for `pt`.

I have added a helper method to `CLocale` which takes a list of locales and tries to find the one that matches the current locale best. If there's an exact match, that locale will be taken. Otherwise we look for the locale that is closest to the current locale.
`CAddonMgr` makes use of that function by collecting all translated versions of summary/description/disclaimer that at least partly match in locale and then tries to find the best match and returns the translated value of the best matching locale.
