### PR TITLE
[guilib] hint text not displayed in keyboard dialog

### DIFF
--- a/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
+++ b/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
@@ -73,12 +73,7 @@ CGUIDialogKeyboardGeneric::CGUIDialogKeyboardGeneric()
 
 void CGUIDialogKeyboardGeneric::OnWindowLoaded()
 {
-  // show the cursor always
-  CGUIEditControl *edit = (CGUIEditControl *)GetControl(CTL_EDIT);
-  if (edit)
-    edit->SetShowCursorAlways(true);
   g_Windowing.EnableTextInput(false);
-
   CGUIDialog::OnWindowLoaded();
 }
 

--- a/xbmc/guilib/GUIEditControl.cpp
+++ b/xbmc/guilib/GUIEditControl.cpp
@@ -486,13 +486,14 @@ void CGUIEditControl::ProcessText(unsigned int currentTime)
     changed |= m_label2.SetMaxRect(m_clipRect.x1 + m_textOffset, m_posY, m_clipRect.Width() - m_textOffset, m_height);
 
     std::wstring text = GetDisplayedText();
-    // add the cursor and highlighting if we're focused
-    if ((HasFocus() || m_cursorShowAlways) && m_inputType != INPUT_TYPE_READONLY)
-      changed |= SetStyledText(text);
+    std::string hint = m_hintInfo.GetLabel(GetParentID());
+
+    if (!HasFocus() && text.empty() && !hint.empty())
+      changed |= m_label2.SetText(hint);
     else
     {
-      if (text.empty())
-        changed |= m_label2.SetText(m_hintInfo.GetLabel(GetParentID()));
+      if (m_inputType != INPUT_TYPE_READONLY)
+        changed |= SetStyledText(text);
       else
         changed |= m_label2.SetTextW(text);
     }
@@ -582,10 +583,13 @@ bool CGUIEditControl::SetStyledText(const std::wstring &text)
   }
 
   // show the cursor
-  unsigned int ch = L'|';
-  if ((++m_cursorBlink % 64) > 32)
-    ch |= (3 << 16);
-  styled.insert(styled.begin() + m_cursorPos, ch);
+  if (HasFocus() || GetParentID() == WINDOW_DIALOG_KEYBOARD)
+  {
+    unsigned int ch = L'|';
+    if ((++m_cursorBlink % 64) > 32)
+      ch |= (3 << 16);
+    styled.insert(styled.begin() + m_cursorPos, ch);
+  }
 
   return m_label2.SetStyledText(styled, colors);
 }

--- a/xbmc/guilib/GUIEditControl.cpp
+++ b/xbmc/guilib/GUIEditControl.cpp
@@ -60,7 +60,6 @@ void CGUIEditControl::DefaultConstructor()
   m_textWidth = GetWidth();
   m_cursorPos = 0;
   m_cursorBlink = 0;
-  m_cursorShowAlways = false;
   m_inputHeading = 0;
   m_inputType = INPUT_TYPE_TEXT;
   m_smsLastKey = 0;

--- a/xbmc/guilib/GUIEditControl.h
+++ b/xbmc/guilib/GUIEditControl.h
@@ -72,8 +72,6 @@ public:
 
   virtual std::string GetLabel2() const;
 
-  void SetShowCursorAlways(bool always) { m_cursorShowAlways = always; }
-
   unsigned int GetCursorPosition() const;
   void SetCursorPosition(unsigned int iPosition);
 
@@ -120,7 +118,6 @@ protected:
 
   unsigned int m_cursorPos;
   unsigned int m_cursorBlink;
-  bool         m_cursorShowAlways;
 
   int m_inputHeading;
   INPUT_TYPE m_inputType;


### PR DESCRIPTION
Since the keyboard dialog is an edit control it should be able to display the hint text provided. First commit adjusts the logic to allow hint text for the keyboard dialog, second one removes now obsolete code.

/cc @BigNoid, @ronie, @HitcherUK. Win32 test build is triggered and should be on the mirrors later today.
