### PR TITLE
rework frame threading for ffmpeg

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodec.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodec.h
@@ -172,6 +172,7 @@ class CDVDCodecOptions;
 #define VC_FLUSHED  0x00000010  // the decoder lost it's state, we need to restart decoding again
 #define VC_DROPPED  0x00000020  // needed to identify if a picture was dropped
 #define VC_NOBUFFER 0x00000040  // last FFmpeg GetBuffer failed
+#define VC_REOPEN   0x00000080  // decoder request to re-open
 
 class CDVDVideoCodec
 {
@@ -339,4 +340,10 @@ public:
    *
    */
   virtual void SetCodecControl(int flags) {}
+
+  /*
+    * Re-open the decoder.
+    * Decoder request to re-open
+    */
+   virtual void Reopen() {};
 };

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.h
@@ -20,6 +20,8 @@
  *
  */
 
+#include "cores/dvdplayer/DVDCodecs/DVDCodecs.h"
+#include "cores/dvdplayer/DVDStreamInfo.h"
 #include "DVDVideoCodec.h"
 #include "DVDResource.h"
 #include <string>
@@ -60,6 +62,7 @@ public:
   virtual void Dispose();
   virtual int Decode(uint8_t* pData, int iSize, double dts, double pts);
   virtual void Reset();
+  virtual void Reopen();
   bool GetPictureCommon(DVDVideoPicture* pDvdVideoPicture);
   virtual bool GetPicture(DVDVideoPicture* pDvdVideoPicture);
   virtual void SetDropState(bool bDrop);
@@ -70,7 +73,6 @@ public:
   virtual bool GetCodecStats(double &pts, int &droppedPics);
   virtual void SetCodecControl(int flags);
 
-  bool               IsHardwareAllowed()                     { return !m_bSoftware; }
   IHardwareDecoder * GetHardware()                           { return m_pHardware; };
   void               SetHardware(IHardwareDecoder* hardware);
 
@@ -113,8 +115,7 @@ protected:
   unsigned int m_uSurfacesCount;
 
   std::string m_name;
-  bool m_bSoftware;
-  bool m_isFrameThreaded;
+  int m_decoderState;
   IHardwareDecoder *m_pHardware;
   std::vector<IHardwareDecoder*> m_disposeDecoders;
   int m_iLastKeyframe;
@@ -125,4 +126,6 @@ protected:
   int    m_skippedDeint;
   bool   m_requestSkipDeint;
   int    m_codecControlFlags;
+  CDVDStreamInfo m_hints;
+  CDVDCodecOptions m_options;
 };

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.cpp
@@ -599,8 +599,7 @@ bool CDecoder::Open(AVCodecContext* avctx, AVCodecContext* mainctx, const enum P
 
   // add an extra surface for safety, some faulty material
   // make ffmpeg require more buffers
-  // frame threading requires an additional one
-  m_vaapiConfig.maxReferences += surfaces + 2;
+  m_vaapiConfig.maxReferences += surfaces + 1;
 
   if (!ConfigVAAPI())
   {

--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
@@ -592,7 +592,6 @@ void CDVDPlayerVideo::Process()
       // loop while no error
       while (!m_bStop)
       {
-
         // if decoder was flushed, we need to seek back again to resume rendering
         if (iDecoderState & VC_FLUSHED)
         {
@@ -609,6 +608,23 @@ void CDVDPlayerVideo::Process()
           }
 
           m_pVideoCodec->Reset();
+          m_packets.clear();
+          picture.iFlags &= ~DVP_FLAG_ALLOCATED;
+          g_renderManager.DiscardBuffer();
+          break;
+        }
+
+        if (iDecoderState & VC_REOPEN)
+        {
+          while(!m_packets.empty())
+          {
+            CDVDMsgDemuxerPacket* msg = (CDVDMsgDemuxerPacket*)m_packets.front().message->Acquire();
+            msg->m_drop = false;
+            m_packets.pop_front();
+            m_messageQueue.Put(msg, iPriority + 10);
+          }
+
+          m_pVideoCodec->Reopen();
           m_packets.clear();
           picture.iFlags &= ~DVP_FLAG_ALLOCATED;
           g_renderManager.DiscardBuffer();


### PR DESCRIPTION
discussion on ffmpeg mailing list showed that a re-open of ffmpeg is the only reliable method for switching between hw and sw codecs.
with this change we try hw codecs first, if enabled. if no hw decoder can be found, we close and re-open frame threaded.
