### PR TITLE
[musicdb] enable the library via xml

### DIFF
--- a/system/library/music/albums.xml
+++ b/system/library/music/albums.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<node order="3" type="filter" visible="Library.HasContent(Music)">
+  <label>132</label>
+  <icon>DefaultMusicAlbums.png</icon>
+  <content>albums</content>
+</node>

--- a/system/library/music/artists.xml
+++ b/system/library/music/artists.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<node order="2" type="filter" visible="Library.HasContent(Music)">
+  <label>133</label>
+  <icon>DefaultMusicArtists.png</icon>
+  <content>artists</content>
+</node>

--- a/system/library/music/compilations.xml
+++ b/system/library/music/compilations.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<node order="10" type="folder" visible="Library.HasContent(Compilations)">
+  <label>521</label>
+  <icon>DefaultMusicCompilations.png</icon>
+  <path>musicdb://compilations/</path>
+</node>

--- a/system/library/music/genres.xml
+++ b/system/library/music/genres.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<node order="1" type="filter" visible="Library.HasContent(Music)">
+  <label>135</label>
+  <icon>DefaultMusicGenres.png</icon>
+  <content>artists</content>
+  <group>genres</group>
+</node>

--- a/system/library/music/musicvideos/albums.xml
+++ b/system/library/music/musicvideos/albums.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<node order="5" type="filter">
+  <label>132</label>
+  <icon>DefaultMusicAlbums.png</icon>
+  <content>musicvideos</content>
+  <group>albums</group>
+</node>

--- a/system/library/music/musicvideos/artists.xml
+++ b/system/library/music/musicvideos/artists.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<node order="4" type="filter">
+  <label>133</label>
+  <icon>DefaultMusicArtists.png</icon>
+  <content>musicvideos</content>
+  <group>artists</group>
+</node>

--- a/system/library/music/musicvideos/directors.xml
+++ b/system/library/music/musicvideos/directors.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<node order="6" type="filter">
+ <label>20348</label>
+  <icon>DefaultDirector.png</icon>
+  <content>musicvideos</content>
+  <group>directors</group>
+</node>

--- a/system/library/music/musicvideos/genres.xml
+++ b/system/library/music/musicvideos/genres.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<node order="1" type="filter">
+  <label>135</label>
+  <icon>DefaultGenre.png</icon>
+  <content>musicvideos</content>
+  <group>genres</group>
+</node>

--- a/system/library/music/musicvideos/index.xml
+++ b/system/library/music/musicvideos/index.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<node order="11" visible="Library.HasContent(MusicVideos)">
+  <label>20389</label>
+  <icon>DefaultMusicVideos.png</icon>
+</node>

--- a/system/library/music/musicvideos/studios.xml
+++ b/system/library/music/musicvideos/studios.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<node order="7" type="filter">
+  <label>20388</label>
+  <icon>DefaultStudios.png</icon>
+  <content>musicvideos</content>
+  <group>studios</group>
+</node>

--- a/system/library/music/musicvideos/tags.xml
+++ b/system/library/music/musicvideos/tags.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<node order="8" type="filter">
+  <label>20459</label>
+  <icon>DefaultTags.png</icon>
+  <content>musicvideos</content>
+  <group>tags</group>
+</node>

--- a/system/library/music/musicvideos/titles.xml
+++ b/system/library/music/musicvideos/titles.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<node order="2" type="filter">
+  <label>369</label>
+  <icon>DefaultMusicVideoTitle.png</icon>
+  <content>musicvideos</content>
+  <order direction="ascending">title</order>
+</node>

--- a/system/library/music/musicvideos/years.xml
+++ b/system/library/music/musicvideos/years.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<node order="3" type="filter">
+  <label>562</label>
+  <icon>DefaultYear.png</icon>
+  <content>musicvideos</content>
+  <group>years</group>
+</node>

--- a/system/library/music/playlists.xml
+++ b/system/library/music/playlists.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<node order="13" type="folder">
+  <label>136</label>
+  <icon>DefaultMusicPlaylists.png</icon>
+  <path>special://musicplaylists/</path>
+</node>

--- a/system/library/music/recentlyaddedalbums.xml
+++ b/system/library/music/recentlyaddedalbums.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<node order="8" type="folder" visible="Library.HasContent(Music)">
+  <label>359</label>
+  <icon>DefaultMusicRecentlyAdded.png</icon>
+  <path>musicdb://recentlyaddedalbums/</path>
+</node>

--- a/system/library/music/recentlyplayedalbums.xml
+++ b/system/library/music/recentlyplayedalbums.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<node order="9" type="folder" visible="Library.HasContent(Music)">
+  <label>517</label>
+  <icon>DefaultMusicRecentlyPlayed.png</icon>
+  <path>musicdb://recentlyplayedalbums/</path>
+</node>

--- a/system/library/music/singles.xml
+++ b/system/library/music/singles.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<node order="4" type="folder" visible="Library.HasContent(Singles)">
+  <label>1050</label>
+  <icon>DefaultMusicSongs.png</icon>
+  <path>musicdb://singles/</path>
+</node>

--- a/system/library/music/songs.xml
+++ b/system/library/music/songs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<node order="5" type="filter" visible="Library.HasContent(Music)">
+  <label>134</label>
+  <icon>DefaultMusicSongs.png</icon>
+  <content>songs</content>
+</node>

--- a/system/library/music/top100/index.xml
+++ b/system/library/music/top100/index.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<node order="7" type="folder" visible="Library.HasContent(Music)">
+  <label>271</label>
+  <icon>DefaultMusicTop100.png</icon>
+</node>

--- a/system/library/music/top100/top100albums.xml
+++ b/system/library/music/top100/top100albums.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<node order="2" type="filter" visible="Library.HasContent(Music)">
+  <label>10505</label>
+  <icon>DefaultMusicTop100Albums.png</icon>
+  <content>albums</content>
+  <match>all</match>
+  <rule field="playcount" operator="greaterthan">
+    <value>0</value>
+  </rule>
+  <limit>100</limit>
+  <order direction="descending">playcount</order>
+</node>

--- a/system/library/music/top100/top100songs.xml
+++ b/system/library/music/top100/top100songs.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<node order="1" type="filter" visible="Library.HasContent(Music)">
+  <label>10504</label>
+  <icon>DefaultMusicTop100Songs.png</icon>
+  <content>songs</content>
+  <match>all</match>
+  <rule field="playcount" operator="greaterthan">
+    <value>0</value>
+  </rule>
+  <limit>100</limit>
+  <order direction="descending">playcount</order>
+</node>

--- a/system/library/music/years.xml
+++ b/system/library/music/years.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<node order="6" type="filter" visible="Library.HasContent(Music)">
+  <label>652</label>
+  <icon>DefaultMusicYears.png</icon>
+  <content>albums</content>
+  <group>years</group>
+</node>

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1037,6 +1037,8 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
         else if (cat == "tvshows") return LIBRARY_HAS_TVSHOWS;
         else if (cat == "musicvideos") return LIBRARY_HAS_MUSICVIDEOS;
         else if (cat == "moviesets") return LIBRARY_HAS_MOVIE_SETS;
+        else if (cat == "singles") return LIBRARY_HAS_SINGLES;
+        else if (cat == "compilations") return LIBRARY_HAS_COMPILATIONS;
       }
     }
     else if (cat.name == "musicplayer")
@@ -2272,7 +2274,7 @@ bool CGUIInfoManager::GetBool(int condition1, int contextWindow, const CGUIListI
   }
   else if (condition == PLAYER_MUTED)
     bReturn = g_application.IsMuted();
-  else if (condition >= LIBRARY_HAS_MUSIC && condition <= LIBRARY_HAS_MUSICVIDEOS)
+  else if (condition >= LIBRARY_HAS_MUSIC && condition <= LIBRARY_HAS_COMPILATIONS)
     bReturn = GetLibraryBool(condition);
   else if (condition == LIBRARY_IS_SCANNING)
   {
@@ -5602,6 +5604,12 @@ void CGUIInfoManager::SetLibraryBool(int condition, bool value)
     case LIBRARY_HAS_MUSICVIDEOS:
       m_libraryHasMusicVideos = value ? 1 : 0;
       break;
+    case LIBRARY_HAS_SINGLES:
+      m_libraryHasSingles = value ? 1 : 0;
+      break;
+    case LIBRARY_HAS_COMPILATIONS:
+      m_libraryHasCompilations = value ? 1 : 0;
+      break;
     default:
       break;
   }
@@ -5614,6 +5622,8 @@ void CGUIInfoManager::ResetLibraryBools()
   m_libraryHasTVShows = -1;
   m_libraryHasMusicVideos = -1;
   m_libraryHasMovieSets = -1;
+  m_libraryHasSingles = -1;
+  m_libraryHasCompilations = -1;
 }
 
 bool CGUIInfoManager::GetLibraryBool(int condition)
@@ -5682,6 +5692,32 @@ bool CGUIInfoManager::GetLibraryBool(int condition)
       }
     }
     return m_libraryHasMusicVideos > 0;
+  }
+  else if (condition == LIBRARY_HAS_SINGLES)
+  {
+    if (m_libraryHasSingles < 0)
+    {
+      CMusicDatabase db;
+      if (db.Open())
+      {
+        m_libraryHasSingles = (db.GetSinglesCount() > 0) ? 1 : 0;
+        db.Close();
+      }
+    }
+    return m_libraryHasSingles > 0;
+  }
+  else if (condition == LIBRARY_HAS_COMPILATIONS)
+  {
+    if (m_libraryHasCompilations < 0)
+    {
+      CMusicDatabase db;
+      if (db.Open())
+      {
+        m_libraryHasCompilations = (db.GetCompilationAlbumsCount() > 0) ? 1 : 0;
+        db.Close();
+      }
+    }
+    return m_libraryHasCompilations > 0;
   }
   else if (condition == LIBRARY_HAS_VIDEO)
   {

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -404,9 +404,11 @@ namespace INFO
 #define LIBRARY_HAS_MOVIE_SETS      723
 #define LIBRARY_HAS_TVSHOWS         724
 #define LIBRARY_HAS_MUSICVIDEOS     725
-#define LIBRARY_IS_SCANNING         726
-#define LIBRARY_IS_SCANNING_VIDEO   727
-#define LIBRARY_IS_SCANNING_MUSIC   728
+#define LIBRARY_HAS_SINGLES         726
+#define LIBRARY_HAS_COMPILATIONS    727
+#define LIBRARY_IS_SCANNING         728
+#define LIBRARY_IS_SCANNING_VIDEO   729
+#define LIBRARY_IS_SCANNING_MUSIC   730
 
 #define SYSTEM_PLATFORM_LINUX       741
 #define SYSTEM_PLATFORM_WINDOWS     742
@@ -958,6 +960,8 @@ protected:
   int m_libraryHasTVShows;
   int m_libraryHasMusicVideos;
   int m_libraryHasMovieSets;
+  int m_libraryHasSingles;
+  int m_libraryHasCompilations;
 
   SPlayerVideoStreamInfo m_videoInfo;
   SPlayerAudioStreamInfo m_audioInfo;

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeOverview.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeOverview.cpp
@@ -71,18 +71,16 @@ std::string CDirectoryNodeOverview::GetLocalizedName() const
 bool CDirectoryNodeOverview::GetContent(CFileItemList& items) const
 {
   CMusicDatabase musicDatabase;
-  bool showSingles = false;
-  if (musicDatabase.Open())
-  {
-    if (musicDatabase.GetSinglesCount() > 0)
-      showSingles = true;
-  }
+  musicDatabase.Open();
+
+  bool hasSingles = (musicDatabase.GetSinglesCount() > 0);
+  bool hasCompilations = (musicDatabase.GetCompilationAlbumsCount() > 0);
 
   for (unsigned int i = 0; i < sizeof(OverviewChildren) / sizeof(Node); ++i)
   {
-    if (i == 3 && !showSingles) // singles
+    if (i == 3 && !hasSingles)
       continue;
-    if (i == 9 && musicDatabase.GetCompilationAlbumsCount() == 0) // compilations
+    if (i == 9 && !hasCompilations)
       continue;
 
     CFileItemPtr pItem(new CFileItem(g_localizeStrings.Get(OverviewChildren[i].label)));

--- a/xbmc/music/GUIViewStateMusic.cpp
+++ b/xbmc/music/GUIViewStateMusic.cpp
@@ -499,29 +499,19 @@ VECSOURCES& CGUIViewStateWindowMusicNav::GetSources()
 {
   //  Setup shares we want to have
   m_sources.clear();
-  //  Musicdb shares
   CFileItemList items;
-  CDirectory::GetDirectory("musicdb://", items, "");
+
+  CDirectory::GetDirectory("library://music/", items, "");
   for (int i=0; i<items.Size(); ++i)
   {
     CFileItemPtr item=items[i];
     CMediaSource share;
-    share.strName=item->GetLabel();
+    share.strName = item->GetLabel();
     share.strPath = item->GetPath();
     share.m_strThumbnailImage = item->GetIconImage();
     share.m_iDriveType = CMediaSource::SOURCE_TYPE_LOCAL;
     m_sources.push_back(share);
   }
-
-  //  Playlists share
-  CMediaSource share;
-  share.strName=g_localizeStrings.Get(136); // Playlists
-  share.strPath = "special://musicplaylists/";
-  share.m_strThumbnailImage = CUtil::GetDefaultFolderThumb("DefaultMusicPlaylists.png");
-  share.m_iDriveType = CMediaSource::SOURCE_TYPE_LOCAL;
-  m_sources.push_back(share);
-
-  AddOnlineShares();
 
   // Search share
   share.strName=g_localizeStrings.Get(137); // Search
@@ -530,17 +520,7 @@ VECSOURCES& CGUIViewStateWindowMusicNav::GetSources()
   share.m_iDriveType = CMediaSource::SOURCE_TYPE_LOCAL;
   m_sources.push_back(share);
 
-  // music video share
-  CVideoDatabase database;
-  database.Open();
-  if (database.HasContent(VIDEODB_CONTENT_MUSICVIDEOS))
-  {
-    share.strName = g_localizeStrings.Get(20389);
-    share.strPath = "videodb://musicvideos/";
-    share.m_strThumbnailImage = CUtil::GetDefaultFolderThumb("DefaultMusicVideos.png");
-    share.m_iDriveType = CMediaSource::SOURCE_TYPE_LOCAL;
-    m_sources.push_back(share);
-  }
+  AddOnlineShares();
 
   return CGUIViewStateWindowMusic::GetSources();
 }

--- a/xbmc/music/GUIViewStateMusic.cpp
+++ b/xbmc/music/GUIViewStateMusic.cpp
@@ -513,13 +513,6 @@ VECSOURCES& CGUIViewStateWindowMusicNav::GetSources()
     m_sources.push_back(share);
   }
 
-  // Search share
-  share.strName=g_localizeStrings.Get(137); // Search
-  share.strPath = "musicsearch://";
-  share.m_strThumbnailImage = CUtil::GetDefaultFolderThumb("DefaultMusicSearch.png");
-  share.m_iDriveType = CMediaSource::SOURCE_TYPE_LOCAL;
-  m_sources.push_back(share);
-
   AddOnlineShares();
 
   return CGUIViewStateWindowMusic::GetSources();


### PR DESCRIPTION
This enables the the music library nodes to be defined via xml just as we're already doing for the video library.

@Montellese for review please. Btw, I could need some smart playlist help so we can group by first letter. It's not really related to this PR but would come handy to have something like a flat and full blown library to choose from ;)
