### PR TITLE
Fix compile with gcc-4.6 (e.g. Ubuntu Precise) after 799094a838d12cc6f9513bd576d35f37668176e8

### DIFF
--- a/xbmc/guilib/GUIIncludes.h
+++ b/xbmc/guilib/GUIIncludes.h
@@ -60,7 +60,7 @@ private:
   };
 
   void ResolveIncludesForNode(TiXmlElement *node, std::map<INFO::InfoPtr, bool>* xmlIncludeConditions = NULL);
-  using Params = std::map<std::string, std::string>;
+  typedef std::map<std::string, std::string> Params;
   static bool GetParameters(const TiXmlElement *include, const char *valueAttribute, Params& params);
   static void ResolveParametersForNode(TiXmlElement *node, const Params& params);
   static ResolveParamsResult ResolveParameters(const std::string& strInput, std::string& strOutput, const Params& params);


### PR DESCRIPTION
See title.

From http://en.cppreference.com/w/cpp/language/type_alias - "There is no difference between a type alias declaration and typedef declaration.", and it doesn't look like Params is used in templating stuff.
