### PR TITLE
fix for gamepad volume change

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2395,9 +2395,9 @@ bool CApplication::OnAction(const CAction &action)
         step *= action.GetRepeat() * 50; // 50 fps
 #endif
       if (action.GetID() == ACTION_VOLUME_UP)
-        volume += (float)fabs(action.GetAmount()) * action.GetAmount() * step;
+        volume += action.GetAmount() * action.GetAmount() * step;
       else
-        volume -= (float)fabs(action.GetAmount()) * action.GetAmount() * step;
+        volume -= action.GetAmount() * action.GetAmount() * step;
       SetVolume(volume, false);
     }
     // show visual feedback of volume change...


### PR DESCRIPTION
Application.cpp assumed that both ACTION_VOLUME_UP/DOWN have always
positive Action.GetAmount(). When gamepad returned negative value
for VOLUME_DOWN, volume was increased.
