### PR TITLE
ADD: [droid] implement Google Breakpad for minidumps

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -221,6 +221,8 @@ libcap_disabled="== Capabilities detection support disabled. =="
 libcap_not_found="== Could not find libcap. Capabilities detection support disabled. =="
 gtest_enabled="== Google Test Framework will be configured. =="
 gtest_disabled="== Google Test Framework will not be configured. =="
+breakpad_enabled="== Google Breakpad will be configured. =="
+breakpad_disabled="== Google Breakpad Framework will not be configured. =="
 
 libudev_not_found="== Could not find libudev. Will use polling to check for device changes. =="
 libudev_disabled="== udev support disabled. Will use polling to check for device changes. =="
@@ -543,6 +545,12 @@ AC_ARG_ENABLE([gtest],
   [configure_gtest=$enableval],
   [configure_gtest=yes])
 
+AC_ARG_ENABLE([breakpad],
+  [AS_HELP_STRING([--enable-breakpad],
+  [configure Google Breakpad (default is no)])],
+  [use_breakpad=$enableval],
+  [use_breakpad=no])
+
 AC_ARG_ENABLE([codec],
   [AS_HELP_STRING([--enable-codec],
   [enable additional codecs from a list of comma separated names, (default is none, choices are amcodec, libstagefright and imxvpu)])],
@@ -777,7 +785,11 @@ else
     DEBUG_FLAGS="-pg -DNDEBUG=1"
   else
     final_message="$final_message\n  Profiling:\tNo"
-    DEBUG_FLAGS="-DNDEBUG=1"
+    if test "$use_breakpad" = "yes"; then
+       DEBUG_FLAGS="-g -DNDEBUG=1"
+    else
+       DEBUG_FLAGS="-DNDEBUG=1"
+    fi
   fi
 fi
 CFLAGS="$DEBUG_FLAGS $CFLAGS"
@@ -2296,6 +2308,21 @@ else
   SKIP_CONFIG_GTEST=1
 fi
 
+# Google Breakpad
+if test "$use_breakpad" = "yes"; then
+  USE_BREAKPAD=1
+  PKG_CHECK_MODULES([BREAKPAD],    [breakpad-client],
+    [INCLUDES="$INCLUDES $BREAKPAD_CFLAGS"; LIBS="$LIBS $BREAKPAD_LIBS"],
+    AC_MSG_ERROR("breakpad-client not found"))
+  AC_DEFINE([HAVE_BREAKPAD],[1],["Define to 1 if Google Breakpad is installed"])
+  AC_MSG_NOTICE($breakpad_enabled)
+  final_message="$final_message\n  Google Breakpad Configured:\tYes"
+else
+  AC_MSG_NOTICE($breakpad_disabled)
+  final_message="$final_message\n  Google Breakpad Configured:\tNo"
+  USE_BREAKPAD=0
+fi
+
 if test "$use_avahi" = "yes"; then
   final_message="$final_message\n  Avahi:\tYes"
 else
@@ -2630,6 +2657,7 @@ AC_SUBST(UPNP_DEFINES)
 AC_SUBST(USE_SSE4)
 AC_SUBST(USE_MMAL)
 AC_SUBST(USE_X11)
+AC_SUBST(USE_BREAKPAD)
 
 # pushd and popd are not available in other shells besides bash, so implement
 # our own pushd/popd functions

--- a/tools/android/packaging/Makefile.in
+++ b/tools/android/packaging/Makefile.in
@@ -72,6 +72,12 @@ apk-noobb: apk-clean package apk-sign
 xbmc/assets:
 	mkdir -p xbmc/assets
 
+symbols: libs
+ifeq (1,@USE_BREAKPAD@)
+	for f in xbmc/obj/local/$(CPU)/*.so; do sh ./make_symbols.sh $$f; done
+	tar -cjf @APP_NAME@.symbols-`$(XBMCROOT)/tools/darwin/packaging/gitrev-posix`.tar.bz2 symbols
+endif
+
 shared:
 	mkdir -p assets
 	cp -rfp $(PREFIX)/share/@APP_NAME_LC@/* ./assets
@@ -133,7 +139,7 @@ xbmc/classes.dex: res
 	@javac -classpath $(SDKROOT)/platforms/$(SDK_PLATFORM)/android.jar:xbmc/obj -d xbmc/obj -sourcepath xbmc/src xbmc/src/org/xbmc/@APP_NAME_LC@/*.java
 	@$(DX) --dex --output=xbmc/classes.dex xbmc/obj
 
-package: libs python xbmc/classes.dex
+package: libs symbols python xbmc/classes.dex
 	@echo "Creating package..."
 	@cp images/@APP_NAME_LC@app-debug-skeleton.apk images/@APP_NAME_LC@app-debug-$(CPU)-unaligned.apk
 	@cd xbmc; $(ZIP) -r -q ../images/@APP_NAME_LC@app-debug-$(CPU)-unaligned.apk lib/$(CPU) assets classes.dex
@@ -152,6 +158,7 @@ $(SRCLIBS):
 
 apk-clean:
 	rm -rf images
+	rm -rf symbols
 	rm -rf xbmc/lib
 	rm -rf xbmc/libs
 	rm -rf xbmc/assets

--- a/tools/android/packaging/Makefile.in
+++ b/tools/android/packaging/Makefile.in
@@ -75,7 +75,7 @@ xbmc/assets:
 symbols: libs
 ifeq (1,@USE_BREAKPAD@)
 	for f in xbmc/obj/local/$(CPU)/*.so; do sh ./make_symbols.sh $$f; done
-	tar -cjf @APP_NAME@.symbols-`$(XBMCROOT)/tools/darwin/packaging/gitrev-posix`.tar.bz2 symbols
+	tar -cjf @APP_NAME@.symbols-$(CPU)-`$(XBMCROOT)/tools/darwin/packaging/gitrev-posix`.tar.bz2 symbols
 endif
 
 shared:

--- a/tools/android/packaging/make_symbols.sh
+++ b/tools/android/packaging/make_symbols.sh
@@ -1,0 +1,6 @@
+FN=$(basename "$1")
+dump_syms "$1" > $FN.sym
+HASH=`head -n 1 $FN.sym | cut -d " " -f 4`
+mkdir -p symbols/$FN/$HASH
+mv $FN.sym symbols/$FN/$HASH
+echo "$FN.sym generated"

--- a/tools/buildsteps/android/package
+++ b/tools/buildsteps/android/package
@@ -18,3 +18,4 @@ if [ -f *.obb ]
 then
   mv *.obb $UPLOAD_FILENAME.obb
 fi
+mv tools/android/packaging/Kodi.symbols*.tar.bz2 $ANDROID_DEV_ROOT/debug-symbols/

--- a/tools/depends/native/Makefile
+++ b/tools/depends/native/Makefile
@@ -9,7 +9,8 @@ NATIVE= m4-native gettext-native autoconf-native automake-native \
         gas-preprocessor-native python26-native zlib-native \
         pcre-native swig-native rpl-native libsdl_image-native libsquish-native \
         tiff-native libpng-native libjpeg-turbo-native liblzo2-native giflib-native \
-        libsdl-native distribute-native distutilscross-native JsonSchemaBuilder TexturePacker
+        libsdl-native distribute-native distutilscross-native JsonSchemaBuilder TexturePacker \
+        google-breakpad-native
 
 
 ifeq ($(OS),ios)

--- a/tools/depends/native/google-breakpad-native/Makefile
+++ b/tools/depends/native/google-breakpad-native/Makefile
@@ -1,0 +1,45 @@
+include ../../Makefile.include
+DEPS= ../../Makefile.include Makefile
+
+PREFIX=$(NATIVEPREFIX)
+PLATFORM=$(NATIVEPLATFORM)
+
+# lib name, version
+LIBNAME=google-breakpad
+VERSION=1434
+ARCHIVE=$(LIBNAME)-$(VERSION).tar.bz2
+
+LIBDYLIB=$(PLATFORM)/src/client/linux/libbreakpad_client.a
+
+# configuration settings
+CONFIGURE= ./configure --prefix=$(PREFIX)
+
+CLEAN_FILES=$(ARCHIVE) $(PLATFORM)
+
+all: .installed-$(PLATFORM)
+
+$(TARBALLS_LOCATION)/$(ARCHIVE):
+	cd $(TARBALLS_LOCATION); $(RETRIEVE_TOOL) $(RETRIEVE_TOOL_FLAGS) $(BASE_URL)/$(ARCHIVE)
+
+$(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
+	rm -rf $(PLATFORM)/*; mkdir -p $(PLATFORM)
+	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
+	cd $(PLATFORM); $(CONFIGURE)
+
+$(LIBDYLIB): $(PLATFORM)
+	$(MAKE) -C $(PLATFORM)
+
+.installed-$(PLATFORM): $(LIBDYLIB)
+	$(MAKE) -C $(PLATFORM) install
+	cp -Rf $(PLATFORM)/src/common/android/include/* $(PREFIX)/include/breakpad/
+	mkdir -p $(PREFIX)/include/breakpad/client/linux/dump_writer_common
+	cp -f $(PLATFORM)/src/client/linux/dump_writer_common/*.h $(PREFIX)/include/breakpad/client/linux/dump_writer_common/
+	touch $@
+
+clean:
+	$(MAKE) -C $(PLATFORM) clean
+	rm -f .installed-$(PLATFORM)
+
+distclean::
+	rm -rf $(PLATFORM) .installed-$(PLATFORM)
+

--- a/tools/depends/target/Makefile
+++ b/tools/depends/target/Makefile
@@ -36,7 +36,7 @@ ifeq ($(OS),osx)
 endif
 
 ifeq ($(OS),android)
-  DEPENDS += mdnsresponder android-sources-ics
+  DEPENDS += mdnsresponder android-sources-ics google-breakpad
 endif
 
 DEPENDS := $(filter-out $(EXCLUDED_DEPENDS),$(DEPENDS))

--- a/tools/depends/target/google-breakpad/Makefile
+++ b/tools/depends/target/google-breakpad/Makefile
@@ -1,0 +1,43 @@
+include ../../Makefile.include
+DEPS= ../../Makefile.include Makefile
+
+# lib name, version
+LIBNAME=google-breakpad
+VERSION=1434
+ARCHIVE=$(LIBNAME)-$(VERSION).tar.bz2
+
+LIBDYLIB=$(PLATFORM)/src/client/linux/libbreakpad_client.a
+
+# configuration settings
+CONFIGURE= ./configure --prefix=$(PREFIX)  \
+  --disable-processor --disable-tools
+
+CLEAN_FILES=$(ARCHIVE) $(PLATFORM)
+
+all: .installed-$(PLATFORM)
+
+$(TARBALLS_LOCATION)/$(ARCHIVE):
+	cd $(TARBALLS_LOCATION); $(RETRIEVE_TOOL) $(RETRIEVE_TOOL_FLAGS) $(BASE_URL)/$(ARCHIVE)
+
+$(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
+	rm -rf $(PLATFORM)/*; mkdir -p $(PLATFORM)
+	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
+	cd $(PLATFORM); $(CONFIGURE)
+
+$(LIBDYLIB): $(PLATFORM)
+	$(MAKE) -C $(PLATFORM)
+
+.installed-$(PLATFORM): $(LIBDYLIB)
+	$(MAKE) -C $(PLATFORM) install
+	cp -Rf $(PLATFORM)/src/common/android/include/* $(PREFIX)/include/breakpad/
+	mkdir -p $(PREFIX)/include/breakpad/client/linux/dump_writer_common
+	cp -f $(PLATFORM)/src/client/linux/dump_writer_common/*.h $(PREFIX)/include/breakpad/client/linux/dump_writer_common/
+	touch $@
+
+clean:
+	$(MAKE) -C $(PLATFORM) clean
+	rm -f .installed-$(PLATFORM)
+
+distclean::
+	rm -rf $(PLATFORM) .installed-$(PLATFORM)
+

--- a/tools/depends/target/xbmc/Makefile
+++ b/tools/depends/target/xbmc/Makefile
@@ -13,7 +13,7 @@ CONFIGURE = cp -f $(CONFIG_SUB) $(CONFIG_GUESS) build-aux/ ;\
   ./configure --prefix=$(PREFIX) $(DEBUG)
 
 ifeq ($(OS),android)
-CONFIGURE += --enable-codec=libstagefright,amcodec
+CONFIGURE += --enable-codec=libstagefright,amcodec --enable-breakpad
 endif
 
 ifeq ($(Configuration),Release)

--- a/xbmc/xbmc.cpp
+++ b/xbmc/xbmc.cpp
@@ -25,6 +25,11 @@
 #include "linux/RBP.h"
 #endif
 
+#if defined(HAVE_BREAKPAD)
+#include "filesystem/SpecialProtocol.h"
+#include "client/linux/handler/exception_handler.h"
+#endif
+
 extern "C" int XBMC_Run(bool renderGUI)
 {
   int status = -1;
@@ -46,6 +51,18 @@ extern "C" int XBMC_Run(bool renderGUI)
     fprintf(stderr, "ERROR: Unable to create application. Exiting\n");
     return status;
   }
+
+#if defined(HAVE_BREAKPAD)
+  // Must have our TEMP dir fixed first
+  std::string tempPath = CSpecialProtocol::TranslatePath("special://temp/");
+  google_breakpad::MinidumpDescriptor descriptor(tempPath.c_str());
+  google_breakpad::ExceptionHandler eh(descriptor,
+                                       NULL,
+                                       NULL,
+                                       NULL,
+                                       true,
+                                       -1);
+#endif
 
 #ifdef TARGET_RASPBERRY_PI
   if(!g_RBP.Initialize())


### PR DESCRIPTION
Implement minidumps for android (no more logcat).

2 sided:
- At build time, symbols are created and must be saved
- At crash time, minidumps are created in our TEMP directory

Reconstruction of the stacktrace is done with:
`minidump_stackwalk <minidimp> <symbols_dir>`

TODO:
- jenkins magic to pack and publish the symbols
- log uploader magic to upload minidumps

/cc @wsnipex @Memphiz @Montellese 
