### PR TITLE
[settings] allow hide watched toggling in files node

### DIFF
--- a/xbmc/settings/MediaSettings.cpp
+++ b/xbmc/settings/MediaSettings.cpp
@@ -44,6 +44,7 @@ using namespace std;
 
 CMediaSettings::CMediaSettings()
 {
+  m_watchedModes["files"] = WatchedModeAll;
   m_watchedModes["movies"] = WatchedModeAll;
   m_watchedModes["tvshows"] = WatchedModeAll;
   m_watchedModes["musicvideos"] = WatchedModeAll;


### PR DESCRIPTION
This allows the user to actually `hide watched` in the files node. Marking as `watched / unwatched` is already possible.

@Montellese for review.
