### PR TITLE
Fix compile warnings + problem in URL.cpp

### DIFF
--- a/xbmc/CueDocument.cpp
+++ b/xbmc/CueDocument.cpp
@@ -131,7 +131,6 @@ public:
   {
     // Read the next line.
     line.clear();
-    bool stop = false;
     while (m_pos < m_data.size())
     {
       // Remove the white space at the beginning of the line.

--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -333,9 +333,9 @@ void CURL::SetFileName(const std::string& strFileName)
 {
   m_strFileName = strFileName;
 
-  int slash = m_strFileName.find_last_of(GetDirectorySeparator());
-  int period = m_strFileName.find_last_of('.');
-  if(period != -1 && (slash == -1 || period > slash))
+  size_t slash = m_strFileName.find_last_of(GetDirectorySeparator());
+  size_t period = m_strFileName.find_last_of('.');
+  if(period != std::string::npos && (slash == std::string::npos || period > slash))
     m_strFileType = m_strFileName.substr(period+1);
   else
     m_strFileType = "";

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -476,7 +476,7 @@ int CDVDInputStreamNavigator::ProcessBlock(uint8_t* dest_buffer, int* read)
         {
           uint64_t* times = NULL;
           uint64_t duration;
-          unsigned int entries = m_dll.dvdnav_describe_title_chapters(m_dvdnav, m_iTitle, &times, &duration);
+          int entries = static_cast<int>(m_dll.dvdnav_describe_title_chapters(m_dvdnav, m_iTitle, &times, &duration));
 
           if (entries != m_iPartCount)
             CLog::Log(LOGDEBUG, "%s - Number of chapters/positions differ: Chapters %d, positions %d\n", __FUNCTION__, m_iPartCount, entries);

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -875,7 +875,7 @@ bool CCurlFile::Download(const std::string& strURL, const std::string& strFileNa
   if (pdwSize != NULL)
     *pdwSize = written > 0 ? written : 0;
 
-  return written == strData.size();
+  return written == static_cast<ssize_t>(strData.size());
 }
 
 // Detect whether we are "online" or not! Very simple and dirty!

--- a/xbmc/filesystem/HTTPFile.cpp
+++ b/xbmc/filesystem/HTTPFile.cpp
@@ -47,7 +47,7 @@ ssize_t CHTTPFile::Write(const void* lpBuf, size_t uiBufSize)
     return -1;
 
   std::string myPostData((char*) lpBuf);
-  if ((int64_t)myPostData.length() != uiBufSize)
+  if (myPostData.length() != uiBufSize)
     return -1;
 
   // If we get here, we (most likely) satisfied the pre-conditions that we used OpenForWrite and passed a string as postdata

--- a/xbmc/filesystem/ISOFile.cpp
+++ b/xbmc/filesystem/ISOFile.cpp
@@ -85,7 +85,9 @@ ssize_t CISOFile::Read(void *lpBuf, size_t uiBufSize)
       if (m_cache.getMaxReadSize() )
       {
         long lBytes2Read = m_cache.getMaxReadSize();
-        if (lBytes2Read > uiBufSize) lBytes2Read = (long)uiBufSize;
+        if (lBytes2Read > static_cast<long>(uiBufSize))
+          lBytes2Read = static_cast<long>(uiBufSize);
+
         m_cache.ReadData(pData, lBytes2Read );
         uiBufSize -= lBytes2Read ;
         pData += lBytes2Read;

--- a/xbmc/filesystem/RarFile.cpp
+++ b/xbmc/filesystem/RarFile.cpp
@@ -302,7 +302,7 @@ ssize_t CRarFile::Read(void *lpBuf, size_t uiBufSize)
   int64_t uicBufSize = uiBufSize;
   if (m_iDataInBuffer > 0)
   {
-    int64_t iCopy = uiBufSize<m_iDataInBuffer?uiBufSize:m_iDataInBuffer;
+    int64_t iCopy = (uiBufSize < static_cast<size_t>(m_iDataInBuffer)) ? uiBufSize : m_iDataInBuffer;
     memcpy(lpBuf,m_szStartOfBuffer,size_t(iCopy));
     m_szStartOfBuffer += iCopy;
     m_iDataInBuffer -= int(iCopy);

--- a/xbmc/filesystem/ZipFile.cpp
+++ b/xbmc/filesystem/ZipFile.cpp
@@ -305,7 +305,7 @@ ssize_t CZipFile::Read(void* lpBuf, size_t uiBufSize)
   {
     uLong iDecompressed = 0;
     uLong prevOut = m_ZStream.total_out;
-    while (((int)iDecompressed < uiBufSize) && ((m_iZipFilePos < mZipItem.csize) || (m_bFlush)))
+    while ((static_cast<size_t>(iDecompressed) < uiBufSize) && ((m_iZipFilePos < mZipItem.csize) || (m_bFlush)))
     {
       m_ZStream.next_out = (Bytef*)(lpBuf)+iDecompressed;
       m_ZStream.avail_out = static_cast<uInt>(uiBufSize-iDecompressed);

--- a/xbmc/filesystem/udf25.cpp
+++ b/xbmc/filesystem/udf25.cpp
@@ -593,7 +593,7 @@ int udf25::ReadAt( int64_t pos, size_t len, unsigned char *data )
     return -1;
 
   ssize_t ret = m_fp->Read(data, len);
-  if ( ret < len)
+  if (static_cast<size_t>(ret) < len)
   {
     CLog::Log(LOGERROR, "udf25::ReadFile - less data than requested available!" );
     return (int)ret;

--- a/xbmc/guilib/GUIFontTTF.cpp
+++ b/xbmc/guilib/GUIFontTTF.cpp
@@ -697,7 +697,7 @@ bool CGUIFontTTFBase::CacheCharacter(wchar_t letter, uint32_t style, Character *
       m_posX += -bitGlyph->left;
 
     // check we have enough room for the character
-    if (m_posX + bitGlyph->left + bitmap.width > (int)m_textureWidth)
+    if (m_posX + bitGlyph->left + bitmap.width > m_textureWidth)
     { // no space - gotta drop to the next line (which means creating a new texture and copying it across)
       m_posX = 0;
       m_posY += GetTextureLineHeight();

--- a/xbmc/guilib/JpegIO.cpp
+++ b/xbmc/guilib/JpegIO.cpp
@@ -525,7 +525,7 @@ bool CJpegIO::CreateThumbnailFromSurface(unsigned char* buffer, unsigned int wid
     delete [] rgbbuf;
 
   XFILE::CFile file;
-  const bool ret = file.OpenForWrite(destFile, true) && file.Write(result, outBufSize) == outBufSize;
+  const bool ret = file.OpenForWrite(destFile, true) && file.Write(result, outBufSize) == static_cast<ssize_t>(outBufSize);
   free(result);
 
   return ret;

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -5192,7 +5192,7 @@ void CMusicDatabase::ExportKaraokeInfo(const std::string & outFile, bool asHTML)
       outdoc = "<html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\"></meta></head>\n"
           "<body>\n<table>\n";
 
-      if (file.Write(outdoc.c_str(), outdoc.size()) != outdoc.size())
+      if (file.Write(outdoc.c_str(), outdoc.size()) != static_cast<ssize_t>(outdoc.size()))
         return; // error
     }
 
@@ -5206,7 +5206,7 @@ void CMusicDatabase::ExportKaraokeInfo(const std::string & outFile, bool asHTML)
       else
         outdoc = songnum + '\t' + StringUtils::Join(song.artist, g_advancedSettings.m_musicItemSeparator) + '\t' + song.strTitle + '\t' + song.strFileName + "\r\n";
 
-      if (file.Write(outdoc.c_str(), outdoc.size()) != outdoc.size())
+      if (file.Write(outdoc.c_str(), outdoc.size()) != static_cast<ssize_t>(outdoc.size()))
         return; // error
 
       if ((current % 50) == 0 && progress)
@@ -5229,7 +5229,7 @@ void CMusicDatabase::ExportKaraokeInfo(const std::string & outFile, bool asHTML)
     if ( asHTML )
     {
       outdoc = "</table>\n</body>\n</html>\n";
-      if (file.Write(outdoc.c_str(), outdoc.size()) != outdoc.size())
+      if (file.Write(outdoc.c_str(), outdoc.size()) != static_cast<ssize_t>(outdoc.size()))
         return; // error
     }
 

--- a/xbmc/music/tags/TagLibVFSStream.cpp
+++ b/xbmc/music/tags/TagLibVFSStream.cpp
@@ -218,7 +218,7 @@ void TagLibVFSStream::removeBlock(TagLib::ulong start, TagLib::ulong length)
       clear();
 
     seek(writePosition);
-    if (m_file.Write(buffer.data(), bytesRead) != bytesRead)
+    if (m_file.Write(buffer.data(), bytesRead) != static_cast<ssize_t>(bytesRead))
       return; // error
     writePosition += bytesRead;
   }

--- a/xbmc/playlists/PlayListM3U.cpp
+++ b/xbmc/playlists/PlayListM3U.cpp
@@ -203,7 +203,7 @@ void CPlayListM3U::Save(const std::string& strFileName) const
     return;
   }
   std::string strLine = StringUtils::Format("%s\n",M3U_START_MARKER);
-  if (file.Write(strLine.c_str(), strLine.size()) != strLine.size())
+  if (file.Write(strLine.c_str(), strLine.size()) != static_cast<ssize_t>(strLine.size()))
     return; // error
 
   for (int i = 0; i < (int)m_vecItems.size(); ++i)
@@ -212,7 +212,7 @@ void CPlayListM3U::Save(const std::string& strFileName) const
     std::string strDescription=item->GetLabel();
     g_charsetConverter.utf8ToStringCharset(strDescription);
     strLine = StringUtils::Format( "%s:%i,%s\n", M3U_INFO_MARKER, item->GetMusicInfoTag()->GetDuration() / 1000, strDescription.c_str() );
-    if (file.Write(strLine.c_str(), strLine.size()) != strLine.size())
+    if (file.Write(strLine.c_str(), strLine.size()) != static_cast<ssize_t>(strLine.size()))
       return; // error
     if (item->m_lStartOffset != 0 || item->m_lEndOffset != 0)
     {
@@ -222,7 +222,7 @@ void CPlayListM3U::Save(const std::string& strFileName) const
     std::string strFileName = ResolveURL(item);
     g_charsetConverter.utf8ToStringCharset(strFileName);
     strLine = StringUtils::Format("%s\n",strFileName.c_str());
-    if (file.Write(strLine.c_str(), strLine.size()) != strLine.size())
+    if (file.Write(strLine.c_str(), strLine.size()) != static_cast<ssize_t>(strLine.size()))
       return; // error
   }
   file.Close();

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -161,7 +161,7 @@ bool CPVRChannelGroup::Load(void)
   if (Size() - iChannelCount > 0)
   {
     CLog::Log(LOGDEBUG, "PVRChannelGroup - %s - %d channels added from clients to group '%s'",
-        __FUNCTION__, Size() - iChannelCount, m_strGroupName.c_str());
+        __FUNCTION__, static_cast<int>(Size() - iChannelCount), m_strGroupName.c_str());
   }
 
   SortAndRenumber();

--- a/xbmc/utils/ScraperUrl.cpp
+++ b/xbmc/utils/ScraperUrl.cpp
@@ -307,7 +307,7 @@ bool CScraperUrl::Get(const SUrlEntry& scrURL, std::string& strHTML, XFILE::CCur
     std::string strCachePath = URIUtils::AddFileToFolder(g_advancedSettings.m_cachePath,
                               "scrapers/" + cacheContext + "/" + scrURL.m_cache);
     XFILE::CFile file;
-    if (!file.OpenForWrite(strCachePath, true) || file.Write(strHTML.data(), strHTML.size()) != strHTML.size())
+    if (!file.OpenForWrite(strCachePath, true) || file.Write(strHTML.data(), strHTML.size()) != static_cast<ssize_t>(strHTML.size()))
       return false;
   }
   return true;

--- a/xbmc/utils/XBMCTinyXML.cpp
+++ b/xbmc/utils/XBMCTinyXML.cpp
@@ -122,7 +122,7 @@ bool CXBMCTinyXML::SaveFile(const std::string& filename) const
   {
     TiXmlPrinter printer;
     Accept(&printer);
-    return file.Write(printer.CStr(), printer.Size()) == printer.Size();
+    return file.Write(printer.CStr(), printer.Size()) == static_cast<ssize_t>(printer.Size());
   }
   return false;
 }

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -159,7 +159,7 @@ bool CThumbExtractor::DoWork()
         db.SetStreamDetailsForFileId(info->m_streamDetails, info->m_iFileId);
 
       // overwrite the runtime value if the one from streamdetails is available
-      if (info->m_iDbId > 0 && info->m_duration != info->GetDuration())
+      if (info->m_iDbId > 0 && info->m_duration != static_cast<int>(info->GetDuration()))
       {
         info->m_duration = info->GetDuration();
 

--- a/xbmc/view/GUIViewState.cpp
+++ b/xbmc/view/GUIViewState.cpp
@@ -300,10 +300,6 @@ void CGUIViewState::AddSortMethod(SortDescription sortDescription, int buttonLab
 void CGUIViewState::SetCurrentSortMethod(int method)
 {
   SortBy sortBy = (SortBy)method;
-  SortAttribute sortAttributes = SortAttributeNone;
-  if (CSettings::Get().GetBool("filelists.ignorethewhensorting"))
-    sortAttributes = SortAttributeIgnoreArticle;
-
   if (sortBy < SortByNone || sortBy > SortByRandom)
     return; // invalid
 


### PR DESCRIPTION
This fixes a bunch of (cosmetic) compile warnings. While fixing these I also found a problem with the use of -1 instead of std::string::npos in URL.cpp (this may require backport!).
