### PR TITLE
python: fix HAS_WEB_SERVER ifdef guard in AddonModuleXbmcwsgi.i

### DIFF
--- a/xbmc/interfaces/python/PythonSwig.cpp.template
+++ b/xbmc/interfaces/python/PythonSwig.cpp.template
@@ -953,3 +953,7 @@ namespace PythonBindings
   }
 
 } // end PythonBindings namespace for python type definitions
+
+<%
+Helper.getInsertNodes(module, 'footer').each { %>${Helper.unescape(it)}<% }
+%>

--- a/xbmc/interfaces/swig/AddonModuleXbmcwsgi.i
+++ b/xbmc/interfaces/swig/AddonModuleXbmcwsgi.i
@@ -18,7 +18,7 @@
  *
  */
 
-%{
+%begin %{
 #include "system.h"
 
 #ifdef HAS_WEB_SERVER
@@ -56,7 +56,7 @@ using namespace xbmcwsgi;
 %include "interfaces/legacy/wsgi/WsgiResponse.h"
 %include "interfaces/legacy/wsgi/WsgiResponseBody.h"
 
-%{
+%insert("footer") %{
 #endif
 %}
 


### PR DESCRIPTION
This fixes an issue brought up in http://trac.kodi.tv/ticket/15849. The generated python API code for the WSGI module, which can only be used through the webserver, is currently compiled independent of the `HAS_WEB_SERVER` define because the respective `#endif` is added before the generated code.

Swig supports "code insertion blocks" (see http://www.swig.org/Doc2.0/SWIGDocumentation.html#SWIG_nn40) to place code from the interface description file into specific places in the generated code. Unfortunately SWIG doesn't support inserting code after the generated code. Therefore I'm using a non-standard insertion code called `footer` (the opposite of the existing `header`).

@jimfcarroll: Please let me know if you can think of a better way to do this. Ideally the interface file would never be processed and the problematic code never generated in which case we wouldn't need the ifdef guard in the first place. Unfortuantely we execute `codegenerator.mk` in `bootstrap` where we have no clue about any configure flags/options and available libraries etc.
