### PR TITLE
[gui] only close modal dialogs if we leave a media window

### DIFF
--- a/xbmc/addons/AddonCallbacksGUI.cpp
+++ b/xbmc/addons/AddonCallbacksGUI.cpp
@@ -2198,7 +2198,7 @@ void CGUIAddonWindowDialog::Show_Internal(bool show /* = true */)
   {
     m_bModal = true;
     m_bRunning = true;
-    g_windowManager.RouteToWindow(this);
+    g_windowManager.RegisterDialog(this);
 
     // active this window...
     CGUIMessage msg(GUI_MSG_WINDOW_INIT, 0, 0, WINDOW_INVALID, m_iWindowId);

--- a/xbmc/dialogs/GUIDialogBusy.cpp
+++ b/xbmc/dialogs/GUIDialogBusy.cpp
@@ -104,7 +104,7 @@ void CGUIDialogBusy::Show_Internal()
   m_bLastVisible = true;
   m_closing = false;
   m_progress = 0;
-  g_windowManager.RouteToWindow(this);
+  g_windowManager.RegisterDialog(this);
 
   // active this window...
   CGUIMessage msg(GUI_MSG_WINDOW_INIT, 0, 0);

--- a/xbmc/dialogs/GUIDialogProgress.cpp
+++ b/xbmc/dialogs/GUIDialogProgress.cpp
@@ -69,7 +69,7 @@ void CGUIDialogProgress::StartModal()
   m_active = true;
   m_bModal = true;
   m_closing = false;
-  g_windowManager.RouteToWindow(this);
+  g_windowManager.RegisterDialog(this);
 
   // active this window...
   ShowProgressBar(false);

--- a/xbmc/guilib/GUIDialog.cpp
+++ b/xbmc/guilib/GUIDialog.cpp
@@ -176,7 +176,7 @@ void CGUIDialog::DoModal_Internal(int iWindowID /*= WINDOW_INVALID */, const std
   // the main rendering thread (this should really be handled via
   // a thread message though IMO)
   m_active = true;
-  g_windowManager.RouteToWindow(this);
+  g_windowManager.RegisterDialog(this);
 
   // active this window...
   CGUIMessage msg(GUI_MSG_WINDOW_INIT, 0, 0, WINDOW_INVALID, iWindowID);
@@ -213,7 +213,7 @@ void CGUIDialog::Show_Internal()
   // a thread message though IMO)
   m_active = true;
   m_closing = false;
-  g_windowManager.AddModeless(this);
+  g_windowManager.RegisterDialog(this);
 
   // active this window...
   CGUIMessage msg(GUI_MSG_WINDOW_INIT, 0, 0);

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -813,6 +813,16 @@ void CGUIWindowManager::CloseDialogs(bool forceClose) const
   }
 }
 
+void CGUIWindowManager::CloseModalDialogs(bool forceClose) const
+{
+  CSingleLock lock(g_graphicsContext);
+  for (const auto& dialog : m_activeDialogs)
+  {
+    if (dialog->IsModalDialog())
+      dialog->Close(forceClose);
+  }
+}
+
 bool CGUIWindowManager::OnAction(const CAction &action) const
 {
   CSingleLock lock(g_graphicsContext);

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -571,12 +571,15 @@ void CGUIWindowManager::AddCustomWindow(CGUIWindow* pWindow)
   m_vecCustomWindows.push_back(pWindow);
 }
 
-void CGUIWindowManager::AddModeless(CGUIWindow* dialog)
+void CGUIWindowManager::RegisterDialog(CGUIWindow* dialog)
 {
   CSingleLock lock(g_graphicsContext);
-  // only add the window if it's not already added
-  for (iDialog it = m_activeDialogs.begin(); it != m_activeDialogs.end(); ++it)
-    if (*it == dialog) return;
+  // only add the window if it does not exists
+  for (const auto& activeDialog : m_activeDialogs)
+  {
+    if (activeDialog->GetID() == dialog->GetID())
+      return;
+  }
   m_activeDialogs.push_back(dialog);
 }
 
@@ -1093,18 +1096,6 @@ void CGUIWindowManager::DeInitialize()
   m_activeDialogs.clear();
 
   m_initialized = false;
-}
-
-/// \brief Route to a window
-/// \param pWindow Window to route to
-void CGUIWindowManager::RouteToWindow(CGUIWindow* dialog)
-{
-  CSingleLock lock(g_graphicsContext);
-  // Just to be sure: Unroute this window,
-  // #we may have routed to it before
-  RemoveDialog(dialog->GetID());
-
-  m_activeDialogs.push_back(dialog);
 }
 
 /// \brief Unroute window

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -125,8 +125,11 @@ public:
   void SetCallback(IWindowManagerCallback& callback);
   void DeInitialize();
 
-  void RouteToWindow(CGUIWindow* dialog);
-  void AddModeless(CGUIWindow* dialog);
+  /*! \brief Register a dialog as active dialog
+   *
+   * \param dialog The dialog to register as active dialog
+   */
+  void RegisterDialog(CGUIWindow* dialog);
   void RemoveDialog(int id);
   int GetTopMostModalDialogID(bool ignoreClosing = false) const;
 

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -64,6 +64,7 @@ public:
   void PreviousWindow();
 
   void CloseDialogs(bool forceClose = false) const;
+  void CloseModalDialogs(bool forceClose = false) const;
 
   // OnAction() runs through our active dialogs and windows and sends the message
   // off to the callbacks (application, python, playlist player) and to the

--- a/xbmc/interfaces/legacy/WindowDialogMixin.cpp
+++ b/xbmc/interfaces/legacy/WindowDialogMixin.cpp
@@ -59,7 +59,7 @@ namespace XBMCAddon
       case HACK_CUSTOM_ACTION_OPENING:
         {
           // This is from the CGUIPythonWindowXMLDialog::Show_Internal
-          g_windowManager.RouteToWindow(w->window->get());
+          g_windowManager.RegisterDialog(w->window->get());
           // active this dialog...
           CGUIMessage msg(GUI_MSG_WINDOW_INIT,0,0);
           w->OnMessage(msg);

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -237,8 +237,8 @@ bool CGUIMediaWindow::OnMessage(CGUIMessage& message)
       m_iLastControl = GetFocusedControlID();
       CGUIWindow::OnMessage(message);
 
-      // Close all open dialogs
-      g_windowManager.CloseDialogs(true);
+      // Close all open modal dialogs
+      g_windowManager.CloseModalDialogs(true);
 
       // get rid of any active filtering
       if (m_canFilterAdvanced)


### PR DESCRIPTION
As introduced by #6546 we close every active dialog if we leave/switch a media window. This also close some non-modal dialogs e.g. extended progress dialog, volumebar dialog etc. which are window independent. This PR will fix it by only closing active modal dialogs instead of all.

This PR also combines the 2 different methods to register a dialog as active dialog into one with a better wording.

@mkortstiege as discussed at IRC, you know it best ;)
@AlwinEsch ping
