### PR TITLE
UPnP: Avoid unnecessary searches for external subtitles

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -10287,7 +10287,12 @@ msgctxt "#20221"
 msgid "With this enabled, any information that is downloaded for albums and artists will override anything you have set in your song tags, such as genres, year, song artists etc. Useful if you have MusicBrainz identifiers in your song tags."
 msgstr ""
 
-#empty strings from id 20222 to 20239
+#: system/settings/settings.xml
+msgctxt "#20222"
+msgid "Look for external subtitles"
+msgstr ""
+
+#empty strings from id 20223 to 20239
 
 #: xbmc/dialogs/GUIDialogMediaSource.cpp
 msgctxt "#20240"
@@ -15845,7 +15850,11 @@ msgctxt "#36419"
 msgid "Define locations used for retrieving weather information."
 msgstr ""
 
-#empty string with id 36420
+#. Description of setting "Services -> UPnP -> Look for external subtitles" with label #20222
+#: system/settings/settings.xml
+msgctxt "#36420"
+msgid "Look for external subtitles for videos provided by the UPnP server. This can cause extensive CPU, filesystem and network load."
+msgstr ""
 
 #. Description of setting "Videos -> Playback -> Prefer VDPAU Video Mixer" with label #13437
 #: system/settings/settings.xml

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2168,6 +2168,14 @@
           </dependencies>
           <control type="toggle" />
         </setting>
+        <setting id="services.upnplookforexternalsubtitles" type="boolean" parent="services.upnpserver" label="20222" help="36420">
+          <level>2</level>
+          <default>false</default>
+          <dependencies>
+            <dependency type="enable" setting="services.upnpserver">true</dependency>
+          </dependencies>
+          <control type="toggle" />
+        </setting>
         <setting id="services.upnpcontroller" type="boolean" parent="services.upnpserver" label="21361" help="36326">
           <level>1</level>
           <default>false</default>

--- a/xbmc/filesystem/UPnPDirectory.cpp
+++ b/xbmc/filesystem/UPnPDirectory.cpp
@@ -320,7 +320,7 @@ CUPnPDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 
             // keep count of classes
             classes[(*entry)->m_ObjectClass.type]++;
-            CFileItemPtr pItem = BuildObject(*entry);
+            CFileItemPtr pItem = BuildObject(*entry, UPnPClient);
             if(!pItem) {
                 ++entry;
                 continue;

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -615,10 +615,12 @@ BuildObject(CFileItem&                    item,
         }
     }
 
-    // look for and add external subtitle if we are being called by a UPnP
-    // player or renderer and we are processing a video file
+    // look for and add external subtitle if we are processing a video file and
+    // we are being called by a UPnP player or renderer or the user has chosen
+    // to look for external subtitles
     if (upnp_server != NULL && item.IsVideo() &&
-       (upnp_service == UPnPPlayer || upnp_service == UPnPRenderer))
+       (upnp_service == UPnPPlayer || upnp_service == UPnPRenderer ||
+        CSettings::Get().GetBool("services.upnplookforexternalsubtitles")))
     {
         // find any available external subtitles
         std::vector<std::string> filenames;

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -615,8 +615,10 @@ BuildObject(CFileItem&                    item,
         }
     }
 
-    //Add external subtitle
-    if (upnp_server && item.IsVideo()) //only if video file
+    // look for and add external subtitle if we are being called by a UPnP
+    // player or renderer and we are processing a video file
+    if (upnp_server != NULL && item.IsVideo() &&
+       (upnp_service == UPnPPlayer || upnp_service == UPnPRenderer))
     {
         // find any available external subtitles
         std::vector<std::string> filenames;

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -222,8 +222,8 @@ bool CResourceFinder::operator()(const PLT_MediaItemResource& resource) const {
 NPT_Result
 PopulateObjectFromTag(CMusicInfoTag&         tag,
                       PLT_MediaObject&       object,
-                      NPT_String*            file_path, /* = NULL */
-                      PLT_MediaItemResource* resource,  /* = NULL */
+                      NPT_String*            file_path,
+                      PLT_MediaItemResource* resource,
                       EClientQuirks          quirks)
 {
     if (!tag.GetURL().empty() && file_path)
@@ -265,8 +265,8 @@ PopulateObjectFromTag(CMusicInfoTag&         tag,
 NPT_Result
 PopulateObjectFromTag(CVideoInfoTag&         tag,
                       PLT_MediaObject&       object,
-                      NPT_String*            file_path, /* = NULL */
-                      PLT_MediaItemResource* resource,  /* = NULL */
+                      NPT_String*            file_path,
+                      PLT_MediaItemResource* resource,
                       EClientQuirks          quirks)
 {
     if (!tag.m_strFileNameAndPath.empty() && file_path)
@@ -729,7 +729,7 @@ CorrectAllItemsSortHack(const std::string &item)
 }
 
 int
-PopulateTagFromObject(CMusicInfoTag&          tag,
+PopulateTagFromObject(CMusicInfoTag&         tag,
                       PLT_MediaObject&       object,
                       PLT_MediaItemResource* resource /* = NULL */)
 {

--- a/xbmc/network/upnp/UPnPInternal.h
+++ b/xbmc/network/upnp/UPnPInternal.h
@@ -41,6 +41,14 @@ class CVideoInfoTag;
 
 namespace UPNP
 {
+  enum Service {
+    None = 0,
+    Client,
+    ContentDirectory,
+    Player,
+    Renderer
+  };
+
   class CResourceFinder {
   public:
     CResourceFinder(const char* protocol, const char* content = NULL);
@@ -87,27 +95,29 @@ namespace UPNP
   NPT_Result PopulateTagFromObject(MUSIC_INFO::CMusicInfoTag& tag,
                                    PLT_MediaObject&           object,
                                    PLT_MediaItemResource*     resource = NULL);
+
   NPT_Result PopulateTagFromObject(CVideoInfoTag&             tag,
                                    PLT_MediaObject&           object,
                                    PLT_MediaItemResource*     resource = NULL);
 
-  NPT_Result PopulateObjectFromTag(MUSIC_INFO::CMusicInfoTag&         tag,
-                                          PLT_MediaObject&       object,
-                                          NPT_String*            file_path,
-                                          PLT_MediaItemResource* resource,
-                                          EClientQuirks          quirks);
-  NPT_Result PopulateObjectFromTag(CVideoInfoTag&         tag,
-                                          PLT_MediaObject&       object,
-                                          NPT_String*            file_path,
-                                          PLT_MediaItemResource* resource,
-                                          EClientQuirks          quirks);
+  NPT_Result PopulateObjectFromTag(MUSIC_INFO::CMusicInfoTag& tag,
+                                   PLT_MediaObject&           object,
+                                   NPT_String*                file_path,
+                                   PLT_MediaItemResource*     resource,
+                                   EClientQuirks              quirks);
 
-  PLT_MediaObject* BuildObject(CFileItem&              item,
-                                      NPT_String&                   file_path,
-                                      bool                          with_count,
-                                      NPT_Reference<CThumbLoader>&  thumb_loader,
-                                      const PLT_HttpRequestContext* context = NULL,
-                                      CUPnPServer*                  upnp_server = NULL);
+  NPT_Result PopulateObjectFromTag(CVideoInfoTag&             tag,
+                                   PLT_MediaObject&           object,
+                                   NPT_String*                file_path,
+                                   PLT_MediaItemResource*     resource,
+                                   EClientQuirks              quirks);
+
+  PLT_MediaObject* BuildObject(CFileItem&                     item,
+                               NPT_String&                    file_path,
+                               bool                           with_count,
+                               NPT_Reference<CThumbLoader>&   thumb_loader,
+                               const PLT_HttpRequestContext*  context = NULL,
+                               CUPnPServer*                   upnp_server = NULL);
 
   CFileItemPtr     BuildObject(PLT_MediaObject* entry);
 

--- a/xbmc/network/upnp/UPnPInternal.h
+++ b/xbmc/network/upnp/UPnPInternal.h
@@ -41,12 +41,12 @@ class CVideoInfoTag;
 
 namespace UPNP
 {
-  enum Service {
-    None = 0,
-    Client,
-    ContentDirectory,
-    Player,
-    Renderer
+  enum UPnPService {
+    UPnPServiceNone = 0,
+    UPnPClient,
+    UPnPContentDirectory,
+    UPnPPlayer,
+    UPnPRenderer
   };
 
   class CResourceFinder {
@@ -94,32 +94,38 @@ namespace UPNP
 
   NPT_Result PopulateTagFromObject(MUSIC_INFO::CMusicInfoTag& tag,
                                    PLT_MediaObject&           object,
-                                   PLT_MediaItemResource*     resource = NULL);
+                                   PLT_MediaItemResource*     resource = NULL,
+                                   UPnPService                service = UPnPServiceNone);
 
   NPT_Result PopulateTagFromObject(CVideoInfoTag&             tag,
                                    PLT_MediaObject&           object,
-                                   PLT_MediaItemResource*     resource = NULL);
+                                   PLT_MediaItemResource*     resource = NULL,
+                                   UPnPService                service = UPnPServiceNone);
 
   NPT_Result PopulateObjectFromTag(MUSIC_INFO::CMusicInfoTag& tag,
                                    PLT_MediaObject&           object,
                                    NPT_String*                file_path,
                                    PLT_MediaItemResource*     resource,
-                                   EClientQuirks              quirks);
+                                   EClientQuirks              quirks,
+                                   UPnPService                service = UPnPServiceNone);
 
   NPT_Result PopulateObjectFromTag(CVideoInfoTag&             tag,
                                    PLT_MediaObject&           object,
                                    NPT_String*                file_path,
                                    PLT_MediaItemResource*     resource,
-                                   EClientQuirks              quirks);
+                                   EClientQuirks              quirks,
+                                   UPnPService                service = UPnPServiceNone);
 
   PLT_MediaObject* BuildObject(CFileItem&                     item,
                                NPT_String&                    file_path,
                                bool                           with_count,
                                NPT_Reference<CThumbLoader>&   thumb_loader,
                                const PLT_HttpRequestContext*  context = NULL,
-                               CUPnPServer*                   upnp_server = NULL);
+                               CUPnPServer*                   upnp_server = NULL,
+                               UPnPService                    upnp_service = UPnPServiceNone);
 
-  CFileItemPtr     BuildObject(PLT_MediaObject* entry);
+  CFileItemPtr     BuildObject(PLT_MediaObject* entry,
+                               UPnPService      upnp_service = UPnPServiceNone);
 
   bool             GetResource(const PLT_MediaObject* entry, CFileItem& item);
   CFileItemPtr     GetFileItem(const NPT_String& uri, const NPT_String& meta);

--- a/xbmc/network/upnp/UPnPPlayer.cpp
+++ b/xbmc/network/upnp/UPnPPlayer.cpp
@@ -226,7 +226,7 @@ int CUPnPPlayer::PlayFile(const CFileItem& file, const CPlayerOptions& options, 
   else if (item.IsMusicDb())
     thumb_loader = NPT_Reference<CThumbLoader>(new CMusicThumbLoader());
 
-  obj = BuildObject(item, path, false, thumb_loader, NULL, CUPnP::GetServer());
+  obj = BuildObject(item, path, false, thumb_loader, NULL, CUPnP::GetServer(), UPnPPlayer);
   if(obj.IsNull()) goto failed;
 
   NPT_CHECK_LABEL_SEVERE(PLT_Didl::ToDidl(*obj, "", tmp), failed_todidl);
@@ -413,7 +413,7 @@ bool CUPnPPlayer::QueueNextFile(const CFileItem& file)
     thumb_loader = NPT_Reference<CThumbLoader>(new CMusicThumbLoader());
 
 
-  obj = BuildObject(item, path, 0, thumb_loader, NULL, CUPnP::GetServer());
+  obj = BuildObject(item, path, 0, thumb_loader, NULL, CUPnP::GetServer(), UPnPPlayer);
   if(!obj.IsNull())
   {
     NPT_CHECK_LABEL_SEVERE(PLT_Didl::ToDidl(*obj, "", tmp), failed);

--- a/xbmc/network/upnp/UPnPRenderer.cpp
+++ b/xbmc/network/upnp/UPnPRenderer.cpp
@@ -400,7 +400,7 @@ CUPnPRenderer::GetMetadata(NPT_String& meta)
     // we pass an empty CThumbLoader reference, as it can't be used
     // without CUPnPServer enabled
     NPT_Reference<CThumbLoader> thumb_loader;
-    PLT_MediaObject* object = BuildObject(item, file_path, false, thumb_loader);
+    PLT_MediaObject* object = BuildObject(item, file_path, false, thumb_loader, NULL, NULL, UPnPRenderer);
     if (object) {
         // fetch the item's artwork
         std::string thumb;

--- a/xbmc/network/upnp/UPnPServer.cpp
+++ b/xbmc/network/upnp/UPnPServer.cpp
@@ -379,7 +379,7 @@ CUPnPServer::Build(CFileItemPtr                  item,
         }
 
         // not a virtual path directory, new system
-        object = BuildObject(*item.get(), file_path, with_count, thumb_loader, &context, this);
+        object = BuildObject(*item.get(), file_path, with_count, thumb_loader, &context, this, UPnPContentDirectory);
 
         // set parent id if passed, otherwise it should have been determined
         if (object && parent_id) {


### PR DESCRIPTION
A while ago we added support for external subtitles over UPnP which has been a much asked for feature. A bit later we got feedback from a user in the forum (see http://forum.kodi.tv/showthread.php?tid=220840) that this new feature is causing a lot of network traffic between his machine running Kodi and the machine where his media files are located. The reason for this is that we currently check for external subtitles for every item that is retrieved through UPnP. So when a UPnP client requests the list of all movies from Kodi we look for external subtitles for every movie we return to the client. Obviously that is not ideal.

So I set out to find a solution and thought it would be enough to only look for external subtitles before sending a single media item to a UPnP renderer or when a UPnP player requests an item. The former works perfectly fine but the latter doesn't because what a UPnP client does is
- it retrieves a list of media items
- the user chooses a media item from that list to play
- the client extracts the resources / stream details from the metadata of the previously retrieved list of media items
- the client passes that information and the streaming (HTTP) URL to the UPnP player

Therefore we already have to provide external subtitles with the original list of all media items because the client doesn't ask for specific details anymore and simply starts playback based on the available information. I'll look into the UPnP specification again to see if there's a way to force the client/player to retrieve the full details before starting playback but I don't remember reading something like that in the past.

What I've done for now is to add logic that limits the search for external subtitles to
- when the request comes from a player or renderer
- when a newly introduced setting to search for external subtitles when listing media items over UPnP is enabled (default is disabled).
