### PR TITLE
[confluence] Move dialog background to include

### DIFF
--- a/addons/skin.confluence/720p/DialogAddonInfo.xml
+++ b/addons/skin.confluence/720p/DialogAddonInfo.xml
@@ -12,52 +12,15 @@
 		<control type="group">
 			<include>VisibleFadeEffect</include>
 			<visible>!Window.isVisible(AddonSettings) + !Window.IsActive(TextViewer)</visible>
-			<control type="image">
-				<description>background image</description>
-				<left>0</left>
-				<top>0</top>
-				<width>920</width>
-				<height>639</height>
-				<texture border="40">DialogBack.png</texture>
-			</control>
-			<control type="image">
-				<description>Dialog Header image</description>
-				<left>40</left>
-				<top>16</top>
-				<width>840</width>
-				<height>40</height>
-				<texture>dialogheader.png</texture>
-			</control>
-			<control type="label">
-				<description>header label</description>
-				<left>40</left>
-				<top>20</top>
-				<width>840</width>
-				<height>30</height>
-				<font>font13_title</font>
-				<label>$LOCALIZE[24003]</label>
-				<align>center</align>
-				<aligny>center</aligny>
-				<textcolor>selected</textcolor>
-				<shadowcolor>black</shadowcolor>
-			</control>
-			<control type="button">
-				<description>Close Window button</description>
-				<left>830</left>
-				<top>15</top>
-				<width>64</width>
-				<height>32</height>
-				<label>-</label>
-				<font>-</font>
-				<onclick>PreviousMenu</onclick>
-				<texturefocus>DialogCloseButton-focus.png</texturefocus>
-				<texturenofocus>DialogCloseButton.png</texturenofocus>
-				<onleft>3</onleft>
-				<onright>3</onright>
-				<onup>3</onup>
-				<ondown>3</ondown>
-				<visible>system.getbool(input.enablemouse)</visible>
-			</control>
+			<include name="DialogBackgroundCommons">
+				<param name="DialogBackgroundWidth" value="920" />
+				<param name="DialogBackgroundHeight" value="639" />
+				<param name="DialogHeaderWidth" value="840" />
+				<param name="DialogHeaderLabel" value="$LOCALIZE[24003]" />
+				<param name="DialogHeaderId" value="2" />
+				<param name="CloseButtonLeft" value="830" />
+				<param name="CloseButtonNav" value="3" />
+			</include>
 			<control type="image">
 				<left>30</left>
 				<top>70</top>

--- a/addons/skin.confluence/720p/DialogAddonSettings.xml
+++ b/addons/skin.confluence/720p/DialogAddonSettings.xml
@@ -8,62 +8,15 @@
 	</coordinates>
 	<include>dialogeffect</include>
 	<controls>
-		<control type="image">
-			<description>background image</description>
-			<left>0</left>
-			<top>0</top>
-			<width>800</width>
-			<height>600</height>
-			<texture border="40">DialogBack.png</texture>
-			<visible>![Window.IsVisible(FullscreenVideo) | Window.IsVisible(Visualisation)]</visible>
-		</control>
-		<control type="image">
-			<description>background image</description>
-			<left>0</left>
-			<top>0</top>
-			<width>800</width>
-			<height>600</height>
-			<texture border="40">DialogBack2.png</texture>
-			<visible>Window.IsVisible(FullscreenVideo) | Window.IsVisible(Visualisation)</visible>
-		</control>
-		<control type="image">
-			<description>Dialog Header image</description>
-			<left>40</left>
-			<top>16</top>
-			<width>720</width>
-			<height>40</height>
-			<texture>dialogheader.png</texture>
-		</control>
-		<control type="label" id="20">
-			<description>header label</description>
-			<left>40</left>
-			<top>20</top>
-			<width>720</width>
-			<height>30</height>
-			<font>font13_title</font>
-			<label>-</label>
-			<align>center</align>
-			<aligny>center</aligny>
-			<textcolor>selected</textcolor>
-			<shadowcolor>black</shadowcolor>
-		</control>
-		<control type="button">
-			<description>Close Window button</description>
-			<left>710</left>
-			<top>15</top>
-			<width>64</width>
-			<height>32</height>
-			<label>-</label>
-			<font>-</font>
-			<onclick>PreviousMenu</onclick>
-			<texturefocus>DialogCloseButton-focus.png</texturefocus>
-			<texturenofocus>DialogCloseButton.png</texturenofocus>
-			<onleft>3</onleft>
-			<onright>3</onright>
-			<onup>3</onup>
-			<ondown>3</ondown>
-			<visible>system.getbool(input.enablemouse)</visible>
-		</control>
+		<include name="DialogBackgroundCommons">
+			<param name="DialogBackgroundWidth" value="800" />
+			<param name="DialogBackgroundHeight" value="600" />
+			<param name="DialogHeaderWidth" value="720" />
+			<param name="DialogHeaderLabel" value="-" />
+			<param name="DialogHeaderId" value="20" />
+			<param name="CloseButtonLeft" value="710" />
+			<param name="CloseButtonNav" value="3" />
+		</include>
 		<control type="grouplist" id="9">
 			<description>button area</description>
 			<left>45</left>

--- a/addons/skin.confluence/720p/DialogContentSettings.xml
+++ b/addons/skin.confluence/720p/DialogContentSettings.xml
@@ -10,52 +10,15 @@
 	<controls>
 		<control type="group">
 			<animation effect="fade" start="100" end="0" time="150" condition="Window.IsActive(AddonSettings)">Conditional</animation>
-			<control type="image">
-				<description>background image</description>
-				<left>0</left>
-				<top>0</top>
-				<width>800</width>
-				<height>680</height>
-				<texture border="40">DialogBack.png</texture>
-			</control>
-			<control type="image">
-				<description>Dialog Header image</description>
-				<left>40</left>
-				<top>16</top>
-				<width>720</width>
-				<height>40</height>
-				<texture>dialogheader.png</texture>
-			</control>
-			<control type="label" id="1">
-				<description>header label</description>
-				<left>40</left>
-				<top>20</top>
-				<width>720</width>
-				<height>30</height>
-				<font>font13_title</font>
-				<label>$LOCALIZE[20333]</label>
-				<align>center</align>
-				<aligny>center</aligny>
-				<textcolor>selected</textcolor>
-				<shadowcolor>black</shadowcolor>
-			</control>
-			<control type="button">
-				<description>Close Window button</description>
-				<left>710</left>
-				<top>15</top>
-				<width>64</width>
-				<height>32</height>
-				<label>-</label>
-				<font>-</font>
-				<onclick>PreviousMenu</onclick>
-				<texturefocus>DialogCloseButton-focus.png</texturefocus>
-				<texturenofocus>DialogCloseButton.png</texturenofocus>
-				<onleft>10</onleft>
-				<onright>10</onright>
-				<onup>10</onup>
-				<ondown>10</ondown>
-				<visible>system.getbool(input.enablemouse)</visible>
-			</control>
+			<include name="DialogBackgroundCommons">
+				<param name="DialogBackgroundWidth" value="800" />
+				<param name="DialogBackgroundHeight" value="680" />
+				<param name="DialogHeaderWidth" value="720" />
+				<param name="DialogHeaderLabel" value="$LOCALIZE[20333]" />
+				<param name="DialogHeaderId" value="1" />
+				<param name="CloseButtonLeft" value="710" />
+				<param name="CloseButtonNav" value="10" />
+			</include>
 			<control type="label">
 				<description>Content Picker Header</description>
 				<left>30</left>

--- a/addons/skin.confluence/720p/DialogGamepad.xml
+++ b/addons/skin.confluence/720p/DialogGamepad.xml
@@ -8,51 +8,15 @@
 	</coordinates>
 	<include>dialogeffect</include>
 	<controls>
-		<control type="image">
-			<left>0</left>
-			<top>0</top>
-			<width>610</width>
-			<height>230</height>
-			<texture border="40">DialogBack.png</texture>
-		</control>
-		<control type="image">
-			<description>Dialog Header image</description>
-			<left>40</left>
-			<top>16</top>
-			<width>530</width>
-			<height>40</height>
-			<texture>dialogheader.png</texture>
-		</control>
-		<control type="label" id="1">
-			<description>header label</description>
-			<left>40</left>
-			<top>20</top>
-			<width>530</width>
-			<height>30</height>
-			<font>font13_title</font>
-			<label>$LOCALIZE[13406]</label>
-			<align>center</align>
-			<aligny>center</aligny>
-			<textcolor>selected</textcolor>
-			<shadowcolor>black</shadowcolor>
-		</control>
-		<control type="button">
-			<description>Close Window button</description>
-			<left>520</left>
-			<top>15</top>
-			<width>64</width>
-			<height>32</height>
-			<label>-</label>
-			<font>-</font>
-			<onclick>PreviousMenu</onclick>
-			<texturefocus>DialogCloseButton-focus.png</texturefocus>
-			<texturenofocus>DialogCloseButton.png</texturenofocus>
-			<onleft>10</onleft>
-			<onright>10</onright>
-			<onup>10</onup>
-			<ondown>10</ondown>
-			<visible>system.getbool(input.enablemouse)</visible>
-		</control>
+		<include name="DialogBackgroundCommons">
+			<param name="DialogBackgroundWidth" value="610" />
+			<param name="DialogBackgroundHeight" value="230" />
+			<param name="DialogHeaderWidth" value="530" />
+			<param name="DialogHeaderLabel" value="$LOCALIZE[13406]" />
+			<param name="DialogHeaderId" value="1" />
+			<param name="CloseButtonLeft" value="520" />
+			<param name="CloseButtonNav" value="10" />
+		</include>
 		<control type="label" id="2">
 			<description>dialog line 1</description>
 			<left>30</left>

--- a/addons/skin.confluence/720p/DialogKaraokeSongSelectorLarge.xml
+++ b/addons/skin.confluence/720p/DialogKaraokeSongSelectorLarge.xml
@@ -8,51 +8,15 @@
 	</coordinates>
 	<controls>
 		<control type="group">
-			<control type="image">
-				<left>0</left>
-				<top>0</top>
-				<width>450</width>
-				<height>170</height>
-				<texture border="40">DialogBack.png</texture>
-			</control>
-			<control type="image">
-				<description>Dialog Header image</description>
-				<left>40</left>
-				<top>16</top>
-				<width>370</width>
-				<height>40</height>
-				<texture>dialogheader.png</texture>
-			</control>
-			<control type="label" id="1">
-				<description>header label</description>
-				<left>40</left>
-				<top>20</top>
-				<width>370</width>
-				<height>30</height>
-				<font>font13_title</font>
-				<label>$LOCALIZE[31321]</label>
-				<align>center</align>
-				<aligny>center</aligny>
-				<textcolor>selected</textcolor>
-				<shadowcolor>black</shadowcolor>
-			</control>
-			<control type="button">
-				<description>Close Window button</description>
-				<left>360</left>
-				<top>15</top>
-				<width>64</width>
-				<height>32</height>
-				<label>-</label>
-				<font>-</font>
-				<onclick>PreviousMenu</onclick>
-				<texturefocus>DialogCloseButton-focus.png</texturefocus>
-				<texturenofocus>DialogCloseButton.png</texturenofocus>
-				<onleft>10</onleft>
-				<onright>10</onright>
-				<onup>10</onup>
-				<ondown>10</ondown>
-				<visible>system.getbool(input.enablemouse)</visible>
-			</control>
+			<include name="DialogBackgroundCommons">
+				<param name="DialogBackgroundWidth" value="450" />
+				<param name="DialogBackgroundHeight" value="170" />
+				<param name="DialogHeaderWidth" value="370" />
+				<param name="DialogHeaderLabel" value="$LOCALIZE[31321]" />
+				<param name="DialogHeaderId" value="1" />
+				<param name="CloseButtonLeft" value="360" />
+				<param name="CloseButtonNav" value="10" />
+			</include>
 			<control type="label" id="401">
 				<description>Song Number Label</description>
 				<left>30</left>

--- a/addons/skin.confluence/720p/DialogKeyboard.xml
+++ b/addons/skin.confluence/720p/DialogKeyboard.xml
@@ -11,50 +11,15 @@
 		<control type="group">
 			<include>VisibleFadeEffect</include>
 			<visible>!Window.IsVisible(numericinput)</visible>
-			<control type="image">
-				<left>0</left>
-				<top>0</top>
-				<width>860</width>
-				<height>430</height>
-				<texture border="40">DialogBack.png</texture>
-			</control>
-			<control type="image">
-				<description>Dialog Header image</description>
-				<left>40</left>
-				<top>16</top>
-				<width>780</width>
-				<height>40</height>
-				<texture>dialogheader.png</texture>
-			</control>
-			<control type="label" id="311">
-				<description>header label</description>
-				<left>40</left>
-				<top>20</top>
-				<width>820</width>
-				<height>30</height>
-				<font>font13_title</font>
-				<align>center</align>
-				<aligny>center</aligny>
-				<textcolor>selected</textcolor>
-				<shadowcolor>black</shadowcolor>
-			</control>
-			<control type="button">
-				<description>Close Window button</description>
-				<left>770</left>
-				<top>15</top>
-				<width>64</width>
-				<height>32</height>
-				<label>-</label>
-				<font>-</font>
-				<onclick>PreviousMenu</onclick>
-				<texturefocus>DialogCloseButton-focus.png</texturefocus>
-				<texturenofocus>DialogCloseButton.png</texturenofocus>
-				<onleft>3</onleft>
-				<onright>3</onright>
-				<onup>3</onup>
-				<ondown>3</ondown>
-				<visible>system.getbool(input.enablemouse)</visible>
-			</control>
+			<include name="DialogBackgroundCommons">
+				<param name="DialogBackgroundWidth" value="860" />
+				<param name="DialogBackgroundHeight" value="430" />
+				<param name="DialogHeaderWidth" value="780" />
+				<param name="DialogHeaderLabel" value="" />
+				<param name="DialogHeaderId" value="311" />
+				<param name="CloseButtonLeft" value="770" />
+				<param name="CloseButtonNav" value="3" />
+			</include>
 			<control type="image">
 				<left>50</left>
 				<top>60</top>

--- a/addons/skin.confluence/720p/DialogMediaFilter.xml
+++ b/addons/skin.confluence/720p/DialogMediaFilter.xml
@@ -8,52 +8,15 @@
 	</coordinates>
 	<include>dialogeffect</include>
 	<controls>
-		<control type="image">
-			<description>background image</description>
-			<left>0</left>
-			<top>0</top>
-			<width>800</width>
-			<height>500</height>
-			<texture border="40">DialogBack.png</texture>
-		</control>
-		<control type="image">
-			<description>Dialog Header image</description>
-			<left>40</left>
-			<top>16</top>
-			<width>720</width>
-			<height>40</height>
-			<texture>dialogheader.png</texture>
-		</control>
-		<control type="label" id="2">
-			<description>header label</description>
-			<left>40</left>
-			<top>20</top>
-			<width>720</width>
-			<height>30</height>
-			<font>font13_title</font>
-			<label>587</label>
-			<align>center</align>
-			<aligny>center</aligny>
-			<textcolor>selected</textcolor>
-			<shadowcolor>black</shadowcolor>
-		</control>
-		<control type="button">
-			<description>Close Window button</description>
-			<left>710</left>
-			<top>15</top>
-			<width>64</width>
-			<height>32</height>
-			<label>-</label>
-			<font>-</font>
-			<onclick>PreviousMenu</onclick>
-			<texturefocus>DialogCloseButton-focus.png</texturefocus>
-			<texturenofocus>DialogCloseButton.png</texturenofocus>
-			<onleft>10</onleft>
-			<onright>10</onright>
-			<onup>10</onup>
-			<ondown>10</ondown>
-			<visible>system.getbool(input.enablemouse)</visible>
-		</control>
+		<include name="DialogBackgroundCommons">
+			<param name="DialogBackgroundWidth" value="800" />
+			<param name="DialogBackgroundHeight" value="500" />
+			<param name="DialogHeaderWidth" value="720" />
+			<param name="DialogHeaderLabel" value="$LOCALIZE[587]" />
+			<param name="DialogHeaderId" value="2" />
+			<param name="CloseButtonLeft" value="710" />
+			<param name="CloseButtonNav" value="10" />
+		</include>
 		<control type="grouplist" id="5">
 			<description>control area</description>
 			<left>30</left>

--- a/addons/skin.confluence/720p/DialogMediaSource.xml
+++ b/addons/skin.confluence/720p/DialogMediaSource.xml
@@ -8,52 +8,15 @@
 	</coordinates>
 	<include>dialogeffect</include>
 	<controls>
-		<control type="image">
-			<description>background image</description>
-			<left>0</left>
-			<top>0</top>
-			<width>800</width>
-			<height>500</height>
-			<texture border="40">DialogBack.png</texture>
-		</control>
-		<control type="image">
-			<description>Dialog Header image</description>
-			<left>40</left>
-			<top>16</top>
-			<width>720</width>
-			<height>40</height>
-			<texture>dialogheader.png</texture>
-		</control>
-		<control type="label" id="2">
-			<description>header label</description>
-			<left>40</left>
-			<top>20</top>
-			<width>720</width>
-			<height>30</height>
-			<font>font13_title</font>
-			<label>$LOCALIZE[13406]</label>
-			<align>center</align>
-			<aligny>center</aligny>
-			<textcolor>selected</textcolor>
-			<shadowcolor>black</shadowcolor>
-		</control>
-		<control type="button">
-			<description>Close Window button</description>
-			<left>710</left>
-			<top>15</top>
-			<width>64</width>
-			<height>32</height>
-			<label>-</label>
-			<font>-</font>
-			<onclick>PreviousMenu</onclick>
-			<texturefocus>DialogCloseButton-focus.png</texturefocus>
-			<texturenofocus>DialogCloseButton.png</texturenofocus>
-			<onleft>10</onleft>
-			<onright>10</onright>
-			<onup>10</onup>
-			<ondown>10</ondown>
-			<visible>system.getbool(input.enablemouse)</visible>
-		</control>
+		<include name="DialogBackgroundCommons">
+			<param name="DialogBackgroundWidth" value="800" />
+			<param name="DialogBackgroundHeight" value="500" />
+			<param name="DialogHeaderWidth" value="720" />
+			<param name="DialogHeaderLabel" value="$LOCALIZE[13406]" />
+			<param name="DialogHeaderId" value="2" />
+			<param name="CloseButtonLeft" value="710" />
+			<param name="CloseButtonNav" value="10" />
+		</include>
 		<control type="label">
 			<description>path label</description>
 			<left>20</left>

--- a/addons/skin.confluence/720p/DialogNetworkSetup.xml
+++ b/addons/skin.confluence/720p/DialogNetworkSetup.xml
@@ -8,52 +8,15 @@
 	</coordinates>
 	<include>dialogeffect</include>
 	<controls>
-		<control type="image">
-			<description>background image</description>
-			<left>0</left>
-			<top>0</top>
-			<width>800</width>
-			<height>440</height>
-			<texture border="40">DialogBack.png</texture>
-		</control>
-		<control type="image">
-			<description>Dialog Header image</description>
-			<left>40</left>
-			<top>16</top>
-			<width>720</width>
-			<height>40</height>
-			<texture>dialogheader.png</texture>
-		</control>
-		<control type="label" id="2">
-			<description>header label</description>
-			<left>40</left>
-			<top>20</top>
-			<width>720</width>
-			<height>30</height>
-			<font>font13_title</font>
-			<label>$LOCALIZE[1007]</label>
-			<align>center</align>
-			<aligny>center</aligny>
-			<textcolor>selected</textcolor>
-			<shadowcolor>black</shadowcolor>
-		</control>
-		<control type="button">
-			<description>Close Window button</description>
-			<left>710</left>
-			<top>15</top>
-			<width>64</width>
-			<height>32</height>
-			<label>-</label>
-			<font>-</font>
-			<onclick>PreviousMenu</onclick>
-			<texturefocus>DialogCloseButton-focus.png</texturefocus>
-			<texturenofocus>DialogCloseButton.png</texturenofocus>
-			<onleft>10</onleft>
-			<onright>10</onright>
-			<onup>10</onup>
-			<ondown>10</ondown>
-			<visible>system.getbool(input.enablemouse)</visible>
-		</control>
+		<include name="DialogBackgroundCommons">
+			<param name="DialogBackgroundWidth" value="800" />
+			<param name="DialogBackgroundHeight" value="440" />
+			<param name="DialogHeaderWidth" value="720" />
+			<param name="DialogHeaderLabel" value="$LOCALIZE[1007]" />
+			<param name="DialogHeaderId" value="2" />
+			<param name="CloseButtonLeft" value="710" />
+			<param name="CloseButtonNav" value="10" />
+		</include>
 		<control type="spincontrolex" id="10">
 			<description>Protocol SpinControl</description>
 			<left>30</left>

--- a/addons/skin.confluence/720p/DialogOK.xml
+++ b/addons/skin.confluence/720p/DialogOK.xml
@@ -8,51 +8,15 @@
 	</coordinates>
 	<include>dialogeffect</include>
 	<controls>
-		<control type="image">
-			<left>0</left>
-			<top>0</top>
-			<width>610</width>
-			<height>240</height>
-			<texture border="40">DialogBack.png</texture>
-		</control>
-		<control type="image">
-			<description>Dialog Header image</description>
-			<left>40</left>
-			<top>16</top>
-			<width>530</width>
-			<height>40</height>
-			<texture>dialogheader.png</texture>
-		</control>
-		<control type="label" id="1">
-			<description>header label</description>
-			<left>40</left>
-			<top>20</top>
-			<width>530</width>
-			<height>30</height>
-			<font>font13_title</font>
-			<label>$LOCALIZE[13406]</label>
-			<align>center</align>
-			<aligny>center</aligny>
-			<textcolor>selected</textcolor>
-			<shadowcolor>black</shadowcolor>
-		</control>
-		<control type="button">
-			<description>Close Window button</description>
-			<left>520</left>
-			<top>15</top>
-			<width>64</width>
-			<height>32</height>
-			<label>-</label>
-			<font>-</font>
-			<onclick>PreviousMenu</onclick>
-			<texturefocus>DialogCloseButton-focus.png</texturefocus>
-			<texturenofocus>DialogCloseButton.png</texturenofocus>
-			<onleft>10</onleft>
-			<onright>10</onright>
-			<onup>10</onup>
-			<ondown>10</ondown>
-			<visible>system.getbool(input.enablemouse)</visible>
-		</control>
+		<include name="DialogBackgroundCommons">
+			<param name="DialogBackgroundWidth" value="610" />
+			<param name="DialogBackgroundHeight" value="240" />
+			<param name="DialogHeaderWidth" value="530" />
+			<param name="DialogHeaderLabel" value="$LOCALIZE[13406]" />
+			<param name="DialogHeaderId" value="1" />
+			<param name="CloseButtonLeft" value="520" />
+			<param name="CloseButtonNav" value="10" />
+		</include>
 		<control type="textbox" id="9">
 			<description>text</description>
 			<left>30</left>

--- a/addons/skin.confluence/720p/DialogPVRChannelManager.xml
+++ b/addons/skin.confluence/720p/DialogPVRChannelManager.xml
@@ -9,66 +9,15 @@
 	</coordinates>
 	<include>dialogeffect</include>
 	<controls>
-		<control type="image">
-			<left>0</left>
-			<top>0</top>
-			<width>1120</width>
-			<height>570</height>
-			<texture border="40">DialogBack.png</texture>
-		</control>
-		<control type="image">
-			<description>Dialog Header image</description>
-			<left>40</left>
-			<top>16</top>
-			<width>1020</width>
-			<height>40</height>
-			<texture>dialogheader.png</texture>
-		</control>
-		<control type="label">
-			<description>header label</description>
-			<left>40</left>
-			<top>20</top>
-			<width>1020</width>
-			<height>30</height>
-			<font>font13_title</font>
-			<label>$LOCALIZE[19199] - $LOCALIZE[19023]</label>
-			<align>center</align>
-			<aligny>center</aligny>
-			<textcolor>selected</textcolor>
-			<shadowcolor>black</shadowcolor>
-			<visible>IsEmpty(Window.Property(IsRadio))</visible>
-		</control>
-		<control type="label">
-			<description>header label</description>
-			<left>40</left>
-			<top>20</top>
-			<width>1020</width>
-			<height>30</height>
-			<font>font13_title</font>
-			<label>$LOCALIZE[19199] - $LOCALIZE[19024]</label>
-			<align>center</align>
-			<aligny>center</aligny>
-			<textcolor>selected</textcolor>
-			<shadowcolor>black</shadowcolor>
-			<visible>!IsEmpty(Window.Property(IsRadio))</visible>
-		</control>
-		<control type="button">
-			<description>Close Window button</description>
-			<left>1030</left>
-			<top>15</top>
-			<width>64</width>
-			<height>32</height>
-			<label>-</label>
-			<font>-</font>
-			<onclick>PreviousMenu</onclick>
-			<texturefocus>DialogCloseButton-focus.png</texturefocus>
-			<texturenofocus>DialogCloseButton.png</texturenofocus>
-			<onleft>10</onleft>
-			<onright>10</onright>
-			<onup>10</onup>
-			<ondown>10</ondown>
-			<visible>system.getbool(input.enablemouse)</visible>
-		</control>
+		<include name="DialogBackgroundCommons">
+			<param name="DialogBackgroundWidth" value="1120" />
+			<param name="DialogBackgroundHeight" value="570" />
+			<param name="DialogHeaderWidth" value="1020" />
+			<param name="DialogHeaderLabel" value="$VAR[PVRChannelMgrHeader]" />
+			<param name="DialogHeaderId" value="2" />
+			<param name="CloseButtonLeft" value="1030" />
+			<param name="CloseButtonNav" value="10" />
+		</include>
 		<control type="group">
 			<left>20</left>
 			<top>70</top>

--- a/addons/skin.confluence/720p/DialogPVRGuideInfo.xml
+++ b/addons/skin.confluence/720p/DialogPVRGuideInfo.xml
@@ -10,62 +10,15 @@
 	<include>dialogeffect</include>
 	<controls>
 		<control type="group">
-			<control type="image">
-				<description>background image</description>
-				<left>0</left>
-				<top>0</top>
-				<width>790</width>
-				<height>660</height>
-				<texture border="40">DialogBack2.png</texture>
-				<visible>Window.IsVisible(FullscreenVideo) | Window.IsVisible(Visualisation)</visible>
-			</control>
-			<control type="image">
-				<description>background image</description>
-				<left>0</left>
-				<top>0</top>
-				<width>790</width>
-				<height>660</height>
-				<texture border="40">DialogBack.png</texture>
-				<visible>![Window.IsVisible(FullscreenVideo) | Window.IsVisible(Visualisation)]</visible>
-			</control>
-			<control type="image">
-				<description>Dialog Header image</description>
-				<left>40</left>
-				<top>16</top>
-				<width>710</width>
-				<height>40</height>
-				<texture>dialogheader.png</texture>
-			</control>
-			<control type="label">
-				<description>header label</description>
-				<left>40</left>
-				<top>20</top>
-				<width>710</width>
-				<height>30</height>
-				<font>font13_title</font>
-				<label>$LOCALIZE[19047]</label>
-				<align>center</align>
-				<aligny>center</aligny>
-				<textcolor>selected</textcolor>
-				<shadowcolor>black</shadowcolor>
-			</control>
-			<control type="button">
-				<description>Close Window button</description>
-				<left>700</left>
-				<top>15</top>
-				<width>64</width>
-				<height>32</height>
-				<label>-</label>
-				<font>-</font>
-				<onclick>PreviousMenu</onclick>
-				<texturefocus>DialogCloseButton-focus.png</texturefocus>
-				<texturenofocus>DialogCloseButton.png</texturenofocus>
-				<onleft>10</onleft>
-				<onright>10</onright>
-				<onup>10</onup>
-				<ondown>10</ondown>
-				<visible>system.getbool(input.enablemouse)</visible>
-			</control>
+			<include name="DialogBackgroundCommons">
+				<param name="DialogBackgroundWidth" value="790" />
+				<param name="DialogBackgroundHeight" value="660" />
+				<param name="DialogHeaderWidth" value="710" />
+				<param name="DialogHeaderLabel" value="$LOCALIZE[19047]" />
+				<param name="DialogHeaderId" value="2" />
+				<param name="CloseButtonLeft" value="700" />
+				<param name="CloseButtonNav" value="10" />
+			</include>
 			<control type="label">
 				<description>Title label</description>
 				<left>40</left>

--- a/addons/skin.confluence/720p/DialogPVRGuideSearch.xml
+++ b/addons/skin.confluence/720p/DialogPVRGuideSearch.xml
@@ -8,52 +8,15 @@
 	</coordinates>
 	<include>dialogeffect</include>
 	<controls>
-		<control type="image">
-			<description>background image</description>
-			<left>0</left>
-			<top>0</top>
-			<width>865</width>
-			<height>605</height>
-			<texture border="40">DialogBack.png</texture>
-		</control>
-		<control type="image">
-			<description>Dialog Header image</description>
-			<left>40</left>
-			<top>16</top>
-			<width>785</width>
-			<height>40</height>
-			<texture>dialogheader.png</texture>
-		</control>
-		<control type="label">
-			<description>header label</description>
-			<left>40</left>
-			<top>20</top>
-			<width>785</width>
-			<height>30</height>
-			<font>font13_title</font>
-			<label>$LOCALIZE[19142]</label>
-			<align>center</align>
-			<aligny>center</aligny>
-			<textcolor>selected</textcolor>
-			<shadowcolor>black</shadowcolor>
-		</control>
-		<control type="button">
-			<description>Close Window button</description>
-			<left>775</left>
-			<top>15</top>
-			<width>64</width>
-			<height>32</height>
-			<label>-</label>
-			<font>-</font>
-			<onclick>PreviousMenu</onclick>
-			<texturefocus>DialogCloseButton-focus.png</texturefocus>
-			<texturenofocus>DialogCloseButton.png</texturenofocus>
-			<onleft>3</onleft>
-			<onright>3</onright>
-			<onup>3</onup>
-			<ondown>3</ondown>
-			<visible>system.getbool(input.enablemouse)</visible>
-		</control>
+		<include name="DialogBackgroundCommons">
+			<param name="DialogBackgroundWidth" value="865" />
+			<param name="DialogBackgroundHeight" value="605" />
+			<param name="DialogHeaderWidth" value="785" />
+			<param name="DialogHeaderLabel" value="$LOCALIZE[19142]" />
+			<param name="DialogHeaderId" value="2" />
+			<param name="CloseButtonLeft" value="775" />
+			<param name="CloseButtonNav" value="3" />
+		</include>
 		<control type="label">
 			<description>Search string</description>
 			<left>30</left>

--- a/addons/skin.confluence/720p/DialogPVRRecordingInfo.xml
+++ b/addons/skin.confluence/720p/DialogPVRRecordingInfo.xml
@@ -8,62 +8,15 @@
 	</coordinates>
 	<include>dialogeffect</include>
 	<controls>
-		<control type="image">
-			<description>background image</description>
-			<left>0</left>
-			<top>0</top>
-			<width>730</width>
-			<height>660</height>
-			<texture border="40">DialogBack2.png</texture>
-			<visible>Window.IsVisible(FullscreenVideo) | Window.IsVisible(Visualisation)</visible>
-		</control>
-		<control type="image">
-			<description>background image</description>
-			<left>0</left>
-			<top>0</top>
-			<width>730</width>
-			<height>660</height>
-			<texture border="40">DialogBack.png</texture>
-			<visible>![Window.IsVisible(FullscreenVideo) | Window.IsVisible(Visualisation)]</visible>
-		</control>
-		<control type="image">
-			<description>Dialog Header image</description>
-			<left>40</left>
-			<top>16</top>
-			<width>650</width>
-			<height>40</height>
-			<texture>dialogheader.png</texture>
-		</control>
-		<control type="label">
-			<description>header label</description>
-			<left>40</left>
-			<top>20</top>
-			<width>650</width>
-			<height>30</height>
-			<font>font13_title</font>
-			<label>$LOCALIZE[19053]</label>
-			<align>center</align>
-			<aligny>center</aligny>
-			<textcolor>selected</textcolor>
-			<shadowcolor>black</shadowcolor>
-		</control>
-		<control type="button">
-			<description>Close Window button</description>
-			<left>640</left>
-			<top>15</top>
-			<width>64</width>
-			<height>32</height>
-			<label>-</label>
-			<font>-</font>
-			<onclick>PreviousMenu</onclick>
-			<texturefocus>DialogCloseButton-focus.png</texturefocus>
-			<texturenofocus>DialogCloseButton.png</texturenofocus>
-			<onleft>10</onleft>
-			<onright>10</onright>
-			<onup>10</onup>
-			<ondown>10</ondown>
-			<visible>system.getbool(input.enablemouse)</visible>
-		</control>
+		<include name="DialogBackgroundCommons">
+			<param name="DialogBackgroundWidth" value="730" />
+			<param name="DialogBackgroundHeight" value="660" />
+			<param name="DialogHeaderWidth" value="650" />
+			<param name="DialogHeaderLabel" value="$LOCALIZE[19053]" />
+			<param name="DialogHeaderId" value="2" />
+			<param name="CloseButtonLeft" value="640" />
+			<param name="CloseButtonNav" value="10" />
+		</include>
 		<control type="label">
 			<description>Title label</description>
 			<left>40</left>

--- a/addons/skin.confluence/720p/DialogPVRTimerSettings.xml
+++ b/addons/skin.confluence/720p/DialogPVRTimerSettings.xml
@@ -8,52 +8,15 @@
 	</coordinates>
 	<include>dialogeffect</include>
 	<controls>
-		<control type="image">
-			<description>background image</description>
-			<left>0</left>
-			<top>0</top>
-			<width>730</width>
-			<height>660</height>
-			<texture border="40">DialogBack.png</texture>
-		</control>
-		<control type="image">
-			<description>Dialog Header image</description>
-			<left>40</left>
-			<top>16</top>
-			<width>650</width>
-			<height>40</height>
-			<texture>dialogheader.png</texture>
-		</control>
-		<control type="label">
-			<description>header label</description>
-			<left>40</left>
-			<top>20</top>
-			<width>650</width>
-			<height>30</height>
-			<font>font13_title</font>
-			<label>$LOCALIZE[19065]</label>
-			<align>center</align>
-			<aligny>center</aligny>
-			<textcolor>selected</textcolor>
-			<shadowcolor>black</shadowcolor>
-		</control>
-		<control type="button">
-			<description>Close Window button</description>
-			<left>640</left>
-			<top>15</top>
-			<width>64</width>
-			<height>32</height>
-			<label>-</label>
-			<font>-</font>
-			<onclick>PreviousMenu</onclick>
-			<texturefocus>DialogCloseButton-focus.png</texturefocus>
-			<texturenofocus>DialogCloseButton.png</texturenofocus>
-			<onleft>10</onleft>
-			<onright>10</onright>
-			<onup>10</onup>
-			<ondown>10</ondown>
-			<visible>system.getbool(input.enablemouse)</visible>
-		</control>
+		<include name="DialogBackgroundCommons">
+			<param name="DialogBackgroundWidth" value="730" />
+			<param name="DialogBackgroundHeight" value="660" />
+			<param name="DialogHeaderWidth" value="650" />
+			<param name="DialogHeaderLabel" value="$LOCALIZE[19065]" />
+			<param name="DialogHeaderId" value="2" />
+			<param name="CloseButtonLeft" value="640" />
+			<param name="CloseButtonNav" value="10" />
+		</include>
 		<control type="grouplist" id="5">
 			<description>control area</description>
 			<left>30</left>

--- a/addons/skin.confluence/720p/DialogPeripheralManager.xml
+++ b/addons/skin.confluence/720p/DialogPeripheralManager.xml
@@ -11,62 +11,15 @@
 		<control type="group">
 			<visible>!Window.IsVisible(PeripheralSettings)</visible>
 			<include>VisibleFadeEffect</include>
-			<control type="image">
-				<description>background image</description>
-				<left>0</left>
-				<top>0</top>
-				<width>610</width>
-				<height>650</height>
-				<texture border="40">DialogBack.png</texture>
-				<visible>![Window.IsVisible(FullscreenVideo) | Window.IsVisible(Visualisation)]</visible>
-			</control>
-			<control type="image">
-				<description>background image</description>
-				<left>0</left>
-				<top>0</top>
-				<width>610</width>
-				<height>650</height>
-				<texture border="40">DialogBack2.png</texture>
-				<visible>Window.IsVisible(FullscreenVideo) | Window.IsVisible(Visualisation)</visible>
-			</control>
-			<control type="image">
-				<description>Dialog Header image</description>
-				<left>40</left>
-				<top>16</top>
-				<width>530</width>
-				<height>40</height>
-				<texture>dialogheader.png</texture>
-			</control>
-			<control type="label" id="1">
-				<description>header label</description>
-				<left>40</left>
-				<top>20</top>
-				<width>530</width>
-				<height>30</height>
-				<font>font13_title</font>
-				<label>$LOCALIZE[35000]</label>
-				<align>center</align>
-				<aligny>center</aligny>
-				<textcolor>selected</textcolor>
-				<shadowcolor>black</shadowcolor>
-			</control>
-			<control type="button">
-				<description>Close Window button</description>
-				<left>520</left>
-				<top>15</top>
-				<width>64</width>
-				<height>32</height>
-				<label>-</label>
-				<font>-</font>
-				<onclick>PreviousMenu</onclick>
-				<texturefocus>DialogCloseButton-focus.png</texturefocus>
-				<texturenofocus>DialogCloseButton.png</texturenofocus>
-				<onleft>10</onleft>
-				<onright>10</onright>
-				<onup>10</onup>
-				<ondown>10</ondown>
-				<visible>system.getbool(input.enablemouse)</visible>
-			</control>
+			<include name="DialogBackgroundCommons">
+				<param name="DialogBackgroundWidth" value="610" />
+				<param name="DialogBackgroundHeight" value="650" />
+				<param name="DialogHeaderWidth" value="530" />
+				<param name="DialogHeaderLabel" value="$LOCALIZE[35000]" />
+				<param name="DialogHeaderId" value="1" />
+				<param name="CloseButtonLeft" value="520" />
+				<param name="CloseButtonNav" value="10" />
+			</include>
 			<control type="list" id="20">
 				<left>20</left>
 				<top>65</top>

--- a/addons/skin.confluence/720p/DialogPeripheralSettings.xml
+++ b/addons/skin.confluence/720p/DialogPeripheralSettings.xml
@@ -8,51 +8,15 @@
 	</coordinates>
 	<include>dialogeffect</include>
 	<controls>
-		<control type="image">
-			<description>background image</description>
-			<left>0</left>
-			<top>0</top>
-			<width>700</width>
-			<height>570</height>
-			<texture border="40">DialogBack.png</texture>
-		</control>
-		<control type="image">
-			<description>Dialog Header image</description>
-			<left>40</left>
-			<top>16</top>
-			<width>620</width>
-			<height>40</height>
-			<texture>dialogheader.png</texture>
-		</control>
-		<control type="label">
-			<description>header label</description>
-			<left>40</left>
-			<top>20</top>
-			<width>620</width>
-			<height>30</height>
-			<font>font13_title</font>
-			<align>center</align>
-			<aligny>center</aligny>
-			<textcolor>selected</textcolor>
-			<shadowcolor>black</shadowcolor>
-		</control>
-		<control type="button">
-			<description>Close Window button</description>
-			<left>610</left>
-			<top>15</top>
-			<width>64</width>
-			<height>32</height>
-			<label>-</label>
-			<font>-</font>
-			<onclick>PreviousMenu</onclick>
-			<texturefocus>DialogCloseButton-focus.png</texturefocus>
-			<texturenofocus>DialogCloseButton.png</texturenofocus>
-			<onleft>5</onleft>
-			<onright>5</onright>
-			<onup>5</onup>
-			<ondown>5</ondown>
-			<visible>system.getbool(input.enablemouse)</visible>
-		</control>
+		<include name="DialogBackgroundCommons">
+			<param name="DialogBackgroundWidth" value="700" />
+			<param name="DialogBackgroundHeight" value="570" />
+			<param name="DialogHeaderWidth" value="620" />
+			<param name="DialogHeaderLabel" value="" />
+			<param name="DialogHeaderId" value="2" />
+			<param name="CloseButtonLeft" value="610" />
+			<param name="CloseButtonNav" value="5" />
+		</include>
 		<control type="grouplist" id="5">
 			<animation effect="slide" start="0,0" end="5,0" time="0" condition="!Control.IsVisible(60)">Conditional</animation>
 			<description>control area</description>

--- a/addons/skin.confluence/720p/DialogProgress.xml
+++ b/addons/skin.confluence/720p/DialogProgress.xml
@@ -8,21 +8,15 @@
 	</coordinates>
 	<include>dialogeffect</include>
 	<controls>
-		<control type="image">
-			<left>0</left>
-			<top>0</top>
-			<width>610</width>
-			<height>240</height>
-			<texture border="40">DialogBack.png</texture>
-		</control>
-		<control type="image">
-			<description>Dialog Header image</description>
-			<left>40</left>
-			<top>16</top>
-			<width>530</width>
-			<height>40</height>
-			<texture>dialogheader.png</texture>
-		</control>
+		<include name="DialogBackgroundCommons">
+			<param name="DialogBackgroundWidth" value="610" />
+			<param name="DialogBackgroundHeight" value="240" />
+			<param name="DialogHeaderWidth" value="530" />
+			<param name="DialogHeaderLabel" value="$INFO[Control.GetLabel(1)] $INFO[System.Progressbar,- ,%]" />
+			<param name="DialogHeaderId" value="0" />
+			<param name="CloseButtonLeft" value="520" />
+			<param name="CloseButtonNav" value="10" />
+		</include>
 		<control type="label" id="1">
 			<description>fake heading label</description>
 			<left>0</left>
@@ -31,36 +25,6 @@
 			<height>0</height>
 			<font>-</font>
 			<visible>false</visible>
-		</control>
-		<control type="label">
-			<description>header label</description>
-			<left>40</left>
-			<top>20</top>
-			<width>530</width>
-			<height>30</height>
-			<font>font13_title</font>
-			<label>$INFO[Control.GetLabel(1)] $INFO[System.Progressbar,- ,%]</label>
-			<align>center</align>
-			<aligny>center</aligny>
-			<textcolor>selected</textcolor>
-			<shadowcolor>black</shadowcolor>
-		</control>
-		<control type="button">
-			<description>Close Window button</description>
-			<left>520</left>
-			<top>15</top>
-			<width>64</width>
-			<height>32</height>
-			<label>-</label>
-			<font>-</font>
-			<onclick>PreviousMenu</onclick>
-			<texturefocus>DialogCloseButton-focus.png</texturefocus>
-			<texturenofocus>DialogCloseButton.png</texturenofocus>
-			<onleft>10</onleft>
-			<onright>10</onright>
-			<onup>10</onup>
-			<ondown>10</ondown>
-			<visible>system.getbool(input.enablemouse)</visible>
 		</control>
 		<control type="textbox" id="9">
 			<description>text</description>

--- a/addons/skin.confluence/720p/DialogSongInfo.xml
+++ b/addons/skin.confluence/720p/DialogSongInfo.xml
@@ -11,52 +11,15 @@
 		<control type="group">
 			<include>VisibleFadeEffect</include>
 			<visible>!Window.IsVisible(MusicInformation)</visible>
-			<control type="image">
-				<description>background image</description>
-				<left>0</left>
-				<top>0</top>
-				<width>910</width>
-				<height>510</height>
-				<texture border="40">DialogBack.png</texture>
-			</control>
-			<control type="image">
-				<description>Dialog Header image</description>
-				<left>40</left>
-				<top>16</top>
-				<width>830</width>
-				<height>40</height>
-				<texture>dialogheader.png</texture>
-			</control>
-			<control type="label">
-				<description>header label</description>
-				<left>40</left>
-				<top>20</top>
-				<width>830</width>
-				<height>30</height>
-				<font>font13_title</font>
-				<label>$LOCALIZE[658]</label>
-				<align>center</align>
-				<aligny>center</aligny>
-				<textcolor>selected</textcolor>
-				<shadowcolor>black</shadowcolor>
-			</control>
-			<control type="button">
-				<description>Close Window button</description>
-				<left>820</left>
-				<top>14</top>
-				<width>64</width>
-				<height>32</height>
-				<label>-</label>
-				<font>-</font>
-				<onclick>PreviousMenu</onclick>
-				<texturefocus>DialogCloseButton-focus.png</texturefocus>
-				<texturenofocus>DialogCloseButton.png</texturenofocus>
-				<onleft>3</onleft>
-				<onright>3</onright>
-				<onup>3</onup>
-				<ondown>3</ondown>
-				<visible>system.getbool(input.enablemouse)</visible>
-			</control>
+			<include name="DialogBackgroundCommons">
+				<param name="DialogBackgroundWidth" value="910" />
+				<param name="DialogBackgroundHeight" value="510" />
+				<param name="DialogHeaderWidth" value="830" />
+				<param name="DialogHeaderLabel" value="$LOCALIZE[658]" />
+				<param name="DialogHeaderId" value="2" />
+				<param name="CloseButtonLeft" value="820" />
+				<param name="CloseButtonNav" value="3" />
+			</include>
 			<control type="label">
 				<description>Song Title value</description>
 				<left>40</left>

--- a/addons/skin.confluence/720p/DialogYesNo.xml
+++ b/addons/skin.confluence/720p/DialogYesNo.xml
@@ -8,51 +8,15 @@
 	</coordinates>
 	<include>dialogeffect</include>
 	<controls>
-		<control type="image">
-			<left>0</left>
-			<top>0</top>
-			<width>610</width>
-			<height>240</height>
-			<texture border="40">DialogBack.png</texture>
-		</control>
-		<control type="image">
-			<description>Dialog Header image</description>
-			<left>40</left>
-			<top>16</top>
-			<width>530</width>
-			<height>40</height>
-			<texture>dialogheader.png</texture>
-		</control>
-		<control type="label" id="1">
-			<description>header label</description>
-			<left>40</left>
-			<top>20</top>
-			<width>530</width>
-			<height>30</height>
-			<font>font13_title</font>
-			<label>$LOCALIZE[13406]</label>
-			<align>center</align>
-			<aligny>center</aligny>
-			<textcolor>selected</textcolor>
-			<shadowcolor>black</shadowcolor>
-		</control>
-		<control type="button">
-			<description>Close Window button</description>
-			<left>520</left>
-			<top>15</top>
-			<width>64</width>
-			<height>32</height>
-			<label>-</label>
-			<font>-</font>
-			<onclick>PreviousMenu</onclick>
-			<texturefocus>DialogCloseButton-focus.png</texturefocus>
-			<texturenofocus>DialogCloseButton.png</texturenofocus>
-			<onleft>10</onleft>
-			<onright>10</onright>
-			<onup>10</onup>
-			<ondown>10</ondown>
-			<visible>system.getbool(input.enablemouse)</visible>
-		</control>
+		<include name="DialogBackgroundCommons">
+			<param name="DialogBackgroundWidth" value="610" />
+			<param name="DialogBackgroundHeight" value="240" />
+			<param name="DialogHeaderWidth" value="530" />
+			<param name="DialogHeaderLabel" value="$LOCALIZE[13406]" />
+			<param name="DialogHeaderId" value="1" />
+			<param name="CloseButtonLeft" value="520" />
+			<param name="CloseButtonNav" value="10" />
+		</include>
 		<control type="textbox" id="9">
 			<description>text</description>
 			<left>30</left>

--- a/addons/skin.confluence/720p/LockSettings.xml
+++ b/addons/skin.confluence/720p/LockSettings.xml
@@ -8,52 +8,15 @@
 	</coordinates>
 	<include>dialogeffect</include>
 	<controls>
-		<control type="image">
-			<description>background image</description>
-			<left>0</left>
-			<top>0</top>
-			<width>700</width>
-			<height>570</height>
-			<texture border="40">DialogBack.png</texture>
-		</control>
-		<control type="image">
-			<description>Dialog Header image</description>
-			<left>40</left>
-			<top>16</top>
-			<width>620</width>
-			<height>40</height>
-			<texture>dialogheader.png</texture>
-		</control>
-		<control type="label" id="2">
-			<description>header label</description>
-			<left>40</left>
-			<top>20</top>
-			<width>620</width>
-			<height>30</height>
-			<font>font13_title</font>
-			<label>$LOCALIZE[20043]</label>
-			<align>center</align>
-			<aligny>center</aligny>
-			<textcolor>selected</textcolor>
-			<shadowcolor>black</shadowcolor>
-		</control>
-		<control type="button">
-			<description>Close Window button</description>
-			<left>610</left>
-			<top>15</top>
-			<width>64</width>
-			<height>32</height>
-			<label>-</label>
-			<font>-</font>
-			<onclick>PreviousMenu</onclick>
-			<texturefocus>DialogCloseButton-focus.png</texturefocus>
-			<texturenofocus>DialogCloseButton.png</texturenofocus>
-			<onleft>5</onleft>
-			<onright>5</onright>
-			<onup>5</onup>
-			<ondown>5</ondown>
-			<visible>system.getbool(input.enablemouse)</visible>
-		</control>
+		<include name="DialogBackgroundCommons">
+			<param name="DialogBackgroundWidth" value="700" />
+			<param name="DialogBackgroundHeight" value="570" />
+			<param name="DialogHeaderWidth" value="620" />
+			<param name="DialogHeaderLabel" value="$LOCALIZE[20043]" />
+			<param name="DialogHeaderId" value="2" />
+			<param name="CloseButtonLeft" value="610" />
+			<param name="CloseButtonNav" value="5" />
+		</include>
 		<control type="grouplist" id="5">
 			<description>control area</description>
 			<left>30</left>

--- a/addons/skin.confluence/720p/ProfileSettings.xml
+++ b/addons/skin.confluence/720p/ProfileSettings.xml
@@ -7,52 +7,15 @@
 	</coordinates>
 	<include>dialogeffect</include>
 	<controls>
-		<control type="image">
-			<description>background image</description>
-			<left>0</left>
-			<top>0</top>
-			<width>700</width>
-			<height>570</height>
-			<texture border="40">DialogBack.png</texture>
-		</control>
-		<control type="image">
-			<description>Dialog Header image</description>
-			<left>40</left>
-			<top>16</top>
-			<width>620</width>
-			<height>40</height>
-			<texture>dialogheader.png</texture>
-		</control>
-		<control type="label" id="2">
-			<description>header label</description>
-			<left>40</left>
-			<top>20</top>
-			<width>620</width>
-			<height>30</height>
-			<font>font13_title</font>
-			<label>-</label>
-			<align>center</align>
-			<aligny>center</aligny>
-			<textcolor>selected</textcolor>
-			<shadowcolor>black</shadowcolor>
-		</control>
-		<control type="button">
-			<description>Close Window button</description>
-			<left>610</left>
-			<top>15</top>
-			<width>64</width>
-			<height>32</height>
-			<label>-</label>
-			<font>-</font>
-			<onclick>PreviousMenu</onclick>
-			<texturefocus>DialogCloseButton-focus.png</texturefocus>
-			<texturenofocus>DialogCloseButton.png</texturenofocus>
-			<onleft>1</onleft>
-			<onright>1</onright>
-			<onup>1</onup>
-			<ondown>1</ondown>
-			<visible>system.getbool(input.enablemouse)</visible>
-		</control>
+		<include name="DialogBackgroundCommons">
+			<param name="DialogBackgroundWidth" value="700" />
+			<param name="DialogBackgroundHeight" value="570" />
+			<param name="DialogHeaderWidth" value="620" />
+			<param name="DialogHeaderLabel" value="-" />
+			<param name="DialogHeaderId" value="2" />
+			<param name="CloseButtonLeft" value="610" />
+			<param name="CloseButtonNav" value="1" />
+		</include>
 		<control type="image" id="101">
 			<description>profile image</description>
 			<left>30</left>

--- a/addons/skin.confluence/720p/SmartPlaylistEditor.xml
+++ b/addons/skin.confluence/720p/SmartPlaylistEditor.xml
@@ -12,51 +12,15 @@
 		<control type="group">
 			<visible>!Window.IsVisible(smartplaylistrule)</visible>
 			<include>VisibleFadeEffect</include>
-			<control type="image">
-				<description>background image</description>
-				<left>0</left>
-				<top>0</top>
-				<width>800</width>
-				<height>675</height>
-				<texture border="40">DialogBack.png</texture>
-			</control>
-			<control type="image">
-				<description>Dialog Header image</description>
-				<left>40</left>
-				<top>16</top>
-				<width>720</width>
-				<height>40</height>
-				<texture>dialogheader.png</texture>
-			</control>
-			<control type="label" id="2">
-				<description>header label</description>
-				<left>40</left>
-				<top>20</top>
-				<width>720</width>
-				<height>30</height>
-				<font>font13_title</font>
-				<align>center</align>
-				<aligny>center</aligny>
-				<textcolor>selected</textcolor>
-				<shadowcolor>black</shadowcolor>
-			</control>
-			<control type="button">
-				<description>Close Window button</description>
-				<left>710</left>
-				<top>9</top>
-				<width>64</width>
-				<height>32</height>
-				<label>-</label>
-				<font>-</font>
-				<onclick>PreviousMenu</onclick>
-				<texturefocus>DialogCloseButton-focus.png</texturefocus>
-				<texturenofocus>DialogCloseButton.png</texturenofocus>
-				<onleft>22</onleft>
-				<onright>22</onright>
-				<onup>22</onup>
-				<ondown>22</ondown>
-				<visible>system.getbool(input.enablemouse)</visible>
-			</control>
+			<include name="DialogBackgroundCommons">
+				<param name="DialogBackgroundWidth" value="800" />
+				<param name="DialogBackgroundHeight" value="675" />
+				<param name="DialogHeaderWidth" value="720" />
+				<param name="DialogHeaderLabel" value="-" />
+				<param name="DialogHeaderId" value="2" />
+				<param name="CloseButtonLeft" value="710" />
+				<param name="CloseButtonNav" value="22" />
+			</include>
 			<control type="spincontrolex" id="22">
 				<description>Set Playlist type</description>
 				<left>30</left>

--- a/addons/skin.confluence/720p/SmartPlaylistRule.xml
+++ b/addons/skin.confluence/720p/SmartPlaylistRule.xml
@@ -9,52 +9,15 @@
 	</coordinates>
 	<include>dialogeffect</include>
 	<controls>
-		<control type="image">
-			<description>background image</description>
-			<left>0</left>
-			<top>0</top>
-			<width>800</width>
-			<height>280</height>
-			<texture border="40">DialogBack.png</texture>
-		</control>
-		<control type="image">
-			<description>Dialog Header image</description>
-			<left>40</left>
-			<top>16</top>
-			<width>720</width>
-			<height>40</height>
-			<texture>dialogheader.png</texture>
-		</control>
-		<control type="label">
-			<description>header label</description>
-			<left>40</left>
-			<top>20</top>
-			<width>720</width>
-			<height>30</height>
-			<font>font13_title</font>
-			<label>$LOCALIZE[21421]</label>
-			<align>center</align>
-			<aligny>center</aligny>
-			<textcolor>selected</textcolor>
-			<shadowcolor>black</shadowcolor>
-		</control>
-		<control type="button">
-			<description>Close Window button</description>
-			<left>710</left>
-			<top>15</top>
-			<width>64</width>
-			<height>32</height>
-			<label>-</label>
-			<font>-</font>
-			<onclick>PreviousMenu</onclick>
-			<texturefocus>DialogCloseButton-focus.png</texturefocus>
-			<texturenofocus>DialogCloseButton.png</texturenofocus>
-			<onleft>9001</onleft>
-			<onright>9001</onright>
-			<onup>9001</onup>
-			<ondown>9001</ondown>
-			<visible>system.getbool(input.enablemouse)</visible>
-		</control>
+		<include name="DialogBackgroundCommons">
+			<param name="DialogBackgroundWidth" value="800" />
+			<param name="DialogBackgroundHeight" value="280" />
+			<param name="DialogHeaderWidth" value="720" />
+			<param name="DialogHeaderLabel" value="$LOCALIZE[21421]" />
+			<param name="DialogHeaderId" value="2" />
+			<param name="CloseButtonLeft" value="710" />
+			<param name="CloseButtonNav" value="9001" />
+		</include>
 		<control type="label">
 			<description>Rule match label</description>
 			<left>40</left>

--- a/addons/skin.confluence/720p/includes.xml
+++ b/addons/skin.confluence/720p/includes.xml
@@ -68,6 +68,58 @@
 		<value condition="Player.Forwarding">$LOCALIZE[31044]</value>
 		<value condition="Player.Rewinding">$LOCALIZE[31045]</value>
 	</variable>
+	<variable name="PVRChannelMgrHeader">
+		<value condition="!IsEmpty(Window.Property(IsRadio))">$LOCALIZE[19199] - $LOCALIZE[19024]</value>
+		<value>$LOCALIZE[19199] - $LOCALIZE[19023]</value>
+	</variable>
+	<include name="DialogBackgroundCommons">			
+		<control type="image">
+			<description>background image</description>
+			<left>0</left>
+			<top>0</top>
+			<width>$PARAM[DialogBackgroundWidth]</width>
+			<height>$PARAM[DialogBackgroundHeight]</height>
+			<texture border="40">$VAR[SelectBack]</texture>
+		</control>
+		<control type="image">
+			<description>Dialog Header image</description>
+			<left>40</left>
+			<top>16</top>
+			<width>$PARAM[DialogHeaderWidth]</width>
+			<height>40</height>
+			<texture>dialogheader.png</texture>
+		</control>
+		<control type="label" id="$PARAM[DialogHeaderId]">
+			<description>header label</description>
+			<left>40</left>
+			<top>20</top>
+			<width>$PARAM[DialogHeaderWidth]</width>
+			<height>30</height>
+			<font>font13_title</font>
+			<label>$PARAM[DialogHeaderLabel]</label>
+			<align>center</align>
+			<aligny>center</aligny>
+			<textcolor>selected</textcolor>
+			<shadowcolor>black</shadowcolor>
+		</control>
+		<control type="button">
+			<description>Close Window button</description>
+			<left>$PARAM[CloseButtonLeft]</left>
+			<top>15</top>
+			<width>64</width>
+			<height>32</height>
+			<label>-</label>
+			<font>-</font>
+			<onclick>PreviousMenu</onclick>
+			<texturefocus>DialogCloseButton-focus.png</texturefocus>
+			<texturenofocus>DialogCloseButton.png</texturenofocus>
+			<onleft>$PARAM[CloseButtonNav]</onleft>
+			<onright>$PARAM[CloseButtonNav]</onright>
+			<onup>$PARAM[CloseButtonNav]</onup>
+			<ondown>$PARAM[CloseButtonNav]</ondown>
+			<visible>system.getbool(input.enablemouse)</visible>
+		</control>
+	</include>
 	<include name="BehindDialogFadeOut">
 		<control type="image">
 			<left>0</left>

--- a/addons/skin.confluence/720p/script-RSS_Editor-rssEditor.xml
+++ b/addons/skin.confluence/720p/script-RSS_Editor-rssEditor.xml
@@ -8,51 +8,15 @@
 	</coordinates>
 	<include>dialogeffect</include>
 	<controls>
-		<control type="image">
-			<description>background image</description>
-			<left>0</left>
-			<top>0</top>
-			<width>800</width>
-			<height>420</height>
-			<texture border="40">DialogBack.png</texture>
-		</control>
-		<control type="image">
-			<description>Dialog Header image</description>
-			<left>40</left>
-			<top>16</top>
-			<width>720</width>
-			<height>40</height>
-			<texture>dialogheader.png</texture>
-		</control>
-		<control type="label" id="2">
-			<description>header label</description>
-			<left>40</left>
-			<top>20</top>
-			<width>720</width>
-			<height>30</height>
-			<font>font13_title</font>
-			<align>center</align>
-			<aligny>center</aligny>
-			<textcolor>selected</textcolor>
-			<shadowcolor>black</shadowcolor>
-		</control>
-		<control type="button">
-			<description>Close Window button</description>
-			<left>710</left>
-			<top>15</top>
-			<width>64</width>
-			<height>32</height>
-			<label>-</label>
-			<font>-</font>
-			<onclick>PreviousMenu</onclick>
-			<texturefocus>DialogCloseButton-focus.png</texturefocus>
-			<texturenofocus>DialogCloseButton.png</texturenofocus>
-			<onleft>10</onleft>
-			<onright>10</onright>
-			<onup>10</onup>
-			<ondown>10</ondown>
-			<visible>system.getbool(input.enablemouse)</visible>
-		</control>
+		<include name="DialogBackgroundCommons">
+			<param name="DialogBackgroundWidth" value="800" />
+			<param name="DialogBackgroundHeight" value="420" />
+			<param name="DialogHeaderWidth" value="720" />
+			<param name="DialogHeaderLabel" value="-" />
+			<param name="DialogHeaderId" value="2" />
+			<param name="CloseButtonLeft" value="710" />
+			<param name="CloseButtonNav" value="10" />
+		</include>
 		<control type="label" id="3">
 			<description>List label</description>
 			<left>20</left>

--- a/addons/skin.confluence/720p/script-RSS_Editor-setEditor.xml
+++ b/addons/skin.confluence/720p/script-RSS_Editor-setEditor.xml
@@ -8,51 +8,15 @@
 	</coordinates>
 	<include>dialogeffect</include>
 	<controls>
-		<control type="image">
-			<description>background image</description>
-			<left>0</left>
-			<top>0</top>
-			<width>800</width>
-			<height>420</height>
-			<texture border="40">DialogBack.png</texture>
-		</control>
-		<control type="image">
-			<description>Dialog Header image</description>
-			<left>40</left>
-			<top>16</top>
-			<width>720</width>
-			<height>40</height>
-			<texture>dialogheader.png</texture>
-		</control>
-		<control type="label" id="2">
-			<description>header label</description>
-			<left>40</left>
-			<top>20</top>
-			<width>720</width>
-			<height>30</height>
-			<font>font13_title</font>
-			<align>center</align>
-			<aligny>center</aligny>
-			<textcolor>selected</textcolor>
-			<shadowcolor>black</shadowcolor>
-		</control>
-		<control type="button">
-			<description>Close Window button</description>
-			<left>710</left>
-			<top>15</top>
-			<width>64</width>
-			<height>32</height>
-			<label>-</label>
-			<font>-</font>
-			<onclick>PreviousMenu</onclick>
-			<texturefocus>DialogCloseButton-focus.png</texturefocus>
-			<texturenofocus>DialogCloseButton.png</texturenofocus>
-			<onleft>10</onleft>
-			<onright>10</onright>
-			<onup>10</onup>
-			<ondown>10</ondown>
-			<visible>system.getbool(input.enablemouse)</visible>
-		</control>
+		<include name="DialogBackgroundCommons">
+			<param name="DialogBackgroundWidth" value="800" />
+			<param name="DialogBackgroundHeight" value="420" />
+			<param name="DialogHeaderWidth" value="720" />
+			<param name="DialogHeaderLabel" value="-" />
+			<param name="DialogHeaderId" value="2" />
+			<param name="CloseButtonLeft" value="710" />
+			<param name="CloseButtonNav" value="10" />
+		</include>
 		<control type="label" id="3">
 			<description>List label</description>
 			<left>20</left>


### PR DESCRIPTION
Each dialog, except for DialogNumeric, now uses an include with parameters for the background image, header image, header label and mouse button. Header labels that didn't have an id, have `<param name="id_label" value="2" />` as thats the default id number afaik.
Nothing should have changed visually, but since its the default skin, we should include some of the new code possibilities as example imo.

@ronie @phil65
