### PR TITLE
[tests] - fix segfaults

### DIFF
--- a/xbmc/utils/test/TestCharsetConverter.cpp
+++ b/xbmc/utils/test/TestCharsetConverter.cpp
@@ -104,7 +104,7 @@ protected:
     CSettings::Get().AddString(sub, "subtitles.charset", 735, "DEFAULT",
                             SPIN_CONTROL_TEXT);
     */
-
+    CSettings::Get().Initialize();
     g_charsetConverter.reset();
     g_charsetConverter.clear();
   }


### PR DESCRIPTION
Initialize CSettings singleton in CharsetConverter test (else g_charsetConvert will access NULL-Ptr settings) 

@Montellese i confirm that this fixes the unit tests (which segfaulted since some days on jenkins). Not sure if this is the right thing to do - can you confirm?
