### PR TITLE
fix htmltow test case

### DIFF
--- a/xbmc/filesystem/test/TestFile.cpp
+++ b/xbmc/filesystem/test/TestFile.cpp
@@ -21,6 +21,7 @@
 #include "filesystem/File.h"
 #include "test/TestUtils.h"
 
+#include <string>
 #include <errno.h>
 
 #include "gtest/gtest.h"
@@ -52,11 +53,11 @@ TEST(TestFile, Read)
   file.Flush();
   currentPos = firstBuf.length();
   EXPECT_EQ(currentPos, file.GetPosition());
-  EXPECT_TRUE(memcmp(firstBuf.c_str(), buf, firstBuf.length()) == 0);
-  EXPECT_TRUE(file.Read(buf, secondBuf.length()));
+  EXPECT_EQ(0, memcmp(firstBuf.c_str(), buf, firstBuf.length()));
+  EXPECT_EQ(secondBuf.length(), file.Read(buf, secondBuf.length()));
   currentPos += secondBuf.length();
   EXPECT_EQ(currentPos, file.GetPosition());
-  EXPECT_TRUE(memcmp(secondBuf.c_str(), buf, secondBuf.length()) == 0);
+  EXPECT_EQ(0, memcmp(secondBuf.c_str(), buf, secondBuf.length()));
   currentPos = 100 + addPerLine * 3;
   EXPECT_EQ(currentPos, file.Seek(currentPos));
   EXPECT_EQ(currentPos, file.GetPosition());
@@ -64,7 +65,7 @@ TEST(TestFile, Read)
   file.Flush();
   currentPos += thirdBuf.length();
   EXPECT_EQ(currentPos, file.GetPosition());
-  EXPECT_TRUE(memcmp(thirdBuf.c_str(), buf, thirdBuf.length()) == 0);
+  EXPECT_EQ(0, memcmp(thirdBuf.c_str(), buf, thirdBuf.length()));
   currentPos += 100 + addPerLine * 1;
   EXPECT_EQ(currentPos, file.Seek(100 + addPerLine * 1, SEEK_CUR));
   EXPECT_EQ(currentPos, file.GetPosition());
@@ -72,7 +73,7 @@ TEST(TestFile, Read)
   file.Flush();
   currentPos += fourthBuf.length();
   EXPECT_EQ(currentPos, file.GetPosition());
-  EXPECT_TRUE(memcmp(fourthBuf.c_str(), buf, fourthBuf.length()) == 0);
+  EXPECT_EQ(0, memcmp(fourthBuf.c_str(), buf, fourthBuf.length()));
   currentPos = realSize - fifthBuf.length();
   EXPECT_EQ(currentPos, file.Seek(-(int64_t)fifthBuf.length(), SEEK_END));
   EXPECT_EQ(currentPos, file.GetPosition());
@@ -80,7 +81,7 @@ TEST(TestFile, Read)
   file.Flush();
   currentPos += fifthBuf.length();
   EXPECT_EQ(currentPos, file.GetPosition());
-  EXPECT_TRUE(memcmp(fifthBuf.c_str(), buf, fifthBuf.length()) == 0);
+  EXPECT_EQ(0, memcmp(fifthBuf.c_str(), buf, fifthBuf.length()));
   currentPos += 100;
   EXPECT_EQ(currentPos, file.Seek(100, SEEK_CUR));
   EXPECT_EQ(currentPos, file.GetPosition());
@@ -90,7 +91,7 @@ TEST(TestFile, Read)
   file.Flush();
   currentPos += firstBuf.length();
   EXPECT_EQ(currentPos, file.GetPosition());
-  EXPECT_TRUE(memcmp(firstBuf.c_str(), buf, firstBuf.length()) == 0);
+  EXPECT_EQ(0, memcmp(firstBuf.c_str(), buf, firstBuf.length()));
   EXPECT_EQ(0, file.Seek(0, SEEK_SET));
   EXPECT_EQ(-1, file.Seek(-100, SEEK_SET));
   file.Close();
@@ -103,7 +104,7 @@ TEST(TestFile, Write)
   char buf[30];
   memset(&buf, 0, sizeof(buf));
 
-  ASSERT_TRUE((file = XBMC_CREATETEMPFILE("")) != NULL);
+  ASSERT_NE(nullptr, file = XBMC_CREATETEMPFILE(""));
   file->Close();
   ASSERT_TRUE(file->OpenForWrite(XBMC_TEMPFILEPATH(file), true));
   EXPECT_EQ((int)sizeof(str), file->Write(str, sizeof(str)));
@@ -118,7 +119,7 @@ TEST(TestFile, Write)
   EXPECT_EQ(sizeof(str), file->Read(buf, sizeof(buf)));
   file->Flush();
   EXPECT_EQ((int64_t)sizeof(str), file->GetPosition());
-  EXPECT_TRUE(!memcmp(str, buf, sizeof(str)));
+  EXPECT_EQ(0, memcmp(str, buf, sizeof(str)));
   file->Close();
   EXPECT_TRUE(XBMC_DELETETEMPFILE(file));
 }
@@ -127,7 +128,7 @@ TEST(TestFile, Exists)
 {
   XFILE::CFile *file;
 
-  ASSERT_TRUE((file = XBMC_CREATETEMPFILE("")) != NULL);
+  ASSERT_NE(nullptr, file = XBMC_CREATETEMPFILE(""));
   file->Close();
   EXPECT_TRUE(XFILE::CFile::Exists(XBMC_TEMPFILEPATH(file)));
   EXPECT_FALSE(XFILE::CFile::Exists(""));
@@ -139,10 +140,10 @@ TEST(TestFile, Stat)
   XFILE::CFile *file;
   struct __stat64 buffer;
 
-  ASSERT_TRUE((file = XBMC_CREATETEMPFILE("")) != NULL);
+  ASSERT_NE(nullptr, file = XBMC_CREATETEMPFILE(""));
   EXPECT_EQ(0, file->Stat(&buffer));
   file->Close();
-  EXPECT_TRUE(buffer.st_mode | _S_IFREG);
+  EXPECT_NE(0, buffer.st_mode | _S_IFREG);
   EXPECT_EQ(-1, XFILE::CFile::Stat("", &buffer));
   EXPECT_EQ(ENOENT, errno);
   EXPECT_TRUE(XBMC_DELETETEMPFILE(file));
@@ -153,7 +154,7 @@ TEST(TestFile, Delete)
   XFILE::CFile *file;
   std::string path;
 
-  ASSERT_TRUE((file = XBMC_CREATETEMPFILE("")) != NULL);
+  ASSERT_NE(nullptr, file = XBMC_CREATETEMPFILE(""));
   file->Close();
   path = XBMC_TEMPFILEPATH(file);
   EXPECT_TRUE(XFILE::CFile::Exists(path));
@@ -166,10 +167,10 @@ TEST(TestFile, Rename)
   XFILE::CFile *file;
   std::string path1, path2;
 
-  ASSERT_TRUE((file = XBMC_CREATETEMPFILE("")) != NULL);
+  ASSERT_NE(nullptr, file = XBMC_CREATETEMPFILE(""));
   file->Close();
   path1 = XBMC_TEMPFILEPATH(file);
-  ASSERT_TRUE((file = XBMC_CREATETEMPFILE("")) != NULL);
+  ASSERT_NE(nullptr, file = XBMC_CREATETEMPFILE(""));
   file->Close();
   path2 = XBMC_TEMPFILEPATH(file);
   EXPECT_TRUE(XFILE::CFile::Delete(path1));
@@ -186,10 +187,10 @@ TEST(TestFile, Copy)
   XFILE::CFile *file;
   std::string path1, path2;
 
-  ASSERT_TRUE((file = XBMC_CREATETEMPFILE("")) != NULL);
+  ASSERT_NE(nullptr, file = XBMC_CREATETEMPFILE(""));
   file->Close();
   path1 = XBMC_TEMPFILEPATH(file);
-  ASSERT_TRUE((file = XBMC_CREATETEMPFILE("")) != NULL);
+  ASSERT_NE(nullptr, file = XBMC_CREATETEMPFILE(""));
   file->Close();
   path2 = XBMC_TEMPFILEPATH(file);
   EXPECT_TRUE(XFILE::CFile::Delete(path1));
@@ -206,7 +207,7 @@ TEST(TestFile, SetHidden)
 {
   XFILE::CFile *file;
 
-  ASSERT_TRUE((file = XBMC_CREATETEMPFILE("")) != NULL);
+  ASSERT_NE(nullptr, file = XBMC_CREATETEMPFILE(""));
   file->Close();
   EXPECT_TRUE(XFILE::CFile::Exists(XBMC_TEMPFILEPATH(file)));
   bool result = XFILE::CFile::SetHidden(XBMC_TEMPFILEPATH(file), true);

--- a/xbmc/test/TestBasicEnvironment.cpp
+++ b/xbmc/test/TestBasicEnvironment.cpp
@@ -35,8 +35,6 @@
 
 void TestBasicEnvironment::SetUp()
 {
-  char *tmp;
-  std::string xbmcTempPath;
   XFILE::CFile *f;
 
   /* NOTE: The below is done to fix memleak warning about unitialized variable
@@ -69,6 +67,7 @@ void TestBasicEnvironment::SetUp()
    * test suite run.
    */
 #ifdef TARGET_WINDOWS
+  std::string xbmcTempPath;
   TCHAR lpTempPathBuffer[MAX_PATH];
   if (!GetTempPath(MAX_PATH, lpTempPathBuffer))
     SetUpError();
@@ -81,7 +80,7 @@ void TestBasicEnvironment::SetUp()
   CSpecialProtocol::SetTempPath(lpTempPathBuffer);
 #else
   char buf[MAX_PATH];
-  (void)xbmcTempPath;
+  char *tmp;
   strcpy(buf, "/tmp/xbmctempdirXXXXXX");
   if ((tmp = mkdtemp(buf)) == NULL)
     SetUpError();

--- a/xbmc/utils/test/TestArchive.cpp
+++ b/xbmc/utils/test/TestArchive.cpp
@@ -42,7 +42,7 @@ protected:
 
 TEST_F(TestArchive, IsStoring)
 {
-  ASSERT_TRUE(file);
+  ASSERT_NE(nullptr, file);
   CArchive arstore(file, CArchive::store);
   EXPECT_TRUE(arstore.IsStoring());
   EXPECT_FALSE(arstore.IsLoading());
@@ -51,7 +51,7 @@ TEST_F(TestArchive, IsStoring)
 
 TEST_F(TestArchive, IsLoading)
 {
-  ASSERT_TRUE(file);
+  ASSERT_NE(nullptr, file);
   CArchive arload(file, CArchive::load);
   EXPECT_TRUE(arload.IsLoading());
   EXPECT_FALSE(arload.IsStoring());
@@ -60,14 +60,14 @@ TEST_F(TestArchive, IsLoading)
 
 TEST_F(TestArchive, FloatArchive)
 {
-  ASSERT_TRUE(file);
+  ASSERT_NE(nullptr, file);
   float float_ref = 1, float_var = 0;
 
   CArchive arstore(file, CArchive::store);
   arstore << float_ref;
   arstore.Close();
 
-  ASSERT_TRUE((file->Seek(0, SEEK_SET) == 0));
+  ASSERT_EQ(0, file->Seek(0, SEEK_SET));
   CArchive arload(file, CArchive::load);
   arload >> float_var;
   arload.Close();
@@ -77,14 +77,14 @@ TEST_F(TestArchive, FloatArchive)
 
 TEST_F(TestArchive, DoubleArchive)
 {
-  ASSERT_TRUE(file);
+  ASSERT_NE(nullptr, file);
   double double_ref = 2, double_var = 0;
 
   CArchive arstore(file, CArchive::store);
   arstore << double_ref;
   arstore.Close();
 
-  ASSERT_TRUE((file->Seek(0, SEEK_SET) == 0));
+  ASSERT_EQ(0, file->Seek(0, SEEK_SET));
   CArchive arload(file, CArchive::load);
   arload >> double_var;
   arload.Close();
@@ -94,14 +94,14 @@ TEST_F(TestArchive, DoubleArchive)
 
 TEST_F(TestArchive, IntegerArchive)
 {
-  ASSERT_TRUE(file);
+  ASSERT_NE(nullptr, file);
   int int_ref = 3, int_var = 0;
 
   CArchive arstore(file, CArchive::store);
   arstore << int_ref;
   arstore.Close();
 
-  ASSERT_TRUE((file->Seek(0, SEEK_SET) == 0));
+  ASSERT_EQ(0, file->Seek(0, SEEK_SET));
   CArchive arload(file, CArchive::load);
   arload >> int_var;
   arload.Close();
@@ -111,14 +111,14 @@ TEST_F(TestArchive, IntegerArchive)
 
 TEST_F(TestArchive, UnsignedIntegerArchive)
 {
-  ASSERT_TRUE(file);
+  ASSERT_NE(nullptr, file);
   unsigned int unsigned_int_ref = 4, unsigned_int_var = 0;
 
   CArchive arstore(file, CArchive::store);
   arstore << unsigned_int_ref;
   arstore.Close();
 
-  ASSERT_TRUE((file->Seek(0, SEEK_SET) == 0));
+  ASSERT_EQ(0, file->Seek(0, SEEK_SET));
   CArchive arload(file, CArchive::load);
   arload >> unsigned_int_var;
   arload.Close();
@@ -128,14 +128,14 @@ TEST_F(TestArchive, UnsignedIntegerArchive)
 
 TEST_F(TestArchive, Int64tArchive)
 {
-  ASSERT_TRUE(file);
+  ASSERT_NE(nullptr, file);
   int64_t int64_t_ref = 5, int64_t_var = 0;
 
   CArchive arstore(file, CArchive::store);
   arstore << int64_t_ref;
   arstore.Close();
 
-  ASSERT_TRUE((file->Seek(0, SEEK_SET) == 0));
+  ASSERT_EQ(0, file->Seek(0, SEEK_SET));
   CArchive arload(file, CArchive::load);
   arload >> int64_t_var;
   arload.Close();
@@ -145,14 +145,14 @@ TEST_F(TestArchive, Int64tArchive)
 
 TEST_F(TestArchive, UInt64tArchive)
 {
-  ASSERT_TRUE(file);
+  ASSERT_NE(nullptr, file);
   uint64_t uint64_t_ref = 6, uint64_t_var = 0;
 
   CArchive arstore(file, CArchive::store);
   arstore << uint64_t_ref;
   arstore.Close();
 
-  ASSERT_TRUE((file->Seek(0, SEEK_SET) == 0));
+  ASSERT_EQ(0, file->Seek(0, SEEK_SET));
   CArchive arload(file, CArchive::load);
   arload >> uint64_t_var;
   arload.Close();
@@ -162,14 +162,14 @@ TEST_F(TestArchive, UInt64tArchive)
 
 TEST_F(TestArchive, BoolArchive)
 {
-  ASSERT_TRUE(file);
+  ASSERT_NE(nullptr, file);
   bool bool_ref = true, bool_var = false;
 
   CArchive arstore(file, CArchive::store);
   arstore << bool_ref;
   arstore.Close();
 
-  ASSERT_TRUE((file->Seek(0, SEEK_SET) == 0));
+  ASSERT_EQ(0, file->Seek(0, SEEK_SET));
   CArchive arload(file, CArchive::load);
   arload >> bool_var;
   arload.Close();
@@ -179,14 +179,14 @@ TEST_F(TestArchive, BoolArchive)
 
 TEST_F(TestArchive, CharArchive)
 {
-  ASSERT_TRUE(file);
+  ASSERT_NE(nullptr, file);
   char char_ref = 'A', char_var = '\0';
 
   CArchive arstore(file, CArchive::store);
   arstore << char_ref;
   arstore.Close();
 
-  ASSERT_TRUE((file->Seek(0, SEEK_SET) == 0));
+  ASSERT_EQ(0, file->Seek(0, SEEK_SET));
   CArchive arload(file, CArchive::load);
   arload >> char_var;
   arload.Close();
@@ -196,14 +196,14 @@ TEST_F(TestArchive, CharArchive)
 
 TEST_F(TestArchive, WStringArchive)
 {
-  ASSERT_TRUE(file);
+  ASSERT_NE(nullptr, file);
   std::wstring wstring_ref = L"test wstring", wstring_var;
 
   CArchive arstore(file, CArchive::store);
   arstore << wstring_ref;
   arstore.Close();
 
-  ASSERT_TRUE((file->Seek(0, SEEK_SET) == 0));
+  ASSERT_EQ(0, file->Seek(0, SEEK_SET));
   CArchive arload(file, CArchive::load);
   arload >> wstring_var;
   arload.Close();
@@ -213,14 +213,14 @@ TEST_F(TestArchive, WStringArchive)
 
 TEST_F(TestArchive, StringArchive)
 {
-  ASSERT_TRUE(file);
+  ASSERT_NE(nullptr, file);
   std::string string_ref = "test string", string_var;
 
   CArchive arstore(file, CArchive::store);
   arstore << string_ref;
   arstore.Close();
 
-  ASSERT_TRUE((file->Seek(0, SEEK_SET) == 0));
+  ASSERT_EQ(0, file->Seek(0, SEEK_SET));
   CArchive arload(file, CArchive::load);
   arload >> string_var;
   arload.Close();
@@ -230,7 +230,7 @@ TEST_F(TestArchive, StringArchive)
 
 TEST_F(TestArchive, SYSTEMTIMEArchive)
 {
-  ASSERT_TRUE(file);
+  ASSERT_NE(nullptr, file);
   SYSTEMTIME SYSTEMTIME_ref = { 1, 2, 3, 4, 5, 6, 7, 8 };
   SYSTEMTIME SYSTEMTIME_var = { 0, 0, 0, 0, 0, 0, 0, 0 };
 
@@ -238,7 +238,7 @@ TEST_F(TestArchive, SYSTEMTIMEArchive)
   arstore << SYSTEMTIME_ref;
   arstore.Close();
 
-  ASSERT_TRUE((file->Seek(0, SEEK_SET) == 0));
+  ASSERT_EQ(0, file->Seek(0, SEEK_SET));
   CArchive arload(file, CArchive::load);
   arload >> SYSTEMTIME_var;
   arload.Close();
@@ -248,14 +248,14 @@ TEST_F(TestArchive, SYSTEMTIMEArchive)
 
 TEST_F(TestArchive, CVariantArchive)
 {
-  ASSERT_TRUE(file);
+  ASSERT_NE(nullptr, file);
   CVariant CVariant_ref((int)1), CVariant_var;
 
   CArchive arstore(file, CArchive::store);
   arstore << CVariant_ref;
   arstore.Close();
 
-  ASSERT_TRUE((file->Seek(0, SEEK_SET) == 0));
+  ASSERT_EQ(0, file->Seek(0, SEEK_SET));
   CArchive arload(file, CArchive::load);
   arload >> CVariant_var;
   arload.Close();
@@ -266,14 +266,14 @@ TEST_F(TestArchive, CVariantArchive)
 
 TEST_F(TestArchive, CVariantArchiveString)
 {
-  ASSERT_TRUE(file);
+  ASSERT_NE(nullptr, file);
   CVariant CVariant_ref("teststring"), CVariant_var;
 
   CArchive arstore(file, CArchive::store);
   arstore << CVariant_ref;
   arstore.Close();
 
-  ASSERT_TRUE((file->Seek(0, SEEK_SET) == 0));
+  ASSERT_EQ(0, file->Seek(0, SEEK_SET));
   CArchive arload(file, CArchive::load);
   arload >> CVariant_var;
   arload.Close();
@@ -284,7 +284,7 @@ TEST_F(TestArchive, CVariantArchiveString)
 
 TEST_F(TestArchive, StringVectorArchive)
 {
-  ASSERT_TRUE(file);
+  ASSERT_NE(nullptr, file);
   std::vector<std::string> strArray_ref, strArray_var;
   strArray_ref.push_back("test strArray_ref 0");
   strArray_ref.push_back("test strArray_ref 1");
@@ -295,7 +295,7 @@ TEST_F(TestArchive, StringVectorArchive)
   arstore << strArray_ref;
   arstore.Close();
 
-  ASSERT_TRUE((file->Seek(0, SEEK_SET) == 0));
+  ASSERT_EQ(0, file->Seek(0, SEEK_SET));
   CArchive arload(file, CArchive::load);
   arload >> strArray_var;
   arload.Close();
@@ -308,7 +308,7 @@ TEST_F(TestArchive, StringVectorArchive)
 
 TEST_F(TestArchive, IntegerVectorArchive)
 {
-  ASSERT_TRUE(file);
+  ASSERT_NE(nullptr, file);
   std::vector<int> iArray_ref, iArray_var;
   iArray_ref.push_back(0);
   iArray_ref.push_back(1);
@@ -319,7 +319,7 @@ TEST_F(TestArchive, IntegerVectorArchive)
   arstore << iArray_ref;
   arstore.Close();
 
-  ASSERT_TRUE((file->Seek(0, SEEK_SET) == 0));
+  ASSERT_EQ(0, file->Seek(0, SEEK_SET));
   CArchive arload(file, CArchive::load);
   arload >> iArray_var;
   arload.Close();
@@ -332,7 +332,7 @@ TEST_F(TestArchive, IntegerVectorArchive)
 
 TEST_F(TestArchive, MultiTypeArchive)
 {
-  ASSERT_TRUE(file);
+  ASSERT_NE(nullptr, file);
   float float_ref = 1, float_var = 0;
   double double_ref = 2, double_var = 0;
   int int_ref = 3, int_var = 0;
@@ -376,7 +376,7 @@ TEST_F(TestArchive, MultiTypeArchive)
   arstore << iArray_ref;
   arstore.Close();
 
-  ASSERT_TRUE((file->Seek(0, SEEK_SET) == 0));
+  ASSERT_EQ(0, file->Seek(0, SEEK_SET));
   CArchive arload(file, CArchive::load);
   EXPECT_TRUE(arload.IsLoading());
   EXPECT_FALSE(arload.IsStoring());

--- a/xbmc/utils/test/TestAsyncFileCopy.cpp
+++ b/xbmc/utils/test/TestAsyncFileCopy.cpp
@@ -38,8 +38,8 @@ TEST(TestAsyncFileCopy, General)
   XFILE::CFile *f1, *f2;
   char vardata[sizeof(refdata)];
 
-  ASSERT_TRUE((f1 = XBMC_CREATETEMPFILE("")));
-  ASSERT_TRUE((f2 = XBMC_CREATETEMPFILE(".copy")));
+  ASSERT_NE(nullptr, (f1 = XBMC_CREATETEMPFILE("")));
+  ASSERT_NE(nullptr, (f2 = XBMC_CREATETEMPFILE(".copy")));
 
   EXPECT_EQ((int)sizeof(refdata), f1->Write(refdata, sizeof(refdata)));
   f1->Close();

--- a/xbmc/utils/test/TestFileOperationJob.cpp
+++ b/xbmc/utils/test/TestFileOperationJob.cpp
@@ -34,7 +34,7 @@ TEST(TestFileOperationJob, ActionCopy)
   CFileItemList items;
   CFileOperationJob job;
 
-  ASSERT_TRUE((tmpfile = XBMC_CREATETEMPFILE("")));
+  ASSERT_NE(nullptr, (tmpfile = XBMC_CREATETEMPFILE("")));
   tmpfilepath = XBMC_TEMPFILEPATH(tmpfile);
   tmpfile->Close();
 
@@ -68,7 +68,7 @@ TEST(TestFileOperationJob, ActionMove)
   CFileItemList items;
   CFileOperationJob job;
 
-  ASSERT_TRUE((tmpfile = XBMC_CREATETEMPFILE("")));
+  ASSERT_NE(nullptr, (tmpfile = XBMC_CREATETEMPFILE("")));
   tmpfilepath = XBMC_TEMPFILEPATH(tmpfile);
   tmpfile->Close();
 
@@ -102,7 +102,7 @@ TEST(TestFileOperationJob, ActionDelete)
   CFileItemList items;
   CFileOperationJob job;
 
-  ASSERT_TRUE((tmpfile = XBMC_CREATETEMPFILE("")));
+  ASSERT_NE(nullptr, (tmpfile = XBMC_CREATETEMPFILE("")));
   tmpfilepath = XBMC_TEMPFILEPATH(tmpfile);
   tmpfile->Close();
 
@@ -152,7 +152,7 @@ TEST(TestFileOperationJob, ActionReplace)
   CFileItemList items;
   CFileOperationJob job;
 
-  ASSERT_TRUE((tmpfile = XBMC_CREATETEMPFILE("")));
+  ASSERT_NE(nullptr, (tmpfile = XBMC_CREATETEMPFILE("")));
   tmpfilepath = XBMC_TEMPFILEPATH(tmpfile);
   tmpfile->Close();
 
@@ -192,7 +192,7 @@ TEST(TestFileOperationJob, ActionCreateFolder)
   CFileItemList items;
   CFileOperationJob job;
 
-  ASSERT_TRUE((tmpfile = XBMC_CREATETEMPFILE("")));
+  ASSERT_NE(nullptr, (tmpfile = XBMC_CREATETEMPFILE("")));
   tmpfilepath = XBMC_TEMPFILEPATH(tmpfile);
 
   std::string tmpfiledirectory =
@@ -228,7 +228,7 @@ TEST(TestFileOperationJob, ActionDeleteFolder)
   CFileItemList items;
   CFileOperationJob job;
 
-  ASSERT_TRUE((tmpfile = XBMC_CREATETEMPFILE("")));
+  ASSERT_NE(nullptr, (tmpfile = XBMC_CREATETEMPFILE("")));
   tmpfilepath = XBMC_TEMPFILEPATH(tmpfile);
 
   std::string tmpfiledirectory =
@@ -268,7 +268,7 @@ TEST(TestFileOperationJob, GetFunctions)
   CFileItemList items;
   CFileOperationJob job;
 
-  ASSERT_TRUE((tmpfile = XBMC_CREATETEMPFILE("")));
+  ASSERT_NE(nullptr, (tmpfile = XBMC_CREATETEMPFILE("")));
   tmpfilepath = XBMC_TEMPFILEPATH(tmpfile);
   tmpfile->Close();
 

--- a/xbmc/utils/test/TestFileUtils.cpp
+++ b/xbmc/utils/test/TestFileUtils.cpp
@@ -30,7 +30,7 @@ TEST(TestFileUtils, DeleteItem_CFileItemPtr)
   XFILE::CFile *tmpfile;
   std::string tmpfilepath;
 
-  ASSERT_TRUE((tmpfile = XBMC_CREATETEMPFILE("")));
+  ASSERT_NE(nullptr, (tmpfile = XBMC_CREATETEMPFILE("")));
   tmpfilepath = XBMC_TEMPFILEPATH(tmpfile);
 
   CFileItemPtr item(new CFileItem(tmpfilepath));
@@ -45,7 +45,7 @@ TEST(TestFileUtils, DeleteItemString)
 {
   XFILE::CFile *tmpfile;
 
-  ASSERT_TRUE((tmpfile = XBMC_CREATETEMPFILE("")));
+  ASSERT_NE(nullptr, (tmpfile = XBMC_CREATETEMPFILE("")));
   EXPECT_TRUE(CFileUtils::DeleteItem(XBMC_TEMPFILEPATH(tmpfile)));
 }
 

--- a/xbmc/utils/test/TestHTMLUtil.cpp
+++ b/xbmc/utils/test/TestHTMLUtil.cpp
@@ -42,7 +42,7 @@ TEST(TestHTMLUtil, ConvertHTMLToW)
 {
   std::wstring inw, refstrw, varstrw;
   inw =     L"&aring;&amp;&euro;";
-  refstrw = L"å&€";
+  refstrw = L"\u00e5&\u20ac";
   HTML::CHTMLUtil::ConvertHTMLToW(inw, varstrw);
   EXPECT_STREQ(refstrw.c_str(), varstrw.c_str());
 }

--- a/xbmc/utils/test/TestLabelFormatter.cpp
+++ b/xbmc/utils/test/TestLabelFormatter.cpp
@@ -57,7 +57,7 @@ TEST_F(TestLabelFormatter, FormatLabel)
   LABEL_MASKS labelMasks;
   CLabelFormatter formatter("", labelMasks.m_strLabel2File);
 
-  ASSERT_TRUE((tmpfile = XBMC_CREATETEMPFILE("")));
+  ASSERT_NE(nullptr, (tmpfile = XBMC_CREATETEMPFILE("")));
   tmpfilepath = XBMC_TEMPFILEPATH(tmpfile);
 
   CFileItemPtr item(new CFileItem(tmpfilepath));
@@ -77,7 +77,7 @@ TEST_F(TestLabelFormatter, FormatLabel2)
   LABEL_MASKS labelMasks;
   CLabelFormatter formatter("", labelMasks.m_strLabel2File);
 
-  ASSERT_TRUE((tmpfile = XBMC_CREATETEMPFILE("")));
+  ASSERT_NE(nullptr, (tmpfile = XBMC_CREATETEMPFILE("")));
   tmpfilepath = XBMC_TEMPFILEPATH(tmpfile);
 
   CFileItemPtr item(new CFileItem(tmpfilepath));

--- a/xbmc/utils/test/TestXBMCTinyXML.cpp
+++ b/xbmc/utils/test/TestXBMCTinyXML.cpp
@@ -53,7 +53,7 @@ TEST(TestXBMCTinyXML, ParseFromFileHandle)
   // scraper results with unescaped &
   CXBMCTinyXML doc;
   FILE *f = fopen(XBMC_REF_FILE_PATH("/xbmc/utils/test/CXBMCTinyXML-test.xml").c_str(), "r");
-  ASSERT_TRUE(f);
+  ASSERT_NE(nullptr, f);
   doc.LoadFile(f);
   fclose(f);
   TiXmlNode *root = doc.RootElement();

--- a/xbmc/utils/test/Testfastmemcpy.cpp
+++ b/xbmc/utils/test/Testfastmemcpy.cpp
@@ -34,6 +34,6 @@ TEST(Testfastmemcpy, General)
 {
   char vardata[sizeof(refdata)];
   memset(vardata, 0, sizeof(vardata));
-  EXPECT_TRUE(fast_memcpy(vardata, refdata, sizeof(refdata)));
-  EXPECT_TRUE(!memcmp(refdata, vardata, sizeof(refdata)));
+  EXPECT_NE(nullptr, fast_memcpy(vardata, refdata, sizeof(refdata)));
+  EXPECT_EQ(0, memcmp(refdata, vardata, sizeof(refdata)));
 }


### PR DESCRIPTION
this silences a bunch of forced conversion to bool performance warnings in VS and also fixes the htmltow test case that failed because of source file encoding issues.
@Memphiz what do you think?
