### PR TITLE
[gui] Extend settings dialog functions to show seperator with group name (small version)

### DIFF
--- a/addons/skin.confluence/720p/DialogPVRTimerSettings.xml
+++ b/addons/skin.confluence/720p/DialogPVRTimerSettings.xml
@@ -115,5 +115,17 @@
 			<texturefocus border="5">button-focus2.png</texturefocus>
 			<texturenofocus border="5">button-nofocus.png</texturenofocus>
 		</control>
+		<control type="label" id="14">
+			<description>Default Label</description>
+			<left>0</left>
+			<top>0</top>
+			<height>30</height>
+			<label>-</label>
+			<align>center</align>
+			<aligny>bottom</aligny>
+			<font>font13_title</font>
+			<textcolor>grey</textcolor>
+			<shadowcolor>black</shadowcolor>
+		</control>
 	</controls>
 </window>

--- a/addons/skin.confluence/720p/DialogPeripheralSettings.xml
+++ b/addons/skin.confluence/720p/DialogPeripheralSettings.xml
@@ -95,6 +95,18 @@
 			<height>2</height>
 			<texture>separator2.png</texture>
 		</control>
+		<control type="label" id="14">
+			<description>Default Label</description>
+			<left>0</left>
+			<top>0</top>
+			<height>30</height>
+			<label>-</label>
+			<align>center</align>
+			<aligny>bottom</aligny>
+			<font>font13_title</font>
+			<textcolor>grey</textcolor>
+			<shadowcolor>black</shadowcolor>
+		</control>
 		<control type="group" id="9000">
 			<left>40</left>
 			<top>505</top>

--- a/addons/skin.confluence/720p/LockSettings.xml
+++ b/addons/skin.confluence/720p/LockSettings.xml
@@ -67,6 +67,18 @@
 			<height>2</height>
 			<texture>separator2.png</texture>
 		</control>
+		<control type="label" id="14">
+			<description>Default Label</description>
+			<left>0</left>
+			<top>0</top>
+			<height>30</height>
+			<label>-</label>
+			<align>center</align>
+			<aligny>bottom</aligny>
+			<font>font13_title</font>
+			<textcolor>grey</textcolor>
+			<shadowcolor>black</shadowcolor>
+		</control>
 		<control type="button" id="28">
 			<description>Ok Button</description>
 			<left>145</left>

--- a/addons/skin.confluence/720p/ProfileSettings.xml
+++ b/addons/skin.confluence/720p/ProfileSettings.xml
@@ -117,6 +117,18 @@
 			<height>2</height>
 			<texture>separator2.png</texture>
 		</control>
+		<control type="label" id="14">
+			<description>Default Label</description>
+			<left>0</left>
+			<top>0</top>
+			<height>30</height>
+			<label>-</label>
+			<align>center</align>
+			<aligny>bottom</aligny>
+			<font>font13_title</font>
+			<textcolor>grey</textcolor>
+			<shadowcolor>black</shadowcolor>
+		</control>
 		<control type="button" id="28">
 			<description>Ok Button</description>
 			<left>145</left>

--- a/addons/skin.confluence/720p/SettingsCategory.xml
+++ b/addons/skin.confluence/720p/SettingsCategory.xml
@@ -254,6 +254,18 @@
 			<height>2</height>
 			<texture>separator2.png</texture>
 		</control>
+		<control type="label" id="14">
+			<description>Default Label</description>
+			<left>0</left>
+			<top>0</top>
+			<height>30</height>
+			<label>-</label>
+			<align>center</align>
+			<aligny>bottom</aligny>
+			<font>font13_title</font>
+			<textcolor>grey</textcolor>
+			<shadowcolor>black</shadowcolor>
+		</control>
 		<control type="label" id="2">
 			<description>Fake Label so we can pass it value down to the one below</description>
 			<left>0</left>

--- a/addons/skin.confluence/720p/VideoOSDSettings.xml
+++ b/addons/skin.confluence/720p/VideoOSDSettings.xml
@@ -133,5 +133,17 @@
 			<height>2</height>
 			<texture>separator2.png</texture>
 		</control>
+		<control type="label" id="14">
+			<description>Default Label</description>
+			<left>0</left>
+			<top>0</top>
+			<height>30</height>
+			<label>-</label>
+			<align>center</align>
+			<aligny>bottom</aligny>
+			<font>font13_title</font>
+			<textcolor>grey</textcolor>
+			<shadowcolor>black</shadowcolor>
+		</control>
 	</controls>
 </window>

--- a/xbmc/settings/SettingControl.cpp
+++ b/xbmc/settings/SettingControl.cpp
@@ -47,6 +47,8 @@ ISettingControl* CSettingControlCreator::CreateControl(const std::string &contro
     return new CSettingControlSlider();
   else if (StringUtils::EqualsNoCase(controlType, "range"))
     return new CSettingControlRange();
+  else if (StringUtils::EqualsNoCase(controlType, "title"))
+    return new CSettingControlTitle();
 
   return NULL;
 }
@@ -316,6 +318,24 @@ bool CSettingControlRange::SetFormat(const std::string &format)
 
   m_format = format;
   StringUtils::ToLower(m_format);
+
+  return true;
+}
+
+bool CSettingControlTitle::Deserialize(const TiXmlNode *node, bool update /* = false */)
+{
+  if (!ISettingControl::Deserialize(node, update))
+    return false;
+
+  std::string strTmp;
+  if (XMLUtils::GetString(node, SETTING_XML_ATTR_SEPARATOR_POSITION, strTmp))
+  {
+    if (!StringUtils::EqualsNoCase(strTmp, "top") && !StringUtils::EqualsNoCase(strTmp, "bottom"))
+      CLog::Log(LOGWARNING, "CSettingControlTitle: error reading \"value\" attribute of <%s>", SETTING_XML_ATTR_SEPARATOR_POSITION);
+    else
+      m_separatorBelowLabel = StringUtils::EqualsNoCase(strTmp, "bottom");
+  }
+  XMLUtils::GetBoolean(node, SETTING_XML_ATTR_HIDE_SEPARATOR, m_separatorHidden);
 
   return true;
 }

--- a/xbmc/settings/SettingControl.h
+++ b/xbmc/settings/SettingControl.h
@@ -32,6 +32,8 @@
 #define SETTING_XML_ELM_CONTROL_FORMATVALUE  "value"
 #define SETTING_XML_ATTR_SHOW_MORE           "more"
 #define SETTING_XML_ATTR_SHOW_DETAILS        "details"
+#define SETTING_XML_ATTR_SEPARATOR_POSITION  "separatorposition"
+#define SETTING_XML_ATTR_HIDE_SEPARATOR      "hideseparator"
 
 class CVariant;
 
@@ -253,4 +255,28 @@ protected:
   int m_formatLabel;
   int m_valueFormatLabel;
   std::string m_valueFormat;
+};
+
+class CSettingControlTitle : public ISettingControl
+{
+public:
+  CSettingControlTitle()
+    : m_separatorHidden(false),
+      m_separatorBelowLabel(true)
+  { }
+  virtual ~CSettingControlTitle() { }
+
+  // implementation of ISettingControl
+  virtual std::string GetType() const { return "title"; }
+  virtual bool Deserialize(const TiXmlNode *node, bool update = false);
+  virtual bool SetFormat(const std::string &format) { return true; }
+
+  bool IsSeparatorHidden() const { return m_separatorHidden; }
+  void SetSeparatorHidden(bool hidden) { m_separatorHidden = hidden; }
+  bool IsSeparatorBelowLabel() const { return m_separatorBelowLabel; }
+  void SetSeparatorBelowLabel(bool below) { m_separatorBelowLabel = below; }
+
+protected:
+  bool m_separatorHidden;
+  bool m_separatorBelowLabel;
 };

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -505,6 +505,7 @@ void CSettings::InitializeControls()
   m_settingsManager->RegisterSettingControl("list", this);
   m_settingsManager->RegisterSettingControl("slider", this);
   m_settingsManager->RegisterSettingControl("range", this);
+  m_settingsManager->RegisterSettingControl("title", this);
 }
 
 void CSettings::InitializeVisibility()

--- a/xbmc/settings/dialogs/GUIDialogSettingsBase.h
+++ b/xbmc/settings/dialogs/GUIDialogSettingsBase.h
@@ -49,6 +49,7 @@ class CGUIEditControl;
 class CGUIButtonControl;
 class CGUIRadioButtonControl;
 class CGUISettingsSliderControl;
+class CGUILabelControl;
 
 class CSetting;
 class CSettingAction;
@@ -148,6 +149,7 @@ protected:
   BaseSettingControlPtr GetSettingControl(int controlId);
   
   CGUIControl* AddSeparator(float width, int &iControlID);
+  CGUIControl* AddLabel(float width, int &iControlID, int label);
 
   std::vector<CSettingCategory*> m_categories;
   std::vector<BaseSettingControlPtr> m_settingControls;
@@ -164,6 +166,7 @@ protected:
   CGUIButtonControl *m_pOriginalButton;
   CGUIEditControl *m_pOriginalEdit;
   CGUIImage *m_pOriginalImage;
+  CGUILabelControl *m_pOriginalGroupTitle;
   bool m_newOriginalEdit;
   
   BaseSettingControlPtr m_delayedSetting; ///< Current delayed setting \sa CBaseSettingControl::SetDelayed()

--- a/xbmc/settings/dialogs/GUIDialogSettingsManualBase.cpp
+++ b/xbmc/settings/dialogs/GUIDialogSettingsManualBase.cpp
@@ -89,7 +89,7 @@ CSettingCategory* CGUIDialogSettingsManualBase::AddCategory(const std::string &i
   return category;
 }
 
-CSettingGroup* CGUIDialogSettingsManualBase::AddGroup(CSettingCategory *category)
+CSettingGroup* CGUIDialogSettingsManualBase::AddGroup(CSettingCategory *category, int label /* = -1 */, int help /* = -1 */, bool separatorBelowLabel /* = true */, bool hideSeparator /* = false */)
 {
   if (category == NULL)
     return NULL;
@@ -99,6 +99,12 @@ CSettingGroup* CGUIDialogSettingsManualBase::AddGroup(CSettingCategory *category
   CSettingGroup *group = new CSettingGroup(StringUtils::Format("%zu", groups + 1), m_settingsManager);
   if (group == NULL)
     return NULL;
+
+  if (label >= 0)
+    group->SetLabel(label);
+  if (help >= 0)
+    group->SetHelp(help);
+  group->SetControl(GetTitleControl(separatorBelowLabel, hideSeparator));
 
   category->AddGroup(group);
   return group;
@@ -948,6 +954,15 @@ ISettingControl* CGUIDialogSettingsManualBase::GetCheckmarkControl(bool delayed 
 {
   CSettingControlCheckmark *control = new CSettingControlCheckmark();
   control->SetDelayed(delayed);
+
+  return control;
+}
+
+ISettingControl* CGUIDialogSettingsManualBase::GetTitleControl(bool separatorBelowLabel /* = true */, bool hideSeparator /* = false */)
+{
+  CSettingControlTitle *control = new CSettingControlTitle();
+  control->SetSeparatorBelowLabel(separatorBelowLabel);
+  control->SetSeparatorHidden(hideSeparator);
 
   return control;
 }

--- a/xbmc/settings/dialogs/GUIDialogSettingsManualBase.h
+++ b/xbmc/settings/dialogs/GUIDialogSettingsManualBase.h
@@ -54,7 +54,7 @@ protected:
   virtual void InitializeSettings();
 
   CSettingCategory* AddCategory(const std::string &id, int label, int help = -1);
-  CSettingGroup* AddGroup(CSettingCategory *category);
+  CSettingGroup* AddGroup(CSettingCategory *category, int label = -1, int help = -1, bool separatorBelowLabel = true, bool hideSeparator = false);
   // checkmark control
   CSettingBool* AddToggle(CSettingGroup *group, const std::string &id, int label, int level, bool value, bool delayed = false, bool visible = true, int help = -1);
   // edit controls
@@ -145,6 +145,7 @@ protected:
   CSettingList* AddTimeRange(CSettingGroup *group, const std::string &id, int label, int level, int valueLower, int valueUpper, int minimum, int step, int maximum,
                              const std::string &valueFormatString = "mm:ss", int formatLabel = 21469, bool delayed = false, bool visible = true, int help = -1);
 
+  ISettingControl* GetTitleControl(bool separatorBelowLabel = true, bool hideSeparator = false);
   ISettingControl* GetCheckmarkControl(bool delayed = false);
   ISettingControl* GetEditControl(const std::string &format, bool delayed = false, bool hidden = false, bool verifyNewValue = false, int heading = -1);
   ISettingControl* GetButtonControl(const std::string &format, bool delayed = false, int heading = -1, bool hideValue = false, bool showInstalledAddons = true,

--- a/xbmc/settings/lib/SettingSection.h
+++ b/xbmc/settings/lib/SettingSection.h
@@ -68,8 +68,13 @@ public:
   void AddSetting(CSetting *setting);
   void AddSettings(const SettingList &settings);
 
+  const ISettingControl *GetControl() const { return m_control; }
+  ISettingControl *GetControl() { return m_control; }
+  void SetControl(ISettingControl *control) { m_control = control; }
+
 private:
   SettingList m_settings;
+  ISettingControl *m_control;
 };
 
 typedef std::vector<CSettingGroup *> SettingGroupList;

--- a/xbmc/settings/windows/GUIControlSettings.cpp
+++ b/xbmc/settings/windows/GUIControlSettings.cpp
@@ -31,6 +31,7 @@
 #include "dialogs/GUIDialogSlider.h"
 #include "guilib/GUIEditControl.h"
 #include "guilib/GUIImage.h"
+#include "guilib/GUILabelControl.h"
 #include "guilib/GUIRadioButtonControl.h"
 #include "guilib/GUISettingsSliderControl.h"
 #include "guilib/GUISpinControlEx.h"
@@ -1144,4 +1145,17 @@ CGUIControlSeparatorSetting::CGUIControlSeparatorSetting(CGUIImage *pImage, int 
 }
 
 CGUIControlSeparatorSetting::~CGUIControlSeparatorSetting()
+{ }
+
+CGUIControlGroupTitleSetting::CGUIControlGroupTitleSetting(CGUILabelControl *pLabel, int id)
+  : CGUIControlBaseSetting(id, NULL)
+{
+  m_pLabel = pLabel;
+  if (m_pLabel == NULL)
+    return;
+
+  m_pLabel->SetID(id);
+}
+
+CGUIControlGroupTitleSetting::~CGUIControlGroupTitleSetting()
 { }

--- a/xbmc/settings/windows/GUIControlSettings.h
+++ b/xbmc/settings/windows/GUIControlSettings.h
@@ -30,6 +30,7 @@ class CGUIEditControl;
 class CGUIButtonControl;
 class CGUIRadioButtonControl;
 class CGUISettingsSliderControl;
+class CGUILabelControl;
 
 class CSetting;
 class CSettingControlSlider;
@@ -223,4 +224,18 @@ public:
   virtual void Clear() { m_pImage = NULL; }
 private:
   CGUIImage *m_pImage;
+};
+
+class CGUIControlGroupTitleSetting : public CGUIControlBaseSetting
+{
+public:
+  CGUIControlGroupTitleSetting(CGUILabelControl* pLabel, int id);
+  virtual ~CGUIControlGroupTitleSetting();
+
+  virtual CGUIControl* GetControl() { return (CGUIControl*)m_pLabel; }
+  virtual bool OnClick() { return false; }
+  virtual void Update() {}
+  virtual void Clear() { m_pLabel = NULL; }
+private:
+  CGUILabelControl *m_pLabel;
 };


### PR DESCRIPTION
This is the reduced version of the request #6502, which have the for AudioDSP needed parts.

![bildschirmfoto8](https://cloud.githubusercontent.com/assets/6879739/6834504/ea0c4184-d334-11e4-885b-76ca96c80062.png)
