### PR TITLE
[jenkins] - prevent cleanout of native tools when pathChanged returns 1 ...

### DIFF
--- a/tools/buildsteps/android/make-native-depends
+++ b/tools/buildsteps/android/make-native-depends
@@ -2,7 +2,7 @@ WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
 XBMC_PLATFORM_DIR=android
 . $WORKSPACE/tools/buildsteps/defaultenv
 
-if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
+if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ] && [ "$BINARY_ADDONS_CLEAN_NATIVETOOLS" != "0" ]
 then
   git clean -xffd $WORKSPACE/tools/depends/native
   cd $WORKSPACE/tools/depends/native;make -j $BUILDTHREADS && tagSuccessFulBuild $WORKSPACE/tools/depends

--- a/tools/buildsteps/android/prepare-xbmc
+++ b/tools/buildsteps/android/prepare-xbmc
@@ -11,4 +11,7 @@ fi
 git submodule update --init $WORKSPACE/addons/skin.re-touched
 
 #build binary addons before building xbmc...
+#make sure that binary_addons don't clean the native tools
+#here (e.x. on release builds where pathChanged always returns 1
+BINARY_ADDONS_CLEAN_NATIVETOOLS="0"
 . $WORKSPACE/tools/buildsteps/$XBMC_PLATFORM_DIR/make-binary-addons

--- a/tools/buildsteps/androidx86/make-native-depends
+++ b/tools/buildsteps/androidx86/make-native-depends
@@ -2,7 +2,7 @@ WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
 XBMC_PLATFORM_DIR=android
 . $WORKSPACE/tools/buildsteps/defaultenv
 
-if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
+if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ] && [ "$BINARY_ADDONS_CLEAN_NATIVETOOLS" != "0" ]
 then
   git clean -xffd $WORKSPACE/tools/depends/native
   cd $WORKSPACE/tools/depends/native;make -j $BUILDTHREADS && tagSuccessFulBuild $WORKSPACE/tools/depends

--- a/tools/buildsteps/androidx86/prepare-xbmc
+++ b/tools/buildsteps/androidx86/prepare-xbmc
@@ -11,4 +11,7 @@ fi
 git submodule update --init $WORKSPACE/addons/skin.re-touched
 
 #build binary addons before building xbmc...
+#make sure that binary_addons don't clean the native tools
+#here (e.x. on release builds where pathChanged always returns 1
+BINARY_ADDONS_CLEAN_NATIVETOOLS="0"
 . $WORKSPACE/tools/buildsteps/$XBMC_PLATFORM_DIR/make-binary-addons

--- a/tools/buildsteps/atv2/make-native-depends
+++ b/tools/buildsteps/atv2/make-native-depends
@@ -2,7 +2,7 @@ WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
 XBMC_PLATFORM_DIR=atv2
 . $WORKSPACE/tools/buildsteps/defaultenv
 
-if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
+if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ] && [ "$BINARY_ADDONS_CLEAN_NATIVETOOLS" != "0" ]
 then
   git clean -xffd $WORKSPACE/tools/depends/native
   cd $WORKSPACE/tools/depends/native;make -j $BUILDTHREADS && tagSuccessFulBuild $WORKSPACE/tools/depends

--- a/tools/buildsteps/atv2/prepare-xbmc
+++ b/tools/buildsteps/atv2/prepare-xbmc
@@ -4,4 +4,7 @@ XBMC_PLATFORM_DIR=atv2
 
 
 #build binary addons before building xbmc...
+#make sure that binary_addons don't clean the native tools
+#here (e.x. on release builds where pathChanged always returns 1
+BINARY_ADDONS_CLEAN_NATIVETOOLS="0"
 . $WORKSPACE/tools/buildsteps/$XBMC_PLATFORM_DIR/make-binary-addons

--- a/tools/buildsteps/ios/make-native-depends
+++ b/tools/buildsteps/ios/make-native-depends
@@ -2,7 +2,7 @@ WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
 XBMC_PLATFORM_DIR=ios
 . $WORKSPACE/tools/buildsteps/defaultenv
 
-if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
+if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ] && [ "$BINARY_ADDONS_CLEAN_NATIVETOOLS" != "0" ]
 then
   git clean -xffd $WORKSPACE/tools/depends/native
   cd $WORKSPACE/tools/depends/native;make -j $BUILDTHREADS && tagSuccessFulBuild $WORKSPACE/tools/depends

--- a/tools/buildsteps/ios/prepare-xbmc
+++ b/tools/buildsteps/ios/prepare-xbmc
@@ -11,4 +11,7 @@ fi
 git submodule update --init $WORKSPACE/addons/skin.re-touched
 
 #build binary addons before building xbmc...
+#make sure that binary_addons don't clean the native tools
+#here (e.x. on release builds where pathChanged always returns 1
+BINARY_ADDONS_CLEAN_NATIVETOOLS="0"
 . $WORKSPACE/tools/buildsteps/$XBMC_PLATFORM_DIR/make-binary-addons

--- a/tools/buildsteps/linux32/make-native-depends
+++ b/tools/buildsteps/linux32/make-native-depends
@@ -2,7 +2,7 @@ WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
 XBMC_PLATFORM_DIR=linux32
 . $WORKSPACE/tools/buildsteps/defaultenv
 
-if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
+if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ] && [ "$BINARY_ADDONS_CLEAN_NATIVETOOLS" != "0" ]
 then
   git clean -xffd $WORKSPACE/tools/depends/native
   cd $WORKSPACE/tools/depends/native;make -j $BUILDTHREADS && tagSuccessFulBuild $WORKSPACE/tools/depends

--- a/tools/buildsteps/linux32/prepare-xbmc
+++ b/tools/buildsteps/linux32/prepare-xbmc
@@ -3,4 +3,7 @@ XBMC_PLATFORM_DIR=linux32
 . $WORKSPACE/tools/buildsteps/defaultenv
 
 #build binary addons before building xbmc...
+#make sure that binary_addons don't clean the native tools
+#here (e.x. on release builds where pathChanged always returns 1
+BINARY_ADDONS_CLEAN_NATIVETOOLS="0"
 . $WORKSPACE/tools/buildsteps/$XBMC_PLATFORM_DIR/make-binary-addons

--- a/tools/buildsteps/linux64/make-native-depends
+++ b/tools/buildsteps/linux64/make-native-depends
@@ -2,7 +2,7 @@ WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
 XBMC_PLATFORM_DIR=linux64
 . $WORKSPACE/tools/buildsteps/defaultenv
 
-if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
+if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ] && [ "$BINARY_ADDONS_CLEAN_NATIVETOOLS" != "0" ]
 then
   git clean -xffd $WORKSPACE/tools/depends/native
   cd $WORKSPACE/tools/depends/native;make -j $BUILDTHREADS && tagSuccessFulBuild $WORKSPACE/tools/depends

--- a/tools/buildsteps/linux64/prepare-xbmc
+++ b/tools/buildsteps/linux64/prepare-xbmc
@@ -3,4 +3,7 @@ XBMC_PLATFORM_DIR=linux64
 . $WORKSPACE/tools/buildsteps/defaultenv
 
 #build binary addons before building xbmc...
+#make sure that binary_addons don't clean the native tools
+#here (e.x. on release builds where pathChanged always returns 1
+BINARY_ADDONS_CLEAN_NATIVETOOLS="0"
 . $WORKSPACE/tools/buildsteps/$XBMC_PLATFORM_DIR/make-binary-addons

--- a/tools/buildsteps/osx32/make-native-depends
+++ b/tools/buildsteps/osx32/make-native-depends
@@ -2,7 +2,7 @@ WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
 XBMC_PLATFORM_DIR=osx32
 . $WORKSPACE/tools/buildsteps/defaultenv
 
-if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
+if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ] && [ "$BINARY_ADDONS_CLEAN_NATIVETOOLS" != "0" ]
 then
   git clean -xffd $WORKSPACE/tools/depends/native
   cd $WORKSPACE/tools/depends/native;make -j $BUILDTHREADS && tagSuccessFulBuild $WORKSPACE/tools/depends

--- a/tools/buildsteps/osx32/prepare-xbmc
+++ b/tools/buildsteps/osx32/prepare-xbmc
@@ -3,4 +3,7 @@ XBMC_PLATFORM_DIR=osx32
 . $WORKSPACE/tools/buildsteps/defaultenv
 
 #build binary addons before building xbmc...
+#make sure that binary_addons don't clean the native tools
+#here (e.x. on release builds where pathChanged always returns 1
+BINARY_ADDONS_CLEAN_NATIVETOOLS="0"
 . $WORKSPACE/tools/buildsteps/$XBMC_PLATFORM_DIR/make-binary-addons

--- a/tools/buildsteps/osx64/make-native-depends
+++ b/tools/buildsteps/osx64/make-native-depends
@@ -2,7 +2,7 @@ WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
 XBMC_PLATFORM_DIR=osx64
 . $WORKSPACE/tools/buildsteps/defaultenv
 
-if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
+if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ] && [ "$BINARY_ADDONS_CLEAN_NATIVETOOLS" != "0" ]
 then
   git clean -xffd $WORKSPACE/tools/depends/native
   cd $WORKSPACE/tools/depends/native;make -j $BUILDTHREADS && tagSuccessFulBuild $WORKSPACE/tools/depends

--- a/tools/buildsteps/osx64/prepare-xbmc
+++ b/tools/buildsteps/osx64/prepare-xbmc
@@ -3,4 +3,7 @@ XBMC_PLATFORM_DIR=osx64
 . $WORKSPACE/tools/buildsteps/defaultenv
 
 #build binary addons before building xbmc...
+#make sure that binary_addons don't clean the native tools
+#here (e.x. on release builds where pathChanged always returns 1
+BINARY_ADDONS_CLEAN_NATIVETOOLS="0"
 . $WORKSPACE/tools/buildsteps/$XBMC_PLATFORM_DIR/make-binary-addons

--- a/tools/buildsteps/rbpi/make-native-depends
+++ b/tools/buildsteps/rbpi/make-native-depends
@@ -2,7 +2,7 @@ WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
 XBMC_PLATFORM_DIR=rbpi
 . $WORKSPACE/tools/buildsteps/defaultenv
 
-if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
+if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ] && [ "$BINARY_ADDONS_CLEAN_NATIVETOOLS" != "0" ]
 then
   git clean -xffd $WORKSPACE/tools/depends/native
   cd $WORKSPACE/tools/depends/native;make -j $BUILDTHREADS && tagSuccessFulBuild $WORKSPACE/tools/depends

--- a/tools/buildsteps/rbpi/prepare-xbmc
+++ b/tools/buildsteps/rbpi/prepare-xbmc
@@ -6,4 +6,7 @@ cd $WORKSPACE
 JSON_BUILDER=$XBMC_DEPENDS_ROOT/i686-linux-gnu-native/bin/JsonSchemaBuilder ./bootstrap
 
 #build binary addons before building xbmc...
+#make sure that binary_addons don't clean the native tools
+#here (e.x. on release builds where pathChanged always returns 1
+BINARY_ADDONS_CLEAN_NATIVETOOLS="0"
 . $WORKSPACE/tools/buildsteps/$XBMC_PLATFORM_DIR/make-binary-addons


### PR DESCRIPTION
...in make-native-depends (due to Configuration set to RELEASE)

this fixes release builds with jenkins (broken when adding the addons build jobs)
