### PR TITLE
[AudioCodecFFMPEG] - disable drc in audio codec context when

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
@@ -92,8 +92,8 @@ bool CDVDAudioCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options
     }
   }
 
-  if (!g_advancedSettings.m_audioApplyDrc)
-    av_opt_set_double(m_pCodecContext, "drc_scale", 0.0, AV_OPT_SEARCH_CHILDREN);
+  if (g_advancedSettings.m_audioApplyDrc >= 0.0)
+    av_opt_set_double(m_pCodecContext, "drc_scale", g_advancedSettings.m_audioApplyDrc, AV_OPT_SEARCH_CHILDREN);
 
   if (avcodec_open2(m_pCodecContext, pCodec, NULL) < 0)
   {

--- a/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
@@ -24,6 +24,10 @@
 #endif
 #include "../../DVDStreamInfo.h"
 #include "utils/log.h"
+#include "settings/AdvancedSettings.h"
+extern "C" {
+#include "libavutil/opt.h"
+}
 
 #if defined(TARGET_DARWIN)
 #include "settings/Settings.h"
@@ -87,6 +91,9 @@ bool CDVDAudioCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options
       memcpy(m_pCodecContext->extradata, hints.extradata, hints.extrasize);
     }
   }
+
+  if (!g_advancedSettings.m_audioApplyDrc)
+    av_opt_set_double(m_pCodecContext, "drc_scale", 0.0, AV_OPT_SEARCH_CHILDREN);
 
   if (avcodec_open2(m_pCodecContext, pCodec, NULL) < 0)
   {

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -109,7 +109,7 @@ void CAdvancedSettings::Initialize()
 
   m_audioHeadRoom = 0;
   m_ac3Gain = 12.0f;
-  m_audioApplyDrc = true;
+  m_audioApplyDrc = -1.0f;
   m_dvdplayerIgnoreDTSinWAV = false;
 
   //default hold time of 25 ms, this allows a 20 hertz sine to pass undistorted
@@ -487,7 +487,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     if (pAudioExcludes)
       GetCustomRegexps(pAudioExcludes, m_audioExcludeFromScanRegExps);
 
-    XMLUtils::GetBoolean(pElement, "applydrc", m_audioApplyDrc);
+    XMLUtils::GetFloat(pElement, "applydrc", m_audioApplyDrc);
     XMLUtils::GetBoolean(pElement, "dvdplayerignoredtsinwav", m_dvdplayerIgnoreDTSinWAV);
 
     XMLUtils::GetFloat(pElement, "limiterhold", m_limiterHold, 0.0f, 100.0f);

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -178,7 +178,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     int m_videoBlackBarColour;
     int m_videoIgnoreSecondsAtStart;
     float m_videoIgnorePercentAtEnd;
-    bool m_audioApplyDrc;
+    float m_audioApplyDrc;
     bool m_useFfmpegVda;
 
     int   m_videoVDPAUScaling;


### PR DESCRIPTION
advancedsetting "applydrc" is disabled

This basically hooks up the unused advancedsetting we had laying around to the ffmpeg drc setting.

Thx  to halfgaar from the forum.

ATM the setting defaults to true which means in AC3 streams the DRC as proposed in the stream metadata is applied. This post from halfgaar makes me think that the default should indeed be off:

http://forum.kodi.tv/showthread.php?tid=219228&pid=1965149#pid1965149

Seem this ffmpeg setting only has any effect on AC3 streams if i got it right.

@FernetMenta and @fritsch to decide if we want this and what the default it should have or if we wanna hook this up in the UI or maybe use the "audiooutput.maintainoriginalvolume" gui setting for this...
