### PR TITLE
[pvr] CGUIDialogPVRTimerSettings fixes

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -49,23 +49,51 @@ using namespace PVR;
 
 CGUIDialogPVRTimerSettings::CGUIDialogPVRTimerSettings(void)
   : CGUIDialogSettingsManualBase(WINDOW_DIALOG_PVR_TIMER_SETTING, "DialogPVRTimerSettings.xml"),
+    m_bIsRadio(false),
+    m_bIsRepeating(false),
+    m_bSupportsFolders(false),
+    m_iWeekdays(0),
+    m_iPriority(0),
+    m_iLifetime(0),
     m_tmp_iFirstDay(0),
     m_tmp_day(11),
     m_bTimerActive(false),
-    m_selectedChannelEntry(0),
-    m_timerItem(NULL)
+    m_selectedChannelEntry(0)
 {
   m_loadType = LOAD_EVERY_TIME;
 }
 
 void CGUIDialogPVRTimerSettings::SetTimer(CFileItem *item)
 {
-  m_timerItem         = item;
+  m_InfoTag = item->GetPVRTimerInfoTag();
 
-  m_timerItem->GetPVRTimerInfoTag()->StartAsLocalTime().GetAsSystemTime(m_timerStartTime);
-  m_timerItem->GetPVRTimerInfoTag()->EndAsLocalTime().GetAsSystemTime(m_timerEndTime);
-  m_timerStartTimeStr   = m_timerItem->GetPVRTimerInfoTag()->StartAsLocalTime().GetAsLocalizedTime("", false);
-  m_timerEndTimeStr     = m_timerItem->GetPVRTimerInfoTag()->EndAsLocalTime().GetAsLocalizedTime("", false);
+  // Copy over data from tag. We must not change the tag until Save()
+  // because it is not a copy, but the (one and only) original.
+
+  m_bIsRadio         = m_InfoTag->m_bIsRadio;
+  m_bIsRepeating     = m_InfoTag->m_bIsRepeating;
+  m_iWeekdays        = m_InfoTag->m_iWeekdays;
+  m_iPriority        = m_InfoTag->m_iPriority;
+  m_iLifetime        = m_InfoTag->m_iLifetime;
+  m_strTitle         = m_InfoTag->m_strTitle;
+  m_strDirectory     = m_InfoTag->m_strDirectory;
+
+  m_FirstDay         = m_InfoTag->FirstDayAsLocalTime();
+  m_StartTime        = m_InfoTag->StartAsLocalTime();
+  m_EndTime          = m_InfoTag->EndAsLocalTime();
+
+  m_bTimerActive     = m_InfoTag->IsActive();
+  m_bSupportsFolders = m_InfoTag->SupportsFolders();
+
+  m_Channel          = m_InfoTag->ChannelTag();
+
+  m_StartTime.GetAsSystemTime(m_timerStartTime);
+  m_EndTime.GetAsSystemTime(m_timerEndTime);
+  m_timerStartTimeStr = m_StartTime.GetAsLocalizedTime("", false);
+  m_timerEndTimeStr   = m_EndTime.GetAsLocalizedTime("", false);
+
+  m_selectedChannelEntry = 0;
+  m_channelEntries.clear();
 
   m_tmp_iFirstDay     = 0;
   m_tmp_day           = 11;
@@ -75,21 +103,7 @@ void CGUIDialogPVRTimerSettings::SetChannelFromSelectedEntry(int iSelectedEntry,
 {
   const std::map<std::pair<bool, int>, int>::const_iterator itc(m_channelEntries.find(std::make_pair(bRadio, iSelectedEntry)));
   if (itc != m_channelEntries.end())
-  {
-    const CPVRChannelPtr channel(g_PVRChannelGroups->GetChannelById(itc->second));
-    if (channel)
-    {
-      CPVRTimerInfoTagPtr tag(m_timerItem->GetPVRTimerInfoTag());
-
-      tag->m_iClientChannelUid = channel->UniqueID();
-      tag->m_iClientId         = channel->ClientID();
-      tag->m_bIsRadio          = channel->IsRadio();
-      tag->m_iChannelNumber    = channel->ChannelNumber();
-
-      // Update channel pointer from above values
-      tag->UpdateChannel();
-    }
-  }
+    m_Channel = g_PVRChannelGroups->GetChannelById(itc->second);
 }
 
 void CGUIDialogPVRTimerSettings::OnSettingChanged(const CSetting *setting)
@@ -99,10 +113,6 @@ void CGUIDialogPVRTimerSettings::OnSettingChanged(const CSetting *setting)
 
   CGUIDialogSettingsManualBase::OnSettingChanged(setting);
 
-  CPVRTimerInfoTagPtr tag = m_timerItem->GetPVRTimerInfoTag();
-  if (tag == NULL)
-    return;
-
   const std::string &settingId = setting->GetId();
   if (settingId == SETTING_TMR_ACTIVE)
     m_bTimerActive = static_cast<const CSettingBool*>(setting)->GetValue();
@@ -110,21 +120,21 @@ void CGUIDialogPVRTimerSettings::OnSettingChanged(const CSetting *setting)
   {
     if (settingId == SETTING_TMR_RADIO)
     {
-      tag->m_bIsRadio = static_cast<const CSettingBool*>(setting)->GetValue();
+      m_bIsRadio = static_cast<const CSettingBool*>(setting)->GetValue();
       m_selectedChannelEntry = 0;
     }
     else
     {
       m_selectedChannelEntry = static_cast<const CSettingInt*>(setting)->GetValue();
     }
-    SetChannelFromSelectedEntry(m_selectedChannelEntry, tag->m_bIsRadio);
+    SetChannelFromSelectedEntry(m_selectedChannelEntry, m_bIsRadio);
   }
   else if (settingId == SETTING_TMR_DAY)
   {
     m_tmp_day = static_cast<const CSettingInt*>(setting)->GetValue();
 
     if (m_tmp_day <= 10)
-      SetTimerFromWeekdaySetting(*tag);
+      SetTimerFromWeekdaySetting();
     else
     {
       CDateTime time = CDateTime::GetCurrentDateTime();
@@ -148,17 +158,17 @@ void CGUIDialogPVRTimerSettings::OnSettingChanged(const CSetting *setting)
       if (newEnd < newStart)
         newEnd += CDateTimeSpan(1, 0, 0, 0);
 
-      tag->SetStartFromLocalTime(newStart);
-      tag->SetEndFromLocalTime(newEnd);
+      m_StartTime = newStart;
+      m_EndTime   = newEnd;
 
-      tag->m_bIsRepeating = false;
-      tag->m_iWeekdays = 0;
+      m_bIsRepeating = false;
+      m_iWeekdays    = 0;
     }
   }
   else if (settingId == SETTING_TMR_PRIORITY)
-    tag->m_iPriority = static_cast<const CSettingInt*>(setting)->GetValue();
+    m_iPriority = static_cast<const CSettingInt*>(setting)->GetValue();
   else if (settingId == SETTING_TMR_LIFETIME)
-    tag->m_iLifetime = static_cast<const CSettingInt*>(setting)->GetValue();
+    m_iLifetime = static_cast<const CSettingInt*>(setting)->GetValue();
   else if (settingId == SETTING_TMR_FIRST_DAY)
   {
     m_tmp_iFirstDay = static_cast<const CSettingInt*>(setting)->GetValue();
@@ -167,14 +177,12 @@ void CGUIDialogPVRTimerSettings::OnSettingChanged(const CSetting *setting)
     if (m_tmp_iFirstDay > 0)
       newFirstDay = CDateTime::GetCurrentDateTime() + CDateTimeSpan(m_tmp_iFirstDay - 1, 0, 0, 0);
 
-    tag->SetFirstDayFromLocalTime(newFirstDay);
+    m_FirstDay = newFirstDay;
   }
   else if (settingId == SETTING_TMR_NAME)
-    tag->m_strTitle = static_cast<const CSettingString*>(setting)->GetValue();
+    m_strTitle = static_cast<const CSettingString*>(setting)->GetValue();
   else if (settingId == SETTING_TMR_DIR)
-    tag->m_strDirectory = static_cast<const CSettingString*>(setting)->GetValue();
-
-  tag->UpdateSummary();
+    m_strDirectory = static_cast<const CSettingString*>(setting)->GetValue();
 }
 
 void CGUIDialogPVRTimerSettings::OnSettingAction(const CSetting *setting)
@@ -184,25 +192,21 @@ void CGUIDialogPVRTimerSettings::OnSettingAction(const CSetting *setting)
 
   CGUIDialogSettingsManualBase::OnSettingAction(setting);
 
-  CPVRTimerInfoTagPtr tag = m_timerItem->GetPVRTimerInfoTag();
-  if (tag == NULL)
-    return;
-
   const std::string &settingId = setting->GetId();
   if (settingId == SETTING_TMR_BEGIN)
   {
     if (CGUIDialogNumeric::ShowAndGetTime(m_timerStartTime, g_localizeStrings.Get(14066)))
     {
       CDateTime timestart = m_timerStartTime;
-      int start_day       = tag->StartAsLocalTime().GetDay();
-      int start_month     = tag->StartAsLocalTime().GetMonth();
-      int start_year      = tag->StartAsLocalTime().GetYear();
+      int start_day       = m_StartTime.GetDay();
+      int start_month     = m_StartTime.GetMonth();
+      int start_year      = m_StartTime.GetYear();
       int start_hour      = timestart.GetHour();
       int start_minute    = timestart.GetMinute();
       CDateTime newStart(start_year, start_month, start_day, start_hour, start_minute, 0);
-      tag->SetStartFromLocalTime(newStart);
+      m_StartTime = newStart;
 
-      m_timerStartTimeStr = tag->StartAsLocalTime().GetAsLocalizedTime("", false);
+      m_timerStartTimeStr = m_StartTime.GetAsLocalizedTime("", false);
       setButtonLabels();
     }
   }
@@ -212,44 +216,50 @@ void CGUIDialogPVRTimerSettings::OnSettingAction(const CSetting *setting)
     {
       CDateTime timestop = m_timerEndTime;
       // TODO: add separate end date control to schedule a show with more then 24 hours
-      int start_day       = tag->StartAsLocalTime().GetDay();
-      int start_month     = tag->StartAsLocalTime().GetMonth();
-      int start_year      = tag->StartAsLocalTime().GetYear();
+      int start_day       = m_StartTime.GetDay();
+      int start_month     = m_StartTime.GetMonth();
+      int start_year      = m_StartTime.GetYear();
       int start_hour      = timestop.GetHour();
       int start_minute    = timestop.GetMinute();
       CDateTime newEnd(start_year, start_month, start_day, start_hour, start_minute, 0);
       
       // add a day to end time if end time is before start time
       // TODO: this should be removed after separate end date control was added
-      if (newEnd < tag->StartAsLocalTime())
+      if (newEnd < m_StartTime)
         newEnd += CDateTimeSpan(1, 0, 0, 0);
 
-      tag->SetEndFromLocalTime(newEnd);
+      m_EndTime = newEnd;
 
-      m_timerEndTimeStr = tag->EndAsLocalTime().GetAsLocalizedTime("", false);
+      m_timerEndTimeStr = m_EndTime.GetAsLocalizedTime("", false);
       setButtonLabels();
     }
   }
-
-  tag->UpdateSummary();
 }
 
 void CGUIDialogPVRTimerSettings::Save()
 {
-  CPVRTimerInfoTagPtr tag = m_timerItem->GetPVRTimerInfoTag();
+  m_InfoTag->m_bIsRadio     = m_bIsRadio;
+  m_InfoTag->m_bIsRepeating = m_bIsRepeating;
+  m_InfoTag->m_iWeekdays    = m_iWeekdays;
+  m_InfoTag->m_iPriority    = m_iPriority;
+  m_InfoTag->m_iLifetime    = m_iLifetime;
+
+  m_InfoTag->SetFirstDayFromLocalTime(m_FirstDay);
+  m_InfoTag->SetStartFromLocalTime(m_StartTime);
+  m_InfoTag->SetEndFromLocalTime(m_EndTime);
+
+  m_InfoTag->SetChannel(m_Channel);
 
   // Set the timer's title to the channel name if it's 'New Timer' or empty
-  if (tag->m_strTitle == g_localizeStrings.Get(19056) || tag->m_strTitle.empty())
-  {
-    CPVRChannelPtr channel = g_PVRChannelGroups->GetByUniqueID(tag->m_iClientChannelUid, tag->m_iClientId);
-    if (channel)
-      tag->m_strTitle = channel->ChannelName();
-  }
+  if (m_strTitle == g_localizeStrings.Get(19056) || m_strTitle.empty())
+    m_strTitle = m_Channel->ChannelName();
 
-  if (m_bTimerActive)
-    tag->m_state = PVR_TIMER_STATE_SCHEDULED;
-  else
-    tag->m_state = PVR_TIMER_STATE_CANCELLED;
+  m_InfoTag->m_strTitle     = m_strTitle;
+  m_InfoTag->m_strDirectory = m_strDirectory;
+
+  m_InfoTag->m_state = m_bTimerActive ? PVR_TIMER_STATE_SCHEDULED : PVR_TIMER_STATE_CANCELLED;
+
+  m_InfoTag->UpdateSummary();
 }
 
 void CGUIDialogPVRTimerSettings::SetupView()
@@ -280,19 +290,13 @@ void CGUIDialogPVRTimerSettings::InitializeSettings()
   // add a condition
   m_settingsManager->AddCondition("IsTimerDayRepeating", IsTimerDayRepeating);
 
-  CPVRTimerInfoTagPtr tag = m_timerItem->GetPVRTimerInfoTag();
-
-  m_selectedChannelEntry = 0;
-  m_channelEntries.clear();
-  m_bTimerActive = tag->IsActive();
-
   AddToggle(group, SETTING_TMR_ACTIVE, 19074, 0, m_bTimerActive);
-  AddEdit(group, SETTING_TMR_NAME, 19075, 0, tag->m_strTitle, false, false, 19097);
+  AddEdit(group, SETTING_TMR_NAME, 19075, 0, m_strTitle, false, false, 19097);
 
-  if (tag->SupportsFolders())
-    AddEdit(group, SETTING_TMR_DIR, 19076, 0, tag->m_strDirectory, true, false, 19104);
+  if (m_bSupportsFolders)
+    AddEdit(group, SETTING_TMR_DIR, 19076, 0, m_strDirectory, true, false, 19104);
 
-  AddToggle(group, SETTING_TMR_RADIO, 19077, 0, tag->m_bIsRadio);
+  AddToggle(group, SETTING_TMR_RADIO, 19077, 0, m_bIsRadio);
 
   /// Channel names
   {
@@ -307,26 +311,26 @@ void CGUIDialogPVRTimerSettings::InitializeSettings()
   {
     // get diffence of timer in days between today and timer start date
     tm time_cur; CDateTime::GetCurrentDateTime().GetAsTm(time_cur);
-    tm time_tmr; tag->StartAsLocalTime().GetAsTm(time_tmr);
+    tm time_tmr; m_StartTime.GetAsTm(time_tmr);
 
     m_tmp_day += time_tmr.tm_yday - time_cur.tm_yday;
     if (time_tmr.tm_yday - time_cur.tm_yday < 0)
       m_tmp_day += 365;
 
-    SetWeekdaySettingFromTimer(*tag);
+    SetWeekdaySettingFromTimer();
 
     AddSpinner(group, SETTING_TMR_DAY, 19079, 0, m_tmp_day, DaysOptionsFiller);
   }
 
   AddButton(group, SETTING_TMR_BEGIN, 19080, 0);
   AddButton(group, SETTING_TMR_END, 19081, 0);
-  AddSpinner(group, SETTING_TMR_PRIORITY, 19082, 0, tag->m_iPriority, 0, 1, 99);
-  AddSpinner(group, SETTING_TMR_LIFETIME, 19083, 0, tag->m_iLifetime, 0, 1, 365);
+  AddSpinner(group, SETTING_TMR_PRIORITY, 19082, 0, m_iPriority, 0, 1, 99);
+  AddSpinner(group, SETTING_TMR_LIFETIME, 19083, 0, m_iLifetime, 0, 1, 365);
 
   /// First day
   {
     CDateTime time = CDateTime::GetCurrentDateTime();
-    CDateTime timestart = tag->FirstDayAsLocalTime();
+    CDateTime timestart = m_FirstDay;
 
     // get diffence of timer in days between today and timer start date
     if (time < timestart)
@@ -357,9 +361,9 @@ CSetting* CGUIDialogPVRTimerSettings::AddChannelNames(CSettingGroup *group, bool
   getChannelNames(bRadio, options, m_selectedChannelEntry, true);
   
   // select the correct channel
-  if (m_timerItem->GetPVRTimerInfoTag()->ChannelTag())
+  if (m_Channel)
   {
-    int timerChannelID = m_timerItem->GetPVRTimerInfoTag()->ChannelTag()->ChannelID();
+    int timerChannelID = m_Channel->ChannelID();
 
     for (std::vector< std::pair<std::string, int> >::const_iterator option = options.begin(); option != options.end(); ++option)
     {
@@ -383,7 +387,7 @@ CSetting* CGUIDialogPVRTimerSettings::AddChannelNames(CSettingGroup *group, bool
   if (setting == NULL)
     return NULL;
 
-  // define an enable dependency with tag->m_bIsRadio
+  // define an enable dependency with bIsRadio
   CSettingDependency depdendencyIsRadio(SettingDependencyTypeEnable, m_settingsManager);
   depdendencyIsRadio.And()
     ->Add(CSettingDependencyConditionPtr(new CSettingDependencyCondition(SETTING_TMR_RADIO, "true", SettingDependencyOperatorEquals, !bRadio, m_settingsManager)));
@@ -394,63 +398,63 @@ CSetting* CGUIDialogPVRTimerSettings::AddChannelNames(CSettingGroup *group, bool
   return setting;
 }
 
-void CGUIDialogPVRTimerSettings::SetWeekdaySettingFromTimer(const CPVRTimerInfoTag &timer)
+void CGUIDialogPVRTimerSettings::SetWeekdaySettingFromTimer()
 {
-  if (timer.m_bIsRepeating)
+  if (m_bIsRepeating)
   {
-    if (timer.m_iWeekdays == 0x01)
+    if (m_iWeekdays == 0x01)
       m_tmp_day = 0;
-    else if (timer.m_iWeekdays == 0x02)
+    else if (m_iWeekdays == 0x02)
       m_tmp_day = 1;
-    else if (timer.m_iWeekdays == 0x04)
+    else if (m_iWeekdays == 0x04)
       m_tmp_day = 2;
-    else if (timer.m_iWeekdays == 0x08)
+    else if (m_iWeekdays == 0x08)
       m_tmp_day = 3;
-    else if (timer.m_iWeekdays == 0x10)
+    else if (m_iWeekdays == 0x10)
       m_tmp_day = 4;
-    else if (timer.m_iWeekdays == 0x20)
+    else if (m_iWeekdays == 0x20)
       m_tmp_day = 5;
-    else if (timer.m_iWeekdays == 0x40)
+    else if (m_iWeekdays == 0x40)
       m_tmp_day = 6;
-    else if (timer.m_iWeekdays == 0x1F)
+    else if (m_iWeekdays == 0x1F)
       m_tmp_day = 7;
-    else if (timer.m_iWeekdays == 0x3F)
+    else if (m_iWeekdays == 0x3F)
       m_tmp_day = 8;
-    else if (timer.m_iWeekdays == 0x7F)
+    else if (m_iWeekdays == 0x7F)
       m_tmp_day = 9;
-    else if (timer.m_iWeekdays == 0x60)
+    else if (m_iWeekdays == 0x60)
       m_tmp_day = 10;
   }
 }
 
-void CGUIDialogPVRTimerSettings::SetTimerFromWeekdaySetting(CPVRTimerInfoTag &timer)
+void CGUIDialogPVRTimerSettings::SetTimerFromWeekdaySetting()
 {
-  timer.m_bIsRepeating = true;
+  m_bIsRepeating = true;
 
   if (m_tmp_day == 0)
-    timer.m_iWeekdays = 0x01;
+    m_iWeekdays = 0x01;
   else if (m_tmp_day == 1)
-    timer.m_iWeekdays = 0x02;
+    m_iWeekdays = 0x02;
   else if (m_tmp_day == 2)
-    timer.m_iWeekdays = 0x04;
+    m_iWeekdays = 0x04;
   else if (m_tmp_day == 3)
-    timer.m_iWeekdays = 0x08;
+    m_iWeekdays = 0x08;
   else if (m_tmp_day == 4)
-    timer.m_iWeekdays = 0x10;
+    m_iWeekdays = 0x10;
   else if (m_tmp_day == 5)
-    timer.m_iWeekdays = 0x20;
+    m_iWeekdays = 0x20;
   else if (m_tmp_day == 6)
-    timer.m_iWeekdays = 0x40;
+    m_iWeekdays = 0x40;
   else if (m_tmp_day == 7)
-    timer.m_iWeekdays = 0x1F;
+    m_iWeekdays = 0x1F;
   else if (m_tmp_day == 8)
-    timer.m_iWeekdays = 0x3F;
+    m_iWeekdays = 0x3F;
   else if (m_tmp_day == 9)
-    timer.m_iWeekdays = 0x7F;
+    m_iWeekdays = 0x7F;
   else if (m_tmp_day == 10)
-    timer.m_iWeekdays = 0x60;
+    m_iWeekdays = 0x60;
   else
-    timer.m_iWeekdays = 0;
+    m_iWeekdays = 0;
 }
 
 void CGUIDialogPVRTimerSettings::getChannelNames(bool bRadio, std::vector< std::pair<std::string, int> > &list, int &current, bool updateChannelEntries /* = false */)
@@ -512,10 +516,6 @@ void CGUIDialogPVRTimerSettings::DaysOptionsFiller(const CSetting *setting, std:
 
   CGUIDialogPVRTimerSettings *dialog = static_cast<CGUIDialogPVRTimerSettings*>(data);
   if (dialog == NULL)
-    return;
-
-  const CPVRTimerInfoTagPtr tag = dialog->m_timerItem->GetPVRTimerInfoTag();
-  if (tag == NULL)
     return;
 
   if (setting->GetId() == SETTING_TMR_DAY)

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.h
@@ -57,6 +57,13 @@ namespace PVR
     virtual void SetWeekdaySettingFromTimer(const CPVRTimerInfoTag &timer);
     virtual void SetTimerFromWeekdaySetting(CPVRTimerInfoTag &timer);
 
+    /*!
+     * @brief Sets dialog's channel according to the currently selected channel list entry.
+     * @param iSelectedEntry the zero-based index of the channel entry in the channel selction list.
+     * @param bRadio specifies whether the entry is for the TV or for the radio channel selection list.
+     */
+    void SetChannelFromSelectedEntry(int iSelectedEntry, bool bRadio);
+
     void getChannelNames(bool bRadio, std::vector< std::pair<std::string, int> > &list, int &current, bool updateChannelEntries = false);
     void setButtonLabels();
 

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.h
@@ -31,6 +31,10 @@ class CSettingGroup;
 namespace PVR
 {
   class CPVRTimerInfoTag;
+  typedef std::shared_ptr<CPVRTimerInfoTag> CPVRTimerInfoTagPtr;
+
+  class CPVRChannel;
+  typedef std::shared_ptr<CPVRChannel> CPVRChannelPtr;
 
   class CGUIDialogPVRTimerSettings : public CGUIDialogSettingsManualBase
   {
@@ -54,8 +58,8 @@ namespace PVR
     virtual void InitializeSettings();
     
     virtual CSetting* AddChannelNames(CSettingGroup *group, bool bRadio);
-    virtual void SetWeekdaySettingFromTimer(const CPVRTimerInfoTag &timer);
-    virtual void SetTimerFromWeekdaySetting(CPVRTimerInfoTag &timer);
+    virtual void SetWeekdaySettingFromTimer();
+    virtual void SetTimerFromWeekdaySetting();
 
     /*!
      * @brief Sets dialog's channel according to the currently selected channel list entry.
@@ -72,6 +76,20 @@ namespace PVR
     static void ChannelNamesOptionsFiller(const CSetting *setting, std::vector< std::pair<std::string, int> > &list, int &current, void *data);
     static void DaysOptionsFiller(const CSetting *setting, std::vector< std::pair<std::string, int> > &list, int &current, void *data);
 
+    CPVRTimerInfoTagPtr                 m_InfoTag;
+    CPVRChannelPtr                      m_Channel;
+    bool                                m_bIsRadio;
+    bool                                m_bIsRepeating;
+    bool                                m_bSupportsFolders;
+    int                                 m_iWeekdays;
+    int                                 m_iPriority;
+    int                                 m_iLifetime;
+    std::string                         m_strTitle;
+    std::string                         m_strDirectory;
+    CDateTime                           m_FirstDay;
+    CDateTime                           m_StartTime;
+    CDateTime                           m_EndTime;
+
     SYSTEMTIME                          m_timerStartTime;
     SYSTEMTIME                          m_timerEndTime;
     std::string                         m_timerStartTimeStr;
@@ -81,7 +99,5 @@ namespace PVR
     bool                                m_bTimerActive;
     int                                 m_selectedChannelEntry;
     std::map<std::pair<bool, int>, int> m_channelEntries;
-
-    CFileItem                          *m_timerItem;
   };
 }

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -634,6 +634,16 @@ void CPVRTimerInfoTag::UpdateChannel(void)
   m_channel = g_PVRChannelGroups->Get(m_bIsRadio)->GetGroupAll()->GetByUniqueID(m_iClientChannelUid, m_iClientId);
 }
 
+void CPVRTimerInfoTag::SetChannel(const CPVRChannelPtr &channel)
+{
+  CSingleLock lock(m_critSection);
+  m_iClientChannelUid = channel->UniqueID();
+  m_iClientId         = channel->ClientID();
+  m_bIsRadio          = channel->IsRadio();
+  m_iChannelNumber    = channel->ChannelNumber();
+  m_channel           = channel;
+}
+
 const std::string& CPVRTimerInfoTag::Title(void) const
 {
   return m_strTitle;

--- a/xbmc/pvr/timers/PVRTimerInfoTag.h
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.h
@@ -165,6 +165,12 @@ namespace PVR
 
     void UpdateChannel(void);
 
+    /*!
+     * @brief Sets a channel for the tag, updates affected members like channel uid accordingly.
+     * @param channel the channel to set.
+     */
+    void SetChannel(const CPVRChannelPtr &channel);
+
     std::string           m_strTitle;           /*!< @brief name of this timer */
     std::string           m_strDirectory;       /*!< @brief directory where the recording must be stored */
     std::string           m_strSummary;         /*!< @brief summary string with the time to show inside a GUI list */


### PR DESCRIPTION
Two fixes:

Bug 1: When in the timer window, select "New Timer", then just hit okay without doing anything else. Results in an error dialog box. New timer gets not created. Reason is that timer tag has now channel set. Commit 1 fixes this.

Bug 2: Since we switched to shared pointers for timer info tags there are no more copies around. With this change, every write to a timer tag (e.g. from inside the timer dialog) modified the original. Thus, if timer dialog is used to modify timer settings those modified values will immediately be written to the original(!) tag. This is no good. Especially, if dialog is aborted instead of closed with okay the modifications done to the tag will no be rolled back. Commit 2 fixes this.
