### PR TITLE
[gui] don't switch to another window if there are active modal dialogs

### DIFF
--- a/addons/skin.confluence/sounds/sounds.xml
+++ b/addons/skin.confluence/sounds/sounds.xml
@@ -66,6 +66,10 @@
       <name>screenshot</name>
       <file>shutter.wav</file>
     </action>
+    <action>
+      <name>error</name>
+      <file>notify.wav</file>
+    </action>
   </actions>
 
   <windows>

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -273,7 +273,8 @@ static const ActionMapping actions[] =
         {"swipeup"           , ACTION_GESTURE_SWIPE_UP},
         {"swipedown"         , ACTION_GESTURE_SWIPE_DOWN},
 
-        // Do nothing action
+        // Do nothing / error action
+        { "error"            , ACTION_ERROR},
         { "noop"             , ACTION_NOOP}
 };
 

--- a/xbmc/input/Key.h
+++ b/xbmc/input/Key.h
@@ -381,7 +381,8 @@
 
 // The NOOP action can be specified to disable an input event. This is
 // useful in user keyboard.xml etc to disable actions specified in the
-// system mappings.
+// system mappings. ERROR action is used to play an error sound
+#define ACTION_ERROR                  998
 #define ACTION_NOOP                   999
 
 #define ICON_TYPE_NONE          101

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -34,6 +34,7 @@
 #include "guilib/GUIKeyboardFactory.h"
 #include "input/Key.h"
 #include "guilib/StereoscopicsManager.h"
+#include "guilib/GUIAudioManager.h"
 #include "dialogs/GUIDialogKaiToast.h"
 #include "dialogs/GUIDialogNumeric.h"
 #include "dialogs/GUIDialogProgress.h"
@@ -300,6 +301,7 @@ bool CBuiltins::ActivateWindow(int iWindowID, const std::vector<std::string>& pa
   if (g_windowManager.HasModalDialog() && !g_windowManager.GetWindow(iWindowID)->IsDialog())
   {
     CLog::Log(LOG_LEVEL_DEBUG, "Activate of window '%i' refused because there are active modal dialogs", iWindowID);
+    g_audioManager.PlayActionSound(CAction(ACTION_ERROR));
     return false;
   }
 

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -294,6 +294,21 @@ void CBuiltins::GetHelp(std::string &help)
   }
 }
 
+bool CBuiltins::ActivateWindow(int iWindowID, const std::vector<std::string>& params /* = {} */, bool swappingWindows /* = false */)
+{
+  // don't activate a window if there are active modal dialogs
+  if (g_windowManager.HasModalDialog() && !g_windowManager.GetWindow(iWindowID)->IsDialog())
+  {
+    CLog::Log(LOG_LEVEL_DEBUG, "Activate of window '%i' refused because there are active modal dialogs", iWindowID);
+    return false;
+  }
+
+  // disable the screensaver
+  g_application.WakeUpScreenSaverAndDPMS();
+  g_windowManager.ActivateWindow(iWindowID, params, swappingWindows);
+  return true;
+}
+
 int CBuiltins::Execute(const std::string& execString)
 {
   // Deprecated. Get the text after the "XBMC."
@@ -442,9 +457,7 @@ int CBuiltins::Execute(const std::string& execString)
       // activate window only if window and path differ from the current active window
       if (iWindow != g_windowManager.GetActiveWindow() || !bIsSameStartFolder)
       {
-        // disable the screensaver
-        g_application.WakeUpScreenSaverAndDPMS();
-        g_windowManager.ActivateWindow(iWindow, params, execute != "activatewindow");
+        return ActivateWindow(iWindow, params, execute != "activatewindow");
       }
     }
     else
@@ -470,10 +483,8 @@ int CBuiltins::Execute(const std::string& execString)
     {
       if (iWindow != g_windowManager.GetActiveWindow())
       {
-        // disable the screensaver
-        g_application.WakeUpScreenSaverAndDPMS();
-        vector<string> dummy;
-        g_windowManager.ActivateWindow(iWindow, dummy, execute != "activatewindowandfocus");
+        if (!ActivateWindow(iWindow, {}, execute != "activatewindowandfocus"))
+          return false;
 
         unsigned int iPtr = 1;
         while (params.size() > iPtr + 1)
@@ -1485,7 +1496,10 @@ int CBuiltins::Execute(const std::string& execString)
     g_application.getNetwork().NetworkMessage(CNetwork::SERVICES_DOWN,1);
     CProfilesManager::Get().LoadMasterProfileForLogin();
     g_passwordManager.bMasterUser = false;
-    g_windowManager.ActivateWindow(WINDOW_LOGIN_SCREEN);
+
+    if (!ActivateWindow(WINDOW_LOGIN_SCREEN))
+      return false;
+
     if (!CNetworkServices::Get().StartEventServer()) // event server could be needed in some situations
       CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Warning, g_localizeStrings.Get(33102), g_localizeStrings.Get(33100));
   }

--- a/xbmc/interfaces/Builtins.h
+++ b/xbmc/interfaces/Builtins.h
@@ -21,6 +21,7 @@
  */
 
 #include <string>
+#include <vector>
 
 class CBuiltins
 {
@@ -29,5 +30,8 @@ public:
   static bool IsSystemPowerdownCommand(const std::string& execString);
   static void GetHelp(std::string &help);
   static int Execute(const std::string& execString);
+
+private:
+  static bool ActivateWindow(int iWindowID, const std::vector<std::string>& params = {}, bool swappingWindows = false);
 };
 

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -237,9 +237,6 @@ bool CGUIMediaWindow::OnMessage(CGUIMessage& message)
       m_iLastControl = GetFocusedControlID();
       CGUIWindow::OnMessage(message);
 
-      // Close all open modal dialogs
-      g_windowManager.CloseModalDialogs(true);
-
       // get rid of any active filtering
       if (m_canFilterAdvanced)
       {


### PR DESCRIPTION
With this Kodi behaves like every other (desktop) application where you can't jump over to another
window if you have open modal dialogs. This only prevents the user from switching to another window which means only if the user actively trigger the window change by a remote key or built-in.

Now we can safely remove the call to `CloseModalDialog()` which introduced some regressions in combination with our python dialogs. Which is done in the first commit.

@mkortstiege @Montellese mind taking a look
@ruuk your python test scripts works as expected
@AlwinEsch as a hint
