### PR TITLE
dvdplayer: Always display some subtitles when subtitles are enabled.

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -889,9 +889,7 @@ void CDVDPlayer::OpenDefaultStreams(bool reset)
     if(OpenStream(m_CurrentSubtitle, it->id, it->source))
     {
       valid = true;
-      if(!psp.relevant(*it))
-        visible = false;
-      else if(it->flags & CDemuxStream::FLAG_FORCED)
+      if (it->flags & CDemuxStream::FLAG_FORCED)
         visible = true;
     }
   }


### PR DESCRIPTION
Consider the following use case.  A video library containing two mkv
files 'A.mkv' and 'B.mkv', both of which have a video stream, audio
stream, and single subtitle stream.  My real problem is that non of the
substitle streams are marked as default.

While watching file 'A.mkv' the user uses the audio/subtitle menu to
'Enable subtitles' and selects subtitle stream 1 (the only one
available). The user then does 'Set as default for all videos'.

Next the users stops watching 'A.mkv' and starts 'B.mkv'.  My
expectation would be that the subtitles should display.  However this is
not currently the case.

This used to be the case in older releases of xbmc (as it was then),
however, this behaviour stopped with commit 30e103633a1d4d0, it is hard
to judge from the commit message, but I find it hard to believe this was
an intended side effect.

Here's the interesting part of commit 30e103633a1d4d0:

```
diff --git a/xbmc/cores/dvdplayer/DVDPlayer.cpp b/xbmc/cores/dvdplayer/DVDPlayer.cpp
index 4093974..614dbc6 100644
--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -3025,7 +3024,6 @@ bool CDVDPlayer::OpenSubtitleStream(CDVDStreamInfo& hint)
   if(!OpenStreamPlayer(m_CurrentSubtitle, hint, true))
     return false;

-  CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleStream = GetSubtitle();
   return true;
 }
```

The problem after this commit is that m_SubtitleStream is no longer
updated.  As a result none of the subtitle streams are recognised as
being relevant (non pass the PredicateSubtitleFilter::operator()
filter).

Obviously the user should mark one of the subtitle streams as default in
order to get the best behaviour, but it still feels like it should be
possible to have some kind of fall-back behaviour where turning on
subtitles everywhere tries to pick some kind of relevant subtitle
stream.

This patch tries to address this issue by adjusting the stream selection
logic in CDVDPlayer::OpenDefaultStreams.  The available subtitles are
returned in a priority order.  The first subtitle stream that can be
opened is considered.  Previously if this stream was not relevant then
the subtitle was disabled, now, if the user has turned subtitles on,
then the first subtitle stream to open (from the ordered list) is used.
