### PR TITLE
[addons] adjustments and fixes to new manager layout

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -12979,11 +12979,7 @@ msgctxt "#24996"
 msgid "Required Dependencies"
 msgstr ""
 
-#: xbmc/addons/CGUIViewStateAddonBrowser.cpp
-#: xbmc/filesystem/AddonsDirectory.cpp
-msgctxt "#24997"
-msgid "System Add-ons"
-msgstr ""
+#empty string id 24997
 
 #: xbmc/addons/CGUIViewStateAddonBrowser.cpp
 #: xbmc/filesystem/AddonsDirectory.cpp

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -12947,7 +12947,13 @@ msgctxt "#24134"
 msgid "We were unable to load your configured language. Please check your language settings."
 msgstr ""
 
-#empty strings from id 24135 to 24992
+#empty strings from id 24135 to 24991
+
+#: xbmc/addons/CGUIViewStateAddonBrowser.cpp
+#: xbmc/filesystem/AddonsDirectory.cpp
+msgctxt "#24992"
+msgid "System"
+msgstr ""
 
 #: xbmc/addons/CGUIViewStateAddonBrowser.cpp
 #: xbmc/filesystem/AddonsDirectory.cpp

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -12981,7 +12981,7 @@ msgstr ""
 #: xbmc/addons/CGUIViewStateAddonBrowser.cpp
 #: xbmc/filesystem/AddonsDirectory.cpp
 msgctxt "#24996"
-msgid "Required Dependencies"
+msgid "Dependencies"
 msgstr ""
 
 #empty string id 24997

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -2547,6 +2547,11 @@ msgctxt "#592"
 msgid "One"
 msgstr ""
 
+#: xbmc/dialogs/GUIDialogMediaFilter.cpp
+#: xbmc/filesystem/AddonsDirectory.cpp
+#: xbmc/PlayListPlayer.cpp
+#: xbmc/profiles/dialogs/GUIDialogLockSettings.cpp
+#: xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
 msgctxt "#593"
 msgid "All"
 msgstr ""

--- a/xbmc/addons/GUIViewStateAddonBrowser.cpp
+++ b/xbmc/addons/GUIViewStateAddonBrowser.cpp
@@ -79,34 +79,6 @@ VECSOURCES& CGUIViewStateAddonBrowser::GetSources()
     share.strName = g_localizeStrings.Get(24043); // "Available updates"
     m_sources.push_back(share);
   }
-  {
-    CMediaSource share;
-    share.strPath = "addons://dependencies/";
-    share.m_iDriveType = CMediaSource::SOURCE_TYPE_LOCAL;
-    share.strName = g_localizeStrings.Get(24996);
-    m_sources.push_back(share);
-  }
-  {
-    CMediaSource share;
-    share.strPath = "addons://orphaned/";
-    share.m_iDriveType = CMediaSource::SOURCE_TYPE_LOCAL;
-    share.strName = g_localizeStrings.Get(24995);
-    m_sources.push_back(share);
-  }
-  {
-    CMediaSource share;
-    share.strPath = "addons://system/";
-    share.m_iDriveType = CMediaSource::SOURCE_TYPE_LOCAL;
-    share.strName = g_localizeStrings.Get(24997);
-    m_sources.push_back(share);
-  }
-  {
-    CMediaSource share;
-    share.strPath = "addons://running/";
-    share.m_iDriveType = CMediaSource::SOURCE_TYPE_LOCAL;
-    share.strName = g_localizeStrings.Get(24994);
-    m_sources.push_back(share);
-  }
   if (CAddonMgr::Get().HasAddons(ADDON_REPOSITORY, true))
   {
     CMediaSource share;
@@ -127,6 +99,13 @@ VECSOURCES& CGUIViewStateAddonBrowser::GetSources()
     share.strPath = "addons://search/";
     share.m_iDriveType = CMediaSource::SOURCE_TYPE_LOCAL;
     share.strName = g_localizeStrings.Get(137);
+    m_sources.push_back(share);
+  }
+  {
+    CMediaSource share;
+    share.strPath = "addons://manage/";
+    share.m_iDriveType = CMediaSource::SOURCE_TYPE_LOCAL;
+    share.strName = g_localizeStrings.Get(24992);
     m_sources.push_back(share);
   }
 

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -72,20 +72,20 @@ static bool IsInfoProviderType(const AddonPtr& addon)
   return std::find(infoProviderTypes.begin(), infoProviderTypes.end(), addon->Type()) != infoProviderTypes.end();
 }
 
-bool IsSystemAddon(const AddonPtr& addon)
+static bool IsSystemAddon(const AddonPtr& addon)
 {
   return StringUtils::StartsWith(addon->Path(), CSpecialProtocol::TranslatePath("special://xbmc/addons"));
 }
 
 
-bool IsUserInstalled(const AddonPtr& addon)
+static bool IsUserInstalled(const AddonPtr& addon)
 {
   return std::find_if(dependencyTypes.begin(), dependencyTypes.end(),
       [&](TYPE type){ return addon->IsType(type); }) == dependencyTypes.end();
 }
 
 
-bool IsOrphaned(const AddonPtr& addon, const VECADDONS& all)
+static bool IsOrphaned(const AddonPtr& addon, const VECADDONS& all)
 {
   if (IsSystemAddon(addon) || IsUserInstalled(addon))
     return false;
@@ -100,7 +100,7 @@ bool IsOrphaned(const AddonPtr& addon, const VECADDONS& all)
 }
 
 
-void SetUpdateAvailProperties(CFileItemList &items)
+static void SetUpdateAvailProperties(CFileItemList &items)
 {
   CAddonDatabase database;
   database.Open();
@@ -140,7 +140,7 @@ bool CAddonsDirectory::GetSearchResults(const CURL& path, CFileItemList &items)
   return true;
 }
 
-void UserInstalledAddons(const CURL& path, CFileItemList &items)
+static void UserInstalledAddons(const CURL& path, CFileItemList &items)
 {
   VECADDONS addons;
   CAddonMgr::Get().GetAllAddons(addons, true);
@@ -151,7 +151,7 @@ void UserInstalledAddons(const CURL& path, CFileItemList &items)
   SetUpdateAvailProperties(items);
 }
 
-void DependencyAddons(const CURL& path, CFileItemList &items)
+static void DependencyAddons(const CURL& path, CFileItemList &items)
 {
   VECADDONS all;
   CAddonMgr::Get().GetAllAddons(all, true);
@@ -165,7 +165,7 @@ void DependencyAddons(const CURL& path, CFileItemList &items)
   SetUpdateAvailProperties(items);
 }
 
-void OrphanedAddons(const CURL& path, CFileItemList &items)
+static void OrphanedAddons(const CURL& path, CFileItemList &items)
 {
   VECADDONS all;
   CAddonMgr::Get().GetAllAddons(all, true);
@@ -187,7 +187,7 @@ static bool HaveOrphaned()
                      [&](const AddonPtr& _){ return IsOrphaned(_, addons); });
 }
 
-void OutdatedAddons(const CURL& path, CFileItemList &items)
+static void OutdatedAddons(const CURL& path, CFileItemList &items)
 {
   VECADDONS addons;
   // Wait for running update to complete
@@ -204,7 +204,7 @@ void OutdatedAddons(const CURL& path, CFileItemList &items)
   }
 }
 
-void RunningAddons(const CURL& path, CFileItemList &items)
+static void RunningAddons(const CURL& path, CFileItemList &items)
 {
   VECADDONS addons;
   CAddonMgr::Get().GetAddons(ADDON_SERVICE, addons);
@@ -214,7 +214,7 @@ void RunningAddons(const CURL& path, CFileItemList &items)
   CAddonsDirectory::GenerateAddonListing(path, addons, items, g_localizeStrings.Get(24994));
 }
 
-bool Browse(const CURL& path, CFileItemList &items)
+static bool Browse(const CURL& path, CFileItemList &items)
 {
   const std::string repo = path.GetHostName();
   const std::string category = path.GetFileName();
@@ -313,7 +313,7 @@ bool Browse(const CURL& path, CFileItemList &items)
 }
 
 
-bool Repos(const CURL& path, CFileItemList &items)
+static bool Repos(const CURL& path, CFileItemList &items)
 {
   items.SetLabel(g_localizeStrings.Get(24033));
 

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -472,6 +472,17 @@ bool CAddonsDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   }
 }
 
+bool CAddonsDirectory::IsRepoDirectory(const CURL& url)
+{
+  if (url.GetHostName().empty() || !url.IsProtocol("addons"))
+    return false;
+
+  AddonPtr tmp;
+  return url.GetHostName() == "repos"
+      || url.GetHostName() == "all"
+      || url.GetHostName() == "search"
+      || CAddonMgr::Get().GetAddon(url.GetHostName(), tmp, ADDON_REPOSITORY);
+}
 
 void CAddonsDirectory::GenerateAddonListing(const CURL &path,
                                             const VECADDONS& addons,

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -67,6 +67,11 @@ const std::array<TYPE, 5> infoProviderTypes = {
 };
 
 
+static bool IsInfoProviderType(const AddonPtr& addon)
+{
+  return std::find(infoProviderTypes.begin(), infoProviderTypes.end(), addon->Type()) != infoProviderTypes.end();
+}
+
 bool IsSystemAddon(const AddonPtr& addon)
 {
   return StringUtils::StartsWith(addon->Path(), CSpecialProtocol::TranslatePath("special://xbmc/addons"));
@@ -254,6 +259,7 @@ bool Browse(const CURL& path, CFileItemList &items)
 
   if (category.empty())
   {
+    if (std::any_of(addons.begin(), addons.end(), IsInfoProviderType))
     {
       CFileItemPtr item(new CFileItem(g_localizeStrings.Get(24993)));
       item->SetPath(URIUtils::AddFileToFolder(path.Get(), "group.infoproviders"));

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -23,6 +23,7 @@
 #include <functional>
 #include "AddonsDirectory.h"
 #include "addons/AddonDatabase.h"
+#include "interfaces/generic/ScriptInvocationManager.h"
 #include "DirectoryFactory.h"
 #include "Directory.h"
 #include "DirectoryCache.h"
@@ -205,9 +206,11 @@ void OutdatedAddons(const CURL& path, CFileItemList &items)
 void RunningAddons(const CURL& path, CFileItemList &items)
 {
   VECADDONS addons;
-  CAddonMgr::Get().GetAddons(ADDON_SERVICE, addons, true);
+  CAddonMgr::Get().GetAddons(ADDON_SERVICE, addons);
+
+  addons.erase(std::remove_if(addons.begin(), addons.end(),
+      [](const AddonPtr& addon){ return !CScriptInvocationManager::Get().IsRunning(addon->LibPath()); }), addons.end());
   CAddonsDirectory::GenerateAddonListing(path, addons, items, g_localizeStrings.Get(24994));
-  //TODO: include web interfaces if web server is running
 }
 
 bool Browse(const CURL& path, CFileItemList &items)

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -366,6 +366,7 @@ static bool Repos(const CURL& path, CFileItemList &items)
   {
     CFileItemPtr item(new CFileItem("addons://all/", true));
     item->SetLabel(g_localizeStrings.Get(24087));
+    item->SetSpecialSort(SortSpecialOnTop);
     items.Add(item);
   }
 

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -187,6 +187,15 @@ void OrphanedAddons(const CURL& path, CFileItemList &items)
   CAddonsDirectory::GenerateAddonListing(path, orphaned, items, g_localizeStrings.Get(24995));
 }
 
+static bool HaveOrphaned()
+{
+  VECADDONS addons;
+  CAddonMgr::Get().GetAllAddons(addons, true);
+  CAddonMgr::Get().GetAllAddons(addons, false);
+  return std::any_of(addons.begin(), addons.end(),
+                     [&](const AddonPtr& _){ return IsOrphaned(_, addons); });
+}
+
 void OutdatedAddons(const CURL& path, CFileItemList &items)
 {
   VECADDONS addons;
@@ -348,6 +357,7 @@ static void Manage(CFileItemList &items)
     item->SetSpecialSort(SortSpecialOnTop);
     items.Add(item);
   }
+  if (HaveOrphaned())
   {
     CFileItemPtr item(new CFileItem("addons://orphaned/", true));
     item->SetLabel(g_localizeStrings.Get(24995));

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -337,6 +337,35 @@ bool Repos(const CURL& path, CFileItemList &items)
   return true;
 }
 
+static void Manage(CFileItemList &items)
+{
+  items.SetLabel(g_localizeStrings.Get(24992));
+
+  {
+    CFileItemPtr item(new CFileItem("addons://dependencies/", true));
+    item->SetLabel(g_localizeStrings.Get(24996));
+    item->SetSpecialSort(SortSpecialOnTop);
+    items.Add(item);
+  }
+  {
+    CFileItemPtr item(new CFileItem("addons://orphaned/", true));
+    item->SetLabel(g_localizeStrings.Get(24995));
+    item->SetSpecialSort(SortSpecialOnTop);
+    items.Add(item);
+  }
+  {
+    CFileItemPtr item(new CFileItem("addons://system/", true));
+    item->SetLabel(g_localizeStrings.Get(24997));
+    item->SetSpecialSort(SortSpecialOnTop);
+    items.Add(item);
+  }
+  {
+    CFileItemPtr item(new CFileItem("addons://running/", true));
+    item->SetLabel(g_localizeStrings.Get(24994));
+    item->SetSpecialSort(SortSpecialOnTop);
+    items.Add(item);
+  }
+}
 
 bool CAddonsDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 {
@@ -400,6 +429,11 @@ bool CAddonsDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   else if (endpoint == "search")
   {
     return GetSearchResults(path, items);
+  }
+  else if (endpoint == "manage")
+  {
+    Manage(items);
+    return true;
   }
   else
   {

--- a/xbmc/filesystem/AddonsDirectory.h
+++ b/xbmc/filesystem/AddonsDirectory.h
@@ -65,6 +65,9 @@ namespace XFILE
     static void GenerateAddonListing(const CURL &path, const ADDON::VECADDONS& addons, CFileItemList &items, const std::string label);
     static CFileItemPtr FileItemFromAddon(const ADDON::AddonPtr &addon, const std::string& path, bool folder = false);
   
+    /*! \brief Returns true if `path` is a path or subpath of the repository directory, otherwise false */
+    static bool IsRepoDirectory(const CURL& path);
+
   private:
     bool GetSearchResults(const CURL& path, CFileItemList &items);
   };

--- a/xbmc/interfaces/generic/ScriptInvocationManager.cpp
+++ b/xbmc/interfaces/generic/ScriptInvocationManager.cpp
@@ -304,6 +304,16 @@ bool CScriptInvocationManager::IsRunning(int scriptId) const
   return !invokerThread.done;
 }
 
+bool CScriptInvocationManager::IsRunning(const std::string& scriptPath) const
+{
+  CSingleLock lock(m_critSection);
+  auto it = m_scriptPaths.find(scriptPath);
+  if (it == m_scriptPaths.end())
+    return false;
+
+  return IsRunning(it->second);
+}
+
 void CScriptInvocationManager::OnScriptEnded(int scriptId)
 {
   if (scriptId < 0)

--- a/xbmc/interfaces/generic/ScriptInvocationManager.h
+++ b/xbmc/interfaces/generic/ScriptInvocationManager.h
@@ -103,6 +103,7 @@ public:
   bool Stop(const std::string &scriptPath, bool wait = false);
 
   bool IsRunning(int scriptId) const;
+  bool IsRunning(const std::string& scriptPath) const;
 
 protected:
   friend class CLanguageInvokerThread;


### PR DESCRIPTION
This tries to address some of the feedback from #5862 with some small changes to the layout and other improvements.
- "Hides" the dependencies/running listing in a "Manage" sub-menu.
- Removes 'System add-on' showing these in My addons and Required dependencies instead.
- Categorizes 'My addons' (optional)
