### PR TITLE
changed: Improve error handling for video db export

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -6975,7 +6975,12 @@ msgctxt "#14110"
 msgid "Long date format"
 msgstr ""
 
-#empty strings from id 14111 to 15011
+#empty strings from id 14111 to 15010
+
+#: xbmc/video/VideoDatabase.cpp
+msgctxt "#15011"
+msgid "%i Items failed to export"
+msgstr ""
 
 #: xbmc/video/VideoDatabase.cpp
 msgctxt "#15012"
@@ -10375,7 +10380,7 @@ msgid "Unable to write to folder:"
 msgstr ""
 
 msgctxt "#20303"
-msgid "Do you want to skip and proceed?"
+msgid ""
 msgstr ""
 
 #: xbmc/network/GUIDialogNetworkSetup.cpp

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -4803,6 +4803,7 @@ std::string CMusicDatabase::GetItemById(const std::string &itemType, int id)
 
 void CMusicDatabase::ExportToXML(const std::string &xmlFile, bool singleFiles, bool images, bool overwrite)
 {
+  CGUIDialogProgress *progress=NULL;
   try
   {
     if (NULL == m_pDB.get()) return;
@@ -4825,7 +4826,7 @@ void CMusicDatabase::ExportToXML(const std::string &xmlFile, bool singleFiles, b
     }
     m_pDS->close();
 
-    CGUIDialogProgress *progress = (CGUIDialogProgress *)g_windowManager.GetWindow(WINDOW_DIALOG_PROGRESS);
+    progress = (CGUIDialogProgress *)g_windowManager.GetWindow(WINDOW_DIALOG_PROGRESS);
     if (progress)
     {
       progress->SetHeading(20196);
@@ -4969,15 +4970,15 @@ void CMusicDatabase::ExportToXML(const std::string &xmlFile, bool singleFiles, b
       current++;
     }
 
-    if (progress)
-      progress->Close();
-
     xmlDoc.SaveFile(xmlFile);
   }
   catch (...)
   {
     CLog::Log(LOGERROR, "%s failed", __FUNCTION__);
   }
+
+  if (progress)
+    progress->Close();
 }
 
 void CMusicDatabase::ImportFromXML(const std::string &xmlFile)

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -41,6 +41,7 @@
 #include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogProgress.h"
 #include "dialogs/GUIDialogYesNo.h"
+#include "dialogs/GUIDialogKaiToast.h"
 #include "dialogs/GUIDialogSelect.h"
 #include "filesystem/File.h"
 #include "profiles/ProfilesManager.h"
@@ -4803,6 +4804,7 @@ std::string CMusicDatabase::GetItemById(const std::string &itemType, int id)
 
 void CMusicDatabase::ExportToXML(const std::string &xmlFile, bool singleFiles, bool images, bool overwrite)
 {
+  int iFailCount = 0;
   CGUIDialogProgress *progress=NULL;
   try
   {
@@ -4867,7 +4869,11 @@ void CMusicDatabase::ExportToXML(const std::string &xmlFile, bool singleFiles, b
           if (overwrite || !CFile::Exists(nfoFile))
           {
             if (!xmlDoc.SaveFile(nfoFile))
+            {
               CLog::Log(LOGERROR, "%s: Album nfo export failed! ('%s')", __FUNCTION__, nfoFile.c_str());
+              CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, g_localizeStrings.Get(20302), nfoFile);
+              iFailCount++;
+            }
           }
 
           if (images)
@@ -4937,7 +4943,11 @@ void CMusicDatabase::ExportToXML(const std::string &xmlFile, bool singleFiles, b
           if (overwrite || !CFile::Exists(nfoFile))
           {
             if (!xmlDoc.SaveFile(nfoFile))
+            {
               CLog::Log(LOGERROR, "%s: Artist nfo export failed! ('%s')", __FUNCTION__, nfoFile.c_str());
+              CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, g_localizeStrings.Get(20302), nfoFile);
+              iFailCount++;
+            }
           }
 
           if (images && !artwork.empty())
@@ -4975,10 +4985,14 @@ void CMusicDatabase::ExportToXML(const std::string &xmlFile, bool singleFiles, b
   catch (...)
   {
     CLog::Log(LOGERROR, "%s failed", __FUNCTION__);
+    iFailCount++;
   }
 
   if (progress)
     progress->Close();
+
+  if (iFailCount > 0)
+    CGUIDialogOK::ShowAndGetInput(g_localizeStrings.Get(20196), StringUtils::Format(g_localizeStrings.Get(15011).c_str(), iFailCount), "", "");
 }
 
 void CMusicDatabase::ImportFromXML(const std::string &xmlFile)

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -724,7 +724,6 @@ public:
   void UpdateFileDateAdded(int idFile, const std::string& strFileNameAndPath);
 
   void ExportToXML(const std::string &path, bool singleFiles = false, bool images=false, bool actorThumbs=false, bool overwrite=false);
-  bool ExportSkipEntry(const std::string &nfoFile);
   void ExportActorThumbs(const std::string &path, const CVideoInfoTag& tag, bool singleFiles, bool overwrite=false);
   void ImportFromXML(const std::string &path);
   void DumpToDummyFiles(const std::string &path);


### PR DESCRIPTION
Previously when users exported their video library and they had e.g. sources that were for some reason not writable (although we assume they are), an error dialog would popup for every single item failing to export. This PR changes this behavior by allowing the user to ignore all remaining errors at the first failure.

As an alternative we could also silently ignore all errors (like is already the case with the music db) and report number of errors when done. Ideas?
