### PR TITLE
[addons] lazy load translated context item label

### DIFF
--- a/xbmc/addons/ContextItemAddon.cpp
+++ b/xbmc/addons/ContextItemAddon.cpp
@@ -50,9 +50,6 @@ CContextItemAddon::CContextItemAddon(const cp_extension_t *ext)
     cp_cfg_element_t *item = items[0];
 
     m_label = CAddonMgr::Get().GetExtValue(item, "label");
-    if (StringUtils::IsNaturalNumber(m_label))
-      m_label = GetString(boost::lexical_cast<int>(m_label.c_str()));
-
     m_parent = CAddonMgr::Get().GetExtValue(item, "parent");
 
     string visible = CAddonMgr::Get().GetExtValue(item, "visible");
@@ -61,6 +58,13 @@ CContextItemAddon::CContextItemAddon(const cp_extension_t *ext)
 
     m_visCondition = g_infoManager.Register(visible, 0);
   }
+}
+
+std::string CContextItemAddon::GetLabel()
+{
+  if (StringUtils::IsNaturalNumber(m_label))
+    return GetString(boost::lexical_cast<int>(m_label.c_str()));
+  return m_label;
 }
 
 bool CContextItemAddon::IsVisible(const CFileItemPtr& item) const

--- a/xbmc/addons/ContextItemAddon.h
+++ b/xbmc/addons/ContextItemAddon.h
@@ -41,7 +41,7 @@ namespace ADDON
     CContextItemAddon(const AddonProps &props);
     virtual ~CContextItemAddon();
 
-    const std::string& GetLabel() const { return m_label; }
+    std::string GetLabel();
 
     /*!
      * \brief Get the parent category of this context item.


### PR DESCRIPTION
Turns out _a lot_ of addon instances where the label is never used are created and immediately destroyed by other parts than the context menu. This moves the call to `GetString` out of the constructor to avoid loading of language files and IO for those case; (if I understood this correctly).

This is the second time I'm changing this part so I could really use some feedback. Ping @alanwww1 
