### PR TITLE
[Default Webinterface] make addon name more descriptive

### DIFF
--- a/addons/webinterface.default/addon.xml
+++ b/addons/webinterface.default/addon.xml
@@ -2,7 +2,7 @@
 <addon
   id="webinterface.default"
   version="2.2.21"
-  name="Default"
+  name="Default webinterface"
   provider-name="Team-Kodi">
   <requires>
     <import addon="xbmc.json" version="6.0.0"/>


### PR DESCRIPTION
The new addon manager layout the active addons category just Lists name "Default", you have to scroll all way to it to see what "Default" is.

Like this should make it slightly more recognizable. I was going to just call it Webinterface because Default is already implied but doesn't hurt in any case.

@MartijnKaijser 
