### PR TITLE
[Fix] dvdplayer: Only one (external) vobsub could be displayed due to a ...

### DIFF
--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxVobsub.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxVobsub.cpp
@@ -45,9 +45,10 @@ CDVDDemuxVobsub::~CDVDDemuxVobsub()
   m_Streams.clear();
 }
 
-bool CDVDDemuxVobsub::Open(const string& filename, const string& subfilename)
+bool CDVDDemuxVobsub::Open(const string& filename, int source, const string& subfilename)
 {
   m_Filename = filename;
+  m_source = source;
 
   unique_ptr<CDVDSubtitleStream> pStream(new CDVDSubtitleStream());
   if(!pStream->Open(filename))
@@ -214,7 +215,7 @@ bool CDVDDemuxVobsub::ParseId(SState& state, char* line)
 
   stream->codec = AV_CODEC_ID_DVD_SUBTITLE;
   stream->iId = m_Streams.size();
-  stream->source = STREAM_SOURCE_DEMUX_SUB;
+  stream->source = m_source;
 
   state.id = stream->iId;
   m_Streams.push_back(stream.release());

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxVobsub.h
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxVobsub.h
@@ -35,7 +35,6 @@ public:
   CDVDDemuxVobsub();
   virtual ~CDVDDemuxVobsub();
 
-  virtual bool          Open(const std::string& filename, const std::string& subfilename = "");
   virtual void          Reset();
   virtual void          Abort() {};
   virtual void          Flush();
@@ -46,6 +45,8 @@ public:
   virtual int           GetNrOfStreams()     { return m_Streams.size(); }
   virtual int           GetStreamLength()    { return 0; }
   virtual std::string   GetFileName()        { return m_Filename; }
+
+  bool                  Open(const std::string& filename, int source, const std::string& subfilename);
 
 private:
   class CStream
@@ -75,6 +76,7 @@ private:
   std::vector<STimestamp>            m_Timestamps;
   std::vector<STimestamp>::iterator  m_Timestamp;
   std::vector<CStream*> m_Streams;
+  int m_source;
 
   typedef struct SState
   {

--- a/xbmc/cores/dvdplayer/DVDFileInfo.cpp
+++ b/xbmc/cores/dvdplayer/DVDFileInfo.cpp
@@ -467,7 +467,7 @@ bool CDVDFileInfo::AddExternalSubtitleToDetails(const std::string &path, CStream
       vobsubfile = URIUtils::ReplaceExtension(filename, ".sub");
 
     CDVDDemuxVobsub v;
-    if(!v.Open(filename, vobsubfile))
+    if (!v.Open(filename, STREAM_SOURCE_NONE, vobsubfile))
       return false;
 
     int count = v.GetNrOfStreams();

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -3169,7 +3169,7 @@ bool CDVDPlayer::OpenStream(CCurrentStream& current, int iStream, int source, bo
     {
       CLog::Log(LOGNOTICE, "Opening Subtitle file: %s", st.filename.c_str());
       unique_ptr<CDVDDemuxVobsub> demux(new CDVDDemuxVobsub());
-      if(!demux->Open(st.filename, st.filename2))
+      if(!demux->Open(st.filename, source, st.filename2))
         return false;
       m_pSubtitleDemuxer = demux.release();
     }
@@ -4232,7 +4232,7 @@ int CDVDPlayer::AddSubtitleFile(const std::string& filename, const std::string& 
     }
 
     CDVDDemuxVobsub v;
-    if(!v.Open(filename, vobsubfile))
+    if (!v.Open(filename, STREAM_SOURCE_NONE, vobsubfile))
       return -1;
     m_SelectionStreams.Update(NULL, &v, vobsubfile);
     int index = m_SelectionStreams.IndexOf(STREAM_SUBTITLE, m_SelectionStreams.Source(STREAM_SOURCE_DEMUX_SUB, filename), 0);


### PR DESCRIPTION
...wrong source numeration.

@mkortstiege for testing.
@FernetMenta for review. A less intrusive fix would be to set the source here:numeration via `if(vobsubdemuxer) {demuxer->setSource()}` What so you think?
