### PR TITLE
[keyboardlayouts] add some symbol keys to english qwerty layout

### DIFF
--- a/system/keyboardlayouts/english.xml
+++ b/system/keyboardlayouts/english.xml
@@ -9,13 +9,13 @@ Default font lacks support for all characters
       <row>1234567890-=</row>
       <row>qwertyuiop[]</row>
       <row>asdfghjkl;'</row>
-      <row>zxcvbnm,./</row>
+      <row>zxcvbnm,./@</row>
     </keyboard>
     <keyboard modifiers="shift">
-      <row>!@#$%^&amp;*()_+</row>
+      <row>1234567890_+</row>
       <row>QWERTYUIOP{}</row>
       <row>ASDFGHJKL:"</row>
-      <row>ZXCVBNM&lt;&gt;?</row>
+      <row>ZXCVBNM&lt;&gt;?@</row>
     </keyboard>
     <keyboard modifiers="symbol,shift+symbol">
       <row>)!@#$%^&amp;*(</row>

--- a/system/keyboardlayouts/english.xml
+++ b/system/keyboardlayouts/english.xml
@@ -6,16 +6,16 @@ Default font lacks support for all characters
 <keyboardlayouts>
   <layout language="English" layout="QWERTY">
     <keyboard>
-      <row>1234567890</row>
-      <row>qwertyuiop</row>
-      <row>asdfghjkl</row>
-      <row>zxcvbnm</row>
+      <row>1234567890-=</row>
+      <row>qwertyuiop[]</row>
+      <row>asdfghjkl;'</row>
+      <row>zxcvbnm,./</row>
     </keyboard>
     <keyboard modifiers="shift">
-      <row>1234567890</row>
-      <row>QWERTYUIOP</row>
-      <row>ASDFGHJKL</row>
-      <row>ZXCVBNM</row>
+      <row>!@#$%^&amp;*()_+</row>
+      <row>QWERTYUIOP{}</row>
+      <row>ASDFGHJKL:"</row>
+      <row>ZXCVBNM&lt;&gt;?</row>
     </keyboard>
     <keyboard modifiers="symbol,shift+symbol">
       <row>)!@#$%^&amp;*(</row>


### PR DESCRIPTION
now, it should be easier (less clicks) to type in email
addresses and urls

http://i.imgur.com/ZADSmnD.png
http://i.imgur.com/f5ODWgt.png

all syms are still available in "symbol" mode.

//cc @Montellese @ronie do we want this ?
