### PR TITLE
[gui] reduce code duplication for mass dialog close

### DIFF
--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -818,7 +818,7 @@ void CGUIWindowManager::CloseModalDialogs(bool forceClose) const
   CSingleLock lock(g_graphicsContext);
   for (const auto& dialog : m_activeDialogs)
   {
-    if (dialog->IsModalDialog())
+    if (dialog->IsModalDialog() && !IsAddonWindow(dialog->GetID()) && !IsPythonWindow(dialog->GetID()))
       dialog->Close(forceClose);
   }
 }

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -813,7 +813,7 @@ void CGUIWindowManager::CloseDialogs(bool forceClose) const
   }
 }
 
-void CGUIWindowManager::CloseModalDialogs(bool forceClose) const
+void CGUIWindowManager::CloseInternalModalDialogs(bool forceClose) const
 {
   CSingleLock lock(g_graphicsContext);
   for (const auto& dialog : m_activeDialogs)

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -152,6 +152,16 @@ public:
   bool IsWindowVisible(const std::string &xmlFile) const;
   bool IsWindowTopMost(const std::string &xmlFile) const;
   bool IsOverlayAllowed() const;
+  /*! \brief Checks if the given window is an addon window.
+   *
+   * \return true if the given window is an addon window, otherwise false.
+   */
+  bool IsAddonWindow(int id) const { return (id >= WINDOW_ADDON_START && id <= WINDOW_ADDON_END); };
+  /*! \brief Checks if the given window is a python window.
+   *
+   * \return true if the given window is a python window, otherwise false.
+   */
+  bool IsPythonWindow(int id) const { return (id >= WINDOW_PYTHON_START && id <= WINDOW_PYTHON_END); };
   void ShowOverlay(CGUIWindow::OVERLAY_STATE state);
   void GetActiveModelessWindows(std::vector<int> &ids);
 #ifdef _DEBUG

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -64,7 +64,7 @@ public:
   void PreviousWindow();
 
   void CloseDialogs(bool forceClose = false) const;
-  void CloseModalDialogs(bool forceClose = false) const;
+  void CloseInternalModalDialogs(bool forceClose = false) const;
 
   // OnAction() runs through our active dialogs and windows and sends the message
   // off to the callbacks (application, python, playlist player) and to the

--- a/xbmc/music/dialogs/GUIDialogMusicOSD.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicOSD.cpp
@@ -64,21 +64,6 @@ bool CGUIDialogMusicOSD::OnMessage(CGUIMessage &message)
       return true;
     }
     break;
-  case GUI_MSG_WINDOW_DEINIT:  // fired when OSD is hidden
-    {
-      CGUIDialog *pDialog;
-
-      pDialog = (CGUIDialog *)g_windowManager.GetWindow(WINDOW_DIALOG_PVR_OSD_CHANNELS);
-      if (pDialog && pDialog->IsDialogRunning())
-        pDialog->Close(true);
-      pDialog = (CGUIDialog *)g_windowManager.GetWindow(WINDOW_DIALOG_PVR_OSD_GUIDE);
-      if (pDialog && pDialog->IsDialogRunning())
-        pDialog->Close(true);
-      pDialog = (CGUIDialog *)g_windowManager.GetWindow(WINDOW_DIALOG_OSD_TELETEXT);
-      if (pDialog && pDialog->IsDialogRunning())
-        pDialog->Close(true);
-    }
-    break;
   }
   return CGUIDialog::OnMessage(message);
 }

--- a/xbmc/music/windows/GUIWindowVisualisation.cpp
+++ b/xbmc/music/windows/GUIWindowVisualisation.cpp
@@ -152,11 +152,9 @@ bool CGUIWindowVisualisation::OnMessage(CGUIMessage& message)
     {
       if (IsActive()) // save any changed settings from the OSD
         CSettings::Get().Save();
-      // check and close any OSD windows
-      CGUIDialogMusicOSD *pOSD = (CGUIDialogMusicOSD *)g_windowManager.GetWindow(WINDOW_DIALOG_MUSIC_OSD);
-      if (pOSD && pOSD->IsDialogRunning()) pOSD->Close(true);
-      CGUIDialogVisualisationPresetList *pList = (CGUIDialogVisualisationPresetList *)g_windowManager.GetWindow(WINDOW_DIALOG_VIS_PRESET_LIST);
-      if (pList && pList->IsDialogRunning()) pList->Close(true);
+
+      // close all active modal dialogs
+      g_windowManager.CloseInternalModalDialogs(true);
     }
     break;
   case GUI_MSG_WINDOW_INIT:

--- a/xbmc/video/dialogs/GUIDialogVideoOSD.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoOSD.cpp
@@ -95,29 +95,6 @@ bool CGUIDialogVideoOSD::OnMessage(CGUIMessage& message)
       Close();
     }
     break;
-  case GUI_MSG_WINDOW_DEINIT:  // fired when OSD is hidden
-    {
-      // Remove our subdialogs if visible
-      CGUIDialog *pDialog = (CGUIDialog *)g_windowManager.GetWindow(WINDOW_DIALOG_VIDEO_OSD_SETTINGS);
-      if (pDialog && pDialog->IsDialogRunning())
-        pDialog->Close(true);
-      pDialog = (CGUIDialog *)g_windowManager.GetWindow(WINDOW_DIALOG_AUDIO_OSD_SETTINGS);
-      if (pDialog && pDialog->IsDialogRunning())
-        pDialog->Close(true);
-      pDialog = (CGUIDialog *)g_windowManager.GetWindow(WINDOW_DIALOG_VIDEO_BOOKMARKS);
-      if (pDialog && pDialog->IsDialogRunning())
-        pDialog->Close(true);
-      pDialog = (CGUIDialog *)g_windowManager.GetWindow(WINDOW_DIALOG_PVR_OSD_CHANNELS);
-      if (pDialog && pDialog->IsDialogRunning())
-        pDialog->Close(true);
-      pDialog = (CGUIDialog *)g_windowManager.GetWindow(WINDOW_DIALOG_PVR_OSD_GUIDE);
-      if (pDialog && pDialog->IsDialogRunning())
-        pDialog->Close(true);
-      pDialog = (CGUIDialog *)g_windowManager.GetWindow(WINDOW_DIALOG_OSD_TELETEXT);
-      if (pDialog && pDialog->IsDialogRunning())
-        pDialog->Close(true);
-    }
-    break;
   }
   return CGUIDialog::OnMessage(message);
 }

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -327,20 +327,8 @@ bool CGUIWindowFullScreen::OnMessage(CGUIMessage& message)
     }
   case GUI_MSG_WINDOW_DEINIT:
     {
-      CGUIDialog *pDialog = (CGUIDialog *)g_windowManager.GetWindow(WINDOW_DIALOG_OSD_TELETEXT);
-      if (pDialog) pDialog->Close(true);
-      pDialog = (CGUIDialog *)g_windowManager.GetWindow(WINDOW_DIALOG_SLIDER);
-      if (pDialog) pDialog->Close(true);
-      pDialog = (CGUIDialog *)g_windowManager.GetWindow(WINDOW_DIALOG_VIDEO_OSD);
-      if (pDialog) pDialog->Close(true);
-      pDialog = (CGUIDialog *)g_windowManager.GetWindow(WINDOW_DIALOG_FULLSCREEN_INFO);
-      if (pDialog) pDialog->Close(true);
-      pDialog = (CGUIDialog *)g_windowManager.GetWindow(WINDOW_DIALOG_PVR_OSD_CHANNELS);
-      if (pDialog) pDialog->Close(true);
-      pDialog = (CGUIDialog *)g_windowManager.GetWindow(WINDOW_DIALOG_PVR_OSD_GUIDE);
-      if (pDialog) pDialog->Close(true);
-      pDialog = (CGUIDialog *)g_windowManager.GetWindow(WINDOW_DIALOG_SUBTITLES);
-      if (pDialog) pDialog->Close(true);
+      // close all active modal dialogs
+      g_windowManager.CloseInternalModalDialogs(true);
 
       CGUIWindow::OnMessage(message);
 


### PR DESCRIPTION
~~This adds a new method `CloseWindows(std::vector<int> windowIds, bool forceClose)` to the window manager which is used on different places where we mass close dialogs. It reduce the code duplication a lot.~~

This excludes the addon/python dialogs in `CloseModalDialogs()` and use this method where we want to close all active modals e.g. if we leave fullscreen, visualation, video/music osd.

@mkortstiege @Montellese ping
