### PR TITLE
[gui] fix endless loop in CloseDialogs() if not force close

### DIFF
--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -806,10 +806,9 @@ void CGUIWindowManager::ActivateWindow_Internal(int iWindowID, const vector<stri
 void CGUIWindowManager::CloseDialogs(bool forceClose) const
 {
   CSingleLock lock(g_graphicsContext);
-  while (m_activeDialogs.size() > 0)
+  for (const auto& dialog : m_activeDialogs)
   {
-    CGUIWindow* win = m_activeDialogs[0];
-    win->Close(forceClose);
+    dialog->Close(forceClose);
   }
 }
 


### PR DESCRIPTION
As pointed out by @phil65 the call to our built-in `Dialog.Close(all)` crashes Kodi because of an endless loop in `CGUIWindowManager::CloseDialogs()`.

I've changed the "while" into a "foreach" which fixes the issue.
