### PR TITLE
[RFC] Thread local database handling

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2746,7 +2746,7 @@ PlayBackRet CApplication::PlayStack(const CFileItem& item, bool bRestart)
   if (!item.IsStack())
     return PLAYBACK_FAIL;
 
-  CVideoDatabase dbs;
+  CVideoDatabase *database = CDatabaseManager::Get().GetVideoDatabase();
 
   // case 1: stacked ISOs
   if (CFileItem(CStackDirectory::GetFirstStackedFile(item.GetPath()),false).IsDiscImage())
@@ -2763,21 +2763,15 @@ PlayBackRet CApplication::PlayStack(const CFileItem& item, bool bRestart)
     // check if we instructed the stack to resume from default
     if (startoffset == STARTOFFSET_RESUME) // selected file is not specified, pick the 'last' resume point
     {
-      if (dbs.Open())
+      CBookmark bookmark;
+      std::string path = item.GetPath();
+      if (item.HasProperty("original_listitem_url") && URIUtils::IsPlugin(item.GetProperty("original_listitem_url").asString()))
+        path = item.GetProperty("original_listitem_url").asString();
+      if( database->GetResumeBookMark(path, bookmark) )
       {
-        CBookmark bookmark;
-        std::string path = item.GetPath();
-        if (item.HasProperty("original_listitem_url") && URIUtils::IsPlugin(item.GetProperty("original_listitem_url").asString()))
-          path = item.GetProperty("original_listitem_url").asString();
-        if( dbs.GetResumeBookMark(path, bookmark) )
-        {
-          startoffset = (int)(bookmark.timeInSeconds*75);
-          selectedFile = bookmark.partNumber;
-        }
-        dbs.Close();
+        startoffset = (int)(bookmark.timeInSeconds*75);
+        selectedFile = bookmark.partNumber;
       }
-      else
-        CLog::LogF(LOGERROR, "Cannot open VideoDatabase");
     }
 
     // make sure that the selected part is within the boundaries
@@ -2810,14 +2804,7 @@ PlayBackRet CApplication::PlayStack(const CFileItem& item, bool bRestart)
     //       A much better solution is a fast reader of FPS and fileLength
     //       that we can use on a file to get it's time.
     vector<int> times;
-    bool haveTimes(false);
-    CVideoDatabase dbs;
-    if (dbs.Open())
-    {
-      haveTimes = dbs.GetStackTimes(item.GetPath(), times);
-      dbs.Close();
-    }
-
+    bool haveTimes = database->GetStackTimes(item.GetPath(), times);
 
     // calculate the total time of the stack
     CStackDirectory dir;
@@ -2846,24 +2833,20 @@ PlayBackRet CApplication::PlayStack(const CFileItem& item, bool bRestart)
 
     if (!haveTimes || item.m_lStartOffset == STARTOFFSET_RESUME )
     {  // have our times now, so update the dB
-      if (dbs.Open())
-      {
-        if (!haveTimes && !times.empty())
-          dbs.SetStackTimes(item.GetPath(), times);
+      if (!haveTimes && !times.empty())
+        database->SetStackTimes(item.GetPath(), times);
 
-        if (item.m_lStartOffset == STARTOFFSET_RESUME)
-        {
-          // can only resume seek here, not dvdstate
-          CBookmark bookmark;
-          std::string path = item.GetPath();
-          if (item.HasProperty("original_listitem_url") && URIUtils::IsPlugin(item.GetProperty("original_listitem_url").asString()))
-            path = item.GetProperty("original_listitem_url").asString();
-          if (dbs.GetResumeBookMark(path, bookmark))
-            seconds = bookmark.timeInSeconds;
-          else
-            seconds = 0.0f;
-        }
-        dbs.Close();
+      if (item.m_lStartOffset == STARTOFFSET_RESUME)
+      {
+        // can only resume seek here, not dvdstate
+        CBookmark bookmark;
+        std::string path = item.GetPath();
+        if (item.HasProperty("original_listitem_url") && URIUtils::IsPlugin(item.GetProperty("original_listitem_url").asString()))
+          path = item.GetProperty("original_listitem_url").asString();
+        if (database->GetResumeBookMark(path, bookmark))
+          seconds = bookmark.timeInSeconds;
+        else
+          seconds = 0.0f;
       }
     }
 
@@ -3004,8 +2987,7 @@ PlayBackRet CApplication::PlayFile(const CFileItem& item, bool bRestart)
     if (item.IsVideo())
     {
       // open the d/b and retrieve the bookmarks for the current movie
-      CVideoDatabase dbs;
-      dbs.Open();
+      CVideoDatabase *database = CDatabaseManager::Get().GetVideoDatabase();
 
       if( item.m_lStartOffset == STARTOFFSET_RESUME )
       {
@@ -3016,7 +2998,7 @@ PlayBackRet CApplication::PlayFile(const CFileItem& item, bool bRestart)
           path = item.GetVideoInfoTag()->m_strFileNameAndPath;
         else if (item.HasProperty("original_listitem_url") && URIUtils::IsPlugin(item.GetProperty("original_listitem_url").asString()))
           path = item.GetProperty("original_listitem_url").asString();
-        if(dbs.GetResumeBookMark(path, bookmark))
+        if(database->GetResumeBookMark(path, bookmark))
         {
           options.starttime = bookmark.timeInSeconds;
           options.state = bookmark.playerState;
@@ -3037,7 +3019,7 @@ PlayBackRet CApplication::PlayFile(const CFileItem& item, bool bRestart)
           if (tag->m_iBookmarkId > 0)
           {
             CBookmark bookmark;
-            dbs.GetBookMarkForEpisode(*tag, bookmark);
+            database->GetBookMarkForEpisode(*tag, bookmark);
             options.starttime = bookmark.timeInSeconds;
             options.state = bookmark.playerState;
           }
@@ -3050,13 +3032,11 @@ PlayBackRet CApplication::PlayFile(const CFileItem& item, bool bRestart)
         if (tag->m_iBookmarkId > 0)
         {
           CBookmark bookmark;
-          dbs.GetBookMarkForEpisode(*tag, bookmark);
+          database->GetBookMarkForEpisode(*tag, bookmark);
           options.starttime = bookmark.timeInSeconds;
           options.state = bookmark.playerState;
         }
       }
-
-      dbs.Close();
     }
 
     if (m_eForcedNextPlayer != EPC_NONE)
@@ -3503,17 +3483,12 @@ void CApplication::UpdateFileState()
 
 void CApplication::LoadVideoSettings(const CFileItem& item)
 {
-  CVideoDatabase dbs;
-  if (dbs.Open())
-  {
-    CLog::Log(LOGDEBUG, "Loading settings for %s", item.GetPath().c_str());
+  CVideoDatabase *database = CDatabaseManager::Get().GetVideoDatabase();
+  CLog::Log(LOGDEBUG, "Loading settings for %s", item.GetPath().c_str());
     
-    // Load stored settings if they exist, otherwise use default
-    if (!dbs.GetVideoSettings(item, CMediaSettings::Get().GetCurrentVideoSettings()))
-      CMediaSettings::Get().GetCurrentVideoSettings() = CMediaSettings::Get().GetDefaultVideoSettings();
-    
-    dbs.Close();
-  }
+  // Load stored settings if they exist, otherwise use default
+  if (!database->GetVideoSettings(item, CMediaSettings::Get().GetCurrentVideoSettings()))
+    CMediaSettings::Get().GetCurrentVideoSettings() = CMediaSettings::Get().GetDefaultVideoSettings();
 }
 
 void CApplication::StopPlaying()

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2179,12 +2179,9 @@ bool CApplication::OnAction(const CAction &action)
       }
       if (needsUpdate)
       {
-        CMusicDatabase db;
-        if (db.Open())      // OpenForWrite() ?
-        {
-          db.SetSongRating(m_itemCurrentFile->GetPath(), m_itemCurrentFile->GetMusicInfoTag()->GetRating());
-          db.Close();
-        }
+        CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
+        database->SetSongRating(m_itemCurrentFile->GetPath(), m_itemCurrentFile->GetMusicInfoTag()->GetRating());
+
         // send a message to all windows to tell them to update the fileitem (eg playlistplayer, media windows)
         CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_ITEM, 0, m_itemCurrentFile);
         g_windowManager.SendMessage(msg);

--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -28,6 +28,7 @@
 #include "GUIPassword.h"
 #include "GUIUserMessages.h"
 #include "PlayListPlayer.h"
+#include "DatabaseManager.h"
 #include "filesystem/StackDirectory.h"
 #include "filesystem/Directory.h"
 #include "filesystem/DirectoryFactory.h"
@@ -497,10 +498,9 @@ bool CAutorun::CanResumePlayDVD(const std::string& path)
   std::string strUniqueId = g_mediaManager.GetDiskUniqueId(path);
   if (!strUniqueId.empty())
   {
-    CVideoDatabase dbs;
-    dbs.Open();
+    CVideoDatabase *database = CDatabaseManager::Get().GetVideoDatabase();
     CBookmark bookmark;
-    if (dbs.GetResumeBookMark(strUniqueId, bookmark))
+    if (database->GetResumeBookMark(strUniqueId, bookmark))
       return true;
   }
   return false;

--- a/xbmc/DatabaseManager.cpp
+++ b/xbmc/DatabaseManager.cpp
@@ -38,6 +38,7 @@ using namespace PVR;
 
 static XbmcThreads::ThreadLocal<CVideoDatabase> videoDatabase;
 static XbmcThreads::ThreadLocal<CViewDatabase> viewDatabase;
+static XbmcThreads::ThreadLocal<CAddonDatabase> addonDatabase;
 
 CDatabaseManager &CDatabaseManager::Get()
 {
@@ -135,6 +136,19 @@ CViewDatabase* CDatabaseManager::GetViewDatabase()
   return database;
 }
 
+CAddonDatabase* CDatabaseManager::GetAddonDatabase()
+{
+  CSingleLock lock(m_section);
+  CAddonDatabase *database = addonDatabase.get();
+  if (database == NULL)
+  {
+    database = new CAddonDatabase();
+    OpenDatabase(*database);
+    addonDatabase.set(database);
+  }
+  return database;
+}
+
 void CDatabaseManager::CloseDatabases()
 {
   CSingleLock lock(m_section);
@@ -148,5 +162,10 @@ void CDatabaseManager::CloseDatabases()
   {
     delete viewDatabase.get();
     viewDatabase.set(NULL);
+  }
+  if(addonDatabase.get() != NULL)
+  {
+    delete addonDatabase.get();
+    addonDatabase.set(NULL);
   }
 }

--- a/xbmc/DatabaseManager.cpp
+++ b/xbmc/DatabaseManager.cpp
@@ -40,6 +40,7 @@ static XbmcThreads::ThreadLocal<CVideoDatabase> videoDatabase;
 static XbmcThreads::ThreadLocal<CViewDatabase> viewDatabase;
 static XbmcThreads::ThreadLocal<CAddonDatabase> addonDatabase;
 static XbmcThreads::ThreadLocal<CTextureDatabase> textureDatabase;
+static XbmcThreads::ThreadLocal<CEpgDatabase> epgDatabase;
 
 CDatabaseManager &CDatabaseManager::Get()
 {
@@ -163,6 +164,19 @@ CTextureDatabase* CDatabaseManager::GetTextureDatabase()
   return database;
 }
 
+EPG::CEpgDatabase* CDatabaseManager::GetEpgDatabase()
+{
+  CSingleLock lock(m_section);
+  CEpgDatabase *database = epgDatabase.get();
+  if (database == NULL)
+  {
+    database = new CEpgDatabase();
+    OpenDatabase(*database);
+    epgDatabase.set(database);
+  }
+  return database;
+}
+
 void CDatabaseManager::CloseDatabases()
 {
   CSingleLock lock(m_section);
@@ -186,5 +200,10 @@ void CDatabaseManager::CloseDatabases()
   {
     delete textureDatabase.get();
     textureDatabase.set(NULL);
+  }
+  if(epgDatabase.get() != NULL)
+  {
+    delete epgDatabase.get();
+    epgDatabase.set(NULL);
   }
 }

--- a/xbmc/DatabaseManager.cpp
+++ b/xbmc/DatabaseManager.cpp
@@ -42,6 +42,7 @@ static XbmcThreads::ThreadLocal<CAddonDatabase> addonDatabase;
 static XbmcThreads::ThreadLocal<CTextureDatabase> textureDatabase;
 static XbmcThreads::ThreadLocal<CEpgDatabase> epgDatabase;
 static XbmcThreads::ThreadLocal<CPVRDatabase> pvrDatabase;
+static XbmcThreads::ThreadLocal<CMusicDatabase> musicDatabase;
 
 CDatabaseManager &CDatabaseManager::Get()
 {
@@ -191,6 +192,19 @@ PVR::CPVRDatabase* CDatabaseManager::GetPVRDatabase()
   return database;
 }
 
+CMusicDatabase* CDatabaseManager::GetMusicDatabase()
+{
+  CSingleLock lock(m_section);
+  CMusicDatabase *database = musicDatabase.get();
+  if (database == NULL)
+  {
+    database = new CMusicDatabase();
+    OpenDatabase(*database);
+    musicDatabase.set(database);
+  }
+  return database;
+}
+
 void CDatabaseManager::CloseDatabases()
 {
   CSingleLock lock(m_section);
@@ -224,5 +238,10 @@ void CDatabaseManager::CloseDatabases()
   {
     delete pvrDatabase.get();
     pvrDatabase.set(NULL);
+  }
+  if(musicDatabase.get() != NULL)
+  {
+    delete musicDatabase.get();
+    musicDatabase.set(NULL);
   }
 }

--- a/xbmc/DatabaseManager.cpp
+++ b/xbmc/DatabaseManager.cpp
@@ -39,6 +39,7 @@ using namespace PVR;
 static XbmcThreads::ThreadLocal<CVideoDatabase> videoDatabase;
 static XbmcThreads::ThreadLocal<CViewDatabase> viewDatabase;
 static XbmcThreads::ThreadLocal<CAddonDatabase> addonDatabase;
+static XbmcThreads::ThreadLocal<CTextureDatabase> textureDatabase;
 
 CDatabaseManager &CDatabaseManager::Get()
 {
@@ -149,6 +150,19 @@ CAddonDatabase* CDatabaseManager::GetAddonDatabase()
   return database;
 }
 
+CTextureDatabase* CDatabaseManager::GetTextureDatabase()
+{
+  CSingleLock lock(m_section);
+  CTextureDatabase *database = textureDatabase.get();
+  if (database == NULL)
+  {
+    database = new CTextureDatabase();
+    OpenDatabase(*database);
+    textureDatabase.set(database);
+  }
+  return database;
+}
+
 void CDatabaseManager::CloseDatabases()
 {
   CSingleLock lock(m_section);
@@ -167,5 +181,10 @@ void CDatabaseManager::CloseDatabases()
   {
     delete addonDatabase.get();
     addonDatabase.set(NULL);
+  }
+  if(textureDatabase.get() != NULL)
+  {
+    delete textureDatabase.get();
+    textureDatabase.set(NULL);
   }
 }

--- a/xbmc/DatabaseManager.cpp
+++ b/xbmc/DatabaseManager.cpp
@@ -41,6 +41,7 @@ static XbmcThreads::ThreadLocal<CViewDatabase> viewDatabase;
 static XbmcThreads::ThreadLocal<CAddonDatabase> addonDatabase;
 static XbmcThreads::ThreadLocal<CTextureDatabase> textureDatabase;
 static XbmcThreads::ThreadLocal<CEpgDatabase> epgDatabase;
+static XbmcThreads::ThreadLocal<CPVRDatabase> pvrDatabase;
 
 CDatabaseManager &CDatabaseManager::Get()
 {
@@ -177,6 +178,19 @@ EPG::CEpgDatabase* CDatabaseManager::GetEpgDatabase()
   return database;
 }
 
+PVR::CPVRDatabase* CDatabaseManager::GetPVRDatabase()
+{
+  CSingleLock lock(m_section);
+  CPVRDatabase *database = pvrDatabase.get();
+  if (database == NULL)
+  {
+    database = new CPVRDatabase();
+    OpenDatabase(*database);
+    pvrDatabase.set(database);
+  }
+  return database;
+}
+
 void CDatabaseManager::CloseDatabases()
 {
   CSingleLock lock(m_section);
@@ -205,5 +219,10 @@ void CDatabaseManager::CloseDatabases()
   {
     delete epgDatabase.get();
     epgDatabase.set(NULL);
+  }
+  if(pvrDatabase.get() != NULL)
+  {
+    delete pvrDatabase.get();
+    pvrDatabase.set(NULL);
   }
 }

--- a/xbmc/DatabaseManager.cpp
+++ b/xbmc/DatabaseManager.cpp
@@ -37,6 +37,7 @@ using namespace EPG;
 using namespace PVR;
 
 static XbmcThreads::ThreadLocal<CVideoDatabase> videoDatabase;
+static XbmcThreads::ThreadLocal<CViewDatabase> viewDatabase;
 
 CDatabaseManager &CDatabaseManager::Get()
 {
@@ -121,6 +122,19 @@ CVideoDatabase* CDatabaseManager::GetVideoDatabase()
   return database;
 }
 
+CViewDatabase* CDatabaseManager::GetViewDatabase()
+{
+  CSingleLock lock(m_section);
+  CViewDatabase *database = viewDatabase.get();
+  if (database == NULL)
+  {
+    database = new CViewDatabase();
+    OpenDatabase(*database);
+    viewDatabase.set(database);
+  }
+  return database;
+}
+
 void CDatabaseManager::CloseDatabases()
 {
   CSingleLock lock(m_section);
@@ -129,5 +143,10 @@ void CDatabaseManager::CloseDatabases()
   {
     delete videoDatabase.get();
     videoDatabase.set(NULL);
+  }
+  if(viewDatabase.get() != NULL)
+  {
+    delete viewDatabase.get();
+    viewDatabase.set(NULL);
   }
 }

--- a/xbmc/DatabaseManager.h
+++ b/xbmc/DatabaseManager.h
@@ -26,6 +26,7 @@
 #include "threads/Event.h"
 
 class CDatabase;
+class CVideoDatabase;
 class DatabaseSettings;
 
 /*!
@@ -64,6 +65,9 @@ public:
    \return true if the database can be opened, false otherwise.
    */ 
   bool CanOpen(const std::string &name);
+  void CloseDatabases();
+
+  CVideoDatabase* GetVideoDatabase();
 
 private:
   // private construction, and no assignements; use the provided singleton methods
@@ -75,6 +79,7 @@ private:
   enum DB_STATUS { DB_CLOSED, DB_UPDATING, DB_READY, DB_FAILED };
   void UpdateStatus(const std::string &name, DB_STATUS status);
   void UpdateDatabase(CDatabase &db, DatabaseSettings *settings = NULL);
+  void OpenDatabase(CDatabase &database) const;
 
   CCriticalSection            m_section;     ///< Critical section protecting m_dbStatus.
   std::map<std::string, DB_STATUS> m_dbStatus;    ///< Our database status map.

--- a/xbmc/DatabaseManager.h
+++ b/xbmc/DatabaseManager.h
@@ -27,6 +27,7 @@
 
 class CDatabase;
 class CAddonDatabase;
+class CTextureDatabase;
 class CViewDatabase;
 class CVideoDatabase;
 class DatabaseSettings;
@@ -70,6 +71,7 @@ public:
   void CloseDatabases();
 
   CAddonDatabase* GetAddonDatabase();
+  CTextureDatabase* GetTextureDatabase();
   CViewDatabase* GetViewDatabase();
   CVideoDatabase* GetVideoDatabase();
 

--- a/xbmc/DatabaseManager.h
+++ b/xbmc/DatabaseManager.h
@@ -27,6 +27,7 @@
 
 class CDatabase;
 class CAddonDatabase;
+class CMusicDatabase;
 class CTextureDatabase;
 class CViewDatabase;
 class CVideoDatabase;
@@ -82,6 +83,7 @@ public:
 
   CAddonDatabase* GetAddonDatabase();
   EPG::CEpgDatabase* GetEpgDatabase();
+  CMusicDatabase* GetMusicDatabase();
   PVR::CPVRDatabase* GetPVRDatabase();
   CTextureDatabase* GetTextureDatabase();
   CViewDatabase* GetViewDatabase();

--- a/xbmc/DatabaseManager.h
+++ b/xbmc/DatabaseManager.h
@@ -26,6 +26,7 @@
 #include "threads/Event.h"
 
 class CDatabase;
+class CViewDatabase;
 class CVideoDatabase;
 class DatabaseSettings;
 
@@ -67,6 +68,7 @@ public:
   bool CanOpen(const std::string &name);
   void CloseDatabases();
 
+  CViewDatabase* GetViewDatabase();
   CVideoDatabase* GetVideoDatabase();
 
 private:

--- a/xbmc/DatabaseManager.h
+++ b/xbmc/DatabaseManager.h
@@ -37,6 +37,11 @@ namespace EPG
   class CEpgDatabase;
 }
 
+namespace PVR
+{
+  class CPVRDatabase;
+}
+
 /*!
  \ingroup database
  \brief Database manager class for handling database updating
@@ -77,6 +82,7 @@ public:
 
   CAddonDatabase* GetAddonDatabase();
   EPG::CEpgDatabase* GetEpgDatabase();
+  PVR::CPVRDatabase* GetPVRDatabase();
   CTextureDatabase* GetTextureDatabase();
   CViewDatabase* GetViewDatabase();
   CVideoDatabase* GetVideoDatabase();

--- a/xbmc/DatabaseManager.h
+++ b/xbmc/DatabaseManager.h
@@ -26,6 +26,7 @@
 #include "threads/Event.h"
 
 class CDatabase;
+class CAddonDatabase;
 class CViewDatabase;
 class CVideoDatabase;
 class DatabaseSettings;
@@ -68,6 +69,7 @@ public:
   bool CanOpen(const std::string &name);
   void CloseDatabases();
 
+  CAddonDatabase* GetAddonDatabase();
   CViewDatabase* GetViewDatabase();
   CVideoDatabase* GetVideoDatabase();
 

--- a/xbmc/DatabaseManager.h
+++ b/xbmc/DatabaseManager.h
@@ -32,6 +32,11 @@ class CViewDatabase;
 class CVideoDatabase;
 class DatabaseSettings;
 
+namespace EPG
+{
+  class CEpgDatabase;
+}
+
 /*!
  \ingroup database
  \brief Database manager class for handling database updating
@@ -71,6 +76,7 @@ public:
   void CloseDatabases();
 
   CAddonDatabase* GetAddonDatabase();
+  EPG::CEpgDatabase* GetEpgDatabase();
   CTextureDatabase* GetTextureDatabase();
   CViewDatabase* GetViewDatabase();
   CVideoDatabase* GetVideoDatabase();

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -21,6 +21,7 @@
 #include <cstdlib>
 
 #include "FileItem.h"
+#include "DatabaseManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
@@ -3005,17 +3006,13 @@ bool CFileItem::LoadMusicTag()
   if (HasMusicInfoTag() && m_musicInfoTag->Loaded())
     return true;
   // check db
-  CMusicDatabase musicDatabase;
-  if (musicDatabase.Open())
+  CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
+  CSong song;
+  if (database->GetSongByFileName(m_strPath, song))
   {
-    CSong song;
-    if (musicDatabase.GetSongByFileName(m_strPath, song))
-    {
-      GetMusicInfoTag()->SetSong(song);
-      SetArt("thumb", song.strThumb);
-      return true;
-    }
-    musicDatabase.Close();
+    GetMusicInfoTag()->SetSong(song);
+    SetArt("thumb", song.strThumb);
+    return true;
   }
   // load tag from file
   CLog::Log(LOGDEBUG, "%s: loading tag information for file: %s", __FUNCTION__, m_strPath.c_str());

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -25,6 +25,7 @@
 #include "windows/GUIMediaWindow.h"
 #include "dialogs/GUIDialogProgress.h"
 #include "Application.h"
+#include "DatabaseManager.h"
 #include "Util.h"
 #include "utils/URIUtils.h"
 #include "utils/Weather.h"
@@ -4215,16 +4216,12 @@ void CGUIInfoManager::SetCurrentMovie(CFileItem &item)
   /* also call GetMovieInfo() when a VideoInfoTag is already present or additional info won't be present in the tag */
   if (!m_currentFile->HasPVRChannelInfoTag())
   {
-    CVideoDatabase dbs;
-    if (dbs.Open())
-    {
-      std::string path = item.GetPath();
-      std::string videoInfoTagPath(item.GetVideoInfoTag()->m_strFileNameAndPath);
-      if (videoInfoTagPath.find("removable://") == 0)
-        path = videoInfoTagPath;
-      dbs.LoadVideoInfo(path, *m_currentFile->GetVideoInfoTag());
-      dbs.Close();
-    }
+    CVideoDatabase *database = CDatabaseManager::Get().GetVideoDatabase();
+    std::string path = item.GetPath();
+    std::string videoInfoTagPath(item.GetVideoInfoTag()->m_strFileNameAndPath);
+    if (videoInfoTagPath.find("removable://") == 0)
+      path = videoInfoTagPath;
+    database->LoadVideoInfo(path, *m_currentFile->GetVideoInfoTag());
   }
 
   // Find a thumb for this file.
@@ -5645,12 +5642,8 @@ bool CGUIInfoManager::GetLibraryBool(int condition)
   {
     if (m_libraryHasMovies < 0)
     {
-      CVideoDatabase db;
-      if (db.Open())
-      {
-        m_libraryHasMovies = db.HasContent(VIDEODB_CONTENT_MOVIES) ? 1 : 0;
-        db.Close();
-      }
+      CVideoDatabase *database = CDatabaseManager::Get().GetVideoDatabase();
+      m_libraryHasMovies = database->HasContent(VIDEODB_CONTENT_MOVIES) ? 1 : 0;
     }
     return m_libraryHasMovies > 0;
   }
@@ -5658,12 +5651,8 @@ bool CGUIInfoManager::GetLibraryBool(int condition)
   {
     if (m_libraryHasMovieSets < 0)
     {
-      CVideoDatabase db;
-      if (db.Open())
-      {
-        m_libraryHasMovieSets = db.HasSets() ? 1 : 0;
-        db.Close();
-      }
+      CVideoDatabase *database = CDatabaseManager::Get().GetVideoDatabase();
+      m_libraryHasMovieSets = database->HasSets() ? 1 : 0;
     }
     return m_libraryHasMovieSets > 0;
   }
@@ -5671,12 +5660,8 @@ bool CGUIInfoManager::GetLibraryBool(int condition)
   {
     if (m_libraryHasTVShows < 0)
     {
-      CVideoDatabase db;
-      if (db.Open())
-      {
-        m_libraryHasTVShows = db.HasContent(VIDEODB_CONTENT_TVSHOWS) ? 1 : 0;
-        db.Close();
-      }
+      CVideoDatabase *database = CDatabaseManager::Get().GetVideoDatabase();
+      m_libraryHasTVShows = database->HasContent(VIDEODB_CONTENT_TVSHOWS) ? 1 : 0;
     }
     return m_libraryHasTVShows > 0;
   }
@@ -5684,12 +5669,8 @@ bool CGUIInfoManager::GetLibraryBool(int condition)
   {
     if (m_libraryHasMusicVideos < 0)
     {
-      CVideoDatabase db;
-      if (db.Open())
-      {
-        m_libraryHasMusicVideos = db.HasContent(VIDEODB_CONTENT_MUSICVIDEOS) ? 1 : 0;
-        db.Close();
-      }
+      CVideoDatabase *database = CDatabaseManager::Get().GetVideoDatabase();
+      m_libraryHasMusicVideos = database->HasContent(VIDEODB_CONTENT_MUSICVIDEOS) ? 1 : 0;
     }
     return m_libraryHasMusicVideos > 0;
   }

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -5629,12 +5629,8 @@ bool CGUIInfoManager::GetLibraryBool(int condition)
   {
     if (m_libraryHasMusic < 0)
     { // query
-      CMusicDatabase db;
-      if (db.Open())
-      {
-        m_libraryHasMusic = (db.GetSongsCount() > 0) ? 1 : 0;
-        db.Close();
-      }
+      CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
+      m_libraryHasMusic = (database->GetSongsCount() > 0) ? 1 : 0;
     }
     return m_libraryHasMusic > 0;
   }
@@ -5678,12 +5674,8 @@ bool CGUIInfoManager::GetLibraryBool(int condition)
   {
     if (m_libraryHasSingles < 0)
     {
-      CMusicDatabase db;
-      if (db.Open())
-      {
-        m_libraryHasSingles = (db.GetSinglesCount() > 0) ? 1 : 0;
-        db.Close();
-      }
+      CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
+      m_libraryHasSingles = (database->GetSinglesCount() > 0) ? 1 : 0;
     }
     return m_libraryHasSingles > 0;
   }
@@ -5691,12 +5683,8 @@ bool CGUIInfoManager::GetLibraryBool(int condition)
   {
     if (m_libraryHasCompilations < 0)
     {
-      CMusicDatabase db;
-      if (db.Open())
-      {
-        m_libraryHasCompilations = (db.GetCompilationAlbumsCount() > 0) ? 1 : 0;
-        db.Close();
-      }
+      CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
+      m_libraryHasCompilations = (database->GetCompilationAlbumsCount() > 0) ? 1 : 0;
     }
     return m_libraryHasCompilations > 0;
   }

--- a/xbmc/PartyModeManager.cpp
+++ b/xbmc/PartyModeManager.cpp
@@ -20,6 +20,7 @@
 
 #include "threads/SystemClock.h"
 #include "PartyModeManager.h"
+#include "DatabaseManager.h"
 #include "PlayListPlayer.h"
 #include "music/MusicDatabase.h"
 #include "music/windows/GUIWindowMusicPlaylist.h"
@@ -143,30 +144,20 @@ bool CPartyModeManager::Enable(PartyModeContext context /*= PARTYMODECONTEXT_MUS
       StringUtils::EqualsNoCase(m_type, "mixed"))
   {
     vector< pair<int,int> > songIDs2;
-    CVideoDatabase db;
-    if (db.Open())
-    {
-      set<std::string> playlists;
-      if ( playlistLoaded )
-        m_strCurrentFilterVideo = playlist.GetWhereClause(db, playlists);
+    CVideoDatabase *database = CDatabaseManager::Get().GetVideoDatabase();
+    set<std::string> playlists;
+    if ( playlistLoaded )
+      m_strCurrentFilterVideo = playlist.GetWhereClause(*database, playlists);
 
-      CLog::Log(LOGINFO, "PARTY MODE MANAGER: Registering filter:[%s]", m_strCurrentFilterVideo.c_str());
-      m_iMatchingSongs += (int)db.GetMusicVideoIDs(m_strCurrentFilterVideo, songIDs2);
-      if (m_iMatchingSongs < 1)
-      {
-        pDialog->Close();
-        db.Close();
-        OnError(16031, (std::string)"Party mode found no matching songs. Aborting.");
-        return false;
-      }
-    }
-    else
+    CLog::Log(LOGINFO, "PARTY MODE MANAGER: Registering filter:[%s]", m_strCurrentFilterVideo.c_str());
+    m_iMatchingSongs += (int)database->GetMusicVideoIDs(m_strCurrentFilterVideo, songIDs2);
+    if (m_iMatchingSongs < 1)
     {
       pDialog->Close();
-      OnError(16033, (std::string)"Party mode could not open database. Aborting.");
+      OnError(16031, (std::string)"Party mode found no matching songs. Aborting.");
       return false;
     }
-    db.Close();
+
     songIDs.insert(songIDs.end(),songIDs2.begin(),songIDs2.end());
   }
 
@@ -385,50 +376,40 @@ bool CPartyModeManager::AddRandomSongs(int iSongs /* = 0 */)
   if (StringUtils::EqualsNoCase(m_type, "musicvideos") ||
       StringUtils::EqualsNoCase(m_type, "mixed"))
   {
-    CVideoDatabase database;
-    if (database.Open())
+    // Method:
+    // 1. Grab a random entry from the database using a where clause
+    // 2. Iterate on iSongs.
+
+    // Note: At present, this method is faster than the alternative, which is to grab
+    // all valid songids, then select a random number of them (as done in AddInitialSongs()).
+    // The reason for this is simply the number of songs we are requesting - we generally
+    // only want one here.  Any more than about 3 songs and it is more efficient
+    // to use the technique in AddInitialSongs.  As it's unlikely that we'll require
+    // more than 1 song at a time here, this method is faster.
+    bool error(false);
+    CVideoDatabase *database = CDatabaseManager::Get().GetVideoDatabase();
+    for (int i = 0; i < iVidsToAdd; i++)
     {
-      // Method:
-      // 1. Grab a random entry from the database using a where clause
-      // 2. Iterate on iSongs.
-
-      // Note: At present, this method is faster than the alternative, which is to grab
-      // all valid songids, then select a random number of them (as done in AddInitialSongs()).
-      // The reason for this is simply the number of songs we are requesting - we generally
-      // only want one here.  Any more than about 3 songs and it is more efficient
-      // to use the technique in AddInitialSongs.  As it's unlikely that we'll require
-      // more than 1 song at a time here, this method is faster.
-      bool error(false);
-      for (int i = 0; i < iVidsToAdd; i++)
-      {
-        pair<std::string,std::string> whereClause = GetWhereClauseWithHistory();
-        CFileItemPtr item(new CFileItem);
-        int songID;
-        if (database.GetRandomMusicVideo(item.get(), songID, whereClause.second))
-        { // success
-          Add(item);
-          AddToHistory(2,songID);
-        }
-        else
-        {
-          error = true;
-          break;
-        }
+      pair<std::string,std::string> whereClause = GetWhereClauseWithHistory();
+      CFileItemPtr item(new CFileItem);
+      int songID;
+      if (database->GetRandomMusicVideo(item.get(), songID, whereClause.second))
+      { // success
+        Add(item);
+        AddToHistory(2,songID);
       }
-
-      if (error)
+      else
       {
-        database.Close();
-        OnError(16034, (std::string)"Cannot get songs from database. Aborting.");
-        return false;
+        error = true;
+        break;
       }
     }
-    else
+
+    if (error)
     {
-      OnError(16033, (std::string)"Party mode could not open database. Aborting.");
+      OnError(16034, (std::string)"Cannot get songs from database. Aborting.");
       return false;
     }
-    database.Close();
   }
   return true;
 }
@@ -631,9 +612,8 @@ bool CPartyModeManager::AddInitialSongs(vector<pair<int,int> > &songIDs)
     if (sqlWhereVideo.size() > 19)
     {
       sqlWhereVideo[sqlWhereVideo.size() - 1] = ')'; // replace the last comma with closing bracket
-      CVideoDatabase database;
-      database.Open();
-      database.GetMusicVideosByWhere("videodb://musicvideos/titles/", sqlWhereVideo, items);
+      CVideoDatabase *database = CDatabaseManager::Get().GetVideoDatabase();
+      database->GetMusicVideosByWhere("videodb://musicvideos/titles/", sqlWhereVideo, items);
     }
 
     m_history = chosenSongIDs;

--- a/xbmc/TextureCache.cpp
+++ b/xbmc/TextureCache.cpp
@@ -20,6 +20,7 @@
 
 #include "TextureCache.h"
 #include "TextureCacheJob.h"
+#include "DatabaseManager.h"
 #include "filesystem/File.h"
 #include "profiles/ProfilesManager.h"
 #include "threads/SingleLock.h"
@@ -49,16 +50,11 @@ CTextureCache::~CTextureCache()
 
 void CTextureCache::Initialize()
 {
-  CSingleLock lock(m_databaseSection);
-  if (!m_database.IsOpen())
-    m_database.Open();
 }
 
 void CTextureCache::Deinitialize()
 {
   CancelJobs();
-  CSingleLock lock(m_databaseSection);
-  m_database.Close();
 }
 
 bool CTextureCache::IsCachedImage(const std::string &url) const
@@ -209,13 +205,15 @@ bool CTextureCache::ClearCachedImage(int id)
 bool CTextureCache::GetCachedTexture(const std::string &url, CTextureDetails &details)
 {
   CSingleLock lock(m_databaseSection);
-  return m_database.GetCachedTexture(url, details);
+  CTextureDatabase *database = CDatabaseManager::Get().GetTextureDatabase();
+  return database->GetCachedTexture(url, details);
 }
 
 bool CTextureCache::AddCachedTexture(const std::string &url, const CTextureDetails &details)
 {
   CSingleLock lock(m_databaseSection);
-  return m_database.AddCachedTexture(url, details);
+  CTextureDatabase *database = CDatabaseManager::Get().GetTextureDatabase();
+  return database->AddCachedTexture(url, details);
 }
 
 void CTextureCache::IncrementUseCount(const CTextureDetails &details)
@@ -234,19 +232,22 @@ void CTextureCache::IncrementUseCount(const CTextureDetails &details)
 bool CTextureCache::SetCachedTextureValid(const std::string &url, bool updateable)
 {
   CSingleLock lock(m_databaseSection);
-  return m_database.SetCachedTextureValid(url, updateable);
+  CTextureDatabase *database = CDatabaseManager::Get().GetTextureDatabase();
+  return database->SetCachedTextureValid(url, updateable);
 }
 
 bool CTextureCache::ClearCachedTexture(const std::string &url, std::string &cachedURL)
 {
   CSingleLock lock(m_databaseSection);
-  return m_database.ClearCachedTexture(url, cachedURL);
+  CTextureDatabase *database = CDatabaseManager::Get().GetTextureDatabase();
+  return database->ClearCachedTexture(url, cachedURL);
 }
 
 bool CTextureCache::ClearCachedTexture(int id, std::string &cachedURL)
 {
   CSingleLock lock(m_databaseSection);
-  return m_database.ClearCachedTexture(id, cachedURL);
+  CTextureDatabase *database = CDatabaseManager::Get().GetTextureDatabase();
+  return database->ClearCachedTexture(id, cachedURL);
 }
 
 std::string CTextureCache::GetCacheFile(const std::string &url)

--- a/xbmc/TextureCache.h
+++ b/xbmc/TextureCache.h
@@ -222,7 +222,6 @@ private:
   void OnCachingComplete(bool success, CTextureCacheJob *job);
 
   CCriticalSection m_databaseSection;
-  CTextureDatabase m_database;
   std::set<std::string> m_processinglist; ///< currently processing list to avoid 2 jobs being processed at once
   CCriticalSection     m_processingSection;
   CEvent               m_completeEvent; ///< Set whenever a job has finished

--- a/xbmc/TextureCacheJob.cpp
+++ b/xbmc/TextureCacheJob.cpp
@@ -20,6 +20,7 @@
 
 #include "TextureCacheJob.h"
 #include "TextureCache.h"
+#include "DatabaseManager.h"
 #include "guilib/Texture.h"
 #include "guilib/DDSImage.h"
 #include "settings/AdvancedSettings.h"
@@ -292,13 +293,10 @@ bool CTextureUseCountJob::operator==(const CJob* job) const
 
 bool CTextureUseCountJob::DoWork()
 {
-  CTextureDatabase db;
-  if (db.Open())
-  {
-    db.BeginTransaction();
-    for (std::vector<CTextureDetails>::const_iterator i = m_textures.begin(); i != m_textures.end(); ++i)
-      db.IncrementUseCount(*i);
-    db.CommitTransaction();
-  }
+  CTextureDatabase *database = CDatabaseManager::Get().GetTextureDatabase();
+  database->BeginTransaction();
+  for (std::vector<CTextureDetails>::const_iterator i = m_textures.begin(); i != m_textures.end(); ++i)
+    database->IncrementUseCount(*i);
+  database->CommitTransaction();
   return true;
 }

--- a/xbmc/ThumbLoader.cpp
+++ b/xbmc/ThumbLoader.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "ThumbLoader.h"
+#include "DatabaseManager.h"
 #include "filesystem/File.h"
 #include "FileItem.h"
 #include "TextureCache.h"
@@ -29,30 +30,14 @@ using namespace XFILE;
 CThumbLoader::CThumbLoader() :
   CBackgroundInfoLoader()
 {
-  m_textureDatabase = new CTextureDatabase();
-}
-
-CThumbLoader::~CThumbLoader()
-{
-  delete m_textureDatabase;
-}
-
-void CThumbLoader::OnLoaderStart()
-{
-  m_textureDatabase->Open();
-}
-
-void CThumbLoader::OnLoaderFinish()
-{
-  m_textureDatabase->Close();
 }
 
 std::string CThumbLoader::GetCachedImage(const CFileItem &item, const std::string &type)
 {
-  if (!item.GetPath().empty() && m_textureDatabase->Open())
+  if (!item.GetPath().empty())
   {
-    std::string image = m_textureDatabase->GetTextureForPath(item.GetPath(), type);
-    m_textureDatabase->Close();
+    CTextureDatabase *database = CDatabaseManager::Get().GetTextureDatabase();
+    std::string image = database->GetTextureForPath(item.GetPath(), type);
     return image;
   }
   return "";
@@ -60,10 +45,10 @@ std::string CThumbLoader::GetCachedImage(const CFileItem &item, const std::strin
 
 void CThumbLoader::SetCachedImage(const CFileItem &item, const std::string &type, const std::string &image)
 {
-  if (!item.GetPath().empty() && m_textureDatabase->Open())
+  if (!item.GetPath().empty())
   {
-    m_textureDatabase->SetTextureForPath(item.GetPath(), type, image);
-    m_textureDatabase->Close();
+    CTextureDatabase *database = CDatabaseManager::Get().GetTextureDatabase();
+    database->SetTextureForPath(item.GetPath(), type, image);
   }
 }
 

--- a/xbmc/ThumbLoader.h
+++ b/xbmc/ThumbLoader.h
@@ -28,10 +28,10 @@ class CThumbLoader : public CBackgroundInfoLoader
 {
 public:
   CThumbLoader();
-  virtual ~CThumbLoader();
+  virtual ~CThumbLoader() {};
 
-  virtual void OnLoaderStart();
-  virtual void OnLoaderFinish();
+  virtual void OnLoaderStart() {};
+  virtual void OnLoaderFinish() {};
 
   /*! \brief helper function to fill the art for a library item
    \param item a CFileItem
@@ -52,9 +52,6 @@ public:
    \param image the URL of the image
    */
   virtual void SetCachedImage(const CFileItem &item, const std::string &type, const std::string &image);
-
-protected:
-  CTextureDatabase *m_textureDatabase;
 };
 
 class CProgramThumbLoader : public CThumbLoader

--- a/xbmc/addons/AddonInstaller.h
+++ b/xbmc/addons/AddonInstaller.h
@@ -79,10 +79,9 @@ public:
    Iterates through the addon's dependencies, checking they're installed or installable.
    Each dependency must also satisfies CheckDependencies in turn.
    \param addon the addon to check
-   \param database the database instance to update. Defaults to NULL.
    \return true if dependencies are available, false otherwise.
    */
-  bool CheckDependencies(const ADDON::AddonPtr &addon, CAddonDatabase *database = NULL);
+  bool CheckDependencies(const ADDON::AddonPtr &addon);
 
   /*! \brief Update all repositories (if needed)
    Runs through all available repositories and queues an update of them if they
@@ -146,7 +145,7 @@ private:
    \param database database instance to update
    \return true if dependencies are available, false otherwise.
    */
-  bool CheckDependencies(const ADDON::AddonPtr &addon, std::vector<std::string>& preDeps, CAddonDatabase &database);
+  bool CheckDependencies(const ADDON::AddonPtr &addon, std::vector<std::string>& preDeps);
 
   void PrunePackageCache();
   int64_t EnumeratePackageFolder(std::map<std::string,CFileItemList*>& result);

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -254,7 +254,6 @@ namespace ADDON
     std::map<std::string, bool> m_disabled;
     static std::map<TYPE, IAddonMgrCallback*> m_managers;
     CCriticalSection m_critSection;
-    CAddonDatabase m_database;
   };
 
 }; /* namespace ADDON */

--- a/xbmc/addons/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/GUIWindowAddonBrowser.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "GUIWindowAddonBrowser.h"
+#include "DatabaseManager.h"
 #include "addons/AddonManager.h"
 #include "addons/Repository.h"
 #include "GUIDialogAddonInfo.h"
@@ -495,8 +496,8 @@ int CGUIWindowAddonBrowser::SelectAddonID(const vector<ADDON::TYPE> &types, vect
   if (showInstallable || showMore)
   {
     VECADDONS installableAddons;
-    CAddonDatabase database;
-    if (database.Open() && database.GetAddons(installableAddons))
+    CAddonDatabase *database = CDatabaseManager::Get().GetAddonDatabase();
+    if (database->GetAddons(installableAddons))
     {
       for (ADDON::IVECADDONS addon = installableAddons.begin(); addon != installableAddons.end();)
       {

--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -247,9 +247,8 @@ bool CRepositoryUpdateJob::DoWork()
   CAddonDatabase *database = CDatabaseManager::Get().GetAddonDatabase();
   database->BeginMultipleExecute();
 
-  CTextureDatabase textureDB;
-  textureDB.Open();
-  textureDB.BeginMultipleExecute();
+  CTextureDatabase *textureDatabase = CDatabaseManager::Get().GetTextureDatabase();
+  textureDatabase->BeginMultipleExecute();
   VECADDONS notifications;
   for (map<string, AddonPtr>::const_iterator i = addons.begin(); i != addons.end(); ++i)
   {
@@ -264,9 +263,9 @@ bool CRepositoryUpdateJob::DoWork()
 
     // invalidate the art associated with this item
     if (!newAddon->Props().fanart.empty())
-      textureDB.InvalidateCachedTexture(newAddon->Props().fanart);
+      textureDatabase->InvalidateCachedTexture(newAddon->Props().fanart);
     if (!newAddon->Props().icon.empty())
-      textureDB.InvalidateCachedTexture(newAddon->Props().icon);
+      textureDatabase->InvalidateCachedTexture(newAddon->Props().icon);
 
     AddonPtr addon;
     CAddonMgr::Get().GetAddon(newAddon->ID(),addon);
@@ -311,7 +310,7 @@ bool CRepositoryUpdateJob::DoWork()
     }
   }
   database->CommitMultipleExecute();
-  textureDB.CommitMultipleExecute();
+  textureDatabase->CommitMultipleExecute();
   if (!notifications.empty() && CSettings::Get().GetBool("general.addonnotifications"))
   {
     if (notifications.size() == 1)

--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -18,6 +18,7 @@
 *
 */
 #include "Scraper.h"
+#include "DatabaseManager.h"
 #include "filesystem/File.h"
 #include "filesystem/Directory.h"
 #include "filesystem/CurlFile.h"
@@ -403,8 +404,8 @@ bool CScraper::IsInUse() const
   }
   else
   { // video scraper
-    CVideoDatabase db;
-    if (db.Open() && db.ScraperInUse(ID()))
+    CVideoDatabase *database = CDatabaseManager::Get().GetVideoDatabase();
+    if (database->ScraperInUse(ID()))
       return true;
   }
   return false;

--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -398,8 +398,8 @@ bool CScraper::IsInUse() const
 {
   if (Supports(CONTENT_ALBUMS) || Supports(CONTENT_ARTISTS))
   { // music scraper
-    CMusicDatabase db;
-    if (db.Open() && db.ScraperInUse(ID()))
+    CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
+    if (database->ScraperInUse(ID()))
       return true;
   }
   else

--- a/xbmc/cdrip/CDDARipper.cpp
+++ b/xbmc/cdrip/CDDARipper.cpp
@@ -25,6 +25,7 @@
 
 #include "CDDARipper.h"
 #include "CDDARipJob.h"
+#include "DatabaseManager.h"
 #include "utils/StringUtils.h"
 #include "Util.h"
 #include "filesystem/CDDADirectory.h"
@@ -314,11 +315,9 @@ void CCDDARipper::OnJobComplete(unsigned int jobID, bool success, CJob* job)
       bool unimportant;
       int source = CUtil::GetMatchingSource(dir, *CMediaSourceSettings::Get().CMediaSourceSettings::GetSources("music"), unimportant);
 
-      CMusicDatabase database;
-      database.Open();
-      if (source>=0 && database.InsideScannedPath(dir))
+      CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
+      if (source>=0 && database->InsideScannedPath(dir))
         g_application.StartMusicScan(dir, false);
-      database.Close();
     }
     return CJobQueue::OnJobComplete(jobID, success, job);
   }

--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -321,7 +321,13 @@ bool CDatabase::Open(const DatabaseSettings &settings)
 
   std::string dbName = dbSettings.name;
   dbName += StringUtils::Format("%d", GetSchemaVersion());
-  return Connect(dbName, dbSettings, false);
+  bool retValue = Connect(dbName, dbSettings, false);
+
+#if (defined TARGET_POSIX)
+  CLog::Log(LOG_LEVEL_DEBUG, "Open database '%s' (address: %p, thread: %lu, connections: %i)", dbName.c_str(), this, (unsigned long)pthread_self(), m_openCount);
+#endif
+  
+  return retValue;
 }
 
 void CDatabase::InitSettings(DatabaseSettings &dbSettings)
@@ -581,6 +587,10 @@ void CDatabase::Close()
 
   m_openCount = 0;
   m_multipleExecute = false;
+
+#if (defined TARGET_POSIX)
+  CLog::Log(LOG_LEVEL_DEBUG, "Close database '%s' (address: %p, thread: %lu, connections: %i)", m_pDB->getDatabase(), this, (unsigned long)pthread_self(), m_openCount);
+#endif
 
   if (NULL == m_pDB.get() ) return ;
   if (NULL != m_pDS.get()) m_pDS->close();

--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -20,6 +20,7 @@
 
 #include "system.h"
 #include "GUIDialogContextMenu.h"
+#include "DatabaseManager.h"
 #include "guilib/GUIButtonControl.h"
 #include "guilib/GUIControlGroupList.h"
 #include "GUIDialogFileBrowser.h"
@@ -467,9 +468,8 @@ bool CGUIDialogContextMenu::OnContextButton(const std::string &type, const CFile
       }
       else if (!strThumb.empty())
       { // this is some sort of an auto-share, so store in the texture database
-        CTextureDatabase db;
-        if (db.Open())
-          db.SetTextureForPath(item->GetPath(), "thumb", strThumb);
+        CTextureDatabase *database = CDatabaseManager::Get().GetTextureDatabase();
+        database->SetTextureForPath(item->GetPath(), "thumb", strThumb);
       }
 
       CGUIMessage msg(GUI_MSG_NOTIFY_ALL,0,0,GUI_MSG_UPDATE_SOURCES);

--- a/xbmc/dialogs/GUIDialogMediaFilter.cpp
+++ b/xbmc/dialogs/GUIDialogMediaFilter.cpp
@@ -658,24 +658,21 @@ int CGUIDialogMediaFilter::GetItems(const Filter &filter, std::vector<std::strin
   }
   else if (m_mediaType == "artists" || m_mediaType == "albums" || m_mediaType == "songs")
   {
-    CMusicDatabase musicdb;
-    if (!musicdb.Open())
-      return -1;
-
+    CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
     std::set<std::string> playlists;
     CDatabase::Filter dbfilter;
-    dbfilter.where = tmpFilter.GetWhereClause(musicdb, playlists);
+    dbfilter.where = tmpFilter.GetWhereClause(*database, playlists);
     
     if (filter.field == FieldGenre)
-      musicdb.GetGenresNav(m_dbUrl->ToString(), selectItems, dbfilter, countOnly);
+      database->GetGenresNav(m_dbUrl->ToString(), selectItems, dbfilter, countOnly);
     else if (filter.field == FieldArtist)
-      musicdb.GetArtistsNav(m_dbUrl->ToString(), selectItems, m_mediaType == "albums", -1, -1, -1, dbfilter, SortDescription(), countOnly);
+      database->GetArtistsNav(m_dbUrl->ToString(), selectItems, m_mediaType == "albums", -1, -1, -1, dbfilter, SortDescription(), countOnly);
     else if (filter.field == FieldAlbum)
-      musicdb.GetAlbumsNav(m_dbUrl->ToString(), selectItems, -1, -1, dbfilter, SortDescription(), countOnly);
+      database->GetAlbumsNav(m_dbUrl->ToString(), selectItems, -1, -1, dbfilter, SortDescription(), countOnly);
     else if (filter.field == FieldAlbumType)
-      musicdb.GetAlbumTypesNav(m_dbUrl->ToString(), selectItems, dbfilter, countOnly);
+      database->GetAlbumTypesNav(m_dbUrl->ToString(), selectItems, dbfilter, countOnly);
     else if (filter.field == FieldMusicLabel)
-      musicdb.GetMusicLabelsNav(m_dbUrl->ToString(), selectItems, dbfilter, countOnly);
+      database->GetMusicLabelsNav(m_dbUrl->ToString(), selectItems, dbfilter, countOnly);
   }
 
   int size = selectItems.Size();

--- a/xbmc/dialogs/GUIDialogMediaFilter.cpp
+++ b/xbmc/dialogs/GUIDialogMediaFilter.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "GUIDialogMediaFilter.h"
+#include "DatabaseManager.h"
 #include "DbUrl.h"
 #include "FileItem.h"
 #include "GUIUserMessages.h"
@@ -629,13 +630,10 @@ int CGUIDialogMediaFilter::GetItems(const Filter &filter, std::vector<std::strin
 
   if (m_mediaType == "movies" || m_mediaType == "tvshows" || m_mediaType == "episodes" || m_mediaType == "musicvideos")
   {
-    CVideoDatabase videodb;
-    if (!videodb.Open())
-      return -1;
-
+    CVideoDatabase *database = CDatabaseManager::Get().GetVideoDatabase();
     std::set<std::string> playlists;
     CDatabase::Filter dbfilter;
-    dbfilter.where = tmpFilter.GetWhereClause(videodb, playlists);
+    dbfilter.where = tmpFilter.GetWhereClause(*database, playlists);
 
     VIDEODB_CONTENT_TYPE type = VIDEODB_CONTENT_MOVIES;    
     if (m_mediaType == "tvshows")
@@ -646,17 +644,17 @@ int CGUIDialogMediaFilter::GetItems(const Filter &filter, std::vector<std::strin
       type = VIDEODB_CONTENT_MUSICVIDEOS;
 
     if (filter.field == FieldGenre)
-      videodb.GetGenresNav(m_dbUrl->ToString(), selectItems, type, dbfilter, countOnly);
+      database->GetGenresNav(m_dbUrl->ToString(), selectItems, type, dbfilter, countOnly);
     else if (filter.field == FieldActor || filter.field == FieldArtist)
-      videodb.GetActorsNav(m_dbUrl->ToString(), selectItems, type, dbfilter, countOnly);
+      database->GetActorsNav(m_dbUrl->ToString(), selectItems, type, dbfilter, countOnly);
     else if (filter.field == FieldDirector)
-      videodb.GetDirectorsNav(m_dbUrl->ToString(), selectItems, type, dbfilter, countOnly);
+      database->GetDirectorsNav(m_dbUrl->ToString(), selectItems, type, dbfilter, countOnly);
     else if (filter.field == FieldStudio)
-      videodb.GetStudiosNav(m_dbUrl->ToString(), selectItems, type, dbfilter, countOnly);
+      database->GetStudiosNav(m_dbUrl->ToString(), selectItems, type, dbfilter, countOnly);
     else if (filter.field == FieldAlbum)
-      videodb.GetMusicVideoAlbumsNav(m_dbUrl->ToString(), selectItems, -1, dbfilter, countOnly);
+      database->GetMusicVideoAlbumsNav(m_dbUrl->ToString(), selectItems, -1, dbfilter, countOnly);
     else if (filter.field == FieldTag)
-      videodb.GetTagsNav(m_dbUrl->ToString(), selectItems, type, dbfilter, countOnly);
+      database->GetTagsNav(m_dbUrl->ToString(), selectItems, type, dbfilter, countOnly);
   }
   else if (m_mediaType == "artists" || m_mediaType == "albums" || m_mediaType == "songs")
   {

--- a/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
@@ -103,8 +103,7 @@ void CGUIDialogSmartPlaylistRule::OnOK()
 void CGUIDialogSmartPlaylistRule::OnBrowse()
 {
   CFileItemList items;
-  CMusicDatabase database;
-  database.Open();
+  CMusicDatabase *musicdatabase = CDatabaseManager::Get().GetMusicDatabase();
   CVideoDatabase *videodatabase = CDatabaseManager::Get().GetVideoDatabase();
 
   std::string basePath;
@@ -147,7 +146,7 @@ void CGUIDialogSmartPlaylistRule::OnBrowse()
              m_type == "albums" ||
              m_type == "artists" ||
              m_type == "mixed")
-      database.GetGenresNav("musicdb://genres/",items);
+      musicdatabase->GetGenresNav("musicdb://genres/",items);
     if (m_type == "musicvideos" ||
         m_type == "mixed")
     {
@@ -165,7 +164,7 @@ void CGUIDialogSmartPlaylistRule::OnBrowse()
   else if (m_rule.m_field == FieldArtist || m_rule.m_field == FieldAlbumArtist)
   {
     if (CSmartPlaylist::IsMusicType(m_type))
-      database.GetArtistsNav("musicdb://artists/", items, m_rule.m_field == FieldAlbumArtist, -1);
+      musicdatabase->GetArtistsNav("musicdb://artists/", items, m_rule.m_field == FieldAlbumArtist, -1);
     if (m_type == "musicvideos" ||
         m_type == "mixed")
     {
@@ -178,7 +177,7 @@ void CGUIDialogSmartPlaylistRule::OnBrowse()
   else if (m_rule.m_field == FieldAlbum)
   {
     if (CSmartPlaylist::IsMusicType(m_type))
-      database.GetAlbumsNav("musicdb://albums/", items);
+      musicdatabase->GetAlbumsNav("musicdb://albums/", items);
     if (m_type == "musicvideos" ||
         m_type == "mixed")
     {
@@ -196,7 +195,7 @@ void CGUIDialogSmartPlaylistRule::OnBrowse()
   else if (m_rule.m_field == FieldYear)
   {
     if (CSmartPlaylist::IsMusicType(m_type))
-      database.GetYearsNav("musicdb://years/", items);
+      musicdatabase->GetYearsNav("musicdb://years/", items);
     if (CSmartPlaylist::IsVideoType(m_type))
     {
       CFileItemList items2;
@@ -230,7 +229,7 @@ void CGUIDialogSmartPlaylistRule::OnBrowse()
   {
     if (m_type == "songs" || m_type == "mixed")
     {
-      database.GetSongsNav("musicdb://songs/", items, -1, -1, -1);
+      musicdatabase->GetSongsNav("musicdb://songs/", items, -1, -1, -1);
       iLabel = 134;
     }
     if (m_type == "movies")

--- a/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "GUIDialogSmartPlaylistRule.h"
+#include "DatabaseManager.h"
 #include "GUIDialogFileBrowser.h"
 #include "music/MusicDatabase.h"
 #include "video/VideoDatabase.h"
@@ -104,8 +105,7 @@ void CGUIDialogSmartPlaylistRule::OnBrowse()
   CFileItemList items;
   CMusicDatabase database;
   database.Open();
-  CVideoDatabase videodatabase;
-  videodatabase.Open();
+  CVideoDatabase *videodatabase = CDatabaseManager::Get().GetVideoDatabase();
 
   std::string basePath;
   if (CSmartPlaylist::IsMusicType(m_type))
@@ -142,7 +142,7 @@ void CGUIDialogSmartPlaylistRule::OnBrowse()
     if (m_type == "tvshows" ||
         m_type == "episodes" ||
         m_type == "movies")
-      videodatabase.GetGenresNav(basePath + "genres/", items, type);
+      videodatabase->GetGenresNav(basePath + "genres/", items, type);
     else if (m_type == "songs" ||
              m_type == "albums" ||
              m_type == "artists" ||
@@ -152,14 +152,14 @@ void CGUIDialogSmartPlaylistRule::OnBrowse()
         m_type == "mixed")
     {
       CFileItemList items2;
-      videodatabase.GetGenresNav("videodb://musicvideos/genres/",items2,VIDEODB_CONTENT_MUSICVIDEOS);
+      videodatabase->GetGenresNav("videodb://musicvideos/genres/",items2,VIDEODB_CONTENT_MUSICVIDEOS);
       items.Append(items2);
     }
     iLabel = 515;
   }
   else if (m_rule.m_field == FieldCountry)
   {
-    videodatabase.GetCountriesNav(basePath, items, type);
+    videodatabase->GetCountriesNav(basePath, items, type);
     iLabel = 574;
   }
   else if (m_rule.m_field == FieldArtist || m_rule.m_field == FieldAlbumArtist)
@@ -170,7 +170,7 @@ void CGUIDialogSmartPlaylistRule::OnBrowse()
         m_type == "mixed")
     {
       CFileItemList items2;
-      videodatabase.GetMusicVideoArtistsByName("", items2);
+      videodatabase->GetMusicVideoArtistsByName("", items2);
       items.Append(items2);
     }
     iLabel = 557;
@@ -183,14 +183,14 @@ void CGUIDialogSmartPlaylistRule::OnBrowse()
         m_type == "mixed")
     {
       CFileItemList items2;
-      videodatabase.GetMusicVideoAlbumsByName("", items2);
+      videodatabase->GetMusicVideoAlbumsByName("", items2);
       items.Append(items2);
     }
     iLabel = 558;
   }
   else if (m_rule.m_field == FieldActor)
   {
-    videodatabase.GetActorsNav(basePath + "actors/",items,type);
+    videodatabase->GetActorsNav(basePath + "actors/",items,type);
     iLabel = 20337;
   }
   else if (m_rule.m_field == FieldYear)
@@ -200,30 +200,30 @@ void CGUIDialogSmartPlaylistRule::OnBrowse()
     if (CSmartPlaylist::IsVideoType(m_type))
     {
       CFileItemList items2;
-      videodatabase.GetYearsNav(basePath + "years/", items2, type);
+      videodatabase->GetYearsNav(basePath + "years/", items2, type);
       items.Append(items2);
     }
     iLabel = 562;
   }
   else if (m_rule.m_field == FieldDirector)
   {
-    videodatabase.GetDirectorsNav(basePath + "directors/", items, type);
+    videodatabase->GetDirectorsNav(basePath + "directors/", items, type);
     iLabel = 20339;
   }
   else if (m_rule.m_field == FieldStudio)
   {
-    videodatabase.GetStudiosNav(basePath + "studios/", items, type);
+    videodatabase->GetStudiosNav(basePath + "studios/", items, type);
     iLabel = 572;
   }
   else if (m_rule.m_field == FieldWriter)
   {
-    videodatabase.GetWritersNav(basePath, items, type);
+    videodatabase->GetWritersNav(basePath, items, type);
     iLabel = 20417;
   }
   else if (m_rule.m_field == FieldTvShowTitle ||
           (m_type == "tvshows" && m_rule.m_field == FieldTitle))
   {
-    videodatabase.GetTvShowsNav(basePath + "titles/", items);
+    videodatabase->GetTvShowsNav(basePath + "titles/", items);
     iLabel = 20343;
   }
   else if (m_rule.m_field == FieldTitle)
@@ -235,12 +235,12 @@ void CGUIDialogSmartPlaylistRule::OnBrowse()
     }
     if (m_type == "movies")
     {
-      videodatabase.GetMoviesNav(basePath + "titles/", items);
+      videodatabase->GetMoviesNav(basePath + "titles/", items);
       iLabel = 20342;
     }
     if (m_type == "episodes")
     {
-      videodatabase.GetEpisodesNav(basePath + "titles/-1/-1/", items);
+      videodatabase->GetEpisodesNav(basePath + "titles/-1/-1/", items);
       // we need to replace the db label (<season>x<episode> <title>) with the title only
       CLabelFormatter format("%T", "");
       for (int i = 0; i < items.Size(); i++)
@@ -249,7 +249,7 @@ void CGUIDialogSmartPlaylistRule::OnBrowse()
     }
     if (m_type == "musicvideos" || m_type == "mixed")
     {
-      videodatabase.GetMusicVideosNav(basePath + "titles/", items);
+      videodatabase->GetMusicVideosNav(basePath + "titles/", items);
       iLabel = 20389;
     }
   }
@@ -314,7 +314,7 @@ void CGUIDialogSmartPlaylistRule::OnBrowse()
   }
   else if (m_rule.m_field == FieldSet)
   {
-    videodatabase.GetSetsNav("videodb://movies/sets/", items, VIDEODB_CONTENT_MOVIES);
+    videodatabase->GetSetsNav("videodb://movies/sets/", items, VIDEODB_CONTENT_MOVIES);
     iLabel = 20434;
   }
   else if (m_rule.m_field == FieldTag)
@@ -328,7 +328,7 @@ void CGUIDialogSmartPlaylistRule::OnBrowse()
     else if (m_type != "movies")
       return;
 
-    videodatabase.GetTagsNav(basePath + "tags/", items, type);
+    videodatabase->GetTagsNav(basePath + "tags/", items, type);
     iLabel = 20459;
   }
   else

--- a/xbmc/epg/Epg.cpp
+++ b/xbmc/epg/Epg.cpp
@@ -18,6 +18,7 @@
  *
  */
 
+#include "DatabaseManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
@@ -353,7 +354,7 @@ bool CEpg::UpdateEntry(const CEpgInfoTag &tag, bool bUpdateDatabase /* = false *
 bool CEpg::Load(void)
 {
   bool bReturn(false);
-  CEpgDatabase *database = g_EpgContainer.GetDatabase();
+  CEpgDatabase *database = CDatabaseManager::Get().GetEpgDatabase();
 
   if (!database || !database->IsOpen())
   {
@@ -418,7 +419,7 @@ CDateTime CEpg::GetLastScanTime(void)
     {
       if (!CSettings::Get().GetBool("epg.ignoredbforclient"))
       {
-        CEpgDatabase *database = g_EpgContainer.GetDatabase();
+        CEpgDatabase *database = CDatabaseManager::Get().GetEpgDatabase();
         CDateTime dtReturn; dtReturn.SetValid(false);
 
         if (database && database->IsOpen())
@@ -528,7 +529,7 @@ bool CEpg::Persist(void)
   CLog::Log(LOGDEBUG, "persist table '%s' (#%d) changed=%d deleted=%d", Name().c_str(), m_iEpgID, m_changedTags.size(), m_deletedTags.size());
 #endif
 
-  CEpgDatabase *database = g_EpgContainer.GetDatabase();
+  CEpgDatabase *database = CDatabaseManager::Get().GetEpgDatabase();
   if (!database || !database->IsOpen())
   {
     CLog::Log(LOGERROR, "EPG - %s - could not open the database", __FUNCTION__);

--- a/xbmc/epg/EpgContainer.h
+++ b/xbmc/epg/EpgContainer.h
@@ -68,12 +68,6 @@ namespace EPG
     static CEpgContainer &Get(void);
 
     /*!
-     * @brief Get a pointer to the database instance.
-     * @return A pointer to the database instance.
-     */
-    CEpgDatabase *GetDatabase(void) { return &m_database; }
-
-    /*!
      * @brief Start the EPG update thread.
      */
     virtual void Start(void);
@@ -285,8 +279,6 @@ namespace EPG
     typedef std::map<unsigned int, CEpg*> EPGMAP;
     typedef EPGMAP::iterator              EPGMAP_ITR;
     typedef EPGMAP::const_iterator        EPGMAP_CITR;
-
-    CEpgDatabase m_database;           /*!< the EPG database */
 
     /** @name Configuration */
     //@{

--- a/xbmc/epg/EpgInfoTag.cpp
+++ b/xbmc/epg/EpgInfoTag.cpp
@@ -18,6 +18,7 @@
  *
  */
 
+#include "DatabaseManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "Epg.h"
 #include "EpgInfoTag.h"
@@ -664,7 +665,7 @@ bool CEpgInfoTag::Persist(bool bSingleUpdate /* = true */)
   CLog::Log(LOGDEBUG, "Epg - %s - Infotag '%s' %s, persisting...", __FUNCTION__, m_strTitle.c_str(), m_iBroadcastId > 0 ? "has changes" : "is new");
 #endif
 
-  CEpgDatabase *database = g_EpgContainer.GetDatabase();
+  CEpgDatabase *database = CDatabaseManager::Get().GetEpgDatabase();
   if (!database || (bSingleUpdate && !database->IsOpen()))
   {
     CLog::Log(LOGERROR, "%s - could not open the database", __FUNCTION__);

--- a/xbmc/filesystem/CDDADirectory.cpp
+++ b/xbmc/filesystem/CDDADirectory.cpp
@@ -23,6 +23,7 @@
 #ifdef HAS_DVD_DRIVE
 
 #include "CDDADirectory.h"
+#include "DatabaseManager.h"
 #include "music/MusicDatabase.h"
 #include "FileItem.h"
 #include "File.h"
@@ -55,8 +56,8 @@ bool CCDDADirectory::GetDirectory(const CURL& url, CFileItemList &items)
     return false;
 
   //  Preload CDDB info
-  CMusicDatabase musicdatabase;
-  musicdatabase.LookupCDDBInfo();
+  CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
+  database->LookupCDDBInfo();
 
   // If the disc has no tracks, we are finished here.
   int nTracks = pCdInfo->GetTrackCount();

--- a/xbmc/filesystem/MusicDatabaseDirectory.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "MusicDatabaseDirectory.h"
+#include "DatabaseManager.h"
 #include "utils/URIUtils.h"
 #include "MusicDatabaseDirectory/QueryParams.h"
 #include "music/MusicDatabase.h"
@@ -151,20 +152,18 @@ bool CMusicDatabaseDirectory::GetLabel(const std::string& strDirectory, std::str
   CQueryParams params;
   CDirectoryNode::GetDatabaseInfo(path, params);
 
-  CMusicDatabase musicdatabase;
-  if (!musicdatabase.Open())
-    return false;
+  CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
 
   // get genre
   if (params.GetGenreId() >= 0)
-    strLabel += musicdatabase.GetGenreById(params.GetGenreId());
+    strLabel += database->GetGenreById(params.GetGenreId());
 
   // get artist
   if (params.GetArtistId() >= 0)
   {
     if (!strLabel.empty())
       strLabel += " / ";
-    strLabel += musicdatabase.GetArtistById(params.GetArtistId());
+    strLabel += database->GetArtistById(params.GetArtistId());
   }
 
   // get album
@@ -172,7 +171,7 @@ bool CMusicDatabaseDirectory::GetLabel(const std::string& strDirectory, std::str
   {
     if (!strLabel.empty())
       strLabel += " / ";
-    strLabel += musicdatabase.GetAlbumById(params.GetAlbumId());
+    strLabel += database->GetAlbumById(params.GetAlbumId());
   }
 
   if (strLabel.empty())

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbum.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbum.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "DirectoryNodeAlbum.h"
+#include "DatabaseManager.h"
 #include "QueryParams.h"
 #include "music/MusicDatabase.h"
 
@@ -39,24 +40,14 @@ std::string CDirectoryNodeAlbum::GetLocalizedName() const
 {
   if (GetID() == -1)
     return g_localizeStrings.Get(15102); // All Albums
-  CMusicDatabase db;
-  if (db.Open())
-    return db.GetAlbumById(GetID());
-  return "";
+  CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
+  return database->GetAlbumById(GetID());
 }
 
 bool CDirectoryNodeAlbum::GetContent(CFileItemList& items) const
 {
-  CMusicDatabase musicdatabase;
-  if (!musicdatabase.Open())
-    return false;
-
   CQueryParams params;
   CollectQueryParams(params);
-
-  bool bSuccess=musicdatabase.GetAlbumsNav(BuildPath(), items, params.GetGenreId(), params.GetArtistId());
-
-  musicdatabase.Close();
-
-  return bSuccess;
+  CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
+  return database->GetAlbumsNav(BuildPath(), items, params.GetGenreId(), params.GetArtistId());
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumCompilations.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumCompilations.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "DirectoryNodeAlbumCompilations.h"
+#include "DatabaseManager.h"
 #include "QueryParams.h"
 #include "music/MusicDatabase.h"
 
@@ -42,24 +43,15 @@ std::string CDirectoryNodeAlbumCompilations::GetLocalizedName() const
 {
   if (GetID() == -1)
     return g_localizeStrings.Get(15102); // All Albums
-  CMusicDatabase db;
-  if (db.Open())
-    return db.GetAlbumById(GetID());
-  return "";
+  CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
+  return database->GetAlbumById(GetID());
 }
 
 bool CDirectoryNodeAlbumCompilations::GetContent(CFileItemList& items) const
 {
-  CMusicDatabase musicdatabase;
-  if (!musicdatabase.Open())
-    return false;
-
   CQueryParams params;
   CollectQueryParams(params);
 
-  bool bSuccess=musicdatabase.GetCompilationAlbums(BuildPath(), items);
-
-  musicdatabase.Close();
-
-  return bSuccess;
+  CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
+  return database->GetCompilationAlbums(BuildPath(), items);
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumCompilationsSongs.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumCompilationsSongs.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "DirectoryNodeAlbumCompilationsSongs.h"
+#include "DatabaseManager.h"
 #include "QueryParams.h"
 #include "music/MusicDatabase.h"
 
@@ -30,19 +31,10 @@ CDirectoryNodeAlbumCompilationsSongs::CDirectoryNodeAlbumCompilationsSongs(const
 
 }
 
-
 bool CDirectoryNodeAlbumCompilationsSongs::GetContent(CFileItemList& items) const
 {
-  CMusicDatabase musicdatabase;
-  if (!musicdatabase.Open())
-    return false;
-
   CQueryParams params;
   CollectQueryParams(params);
-
-  bool bSuccess=musicdatabase.GetCompilationSongs(BuildPath(), items);
-
-  musicdatabase.Close();
-
-  return bSuccess;
+  CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
+  return database->GetCompilationSongs(BuildPath(), items);
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyAdded.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyAdded.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "DirectoryNodeAlbumRecentlyAdded.h"
+#include "DatabaseManager.h"
 #include "music/MusicDatabase.h"
 #include "FileItem.h"
 #include "utils/StringUtils.h"
@@ -43,24 +44,17 @@ std::string CDirectoryNodeAlbumRecentlyAdded::GetLocalizedName() const
 {
   if (GetID() == -1)
     return g_localizeStrings.Get(15102); // All Albums
-  CMusicDatabase db;
-  if (db.Open())
-    return db.GetAlbumById(GetID());
-  return "";
+  CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
+  return database->GetAlbumById(GetID());
 }
 
 bool CDirectoryNodeAlbumRecentlyAdded::GetContent(CFileItemList& items) const
 {
-  CMusicDatabase musicdatabase;
-  if (!musicdatabase.Open())
-    return false;
+  CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
 
   VECALBUMS albums;
-  if (!musicdatabase.GetRecentlyAddedAlbums(albums))
-  {
-    musicdatabase.Close();
+  if (!database->GetRecentlyAddedAlbums(albums))
     return false;
-  }
 
   for (int i=0; i<(int)albums.size(); ++i)
   {
@@ -70,6 +64,5 @@ bool CDirectoryNodeAlbumRecentlyAdded::GetContent(CFileItemList& items) const
     items.Add(pItem);
   }
 
-  musicdatabase.Close();
   return true;
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyAddedSong.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyAddedSong.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "DirectoryNodeAlbumRecentlyAddedSong.h"
+#include "DatabaseManager.h"
 #include "music/MusicDatabase.h"
 
 using namespace XFILE::MUSICDATABASEDIRECTORY;
@@ -31,14 +32,6 @@ CDirectoryNodeAlbumRecentlyAddedSong::CDirectoryNodeAlbumRecentlyAddedSong(const
 
 bool CDirectoryNodeAlbumRecentlyAddedSong::GetContent(CFileItemList& items) const
 {
-  CMusicDatabase musicdatabase;
-  if (!musicdatabase.Open())
-    return false;
-
-  std::string strBaseDir=BuildPath();
-  bool bSuccess=musicdatabase.GetRecentlyAddedAlbumSongs(strBaseDir, items);
-
-  musicdatabase.Close();
-
-  return bSuccess;
+  CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
+  return database->GetRecentlyAddedAlbumSongs(BuildPath(), items);
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyPlayed.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyPlayed.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "DirectoryNodeAlbumRecentlyPlayed.h"
+#include "DatabaseManager.h"
 #include "music/MusicDatabase.h"
 #include "FileItem.h"
 #include "utils/StringUtils.h"
@@ -43,24 +44,17 @@ std::string CDirectoryNodeAlbumRecentlyPlayed::GetLocalizedName() const
 {
   if (GetID() == -1)
     return g_localizeStrings.Get(15102); // All Albums
-  CMusicDatabase db;
-  if (db.Open())
-    return db.GetAlbumById(GetID());
-  return "";
+  CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
+  return database->GetAlbumById(GetID());
 }
 
 bool CDirectoryNodeAlbumRecentlyPlayed::GetContent(CFileItemList& items) const
 {
-  CMusicDatabase musicdatabase;
-  if (!musicdatabase.Open())
-    return false;
+  CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
 
   VECALBUMS albums;
-  if (!musicdatabase.GetRecentlyPlayedAlbums(albums))
-  {
-    musicdatabase.Close();
+  if (!database->GetRecentlyPlayedAlbums(albums))
     return false;
-  }
 
   for (int i=0; i<(int)albums.size(); ++i)
   {
@@ -69,9 +63,6 @@ bool CDirectoryNodeAlbumRecentlyPlayed::GetContent(CFileItemList& items) const
     CFileItemPtr pItem(new CFileItem(strDir, album));
     items.Add(pItem);
   }
-
-
-  musicdatabase.Close();
 
   return true;
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyPlayedSong.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyPlayedSong.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "DirectoryNodeAlbumRecentlyPlayedSong.h"
+#include "DatabaseManager.h"
 #include "music/MusicDatabase.h"
 
 using namespace XFILE::MUSICDATABASEDIRECTORY;
@@ -31,14 +32,6 @@ CDirectoryNodeAlbumRecentlyPlayedSong::CDirectoryNodeAlbumRecentlyPlayedSong(con
 
 bool CDirectoryNodeAlbumRecentlyPlayedSong::GetContent(CFileItemList& items) const
 {
-  CMusicDatabase musicdatabase;
-  if (!musicdatabase.Open())
-    return false;
-
-  std::string strBaseDir=BuildPath();
-  bool bSuccess=musicdatabase.GetRecentlyPlayedAlbumSongs(strBaseDir, items);
-
-  musicdatabase.Close();
-
-  return bSuccess;
+  CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
+  return database->GetRecentlyPlayedAlbumSongs(BuildPath(), items);
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumTop100.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumTop100.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "DirectoryNodeAlbumTop100.h"
+#include "DatabaseManager.h"
 #include "music/MusicDatabase.h"
 #include "FileItem.h"
 #include "utils/StringUtils.h"
@@ -41,24 +42,17 @@ NODE_TYPE CDirectoryNodeAlbumTop100::GetChildType() const
 
 std::string CDirectoryNodeAlbumTop100::GetLocalizedName() const
 {
-  CMusicDatabase db;
-  if (db.Open())
-    return db.GetAlbumById(GetID());
-  return "";
+  CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
+  return database->GetAlbumById(GetID());
 }
 
 bool CDirectoryNodeAlbumTop100::GetContent(CFileItemList& items) const
 {
-  CMusicDatabase musicdatabase;
-  if (!musicdatabase.Open())
-    return false;
+  CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
 
   VECALBUMS albums;
-  if (!musicdatabase.GetTop100Albums(albums))
-  {
-    musicdatabase.Close();
+  if (!database->GetTop100Albums(albums))
     return false;
-  }
 
   for (int i=0; i<(int)albums.size(); ++i)
   {
@@ -67,8 +61,6 @@ bool CDirectoryNodeAlbumTop100::GetContent(CFileItemList& items) const
     CFileItemPtr pItem(new CFileItem(strDir, album));
     items.Add(pItem);
   }
-
-  musicdatabase.Close();
 
   return true;
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumTop100Song.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumTop100Song.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "DirectoryNodeAlbumTop100Song.h"
+#include "DatabaseManager.h"
 #include "music/MusicDatabase.h"
 
 using namespace XFILE::MUSICDATABASEDIRECTORY;
@@ -31,14 +32,6 @@ CDirectoryNodeAlbumTop100Song::CDirectoryNodeAlbumTop100Song(const std::string& 
 
 bool CDirectoryNodeAlbumTop100Song::GetContent(CFileItemList& items) const
 {
-  CMusicDatabase musicdatabase;
-  if (!musicdatabase.Open())
-    return false;
-
-  std::string strBaseDir=BuildPath();
-  bool bSuccess=musicdatabase.GetTop100AlbumSongs(strBaseDir, items);
-
-  musicdatabase.Close();
-
-  return bSuccess;
+  CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
+  return database->GetTop100AlbumSongs(BuildPath(), items);
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeArtist.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeArtist.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "DirectoryNodeArtist.h"
+#include "DatabaseManager.h"
 #include "QueryParams.h"
 #include "music/MusicDatabase.h"
 #include "settings/Settings.h"
@@ -40,24 +41,14 @@ std::string CDirectoryNodeArtist::GetLocalizedName() const
 {
   if (GetID() == -1)
     return g_localizeStrings.Get(15103); // All Artists
-  CMusicDatabase db;
-  if (db.Open())
-    return db.GetArtistById(GetID());
-  return "";
+  CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
+  return database->GetArtistById(GetID());
 }
 
 bool CDirectoryNodeArtist::GetContent(CFileItemList& items) const
 {
-  CMusicDatabase musicdatabase;
-  if (!musicdatabase.Open())
-    return false;
-
   CQueryParams params;
   CollectQueryParams(params);
-
-  bool bSuccess = musicdatabase.GetArtistsNav(BuildPath(), items, !CSettings::Get().GetBool("musiclibrary.showcompilationartists"), params.GetGenreId());
-
-  musicdatabase.Close();
-
-  return bSuccess;
+  CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
+  return database->GetArtistsNav(BuildPath(), items, !CSettings::Get().GetBool("musiclibrary.showcompilationartists"), params.GetGenreId());
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeGrouped.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeGrouped.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "DirectoryNodeGrouped.h"
+#include "DatabaseManager.h"
 #include "QueryParams.h"
 #include "music/MusicDatabase.h"
 
@@ -38,19 +39,14 @@ NODE_TYPE CDirectoryNodeGrouped::GetChildType() const
 
 std::string CDirectoryNodeGrouped::GetLocalizedName() const
 {
-  CMusicDatabase db;
-  if (db.Open())
-    return db.GetItemById(GetContentType(), GetID());
-  return "";
+  CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
+  return database->GetItemById(GetContentType(), GetID());
 }
 
 bool CDirectoryNodeGrouped::GetContent(CFileItemList& items) const
 {
-  CMusicDatabase musicdatabase;
-  if (!musicdatabase.Open())
-    return false;
-
-  return musicdatabase.GetItems(BuildPath(), GetContentType(), items);
+  CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
+  return database->GetItems(BuildPath(), GetContentType(), items);
 }
 
 std::string CDirectoryNodeGrouped::GetContentType() const

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeOverview.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeOverview.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "DirectoryNodeOverview.h"
+#include "DatabaseManager.h"
 #include "FileItem.h"
 #include "music/MusicDatabase.h"
 #include "guilib/LocalizeStrings.h"
@@ -70,11 +71,10 @@ std::string CDirectoryNodeOverview::GetLocalizedName() const
 
 bool CDirectoryNodeOverview::GetContent(CFileItemList& items) const
 {
-  CMusicDatabase musicDatabase;
-  musicDatabase.Open();
+  CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
 
-  bool hasSingles = (musicDatabase.GetSinglesCount() > 0);
-  bool hasCompilations = (musicDatabase.GetCompilationAlbumsCount() > 0);
+  bool hasSingles = (database->GetSinglesCount() > 0);
+  bool hasCompilations = (database->GetCompilationAlbumsCount() > 0);
 
   for (unsigned int i = 0; i < sizeof(OverviewChildren) / sizeof(Node); ++i)
   {

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeSingles.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeSingles.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "DirectoryNodeSingles.h"
+#include "DatabaseManager.h"
 #include "QueryParams.h"
 #include "music/MusicDatabase.h"
 
@@ -32,13 +33,6 @@ CDirectoryNodeSingles::CDirectoryNodeSingles(const std::string& strName, CDirect
 
 bool CDirectoryNodeSingles::GetContent(CFileItemList& items) const
 {
-  CMusicDatabase musicdatabase;
-  if (!musicdatabase.Open())
-    return false;
-
-  bool bSuccess=musicdatabase.GetSongsByWhere(BuildPath(), CDatabase::Filter(), items);
-
-  musicdatabase.Close();
-
-  return bSuccess;
+  CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
+  return database->GetSongsByWhere(BuildPath(), CDatabase::Filter(), items);
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeSong.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeSong.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "DirectoryNodeSong.h"
+#include "DatabaseManager.h"
 #include "QueryParams.h"
 #include "music/MusicDatabase.h"
 
@@ -32,17 +33,9 @@ CDirectoryNodeSong::CDirectoryNodeSong(const std::string& strName, CDirectoryNod
 
 bool CDirectoryNodeSong::GetContent(CFileItemList& items) const
 {
-  CMusicDatabase musicdatabase;
-  if (!musicdatabase.Open())
-    return false;
-
   CQueryParams params;
   CollectQueryParams(params);
+  CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
 
-  std::string strBaseDir=BuildPath();
-  bool bSuccess=musicdatabase.GetSongsNav(strBaseDir, items, params.GetGenreId(), params.GetArtistId(), params.GetAlbumId());
-
-  musicdatabase.Close();
-
-  return bSuccess;
+  return database->GetSongsNav(BuildPath(), items, params.GetGenreId(), params.GetArtistId(), params.GetAlbumId());
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeSongTop100.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeSongTop100.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "DirectoryNodeSongTop100.h"
+#include "DatabaseManager.h"
 #include "music/MusicDatabase.h"
 
 using namespace XFILE::MUSICDATABASEDIRECTORY;
@@ -31,14 +32,6 @@ CDirectoryNodeSongTop100::CDirectoryNodeSongTop100(const std::string& strName, C
 
 bool CDirectoryNodeSongTop100::GetContent(CFileItemList& items) const
 {
-  CMusicDatabase musicdatabase;
-  if (!musicdatabase.Open())
-    return false;
-
-  std::string strBaseDir=BuildPath();
-  bool bSuccess=musicdatabase.GetTop100(strBaseDir, items);
-
-  musicdatabase.Close();
-
-  return bSuccess;
+  CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
+  return database->GetTop100(BuildPath(), items);
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeYearAlbum.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeYearAlbum.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "DirectoryNodeYearAlbum.h"
+#include "DatabaseManager.h"
 #include "QueryParams.h"
 #include "music/MusicDatabase.h"
 
@@ -42,24 +43,15 @@ std::string CDirectoryNodeYearAlbum::GetLocalizedName() const
 {
   if (GetID() == -1)
     return g_localizeStrings.Get(15102); // All Albums
-  CMusicDatabase db;
-  if (db.Open())
-    return db.GetAlbumById(GetID());
-  return "";
+  CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
+  return database->GetAlbumById(GetID());
 }
 
 bool CDirectoryNodeYearAlbum::GetContent(CFileItemList& items) const
 {
-  CMusicDatabase musicdatabase;
-  if (!musicdatabase.Open())
-    return false;
-
   CQueryParams params;
   CollectQueryParams(params);
+  CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
 
-  bool bSuccess=musicdatabase.GetAlbumsByYear(BuildPath(), items, params.GetYear());
-
-  musicdatabase.Close();
-
-  return bSuccess;
+  return database->GetAlbumsByYear(BuildPath(), items, params.GetYear());
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeYearSong.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeYearSong.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "DirectoryNodeYearSong.h"
+#include "DatabaseManager.h"
 #include "QueryParams.h"
 #include "music/MusicDatabase.h"
 
@@ -32,17 +33,9 @@ CDirectoryNodeYearSong::CDirectoryNodeYearSong(const std::string& strName, CDire
 
 bool CDirectoryNodeYearSong::GetContent(CFileItemList& items) const
 {
-  CMusicDatabase musicdatabase;
-  if (!musicdatabase.Open())
-    return false;
-
   CQueryParams params;
   CollectQueryParams(params);
+  CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
 
-  std::string strBaseDir=BuildPath();
-  bool bSuccess=musicdatabase.GetSongsByYear(strBaseDir, items, params.GetYear());
-
-  musicdatabase.Close();
-
-  return bSuccess;
+  return database->GetSongsByYear(BuildPath(), items, params.GetYear());
 }

--- a/xbmc/filesystem/MusicDatabaseFile.cpp
+++ b/xbmc/filesystem/MusicDatabaseFile.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "MusicDatabaseFile.h"
+#include "DatabaseManager.h"
 #include "music/MusicDatabase.h"
 #include "URL.h"
 #include "utils/StringUtils.h"
@@ -39,10 +40,6 @@ CMusicDatabaseFile::~CMusicDatabaseFile(void)
 
 std::string CMusicDatabaseFile::TranslateUrl(const CURL& url)
 {
-  CMusicDatabase musicDatabase;
-  if (!musicDatabase.Open())
-    return "";
-
   std::string strFileName=URIUtils::GetFileName(url.Get());
   std::string strExtension = URIUtils::GetExtension(strFileName);
   URIUtils::RemoveExtension(strFileName);
@@ -52,8 +49,9 @@ std::string CMusicDatabaseFile::TranslateUrl(const CURL& url)
 
   long idSong=atol(strFileName.c_str());
 
+  CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
   CSong song;
-  if (!musicDatabase.GetSong(idSong, song))
+  if (!database->GetSong(idSong, song))
     return "";
 
   StringUtils::ToLower(strExtension);

--- a/xbmc/filesystem/MusicSearchDirectory.cpp
+++ b/xbmc/filesystem/MusicSearchDirectory.cpp
@@ -20,6 +20,7 @@
 
 #include "threads/SystemClock.h"
 #include "MusicSearchDirectory.h"
+#include "DatabaseManager.h"
 #include "music/MusicDatabase.h"
 #include "URL.h"
 #include "FileItem.h"
@@ -49,10 +50,9 @@ bool CMusicSearchDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   // and retrieve the search details
   items.SetURL(url);
   unsigned int time = XbmcThreads::SystemClockMillis();
-  CMusicDatabase db;
-  db.Open();
-  db.Search(search, items);
-  db.Close();
+
+  CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
+  database->Search(search, items);
   CLog::Log(LOGDEBUG, "%s (%s) took %u ms",
             __FUNCTION__, url.GetRedacted().c_str(), XbmcThreads::SystemClockMillis() - time);
   items.SetLabel(g_localizeStrings.Get(137)); // Search

--- a/xbmc/filesystem/SmartPlaylistDirectory.cpp
+++ b/xbmc/filesystem/SmartPlaylistDirectory.cpp
@@ -21,6 +21,7 @@
 #include <math.h>
 
 #include "SmartPlaylistDirectory.h"
+#include "DatabaseManager.h"
 #include "FileItem.h"
 #include "filesystem/Directory.h"
 #include "filesystem/File.h"
@@ -99,58 +100,54 @@ namespace XFILE
         playlist.GetType() == "tvshows" ||
         playlist.GetType() == "episodes")
     {
-      CVideoDatabase db;
-      if (db.Open())
+      MediaType mediaType = MediaTypes::FromString(playlist.GetType());
+
+      std::string baseDir = strBaseDir;
+      if (strBaseDir.empty())
       {
-        MediaType mediaType = MediaTypes::FromString(playlist.GetType());
-
-        std::string baseDir = strBaseDir;
-        if (strBaseDir.empty())
-        {
-          if (mediaType == MediaTypeTvShow || mediaType == MediaTypeEpisode)
-            baseDir = "videodb://tvshows/";
-          else if (mediaType == MediaTypeMovie)
-            baseDir = "videodb://movies/";
-          else
-            return false;
-
-          if (!isGrouped)
-            baseDir += "titles";
-          else
-            baseDir += group;
-          URIUtils::AddSlashAtEnd(baseDir);
-
-          if (mediaType == MediaTypeEpisode)
-            baseDir += "-1/-1/";
-        }
-
-        CVideoDbUrl videoUrl;
-        if (!videoUrl.FromString(baseDir))
+        if (mediaType == MediaTypeTvShow || mediaType == MediaTypeEpisode)
+          baseDir = "videodb://tvshows/";
+        else if (mediaType == MediaTypeMovie)
+          baseDir = "videodb://movies/";
+        else
           return false;
 
-        // store the smartplaylist as JSON in the URL as well
-        std::string xsp;
-        if (!playlist.IsEmpty(filter))
-        {
-          if (!playlist.SaveAsJson(xsp, !filter))
-            return false;
-        }
-
-        if (!xsp.empty())
-          videoUrl.AddOption(option, xsp);
+        if (!isGrouped)
+          baseDir += "titles";
         else
-          videoUrl.RemoveOption(option);
-        
-        CDatabase::Filter dbfilter;
-        success = db.GetItems(videoUrl.ToString(), items, dbfilter, sorting);
-        db.Close();
+          baseDir += group;
+        URIUtils::AddSlashAtEnd(baseDir);
 
-        // if we retrieve a list of episodes and we didn't receive
-        // a pre-defined base path, we need to fix it
-        if (strBaseDir.empty() && mediaType == MediaTypeEpisode && !isGrouped)
-          videoUrl.AppendPath("-1/-1/");
-        items.SetProperty(PROPERTY_PATH_DB, videoUrl.ToString());
+        if (mediaType == MediaTypeEpisode)
+          baseDir += "-1/-1/";
       }
+
+      CVideoDbUrl videoUrl;
+      if (!videoUrl.FromString(baseDir))
+        return false;
+
+      // store the smartplaylist as JSON in the URL as well
+      std::string xsp;
+      if (!playlist.IsEmpty(filter))
+      {
+        if (!playlist.SaveAsJson(xsp, !filter))
+          return false;
+      }
+
+      if (!xsp.empty())
+        videoUrl.AddOption(option, xsp);
+      else
+        videoUrl.RemoveOption(option);
+      
+      CDatabase::Filter dbfilter;
+      CVideoDatabase *database = CDatabaseManager::Get().GetVideoDatabase();
+      success = database->GetItems(videoUrl.ToString(), items, dbfilter, sorting);
+
+      // if we retrieve a list of episodes and we didn't receive
+      // a pre-defined base path, we need to fix it
+      if (strBaseDir.empty() && mediaType == MediaTypeEpisode && !isGrouped)
+        videoUrl.AppendPath("-1/-1/");
+      items.SetProperty(PROPERTY_PATH_DB, videoUrl.ToString());
     }
     else if (playlist.IsMusicType() || playlist.GetType().empty())
     {
@@ -211,60 +208,57 @@ namespace XFILE
 
     if (playlist.GetType() == "musicvideos" || playlist.GetType() == "mixed")
     {
-      CVideoDatabase db;
-      if (db.Open())
+
+      CSmartPlaylist mvidPlaylist(playlist);
+      if (playlist.GetType() == "mixed")
+        mvidPlaylist.SetType("musicvideos");
+
+      std::string baseDir = strBaseDir;
+      if (baseDir.empty())
       {
-        CSmartPlaylist mvidPlaylist(playlist);
-        if (playlist.GetType() == "mixed")
-          mvidPlaylist.SetType("musicvideos");
+        baseDir = "videodb://musicvideos/";
 
-        std::string baseDir = strBaseDir;
-        if (baseDir.empty())
-        {
-          baseDir = "videodb://musicvideos/";
-
-          if (!isGrouped)
-            baseDir += "titles";
-          else
-            baseDir += group;
-          URIUtils::AddSlashAtEnd(baseDir);
-        }
-
-        CVideoDbUrl videoUrl;
-        if (!videoUrl.FromString(baseDir))
-          return false;
-
-        // store the smartplaylist as JSON in the URL as well
-        std::string xsp;
-        if (!mvidPlaylist.IsEmpty(filter))
-        {
-          if (!mvidPlaylist.SaveAsJson(xsp, !filter))
-            return false;
-        }
-
-        if (!xsp.empty())
-          videoUrl.AddOption(option, xsp);
+        if (!isGrouped)
+          baseDir += "titles";
         else
-          videoUrl.RemoveOption(option);
-        
-        CFileItemList items2;
-        CDatabase::Filter dbfilter;
-        success2 = db.GetItems(videoUrl.ToString(), items2, dbfilter, sorting);
-
-        db.Close();
-        if (items.Size() <= 0)
-          items.SetPath(videoUrl.ToString());
-
-        items.Append(items2);
-        if (items2.Size())
-        {
-          if (items.Size() > items2.Size())
-            items.SetContent("mixed");
-          else
-            items.SetContent("musicvideos");
-        }
-        items.SetProperty(PROPERTY_PATH_DB, videoUrl.ToString());
+          baseDir += group;
+        URIUtils::AddSlashAtEnd(baseDir);
       }
+
+      CVideoDbUrl videoUrl;
+      if (!videoUrl.FromString(baseDir))
+        return false;
+
+      // store the smartplaylist as JSON in the URL as well
+      std::string xsp;
+      if (!mvidPlaylist.IsEmpty(filter))
+      {
+        if (!mvidPlaylist.SaveAsJson(xsp, !filter))
+          return false;
+      }
+
+      if (!xsp.empty())
+        videoUrl.AddOption(option, xsp);
+      else
+        videoUrl.RemoveOption(option);
+      
+      CFileItemList items2;
+      CDatabase::Filter dbfilter;
+      CVideoDatabase *database = CDatabaseManager::Get().GetVideoDatabase();
+      success2 = database->GetItems(videoUrl.ToString(), items2, dbfilter, sorting);
+
+      if (items.Size() <= 0)
+        items.SetPath(videoUrl.ToString());
+
+      items.Append(items2);
+      if (items2.Size())
+      {
+        if (items.Size() > items2.Size())
+          items.SetContent("mixed");
+        else
+          items.SetContent("musicvideos");
+      }
+      items.SetProperty(PROPERTY_PATH_DB, videoUrl.ToString());
     }
 
     items.SetLabel(playlist.GetName());

--- a/xbmc/filesystem/VideoDatabaseDirectory.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "VideoDatabaseDirectory.h"
+#include "DatabaseManager.h"
 #include "utils/URIUtils.h"
 #include "VideoDatabaseDirectory/QueryParams.h"
 #include "video/VideoDatabase.h"
@@ -151,25 +152,23 @@ bool CVideoDatabaseDirectory::GetLabel(const std::string& strDirectory, std::str
   CQueryParams params;
   CDirectoryNode::GetDatabaseInfo(path, params);
 
-  CVideoDatabase videodatabase;
-  if (!videodatabase.Open())
-    return false;
+  CVideoDatabase *database = CDatabaseManager::Get().GetVideoDatabase();
 
   // get genre
   if (params.GetGenreId() != -1)
-    strLabel += videodatabase.GetGenreById(params.GetGenreId());
+    strLabel += database->GetGenreById(params.GetGenreId());
 
   // get country
   if (params.GetCountryId() != -1)
-    strLabel += videodatabase.GetCountryById(params.GetCountryId());
+    strLabel += database->GetCountryById(params.GetCountryId());
 
   // get set
   if (params.GetSetId() != -1)
-    strLabel += videodatabase.GetSetById(params.GetSetId());
+    strLabel += database->GetSetById(params.GetSetId());
 
   // get tag
   if (params.GetTagId() != -1)
-    strLabel += videodatabase.GetTagById(params.GetTagId());
+    strLabel += database->GetTagById(params.GetTagId());
 
   // get year
   if (params.GetYear() != -1)

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "DirectoryNode.h"
+#include "DatabaseManager.h"
 #include "utils/URIUtils.h"
 #include "QueryParams.h"
 #include "DirectoryNodeRoot.h"
@@ -328,12 +329,9 @@ void CDirectoryNode::AddQueuingFolder(CFileItemList& items) const
         pItem->GetVideoInfoTag()->m_strTitle = strLabel;
         pItem->GetVideoInfoTag()->m_iEpisode = watched + unwatched;
         pItem->GetVideoInfoTag()->m_playCount = (unwatched == 0) ? 1 : 0;
-        CVideoDatabase db;
-        if (db.Open())
-        {
-          pItem->GetVideoInfoTag()->m_iDbId = db.GetSeasonId(pItem->GetVideoInfoTag()->m_iIdShow, -1);
-          db.Close();
-        }
+
+        CVideoDatabase *database = CDatabaseManager::Get().GetVideoDatabase();
+        pItem->GetVideoInfoTag()->m_iDbId = database->GetSeasonId(pItem->GetVideoInfoTag()->m_iIdShow, -1);
         pItem->GetVideoInfoTag()->m_type = MediaTypeSeason;
       }
       break;

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeEpisodes.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeEpisodes.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "DirectoryNodeEpisodes.h"
+#include "DatabaseManager.h"
 #include "QueryParams.h"
 #include "video/VideoDatabase.h"
 
@@ -32,9 +33,7 @@ CDirectoryNodeEpisodes::CDirectoryNodeEpisodes(const std::string& strName, CDire
 
 bool CDirectoryNodeEpisodes::GetContent(CFileItemList& items) const
 {
-  CVideoDatabase videodatabase;
-  if (!videodatabase.Open())
-    return false;
+  CVideoDatabase *database = CDatabaseManager::Get().GetVideoDatabase();
 
   CQueryParams params;
   CollectQueryParams(params);
@@ -43,9 +42,6 @@ bool CDirectoryNodeEpisodes::GetContent(CFileItemList& items) const
   if (season == -2)
     season = -1;
 
-  bool bSuccess=videodatabase.GetEpisodesNav(BuildPath(), items, params.GetGenreId(), params.GetYear(), params.GetActorId(), params.GetDirectorId(), params.GetTvShowId(), season);
-
-  videodatabase.Close();
-
+  bool bSuccess = database->GetEpisodesNav(BuildPath(), items, params.GetGenreId(), params.GetYear(), params.GetActorId(), params.GetDirectorId(), params.GetTvShowId(), season);
   return bSuccess;
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeGrouped.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeGrouped.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "DirectoryNodeGrouped.h"
+#include "DatabaseManager.h"
 #include "QueryParams.h"
 #include "video/VideoDatabase.h"
 #include "video/VideoDbUrl.h"
@@ -49,19 +50,13 @@ NODE_TYPE CDirectoryNodeGrouped::GetChildType() const
 
 std::string CDirectoryNodeGrouped::GetLocalizedName() const
 {
-  CVideoDatabase db;
-  if (db.Open())
-    return db.GetItemById(GetContentType(), GetID());
-
-  return "";
+  CVideoDatabase *database = CDatabaseManager::Get().GetVideoDatabase();
+  return database->GetItemById(GetContentType(), GetID());
 }
 
 bool CDirectoryNodeGrouped::GetContent(CFileItemList& items) const
 {
-  CVideoDatabase videodatabase;
-  if (!videodatabase.Open())
-    return false;
-
+  CVideoDatabase *database = CDatabaseManager::Get().GetVideoDatabase();
   CQueryParams params;
   CollectQueryParams(params);
 
@@ -74,7 +69,7 @@ bool CDirectoryNodeGrouped::GetContent(CFileItemList& items) const
   if (!videoUrl.FromString(BuildPath()))
     return false;
 
-  return videodatabase.GetItems(videoUrl.ToString(), (VIDEODB_CONTENT_TYPE)params.GetContentType(), itemType, items);
+  return database->GetItems(videoUrl.ToString(), (VIDEODB_CONTENT_TYPE)params.GetContentType(), itemType, items);
 }
 
 std::string CDirectoryNodeGrouped::GetContentType() const

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMoviesOverview.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMoviesOverview.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "DirectoryNodeMoviesOverview.h"
+#include "DatabaseManager.h"
 #include "FileItem.h"
 #include "guilib/LocalizeStrings.h"
 #include "video/VideoDatabase.h"
@@ -65,18 +66,15 @@ std::string CDirectoryNodeMoviesOverview::GetLocalizedName() const
 
 bool CDirectoryNodeMoviesOverview::GetContent(CFileItemList& items) const
 {
+  CVideoDatabase *database = CDatabaseManager::Get().GetVideoDatabase();
   CVideoDbUrl videoUrl;
   if (!videoUrl.FromString(BuildPath()))
     return false;
   
   for (unsigned int i = 0; i < sizeof(MovieChildren) / sizeof(Node); ++i)
   {
-    if (i == 6)
-    {
-      CVideoDatabase db;
-      if (db.Open() && !db.HasSets())
-        continue;
-    }
+    if (i == 6 && !database->HasSets())
+      continue;
 
     CVideoDbUrl itemUrl = videoUrl;
     std::string strDir = StringUtils::Format("%s/", MovieChildren[i].id.c_str());

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeOverview.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeOverview.cpp
@@ -18,8 +18,9 @@
  *
  */
 
-#include "video/VideoDatabase.h"
 #include "DirectoryNodeOverview.h"
+#include "DatabaseManager.h"
+#include "video/VideoDatabase.h"
 #include "settings/Settings.h"
 #include "FileItem.h"
 #include "guilib/LocalizeStrings.h"
@@ -64,11 +65,10 @@ std::string CDirectoryNodeOverview::GetLocalizedName() const
 
 bool CDirectoryNodeOverview::GetContent(CFileItemList& items) const
 {
-  CVideoDatabase database;
-  database.Open();
-  bool hasMovies = database.HasContent(VIDEODB_CONTENT_MOVIES);
-  bool hasTvShows = database.HasContent(VIDEODB_CONTENT_TVSHOWS);
-  bool hasMusicVideos = database.HasContent(VIDEODB_CONTENT_MUSICVIDEOS);
+  CVideoDatabase *database = CDatabaseManager::Get().GetVideoDatabase();
+  bool hasMovies = database->HasContent(VIDEODB_CONTENT_MOVIES);
+  bool hasTvShows = database->HasContent(VIDEODB_CONTENT_TVSHOWS);
+  bool hasMusicVideos = database->HasContent(VIDEODB_CONTENT_MUSICVIDEOS);
   vector<pair<const char*, int> > vec;
   if (hasMovies)
   {

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedEpisodes.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedEpisodes.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "DirectoryNodeRecentlyAddedEpisodes.h"
+#include "DatabaseManager.h"
 #include "video/VideoDatabase.h"
 
 using namespace XFILE::VIDEODATABASEDIRECTORY;
@@ -31,13 +32,6 @@ CDirectoryNodeRecentlyAddedEpisodes::CDirectoryNodeRecentlyAddedEpisodes(const s
 
 bool CDirectoryNodeRecentlyAddedEpisodes::GetContent(CFileItemList& items) const
 {
-  CVideoDatabase videodatabase;
-  if (!videodatabase.Open())
-    return false;
-  
-  bool bSuccess=videodatabase.GetRecentlyAddedEpisodesNav(BuildPath(), items);
-
-  videodatabase.Close();
-
-  return bSuccess;
+  CVideoDatabase *database = CDatabaseManager::Get().GetVideoDatabase();
+  return database->GetRecentlyAddedEpisodesNav(BuildPath(), items);
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedMovies.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedMovies.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "DirectoryNodeRecentlyAddedMovies.h"
+#include "DatabaseManager.h"
 #include "video/VideoDatabase.h"
 
 using namespace XFILE::VIDEODATABASEDIRECTORY;
@@ -31,13 +32,6 @@ CDirectoryNodeRecentlyAddedMovies::CDirectoryNodeRecentlyAddedMovies(const std::
 
 bool CDirectoryNodeRecentlyAddedMovies::GetContent(CFileItemList& items) const
 {
-  CVideoDatabase videodatabase;
-  if (!videodatabase.Open())
-    return false;
-  
-  bool bSuccess=videodatabase.GetRecentlyAddedMoviesNav(BuildPath(), items);
-
-  videodatabase.Close();
-
-  return bSuccess;
+  CVideoDatabase *database = CDatabaseManager::Get().GetVideoDatabase();
+  return database->GetRecentlyAddedMoviesNav(BuildPath(), items);
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedMusicVideos.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedMusicVideos.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "DirectoryNodeRecentlyAddedMusicVideos.h"
+#include "DatabaseManager.h"
 #include "video/VideoDatabase.h"
 
 using namespace XFILE::VIDEODATABASEDIRECTORY;
@@ -31,14 +32,7 @@ CDirectoryNodeRecentlyAddedMusicVideos::CDirectoryNodeRecentlyAddedMusicVideos(c
 
 bool CDirectoryNodeRecentlyAddedMusicVideos::GetContent(CFileItemList& items) const
 {
-  CVideoDatabase videodatabase;
-  if (!videodatabase.Open())
-    return false;
-  
-  bool bSuccess=videodatabase.GetRecentlyAddedMusicVideosNav(BuildPath(), items);
-
-  videodatabase.Close();
-
-  return bSuccess;
+  CVideoDatabase *database = CDatabaseManager::Get().GetVideoDatabase();
+  return database->GetRecentlyAddedMusicVideosNav(BuildPath(), items);
 }
 

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeSeasons.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeSeasons.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "DirectoryNodeSeasons.h"
+#include "DatabaseManager.h"
 #include "QueryParams.h"
 #include "video/VideoDatabase.h"
 #include "video/VideoDbUrl.h"
@@ -64,16 +65,9 @@ std::string CDirectoryNodeSeasons::GetLocalizedName() const
 
 bool CDirectoryNodeSeasons::GetContent(CFileItemList& items) const
 {
-  CVideoDatabase videodatabase;
-  if (!videodatabase.Open())
-    return false;
-
+  CVideoDatabase *database = CDatabaseManager::Get().GetVideoDatabase();
   CQueryParams params;
   CollectQueryParams(params);
 
-  bool bSuccess=videodatabase.GetSeasonsNav(BuildPath(), items, params.GetActorId(), params.GetDirectorId(), params.GetGenreId(), params.GetYear(), params.GetTvShowId());
-
-  videodatabase.Close();
-
-  return bSuccess;
+  return database->GetSeasonsNav(BuildPath(), items, params.GetActorId(), params.GetDirectorId(), params.GetGenreId(), params.GetYear(), params.GetTvShowId());
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleMovies.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleMovies.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "DirectoryNodeTitleMovies.h"
+#include "DatabaseManager.h"
 #include "QueryParams.h"
 #include "video/VideoDatabase.h"
 
@@ -32,16 +33,9 @@ CDirectoryNodeTitleMovies::CDirectoryNodeTitleMovies(const std::string& strName,
 
 bool CDirectoryNodeTitleMovies::GetContent(CFileItemList& items) const
 {
-  CVideoDatabase videodatabase;
-  if (!videodatabase.Open())
-    return false;
-
+  CVideoDatabase *database = CDatabaseManager::Get().GetVideoDatabase();
   CQueryParams params;
   CollectQueryParams(params);
 
-  bool bSuccess=videodatabase.GetMoviesNav(BuildPath(), items, params.GetGenreId(), params.GetYear(), params.GetActorId(), params.GetDirectorId(), params.GetStudioId(), params.GetCountryId(), params.GetSetId(), params.GetTagId());
-
-  videodatabase.Close();
-
-  return bSuccess;
+  return database->GetMoviesNav(BuildPath(), items, params.GetGenreId(), params.GetYear(), params.GetActorId(), params.GetDirectorId(), params.GetStudioId(), params.GetCountryId(), params.GetSetId(), params.GetTagId());
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleMusicVideos.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleMusicVideos.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "DirectoryNodeTitleMusicVideos.h"
+#include "DatabaseManager.h"
 #include "QueryParams.h"
 #include "video/VideoDatabase.h"
 
@@ -32,16 +33,9 @@ CDirectoryNodeTitleMusicVideos::CDirectoryNodeTitleMusicVideos(const std::string
 
 bool CDirectoryNodeTitleMusicVideos::GetContent(CFileItemList& items) const
 {
-  CVideoDatabase videodatabase;
-  if (!videodatabase.Open())
-    return false;
-
+  CVideoDatabase *database = CDatabaseManager::Get().GetVideoDatabase();
   CQueryParams params;
   CollectQueryParams(params);
 
-  bool bSuccess=videodatabase.GetMusicVideosNav(BuildPath(), items, params.GetGenreId(), params.GetYear(), params.GetActorId(), params.GetDirectorId(), params.GetStudioId(), params.GetAlbumId(), params.GetTagId());
-
-  videodatabase.Close();
-
-  return bSuccess;
+  return database->GetMusicVideosNav(BuildPath(), items, params.GetGenreId(), params.GetYear(), params.GetActorId(), params.GetDirectorId(), params.GetStudioId(), params.GetAlbumId(), params.GetTagId());
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleTvShows.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleTvShows.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "DirectoryNodeTitleTvShows.h"
+#include "DatabaseManager.h"
 #include "QueryParams.h"
 #include "video/VideoDatabase.h"
 
@@ -37,24 +38,15 @@ NODE_TYPE CDirectoryNodeTitleTvShows::GetChildType() const
 
 std::string CDirectoryNodeTitleTvShows::GetLocalizedName() const
 {
-  CVideoDatabase db;
-  if (db.Open())
-    return db.GetTvShowTitleById(GetID());
-  return "";
+  CVideoDatabase *database = CDatabaseManager::Get().GetVideoDatabase();
+  return database->GetTvShowTitleById(GetID());
 }
 
 bool CDirectoryNodeTitleTvShows::GetContent(CFileItemList& items) const
 {
-  CVideoDatabase videodatabase;
-  if (!videodatabase.Open())
-    return false;
-
+  CVideoDatabase *database = CDatabaseManager::Get().GetVideoDatabase();
   CQueryParams params;
   CollectQueryParams(params);
 
-  bool bSuccess=videodatabase.GetTvShowsNav(BuildPath(), items, params.GetGenreId(), params.GetYear(), params.GetActorId(), params.GetDirectorId(), params.GetStudioId(), params.GetTagId());
-
-  videodatabase.Close();
-
-  return bSuccess;
+  return database->GetTvShowsNav(BuildPath(), items, params.GetGenreId(), params.GetYear(), params.GetActorId(), params.GetDirectorId(), params.GetStudioId(), params.GetTagId());
 }

--- a/xbmc/interfaces/AnnouncementManager.cpp
+++ b/xbmc/interfaces/AnnouncementManager.cpp
@@ -195,17 +195,12 @@ void CAnnouncementManager::Announce(AnnouncementFlag flag, const char *sender, c
     if (id <= 0 && !item->GetPath().empty() &&
        (!item->HasProperty(LOOKUP_PROPERTY) || item->GetProperty(LOOKUP_PROPERTY).asBoolean()))
     {
-      CMusicDatabase musicdatabase;
-      if (musicdatabase.Open())
+      CMusicDatabase *musicDatabase = CDatabaseManager::Get().GetMusicDatabase();
+      CSong song;
+      if (musicDatabase->GetSongByFileName(item->GetPath(), song, item->m_lStartOffset))
       {
-        CSong song;
-        if (musicdatabase.GetSongByFileName(item->GetPath(), song, item->m_lStartOffset))
-        {
-          item->GetMusicInfoTag()->SetSong(song);
-          id = item->GetMusicInfoTag()->GetDatabaseId();
-        }
-
-        musicdatabase.Close();
+        item->GetMusicInfoTag()->SetSong(song);
+        id = item->GetMusicInfoTag()->GetDatabaseId();
       }
     }
 

--- a/xbmc/interfaces/AnnouncementManager.cpp
+++ b/xbmc/interfaces/AnnouncementManager.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "AnnouncementManager.h"
+#include "DatabaseManager.h"
 #include "threads/SingleLock.h"
 #include <stdio.h>
 #include "utils/log.h"
@@ -138,18 +139,13 @@ void CAnnouncementManager::Announce(AnnouncementFlag flag, const char *sender, c
     if (id <= 0 && !item->GetPath().empty() &&
        (!item->HasProperty(LOOKUP_PROPERTY) || item->GetProperty(LOOKUP_PROPERTY).asBoolean()))
     {
-      CVideoDatabase videodatabase;
-      if (videodatabase.Open())
-      {
-        std::string path = item->GetPath();
-        std::string videoInfoTagPath(item->GetVideoInfoTag()->m_strFileNameAndPath);
-        if (StringUtils::StartsWith(videoInfoTagPath, "removable://"))
-          path = videoInfoTagPath;
-        if (videodatabase.LoadVideoInfo(path, *item->GetVideoInfoTag()))
-          id = item->GetVideoInfoTag()->m_iDbId;
-
-        videodatabase.Close();
-      }
+      CVideoDatabase *videodatabase = CDatabaseManager::Get().GetVideoDatabase();
+      std::string path = item->GetPath();
+      std::string videoInfoTagPath(item->GetVideoInfoTag()->m_strFileNameAndPath);
+      if (StringUtils::StartsWith(videoInfoTagPath, "removable://"))
+        path = videoInfoTagPath;
+      if (videodatabase->LoadVideoInfo(path, *item->GetVideoInfoTag()))
+        id = item->GetVideoInfoTag()->m_iDbId;
     }
 
     if (!item->GetVideoInfoTag()->m_type.empty())

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -1630,10 +1630,8 @@ int CBuiltins::Execute(const std::string& execString)
       {
         if (URIUtils::HasSlashAtEnd(path))
           path = URIUtils::AddFileToFolder(path, "musicdb.xml");
-        CMusicDatabase musicdatabase;
-        musicdatabase.Open();
-        musicdatabase.ExportToXML(path, singleFile, thumbs, overwrite);
-        musicdatabase.Close();
+        CMusicDatabase *musicDatabase = CDatabaseManager::Get().GetMusicDatabase();
+        musicDatabase->ExportToXML(path, singleFile, thumbs, overwrite);
       }
     }
   }

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -26,6 +26,7 @@
 #include "ApplicationMessenger.h"
 #include "Autorun.h"
 #include "Builtins.h"
+#include "DatabaseManager.h"
 #include "input/ButtonTranslator.h"
 #include "input/InputManager.h"
 #include "FileItem.h"
@@ -1622,10 +1623,8 @@ int CBuiltins::Execute(const std::string& execString)
     {
       if (StringUtils::EqualsNoCase(params[0], "video"))
       {
-        CVideoDatabase videodatabase;
-        videodatabase.Open();
-        videodatabase.ExportToXML(path, singleFile, thumbs, actorThumbs, overwrite);
-        videodatabase.Close();
+        CVideoDatabase *database = CDatabaseManager::Get().GetVideoDatabase();
+        database->ExportToXML(path, singleFile, thumbs, actorThumbs, overwrite);
       }
       else
       {

--- a/xbmc/interfaces/json-rpc/AddonsOperations.cpp
+++ b/xbmc/interfaces/json-rpc/AddonsOperations.cpp
@@ -118,10 +118,9 @@ JSONRPC_STATUS CAddonsOperations::GetAddons(const std::string &method, ITranspor
 
   int start, end;
   HandleLimits(parameterObject, result, addons.size(), start, end);
-  
-  CAddonDatabase addondb;
+
   for (int index = start; index < end; index++)
-    FillDetails(addons.at(index), parameterObject["properties"], result["addons"], addondb, true);
+    FillDetails(addons.at(index), parameterObject["properties"], result["addons"], true);
   
   return OK;
 }
@@ -133,9 +132,8 @@ JSONRPC_STATUS CAddonsOperations::GetAddonDetails(const std::string &method, ITr
   if (!CAddonMgr::Get().GetAddon(id, addon, ADDON::ADDON_UNKNOWN, false) || addon.get() == NULL ||
       addon->Type() <= ADDON_UNKNOWN || addon->Type() >= ADDON_MAX)
     return InvalidParams;
-    
-  CAddonDatabase addondb;
-  FillDetails(addon, parameterObject["properties"], result["addon"], addondb);
+
+  FillDetails(addon, parameterObject["properties"], result["addon"]);
 
   return OK;
 }
@@ -202,7 +200,7 @@ JSONRPC_STATUS CAddonsOperations::ExecuteAddon(const std::string &method, ITrans
   return ACK;
 }
 
-void CAddonsOperations::FillDetails(AddonPtr addon, const CVariant& fields, CVariant &result, CAddonDatabase &addondb, bool append /* = false */)
+void CAddonsOperations::FillDetails(AddonPtr addon, const CVariant& fields, CVariant &result, bool append /* = false */)
 {
   if (addon.get() == NULL)
     return;

--- a/xbmc/interfaces/json-rpc/AddonsOperations.h
+++ b/xbmc/interfaces/json-rpc/AddonsOperations.h
@@ -36,6 +36,6 @@ namespace JSONRPC
     static JSONRPC_STATUS ExecuteAddon(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result);
     
   private:
-    static void FillDetails(ADDON::AddonPtr addon, const CVariant& fields, CVariant &result, CAddonDatabase &addondb, bool append = false);
+    static void FillDetails(ADDON::AddonPtr addon, const CVariant& fields, CVariant &result, bool append = false);
   };
 }

--- a/xbmc/interfaces/json-rpc/AudioLibrary.h
+++ b/xbmc/interfaces/json-rpc/AudioLibrary.h
@@ -56,8 +56,8 @@ namespace JSONRPC
     static bool FillFileItemList(const CVariant &parameterObject, CFileItemList &list);
 
     static JSONRPC_STATUS GetAdditionalDetails(const CVariant &parameterObject, CFileItemList &items);
-    static JSONRPC_STATUS GetAdditionalAlbumDetails(const CVariant &parameterObject, CFileItemList &items, CMusicDatabase &musicdatabase);
-    static JSONRPC_STATUS GetAdditionalSongDetails(const CVariant &parameterObject, CFileItemList &items, CMusicDatabase &musicdatabase);
+    static JSONRPC_STATUS GetAdditionalAlbumDetails(const CVariant &parameterObject, CFileItemList &items);
+    static JSONRPC_STATUS GetAdditionalSongDetails(const CVariant &parameterObject, CFileItemList &items);
 
   private:
     static void FillAlbumItem(const CAlbum &album, const std::string &path, CFileItemPtr &item);

--- a/xbmc/interfaces/json-rpc/PlayerOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlayerOperations.cpp
@@ -20,6 +20,7 @@
 
 #include "PlayerOperations.h"
 #include "Application.h"
+#include "DatabaseManager.h"
 #include "Util.h"
 #include "PlayListPlayer.h"
 #include "playlists/PlayList.h"
@@ -217,24 +218,23 @@ JSONRPC_STATUS CPlayerOperations::GetItem(const std::string &method, ITransportL
             additionalInfo = true;
         }
 
-        CVideoDatabase videodatabase;
-        if ((additionalInfo) &&
-            videodatabase.Open())
+        if ((additionalInfo))
         {
           if (additionalInfo)
           {
+            CVideoDatabase *database = CDatabaseManager::Get().GetVideoDatabase();
             switch (fileItem->GetVideoContentType())
             {
               case VIDEODB_CONTENT_MOVIES:
-                videodatabase.GetMovieInfo("", *(fileItem->GetVideoInfoTag()), fileItem->GetVideoInfoTag()->m_iDbId);
+                database->GetMovieInfo("", *(fileItem->GetVideoInfoTag()), fileItem->GetVideoInfoTag()->m_iDbId);
                 break;
 
               case VIDEODB_CONTENT_MUSICVIDEOS:
-                videodatabase.GetMusicVideoInfo("", *(fileItem->GetVideoInfoTag()), fileItem->GetVideoInfoTag()->m_iDbId);
+                database->GetMusicVideoInfo("", *(fileItem->GetVideoInfoTag()), fileItem->GetVideoInfoTag()->m_iDbId);
                 break;
 
               case VIDEODB_CONTENT_EPISODES:
-                videodatabase.GetEpisodeInfo("", *(fileItem->GetVideoInfoTag()), fileItem->GetVideoInfoTag()->m_iDbId);
+                database->GetEpisodeInfo("", *(fileItem->GetVideoInfoTag()), fileItem->GetVideoInfoTag()->m_iDbId);
                 break;
 
               case VIDEODB_CONTENT_TVSHOWS:
@@ -243,8 +243,6 @@ JSONRPC_STATUS CPlayerOperations::GetItem(const std::string &method, ITransportL
                 break;
             }
           }
-
-          videodatabase.Close();
         }
       }
       else if (player == Audio)

--- a/xbmc/interfaces/json-rpc/PlayerOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlayerOperations.cpp
@@ -249,10 +249,9 @@ JSONRPC_STATUS CPlayerOperations::GetItem(const std::string &method, ITransportL
       {
         if (fileItem->IsMusicDb())
         {
-          CMusicDatabase musicdb;
           CFileItemList items;
           items.Add(fileItem);
-          CAudioLibrary::GetAdditionalSongDetails(parameterObject, items, musicdb);
+          CAudioLibrary::GetAdditionalSongDetails(parameterObject, items);
         }
       }
       break;

--- a/xbmc/interfaces/json-rpc/VideoLibrary.h
+++ b/xbmc/interfaces/json-rpc/VideoLibrary.h
@@ -71,12 +71,12 @@ namespace JSONRPC
     static bool FillFileItemList(const CVariant &parameterObject, CFileItemList &list);
 
   private:
-    static JSONRPC_STATUS GetAdditionalMovieDetails(const CVariant &parameterObject, CFileItemList &items, CVariant &result, CVideoDatabase &videodatabase, bool limit = true);
-    static JSONRPC_STATUS GetAdditionalEpisodeDetails(const CVariant &parameterObject, CFileItemList &items, CVariant &result, CVideoDatabase &videodatabase, bool limit = true);
-    static JSONRPC_STATUS GetAdditionalMusicVideoDetails(const CVariant &parameterObject, CFileItemList &items, CVariant &result, CVideoDatabase &videodatabase, bool limit = true);
+    static JSONRPC_STATUS GetAdditionalMovieDetails(const CVariant &parameterObject, CFileItemList &items, CVariant &result, bool limit = true);
+    static JSONRPC_STATUS GetAdditionalEpisodeDetails(const CVariant &parameterObject, CFileItemList &items, CVariant &result, bool limit = true);
+    static JSONRPC_STATUS GetAdditionalMusicVideoDetails(const CVariant &parameterObject, CFileItemList &items, CVariant &result, bool limit = true);
     static JSONRPC_STATUS RemoveVideo(const CVariant &parameterObject);
     static void UpdateVideoTag(const CVariant &parameterObject, CVideoInfoTag &details, std::map<std::string, std::string> &artwork, std::set<std::string> &removedArtwork, std::set<std::string>& updatedDetails);
     static void UpdateVideoTagField(const CVariant& parameterObject, const std::string& fieldName, std::vector<std::string>& fieldValue, std::set<std::string>& updatedDetails);
-    static void UpdateResumePoint(const CVariant &parameterObject, CVideoInfoTag &details, CVideoDatabase &videodatabase);
+    static void UpdateResumePoint(const CVariant &parameterObject, CVideoInfoTag &details);
   };
 }

--- a/xbmc/music/GUIViewStateMusic.cpp
+++ b/xbmc/music/GUIViewStateMusic.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "GUIViewStateMusic.h"
+#include "DatabaseManager.h"
 #include "PlayListPlayer.h"
 #include "video/VideoDatabase.h"
 #include "settings/AdvancedSettings.h"

--- a/xbmc/music/MusicInfoLoader.h
+++ b/xbmc/music/MusicInfoLoader.h
@@ -48,7 +48,6 @@ protected:
   CFileItemList* m_mapFileItems;
   MAPSONGS m_songsMap;
   std::string m_strPrevPath;
-  CMusicDatabase m_musicDatabase;
   unsigned int m_databaseHits;
   unsigned int m_tagReads;
   CMusicThumbLoader *m_thumbLoader;

--- a/xbmc/music/MusicThumbLoader.h
+++ b/xbmc/music/MusicThumbLoader.h
@@ -60,7 +60,6 @@ public:
   static bool GetEmbeddedThumb(const std::string &path, MUSIC_INFO::EmbeddedArt &art);
 
 protected:
-  CMusicDatabase *m_musicDatabase;
   typedef std::map<int, std::map<std::string, std::string> > ArtCache;
   ArtCache m_albumArt;
 };

--- a/xbmc/music/infoscanner/MusicInfoScanner.h
+++ b/xbmc/music/infoscanner/MusicInfoScanner.h
@@ -213,7 +213,6 @@ protected:
   bool m_bClean;
   bool m_needsCleanup;
   int m_scanType; // 0 - load from files, 1 - albums, 2 - artists
-  CMusicDatabase m_musicDatabase;
 
   std::map<CAlbum, CAlbum> m_albumCache;
   std::map<CArtistCredit, CArtist> m_artistCache;

--- a/xbmc/music/karaoke/GUIDialogKaraokeSongSelector.cpp
+++ b/xbmc/music/karaoke/GUIDialogKaraokeSongSelector.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "GUIDialogKaraokeSongSelector.h"
+#include "DatabaseManager.h"
 #include "PlayListPlayer.h"
 #include "playlists/PlayList.h"
 #include "input/Key.h"
@@ -174,7 +175,8 @@ void CGUIDialogKaraokeSongSelector::UpdateData()
     SET_CONTROL_LABEL(CONTROL_LABEL_SONGNUMBER, message);
 
     // Now try to find this song in the database
-    m_songSelected = m_musicdatabase.GetSongByKaraokeNumber( m_selectedNumber, m_karaokeSong );
+    CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
+    m_songSelected = database->GetSongByKaraokeNumber( m_selectedNumber, m_karaokeSong );
 
     if ( m_songSelected )
       message = m_karaokeSong.strTitle;
@@ -226,14 +228,8 @@ void CGUIDialogKaraokeSongSelector::OnInitWindow()
 {
   CGUIDialog::OnInitWindow();
 
-  // Check if there are any karaoke songs in the database
-  if ( !m_musicdatabase.Open() )
-  {
-    Close();
-    return;
-  }
-
-  if ( m_musicdatabase.GetKaraokeSongsCount() == 0 )
+  CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
+  if (database->GetKaraokeSongsCount() == 0)
   {
     Close();
     return;
@@ -246,7 +242,6 @@ void CGUIDialogKaraokeSongSelector::OnInitWindow()
 void CGUIDialogKaraokeSongSelector::OnDeinitWindow(int nextWindowID)
 {
   CGUIDialog::OnDeinitWindow(nextWindowID);
-  m_musicdatabase.Close();
 }
 
 

--- a/xbmc/music/karaoke/GUIDialogKaraokeSongSelector.h
+++ b/xbmc/music/karaoke/GUIDialogKaraokeSongSelector.h
@@ -63,8 +63,6 @@ protected:
   //! True if we need to update fields before rendering
   bool      m_updateData;
 
-  //! Database stuff
-  CMusicDatabase m_musicdatabase;
   CSong          m_karaokeSong;
 };
 

--- a/xbmc/music/tags/MusicInfoTagLoaderDatabase.cpp
+++ b/xbmc/music/tags/MusicInfoTagLoaderDatabase.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "MusicInfoTagLoaderDatabase.h"
+#include "DatabaseManager.h"
 #include "music/MusicDatabase.h"
 #include "filesystem/MusicDatabaseDirectory.h"
 #include "filesystem/MusicDatabaseDirectory/DirectoryNode.h"
@@ -37,17 +38,14 @@ CMusicInfoTagLoaderDatabase::~CMusicInfoTagLoaderDatabase()
 bool CMusicInfoTagLoaderDatabase::Load(const std::string& strFileName, CMusicInfoTag& tag, EmbeddedArt *art)
 {
   tag.SetLoaded(false);
-  CMusicDatabase database;
-  database.Open();
+  CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
   XFILE::MUSICDATABASEDIRECTORY::CQueryParams param;
   XFILE::MUSICDATABASEDIRECTORY::CDirectoryNode::GetDatabaseInfo(strFileName,param);
 
   CSong song;
-  if (database.GetSong(param.GetSongId(),song))
+  if (database->GetSong(param.GetSongId(),song))
     tag.SetSong(song);
-
-  database.Close();
-
+  
   return tag.Loaded();
 }
 

--- a/xbmc/music/windows/GUIWindowMusicBase.h
+++ b/xbmc/music/windows/GUIWindowMusicBase.h
@@ -99,6 +99,5 @@ protected:
 
   // member variables to save frequently used CSettings (which is slow)
   bool m_hideExtensions;
-  CMusicDatabase m_musicdatabase;
   MUSIC_INFO::CMusicInfoLoader m_musicInfoLoader;
 };

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "GUIWindowMusicNav.h"
+#include "DatabaseManager.h"
 #include "addons/AddonManager.h"
 #include "utils/FileUtils.h"
 #include "utils/URIUtils.h"
@@ -537,18 +538,16 @@ void CGUIWindowMusicNav::GetContextButtons(int itemNumber, CContextButtons &butt
     }
     if (item->HasMusicInfoTag() && item->GetMusicInfoTag()->GetArtist().size() > 0)
     {
-      CVideoDatabase database;
-      database.Open();
-      if (database.GetMatchingMusicVideo(StringUtils::Join(item->GetMusicInfoTag()->GetArtist(), g_advancedSettings.m_musicItemSeparator)) > -1)
+      CVideoDatabase *database = CDatabaseManager::Get().GetVideoDatabase();
+      if (database->GetMatchingMusicVideo(StringUtils::Join(item->GetMusicInfoTag()->GetArtist(), g_advancedSettings.m_musicItemSeparator)) > -1)
         buttons.Add(CONTEXT_BUTTON_GO_TO_ARTIST, 20400);
     }
     if (item->HasMusicInfoTag() && item->GetMusicInfoTag()->GetArtist().size() > 0 &&
         item->GetMusicInfoTag()->GetAlbum().size() > 0 &&
         item->GetMusicInfoTag()->GetTitle().size() > 0)
     {
-      CVideoDatabase database;
-      database.Open();
-      if (database.GetMatchingMusicVideo(StringUtils::Join(item->GetMusicInfoTag()->GetArtist(), g_advancedSettings.m_musicItemSeparator),item->GetMusicInfoTag()->GetAlbum(),item->GetMusicInfoTag()->GetTitle()) > -1)
+      CVideoDatabase *database = CDatabaseManager::Get().GetVideoDatabase();
+      if (database->GetMatchingMusicVideo(StringUtils::Join(item->GetMusicInfoTag()->GetArtist(), g_advancedSettings.m_musicItemSeparator),item->GetMusicInfoTag()->GetAlbum(),item->GetMusicInfoTag()->GetTitle()) > -1)
         buttons.Add(CONTEXT_BUTTON_PLAY_OTHER, 20401);
     }
     if (item->HasVideoInfoTag() && !item->m_bIsFolder)
@@ -654,20 +653,18 @@ bool CGUIWindowMusicNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
   case CONTEXT_BUTTON_GO_TO_ARTIST:
     {
       std::string strPath;
-      CVideoDatabase database;
-      database.Open();
+      CVideoDatabase *database = CDatabaseManager::Get().GetVideoDatabase();
       strPath = StringUtils::Format("videodb://musicvideos/artists/%i/",
-                                    database.GetMatchingMusicVideo(StringUtils::Join(item->GetMusicInfoTag()->GetArtist(), g_advancedSettings.m_musicItemSeparator)));
+                                    database->GetMatchingMusicVideo(StringUtils::Join(item->GetMusicInfoTag()->GetArtist(), g_advancedSettings.m_musicItemSeparator)));
       g_windowManager.ActivateWindow(WINDOW_VIDEO_NAV,strPath);
       return true;
     }
 
   case CONTEXT_BUTTON_PLAY_OTHER:
     {
-      CVideoDatabase database;
-      database.Open();
+      CVideoDatabase *database = CDatabaseManager::Get().GetVideoDatabase();
       CVideoInfoTag details;
-      database.GetMusicVideoInfo("",details,database.GetMatchingMusicVideo(StringUtils::Join(item->GetMusicInfoTag()->GetArtist(), g_advancedSettings.m_musicItemSeparator),item->GetMusicInfoTag()->GetAlbum(),item->GetMusicInfoTag()->GetTitle()));
+      database->GetMusicVideoInfo("",details,database->GetMatchingMusicVideo(StringUtils::Join(item->GetMusicInfoTag()->GetArtist(), g_advancedSettings.m_musicItemSeparator),item->GetMusicInfoTag()->GetAlbum(),item->GetMusicInfoTag()->GetTitle()));
       CApplicationMessenger::Get().PlayFile(CFileItem(details));
       return true;
     }

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -117,7 +117,8 @@ bool CGUIWindowMusicNav::OnMessage(CGUIMessage& message)
         return false;
 
       //  base class has opened the database, do our check
-      DisplayEmptyDatabaseMessage(m_musicdatabase.GetSongsCount() <= 0);
+      CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
+      DisplayEmptyDatabaseMessage(database->GetSongsCount() <= 0);
 
       if (m_bDisplayEmptyDatabaseMessage)
       {
@@ -274,8 +275,11 @@ bool CGUIWindowMusicNav::OnClick(int iItem)
     return true;
   }
   if (item->IsMusicDb() && !item->m_bIsFolder)
-    m_musicdatabase.SetPropertiesForFileItem(*item);
-    
+  {
+    CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
+    database->SetPropertiesForFileItem(*item);
+  }
+
   return CGUIWindowMusicBase::OnClick(iItem);
 }
 
@@ -474,7 +478,8 @@ void CGUIWindowMusicNav::GetContextButtons(int itemNumber, CContextButtons &butt
        buttons.Add(CONTEXT_BUTTON_INFO, 20393);
       if (StringUtils::StartsWithNoCase(item->GetPath(), "videodb://musicvideos/artists/") && item->m_bIsFolder)
       {
-        long idArtist = m_musicdatabase.GetArtistByName(m_vecItems->Get(itemNumber)->GetLabel());
+        CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
+        long idArtist = database->GetArtistByName(m_vecItems->Get(itemNumber)->GetLabel());
         if (idArtist > - 1)
           buttons.Add(CONTEXT_BUTTON_INFO,21891);
       }
@@ -504,7 +509,8 @@ void CGUIWindowMusicNav::GetContextButtons(int itemNumber, CContextButtons &butt
       item->m_bIsFolder && !item->IsVideoDb())
     {
       ADDON::ScraperPtr info;
-      m_musicdatabase.GetScraperForPath(item->GetPath(), info, ADDON::ADDON_SCRAPER_ARTISTS);
+      CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
+      database->GetScraperForPath(item->GetPath(), info, ADDON::ADDON_SCRAPER_ARTISTS);
       if (info && info->Supports(CONTENT_ARTISTS))
         buttons.Add(CONTEXT_BUTTON_INFO_ALL, 21884);
     }
@@ -589,15 +595,18 @@ bool CGUIWindowMusicNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
       if (!item->IsVideoDb())
         return CGUIWindowMusicBase::OnContextButton(itemNumber,button);
 
+      CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
+
       // music videos - artists
       if (StringUtils::StartsWithNoCase(item->GetPath(), "videodb://musicvideos/artists/"))
       {
-        long idArtist = m_musicdatabase.GetArtistByName(item->GetLabel());
+        CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
+        long idArtist = database->GetArtistByName(item->GetLabel());
         if (idArtist == -1)
           return false;
         std::string path = StringUtils::Format("musicdb://artists/%ld/", idArtist);
         CArtist artist;
-        m_musicdatabase.GetArtist(idArtist, artist, false);
+        database->GetArtist(idArtist, artist, false);
         *item = CFileItem(artist);
         item->SetPath(path);
         CGUIWindowMusicBase::OnContextButton(itemNumber,button);
@@ -609,12 +618,13 @@ bool CGUIWindowMusicNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
       // music videos - albums
       if (StringUtils::StartsWithNoCase(item->GetPath(), "videodb://musicvideos/albums/"))
       {
-        long idAlbum = m_musicdatabase.GetAlbumByName(item->GetLabel());
+        CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
+        long idAlbum = database->GetAlbumByName(item->GetLabel());
         if (idAlbum == -1)
           return false;
         std::string path = StringUtils::Format("musicdb://albums/%ld/", idAlbum);
         CAlbum album;
-        m_musicdatabase.GetAlbum(idAlbum, album, false);
+        database->GetAlbum(idAlbum, album, false);
         *item = CFileItem(path,album);
         item->SetPath(path);
         CGUIWindowMusicBase::OnContextButton(itemNumber,button);
@@ -709,7 +719,8 @@ bool CGUIWindowMusicNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
         content = CONTENT_ARTISTS;
       }
 
-      if (!m_musicdatabase.GetScraperForPath(path, scraper, ADDON::ScraperTypeFromContent(content)))
+      CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
+      if (!database->GetScraperForPath(path, scraper, ADDON::ScraperTypeFromContent(content)))
       {
         ADDON::AddonPtr defaultScraper;
         if (ADDON::CAddonMgr::Get().GetDefault(ADDON::ScraperTypeFromContent(content), defaultScraper))
@@ -720,7 +731,8 @@ bool CGUIWindowMusicNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
 
       if (CGUIDialogContentSettings::Show(scraper, content))
       {
-        m_musicdatabase.SetScraperForPath(path,scraper);
+        CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
+        database->SetScraperForPath(path,scraper);
         if (CGUIDialogYesNo::ShowAndGetInput(20442,20443,20444,20022))
         {
           OnInfoAll(itemNumber,true,true);

--- a/xbmc/music/windows/GUIWindowMusicSongs.cpp
+++ b/xbmc/music/windows/GUIWindowMusicSongs.cpp
@@ -20,6 +20,7 @@
 
 #include "system.h"
 #include "GUIWindowMusicSongs.h"
+#include "DatabaseManager.h"
 #include "Util.h"
 #include "GUIInfoManager.h"
 #include "Application.h"
@@ -333,7 +334,8 @@ void CGUIWindowMusicSongs::GetContextButtons(int itemNumber, CContextButtons &bu
         else if (!item->IsParentFolder() &&
                  !StringUtils::StartsWithNoCase(item->GetPath(), "new") && item->m_bIsFolder)
         {
-          if (m_musicdatabase.GetAlbumIdByPath(item->GetPath()) > -1)
+          CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
+          if (database->GetAlbumIdByPath(item->GetPath()) > -1)
             buttons.Add(CONTEXT_BUTTON_INFO, 13351); // Album Info
         }
       }
@@ -423,10 +425,12 @@ bool CGUIWindowMusicSongs::OnContextButton(int itemNumber, CONTEXT_BUTTON button
 #endif
 
   case CONTEXT_BUTTON_CDDB:
-    if (m_musicdatabase.LookupCDDBInfo(true))
+  {
+    CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
+    if (database->LookupCDDBInfo(true))
       Refresh();
     return true;
-
+  }
   case CONTEXT_BUTTON_DELETE:
     OnDeleteItem(itemNumber);
     return true;

--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "PVRDatabase.h"
+#include "DatabaseManager.h"
 #include "dbwrappers/dataset.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/VideoSettings.h"
@@ -139,9 +140,10 @@ void CPVRDatabase::UpdateTables(int iVersion)
   if (iVersion < 28)
   {
     VECADDONS addons;
-    CAddonDatabase database;
-    if (database.Open() && CAddonMgr::Get().GetAddons(ADDON_PVRDLL, addons, true))
+    if (CAddonMgr::Get().GetAddons(ADDON_PVRDLL, addons, true))
     {
+      CAddonDatabase *database = CDatabaseManager::Get().GetAddonDatabase();
+
       /** find all old client IDs */
       std::string strQuery(PrepareSQL("SELECT idClient, sUid FROM clients"));
       m_pDS->query(strQuery);
@@ -153,10 +155,10 @@ void CPVRDatabase::UpdateTables(int iVersion)
           if ((*it)->ID() == m_pDS->fv(1).get_asString())
           {
             /** try to get the current ID from the database */
-            int iAddonId = database.GetAddonId(*it);
+            int iAddonId = database->GetAddonId(*it);
             /** register a new id if it didn't exist */
             if (iAddonId <= 0)
-              iAddonId = database.AddAddon(*it, 0);
+              iAddonId = database->AddAddon(*it, 0);
             if (iAddonId > 0)
             {
               // this fails when an id becomes the id of one that's being replaced next iteration

--- a/xbmc/pvr/PVRDatabase.h
+++ b/xbmc/pvr/PVRDatabase.h
@@ -195,20 +195,4 @@ namespace PVR
 
     bool RemoveChannelsFromGroup(const CPVRChannelGroup &group);
   };
-
-  /*!
-   * @brief Try to open the PVR database.
-   * @return The opened database or NULL if the database failed to open.
-   */
-  inline CPVRDatabase *GetPVRDatabase(void)
-  {
-    CPVRDatabase *database = g_PVRManager.GetTVDatabase();
-    if (!database || !database->IsOpen())
-    {
-      CLog::Log(LOGERROR, "PVR - failed to open the database");
-      database = NULL;
-    }
-
-    return database;
-  }
 }

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -20,6 +20,7 @@
 
 #include "Application.h"
 #include "ApplicationMessenger.h"
+#include "DatabaseManager.h"
 #include "GUIInfoManager.h"
 #include "Util.h"
 #include "dialogs/GUIDialogOK.h"
@@ -815,14 +816,9 @@ void CPVRManager::ResetDatabase(bool bResetEPGOnly /* = false */)
       pDlgProgress->Progress();
 
       /* delete all channel and recording settings */
-      CVideoDatabase videoDatabase;
-
-      if (videoDatabase.Open())
-      {
-        videoDatabase.EraseVideoSettings("pvr://channels/");
-        videoDatabase.EraseVideoSettings("pvr://recordings/");
-        videoDatabase.Close();
-      }
+      CVideoDatabase *database = CDatabaseManager::Get().GetVideoDatabase();
+      database->EraseVideoSettings("pvr://channels/");
+      database->EraseVideoSettings("pvr://recordings/");
       
       pDlgProgress->SetPercentage(80);
       pDlgProgress->Progress();

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -93,7 +93,6 @@ CPVRManager::CPVRManager(void) :
     m_guiInfo(NULL),
     m_triggerEvent(true),
     m_currentFile(NULL),
-    m_database(NULL),
     m_bFirstStart(true),
     m_bEpgsCreated(false),
     m_progressHandle(NULL),
@@ -354,7 +353,6 @@ void CPVRManager::Cleanup(void)
   SAFE_DELETE(m_recordings);
   SAFE_DELETE(m_channelGroups);
   SAFE_DELETE(m_parentalTimer);
-  SAFE_DELETE(m_database);
   m_triggerEvent.Set();
 
   m_currentFile           = NULL;
@@ -428,11 +426,6 @@ void CPVRManager::Start(bool bAsync /* = false */, int openWindowId /* = 0 */)
   ResetProperties();
   SetState(ManagerStateStarting);
   m_openWindowId = openWindowId;
-
-  /* create and open database */
-  if (!m_database)
-    m_database = new CPVRDatabase;
-  m_database->Open();
   
   /* register application action listener */
   g_application.RegisterActionListener(&CPVRActionListener::Get());
@@ -466,10 +459,6 @@ void CPVRManager::Stop(void)
 
   /* executes the set wakeup command */
   SetWakeupCommand();
-
-  /* close database */
-  if (m_database->IsOpen())
-    m_database->Close();
 
   /* unload all data */
   Cleanup();
@@ -785,19 +774,17 @@ void CPVRManager::ResetDatabase(bool bResetEPGOnly /* = false */)
   pDlgProgress->Progress();
 
   /* reset the EPG pointers */
-  if (m_database)
-    m_database->ResetEPG();
+  CPVRDatabase *database = CDatabaseManager::Get().GetPVRDatabase();
+  database->ResetEPG();
 
   /* stop the thread */
   Stop();
-
+  
   pDlgProgress->SetPercentage(20);
   pDlgProgress->Progress();
 
-  if (!m_database)
-    m_database = new CPVRDatabase;
-
-  if (m_database && m_database->Open())
+  database = CDatabaseManager::Get().GetPVRDatabase();
+  if (database && database->IsOpen())
   {
     /* clean the EPG database */
     g_EpgContainer.Reset();
@@ -806,12 +793,12 @@ void CPVRManager::ResetDatabase(bool bResetEPGOnly /* = false */)
 
     if (!bResetEPGOnly)
     {
-      m_database->DeleteChannelGroups();
+      database->DeleteChannelGroups();
       pDlgProgress->SetPercentage(50);
       pDlgProgress->Progress();
 
       /* delete all channels */
-      m_database->DeleteChannels();
+      database->DeleteChannels();
       pDlgProgress->SetPercentage(70);
       pDlgProgress->Progress();
 
@@ -827,8 +814,6 @@ void CPVRManager::ResetDatabase(bool bResetEPGOnly /* = false */)
       pDlgProgress->SetPercentage(90);
       pDlgProgress->Progress();
     }
-
-    m_database->Close();
   }
 
   CLog::Log(LOGNOTICE,"PVRManager - %s - %s database cleared", __FUNCTION__, bResetEPGOnly ? "EPG" : "PVR and EPG");
@@ -836,7 +821,6 @@ void CPVRManager::ResetDatabase(bool bResetEPGOnly /* = false */)
   if (CSettings::Get().GetBool("pvrmanager.enabled"))
   {
     CLog::Log(LOGNOTICE,"PVRManager - %s - restarting the PVRManager", __FUNCTION__);
-    m_database->Open();
     Cleanup();
     Start();
   }

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -191,12 +191,6 @@ namespace PVR
     bool UpgradeOutdatedAddons(void);
 
     /*!
-     * @brief Get the TV database.
-     * @return The TV database.
-     */
-    CPVRDatabase *GetTVDatabase(void) const { return m_database; }
-
-    /*!
      * @brief Get a GUIInfoManager character string.
      * @param dwInfo The string to get.
      * @return The requested string or an empty one if it wasn't found.
@@ -657,7 +651,6 @@ namespace PVR
     std::vector<CJob *>             m_pendingUpdates;              /*!< vector of pending pvr updates */
 
     CFileItem *                     m_currentFile;                 /*!< the PVR file that is currently playing */
-    CPVRDatabase *                  m_database;                    /*!< the database for all PVR related data */
     CCriticalSection                m_critSection;                 /*!< critical section for all changes to this class, except for changes to triggers */
     bool                            m_bFirstStart;                 /*!< true when the PVR manager was started first, false otherwise */
     bool                            m_bIsSwitchingChannels;        /*!< true while switching channels */

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -22,6 +22,7 @@
 
 #include "Application.h"
 #include "ApplicationMessenger.h"
+#include "DatabaseManager.h"
 #include "GUIUserMessages.h"
 #include "dialogs/GUIDialogExtendedProgressBar.h"
 #include "dialogs/GUIDialogOK.h"
@@ -1020,20 +1021,21 @@ bool CPVRClients::IsKnownClient(const AddonPtr client) const
 int CPVRClients::RegisterClient(AddonPtr client)
 {
   int iClientId(-1);
-  CAddonDatabase database;
   PVR_CLIENT addon;
 
-  if (!client->Enabled() || !database.Open())
+  if (!client->Enabled())
     return -1;
+
+  CAddonDatabase *database = CDatabaseManager::Get().GetAddonDatabase();
 
   CLog::Log(LOGDEBUG, "%s - registering add-on '%s'", __FUNCTION__, client->Name().c_str());
 
   // check whether we already know this client
-  iClientId = database.GetAddonId(client); //database->GetClientId(client->ID());
+  iClientId = database->GetAddonId(client);
 
   // try to register the new client in the db
   if (iClientId <= 0)
-    iClientId = database.AddAddon(client, 0);
+    iClientId = database->AddAddon(client, 0);
 
   if (iClientId > 0)
   // load and initialise the client libraries

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -18,6 +18,7 @@
  *
  */
 
+#include "DatabaseManager.h"
 #include "FileItem.h"
 #include "guilib/LocalizeStrings.h"
 #include "utils/log.h"
@@ -141,7 +142,7 @@ void CPVRChannel::Serialize(CVariant& value) const
 bool CPVRChannel::Delete(void)
 {
   bool bReturn = false;
-  CPVRDatabase *database = GetPVRDatabase();
+  CPVRDatabase *database = CDatabaseManager::Get().GetPVRDatabase();
   if (!database)
     return bReturn;
 
@@ -215,7 +216,7 @@ bool CPVRChannel::Persist()
       return true;
   }
 
-  if (CPVRDatabase *database = GetPVRDatabase())
+  if (CPVRDatabase *database = CDatabaseManager::Get().GetPVRDatabase())
   {
     bool bReturn = database->Persist(*this) && database->CommitInsertQueries();
     CSingleLock lock(m_critSection);
@@ -365,7 +366,7 @@ bool CPVRChannel::SetLastWatched(time_t iLastWatched)
       m_iLastWatched = iLastWatched;
   }
 
-  if (CPVRDatabase *database = GetPVRDatabase())
+  if (CPVRDatabase *database = CDatabaseManager::Get().GetPVRDatabase())
     return database->UpdateLastWatched(*this);
 
   return false;

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -23,6 +23,7 @@
  * - use Observable here, so we can use event driven operations later
  */
 
+#include "DatabaseManager.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/lib/Setting.h"
 #include "settings/Settings.h"
@@ -265,7 +266,7 @@ void CPVRChannelGroup::SearchAndSetChannelIcons(bool bUpdateDb /* = false */)
   if (iconPath.empty())
     return;
 
-  CPVRDatabase *database = GetPVRDatabase();
+  CPVRDatabase *database = CDatabaseManager::Get().GetPVRDatabase();
   if (!database)
     return;
 
@@ -576,7 +577,7 @@ CPVRChannelGroupPtr CPVRChannelGroup::GetPreviousGroup(void) const
 
 int CPVRChannelGroup::LoadFromDb(bool bCompress /* = false */)
 {
-  CPVRDatabase *database = GetPVRDatabase();
+  CPVRDatabase *database = CDatabaseManager::Get().GetPVRDatabase();
   if (!database)
     return -1;
 
@@ -676,7 +677,7 @@ bool CPVRChannelGroup::UpdateGroupEntries(const CPVRChannelGroup &channels)
   /* sort by client channel number if this is the first time or if pvrmanager.backendchannelorder is true */
   bool bUseBackendChannelNumbers(m_members.empty() || m_bUsingBackendChannelOrder);
 
-  CPVRDatabase *database = GetPVRDatabase();
+  CPVRDatabase *database = CDatabaseManager::Get().GetPVRDatabase();
   if (!database)
     return bReturn;
 
@@ -853,7 +854,7 @@ bool CPVRChannelGroup::Persist(void)
   if (!HasChanges() || !m_bLoaded)
     return bReturn;
 
-  if (CPVRDatabase *database = GetPVRDatabase())
+  if (CPVRDatabase *database = CDatabaseManager::Get().GetPVRDatabase())
   {
     CLog::Log(LOGDEBUG, "CPVRChannelGroup - %s - persisting channel group '%s' with %d channels",
         __FUNCTION__, GroupName().c_str(), (int) m_members.size());
@@ -1161,7 +1162,7 @@ bool CPVRChannelGroup::SetLastWatched(time_t iLastWatched)
     lock.Leave();
 
     /* update the database immediately */
-    if (CPVRDatabase *database = GetPVRDatabase())
+    if (CPVRDatabase *database = CDatabaseManager::Get().GetPVRDatabase())
       return database->UpdateLastWatched(*this);
   }
 

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
@@ -20,6 +20,7 @@
 
 #include "PVRChannelGroupInternal.h"
 
+#include "DatabaseManager.h"
 #include "guilib/GUIWindowManager.h"
 #include "dialogs/GUIDialogYesNo.h"
 #include "dialogs/GUIDialogOK.h"
@@ -220,7 +221,7 @@ int CPVRChannelGroupInternal::GetMembers(CFileItemList &results, bool bGroupMemb
 
 int CPVRChannelGroupInternal::LoadFromDb(bool bCompress /* = false */)
 {
-  CPVRDatabase *database = GetPVRDatabase();
+  CPVRDatabase *database = CDatabaseManager::Get().GetPVRDatabase();
   if (!database)
     return -1;
 

--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -20,6 +20,7 @@
 
 #include "PVRChannelGroups.h"
 
+#include "DatabaseManager.h"
 #include "FileItem.h"
 #include "settings/Settings.h"
 #include "guilib/GUIWindowManager.h"
@@ -293,7 +294,7 @@ bool CPVRChannelGroups::LoadUserDefinedChannelGroups(void)
 
 bool CPVRChannelGroups::Load(void)
 {
-  CPVRDatabase *database = GetPVRDatabase();
+  CPVRDatabase *database = CDatabaseManager::Get().GetPVRDatabase();
   if (!database)
     return false;
 
@@ -551,7 +552,7 @@ bool CPVRChannelGroups::DeleteGroup(const CPVRChannelGroup &group)
   if (group.GroupID() > 0)
   {
     // delete the group from the database
-    CPVRDatabase *database = GetPVRDatabase();
+    CPVRDatabase *database = CDatabaseManager::Get().GetPVRDatabase();
     return database ? database->Delete(group) : false;
   }
   return bFound;

--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -17,12 +17,13 @@
  *  <http://www.gnu.org/licenses/>.
  *
  */
+#include "PVRRecordings.h"
 
+#include "DatabaseManager.h"
 #include "dialogs/GUIDialogOK.h"
 #include "epg/EpgContainer.h"
 #include "pvr/PVRManager.h"
 #include "settings/AdvancedSettings.h"
-#include "PVRRecordings.h"
 #include "pvr/addons/PVRClients.h"
 #include "utils/StringUtils.h"
 #include "utils/RegExp.h"
@@ -250,21 +251,23 @@ bool CPVRRecording::SetPlayCount(int count)
   return true;
 }
 
-void CPVRRecording::UpdateMetadata(CVideoDatabase &db)
+void CPVRRecording::UpdateMetadata()
 {
   if (m_bGotMetaData)
     return;
-    
+
+  CVideoDatabase *database = CDatabaseManager::Get().GetVideoDatabase();
+
   bool supportsPlayCount  = g_PVRClients->SupportsRecordingPlayCount(m_iClientId);
   bool supportsLastPlayed = g_PVRClients->SupportsLastPlayedPosition(m_iClientId);
   
   if (!supportsPlayCount || !supportsLastPlayed)
   {
     if (!supportsPlayCount)
-      m_playCount = db.GetPlayCount(m_strFileNameAndPath);
+      m_playCount = database->GetPlayCount(m_strFileNameAndPath);
 
     if (!supportsLastPlayed)
-      db.GetResumeBookMark(m_strFileNameAndPath, m_resumePoint);
+      database->GetResumeBookMark(m_strFileNameAndPath, m_resumePoint);
   }
   
   m_bGotMetaData = true;

--- a/xbmc/pvr/recordings/PVRRecording.h
+++ b/xbmc/pvr/recordings/PVRRecording.h
@@ -174,7 +174,7 @@ namespace PVR
      * @brief Get the resume point and play count from the database if the 
      * client doesn't handle it itself.
      */
-    void UpdateMetadata(CVideoDatabase &db);
+    void UpdateMetadata();
 
     /*!
      * @brief Update this tag with the contents of the given tag.

--- a/xbmc/pvr/recordings/PVRRecordings.h
+++ b/xbmc/pvr/recordings/PVRRecordings.h
@@ -42,7 +42,6 @@ namespace PVR
     PVR_RECORDINGMAP             m_recordings;
     unsigned int                 m_iLastId;
     bool                         m_bGroupItems;
-    CVideoDatabase               m_database;
     bool                         m_bHasDeleted;
 
     virtual void UpdateFromClients(void);

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -20,6 +20,7 @@
 
 #include "GUIWindowPVRRecordings.h"
 
+#include "DatabaseManager.h"
 #include "ContextMenuManager.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "dialogs/GUIDialogYesNo.h"
@@ -90,15 +91,11 @@ std::string CGUIWindowPVRRecordings::GetResumeString(const CFileItem& item)
     // If the back-end does report a saved position it will be picked up by FileItem
     if (positionInSeconds < 0)
     {
-      CVideoDatabase db;
-      if (db.Open())
-      {
-        CBookmark bookmark;
-        std::string itemPath(item.GetPVRRecordingInfoTag()->m_strFileNameAndPath);
-        if (db.GetResumeBookMark(itemPath, bookmark) )
-          positionInSeconds = lrint(bookmark.timeInSeconds);
-        db.Close();
-      }
+      CVideoDatabase *database = CDatabaseManager::Get().GetVideoDatabase();
+      CBookmark bookmark;
+      std::string itemPath(item.GetPVRRecordingInfoTag()->m_strFileNameAndPath);
+      if (database->GetResumeBookMark(itemPath, bookmark) )
+        positionInSeconds = lrint(bookmark.timeInSeconds);
     }
 
     // Suppress resume from 0
@@ -514,11 +511,7 @@ void CGUIWindowPVRRecordings::OnPrepareFileItems(CFileItemList& items)
 
   if (!files.IsEmpty())
   {
-    if (m_database.Open())
-    {
-      CGUIWindowVideoNav::LoadVideoInfo(files, m_database, false);
-      m_database.Close();
-    }
+    CGUIWindowVideoNav::LoadVideoInfo(files, false);
     m_thumbLoader.Load(files);
   }
 

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.h
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.h
@@ -59,7 +59,6 @@ namespace PVR
     bool OnContextButtonMarkWatched(const CFileItemPtr &item, CONTEXT_BUTTON button);
 
     CVideoThumbLoader m_thumbLoader;
-    CVideoDatabase m_database;
     bool m_bShowDeletedRecordings;
   };
 }

--- a/xbmc/settings/MediaSettings.cpp
+++ b/xbmc/settings/MediaSettings.cpp
@@ -282,20 +282,18 @@ void CMediaSettings::OnSettingAction(const CSetting *setting)
       g_mediaManager.GetLocalDrives(shares);
       if (CGUIDialogFileBrowser::ShowAndGetDirectory(shares, g_localizeStrings.Get(661), path, true))
       {
-        CMusicDatabase musicdatabase;
-        musicdatabase.Open();
+        CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
 
         if ( retVal == 1 )
         {
           path = URIUtils::AddFileToFolder(path, "karaoke.html");
-          musicdatabase.ExportKaraokeInfo( path, true );
+          database->ExportKaraokeInfo( path, true );
         }
         else
         {
           path = URIUtils::AddFileToFolder(path, "karaoke.csv");
-          musicdatabase.ExportKaraokeInfo( path, false );
+          database->ExportKaraokeInfo( path, false );
         }
-        musicdatabase.Close();
       }
     }
   }
@@ -306,10 +304,8 @@ void CMediaSettings::OnSettingAction(const CSetting *setting)
     g_mediaManager.GetLocalDrives(shares);
     if (CGUIDialogFileBrowser::ShowAndGetFile(shares, "karaoke.csv", g_localizeStrings.Get(651) , path))
     {
-      CMusicDatabase musicdatabase;
-      musicdatabase.Open();
-      musicdatabase.ImportKaraokeInfo(path);
-      musicdatabase.Close();
+      CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
+      database->ImportKaraokeInfo(path);
     }
   }
   else if (settingId == "musiclibrary.cleanup")
@@ -326,10 +322,8 @@ void CMediaSettings::OnSettingAction(const CSetting *setting)
     g_mediaManager.GetLocalDrives(shares);
     if (CGUIDialogFileBrowser::ShowAndGetFile(shares, "musicdb.xml", g_localizeStrings.Get(651) , path))
     {
-      CMusicDatabase musicdatabase;
-      musicdatabase.Open();
-      musicdatabase.ImportFromXML(path);
-      musicdatabase.Close();
+      CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
+      database->ImportFromXML(path);
     }
   }
   else if (settingId == "videolibrary.cleanup")

--- a/xbmc/settings/MediaSettings.cpp
+++ b/xbmc/settings/MediaSettings.cpp
@@ -22,6 +22,7 @@
 
 #include "MediaSettings.h"
 #include "Application.h"
+#include "DatabaseManager.h"
 #include "PlayListPlayer.h"
 #include "Util.h"
 #include "dialogs/GUIDialogContextMenu.h"
@@ -345,10 +346,8 @@ void CMediaSettings::OnSettingAction(const CSetting *setting)
     g_mediaManager.GetLocalDrives(shares);
     if (CGUIDialogFileBrowser::ShowAndGetDirectory(shares, g_localizeStrings.Get(651) , path))
     {
-      CVideoDatabase videodatabase;
-      videodatabase.Open();
-      videodatabase.ImportFromXML(path);
-      videodatabase.Close();
+      CVideoDatabase *database = CDatabaseManager::Get().GetVideoDatabase();
+      database->ImportFromXML(path);
     }
   }
 }

--- a/xbmc/threads/Thread.cpp
+++ b/xbmc/threads/Thread.cpp
@@ -25,6 +25,7 @@
 #include "threads/ThreadLocal.h"
 #include "threads/SingleLock.h"
 #include "commons/Exception.h"
+#include "DatabaseManager.h"
 #include <stdlib.h>
 
 #define __STDC_FORMAT_MACROS
@@ -158,6 +159,9 @@ bool CThread::IsAutoDelete() const
 
 void CThread::StopThread(bool bWait /*= true*/)
 {
+  // close/free thread local databases
+  CDatabaseManager::Get().CloseDatabases();
+
   m_bStop = true;
   m_StopEvent.Set();
   CSingleLock lock(m_CriticalSection);

--- a/xbmc/utils/RecentlyAddedJob.cpp
+++ b/xbmc/utils/RecentlyAddedJob.cpp
@@ -198,13 +198,12 @@ bool CRecentlyAddedJob::UpdateMusic()
   
   int            i = 0;
   CFileItemList  musicItems;
-  CMusicDatabase musicdatabase;
   CMusicThumbLoader loader;
   loader.OnLoaderStart();
+
+  CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
   
-  musicdatabase.Open();
-  
-  if (musicdatabase.GetRecentlyAddedAlbumSongs("musicdb://songs/", musicItems, NUM_ITEMS))
+  if (database->GetRecentlyAddedAlbumSongs("musicdb://songs/", musicItems, NUM_ITEMS))
   {
     long idAlbum = -1;
     std::string strAlbumThumb;
@@ -259,17 +258,17 @@ bool CRecentlyAddedJob::UpdateMusic()
   i = 0;
   VECALBUMS albums;
   
-  if (musicdatabase.GetRecentlyAddedAlbums(albums, NUM_ITEMS))
+  if (database->GetRecentlyAddedAlbums(albums, NUM_ITEMS))
   { 
     for (; i < (int)albums.size(); ++i)
     {
       CAlbum&    album=albums[i];
       std::string value = StringUtils::Format("%i", i + 1);
-      std::string strThumb = musicdatabase.GetArtForItem(album.idAlbum, MediaTypeAlbum, "thumb");
-      std::string strFanart = musicdatabase.GetArtistArtForItem(album.idAlbum, MediaTypeAlbum, "fanart");
+      std::string strThumb = database->GetArtForItem(album.idAlbum, MediaTypeAlbum, "thumb");
+      std::string strFanart = database->GetArtistArtForItem(album.idAlbum, MediaTypeAlbum, "fanart");
       std::string strDBpath = StringUtils::Format("musicdb://albums/%li/", album.idAlbum);
       std::string strSQLAlbum = StringUtils::Format("idAlbum=%li", album.idAlbum);
-      std::string strArtist = musicdatabase.GetSingleValue("albumview", "strArtists", strSQLAlbum);
+      std::string strArtist = database->GetSingleValue("albumview", "strArtists", strSQLAlbum);
       
       home->SetProperty("LatestAlbum." + value + ".Title"   , album.strAlbum);
       home->SetProperty("LatestAlbum." + value + ".Year"    , album.iYear);
@@ -291,8 +290,7 @@ bool CRecentlyAddedJob::UpdateMusic()
     home->SetProperty("LatestAlbum." + value + ".Thumb"   , "");
     home->SetProperty("LatestAlbum." + value + ".Fanart"  , "");            
   }
-  
-  musicdatabase.Close();
+
   return true;
 }
 
@@ -306,13 +304,11 @@ bool CRecentlyAddedJob::UpdateTotal()
   CLog::Log(LOGDEBUG, "CRecentlyAddedJob::UpdateTotal() - Running RecentlyAdded home screen update");
   
   CVideoDatabase *videodatabase = CDatabaseManager::Get().GetVideoDatabase();
-  CMusicDatabase musicdatabase;
-  
-  musicdatabase.Open();
-  int MusSongTotals   = atoi(musicdatabase.GetSingleValue("songview"       , "count(1)").c_str());
-  int MusAlbumTotals  = atoi(musicdatabase.GetSingleValue("songview"       , "count(distinct strAlbum)").c_str());
-  int MusArtistTotals = atoi(musicdatabase.GetSingleValue("songview"       , "count(distinct strArtists)").c_str());
-  musicdatabase.Close();
+  CMusicDatabase *musicdatabase = CDatabaseManager::Get().GetMusicDatabase();
+
+  int MusSongTotals   = atoi(musicdatabase->GetSingleValue("songview"       , "count(1)").c_str());
+  int MusAlbumTotals  = atoi(musicdatabase->GetSingleValue("songview"       , "count(distinct strAlbum)").c_str());
+  int MusArtistTotals = atoi(musicdatabase->GetSingleValue("songview"       , "count(distinct strArtists)").c_str());
 
   int tvShowCount     = atoi(videodatabase->GetSingleValue("tvshow_view"     , "count(1)").c_str());
   int movieTotals     = atoi(videodatabase->GetSingleValue("movie_view"      , "count(1)").c_str());

--- a/xbmc/utils/RecentlyAddedJob.cpp
+++ b/xbmc/utils/RecentlyAddedJob.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "utils/log.h"
+#include "DatabaseManager.h"
 #include "video/VideoDatabase.h"
 #include "video/VideoInfoTag.h"
 #include "FileItem.h"
@@ -52,13 +53,11 @@ bool CRecentlyAddedJob::UpdateVideo()
   
   int            i = 0;
   CFileItemList  items;
-  CVideoDatabase videodatabase;
   CVideoThumbLoader loader;
   loader.OnLoaderStart();
-  
-  videodatabase.Open();
 
-  if (videodatabase.GetRecentlyAddedMoviesNav("videodb://recentlyaddedmovies/", items, NUM_ITEMS))
+  CVideoDatabase *database = CDatabaseManager::Get().GetVideoDatabase();
+  if (database->GetRecentlyAddedMoviesNav("videodb://recentlyaddedmovies/", items, NUM_ITEMS))
   {  
     for (; i < items.Size(); ++i)
     {
@@ -98,7 +97,7 @@ bool CRecentlyAddedJob::UpdateVideo()
   i = 0;
   CFileItemList  TVShowItems; 
  
-  if (videodatabase.GetRecentlyAddedEpisodesNav("videodb://recentlyaddedepisodes/", TVShowItems, NUM_ITEMS))
+  if (database->GetRecentlyAddedEpisodesNav("videodb://recentlyaddedepisodes/", TVShowItems, NUM_ITEMS))
   {
     for (; i < TVShowItems.Size(); ++i)
     {    
@@ -123,7 +122,7 @@ bool CRecentlyAddedJob::UpdateVideo()
 
       std::string seasonThumb;
       if (item->GetVideoInfoTag()->m_iIdSeason > 0)
-        seasonThumb = videodatabase.GetArtForItem(item->GetVideoInfoTag()->m_iIdSeason, MediaTypeSeason, "thumb");
+        seasonThumb = database->GetArtForItem(item->GetVideoInfoTag()->m_iIdSeason, MediaTypeSeason, "thumb");
 
       home->SetProperty("LatestEpisode." + value + ".Thumb"         , item->GetArt("thumb"));
       home->SetProperty("LatestEpisode." + value + ".ShowThumb"     , item->GetArt("tvshow.thumb"));
@@ -151,7 +150,7 @@ bool CRecentlyAddedJob::UpdateVideo()
   i = 0;
   CFileItemList MusicVideoItems;
 
-  if (videodatabase.GetRecentlyAddedMusicVideosNav("videodb://recentlyaddedmusicvideos/", MusicVideoItems, NUM_ITEMS))
+  if (database->GetRecentlyAddedMusicVideosNav("videodb://recentlyaddedmusicvideos/", MusicVideoItems, NUM_ITEMS))
   {
     for (; i < MusicVideoItems.Size(); ++i)
     {
@@ -185,7 +184,6 @@ bool CRecentlyAddedJob::UpdateVideo()
     home->SetProperty("LatestMusicVideo." + value + ".Fanart"      , "");
   }
 
-  videodatabase.Close();
   return true;
 }
 
@@ -307,7 +305,7 @@ bool CRecentlyAddedJob::UpdateTotal()
   
   CLog::Log(LOGDEBUG, "CRecentlyAddedJob::UpdateTotal() - Running RecentlyAdded home screen update");
   
-  CVideoDatabase videodatabase;  
+  CVideoDatabase *videodatabase = CDatabaseManager::Get().GetVideoDatabase();
   CMusicDatabase musicdatabase;
   
   musicdatabase.Open();
@@ -315,17 +313,15 @@ bool CRecentlyAddedJob::UpdateTotal()
   int MusAlbumTotals  = atoi(musicdatabase.GetSingleValue("songview"       , "count(distinct strAlbum)").c_str());
   int MusArtistTotals = atoi(musicdatabase.GetSingleValue("songview"       , "count(distinct strArtists)").c_str());
   musicdatabase.Close();
- 
-  videodatabase.Open();
-  int tvShowCount     = atoi(videodatabase.GetSingleValue("tvshow_view"     , "count(1)").c_str());
-  int movieTotals     = atoi(videodatabase.GetSingleValue("movie_view"      , "count(1)").c_str());
-  int movieWatched    = atoi(videodatabase.GetSingleValue("movie_view"      , "count(playCount)").c_str());
-  int MusVidTotals    = atoi(videodatabase.GetSingleValue("musicvideo_view" , "count(1)").c_str());
-  int MusVidWatched   = atoi(videodatabase.GetSingleValue("musicvideo_view" , "count(playCount)").c_str());
-  int EpWatched       = atoi(videodatabase.GetSingleValue("tvshow_view"     , "sum(watchedcount)").c_str());
-  int EpCount         = atoi(videodatabase.GetSingleValue("tvshow_view"     , "sum(totalcount)").c_str());
-  int TvShowsWatched  = atoi(videodatabase.GetSingleValue("tvshow_view"     , "sum(watchedcount = totalcount)").c_str());
-  videodatabase.Close();
+
+  int tvShowCount     = atoi(videodatabase->GetSingleValue("tvshow_view"     , "count(1)").c_str());
+  int movieTotals     = atoi(videodatabase->GetSingleValue("movie_view"      , "count(1)").c_str());
+  int movieWatched    = atoi(videodatabase->GetSingleValue("movie_view"      , "count(playCount)").c_str());
+  int MusVidTotals    = atoi(videodatabase->GetSingleValue("musicvideo_view" , "count(1)").c_str());
+  int MusVidWatched   = atoi(videodatabase->GetSingleValue("musicvideo_view" , "count(playCount)").c_str());
+  int EpWatched       = atoi(videodatabase->GetSingleValue("tvshow_view"     , "sum(watchedcount)").c_str());
+  int EpCount         = atoi(videodatabase->GetSingleValue("tvshow_view"     , "sum(totalcount)").c_str());
+  int TvShowsWatched  = atoi(videodatabase->GetSingleValue("tvshow_view"     , "sum(watchedcount = totalcount)").c_str());
   
   home->SetProperty("TVShows.Count"         , tvShowCount);
   home->SetProperty("TVShows.Watched"       , TvShowsWatched);

--- a/xbmc/utils/SaveFileStateJob.cpp
+++ b/xbmc/utils/SaveFileStateJob.cpp
@@ -168,19 +168,10 @@ bool CSaveFileStateJob::DoWork()
         if (dialog && !dialog->IsDialogRunning())
 #endif
         {
-          CMusicDatabase musicdatabase;
-          if (!musicdatabase.Open())
-          {
-            CLog::Log(LOGWARNING, "%s - Unable to open music database. Can not save file state!", __FUNCTION__);
-          }
-          else
-          {
-            // consider this item as played
-            CLog::Log(LOGDEBUG, "%s - Marking audio item %s as listened", __FUNCTION__, redactPath.c_str());
-
-            musicdatabase.IncrementPlayCount(m_item);
-            musicdatabase.Close();
-          }
+          CMusicDatabase *musicdatabase = CDatabaseManager::Get().GetMusicDatabase();
+          // consider this item as played
+          CLog::Log(LOGDEBUG, "%s - Marking audio item %s as listened", __FUNCTION__, redactPath.c_str());
+          musicdatabase->IncrementPlayCount(m_item);
         }
       }
     }

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -23,6 +23,7 @@
 #endif
 
 #include "ApplicationMessenger.h"
+#include "DatabaseManager.h"
 #include "threads/SystemClock.h"
 #include "VideoDatabase.h"
 #include "video/windows/GUIWindowVideoBase.h"
@@ -4355,35 +4356,32 @@ void CVideoDatabase::UpdateTables(int iVersion)
   }
   if (iVersion < 72)
   { // Update thumb to poster or banner as applicable
-    CTextureDatabase db;
-    if (db.Open())
+    CTextureDatabase *textureDatabase = CDatabaseManager::Get().GetTextureDatabase();
+    m_pDS->query("select art_id,url,media_id,media_type from art where type='thumb' and media_type in ('movie', 'musicvideo', 'tvshow', 'season', 'set')");
+    vector<CArtItem> art;
+    while (!m_pDS->eof())
     {
-      m_pDS->query("select art_id,url,media_id,media_type from art where type='thumb' and media_type in ('movie', 'musicvideo', 'tvshow', 'season', 'set')");
-      vector<CArtItem> art;
-      while (!m_pDS->eof())
+      CTextureDetails details;
+      if (textureDatabase->GetCachedTexture(m_pDS->fv(1).get_asString(), details))
       {
-        CTextureDetails details;
-        if (db.GetCachedTexture(m_pDS->fv(1).get_asString(), details))
-        {
-          CArtItem item;
-          item.art_id = m_pDS->fv(0).get_asInt();
-          item.art_url = m_pDS->fv(1).get_asString();
-          item.art_type = CVideoInfoScanner::GetArtTypeFromSize(details.width, details.height);
-          item.media_id = m_pDS->fv(2).get_asInt();
-          item.media_type = m_pDS->fv(3).get_asString();
-          if (item.art_type != "thumb")
-            art.push_back(item);
-        }
-        m_pDS->next();
+        CArtItem item;
+        item.art_id = m_pDS->fv(0).get_asInt();
+        item.art_url = m_pDS->fv(1).get_asString();
+        item.art_type = CVideoInfoScanner::GetArtTypeFromSize(details.width, details.height);
+        item.media_id = m_pDS->fv(2).get_asInt();
+        item.media_type = m_pDS->fv(3).get_asString();
+        if (item.art_type != "thumb")
+          art.push_back(item);
       }
-      m_pDS->close();
-      for (vector<CArtItem>::iterator i = art.begin(); i != art.end(); ++i)
-      {
-        if (GetArtForItem(i->media_id, i->media_type, i->art_type).empty())
-          m_pDS->exec(PrepareSQL("update art set type='%s' where art_id=%d", i->art_type.c_str(), i->art_id));
-        else
-          m_pDS->exec(PrepareSQL("delete from art where art_id=%d", i->art_id));
-      }
+      m_pDS->next();
+    }
+    m_pDS->close();
+    for (vector<CArtItem>::iterator i = art.begin(); i != art.end(); ++i)
+    {
+      if (GetArtForItem(i->media_id, i->media_type, i->art_type).empty())
+        m_pDS->exec(PrepareSQL("update art set type='%s' where art_id=%d", i->art_type.c_str(), i->art_id));
+      else
+        m_pDS->exec(PrepareSQL("delete from art where art_id=%d", i->art_id));
     }
   }
   if (iVersion < 74)

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -251,7 +251,6 @@ namespace VIDEO
     bool m_bClean;
     bool m_scanAll;
     std::string m_strStartDir;
-    CVideoDatabase m_database;
     std::set<std::string> m_pathsToScan;
     std::set<std::string> m_pathsToCount;
     std::set<int> m_pathsToClean;

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -423,18 +423,16 @@ bool CVideoThumbLoader::FillLibraryArt(CFileItem &item)
       SetArt(item, artwork);
     else if (tag.m_type == MediaTypeArtist)
     { // we retrieve music video art from the music database (no backward compat)
-      CMusicDatabase database;
-      database.Open();
-      int idArtist = database.GetArtistByName(item.GetLabel());
-      if (database.GetArtForItem(idArtist, MediaTypeArtist, artwork))
+      CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
+      int idArtist = database->GetArtistByName(item.GetLabel());
+      if (database->GetArtForItem(idArtist, MediaTypeArtist, artwork))
         item.SetArt(artwork);
     }
     else if (tag.m_type == MediaTypeAlbum)
     { // we retrieve music video art from the music database (no backward compat)
-      CMusicDatabase database;
-      database.Open();
-      int idAlbum = database.GetAlbumByName(item.GetLabel(), tag.m_artist);
-      if (database.GetArtForItem(idAlbum, MediaTypeAlbum, artwork))
+      CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
+      int idAlbum = database->GetAlbumByName(item.GetLabel(), tag.m_artist);
+      if (database->GetArtForItem(idAlbum, MediaTypeAlbum, artwork))
         item.SetArt(artwork);
     }
     // For episodes and seasons, we want to set fanart for that of the show

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -21,6 +21,7 @@
 #include <cstdlib>
 
 #include "VideoThumbLoader.h"
+#include "DatabaseManager.h"
 #include "filesystem/StackDirectory.h"
 #include "utils/URIUtils.h"
 #include "URL.h"
@@ -103,6 +104,8 @@ bool CThumbExtractor::DoWork()
       return false;
   }
 
+  CVideoDatabase *database = CDatabaseManager::Get().GetVideoDatabase();
+
   bool result=false;
   if (m_thumb)
   {
@@ -121,12 +124,8 @@ bool CThumbExtractor::DoWork()
       CVideoInfoTag* info = m_item.GetVideoInfoTag();
       if (info->m_iDbId > 0 && !info->m_type.empty())
       {
-        CVideoDatabase db;
-        if (db.Open())
-        {
-          db.SetArtForItem(info->m_iDbId, info->m_type, "thumb", m_item.GetArt("thumb"));
-          db.Close();
-        }
+        database->SetArtForItem(info->m_iDbId, info->m_type, "thumb", m_item.GetArt("thumb"));
+        database->Close();
       }
     }
   }
@@ -140,33 +139,27 @@ bool CThumbExtractor::DoWork()
   if (result)
   {
     CVideoInfoTag* info = m_item.GetVideoInfoTag();
-    CVideoDatabase db;
-    if (db.Open())
+    if (URIUtils::IsStack(m_listpath))
     {
-      if (URIUtils::IsStack(m_listpath))
-      {
-        // Don't know the total time of the stack, so set duration to zero to avoid confusion
-        info->m_streamDetails.SetVideoDuration(0, 0);
+      // Don't know the total time of the stack, so set duration to zero to avoid confusion
+      info->m_streamDetails.SetVideoDuration(0, 0);
 
-        // Restore original stack path
-        m_item.SetPath(m_listpath);
-      }
+      // Restore original stack path
+      m_item.SetPath(m_listpath);
+    }
 
-      if (info->m_iFileId < 0)
-        db.SetStreamDetailsForFile(info->m_streamDetails, !info->m_strFileNameAndPath.empty() ? info->m_strFileNameAndPath : static_cast<const std::string&>(m_item.GetPath()));
-      else
-        db.SetStreamDetailsForFileId(info->m_streamDetails, info->m_iFileId);
+    if (info->m_iFileId < 0)
+      database->SetStreamDetailsForFile(info->m_streamDetails, !info->m_strFileNameAndPath.empty() ? info->m_strFileNameAndPath : static_cast<const std::string&>(m_item.GetPath()));
+    else
+      database->SetStreamDetailsForFileId(info->m_streamDetails, info->m_iFileId);
 
-      // overwrite the runtime value if the one from streamdetails is available
-      if (info->m_iDbId > 0 && info->m_duration != static_cast<int>(info->GetDuration()))
-      {
-        info->m_duration = info->GetDuration();
+    // overwrite the runtime value if the one from streamdetails is available
+    if (info->m_iDbId > 0 && info->m_duration != static_cast<int>(info->GetDuration()))
+    {
+      info->m_duration = info->GetDuration();
 
-        // store the updated information in the database
-        db.SetDetailsForItem(info->m_iDbId, info->m_type, *info, m_item.GetArt());
-      }
-
-      db.Close();
+      // store the updated information in the database
+      database->SetDetailsForItem(info->m_iDbId, info->m_type, *info, m_item.GetArt());
     }
     return true;
   }
@@ -177,25 +170,21 @@ bool CThumbExtractor::DoWork()
 CVideoThumbLoader::CVideoThumbLoader() :
   CThumbLoader(), CJobQueue(true, 1, CJob::PRIORITY_LOW_PAUSABLE)
 {
-  m_videoDatabase = new CVideoDatabase();
 }
 
 CVideoThumbLoader::~CVideoThumbLoader()
 {
   StopThread();
-  delete m_videoDatabase;
 }
 
 void CVideoThumbLoader::OnLoaderStart()
 {
-  m_videoDatabase->Open();
   m_showArt.clear();
   CThumbLoader::OnLoaderStart();
 }
 
 void CVideoThumbLoader::OnLoaderFinish()
 {
-  m_videoDatabase->Close();
   m_showArt.clear();
   CThumbLoader::OnLoaderFinish();
 }
@@ -267,14 +256,14 @@ bool CVideoThumbLoader::LoadItemCached(CFileItem* pItem)
   ||  pItem->IsParentFolder())
     return false;
 
-  m_videoDatabase->Open();
+  CVideoDatabase *database = CDatabaseManager::Get().GetVideoDatabase();
 
   if (!pItem->HasVideoInfoTag() || !pItem->GetVideoInfoTag()->HasStreamDetails()) // no stream details
   {
     if ((pItem->HasVideoInfoTag() && pItem->GetVideoInfoTag()->m_iFileId >= 0) // file (or maybe folder) is in the database
     || (!pItem->m_bIsFolder && pItem->IsVideo())) // Some other video file for which we haven't yet got any database details
     {
-      if (m_videoDatabase->GetStreamDetails(*pItem))
+      if (database->GetStreamDetails(*pItem))
         pItem->SetInvalid();
     }
   }
@@ -290,7 +279,7 @@ bool CVideoThumbLoader::LoadItemCached(CFileItem* pItem)
          pItem->GetVideoInfoTag()->m_type != MediaTypeEpisode    &&
          pItem->GetVideoInfoTag()->m_type != MediaTypeMusicVideo)
     {
-      m_videoDatabase->Close();
+      database->Close();
       return true; // nothing else to be done
     }
   }
@@ -312,8 +301,6 @@ bool CVideoThumbLoader::LoadItemCached(CFileItem* pItem)
     SetArt(*pItem, artwork);
   }
 
-  m_videoDatabase->Close();
-
   return true;
 }
 
@@ -332,7 +319,7 @@ bool CVideoThumbLoader::LoadItemLookup(CFileItem* pItem)
 
   DetectAndAddMissingItemData(*pItem);
 
-  m_videoDatabase->Open();
+  CVideoDatabase *database = CDatabaseManager::Get().GetVideoDatabase();
 
   map<string, string> artwork = pItem->GetArt();
   vector<string> artTypes = GetArtTypes(pItem->HasVideoInfoTag() ? pItem->GetVideoInfoTag()->m_type : "");
@@ -378,7 +365,7 @@ bool CVideoThumbLoader::LoadItemLookup(CFileItem* pItem)
           // Item has cached autogen image but no art entry. Save it to db.
           CVideoInfoTag* info = pItem->GetVideoInfoTag();
           if (info->m_iDbId > 0 && !info->m_type.empty())
-            m_videoDatabase->SetArtForItem(info->m_iDbId, info->m_type, "thumb", thumbURL);
+            database->SetArtForItem(info->m_iDbId, info->m_type, "thumb", thumbURL);
         }
       }
       else if (CSettings::Get().GetBool("myvideos.extractthumb") &&
@@ -392,7 +379,6 @@ bool CVideoThumbLoader::LoadItemLookup(CFileItem* pItem)
         CThumbExtractor* extract = new CThumbExtractor(item, path, true, thumbURL);
         AddJob(extract);
 
-        m_videoDatabase->Close();
         return true;
       }
     }
@@ -411,7 +397,6 @@ bool CVideoThumbLoader::LoadItemLookup(CFileItem* pItem)
     }
   }
 
-  m_videoDatabase->Close();
   return true;
 }
 
@@ -433,8 +418,8 @@ bool CVideoThumbLoader::FillLibraryArt(CFileItem &item)
   if (tag.m_iDbId > -1 && !tag.m_type.empty())
   {
     map<string, string> artwork;
-    m_videoDatabase->Open();
-    if (m_videoDatabase->GetArtForItem(tag.m_iDbId, tag.m_type, artwork))
+    CVideoDatabase *database = CDatabaseManager::Get().GetVideoDatabase();
+    if (database->GetArtForItem(tag.m_iDbId, tag.m_type, artwork))
       SetArt(item, artwork);
     else if (tag.m_type == MediaTypeArtist)
     { // we retrieve music video art from the music database (no backward compat)
@@ -459,7 +444,7 @@ bool CVideoThumbLoader::FillLibraryArt(CFileItem &item)
       if (i == m_showArt.end())
       {
         map<string, string> showArt;
-        m_videoDatabase->GetArtForItem(tag.m_iIdShow, MediaTypeTvShow, showArt);
+        database->GetArtForItem(tag.m_iIdShow, MediaTypeTvShow, showArt);
         i = m_showArt.insert(make_pair(tag.m_iIdShow, showArt)).first;
       }
       if (i != m_showArt.end())
@@ -469,7 +454,6 @@ bool CVideoThumbLoader::FillLibraryArt(CFileItem &item)
         item.SetArtFallback("tvshow.thumb", "tvshow.poster");
       }
     }
-    m_videoDatabase->Close();
   }
   return !item.GetArt().empty();
 }
@@ -570,10 +554,9 @@ void CVideoThumbLoader::DetectAndAddMissingItemData(CFileItem &item)
 
     // check for custom stereomode setting in video settings
     CVideoSettings itemVideoSettings;
-    m_videoDatabase->Open();
-    if (m_videoDatabase->GetVideoSettings(item, itemVideoSettings) && itemVideoSettings.m_StereoMode != RENDER_STEREO_MODE_OFF)
+    CVideoDatabase *database = CDatabaseManager::Get().GetVideoDatabase();
+    if (database->GetVideoSettings(item, itemVideoSettings) && itemVideoSettings.m_StereoMode != RENDER_STEREO_MODE_OFF)
       stereoMode = CStereoscopicsManager::Get().ConvertGuiStereoModeToString( (RENDER_STEREO_MODE) itemVideoSettings.m_StereoMode );
-    m_videoDatabase->Close();
 
     // still empty, try grabbing from filename
     // TODO: in case of too many false positives due to using the full path, extract the filename only using string utils

--- a/xbmc/video/VideoThumbLoader.h
+++ b/xbmc/video/VideoThumbLoader.h
@@ -126,7 +126,6 @@ public:
   static void SetArt(CFileItem &item, const std::map<std::string, std::string> &artwork);
 
 protected:
-  CVideoDatabase *m_videoDatabase;
   typedef std::map<int, std::map<std::string, std::string> > ArtCache;
   ArtCache m_showArt;
 

--- a/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
@@ -20,6 +20,7 @@
 
 #include "GUIDialogAudioSubtitleSettings.h"
 #include "Application.h"
+#include "DatabaseManager.h"
 #include "FileItem.h"
 #include "GUIPassword.h"
 #include "URL.h"
@@ -239,12 +240,8 @@ void CGUIDialogAudioSubtitleSettings::Save()
     return;
 
   // reset the settings
-  CVideoDatabase db;
-  if (!db.Open())
-    return;
-
-  db.EraseVideoSettings();
-  db.Close();
+  CVideoDatabase *database = CDatabaseManager::Get().GetVideoDatabase();
+  database->EraseVideoSettings();
 
   CMediaSettings::Get().GetDefaultVideoSettings() = CMediaSettings::Get().GetCurrentVideoSettings();
   CMediaSettings::Get().GetDefaultVideoSettings().m_SubtitleStream = -1;

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -242,13 +242,12 @@ void CGUIDialogVideoInfo::SetMovie(const CFileItem *item)
   VIDEODB_CONTENT_TYPE type = (VIDEODB_CONTENT_TYPE)m_movieItem->GetVideoContentType();
   if (type == VIDEODB_CONTENT_MUSICVIDEOS)
   { // music video
-    CMusicDatabase database;
-    database.Open();
+    CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
     const std::vector<std::string> &artists = m_movieItem->GetVideoInfoTag()->m_artist;
     for (std::vector<std::string>::const_iterator it = artists.begin(); it != artists.end(); ++it)
     {
-      int idArtist = database.GetArtistByName(*it);
-      std::string thumb = database.GetArtForItem(idArtist, MediaTypeArtist, "thumb");
+      int idArtist = database->GetArtistByName(*it);
+      std::string thumb = database->GetArtForItem(idArtist, MediaTypeArtist, "thumb");
       CFileItemPtr item(new CFileItem(*it));
       if (!thumb.empty())
         item->SetArt("thumb", thumb);
@@ -1555,16 +1554,13 @@ bool CGUIDialogVideoInfo::ManageVideoItemArtwork(const CFileItemPtr &item, const
   string artType = "thumb";
   if (type == MediaTypeArtist)
   {
-    CMusicDatabase musicdb;
-    if (musicdb.Open())
+    CMusicDatabase *musicDatabase = CDatabaseManager::Get().GetMusicDatabase();
+    idArtist = musicDatabase->GetArtistByName(item->GetLabel());
+    if (idArtist >= 0 && musicDatabase->GetArtistPath(idArtist, artistPath))
     {
-      idArtist = musicdb.GetArtistByName(item->GetLabel());
-      if (idArtist >= 0 && musicdb.GetArtistPath(idArtist, artistPath))
-      {
-        currentThumb = musicdb.GetArtForItem(idArtist, MediaTypeArtist, "thumb");
-        if (currentThumb.empty())
-          currentThumb = database->GetArtForItem(item->GetVideoInfoTag()->m_iDbId, item->GetVideoInfoTag()->m_type, artType);
-      }
+      currentThumb = musicDatabase->GetArtForItem(idArtist, MediaTypeArtist, "thumb");
+      if (currentThumb.empty())
+        currentThumb = database->GetArtForItem(item->GetVideoInfoTag()->m_iDbId, item->GetVideoInfoTag()->m_type, artType);
     }
   }
   else if (type == "actor")
@@ -1702,9 +1698,8 @@ bool CGUIDialogVideoInfo::ManageVideoItemArtwork(const CFileItemPtr &item, const
     database->SetArtForItem(item->GetVideoInfoTag()->m_iDbId, item->GetVideoInfoTag()->m_type, artType, result);
   else
   {
-    CMusicDatabase musicdb;
-    if (musicdb.Open())
-      musicdb.SetArtForItem(idArtist, MediaTypeArtist, artType, result);
+    CMusicDatabase *musicDatabase = CDatabaseManager::Get().GetMusicDatabase();
+    musicDatabase->SetArtForItem(idArtist, MediaTypeArtist, artType, result);
   }
 
   CUtil::DeleteVideoDatabaseDirectoryCache();

--- a/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
@@ -20,6 +20,7 @@
 
 #include "system.h"
 #include "GUIDialogVideoSettings.h"
+#include "DatabaseManager.h"
 #include "GUIPassword.h"
 #include "addons/Skin.h"
 #ifdef HAS_VIDEO_PLAYBACK
@@ -172,11 +173,9 @@ void CGUIDialogVideoSettings::Save()
   // prompt user if they are sure
   if (CGUIDialogYesNo::ShowAndGetInput(12376, 750, 0, 12377))
   { // reset the settings
-    CVideoDatabase db;
-    if (!db.Open())
-      return;
-    db.EraseVideoSettings();
-    db.Close();
+    CVideoDatabase *database = CDatabaseManager::Get().GetVideoDatabase();
+    database->EraseVideoSettings();
+    database->Close();
 
     CMediaSettings::Get().GetDefaultVideoSettings() = CMediaSettings::Get().GetCurrentVideoSettings();
     CMediaSettings::Get().GetDefaultVideoSettings().m_SubtitleStream = -1;

--- a/xbmc/video/jobs/VideoLibraryCleaningJob.cpp
+++ b/xbmc/video/jobs/VideoLibraryCleaningJob.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "VideoLibraryCleaningJob.h"
+#include "DatabaseManager.h"
 #include "dialogs/GUIDialogExtendedProgressBar.h"
 #include "video/VideoDatabase.h"
 
@@ -52,8 +53,9 @@ bool CVideoLibraryCleaningJob::operator==(const CJob* job) const
          m_showDialog == cleaningJob->m_showDialog;
 }
 
-bool CVideoLibraryCleaningJob::Work(CVideoDatabase &db)
+bool CVideoLibraryCleaningJob::Work()
 {
-  db.CleanDatabase(GetProgressBar(), m_paths, m_showDialog);
+  CVideoDatabase *database = CDatabaseManager::Get().GetVideoDatabase();
+  database->CleanDatabase(GetProgressBar(), m_paths, m_showDialog);
   return true;
 }

--- a/xbmc/video/jobs/VideoLibraryCleaningJob.h
+++ b/xbmc/video/jobs/VideoLibraryCleaningJob.h
@@ -54,7 +54,7 @@ public:
 
 protected:
   // implementation of CVideoLibraryJob
-  virtual bool Work(CVideoDatabase &db);
+  virtual bool Work();
 
 private:
   std::set<int> m_paths;

--- a/xbmc/video/jobs/VideoLibraryJob.cpp
+++ b/xbmc/video/jobs/VideoLibraryJob.cpp
@@ -20,20 +20,3 @@
 
 #include "VideoLibraryJob.h"
 #include "video/VideoDatabase.h"
-
-using namespace std;
-
-CVideoLibraryJob::CVideoLibraryJob()
-{ }
-
-CVideoLibraryJob::~CVideoLibraryJob()
-{ }
-
-bool CVideoLibraryJob::DoWork()
-{
-  CVideoDatabase db;
-  if (!db.Open())
-    return false;
-
-  return Work(db);
-}

--- a/xbmc/video/jobs/VideoLibraryJob.h
+++ b/xbmc/video/jobs/VideoLibraryJob.h
@@ -30,7 +30,7 @@ class CVideoDatabase;
 class CVideoLibraryJob : public CJob
 {
 public:
-  virtual ~CVideoLibraryJob();
+  virtual ~CVideoLibraryJob() {};
 
   /*!
    \brief Whether the job can be cancelled or not.
@@ -45,18 +45,16 @@ public:
   virtual bool Cancel() { return false; }
 
   // implementation of CJob
-  virtual bool DoWork();
+  virtual bool DoWork() { return false; }
   virtual const char *GetType() const { return "VideoLibraryJob"; }
   virtual bool operator==(const CJob* job) const { return false; }
 
 protected:
-  CVideoLibraryJob();
+  CVideoLibraryJob() {};
 
   /*!
    \brief Worker method to be implemented by an actual implementation.
-
-   \param[in] db Already open video database to be used for interaction
    \return True if the process succeeded, false otherwise
    */
-  virtual bool Work(CVideoDatabase &db) = 0;
+  virtual bool Work() = 0;
 };

--- a/xbmc/video/jobs/VideoLibraryMarkWatchedJob.h
+++ b/xbmc/video/jobs/VideoLibraryMarkWatchedJob.h
@@ -41,7 +41,7 @@ public:
   virtual bool operator==(const CJob* job) const;
 
 protected:
-  virtual bool Work(CVideoDatabase &db);
+  virtual bool Work();
 
 private:
   CFileItemPtr m_item;

--- a/xbmc/video/jobs/VideoLibraryScanningJob.cpp
+++ b/xbmc/video/jobs/VideoLibraryScanningJob.cpp
@@ -55,7 +55,7 @@ bool CVideoLibraryScanningJob::operator==(const CJob* job) const
          m_scanAll == scanningJob->m_scanAll;
 }
 
-bool CVideoLibraryScanningJob::Work(CVideoDatabase &db)
+bool CVideoLibraryScanningJob::Work()
 {
   m_scanner.ShowDialog(m_showProgress);
   m_scanner.Start(m_directory, m_scanAll);

--- a/xbmc/video/jobs/VideoLibraryScanningJob.h
+++ b/xbmc/video/jobs/VideoLibraryScanningJob.h
@@ -53,7 +53,7 @@ public:
 
 protected:
   // implementation of CVideoLibraryJob
-  virtual bool Work(CVideoDatabase &db);
+  virtual bool Work();
 
 private:
   VIDEO::CVideoInfoScanner m_scanner;

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -540,13 +540,10 @@ bool CGUIWindowVideoBase::ShowIMDB(CFileItem *item, const ScraperPtr &info2, boo
       // show dialog that we're downloading the movie info
 
       // clear artwork and invalidate hashes
-      CTextureDatabase db;
-      if (db.Open())
-      {
-        for (CGUIListItem::ArtMap::const_iterator i = item->GetArt().begin(); i != item->GetArt().end(); ++i)
-          db.InvalidateCachedTexture(i->second);
-        db.Close();
-      }
+      CTextureDatabase *textureDatabase = CDatabaseManager::Get().GetTextureDatabase();
+      for (CGUIListItem::ArtMap::const_iterator i = item->GetArt().begin(); i != item->GetArt().end(); ++i)
+        textureDatabase->InvalidateCachedTexture(i->second);
+
       item->ClearArt();
 
       CFileItemList list;
@@ -554,9 +551,9 @@ bool CGUIWindowVideoBase::ShowIMDB(CFileItem *item, const ScraperPtr &info2, boo
       if (item->IsVideoDb() || fromDB)
       {
         vector<string> paths;
-        CVideoDatabase *database = CDatabaseManager::Get().GetVideoDatabase();
+        CVideoDatabase *textureDatabase = CDatabaseManager::Get().GetVideoDatabase();
         if (item->GetVideoInfoTag()->m_type == "tvshow" && pDlgInfo->RefreshAll() &&
-            database->GetPathsLinkedToTvShow(item->GetVideoInfoTag()->m_iDbId, paths))
+            textureDatabase->GetPathsLinkedToTvShow(item->GetVideoInfoTag()->m_iDbId, paths))
         {
           for (vector<string>::const_iterator i = paths.begin(); i != paths.end(); ++i)
           {

--- a/xbmc/video/windows/GUIWindowVideoBase.h
+++ b/xbmc/video/windows/GUIWindowVideoBase.h
@@ -139,7 +139,6 @@ protected:
   bool OnPlayStackPart(int item);
 
   CGUIDialogProgress* m_dlgProgress;
-  CVideoDatabase m_database;
 
   CVideoThumbLoader m_thumbLoader;
   bool m_stackingAvailable;

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -870,25 +870,22 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
 
     if (item->HasVideoInfoTag() && !item->GetVideoInfoTag()->m_artist.empty())
     {
-      CMusicDatabase database;
-      database.Open();
-      if (database.GetArtistByName(StringUtils::Join(item->GetVideoInfoTag()->m_artist, g_advancedSettings.m_videoItemSeparator)) > -1)
+      CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
+      if (database->GetArtistByName(StringUtils::Join(item->GetVideoInfoTag()->m_artist, g_advancedSettings.m_videoItemSeparator)) > -1)
         buttons.Add(CONTEXT_BUTTON_GO_TO_ARTIST, 20396);
     }
     if (item->HasVideoInfoTag() && item->GetVideoInfoTag()->m_strAlbum.size() > 0)
     {
-      CMusicDatabase database;
-      database.Open();
-      if (database.GetAlbumByName(item->GetVideoInfoTag()->m_strAlbum) > -1)
+      CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
+      if (database->GetAlbumByName(item->GetVideoInfoTag()->m_strAlbum) > -1)
         buttons.Add(CONTEXT_BUTTON_GO_TO_ALBUM, 20397);
     }
     if (item->HasVideoInfoTag() && item->GetVideoInfoTag()->m_strAlbum.size() > 0 &&
         item->GetVideoInfoTag()->m_artist.size() > 0                              &&
         item->GetVideoInfoTag()->m_strTitle.size() > 0)
     {
-      CMusicDatabase database;
-      database.Open();
-      if (database.GetSongByArtistAndAlbumAndTitle(StringUtils::Join(item->GetVideoInfoTag()->m_artist, g_advancedSettings.m_videoItemSeparator),
+      CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
+      if (database->GetSongByArtistAndAlbumAndTitle(StringUtils::Join(item->GetVideoInfoTag()->m_artist, g_advancedSettings.m_videoItemSeparator),
                                                    item->GetVideoInfoTag()->m_strAlbum,
                                                    item->GetVideoInfoTag()->m_strTitle) > -1)
       {
@@ -1048,29 +1045,26 @@ bool CGUIWindowVideoNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
   case CONTEXT_BUTTON_GO_TO_ARTIST:
     {
       std::string strPath;
-      CMusicDatabase database;
-      database.Open();
+      CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
       strPath = StringUtils::Format("musicdb://artists/%i/",
-                                    database.GetArtistByName(StringUtils::Join(m_vecItems->Get(itemNumber)->GetVideoInfoTag()->m_artist, g_advancedSettings.m_videoItemSeparator)));
+                                    database->GetArtistByName(StringUtils::Join(m_vecItems->Get(itemNumber)->GetVideoInfoTag()->m_artist, g_advancedSettings.m_videoItemSeparator)));
       g_windowManager.ActivateWindow(WINDOW_MUSIC_NAV,strPath);
       return true;
     }
   case CONTEXT_BUTTON_GO_TO_ALBUM:
     {
       std::string strPath;
-      CMusicDatabase database;
-      database.Open();
+      CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
       strPath = StringUtils::Format("musicdb://albums/%i/",
-                                    database.GetAlbumByName(m_vecItems->Get(itemNumber)->GetVideoInfoTag()->m_strAlbum));
+                                    database->GetAlbumByName(m_vecItems->Get(itemNumber)->GetVideoInfoTag()->m_strAlbum));
       g_windowManager.ActivateWindow(WINDOW_MUSIC_NAV,strPath);
       return true;
     }
   case CONTEXT_BUTTON_PLAY_OTHER:
     {
-      CMusicDatabase database;
-      database.Open();
+      CMusicDatabase *database = CDatabaseManager::Get().GetMusicDatabase();
       CSong song;
-      if (database.GetSong(database.GetSongByArtistAndAlbumAndTitle(StringUtils::Join(m_vecItems->Get(itemNumber)->GetVideoInfoTag()->m_artist, g_advancedSettings.m_videoItemSeparator),m_vecItems->Get(itemNumber)->GetVideoInfoTag()->m_strAlbum,
+      if (database->GetSong(database->GetSongByArtistAndAlbumAndTitle(StringUtils::Join(m_vecItems->Get(itemNumber)->GetVideoInfoTag()->m_artist, g_advancedSettings.m_videoItemSeparator),m_vecItems->Get(itemNumber)->GetVideoInfoTag()->m_strAlbum,
                                                                         m_vecItems->Get(itemNumber)->GetVideoInfoTag()->m_strTitle),
                                                                         song))
       {

--- a/xbmc/video/windows/GUIWindowVideoNav.h
+++ b/xbmc/video/windows/GUIWindowVideoNav.h
@@ -54,18 +54,11 @@ public:
   /*! \brief Load video information from the database for these items (public static version)
    Useful for grabbing information for file listings, from watched status to full metadata
    \param items the items to load information for.
-   \param database open database object to retrieve the data from
    \param allowReplaceLabels allow label replacement if according GUI setting is enabled
    */
-  static void LoadVideoInfo(CFileItemList &items, CVideoDatabase &database, bool allowReplaceLabels = true);
+  static void LoadVideoInfo(CFileItemList &items, bool allowReplaceLabels = true);
 
 protected:
-  /*! \brief Load video information from the database for these items
-   Useful for grabbing information for file listings, from watched status to full metadata
-   \param items the items to load information for.
-   */
-  void LoadVideoInfo(CFileItemList &items);
-
   bool ApplyWatchedFilter(CFileItemList &items);
   virtual bool GetFilteredItems(const std::string &filter, CFileItemList &items);
 

--- a/xbmc/view/GUIViewState.cpp
+++ b/xbmc/view/GUIViewState.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "view/GUIViewState.h"
+#include "DatabaseManager.h"
 #include "pvr/windows/GUIViewStatePVR.h"
 #include "addons/GUIViewStateAddonBrowser.h"
 #include "music/GUIViewStateMusic.h"
@@ -476,13 +477,10 @@ void CGUIViewState::SetSortOrder(SortOrder sortOrder)
 
 void CGUIViewState::LoadViewState(const std::string &path, int windowID)
 { // get our view state from the db
-  CViewDatabase db;
-  if (!db.Open())
-    return;
-
+  CViewDatabase *database = CDatabaseManager::Get().GetViewDatabase();
   CViewState state;
-  if (db.GetViewState(path, windowID, state, CSettings::Get().GetString("lookandfeel.skin")) ||
-      db.GetViewState(path, windowID, state, ""))
+  if (database->GetViewState(path, windowID, state, CSettings::Get().GetString("lookandfeel.skin")) ||
+      database->GetViewState(path, windowID, state, ""))
   {
     SetViewAsControl(state.m_viewMode);
     SetSortMethod(state.m_sortDescription);
@@ -491,17 +489,14 @@ void CGUIViewState::LoadViewState(const std::string &path, int windowID)
 
 void CGUIViewState::SaveViewToDb(const std::string &path, int windowID, CViewState *viewState)
 {
-  CViewDatabase db;
-  if (!db.Open())
-    return;
-
+  CViewDatabase *database = CDatabaseManager::Get().GetViewDatabase();
   SortDescription sorting = GetSortMethod();
   CViewState state(m_currentViewAsControl, sorting.sortBy, sorting.sortOrder, sorting.sortAttributes);
   if (viewState != NULL)
     *viewState = state;
 
-  db.SetViewState(path, windowID, state, CSettings::Get().GetString("lookandfeel.skin"));
-  db.Close();
+  database->SetViewState(path, windowID, state, CSettings::Get().GetString("lookandfeel.skin"));
+  database->Close();
 
   if (viewState != NULL)
     CSettings::Get().Save();


### PR DESCRIPTION
This introduces thread local database instances accessible via the CDatabaseManager. 
The main goal is holding only one connection/database instance per thread and do not open/close per method call or pass database instances as method parameters to the underlying implementations.

@Montellese @jimfcarroll mind taking a look?
