### PR TITLE
UPnP: some fixes and improvements

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2168,7 +2168,7 @@
           </dependencies>
           <control type="toggle" />
         </setting>
-        <setting id="services.upnpcontroller" type="boolean" label="21361" help="36326">
+        <setting id="services.upnpcontroller" type="boolean" parent="services.upnpserver" label="21361" help="36326">
           <level>1</level>
           <default>false</default>
           <dependencies>

--- a/xbmc/network/NetworkServices.cpp
+++ b/xbmc/network/NetworkServices.cpp
@@ -279,9 +279,11 @@ bool CNetworkServices::OnSettingChanging(const CSetting *setting)
       if (!StartUPnPServer())
         return false;
 
-      // always stop and restart the client if necessary
+      // always stop and restart the client and controller if necessary
       StopUPnPClient();
+      StopUPnPController();
       StartUPnPClient();
+      StartUPnPController();
     }
     else
       return StopUPnPServer();
@@ -296,9 +298,9 @@ bool CNetworkServices::OnSettingChanging(const CSetting *setting)
   else if (settingId == "services.upnpcontroller")
   {
     // always stop and restart
-    StopUPnPClient();
+    StopUPnPController();
     if (((CSettingBool*)setting)->GetValue())
-      return StartUPnPClient();
+      return StartUPnPController();
   }
   else
 #endif // HAS_UPNP
@@ -799,6 +801,7 @@ bool CNetworkServices::StartUPnP()
 #ifdef HAS_UPNP
   ret |= StartUPnPClient();
   ret |= StartUPnPServer();
+  ret |= StartUPnPController();
   ret |= StartUPnPRenderer();
 #endif // HAS_UPNP
   return ret;
@@ -821,11 +824,7 @@ bool CNetworkServices::StopUPnP(bool bWait)
 bool CNetworkServices::StartUPnPClient()
 {
 #ifdef HAS_UPNP
-  if (!CSettings::Get().GetBool("services.upnpcontroller") ||
-      !CSettings::Get().GetBool("services.upnpserver"))
-    return false;
-
-  CLog::Log(LOGNOTICE, "starting upnp controller");
+  CLog::Log(LOGNOTICE, "starting upnp client");
   CUPnP::GetInstance()->StartClient();
   return IsUPnPClientRunning();
 #endif // HAS_UPNP
@@ -848,6 +847,42 @@ bool CNetworkServices::StopUPnPClient()
 
   CLog::Log(LOGNOTICE, "stopping upnp client");
   CUPnP::GetInstance()->StopClient();
+
+  return true;
+#endif // HAS_UPNP
+  return false;
+}
+
+bool CNetworkServices::StartUPnPController()
+{
+#ifdef HAS_UPNP
+  if (!CSettings::Get().GetBool("services.upnpcontroller") ||
+      !CSettings::Get().GetBool("services.upnpserver"))
+    return false;
+
+  CLog::Log(LOGNOTICE, "starting upnp controller");
+  CUPnP::GetInstance()->StartController();
+  return IsUPnPControllerRunning();
+#endif // HAS_UPNP
+  return false;
+}
+
+bool CNetworkServices::IsUPnPControllerRunning()
+{
+#ifdef HAS_UPNP
+  return CUPnP::GetInstance()->IsControllerStarted();
+#endif // HAS_UPNP
+  return false;
+}
+
+bool CNetworkServices::StopUPnPController()
+{
+#ifdef HAS_UPNP
+  if (!IsUPnPControllerRunning())
+    return true;
+
+  CLog::Log(LOGNOTICE, "stopping upnp controller");
+  CUPnP::GetInstance()->StopController();
 
   return true;
 #endif // HAS_UPNP
@@ -914,7 +949,7 @@ bool CNetworkServices::StopUPnPServer()
   if (!IsUPnPServerRunning())
     return true;
 
-  StopUPnPClient();
+  StopUPnPController();
 
   CLog::Log(LOGNOTICE, "stopping upnp server");
   CUPnP::GetInstance()->StopServer();

--- a/xbmc/network/NetworkServices.cpp
+++ b/xbmc/network/NetworkServices.cpp
@@ -843,7 +843,7 @@ bool CNetworkServices::IsUPnPClientRunning()
 bool CNetworkServices::StopUPnPClient()
 {
 #ifdef HAS_UPNP
-  if (!IsUPnPRendererRunning())
+  if (!IsUPnPClientRunning())
     return true;
 
   CLog::Log(LOGNOTICE, "stopping upnp client");
@@ -911,7 +911,7 @@ bool CNetworkServices::IsUPnPServerRunning()
 bool CNetworkServices::StopUPnPServer()
 {
 #ifdef HAS_UPNP
-  if (!IsUPnPRendererRunning())
+  if (!IsUPnPServerRunning())
     return true;
 
   StopUPnPClient();

--- a/xbmc/network/NetworkServices.h
+++ b/xbmc/network/NetworkServices.h
@@ -76,6 +76,9 @@ public:
   bool StartUPnPClient();
   bool IsUPnPClientRunning();
   bool StopUPnPClient();
+  bool StartUPnPController();
+  bool IsUPnPControllerRunning();
+  bool StopUPnPController();
   bool StartUPnPRenderer();
   bool IsUPnPRendererRunning();
   bool StopUPnPRenderer();

--- a/xbmc/network/upnp/UPnP.h
+++ b/xbmc/network/upnp/UPnP.h
@@ -58,6 +58,11 @@ public:
     void StopClient();
     bool IsClientStarted() { return (m_MediaBrowser != NULL); }
 
+    // controller
+    void StartController();
+    void StopController();
+    bool IsControllerStarted() { return (m_MediaController != NULL); }
+
     // renderer
     bool StartRenderer();
     void StopRenderer();
@@ -79,6 +84,9 @@ public:
     static void RegisterUserdata(void* ptr);
     static void UnregisterUserdata(void* ptr);
 private:
+    void CreateControlPoint();
+    void DestroyControlPoint();
+
     // methods
     CUPnPRenderer* CreateRenderer(int port = 0);
     CUPnPServer*   CreateServer(int port = 0);


### PR DESCRIPTION
I noticed some odd checks in `CNetworkServices` concerning the different UPnP services (browser, controller, server, renderer) which made it impossible to stop the controller and/or server under certain conditions.

When I looked into that code in more detail I noticed that the current code always starts and stops the client/browser and the controller simultaneously and when the controller is disabled in the settings we also can't browse remote UPnP servers. That doesn't make any sense at all. Therefore I split them up and now the client/browser is basically always active so it's always possible to browse remote UPnP servers but the server, controller and renderer are only running if enabled in the settings.
