### PR TITLE
dvdplayer: protect live streams from stalling

### DIFF
--- a/xbmc/cores/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoRenderers/RenderManager.cpp
@@ -175,6 +175,15 @@ void CXBMCRenderManager::WaitPresentTime(double presenttime)
     return;
   }
 
+  CDVDClock *dvdclock = CDVDClock::GetMasterClock();
+  if(dvdclock != NULL && dvdclock->GetSpeedAdjust() != 0.0)
+  {
+    CDVDClock::WaitAbsoluteClock(presenttime * DVD_TIME_BASE);
+    m_presenterr = 0;
+    m_presentcorr = 0;
+    return;
+  }
+
   double clock     = CDVDClock::WaitAbsoluteClock(presenttime * DVD_TIME_BASE) / DVD_TIME_BASE;
   double target    = 0.5;
   double error     = ( clock - presenttime ) / frametime - target;

--- a/xbmc/cores/dvdplayer/DVDClock.cpp
+++ b/xbmc/cores/dvdplayer/DVDClock.cpp
@@ -29,7 +29,7 @@
 int64_t CDVDClock::m_systemOffset;
 int64_t CDVDClock::m_systemFrequency;
 CCriticalSection CDVDClock::m_systemsection;
-CDVDClock *CDVDClock::m_playerclock = NULL;;
+CDVDClock *CDVDClock::m_playerclock = NULL;
 
 CDVDClock::CDVDClock()
   :  m_master(MASTER_CLOCK_NONE)
@@ -42,6 +42,9 @@ CDVDClock::CDVDClock()
   m_bReset = true;
   m_iDisc = 0;
   m_maxspeedadjust = 0.0;
+  m_lastSystemTime = g_VideoReferenceClock.GetTime();
+  m_systemAdjust = 0;
+  m_speedAdjust = 0;
 
   m_startClock = 0;
 
@@ -103,7 +106,12 @@ CDVDClock* CDVDClock::GetMasterClock()
 double CDVDClock::GetClock(bool interpolated /*= true*/)
 {
   CSharedLock lock(m_critSection);
-  return SystemToPlaying(g_VideoReferenceClock.GetTime(interpolated));
+
+  int64_t current = g_VideoReferenceClock.GetTime(interpolated);
+  m_systemAdjust += m_speedAdjust * (current - m_lastSystemTime);
+  m_lastSystemTime = current;
+
+  return SystemToPlaying(current);
 }
 
 double CDVDClock::GetClock(double& absolute, bool interpolated /*= true*/)
@@ -115,8 +123,7 @@ double CDVDClock::GetClock(double& absolute, bool interpolated /*= true*/)
     absolute = SystemToAbsolute(current);
   }
 
-  CSharedLock lock(m_critSection);
-  return SystemToPlaying(current);
+  return GetClock(interpolated);
 }
 
 void CDVDClock::SetSpeed(int iSpeed)
@@ -143,6 +150,18 @@ void CDVDClock::SetSpeed(int iSpeed)
 
   m_startClock = current - (int64_t)((double)(current - m_startClock) * newfreq / m_systemUsed);
   m_systemUsed = newfreq;
+}
+
+void CDVDClock::SetSpeedAdjust(double adjust)
+{
+  CExclusiveLock lock(m_critSection);
+  m_speedAdjust = adjust;
+}
+
+double CDVDClock::GetSpeedAdjust()
+{
+  CExclusiveLock lock(m_critSection);
+  return m_speedAdjust;
 }
 
 bool CDVDClock::Update(double clock, double absolute, double limit, const char* log)
@@ -174,26 +193,8 @@ void CDVDClock::Discontinuity(double clock, double absolute)
     m_pauseClock = m_startClock;
   m_iDisc = clock;
   m_bReset = false;
-}
-
-void CDVDClock::Pause()
-{
-  CExclusiveLock lock(m_critSection);
-  if(!m_pauseClock)
-    m_pauseClock = g_VideoReferenceClock.GetTime();
-}
-
-void CDVDClock::Resume()
-{
-  CExclusiveLock lock(m_critSection);
-  if( m_pauseClock )
-  {
-    int64_t current;
-    current = g_VideoReferenceClock.GetTime();
-
-    m_startClock += current - m_pauseClock;
-    m_pauseClock = 0;
-  }
+  m_systemAdjust = 0;
+  m_speedAdjust = 0;
 }
 
 void CDVDClock::SetMaxSpeedAdjust(double speed)
@@ -265,6 +266,8 @@ double CDVDClock::SystemToPlaying(int64_t system)
     if(m_pauseClock)
       m_pauseClock = m_startClock;
     m_iDisc = 0;
+    m_systemAdjust = 0;
+    m_speedAdjust = 0;
     m_bReset = false;
   }
   
@@ -273,7 +276,7 @@ double CDVDClock::SystemToPlaying(int64_t system)
   else
     current = system;
 
-  return DVD_TIME_BASE * (double)(current - m_startClock) / m_systemUsed + m_iDisc;
+  return DVD_TIME_BASE * (double)(current - m_startClock + m_systemAdjust) / m_systemUsed + m_iDisc;
 }
 
 EMasterClock CDVDClock::GetMaster()

--- a/xbmc/cores/dvdplayer/DVDClock.h
+++ b/xbmc/cores/dvdplayer/DVDClock.h
@@ -66,9 +66,9 @@ public:
   }
 
   void Reset() { m_bReset = true; }
-  void Pause();
-  void Resume();
   void SetSpeed(int iSpeed);
+  void SetSpeedAdjust(double adjust);
+  double GetSpeedAdjust();
 
   double GetClockSpeed(); /**< get the current speed of the clock relative normal system time */
 
@@ -101,7 +101,11 @@ protected:
   static int64_t m_systemOffset;
   static CCriticalSection m_systemsection;
 
-  double           m_maxspeedadjust;
+  int64_t m_systemAdjust;
+  int64_t m_lastSystemTime;
+  double m_speedAdjust;
+
+  double m_maxspeedadjust;
   CCriticalSection m_speedsection;
   static CDVDClock *m_playerclock;
 };

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -1391,16 +1391,18 @@ void CDVDPlayer::Process()
 
         m_OmxPlayerState.bOmxSentEOFs = true;
       }
+
       if(m_CurrentAudio.inited)
-        m_dvdPlayerAudio->SendMessage   (new CDVDMsg(CDVDMsg::GENERAL_EOF));
+        m_dvdPlayerAudio->SendMessage(new CDVDMsg(CDVDMsg::GENERAL_EOF));
       if(m_CurrentVideo.inited)
-        m_dvdPlayerVideo->SendMessage   (new CDVDMsg(CDVDMsg::GENERAL_EOF));
+        m_dvdPlayerVideo->SendMessage(new CDVDMsg(CDVDMsg::GENERAL_EOF));
       if(m_CurrentSubtitle.inited)
         m_dvdPlayerSubtitle->SendMessage(new CDVDMsg(CDVDMsg::GENERAL_EOF));
       if(m_CurrentTeletext.inited)
         m_dvdPlayerTeletext->SendMessage(new CDVDMsg(CDVDMsg::GENERAL_EOF));
-      m_CurrentAudio.inited    = false;
-      m_CurrentVideo.inited    = false;
+
+      m_CurrentAudio.inited = false;
+      m_CurrentVideo.inited = false;
       m_CurrentSubtitle.inited = false;
       m_CurrentTeletext.inited = false;
 
@@ -1510,21 +1512,22 @@ bool CDVDPlayer::CheckIsCurrent(CCurrentStream& current, CDemuxStream* stream, D
 
 void CDVDPlayer::ProcessPacket(CDemuxStream* pStream, DemuxPacket* pPacket)
 {
-    /* process packet if it belongs to selected stream. for dvd's don't allow automatic opening of streams*/
+  // process packet if it belongs to selected stream.
+  // for dvd's don't allow automatic opening of streams*/
 
-      if (CheckIsCurrent(m_CurrentAudio, pStream, pPacket))
-        ProcessAudioData(pStream, pPacket);
-      else if (CheckIsCurrent(m_CurrentVideo, pStream, pPacket))
-        ProcessVideoData(pStream, pPacket);
-      else if (CheckIsCurrent(m_CurrentSubtitle, pStream, pPacket))
-        ProcessSubData(pStream, pPacket);
-      else if (CheckIsCurrent(m_CurrentTeletext, pStream, pPacket))
-        ProcessTeletextData(pStream, pPacket);
-      else
-      {
-        pStream->SetDiscard(AVDISCARD_ALL);
-        CDVDDemuxUtils::FreeDemuxPacket(pPacket); // free it since we won't do anything with it
-      }
+  if (CheckIsCurrent(m_CurrentAudio, pStream, pPacket))
+    ProcessAudioData(pStream, pPacket);
+  else if (CheckIsCurrent(m_CurrentVideo, pStream, pPacket))
+    ProcessVideoData(pStream, pPacket);
+  else if (CheckIsCurrent(m_CurrentSubtitle, pStream, pPacket))
+    ProcessSubData(pStream, pPacket);
+  else if (CheckIsCurrent(m_CurrentTeletext, pStream, pPacket))
+    ProcessTeletextData(pStream, pPacket);
+  else
+  {
+    pStream->SetDiscard(AVDISCARD_ALL);
+    CDVDDemuxUtils::FreeDemuxPacket(pPacket); // free it since we won't do anything with it
+  }
 }
 
 void CDVDPlayer::CheckStreamChanges(CCurrentStream& current, CDemuxStream* stream)

--- a/xbmc/cores/dvdplayer/DVDPlayer.h
+++ b/xbmc/cores/dvdplayer/DVDPlayer.h
@@ -68,6 +68,7 @@ public:
   bool OMXStateExecute(bool lock = true) { return false; }
   void OMXStateIdle(bool lock = true) {}
   bool HDMIClockSync(bool lock = true) { return false; }
+  void OMXSetSpeedAdjust(double adjust, bool lock = true) {}
 };
 #endif
 

--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
@@ -201,10 +201,7 @@ bool CDVDPlayerVideo::OpenStream( CDVDStreamInfo &hint )
     return false;
   }
 
-  if(CSettings::Get().GetBool("videoplayer.usedisplayasclock") && !g_VideoReferenceClock.IsRunning())
-  {
-    g_VideoReferenceClock.Create();
-  }
+  g_VideoReferenceClock.Start();
 
   if(m_messageQueue.IsInited())
     m_messageQueue.Put(new CDVDMsgVideoCodecChange(hint, codec), 0);

--- a/xbmc/linux/OMXClock.h
+++ b/xbmc/linux/OMXClock.h
@@ -59,6 +59,7 @@ private:
   COMXCoreComponent m_omx_clock;
   double            m_last_media_time;
   double            m_last_media_time_read;
+  double            m_speedAdjust;
 public:
   OMXClock();
   ~OMXClock();
@@ -82,6 +83,7 @@ public:
   bool OMXPause(bool lock = true);
   bool OMXResume(bool lock = true);
   bool OMXSetSpeed(int speed, bool lock = true, bool pause_resume = false);
+  void OMXSetSpeedAdjust(double adjust, bool lock = true);
   int  OMXPlaySpeed() { return m_omx_speed; };
   bool OMXFlush(bool lock = true);
   COMXCoreComponent *GetOMXClock();

--- a/xbmc/video/VideoReferenceClock.cpp
+++ b/xbmc/video/VideoReferenceClock.cpp
@@ -28,6 +28,7 @@
 #include "guilib/GraphicContext.h"
 #include "video/videosync/VideoSync.h"
 #include "windowing/WindowingFactory.h"
+#include "settings/Settings.h"
 
 #if defined(HAS_GLX)
 #include "video/videosync/VideoSyncGLX.h"
@@ -70,6 +71,13 @@ CVideoReferenceClock::CVideoReferenceClock() : CThread("RefClock")
 
 CVideoReferenceClock::~CVideoReferenceClock()
 {
+}
+
+void CVideoReferenceClock::Start()
+{
+  CSingleExit lock(g_graphicsContext);
+  if(CSettings::Get().GetBool("videoplayer.usedisplayasclock") && !IsRunning())
+    Create();
 }
 
 void CVideoReferenceClock::Stop()

--- a/xbmc/video/VideoReferenceClock.h
+++ b/xbmc/video/VideoReferenceClock.h
@@ -39,6 +39,7 @@ class CVideoReferenceClock : public CThread
     bool    GetClockInfo(int& MissedVblanks, double& ClockSpeed, double& RefreshRate);
     void    SetFineAdjust(double fineadjust);
     void    RefreshChanged();
+    void    Start();
     void    Stop();
 
   private:


### PR DESCRIPTION
this protects live streams, currently only PVR, from stalling by changing clock speed. if audio queue is about to run dry, clock speed is reduced by 4% until level has reached a given threshold. if queue is about to get full, speed is increased.

@popcornmix does OMX require adjustments?
