### PR TITLE
[pvr] fix wrong logic which made it impossible to persist changes in the channel manager

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -769,12 +769,14 @@ void CGUIDialogPVRChannelManager::SaveList(void)
   CPVRChannelGroupPtr group = g_PVRChannelGroups->GetGroupAll(m_bIsRadio);
   if (!group)
     return;
+
   for (int iListPtr = 0; iListPtr < m_channelItems->Size(); iListPtr++)
   {
-    if (!m_channelItems->HasPVRChannelInfoTag())
+    CFileItemPtr pItem = m_channelItems->Get(iListPtr);
+
+    if (!pItem->HasPVRChannelInfoTag())
       continue;
 
-    CFileItemPtr pItem = m_channelItems->Get(iListPtr);
     if (pItem->GetProperty("SupportsSettings").asBoolean())
       RenameChannel(pItem);
 


### PR DESCRIPTION
@xhaggi @AlwinEsch can you take a quick look? Looks like a brainfart, the solution is pretty straight-forward. `m_channelItems` obviously doesn't have any info tags.
