### PR TITLE
[python] add DelayedCallGuard to xbmcvfs.listdir. closes #14212

### DIFF
--- a/xbmc/interfaces/legacy/ModuleXbmcvfs.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmcvfs.cpp
@@ -82,6 +82,7 @@ namespace XBMCAddon
 
     Tuple<std::vector<String>, std::vector<String> > listdir(const String& path)
     {
+      DelayedCallGuard dg;
       CFileItemList items;
       std::string strSource;
       strSource = path;


### PR DESCRIPTION
No idea why this never had DelayedCallGuard, and don't ask me how but it seems to fix http://trac.kodi.tv/ticket/14212 Ping @jimfcarroll 
