### PR TITLE
[music videos] adding "All albums" option

### DIFF
--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.cpp
@@ -337,6 +337,11 @@ void CDirectoryNode::AddQueuingFolder(CFileItemList& items) const
         pItem->GetVideoInfoTag()->m_type = MediaTypeSeason;
       }
       break;
+    case NODE_TYPE_MUSICVIDEOS_ALBUM:
+      pItem.reset(new CFileItem(g_localizeStrings.Get(15102)));  // "All Albums"
+      videoUrl.AppendPath("-1/");
+      pItem->SetPath(videoUrl.ToString());
+      break;
     default:
       break;
   }


### PR DESCRIPTION
Adds the missing "All albums" option when browsing Music Videos by Artist, which was requested in [this thread.](http://forum.kodi.tv/showthread.php?tid=185443)
