### PR TITLE
FIX: [egl;font] assert if cache texture was not created

### DIFF
--- a/xbmc/guilib/GUIFontTTFGL.cpp
+++ b/xbmc/guilib/GUIFontTTFGL.cpp
@@ -140,8 +140,6 @@ bool CGUIFontTTFGL::FirstBegin()
     VerifyGLState();
   }
 
-#else
-  g_Windowing.EnableGUIShader(SM_FONTS);
 #endif
   return true;
 }
@@ -168,6 +166,8 @@ void CGUIFontTTFGL::LastEnd()
   glDisable(GL_TEXTURE_2D);
 #else
   // GLES 2.0 version.
+  g_Windowing.EnableGUIShader(SM_FONTS);
+
   CreateStaticVertexBuffers();
 
   GLint posLoc  = g_Windowing.GUIShaderGetPos();


### PR DESCRIPTION
@bavison I have a crash when using the Eminence skin on Android (EGL)
If the texture is not created (no cache?), CGUIFontTTFGL::FirstBegin is not called -> EnableGUIShader is not called and ClipRectToScissorRect() produces aberrant values.

This fixes it, but not sure:
1) If it's the proper fix
2) If the root cause (m_texture == NULL) is a normal occurrence

By the way, this same skin seems to use rotated text, and it's badly clipped (see in "Settings", on the right side). Works fine on Windows, though.

/cc @Memphiz because it should occur on ios, too
