### PR TITLE
[repository] bump to 13.0.0

### DIFF
--- a/addons/repository.xbmc.org/addon.xml
+++ b/addons/repository.xbmc.org/addon.xml
@@ -4,7 +4,7 @@
 		version="2.2.30"
 		provider-name="XBMC Foundation">
   <requires>
-    <import addon="xbmc.addon" version="12.0.0"/>
+    <import addon="xbmc.addon" version="13.0.0"/>
   </requires>
 	<extension point="xbmc.addon.repository"
 		name="Official XBMC.org Add-on Repository">


### PR DESCRIPTION
xbmc.addon https://github.com/xbmc/xbmc/blob/master/addons/xbmc.addon/addon.xml.in#L3 abi backwards compat already adds backwards compat to 12.0

But here if I read this right 13.0.0 should be here, no? Or does the backward compat abi also need to be updated in  https://github.com/xbmc/xbmc/blob/master/addons/xbmc.addon/addon.xml.in#L3 to also  13.0 as this change?

@MartijnKaijser
