### PR TITLE
[pvr] Fix channel scan seg faults, init seg faults and code cleanup

### DIFF
--- a/xbmc/epg/EpgContainer.cpp
+++ b/xbmc/epg/EpgContainer.cpp
@@ -642,7 +642,7 @@ bool CEpgContainer::UpdateEPG(bool bOnlyPending /* = false */)
 
     // we currently only support update via pvr add-ons. skip update when the pvr manager isn't started
     if (!g_PVRManager.IsStarted())
-      continue;
+      break;
 
     // check the pvr manager when the channel pointer isn't set
     if (!epg->Channel())

--- a/xbmc/epg/GUIEPGGridContainer.cpp
+++ b/xbmc/epg/GUIEPGGridContainer.cpp
@@ -586,7 +586,7 @@ void CGUIEPGGridContainer::ProcessProgressIndicator(unsigned int currentTime, CD
   {
     m_guiProgressIndicatorTexture.SetVisible(false);
   }
-  
+
   m_guiProgressIndicatorTexture.Process(currentTime);
 }
 
@@ -963,7 +963,7 @@ void CGUIEPGGridContainer::UpdateItems(CFileItemList *items)
           m_gridIndex[row][block].item = item;
           break;
         }
-        
+
         progIdx++;
       }
 
@@ -1409,7 +1409,7 @@ CPVRChannelPtr CGUIEPGGridContainer::GetChannel(int iIndex)
     if (fileItem->HasPVRChannelInfoTag())
       return fileItem->GetPVRChannelInfoTag();
   }
-  
+
   return CPVRChannelPtr();
 }
 
@@ -1913,7 +1913,7 @@ void CGUIEPGGridContainer::GoToEnd()
   {
     if (!blocksEnd && m_gridIndex[m_channelCursor + m_channelOffset][blockIndex].item != NULL)
       blocksEnd = blockIndex;
-    if (blocksEnd && m_gridIndex[m_channelCursor + m_channelOffset][blocksEnd].item != 
+    if (blocksEnd && m_gridIndex[m_channelCursor + m_channelOffset][blocksEnd].item !=
                      m_gridIndex[m_channelCursor + m_channelOffset][blockIndex].item)
       blocksStart = blockIndex + 1;
   }

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -540,13 +540,16 @@ void CPVRManager::Process(void)
       bRestart = true;
     }
 
-    if (!UpgradeOutdatedAddons())
+    if (GetState() == ManagerStateStarted)
     {
-      // failed to load after upgrading
-      CLog::Log(LOGERROR, "PVRManager - %s - could not load pvr data after upgrading. stopping the pvrmanager", __FUNCTION__);
+      if (!UpgradeOutdatedAddons())
+      {
+        // failed to load after upgrading
+        CLog::Log(LOGERROR, "PVRManager - %s - could not load pvr data after upgrading. stopping the pvrmanager", __FUNCTION__);
+      }
+      else if (IsStarted() && !bRestart)
+        m_triggerEvent.WaitMSec(1000);
     }
-    else if (IsStarted() && !bRestart)
-      m_triggerEvent.WaitMSec(1000);
   }
 
   if (IsStarted())
@@ -600,11 +603,11 @@ void CPVRManager::StopUpdateThreads(void)
 {
   SetState(ManagerStateInterrupted);
 
-  StopThread();
   if (m_guiInfo)
     m_guiInfo->Stop();
   if (m_addons)
     m_addons->Stop();
+  StopThread();
 }
 
 bool CPVRManager::Load(void)

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -993,16 +993,12 @@ void CPVRClients::StartChannelScan(void)
       __FUNCTION__, scanClient->GetFriendlyName().c_str());
   long perfCnt = XbmcThreads::SystemClockMillis();
 
-  /* stop the supervisor thread */
-  g_PVRManager.StopUpdateThreads();
-
   /* do the scan */
-  if (scanClient->StartChannelScan() != PVR_ERROR_NO_ERROR)
-    /* an error occured */
-    CGUIDialogOK::ShowAndGetInput(CVariant{19111}, CVariant{19193});
-
-  /* restart the supervisor thread */
-  g_PVRManager.StartUpdateThreads();
+  PVR_ERROR err = scanClient->StartChannelScan();
+  if (err == PVR_ERROR_NO_ERROR)
+    CApplicationMessenger::Get().SetPVRManagerState(true);           /*!< Restart complete PVR Manager to handle channel changes */
+  else
+    CGUIDialogOK::ShowAndGetInput(CVariant{19111}, CVariant{19193}); /*!< an error occured */
 
   CLog::Log(LOGNOTICE, "PVRManager - %s - channel scan finished after %li.%li seconds",
       __FUNCTION__, (XbmcThreads::SystemClockMillis()-perfCnt)/1000, (XbmcThreads::SystemClockMillis()-perfCnt)%1000);

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.h
@@ -58,7 +58,7 @@ namespace PVR
 
     // specialization of CGUIDialogSettingsManualBase
     virtual void InitializeSettings();
-    
+
   private:
     void InitializeTypesList();
     void InitializeChannelsList();


### PR DESCRIPTION
The following changes fix segmention faults during open of PVR channel scan dialog.
