### PR TITLE
IMX: Several fixes screenshot, deint of progressive, minors

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
@@ -33,6 +33,7 @@
 #include <unistd.h>
 #include <string.h>
 #include <fcntl.h>
+#include <algorithm>
 
 #define IMX_VDI_MAX_WIDTH 968
 #define FRAME_ALIGN 16
@@ -1652,8 +1653,16 @@ void CIMXContext::CaptureDisplay(unsigned char *buffer, int iWidth, int iHeight)
   }
   unsigned char *display = m_fbVirtAddr + m_fbCurrentPage*m_fbPageSize;
 
-  if (m_fbVar.nonstd != _4CC('R', 'G', 'B', '4'))
+  if (m_fbVar.nonstd == _4CC('R', 'G', 'B', '4'))
+  {
     memcpy(buffer, display, iWidth * iHeight * 4);
+    // BGRA is needed RGBA we get
+    unsigned int size = iWidth * iHeight * 4;
+    for (unsigned int i = 0; i < size; i += 4)
+    {
+       std::swap(buffer[i], buffer[i + 2]);
+    }
+  }
   else //_4CC('U', 'Y', 'V', 'Y')))
   {
     int r,g,b,a;

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
@@ -516,9 +516,9 @@ bool CDVDVideoCodecIMX::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
   {
     // Test for VPU unsupported profiles to revert to sw decoding
     if ((m_hints.profile == 110) || //hi10p
-        (m_hints.profile == 578))   //quite uncommon h264 profile
+        (m_hints.profile == 578 && m_hints.level == 30))   //quite uncommon h264 profile with Main 3.0
     {
-      CLog::Log(LOGNOTICE, "i.MX6 VPU is not able to decode AVC profile %d", m_hints.profile);
+      CLog::Log(LOGNOTICE, "i.MX6 VPU is not able to decode AVC profile %d level %d", m_hints.profile, m_hints.level);
       return false;
     }
     m_decOpenParam.CodecFormat = VPU_V_AVC;

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
@@ -420,6 +420,7 @@ CDVDVideoCodecIMX::CDVDVideoCodecIMX()
   m_convert_bitstream = false;
   m_bytesToBeConsumed = 0;
   m_previousPts = DVD_NOPTS_VALUE;
+  m_warnOnce = true;
 #ifdef DUMP_STREAM
   m_dump = NULL;
 #endif
@@ -1079,8 +1080,21 @@ bool CDVDVideoCodecIMX::GetPicture(DVDVideoPicture* pDvdVideoPicture)
   else
     pDvdVideoPicture->iFlags &= ~DVP_FLAG_INTERLACED;
 
-  if (m_currentBuffer->GetFieldType() != VPU_FIELD_BOTTOM && m_currentBuffer->GetFieldType() != VPU_FIELD_BT)
-    pDvdVideoPicture->iFlags |= DVP_FLAG_TOP_FIELD_FIRST;
+  // do a sanity check to not deinterlace progressive content
+  if ((pDvdVideoPicture->iFlags & DVP_FLAG_INTERLACED) && (m_currentBuffer->GetFieldType() == VPU_FIELD_NONE))
+  {
+    if (m_warnOnce)
+    {
+      m_warnOnce = false;
+      CLog::Log(LOGWARNING, "Interlaced content reported by VPU, but full frames detected - Please turn off deinterlacing manually.");
+    }
+  }
+
+  if (pDvdVideoPicture->iFlags & DVP_FLAG_INTERLACED)
+  {
+    if (m_currentBuffer->GetFieldType() != VPU_FIELD_BOTTOM && m_currentBuffer->GetFieldType() != VPU_FIELD_BT)
+      pDvdVideoPicture->iFlags |= DVP_FLAG_TOP_FIELD_FIRST;
+  }
   else
     pDvdVideoPicture->iFlags &= ~DVP_FLAG_TOP_FIELD_FIRST;
 
@@ -1278,6 +1292,7 @@ CIMXContext::CIMXContext()
   , m_fbVirtAddr(NULL)
   , m_ipuHandle(0)
   , m_vsync(true)
+  , m_deInterlacing(false)
   , m_pageCrops(NULL)
   , m_g2dHandle(NULL)
   , m_bufferCapture(NULL)

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
@@ -439,6 +439,11 @@ bool CDVDVideoCodecIMX::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
     CLog::Log(LOGNOTICE, "iMX VPU : software decoding requested.\n");
     return false;
   }
+  else if (hints.width > 1920)
+  {
+    CLog::Log(LOGNOTICE, "iMX VPU : software decoding forced - video dimensions out of spec: %d %d.", hints.width, hints.height);
+    return false;
+  }
 
   g_IMXContext.RequireConfiguration();
 

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.h
@@ -341,6 +341,7 @@ protected:
   int                          m_bytesToBeConsumed; // Remaining bytes in VPU
   double                       m_previousPts;       // Enable to keep pts when needed
   bool                         m_frameReported;     // State whether the frame consumed event will be reported by libfslvpu
+  bool                         m_warnOnce;          // Track warning messages to only warn once
 #ifdef DUMP_STREAM
   FILE                        *m_dump;
 #endif

--- a/xbmc/windowing/egl/EGLNativeTypeIMX.cpp
+++ b/xbmc/windowing/egl/EGLNativeTypeIMX.cpp
@@ -53,7 +53,7 @@ CEGLNativeTypeIMX::~CEGLNativeTypeIMX()
 bool CEGLNativeTypeIMX::CheckCompatibility()
 {
   std::ifstream file("/sys/class/graphics/fb0/fsl_disp_dev_property");
-  return file;
+  return file.is_open();
 }
 
 void CEGLNativeTypeIMX::Initialize()


### PR DESCRIPTION
This should fix: https://github.com/OpenELEC/OpenELEC.tv/issues/4063 the var was used in Config() without proper initialization. With bad luck we would enable Deinterlacing by default.
