### PR TITLE
ADD: add a fallback site for internet detection

### DIFF
--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -902,8 +902,15 @@ bool CCurlFile::Download(const std::string& strURL, const std::string& strFileNa
 // Detect whether we are "online" or not! Very simple and dirty!
 bool CCurlFile::IsInternet()
 {
-  CURL url("http://www.google.com");
+  CURL url("http://www.msftncsi.com/ncsi.txt");
   bool found = Exists(url);
+  if (!found)
+  {
+    // fallback
+    Close();
+    url.Parse("http://www.w3.org/");
+    found = Exists(url);
+  }
   Close();
 
   return found;


### PR DESCRIPTION
Somehow, google might be blocked ("Great Wall", firewall, proxy).
Little chance anyone would care to block w3c ;)

/cc @Montellese 
