### PR TITLE
FIX: [droid] possible fix for localtime crash

### DIFF
--- a/xbmc/android/activity/XBMCApp.cpp
+++ b/xbmc/android/activity/XBMCApp.cpp
@@ -677,6 +677,13 @@ void CXBMCApp::SetupEnv()
     setenv("HOME", externalDir.c_str(), 0);
   else
     setenv("HOME", getenv("KODI_TEMP"), 0);
+
+  std::string apkPath = getenv("XBMC_ANDROID_APK");
+  apkPath += "/assets/python2.6";
+  setenv("PYTHONHOME", apkPath.c_str(), 1);
+  setenv("PYTHONPATH", "", 1);
+  setenv("PYTHONOPTIMIZE","", 1);
+  setenv("PYTHONNOUSERSITE", "1", 1);
 }
 
 std::string CXBMCApp::GetFilenameFromIntent(const CJNIIntent &intent)

--- a/xbmc/interfaces/python/XBPython.cpp
+++ b/xbmc/interfaces/python/XBPython.cpp
@@ -600,12 +600,7 @@ bool XBPython::OnScriptInitialized(ILanguageInvoker *invoker)
     CEnvironment::putenv(buf);
 
 #elif defined(TARGET_ANDROID)
-    std::string apkPath = getenv("XBMC_ANDROID_APK");
-    apkPath += "/assets/python2.6";
-    setenv("PYTHONHOME", apkPath.c_str(), 1);
-    setenv("PYTHONPATH", "", 1);
-    setenv("PYTHONOPTIMIZE", "", 1);
-    setenv("PYTHONNOUSERSITE", "1", 1);
+    // Set earlier to avoid random crashes
 #endif
 
     if (PyEval_ThreadsInitialized())


### PR DESCRIPTION
There are (were?) random crashes ("localtime") when starting Kodi on some droid devices.
It seemed to be due to setenv not being thread safe and clashing when we try to extract localtime for the log.
Never saw this crash after this one.

Generally speaking, doesn't make much sense to do a setenv for every python script startup ;)

/cc @Montellese 
