### PR TITLE
Fixed some lingering grammar errors from the name change to Kodi

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -15830,7 +15830,7 @@ msgstr ""
 #. Description of setting "System -> Input Devices -> Allow start of Kodi with remote" with label #13602
 #: system/settings/settings.xml
 msgctxt "#36417"
-msgid "Always run an Kodi helper so that the remote can be used to start Kodi."
+msgid "Always run a Kodi helper so that the remote can be used to start Kodi."
 msgstr ""
 
 #. Description of setting "System -> Input Devices -> Sequence delay time" with label #13603

--- a/project/Win32BuildSetup/readme.txt
+++ b/project/Win32BuildSetup/readme.txt
@@ -1,4 +1,4 @@
-Prerequisites for building an Kodi for Windows installer:
+Prerequisites for building a Kodi for Windows installer:
 
 1) A working Visual C++ 2013 Express Kodi environment (See also http://kodi.wiki/view/HOW-TO:Compile_for_Windows)
 2) Nullsoft sciptable install system (http://nsis.sourceforge.net/Download)


### PR DESCRIPTION
There were two files that said `an Kodi` instead of `a Kodi`
