### PR TITLE
Limit Gui Rendering when playing fullscreen video

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -16532,3 +16532,27 @@ msgstr ""
 msgctxt "#38012"
 msgid "Show "All Items" entry in directory (for example All Albums or All Seasons)"
 msgstr ""
+
+#. Label of a setting to limit the number of fps used for updating the GUI while playing videos. This is useful for slow systems that have problems rendering GUI and video at the same time in full speed.
+#: system/settings/settings.xml
+msgctxt "#38013"
+msgid "Limit GUI updates during playback"
+msgstr ""
+
+#. Description for the setting Video -> Acceleration -> Limit GUI updates when playing video with label #38013
+#: system/settings/settings.xml
+msgctxt "#38014"
+msgid "Limits the speed (fps) used to update the GUI while playing videos. This can reduce CPU load and fix playback issues while the GUI is shown."
+msgstr ""
+
+#. Label of a settings value to indicate the "disabled" state of an otherwise limiting setting (like fps limit, bandwidth limit, ...)
+#: system/settings/settings.xml
+msgctxt "#38015"
+msgid "Unlimited"
+msgstr ""
+
+#. Used to format framerate values. %d will be replaced with the according number/integer, like "24 fps", "50 fps"
+#: system/settings/settings.xml
+msgctxt "#38016"
+msgid "%d fps"
+msgstr ""

--- a/system/settings/imx6.xml
+++ b/system/settings/imx6.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<settings>
+  <section id="system">
+    <category id="videoscreen">
+      <group id="1">
+        <setting id="videoscreen.fakefullscreen">
+          <visible>false</visible>
+        </setting>
+      </group>
+      <group id="3">
+        <setting id="videoscreen.vsync">
+          <default>3</default> <!-- VSYNC_DRIVER -->
+        </setting>
+      </group>
+    </category>
+  </section>
+  <section id="videos">
+    <category id="videoacceleration">
+      <group id="3">
+        <setting id="videoplayer.limitguiupdate" type="integer" label="38013" help="38014">
+          <level>2</level>
+          <default>10</default>
+          <constraints>
+            <minimum label="38015">0</minimum> <!-- Unlimited -->
+            <step>5</step>
+            <maximum>25</maximum>
+          </constraints>
+          <control type="spinner" format="string">
+            <formatlabel>38016</formatlabel>
+          </control>
+          <control type="edit" format="integer" />
+        </setting>
+      </group>
+    </category>
+  </section>
+</settings>

--- a/system/settings/rbp.xml
+++ b/system/settings/rbp.xml
@@ -15,6 +15,21 @@
           <control type="toggle" />
         </setting>
       </group>
+      <group id="3">
+        <setting id="videoplayer.limitguiupdate" type="integer" label="38013" help="38014">
+          <level>2</level>
+          <default>10</default>
+          <constraints>
+            <minimum label="38015">0</minimum> <!-- Unlimited -->
+            <step>5</step>
+            <maximum>25</maximum>
+          </constraints>
+          <control type="spinner" format="string">
+            <formatlabel>38016</formatlabel>
+          </control>
+          <control type="edit" format="integer" />
+        </setting>
+      </group>
     </category>
     <category id="myvideos">
       <group id="1">

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -463,6 +463,7 @@ protected:
   bool m_bPresentFrame;
   unsigned int m_lastFrameTime;
   unsigned int m_lastRenderTime;
+  bool m_skipGuiRender;
 
   bool m_bStandalone;
   bool m_bEnableLegacyRes;

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -986,8 +986,6 @@ bool CGUIWindowManager::Render()
       CGUITexture::DrawQuad(*i, 0x4c00ff00);
   }
 
-  RenderEx();
-
   return hasRendered;
 }
 

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -94,6 +94,8 @@ public:
    */
   bool Render();
 
+  void RenderEx() const;
+
   /*! \brief Do any post render activities.
    */
   void AfterRender();
@@ -169,7 +171,6 @@ public:
 #endif
 private:
   void RenderPass() const;
-  void RenderEx() const;
 
   void LoadNotOnDemandWindows();
   void UnloadNotOnDemandWindows();

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -459,6 +459,9 @@ bool CSettings::InitializeDefinitions()
 #elif defined(TARGET_FREEBSD)
   if (CFile::Exists(SETTINGS_XML_FOLDER "freebsd.xml") && !Initialize(SETTINGS_XML_FOLDER "freebsd.xml"))
     CLog::Log(LOGFATAL, "Unable to load freebsd-specific settings definitions");
+#elif defined(HAS_IMXVPU)
+  if (CFile::Exists(SETTINGS_XML_FOLDER "imx6.xml") && !Initialize(SETTINGS_XML_FOLDER "imx6.xml"))
+    CLog::Log(LOGFATAL, "Unable to load imx6-specific settings definitions");
 #elif defined(TARGET_LINUX)
   if (CFile::Exists(SETTINGS_XML_FOLDER "linux.xml") && !Initialize(SETTINGS_XML_FOLDER "linux.xml"))
     CLog::Log(LOGFATAL, "Unable to load linux-specific settings definitions");


### PR DESCRIPTION
Allow Render skips:
This is work done by @popcornmix and @FernetMenta monkeyed together by me. This was tested for RPB in the @Milhouse builds for months. It was also tested be volunteers of OpenELEC and OSMC during the easter weekend.

IMX specifics:
IMX is currently too slow for rendering 50 progressive frames while anything from fb0 is blended into the image. We found out, that the hw is capable enough to render OSD, subs, etc. with 15 fps while in fullscreen. Therefore the new special settings.

RPB:
I adjusted popcornmix's work to fit the new string numbers
