### PR TITLE
[CONFLUENCE] - cleaned up PlayerControl RepeatButton images

### DIFF
--- a/addons/skin.confluence/720p/includes.xml
+++ b/addons/skin.confluence/720p/includes.xml
@@ -68,6 +68,14 @@
 		<value condition="Player.Forwarding">$LOCALIZE[31044]</value>
 		<value condition="Player.Rewinding">$LOCALIZE[31045]</value>
 	</variable>
+	<variable name="PlayerControlsRepeatImageVar">
+		<value condition="Playlist.IsRepeatOne + Control.HasFocus(604)">OSDRepeatOneFO.png</value>
+		<value condition="Playlist.IsRepeat + Control.HasFocus(604)">OSDRepeatAllFO.png</value>
+		<value condition="Control.HasFocus(604)">OSDRepeatFO.png</value>
+		<value condition="Playlist.IsRepeatOne">OSDRepeatOneNF.png</value>
+		<value condition="Playlist.IsRepeat">OSDRepeatAllNF.png</value>
+		<value>OSDRepeatNF.png</value>
+	</variable>
 	<variable name="PVRChannelMgrHeader">
 		<value condition="!IsEmpty(Window.Property(IsRadio))">$LOCALIZE[19199] - $LOCALIZE[19024]</value>
 		<value>$LOCALIZE[19199] - $LOCALIZE[19023]</value>
@@ -897,54 +905,7 @@
 					<top>2</top>
 					<width>39</width>
 					<height>39</height>
-					<texture>OSDRepeatNF.png</texture>
-					<visible>!Playlist.IsRepeat + !Playlist.IsRepeatOne</visible>
-					<visible>!Control.HasFocus(604)</visible>
-				</control>
-				<control type="image">
-					<left>165</left>
-					<top>2</top>
-					<width>39</width>
-					<height>39</height>
-					<texture>OSDRepeatFO.png</texture>
-					<visible>!Playlist.IsRepeat + !Playlist.IsRepeatOne</visible>
-					<visible>Control.HasFocus(604)</visible>
-				</control>
-				<control type="image">
-					<left>165</left>
-					<top>2</top>
-					<width>39</width>
-					<height>39</height>
-					<texture>OSDRepeatOneNF.png</texture>
-					<visible>Playlist.IsRepeatOne</visible>
-					<visible>!Control.HasFocus(604)</visible>
-				</control>
-				<control type="image">
-					<left>165</left>
-					<top>2</top>
-					<width>39</width>
-					<height>39</height>
-					<texture>OSDRepeatOneFO.png</texture>
-					<visible>Playlist.IsRepeatOne</visible>
-					<visible>Control.HasFocus(604)</visible>
-				</control>
-				<control type="image">
-					<left>165</left>
-					<top>2</top>
-					<width>39</width>
-					<height>39</height>
-					<texture>OSDRepeatAllNF.png</texture>
-					<visible>Playlist.IsRepeat</visible>
-					<visible>!Control.HasFocus(604)</visible>
-				</control>
-				<control type="image">
-					<left>165</left>
-					<top>2</top>
-					<width>39</width>
-					<height>39</height>
-					<texture>OSDRepeatAllFO.png</texture>
-					<visible>Playlist.IsRepeat</visible>
-					<visible>Control.HasFocus(604)</visible>
+					<texture>$VAR[PlayerControlsRepeatImageVar]</texture>
 				</control>
 				<control type="togglebutton" id="605">
 					<left>205</left>


### PR DESCRIPTION
use a $VAR[] instead of 6 separate image controls for the RepeatButton texture.
