### PR TITLE
[video] re-scrape season art for newly added seasons

### DIFF
--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -1029,5 +1029,34 @@ bool CScraper::GetArtistDetails(CCurlFile &fcurl, const CScraperUrl &scurl,
   return fRet;
 }
 
+bool CScraper::GetArtwork(XFILE::CCurlFile &fcurl, CVideoInfoTag &details)
+{
+  if (details.m_strIMDBNumber.empty())
+    return false;
+
+  CLog::Log(LOGDEBUG, "%s: Reading artwork for '%s' using %s scraper "
+    "(file: '%s', content: '%s', version: '%s')", __FUNCTION__, details.m_strIMDBNumber.c_str(),
+    Name().c_str(), Path().c_str(), ADDON::TranslateContent(Content()).c_str(), Version().asString().c_str());
+
+  std::vector<std::string> vcsIn;
+  CScraperUrl scurl;
+  vcsIn.push_back(details.m_strIMDBNumber);
+  std::vector<std::string> vcsOut = RunNoThrow("GetArt", scurl, fcurl, &vcsIn);
+
+  bool fRet(false);
+  for (std::vector<std::string>::const_iterator it = vcsOut.begin(); it != vcsOut.end(); ++it)
+  {
+    CXBMCTinyXML doc;
+    doc.Parse(*it, TIXML_ENCODING_UTF8);
+    if (!doc.RootElement())
+    {
+      CLog::Log(LOGERROR, "%s: Unable to parse XML", __FUNCTION__);
+      return false;
+    }
+    fRet = details.Load(doc.RootElement(), it != vcsOut.begin());
+  }
+  return fRet;
+}
+
 }
 

--- a/xbmc/addons/Scraper.h
+++ b/xbmc/addons/Scraper.h
@@ -149,6 +149,7 @@ public:
     CAlbum &album);
   bool GetArtistDetails(XFILE::CCurlFile &fcurl, const CScraperUrl &scurl,
     const std::string &sSearch, CArtist &artist);
+  bool GetArtwork(XFILE::CCurlFile &fcurl, CVideoInfoTag &details);
 
 private:
   CScraper(const CScraper &rhs);

--- a/xbmc/video/VideoInfoDownloader.cpp
+++ b/xbmc/video/VideoInfoDownloader.cpp
@@ -156,6 +156,11 @@ int CVideoInfoDownloader::FindMovie(const std::string &strMovie,
   return success;
 }
 
+bool CVideoInfoDownloader::GetArtwork(CVideoInfoTag &details)
+{
+  return m_info->GetArtwork(*m_http, details);
+}
+
 bool CVideoInfoDownloader::GetDetails(const CScraperUrl &url,
                                       CVideoInfoTag &movieDetails,
                                       CGUIDialogProgress *pProgress /* = NULL */)

--- a/xbmc/video/VideoInfoDownloader.h
+++ b/xbmc/video/VideoInfoDownloader.h
@@ -54,6 +54,13 @@ public:
    \return 1 on success, -1 on a scraper-specific error, 0 on some other error
    */
   int FindMovie(const std::string& strMovie, MOVIELIST& movielist, CGUIDialogProgress *pProgress = NULL);
+
+  /*! \brief Fetch art URLs for an item with our scraper
+   \param details the video info tag structure to fill with art.
+   \return true on success, false on failure.
+   */
+  bool GetArtwork(CVideoInfoTag &details);
+
   bool GetDetails(const CScraperUrl& url, CVideoInfoTag &movieDetails, CGUIDialogProgress *pProgress = NULL);
   bool GetEpisodeDetails(const CScraperUrl& url, CVideoInfoTag &movieDetails, CGUIDialogProgress *pProgress = NULL);
   bool GetEpisodeList(const CScraperUrl& url, VIDEO::EPISODELIST& details, CGUIDialogProgress *pProgress = NULL);

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -676,18 +676,33 @@ namespace VIDEO
 
     CVideoInfoTag showInfo;
     m_database.GetTvShowInfo("", showInfo, showID);
-    bool updatedSeasons = false;
-    INFO_RET ret = OnProcessSeriesFolder(files, scraper, useLocal, showInfo, updatedSeasons, progress);
+    INFO_RET ret = OnProcessSeriesFolder(files, scraper, useLocal, showInfo, progress);
 
-    if (ret == INFO_ADDED && updatedSeasons)
+    if (ret == INFO_ADDED)
     {
       map<int, map<string, string> > seasonArt;
       m_database.GetTvShowSeasonArt(showID, seasonArt);
-      GetSeasonThumbs(showInfo, seasonArt, CVideoThumbLoader::GetArtTypes(MediaTypeSeason), useLocal);
+
+      bool updateSeasonArt = false;
       for (map<int, map<string, string> >::const_iterator i = seasonArt.begin(); i != seasonArt.end(); ++i)
       {
-        int seasonID = m_database.AddSeason(showID, i->first);
-        m_database.SetArtForItem(seasonID, MediaTypeSeason, i->second);
+        if (i->second.empty())
+        {
+          updateSeasonArt = true;
+          break;
+        }
+      }
+
+      if (updateSeasonArt)
+      {
+        CVideoInfoDownloader loader(scraper);
+        loader.GetArtwork(showInfo);
+        GetSeasonThumbs(showInfo, seasonArt, CVideoThumbLoader::GetArtTypes(MediaTypeSeason), useLocal);
+        for (map<int, map<string, string> >::const_iterator i = seasonArt.begin(); i != seasonArt.end(); ++i)
+        {
+          int seasonID = m_database.AddSeason(showID, i->first);
+          m_database.SetArtForItem(seasonID, MediaTypeSeason, i->second);
+        }
       }
     }
     return ret;
@@ -1385,7 +1400,7 @@ namespace VIDEO
     return fanart;
   }
 
-  INFO_RET CVideoInfoScanner::OnProcessSeriesFolder(EPISODELIST& files, const ADDON::ScraperPtr &scraper, bool useLocal, const CVideoInfoTag& showInfo, bool& updatedSeasons, CGUIDialogProgress* pDlgProgress /* = NULL */)
+  INFO_RET CVideoInfoScanner::OnProcessSeriesFolder(EPISODELIST& files, const ADDON::ScraperPtr &scraper, bool useLocal, const CVideoInfoTag& showInfo, CGUIDialogProgress* pDlgProgress /* = NULL */)
   {
     if (pDlgProgress)
     {
@@ -1397,12 +1412,7 @@ namespace VIDEO
     }
 
     EPISODELIST episodes;
-    updatedSeasons = false;
     bool hasEpisodeGuide = false;
-
-    // grab currently known seasons
-    map<int, int> seasons;
-    m_database.GetTvShowSeasons(showInfo.m_iDbId, seasons);
 
     int iMax = files.size();
     int iCurr = 1;
@@ -1449,9 +1459,6 @@ namespace VIDEO
         }
         if (AddVideo(&item, CONTENT_TVSHOWS, file->isFolder, true, &showInfo) < 0)
           return INFO_ERROR;
-
-        if (seasons.find(item.GetVideoInfoTag()->m_iSeason) == seasons.end())
-          updatedSeasons = true;
         continue;
       }
 
@@ -1581,9 +1588,6 @@ namespace VIDEO
           
         if (AddVideo(&item, CONTENT_TVSHOWS, file->isFolder, useLocal, &showInfo) < 0)
           return INFO_ERROR;
-
-        if (seasons.find(item.GetVideoInfoTag()->m_iSeason) == seasons.end())
-          updatedSeasons = true;
       }
       else
       {

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -223,12 +223,11 @@ namespace VIDEO
      \param files the episode files to process.
      \param scraper scraper to use for finding online info
      \param showInfo information for the show.
-     \param updatedSeasons returns true in case a new season was found
      \param pDlgProcess progress dialog to update during processing.  Defaults to NULL.
      \return INFO_ERROR on failure, INFO_CANCELLED on cancellation,
      INFO_NOT_FOUND if an episode isn't found, or INFO_ADDED if all episodes are added.
      */
-    INFO_RET OnProcessSeriesFolder(EPISODELIST& files, const ADDON::ScraperPtr &scraper, bool useLocal, const CVideoInfoTag& showInfo, bool& updatedSeasons, CGUIDialogProgress* pDlgProgress = NULL);
+    INFO_RET OnProcessSeriesFolder(EPISODELIST& files, const ADDON::ScraperPtr &scraper, bool useLocal, const CVideoInfoTag& showInfo, CGUIDialogProgress* pDlgProgress = NULL);
 
     bool EnumerateSeriesFolder(CFileItem* item, EPISODELIST& episodeList);
     bool ProcessItemByVideoInfoTag(const CFileItem *item, EPISODELIST &episodeList);


### PR DESCRIPTION
This fixes the stale season artwork bug in case new artwork becomes available after initial scrape by adding a `GetArtwork()` function to the scraper, allowing us to re-fetch the art URLs for a particular item. 

It is triggered whenever a missing season art is detected after adding new episodes. Lookups are done via the unique identifier `m_strIMDBNumber' within the video info tag. It uses the scraper cache where possible to avoid another API hits.

Note:
This has to go in after the scraper changes (https://github.com/xbmc/repo-scrapers/pull/4). Once merged `metadata.tvdb.com` and `metadata.tvshows.themoviedb.org` (already chaining via GetArt) will support this. Others have to adopt this and move the actual artwork fetches to a `GetArt` chain. There's no change in behavior in case the scraper does not support this.

This is entirely based on @jmarshallnz work in PR https://github.com/xbmc/xbmc/pull/3546 and just slightly modified.

@Montellese for review please
