### PR TITLE
[pvr] check linked recordings when determining if an EPG tag is currently being recorded

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -5382,6 +5382,13 @@ bool CGUIInfoManager::GetItemBool(const CGUIListItem *item, int condition) const
       }
       else if (pItem->HasEPGInfoTag())
       {
+        CEpgInfoTagPtr epgTag = pItem->GetEPGInfoTag();
+
+        // Check if the tag has a currently active recording associated
+        if (epgTag->HasRecording() && epgTag->IsActive())
+          return true;
+
+        // Search all timers for something that matches the tag
         CFileItemPtr timer = g_PVRTimers->GetTimerForEpgTag(pItem);
         if (timer && timer->HasPVRTimerInfoTag())
           return timer->GetPVRTimerInfoTag()->IsRecording();


### PR DESCRIPTION
Some backends may set the timer/recording start time to the actual time the user started the recording, which means the search for a matching timer based on the EPG tag's start and end time would fail unless the recording was scheduled before the event started. This would happen regardless of whether the addon has associated an event with the recording.

This changes the logic so that we don't bother to search through all timers if the EPG tag is active and has a recording assoicated.

@opdenkamp @xhaggi mind having a look?

Another idea would be to fix the "find a timer based on a channel, start time and end time" by starting the search from the end (i.e. the farthest in the future event) for an event with a matching channel and end time (but not start time), then stop. This way the start time would not be required in the equation. Chances are it would be slower though.
