### PR TITLE
[confluence] fix MediaItemDetailBG alignment to match MenuItemFO

### DIFF
--- a/addons/skin.confluence/720p/FileManager.xml
+++ b/addons/skin.confluence/720p/FileManager.xml
@@ -176,9 +176,9 @@
 					</control>
 					<control type="image">
 						<left>340</left>
-						<top>2</top>
+						<top>0</top>
 						<width>200</width>
-						<height>31</height>
+						<height>36</height>
 						<texture border="0,0,14,0">MediaItemDetailBG.png</texture>
 						<visible>Control.HasFocus(20) + !IsEmpty(ListItem.Label2)</visible>
 					</control>
@@ -350,9 +350,9 @@
 					</control>
 					<control type="image">
 						<left>340</left>
-						<top>2</top>
+						<top>0</top>
 						<width>200</width>
-						<height>31</height>
+						<height>36</height>
 						<texture border="0,0,14,0">MediaItemDetailBG.png</texture>
 						<visible>Control.HasFocus(21) + !IsEmpty(ListItem.Label2)</visible>
 					</control>

--- a/addons/skin.confluence/720p/MyPVRRecordings.xml
+++ b/addons/skin.confluence/720p/MyPVRRecordings.xml
@@ -148,9 +148,9 @@
 					</control>
 					<control type="image">
 						<left>560</left>
-						<top>5</top>
+						<top>0</top>
 						<width>200</width>
-						<height>31</height>
+						<height>41</height>
 						<texture border="0,0,14,0">MediaItemDetailBG.png</texture>
 						<visible>Control.HasFocus(50) + !IsEmpty(ListItem.Date)</visible>
 					</control>

--- a/addons/skin.confluence/720p/ViewsAddonBrowser.xml
+++ b/addons/skin.confluence/720p/ViewsAddonBrowser.xml
@@ -71,9 +71,9 @@
 					</control>
 					<control type="image">
 						<left>370</left>
-						<top>5</top>
+						<top>0</top>
 						<width>200</width>
-						<height>31</height>
+						<height>41</height>
 						<texture border="0,0,14,0">MediaItemDetailBG.png</texture>
 						<visible>Control.HasFocus(550) + !IsEmpty(ListItem.Property(Addon.Status))</visible>
 					</control>

--- a/addons/skin.confluence/720p/ViewsFileMode.xml
+++ b/addons/skin.confluence/720p/ViewsFileMode.xml
@@ -121,9 +121,9 @@
 					</control>
 					<control type="image">
 						<left>490</left>
-						<top>4</top>
+						<top>0</top>
 						<width>200</width>
-						<height>33</height>
+						<height>41</height>
 						<texture border="0,0,14,0">MediaItemDetailBG.png</texture>
 						<visible>Control.HasFocus(50) + !IsEmpty(ListItem.Label2)</visible>
 					</control>
@@ -641,9 +641,9 @@
 					</control>
 					<control type="image">
 						<left>875</left>
-						<top>4</top>
+						<top>0</top>
 						<width>200</width>
-						<height>33</height>
+						<height>41</height>
 						<texture border="0,0,14,0">MediaItemDetailBG.png</texture>
 						<visible>Control.HasFocus(51) + !IsEmpty(ListItem.Label2)</visible>
 					</control>

--- a/addons/skin.confluence/720p/ViewsLiveTV.xml
+++ b/addons/skin.confluence/720p/ViewsLiveTV.xml
@@ -71,9 +71,9 @@
 					</control>
 					<control type="image">
 						<left>560</left>
-						<top>5</top>
+						<top>0</top>
 						<width>200</width>
-						<height>31</height>
+						<height>41</height>
 						<texture border="0,0,14,0">MediaItemDetailBG.png</texture>
 						<visible>Control.HasFocus(560) + !IsEmpty(ListItem.Label2)</visible>
 					</control>

--- a/addons/skin.confluence/720p/ViewsMusicLibrary.xml
+++ b/addons/skin.confluence/720p/ViewsMusicLibrary.xml
@@ -71,9 +71,9 @@
 					</control>
 					<control type="image">
 						<left>580</left>
-						<top>5</top>
+						<top>0</top>
 						<width>200</width>
-						<height>31</height>
+						<height>41</height>
 						<texture border="0,0,14,0">MediaItemDetailBG.png</texture>
 						<visible>Control.HasFocus(506) + !IsEmpty(ListItem.Label2)</visible>
 					</control>
@@ -559,9 +559,9 @@
 					</control>
 					<control type="image">
 						<left>560</left>
-						<top>5</top>
+						<top>0</top>
 						<width>200</width>
-						<height>31</height>
+						<height>41</height>
 						<texture border="0,0,14,0">MediaItemDetailBG.png</texture>
 						<visible>Control.HasFocus(511) + !IsEmpty(ListItem.Label2)</visible>
 					</control>
@@ -983,9 +983,9 @@
 					</control>
 					<control type="image">
 						<left>580</left>
-						<top>5</top>
+						<top>0</top>
 						<width>200</width>
-						<height>31</height>
+						<height>41</height>
 						<texture border="0,0,14,0">MediaItemDetailBG.png</texture>
 						<visible>Control.HasFocus(513) + !IsEmpty(ListItem.Label2)</visible>
 					</control>

--- a/addons/skin.confluence/720p/ViewsVideoLibrary.xml
+++ b/addons/skin.confluence/720p/ViewsVideoLibrary.xml
@@ -845,9 +845,9 @@
 					</control>
 					<control type="image">
 						<left>380</left>
-						<top>4</top>
+						<top>0</top>
 						<width>200</width>
-						<height>33</height>
+						<height>41</height>
 						<texture border="0,0,14,0">MediaItemDetailBG.png</texture>
 						<visible>Control.HasFocus(503) + !IsEmpty(ListItem.Label2)</visible>
 					</control>
@@ -1261,9 +1261,9 @@
 					</control>
 					<control type="image">
 						<left>380</left>
-						<top>4</top>
+						<top>0</top>
 						<width>200</width>
-						<height>33</height>
+						<height>41</height>
 						<texture border="0,0,14,0">MediaItemDetailBG.png</texture>
 						<visible>Control.HasFocus(504) + !IsEmpty(ListItem.Label2)</visible>
 					</control>


### PR DESCRIPTION
The MediaItemDetailBG alignment is off in respect to MenuItemFO

This makes it consistent across all views where its used, and removes the visual glitch you can see at
the tip.

This doesn't look consistent across other views as is, and one of the peeves missus pointed out to me :+1: , her eyes are much better than mine. :smiley: 

Below is screenshot before / after
![fixmediablade](https://cloud.githubusercontent.com/assets/3521959/7062189/b1e807f2-de92-11e4-9df5-bd932f040f4c.jpg)

@ronie @da-anda
