### PR TITLE
[rbp] tools: only use sudo if we have it on the system

### DIFF
--- a/tools/rbp/setup-sdk.sh
+++ b/tools/rbp/setup-sdk.sh
@@ -23,9 +23,9 @@ fi
 
 if [ -d $XBMCPREFIX ]
 then
-  [ -O $XBMCPREFIX ] || SUDO="sudo"
+  [ -O $XBMCPREFIX ] || { command -v sudo >/dev/null 2>&1 && SUDO="sudo"; }
 else
-  [ -w $(dirname $XBMCPREFIX) ] || SUDO="sudo"
+  [ -w $(dirname $XBMCPREFIX) ] || { command -v sudo >/dev/null 2>&1 && SUDO="sudo"; }
 fi
 
 $SUDO mkdir -p $XBMCPREFIX


### PR DESCRIPTION
We should not always assume that sudo is on the host system or even in PATH
