### PR TITLE
move CUtil tests to gtest unit tests

### DIFF
--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -799,6 +799,10 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\test\TestUtil.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\..\xbmc\test\TestUtils.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -3081,6 +3081,9 @@
       <Filter>music</Filter>
     </ClCompile>
     <ClCompile Include="..\..\xbmc\filesystem\NFSDirectory.cpp" />
+    <ClCompile Include="..\..\xbmc\test\TestUtil.cpp">
+      <Filter>test</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\xbmc\win32\pch.h">

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -343,42 +343,6 @@ void CUtil::GetQualifiedFilename(const std::string &strBasePath, std::string &st
   }
 }
 
-#ifdef UNIT_TESTING
-bool CUtil::TestGetQualifiedFilename()
-{
-  std::string file = "../foo"; GetQualifiedFilename("smb://", file);
-  if (file != "foo") return false;
-  file = "C:\\foo\\bar"; GetQualifiedFilename("smb://", file);
-  if (file != "C:\\foo\\bar") return false;
-  file = "../foo/./bar"; GetQualifiedFilename("smb://my/path", file);
-  if (file != "smb://my/foo/bar") return false;
-  file = "smb://foo/bar/"; GetQualifiedFilename("upnp://", file);
-  if (file != "smb://foo/bar/") return false;
-  return true;
-}
-
-bool CUtil::TestMakeLegalPath()
-{
-  std::string path;
-#ifdef TARGET_WINDOWS
-  path = "C:\\foo\\bar"; path = MakeLegalPath(path);
-  if (path != "C:\\foo\\bar") return false;
-  path = "C:\\foo:\\bar\\"; path = MakeLegalPath(path);
-  if (path != "C:\\foo_\\bar\\") return false;
-#elif
-  path = "/foo/bar/"; path = MakeLegalPath(path);
-  if (path != "/foo/bar/") return false;
-  path = "/foo?/bar"; path = MakeLegalPath(path);
-  if (path != "/foo_/bar") return false;
-#endif
-  path = "smb://foo/bar"; path = MakeLegalPath(path);
-  if (path != "smb://foo/bar") return false;
-  path = "smb://foo/bar?/"; path = MakeLegalPath(path);
-  if (path != "smb://foo/bar_/") return false;
-  return true;
-}
-#endif
-
 void CUtil::RunShortcut(const char* szShortcutPath)
 {
 }
@@ -995,34 +959,6 @@ bool CUtil::IsUsingTTFSubtitles()
 {
   return URIUtils::HasExtension(CSettings::Get().GetString("subtitles.font"), ".ttf");
 }
-
-#ifdef UNIT_TESTING
-bool CUtil::TestSplitExec()
-{
-  std::string function;
-  vector<std::string> params;
-  CUtil::SplitExecFunction("ActivateWindow(Video, \"C:\\test\\foo\")", function, params);
-  if (function != "ActivateWindow" || params.size() != 2 || params[0] != "Video" || params[1] != "C:\\test\\foo")
-    return false;
-  params.clear();
-  CUtil::SplitExecFunction("ActivateWindow(Video, \"C:\\test\\foo\\\")", function, params);
-  if (function != "ActivateWindow" || params.size() != 2 || params[0] != "Video" || params[1] != "C:\\test\\foo\"")
-    return false;
-  CUtil::SplitExecFunction("ActivateWindow(Video, \"C:\\\\test\\\\foo\\\\\")", function, params);
-  if (function != "ActivateWindow" || params.size() != 2 || params[0] != "Video" || params[1] != "C:\\test\\foo\\")
-    return false;
-  CUtil::SplitExecFunction("ActivateWindow(Video, \"C:\\\\\\\\test\\\\\\foo\\\\\")", function, params);
-  if (function != "ActivateWindow" || params.size() != 2 || params[0] != "Video" || params[1] != "C:\\\\test\\\\foo\\")
-    return false;
-  CUtil::SplitExecFunction("SetProperty(Foo,\"\")", function, params);
-  if (function != "SetProperty" || params.size() != 2 || params[0] != "Foo" || params[1] != "")
-   return false;
-  CUtil::SplitExecFunction("SetProperty(foo,ba(\"ba black )\",sheep))", function, params);
-  if (function != "SetProperty" || params.size() != 2 || params[0] != "foo" || params[1] != "ba(\"ba black )\",sheep)")
-    return false;
-  return true;
-}
-#endif
 
 void CUtil::SplitExecFunction(const std::string &execString, std::string &function, vector<string> &parameters)
 {

--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -161,12 +161,6 @@ public:
   static bool SupportsReadFileOperations(const std::string& strPath);
   static std::string GetDefaultFolderThumb(const std::string &folderThumb);
 
-#ifdef UNIT_TESTING
-  static bool TestSplitExec();
-  static bool TestGetQualifiedFilename();
-  static bool TestMakeLegalPath();
-#endif
-
   static void InitRandomSeed();
 
   // Get decimal integer representation of roman digit, ivxlcdm are valid

--- a/xbmc/test/Makefile
+++ b/xbmc/test/Makefile
@@ -3,6 +3,7 @@ SRCS=	\
 	TestFileItem.cpp \
 	TestTextureUtils.cpp \
 	TestURL.cpp \
+	TestUtil.cpp \
 	TestUtils.cpp \
 	xbmc-test.cpp
 

--- a/xbmc/test/TestUtil.cpp
+++ b/xbmc/test/TestUtil.cpp
@@ -1,0 +1,100 @@
+/*
+ *      Copyright (C) 2005-2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "Util.h"
+
+#include "gtest/gtest.h"
+
+TEST(TestUtil, GetQualifiedFilename)
+{
+  std::string file = "../foo";
+  CUtil::GetQualifiedFilename("smb://", file);
+  EXPECT_EQ(file, "foo");
+  file = "C:\\foo\\bar";
+  CUtil::GetQualifiedFilename("smb://", file);
+  EXPECT_EQ(file, "C:\\foo\\bar");
+  file = "../foo/./bar";
+  CUtil::GetQualifiedFilename("smb://my/path", file);
+  EXPECT_EQ(file, "smb://my/foo/bar");
+  file = "smb://foo/bar/";
+  CUtil::GetQualifiedFilename("upnp://", file);
+  EXPECT_EQ(file, "smb://foo/bar/");
+}
+
+TEST(TestUtil, MakeLegalPath)
+{
+  std::string path;
+#ifdef TARGET_WINDOWS
+  path = "C:\\foo\\bar";
+  EXPECT_EQ(CUtil::MakeLegalPath(path), "C:\\foo\\bar");
+  path = "C:\\foo:\\bar\\";
+  EXPECT_EQ(CUtil::MakeLegalPath(path), "C:\\foo_\\bar\\");
+#else
+  path = "/foo/bar/";
+  EXPECT_EQ(CUtil::MakeLegalPath(path),"/foo/bar/");
+  path = "/foo?/bar";
+  EXPECT_EQ(CUtil::MakeLegalPath(path),"/foo_/bar");
+#endif
+  path = "smb://foo/bar";
+  EXPECT_EQ(CUtil::MakeLegalPath(path), "smb://foo/bar");
+  path = "smb://foo/bar?/";
+  EXPECT_EQ(CUtil::MakeLegalPath(path), "smb://foo/bar_/");
+}
+
+TEST(TestUtil, SplitExec)
+{
+  std::string function;
+  std::vector<std::string> params;
+  CUtil::SplitExecFunction("ActivateWindow(Video, \"C:\\test\\foo\")", function, params);
+  EXPECT_EQ(function,  "ActivateWindow");
+  EXPECT_EQ(params.size(), 2);
+  EXPECT_EQ(params[0], "Video");
+  EXPECT_EQ(params[1], "C:\\test\\foo");
+  params.clear();
+  CUtil::SplitExecFunction("ActivateWindow(Video, \"C:\\test\\foo\\\")", function, params);
+  EXPECT_EQ(function,  "ActivateWindow");
+  EXPECT_EQ(params.size(), 2);
+  EXPECT_EQ(params[0], "Video");
+  EXPECT_EQ(params[1], "C:\\test\\foo");
+  params.clear();
+  CUtil::SplitExecFunction("ActivateWindow(Video, \"C:\\\\test\\\\foo\\\\\")", function, params);
+  EXPECT_EQ(function,  "ActivateWindow");
+  EXPECT_EQ(params.size(), 2);
+  EXPECT_EQ(params[0], "Video");
+  EXPECT_EQ(params[1], "C:\\test\\foo\\");
+  params.clear();
+  CUtil::SplitExecFunction("ActivateWindow(Video, \"C:\\\\\\\\test\\\\\\foo\\\\\")", function, params);
+  EXPECT_EQ(function,  "ActivateWindow");
+  EXPECT_EQ(params.size(), 2);
+  EXPECT_EQ(params[0], "Video");
+  EXPECT_EQ(params[1], "C:\\\\test\\\\foo\\");
+  params.clear();
+  CUtil::SplitExecFunction("SetProperty(Foo,\"\")", function, params);
+  EXPECT_EQ(function,  "SetProperty");
+  EXPECT_EQ(params.size(), 2);
+  EXPECT_EQ(params[0], "Foo");
+  EXPECT_EQ(params[1], "");
+  params.clear();
+  CUtil::SplitExecFunction("SetProperty(foo,ba(\"ba black )\",sheep))", function, params);
+  EXPECT_EQ(function,  "SetProperty");
+  EXPECT_EQ(params.size(), 2);
+  EXPECT_EQ(params[0], "foo");
+  EXPECT_EQ(params[1], "ba(\"ba black )\",sheep)");
+}


### PR DESCRIPTION
Some tests for CUtil exist under some nasty define. Move them to proper gtest unit tests.

Requires project updates.
