### PR TITLE
Quell warnings and fix include paths

### DIFF
--- a/lib/libexif/JpegParse.cpp
+++ b/lib/libexif/JpegParse.cpp
@@ -108,7 +108,7 @@ bool CJpegParse::GetSection (FILE *infile, const unsigned short sectionLength)
   }
   // Store first two pre-read bytes.
   m_SectionBuffer[0] = (unsigned char)(sectionLength >> 8);
-  m_SectionBuffer[1] = (unsigned char)(sectionLength && 0x00FF);
+  m_SectionBuffer[1] = (unsigned char)(sectionLength & 0x00FF);
 
   unsigned int len = (unsigned int)sectionLength;
 

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -104,21 +104,8 @@ using namespace std;
 using namespace MEDIA_DETECT;
 #endif
 
-#define clamp(x) (x) > 255.f ? 255 : ((x) < 0 ? 0 : (BYTE)(x+0.5f)) // Valid ranges: brightness[-1 -> 1 (0 is default)] contrast[0 -> 2 (1 is default)]  gamma[0.5 -> 3.5 (1 is default)] default[ramp is linear]
-
 using namespace XFILE;
 using namespace PLAYLIST;
-
-#ifdef HAS_DX
-static D3DGAMMARAMP oldramp, flashramp;
-#elif defined(HAS_SDL_2D)
-static uint16_t oldrampRed[256];
-static uint16_t oldrampGreen[256];
-static uint16_t oldrampBlue[256];
-static uint16_t flashrampRed[256];
-static uint16_t flashrampGreen[256];
-static uint16_t flashrampBlue[256];
-#endif
 
 #if !defined(TARGET_WINDOWS)
 unsigned int CUtil::s_randomSeed = time(NULL);

--- a/xbmc/cdrip/Encoder.cpp
+++ b/xbmc/cdrip/Encoder.cpp
@@ -21,6 +21,7 @@
 #include "Encoder.h"
 #include "filesystem/File.h"
 #include "utils/log.h"
+#include <string.h>
 
 CEncoder::CEncoder(std::shared_ptr<IEncoder> encoder)
 {

--- a/xbmc/cores/DllLoader/dll_util.cpp
+++ b/xbmc/cores/DllLoader/dll_util.cpp
@@ -72,7 +72,7 @@ uintptr_t create_dummy_function(const char* strDllName, const char* strFunctionN
   // allocate memory for function + strings + 3 x 4 bytes for three datapointers
   char* pData = (char*)malloc(iFunctionSize + 12 + iDllNameSize + iFunctionNameSize);
   if (!pData)
-    return NULL;
+    return 0;
 
   char* offDataPointer1 = pData + iFunctionSize;
   char* offDataPointer2 = pData + iFunctionSize + 4;

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFFmpeg.cpp
@@ -19,7 +19,7 @@
  */
 
 #include "DVDInputStreamFFmpeg.h"
-#include "xbmc/playlists/PlayListM3U.h"
+#include "playlists/PlayListM3U.h"
 #include "settings/Settings.h"
 #include "Util.h"
 #include "utils/log.h"

--- a/xbmc/filesystem/BlurayFile.cpp
+++ b/xbmc/filesystem/BlurayFile.cpp
@@ -24,6 +24,7 @@
 
 #include "BlurayFile.h"
 #include "URL.h"
+#include <assert.h>
 
 namespace XFILE
 {

--- a/xbmc/filesystem/test/TestFileFactory.cpp
+++ b/xbmc/filesystem/test/TestFileFactory.cpp
@@ -21,6 +21,7 @@
 #include "filesystem/File.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
+#include "utils/StringUtils.h"
 #include "test/TestUtils.h"
 #include "utils/StringUtils.h"
 

--- a/xbmc/guilib/MatrixGLES.cpp
+++ b/xbmc/guilib/MatrixGLES.cpp
@@ -44,13 +44,10 @@ CMatrixGLStack glMatrixTexture(0);
 
 void CMatrixGL::LoadIdentity()
 {
-  if (m_pMatrix)
-  {
-    m_pMatrix[0] = 1.0f;  m_pMatrix[4] = 0.0f;  m_pMatrix[8]  = 0.0f;  m_pMatrix[12] = 0.0f;
-    m_pMatrix[1] = 0.0f;  m_pMatrix[5] = 1.0f;  m_pMatrix[9]  = 0.0f;  m_pMatrix[13] = 0.0f;
-    m_pMatrix[2] = 0.0f;  m_pMatrix[6] = 0.0f;  m_pMatrix[10] = 1.0f;  m_pMatrix[14] = 0.0f;
-    m_pMatrix[3] = 0.0f;  m_pMatrix[7] = 0.0f;  m_pMatrix[11] = 0.0f;  m_pMatrix[15] = 1.0f;
-  }
+  m_pMatrix[0] = 1.0f;  m_pMatrix[4] = 0.0f;  m_pMatrix[8]  = 0.0f;  m_pMatrix[12] = 0.0f;
+  m_pMatrix[1] = 0.0f;  m_pMatrix[5] = 1.0f;  m_pMatrix[9]  = 0.0f;  m_pMatrix[13] = 0.0f;
+  m_pMatrix[2] = 0.0f;  m_pMatrix[6] = 0.0f;  m_pMatrix[10] = 1.0f;  m_pMatrix[14] = 0.0f;
+  m_pMatrix[3] = 0.0f;  m_pMatrix[7] = 0.0f;  m_pMatrix[11] = 0.0f;  m_pMatrix[15] = 1.0f;
 }
 
 void CMatrixGL::Ortho(GLfloat l, GLfloat r, GLfloat b, GLfloat t, GLfloat n, GLfloat f)
@@ -185,8 +182,6 @@ inline void Matrix4Mul(const float* src_mat_1, const float* src_mat_2, float* ds
 #endif
 void CMatrixGL::MultMatrixf(const GLfloat *matrix)
 {
-  if (m_pMatrix)
-  {
 #if defined(__ARM_NEON__)
     if ((g_cpuInfo.GetCPUFeatures() & CPU_FEATURE_NEON) == CPU_FEATURE_NEON)
     {
@@ -215,7 +210,6 @@ void CMatrixGL::MultMatrixf(const GLfloat *matrix)
     m_pMatrix[1] = b;  m_pMatrix[5] = f;  m_pMatrix[9]  = j;  m_pMatrix[13] = n;
     m_pMatrix[2] = c;  m_pMatrix[6] = g;  m_pMatrix[10] = k;  m_pMatrix[14] = o;
     m_pMatrix[3] = d;  m_pMatrix[7] = h;  m_pMatrix[11] = l;  m_pMatrix[15] = p;
-  }
 }
 
 // gluLookAt implementation taken from Mesa3D

--- a/xbmc/utils/POUtils.h
+++ b/xbmc/utils/POUtils.h
@@ -22,12 +22,12 @@
 #include <vector>
 #include <stdint.h>
 
-enum
+typedef enum
 {
   ID_FOUND = 0, // We have an entry with a numeric (previously XML) identification number.
   MSGID_FOUND = 1, // We have a classic gettext entry with textual msgid. No numeric ID.
   MSGID_PLURAL_FOUND = 2 // We have a classic gettext entry with textual msgid in plural form.
-};
+} POIdType;
 
 enum
 {

--- a/xbmc/utils/test/TestCharsetConverter.cpp
+++ b/xbmc/utils/test/TestCharsetConverter.cpp
@@ -124,7 +124,7 @@ TEST_F(TestCharsetConverter, utf8ToW)
   refstra1 = "test utf8ToW";
   refstrw1 = L"test utf8ToW";
   varstrw1.clear();
-  g_charsetConverter.utf8ToW(refstra1, varstrw1, true, false, NULL);
+  g_charsetConverter.utf8ToW(refstra1, varstrw1, true, false, false);
   EXPECT_STREQ(refstrw1.c_str(), varstrw1.c_str());
 }
 


### PR DESCRIPTION
This quells various compiler warnings, fixes some include paths, and removes some unused defines and structs.
