### PR TITLE
[confluence] fix cosmetic scrollbar

### DIFF
--- a/addons/skin.confluence/720p/VideoOSDSettings.xml
+++ b/addons/skin.confluence/720p/VideoOSDSettings.xml
@@ -60,7 +60,7 @@
 				<left>40</left>
 				<top>65</top>
 				<width>720</width>
-				<height>505</height>
+				<height>515</height>
 				<itemgap>5</itemgap>
 				<pagecontrol>60</pagecontrol>
 				<onleft>60</onleft>


### PR DESCRIPTION
revisit #6117 as this seems to have re-appeared maybe due to https://github.com/xbmc/xbmc/pull/6818
more specifically https://github.com/AlwinEsch/kodi/blob/51918331c44daa2e745a81978de57bcc44efd728/addons/skin.confluence/720p/VideoOSDSettings.xml#L136-L147

**looks like a new separator has been added to the top**\* No idea if it can be hidden? See https://github.com/xbmc/xbmc/pull/6818#issuecomment-88445168 @AlwinEsch 

**Before This PR**
![before](https://cloud.githubusercontent.com/assets/3521959/7100762/d9acdd4a-e02b-11e4-965d-34026da20ea4.png)

**After this PR**
![after](https://cloud.githubusercontent.com/assets/3521959/7100765/f7859b18-e02b-11e4-8e74-9f29230cfe1f.png)

Probably could be fixed by removing the separator onto but Idk where
that is defined or if its desired.

@ronie @da-anda
