### PR TITLE
[addons] show progress of repository updates

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -12430,6 +12430,7 @@ msgctxt "#24033"
 msgid "Install from repository"
 msgstr ""
 
+#: xbmc/addons/GUIViewStateAddonBrowser.cpp
 msgctxt "#24034"
 msgid "Check for updates"
 msgstr ""
@@ -12717,7 +12718,17 @@ msgctxt "#24091"
 msgid "This Add-on cannot be disabled"
 msgstr ""
 
-#empty strings from id 24092 to 24093
+#. Used as title of the progress dialog when checking for add-on updates in add-on browser
+#: xbmc/addons/AddonInstaller.cpp
+msgctxt "#24092"
+msgid "Checking for add-on updates"
+msgstr ""
+
+#. Used as a text in the progress dialog when checking for add-on updates. %s contains repository name
+#: xbmc/addons/Repository.cpp
+msgctxt "#24093"
+msgid "Checking %s..."
+msgstr ""
 
 #: xbmc/addons/guidialogaddoninfo.cpp
 msgctxt "#24094"

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -280,16 +280,6 @@ bool CAddonInstaller::InstallFromZip(const std::string &path)
   return false;
 }
 
-void CAddonInstaller::InstallFromXBMCRepo(const set<std::string> &addonIDs)
-{
-  // first check we have the our repositories up to date (and wait until we do)
-  UpdateRepos(false, true);
-
-  // now install the addons
-  for (set<std::string>::const_iterator i = addonIDs.begin(); i != addonIDs.end(); ++i)
-    Install(*i);
-}
-
 bool CAddonInstaller::CheckDependencies(const AddonPtr &addon, CAddonDatabase *database /* = NULL */)
 {
   std::vector<std::string> preDeps;

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -39,6 +39,7 @@
 #include "dialogs/GUIDialogKaiToast.h"
 #include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogProgress.h"
+#include "dialogs/GUIDialogExtendedProgressBar.h"
 #include "URL.h"
 
 #include <functional>
@@ -57,7 +58,7 @@ struct find_map : public binary_function<CAddonInstaller::JobMap::value_type, un
 };
 
 CAddonInstaller::CAddonInstaller()
-  : m_repoUpdateJob(0)
+  : m_repoUpdateJob(nullptr)
 { }
 
 CAddonInstaller::~CAddonInstaller()
@@ -79,7 +80,7 @@ void CAddonInstaller::OnJobComplete(unsigned int jobID, bool success, CJob* job)
   {
     // repo job finished
     m_repoUpdateDone.Set();
-    m_repoUpdateJob = 0;
+    m_repoUpdateJob = nullptr;
     lock.Leave();
   }
   else
@@ -356,11 +357,19 @@ CDateTime CAddonInstaller::LastRepoUpdate() const
   return update;
 }
 
-void CAddonInstaller::UpdateRepos(bool force, bool wait)
+void CAddonInstaller::UpdateRepos(bool force /*= false*/, bool wait /*= false*/, bool showProgress /*= false*/)
 {
   CSingleLock lock(m_critSection);
-  if (m_repoUpdateJob)
+  if (m_repoUpdateJob != nullptr)
   {
+    //Hook up dialog to running job
+    if (showProgress && !m_repoUpdateJob->HasProgressIndicator())
+    {
+      auto* dialog = static_cast<CGUIDialogExtendedProgressBar*>(g_windowManager.GetWindow(WINDOW_DIALOG_EXT_PROGRESS));
+      if (dialog)
+        m_repoUpdateJob->SetProgressIndicators(dialog->GetHandle(g_localizeStrings.Get(24092)), nullptr);
+    }
+
     if (wait)
     {
       // wait for our job to complete
@@ -394,7 +403,15 @@ void CAddonInstaller::UpdateRepos(bool force, bool wait)
         || repo->Version() != database.GetRepoVersion(repo->ID()))
       {
         CLog::Log(LOGDEBUG, "Checking repositories for updates (triggered by %s)", repo->Name().c_str());
-        m_repoUpdateJob = CJobManager::GetInstance().AddJob(new CRepositoryUpdateJob(addons), this);
+
+        m_repoUpdateJob = new CRepositoryUpdateJob(addons);
+        if (showProgress)
+        {
+          auto* dialog = static_cast<CGUIDialogExtendedProgressBar*>(g_windowManager.GetWindow(WINDOW_DIALOG_EXT_PROGRESS));
+          if (dialog)
+            m_repoUpdateJob->SetProgressIndicators(dialog->GetHandle(g_localizeStrings.Get(24092)), nullptr);
+        }
+        CJobManager::GetInstance().AddJob(m_repoUpdateJob, this);
         if (wait)
         {
           // wait for our job to complete

--- a/xbmc/addons/AddonInstaller.h
+++ b/xbmc/addons/AddonInstaller.h
@@ -70,11 +70,6 @@ public:
    */
   bool InstallFromZip(const std::string &path);
 
-  /*! \brief Install a set of addons from the official repository (if needed)
-   \param addonIDs a set of addon IDs to install
-   */
-  void InstallFromXBMCRepo(const std::set<std::string> &addonIDs);
-
   /*! \brief Check whether dependencies of an addon exist or are installable.
    Iterates through the addon's dependencies, checking they're installed or installable.
    Each dependency must also satisfies CheckDependencies in turn.

--- a/xbmc/addons/AddonInstaller.h
+++ b/xbmc/addons/AddonInstaller.h
@@ -21,6 +21,7 @@
 
 #include "utils/FileOperationJob.h"
 #include "addons/Addon.h"
+#include "addons/Repository.h"
 #include "utils/Stopwatch.h"
 #include "threads/Event.h"
 
@@ -97,7 +98,7 @@ public:
    \return the last time a repository was updated.
    */
   CDateTime LastRepoUpdate() const;
-  void UpdateRepos(bool force = false, bool wait = false);
+  void UpdateRepos(bool force = false, bool wait = false, bool showProgress = false);
 
   void OnJobComplete(unsigned int jobID, bool success, CJob* job);
   void OnJobProgress(unsigned int jobID, unsigned int progress, unsigned int total, const CJob *job);
@@ -149,7 +150,7 @@ private:
   CCriticalSection m_critSection;
   JobMap m_downloadJobs;
   CStopWatch m_repoUpdateWatch;   ///< repository updates are done based on this counter
-  unsigned int m_repoUpdateJob;   ///< the job ID of the repository updates
+  ADDON::CRepositoryUpdateJob* m_repoUpdateJob;
   CEvent m_repoUpdateDone;        ///< event set when the repository updates are complete
 };
 

--- a/xbmc/addons/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/GUIWindowAddonBrowser.cpp
@@ -225,13 +225,6 @@ class UpdateAddons : public IRunnable
   }
 };
 
-class UpdateRepos : public IRunnable
-{
-  virtual void Run()
-  {
-    CAddonInstaller::Get().UpdateRepos(true, true);
-  }
-};
 
 bool CGUIWindowAddonBrowser::OnClick(int iItem)
 {
@@ -245,14 +238,6 @@ bool CGUIWindowAddonBrowser::OnClick(int iItem)
     std::string path;
     if (CGUIDialogFileBrowser::ShowAndGetFile(shares, "*.zip", g_localizeStrings.Get(24041), path))
       CAddonInstaller::Get().InstallFromZip(path);
-    return true;
-  }
-  else if (item->GetPath() == "addons://check/")
-  {
-    // perform the check for updates
-    UpdateRepos updater;
-    if (CGUIDialogBusy::Wait(&updater))
-      Refresh();
     return true;
   }
   if (item->GetPath() == "addons://update_all/")

--- a/xbmc/addons/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/GUIWindowAddonBrowser.cpp
@@ -125,7 +125,7 @@ bool CGUIWindowAddonBrowser::OnMessage(CGUIMessage& message)
       }
       else if (iControl == CONTROL_CHECK_FOR_UPDATES)
       {
-        CAddonInstaller::Get().UpdateRepos(true);
+        CAddonInstaller::Get().UpdateRepos(true, false, true);
         return true;
       }
       else if (m_viewControl.HasControl(iControl))  // list/thumb control

--- a/xbmc/addons/Repository.h
+++ b/xbmc/addons/Repository.h
@@ -21,6 +21,7 @@
 
 #include "Addon.h"
 #include "utils/Job.h"
+#include "utils/ProgressJob.h"
 
 namespace ADDON
 {
@@ -64,7 +65,7 @@ namespace ADDON
     CRepository(const CRepository &rhs);
   };
 
-  class CRepositoryUpdateJob : public CJob
+  class CRepositoryUpdateJob : public CProgressJob
   {
   public:
     CRepositoryUpdateJob(const VECADDONS& repos);

--- a/xbmc/dialogs/GUIDialogExtendedProgressBar.cpp
+++ b/xbmc/dialogs/GUIDialogExtendedProgressBar.cpp
@@ -18,6 +18,7 @@
  *
  */
 
+#include <cmath>
 #include "GUIDialogExtendedProgressBar.h"
 #include "guilib/GUIProgressControl.h"
 #include "guilib/GUISliderControl.h"
@@ -53,11 +54,9 @@ void CGUIDialogProgressBarHandle::SetTitle(const string &strTitle)
 
 void CGUIDialogProgressBarHandle::SetProgress(int currentItem, int itemCount)
 {
-  float fPercentage = (float)((currentItem*100)/itemCount);
-  if (fPercentage > 100.0F)
-    fPercentage = 100.0F;
-
-  m_fPercentage = fPercentage;
+  float fPercentage = (currentItem*100.0f)/itemCount;
+  if (!std::isnan(fPercentage))
+    m_fPercentage = std::min(100.0f, fPercentage);
 }
 
 CGUIDialogExtendedProgressBar::CGUIDialogExtendedProgressBar(void)

--- a/xbmc/utils/ProgressJob.cpp
+++ b/xbmc/utils/ProgressJob.cpp
@@ -192,3 +192,8 @@ bool CProgressJob::IsCancelled() const
 
   return false;
 }
+
+bool CProgressJob::HasProgressIndicator() const
+{
+  return m_progress != nullptr || m_progressDialog != nullptr;
+}

--- a/xbmc/utils/ProgressJob.cpp
+++ b/xbmc/utils/ProgressJob.cpp
@@ -55,13 +55,10 @@ CProgressJob::~CProgressJob()
 
 bool CProgressJob::ShouldCancel(unsigned int progress, unsigned int total) const
 {
-  if (m_progressDialog != NULL)
-  {
-    if (IsCancelled())
-      return true;
+  if (IsCancelled())
+    return true;
 
-    SetProgress(progress, total);
-  }
+  SetProgress(progress, total);
 
   return CJob::ShouldCancel(progress, total);
 }

--- a/xbmc/utils/ProgressJob.h
+++ b/xbmc/utils/ProgressJob.h
@@ -59,6 +59,8 @@ public:
    */
   void SetProgressIndicators(CGUIDialogProgressBarHandle* progressBar, CGUIDialogProgress* progressDialog, bool updateProgress = true, bool updateInformation = true);
 
+  bool HasProgressIndicator() const;
+
 protected:
   CProgressJob();
   CProgressJob(CGUIDialogProgressBarHandle* progressBar);


### PR DESCRIPTION
Adds a background dialog indicating the progress of 'Check for updates' after it was moved to the side menu in #6602 and all visual feedback removed as a result of that.

cc @stefansaraev, @Montellese for review.
