### PR TITLE
[settings] only add separator for the very first group item if required

### DIFF
--- a/xbmc/settings/dialogs/GUIDialogSettingsBase.cpp
+++ b/xbmc/settings/dialogs/GUIDialogSettingsBase.cpp
@@ -521,13 +521,21 @@ std::set<std::string> CGUIDialogSettingsBase::CreateSettings()
     const CSettingControlTitle *title = dynamic_cast<CSettingControlTitle *>((*groupIt)->GetControl());
     bool hideSeparator = title ? title->IsSeparatorHidden() : false;
     bool separatorBelowGroupLabel = title ? title->IsSeparatorBelowLabel() : false;
+    int groupLabel = (*groupIt)->GetLabel();
+
+    // hide the separator for the first settings grouplist if it
+    // is the very first item in the list (also above the label)
     if (first)
+    {
       first = false;
+      if (groupLabel <= 0)
+        hideSeparator = true;
+    }
     else if (!separatorBelowGroupLabel && !hideSeparator)
       AddSeparator(group->GetWidth(), iControlID);
 
-    if ((*groupIt)->GetLabel() > 0)
-      AddLabel(group->GetWidth(), iControlID, (*groupIt)->GetLabel());
+    if (groupLabel > 0)
+      AddLabel(group->GetWidth(), iControlID, groupLabel);
 
     if (separatorBelowGroupLabel && !hideSeparator)
       AddSeparator(group->GetWidth(), iControlID);


### PR DESCRIPTION
this should fix the issue mentioned in #6926 by restoring the old behavior which was accidentally changed by #6818.

Please note that this is not yet compile or runtime tested as I currently lack a build env.

@uNiversaI @AlwinEsch 
