### PR TITLE
i.MX: allow other modes to be set as resolution.

### DIFF
--- a/xbmc/windowing/egl/EGLNativeTypeIMX.cpp
+++ b/xbmc/windowing/egl/EGLNativeTypeIMX.cpp
@@ -280,8 +280,6 @@ bool CEGLNativeTypeIMX::ProbeResolutions(std::vector<RESOLUTION_INFO> &resolutio
   RESOLUTION_INFO res;
   for (size_t i = 0; i < probe_str.size(); i++)
   {
-    if(!StringUtils::StartsWith(probe_str[i], "S:"))
-      continue;
     if(ModeToResolution(probe_str[i], &res))
       resolutions.push_back(res);
   }


### PR DESCRIPTION
- This has had no ill effect so far but allows some non-standard resolutions such as 1024x768 on DVI monitors.

Is there a reason that this is in here? I have seen problems with older kernels but with a stable LK 3.14 (which people / distributors should really be using), there seems to be no problems. 
