### PR TITLE
[FileUtils] add library://music path

### DIFF
--- a/xbmc/utils/FileUtils.cpp
+++ b/xbmc/utils/FileUtils.cpp
@@ -125,6 +125,8 @@ bool CFileUtils::RemoteAccessAllowed(const std::string &strPath)
     return true;
   else if (StringUtils::StartsWithNoCase(realPath, "library://video"))
     return true;
+  else if (StringUtils::StartsWithNoCase(realPath, "library://music"))
+    return true;
   else if (StringUtils::StartsWithNoCase(realPath, "sources://video"))
     return true;
   else if (StringUtils::StartsWithNoCase(realPath, "special://musicplaylists"))


### PR DESCRIPTION
library://music was introduced by https://github.com/xbmc/xbmc/pull/6772

i noticed json-rpc failed when trying to list the contents of this path when using Files.GetDirectory.
this commit fixes that issue.
