### PR TITLE
[GUIInfoManager] update label from fps to gui fps

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1748,14 +1748,14 @@ std::string CGUIInfoManager::GetLabel(int info, int contextWindow, std::string *
 
   case SYSTEM_SCREEN_RESOLUTION:
     if(g_Windowing.IsFullScreen())
-      strLabel = StringUtils::Format("%ix%i@%.2fHz - %s (%02.2f fps)",
+      strLabel = StringUtils::Format("%ix%i@%.2fHz - %s (%02.2f gui fps)",
         CDisplaySettings::Get().GetCurrentResolutionInfo().iScreenWidth,
         CDisplaySettings::Get().GetCurrentResolutionInfo().iScreenHeight,
         CDisplaySettings::Get().GetCurrentResolutionInfo().fRefreshRate,
         g_localizeStrings.Get(244).c_str(),
         GetFPS());
     else
-      strLabel = StringUtils::Format("%ix%i - %s (%02.2f fps)",
+      strLabel = StringUtils::Format("%ix%i - %s (%02.2f gui fps)",
         CDisplaySettings::Get().GetCurrentResolutionInfo().iScreenWidth,
         CDisplaySettings::Get().GetCurrentResolutionInfo().iScreenHeight,
         g_localizeStrings.Get(242).c_str(),


### PR DESCRIPTION
Since https://github.com/xbmc/xbmc/pull/6872 the system information is reporting ~ 4.88fps - 7.5fps which is correct since Default Dirty Regions is 3 which makes this low value  slightly confusing at first.
Setting dirty regions to 0 confirms this as FPS go up to ~59.94 - 60

With a label of gui fps to make it clear what the system information value reports.

~~This isnt runtime tested yet (linux), will test earliest things tomorrow and report back.~~

**Edit** Now tested.
![screenshot049](https://cloud.githubusercontent.com/assets/3521959/7105461/a5314776-e112-11e4-864b-8d49e4b8d7fe.png)

@FernetMenta 
