### PR TITLE
[epg] start epg container asynchronously

### DIFF
--- a/xbmc/epg/EpgContainer.h
+++ b/xbmc/epg/EpgContainer.h
@@ -74,8 +74,9 @@ namespace EPG
 
     /*!
      * @brief Start the EPG update thread.
+     * @param bAsync Should the EPG container starts asynchronously
      */
-    virtual void Start(void);
+    virtual void Start(bool bAsync);
 
     /*!
      * @brief Stop the EPG update thread.

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -332,7 +332,7 @@ bool CPVRManager::UpgradeOutdatedAddons(void)
   if (IsInitialising())
   {
     SetState(ManagerStateStarted);
-    g_EpgContainer.Start();
+    g_EpgContainer.Start(true);
 
     CLog::Log(LOGDEBUG, "PVRManager - %s - restarted", __FUNCTION__);
     return true;
@@ -508,9 +508,11 @@ void CPVRManager::Process(void)
 
   SetState(ManagerStateStarted);
 
+  /* start epg container */
+  g_EpgContainer.Start(true);
+
   /* main loop */
   CLog::Log(LOGDEBUG, "PVRManager - %s - entering main loop", __FUNCTION__);
-  g_EpgContainer.Start();
 
   /* activate startup window */
   if (m_openWindowId > 0)


### PR DESCRIPTION
As the title said this adds asynchronously start of the EPG container which do not block the entire PVR manager startup and results in a really fast resumption of playback for the last played channel if you enable "continue last played channel" in TV settings.

@opdenkamp or @Jalle19 ping
