### PR TITLE
[PVR] fix timersettings dialog

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -7955,9 +7955,7 @@ msgctxt "#19076"
 msgid "Folder:"
 msgstr ""
 
-msgctxt "#19077"
-msgid "Radio:"
-msgstr ""
+#empty string with id 19077
 
 msgctxt "#19078"
 msgid "Channel:"

--- a/addons/skin.confluence/720p/DialogPVRTimerSettings.xml
+++ b/addons/skin.confluence/720p/DialogPVRTimerSettings.xml
@@ -4,13 +4,13 @@
 	<coordinates>
 		<system>1</system>
 		<left>275</left>
-		<top>30</top>
+		<top>50</top>
 	</coordinates>
 	<include>dialogeffect</include>
 	<controls>
 		<include name="DialogBackgroundCommons">
 			<param name="DialogBackgroundWidth" value="730" />
-			<param name="DialogBackgroundHeight" value="660" />
+			<param name="DialogBackgroundHeight" value="620" />
 			<param name="DialogHeaderWidth" value="650" />
 			<param name="DialogHeaderLabel" value="$LOCALIZE[19065]" />
 			<param name="DialogHeaderId" value="2" />
@@ -31,7 +31,7 @@
 		</control>
 		<control type="group" id="9001">
 			<left>160</left>
-			<top>590</top>
+			<top>550</top>
 			<control type="button" id="28">
 				<description>OK Button</description>
 				<left>0</left>

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -84,25 +84,7 @@ void CGUIDialogPVRTimerSettings::OnSettingChanged(const CSetting *setting)
   if (settingId == SETTING_TMR_ACTIVE)
     m_bTimerActive = static_cast<const CSettingBool*>(setting)->GetValue();
   if (settingId == SETTING_TMR_CHNAME)
-  {
     m_selectedChannelEntry = static_cast<const CSettingInt*>(setting)->GetValue();
-
-    std::map<std::pair<bool, int>, int>::iterator itc = m_channelEntries.find(std::make_pair(tag->m_bIsRadio, m_selectedChannelEntry));
-    if (itc != m_channelEntries.end())
-    {
-      CPVRChannelPtr channel =  g_PVRChannelGroups->GetChannelById(itc->second);
-      if (channel)
-      {
-        tag->m_iClientChannelUid = channel->UniqueID();
-        tag->m_iClientId         = channel->ClientID();
-        tag->m_bIsRadio          = channel->IsRadio();
-        tag->m_iChannelNumber    = channel->ChannelNumber();
-       
-        // Update channel pointer from above values
-        tag->UpdateChannel();
-      }
-    }
-  }
   else if (settingId == SETTING_TMR_DAY)
   {
     m_tmp_day = static_cast<const CSettingInt*>(setting)->GetValue();
@@ -221,6 +203,23 @@ void CGUIDialogPVRTimerSettings::OnSettingAction(const CSetting *setting)
 void CGUIDialogPVRTimerSettings::Save()
 {
   CPVRTimerInfoTagPtr tag = m_timerItem->GetPVRTimerInfoTag();
+
+  // Set the timer's channel
+  std::map<std::pair<bool, int>, int>::iterator itc = m_channelEntries.find(std::make_pair(tag->m_bIsRadio, m_selectedChannelEntry));
+  if (itc != m_channelEntries.end())
+  {
+    CPVRChannelPtr channel =  g_PVRChannelGroups->GetChannelById(itc->second);
+    if (channel)
+    {
+      tag->m_iClientChannelUid = channel->UniqueID();
+      tag->m_iClientId         = channel->ClientID();
+      tag->m_bIsRadio          = channel->IsRadio();
+      tag->m_iChannelNumber    = channel->ChannelNumber();
+
+      // Update channel pointer from above values
+      tag->UpdateChannel();
+    }
+  }
 
   // Set the timer's title to the channel name if it's 'New Timer' or empty
   if (tag->m_strTitle == g_localizeStrings.Get(19056) || tag->m_strTitle.empty())

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -35,7 +35,7 @@
 using namespace PVR;
 
 #define SETTING_TMR_ACTIVE              "timer.active"
-#define SETTING_TMR_CHNAME_TV           "timer.tvchannelname"
+#define SETTING_TMR_CHNAME              "timer.channelname"
 #define SETTING_TMR_DAY                 "timer.day"
 #define SETTING_TMR_BEGIN               "timer.begin"
 #define SETTING_TMR_END                 "timer.end"
@@ -44,8 +44,6 @@ using namespace PVR;
 #define SETTING_TMR_FIRST_DAY           "timer.firstday"
 #define SETTING_TMR_NAME                "timer.name"
 #define SETTING_TMR_DIR                 "timer.directory"
-#define SETTING_TMR_RADIO               "timer.radio"
-#define SETTING_TMR_CHNAME_RADIO        "timer.radiochannelname"
 
 CGUIDialogPVRTimerSettings::CGUIDialogPVRTimerSettings(void)
   : CGUIDialogSettingsManualBase(WINDOW_DIALOG_PVR_TIMER_SETTING, "DialogPVRTimerSettings.xml"),
@@ -85,15 +83,9 @@ void CGUIDialogPVRTimerSettings::OnSettingChanged(const CSetting *setting)
   const std::string &settingId = setting->GetId();
   if (settingId == SETTING_TMR_ACTIVE)
     m_bTimerActive = static_cast<const CSettingBool*>(setting)->GetValue();
-  if (settingId == SETTING_TMR_RADIO || settingId == SETTING_TMR_CHNAME_TV || settingId == SETTING_TMR_CHNAME_RADIO)
+  if (settingId == SETTING_TMR_CHNAME)
   {
-    if (settingId == SETTING_TMR_RADIO)
-    {
-      tag->m_bIsRadio = static_cast<const CSettingBool*>(setting)->GetValue();
-      m_selectedChannelEntry = 0;
-    }
-    else
-      m_selectedChannelEntry = static_cast<const CSettingInt*>(setting)->GetValue();
+    m_selectedChannelEntry = static_cast<const CSettingInt*>(setting)->GetValue();
 
     std::map<std::pair<bool, int>, int>::iterator itc = m_channelEntries.find(std::make_pair(tag->m_bIsRadio, m_selectedChannelEntry));
     if (itc != m_channelEntries.end())
@@ -284,15 +276,9 @@ void CGUIDialogPVRTimerSettings::InitializeSettings()
   if (tag->SupportsFolders())
     AddEdit(group, SETTING_TMR_DIR, 19076, 0, tag->m_strDirectory, true, false, 19104);
 
-  AddToggle(group, SETTING_TMR_RADIO, 19077, 0, tag->m_bIsRadio);
-
   /// Channel names
   {
-    // For TV
-    AddChannelNames(group, false);
-
-    // For Radio
-    AddChannelNames(group, true);
+    AddChannelNames(group, tag->m_bIsRadio);
   }
 
   /// Day
@@ -363,17 +349,9 @@ CSetting* CGUIDialogPVRTimerSettings::AddChannelNames(CSettingGroup *group, bool
     }
   }
 
-  CSettingInt *setting = AddSpinner(group, bRadio ? SETTING_TMR_CHNAME_RADIO : SETTING_TMR_CHNAME_TV, 19078, 0, m_selectedChannelEntry, ChannelNamesOptionsFiller);
+  CSettingInt *setting = AddSpinner(group, SETTING_TMR_CHNAME, 19078, 0, m_selectedChannelEntry, ChannelNamesOptionsFiller);
   if (setting == NULL)
     return NULL;
-
-  // define an enable dependency with tag->m_bIsRadio
-  CSettingDependency depdendencyIsRadio(SettingDependencyTypeEnable, m_settingsManager);
-  depdendencyIsRadio.And()
-    ->Add(CSettingDependencyConditionPtr(new CSettingDependencyCondition(SETTING_TMR_RADIO, "true", SettingDependencyOperatorEquals, !bRadio, m_settingsManager)));
-  SettingDependencies deps;
-  deps.push_back(depdendencyIsRadio);
-  setting->SetDependencies(deps);
 
   return setting;
 }
@@ -486,7 +464,11 @@ void CGUIDialogPVRTimerSettings::ChannelNamesOptionsFiller(const CSetting *setti
   if (dialog == NULL)
     return;
 
-  dialog->getChannelNames(setting->GetId() == SETTING_TMR_CHNAME_RADIO, list, current, false);
+  const CPVRTimerInfoTagPtr tag = dialog->m_timerItem->GetPVRTimerInfoTag();
+  if (tag == NULL)
+    return;
+
+  dialog->getChannelNames(tag->m_bIsRadio, list, current, false);
 }
 
 void CGUIDialogPVRTimerSettings::DaysOptionsFiller(const CSetting *setting, std::vector< std::pair<std::string, int> > &list, int &current, void *data)


### PR DESCRIPTION
2 fixes:

1) Users should add radio timers is the radio section and tv timers in the tv section now radio and tv windows are separated. There is no need for both tv and radio channels in the same dialog anymore, it's just confusing. If you want to add a radio timer, you'll have to go to the radio section.

2) Adding a new timer on the 1st channel, so without adjusting the channel spinner will not set any channel and will throw this error: "ERROR: PVRTimers - AddTimer - no channel given"
