### PR TITLE
Application: Don't slow down videos rendered on GuiLayer

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2486,7 +2486,7 @@ void CApplication::FrameMove(bool processEvents, bool processGUI)
 #if defined(TARGET_RASPBERRY_PI) || defined(HAS_IMXVPU)
     // This code reduces rendering fps of the GUI layer when playing videos in fullscreen mode
     // it makes only sense on architectures with multiple layers
-    if (g_graphicsContext.IsFullScreenVideo() && !m_pPlayer->IsPausedPlayback())
+    if (g_graphicsContext.IsFullScreenVideo() && !m_pPlayer->IsPausedPlayback() && g_renderManager.IsVideoLayer())
       fps = CSettings::Get().GetInt("videoplayer.limitguiupdate");
 #endif
 


### PR DESCRIPTION
Fixup of: https://github.com/xbmc/xbmc/pull/6898

This broke sw decoding which happened in the GUI layer, which was slowed down.
