### PR TITLE
Fix potential endless loop

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4807,7 +4807,7 @@ void CApplication::CheckPlayingProgress()
   if (m_pPlayer->IsPlaying())
   {
     int iSpeed = g_application.m_pPlayer->GetPlaySpeed();
-    if (iSpeed < 1)
+    if (iSpeed < 0)
     {
       iSpeed *= -1;
       int iPower = 0;

--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -27,6 +27,9 @@ CApplicationPlayer::CApplicationPlayer()
 {
   m_iPlayerOPSeq = 0;
   m_eCurrentPlayer = EPC_NONE;
+  m_iAudioStream = -1;
+  m_iSubtitleStream = -1;
+  m_iPlaySpeed = 1;
 }
 
 std::shared_ptr<IPlayer> CApplicationPlayer::GetInternal() const


### PR DESCRIPTION
If CApplication::PlayFile is called with bRestart=true directly after start, CheckPlayingProgress can get stuck in an endless loop if m_iPlaySpeed is initialized with 0.
This PR fixes this by initializing CApplicationPlayer members and protects against the endless loop

```
(gdb) bt
#0  0x00671eb8 in CApplication::CheckPlayingProgress() ()
#1  0x006787e8 in CApplication::Process() ()
#2  0x003fe9fc in CGUIWindowManager::ProcessRenderLoop(bool) ()
#3  0x004d0744 in CGUIDialogBusy::WaitOnEvent(CEvent&, unsigned int, bool) ()
#4  0x0084544c in CDVDPlayer::OpenFile(CFileItem const&, CPlayerOptions const&) ()
#5  0x0068097c in CApplicationPlayer::OpenFile(CFileItem const&, CPlayerOptions const&) ()
#6  0x00673b80 in CApplication::PlayFile(CFileItem const&, bool) ()
```
