### PR TITLE
[confluence] update info formatting in SettingsSystemInfo - no core

### DIFF
--- a/addons/skin.confluence/720p/SettingsSystemInfo.xml
+++ b/addons/skin.confluence/720p/SettingsSystemInfo.xml
@@ -273,25 +273,14 @@
 					<label>-</label>
 					<font>font13</font>
 				</control>
-				<control type="label" id="52">
-					<description>Kodi Build Version</description>
-					<left>20</left>
-					<top>400</top>
-					<width>730</width>
-					<label>144</label>
-					<align>right</align>
-					<textcolor>blue</textcolor>
-					<shadowcolor>black</shadowcolor>
-					<font>font13_title</font>
-				</control>
 				<control type="label">
 					<description>CPU Text</description>
-					<left>70</left>
-					<top>450</top>
-					<width>350</width>
+					<left>0</left>
+					<top>380</top>
+					<width>750</width>
 					<height>25</height>
 					<label>$LOCALIZE[13271] $INFO[System.CPUUsage]</label>
-					<align>right</align>
+					<align>left</align>
 					<aligny>center</aligny>
 					<textcolor>white</textcolor>
 					<shadowcolor>black</shadowcolor>
@@ -299,20 +288,20 @@
 				</control>
 				<control type="progress">
 					<description>CPU BAR</description>
-					<left>430</left>
-					<top>455</top>
-					<width>320</width>
+					<left>0</left>
+					<top>405</top>
+					<width>750</width>
 					<height>16</height>
 					<info>System.CPUUsage</info>
 				</control>
 				<control type="label">
 					<description>Memory Text</description>
-					<left>70</left>
-					<top>480</top>
-					<width>350</width>
+					<left>0</left>
+					<top>425</top>
+					<width>auto</width>
 					<height>25</height>
-					<label>$LOCALIZE[31309] $INFO[system.memory(used.percent)]</label>
-					<align>right</align>
+					<label>$LOCALIZE[31309] $INFO[system.memory(used)] [B]/[/B] $INFO[system.memory(total)] [B]-[/B] $INFO[system.memory(used.percent)]</label>
+					<align>left</align>
 					<aligny>center</aligny>
 					<textcolor>white</textcolor>
 					<shadowcolor>black</shadowcolor>
@@ -320,11 +309,22 @@
 				</control>
 				<control type="progress">
 					<description>Memory BAR</description>
-					<left>430</left>
-					<top>485</top>
-					<width>320</width>
+					<left>0</left>
+					<top>450</top>
+					<width>750</width>
 					<height>16</height>
 					<info>system.memory(used)</info>
+				</control>
+				<control type="label" id="52">
+					<description>Kodi Build Version</description>
+					<left>0</left>
+					<top>480</top>
+					<width>730</width>
+					<label>144</label>
+					<align>left</align>
+					<textcolor>blue</textcolor>
+					<shadowcolor>black</shadowcolor>
+					<font>font13_title</font>
 				</control>
 			</control>
 		</control>


### PR DESCRIPTION
This change is mostly cosmetic and makes all cores visible in systeminfo.
Keeping old formatting wasnt enterily possible if alignment between end of cpu text and memory info text no longer aligned before start of the BARs

This way it all aligns and gives it room to breath.

Goes from this

![screenshot048](https://cloud.githubusercontent.com/assets/3521959/7136826/45fdc19e-e2ac-11e4-845c-c251c516f74e.png)

updated after comments - newer screenshot at bottom post memory info updated.
![screenshot076](https://cloud.githubusercontent.com/assets/3521959/7200272/57da952e-e4f3-11e4-85ce-cc3a02b570d2.png)

The kodi version string no longer feels out of place like this as well, I tried keeping it at the top but somehow felt awkward like before as well.

@da-anda @ronie
