### PR TITLE
Don't treat smb connections to same machine as a local path

### DIFF
--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -501,7 +501,10 @@ const std::string CURL::GetFileNameWithoutPath() const
 char CURL::GetDirectorySeparator() const
 {
 #ifndef TARGET_POSIX
-  if ( IsLocal() )
+  //We don't want to use IsLocal here, it can return true
+  //for network protocols that matches localhost or hostname
+  //we only ever want to use \ for win32 local filesystem
+  if ( m_strProtocol.empty() )
     return '\\';
   else
 #endif


### PR DESCRIPTION
When connecting through smb to the same host the path would be identified as a local path and GetDirectorySeparator would return \ instead of /. This resulted in m_strShareName getting a trailing / which caused checks for it to fail since there's no such folder.
