### PR TITLE
android: Fix the readme to reflect the changes to bump SDK to 17

### DIFF
--- a/tools/depends/README
+++ b/tools/depends/README
@@ -14,9 +14,9 @@ IOS:
 
 Android (the pathes are examples and have to match those of docs/READM.android):
   arm:
-    ./configure --with-tarballs=/opt/xbmc-tarballs --host=arm-linux-androideabi --with-sdk-path=/opt/android-sdk-linux --with-ndk=/opt/android-ndk-r10d --with-toolchain=/opt/arm-linux-androideabi-4.8-vanilla/android-14 --prefix=/opt/xbmc-depends
+    ./configure --with-tarballs=/opt/xbmc-tarballs --host=arm-linux-androideabi --with-sdk-path=/opt/android-sdk-linux --with-ndk=/opt/android-ndk-r10d --with-toolchain=/opt/arm-linux-androideabi-4.8-vanilla/android-17 --prefix=/opt/xbmc-depends
   x86:
-    ./configure --with-tarballs=/opt/xbmc-tarballs --host=i686-linux-android --with-sdk-path=/opt/android-sdk-linux --with-ndk=/opt/android-ndk-r10d --with-toolchain=/opt/x86-linux-4.8-vanilla/android-14 --prefix=/opt/xbmc-depends
+    ./configure --with-tarballs=/opt/xbmc-tarballs --host=i686-linux-android --with-sdk-path=/opt/android-sdk-linux --with-ndk=/opt/android-ndk-r10d --with-toolchain=/opt/x86-linux-4.8-vanilla/android-17 --prefix=/opt/xbmc-depends
 
   
 

--- a/tools/depends/configure.ac
+++ b/tools/depends/configure.ac
@@ -46,7 +46,7 @@ AC_ARG_WITH([sdk-path],
 
 AC_ARG_WITH([sdk],
   [AS_HELP_STRING([--with-sdk],
-  [spcify sdk platform version (optional for android). default is android-14])],
+  [spcify sdk platform version (optional for android). default is android-17])],
   [use_sdk=$withval])
 
 AC_ARG_ENABLE([gplv3],


### PR DESCRIPTION
The ndk toolchains are now in /android-17 so if someone was new to
compiling and strictly followed the readme they would end up with
and invalid path for the ndk toolchain when doing ./configure.
