### PR TITLE
[rbp] Disable analogue output of sink when passthrough is enabled

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkPi.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPi.cpp
@@ -45,7 +45,8 @@ CAESinkPi::CAESinkPi() :
     m_sinkbuffer_sec_per_byte(0),
     m_Initialized(false),
     m_submitted(0),
-    m_omx_output(NULL)
+    m_omx_output(NULL),
+    m_output(AESINKPI_UNKNOWN)
 {
 }
 
@@ -60,7 +61,7 @@ void CAESinkPi::SetAudioDest()
   OMX_INIT_STRUCTURE(audioDest);
   if ( m_omx_render.IsInitialized() )
   {
-    if (CSettings::Get().GetString("audiooutput.audiodevice") == "PI:Analogue")
+    if (m_output == AESINKPI_ANALOGUE)
       strncpy((char *)audioDest.sName, "local", strlen("local"));
     else
       strncpy((char *)audioDest.sName, "hdmi", strlen("hdmi"));
@@ -70,7 +71,7 @@ void CAESinkPi::SetAudioDest()
   }
   if ( m_omx_render_slave.IsInitialized() )
   {
-    if (CSettings::Get().GetString("audiooutput.audiodevice") != "PI:Analogue")
+    if (m_output != AESINKPI_ANALOGUE)
       strncpy((char *)audioDest.sName, "local", strlen("local"));
     else
       strncpy((char *)audioDest.sName, "hdmi", strlen("hdmi"));
@@ -190,12 +191,17 @@ bool CAESinkPi::Initialize(AEAudioFormat &format, std::string &device)
   m_initDevice = device;
   m_initFormat = format;
 
+  if (m_passthrough || CSettings::Get().GetString("audiooutput.audiodevice") == "PI:HDMI")
+    m_output = AESINKPI_HDMI;
+  else if (CSettings::Get().GetString("audiooutput.audiodevice") == "PI:Analogue")
+    m_output = AESINKPI_ANALOGUE;
+  else if (CSettings::Get().GetString("audiooutput.audiodevice") == "PI:Both")
+    m_output = AESINKPI_BOTH;
+  else assert(0);
+
   // analogue only supports stereo
-  if (CSettings::Get().GetString("audiooutput.audiodevice") == "PI:Analogue" || CSettings::Get().GetString("audiooutput.audiodevice") == "PI:Both")
-  {
+  if (m_output == AESINKPI_ANALOGUE || m_output == AESINKPI_BOTH)
     format.m_channelLayout = AE_CH_LAYOUT_2_0;
-    m_passthrough = false;
-  }
 
   // setup for a 50ms sink feed from SoftAE
   if (format.m_dataFormat != AE_FMT_FLOATP && format.m_dataFormat != AE_FMT_FLOAT &&
@@ -223,7 +229,7 @@ bool CAESinkPi::Initialize(AEAudioFormat &format, std::string &device)
   if (!m_omx_render.Initialize("OMX.broadcom.audio_render", OMX_IndexParamAudioInit))
     CLog::Log(LOGERROR, "%s::%s - m_omx_render.Initialize omx_err(0x%08x)", CLASSNAME, __func__, omx_err);
 
-  if (CSettings::Get().GetString("audiooutput.audiodevice") == "PI:Both")
+  if (m_output == AESINKPI_BOTH)
   {
     if (!m_omx_splitter.Initialize("OMX.broadcom.audio_splitter", OMX_IndexParamAudioInit))
       CLog::Log(LOGERROR, "%s::%s - m_omx_splitter.Initialize omx_err(0x%08x)", CLASSNAME, __func__, omx_err);

--- a/xbmc/cores/AudioEngine/Sinks/AESinkPi.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPi.h
@@ -64,6 +64,7 @@ private:
   bool                 m_passthrough;
   COMXCoreTunel        m_omx_tunnel_splitter;
   COMXCoreTunel        m_omx_tunnel_splitter_slave;
+  enum { AESINKPI_UNKNOWN, AESINKPI_HDMI, AESINKPI_ANALOGUE, AESINKPI_BOTH } m_output;
 };
 
 #endif

--- a/xbmc/cores/omxplayer/OMXAudio.cpp
+++ b/xbmc/cores/omxplayer/OMXAudio.cpp
@@ -88,7 +88,8 @@ COMXAudio::COMXAudio() :
   m_extrasize       (0      ),
   m_last_pts        (DVD_NOPTS_VALUE),
   m_submitted_eos   (false  ),
-  m_failed_eos      (false  )
+  m_failed_eos      (false  ),
+  m_output          (AESINKPI_UNKNOWN)
 {
   CAEFactory::Suspend();
   while (!CAEFactory::IsSuspended())
@@ -119,17 +120,17 @@ bool COMXAudio::PortSettingsChanged()
     if(!m_omx_mixer.Initialize("OMX.broadcom.audio_mixer", OMX_IndexParamAudioInit))
       return false;
   }
-  if(CSettings::Get().GetString("audiooutput.audiodevice") == "PI:Both")
+  if(m_output == AESINKPI_BOTH)
   {
     if(!m_omx_splitter.Initialize("OMX.broadcom.audio_splitter", OMX_IndexParamAudioInit))
       return false;
   }
-  if (CSettings::Get().GetString("audiooutput.audiodevice") == "PI:Both" || CSettings::Get().GetString("audiooutput.audiodevice") == "PI:Analogue")
+  if (m_output == AESINKPI_BOTH || m_output == AESINKPI_ANALOGUE)
   {
     if(!m_omx_render_analog.Initialize("OMX.broadcom.audio_render", OMX_IndexParamAudioInit))
       return false;
   }
-  if (CSettings::Get().GetString("audiooutput.audiodevice") == "PI:Both" || CSettings::Get().GetString("audiooutput.audiodevice") != "PI:Analogue")
+  if (m_output == AESINKPI_BOTH || m_output != AESINKPI_ANALOGUE)
   {
     if(!m_omx_render_hdmi.Initialize("OMX.broadcom.audio_render", OMX_IndexParamAudioInit))
       return false;
@@ -247,7 +248,7 @@ bool COMXAudio::PortSettingsChanged()
   {
     // By default audio_render is the clock master, and if output samples don't fit the timestamps, it will speed up/slow down the clock.
     // This tends to be better for maintaining audio sync and avoiding audio glitches, but can affect video/display sync
-    if(CSettings::Get().GetBool("videoplayer.usedisplayasclock") || CSettings::Get().GetString("audiooutput.audiodevice") == "PI:Both")
+    if(CSettings::Get().GetBool("videoplayer.usedisplayasclock") || m_output == AESINKPI_BOTH)
     {
       OMX_CONFIG_BOOLEANTYPE configBool;
       OMX_INIT_STRUCTURE(configBool);
@@ -569,6 +570,14 @@ bool COMXAudio::Initialize(AEAudioFormat format, OMXClock *clock, CDVDStreamInfo
   }
   SetCodingType(format.m_dataFormat);
 
+  if (m_Passthrough || CSettings::Get().GetString("audiooutput.audiodevice") == "PI:HDMI")
+    m_output = AESINKPI_HDMI;
+  else if (CSettings::Get().GetString("audiooutput.audiodevice") == "PI:Analogue")
+    m_output = AESINKPI_ANALOGUE;
+  else if (CSettings::Get().GetString("audiooutput.audiodevice") == "PI:Both")
+    m_output = AESINKPI_BOTH;
+  else assert(0);
+
   if(hints.extrasize > 0 && hints.extradata != NULL)
   {
     m_extrasize = hints.extrasize;
@@ -596,7 +605,7 @@ bool COMXAudio::Initialize(AEAudioFormat format, OMXClock *clock, CDVDStreamInfo
     CAEChannelInfo stdLayout = (enum AEStdChLayout)CSettings::Get().GetInt("audiooutput.channels");
 
     // ignore layout setting for analogue
-    if (CSettings::Get().GetString("audiooutput.audiodevice") == "PI:Both" || CSettings::Get().GetString("audiooutput.audiodevice") == "PI:Analogue")
+    if (m_output == AESINKPI_ANALOGUE || m_output == AESINKPI_BOTH)
       stdLayout = AE_CH_LAYOUT_2_0;
 
     // force out layout to stereo if input is not multichannel - it gives the receiver a chance to upmix

--- a/xbmc/cores/omxplayer/OMXAudio.h
+++ b/xbmc/cores/omxplayer/OMXAudio.h
@@ -124,6 +124,7 @@ private:
   double        m_last_pts;
   bool          m_submitted_eos;
   bool          m_failed_eos;
+  enum { AESINKPI_UNKNOWN, AESINKPI_HDMI, AESINKPI_ANALOGUE, AESINKPI_BOTH } m_output;
 
   typedef struct {
     double pts;


### PR DESCRIPTION
The analogue and output of Pi Sink doesn't support passthrough.
This also applies to the 'Both' (HDMI and Analogue) setting.
If passthrough is enabled in GUI you get black screen and errors:
https://discourse.osmc.tv/t/some-streams-are-staying-black/2311

We need to either disable passthrough or disable analogue.

I think the best solution to this is to force HDMI output when passthrough is active.

This allows a user to use receiver for videos with dts/ac3 and TV for music or lower quality formats.
