### PR TITLE
[rbp] Add Pi 2 specific settings defaults

### DIFF
--- a/system/settings/rbp2.xml
+++ b/system/settings/rbp2.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<settings>
+  <section id="videos">
+    <category id="videoacceleration">
+      <group id="3">
+        <setting id="videoplayer.useomxplayer">
+          <default>false</default>
+        </setting>
+      </group>
+    </category>
+  </section>
+
+  <section id="system">
+    <category id="videoscreen">
+      <group id="1">
+        <setting id="videoscreen.textures32">
+          <default>true</default>
+        </setting>
+      </group>
+    </category>
+    <category id="audiooutput">
+      <group id="3">
+        <setting id="audiooutput.ac3transcode" help="36429">
+        </setting>
+      </group>
+    </category>
+  </section>
+</settings>

--- a/xbmc/linux/RBP.h
+++ b/xbmc/linux/RBP.h
@@ -37,6 +37,7 @@
 #if defined(TARGET_RASPBERRY_PI)
 #include "DllBCM.h"
 #include "OMXCore.h"
+#include "xbmc/utils/CPUInfo.h"
 #include "threads/CriticalSection.h"
 
 class CRBP
@@ -51,6 +52,7 @@ public:
   int GetArmMem() { return m_arm_mem; }
   int GetGpuMem() { return m_gpu_mem; }
   bool GetCodecMpg2() { return m_codec_mpg2_enabled; }
+  int RasberryPiVersion() { return g_cpuInfo.getCPUCount() == 1 ? 1 : 2; };
   bool GetCodecWvc1() { return m_codec_wvc1_enabled; }
   void GetDisplaySize(int &width, int &height);
   int GetGUIResolutionLimit() { return m_gui_resolution_limit; }

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -49,6 +49,9 @@
 #if defined(TARGET_DARWIN)
 #include "osx/DarwinUtils.h"
 #endif
+#if defined(TARGET_RASPBERRY_PI)
+#include "linux/RBP.h"
+#endif
 #include "peripherals/Peripherals.h"
 #include "powermanagement/PowerManager.h"
 #include "profiles/ProfilesManager.h"
@@ -456,6 +459,8 @@ bool CSettings::InitializeDefinitions()
 #elif defined(TARGET_RASPBERRY_PI)
   if (CFile::Exists(SETTINGS_XML_FOLDER "rbp.xml") && !Initialize(SETTINGS_XML_FOLDER "rbp.xml"))
     CLog::Log(LOGFATAL, "Unable to load rbp-specific settings definitions");
+  if (g_RBP.RasberryPiVersion() > 1 && CFile::Exists(SETTINGS_XML_FOLDER "rbp2.xml") && !Initialize(SETTINGS_XML_FOLDER "rbp2.xml"))
+    CLog::Log(LOGFATAL, "Unable to load rbp2-specific settings definitions");
 #elif defined(TARGET_FREEBSD)
   if (CFile::Exists(SETTINGS_XML_FOLDER "freebsd.xml") && !Initialize(SETTINGS_XML_FOLDER "freebsd.xml"))
     CLog::Log(LOGFATAL, "Unable to load freebsd-specific settings definitions");


### PR DESCRIPTION
The Pi2 has fewer limitations compared to the Pi1 so some
settings defaults should be changed.

This disables omxplayer by default as dvdplayer is pretty usable on Pi2
We no longer need to warn against using ac3 transcode as it works fine
We now default textures to 32bpp
