### PR TITLE
[rbp/mmal] A collection of MMAL fixes from newclock4

### DIFF
--- a/xbmc/cores/VideoRenderers/MMALRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/MMALRenderer.cpp
@@ -510,6 +510,8 @@ bool CMMALRenderer::Supports(EDEINTERLACEMODE mode)
 
 bool CMMALRenderer::Supports(EINTERLACEMETHOD method)
 {
+  if (method == VS_INTERLACEMETHOD_AUTO)
+    return true;
   if (method == VS_INTERLACEMETHOD_MMAL_ADVANCED)
     return true;
   if (method == VS_INTERLACEMETHOD_MMAL_ADVANCED_HALF)

--- a/xbmc/cores/VideoRenderers/MMALRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/MMALRenderer.cpp
@@ -46,9 +46,8 @@ static void vout_control_port_cb(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer
 
 void CMMALRenderer::vout_input_port_cb(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer)
 {
-  CMMALVideoBuffer *omvb = (CMMALVideoBuffer *)buffer->user_data;
-
   #if defined(MMAL_DEBUG_VERBOSE)
+  CMMALVideoBuffer *omvb = (CMMALVideoBuffer *)buffer->user_data;
   CLog::Log(LOGDEBUG, "%s::%s port:%p buffer %p (%p), len %d cmd:%x", CLASSNAME, __func__, port, buffer, omvb, buffer->length, buffer->cmd);
   #endif
 
@@ -305,7 +304,7 @@ void CMMALRenderer::ReleaseBuffer(int idx)
     return;
 
 #if defined(MMAL_DEBUG_VERBOSE)
-  CLog::Log(LOGDEBUG, "%s::%s - %d", CLASSNAME, __func__, idx);
+  CLog::Log(LOGDEBUG, "%s::%s - %d (%p)", CLASSNAME, __func__, idx, m_buffers[idx].MMALBuffer);
 #endif
   YUVBUFFER &buf = m_buffers[idx];
   SAFE_RELEASE(buf.MMALBuffer);
@@ -314,7 +313,7 @@ void CMMALRenderer::ReleaseBuffer(int idx)
 void CMMALRenderer::ReleaseImage(int source, bool preserve)
 {
 #if defined(MMAL_DEBUG_VERBOSE)
-  CLog::Log(LOGDEBUG, "%s::%s - %d %d", CLASSNAME, __func__, source, preserve);
+  CLog::Log(LOGDEBUG, "%s::%s - %d %d (%p)", CLASSNAME, __func__, source, preserve, m_buffers[source].MMALBuffer);
 #endif
 }
 

--- a/xbmc/cores/VideoRenderers/MMALRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/MMALRenderer.cpp
@@ -150,6 +150,8 @@ CMMALRenderer::CMMALRenderer()
   memset(m_buffers, 0, sizeof m_buffers);
   mmal_buffer_header_reset(&m_quit_packet);
   m_release_queue = mmal_queue_create();
+  m_iFlags = 0;
+  m_format = RENDER_FMT_NONE;
   m_iYV12RenderBuffer = 0;
   Create();
 }

--- a/xbmc/cores/VideoRenderers/MMALRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/MMALRenderer.cpp
@@ -374,7 +374,9 @@ void CMMALRenderer::RenderUpdate(bool clear, DWORD flags, DWORD alpha)
       omvb->Acquire();
       omvb->mmal_buffer->flags |= MMAL_BUFFER_HEADER_FLAG_USER1 | MMAL_BUFFER_HEADER_FLAG_USER2;
       mmal_port_send_buffer(m_vout_input, omvb->mmal_buffer);
-    } else assert(0);
+    }
+    else
+      CLog::Log(LOGDEBUG, "%s::%s - No buffer to update", CLASSNAME, __func__);
   }
   else if (m_format == RENDER_FMT_YUV420P)
   {
@@ -388,7 +390,8 @@ void CMMALRenderer::RenderUpdate(bool clear, DWORD flags, DWORD alpha)
       buffer->mmal_buffer->flags |= MMAL_BUFFER_HEADER_FLAG_USER1;
       mmal_port_send_buffer(m_vout_input, buffer->mmal_buffer);
     }
-    else assert(0);
+    else
+      CLog::Log(LOGDEBUG, "%s::%s - No buffer to update", CLASSNAME, __func__);
   }
   else assert(0);
 }
@@ -423,6 +426,7 @@ unsigned int CMMALRenderer::PreInit()
   m_formats.push_back(RENDER_FMT_MMAL);
   m_formats.push_back(RENDER_FMT_BYPASS);
 
+  memset(m_buffers, 0, sizeof m_buffers);
   m_iYV12RenderBuffer = 0;
   m_NumYV12Buffers = NUM_BUFFERS;
 

--- a/xbmc/cores/VideoRenderers/MMALRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/MMALRenderer.cpp
@@ -178,6 +178,7 @@ void CMMALRenderer::AddProcessor(CMMALVideoBuffer *buffer, int index)
 
 bool CMMALRenderer::Configure(unsigned int width, unsigned int height, unsigned int d_width, unsigned int d_height, float fps, unsigned flags, ERenderFormat format, unsigned extended_format, unsigned int orientation)
 {
+  bool formatChanged = m_format != format;
   ReleaseBuffers();
 
   m_sourceWidth  = width;
@@ -230,9 +231,10 @@ bool CMMALRenderer::Configure(unsigned int width, unsigned int height, unsigned 
       else if (CONF_FLAGS_YUVCOEF_MASK(m_iFlags) == CONF_FLAGS_YUVCOEF_240M)
         es_format->es->video.color_space = MMAL_COLOR_SPACE_SMPTE240M;
     }
-    if (m_bConfigured)
+    if (m_bConfigured && formatChanged)
       UnInitMMAL();
-    m_bConfigured = init_vout(es_format);
+    if (!m_bConfigured)
+      m_bConfigured = init_vout(es_format);
     mmal_format_free(es_format);
   }
   else

--- a/xbmc/cores/VideoRenderers/MMALRenderer.h
+++ b/xbmc/cores/VideoRenderers/MMALRenderer.h
@@ -49,7 +49,6 @@ class CMMALRenderer : public CBaseRenderer, public CThread
   {
     CMMALVideoBuffer *MMALBuffer; // used for hw decoded buffers
     MMAL_BUFFER_HEADER_T *mmal_buffer;  // used for sw decoded buffers
-    unsigned flipindex; /* used to decide if this has been uploaded */
   };
 public:
   CMMALRenderer();

--- a/xbmc/cores/VideoRenderers/MMALRenderer.h
+++ b/xbmc/cores/VideoRenderers/MMALRenderer.h
@@ -117,7 +117,7 @@ protected:
   CEvent            m_sync;
   MMAL_BUFFER_HEADER_T m_quit_packet;
 
-  bool init_vout(MMAL_ES_FORMAT_T *m_format);
+  bool init_vout(ERenderFormat format);
   void ReleaseBuffers();
   void UnInitMMAL();
 };

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/MMALCodec.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/MMALCodec.cpp
@@ -273,7 +273,6 @@ void CMMALVideo::dec_output_port_cb(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buf
       else
       {
         CMMALVideoBuffer *omvb = new CMMALVideoBuffer(this);
-        m_output_busy++;
         if (g_advancedSettings.CanLogComponent(LOGVIDEO))
           CLog::Log(LOGDEBUG, "%s::%s - %p (%p) buffer_size(%u) dts:%.3f pts:%.3f flags:%x:%x frame:%d",
             CLASSNAME, __func__, buffer, omvb, buffer->length, dts*1e-6, buffer->pts*1e-6, buffer->flags, buffer->type->video.flags, omvb->m_changed_count);
@@ -285,6 +284,7 @@ void CMMALVideo::dec_output_port_cb(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buf
         omvb->height = m_decoded_height;
         omvb->m_aspect_ratio = m_aspect_ratio;
         pthread_mutex_lock(&m_output_mutex);
+        m_output_busy++;
         m_output_ready.push(omvb);
         pthread_mutex_unlock(&m_output_mutex);
         kept = true;

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/MMALCodec.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/MMALCodec.cpp
@@ -895,7 +895,7 @@ int CMMALVideo::Decode(uint8_t* pData, int iSize, double dts, double pts)
 
          bool deinterlace = m_interlace_mode != MMAL_InterlaceProgressive;
 
-         if (m_hints.stills || deinterlace_request == VS_DEINTERLACEMODE_OFF)
+         if (m_hints.stills || deinterlace_request == VS_DEINTERLACEMODE_OFF || interlace_method == VS_INTERLACEMETHOD_NONE)
            deinterlace = false;
          else if (deinterlace_request == VS_DEINTERLACEMODE_FORCE)
            deinterlace = true;

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/MMALCodec.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/MMALCodec.cpp
@@ -832,7 +832,7 @@ int CMMALVideo::Decode(uint8_t* pData, int iSize, double dts, double pts)
 
        mmal_buffer_header_reset(buffer);
        buffer->cmd = 0;
-       if (m_startframe && pts == DVD_NOPTS_VALUE)
+       if (!m_startframe && pts == DVD_NOPTS_VALUE)
          pts = 0;
        buffer->pts = pts == DVD_NOPTS_VALUE ? MMAL_TIME_UNKNOWN : pts;
        buffer->dts = dts == DVD_NOPTS_VALUE ? MMAL_TIME_UNKNOWN : dts;

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/MMALCodec.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/MMALCodec.cpp
@@ -55,7 +55,6 @@ CMMALVideoBuffer::CMMALVideoBuffer(CMMALVideo *omv)
   mmal_buffer = NULL;
   width = 0;
   height = 0;
-  index = 0;
   m_aspect_ratio = 0.0f;
   m_changed_count = 0;
   dts = DVD_NOPTS_VALUE;
@@ -110,7 +109,6 @@ CMMALVideo::CMMALVideo()
   m_startframe = false;
   m_decoderPts = DVD_NOPTS_VALUE;
   m_droppedPics = 0;
-  m_decode_frame_number = 1;
 
   m_dec = NULL;
   m_dec_input = NULL;
@@ -837,7 +835,6 @@ int CMMALVideo::Decode(uint8_t* pData, int iSize, double dts, double pts)
        buffer->pts = pts == DVD_NOPTS_VALUE ? MMAL_TIME_UNKNOWN : pts;
        buffer->dts = dts == DVD_NOPTS_VALUE ? MMAL_TIME_UNKNOWN : dts;
        buffer->length = demuxer_bytes > buffer->alloc_size ? buffer->alloc_size : demuxer_bytes;
-       buffer->user_data = (void *)m_decode_frame_number;
        // set a flag so we can identify primary frames from generated frames (deinterlace)
        buffer->flags = MMAL_BUFFER_HEADER_FLAG_USER0;
 
@@ -866,7 +863,6 @@ int CMMALVideo::Decode(uint8_t* pData, int iSize, double dts, double pts)
        if (demuxer_bytes == 0)
        {
          pthread_mutex_lock(&m_output_mutex);
-         m_decode_frame_number++;
          m_startframe = true;
          if (m_drop_state)
          {
@@ -987,7 +983,6 @@ void CMMALVideo::Reset(void)
 
   m_startframe = false;
   m_decoderPts = DVD_NOPTS_VALUE;
-  m_decode_frame_number = 1;
   m_preroll = !m_hints.stills && (m_speed == DVD_PLAYSPEED_NORMAL || m_speed == DVD_PLAYSPEED_PAUSE);
 }
 

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/MMALCodec.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/MMALCodec.cpp
@@ -999,7 +999,8 @@ void CMMALVideo::ReturnBuffer(CMMALVideoBuffer *buffer)
 {
   if (g_advancedSettings.CanLogComponent(LOGVIDEO))
     CLog::Log(LOGDEBUG, "%s::%s %p (%d)", CLASSNAME, __func__, buffer, m_output_busy);
-
+  // sanity check it is not on display
+  assert(!(buffer->mmal_buffer->flags & MMAL_BUFFER_HEADER_FLAG_USER2));
   mmal_buffer_header_release(buffer->mmal_buffer);
 }
 

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/MMALCodec.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/MMALCodec.h
@@ -103,7 +103,6 @@ public:
 
 protected:
   void QueryCodec(void);
-  void ReturnBuffer(CMMALVideoBuffer *buffer);
   bool CreateDeinterlace(EINTERLACEMETHOD interlace_method);
   bool DestroyDeinterlace();
 

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/MMALCodec.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/MMALCodec.h
@@ -55,7 +55,6 @@ public:
   int width;
   int height;
   float m_aspect_ratio;
-  int index;
   double dts;
   uint32_t m_changed_count;
   // reference counting
@@ -126,7 +125,6 @@ protected:
   pthread_mutex_t   m_output_mutex;
   int m_output_busy;
   std::queue<CMMALVideoBuffer*> m_output_ready;
-  std::vector<CMMALVideoBuffer*> m_output_buffers;
 
   // initialize mmal and get decoder component
   bool Initialize( const std::string &decoder_name);
@@ -138,7 +136,6 @@ protected:
   MMAL_INTERLACETYPE_T m_interlace_mode;
   EINTERLACEMETHOD  m_interlace_method;
   bool              m_startframe;
-  unsigned int      m_decode_frame_number;
   double            m_decoderPts;
   unsigned int      m_droppedPics;
   int               m_speed;

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/MMALCodec.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/MMALCodec.h
@@ -98,6 +98,7 @@ public:
   // MMAL decoder callback routines.
   void dec_output_port_cb(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer);
   void dec_control_port_cb(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer);
+  void dec_input_port_cb(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer);
   uint32_t          m_changed_count;
   uint32_t          m_changed_count_dec;
 


### PR DESCRIPTION
The submitting buffers twice and reset of m_buffers on PreInit are proper crash and burn bugs.
The fast deinterlace change saves two frame buffers (6M) in some circumstances.
The resolution change makes resolution changes cleaner.
Others are just tidy-ups.
