### PR TITLE
CLangInfo: fix GetMeridiemSymbol to return the proper string based on the current 12/24-hour clock settings

### DIFF
--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -895,6 +895,15 @@ const std::string& CLangInfo::GetTimeZone() const
 // Returns the AM/PM symbol of the current language
 const std::string& CLangInfo::GetMeridiemSymbol(MeridiemSymbol symbol) const
 {
+  // nothing to return if we use 24-hour clock
+  if (m_use24HourClock)
+    return StringUtils::Empty;
+
+  return MeridiemSymbolToString(symbol);
+}
+
+const std::string& CLangInfo::MeridiemSymbolToString(MeridiemSymbol symbol)
+{
   switch (symbol)
   {
   case MeridiemSymbolAM:

--- a/xbmc/LangInfo.h
+++ b/xbmc/LangInfo.h
@@ -154,6 +154,7 @@ public:
   void Set24HourClock(bool use24HourClock);
   void Set24HourClock(const std::string& str24HourClock);
   const std::string& GetMeridiemSymbol(MeridiemSymbol symbol) const;
+  static const std::string& MeridiemSymbolToString(MeridiemSymbol symbol);
 
   CTemperature::Unit GetTemperatureUnit() const;
   void SetTemperatureUnit(CTemperature::Unit temperatureUnit);

--- a/xbmc/XBDateTime.cpp
+++ b/xbmc/XBDateTime.cpp
@@ -1115,7 +1115,7 @@ std::string CDateTime::GetAsLocalizedTime(const std::string &format, bool withSe
   GetAsSystemTime(dateTime);
 
   // Prefetch meridiem symbol
-  const std::string& strMeridiem = g_langInfo.GetMeridiemSymbol(dateTime.wHour > 11 ? MeridiemSymbolPM : MeridiemSymbolAM);
+  const std::string& strMeridiem = CLangInfo::MeridiemSymbolToString(dateTime.wHour > 11 ? MeridiemSymbolPM : MeridiemSymbolAM);
 
   size_t length = strFormat.size();
   for (size_t i=0; i < length; ++i)


### PR DESCRIPTION
This fixes python's `xbmc.getRegion('meridiem')` after f09ce552fb01ad58f3819c82609bee1ee38b58ef as reported broken by @ronie.
