### PR TITLE
addonbrowser: add LastUpdated window property

### DIFF
--- a/xbmc/addons/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/GUIWindowAddonBrowser.cpp
@@ -86,6 +86,8 @@ bool CGUIWindowAddonBrowser::OnMessage(CGUIMessage& message)
       // is this the first time the window is opened?
       if (m_vecItems->GetPath() == "?" && message.GetStringParam().empty())
         m_vecItems->SetPath("");
+
+      SetProperties();
     }
     break;
   case GUI_MSG_CLICKED:
@@ -156,12 +158,21 @@ bool CGUIWindowAddonBrowser::OnMessage(CGUIMessage& message)
           }
         }
       }
+      else if (message.GetParam1() == GUI_MSG_UPDATE && IsActive())
+        SetProperties();
     }
     break;
    default:
      break;
   }
   return CGUIMediaWindow::OnMessage(message);
+}
+
+void CGUIWindowAddonBrowser::SetProperties()
+{
+  auto lastChecked = CAddonInstaller::Get().LastRepoUpdate();
+  if (lastChecked.IsValid())
+    SetProperty("Updated", lastChecked.GetAsLocalizedDateTime());
 }
 
 void CGUIWindowAddonBrowser::GetContextButtons(int itemNumber, CContextButtons& buttons)

--- a/xbmc/addons/GUIWindowAddonBrowser.h
+++ b/xbmc/addons/GUIWindowAddonBrowser.h
@@ -73,7 +73,9 @@ protected:
   virtual bool GetDirectory(const std::string &strDirectory, CFileItemList &items);
   virtual bool Update(const std::string &strDirectory, bool updateFilterPath = true);
   virtual std::string GetStartFolder(const std::string &dir);
+
 private:
+  void SetProperties();
   CProgramThumbLoader m_thumbLoader;
 };
 


### PR DESCRIPTION
Adds a window property to show the last date and time repositories was checked for updates. I'm not sure if 'window properties' is the preferred way to do this. (please comment)
