### PR TITLE
[stringutils] do not capitalize after apostrophes

### DIFF
--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -389,7 +389,8 @@ void StringUtils::ToCapitalize(std::wstring &str)
   bool isFirstLetter = true;
   for (std::wstring::iterator it = str.begin(); it < str.end(); ++it)
   {
-    if (std::isspace(*it, loc) || std::ispunct(*it, loc))
+    // capitalize after spaces and punctuation characters (except apostrophes)
+    if (std::isspace(*it, loc) || (std::ispunct(*it, loc) && *it != '\''))
       isFirstLetter = true;
     else if (isFirstLetter)
     {


### PR DESCRIPTION
Fixes unwanted capitalization after apostrophes (eg. they're -> They'Re).
