### PR TITLE
settings: fix position of musiclibrary.showallitems setting

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1658,6 +1658,13 @@
         </setting>
       </group>
       <group id="3">
+        <setting id="musiclibrary.showallitems" type="boolean" label="38011" help="38012">
+          <level>2</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+      </group>
+      <group id="4">
         <setting id="musiclibrary.updateonstartup" type="boolean" label="22000" help="36259">
           <level>1</level>
           <default>false</default>
@@ -1669,12 +1676,7 @@
           <control type="toggle" />
         </setting>
       </group>
-      <group id="4">
-        <setting id="musiclibrary.showallitems" type="boolean" label="38011" help="38012">
-          <level>2</level>
-          <default>true</default>
-          <control type="toggle" />
-        </setting>
+      <group id="5">
         <setting id="musiclibrary.cleanup" type="action" label="334" help="36148">
           <level>2</level>
           <control type="button" format="action" />


### PR DESCRIPTION
This fixes the position of the `musiclibrary.showallitems` setting in the `Music` --> `Music Library` category. Right now it is in the same group as the export, import and clean settings where it certainly doesn't belong. I've moved it into it's own group as it doesn't really belong in any of the others.

With this change the setting's position is much more in line with its video library twin.
