### PR TITLE
[videodatabase] fix 'replace file names with library titles' not working...

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -6876,15 +6876,20 @@ std::string CVideoDatabase::GetContentForPath(const std::string& strPath)
   if (scraper)
   {
     if (scraper->Content() == CONTENT_TVSHOWS)
-    { // check for episodes or seasons.  Assumptions are:
+    {
+      if (foundDirectly)
+        return "tvshows";
+
+      // check for episodes or seasons.  Assumptions are:
       // 1. if episodes are in the path then we're in episodes.
       // 2. if no episodes are found, and content was set directly on this path, then we're in shows.
       // 3. if no episodes are found, and content was not set directly on this path, we're in seasons (assumes tvshows/seasons/episodes)
-      std::string sql = PrepareSQL("select count(1) from episode_view where strPath = '%s' limit 1", strPath.c_str());
+      std::string sql = PrepareSQL("SELECT count(1) FROM episode_view WHERE strPath LIKE '%s%%' LIMIT 1", strPath.c_str());
+
       m_pDS->query( sql.c_str() );
       if (m_pDS->num_rows() && m_pDS->fv(0).get_asInt() > 0)
         return "episodes";
-      return foundDirectly ? "tvshows" : "seasons";
+      return "seasons";
     }
     return TranslateContent(scraper->Content());
   }


### PR DESCRIPTION
This fixes a files node issue where episodes in sub-directories are not properly replaced with library titles.

@Montellese for review please.
