### PR TITLE
dvdplayer: reduce time for initial audio sync

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
@@ -667,7 +667,7 @@ void CDVDPlayerAudio::HandleSyncError(double duration)
   // error because drop/dupe changes the value
   if (m_syncclock && fabs(error) > threshold1)
   {
-    m_errors.Flush(500);
+    m_errors.Flush();
     m_integral = 0.0;
     m_resampleratio = 0.0;
     return;
@@ -684,13 +684,13 @@ void CDVDPlayerAudio::HandleSyncError(double duration)
   // 500ms in order to get first resample ratio early. If we don't adjust rr early, error
   // may get above threshold1 again. Too small values for interval result in worse average errors
 
-  if (!m_errors.Get(m_error, m_syncclock ? 500 : 2000))
+  if (!m_errors.Get(m_error, m_syncclock ? 100 : 2000))
     return;
 
   if (fabs(m_error) > threshold1)
   {
     m_syncclock = true;
-    m_errors.Flush(500);
+    m_errors.Flush(100);
     m_integral = 0.0;
     m_resampleratio = 0.0;
     CLog::Log(LOGDEBUG,"CDVDPlayerAudio::HandleSyncError - average error %f above threshold of %f",

--- a/xbmc/cores/dvdplayer/DVDPlayerAudio.h
+++ b/xbmc/cores/dvdplayer/DVDPlayerAudio.h
@@ -69,7 +69,7 @@ public:
     m_count++;
   }
 
-  void Flush(int interval = 500)
+  void Flush(int interval = 100)
   {
     m_buffer = 0.0f;
     m_count  = 0;
@@ -84,7 +84,7 @@ public:
       return 0.0;
   }
 
-  bool Get(double& error, int interval = 500)
+  bool Get(double& error, int interval = 100)
   {
     if(m_timer.IsTimePast())
     {


### PR DESCRIPTION
after recent improvements for audio sync it should be possible to reduce time for initial sync.

feedback appreciated. does anyone have any sample which brakes?
