### PR TITLE
[confluence][core] update build info formatting in SettingsSystemInfo

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -592,6 +592,8 @@ msgctxt "#143"
 msgid "Current:"
 msgstr ""
 
+#. Used in Confluence system info to show build info
+#: addons/skin.confluence/720p/SettingsSystemInfo.xml
 msgctxt "#144"
 msgid "Build:"
 msgstr ""
@@ -725,7 +727,11 @@ msgctxt "#173"
 msgid "Display 4:3 videos as"
 msgstr ""
 
-#empty string with id 174
+#. Used in Confluence system info to show build date
+#: addons/skin.confluence/720p/SettingsSystemInfo.xml
+msgctxt "#174"
+msgid "Compiled:"
+msgstr ""
 
 #: xbmc/playlists/SmartPlaylist.cpp
 msgctxt "#175"

--- a/addons/skin.confluence/720p/SettingsSystemInfo.xml
+++ b/addons/skin.confluence/720p/SettingsSystemInfo.xml
@@ -273,25 +273,14 @@
 					<label>-</label>
 					<font>font13</font>
 				</control>
-				<control type="label" id="52">
-					<description>Kodi Build Version</description>
-					<left>20</left>
-					<top>400</top>
-					<width>730</width>
-					<label>144</label>
-					<align>right</align>
-					<textcolor>blue</textcolor>
-					<shadowcolor>black</shadowcolor>
-					<font>font13_title</font>
-				</control>
 				<control type="label">
 					<description>CPU Text</description>
-					<left>70</left>
-					<top>450</top>
-					<width>350</width>
+					<left>0</left>
+					<top>350</top>
+					<width>750</width>
 					<height>25</height>
 					<label>$LOCALIZE[13271] $INFO[System.CPUUsage]</label>
-					<align>right</align>
+					<align>left</align>
 					<aligny>center</aligny>
 					<textcolor>white</textcolor>
 					<shadowcolor>black</shadowcolor>
@@ -299,20 +288,20 @@
 				</control>
 				<control type="progress">
 					<description>CPU BAR</description>
-					<left>430</left>
-					<top>455</top>
-					<width>320</width>
+					<left>0</left>
+					<top>375</top>
+					<width>750</width>
 					<height>16</height>
 					<info>System.CPUUsage</info>
 				</control>
 				<control type="label">
 					<description>Memory Text</description>
-					<left>70</left>
-					<top>480</top>
-					<width>350</width>
+					<left>0</left>
+					<top>395</top>
+					<width>auto</width>
 					<height>25</height>
-					<label>$LOCALIZE[31309] $INFO[system.memory(used.percent)]</label>
-					<align>right</align>
+					<label>$LOCALIZE[31309] $INFO[system.memory(used)] [B]/[/B] $INFO[system.memory(total)] [B]-[/B] $INFO[system.memory(used.percent)]</label>
+					<align>left</align>
 					<aligny>center</aligny>
 					<textcolor>white</textcolor>
 					<shadowcolor>black</shadowcolor>
@@ -320,11 +309,61 @@
 				</control>
 				<control type="progress">
 					<description>Memory BAR</description>
-					<left>430</left>
-					<top>485</top>
-					<width>320</width>
+					<left>0</left>
+					<top>420</top>
+					<width>750</width>
 					<height>16</height>
 					<info>system.memory(used)</info>
+				</control>
+				<control type="grouplist">
+					<description>Kodi build version</description>
+					<itemgap>50</itemgap>
+					<top>450</top>
+					<left>0</left>
+					<align>left</align>
+					<orientation>horizontal</orientation>
+					<control type="label">
+						<description>Build label</description>
+						<width>auto</width>
+						<height>25</height>
+						<label>$LOCALIZE[144]</label>
+						<textcolor>white</textcolor>
+						<shadowcolor>black</shadowcolor>
+						<font>font13_title</font>
+					</control>
+					<control type="label" id="52">
+						<description>Kodi Build Version</description>
+						<left>90</left>
+						<top>450</top>
+						<width>auto</width>
+						<textcolor>blue</textcolor>
+						<shadowcolor>black</shadowcolor>
+						<font>font13_title</font>
+					</control>
+				</control>
+				<control type="grouplist">
+					<description>Build date</description>
+					<itemgap>10</itemgap>
+					<top>480</top>
+					<align>left</align>
+					<left>0</left>
+					<orientation>horizontal</orientation>
+					<control type="label">
+						<description>kodi Compiled Text</description>
+						<width>auto</width>
+						<height>25</height>
+						<label>$LOCALIZE[174]</label>
+						<textcolor>white</textcolor>
+						<shadowcolor>black</shadowcolor>
+						<font>font13_title</font>
+					</control>
+					<control type="label" id="53">
+						<description>Kodi Build Date</description>
+						<width>auto</width>
+						<textcolor>blue</textcolor>
+						<shadowcolor>black</shadowcolor>
+						<font>font13_title</font>
+					</control>
 				</control>
 			</control>
 		</control>

--- a/xbmc/windows/GUIWindowSystemInfo.cpp
+++ b/xbmc/windows/GUIWindowSystemInfo.cpp
@@ -1,6 +1,6 @@
 /*
- *      Copyright (C) 2005-2013 Team XBMC
- *      http://xbmc.org
+ *      Copyright (C) 2005-2015 Team XBMC
+ *      http://kodi.tv
  *
  *  This Program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -39,20 +39,22 @@
 #define CONTROL_START       CONTROL_BT_STORAGE
 #define CONTROL_END         CONTROL_BT_PVR
 
-CGUIWindowSystemInfo::CGUIWindowSystemInfo(void)
-:CGUIWindow(WINDOW_SYSTEM_INFORMATION, "SettingsSystemInfo.xml")
+CGUIWindowSystemInfo::CGUIWindowSystemInfo(void) :
+    CGUIWindow(WINDOW_SYSTEM_INFORMATION, "SettingsSystemInfo.xml")
 {
   m_section = CONTROL_BT_DEFAULT;
   m_loadType = KEEP_IN_MEMORY;
 }
+
 CGUIWindowSystemInfo::~CGUIWindowSystemInfo(void)
 {
 }
+
 bool CGUIWindowSystemInfo::OnMessage(CGUIMessage& message)
 {
-  switch ( message.GetMessage() )
+  switch (message.GetMessage())
   {
-  case GUI_MSG_WINDOW_INIT:
+    case GUI_MSG_WINDOW_INIT:
     {
       CGUIWindow::OnMessage(message);
       SET_CONTROL_LABEL(52, CSysInfo::GetAppName() + " " + CSysInfo::GetVersion());
@@ -61,14 +63,16 @@ bool CGUIWindowSystemInfo::OnMessage(CGUIMessage& message)
       return true;
     }
     break;
-  case GUI_MSG_WINDOW_DEINIT:
+
+    case GUI_MSG_WINDOW_DEINIT:
     {
       CGUIWindow::OnMessage(message);
       m_diskUsage.clear();
       return true;
     }
     break;
-  case GUI_MSG_FOCUSED:
+
+    case GUI_MSG_FOCUSED:
     {
       CGUIWindow::OnMessage(message);
       int focusedControl = GetFocusedControlID();
@@ -89,7 +93,7 @@ void CGUIWindowSystemInfo::FrameMove()
   int i = 2;
   if (m_section == CONTROL_BT_DEFAULT)
   {
-    SET_CONTROL_LABEL(40,g_localizeStrings.Get(20154));
+    SET_CONTROL_LABEL(40, g_localizeStrings.Get(20154));
     SetControlLabel(i++, "%s: %s", 158, SYSTEM_FREE_MEMORY);
     SetControlLabel(i++, "%s: %s", 150, NETWORK_IP_ADDRESS);
     SetControlLabel(i++, "%s %s", 13287, SYSTEM_SCREEN_RESOLUTION);
@@ -98,9 +102,10 @@ void CGUIWindowSystemInfo::FrameMove()
     SetControlLabel(i++, "%s: %s", 12394, SYSTEM_TOTALUPTIME);
     SetControlLabel(i++, "%s: %s", 12395, SYSTEM_BATTERY_LEVEL);
   }
+
   else if (m_section == CONTROL_BT_STORAGE)
   {
-    SET_CONTROL_LABEL(40,g_localizeStrings.Get(20155));
+    SET_CONTROL_LABEL(40, g_localizeStrings.Get(20155));
     if (m_diskUsage.size() == 0)
       m_diskUsage = g_mediaManager.GetDiskUsage();
 
@@ -109,6 +114,7 @@ void CGUIWindowSystemInfo::FrameMove()
       SET_CONTROL_LABEL(i++, m_diskUsage[d]);
     }
   }
+
   else if (m_section == CONTROL_BT_NETWORK)
   {
     SET_CONTROL_LABEL(40,g_localizeStrings.Get(20158));
@@ -121,6 +127,7 @@ void CGUIWindowSystemInfo::FrameMove()
     SetControlLabel(i++, "%s: %s", 20307, NETWORK_DNS2_ADDRESS);
     SetControlLabel(i++, "%s %s", 13295, SYSTEM_INTERNET_STATE);
   }
+
   else if (m_section == CONTROL_BT_VIDEO)
   {
     SET_CONTROL_LABEL(40,g_localizeStrings.Get(20159));
@@ -136,6 +143,7 @@ void CGUIWindowSystemInfo::FrameMove()
     SetControlLabel(i++, "%s %s", 22010, SYSTEM_GPU_TEMPERATURE);
 #endif
   }
+
   else if (m_section == CONTROL_BT_HARDWARE)
   {
     SET_CONTROL_LABEL(40,g_localizeStrings.Get(20160));
@@ -153,27 +161,27 @@ void CGUIWindowSystemInfo::FrameMove()
 #if !(defined(__arm__) && defined(TARGET_LINUX))
     SetControlLabel(i++, "%s %s", 13271, SYSTEM_CPU_USAGE);
 #endif
-    i++; // empty line
+    i++;  // empty line
     SetControlLabel(i++, "%s: %s", 22012, SYSTEM_TOTAL_MEMORY);
     SetControlLabel(i++, "%s: %s", 158, SYSTEM_FREE_MEMORY);
   }
-  else if(m_section == CONTROL_BT_PVR)
+
+  else if (m_section == CONTROL_BT_PVR)
   {
-    SET_CONTROL_LABEL(40,g_localizeStrings.Get(19166));
+    SET_CONTROL_LABEL(40, g_localizeStrings.Get(19166));
     int i = 2;
 
     SetControlLabel(i++, "%s: %s", 19120, PVR_BACKEND_NUMBER);
-    i++; // empty line
+    i++;  // empty line
     SetControlLabel(i++, "%s: %s", 19012, PVR_BACKEND_NAME);
     SetControlLabel(i++, "%s: %s", 19114, PVR_BACKEND_VERSION);
     SetControlLabel(i++, "%s: %s", 19115, PVR_BACKEND_HOST);
     SetControlLabel(i++, "%s: %s", 19116, PVR_BACKEND_DISKSPACE);
     SetControlLabel(i++, "%s: %s", 19019, PVR_BACKEND_CHANNELS);
     SetControlLabel(i++, "%s: %s", 19163, PVR_BACKEND_RECORDINGS);
-    SetControlLabel(i++, "%s: %s", 19168, PVR_BACKEND_DELETED_RECORDINGS); // Deleted and recoverable recordings
+    SetControlLabel(i++, "%s: %s", 19168, PVR_BACKEND_DELETED_RECORDINGS);  // Deleted and recoverable recordings
     SetControlLabel(i++, "%s: %s", 19025, PVR_BACKEND_TIMERS);
   }
-
   CGUIWindow::FrameMove();
 }
 
@@ -181,12 +189,13 @@ void CGUIWindowSystemInfo::ResetLabels()
 {
   for (int i = 2; i < 12; i++)
   {
-    SET_CONTROL_LABEL(i,"");
+    SET_CONTROL_LABEL(i, "");
   }
 }
 
 void CGUIWindowSystemInfo::SetControlLabel(int id, const char *format, int label, int info)
 {
-  std::string tmpStr = StringUtils::Format(format, g_localizeStrings.Get(label).c_str(), g_infoManager.GetLabel(info).c_str());
+  std::string tmpStr = StringUtils::Format(format, g_localizeStrings.Get(label).c_str(),
+      g_infoManager.GetLabel(info).c_str());
   SET_CONTROL_LABEL(id, tmpStr);
 }

--- a/xbmc/windows/GUIWindowSystemInfo.cpp
+++ b/xbmc/windows/GUIWindowSystemInfo.cpp
@@ -55,10 +55,9 @@ bool CGUIWindowSystemInfo::OnMessage(CGUIMessage& message)
   case GUI_MSG_WINDOW_INIT:
     {
       CGUIWindow::OnMessage(message);
-      SET_CONTROL_LABEL(52, CSysInfo::GetAppName() + " " + CSysInfo::GetVersion() +
-                            " (Compiled: " + CSysInfo::GetBuildDate() +")");
-      CONTROL_ENABLE_ON_CONDITION(CONTROL_BT_PVR,
-                                  PVR::CPVRManager::Get().IsStarted());
+      SET_CONTROL_LABEL(52, CSysInfo::GetAppName() + " " + CSysInfo::GetVersion());
+      SET_CONTROL_LABEL(53, CSysInfo::GetBuildDate());
+      CONTROL_ENABLE_ON_CONDITION(CONTROL_BT_PVR, PVR::CPVRManager::Get().IsStarted());
       return true;
     }
     break;


### PR DESCRIPTION
This is a retake of https://github.com/xbmc/xbmc/pull/6949  with core changes added.
This PR cherry picks https://github.com/hudokkow/kodi/commit/cc86966a0d1d574e935e097d32aa0818d4e5b4d2 from @hudokkow help in splitting the info in core.

Essentially splits build date from the kodi compile version info and adjust cpu & label and memory % label so that max cores are visible up to the width available. 

Goes from this

![screenshot048](https://cloud.githubusercontent.com/assets/3521959/7136826/45fdc19e-e2ac-11e4-845c-c251c516f74e.png)

To this. (updated memory line according to request in #6949)

![screenshot094](https://cloud.githubusercontent.com/assets/3521959/7241282/bca4e720-e7af-11e4-8fc1-83e89797a074.png)

@HitcherUK skinning wise this is the best I could do to figure out grouplists it probably can be done better yet but I have no idea how.

@da-anda @ronie @Montellese @phil65 for bikeshedding I guess.
