### PR TITLE
[video] no need to re-fetch (and stack) directory in case we already kno...

### DIFF
--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -227,7 +227,8 @@ void CGUIWindowVideoBase::OnInfo(CFileItem* pItem, ADDON::ScraperPtr& scraper)
   // so take a copy of the item now
   CFileItem item(*pItem);
   bool fromDB = false;
-  if (item.IsVideoDb() && item.HasVideoInfoTag())
+  if ((item.IsVideoDb() && item.HasVideoInfoTag()) ||
+      (item.HasVideoInfoTag() && item.GetVideoInfoTag()->m_iDbId != -1))
   {
     if (item.GetVideoInfoTag()->m_type == MediaTypeSeason)
     { // clear out the art - we're really grabbing the info on the show here


### PR DESCRIPTION
This gets rid of a useless extra directory fetch and stacking when you hit `info` on a folder that is already added and known.

@Montellese, @xhaggi for review please.
