### PR TITLE
Prevent mistimed subtitles when using <latency> advanced setting

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
@@ -1096,6 +1096,9 @@ int CDVDPlayerVideo::OutputPicture(const DVDVideoPicture* src, double pts)
   //try to calculate the framerate
   CalcFrameRate();
 
+  // remember original pts, we need it later for overlaying subtitles
+  double ptsovl = pts;
+
   // signal to clock what our framerate is, it may want to adjust it's
   // speed to better match with our video renderer's output speed
   double interval;
@@ -1187,7 +1190,7 @@ int CDVDPlayerVideo::OutputPicture(const DVDVideoPicture* src, double pts)
     return EOS_DROPPED;
   }
 
-  ProcessOverlays(pPicture, pts);
+  ProcessOverlays(pPicture, ptsovl);
 
   int index = g_renderManager.AddVideoPicture(*pPicture);
 


### PR DESCRIPTION
Subtitles and other overlays should always be in sync with the actual video PTS, not with the (corrected) audio PTS - otherwise subtitles will be delayed twice: once by Kodi and again by the display hardware, which causes ugly scene bleed.
