### PR TITLE
Bugfix: Audio stays muted when there is no sync error at the beginning of playback

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
@@ -803,6 +803,7 @@ bool CDVDPlayerAudio::OutputPacket(DVDAudioFrame &audioframe)
     }
     else
     {
+      m_syncclock = false;
       m_dvdAudio.AddPackets(audioframe);
     }
   }


### PR DESCRIPTION
I guess this went unnoticed because the chance for this happening is close to zero.
When there is no resync event happening at all when starting playback (ie. NO frame dropped/duped), then the audio will remain silent until you seek/skip:

m_syncclock is "true" by default. It is reset to "false" only in CDVDPlayerAudio::HandleSyncError(). If this function is never called, because there is no sync error, audio will never be unmuted. m_syncclock should be set to "false" in CDVDPlayerAudio::OutputPacket() if no drop/dupe is necessary.

@FernetMenta
The following is unrelated, I'm just posting this here to get your attention:

This new method of syncing audio by adding/dropping zeroed audio frames doesn't work well with my AVR, and possibly with quite a lot of AVRs.

After starting playback or skipping forward/backward, it takes up to 2 seconds until it actually recovers and starts outputting audio again.

To my knowledge, this is the reason why the setting "keep audio device alive" has been introduced long ago, which outputs low volume noise instead of total silence. This should be done during audio resync as well, instead of zeroed frames.
