### PR TITLE
[switchplayer] fix multiple ghost choices in contextmenu

### DIFF
--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -102,7 +102,8 @@ bool CGUIDialogContextMenu::OnMessage(CGUIMessage &message)
 
 bool CGUIDialogContextMenu::OnAction(const CAction& action)
 {
-  if (action.GetID() == ACTION_CONTEXT_MENU)
+  if (action.GetID() == ACTION_CONTEXT_MENU ||
+      action.GetID() == ACTION_SWITCH_PLAYER)
   {
     Close();
     return true;


### PR DESCRIPTION
Due to no proper de-init of the context menu we ended up with multiple ghost entries for available players when pressing y `(SwitchPlayer)` while the actual menu was already loaded. With this change the switch player menu will close itself when the built-in is fired a second time (just as we do for the regular context menu).
