### PR TITLE
support specifying the image scaling algorithm for image resizing/caching

### DIFF
--- a/Kodi.xcodeproj/project.pbxproj
+++ b/Kodi.xcodeproj/project.pbxproj
@@ -999,6 +999,9 @@
 		DFD882F817DD1A5B001516FE /* AddonPythonInvoker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFD882F417DD1A5B001516FE /* AddonPythonInvoker.cpp */; };
 		DFD928F316384B6800709DAE /* Timer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFD928F116384B6800709DAE /* Timer.cpp */; };
 		DFDA3153160E34230047A626 /* DVDOverlayCodec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFDA3152160E34230047A626 /* DVDOverlayCodec.cpp */; };
+		DFDE5D511AE5658200EE53AD /* PictureScalingAlgorithm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFDE5D4F1AE5658200EE53AD /* PictureScalingAlgorithm.cpp */; };
+		DFDE5D521AE5658200EE53AD /* PictureScalingAlgorithm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFDE5D4F1AE5658200EE53AD /* PictureScalingAlgorithm.cpp */; };
+		DFDE5D531AE5658200EE53AD /* PictureScalingAlgorithm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFDE5D4F1AE5658200EE53AD /* PictureScalingAlgorithm.cpp */; };
 		DFE4095B17417FDF00473BD9 /* LegacyPathTranslation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFE4095917417FDF00473BD9 /* LegacyPathTranslation.cpp */; };
 		DFEB902819E9337200728978 /* AEResampleFactory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFEB902619E9337200728978 /* AEResampleFactory.cpp */; };
 		DFEB902919E9337200728978 /* AEResampleFactory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFEB902619E9337200728978 /* AEResampleFactory.cpp */; };
@@ -4612,6 +4615,8 @@
 		DFD928F116384B6800709DAE /* Timer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Timer.cpp; sourceTree = "<group>"; };
 		DFD928F216384B6800709DAE /* Timer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Timer.h; sourceTree = "<group>"; };
 		DFDA3152160E34230047A626 /* DVDOverlayCodec.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DVDOverlayCodec.cpp; sourceTree = "<group>"; };
+		DFDE5D4F1AE5658200EE53AD /* PictureScalingAlgorithm.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PictureScalingAlgorithm.cpp; sourceTree = "<group>"; };
+		DFDE5D501AE5658200EE53AD /* PictureScalingAlgorithm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PictureScalingAlgorithm.h; sourceTree = "<group>"; };
 		DFE4095917417FDF00473BD9 /* LegacyPathTranslation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LegacyPathTranslation.cpp; sourceTree = "<group>"; };
 		DFE4095A17417FDF00473BD9 /* LegacyPathTranslation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LegacyPathTranslation.h; sourceTree = "<group>"; };
 		DFEB902519E9335E00728978 /* AEResample.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AEResample.h; sourceTree = "<group>"; };
@@ -6342,6 +6347,8 @@
 				E38E1DDA0D25F9FD00618676 /* PictureInfoLoader.h */,
 				E38E1DDB0D25F9FD00618676 /* PictureInfoTag.cpp */,
 				E38E1DDC0D25F9FD00618676 /* PictureInfoTag.h */,
+				DFDE5D4F1AE5658200EE53AD /* PictureScalingAlgorithm.cpp */,
+				DFDE5D501AE5658200EE53AD /* PictureScalingAlgorithm.h */,
 				E38E1DDD0D25F9FD00618676 /* PictureThumbLoader.cpp */,
 				E38E1DDE0D25F9FD00618676 /* PictureThumbLoader.h */,
 				E38E1E090D25F9FD00618676 /* SlideShowPicture.cpp */,
@@ -10691,6 +10698,7 @@
 				F5E1138014357F3800175026 /* PeripheralCecAdapter.cpp in Sources */,
 				F54BCC5F1439345300F86B0F /* HotKeyController.m in Sources */,
 				DF673AA51443819600A5A509 /* AddonManager.cpp in Sources */,
+				DFDE5D511AE5658200EE53AD /* PictureScalingAlgorithm.cpp in Sources */,
 				F5BD02F6148D3A7E001B5583 /* CryptThreading.cpp in Sources */,
 				DF5276E1151BAEDA00B5B63B /* Base64.cpp in Sources */,
 				DF5276E2151BAEDA00B5B63B /* HttpResponse.cpp in Sources */,
@@ -11447,6 +11455,7 @@
 				DFF0F27D17528350002DA3A4 /* GUIBorderedImage.cpp in Sources */,
 				DFF0F27E17528350002DA3A4 /* GUIButtonControl.cpp in Sources */,
 				DFF0F27F17528350002DA3A4 /* GUICheckMarkControl.cpp in Sources */,
+				DFDE5D531AE5658200EE53AD /* PictureScalingAlgorithm.cpp in Sources */,
 				DFF0F28017528350002DA3A4 /* GUIColorManager.cpp in Sources */,
 				DFF0F28117528350002DA3A4 /* GUIControl.cpp in Sources */,
 				DFF0F28217528350002DA3A4 /* GUIControlFactory.cpp in Sources */,
@@ -12465,6 +12474,7 @@
 				395C2A201A9F96A700EBC7AD /* ContextItemAddon.cpp in Sources */,
 				E49912CC174E5DA000741B6D /* DirectoryNodeTitleMovies.cpp in Sources */,
 				E49912CD174E5DA000741B6D /* DirectoryNodeTitleMusicVideos.cpp in Sources */,
+				DFDE5D521AE5658200EE53AD /* PictureScalingAlgorithm.cpp in Sources */,
 				E49912CE174E5DA000741B6D /* DirectoryNodeTitleTvShows.cpp in Sources */,
 				E49912CF174E5DA000741B6D /* DirectoryNodeTvShowsOverview.cpp in Sources */,
 				E49912D0174E5DA000741B6D /* QueryParams.cpp in Sources */,

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -713,6 +713,7 @@
     <ClCompile Include="..\..\xbmc\pictures\Picture.cpp" />
     <ClCompile Include="..\..\xbmc\pictures\PictureInfoLoader.cpp" />
     <ClCompile Include="..\..\xbmc\pictures\PictureInfoTag.cpp" />
+    <ClCompile Include="..\..\xbmc\pictures\PictureScalingAlgorithm.cpp" />
     <ClCompile Include="..\..\xbmc\pictures\PictureThumbLoader.cpp" />
     <ClCompile Include="..\..\xbmc\pictures\SlideShowPicture.cpp" />
     <ClCompile Include="..\..\xbmc\PlayListPlayer.cpp" />
@@ -999,6 +1000,7 @@
     <ClInclude Include="..\..\xbmc\network\NetworkServices.h" />
     <ClInclude Include="..\..\xbmc\peripherals\bus\virtual\PeripheralBusCEC.h" />
     <ClInclude Include="..\..\xbmc\network\upnp\UPnPSettings.h" />
+    <ClInclude Include="..\..\xbmc\pictures\PictureScalingAlgorithm.h" />
     <ClInclude Include="..\..\xbmc\playlists\SmartPlaylistFileItemListModifier.h" />
     <ClInclude Include="..\..\xbmc\profiles\dialogs\GUIDialogLockSettings.h" />
     <ClInclude Include="..\..\xbmc\profiles\dialogs\GUIDialogProfileSettings.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -3096,6 +3096,9 @@
     <ClCompile Include="..\..\xbmc\addons\ImageResource.cpp">
       <Filter>addons</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\pictures\PictureScalingAlgorithm.cpp">
+      <Filter>pictures</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\xbmc\win32\pch.h">
@@ -5985,6 +5988,9 @@
     </ClInclude>
     <ClInclude Include="..\..\xbmc\addons\ImageResource.h">
       <Filter>addons</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\pictures\PictureScalingAlgorithm.h">
+      <Filter>pictures</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/xbmc/TextureCacheJob.cpp
+++ b/xbmc/TextureCacheJob.cpp
@@ -79,7 +79,8 @@ bool CTextureCacheJob::CacheTexture(CBaseTexture **out_texture)
   // unwrap the URL as required
   std::string additional_info;
   unsigned int width, height;
-  std::string image = DecodeImageURL(m_url, width, height, additional_info);
+  CPictureScalingAlgorithm::Algorithm scalingAlgorithm;
+  std::string image = DecodeImageURL(m_url, width, height, scalingAlgorithm, additional_info);
 
   m_details.updateable = additional_info != "music" && UpdateableURL(image);
 
@@ -112,7 +113,7 @@ bool CTextureCacheJob::CacheTexture(CBaseTexture **out_texture)
 
     CLog::Log(LOGDEBUG, "%s image '%s' to '%s':", m_oldHash.empty() ? "Caching" : "Recaching", image.c_str(), m_details.file.c_str());
 
-    if (CPicture::CacheTexture(texture, width, height, CTextureCache::GetCachedPath(m_details.file)))
+    if (CPicture::CacheTexture(texture, width, height, CTextureCache::GetCachedPath(m_details.file), scalingAlgorithm))
     {
       m_details.width = width;
       m_details.height = height;
@@ -138,7 +139,8 @@ bool CTextureCacheJob::ResizeTexture(const std::string &url, uint8_t* &result, s
   // unwrap the URL as required
   std::string additional_info;
   unsigned int width, height;
-  std::string image = DecodeImageURL(url, width, height, additional_info);
+  CPictureScalingAlgorithm::Algorithm scalingAlgorithm;
+  std::string image = DecodeImageURL(url, width, height, scalingAlgorithm, additional_info);
   if (image.empty())
     return false;
 
@@ -146,18 +148,19 @@ bool CTextureCacheJob::ResizeTexture(const std::string &url, uint8_t* &result, s
   if (texture == NULL)
     return false;
 
-  bool success = CPicture::ResizeTexture(image, texture, width, height, result, result_size);
+  bool success = CPicture::ResizeTexture(image, texture, width, height, result, result_size, scalingAlgorithm);
   delete texture;
 
   return success;
 }
 
-std::string CTextureCacheJob::DecodeImageURL(const std::string &url, unsigned int &width, unsigned int &height, std::string &additional_info)
+std::string CTextureCacheJob::DecodeImageURL(const std::string &url, unsigned int &width, unsigned int &height, CPictureScalingAlgorithm::Algorithm& scalingAlgorithm, std::string &additional_info)
 {
   // unwrap the URL as required
   std::string image(url);
   additional_info.clear();
   width = height = 0;
+  scalingAlgorithm = CPictureScalingAlgorithm::NoAlgorithm;
   if (StringUtils::StartsWith(url, "image://"))
   {
     // format is image://[type@]<url_encoded_path>?options
@@ -182,6 +185,9 @@ std::string CTextureCacheJob::DecodeImageURL(const std::string &url, unsigned in
       if (thumbURL.HasOption("height") && StringUtils::IsInteger(thumbURL.GetOption("height")))
         height = strtol(thumbURL.GetOption("height").c_str(), NULL, 0);
     }
+
+    if (thumbURL.HasOption("scaling_algorithm"))
+      scalingAlgorithm = CPictureScalingAlgorithm::FromString(thumbURL.GetOption("scaling_algorithm"));
   }
   return image;
 }

--- a/xbmc/TextureCacheJob.h
+++ b/xbmc/TextureCacheJob.h
@@ -23,6 +23,8 @@
 #include <stdint.h>
 #include <string>
 #include <vector>
+
+#include "pictures/PictureScalingAlgorithm.h"
 #include "utils/Job.h"
 
 class CBaseTexture;
@@ -103,10 +105,11 @@ private:
    \param url wrapped URL of the image
    \param width width derived from URL
    \param height height derived from URL
+   \param scalingAlgorithm scaling algorithm derived from URL
    \param additional_info additional information, such as "flipped" to flip horizontally
    \return URL of the underlying image file.
    */
-  static std::string DecodeImageURL(const std::string &url, unsigned int &width, unsigned int &height, std::string &additional_info);
+  static std::string DecodeImageURL(const std::string &url, unsigned int &width, unsigned int &height, CPictureScalingAlgorithm::Algorithm& scalingAlgorithm, std::string &additional_info);
 
   /*! \brief Load an image at a given target size and orientation.
 

--- a/xbmc/network/httprequesthandler/HTTPImageTransformationHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPImageTransformationHandler.cpp
@@ -29,8 +29,9 @@
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 
-#define TRANSFORMATION_OPTION_WIDTH   "width"
-#define TRANSFORMATION_OPTION_HEIGHT  "height"
+#define TRANSFORMATION_OPTION_WIDTH             "width"
+#define TRANSFORMATION_OPTION_HEIGHT            "height"
+#define TRANSFORMATION_OPTION_SCALING_ALGORITHM "scaling_algorithm"
 
 static const std::string ImageBasePath = "/image/";
 
@@ -140,6 +141,10 @@ int CHTTPImageTransformationHandler::HandleRequest()
   option = options.find(TRANSFORMATION_OPTION_HEIGHT);
   if (option != options.end())
     urlOptions.push_back(TRANSFORMATION_OPTION_HEIGHT "=" + option->second);
+
+  option = options.find(TRANSFORMATION_OPTION_SCALING_ALGORITHM);
+  if (option != options.end())
+    urlOptions.push_back(TRANSFORMATION_OPTION_SCALING_ALGORITHM "=" + option->second);
 
   std::string imagePath = m_url;
   if (!urlOptions.empty())

--- a/xbmc/pictures/Makefile
+++ b/xbmc/pictures/Makefile
@@ -5,6 +5,7 @@ SRCS=GUIDialogPictureInfo.cpp \
      Picture.cpp \
      PictureInfoLoader.cpp \
      PictureInfoTag.cpp \
+     PictureScalingAlgorithm.cpp \
      PictureThumbLoader.cpp \
      SlideShowPicture.cpp \
      

--- a/xbmc/pictures/Picture.cpp
+++ b/xbmc/pictures/Picture.cpp
@@ -219,6 +219,8 @@ bool CPicture::CacheTexture(uint8_t *pixels, uint32_t width, uint32_t height, ui
     dest_width = width;
   if (dest_height == 0)
     dest_height = height;
+  if (scalingAlgorithm == CPictureScalingAlgorithm::NoAlgorithm)
+    scalingAlgorithm = g_advancedSettings.m_imageScalingAlgorithm;
 
   uint32_t max_height = g_advancedSettings.m_imageRes;
   if (g_advancedSettings.m_fanartRes > g_advancedSettings.m_imageRes)

--- a/xbmc/pictures/Picture.h
+++ b/xbmc/pictures/Picture.h
@@ -18,9 +18,12 @@
  *  <http://www.gnu.org/licenses/>.
  *
  */
-#include "utils/Job.h"
+
 #include <string>
 #include <vector>
+
+#include "pictures/PictureScalingAlgorithm.h"
+#include "utils/Job.h"
 
 class CBaseTexture;
 
@@ -36,8 +39,12 @@ public:
    */
   static bool CreateTiledThumb(const std::vector<std::string> &files, const std::string &thumb);
 
-  static bool ResizeTexture(const std::string &image, CBaseTexture *texture, uint32_t &dest_width, uint32_t &dest_height, uint8_t* &result, size_t& result_size);
-  static bool ResizeTexture(const std::string &image, uint8_t *pixels, uint32_t width, uint32_t height, uint32_t pitch, uint32_t &dest_width, uint32_t &dest_height, uint8_t* &result, size_t& result_size);
+  static bool ResizeTexture(const std::string &image, CBaseTexture *texture,
+    uint32_t &dest_width, uint32_t &dest_height, uint8_t* &result, size_t& result_size,
+    CPictureScalingAlgorithm::Algorithm scalingAlgorithm = CPictureScalingAlgorithm::NoAlgorithm);
+  static bool ResizeTexture(const std::string &image, uint8_t *pixels, uint32_t width, uint32_t height, uint32_t pitch,
+    uint32_t &dest_width, uint32_t &dest_height, uint8_t* &result, size_t& result_size,
+    CPictureScalingAlgorithm::Algorithm scalingAlgorithm = CPictureScalingAlgorithm::NoAlgorithm);
 
   /*! \brief Cache a texture, resizing, rotating and flipping as needed, and saving as a JPG or PNG
    \param texture a pointer to a CBaseTexture
@@ -46,13 +53,17 @@ public:
    \param dest the output cache file
    \return true if successful, false otherwise
    */
-  static bool CacheTexture(CBaseTexture *texture, uint32_t &dest_width, uint32_t &dest_height, const std::string &dest);
-  static bool CacheTexture(uint8_t *pixels, uint32_t width, uint32_t height, uint32_t pitch, int orientation, uint32_t &dest_width, uint32_t &dest_height, const std::string &dest);
+  static bool CacheTexture(CBaseTexture *texture, uint32_t &dest_width, uint32_t &dest_height, const std::string &dest,
+    CPictureScalingAlgorithm::Algorithm scalingAlgorithm = CPictureScalingAlgorithm::NoAlgorithm);
+  static bool CacheTexture(uint8_t *pixels, uint32_t width, uint32_t height, uint32_t pitch, int orientation,
+    uint32_t &dest_width, uint32_t &dest_height, const std::string &dest,
+    CPictureScalingAlgorithm::Algorithm scalingAlgorithm = CPictureScalingAlgorithm::NoAlgorithm);
 
 private:
   static void GetScale(unsigned int width, unsigned int height, unsigned int &out_width, unsigned int &out_height);
   static bool ScaleImage(uint8_t *in_pixels, unsigned int in_width, unsigned int in_height, unsigned int in_pitch,
-                         uint8_t *out_pixels, unsigned int out_width, unsigned int out_height, unsigned int out_pitch);
+                         uint8_t *out_pixels, unsigned int out_width, unsigned int out_height, unsigned int out_pitch,
+                         CPictureScalingAlgorithm::Algorithm scalingAlgorithm = CPictureScalingAlgorithm::NoAlgorithm);
   static bool OrientateImage(uint32_t *&pixels, unsigned int &width, unsigned int &height, int orientation);
 
   static bool FlipHorizontal(uint32_t *&pixels, unsigned int &width, unsigned int &height);

--- a/xbmc/pictures/PictureScalingAlgorithm.cpp
+++ b/xbmc/pictures/PictureScalingAlgorithm.cpp
@@ -1,0 +1,77 @@
+/*
+ *      Copyright (C) 2015 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <algorithm>
+
+extern "C" {
+#include "libswscale/swscale.h"
+}
+
+#include "PictureScalingAlgorithm.h"
+#include "utils/StringUtils.h"
+
+CPictureScalingAlgorithm::Algorithm CPictureScalingAlgorithm::Default = CPictureScalingAlgorithm::FastBilinear;
+
+CPictureScalingAlgorithm::AlgorithmMap CPictureScalingAlgorithm::m_algorithms = {
+  { FastBilinear,     { "fast_bilinear",    SWS_FAST_BILINEAR } },
+  { Bilinear,         { "bilinear",         SWS_BILINEAR } },
+  { Bicubic,          { "bicubic",          SWS_BICUBIC } },
+  { Experimental,     { "experimental",     SWS_X } },
+  { NearestNeighbor,  { "nearest_neighbor", SWS_POINT } },
+  { AveragingArea,    { "averaging_area",   SWS_AREA } },
+  { Bicublin,         { "bicublin",         SWS_BICUBLIN } },
+  { Gaussian,         { "gaussian",         SWS_GAUSS } },
+  { Sinc,             { "sinc",             SWS_SINC } },
+  { Lanczos,          { "lanczos",          SWS_LANCZOS } },
+  { BicubicSpline,    { "bicubic_spline",   SWS_SPLINE } },
+};
+
+CPictureScalingAlgorithm::Algorithm CPictureScalingAlgorithm::FromString(const std::string& scalingAlgorithm)
+{
+  const auto& algorithm = std::find_if(m_algorithms.begin(), m_algorithms.end(),
+    [&scalingAlgorithm](const std::pair<Algorithm, ScalingAlgorithm>& algo) { return StringUtils::EqualsNoCase(algo.second.name, scalingAlgorithm); });
+  if (algorithm != m_algorithms.end())
+    return algorithm->first;
+
+  return NoAlgorithm;
+}
+
+std::string CPictureScalingAlgorithm::ToString(Algorithm scalingAlgorithm)
+{
+  const auto& algorithm = m_algorithms.find(scalingAlgorithm);
+  if (algorithm != m_algorithms.end())
+    return algorithm->second.name;
+
+  return "";
+}
+
+int CPictureScalingAlgorithm::ToSwscale(const std::string& scalingAlgorithm)
+{
+  return ToSwscale(FromString(scalingAlgorithm));
+}
+
+int CPictureScalingAlgorithm::ToSwscale(Algorithm scalingAlgorithm)
+{
+  const auto& algorithm = m_algorithms.find(scalingAlgorithm);
+  if (algorithm != m_algorithms.end())
+    return algorithm->second.swscale;
+
+  return ToSwscale(Default);
+}

--- a/xbmc/pictures/PictureScalingAlgorithm.h
+++ b/xbmc/pictures/PictureScalingAlgorithm.h
@@ -1,0 +1,62 @@
+#pragma once
+/*
+ *      Copyright (C) 2015 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <string>
+#include <map>
+
+class CPictureScalingAlgorithm
+{
+public:
+  typedef enum Algorithm
+  {
+    NoAlgorithm,
+    FastBilinear,
+    Bilinear,
+    Bicubic,
+    Experimental,
+    NearestNeighbor,
+    AveragingArea,
+    Bicublin,
+    Gaussian,
+    Sinc,
+    Lanczos,
+    BicubicSpline
+  } Algorithm;
+
+  static Algorithm Default;
+
+  static Algorithm FromString(const std::string& scalingAlgorithm);
+  static std::string ToString(Algorithm scalingAlgorithm);
+  static int ToSwscale(const std::string& scalingAlgorithm);
+  static int ToSwscale(Algorithm scalingAlgorithm);
+
+private:
+  CPictureScalingAlgorithm();
+
+  typedef struct ScalingAlgorithm
+  {
+    std::string name;
+    int swscale;
+  } ScalingAlgorithm;
+
+  typedef std::map<CPictureScalingAlgorithm::Algorithm, CPictureScalingAlgorithm::ScalingAlgorithm> AlgorithmMap;
+  static AlgorithmMap m_algorithms;
+};

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -254,6 +254,7 @@ void CAdvancedSettings::Initialize()
   m_fanartRes = 1080;
   m_imageRes = 720;
   m_useDDSFanart = false;
+  m_imageScalingAlgorithm = CPictureScalingAlgorithm::Default;
 
   m_sambaclienttimeout = 10;
   m_sambadoscodepage = "";
@@ -995,6 +996,8 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
 #if !defined(TARGET_RASPBERRY_PI)
   XMLUtils::GetBoolean(pRootElement, "useddsfanart", m_useDDSFanart);
 #endif
+  if (XMLUtils::GetString(pRootElement, "imagescalingalgorithm", tmp))
+    m_imageScalingAlgorithm = CPictureScalingAlgorithm::FromString(tmp);
   XMLUtils::GetBoolean(pRootElement, "playlistasfolders", m_playlistAsFolders);
   XMLUtils::GetBoolean(pRootElement, "detectasudf", m_detectAsUdf);
 

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -23,6 +23,7 @@
 #include <string>
 #include <vector>
 
+#include "pictures/PictureScalingAlgorithm.h"
 #include "settings/lib/ISettingCallback.h"
 #include "settings/lib/ISettingsHandler.h"
 #include "utils/GlobalsHandling.h"
@@ -252,6 +253,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
      */
     unsigned int GetThumbSize() const { return m_imageRes / 2; };
     bool m_useDDSFanart;
+    CPictureScalingAlgorithm::Algorithm m_imageScalingAlgorithm;
 
     int m_sambaclienttimeout;
     std::string m_sambadoscodepage;


### PR DESCRIPTION
These commits add the possibility to specify the image scaling algorithm to be used for image resizing/caching using `CPicture` (no support for RPI's `OMXImage`). The scaling algorithm can be specified in two ways:
- through `<imagescalingalgorithm>` in `advancedsettings.xml` (which will automatically apply to all images being cached but only if they are resized)
- as a `scaling_algorithm` option in the `image://` URL (this will overrule whatever has been set in `advancedsettings.xml`)

I wasn't sure whether to put the option in `advancedsettings.xml` or as a GUI setting. I put it in `advancedsettings.xml` because the maximum resolution settings are there as well but having it as a GUI setting would have the advantage that we could specify different default depending on the platform.

Due to the support for a `scaling_algorithm` option in the `image://` URL this can also be used when retrieving resized images through the webserver.

I've noticed that there is also some resizing logic in `CJpegIO` which doesn't benefit from this change. I also don't know how we resize images/textures in the GUI so this only affects the quality of images we cache.

This is something that has bothered me for a while now and manually increasing the maximum image size/resolution of cached images through `advancedsettings.xml` hasn't been good enough. And I don't seem to be the only one as there are several threads in the forum about this. One of them is http://forum.kodi.tv/showthread.php?tid=200401.

**Needs Xcode sync**
