### PR TITLE
[builtins] fix bad access if GetWindow() is called with virtual window id

### DIFF
--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -775,6 +775,14 @@ void CGUIWindowManager::ActivateWindow_Internal(int iWindowID, const vector<stri
     return;
   }
 
+  // don't activate a window if there are active modal dialogs
+  if (HasModalDialog())
+  {
+    CLog::Log(LOG_LEVEL_DEBUG, "Activate of window '%i' refused because there are active modal dialogs", iWindowID);
+    g_audioManager.PlayActionSound(CAction(ACTION_ERROR));
+    return;
+  }
+
   g_infoManager.SetNextWindow(iWindowID);
 
   // set our overlay state

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -299,14 +299,6 @@ void CBuiltins::GetHelp(std::string &help)
 
 bool CBuiltins::ActivateWindow(int iWindowID, const std::vector<std::string>& params /* = {} */, bool swappingWindows /* = false */)
 {
-  // don't activate a window if there are active modal dialogs
-  if (g_windowManager.HasModalDialog() && !g_windowManager.GetWindow(iWindowID)->IsDialog())
-  {
-    CLog::Log(LOG_LEVEL_DEBUG, "Activate of window '%i' refused because there are active modal dialogs", iWindowID);
-    g_audioManager.PlayActionSound(CAction(ACTION_ERROR));
-    return false;
-  }
-
   // disable the screensaver
   g_application.WakeUpScreenSaverAndDPMS();
   g_windowManager.ActivateWindow(iWindowID, params, swappingWindows);


### PR DESCRIPTION
As pointed out by @mkortstiege this will fix a null access if we call `g_windowManager.GetWindow(iWindowID)` with a virtual window id e.g. WINDOW_MUSIC -> 10005.
