### PR TITLE
[win32] CLog: Do not use FlushFileBuffers after each write to file which...

### DIFF
--- a/xbmc/utils/win32/Win32InterfaceForCLog.cpp
+++ b/xbmc/utils/win32/Win32InterfaceForCLog.cpp
@@ -67,6 +67,7 @@ bool CWin32InterfaceForCLog::OpenLogFile(const std::string& logFilename, const s
   static const unsigned char BOM[3] = { 0xEF, 0xBB, 0xBF };
   DWORD written;
   (void)WriteFile(m_hFile, BOM, sizeof(BOM), &written, NULL); // write BOM, ignore possible errors
+  (void)FlushFileBuffers(m_hFile);
 
   return true;
 }
@@ -91,7 +92,6 @@ bool CWin32InterfaceForCLog::WriteStringToLog(const std::string& logString)
 
   DWORD written;
   const bool ret = (WriteFile(m_hFile, strData.c_str(), strData.length(), &written, NULL) != 0) && written == strData.length();
-  (void)FlushFileBuffers(m_hFile);
 
   return ret;
 }


### PR DESCRIPTION
... causes unnecessary performance penalties. Instead of using FlushFileBuffers specify FILE_FLAG_WRITE_THROUGH flag on the creation which causes any writes made to that handle to be written directly to the file without being buffered.

I've already told @Karlson2k about this issue. He is agree with me. 

This is possible way to solve performance issue.
