### PR TITLE
[input/touch] - when translating mapped touch events don't loose the

### DIFF
--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -1043,7 +1043,7 @@ bool CButtonTranslator::TranslateJoystickString(int window, const std::string& j
   return (action > 0);
 }
 
-bool CButtonTranslator::TranslateTouchAction(int window, int touchAction, int touchPointers, int &action)
+bool CButtonTranslator::TranslateTouchAction(int window, int touchAction, int touchPointers, int &action, std::string &actionString)
 {
   action = 0;
   if (touchPointers <= 0)
@@ -1052,14 +1052,14 @@ bool CButtonTranslator::TranslateTouchAction(int window, int touchAction, int to
   touchAction += touchPointers - 1;
   touchAction |= KEY_TOUCH;
 
-  action = GetTouchActionCode(window, touchAction);
+  action = GetTouchActionCode(window, touchAction, actionString);
   if (action <= 0)
   {
     int fallbackWindow = GetFallbackWindow(window);
     if (fallbackWindow > -1)
-      action = GetTouchActionCode(fallbackWindow, touchAction);
+      action = GetTouchActionCode(fallbackWindow, touchAction, actionString);
     if (action <= 0)
-      action = GetTouchActionCode(-1, touchAction);
+      action = GetTouchActionCode(-1, touchAction, actionString);
   }
 
   return action > 0;
@@ -1746,7 +1746,7 @@ void CButtonTranslator::MapTouchActions(int windowID, TiXmlNode *pTouch)
     m_touchMap.insert(std::pair<int, buttonMap>(windowID, map));
 }
 
-int CButtonTranslator::GetTouchActionCode(int window, int action)
+int CButtonTranslator::GetTouchActionCode(int window, int action, std::string &actionString)
 {
   std::map<int, buttonMap>::const_iterator windowIt = m_touchMap.find(window);
   if (windowIt == m_touchMap.end())
@@ -1756,5 +1756,6 @@ int CButtonTranslator::GetTouchActionCode(int window, int action)
   if (touchIt == windowIt->second.end())
     return ACTION_NONE;
 
+  actionString = touchIt->second.strID;
   return touchIt->second.id;
 }

--- a/xbmc/input/ButtonTranslator.h
+++ b/xbmc/input/ButtonTranslator.h
@@ -103,7 +103,7 @@ public:
   const AxesConfig* GetAxesConfigFor(const std::string& joyName) const;
 #endif
 
-  bool TranslateTouchAction(int window, int touchAction, int touchPointers, int &action);
+  bool TranslateTouchAction(int window, int touchAction, int touchPointers, int &action, std::string &actionString);
 
 private:
   typedef std::multimap<uint32_t, CButtonAction> buttonMap; // our button map to fill in
@@ -165,7 +165,7 @@ private:
 
   void MapTouchActions(int windowID, TiXmlNode *pTouch);
   static uint32_t TranslateTouchCommand(TiXmlElement *pButton, CButtonAction &action);
-  int GetTouchActionCode(int window, int action);
+  int GetTouchActionCode(int window, int action, std::string &actionString);
 
   std::map<int, buttonMap> m_touchMap;
 

--- a/xbmc/input/InputManager.cpp
+++ b/xbmc/input/InputManager.cpp
@@ -476,12 +476,13 @@ bool CInputManager::OnEvent(XBMC_Event& newEvent)
       g_application.OnAction(CAction(ACTION_MOUSE_MOVE, 0, newEvent.touch.x, newEvent.touch.y, 0, 0));
     }
     int actionId = 0;
+    std::string actionString;
     if (newEvent.touch.action == ACTION_GESTURE_BEGIN || newEvent.touch.action == ACTION_GESTURE_END)
       actionId = newEvent.touch.action;
     else
     {
       int iWin = g_windowManager.GetActiveWindowID();
-      CButtonTranslator::GetInstance().TranslateTouchAction(iWin, newEvent.touch.action, newEvent.touch.pointers, actionId);
+      CButtonTranslator::GetInstance().TranslateTouchAction(iWin, newEvent.touch.action, newEvent.touch.pointers, actionId, actionString);
     }
 
     if (actionId <= 0)
@@ -491,7 +492,12 @@ bool CInputManager::OnEvent(XBMC_Event& newEvent)
         || (actionId >= ACTION_MOUSE_START && actionId <= ACTION_MOUSE_END))
         CApplicationMessenger::Get().SendAction(CAction(actionId, 0, newEvent.touch.x, newEvent.touch.y, newEvent.touch.x2, newEvent.touch.y2), WINDOW_INVALID, false);
     else
-      CApplicationMessenger::Get().SendAction(CAction(actionId), WINDOW_INVALID, false);
+    {
+      if (actionId == ACTION_BUILT_IN_FUNCTION && !actionString.empty())
+        CApplicationMessenger::Get().SendAction(CAction(actionId, actionString), WINDOW_INVALID, false);
+      else
+        CApplicationMessenger::Get().SendAction(CAction(actionId), WINDOW_INVALID, false);
+    }
 
     // Post an unfocus message for touch device after the action.
     if (newEvent.touch.action == ACTION_GESTURE_END || newEvent.touch.action == ACTION_TOUCH_TAP)


### PR DESCRIPTION
actionstring so that builtin functions can be used. - fixes #15245

The bug from trac is that in touchscreen.xml you can't map to builtin functions
- link to trac:

http://trac.kodi.tv/ticket/15245

testbuild is in the works and i let the ticket creator verify it. @koying care to test this on android? (i just used the touchscreen.xml from the trac ticket for verifying it).
