### PR TITLE
[settings] adjusts seek steps default configurations

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -515,7 +515,7 @@
       <group id="2">
         <setting id="videoplayer.seeksteps" type="list[integer]" label="13556" help="37042">
           <level>2</level>
-          <default>-1800,-900,-600,-300,-180,-60,-30,-15,-7,15,30,60,180,300,600,900,1800</default>
+          <default>-600,-300,-180,-60,-30,-10,10,30,60,180,300,600</default>
           <constraints>
             <options>videoseeksteps</options>
             <delimiter>,</delimiter>
@@ -1710,7 +1710,7 @@
       <group id="2">
         <setting id="musicplayer.seeksteps" type="list[integer]" label="13556" help="37042">
           <level>2</level>
-          <default>-60,-30,-15,-7,7,15,30,60</default>
+          <default>-60,-30,-10,10,30,60</default>
           <constraints>
             <options>videoseeksteps</options>
             <delimiter>,</delimiter>

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -116,7 +116,7 @@ void CAdvancedSettings::Initialize()
   m_limiterHold = 0.025f;
   m_limiterRelease = 0.1f;
 
-  m_seekSteps = { 7, 15, 30, 60, 180, 300, 600, 900, 1800 };
+  m_seekSteps = { 10, 30, 60, 180, 300, 600, 1800 };
 
   m_omxHWAudioDecode = false;
   m_omxDecodeStartWithValidFrame = true;


### PR DESCRIPTION
As discussed at https://github.com/xbmc/xbmc/commit/face9ead060c964f0bae4c3b6179ea36d98708a5#commitcomment-10808787 this will adjusts our seek steps default configurations.

Now we have the following available seek steps (forward/backward):
10s, 30s, 60s, 3m, 5m, 10m, 30m

Enabled by default (forward/backward):
Video: 10s, 30s, 60s, 3m, 5m, 10m
Music: 10s, 30s, 60s

@FernetMenta hope this is fine for the demuxer.
