### PR TITLE
[confluence language strings] fix typo - capitalized second word

### DIFF
--- a/addons/skin.confluence/language/English/strings.po
+++ b/addons/skin.confluence/language/English/strings.po
@@ -431,7 +431,7 @@ msgid "Resolution"
 msgstr ""
 
 msgctxt "#31328"
-msgid "Recently Added"
+msgid "Recently added"
 msgstr ""
 
 msgctxt "#31329"


### PR DESCRIPTION
All sub menu entries are capitalized first letter word and lowercase second word.

`Recently Added -> Recently added`

@MartijnKaijser 
