### PR TITLE
AE: fix init of resampler (remapper) after flush

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
@@ -164,6 +164,7 @@ bool CActiveAEBufferPoolResample::Create(unsigned int totaltime, bool remap, boo
 {
   CActiveAEBufferPool::Create(totaltime);
 
+  m_remap = remap;
   m_stereoUpmix = upmix;
   m_normalize = true;
   if ((m_format.m_channelLayout.Count() < m_inputFormat.m_channelLayout.Count() && !normalize))
@@ -218,7 +219,7 @@ void CActiveAEBufferPoolResample::ChangeResampler()
                                 CAEUtil::DataFormatToDitherBits(m_inputFormat.m_dataFormat),
                                 m_stereoUpmix,
                                 m_normalize,
-                                NULL,
+                                m_remap ? &m_format.m_channelLayout : NULL,
                                 m_resampleQuality,
                                 m_forceResampler);
 

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.h
@@ -115,6 +115,7 @@ public:
   AEQuality m_resampleQuality;
   bool m_stereoUpmix;
   bool m_normalize;
+  bool m_remap;
   int64_t m_lastSamplePts;
 };
 


### PR DESCRIPTION
fix messed up channel mapping after flush. credits to @fritsch for tracking this down
