### PR TITLE
emulate fputs to fix curl warning

### DIFF
--- a/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
+++ b/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
@@ -1313,7 +1313,8 @@ extern "C"
     {
       if (g_emuFileWrapper.StreamIsEmulatedFile(stream))
       {
-        not_implement("msvcrt.dll fake function dll_fputs() called\n");
+        size_t len = strlen(szLine);
+        return dll_fwrite(static_cast<const void*>(szLine), sizeof(char), len, stream);
       }
       else if (!IS_STD_STREAM(stream))
       {


### PR DESCRIPTION
Curl uses fputs to write the header of it's cookie file and we haven't emulated this which causes errors to be reported in the log. I haven't noticed any issue with functionality but it's likely that curl can't read it's cookie file when the header is missing.
