### PR TITLE
Add support for file based stubs and improve support for disc stubs

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -1340,7 +1340,10 @@ msgctxt "#294"
 msgid "Create bookmark"
 msgstr ""
 
-#empty string with id 295
+#: xbmc/dialogs/GUIDialogPlayEject.cpp
+msgctxt "#295"
+msgid "Please attach storage device"
+msgstr ""
 
 msgctxt "#296"
 msgid "Clear bookmarks"
@@ -2137,7 +2140,14 @@ msgctxt "#470"
 msgid "Credits"
 msgstr ""
 
-#empty strings from id 471 to 473
+#empty string with id 471
+
+#: xbmc/dialogs/GUIDialogPlayEject.cpp
+msgctxt "#472"
+msgid "Please insert the following hard drive:"
+msgstr ""
+
+#empty string with id 473
 
 msgctxt "#474"
 msgid "Off"

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -386,6 +386,7 @@ copy "..\Win32BuildSetup\dependencies\python27.dll" "$(TargetDir)"</Command>
     <ClCompile Include="..\..\xbmc\filesystem\DirectoryFactory.cpp" />
     <ClCompile Include="..\..\xbmc\filesystem\DirectoryHistory.cpp" />
     <ClCompile Include="..\..\xbmc\filesystem\DllLibCurl.cpp" />
+    <ClCompile Include="..\..\xbmc\filesystem\EFileFile.cpp" />
     <ClCompile Include="..\..\xbmc\filesystem\File.cpp" />
     <ClCompile Include="..\..\xbmc\filesystem\FileCache.cpp" />
     <ClCompile Include="..\..\xbmc\filesystem\FavouritesDirectory.cpp" />
@@ -1409,6 +1410,7 @@ copy "..\Win32BuildSetup\dependencies\python27.dll" "$(TargetDir)"</Command>
     <ClInclude Include="..\..\xbmc\filesystem\DirectoryHistory.h" />
     <ClInclude Include="..\..\xbmc\filesystem\DllLibCurl.h" />
     <ClInclude Include="..\..\xbmc\filesystem\DllLibNfs.h" />
+    <ClInclude Include="..\..\xbmc\filesystem\EFileFile.h" />
     <ClInclude Include="..\..\xbmc\filesystem\File.h" />
     <ClInclude Include="..\..\xbmc\filesystem\FileDirectoryFactory.h" />
     <ClInclude Include="..\..\xbmc\filesystem\FileFactory.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -1920,6 +1920,9 @@
     <ClCompile Include="..\..\xbmc\filesystem\DllLibCurl.cpp">
       <Filter>filesystem</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\filesystem\EFileFile.cpp">
+      <Filter>filesystem</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\xbmc\filesystem\File.cpp">
       <Filter>filesystem</Filter>
     </ClCompile>
@@ -5076,6 +5079,9 @@
     <ClInclude Include="..\..\xbmc\filesystem\DllLibNfs.h">
       <Filter>filesystem</Filter>
     </ClInclude>
+    <ClCompile Include="..\..\xbmc\filesystem\EFileFile.h">
+      <Filter>filesystem</Filter>
+    </ClCompile>
     <ClInclude Include="..\..\xbmc\filesystem\File.h">
       <Filter>filesystem</Filter>
     </ClInclude>

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3174,6 +3174,12 @@ PlayBackRet CApplication::PlayFile(CFileItem item, const std::string& player, bo
       CUtil::ClearSubtitles();
   }
 
+  if (item.IsEFileStub())
+  {
+    if (!CGUIDialogPlayEject::ShowAndGetInput(item))
+      return PLAYBACK_CANCELED;
+  }
+
   if (item.IsDiscStub())
   {
 #ifdef HAS_DVD_DRIVE

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3002,9 +3002,9 @@ PlayBackRet CApplication::PlayStack(const CFileItem& item, bool bRestart)
     return PLAYBACK_FAIL;
 
   CVideoDatabase dbs;
-
-  // case 1: stacked ISOs
-  if (CFileItem(CStackDirectory::GetFirstStackedFile(item.GetPath()),false).IsDiscImage())
+  std::string firstStacked = CStackDirectory::GetFirstStackedFile(item.GetPath());
+  // case 1: stacked ISOs or stub discs
+  if (URIUtils::IsDiscImage(firstStacked) || URIUtils::IsDiscStub(firstStacked))
   {
     CStackDirectory dir;
     CFileItemList movieList;
@@ -3174,28 +3174,10 @@ PlayBackRet CApplication::PlayFile(CFileItem item, const std::string& player, bo
       CUtil::ClearSubtitles();
   }
 
-  if (item.IsEFileStub())
+  if (item.IsEFileStub() || item.IsDiscStub())
   {
     if (!CGUIDialogPlayEject::ShowAndGetInput(item))
       return PLAYBACK_CANCELED;
-  }
-
-  if (item.IsDiscStub())
-  {
-#ifdef HAS_DVD_DRIVE
-    // Display the Play Eject dialog if there is any optical disc drive
-    if (g_mediaManager.HasOpticalDrive())
-    {
-      if (CGUIDialogPlayEject::ShowAndGetInput(item))
-        // PlayDiscAskResume takes path to disc. No parameter means default DVD drive.
-        // Can't do better as CGUIDialogPlayEject calls CMediaManager::IsDiscInDrive, which assumes default DVD drive anyway
-        return MEDIA_DETECT::CAutorun::PlayDiscAskResume() ? PLAYBACK_OK : PLAYBACK_FAIL;
-    }
-    else
-#endif
-      CGUIDialogOK::ShowAndGetInput(CVariant{435}, CVariant{436});
-
-    return PLAYBACK_OK;
   }
 
   if (item.IsPlayList())
@@ -3210,7 +3192,7 @@ PlayBackRet CApplication::PlayFile(CFileItem item, const std::string& player, bo
   }
 
   // a disc image might be Blu-Ray disc
-  if (item.IsBDFile() || item.IsDiscImage())
+  if (item.IsBDFile() || item.IsDiscImage() || item.IsDiscStub())
   {
     //check if we must show the simplified bd menu
     if (!CGUIDialogSimpleMenu::ShowPlaySelection(const_cast<CFileItem&>(item)))

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -883,6 +883,7 @@ bool CFileItem::IsFileFolder(EFileFolderType types) const
     || IsAPK()
     || IsZIP()
     || IsRAR()
+    || IsEFileStub()
     || IsRSS()
     || IsType(".ogg|.oga|.nsf|.sid|.sap|.xbt|.xsp")
 #if defined(TARGET_ANDROID)
@@ -941,7 +942,18 @@ bool CFileItem::IsNFO() const
 
 bool CFileItem::IsDiscImage() const
 {
-  return URIUtils::HasExtension(m_strPath, ".img|.iso|.nrg");
+  switch (m_isDiscImage)
+  {
+    case 0:
+      if (URIUtils::IsDiscImage(m_strPath))
+        m_isDiscImage = 1;
+      else
+        m_isDiscImage = 2;
+    case 1:
+      return true;
+    default:
+      return false;
+  }
 }
 
 bool CFileItem::IsOpticalMediaFile() const
@@ -992,6 +1004,11 @@ bool CFileItem::IsAPK() const
 bool CFileItem::IsZIP() const
 {
   return URIUtils::IsZIP(m_strPath);
+}
+
+bool CFileItem::IsEFileStub() const
+{
+  return URIUtils::IsEFileStub(m_strPath);
 }
 
 bool CFileItem::IsCBZ() const
@@ -1527,36 +1544,7 @@ void CFileItem::SetFromSong(const CSong &song)
 
 std::string CFileItem::GetOpticalMediaPath() const
 {
-  std::string path;
-  std::string dvdPath;
-  path = URIUtils::AddFileToFolder(GetPath(), "VIDEO_TS.IFO");
-  if (CFile::Exists(path))
-    dvdPath = path;
-  else
-  {
-    dvdPath = URIUtils::AddFileToFolder(GetPath(), "VIDEO_TS");
-    path = URIUtils::AddFileToFolder(dvdPath, "VIDEO_TS.IFO");
-    dvdPath.clear();
-    if (CFile::Exists(path))
-      dvdPath = path;
-  }
-#ifdef HAVE_LIBBLURAY
-  if (dvdPath.empty())
-  {
-    path = URIUtils::AddFileToFolder(GetPath(), "index.bdmv");
-    if (CFile::Exists(path))
-      dvdPath = path;
-    else
-    {
-      dvdPath = URIUtils::AddFileToFolder(GetPath(), "BDMV");
-      path = URIUtils::AddFileToFolder(dvdPath, "index.bdmv");
-      dvdPath.clear();
-      if (CFile::Exists(path))
-        dvdPath = path;
-    }
-  }
-#endif
-  return dvdPath;
+  return URIUtils::GetOpticalMediaPath(GetPath());
 }
 
 /*
@@ -2998,7 +2986,7 @@ std::string CFileItem::GetBaseMoviePath(bool bUseFolderNames) const
   {
     std::string name2(strMovieName);
     URIUtils::GetParentPath(name2,strMovieName);
-    if (URIUtils::IsInArchive(m_strPath))
+    if (URIUtils::IsInArchive(m_strPath) || URIUtils::IsEFileStub(m_strPath))
     {
       std::string strArchivePath;
       URIUtils::GetParentPath(strMovieName, strArchivePath);

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -788,13 +788,7 @@ bool CFileItem::IsPVRRadioRDS() const
 
 bool CFileItem::IsDiscStub() const
 {
-  if (IsVideoDb() && HasVideoInfoTag())
-  {
-    CFileItem dbItem(m_bIsFolder ? GetVideoInfoTag()->m_strPath : GetVideoInfoTag()->m_strFileNameAndPath, m_bIsFolder);
-    return dbItem.IsDiscStub();
-  }
-
-  return URIUtils::HasExtension(m_strPath, g_advancedSettings.m_discStubExtensions);
+  return URIUtils::IsDiscStub(m_strPath);
 }
 
 bool CFileItem::IsAudio() const

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -159,6 +159,8 @@ public:
    */
   bool IsVideo() const;
 
+  bool IsEFileStub() const;
+
   bool IsDiscStub() const;
 
   /*!
@@ -512,6 +514,7 @@ public:
   std::string m_strLockCode;
   int m_iHasLock; // 0 - no lock 1 - lock, but unlocked 2 - locked
   int m_iBadPwdCount;
+  mutable int m_isDiscImage;
 
   void SetCueDocument(const CCueDocumentPtr& cuePtr);
   void LoadEmbeddedCue();

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -72,6 +72,7 @@
 #include "platform/darwin/DarwinUtils.h"
 #endif
 #include "filesystem/File.h"
+#include "filesystem/EfileFile.h"
 #include "settings/MediaSettings.h"
 #include "settings/Settings.h"
 #include "utils/StringUtils.h"
@@ -1174,6 +1175,14 @@ int CUtil::GetMatchingSource(const std::string& strPath1, VECSOURCES& VECSOURCES
       // get the hostname portion of the url since it contains the archive file
       strPath = checkURL.GetHostName();
 
+      bIsSourceName = false;
+      bool bDummy;
+      return GetMatchingSource(strPath, VECSOURCES, bDummy);
+    }
+    if (StringUtils::StartsWithNoCase(strPath, "efile://"))
+    {
+      // get the original file name since it contains the efile
+      strPath = CEFileFile::GetOriginalPath(CURL(strPath));
       bIsSourceName = false;
       bool bDummy;
       return GetMatchingSource(strPath, VECSOURCES, bDummy);

--- a/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
+++ b/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
@@ -27,6 +27,7 @@
 #include "dialogs/GUIDialogOK.h"
 #include "guilib/GUIWindowManager.h"
 #include "Application.h"
+#include "filesystem/EfileFile.h"
 #include "filesystem/MusicDatabaseFile.h"
 #include "FileItem.h"
 #include "utils/RegExp.h"
@@ -164,6 +165,8 @@ void CExternalPlayer::Process()
       else
         mainFile = URIUtils::AddFileToFolder(base.Get(), url.GetFileName());
     }
+    if (url.IsProtocol("efile"))
+      mainFile = CEFileFile::GetTranslatedPath(url);
   }
 
   if (!m_filenameReplacers.empty())

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -40,6 +40,7 @@
 #include "settings/DiscSettings.h"
 #include "utils/LangCodeExpander.h"
 #include "filesystem/SpecialProtocol.h"
+#include "storage/MediaManager.h"
 
 #ifdef TARGET_POSIX
 #include "linux/XTimeUtils.h"
@@ -273,13 +274,16 @@ bool CDVDInputStreamBluray::Open()
   std::string filename;
   std::string root;
 
-  if(URIUtils::IsProtocol(strPath, "bluray"))
+  if(g_mediaManager.TranslateDevicePath("") == strPath)
+    strPath = URIUtils::AddFileToFolder(strFile, "BDMV/index.bdmv");
+
+  if (URIUtils::IsProtocol(strPath, "bluray"))
   {
     CURL url(strPath);
     root     = url.GetHostName();
     filename = URIUtils::GetFileName(url.GetFileName());
   }
-  else if(URIUtils::HasExtension(strPath, ".iso|.img"))
+  else if(URIUtils::IsDiscImage(strPath))
   {
     CURL url("udf://");
     url.SetHostName(strPath);

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -778,7 +778,8 @@ bool CVideoPlayer::OpenInputStream()
   // correct the filename if needed
   std::string filename(m_item.GetPath());
   if (URIUtils::IsProtocol(filename, "dvd") ||
-      StringUtils::EqualsNoCase(filename, "iso9660://video_ts/video_ts.ifo"))
+      StringUtils::EqualsNoCase(filename, "iso9660://video_ts/video_ts.ifo") || 
+      URIUtils::IsDiscStub(filename))
   {
     m_item.SetPath(g_mediaManager.TranslateDevicePath(""));
   }

--- a/xbmc/dialogs/GUIDialogSimpleMenu.cpp
+++ b/xbmc/dialogs/GUIDialogSimpleMenu.cpp
@@ -31,6 +31,7 @@
 #include "video/VideoInfoTag.h"
 #include "URL.h"
 #include "utils/Variant.h"
+#include "storage/MediaManager.h"
 
 bool CGUIDialogSimpleMenu::ShowPlaySelection(CFileItem& item)
 {
@@ -75,6 +76,19 @@ bool CGUIDialogSimpleMenu::ShowPlaySelection(CFileItem& item)
       return ShowPlaySelection(item, url.Get());
     }
   }
+
+  if (item.IsDiscStub())
+  {
+    std::string filename(g_mediaManager.TranslateDevicePath(""));
+    if (XFILE::CFile::Exists(URIUtils::AddFileToFolder(filename, "BDMV/index.bdmv")))
+    {
+      CURL url("bluray://");
+      url.SetHostName(filename);
+      url.SetFileName("root");
+      return ShowPlaySelection(item, url.Get());
+    }
+  }
+
   return true;
 }
 

--- a/xbmc/filesystem/EFileFile.cpp
+++ b/xbmc/filesystem/EFileFile.cpp
@@ -1,0 +1,86 @@
+/*
+ *      Copyright (C) 2005-2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "EFileFile.h"
+#include "URL.h"
+#include "utils/log.h"
+#include "utils/StringUtils.h"
+#include "utils/URIUtils.h"
+#include "utils/XMLUtils.h"
+
+using namespace XFILE;
+
+CEFileFile::CEFileFile(void)
+  : COverrideFile(true)
+{ }
+
+CEFileFile::~CEFileFile(void)
+{ }
+
+bool CEFileFile::Exists(const CURL& url)
+{
+  return CFile::Exists(GetOriginalPath(url));
+}
+
+void CEFileFile::GetMessages(const CURL& url, std::string& title, std::string& message)
+{
+  GetXMLString(url, "title", title);
+  GetXMLString(url, "message", message);
+}
+
+std::string CEFileFile::GetOriginalPath(const CURL& url)
+{
+  return URIUtils::AddFileToFolder(url.GetHostName(), url.GetFileName());
+}
+
+std::string CEFileFile::GetTranslatedPath(const CURL& url)
+{
+  return GetXMLString(url, "path");
+}
+
+std::string CEFileFile::GetXMLString(const CURL& url, std::string strXMLTag)
+{
+  std::string strValue;
+  GetXMLString(url, strXMLTag, strValue);
+  return strValue;
+}
+
+void CEFileFile::GetXMLString(const CURL& url, std::string strXMLTag, std::string& strValue)
+{
+  CXBMCTinyXML stubXML;
+  std::string strFilename(GetOriginalPath(url));
+  if (stubXML.LoadFile(strFilename))
+  {
+    TiXmlElement * pRootElement = stubXML.RootElement();
+    if (pRootElement)
+    {
+      if (!strXMLTag.empty()) {
+        XMLUtils::GetString(pRootElement, strXMLTag.c_str(), strValue);
+      }
+      return;
+    }
+  }
+  CLog::Log(LOGERROR, "Error loading %s", strFilename.c_str());
+}
+
+std::string CEFileFile::TranslatePath(const CURL& url)
+{
+  return GetTranslatedPath(url);
+}

--- a/xbmc/filesystem/EFileFile.h
+++ b/xbmc/filesystem/EFileFile.h
@@ -1,0 +1,41 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "filesystem/OverrideFile.h"
+
+namespace XFILE
+{
+class CEFileFile : public COverrideFile
+{
+public:
+  CEFileFile(void);
+  virtual ~CEFileFile(void);
+  virtual bool Exists(const CURL& url);
+  static std::string GetOriginalPath(const CURL& url);
+  static void GetMessages(const CURL& url, std::string& title, std::string& message);
+  static std::string GetTranslatedPath(const CURL& url);
+
+protected:
+  static std::string CEFileFile::GetXMLString(const CURL& url, std::string strXMLTag);
+  static void CEFileFile::GetXMLString(const CURL& url, std::string strXMLTag, std::string& strValue);
+  virtual std::string TranslatePath(const CURL& url);
+};
+}

--- a/xbmc/filesystem/FileDirectoryFactory.cpp
+++ b/xbmc/filesystem/FileDirectoryFactory.cpp
@@ -116,6 +116,15 @@ IFileDirectory* CFileDirectoryFactory::Create(const CURL& url, CFileItem* pItem,
     return NULL;
   }
 #endif
+  if (url.IsFileType("efile") && !url.IsProtocol("efile"))
+  {
+    std::string filename(url.Get());
+    pItem->SetPath((URIUtils::CreateArchivePath("efile", 
+      CURL(URIUtils::GetDirectory(filename)), 
+      URIUtils::GetFileName(filename))
+      ).Get());
+    return NULL;
+  }
   if (url.IsFileType("zip"))
   {
     CURL zipURL = URIUtils::CreateArchivePath("zip", url);

--- a/xbmc/filesystem/FileFactory.cpp
+++ b/xbmc/filesystem/FileFactory.cpp
@@ -72,6 +72,7 @@
 #include "PipeFile.h"
 #include "MusicDatabaseFile.h"
 #include "SpecialProtocolFile.h"
+#include "EfileFile.h"
 #include "MultiPathFile.h"
 #include "UDFFile.h"
 #include "ImageFile.h"
@@ -118,6 +119,7 @@ IFile* CFileFactory::CreateLoader(const CURL& url)
   else if (url.IsProtocol("musicdb")) return new CMusicDatabaseFile();
   else if (url.IsProtocol("videodb")) return NULL;
   else if (url.IsProtocol("special")) return new CSpecialProtocolFile();
+  else if (url.IsProtocol("efile")) return new CEFileFile();
   else if (url.IsProtocol("multipath")) return new CMultiPathFile();
   else if (url.IsProtocol("image")) return new CImageFile();
 #ifdef TARGET_POSIX

--- a/xbmc/filesystem/Makefile.in
+++ b/xbmc/filesystem/Makefile.in
@@ -15,6 +15,7 @@ SRCS += DirectoryFactory.cpp
 SRCS += DirectoryHistory.cpp
 SRCS += DllLibCurl.cpp
 SRCS += EventsDirectory.cpp
+SRCS += EFileFile.cpp
 SRCS += FavouritesDirectory.cpp
 SRCS += File.cpp
 SRCS += FileCache.cpp

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -384,9 +384,8 @@ void CAdvancedSettings::Initialize()
 
   m_pictureExtensions = ".png|.jpg|.jpeg|.bmp|.gif|.ico|.tif|.tiff|.tga|.pcx|.cbz|.zip|.cbr|.rar|.dng|.nef|.cr2|.crw|.orf|.arw|.erf|.3fr|.dcr|.x3f|.mef|.raf|.mrw|.pef|.sr2|.rss|.webp|.jp2|.apng";
   m_musicExtensions = ".nsv|.m4a|.flac|.aac|.strm|.pls|.rm|.rma|.mpa|.wav|.wma|.ogg|.mp3|.mp2|.m3u|.gdm|.imf|.m15|.sfx|.uni|.ac3|.dts|.cue|.aif|.aiff|.wpl|.ape|.mac|.mpc|.mp+|.mpp|.shn|.zip|.rar|.wv|.dsp|.xsp|.xwav|.waa|.wvs|.wam|.gcm|.idsp|.mpdsp|.mss|.spt|.rsd|.sap|.cmc|.cmr|.dmc|.mpt|.mpd|.rmt|.tmc|.tm8|.tm2|.oga|.url|.pxml|.tta|.rss|.wtv|.mka|.tak|.opus|.dff|.dsf";
-  m_videoExtensions = ".m4v|.3g2|.3gp|.nsv|.tp|.ts|.ty|.strm|.pls|.rm|.rmvb|.mpd|.m3u|.m3u8|.ifo|.mov|.qt|.divx|.xvid|.bivx|.vob|.nrg|.img|.iso|.pva|.wmv|.asf|.asx|.ogm|.m2v|.avi|.bin|.dat|.mpg|.mpeg|.mp4|.mkv|.mk3d|.avc|.vp3|.svq3|.nuv|.viv|.dv|.fli|.flv|.rar|.001|.wpl|.zip|.vdr|.dvr-ms|.xsp|.mts|.m2t|.m2ts|.evo|.ogv|.sdp|.avs|.rec|.url|.pxml|.vc1|.h264|.rcv|.rss|.mpls|.webm|.bdmv|.wtv|.efile";
+  m_videoExtensions = ".m4v|.3g2|.3gp|.nsv|.tp|.ts|.ty|.strm|.pls|.rm|.rmvb|.mpd|.m3u|.m3u8|.ifo|.mov|.qt|.divx|.xvid|.bivx|.vob|.nrg|.img|.iso|.pva|.wmv|.asf|.asx|.ogm|.m2v|.avi|.bin|.dat|.mpg|.mpeg|.mp4|.mkv|.mk3d|.avc|.vp3|.svq3|.nuv|.viv|.dv|.fli|.flv|.rar|.001|.wpl|.zip|.vdr|.dvr-ms|.xsp|.mts|.m2t|.m2ts|.evo|.ogv|.sdp|.avs|.rec|.url|.pxml|.vc1|.h264|.rcv|.rss|.mpls|.webm|.bdmv|.wtv|.efile|.disc";
   m_subtitlesExtensions = ".utf|.utf8|.utf-8|.sub|.srt|.smi|.rt|.txt|.ssa|.text|.ssa|.aqt|.jss|.ass|.idx|.ifo|.rar|.zip";
-  m_discStubExtensions = ".disc";
   // internal music extensions
   m_musicExtensions += "|.cdda";
   // internal video extensions

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -384,7 +384,7 @@ void CAdvancedSettings::Initialize()
 
   m_pictureExtensions = ".png|.jpg|.jpeg|.bmp|.gif|.ico|.tif|.tiff|.tga|.pcx|.cbz|.zip|.cbr|.rar|.dng|.nef|.cr2|.crw|.orf|.arw|.erf|.3fr|.dcr|.x3f|.mef|.raf|.mrw|.pef|.sr2|.rss|.webp|.jp2|.apng";
   m_musicExtensions = ".nsv|.m4a|.flac|.aac|.strm|.pls|.rm|.rma|.mpa|.wav|.wma|.ogg|.mp3|.mp2|.m3u|.gdm|.imf|.m15|.sfx|.uni|.ac3|.dts|.cue|.aif|.aiff|.wpl|.ape|.mac|.mpc|.mp+|.mpp|.shn|.zip|.rar|.wv|.dsp|.xsp|.xwav|.waa|.wvs|.wam|.gcm|.idsp|.mpdsp|.mss|.spt|.rsd|.sap|.cmc|.cmr|.dmc|.mpt|.mpd|.rmt|.tmc|.tm8|.tm2|.oga|.url|.pxml|.tta|.rss|.wtv|.mka|.tak|.opus|.dff|.dsf";
-  m_videoExtensions = ".m4v|.3g2|.3gp|.nsv|.tp|.ts|.ty|.strm|.pls|.rm|.rmvb|.mpd|.m3u|.m3u8|.ifo|.mov|.qt|.divx|.xvid|.bivx|.vob|.nrg|.img|.iso|.pva|.wmv|.asf|.asx|.ogm|.m2v|.avi|.bin|.dat|.mpg|.mpeg|.mp4|.mkv|.mk3d|.avc|.vp3|.svq3|.nuv|.viv|.dv|.fli|.flv|.rar|.001|.wpl|.zip|.vdr|.dvr-ms|.xsp|.mts|.m2t|.m2ts|.evo|.ogv|.sdp|.avs|.rec|.url|.pxml|.vc1|.h264|.rcv|.rss|.mpls|.webm|.bdmv|.wtv";
+  m_videoExtensions = ".m4v|.3g2|.3gp|.nsv|.tp|.ts|.ty|.strm|.pls|.rm|.rmvb|.mpd|.m3u|.m3u8|.ifo|.mov|.qt|.divx|.xvid|.bivx|.vob|.nrg|.img|.iso|.pva|.wmv|.asf|.asx|.ogm|.m2v|.avi|.bin|.dat|.mpg|.mpeg|.mp4|.mkv|.mk3d|.avc|.vp3|.svq3|.nuv|.viv|.dv|.fli|.flv|.rar|.001|.wpl|.zip|.vdr|.dvr-ms|.xsp|.mts|.m2t|.m2ts|.evo|.ogv|.sdp|.avs|.rec|.url|.pxml|.vc1|.h264|.rcv|.rss|.mpls|.webm|.bdmv|.wtv|.efile";
   m_subtitlesExtensions = ".utf|.utf8|.utf-8|.sub|.srt|.smi|.rt|.txt|.ssa|.text|.ssa|.aqt|.jss|.ass|.idx|.ifo|.rar|.zip";
   m_discStubExtensions = ".disc";
   // internal music extensions

--- a/xbmc/utils/FileUtils.cpp
+++ b/xbmc/utils/FileUtils.cpp
@@ -27,6 +27,7 @@
 #include "FileOperationJob.h"
 #include "URIUtils.h"
 #include "filesystem/StackDirectory.h"
+#include "filesystem/EFileFile.h"
 #include "filesystem/MultiPathDirectory.h"
 #include <vector>
 #include "settings/MediaSourceSettings.h"
@@ -112,7 +113,11 @@ bool CFileUtils::RemoteAccessAllowed(const std::string &strPath)
   const unsigned int SourcesSize = 5;
   std::string SourceNames[] = { "programs", "files", "video", "music", "pictures" };
 
-  std::string realPath = URIUtils::GetRealPath(strPath);
+  std::string realPath = strPath;
+  // for stub files we need to retrieve the original file
+  if (URIUtils::IsEFileStub(strPath))
+    realPath = CEFileFile::GetTranslatedPath(CURL(strPath));
+  realPath = URIUtils::GetRealPath(realPath);
   // for rar:// and zip:// paths we need to extract the path to the archive
   // instead of using the VFS path
   while (URIUtils::IsInArchive(realPath))

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -67,6 +67,8 @@ public:
                     std::string& strPath, std::string& strFileName);
   static std::vector<std::string> SplitPath(const std::string& strPath);
 
+  static std::string GetOpticalMediaPath();
+  static std::string GetOpticalMediaPath(const std::string& filename);
   static void GetCommonPath(std::string& strPath, const std::string& strPath2);
   static std::string GetParentPath(const std::string& strPath);
   static bool GetParentPath(const std::string& strPath, std::string& strParent);
@@ -157,6 +159,9 @@ public:
   static bool IsVideoDb(const std::string& strFile);
   static bool IsAPK(const std::string& strFile);
   static bool IsZIP(const std::string& strFile);
+  static bool IsDiscImage(const std::string& strFile);
+  static bool IsDiscStub(const std::string& strFile);
+  static bool IsEFileStub(const std::string& strFile);
   static bool IsArchive(const std::string& strFile);
   static bool IsBluray(const std::string& strFile);
   static bool IsAndroidApp(const std::string& strFile);

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -41,8 +41,10 @@
 #include "dialogs/GUIDialogYesNo.h"
 #include "FileItem.h"
 #include "filesystem/Directory.h"
+#include "filesystem/EFileFile.h"
 #include "filesystem/File.h"
 #include "filesystem/MultiPathDirectory.h"
+#include "filesystem/SpecialProtocol.h"
 #include "filesystem/StackDirectory.h"
 #include "guiinfo/GUIInfoLabels.h"
 #include "GUIInfoManager.h"
@@ -501,7 +503,10 @@ int CVideoDatabase::GetPathId(const std::string& strPath)
     if (NULL == m_pDS.get()) return -1;
 
     std::string strPath1(strPath);
-    if (URIUtils::IsStack(strPath) || StringUtils::StartsWithNoCase(strPath, "rar://") || StringUtils::StartsWithNoCase(strPath, "zip://"))
+    if (URIUtils::IsStack(strPath) || 
+        StringUtils::StartsWithNoCase(strPath, "rar://") || 
+        StringUtils::StartsWithNoCase(strPath, "zip://") || 
+        StringUtils::StartsWithNoCase(strPath, "efile://"))
       URIUtils::GetParentPath(strPath,strPath1);
 
     URIUtils::AddSlashAtEnd(strPath1);
@@ -701,7 +706,10 @@ int CVideoDatabase::AddPath(const std::string& strPath, const std::string &paren
     if (NULL == m_pDS.get()) return -1;
 
     std::string strPath1(strPath);
-    if (URIUtils::IsStack(strPath) || StringUtils::StartsWithNoCase(strPath, "rar://") || StringUtils::StartsWithNoCase(strPath, "zip://"))
+    if (URIUtils::IsStack(strPath) || 
+        StringUtils::StartsWithNoCase(strPath, "rar://") || 
+        StringUtils::StartsWithNoCase(strPath, "zip://") || 
+        StringUtils::StartsWithNoCase(strPath, "efile://"))
       URIUtils::GetParentPath(strPath,strPath1);
 
     URIUtils::AddSlashAtEnd(strPath1);
@@ -9241,7 +9249,9 @@ bool CVideoDatabase::ImportArtFromXML(const TiXmlNode *node, std::map<std::strin
 void CVideoDatabase::ConstructPath(std::string& strDest, const std::string& strPath, const std::string& strFileName)
 {
   if (URIUtils::IsStack(strFileName) || 
-      URIUtils::IsInArchive(strFileName) || URIUtils::IsPlugin(strPath))
+      URIUtils::IsInArchive(strFileName) || 
+      URIUtils::IsPlugin(strPath) || 
+      URIUtils::IsEFileStub(strFileName))
     strDest = strFileName;
   else
     strDest = URIUtils::AddFileToFolder(strPath, strFileName);
@@ -9249,7 +9259,10 @@ void CVideoDatabase::ConstructPath(std::string& strDest, const std::string& strP
 
 void CVideoDatabase::SplitPath(const std::string& strFileNameAndPath, std::string& strPath, std::string& strFileName)
 {
-  if (URIUtils::IsStack(strFileNameAndPath) || StringUtils::StartsWithNoCase(strFileNameAndPath, "rar://") || StringUtils::StartsWithNoCase(strFileNameAndPath, "zip://"))
+  if (URIUtils::IsStack(strFileNameAndPath) || 
+      StringUtils::StartsWithNoCase(strFileNameAndPath, "rar://") || 
+      StringUtils::StartsWithNoCase(strFileNameAndPath, "zip://") || 
+      StringUtils::StartsWithNoCase(strFileNameAndPath, "efile://"))
   {
     URIUtils::GetParentPath(strFileNameAndPath,strPath);
     strFileName = strFileNameAndPath;

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -2851,7 +2851,10 @@ void CVideoDatabase::GetBookMarksForFile(const std::string& strFilenameAndPath, 
 {
   try
   {
-    if (URIUtils::IsStack(strFilenameAndPath) && CFileItem(CStackDirectory::GetFirstStackedFile(strFilenameAndPath),false).IsDiscImage())
+    std::string firstStacked = CStackDirectory::GetFirstStackedFile(strFilenameAndPath);
+    if (URIUtils::IsStack(strFilenameAndPath) &&
+       (URIUtils::IsDiscImage(firstStacked) ||
+        URIUtils::IsDiscStub(firstStacked)))
     {
       CStackDirectory dir;
       CFileItemList fileList;
@@ -3591,7 +3594,10 @@ bool CVideoDatabase::GetResumePoint(CVideoInfoTag& tag)
 
   try
   {
-    if (URIUtils::IsStack(tag.m_strFileNameAndPath) && CFileItem(CStackDirectory::GetFirstStackedFile(tag.m_strFileNameAndPath),false).IsDiscImage())
+    std::string firstStacked = CStackDirectory::GetFirstStackedFile(tag.m_strFileNameAndPath);
+    if (URIUtils::IsStack(tag.m_strFileNameAndPath) &&
+       (URIUtils::IsDiscImage(firstStacked) ||
+        URIUtils::IsDiscStub(firstStacked)))
     {
       CStackDirectory dir;
       CFileItemList fileList;

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -26,6 +26,8 @@
 #include "cores/VideoPlayer/DVDFileInfo.h"
 #include "FileItem.h"
 #include "filesystem/DirectoryCache.h"
+#include "filesystem/EFileFile.h"
+#include "filesystem/File.h"
 #include "filesystem/StackDirectory.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/StereoscopicsManager.h"
@@ -93,8 +95,9 @@ bool CThumbExtractor::DoWork()
   ||  m_item.IsDiscImage()
   ||  m_item.IsDVDFile(false, true)
   ||  m_item.IsInternetStream()
-  ||  m_item.IsDiscStub()
-  ||  m_item.IsPlayList())
+  || m_item.IsPlayList()
+  || m_item.IsEFileStub()
+  || m_item.IsDiscStub())
     return false;
 
   // For HTTP/FTP we only allow extraction when on a LAN

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -646,7 +646,10 @@ bool CGUIWindowVideoBase::OnFileAction(int iItem, int action, std::string player
       {
         std::string itemPath(item->GetPath());
         itemPath = item->GetVideoInfoTag()->m_strFileNameAndPath;
-        if (URIUtils::IsStack(itemPath) && CFileItem(CStackDirectory::GetFirstStackedFile(itemPath),false).IsDiscImage())
+        std::string firstStacked = CStackDirectory::GetFirstStackedFile(itemPath);
+        if (URIUtils::IsStack(itemPath) && 
+           (URIUtils::IsDiscImage(firstStacked) ||
+            URIUtils::IsDiscStub(firstStacked)))
           choices.Add(SELECT_ACTION_PLAYPART, 20324); // Play Part
       }
 
@@ -834,7 +837,10 @@ void CGUIWindowVideoBase::GetContextButtons(int itemNumber, CContextButtons &but
         if (URIUtils::IsStack(path))
         {
           std::vector<int> times;
-          if (m_database.GetStackTimes(path,times) || CFileItem(CStackDirectory::GetFirstStackedFile(path),false).IsDiscImage())
+          std::string firstStacked = CStackDirectory::GetFirstStackedFile(path);
+          if (m_database.GetStackTimes(path, times) || 
+             (URIUtils::IsDiscImage(firstStacked) || 
+              URIUtils::IsDiscStub(firstStacked)))
             buttons.Add(CONTEXT_BUTTON_PLAY_PART, 20324);
         }
 
@@ -920,7 +926,8 @@ bool CGUIWindowVideoBase::OnPlayStackPart(int iItem)
   if (selectedFile >= 0)
   {
     // ISO stack
-    if (CFileItem(CStackDirectory::GetFirstStackedFile(path),false).IsDiscImage())
+    std::string firstStacked = CStackDirectory::GetFirstStackedFile(path);
+    if (URIUtils::IsDiscImage(firstStacked) || URIUtils::IsDiscStub(firstStacked))
     {
       std::string resumeString = CGUIWindowVideoBase::GetResumeString(*(parts[selectedFile].get()));
       stack->m_lStartOffset = 0;


### PR DESCRIPTION
This is a different version of https://github.com/xbmc/xbmc/pull/551.

It's the first time I go deep in Kodi code so please be patient with me.
I tried to hide stub files under Kodi vfs in efile:// urls. I used something similar to a mix of Zip and special protocol file for efile stubs.
I also improved disc stubs handling. Now theyworks similarly to iso files. Both they should work better now (thumbs creation, resume support, watched state, right info, episode bookmarks etc etc).

I also removed several CFileItem creations only to get to IsDiscImage with a specific URIUtils method (called also from CFileItem).

I have 3 doubts:
1) I used FileDirectoryFactory to translate to efile links because is the only way I could find to store an efile:// in the database so I could both get access to the real efile file and the destination one. There are better solutions?
2) I'm not sure if I have to disable thumbs creation for efile stubs or not. right now is disabled.
3) (unrelated) In DVDInputStreamBluray before kodi was checking for ".iso|.img" extensions. It's the only place where it doesn't use IsDiscImage that checks also for .nrg files. I replaced it with IsDiscImage. There's a different path for .nrg files I missed?

Needs xcode sync
