### PR TITLE
add 7 seconds as a seek option in the GUI without changing the defaults.

### DIFF
--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -116,7 +116,7 @@ void CAdvancedSettings::Initialize()
   m_limiterHold = 0.025f;
   m_limiterRelease = 0.1f;
 
-  m_seekSteps = { 10, 30, 60, 180, 300, 600, 1800 };
+  m_seekSteps = { 7, 10, 30, 60, 180, 300, 600, 1800 };
 
   m_omxHWAudioDecode = false;
   m_omxDecodeStartWithValidFrame = true;


### PR DESCRIPTION
This only makes it possible to select 7 seconds in the GUI. It is not selected by default. I'm hoping this is a fair compromise, since it is still easier to select in the GUI than making a keymap or advancedsettings.xml file.

7 seconds as a jump back has long since proven itself and is not an arbitrary value. People have tried to use other values for smallstepback/quick jump backs, and have compared our -7 seconds to what other video players use (5, 10, 15, etc), and what I've seen shows specific support for that amount of time. A lot of people are going to want an easy way to select that again in the GUI, especially after being used to 7 seconds for over 5 years. (5 years at least, I haven't found the exact date.)
