### PR TITLE
Change smallstepback to seek(-7) + debugging and reload keymap

### DIFF
--- a/system/keymaps/gamepad.xml
+++ b/system/keymaps/gamepad.xml
@@ -100,7 +100,7 @@
       <Y>AspectRatio</Y>
       <black>CodecInfo</black>
       <white>Info</white>
-      <back>SmallStepBack</back>
+      <back>Seek(-7)</back><!-- Replaces smallstepback -->
       <start>OSD</start>
       <leftanalogtrigger>AnalogRewind</leftanalogtrigger>
       <rightanalogtrigger>AnalogFastForward</rightanalogtrigger>

--- a/system/keymaps/joystick.Harmony.xml
+++ b/system/keymaps/joystick.Harmony.xml
@@ -167,7 +167,7 @@
       <!-- left       	-->      <button id="3">StepBack</button>
       <!-- right      	-->      <button id="4">StepForward</button>
       <!-- menu       	-->      <button id="6">OSD</button>
-      <!-- Prev		-->      <button id="32">SmallStepBack</button>
+      <!-- Prev		-->      <button id="32">Seek(-7)</button>
       <!-- Info  	-->      <button id="31">Info</button>
       <!-- F7		-->      <button id="95">NextSubtitle</button>
       <!-- F6		-->      <button id="94">ShowSubtitles</button>

--- a/system/keymaps/joystick.Microsoft.Xbox.360.Controller.xml
+++ b/system/keymaps/joystick.Microsoft.Xbox.360.Controller.xml
@@ -269,7 +269,7 @@
             -->
       <button id="5">AspectRatio</button>
       <button id="6">ShowSubtitles</button>
-      <button id="7">SmallStepBack</button>
+      <button id="7">Seek(-7)</button><!-- Replaces smallstepback -->
       <button id="8">Info</button>
       <button id="10">AudioNextLanguage</button>
       <button id="11">ChapterOrBigStepForward</button>
@@ -290,7 +290,7 @@
       <button id="3">OSD</button>
       <button id="5">AspectRatio</button>
       <button id="6">ShowSubtitles</button>
-      <button id="7">SmallStepBack</button>
+      <button id="7">Seek(-7)</button><!-- Replaces smallstepback -->
       <button id="8">Info</button>
       <button id="9">ActivateWindow(Home)</button>  <!-- guide -->
       <button id="10">ActivateWindow(ShutdownMenu)</button>  <!-- left stick -->

--- a/system/keymaps/joystick.Microsoft.Xbox.Controller.S.xml
+++ b/system/keymaps/joystick.Microsoft.Xbox.Controller.S.xml
@@ -124,7 +124,7 @@
       <button id="14">ChapterOrStepForward</button>
       <button id="15">BigStepBack</button>
       <button id="16">StepBack</button>
-      <button id="17">SmallStepBack</button>
+      <button id="17">Seek(-7)</button><!-- Replaces smallstepback -->
       <axis limit="0" id="3">AnalogRewind</axis>
       <axis limit="0" id="6">AnalogFastForward</axis>
     </joystick>

--- a/system/keymaps/joystick.Ouya.Controller.xml
+++ b/system/keymaps/joystick.Ouya.Controller.xml
@@ -80,7 +80,7 @@
       <button id="4">Stop</button>
       <button id="5">AspectRatio</button>
       <button id="6">ShowSubtitles</button>
-      <button id="7">SmallStepBack</button>
+      <button id="7">Seek(-7)</button><!-- Replaces smallstepback -->
       <button id="8">Info</button>
       <button id="9">BigStepForward</button>
       <button id="10">BigStepBack</button>

--- a/system/keymaps/joystick.PS4.Controller.xml
+++ b/system/keymaps/joystick.PS4.Controller.xml
@@ -84,7 +84,7 @@
       <button id="3">Stop</button>
       <button id="5">AspectRatio</button>
       <button id="6">ShowSubtitles</button>
-      <button id="11">SmallStepBack</button>
+      <button id="11">Seek(-7)</button><!-- Replaces smallstepback -->
       <button id="12">Info</button>
       <hat    id="1" position="left">StepBack</hat>
       <hat    id="1" position="right">StepForward</hat>

--- a/system/keymaps/joystick.Sony.PLAYSTATION(R)3.Controller.xml
+++ b/system/keymaps/joystick.Sony.PLAYSTATION(R)3.Controller.xml
@@ -156,7 +156,7 @@
       <button id="16">OSD</button>
       <button id="11">AspectRatio</button>
       <button id="12">ShowSubtitles</button>
-      <button id="1">SmallStepBack</button>
+      <button id="1">Seek(-7)</button><!-- Replaces smallstepback -->
       <button id="4">Info</button>
       <button id="17">ActivateWindow(Home)</button>
       <button id="2">ActivateWindow(ShutdownMenu)</button>

--- a/system/keymaps/joystick.xml.sample
+++ b/system/keymaps/joystick.xml.sample
@@ -106,7 +106,7 @@
             -->
       <button id="5">AspectRatio</button>
       <button id="6">ShowSubtitles</button>
-      <button id="7">SmallStepBack</button>
+      <button id="7">Seek(-7)</button><!-- Replaces smallstepback -->
       <button id="8">Info</button>
       <button id="10">AudioNextLanguage</button>
       <button id="11">BigStepForward</button>

--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -249,7 +249,7 @@
       <period>StepForward</period>
       <comma>StepBack</comma>
       <backspace>Fullscreen</backspace>
-      <quote>SmallStepBack</quote>
+      <quote>Seek(-7)</quote><!-- Replaces smallstepback -->
       <opensquarebracket>BigStepForward</opensquarebracket>
       <closesquarebracket>BigStepBack</closesquarebracket>
       <return>OSD</return>

--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -154,6 +154,8 @@
       <!-- MCE keypresses without an obvious use in XBMC -->
       <u mod="ctrl">Notification(MCEKeypress, DVD subtitle, 3)</u>
       <a mod="ctrl,shift">Notification(MCEKeypress, DVD audio, 3)</a>
+      <k mod="ctrl,shift">ReloadKeymaps</k>
+      <d mod="ctrl,shift">ToggleDebug</d>
     </keyboard>
   </global>
   <LoginScreen>

--- a/system/keymaps/touchscreen.xml
+++ b/system/keymaps/touchscreen.xml
@@ -19,7 +19,7 @@
       <swipe direction="right">StepForward</swipe>
       <swipe direction="up">ChapterOrBigStepForward</swipe>
       <swipe direction="down">ChapterOrBigStepBack</swipe>
-      <swipe direction="left" pointers="2">SmallStepBack</swipe>
+      <swipe direction="left" pointers="2">Seek(-7)</swipe>
     </touch>
   </FullScreenVideo>
   <Visualisation>


### PR DESCRIPTION
This way we can start to deprecate smallstepback completely thanks to the new seek built-in.

smallstepback to Seek(-7) on all our default keymaps.

Plus two actions I've been meaning to do as a PR anyways, but they seemed too minor to do on their own. For keymap.xml only:
shift+control+K: reloads keymaps
shift+control+d: toggle debugging

Two modifiers are used to help prevent any accidental triggering and shouldn't conflict with anything else.
