### PR TITLE
Add romanian keyboard layout

### DIFF
--- a/system/keyboardlayouts/romanian.xml
+++ b/system/keyboardlayouts/romanian.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+Please use English language names instead.
+Default font lacks support for all characters
+-->
+<keyboardlayouts>
+  <layout language="Romanian" layout="QWERTY">
+    <keyboard>
+      <row>1234567890</row>
+      <row>qwertyuiopăî</row>
+      <row>asdfghjklșțâ</row>
+      <row>zxcvbnm</row>
+    </keyboard>
+    <keyboard modifiers="shift">
+      <row>1234567890</row>
+      <row>QWERTYUIOPĂÎ</row>
+      <row>ASDFGHJKLȘȚÂ</row>
+      <row>ZXCVBNM</row>
+    </keyboard>
+    <keyboard modifiers="symbol,shift+symbol">
+      <row>)!@#$%^&amp;*(</row>
+      <row>[]{}-_=+;:</row>
+      <row>'",.&lt;&gt;/?\|</row>
+      <row>`~„”</row>
+    </keyboard>
+  </layout>
+</keyboardlayouts>


### PR DESCRIPTION
Hi guys

I added the romanian keyboard layout

For this to work properly this ticket must be fixed:
http://trac.kodi.tv/ticket/15847
It takes less than 2 minutes (see my comment there)
On my computer is fixed so this works as it should
I didn't include the fix in this pull request since I don't want to overstep and I'm not sure if github can show the difference between the two fonts.

Also I wanted to update  the romanian langinfo.xml, but i couldn't find it
Before it was in the root directory in language/romanian folder
Can you tell me where is it now?

Thanks
