### PR TITLE
upnp: fix renderer's PlayMedia()

### DIFF
--- a/xbmc/network/upnp/UPnPRenderer.cpp
+++ b/xbmc/network/upnp/UPnPRenderer.cpp
@@ -628,17 +628,12 @@ CUPnPRenderer::PlayMedia(const NPT_String& uri, const NPT_String& meta, PLT_Acti
         CApplicationMessenger::Get().MediaPlay(*item, false);
     }
 
-    if (g_application.m_pPlayer->IsPlaying() || g_windowManager.GetActiveWindow() == WINDOW_SLIDESHOW) {
-        NPT_AutoLock lock(m_state);
-        service->SetStateVariable("TransportState", "PLAYING");
-        service->SetStateVariable("TransportStatus", "OK");
-        service->SetStateVariable("AVTransportURI", uri);
-        service->SetStateVariable("AVTransportURIMetaData", meta);
-    } else {
-        NPT_AutoLock lock(m_state);
-        service->SetStateVariable("TransportState", "STOPPED");
-        service->SetStateVariable("TransportStatus", "ERROR_OCCURRED");
-    }
+    // just return success because the play actions are asynchronous
+    NPT_AutoLock lock(m_state);
+    service->SetStateVariable("TransportState", "PLAYING");
+    service->SetStateVariable("TransportStatus", "OK");
+    service->SetStateVariable("AVTransportURI", uri);
+    service->SetStateVariable("AVTransportURIMetaData", meta);
 
     service->SetStateVariable("NextAVTransportURI", "");
     service->SetStateVariable("NextAVTransportURIMetaData", "");


### PR DESCRIPTION
This kind of fixes our UPnP renderer. Since 6cbc08511db03ec39c29c5cc3f19b6cbc3e19f84 it has been partially broken because the call to `CApplicationMessenger::Get().MediaPlay(*item, false);` has become asynchronous so the check for `g_application.m_pPlayer->IsPlaying()` will most likely fail because playback hasn't been started yet (because it happens asynchronously) so we always return state `STOPPED` and status `ERROR_OCCURED` even though playback will most likely start a second or so later.

So while playback may successfully start, the UPnP controller that started playback will have received an error and will assume that starting playback failed and will not offer any playback controls.

Due to missing callbacks from the player to anything else but `CApplication` it's not easily possible to be notified in `CUPnPRenderer` about playback success or failure so we simply assume that starting playback succeeded and return success. Our UPnP controller implementation constantly polls the renderer during playback to get updates on the current status like playing, pausing, current position etc. so it will immediately notice if playback didn't actually start.

I still have to test this with a case where starting playback actually fails but the other case works now again (even though I don't really like the approach).
