### PR TITLE
[seekhandler] get rid of inaccurate seek size percent calculation

### DIFF
--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -264,6 +264,20 @@ void CApplicationPlayer::SeekTime(int64_t iTime)
     player->SeekTime(iTime);
 }
 
+void CApplicationPlayer::SeekTimeRelative(int64_t iTime)
+{
+  std::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+  {
+    // use relative seeking if implemented by player
+    if (!player->SeekTimeRelative(iTime))
+    {
+      int64_t abstime = player->GetTime() + iTime;
+      player->SeekTime(abstime);
+    }
+  }
+}
+
 std::string CApplicationPlayer::GetPlayingTitle()
 {
   std::shared_ptr<IPlayer> player = GetInternal();

--- a/xbmc/ApplicationPlayer.h
+++ b/xbmc/ApplicationPlayer.h
@@ -140,6 +140,7 @@ public:
   void  SeekPercentage(float fPercent = 0);
   bool  SeekScene(bool bPlus = true);
   void  SeekTime(int64_t iTime = 0);
+  void  SeekTimeRelative(int64_t iTime = 0);
   void  SetAudioStream(int iStream);
   void  SetAVDelay(float fValue = 0.0f);
   void  SetDynamicRangeCompression(long drc);

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -2144,7 +2144,7 @@ bool CGUIInfoManager::GetInt(int &value, int info, int contextWindow, const CGUI
             value = (int)(g_application.GetCachePercentage());
             break;
           case PLAYER_SEEKBAR:
-            value = (int)CSeekHandler::Get().GetPercent();
+            value = (int)GetSeekPercent();
             break;
           case PLAYER_CACHELEVEL:
             value = (int)(g_application.m_pPlayer->GetCacheLevel());
@@ -3276,11 +3276,12 @@ std::string CGUIInfoManager::GetMultiInfoLabel(const GUIInfo &info, int contextW
   }
   else if (info.m_info == PLAYER_SEEKSTEPSIZE)
   {
-    std::string seekOffset = StringUtils::SecondsToTimeString(abs(m_seekStepSize), (TIME_FORMAT)info.GetData1());
-    if (m_seekStepSize < 0)
-      return "-" + seekOffset;
-    if (m_seekStepSize > 0)
-      return "+" + seekOffset;
+    int seekSize = CSeekHandler::Get().GetSeekSize();
+    std::string strSeekSize = StringUtils::SecondsToTimeString(abs(seekSize), (TIME_FORMAT)info.GetData1());
+    if (seekSize < 0)
+      return "-" + strSeekSize;
+    if (seekSize > 0)
+      return "+" + strSeekSize;
   }
   else if (info.m_info == PLAYER_ITEM_ART)
   {
@@ -4110,8 +4111,7 @@ std::string CGUIInfoManager::GetCurrentSeekTime(TIME_FORMAT format) const
 {
   if (format == TIME_FORMAT_GUESS && GetTotalPlayTime() >= 3600)
     format = TIME_FORMAT_HH_MM_SS;
-  float time = GetTotalPlayTime() * CSeekHandler::Get().GetPercent() * 0.01f;
-  return StringUtils::SecondsToTimeString((int)time, format);
+  return StringUtils::SecondsToTimeString(g_application.GetTime() + CSeekHandler::Get().GetSeekSize(), format);
 }
 
 int CGUIInfoManager::GetTotalPlayTime() const
@@ -4124,6 +4124,23 @@ int CGUIInfoManager::GetPlayTimeRemaining() const
 {
   int iReverse = GetTotalPlayTime() - (int)g_application.GetTime();
   return iReverse > 0 ? iReverse : 0;
+}
+
+float CGUIInfoManager::GetSeekPercent() const
+{
+  if (g_infoManager.GetTotalPlayTime() == 0)
+    return 0.0f;
+
+  float percentPlayTime = static_cast<float>(GetPlayTime()) / GetTotalPlayTime() * 0.1f;
+  float percentPerSecond = 100.0f / static_cast<float>(GetTotalPlayTime());
+  float percent = percentPlayTime + percentPerSecond * CSeekHandler::Get().GetSeekSize();
+
+  if (percent > 100.0f)
+    percent = 100.0f;
+  if (percent < 0.0f)
+    percent = 0.0f;
+
+  return percent;
 }
 
 std::string CGUIInfoManager::GetCurrentPlayTimeRemaining(TIME_FORMAT format) const

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -112,8 +112,6 @@ CGUIInfoManager::CGUIInfoManager(void) :
   m_fanSpeed = 0;
   m_AfterSeekTimeout = 0;
   m_seekOffset = 0;
-  m_playerSeeking = false;
-  m_performingSeek = false;
   m_nextWindowID = WINDOW_INVALID;
   m_prevWindowID = WINDOW_INVALID;
   m_stringParameters.push_back("__ZZZZ__");   // to offset the string parameters by 1 to assure that all entries are non-zero
@@ -2592,7 +2590,7 @@ bool CGUIInfoManager::GetBool(int condition1, int contextWindow, const CGUIListI
       }
     break;
     case PLAYER_SEEKING:
-      bReturn = m_playerSeeking;
+      bReturn = CSeekHandler::Get().InProgress();
     break;
     case PLAYER_SHOWTIME:
       bReturn = m_playerShowTime;
@@ -4376,7 +4374,6 @@ std::string CGUIInfoManager::GetAppName()
 
 void CGUIInfoManager::SetDisplayAfterSeek(unsigned int timeOut, int seekOffset)
 {
-  g_infoManager.m_performingSeek = false;
   if (timeOut>0)
   {
     m_AfterSeekTimeout = CTimeUtils::GetFrameTime() +  timeOut;

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -803,6 +803,7 @@ public:
   std::string GetCurrentSeekTime(TIME_FORMAT format = TIME_FORMAT_GUESS) const;
   int GetPlayTimeRemaining() const;
   int GetTotalPlayTime() const;
+  float GetSeekPercent() const;
   std::string GetCurrentPlayTimeRemaining(TIME_FORMAT format) const;
   std::string GetVersionShort(void);
   std::string GetAppName();
@@ -811,7 +812,6 @@ public:
 
   bool GetDisplayAfterSeek();
   void SetDisplayAfterSeek(unsigned int timeOut = 2500, int seekOffset = 0);
-  void SetSeekStepSize(int seekStepSize) { m_seekStepSize = seekStepSize; };
   void SetSeeking(bool seeking) { m_playerSeeking = seeking; };
   void SetShowTime(bool showtime) { m_playerShowTime = showtime; };
   void SetShowCodec(bool showcodec) { m_playerShowCodec = showcodec; };
@@ -939,7 +939,6 @@ protected:
   //Fullscreen OSD Stuff
   unsigned int m_AfterSeekTimeout;
   int m_seekOffset;
-  int m_seekStepSize;
   bool m_playerSeeking;
   bool m_playerShowTime;
   bool m_playerShowCodec;

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -812,13 +812,11 @@ public:
 
   bool GetDisplayAfterSeek();
   void SetDisplayAfterSeek(unsigned int timeOut = 2500, int seekOffset = 0);
-  void SetSeeking(bool seeking) { m_playerSeeking = seeking; };
   void SetShowTime(bool showtime) { m_playerShowTime = showtime; };
   void SetShowCodec(bool showcodec) { m_playerShowCodec = showcodec; };
   void SetShowInfo(bool showinfo) { m_playerShowInfo = showinfo; };
   void ToggleShowCodec() { m_playerShowCodec = !m_playerShowCodec; };
   bool ToggleShowInfo() { m_playerShowInfo = !m_playerShowInfo; return m_playerShowInfo; };
-  bool m_performingSeek;
 
   std::string GetSystemHeatInfo(int info);
   CTemperature GetGPUTemperature();
@@ -939,7 +937,6 @@ protected:
   //Fullscreen OSD Stuff
   unsigned int m_AfterSeekTimeout;
   int m_seekOffset;
-  bool m_playerSeeking;
   bool m_playerShowTime;
   bool m_playerShowCodec;
   bool m_playerShowInfo;

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -194,6 +194,12 @@ public:
 
   virtual float GetActualFPS() { return 0.0f; };
   virtual void SeekTime(int64_t iTime = 0){};
+  /*
+   \brief seek relative to current time, returns false if not implemented by player
+   \param iTime The time in milliseconds to seek. A positive value will seek forward, a negative backward.
+   \return True if the player supports relative seeking, otherwise false
+   */
+  virtual bool SeekTimeRelative(int64_t iTime) { return false; }
   /*!
    \brief current time in milliseconds
    */

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -3158,6 +3158,15 @@ void CDVDPlayer::SeekTime(int64_t iTime)
   m_callback.OnPlayBackSeek((int)iTime, seekOffset);
 }
 
+bool CDVDPlayer::SeekTimeRelative(int64_t iTime)
+{
+  int64_t abstime = GetTime() + iTime;
+  m_messenger.Put(new CDVDMsgPlayerSeek((int)abstime, (iTime < 0) ? true : false, true, false));
+  SynchronizeDemuxer(100);
+  m_callback.OnPlayBackSeek((int)abstime, iTime);
+  return true;
+}
+
 // return the time in milliseconds
 int64_t CDVDPlayer::GetTime()
 {

--- a/xbmc/cores/dvdplayer/DVDPlayer.h
+++ b/xbmc/cores/dvdplayer/DVDPlayer.h
@@ -267,6 +267,7 @@ public:
   virtual int  SeekChapter(int iChapter);
 
   virtual void SeekTime(int64_t iTime);
+  virtual bool SeekTimeRelative(int64_t iTime);
   virtual int64_t GetTime();
   virtual int64_t GetTotalTime();
   virtual void ToFFRW(int iSpeed);

--- a/xbmc/dialogs/GUIDialogSeekBar.cpp
+++ b/xbmc/dialogs/GUIDialogSeekBar.cpp
@@ -68,8 +68,7 @@ void CGUIDialogSeekBar::FrameMove()
   }
 
   // update controls
-  if (!CSeekHandler::Get().InProgress() && !g_infoManager.m_performingSeek
-    && g_infoManager.GetTotalPlayTime())
+  if (!CSeekHandler::Get().InProgress() && g_infoManager.GetTotalPlayTime())
   { // position the bar at our current time
     CONTROL_SELECT_ITEM(POPUP_SEEK_PROGRESS, (unsigned int)(g_infoManager.GetPlayTime()/g_infoManager.GetTotalPlayTime() * 0.1f));
     SET_CONTROL_LABEL(POPUP_SEEK_LABEL, g_infoManager.GetCurrentPlayTime());

--- a/xbmc/dialogs/GUIDialogSeekBar.cpp
+++ b/xbmc/dialogs/GUIDialogSeekBar.cpp
@@ -76,7 +76,7 @@ void CGUIDialogSeekBar::FrameMove()
   }
   else
   {
-    CONTROL_SELECT_ITEM(POPUP_SEEK_PROGRESS, (unsigned int)CSeekHandler::Get().GetPercent());
+    CONTROL_SELECT_ITEM(POPUP_SEEK_PROGRESS, (unsigned int)g_infoManager.GetSeekPercent());
     SET_CONTROL_LABEL(POPUP_SEEK_LABEL, g_infoManager.GetCurrentSeekTime());
   }
 

--- a/xbmc/utils/SeekHandler.cpp
+++ b/xbmc/utils/SeekHandler.cpp
@@ -34,9 +34,8 @@
 CSeekHandler::CSeekHandler()
 : m_seekDelay(500),
   m_requireSeek(false),
-  m_percent(0.0f),
-  m_percentPlayTime(0.0f),
   m_analogSeek(false),
+  m_seekSize(0),
   m_seekStep(0)
 {
 }
@@ -57,8 +56,8 @@ CSeekHandler& CSeekHandler::Get()
 void CSeekHandler::Reset()
 {
   m_requireSeek = false;
-  m_percent = 0;
   m_seekStep = 0;
+  m_seekSize = 0;
 
   m_seekDelays.clear();
   m_seekDelays.insert(std::make_pair(SEEK_TYPE_VIDEO, CSettings::Get().GetInt("videoplayer.seekdelay")));
@@ -121,8 +120,7 @@ int CSeekHandler::GetSeekSeconds(bool forward, SeekType type)
 void CSeekHandler::Seek(bool forward, float amount, float duration /* = 0 */, bool analogSeek /* = false */, SeekType type /* = SEEK_TYPE_VIDEO */)
 {
   // abort if we do not have a play time or already perform a seek
-  if (g_infoManager.GetTotalPlayTime() == 0 ||
-      g_infoManager.m_performingSeek)
+  if (g_infoManager.m_performingSeek)
     return;
 
   CSingleLock lock(m_critSection);
@@ -130,56 +128,44 @@ void CSeekHandler::Seek(bool forward, float amount, float duration /* = 0 */, bo
   // not yet seeking
   if (!m_requireSeek)
   {
-    m_percent = static_cast<float>(g_infoManager.GetPlayTime()) / g_infoManager.GetTotalPlayTime() * 0.1f;
-    m_percentPlayTime = m_percent;
-
     // tell info manager that we have started a seek operation
     m_requireSeek = true;
     g_infoManager.SetSeeking(true);
     m_seekStep = 0;
+    m_seekSize = 0;
     m_analogSeek = analogSeek;
     m_seekDelay = analogSeek ? analogSeekDelay : m_seekDelays.at(type);
   }
 
   // calculate our seek amount
-  if (!g_infoManager.m_performingSeek)
+  if (analogSeek)
   {
-    if (analogSeek)
-    {
-      //100% over 1 second.
-      float speed = 100.0f;
-      if( duration )
-        speed *= duration;
-      else
-        speed /= g_infoManager.GetFPS();
+    //100% over 1 second.
+    float speed = 100.0f;
+    if( duration )
+      speed *= duration;
+    else
+      speed /= g_infoManager.GetFPS();
 
-      if (forward)
-        m_percent += amount * amount * speed;
-      else
-        m_percent -= amount * amount * speed;
+    int seekSize = (amount * amount * speed) * g_infoManager.GetTotalPlayTime() / 100;
+    if (forward)
+      m_seekSize += seekSize;
+    else
+      m_seekSize -= seekSize;
+  }
+  else
+  {
+    int seekSeconds = GetSeekSeconds(forward, type);
+    if (seekSeconds != 0)
+    {
+      m_seekSize = seekSeconds;
     }
     else
     {
-      int seekSeconds = GetSeekSeconds(forward, type);
-      if (seekSeconds != 0)
-      {
-        float percentPerSecond = 100.0f / static_cast<float>(g_infoManager.GetTotalPlayTime());
-        m_percent = m_percentPlayTime + percentPerSecond * seekSeconds;
-
-        g_infoManager.SetSeekStepSize(seekSeconds);
-      }
-      else
-      {
-        // nothing to do, abort seeking
-        m_requireSeek = false;
-        g_infoManager.SetSeeking(false);
-      }
+      // nothing to do, abort seeking
+      m_requireSeek = false;
+      g_infoManager.SetSeeking(false);
     }
-
-    if (m_percent > 100.0f)
-      m_percent = 100.0f;
-    if (m_percent < 0.0f)
-      m_percent = 0.0f;
   }
 
   m_timer.StartZero();
@@ -188,35 +174,22 @@ void CSeekHandler::Seek(bool forward, float amount, float duration /* = 0 */, bo
 void CSeekHandler::SeekSeconds(int seconds)
 {
   // abort if we do not have a play time or already perform a seek
-  if (seconds == 0 ||
-      g_infoManager.GetTotalPlayTime() == 0 ||
-      g_infoManager.m_performingSeek)
+  if (seconds == 0 || g_infoManager.m_performingSeek)
     return;
 
   CSingleLock lock(m_critSection);
 
   m_requireSeek = true;
   m_seekDelay = 0;
-
+  m_seekSize = seconds;
   g_infoManager.SetSeeking(true);
-  g_infoManager.SetSeekStepSize(seconds);
-
-  float percentPlayTime = static_cast<float>(g_infoManager.GetPlayTime()) / g_infoManager.GetTotalPlayTime() * 0.1f;
-  float percentPerSecond = 100.0f / static_cast<float>(g_infoManager.GetTotalPlayTime());
-
-  m_percent = percentPlayTime + percentPerSecond * seconds;
-
-  if (m_percent > 100.0f)
-    m_percent = 100.0f;
-  if (m_percent < 0.0f)
-    m_percent = 0.0f;
 
   m_timer.StartZero();
 }
 
-float CSeekHandler::GetPercent() const
+int CSeekHandler::GetSeekSize() const
 {
-  return m_percent;
+  return m_seekSize;
 }
 
 bool CSeekHandler::InProgress() const
@@ -230,13 +203,9 @@ void CSeekHandler::Process()
   {
     g_infoManager.m_performingSeek = true;
 
-    // reset seek step size
-    g_infoManager.SetSeekStepSize(0);
+    // perform relative seek
+    g_application.m_pPlayer->SeekTimeRelative(static_cast<int64_t>(m_seekSize * 1000));
 
-    // calculate the seek time
-    double time = g_infoManager.GetTotalPlayTime() * m_percent * 0.01;
-
-    g_application.SeekTime(time);
     m_requireSeek = false;
     g_infoManager.SetSeeking(false);
   }

--- a/xbmc/utils/SeekHandler.h
+++ b/xbmc/utils/SeekHandler.h
@@ -65,6 +65,7 @@ private:
   std::map<SeekType, int > m_seekDelays;
   bool       m_requireSeek;
   bool       m_analogSeek;
+  bool       m_performingSeek;
   int        m_seekSize;
   int        m_seekStep;
   std::map<SeekType, std::vector<int> > m_forwardSeekSteps;

--- a/xbmc/utils/SeekHandler.h
+++ b/xbmc/utils/SeekHandler.h
@@ -48,7 +48,7 @@ public:
   void Process();
   void Reset();
 
-  float GetPercent() const;
+  int GetSeekSize() const;
   bool InProgress() const;
 
 protected:
@@ -64,9 +64,8 @@ private:
   int        m_seekDelay;
   std::map<SeekType, int > m_seekDelays;
   bool       m_requireSeek;
-  float      m_percent;
-  float      m_percentPlayTime;
   bool       m_analogSeek;
+  int        m_seekSize;
   int        m_seekStep;
   std::map<SeekType, std::vector<int> > m_forwardSeekSteps;
   std::map<SeekType, std::vector<int> > m_backwardSeekSteps;


### PR DESCRIPTION
This removes the inaccurate seek size calculation which relies on percent and uses seconds instead.
As we need the seek size percent for the GUI seek progress bar this calculation is refactored into our CGUIInfoManager.

@FernetMenta mind taking a look
