### PR TITLE
Expand episode bookmarks to every media

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -12784,11 +12784,11 @@ msgid "Remove bookmark"
 msgstr ""
 
 msgctxt "#20405"
-msgid "Remove episode bookmark"
+msgid "Remove media bookmark"
 msgstr ""
 
 msgctxt "#20406"
-msgid "Set episode bookmark"
+msgid "Set media bookmark"
 msgstr ""
 
 msgctxt "#20407"
@@ -13103,7 +13103,22 @@ msgctxt "#20471"
 msgid "Show empty TV shows"
 msgstr ""
 
-#empty strings from id 20472 to 21329
+#: xbmc/video/Bookmark.cpp
+msgctxt "#20472"
+msgid "Main music video"
+msgstr ""
+
+#: xbmc/video/Bookmark.cpp
+msgctxt "#20473"
+msgid "Season %i Episode %i"
+msgstr ""
+
+#: xbmc/video/Bookmark.cpp
+msgctxt "#20474"
+msgid "Main movie"
+msgstr ""
+
+#empty strings from id 20475 to 21329
 #up to 21329 is reserved for the video db !! !
 
 #: system/settings/settings.xml
@@ -13200,7 +13215,7 @@ msgstr ""
 
 #: xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
 msgctxt "#21363"
-msgid "Episode bookmark created"
+msgid "Media Bookmark created"
 msgstr ""
 
 #: xbmc/dialogs/GUIDialogFileBrowser.cpp

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1956,9 +1956,9 @@ bool CApplication::OnAction(const CAction &action)
   if (action.IsMouse())
     CServiceBroker::GetInputManager().SetMouseActive(true);
 
-  if (action.GetID() == ACTION_CREATE_EPISODE_BOOKMARK)
+  if (action.GetID() == ACTION_CREATE_MEDIA_BOOKMARK)
   {
-    CGUIDialogVideoBookmarks::OnAddEpisodeBookmark();
+    CGUIDialogVideoBookmarks::OnAddMediaBookmark();
   }
   if (action.GetID() == ACTION_CREATE_BOOKMARK)
   {
@@ -3287,7 +3287,7 @@ PlayBackRet CApplication::PlayFile(CFileItem item, const std::string& player, bo
           if (tag->m_iBookmarkId > 0)
           {
             CBookmark bookmark;
-            dbs.GetBookMarkForEpisode(*tag, bookmark);
+            dbs.GetBookMarkForMedia(*tag, bookmark);
             options.starttime = bookmark.timeInSeconds;
             options.state = bookmark.playerState;
           }
@@ -3300,7 +3300,7 @@ PlayBackRet CApplication::PlayFile(CFileItem item, const std::string& player, bo
         if (tag->m_iBookmarkId > 0)
         {
           CBookmark bookmark;
-          dbs.GetBookMarkForEpisode(*tag, bookmark);
+          dbs.GetBookMarkForMedia(*tag, bookmark);
           options.starttime = bookmark.timeInSeconds;
           options.state = bookmark.playerState;
         }

--- a/xbmc/input/ActionIDs.h
+++ b/xbmc/input/ActionIDs.h
@@ -124,7 +124,7 @@
 #define ACTION_VOLAMP_UP            93
 #define ACTION_VOLAMP_DOWN          94
 
-#define ACTION_CREATE_EPISODE_BOOKMARK 95 //!< Creates an episode bookmark on the currently playing video file containing more than one episode
+#define ACTION_CREATE_MEDIA_BOOKMARK   95 //!< Creates a media bookmark on the currently playing video file containing more than one episode
 #define ACTION_CREATE_BOOKMARK         96 //!< Creates a bookmark of the currently playing video file
 
 #define ACTION_CHAPTER_OR_BIG_STEP_FORWARD       97 //!< Goto the next chapter, if not available perform a big step forward

--- a/xbmc/input/ActionTranslator.cpp
+++ b/xbmc/input/ActionTranslator.cpp
@@ -195,7 +195,8 @@ static const std::map<ActionName, ActionID> ActionMappings =
     { "volampdown"               , ACTION_VOLAMP_DOWN },
     { "volumeamplification"      , ACTION_VOLAMP },
     { "createbookmark"           , ACTION_CREATE_BOOKMARK },
-    { "createepisodebookmark"    , ACTION_CREATE_EPISODE_BOOKMARK },
+    { "createepisodebookmark"    , ACTION_CREATE_MEDIA_BOOKMARK },
+    { "createmediabookmark"      , ACTION_CREATE_MEDIA_BOOKMARK },
     { "settingsreset"            , ACTION_SETTINGS_RESET },
     { "settingslevelchange"      , ACTION_SETTINGS_LEVEL_CHANGE },
 

--- a/xbmc/video/Bookmark.cpp
+++ b/xbmc/video/Bookmark.cpp
@@ -19,6 +19,9 @@
  */
 
 #include "Bookmark.h"
+#include "guilib/LocalizeStrings.h"
+#include "utils/StringUtils.h"
+#include "video/VideoDatabase.h"
 
 CBookmark::CBookmark()
 {
@@ -27,11 +30,13 @@ CBookmark::CBookmark()
 
 void CBookmark::Reset()
 {
+  idBookmark = -1;
   episodeNumber = 0;
-  seasonNumber = 0;
+  seasonNumber = -1;
   timeInSeconds = 0.0f;
   totalTimeInSeconds = 0.0f;
   partNumber = 0;
+  mediaType = MediaTypeNone;
   type = STANDARD;
 }
 
@@ -43,4 +48,32 @@ bool CBookmark::IsSet() const
 bool CBookmark::IsPartWay() const
 {
   return totalTimeInSeconds > 0.0f && timeInSeconds > 0.0f;
+}
+
+std::string CBookmark::GetBookmarkTitle()
+{
+  switch (type)
+  {
+  case CBookmark::RESUME:
+  case CBookmark::STANDARD:
+    return StringUtils::SecondsToTimeString(static_cast<long>(timeInSeconds), TIME_FORMAT_HH_MM_SS);
+  default:
+    if (mediaType == MediaTypeEpisode)
+    {
+      if (seasonNumber == -1 && episodeNumber == 0)
+      {
+        CVideoDatabase videoDatabase;
+        videoDatabase.Open();
+        videoDatabase.GetEpisodeByBookmarkID(idBookmark, seasonNumber, episodeNumber);
+        videoDatabase.Close();
+      }
+      return StringUtils::Format(g_localizeStrings.Get(20473).c_str(), seasonNumber, episodeNumber);
+    }
+    if (mediaType == MediaTypeMovie)
+      return g_localizeStrings.Get(20474);
+    if (mediaType == MediaTypeMusicVideo)
+      return g_localizeStrings.Get(20472);
+    break;
+  }
+  return "";
 }

--- a/xbmc/video/Bookmark.h
+++ b/xbmc/video/Bookmark.h
@@ -21,6 +21,7 @@
 
 #include <string>
 #include <vector>
+#include "media/MediaType.h"
 
 class CBookmark
 {
@@ -38,20 +39,24 @@ public:
    */
   bool IsPartWay() const;
 
+  std::string GetBookmarkTitle();
+
   double timeInSeconds;
   double totalTimeInSeconds;
   long partNumber;
   std::string thumbNailImage;
   std::string playerState;
   std::string player;
+  int idBookmark;
   long seasonNumber;
   long episodeNumber;
+  MediaType mediaType;
 
   enum EType
   {
     STANDARD = 0,
     RESUME = 1,
-    EPISODE = 2
+    MEDIA = 2
   } type;
 };
 

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -89,21 +89,22 @@ enum VideoDbDetails
 #define VIDEODB_DETAILS_MOVIE_SET_ID            VIDEODB_MAX_COLUMNS + 2
 #define VIDEODB_DETAILS_MOVIE_USER_RATING       VIDEODB_MAX_COLUMNS + 3
 #define VIDEODB_DETAILS_MOVIE_PREMIERED         VIDEODB_MAX_COLUMNS + 4
-#define VIDEODB_DETAILS_MOVIE_SET_NAME          VIDEODB_MAX_COLUMNS + 5
-#define VIDEODB_DETAILS_MOVIE_SET_OVERVIEW      VIDEODB_MAX_COLUMNS + 6
-#define VIDEODB_DETAILS_MOVIE_FILE              VIDEODB_MAX_COLUMNS + 7
-#define VIDEODB_DETAILS_MOVIE_PATH              VIDEODB_MAX_COLUMNS + 8
-#define VIDEODB_DETAILS_MOVIE_PLAYCOUNT         VIDEODB_MAX_COLUMNS + 9
-#define VIDEODB_DETAILS_MOVIE_LASTPLAYED        VIDEODB_MAX_COLUMNS + 10
-#define VIDEODB_DETAILS_MOVIE_DATEADDED         VIDEODB_MAX_COLUMNS + 11
-#define VIDEODB_DETAILS_MOVIE_RESUME_TIME       VIDEODB_MAX_COLUMNS + 12
-#define VIDEODB_DETAILS_MOVIE_TOTAL_TIME        VIDEODB_MAX_COLUMNS + 13
-#define VIDEODB_DETAILS_MOVIE_PLAYER_STATE      VIDEODB_MAX_COLUMNS + 14
-#define VIDEODB_DETAILS_MOVIE_RATING            VIDEODB_MAX_COLUMNS + 15
-#define VIDEODB_DETAILS_MOVIE_VOTES             VIDEODB_MAX_COLUMNS + 16
-#define VIDEODB_DETAILS_MOVIE_RATING_TYPE       VIDEODB_MAX_COLUMNS + 17
-#define VIDEODB_DETAILS_MOVIE_UNIQUEID_VALUE    VIDEODB_MAX_COLUMNS + 18
-#define VIDEODB_DETAILS_MOVIE_UNIQUEID_TYPE     VIDEODB_MAX_COLUMNS + 19
+#define VIDEODB_DETAILS_MOVIE_BOOKMARK          VIDEODB_MAX_COLUMNS + 5
+#define VIDEODB_DETAILS_MOVIE_SET_NAME          VIDEODB_MAX_COLUMNS + 6
+#define VIDEODB_DETAILS_MOVIE_SET_OVERVIEW      VIDEODB_MAX_COLUMNS + 7
+#define VIDEODB_DETAILS_MOVIE_FILE              VIDEODB_MAX_COLUMNS + 8
+#define VIDEODB_DETAILS_MOVIE_PATH              VIDEODB_MAX_COLUMNS + 9
+#define VIDEODB_DETAILS_MOVIE_PLAYCOUNT         VIDEODB_MAX_COLUMNS + 10
+#define VIDEODB_DETAILS_MOVIE_LASTPLAYED        VIDEODB_MAX_COLUMNS + 11
+#define VIDEODB_DETAILS_MOVIE_DATEADDED         VIDEODB_MAX_COLUMNS + 12
+#define VIDEODB_DETAILS_MOVIE_RESUME_TIME       VIDEODB_MAX_COLUMNS + 13
+#define VIDEODB_DETAILS_MOVIE_TOTAL_TIME        VIDEODB_MAX_COLUMNS + 14
+#define VIDEODB_DETAILS_MOVIE_PLAYER_STATE      VIDEODB_MAX_COLUMNS + 15
+#define VIDEODB_DETAILS_MOVIE_RATING            VIDEODB_MAX_COLUMNS + 16
+#define VIDEODB_DETAILS_MOVIE_VOTES             VIDEODB_MAX_COLUMNS + 17
+#define VIDEODB_DETAILS_MOVIE_RATING_TYPE       VIDEODB_MAX_COLUMNS + 18
+#define VIDEODB_DETAILS_MOVIE_UNIQUEID_VALUE    VIDEODB_MAX_COLUMNS + 19
+#define VIDEODB_DETAILS_MOVIE_UNIQUEID_TYPE     VIDEODB_MAX_COLUMNS + 20
 
 #define VIDEODB_DETAILS_EPISODE_TVSHOW_ID       VIDEODB_MAX_COLUMNS + 2
 #define VIDEODB_DETAILS_EPISODE_USER_RATING     VIDEODB_MAX_COLUMNS + 3
@@ -144,14 +145,15 @@ enum VideoDbDetails
 
 #define VIDEODB_DETAILS_MUSICVIDEO_USER_RATING  VIDEODB_MAX_COLUMNS + 2
 #define VIDEODB_DETAILS_MUSICVIDEO_PREMIERED    VIDEODB_MAX_COLUMNS + 3
-#define VIDEODB_DETAILS_MUSICVIDEO_FILE         VIDEODB_MAX_COLUMNS + 4
-#define VIDEODB_DETAILS_MUSICVIDEO_PATH         VIDEODB_MAX_COLUMNS + 5
-#define VIDEODB_DETAILS_MUSICVIDEO_PLAYCOUNT    VIDEODB_MAX_COLUMNS + 6
-#define VIDEODB_DETAILS_MUSICVIDEO_LASTPLAYED   VIDEODB_MAX_COLUMNS + 7
-#define VIDEODB_DETAILS_MUSICVIDEO_DATEADDED    VIDEODB_MAX_COLUMNS + 8
-#define VIDEODB_DETAILS_MUSICVIDEO_RESUME_TIME  VIDEODB_MAX_COLUMNS + 9
-#define VIDEODB_DETAILS_MUSICVIDEO_TOTAL_TIME   VIDEODB_MAX_COLUMNS + 10
-#define VIDEODB_DETAILS_MUSICVIDEO_PLAYER_STATE VIDEODB_MAX_COLUMNS + 11
+#define VIDEODB_DETAILS_MUSICVIDEO_BOOKMARK     VIDEODB_MAX_COLUMNS + 4
+#define VIDEODB_DETAILS_MUSICVIDEO_FILE         VIDEODB_MAX_COLUMNS + 5
+#define VIDEODB_DETAILS_MUSICVIDEO_PATH         VIDEODB_MAX_COLUMNS + 6
+#define VIDEODB_DETAILS_MUSICVIDEO_PLAYCOUNT    VIDEODB_MAX_COLUMNS + 7
+#define VIDEODB_DETAILS_MUSICVIDEO_LASTPLAYED   VIDEODB_MAX_COLUMNS + 8
+#define VIDEODB_DETAILS_MUSICVIDEO_DATEADDED    VIDEODB_MAX_COLUMNS + 9
+#define VIDEODB_DETAILS_MUSICVIDEO_RESUME_TIME  VIDEODB_MAX_COLUMNS + 10
+#define VIDEODB_DETAILS_MUSICVIDEO_TOTAL_TIME   VIDEODB_MAX_COLUMNS + 11
+#define VIDEODB_DETAILS_MUSICVIDEO_PLAYER_STATE VIDEODB_MAX_COLUMNS + 12
 
 #define VIDEODB_TYPE_UNUSED 0
 #define VIDEODB_TYPE_STRING 1
@@ -600,16 +602,17 @@ public:
   bool GetStackTimes(const std::string &filePath, std::vector<int> &times);
   void SetStackTimes(const std::string &filePath, const std::vector<int> &times);
 
-  void GetBookMarksForFile(const std::string& strFilenameAndPath, VECBOOKMARKS& bookmarks, CBookmark::EType type = CBookmark::STANDARD, bool bAppend=false, long partNumber=0);
-  void AddBookMarkToFile(const std::string& strFilenameAndPath, const CBookmark &bookmark, CBookmark::EType type = CBookmark::STANDARD);
+  void GetBookMarksForFile(const std::string& strFilenameAndPath, VECBOOKMARKS& bookmarks, CBookmark::EType type = CBookmark::STANDARD, MediaType mediaType = MediaTypeNone, bool bAppend=false, long partNumber=0);
+  void AddBookMarkToFile(const std::string& strFilenameAndPath, const CBookmark &bookmark, CBookmark::EType type = CBookmark::STANDARD, MediaType mediaType = MediaTypeNone, int idFile = -1);
   bool GetResumeBookMark(const std::string& strFilenameAndPath, CBookmark &bookmark);
   void DeleteResumeBookMark(const std::string &strFilenameAndPath);
-  void ClearBookMarkOfFile(const std::string& strFilenameAndPath, CBookmark& bookmark, CBookmark::EType type = CBookmark::STANDARD);
-  void ClearBookMarksOfFile(const std::string& strFilenameAndPath, CBookmark::EType type = CBookmark::STANDARD);
-  void ClearBookMarksOfFile(int idFile, CBookmark::EType type = CBookmark::STANDARD);
-  bool GetBookMarkForEpisode(const CVideoInfoTag& tag, CBookmark& bookmark);
-  void AddBookMarkForEpisode(const CVideoInfoTag& tag, const CBookmark& bookmark);
-  void DeleteBookMarkForEpisode(const CVideoInfoTag& tag);
+  void ClearBookMarkOfFile(const std::string& strFilenameAndPath, CBookmark& bookmark, CBookmark::EType type = CBookmark::STANDARD, MediaType mediaType = MediaTypeNone);
+  void ClearBookMarksOfFile(const std::string& strFilenameAndPath, CBookmark::EType type = CBookmark::STANDARD, MediaType mediaType = MediaTypeNone);
+  void ClearBookMarksOfFile(int idFile, CBookmark::EType type = CBookmark::STANDARD, MediaType mediaType = MediaTypeNone);
+  void GetEpisodeByBookmarkID(int bookmarkID, long& season, long& episode);
+  bool GetBookMarkForMedia(const CVideoInfoTag& tag, CBookmark& bookmark);
+  void AddBookMarkForMedia(const CVideoInfoTag& tag);
+  void DeleteBookMarkForMedia(const CVideoInfoTag& tag);
   bool GetResumePoint(CVideoInfoTag& tag);
   bool GetStreamDetails(CFileItem& item);
   bool GetStreamDetails(CVideoInfoTag& tag) const;

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1231,6 +1231,11 @@ namespace VIDEO
         else
           CLog::Log(LOGDEBUG, "VideoInfoScanner: Failed to link movie %s to show %s", movieDetails.m_strTitle.c_str(), movieDetails.m_showLink[i].c_str());
       }
+      if (movieDetails.m_EpBookmark.timeInSeconds > 0)
+      {
+        movieDetails.m_strFileNameAndPath = pItem->GetPath();
+        m_database.AddBookMarkForMedia(movieDetails);
+      }
     }
     else if (content == CONTENT_TVSHOWS)
     {
@@ -1269,9 +1274,7 @@ namespace VIDEO
         if (movieDetails.m_EpBookmark.timeInSeconds > 0)
         {
           movieDetails.m_strFileNameAndPath = pItem->GetPath();
-          movieDetails.m_EpBookmark.seasonNumber = movieDetails.m_iSeason;
-          movieDetails.m_EpBookmark.episodeNumber = movieDetails.m_iEpisode;
-          m_database.AddBookMarkForEpisode(movieDetails, movieDetails.m_EpBookmark);
+          m_database.AddBookMarkForMedia(movieDetails);
         }
       }
     }
@@ -1280,6 +1283,11 @@ namespace VIDEO
       lResult = m_database.SetDetailsForMusicVideo(pItem->GetPath(), movieDetails, art);
       movieDetails.m_iDbId = lResult;
       movieDetails.m_type = MediaTypeMusicVideo;
+      if (movieDetails.m_EpBookmark.timeInSeconds > 0)
+      {
+        movieDetails.m_strFileNameAndPath = pItem->GetPath();
+        m_database.AddBookMarkForMedia(movieDetails);
+      }
     }
 
     if (g_advancedSettings.m_bVideoLibraryImportWatchedState || libraryImport)

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -89,7 +89,7 @@ void CVideoInfoTag::Reset()
   m_streamDetails.Reset();
   m_playCount = PLAYCOUNT_NOT_SET;
   m_EpBookmark.Reset();
-  m_EpBookmark.type = CBookmark::EPISODE;
+  m_EpBookmark.type = CBookmark::MEDIA;
   m_basePath.clear();
   m_parentPathID = -1;
   m_resumePoint.Reset();

--- a/xbmc/video/dialogs/GUIDialogVideoBookmarks.h
+++ b/xbmc/video/dialogs/GUIDialogVideoBookmarks.h
@@ -44,7 +44,7 @@ public:
    
           NOTE: sends a GUI_MSG_REFRESH_LIST message to DialogVideoBookmark on success
    \return True if creation of bookmark was succesful
-   \sa OnAddEpisodeBookmark
+   \sa OnAddMediaBookmark
    */
   static bool OnAddBookmark();
   
@@ -57,14 +57,14 @@ public:
    \return True, if bookmark was successfully created
    \sa OnAddBookmark
    **/
-  static bool OnAddEpisodeBookmark();
+  static bool OnAddMediaBookmark();
   
   
   void Update();
 protected:
   void GotoBookmark(int iItem);
   void ClearBookmarks();
-  static bool AddEpisodeBookmark();
+  static bool AddMediaBookmark();
   static bool AddBookmark(CVideoInfoTag *tag=NULL);
   void Delete(int item);
   void Clear();
@@ -80,6 +80,7 @@ protected:
 
 private:
   void UpdateItem(unsigned int chapterIdx);
+  static bool GetEpisodesByFile(const std::string& currentFile, std::vector<CVideoInfoTag>& episodes);
 
   int m_jobsStarted;
   std::string m_filePath;

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -1033,7 +1033,7 @@ int CGUIDialogVideoInfo::ManageVideoItem(const CFileItemPtr &item)
     buttons.Add(CONTEXT_BUTTON_SET_MOVIESET, 20465);
   }
 
-  if (type == MediaTypeEpisode &&
+  if (!CMediaTypes::IsContainer(type) &&
       item->GetVideoInfoTag()->m_iBookmarkId > 0)
     buttons.Add(CONTEXT_BUTTON_UNLINK_BOOKMARK, 20405);
 
@@ -1101,7 +1101,7 @@ int CGUIDialogVideoInfo::ManageVideoItem(const CFileItemPtr &item)
       }
 
       case CONTEXT_BUTTON_UNLINK_BOOKMARK:
-        database.DeleteBookMarkForEpisode(*item->GetVideoInfoTag());
+        database.DeleteBookMarkForMedia(*item->GetVideoInfoTag());
         result = true;
         break;
 


### PR DESCRIPTION
I have a lot of blurays and I find episode bookmarks a very useful feature. It allows me to jump to the right episode if I want to. But bluray playback is not perfect, sometimes the longest video track is not the default one or there are too many to chose so I thought it might be useful to be able to set where a video should start in any media, not only multiple episodes.
I renamed the feature "media bookmarks" and expanded to all three media types.
