### PR TITLE
Honor episode bookmarks in bd simple menu

### DIFF
--- a/xbmc/dialogs/GUIDialogSimpleMenu.cpp
+++ b/xbmc/dialogs/GUIDialogSimpleMenu.cpp
@@ -34,7 +34,7 @@
 bool CGUIDialogSimpleMenu::ShowPlaySelection(CFileItem& item)
 {
   /* if asked to resume somewhere, we should not show anything */
-  if (item.m_lStartOffset)
+  if (item.m_lStartOffset || (item.HasVideoInfoTag() && item.GetVideoInfoTag()->m_iBookmarkId > 0))
     return true;
 
   if (CSettings::Get().GetInt("disc.playback") != BD_PLAYBACK_SIMPLE_MENU)


### PR DESCRIPTION
I noticed that Episode bookmarks are observed with full bd menu, dvd menu and play main title but not in simple bd menu where there's a check for resume point to skip it but there's no check for bookmark episode. 
