### PR TITLE
add advanced setting assfixedworks

### DIFF
--- a/xbmc/cores/VideoRenderers/OverlayRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/OverlayRenderer.cpp
@@ -30,6 +30,7 @@
 #include "guilib/GraphicContext.h"
 #include "Application.h"
 #include "settings/Settings.h"
+#include "settings/AdvancedSettings.h"
 #include "threads/SingleLock.h"
 #include "utils/MathUtils.h"
 #include "OverlayRendererUtil.h"
@@ -335,7 +336,7 @@ COverlay* CRenderer::Convert(CDVDOverlaySSA* o, double pts)
   int subalign = CSettings::Get().GetInt("subtitles.align");
   if(subalign == SUBTITLE_ALIGN_BOTTOM_OUTSIDE
   || subalign == SUBTITLE_ALIGN_TOP_OUTSIDE
-  || subalign == SUBTITLE_ALIGN_MANUAL)
+  ||(subalign == SUBTITLE_ALIGN_MANUAL && g_advancedSettings.m_videoAssFixedWorks))
     useMargin = 1;
   else
     useMargin = 0;
@@ -345,7 +346,7 @@ COverlay* CRenderer::Convert(CDVDOverlaySSA* o, double pts)
   if(subalign == SUBTITLE_ALIGN_TOP_INSIDE
   || subalign == SUBTITLE_ALIGN_TOP_OUTSIDE)
     position = 100.0;
-  else if (subalign == SUBTITLE_ALIGN_MANUAL)
+  else if (subalign == SUBTITLE_ALIGN_MANUAL && g_advancedSettings.m_videoAssFixedWorks)
   {
     RESOLUTION_INFO res;
     res = g_graphicsContext.GetResInfo(g_renderManager.GetResolution());

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -388,6 +388,8 @@ void CAdvancedSettings::Initialize()
   m_stereoscopicregex_sbs = "[-. _]h?sbs[-. _]";
   m_stereoscopicregex_tab = "[-. _]h?tab[-. _]";
 
+  m_videoAssFixedWorks = false;
+
   m_logLevelHint = m_logLevel = LOG_LEVEL_NORMAL;
   m_extraLogEnabled = false;
   m_extraLogLevels = 0;
@@ -523,6 +525,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
   pElement = pRootElement->FirstChildElement("video");
   if (pElement)
   {
+    XMLUtils::GetBoolean(pElement, "assfixedworks", m_videoAssFixedWorks);
     XMLUtils::GetString(pElement, "stereoscopicregex3d", m_stereoscopicregex_3d);
     XMLUtils::GetString(pElement, "stereoscopicregexsbs", m_stereoscopicregex_sbs);
     XMLUtils::GetString(pElement, "stereoscopicregextab", m_stereoscopicregex_tab);

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -393,6 +393,11 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     std::string m_stereoscopicregex_sbs;
     std::string m_stereoscopicregex_tab;
 
+    /*!< @brief position behavior of ass subtitiles when setting "subtitle position on screen" set to "fixed"
+    True to show at the fixed position set in video calibration
+    False to show at the bottom of video (default) */
+    bool m_videoAssFixedWorks;
+
     std::string m_logFolder;
 
     std::string m_userAgent;


### PR DESCRIPTION
We let setting "subtitle position on screen" works for ass subtitles with #5013. But some users  are accustomed to the status of  "subtitle position on screen" setting invalid for ass subtitiles. Mean they want "fixed" act the same as "bottom of video". So add an advanced setting assfixedworks as @FernetMenta suggestted.
