### PR TITLE
Fix series dvd/bluray folders scan

### DIFF
--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -951,7 +951,17 @@ namespace VIDEO
   {
     SETTINGS_TVSHOWLIST expression = g_advancedSettings.m_tvshowEnumRegExps;
 
-    std::string strLabel=item->GetPath();
+    std::string strLabel;
+
+    // remove path to main file if it's a bd or dvd folder to regex the right (folder) name
+    if (item->IsOpticalMediaFile())
+    {
+      strLabel = item->GetLocalMetadataPath();
+      URIUtils::RemoveSlashAtEnd(strLabel);
+    }
+    else
+      strLabel = item->GetPath();
+
     // URLDecode in case an episode is on a http/https/dav/davs:// source and URL-encoded like foo%201x01%20bar.avi
     strLabel = CURL::Decode(strLabel);
 
@@ -981,7 +991,7 @@ namespace VIDEO
         if (!GetAirDateFromRegExp(reg, episode))
           continue;
 
-        CLog::Log(LOGDEBUG, "VideoInfoScanner: Found date based match %s (%s) [%s]", CURL::GetRedacted(strLabel).c_str(),
+        CLog::Log(LOGDEBUG, "VideoInfoScanner: Found date based match %s (%s) [%s]", CURL::GetRedacted(episode.strPath).c_str(),
                   episode.cDate.GetAsLocalizedDate().c_str(), expression[i].regexp.c_str());
       }
       else
@@ -989,7 +999,7 @@ namespace VIDEO
         if (!GetEpisodeAndSeasonFromRegExp(reg, episode, defaultSeason))
           continue;
 
-        CLog::Log(LOGDEBUG, "VideoInfoScanner: Found episode match %s (s%ie%i) [%s]", CURL::GetRedacted(strLabel).c_str(),
+        CLog::Log(LOGDEBUG, "VideoInfoScanner: Found episode match %s (s%ie%i) [%s]", CURL::GetRedacted(episode.strPath).c_str(),
                   episode.iSeason, episode.iEpisode, expression[i].regexp.c_str());
       }
 


### PR DESCRIPTION
regex expressions considers only the tv filename in tv series but this doesn't allow to scan dvd folders and bd folders in tv series folders.
Users created regex that include "video_ts" to match those (http://forum.kodi.tv/showthread.php?tid=55497&page=2) but with this kind of files kodi should use the root folder name to check the regex expressions
