### PR TITLE
[pvr] finally make it possible to use multiple PVR clients

### DIFF
--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -640,10 +640,22 @@ bool CPVRManager::Load(void)
   /* wait until the addons have loaded */
   m_addons->WaitForInitialisation();
 
+  int numConnectedClients = m_addons->ConnectedClientAmount();
+  int numEnabledClients = m_addons->EnabledClientAmount();
+
+  if (numConnectedClients == 0)
+  {
+    CLog::Log(LOGINFO, "PVRManager - %s - %d of %d enabled clients connected in time, will not start",
+      __FUNCTION__, numConnectedClients, numEnabledClients);
+  }
+  else
+  {
+    CLog::Log(LOGINFO, "PVRManager - %s - %d of %d enabled clients connected in time, continue to start", 
+      __FUNCTION__, numConnectedClients, numEnabledClients);
+  }
+
   if (!IsInitialising() || !m_addons->HasConnectedClients())
     return false;
-
-  CLog::Log(LOGDEBUG, "PVRManager - %s - active clients found. continue to start", __FUNCTION__);
 
   /* reset observer for pvr windows */
   for (std::size_t i = 0; i != ARRAY_SIZE(m_pvrWindowIds); i++)

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -634,12 +634,14 @@ bool CPVRManager::Load(void)
   /* start the add-on update thread */
   if (m_addons)
     m_addons->Start();
+  else
+    return false;
 
   /* load at least one client */
-  while (IsInitialising() && m_addons && !m_addons->HasConnectedClients())
+  while (IsInitialising() && !m_addons->HasConnectedClients())
     Sleep(50);
 
-  if (!IsInitialising() || !m_addons || !m_addons->HasConnectedClients())
+  if (!IsInitialising() || !m_addons->HasConnectedClients())
     return false;
 
   CLog::Log(LOGDEBUG, "PVRManager - %s - active clients found. continue to start", __FUNCTION__);

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -637,9 +637,8 @@ bool CPVRManager::Load(void)
   else
     return false;
 
-  /* load at least one client */
-  while (IsInitialising() && !m_addons->HasConnectedClients())
-    Sleep(50);
+  /* wait until the addons have loaded */
+  m_addons->WaitForInitialisation();
 
   if (!IsInitialising() || !m_addons->HasConnectedClients())
     return false;

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -1164,7 +1164,7 @@ int CPVRClients::RegisterClient(AddonPtr client)
   return iClientId;
 }
 
-bool CPVRClients::UpdateAndInitialiseClients(bool bInitialiseAllClients /* = false */)
+bool CPVRClients::UpdateAndInitialiseClients()
 {
   bool bReturn(true);
   VECADDONS map;
@@ -1189,7 +1189,7 @@ bool CPVRClients::UpdateAndInitialiseClients(bool bInitialiseAllClients /* = fal
       disableAddons.push_back(*it);
 
     }
-    else if (bEnabled && (bInitialiseAllClients || !IsKnownClient(*it) || !IsConnectedClient(*it)))
+    else if (bEnabled && (!IsKnownClient(*it) || !IsConnectedClient(*it)))
     {
       bool bDisabled(false);
 

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -731,10 +731,9 @@ namespace PVR
 
     /*!
      * @brief Check whether there are any new pvr add-ons enabled or whether any of the known clients has been disabled.
-     * @param bInitialiseAllClients True to initialise all clients, false to only initialise new clients.
      * @return True if all clients were updated successfully, false otherwise.
      */
-    bool UpdateAndInitialiseClients(bool bInitialiseAllClients = false);
+    bool UpdateAndInitialiseClients();
 
     /*!
      * @brief Initialise and connect a client.

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -22,6 +22,7 @@
 #include "addons/AddonDatabase.h"
 #include "threads/CriticalSection.h"
 #include "threads/Thread.h"
+#include "threads/Event.h"
 #include "utils/Observer.h"
 
 #include "pvr/channels/PVRChannel.h"
@@ -674,6 +675,12 @@ namespace PVR
 
     bool IsRealTimeStream() const;
 
+    /**
+     * Blocks for PVR_CLIENT_LOAD_TIMEOUT_MS milliseconds while waiting for the addon
+     * load event to be triggered.
+     */
+    void WaitForInitialisation();
+
   private:
     /*!
      * @brief Update add-ons from the AddonManager
@@ -760,6 +767,7 @@ namespace PVR
     PVR_CLIENTMAP         m_clientMap;                /*!< a map of all known clients */
     bool                  m_bNoAddonWarningDisplayed; /*!< true when a warning was displayed that no add-ons were found, false otherwise */
     CCriticalSection      m_critSection;
+    CEvent                m_loadedEvent;
     std::map<int, time_t> m_connectionAttempts;       /*!< last connection attempt per add-on */
     bool                  m_bRestartManagerOnAddonDisabled; /*!< true to restart the manager when an add-on is enabled/disabled */
     std::map<std::string, int> m_addonNameIds; /*!< map add-on names to IDs */


### PR DESCRIPTION
I've grown tired of telling users that it's not possible to use more than one addon at a time due to a bug, so this is my attempt at fixing it. We really need a solution for this for Isengard so I'd appreciate it if we can keep the bikeshedding to a minimum and focus on getting something that works done, even though the solution might not be the prettiest.

The problem:
- the addons are started by `CPVRClients` on a background thread. Meanwhile, `CPVRManager` used a simple sleep loop while waiting for at least one addon to load before continuing. If the second (or third) addon didn't load during the same 50 millisecond sleep duration, the startup would continue with just one addon.

The solution:
- use a boolean in `CPVRClients` to indicate whether all clients have been loaded or not. From `CPVRManager` we call a method which blocks until this boolean's condition variable is signaled.

Ping @opdenkamp @ksooo @xhaggi @FernetMenta

I'm not convinced this is the ultimate solution, but at least it works and it doesn't introduce arbitrary sleep durations.
