### PR TITLE
[gui] Delay asking stereoscopic playback mode to fix switching to fullsc...

### DIFF
--- a/xbmc/GUIUserMessages.h
+++ b/xbmc/GUIUserMessages.h
@@ -135,3 +135,6 @@
 
 // Sent to text field to support 'input method'
 #define GUI_MSG_INPUT_TEXT_EDIT       GUI_MSG_USER + 38
+
+// Sent to stereoscopic manager to ask user 'stereoscopic mode'
+#define GUI_MSG_STEREOSCOPIC_MODE_ASK GUI_MSG_USER + 39

--- a/xbmc/guilib/StereoscopicsManager.h
+++ b/xbmc/guilib/StereoscopicsManager.h
@@ -92,6 +92,7 @@ private:
   void ApplyStereoMode(const RENDER_STEREO_MODE &mode, bool notify = true);
   void OnPlaybackStarted(void);
   void OnPlaybackStopped(void);
+  void OnStereoscopicModeAsk(void);
 
   RENDER_STEREO_MODE m_stereoModeSetByUser;
   RENDER_STEREO_MODE m_lastStereoModeSetByUser;


### PR DESCRIPTION
...reen video on stereoscopic movies.

Problem:
1. After #6828 there is impossibility to switch to fullscreen video while modal dialog is active. 
2. StereoscopicsManager receives GUI_MSG_PLAYBACK_STARTED message early than switching to fullscreen video is occured and shows modal dialog which causes impossibility to switch to full screen. 
Solution:
This introduce a new GUI msg which used only by StereoscopicsManager which delays asking stereoscopic playback mode.

I do not sure what this is right solution, but I don't see another.

@xhaggi @FernetMenta @da-anda your comments are welcome.
