### PR TITLE
[pictures] SlideShowPicture: fix texels to display only filled part of t...

### DIFF
--- a/xbmc/pictures/SlideShowPicture.cpp
+++ b/xbmc/pictures/SlideShowPicture.cpp
@@ -764,10 +764,16 @@ void CSlideShowPic::Render(float *x, float *y, CBaseTexture* pTexture, color_t c
     vertex[i].col = color;
   }
 
-  vertex[1].tu = 1.0f;
-  vertex[2].tu = 1.0f;
-  vertex[2].tv = 1.0f;
-  vertex[3].tv = 1.0f;
+  if (pTexture)
+  {
+    vertex[1].tu = vertex[2].tu = (float)pTexture->GetWidth() / pTexture->GetTextureWidth();
+    vertex[2].tv = vertex[3].tv = (float)pTexture->GetHeight() / pTexture->GetTextureHeight();
+  }
+  else
+  {
+    vertex[1].tu = vertex[2].tu = 1.0f;
+    vertex[2].tv = vertex[3].tv = 1.0f;
+  }
   
   vertex[4] = vertex[0]; // Not used when pTexture != NULL
 


### PR DESCRIPTION
...exture instead of displaying whole texture.

This fixes http://trac.kodi.tv/ticket/15377

I've found this bug during working on dx11 version, just forgot to send patch.
