### PR TITLE
[seekhandler] fix wrong seek step processing if no delay is configured

### DIFF
--- a/xbmc/utils/SeekHandler.cpp
+++ b/xbmc/utils/SeekHandler.cpp
@@ -176,12 +176,10 @@ void CSeekHandler::SeekSeconds(int seconds)
     return;
 
   CSingleLock lock(m_critSection);
-
-  m_requireSeek = true;
-  m_seekDelay = 0;
   m_seekSize = seconds;
 
-  m_timer.StartZero();
+  // perform relative seek
+  g_application.m_pPlayer->SeekTimeRelative(static_cast<int64_t>(seconds * 1000));
 }
 
 int CSeekHandler::GetSeekSize() const

--- a/xbmc/utils/SeekHandler.cpp
+++ b/xbmc/utils/SeekHandler.cpp
@@ -119,10 +119,6 @@ int CSeekHandler::GetSeekSeconds(bool forward, SeekType type)
 
 void CSeekHandler::Seek(bool forward, float amount, float duration /* = 0 */, bool analogSeek /* = false */, SeekType type /* = SEEK_TYPE_VIDEO */)
 {
-  // abort if we do not have a play time or already perform a seek
-  if (m_performingSeek)
-    return;
-
   CSingleLock lock(m_critSection);
 
   // not yet seeking
@@ -176,7 +172,7 @@ void CSeekHandler::Seek(bool forward, float amount, float duration /* = 0 */, bo
 void CSeekHandler::SeekSeconds(int seconds)
 {
   // abort if we do not have a play time or already perform a seek
-  if (seconds == 0 || m_performingSeek)
+  if (seconds == 0)
     return;
 
   CSingleLock lock(m_critSection);
@@ -203,13 +199,11 @@ void CSeekHandler::Process()
   if (m_timer.GetElapsedMilliseconds() >= m_seekDelay && m_requireSeek)
   {
     CSingleLock lock(m_critSection);
-    m_performingSeek = true;
 
     // perform relative seek
     g_application.m_pPlayer->SeekTimeRelative(static_cast<int64_t>(m_seekSize * 1000));
 
     m_requireSeek = false;
-    m_performingSeek = false;
   }
 }
 

--- a/xbmc/utils/SeekHandler.cpp
+++ b/xbmc/utils/SeekHandler.cpp
@@ -119,7 +119,13 @@ void CSeekHandler::Seek(bool forward, float amount, float duration /* = 0 */, bo
   // not yet seeking
   if (!m_requireSeek)
   {
-    // tell info manager that we have started a seek operation
+    // use only the first step forward/backward for a seek without a delay
+    if (!analogSeek && m_seekDelays.at(type) == 0)
+    {
+      SeekSeconds(GetSeekStepSize(type, forward ? 1 : -1));
+      return;
+    }
+
     m_requireSeek = true;
     m_seekStep = 0;
     m_seekSize = 0;

--- a/xbmc/utils/SeekHandler.h
+++ b/xbmc/utils/SeekHandler.h
@@ -60,7 +60,7 @@ protected:
 private:
   static const int analogSeekDelay = 500;
   
-  int        GetSeekSeconds(bool forward, SeekType type);
+  int        GetSeekStepSize(SeekType type, int step);
   int        m_seekDelay;
   std::map<SeekType, int > m_seekDelays;
   bool       m_requireSeek;

--- a/xbmc/utils/SeekHandler.h
+++ b/xbmc/utils/SeekHandler.h
@@ -65,7 +65,6 @@ private:
   std::map<SeekType, int > m_seekDelays;
   bool       m_requireSeek;
   bool       m_analogSeek;
-  bool       m_performingSeek;
   int        m_seekSize;
   int        m_seekStep;
   std::map<SeekType, std::vector<int> > m_forwardSeekSteps;


### PR DESCRIPTION
This will refactors the seek step processing and reduce the roundtrips we need to process a seek with no delay or the built-in seek by seconds. It also fix the wrong seek size calculation if you hold the seek button down for a period of time while you have no seek delay configured.

@FernetMenta mind taking a look. I hope it's the last time :smile: 
