### PR TITLE
ActiveAE: slightly reduce buffer size

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -30,8 +30,8 @@ using namespace ActiveAE;
 #include "settings/Settings.h"
 #include "windowing/WindowingFactory.h"
 
-#define MAX_CACHE_LEVEL 0.5   // total cache time of stream in seconds
-#define MAX_WATER_LEVEL 0.25  // buffered time after stream stages in seconds
+#define MAX_CACHE_LEVEL 0.4   // total cache time of stream in seconds
+#define MAX_WATER_LEVEL 0.2   // buffered time after stream stages in seconds
 #define MAX_BUFFER_TIME 0.1   // max time of a buffer in seconds
 
 void CEngineStats::Reset(unsigned int sampleRate)


### PR DESCRIPTION
I have been carrying this for ages in my repo but had no compelling reason to submit it. Now it reduces time for audio to become audible after sync.
