### PR TITLE
[pvr] Fix wrong notifications when stopping/deleting recordings/timers

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -8602,8 +8602,9 @@ msgctxt "#19227"
 msgid "Recording completed"
 msgstr ""
 
+#: xbmc/pvr/timers/PVRTimerInfoTag.cpp, displayed when a timer is deleted
 msgctxt "#19228"
-msgid "Recording deleted"
+msgid "Timer deleted"
 msgstr ""
 
 msgctxt "#19229"

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -596,7 +596,7 @@ std::string CPVRTimerInfoTag::GetDeletedNotificationText() const
     return StringUtils::Format("%s: '%s'", g_localizeStrings.Get(19227).c_str(), m_strTitle.c_str()); // Recording completed
   case PVR_TIMER_STATE_SCHEDULED:
   default:
-    return StringUtils::Format("%s: '%s'", g_localizeStrings.Get(19228).c_str(), m_strTitle.c_str()); // Recording deleted
+    return StringUtils::Format("%s: '%s'", g_localizeStrings.Get(19228).c_str(), m_strTitle.c_str()); // Timer deleted
   }
 }
 

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -585,6 +585,21 @@ void CPVRTimerInfoTag::GetNotificationText(std::string &strText) const
   }
 }
 
+std::string CPVRTimerInfoTag::GetDeletedNotificationText() const
+{
+  CSingleLock lock(m_critSection);
+
+  // The state in this case is the state the timer had when it was last seen
+  switch (m_state)
+  {
+  case PVR_TIMER_STATE_RECORDING:
+    return StringUtils::Format("%s: '%s'", g_localizeStrings.Get(19227).c_str(), m_strTitle.c_str()); // Recording completed
+  case PVR_TIMER_STATE_SCHEDULED:
+  default:
+    return StringUtils::Format("%s: '%s'", g_localizeStrings.Get(19228).c_str(), m_strTitle.c_str()); // Recording deleted
+  }
+}
+
 void CPVRTimerInfoTag::QueueNotification(void) const
 {
   if (CSettings::Get().GetBool("pvrrecord.timernotifications"))

--- a/xbmc/pvr/timers/PVRTimerInfoTag.h
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.h
@@ -154,6 +154,11 @@ namespace PVR
      */
     void GetNotificationText(std::string &strText) const;
 
+    /*!
+    * @brief Get the text for the notification when a timer has been deleted
+    */
+    std::string GetDeletedNotificationText() const;
+
     const std::string& Title(void) const;
     const std::string& Summary(void) const;
     const std::string& Path(void) const;

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -188,15 +188,7 @@ bool CPVRTimers::UpdateEntries(const CPVRTimers &timers)
             __FUNCTION__, timer->m_iClientIndex, timer->m_iClientId);
 
         if (g_PVRManager.IsStarted())
-        {
-          std::string strMessage;
-          strMessage = StringUtils::Format("%s: '%s'",
-                                           (timer->EndAsUTC() <= CDateTime::GetCurrentDateTime().GetAsUTCDateTime()) ?
-                                           g_localizeStrings.Get(19227).c_str() :
-                                           g_localizeStrings.Get(19228).c_str(),
-                                           timer->m_strTitle.c_str());
-          timerNotifications.push_back(strMessage);
-        }
+          timerNotifications.push_back(timer->GetDeletedNotificationText());
 
         /** clear the EPG tag explicitly here, because it no longer happens automatically with shared pointers */
         timer->ClearEpgTag();


### PR DESCRIPTION
#### Scenario 1:
- start a recording
- stop that recording

What happens: a "recording deleted" message is shown in almost all cases, when in fact the recording was never deleted, just stopped. This fixes that. The problem is that we've been looking at the current time and the end time for the recording when determining what message to display. I've refactored this to look at the last known state of the timer, which is both simpler and more reliable.
#### Scenario 2:
- schedule a recording
- delete the schedule

What happens: a "recording deleted" message is shown, when in fact there was no recording to begin with, just a timer. This fixes that too by simply changing the message string (it's not used anywhere else). I left this as a separate commit so we can drop it if you feel it's too late for language changes at this stage.

@xhaggi @ksooo you okay with this?
