### PR TITLE
dvdplayer: transform 32x (ff/rw) into as fast as possible

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -177,12 +177,12 @@ const infomap player_labels[] =  {{ "hasmedia",         PLAYER_HAS_MEDIA },     
                                   { "rewinding4x",      PLAYER_REWINDING_4x },
                                   { "rewinding8x",      PLAYER_REWINDING_8x },
                                   { "rewinding16x",     PLAYER_REWINDING_16x },
-                                  { "rewinding32x",     PLAYER_REWINDING_32x },
+                                  { "rewindingrrx",     PLAYER_REWINDING_RRx },
                                   { "forwarding2x",     PLAYER_FORWARDING_2x },
                                   { "forwarding4x",     PLAYER_FORWARDING_4x },
                                   { "forwarding8x",     PLAYER_FORWARDING_8x },
                                   { "forwarding16x",    PLAYER_FORWARDING_16x },
-                                  { "forwarding32x",    PLAYER_FORWARDING_32x },
+                                  { "forwardingffx",    PLAYER_FORWARDING_FFx },
                                   { "canrecord",        PLAYER_CAN_RECORD },
                                   { "recording",        PLAYER_RECORDING },
                                   { "displayafterseek", PLAYER_DISPLAY_AFTER_SEEK },
@@ -2547,7 +2547,7 @@ bool CGUIInfoManager::GetBool(int condition1, int contextWindow, const CGUIListI
     case PLAYER_REWINDING_16x:
       bReturn = !g_application.m_pPlayer->IsPausedPlayback() && g_application.m_pPlayer->GetPlaySpeed() == -16;
       break;
-    case PLAYER_REWINDING_32x:
+    case PLAYER_REWINDING_RRx:
       bReturn = !g_application.m_pPlayer->IsPausedPlayback() && g_application.m_pPlayer->GetPlaySpeed() == -32;
       break;
     case PLAYER_FORWARDING_2x:
@@ -2562,7 +2562,7 @@ bool CGUIInfoManager::GetBool(int condition1, int contextWindow, const CGUIListI
     case PLAYER_FORWARDING_16x:
       bReturn = !g_application.m_pPlayer->IsPausedPlayback() && g_application.m_pPlayer->GetPlaySpeed() == 16;
       break;
-    case PLAYER_FORWARDING_32x:
+    case PLAYER_FORWARDING_FFx:
       bReturn = !g_application.m_pPlayer->IsPausedPlayback() && g_application.m_pPlayer->GetPlaySpeed() == 32;
       break;
     case PLAYER_CAN_RECORD:

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -66,13 +66,13 @@ namespace INFO
 #define PLAYER_REWINDING_4x           8
 #define PLAYER_REWINDING_8x           9
 #define PLAYER_REWINDING_16x         10
-#define PLAYER_REWINDING_32x         11
+#define PLAYER_REWINDING_RRx         11
 #define PLAYER_FORWARDING            12
 #define PLAYER_FORWARDING_2x         13
 #define PLAYER_FORWARDING_4x         14
 #define PLAYER_FORWARDING_8x         15
 #define PLAYER_FORWARDING_16x        16
-#define PLAYER_FORWARDING_32x        17
+#define PLAYER_FORWARDING_FFx        17
 #define PLAYER_CAN_RECORD            18
 #define PLAYER_RECORDING             19
 #define PLAYER_CACHING               20

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -1843,7 +1843,7 @@ void CDVDPlayer::HandlePlaySpeed()
         error /= m_playSpeed / DVD_PLAYSPEED_NORMAL;
       }
 
-      if(error > DVD_MSEC_TO_TIME(1000))
+      if(error > DVD_MSEC_TO_TIME(1000) && m_playSpeed < (32 * DVD_PLAYSPEED_NORMAL))
       {
         error  = (int)DVD_TIME_TO_MSEC(m_clock.GetClock()) - m_SpeedState.lastseekpts;
 

--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
@@ -1172,7 +1172,8 @@ int CDVDPlayerVideo::OutputPicture(const DVDVideoPicture* src, double pts)
       mDisplayField = FS_BOT;
   }
 
-  int buffer = g_renderManager.WaitForBuffer(m_bStop, std::max(DVD_TIME_TO_MSEC(iSleepTime) + 500, 50));
+  int bufferwait = (abs(m_speed) > DVD_PLAYSPEED_NORMAL * 16) ? 0 : std::max(DVD_TIME_TO_MSEC(iSleepTime) + 500, 50);
+  int buffer = g_renderManager.WaitForBuffer(m_bStop, bufferwait);
   if (buffer < 0)
   {
     m_droppingStats.AddOutputDropGain(pts, 1/m_fFrameRate);


### PR DESCRIPTION
there were complaints about stalls when going ff/rw > 16x
imo 16x and 32x are nonsense anyway because hardly a system can go this speed. but there were also complaints as I suggested to remove those speeds.

this transforms 32x into "as fast as possible" without letting the system stall, means "seek to catch up"

@ronie could you create an image for this and adopt confluence?
