### PR TITLE
[Skin] optimitation for picons in livetv

### DIFF
--- a/addons/skin.confluence/720p/VideoFullScreen.xml
+++ b/addons/skin.confluence/720p/VideoFullScreen.xml
@@ -72,7 +72,7 @@
 				<aspectratio aligny="bottom">keep</aspectratio>
 				<bordertexture border="8">ThumbShadow.png</bordertexture>
 				<bordersize>8</bordersize>
-				<visible>!VideoPlayer.Content(Movies)</visible>
+				<visible>![VideoPlayer.Content(Movies) | VideoPlayer.Content(LiveTV)]</visible>
 			</control>
 			<control type="image" id="1">
 				<description>Movie cover image</description>
@@ -85,6 +85,16 @@
 				<bordertexture border="8">ThumbShadow.png</bordertexture>
 				<bordersize>8</bordersize>
 				<visible>VideoPlayer.Content(Movies)</visible>
+			</control>
+			<control type="image" id="1">
+				<description>PIcon image</description>
+				<left>20</left>
+				<top>200r</top>
+				<width>300</width>
+				<height>150</height>
+				<texture fallback="DefaultVideoCover.png" aligny="center">$INFO[Player.Art(thumb)]</texture>
+				<aspectratio aligny="center">keep</aspectratio>
+				<visible>VideoPlayer.Content(LiveTV)</visible>
 			</control>
 			<control type="group" id="1">
 				<left>330</left>


### PR DESCRIPTION
many picons have transparent background and an other dimention as cover images.
- no border around picon in fullscreen
- center picon vertical, and adjust vertical position
