### PR TITLE
fixed: Don't try to delete empty filename

### DIFF
--- a/xbmc/filesystem/CacheStrategy.cpp
+++ b/xbmc/filesystem/CacheStrategy.cpp
@@ -123,7 +123,7 @@ void CSimpleFileCache::Close()
   m_cacheFileWrite->Close();
   m_cacheFileRead->Close();
 
-  if (!m_cacheFileRead->Delete(CURL(m_filename)))
+  if (!m_filename.empty() && !m_cacheFileRead->Delete(CURL(m_filename)))
     CLog::LogF(LOGWARNING, "failed to delete temporary file \"%s\"", m_filename.c_str());
 
   m_filename.clear();


### PR DESCRIPTION
Probably not spotted before since we don't use SimpleCache (anymore) by default.
