### PR TITLE
FIX: [gles;font] do not clip rotated text

### DIFF
--- a/xbmc/guilib/GUIFontTTFGL.cpp
+++ b/xbmc/guilib/GUIFontTTFGL.cpp
@@ -217,7 +217,8 @@ void CGUIFontTTFGL::LastEnd()
     {
       // Apply the clip rectangle
       CRect clip = g_Windowing.ClipRectToScissorRect(m_vertexTrans[i].clip);
-      g_Windowing.SetScissors(clip);
+      if (!clip.IsEmpty())
+        g_Windowing.SetScissors(clip);
 
       // Apply the translation to the currently active (top-of-stack) model view matrix
       glMatrixModview.Push();

--- a/xbmc/guilib/GUIShader.cpp
+++ b/xbmc/guilib/GUIShader.cpp
@@ -160,6 +160,12 @@ bool CGUIShader::OnEnabled()
       projMatrix[3+0*4] == 0 &&
       projMatrix[3+1*4] == 0 &&
       projMatrix[3+3*4] == 0;
+
+  m_clipXFactor = 0.0;
+  m_clipXOffset = 0.0;
+  m_clipYFactor = 0.0;
+  m_clipYOffset = 0.0;
+
   if (m_clipPossible)
   {
     m_clipXFactor = guiMatrix.m[0][0] * modelMatrix[0+0*4] * projMatrix[0+0*4];


### PR DESCRIPTION
@bavison This seems to fix a bad clipping issue with rotated font.
Check the Eminence skin for examples of the issue, in Settings, on the right.
