### PR TITLE
fixed: Webdav file existance

### DIFF
--- a/xbmc/filesystem/DAVFile.cpp
+++ b/xbmc/filesystem/DAVFile.cpp
@@ -132,7 +132,12 @@ bool CDAVFile::Delete(const CURL& url)
 
 bool CDAVFile::Exists(const CURL& url)
 {
-  return Stat(url,NULL) == 0;
+  CCurlFile dav;
+  std::string strRequest = "PROPFIND";
+  dav.SetCustomRequest(strRequest);
+  dav.SetRequestHeader("depth", 0);
+
+  return dav.Exists(url);
 }
 
 int CDAVFile::Stat(const CURL& url, struct __stat64* buffer)


### PR DESCRIPTION
stat == 0 does not mean a file exists, furthermore the Exists() and Stat() functions in the Curl baseclass differ and derived classes should called the proper ones. Hopefully fixes #15958
