### PR TITLE
[cmake] - only evaluate the sudo check on linux. On darwin with cmake 2....

### DIFF
--- a/project/cmake/addons/CMakeLists.txt
+++ b/project/cmake/addons/CMakeLists.txt
@@ -122,7 +122,7 @@ include(${APP_ROOT}/project/cmake/scripts/common/check_target_platform.cmake)
 # check install permissions
 set(ADDON_INSTALL_DIR ${CMAKE_INSTALL_PREFIX})
 check_install_permissions(${CMAKE_INSTALL_PREFIX} can_write)
-if(NOT ${can_write} AND NOT WIN32)
+if(NOT ${can_write} AND CMAKE_SYSTEM_NAME STREQUAL "Linux")
   set(NEED_SUDO TRUE)
   set(ADDON_INSTALL_DIR ${CMAKE_BINARY_DIR}/.install)
   message(STATUS "NEED_SUDO: ${NEED_SUDO}")


### PR DESCRIPTION
...8.12 the execute_process with the multiple commands inside doesn't seem to work (it detects that it needs sudo and so it doesn't install into the addons dir). Bumping to cmake 3.2.2 was an other solution which made it work but bumping cmake is considered to dangerous at this stage. Fixes missing addons on ios and osx builds.

This should give us back the binary addons in osx and ios jenkins builds.
