### PR TITLE
[AirTunes]  - fix - png coverart didn't show

### DIFF
--- a/project/BuildDependencies/scripts/0_package.list
+++ b/project/BuildDependencies/scripts/0_package.list
@@ -34,7 +34,7 @@ libpng-1.5.13-win32.7z
 librtmp-20150114-git-a107ce-win32.7z
 libsdl-1.2.10-win32.7z
 libsdl_image-1.2.14-win32.7z
-libshairplay-41a66c9-win32.7z
+libshairplay-0e439f0-win32.7z
 libssh-0.5.0-1-win32.zip
 libvorbis-vc100-1.3.1-win32.7z
 libxml2-2.7.8_1-win32.7z

--- a/tools/depends/target/libshairplay/04-raop-also-forward-png-data-to-the-coverart-callback.patch
+++ b/tools/depends/target/libshairplay/04-raop-also-forward-png-data-to-the-coverart-callback.patch
@@ -1,0 +1,22 @@
+From 71bae68d91aca9f0399acc163b97ca73702dbb7b Mon Sep 17 00:00:00 2001
+From: Memphiz <memphis@machzwo.de>
+Date: Mon, 4 May 2015 23:28:31 +0200
+Subject: [PATCH] [raop] - also forward png data to the coverart callback
+
+
+diff --git a/src/lib/raop.c b/src/lib/raop.c
+index e5c6539..889b44f 100644
+--- a/src/lib/raop.c
++++ b/src/lib/raop.c
+@@ -312,7 +312,7 @@ conn_request(void *ptr, http_request_t *request, http_response_t **response)
+ 				logger_log(conn->raop->logger, LOGGER_WARNING, "RAOP not initialized at SET_PARAMETER volume");
+ 			}
+ 			free(datastr);
+-		} else if (!strcmp(content_type, "image/jpeg")) {
++		} else if (!strcmp(content_type, "image/jpeg") || !strcmp(content_type, "image/png")) {
+ 			logger_log(conn->raop->logger, LOGGER_INFO, "Got image data of %d bytes", datalen);
+ 			if (conn->raop_rtp) {
+ 				raop_rtp_set_coverart(conn->raop_rtp, data, datalen);
+-- 
+1.9.5 (Apple Git-50.3)
+

--- a/tools/depends/target/libshairplay/Makefile
+++ b/tools/depends/target/libshairplay/Makefile
@@ -26,6 +26,7 @@ ifeq ($(OS),ios)
 endif
 	cd $(PLATFORM); patch -p1 < ../02-fixipv4ipv6race.patch
 	cd $(PLATFORM); patch -p1 < ../03-fixpasswordauthitunes.patch
+	cd $(PLATFORM); patch -p1 < ../04-raop-also-forward-png-data-to-the-coverart-callback.patch
 	cd $(PLATFORM); $(AUTORECONF) -vif
 	cd $(PLATFORM); $(CONFIGURE)
 

--- a/xbmc/network/AirTunesServer.h
+++ b/xbmc/network/AirTunesServer.h
@@ -55,7 +55,7 @@ private:
   ~CAirTunesServer();
   bool Initialize(const std::string &password);
   void Deinitialize();
-  static void RefreshCoverArt();
+  static void RefreshCoverArt(const char *outputFilename = NULL);
   static void RefreshMetadata();
   static void ResetMetadata();
 


### PR DESCRIPTION
When i added the coverart support i was not aware of the fact that there could be anything else then jpeg. As a user pointed out there could also be PNGs as coverart.

This PR fixes this by
1. making libshairplay also push png coverart via the callback
2. In our callback check if it is an jpeg (by checking jpeg markers - code is taken from our TexturePacker and should be well working), if not - treat it as png.

The libshairplay patch was upstreamed - i already created the win32 package for it - just need to upload it once i am home.

To late for Isengard - but safe for early integration afterwards...
