### PR TITLE
[gui] fix internal window activation

### DIFF
--- a/xbmc/ApplicationMessenger.cpp
+++ b/xbmc/ApplicationMessenger.cpp
@@ -705,7 +705,7 @@ void CApplicationMessenger::ProcessMessage(ThreadMessage *pMsg)
 
     case TMSG_GUI_ACTIVATE_WINDOW:
       {
-        g_windowManager.ActivateWindow(pMsg->param1, pMsg->params, pMsg->param2 > 0);
+        g_windowManager.ActivateWindow(pMsg->param1, pMsg->params, pMsg->param2 & 0x1 ? true : false, pMsg->param2 & 0x2 ? true : false);
       }
       break;
 
@@ -1256,9 +1256,10 @@ void CApplicationMessenger::Close(CGUIWindow *window, bool forceClose, bool wait
   SendMessage(tMsg, waitResult);
 }
 
-void CApplicationMessenger::ActivateWindow(int windowID, const vector<string> &params, bool swappingWindows)
+void CApplicationMessenger::ActivateWindow(int windowID, const vector<string> &params, bool swappingWindows, bool checkModals  /* = false */)
 {
-  ThreadMessage tMsg = {TMSG_GUI_ACTIVATE_WINDOW, windowID, swappingWindows ? 1 : 0};
+  ThreadMessage tMsg = {TMSG_GUI_ACTIVATE_WINDOW, windowID};
+  tMsg.param2 = (swappingWindows ? 0x01 : 0) | (checkModals ? 0x02 : 0);
   tMsg.params = params;
   SendMessage(tMsg, true);
 }

--- a/xbmc/ApplicationMessenger.h
+++ b/xbmc/ApplicationMessenger.h
@@ -231,7 +231,7 @@ public:
   void DoModal(CGUIDialog *pDialog, int iWindowID, const std::string &param = "");
   void Show(CGUIDialog *pDialog);
   void Close(CGUIWindow *window, bool forceClose, bool waitResult = true, int nextWindowID = 0, bool enableSound = true);
-  void ActivateWindow(int windowID, const std::vector<std::string> &params, bool swappingWindows);
+  void ActivateWindow(int windowID, const std::vector<std::string> &params, bool swappingWindows, bool checkModals = false);
   void SendAction(const CAction &action, int windowID = WINDOW_INVALID, bool waitResult=true);
 
   //! \brief Send text to currently focused window / keyboard.

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -707,22 +707,22 @@ void CGUIWindowManager::ActivateWindow(int iWindowID, const std::string& strPath
   ActivateWindow(iWindowID, params, false);
 }
 
-void CGUIWindowManager::ActivateWindow(int iWindowID, const vector<string>& params, bool swappingWindows)
+void CGUIWindowManager::ActivateWindow(int iWindowID, const vector<string>& params, bool swappingWindows /* = false */, bool checkModals /* = false */)
 {
   if (!g_application.IsCurrentThread())
   {
     // make sure graphics lock is not held
     CSingleExit leaveIt(g_graphicsContext);
-    CApplicationMessenger::Get().ActivateWindow(iWindowID, params, swappingWindows);
+    CApplicationMessenger::Get().ActivateWindow(iWindowID, params, swappingWindows, checkModals);
   }
   else
   {
     CSingleLock lock(g_graphicsContext);
-    ActivateWindow_Internal(iWindowID, params, swappingWindows);
+    ActivateWindow_Internal(iWindowID, params, swappingWindows, checkModals);
   }
 }
 
-void CGUIWindowManager::ActivateWindow_Internal(int iWindowID, const vector<string>& params, bool swappingWindows)
+void CGUIWindowManager::ActivateWindow_Internal(int iWindowID, const vector<string>& params, bool swappingWindows, bool checkModals /* = false */)
 {
   // translate virtual windows
   // virtual music window which returns the last open music window (aka the music start window)
@@ -776,7 +776,7 @@ void CGUIWindowManager::ActivateWindow_Internal(int iWindowID, const vector<stri
   }
 
   // don't activate a window if there are active modal dialogs
-  if (HasModalDialog())
+  if (checkModals && HasModalDialog())
   {
     CLog::Log(LOG_LEVEL_DEBUG, "Activate of window '%i' refused because there are active modal dialogs", iWindowID);
     g_audioManager.PlayActionSound(CAction(ACTION_ERROR));

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -60,7 +60,7 @@ public:
   void Delete(int id);
   void ActivateWindow(int iWindowID, const std::string &strPath = "");
   void ChangeActiveWindow(int iNewID, const std::string &strPath = "");
-  void ActivateWindow(int iWindowID, const std::vector<std::string>& params, bool swappingWindows = false);
+  void ActivateWindow(int iWindowID, const std::vector<std::string>& params, bool swappingWindows = false, bool checkModals = false);
   void PreviousWindow();
 
   void CloseDialogs(bool forceClose = false) const;
@@ -181,7 +181,7 @@ private:
   CGUIWindow *GetTopMostDialog() const;
 
   friend class CApplicationMessenger;
-  void ActivateWindow_Internal(int windowID, const std::vector<std::string> &params, bool swappingWindows);
+  void ActivateWindow_Internal(int windowID, const std::vector<std::string> &params, bool swappingWindows, bool checkModals = false);
 
   typedef std::map<int, CGUIWindow *> WindowMap;
   WindowMap m_mapWindows;

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -301,7 +301,7 @@ bool CBuiltins::ActivateWindow(int iWindowID, const std::vector<std::string>& pa
 {
   // disable the screensaver
   g_application.WakeUpScreenSaverAndDPMS();
-  g_windowManager.ActivateWindow(iWindowID, params, swappingWindows);
+  g_windowManager.ActivateWindow(iWindowID, params, swappingWindows, true);
   return true;
 }
 


### PR DESCRIPTION
There are different reported issues (http://trac.kodi.tv/ticket/15960, #7022) where windows can't be activated because of active modals. The first approach made in PR #6828 was to only block user-interactive activation (via built-ins) of new windows while a modal dialog is open. After #6990 I've moved the check to `CGUIWindowManager::ActivateWindow_Internal` which results in all of the reported issues.

This PR is an attempt to fix the issue while reverting to the old behavior and only block user-interactive window switches triggered by built-in commands.

@FernetMenta @Montellese @mkortstiege mind taking a look.

BTW please take a look at the RFC commit where I spotted and fixed a wrong parameter usage for TMSG_GUI_WINDOW_CLOSE in our appmessenger.
