### PR TITLE
[win32] Fix: CWinIdleTimer::StartZero - do not set ES_SYSTEM_REQUIRED…

### DIFF
--- a/xbmc/win32/WIN32Util.cpp
+++ b/xbmc/win32/WIN32Util.cpp
@@ -1520,7 +1520,8 @@ void CWIN32Util::CropSource(CRect& src, CRect& dst, CRect target)
 
 void CWinIdleTimer::StartZero()
 {
-  SetThreadExecutionState(ES_SYSTEM_REQUIRED|ES_DISPLAY_REQUIRED);
+  if (!g_application.IsDPMSActive())
+    SetThreadExecutionState(ES_SYSTEM_REQUIRED|ES_DISPLAY_REQUIRED);
   CStopWatch::StartZero();
 }
 


### PR DESCRIPTION
… and ES_DISPLAY_REQUIRED if DPMS is active.

It is a very old bug introduced by #2068
