### PR TITLE
[addons] fix launch addon from within CGUIDialogAddonInfo

### DIFF
--- a/xbmc/addons/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/GUIDialogAddonInfo.cpp
@@ -194,8 +194,8 @@ void CGUIDialogAddonInfo::OnLaunch()
   if (!m_localAddon)
     return;
 
-  CBuiltins::Execute("RunAddon(" + m_localAddon->ID() + ")");
   Close();
+  CBuiltins::Execute("RunAddon(" + m_localAddon->ID() + ")");
 }
 
 bool CGUIDialogAddonInfo::PromptIfDependency(int heading, int line2)


### PR DESCRIPTION
After introducing #6828 we can't launch an addon from within the addon info dialog, because the window activation is refused by the active addon info dialog. This is close the dialog first before execute addon built-in.

Related ticket http://trac.kodi.tv/ticket/15960

@mkortstiege @Montellese ping
