### PR TITLE
[messenger] fix wrong parameter usage for TMSG_GUI_WINDOW_CLOSE

### DIFF
--- a/xbmc/ApplicationMessenger.cpp
+++ b/xbmc/ApplicationMessenger.cpp
@@ -699,7 +699,7 @@ void CApplicationMessenger::ProcessMessage(ThreadMessage *pMsg)
       {
         CGUIWindow *window = (CGUIWindow *)pMsg->lpVoid;
         if (window)
-          window->Close(pMsg->param1 & 0x1 ? true : false, pMsg->param1, pMsg->param1 & 0x2 ? true : false);
+          window->Close(pMsg->param2 & 0x1 ? true : false, pMsg->param1, pMsg->param2 & 0x2 ? true : false);
       }
       break;
 


### PR DESCRIPTION
I've spotted this while I'm working on something other. We use the wrong parameter from the ThreadMessage in case we call close for a window.

`param2` is used to hold the corresponding value, see
https://github.com/xhaggi/xbmc/blob/7e3e9bb783714485b6785dc0787fb93eb18727de/xbmc/ApplicationMessenger.cpp#L1254

@Montellese @mkortstiege mind taking a look
