### PR TITLE
[cmake] add libplatform to kodi-platform depends

### DIFF
--- a/project/BuildDependencies/scripts/0_package.list
+++ b/project/BuildDependencies/scripts/0_package.list
@@ -19,7 +19,7 @@ jsonschemabuilder-1.0.0-win32-3.7z
 libass-0.12.1-win32.7z
 libbluray-0.4.0-win32.zip
 libcdio-0.83-win32-2.7z
-libcec-3.0.0-win32-1.7z
+libcec-3.0.0-win32-2.7z
 libexpat_2.0.1-win32.7z
 libflac-1.2.1-win32.7z
 libfribidi-0.19.2-win32.7z

--- a/project/cmake/addons/addons/audiodecoder.modplug/audiodecoder.modplug.txt
+++ b/project/cmake/addons/addons/audiodecoder.modplug/audiodecoder.modplug.txt
@@ -1,1 +1,1 @@
-audiodecoder.modplug https://github.com/notspiff/audiodecoder.modplug c7e8ca8
+audiodecoder.modplug https://github.com/notspiff/audiodecoder.modplug 2de539b

--- a/project/cmake/addons/addons/audiodecoder.nosefart/audiodecoder.nosefart.txt
+++ b/project/cmake/addons/addons/audiodecoder.nosefart/audiodecoder.nosefart.txt
@@ -1,1 +1,1 @@
-audiodecoder.nosefart https://github.com/notspiff/audiodecoder.nosefart c77e5a1
+audiodecoder.nosefart https://github.com/notspiff/audiodecoder.nosefart a49ba6e

--- a/project/cmake/addons/addons/audiodecoder.sidplay/audiodecoder.sidplay.txt
+++ b/project/cmake/addons/addons/audiodecoder.sidplay/audiodecoder.sidplay.txt
@@ -1,1 +1,1 @@
-audiodecoder.sidplay https://github.com/notspiff/audiodecoder.sidplay f2e7d98
+audiodecoder.sidplay https://github.com/notspiff/audiodecoder.sidplay 6568676

--- a/project/cmake/addons/addons/audiodecoder.snesapu/audiodecoder.snesapu.txt
+++ b/project/cmake/addons/addons/audiodecoder.snesapu/audiodecoder.snesapu.txt
@@ -1,1 +1,1 @@
-audiodecoder.snesapu https://github.com/notspiff/audiodecoder.snesapu 9fc775b
+audiodecoder.snesapu https://github.com/notspiff/audiodecoder.snesapu 2bd1e34

--- a/project/cmake/addons/addons/audiodecoder.stsound/audiodecoder.stsound.txt
+++ b/project/cmake/addons/addons/audiodecoder.stsound/audiodecoder.stsound.txt
@@ -1,1 +1,1 @@
-audiodecoder.stsound https://github.com/notspiff/audiodecoder.stsound 775c858
+audiodecoder.stsound https://github.com/notspiff/audiodecoder.stsound 640b049

--- a/project/cmake/addons/addons/audiodecoder.timidity/audiodecoder.timidity.txt
+++ b/project/cmake/addons/addons/audiodecoder.timidity/audiodecoder.timidity.txt
@@ -1,1 +1,1 @@
-audiodecoder.timidity https://github.com/notspiff/audiodecoder.timidity bf9ff93
+audiodecoder.timidity https://github.com/notspiff/audiodecoder.timidity 7f079c1

--- a/project/cmake/addons/addons/audiodecoder.vgmstream/audiodecoder.vgmstream.txt
+++ b/project/cmake/addons/addons/audiodecoder.vgmstream/audiodecoder.vgmstream.txt
@@ -1,1 +1,1 @@
-audiodecoder.vgmstream https://github.com/notspiff/audiodecoder.vgmstream 0c3a51a
+audiodecoder.vgmstream https://github.com/notspiff/audiodecoder.vgmstream 715c580

--- a/project/cmake/addons/addons/pvr.argustv/pvr.argustv.txt
+++ b/project/cmake/addons/addons/pvr.argustv/pvr.argustv.txt
@@ -1,1 +1,1 @@
-pvr.argustv https://github.com/kodi-pvr/pvr.argustv 96ee875
+pvr.argustv https://github.com/kodi-pvr/pvr.argustv fa84ac2

--- a/project/cmake/addons/addons/pvr.demo/pvr.demo.txt
+++ b/project/cmake/addons/addons/pvr.demo/pvr.demo.txt
@@ -1,1 +1,1 @@
-pvr.demo https://github.com/kodi-pvr/pvr.demo b4b7de1
+pvr.demo https://github.com/kodi-pvr/pvr.demo 34d60a1

--- a/project/cmake/addons/addons/pvr.dvblink/pvr.dvblink.txt
+++ b/project/cmake/addons/addons/pvr.dvblink/pvr.dvblink.txt
@@ -1,1 +1,1 @@
-pvr.dvblink https://github.com/kodi-pvr/pvr.dvblink 5d505b8
+pvr.dvblink https://github.com/kodi-pvr/pvr.dvblink 6084c4e

--- a/project/cmake/addons/addons/pvr.dvbviewer/pvr.dvbviewer.txt
+++ b/project/cmake/addons/addons/pvr.dvbviewer/pvr.dvbviewer.txt
@@ -1,1 +1,1 @@
-pvr.dvbviewer https://github.com/kodi-pvr/pvr.dvbviewer bd2c01f
+pvr.dvbviewer https://github.com/kodi-pvr/pvr.dvbviewer 3dd826e

--- a/project/cmake/addons/addons/pvr.filmon/pvr.filmon.txt
+++ b/project/cmake/addons/addons/pvr.filmon/pvr.filmon.txt
@@ -1,1 +1,1 @@
-pvr.filmon https://github.com/kodi-pvr/pvr.filmon 413fe9e
+pvr.filmon https://github.com/kodi-pvr/pvr.filmon 8794b9c

--- a/project/cmake/addons/addons/pvr.hts/pvr.hts.txt
+++ b/project/cmake/addons/addons/pvr.hts/pvr.hts.txt
@@ -1,1 +1,1 @@
-pvr.hts https://github.com/kodi-pvr/pvr.hts 4bf1a97
+pvr.hts https://github.com/kodi-pvr/pvr.hts d038dfc

--- a/project/cmake/addons/addons/pvr.iptvsimple/pvr.iptvsimple.txt
+++ b/project/cmake/addons/addons/pvr.iptvsimple/pvr.iptvsimple.txt
@@ -1,1 +1,1 @@
-pvr.iptvsimple https://github.com/kodi-pvr/pvr.iptvsimple a2e6c6f
+pvr.iptvsimple https://github.com/kodi-pvr/pvr.iptvsimple 27c4221

--- a/project/cmake/addons/addons/pvr.mediaportal.tvserver/pvr.mediaportal.tvserver.txt
+++ b/project/cmake/addons/addons/pvr.mediaportal.tvserver/pvr.mediaportal.tvserver.txt
@@ -1,1 +1,1 @@
-pvr.mediaportal.tvserver https://github.com/kodi-pvr/pvr.mediaportal.tvserver 6f8ca82
+pvr.mediaportal.tvserver https://github.com/kodi-pvr/pvr.mediaportal.tvserver d9bfdee

--- a/project/cmake/addons/addons/pvr.mythtv/pvr.mythtv.txt
+++ b/project/cmake/addons/addons/pvr.mythtv/pvr.mythtv.txt
@@ -1,1 +1,1 @@
-pvr.mythtv https://github.com/kodi-pvr/pvr.mythtv ef9cf41
+pvr.mythtv https://github.com/kodi-pvr/pvr.mythtv c810489

--- a/project/cmake/addons/addons/pvr.nextpvr/pvr.nextpvr.txt
+++ b/project/cmake/addons/addons/pvr.nextpvr/pvr.nextpvr.txt
@@ -1,1 +1,1 @@
-pvr.nextpvr https://github.com/kodi-pvr/pvr.nextpvr 1ecbf87
+pvr.nextpvr https://github.com/kodi-pvr/pvr.nextpvr ecc6598

--- a/project/cmake/addons/addons/pvr.njoy/pvr.njoy.txt
+++ b/project/cmake/addons/addons/pvr.njoy/pvr.njoy.txt
@@ -1,1 +1,1 @@
-pvr.njoy https://github.com/kodi-pvr/pvr.njoy fcd6294
+pvr.njoy https://github.com/kodi-pvr/pvr.njoy 2733f34

--- a/project/cmake/addons/addons/pvr.pctv/pvr.pctv.txt
+++ b/project/cmake/addons/addons/pvr.pctv/pvr.pctv.txt
@@ -1,1 +1,1 @@
-pvr.pctv https://github.com/kodi-pvr/pvr.pctv 0a0924e
+pvr.pctv https://github.com/kodi-pvr/pvr.pctv c240226

--- a/project/cmake/addons/addons/pvr.stalker/pvr.stalker.txt
+++ b/project/cmake/addons/addons/pvr.stalker/pvr.stalker.txt
@@ -1,1 +1,1 @@
-pvr.stalker https://github.com/kodi-pvr/pvr.stalker 118b2ef
+pvr.stalker https://github.com/kodi-pvr/pvr.stalker 2d65b21

--- a/project/cmake/addons/addons/pvr.vbox/pvr.vbox.txt
+++ b/project/cmake/addons/addons/pvr.vbox/pvr.vbox.txt
@@ -1,1 +1,1 @@
-pvr.vbox https://github.com/kodi-pvr/pvr.vbox 4449aa5
+pvr.vbox https://github.com/kodi-pvr/pvr.vbox 52fe59a

--- a/project/cmake/addons/addons/pvr.vdr.vnsi/pvr.vdr.vnsi.txt
+++ b/project/cmake/addons/addons/pvr.vdr.vnsi/pvr.vdr.vnsi.txt
@@ -1,1 +1,1 @@
-pvr.vdr.vnsi https://github.com/kodi-pvr/pvr.vdr.vnsi 3a28e39
+pvr.vdr.vnsi https://github.com/kodi-pvr/pvr.vdr.vnsi 824a8a4

--- a/project/cmake/addons/addons/pvr.vuplus/pvr.vuplus.txt
+++ b/project/cmake/addons/addons/pvr.vuplus/pvr.vuplus.txt
@@ -1,1 +1,1 @@
-pvr.vuplus https://github.com/kodi-pvr/pvr.vuplus d6abad3
+pvr.vuplus https://github.com/kodi-pvr/pvr.vuplus d727091

--- a/project/cmake/addons/addons/pvr.wmc/pvr.wmc.txt
+++ b/project/cmake/addons/addons/pvr.wmc/pvr.wmc.txt
@@ -1,1 +1,1 @@
-pvr.wmc https://github.com/kodi-pvr/pvr.wmc 37b4b29
+pvr.wmc https://github.com/kodi-pvr/pvr.wmc 295b216

--- a/project/cmake/addons/depends/common/kodi-platform/deps.txt
+++ b/project/cmake/addons/depends/common/kodi-platform/deps.txt
@@ -1,2 +1,3 @@
 kodi
 tinyxml
+platform

--- a/project/cmake/addons/depends/common/kodi-platform/kodi-platform.txt
+++ b/project/cmake/addons/depends/common/kodi-platform/kodi-platform.txt
@@ -1,1 +1,1 @@
-kodi-platform https://github.com/xbmc/kodi-platform 48bdd985
+kodi-platform https://github.com/xbmc/kodi-platform 054a42f66

--- a/project/cmake/addons/depends/common/platform/platform.txt
+++ b/project/cmake/addons/depends/common/platform/platform.txt
@@ -1,0 +1,1 @@
+platform http://mirrors.kodi.tv/build-deps/sources/platform-1.0.6.tar.gz

--- a/project/cmake/addons/depends/common/platform/platform.txt
+++ b/project/cmake/addons/depends/common/platform/platform.txt
@@ -1,1 +1,1 @@
-platform http://mirrors.kodi.tv/build-deps/sources/platform-1.0.6.tar.gz
+platform http://mirrors.kodi.tv/build-deps/sources/platform-1.0.9.tar.gz

--- a/tools/depends/target/platform/Makefile
+++ b/tools/depends/target/platform/Makefile
@@ -1,9 +1,10 @@
-include ../../Makefile.include
+-include ../../Makefile.include
+include ../../xbmc-addons.include
 DEPS= ../../Makefile.include Makefile
 
 # lib name, version
 LIBNAME=platform
-VERSION=1.0.4
+VERSION=1.0.9
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
 


### PR DESCRIPTION
kodi-platform needs (lib)platform since https://github.com/xbmc/kodi-platform/pull/5

In the longer run, this should probably be moved to kodi-platform itself as dependency.
