### PR TITLE
[Python] Fix ControlList.additems() method

### DIFF
--- a/xbmc/interfaces/legacy/Control.cpp
+++ b/xbmc/interfaces/legacy/Control.cpp
@@ -52,9 +52,9 @@ namespace XBMCAddon
 
     // ============================================================
     // ============================================================
-    ControlFadeLabel::ControlFadeLabel(long x, long y, long width, long height, 
-                                       const char* font, const char* _textColor, 
-                                       long _alignment) : 
+    ControlFadeLabel::ControlFadeLabel(long x, long y, long width, long height,
+                                       const char* font, const char* _textColor,
+                                       long _alignment) :
       strFont("font13"), textColor(0xffffffff), align(_alignment)
     {
       dwPosX = x;
@@ -65,7 +65,7 @@ namespace XBMCAddon
       if (font)
         strFont = font;
 
-      if (_textColor) 
+      if (_textColor)
         sscanf(_textColor, "%x", &textColor);
 
       pGUIControl = NULL;
@@ -115,8 +115,8 @@ namespace XBMCAddon
 
     // ============================================================
     // ============================================================
-    ControlTextBox::ControlTextBox(long x, long y, long width, long height, 
-                                   const char* font, const char* _textColor) : 
+    ControlTextBox::ControlTextBox(long x, long y, long width, long height,
+                                   const char* font, const char* _textColor) :
       strFont("font13"), textColor(0xffffffff)
     {
       dwPosX = x;
@@ -127,7 +127,7 @@ namespace XBMCAddon
       if (font)
         strFont = font;
 
-      if (_textColor) 
+      if (_textColor)
         sscanf(_textColor, "%x", &textColor);
     }
 
@@ -189,8 +189,8 @@ namespace XBMCAddon
     // ============================================================
     // ============================================================
     ControlButton::ControlButton(long x, long y, long width, long height, const String& label,
-                                 const char* focusTexture, const char* noFocusTexture, 
-                                 long _textOffsetX, long _textOffsetY, 
+                                 const char* focusTexture, const char* noFocusTexture,
+                                 long _textOffsetX, long _textOffsetY,
                                  long alignment, const char* font, const char* _textColor,
                                  const char* _disabledColor, long angle,
                                  const char* _shadowColor, const char* _focusedColor) :
@@ -210,7 +210,7 @@ namespace XBMCAddon
         XBMCAddonUtils::getDefaultImage((char*)"button", (char*)"texturefocus", (char*)"button-focus.png");
       strTextureNoFocus = noFocusTexture ? noFocusTexture :
         XBMCAddonUtils::getDefaultImage((char*)"button", (char*)"texturenofocus", (char*)"button-nofocus.jpg");
-      
+
       if (font) strFont = font;
       if (_textColor) sscanf( _textColor, "%x", &textColor );
       if (_disabledColor) sscanf( _disabledColor, "%x", &disabledColor );
@@ -218,7 +218,7 @@ namespace XBMCAddon
       if (_focusedColor) sscanf( _focusedColor, "%x", &focusedColor );
     }
 
-    void ControlButton::setLabel(const String& label, 
+    void ControlButton::setLabel(const String& label,
                                  const char* font,
                                  const char* _textColor,
                                  const char* _disabledColor,
@@ -244,7 +244,7 @@ namespace XBMCAddon
     }
 
     void ControlButton::setDisabledColor(const char* color)
-    { 
+    {
       if (color) sscanf(color, "%x", &disabledColor);
 
       if (pGUIControl)
@@ -307,9 +307,9 @@ namespace XBMCAddon
     // ============================================================
     // ============================================================
     ControlCheckMark::ControlCheckMark(long x, long y, long width, long height, const String& label,
-                                       const char* focusTexture, const char* noFocusTexture, 
+                                       const char* focusTexture, const char* noFocusTexture,
                                        long _checkWidth, long _checkHeight,
-                                       long _alignment, const char* font, 
+                                       long _alignment, const char* font,
                                        const char* _textColor, const char* _disabledColor) :
       strFont("font13"), checkWidth(_checkWidth), checkHeight(_checkHeight),
       align(_alignment), textColor(0xffffffff), disabledColor(0x60ffffff)
@@ -352,7 +352,7 @@ namespace XBMCAddon
       }
     }
 
-    void ControlCheckMark::setLabel(const String& label, 
+    void ControlCheckMark::setLabel(const String& label,
                                     const char* font,
                                     const char* _textColor,
                                     const char* _disabledColor,
@@ -415,7 +415,7 @@ namespace XBMCAddon
 
     // ============================================================
     // ============================================================
-    ControlImage::ControlImage(long x, long y, long width, long height, 
+    ControlImage::ControlImage(long x, long y, long width, long height,
                                const char* filename, long aRatio,
                                const char* _colorDiffuse):
       aspectRatio(aRatio), colorDiffuse(0)
@@ -427,7 +427,7 @@ namespace XBMCAddon
 
       // check if filename exists
       strFileName = filename;
-      if (_colorDiffuse) 
+      if (_colorDiffuse)
         sscanf(_colorDiffuse, "%x", &colorDiffuse);
     }
 
@@ -449,7 +449,7 @@ namespace XBMCAddon
       if (pGUIControl)
         ((CGUIImage *)pGUIControl)->SetColorDiffuse(colorDiffuse);
     }
-    
+
     CGUIControl* ControlImage::Create()
     {
       pGUIControl = new CGUIImage(iParentId, iControlId,
@@ -469,7 +469,7 @@ namespace XBMCAddon
 
     // ============================================================
     // ============================================================
-    ControlProgress::ControlProgress(long x, long y, long width, long height, 
+    ControlProgress::ControlProgress(long x, long y, long width, long height,
                                      const char* texturebg,
                                      const char* textureleft,
                                      const char* texturemid,
@@ -482,15 +482,15 @@ namespace XBMCAddon
       dwHeight = height;
 
       // if texture is supplied use it, else get default ones
-      strTextureBg = texturebg ? texturebg : 
+      strTextureBg = texturebg ? texturebg :
         XBMCAddonUtils::getDefaultImage((char*)"progress", (char*)"texturebg", (char*)"progress_back.png");
-      strTextureLeft = textureleft ? textureleft : 
+      strTextureLeft = textureleft ? textureleft :
         XBMCAddonUtils::getDefaultImage((char*)"progress", (char*)"lefttexture", (char*)"progress_left.png");
-      strTextureMid = texturemid ? texturemid : 
+      strTextureMid = texturemid ? texturemid :
         XBMCAddonUtils::getDefaultImage((char*)"progress", (char*)"midtexture", (char*)"progress_mid.png");
-      strTextureRight = textureright ? textureright : 
+      strTextureRight = textureright ? textureright :
         XBMCAddonUtils::getDefaultImage((char*)"progress", (char*)"righttexture", (char*)"progress_right.png");
-      strTextureOverlay = textureoverlay ? textureoverlay : 
+      strTextureOverlay = textureoverlay ? textureoverlay :
         XBMCAddonUtils::getDefaultImage((char*)"progress", (char*)"overlaytexture", (char*)"progress_over.png");
     }
 
@@ -524,8 +524,8 @@ namespace XBMCAddon
 
     // ============================================================
     // ============================================================
-    ControlSlider::ControlSlider(long x, long y, long width, long height, 
-                                 const char* textureback, 
+    ControlSlider::ControlSlider(long x, long y, long width, long height,
+                                 const char* textureback,
                                  const char* texture,
                                  const char* texturefocus)
     {
@@ -535,11 +535,11 @@ namespace XBMCAddon
       dwHeight = height;
 
       // if texture is supplied use it, else get default ones
-      strTextureBack = textureback ? textureback : 
+      strTextureBack = textureback ? textureback :
         XBMCAddonUtils::getDefaultImage((char*)"slider", (char*)"texturesliderbar", (char*)"osd_slider_bg_2.png");
-      strTexture = texture ? texture : 
+      strTexture = texture ? texture :
         XBMCAddonUtils::getDefaultImage((char*)"slider", (char*)"textureslidernib", (char*)"osd_slider_nibNF.png");
-      strTextureFoc = texturefocus ? texturefocus : 
+      strTextureFoc = texturefocus ? texturefocus :
         XBMCAddonUtils::getDefaultImage((char*)"slider", (char*)"textureslidernibfocus", (char*)"osd_slider_nib.png");
     }
 
@@ -560,9 +560,9 @@ namespace XBMCAddon
                                           (float)dwWidth,(float)dwHeight,
                                           CTextureInfo(strTextureBack),CTextureInfo(strTexture),
                                           CTextureInfo(strTextureFoc),0);
-    
+
       return pGUIControl;
-    }  
+    }
 
     // ============================================================
 
@@ -594,13 +594,13 @@ namespace XBMCAddon
     ControlRadioButton::ControlRadioButton(long x, long y, long width, long height, const String& label,
                                            const char* focusOnTexture,  const char* noFocusOnTexture,
                                            const char* focusOffTexture, const char* noFocusOffTexture,
-                                           const char* focusTexture,    const char* noFocusTexture, 
-                                           long _textOffsetX, long _textOffsetY, 
+                                           const char* focusTexture,    const char* noFocusTexture,
+                                           long _textOffsetX, long _textOffsetY,
                                            long alignment, const char* font, const char* _textColor,
                                            const char* _disabledColor, long angle,
                                            const char* _shadowColor, const char* _focusedColor) :
-      strFont("font13"), textColor(0xffffffff), disabledColor(0x60ffffff), 
-      textOffsetX(_textOffsetX), textOffsetY(_textOffsetY), align(alignment), iAngle(angle), 
+      strFont("font13"), textColor(0xffffffff), disabledColor(0x60ffffff),
+      textOffsetX(_textOffsetX), textOffsetY(_textOffsetY), align(alignment), iAngle(angle),
       shadowColor(0), focusedColor(0xffffffff)
     {
       dwPosX = x;
@@ -666,7 +666,7 @@ namespace XBMCAddon
       return isSelected;
     }
 
-    void ControlRadioButton::setLabel(const String& label, 
+    void ControlRadioButton::setLabel(const String& label,
                                       const char* font,
                                       const char* _textColor,
                                       const char* _disabledColor,
@@ -689,7 +689,7 @@ namespace XBMCAddon
       }
     }
 
-    void ControlRadioButton::setRadioDimension(long x, long y, long width, long height) 
+    void ControlRadioButton::setRadioDimension(long x, long y, long width, long height)
     {
       dwPosX = x;
       dwPosY = y;
@@ -847,7 +847,7 @@ namespace XBMCAddon
       DelayedCallGuard dcguard(languageHook);
       LOCKGUI;
       dwWidth = width;
-      if (pGUIControl) 
+      if (pGUIControl)
         pGUIControl->SetWidth((float)dwWidth);
     }
 
@@ -856,12 +856,12 @@ namespace XBMCAddon
       DelayedCallGuard dcguard(languageHook);
       LOCKGUI;
       dwHeight = height;
-      if (pGUIControl) 
+      if (pGUIControl)
         pGUIControl->SetHeight((float)dwHeight);
     }
 
     void Control::setNavigation(const Control* up, const Control* down,
-                                const Control* left, const Control* right) 
+                                const Control* left, const Control* right)
     {
       if(iControlId == 0)
         throw WindowException("Control has to be added to a window first");
@@ -885,7 +885,7 @@ namespace XBMCAddon
 
       {
         LOCKGUI;
-        if (pGUIControl) 
+        if (pGUIControl)
           pGUIControl->SetNavigationAction(ACTION_MOVE_UP, control->iControlId);
       }
     }
@@ -945,8 +945,8 @@ namespace XBMCAddon
       strTextureDownFocus = XBMCAddonUtils::getDefaultImage((char*)"listcontrol", (char*)"texturedownfocus", (char*)"scroll-down-focus.png");
     }
 
-    void ControlSpin::setTextures(const char* up, const char* down, 
-                                  const char* upFocus, 
+    void ControlSpin::setTextures(const char* up, const char* down,
+                                  const char* upFocus,
                                   const char* downFocus)
     {
       strTextureUp = up;
@@ -969,13 +969,13 @@ namespace XBMCAddon
     // ============================================================
     //  ControlLabel
     // ============================================================
-    ControlLabel::ControlLabel(long x, long y, long width, long height, 
+    ControlLabel::ControlLabel(long x, long y, long width, long height,
                                const String& label,
-                               const char* font, const char* p_textColor, 
+                               const char* font, const char* p_textColor,
                                const char* p_disabledColor,
-                               long p_alignment, 
+                               long p_alignment,
                                bool hasPath, long angle) :
-      strFont("font13"), 
+      strFont("font13"),
       textColor(0xffffffff), disabledColor(0x60ffffff),
       align(p_alignment), bHasPath(hasPath), iAngle(angle)
     {
@@ -988,7 +988,7 @@ namespace XBMCAddon
       if (font)
         strFont = font;
 
-      if (p_textColor) 
+      if (p_textColor)
         sscanf(p_textColor, "%x", &textColor);
 
       if (p_disabledColor)
@@ -997,7 +997,7 @@ namespace XBMCAddon
 
     ControlLabel::~ControlLabel() {}
 
-    CGUIControl* ControlLabel::Create() 
+    CGUIControl* ControlLabel::Create()
     {
       CLabelInfo label;
       label.font = g_fontManager.GetFont(strFont);
@@ -1017,7 +1017,7 @@ namespace XBMCAddon
         bHasPath);
       ((CGUILabelControl *)pGUIControl)->SetLabel(strText);
       return pGUIControl;
-    }    
+    }
 
     void ControlLabel::setLabel(const String& label, const char* font,
                                 const char* textColor, const char* disabledColor,
@@ -1032,7 +1032,7 @@ namespace XBMCAddon
 
     String ControlLabel::getLabel()
     {
-      if (!pGUIControl) 
+      if (!pGUIControl)
         return NULL;
       return strText;
     }
@@ -1042,7 +1042,7 @@ namespace XBMCAddon
     //  ControlEdit
     // ============================================================
     ControlEdit::ControlEdit(long x, long y, long width, long height, const String& label,
-                             const char* font, const char* _textColor, 
+                             const char* font, const char* _textColor,
                              const char* _disabledColor,
                              long _alignment, const char* focusTexture,
                              const char* noFocusTexture, bool isPassword) :
@@ -1061,7 +1061,7 @@ namespace XBMCAddon
       if (_disabledColor) sscanf( _disabledColor, "%x", &disabledColor );
     }
 
-    CGUIControl* ControlEdit::Create() 
+    CGUIControl* ControlEdit::Create()
     {
       CLabelInfo label;
       label.font = g_fontManager.GetFont(strFont);
@@ -1098,7 +1098,7 @@ namespace XBMCAddon
 
     String ControlEdit::getLabel()
     {
-      if (!pGUIControl) 
+      if (!pGUIControl)
         return NULL;
       return strText;
     }
@@ -1130,7 +1130,7 @@ namespace XBMCAddon
                              const char* cselectedColor,
                              long _imageWidth, long _imageHeight, long _itemTextXOffset,
                              long _itemTextYOffset, long _itemHeight, long _space, long _alignmentY) :
-      strFont("font13"), 
+      strFont("font13"),
       textColor(0xe0f0f0f0), selectedColor(0xffffffff),
       imageHeight(_imageHeight), imageWidth(_imageWidth),
       itemHeight(_itemHeight), space(_space),
@@ -1284,7 +1284,7 @@ namespace XBMCAddon
     {
       DelayedCallGuard dcguard(languageHook);
       LOCKGUI;
-      
+
       // create message
       CGUIMessage msg(GUI_MSG_ITEM_SELECTED, iParentId, iControlId);
       long pos = -1;

--- a/xbmc/interfaces/legacy/Control.cpp
+++ b/xbmc/interfaces/legacy/Control.cpp
@@ -1217,7 +1217,7 @@ namespace XBMCAddon
 
       for (std::vector<Alternative<String, const XBMCAddon::xbmcgui::ListItem* > >::const_iterator iter = items.begin(); iter != items.end(); ++iter)
         addItem(*iter,false);
-      sendLabelBind(items.size());
+      sendLabelBind(vecItems.size());
     }
 
     void ControlList::internAddListItem(AddonClass::Ref<ListItem> pListItem, bool sendMessage)


### PR DESCRIPTION
fixes Python xbmcgui.ControlList.addItems() which behaves like setItems() at the moment instead of like appendItems().

Core does a reset on the list in guilib on GUI_MSG_BIND_LABEL.  As such
we need to send the full list up to core, not just the new appended
items.

first commit is fix, second just cosmetics.
Thx to @t-nelson for spotting this :)

@jimfcarroll @mkortstiege 
