### PR TITLE
[Webdav]: Native Exists() and Stat() functions

### DIFF
--- a/xbmc/filesystem/DAVFile.cpp
+++ b/xbmc/filesystem/DAVFile.cpp
@@ -34,7 +34,7 @@ using namespace XCURL;
 
 CDAVFile::CDAVFile(void)
   : CCurlFile()
-  , lastResponseCode(0)
+  , m_lastResponseCode(0)
 {
 }
 
@@ -47,8 +47,6 @@ bool CDAVFile::Execute(const CURL& url)
   CURL url2(url);
   ParseAndCorrectUrl(url2);
 
-  CLog::Log(LOGDEBUG, "CDAVFile::Execute(%p) %s", (void*)this, m_url.c_str());
-
   assert(!(!m_state->m_easyHandle ^ !m_state->m_multiHandle));
   if( m_state->m_easyHandle == NULL )
     g_curlInterface.easy_aquire(url2.GetProtocol().c_str(),
@@ -60,32 +58,32 @@ bool CDAVFile::Execute(const CURL& url)
   SetCommonOptions(m_state);
   SetRequestHeaders(m_state);
 
-  lastResponseCode = m_state->Connect(m_bufferSize);
-  if( lastResponseCode < 0 || lastResponseCode >= 400)
+  m_lastResponseCode = m_state->Connect(m_bufferSize);
+  if (m_lastResponseCode < 0 || m_lastResponseCode >= 400)
     return false;
 
   char* efurl;
   if (CURLE_OK == g_curlInterface.easy_getinfo(m_state->m_easyHandle, CURLINFO_EFFECTIVE_URL,&efurl) && efurl)
     m_url = efurl;
 
-  if (lastResponseCode == 207)
+  if (m_lastResponseCode == 207)
   {
     std::string strResponse;
     ReadData(strResponse);
 
-    CXBMCTinyXML davResponse;
-    davResponse.Parse(strResponse);
+    m_davResponse.Clear();
+    m_davResponse.Parse(strResponse);
 
-    if (!davResponse.Parse(strResponse))
+    if (!m_davResponse.Parse(strResponse))
     {
-      CLog::Log(LOGERROR, "%s - Unable to process dav response (%s)", __FUNCTION__, m_url.c_str());
+      CLog::Log(LOGERROR, "CDAVFile::Execute - Unable to process dav response (%s)", CURL(m_url).GetRedacted().c_str());
       Close();
       return false;
     }
 
     TiXmlNode *pChild;
     // Iterate over all responses
-    for (pChild = davResponse.RootElement()->FirstChild(); pChild != 0; pChild = pChild->NextSibling())
+    for (pChild = m_davResponse.RootElement()->FirstChild(); pChild != 0; pChild = pChild->NextSibling())
     {
       if (CDAVCommon::ValueWithoutNamespace(pChild, "response"))
       {
@@ -96,14 +94,152 @@ bool CDAVFile::Execute(const CURL& url)
         {
           if (rxCode.GetSubCount())
           {
-            lastResponseCode = atoi(rxCode.GetMatch(1).c_str());
-            if( lastResponseCode < 0 || lastResponseCode >= 400)
+            m_lastResponseCode = atoi(rxCode.GetMatch(1).c_str());
+            if (m_lastResponseCode < 0 || m_lastResponseCode >= 400)
               return false;
           }
         }
-
       }
     }
+  }
+
+  return true;
+}
+
+/*
+ * Parses a <response>
+ *
+ * <!ELEMENT response (href, ((href*, status)|(propstat+)), responsedescription?) >
+ * <!ELEMENT propstat (prop, status, responsedescription?) >
+ *
+ */
+bool CDAVFile::ParseResponse(const TiXmlElement *pElement, struct __stat64* statBuffer)
+{
+  const TiXmlElement *pResponseChild;
+  const TiXmlNode *pPropstatChild;
+  const TiXmlElement *pPropChild;
+
+  /* Iterate response children elements */
+  for (pResponseChild = pElement->FirstChildElement(); pResponseChild != 0; pResponseChild = pResponseChild->NextSiblingElement())
+  {
+    if (CDAVCommon::ValueWithoutNamespace(pResponseChild, "propstat"))
+    {
+      if (CDAVCommon::GetStatusTag(pResponseChild->ToElement()) == "HTTP/1.1 200 OK")
+      {
+        if (!statBuffer) // If caller is not interested in the rest, we're done
+          return true;
+
+        /* Iterate propstat children elements */
+        for (pPropstatChild = pResponseChild->FirstChild(); pPropstatChild != 0; pPropstatChild = pPropstatChild->NextSibling())
+        {
+          if (CDAVCommon::ValueWithoutNamespace(pPropstatChild, "prop"))
+          {
+            memset(statBuffer, 0, sizeof(struct __stat64));
+
+            /* Iterate all properties available */
+            for (pPropChild = pPropstatChild->FirstChildElement(); pPropChild != 0; pPropChild = pPropChild->NextSiblingElement())
+            {
+              if (CDAVCommon::ValueWithoutNamespace(pPropChild, "getcontentlength") && !pPropChild->NoChildren())
+              {
+                statBuffer->st_size = strtoll(pPropChild->FirstChild()->Value(), NULL, 10);
+              }
+              else
+              if (CDAVCommon::ValueWithoutNamespace(pPropChild, "getlastmodified") && !pPropChild->NoChildren())
+              {
+                struct tm timeDate = { 0 };
+                strptime(pPropChild->FirstChild()->Value(), "%a, %d %b %Y %T", &timeDate);
+                statBuffer->st_mtime = mktime(&timeDate);
+              }
+              else
+              if (statBuffer->st_mtime == 0 && CDAVCommon::ValueWithoutNamespace(pPropChild, "creationdate") && !pPropChild->NoChildren())
+              {
+                struct tm timeDate = { 0 };
+                strptime(pPropChild->FirstChild()->Value(), "%Y-%m-%dT%T", &timeDate);
+                statBuffer->st_mtime = mktime(&timeDate);
+              }
+              else
+              if (CDAVCommon::ValueWithoutNamespace(pPropChild, "resourcetype"))
+              {
+                if (CDAVCommon::ValueWithoutNamespace(pPropChild->FirstChild(), "collection"))
+                  statBuffer->st_mode = _S_IFDIR;
+                else
+                  statBuffer->st_mode = _S_IFREG;
+              }
+            }
+
+            return true;
+          }
+        }
+      }
+    }
+  }
+
+  return false;
+}
+
+int CDAVFile::Stat(const CURL& url, struct __stat64* buffer)
+{
+  CDAVFile dav;
+  std::string strRequest = "PROPFIND";
+  dav.SetCustomRequest(strRequest);
+  dav.SetRequestHeader("depth", 0);
+  dav.SetMimeType("text/xml; charset=\"utf-8\"");
+
+  if (buffer)
+  {
+    CLog::Log(LOGDEBUG, "CDAVFile::Stat - Execute STAT (%s)", url.GetRedacted().c_str());
+
+    dav.SetPostData(
+      "<?xml version=\"1.0\" encoding=\"utf-8\" ?>"
+      " <D:propfind xmlns:D=\"DAV:\">"
+      "   <D:prop>"
+      "     <D:resourcetype/>"
+      "     <D:getcontentlength/>"
+      "     <D:getlastmodified/>"
+      "     <D:creationdate/>"
+      "     <D:displayname/>"
+      "    </D:prop>"
+      "  </D:propfind>");
+  }
+  else
+  {
+    dav.SetPostData(
+      "<?xml version=\"1.0\" encoding=\"utf-8\" ?>");
+  }
+
+  if (!dav.Execute(url))
+  {
+    if (buffer)
+      CLog::Log(LOGERROR, "CDAVFile::Stat - Unable to stat resource (%s) with code %i", url.GetRedacted().c_str(), m_lastResponseCode);
+
+    return -1;
+  }
+
+  dav.Close();
+
+  // Iterate over all responses
+  for (TiXmlNode *pChild = m_davResponse.RootElement()->FirstChild(); pChild != 0; pChild = pChild->NextSibling())
+  {
+    if (CDAVCommon::ValueWithoutNamespace(pChild, "response"))
+    {
+      if (ParseResponse(pChild->ToElement(), buffer))
+        return 0;
+      else
+        return -1;
+    }
+  }
+
+  return -1;
+}
+
+bool CDAVFile::Exists(const CURL& url)
+{
+  if (Stat(url, NULL) != 0)
+  {
+    if (m_lastResponseCode >= 400 && m_lastResponseCode != 404)
+      CLog::Log(LOGERROR, "CDAVFile::Exists - Unable to stat resource (%s) with code %i", url.GetRedacted().c_str(), m_lastResponseCode);
+
+    return false;
   }
 
   return true;
@@ -119,9 +255,10 @@ bool CDAVFile::Delete(const CURL& url)
 
   dav.SetCustomRequest(strRequest);
  
+  CLog::Log(LOGDEBUG, "CDAVFile::Delete - Execute DELETE (%s)", url.GetRedacted().c_str());
   if (!dav.Execute(url))
   {
-    CLog::Log(LOGERROR, "%s - Unable to delete dav resource (%s)", __FUNCTION__, url.Get().c_str());
+    CLog::Log(LOGERROR, "CDAVFile::Delete - Unable to delete dav resource (%s)", url.GetRedacted().c_str());
     return false;
   }
 
@@ -145,9 +282,10 @@ bool CDAVFile::Rename(const CURL& url, const CURL& urlnew)
   dav.SetCustomRequest(strRequest);
   dav.SetRequestHeader("Destination", url2.GetWithoutUserDetails());
 
+  CLog::Log(LOGDEBUG, "CDAVFile::Rename - Execute MOVE (%s -> %s)", url.GetRedacted().c_str(), url2.GetRedacted().c_str());
   if (!dav.Execute(url))
   {
-    CLog::Log(LOGERROR, "%s - Unable to rename dav resource (%s)", __FUNCTION__, url.Get().c_str());
+    CLog::Log(LOGERROR, "CDAVFile::Rename - Unable to rename dav resource (%s -> %s)", url.GetRedacted().c_str(), url2.GetRedacted().c_str());
     return false;
   }
 

--- a/xbmc/filesystem/DAVFile.h
+++ b/xbmc/filesystem/DAVFile.h
@@ -21,6 +21,7 @@
 
 #include "IFile.h"
 #include "CurlFile.h"
+#include "utils/XBMCTinyXML.h"
 
 namespace XFILE
 {
@@ -35,9 +36,15 @@ namespace XFILE
     virtual bool Delete(const CURL& url);
     virtual bool Rename(const CURL& url, const CURL& urlnew);
 
-    virtual int GetLastResponseCode() { return lastResponseCode; }
+    virtual bool Exists(const CURL& url);
+    virtual int Stat(const CURL& url, struct __stat64* buffer);
+
+    virtual int GetLastResponseCode() { return m_lastResponseCode; }
 
   private:
-    int lastResponseCode;
+    bool ParseResponse(const TiXmlElement *pElement, struct __stat64* statBuffer);
+
+    int m_lastResponseCode;
+    CXBMCTinyXML m_davResponse;
   };
 }


### PR DESCRIPTION
Previously we used plain http methods for Webdav file Exists/Stat, and although it works (most of the time), it is wrong and may not work properly with all clients. This PR implements the proper native functions.
