### PR TITLE
Allow uppercase input via SMS

### DIFF
--- a/xbmc/guilib/GUIEditControl.cpp
+++ b/xbmc/guilib/GUIEditControl.cpp
@@ -35,7 +35,7 @@
 #include "osx/CocoaInterface.h"
 #endif
 
-const char* CGUIEditControl::smsLetters[10] = { " !@#$%^&*()[]{}<>/\\|0", ".,;:\'\"-+_=?`~1", "abc2", "def3", "ghi4", "jkl5", "mno6", "pqrs7", "tuv8", "wxyz9" };
+const char* CGUIEditControl::smsLetters[10] = { " !@#$%^&*()[]{}<>/\\|0", ".,;:\'\"-+_=?`~1", "abc2ABC", "def3DEF", "ghi4GHI", "jkl5JKL", "mno6MNO", "pqrs7PQRS", "tuv8TUV", "wxyz9WXYZ" };
 const unsigned int CGUIEditControl::smsDelay = 1000;
 
 using namespace std;


### PR DESCRIPTION
This is a response to ticket http://trac.kodi.tv/ticket/15952

This seems an obvious and easy way to allow uppercase entry via SMS type input, but this is as much an RFC as a proposed solution. I'd be grateful for advice on whether this is a useful solution or not.
