### PR TITLE
[strings] take 3 - fix  misspellings/typos, apostrophes/hyphens and cosmetics

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -2640,7 +2640,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#620"
-msgid "Audio CDs"
+msgid "Audio CD's"
 msgstr ""
 
 #: system/settings/settings.xml
@@ -4793,7 +4793,7 @@ msgstr ""
 
 #: skin.confluence
 msgctxt "#12321"
-msgid "Ok"
+msgid "OK"
 msgstr ""
 
 #: xbmc/dialogs/GUIDialogGamepad.cpp
@@ -5117,7 +5117,7 @@ msgstr ""
 
 #: unknown
 msgctxt "#13001"
-msgid "Immediate HD spindown"
+msgid "Immediate HDD spindown"
 msgstr ""
 
 #: unknown
@@ -6849,7 +6849,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#14088"
-msgid "Play DVDs automatically"
+msgid "Play DVD's automatically"
 msgstr ""
 
 #: system/settings/settings.xml
@@ -7225,7 +7225,7 @@ msgstr ""
 
 #: xbmc/video/dialogs/GUIDialogVideoSettings.cpp
 msgctxt "#16020"
-msgid "De-interlace"
+msgid "Deinterlace"
 msgstr ""
 
 #: xbmc/video/dialogs/GUIDialogVideoSettings.cpp
@@ -7292,7 +7292,7 @@ msgstr ""
 
 #: xbmc/video/dialogs/GUIDialogVideoSettings.cpp
 msgctxt "#16036"
-msgid "De-interlace (Half)"
+msgid "Deinterlace (Half)"
 msgstr ""
 
 msgctxt "#16037"
@@ -11546,7 +11546,7 @@ msgid "Cache full"
 msgstr ""
 
 msgctxt "#21455"
-msgid "Cache filled before reaching required amount for continous playback"
+msgid "Cache filled before reaching required amount for continuous playback"
 msgstr ""
 
 #: xbmc/playlists/SmartPlaylist.cpp
@@ -13693,18 +13693,18 @@ msgctxt "#35000"
 msgid "Peripherals"
 msgstr ""
 
-#: xbmc/pheripherals/devices/PeripheralHID.cpp
-#: xbmc/pheripherals/devices/Peripheralmon.cpp
+#: xbmc/peripherals/devices/PeripheralHID.cpp
+#: xbmc/peripherals/devices/Peripheralmon.cpp
 msgctxt "#35001"
 msgid "Generic HID device"
 msgstr ""
 
-#: xbmc/pheripherals/devices/PeripheralNIC.cpp
+#: xbmc/peripherals/devices/PeripheralNIC.cpp
 msgctxt "#35002"
 msgid "Generic network adaptor"
 msgstr ""
 
-#: xbmc/pheripherals/devices/PeripheralDisk.cpp
+#: xbmc/peripherals/devices/PeripheralDisk.cpp
 msgctxt "#35003"
 msgid "Generic disk"
 msgstr ""
@@ -13714,12 +13714,12 @@ msgctxt "#35004"
 msgid "There are no settings available\nfor this peripheral."
 msgstr ""
 
-#: xbmc/pheripherals/Peripherals.cpp
+#: xbmc/peripherals/Peripherals.cpp
 msgctxt "#35005"
 msgid "New device configured"
 msgstr ""
 
-#: xbmc/pheripherals/Peripherals.cpp
+#: xbmc/peripherals/Peripherals.cpp
 msgctxt "#35006"
 msgid "Device removed"
 msgstr ""
@@ -14092,19 +14092,19 @@ msgctxt "#36114"
 msgid "Chooses the language of the user interface."
 msgstr ""
 
-#.  Description of setting "Appearance -> International -> Region" with label #20026
+#. Description of setting "Appearance -> International -> Region" with label #20026
 #: system/settings/settings.xml
 msgctxt "#36115"
 msgid "Select the formats for temperature, time and date. The available options depend on the selected language."
 msgstr ""
 
-#.  Description of setting "Appearance -> International -> Character set" with label #14091
+#. Description of setting "Appearance -> International -> Character set" with label #14091
 #: system/settings/settings.xml
 msgctxt "#36116"
 msgid "Choose which character set is used for displaying text in the user interface."
 msgstr ""
 
-#.  Description of setting "Appearance -> International -> Timezone country" with label #14079
+#. Description of setting "Appearance -> International -> Timezone country" with label #14079
 #: system/settings/settings.xml
 msgctxt "#36117"
 msgid "Select country location."
@@ -14116,13 +14116,13 @@ msgctxt "#36118"
 msgid "Select your current timezone."
 msgstr ""
 
-#.  Description of setting "Appearance -> International -> Preferred audio language" with label #285
+#. Description of setting "Appearance -> International -> Preferred audio language" with label #285
 #: system/settings/settings.xml
 msgctxt "#36119"
 msgid "Defaults to the selected audio language if more than one language is available."
 msgstr ""
 
-#.  Description of setting "Video -> Subtitles -> Preferred subtitle language" with label #286
+#. Description of setting "Video -> Subtitles -> Preferred subtitle language" with label #286
 #: system/settings/settings.xml
 msgctxt "#36120"
 msgid "Defaults to the selected subtitle language if more than one language is available."
@@ -14134,37 +14134,37 @@ msgctxt "#36121"
 msgid "Category containing settings related to how file lists are displayed."
 msgstr ""
 
-#.  Description of setting "Appearance -> File lists -> Show parent folder items" with label #13306
+#. Description of setting "Appearance -> File lists -> Show parent folder items" with label #13306
 #: system/settings/settings.xml
 msgctxt "#36122"
 msgid "Display the (..) item in lists for visiting the parent folder."
 msgstr ""
 
-#.  Description of setting "Appearance -> File lists -> Show file extensions" with label #497
+#. Description of setting "Appearance -> File lists -> Show file extensions" with label #497
 #: system/settings/settings.xml
 msgctxt "#36123"
 msgid "Show file extensions on media files. For example, 'You Enjoy Myself.mp3' would be simply be shown as 'You Enjoy Myself'."
 msgstr ""
 
-#. #.  Description of setting "Appearance -> File lists -> Ignore articles when sorting with label #13399
+#. Description of setting "Appearance -> File lists -> Ignore articles when sorting with label #13399
 #: system/settings/settings.xml
 msgctxt "#36124"
 msgid "Ignore certain tokens (e.g. \"the\") during sort operations. For example, 'The Simpsons' would be sorted as 'Simpsons'."
 msgstr ""
 
-#.  Description of setting "Appearance -> File lists -> Allow file renaming and deletion" with label #14071
+#. Description of setting "Appearance -> File lists -> Allow file renaming and deletion" with label #14071
 #: system/settings/settings.xml
 msgctxt "#36125"
 msgid "Allow files to be deleted and renamed through the user interface, via the contextual menu (press C on a keyboard, for example, to bring up this menu)."
 msgstr ""
 
-#.  Description of setting "Appearance -> File lists -> Show "Add source" buttons in files lists" with label #21382
+#. Description of setting "Appearance -> File lists -> Show "Add source" buttons in files lists" with label #21382
 #: system/settings/settings.xml
 msgctxt "#36126"
 msgid "Show the add source button in root sections of the user interface."
 msgstr ""
 
-#.  Description of setting "Appearance -> File lists -> Show hidden files and directories" with label #21330
+#. Description of setting "Appearance -> File lists -> Show hidden files and directories" with label #21330
 #: system/settings/settings.xml
 msgctxt "#36127"
 msgid "Show hidden files and directories when listing files."
@@ -14239,7 +14239,7 @@ msgctxt "#36139"
 msgid "Category containing the settings for how the video library is handled."
 msgstr ""
 
-#.  Description of setting "Appearance -> International -> Temperature unit" with label #14105
+#. Description of setting "Appearance -> International -> Temperature unit" with label #14105
 #: system/settings/settings.xml
 msgctxt "#36140"
 msgid "Choose which temperature unit is used for displaying temperatures in the user interface."
@@ -14251,7 +14251,7 @@ msgctxt "#36141"
 msgid "Show plot information for unwatched media in the Video Library."
 msgstr ""
 
-#.  Description of setting "Appearance -> International -> Speed unit" with label #14106
+#. Description of setting "Appearance -> International -> Speed unit" with label #14106
 #: system/settings/settings.xml
 msgctxt "#36142"
 msgid "Choose which speed unit is used for displaying speeds in the user interface."
@@ -14325,7 +14325,7 @@ msgctxt "#36153"
 msgid "Adjust the method used to process and display video."
 msgstr ""
 
-#. Description of setting "Videos -> Playback -> Enable HQ Scalers for scalings above" with label #13435
+#. Description of setting "Videos -> Playback -> Enable HQ Scalers for scaling above" with label #13435
 #: system/settings/settings.xml
 msgctxt "#36154"
 msgid "Use high quality scalers when upscaling a video by at least this percentage."
@@ -14549,7 +14549,7 @@ msgstr ""
 #. Description of settings category "Videos -> DVDs" with label #14087
 #: system/settings/settings.xml
 msgctxt "#36193"
-msgid "Category containing settings for how DVDs are handled."
+msgid "Category containing settings for how DVD's are handled."
 msgstr ""
 
 #. Description of setting "Videos -> DVDs -> Play DVDs automatically" with label #14088
@@ -15020,13 +15020,13 @@ msgstr ""
 #. Description of settings category "Music -> Audio CDs" with label #620
 #: system/settings/settings.xml
 msgctxt "#36282"
-msgid "Category containing settings for how CDs are handled."
+msgid "Category containing settings for how CD's are handled."
 msgstr ""
 
 #. Description of setting "Music -> Audio CDs -> Audio CD Insert Action" with label #14097
 #: system/settings/settings.xml
 msgctxt "#36283"
-msgid "Autorun CDs when inserted in drive."
+msgid "Autorun CD's when inserted in drive."
 msgstr ""
 
 #. Description of setting "Music -> Audio CDs -> Load audio CD information from online service" with label #227
@@ -15269,7 +15269,7 @@ msgstr ""
 #. Description of setting "Services -> UPnP -> Announce library updates" with label #20188
 #: system/settings/settings.xml
 msgctxt "#36324"
-msgid "When a manual or automatical library update occurs, notify UPnP clients."
+msgid "When a manual or automatic library update occurs, notify UPnP clients."
 msgstr ""
 
 #. Description of setting "Services -> UPnP -> Allow playback control via UPnP" with label #21881
@@ -15723,7 +15723,7 @@ msgstr ""
 #. Description of settings category "System -> Cache -> Video/Audio/DVD cache - Hard disk" with label #14025
 #: system/settings/settings.xml
 msgctxt "#36400"
-msgid "Enable cache for playback of Video, Audio or DVDs from hard disk."
+msgid "Enable cache for playback of Video, Audio or DVD's from hard disk."
 msgstr ""
 
 #. Description of settings category "System -> Cache -> Video cache - DVD-ROM" with label #14026
@@ -15898,7 +15898,7 @@ msgstr ""
 #. Description for video related setting #13457: vaapi sw filter
 #: system/settings/settings.xml
 msgctxt "#36433"
-msgid "If enabled VAAPI render method is prefered. This puts less load on the CPU but driver may hang!"
+msgid "When enabled, VAAPI render method is preferred and the CPU has less load. If you experience hangs, disable this option."
 msgstr ""
 
 #. Description of setting "Videos -> Playback -> Enable MMAL hardware decoding of video files"
@@ -16034,7 +16034,7 @@ msgctxt "#36527"
 msgid "Select playback mode"
 msgstr ""
 
-#. label of a dialog box promting the user to selected the desired playback mode of the detected stereoscopic video
+#. label of a dialog box prompting the user to selected the desired playback mode of the detected stereoscopic video
 #: guilib/StereoscopicsManager.cpp
 msgctxt "#36528"
 msgid "Select stereoscopic 3D mode"
@@ -16224,12 +16224,12 @@ msgstr ""
 
 #: xbmc/media/MediaType.cpp
 msgctxt "#36908"
-msgid "musicvideo"
+msgid "music video"
 msgstr ""
 
 #: xbmc/media/MediaType.cpp
 msgctxt "#36909"
-msgid "musicvideos"
+msgid "music videos"
 msgstr ""
 
 #: xbmc/media/MediaType.cpp
@@ -16412,7 +16412,7 @@ msgstr ""
 #. Description of setting #14102 Settings -> Video -> Discs -> Blu-ray playback mode
 #: system/settings/settings.xml
 msgctxt "#37031"
-msgid "Specifies how Blu-rays should be opened/played back. Disc menus are not fully supported yet and may cause problems."
+msgid "Specifies how Blu-ray's should be opened/played back. Disc menus are not fully supported yet and may cause problems."
 msgstr ""
 
 #. Title of category #37032 Settings -> Video -> Accessibility
@@ -16427,37 +16427,37 @@ msgctxt "#37033"
 msgid "Video playback related accessibility settings, e.g., \"Prefer subtitles for the hearing impaired\""
 msgstr ""
 
-#. Setting #37034 Settings -> Video -> Accessibility 
+#. Setting #37034 Settings -> Video -> Accessibility
 #: system/settings/settings.xml
 msgctxt "#37034"
 msgid "Prefer audio stream for the visually impaired"
 msgstr ""
 
-#. Description of setting #37034 Settings -> Video -> Accessibility 
+#. Description of setting #37034 Settings -> Video -> Accessibility
 #: system/settings/settings.xml
 msgctxt "#37035"
 msgid "Prefer the audio stream for the visually impaired to other audio streams of the same language"
 msgstr ""
 
-#. Setting #37036 Settings -> Video -> Accessibility 
+#. Setting #37036 Settings -> Video -> Accessibility
 #: system/settings/settings.xml
 msgctxt "#37036"
 msgid "Prefer audio stream for the hearing impaired"
 msgstr ""
 
-#. Description of setting #37036 Settings -> Video -> Accessibility 
+#. Description of setting #37036 Settings -> Video -> Accessibility
 #: system/settings/settings.xml
 msgctxt "#37037"
 msgid "Prefer the audio stream for the hearing impaired to other audio streams of the same language"
 msgstr ""
 
-#. Setting #37038 Settings -> Video -> Accessibility 
+#. Setting #37038 Settings -> Video -> Accessibility
 #: system/settings/settings.xml
 msgctxt "#37038"
 msgid "Prefer subtitles for the hearing impaired"
 msgstr ""
 
-#. Description of setting #37038 Settings -> Video -> Accessibility 
+#. Description of setting #37038 Settings -> Video -> Accessibility
 #: system/settings/settings.xml
 msgctxt "#37039"
 msgid "Prefer the subtitle stream for the hearing impaired to other subtitle streams of the same language"
@@ -16509,13 +16509,13 @@ msgstr ""
 #. Setting #38011 "Videos -> Library -> Show All Items entry"
 #: system/settings/settings.xml
 msgctxt "#38011"
-msgid "Show \"All Items\" entry"
+msgid "Show \"All items\" entry"
 msgstr ""
 
 #. Description of setting "Videos -> Library -> Show All Items entry"
 #: system/settings/settings.xml
 msgctxt "#38012"
-msgid "Show \"All Items\" entry in directory (for example All Albums or All Seasons)"
+msgid "Show \"All items\" entry in directory (for example All Albums or All Seasons)"
 msgstr ""
 
 #. Label of a setting to limit the number of fps used for updating the GUI while playing videos. This is useful for slow systems that have problems rendering GUI and video at the same time in full speed.


### PR DESCRIPTION
Again looking at resource.language.en_gb strings

---
###### Note to reviewers

Capitalization is handled in https://github.com/xbmc/xbmc/pull/7080 and this PR **is not** based off of that one but I can merge the two PRs if thats desired. 

---

In the end, I decided not to address unused strings here, not even sure if I wish to tackle that pickle.

  The Misspellings/typos just had to be done, cant believe it survived translations even after this long.  
  The apostrophes arent a big issue, and could have been slightly more aggressive in this review in fact but this way some feedback will probably be best way to start that.  
  Cosmetics are just that could have been totally left out but were easy to spot/fix despite not being worried about comments in the scope of the PR at all.
- I think it would be a good opportunity to get rid of **Americanisms** here once and for all.

@MartijnKaijser @jjd-uk @alanwww1 For review maybe even @Jalle19 and @Paxxi 

A shout to native speakers on this.
