### PR TITLE
dvdplayer: fix display time after 43b6cf683abf16bc41e9b7f624a678c285c…

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
@@ -470,6 +470,7 @@ void CDVDPlayerVideo::Process()
         if (pts == DVD_NOPTS_VALUE)
           pts = m_pClock->GetClock();
         state.time = DVD_TIME_TO_MSEC(pts + state.time_offset);
+        state.disptime = state.time;
         state.timestamp = CDVDClock::GetAbsoluteClock();
       }
       else


### PR DESCRIPTION
see title

I forgot to send back display time. Result was wrong time in particular at the beginning of video
