### PR TITLE
IMX: Fix path to edid on default imx kernel

### DIFF
--- a/xbmc/windowing/egl/EGLNativeTypeIMX.cpp
+++ b/xbmc/windowing/egl/EGLNativeTypeIMX.cpp
@@ -337,11 +337,11 @@ float CEGLNativeTypeIMX::GetMonitorSAR()
   size_t n;
   int done = 0;
 
-  // kernels <= 3.18 use ./soc0/soc.0
+  // kernels <= 3.18 use ./soc0/soc.1 in official imx kernel
   // kernels  > 3.18 use ./soc0/soc
   f_edid = fopen("/sys/devices/soc0/soc/20e0000.hdmi_video/edid", "r");
   if(!f_edid)
-    f_edid = fopen("/sys/devices/soc0/soc.0/20e0000.hdmi_video/edid", "r");
+    f_edid = fopen("/sys/devices/soc0/soc.1/20e0000.hdmi_video/edid", "r");
 
   if(!f_edid)
     return 0;


### PR DESCRIPTION
This is a follow up of: 31e87e2e6dd21c9d8ea5c7412e4401a114392743

thanks @samnazarko for spotting.
