### PR TITLE
Fixed OS X i386 Xcode builds on x86_64 build machines

### DIFF
--- a/Kodi.xcodeproj/project.pbxproj
+++ b/Kodi.xcodeproj/project.pbxproj
@@ -13337,6 +13337,7 @@
 		};
 		6E2FACBB0E26DF7A00DF79EA /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = E49910D1174E2E0000741B6D /* App-OSX.xcconfig */;
 			buildSettings = {
 				ARCHS = (
 					i386,
@@ -13353,6 +13354,7 @@
 		};
 		6E2FACBD0E26DF7A00DF79EA /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = E49910D1174E2E0000741B6D /* App-OSX.xcconfig */;
 			buildSettings = {
 				ARCHS = (
 					i386,


### PR DESCRIPTION
Without assigning App-OSX.xcconfig to Kodi.app target building i386
target will not fix dependent libraries when bundling the Kodi.app with
copyframeworks-osx.command

copyframeworks-osx.command uses XBMC_DEPENDS that composed like
$(XBMC_DEPENDS_ROOT)/$(SDK_NAME)_$(CURRENT_ARCH)-target

CURRENT_ARCH not set correctly, without assigning App-OSX.xcconfig the
ONLY_ACTIVE_ARCH is not set and the builder machine architecture will
be used instead of the targeted architecture.
