### PR TITLE
Revert "[ActiveAE] - ActiveAESink: Change several LOGNOTICE to LOGDEB…

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -570,13 +570,13 @@ void CActiveAESink::EnumerateSinkList(bool force)
   CAESinkFactory::EnumerateEx(m_sinkInfoList);
   while(m_sinkInfoList.size() == 0 && c_retry > 0)
   {
-    CLog::Log(LOGDEBUG, "No Devices found - retry: %d", c_retry);
+    CLog::Log(LOGNOTICE, "No Devices found - retry: %d", c_retry);
     Sleep(1500);
     c_retry--;
     // retry the enumeration
     CAESinkFactory::EnumerateEx(m_sinkInfoList, true);
   }
-  CLog::Log(LOGDEBUG, "Found %lu Lists of Devices", m_sinkInfoList.size());
+  CLog::Log(LOGNOTICE, "Found %lu Lists of Devices", m_sinkInfoList.size());
   PrintSinks();
 }
 
@@ -584,16 +584,16 @@ void CActiveAESink::PrintSinks()
 {
   for (AESinkInfoList::iterator itt = m_sinkInfoList.begin(); itt != m_sinkInfoList.end(); ++itt)
   {
-    CLog::Log(LOGDEBUG, "Enumerated %s devices:", itt->m_sinkName.c_str());
+    CLog::Log(LOGNOTICE, "Enumerated %s devices:", itt->m_sinkName.c_str());
     int count = 0;
     for (AEDeviceInfoList::iterator itt2 = itt->m_deviceInfoList.begin(); itt2 != itt->m_deviceInfoList.end(); ++itt2)
     {
-      CLog::Log(LOGDEBUG, "    Device %d", ++count);
+      CLog::Log(LOGNOTICE, "    Device %d", ++count);
       CAEDeviceInfo& info = *itt2;
       std::stringstream ss((std::string)info);
       std::string line;
       while(std::getline(ss, line, '\n'))
-        CLog::Log(LOGDEBUG, "        %s", line.c_str());
+        CLog::Log(LOGNOTICE, "        %s", line.c_str());
     }
   }
 }


### PR DESCRIPTION
debug logs go to nirvana at the time AE is initialized. We need those logs to track down audio issues.
