### PR TITLE
[pi/players] Make use of new scheme to submit DTS timestamps

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/MMALCodec.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/MMALCodec.h
@@ -55,7 +55,6 @@ public:
   int width;
   int height;
   float m_aspect_ratio;
-  double dts;
   uint32_t m_changed_count;
   // reference counting
   CMMALVideoBuffer* Acquire();
@@ -117,7 +116,6 @@ protected:
   const char        *m_pFormatName;
   MMALVideoPtr      m_myself;
 
-  std::queue<double> m_dts_queue;
   std::queue<mmal_demux_packet> m_demux_queue;
   unsigned           m_demux_queue_length;
 

--- a/xbmc/cores/omxplayer/OMXPlayerVideo.h
+++ b/xbmc/cores/omxplayer/OMXPlayerVideo.h
@@ -69,7 +69,6 @@ protected:
   RENDER_STEREO_MODE        m_video_stereo_mode;
   RENDER_STEREO_MODE        m_display_stereo_mode;
   bool                      m_StereoInvert;
-  uint32_t                  m_history_valid_pts;
   DllBcmHost                m_DllBcmHost;
 
   CDVDOverlayContainer  *m_pOverlayContainer;

--- a/xbmc/cores/omxplayer/OMXVideo.h
+++ b/xbmc/cores/omxplayer/OMXVideo.h
@@ -55,7 +55,7 @@ public:
   void Close(void);
   unsigned int GetFreeSpace();
   unsigned int GetSize();
-  int  Decode(uint8_t *pData, int iSize, double pts);
+  int  Decode(uint8_t *pData, int iSize, double dts, double pts);
   void Reset(void);
   void SetDropState(bool bDrop);
   std::string GetDecoderName() { return m_video_codec_name; };


### PR DESCRIPTION
Latest firmware supports marking timestamps as DTS,
and it will reorder the timestamps with the decoded frame

This avoids some of the current hacks of supporting PTS and DTS
timestamps in a single field.

The current dts queue in mmal decoder gets out-of-sync for
some streams, where there isn't an exact 1:1 mapping of submitted
frame and returned picture (e.g. MBAFF or streams wih errors)
causing audio sync errors or stutter.
