### PR TITLE
[mmalcodec] Remove dropping logic. It only seems to make things worse

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/MMALCodec.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/MMALCodec.h
@@ -107,7 +107,6 @@ protected:
   bool DestroyDeinterlace();
 
   // Video format
-  bool              m_drop_state;
   int               m_decoded_width;
   int               m_decoded_height;
   unsigned int      m_egl_buffer_count;
@@ -135,7 +134,6 @@ protected:
   EINTERLACEMETHOD  m_interlace_method;
   bool              m_startframe;
   double            m_decoderPts;
-  unsigned int      m_droppedPics;
   int               m_speed;
   bool              m_preroll;
 


### PR DESCRIPTION
We get frequent reports of stuttery playback especially with live tv,
the PVR channel preview window and overlays with mmal.

The problem is whenever the dropping code is triggered it makes the
problem worse.

I suspect this is an issue with the asynchronous mmal decoder which has
a large input buffer (~2MB) which for a low bitrate stream can contain
a couple of seconds of video. We end up dropping a very large number of
frames which tends to upset dvdplayer more.

Seeing as dropping frames has marginal benefit - the work is done on
the gpu which isn't the bottleneck, and discarding frames doesn't help
the processing on the arm side sigificantly, just don't do it.
