### PR TITLE
Fix grouping movies into sets in smartplaylists

### DIFF
--- a/xbmc/filesystem/DirectoryHistory.cpp
+++ b/xbmc/filesystem/DirectoryHistory.cpp
@@ -81,7 +81,11 @@ const std::string& CDirectoryHistory::GetSelectedItem(const std::string& strDire
 void CDirectoryHistory::AddPath(const std::string& strPath, const std::string &strFilterPath /* = "" */)
 {
   if (!m_vecPathHistory.empty() && m_vecPathHistory.back().m_strPath == strPath)
+  {
+    if (!strFilterPath.empty())
+      m_vecPathHistory.back().m_strFilterPath = strFilterPath;
     return;
+  }
 
   CPathHistoryItem item;
   item.m_strPath = strPath;

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -1238,6 +1238,7 @@ void CGUIMediaWindow::SetHistoryForPath(const std::string& strDirectory)
 
     m_history.ClearPathHistory();
 
+    bool originalPath = true;
     while (URIUtils::GetParentPath(strPath, strParentPath))
     {
       for (int i = 0; i < (int)items.Size(); ++i)
@@ -1272,8 +1273,9 @@ void CGUIMediaWindow::SetHistoryForPath(const std::string& strDirectory)
       else
         URIUtils::AddSlashAtEnd(strPath);
 
-      m_history.AddPathFront(strPath);
+      m_history.AddPathFront(strPath, originalPath ? m_strFilterPath : "");
       m_history.SetSelectedItem(strPath, strParentPath);
+      originalPath = false;
       strPath = strParentPath;
       URIUtils::RemoveSlashAtEnd(strPath);
     }


### PR DESCRIPTION
As reported in http://trac.kodi.tv/ticket/15746 we have an issue with grouping movies into sets in smartplaylists that are opened from the home screen (or rather if not opened from the "Playlists" node). When first entering the smartplaylist everything is fine but when entering a grouped movie set and then going back to the full movie list movies aren't grouped into sets anymore.
This issue has been introduced in a fix for a similar issue back in Helix 14.1. The whole path history handling in the media windows is very brittle.

The root of the issue is that when opening a media library list from a non media library node we first get all the items etc and then we re-create the path history that leads to the node that has been opened directly. In that logic we currently don't store the filter path (which is the actual `videodb://` path used to retrieve the item listing). This is fixed by storing the determined filter path alongside the current path (the one which was used to open the list/node). That way when the user goes into a movie set and comes back out we can retrieve the proper filter path.

This whole path and path history handling needs a complete revamp. The path history handling by itself would work but there is so much code in the media library that makes assumptions about the meaning of a path which were true at one point (a few years ago) but don't cover all cases anymore. But obviously this is a very sensitive part of the whole media library implementation and it's (almost) impossible to test/cover all possible cases which makes validating a refactored implementation very difficult.
