### PR TITLE
GUI sounds: hide 'skin default' if skin doesn't come with sounds

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -7044,7 +7044,10 @@ msgctxt "#15105"
 msgid "* All genres"
 msgstr ""
 
-#empty string with id 15106
+#: xbmc/addons/Skin.cpp
+msgctxt "#15106"
+msgid "Skin built-in"
+msgstr ""
 
 msgctxt "#15107"
 msgid "Buffering..."

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1368,16 +1368,31 @@ void CApplication::OnSettingChanged(const CSetting *setting)
     // which in turn will reload the skin.  Similarly, if the current skin font is not
     // the default, reset it as well.
     if (settingId == "lookandfeel.skin" && CSettings::Get().GetString("lookandfeel.skintheme") != "SKINDEFAULT")
-      CSettings::Get().SetString("lookandfeel.skintheme", "SKINDEFAULT");
-    else if (settingId == "lookandfeel.skin" && CSettings::Get().GetString("lookandfeel.font") != "Default")
-      CSettings::Get().SetString("lookandfeel.font", "Default");
-    else
     {
-      std::string builtin("ReloadSkin");
-      if (settingId == "lookandfeel.skin" && !m_skinReverting)
-        builtin += "(confirm)";
-      CApplicationMessenger::Get().ExecBuiltIn(builtin);
+      CSettings::Get().SetString("lookandfeel.skintheme", "SKINDEFAULT");
+      return;
     }
+    if (settingId == "lookandfeel.skin" && CSettings::Get().GetString("lookandfeel.font") != "Default")
+    {
+      CSettings::Get().SetString("lookandfeel.font", "Default");
+      return;
+    }
+
+    // Reset sounds setting if new skin doen't provide sounds
+    if (settingId == "lookandfeel.skin" && CSettings::Get().GetString("lookandfeel.soundskin") == "SKINDEFAULT")
+    {
+      ADDON::AddonPtr addon;
+      if (CAddonMgr::Get().GetAddon(((CSettingString*)setting)->GetValue(), addon, ADDON_SKIN))
+      {
+        if (!CDirectory::Exists(URIUtils::AddFileToFolder(addon->Path(), "sounds")))
+          CSettings::Get().GetSetting("lookandfeel.soundskin")->Reset();
+      }
+    }
+
+    std::string builtin("ReloadSkin");
+    if (settingId == "lookandfeel.skin" && !m_skinReverting)
+      builtin += "(confirm)";
+    CApplicationMessenger::Get().ExecBuiltIn(builtin);
   }
   else if (settingId == "lookandfeel.skintheme")
   {

--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -395,7 +395,9 @@ void CSkinInfo::SettingOptionsSkinSoundFiller(const CSetting *setting, std::vect
   current = "SKINDEFAULT";
 
   list.push_back(make_pair(g_localizeStrings.Get(474), "OFF"));
-  list.push_back(make_pair(g_localizeStrings.Get(15109), "SKINDEFAULT"));
+
+  if (CDirectory::Exists(URIUtils::AddFileToFolder(g_SkinInfo->Path(), "sounds")))
+    list.push_back(make_pair(g_localizeStrings.Get(15109), "SKINDEFAULT"));
 
   ADDON::VECADDONS addons;
   if (ADDON::CAddonMgr::Get().GetAddons(ADDON::ADDON_RESOURCE_UISOUNDS, addons))

--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -397,7 +397,7 @@ void CSkinInfo::SettingOptionsSkinSoundFiller(const CSetting *setting, std::vect
   list.push_back(make_pair(g_localizeStrings.Get(474), "OFF"));
 
   if (CDirectory::Exists(URIUtils::AddFileToFolder(g_SkinInfo->Path(), "sounds")))
-    list.push_back(make_pair(g_localizeStrings.Get(15109), "SKINDEFAULT"));
+    list.push_back(make_pair(g_localizeStrings.Get(15106), "SKINDEFAULT"));
 
   ADDON::VECADDONS addons;
   if (ADDON::CAddonMgr::Get().GetAddons(ADDON::ADDON_RESOURCE_UISOUNDS, addons))


### PR DESCRIPTION
Fixes http://trac.kodi.tv/ticket/15965

Also changes the name of the option to "Skin built-in", which I think is more accurate description of what it is.
