### PR TITLE
renderer: fix wrong subtitle position when not fullscreen

### DIFF
--- a/xbmc/cores/VideoRenderers/OverlayRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/OverlayRenderer.cpp
@@ -216,9 +216,7 @@ void CRenderer::Render(int idx)
 void CRenderer::Render(COverlay* o, float adjust_height)
 {
   CRect rs, rd, rv;
-  RESOLUTION_INFO res;
   g_renderManager.GetVideoRect(rs, rd, rv);
-  res = g_graphicsContext.GetResInfo(g_renderManager.GetResolution());
 
   SRenderState state;
   state.x       = o->m_x;
@@ -237,8 +235,8 @@ void CRenderer::Render(COverlay* o, float adjust_height)
     if(align == COverlay::ALIGN_SCREEN
     || align == COverlay::ALIGN_SUBTITLE)
     {
-      scale_x = (float)res.iWidth;
-      scale_y = (float)res.iHeight;
+      scale_x = (float)rd.Width();
+      scale_y = (float)rd.Height();
     }
 
     if(align == COverlay::ALIGN_VIDEO)
@@ -260,8 +258,8 @@ void CRenderer::Render(COverlay* o, float adjust_height)
     if(align == COverlay::ALIGN_SCREEN
     || align == COverlay::ALIGN_SUBTITLE)
     {
-      float scale_x = rv.Width() / res.iWidth;
-      float scale_y = rv.Height()  / res.iHeight;
+      float scale_x = rv.Width() / rd.Width();
+      float scale_y = rv.Height()  / rd.Height();
 
       state.x      *= scale_x;
       state.y      *= scale_y;
@@ -270,6 +268,7 @@ void CRenderer::Render(COverlay* o, float adjust_height)
 
       if(align == COverlay::ALIGN_SUBTITLE)
       {
+        RESOLUTION_INFO res = g_graphicsContext.GetResInfo(g_renderManager.GetResolution());
         state.x += rv.x1 + rv.Width() * 0.5f;
         state.y += rv.y1  + (res.iSubtitles - res.Overscan.top) * scale_y;
       }

--- a/xbmc/guilib/GUIVideoControl.cpp
+++ b/xbmc/guilib/GUIVideoControl.cpp
@@ -67,6 +67,8 @@ void CGUIVideoControl::Render()
       g_application.ResetScreenSaver();
 
     g_graphicsContext.SetViewWindow(m_posX, m_posY, m_posX + m_width, m_posY + m_height);
+    TransformMatrix mat;
+    g_graphicsContext.SetTransform(mat, 1.0, 1.0);
 
 #ifdef HAS_VIDEO_PLAYBACK
     color_t alpha = g_graphicsContext.MergeAlpha(0xFF000000) >> 24;
@@ -90,6 +92,8 @@ void CGUIVideoControl::Render()
 #else
     ((CDummyVideoPlayer *)g_application.m_pPlayer->GetInternal())->Render();
 #endif
+
+    g_graphicsContext.RemoveTransform();
   }
   // TODO: remove this crap: HAS_VIDEO_PLAYBACK
   // instantiateing a vidio control having no playback is complete nonsense


### PR DESCRIPTION
fix for trac #15969: Subtitles rendered off position when video is not playing in
VideoFullScreen and bottom of the video subtiles position is selected
http://trac.kodi.tv/ticket/15969
