### PR TITLE
[KeyMapping/Joystick] - fix regression introduced in https://github.c…

### DIFF
--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -922,9 +922,17 @@ void CButtonTranslator::MapJoystickActions(int windowID, TiXmlNode *pJoystick)
 
     pButton = pButton->NextSiblingElement();
   }
-  m_joystickButtonMap[joyFamilyName][windowID].insert(buttonMap.begin(), buttonMap.end());
-  m_joystickAxisMap[joyFamilyName][windowID].insert(axisMap.begin(), axisMap.end());
-  m_joystickHatMap[joyFamilyName][windowID].insert(hatMap.begin(), hatMap.end());
+
+  // add/overwrite keys with mapped actions
+  for (auto button : buttonMap)
+    m_joystickButtonMap[joyFamilyName][windowID][button.first] = button.second;
+
+  for (auto axis : axisMap)
+    m_joystickAxisMap[joyFamilyName][windowID][axis.first] = axis.second;
+
+  for (auto hat : hatMap)
+    m_joystickHatMap[joyFamilyName][windowID][hat.first] = hat.second;
+
   if (windowID == -1) 
     m_joystickAxesConfigs[joyFamilyName] = axesConfig;
 }


### PR DESCRIPTION
…om/xbmc/xbmc/pull/5624 - allow to overwrite joystick mappings with user keymaps again.

As the topic says. zzattack already spotted this and fixed it for keymaps here:

https://github.com/xbmc/xbmc/pull/5712

but he missed the joystick mappings.

This is a regression from Helix and needs to be merged for Isengard.

Runtime tested on osx with apple remote.
