### PR TITLE
IMX: Attempt to revert last buffer alignment change and to improve it

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
@@ -1813,15 +1813,15 @@ void CIMXContext::PrepareTask(IPUTask &ipu, CIMXBuffer *source_p, CIMXBuffer *so
     dstRect.y2 = m_fbHeight;
   }
 
-  iSrcRect.x1 = Align((int)srcRect.x1,2);
-  iSrcRect.y1 = Align((int)srcRect.y1,2);
-  iSrcRect.x2 = Align((int)srcRect.x2,2);
-  iSrcRect.y2 = Align((int)srcRect.y2,2);
+  iSrcRect.x1 = (int)srcRect.x1;
+  iSrcRect.y1 = (int)srcRect.y1;
+  iSrcRect.x2 = (int)srcRect.x2;
+  iSrcRect.y2 = (int)srcRect.y2;
 
-  iDstRect.x1 = Align((int)dstRect.x1,2);
-  iDstRect.y1 = Align((int)dstRect.y1,2);
-  iDstRect.x2 = Align((int)dstRect.x2,2);
-  iDstRect.y2 = Align((int)dstRect.y2,2);
+  iDstRect.x1 = Align((int)dstRect.x1,8);
+  iDstRect.y1 = Align((int)dstRect.y1,8);
+  iDstRect.x2 = Align2((int)dstRect.x2,8);
+  iDstRect.y2 = Align2((int)dstRect.y2,8);
 
   ipu.task.input.crop.pos.x  = iSrcRect.x1;
   ipu.task.input.crop.pos.y  = iSrcRect.y1;


### PR DESCRIPTION
After testing all my samples and the sample in #6922 it seems that the source rect does not need the 8 pixel alignment (neither width nor height) whereas the destination rect does. @fritsch, @wolfgar, @samnazarko please double check ...
