### PR TITLE
[TouchScreen] - Fixed touch screen support in WindowScreenCalibration

### DIFF
--- a/system/keymaps/touchscreen.xml
+++ b/system/keymaps/touchscreen.xml
@@ -43,4 +43,13 @@
       <swipe direction="right">Highlight</swipe>
     </touch>
   </MyFiles>
+  <ScreenCalibration>
+    <touch>
+      <swipe direction="up">Up</swipe>
+      <swipe direction="down">Down</swipe>
+      <swipe direction="right">Right</swipe>
+      <swipe direction="left">Left</swipe>
+      <tap pointers="1">NextCalibration</tap>
+    </touch>
+  </ScreenCalibration>
 </keymap>


### PR DESCRIPTION
As pointed out by users and @NedScott the WindowScreenCalibration was not compatible with touchscreen/gestures yet. Its important for beeing able to set the subtitle position (not so much the rest of the calibration).

This PR makes the window touchscreen aware and adds a default touchscreen mapping for it (swipe up, left, right, down for changing the positions and single finger tap for switching between the calibration modes).

All messages and actions which are altered here are touchscreen specific so i consider this PR safe for Isengard.

Runtime tested on iOS and android tablets...
