### PR TITLE
[keymapping/joystick] - fix the annoying error logging which is logge…

### DIFF
--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -855,6 +855,13 @@ void CButtonTranslator::MapJoystickActions(int windowID, TiXmlNode *pJoystick)
     if (!pButton->NoChildren())
       action = pButton->FirstChild()->ValueStr();
 
+    // skip altname tags here because those contain no mappings ...
+    if (type == "altname")
+    {
+      pButton = pButton->NextSiblingElement();
+      continue;
+    }
+
     if ((pButton->QueryIntAttribute("id", &id) == TIXML_SUCCESS) && id>=0 && id<=256)
     {
       if (type == "button")


### PR DESCRIPTION
…d in accident because altname tags are tried to be treated like mappings

@MilhouseVH

This fixes those annoying ERROR: Error reading joystick map element, Invalid id: 0 errors.

Whoever added the altname support should have seen this prior adding the feature imo ...
