### PR TITLE
[renderer] Fix for number of surfaces being passed to codec

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/DVDFactoryCodec.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/DVDFactoryCodec.cpp
@@ -333,7 +333,7 @@ CDVDVideoCodec* CDVDFactoryCodec::CreateVideoCodec(CDVDStreamInfo &hint, const C
   }
 #endif
 
-  std::string value = StringUtils::Format("%d", info.optimal_buffer_size);
+  std::string value = StringUtils::Format("%d", info.max_buffer_size);
   options.m_keys.push_back(CDVDCodecOption("surfaces", value));
   if( (pCodec = OpenCodec(new CDVDVideoCodecFFmpeg(), hint, options)) ) return pCodec;
 


### PR DESCRIPTION
This fixes a bug introduced in https://github.com/xbmc/xbmc/pull/7087
Ping @FernetMenta 
