### PR TITLE
[gui] fix window activation

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3220,13 +3220,10 @@ PlayBackRet CApplication::PlayFile(const CFileItem& item, bool bRestart)
 #ifdef HAS_VIDEO_PLAYBACK
     else if( m_pPlayer->IsPlayingVideo() )
     {
-      if (g_windowManager.GetActiveWindow() == WINDOW_VISUALISATION)
-        g_windowManager.ActivateWindow(WINDOW_FULLSCREEN_VIDEO);
-
       // if player didn't manange to switch to fullscreen by itself do it here
-      if( options.fullscreen && g_renderManager.IsStarted()
-       && g_windowManager.GetActiveWindow() != WINDOW_FULLSCREEN_VIDEO )
-       SwitchToFullScreen();
+      if (options.fullscreen && g_renderManager.IsStarted() &&
+          g_windowManager.GetActiveWindow() != WINDOW_FULLSCREEN_VIDEO )
+       SwitchToFullScreen(true);
     }
 #endif
     else
@@ -4663,7 +4660,7 @@ void CApplication::SeekPercentage(float percent)
 }
 
 // SwitchToFullScreen() returns true if a switch is made, else returns false
-bool CApplication::SwitchToFullScreen()
+bool CApplication::SwitchToFullScreen(bool force /* = false */)
 {
   // if playing from the video info window, close it first!
   if (g_windowManager.HasModalDialog() && g_windowManager.GetTopMostModalDialogID() == WINDOW_DIALOG_VIDEO_INFO)
@@ -4672,23 +4669,29 @@ bool CApplication::SwitchToFullScreen()
     if (pDialog) pDialog->Close(true);
   }
 
-  // don't switch if there is a dialog on screen or the slideshow is active
-  if (/*g_windowManager.HasModalDialog() ||*/ g_windowManager.GetActiveWindow() == WINDOW_SLIDESHOW)
+  // don't switch if the slideshow is active
+  if (g_windowManager.GetActiveWindow() == WINDOW_SLIDESHOW)
     return false;
 
+  int windowID = WINDOW_INVALID;
   // See if we're playing a video, and are in GUI mode
-  if ( m_pPlayer->IsPlayingVideo() && g_windowManager.GetActiveWindow() != WINDOW_FULLSCREEN_VIDEO)
-  {
-    // then switch to fullscreen mode
-    g_windowManager.ActivateWindow(WINDOW_FULLSCREEN_VIDEO);
-    return true;
-  }
+  if (m_pPlayer->IsPlayingVideo() && g_windowManager.GetActiveWindow() != WINDOW_FULLSCREEN_VIDEO)
+    windowID = WINDOW_FULLSCREEN_VIDEO;
+
   // special case for switching between GUI & visualisation mode. (only if we're playing an audio song)
   if (m_pPlayer->IsPlayingAudio() && g_windowManager.GetActiveWindow() != WINDOW_VISUALISATION)
-  { // then switch to visualisation
-    g_windowManager.ActivateWindow(WINDOW_VISUALISATION);
+    windowID = WINDOW_VISUALISATION;
+
+
+  if (windowID != WINDOW_INVALID)
+  {
+    if (force)
+      g_windowManager.ForceActivateWindow(windowID);
+    else
+      g_windowManager.ActivateWindow(windowID);
     return true;
   }
+
   return false;
 }
 

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3207,18 +3207,18 @@ PlayBackRet CApplication::PlayFile(const CFileItem& item, bool bRestart)
     // if player has volume control, set it.
     if (m_pPlayer->ControlsVolume())
     {
-       m_pPlayer->SetVolume(m_volumeLevel);
-       m_pPlayer->SetMute(m_muted);
+      m_pPlayer->SetVolume(m_volumeLevel);
+      m_pPlayer->SetMute(m_muted);
     }
 
-    if( m_pPlayer->IsPlayingAudio() )
+    if(m_pPlayer->IsPlayingAudio())
     {
       if (g_windowManager.GetActiveWindow() == WINDOW_FULLSCREEN_VIDEO)
         g_windowManager.ActivateWindow(WINDOW_VISUALISATION);
     }
 
 #ifdef HAS_VIDEO_PLAYBACK
-    else if( m_pPlayer->IsPlayingVideo() )
+    else if(m_pPlayer->IsPlayingVideo())
     {
       // if player didn't manange to switch to fullscreen by itself do it here
       if (options.fullscreen && g_renderManager.IsStarted() &&
@@ -3228,10 +3228,9 @@ PlayBackRet CApplication::PlayFile(const CFileItem& item, bool bRestart)
 #endif
     else
     {
-      if (g_windowManager.GetActiveWindow() == WINDOW_VISUALISATION
-      ||  g_windowManager.GetActiveWindow() == WINDOW_FULLSCREEN_VIDEO)
+      if (g_windowManager.GetActiveWindow() == WINDOW_VISUALISATION ||
+          g_windowManager.GetActiveWindow() == WINDOW_FULLSCREEN_VIDEO)
         g_windowManager.PreviousWindow();
-
     }
 
 #if !defined(TARGET_POSIX)

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -365,7 +365,7 @@ public:
 
   float GetDimScreenSaverLevel() const;
 
-  bool SwitchToFullScreen();
+  bool SwitchToFullScreen(bool force = false);
 
   CSplash* GetSplash() { return m_splash; }
   void SetRenderGUI(bool renderGUI);

--- a/xbmc/ApplicationMessenger.cpp
+++ b/xbmc/ApplicationMessenger.cpp
@@ -705,7 +705,7 @@ void CApplicationMessenger::ProcessMessage(ThreadMessage *pMsg)
 
     case TMSG_GUI_ACTIVATE_WINDOW:
       {
-        g_windowManager.ActivateWindow(pMsg->param1, pMsg->params, pMsg->param2 > 0);
+        g_windowManager.ActivateWindow(pMsg->param1, pMsg->params, pMsg->param2 & 0x1 ? true : false, pMsg->param2 & 0x2 ? true : false);
       }
       break;
 
@@ -1256,9 +1256,10 @@ void CApplicationMessenger::Close(CGUIWindow *window, bool forceClose, bool wait
   SendMessage(tMsg, waitResult);
 }
 
-void CApplicationMessenger::ActivateWindow(int windowID, const vector<string> &params, bool swappingWindows)
+void CApplicationMessenger::ActivateWindow(int windowID, const vector<string> &params, bool swappingWindows, bool force  /* = false */)
 {
-  ThreadMessage tMsg = {TMSG_GUI_ACTIVATE_WINDOW, windowID, swappingWindows ? 1 : 0};
+  ThreadMessage tMsg = {TMSG_GUI_ACTIVATE_WINDOW, windowID};
+  tMsg.param2 = (swappingWindows ? 0x01 : 0) | (force ? 0x02 : 0);
   tMsg.params = params;
   SendMessage(tMsg, true);
 }

--- a/xbmc/ApplicationMessenger.cpp
+++ b/xbmc/ApplicationMessenger.cpp
@@ -533,8 +533,8 @@ void CApplicationMessenger::ProcessMessage(ThreadMessage *pMsg)
       break;
 
     case TMSG_SWITCHTOFULLSCREEN:
-      if( g_windowManager.GetActiveWindow() != WINDOW_FULLSCREEN_VIDEO )
-        g_application.SwitchToFullScreen();
+      if(g_windowManager.GetActiveWindow() != WINDOW_FULLSCREEN_VIDEO)
+        g_application.SwitchToFullScreen(true);
       break;
 
     case TMSG_SETVIDEORESOLUTION:

--- a/xbmc/ApplicationMessenger.h
+++ b/xbmc/ApplicationMessenger.h
@@ -231,7 +231,7 @@ public:
   void DoModal(CGUIDialog *pDialog, int iWindowID, const std::string &param = "");
   void Show(CGUIDialog *pDialog);
   void Close(CGUIWindow *window, bool forceClose, bool waitResult = true, int nextWindowID = 0, bool enableSound = true);
-  void ActivateWindow(int windowID, const std::vector<std::string> &params, bool swappingWindows);
+  void ActivateWindow(int windowID, const std::vector<std::string> &params, bool swappingWindows, bool force = false);
   void SendAction(const CAction &action, int windowID = WINDOW_INVALID, bool waitResult=true);
 
   //! \brief Send text to currently focused window / keyboard.

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -707,22 +707,30 @@ void CGUIWindowManager::ActivateWindow(int iWindowID, const std::string& strPath
   ActivateWindow(iWindowID, params, false);
 }
 
-void CGUIWindowManager::ActivateWindow(int iWindowID, const vector<string>& params, bool swappingWindows)
+void CGUIWindowManager::ForceActivateWindow(int iWindowID, const std::string& strPath)
+{
+  vector<string> params;
+  if (!strPath.empty())
+    params.push_back(strPath);
+  ActivateWindow(iWindowID, params, false, true);
+}
+
+void CGUIWindowManager::ActivateWindow(int iWindowID, const vector<string>& params, bool swappingWindows /* = false */, bool force /* = false */)
 {
   if (!g_application.IsCurrentThread())
   {
     // make sure graphics lock is not held
     CSingleExit leaveIt(g_graphicsContext);
-    CApplicationMessenger::Get().ActivateWindow(iWindowID, params, swappingWindows);
+    CApplicationMessenger::Get().ActivateWindow(iWindowID, params, swappingWindows, force);
   }
   else
   {
     CSingleLock lock(g_graphicsContext);
-    ActivateWindow_Internal(iWindowID, params, swappingWindows);
+    ActivateWindow_Internal(iWindowID, params, swappingWindows, force);
   }
 }
 
-void CGUIWindowManager::ActivateWindow_Internal(int iWindowID, const vector<string>& params, bool swappingWindows)
+void CGUIWindowManager::ActivateWindow_Internal(int iWindowID, const vector<string>& params, bool swappingWindows, bool force /* = false */)
 {
   // translate virtual windows
   // virtual music window which returns the last open music window (aka the music start window)
@@ -776,7 +784,7 @@ void CGUIWindowManager::ActivateWindow_Internal(int iWindowID, const vector<stri
   }
 
   // don't activate a window if there are active modal dialogs
-  if (HasModalDialog())
+  if (!force && HasModalDialog())
   {
     CLog::Log(LOG_LEVEL_DEBUG, "Activate of window '%i' refused because there are active modal dialogs", iWindowID);
     g_audioManager.PlayActionSound(CAction(ACTION_ERROR));

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -59,8 +59,9 @@ public:
   void Remove(int id);
   void Delete(int id);
   void ActivateWindow(int iWindowID, const std::string &strPath = "");
+  void ForceActivateWindow(int iWindowID, const std::string &strPath = "");
   void ChangeActiveWindow(int iNewID, const std::string &strPath = "");
-  void ActivateWindow(int iWindowID, const std::vector<std::string>& params, bool swappingWindows = false);
+  void ActivateWindow(int iWindowID, const std::vector<std::string>& params, bool swappingWindows = false, bool force = false);
   void PreviousWindow();
 
   void CloseDialogs(bool forceClose = false) const;
@@ -181,7 +182,15 @@ private:
   CGUIWindow *GetTopMostDialog() const;
 
   friend class CApplicationMessenger;
-  void ActivateWindow_Internal(int windowID, const std::vector<std::string> &params, bool swappingWindows);
+
+  /*! \brief Activate the given window.
+   *
+   * \param windowID The window ID to activate.
+   * \param params Parameter
+   * \param swappingWindows True if the window should be swapped with the previous window instead of put it in the window history, otherwise false
+   * \param force True to ignore checks which refuses opening the window, otherwise false
+   */
+  void ActivateWindow_Internal(int windowID, const std::vector<std::string> &params, bool swappingWindows, bool force = false);
 
   typedef std::map<int, CGUIWindow *> WindowMap;
   WindowMap m_mapWindows;

--- a/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
@@ -156,7 +156,7 @@ void CGUIDialogVideoSettings::OnSettingAction(const CSetting *setting)
     if (CProfilesManager::Get().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE  &&
         g_passwordManager.CheckSettingLevelLock(CSettings::Get().GetSetting("videoscreen.guicalibration")->GetLevel()))
       return;
-    g_windowManager.ActivateWindow(WINDOW_SCREEN_CALIBRATION);
+    g_windowManager.ForceActivateWindow(WINDOW_SCREEN_CALIBRATION);
   }
   // TODO
   else if (settingId == SETTING_VIDEO_MAKE_DEFAULT)


### PR DESCRIPTION
This introduces a new method `ForceActivateWindow()` in our window manager which could be used to force open a window because it skips the check for active modals. Furthermore I've used this method in different cases where we want to force activate a window e.g. fullscreen, screen calibration window (see commits)

This will fix #7022 and http://trac.kodi.tv/ticket/15960#comment:9

@Montellese @mkortstiege mind taking a look.
