### PR TITLE
[settings] default locale to match default language

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -129,7 +129,7 @@
         </setting>
         <setting id="locale.country" type="string" label="20026" help="36115">
           <level>0</level>
-          <default>USA (12h)</default>
+          <default>UK (12h)</default>
           <constraints>
             <options>regions</options>
           </constraints>


### PR DESCRIPTION
The default language locale is GB and has been GB for the longest time. But localization is USA

This portion goes into conflict with default language locale for some reason.

I would even ask if theres any reason why the default isn't 24 hour! But...

@MartijnKaijser @jjd-uk
