### PR TITLE
Fix coverity #1287129

### DIFF
--- a/addons/library.kodi.guilib/libKODI_guilib.h
+++ b/addons/library.kodi.guilib/libKODI_guilib.h
@@ -488,7 +488,7 @@ public:
 
   bool Dialog_Numeric_ShowAndGetNumber(char &strInput, unsigned int iMaxStringSize, const char *strHeading, unsigned int iAutoCloseTimeoutMs = 0)
   {
-    return GUI_dialog_numeric_show_and_get_number(m_Handle, m_Callbacks, strInput, iMaxStringSize, strHeading, iAutoCloseTimeoutMs = 0);
+    return GUI_dialog_numeric_show_and_get_number(m_Handle, m_Callbacks, strInput, iMaxStringSize, strHeading, iAutoCloseTimeoutMs);
   }
 
   bool Dialog_Numeric_ShowAndGetSeconds(char &strTime, unsigned int iMaxStringSize, const char *strHeading)


### PR DESCRIPTION
CID 1287129 (#1 of 1): Parse warning (PW.PARAM_SET_BUT_NOT_USED)
1. param_set_but_not_used: parameter "iAutoCloseTimeoutMs" was set but never used
