### PR TITLE
[PVR][Fix] A possible fix for looping over a modified vector

### DIFF
--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -644,16 +644,33 @@ bool CPVRChannelGroup::RemoveDeletedChannels(const CPVRChannelGroup &channels)
 
       m_members.erase((*it).channel->StorageId());
 
+      //we need a copy of our iterators data so that we can find it later on
+      //if the vector has changed.
+      auto group = *it;
       /* remove this channel from all non-system groups if this is the internal group */
       if (IsInternalGroup())
       {
         g_PVRChannelGroups->Get(m_bRadio)->RemoveFromAllGroups((*it).channel);
 
         /* since it was not found in the internal group, it was deleted from the backend */
-        (*it).channel->Delete();
+        group.channel->Delete();
       }
 
-      it = m_sortedMembers.erase(it);
+      //our vector can have been modified during the call to RemoveFromAllGroups
+      //make no assumption and search for the value to be removed
+      auto possiblyRemovedGroup = std::find_if(m_sortedMembers.begin(), m_sortedMembers.end(), [&group](const PVRChannelGroupMember& it)
+      {
+        return  group.channel == it.channel &&
+                group.iChannelNumber == it.iChannelNumber &&
+                group.iSubChannelNumber == it.iSubChannelNumber;
+      });
+
+      if (possiblyRemovedGroup != m_sortedMembers.end())
+        m_sortedMembers.erase(possiblyRemovedGroup);
+      
+      //We have to start over from the beginning, list can have been modified and
+      //resorted, there's no safe way to continue where we left of
+      it = m_sortedMembers.begin();
       m_bChanged = true;
       bReturn = true;
     }


### PR DESCRIPTION
spotted an issue going through a callstack @fritsch linked.

first, this is the callstack
PVR::CPVRChannelGroup::RemoveFromGroup
PVR::CPVRChannelGroups::RemoveFromAllGroups
PVR::CPVRChannelGroup::RemoveDeletedChannels

The issue is that in RemoveDeletedChannels we iterate over m_sortedMembers and then call into RemoveFromGroup which modifies m_sortedMembers and then resorts it? renumbers? In any case when we return to RemoveDeletedChannels we have an iterator that could point to freed memory but most likely pointing at random data or another place in the vector which is a bad thing.

Locks won't protect us since the callers are in the same thread. The solution I'm suggesting here is one possible way to solve it.
