### PR TITLE
[Libcurl] 404 fix + misc. tweaks

### DIFF
--- a/xbmc/filesystem/HTTPDirectory.cpp
+++ b/xbmc/filesystem/HTTPDirectory.cpp
@@ -45,7 +45,7 @@ bool CHTTPDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 
   if(!http.Open(url))
   {
-    CLog::Log(LOGERROR, "%s - Unable to get http directory", __FUNCTION__);
+    CLog::Log(LOGERROR, "%s - Unable to get http directory (%s)", __FUNCTION__, url.GetRedacted().c_str());
     return false;
   }
 


### PR DESCRIPTION
This PR contains the "safe" fixes from https://github.com/xbmc/xbmc/pull/7073 . It mainly fixes an issue where we hammer remote servers when getting a 404. Furthermore we should only retry without range set when we encounter an actual http range-error, not all http-errors.
