### PR TITLE
CVE-2015-3885 fix

### DIFF
--- a/lib/cximage-6.0/raw/dcraw.c
+++ b/lib/cximage-6.0/raw/dcraw.c
@@ -820,7 +820,8 @@ struct jhead {
 
 int CLASS ljpeg_start (struct jhead *jh, int info_only)
 {
-  int c, tag, len;
+  int c, tag;
+  ushort len;
   uchar data[0x10000], *dp;
 
   init_decoder();


### PR DESCRIPTION
The dcraw photo decoder is an open source project for raw image parsing.

Import fix from libRaw. This need to be merge in all version of kodi :)

see
http://www.ocert.org/advisories/ocert-2015-006.html
https://github.com/LibRaw/LibRaw/commit/4606c28f494a750892c5c1ac7903e62dd1c6fdb5
