### PR TITLE
[depends] fix (lib)platform build

### DIFF
--- a/tools/depends/target/platform/Makefile
+++ b/tools/depends/target/platform/Makefile
@@ -1,5 +1,4 @@
--include ../../Makefile.include
-include ../../xbmc-addons.include
+include ../../Makefile.include
 DEPS= ../../Makefile.include Makefile
 
 # lib name, version


### PR DESCRIPTION
do not include binary addon specific Makefiles. This partially reverts
4414d89da0f04a4898543db008b354da62721c7d
