### PR TITLE
[stacking] skip folder stacking entirely in case no patterns available

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -2315,6 +2315,12 @@ void CFileItemList::StackFolders()
     strExpression++;
   }
 
+  if (!folderRegExp.IsCompiled())
+  {
+    CLog::Log(LOGDEBUG, "%s: No stack expressions available. Skipping folder stacking", __FUNCTION__);
+    return;
+  }
+
   // stack folders
   for (int i = 0; i < Size(); i++)
   {


### PR DESCRIPTION
Skip folder stacking in case there are no patterns to perform the matching against via ..

> advancedsettings.xml: `<folderstacking append="no" />`

Note, this will also skip the utterly expensive optical media folder stacking where we blindly dive into sub directories doing stats for known video_ts and/or bdmv items. There might be better ways to achieve this, but i don't want to add yet anther gui or advanced setting for this.

Comments?
