### PR TITLE
File progress fix (fixes #15943)

### DIFF
--- a/xbmc/utils/FileOperationJob.cpp
+++ b/xbmc/utils/FileOperationJob.cpp
@@ -266,6 +266,7 @@ bool CFileOperationJob::CFileOperation::ExecuteOperation(CFileOperationJob *base
     return false;
 
   base->SetText(base->GetCurrentFile());
+  base->SetProgress((float)current);
 
   DataHolder data = {base, current, opWeight};
 
@@ -355,6 +356,7 @@ bool CFileOperationJob::CFileOperation::OnFileCallback(void* pContext, int iperc
                               data->base->GetCurrentFile().c_str(),
                               data->base->GetAverageSpeed().c_str());
   data->base->SetText(line);
+  data->base->SetProgress((float)current);
   return !data->base->ShouldCancel((unsigned)current, 100);
 }
 


### PR DESCRIPTION
This fixes a regression introduced by 5246023444e1a1ffa640fed28dc9da9fcb70e853 where the percent progress bar for file operations would never update. Not 100% sure whether this fix is correct.
