### PR TITLE
videorefclock: fix wrong speed when in windowed mode

### DIFF
--- a/xbmc/guilib/GraphicContext.cpp
+++ b/xbmc/guilib/GraphicContext.cpp
@@ -52,6 +52,7 @@ CGraphicContext::CGraphicContext(void) :
   m_bFullScreenVideo(false),
   m_bCalibrating(false),
   m_Resolution(RES_INVALID),
+  m_fFPSOverride(0.0),
   /*m_windowResolution,*/
   /*,m_cameras, */
   /*m_origins, */
@@ -466,6 +467,7 @@ void CGraphicContext::SetVideoResolutionInternal(RESOLUTION res, bool forceUpdat
   m_iScreenId     = info_mod.iScreen;
   m_scissors.SetRect(0, 0, (float)m_iScreenWidth, (float)m_iScreenHeight);
   m_Resolution    = res;
+  m_fFPSOverride = 0 ;
 
   if (g_advancedSettings.m_fullScreen)
   {
@@ -739,6 +741,12 @@ const RESOLUTION_INFO CGraphicContext::GetResInfo(RESOLUTION res) const
     info.Overscan.left   /= 2;
     info.Overscan.right   = (info.Overscan.right - info.iBlanking) / 2;
   }
+
+  if (res == m_Resolution && m_fFPSOverride != 0)
+  {
+    info.fRefreshRate = m_fFPSOverride;
+  }
+
   return info;
 }
 
@@ -1064,3 +1072,7 @@ void CGraphicContext::GetAllowedResolutions(vector<RESOLUTION> &res)
   }
 }
 
+void CGraphicContext::SetFPS(float fps)
+{
+  m_fFPSOverride = fps;
+}

--- a/xbmc/guilib/GraphicContext.h
+++ b/xbmc/guilib/GraphicContext.h
@@ -238,6 +238,11 @@ public:
 
   CRect generateAABB(const CRect &rect) const;
 
+  /*! \brief sets refresh rate, overrides the one stored with modes
+   *  \param fps refresh rate
+   */
+  void SetFPS(float fps);
+
 protected:
   std::stack<CRect> m_viewStack;
 
@@ -250,6 +255,7 @@ protected:
   bool m_bFullScreenVideo;
   bool m_bCalibrating;
   RESOLUTION m_Resolution;
+  float m_fFPSOverride;
 
 private:
   class UITransform

--- a/xbmc/video/videosync/VideoSyncDRM.cpp
+++ b/xbmc/video/videosync/VideoSyncDRM.cpp
@@ -176,4 +176,10 @@ float CVideoSyncDRM::GetFps()
   return m_fps;
 }
 
+void CVideoSyncDRM::RefreshChanged()
+{
+  if (m_fps != g_graphicsContext.GetFPS())
+    m_abort = true;
+}
+
 #endif

--- a/xbmc/video/videosync/VideoSyncDRM.h
+++ b/xbmc/video/videosync/VideoSyncDRM.h
@@ -32,6 +32,7 @@ public:
   virtual void Cleanup();
   virtual float GetFps();
   virtual void OnResetDevice();
+  virtual void RefreshChanged();
 private:
   static void EventHandler(int fd, unsigned int frame, unsigned int sec, unsigned int usec, void *data);
   int m_fd;

--- a/xbmc/windowing/X11/WinSystemX11.cpp
+++ b/xbmc/windowing/X11/WinSystemX11.cpp
@@ -1468,12 +1468,14 @@ void CWinSystemX11::UpdateCrtc()
 {
   XWindowAttributes winattr;
   int posx, posy;
+  float fps;
   Window child;
   XGetWindowAttributes(m_dpy, m_mainWindow, &winattr);
   XTranslateCoordinates(m_dpy, m_mainWindow, RootWindow(m_dpy, m_nScreen), winattr.x, winattr.y,
                         &posx, &posy, &child);
 
-  m_crtc = g_xrandr.GetCrtc(posx+winattr.width/2, posy+winattr.height/2);
+  m_crtc = g_xrandr.GetCrtc(posx+winattr.width/2, posy+winattr.height/2, fps);
+  g_graphicsContext.SetFPS(fps);
 }
 
 #endif

--- a/xbmc/windowing/X11/XRandR.cpp
+++ b/xbmc/windowing/X11/XRandR.cpp
@@ -480,7 +480,7 @@ XOutput* CXRandR::GetOutput(const std::string& outputName)
   return result;
 }
 
-int CXRandR::GetCrtc(int x, int y)
+int CXRandR::GetCrtc(int x, int y, float &hz)
 {
   int crtc = 0;
   for (unsigned int i = 0; i < m_outputs.size(); ++i)
@@ -492,6 +492,14 @@ int CXRandR::GetCrtc(int x, int y)
         (m_outputs[i].y <= y && (m_outputs[i].y+m_outputs[i].h) > y))
     {
       crtc = m_outputs[i].crtc;
+      for (auto mode: m_outputs[i].modes)
+      {
+        if (mode.isCurrent)
+        {
+          hz = mode.hz;
+          break;
+        }
+      }
       break;
     }
   }

--- a/xbmc/windowing/X11/XRandR.h
+++ b/xbmc/windowing/X11/XRandR.h
@@ -108,7 +108,7 @@ public:
   bool IsOutputConnected(const std::string& name);
   bool TurnOffOutput(const std::string& name);
   bool TurnOnOutput(const std::string& name);
-  int GetCrtc(int x, int y);
+  int GetCrtc(int x, int y, float &hz);
   //bool Has1080i();
   //bool Has1080p();
   //bool Has720p();


### PR DESCRIPTION
In discussions with @Memphiz we noticed that video reference clock goes wrong speed if Kodi is in windowed mode. FPS  did default to 60Hz in windowed mode which of course can be wrong.
Further a user may move the main window from one monitor to another with different refresh rate. This PR has fixes for X11. @Memphiz has more for Cocoa
