### PR TITLE
[alternative] add logic to wait for the startup window to finish before showing information dialogs during startup

### DIFF
--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -372,7 +372,7 @@ public:
   bool GetRenderGUI() const { return m_renderGUI; };
 
   bool SetLanguage(const std::string &strLanguage);
-  bool LoadLanguage(bool reload, bool& fallback);
+  bool LoadLanguage(bool reload);
 
   ReplayGainSettings& GetReplayGainSettings() { return m_replayGainSettings; }
 
@@ -502,6 +502,8 @@ protected:
   ReplayGainSettings m_replayGainSettings;
   
   std::vector<IActionListener *> m_actionListeners;
+
+  bool m_fallbackLanguageLoaded;
   
 private:
   CCriticalSection                m_critSection;                 /*!< critical section for all changes to this class, except for changes to triggers */

--- a/xbmc/guilib/GUIMessage.h
+++ b/xbmc/guilib/GUIMessage.h
@@ -156,6 +156,11 @@
 
 #define GUI_MSG_GET_FILENAME   48
 
+/*!
+ \brief The user interface is ready for usage
+ */
+#define GUI_MSG_UI_READY       49
+
 #define GUI_MSG_USER         1000
 
 /*!

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -519,6 +519,10 @@ void CPVRManager::Process(void)
   {
     g_windowManager.ActivateWindow(m_openWindowId);
     m_openWindowId = 0;
+
+    // let everyone know that the user interface is now ready for usage
+    CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UI_READY);
+    g_windowManager.SendThreadMessage(msg);
   }
 
   bool bRestart(false);

--- a/xbmc/windows/GUIWindowLoginScreen.cpp
+++ b/xbmc/windows/GUIWindowLoginScreen.cpp
@@ -303,8 +303,7 @@ void CGUIWindowLoginScreen::LoadProfile(unsigned int profile)
   // reload the add-ons, or we will first load all add-ons from the master account without checking disabled status
   ADDON::CAddonMgr::Get().ReInit();
 
-  bool fallbackLanguage = false;
-  if (!g_application.LoadLanguage(true, fallbackLanguage))
+  if (!g_application.LoadLanguage(true))
   {
     CLog::Log(LOGFATAL, "CGUIWindowLoginScreen: unable to load language for profile \"%s\"", CProfilesManager::Get().GetCurrentProfile().getName().c_str());
     return;
@@ -312,9 +311,6 @@ void CGUIWindowLoginScreen::LoadProfile(unsigned int profile)
 
   g_weatherManager.Refresh();
   g_application.SetLoggingIn(true);
-
-  if (fallbackLanguage)
-    CGUIDialogOK::ShowAndGetInput("Failed to load language", "We were unable to load your configured language. Please check your language settings.");
 
 #ifdef HAS_JSONRPC
   JSONRPC::CJSONRPC::Initialize();

--- a/xbmc/windows/GUIWindowLoginScreen.cpp
+++ b/xbmc/windows/GUIWindowLoginScreen.cpp
@@ -326,8 +326,19 @@ void CGUIWindowLoginScreen::LoadProfile(unsigned int profile)
   // start PVR related services
   g_application.StartPVRManager();
 
-  g_windowManager.ChangeActiveWindow(g_SkinInfo->GetFirstWindow());
+  int firstWindow = g_SkinInfo->GetFirstWindow();
+  // the startup window is considered part of the initialization as it most likely switches to the final window
+  bool uiInitializationFinished = firstWindow != WINDOW_STARTUP_ANIM;
+
+  g_windowManager.ChangeActiveWindow(firstWindow);
 
   g_application.UpdateLibraries();
   CStereoscopicsManager::Get().Initialize();
+
+  // if the user interfaces has been fully initialized let everyone know
+  if (uiInitializationFinished)
+  {
+    CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UI_READY);
+    g_windowManager.SendThreadMessage(msg);
+  }
 }

--- a/xbmc/windows/GUIWindowStartup.cpp
+++ b/xbmc/windows/GUIWindowStartup.cpp
@@ -20,6 +20,7 @@
 
 #include "GUIWindowStartup.h"
 #include "input/Key.h"
+#include "guilib/GUIWindowManager.h"
 #include "guilib/WindowIDs.h"
 
 CGUIWindowStartup::CGUIWindowStartup(void)
@@ -36,4 +37,13 @@ bool CGUIWindowStartup::OnAction(const CAction &action)
   if (action.IsMouse())
     return true;
   return CGUIWindow::OnAction(action);
+}
+
+void CGUIWindowStartup::OnDeinitWindow(int nextWindowID)
+{
+  CGUIWindow::OnDeinitWindow(nextWindowID);
+
+  // let everyone know that the user interface is now ready for usage
+  CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UI_READY);
+  g_windowManager.SendThreadMessage(msg);
 }

--- a/xbmc/windows/GUIWindowStartup.h
+++ b/xbmc/windows/GUIWindowStartup.h
@@ -29,4 +29,7 @@ public:
   CGUIWindowStartup(void);
   virtual ~CGUIWindowStartup(void);
   virtual bool OnAction(const CAction &action);
+
+  // specialization of CGUIWindow
+  virtual void OnDeinitWindow(int nextWindowID);
 };


### PR DESCRIPTION
This is an alternative (and IMO cleaner) approach to #6666.

This is an attempt at solving the problem that when we try to show a modal dialog during startup to provide the user with some information, the dialog isn't really shown to the user most of the time because by the time the dialog becomes visible, Confluence's Startup.xml kicks in and executes a ReplaceWindow() call to go to the home window. That ReplaceWindow() call changes the active window and basically hides the modal dialog in the background.

The difference to #6666 is that this doesn't add an ugly busy loop on the window manager to know when the user interface is really ready for these dialogs but instead uses a new GUI message `GUI_MSG_UI_READY`. That message is sent out in one of these cases:
- Kodi has started without the login window and the startup window is not `CGUIWindowStartup` / `Startup.xml`
- Kodi has started with the login window, the user has logged into one of the profiles and the startup window is not `CGUIWindowStartup` / `Startup.xml`
- Kodi has started (with or without the login window) and the startup window is `CGUIWindowStartup` / `Startup.xml` and has been closed
