### PR TITLE
addons: fix fallback language handling for metadata

### DIFF
--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -787,11 +787,10 @@ std::string CAddonMgr::GetTranslatedString(const cp_cfg_element_t *root, const c
     {
       // see if we have a "lang" attribute
       const char *lang = m_cpluff->lookup_cfg_value((cp_cfg_element_t*)&child, "@lang");
-      if (lang != NULL &&
-         (g_langInfo.GetLocale().Matches(lang) || strcmp(lang, "en") == 0))
+      if (lang != NULL && g_langInfo.GetLocale().Matches(lang))
         translatedValues.insert(std::make_pair(lang, child.value != NULL ? child.value : ""));
-      else if (lang == NULL)
-        translatedValues.insert(std::make_pair("en", child.value != NULL ? child.value : ""));
+      else if (lang == NULL || strcmp(lang, "en") == 0 || strcmp(lang, "en_GB") == 0)
+        translatedValues.insert(std::make_pair("en_GB", child.value != NULL ? child.value : ""));
     }
   }
 
@@ -803,7 +802,7 @@ std::string CAddonMgr::GetTranslatedString(const cp_cfg_element_t *root, const c
   // find the language from the list that matches the current locale best
   std::string matchingLanguage = g_langInfo.GetLocale().FindBestMatch(languages);
   if (matchingLanguage.empty())
-    matchingLanguage = "en";
+    matchingLanguage = "en_GB";
 
   auto const& translatedValue = translatedValues.find(matchingLanguage);
   if (translatedValue != translatedValues.end())


### PR DESCRIPTION
@alanwww1 told me that with the change to the new addon based languages and the usage of `xx_YY` for language/locale representation the fallback mechanism for addon summaries, descriptions etc. doesn't work for the new `en_GB` language representation which is the new default. This commit takes care of that problem and allows to either use `en` (which is the currently used fallback) or `en_GB` as the fallback.

@alanwww1 has tested this and confirmed it working.
