### PR TITLE
CLocalizeStrings: unify fallback language handling (fixes skin strings loading)

### DIFF
--- a/xbmc/guilib/LocalizeStrings.cpp
+++ b/xbmc/guilib/LocalizeStrings.cpp
@@ -64,13 +64,13 @@ bool CLocalizeStrings::LoadSkinStrings(const std::string& path, const std::strin
   std::string encoding;
   if (!LoadStr2Mem(path, language, encoding))
   {
-    if (StringUtils::EqualsNoCase(language, ADDON_LANGUAGE_DEFAULT)) // no fallback, nothing to do
+    if (StringUtils::EqualsNoCase(language, LANGUAGE_DEFAULT)) // no fallback, nothing to do
       return false;
   }
 
   // load the fallback
-  if (!StringUtils::EqualsNoCase(language, ADDON_LANGUAGE_DEFAULT))
-    LoadStr2Mem(path, ADDON_LANGUAGE_DEFAULT, encoding);
+  if (!StringUtils::EqualsNoCase(language, LANGUAGE_DEFAULT))
+    LoadStr2Mem(path, LANGUAGE_DEFAULT, encoding);
 
   return true;
 }
@@ -100,7 +100,7 @@ bool CLocalizeStrings::LoadStr2Mem(const std::string &pathname_in, const std::st
   }
 
   if (LoadPO(URIUtils::AddFileToFolder(pathname, "strings.po"), encoding, offset,
-             StringUtils::EqualsNoCase(language, CORE_LANGUAGE_DEFAULT) || StringUtils::EqualsNoCase(language, ADDON_LANGUAGE_DEFAULT)))
+             StringUtils::EqualsNoCase(language, LANGUAGE_DEFAULT) || StringUtils::EqualsNoCase(language, LANGUAGE_OLD_DEFAULT)))
     return true;
 
   CLog::Log(LOGDEBUG, "LocalizeStrings: no strings.po file exist at %s, fallback to strings.xml",
@@ -198,7 +198,7 @@ bool CLocalizeStrings::LoadXML(const std::string &filename, std::string &encodin
 
 bool CLocalizeStrings::Load(const std::string& strPathName, const std::string& strLanguage)
 {
-  bool bLoadFallback = !StringUtils::EqualsNoCase(strLanguage, CORE_LANGUAGE_DEFAULT);
+  bool bLoadFallback = !StringUtils::EqualsNoCase(strLanguage, LANGUAGE_DEFAULT);
 
   std::string encoding;
   CSingleLock lock(m_critSection);
@@ -207,14 +207,14 @@ bool CLocalizeStrings::Load(const std::string& strPathName, const std::string& s
   if (!LoadStr2Mem(strPathName, strLanguage, encoding))
   {
     // try loading the fallback
-    if (!bLoadFallback || !LoadStr2Mem(strPathName, CORE_LANGUAGE_DEFAULT, encoding))
+    if (!bLoadFallback || !LoadStr2Mem(strPathName, LANGUAGE_DEFAULT, encoding))
       return false;
 
     bLoadFallback = false;
   }
 
   if (bLoadFallback)
-    LoadStr2Mem(strPathName, CORE_LANGUAGE_DEFAULT, encoding);
+    LoadStr2Mem(strPathName, LANGUAGE_DEFAULT, encoding);
 
   // fill in the constant strings
   m_strings[20022].strTranslated = "";

--- a/xbmc/guilib/LocalizeStrings.h
+++ b/xbmc/guilib/LocalizeStrings.h
@@ -46,8 +46,8 @@ struct LocStr
 };
 
 // The default fallback language is fixed to be English
-const std::string CORE_LANGUAGE_DEFAULT = "resource.language.en_gb";
-const std::string ADDON_LANGUAGE_DEFAULT = "English";
+const std::string LANGUAGE_DEFAULT = "resource.language.en_gb";
+const std::string LANGUAGE_OLD_DEFAULT = "English";
 
 class CLocalizeStrings
 {

--- a/xbmc/utils/Weather.cpp
+++ b/xbmc/utils/Weather.cpp
@@ -162,7 +162,7 @@ void CWeatherJob::FormatTemperature(std::string &text, int temp)
 void CWeatherJob::LoadLocalizedToken()
 {
   // We load the english strings in to get our tokens
-  std::string language = CORE_LANGUAGE_DEFAULT;
+  std::string language = LANGUAGE_DEFAULT;
   CSettingString* languageSetting = static_cast<CSettingString*>(CSettings::Get().GetSetting("locale.language"));
   if (languageSetting != NULL)
     language = languageSetting->GetDefault();


### PR DESCRIPTION
As mentioned by @stefansaraev since the language update of all system addons (including Confluence) loading the fallback translation strings from the English translation doesn't work anymore because it looks for `English` instead of `resource.language.en_gb`.

This unifies the handling of the default language and in the process fixes above issue. When loading skin strings it now first tries to load them in the language selected in Kodi's settings and in the English language from `resource.language.en_gb` and if that doesn't exist it even falls back to `English`.
