### PR TITLE
Remove unsuported actions form the onunload tag, fix the infinite loo

### DIFF
--- a/xbmc/guilib/GUIAction.cpp
+++ b/xbmc/guilib/GUIAction.cpp
@@ -23,6 +23,9 @@
 #include "GUIWindowManager.h"
 #include "GUIControl.h"
 #include "GUIInfoManager.h"
+#include "utils/StringUtils.h"
+#include "Util.h"
+#include "utils/log.h"
 
 using namespace std;
 
@@ -76,6 +79,42 @@ int CGUIAction::GetNavigation() const
     }
   }
   return 0;
+}
+
+bool CGUIAction::RemoveActions(const std::string toremove)
+{
+  std::string function;
+  vector<string> parameters;
+  iActions it = m_actions.begin();
+  bool ret     = false;
+
+  while(it != m_actions.end())
+  {
+    CUtil::SplitExecFunction(it->action, function, parameters);
+    if(function == toremove)
+    {
+      it  = m_actions.erase(it);
+      ret = true;
+    }
+    else
+      it++;
+  }
+
+  return ret;
+}
+
+void CGUIAction::LogActions() const
+{
+  if (m_actions.size() == 0) return;
+
+  std::string function;
+  vector<string> parameters;
+
+  for (ciActions it = m_actions.begin() ; it != m_actions.end() ; ++it)
+  {
+    CUtil::SplitExecFunction(it->action, function, parameters);
+    CLog::Log(LOGDEBUG, "CGUIAction::LogActions: %s, function is: %s", it->action.c_str(), function.c_str());
+  }
 }
 
 void CGUIAction::SetNavigation(int id)

--- a/xbmc/guilib/GUIAction.h
+++ b/xbmc/guilib/GUIAction.h
@@ -50,6 +50,14 @@ public:
    */
   int GetNavigation() const;
   /**
+   * Log all actions in log file (for debugging purpose)
+   */
+  void LogActions() const;
+  /**;
+   * Remove all actions with the given function name
+   */
+  bool RemoveActions(const std::string function);
+  /**
    * Set navigation route
    */
   void SetNavigation(int id);

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -495,7 +495,7 @@ bool CGUIControlFactory::GetAnimations(TiXmlNode *control, const CRect &rect, in
   return ret;
 }
 
-bool CGUIControlFactory::GetActions(const TiXmlNode* pRootNode, const char* strTag, CGUIAction& action)
+bool CGUIControlFactory::GetActions(const TiXmlNode* pRootNode, const char* strTag, CGUIAction& action, const std::vector<string> actionsIgnore)
 {
   action.m_actions.clear();
   const TiXmlElement* pElement = pRootNode->FirstChildElement(strTag);
@@ -504,9 +504,16 @@ bool CGUIControlFactory::GetActions(const TiXmlNode* pRootNode, const char* strT
     if (pElement->FirstChild())
     {
       CGUIAction::cond_action_pair pair;
+      std::string function;
+      vector<string> parameters;
+
       pair.condition = XMLUtils::GetAttribute(pElement, "condition");
       pair.action = pElement->FirstChild()->Value();
-      action.m_actions.push_back(pair);
+      // check if action is supported
+      CUtil::SplitExecFunction(pair.action, function, parameters);
+      if(actionsIgnore.size() == 0 || 
+          std::find(actionsIgnore.begin(), actionsIgnore.end(), function) == actionsIgnore.end())
+        action.m_actions.push_back(pair);
     }
     pElement = pElement->NextSiblingElement(strTag);
   }

--- a/xbmc/guilib/GUIControlFactory.h
+++ b/xbmc/guilib/GUIControlFactory.h
@@ -83,7 +83,7 @@ public:
   static bool GetInfoColor(const TiXmlNode* pRootNode, const char* strTag, CGUIInfoColor &value, int parentID);
   static std::string FilterLabel(const std::string &label);
   static bool GetConditionalVisibility(const TiXmlNode* control, std::string &condition);
-  static bool GetActions(const TiXmlNode* pRootNode, const char* strTag, CGUIAction& actions);
+  static bool GetActions(const TiXmlNode* pRootNode, const char* strTag, CGUIAction& actions, const std::vector<std::string> actionsIgnore = std::vector<std::string>());
   static void GetRectFromString(const std::string &string, CRect &rect);
   static bool GetHitRect(const TiXmlNode* pRootNode, CRect &rect);
   static bool GetScroller(const TiXmlNode *pControlNode, const std::string &scrollerTag, CScroller& scroller);

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -178,9 +178,13 @@ bool CGUIWindow::Load(TiXmlElement* pRootElement)
   // now load in the skin file
   SetDefaults();
 
+  // list of actions *not* supported
+  std::vector<string> actionsUnsuported; 
+  actionsUnsuported.push_back("ActivateWindow");
+
   CGUIControlFactory::GetInfoColor(pRootElement, "backgroundcolor", m_clearBackground, GetID());
   CGUIControlFactory::GetActions(pRootElement, "onload", m_loadActions);
-  CGUIControlFactory::GetActions(pRootElement, "onunload", m_unloadActions);
+  CGUIControlFactory::GetActions(pRootElement, "onunload", m_unloadActions, actionsUnsuported);
   CGUIControlFactory::GetHitRect(pRootElement, m_hitRect);
 
   TiXmlElement *pChild = pRootElement->FirstChildElement();

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -178,13 +178,9 @@ bool CGUIWindow::Load(TiXmlElement* pRootElement)
   // now load in the skin file
   SetDefaults();
 
-  // list of actions *not* supported
-  std::vector<string> actionsUnsuported; 
-  actionsUnsuported.push_back("ActivateWindow");
-
   CGUIControlFactory::GetInfoColor(pRootElement, "backgroundcolor", m_clearBackground, GetID());
   CGUIControlFactory::GetActions(pRootElement, "onload", m_loadActions);
-  CGUIControlFactory::GetActions(pRootElement, "onunload", m_unloadActions, actionsUnsuported);
+  CGUIControlFactory::GetActions(pRootElement, "onunload", m_unloadActions, ONUNLOAD_DISALLOWED_ACTIONS);
   CGUIControlFactory::GetHitRect(pRootElement, m_hitRect);
 
   TiXmlElement *pChild = pRootElement->FirstChildElement();

--- a/xbmc/guilib/GUIWindow.h
+++ b/xbmc/guilib/GUIWindow.h
@@ -277,6 +277,8 @@ protected:
 private:
   std::map<std::string, CVariant, icompare> m_mapProperties;
   std::map<INFO::InfoPtr, bool> m_xmlIncludeConditions; ///< \brief used to store conditions used to resolve includes for this window
+  // list of actions *not* supported
+  static const std::vector<std::string> ONUNLOAD_DISALLOWED_ACTIONS = {"ActivateWindow"};
 };
 
 #endif


### PR DESCRIPTION
When ActivateWindow() command is passed inside the <onunload> tag, it triggers an infinite loop as ActivateWindow() will fire a window_deinit message, that calls the <onunload> actions again.

This fix has been tested on Helix and master, it provides a way to reject unsupported actions when creating the actions list in the window init phase.

GUIAction.cpp is also modified, even though it is not implied in the fix, I first tried a different approach by removing actions from the list after GetActions(). The final implementation seems much cleaner, but the GUIAction::RemoveActions() method is working and could be useful.
