### PR TITLE
[IMX] Parse screen dimensions from Detailed timing section first.

### DIFF
--- a/xbmc/windowing/egl/EGLNativeTypeIMX.cpp
+++ b/xbmc/windowing/egl/EGLNativeTypeIMX.cpp
@@ -397,7 +397,9 @@ void CEGLNativeTypeIMX::GetMonitorSAR()
   // enumerate through (max four) detailed timing info blocks
   // specs and lookup WxH [mm / in]. W and H are in 3 bytes,
   // where 1st = W, 2nd = H, 3rd byte is 4bit/4bit.
-  for (int i = EDID_DTM_START; i < 126 && m_sar == 0; i += 18)
+  //
+  // if DTM block starts with 0 - it is not DTM, skip
+  for (int i = EDID_DTM_START; i < 126 && m_sar == 0 && *(m_edid +i); i += 18)
     m_sar = ValidateSAR((struct dt_dim *)(m_edid +i +EDID_DTM_OFFSET_DIMENSION), true);
 
   // fallback - info related to 'Basic display parameters.' is at offset 0x14-0x18.

--- a/xbmc/windowing/egl/EGLNativeTypeIMX.h
+++ b/xbmc/windowing/egl/EGLNativeTypeIMX.h
@@ -24,10 +24,18 @@
 #include <EGL/egl.h>
 #include "EGLNativeType.h"
 
-#define EDID_STRUCT_DISPLAY     0x14
+#define EDID_STRUCT_DISPLAY             0x14
+#define EDID_DTM_START                  0x36
+#define EDID_DTM_OFFSET_DIMENSION       0x0c
 
 class CEGLNativeTypeIMX : public CEGLNativeType
 {
+  struct dt_dim {
+    uint8_t Width;
+    uint8_t Height;
+    uint8_t msbits;
+  };
+
 public:
   CEGLNativeTypeIMX();
   virtual ~CEGLNativeTypeIMX();
@@ -57,7 +65,8 @@ protected:
   float m_sar;
   bool ModeToResolution(std::string mode, RESOLUTION_INFO *res) const;
   bool FindMatchingResolution(const RESOLUTION_INFO &res, const std::vector<RESOLUTION_INFO> &resolutions);
-  float GetMonitorSAR();
+  void GetMonitorSAR();
+  float ValidateSAR(struct dt_dim *dtm, bool mb = false);
 
   EGLNativeDisplayType m_display;
   EGLNativeWindowType  m_window;


### PR DESCRIPTION
This section (should) contain WxH in [mm].

(if not defined, revert back to standard info [cm], then as before
 revert to 1.0f)
