### PR TITLE
Allow Settings to be saved from the xbmc. Python API

### DIFF
--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -488,6 +488,11 @@ namespace XBMCAddon
       CAEFactory::Resume();
     }
 
+   void saveSettings()
+   {
+      CSettings::Get().Save();
+   }
+
     String convertLanguage(const char* language, int format)
     {
       std::string convertedLanguage;

--- a/xbmc/interfaces/legacy/ModuleXbmc.h
+++ b/xbmc/interfaces/legacy/ModuleXbmc.h
@@ -405,6 +405,14 @@ namespace XBMCAddon
      */  
     void audioResume();
 
+   /**
+    * saveSettings() -- saves settings to guisettings.xml
+    *
+    * example:
+    *   xbmc.saveSettings()
+    */
+    void saveSettings();
+
     /**
     * convertLanguage(language, format) -- Returns the given language converted to the given format as a string.
     *


### PR DESCRIPTION
In OSMC we are working on a backup addon and have noticed that sometimes guisettings.xml is left in an inconsistent state. 

I have seen in xbmc/Application.cpp that guisettings is sometimes saved based on certain events such as XBMC_VIDEORESIZE.

I have added this functionality to the legacy interface so that it can be invoked via plugins easily in Python. I am not sure if this is the best place to put this functionality. One of our developers notes this may be beneficial to other plugins. The 'XBMC Backup Addon' uses the JSON API for setting and writes each one to a brand new XML file because the state of guisettings.xml cannot be trusted. 
