### PR TITLE
[libexif] Fix buffer overflow due to invalid GPS coordinates

### DIFF
--- a/lib/libexif/ExifParse.cpp
+++ b/lib/libexif/ExifParse.cpp
@@ -823,9 +823,18 @@ void CExifParse::GetLatLong(
     {
       Values[a] = ConvertAnyFormat(ValuePtr+a*ComponentSize, Format);
     }
-    char latLong[30];
-    sprintf(latLong, "%3.0fd %2.0f' %5.2f\"", Values[0], Values[1], Values[2]);
-    strcat(latLongString, latLong);
+    if (Values[0] < 0 || Values[0] > 180 || Values[1] < 0 || Values[1] >= 60 || Values[2] < 0 || Values[2] >= 60)
+    {
+      // Ignore invalid values (DMS format expected)
+      ErrNonfatal("Invalid Lat/Long value", 0, 0);
+      latLongString[0] = 0;
+    }
+    else
+    {
+      char latLong[30];
+      sprintf(latLong, "%3.0fd %2.0f' %5.2f\"", Values[0], Values[1], Values[2]);
+      strcat(latLongString, latLong);
+    }
   }
 }
 


### PR DESCRIPTION
Fix crash when viewing pictures taken on a Panasonic TZ-40.
The crash occurs when reading Exif GPS data.
Sometimes, Lat&Long are incorrect (16777215d 16777215' 167772.15") and cause buffer overflow.
The fix consists in checking Lat&Long values, and if values are incorrect, coordinates are set to 0.

See http://trac.kodi.tv/ticket/15231 for details of the bug.
