### PR TITLE
Always declare gnu89 inline standard

### DIFF
--- a/xbmc/screensavers/rsxs-0.9/lib/argp-fmtstream.h
+++ b/xbmc/screensavers/rsxs-0.9/lib/argp-fmtstream.h
@@ -198,11 +198,7 @@ extern int __argp_fmtstream_ensure (argp_fmtstream_t __fs, size_t __amount);
 #endif
 
 #ifndef ARGP_FS_EI
-#ifdef __clang__
 #define ARGP_FS_EI extern inline __attribute__ ((__gnu_inline__))
-#else
-#define ARGP_FS_EI extern inline
-#endif
 #endif
 
 ARGP_FS_EI size_t

--- a/xbmc/screensavers/rsxs-0.9/lib/argp.h
+++ b/xbmc/screensavers/rsxs-0.9/lib/argp.h
@@ -559,7 +559,7 @@ extern void *__argp_input (const struct argp *__restrict __argp,
 # endif
 
 # ifndef ARGP_EI
-#  define ARGP_EI extern __inline__
+#  define ARGP_EI extern __inline__ __attribute__ ((gnu_inline)) 
 # endif
 
 ARGP_EI void


### PR DESCRIPTION
GCC5 switches the minimum inline standard requirements from gnu89 to gnu11.

Without this change you cannot compile with GCC 5.0+. The alternative would be to move all the inline functions out of headers and make the code gnu11 compliant. This commit is the quickest fix.
