### PR TITLE
WinSystemX11: Properly initialize fps value - it might not be set at all

### DIFF
--- a/xbmc/windowing/X11/WinSystemX11.cpp
+++ b/xbmc/windowing/X11/WinSystemX11.cpp
@@ -1468,7 +1468,7 @@ void CWinSystemX11::UpdateCrtc()
 {
   XWindowAttributes winattr;
   int posx, posy;
-  float fps;
+  float fps = 0.0f;
   Window child;
   XGetWindowAttributes(m_dpy, m_mainWindow, &winattr);
   XTranslateCoordinates(m_dpy, m_mainWindow, RootWindow(m_dpy, m_nScreen), winattr.x, winattr.y,


### PR DESCRIPTION
See discussion here: https://github.com/notspiff/kodi-cmake/commit/b16bd4c0f2a889cb0cfa90b34b339e43190683aa#commitcomment-11277738

If the target platform has non working xrandr support, fps ends up uninitialized and CGraphicContext::GetResInfo(RESOLUTION res) has unwanted sideeffects in further processing.

@FernetMenta ping
