### PR TITLE
Don't set FPS when the value is uknown

### DIFF
--- a/xbmc/windowing/X11/WinSystemX11.cpp
+++ b/xbmc/windowing/X11/WinSystemX11.cpp
@@ -1468,14 +1468,15 @@ void CWinSystemX11::UpdateCrtc()
 {
   XWindowAttributes winattr;
   int posx, posy;
-  float fps;
+  float fps = 0.0f;
   Window child;
   XGetWindowAttributes(m_dpy, m_mainWindow, &winattr);
   XTranslateCoordinates(m_dpy, m_mainWindow, RootWindow(m_dpy, m_nScreen), winattr.x, winattr.y,
                         &posx, &posy, &child);
 
   m_crtc = g_xrandr.GetCrtc(posx+winattr.width/2, posy+winattr.height/2, fps);
-  g_graphicsContext.SetFPS(fps);
+  if (fps)
+    g_graphicsContext.SetFPS(fps);
 }
 
 #endif


### PR DESCRIPTION
This commit fixes the endless loop with 100% CPU load when
setting the 0.0 FPS value.
In some configurations the RandR extension is not available
or is unable to query the Hz value.
In such cases CXRandR::GetCrtc() is not iterating in inner
loop introduced in commit cb540ac, leading to not touching
the 'hz' input variable.
