### PR TITLE
[WIN32][VFS][CURL]Possible fix for deadlock when stopping playback

### DIFF
--- a/project/BuildDependencies/scripts/0_package.list
+++ b/project/BuildDependencies/scripts/0_package.list
@@ -8,7 +8,7 @@
 ;PLEASE KEEP THIS LIST IN ALPHABETICAL ORDER!
 boost-1.46.1-headers-win32.7z
 bzip2-1.0.5-win32.7z
-curl-7.40-win32.7z
+curl-7.42.1-win32.7z
 dnssd-541-win32.zip
 doxygen-1.8.2-win32.7z
 fontconfig-2.8.0-win32.7z


### PR DESCRIPTION
This is to get a discussion started on how best to fix a deadlock mentioned by @natethomas and referenced in http://forum.kodi.tv/showthread.php?tid=200735&pid=2006850#pid2006850 . 

What happens in my testing is that CFileCache is waiting on either m_seekEnded or for more data. When we stop playback our main thread calls stopthread on dvdplayer and blocks. Dvdplayer calls stopthread on CFileCache and blocks. CFileCache doesn't get any new events since everything is blocking waiting for it to go away.

First line of the fix seems like it shoul've been there from the start and I think it should go in.
Second line I'm not entirely sure about. I don't see a scenario where it would be bad to force close the file but maybe someone more familiar with dvdplayer can chime in on what bad things can happen.
@FernetMenta thoughts?
