### PR TITLE
[CURL] xbmc/URL.cpp adapted to parse URI containing IPv6

### DIFF
--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -253,35 +253,33 @@ void CURL::Parse(const std::string& strURL1)
     }
   }
 
-  // detect hostname:port/
-  if (iSlash == std::string::npos)
+  std::string strHostNameAndPort = strURL.substr(iPos, (iSlash == std::string::npos) ? iEnd - iPos : iSlash - iPos);
+  // check for IPv6 numerical representation inside [].
+  // if [] found, let's store string inside as hostname
+  // and remove that parsed part from strHostNameAndPort
+  size_t iBrk = strHostNameAndPort.rfind("]");
+  if (iBrk != std::string::npos && strHostNameAndPort.find("[") == 0)
   {
-    std::string strHostNameAndPort = strURL.substr(iPos, iEnd - iPos);
-    size_t iColon = strHostNameAndPort.find(":");
-    if (iColon != std::string::npos)
-    {
-      m_strHostName = strHostNameAndPort.substr(0, iColon);
-      m_iPort = atoi(strHostNameAndPort.substr(iColon + 1).c_str());
-    }
-    else
-    {
-      m_strHostName = strHostNameAndPort;
-    }
-
+    m_strHostName = strHostNameAndPort.substr(1, iBrk-1);
+    strHostNameAndPort.erase(0, iBrk+1);
   }
-  else
+
+  // detect hostname:port/ or just :port/ if previous step found [IPv6] format
+  size_t iColon = strHostNameAndPort.rfind(":");
+  if (iColon != std::string::npos && iColon == strHostNameAndPort.find(":"))
   {
-    std::string strHostNameAndPort = strURL.substr(iPos, iSlash - iPos);
-    size_t iColon = strHostNameAndPort.find(":");
-    if (iColon != std::string::npos)
-    {
+    if (m_strHostName.empty())
       m_strHostName = strHostNameAndPort.substr(0, iColon);
-      m_iPort = atoi(strHostNameAndPort.substr(iColon + 1).c_str());
-    }
-    else
-    {
-      m_strHostName = strHostNameAndPort;
-    }
+    m_iPort = atoi(strHostNameAndPort.substr(iColon + 1).c_str());
+  }
+
+  // if we still don't have hostname, the strHostNameAndPort substring
+  // is 'just' hostname without :port specification - so use it as is.
+  if (m_strHostName.empty())
+    m_strHostName = strHostNameAndPort;
+
+  if (iSlash != std::string::npos)
+  {
     iPos = iSlash + 1;
     if (iEnd > iPos)
       m_strFileName = strURL.substr(iPos, iEnd - iPos);
@@ -494,6 +492,16 @@ const std::string CURL::GetFileNameWithoutPath() const
   return URIUtils::GetFileName(file);
 }
 
+inline
+void protectIPv6(std::string &hn)
+{
+  if (!hn.empty() && hn.find(":") != hn.rfind(":")
+   && hn.find(":") != std::string::npos)
+  {
+    hn = '[' + hn + ']';
+  }
+}
+
 char CURL::GetDirectorySeparator() const
 {
 #ifndef TARGET_POSIX
@@ -595,14 +603,16 @@ std::string CURL::GetWithoutUserDetails(bool redact) const
       strHostName = m_strHostName;
 
     if (URIUtils::HasEncodedHostname(*this))
-      strURL += Encode(strHostName);
-    else
-      strURL += strHostName;
+      strHostName = Encode(strHostName);
 
     if ( HasPort() )
     {
-      strURL += StringUtils::Format(":%i", m_iPort);
+      protectIPv6(strHostName);
+      strURL += strHostName + StringUtils::Format(":%i", m_iPort);
     }
+    else
+      strURL += strHostName;
+
     strURL += "/";
   }
   strURL += m_strFileName;
@@ -654,12 +664,21 @@ std::string CURL::GetWithoutFilename() const
 
   if (!m_strHostName.empty())
   {
+    std::string hostname;
+
     if( URIUtils::HasEncodedHostname(*this) )
-      strURL += Encode(m_strHostName);
+      hostname = Encode(m_strHostName);
     else
-      strURL += m_strHostName;
+      hostname = m_strHostName;
+
     if (HasPort())
-      strURL += ':' + StringUtils::Format("%i", m_iPort);
+    {
+      protectIPv6(hostname);
+      strURL += hostname + StringUtils::Format(":%i", m_iPort);
+    }
+    else
+      strURL += hostname;
+
     strURL += "/";
   }
 

--- a/xbmc/test/TestURL.cpp
+++ b/xbmc/test/TestURL.cpp
@@ -59,7 +59,20 @@ const TestURLGetWithoutUserDetailsData values[] = {
   { std::string("smb://god:universe@example.com/example"), std::string("smb://example.com/example"), false },
   { std::string("smb://god@example.com/example"), std::string("smb://USERNAME@example.com/example"), true },
   { std::string("smb://god:universe@example.com/example"), std::string("smb://USERNAME:PASSWORD@example.com/example"), true },
-  { std::string("http://god:universe@example.com:8448/example|auth=digest"), std::string("http://USERNAME:PASSWORD@example.com:8448/example|auth=digest"), true }
+  { std::string("http://god:universe@example.com:8448/example|auth=digest"), std::string("http://USERNAME:PASSWORD@example.com:8448/example|auth=digest"), true },
+  { std::string("smb://fd00::1/example"), std::string("smb://fd00::1/example"), false },
+  { std::string("smb://fd00::1/example"), std::string("smb://fd00::1/example"), true },
+  { std::string("smb://[fd00::1]:8080/example"), std::string("smb://[fd00::1]:8080/example"), false },
+  { std::string("smb://[fd00::1]:8080/example"), std::string("smb://[fd00::1]:8080/example"), true },
+  { std::string("smb://god:universe@[fd00::1]:8080/example"), std::string("smb://[fd00::1]:8080/example"), false },
+  { std::string("smb://god@[fd00::1]:8080/example"), std::string("smb://USERNAME@[fd00::1]:8080/example"), true },
+  { std::string("smb://god:universe@fd00::1/example"), std::string("smb://USERNAME:PASSWORD@fd00::1/example"), true },
+  { std::string("http://god:universe@[fd00::1]:8448/example|auth=digest"), std::string("http://USERNAME:PASSWORD@[fd00::1]:8448/example|auth=digest"), true },
+  { std::string("smb://00ff:1:0000:abde::/example"), std::string("smb://00ff:1:0000:abde::/example"), true },
+  { std::string("smb://god:universe@[00ff:1:0000:abde::]:8080/example"), std::string("smb://[00ff:1:0000:abde::]:8080/example"), false },
+  { std::string("smb://god@[00ff:1:0000:abde::]:8080/example"), std::string("smb://USERNAME@[00ff:1:0000:abde::]:8080/example"), true },
+  { std::string("smb://god:universe@00ff:1:0000:abde::/example"), std::string("smb://USERNAME:PASSWORD@00ff:1:0000:abde::/example"), true },
+  { std::string("http://god:universe@[00ff:1:0000:abde::]:8448/example|auth=digest"), std::string("http://USERNAME:PASSWORD@[00ff:1:0000:abde::]:8448/example|auth=digest"), true }
   };
 
 INSTANTIATE_TEST_CASE_P(URL, TestURLGetWithoutUserDetails, ValuesIn(values));


### PR DESCRIPTION
```
   address.
```

   It recognises strings conforming to RFC 2373. This means
at least '::x' .
   The parsed address is NOT checked for actual correctness,
availability etc (but this is not present for IPv4 too).

   In case a port is specified within URI too, IPv6 address
MUST be enclosed within [] eg [fd00::1]:8080. If port is not
specified, enclosing is not required.
