### PR TITLE
[input] drop fallback window configuration for fullscreeninfo dialog

### DIFF
--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -440,7 +440,6 @@ static const ActionMapping touchcommands[] =
 static const WindowMapping fallbackWindows[] =
 {
   { WINDOW_FULLSCREEN_LIVETV,          WINDOW_FULLSCREEN_VIDEO },
-  { WINDOW_DIALOG_FULLSCREEN_INFO,     WINDOW_FULLSCREEN_VIDEO },
   { WINDOW_FULLSCREEN_RADIO,           WINDOW_VISUALISATION    }
 };
 


### PR DESCRIPTION
This drops the fallback configuration for dialog fullscreeninfo which is currently set to fullscreenvideo.
It is done because it's impossible to navigate inside this modal. Instead of using the default key mapping for left/right/up/down the key mappings of the fallback window are applied.
This is an issue if skins want to use buttons to close or control some elements within this dialog e.g. toggle epg now/next for livetv etc.

@da-anda @mkortstiege mind taking a look
