### PR TITLE
[RFC] Add multi source input stream/demuxer

### DIFF
--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -235,6 +235,7 @@
     <ClCompile Include="..\..\xbmc\cores\dvdplayer\DVDDemuxers\DVDDemuxCDDA.cpp" />
     <ClCompile Include="..\..\xbmc\cores\dvdplayer\DVDDemuxers\DVDDemuxPVRClient.cpp" />
     <ClCompile Include="..\..\xbmc\cores\dvdplayer\DVDInputStreams\DVDInputStreamBluray.cpp" />
+    <ClCompile Include="..\..\xbmc\cores\dvdplayer\DVDInputStreams\DVDInputStreamMultiSource.cpp" />
     <ClCompile Include="..\..\xbmc\cores\dvdplayer\DVDInputStreams\DVDInputStreamPVRManager.cpp" />
     <ClCompile Include="..\..\xbmc\cores\FFmpeg.cpp" />
     <ClCompile Include="..\..\xbmc\cores\VideoRenderers\OverlayRendererGUI.cpp" />
@@ -861,6 +862,7 @@
     <ClInclude Include="..\..\xbmc\cores\dvdplayer\DVDDemuxers\DVDDemuxBXA.h" />
     <ClInclude Include="..\..\xbmc\cores\dvdplayer\DVDDemuxers\DVDDemuxCC.h" />
     <ClInclude Include="..\..\xbmc\cores\dvdplayer\DVDDemuxers\DVDDemuxCDDA.h" />
+    <ClInclude Include="..\..\xbmc\cores\dvdplayer\DVDInputStreams\DVDInputStreamMultiSource.h" />
     <ClInclude Include="..\..\xbmc\cores\FFmpeg.h" />
     <ClInclude Include="..\..\xbmc\cores\VideoRenderers\OverlayRendererGUI.h" />
     <ClInclude Include="..\..\xbmc\dialogs\GUIDialogKeyboardGeneric.h" />

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -233,6 +233,7 @@
     <ClCompile Include="..\..\xbmc\cores\dvdplayer\DVDDemuxers\DVDDemuxBXA.cpp" />
     <ClCompile Include="..\..\xbmc\cores\dvdplayer\DVDDemuxers\DVDDemuxCC.cpp" />
     <ClCompile Include="..\..\xbmc\cores\dvdplayer\DVDDemuxers\DVDDemuxCDDA.cpp" />
+    <ClCompile Include="..\..\xbmc\cores\dvdplayer\DVDDemuxers\DVDDemuxMultiSource.cpp" />
     <ClCompile Include="..\..\xbmc\cores\dvdplayer\DVDDemuxers\DVDDemuxPVRClient.cpp" />
     <ClCompile Include="..\..\xbmc\cores\dvdplayer\DVDInputStreams\DVDInputStreamBluray.cpp" />
     <ClCompile Include="..\..\xbmc\cores\dvdplayer\DVDInputStreams\DVDInputStreamMultiSource.cpp" />
@@ -862,6 +863,7 @@
     <ClInclude Include="..\..\xbmc\cores\dvdplayer\DVDDemuxers\DVDDemuxBXA.h" />
     <ClInclude Include="..\..\xbmc\cores\dvdplayer\DVDDemuxers\DVDDemuxCC.h" />
     <ClInclude Include="..\..\xbmc\cores\dvdplayer\DVDDemuxers\DVDDemuxCDDA.h" />
+    <ClInclude Include="..\..\xbmc\cores\dvdplayer\DVDDemuxers\DVDDemuxMultiSource.h" />
     <ClInclude Include="..\..\xbmc\cores\dvdplayer\DVDInputStreams\DVDInputStreamMultiSource.h" />
     <ClInclude Include="..\..\xbmc\cores\FFmpeg.h" />
     <ClInclude Include="..\..\xbmc\cores\VideoRenderers\OverlayRendererGUI.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -3090,6 +3090,9 @@
     <ClCompile Include="..\..\xbmc\cores\dvdplayer\DVDInputStreams\DVDInputStreamMultiSource.cpp">
       <Filter>cores\dvdplayer\DVDInputStreams</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\cores\dvdplayer\DVDDemuxers\DVDDemuxMultiSource.cpp">
+      <Filter>cores\dvdplayer\DVDDemuxers</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\xbmc\win32\pch.h">
@@ -5976,6 +5979,9 @@
     </ClInclude>
     <ClInclude Include="..\..\xbmc\cores\dvdplayer\DVDInputStreams\DVDInputStreamMultiSource.h">
       <Filter>cores\dvdplayer\DVDInputStreams</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\cores\dvdplayer\DVDDemuxers\DVDDemuxMultiSource.h">
+      <Filter>cores\dvdplayer\DVDDemuxers</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -3087,6 +3087,9 @@
     <ClCompile Include="..\..\xbmc\test\TestUtil.cpp">
       <Filter>test</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\cores\dvdplayer\DVDInputStreams\DVDInputStreamMultiSource.cpp">
+      <Filter>cores\dvdplayer\DVDInputStreams</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\xbmc\win32\pch.h">
@@ -5970,6 +5973,9 @@
     </ClInclude>
     <ClInclude Include="..\..\xbmc\music\EmbeddedArt.h">
       <Filter>music</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\cores\dvdplayer\DVDInputStreams\DVDInputStreamMultiSource.h">
+      <Filter>cores\dvdplayer\DVDInputStreams</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -2350,6 +2350,34 @@ std::string CUtil::GetVobSubIdxFromSub(const std::string& vobSub)
   return std::string();
 }
 
+
+void CUtil::ScanForExternalAudio(const std::string& videoPath, std::vector<std::string>& vecAudio)
+{
+  unsigned int startTimer = XbmcThreads::SystemClockMillis();
+
+  // new array for commons audio sub dirs
+  const char * common_audio_dirs[] = {"audio",
+    "tracks",
+    NULL};
+
+  CFileItem item(videoPath, false);
+  if ( item.IsInternetStream()
+   ||  item.IsHDHomeRun()
+   ||  item.IsSlingbox()
+   ||  item.IsPlayList()
+   ||  item.IsLiveTV()
+   || !item.IsVideo()) 
+    return;
+
+  std::vector<std::string> strLookInPaths;
+  GetPathsToLookForAssociatedItems(videoPath, common_audio_dirs, strLookInPaths);
+
+  std::vector<std::string> audio_exts = StringUtils::Split(g_advancedSettings.GetMusicExtensions(), "|");
+  ScanPathsForAssociatedItems(videoPath, strLookInPaths, audio_exts, vecAudio);
+
+  CLog::Log(LOGDEBUG,"%s: END (total time: %i ms)", __FUNCTION__, (int)(XbmcThreads::SystemClockMillis() - startTimer));
+}
+
 bool CUtil::CanBindPrivileged()
 {
 #ifdef TARGET_POSIX

--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -121,6 +121,12 @@ public:
   static bool IsVobSub(const std::vector<std::string>& vecSubtitles, const std::string& strSubPath);
   static std::string GetVobSubSubFromIdx(const std::string& vobSubIdx);
   static std::string GetVobSubIdxFromSub(const std::string& vobSub);
+  
+  /** \brief Retrieves paths of external audio files for a given video.
+  *   \param[in] videoPath The full path of the video file.
+  *   \param[out] vecAudio A vector containing the full paths of all found external audio files.
+  */
+  static void ScanForExternalAudio(const std::string& videoPath, std::vector<std::string>& vecAudio);
   static int64_t ToInt64(uint32_t high, uint32_t low);
   static std::string GetNextFilename(const std::string &fn_template, int max);
   static std::string GetNextPathname(const std::string &path_template, int max);

--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -82,6 +82,38 @@ public:
   static void ClearTempFonts();
 
   static void ClearSubtitles();
+
+  /** \brief Retrieves paths that could contain associated files of a given video.
+  *   \param[in] videoPath The full path of the video file.
+  *   \param[in] common_sub_dirs[] An array of sub directory names to look for.
+  *   \param[out] paths A vector of found paths to look for associated files.
+  */
+  static void GetPathsToLookForAssociatedItems(const std::string& videoPath,
+    const char* common_sub_dirs[],
+    std::vector<std::string>& paths);
+
+  /** \brief Searches for associated files of a given video.
+  *   \param[in] videoPath The full path of the video file.
+  *   \param[in] paths A vector of paths to look for associated files.
+  *   \param[in] item_exts An array of extensions specifying the associated files.
+  *   \param[out] itemPaths A vector containing the full paths of all found associated files.
+  */
+  static void ScanPathsForAssociatedItems(const std::string& videoPath,
+    std::vector<std::string>& paths,
+    const std::vector<std::string>& item_exts,
+    std::vector<std::string>& itemPaths);
+
+  /** \brief Searches in an archive for associated files of a given video.
+  *   \param[in] strArchivePath The full path of the archive.
+  *   \param[in] videoNameNoExt The filename of the video without extension for which associated files should be retrieved.
+  *   \param[in] item_exts An array of extensions specifying the associated files.
+  *   \param[out] itemPaths A vector containing the full paths of all found associated files.
+  */
+  static int ScanArchiveForAssociatedItems(const std::string& strArchivePath,
+    const std::string& videoNameNoExt,
+    const std::vector<std::string>& item_exts,
+    std::vector<std::string>& itemPaths);
+
   static void ScanForExternalSubtitles(const std::string& strMovie, std::vector<std::string>& vecSubtitles );
   static int ScanArchiveForSubtitles( const std::string& strArchivePath, const std::string& strMovieFileNameNoExt, std::vector<std::string>& vecSubtitles );
   static void GetExternalStreamDetailsFromFilename(const std::string& strMovie, const std::string& strSubtitles, ExternalStreamInfo& info); 

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemux.h
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemux.h
@@ -356,4 +356,11 @@ public:
    * return a user-presentable codec name of the given stream
    */
   virtual void GetStreamCodecName(int iStreamId, std::string &strName) {};
+
+  /*
+  * Renumbers the stream ids beginning with the given offset.
+  * Additionally the offset is stored for new streams. 
+  * Returns true if the operation was successful.
+  */
+  virtual bool RenumberStreamIds(unsigned int offset) { return false; };
 };

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1103,7 +1103,7 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int iId)
         st->iBitsPerSample = pStream->codec->bits_per_raw_sample;
         if (st->iBitsPerSample == 0)
           st->iBitsPerSample = pStream->codec->bits_per_coded_sample;
-	
+  
         if(av_dict_get(pStream->metadata, "title", NULL, 0))
           st->m_description = av_dict_get(pStream->metadata, "title", NULL, 0)->value;
 
@@ -1220,10 +1220,10 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int iId)
         {
           CDemuxStreamSubtitleFFmpeg* st = new CDemuxStreamSubtitleFFmpeg(this, pStream);
           stream = st;
-	    
+      
           if(av_dict_get(pStream->metadata, "title", NULL, 0))
             st->m_description = av_dict_get(pStream->metadata, "title", NULL, 0)->value;
-	
+  
           break;
         }
       }

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -991,10 +991,11 @@ int CDVDDemuxFFmpeg::GetStreamLength()
  */
 CDemuxStream* CDVDDemuxFFmpeg::GetStream(int iStreamId)
 {
-  if(iStreamId >= 0 && (size_t)iStreamId < m_stream_index.size())
-    return m_stream_index[iStreamId]->second;
-  else
+  auto it = m_stream_index.find(iStreamId);
+  if (it == m_stream_index.end())
     return NULL;
+  else
+    return it->second->second;
 }
 
 /**
@@ -1342,12 +1343,12 @@ void CDVDDemuxFFmpeg::AddStream(int iId, CDemuxStream* stream)
 {
   std::pair<std::map<int, CDemuxStream*>::iterator, bool> res;
 
-  res = m_streams.insert(std::make_pair(iId, stream));
+  res = m_streams.insert(std::make_pair(m_streamIdOffset + iId, stream));
   if(res.second)
   {
     /* was new stream */
-    stream->iId = m_stream_index.size();
-    m_stream_index.push_back(res.first);
+    stream->iId = m_streamIdOffset + m_stream_index.size();
+    m_stream_index[stream->iId] = res.first;
   }
   else
   {
@@ -1358,7 +1359,7 @@ void CDVDDemuxFFmpeg::AddStream(int iId, CDemuxStream* stream)
     res.first->second = stream;
   }
   if(g_advancedSettings.m_logLevel > LOG_LEVEL_NORMAL)
-    CLog::Log(LOGDEBUG, "CDVDDemuxFFmpeg::AddStream(%d, ...) -> %d", iId, stream->iId);
+    CLog::Log(LOGDEBUG, "CDVDDemuxFFmpeg::AddStream(%d, ...) -> %d", (m_streamIdOffset + iId), stream->iId);
 }
 
 
@@ -1768,3 +1769,18 @@ void CDVDDemuxFFmpeg::GetL16Parameters(int &channels, int &samplerate)
     }
   }
 }
+
+bool CDVDDemuxFFmpeg::RenumberStreamIds(unsigned int offset)
+{
+  m_streamIdOffset = offset;
+
+  std::map<int, std::map<int, CDemuxStream*>::iterator> temp;
+  for (auto iter : m_stream_index)
+  {
+    unsigned int newIndex = offset + iter.first;
+    iter.second->second->iId = newIndex;
+    temp[newIndex] =  iter.second;
+  }
+  m_stream_index = temp;
+  return true;
+};

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.h
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.h
@@ -116,6 +116,8 @@ public:
 
   bool Aborted();
 
+  bool RenumberStreamIds(unsigned int offset);
+
   AVFormatContext* m_pFormatContext;
   CDVDInputStream* m_pInput;
 
@@ -146,7 +148,7 @@ protected:
 
   CCriticalSection m_critSection;
   std::map<int, CDemuxStream*> m_streams;
-  std::vector<std::map<int, CDemuxStream*>::iterator> m_stream_index;
+  std::map<int, std::map<int, CDemuxStream*>::iterator> m_stream_index;
 
   AVIOContext* m_ioContext;
 
@@ -168,5 +170,7 @@ protected:
 
   bool m_streaminfo;
   bool m_checkvideo;
+
+  unsigned int m_streamIdOffset = 0;
 };
 

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxMultiSource.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxMultiSource.cpp
@@ -1,0 +1,246 @@
+/*
+ *      Copyright (C) 2005-2015 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "DVDClock.h"
+#include "DVDDemuxMultiSource.h"
+#include "DVDDemuxUtils.h"
+#include "DVDFactoryDemuxer.h"
+#include "DVDInputStreams/DVDInputStream.h"
+#include "utils/log.h"
+
+
+CDVDDemuxMultiSource::CDVDDemuxMultiSource()
+{
+}
+
+CDVDDemuxMultiSource::~CDVDDemuxMultiSource()
+{
+  Dispose();
+}
+
+void CDVDDemuxMultiSource::Abort()
+{
+  for (auto iter : m_pDemuxers)
+    iter->Abort();
+}
+
+void CDVDDemuxMultiSource::Dispose()
+{
+  while (!m_demuxerQueue.empty())
+  {
+    m_demuxerQueue.pop();
+  }
+
+  m_streamIdToDemuxerMap.clear();
+  m_DemuxerToInputStreamMap.clear();
+  m_pDemuxers.clear();
+  m_currentDemuxer = NULL;
+  m_pInput = NULL;
+
+}
+
+void CDVDDemuxMultiSource::Flush()
+{
+  for (auto iter : m_pDemuxers)
+    iter->Flush();
+}
+
+int CDVDDemuxMultiSource::GetNrOfStreams()
+{
+  int streamsCount = 0;
+  for (auto iter : m_pDemuxers)
+    streamsCount += iter->GetNrOfStreams();
+
+  return streamsCount;
+}
+
+CDemuxStream* CDVDDemuxMultiSource::GetStream(int iStreamId)
+{
+  auto iter = m_streamIdToDemuxerMap.find(iStreamId);
+  if (iter != m_streamIdToDemuxerMap.end())
+  {
+    return iter->second->GetStream(iStreamId);
+  }
+  else
+    return NULL;
+}
+
+void CDVDDemuxMultiSource::GetStreamCodecName(int iStreamId, std::string &strName)
+{
+  auto iter = m_streamIdToDemuxerMap.find(iStreamId);
+  if (iter != m_streamIdToDemuxerMap.end())
+  {
+    iter->second->GetStreamCodecName(iStreamId, strName);
+  }
+};
+
+int CDVDDemuxMultiSource::GetStreamLength()
+{
+  int length = 0;
+  for (auto iter : m_pDemuxers)
+  {
+    length = std::max(length, iter->GetStreamLength());
+  }
+
+  return length;
+}
+
+bool CDVDDemuxMultiSource::Open(CDVDInputStream* pInput)
+{
+  if (!pInput || !pInput->IsStreamType(DVDSTREAM_TYPE_MULTIFILES))
+    return false;
+
+  m_pInput = dynamic_cast<CDVDInputStreamMultiSource*>(pInput);
+
+  if (!m_pInput)
+    return false;
+
+  auto iter = m_pInput->m_pInputStreams.begin();
+  while (iter != m_pInput->m_pInputStreams.end())
+  {
+    DemuxPtr demuxer = DemuxPtr(CDVDFactoryDemuxer::CreateDemuxer(iter->get()));
+    if (!demuxer)
+    {
+      iter = m_pInput->m_pInputStreams.erase(iter);
+    }
+    else
+    {
+      unsigned int offset = m_streamIdToDemuxerMap.size();
+      demuxer->RenumberStreamIds(offset);
+      m_DemuxerStreamsOffset[demuxer] = offset;
+      if (!UpdateStreamMap(demuxer))
+      {
+        iter = m_pInput->m_pInputStreams.erase(iter);
+        m_DemuxerStreamsOffset.erase(demuxer);
+        continue;
+      }
+
+      m_DemuxerToInputStreamMap[demuxer] = *iter;
+      m_pDemuxers.push_back(demuxer);
+      m_demuxerQueue.push(std::make_pair((double)DVD_NOPTS_VALUE, demuxer));
+      ++iter;
+    }
+  }
+  return !m_pDemuxers.empty();
+}
+
+bool CDVDDemuxMultiSource::RebuildStreamMap()
+{
+  auto iter = std::find(m_pDemuxers.begin(), m_pDemuxers.end(), m_currentDemuxer);
+  m_DemuxerToInputStreamMap.erase(m_DemuxerToInputStreamMap.find(m_currentDemuxer));
+  m_pDemuxers.erase(iter);
+  m_currentDemuxer = NULL;
+
+  // TODO: 
+  // - rebuild m_DemuxerStreamsOffset
+  // - rebuild m_streamIdToDemuxerMap
+
+  return true;
+}
+
+void CDVDDemuxMultiSource::Reset()
+{
+  for (auto iter : m_pDemuxers)
+    iter->Reset();
+}
+
+DemuxPacket* CDVDDemuxMultiSource::Read()
+{
+  if (m_demuxerQueue.empty())
+    return NULL;
+
+  m_currentDemuxer = m_demuxerQueue.top().second;
+  m_demuxerQueue.pop();
+
+  if (!m_currentDemuxer)
+    return NULL;
+
+  DemuxPacket* packet = m_currentDemuxer->Read();
+  if (packet)
+  {
+    // new stream?
+    if (m_streamIdToDemuxerMap.find(packet->iStreamId) == m_streamIdToDemuxerMap.end())
+    {
+      //UpdateStreamMap()
+    }
+  }
+  else
+  {
+    packet = CDVDDemuxUtils::AllocateDemuxPacket(0);
+    packet->iStreamId = DMX_SPECIALID_STREAMCHANGE;
+    return packet;
+  }
+
+  m_demuxerQueue.push(std::make_pair(packet->dts != DVD_NOPTS_VALUE ? packet->dts : packet->pts, m_currentDemuxer));
+
+  return packet;
+}
+
+bool CDVDDemuxMultiSource::SeekTime(int time, bool backwords, double* startpts)
+{
+  m_demuxerQueue = std::priority_queue < std::pair<double, DemuxPtr>, std::vector<std::pair<double, DemuxPtr>>, comparator >();
+  for (auto iter : m_pDemuxers)
+  {
+    if (iter->SeekTime(time, false, startpts))
+    {
+      m_demuxerQueue.push(std::make_pair((double)DVD_NOPTS_VALUE, iter));
+      CLog::Log(LOGDEBUG, "%s - starting demuxer from: %d", __FUNCTION__, time);
+    }
+    else
+    {
+      CLog::Log(LOGDEBUG, "%s - failed to start demuxing from: %d", __FUNCTION__, time);
+    }
+  }
+  return true;
+}
+
+bool CDVDDemuxMultiSource::UpdateStreamMap(DemuxPtr demuxer)
+{
+  if (!demuxer.get())
+    return false;
+
+  unsigned int offset = 0;
+  auto iter = m_DemuxerStreamsOffset.find(demuxer);
+  if (iter != m_DemuxerStreamsOffset.end())
+  {
+    offset = iter->second;
+  }
+  else
+  {
+    return false;
+  }
+
+  size_t count = m_streamIdToDemuxerMap.size();
+  for (int i = 0; i < demuxer->GetNrOfStreams(); ++i)
+  {
+
+    CDemuxStream* stream = demuxer->GetStream(offset + i);
+
+    if (!stream || m_streamIdToDemuxerMap.find(stream->iId) != m_streamIdToDemuxerMap.end())
+    {
+      CLog::Log(LOGNOTICE, "%s - abnormal steam mapping found,"
+                           "skipping demuxer for file %s.", __FUNCTION__, demuxer->GetFileName().c_str());
+      return false;
+    }
+    m_streamIdToDemuxerMap[stream->iId] = demuxer;
+  }
+
+  return m_streamIdToDemuxerMap.size() > count;
+}

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxMultiSource.h
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxMultiSource.h
@@ -1,0 +1,73 @@
+/*
+ *      Copyright (C) 2005-2015 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+#include "DVDDemux.h"
+#include "DVDInputStreams/DVDInputStreamMultiSource.h"
+
+#include <map>
+#include <queue>
+#include <string>
+#include <utility>
+#include <vector>
+
+typedef std::shared_ptr<CDVDDemux> DemuxPtr;
+
+struct comparator{
+  bool operator() (std::pair<double, DemuxPtr> x, std::pair<double, DemuxPtr> y) const
+  {
+    return x.first > y.first;
+  }
+};
+
+
+class CDVDDemuxMultiSource : public CDVDDemux
+{
+
+public:
+  CDVDDemuxMultiSource();
+  virtual ~CDVDDemuxMultiSource();
+  
+  void Abort();
+  void Flush();
+  virtual std::string GetFileName() { return ""; };
+  int GetNrOfStreams();
+  virtual CDemuxStream* GetStream(int iStreamId);
+  void GetStreamCodecName(int iStreamId, std::string &strName);
+  int GetStreamLength();
+  bool Open(CDVDInputStream* pInput);
+  DemuxPacket* Read();
+  void Reset();
+  bool SeekTime(int time, bool backwords = false, double* startpts = NULL);
+  virtual void SetSpeed(int iSpeed) {};
+
+private:
+  void Dispose();
+  bool RebuildStreamMap();
+  bool UpdateStreamMap(DemuxPtr demuxer);
+  
+  CDVDInputStreamMultiSource* m_pInput = NULL;
+  std::vector<DemuxPtr> m_pDemuxers;
+  DemuxPtr m_currentDemuxer = NULL;
+  std::map<DemuxPtr, InputStreamPtr> m_DemuxerToInputStreamMap;
+  std::priority_queue<std::pair<double, DemuxPtr>, std::vector<std::pair<double, DemuxPtr>>, comparator> m_demuxerQueue;
+  std::map<int, DemuxPtr> m_streamIdToDemuxerMap;
+  std::map<DemuxPtr, int> m_DemuxerStreamsOffset;
+};

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDFactoryDemuxer.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDFactoryDemuxer.cpp
@@ -32,6 +32,7 @@
 #include "DVDDemuxPVRClient.h"
 #include "pvr/PVRManager.h"
 #include "pvr/addons/PVRClients.h"
+#include "DVDDemuxMultiSource.h"
 
 using namespace std;
 using namespace PVR;
@@ -128,6 +129,16 @@ CDVDDemux* CDVDFactoryDemuxer::CreateDemuxer(CDVDInputStream* pInputStream, bool
   {
     bool useFastswitch = URIUtils::IsUsingFastSwitch(pInputStream->GetFileName());
     streaminfo = !useFastswitch;
+  }
+
+  // Try to open the MultiFiles demuxer
+  if (pInputStream->IsStreamType(DVDSTREAM_TYPE_MULTIFILES))
+  {
+    unique_ptr<CDVDDemuxMultiSource> demuxer(new CDVDDemuxMultiSource());
+    if (demuxer->Open(pInputStream))
+      return demuxer.release();
+    else
+      return NULL;
   }
 
   unique_ptr<CDVDDemuxFFmpeg> demuxer(new CDVDDemuxFFmpeg());

--- a/xbmc/cores/dvdplayer/DVDDemuxers/Makefile.in
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/Makefile.in
@@ -4,6 +4,7 @@ SRCS  = DVDDemux.cpp
 SRCS += DVDDemuxBXA.cpp
 SRCS += DVDDemuxCDDA.cpp
 SRCS += DVDDemuxFFmpeg.cpp
+SRCS += DVDDemuxMultiSource.cpp
 SRCS += DVDDemuxPVRClient.cpp
 SRCS += DVDDemuxShoutcast.cpp
 SRCS += DVDDemuxUtils.cpp

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDFactoryInputStream.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDFactoryInputStream.cpp
@@ -33,15 +33,29 @@
 #ifdef ENABLE_DVDINPUTSTREAM_STACK
 #include "DVDInputStreamStack.h"
 #endif
+#include "DVDInputStreamMultiSource.h"
 #include "FileItem.h"
 #include "storage/MediaManager.h"
 #include "URL.h"
 #include "filesystem/File.h"
 #include "utils/URIUtils.h"
+#include "Util.h"
 
 
-CDVDInputStream* CDVDFactoryInputStream::CreateInputStream(IDVDPlayer* pPlayer, const std::string& file, const std::string& content)
+CDVDInputStream* CDVDFactoryInputStream::CreateInputStream(IDVDPlayer* pPlayer, const std::string& file, const std::string& content, bool scanforextaudio)
 {
+  if (scanforextaudio)
+  {
+    // find any available external audio tracks
+    std::vector<std::string> filenames;
+    filenames.push_back(file);
+    CUtil::ScanForExternalAudio(file, filenames);
+    if (filenames.size() >= 2)
+    {
+      return CreateInputStream(pPlayer, filenames);
+    }
+  }
+
   CFileItem item(file.c_str(), false);
 
   if(item.IsDiscImage())
@@ -111,4 +125,9 @@ CDVDInputStream* CDVDFactoryInputStream::CreateInputStream(IDVDPlayer* pPlayer, 
 
   // our file interface handles all these types of streams
   return (new CDVDInputStreamFile());
+}
+
+CDVDInputStream* CDVDFactoryInputStream::CreateInputStream(IDVDPlayer* pPlayer, const std::vector<std::string>& filenames)
+{
+  return (new CDVDInputStreamMultiSource(pPlayer, filenames));
 }

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDFactoryInputStream.h
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDFactoryInputStream.h
@@ -21,6 +21,7 @@
  */
 
 #include <string>
+#include <vector>
 
 class CDVDInputStream;
 class IDVDPlayer;
@@ -28,5 +29,6 @@ class IDVDPlayer;
 class CDVDFactoryInputStream
 {
 public:
-  static CDVDInputStream* CreateInputStream(IDVDPlayer* pPlayer, const std::string& file, const std::string& content);
+  static CDVDInputStream* CreateInputStream(IDVDPlayer* pPlayer, const std::string& file, const std::string& content, bool scanforextaudio = false);
+  static CDVDInputStream* CreateInputStream(IDVDPlayer* pPlayer, const std::vector<std::string>& filenames);
 };

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStream.h
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStream.h
@@ -41,6 +41,7 @@ enum DVDStreamType
   DVDSTREAM_TYPE_MPLS   = 10,
   DVDSTREAM_TYPE_BLURAY = 11,
   DVDSTREAM_TYPE_PVRMANAGER = 12,
+  DVDSTREAM_TYPE_MULTIFILES = 13
 };
 
 #define SEEK_POSSIBLE 0x10 // flag used to check if protocol allows seeks

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamMultiSource.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamMultiSource.cpp
@@ -1,0 +1,137 @@
+/*
+ *      Copyright (C) 2005-2015 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "DVDInputStreamMultiSource.h"
+#include "DVDFactoryInputStream.h"
+#include "filesystem/File.h"
+#include "filesystem/IFile.h"
+#include "settings/AdvancedSettings.h"
+#include "utils/log.h"
+#include "utils/StringUtils.h"
+#include<map>
+
+using namespace XFILE;
+
+CDVDInputStreamMultiSource::CDVDInputStreamMultiSource(IDVDPlayer* pPlayer, const std::vector<std::string>& filenames) : CDVDInputStream(DVDSTREAM_TYPE_MULTIFILES),
+  m_pPlayer(pPlayer),
+  m_filenames(filenames)
+{
+}
+
+CDVDInputStreamMultiSource::~CDVDInputStreamMultiSource()
+{
+  Close();
+}
+
+void CDVDInputStreamMultiSource::Abort()
+{
+  for (auto iter : m_pInputStreams)
+    iter->Abort();
+}
+
+void CDVDInputStreamMultiSource::Close()
+{
+  m_pInputStreams.clear();
+  CDVDInputStream::Close();
+}
+
+BitstreamStats CDVDInputStreamMultiSource::GetBitstreamStats() const
+{
+  return m_stats;
+}
+
+int CDVDInputStreamMultiSource::GetBlockSize()
+{
+  return 0;
+}
+
+bool CDVDInputStreamMultiSource::GetCacheStatus(XFILE::SCacheStatus *status)
+{
+  return false;
+}
+
+int64_t CDVDInputStreamMultiSource::GetLength()
+{
+  int64_t length = 0;
+  for (auto iter : m_pInputStreams)
+  {
+    length = std::max(length, iter->GetLength());
+  }
+
+  return length;
+}
+
+bool CDVDInputStreamMultiSource::IsEOF()
+{
+  if (m_pInputStreams.empty())
+    return true;
+
+  for (auto iter : m_pInputStreams)
+  {
+    if (!(iter->IsEOF()))
+      return false;
+  }
+
+  return true;
+}
+
+bool CDVDInputStreamMultiSource::Open(const char* strFile, const std::string& content)
+{
+  if (!m_pPlayer || m_filenames.empty())
+    return false;
+
+  for (unsigned int i = 0, j = 0; i < m_filenames.size(); i++)
+  {
+    CFileItem fileitem = CFileItem(m_filenames[i]);
+    std::string filemimetype = fileitem.GetMimeType();
+    InputStreamPtr inputstream(CDVDFactoryInputStream::CreateInputStream(m_pPlayer, m_filenames[i], filemimetype));
+    if (!inputstream)
+    {
+      CLog::Log(LOGERROR, "CDVDPlayer::OpenInputStream - unable to create input stream for file [%s]", m_filenames[i].c_str());
+      continue;
+    }
+    else
+      inputstream->SetFileItem(fileitem);
+
+    if (!inputstream->Open(m_filenames[i].c_str(), filemimetype))
+    {
+      CLog::Log(LOGERROR, "CDVDPlayer::OpenInputStream - error opening file [%s]", m_filenames[i].c_str());
+      continue;
+    }
+    m_pInputStreams.push_back(inputstream);
+  }
+  return !m_pInputStreams.empty();
+}
+
+int CDVDInputStreamMultiSource::Read(uint8_t* buf, int buf_size)
+{
+  return -1;
+}
+
+int64_t CDVDInputStreamMultiSource::Seek(int64_t offset, int whence)
+{
+  return -1;
+}
+
+void CDVDInputStreamMultiSource::SetReadRate(unsigned rate)
+{
+  for (auto iter : m_pInputStreams)
+    iter->SetReadRate(rate);
+}

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamMultiSource.h
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamMultiSource.h
@@ -31,6 +31,8 @@ class IDVDPlayer;
 class CDVDInputStreamMultiSource : public CDVDInputStream
 {
 
+  friend class CDVDDemuxMultiSource;
+
 public:
   CDVDInputStreamMultiSource(IDVDPlayer* pPlayer, const std::vector<std::string>& filenames);
   virtual ~CDVDInputStreamMultiSource();

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamMultiSource.h
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamMultiSource.h
@@ -1,0 +1,55 @@
+#pragma once
+
+/*
+ *      Copyright (C) 2005-2015 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "DVDInputStream.h"
+
+#include <string>
+#include <vector>
+
+typedef std::shared_ptr<CDVDInputStream> InputStreamPtr;
+class IDVDPlayer;
+
+class CDVDInputStreamMultiSource : public CDVDInputStream
+{
+
+public:
+  CDVDInputStreamMultiSource(IDVDPlayer* pPlayer, const std::vector<std::string>& filenames);
+  virtual ~CDVDInputStreamMultiSource();
+
+  virtual void Abort();
+  virtual void Close();
+  virtual BitstreamStats GetBitstreamStats() const ;
+  virtual int GetBlockSize();
+  virtual bool GetCacheStatus(XFILE::SCacheStatus *status);
+  int64_t GetLength();
+  virtual bool IsEOF();
+  virtual bool Open(const char* strFile, const std::string &content);
+  virtual bool Pause(double dTime) { return false; };
+  virtual int Read(uint8_t* buf, int buf_size);
+  virtual int64_t Seek(int64_t offset, int whence);
+  virtual void SetReadRate(unsigned rate);
+
+protected:
+  IDVDPlayer* m_pPlayer;
+  std::vector<std::string> m_filenames;
+  std::vector<InputStreamPtr> m_pInputStreams;    // input streams for current playing file
+};

--- a/xbmc/cores/dvdplayer/DVDInputStreams/Makefile
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/Makefile
@@ -8,6 +8,7 @@ SRCS=	DVDFactoryInputStream.cpp \
 	DVDInputStreamFile.cpp \
 	DVDInputStreamHttp.cpp \
 	DVDInputStreamMemory.cpp \
+	DVDInputStreamMultiSource.cpp\
 	DVDInputStreamNavigator.cpp \
 	DVDInputStreamRTMP.cpp \
 	DVDInputStreamPVRManager.cpp \

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -724,7 +724,7 @@ bool CDVDPlayer::OpenInputStream()
     m_filename = g_mediaManager.TranslateDevicePath("");
   }
 
-  m_pInputStream = CDVDFactoryInputStream::CreateInputStream(this, m_filename, m_mimetype);
+  m_pInputStream = CDVDFactoryInputStream::CreateInputStream(this, m_filename, m_mimetype, true);
   if(m_pInputStream == NULL)
   {
     CLog::Log(LOGERROR, "CDVDPlayer::OpenInputStream - unable to create input stream for [%s]", m_filename.c_str());


### PR DESCRIPTION
@FernetMenta 
Still a bit work to do, therefore RFC. Please ignore the [Util] changes.

**_Reading from demuxers:_**

The available demuxers are organized via a min heap. The sorting criteria is the dts or pts of the last packet they had delivered. The top demuxer in that heap is selected for reading.

**_Organizing the streams:_**

Unfortunately this does not work out of the box because each demuxer d_i numbers its streams from 0 to n_i, but the dvdplayer numbers them from 0 to sum_i(n_i). Hence the dvdplayer can't determine if the current packet should be forwarded to the audio/video player (because of the stream id mismatch). There are two solutions I can think of.  First we could copy the streams and collected them in the multi source demuxer. This is less future-proof and less efficient imo.I have implemented that as a poc here: https://github.com/xbmc/xbmc/compare/master...ace20022:ext3

The second one is presented by this pr. The streams of the demuxers are renumbered so that the ids match the ids of the dvdplayer. 
Before I put more work into it, which solution is preferable, or is there an even better one?
