### PR TITLE
[addons] fix toast dialog showing wrong icon on install errors

### DIFF
--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -257,7 +257,7 @@ bool CAddonInstaller::InstallFromZip(const std::string &path)
   CURL zipDir = URIUtils::CreateArchivePath("zip", pathToUrl, "");
   if (!CDirectory::GetDirectory(zipDir, items) || items.Size() != 1 || !items[0]->m_bIsFolder)
   {
-    CGUIDialogKaiToast::QueueNotification("", path, g_localizeStrings.Get(24045), TOAST_DISPLAY_TIME, false);
+    CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, g_localizeStrings.Get(24045), path, TOAST_DISPLAY_TIME, false);
     return false;
   }
 
@@ -276,7 +276,7 @@ bool CAddonInstaller::InstallFromZip(const std::string &path)
     return DoInstall(addon);
   }
 
-  CGUIDialogKaiToast::QueueNotification("", path, g_localizeStrings.Get(24045), TOAST_DISPLAY_TIME, false);
+  CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, g_localizeStrings.Get(24045), path, TOAST_DISPLAY_TIME, false);
   return false;
 }
 


### PR DESCRIPTION
This fixes an issue where the previous addon icon is shown in the toast dialog whenever an addon can't be installed due to wrong structure.

Note, this is not fixing the root cause since `m_defaultIcon` in GUIDialogKaiToast.cpp is not cleared properly. I have no idea what the intention was to fill the default icon from the GuiMessage label. Anyone?

/cc @MartijnKaijser, @Montellese, @tamland 
