### PR TITLE
[win32] Fix crash after 8e1f62cc1b80918d723edc40e7b2a903cbef96e2 due …

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1107,7 +1107,7 @@ void CApplication::CreateUserDirs()
 
 bool CApplication::Initialize()
 {
-#if defined(HAS_DVD_DRIVE)
+#if defined(HAS_DVD_DRIVE) && !defined(TARGET_WINDOWS) // somehow this throws an "unresolved external symbol" on win32
   // turn off cdio logging
   cdio_loglevel_default = CDIO_LOG_ERROR;
 #endif


### PR DESCRIPTION
…to cdio logging.

thx @Voyager1 !
