### PR TITLE
fix kaitoast dialog loading the previous icon instead of the default …

### DIFF
--- a/xbmc/dialogs/GUIDialogKaiToast.cpp
+++ b/xbmc/dialogs/GUIDialogKaiToast.cpp
@@ -71,7 +71,8 @@ void CGUIDialogKaiToast::OnWindowLoaded()
 {
   CGUIDialog::OnWindowLoaded();
   CGUIMessage msg(GUI_MSG_GET_FILENAME, GetID(), POPUP_ICON);
-  m_defaultIcon = msg.GetLabel();
+  if (OnMessage(msg))
+    m_defaultIcon = msg.GetLabel();
 }
 
 void CGUIDialogKaiToast::QueueNotification(eMessageType eType, const std::string& aCaption, const std::string& aDescription, unsigned int displayTime /*= TOAST_DISPLAY_TIME*/, bool withSound /*= true*/, unsigned int messageTime /*= TOAST_MESSAGE_TIME*/)
@@ -134,20 +135,22 @@ bool CGUIDialogKaiToast::DoWork()
 
       if (strTypeImage.empty())
       {
-        int imageControl = POPUP_ICON;
-
-        if (toast.eType == Info)
-          imageControl = POPUP_ICON_INFO;
-        else if (toast.eType == Warning)
-          imageControl = POPUP_ICON_WARNING;
-        else if (toast.eType == Error)
-          imageControl = POPUP_ICON_ERROR;
-
-        CGUIMessage msg(GUI_MSG_GET_FILENAME, GetID(), imageControl);
-        if (OnMessage(msg))
-          strTypeImage = msg.GetLabel();
-        else
+        if (toast.eType == Default)
           strTypeImage = m_defaultIcon;
+        else
+        {
+          int imageControl = -1;
+          if (toast.eType == Info)
+            imageControl = POPUP_ICON_INFO;
+          else if (toast.eType == Warning)
+            imageControl = POPUP_ICON_WARNING;
+          else if (toast.eType == Error)
+            imageControl = POPUP_ICON_ERROR;
+
+          CGUIMessage msg(GUI_MSG_GET_FILENAME, GetID(), imageControl);
+          if (OnMessage(msg))
+            strTypeImage = msg.GetLabel();
+        }
       }
 
       SET_CONTROL_FILENAME(POPUP_ICON, strTypeImage);


### PR DESCRIPTION
…when no icon or type is passed. Bad refactoring in 3d4e2760b07c7f0d83b33c97cc9c60d50fb5894c
