### PR TITLE
Cleanup kai toast icons

### DIFF
--- a/addons/skin.confluence/720p/DialogKaiToast.xml
+++ b/addons/skin.confluence/720p/DialogKaiToast.xml
@@ -24,7 +24,6 @@
 				<width>50</width>
 				<height>50</height>
 				<aspectratio>keep</aspectratio>
-				<texture>DefaultFile.png</texture>
 			</control>
 			<control type="fadelabel" id="401">
 				<description>Line 1 Label</description>
@@ -51,36 +50,6 @@
 				<aligny>center</aligny>
 				<scrollout>false</scrollout>
 				<pauseatend>2000</pauseatend>
-			</control>
-			<control type="image" id="403">
-				<description>avatar</description>
-				<left>20</left>
-				<top>10</top>
-				<width>50</width>
-				<height>50</height>
-				<aspectratio>keep</aspectratio>
-				<visible>false</visible>
-				<texture>DefaultIconInfo.png</texture>
-			</control>
-			<control type="image" id="404">
-				<description>avatar</description>
-				<left>20</left>
-				<top>10</top>
-				<width>50</width>
-				<height>50</height>
-				<aspectratio>keep</aspectratio>
-				<visible>false</visible>
-				<texture>DefaultIconWarning.png</texture>
-			</control>
-			<control type="image" id="405">
-				<description>avatar</description>
-				<left>20</left>
-				<top>10</top>
-				<width>50</width>
-				<height>50</height>
-				<aspectratio>keep</aspectratio>
-				<visible>false</visible>
-				<texture>DefaultIconError.png</texture>
 			</control>
 		</control>
 	</controls>

--- a/xbmc/dialogs/GUIDialogKaiToast.cpp
+++ b/xbmc/dialogs/GUIDialogKaiToast.cpp
@@ -27,9 +27,6 @@
 #define POPUP_ICON                400
 #define POPUP_CAPTION_TEXT        401
 #define POPUP_NOTIFICATION_BUTTON 402
-#define POPUP_ICON_INFO           403
-#define POPUP_ICON_WARNING        404
-#define POPUP_ICON_ERROR          405
 
 CGUIDialogKaiToast::TOASTQUEUE CGUIDialogKaiToast::m_notifications;
 CCriticalSection CGUIDialogKaiToast::m_critical;
@@ -65,14 +62,6 @@ bool CGUIDialogKaiToast::OnMessage(CGUIMessage& message)
     break;
   }
   return CGUIDialog::OnMessage(message);
-}
-
-void CGUIDialogKaiToast::OnWindowLoaded()
-{
-  CGUIDialog::OnWindowLoaded();
-  CGUIMessage msg(GUI_MSG_GET_FILENAME, GetID(), POPUP_ICON);
-  if (OnMessage(msg))
-    m_defaultIcon = msg.GetLabel();
 }
 
 void CGUIDialogKaiToast::QueueNotification(eMessageType eType, const std::string& aCaption, const std::string& aDescription, unsigned int displayTime /*= TOAST_DISPLAY_TIME*/, bool withSound /*= true*/, unsigned int messageTime /*= TOAST_MESSAGE_TIME*/)
@@ -131,29 +120,17 @@ bool CGUIDialogKaiToast::DoWork()
 
     // set the appropriate icon
     {
-      std::string strTypeImage = toast.imagefile;
-
-      if (strTypeImage.empty())
+      std::string icon = toast.imagefile;
+      if (icon.empty())
       {
-        if (toast.eType == Default)
-          strTypeImage = m_defaultIcon;
+        if (toast.eType == Warning)
+          icon = "DefaultIconWarning.png";
+        else if (toast.eType == Error)
+          icon = "DefaultIconError.png";
         else
-        {
-          int imageControl = -1;
-          if (toast.eType == Info)
-            imageControl = POPUP_ICON_INFO;
-          else if (toast.eType == Warning)
-            imageControl = POPUP_ICON_WARNING;
-          else if (toast.eType == Error)
-            imageControl = POPUP_ICON_ERROR;
-
-          CGUIMessage msg(GUI_MSG_GET_FILENAME, GetID(), imageControl);
-          if (OnMessage(msg))
-            strTypeImage = msg.GetLabel();
-        }
+          icon = "DefaultIconInfo.png";
       }
-
-      SET_CONTROL_FILENAME(POPUP_ICON, strTypeImage);
+      SET_CONTROL_FILENAME(POPUP_ICON, icon);
     }
 
     //  Play the window specific init sound for each notification queued

--- a/xbmc/dialogs/GUIDialogKaiToast.cpp
+++ b/xbmc/dialogs/GUIDialogKaiToast.cpp
@@ -71,7 +71,8 @@ void CGUIDialogKaiToast::OnWindowLoaded()
 {
   CGUIDialog::OnWindowLoaded();
   CGUIMessage msg(GUI_MSG_GET_FILENAME, GetID(), POPUP_ICON);
-  m_defaultIcon = msg.GetLabel();
+  if (OnMessage(msg))
+    m_defaultIcon = msg.GetLabel();
 }
 
 void CGUIDialogKaiToast::QueueNotification(eMessageType eType, const std::string& aCaption, const std::string& aDescription, unsigned int displayTime /*= TOAST_DISPLAY_TIME*/, bool withSound /*= true*/, unsigned int messageTime /*= TOAST_MESSAGE_TIME*/)
@@ -134,20 +135,22 @@ bool CGUIDialogKaiToast::DoWork()
 
       if (strTypeImage.empty())
       {
-        int imageControl = POPUP_ICON;
-
-        if (toast.eType == Info)
-          imageControl = POPUP_ICON_INFO;
-        else if (toast.eType == Warning)
-          imageControl = POPUP_ICON_WARNING;
-        else if (toast.eType == Error)
-          imageControl = POPUP_ICON_ERROR;
-
-        CGUIMessage msg(GUI_MSG_GET_FILENAME, GetID(), imageControl);
-        if (OnMessage(msg))
-          strTypeImage = msg.GetLabel();
-        else
+        if (toast.eType == Default)
           strTypeImage = m_defaultIcon;
+        else
+        {
+          int imageControl = -1;
+          if (toast.eType == Info)
+            imageControl = POPUP_ICON_INFO;
+          else if (toast.eType == Warning)
+            imageControl = POPUP_ICON_WARNING;
+          else if (toast.eType == Error)
+            imageControl = POPUP_ICON_ERROR;
+
+          CGUIMessage msg(GUI_MSG_GET_FILENAME, GetID(), imageControl);
+          if (OnMessage(msg))
+            strTypeImage = msg.GetLabel();
+        }
       }
 
       SET_CONTROL_FILENAME(POPUP_ICON, strTypeImage);

--- a/xbmc/dialogs/GUIDialogKaiToast.h
+++ b/xbmc/dialogs/GUIDialogKaiToast.h
@@ -54,7 +54,6 @@ public:
   bool DoWork();
 
   virtual bool OnMessage(CGUIMessage& message);
-  virtual void OnWindowLoaded();
   virtual void FrameMove();
   void ResetTimer();
 
@@ -65,8 +64,6 @@ protected:
 
   unsigned int m_toastDisplayTime;
   unsigned int m_toastMessageTime;
-
-  std::string m_defaultIcon;
   
   static TOASTQUEUE m_notifications;
   static CCriticalSection m_critical;


### PR DESCRIPTION
@mkortstiege while we're at it, I don't see why this has to be so complicated.

This replaces control 403, 404 and 405 with the predefined names `DefaultIconError.png`, `DefaultIconWarning.png` and `DefaultIconInfo.png` as we already do with other images.

Is there any reason these controls exist other than for skins to define the image name?
