### PR TITLE
[strings] info -> information

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -11059,7 +11059,7 @@ msgid "Change content"
 msgstr ""
 
 msgctxt "#20443"
-msgid "Do you want to refresh info for all items within this path?"
+msgid "Do you want to refresh information for all items within this path?"
 msgstr ""
 
 #empty string id 20444


### PR DESCRIPTION
@MartijnKaijser 

https://github.com/xbmc/xbmc/pull/7111 at https://github.com/MartijnKaijser/xbmc/commit/3105de70d9ec7e3927ca00427d1ec310bcb3e204#diff-1662af1d5461440bf3871a2e8d053e10L11060 reverted one previous wording strings fixups

All references to "info" were changed to information where messages in dialogue boxes except the one context menu entry.
