### PR TITLE
cximage: Fix dcraw input sanitization (CVE-2015-3885)

### DIFF
--- a/lib/cximage-6.0/raw/dcraw.c
+++ b/lib/cximage-6.0/raw/dcraw.c
@@ -820,7 +820,8 @@ struct jhead {
 
 int CLASS ljpeg_start (struct jhead *jh, int info_only)
 {
-  int c, tag, len;
+  int c, tag;
+  ushort len;
   uchar data[0x10000], *dp;
 
   init_decoder();

--- a/lib/cximage-6.0/raw/libdcr.c
+++ b/lib/cximage-6.0/raw/libdcr.c
@@ -783,7 +783,8 @@ enough to decode Canon, Kodak and Adobe DNG images.
 
 int DCR_CLASS dcr_ljpeg_start (DCRAW* p, struct dcr_jhead *jh, int info_only)
 {
-	int c, tag, len;
+	int c, tag;
+	ushort len;
 	uchar data[0x10000], *dp;
 
 	dcr_init_decoder(p);


### PR DESCRIPTION
From http://www.ocert.org/advisories/ocert-2015-006.html :
The dcraw tool, as well as several other projects re-using its code,
suffers from an integer overflow condition which lead to a buffer
overflow. The vulnerability concerns the 'len' variable, parsed
without validation from opened images, used in the ljpeg_start()
function.
A maliciously crafted raw image file can be used to trigger the
vulnerability, causing a Denial of Service condition.

Build-tested on Debian Jessie, public exploit to test with is not available AFAIK.
