### PR TITLE
UPnP: fix playcount and watched state of tvshows and seasons

### DIFF
--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -990,7 +990,7 @@ CFileItemPtr BuildObject(PLT_MediaObject* entry,
       pItem->SetProperty("numepisodes", episodes);
       pItem->SetProperty("watchedepisodes", played);
       pItem->SetProperty("unwatchedepisodes", episodes - played);
-      watched = (episodes && played == episodes);
+      watched = (episodes && played >= episodes);
     }
     else if (type == MediaTypeEpisode || type == MediaTypeMovie)
       watched = (played > 0);

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -991,6 +991,7 @@ CFileItemPtr BuildObject(PLT_MediaObject* entry,
       pItem->SetProperty("watchedepisodes", played);
       pItem->SetProperty("unwatchedepisodes", episodes - played);
       watched = (episodes && played >= episodes);
+      pItem->GetVideoInfoTag()->m_playCount = watched ? 1 : 0;
     }
     else if (type == MediaTypeEpisode || type == MediaTypeMovie)
       watched = (played > 0);


### PR DESCRIPTION
These two commits fix two issues with the playcount and watched state of tvshows and seasons from a UPnP server:
- the watched overlay isn't displayed properly if the total playcount of all episodes is bigger than the total number of episodes
- tvshows with a single watched episode are considered watched and are therefore hidden when using "Hide watched"
