### PR TITLE
[pvr] fix CPVRDirectory::Exists always returns false (fixes 15997)

### DIFF
--- a/xbmc/filesystem/PVRDirectory.cpp
+++ b/xbmc/filesystem/PVRDirectory.cpp
@@ -45,7 +45,10 @@ CPVRDirectory::~CPVRDirectory()
 
 bool CPVRDirectory::Exists(const CURL& url)
 {
-  return (url.IsProtocol("pvr") && url.GetHostName() == "recordings");
+  if (!g_PVRManager.IsStarted())
+    return false;
+
+  return (url.IsProtocol("pvr") && StringUtils::StartsWith(url.GetFileName(), "recordings"));
 }
 
 bool CPVRDirectory::GetDirectory(const CURL& url, CFileItemList &items)


### PR DESCRIPTION
This fixes the reported issue http://trac.kodi.tv/ticket/15997

> After adding pvr://recordings/Films as a Video files directory (pvr.mythtv) using "The Movie Database" as a scraper, updating the video database using XBMC Library Auto Updater was intermittent (i.e. mostly fails), only working when the recordings/Films directory was open in the background (I have a remote key bound to 'Home').
> 
> Investigating the debug log showed the following entry when requesting an immediate scan via XBMC Library Auto Updater without the recordings/Films directory open in the background: "Process directory 'pvr://recordings/Films/' does not exist - skipping scan."
> 
> Investigating VideoInfoScanner.cpp and filesystem/Directory.cpp highlighted this occurs when the directory isn't already in cache resulting in a call to CPVRDirectory::Exists.
> 
> Unfortunately CURL::Parse on line 292 of xbmc/URL.cpp deliberately sets m_strHostName = "" if the protocol is iso9660, musicdb, videodb, sources or pvr which is what GetHostName() returns. 
