### PR TITLE
[pvr] fix incorrect usage of string on PVR backend error

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -7982,6 +7982,7 @@ msgid "Channel icons"
 msgstr ""
 
 #: xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
+#: xbmc/pvr/timers/PVRTimerInfoTag.cpp
 msgctxt "#19067"
 msgid "This event is already being recorded."
 msgstr ""
@@ -8162,11 +8163,13 @@ msgctxt "#19109"
 msgid "Couldn't save timer.[CR]Check the log for more information about this message."
 msgstr ""
 
+#: xbmc/pvr/timers/PVRTimerInfoTag.cpp
 msgctxt "#19110"
 msgid "An unexpected error occurred.[CR]Try again later or check the log for more information."
 msgstr ""
 
 #: xbmc/pvr/addons/PVRClients.cpp
+#: xbmc/pvr/timers/PVRTimerInfoTag.cpp
 msgctxt "#19111"
 msgid "PVR backend error.[CR]Check the log for more information about this message."
 msgstr ""

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -398,13 +398,13 @@ bool CPVRTimerInfoTag::UpdateOnClient()
 void CPVRTimerInfoTag::DisplayError(PVR_ERROR err) const
 {
   if (err == PVR_ERROR_SERVER_ERROR)
-    CGUIDialogOK::ShowAndGetInput(19033,19111,19110,0); /* print info dialog "Server error!" */
+    CGUIDialogOK::ShowAndGetInput(19033, 19111, -1, -1); /* print info dialog "Server error!" */
   else if (err == PVR_ERROR_REJECTED)
-    CGUIDialogOK::ShowAndGetInput(19033,19109,19110,0); /* print info dialog "Couldn't delete timer!" */
+    CGUIDialogOK::ShowAndGetInput(19033, 19109, -1, -1); /* print info dialog "Couldn't save timer!" */
   else if (err == PVR_ERROR_ALREADY_PRESENT)
-    CGUIDialogOK::ShowAndGetInput(19033,19109,0,19067); /* print info dialog */
+    CGUIDialogOK::ShowAndGetInput(19033, 19067, -1, -1); /* print info dialog */
   else
-    CGUIDialogOK::ShowAndGetInput(19033,19147,19110,0); /* print info dialog "Unknown error!" */
+    CGUIDialogOK::ShowAndGetInput(19033, 19110, -1, -1); /* print info dialog "Unknown error!" */
 }
 
 void CPVRTimerInfoTag::SetEpgInfoTag(CEpgInfoTagPtr &tag)


### PR DESCRIPTION
@xhaggi @negge could you please comment on this?
To me the used strings in these dialogs are either redundant or incorrect

Edit:
Same here https://github.com/xbmc/xbmc/blob/master/xbmc/pvr/recordings/PVRRecording.cpp#L318
