### PR TITLE
[guilib] use textcolor from labelInfo for textboxes

### DIFF
--- a/xbmc/guilib/GUITextBox.cpp
+++ b/xbmc/guilib/GUITextBox.cpp
@@ -240,6 +240,7 @@ void CGUITextBox::Render()
     {
       m_font->Begin();
       int current = offset;
+      m_colors.push_back(m_textColor);
       while (posY < m_posY + m_renderHeight && current < (int)m_lines.size())
       {
         uint32_t align = alignment;


### PR DESCRIPTION
Fixes non-working `<textcolor>` in textboxes. Reported @ http://forum.kodi.tv/showthread.php?tid=228187

@BigNoid, @ronie for review please. You guys think this is Isengard material?
