### PR TITLE
add Skin.ToggleDebug function

### DIFF
--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -575,6 +575,11 @@ void CSkinInfo::SettingOptionsStartupWindowsFiller(const CSetting *setting, std:
     current = list[0].second;
 }
 
+void CSkinInfo::ToggleDebug()
+{
+  m_debugging = !m_debugging;
+}
+
 int CSkinInfo::TranslateString(const string &setting)
 {
   // run through and see if we have this setting

--- a/xbmc/addons/Skin.h
+++ b/xbmc/addons/Skin.h
@@ -169,6 +169,7 @@ public:
   const std::string& GetCurrentAspect() const { return m_currentAspect; }
 
   void LoadIncludes();
+  void ToggleDebug();
   const INFO::CSkinVariableString* CreateSkinVariable(const std::string& name, int context);
 
   static void SettingOptionsSkinColorsFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data);

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -48,6 +48,7 @@
 #include "addons/AddonInstaller.h"
 #include "addons/AddonManager.h"
 #include "addons/PluginSource.h"
+#include "addons/Skin.h"
 #include "interfaces/generic/ScriptInvocationManager.h"
 #include "interfaces/AnnouncementManager.h"
 #include "network/NetworkServices.h"
@@ -171,6 +172,7 @@ const BUILT_IN commands[] = {
   { "PlayDVD",                    false,  "Plays the inserted CD or DVD media from the DVD-ROM Drive!" },
   { "RipCD",                      false,  "Rip the currently inserted audio CD"},
   { "Skin.ToggleSetting",         true,   "Toggles a skin setting on or off" },
+  { "Skin.ToggleDebug",           false,  "Toggles skin debug info on or off" },
   { "Skin.SetString",             true,   "Prompts and sets skin string" },
   { "Skin.SetNumeric",            true,   "Prompts and sets numeric input" },
   { "Skin.SetPath",               true,   "Prompts and sets a skin path" },
@@ -1466,6 +1468,10 @@ int CBuiltins::Execute(const std::string& execString)
       CSkinSettings::Get().SetString(string, result);
       CSettings::Get().Save();
     }
+  }
+  else if (execute == "skin.toggledebug")
+  {
+    g_SkinInfo->ToggleDebug();
   }
   else if (execute == "dialog.close" && params.size())
   {


### PR DESCRIPTION
currently skins can only activate the display of skin debug info by modifying their addon.xml (debugging="true") and restarting kodi.
this adds a build-in function to toggle the info on/off on the fly. 

@mkortstiege please have a look if this is acceptable code-wise.
