### PR TITLE
[gui] render dialog teletext always on top

### DIFF
--- a/xbmc/video/dialogs/GUIDialogTeletext.cpp
+++ b/xbmc/video/dialogs/GUIDialogTeletext.cpp
@@ -34,8 +34,8 @@ static int teletextFadeAmount = 0;
 CGUIDialogTeletext::CGUIDialogTeletext()
     : CGUIDialog(WINDOW_DIALOG_OSD_TELETEXT, "")
 {
-  m_isDialog    = false;
   m_pTxtTexture = NULL;
+  m_renderOrder = INT_MAX - 3;
 }
 
 CGUIDialogTeletext::~CGUIDialogTeletext()


### PR DESCRIPTION
Skins like Xperience1080 use a zorder e.g. 2 in `DialogVideoOSD.xml` and therefore the `CGUIDialogTeletext` isn't rendered at top. This will fix the issue by setting the render order to `INT_MAX - 3` for `CGUIDialogTeletext` (behind window debug info `INT_MAX - 2` and window pointer `INT_MAX - 1`). Keep in mind that dialog teletext is a special dialog with no corresponding skin XML.

@Montellese or someone else mind taking a look.
