### PR TITLE
add the option to conditionally include files

### DIFF
--- a/xbmc/guilib/GUIIncludes.cpp
+++ b/xbmc/guilib/GUIIncludes.cpp
@@ -146,8 +146,21 @@ bool CGUIIncludes::LoadIncludesFromXML(const TiXmlElement *root)
         m_includes.insert({ tagName, { *includeBody, std::move(defaultParams) } });
     }
     else if (node->Attribute("file"))
-    { // load this file in as well
-      LoadIncludes(g_SkinInfo->GetSkinPath(node->Attribute("file")));
+    { 
+      const char *condition = node->Attribute("condition");
+      if (condition)
+      { // check this condition
+        INFO::InfoPtr conditionID = g_infoManager.Register(condition);
+        bool value = conditionID->Get();
+
+        if (value)
+        {
+          // load this file in as well
+          LoadIncludes(g_SkinInfo->GetSkinPath(node->Attribute("file")));
+        }
+      }
+      else
+        LoadIncludes(g_SkinInfo->GetSkinPath(node->Attribute("file")));
     }
     node = node->NextSiblingElement("include");
   }


### PR DESCRIPTION
allow skinners to conditionally include a file:
`<include condition="StringCompare(Skin.AspectRatio,16:9)" file="ViewsAddonBrowser.xml" />`
`<include condition="StringCompare(Skin.AspectRatio,4:3)" file="ViewsAddonBrowser-4x3.xml" />`

this will make it a lot easier for skins to support multiple aspect-ratios (for instance the re-touched skin).

another use case might be to include platform specific files:
`<include condition="System.Platform.Android" file="customAndroidSettings.xml" />`
