### PR TITLE
Curl improvements

### DIFF
--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -1595,11 +1595,33 @@ bool CCurlFile::CReadState::FillBuffer(unsigned int want)
 
         do
         {
-          unsigned int time_left = endTime.MillisLeft();
-          struct timeval t = { (int)time_left / 1000, ((int)time_left % 1000) * 1000 };
-
-          // Wait until data is available or a timeout occurs.
-          rc = select(maxfd + 1, &fdread, &fdwrite, &fdexcep, &t);
+          /* On success the value of maxfd is guaranteed to be >= -1. We call
+           * select(maxfd + 1, ...); specially in case of (maxfd == -1) there are
+           * no fds ready yet so we call select(0, ...) --or Sleep() on Windows--
+           * to sleep 100ms, which is the minimum suggested value in the
+           * curl_multi_fdset() doc.
+           */
+          if (maxfd == -1)
+          {
+#ifdef TARGET_WINDOWS
+            /* Windows does not support using select() for sleeping without a dummy
+             * socket. Instead use Windows' Sleep() and sleep for 100ms which is the
+             * minimum suggested value in the curl_multi_fdset() doc.
+             */
+            Sleep(100);
+            rc = 0;
+#else
+            /* Portable sleep for platforms other than Windows. */
+            struct timeval wait = { 0, 100 * 1000 }; /* 100ms */
+            rc = select(0, NULL, NULL, NULL, &wait);
+#endif
+          }
+          else
+          {
+            unsigned int time_left = endTime.MillisLeft();
+            struct timeval wait = { (int)time_left / 1000, ((int)time_left % 1000) * 1000 };
+            rc = select(maxfd + 1, &fdread, &fdwrite, &fdexcep, &wait);
+          }
 #ifdef TARGET_WINDOWS
         } while(rc == SOCKET_ERROR && WSAGetLastError() == WSAEINTR);
 #else

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -1560,6 +1560,9 @@ bool CCurlFile::CReadState::FillBuffer(unsigned int want)
 
         CLog::Log(LOGNOTICE, "CCurlFile::FillBuffer - Reconnect, (re)try %i", retry);
 
+        // Progressive sleep. TODO: Find a better optimum for this?
+        Sleep( (retry - 1) * 1000);
+
         // Connect + seek to current position (again)
         SetResume();
         g_curlInterface.multi_add_handle(m_multiHandle, m_easyHandle);


### PR DESCRIPTION
This PR syncs our select/sleep handling for Curl with upstream. Apparently this never worked properly on at least Windows. Furthermore I added a change where we Sleep between Curl retries as this may increase the chances of a successful recovery in several scenarios (I'm still looking for an optimum here, in case other people have a better idea, please speak up :-)).
