### PR TITLE
Revert "[Fix][subs] Don't try to read a vob sub file without a corres…

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -4388,8 +4388,6 @@ int CDVDPlayer::AddSubtitleFile(const std::string& filename, const std::string& 
     std::string vobsubidx = CUtil::GetVobSubIdxFromSub(filename);
     if (!vobsubidx.empty())
       return AddSubtitleFile(vobsubidx, filename);
-    else
-      return -1;
   }
   SelectionStream s;
   s.source   = m_SelectionStreams.Source(STREAM_SOURCE_TEXT, filename);


### PR DESCRIPTION
…ponding idx file."

This reverts commit 37588c95a88c9e970268e0ffb8ddf4ae4024938b.

This broke MicroDVD subtitles that also uses the ".sub" extension.
