### PR TITLE
revert ecea1fff0

### DIFF
--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -537,7 +537,7 @@ void CUtil::GetDVDDriveIcon(const std::string& strPath, std::string& strIcon)
 
   if ( URIUtils::IsDVD(strPath) )
   {
-    strIcon = "defaultDVDFull.png";
+    strIcon = "DefaultDVDRom.png";
     return ;
   }
 

--- a/xbmc/filesystem/SourcesDirectory.cpp
+++ b/xbmc/filesystem/SourcesDirectory.cpp
@@ -90,7 +90,7 @@ bool CSourcesDirectory::GetDirectory(const VECSOURCES &sources, CFileItemList &i
     else if (pItem->IsISO9660())
       strIcon = "DefaultDVDRom.png";
     else if (pItem->IsDVD())
-      strIcon = "defaultDVDFull.png";
+      strIcon = "DefaultDVDRom.png";
     else if (pItem->IsCDDA())
       strIcon = "DefaultCDDA.png";
     else if (pItem->IsRemovable() && g_TextureManager.HasTexture("DefaultRemovableDisk.png"))


### PR DESCRIPTION
No idea why this breaks anything but there you are

@ronie asked for this revert @  https://github.com/xbmc/xbmc/pull/6829#issuecomment-107155817

I would like to know if defaultDVDFull.png is suppose to be uppercase DefaultDVDFull.png and if thats the reason why this supposedly fails.
**_It would be nice if someone explained why this breaks anything as the icon defaultDVDFull.png has existed since forever as is and according to history its always been lowercase.**_

I tried fixing the uppercase but @da-anda said no that this would break other skins.

So after isengard is branched Ill revert this again and make file defaultDVDFull.png uppercase
