### PR TITLE
[PVR] Fix crash in PVR::CPVRClient::GetDriveSpace (Trac #15942)

### DIFF
--- a/xbmc/pvr/PVRGUIInfo.cpp
+++ b/xbmc/pvr/PVRGUIInfo.cpp
@@ -706,6 +706,16 @@ void CPVRGUIInfo::UpdateBackendCache(void)
   PVR_CLIENTMAP activeClients;
   iActiveClients = clients->GetConnectedClients(activeClients);
 
+  {
+    CSingleLock lock(m_critSection);
+    if (m_iAddonInfoToggleCurrent >= iActiveClients)
+    {
+      // Number of connected clients decreased since last call.
+      // Current toggle position now points after end of iActiveClients!
+      m_iAddonInfoToggleCurrent = 0;
+    }
+  }
+
   if (iActiveClients > 1 && !AddonInfoToggle())
     return;
 


### PR DESCRIPTION
I'm not 100% sure about the root cause, but the various stack traces I got show that the CPVRClient instance on which GetDriveSpace gets called is NULL. Thus, my simple fix should prevent the crash.

Root cause could be a multithreading issue. One piece of code looks suspicious to me: 

<pre>
CSingleLock lock(m_critSection);
 ...
  {
    unsigned int iPrevious = m_iAddonInfoToggleCurrent;
    if (((int) ++m_iAddonInfoToggleCurrent) > m_iActiveClients - 1)
      m_iAddonInfoToggleCurrent = 0;
</pre>


For a short moment m_iAddonInfoToggleCurrent can have a value that is too large.

This piece of code reads m_iAddonInfoToggleCurrent without a mutex.

<pre>
/* safe to read unlocked */
    for (unsigned int i = 0; i < m_iAddonInfoToggleCurrent; i++)
      activeClient++;

    if (activeClient->second->GetDriveSpace(&iBackendkBTotal, &iBackendkBUsed) == PVR_ERROR_NO_ERROR)
</pre>


So far so bad, activeClient might point activeClients.end() due to the potential multithreading issue here. But I was unable to actually find out the use case where the writing code runs in another thread than the reading code... strange.

@opdenkamp mind taking a look?
