### PR TITLE
[binary addons] bump audio decoders

### DIFF
--- a/project/cmake/addons/addons/audiodecoder.modplug/audiodecoder.modplug.txt
+++ b/project/cmake/addons/addons/audiodecoder.modplug/audiodecoder.modplug.txt
@@ -1,1 +1,1 @@
-audiodecoder.modplug https://github.com/notspiff/audiodecoder.modplug 2de539b
+audiodecoder.modplug https://github.com/notspiff/audiodecoder.modplug 5ae7349

--- a/project/cmake/addons/addons/audiodecoder.nosefart/audiodecoder.nosefart.txt
+++ b/project/cmake/addons/addons/audiodecoder.nosefart/audiodecoder.nosefart.txt
@@ -1,1 +1,1 @@
-audiodecoder.nosefart https://github.com/notspiff/audiodecoder.nosefart a49ba6e
+audiodecoder.nosefart https://github.com/notspiff/audiodecoder.nosefart 936313f

--- a/project/cmake/addons/addons/audiodecoder.sidplay/audiodecoder.sidplay.txt
+++ b/project/cmake/addons/addons/audiodecoder.sidplay/audiodecoder.sidplay.txt
@@ -1,1 +1,1 @@
-audiodecoder.sidplay https://github.com/notspiff/audiodecoder.sidplay 6568676
+audiodecoder.sidplay https://github.com/notspiff/audiodecoder.sidplay 27b2c05

--- a/project/cmake/addons/addons/audiodecoder.snesapu/audiodecoder.snesapu.txt
+++ b/project/cmake/addons/addons/audiodecoder.snesapu/audiodecoder.snesapu.txt
@@ -1,1 +1,1 @@
-audiodecoder.snesapu https://github.com/notspiff/audiodecoder.snesapu 2bd1e34
+audiodecoder.snesapu https://github.com/notspiff/audiodecoder.snesapu 399d1d3

--- a/project/cmake/addons/addons/audiodecoder.stsound/audiodecoder.stsound.txt
+++ b/project/cmake/addons/addons/audiodecoder.stsound/audiodecoder.stsound.txt
@@ -1,1 +1,1 @@
-audiodecoder.stsound https://github.com/notspiff/audiodecoder.stsound 640b049
+audiodecoder.stsound https://github.com/notspiff/audiodecoder.stsound f6fbae9

--- a/project/cmake/addons/addons/audiodecoder.timidity/audiodecoder.timidity.txt
+++ b/project/cmake/addons/addons/audiodecoder.timidity/audiodecoder.timidity.txt
@@ -1,1 +1,1 @@
-audiodecoder.timidity https://github.com/notspiff/audiodecoder.timidity 7f079c1
+audiodecoder.timidity https://github.com/notspiff/audiodecoder.timidity da5eb9a

--- a/project/cmake/addons/addons/audiodecoder.vgmstream/audiodecoder.vgmstream.txt
+++ b/project/cmake/addons/addons/audiodecoder.vgmstream/audiodecoder.vgmstream.txt
@@ -1,1 +1,1 @@
-audiodecoder.vgmstream https://github.com/notspiff/audiodecoder.vgmstream 715c580
+audiodecoder.vgmstream https://github.com/notspiff/audiodecoder.vgmstream 7723f91


### PR DESCRIPTION
Similar to https://github.com/xbmc/xbmc/pull/7221 for same reasons Ive made PRs and they been merged there.

@wsnipex 

Only pvr ones left?

You may like to glance over the includes changed just in case, though looks OK from here. Jenkins should know.
