### PR TITLE
[gui] Improve overloads in CGUIDialogYesNo

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1532,7 +1532,7 @@ void CApplication::ReloadSkin(bool confirm/*=false*/)
     if (confirm && !m_skinReverting)
     {
       bool cancelled;
-      if (!CGUIDialogYesNo::ShowAndGetInput(13123, 13111, -1, -1, -1, -1, cancelled, 10000))
+      if (!CGUIDialogYesNo::ShowAndGetInput(13123, 13111, cancelled, "", "", 10000))
       {
         m_skinReverting = true;
         if (oldSkin.empty())

--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -489,7 +489,7 @@ bool CAutorun::IsEnabled() const
 
 bool CAutorun::PlayDiscAskResume(const std::string& path)
 {
-  return PlayDisc(path, true, !CanResumePlayDVD(path) || CGUIDialogYesNo::ShowAndGetInput(341, -1, -1, -1, 13404, 12021));
+  return PlayDisc(path, true, !CanResumePlayDVD(path) || CGUIDialogYesNo::ShowAndGetInput(341, "", "", "", 13404, 12021));
 }
 
 bool CAutorun::CanResumePlayDVD(const std::string& path)

--- a/xbmc/addons/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/GUIDialogAddonInfo.cpp
@@ -235,7 +235,7 @@ void CGUIDialogAddonInfo::OnUninstall()
     return;
 
   // prompt user to be sure
-  if (!CGUIDialogYesNo::ShowAndGetInput(24037, 750, 0, 0))
+  if (!CGUIDialogYesNo::ShowAndGetInput(24037, 750))
     return;
 
   CJobManager::GetInstance().AddJob(new CAddonUnInstallJob(m_localAddon),

--- a/xbmc/addons/LanguageResource.cpp
+++ b/xbmc/addons/LanguageResource.cpp
@@ -111,7 +111,7 @@ bool CLanguageResource::IsInUse() const
 void CLanguageResource::OnPostInstall(bool update, bool modal)
 {
   if (IsInUse() ||
-     (!update && !modal && CGUIDialogYesNo::ShowAndGetInput(Name(), g_localizeStrings.Get(24132), "", "")))
+     (!update && !modal && CGUIDialogYesNo::ShowAndGetInput(Name(), g_localizeStrings.Get(24132))))
   {
     CGUIDialogKaiToast *toast = (CGUIDialogKaiToast *)g_windowManager.GetWindow(WINDOW_DIALOG_KAI_TOAST);
     if (toast)

--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -283,7 +283,7 @@ void CSkinInfo::OnPreInstall()
 
 void CSkinInfo::OnPostInstall(bool update, bool modal)
 {
-  if (IsInUse() || (!update && !modal && CGUIDialogYesNo::ShowAndGetInput(Name(), g_localizeStrings.Get(24099),"","")))
+  if (IsInUse() || (!update && !modal && CGUIDialogYesNo::ShowAndGetInput(Name(), g_localizeStrings.Get(24099))))
   {
     CGUIDialogKaiToast *toast = (CGUIDialogKaiToast *)g_windowManager.GetWindow(WINDOW_DIALOG_KAI_TOAST);
     if (toast)

--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -370,7 +370,7 @@ bool CGUIDialogContextMenu::OnContextButton(const std::string &type, const CFile
         return false;
     }
     // prompt user if they want to really delete the source
-    if (!CGUIDialogYesNo::ShowAndGetInput(751, 750, -1, -1))
+    if (!CGUIDialogYesNo::ShowAndGetInput(751, 750))
       return false;
 
     // check default before we delete, as deletion will kill the share object
@@ -512,7 +512,7 @@ bool CGUIDialogContextMenu::OnContextButton(const std::string &type, const CFile
       if (!g_passwordManager.IsMasterLockUnlocked(true))
         return false;
 
-      if (!CGUIDialogYesNo::ShowAndGetInput(12335, 750, -1, -1))
+      if (!CGUIDialogYesNo::ShowAndGetInput(12335, 750))
         return false;
 
       share->m_iHasLock = 0;

--- a/xbmc/dialogs/GUIDialogYesNo.cpp
+++ b/xbmc/dialogs/GUIDialogYesNo.cpp
@@ -72,71 +72,59 @@ bool CGUIDialogYesNo::OnBack(int actionID)
   return CGUIDialogBoxBase::OnBack(actionID);
 }
 
-bool CGUIDialogYesNo::ShowAndGetInput(int heading, int line0, int line1, int line2, bool &bCanceled)
+bool CGUIDialogYesNo::ShowAndGetInput(const CVariant &heading, const CVariant &line0, const CVariant &line1, const CVariant &line2, bool &bCanceled)
 {
-  return ShowAndGetInput(heading, line0, line1, line2, -1, -1, bCanceled);
+  return ShowAndGetInput(heading, line0, line1, line2, bCanceled, "", "");
 }
 
-bool CGUIDialogYesNo::ShowAndGetInput(int heading, int line0, int line1, int line2, int iNoLabel /* = -1 */, int iYesLabel /* = -1 */)
+bool CGUIDialogYesNo::ShowAndGetInput(const CVariant &heading, const CVariant &line0, const CVariant &line1, const CVariant &line2, const CVariant &noLabel /* = "" */, const CVariant &yesLabel /* = "" */)
 {
   bool bDummy;
-  return ShowAndGetInput(heading, line0, line1, line2, iNoLabel, iYesLabel, bDummy);
+  return ShowAndGetInput(heading, line0, line1, line2, bDummy, noLabel, yesLabel);
 }
 
-bool CGUIDialogYesNo::ShowAndGetInput(int heading, int line0, int line1, int line2, int iNoLabel, int iYesLabel, bool &bCanceled, unsigned int autoCloseTime /* = 0 */)
+bool CGUIDialogYesNo::ShowAndGetInput(const CVariant &heading, const CVariant &line0, const CVariant &line1, const CVariant &line2, bool &bCanceled, const CVariant &noLabel, const CVariant &yesLabel, unsigned int autoCloseTime /* = 0 */)
 {
   CGUIDialogYesNo *dialog = (CGUIDialogYesNo *)g_windowManager.GetWindow(WINDOW_DIALOG_YES_NO);
-  if (!dialog) return false;
+  if (!dialog)
+    return false;
+
   dialog->SetHeading(heading);
   dialog->SetLine(0, line0);
   dialog->SetLine(1, line1);
   dialog->SetLine(2, line2);
   if (autoCloseTime)
     dialog->SetAutoClose(autoCloseTime);
-  if (iNoLabel != -1)
-    dialog->SetChoice(0,iNoLabel);
-  else
-    dialog->SetChoice(0,106);
-  if (iYesLabel != -1)
-    dialog->SetChoice(1,iYesLabel);
-  else
-    dialog->SetChoice(1,107);
+  dialog->SetChoice(0, !noLabel.empty() ? noLabel : 106);
+  dialog->SetChoice(1, !yesLabel.empty() ? yesLabel : 107);
   dialog->m_bCanceled = false;
   dialog->DoModal();
+
   bCanceled = dialog->m_bCanceled;
   return (dialog->IsConfirmed()) ? true : false;
 }
 
-bool CGUIDialogYesNo::ShowAndGetInput(const std::string &heading, const std::string &line0, const std::string &line1, const std::string &line2, const std::string &noLabel /* = "" */, const std::string &yesLabel /* = "" */)
+bool CGUIDialogYesNo::ShowAndGetInput(const CVariant &heading, const CVariant &text)
 {
   bool bDummy;
-  return ShowAndGetInput(heading, line0, line1, line2, bDummy, noLabel, yesLabel);
+  return ShowAndGetInput(heading, text, bDummy, "", "");
 }
 
-bool CGUIDialogYesNo::ShowAndGetInput(const std::string &heading, const std::string &line0, const std::string &line1, const std::string &line2, bool &bCanceled, const std::string &noLabel /* = "" */, const std::string &yesLabel /* = "" */, unsigned int autoCloseTime /* = 0 */)
-{
-  std::string text = line0 + "\n" + line1 + "\n" + line2;
-  return ShowAndGetInput(heading, text, bCanceled, noLabel, yesLabel, autoCloseTime);
-}
-
-bool CGUIDialogYesNo::ShowAndGetInput(const std::string &heading, const std::string &text, bool &bCanceled, const std::string &noLabel, const std::string &yesLabel, unsigned int autoCloseTime /* = 0 */)
+bool CGUIDialogYesNo::ShowAndGetInput(const CVariant &heading, const CVariant &text, bool &bCanceled, const CVariant &noLabel /* = "" */, const CVariant &yesLabel /* = "" */, unsigned int autoCloseTime /* = 0 */)
 {
   CGUIDialogYesNo *dialog = (CGUIDialogYesNo *)g_windowManager.GetWindow(WINDOW_DIALOG_YES_NO);
-  if (!dialog) return false;
+  if (!dialog)
+    return false;
+
   dialog->SetHeading(heading);
   dialog->SetText(text);
   if (autoCloseTime)
     dialog->SetAutoClose(autoCloseTime);
   dialog->m_bCanceled = false;
-  if (!noLabel.empty())
-    dialog->SetChoice(0,noLabel);
-  else
-    dialog->SetChoice(0,106);
-  if (!yesLabel.empty())
-    dialog->SetChoice(1,yesLabel);
-  else
-    dialog->SetChoice(1,107);
+  dialog->SetChoice(0, !noLabel.empty() ? noLabel : 106);
+  dialog->SetChoice(1, !yesLabel.empty() ? yesLabel : 107);
   dialog->DoModal();
+
   bCanceled = dialog->m_bCanceled;
   return (dialog->IsConfirmed()) ? true : false;
 }

--- a/xbmc/dialogs/GUIDialogYesNo.cpp
+++ b/xbmc/dialogs/GUIDialogYesNo.cpp
@@ -72,20 +72,18 @@ bool CGUIDialogYesNo::OnBack(int actionID)
   return CGUIDialogBoxBase::OnBack(actionID);
 }
 
-// \brief Show CGUIDialogYesNo dialog, then wait for user to dismiss it.
-// \return true if user selects Yes, false if user selects No.
-bool CGUIDialogYesNo::ShowAndGetInput(int heading, int line0, int line1, int line2, bool& bCanceled)
+bool CGUIDialogYesNo::ShowAndGetInput(int heading, int line0, int line1, int line2, bool &bCanceled)
 {
-  return ShowAndGetInput(heading,line0,line1,line2,-1,-1,bCanceled);
+  return ShowAndGetInput(heading, line0, line1, line2, -1, -1, bCanceled);
 }
 
-bool CGUIDialogYesNo::ShowAndGetInput(int heading, int line0, int line1, int line2, int iNoLabel, int iYesLabel)
+bool CGUIDialogYesNo::ShowAndGetInput(int heading, int line0, int line1, int line2, int iNoLabel /* = -1 */, int iYesLabel /* = -1 */)
 {
   bool bDummy;
-  return ShowAndGetInput(heading,line0,line1,line2,iNoLabel,iYesLabel,bDummy);
+  return ShowAndGetInput(heading, line0, line1, line2, iNoLabel, iYesLabel, bDummy);
 }
 
-bool CGUIDialogYesNo::ShowAndGetInput(int heading, int line0, int line1, int line2, int iNoLabel, int iYesLabel, bool& bCanceled, unsigned int autoCloseTime)
+bool CGUIDialogYesNo::ShowAndGetInput(int heading, int line0, int line1, int line2, int iNoLabel, int iYesLabel, bool &bCanceled, unsigned int autoCloseTime /* = 0 */)
 {
   CGUIDialogYesNo *dialog = (CGUIDialogYesNo *)g_windowManager.GetWindow(WINDOW_DIALOG_YES_NO);
   if (!dialog) return false;
@@ -109,13 +107,19 @@ bool CGUIDialogYesNo::ShowAndGetInput(int heading, int line0, int line1, int lin
   return (dialog->IsConfirmed()) ? true : false;
 }
 
-bool CGUIDialogYesNo::ShowAndGetInput(const std::string& heading, const std::string& line0, const std::string& line1, const std::string& line2, const std::string& noLabel, const std::string& yesLabel)
+bool CGUIDialogYesNo::ShowAndGetInput(const std::string &heading, const std::string &line0, const std::string &line1, const std::string &line2, const std::string &noLabel /* = "" */, const std::string &yesLabel /* = "" */)
 {
   bool bDummy;
-  return ShowAndGetInput(heading,line0,line1,line2,bDummy,noLabel,yesLabel);
+  return ShowAndGetInput(heading, line0, line1, line2, bDummy, noLabel, yesLabel);
 }
 
-bool CGUIDialogYesNo::ShowAndGetInput(const std::string& heading, const std::string& text, bool& bCanceled, const std::string& noLabel, const std::string& yesLabel, unsigned int autoCloseTime)
+bool CGUIDialogYesNo::ShowAndGetInput(const std::string &heading, const std::string &line0, const std::string &line1, const std::string &line2, bool &bCanceled, const std::string &noLabel /* = "" */, const std::string &yesLabel /* = "" */, unsigned int autoCloseTime /* = 0 */)
+{
+  std::string text = line0 + "\n" + line1 + "\n" + line2;
+  return ShowAndGetInput(heading, text, bCanceled, noLabel, yesLabel, autoCloseTime);
+}
+
+bool CGUIDialogYesNo::ShowAndGetInput(const std::string &heading, const std::string &text, bool &bCanceled, const std::string &noLabel, const std::string &yesLabel, unsigned int autoCloseTime /* = 0 */)
 {
   CGUIDialogYesNo *dialog = (CGUIDialogYesNo *)g_windowManager.GetWindow(WINDOW_DIALOG_YES_NO);
   if (!dialog) return false;
@@ -135,12 +139,6 @@ bool CGUIDialogYesNo::ShowAndGetInput(const std::string& heading, const std::str
   dialog->DoModal();
   bCanceled = dialog->m_bCanceled;
   return (dialog->IsConfirmed()) ? true : false;
-}
-
-bool CGUIDialogYesNo::ShowAndGetInput(const std::string& heading, const std::string& line0, const std::string& line1, const std::string& line2, bool& bCanceled, const std::string& noLabel, const std::string& yesLabel, unsigned int autoCloseTime)
-{
-  std::string text = line0 + "\n" + line1 + "\n" + line2;
-  return ShowAndGetInput(heading, text, bCanceled, noLabel, yesLabel, autoCloseTime);
 }
 
 int CGUIDialogYesNo::GetDefaultLabelID(int controlId) const

--- a/xbmc/dialogs/GUIDialogYesNo.h
+++ b/xbmc/dialogs/GUIDialogYesNo.h
@@ -32,12 +32,75 @@ public:
   virtual bool OnMessage(CGUIMessage& message);
   virtual bool OnBack(int actionID);
 
-  static bool ShowAndGetInput(int heading, int line0, int line1, int line2, int iNoLabel=-1, int iYesLabel=-1);
-  static bool ShowAndGetInput(int heading, int line0, int line1, int line2, bool& bCanceled);
-  static bool ShowAndGetInput(int heading, int line0, int line1, int line2, int iNoLabel, int iYesLabel, bool& bCanceled, unsigned int autoCloseTime = 0);
-  static bool ShowAndGetInput(const std::string& heading, const std::string& line0, const std::string& line1, const std::string& line2, const std::string& noLabel="", const std::string& yesLabel="");
-  static bool ShowAndGetInput(const std::string& heading, const std::string& text, bool& bCanceled, const std::string& noLabel, const std::string& yesLabel, unsigned int autoCloseTime = 0);
-  static bool ShowAndGetInput(const std::string& heading, const std::string& line0, const std::string& line1, const std::string& line2, bool &bCanceled, const std::string& noLabel="", const std::string& yesLabel="", unsigned int autoCloseTime = 0);
+  /*! \brief Show a yes-no dialog, then wait for user to dismiss it.
+   \param heading The heading of the dialog
+   \param line0 Localized label id for line 1 of the dialog message
+   \param line1 Localized label id for line 2 of the dialog message
+   \param line2 Localized label id for line 3 of the dialog message
+   \param bCanceled Holds true if the dialog was canceled otherwise false
+   \return true if user selects Yes, otherwise false if user selects No.
+   */
+  static bool ShowAndGetInput(int heading, int line0, int line1, int line2, bool &bCanceled);
+
+  /*! \brief Show a yes-no dialog, then wait for user to dismiss it.
+   \param heading The heading of the dialog
+   \param line0 Localized label id for line 1 of the dialog message
+   \param line1 Localized label id for line 2 of the dialog message
+   \param line2 Localized label id for line 3 of the dialog message
+   \param iNoLabel Localized label id for the no button
+   \param iYesLabel Localized label id for the yes button
+   \return true if user selects Yes, otherwise false if user selects No.
+   */
+  static bool ShowAndGetInput(int heading, int line0, int line1, int line2, int iNoLabel = -1, int iYesLabel = -1);
+
+  /*! \brief Show a yes-no dialog, then wait for user to dismiss it.
+   \param heading The heading of the dialog
+   \param line0 Localized label id for line 1 of the dialog message
+   \param line1 Localized label id for line 2 of the dialog message
+   \param line2 Localized label id for line 3 of the dialog message
+   \param iNoLabel Localized label id for the no button
+   \param iYesLabel Localized label id for the yes button
+   \param bCanceled Holds true if the dialog was canceled otherwise false
+   \param autoCloseTime Time in ms before the dialog becomes automatically closed
+   \return true if user selects Yes, otherwise false if user selects No.
+   */
+  static bool ShowAndGetInput(int heading, int line0, int line1, int line2, int iNoLabel, int iYesLabel, bool &bCanceled, unsigned int autoCloseTime = 0);
+
+  /*! \brief Show a yes-no dialog, then wait for user to dismiss it.
+   \param heading The heading of the dialog
+   \param line0 String for line 1 of the dialog message
+   \param line1 String for line 2 of the dialog message
+   \param line2 String for line 3 of the dialog message
+   \param iNoLabel Label for the no button
+   \param iYesLabel Label for the yes button
+   \return true if user selects Yes, otherwise false if user selects No.
+   */
+  static bool ShowAndGetInput(const std::string &heading, const std::string &line0, const std::string &line1, const std::string &line2, const std::string &noLabel = "", const std::string &yesLabel = "");
+
+  /*! \brief Show a yes-no dialog, then wait for user to dismiss it.
+   \param heading The heading of the dialog
+   \param line0 String for line 1 of the dialog message
+   \param line1 String for line 2 of the dialog message
+   \param line2 String for line 3 of the dialog message
+   \param bCanceled Holds true if the dialog was canceled otherwise false
+   \param iNoLabel Label for the no button
+   \param iYesLabel Label for the yes button
+   \param autoCloseTime Time in ms before the dialog becomes automatically closed
+   \return true if user selects Yes, otherwise false if user selects No.
+   */
+  static bool ShowAndGetInput(const std::string &heading, const std::string &line0, const std::string &line1, const std::string &line2, bool &bCanceled, const std::string &noLabel = "", const std::string &yesLabel = "", unsigned int autoCloseTime = 0);
+
+  /*! \brief Show a yes-no dialog, then wait for user to dismiss it.
+   \param heading The heading of the dialog
+   \param text The dialog message
+   \param bCanceled Holds true if the dialog was canceled otherwise false
+   \param iNoLabel Label for the no button
+   \param iYesLabel Label for the yes button
+   \param autoCloseTime Time in ms before the dialog becomes automatically closed
+   \return true if user selects Yes, otherwise false if user selects No.
+   */
+  static bool ShowAndGetInput(const std::string &heading, const std::string &text, bool &bCanceled, const std::string &noLabel, const std::string &yesLabel, unsigned int autoCloseTime = 0);
+
 protected:
   virtual int GetDefaultLabelID(int controlId) const;
 

--- a/xbmc/dialogs/GUIDialogYesNo.h
+++ b/xbmc/dialogs/GUIDialogYesNo.h
@@ -33,73 +33,56 @@ public:
   virtual bool OnBack(int actionID);
 
   /*! \brief Show a yes-no dialog, then wait for user to dismiss it.
-   \param heading The heading of the dialog
-   \param line0 Localized label id for line 1 of the dialog message
-   \param line1 Localized label id for line 2 of the dialog message
-   \param line2 Localized label id for line 3 of the dialog message
+   \param heading Localized label id or string for the heading of the dialog
+   \param line0 Localized label id or string for line 1 of the dialog message
+   \param line1 Localized label id or string for line 2 of the dialog message
+   \param line2 Localized label id or string for line 3 of the dialog message
    \param bCanceled Holds true if the dialog was canceled otherwise false
    \return true if user selects Yes, otherwise false if user selects No.
    */
-  static bool ShowAndGetInput(int heading, int line0, int line1, int line2, bool &bCanceled);
+  static bool ShowAndGetInput(const CVariant &heading, const CVariant &line0, const CVariant &line1, const CVariant &line2, bool &bCanceled);
 
   /*! \brief Show a yes-no dialog, then wait for user to dismiss it.
-   \param heading The heading of the dialog
-   \param line0 Localized label id for line 1 of the dialog message
-   \param line1 Localized label id for line 2 of the dialog message
-   \param line2 Localized label id for line 3 of the dialog message
-   \param iNoLabel Localized label id for the no button
-   \param iYesLabel Localized label id for the yes button
+   \param heading Localized label id or string for the heading of the dialog
+   \param line0 Localized label id or string for line 1 of the dialog message
+   \param line1 Localized label id or string for line 2 of the dialog message
+   \param line2 Localized label id or string for line 3 of the dialog message
+   \param iNoLabel Localized label id or string for the no button
+   \param iYesLabel Localized label id or string for the yes button
    \return true if user selects Yes, otherwise false if user selects No.
    */
-  static bool ShowAndGetInput(int heading, int line0, int line1, int line2, int iNoLabel = -1, int iYesLabel = -1);
+  static bool ShowAndGetInput(const CVariant &heading, const CVariant &line0, const CVariant &line1, const CVariant &line2, const CVariant &noLabel = "", const CVariant &yesLabel = "");
 
   /*! \brief Show a yes-no dialog, then wait for user to dismiss it.
-   \param heading The heading of the dialog
-   \param line0 Localized label id for line 1 of the dialog message
-   \param line1 Localized label id for line 2 of the dialog message
-   \param line2 Localized label id for line 3 of the dialog message
-   \param iNoLabel Localized label id for the no button
-   \param iYesLabel Localized label id for the yes button
+   \param heading Localized label id or string for the heading of the dialog
+   \param line0 Localized label id or string for line 1 of the dialog message
+   \param line1 Localized label id or string for line 2 of the dialog message
+   \param line2 Localized label id or string for line 3 of the dialog message
    \param bCanceled Holds true if the dialog was canceled otherwise false
+   \param iNoLabel Localized label id or string for the no button
+   \param iYesLabel Localized label id or string for the yes button
    \param autoCloseTime Time in ms before the dialog becomes automatically closed
    \return true if user selects Yes, otherwise false if user selects No.
    */
-  static bool ShowAndGetInput(int heading, int line0, int line1, int line2, int iNoLabel, int iYesLabel, bool &bCanceled, unsigned int autoCloseTime = 0);
+  static bool ShowAndGetInput(const CVariant &heading, const CVariant &line0, const CVariant &line1, const CVariant &line2, bool &bCanceled, const CVariant &noLabel, const CVariant &yesLabel, unsigned int autoCloseTime = 0);
 
   /*! \brief Show a yes-no dialog, then wait for user to dismiss it.
-   \param heading The heading of the dialog
-   \param line0 String for line 1 of the dialog message
-   \param line1 String for line 2 of the dialog message
-   \param line2 String for line 3 of the dialog message
-   \param iNoLabel Label for the no button
-   \param iYesLabel Label for the yes button
+   \param heading Localized label id or string for the heading of the dialog
+   \param text Localized label id or string for the dialog message
    \return true if user selects Yes, otherwise false if user selects No.
    */
-  static bool ShowAndGetInput(const std::string &heading, const std::string &line0, const std::string &line1, const std::string &line2, const std::string &noLabel = "", const std::string &yesLabel = "");
+  static bool ShowAndGetInput(const CVariant &heading, const CVariant &text);
 
   /*! \brief Show a yes-no dialog, then wait for user to dismiss it.
-   \param heading The heading of the dialog
-   \param line0 String for line 1 of the dialog message
-   \param line1 String for line 2 of the dialog message
-   \param line2 String for line 3 of the dialog message
+   \param heading Localized label id or string for the heading of the dialog
+   \param text Localized label id or string for the dialog message
    \param bCanceled Holds true if the dialog was canceled otherwise false
-   \param iNoLabel Label for the no button
-   \param iYesLabel Label for the yes button
+   \param iNoLabel Localized label id or string for the no button
+   \param iYesLabel Localized label id or string for the yes button
    \param autoCloseTime Time in ms before the dialog becomes automatically closed
    \return true if user selects Yes, otherwise false if user selects No.
    */
-  static bool ShowAndGetInput(const std::string &heading, const std::string &line0, const std::string &line1, const std::string &line2, bool &bCanceled, const std::string &noLabel = "", const std::string &yesLabel = "", unsigned int autoCloseTime = 0);
-
-  /*! \brief Show a yes-no dialog, then wait for user to dismiss it.
-   \param heading The heading of the dialog
-   \param text The dialog message
-   \param bCanceled Holds true if the dialog was canceled otherwise false
-   \param iNoLabel Label for the no button
-   \param iYesLabel Label for the yes button
-   \param autoCloseTime Time in ms before the dialog becomes automatically closed
-   \return true if user selects Yes, otherwise false if user selects No.
-   */
-  static bool ShowAndGetInput(const std::string &heading, const std::string &text, bool &bCanceled, const std::string &noLabel, const std::string &yesLabel, unsigned int autoCloseTime = 0);
+  static bool ShowAndGetInput(const CVariant &heading, const CVariant &text, bool &bCanceled, const CVariant &noLabel = "", const CVariant &yesLabel = "", unsigned int autoCloseTime = 0);
 
 protected:
   virtual int GetDefaultLabelID(int controlId) const;

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -1581,7 +1581,7 @@ int CBuiltins::Execute(const std::string& execString)
     if (params.size() > 1)
       singleFile = StringUtils::EqualsNoCase(params[1], "true");
     else
-      singleFile = CGUIDialogYesNo::ShowAndGetInput(iHeading, 20426, -1, -1, 20428, 20429, cancelled);
+      singleFile = CGUIDialogYesNo::ShowAndGetInput(iHeading, 20426, cancelled, 20428, 20429);
 
     if (cancelled)
         return -1;
@@ -1591,7 +1591,7 @@ int CBuiltins::Execute(const std::string& execString)
       if (params.size() > 2)
         thumbs = StringUtils::EqualsNoCase(params[2], "true");
       else
-        thumbs = CGUIDialogYesNo::ShowAndGetInput(iHeading,20430,-1,-1,cancelled);
+        thumbs = CGUIDialogYesNo::ShowAndGetInput(iHeading, 20430, cancelled);
     }
 
     if (cancelled)
@@ -1602,7 +1602,7 @@ int CBuiltins::Execute(const std::string& execString)
       if (params.size() > 4)
         actorThumbs = StringUtils::EqualsNoCase(params[4], "true");
       else
-        actorThumbs = CGUIDialogYesNo::ShowAndGetInput(iHeading,20436,-1,-1,cancelled);
+        actorThumbs = CGUIDialogYesNo::ShowAndGetInput(iHeading, 20436, cancelled);
     }
 
     if (cancelled)
@@ -1613,7 +1613,7 @@ int CBuiltins::Execute(const std::string& execString)
       if (params.size() > 3)
         overwrite = StringUtils::EqualsNoCase(params[3], "true");
       else
-        overwrite = CGUIDialogYesNo::ShowAndGetInput(iHeading,20431,-1,-1,cancelled);
+        overwrite = CGUIDialogYesNo::ShowAndGetInput(iHeading, 20431, cancelled);
     }
 
     if (cancelled)

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -2945,7 +2945,7 @@ void CMusicDatabase::Clean()
     return;
   }
 
-  if (CGUIDialogYesNo::ShowAndGetInput(313, 333, 0, 0))
+  if (CGUIDialogYesNo::ShowAndGetInput(313, 333))
   {
     CMusicDatabase musicdatabase;
     if (musicdatabase.Open())

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -1183,7 +1183,7 @@ void CGUIWindowMusicBase::OnInitWindow()
       g_infoManager.GetLibraryBool(LIBRARY_HAS_MUSIC))
   {
     // rescan of music library required
-    if (CGUIDialogYesNo::ShowAndGetInput(799, 800, -1, -1))
+    if (CGUIDialogYesNo::ShowAndGetInput(799, 800))
     {
       int flags = CMusicInfoScanner::SCAN_RESCAN;
       if (CSettings::Get().GetBool("musiclibrary.downloadinfo"))

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -722,7 +722,7 @@ bool CGUIWindowMusicNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
       if (CGUIDialogContentSettings::Show(scraper, content))
       {
         m_musicdatabase.SetScraperForPath(path,scraper);
-        if (CGUIDialogYesNo::ShowAndGetInput(20442, 20443, -1, -1))
+        if (CGUIDialogYesNo::ShowAndGetInput(20442, 20443))
         {
           OnInfoAll(itemNumber,true,true);
         }

--- a/xbmc/music/windows/GUIWindowMusicSongs.cpp
+++ b/xbmc/music/windows/GUIWindowMusicSongs.cpp
@@ -480,7 +480,7 @@ bool CGUIWindowMusicSongs::Update(const std::string &strDirectory, bool updateFi
 void CGUIWindowMusicSongs::OnRemoveSource(int iItem)
 {
   bool bCanceled;
-  if (CGUIDialogYesNo::ShowAndGetInput(522, 20340, -1, -1, bCanceled))
+  if (CGUIDialogYesNo::ShowAndGetInput(522, 20340, bCanceled))
   {
     MAPSONGS songs;
     CMusicDatabase database;

--- a/xbmc/network/NetworkServices.cpp
+++ b/xbmc/network/NetworkServices.cpp
@@ -412,7 +412,7 @@ void CNetworkServices::OnSettingChanged(const CSetting *setting)
   {
     // okey we really don't need to restart, only deinit samba, but that could be damn hard if something is playing
     // TODO - General way of handling setting changes that require restart
-    if (CGUIDialogYesNo::ShowAndGetInput(14038, 14039, -1, -1))
+    if (CGUIDialogYesNo::ShowAndGetInput(14038, 14039))
     {
       CSettings::Get().Save();
       CApplicationMessenger::Get().RestartApp();
@@ -755,7 +755,7 @@ bool CNetworkServices::StopEventServer(bool bWait, bool promptuser)
     if (server->GetNumberOfClients() > 0)
     {
       bool cancelled = false;
-      if (!CGUIDialogYesNo::ShowAndGetInput(13140, 13141, cancelled, -1, -1, 10000)
+      if (!CGUIDialogYesNo::ShowAndGetInput(13140, 13141, cancelled, "", "", 10000)
           || cancelled)
       {
         CLog::Log(LOGNOTICE, "ES: Not stopping event server");

--- a/xbmc/network/upnp/UPnPPlayer.cpp
+++ b/xbmc/network/upnp/UPnPPlayer.cpp
@@ -603,7 +603,7 @@ bool CUPnPPlayer::OnAction(const CAction &action)
     case ACTION_STOP:
       if(IsPlaying())
       {
-        if(CGUIDialogYesNo::ShowAndGetInput(37022, 37023, 0, 0)) /* stop on remote system */
+        if(CGUIDialogYesNo::ShowAndGetInput(37022, 37023)) /* stop on remote system */
           m_stopremote = true;
         else
           m_stopremote = false;

--- a/xbmc/osx/XBMCHelper.cpp
+++ b/xbmc/osx/XBMCHelper.cpp
@@ -114,7 +114,7 @@ bool XBMCHelper::OnSettingChanging(const CSetting *setting)
     if (IsRunning() && GetMode() != remoteMode)
     {
       bool cancelled;
-      if (!CGUIDialogYesNo::ShowAndGetInput(13144, 13145, cancelled, -1, -1, 10000))
+      if (!CGUIDialogYesNo::ShowAndGetInput(13144, 13145, cancelled, "", "", 10000))
         return false;
       // reload configuration
       else

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -396,10 +396,8 @@ void CPeripheralCecAdapter::Process(void)
       else if (timeout.GetElapsedSeconds() >= CEC_TV_PRESENT_CHECK_TIMEOUT)
       {
         /** no TV found for 30 seconds, ask if the user wants to disable CEC */
-        if (CGUIDialogYesNo::ShowAndGetInput(36000, // Pulse-Eight CEC adaptor
-                                             36043, // No CEC capable TV detected. Disable polling for CEC capable devices?
-                                             -1,
-                                             -1))
+        if (!CGUIDialogYesNo::ShowAndGetInput(36000,  // Pulse-Eight CEC adaptor
+                                              36043)) // No CEC capable TV detected. Disable polling for CEC capable devices?
         {
           SetSetting("enabled", false);
           m_bStop          = true;

--- a/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.cpp
+++ b/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.cpp
@@ -106,7 +106,7 @@ void CGUIDialogPeripheralSettings::OnResetSettings()
   if (peripheral == NULL)
     return;
 
-  if (!CGUIDialogYesNo::ShowAndGetInput(10041, 10042, -1, -1))
+  if (!CGUIDialogYesNo::ShowAndGetInput(10041, 10042))
     return;
 
   // reset the settings in the peripheral

--- a/xbmc/profiles/dialogs/GUIDialogProfileSettings.cpp
+++ b/xbmc/profiles/dialogs/GUIDialogProfileSettings.cpp
@@ -142,7 +142,7 @@ bool CGUIDialogProfileSettings::ShowForProfile(unsigned int iProfile, bool first
       CProfilesManager::Get().AddProfile(profile);
       bool exists = XFILE::CFile::Exists(URIUtils::AddFileToFolder("special://masterprofile/", dialog->m_directory + "/guisettings.xml"));
 
-      if (exists && !CGUIDialogYesNo::ShowAndGetInput(20058, 20104, -1, -1))
+      if (exists && !CGUIDialogYesNo::ShowAndGetInput(20058, 20104))
         exists = false;
 
       if (!exists)
@@ -150,7 +150,7 @@ bool CGUIDialogProfileSettings::ShowForProfile(unsigned int iProfile, bool first
         // copy masterprofile guisettings to new profile guisettings
         // If the user selects 'start fresh', do nothing as a fresh
         // guisettings.xml will be created on first profile use.
-        if (CGUIDialogYesNo::ShowAndGetInput(20058, 20048, -1, -1, 20044, 20064))
+        if (CGUIDialogYesNo::ShowAndGetInput(20058, 20048, "", "", 20044, 20064))
         {
           XFILE::CFile::Copy(URIUtils::AddFileToFolder("special://masterprofile/", "guisettings.xml"),
                               URIUtils::AddFileToFolder("special://masterprofile/", dialog->m_directory + "/guisettings.xml"));
@@ -158,7 +158,7 @@ bool CGUIDialogProfileSettings::ShowForProfile(unsigned int iProfile, bool first
       }
 
       exists = XFILE::CFile::Exists(URIUtils::AddFileToFolder("special://masterprofile/", dialog->m_directory + "/sources.xml"));
-      if (exists && !CGUIDialogYesNo::ShowAndGetInput(20058, 20106, -1, -1))
+      if (exists && !CGUIDialogYesNo::ShowAndGetInput(20058, 20106))
         exists = false;
 
       if (!exists)
@@ -166,7 +166,7 @@ bool CGUIDialogProfileSettings::ShowForProfile(unsigned int iProfile, bool first
         if ((dialog->m_sourcesMode & 2) == 2)
           // prompt user to copy masterprofile's sources.xml file
           // If 'start fresh' (no) is selected, do nothing.
-          if (CGUIDialogYesNo::ShowAndGetInput(20058, 20071, -1, -1, 20044, 20064))
+          if (CGUIDialogYesNo::ShowAndGetInput(20058, 20071, "", "", 20044, 20064))
           {
             XFILE::CFile::Copy(URIUtils::AddFileToFolder("special://masterprofile/", "sources.xml"),
                                 URIUtils::AddFileToFolder("special://masterprofile/", dialog->m_directory + "/sources.xml"));
@@ -175,7 +175,7 @@ bool CGUIDialogProfileSettings::ShowForProfile(unsigned int iProfile, bool first
     }
 
     /*if (!dialog->m_bIsNewUser)
-      if (!CGUIDialogYesNo::ShowAndGetInput(20067, 20103, -1, -1))
+      if (!CGUIDialogYesNo::ShowAndGetInput(20067, 20103))
         return false;*/
 
     CProfile *profile = CProfilesManager::Get().GetProfile(iProfile);
@@ -277,7 +277,7 @@ void CGUIDialogProfileSettings::OnSettingAction(const CSetting *setting)
     {
       if (CProfilesManager::Get().GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE && !m_isDefault)
       {
-        if (CGUIDialogYesNo::ShowAndGetInput(20066, 20118, -1, -1))
+        if (CGUIDialogYesNo::ShowAndGetInput(20066, 20118))
           g_passwordManager.SetMasterLockMode(false);
         if (CProfilesManager::Get().GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE)
           return;

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -314,7 +314,7 @@ bool CPVRTimerInfoTag::DeleteFromClient(bool bForce /* = false */) const
   if (error == PVR_ERROR_RECORDING_RUNNING)
   {
     // recording running. ask the user if it should be deleted anyway
-    if (!CGUIDialogYesNo::ShowAndGetInput(122, 19122, -1, -1))
+    if (!CGUIDialogYesNo::ShowAndGetInput(122, 19122))
       return false;
 
     error = g_PVRClients->DeleteTimer(*this, true);

--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -254,7 +254,7 @@ bool CDisplaySettings::OnSettingChanging(const CSetting *setting)
       if (!m_resolutionChangeAborted)
       {
         bool cancelled = false;
-        if (!CGUIDialogYesNo::ShowAndGetInput(13110, 13111, cancelled, -1, -1, 10000))
+        if (!CGUIDialogYesNo::ShowAndGetInput(13110, 13111, cancelled, "", "", 10000))
         {
           m_resolutionChangeAborted = true;
           return false;
@@ -275,7 +275,7 @@ bool CDisplaySettings::OnSettingChanging(const CSetting *setting)
     if (!m_resolutionChangeAborted)
     {
       bool cancelled = false;
-      if (!CGUIDialogYesNo::ShowAndGetInput(13110, 13111, cancelled, -1, -1, 10000))
+      if (!CGUIDialogYesNo::ShowAndGetInput(13110, 13111, cancelled, "", "", 10000))
       {
         m_resolutionChangeAborted = true;
         return false;

--- a/xbmc/settings/MediaSettings.cpp
+++ b/xbmc/settings/MediaSettings.cpp
@@ -310,7 +310,7 @@ void CMediaSettings::OnSettingAction(const CSetting *setting)
   }
   else if (settingId == "musiclibrary.cleanup")
   {
-    if (CGUIDialogYesNo::ShowAndGetInput(313, 333, 0, 0))
+    if (CGUIDialogYesNo::ShowAndGetInput(313, 333))
       g_application.StartMusicCleanup(true);
   }
   else if (settingId == "musiclibrary.export")
@@ -330,7 +330,7 @@ void CMediaSettings::OnSettingAction(const CSetting *setting)
   }
   else if (settingId == "videolibrary.cleanup")
   {
-    if (CGUIDialogYesNo::ShowAndGetInput(313, 333, 0, 0))
+    if (CGUIDialogYesNo::ShowAndGetInput(313, 333))
       g_application.StartVideoCleanup(true);
   }
   else if (settingId == "videolibrary.export")

--- a/xbmc/settings/dialogs/GUIDialogSettingsBase.cpp
+++ b/xbmc/settings/dialogs/GUIDialogSettingsBase.cpp
@@ -753,7 +753,7 @@ void CGUIDialogSettingsBase::SetDescription(const CVariant &label)
 
 void CGUIDialogSettingsBase::OnResetSettings()
 {
-  if (CGUIDialogYesNo::ShowAndGetInput(10041, 10042, -1, -1))
+  if (CGUIDialogYesNo::ShowAndGetInput(10041, 10042))
   {
     for(vector<BaseSettingControlPtr>::iterator it = m_settingControls.begin(); it != m_settingControls.end(); ++it)
     {

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -2037,7 +2037,7 @@ namespace VIDEO
       CGUIDialogOK::ShowAndGetInput(20448, 20449);
       return false;
     }
-    return CGUIDialogYesNo::ShowAndGetInput(20448, 20450, -1, -1);
+    return CGUIDialogYesNo::ShowAndGetInput(20448, 20450);
   }
 
   bool CVideoInfoScanner::ProgressCancelled(CGUIDialogProgress* progress, int heading, const std::string &line1)

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -116,7 +116,7 @@ bool CGUIDialogVideoInfo::OnMessage(CGUIMessage& message)
         if (m_movieItem->GetVideoInfoTag()->m_type == MediaTypeTvShow)
         {
           bool bCanceled=false;
-          if (CGUIDialogYesNo::ShowAndGetInput(20377, 20378, -1, -1, bCanceled))
+          if (CGUIDialogYesNo::ShowAndGetInput(20377, 20378, bCanceled))
           {
             m_bRefreshAll = true;
             CVideoDatabase db;

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -437,7 +437,7 @@ bool CGUIWindowVideoBase::ShowIMDB(CFileItem *item, const ScraperPtr &info2, boo
         bHasInfo = true;
         if (!info->IsNoop() && (nfoResult == CNfoFile::URL_NFO || nfoResult == CNfoFile::COMBINED_NFO || nfoResult == CNfoFile::FULL_NFO))
         {
-          if (CGUIDialogYesNo::ShowAndGetInput(13346, 20446, -1, -1))
+          if (CGUIDialogYesNo::ShowAndGetInput(13346, 20446))
           {
             hasDetails = false;
             ignoreNfo = true;
@@ -1888,7 +1888,7 @@ bool CGUIWindowVideoBase::OnUnAssignContent(const std::string &path, int label1,
   bool bCanceled;
   CVideoDatabase db;
   db.Open();
-  if (CGUIDialogYesNo::ShowAndGetInput(label1, label2, label3, -1, bCanceled))
+  if (CGUIDialogYesNo::ShowAndGetInput(label1, label2, label3, "", bCanceled))
   {
     CGUIDialogProgress *progress = (CGUIDialogProgress *)g_windowManager.GetWindow(WINDOW_DIALOG_PROGRESS);
     db.RemoveContentForPath(path, progress);

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -684,7 +684,7 @@ void CGUIWindowFileManager::OnMark(int iList, int iItem)
 
 void CGUIWindowFileManager::OnCopy(int iList)
 {
-  if (!CGUIDialogYesNo::ShowAndGetInput(120, 123, 0, 0))
+  if (!CGUIDialogYesNo::ShowAndGetInput(120, 123))
     return;
 
   AddJob(new CFileOperationJob(CFileOperationJob::ActionCopy, 
@@ -695,7 +695,7 @@ void CGUIWindowFileManager::OnCopy(int iList)
 
 void CGUIWindowFileManager::OnMove(int iList)
 {
-  if (!CGUIDialogYesNo::ShowAndGetInput(121, 124, 0, 0))
+  if (!CGUIDialogYesNo::ShowAndGetInput(121, 124))
     return;
 
   AddJob(new CFileOperationJob(CFileOperationJob::ActionMove,
@@ -706,7 +706,7 @@ void CGUIWindowFileManager::OnMove(int iList)
 
 void CGUIWindowFileManager::OnDelete(int iList)
 {
-  if (!CGUIDialogYesNo::ShowAndGetInput(122, 125, 0, 0))
+  if (!CGUIDialogYesNo::ShowAndGetInput(122, 125))
     return;
 
   AddJob(new CFileOperationJob(CFileOperationJob::ActionDelete,


### PR DESCRIPTION
@MartijnKaijser as promised this unifies the method overloads in `CGUIDialogYesNo` by using `CVariant`.

Now you can use label id's or strings for every label field parameter. I've also added a new convenience method `CGUIDialogYesNo::ShowAndGetInput(const CVariant &heading, const CVariant &text)`.

@Montellese mind taking a look for review.
