### PR TITLE
[video] fix leading/trailing whitespaces in video details

### DIFF
--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -1456,7 +1456,15 @@ int MysqlDataset::exec(const string &sql) {
   if ( ci_find(qry, "CREATE TABLE") != string::npos 
     || ci_find(qry, "CREATE TEMPORARY TABLE") != string::npos )
   {
-    qry += " CHARACTER SET utf8 COLLATE utf8_general_ci";
+    // If CREATE TABLE ... SELECT Syntax is used we need to add the encoding after the table before the select
+    // e.g. CREATE TABLE x CHARACTER SET utf8 COLLATE utf8_general_ci [AS] SELECT * FROM y
+    if ((loc = qry.find(" AS SELECT ")) != string::npos ||
+        (loc = qry.find(" SELECT ")) != string::npos)
+    {
+      qry = qry.insert(loc, " CHARACTER SET utf8 COLLATE utf8_general_ci");
+    }
+    else
+      qry += " CHARACTER SET utf8 COLLATE utf8_general_ci";
   }
 
   CLog::Log(LOGDEBUG,"Mysql execute: %s", qry.c_str());

--- a/xbmc/interfaces/json-rpc/VideoLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/VideoLibrary.cpp
@@ -994,74 +994,104 @@ void CVideoLibrary::UpdateVideoTagField(const CVariant& parameterObject, const s
 void CVideoLibrary::UpdateVideoTag(const CVariant &parameterObject, CVideoInfoTag& details, std::map<std::string, std::string> &artwork, std::set<std::string> &removedArtwork, std::set<std::string> &updatedDetails)
 {
   if (ParameterNotNull(parameterObject, "title"))
-    details.m_strTitle = parameterObject["title"].asString();
+    details.SetTitle(parameterObject["title"].asString());
   if (ParameterNotNull(parameterObject, "playcount"))
     details.m_playCount = (int)parameterObject["playcount"].asInteger();
   if (ParameterNotNull(parameterObject, "runtime"))
     details.m_duration = (int)parameterObject["runtime"].asInteger();
-  UpdateVideoTagField(parameterObject, "director", details.m_director, updatedDetails);
-  UpdateVideoTagField(parameterObject, "studio", details.m_studio, updatedDetails);
+
+  std::vector<std::string> director(details.m_director);
+  UpdateVideoTagField(parameterObject, "director", director, updatedDetails);
+  details.SetDirector(director);
+
+  std::vector<std::string> studio(details.m_studio);
+  UpdateVideoTagField(parameterObject, "studio", studio, updatedDetails);
+  details.SetStudio(studio);
+
   if (ParameterNotNull(parameterObject, "year"))
     details.m_iYear = (int)parameterObject["year"].asInteger();
   if (ParameterNotNull(parameterObject, "plot"))
-    details.m_strPlot = parameterObject["plot"].asString();
+    details.SetPlot(parameterObject["plot"].asString());
   if (ParameterNotNull(parameterObject, "album"))
-    details.m_strAlbum = parameterObject["album"].asString();
-  UpdateVideoTagField(parameterObject, "artist", details.m_artist, updatedDetails);
-  UpdateVideoTagField(parameterObject, "genre", details.m_genre, updatedDetails);
+    details.SetAlbum(parameterObject["album"].asString());
+
+  std::vector<std::string> artist(details.m_artist);
+  UpdateVideoTagField(parameterObject, "artist", artist, updatedDetails);
+  details.SetArtist(artist);
+
+  std::vector<std::string> genre(details.m_genre);
+  UpdateVideoTagField(parameterObject, "genre", genre, updatedDetails);
+  details.SetGenre(genre);
+
   if (ParameterNotNull(parameterObject, "track"))
     details.m_iTrack = (int)parameterObject["track"].asInteger();
   if (ParameterNotNull(parameterObject, "rating"))
     details.m_fRating = parameterObject["rating"].asFloat();
   if (ParameterNotNull(parameterObject, "mpaa"))
-    details.m_strMPAARating = parameterObject["mpaa"].asString();
+    details.SetMPAARating(parameterObject["mpaa"].asString());
   if (ParameterNotNull(parameterObject, "imdbnumber"))
-    details.m_strIMDBNumber = parameterObject["imdbnumber"].asString();
+    details.SetIMDBNumber(parameterObject["imdbnumber"].asString());
   if (ParameterNotNull(parameterObject, "premiered"))
     SetFromDBDate(parameterObject["premiered"], details.m_premiered);
   if (ParameterNotNull(parameterObject, "votes"))
-    details.m_strVotes = parameterObject["votes"].asString();
+    details.SetVotes(parameterObject["votes"].asString());
   if (ParameterNotNull(parameterObject, "lastplayed"))
     SetFromDBDateTime(parameterObject["lastplayed"], details.m_lastPlayed);
   if (ParameterNotNull(parameterObject, "firstaired"))
     SetFromDBDate(parameterObject["firstaired"], details.m_firstAired);
   if (ParameterNotNull(parameterObject, "productioncode"))
-    details.m_strProductionCode = parameterObject["productioncode"].asString();
+    details.SetProductionCode(parameterObject["productioncode"].asString());
   if (ParameterNotNull(parameterObject, "season"))
     details.m_iSeason = (int)parameterObject["season"].asInteger();
   if (ParameterNotNull(parameterObject, "episode"))
     details.m_iEpisode = (int)parameterObject["episode"].asInteger();
   if (ParameterNotNull(parameterObject, "originaltitle"))
-    details.m_strOriginalTitle = parameterObject["originaltitle"].asString();
+    details.SetOriginalTitle(parameterObject["originaltitle"].asString());
   if (ParameterNotNull(parameterObject, "trailer"))
-    details.m_strTrailer = parameterObject["trailer"].asString();
+    details.SetTrailer(parameterObject["trailer"].asString());
   if (ParameterNotNull(parameterObject, "tagline"))
-    details.m_strTagLine = parameterObject["tagline"].asString();
+    details.SetTagLine(parameterObject["tagline"].asString());
   if (ParameterNotNull(parameterObject, "plotoutline"))
-    details.m_strPlotOutline = parameterObject["plotoutline"].asString();
-  UpdateVideoTagField(parameterObject, "writer", details.m_writingCredits, updatedDetails);
-  UpdateVideoTagField(parameterObject, "country", details.m_country, updatedDetails);
+    details.SetPlotOutline(parameterObject["plotoutline"].asString());
+
+  std::vector<std::string> credits(details.m_writingCredits);
+  UpdateVideoTagField(parameterObject, "writer", credits, updatedDetails);
+  details.SetWritingCredits(credits);
+
+  std::vector<std::string> country(details.m_country);
+  UpdateVideoTagField(parameterObject, "country", country, updatedDetails);
+  details.SetCountry(country);
+
   if (ParameterNotNull(parameterObject, "top250"))
     details.m_iTop250 = (int)parameterObject["top250"].asInteger();
   if (ParameterNotNull(parameterObject, "sorttitle"))
-    details.m_strSortTitle = parameterObject["sorttitle"].asString();
+    details.SetSortTitle(parameterObject["sorttitle"].asString());
   if (ParameterNotNull(parameterObject, "episodeguide"))
-    details.m_strEpisodeGuide = parameterObject["episodeguide"].asString();
+    details.SetEpisodeGuide(parameterObject["episodeguide"].asString());
   if (ParameterNotNull(parameterObject, "set"))
   {
-    details.m_strSet = parameterObject["set"].asString();
+    details.SetSet(parameterObject["set"].asString());
     updatedDetails.insert("set");
   }
-  UpdateVideoTagField(parameterObject, "showlink", details.m_showLink, updatedDetails);
-  UpdateVideoTagField(parameterObject, "tag", details.m_tags, updatedDetails);
+
+  std::vector<std::string> showLink(details.m_showLink);
+  UpdateVideoTagField(parameterObject, "showlink", showLink, updatedDetails);
+  details.SetShowLink(showLink);
+
+  std::vector<std::string> tags(details.m_tags);
+  UpdateVideoTagField(parameterObject, "tag", tags, updatedDetails);
+  details.SetTags(tags);
+
   if (ParameterNotNull(parameterObject, "thumbnail"))
   {
-    artwork["thumb"] = parameterObject["thumbnail"].asString();
+    std::string value = parameterObject["thumbnail"].asString();
+    artwork["thumb"] = StringUtils::Trim(value);
     updatedDetails.insert("art.altered");
   }
   if (ParameterNotNull(parameterObject, "fanart"))
   {
-    artwork["fanart"] = parameterObject["fanart"].asString();
+    std::string value = parameterObject["fanart"].asString();
+    artwork["fanart"] = StringUtils::Trim(value);
     updatedDetails.insert("art.altered");
   }
 

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -1388,13 +1388,13 @@ int CVideoDatabase::AddToTable(const std::string& table, const std::string& firs
     if (NULL == m_pDB.get()) return -1;
     if (NULL == m_pDS.get()) return -1;
 
-    std::string strSQL = PrepareSQL("select %s from %s where %s like '%s'", firstField.c_str(), table.c_str(), secondField.c_str(), value.c_str());
+    std::string strSQL = PrepareSQL("select %s from %s where %s like '%s'", firstField.c_str(), table.c_str(), secondField.c_str(), value.substr(0, 255).c_str());
     m_pDS->query(strSQL.c_str());
     if (m_pDS->num_rows() == 0)
     {
       m_pDS->close();
       // doesnt exists, add it
-      strSQL = PrepareSQL("insert into %s (%s, %s) values(NULL, '%s')", table.c_str(), firstField.c_str(), secondField.c_str(), value.c_str());      
+      strSQL = PrepareSQL("insert into %s (%s, %s) values(NULL, '%s')", table.c_str(), firstField.c_str(), secondField.c_str(), value.substr(0, 255).c_str());      
       m_pDS->exec(strSQL.c_str());
       int id = (int)m_pDS->lastinsertid();
       return id;
@@ -1442,13 +1442,13 @@ int CVideoDatabase::AddActor(const std::string& name, const std::string& thumbUR
     std::string trimmedName = name.c_str();
     StringUtils::Trim(trimmedName);
 
-    std::string strSQL=PrepareSQL("select actor_id from actor where name = '%s'", trimmedName.c_str());
+    std::string strSQL=PrepareSQL("select actor_id from actor where name like '%s'", trimmedName.substr(0, 255).c_str());
     m_pDS->query(strSQL.c_str());
     if (m_pDS->num_rows() == 0)
     {
       m_pDS->close();
       // doesnt exists, add it
-      strSQL=PrepareSQL("insert into actor (actor_id, name, art_urls) values(NULL, '%s', '%s')", trimmedName.c_str(), thumbURLs.c_str());
+      strSQL=PrepareSQL("insert into actor (actor_id, name, art_urls) values(NULL, '%s', '%s')", trimmedName.substr(0,255).c_str(), thumbURLs.c_str());
       m_pDS->exec(strSQL.c_str());
       idActor = (int)m_pDS->lastinsertid();
     }
@@ -1459,7 +1459,7 @@ int CVideoDatabase::AddActor(const std::string& name, const std::string& thumbUR
       // update the thumb url's
       if (!thumbURLs.empty())
       {
-        strSQL=PrepareSQL("update actor set art_urls='%s' where actor_id=%i",thumbURLs.c_str(),idActor);
+        strSQL=PrepareSQL("update actor set art_urls = '%s' where actor_id = %i", thumbURLs.c_str(), idActor);
         m_pDS->exec(strSQL.c_str());
       }
     }

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -1394,7 +1394,7 @@ int CVideoDatabase::AddToTable(const std::string& table, const std::string& firs
     {
       m_pDS->close();
       // doesnt exists, add it
-      strSQL = PrepareSQL("insert into %s (%s, %s) values(NULL, '%s')", table.c_str(), firstField.c_str(), secondField.c_str(), value.substr(0, 255).c_str());      
+      strSQL = PrepareSQL("insert into %s (%s, %s) values(NULL, '%s')", table.c_str(), firstField.c_str(), secondField.c_str(), value.substr(0, 255).c_str());
       m_pDS->exec(strSQL.c_str());
       int id = (int)m_pDS->lastinsertid();
       return id;
@@ -4552,74 +4552,11 @@ void CVideoDatabase::UpdateTables(int iVersion)
   }
   if (iVersion < 91)
   {
-    // handle corrupted databases with multiple actors with the same name
-    std::map<std::string, std::vector<int> > duplicateActors;
-    m_pDS->query("SELECT TRIM(strActor) as strActor FROM actors GROUP BY TRIM(strActor) HAVING COUNT(1) > 1");
-    while (!m_pDS->eof())
-    {
-      std::string strActor = m_pDS->fv(0).get_asString();
-      std::vector<int> ids;
-
-      m_pDS2->query(PrepareSQL("SELECT idActor FROM actors WHERE TRIM(strActor) = '%s' ORDER BY strThumb DESC", strActor.c_str()));
-      while (!m_pDS2->eof())
-      {
-        ids.push_back(m_pDS2->fv(0).get_asInt());
-        m_pDS2->next();
-      }
-      m_pDS2->close();
-
-      duplicateActors.insert(std::make_pair(strActor, ids));
-
-      m_pDS->next();
-    }
-    m_pDS->close();
-
-    // now go through all duplicate actors and adjust all link tables to use the first actor entry
-    for (std::map<std::string, std::vector<int> >::const_iterator actor = duplicateActors.begin(); actor != duplicateActors.end(); ++actor)
-    {
-      // we are only interested in duplicate actors
-      if (actor->second.size() < 2)
-        continue;
-
-      int newActorId = *actor->second.begin();
-
-      // cleanup all duplicate actor references in the link tables
-      CleanupActorLinkTablePre91("actorlinkmovie", "idActor", "idMovie", newActorId, actor->first);
-      CleanupActorLinkTablePre91("actorlinktvshow", "idActor", "idShow", newActorId, actor->first);
-      CleanupActorLinkTablePre91("actorlinkepisode", "idActor", "idEpisode", newActorId, actor->first);
-      CleanupActorLinkTablePre91("directorlinkmovie", "idDirector", "idMovie", newActorId, actor->first);
-      CleanupActorLinkTablePre91("directorlinktvshow", "idDirector", "idShow", newActorId, actor->first);
-      CleanupActorLinkTablePre91("directorlinkepisode", "idDirector", "idEpisode", newActorId, actor->first);
-      CleanupActorLinkTablePre91("directorlinkmusicvideo", "idDirector", "idMVideo", newActorId, actor->first);
-      CleanupActorLinkTablePre91("writerlinkmovie", "idWriter", "idMovie", newActorId, actor->first);
-      CleanupActorLinkTablePre91("writerlinkepisode", "idWriter", "idEpisode", newActorId, actor->first);
-      CleanupActorLinkTablePre91("artistlinkmusicvideo", "idArtist", "idMVideo", newActorId, actor->first);
-
-      for (std::vector<int>::const_iterator actorId = actor->second.begin() + 1; actorId != actor->second.end(); ++actorId)
-      {
-        // update all the link tables refering to the actors table
-        m_pDS->exec(PrepareSQL("UPDATE actorlinkmovie SET idActor = %d WHERE idActor = %d", newActorId, *actorId));
-        m_pDS->exec(PrepareSQL("UPDATE actorlinktvshow SET idActor = %d WHERE idActor = %d", newActorId, *actorId));
-        m_pDS->exec(PrepareSQL("UPDATE actorlinkepisode SET idActor = %d WHERE idActor = %d", newActorId, *actorId));
-        m_pDS->exec(PrepareSQL("UPDATE directorlinkmovie SET idDirector = %d WHERE idDirector = %d", newActorId, *actorId));
-        m_pDS->exec(PrepareSQL("UPDATE directorlinktvshow SET idDirector = %d WHERE idDirector = %d", newActorId, *actorId));
-        m_pDS->exec(PrepareSQL("UPDATE directorlinkepisode SET idDirector = %d WHERE idDirector = %d", newActorId, *actorId));
-        m_pDS->exec(PrepareSQL("UPDATE directorlinkmusicvideo SET idDirector = %d WHERE idDirector = %d", newActorId, *actorId));
-        m_pDS->exec(PrepareSQL("UPDATE writerlinkmovie SET idWriter = %d WHERE idWriter = %d", newActorId, *actorId));
-        m_pDS->exec(PrepareSQL("UPDATE writerlinkepisode SET idWriter = %d WHERE idWriter = %d", newActorId, *actorId));
-        m_pDS->exec(PrepareSQL("UPDATE artistlinkmusicvideo SET idArtist = %d WHERE idArtist = %d", newActorId, *actorId));
-
-        // remove the duplicate entry from the actors table
-        m_pDS->exec(PrepareSQL("DELETE FROM actors WHERE idActor = %d", *actorId));
-      }
-    }
-    m_pDS->exec("UPDATE actors set strActor = TRIM(strActor)");
-
     // create actor link table
     m_pDS->exec("CREATE TABLE actor_link(actor_id INT, media_id INT, media_type TEXT, role TEXT, cast_order INT)");
-    m_pDS->exec("INSERT INTO actor_link(actor_id, media_id, media_type, role, cast_order) SELECT idActor,idMovie,'movie',strRole,iOrder from actorlinkmovie");
-    m_pDS->exec("INSERT INTO actor_link(actor_id, media_id, media_type, role, cast_order) SELECT idActor,idShow,'tvshow',strRole,iOrder from actorlinktvshow");
-    m_pDS->exec("INSERT INTO actor_link(actor_id, media_id, media_type, role, cast_order) SELECT idActor,idEpisode,'episode',strRole,iOrder from actorlinkepisode");
+    m_pDS->exec("INSERT INTO actor_link(actor_id, media_id, media_type, role, cast_order) SELECT DISTINCT idActor, idMovie, 'movie', strRole, iOrder from actorlinkmovie");
+    m_pDS->exec("INSERT INTO actor_link(actor_id, media_id, media_type, role, cast_order) SELECT DISTINCT idActor, idShow, 'tvshow', strRole, iOrder from actorlinktvshow");
+    m_pDS->exec("INSERT INTO actor_link(actor_id, media_id, media_type, role, cast_order) SELECT DISTINCT idActor, idEpisode, 'episode', strRole, iOrder from actorlinkepisode");
     m_pDS->exec("DROP TABLE IF EXISTS actorlinkmovie");
     m_pDS->exec("DROP TABLE IF EXISTS actorlinktvshow");
     m_pDS->exec("DROP TABLE IF EXISTS actorlinkepisode");
@@ -4629,10 +4566,10 @@ void CVideoDatabase::UpdateTables(int iVersion)
 
     // directors
     m_pDS->exec("CREATE TABLE director_link(actor_id INTEGER, media_id INTEGER, media_type TEXT)");
-    m_pDS->exec("INSERT INTO director_link(actor_id, media_id, media_type) SELECT idDirector,idMovie,'movie' FROM directorlinkmovie");
-    m_pDS->exec("INSERT INTO director_link(actor_id, media_id, media_type) SELECT idDirector,idShow,'tvshow' FROM directorlinktvshow");
-    m_pDS->exec("INSERT INTO director_link(actor_id, media_id, media_type) SELECT idDirector,idEpisode,'episode' FROM directorlinkepisode");
-    m_pDS->exec("INSERT INTO director_link(actor_id, media_id, media_type) SELECT idDirector,idMVideo,'musicvideo' FROM directorlinkmusicvideo");
+    m_pDS->exec("INSERT INTO director_link(actor_id, media_id, media_type) SELECT DISTINCT idDirector, idMovie, 'movie' FROM directorlinkmovie");
+    m_pDS->exec("INSERT INTO director_link(actor_id, media_id, media_type) SELECT DISTINCT idDirector, idShow, 'tvshow' FROM directorlinktvshow");
+    m_pDS->exec("INSERT INTO director_link(actor_id, media_id, media_type) SELECT DISTINCT idDirector, idEpisode, 'episode' FROM directorlinkepisode");
+    m_pDS->exec("INSERT INTO director_link(actor_id, media_id, media_type) SELECT DISTINCT idDirector, idMVideo, 'musicvideo' FROM directorlinkmusicvideo");
     m_pDS->exec("DROP TABLE IF EXISTS directorlinkmovie");
     m_pDS->exec("DROP TABLE IF EXISTS directorlinktvshow");
     m_pDS->exec("DROP TABLE IF EXISTS directorlinkepisode");
@@ -4640,20 +4577,20 @@ void CVideoDatabase::UpdateTables(int iVersion)
 
     // writers
     m_pDS->exec("CREATE TABLE writer_link(actor_id INTEGER, media_id INTEGER, media_type TEXT)");
-    m_pDS->exec("INSERT INTO writer_link(actor_id, media_id, media_type) SELECT idWriter,idMovie,'movie' FROM writerlinkmovie");
-    m_pDS->exec("INSERT INTO writer_link(actor_id, media_id, media_type) SELECT idWriter,idEpisode,'episode' FROM writerlinkepisode");
+    m_pDS->exec("INSERT INTO writer_link(actor_id, media_id, media_type) SELECT DISTINCT idWriter, idMovie, 'movie' FROM writerlinkmovie");
+    m_pDS->exec("INSERT INTO writer_link(actor_id, media_id, media_type) SELECT DISTINCT idWriter, idEpisode, 'episode' FROM writerlinkepisode");
     m_pDS->exec("DROP TABLE IF EXISTS writerlinkmovie");
     m_pDS->exec("DROP TABLE IF EXISTS writerlinkepisode");
 
     // music artist
-    m_pDS->exec("INSERT INTO actor_link(actor_id, media_id, media_type) SELECT idArtist,idMVideo,'musicvideo' FROM artistlinkmusicvideo");
+    m_pDS->exec("INSERT INTO actor_link(actor_id, media_id, media_type) SELECT DISTINCT idArtist, idMVideo, 'musicvideo' FROM artistlinkmusicvideo");
     m_pDS->exec("DROP TABLE IF EXISTS artistlinkmusicvideo");
 
     // studios
     m_pDS->exec("CREATE TABLE studio_link(studio_id INTEGER, media_id INTEGER, media_type TEXT)");
-    m_pDS->exec("INSERT INTO studio_link(studio_id, media_id, media_type) SELECT idStudio,idMovie,'movie' FROM studiolinkmovie");
-    m_pDS->exec("INSERT INTO studio_link(studio_id, media_id, media_type) SELECT idStudio,idShow,'tvshow' FROM studiolinktvshow");
-    m_pDS->exec("INSERT INTO studio_link(studio_id, media_id, media_type) SELECT idStudio,idMVideo,'musicvideo' FROM studiolinkmusicvideo");
+    m_pDS->exec("INSERT INTO studio_link(studio_id, media_id, media_type) SELECT DISTINCT idStudio, idMovie, 'movie' FROM studiolinkmovie");
+    m_pDS->exec("INSERT INTO studio_link(studio_id, media_id, media_type) SELECT DISTINCT idStudio, idShow, 'tvshow' FROM studiolinktvshow");
+    m_pDS->exec("INSERT INTO studio_link(studio_id, media_id, media_type) SELECT DISTINCT idStudio, idMVideo, 'musicvideo' FROM studiolinkmusicvideo");
     m_pDS->exec("DROP TABLE IF EXISTS studiolinkmovie");
     m_pDS->exec("DROP TABLE IF EXISTS studiolinktvshow");
     m_pDS->exec("DROP TABLE IF EXISTS studiolinkmusicvideo");
@@ -4664,9 +4601,9 @@ void CVideoDatabase::UpdateTables(int iVersion)
 
     // genres
     m_pDS->exec("CREATE TABLE genre_link(genre_id INTEGER, media_id INTEGER, media_type TEXT)");
-    m_pDS->exec("INSERT INTO genre_link(genre_id, media_id, media_type) SELECT idGenre,idMovie,'movie' FROM genrelinkmovie");
-    m_pDS->exec("INSERT INTO genre_link(genre_id, media_id, media_type) SELECT idGenre,idShow,'tvshow' FROM genrelinktvshow");
-    m_pDS->exec("INSERT INTO genre_link(genre_id, media_id, media_type) SELECT idGenre,idMVideo,'musicvideo' FROM genrelinkmusicvideo");
+    m_pDS->exec("INSERT INTO genre_link(genre_id, media_id, media_type) SELECT DISTINCT idGenre, idMovie, 'movie' FROM genrelinkmovie");
+    m_pDS->exec("INSERT INTO genre_link(genre_id, media_id, media_type) SELECT DISTINCT idGenre, idShow, 'tvshow' FROM genrelinktvshow");
+    m_pDS->exec("INSERT INTO genre_link(genre_id, media_id, media_type) SELECT DISTINCT idGenre, idMVideo, 'musicvideo' FROM genrelinkmusicvideo");
     m_pDS->exec("DROP TABLE IF EXISTS genrelinkmovie");
     m_pDS->exec("DROP TABLE IF EXISTS genrelinktvshow");
     m_pDS->exec("DROP TABLE IF EXISTS genrelinkmusicvideo");
@@ -4677,7 +4614,7 @@ void CVideoDatabase::UpdateTables(int iVersion)
 
     // country
     m_pDS->exec("CREATE TABLE country_link(country_id INTEGER, media_id INTEGER, media_type TEXT)");
-    m_pDS->exec("INSERT INTO country_link(country_id, media_id, media_type) SELECT idCountry,idMovie,'movie' FROM countrylinkmovie");
+    m_pDS->exec("INSERT INTO country_link(country_id, media_id, media_type) SELECT DISTINCT idCountry, idMovie, 'movie' FROM countrylinkmovie");
     m_pDS->exec("DROP TABLE IF EXISTS countrylinkmovie");
     m_pDS->exec("CREATE TABLE countrynew(country_id INTEGER PRIMARY KEY, name TEXT)");
     m_pDS->exec("INSERT INTO countrynew(country_id, name) SELECT idCountry,strCountry FROM country");
@@ -4686,49 +4623,136 @@ void CVideoDatabase::UpdateTables(int iVersion)
 
     // tags
     m_pDS->exec("CREATE TABLE tag_link(tag_id INTEGER, media_id INTEGER, media_type TEXT)");
-    m_pDS->exec("INSERT INTO tag_link(tag_id, media_id, media_type) SELECT idTag,idMedia,media_type FROM taglinks");
+    m_pDS->exec("INSERT INTO tag_link(tag_id, media_id, media_type) SELECT DISTINCT idTag, idMedia, media_type FROM taglinks");
     m_pDS->exec("DROP TABLE IF EXISTS taglinks");
     m_pDS->exec("CREATE TABLE tagnew(tag_id INTEGER PRIMARY KEY, name TEXT)");
     m_pDS->exec("INSERT INTO tagnew(tag_id, name) SELECT idTag,strTag FROM tag");
     m_pDS->exec("DROP TABLE IF EXISTS tag");
     m_pDS->exec("ALTER TABLE tagnew RENAME TO tag");
   }
+
+  if (iVersion < 93)
+  {
+    // cleanup main tables
+    std::string valuesSql;
+    for(int i = 0; i < VIDEODB_MAX_COLUMNS; i++)
+    {
+      valuesSql += StringUtils::Format("c%02d = TRIM(c%02d)", i, i);
+      if (i < VIDEODB_MAX_COLUMNS - 1)
+        valuesSql += ",";
+    }
+    m_pDS->exec("UPDATE episode SET " + valuesSql);
+    m_pDS->exec("UPDATE movie SET " + valuesSql);
+    m_pDS->exec("UPDATE musicvideo SET " + valuesSql);
+    m_pDS->exec("UPDATE tvshow SET " + valuesSql);
+
+    // cleanup additional tables
+    std::map<std::string, std::vector<std::string>> additionalTablesMap = {
+      {"actor", {"actor_link", "director_link", "writer_link"}},
+      {"studio", {"studio_link"}},
+      {"genre", {"genre_link"}},
+      {"country", {"country_link"}},
+      {"tag", {"tag_link"}}
+    };
+    for (const auto& addtionalTableEntry : additionalTablesMap)
+    {
+      std::string table = addtionalTableEntry.first;
+      std::string tablePk = addtionalTableEntry.first + "_id";
+      std::map<int, std::string> duplicatesMinMap;
+      std::map<int, std::string> duplicatesMap;
+
+      // cleanup name
+      m_pDS->exec(PrepareSQL("UPDATE %s SET name = TRIM(name)",
+                             table.c_str()));
+
+      // shrink name to length 255
+      m_pDS->exec(PrepareSQL("UPDATE %s SET name = SUBSTR(name, 1, 255) WHERE LENGTH(name) > 255",
+                             table.c_str()));
+
+      // fetch main entries
+      m_pDS->query(PrepareSQL("SELECT MIN(%s), name FROM %s GROUP BY name HAVING COUNT(1) > 1",
+                              tablePk.c_str(), table.c_str()));
+
+      while (!m_pDS->eof())
+      {
+        duplicatesMinMap.insert(std::make_pair(m_pDS->fv(0).get_asInt(), m_pDS->fv(1).get_asString()));
+        m_pDS->next();
+      }
+      m_pDS->close();
+
+      // fetch duplicate entries
+      for (const auto& entry : duplicatesMinMap)
+      {
+        m_pDS->query(PrepareSQL("SELECT %s FROM %s WHERE name = '%s' AND %s <> %i",
+                                tablePk.c_str(), table.c_str(),
+                                entry.second.c_str(), tablePk.c_str(), entry.first));
+
+        std::stringstream ids;
+        while (!m_pDS->eof())
+        {
+          int id = m_pDS->fv(0).get_asInt();
+          m_pDS->next();
+
+          ids << id;
+          if (!m_pDS->eof())
+            ids << ",";
+        }
+        m_pDS->close();
+
+        duplicatesMap.insert(std::make_pair(entry.first, ids.str()));
+      }
+
+      // cleanup duplicates in link tables
+      for (const auto& subTable : addtionalTableEntry.second)
+      {
+        // create indexes to speed up things
+        m_pDS->exec(PrepareSQL("CREATE INDEX ix_%s ON %s (%s)",
+                               subTable.c_str(), subTable.c_str(), tablePk.c_str()));
+
+        // migrate every duplicate entry to the main entry
+        for (const auto& entry : duplicatesMap)
+        {
+          m_pDS->exec(PrepareSQL("UPDATE %s SET %s = %i WHERE %s IN (%s) ",
+                                 subTable.c_str(), tablePk.c_str(), entry.first,
+                                 tablePk.c_str(), entry.second.c_str()));
+        }
+
+        // clear all duplicates in the link tables
+        if (subTable == "actor_link")
+        {
+          // as a distinct won't work because of role and cast_order and a group by kills a
+          // low powered mysql, we de-dupe it with REPLACE INTO while using the real unique index
+          m_pDS->exec("CREATE TABLE temp_actor_link(actor_id INT, media_id INT, media_type TEXT, role TEXT, cast_order INT)");
+          m_pDS->exec("CREATE UNIQUE INDEX ix_temp_actor_link ON temp_actor_link (actor_id, media_type(20), media_id)");
+          m_pDS->exec("REPLACE INTO temp_actor_link SELECT * FROM actor_link");
+          m_pDS->exec("DROP INDEX ix_temp_actor_link ON temp_actor_link");
+        }
+        else
+        {
+          m_pDS->exec(PrepareSQL("CREATE TABLE temp_%s AS SELECT DISTINCT * FROM %s",
+                                 subTable.c_str(), subTable.c_str()));
+        }
+
+        m_pDS->exec(PrepareSQL("DROP TABLE IF EXISTS %s",
+                               subTable.c_str()));
+
+        m_pDS->exec(PrepareSQL("ALTER TABLE temp_%s RENAME TO %s",
+                               subTable.c_str(), subTable.c_str()));
+      }
+
+      // delete duplicates in main table
+      for (const auto& entry : duplicatesMap)
+      {
+        m_pDS->exec(PrepareSQL("DELETE FROM %s WHERE %s IN (%s)",
+                               table.c_str(), tablePk.c_str(), entry.second.c_str()));
+      }
+    }
+  }
 }
 
 int CVideoDatabase::GetSchemaVersion() const
 {
-  return 92;
-}
-
-void CVideoDatabase::CleanupActorLinkTablePre91(const std::string &linkTable, const std::string &linkTableIdActor, const std::string &linkTableIdMedia, int idActor, const std::string &strActor)
-{
-  if (linkTable.empty() || linkTableIdActor.empty() || linkTableIdMedia.empty() ||
-    idActor <= 0 || strActor.empty())
-    return;
-
-  // get all duplicate actors linked to the same media item
-  m_pDS->query(PrepareSQL("SELECT actors.idActor, l1.%s FROM actors "
-    "JOIN %s AS l1 ON "
-    "  l1.%s = actors.idActor "
-    "JOIN %s AS l2 ON "
-    "  l2.%s = l1.%s "
-    "WHERE TRIM(actors.strActor) = '%s' AND l1.%s != %d AND l2.%s = %d",
-    linkTableIdMedia.c_str(),
-    linkTable.c_str(), linkTableIdActor.c_str(),
-    linkTable.c_str(), linkTableIdMedia.c_str(), linkTableIdMedia.c_str(),
-    strActor.c_str(), linkTableIdActor.c_str(), idActor, linkTableIdActor.c_str(), idActor));
-
-  // and delete the duplicates
-  while (!m_pDS->eof())
-  {
-    int idActor = m_pDS->fv(0).get_asInt();
-    int idLink = m_pDS->fv(1).get_asInt();
-    m_pDS2->exec(PrepareSQL("DELETE FROM %s WHERE %s = %d AND %s = %d",
-      linkTable.c_str(), linkTableIdMedia.c_str(), idLink, linkTableIdActor.c_str(), idActor));
-
-    m_pDS->next();
-  }
-  m_pDS->close();
+  return 93;
 }
 
 bool CVideoDatabase::LookupByFolders(const std::string &path, bool shows)

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -909,8 +909,6 @@ private:
   virtual int GetExportVersion() const { return 1; };
   const char *GetBaseDBName() const { return "MyVideos"; };
 
-  void CleanupActorLinkTablePre91(const std::string &linkTable, const std::string &linkTableIdActor, const std::string &linkTableIdMedia, int idActor, const std::string &strActor);
-
   void ConstructPath(std::string& strDest, const std::string& strPath, const std::string& strFileName);
   void SplitPath(const std::string& strFileNameAndPath, std::string& strPath, std::string& strFileName);
   void InvalidatePathHash(const std::string& strPath);

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -567,10 +567,15 @@ const std::string CVideoInfoTag::GetCast(bool bIncludeRole /*= false*/) const
 
 void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
 {
-  XMLUtils::GetString(movie, "title", m_strTitle);
-  XMLUtils::GetString(movie, "originaltitle", m_strOriginalTitle);
-  XMLUtils::GetString(movie, "showtitle", m_strShowTitle);
-  XMLUtils::GetString(movie, "sorttitle", m_strSortTitle);
+  std::string value;
+  XMLUtils::GetString(movie, "title", value);
+  SetTitle(value);
+  XMLUtils::GetString(movie, "originaltitle", value);
+  SetOriginalTitle(value);
+  XMLUtils::GetString(movie, "showtitle", value);
+  SetShowTitle(value);
+  XMLUtils::GetString(movie, "sorttitle", value);
+  SetSortTitle(value);
   XMLUtils::GetFloat(movie, "rating", m_fRating);
   XMLUtils::GetFloat(movie, "epbookmark", m_fEpBookmark);
   int max_value = 10;
@@ -584,7 +589,8 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
   XMLUtils::GetInt(movie, "season", m_iSeason);
   XMLUtils::GetInt(movie, "episode", m_iEpisode);
   XMLUtils::GetInt(movie, "track", m_iTrack);
-  XMLUtils::GetString(movie, "uniqueid", m_strUniqueId);
+  XMLUtils::GetString(movie, "uniqueid", value);
+  SetUniqueId(value);
   XMLUtils::GetInt(movie, "displayseason", m_iSpecialSortSeason);
   XMLUtils::GetInt(movie, "displayepisode", m_iSpecialSortEpisode);
   int after=0;
@@ -594,27 +600,40 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
     m_iSpecialSortSeason = after;
     m_iSpecialSortEpisode = 0x1000; // should be more than any realistic episode number
   }
-  XMLUtils::GetString(movie, "votes", m_strVotes);
-  XMLUtils::GetString(movie, "outline", m_strPlotOutline);
-  XMLUtils::GetString(movie, "plot", m_strPlot);
-  XMLUtils::GetString(movie, "tagline", m_strTagLine);
-  std::string runtime;
-  if (XMLUtils::GetString(movie, "runtime", runtime) && !runtime.empty())
-    m_duration = GetDurationFromMinuteString(runtime);
-  XMLUtils::GetString(movie, "mpaa", m_strMPAARating);
+  XMLUtils::GetString(movie, "votes", value);
+  SetVotes(value);
+  XMLUtils::GetString(movie, "outline", value);
+  SetPlotOutline(value);
+  XMLUtils::GetString(movie, "plot", value);
+  SetPlot(value);
+  XMLUtils::GetString(movie, "tagline", value);
+  SetTagLine(value);
+  if (XMLUtils::GetString(movie, "runtime", value) && !value.empty())
+    m_duration = GetDurationFromMinuteString(StringUtils::Trim(value));
+  XMLUtils::GetString(movie, "mpaa", value);
+  SetMPAARating(value);
   XMLUtils::GetInt(movie, "playcount", m_playCount);
   XMLUtils::GetDate(movie, "lastplayed", m_lastPlayed);
-  XMLUtils::GetString(movie, "file", m_strFile);
-  XMLUtils::GetString(movie, "path", m_strPath);
-  XMLUtils::GetString(movie, "id", m_strIMDBNumber);
-  XMLUtils::GetString(movie, "filenameandpath", m_strFileNameAndPath);
+  XMLUtils::GetString(movie, "file", value);
+  SetFile(value);
+  XMLUtils::GetString(movie, "path", value);
+  SetPath(value);
+  XMLUtils::GetString(movie, "id", value);
+  SetIMDBNumber(value);
+  XMLUtils::GetString(movie, "filenameandpath", value);
+  SetFileNameAndPath(value);
   XMLUtils::GetDate(movie, "premiered", m_premiered);
-  XMLUtils::GetString(movie, "status", m_strStatus);
-  XMLUtils::GetString(movie, "code", m_strProductionCode);
+  XMLUtils::GetString(movie, "status", value);
+  SetStatus(value);
+  XMLUtils::GetString(movie, "code", value);
+  SetProductionCode(value);
   XMLUtils::GetDate(movie, "aired", m_firstAired);
-  XMLUtils::GetString(movie, "album", m_strAlbum);
-  XMLUtils::GetString(movie, "trailer", m_strTrailer);
-  XMLUtils::GetString(movie, "basepath", m_basePath);
+  XMLUtils::GetString(movie, "album", value);
+  SetAlbum(value);
+  XMLUtils::GetString(movie, "trailer", value);
+  SetTrailer(value);
+  XMLUtils::GetString(movie, "basepath", value);
+  SetBasePath(value);
 
   size_t iThumbCount = m_strPictureURL.m_url.size();
   std::string xmlAdd = m_strPictureURL.m_xml;
@@ -641,11 +660,25 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
     m_strPictureURL.m_xml = xmlAdd;
   }
 
-  XMLUtils::GetStringArray(movie, "genre", m_genre, prioritise, g_advancedSettings.m_videoItemSeparator);
-  XMLUtils::GetStringArray(movie, "country", m_country, prioritise, g_advancedSettings.m_videoItemSeparator);
-  XMLUtils::GetStringArray(movie, "credits", m_writingCredits, prioritise, g_advancedSettings.m_videoItemSeparator);
-  XMLUtils::GetStringArray(movie, "director", m_director, prioritise, g_advancedSettings.m_videoItemSeparator);
-  XMLUtils::GetStringArray(movie, "showlink", m_showLink, prioritise, g_advancedSettings.m_videoItemSeparator);
+  std::vector<std::string> genres(m_genre);
+  XMLUtils::GetStringArray(movie, "genre", genres, prioritise, g_advancedSettings.m_videoItemSeparator);
+  SetGenre(genres);
+
+  std::vector<std::string> country(m_country);
+  XMLUtils::GetStringArray(movie, "country", country, prioritise, g_advancedSettings.m_videoItemSeparator);
+  SetCountry(country);
+
+  std::vector<std::string> credits(m_writingCredits);
+  XMLUtils::GetStringArray(movie, "credits", credits, prioritise, g_advancedSettings.m_videoItemSeparator);
+  SetWritingCredits(credits);
+
+  std::vector<std::string> director(m_director);
+  XMLUtils::GetStringArray(movie, "director", director, prioritise, g_advancedSettings.m_videoItemSeparator);
+  SetDirector(director);
+
+  std::vector<std::string> showLink(m_showLink);
+  XMLUtils::GetStringArray(movie, "showlink", showLink, prioritise, g_advancedSettings.m_videoItemSeparator);
+  SetShowLink(showLink);
 
   // cast
   const TiXmlElement* node = movie->FirstChildElement("actor");
@@ -658,7 +691,8 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
     {
       SActorInfo info;
       info.strName = actor->FirstChild()->Value();
-      XMLUtils::GetString(node, "role", info.strRole);
+      XMLUtils::GetString(node, "role", value);
+      info.strRole = StringUtils::Trim(value);
       XMLUtils::GetInt(node, "order", info.order);
       const TiXmlElement* thumb = node->FirstChildElement("thumb");
       while (thumb)
@@ -674,13 +708,22 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
     node = node->NextSiblingElement("actor");
   }
 
-  XMLUtils::GetString(movie, "set", m_strSet);
-  XMLUtils::GetStringArray(movie, "tag", m_tags, prioritise, g_advancedSettings.m_videoItemSeparator);
-  XMLUtils::GetStringArray(movie, "studio", m_studio, prioritise, g_advancedSettings.m_videoItemSeparator);
+  XMLUtils::GetString(movie, "set", value);
+  SetSet(value);
+
+  std::vector<std::string> tags(m_tags);
+  XMLUtils::GetStringArray(movie, "tag", tags, prioritise, g_advancedSettings.m_videoItemSeparator);
+  SetTags(tags);
+
+  std::vector<std::string> studio(m_studio);
+  XMLUtils::GetStringArray(movie, "studio", studio, prioritise, g_advancedSettings.m_videoItemSeparator);
+  SetStudio(studio);
+
   // artists
+  std::vector<std::string> artist(m_artist);
   node = movie->FirstChildElement("artist");
   if (node && node->FirstChild() && prioritise)
-    m_artist.clear();
+    artist.clear();
   while (node)
   {
     const TiXmlNode* pNode = node->FirstChild("name");
@@ -693,12 +736,13 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
     {
       const char* clear=node->Attribute("clear");
       if (clear && stricmp(clear,"true")==0)
-        m_artist.clear();
-      vector<string> artists = StringUtils::Split(pValue, g_advancedSettings.m_videoItemSeparator);
-      m_artist.insert(m_artist.end(), artists.begin(), artists.end());
+        artist.clear();
+      vector<string> newArtists = StringUtils::Split(pValue, g_advancedSettings.m_videoItemSeparator);
+      artist.insert(artist.end(), newArtists.begin(), newArtists.end());
     }
     node = node->NextSiblingElement("artist");
   }
+  SetArtist(artist);
 
   node = movie->FirstChildElement("fileinfo");
   if (node)
@@ -711,8 +755,10 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
       while ((nodeDetail = nodeStreamDetails->IterateChildren("audio", nodeDetail)))
       {
         CStreamDetailAudio *p = new CStreamDetailAudio();
-        XMLUtils::GetString(nodeDetail, "codec", p->m_strCodec);
-        XMLUtils::GetString(nodeDetail, "language", p->m_strLanguage);
+        XMLUtils::GetString(nodeDetail, "codec", value);
+        p->m_strCodec = StringUtils::Trim(value);
+        XMLUtils::GetString(nodeDetail, "language", value);
+        p->m_strLanguage = StringUtils::Trim(value);
         XMLUtils::GetInt(nodeDetail, "channels", p->m_iChannels);
         StringUtils::ToLower(p->m_strCodec);
         StringUtils::ToLower(p->m_strLanguage);
@@ -722,12 +768,14 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
       while ((nodeDetail = nodeStreamDetails->IterateChildren("video", nodeDetail)))
       {
         CStreamDetailVideo *p = new CStreamDetailVideo();
-        XMLUtils::GetString(nodeDetail, "codec", p->m_strCodec);
+        XMLUtils::GetString(nodeDetail, "codec", value);
+        p->m_strCodec = StringUtils::Trim(value);
         XMLUtils::GetFloat(nodeDetail, "aspect", p->m_fAspect);
         XMLUtils::GetInt(nodeDetail, "width", p->m_iWidth);
         XMLUtils::GetInt(nodeDetail, "height", p->m_iHeight);
         XMLUtils::GetInt(nodeDetail, "durationinseconds", p->m_iDuration);
-        XMLUtils::GetString(nodeDetail, "stereomode", p->m_strStereoMode);
+        XMLUtils::GetString(nodeDetail, "stereomode", value);
+        p->m_strStereoMode = StringUtils::Trim(value);
         StringUtils::ToLower(p->m_strCodec);
         StringUtils::ToLower(p->m_strStereoMode);
         m_streamDetails.AddStream(p);
@@ -736,7 +784,8 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
       while ((nodeDetail = nodeStreamDetails->IterateChildren("subtitle", nodeDetail)))
       {
         CStreamDetailSubtitle *p = new CStreamDetailSubtitle();
-        XMLUtils::GetString(nodeDetail, "language", p->m_strLanguage);
+        XMLUtils::GetString(nodeDetail, "language", value);
+        p->m_strLanguage = StringUtils::Trim(value);
         StringUtils::ToLower(p->m_strLanguage);
         m_streamDetails.AddStream(p);
       }
@@ -819,4 +868,167 @@ unsigned int CVideoInfoTag::GetDurationFromMinuteString(const std::string &runti
     CLog::Log(LOGWARNING, "%s <runtime> should be in minutes. Interpreting '%s' as %u minutes", __FUNCTION__, runtime.c_str(), duration);
   }
   return duration*60;
+}
+
+void CVideoInfoTag::SetBasePath(std::string basePath)
+{
+  m_basePath = Trim(std::move(basePath));
+}
+
+void CVideoInfoTag::SetDirector(std::vector<std::string> director)
+{
+  m_director = Trim(std::move(director));
+}
+
+void CVideoInfoTag::SetWritingCredits(std::vector<std::string> writingCredits)
+{
+  m_writingCredits = Trim(std::move(writingCredits));
+}
+
+void CVideoInfoTag::SetGenre(std::vector<std::string> genre)
+{
+  m_genre = Trim(std::move(genre));
+}
+
+void CVideoInfoTag::SetCountry(std::vector<std::string> country)
+{
+  m_country = Trim(std::move(country));
+}
+
+void CVideoInfoTag::SetTagLine(std::string tagLine)
+{
+  m_strTagLine = Trim(std::move(tagLine));
+}
+
+void CVideoInfoTag::SetPlotOutline(std::string plotOutline)
+{
+  m_strPlotOutline = Trim(std::move(plotOutline));
+}
+
+void CVideoInfoTag::SetTrailer(std::string trailer)
+{
+  m_strTrailer = Trim(std::move(trailer));
+}
+
+void CVideoInfoTag::SetPlot(std::string plot)
+{
+  m_strPlot = Trim(std::move(plot));
+}
+
+void CVideoInfoTag::SetTitle(std::string title)
+{
+  m_strTitle = Trim(std::move(title));
+}
+
+void CVideoInfoTag::SetSortTitle(std::string sortTitle)
+{
+  m_strSortTitle = Trim(std::move(sortTitle));
+}
+
+void CVideoInfoTag::SetPictureURL(CScraperUrl &pictureURL)
+{
+  m_strPictureURL = pictureURL;
+}
+
+void CVideoInfoTag::SetVotes(std::string votes)
+{
+  m_strVotes = Trim(std::move(votes));
+}
+
+void CVideoInfoTag::SetArtist(std::vector<std::string> artist)
+{
+  m_artist = Trim(std::move(artist));
+}
+
+void CVideoInfoTag::SetSet(std::string set)
+{
+  m_strSet = Trim(std::move(set));
+}
+
+void CVideoInfoTag::SetTags(std::vector<std::string> tags)
+{
+  m_tags = Trim(std::move(tags));
+}
+
+void CVideoInfoTag::SetFile(std::string file)
+{
+  m_strFile = Trim(std::move(file));
+}
+
+void CVideoInfoTag::SetPath(std::string path)
+{
+  m_strPath = Trim(std::move(path));
+}
+
+void CVideoInfoTag::SetIMDBNumber(std::string imdbNumber)
+{
+  m_strIMDBNumber = Trim(std::move(imdbNumber));
+}
+
+void CVideoInfoTag::SetMPAARating(std::string mpaaRating)
+{
+  m_strMPAARating = Trim(std::move(mpaaRating));
+}
+
+void CVideoInfoTag::SetFileNameAndPath(std::string fileNameAndPath)
+{
+  m_strFileNameAndPath = Trim(std::move(fileNameAndPath));
+}
+
+void CVideoInfoTag::SetOriginalTitle(std::string originalTitle)
+{
+  m_strOriginalTitle = Trim(std::move(originalTitle));
+}
+
+void CVideoInfoTag::SetEpisodeGuide(std::string episodeGuide)
+{
+  m_strEpisodeGuide = Trim(std::move(episodeGuide));
+}
+
+void CVideoInfoTag::SetStatus(std::string status)
+{
+  m_strStatus = Trim(std::move(status));
+}
+
+void CVideoInfoTag::SetProductionCode(std::string productionCode)
+{
+  m_strProductionCode = Trim(std::move(productionCode));
+}
+
+void CVideoInfoTag::SetShowTitle(std::string showTitle)
+{
+  m_strShowTitle = Trim(std::move(showTitle));
+}
+
+void CVideoInfoTag::SetStudio(std::vector<std::string> studio)
+{
+  m_studio = Trim(std::move(studio));
+}
+
+void CVideoInfoTag::SetAlbum(std::string album)
+{
+  m_strAlbum = Trim(std::move(album));
+}
+
+void CVideoInfoTag::SetShowLink(std::vector<std::string> showLink)
+{
+  m_showLink = Trim(std::move(showLink));
+}
+
+void CVideoInfoTag::SetUniqueId(std::string uniqueId)
+{
+  m_strUniqueId = Trim(std::move(uniqueId));
+}
+
+std::string CVideoInfoTag::Trim(std::string &&value)
+{
+  return StringUtils::Trim(value);
+}
+
+std::vector<std::string> CVideoInfoTag::Trim(std::vector<std::string>&& items)
+{
+  std::for_each(items.begin(), items.end(), [](std::string &str){
+    str = StringUtils::Trim(str);
+  });
+  return items;
 }

--- a/xbmc/video/VideoInfoTag.h
+++ b/xbmc/video/VideoInfoTag.h
@@ -93,6 +93,38 @@ public:
    */
   static unsigned int GetDurationFromMinuteString(const std::string &runtime);
 
+  void SetBasePath(std::string basePath);
+  void SetDirector(std::vector<std::string> director);
+  void SetWritingCredits(std::vector<std::string> writingCredits);
+  void SetGenre(std::vector<std::string> genre);
+  void SetCountry(std::vector<std::string> country);
+  void SetTagLine(std::string tagLine);
+  void SetPlotOutline(std::string plotOutline);
+  void SetTrailer(std::string trailer);
+  void SetPlot(std::string plot);
+  void SetTitle(std::string title);
+  void SetSortTitle(std::string sortTitle);
+  void SetPictureURL(CScraperUrl &pictureURL);
+  void SetVotes(std::string votes);
+  void SetArtist(std::vector<std::string> artist);
+  void SetSet(std::string set);
+  void SetTags(std::vector<std::string> tags);
+  void SetFile(std::string file);
+  void SetPath(std::string path);
+  void SetIMDBNumber(std::string imdbNumber);
+  void SetMPAARating(std::string mpaaRating);
+  void SetFileNameAndPath(std::string fileNameAndPath);
+  void SetOriginalTitle(std::string originalTitle);
+  void SetEpisodeGuide(std::string episodeGuide);
+  void SetStatus(std::string status);
+  void SetProductionCode(std::string productionCode);
+  void SetShowTitle(std::string showTitle);
+  void SetStudio(std::vector<std::string> studio);
+  void SetAlbum(std::string album);
+  void SetShowLink(std::vector<std::string> showLink);
+  void SetUniqueId(std::string uniqueId);
+
+
   std::string m_basePath; // the base path of the video, for folder-based lookups
   int m_parentPathID;      // the parent path id where the base path of the video lies
   std::vector<std::string> m_director;
@@ -161,6 +193,9 @@ private:
    \sa Load
    */
   void ParseNative(const TiXmlElement* element, bool prioritise);
+
+  std::string Trim(std::string &&value);
+  std::vector<std::string> Trim(std::vector<std::string> &&items);
 };
 
 typedef std::vector<CVideoInfoTag> VECMOVIES;


### PR DESCRIPTION
This is an attempt to fix the crap provided by metadata websites (extra spaces before and after actors/studios/etc.... or \t in actors).

@Montellese @MartijnKaijser @mkortstiege mind taking a look.
