### PR TITLE
Disable autoscroll in Confluence while screensaver is active

### DIFF
--- a/addons/skin.confluence/720p/DialogAddonInfo.xml
+++ b/addons/skin.confluence/720p/DialogAddonInfo.xml
@@ -226,7 +226,7 @@
 						<align>left</align>
 						<textcolor>white</textcolor>
 						<label>$INFO[ListItem.Property(Addon.Disclaimer)]</label>
-						<autoscroll time="2000" delay="3000" repeat="5000">true</autoscroll>
+						<autoscroll time="2000" delay="3000" repeat="5000">!System.ScreenSaverActive</autoscroll>
 					</control>
 				</control>
 				<control type="group">

--- a/addons/skin.confluence/720p/DialogAlbumInfo.xml
+++ b/addons/skin.confluence/720p/DialogAlbumInfo.xml
@@ -478,7 +478,7 @@
 					<align>justify</align>
 					<textcolor>white</textcolor>
 					<pagecontrol>61</pagecontrol>
-					<autoscroll time="3000" delay="4000" repeat="5000">!Control.HasFocus(61) + Skin.HasSetting(AutoScroll)</autoscroll>
+					<autoscroll time="3000" delay="4000" repeat="5000">!Control.HasFocus(61) + Skin.HasSetting(AutoScroll)+!System.ScreenSaverActive</autoscroll>
 					<visible>!Control.IsVisible(50)</visible>
 				</control>
 				<control type="image">

--- a/addons/skin.confluence/720p/DialogOK.xml
+++ b/addons/skin.confluence/720p/DialogOK.xml
@@ -26,7 +26,7 @@
 			<align>left</align>
 			<label>-</label>
 			<font>font13</font>
-			<autoscroll time="3000" delay="4000" repeat="5000">true</autoscroll>
+			<autoscroll time="3000" delay="4000" repeat="5000">!System.ScreenSaverActive</autoscroll>
 		</control>
 		<control type="button" id="10">
 			<description>OK button</description>

--- a/addons/skin.confluence/720p/DialogPVRGuideInfo.xml
+++ b/addons/skin.confluence/720p/DialogPVRGuideInfo.xml
@@ -142,7 +142,7 @@
 					<textcolor>white</textcolor>
 					<shadowcolor>black</shadowcolor>
 					<pagecontrol>-</pagecontrol>
-					<autoscroll time="2000" delay="3000" repeat="5000">true</autoscroll>
+					<autoscroll time="2000" delay="3000" repeat="5000">!System.ScreenSaverActive</autoscroll>
 					<label fallback="161">$INFO[ListItem.Plot]</label>
 				</control>
 				<control type="grouplist" id="9000">

--- a/addons/skin.confluence/720p/DialogProgress.xml
+++ b/addons/skin.confluence/720p/DialogProgress.xml
@@ -35,7 +35,7 @@
 			<align>left</align>
 			<label>-</label>
 			<font>font13</font>
-			<autoscroll time="3000" delay="4000" repeat="5000">true</autoscroll>
+			<autoscroll time="3000" delay="4000" repeat="5000">!System.ScreenSaverActive</autoscroll>
 		</control>
 		<control type="progress">
 			<description>Progressbar</description>

--- a/addons/skin.confluence/720p/DialogVideoInfo.xml
+++ b/addons/skin.confluence/720p/DialogVideoInfo.xml
@@ -857,7 +857,7 @@
 					<textcolor>white</textcolor>
 					<pagecontrol>61</pagecontrol>
 					<label>$INFO[ListItem.Plot]</label>
-					<autoscroll time="3000" delay="4000" repeat="5000">!Control.HasFocus(61) + Skin.HasSetting(AutoScroll)</autoscroll>
+					<autoscroll time="3000" delay="4000" repeat="5000">!Control.HasFocus(61) + Skin.HasSetting(AutoScroll)+!System.ScreenSaverActive</autoscroll>
 					<visible>!Control.IsVisible(50)</visible>
 				</control>
 				<control type="image">

--- a/addons/skin.confluence/720p/DialogYesNo.xml
+++ b/addons/skin.confluence/720p/DialogYesNo.xml
@@ -26,7 +26,7 @@
 			<align>left</align>
 			<label>-</label>
 			<font>font13</font>
-			<autoscroll time="3000" delay="4000" repeat="5000">true</autoscroll>
+			<autoscroll time="3000" delay="4000" repeat="5000">!System.ScreenSaverActive</autoscroll>
 		</control>
 		<control type="button" id="11">
 			<description>Yes button</description>

--- a/addons/skin.confluence/720p/MyPVRChannels.xml
+++ b/addons/skin.confluence/720p/MyPVRChannels.xml
@@ -170,7 +170,7 @@
 					<shadowcolor>black</shadowcolor>
 					<pagecontrol>-</pagecontrol>
 					<label>$INFO[Container(50).ListItem.Plot]</label>
-					<autoscroll time="2000" delay="3000" repeat="5000">true</autoscroll>
+					<autoscroll time="2000" delay="3000" repeat="5000">!System.ScreenSaverActive</autoscroll>
 				</control>
 				<control type="label">
 					<left>0</left>

--- a/addons/skin.confluence/720p/MyPVRRecordings.xml
+++ b/addons/skin.confluence/720p/MyPVRRecordings.xml
@@ -273,7 +273,7 @@
 					<align>justify</align>
 					<textcolor>white</textcolor>
 					<label>$INFO[Container(50).ListItem.Plot]</label>
-					<autoscroll time="2000" delay="3000" repeat="5000">Skin.HasSetting(AutoScroll)</autoscroll>
+					<autoscroll time="2000" delay="3000" repeat="5000">Skin.HasSetting(AutoScroll)+!System.ScreenSaverActive</autoscroll>
 				</control>
 				<control type="label">
 					<description>Disk usage text</description>

--- a/addons/skin.confluence/720p/SettingsCategory.xml
+++ b/addons/skin.confluence/720p/SettingsCategory.xml
@@ -183,7 +183,7 @@
 				<font>font12</font>
 				<align>justify</align>
 				<textcolor>white</textcolor>
-				<autoscroll time="3000" delay="4000" repeat="5000">true</autoscroll>
+				<autoscroll time="3000" delay="4000" repeat="5000">!System.ScreenSaverActive</autoscroll>
 			</control>
 		</control>
 		<include>BehindDialogFadeOut</include>

--- a/addons/skin.confluence/720p/SettingsProfile.xml
+++ b/addons/skin.confluence/720p/SettingsProfile.xml
@@ -278,7 +278,7 @@
 						<label>$LOCALIZE[31422]</label>
 						<align>justify</align>
 						<textcolor>white</textcolor>
-						<autoscroll time="3000" delay="4000" repeat="5000">true</autoscroll>
+						<autoscroll time="3000" delay="4000" repeat="5000">!System.ScreenSaverActive</autoscroll>
 						<visible>Control.Hasfocus(4)</visible>
 					</control>
 					<control type="textbox">
@@ -291,7 +291,7 @@
 						<label>$LOCALIZE[31423]</label>
 						<align>justify</align>
 						<textcolor>white</textcolor>
-						<autoscroll time="3000" delay="4000" repeat="5000">true</autoscroll>
+						<autoscroll time="3000" delay="4000" repeat="5000">!System.ScreenSaverActive</autoscroll>
 						<visible>Control.Hasfocus(5)</visible>
 					</control>
 				</control>

--- a/addons/skin.confluence/720p/ViewsAddonBrowser.xml
+++ b/addons/skin.confluence/720p/ViewsAddonBrowser.xml
@@ -216,7 +216,7 @@
 						<align>left</align>
 						<textcolor>white</textcolor>
 						<label>$INFO[ListItem.Property(Addon.Description)]</label>
-						<autoscroll time="2000" delay="3000" repeat="5000">Skin.HasSetting(AutoScroll)</autoscroll>
+						<autoscroll time="2000" delay="3000" repeat="5000">Skin.HasSetting(AutoScroll)+!System.ScreenSaverActive</autoscroll>
 					</control>
 				</control>
 			</control>
@@ -448,7 +448,7 @@
 						<align>left</align>
 						<textcolor>white</textcolor>
 						<label>$INFO[ListItem.Property(Addon.Description)]</label>
-						<autoscroll time="2000" delay="3000" repeat="5000">Skin.HasSetting(AutoScroll)</autoscroll>
+						<autoscroll time="2000" delay="3000" repeat="5000">Skin.HasSetting(AutoScroll)+!System.ScreenSaverActive</autoscroll>
 					</control>
 				</control>
 			</control>

--- a/addons/skin.confluence/720p/ViewsLiveTV.xml
+++ b/addons/skin.confluence/720p/ViewsLiveTV.xml
@@ -158,7 +158,7 @@
 					<align>justify</align>
 					<textcolor>white</textcolor>
 					<label>$INFO[ListItem.Plot]</label>
-					<autoscroll time="2000" delay="3000" repeat="5000">Skin.HasSetting(AutoScroll)</autoscroll>
+					<autoscroll time="2000" delay="3000" repeat="5000">Skin.HasSetting(AutoScroll)+!System.ScreenSaverActive</autoscroll>
 				</control>
 			</control>
 		</control>

--- a/addons/skin.confluence/720p/ViewsMusicLibrary.xml
+++ b/addons/skin.confluence/720p/ViewsMusicLibrary.xml
@@ -475,7 +475,7 @@
 					<pagecontrol>-</pagecontrol>
 					<textcolor>white</textcolor>
 					<label>$INFO[ListItem.Property(Album_Description)]</label>
-					<autoscroll time="2000" delay="3000" repeat="5000">Skin.HasSetting(AutoScroll)</autoscroll>
+					<autoscroll time="2000" delay="3000" repeat="5000">Skin.HasSetting(AutoScroll)+!System.ScreenSaverActive</autoscroll>
 				</control>
 			</control>
 		</control>
@@ -906,7 +906,7 @@
 						<align>justify</align>
 						<textcolor>white</textcolor>
 						<label>$INFO[ListItem.Property(Artist_Description)]</label>
-						<autoscroll time="2000" delay="3000" repeat="5000">Skin.HasSetting(AutoScroll)</autoscroll>
+						<autoscroll time="2000" delay="3000" repeat="5000">Skin.HasSetting(AutoScroll)+!System.ScreenSaverActive</autoscroll>
 					</control>
 				</control>
 			</control>
@@ -1069,7 +1069,7 @@
 					<pagecontrol>-</pagecontrol>
 					<textcolor>white</textcolor>
 					<label>$INFO[ListItem.Property(Album_Description)]</label>
-					<autoscroll time="2000" delay="3000" repeat="5000">Skin.HasSetting(AutoScroll)</autoscroll>
+					<autoscroll time="2000" delay="3000" repeat="5000">Skin.HasSetting(AutoScroll)+!System.ScreenSaverActive</autoscroll>
 				</control>
 			</control>
 		</control>

--- a/addons/skin.confluence/720p/ViewsPVRGuide.xml
+++ b/addons/skin.confluence/720p/ViewsPVRGuide.xml
@@ -287,7 +287,7 @@
 					<font>font12</font>
 					<align>justify</align>
 					<textcolor>grey</textcolor>
-					<autoscroll delay="10000" time="3000" repeat="6000">true</autoscroll>
+					<autoscroll delay="10000" time="3000" repeat="6000">!System.ScreenSaverActive</autoscroll>
 					<label>$INFO[ListItem.Plot]</label>
 				</control>
 			</control>

--- a/addons/skin.confluence/720p/ViewsVideoLibrary.xml
+++ b/addons/skin.confluence/720p/ViewsVideoLibrary.xml
@@ -725,7 +725,7 @@
 					<align>justify</align>
 					<textcolor>white</textcolor>
 					<label>$INFO[ListItem.Plot]</label>
-					<autoscroll time="2000" delay="3000" repeat="5000">Skin.HasSetting(AutoScroll)</autoscroll>
+					<autoscroll time="2000" delay="3000" repeat="5000">Skin.HasSetting(AutoScroll)+!System.ScreenSaverActive+!System.ScreenSaverActive</autoscroll>
 				</control>
 			</control>
 			<control type="grouplist">
@@ -1017,7 +1017,7 @@
 					<align>justify</align>
 					<textcolor>white</textcolor>
 					<label>$INFO[ListItem.Plot]</label>
-					<autoscroll time="2000" delay="3000" repeat="5000">Skin.HasSetting(AutoScroll)</autoscroll>
+					<autoscroll time="2000" delay="3000" repeat="5000">Skin.HasSetting(AutoScroll)+!System.ScreenSaverActive+!System.ScreenSaverActive</autoscroll>
 				</control>
 			</control>
 			<control type="group">
@@ -1081,7 +1081,7 @@
 					<align>justify</align>
 					<textcolor>white</textcolor>
 					<label>$INFO[ListItem.Plot]</label>
-					<autoscroll time="2000" delay="3000" repeat="5000">Skin.HasSetting(AutoScroll)</autoscroll>
+					<autoscroll time="2000" delay="3000" repeat="5000">Skin.HasSetting(AutoScroll)+!System.ScreenSaverActive+!System.ScreenSaverActive</autoscroll>
 				</control>
 			</control>
 			<control type="group">
@@ -1109,7 +1109,7 @@
 					<align>justify</align>
 					<textcolor>white</textcolor>
 					<label>$INFO[Container.ShowPlot]</label>
-					<autoscroll time="2000" delay="3000" repeat="5000">Skin.HasSetting(AutoScroll)</autoscroll>
+					<autoscroll time="2000" delay="3000" repeat="5000">Skin.HasSetting(AutoScroll)+!System.ScreenSaverActive+!System.ScreenSaverActive</autoscroll>
 					<visible>Container.Content(Seasons)</visible>
 				</control>
 				<control type="label">
@@ -1166,7 +1166,7 @@
 					<align>justify</align>
 					<textcolor>white</textcolor>
 					<label>$INFO[ListItem.Plot]</label>
-					<autoscroll time="2000" delay="3000" repeat="5000">Skin.HasSetting(AutoScroll)</autoscroll>
+					<autoscroll time="2000" delay="3000" repeat="5000">Skin.HasSetting(AutoScroll)+!System.ScreenSaverActive+!System.ScreenSaverActive</autoscroll>
 				</control>
 			</control>
 		</control>
@@ -1444,7 +1444,7 @@
 					<align>justify</align>
 					<textcolor>white</textcolor>
 					<label>$INFO[ListItem.Plot]</label>
-					<autoscroll time="2000" delay="3000" repeat="5000">Skin.HasSetting(AutoScroll)</autoscroll>
+					<autoscroll time="2000" delay="3000" repeat="5000">Skin.HasSetting(AutoScroll)+!System.ScreenSaverActive+!System.ScreenSaverActive</autoscroll>
 				</control>
 			</control>
 			<control type="group">
@@ -1550,7 +1550,7 @@
 					<align>justify</align>
 					<textcolor>white</textcolor>
 					<label>$INFO[ListItem.Plot]</label>
-					<autoscroll time="2000" delay="3000" repeat="5000">Skin.HasSetting(AutoScroll)</autoscroll>
+					<autoscroll time="2000" delay="3000" repeat="5000">Skin.HasSetting(AutoScroll)+!System.ScreenSaverActive+!System.ScreenSaverActive</autoscroll>
 				</control>
 			</control>
 		</control>
@@ -1711,7 +1711,7 @@
 					<align>justify</align>
 					<textcolor>white</textcolor>
 					<label>$INFO[ListItem.Plot]</label>
-					<autoscroll time="2000" delay="3000" repeat="5000">Skin.HasSetting(AutoScroll)</autoscroll>
+					<autoscroll time="2000" delay="3000" repeat="5000">Skin.HasSetting(AutoScroll)+!System.ScreenSaverActive+!System.ScreenSaverActive</autoscroll>
 				</control>
 				<control type="grouplist">
 					<description>Media Codec Flagging Images</description>
@@ -1775,7 +1775,7 @@
 					<align>justify</align>
 					<textcolor>white</textcolor>
 					<label>$INFO[ListItem.Plot]</label>
-					<autoscroll time="2000" delay="3000" repeat="5000">Skin.HasSetting(AutoScroll)</autoscroll>
+					<autoscroll time="2000" delay="3000" repeat="5000">Skin.HasSetting(AutoScroll)+!System.ScreenSaverActive+!System.ScreenSaverActive</autoscroll>
 				</control>
 				<control type="image">
 					<left>560</left>
@@ -1824,7 +1824,7 @@
 					<align>justify</align>
 					<textcolor>white</textcolor>
 					<label>$INFO[Container.ShowPlot]</label>
-					<autoscroll time="2000" delay="3000" repeat="5000">Skin.HasSetting(AutoScroll)</autoscroll>
+					<autoscroll time="2000" delay="3000" repeat="5000">Skin.HasSetting(AutoScroll)+!System.ScreenSaverActive+!System.ScreenSaverActive</autoscroll>
 				</control>
 				<control type="image">
 					<left>560</left>
@@ -1873,7 +1873,7 @@
 					<align>justify</align>
 					<textcolor>white</textcolor>
 					<label>$INFO[ListItem.Plot]</label>
-					<autoscroll time="2000" delay="3000" repeat="5000">Skin.HasSetting(AutoScroll)</autoscroll>
+					<autoscroll time="2000" delay="3000" repeat="5000">Skin.HasSetting(AutoScroll)+!System.ScreenSaverActive+!System.ScreenSaverActive</autoscroll>
 				</control>
 				<control type="grouplist">
 					<description>Media Codec Flagging Images</description>

--- a/addons/skin.confluence/720p/ViewsWeather.xml
+++ b/addons/skin.confluence/720p/ViewsWeather.xml
@@ -1548,7 +1548,7 @@
 					<selectedcolor>selected</selectedcolor>
 					<align>center</align>
 					<label>$INFO[Window.Property(Alerts)]</label>
-					<autoscroll time="2000" delay="3000" repeat="5000">Skin.HasSetting(AutoScroll)</autoscroll>
+					<autoscroll time="2000" delay="3000" repeat="5000">Skin.HasSetting(AutoScroll)+!System.ScreenSaverActive</autoscroll>
 				</control>
 			</control>
 			<control type="label">


### PR DESCRIPTION
Reduce GUI activity by disabling animations while the screen saver is active. It reduces idle CPU use.
