### PR TITLE
[builtin] use active window if no window is specified for built-in action

### DIFF
--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -1734,7 +1734,7 @@ int CBuiltins::Execute(const std::string& execString)
     int actionID;
     if (CButtonTranslator::TranslateActionString(params[0].c_str(), actionID))
     {
-      int windowID = params.size() == 2 ? CButtonTranslator::TranslateWindow(params[1]) : WINDOW_INVALID;
+      int windowID = params.size() == 2 ? CButtonTranslator::TranslateWindow(params[1]) : g_windowManager.GetActiveWindow();
       CApplicationMessenger::Get().SendAction(CAction(actionID), windowID);
     }
   }


### PR DESCRIPTION
I've spotted this while I'm working on something other.

The built-in `Action(action)` which could hold an optional second parameter (atm undocumented in our wiki) which is the window name,  don't work like expected if you don't supply the window name. As documented in our wiki it should be `Executes an action for the active window (same as in keymap)`, but instead it calls `g_application.OnAction()` see https://github.com/xbmc/xbmc/blob/master/xbmc/ApplicationMessenger.cpp#L745
