### PR TITLE
[AddonsDirectory] show label "All enabled" instead of "All"

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -12647,11 +12647,9 @@ msgctxt "#24061"
 msgid "Add-on update available!"
 msgstr ""
 
-#: xbmc/addons/GUIViewStateAddonBrowser.cpp
 #: xbmc/filesystem/AddonsDirectory.cpp
-#: xbmc/filesystem/AndroidAppDirectory.cpp
 msgctxt "#24062"
-msgid "Enabled add-ons"
+msgid "All enabled"
 msgstr ""
 
 msgctxt "#24063"

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -229,13 +229,13 @@ static void UserInstalledAddons(const CURL& path, CFileItemList &items)
   {
     GenerateCategoryListing(path, addons, items);
 
-    //"All" node
+    //"All" enabled node
     CFileItemPtr item(new CFileItem());
     item->m_bIsFolder = true;
     CURL itemPath = path;
     itemPath.SetFileName("all");
     item->SetPath(itemPath.Get());
-    item->SetLabel(g_localizeStrings.Get(593));
+    item->SetLabel(g_localizeStrings.Get(24062));
     item->SetSpecialSort(SortSpecialOnTop);
     items.Add(item);
   }


### PR DESCRIPTION
When you navigate into this node, you do not get "All add-ons" only "all enabled".
So label All here does not refer to All add-ons but rather to All enabled

One expects All to mean All -> irrespective of status and is not.

![screenshot059](https://cloud.githubusercontent.com/assets/3521959/8010292/fcd28a44-0ba6-11e5-91e4-1d4b3738d774.png)
![screenshot060](https://cloud.githubusercontent.com/assets/3521959/8010293/fcd6d61c-0ba6-11e5-8dea-8a9febdc1180.png)

Now it reflects what it should be.
