### PR TITLE
[videodb] Add missing argument on JSON filter PrepareSQL()

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -9297,7 +9297,7 @@ void CVideoDatabase::AppendLinkFilter(const char* field, const char *table, cons
     return;
 
   filter.AppendJoin(PrepareSQL("JOIN %s_link ON %s_link.media_id=%s_view.%s AND %s_link.media_type='%s'", field, field, view, viewKey, field, mediaType.c_str()));
-  filter.AppendJoin(PrepareSQL("JOIN %s ON %s.%s_id=%s_link.%s_id", table, table, field, table));
+  filter.AppendJoin(PrepareSQL("JOIN %s ON %s.%s_id=%s_link.%s_id", table, table, field, table, field));
   filter.AppendWhere(PrepareSQL("%s.name like '%s'", table, option->second.asString().c_str()));
 }
 


### PR DESCRIPTION
See [forum](http://forum.kodi.tv/showthread.php?tid=228839&pid=2022395#pid2022395) post.

The existing (buggy) code seems to work OK on Linux - maybe duplicating the last `table` arg? - but outputs gibberish on Windows.
