### PR TITLE
[PVR] Fix crash in PVR::CPVRClient::GetDriveSpace, take two (Trac #15942)

### DIFF
--- a/xbmc/pvr/PVRGUIInfo.cpp
+++ b/xbmc/pvr/PVRGUIInfo.cpp
@@ -706,6 +706,9 @@ void CPVRGUIInfo::UpdateBackendCache(void)
   PVR_CLIENTMAP activeClients;
   iActiveClients = clients->GetConnectedClients(activeClients);
 
+  if (iActiveClients > 1 && !AddonInfoToggle())
+    return;
+
   {
     CSingleLock lock(m_critSection);
     if (m_iAddonInfoToggleCurrent >= iActiveClients)
@@ -715,9 +718,6 @@ void CPVRGUIInfo::UpdateBackendCache(void)
       m_iAddonInfoToggleCurrent = 0;
     }
   }
-
-  if (iActiveClients > 1 && !AddonInfoToggle())
-    return;
 
   if (iActiveClients > 0)
   {


### PR DESCRIPTION
"Fix" <code>m_iAddonInfoToggleCurrent</code> after calling <code>AddonInfoToggle()</code>, because <code>AddonInfoToggle()</code> may increase value of <code>m_iAddonInfoToggleCurrent</code>. Due to a brainfart, my first fix attempt did it the other way around.

We definitely need a better fix for J****, but this seems not to be trivial. For Isengard, this one has low risk and should (now finally) fix the many crashes reported by our users.

@opdenkamp @paxi mind taking a look?  
