### PR TITLE
[pvr] match EPG tag pointers when associating timers with events

### DIFF
--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -629,10 +629,12 @@ CFileItemPtr CPVRTimers::GetTimerForEpgTag(const CFileItem *item) const
       for (VecTimerInfoTag::const_iterator timerIt = it->second->begin(); timerIt != it->second->end(); ++timerIt)
       {
         CPVRTimerInfoTagPtr timer = *timerIt;
-        if (timer->m_iClientChannelUid == channel->UniqueID() &&
+
+        if (timer->GetEpgInfoTag() == epgTag || 
+            (timer->m_iClientChannelUid == channel->UniqueID() &&
             timer->m_bIsRadio == channel->IsRadio() &&
             timer->StartAsUTC() <= epgTag->StartAsUTC() &&
-            timer->EndAsUTC() >= epgTag->EndAsUTC())
+            timer->EndAsUTC() >= epgTag->EndAsUTC()))
         {
           CFileItemPtr fileItem(new CFileItem(timer));
           return fileItem;


### PR DESCRIPTION
Some backends may consider a recording to have started when the actual recording
started, not when the recorded programme starts. This means the start time differs and the timer/recording cannot be matched with the corresponding EPG tag.

For backends that provide a link between EPG tags and timers this also implies a minor speedup since the various comparisons are skipped if a matching pointer is found.

@opdenkamp @ksooo @xhaggi can we include this for Isengard? I can't really work around this in the addon.
