### PR TITLE
[cec] replace disable-cec-adapter-if-no-cec-tv-found dialog with a setting

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -14082,9 +14082,10 @@ msgctxt "#36042"
 msgid "Use limited colour range (16-235)"
 msgstr ""
 
-#: xbmc/peripherals/devices/peripheralcecadapter.cpp
+#. CEC Adapter preference "Deactive adapter if no CEC capable TV is present"
+#: system/peripherals.xml
 msgctxt "#36043"
-msgid "No CEC capable TV detected. Disable polling for CEC capable devices?"
+msgid "Disable adapter if no CEC capable TV is present"
 msgstr ""
 
 #empty strings from id 36044 to 36100

--- a/system/peripherals.xml
+++ b/system/peripherals.xml
@@ -20,10 +20,11 @@
     <setting key="standby_tv_on_pc_standby" type="bool" value="1" label="36026" order="9" />
     <setting key="use_tv_menu_language" type="bool" value="1" label="36018" order="10" />
     <setting key="pause_playback_on_deactivate" type="bool" value="1" label="36033" order="11" />
-    <setting key="connected_device" type="enum" label="36019" value="36037" lvalues="36037|36038" order="12" />
-    <setting key="cec_hdmi_port" type="int" value="1" min="1" max="15" label="36015" order="13" />
-    <setting key="physical_address" type="string" label="36021" value="0" order="14" />
-    <setting key="port" type="string" value="" label="36022" order="15" />
+    <setting key="disable_adapter_if_no_cec_tv_present" type="bool" value="0" label="36043" order="12" />
+    <setting key="connected_device" type="enum" label="36019" value="36037" lvalues="36037|36038" order="13" />
+    <setting key="cec_hdmi_port" type="int" value="1" min="1" max="15" label="36015" order="14" />
+    <setting key="physical_address" type="string" label="36021" value="0" order="15" />
+    <setting key="port" type="string" value="" label="36022" order="16" />
 
     <setting key="tv_vendor" type="int" value="0" configurable="0" />
     <setting key="device_name" type="string" value="Kodi" configurable="0" />

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -27,7 +27,6 @@
 #include "DynamicDll.h"
 #include "threads/SingleLock.h"
 #include "dialogs/GUIDialogKaiToast.h"
-#include "dialogs/GUIDialogYesNo.h"
 #include "guilib/GUIWindowManager.h"
 #include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
@@ -395,9 +394,8 @@ void CPeripheralCecAdapter::Process(void)
       }
       else if (timeout.GetElapsedSeconds() >= CEC_TV_PRESENT_CHECK_TIMEOUT)
       {
-        /** no TV found for 30 seconds, ask if the user wants to disable CEC */
-        if (!CGUIDialogYesNo::ShowAndGetInput(36000,  // Pulse-Eight CEC adaptor
-                                              36043)) // No CEC capable TV detected. Disable polling for CEC capable devices?
+        /** no TV found for 30 seconds, disable CEC (if configured to do so) */
+        if (GetSettingBool("disable_adapter_if_no_cec_tv_present"))
         {
           SetSetting("enabled", false);
           m_bStop          = true;


### PR DESCRIPTION
Followup to #6653. Replaces the dialog in question with an adapter setting.

@opdenkamp what do you think?
