### PR TITLE
[epg] Remove call a bit

### DIFF
--- a/xbmc/epg/Epg.cpp
+++ b/xbmc/epg/Epg.cpp
@@ -737,8 +737,8 @@ bool CEpg::UpdateEntry(const EPG_TAG *data, bool bUpdateDatabase /* = false */)
 
 bool CEpg::IsRadio(void) const
 {
-  CPVRChannelPtr channel = Channel();
-  return channel ? channel->IsRadio() : false;
+  CSingleLock lock(m_critSection);
+  return m_pvrChannel ? m_pvrChannel->IsRadio() : false;
 }
 
 bool CEpg::IsRemovableTag(const CEpgInfoTag &tag) const
@@ -859,6 +859,6 @@ bool CEpg::IsValid(void) const
 {
   CSingleLock lock(m_critSection);
   if (ScraperName() == "client")
-    return Channel().get() != NULL;
+    return m_pvrChannel != NULL;
   return true;
 }


### PR DESCRIPTION
This change remove the amount of functions calls on egp load a bit.
In machine code are for around on 1 epg entry 2-4 calls removed, for 10000 epg entries it is a lot for me and can reduce the time a bit (Not much, but better as nothing)

This change is taken from #6877 to have only the there described fault on end.
