### PR TITLE
changed: Properly exit screensaver on shutdown (fixes #16028)

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2595,6 +2595,9 @@ void CApplication::Stop(int exitCode)
     vExitCode["exitcode"] = exitCode;
     CAnnouncementManager::Get().Announce(System, "xbmc", "OnQuit", vExitCode);
 
+    // Abort any active screensaver
+    WakeUpScreenSaverAndDPMS();
+
     SaveFileState(true);
 
     g_alarmClock.StopThread();


### PR DESCRIPTION
Ideally we should abort any Python (addon) script before we start shutting down, but some skins (why?) rely on some addons, so (for now?) let's at least properly shutdown the screensaver. This also partially fixes the crash in ticket #16028.
