### PR TITLE
[aml] Override resolutions for missing/corrupt hdmi edid data.

### DIFF
--- a/xbmc/windowing/egl/EGLNativeTypeAmlAndroid.cpp
+++ b/xbmc/windowing/egl/EGLNativeTypeAmlAndroid.cpp
@@ -27,6 +27,7 @@
 #include "utils/StringUtils.h"
 #include "utils/SysfsUtils.h"
 #include "utils/AMLUtils.h"
+#include "filesystem/SpecialProtocol.h"
 
 bool CEGLNativeTypeAmlAndroid::CheckCompatibility()
 {
@@ -140,9 +141,14 @@ bool CEGLNativeTypeAmlAndroid::ProbeResolutions(std::vector<RESOLUTION_INFO> &re
 {
   CEGLNativeTypeAndroid::GetNativeResolution(&m_fb_res);
 
-  std::string valstr;
-  if (SysfsUtils::GetString("/sys/class/amhdmitx/amhdmitx0/disp_cap", valstr) < 0)
-    return false;
+  std::string valstr, dcapfile;
+  dcapfile = CSpecialProtocol::TranslatePath("special://home/userdata/disp_cap");
+
+  if (SysfsUtils::GetString(dcapfile, valstr) < 0)
+  {
+    if (SysfsUtils::GetString("/sys/class/amhdmitx/amhdmitx0/disp_cap", valstr) < 0)
+      return false;
+  }
   std::vector<std::string> probe_str = StringUtils::Split(valstr, "\n");
 
   resolutions.clear();


### PR DESCRIPTION
Read user supplied disp_cap from userdata directory if it exists.

Some TV/Box combinations fail to handshake valid edid info, preventing
kodi from using supported resolutions/refresh rates when 'adjust display
refresh rate' is used.

Only implemented for amlogic hardware.

userdata/disp_cap in native aml format. Example file:
720p
1080p
720p50hz
1080p50hz
1080p24hz
