### PR TITLE
[pvr] Remove not needed trailing spaces

### DIFF
--- a/xbmc/epg/EpgContainer.cpp
+++ b/xbmc/epg/EpgContainer.cpp
@@ -248,7 +248,7 @@ bool CEpgContainer::PersistAll(void)
   m_critSection.lock();
   std::map<unsigned int, CEpg*> copy = m_epgs;
   m_critSection.unlock();
-  
+
   for (EPGMAP_CITR it = copy.begin(); it != copy.end() && !m_bStop; it++)
   {
     CEpg *epg = it->second;

--- a/xbmc/epg/EpgDatabase.cpp
+++ b/xbmc/epg/EpgDatabase.cpp
@@ -104,7 +104,7 @@ void CEpgDatabase::UpdateTables(int iVersion)
 
   if (iVersion < 9)
     m_pDS->exec("ALTER TABLE epgtags ADD sIconPath varchar(255);");
-  
+
   if (iVersion < 10)
   {
     m_pDS->exec("ALTER TABLE epgtags ADD sOriginalTitle varchar(128);");
@@ -347,7 +347,7 @@ int CEpgDatabase::Persist(const CEpgInfoTag &tag, bool bSingleUpdate /* = true *
 
   int iBroadcastId = tag.BroadcastId();
   std::string strQuery;
-  
+
   /* Only store the genre string when needed */
   std::string strGenre = (tag.GenreType() == EPG_GENRE_USE_STRING) ? StringUtils::Join(tag.Genre(), g_advancedSettings.m_videoItemSeparator) : "";
 

--- a/xbmc/epg/EpgInfoTag.h
+++ b/xbmc/epg/EpgInfoTag.h
@@ -69,13 +69,13 @@ namespace EPG
 
     // Prevent copy construction, even for CEpgInfoTag instances and friends.
     // Note: Only declared, but intentionally not implemented
-    //       to prevent compiler generated copy ctor and to force 
+    //       to prevent compiler generated copy ctor and to force
     //       a linker error in case somebody tries to call it.
     CEpgInfoTag(const CEpgInfoTag &tag);
 
     // Prevent copy by assignment, even for CEpgInfoTag instances and friends.
     // Note: Only declared, but intentionally not implemented
-    //       to prevent compiler generated assignment operator and to force 
+    //       to prevent compiler generated assignment operator and to force
     //       a linker error in case somebody tries to call it.
     CEpgInfoTag &operator =(const CEpgInfoTag &other);
 

--- a/xbmc/epg/GUIEPGGridContainer.cpp
+++ b/xbmc/epg/GUIEPGGridContainer.cpp
@@ -517,7 +517,7 @@ void CGUIEPGGridContainer::ProcessProgressIndicator(unsigned int currentTime, CD
   {
     m_guiProgressIndicatorTexture.SetVisible(false);
   }
-  
+
   m_guiProgressIndicatorTexture.Process(currentTime);
 }
 
@@ -887,7 +887,7 @@ void CGUIEPGGridContainer::UpdateItems()
           m_gridIndex[row][block].item = item;
           break;
         }
-        
+
         progIdx++;
       }
 
@@ -1289,7 +1289,7 @@ CPVRChannelPtr CGUIEPGGridContainer::GetChannel(int iIndex)
     if (fileItem->HasPVRChannelInfoTag())
       return fileItem->GetPVRChannelInfoTag();
   }
-  
+
   return CPVRChannelPtr();
 }
 
@@ -1297,7 +1297,7 @@ void CGUIEPGGridContainer::SetSelectedChannel(int channelIndex)
 {
   if (channelIndex < 0)
     return;
-  
+
   if (channelIndex - m_channelOffset <= 0)
   {
     ScrollToChannelOffset(0);
@@ -1680,7 +1680,7 @@ void CGUIEPGGridContainer::GoToEnd()
   {
     if (!blocksEnd && m_gridIndex[m_channelCursor + m_channelOffset][blockIndex].item != NULL)
       blocksEnd = blockIndex;
-    if (blocksEnd && m_gridIndex[m_channelCursor + m_channelOffset][blocksEnd].item != 
+    if (blocksEnd && m_gridIndex[m_channelCursor + m_channelOffset][blocksEnd].item !=
                      m_gridIndex[m_channelCursor + m_channelOffset][blockIndex].item)
       blocksStart = blockIndex + 1;
   }

--- a/xbmc/pvr/PVRActionListener.cpp
+++ b/xbmc/pvr/PVRActionListener.cpp
@@ -92,7 +92,7 @@ bool CPVRActionListener::OnAction(const CAction &action)
           CPVRChannelPtr playingChannel(g_PVRManager.GetCurrentChannel());
           if(!playingChannel)
             return false;
-          
+
           if (action.GetID() == REMOTE_0)
           {
             CPVRChannelGroupPtr group = g_PVRChannelGroups->GetPreviousPlayedGroup();
@@ -120,7 +120,7 @@ bool CPVRActionListener::OnAction(const CAction &action)
                 CFileItemPtr channel = selectedGroup->GetByChannelNumber(iChannelNumber);
                 if (!channel || !channel->HasPVRChannelInfoTag())
                   return false;
-                
+
                 CApplicationMessenger::Get().SendAction(CAction(ACTION_CHANNEL_SWITCH, (float)iChannelNumber), WINDOW_INVALID, false);
               }
             }
@@ -133,7 +133,7 @@ bool CPVRActionListener::OnAction(const CAction &action)
           std::string strChannel = StringUtils::Format("%i", action.GetID() - REMOTE_0);
           if (CGUIDialogNumeric::ShowAndGetNumber(strChannel, g_localizeStrings.Get(19000)))
             iChannelNumber = atoi(strChannel.c_str());
-          
+
           if (iChannelNumber > 0)
             CApplicationMessenger::Get().SendAction(CAction(ACTION_CHANNEL_SWITCH, (float)iChannelNumber), WINDOW_INVALID, false);
         }
@@ -142,6 +142,6 @@ bool CPVRActionListener::OnAction(const CAction &action)
     }
     break;
   }
-  
+
   return false;
 }

--- a/xbmc/pvr/PVRActionListener.h
+++ b/xbmc/pvr/PVRActionListener.h
@@ -25,11 +25,11 @@
 class CPVRActionListener : public IActionListener
 {
 public:
-  
+
   static CPVRActionListener &Get();
-  
+
   bool OnAction(const CAction &action);
-  
+
 private:
   CPVRActionListener();
   CPVRActionListener(const CPVRActionListener&);

--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -120,7 +120,7 @@ void CPVRDatabase::UpdateTables(int iVersion)
 
   if (iVersion < 24)
     m_pDS->exec("ALTER TABLE channels ADD bIsUserSetName bool");
-  
+
   if (iVersion < 25)
     m_pDS->exec("DROP TABLE IF EXISTS channelsettings");
 

--- a/xbmc/pvr/PVRGUIInfo.cpp
+++ b/xbmc/pvr/PVRGUIInfo.cpp
@@ -260,7 +260,7 @@ void CPVRGUIInfo::UpdateMisc(void)
   bool       bHasTVChannels            = bStarted && g_PVRChannelGroups->GetGroupAllTV()->HasChannels();
   bool       bHasRadioChannels         = bStarted && g_PVRChannelGroups->GetGroupAllRadio()->HasChannels();
   std::string strPlayingTVGroup        = (bStarted && bIsPlayingTV) ? g_PVRManager.GetPlayingGroup(false)->GroupName() : "";
-  
+
   /* safe to fetch these unlocked, since they're updated from the same thread as this one */
   bool       bHasNonRecordingTimers    = bStarted && m_iTimerAmount - m_iRecordingTimerAmount > 0;
 

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -118,7 +118,7 @@ void CPVRManager::Announce(AnnouncementFlag flag, const char *sender, const char
 
     /* continue last watched channel */
     ContinueLastChannel();
-    
+
     /* trigger PVR data updates */
     TriggerChannelGroupsUpdate();
     TriggerChannelsUpdate();
@@ -361,7 +361,7 @@ void CPVRManager::Cleanup(void)
   for (unsigned int iJobPtr = 0; iJobPtr < m_pendingUpdates.size(); iJobPtr++)
     delete m_pendingUpdates.at(iJobPtr);
   m_pendingUpdates.clear();
-  
+
   /* unregister application action listener */
   g_application.UnregisterActionListener(&CPVRActionListener::Get());
 
@@ -428,7 +428,7 @@ void CPVRManager::Start(bool bAsync /* = false */, int openWindowId /* = 0 */)
   if (!m_database)
     m_database = new CPVRDatabase;
   m_database->Open();
-  
+
   /* register application action listener */
   g_application.RegisterActionListener(&CPVRActionListener::Get());
 
@@ -476,7 +476,7 @@ ManagerState CPVRManager::GetState(void) const
   return m_managerState;
 }
 
-void CPVRManager::SetState(ManagerState state) 
+void CPVRManager::SetState(ManagerState state)
 {
   {
     CSingleLock lock(m_managerStateMutex);
@@ -531,10 +531,10 @@ void CPVRManager::Process(void)
         CSingleLock lock(m_critSection);
         m_bFirstStart = false;
       }
-      
+
       /* start job to search for missing channel icons */
       TriggerSearchMissingChannelIcons();
-      
+
       /* try to continue last watched channel otherwise set group to last played group */
       if (!ContinueLastChannel())
         SetPlayingGroup(m_channelGroups->GetLastPlayedGroup());
@@ -584,13 +584,13 @@ bool CPVRManager::SetWakeupCommand(void)
     if (nextEvent.IsValid())
     {
       nextEvent.GetAsTime(iWakeupTime);
-        
+
       std::string strExecCommand = StringUtils::Format("%s %ld", strWakeupCommand.c_str(), iWakeupTime);
-        
+
       const int iReturn = system(strExecCommand.c_str());
       if (iReturn != 0)
         CLog::Log(LOGERROR, "%s - failed to execute wakeup command '%s': %s (%d)", __FUNCTION__, strExecCommand.c_str(), strerror(iReturn), iReturn);
-        
+
       return iReturn == 0;
     }
   }
@@ -823,7 +823,7 @@ void CPVRManager::ResetDatabase(bool bResetEPGOnly /* = false */)
         videoDatabase.EraseVideoSettings("pvr://recordings/");
         videoDatabase.Close();
       }
-      
+
       pDlgProgress->SetPercentage(80);
       pDlgProgress->Progress();
 
@@ -1104,20 +1104,20 @@ bool CPVRManager::PlayMedia(const CFileItem& item)
     pvrItem = *g_PVRChannelGroups->GetByPath(item.GetPath());
   else if (URIUtils::IsPVRRecording(item.GetPath()) && !item.HasPVRRecordingInfoTag())
     pvrItem = *g_PVRRecordings->GetByPath(item.GetPath());
-  
+
   if (!pvrItem.HasPVRChannelInfoTag() && !pvrItem.HasPVRRecordingInfoTag())
     return false;
-    
+
   // check parental lock if we want to play a channel
   if (pvrItem.IsPVRChannel() && !g_PVRManager.CheckParentalLock(pvrItem.GetPVRChannelInfoTag()))
     return false;
-  
-  if (!g_application.IsCurrentThread())  
+
+  if (!g_application.IsCurrentThread())
   {
     CApplicationMessenger::Get().MediaPlay(pvrItem);
     return true;
   }
-    
+
   return g_application.PlayFile(pvrItem, false) == PLAYBACK_OK;
 }
 
@@ -1332,11 +1332,11 @@ bool CPVRManager::PerformChannelSwitch(const CPVRChannelPtr &channel, bool bPrev
     // switch successful
     bSwitched = true;
 
-    // save previous and load new channel's settings (view mode is updated in 
+    // save previous and load new channel's settings (view mode is updated in
     // the player)
     g_application.SaveFileState();
     g_application.LoadVideoSettings(channel);
-    
+
     // set channel as selected item
     CGUIWindowPVRBase::SetSelectedItemPath(channel->IsRadio(), channel->Path());
 

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -244,7 +244,7 @@ namespace PVR
     {
       return GetState() == ManagerStateStarting;
     }
-    
+
     /*!
      * @brief Check whether the PVRManager has fully started.
      * @return True if started, false otherwise.
@@ -259,7 +259,7 @@ namespace PVR
      * @return True if it should be restarted, false otherwise
      */
     bool RestartManagerOnAddonDisabled(void) const;
-    
+
     /*!
      * @brief Check whether the PVRManager is stopping
      * @return True while the PVRManager is stopping.
@@ -268,7 +268,7 @@ namespace PVR
     {
       return GetState() == ManagerStateStopping;
     }
-    
+
     /*!
      * @brief Check whether the PVRManager has been stopped.
      * @return True if stopped, false otherwise.
@@ -582,7 +582,7 @@ namespace PVR
      * @return If at least one client and all pvr data was loaded, false otherwise.
      */
     bool Load(void);
-    
+
     /*!
      * @brief Reset all properties.
      */
@@ -630,7 +630,7 @@ namespace PVR
     bool IsJobPending(const char *strJobName) const;
 
     /*!
-     * @brief Adds the job to the list of pending jobs unless an identical 
+     * @brief Adds the job to the list of pending jobs unless an identical
      * job is already queued
      * @param job the job
      */

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -95,7 +95,7 @@ bool CPVRClients::IsConnectedClient(int iClientId) const
 bool CPVRClients::IsConnectedClient(const AddonPtr addon)
 {
   CSingleLock lock(m_critSection);
-  
+
   for (PVR_CLIENTMAP_CITR itr = m_clientMap.begin(); itr != m_clientMap.end(); itr++)
     if (itr->second->ID() == addon->ID())
       return itr->second->ReadyToUse();
@@ -209,7 +209,7 @@ bool CPVRClients::HasEnabledClients(void) const
 
 bool CPVRClients::StopClient(AddonPtr client, bool bRestart)
 {
-  CSingleLock lock(m_critSection);  
+  CSingleLock lock(m_critSection);
   int iId = GetClientId(client);
   PVR_CLIENT mappedClient;
   if (GetClient(iId, mappedClient))
@@ -1290,9 +1290,9 @@ bool CPVRClients::UpdateAddons(void)
     CSingleLock lock(m_critSection);
     m_addons = addons;
   }
-  
+
   usableClients = m_addons.size();
-  
+
   // handle "new" addons which aren't yet in the db - these have to be added first
   for (VECADDONS::const_iterator it = addons.begin(); it != addons.end(); ++it)
   {

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -120,7 +120,7 @@ void CPVRChannel::Serialize(CVariant& value) const
   value["lastplayed"] = lastPlayed.IsValid() ? lastPlayed.GetAsDBDate() : "";
   value["channelnumber"] = m_iCachedChannelNumber;
   value["subchannelnumber"] = m_iCachedSubChannelNumber;
-  
+
   CEpgInfoTagPtr epg(GetEPGNow());
   if (epg)
   {
@@ -318,7 +318,7 @@ bool CPVRChannel::SetIconPath(const std::string &strIconPath, bool bIsUserSetIco
     SetChanged();
     m_bChanged = true;
     m_bIsUserSetIcon = bIsUserSetIcon && !m_strIconPath.empty();
-	  
+
     return true;
   }
 
@@ -337,15 +337,15 @@ bool CPVRChannel::SetChannelName(const std::string &strChannelName, bool bIsUser
   {
     m_strChannelName = strName;
     m_bIsUserSetName = bIsUserSetName;
-    
-    /* if the user changes the name manually to an empty string we reset the 
+
+    /* if the user changes the name manually to an empty string we reset the
        flag and use the name from the client instead */
     if (bIsUserSetName && strChannelName.empty())
     {
       m_bIsUserSetName = false;
       m_strChannelName = ClientChannelName();
     }
-    
+
     SetChanged();
     m_bChanged = true;
 

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -1095,7 +1095,7 @@ CDateTime CPVRChannelGroup::GetEPGDate(EpgDateType epgDateType) const
   CEpg* epg;
   CPVRChannelPtr channel;
   CSingleLock lock(m_critSection);
-  
+
   for (PVR_CHANNEL_GROUP_MEMBERS::const_iterator it = m_members.begin(); it != m_members.end(); ++it)
   {
     channel = it->second.channel;
@@ -1109,7 +1109,7 @@ CDateTime CPVRChannelGroup::GetEPGDate(EpgDateType epgDateType) const
           if (epgDate.IsValid() && (!date.IsValid() || epgDate < date))
             date = epgDate;
           break;
-            
+
         case EPG_LAST_DATE:
           epgDate = epg->GetLastDate();
           if (epgDate.IsValid() && (!date.IsValid() || epgDate > date))
@@ -1118,7 +1118,7 @@ CDateTime CPVRChannelGroup::GetEPGDate(EpgDateType epgDateType) const
       }
     }
   }
-  
+
   return date;
 }
 

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -60,7 +60,7 @@ namespace PVR
     EPG_FIRST_DATE = 0,
     EPG_LAST_DATE = 1
   };
-  
+
   class CPVRChannelGroup;
   typedef std::shared_ptr<PVR::CPVRChannelGroup> CPVRChannelGroupPtr;
 
@@ -412,13 +412,13 @@ namespace PVR
      * @return The amount of entries that were added.
      */
     int GetEPGNext(CFileItemList &results) const { return GetEPGNowOrNext(results, true); }
-    
+
     /*!
      * @brief Get the start time of the first entry.
      * @return The start time.
      */
     CDateTime GetFirstEPGDate(void) const;
-    
+
     /*!
      * @brief Get the end time of the last entry.
      * @return The end time.
@@ -538,7 +538,7 @@ namespace PVR
     PVR_CHANNEL_GROUP_SORTED_MEMBERS m_sortedMembers; /*!< members sorted by channel number */
     PVR_CHANNEL_GROUP_MEMBERS        m_members;       /*!< members with key clientid+uniqueid */
     CCriticalSection m_critSection;
-    
+
   private:
     CDateTime GetEPGDate(EpgDateType epgDateType) const;
     /*!

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
@@ -60,7 +60,7 @@ bool CPVRChannelGroupInternal::Load(void)
   {
     UpdateChannelPaths();
     g_PVRManager.RegisterObserver(this);
-      
+
     return true;
   }
 

--- a/xbmc/pvr/channels/PVRChannelGroups.h
+++ b/xbmc/pvr/channels/PVRChannelGroups.h
@@ -107,7 +107,7 @@ namespace PVR
      * @return The last group in this container.
      */
     CPVRChannelGroupPtr GetLastGroup(void) const;
-    
+
     /*!
      * @brief The group that was played last and optionally contains the given channel.
      * @param iChannelID The channel ID

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -184,7 +184,7 @@ void CGUIDialogPVRTimerSettings::OnSettingAction(const CSetting *setting)
       int start_hour      = timestop.GetHour();
       int start_minute    = timestop.GetMinute();
       CDateTime newEnd(start_year, start_month, start_day, start_hour, start_minute, 0);
-      
+
       // add a day to end time if end time is before start time
       // TODO: this should be removed after separate end date control was added
       if (newEnd < tag->StartAsLocalTime())
@@ -332,7 +332,7 @@ CSetting* CGUIDialogPVRTimerSettings::AddChannelNames(CSettingGroup *group, bool
 {
   std::vector< std::pair<std::string, int> > options;
   getChannelNames(bRadio, options, m_selectedChannelEntry, true);
-  
+
   // select the correct channel
   int timerChannelID = 0;
   if (m_timerItem->GetPVRTimerInfoTag()->ChannelTag())
@@ -418,13 +418,13 @@ void CGUIDialogPVRTimerSettings::getChannelNames(bool bRadio, std::vector< std::
 {
   CFileItemList channelsList;
   g_PVRChannelGroups->GetGroupAll(bRadio)->GetMembers(channelsList);
-  
+
   int entry = 0;
 
   for (int i = 0; i < channelsList.Size(); i++)
   {
     const CPVRChannelPtr channel(channelsList[i]->GetPVRChannelInfoTag());
-    
+
     list.push_back(std::make_pair(StringUtils::Format("%i %s", channel->ChannelNumber(), channel->ChannelName().c_str()), entry));
     if (updateChannelEntries)
       m_channelEntries.insert(std::make_pair(std::make_pair(bRadio, entry), channel->ChannelID()));
@@ -490,7 +490,7 @@ void CGUIDialogPVRTimerSettings::DaysOptionsFiller(const CSetting *setting, std:
   }
   else if (setting->GetId() == SETTING_TMR_FIRST_DAY)
     list.push_back(std::make_pair(g_localizeStrings.Get(19030), 0));
-  
+
   CDateTime time = CDateTime::GetCurrentDateTime();
   for (int i = 1; i < 365; ++i)
   {

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.h
@@ -51,7 +51,7 @@ namespace PVR
 
     // specialization of CGUIDialogSettingsManualBase
     virtual void InitializeSettings();
-    
+
     virtual CSetting* AddChannelNames(CSettingGroup *group, bool bRadio);
     virtual void SetWeekdaySettingFromTimer(const CPVRTimerInfoTag &timer);
     virtual void SetTimerFromWeekdaySetting(CPVRTimerInfoTag &timer);

--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -40,7 +40,7 @@ CPVRRecordingUid::CPVRRecordingUid() :
 CPVRRecordingUid::CPVRRecordingUid(const CPVRRecordingUid &recordingId) :
   m_iClientId(recordingId.m_iClientId),
   m_strRecordingId(recordingId.m_strRecordingId)
-{ 
+{
 }
 
 CPVRRecordingUid::CPVRRecordingUid(int iClientId, const std::string& strRecordingId) :
@@ -252,10 +252,10 @@ void CPVRRecording::UpdateMetadata(CVideoDatabase &db)
 {
   if (m_bGotMetaData)
     return;
-    
+
   bool supportsPlayCount  = g_PVRClients->SupportsRecordingPlayCount(m_iClientId);
   bool supportsLastPlayed = g_PVRClients->SupportsLastPlayedPosition(m_iClientId);
-  
+
   if (!supportsPlayCount || !supportsLastPlayed)
   {
     if (!supportsPlayCount)
@@ -264,7 +264,7 @@ void CPVRRecording::UpdateMetadata(CVideoDatabase &db)
     if (!supportsLastPlayed)
       db.GetResumeBookMark(m_strFileNameAndPath, m_resumePoint);
   }
-  
+
   m_bGotMetaData = true;
 }
 
@@ -359,7 +359,7 @@ void CPVRRecording::Update(const CPVRRecording &tag)
   {
     std::string strEpisode = m_strPlotOutline;
     std::string strTitle = m_strDirectory;
-    
+
     size_t pos = strTitle.rfind('/');
     strTitle.erase(0, pos + 1);
     strEpisode.erase(0, strShow.size());

--- a/xbmc/pvr/recordings/PVRRecording.h
+++ b/xbmc/pvr/recordings/PVRRecording.h
@@ -171,7 +171,7 @@ namespace PVR
     std::vector<PVR_EDL_ENTRY> GetEdl() const;
 
     /*!
-     * @brief Get the resume point and play count from the database if the 
+     * @brief Get the resume point and play count from the database if the
      * client doesn't handle it itself.
      */
     void UpdateMetadata(CVideoDatabase &db);

--- a/xbmc/pvr/recordings/PVRRecordings.cpp
+++ b/xbmc/pvr/recordings/PVRRecordings.cpp
@@ -234,7 +234,7 @@ bool CPVRRecordings::DeleteDirectory(const CFileItem& directory)
 
   VECFILEITEMS itemList = items.GetList();
   CFileItem item;
-  
+
   for (VECFILEITEMS::const_iterator it = itemList.begin(); it != itemList.end(); ++it)
     allDeleted &= Delete(*(it->get()));
 

--- a/xbmc/pvr/recordings/PVRRecordings.h
+++ b/xbmc/pvr/recordings/PVRRecordings.h
@@ -75,7 +75,7 @@ namespace PVR
     int GetNumRecordings();
     bool HasDeletedRecordings();
     int GetRecordings(CFileItemList* results, bool bDeleted = false);
-    
+
     /**
      * Deletes the item in question, be it a directory or a file
      * @param item the item to delete

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -288,8 +288,8 @@ std::string CPVRTimerInfoTag::GetStatus() const
     strReturn = g_localizeStrings.Get(19162);
   else if (m_state == PVR_TIMER_STATE_CONFLICT_OK)
     strReturn = g_localizeStrings.Get(19275);
-  else if (m_state == PVR_TIMER_STATE_CONFLICT_NOK)	
-    strReturn = g_localizeStrings.Get(19276);	
+  else if (m_state == PVR_TIMER_STATE_CONFLICT_NOK)
+    strReturn = g_localizeStrings.Get(19276);
   else if (m_state == PVR_TIMER_STATE_ERROR)
     strReturn = g_localizeStrings.Get(257);
 
@@ -572,8 +572,8 @@ void CPVRTimerInfoTag::GetNotificationText(std::string &strText) const
   case PVR_TIMER_STATE_COMPLETED:
     strText = StringUtils::Format("%s: '%s'", g_localizeStrings.Get(19227).c_str(), m_strTitle.c_str());
     break;
-  case PVR_TIMER_STATE_CONFLICT_OK:	
-  case PVR_TIMER_STATE_CONFLICT_NOK:	
+  case PVR_TIMER_STATE_CONFLICT_OK:
+  case PVR_TIMER_STATE_CONFLICT_NOK:
     strText = StringUtils::Format("%s: '%s'", g_localizeStrings.Get(19277).c_str(), m_strTitle.c_str());
     break;
   case PVR_TIMER_STATE_ERROR:

--- a/xbmc/pvr/timers/PVRTimerInfoTag.h
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.h
@@ -109,9 +109,9 @@ namespace PVR
 
     void UpdateEpgEvent(bool bClear = false);
 
-    bool IsActive(void) const 
-    { 	
-      return m_state == PVR_TIMER_STATE_SCHEDULED 
+    bool IsActive(void) const
+    {
+      return m_state == PVR_TIMER_STATE_SCHEDULED
         || m_state == PVR_TIMER_STATE_RECORDING
         || m_state == PVR_TIMER_STATE_CONFLICT_OK
         || m_state == PVR_TIMER_STATE_CONFLICT_NOK

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -173,7 +173,7 @@ bool CPVRTimers::UpdateEntries(const CPVRTimers &timers)
 
   /* to collect timer with changed starting time */
   VecTimerInfoTag timersToMove;
-  
+
   /* check for deleted timers */
   for (MapTags::iterator it = m_tags.begin(); it != m_tags.end();)
   {
@@ -206,7 +206,7 @@ bool CPVRTimers::UpdateEntries(const CPVRTimers &timers)
 
         /* remember timer */
         timersToMove.push_back(timer);
-        
+
         /* remove timer for now, reinsert later */
         it2 = it->second->erase(it2);
 

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -148,7 +148,7 @@ bool CGUIWindowPVRBase::OnMessage(CGUIMessage& message)
       SetProperty("IsRadio", m_bRadio ? "true" : "");
     }
     break;
-      
+
     case GUI_MSG_CLICKED:
     {
       switch (message.GetSenderId())

--- a/xbmc/pvr/windows/GUIWindowPVRBase.h
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.h
@@ -70,7 +70,7 @@ namespace PVR
     virtual void ResetObservers(void) {};
     virtual void Notify(const Observable &obs, const ObservableMessage msg);
     virtual void SetInvalid();
-    
+
     static std::string GetSelectedItemPath(bool bRadio);
     static void SetSelectedItemPath(bool bRadio, const std::string &path);
 

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -82,7 +82,7 @@ void CGUIWindowPVRChannels::GetContextButtons(int itemNumber, CContextButtons &b
 
   // Add parent buttons before the Manage button
   CGUIWindowPVRBase::GetContextButtons(itemNumber, buttons);
-    
+
   buttons.Add(CONTEXT_BUTTON_EDIT, 16106);                                          /* "Manage" submenu */
 
   CContextMenuManager::Get().AddVisibleItems(pItem, buttons);
@@ -325,7 +325,7 @@ bool CGUIWindowPVRChannels::OnContextButtonManage(CFileItem *item, CONTEXT_BUTTO
 bool CGUIWindowPVRChannels::OnContextButtonRecord(CFileItem *item, CONTEXT_BUTTON button)
 {
   bool bReturn(false);
-  
+
   if (button == CONTEXT_BUTTON_RECORD_ITEM)
   {
     CPVRChannelPtr channel(item->GetPVRChannelInfoTag());

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -296,7 +296,7 @@ void CGUIWindowPVRGuide::UpdateViewNow()
 
   m_vecItems->Clear();
   int iEpgItems = GetGroup()->GetEPGNow(*m_vecItems);
-  
+
   if (iEpgItems == 0)
   {
     CFileItemPtr item;
@@ -355,23 +355,23 @@ void CGUIWindowPVRGuide::UpdateViewTimeline()
   CDateTime startDate(m_cachedChannelGroup->GetFirstEPGDate());
   CDateTime endDate(m_cachedChannelGroup->GetLastEPGDate());
   CDateTime currentDate = CDateTime::GetCurrentDateTime().GetAsUTCDateTime();
-  
+
   if (!startDate.IsValid())
     startDate = currentDate;
-  
+
   if (!endDate.IsValid() || endDate < startDate)
     endDate = startDate;
-  
+
   // limit start to linger time
   CDateTime maxPastDate = currentDate - CDateTimeSpan(0, 0, g_advancedSettings.m_iEpgLingerTime, 0);
   if (startDate < maxPastDate)
     startDate = maxPastDate;
-  
+
   epgGridContainer->SetStartEnd(startDate, endDate);
 
   SET_CONTROL_LABEL(CONTROL_LABEL_HEADER1, g_localizeStrings.Get(19032));
   SET_CONTROL_LABEL(CONTROL_LABEL_HEADER2, GetGroup()->GroupName());
-  
+
   m_viewControl.SetItems(*m_vecItems);
 
   epgGridContainer->SetChannel(GetSelectedItemPath(m_bRadio));
@@ -442,7 +442,7 @@ bool CGUIWindowPVRGuide::OnContextButtonNow(CFileItem *item, CONTEXT_BUTTON butt
     epgGridContainer->GoToNow();
     bReturn = true;
   }
-  
+
   return bReturn;
 }
 


### PR DESCRIPTION
Not a change of functions, only a clean up to remove trailing white spaces from strings.
Don't want after changes always look for wrongly removed spaces.
