### PR TITLE
[seek] fix: reset seek size after seeking

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1226,6 +1226,9 @@ bool CApplication::Initialize()
 
   CAddonMgr::Get().StartServices(true);
 
+  // configure seek handler
+  CSeekHandler::Get().Configure();
+
   // register action listeners
   RegisterActionListener(&CSeekHandler::Get());
 
@@ -3889,8 +3892,6 @@ bool CApplication::OnMessage(CGUIMessage& message)
 #ifdef TARGET_DARWIN
       CDarwinUtils::SetScheduling(message.GetMessage());
 #endif
-      // reset the seek handler
-      CSeekHandler::Get().Reset();
       CPlayList playList = g_playlistPlayer.GetPlaylist(g_playlistPlayer.GetCurrentPlaylist());
 
       // Update our infoManager with the new details etc.

--- a/xbmc/utils/SeekHandler.h
+++ b/xbmc/utils/SeekHandler.h
@@ -49,6 +49,7 @@ public:
   void SeekSeconds(int seconds);
   void Process();
   void Reset();
+  void Configure();
 
   int GetSeekSize() const;
   bool InProgress() const;
@@ -62,13 +63,13 @@ protected:
 private:
   static const int analogSeekDelay = 500;
   
-  int        GetSeekStepSize(SeekType type, int step);
-  int        m_seekDelay;
+  int GetSeekStepSize(SeekType type, int step);
+  int m_seekDelay;
   std::map<SeekType, int > m_seekDelays;
-  bool       m_requireSeek;
-  bool       m_analogSeek;
-  int        m_seekSize;
-  int        m_seekStep;
+  bool m_requireSeek;
+  bool m_analogSeek;
+  int m_seekSize;
+  int m_seekStep;
   std::map<SeekType, std::vector<int> > m_forwardSeekSteps;
   std::map<SeekType, std::vector<int> > m_backwardSeekSteps;
   CStopWatch m_timer;


### PR DESCRIPTION
This fix the issue that if you use adaptive seek and then doing up/down bigstep seek, it shows the last used adaptive seek size instead of bigstep seek size.

@mkortstiege mind taking a look
@MartijnKaijser ping
