### PR TITLE
[epg] Remove usage of 'using namespace std'

### DIFF
--- a/xbmc/epg/EpgContainer.cpp
+++ b/xbmc/epg/EpgContainer.cpp
@@ -35,7 +35,6 @@
 #include "EpgContainer.h"
 #include "EpgSearchFilter.h"
 
-using namespace std;
 using namespace EPG;
 using namespace PVR;
 
@@ -341,7 +340,7 @@ CEpg *CEpgContainer::GetById(int iEpgId) const
     return NULL;
 
   CSingleLock lock(m_critSection);
-  map<unsigned int, CEpg *>::const_iterator it = m_epgs.find((unsigned int) iEpgId);
+  std::map<unsigned int, CEpg *>::const_iterator it = m_epgs.find((unsigned int) iEpgId);
   return it != m_epgs.end() ? it->second : NULL;
 }
 
@@ -349,7 +348,7 @@ CEpgInfoTagPtr CEpgContainer::GetTagById(int iBroadcastId) const
 {
   CEpgInfoTagPtr retval;
   CSingleLock lock(m_critSection);
-  for (map<unsigned int, CEpg *>::const_iterator it = m_epgs.begin(); !retval && it != m_epgs.end(); ++it)
+  for (std::map<unsigned int, CEpg *>::const_iterator it = m_epgs.begin(); !retval && it != m_epgs.end(); ++it)
     retval = it->second->GetTag(iBroadcastId);
   return retval;
 }
@@ -357,7 +356,7 @@ CEpgInfoTagPtr CEpgContainer::GetTagById(int iBroadcastId) const
 CEpg *CEpgContainer::GetByChannel(const CPVRChannel &channel) const
 {
   CSingleLock lock(m_critSection);
-  for (map<unsigned int, CEpg *>::const_iterator it = m_epgs.begin(); it != m_epgs.end(); ++it)
+  for (std::map<unsigned int, CEpg *>::const_iterator it = m_epgs.begin(); it != m_epgs.end(); ++it)
     if (channel.ChannelID() == it->second->ChannelID())
       return it->second;
 
@@ -383,7 +382,7 @@ void CEpgContainer::InsertFromDatabase(int iEpgID, const std::string &strName, c
     epg = new CEpg(iEpgID, strName, strScraperName, true);
     if (epg)
     {
-      m_epgs.insert(make_pair(iEpgID, epg));
+      m_epgs.insert(std::make_pair(iEpgID, epg));
       SetChanged();
       epg->RegisterObserver(this);
     }
@@ -408,7 +407,7 @@ CEpg *CEpgContainer::CreateChannelEpg(CPVRChannelPtr channel)
     epg = new CEpg(channel, false);
 
     CSingleLock lock(m_critSection);
-    m_epgs.insert(make_pair((unsigned int)epg->EpgID(), epg));
+    m_epgs.insert(std::make_pair((unsigned int)epg->EpgID(), epg));
     SetChanged();
     epg->RegisterObserver(this);
   }
@@ -579,7 +578,7 @@ bool CEpgContainer::UpdateEPG(bool bOnlyPending /* = false */)
     return false;
   }
 
-  vector<CEpg*> invalidTables;
+  std::vector<CEpg*> invalidTables;
 
   /* load or update all EPG tables */
   CEpg *epg;
@@ -617,7 +616,7 @@ bool CEpgContainer::UpdateEPG(bool bOnlyPending /* = false */)
       invalidTables.push_back(epg);
   }
 
-  for (vector<CEpg*>::iterator it = invalidTables.begin(); it != invalidTables.end(); ++it)
+  for (std::vector<CEpg*>::iterator it = invalidTables.begin(); it != invalidTables.end(); ++it)
     DeleteEpg(**it, true);
 
   if (bInterrupted)

--- a/xbmc/epg/EpgDatabase.cpp
+++ b/xbmc/epg/EpgDatabase.cpp
@@ -30,7 +30,6 @@
 #include "EpgContainer.h"
 #include "EpgDatabase.h"
 
-using namespace std;
 using namespace dbiplus;
 using namespace EPG;
 
@@ -293,9 +292,9 @@ bool CEpgDatabase::PersistLastEpgScanTime(int iEpgId /* = 0 */, bool bQueueWrite
   return bQueueWrite ? QueueInsertQuery(strQuery) : ExecuteQuery(strQuery);
 }
 
-bool CEpgDatabase::Persist(const map<unsigned int, CEpg *> &epgs)
+bool CEpgDatabase::Persist(const std::map<unsigned int, CEpg *> &epgs)
 {
-  for (map<unsigned int, CEpg *>::const_iterator it = epgs.begin(); it != epgs.end(); ++it)
+  for (std::map<unsigned int, CEpg *>::const_iterator it = epgs.begin(); it != epgs.end(); ++it)
   {
     CEpg *epg = it->second;
     if (epg)

--- a/xbmc/epg/EpgInfoTag.cpp
+++ b/xbmc/epg/EpgInfoTag.cpp
@@ -33,7 +33,6 @@
 #include "EpgContainer.h"
 #include "EpgDatabase.h"
 
-using namespace std;
 using namespace EPG;
 using namespace PVR;
 
@@ -454,7 +453,7 @@ int CEpgInfoTag::GenreSubType(void) const
   return m_iGenreSubType;
 }
 
-const vector<string> CEpgInfoTag::Genre(void) const
+const std::vector<std::string> CEpgInfoTag::Genre(void) const
 {
   return m_genre;
 }

--- a/xbmc/epg/EpgSearchFilter.cpp
+++ b/xbmc/epg/EpgSearchFilter.cpp
@@ -30,7 +30,6 @@
 #include "EpgContainer.h"
 #include "EpgSearchFilter.h"
 
-using namespace std;
 using namespace EPG;
 using namespace PVR;
 
@@ -235,7 +234,7 @@ int EpgSearchFilter::FilterTimers(CFileItemList &results)
   if (!g_PVRManager.IsStarted())
     return iRemoved;
 
-  vector<CFileItemPtr> timers = g_PVRTimers->GetActiveTimers();
+  std::vector<CFileItemPtr> timers = g_PVRTimers->GetActiveTimers();
   // TODO inefficient!
   for (unsigned int iTimerPtr = 0; iTimerPtr < timers.size(); iTimerPtr++)
   {

--- a/xbmc/epg/GUIEPGGridContainer.cpp
+++ b/xbmc/epg/GUIEPGGridContainer.cpp
@@ -38,7 +38,6 @@
 
 using namespace PVR;
 using namespace EPG;
-using namespace std;
 
 #define SHORTGAP     5 // how many blocks is considered a short-gap in nav logic
 #define MINSPERBLOCK 5 /// would be nice to offer zooming of busy schedules /// performance cost to increase resolution 5 fold?


### PR DESCRIPTION
Also only code clean up and the "using namespace std" becomes removed from EPG parts.
