### PR TITLE
[RFC] Handle bigstep and chapter seek in SeekHandler

### DIFF
--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -239,6 +239,22 @@ void CApplicationPlayer::SeekPercentage(float fPercent)
     player->SeekPercentage(fPercent);
 }
 
+void CApplicationPlayer::SeekPercentageRelative(float fPercent)
+{
+  std::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+  {
+    // use relative seeking if implemented by player
+    if (!player->SeekPercentageRelative(fPercent))
+    {
+      int64_t iTotalTime = GetTotalTime();
+      if (!iTotalTime)
+        return;
+      player->SeekTime((int64_t)(iTotalTime * (GetPercentage()+fPercent) / 100));
+    }
+  }
+}
+
 bool CApplicationPlayer::IsPassthrough() const
 {
   std::shared_ptr<IPlayer> player = GetInternal();

--- a/xbmc/ApplicationPlayer.h
+++ b/xbmc/ApplicationPlayer.h
@@ -138,6 +138,7 @@ public:
   void  Seek(bool bPlus = true, bool bLargeStep = false, bool bChapterOverride = false);
   int   SeekChapter(int iChapter);
   void  SeekPercentage(float fPercent = 0);
+  void  SeekPercentageRelative(float fPercent = 0);
   bool  SeekScene(bool bPlus = true);
   void  SeekTime(int64_t iTime = 0);
   void  SeekTimeRelative(int64_t iTime = 0);

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -145,7 +145,13 @@ public:
   virtual bool CanSeek() {return true;}
   virtual void Seek(bool bPlus = true, bool bLargeStep = false, bool bChapterOverride = false) = 0;
   virtual bool SeekScene(bool bPlus = true) {return false;}
-  virtual void SeekPercentage(float fPercent = 0){}
+  virtual void SeekPercentage(float fPercent = 0) {}
+  /*
+   \brief seek relative to current time in percent, returns false if not implemented by player
+   \param fPercent The percent to seek. A positive value will seek forward, a negative backward.
+   \return True if the player supports relative seeking by percent, otherwise false
+   */
+  virtual bool SeekPercentageRelative(float fPercent = 0) { return false; }
   virtual float GetPercentage(){ return 0;}
   virtual float GetCachePercentage(){ return 0;}
   virtual void SetMute(bool bOnOff){}

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -3043,14 +3043,25 @@ void CDVDPlayer::GetGeneralInfo(std::string& strGeneralInfo)
   }
 }
 
-void CDVDPlayer::SeekPercentage(float iPercent)
+void CDVDPlayer::SeekPercentage(float fPercent)
 {
   int64_t iTotalTime = GetTotalTimeInMsec();
 
   if (!iTotalTime)
     return;
 
-  SeekTime((int64_t)(iTotalTime * iPercent / 100));
+  SeekTime((int64_t)(iTotalTime * fPercent / 100));
+}
+
+bool CDVDPlayer::SeekPercentageRelative(float fPercent)
+{
+  int64_t iTotalTime = GetTotalTimeInMsec();
+
+  if (!iTotalTime)
+    return true;
+
+  SeekTime((int64_t)(iTotalTime * (GetPercentage()+fPercent) / 100));
+  return true;
 }
 
 float CDVDPlayer::GetPercentage()

--- a/xbmc/cores/dvdplayer/DVDPlayer.h
+++ b/xbmc/cores/dvdplayer/DVDPlayer.h
@@ -226,7 +226,8 @@ public:
   virtual bool CanSeek();
   virtual void Seek(bool bPlus, bool bLargeStep, bool bChapterOverride);
   virtual bool SeekScene(bool bPlus = true);
-  virtual void SeekPercentage(float iPercent);
+  virtual void SeekPercentage(float fPercent);
+  virtual bool SeekPercentageRelative(float fPercent);
   virtual float GetPercentage();
   virtual float GetCachePercentage();
 

--- a/xbmc/utils/SeekHandler.cpp
+++ b/xbmc/utils/SeekHandler.cpp
@@ -145,7 +145,7 @@ void CSeekHandler::Seek(bool forward, float amount, float duration /* = 0 */, bo
   {
     //100% over 1 second.
     float speed = 100.0f;
-    if( duration )
+    if (duration)
       speed *= duration;
     else
       speed /= g_graphicsContext.GetFPS();
@@ -180,7 +180,6 @@ void CSeekHandler::Seek(bool forward, float amount, float duration /* = 0 */, bo
 
 void CSeekHandler::SeekSeconds(int seconds)
 {
-  // abort if we do not have a play time or already perform a seek
   if (seconds == 0)
     return;
 
@@ -191,6 +190,36 @@ void CSeekHandler::SeekSeconds(int seconds)
   g_application.m_pPlayer->SeekTimeRelative(static_cast<int64_t>(seconds * 1000));
 
   Reset();
+}
+
+void CSeekHandler::SeekPercentage(float percent)
+{
+  if (percent == 0)
+    return;
+
+  CSingleLock lock(m_critSection);
+  double totalTime = g_application.GetTotalTime();
+  if (totalTime < 0)
+    totalTime = 0;
+  m_seekSize = (totalTime * (g_application.m_pPlayer->GetPercentage() + percent) / 100);
+
+  // perform relative seek
+  g_application.m_pPlayer->SeekPercentageRelative(percent);
+
+  Reset();
+}
+
+bool CSeekHandler::SeekChapter(int offset) const
+{
+  int chapter = g_application.m_pPlayer->GetChapter();
+  if (chapter > 0)
+  {
+    int seekChapter = chapter + offset;
+    if (seekChapter > 0 && seekChapter <= g_application.m_pPlayer->GetChapterCount())
+      g_application.m_pPlayer->SeekChapter(seekChapter);
+    return true;
+  }
+  return false;
 }
 
 int CSeekHandler::GetSeekSize() const
@@ -266,13 +295,29 @@ bool CSeekHandler::OnAction(const CAction &action)
     case ACTION_BIG_STEP_BACK:
     case ACTION_CHAPTER_OR_BIG_STEP_BACK:
     {
-      g_application.m_pPlayer->Seek(false, true, action.GetID() == ACTION_CHAPTER_OR_BIG_STEP_BACK);
+      if (action.GetID() == ACTION_CHAPTER_OR_BIG_STEP_BACK &&
+          SeekChapter(-1))
+        return true;
+
+      if (g_advancedSettings.m_videoUseTimeSeeking)
+        SeekSeconds(g_advancedSettings.m_videoTimeSeekBackwardBig);
+      else
+        SeekPercentage(g_advancedSettings.m_videoPercentSeekBackwardBig);
+
       return true;
     }
     case ACTION_BIG_STEP_FORWARD:
     case ACTION_CHAPTER_OR_BIG_STEP_FORWARD:
     {
-      g_application.m_pPlayer->Seek(true, true, action.GetID() == ACTION_CHAPTER_OR_BIG_STEP_FORWARD);
+      if (action.GetID() == ACTION_CHAPTER_OR_BIG_STEP_FORWARD &&
+          SeekChapter(1))
+        return true;
+
+      if (g_advancedSettings.m_videoUseTimeSeeking)
+        SeekSeconds(g_advancedSettings.m_videoTimeSeekForwardBig);
+      else
+        SeekPercentage(g_advancedSettings.m_videoPercentSeekForwardBig);
+
       return true;
     }
     case ACTION_NEXT_SCENE:

--- a/xbmc/utils/SeekHandler.h
+++ b/xbmc/utils/SeekHandler.h
@@ -47,6 +47,8 @@ public:
 
   void Seek(bool forward, float amount, float duration = 0, bool analogSeek = false, SeekType type = SEEK_TYPE_VIDEO);
   void SeekSeconds(int seconds);
+  void SeekPercentage(float percent);
+  bool SeekChapter(int offset) const;
   void Process();
   void Reset();
   void Configure();


### PR DESCRIPTION
Not sure if it really makes sense, but IMO we should handle all kinds of seeking in our SeekHandler. The Player shouldn't handle things like bigstep, smallstep + AS stuff or if we want to seek in percent. Instead it should only expose methods to seek by chapter, time, percentage, scene. The seek handler will do the necessary stuff to choose which method fits and call it.

Therefore the method `Seek(bool bPlus, bool bLargeStep, bool bChapterOverride)` should die, but ATM i leave it in because of the EDL handling and I'm not sure where this part should be moved to.

@FernetMenta mind taking a look
