### PR TITLE
[epg] Swap everything from 'std::map<unsigned int, CEpg*>' to 'EPGMAP'

### DIFF
--- a/xbmc/epg/Epg.h
+++ b/xbmc/epg/Epg.h
@@ -35,6 +35,8 @@ namespace PVR
 /** EPG container for CEpgInfoTag instances */
 namespace EPG
 {
+  typedef std::map<unsigned int, CEpg*> EPGMAP;
+
   class CEpg : public Observable
   {
     friend class CEpgDatabase;

--- a/xbmc/epg/EpgContainer.h
+++ b/xbmc/epg/EpgContainer.h
@@ -281,10 +281,6 @@ namespace EPG
 
     void InsertFromDatabase(int iEpgID, const std::string &strName, const std::string &strScraperName);
 
-    typedef std::map<unsigned int, CEpg*> EPGMAP;
-    typedef EPGMAP::iterator              EPGMAP_ITR;
-    typedef EPGMAP::const_iterator        EPGMAP_CITR;
-
     CEpgDatabase m_database;           /*!< the EPG database */
 
     /** @name Configuration */

--- a/xbmc/epg/EpgDatabase.cpp
+++ b/xbmc/epg/EpgDatabase.cpp
@@ -292,13 +292,12 @@ bool CEpgDatabase::PersistLastEpgScanTime(int iEpgId /* = 0 */, bool bQueueWrite
   return bQueueWrite ? QueueInsertQuery(strQuery) : ExecuteQuery(strQuery);
 }
 
-bool CEpgDatabase::Persist(const std::map<unsigned int, CEpg *> &epgs)
+bool CEpgDatabase::Persist(const EPGMAP &epgs)
 {
-  for (std::map<unsigned int, CEpg *>::const_iterator it = epgs.begin(); it != epgs.end(); ++it)
+  for (const auto &epgEntry : epgs)
   {
-    CEpg *epg = it->second;
-    if (epg)
-      Persist(*epg, true);
+    if (epgEntry.second)
+      Persist(*epgEntry.second, true);
   }
 
   return CommitInsertQueries();

--- a/xbmc/epg/EpgDatabase.h
+++ b/xbmc/epg/EpgDatabase.h
@@ -24,6 +24,8 @@
 #include "XBDateTime.h"
 #include "dbwrappers/Database.h"
 
+#include "Epg.h"
+
 namespace EPG
 {
   class CEpg;
@@ -122,7 +124,7 @@ namespace EPG
      */
     virtual bool PersistLastEpgScanTime(int iEpgId = 0, bool bQueueWrite = false);
 
-    bool Persist(const std::map<unsigned int, CEpg *> &epgs);
+    bool Persist(const EPGMAP &epgs);
 
     /*!
      * @brief Persist an EPG table. It's entries are not persisted.


### PR DESCRIPTION
It was already defined in EpgContainer.h and now used on all places who have this type.
