### PR TITLE
[Python] add xbmcgui.Dialog().textviewer()

### DIFF
--- a/xbmc/interfaces/legacy/Dialog.cpp
+++ b/xbmc/interfaces/legacy/Dialog.cpp
@@ -22,6 +22,7 @@
 #include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogYesNo.h"
 #include "dialogs/GUIDialogSelect.h"
+#include "dialogs/GUIDialogTextViewer.h"
 #include "guilib/GUIWindowManager.h"
 #include "dialogs/GUIDialogFileBrowser.h"
 #include "dialogs/GUIDialogNumeric.h"
@@ -137,6 +138,24 @@ namespace XBMCAddon
 
       return pDialog->IsConfirmed();
     }
+
+    void Dialog::textviewer(const String& heading, const String& text)
+    {
+      DelayedCallGuard dcguard(languageHook);
+      const int window = WINDOW_DIALOG_TEXT_VIEWER;
+
+      CGUIDialogTextViewer* pDialog = (CGUIDialogTextViewer*)g_windowManager.GetWindow(window);
+      if (pDialog == NULL)
+        throw WindowException("Error: Window is NULL, this is not possible :-)");
+      if (!heading.empty())
+        pDialog->SetHeading(heading);
+      if (!text.empty())
+        pDialog->SetText(text);
+
+      //send message and wait for user input
+      XBMCWaitForThreadMessage(TMSG_DIALOG_DOMODAL, window, ACTIVE_WINDOW);
+    }
+
 
     Alternative<String, std::vector<String> > Dialog::browse(int type, const String& heading, 
                                 const String& s_shares, const String& maskparam, bool useThumbs, 

--- a/xbmc/interfaces/legacy/Dialog.h
+++ b/xbmc/interfaces/legacy/Dialog.h
@@ -112,6 +112,19 @@ namespace XBMCAddon
               const String& line3 = emptyString);
 
       /**
+      * textviewer(heading, text) -- Show a dialog 'TextViewer'.\n
+      * \n
+      * heading        : string or unicode - dialog heading.\n
+      * text          : string or unicode - text.\n
+      * \n
+      * example:\n
+      *   - dialog = xbmcgui.Dialog()\n
+      *   - dialog.textviewer('Plot', 'Some movie plot.')n\n
+      */
+      void textviewer(const String& heading, const String& text);
+
+
+      /**
        * browse(type, heading, shares[, mask, useThumbs, treatAsFolder, default, enableMultiple]) -- Show a 'Browse' dialog.\n
        * \n
        * type           : integer - the type of browse dialog.\n


### PR DESCRIPTION
Adds a textviewer method to xbmcgui.Dialog().
Now I only need someone to expose parts of the python interface to skinners, as discussed with @FernetMenta . :)    
