### PR TITLE
Fix ticket 15727, SMS input not updating CGUIKeyboardGeneric

### DIFF
--- a/xbmc/guilib/GUIEditControl.cpp
+++ b/xbmc/guilib/GUIEditControl.cpp
@@ -654,7 +654,6 @@ void CGUIEditControl::SetCursorPosition(unsigned int iPosition)
 void CGUIEditControl::OnSMSCharacter(unsigned int key)
 {
   assert(key < 10);
-  bool sendUpdate = false;
   if (m_smsTimer.IsRunning())
   {
     // we're already entering an SMS character
@@ -662,7 +661,6 @@ void CGUIEditControl::OnSMSCharacter(unsigned int key)
     { // a different key was clicked than last time, or we have timed out
       m_smsLastKey = key;
       m_smsKeyIndex = 0;
-      sendUpdate = true;
     }
     else
     { // same key as last time within the appropriate time period
@@ -680,7 +678,7 @@ void CGUIEditControl::OnSMSCharacter(unsigned int key)
   m_smsKeyIndex = m_smsKeyIndex % strlen(smsLetters[key]);
 
   m_text2.insert(m_text2.begin() + m_cursorPos++, smsLetters[key][m_smsKeyIndex]);
-  UpdateText(sendUpdate);
+  UpdateText();
   m_smsTimer.StartZero();
 }
 


### PR DESCRIPTION
This addresses ticket 15727.

The CGUIDialogKeyboardGeneric never directly reads the text from the edit control. Instead the control updates the parent dialog by sending it CTL_EDIT messages, which is done by calling UpdateText(true) or just UpdateText() - true is the default argument.

The SMS input only calls UpdateText(true) when the current SMS character is locked in i.e. when a different SMS key is pressed or when the SMS timer expires. The problem is that if the keyboard dialog is closed before the current SMS timer has expired, the keyboard dialog misses the last SMS keypress because it was never notified of it.

The code was obviously deliberately designed that way, but I cannot see the reason for that design choice. Calling UpdateText() immediately on every SMS keypress fixes the bug, and I cannot see why it would cause any problems.

The only other way to fix the problem would be for the CGUIDialogKeyboardGeneric dialog to read the text from the edit control as part of the CGUIKeyboardGeneric::OnOK method. I assume there's a good reason why this hasn't been done, and anyway if we chose this path we would need to check every dialog that uses an edit control in case they have the same problem.
