### PR TITLE
[xbmc][music] Better handling of tags for multifile cue files

### DIFF
--- a/xbmc/CueDocument.cpp
+++ b/xbmc/CueDocument.cpp
@@ -160,6 +160,7 @@ CCueDocument::CCueDocument()
   : m_iYear(0)
   , m_iTrack(0)
   , m_iDiscNumber(0)
+  , m_bOneFilePerTrack(false)
 {
 }
 
@@ -230,6 +231,11 @@ bool CCueDocument::IsLoaded() const
   return !m_tracks.empty();
 }
 
+bool CCueDocument::IsOneFilePerTrack() const
+{
+  return m_bOneFilePerTrack;
+}
+
 bool CCueDocument::GetSong(int aTrackNumber, CSong& aSong)
 {
   if (aTrackNumber < 0 || aTrackNumber >= static_cast<int>(m_tracks.size()))
@@ -294,6 +300,7 @@ bool CCueDocument::Parse(CueReader& reader, const std::string& strFile)
   bool bCurrentFileChanged = false;
   int time;
   int totalTracks = -1;
+  int numberFiles = -1;
 
   // Run through the .CUE file and extract the tracks...
   while (true)
@@ -359,6 +366,7 @@ bool CCueDocument::Parse(CueReader& reader, const std::string& strFile)
     }
     else if (StringUtils::StartsWithNoCase(strLine, "FILE"))
     {
+      numberFiles++;
       // already a file name? then the time computation will be changed
       if (!strCurrentFile.empty())
         bCurrentFileChanged = true;
@@ -395,6 +403,10 @@ bool CCueDocument::Parse(CueReader& reader, const std::string& strFile)
     m_tracks[totalTracks].iEndTime = 0;
   else
     CLog::Log(LOGERROR, "No INDEX 01 tags in CUE file!");
+
+  if ( totalTracks == numberFiles )
+    m_bOneFilePerTrack = true;
+
   return (totalTracks >= 0);
 }
 

--- a/xbmc/CueDocument.h
+++ b/xbmc/CueDocument.h
@@ -57,6 +57,7 @@ public:
   std::string GetMediaTitle();
   void GetMediaFiles(std::vector<std::string>& mediaFiles);
   void UpdateMediaFile(const std::string& oldMediaFile, const std::string& mediaFile);
+  bool IsOneFilePerTrack() const;
   bool IsLoaded() const;
 private:
   void Clear();
@@ -70,6 +71,8 @@ private:
   int m_iTrack;   // current track
   int m_iDiscNumber;  // Disc number
   ReplayGain::Info m_albumReplayGain;
+
+  bool m_bOneFilePerTrack;
 
   // cuetrack array
   typedef std::vector<CCueTrack> Tracks;

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -75,6 +75,13 @@ CFileItem::CFileItem(const CSong& song)
   SetFromSong(song);
 }
 
+CFileItem::CFileItem(const CSong& song, const CMusicInfoTag& music)
+{
+  Initialize();
+  SetFromSong(song);
+  *GetMusicInfoTag() = music;
+}
+
 CFileItem::CFileItem(const CURL &url, const CAlbum& album)
 {
   Initialize();
@@ -1561,6 +1568,8 @@ bool CFileItem::LoadTracksFromCueDocument(CFileItemList& scannedItems)
 
   VECSONGS tracks;
   m_cueDocument->GetSongs(tracks);
+
+  bool oneFilePerTrack = m_cueDocument->IsOneFilePerTrack();
   m_cueDocument.reset();
 
   int tracksFound = 0;
@@ -1596,7 +1605,15 @@ bool CFileItem::LoadTracksFromCueDocument(CFileItemList& scannedItems)
       { // must be the last song
         song.iDuration = (tag.GetDuration() * 75 - song.iStartOffset + 37) / 75;
       }
-      scannedItems.Add(CFileItemPtr(new CFileItem(song)));
+      if ( tag.Loaded() && oneFilePerTrack && ! ( tag.GetAlbum().empty() || tag.GetArtist().empty() || tag.GetTitle().empty() ) )
+      {
+        // If there are multiple files in a cue file, the tags from the files should be prefered if they exist.
+        scannedItems.Add(CFileItemPtr(new CFileItem(song, tag)));
+      }
+      else
+      {
+        scannedItems.Add(CFileItemPtr(new CFileItem(song)));
+      }
       ++tracksFound;
     }
   }

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -102,6 +102,7 @@ public:
   CFileItem(const CURL& path, bool bIsFolder);
   CFileItem(const std::string& strPath, bool bIsFolder);
   CFileItem(const CSong& song);
+  CFileItem(const CSong& song, const MUSIC_INFO::CMusicInfoTag& music);
   CFileItem(const CURL &path, const CAlbum& album);
   CFileItem(const std::string &path, const CAlbum& album);
   CFileItem(const CArtist& artist);


### PR DESCRIPTION
As discussed in http://forum.kodi.tv/showthread.php?tid=189148 (a year ago, but the problem is still the same) if you have a cue file for your audio file(s), kodi will prefer the information from the cue file compared to the information in the tags. This is fine for cases when you have a single flac/cue (for example) but causes problems when you have multiple flac files with a cue and have re-tagged the flac files so that the tags are no longer in sync. This pr adds an advancedsetting that handles how cue files with multiple audiofiles should be handled, the default in this pr is to ignore information in cue files for these cases but that can be configured. 
