### PR TITLE
[xbmc] Fix includes of CVariant and some improvements

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1539,7 +1539,7 @@ void CApplication::ReloadSkin(bool confirm/*=false*/)
     if (confirm && !m_skinReverting)
     {
       bool cancelled;
-      if (!CGUIDialogYesNo::ShowAndGetInput(13123, 13111, cancelled, "", "", 10000))
+      if (!CGUIDialogYesNo::ShowAndGetInput(CVariant{13123}, CVariant{13111}, cancelled, CVariant{""}, CVariant{""}, CVariant{10000}))
       {
         m_skinReverting = true;
         if (oldSkin.empty())
@@ -2996,7 +2996,7 @@ PlayBackRet CApplication::PlayFile(const CFileItem& item, bool bRestart)
     }
     else
 #endif
-      CGUIDialogOK::ShowAndGetInput(435, 436);
+      CGUIDialogOK::ShowAndGetInput(CVariant{435}, CVariant{436});
 
     return PLAYBACK_OK;
   }
@@ -3910,7 +3910,7 @@ bool CApplication::OnMessage(CGUIMessage& message)
       else if (message.GetParam1() == GUI_MSG_UI_READY)
       {
         if (m_fallbackLanguageLoaded)
-          CGUIDialogOK::ShowAndGetInput(24133, 24134);
+          CGUIDialogOK::ShowAndGetInput(CVariant{24133}, CVariant{24134});
 
         // show info dialog about moved configuration files if needed
         ShowAppMigrationMessage();
@@ -4200,7 +4200,7 @@ void CApplication::ShowAppMigrationMessage()
   if (CFile::Exists("special://home/.kodi_data_was_migrated") &&
       !CFile::Exists("special://home/.kodi_migration_info_shown"))
   {
-    CGUIDialogOK::ShowAndGetInput(24128, 24129);
+    CGUIDialogOK::ShowAndGetInput(CVariant{24128}, CVariant{24129});
     CFile tmpFile;
     // create the file which will prevent this dialog from appearing in the future
     tmpFile.OpenForWrite("special://home/.kodi_migration_info_shown");

--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -43,6 +43,7 @@
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
+#include "utils/Variant.h"
 #ifdef HAS_CDDA_RIPPER
 #include "cdrip/CDDARipper.h"
 #endif
@@ -489,7 +490,7 @@ bool CAutorun::IsEnabled() const
 
 bool CAutorun::PlayDiscAskResume(const std::string& path)
 {
-  return PlayDisc(path, true, !CanResumePlayDVD(path) || CGUIDialogYesNo::ShowAndGetInput(341, "", "", "", 13404, 12021));
+  return PlayDisc(path, true, !CanResumePlayDVD(path) || CGUIDialogYesNo::ShowAndGetInput(CVariant{341}, CVariant{""}, CVariant{""}, CVariant{""}, CVariant{13404}, CVariant{12021}));
 }
 
 bool CAutorun::CanResumePlayDVD(const std::string& path)

--- a/xbmc/DbUrl.cpp
+++ b/xbmc/DbUrl.cpp
@@ -22,6 +22,7 @@
 
 #include "DbUrl.h"
 #include "utils/URIUtils.h"
+#include "utils/Variant.h"
 
 using namespace std;
 

--- a/xbmc/DbUrl.h
+++ b/xbmc/DbUrl.h
@@ -25,6 +25,8 @@
 #include "URL.h"
 #include "utils/UrlOptions.h"
 
+class CVariant;
+
 class CDbUrl : public CUrlOptions
 {
 public:

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -63,6 +63,7 @@ class CSong;
 class CGenre;
 
 class CURL;
+class CVariant;
 
 class CFileItemList;
 class CCueDocument;

--- a/xbmc/GUIPassword.cpp
+++ b/xbmc/GUIPassword.cpp
@@ -36,6 +36,9 @@
 #include "guilib/LocalizeStrings.h"
 #include "utils/StringUtils.h"
 #include "view/ViewStateSettings.h"
+#include "utils/Variant.h"
+
+#include <utility>
 
 CGUIPassword::CGUIPassword(void)
 {
@@ -68,7 +71,7 @@ bool CGUIPassword::IsItemUnlocked(CFileItem* pItem, const std::string &strType)
     {
       if (0 != CSettings::Get().GetInt("masterlock.maxretries") && pItem->m_iBadPwdCount >= CSettings::Get().GetInt("masterlock.maxretries"))
       { // user previously exhausted all retries, show access denied error
-        CGUIDialogOK::ShowAndGetInput(12345, 12346);
+        CGUIDialogOK::ShowAndGetInput(CVariant{12345}, CVariant{12346});
         return false;
       }
       // show the appropriate lock dialog
@@ -143,7 +146,7 @@ bool CGUIPassword::CheckStartUpLock()
         std::string strLabel = StringUtils::Format("%i %s", iLeft, strLabel1.c_str());
 
         // PopUp OK and Display: MasterLock mode has changed but no new Mastercode has been set!
-        CGUIDialogOK::ShowAndGetInput(12360, 12367, strLabel, "");
+        CGUIDialogOK::ShowAndGetInput(CVariant{12360}, CVariant{12367}, CVariant{strLabel}, CVariant{""});
       }
       else
         i=g_passwordManager.iMasterLockRetriesLeft;
@@ -281,7 +284,7 @@ void CGUIPassword::UpdateMasterLockRetryCount(bool bResetCount)
         // user has run out of retry attempts
         g_passwordManager.iMasterLockRetriesLeft = 0;
         // Tell the user they ran out of retry attempts
-        CGUIDialogOK::ShowAndGetInput(12345, 12346);
+        CGUIDialogOK::ShowAndGetInput(CVariant{12345}, CVariant{12346});
         return ;
       }
     }
@@ -290,7 +293,7 @@ void CGUIPassword::UpdateMasterLockRetryCount(bool bResetCount)
       dlgLine1 = StringUtils::Format("%d %s",
                                      g_passwordManager.iMasterLockRetriesLeft,
                                      g_localizeStrings.Get(12343).c_str());
-    CGUIDialogOK::ShowAndGetInput(20075, 12345, dlgLine1, 0);
+    CGUIDialogOK::ShowAndGetInput(CVariant{20075}, CVariant{12345}, CVariant{std::move(dlgLine1)}, CVariant{0});
   }
   else
     g_passwordManager.iMasterLockRetriesLeft = CSettings::Get().GetInt("masterlock.maxretries"); // user entered correct mastercode, reset retries to max allowed

--- a/xbmc/PartyModeManager.cpp
+++ b/xbmc/PartyModeManager.cpp
@@ -33,6 +33,7 @@
 #include "playlists/PlayList.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
+#include "utils/Variant.h"
 #include "Application.h"
 #include "interfaces/AnnouncementManager.h"
 
@@ -100,10 +101,10 @@ bool CPartyModeManager::Enable(PartyModeContext context /*= PARTYMODECONTEXT_MUS
   CGUIDialogProgress* pDialog = (CGUIDialogProgress*)g_windowManager.GetWindow(WINDOW_DIALOG_PROGRESS);
   int iHeading = (m_bIsVideo ? 20250 : 20121);
   int iLine0 = (m_bIsVideo ? 20251 : 20123);
-  pDialog->SetHeading(iHeading);
-  pDialog->SetLine(0, iLine0);
-  pDialog->SetLine(1, "");
-  pDialog->SetLine(2, "");
+  pDialog->SetHeading(CVariant{iHeading});
+  pDialog->SetLine(0, CVariant{iLine0});
+  pDialog->SetLine(1, CVariant{""});
+  pDialog->SetLine(2, CVariant{""});
   pDialog->StartModal();
 
   ClearState();
@@ -186,7 +187,7 @@ bool CPartyModeManager::Enable(PartyModeContext context /*= PARTYMODECONTEXT_MUS
   g_playlistPlayer.SetShuffle(iPlaylist, false);
   g_playlistPlayer.SetRepeat(iPlaylist, PLAYLIST::REPEAT_NONE);
 
-  pDialog->SetLine(0, (m_bIsVideo ? 20252 : 20124));
+  pDialog->SetLine(0, CVariant{m_bIsVideo ? 20252 : 20124});
   pDialog->Progress();
   // add initial songs
   if (!AddInitialSongs(songIDs))
@@ -512,7 +513,7 @@ void CPartyModeManager::Play(int iPos)
 void CPartyModeManager::OnError(int iError, const std::string&  strLogMessage)
 {
   // open error dialog
-  CGUIDialogOK::ShowAndGetInput(257, 16030, iError, 0);
+  CGUIDialogOK::ShowAndGetInput(CVariant{257}, CVariant{16030}, CVariant{iError}, CVariant{0});
   CLog::Log(LOGERROR, "PARTY MODE MANAGER: %s", strLogMessage.c_str());
   m_bEnabled = false;
   SendUpdateMessage();

--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -29,6 +29,7 @@
 #include "playlists/PlayList.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
+#include "utils/Variant.h"
 #include "music/tags/MusicInfoTag.h"
 #include "dialogs/GUIDialogKaiToast.h"
 #include "guilib/LocalizeStrings.h"
@@ -299,7 +300,7 @@ bool CPlayListPlayer::Play(int iSong, bool bAutoPlay /* = false */, bool bPlayPr
       CLog::Log(LOGDEBUG,"Playlist Player: one or more items failed to play... aborting playback");
 
       // open error dialog
-      CGUIDialogOK::ShowAndGetInput(16026, 16027);
+      CGUIDialogOK::ShowAndGetInput(CVariant{16026}, CVariant{16027});
 
       CGUIMessage msg(GUI_MSG_PLAYLISTPLAYER_STOPPED, 0, 0, m_iCurrentPlayList, m_iCurrentSong);
       g_windowManager.SendThreadMessage(msg);

--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -38,6 +38,7 @@
 #include "utils/log.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
+#include "utils/Variant.h"
 #include "URL.h"
 #include "Util.h"
 #include <vector>

--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -28,6 +28,7 @@
 
 class TiXmlElement;
 class CAddonCallbacksAddon;
+class CVariant;
 
 typedef struct cp_plugin_info_t cp_plugin_info_t;
 typedef struct cp_extension_t cp_extension_t;

--- a/xbmc/addons/AddonCallbacksGUI.cpp
+++ b/xbmc/addons/AddonCallbacksGUI.cpp
@@ -28,6 +28,7 @@
 #include "filesystem/File.h"
 #include "utils/URIUtils.h"
 #include "utils/StringUtils.h"
+#include "utils/Variant.h"
 #include "guilib/GUIWindowManager.h"
 #include "input/Key.h"
 #include "guilib/TextureManager.h"
@@ -1667,7 +1668,7 @@ void CAddonCallbacksGUI::RenderAddon_Delete(void *addonData, GUIHANDLE handle)
 bool CAddonCallbacksGUI::Dialog_Keyboard_ShowAndGetInputWithHead(char &aTextString, unsigned int iMaxStringSize, const char *strHeading, bool allowEmptyResult, bool hiddenInput, unsigned int autoCloseMs)
 {
   std::string str = &aTextString;
-  bool bRet = CGUIKeyboardFactory::ShowAndGetInput(str, strHeading, allowEmptyResult, hiddenInput, autoCloseMs);
+  bool bRet = CGUIKeyboardFactory::ShowAndGetInput(str, CVariant{strHeading}, allowEmptyResult, hiddenInput, autoCloseMs);
   if (bRet)
     strncpy(&aTextString, str.c_str(), iMaxStringSize);
   return bRet;
@@ -1848,12 +1849,12 @@ bool CAddonCallbacksGUI::Dialog_FileBrowser_ShowAndGetFile(const char *directory
 //@{
 void CAddonCallbacksGUI::Dialog_OK_ShowAndGetInputSingleText(const char *heading, const char *text)
 {
-  CGUIDialogOK::ShowAndGetInput(heading, text);
+  CGUIDialogOK::ShowAndGetInput(CVariant{heading}, CVariant{text});
 }
 
 void CAddonCallbacksGUI::Dialog_OK_ShowAndGetInputLineText(const char *heading, const char *line0, const char *line1, const char *line2)
 {
-  CGUIDialogOK::ShowAndGetInput(heading, line0, line1, line2);
+  CGUIDialogOK::ShowAndGetInput(CVariant{heading}, CVariant{line0}, CVariant{line1}, CVariant{line2});
 }
 //@}
 
@@ -1861,17 +1862,17 @@ void CAddonCallbacksGUI::Dialog_OK_ShowAndGetInputLineText(const char *heading, 
 //@{
 bool CAddonCallbacksGUI::Dialog_YesNo_ShowAndGetInputSingleText(const char *heading, const char *text, bool& bCanceled, const char *noLabel, const char *yesLabel)
 {
-  return CGUIDialogYesNo::ShowAndGetInput(heading, text, bCanceled, noLabel, yesLabel);
+  return CGUIDialogYesNo::ShowAndGetInput(CVariant{heading}, CVariant{text}, CVariant{bCanceled}, CVariant{noLabel}, CVariant{yesLabel});
 }
 
 bool CAddonCallbacksGUI::Dialog_YesNo_ShowAndGetInputLineText(const char *heading, const char *line0, const char *line1, const char *line2, const char *noLabel, const char *yesLabel)
 {
-  return CGUIDialogYesNo::ShowAndGetInput(heading, line0, line1, line2, noLabel, yesLabel);
+  return CGUIDialogYesNo::ShowAndGetInput(CVariant{heading}, CVariant{line0}, CVariant{line1}, CVariant{line2}, CVariant{noLabel}, CVariant{yesLabel});
 }
 
 bool CAddonCallbacksGUI::Dialog_YesNo_ShowAndGetInputLineButtonText(const char *heading, const char *line0, const char *line1, const char *line2, bool &bCanceled, const char *noLabel, const char *yesLabel)
 {
-  return CGUIDialogYesNo::ShowAndGetInput(heading, line0, line1, line2, bCanceled, noLabel, yesLabel);
+  return CGUIDialogYesNo::ShowAndGetInput(CVariant{heading}, CVariant{line0}, CVariant{line1}, CVariant{line2}, bCanceled, CVariant{noLabel}, CVariant{yesLabel});
 }
 //@}
 
@@ -1892,7 +1893,7 @@ int CAddonCallbacksGUI::Dialog_Select(const char *heading, const char *entries[]
 {
   CGUIDialogSelect* pDialog = (CGUIDialogSelect*)g_windowManager.GetWindow(WINDOW_DIALOG_SELECT);
   pDialog->Reset();
-  pDialog->SetHeading(heading);
+  pDialog->SetHeading(CVariant{heading});
 
   for (unsigned int i = 0; i < size; i++)
     pDialog->Add(entries[i]);

--- a/xbmc/addons/AddonDll.h
+++ b/xbmc/addons/AddonDll.h
@@ -34,6 +34,7 @@
 #include "interfaces/IAnnouncer.h"
 #include "interfaces/AnnouncementManager.h"
 #include "utils/XMLUtils.h"
+#include "utils/Variant.h"
 #include "Util.h"
 
 namespace ADDON

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -22,6 +22,7 @@
 #include "utils/log.h"
 #include "utils/FileUtils.h"
 #include "utils/URIUtils.h"
+#include "utils/Variant.h"
 #include "Util.h"
 #include "guilib/LocalizeStrings.h"
 #include "filesystem/Directory.h"
@@ -182,7 +183,7 @@ bool CAddonInstaller::InstallModal(const std::string &addonID, ADDON::AddonPtr &
 
   // if specified ask the user if he wants it installed
   if (promptForInstall &&
-      !CGUIDialogYesNo::ShowAndGetInput(24076, 24100, addon->Name().c_str(), 24101))
+      !CGUIDialogYesNo::ShowAndGetInput(CVariant{24076}, CVariant{24100}, CVariant{addon->Name()}, CVariant{24101}))
     return false;
 
   if (!Install(addonID, true, "", false, true))
@@ -899,7 +900,7 @@ void CAddonInstallJob::ReportInstallError(const std::string& addonID, const std:
       msg = g_localizeStrings.Get(addon2 != NULL ? 113 : 114);
 
     if (IsModal())
-      CGUIDialogOK::ShowAndGetInput(m_addon->Name(), msg);
+      CGUIDialogOK::ShowAndGetInput(CVariant{m_addon->Name()}, CVariant{msg});
     else
       CGUIDialogKaiToast::QueueNotification(addon->Icon(), addon->Name(), msg, TOAST_DISPLAY_TIME, false);
   }
@@ -908,7 +909,7 @@ void CAddonInstallJob::ReportInstallError(const std::string& addonID, const std:
     if (msg.empty())
       msg = g_localizeStrings.Get(114);
     if (IsModal())
-      CGUIDialogOK::ShowAndGetInput(fileName, msg);
+      CGUIDialogOK::ShowAndGetInput(CVariant{fileName}, CVariant{msg});
     else
       CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, fileName, msg, TOAST_DISPLAY_TIME, false);
   }

--- a/xbmc/addons/AddonStatusHandler.cpp
+++ b/xbmc/addons/AddonStatusHandler.cpp
@@ -29,6 +29,7 @@
 #include "settings/Settings.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
+#include "utils/Variant.h"
 
 namespace ADDON
 {
@@ -98,9 +99,9 @@ void CAddonStatusHandler::Process()
       CGUIDialogYesNo* pDialog = (CGUIDialogYesNo*)g_windowManager.GetWindow(WINDOW_DIALOG_YES_NO);
       if (!pDialog) return;
 
-      pDialog->SetHeading(heading);
-      pDialog->SetLine(1, 24070);
-      pDialog->SetLine(2, 24073);
+      pDialog->SetHeading(CVariant{heading});
+      pDialog->SetLine(1, CVariant{24070});
+      pDialog->SetLine(2, CVariant{24073});
 
       //send message and wait for user input
       ThreadMessage tMsg = {TMSG_DIALOG_DOMODAL, WINDOW_DIALOG_YES_NO, g_windowManager.GetActiveWindow()};
@@ -116,8 +117,8 @@ void CAddonStatusHandler::Process()
     CGUIDialogOK* pDialog = (CGUIDialogOK*)g_windowManager.GetWindow(WINDOW_DIALOG_OK);
     if (!pDialog) return;
 
-    pDialog->SetHeading(heading);
-    pDialog->SetLine(1, 24074);
+    pDialog->SetHeading(CVariant{heading});
+    pDialog->SetLine(1, CVariant{24074});
 
     //send message and wait for user input
     ThreadMessage tMsg = {TMSG_DIALOG_DOMODAL, WINDOW_DIALOG_OK, g_windowManager.GetActiveWindow()};
@@ -131,10 +132,10 @@ void CAddonStatusHandler::Process()
     CGUIDialogYesNo* pDialogYesNo = (CGUIDialogYesNo*)g_windowManager.GetWindow(WINDOW_DIALOG_YES_NO);
     if (!pDialogYesNo) return;
 
-    pDialogYesNo->SetHeading(heading);
-    pDialogYesNo->SetLine(1, 24070);
-    pDialogYesNo->SetLine(2, 24072);
-    pDialogYesNo->SetLine(3, m_message);
+    pDialogYesNo->SetHeading(CVariant{heading});
+    pDialogYesNo->SetLine(1, CVariant{24070});
+    pDialogYesNo->SetLine(2, CVariant{24072});
+    pDialogYesNo->SetLine(3, CVariant{m_message});
 
     //send message and wait for user input
     ThreadMessage tMsg = {TMSG_DIALOG_DOMODAL, WINDOW_DIALOG_YES_NO, g_windowManager.GetActiveWindow()};
@@ -158,10 +159,10 @@ void CAddonStatusHandler::Process()
     CGUIDialogOK* pDialog = (CGUIDialogOK*)g_windowManager.GetWindow(WINDOW_DIALOG_OK);
     if (!pDialog) return;
 
-    pDialog->SetHeading(heading);
-    pDialog->SetLine(1, 24070);
-    pDialog->SetLine(2, 24071);
-    pDialog->SetLine(3, m_message);
+    pDialog->SetHeading(CVariant{heading});
+    pDialog->SetLine(1, CVariant{24070});
+    pDialog->SetLine(2, CVariant{24071});
+    pDialog->SetLine(3, CVariant{m_message});
 
     //send message and wait for user input
     ThreadMessage tMsg = {TMSG_DIALOG_DOMODAL, WINDOW_DIALOG_OK, g_windowManager.GetActiveWindow()};

--- a/xbmc/addons/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/GUIDialogAddonInfo.cpp
@@ -36,9 +36,12 @@
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
+#include "utils/Variant.h"
 #include "addons/AddonInstaller.h"
 #include "Util.h"
 #include "interfaces/Builtins.h"
+
+#include <utility>
 
 #define CONTROL_BTN_INSTALL          6
 #define CONTROL_BTN_ENABLE           7
@@ -216,7 +219,7 @@ bool CGUIDialogAddonInfo::PromptIfDependency(int heading, int line2)
   {
     string line0 = StringUtils::Format(g_localizeStrings.Get(24046).c_str(), m_localAddon->Name().c_str());
     string line1 = StringUtils::Join(deps, ", ");
-    CGUIDialogOK::ShowAndGetInput(heading, line0, line1, line2);
+    CGUIDialogOK::ShowAndGetInput(CVariant{heading}, CVariant{std::move(line0)}, CVariant{std::move(line1)}, CVariant{line2});
     return true;
   }
   return false;
@@ -235,7 +238,7 @@ void CGUIDialogAddonInfo::OnUninstall()
     return;
 
   // prompt user to be sure
-  if (!CGUIDialogYesNo::ShowAndGetInput(24037, 750))
+  if (!CGUIDialogYesNo::ShowAndGetInput(CVariant{24037}, CVariant{750}))
     return;
 
   CJobManager::GetInstance().AddJob(new CAddonUnInstallJob(m_localAddon),

--- a/xbmc/addons/GUIDialogAddonSettings.cpp
+++ b/xbmc/addons/GUIDialogAddonSettings.cpp
@@ -49,6 +49,7 @@
 #include "utils/log.h"
 #include "URL.h"
 #include "utils/XMLUtils.h"
+#include "utils/Variant.h"
 
 using namespace std;
 using namespace ADDON;
@@ -218,7 +219,7 @@ bool CGUIDialogAddonSettings::ShowAndGetInput(const AddonPtr &addon, bool saveTo
   }
   else
   { // addon does not support settings, inform user
-    CGUIDialogOK::ShowAndGetInput(24000, 24030);
+    CGUIDialogOK::ShowAndGetInput(CVariant{24000}, CVariant{24030});
   }
 
   return ret;
@@ -276,7 +277,7 @@ bool CGUIDialogAddonSettings::ShowVirtualKeyboard(int iControl)
           if (bEncoded)
             value = CURL::Decode(value);
 
-          if (CGUIKeyboardFactory::ShowAndGetInput(value, label, true, bHidden))
+          if (CGUIKeyboardFactory::ShowAndGetInput(value, CVariant{label}, true, bHidden))
           {
             // if hidden hide input
             if (bHidden)
@@ -304,7 +305,7 @@ bool CGUIDialogAddonSettings::ShowVirtualKeyboard(int iControl)
           CGUIDialogSelect *pDlg = (CGUIDialogSelect*)g_windowManager.GetWindow(WINDOW_DIALOG_SELECT);
           if (pDlg)
           {
-            pDlg->SetHeading(label.c_str());
+            pDlg->SetHeading(CVariant{label});
             pDlg->Reset();
 
             int selected = -1;

--- a/xbmc/addons/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/GUIWindowAddonBrowser.cpp
@@ -36,11 +36,14 @@
 #include "settings/Settings.h"
 #include "settings/MediaSourceSettings.h"
 #include "utils/StringUtils.h"
+#include "utils/Variant.h"
 #include "AddonDatabase.h"
 #include "storage/MediaManager.h"
 #include "LangInfo.h"
 #include "input/Key.h"
 #include "ContextMenuManager.h"
+
+#include <utility>
 
 #define CONTROL_AUTOUPDATE    5
 #define CONTROL_SHUTUP        6
@@ -250,7 +253,7 @@ bool CGUIWindowAddonBrowser::OnClick(int iItem)
     // cancel a downloading job
     if (item->HasProperty("Addon.Downloading"))
     {
-      if (CGUIDialogYesNo::ShowAndGetInput(24000, item->GetProperty("Addon.Name").asString(), 24066, ""))
+      if (CGUIDialogYesNo::ShowAndGetInput(CVariant{24000}, item->GetProperty("Addon.Name"), CVariant{24066}, CVariant{""}))
       {
         if (CAddonInstaller::Get().Cancel(item->GetProperty("Addon.ID").asString()))
           Refresh();
@@ -564,7 +567,7 @@ int CGUIWindowAddonBrowser::SelectAddonID(const vector<ADDON::TYPE> &types, vect
     heading += TranslateType(*type, true);
   }
 
-  dialog->SetHeading(heading);
+  dialog->SetHeading(CVariant{std::move(heading)});
   dialog->Reset();
   dialog->SetUseDetails(showDetails);
 

--- a/xbmc/addons/LanguageResource.cpp
+++ b/xbmc/addons/LanguageResource.cpp
@@ -25,6 +25,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "settings/Settings.h"
 #include "utils/StringUtils.h"
+#include "utils/Variant.h"
 
 #define LANGUAGE_SETTING        "locale.language"
 #define LANGUAGE_ADDON_PREFIX   "resource.language."
@@ -111,7 +112,7 @@ bool CLanguageResource::IsInUse() const
 void CLanguageResource::OnPostInstall(bool update, bool modal)
 {
   if (IsInUse() ||
-     (!update && !modal && CGUIDialogYesNo::ShowAndGetInput(Name(), 24132)))
+     (!update && !modal && CGUIDialogYesNo::ShowAndGetInput(CVariant{Name()}, CVariant{24132})))
   {
     CGUIDialogKaiToast *toast = (CGUIDialogKaiToast *)g_windowManager.GetWindow(WINDOW_DIALOG_KAI_TOAST);
     if (toast)

--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -32,6 +32,7 @@
 #include "utils/JobManager.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
+#include "utils/Variant.h"
 #include "utils/XBMCTinyXML.h"
 #include "FileItem.h"
 #include "TextureDatabase.h"
@@ -301,7 +302,7 @@ bool CRepositoryUpdateJob::DoWork()
           std::string line = g_localizeStrings.Get(24096);
           if (newAddon->Props().broken == "DEPSNOTMET")
             line = g_localizeStrings.Get(24104);
-          if (addon && CGUIDialogYesNo::ShowAndGetInput(newAddon->Name(), line, 24097, ""))
+          if (addon && CGUIDialogYesNo::ShowAndGetInput(CVariant{newAddon->Name()}, CVariant{line}, CVariant{24097}, CVariant{""}))
             CAddonMgr::Get().DisableAddon(newAddon->ID());
         }
       }

--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -36,6 +36,7 @@
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/XMLUtils.h"
+#include "utils/Variant.h"
 
 #define XML_SETTINGS      "settings"
 #define XML_SETTING       "setting"
@@ -371,7 +372,7 @@ void CSkinInfo::OnPreInstall()
 
 void CSkinInfo::OnPostInstall(bool update, bool modal)
 {
-  if (IsInUse() || (!update && !modal && CGUIDialogYesNo::ShowAndGetInput(Name(), 24099)))
+  if (IsInUse() || (!update && !modal && CGUIDialogYesNo::ShowAndGetInput(CVariant{Name()}, CVariant{24099})))
   {
     CGUIDialogKaiToast *toast = (CGUIDialogKaiToast *)g_windowManager.GetWindow(WINDOW_DIALOG_KAI_TOAST);
     if (toast)

--- a/xbmc/cdrip/CDDARipper.cpp
+++ b/xbmc/cdrip/CDDARipper.cpp
@@ -40,6 +40,7 @@
 #include "storage/MediaManager.h"
 #include "utils/log.h"
 #include "utils/URIUtils.h"
+#include "utils/Variant.h"
 #include "settings/MediaSourceSettings.h"
 #include "Application.h"
 #include "music/MusicDatabase.h"
@@ -168,7 +169,7 @@ bool CCDDARipper::CreateAlbumDir(const MUSIC_INFO::CMusicInfoTag& infoTag, std::
     // no rip path has been set, show error
     CLog::Log(LOGERROR, "Error: CDDARipPath has not been set");
     g_graphicsContext.Lock();
-    CGUIDialogOK::ShowAndGetInput(257, 608);
+    CGUIDialogOK::ShowAndGetInput(CVariant{257}, CVariant{608});
     g_graphicsContext.Unlock();
     return false;
   }

--- a/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
+++ b/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
@@ -35,6 +35,7 @@
 #include "URL.h"
 #include "utils/XMLUtils.h"
 #include "utils/log.h"
+#include "utils/Variant.h"
 #include "cores/AudioEngine/AEFactory.h"
 #include "input/InputManager.h"
 #if defined(TARGET_WINDOWS)
@@ -338,10 +339,10 @@ void CExternalPlayer::Process()
     {
       CSingleLock lock(g_graphicsContext);
       m_dialog = (CGUIDialogOK *)g_windowManager.GetWindow(WINDOW_DIALOG_OK);
-      m_dialog->SetHeading(23100);
-      m_dialog->SetLine(1, 23104);
-      m_dialog->SetLine(2, 23105);
-      m_dialog->SetLine(3, 23106);
+      m_dialog->SetHeading(CVariant{23100});
+      m_dialog->SetLine(1, CVariant{23104});
+      m_dialog->SetLine(2, CVariant{23105});
+      m_dialog->SetLine(3, CVariant{23106});
     }
 
     if (!m_bAbortRequest) m_dialog->DoModal();

--- a/xbmc/dialogs/GUIDialogBoxBase.cpp
+++ b/xbmc/dialogs/GUIDialogBoxBase.cpp
@@ -23,6 +23,8 @@
 #include "guilib/LocalizeStrings.h"
 #include "threads/SingleLock.h"
 #include "utils/StringUtils.h"
+#include "utils/Variant.h"
+
 
 using namespace std;
 

--- a/xbmc/dialogs/GUIDialogBoxBase.cpp
+++ b/xbmc/dialogs/GUIDialogBoxBase.cpp
@@ -65,7 +65,7 @@ bool CGUIDialogBoxBase::IsConfirmed() const
   return m_bConfirmed;
 }
 
-void CGUIDialogBoxBase::SetHeading(const CVariant& heading)
+void CGUIDialogBoxBase::SetHeading(CVariant heading)
 {
   std::string label = GetLocalized(heading);
   CSingleLock lock(m_section);
@@ -76,7 +76,7 @@ void CGUIDialogBoxBase::SetHeading(const CVariant& heading)
   }
 }
 
-void CGUIDialogBoxBase::SetLine(unsigned int iLine, const CVariant& line)
+void CGUIDialogBoxBase::SetLine(unsigned int iLine, CVariant line)
 {
   std::string label = GetLocalized(line);
   CSingleLock lock(m_section);
@@ -88,7 +88,7 @@ void CGUIDialogBoxBase::SetLine(unsigned int iLine, const CVariant& line)
   SetText(text);
 }
 
-void CGUIDialogBoxBase::SetText(const CVariant& text)
+void CGUIDialogBoxBase::SetText(CVariant text)
 {
   std::string label = GetLocalized(text);
   CSingleLock lock(m_section);

--- a/xbmc/dialogs/GUIDialogBoxBase.h
+++ b/xbmc/dialogs/GUIDialogBoxBase.h
@@ -38,9 +38,9 @@ public:
   virtual ~CGUIDialogBoxBase(void);
   virtual bool OnMessage(CGUIMessage& message);
   bool IsConfirmed() const;
-  void SetLine(unsigned int iLine, const CVariant &line);
-  void SetText(const CVariant &text);
-  void SetHeading(const CVariant &heading);
+  void SetLine(unsigned int iLine, CVariant line);
+  void SetText(CVariant text);
+  void SetHeading(CVariant heading);
   void SetChoice(int iButton, const CVariant &choice);
 protected:
   std::string GetDefaultLabel(int controlId) const;

--- a/xbmc/dialogs/GUIDialogBoxBase.h
+++ b/xbmc/dialogs/GUIDialogBoxBase.h
@@ -23,11 +23,12 @@
 #include <vector>
 
 #include "guilib/GUIDialog.h"
-#include "utils/Variant.h"
 #include "threads/CriticalSection.h"
 
 #define DIALOG_MAX_LINES 3
 #define DIALOG_MAX_CHOICES 2
+
+class CVariant;
 
 class CGUIDialogBoxBase :
       public CGUIDialog

--- a/xbmc/dialogs/GUIDialogCache.cpp
+++ b/xbmc/dialogs/GUIDialogCache.cpp
@@ -26,6 +26,8 @@
 #include "guilib/LocalizeStrings.h"
 #include "utils/log.h"
 #include "threads/SingleLock.h"
+#include "utils/Variant.h"
+
 
 CGUIDialogCache::CGUIDialogCache(DWORD dwDelay, const std::string& strHeader, const std::string& strMsg) : CThread("GUIDialogCache"),
   m_strHeader(strHeader),
@@ -74,11 +76,11 @@ void CGUIDialogCache::OpenDialog()
   if (m_pDlg)
   {
     if (m_strHeader.empty())
-      m_pDlg->SetHeading(438);
+      m_pDlg->SetHeading(CVariant{438});
     else
-      m_pDlg->SetHeading(m_strHeader);
+      m_pDlg->SetHeading(CVariant{m_strHeader});
 
-    m_pDlg->SetLine(2, m_strLinePrev);
+    m_pDlg->SetLine(2, CVariant{m_strLinePrev});
     m_pDlg->StartModal();
   }
   bSentCancel = false;
@@ -98,9 +100,9 @@ void CGUIDialogCache::SetMessage(const std::string& strMessage)
 {
   if (m_pDlg)
   {
-    m_pDlg->SetLine(0, m_strLinePrev2);
-    m_pDlg->SetLine(1, m_strLinePrev);
-    m_pDlg->SetLine(2, strMessage);
+    m_pDlg->SetLine(0, CVariant{m_strLinePrev2});
+    m_pDlg->SetLine(1, CVariant{m_strLinePrev});
+    m_pDlg->SetLine(2, CVariant{strMessage});
   }
   m_strLinePrev2 = m_strLinePrev;
   m_strLinePrev = strMessage; 

--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -45,6 +45,7 @@
 #include "video/windows/GUIWindowVideoBase.h"
 #include "URL.h"
 #include "utils/StringUtils.h"
+#include "utils/Variant.h"
 
 using namespace std;
 
@@ -370,7 +371,7 @@ bool CGUIDialogContextMenu::OnContextButton(const std::string &type, const CFile
         return false;
     }
     // prompt user if they want to really delete the source
-    if (!CGUIDialogYesNo::ShowAndGetInput(751, 750))
+    if (!CGUIDialogYesNo::ShowAndGetInput(CVariant{751}, CVariant{750}))
       return false;
 
     // check default before we delete, as deletion will kill the share object
@@ -512,7 +513,7 @@ bool CGUIDialogContextMenu::OnContextButton(const std::string &type, const CFile
       if (!g_passwordManager.IsMasterLockUnlocked(true))
         return false;
 
-      if (!CGUIDialogYesNo::ShowAndGetInput(12335, 750))
+      if (!CGUIDialogYesNo::ShowAndGetInput(CVariant{12335}, CVariant{750}))
         return false;
 
       share->m_iHasLock = 0;

--- a/xbmc/dialogs/GUIDialogFavourites.cpp
+++ b/xbmc/dialogs/GUIDialogFavourites.cpp
@@ -31,6 +31,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "storage/MediaManager.h"
 #include "ContextMenuManager.h"
+#include "utils/Variant.h"
 
 using namespace XFILE;
 
@@ -188,7 +189,7 @@ void CGUIDialogFavourites::OnRename(int item)
     return;
 
   std::string label((*m_favourites)[item]->GetLabel());
-  if (CGUIKeyboardFactory::ShowAndGetInput(label, g_localizeStrings.Get(16008), false))
+  if (CGUIKeyboardFactory::ShowAndGetInput(label, CVariant{g_localizeStrings.Get(16008)}, false))
     (*m_favourites)[item]->SetLabel(label);
 
   CFavouritesDirectory::Save(*m_favourites);

--- a/xbmc/dialogs/GUIDialogFileBrowser.cpp
+++ b/xbmc/dialogs/GUIDialogFileBrowser.cpp
@@ -45,6 +45,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "utils/log.h"
 #include "URL.h"
+#include "utils/Variant.h"
 
 using namespace XFILE;
 
@@ -222,7 +223,7 @@ bool CGUIDialogFileBrowser::OnMessage(CGUIMessage& message)
             Close();
           }
           else
-            CGUIDialogOK::ShowAndGetInput(257, 20072);
+            CGUIDialogOK::ShowAndGetInput(CVariant{257}, CVariant{20072});
         }
         else
         {
@@ -248,13 +249,13 @@ bool CGUIDialogFileBrowser::OnMessage(CGUIMessage& message)
       else if (message.GetSenderId() == CONTROL_NEWFOLDER)
       {
         std::string strInput;
-        if (CGUIKeyboardFactory::ShowAndGetInput(strInput,g_localizeStrings.Get(119),false))
+        if (CGUIKeyboardFactory::ShowAndGetInput(strInput, CVariant{g_localizeStrings.Get(119)}, false))
         {
           std::string strPath = URIUtils::AddFileToFolder(m_vecItems->GetPath(), strInput);
           if (CDirectory::Create(strPath))
             Update(m_vecItems->GetPath());
           else
-            CGUIDialogOK::ShowAndGetInput(20069, 20072);
+            CGUIDialogOK::ShowAndGetInput(CVariant{20069}, CVariant{20072});
         }
       }
       else if (message.GetSenderId() == CONTROL_FLIP)
@@ -567,7 +568,7 @@ bool CGUIDialogFileBrowser::HaveDiscOrConnection( int iDriveType )
   {
     if ( !g_mediaManager.IsDiscInDrive() )
     {
-      CGUIDialogOK::ShowAndGetInput(218, 219);
+      CGUIDialogOK::ShowAndGetInput(CVariant{218}, CVariant{219});
       return false;
     }
   }
@@ -576,7 +577,7 @@ bool CGUIDialogFileBrowser::HaveDiscOrConnection( int iDriveType )
     // TODO: Handle not connected to a remote share
     if ( !g_application.getNetwork().IsConnected() )
     {
-      CGUIDialogOK::ShowAndGetInput(220, 221);
+      CGUIDialogOK::ShowAndGetInput(CVariant{220}, CVariant{221});
       return false;
     }
   }
@@ -895,7 +896,7 @@ void CGUIDialogFileBrowser::OnAddNetworkLocation()
   {
     // verify the path by doing a GetDirectory.
     CFileItemList items;
-    if (CDirectory::GetDirectory(path, items, "", DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_ALLOW_PROMPT) || CGUIDialogYesNo::ShowAndGetInput(1001, 1002))
+    if (CDirectory::GetDirectory(path, items, "", DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_ALLOW_PROMPT) || CGUIDialogYesNo::ShowAndGetInput(CVariant{1001}, CVariant{1002}))
     { // add the network location to the shares list
       CMediaSource share;
       share.strPath = path; //setPath(path);

--- a/xbmc/dialogs/GUIDialogGamepad.cpp
+++ b/xbmc/dialogs/GUIDialogGamepad.cpp
@@ -26,6 +26,9 @@
 #include "GUIDialogOK.h"
 #include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
+#include "utils/Variant.h"
+
+#include <utility>
 
 CGUIDialogGamepad::CGUIDialogGamepad(void)
     : CGUIDialogBoxBase(WINDOW_DIALOG_GAMEPAD, "DialogGamepad.xml")
@@ -84,7 +87,7 @@ bool CGUIDialogGamepad::OnAction(const CAction &action)
     {
       strHiddenInput[i] = m_cHideInputChar;
     }
-    SetLine(2, strHiddenInput);
+    SetLine(2, CVariant{std::move(strHiddenInput)});
     return true;
   }
   else if (action.GetButtonCode() == KEY_BUTTON_BACK || action.GetID() == ACTION_PREVIOUS_MENU || action.GetID() == ACTION_NAV_BACK)
@@ -196,7 +199,7 @@ bool CGUIDialogGamepad::ShowAndVerifyNewPassword(std::string& strNewPassword)
   if (ShowAndVerifyInput(strUserInput, "12340", "12330", "12331", "", true, true))
   {
     // TODO: Show error to user saying the password entry was blank
-    CGUIDialogOK::ShowAndGetInput(12357, 12358); // Password is empty/blank
+    CGUIDialogOK::ShowAndGetInput(CVariant{12357}, CVariant{12358}); // Password is empty/blank
     return false;
   }
 
@@ -208,7 +211,7 @@ bool CGUIDialogGamepad::ShowAndVerifyNewPassword(std::string& strNewPassword)
   if (!ShowAndVerifyInput(strUserInput, "12341", "12330", "12331", "", false, true))
   {
     // TODO: Show error to user saying the password re-entry failed
-    CGUIDialogOK::ShowAndGetInput(12357, 12344); // Password do not match
+    CGUIDialogOK::ShowAndGetInput(CVariant{12357}, CVariant{12344}); // Password do not match
     return false;
   }
 
@@ -268,24 +271,24 @@ bool CGUIDialogGamepad::ShowAndVerifyInput(std::string& strToVerify, const std::
 
   // HACK: This won't work if the label specified is actually a positive numeric value, but that's very unlikely
   if (!StringUtils::IsNaturalNumber(dlgHeading))
-    pDialog->SetHeading( dlgHeading );
+    pDialog->SetHeading(CVariant{dlgHeading});
   else
-    pDialog->SetHeading( atoi(dlgHeading.c_str()) );
+    pDialog->SetHeading(CVariant{atoi(dlgHeading.c_str())});
 
   if (!StringUtils::IsNaturalNumber(dlgLine0))
-    pDialog->SetLine( 0, dlgLine0 );
+    pDialog->SetLine(0, CVariant{dlgLine0});
   else
-    pDialog->SetLine( 0, atoi(dlgLine0.c_str()) );
+    pDialog->SetLine(0, CVariant{atoi(dlgLine0.c_str())});
 
   if (!StringUtils::IsNaturalNumber(dlgLine1))
-    pDialog->SetLine( 1, dlgLine1 );
+    pDialog->SetLine(1, CVariant{dlgLine1});
   else
-    pDialog->SetLine( 1, atoi(dlgLine1.c_str()) );
+    pDialog->SetLine(1, CVariant{atoi(dlgLine1.c_str())});
 
   if (!StringUtils::IsNaturalNumber(dlgLine2))
-    pDialog->SetLine( 2, dlgLine2 );
+    pDialog->SetLine(2, CVariant{dlgLine2});
   else
-    pDialog->SetLine( 2, atoi(dlgLine2.c_str()) );
+    pDialog->SetLine(2, CVariant{atoi(dlgLine2.c_str())});
 
   g_audioManager.Enable(false); // dont do sounds during pwd input
   pDialog->DoModal();

--- a/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
+++ b/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
@@ -31,6 +31,7 @@
 #include "GUIDialogKeyboardGeneric.h"
 #include "settings/Settings.h"
 #include "utils/RegExp.h"
+#include "utils/Variant.h"
 #include "ApplicationMessenger.h"
 #include "windowing/WindowingFactory.h"
 

--- a/xbmc/dialogs/GUIDialogMediaFilter.cpp
+++ b/xbmc/dialogs/GUIDialogMediaFilter.cpp
@@ -34,6 +34,7 @@
 #include "utils/log.h"
 #include "utils/SortUtils.h"
 #include "utils/StringUtils.h"
+#include "utils/Variant.h"
 #include "video/VideoDatabase.h"
 #include "video/VideoDbUrl.h"
 

--- a/xbmc/dialogs/GUIDialogMediaSource.cpp
+++ b/xbmc/dialogs/GUIDialogMediaSource.cpp
@@ -1,3 +1,4 @@
+
 /*
  *      Copyright (C) 2005-2013 Team XBMC
  *      http://xbmc.org
@@ -27,6 +28,7 @@
 #include "Util.h"
 #include "utils/URIUtils.h"
 #include "utils/StringUtils.h"
+#include "utils/Variant.h"
 #include "filesystem/Directory.h"
 #include "filesystem/PVRDirectory.h"
 #include "GUIDialogYesNo.h"
@@ -360,7 +362,7 @@ void CGUIDialogMediaSource::OnPath(int item)
     m_bNameChanged=true;
 
   std::string path(m_paths->Get(item)->GetPath());
-  CGUIKeyboardFactory::ShowAndGetInput(path, g_localizeStrings.Get(1021), false);
+  CGUIKeyboardFactory::ShowAndGetInput(path, CVariant{g_localizeStrings.Get(1021)}, false);
   m_paths->Get(item)->SetPath(path);
 
   if (!m_bNameChanged || m_name.empty())
@@ -384,7 +386,7 @@ void CGUIDialogMediaSource::OnOK()
   VECSOURCES *shares = CMediaSourceSettings::Get().GetSources(m_type);
   if (shares)
     shares->push_back(share);
-  if (StringUtils::StartsWithNoCase(share.strPath, "plugin://") || CDirectory::GetDirectory(share.strPath, items, "", DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_ALLOW_PROMPT) || CGUIDialogYesNo::ShowAndGetInput(1001, 1025))
+  if (StringUtils::StartsWithNoCase(share.strPath, "plugin://") || CDirectory::GetDirectory(share.strPath, items, "", DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_ALLOW_PROMPT) || CGUIDialogYesNo::ShowAndGetInput(CVariant{1001}, CVariant{1025}))
   {
     m_confirmed = true;
     Close();

--- a/xbmc/dialogs/GUIDialogNumeric.cpp
+++ b/xbmc/dialogs/GUIDialogNumeric.cpp
@@ -25,6 +25,7 @@
 #include "GUIDialogOK.h"
 #include "input/XBMC_vkeys.h"
 #include "utils/StringUtils.h"
+#include "utils/Variant.h"
 #include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
 #include "interfaces/AnnouncementManager.h"
@@ -733,7 +734,7 @@ bool CGUIDialogNumeric::ShowAndVerifyNewPassword(std::string& strNewPassword)
   if (!ShowAndVerifyInput(strUserInput, g_localizeStrings.Get(12340), false))
   {
     // Show error to user saying the password entry was blank
-    CGUIDialogOK::ShowAndGetInput(12357, 12358); // Password is empty/blank
+    CGUIDialogOK::ShowAndGetInput(CVariant{12357}, CVariant{12358}); // Password is empty/blank
     return false;
   }
 
@@ -745,7 +746,7 @@ bool CGUIDialogNumeric::ShowAndVerifyNewPassword(std::string& strNewPassword)
   if (!ShowAndVerifyInput(strUserInput, g_localizeStrings.Get(12341), true))
   {
     // Show error to user saying the password re-entry failed
-    CGUIDialogOK::ShowAndGetInput(12357, 12344); // Password do not match
+    CGUIDialogOK::ShowAndGetInput(CVariant{12357}, CVariant{12344}); // Password do not match
     return false;
   }
 

--- a/xbmc/dialogs/GUIDialogOK.cpp
+++ b/xbmc/dialogs/GUIDialogOK.cpp
@@ -49,7 +49,7 @@ bool CGUIDialogOK::OnMessage(CGUIMessage& message)
 }
 
 // \brief Show CGUIDialogOK dialog, then wait for user to dismiss it.
-void CGUIDialogOK::ShowAndGetInput(const CVariant &heading, const CVariant &text)
+void CGUIDialogOK::ShowAndGetInput(CVariant heading, CVariant text)
 {
   CGUIDialogOK *dialog = (CGUIDialogOK *)g_windowManager.GetWindow(WINDOW_DIALOG_OK);
   if (!dialog)
@@ -60,7 +60,7 @@ void CGUIDialogOK::ShowAndGetInput(const CVariant &heading, const CVariant &text
 }
 
 // \brief Show CGUIDialogOK dialog, then wait for user to dismiss it.
-void CGUIDialogOK::ShowAndGetInput(const CVariant &heading, const CVariant &line0, const CVariant &line1, const CVariant &line2)
+void CGUIDialogOK::ShowAndGetInput(CVariant heading, CVariant line0, CVariant line1, CVariant line2)
 {
   CGUIDialogOK *dialog = (CGUIDialogOK *)g_windowManager.GetWindow(WINDOW_DIALOG_OK);
   if (!dialog) 

--- a/xbmc/dialogs/GUIDialogOK.cpp
+++ b/xbmc/dialogs/GUIDialogOK.cpp
@@ -20,6 +20,8 @@
 
 #include "GUIDialogOK.h"
 #include "guilib/GUIWindowManager.h"
+#include "guilib/GUIMessage.h"
+#include "utils/Variant.h"
 
 #define ID_BUTTON_OK   10
 

--- a/xbmc/dialogs/GUIDialogOK.h
+++ b/xbmc/dialogs/GUIDialogOK.h
@@ -32,8 +32,8 @@ public:
   CGUIDialogOK(void);
   virtual ~CGUIDialogOK(void);
   virtual bool OnMessage(CGUIMessage& message);
-  static void ShowAndGetInput(const CVariant &heading, const CVariant &text);
-  static void ShowAndGetInput(const CVariant &heading, const CVariant &line0, const CVariant &line1, const CVariant &line2);
+  static void ShowAndGetInput(CVariant heading, CVariant text);
+  static void ShowAndGetInput(CVariant heading, CVariant line0, CVariant line1, CVariant line2);
 protected:
   virtual int GetDefaultLabelID(int controlId) const;
 };

--- a/xbmc/dialogs/GUIDialogOK.h
+++ b/xbmc/dialogs/GUIDialogOK.h
@@ -22,6 +22,9 @@
 
 #include "GUIDialogBoxBase.h"
 
+class CGUIMessage;
+class CVariant;
+
 class CGUIDialogOK :
       public CGUIDialogBoxBase
 {

--- a/xbmc/dialogs/GUIDialogPlayEject.cpp
+++ b/xbmc/dialogs/GUIDialogPlayEject.cpp
@@ -22,7 +22,10 @@
 #include "guilib/GUIWindowManager.h"
 #include "storage/MediaManager.h"
 #include "utils/log.h"
+#include "utils/Variant.h"
 #include "utils/XMLUtils.h"
+
+#include <utility>
 
 #define ID_BUTTON_PLAY      11
 #define ID_BUTTON_EJECT     10
@@ -116,10 +119,10 @@ bool CGUIDialogPlayEject::ShowAndGetInput(const CFileItem & item,
     strLine1 = item.GetLabel();
 
   // Setup dialog parameters
-  pDialog->SetHeading(219);
-  pDialog->SetLine(0, 429);
-  pDialog->SetLine(1, strLine1);
-  pDialog->SetLine(2, strLine2);
+  pDialog->SetHeading(CVariant{219});
+  pDialog->SetLine(0, CVariant{429});
+  pDialog->SetLine(1, CVariant{std::move(strLine1)});
+  pDialog->SetLine(2, CVariant{std::move(strLine2)});
   pDialog->SetChoice(ID_BUTTON_PLAY - 10, 208);
   pDialog->SetChoice(ID_BUTTON_EJECT - 10, 13391);
   if (uiAutoCloseTime)

--- a/xbmc/dialogs/GUIDialogProgress.cpp
+++ b/xbmc/dialogs/GUIDialogProgress.cpp
@@ -26,6 +26,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "threads/SingleLock.h"
 #include "utils/log.h"
+#include "utils/Variant.h"
 
 using namespace std;
 
@@ -123,7 +124,7 @@ bool CGUIDialogProgress::OnMessage(CGUIMessage& message)
         string strHeading = m_strHeading;
         strHeading.append(" : ");
         strHeading.append(g_localizeStrings.Get(16024));
-        CGUIDialogBoxBase::SetHeading(strHeading);
+        CGUIDialogBoxBase::SetHeading(CVariant{strHeading});
         m_bCanceled = true;
         return true;
       }

--- a/xbmc/dialogs/GUIDialogSimpleMenu.cpp
+++ b/xbmc/dialogs/GUIDialogSimpleMenu.cpp
@@ -30,6 +30,7 @@
 #include "utils/log.h"
 #include "video/VideoInfoTag.h"
 #include "URL.h"
+#include "utils/Variant.h"
 
 bool CGUIDialogSimpleMenu::ShowPlaySelection(CFileItem& item)
 {
@@ -98,7 +99,7 @@ bool CGUIDialogSimpleMenu::ShowPlaySelection(CFileItem& item, const std::string&
   while (true)
   {
     dialog->Reset();
-    dialog->SetHeading(25006 /* Select playback item */);
+    dialog->SetHeading(CVariant{25006}); // Select playback item
     dialog->SetItems(&items);
     dialog->SetUseDetails(true);
     dialog->DoModal();

--- a/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
@@ -24,6 +24,7 @@
 #include "utils/SortUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
+#include "utils/Variant.h"
 #include "GUIDialogSmartPlaylistRule.h"
 #include "guilib/GUIWindowManager.h"
 #include "filesystem/File.h"
@@ -32,6 +33,7 @@
 #include "FileItem.h"
 #include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
+
 
 using namespace std;
 
@@ -201,7 +203,7 @@ void CGUIDialogSmartPlaylistEditor::OnOK()
   {
     std::string filename(CUtil::MakeLegalFileName(m_playlist.m_playlistName));
     std::string path;
-    if (CGUIKeyboardFactory::ShowAndGetInput(filename, g_localizeStrings.Get(16013), false))
+    if (CGUIKeyboardFactory::ShowAndGetInput(filename, CVariant{g_localizeStrings.Get(16013)}, false))
     {
       path = URIUtils::AddFileToFolder(systemPlaylistsPath, m_playlist.GetSaveLocation());
       path = URIUtils::AddFileToFolder(path, CUtil::MakeLegalFileName(filename));

--- a/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
@@ -33,6 +33,9 @@
 #include "utils/LabelFormatter.h"
 #include "utils/StringUtils.h"
 #include "settings/Settings.h"
+#include "utils/Variant.h"
+
+#include <utility>
 
 #define CONTROL_FIELD           15
 #define CONTROL_OPERATOR        16
@@ -344,7 +347,7 @@ void CGUIDialogSmartPlaylistRule::OnBrowse()
   pDialog->Reset();
   pDialog->SetItems(&items);
   std::string strHeading = StringUtils::Format(g_localizeStrings.Get(13401).c_str(), g_localizeStrings.Get(iLabel).c_str());
-  pDialog->SetHeading(strHeading);
+  pDialog->SetHeading(CVariant{std::move(strHeading)});
   pDialog->SetMultiSelection(m_rule.m_field != FieldPlaylist && m_rule.m_field != FieldVirtualFolder);
 
   if (!m_rule.m_parameter.empty())

--- a/xbmc/dialogs/GUIDialogYesNo.cpp
+++ b/xbmc/dialogs/GUIDialogYesNo.cpp
@@ -72,18 +72,18 @@ bool CGUIDialogYesNo::OnBack(int actionID)
   return CGUIDialogBoxBase::OnBack(actionID);
 }
 
-bool CGUIDialogYesNo::ShowAndGetInput(const CVariant &heading, const CVariant &line0, const CVariant &line1, const CVariant &line2, bool &bCanceled)
+bool CGUIDialogYesNo::ShowAndGetInput(CVariant heading, CVariant line0, CVariant line1, CVariant line2, bool &bCanceled)
 {
   return ShowAndGetInput(heading, line0, line1, line2, bCanceled, "", "");
 }
 
-bool CGUIDialogYesNo::ShowAndGetInput(const CVariant &heading, const CVariant &line0, const CVariant &line1, const CVariant &line2, const CVariant &noLabel /* = "" */, const CVariant &yesLabel /* = "" */)
+bool CGUIDialogYesNo::ShowAndGetInput(CVariant heading, CVariant line0, CVariant line1, CVariant line2, CVariant noLabel /* = "" */, CVariant yesLabel /* = "" */)
 {
   bool bDummy;
   return ShowAndGetInput(heading, line0, line1, line2, bDummy, noLabel, yesLabel);
 }
 
-bool CGUIDialogYesNo::ShowAndGetInput(const CVariant &heading, const CVariant &line0, const CVariant &line1, const CVariant &line2, bool &bCanceled, const CVariant &noLabel, const CVariant &yesLabel, unsigned int autoCloseTime /* = 0 */)
+bool CGUIDialogYesNo::ShowAndGetInput(CVariant heading, CVariant line0, CVariant line1, CVariant line2, bool &bCanceled, CVariant noLabel, CVariant yesLabel, unsigned int autoCloseTime /* = 0 */)
 {
   CGUIDialogYesNo *dialog = (CGUIDialogYesNo *)g_windowManager.GetWindow(WINDOW_DIALOG_YES_NO);
   if (!dialog)
@@ -104,13 +104,13 @@ bool CGUIDialogYesNo::ShowAndGetInput(const CVariant &heading, const CVariant &l
   return (dialog->IsConfirmed()) ? true : false;
 }
 
-bool CGUIDialogYesNo::ShowAndGetInput(const CVariant &heading, const CVariant &text)
+bool CGUIDialogYesNo::ShowAndGetInput(CVariant heading, CVariant text)
 {
   bool bDummy;
   return ShowAndGetInput(heading, text, bDummy, "", "");
 }
 
-bool CGUIDialogYesNo::ShowAndGetInput(const CVariant &heading, const CVariant &text, bool &bCanceled, const CVariant &noLabel /* = "" */, const CVariant &yesLabel /* = "" */, unsigned int autoCloseTime /* = 0 */)
+bool CGUIDialogYesNo::ShowAndGetInput(CVariant heading, CVariant text, bool &bCanceled, CVariant noLabel /* = "" */, CVariant yesLabel /* = "" */, unsigned int autoCloseTime /* = 0 */)
 {
   CGUIDialogYesNo *dialog = (CGUIDialogYesNo *)g_windowManager.GetWindow(WINDOW_DIALOG_YES_NO);
   if (!dialog)

--- a/xbmc/dialogs/GUIDialogYesNo.h
+++ b/xbmc/dialogs/GUIDialogYesNo.h
@@ -22,6 +22,7 @@
 
 #include <string>
 #include "GUIDialogBoxBase.h"
+#include "utils/Variant.h"
 
 class CGUIDialogYesNo :
       public CGUIDialogBoxBase

--- a/xbmc/dialogs/GUIDialogYesNo.h
+++ b/xbmc/dialogs/GUIDialogYesNo.h
@@ -41,7 +41,7 @@ public:
    \param bCanceled Holds true if the dialog was canceled otherwise false
    \return true if user selects Yes, otherwise false if user selects No.
    */
-  static bool ShowAndGetInput(const CVariant &heading, const CVariant &line0, const CVariant &line1, const CVariant &line2, bool &bCanceled);
+  static bool ShowAndGetInput(CVariant heading, CVariant line0, CVariant line1, CVariant line2, bool &bCanceled);
 
   /*! \brief Show a yes-no dialog, then wait for user to dismiss it.
    \param heading Localized label id or string for the heading of the dialog
@@ -52,7 +52,7 @@ public:
    \param iYesLabel Localized label id or string for the yes button
    \return true if user selects Yes, otherwise false if user selects No.
    */
-  static bool ShowAndGetInput(const CVariant &heading, const CVariant &line0, const CVariant &line1, const CVariant &line2, const CVariant &noLabel = "", const CVariant &yesLabel = "");
+  static bool ShowAndGetInput(CVariant heading, CVariant line0, CVariant line1, CVariant line2, CVariant noLabel = "", CVariant yesLabel = "");
 
   /*! \brief Show a yes-no dialog, then wait for user to dismiss it.
    \param heading Localized label id or string for the heading of the dialog
@@ -65,14 +65,14 @@ public:
    \param autoCloseTime Time in ms before the dialog becomes automatically closed
    \return true if user selects Yes, otherwise false if user selects No.
    */
-  static bool ShowAndGetInput(const CVariant &heading, const CVariant &line0, const CVariant &line1, const CVariant &line2, bool &bCanceled, const CVariant &noLabel, const CVariant &yesLabel, unsigned int autoCloseTime = 0);
+  static bool ShowAndGetInput(CVariant heading, CVariant line0, CVariant line1, CVariant line2, bool &bCanceled, CVariant noLabel, CVariant yesLabel, unsigned int autoCloseTime = 0);
 
   /*! \brief Show a yes-no dialog, then wait for user to dismiss it.
    \param heading Localized label id or string for the heading of the dialog
    \param text Localized label id or string for the dialog message
    \return true if user selects Yes, otherwise false if user selects No.
    */
-  static bool ShowAndGetInput(const CVariant &heading, const CVariant &text);
+  static bool ShowAndGetInput(CVariant heading, CVariant text);
 
   /*! \brief Show a yes-no dialog, then wait for user to dismiss it.
    \param heading Localized label id or string for the heading of the dialog
@@ -83,7 +83,7 @@ public:
    \param autoCloseTime Time in ms before the dialog becomes automatically closed
    \return true if user selects Yes, otherwise false if user selects No.
    */
-  static bool ShowAndGetInput(const CVariant &heading, const CVariant &text, bool &bCanceled, const CVariant &noLabel = "", const CVariant &yesLabel = "", unsigned int autoCloseTime = 0);
+  static bool ShowAndGetInput(CVariant heading, CVariant text, bool &bCanceled, CVariant noLabel = "", CVariant yesLabel = "", unsigned int autoCloseTime = 0);
 
 protected:
   virtual int GetDefaultLabelID(int controlId) const;

--- a/xbmc/epg/EpgInfoTag.h
+++ b/xbmc/epg/EpgInfoTag.h
@@ -30,6 +30,7 @@
 
 #define EPG_DEBUGGING 0
 
+class CVariant;
 /** an EPG info tag */
 namespace EPG
 {

--- a/xbmc/filesystem/MultiPathDirectory.cpp
+++ b/xbmc/filesystem/MultiPathDirectory.cpp
@@ -28,6 +28,7 @@
 #include "FileItem.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
+#include "utils/Variant.h"
 #include "utils/URIUtils.h"
 
 using namespace std;
@@ -66,10 +67,10 @@ bool CMultiPathDirectory::GetDirectory(const CURL& url, CFileItemList &items)
       dlgProgress = (CGUIDialogProgress *)g_windowManager.GetWindow(WINDOW_DIALOG_PROGRESS);
       if (dlgProgress)
       {
-        dlgProgress->SetHeading(15310);
-        dlgProgress->SetLine(0, 15311);
-        dlgProgress->SetLine(1, "");
-        dlgProgress->SetLine(2, "");
+        dlgProgress->SetHeading(CVariant{15310});
+        dlgProgress->SetLine(0, CVariant{15311});
+        dlgProgress->SetLine(1, CVariant{""});
+        dlgProgress->SetLine(2, CVariant{""});
         dlgProgress->StartModal();
         dlgProgress->ShowProgressBar(true);
         dlgProgress->SetProgressMax((int)vecPaths.size()*2);
@@ -79,7 +80,7 @@ bool CMultiPathDirectory::GetDirectory(const CURL& url, CFileItemList &items)
     if (dlgProgress)
     {
       CURL url(vecPaths[i]);
-      dlgProgress->SetLine(1, url.GetWithoutUserDetails());
+      dlgProgress->SetLine(1, CVariant{url.GetWithoutUserDetails()});
       dlgProgress->SetProgressAdvance();
       dlgProgress->Progress();
     }

--- a/xbmc/filesystem/PluginDirectory.cpp
+++ b/xbmc/filesystem/PluginDirectory.cpp
@@ -498,10 +498,10 @@ bool CPluginDirectory::WaitOnScriptResult(const std::string &scriptPath, int scr
 
       if (progressBar)
       {
-        progressBar->SetHeading(scriptName);
-        progressBar->SetLine(0, 10214);
-        progressBar->SetLine(1, "");
-        progressBar->SetLine(2, "");
+        progressBar->SetHeading(CVariant{scriptName});
+        progressBar->SetLine(0, CVariant{10214});
+        progressBar->SetLine(1, CVariant{""});
+        progressBar->SetLine(2, CVariant{""});
         progressBar->ShowProgressBar(false);
         progressBar->StartModal();
       }

--- a/xbmc/filesystem/RarManager.cpp
+++ b/xbmc/filesystem/RarManager.cpp
@@ -36,6 +36,7 @@
 #include "dialogs/GUIDialogProgress.h"
 #include "guilib/GUIWindowManager.h"
 #include "utils/StringUtils.h"
+#include "utils/Variant.h"
 
 #include <set>
 
@@ -97,7 +98,7 @@ public:
       {
         if (!shown)
         {
-          dlg->SetHeading(heading);
+          dlg->SetHeading(CVariant{heading});
           dlg->StartModal();
         }
         if (progress >= 0)
@@ -106,7 +107,7 @@ public:
           dlg->SetPercentage(progress);
         }
         if (text)
-          dlg->SetLine(1, text);
+          dlg->SetLine(1, CVariant{text});
         cont = !dlg->IsCanceled();
         shown = true;
         // tell render loop to spin
@@ -170,10 +171,10 @@ bool CRarManager::CacheRarredFile(std::string& strPathInCache, const std::string
     CGUIDialogYesNo* pDialog = (CGUIDialogYesNo*)g_windowManager.GetWindow(WINDOW_DIALOG_YES_NO);
     if (pDialog)
     {
-      pDialog->SetHeading(120);
-      pDialog->SetLine(0, 645);
-      pDialog->SetLine(1, URIUtils::GetFileName(strPathInRar));
-      pDialog->SetLine(2, "");
+      pDialog->SetHeading(CVariant{120});
+      pDialog->SetLine(0, CVariant{645});
+      pDialog->SetLine(1, CVariant{URIUtils::GetFileName(strPathInRar)});
+      pDialog->SetLine(2, CVariant{""});
       pDialog->DoModal();
       if (!pDialog->IsConfirmed())
         iRes = 2; // pretend to be canceled

--- a/xbmc/guilib/GUIEditControl.cpp
+++ b/xbmc/guilib/GUIEditControl.cpp
@@ -21,6 +21,7 @@
 #include "GUIEditControl.h"
 #include "GUIWindowManager.h"
 #include "utils/CharsetConverter.h"
+#include "utils/Variant.h"
 #include "GUIKeyboardFactory.h"
 #include "dialogs/GUIDialogNumeric.h"
 #include "input/XBMC_vkeys.h"
@@ -363,7 +364,7 @@ void CGUIEditControl::OnClick()
       // fallthrough
     case INPUT_TYPE_TEXT:
     default:
-      textChanged = CGUIKeyboardFactory::ShowAndGetInput(utf8, heading, true, m_inputType == INPUT_TYPE_PASSWORD || m_inputType == INPUT_TYPE_PASSWORD_MD5);
+      textChanged = CGUIKeyboardFactory::ShowAndGetInput(utf8, CVariant{heading}, true, m_inputType == INPUT_TYPE_PASSWORD || m_inputType == INPUT_TYPE_PASSWORD_MD5);
       break;
   }
   if (textChanged)

--- a/xbmc/guilib/GUIKeyboardFactory.cpp
+++ b/xbmc/guilib/GUIKeyboardFactory.cpp
@@ -28,6 +28,7 @@
 #include "settings/Settings.h"
 #include "utils/md5.h"
 #include "utils/StringUtils.h"
+#include "utils/Variant.h"
 
 #include "dialogs/GUIDialogKeyboardGeneric.h"
 #if defined(TARGET_DARWIN_IOS)
@@ -125,7 +126,7 @@ bool CGUIKeyboardFactory::ShowAndGetInput(std::string& aTextString, const CVaria
 
 bool CGUIKeyboardFactory::ShowAndGetInput(std::string& aTextString, bool allowEmptyResult, unsigned int autoCloseMs /* = 0 */)
 {
-  return ShowAndGetInput(aTextString, "", allowEmptyResult, false, autoCloseMs);
+  return ShowAndGetInput(aTextString, CVariant{""}, allowEmptyResult, false, autoCloseMs);
 }
 
 // Shows keyboard and prompts for a password.
@@ -177,7 +178,7 @@ bool CGUIKeyboardFactory::ShowAndVerifyNewPassword(std::string& newPassword, con
     StringUtils::ToLower(newPassword);
     return true;
   }
-  CGUIDialogOK::ShowAndGetInput(12341, 12344);
+  CGUIDialogOK::ShowAndGetInput(CVariant{12341}, CVariant{12344});
   return false;
 }
 

--- a/xbmc/guilib/GUIKeyboardFactory.cpp
+++ b/xbmc/guilib/GUIKeyboardFactory.cpp
@@ -82,7 +82,7 @@ bool CGUIKeyboardFactory::SendTextToActiveKeyboard(const std::string &aTextStrin
 // Show keyboard with initial value (aTextString) and replace with result string.
 // Returns: true  - successful display and input (empty result may return true or false depending on parameter)
 //          false - unsuccessful display of the keyboard or cancelled editing
-bool CGUIKeyboardFactory::ShowAndGetInput(std::string& aTextString, const CVariant &heading, bool allowEmptyResult, bool hiddenInput /* = false */, unsigned int autoCloseMs /* = 0 */)
+bool CGUIKeyboardFactory::ShowAndGetInput(std::string& aTextString, CVariant heading, bool allowEmptyResult, bool hiddenInput /* = false */, unsigned int autoCloseMs /* = 0 */)
 {
   bool confirmed = false;
   CGUIKeyboard *kb = NULL;
@@ -131,7 +131,7 @@ bool CGUIKeyboardFactory::ShowAndGetInput(std::string& aTextString, bool allowEm
 
 // Shows keyboard and prompts for a password.
 // Differs from ShowAndVerifyNewPassword() in that no second verification is necessary.
-bool CGUIKeyboardFactory::ShowAndGetNewPassword(std::string& newPassword, const CVariant &heading, bool allowEmpty, unsigned int autoCloseMs /* = 0 */)
+bool CGUIKeyboardFactory::ShowAndGetNewPassword(std::string& newPassword, CVariant heading, bool allowEmpty, unsigned int autoCloseMs /* = 0 */)
 {
   return ShowAndGetInput(newPassword, heading, allowEmpty, true, autoCloseMs);
 }
@@ -157,7 +157,7 @@ bool CGUIKeyboardFactory::ShowAndGetFilter(std::string &filter, bool searching, 
 // \param heading Heading to display
 // \param allowEmpty Whether a blank password is valid or not.
 // \return true if successful display and user input entry/re-entry. false if unsuccessful display, no user input, or canceled editing.
-bool CGUIKeyboardFactory::ShowAndVerifyNewPassword(std::string& newPassword, const CVariant &heading, bool allowEmpty, unsigned int autoCloseMs /* = 0 */)
+bool CGUIKeyboardFactory::ShowAndVerifyNewPassword(std::string& newPassword, CVariant heading, bool allowEmpty, unsigned int autoCloseMs /* = 0 */)
 {
   // Prompt user for password input
   std::string userInput;

--- a/xbmc/guilib/GUIKeyboardFactory.h
+++ b/xbmc/guilib/GUIKeyboardFactory.h
@@ -20,9 +20,10 @@
  *
  */
 
-#include "utils/Variant.h"
 #include "GUIKeyboard.h"
 #include <string>
+
+class CVariant;
 
 class CGUIKeyboardFactory
 {

--- a/xbmc/guilib/GUIKeyboardFactory.h
+++ b/xbmc/guilib/GUIKeyboardFactory.h
@@ -33,11 +33,11 @@ class CGUIKeyboardFactory
     virtual ~CGUIKeyboardFactory(void);
 
     static bool ShowAndGetInput(std::string& aTextString, bool allowEmptyResult, unsigned int autoCloseMs = 0);
-    static bool ShowAndGetInput(std::string& aTextString, const CVariant &heading, bool allowEmptyResult, bool hiddenInput = false, unsigned int autoCloseMs = 0);
+    static bool ShowAndGetInput(std::string& aTextString, CVariant heading, bool allowEmptyResult, bool hiddenInput = false, unsigned int autoCloseMs = 0);
     static bool ShowAndGetNewPassword(std::string& strNewPassword, unsigned int autoCloseMs = 0);
-    static bool ShowAndGetNewPassword(std::string& newPassword, const CVariant &heading, bool allowEmpty, unsigned int autoCloseMs = 0);
+    static bool ShowAndGetNewPassword(std::string& newPassword, CVariant heading, bool allowEmpty, unsigned int autoCloseMs = 0);
     static bool ShowAndVerifyNewPassword(std::string& strNewPassword, unsigned int autoCloseMs = 0);
-    static bool ShowAndVerifyNewPassword(std::string& newPassword, const CVariant &heading, bool allowEmpty, unsigned int autoCloseMs = 0);
+    static bool ShowAndVerifyNewPassword(std::string& newPassword, CVariant heading, bool allowEmpty, unsigned int autoCloseMs = 0);
     static int  ShowAndVerifyPassword(std::string& strPassword, const std::string& strHeading, int iRetries, unsigned int autoCloseMs = 0);
     static bool ShowAndGetFilter(std::string& aTextString, bool searching, unsigned int autoCloseMs = 0);
 

--- a/xbmc/guilib/StereoscopicsManager.cpp
+++ b/xbmc/guilib/StereoscopicsManager.cpp
@@ -42,6 +42,7 @@
 #include "utils/log.h"
 #include "utils/RegExp.h"
 #include "utils/StringUtils.h"
+#include "utils/Variant.h"
 #include "windowing/WindowingFactory.h"
 #include "guiinfo/GUIInfoLabels.h"
 
@@ -213,9 +214,9 @@ RENDER_STEREO_MODE CStereoscopicsManager::GetStereoModeByUserChoice(const std::s
   CGUIDialogSelect* pDlgSelect = (CGUIDialogSelect*)g_windowManager.GetWindow(WINDOW_DIALOG_SELECT);
   pDlgSelect->Reset();
   if (heading.empty())
-    pDlgSelect->SetHeading(g_localizeStrings.Get(36528).c_str());
+    pDlgSelect->SetHeading(CVariant{g_localizeStrings.Get(36528)});
   else
-    pDlgSelect->SetHeading(heading.c_str());
+    pDlgSelect->SetHeading(CVariant{heading});
 
   // prepare selectable stereo modes
   std::vector<RENDER_STEREO_MODE> selectableModes;
@@ -552,7 +553,7 @@ void CStereoscopicsManager::OnPlaybackStarted(void)
 
       CGUIDialogSelect* pDlgSelect = (CGUIDialogSelect*)g_windowManager.GetWindow(WINDOW_DIALOG_SELECT);
       pDlgSelect->Reset();
-      pDlgSelect->SetHeading(g_localizeStrings.Get(36527).c_str());
+      pDlgSelect->SetHeading(CVariant{g_localizeStrings.Get(36527)});
 
       int idx_playing   = -1;
 

--- a/xbmc/interfaces/AnnouncementManager.h
+++ b/xbmc/interfaces/AnnouncementManager.h
@@ -25,6 +25,8 @@
 #include "threads/CriticalSection.h"
 #include "utils/GlobalsHandling.h"
 
+class CVariant;
+
 namespace ANNOUNCEMENT
 {
   class CAnnouncementManager

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -64,6 +64,7 @@
 #include "settings/SkinSettings.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
+#include "utils/Variant.h"
 #include "video/VideoLibraryQueue.h"
 #include "Util.h"
 #include "URL.h"
@@ -1346,7 +1347,7 @@ int CBuiltins::Execute(const std::string& execString)
     g_mediaManager.GetLocalDrives(localShares);
     if (execute == "skin.setstring")
     {
-      if (CGUIKeyboardFactory::ShowAndGetInput(value, g_localizeStrings.Get(1029), true))
+      if (CGUIKeyboardFactory::ShowAndGetInput(value, CVariant{g_localizeStrings.Get(1029)}, true))
         CSkinSettings::Get().SetString(string, value);
     }
     else if (execute == "skin.setnumeric")
@@ -1581,7 +1582,7 @@ int CBuiltins::Execute(const std::string& execString)
     if (params.size() > 1)
       singleFile = StringUtils::EqualsNoCase(params[1], "true");
     else
-      singleFile = CGUIDialogYesNo::ShowAndGetInput(iHeading, 20426, cancelled, 20428, 20429);
+      singleFile = CGUIDialogYesNo::ShowAndGetInput(CVariant{iHeading}, CVariant{20426}, cancelled, CVariant{20428}, CVariant{20429});
 
     if (cancelled)
         return -1;
@@ -1591,7 +1592,7 @@ int CBuiltins::Execute(const std::string& execString)
       if (params.size() > 2)
         thumbs = StringUtils::EqualsNoCase(params[2], "true");
       else
-        thumbs = CGUIDialogYesNo::ShowAndGetInput(iHeading, 20430, cancelled);
+        thumbs = CGUIDialogYesNo::ShowAndGetInput(CVariant{iHeading}, CVariant{20430}, cancelled);
     }
 
     if (cancelled)
@@ -1602,7 +1603,7 @@ int CBuiltins::Execute(const std::string& execString)
       if (params.size() > 4)
         actorThumbs = StringUtils::EqualsNoCase(params[4], "true");
       else
-        actorThumbs = CGUIDialogYesNo::ShowAndGetInput(iHeading, 20436, cancelled);
+        actorThumbs = CGUIDialogYesNo::ShowAndGetInput(CVariant{iHeading}, CVariant{20436}, cancelled);
     }
 
     if (cancelled)
@@ -1613,7 +1614,7 @@ int CBuiltins::Execute(const std::string& execString)
       if (params.size() > 3)
         overwrite = StringUtils::EqualsNoCase(params[3], "true");
       else
-        overwrite = CGUIDialogYesNo::ShowAndGetInput(iHeading, 20431, cancelled);
+        overwrite = CGUIDialogYesNo::ShowAndGetInput(CVariant{iHeading}, CVariant{20431}, cancelled);
     }
 
     if (cancelled)

--- a/xbmc/interfaces/json-rpc/AddonsOperations.cpp
+++ b/xbmc/interfaces/json-rpc/AddonsOperations.cpp
@@ -27,6 +27,7 @@
 #include "TextureCache.h"
 #include "filesystem/File.h"
 #include "utils/StringUtils.h"
+#include "utils/Variant.h"
 
 using namespace std;
 using namespace JSONRPC;

--- a/xbmc/interfaces/json-rpc/AddonsOperations.h
+++ b/xbmc/interfaces/json-rpc/AddonsOperations.h
@@ -23,6 +23,7 @@
 #include "addons/IAddon.h"
 
 class CAddonDatabase;
+class CVariant;
 
 namespace JSONRPC
 {

--- a/xbmc/interfaces/json-rpc/ApplicationOperations.cpp
+++ b/xbmc/interfaces/json-rpc/ApplicationOperations.cpp
@@ -25,6 +25,7 @@
 #include "system.h"
 #include "CompileInfo.h"
 #include "utils/StringUtils.h"
+#include "utils/Variant.h"
 #include <string.h>
 
 using namespace JSONRPC;

--- a/xbmc/interfaces/json-rpc/ApplicationOperations.h
+++ b/xbmc/interfaces/json-rpc/ApplicationOperations.h
@@ -22,6 +22,8 @@
 #include "JSONRPC.h"
 #include "FileItemHandler.h"
 
+class CVariant;
+
 namespace JSONRPC
 {
   class CApplicationOperations : CFileItemHandler

--- a/xbmc/interfaces/json-rpc/AudioLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/AudioLibrary.cpp
@@ -25,6 +25,7 @@
 #include "utils/SortUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
+#include "utils/Variant.h"
 #include "music/tags/MusicInfoTag.h"
 #include "music/Artist.h"
 #include "music/Album.h"

--- a/xbmc/interfaces/json-rpc/AudioLibrary.h
+++ b/xbmc/interfaces/json-rpc/AudioLibrary.h
@@ -25,6 +25,7 @@
 #include "FileItemHandler.h"
 
 class CMusicDatabase;
+class CVariant;
 
 namespace JSONRPC
 {

--- a/xbmc/interfaces/json-rpc/FavouritesOperations.cpp
+++ b/xbmc/interfaces/json-rpc/FavouritesOperations.cpp
@@ -24,6 +24,7 @@
 #include "utils/StringUtils.h"
 #include "Util.h"
 #include "utils/URIUtils.h"
+#include "utils/Variant.h"
 #include "guilib/WindowIDs.h"
 #include <vector>
 

--- a/xbmc/interfaces/json-rpc/FavouritesOperations.h
+++ b/xbmc/interfaces/json-rpc/FavouritesOperations.h
@@ -21,6 +21,8 @@
 
 #include "JSONRPC.h"
 
+class CVariant;
+
 namespace JSONRPC
 {
   class CFavouritesOperations : public CJSONUtils

--- a/xbmc/interfaces/json-rpc/FileItemHandler.h
+++ b/xbmc/interfaces/json-rpc/FileItemHandler.h
@@ -26,6 +26,7 @@
 #include "FileItem.h"
 
 class CThumbLoader;
+class CVariant;
 
 namespace JSONRPC
 {

--- a/xbmc/interfaces/json-rpc/FileOperations.cpp
+++ b/xbmc/interfaces/json-rpc/FileOperations.cpp
@@ -31,6 +31,7 @@
 #include "URL.h"
 #include "utils/URIUtils.h"
 #include "utils/FileUtils.h"
+#include "utils/Variant.h"
 
 using namespace XFILE;
 using namespace JSONRPC;

--- a/xbmc/interfaces/json-rpc/FileOperations.h
+++ b/xbmc/interfaces/json-rpc/FileOperations.h
@@ -22,6 +22,8 @@
 #include "JSONRPC.h"
 #include "FileItemHandler.h"
 
+class CVariant;
+
 namespace JSONRPC
 {
   class CFileOperations : public CFileItemHandler

--- a/xbmc/interfaces/json-rpc/GUIOperations.h
+++ b/xbmc/interfaces/json-rpc/GUIOperations.h
@@ -21,6 +21,8 @@
 
 #include "JSONRPC.h"
 
+class CVariant;
+
 namespace JSONRPC
 {
   class CGUIOperations

--- a/xbmc/interfaces/json-rpc/IJSONRPCAnnouncer.h
+++ b/xbmc/interfaces/json-rpc/IJSONRPCAnnouncer.h
@@ -21,6 +21,7 @@
 
 #include "interfaces/IAnnouncer.h"
 #include "utils/JSONVariantWriter.h"
+#include "utils/Variant.h"
 
 namespace JSONRPC
 {

--- a/xbmc/interfaces/json-rpc/InputOperations.cpp
+++ b/xbmc/interfaces/json-rpc/InputOperations.cpp
@@ -24,6 +24,7 @@
 #include "guilib/GUIAudioManager.h"
 #include "guilib/GUIWindow.h"
 #include "input/ButtonTranslator.h"
+#include "utils/Variant.h"
 
 using namespace JSONRPC;
 

--- a/xbmc/interfaces/json-rpc/InputOperations.h
+++ b/xbmc/interfaces/json-rpc/InputOperations.h
@@ -21,6 +21,8 @@
 
 #include "JSONRPC.h"
 
+class CVariant;
+
 namespace JSONRPC
 {
   class CInputOperations

--- a/xbmc/interfaces/json-rpc/JSONRPC.h
+++ b/xbmc/interfaces/json-rpc/JSONRPC.h
@@ -27,6 +27,8 @@
 #include "JSONRPCUtils.h"
 #include "JSONServiceDescription.h"
 
+class CVariant;
+
 namespace JSONRPC
 {
   /*!

--- a/xbmc/interfaces/json-rpc/JSONRPCUtils.h
+++ b/xbmc/interfaces/json-rpc/JSONRPCUtils.h
@@ -24,7 +24,8 @@
 #include "FileItem.h"
 #include "GUIUserMessages.h"
 #include "guilib/GUIWindowManager.h"
-#include "utils/Variant.h"
+
+class CVariant;
 
 namespace JSONRPC
 {

--- a/xbmc/interfaces/json-rpc/JSONServiceDescription.h
+++ b/xbmc/interfaces/json-rpc/JSONServiceDescription.h
@@ -25,6 +25,7 @@
 #include <memory>
 
 #include "JSONUtils.h"
+#include "utils/Variant.h"
 
 namespace JSONRPC
 {

--- a/xbmc/interfaces/json-rpc/JSONUtils.h
+++ b/xbmc/interfaces/json-rpc/JSONUtils.h
@@ -29,6 +29,7 @@
 #include "utils/JSONVariantWriter.h"
 #include "utils/JSONVariantParser.h"
 #include "utils/StringUtils.h"
+#include "utils/Variant.h"
 
 namespace JSONRPC
 {

--- a/xbmc/interfaces/json-rpc/PVROperations.cpp
+++ b/xbmc/interfaces/json-rpc/PVROperations.cpp
@@ -27,6 +27,7 @@
 #include "pvr/recordings/PVRRecordings.h"
 #include "epg/Epg.h"
 #include "epg/EpgContainer.h"
+#include "utils/Variant.h"
 
 using namespace std;
 using namespace JSONRPC;

--- a/xbmc/interfaces/json-rpc/PVROperations.h
+++ b/xbmc/interfaces/json-rpc/PVROperations.h
@@ -22,6 +22,8 @@
 #include "FileItemHandler.h"
 #include "pvr/channels/PVRChannelGroup.h"
 
+class CVariant;
+
 namespace JSONRPC
 {
   class CPVROperations : public CFileItemHandler

--- a/xbmc/interfaces/json-rpc/PlayerOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlayerOperations.cpp
@@ -43,6 +43,7 @@
 #include "cores/playercorefactory/PlayerCoreConfig.h"
 #include "cores/playercorefactory/PlayerCoreFactory.h"
 #include "utils/SeekHandler.h"
+#include "utils/Variant.h"
 
 using namespace JSONRPC;
 using namespace PLAYLIST;

--- a/xbmc/interfaces/json-rpc/PlayerOperations.h
+++ b/xbmc/interfaces/json-rpc/PlayerOperations.h
@@ -22,6 +22,8 @@
 #include "JSONRPC.h"
 #include "FileItemHandler.h"
 
+class CVariant;
+
 namespace EPG
 {
   class CEpgInfoTag;

--- a/xbmc/interfaces/json-rpc/PlaylistOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlaylistOperations.cpp
@@ -26,6 +26,7 @@
 #include "ApplicationMessenger.h"
 #include "pictures/GUIWindowSlideShow.h"
 #include "pictures/PictureInfoTag.h"
+#include "utils/Variant.h"
 
 using namespace JSONRPC;
 using namespace PLAYLIST;

--- a/xbmc/interfaces/json-rpc/PlaylistOperations.h
+++ b/xbmc/interfaces/json-rpc/PlaylistOperations.h
@@ -22,6 +22,8 @@
 #include "FileItemHandler.h"
 #include "FileItem.h"
 
+class CVariant;
+
 namespace JSONRPC
 {
   class CPlaylistOperations : public CFileItemHandler

--- a/xbmc/interfaces/json-rpc/ProfilesOperations.cpp
+++ b/xbmc/interfaces/json-rpc/ProfilesOperations.cpp
@@ -22,6 +22,7 @@
 #include "ApplicationMessenger.h"
 #include "profiles/ProfilesManager.h"
 #include "utils/md5.h"
+#include "utils/Variant.h"
 
 using namespace JSONRPC;
 

--- a/xbmc/interfaces/json-rpc/ProfilesOperations.h
+++ b/xbmc/interfaces/json-rpc/ProfilesOperations.h
@@ -22,6 +22,8 @@
 #include "JSONRPC.h"
 #include "FileItemHandler.h"
 
+class CVariant;
+
 namespace JSONRPC
 {
   class CProfilesOperations : CFileItemHandler

--- a/xbmc/interfaces/json-rpc/SettingsOperations.cpp
+++ b/xbmc/interfaces/json-rpc/SettingsOperations.cpp
@@ -29,6 +29,7 @@
 #include "settings/lib/SettingSection.h"
 #include "guilib/LocalizeStrings.h"
 #include "utils/StringUtils.h"
+#include "utils/Variant.h"
 
 using namespace std;
 using namespace JSONRPC;

--- a/xbmc/interfaces/json-rpc/SettingsOperations.h
+++ b/xbmc/interfaces/json-rpc/SettingsOperations.h
@@ -21,6 +21,7 @@
 
 #include "JSONRPC.h"
 
+class CVariant;
 class ISetting;
 class CSettingSection;
 class CSettingCategory;

--- a/xbmc/interfaces/json-rpc/SystemOperations.h
+++ b/xbmc/interfaces/json-rpc/SystemOperations.h
@@ -21,6 +21,8 @@
 
 #include "JSONRPC.h"
 
+class CVariant;
+
 namespace JSONRPC
 {
   class CSystemOperations

--- a/xbmc/interfaces/json-rpc/TextureOperations.cpp
+++ b/xbmc/interfaces/json-rpc/TextureOperations.cpp
@@ -21,6 +21,7 @@
 #include "TextureOperations.h"
 #include "TextureDatabase.h"
 #include "TextureCache.h"
+#include "utils/Variant.h"
 
 using namespace JSONRPC;
 

--- a/xbmc/interfaces/json-rpc/TextureOperations.h
+++ b/xbmc/interfaces/json-rpc/TextureOperations.h
@@ -21,6 +21,8 @@
 
 #include "JSONRPC.h"
 
+class CVariant;
+
 namespace JSONRPC
 {
   class CTextureOperations

--- a/xbmc/interfaces/json-rpc/VideoLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/VideoLibrary.cpp
@@ -25,6 +25,7 @@
 #include "utils/SortUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
+#include "utils/Variant.h"
 #include "video/VideoDatabase.h"
 
 using namespace JSONRPC;

--- a/xbmc/interfaces/json-rpc/VideoLibrary.h
+++ b/xbmc/interfaces/json-rpc/VideoLibrary.h
@@ -24,6 +24,7 @@
 #include "FileItemHandler.h"
 
 class CVideoDatabase;
+class CVariant;
 
 namespace JSONRPC
 {

--- a/xbmc/interfaces/json-rpc/XBMCOperations.h
+++ b/xbmc/interfaces/json-rpc/XBMCOperations.h
@@ -21,6 +21,8 @@
 
 #include "JSONRPC.h"
 
+class CVariant;
+
 namespace JSONRPC
 {
   class CXBMCOperations

--- a/xbmc/interfaces/legacy/Dialog.cpp
+++ b/xbmc/interfaces/legacy/Dialog.cpp
@@ -30,6 +30,7 @@
 #include "ModuleXbmcgui.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "utils/StringUtils.h"
+#include "utils/Variant.h"
 #include "WindowException.h"
 #include "ApplicationMessenger.h"
 #include "Dialog.h"
@@ -63,18 +64,18 @@ namespace XBMCAddon
 
       // get lines, last 4 lines are optional.
       if (!heading.empty())
-        pDialog->SetHeading(heading);
+        pDialog->SetHeading(CVariant{heading});
       if (!line1.empty())
-        pDialog->SetLine(0, line1);
+        pDialog->SetLine(0, CVariant{line1});
       if (!line2.empty())
-        pDialog->SetLine(1, line2);
+        pDialog->SetLine(1, CVariant{line2});
       if (!line3.empty())
-        pDialog->SetLine(2, line3);
+        pDialog->SetLine(2, CVariant{line3});
 
       if (!nolabel.empty())
-        pDialog->SetChoice(0,nolabel);
+        pDialog->SetChoice(0, CVariant{nolabel});
       if (!yeslabel.empty())
-        pDialog->SetChoice(1,yeslabel);
+        pDialog->SetChoice(1, CVariant{yeslabel});
 
       if (autoclose > 0)
         pDialog->SetAutoClose(autoclose);
@@ -95,7 +96,7 @@ namespace XBMCAddon
 
       pDialog->Reset();
       if (!heading.empty())
-        pDialog->SetHeading(heading);
+        pDialog->SetHeading(CVariant{heading});
 
       String listLine;
       for(unsigned int i = 0; i < list.size(); i++)
@@ -124,13 +125,13 @@ namespace XBMCAddon
         throw WindowException("Error: Window is NULL, this is not possible :-)");
 
       if (!heading.empty())
-        pDialog->SetHeading(heading);
+        pDialog->SetHeading(CVariant{heading});
       if (!line1.empty())
-        pDialog->SetLine(0, line1);
+        pDialog->SetLine(0, CVariant{line1});
       if (!line2.empty())
-        pDialog->SetLine(1, line2);
+        pDialog->SetLine(1, CVariant{line2});
       if (!line3.empty())
-        pDialog->SetLine(2, line3);
+        pDialog->SetLine(2, CVariant{line3});
 
       //send message and wait for user input
       XBMCWaitForThreadMessage(TMSG_DIALOG_DOMODAL, window, ACTIVE_WINDOW);
@@ -286,7 +287,7 @@ namespace XBMCAddon
         case INPUT_ALPHANUM:
           {
             bool bHiddenInput = (option & ALPHANUM_HIDE_INPUT) == ALPHANUM_HIDE_INPUT;
-            if (!CGUIKeyboardFactory::ShowAndGetInput(value, heading, true, bHiddenInput, autoclose))
+            if (!CGUIKeyboardFactory::ShowAndGetInput(value, CVariant{heading}, true, bHiddenInput, autoclose))
               value = emptyString;
           }
           break;
@@ -378,14 +379,14 @@ namespace XBMCAddon
       dlg = pDialog;
       open = true;
 
-      pDialog->SetHeading(heading);
+      pDialog->SetHeading(CVariant{heading});
 
       if (!line1.empty())
-        pDialog->SetLine(0, line1);
+        pDialog->SetLine(0, CVariant{line1});
       if (!line2.empty())
-        pDialog->SetLine(1, line2);
+        pDialog->SetLine(1, CVariant{line2});
       if (!line3.empty())
-        pDialog->SetLine(2, line3);
+        pDialog->SetLine(2, CVariant{line3});
 
       pDialog->StartModal();
     }
@@ -411,11 +412,11 @@ namespace XBMCAddon
       }
 
       if (!line1.empty())
-        pDialog->SetLine(0, line1);
+        pDialog->SetLine(0, CVariant{line1});
       if (!line2.empty())
-        pDialog->SetLine(1, line2);
+        pDialog->SetLine(1, CVariant{line2});
       if (!line3.empty())
-        pDialog->SetLine(2, line3);
+        pDialog->SetLine(2, CVariant{line3});
     }
 
     void DialogProgress::close()

--- a/xbmc/interfaces/legacy/Keyboard.cpp
+++ b/xbmc/interfaces/legacy/Keyboard.cpp
@@ -22,6 +22,7 @@
 #include "LanguageHook.h"
 
 #include "guilib/GUIKeyboardFactory.h"
+#include "utils/Variant.h"
 
 namespace XBMCAddon
 {
@@ -41,7 +42,7 @@ namespace XBMCAddon
       // using keyboardfactory method to get native keyboard if there is.
       strText = strDefault;
       std::string text(strDefault);
-      bConfirmed = CGUIKeyboardFactory::ShowAndGetInput(text, strHeading, true, bHidden, autoclose * 1000);
+      bConfirmed = CGUIKeyboardFactory::ShowAndGetInput(text, CVariant{strHeading}, true, bHidden, autoclose * 1000);
       strText = text;
     }
 

--- a/xbmc/interfaces/legacy/aojsonrpc.h
+++ b/xbmc/interfaces/legacy/aojsonrpc.h
@@ -22,6 +22,8 @@
 #include "interfaces/json-rpc/ITransportLayer.h"
 #include "interfaces/json-rpc/JSONRPC.h"
 
+class CVariant;
+
 #ifdef HAS_JSONRPC
 class CAddOnTransport : public JSONRPC::ITransportLayer
 {

--- a/xbmc/interfaces/python/XBPython.cpp
+++ b/xbmc/interfaces/python/XBPython.cpp
@@ -35,6 +35,7 @@
 #include "filesystem/SpecialProtocol.h"
 #include "utils/JSONVariantWriter.h"
 #include "utils/log.h"
+#include "utils/Variant.h"
 #include "Util.h"
 #ifdef TARGET_WINDOWS
 #include "utils/Environment.h"

--- a/xbmc/interfaces/python/XBPython.h
+++ b/xbmc/interfaces/python/XBPython.h
@@ -31,6 +31,7 @@
 #include <vector>
 
 class CPythonInvoker;
+class CVariant;
 
 typedef struct {
   int id;

--- a/xbmc/listproviders/DirectoryProvider.cpp
+++ b/xbmc/listproviders/DirectoryProvider.cpp
@@ -25,6 +25,7 @@
 #include "utils/JobManager.h"
 #include "utils/XMLUtils.h"
 #include "utils/URIUtils.h"
+#include "utils/Variant.h"
 #include "threads/SingleLock.h"
 #include "FileItem.h"
 #include "video/VideoThumbLoader.h"

--- a/xbmc/listproviders/DirectoryProvider.h
+++ b/xbmc/listproviders/DirectoryProvider.h
@@ -28,6 +28,7 @@
 #include "interfaces/IAnnouncer.h"
 
 class TiXmlElement;
+class CVariant;
 
 typedef enum
 {

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -53,6 +53,7 @@
 #include "settings/MediaSettings.h"
 #include "settings/Settings.h"
 #include "utils/StringUtils.h"
+#include "utils/Variant.h"
 #include "guilib/LocalizeStrings.h"
 #include "utils/FileUtils.h"
 #include "utils/LegacyPathTranslation.h"
@@ -66,6 +67,8 @@
 #include "playlists/SmartPlayList.h"
 #include "CueInfoLoader.h"
 #include "guiinfo/GUIInfoLabels.h"
+
+#include <utility>
 
 using namespace std;
 using namespace AUTOPTR;
@@ -2665,10 +2668,10 @@ int CMusicDatabase::Cleanup(bool bShowProgress /* = true */)
     pDlgProgress = (CGUIDialogProgress*)g_windowManager.GetWindow(WINDOW_DIALOG_PROGRESS);
     if (pDlgProgress)
     {
-      pDlgProgress->SetHeading(700);
-      pDlgProgress->SetLine(0, "");
-      pDlgProgress->SetLine(1, 318);
-      pDlgProgress->SetLine(2, 330);
+      pDlgProgress->SetHeading(CVariant{700});
+      pDlgProgress->SetLine(0, CVariant{""});
+      pDlgProgress->SetLine(1, CVariant{318});
+      pDlgProgress->SetLine(2, CVariant{330});
       pDlgProgress->SetPercentage(0);
       pDlgProgress->StartModal();
       pDlgProgress->ShowProgressBar(true);
@@ -2682,7 +2685,7 @@ int CMusicDatabase::Cleanup(bool bShowProgress /* = true */)
   // then the albums that are not linked to a song or to album, or whose path is removed
   if (pDlgProgress)
   {
-    pDlgProgress->SetLine(1, 326);
+    pDlgProgress->SetLine(1, CVariant{326});
     pDlgProgress->SetPercentage(20);
     pDlgProgress->Progress();
   }
@@ -2694,7 +2697,7 @@ int CMusicDatabase::Cleanup(bool bShowProgress /* = true */)
   // now the paths
   if (pDlgProgress)
   {
-    pDlgProgress->SetLine(1, 324);
+    pDlgProgress->SetLine(1, CVariant{324});
     pDlgProgress->SetPercentage(40);
     pDlgProgress->Progress();
   }
@@ -2706,7 +2709,7 @@ int CMusicDatabase::Cleanup(bool bShowProgress /* = true */)
   // and finally artists + genres
   if (pDlgProgress)
   {
-    pDlgProgress->SetLine(1, 320);
+    pDlgProgress->SetLine(1, CVariant{320});
     pDlgProgress->SetPercentage(60);
     pDlgProgress->Progress();
   }
@@ -2717,7 +2720,7 @@ int CMusicDatabase::Cleanup(bool bShowProgress /* = true */)
   }
   if (pDlgProgress)
   {
-    pDlgProgress->SetLine(1, 322);
+    pDlgProgress->SetLine(1, CVariant{322});
     pDlgProgress->SetPercentage(80);
     pDlgProgress->Progress();
   }
@@ -2729,7 +2732,7 @@ int CMusicDatabase::Cleanup(bool bShowProgress /* = true */)
   // commit transaction
   if (pDlgProgress)
   {
-    pDlgProgress->SetLine(1, 328);
+    pDlgProgress->SetLine(1, CVariant{328});
     pDlgProgress->SetPercentage(90);
     pDlgProgress->Progress();
   }
@@ -2741,7 +2744,7 @@ int CMusicDatabase::Cleanup(bool bShowProgress /* = true */)
   // and compress the database
   if (pDlgProgress)
   {
-    pDlgProgress->SetLine(1, 331);
+    pDlgProgress->SetLine(1, CVariant{331});
     pDlgProgress->SetPercentage(100);
     pDlgProgress->Progress();
     pDlgProgress->Close();
@@ -2803,10 +2806,10 @@ bool CMusicDatabase::LookupCDDBInfo(bool bRequery/*=false*/)
     if (!pDlgSelect) return false;
 
     // Show progress dialog if we have to connect to freedb.org
-    pDialogProgress->SetHeading(255); //CDDB
-    pDialogProgress->SetLine(0, ""); // Querying freedb for CDDB info
-    pDialogProgress->SetLine(1, 256);
-    pDialogProgress->SetLine(2, "");
+    pDialogProgress->SetHeading(CVariant{255}); //CDDB
+    pDialogProgress->SetLine(0, CVariant{""}); // Querying freedb for CDDB info
+    pDialogProgress->SetLine(1, CVariant{256});
+    pDialogProgress->SetLine(2, CVariant{""});
     pDialogProgress->ShowProgressBar(false);
     pDialogProgress->StartModal();
 
@@ -2822,7 +2825,7 @@ bool CMusicDatabase::LookupCDDBInfo(bool bRequery/*=false*/)
         // ...yes, show the matches found in a select dialog
         // and let the user choose an entry.
         pDlgSelect->Reset();
-        pDlgSelect->SetHeading(255);
+        pDlgSelect->SetHeading(CVariant{255});
         int i = 1;
         while (1)
         {
@@ -2858,7 +2861,7 @@ bool CMusicDatabase::LookupCDDBInfo(bool bRequery/*=false*/)
         pCdInfo->SetNoCDDBInfo();
         // ..no, an error occured, display it to the user
         std::string strErrorText = StringUtils::Format("[%d] %s", cddb.getLastError(), cddb.getLastErrorText());
-        CGUIDialogOK::ShowAndGetInput(255, 257, strErrorText, 0);
+        CGUIDialogOK::ShowAndGetInput(CVariant{255}, CVariant{257}, CVariant{std::move(strErrorText)}, CVariant{0});
       }
     } // if ( !cddb.queryCDinfo( pCdInfo ) )
     else
@@ -2879,14 +2882,14 @@ void CMusicDatabase::DeleteCDDBInfo()
   CFileItemList items;
   if (!CDirectory::GetDirectory(CProfilesManager::Get().GetCDDBFolder(), items, ".cddb", DIR_FLAG_NO_FILE_DIRS))
   {
-    CGUIDialogOK::ShowAndGetInput(313, 426);
+    CGUIDialogOK::ShowAndGetInput(CVariant{313}, CVariant{426});
     return ;
   }
   // Show a selectdialog that the user can select the album to delete
   CGUIDialogSelect *pDlg = (CGUIDialogSelect*)g_windowManager.GetWindow(WINDOW_DIALOG_SELECT);
   if (pDlg)
   {
-    pDlg->SetHeading(g_localizeStrings.Get(181).c_str());
+    pDlg->SetHeading(CVariant{g_localizeStrings.Get(181)});
     pDlg->Reset();
 
     map<ULONG, std::string> mapCDDBIds;
@@ -2951,11 +2954,11 @@ void CMusicDatabase::Clean()
   // other writing access to the database is prohibited.
   if (g_application.IsMusicScanning())
   {
-    CGUIDialogOK::ShowAndGetInput(189, 14057);
+    CGUIDialogOK::ShowAndGetInput(CVariant{189}, CVariant{14057});
     return;
   }
 
-  if (CGUIDialogYesNo::ShowAndGetInput(313, 333))
+  if (CGUIDialogYesNo::ShowAndGetInput(CVariant{313}, CVariant{333}))
   {
     CMusicDatabase musicdatabase;
     if (musicdatabase.Open())
@@ -2965,7 +2968,7 @@ void CMusicDatabase::Clean()
 
       if (iReturnString != ERROR_OK)
       {
-        CGUIDialogOK::ShowAndGetInput(313, iReturnString);
+        CGUIDialogOK::ShowAndGetInput(CVariant{313}, CVariant{iReturnString});
       }
     }
   }
@@ -4651,10 +4654,10 @@ void CMusicDatabase::ExportToXML(const std::string &xmlFile, bool singleFiles, b
     progress = (CGUIDialogProgress *)g_windowManager.GetWindow(WINDOW_DIALOG_PROGRESS);
     if (progress)
     {
-      progress->SetHeading(20196);
-      progress->SetLine(0, 650);
-      progress->SetLine(1, "");
-      progress->SetLine(2, "");
+      progress->SetHeading(CVariant{20196});
+      progress->SetLine(0, CVariant{650});
+      progress->SetLine(1, CVariant{""});
+      progress->SetLine(2, CVariant{""});
       progress->SetPercentage(0);
       progress->StartModal();
       progress->ShowProgressBar(true);
@@ -4710,7 +4713,7 @@ void CMusicDatabase::ExportToXML(const std::string &xmlFile, bool singleFiles, b
 
       if ((current % 50) == 0 && progress)
       {
-        progress->SetLine(1, album.strAlbum);
+        progress->SetLine(1, CVariant{album.strAlbum});
         progress->SetPercentage(current * 100 / total);
         progress->Progress();
         if (progress->IsCanceled())
@@ -4787,7 +4790,7 @@ void CMusicDatabase::ExportToXML(const std::string &xmlFile, bool singleFiles, b
 
       if ((current % 50) == 0 && progress)
       {
-        progress->SetLine(1, artist.strArtist);
+        progress->SetLine(1, CVariant{artist.strArtist});
         progress->SetPercentage(current * 100 / total);
         progress->Progress();
         if (progress->IsCanceled())
@@ -4812,7 +4815,7 @@ void CMusicDatabase::ExportToXML(const std::string &xmlFile, bool singleFiles, b
     progress->Close();
 
   if (iFailCount > 0)
-    CGUIDialogOK::ShowAndGetInput(20196, StringUtils::Format(g_localizeStrings.Get(15011).c_str(), iFailCount));
+    CGUIDialogOK::ShowAndGetInput(CVariant{20196}, CVariant{StringUtils::Format(g_localizeStrings.Get(15011).c_str(), iFailCount)});
 }
 
 void CMusicDatabase::ImportFromXML(const std::string &xmlFile)
@@ -4832,10 +4835,10 @@ void CMusicDatabase::ImportFromXML(const std::string &xmlFile)
 
     if (progress)
     {
-      progress->SetHeading(20197);
-      progress->SetLine(0, 649);
-      progress->SetLine(1, 330);
-      progress->SetLine(2, "");
+      progress->SetHeading(CVariant{20197});
+      progress->SetLine(0, CVariant{649});
+      progress->SetLine(1, CVariant{330});
+      progress->SetLine(2, CVariant{""});
       progress->SetPercentage(0);
       progress->StartModal();
       progress->ShowProgressBar(true);
@@ -4894,7 +4897,7 @@ void CMusicDatabase::ImportFromXML(const std::string &xmlFile)
       if (progress && total)
       {
         progress->SetPercentage(current * 100 / total);
-        progress->SetLine(2, strTitle);
+        progress->SetLine(2, CVariant{std::move(strTitle)});
         progress->Progress();
         if (progress->IsCanceled())
         {
@@ -5012,10 +5015,10 @@ void CMusicDatabase::ExportKaraokeInfo(const std::string & outFile, bool asHTML)
     CGUIDialogProgress *progress = (CGUIDialogProgress *)g_windowManager.GetWindow(WINDOW_DIALOG_PROGRESS);
     if (progress)
     {
-      progress->SetHeading(asHTML ? 22034 : 22035);
-      progress->SetLine(0, 650);
-      progress->SetLine(1, "");
-      progress->SetLine(2, "");
+      progress->SetHeading(CVariant{asHTML ? 22034 : 22035});
+      progress->SetLine(0, CVariant{650});
+      progress->SetLine(1, CVariant{""});
+      progress->SetLine(2, CVariant{""});
       progress->SetPercentage(0);
       progress->StartModal();
       progress->ShowProgressBar(true);
@@ -5104,10 +5107,10 @@ void CMusicDatabase::ImportKaraokeInfo(const std::string & inputFile)
 
     if (progress)
     {
-      progress->SetHeading( 22036 );
-      progress->SetLine(0, 649);
-      progress->SetLine(1, "");
-      progress->SetLine(2, "");
+      progress->SetHeading(CVariant{22036});
+      progress->SetLine(0, CVariant{649});
+      progress->SetLine(1, CVariant{""});
+      progress->SetLine(2, CVariant{""});
       progress->SetPercentage(0);
       progress->StartModal();
       progress->ShowProgressBar(true);

--- a/xbmc/music/MusicDbUrl.h
+++ b/xbmc/music/MusicDbUrl.h
@@ -23,6 +23,8 @@
 
 #include "DbUrl.h"
 
+class CVariant;
+
 class CMusicDbUrl : public CDbUrl
 {
 public:

--- a/xbmc/music/Song.h
+++ b/xbmc/music/Song.h
@@ -32,6 +32,8 @@
 #include <string>
 #include <vector>
 
+class CVariant;
+
 /*!
  \ingroup music
  \brief Class to store and read album information from CMusicDatabase

--- a/xbmc/music/dialogs/GUIDialogSongInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogSongInfo.cpp
@@ -21,6 +21,7 @@
 #include "GUIDialogSongInfo.h"
 #include "utils/URIUtils.h"
 #include "utils/StringUtils.h"
+#include "utils/Variant.h"
 #include "dialogs/GUIDialogFileBrowser.h"
 #include "GUIPassword.h"
 #include "GUIUserMessages.h"

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -44,6 +44,7 @@
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 #include "utils/URIUtils.h"
+#include "utils/Variant.h"
 #include "TextureCache.h"
 #include "music/MusicThumbLoader.h"
 #include "interfaces/AnnouncementManager.h"
@@ -963,11 +964,11 @@ loop:
   {
     if (pDialog && bAllowSelection)
     {
-      if (!CGUIKeyboardFactory::ShowAndGetInput(album.strAlbum, g_localizeStrings.Get(16011), false))
+      if (!CGUIKeyboardFactory::ShowAndGetInput(album.strAlbum, CVariant{g_localizeStrings.Get(16011)}, false))
         return INFO_CANCELLED;
 
       std::string strTempArtist(StringUtils::Join(album.artist, g_advancedSettings.m_musicItemSeparator));
-      if (!CGUIKeyboardFactory::ShowAndGetInput(strTempArtist, g_localizeStrings.Get(16025), false))
+      if (!CGUIKeyboardFactory::ShowAndGetInput(strTempArtist, CVariant{g_localizeStrings.Get(16025)}, false))
         return INFO_CANCELLED;
 
       album.artist = StringUtils::Split(strTempArtist, g_advancedSettings.m_musicItemSeparator);
@@ -1000,7 +1001,7 @@ loop:
   {
     if (pDialog && bAllowSelection)
     {
-      if (!CGUIKeyboardFactory::ShowAndGetInput(artist.strArtist, g_localizeStrings.Get(16025), false))
+      if (!CGUIKeyboardFactory::ShowAndGetInput(artist.strArtist, CVariant{g_localizeStrings.Get(16025)}, false))
         return INFO_CANCELLED;
       goto loop;
     }
@@ -1114,7 +1115,7 @@ INFO_RET CMusicInfoScanner::DownloadAlbumInfo(const CAlbum& album, const ADDON::
         if (pDialog)
         {
           pDlg = (CGUIDialogSelect*)g_windowManager.GetWindow(WINDOW_DIALOG_SELECT);
-          pDlg->SetHeading(g_localizeStrings.Get(181).c_str());
+          pDlg->SetHeading(CVariant{g_localizeStrings.Get(181)});
           pDlg->Reset();
           pDlg->EnableButton(true, 413); // manual
         }
@@ -1158,14 +1159,17 @@ INFO_RET CMusicInfoScanner::DownloadAlbumInfo(const CAlbum& album, const ADDON::
 
             // manual button pressed
             std::string strNewAlbum = album.strAlbum;
-            if (!CGUIKeyboardFactory::ShowAndGetInput(strNewAlbum, g_localizeStrings.Get(16011), false)) return INFO_CANCELLED;
-            if (strNewAlbum == "") return INFO_CANCELLED;
+            if (!CGUIKeyboardFactory::ShowAndGetInput(strNewAlbum, CVariant{g_localizeStrings.Get(16011)}, false))
+              return INFO_CANCELLED;
+            if (strNewAlbum == "")
+              return INFO_CANCELLED;
 
             std::string strNewArtist = StringUtils::Join(album.artist, g_advancedSettings.m_musicItemSeparator);
-            if (!CGUIKeyboardFactory::ShowAndGetInput(strNewArtist, g_localizeStrings.Get(16025), false)) return INFO_CANCELLED;
+            if (!CGUIKeyboardFactory::ShowAndGetInput(strNewArtist, CVariant{g_localizeStrings.Get(16025)}, false))
+              return INFO_CANCELLED;
 
-            pDialog->SetLine(0, strNewAlbum);
-            pDialog->SetLine(1, strNewArtist);
+            pDialog->SetLine(0, CVariant{strNewAlbum});
+            pDialog->SetLine(1, CVariant{strNewArtist});
             pDialog->Progress();
 
             CAlbum newAlbum = album;
@@ -1320,7 +1324,7 @@ INFO_RET CMusicInfoScanner::DownloadArtistInfo(const CArtist& artist, const ADDO
         CGUIDialogSelect *pDlg = (CGUIDialogSelect*)g_windowManager.GetWindow(WINDOW_DIALOG_SELECT);
         if (pDlg)
         {
-          pDlg->SetHeading(g_localizeStrings.Get(21890));
+          pDlg->SetHeading(CVariant{g_localizeStrings.Get(21890)});
           pDlg->Reset();
           pDlg->EnableButton(true, 413); // manual
 
@@ -1351,11 +1355,12 @@ INFO_RET CMusicInfoScanner::DownloadArtistInfo(const CArtist& artist, const ADDO
 
             // manual button pressed
             std::string strNewArtist = artist.strArtist;
-            if (!CGUIKeyboardFactory::ShowAndGetInput(strNewArtist, g_localizeStrings.Get(16025), false)) return INFO_CANCELLED;
+            if (!CGUIKeyboardFactory::ShowAndGetInput(strNewArtist, CVariant{g_localizeStrings.Get(16025)}, false))
+              return INFO_CANCELLED;
 
             if (pDialog)
             {
-              pDialog->SetLine(0, strNewArtist);
+              pDialog->SetLine(0, CVariant{strNewArtist});
               pDialog->Progress();
             }
 

--- a/xbmc/music/tags/MusicInfoTag.h
+++ b/xbmc/music/tags/MusicInfoTag.h
@@ -21,6 +21,7 @@
 
 class CSong;
 class CArtist;
+class CVariant;
 
 #include <stdint.h>
 #include <string>

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -55,6 +55,7 @@
 #include "utils/log.h"
 #include "utils/URIUtils.h"
 #include "utils/StringUtils.h"
+#include "utils/Variant.h"
 #include "URL.h"
 #include "music/infoscanner/MusicInfoScanner.h"
 #include "guiinfo/GUIInfoLabels.h"
@@ -352,24 +353,24 @@ void CGUIWindowMusicBase::ShowArtistInfo(const CFileItem *pItem, bool bShowInfo 
 
       if (g_application.IsMusicScanning())
       {
-        CGUIDialogOK::ShowAndGetInput(189, 14057);
+        CGUIDialogOK::ShowAndGetInput(CVariant{189}, CVariant{14057});
         break;
       }
 
       // show dialog box indicating we're searching the album
       if (m_dlgProgress && bShowInfo)
       {
-        m_dlgProgress->SetHeading(21889);
-        m_dlgProgress->SetLine(0, pItem->GetMusicInfoTag()->GetArtist());
-        m_dlgProgress->SetLine(1, "");
-        m_dlgProgress->SetLine(2, "");
+        m_dlgProgress->SetHeading(CVariant{21889});
+        m_dlgProgress->SetLine(0, CVariant{pItem->GetMusicInfoTag()->GetArtist()});
+        m_dlgProgress->SetLine(1, CVariant{""});
+        m_dlgProgress->SetLine(2, CVariant{""});
         m_dlgProgress->StartModal();
       }
 
       CMusicInfoScanner scanner;
       if (scanner.UpdateDatabaseArtistInfo(artist, scraper, bShowInfo, m_dlgProgress) != INFO_ADDED)
       {
-        CGUIDialogOK::ShowAndGetInput(21889, 20199);
+        CGUIDialogOK::ShowAndGetInput(CVariant{21889}, CVariant{20199});
         break;
       }
     }
@@ -427,7 +428,7 @@ bool CGUIWindowMusicBase::ShowAlbumInfo(const CFileItem *pItem, bool bShowInfo /
 
       if (g_application.IsMusicScanning())
       {
-        CGUIDialogOK::ShowAndGetInput(189, 14057);
+        CGUIDialogOK::ShowAndGetInput(CVariant{189}, CVariant{14057});
         if (m_dlgProgress)
           m_dlgProgress->Close();
         return false;
@@ -436,17 +437,17 @@ bool CGUIWindowMusicBase::ShowAlbumInfo(const CFileItem *pItem, bool bShowInfo /
       // show dialog box indicating we're searching the album
       if (m_dlgProgress && bShowInfo)
       {
-        m_dlgProgress->SetHeading(185);
-        m_dlgProgress->SetLine(0, pItem->GetMusicInfoTag()->GetAlbum());
-        m_dlgProgress->SetLine(1, StringUtils::Join(pItem->GetMusicInfoTag()->GetAlbumArtist(), g_advancedSettings.m_musicItemSeparator));
-        m_dlgProgress->SetLine(2, "");
+        m_dlgProgress->SetHeading(CVariant{185});
+        m_dlgProgress->SetLine(0, CVariant{pItem->GetMusicInfoTag()->GetAlbum()});
+        m_dlgProgress->SetLine(1, CVariant{StringUtils::Join(pItem->GetMusicInfoTag()->GetAlbumArtist(), g_advancedSettings.m_musicItemSeparator)});
+        m_dlgProgress->SetLine(2, CVariant{""});
         m_dlgProgress->StartModal();
       }
 
       CMusicInfoScanner scanner;
       if (scanner.UpdateDatabaseAlbumInfo(album, scraper, bShowInfo, m_dlgProgress) != INFO_ADDED)
       {
-        CGUIDialogOK::ShowAndGetInput(185, 500);
+        CGUIDialogOK::ShowAndGetInput(CVariant{185}, CVariant{500});
         if (m_dlgProgress)
           m_dlgProgress->Close();
         return false;
@@ -656,7 +657,7 @@ void CGUIWindowMusicBase::AddItemToPlayList(const CFileItemPtr &pItem, CFileItem
         // load it
         if (!pPlayList->Load(pItem->GetPath()))
         {
-          CGUIDialogOK::ShowAndGetInput(6, 477);
+          CGUIDialogOK::ShowAndGetInput(CVariant{6}, CVariant{477});
           return; //hmmm unable to load playlist?
         }
 
@@ -854,7 +855,7 @@ void CGUIWindowMusicBase::OnRipCD()
 #endif
     }
     else
-      CGUIDialogOK::ShowAndGetInput(257, 20099);
+      CGUIDialogOK::ShowAndGetInput(CVariant{257}, CVariant{20099});
   }
 }
 
@@ -870,7 +871,7 @@ void CGUIWindowMusicBase::OnRipTrack(int iItem)
 #endif
     }
     else
-      CGUIDialogOK::ShowAndGetInput(257, 20099);
+      CGUIDialogOK::ShowAndGetInput(CVariant{257}, CVariant{20099});
   }
 }
 
@@ -945,7 +946,7 @@ void CGUIWindowMusicBase::LoadPlayList(const std::string& strPlayList)
     // load it
     if (!pPlayList->Load(strPlayList))
     {
-      CGUIDialogOK::ShowAndGetInput(6, 477);
+      CGUIDialogOK::ShowAndGetInput(CVariant{6}, CVariant{477});
       return; //hmmm unable to load playlist?
     }
   }
@@ -1087,11 +1088,10 @@ void CGUIWindowMusicBase::OnRetrieveMusicInfo(CFileItemList& items)
       if (!bProgressVisible && elapsed>1500 && m_dlgProgress)
       { // tag loading takes more then 1.5 secs, show a progress dialog
         CURL url(items.GetPath());
-        std::string strStrippedPath = url.GetWithoutUserDetails();
-        m_dlgProgress->SetHeading(189);
-        m_dlgProgress->SetLine(0, 505);
-        m_dlgProgress->SetLine(1, "");
-        m_dlgProgress->SetLine(2, strStrippedPath );
+        m_dlgProgress->SetHeading(CVariant{189});
+        m_dlgProgress->SetLine(0, CVariant{505});
+        m_dlgProgress->SetLine(1, CVariant{""});
+        m_dlgProgress->SetLine(2, CVariant{url.GetWithoutUserDetails()});
         m_dlgProgress->StartModal();
         m_dlgProgress->ShowProgressBar(true);
         bProgressVisible = true;
@@ -1183,20 +1183,20 @@ void CGUIWindowMusicBase::OnInitWindow()
   if (CMediaSettings::Get().GetMusicNeedsUpdate() == 53)
   {
     if (g_infoManager.GetLibraryBool(LIBRARY_HAS_MUSIC) && !g_application.IsMusicScanning())
-  {
-    // rescan of music library required
-      if (CGUIDialogYesNo::ShowAndGetInput(799, 800))
     {
-      int flags = CMusicInfoScanner::SCAN_RESCAN;
-      if (CSettings::Get().GetBool("musiclibrary.downloadinfo"))
-        flags |= CMusicInfoScanner::SCAN_ONLINE;
-      if (CSettings::Get().GetBool("musiclibrary.backgroundupdate"))
-        flags |= CMusicInfoScanner::SCAN_BACKGROUND;
-      g_application.StartMusicScan("", true, flags);
-      CMediaSettings::Get().SetMusicNeedsUpdate(0); // once is enough (user may interrupt, but that's up to them)
-      CSettings::Get().Save();
+      // rescan of music library required
+      if (CGUIDialogYesNo::ShowAndGetInput(CVariant{799}, CVariant{800}))
+      {
+        int flags = CMusicInfoScanner::SCAN_RESCAN;
+        if (CSettings::Get().GetBool("musiclibrary.downloadinfo"))
+          flags |= CMusicInfoScanner::SCAN_ONLINE;
+        if (CSettings::Get().GetBool("musiclibrary.backgroundupdate"))
+          flags |= CMusicInfoScanner::SCAN_BACKGROUND;
+        g_application.StartMusicScan("", true, flags);
+        CMediaSettings::Get().SetMusicNeedsUpdate(0); // once is enough (user may interrupt, but that's up to them)
+        CSettings::Get().Save();
+      }
     }
-  }
     else
     {
       // no need to force a rescan if there's no music in the library or if a library scan is already active

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -51,6 +51,7 @@
 #include "utils/LegacyPathTranslation.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
+#include "utils/Variant.h"
 #include "Util.h"
 #include "URL.h"
 #include "ContextMenuManager.h"
@@ -722,7 +723,7 @@ bool CGUIWindowMusicNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
       if (CGUIDialogContentSettings::Show(scraper, content))
       {
         m_musicdatabase.SetScraperForPath(path,scraper);
-        if (CGUIDialogYesNo::ShowAndGetInput(20442, 20443))
+        if (CGUIDialogYesNo::ShowAndGetInput(CVariant{20442}, CVariant{20443}))
         {
           OnInfoAll(itemNumber,true,true);
         }
@@ -758,7 +759,7 @@ bool CGUIWindowMusicNav::GetSongsFromPlayList(const std::string& strPlayList, CF
     // load it
     if (!pPlayList->Load(strPlayList))
     {
-      CGUIDialogOK::ShowAndGetInput(6, 477);
+      CGUIDialogOK::ShowAndGetInput(CVariant{6}, CVariant{477});
       return false; //hmmm unable to load playlist?
     }
     CPlayList playlist = *pPlayList;

--- a/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
@@ -40,6 +40,7 @@
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 #include "utils/URIUtils.h"
+#include "utils/Variant.h"
 
 using namespace PLAYLIST;
 
@@ -282,7 +283,7 @@ bool CGUIWindowMusicPlayList::MoveCurrentPlayListItem(int iItem, int iAction, bo
 void CGUIWindowMusicPlayList::SavePlayList()
 {
   std::string strNewFileName;
-  if (CGUIKeyboardFactory::ShowAndGetInput(strNewFileName, g_localizeStrings.Get(16012), false))
+  if (CGUIKeyboardFactory::ShowAndGetInput(strNewFileName, CVariant{g_localizeStrings.Get(16012)}, false))
   {
     // need 2 rename it
     std::string strFolder = URIUtils::AddFileToFolder(CSettings::Get().GetString("system.playlistspath"), "music");

--- a/xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
@@ -23,6 +23,7 @@
 #include "Util.h"
 #include "utils/URIUtils.h"
 #include "utils/StringUtils.h"
+#include "utils/Variant.h"
 #include "Autorun.h"
 #include "dialogs/GUIDialogFileBrowser.h"
 #include "filesystem/PlaylistFileDirectory.h"
@@ -402,7 +403,7 @@ void CGUIWindowMusicPlaylistEditor::OnSavePlaylist()
   std::string name = URIUtils::GetFileName(m_strLoadedPlaylist);
   URIUtils::RemoveExtension(name);
 
-  if (CGUIKeyboardFactory::ShowAndGetInput(name, g_localizeStrings.Get(16012), false))
+  if (CGUIKeyboardFactory::ShowAndGetInput(name, CVariant{g_localizeStrings.Get(16012)}, false))
   { // save playlist as an .m3u
     PLAYLIST::CPlayListM3U playlist;
     playlist.Add(*m_playlist);

--- a/xbmc/music/windows/GUIWindowMusicSongs.cpp
+++ b/xbmc/music/windows/GUIWindowMusicSongs.cpp
@@ -35,6 +35,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "utils/URIUtils.h"
 #include "utils/StringUtils.h"
+#include "utils/Variant.h"
 #include "Autorun.h"
 #include "cdrip/CDDARipper.h"
 #include "ContextMenuManager.h"
@@ -480,7 +481,7 @@ bool CGUIWindowMusicSongs::Update(const std::string &strDirectory, bool updateFi
 void CGUIWindowMusicSongs::OnRemoveSource(int iItem)
 {
   bool bCanceled;
-  if (CGUIDialogYesNo::ShowAndGetInput(522, 20340, bCanceled))
+  if (CGUIDialogYesNo::ShowAndGetInput(CVariant{522}, CVariant{20340}, bCanceled))
   {
     MAPSONGS songs;
     CMusicDatabase database;

--- a/xbmc/network/AirPlayServer.h
+++ b/xbmc/network/AirPlayServer.h
@@ -33,6 +33,7 @@
 #include "interfaces/IAnnouncer.h"
 
 class DllLibPlist;
+class CVariant;
 
 #define AIRPLAY_SERVER_VERSION_STR "101.28"
 

--- a/xbmc/network/AirTunesServer.h
+++ b/xbmc/network/AirTunesServer.h
@@ -41,6 +41,8 @@
 #include "interfaces/IActionListener.h"
 
 class CDACP;
+class CVariant;
+
 class CAirTunesServer : public ANNOUNCEMENT::IAnnouncer, public IActionListener, public CThread
 {
 public:

--- a/xbmc/network/GUIDialogAccessPoints.cpp
+++ b/xbmc/network/GUIDialogAccessPoints.cpp
@@ -27,6 +27,7 @@
 #include "FileItem.h"
 #include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
+#include "utils/Variant.h"
 
 #define CONTROL_ACCESS_POINTS 3
 
@@ -52,7 +53,7 @@ bool CGUIDialogAccessPoints::OnAction(const CAction &action)
     if (iItem == (int) m_aps.size())
     {
        m_selectedAPEssId = "";
-       if (CGUIKeyboardFactory::ShowAndGetInput(m_selectedAPEssId, g_localizeStrings.Get(789), false))
+       if (CGUIKeyboardFactory::ShowAndGetInput(m_selectedAPEssId, CVariant{g_localizeStrings.Get(789)}, false))
        {
          m_selectedAPEncMode = m_aps[iItem].getEncryptionMode();
          m_wasItemSelected = true;

--- a/xbmc/network/NetworkServices.cpp
+++ b/xbmc/network/NetworkServices.cpp
@@ -82,6 +82,7 @@
 #include "utils/log.h"
 #include "utils/RssManager.h"
 #include "utils/SystemInfo.h"
+#include "utils/Variant.h"
 
 using namespace std;
 #ifdef HAS_JSONRPC
@@ -181,7 +182,7 @@ bool CNetworkServices::OnSettingChanging(const CSetting *setting)
     {
       if (!StartWebserver())
       {
-        CGUIDialogOK::ShowAndGetInput(33101, 33100);
+        CGUIDialogOK::ShowAndGetInput(CVariant{33101}, CVariant{33100});
         return false;
       }
     }
@@ -203,7 +204,7 @@ bool CNetworkServices::OnSettingChanging(const CSetting *setting)
       // cannot disable 
       if (IsAirPlayServerRunning() || IsAirTunesServerRunning())
       {
-        CGUIDialogOK::ShowAndGetInput(1259, 34303);
+        CGUIDialogOK::ShowAndGetInput(CVariant{1259}, CVariant{34303});
         return false;
       }
 
@@ -223,7 +224,7 @@ bool CNetworkServices::OnSettingChanging(const CSetting *setting)
       // AirPlay needs zeroconf
       if (!CSettings::Get().GetBool("services.zeroconf"))
       {
-        CGUIDialogOK::ShowAndGetInput(1273, 34302);
+        CGUIDialogOK::ShowAndGetInput(CVariant{1273}, CVariant{34302});
         return false;
       }
 #endif //HAS_ZEROCONF
@@ -232,14 +233,14 @@ bool CNetworkServices::OnSettingChanging(const CSetting *setting)
 #ifdef HAS_AIRTUNES
       if (!StartAirTunesServer())
       {
-        CGUIDialogOK::ShowAndGetInput(1274, 33100);
+        CGUIDialogOK::ShowAndGetInput(CVariant{1274}, CVariant{33100});
         return false;
       }
 #endif //HAS_AIRTUNES
       
       if (!StartAirPlayServer())
       {
-        CGUIDialogOK::ShowAndGetInput(1273, 33100);
+        CGUIDialogOK::ShowAndGetInput(CVariant{1273}, CVariant{33100});
         return false;
       }      
     }
@@ -312,7 +313,7 @@ bool CNetworkServices::OnSettingChanging(const CSetting *setting)
     {
       if (!StartEventServer())
       {
-        CGUIDialogOK::ShowAndGetInput(33102, 33100);
+        CGUIDialogOK::ShowAndGetInput(CVariant{33102}, CVariant{33100});
         return false;
       }
     }
@@ -325,7 +326,7 @@ bool CNetworkServices::OnSettingChanging(const CSetting *setting)
     {
       if (!StartJSONRPCServer())
       {
-        CGUIDialogOK::ShowAndGetInput(33103, 33100);
+        CGUIDialogOK::ShowAndGetInput(CVariant{33103}, CVariant{33100});
         return false;
       }
     }
@@ -342,7 +343,7 @@ bool CNetworkServices::OnSettingChanging(const CSetting *setting)
 
     if (!StartEventServer())
     {
-      CGUIDialogOK::ShowAndGetInput(33102, 33100);
+      CGUIDialogOK::ShowAndGetInput(CVariant{33102}, CVariant{33100});
       return false;
     }
 
@@ -362,7 +363,7 @@ bool CNetworkServices::OnSettingChanging(const CSetting *setting)
 
       if (!StartEventServer())
       {
-        CGUIDialogOK::ShowAndGetInput(33102, 33100);
+        CGUIDialogOK::ShowAndGetInput(CVariant{33102}, CVariant{33100});
         return false;
       }
     }
@@ -373,7 +374,7 @@ bool CNetworkServices::OnSettingChanging(const CSetting *setting)
     {
       if (!StartJSONRPCServer())
       {
-        CGUIDialogOK::ShowAndGetInput(33103, 33100);
+        CGUIDialogOK::ShowAndGetInput(CVariant{33103}, CVariant{33100});
         return false;
       }
     }
@@ -412,7 +413,7 @@ void CNetworkServices::OnSettingChanged(const CSetting *setting)
   {
     // okey we really don't need to restart, only deinit samba, but that could be damn hard if something is playing
     // TODO - General way of handling setting changes that require restart
-    if (CGUIDialogYesNo::ShowAndGetInput(14038, 14039))
+    if (CGUIDialogYesNo::ShowAndGetInput(CVariant{14038}, CVariant{14039}))
     {
       CSettings::Get().Save();
       CApplicationMessenger::Get().RestartApp();
@@ -755,7 +756,7 @@ bool CNetworkServices::StopEventServer(bool bWait, bool promptuser)
     if (server->GetNumberOfClients() > 0)
     {
       bool cancelled = false;
-      if (!CGUIDialogYesNo::ShowAndGetInput(13140, 13141, cancelled, "", "", 10000)
+      if (!CGUIDialogYesNo::ShowAndGetInput(CVariant{13140}, CVariant{13141}, cancelled, CVariant{""}, CVariant{""}, CVariant{10000})
           || cancelled)
       {
         CLog::Log(LOGNOTICE, "ES: Not stopping event server");

--- a/xbmc/network/TCPServer.h
+++ b/xbmc/network/TCPServer.h
@@ -30,6 +30,8 @@
 #include "threads/Thread.h"
 #include "websocket/WebSocket.h"
 
+class CVariant;
+
 namespace JSONRPC
 {
   class CTCPServer : public ITransportLayer, public JSONRPC::IJSONRPCAnnouncer, public CThread

--- a/xbmc/network/WakeOnAccess.cpp
+++ b/xbmc/network/WakeOnAccess.cpp
@@ -40,6 +40,7 @@
 #include "utils/XMLUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/StringUtils.h"
+#include "utils/Variant.h"
 
 #include "WakeOnAccess.h"
 
@@ -167,16 +168,15 @@ public:
 
     if (m_dialog)
     {
-      m_dialog->SetHeading (heading); 
-      m_dialog->SetLine(0, "");
-      m_dialog->SetLine(1, "");
-      m_dialog->SetLine(2, "");
+      m_dialog->SetHeading(CVariant{heading}); 
+      m_dialog->SetLine(0, CVariant{""});
+      m_dialog->SetLine(1, CVariant{""});
+      m_dialog->SetLine(2, CVariant{""});
 
       int nest_level = NestDetect::Level();
       if (nest_level > 1)
       {
-        std::string nest = StringUtils::Format("Nesting:%d", nest_level);
-        m_dialog->SetLine(2, nest);
+        m_dialog->SetLine(2, CVariant{StringUtils::Format("Nesting:%d", nest_level)});
       }
     }
   }
@@ -196,7 +196,7 @@ public:
 
     if (m_dialog)
     {
-      m_dialog->SetLine(1, line1);
+      m_dialog->SetLine(1, CVariant{line1});
 
       m_dialog->SetPercentage(1); // avoid flickering by starting at 1% ..
     }

--- a/xbmc/network/WebServer.h
+++ b/xbmc/network/WebServer.h
@@ -33,6 +33,7 @@ namespace XFILE
   class CFile;
 }
 class CDateTime;
+class CVariant;
 
 class CWebServer : public JSONRPC::ITransportLayer
 {

--- a/xbmc/network/httprequesthandler/HTTPJsonRpcHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPJsonRpcHandler.cpp
@@ -25,6 +25,7 @@
 #include "network/WebServer.h"
 #include "utils/JSONVariantWriter.h"
 #include "utils/log.h"
+#include "utils/Variant.h"
 
 #define MAX_STRING_POST_SIZE 20000
 

--- a/xbmc/network/test/TestWebServer.cpp
+++ b/xbmc/network/test/TestWebServer.cpp
@@ -33,6 +33,7 @@
 #include "utils/JSONVariantParser.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
+#include "utils/Variant.h"
 
 using namespace XFILE;
 

--- a/xbmc/network/upnp/UPnPPlayer.cpp
+++ b/xbmc/network/upnp/UPnPPlayer.cpp
@@ -29,6 +29,7 @@
 #include "threads/Event.h"
 #include "utils/log.h"
 #include "utils/TimeUtils.h"
+#include "utils/Variant.h"
 #include "GUIInfoManager.h"
 #include "ThumbLoader.h"
 #include "video/VideoThumbLoader.h"
@@ -603,7 +604,7 @@ bool CUPnPPlayer::OnAction(const CAction &action)
     case ACTION_STOP:
       if(IsPlaying())
       {
-        if(CGUIDialogYesNo::ShowAndGetInput(37022, 37023)) /* stop on remote system */
+        if(CGUIDialogYesNo::ShowAndGetInput(CVariant{37022}, CVariant{37023})) /* stop on remote system */
           m_stopremote = true;
         else
           m_stopremote = false;

--- a/xbmc/network/upnp/UPnPRenderer.h
+++ b/xbmc/network/upnp/UPnPRenderer.h
@@ -22,6 +22,8 @@
 
 #include "interfaces/IAnnouncer.h"
 
+class CVariant;
+
 namespace UPNP
 {
 

--- a/xbmc/network/upnp/UPnPServer.cpp
+++ b/xbmc/network/upnp/UPnPServer.cpp
@@ -40,6 +40,7 @@
 #include "utils/SortUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
+#include "utils/Variant.h"
 #include "Util.h"
 #include "music/MusicDatabase.h"
 #include "video/VideoDatabase.h"

--- a/xbmc/network/upnp/UPnPServer.h
+++ b/xbmc/network/upnp/UPnPServer.h
@@ -23,6 +23,7 @@
 #include "interfaces/IAnnouncer.h"
 #include "FileItem.h"
 
+class CVariant;
 class CThumbLoader;
 class PLT_MediaObject;
 class PLT_HttpRequestContext;

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.h
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.h
@@ -58,6 +58,7 @@ namespace PERIPHERALS
 #include <libcec/cectypes.h>
 
 class DllLibCEC;
+class CVariant;
 
 namespace CEC
 {

--- a/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.cpp
+++ b/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.cpp
@@ -26,6 +26,7 @@
 #include "settings/lib/Setting.h"
 #include "settings/lib/SettingSection.h"
 #include "utils/log.h"
+#include "utils/Variant.h"
 
 #define CONTROL_BUTTON_DEFAULTS 50
 
@@ -106,7 +107,7 @@ void CGUIDialogPeripheralSettings::OnResetSettings()
   if (peripheral == NULL)
     return;
 
-  if (!CGUIDialogYesNo::ShowAndGetInput(10041, 10042))
+  if (!CGUIDialogYesNo::ShowAndGetInput(CVariant{10041}, CVariant{10042}))
     return;
 
   // reset the settings in the peripheral

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -38,6 +38,7 @@
 #include "settings/Settings.h"
 #include "utils/log.h"
 #include "utils/URIUtils.h"
+#include "utils/Variant.h"
 #include "Autorun.h"
 #include "interfaces/AnnouncementManager.h"
 #include "utils/SortUtils.h"
@@ -234,10 +235,10 @@ void CGUIWindowPictures::OnPrepareFileItems(CFileItemList& items)
       { // tag loading takes more then 1.5 secs, show a progress dialog
         CURL url(items.GetPath());
 
-        m_dlgProgress->SetHeading(189);
-        m_dlgProgress->SetLine(0, 505);
-        m_dlgProgress->SetLine(1, "");
-        m_dlgProgress->SetLine(2, url.GetWithoutUserDetails());
+        m_dlgProgress->SetHeading(CVariant{189});
+        m_dlgProgress->SetLine(0, CVariant{505});
+        m_dlgProgress->SetLine(1, CVariant{""});
+        m_dlgProgress->SetLine(2, CVariant{url.GetWithoutUserDetails()});
         m_dlgProgress->StartModal();
         m_dlgProgress->ShowProgressBar(true);
         bProgressVisible = true;
@@ -566,7 +567,7 @@ void CGUIWindowPictures::LoadPlayList(const std::string& strPlayList)
   {
     if (!pPlayList->Load(strPlayList))
     {
-      CGUIDialogOK::ShowAndGetInput(6, 477);
+      CGUIDialogOK::ShowAndGetInput(CVariant{6}, CVariant{477});
       return ; //hmmm unable to load playlist?
     }
   }

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -41,6 +41,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "threads/SingleLock.h"
 #include "utils/log.h"
+#include "utils/Variant.h"
 #include "interfaces/AnnouncementManager.h"
 #include "pictures/GUIViewStatePictures.h"
 #include "pictures/PictureThumbLoader.h"

--- a/xbmc/pictures/PictureInfoTag.h
+++ b/xbmc/pictures/PictureInfoTag.h
@@ -89,6 +89,8 @@
 #define SLIDE_IPTC_COUNTRY_CODE     979
 #define SLIDE_IPTC_REF_SERVICE      980
 
+class CVariant;
+
 class CPictureInfoTag : public IArchivable, public ISerializable, public ISortable
 {
 public:

--- a/xbmc/profiles/ProfilesManager.cpp
+++ b/xbmc/profiles/ProfilesManager.cpp
@@ -45,6 +45,7 @@
 #include "utils/log.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
+#include "utils/Variant.h"
 #include "utils/XMLUtils.h"
 
 // TODO
@@ -294,13 +295,11 @@ bool CProfilesManager::DeleteProfile(size_t index)
   if (dlgYesNo == NULL)
     return false;
 
-  string message;
   string str = g_localizeStrings.Get(13201);
-  message = StringUtils::Format(str.c_str(), profile->getName().c_str());
-  dlgYesNo->SetHeading(13200);
-  dlgYesNo->SetLine(0, message);
-  dlgYesNo->SetLine(1, "");
-  dlgYesNo->SetLine(2, "");
+  dlgYesNo->SetHeading(CVariant{13200});
+  dlgYesNo->SetLine(0, CVariant{StringUtils::Format(str.c_str(), profile->getName().c_str())});
+  dlgYesNo->SetLine(1, CVariant{""});
+  dlgYesNo->SetLine(2, CVariant{""});
   dlgYesNo->DoModal();
 
   if (!dlgYesNo->IsConfirmed())

--- a/xbmc/profiles/dialogs/GUIDialogProfileSettings.cpp
+++ b/xbmc/profiles/dialogs/GUIDialogProfileSettings.cpp
@@ -36,6 +36,7 @@
 #include "utils/log.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
+#include "utils/Variant.h"
 
 #define CONTROL_PROFILE_IMAGE         CONTROL_SETTINGS_CUSTOM + 1
 #define CONTROL_PROFILE_NAME          CONTROL_SETTINGS_CUSTOM + 2
@@ -87,7 +88,7 @@ bool CGUIDialogProfileSettings::ShowForProfile(unsigned int iProfile, bool first
 
     // prompt for a name
     std::string profileName;
-    if (!CGUIKeyboardFactory::ShowAndGetInput(profileName, g_localizeStrings.Get(20093),false) || profileName.empty())
+    if (!CGUIKeyboardFactory::ShowAndGetInput(profileName, CVariant{g_localizeStrings.Get(20093)}, false) || profileName.empty())
       return false;
     dialog->m_name = profileName;
 
@@ -142,7 +143,7 @@ bool CGUIDialogProfileSettings::ShowForProfile(unsigned int iProfile, bool first
       CProfilesManager::Get().AddProfile(profile);
       bool exists = XFILE::CFile::Exists(URIUtils::AddFileToFolder("special://masterprofile/", dialog->m_directory + "/guisettings.xml"));
 
-      if (exists && !CGUIDialogYesNo::ShowAndGetInput(20058, 20104))
+      if (exists && !CGUIDialogYesNo::ShowAndGetInput(CVariant{20058}, CVariant{20104}))
         exists = false;
 
       if (!exists)
@@ -150,7 +151,7 @@ bool CGUIDialogProfileSettings::ShowForProfile(unsigned int iProfile, bool first
         // copy masterprofile guisettings to new profile guisettings
         // If the user selects 'start fresh', do nothing as a fresh
         // guisettings.xml will be created on first profile use.
-        if (CGUIDialogYesNo::ShowAndGetInput(20058, 20048, "", "", 20044, 20064))
+        if (CGUIDialogYesNo::ShowAndGetInput(CVariant{20058}, CVariant{20048}, CVariant{""}, CVariant{""}, CVariant{20044}, CVariant{20064}))
         {
           XFILE::CFile::Copy(URIUtils::AddFileToFolder("special://masterprofile/", "guisettings.xml"),
                               URIUtils::AddFileToFolder("special://masterprofile/", dialog->m_directory + "/guisettings.xml"));
@@ -158,7 +159,7 @@ bool CGUIDialogProfileSettings::ShowForProfile(unsigned int iProfile, bool first
       }
 
       exists = XFILE::CFile::Exists(URIUtils::AddFileToFolder("special://masterprofile/", dialog->m_directory + "/sources.xml"));
-      if (exists && !CGUIDialogYesNo::ShowAndGetInput(20058, 20106))
+      if (exists && !CGUIDialogYesNo::ShowAndGetInput(CVariant{20058}, CVariant{20106}))
         exists = false;
 
       if (!exists)
@@ -166,7 +167,7 @@ bool CGUIDialogProfileSettings::ShowForProfile(unsigned int iProfile, bool first
         if ((dialog->m_sourcesMode & 2) == 2)
           // prompt user to copy masterprofile's sources.xml file
           // If 'start fresh' (no) is selected, do nothing.
-          if (CGUIDialogYesNo::ShowAndGetInput(20058, 20071, "", "", 20044, 20064))
+          if (CGUIDialogYesNo::ShowAndGetInput(CVariant{20058}, CVariant{20071}, CVariant{""}, CVariant{""}, CVariant{20044}, CVariant{20064}))
           {
             XFILE::CFile::Copy(URIUtils::AddFileToFolder("special://masterprofile/", "sources.xml"),
                                 URIUtils::AddFileToFolder("special://masterprofile/", dialog->m_directory + "/sources.xml"));
@@ -277,7 +278,7 @@ void CGUIDialogProfileSettings::OnSettingAction(const CSetting *setting)
     {
       if (CProfilesManager::Get().GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE && !m_isDefault)
       {
-        if (CGUIDialogYesNo::ShowAndGetInput(20066, 20118))
+        if (CGUIDialogYesNo::ShowAndGetInput(CVariant{20066}, CVariant{20118}))
           g_passwordManager.SetMasterLockMode(false);
         if (CProfilesManager::Get().GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE)
           return;

--- a/xbmc/profiles/windows/GUIWindowSettingsProfile.cpp
+++ b/xbmc/profiles/windows/GUIWindowSettingsProfile.cpp
@@ -35,6 +35,7 @@
 #include "FileItem.h"
 #include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
+#include "utils/Variant.h"
 
 using namespace XFILE;
 
@@ -258,7 +259,7 @@ bool CGUIWindowSettingsProfile::GetAutoLoginProfileChoice(int &iProfile)
     items.Add(item);
   }
 
-  dialog->SetHeading(20093); // Profile name
+  dialog->SetHeading(CVariant{20093}); // Profile name
   dialog->Reset();
   dialog->SetItems(&items);
   dialog->SetSelected(autoLoginProfileId);

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -40,6 +40,7 @@
 #include "utils/Stopwatch.h"
 #include "utils/StringUtils.h"
 #include "utils/JobManager.h"
+#include "utils/Variant.h"
 #include "interfaces/AnnouncementManager.h"
 #include "video/VideoDatabase.h"
 #include "network/Network.h"
@@ -183,7 +184,7 @@ void CPVRManager::OnSettingAction(const CSetting *setting)
   else if (settingId == "pvrmanager.resetdb")
   {
     if (CheckParentalPIN(g_localizeStrings.Get(19262)) &&
-        CGUIDialogYesNo::ShowAndGetInput(19098, 19186))
+        CGUIDialogYesNo::ShowAndGetInput(CVariant{19098}, CVariant{19186}))
     {
       CDateTime::ResetTimezoneBias();
       ResetDatabase(false);
@@ -191,7 +192,7 @@ void CPVRManager::OnSettingAction(const CSetting *setting)
   }
   else if (settingId == "epg.resetepg")
   {
-    if (CGUIDialogYesNo::ShowAndGetInput(19098, 19188))
+    if (CGUIDialogYesNo::ShowAndGetInput(CVariant{19098}, CVariant{19188}))
     {
       CDateTime::ResetTimezoneBias();
       ResetDatabase(true);
@@ -768,9 +769,9 @@ void CPVRManager::ResetDatabase(bool bResetEPGOnly /* = false */)
   g_EpgContainer.Stop();
 
   CGUIDialogProgress* pDlgProgress = (CGUIDialogProgress*)g_windowManager.GetWindow(WINDOW_DIALOG_PROGRESS);
-  pDlgProgress->SetLine(0, "");
-  pDlgProgress->SetLine(1, g_localizeStrings.Get(19186)); // All data in the PVR database is being erased
-  pDlgProgress->SetLine(2, "");
+  pDlgProgress->SetLine(0, CVariant{""});
+  pDlgProgress->SetLine(1, CVariant{g_localizeStrings.Get(19186)}); // All data in the PVR database is being erased
+  pDlgProgress->SetLine(2, CVariant{""});
   pDlgProgress->StartModal();
   pDlgProgress->Progress();
 
@@ -894,7 +895,7 @@ bool CPVRManager::ToggleRecordingOnChannel(unsigned int iChannelId)
     {
       bReturn = m_timers->InstantTimer(channel);
       if (!bReturn)
-        CGUIDialogOK::ShowAndGetInput(19033, 19164);
+        CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{19164});
     }
     else
     {
@@ -921,7 +922,7 @@ bool CPVRManager::StartRecordingOnPlayingChannel(bool bOnOff)
     {
       bReturn = m_timers->InstantTimer(channel);
       if (!bReturn)
-        CGUIDialogOK::ShowAndGetInput(19033, 19164);
+        CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{19164});
     }
     else if (!bOnOff && channel->IsRecording())
     {
@@ -978,7 +979,7 @@ bool CPVRManager::CheckParentalPIN(const std::string& strTitle /* = "" */)
   bool bValidPIN = CGUIDialogNumeric::ShowAndVerifyInput(pinCode, !strTitle.empty() ? strTitle : g_localizeStrings.Get(19263), true);
   if (!bValidPIN)
     // display message: The entered PIN number was incorrect
-    CGUIDialogOK::ShowAndGetInput(19264, 19265);
+    CGUIDialogOK::ShowAndGetInput(CVariant{19264}, CVariant{19265});
   else if (m_parentalTimer)
   {
     // reset the timer
@@ -1488,12 +1489,12 @@ bool CPVRManager::CanSystemPowerdown(bool bAskUser /*= true*/) const
 
         // Inform user about PVR being busy. Ask if user wants to powerdown anyway.
         bool bCanceled = false;
-        bReturn = CGUIDialogYesNo::ShowAndGetInput(19685, // "Confirm shutdown"
-                                                   text,
+        bReturn = CGUIDialogYesNo::ShowAndGetInput(CVariant{19685}, // "Confirm shutdown"
+                                                   CVariant{text},
                                                    bCanceled,
-                                                   222,   // "Cancel"
-                                                   19696, // "Shutdown anyway"
-                                                   10000);
+                                                   CVariant{222},   // "Cancel"
+                                                   CVariant{19696}, // "Shutdown anyway"
+                                                   CVariant{10000});
       }
       else
         bReturn = false; // do not powerdown (busy, but no user interaction requested).

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -35,6 +35,7 @@ class CGUIDialogProgressBarHandle;
 class CStopWatch;
 class CAction;
 class CFileItemList;
+class CVariant;
 
 namespace EPG
 {

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -33,6 +33,7 @@
 #include "settings/Settings.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
+#include "utils/Variant.h"
 
 #include <assert.h>
 
@@ -1919,10 +1920,10 @@ bool CPVRClient::Autoconfigure(void)
         std::string strLogLine(StringUtils::Format(g_localizeStrings.Get(19689).c_str(), (*it).GetName().c_str(), (*it).GetIP().c_str()));
         CLog::Log(LOGDEBUG, "%s - %s", __FUNCTION__, strLogLine.c_str());
 
-        if (!CGUIDialogYesNo::ShowAndGetInput(19688, // Scanning for PVR services
-                                              strLogLine,
-                                              19690, // Do you want to use this service?
-                                              ""))
+        if (!CGUIDialogYesNo::ShowAndGetInput(CVariant{19688}, // Scanning for PVR services
+                                              CVariant{strLogLine},
+                                              CVariant{19690}, // Do you want to use this service?
+                                              CVariant{""}))
         {
           CLog::Log(LOGDEBUG, "%s - %s service found but not enabled by the user", __FUNCTION__, (*it).GetName().c_str());
           m_rejectedAvahiHosts.push_back(*it);

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -33,6 +33,7 @@
 #include "pvr/channels/PVRChannelGroupInternal.h"
 #include "pvr/recordings/PVRRecordings.h"
 #include "pvr/timers/PVRTimers.h"
+#include "utils/Variant.h"
 
 #include <assert.h>
 
@@ -627,8 +628,8 @@ PVR_ERROR CPVRClients::DeleteAllRecordingsFromTrash()
     // have user select client
     CGUIDialogSelect* pDialog = (CGUIDialogSelect*)g_windowManager.GetWindow(WINDOW_DIALOG_SELECT);
     pDialog->Reset();
-    pDialog->SetHeading(19292);                 /* Delete all permanently */
-    pDialog->Add(g_localizeStrings.Get(24032)); /* All Add-ons */
+    pDialog->SetHeading(CVariant{19292});       //Delete all permanently
+    pDialog->Add(g_localizeStrings.Get(24032)); // All Add-ons
 
     PVR_CLIENTMAP_CITR itrClients;
     for (itrClients = clients.begin(); itrClients != clients.end(); ++itrClients)
@@ -870,7 +871,7 @@ void CPVRClients::ProcessMenuHooks(int iClientID, PVR_MENUHOOK_CAT cat, const CF
       // have user select client
       CGUIDialogSelect* pDialog = (CGUIDialogSelect*)g_windowManager.GetWindow(WINDOW_DIALOG_SELECT);
       pDialog->Reset();
-      pDialog->SetHeading(19196);
+      pDialog->SetHeading(CVariant{19196});
 
       PVR_CLIENTMAP_CITR itrClients;
       for (itrClients = clients.begin(); itrClients != clients.end(); itrClients++)
@@ -902,7 +903,7 @@ void CPVRClients::ProcessMenuHooks(int iClientID, PVR_MENUHOOK_CAT cat, const CF
 
     CGUIDialogSelect* pDialog = (CGUIDialogSelect*)g_windowManager.GetWindow(WINDOW_DIALOG_SELECT);
     pDialog->Reset();
-    pDialog->SetHeading(19196);
+    pDialog->SetHeading(CVariant{19196});
     for (unsigned int i = 0; i < hooks->size(); i++)
       if (hooks->at(i).category == cat || hooks->at(i).category == PVR_MENUHOOK_ALL)
       {
@@ -953,7 +954,7 @@ void CPVRClients::StartChannelScan(void)
     CGUIDialogSelect* pDialog= (CGUIDialogSelect*)g_windowManager.GetWindow(WINDOW_DIALOG_SELECT);
 
     pDialog->Reset();
-    pDialog->SetHeading(19119);
+    pDialog->SetHeading(CVariant{19119});
 
     for (unsigned int i = 0; i < possibleScanClients.size(); i++)
       pDialog->Add(possibleScanClients[i]->GetFriendlyName());
@@ -972,7 +973,7 @@ void CPVRClients::StartChannelScan(void)
   /* no clients found */
   else if (!scanClient)
   {
-    CGUIDialogOK::ShowAndGetInput(19033, 19192);
+    CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{19192});
     return;
   }
 
@@ -987,7 +988,7 @@ void CPVRClients::StartChannelScan(void)
   /* do the scan */
   if (scanClient->StartChannelScan() != PVR_ERROR_NO_ERROR)
     /* an error occured */
-    CGUIDialogOK::ShowAndGetInput(19111, 19193);
+    CGUIDialogOK::ShowAndGetInput(CVariant{19111}, CVariant{19193});
 
   /* restart the supervisor thread */
   g_PVRManager.StartUpdateThreads();
@@ -1026,7 +1027,7 @@ bool CPVRClients::OpenDialogChannelAdd(const CPVRChannelPtr &channel)
 
   if (error == PVR_ERROR_NOT_IMPLEMENTED)
   {
-    CGUIDialogOK::ShowAndGetInput(19033, 19038);
+    CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{19038});
     return true;
   }
 
@@ -1045,7 +1046,7 @@ bool CPVRClients::OpenDialogChannelSettings(const CPVRChannelPtr &channel)
 
   if (error == PVR_ERROR_NOT_IMPLEMENTED)
   {
-    CGUIDialogOK::ShowAndGetInput(19033, 19038);
+    CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{19038});
     return true;
   }
 
@@ -1064,7 +1065,7 @@ bool CPVRClients::DeleteChannel(const CPVRChannelPtr &channel)
 
   if (error == PVR_ERROR_NOT_IMPLEMENTED)
   {
-    CGUIDialogOK::ShowAndGetInput(19033, 19038);
+    CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{19038});
     return true;
   }
 
@@ -1212,7 +1213,7 @@ bool CPVRClients::UpdateAndInitialiseClients(bool bInitialiseAllClients /* = fal
       }
 
       if (bDisabled && (g_PVRManager.IsStarted() || g_PVRManager.IsInitialising()))
-        CGUIDialogOK::ShowAndGetInput(24070, 16029);
+        CGUIDialogOK::ShowAndGetInput(CVariant{24070}, CVariant{16029});
     }
   }
 
@@ -1344,7 +1345,7 @@ void CPVRClients::ShowDialogNoClientsEnabled(void)
   if (!g_PVRManager.IsStarted() && !g_PVRManager.IsInitialising())
     return;
 
-  CGUIDialogOK::ShowAndGetInput(19240, 19241);
+  CGUIDialogOK::ShowAndGetInput(CVariant{19240}, CVariant{19241});
 
   std::vector<std::string> params;
   params.push_back("addons://disabled/xbmc.pvrclient");
@@ -1398,7 +1399,7 @@ bool CPVRClients::UpdateAddons(void)
     // You need a tuner, backend software, and an add-on for the backend to be able to use PVR.
     // Please visit http://kodi.wiki/view/PVR to learn more.
     m_bNoAddonWarningDisplayed = true;
-    CGUIDialogOK::ShowAndGetInput(19271, 19272);
+    CGUIDialogOK::ShowAndGetInput(CVariant{19271}, CVariant{19272});
     CSettings::Get().SetBool("pvrmanager.enabled", false);
     CGUIMessage msg(GUI_MSG_UPDATE, WINDOW_SETTINGS_MYPVR, 0);
     g_windowManager.SendThreadMessage(msg, WINDOW_SETTINGS_MYPVR);

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -23,6 +23,7 @@
 #include "utils/log.h"
 #include "filesystem/File.h"
 #include "utils/StringUtils.h"
+#include "utils/Variant.h"
 #include "threads/SingleLock.h"
 
 #include "pvr/channels/PVRChannelGroupInternal.h"

--- a/xbmc/pvr/channels/PVRChannel.h
+++ b/xbmc/pvr/channels/PVRChannel.h
@@ -30,6 +30,8 @@
 
 #define PVR_INVALID_CHANNEL_UID -1
 
+class CVariant;
+
 namespace EPG
 {
   class CEpg;

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
@@ -23,6 +23,7 @@
 #include "dialogs/GUIDialogOK.h"
 #include "settings/AdvancedSettings.h"
 #include "utils/log.h"
+#include "utils/Variant.h"
 
 #include "pvr/PVRDatabase.h"
 #include "pvr/PVRManager.h"
@@ -169,7 +170,7 @@ bool CPVRChannelGroupInternal::RemoveFromGroup(const CPVRChannelPtr &channel)
   CPVRChannelPtr currentChannel(g_PVRManager.GetCurrentChannel());
   if (currentChannel && currentChannel == channel)
   {
-    CGUIDialogOK::ShowAndGetInput(19098, 19102);
+    CGUIDialogOK::ShowAndGetInput(CVariant{19098}, CVariant{19102});
     return false;
   }
 

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -39,6 +39,7 @@
 #include "settings/Settings.h"
 #include "storage/MediaManager.h"
 #include "utils/StringUtils.h"
+#include "utils/Variant.h"
 
 #define BUTTON_OK                 4
 #define BUTTON_APPLY              5
@@ -237,10 +238,10 @@ bool CGUIDialogPVRChannelManager::OnClickButtonRadioTV(CGUIMessage &message)
     if (!pDialog)
       return true;
 
-    pDialog->SetHeading(20052);
-    pDialog->SetLine(0, "");
-    pDialog->SetLine(1, 19212);
-    pDialog->SetLine(2, 20103);
+    pDialog->SetHeading(CVariant{20052});
+    pDialog->SetLine(0, CVariant{""});
+    pDialog->SetLine(1, CVariant{19212});
+    pDialog->SetLine(2, CVariant{20103});
     pDialog->DoModal();
 
     if (pDialog->IsConfirmed())
@@ -447,7 +448,7 @@ bool CGUIDialogPVRChannelManager::OnClickButtonNewChannel()
     if (!pDlgSelect)
       return false;
 
-    pDlgSelect->SetHeading(19213); // Select Client
+    pDlgSelect->SetHeading(CVariant{19213}); // Select Client
 
     PVR_CLIENT_ITR itr;
     for (itr = m_clientsWithSettingsList.begin() ; itr != m_clientsWithSettingsList.end(); ++itr)
@@ -469,7 +470,7 @@ bool CGUIDialogPVRChannelManager::OnClickButtonNewChannel()
     if (g_PVRClients->OpenDialogChannelAdd(channel))
       Update();
     else
-      CGUIDialogOK::ShowAndGetInput(2103, 16029);  // Add-on error;Check the log file for details.
+      CGUIDialogOK::ShowAndGetInput(CVariant{2103}, CVariant{16029});  // Add-on error;Check the log file for details.
   }
   return true;
 }
@@ -596,7 +597,7 @@ bool CGUIDialogPVRChannelManager::OnContextButton(int itemNumber, CONTEXT_BUTTON
   else if (button == CONTEXT_BUTTON_SETTINGS)
   {
     if (!g_PVRClients->OpenDialogChannelSettings(pItem->GetPVRChannelInfoTag()))
-      CGUIDialogOK::ShowAndGetInput(2103, 16029);  // Add-on error;Check the log file for details.
+      CGUIDialogOK::ShowAndGetInput(CVariant{2103}, CVariant{16029});  // Add-on error;Check the log file for details.
   }
   else if (button == CONTEXT_BUTTON_DELETE)
   {
@@ -604,8 +605,8 @@ bool CGUIDialogPVRChannelManager::OnContextButton(int itemNumber, CONTEXT_BUTTON
     if (!pDialog)
       return true;
 
-    pDialog->SetHeading(19211); // Delete channel
-    pDialog->SetText(750);      // Are you sure?
+    pDialog->SetHeading(CVariant{19211}); // Delete channel
+    pDialog->SetText(CVariant{750});      // Are you sure?
     pDialog->DoModal();
 
     if (pDialog->IsConfirmed())
@@ -619,13 +620,13 @@ bool CGUIDialogPVRChannelManager::OnContextButton(int itemNumber, CONTEXT_BUTTON
         Renumber();
       }
       else
-        CGUIDialogOK::ShowAndGetInput(2103, 16029);  // Add-on error;Check the log file for details.
+        CGUIDialogOK::ShowAndGetInput(CVariant{2103}, CVariant{16029});  // Add-on error;Check the log file for details.
     }
   }
   else if (button == CONTEXT_BUTTON_EDIT_SOURCE)
   {
     std::string strURL = pItem->GetProperty("StreamURL").asString();
-    if (CGUIKeyboardFactory::ShowAndGetInput(strURL, g_localizeStrings.Get(19214), false))
+    if (CGUIKeyboardFactory::ShowAndGetInput(strURL, CVariant{g_localizeStrings.Get(19214)}, false))
       pItem->SetProperty("StreamURL", strURL);
   }
   return true;
@@ -727,7 +728,7 @@ void CGUIDialogPVRChannelManager::RenameChannel(CFileItemPtr pItem)
     channel->SetChannelName(strChannelName);
 
     if (!g_PVRClients->RenameChannel(channel))
-      CGUIDialogOK::ShowAndGetInput(2103, 16029);  // Add-on error;Check the log file for details.
+      CGUIDialogOK::ShowAndGetInput(CVariant{2103}, CVariant{16029});  // Add-on error;Check the log file for details.
   }
 }
 
@@ -756,10 +757,10 @@ void CGUIDialogPVRChannelManager::SaveList(void)
 
   /* display the progress dialog */
   CGUIDialogProgress* pDlgProgress = (CGUIDialogProgress*)g_windowManager.GetWindow(WINDOW_DIALOG_PROGRESS);
-  pDlgProgress->SetHeading(190);
-  pDlgProgress->SetLine(0, "");
-  pDlgProgress->SetLine(1, 328);
-  pDlgProgress->SetLine(2, "");
+  pDlgProgress->SetHeading(CVariant{190});
+  pDlgProgress->SetLine(0, CVariant{""});
+  pDlgProgress->SetLine(1, CVariant{328});
+  pDlgProgress->SetLine(2, CVariant{""});
   pDlgProgress->StartModal();
   pDlgProgress->Progress();
   pDlgProgress->SetPercentage(0);

--- a/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
@@ -28,6 +28,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "guilib/GUIRadioButtonControl.h"
 #include "utils/StringUtils.h"
+#include "utils/Variant.h"
 
 #include "pvr/PVRManager.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
@@ -100,7 +101,7 @@ bool CGUIDialogPVRGroupManager::ActionButtonNewGroup(CGUIMessage &message)
   {
     std::string strGroupName = "";
     /* prompt for a group name */
-    if (CGUIKeyboardFactory::ShowAndGetInput(strGroupName, g_localizeStrings.Get(19139), false))
+    if (CGUIKeyboardFactory::ShowAndGetInput(strGroupName, CVariant{g_localizeStrings.Get(19139)}, false))
     {
       if (strGroupName != "")
       {
@@ -134,10 +135,10 @@ bool CGUIDialogPVRGroupManager::ActionButtonDeleteGroup(CGUIMessage &message)
     if (!pDialog)
       return bReturn;
 
-    pDialog->SetHeading(117);
-    pDialog->SetLine(0, "");
-    pDialog->SetLine(1, m_selectedGroup->GroupName());
-    pDialog->SetLine(2, "");
+    pDialog->SetHeading(CVariant{117});
+    pDialog->SetLine(0, CVariant{""});
+    pDialog->SetLine(1, CVariant{m_selectedGroup->GroupName()});
+    pDialog->SetLine(2, CVariant{""});
     pDialog->DoModal();
 
     if (pDialog->IsConfirmed())
@@ -163,7 +164,7 @@ bool CGUIDialogPVRGroupManager::ActionButtonRenameGroup(CGUIMessage &message)
       return bReturn;
 
     std::string strGroupName(m_selectedGroup->GroupName());
-    if (CGUIKeyboardFactory::ShowAndGetInput(strGroupName, g_localizeStrings.Get(19139), false))
+    if (CGUIKeyboardFactory::ShowAndGetInput(strGroupName, CVariant{g_localizeStrings.Get(19139)}, false))
     {
       if (strGroupName != "")
       {
@@ -192,7 +193,7 @@ bool CGUIDialogPVRGroupManager::ActionButtonUngroupedChannels(CGUIMessage &messa
     {
       if (m_channelGroups->GetFolderCount() == 0)
       {
-        CGUIDialogOK::ShowAndGetInput(19033, 19137);
+        CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{19137});
       }
       else if (m_ungroupedChannels->GetFileCount() > 0)
       {

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
@@ -95,21 +95,21 @@ bool CGUIDialogPVRGuideInfo::ActionCancelTimer(CFileItemPtr timer)
     // prompt user for confirmation for deleting the complete repeating timer, including scheduled timers.
     bool bCancel(false);
     bDeleteScheduled = CGUIDialogYesNo::ShowAndGetInput(
-                        CVariant{122}, // "Confirm delete"
-                        CVariant{840}, // "You are about to delete a repeating timer. Do you also want to delete all timers currently scheduled by this timer?"
-                        CVariant{""},
-                        CVariant{timer->GetPVRTimerInfoTag()->Title()},
-                        bCancel);
+                                                        CVariant{122}, // "Confirm delete"
+                                                        CVariant{840}, // "You are about to delete a repeating timer. Do you also want to delete all timers currently scheduled by this timer?"
+                                                        CVariant{""},
+                                                        CVariant{timer->GetPVRTimerInfoTag()->Title()},
+                                                        bCancel);
     bDelete = !bCancel;
   }
   else
   {
     // prompt user for confirmation for deleting the timer
     bDelete = CGUIDialogYesNo::ShowAndGetInput(
-                        CVariant{122}, // "Confirm delete"
-                        CVariant{19040}, // Timer
-                        CVariant{""},
-                        CVariant{timer->GetPVRTimerInfoTag()->Title()});
+                                               CVariant{122}, // "Confirm delete"
+                                               CVariant{19040}, // Timer
+                                               CVariant{""},
+                                               CVariant{timer->GetPVRTimerInfoTag()->Title()});
     bDeleteScheduled = false;
   }
 

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
@@ -25,6 +25,7 @@
 #include "dialogs/GUIDialogYesNo.h"
 #include "guilib/LocalizeStrings.h"
 #include "utils/StringUtils.h"
+#include "utils/Variant.h"
 
 #include "pvr/PVRManager.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
@@ -32,6 +33,8 @@
 #include "pvr/timers/PVRTimers.h"
 #include "pvr/timers/PVRTimerInfoTag.h"
 #include "pvr/windows/GUIWindowPVRBase.h"
+
+#include <utility>
 
 using namespace PVR;
 using namespace EPG;
@@ -64,7 +67,7 @@ bool CGUIDialogPVRGuideInfo::ActionStartTimer(const CEpgInfoTagPtr &tag)
     return false;
 
   // prompt user for confirmation of channel record
-  if (CGUIDialogYesNo::ShowAndGetInput( 264 /* "Record" */, tag->Title()))
+  if (CGUIDialogYesNo::ShowAndGetInput(CVariant{264} /* "Record" */, CVariant{tag->Title()}))
   {
     Close();
 
@@ -92,10 +95,10 @@ bool CGUIDialogPVRGuideInfo::ActionCancelTimer(CFileItemPtr timer)
     // prompt user for confirmation for deleting the complete repeating timer, including scheduled timers.
     bool bCancel(false);
     bDeleteScheduled = CGUIDialogYesNo::ShowAndGetInput(
-                        122, // "Confirm delete"
-                        840, // "You are about to delete a repeating timer. Do you also want to delete all timers currently scheduled by this timer?"
-                        "",
-                        timer->GetPVRTimerInfoTag()->Title(),
+                        CVariant{122}, // "Confirm delete"
+                        CVariant{840}, // "You are about to delete a repeating timer. Do you also want to delete all timers currently scheduled by this timer?"
+                        CVariant{""},
+                        CVariant{timer->GetPVRTimerInfoTag()->Title()},
                         bCancel);
     bDelete = !bCancel;
   }
@@ -103,10 +106,10 @@ bool CGUIDialogPVRGuideInfo::ActionCancelTimer(CFileItemPtr timer)
   {
     // prompt user for confirmation for deleting the timer
     bDelete = CGUIDialogYesNo::ShowAndGetInput(
-                        122, // "Confirm delete"
-                        19040, // Timer
-                        "",
-                        timer->GetPVRTimerInfoTag()->Title());
+                        CVariant{122}, // "Confirm delete"
+                        CVariant{19040}, // Timer
+                        CVariant{""},
+                        CVariant{timer->GetPVRTimerInfoTag()->Title()});
     bDeleteScheduled = false;
   }
 
@@ -144,7 +147,7 @@ bool CGUIDialogPVRGuideInfo::OnClickButtonRecord(CGUIMessage &message)
     if (!tag || !tag->HasPVRChannel())
     {
       /* invalid channel */
-      CGUIDialogOK::ShowAndGetInput(19033, 19067);
+      CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{19067});
       Close();
       return bReturn;
     }
@@ -184,7 +187,7 @@ bool CGUIDialogPVRGuideInfo::OnClickButtonPlay(CGUIMessage &message)
     if (ret == PLAYBACK_FAIL)
     {
       std::string msg = StringUtils::Format(g_localizeStrings.Get(19035).c_str(), g_localizeStrings.Get(19029).c_str()); // Channel could not be played. Check the log for details.
-      CGUIDialogOK::ShowAndGetInput(19033, msg);
+      CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{std::move(msg)});
     }
     else if (ret == PLAYBACK_OK)
     {

--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -25,6 +25,7 @@
 #include "pvr/addons/PVRClients.h"
 #include "utils/StringUtils.h"
 #include "utils/RegExp.h"
+#include "utils/Variant.h"
 #include "video/VideoDatabase.h"
 
 #include "epg/Epg.h"
@@ -315,11 +316,11 @@ std::vector<PVR_EDL_ENTRY> CPVRRecording::GetEdl() const
 void CPVRRecording::DisplayError(PVR_ERROR err) const
 {
   if (err == PVR_ERROR_SERVER_ERROR)
-    CGUIDialogOK::ShowAndGetInput(19033, 19111); /* print info dialog "Server error!" */
+    CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{19111}); /* print info dialog "Server error!" */
   else if (err == PVR_ERROR_REJECTED)
-    CGUIDialogOK::ShowAndGetInput(19033, 19068); /* print info dialog "Couldn't delete recording!" */
+    CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{19068}); /* print info dialog "Couldn't delete recording!" */
   else
-    CGUIDialogOK::ShowAndGetInput(19033, 19147); /* print info dialog "Unknown error!" */
+    CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{19147}); /* print info dialog "Unknown error!" */
 
   return;
 }

--- a/xbmc/pvr/recordings/PVRRecording.h
+++ b/xbmc/pvr/recordings/PVRRecording.h
@@ -44,6 +44,7 @@
 #define PVR_RECORDING_ACTIVE_PATH   "active"
 
 class CVideoDatabase;
+class CVariant;
 
 namespace PVR
 {

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -25,6 +25,7 @@
 #include "settings/Settings.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
+#include "utils/Variant.h"
 
 #include "PVRTimers.h"
 #include "pvr/PVRManager.h"
@@ -504,7 +505,7 @@ bool CPVRTimerInfoTag::DeleteFromClient(bool bForce /* = false */ , bool bDelete
   if (error == PVR_ERROR_RECORDING_RUNNING)
   {
     // recording running. ask the user if it should be deleted anyway
-    if (!CGUIDialogYesNo::ShowAndGetInput(122, 19122))
+    if (!CGUIDialogYesNo::ShowAndGetInput(CVariant{122}, CVariant{19122}))
       return false;
 
     error = g_PVRClients->DeleteTimer(*this, true, bDeleteSchedule);
@@ -594,13 +595,13 @@ bool CPVRTimerInfoTag::UpdateOnClient()
 void CPVRTimerInfoTag::DisplayError(PVR_ERROR err) const
 {
   if (err == PVR_ERROR_SERVER_ERROR)
-    CGUIDialogOK::ShowAndGetInput(19033, 19111); /* print info dialog "Server error!" */
+    CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{19111}); /* print info dialog "Server error!" */
   else if (err == PVR_ERROR_REJECTED)
-    CGUIDialogOK::ShowAndGetInput(19033, 19109); /* print info dialog "Couldn't save timer!" */
+    CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{19109}); /* print info dialog "Couldn't save timer!" */
   else if (err == PVR_ERROR_ALREADY_PRESENT)
-    CGUIDialogOK::ShowAndGetInput(19033, 19067); /* print info dialog */
+    CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{19067}); /* print info dialog */
   else
-    CGUIDialogOK::ShowAndGetInput(19033, 19110); /* print info dialog "Unknown error!" */
+    CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{19110}); /* print info dialog "Unknown error!" */
 }
 
 void CPVRTimerInfoTag::SetEpgInfoTag(CEpgInfoTagPtr &tag)

--- a/xbmc/pvr/timers/PVRTimerInfoTag.h
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.h
@@ -45,6 +45,7 @@
 #include <memory>
 
 class CFileItem;
+class CVariant;
 
 namespace EPG
 {

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -26,6 +26,7 @@
 #include "utils/log.h"
 #include "utils/URIUtils.h"
 #include "utils/StringUtils.h"
+#include "utils/Variant.h"
 
 #include "PVRTimers.h"
 #include "pvr/PVRManager.h"
@@ -562,13 +563,13 @@ bool CPVRTimers::AddTimer(const CPVRTimerInfoTagPtr &item)
   if (!item->m_channel && item->GetTimerType() && !item->GetTimerType()->IsRepeatingEpgBased())
   {
     CLog::Log(LOGERROR, "PVRTimers - %s - no channel given", __FUNCTION__);
-    CGUIDialogOK::ShowAndGetInput(19033, 19109); // Couldn't save timer
+    CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{19109}); // Couldn't save timer
     return false;
   }
 
   if (!g_PVRClients->SupportsTimers(item->m_iClientId))
   {
-    CGUIDialogOK::ShowAndGetInput(19033, 19215);
+    CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{19215});
     return false;
   }
 

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -407,7 +407,7 @@ bool CGUIWindowPVRBase::StartRecordFile(CFileItem *item, bool bAdvanced)
     if (!CGUIDialogYesNo::ShowAndGetInput(
         CVariant{264} /* "Record" */, CVariant{tag->PVRChannelName()}, CVariant{""}, CVariant{tag->Title()}))
       return false;
-
+  
     CPVRTimerInfoTagPtr newTimer = CPVRTimerInfoTag::CreateFromEpg(tag);
 
     if (newTimer)

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -45,6 +45,9 @@
 #include "threads/SingleLock.h"
 #include "utils/StringUtils.h"
 #include "utils/Observer.h"
+#include "utils/Variant.h"
+
+#include <utility>
 
 using namespace PVR;
 using namespace EPG;
@@ -226,7 +229,7 @@ bool CGUIWindowPVRBase::OpenGroupSelectionDialog(void)
   g_PVRChannelGroups->Get(m_bRadio)->GetGroupList(&options, true);
 
   dialog->Reset();
-  dialog->SetHeading(g_localizeStrings.Get(19146));
+  dialog->SetHeading(CVariant{g_localizeStrings.Get(19146)});
   dialog->SetItems(&options);
   dialog->SetMultiSelection(false);
   dialog->SetSelected(m_group->GroupName());
@@ -303,10 +306,10 @@ bool CGUIWindowPVRBase::PlayFile(CFileItem *item, bool bPlayMinimized /* = false
         CGUIDialogYesNo* pDialog = (CGUIDialogYesNo*) g_windowManager.GetWindow(WINDOW_DIALOG_YES_NO);
         if (pDialog)
         {
-          pDialog->SetHeading(19687); // Play recording
-          pDialog->SetLine(0, "");
-          pDialog->SetLine(1, 12021); // Start from beginning
-          pDialog->SetLine(2, recording->m_strTitle.c_str());
+          pDialog->SetHeading(CVariant{19687}); // Play recording
+          pDialog->SetLine(0, CVariant{""});
+          pDialog->SetLine(1, CVariant{12021}); // Start from beginning
+          pDialog->SetLine(2, CVariant{recording->m_strTitle});
           pDialog->DoModal();
 
           if (pDialog->IsConfirmed())
@@ -379,7 +382,7 @@ bool CGUIWindowPVRBase::StartRecordFile(CFileItem *item, bool bAdvanced)
   CFileItemPtr timer = g_PVRTimers->GetTimerForEpgTag(item);
   if (timer && timer->HasPVRTimerInfoTag())
   {
-    CGUIDialogOK::ShowAndGetInput(19033, 19034);
+    CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{19034});
     return false;
   }
 
@@ -402,7 +405,7 @@ bool CGUIWindowPVRBase::StartRecordFile(CFileItem *item, bool bAdvanced)
   {
     // ask for confirmation before starting a timer
     if (!CGUIDialogYesNo::ShowAndGetInput(
-          264 /* "Record" */, tag->PVRChannelName(), "", tag->Title()))
+        CVariant{264} /* "Record" */, CVariant{tag->PVRChannelName()}, CVariant{""}, CVariant{tag->Title()}))
       return false;
 
     CPVRTimerInfoTagPtr newTimer = CPVRTimerInfoTag::CreateFromEpg(tag);
@@ -503,7 +506,7 @@ bool CGUIWindowPVRBase::PlayRecording(CFileItem *item, bool bPlayMinimized /* = 
   else
   {
     CLog::Log(LOGERROR, "CGUIWindowPVRCommon - %s - can't open recording: no valid filename", __FUNCTION__);
-    CGUIDialogOK::ShowAndGetInput(19033, 19036);
+    CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{19036});
     return false;
   }
 
@@ -555,7 +558,7 @@ void CGUIWindowPVRBase::ShowEPGInfo(CFileItem *item)
     bHasChannel = true;
     if (!epgnow)
     {
-      CGUIDialogOK::ShowAndGetInput(19033, 19055);
+      CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{19055});
       return;
     }
     tag = new CFileItem(epgnow);
@@ -637,7 +640,7 @@ bool CGUIWindowPVRBase::ActionPlayEpg(CFileItem *item, bool bPlayRecording)
   {
     // CHANNELNAME could not be played. Check the log for details.
     std::string msg = StringUtils::Format(g_localizeStrings.Get(19035).c_str(), channel->ChannelName().c_str());
-    CGUIDialogOK::ShowAndGetInput(19033, msg);
+    CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{std::move(msg)});
     return false;
   }
 
@@ -656,10 +659,10 @@ bool CGUIWindowPVRBase::ActionDeleteChannel(CFileItem *item)
   CGUIDialogYesNo* pDialog = (CGUIDialogYesNo*) g_windowManager.GetWindow(WINDOW_DIALOG_YES_NO);
   if (!pDialog)
     return false;
-  pDialog->SetHeading(19039);
-  pDialog->SetLine(0, "");
-  pDialog->SetLine(1, channel->ChannelName());
-  pDialog->SetLine(2, "");
+  pDialog->SetHeading(CVariant{19039});
+  pDialog->SetLine(0, CVariant{""});
+  pDialog->SetLine(1, CVariant{channel->ChannelName()});
+  pDialog->SetLine(2, CVariant{""});
   pDialog->DoModal();
 
   /* prompt for the user's confirmation */
@@ -691,10 +694,10 @@ bool CGUIWindowPVRBase::ActionRecord(CFileItem *item)
     if (!pDialog)
       return bReturn;
 
-    pDialog->SetHeading(264);
-    pDialog->SetLine(0, "");
-    pDialog->SetLine(1, epgTag->Title());
-    pDialog->SetLine(2, "");
+    pDialog->SetHeading(CVariant{264});
+    pDialog->SetLine(0, CVariant{""});
+    pDialog->SetLine(1, CVariant{epgTag->Title()});
+    pDialog->SetLine(2, CVariant{""});
     pDialog->DoModal();
 
     /* prompt for the user's confirmation */
@@ -713,7 +716,7 @@ bool CGUIWindowPVRBase::ActionRecord(CFileItem *item)
   }
   else
   {
-    CGUIDialogOK::ShowAndGetInput(19033, 19034);
+    CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{19034});
     bReturn = true;
   }
 
@@ -752,10 +755,10 @@ bool CGUIWindowPVRBase::ConfirmDeleteTimer(CFileItem *item, bool &bDeleteSchedul
     // prompt user for confirmation for deleting the complete repeating timer, including scheduled timers.
     bool bCancel(false);
     bDeleteSchedule = CGUIDialogYesNo::ShowAndGetInput(
-                        122, // "Confirm delete"
-                        840, // "You are about to delete a repeating timer. Do you also want to delete all timers currently scheduled by this timer?"
-                        "",
-                        item->GetPVRTimerInfoTag()->Title(),
+                        CVariant{122}, // "Confirm delete"
+                        CVariant{840}, // "You are about to delete a repeating timer. Do you also want to delete all timers currently scheduled by this timer?"
+                        CVariant{""},
+                        CVariant{item->GetPVRTimerInfoTag()->Title()},
                         bCancel);
     bConfirmed = !bCancel;
   }
@@ -763,10 +766,10 @@ bool CGUIWindowPVRBase::ConfirmDeleteTimer(CFileItem *item, bool &bDeleteSchedul
   {
     // prompt user for confirmation for deleting the timer
     bConfirmed = CGUIDialogYesNo::ShowAndGetInput(
-                        122, // Confirm delete
-                        19040, // Timer
-                        "",
-                        item->GetPVRTimerInfoTag()->Title());
+                        CVariant{122}, // Confirm delete
+                        CVariant{19040}, // Timer
+                        CVariant{""},
+                        CVariant{item->GetPVRTimerInfoTag()->Title()});
     bDeleteSchedule = false;
   }
 

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -37,6 +37,7 @@
 #include "pvr/timers/PVRTimers.h"
 #include "epg/EpgContainer.h"
 #include "utils/StringUtils.h"
+#include "utils/Variant.h"
 #include "threads/SingleLock.h"
 
 using namespace PVR;
@@ -248,7 +249,7 @@ bool CGUIWindowPVRChannels::OnContextButtonAdd(CFileItem *item, CONTEXT_BUTTON b
 
   if (button == CONTEXT_BUTTON_ADD)
   {
-    CGUIDialogOK::ShowAndGetInput(19033, 19038);
+    CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{19038});
     bReturn = true;
   }
 
@@ -349,10 +350,10 @@ bool CGUIWindowPVRChannels::OnContextButtonUpdateEpg(CFileItem *item, CONTEXT_BU
 
     CPVRChannelPtr channel(item->GetPVRChannelInfoTag());
 
-    pDialog->SetHeading(19251);
-    pDialog->SetLine(0, g_localizeStrings.Get(19252));
-    pDialog->SetLine(1, channel->ChannelName());
-    pDialog->SetLine(2, "");
+    pDialog->SetHeading(CVariant{19251});
+    pDialog->SetLine(0, CVariant{g_localizeStrings.Get(19252)});
+    pDialog->SetLine(1, CVariant{channel->ChannelName()});
+    pDialog->SetLine(2, CVariant{""});
     pDialog->DoModal();
 
     if (!pDialog->IsConfirmed())

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -32,6 +32,7 @@
 #include "pvr/recordings/PVRRecordings.h"
 #include "pvr/timers/PVRTimers.h"
 #include "utils/StringUtils.h"
+#include "utils/Variant.h"
 #include "threads/SingleLock.h"
 #include "pvr/addons/PVRClients.h"
 #include "video/windows/GUIWindowVideoNav.h"
@@ -327,11 +328,12 @@ bool CGUIWindowPVRRecordings::ActionDeleteRecording(CFileItem *item)
   if (!pDialog)
     return bReturn;
 
-  pDialog->SetHeading(122); // Confirm delete
-  pDialog->SetLine(0, item->m_bIsFolder ? 19113 : item->GetPVRRecordingInfoTag()->IsDeleted() ? 19294 : 19112); // Delete all recordings in this folder? / Delete this recording permanently? / Delete this recording?
-  pDialog->SetLine(1, "");
-  pDialog->SetLine(2, item->GetLabel());
-  pDialog->SetChoice(1, 117); // Delete
+  int iLine0 = item->m_bIsFolder ? 19113 : item->GetPVRRecordingInfoTag()->IsDeleted() ? 19294 : 19112;
+  pDialog->SetHeading(CVariant{122}); // Confirm delete
+  pDialog->SetLine(0, CVariant{iLine0}); // Delete all recordings in this folder? / Delete this recording permanently? / Delete this recording?
+  pDialog->SetLine(1, CVariant{""});
+  pDialog->SetLine(2, CVariant{item->GetLabel()});
+  pDialog->SetChoice(1, CVariant{117}); // Delete
 
   /* prompt for the user's confirmation */
   pDialog->DoModal();
@@ -400,11 +402,11 @@ bool CGUIWindowPVRRecordings::OnContextButtonDeleteAll(CFileItem *item, CONTEXT_
     return bReturn;
 
 
-  pDialog->SetHeading(19292); // Delete all permanently
-  pDialog->SetLine(0, 19293); // Delete all recordings permanently?
-  pDialog->SetLine(1, "");
-  pDialog->SetLine(2, "");
-  pDialog->SetChoice(1, 117); // Delete
+  pDialog->SetHeading(CVariant{19292}); // Delete all permanently
+  pDialog->SetLine(0, CVariant{19293}); // Delete all recordings permanently?
+  pDialog->SetLine(1, CVariant{""});
+  pDialog->SetLine(2, CVariant{""});
+  pDialog->SetChoice(1, CVariant{117}); // Delete
 
   /* prompt for the user's confirmation */
   pDialog->DoModal();
@@ -467,7 +469,7 @@ bool CGUIWindowPVRRecordings::OnContextButtonRename(CFileItem *item, CONTEXT_BUT
       bReturn = true;
 
       std::string strNewName = recording->m_strTitle;
-      if (CGUIKeyboardFactory::ShowAndGetInput(strNewName, g_localizeStrings.Get(19041), false))
+      if (CGUIKeyboardFactory::ShowAndGetInput(strNewName, CVariant{g_localizeStrings.Get(19041)}, false))
       {
         if (g_PVRRecordings->RenameRecording(*item, strNewName))
           Refresh(true);

--- a/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
@@ -30,6 +30,7 @@
 #include "pvr/dialogs/GUIDialogPVRGuideSearch.h"
 #include "epg/EpgContainer.h"
 #include "pvr/addons/PVRClients.h"
+#include "utils/Variant.h"
 
 using namespace PVR;
 using namespace EPG;
@@ -150,8 +151,8 @@ void CGUIWindowPVRSearch::OnPrepareFileItems(CFileItemList &items)
     CGUIDialogProgress* dlgProgress = (CGUIDialogProgress*)g_windowManager.GetWindow(WINDOW_DIALOG_PROGRESS);
     if (dlgProgress)
     {
-      dlgProgress->SetHeading(194);
-      dlgProgress->SetText(CVariant(m_searchfilter.m_strSearchTerm));
+      dlgProgress->SetHeading(CVariant{194});
+      dlgProgress->SetText(CVariant{m_searchfilter.m_strSearchTerm});
       dlgProgress->StartModal();
       dlgProgress->Progress();
     }
@@ -164,7 +165,7 @@ void CGUIWindowPVRSearch::OnPrepareFileItems(CFileItemList &items)
 
     if (items.IsEmpty())
     {
-      CGUIDialogOK::ShowAndGetInput(194, 284);
+      CGUIDialogOK::ShowAndGetInput(CVariant{194}, CVariant{284});
       m_bSearchConfirmed = false;
     }
   }

--- a/xbmc/pvr/windows/GUIWindowPVRTimers.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRTimers.cpp
@@ -34,6 +34,7 @@
 #include "settings/Settings.h"
 #include "threads/SingleLock.h"
 #include "utils/StringUtils.h"
+#include "utils/Variant.h"
 
 using namespace PVR;
 
@@ -321,7 +322,7 @@ bool CGUIWindowPVRTimers::OnContextButtonRename(CFileItem *item, CONTEXT_BUTTON 
     CPVRTimerInfoTagPtr timer = item->GetPVRTimerInfoTag();
 
     std::string strNewName(timer->m_strTitle);
-    if (CGUIKeyboardFactory::ShowAndGetInput(strNewName, g_localizeStrings.Get(19042), false))
+    if (CGUIKeyboardFactory::ShowAndGetInput(strNewName, CVariant{g_localizeStrings.Get(19042)}, false))
       g_PVRTimers->RenameTimer(*item, strNewName);
   }
 

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -36,6 +36,7 @@
 #include "utils/URIUtils.h"
 #include "utils/XMLUtils.h"
 #include "utils/log.h"
+#include "utils/Variant.h"
 #include "filesystem/SpecialProtocol.h"
 #include "addons/IAddon.h"
 #include "addons/AddonManager.h"

--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -33,6 +33,7 @@
 #include "threads/SingleLock.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
+#include "utils/Variant.h"
 #include "utils/XMLUtils.h"
 #include "windowing/WindowingFactory.h"
 
@@ -254,7 +255,7 @@ bool CDisplaySettings::OnSettingChanging(const CSetting *setting)
       if (!m_resolutionChangeAborted)
       {
         bool cancelled = false;
-        if (!CGUIDialogYesNo::ShowAndGetInput(13110, 13111, cancelled, "", "", 10000))
+        if (!CGUIDialogYesNo::ShowAndGetInput(CVariant{13110}, CVariant{13111}, cancelled, CVariant{""}, CVariant{""}, CVariant{10000}))
         {
           m_resolutionChangeAborted = true;
           return false;
@@ -275,7 +276,7 @@ bool CDisplaySettings::OnSettingChanging(const CSetting *setting)
     if (!m_resolutionChangeAborted)
     {
       bool cancelled = false;
-      if (!CGUIDialogYesNo::ShowAndGetInput(13110, 13111, cancelled, "", "", 10000))
+      if (!CGUIDialogYesNo::ShowAndGetInput(CVariant{13110}, CVariant{13111}, cancelled, CVariant{""}, CVariant{""}, CVariant{10000}))
       {
         m_resolutionChangeAborted = true;
         return false;

--- a/xbmc/settings/MediaSettings.cpp
+++ b/xbmc/settings/MediaSettings.cpp
@@ -35,6 +35,7 @@
 #include "utils/URIUtils.h"
 #include "utils/XBMCTinyXML.h"
 #include "utils/XMLUtils.h"
+#include "utils/Variant.h"
 #include "video/VideoDatabase.h"
 
 using namespace std;
@@ -310,7 +311,7 @@ void CMediaSettings::OnSettingAction(const CSetting *setting)
   }
   else if (settingId == "musiclibrary.cleanup")
   {
-    if (CGUIDialogYesNo::ShowAndGetInput(313, 333))
+    if (CGUIDialogYesNo::ShowAndGetInput(CVariant{313}, CVariant{333}))
       g_application.StartMusicCleanup(true);
   }
   else if (settingId == "musiclibrary.export")
@@ -330,7 +331,7 @@ void CMediaSettings::OnSettingAction(const CSetting *setting)
   }
   else if (settingId == "videolibrary.cleanup")
   {
-    if (CGUIDialogYesNo::ShowAndGetInput(313, 333))
+    if (CGUIDialogYesNo::ShowAndGetInput(CVariant{313}, CVariant{333}))
       g_application.StartVideoCleanup(true);
   }
   else if (settingId == "videolibrary.export")

--- a/xbmc/settings/SettingUtils.cpp
+++ b/xbmc/settings/SettingUtils.cpp
@@ -21,6 +21,7 @@
 #include "SettingUtils.h"
 #include "settings/lib/Setting.h"
 #include "utils/StringUtils.h"
+#include "utils/Variant.h"
 
 std::vector<CVariant> CSettingUtils::GetList(const CSettingList *settingList)
 {

--- a/xbmc/settings/SettingUtils.h
+++ b/xbmc/settings/SettingUtils.h
@@ -21,8 +21,7 @@
 #include <vector>
 #include <memory>
 
-#include "utils/Variant.h"
-
+class CVariant;
 class CSettingList;
 class CSetting;
 

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -78,6 +78,7 @@
 #include "utils/Weather.h"
 #include "utils/XBMCTinyXML.h"
 #include "utils/SeekHandler.h"
+#include "utils/Variant.h"
 #include "view/ViewStateSettings.h"
 #include "input/InputManager.h"
 

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -29,7 +29,6 @@
 #include "settings/SettingCreator.h"
 #include "settings/lib/ISettingCallback.h"
 #include "threads/CriticalSection.h"
-#include "utils/Variant.h"
 
 class CSetting;
 class CSettingList;
@@ -37,6 +36,7 @@ class CSettingSection;
 class CSettingsManager;
 class TiXmlElement;
 class TiXmlNode;
+class CVariant;
 
 /*!
  \brief Wrapper around CSettingsManager responsible for properly setting up

--- a/xbmc/settings/dialogs/GUIDialogSettingsBase.cpp
+++ b/xbmc/settings/dialogs/GUIDialogSettingsBase.cpp
@@ -36,6 +36,7 @@
 #include "settings/lib/SettingSection.h"
 #include "settings/windows/GUIControlSettings.h"
 #include "utils/StringUtils.h"
+#include "utils/Variant.h"
 
 using namespace std;
 
@@ -753,7 +754,7 @@ void CGUIDialogSettingsBase::SetDescription(const CVariant &label)
 
 void CGUIDialogSettingsBase::OnResetSettings()
 {
-  if (CGUIDialogYesNo::ShowAndGetInput(10041, 10042))
+  if (CGUIDialogYesNo::ShowAndGetInput(CVariant{10041}, CVariant{10042}))
   {
     for(vector<BaseSettingControlPtr>::iterator it = m_settingControls.begin(); it != m_settingControls.end(); ++it)
     {

--- a/xbmc/settings/dialogs/GUIDialogSettingsBase.h
+++ b/xbmc/settings/dialogs/GUIDialogSettingsBase.h
@@ -56,6 +56,8 @@ class CSettingAction;
 class CSettingCategory;
 class CSettingSection;
 
+class CVariant;
+
 typedef std::shared_ptr<CGUIControlBaseSetting> BaseSettingControlPtr;
 
 class CGUIDialogSettingsBase

--- a/xbmc/settings/dialogs/GUIDialogSettingsManualBase.cpp
+++ b/xbmc/settings/dialogs/GUIDialogSettingsManualBase.cpp
@@ -26,6 +26,7 @@
 #include "settings/lib/SettingSection.h"
 #include "settings/lib/SettingsManager.h"
 #include "utils/StringUtils.h"
+#include "utils/Variant.h"
 
 using namespace std;
 

--- a/xbmc/settings/windows/GUIControlSettings.cpp
+++ b/xbmc/settings/windows/GUIControlSettings.cpp
@@ -45,6 +45,7 @@
 #include "settings/lib/Setting.h"
 #include "storage/MediaManager.h"
 #include "utils/StringUtils.h"
+#include "utils/Variant.h"
 
 using namespace ADDON;
 
@@ -285,7 +286,7 @@ bool CGUIControlListSetting::OnClick()
   const CSettingControlList *control = static_cast<const CSettingControlList*>(m_pSetting->GetControl());
   
   dialog->Reset();
-  dialog->SetHeading(g_localizeStrings.Get(m_pSetting->GetLabel()));
+  dialog->SetHeading(CVariant{g_localizeStrings.Get(m_pSetting->GetLabel())});
   dialog->SetItems(&options);
   dialog->SetMultiSelection(control->CanMultiSelect());
   dialog->DoModal();

--- a/xbmc/settings/windows/GUIWindowSettingsScreenCalibration.cpp
+++ b/xbmc/settings/windows/GUIWindowSettingsScreenCalibration.cpp
@@ -34,7 +34,10 @@
 #include "guilib/LocalizeStrings.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
+#include "utils/Variant.h"
 #include "windowing/WindowingFactory.h"
+
+#include <utility>
 
 using namespace std;
 
@@ -74,12 +77,12 @@ bool CGUIWindowSettingsScreenCalibration::OnAction(const CAction &action)
   case ACTION_CALIBRATE_RESET:
     {
       CGUIDialogYesNo* pDialog = (CGUIDialogYesNo*)g_windowManager.GetWindow(WINDOW_DIALOG_YES_NO);
-      pDialog->SetHeading(20325);
+      pDialog->SetHeading(CVariant{20325});
       std::string strText = StringUtils::Format(g_localizeStrings.Get(20326).c_str(), g_graphicsContext.GetResInfo(m_Res[m_iCurRes]).strMode.c_str());
-      pDialog->SetLine(0, strText);
-      pDialog->SetLine(1, 20327);
-      pDialog->SetChoice(0, 222);
-      pDialog->SetChoice(1, 186);
+      pDialog->SetLine(0, CVariant{std::move(strText)});
+      pDialog->SetLine(1, CVariant{20327});
+      pDialog->SetChoice(0, CVariant{222});
+      pDialog->SetChoice(1, CVariant{186});
       pDialog->DoModal();
       if (pDialog->IsConfirmed())
       {

--- a/xbmc/storage/AutorunMediaJob.cpp
+++ b/xbmc/storage/AutorunMediaJob.cpp
@@ -24,6 +24,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "dialogs/GUIDialogSelect.h"
 #include "utils/StringUtils.h"
+#include "utils/Variant.h"
 
 CAutorunMediaJob::CAutorunMediaJob(const std::string &label, const std::string &path):
   m_path(path),
@@ -40,9 +41,9 @@ bool CAutorunMediaJob::DoWork()
 
   pDialog->Reset();
   if (m_label.size() > 0)
-    pDialog->SetHeading(m_label);
+    pDialog->SetHeading(CVariant{m_label});
   else
-    pDialog->SetHeading(g_localizeStrings.Get(21331));
+    pDialog->SetHeading(CVariant{g_localizeStrings.Get(21331)});
 
   pDialog->Add(g_localizeStrings.Get(21332));
   pDialog->Add(g_localizeStrings.Get(21333));

--- a/xbmc/utils/Archive.cpp
+++ b/xbmc/utils/Archive.cpp
@@ -23,7 +23,7 @@
 #include "Archive.h"
 #include "IArchivable.h"
 #include "filesystem/File.h"
-#include "Variant.h"
+#include "utils/Variant.h"
 #include "utils/log.h"
 
 #ifdef __GNUC__

--- a/xbmc/utils/AsyncFileCopy.cpp
+++ b/xbmc/utils/AsyncFileCopy.cpp
@@ -25,6 +25,7 @@
 #include "log.h"
 #include "utils/StringUtils.h"
 #include "URL.h"
+#include "utils/Variant.h"
 
 CAsyncFileCopy::CAsyncFileCopy() : CThread("AsyncFileCopy")
 {
@@ -65,20 +66,19 @@ bool CAsyncFileCopy::Copy(const std::string &from, const std::string &to, const 
     // start the dialog up as needed
     if (dlg && !dlg->IsDialogRunning() && (XbmcThreads::SystemClockMillis() - time) > 500) // wait 0.5 seconds before starting dialog
     {
-      dlg->SetHeading(heading);
-      dlg->SetLine(0, url1.GetWithoutUserDetails());
-      dlg->SetLine(1, url2.GetWithoutUserDetails());
+      dlg->SetHeading(CVariant{heading});
+      dlg->SetLine(0, CVariant{url1.GetWithoutUserDetails()});
+      dlg->SetLine(1, CVariant{url2.GetWithoutUserDetails()});
       dlg->SetPercentage(0);
       dlg->StartModal();
     }
     // and update the dialog as we go
     if (dlg && dlg->IsDialogRunning())
     {
-      std::string speedString = StringUtils::Format("%2.2f KB/s", m_speed / 1024);
-      dlg->SetHeading(heading);
-      dlg->SetLine(0, url1.Get());
-      dlg->SetLine(1, url2.Get());
-      dlg->SetLine(2, speedString);
+      dlg->SetHeading(CVariant{heading});
+      dlg->SetLine(0, CVariant{url1.Get()});
+      dlg->SetLine(1, CVariant{url2.Get()});
+      dlg->SetLine(2, CVariant{ StringUtils::Format("%2.2f KB/s", m_speed / 1024) });
       dlg->SetPercentage(m_percent);
       dlg->Progress();
       m_cancelled = dlg->IsCanceled();

--- a/xbmc/utils/FileUtils.cpp
+++ b/xbmc/utils/FileUtils.cpp
@@ -34,6 +34,7 @@
 #include "StringUtils.h"
 #include "URL.h"
 #include "settings/Settings.h"
+#include "utils/Variant.h"
 
 using namespace XFILE;
 using namespace std;
@@ -55,10 +56,10 @@ bool CFileUtils::DeleteItem(const CFileItemPtr &item, bool force)
   CGUIDialogYesNo* pDialog = (CGUIDialogYesNo*)g_windowManager.GetWindow(WINDOW_DIALOG_YES_NO);
   if (!force && pDialog)
   {
-    pDialog->SetHeading(122);
-    pDialog->SetLine(0, 125);
-    pDialog->SetLine(1, CURL(item->GetPath()).GetWithoutUserDetails());
-    pDialog->SetLine(2, "");
+    pDialog->SetHeading(CVariant{122});
+    pDialog->SetLine(0, CVariant{125});
+    pDialog->SetLine(1, CVariant{CURL(item->GetPath()).GetWithoutUserDetails()});
+    pDialog->SetLine(2, CVariant{""});
     pDialog->DoModal();
     if (!pDialog->IsConfirmed()) return false;
   }
@@ -82,7 +83,7 @@ bool CFileUtils::RenameFile(const std::string &strFile)
   URIUtils::RemoveSlashAtEnd(strFileAndPath);
   std::string strFileName = URIUtils::GetFileName(strFileAndPath);
   std::string strPath = URIUtils::GetDirectory(strFileAndPath);
-  if (CGUIKeyboardFactory::ShowAndGetInput(strFileName, g_localizeStrings.Get(16013), false))
+  if (CGUIKeyboardFactory::ShowAndGetInput(strFileName, CVariant{g_localizeStrings.Get(16013)}, false))
   {
     strPath = URIUtils::AddFileToFolder(strPath, strFileName);
     CLog::Log(LOGINFO,"FileUtils: rename %s->%s\n", strFileAndPath.c_str(), strPath.c_str());

--- a/xbmc/utils/JSONVariantParser.h
+++ b/xbmc/utils/JSONVariantParser.h
@@ -19,7 +19,7 @@
  *
  */
 
-#include "Variant.h"
+#include "utils/Variant.h"
 
 #include <yajl/yajl_parse.h>
 

--- a/xbmc/utils/JSONVariantWriter.cpp
+++ b/xbmc/utils/JSONVariantWriter.cpp
@@ -21,6 +21,7 @@
 #include <locale>
 
 #include "JSONVariantWriter.h"
+#include "utils/Variant.h"
 
 using namespace std;
 

--- a/xbmc/utils/JSONVariantWriter.h
+++ b/xbmc/utils/JSONVariantWriter.h
@@ -19,8 +19,10 @@
  *
  */
 
-#include "Variant.h"
 #include <yajl/yajl_gen.h>
+#include <string>
+
+class CVariant;
 
 class CJSONVariantWriter
 {

--- a/xbmc/utils/ProgressJob.cpp
+++ b/xbmc/utils/ProgressJob.cpp
@@ -24,6 +24,7 @@
 #include "dialogs/GUIDialogProgress.h"
 #include "dialogs/GUIDialogExtendedProgressBar.h"
 #include "guilib/GUIWindowManager.h"
+#include "utils/Variant.h"
 
 using namespace std;
 
@@ -120,7 +121,7 @@ void CProgressJob::SetTitle(const std::string &title)
     m_progress->SetTitle(title);
   else if (m_progressDialog != NULL)
   {
-    m_progressDialog->SetHeading(title);
+    m_progressDialog->SetHeading(CVariant{title});
 
     ShowProgressDialog();
   }
@@ -135,7 +136,7 @@ void CProgressJob::SetText(const std::string &text)
     m_progress->SetText(text);
   else if (m_progressDialog != NULL)
   {
-    m_progressDialog->SetText(text);
+    m_progressDialog->SetText(CVariant{text});
 
     ShowProgressDialog();
   }

--- a/xbmc/utils/RssManager.cpp
+++ b/xbmc/utils/RssManager.cpp
@@ -30,6 +30,7 @@
 #include "utils/log.h"
 #include "utils/RssReader.h"
 #include "utils/StringUtils.h"
+#include "utils/Variant.h"
 
 using namespace std;
 using namespace XFILE;
@@ -72,7 +73,7 @@ void CRssManager::OnSettingAction(const CSetting *setting)
     ADDON::CAddonMgr::Get().GetAddon("script.rss.editor",addon);
     if (!addon)
     {
-      if (!CGUIDialogYesNo::ShowAndGetInput(24076, 24100, "RSS Editor", 24101))
+      if (!CGUIDialogYesNo::ShowAndGetInput(CVariant{24076}, CVariant{24100}, CVariant{"RSS Editor"}, CVariant{24101}))
         return;
       CAddonInstaller::Get().Install("script.rss.editor", true, "", false);
     }

--- a/xbmc/utils/SaveFileStateJob.cpp
+++ b/xbmc/utils/SaveFileStateJob.cpp
@@ -23,7 +23,7 @@
 #include "settings/MediaSettings.h"
 #include "network/upnp/UPnP.h"
 #include "StringUtils.h"
-#include "Variant.h"
+#include "utils/Variant.h"
 #include "URIUtils.h"
 #include "URL.h"
 #include "log.h"

--- a/xbmc/utils/SeekHandler.cpp
+++ b/xbmc/utils/SeekHandler.cpp
@@ -30,6 +30,7 @@
 #include "settings/lib/Setting.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
+#include "utils/Variant.h"
 
 CSeekHandler::CSeekHandler()
 : m_seekDelay(500),

--- a/xbmc/utils/StreamDetails.cpp
+++ b/xbmc/utils/StreamDetails.cpp
@@ -21,7 +21,7 @@
 #include <math.h>
 #include "StreamDetails.h"
 #include "StreamUtils.h"
-#include "Variant.h"
+#include "utils/Variant.h"
 #include "LangInfo.h"
 #include "utils/LangCodeExpander.h"
 #include "utils/Archive.h"

--- a/xbmc/utils/StreamDetails.h
+++ b/xbmc/utils/StreamDetails.h
@@ -25,6 +25,7 @@
 #include <vector>
 
 class CStreamDetails;
+class CVariant;
 
 class CStreamDetail : public IArchivable, public ISerializable
 {

--- a/xbmc/utils/Variant.cpp
+++ b/xbmc/utils/Variant.cpp
@@ -21,6 +21,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sstream>
+#include <utility>
 
 #include "Variant.h"
 
@@ -226,6 +227,12 @@ CVariant::CVariant(const string &str)
   m_data.string = new string(str);
 }
 
+CVariant::CVariant(std::string &&str)
+{
+  m_type = VariantTypeString;
+  m_data.string = new string(std::move(str));
+}
+
 CVariant::CVariant(const wchar_t *str)
 {
   m_type = VariantTypeWideString;
@@ -244,13 +251,19 @@ CVariant::CVariant(const wstring &str)
   m_data.wstring = new wstring(str);
 }
 
+CVariant::CVariant(std::wstring &&str)
+{
+  m_type = VariantTypeWideString;
+  m_data.wstring = new std::wstring(std::move(str));
+}
+
 CVariant::CVariant(const std::vector<std::string> &strArray)
 {
   m_type = VariantTypeArray;
   m_data.array = new VariantArray;
   m_data.array->reserve(strArray.size());
-  for (unsigned int index = 0; index < strArray.size(); index++)
-    m_data.array->push_back(strArray.at(index));
+  for (const auto& item : strArray)
+    m_data.array->push_back(CVariant(item));
 }
 
 CVariant::CVariant(const std::map<std::string, std::string> &strMap)
@@ -271,6 +284,12 @@ CVariant::CVariant(const CVariant &variant)
 {
   m_type = VariantTypeNull;
   *this = variant;
+}
+
+CVariant::CVariant(CVariant&& rhs)
+  : m_type(rhs.m_type)
+  , m_data(std::move(rhs.m_data))
+{
 }
 
 CVariant::~CVariant()
@@ -589,6 +608,15 @@ CVariant &CVariant::operator=(const CVariant &rhs)
   return *this;
 }
 
+CVariant& CVariant::operator=(CVariant&& rhs)
+{
+  if (this == &rhs)
+    return *this;
+  m_type = rhs.m_type;
+  m_data = std::move(rhs.m_data);
+  return *this;
+}
+
 bool CVariant::operator==(const CVariant &rhs) const
 {
   if (m_type == rhs.m_type)
@@ -631,9 +659,26 @@ void CVariant::push_back(const CVariant &variant)
     m_data.array->push_back(variant);
 }
 
+void CVariant::push_back(CVariant &&variant)
+{
+  if (m_type == VariantTypeNull)
+  {
+    m_type = VariantTypeArray;
+    m_data.array = new VariantArray;
+  }
+
+  if (m_type == VariantTypeArray)
+    m_data.array->push_back(std::move(variant));
+}
+
 void CVariant::append(const CVariant &variant)
 {
   push_back(variant);
+}
+
+void CVariant::append(CVariant&& variant)
+{
+  push_back(std::move(variant));
 }
 
 const char *CVariant::c_str() const

--- a/xbmc/utils/Variant.h
+++ b/xbmc/utils/Variant.h
@@ -59,15 +59,20 @@ public:
   CVariant(const char *str);
   CVariant(const char *str, unsigned int length);
   CVariant(const std::string &str);
+  CVariant(std::string &&str);
   CVariant(const wchar_t *str);
   CVariant(const wchar_t *str, unsigned int length);
   CVariant(const std::wstring &str);
+  CVariant(std::wstring &&str);
   CVariant(const std::vector<std::string> &strArray);
   CVariant(const std::map<std::string, std::string> &strMap);
   CVariant(const std::map<std::string, CVariant> &variantMap);
   CVariant(const CVariant &variant);
+  CVariant(CVariant &&rhs);
   ~CVariant();
 
+
+  
   bool isInteger() const;
   bool isUnsignedInteger() const;
   bool isBoolean() const;
@@ -94,11 +99,14 @@ public:
   const CVariant &operator[](unsigned int position) const;
 
   CVariant &operator=(const CVariant &rhs);
+  CVariant &operator=(CVariant &&rhs);
   bool operator==(const CVariant &rhs) const;
   bool operator!=(const CVariant &rhs) const { return !(*this == rhs); }
 
   void push_back(const CVariant &variant);
+  void push_back(CVariant &&variant);
   void append(const CVariant &variant);
+  void append(CVariant &&variant);
 
   const char *c_str() const;
 

--- a/xbmc/utils/test/TestJSONVariantParser.cpp
+++ b/xbmc/utils/test/TestJSONVariantParser.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "utils/JSONVariantParser.h"
+#include "utils/Variant.h"
 
 #include "gtest/gtest.h"
 

--- a/xbmc/utils/test/TestJSONVariantWriter.cpp
+++ b/xbmc/utils/test/TestJSONVariantWriter.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "utils/JSONVariantWriter.h"
+#include "utils/Variant.h"
 
 #include "gtest/gtest.h"
 

--- a/xbmc/utils/test/TestUrlOptions.cpp
+++ b/xbmc/utils/test/TestUrlOptions.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "utils/UrlOptions.h"
+#include "utils/Variant.h"
 
 #include "gtest/gtest.h"
 

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -63,6 +63,7 @@
 #include "video/VideoDbUrl.h"
 #include "playlists/SmartPlayList.h"
 #include "utils/GroupUtils.h"
+#include "utils/Variant.h"
 #include "Application.h"
 #include "guiinfo/GUIInfoLabels.h"
 
@@ -4071,10 +4072,10 @@ void CVideoDatabase::RemoveContentForPath(const std::string& strPath, CGUIDialog
 
     if (progress)
     {
-      progress->SetHeading(700);
-      progress->SetLine(0, "");
-      progress->SetLine(1, 313);
-      progress->SetLine(2, 330);
+      progress->SetHeading(CVariant{700});
+      progress->SetLine(0, CVariant{""});
+      progress->SetLine(1, CVariant{313});
+      progress->SetLine(2, CVariant{330});
       progress->SetPercentage(0);
       progress->StartModal();
       progress->ShowProgressBar(true);
@@ -7656,10 +7657,10 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const se
       progress = (CGUIDialogProgress *)g_windowManager.GetWindow(WINDOW_DIALOG_PROGRESS);
       if (progress)
       {
-        progress->SetHeading(700);
-        progress->SetLine(0, "");
-        progress->SetLine(1, 313);
-        progress->SetLine(2, 330);
+        progress->SetHeading(CVariant{700});
+        progress->SetLine(0, CVariant{""});
+        progress->SetLine(1, CVariant{313});
+        progress->SetLine(2, CVariant{330});
         progress->SetPercentage(0);
         progress->StartModal();
         progress->ShowProgressBar(true);
@@ -8034,10 +8035,10 @@ std::vector<int> CVideoDatabase::CleanMediaType(const std::string &mediaType, co
             if (pDialog != NULL)
             {
               CURL sourceUrl(sourcePath);
-              pDialog->SetHeading(15012);
-              pDialog->SetText(StringUtils::Format(g_localizeStrings.Get(15013).c_str(), sourceUrl.GetWithoutUserDetails().c_str()));
-              pDialog->SetChoice(0, 15015);
-              pDialog->SetChoice(1, 15014);
+              pDialog->SetHeading(CVariant{15012});
+              pDialog->SetText(CVariant{StringUtils::Format(g_localizeStrings.Get(15013).c_str(), sourceUrl.GetWithoutUserDetails().c_str())});
+              pDialog->SetChoice(0, CVariant{15015});
+              pDialog->SetChoice(1, CVariant{15014});
 
               //send message and wait for user input
               ThreadMessage tMsg = { TMSG_DIALOG_DOMODAL, WINDOW_DIALOG_YES_NO, g_windowManager.GetActiveWindow() };
@@ -8165,10 +8166,10 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFiles /* = 
 
     if (progress)
     {
-      progress->SetHeading(647);
-      progress->SetLine(0, 650);
-      progress->SetLine(1, "");
-      progress->SetLine(2, "");
+      progress->SetHeading(CVariant{647});
+      progress->SetLine(0, CVariant{650});
+      progress->SetLine(1, CVariant{""});
+      progress->SetLine(2, CVariant{""});
       progress->SetPercentage(0);
       progress->StartModal();
       progress->ShowProgressBar(true);
@@ -8213,7 +8214,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFiles /* = 
 
       if (progress)
       {
-        progress->SetLine(1, movie.m_strTitle);
+        progress->SetLine(1, CVariant{movie.m_strTitle});
         progress->SetPercentage(current * 100 / total);
         progress->Progress();
         if (progress->IsCanceled())
@@ -8310,7 +8311,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFiles /* = 
 
       if (progress)
       {
-        progress->SetLine(1, movie.m_strTitle);
+        progress->SetLine(1, CVariant{movie.m_strTitle});
         progress->SetPercentage(current * 100 / total);
         progress->Progress();
         if (progress->IsCanceled())
@@ -8408,7 +8409,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFiles /* = 
 
       if (progress)
       {
-        progress->SetLine(1, tvshow.m_strTitle);
+        progress->SetLine(1, CVariant{tvshow.m_strTitle});
         progress->SetPercentage(current * 100 / total);
         progress->Progress();
         if (progress->IsCanceled())
@@ -8608,7 +8609,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFiles /* = 
     progress->Close();
 
   if (iFailCount > 0)
-    CGUIDialogOK::ShowAndGetInput(647, StringUtils::Format(g_localizeStrings.Get(15011).c_str(), iFailCount));
+    CGUIDialogOK::ShowAndGetInput(CVariant{647}, CVariant{StringUtils::Format(g_localizeStrings.Get(15011).c_str(), iFailCount)});
 }
 
 void CVideoDatabase::ExportActorThumbs(const std::string &strDir, const CVideoInfoTag &tag, bool singleFiles, bool overwrite /*=false*/)
@@ -8654,10 +8655,10 @@ void CVideoDatabase::ImportFromXML(const std::string &path)
     progress = (CGUIDialogProgress *)g_windowManager.GetWindow(WINDOW_DIALOG_PROGRESS);
     if (progress)
     {
-      progress->SetHeading(648);
-      progress->SetLine(0, 649);
-      progress->SetLine(1, 330);
-      progress->SetLine(2, "");
+      progress->SetHeading(CVariant{648});
+      progress->SetLine(0, CVariant{649});
+      progress->SetLine(1, CVariant{330});
+      progress->SetLine(2, CVariant{""});
       progress->SetPercentage(0);
       progress->StartModal();
       progress->ShowProgressBar(true);
@@ -8794,7 +8795,7 @@ void CVideoDatabase::ImportFromXML(const std::string &path)
       if (progress && total)
       {
         progress->SetPercentage(current * 100 / total);
-        progress->SetLine(2, info.m_strTitle);
+        progress->SetLine(2, CVariant{info.m_strTitle});
         progress->Progress();
         if (progress->IsCanceled())
         {

--- a/xbmc/video/VideoDbUrl.h
+++ b/xbmc/video/VideoDbUrl.h
@@ -21,6 +21,8 @@
 
 #include "DbUrl.h"
 
+class CVariant;
+
 class CVideoDbUrl : public CDbUrl
 {
 public:

--- a/xbmc/video/VideoInfoDownloader.cpp
+++ b/xbmc/video/VideoInfoDownloader.cpp
@@ -24,6 +24,7 @@
 #include "ApplicationMessenger.h"
 #include "guilib/GUIWindowManager.h"
 #include "utils/log.h"
+#include "utils/Variant.h"
 
 using namespace std;
 using namespace VIDEO;
@@ -65,8 +66,8 @@ void CVideoInfoDownloader::ShowErrorDialog(const ADDON::CScraperError &sce)
   if (!sce.Title().empty())
   {
     CGUIDialogOK *pdlg = (CGUIDialogOK *)g_windowManager.GetWindow(WINDOW_DIALOG_OK);
-    pdlg->SetHeading(sce.Title());
-    pdlg->SetLine(0, sce.Message());
+    pdlg->SetHeading(CVariant{sce.Title()});
+    pdlg->SetLine(0, CVariant{sce.Message()});
     CApplicationMessenger::Get().DoModal(pdlg, WINDOW_DIALOG_OK);
   }
 }

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1412,8 +1412,8 @@ namespace VIDEO
   {
     if (pDlgProgress)
     {
-      pDlgProgress->SetLine(1, showInfo.m_strTitle);
-      pDlgProgress->SetLine(2, 20361);
+      pDlgProgress->SetLine(1, CVariant{showInfo.m_strTitle});
+      pDlgProgress->SetLine(2, CVariant{20361});
       pDlgProgress->SetPercentage(0);
       pDlgProgress->ShowProgressBar(true);
       pDlgProgress->Progress();
@@ -1429,7 +1429,7 @@ namespace VIDEO
       m_nfoReader.Close();
       if (pDlgProgress)
       {
-        pDlgProgress->SetLine(2, 20361);
+        pDlgProgress->SetLine(2, CVariant{20361});
         pDlgProgress->SetPercentage((int)((float)(iCurr++)/iMax*100));
         pDlgProgress->Progress();
       }
@@ -1480,7 +1480,7 @@ namespace VIDEO
 
           if (pDlgProgress)
           {
-            pDlgProgress->SetLine(2, 20354);
+            pDlgProgress->SetLine(2, CVariant{20354});
             pDlgProgress->Progress();
           }
 
@@ -1737,7 +1737,7 @@ namespace VIDEO
 
       if (pDialog)
       {
-        pDialog->SetLine(1, movieDetails.m_strTitle);
+        pDialog->SetLine(1, CVariant{movieDetails.m_strTitle});
         pDialog->Progress();
       }
 
@@ -2034,19 +2034,19 @@ namespace VIDEO
 
     if (pDialog)
     {
-      CGUIDialogOK::ShowAndGetInput(20448, 20449);
+      CGUIDialogOK::ShowAndGetInput(CVariant{20448}, CVariant{20449});
       return false;
     }
-    return CGUIDialogYesNo::ShowAndGetInput(20448, 20450);
+    return CGUIDialogYesNo::ShowAndGetInput(CVariant{20448}, CVariant{20450});
   }
 
   bool CVideoInfoScanner::ProgressCancelled(CGUIDialogProgress* progress, int heading, const std::string &line1)
   {
     if (progress)
     {
-      progress->SetHeading(heading);
-      progress->SetLine(0, line1);
-      progress->SetLine(2, "");
+      progress->SetHeading(CVariant{heading});
+      progress->SetLine(0, CVariant{line1});
+      progress->SetLine(2, CVariant{""});
       progress->Progress();
       return progress->IsCanceled();
     }

--- a/xbmc/video/VideoInfoTag.h
+++ b/xbmc/video/VideoInfoTag.h
@@ -31,6 +31,7 @@
 class CArchive;
 class TiXmlNode;
 class TiXmlElement;
+class CVariant;
 
 struct SActorInfo
 {

--- a/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
@@ -41,6 +41,7 @@
 #include "utils/log.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
+#include "utils/Variant.h"
 #include "video/VideoDatabase.h"
 
 #define SETTING_AUDIO_VOLUME                   "audio.volume"
@@ -228,7 +229,7 @@ void CGUIDialogAudioSubtitleSettings::Save()
     return;
 
   // prompt user if they are sure
-  if (!CGUIDialogYesNo::ShowAndGetInput(12376, 12377))
+  if (!CGUIDialogYesNo::ShowAndGetInput(CVariant{12376}, CVariant{12377}))
     return;
 
   // reset the settings

--- a/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.h
+++ b/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.h
@@ -22,6 +22,8 @@
 
 #include "settings/dialogs/GUIDialogSettingsManualBase.h"
 
+class CVariant;
+
 class CGUIDialogAudioSubtitleSettings : public CGUIDialogSettingsManualBase
 {
 public:

--- a/xbmc/video/dialogs/GUIDialogSubtitles.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitles.cpp
@@ -39,6 +39,7 @@
 #include "utils/log.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
+#include "utils/Variant.h"
 #include "URL.h"
 #include "Util.h"
 #include "video/VideoDatabase.h"
@@ -146,7 +147,7 @@ bool CGUIDialogSubtitles::OnMessage(CGUIMessage& message)
     else if (iControl == CONTROL_MANUALSEARCH)
     {
       //manual search
-      if (CGUIKeyboardFactory::ShowAndGetInput(m_strManualSearch, g_localizeStrings.Get(24121), true))
+      if (CGUIKeyboardFactory::ShowAndGetInput(m_strManualSearch, CVariant{g_localizeStrings.Get(24121)}, true))
       {
         Search(m_strManualSearch);
         return true;

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -56,9 +56,8 @@
 #include "filesystem/Directory.h"
 #include "filesystem/VideoDatabaseDirectory.h"
 #include "filesystem/VideoDatabaseDirectory/QueryParams.h"
-#ifdef HAS_UPNP
-#endif
 #include "utils/FileUtils.h"
+#include "utils/Variant.h"
 
 using namespace std;
 using namespace XFILE::VIDEODATABASEDIRECTORY;
@@ -117,7 +116,7 @@ bool CGUIDialogVideoInfo::OnMessage(CGUIMessage& message)
         if (m_movieItem->GetVideoInfoTag()->m_type == MediaTypeTvShow)
         {
           bool bCanceled=false;
-          if (CGUIDialogYesNo::ShowAndGetInput(20377, 20378, bCanceled))
+          if (CGUIDialogYesNo::ShowAndGetInput(CVariant{20377}, CVariant{20378}, bCanceled))
           {
             m_bRefreshAll = true;
             CVideoDatabase db;
@@ -435,10 +434,10 @@ void CGUIDialogVideoInfo::OnSearch(std::string& strSearch)
   CGUIDialogProgress *progress = (CGUIDialogProgress *)g_windowManager.GetWindow(WINDOW_DIALOG_PROGRESS);
   if (progress)
   {
-    progress->SetHeading(194);
-    progress->SetLine(0, strSearch);
-    progress->SetLine(1, "");
-    progress->SetLine(2, "");
+    progress->SetHeading(CVariant{194});
+    progress->SetLine(0, CVariant{strSearch});
+    progress->SetLine(1, CVariant{""});
+    progress->SetLine(2, CVariant{""});
     progress->StartModal();
     progress->Progress();
   }
@@ -452,7 +451,7 @@ void CGUIDialogVideoInfo::OnSearch(std::string& strSearch)
   {
     CGUIDialogSelect* pDlgSelect = (CGUIDialogSelect*)g_windowManager.GetWindow(WINDOW_DIALOG_SELECT);
     pDlgSelect->Reset();
-    pDlgSelect->SetHeading(283);
+    pDlgSelect->SetHeading(CVariant{283});
 
     for (int i = 0; i < (int)items.Size(); i++)
     {
@@ -474,7 +473,7 @@ void CGUIDialogVideoInfo::OnSearch(std::string& strSearch)
   }
   else
   {
-    CGUIDialogOK::ShowAndGetInput(194, 284);
+    CGUIDialogOK::ShowAndGetInput(CVariant{194}, CVariant{284});
   }
 }
 
@@ -602,7 +601,7 @@ string CGUIDialogVideoInfo::ChooseArtType(const CFileItem &videoItem, map<string
     return "";
 
   CFileItemList items;
-  dialog->SetHeading(13511);
+  dialog->SetHeading(CVariant{13511});
   dialog->Reset();
   dialog->SetUseDetails(true);
   dialog->EnableButton(true, 13516);
@@ -646,7 +645,7 @@ string CGUIDialogVideoInfo::ChooseArtType(const CFileItem &videoItem, map<string
   {
     // Get the new artwork name
     std::string strArtworkName;
-    if (!CGUIKeyboardFactory::ShowAndGetInput(strArtworkName, g_localizeStrings.Get(13516), false))
+    if (!CGUIKeyboardFactory::ShowAndGetInput(strArtworkName, CVariant{g_localizeStrings.Get(13516)}, false))
       return "";
 
     return strArtworkName;
@@ -1089,7 +1088,7 @@ bool CGUIDialogVideoInfo::UpdateVideoItemTitle(const CFileItemPtr &pItem)
   // dont allow update while scanning
   if (g_application.IsVideoScanning())
   {
-    CGUIDialogOK::ShowAndGetInput(257, 14057);
+    CGUIDialogOK::ShowAndGetInput(CVariant{257}, CVariant{14057});
     return false;
   }
 
@@ -1112,7 +1111,7 @@ bool CGUIDialogVideoInfo::UpdateVideoItemTitle(const CFileItemPtr &pItem)
     database.GetMusicVideoInfo(pItem->GetVideoInfoTag()->m_strFileNameAndPath, detail, iDbId);
 
   // get the new title
-  if (!CGUIKeyboardFactory::ShowAndGetInput(detail.m_strTitle, g_localizeStrings.Get(16105), false))
+  if (!CGUIKeyboardFactory::ShowAndGetInput(detail.m_strTitle, CVariant{g_localizeStrings.Get(16105)}, false))
     return false;
 
   database.UpdateMovieTitle(iDbId, detail.m_strTitle, iType);
@@ -1144,7 +1143,7 @@ bool CGUIDialogVideoInfo::DeleteVideoItemFromDatabase(const CFileItemPtr &item, 
   // dont allow update while scanning
   if (g_application.IsVideoScanning())
   {
-    CGUIDialogOK::ShowAndGetInput(257, 14057);
+    CGUIDialogOK::ShowAndGetInput(CVariant{257}, CVariant{14057});
     return false;
   }
 
@@ -1176,19 +1175,19 @@ bool CGUIDialogVideoInfo::DeleteVideoItemFromDatabase(const CFileItemPtr &item, 
       return false;
   }
 
-  pDialog->SetHeading(heading);
+  pDialog->SetHeading(CVariant{heading});
 
   if (unavailable)
   {
-    pDialog->SetLine(0, g_localizeStrings.Get(662));
-    pDialog->SetLine(1, g_localizeStrings.Get(663));
+    pDialog->SetLine(0, CVariant{g_localizeStrings.Get(662)});
+    pDialog->SetLine(1, CVariant{g_localizeStrings.Get(663)});
   }
   else
   {
-    pDialog->SetLine(0, StringUtils::Format(g_localizeStrings.Get(433).c_str(), item->GetLabel().c_str()));
-    pDialog->SetLine(1, "");
+    pDialog->SetLine(0, CVariant{StringUtils::Format(g_localizeStrings.Get(433).c_str(), item->GetLabel().c_str())});
+    pDialog->SetLine(1, CVariant{""});
   }
-  pDialog->SetLine(2, "");
+  pDialog->SetLine(2, CVariant{""});
   pDialog->DoModal();
 
   if (!pDialog->IsConfirmed())
@@ -1319,7 +1318,6 @@ bool CGUIDialogVideoInfo::GetMoviesForSet(const CFileItem *setItem, CFileItemLis
   if (!videodb.Open())
     return false;
 
-  std::string strHeading = g_localizeStrings.Get(20457);
   std::string baseDir = StringUtils::Format("videodb://movies/sets/%d", setItem->GetVideoInfoTag()->m_iDbId);
 
   if (!CDirectory::GetDirectory(baseDir, originalMovies) || originalMovies.Size() <= 0) // keep a copy of the original members of the set
@@ -1337,7 +1335,7 @@ bool CGUIDialogVideoInfo::GetMoviesForSet(const CFileItem *setItem, CFileItemLis
 
   dialog->Reset();
   dialog->SetMultiSelection(true);
-  dialog->SetHeading(strHeading);
+  dialog->SetHeading(CVariant{g_localizeStrings.Get(20457)});
   dialog->SetItems(&listItems);
   vector<int> selectedIndices;
   for (int i = 0; i < originalMovies.Size(); i++)
@@ -1406,9 +1404,8 @@ bool CGUIDialogVideoInfo::GetSetForMovie(const CFileItem *movieItem, CFileItemPt
   if (dialog == NULL)
     return false;
 
-  std::string strHeading = g_localizeStrings.Get(20466);
   dialog->Reset();
-  dialog->SetHeading(strHeading);
+  dialog->SetHeading(CVariant{g_localizeStrings.Get(20466)});
   dialog->SetItems(&listItems);
   if (currentSetId >= 0)
   {
@@ -1427,7 +1424,7 @@ bool CGUIDialogVideoInfo::GetSetForMovie(const CFileItem *movieItem, CFileItemPt
   if (dialog->IsButtonPressed())
   { // creating new set
     std::string newSetTitle;
-    if (!CGUIKeyboardFactory::ShowAndGetInput(newSetTitle, g_localizeStrings.Get(20468), false))
+    if (!CGUIKeyboardFactory::ShowAndGetInput(newSetTitle, CVariant{g_localizeStrings.Get(20468)}, false))
       return false;
     int idSet = videodb.AddSet(newSetTitle);
     map<string, string> movieArt, setArt;
@@ -1518,7 +1515,7 @@ bool CGUIDialogVideoInfo::GetItemsForTag(const std::string &strHeading, const st
 
   dialog->Reset();
   dialog->SetMultiSelection(true);
-  dialog->SetHeading(strHeading);
+  dialog->SetHeading(CVariant{strHeading});
   dialog->SetItems(&listItems);
   dialog->EnableButton(true, 186);
   dialog->DoModal();
@@ -1789,7 +1786,7 @@ bool CGUIDialogVideoInfo::UpdateVideoItemSortTitle(const CFileItemPtr &pItem)
   // dont allow update while scanning
   if (g_application.IsVideoScanning())
   {
-    CGUIDialogOK::ShowAndGetInput(257, 14057);
+    CGUIDialogOK::ShowAndGetInput(CVariant{257}, CVariant{14057});
     return false;
   }
 
@@ -1812,7 +1809,7 @@ bool CGUIDialogVideoInfo::UpdateVideoItemSortTitle(const CFileItemPtr &pItem)
     currentTitle = detail.m_strSortTitle;
   
   // get the new sort title
-  if (!CGUIKeyboardFactory::ShowAndGetInput(currentTitle, g_localizeStrings.Get(16107), false))
+  if (!CGUIKeyboardFactory::ShowAndGetInput(currentTitle, CVariant{g_localizeStrings.Get(16107)}, false))
     return false;
 
   return database.UpdateVideoSortTitle(iDbId, currentTitle, iType);
@@ -1868,7 +1865,7 @@ bool CGUIDialogVideoInfo::LinkMovieToTvShow(const CFileItemPtr &item, bool bRemo
     CGUIDialogSelect* pDialog = (CGUIDialogSelect*)g_windowManager.GetWindow(WINDOW_DIALOG_SELECT);
     pDialog->Reset();
     pDialog->SetItems(&list);
-    pDialog->SetHeading(20356);
+    pDialog->SetHeading(CVariant{20356});
     pDialog->DoModal();
     iSelectedLabel = pDialog->GetSelectedLabel();
   }

--- a/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
@@ -34,6 +34,7 @@
 #include "settings/lib/SettingsManager.h"
 #include "utils/log.h"
 #include "video/VideoDatabase.h"
+#include "utils/Variant.h"
 
 #define SETTING_VIDEO_VIEW_MODE           "video.viewmode"
 #define SETTING_VIDEO_ZOOM                "video.zoom"
@@ -169,7 +170,7 @@ void CGUIDialogVideoSettings::Save()
     return;
 
   // prompt user if they are sure
-  if (CGUIDialogYesNo::ShowAndGetInput(12376, 12377))
+  if (CGUIDialogYesNo::ShowAndGetInput(CVariant(12376), CVariant(12377)))
   { // reset the settings
     CVideoDatabase db;
     if (!db.Open())

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -23,7 +23,6 @@
 #include "Util.h"
 #include "video/VideoInfoDownloader.h"
 #include "video/VideoInfoScanner.h"
-#include "utils/Variant.h"
 #include "addons/GUIDialogAddonInfo.h"
 #include "video/dialogs/GUIDialogVideoInfo.h"
 #include "dialogs/GUIDialogSmartPlaylistEditor.h"
@@ -54,6 +53,7 @@
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 #include "utils/FileUtils.h"
+#include "utils/Variant.h"
 #include "pvr/PVRManager.h"
 #include "pvr/recordings/PVRRecordings.h"
 #include "utils/URIUtils.h"
@@ -253,7 +253,7 @@ void CGUIWindowVideoBase::OnInfo(CFileItem* pItem, ADDON::ScraperPtr& scraper)
       // no video file in this folder
       if (!bFoundFile)
       {
-        CGUIDialogOK::ShowAndGetInput(13346, 20349);
+        CGUIDialogOK::ShowAndGetInput(CVariant{13346}, CVariant{20349});
         return;
       }
     }
@@ -400,7 +400,7 @@ bool CGUIWindowVideoBase::ShowIMDB(CFileItem *item, const ScraperPtr &info2, boo
 
   if (g_application.IsVideoScanning())
   {
-    CGUIDialogOK::ShowAndGetInput(13346, 14057);
+    CGUIDialogOK::ShowAndGetInput(CVariant{13346}, CVariant{14057});
     return false;
   }
 
@@ -437,7 +437,7 @@ bool CGUIWindowVideoBase::ShowIMDB(CFileItem *item, const ScraperPtr &info2, boo
         bHasInfo = true;
         if (!info->IsNoop() && (nfoResult == CNfoFile::URL_NFO || nfoResult == CNfoFile::COMBINED_NFO || nfoResult == CNfoFile::FULL_NFO))
         {
-          if (CGUIDialogYesNo::ShowAndGetInput(13346, 20446))
+          if (CGUIDialogYesNo::ShowAndGetInput(CVariant{13346}, CVariant{20446}))
           {
             hasDetails = false;
             ignoreNfo = true;
@@ -458,10 +458,10 @@ bool CGUIWindowVideoBase::ShowIMDB(CFileItem *item, const ScraperPtr &info2, boo
     {
       // 4a. show dialog that we're busy querying www.imdb.com
       std::string strHeading = StringUtils::Format(g_localizeStrings.Get(197).c_str(),info->Name().c_str());
-      pDlgProgress->SetHeading(strHeading);
-      pDlgProgress->SetLine(0, movieName);
-      pDlgProgress->SetLine(1, "");
-      pDlgProgress->SetLine(2, "");
+      pDlgProgress->SetHeading(CVariant{std::move(strHeading)});
+      pDlgProgress->SetLine(0, CVariant{movieName}); //don't use std::move as it's used further down
+      pDlgProgress->SetLine(1, CVariant{""});
+      pDlgProgress->SetLine(2, CVariant{""});
       pDlgProgress->StartModal();
       pDlgProgress->Progress();
 
@@ -477,7 +477,7 @@ bool CGUIWindowVideoBase::ShowIMDB(CFileItem *item, const ScraperPtr &info2, boo
           int iString = 196;
           if (info->Content() == CONTENT_TVSHOWS)
             iString = 20356;
-          pDlgSelect->SetHeading(iString);
+          pDlgSelect->SetHeading(CVariant{iString});
           pDlgSelect->Reset();
           for (unsigned int i = 0; i < movielist.size(); ++i)
             pDlgSelect->Add(movielist[i].strTitle);
@@ -521,7 +521,7 @@ bool CGUIWindowVideoBase::ShowIMDB(CFileItem *item, const ScraperPtr &info2, boo
       int iString = 16009;
       if (info->Content() == CONTENT_TVSHOWS)
         iString = 20357;
-      if (!CGUIKeyboardFactory::ShowAndGetInput(movieName, g_localizeStrings.Get(iString), false))
+      if (!CGUIKeyboardFactory::ShowAndGetInput(movieName, CVariant{g_localizeStrings.Get(iString)}, false))
       {
         m_database.Close();
         return listNeedsUpdating; // user backed out
@@ -587,10 +587,10 @@ bool CGUIWindowVideoBase::ShowIMDB(CFileItem *item, const ScraperPtr &info2, boo
       }
       if (info->Content() == CONTENT_MUSICVIDEOS)
         iString = 20394;
-      pDlgProgress->SetHeading(iString);
-      pDlgProgress->SetLine(0, movieName);
-      pDlgProgress->SetLine(1, scrUrl.strTitle);
-      pDlgProgress->SetLine(2, "");
+      pDlgProgress->SetHeading(CVariant{iString});
+      pDlgProgress->SetLine(0, CVariant{movieName});
+      pDlgProgress->SetLine(1, CVariant{scrUrl.strTitle});
+      pDlgProgress->SetLine(2, CVariant{""});
       pDlgProgress->StartModal();
       pDlgProgress->Progress();
       if (bHasInfo && movieDetails.m_iDbId != -1)
@@ -649,7 +649,7 @@ bool CGUIWindowVideoBase::ShowIMDB(CFileItem *item, const ScraperPtr &info2, boo
           m_database.Close();
           return listNeedsUpdating; // user cancelled
         }
-        CGUIDialogOK::ShowAndGetInput(195, movieName);
+        CGUIDialogOK::ShowAndGetInput(CVariant{195}, CVariant{movieName});
         m_database.Close();
         return listNeedsUpdating;
       }
@@ -762,7 +762,7 @@ void CGUIWindowVideoBase::AddItemToPlayList(const CFileItemPtr &pItem, CFileItem
         // load it
         if (!pPlayList->Load(pItem->GetPath()))
         {
-          CGUIDialogOK::ShowAndGetInput(6, 477);
+          CGUIDialogOK::ShowAndGetInput(CVariant{6}, CVariant{477});
           return; //hmmm unable to load playlist?
         }
 
@@ -1397,7 +1397,7 @@ bool CGUIWindowVideoBase::OnPlayMedia(int iItem)
       else
       {
         CLog::Log(LOGERROR, "CGUIWindowTV: Can't open recording, no valid filename!");
-        CGUIDialogOK::ShowAndGetInput(19033, 19036);
+        CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{19036});
         return false;
       }
     }
@@ -1485,7 +1485,7 @@ void CGUIWindowVideoBase::LoadPlayList(const std::string& strPlayList, int iPlay
     // load it
     if (!pPlayList->Load(strPlayList))
     {
-      CGUIDialogOK::ShowAndGetInput(6, 477);
+      CGUIDialogOK::ShowAndGetInput(CVariant{6}, CVariant{477});
       return; //hmmm unable to load playlist?
     }
   }
@@ -1673,7 +1673,7 @@ void CGUIWindowVideoBase::AddToDatabase(int iItem)
   // prompt for data
   // enter a new title
   std::string strTitle = pItem->GetLabel();
-  if (!CGUIKeyboardFactory::ShowAndGetInput(strTitle, g_localizeStrings.Get(528), false)) // Enter Title
+  if (!CGUIKeyboardFactory::ShowAndGetInput(strTitle, CVariant{g_localizeStrings.Get(528)}, false)) // Enter Title
     return;
 
   // pick genre
@@ -1681,7 +1681,7 @@ void CGUIWindowVideoBase::AddToDatabase(int iItem)
   if (!pSelect)
     return;
 
-  pSelect->SetHeading(530); // Select Genre
+  pSelect->SetHeading(CVariant{530}); // Select Genre
   pSelect->Reset();
   CFileItemList items;
   if (!CDirectory::GetDirectory("videodb://movies/genres/", items))
@@ -1700,7 +1700,7 @@ void CGUIWindowVideoBase::AddToDatabase(int iItem)
   if (strGenre.empty())
   {
     strGenre = g_localizeStrings.Get(532); // Manual Addition
-    if (!CGUIKeyboardFactory::ShowAndGetInput(strGenre, g_localizeStrings.Get(533), false)) // Enter Genre
+    if (!CGUIKeyboardFactory::ShowAndGetInput(strGenre, CVariant{g_localizeStrings.Get(533)}, false)) // Enter Genre
       return; // user backed out
     if (strGenre.empty())
       return; // no genre string
@@ -1718,7 +1718,9 @@ void CGUIWindowVideoBase::AddToDatabase(int iItem)
   m_database.Close();
 
   // done...
-  CGUIDialogOK::ShowAndGetInput(20177, movie.m_strTitle, StringUtils::Join(movie.m_genre, g_advancedSettings.m_videoItemSeparator), movie.m_strIMDBNumber);
+  CGUIDialogOK::ShowAndGetInput(CVariant{20177}, CVariant{movie.m_strTitle},
+                                CVariant{StringUtils::Join(movie.m_genre, g_advancedSettings.m_videoItemSeparator)},
+                                CVariant{movie.m_strIMDBNumber});
 
   // library view cache needs to be cleared
   CUtil::DeleteVideoDatabaseDirectoryCache();
@@ -1728,16 +1730,16 @@ void CGUIWindowVideoBase::AddToDatabase(int iItem)
 void CGUIWindowVideoBase::OnSearch()
 {
   std::string strSearch;
-  if (!CGUIKeyboardFactory::ShowAndGetInput(strSearch, g_localizeStrings.Get(16017), false))
+  if (!CGUIKeyboardFactory::ShowAndGetInput(strSearch, CVariant{g_localizeStrings.Get(16017)}, false))
     return ;
 
   StringUtils::ToLower(strSearch);
   if (m_dlgProgress)
   {
-    m_dlgProgress->SetHeading(194);
-    m_dlgProgress->SetLine(0, strSearch);
-    m_dlgProgress->SetLine(1, "");
-    m_dlgProgress->SetLine(2, "");
+    m_dlgProgress->SetHeading(CVariant{194});
+    m_dlgProgress->SetLine(0, CVariant{strSearch});
+    m_dlgProgress->SetLine(1, CVariant{""});
+    m_dlgProgress->SetLine(2, CVariant{""});
     m_dlgProgress->StartModal();
     m_dlgProgress->Progress();
   }
@@ -1751,7 +1753,7 @@ void CGUIWindowVideoBase::OnSearch()
   {
     CGUIDialogSelect* pDlgSelect = (CGUIDialogSelect*)g_windowManager.GetWindow(WINDOW_DIALOG_SELECT);
     pDlgSelect->Reset();
-    pDlgSelect->SetHeading(283);
+    pDlgSelect->SetHeading(CVariant{283});
 
     for (int i = 0; i < (int)items.Size(); i++)
     {
@@ -1771,7 +1773,7 @@ void CGUIWindowVideoBase::OnSearch()
   }
   else
   {
-    CGUIDialogOK::ShowAndGetInput(194, 284);
+    CGUIDialogOK::ShowAndGetInput(CVariant{194}, CVariant{284});
   }
 }
 
@@ -1888,7 +1890,7 @@ bool CGUIWindowVideoBase::OnUnAssignContent(const std::string &path, int header,
   bool bCanceled;
   CVideoDatabase db;
   db.Open();
-  if (CGUIDialogYesNo::ShowAndGetInput(header, text, bCanceled))
+  if (CGUIDialogYesNo::ShowAndGetInput(CVariant{header}, CVariant{text}, bCanceled))
   {
     CGUIDialogProgress *progress = (CGUIDialogProgress *)g_windowManager.GetWindow(WINDOW_DIALOG_PROGRESS);
     db.RemoveContentForPath(path, progress);

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -45,11 +45,14 @@
 #include "utils/log.h"
 #include "utils/URIUtils.h"
 #include "utils/StringUtils.h"
+#include "utils/Variant.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "video/VideoInfoScanner.h"
 #include "video/dialogs/GUIDialogVideoInfo.h"
 #include "pvr/recordings/PVRRecording.h"
 #include "ContextMenuManager.h"
+
+#include <utility>
 
 using namespace XFILE;
 using namespace VIDEODATABASEDIRECTORY;
@@ -750,10 +753,10 @@ void CGUIWindowVideoNav::OnDeleteItem(CFileItemPtr pItem)
            pItem->GetPath().size() > 22 && pItem->m_bIsFolder)
   {
     CGUIDialogYesNo* pDialog = (CGUIDialogYesNo*)g_windowManager.GetWindow(WINDOW_DIALOG_YES_NO);
-    pDialog->SetHeading(432);
+    pDialog->SetHeading(CVariant{432});
     std::string strLabel = StringUtils::Format(g_localizeStrings.Get(433).c_str(),pItem->GetLabel().c_str());
-    pDialog->SetLine(1, strLabel);
-    pDialog->SetLine(2, "");;
+    pDialog->SetLine(1, CVariant{std::move(strLabel)});
+    pDialog->SetLine(2, CVariant{""});
     pDialog->DoModal();
     if (pDialog->IsConfirmed())
     {
@@ -771,10 +774,9 @@ void CGUIWindowVideoNav::OnDeleteItem(CFileItemPtr pItem)
   else if (m_vecItems->GetContent() == "tags" && pItem->m_bIsFolder)
   {
     CGUIDialogYesNo* pDialog = (CGUIDialogYesNo*)g_windowManager.GetWindow(WINDOW_DIALOG_YES_NO);
-    pDialog->SetHeading(432);
-    std::string strLabel = StringUtils::Format(g_localizeStrings.Get(433).c_str(), pItem->GetLabel().c_str());
-    pDialog->SetLine(1, strLabel);
-    pDialog->SetLine(2, "");
+    pDialog->SetHeading(CVariant{432});
+    pDialog->SetLine(1, CVariant{ StringUtils::Format(g_localizeStrings.Get(433).c_str(), pItem->GetLabel().c_str()) });
+    pDialog->SetLine(2, CVariant{""});
     pDialog->DoModal();
     if (pDialog->IsConfirmed())
     {
@@ -1085,7 +1087,7 @@ bool CGUIWindowVideoNav::OnClick(int iItem)
     }
     else
     {
-      CGUIDialogOK::ShowAndGetInput(257, 662);
+      CGUIDialogOK::ShowAndGetInput(CVariant{257}, CVariant{662});
       return true;
     }	  
   }
@@ -1094,13 +1096,13 @@ bool CGUIWindowVideoNav::OnClick(int iItem)
     // dont allow update while scanning
     if (g_application.IsVideoScanning())
     {
-      CGUIDialogOK::ShowAndGetInput(257, 14057);
+      CGUIDialogOK::ShowAndGetInput(CVariant{257}, CVariant{14057});
       return true;
     }
 
     //Get the new title
     std::string strTag;
-    if (!CGUIKeyboardFactory::ShowAndGetInput(strTag, g_localizeStrings.Get(20462), false))
+    if (!CGUIKeyboardFactory::ShowAndGetInput(strTag, CVariant{g_localizeStrings.Get(20462)}, false))
       return true;
 
     CVideoDatabase videodb;
@@ -1117,7 +1119,7 @@ bool CGUIWindowVideoNav::OnClick(int iItem)
     if (!videodb.GetSingleValue("tag", "tag.tag_id", videodb.PrepareSQL("tag.name = '%s' AND tag.tag_id IN (SELECT tag_link.tag_id FROM tag_link WHERE tag_link.media_type = '%s')", strTag.c_str(), mediaType.c_str())).empty())
     {
       std::string strError = StringUtils::Format(g_localizeStrings.Get(20463).c_str(), strTag.c_str());
-      CGUIDialogOK::ShowAndGetInput(20462, strError);
+      CGUIDialogOK::ShowAndGetInput(CVariant{20462}, CVariant{std::move(strError)});
       return true;
     }
 

--- a/xbmc/video/windows/GUIWindowVideoPlaylist.cpp
+++ b/xbmc/video/windows/GUIWindowVideoPlaylist.cpp
@@ -35,6 +35,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "utils/log.h"
 #include "utils/URIUtils.h"
+#include "utils/Variant.h"
 #include "ContextMenuManager.h"
 
 using namespace PLAYLIST;
@@ -372,7 +373,7 @@ void CGUIWindowVideoPlaylist::RemovePlayListItem(int iItem)
 void CGUIWindowVideoPlaylist::SavePlayList()
 {
   std::string strNewFileName;
-  if (CGUIKeyboardFactory::ShowAndGetInput(strNewFileName, g_localizeStrings.Get(16012), false))
+  if (CGUIKeyboardFactory::ShowAndGetInput(strNewFileName, CVariant{g_localizeStrings.Get(16012)}, false))
   {
     // need 2 rename it
     std::string strFolder = URIUtils::AddFileToFolder(CSettings::Get().GetString("system.playlistspath"), "video");

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -66,6 +66,7 @@
 #include "utils/SortUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
+#include "utils/Variant.h"
 #include "video/VideoLibraryQueue.h"
 
 #define CONTROL_BTNVIEWASICONS       2
@@ -1064,7 +1065,7 @@ bool CGUIMediaWindow::HaveDiscOrConnection(const std::string& strPath, int iDriv
   {
     if (!g_mediaManager.IsDiscInDrive(strPath))
     {
-      CGUIDialogOK::ShowAndGetInput(218, 219);
+      CGUIDialogOK::ShowAndGetInput(CVariant{218}, CVariant{219});
       return false;
     }
   }
@@ -1073,7 +1074,7 @@ bool CGUIMediaWindow::HaveDiscOrConnection(const std::string& strPath, int iDriv
     // TODO: Handle not connected to a remote share
     if ( !g_application.getNetwork().IsConnected() )
     {
-      CGUIDialogOK::ShowAndGetInput(220, 221);
+      CGUIDialogOK::ShowAndGetInput(CVariant{220}, CVariant{221});
       return false;
     }
   }
@@ -1097,7 +1098,7 @@ void CGUIMediaWindow::ShowShareErrorMessage(CFileItem* pItem)
   else
     idMessageText = 15300; // Path not found or invalid
 
-  CGUIDialogOK::ShowAndGetInput(220, idMessageText);
+  CGUIDialogOK::ShowAndGetInput(CVariant{220}, CVariant{idMessageText});
 }
 
 // \brief The functon goes up one level in the directory tree
@@ -1640,8 +1641,8 @@ bool CGUIMediaWindow::WaitForNetwork() const
     return true;
 
   CURL url(m_vecItems->GetPath());
-  progress->SetHeading(1040); // Loading Directory
-  progress->SetLine(1, url.GetWithoutUserDetails());
+  progress->SetHeading(CVariant{1040}); // Loading Directory
+  progress->SetLine(1, CVariant{url.GetWithoutUserDetails()});
   progress->ShowProgressBar(false);
   progress->StartModal();
   while (!g_application.getNetwork().IsAvailable())

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -54,6 +54,7 @@
 #include "utils/FileOperationJob.h"
 #include "utils/FileUtils.h"
 #include "utils/URIUtils.h"
+#include "utils/Variant.h"
 #include "Autorun.h"
 #include "URL.h"
 
@@ -596,7 +597,7 @@ void CGUIWindowFileManager::OnStart(CFileItem *pItem)
     {
       if (!pPlayList->Load(strPlayList))
       {
-        CGUIDialogOK::ShowAndGetInput(6, 477);
+        CGUIDialogOK::ShowAndGetInput(CVariant{6}, CVariant{477});
         return;
       }
     }
@@ -637,7 +638,7 @@ bool CGUIWindowFileManager::HaveDiscOrConnection( std::string& strPath, int iDri
   {
     if ( !g_mediaManager.IsDiscInDrive(strPath) )
     {
-      CGUIDialogOK::ShowAndGetInput(218, 219);
+      CGUIDialogOK::ShowAndGetInput(CVariant{218}, CVariant{219});
       int iList = GetFocusedList();
       int iItem = GetSelectedItem(iList);
       Update(iList, "");
@@ -650,7 +651,7 @@ bool CGUIWindowFileManager::HaveDiscOrConnection( std::string& strPath, int iDri
     // TODO: Handle not connected to a remote share
     if ( !g_application.getNetwork().IsConnected() )
     {
-      CGUIDialogOK::ShowAndGetInput(220, 221);
+      CGUIDialogOK::ShowAndGetInput(CVariant{220}, CVariant{221});
       return false;
     }
   }
@@ -684,7 +685,7 @@ void CGUIWindowFileManager::OnMark(int iList, int iItem)
 
 void CGUIWindowFileManager::OnCopy(int iList)
 {
-  if (!CGUIDialogYesNo::ShowAndGetInput(120, 123))
+  if (!CGUIDialogYesNo::ShowAndGetInput(CVariant{120}, CVariant{123}))
     return;
 
   AddJob(new CFileOperationJob(CFileOperationJob::ActionCopy, 
@@ -695,7 +696,7 @@ void CGUIWindowFileManager::OnCopy(int iList)
 
 void CGUIWindowFileManager::OnMove(int iList)
 {
-  if (!CGUIDialogYesNo::ShowAndGetInput(121, 124))
+  if (!CGUIDialogYesNo::ShowAndGetInput(CVariant{121}, CVariant{124}))
     return;
 
   AddJob(new CFileOperationJob(CFileOperationJob::ActionMove,
@@ -706,7 +707,7 @@ void CGUIWindowFileManager::OnMove(int iList)
 
 void CGUIWindowFileManager::OnDelete(int iList)
 {
-  if (!CGUIDialogYesNo::ShowAndGetInput(122, 125))
+  if (!CGUIDialogYesNo::ShowAndGetInput(CVariant{122}, CVariant{125}))
     return;
 
   AddJob(new CFileOperationJob(CFileOperationJob::ActionDelete,
@@ -748,7 +749,7 @@ void CGUIWindowFileManager::OnSelectAll(int iList)
 void CGUIWindowFileManager::OnNewFolder(int iList)
 {
   std::string strNewFolder = "";
-  if (CGUIKeyboardFactory::ShowAndGetInput(strNewFolder, g_localizeStrings.Get(16014), false))
+  if (CGUIKeyboardFactory::ShowAndGetInput(strNewFolder, CVariant{g_localizeStrings.Get(16014)}, false))
   {
     std::string strNewPath = m_Directory[iList]->GetPath();
     URIUtils::AddSlashAtEnd(strNewPath);
@@ -1047,9 +1048,9 @@ void CGUIWindowFileManager::OnPopupMenu(int list, int item, bool bContextDriven 
     CGUIDialogProgress *progress = (CGUIDialogProgress *)g_windowManager.GetWindow(WINDOW_DIALOG_PROGRESS);
     if (progress)
     {
-      progress->SetHeading(13394);
+      progress->SetHeading(CVariant{13394});
       for (int i=0; i < 3; i++)
-        progress->SetLine(i, "");
+        progress->SetLine(i, CVariant{""});
       progress->StartModal();
     }
 
@@ -1144,8 +1145,8 @@ void CGUIWindowFileManager::OnJobComplete(unsigned int jobID, bool success, CJob
   if(!success)
   {
     CFileOperationJob* fileJob = (CFileOperationJob*)job;
-    CGUIDialogOK::ShowAndGetInput(fileJob->GetHeading(),
-                                  fileJob->GetLine(), 16200, 0);
+    CGUIDialogOK::ShowAndGetInput(CVariant{fileJob->GetHeading()},
+                                  CVariant{fileJob->GetLine()}, CVariant{16200}, CVariant{0});
   }
 
   if (IsActive())
@@ -1169,7 +1170,7 @@ void CGUIWindowFileManager::ShowShareErrorMessage(CFileItem* pItem)
   else
     idMessageText = 15300; // Path not found or invalid
 
-  CGUIDialogOK::ShowAndGetInput(220, idMessageText);
+  CGUIDialogOK::ShowAndGetInput(CVariant{220}, CVariant{idMessageText});
 }
 
 void CGUIWindowFileManager::OnInitWindow()

--- a/xbmc/windows/GUIWindowHome.h
+++ b/xbmc/windows/GUIWindowHome.h
@@ -24,6 +24,8 @@
 #include "interfaces/IAnnouncer.h"
 #include "utils/Job.h"
 
+class CVariant;
+
 class CGUIWindowHome :
       public CGUIWindow,
       public ANNOUNCEMENT::IAnnouncer,

--- a/xbmc/windows/GUIWindowLoginScreen.cpp
+++ b/xbmc/windows/GUIWindowLoginScreen.cpp
@@ -34,6 +34,7 @@
 #include "utils/log.h"
 #include "utils/Weather.h"
 #include "utils/StringUtils.h"
+#include "utils/Variant.h"
 #include "network/Network.h"
 #include "addons/Skin.h"
 #include "guilib/GUIMessage.h"
@@ -112,7 +113,7 @@ bool CGUIWindowLoginScreen::OnMessage(CGUIMessage& message)
           else
           {
             if (!bCanceled && iItem != 0)
-              CGUIDialogOK::ShowAndGetInput(20068, 20117);
+              CGUIDialogOK::ShowAndGetInput(CVariant{20068}, CVariant{20117});
           }
         }
       }

--- a/xbmc/windows/GUIWindowWeather.cpp
+++ b/xbmc/windows/GUIWindowWeather.cpp
@@ -24,6 +24,7 @@
 #include "GUIWindowWeather.h"
 #include "utils/Weather.h"
 #include "utils/URIUtils.h"
+#include "utils/Variant.h"
 #ifdef HAS_PYTHON
 #endif
 #include "LangInfo.h"


### PR DESCRIPTION
Added Move constructors for a few types for CVariant and added
move versions to push_back and append.
Added plenty of include directives as they were missing.
Made many conversions to CVariant explicit to make it clear what happens and that the include is needed.
