### PR TITLE
consider a CURLINFO_RESPONSE_CODE of zero a failed request

### DIFF
--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -962,7 +962,7 @@ bool CCurlFile::Open(const CURL& url)
   m_state->m_sendRange = m_seekable;
 
   m_httpresponse = m_state->Connect(m_bufferSize);
-  if (m_httpresponse < 0 || m_httpresponse >= 400)
+  if (m_httpresponse <= 0 || m_httpresponse >= 400)
   {
     CLog::Log(LOGERROR, "CCurlFile::Open failed with code %li for %s", m_httpresponse, url.GetRedacted().c_str());
     return false;


### PR DESCRIPTION
Currently without this `CCurlFile::Open()` will happily return true even when the server could not be contacted. I believe this broke in https://github.com/xbmc/xbmc/commit/93db3b5f0ab72e0f27ff44814d292755b82d6f73 since cURL also happily reports CURLE_OK even when no response is received.
