### PR TITLE
[GL] Fixed: FontTTF breaks scissor which causes bad rendering with di…

### DIFF
--- a/xbmc/guilib/GUIFontTTFGL.cpp
+++ b/xbmc/guilib/GUIFontTTFGL.cpp
@@ -212,13 +212,22 @@ void CGUIFontTTFGL::LastEnd()
 
     // Bind our pre-calculated array to GL_ELEMENT_ARRAY_BUFFER
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_elementArrayHandle);
+    // Store currect scissor
+    CRect scissor = g_graphicsContext.StereoCorrection(g_graphicsContext.GetScissors());
 
     for (size_t i = 0; i < m_vertexTrans.size(); i++)
     {
       // Apply the clip rectangle
       CRect clip = g_Windowing.ClipRectToScissorRect(m_vertexTrans[i].clip);
       if (!clip.IsEmpty())
+      {
+        // intersect with current scissor
+        clip.Intersect(scissor);
+        // skip empty clip
+        if (clip.IsEmpty())
+          continue;
         g_Windowing.SetScissors(clip);
+      }
 
       // Apply the translation to the currently active (top-of-stack) model view matrix
       glMatrixModview.Push();
@@ -247,7 +256,7 @@ void CGUIFontTTFGL::LastEnd()
       glMatrixModview.Pop();
     }
     // Restore the original scissor rectangle
-    g_Windowing.ResetScissors();
+    g_Windowing.SetScissors(scissor);
     // Restore the original model view matrix
     glUniformMatrix4fv(modelLoc, 1, GL_FALSE, glMatrixModview.Get());
     // Unbind GL_ARRAY_BUFFER and GL_ELEMENT_ARRAY_BUFFER


### PR DESCRIPTION
…rty regions.

I encountered with same issue in dx11 version.

I didn't test this with OpenGL but this fixes ugly rendering with dirty regions algorithm 1 and 2 in dx11 branch.

Still exists an issue when control still rendering whose rendering region  does not overlap with the dirty region. The issue causes performance issue. 

@fritsch @FernetMenta - your comments are welcome.
