### PR TITLE
[pvr] bump pvr.hts to 2.1.10

### DIFF
--- a/project/cmake/addons/addons/pvr.hts/pvr.hts.txt
+++ b/project/cmake/addons/addons/pvr.hts/pvr.hts.txt
@@ -1,1 +1,1 @@
-pvr.hts https://github.com/kodi-pvr/pvr.hts 98d93e7
+pvr.hts https://github.com/kodi-pvr/pvr.hts 26d6e73


### PR DESCRIPTION
Managed to introduce a version compatibility regression in the old release, this fixes that.
