### PR TITLE
[lang] Fix overlapping kaitoast messages

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -4267,7 +4267,7 @@ msgstr ""
 #empty strings from id 2082 to 2100
 
 msgctxt "#2101"
-msgid "Newer version needed.[CR]Check the log for more information about this message."
+msgid "Newer version needed. Check the log for more information about this message."
 msgstr ""
 
 #. Notification message indicating an add-on error. "<Add-on name> error".
@@ -7828,7 +7828,7 @@ msgid "Already started recording on this channel"
 msgstr ""
 
 msgctxt "#19035"
-msgid "%s couldn't be played.[CR]Check the log for more information about this message."
+msgid "%s couldn't be played. Check the log for more information about this message."
 msgstr ""
 
 #: xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -13707,7 +13707,7 @@ msgstr ""
 
 #: xbmc\network\windows\ZeroconfWIN.cpp
 msgctxt "#34301"
-msgid "Is Apple's Bonjour service installed?[CR]Check the log for more information about this message."
+msgid "Is Apple's Bonjour service installed? Check the log for more information about this message."
 msgstr ""
 
 #: xbmc/network/NetworkServices.cpp


### PR DESCRIPTION
Example:
When zeroconf cant be enabled the error message has a linebreak. This conflicts with all skins in kaitoast as that results in an overlapping fadelabel which doesnt display the whole message.
The label is only used [here](https://github.com/xbmc/xbmc/blob/master/xbmc/network/mdns/ZeroconfMDNS.cpp#L81).

Before:
![screenshot000](https://cloud.githubusercontent.com/assets/447067/8204061/360320f6-14e6-11e5-8e51-d2a2e5840397.jpg)

After:
![screenshot001](https://cloud.githubusercontent.com/assets/447067/8204065/389dc082-14e6-11e5-80fd-139775dce049.jpg)
