### PR TITLE
[infomanager] fix wrong value of listitem.path and listitem.foldername

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -4980,7 +4980,7 @@ std::string CGUIInfoManager::GetItemLabel(const CFileItem *item, int info, std::
   case LISTITEM_FOLDERNAME:
   case LISTITEM_PATH:
     {
-      std::string path;
+      std::string path(item->GetPath());
       if (item->IsMusicDb() && item->HasMusicInfoTag())
         path = URIUtils::GetDirectory(item->GetMusicInfoTag()->GetURL());
       else if (item->IsVideoDb() && item->HasVideoInfoTag())
@@ -4990,8 +4990,6 @@ std::string CGUIInfoManager::GetItemLabel(const CFileItem *item, int info, std::
         else
           URIUtils::GetParentPath(item->GetVideoInfoTag()->m_strFileNameAndPath, path);
       }
-      else
-        URIUtils::GetParentPath(item->GetPath(), path);
       path = CURL(path).GetWithoutUserDetails();
       if (info==LISTITEM_FOLDERNAME)
       {


### PR DESCRIPTION
We're not interested in the parentpath here. I am not sure when this one was introduced but it's clearly returning the wrong value(s).

@Montellese, @xhaggi for review please.
