### PR TITLE
[pvr] bump pvr.hts to 2.1.11

### DIFF
--- a/project/cmake/addons/addons/pvr.hts/pvr.hts.txt
+++ b/project/cmake/addons/addons/pvr.hts/pvr.hts.txt
@@ -1,1 +1,1 @@
-pvr.hts https://github.com/kodi-pvr/pvr.hts 26d6e73
+pvr.hts https://github.com/kodi-pvr/pvr.hts 3dbcee7


### PR DESCRIPTION
Fixes endless HTSP version mismatch alerts if tvheadend server is down.
