### PR TITLE
[win32][curl] Using CEnvironment::unsetenv() instead of SetEnvironmen…

### DIFF
--- a/xbmc/win32/XBMC_PC.cpp
+++ b/xbmc/win32/XBMC_PC.cpp
@@ -29,6 +29,7 @@
 #include "XbmcContext.h"
 #include "GUIInfoManager.h"
 #include "utils/CPUInfo.h"
+#include "utils/Environment.h"
 #include <mmdeviceapi.h>
 #include "win32/IMMNotificationClient.h"
 
@@ -55,7 +56,7 @@ INT WINAPI WinMain( HINSTANCE hInst, HINSTANCE, LPSTR commandLine, INT )
 
   // this fixes crash if OPENSSL_CONF is set to existed openssl.cfg
   // need to set it as soon as possible
-  SetEnvironmentVariable("OPENSSL_CONF", "");
+  CEnvironment::unsetenv("OPENSSL_CONF");
 
   //this can't be set from CAdvancedSettings::Initialize() because it will overwrite
   //the loglevel set with the --debug flag


### PR DESCRIPTION
…tVariable. It's proper way to unset environment variable.

this proper fix than #7294, suggested by @Karlson2k [(link)](https://github.com/xbmc/xbmc/pull/7294#issuecomment-113109996)
