### PR TITLE
Fixed: visualization settings dialog broken if press 'V' key

### DIFF
--- a/system/keymaps/joystick.Harmony.xml
+++ b/system/keymaps/joystick.Harmony.xml
@@ -209,7 +209,7 @@
       <!-- Prev		-->      <button id="32">LockPreset</button>
       <!-- Info  	-->      <button id="31">Info</button>
       <!-- F8		-->      <button id="96">ActivateWindow(VisualisationPresetList)</button>
-      <!-- F9		-->      <button id="73">ActivateWindow(VisualisationSettings)</button>
+      <!-- F9		-->      <button id="73">Addon.Default.OpenSettings(xbmc.player.musicviz)</button>
     </joystick>
   </Visualisation>
   <MusicOSD>

--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -313,7 +313,7 @@
       <m>OSD</m>
       <i>Info</i>
       <p>ActivateWindow(VisualisationPresetList)</p>
-      <v>ActivateWindow(VisualisationSettings)</v>
+      <v>Addon.Default.OpenSettings(xbmc.player.musicviz)</v>
       <n>ActivateWindow(MusicPlaylist)</n>
       <left>StepBack</left>
       <right>StepForward</right>
@@ -336,7 +336,7 @@
       <i>Info</i>
       <o>CodecInfo</o>
       <p>ActivateWindow(VisualisationPresetList)</p>
-      <v>ActivateWindow(VisualisationSettings)</v>
+      <v>Addon.Default.OpenSettings(xbmc.player.musicviz)</v>
       <n>ActivateWindow(MusicPlaylist)</n>
     </keyboard>
   </MusicOSD>

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -1760,8 +1760,8 @@ int CBuiltins::Execute(const std::string& execString)
     ADDON::TYPE type = TranslateType(params[0]);
     if (CAddonMgr::Get().GetDefault(type, addon))
     {
-      CGUIDialogAddonSettings::ShowAndGetInput(addon);
-      if (type == ADDON_VIZ)
+      bool changed = CGUIDialogAddonSettings::ShowAndGetInput(addon);
+      if (type == ADDON_VIZ && changed)
         g_windowManager.SendMessage(GUI_MSG_VISUALISATION_RELOAD, 0, 0);
     }
   }


### PR DESCRIPTION
second commit it's a little improvement to not doing restart addon if it has no settings.

@MartijnKaijser ping someone who responsible for this part
