### PR TITLE
[osx] fix deadlock when videosync and refreshrate adaption are enabled

### DIFF
--- a/xbmc/osx/CocoaInterface.mm
+++ b/xbmc/osx/CocoaInterface.mm
@@ -24,6 +24,7 @@
 #define BOOL XBMC_BOOL 
 #include "utils/log.h"
 #include "CompileInfo.h"
+#include "windowing/WindowingFactory.h"
 #undef BOOL
 
 #import <Cocoa/Cocoa.h>
@@ -53,23 +54,7 @@ CGDirectDisplayID Cocoa_GetDisplayIDFromScreen(NSScreen *screen);
 
 NSOpenGLContext* Cocoa_GL_GetCurrentContext(void)
 {
-  __block NSOpenGLContext* context = nil;
-  
-  if(![NSThread isMainThread])
-  {
-    // needs to be fetched from the main thread
-    dispatch_sync(dispatch_get_main_queue(), ^{
-
-      context = [NSOpenGLContext currentContext];
-
-    });
-  }
-  else
-  {
-    context = [NSOpenGLContext currentContext];
-  }
-
-  return context;
+  return (NSOpenGLContext *)g_Windowing.GetNSOpenGLContext();
 }
 
 uint32_t Cocoa_GL_GetCurrentDisplayID(void)

--- a/xbmc/windowing/osx/WinSystemOSX.h
+++ b/xbmc/windowing/osx/WinSystemOSX.h
@@ -81,6 +81,7 @@ public:
   void        StopLostDeviceTimer();
   
   void* GetCGLContextObj();
+  void* GetNSOpenGLContext();
 
   std::string GetClipboardText(void);
 

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -1809,6 +1809,11 @@ void* CWinSystemOSX::GetCGLContextObj()
   return [(NSOpenGLContext*)m_glContext CGLContextObj];
 }
 
+void* CWinSystemOSX::GetNSOpenGLContext()
+{
+  return m_glContext;
+}
+
 std::string CWinSystemOSX::GetClipboardText(void)
 {
   std::string utf8_text;


### PR DESCRIPTION
As reported in the forum there was a deadlock when stopping playback. Problem was that the refclock was about to stop and hold the gfx lock while doing so. At the same time due to refreshrate switching back we tried to init the display link which in return tried to fetch the current gl context. 

As i figured out this context might return nil (NULL) if its not queried from the main thread. Thats why i altered it to force execution via mainthread in PR #7143. This deadlocked because mainthread was waiting for us to exit the videosync thread while we were stuck waiting for the mainthread to become free.

This fixes the issue by using the tracked gl context from windowing instead of querying it ourselfs.

Fix was reported valid by the bug reporter here:

http://forum.kodi.tv/showthread.php?tid=229762&page=2

@FernetMenta IIRC you even suggested this in the first place. Sry for not having the overview here :/
