### PR TITLE
[pvr] bump pvr.hts to 2.1.12

### DIFF
--- a/project/cmake/addons/addons/pvr.hts/pvr.hts.txt
+++ b/project/cmake/addons/addons/pvr.hts/pvr.hts.txt
@@ -1,1 +1,1 @@
-pvr.hts https://github.com/kodi-pvr/pvr.hts 3dbcee7
+pvr.hts https://github.com/kodi-pvr/pvr.hts cd7ca22


### PR DESCRIPTION
- fixed: channel icon compatibility issue with recent tvheadend servers.
- fixed: EPG events update (some data was not updated correctly)
