### PR TITLE
Update Confluence hooks for TvTunes v5.0.0 (Simplification)

### DIFF
--- a/addons/skin.confluence/720p/DialogVideoInfo.xml
+++ b/addons/skin.confluence/720p/DialogVideoInfo.xml
@@ -2,7 +2,6 @@
 <window>
 	<defaultcontrol always="true">8</defaultcontrol>
 	<allowoverlay>no</allowoverlay>
-	<onload condition="Skin.HasSetting(ActivateTvTunes) + System.HasAddon(script.tvtunes)">RunScript(script.tvtunes,backend=True)</onload>
 	<controls>
 		<control type="group">
 			<visible>!Window.IsVisible(FileBrowser)</visible>

--- a/addons/skin.confluence/720p/Home.xml
+++ b/addons/skin.confluence/720p/Home.xml
@@ -31,7 +31,7 @@
 		<control type="group">
 			<left>0</left>
 			<top>60</top>
-			<visible>Player.HasAudio + !Skin.HasSetting(homepageMusicinfo) + !SubString(Window(videolibrary).Property(PlayingBackgroundMedia),True)</visible>
+			<visible>Player.HasAudio + !Skin.HasSetting(homepageMusicinfo) + IsEmpty(Window(videolibrary).Property(PlayingBackgroundMedia))</visible>
 			<include>VisibleFadeEffect</include>
 			<include>Window_OpenClose_Animation</include>
 			<control type="image">
@@ -233,7 +233,7 @@
 		<control type="group">
 			<left>0</left>
 			<top>50</top>
-			<visible>Player.HasVideo + !Skin.HasSetting(homepageVideoinfo) + !SubString(Window(videolibrary).Property(PlayingBackgroundMedia),True)</visible>
+			<visible>Player.HasVideo + !Skin.HasSetting(homepageVideoinfo) + IsEmpty(Window(videolibrary).Property(PlayingBackgroundMedia))</visible>
 			<include>VisibleFadeEffect</include>
 			<include>Window_OpenClose_Animation</include>
 			<control type="group">
@@ -466,7 +466,7 @@
 				<effect type="zoom" start="100" end="80" center="640,360" easing="in" tween="back" time="225" />
 				<effect type="fade" start="100" end="0" time="225" />
 			</animation>
-			<visible>!SubString(Window(videolibrary).Property(PlayingBackgroundMedia),True)</visible>
+			<visible>IsEmpty(Window(videolibrary).Property(PlayingBackgroundMedia))</visible>
 			<control type="image">
 				<description>Background End image</description>
 				<left>0</left>

--- a/addons/skin.confluence/720p/Home.xml
+++ b/addons/skin.confluence/720p/Home.xml
@@ -31,7 +31,7 @@
 		<control type="group">
 			<left>0</left>
 			<top>60</top>
-			<visible>Player.HasAudio + !Skin.HasSetting(homepageMusicinfo)</visible>
+			<visible>Player.HasAudio + !Skin.HasSetting(homepageMusicinfo) + !SubString(Window(videolibrary).Property(PlayingBackgroundMedia),True)</visible>
 			<include>VisibleFadeEffect</include>
 			<include>Window_OpenClose_Animation</include>
 			<control type="image">
@@ -233,7 +233,7 @@
 		<control type="group">
 			<left>0</left>
 			<top>50</top>
-			<visible>Player.HasVideo + !Skin.HasSetting(homepageVideoinfo)</visible>
+			<visible>Player.HasVideo + !Skin.HasSetting(homepageVideoinfo) + !SubString(Window(videolibrary).Property(PlayingBackgroundMedia),True)</visible>
 			<include>VisibleFadeEffect</include>
 			<include>Window_OpenClose_Animation</include>
 			<control type="group">
@@ -466,6 +466,7 @@
 				<effect type="zoom" start="100" end="80" center="640,360" easing="in" tween="back" time="225" />
 				<effect type="fade" start="100" end="0" time="225" />
 			</animation>
+			<visible>!SubString(Window(videolibrary).Property(PlayingBackgroundMedia),True)</visible>
 			<control type="image">
 				<description>Background End image</description>
 				<left>0</left>

--- a/addons/skin.confluence/720p/IncludesBackgroundBuilding.xml
+++ b/addons/skin.confluence/720p/IncludesBackgroundBuilding.xml
@@ -51,7 +51,7 @@
 			<width>1280</width>
 			<height>720</height>
 			<visible>Player.HasAudio + !Skin.HasSetting(ShowBackgroundVis)</visible>
-			<visible>!SubString(Window(videolibrary).Property(TvTunesIsAlive),True)</visible>
+			<visible>!SubString(Window(videolibrary).Property(PlayingBackgroundMedia),True)</visible>
 		</control>
 		<control type="videowindow">
 			<left>0</left>
@@ -66,7 +66,7 @@
 			<width>1280</width>
 			<height>120</height>
 			<texture flipy="true" border="1">HomeNowPlayingBack.png</texture>
-			<visible>[Player.HasVideo + !Skin.HasSetting(ShowBackgroundVideo)] | [Player.HasAudio + ![Skin.HasSetting(ShowBackgroundVis) | SubString(Window(videolibrary).Property(TvTunesIsAlive),True)]] | [!Skin.HasSetting(HideBackGroundFanart) + !IsEmpty(ListItem.Property(Fanart_Image))]</visible>
+			<visible>[Player.HasVideo + !Skin.HasSetting(ShowBackgroundVideo)] | [Player.HasAudio + ![Skin.HasSetting(ShowBackgroundVis) | SubString(Window(videolibrary).Property(PlayingBackgroundMedia),True)]] | [!Skin.HasSetting(HideBackGroundFanart) + !IsEmpty(ListItem.Property(Fanart_Image))]</visible>
 			<include>VisibleFadeEffect</include>
 		</control>
 	</include>

--- a/addons/skin.confluence/720p/IncludesBackgroundBuilding.xml
+++ b/addons/skin.confluence/720p/IncludesBackgroundBuilding.xml
@@ -51,7 +51,7 @@
 			<width>1280</width>
 			<height>720</height>
 			<visible>Player.HasAudio + !Skin.HasSetting(ShowBackgroundVis)</visible>
-			<visible>!SubString(Window(videolibrary).Property(PlayingBackgroundMedia),True)</visible>
+			<visible>IsEmpty(Window(videolibrary).Property(PlayingBackgroundMedia))</visible>
 		</control>
 		<control type="videowindow">
 			<left>0</left>
@@ -66,7 +66,7 @@
 			<width>1280</width>
 			<height>120</height>
 			<texture flipy="true" border="1">HomeNowPlayingBack.png</texture>
-			<visible>[Player.HasVideo + !Skin.HasSetting(ShowBackgroundVideo)] | [Player.HasAudio + ![Skin.HasSetting(ShowBackgroundVis) | SubString(Window(videolibrary).Property(PlayingBackgroundMedia),True)]] | [!Skin.HasSetting(HideBackGroundFanart) + !IsEmpty(ListItem.Property(Fanart_Image))]</visible>
+			<visible>[Player.HasVideo + !Skin.HasSetting(ShowBackgroundVideo)] | [Player.HasAudio + ![Skin.HasSetting(ShowBackgroundVis) | !IsEmpty(Window(videolibrary).Property(PlayingBackgroundMedia))]] | [!Skin.HasSetting(HideBackGroundFanart) + !IsEmpty(ListItem.Property(Fanart_Image))]</visible>
 			<include>VisibleFadeEffect</include>
 		</control>
 	</include>

--- a/addons/skin.confluence/720p/MyVideoNav.xml
+++ b/addons/skin.confluence/720p/MyVideoNav.xml
@@ -4,7 +4,6 @@
 	<allowoverlay>no</allowoverlay>
 	<views>50,51,500,550,551,560,501,508,504,503,515,505,511</views>
 	<onload condition="!Skin.HasSetting(FirstTimeRun)">ActivateWindow(1112)</onload>
-	<onload condition="Skin.HasSetting(ActivateTvTunes) + System.HasAddon(script.tvtunes)">RunScript(script.tvtunes,backend=True)</onload>
 	<controls>
 		<include>CommonBackground</include>
 		<include>ContentPanelBackgrounds</include>

--- a/addons/skin.confluence/720p/includes.xml
+++ b/addons/skin.confluence/720p/includes.xml
@@ -316,7 +316,7 @@
 	</include>
 	<include name="CommonNowPlaying">
 		<control type="group">
-			<visible>Player.HasMedia + !SubString(Window(videolibrary).Property(TvTunesIsAlive),TRUE)</visible>
+			<visible>Player.HasMedia + !SubString(Window(videolibrary).Property(PlayingBackgroundMedia),True)</visible>
 			<include>VisibleFadeEffect</include>
 			<animation effect="fade" time="200" condition="Window.Previous(Home)">WindowOpen</animation>
 			<animation effect="fade" time="200" condition="Window.Next(Home)">WindowClose</animation>

--- a/addons/skin.confluence/720p/includes.xml
+++ b/addons/skin.confluence/720p/includes.xml
@@ -316,7 +316,7 @@
 	</include>
 	<include name="CommonNowPlaying">
 		<control type="group">
-			<visible>Player.HasMedia + !SubString(Window(videolibrary).Property(PlayingBackgroundMedia),True)</visible>
+			<visible>Player.HasMedia + IsEmpty(Window(videolibrary).Property(PlayingBackgroundMedia))</visible>
 			<include>VisibleFadeEffect</include>
 			<animation effect="fade" time="200" condition="Window.Previous(Home)">WindowOpen</animation>
 			<animation effect="fade" time="200" condition="Window.Next(Home)">WindowClose</animation>


### PR DESCRIPTION
This pull requests makes use of changes in TvTunes v5.0 onwards.

The key change is that it removes the need for the Confluence skin to call TvTunes via the onLoad on some of the windows.

The second change is to change where the skin checks "TvTunesIsAlive" to a more generic "PlayingBackgroundMedia" - this means that any addon that plays media in the background should be able to make use of this, and it isn't specifically designed for TvTunes.

I know that there is a preference by some people to remove some of the links between confluence and TvTunes - this should go a very large way toward that.
