### PR TITLE
Process physical interface only.

### DIFF
--- a/xbmc/network/linux/NetworkLinux.cpp
+++ b/xbmc/network/linux/NetworkLinux.cpp
@@ -425,8 +425,11 @@ void CNetworkLinux::queryInterfaceList()
        continue;
 
      GetMacAddress(cur->ifa_name, macAddrRaw);
-     // Add the interface.
-     m_interfaces.push_back(new CNetworkInterfaceLinux(this, cur->ifa_name, macAddrRaw));
+
+      // check whether or not MAC address is not zero. 
+      if (macAddrRaw[0] || macAddrRaw[1] || macAddrRaw[2] || macAddrRaw[3] || macAddrRaw[4] || macAddrRaw[5])
+         // Add the interface.
+         m_interfaces.push_back(new CNetworkInterfaceLinux(this, cur->ifa_name, macAddrRaw));
    }
 
    freeifaddrs(list);
@@ -462,7 +465,10 @@ void CNetworkLinux::queryInterfaceList()
       // save the result
       std::string interfaceName = p;
       GetMacAddress(interfaceName, macAddrRaw);
-      m_interfaces.push_back(new CNetworkInterfaceLinux(this, interfaceName, macAddrRaw));
+
+      // check whether or not MAC address is not zero. 
+      if (macAddrRaw[0] || macAddrRaw[1] || macAddrRaw[2] || macAddrRaw[3] || macAddrRaw[4] || macAddrRaw[5])
+          m_interfaces.push_back(new CNetworkInterfaceLinux(this, interfaceName, macAddrRaw));
    }
    free(line);
    fclose(fp);

--- a/xbmc/network/linux/NetworkLinux.cpp
+++ b/xbmc/network/linux/NetworkLinux.cpp
@@ -426,7 +426,7 @@ void CNetworkLinux::queryInterfaceList()
 
      GetMacAddress(cur->ifa_name, macAddrRaw);
 
-      // check whether or not MAC address is not zero. 
+      // only add interfaces with non-zero mac addresses
       if (macAddrRaw[0] || macAddrRaw[1] || macAddrRaw[2] || macAddrRaw[3] || macAddrRaw[4] || macAddrRaw[5])
          // Add the interface.
          m_interfaces.push_back(new CNetworkInterfaceLinux(this, cur->ifa_name, macAddrRaw));
@@ -466,7 +466,7 @@ void CNetworkLinux::queryInterfaceList()
       std::string interfaceName = p;
       GetMacAddress(interfaceName, macAddrRaw);
 
-      // check whether or not MAC address is not zero. 
+      // only add interfaces with non-zero mac addresses
       if (macAddrRaw[0] || macAddrRaw[1] || macAddrRaw[2] || macAddrRaw[3] || macAddrRaw[4] || macAddrRaw[5])
           m_interfaces.push_back(new CNetworkInterfaceLinux(this, interfaceName, macAddrRaw));
    }


### PR DESCRIPTION
When VPN is established in Ubuntu, the first connected interface is ppp0 and MAC is 00:00:00:00:00:00. AirTunes/Airplay use MAC of first connected interface. Airplay device can not discover Kodi when the deviceid is all zeros.
