### PR TITLE
Addons API - Added dump methods for live streams

### DIFF
--- a/Kodi.xcodeproj/project.pbxproj
+++ b/Kodi.xcodeproj/project.pbxproj
@@ -6,26 +6,6 @@
 	objectVersion = 46;
 	objects = {
 
-/* Begin PBXNativeTarget section */
-		6E2FACBA0E26DF7A00DF79EA /* Kodi.app */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 6E2FACC10E26DFA300DF79EA /* Build configuration list for PBXNativeTarget "Kodi.app" */;
-			buildPhases = (
-				F5DEC3580E6DEBB2005A4E24 /* copy root files */,
-				6E2FACC70E26E22400DF79EA /* copy frameworks */,
-				81B8FC150E7D927A00354E2E /* update version info */,
-				1D64E5FC157BD76F001ACEBE /* genoutputdirlink */,
-			);
-			dependencies = (
-				6E2FACC40E26E08100DF79EA /* PBXTargetDependency */,
-			);
-			name = Kodi.app;
-			productName = Kodi.app;
-			productReference = D6299ABB1AFC2A9F00E3059D /* Kodi.app */;
-			productType = "com.apple.product-type.application";
-		};
-/* End PBXAggregateTarget section */
-
 /* Begin PBXBuildFile section */
 		0E3036EC1760F68A00D93596 /* FavouritesDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0E3036EA1760F68A00D93596 /* FavouritesDirectory.cpp */; };
 		0E3036ED1760F68A00D93596 /* FavouritesDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0E3036EA1760F68A00D93596 /* FavouritesDirectory.cpp */; };
@@ -3192,6 +3172,7 @@
 		F5E55B5D10741272006E788A /* DVDPlayerTeletext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5E55B5B10741272006E788A /* DVDPlayerTeletext.cpp */; };
 		F5E55B66107412DE006E788A /* GUIDialogTeletext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5E55B65107412DE006E788A /* GUIDialogTeletext.cpp */; };
 		F5E55B7010741340006E788A /* Teletext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5E55B6E10741340006E788A /* Teletext.cpp */; };
+		F5E5697310803FC3006E788A /* fastmemcpy.c in Sources */ = {isa = PBXBuildFile; fileRef = F5E5697210803FC3006E788A /* fastmemcpy.c */; };
 		F5E56BA61082A675006E788A /* PosixMountProvider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5E56BA51082A675006E788A /* PosixMountProvider.cpp */; };
 		F5EA02260F6DA990005C2EC5 /* CocoaPowerSyscall.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5EA02200F6DA85C005C2EC5 /* CocoaPowerSyscall.cpp */; };
 		F5EA02270F6DA9A5005C2EC5 /* PowerManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5EA021A0F6DA7E8005C2EC5 /* PowerManager.cpp */; };
@@ -3631,6 +3612,7 @@
 		43348AAB1077486D00F859CF /* PlayerSelectionRule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PlayerSelectionRule.h; path = playercorefactory/PlayerSelectionRule.h; sourceTree = "<group>"; };
 		436721A612D66A09002508E6 /* IAnnouncer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IAnnouncer.h; sourceTree = "<group>"; };
 		436B38F3106628850049AB3B /* EndianSwap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EndianSwap.h; sourceTree = "<group>"; };
+		43BF09DD1080D39300E25290 /* fastmemcpy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fastmemcpy.h; sourceTree = "<group>"; };
 		43FAC87112D6349400F67914 /* IStorageProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IStorageProvider.h; sourceTree = "<group>"; };
 		551C3A43175A12010051AAAD /* VDA.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VDA.cpp; sourceTree = "<group>"; };
 		551C3A44175A12010051AAAD /* VDA.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VDA.h; sourceTree = "<group>"; };
@@ -4198,7 +4180,6 @@
 		889B4D8D0E0EF86C00FAD25E /* RSSDirectory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RSSDirectory.h; sourceTree = "<group>"; };
 		88ECB6580DE013C4003396A7 /* DiskArbitration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = DiskArbitration.framework; path = /System/Library/Frameworks/DiskArbitration.framework; sourceTree = "<absolute>"; };
 		8DD76F7E0486A8DE00D96B5E /* Kodi */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = Kodi; sourceTree = BUILT_PRODUCTS_DIR; };
-		D6299ABB1AFC2A9F00E3059D /* Kodi.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Kodi.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AE4E87A517354C4A00D15206 /* XSLTUtils.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = XSLTUtils.cpp; sourceTree = "<group>"; };
 		AE4E87A617354C4A00D15206 /* XSLTUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XSLTUtils.h; sourceTree = "<group>"; };
 		AE84CB5915A5B8A600A3810E /* TagLibVFSStream.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TagLibVFSStream.cpp; sourceTree = "<group>"; };
@@ -4315,6 +4296,7 @@
 		C8D0B2AE1265A9A800F0C0AC /* SystemGlobals.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SystemGlobals.cpp; sourceTree = "<group>"; };
 		C8EC5D0C1369519D00CCC10D /* XBMC_keytable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = XBMC_keytable.cpp; sourceTree = "<group>"; };
 		C8EC5D0D1369519D00CCC10D /* XBMC_keytable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XBMC_keytable.h; sourceTree = "<group>"; };
+		D6299ABB1AFC2A9F00E3059D /* Kodi.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Kodi.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		DF00492B162DAEA200A971AD /* PVROperations.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PVROperations.cpp; sourceTree = "<group>"; };
 		DF00492C162DAEA200A971AD /* PVROperations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PVROperations.h; sourceTree = "<group>"; };
 		DF02BA601A910623006DCA16 /* VideoSyncIos.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = VideoSyncIos.cpp; path = videosync/VideoSyncIos.cpp; sourceTree = "<group>"; };
@@ -5429,7 +5411,7 @@
 		E46F7C2B0F77219700C25D29 /* ZeroconfOSX.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ZeroconfOSX.h; sourceTree = "<group>"; };
 		E46F7C2C0F77219700C25D29 /* ZeroconfOSX.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ZeroconfOSX.cpp; sourceTree = "<group>"; };
 		E47252BF175115F9001C1AAA /* Codesign.command */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = Codesign.command; sourceTree = "<group>"; };
-		E4991089174D0D2600741B6D /* Kodi.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = Kodi.app; path = .app; sourceTree = BUILT_PRODUCTS_DIR; };
+		E4991089174D0D2600741B6D /* Kodi.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Kodi.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E499108B174D0D2600741B6D /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
 		E499108D174D0D2600741B6D /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		E499108F174D0D2600741B6D /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = Library/Frameworks/CoreGraphics.framework; sourceTree = DEVELOPER_DIR; };
@@ -5733,6 +5715,7 @@
 		F5E55B6D10741340006E788A /* Teletext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Teletext.h; sourceTree = "<group>"; };
 		F5E55B6E10741340006E788A /* Teletext.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Teletext.cpp; sourceTree = "<group>"; };
 		F5E55B6F10741340006E788A /* TeletextDefines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TeletextDefines.h; sourceTree = "<group>"; };
+		F5E5697210803FC3006E788A /* fastmemcpy.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = fastmemcpy.c; sourceTree = "<group>"; };
 		F5E56BA41082A675006E788A /* PosixMountProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PosixMountProvider.h; sourceTree = "<group>"; };
 		F5E56BA51082A675006E788A /* PosixMountProvider.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PosixMountProvider.cpp; sourceTree = "<group>"; };
 		F5EA021A0F6DA7E8005C2EC5 /* PowerManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PowerManager.cpp; sourceTree = "<group>"; };
@@ -9199,6 +9182,8 @@
 				DF529BAD1741697B00523FB4 /* Environment.h */,
 				E36C29E90DA72486001F0C9D /* Fanart.cpp */,
 				6E97BDC30DA2B620003A2A89 /* Fanart.h */,
+				F5E5697210803FC3006E788A /* fastmemcpy.c */,
+				43BF09DD1080D39300E25290 /* fastmemcpy.h */,
 				F5F244641110DC6B009126C6 /* FileOperationJob.cpp */,
 				F5F244631110DC6B009126C6 /* FileOperationJob.h */,
 				F5F245EC1112C9AB009126C6 /* FileUtils.cpp */,
@@ -9721,6 +9706,25 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		6E2FACBA0E26DF7A00DF79EA /* Kodi.app */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6E2FACC10E26DFA300DF79EA /* Build configuration list for PBXNativeTarget "Kodi.app" */;
+			buildPhases = (
+				F5DEC3580E6DEBB2005A4E24 /* copy root files */,
+				6E2FACC70E26E22400DF79EA /* copy frameworks */,
+				81B8FC150E7D927A00354E2E /* update version info */,
+				1D64E5FC157BD76F001ACEBE /* genoutputdirlink */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				6E2FACC40E26E08100DF79EA /* PBXTargetDependency */,
+			);
+			name = Kodi.app;
+			productName = Kodi.app;
+			productReference = D6299ABB1AFC2A9F00E3059D /* Kodi.app */;
+			productType = "com.apple.product-type.application";
+		};
 		8DD76F740486A8DE00D96B5E /* Kodi */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 1DEB924708733DCA0010E9CD /* Build configuration list for PBXNativeTarget "Kodi" */;
@@ -10514,6 +10518,7 @@
 				43348AAE1077486D00F859CF /* PlayerCoreFactory.cpp in Sources */,
 				43348AAF1077486D00F859CF /* PlayerSelectionRule.cpp in Sources */,
 				7CAA20511079C8160096DE39 /* BaseRenderer.cpp in Sources */,
+				F5E5697310803FC3006E788A /* fastmemcpy.c in Sources */,
 				55D3604E1826CAB900DA66D2 /* OverlayRendererGUI.cpp in Sources */,
 				F5E56BA61082A675006E788A /* PosixMountProvider.cpp in Sources */,
 				7CAA25351085963B0096DE39 /* PasswordManager.cpp in Sources */,
@@ -13611,7 +13616,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		6E2FACC10E26DFA300DF79EA /* Build configuration list for PBXAggregateTarget "Kodi.app" */ = {
+		6E2FACC10E26DFA300DF79EA /* Build configuration list for PBXNativeTarget "Kodi.app" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				6E2FACBB0E26DF7A00DF79EA /* Debug */,

--- a/xbmc/addons/AddonCallbacks.h
+++ b/xbmc/addons/AddonCallbacks.h
@@ -98,10 +98,10 @@ typedef struct CB_AddOn
   AddOnDirectoryExists    DirectoryExists;
   AddOnRemoveDirectory    RemoveDirectory;
 
-  AddOnGetStreamChunksList  GetStreamPlaylist;
-  AddOnOpenStream           OpenStream;
-  AddOnReadStream           ReadStream;
-  AddOnCloseStream          CloseStream;
+  AddOnGetStreamPlaylist  GetStreamPlaylist;
+  AddOnOpenStream         OpenStream;
+  AddOnReadStream         ReadStream;
+  AddOnCloseStream        CloseStream;
 } CB_AddOnLib;
 
 typedef xbmc_codec_t (*CODECGetCodecByName)(const void* addonData, const char* strCodecName);

--- a/xbmc/addons/AddonCallbacks.h
+++ b/xbmc/addons/AddonCallbacks.h
@@ -62,6 +62,11 @@ typedef bool (*AddOnCreateDirectory)(const void* addonData, const char *strPath)
 typedef bool (*AddOnDirectoryExists)(const void* addonData, const char *strPath);
 typedef bool (*AddOnRemoveDirectory)(const void* addonData, const char *strPath);
 
+typedef int (*AddOnGetStreamPlaylist)(const void* addonData, const char* strStreamUrl, void* strList, size_t uListSize);
+typedef void* (*AddOnOpenStream)(const void* addonData, const char* strStreamUrl);
+typedef ssize_t (*AddOnReadStream)(const void* addonData, void* stream, void* lpBuf, size_t uiBufSize);
+typedef void (*AddOnCloseStream)(const void* addonData, void* stream);
+
 typedef struct CB_AddOn
 {
   AddOnLogCallback        Log;
@@ -92,6 +97,11 @@ typedef struct CB_AddOn
   AddOnCreateDirectory    CreateDirectory;
   AddOnDirectoryExists    DirectoryExists;
   AddOnRemoveDirectory    RemoveDirectory;
+
+  AddOnGetStreamChunksList  GetStreamChunksList;
+  AddOnOpenStream           OpenStream;
+  AddOnReadStream           ReadStream;
+  AddOnCloseStream          CloseStream;
 } CB_AddOnLib;
 
 typedef xbmc_codec_t (*CODECGetCodecByName)(const void* addonData, const char* strCodecName);

--- a/xbmc/addons/AddonCallbacks.h
+++ b/xbmc/addons/AddonCallbacks.h
@@ -98,7 +98,7 @@ typedef struct CB_AddOn
   AddOnDirectoryExists    DirectoryExists;
   AddOnRemoveDirectory    RemoveDirectory;
 
-  AddOnGetStreamChunksList  GetStreamChunksList;
+  AddOnGetStreamChunksList  GetStreamPlaylist;
   AddOnOpenStream           OpenStream;
   AddOnReadStream           ReadStream;
   AddOnCloseStream          CloseStream;

--- a/xbmc/addons/AddonCallbacksAddon.cpp
+++ b/xbmc/addons/AddonCallbacksAddon.cpp
@@ -82,11 +82,11 @@ CAddonCallbacksAddon::CAddonCallbacksAddon(CAddon* addon)
   m_callbacks->CreateDirectory    = CreateDirectory;
   m_callbacks->DirectoryExists    = DirectoryExists;
   m_callbacks->RemoveDirectory    = RemoveDirectory;
-  
-  m_callbacks->GetStreamChunksList = GetStreamChunksList;
-  m_callbacks->OpenStream          = OpenStream;
-  m_callbacks->ReadStream          = ReadStream;
-  m_callbacks->CloseStream         = CloseStream;
+
+  m_callbacks->GetStreamPlaylist  = GetStreamPlaylist;
+  m_callbacks->OpenStream         = OpenStream;
+  m_callbacks->ReadStream         = ReadStream;
+  m_callbacks->CloseStream        = CloseStream;
 }
 
 CAddonCallbacksAddon::~CAddonCallbacksAddon()

--- a/xbmc/addons/AddonCallbacksAddon.cpp
+++ b/xbmc/addons/AddonCallbacksAddon.cpp
@@ -32,6 +32,16 @@
 #include "utils/StringUtils.h"
 #include "utils/XMLUtils.h"
 
+#include <vector>
+#include <string>
+#include <climits>
+#include "utils/StringUtils.h"
+#include "cores/dvdplayer/DVDInputStreams/DVDFactoryInputStream.h"
+#include "cores/dvdplayer/DVDInputStreams/DVDInputStream.h"
+#include "playlists/PlayList.h"
+#include "playlists/PlayListM3U.h"
+#include "settings/Settings.h"
+
 using namespace XFILE;
 
 namespace ADDON
@@ -72,6 +82,11 @@ CAddonCallbacksAddon::CAddonCallbacksAddon(CAddon* addon)
   m_callbacks->CreateDirectory    = CreateDirectory;
   m_callbacks->DirectoryExists    = DirectoryExists;
   m_callbacks->RemoveDirectory    = RemoveDirectory;
+  
+  m_callbacks->GetStreamChunksList = GetStreamChunksList;
+  m_callbacks->OpenStream          = OpenStream;
+  m_callbacks->ReadStream          = ReadStream;
+  m_callbacks->CloseStream         = CloseStream;
 }
 
 CAddonCallbacksAddon::~CAddonCallbacksAddon()
@@ -525,6 +540,98 @@ bool CAddonCallbacksAddon::RemoveDirectory(const void* addonData, const char *st
     CFile::Delete(fileItems.Get(i)->GetPath());
 
   return CDirectory::Remove(strPath);
+}
+
+int CAddonCallbacksAddon::GetStreamPlaylist(const void* addonData, const char* strStreamUrl, void* strList, size_t uListSize)
+{
+  CAddonCallbacks* helper = (CAddonCallbacks*) addonData;
+  if (!helper)
+    return -2;
+  
+  // get the available bandwidth and  determine the most appropriate stream
+  int bandwidth = CSettings::Get().GetInt("network.bandwidth");
+  if(bandwidth <= 0)
+    bandwidth = INT_MAX;
+  std::string selected;
+  selected = PLAYLIST::CPlayListM3U::GetBestBandwidthStream(strStreamUrl, bandwidth);
+  if (selected.compare(strStreamUrl) != 0)
+    strStreamUrl = selected.c_str();
+
+  CFileItem item(strStreamUrl, false);
+  if (!item.IsType(".m3u8"))
+    return -2;
+
+  PLAYLIST::CPlayList* list = new PLAYLIST::CPlayListM3U;
+  list->Load(strStreamUrl);
+  if (!list->size())
+  {
+    delete (list);
+    return 0;
+  }
+
+  std::string t_strList;
+  bool first = true;
+  for (int elem=0; elem<list->size(); elem++)
+  {
+    CFileItemPtr playlistItem = list->operator[](elem);
+    CFileItem* name = playlistItem.get();
+    std::string strName = name->GetPath();
+    strName = StringUtils::Trim(strName);
+    if (first==true)
+      first = false;
+    else
+      t_strList.append("\n");
+    t_strList.append(strName);
+  }
+  delete (list);
+
+  size_t size = strlen(t_strList.c_str());
+  if (size>=uListSize)
+    return -1;
+  memcpy(strList, t_strList.c_str(), t_strList.size());
+  return size;
+}
+
+void* CAddonCallbacksAddon::OpenStream(const void* addonData, const char* strStreamUrl)
+{  
+  CAddonCallbacks* helper = (CAddonCallbacks*) addonData;
+  if (!helper)
+    return NULL;
+
+  CDVDInputStream *cInputStream = CDVDFactoryInputStream::CreateInputStream(NULL, strStreamUrl, "");
+  if (!cInputStream || cInputStream->IsStreamType(DVDSTREAM_TYPE_DVD) || cInputStream->IsStreamType(DVDSTREAM_TYPE_BLURAY) || cInputStream->IsStreamType(DVDSTREAM_TYPE_PVRMANAGER))
+    return NULL;
+
+  if (cInputStream->Open(strStreamUrl, "READ_NO_CACHE"))
+    return ((void*)cInputStream);
+  return NULL;
+}
+
+ssize_t CAddonCallbacksAddon::ReadStream(const void* addonData, void* stream, void* lpBuf, size_t uiBufSize)
+{
+  CAddonCallbacks* helper = (CAddonCallbacks*) addonData;
+  if (!helper)
+    return 0;
+
+  CDVDInputStream* cInputStream = (CDVDInputStream*)stream;
+  if (!cInputStream)
+    return 0;
+
+  return cInputStream->Read((uint8_t*)lpBuf, uiBufSize);
+}
+
+void CAddonCallbacksAddon::CloseStream(const void* addonData, void* stream)
+{
+  CAddonCallbacks* helper = (CAddonCallbacks*) addonData;
+  if (!helper)
+    return;
+
+  CDVDInputStream* cInputStream = (CDVDInputStream*)stream;
+  if (cInputStream)
+  {
+    cInputStream->Close();
+    delete cInputStream;
+  }
 }
 
 }; /* namespace ADDON */

--- a/xbmc/addons/AddonCallbacksAddon.h
+++ b/xbmc/addons/AddonCallbacksAddon.h
@@ -65,6 +65,12 @@ public:
   static bool DirectoryExists(const void* addonData, const char *strPath);
   static bool RemoveDirectory(const void* addonData, const char *strPath);
 
+  // stream operations
+  static int GetStreamPlaylist(const void* addonData, const char* strStreamUrl, void* strList, size_t uListSize);
+  static void* OpenStream(const void* addonData, const char* strStreamUrl);
+  static ssize_t ReadStream(const void* addonData, void* stream, void* lpBuf, size_t uiBufSize);
+  static void CloseStream(const void* addonData, void* stream);
+
 private:
   CB_AddOnLib  *m_callbacks; /*!< callback addresses */
   CAddon       *m_addon;     /*!< the add-on */

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFile.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFile.cpp
@@ -61,7 +61,7 @@ bool CDVDInputStreamFile::Open(const char* strFile, const std::string& content)
    * 2) Only buffer true internet filesystems (streams) (http, etc.)
    * 3) No buffer
    */
-  if (!URIUtils::IsOnDVD(strFile) && !URIUtils::IsBluray(strFile)) // Never cache these
+  if (!URIUtils::IsOnDVD(strFile) && !URIUtils::IsBluray(strFile) && content!="READ_NO_CACHE") // Never cache these
   {
     if (g_advancedSettings.m_networkBufferMode == 0 || g_advancedSettings.m_networkBufferMode == 2)
     {
@@ -73,7 +73,7 @@ bool CDVDInputStreamFile::Open(const char* strFile, const std::string& content)
       flags |= READ_CACHED; // In buffer mode 1 force cache for (almost) all files
     }
   }
-
+  
   if (!(flags & READ_CACHED))
     flags |= READ_NO_CACHE; // Make sure CFile honors our no-cache hint
 


### PR DESCRIPTION
New methods for Addons API:
- GetStreamPlaylist
- OpenStream
- ReadStream
- CloseStream
  This methods are needed for live stream recording (eg. using PVR IPTVSimple addon - under development ) and deep stream buffering. 
