### PR TITLE
Addons API - Added dump methods for live streams

### DIFF
--- a/lib/addons/library.xbmc.addon/libXBMC_addon.cpp
+++ b/lib/addons/library.xbmc.addon/libXBMC_addon.cpp
@@ -124,6 +124,38 @@ DLLEXPORT void XBMC_free_string(void* hdl, void* cb, char* str)
   ((CB_AddOnLib*)cb)->FreeString(((AddonCB*)hdl)->addonData, str);
 }
 
+DLLEXPORT int XBMC_get_stream_playlist(void *hdl, void* cb, const char* strStreamUrl, void* strList, size_t uListSize)
+{
+  if (cb == NULL)
+    return NULL;
+
+  return ((CB_AddOnLib*)cb)->GetStreamChunksList(((AddonCB*)hdl)->addonData, strStreamUrl, strList, uListSize);
+}
+
+DLLEXPORT void* XBMC_open_stream(void *hdl, void* cb, const char* strStreamUrl)
+{
+  if (cb == NULL)
+    return NULL;
+
+  return ((CB_AddOnLib*)cb)->OpenStream(((AddonCB*)hdl)->addonData, strStreamUrl);
+}
+
+DLLEXPORT ssize_t XBMC_read_stream(void *hdl, void* cb, void* stream, void* lpBuf, size_t uiBufSize)
+{
+  if (cb == NULL)
+    return -1;
+
+  return ((CB_AddOnLib*)cb)->ReadStream(((AddonCB*)hdl)->addonData, stream, lpBuf, uiBufSize);
+}
+
+DLLEXPORT void XBMC_close_stream(void *hdl, void* cb, void* stream)
+{
+  if (cb == NULL)
+    return;
+
+  ((CB_AddOnLib*)cb)->CloseStream(((AddonCB*)hdl)->addonData, stream);
+}
+
 DLLEXPORT void* XBMC_open_file(void *hdl, void* cb, const char* strFileName, unsigned int flags)
 {
   if (cb == NULL)

--- a/lib/addons/library.xbmc.addon/libXBMC_addon.cpp
+++ b/lib/addons/library.xbmc.addon/libXBMC_addon.cpp
@@ -129,7 +129,7 @@ DLLEXPORT int XBMC_get_stream_playlist(void *hdl, void* cb, const char* strStrea
   if (cb == NULL)
     return NULL;
 
-  return ((CB_AddOnLib*)cb)->GetStreamChunksList(((AddonCB*)hdl)->addonData, strStreamUrl, strList, uListSize);
+  return ((CB_AddOnLib*)cb)->GetStreamPlaylist(((AddonCB*)hdl)->addonData, strStreamUrl, strList, uListSize);
 }
 
 DLLEXPORT void* XBMC_open_stream(void *hdl, void* cb, const char* strStreamUrl)

--- a/project/cmake/addons/addons/pvr.iptvsimple/pvr.iptvsimple.txt
+++ b/project/cmake/addons/addons/pvr.iptvsimple/pvr.iptvsimple.txt
@@ -1,1 +1,1 @@
-pvr.iptvsimple https://github.com/kodi-pvr/pvr.iptvsimple 191972c
+pvr.iptvsimple https://github.com/rkubera/pvr.iptvsimple 191972c

--- a/xbmc/addons/AddonCallbacks.h
+++ b/xbmc/addons/AddonCallbacks.h
@@ -98,7 +98,7 @@ typedef struct CB_AddOn
   AddOnDirectoryExists    DirectoryExists;
   AddOnRemoveDirectory    RemoveDirectory;
 
-  AddOnGetStreamChunksList  GetStreamChunksList;
+  AddOnGetStreamPlaylist  GetStreamChunksList;
   AddOnOpenStream           OpenStream;
   AddOnReadStream           ReadStream;
   AddOnCloseStream          CloseStream;

--- a/xbmc/addons/AddonCallbacks.h
+++ b/xbmc/addons/AddonCallbacks.h
@@ -62,6 +62,11 @@ typedef bool (*AddOnCreateDirectory)(const void* addonData, const char *strPath)
 typedef bool (*AddOnDirectoryExists)(const void* addonData, const char *strPath);
 typedef bool (*AddOnRemoveDirectory)(const void* addonData, const char *strPath);
 
+typedef int (*AddOnGetStreamPlaylist)(const void* addonData, const char* strStreamUrl, void* strList, size_t uListSize);
+typedef void* (*AddOnOpenStream)(const void* addonData, const char* strStreamUrl);
+typedef ssize_t (*AddOnReadStream)(const void* addonData, void* stream, void* lpBuf, size_t uiBufSize);
+typedef void (*AddOnCloseStream)(const void* addonData, void* stream);
+
 typedef struct CB_AddOn
 {
   AddOnLogCallback        Log;
@@ -92,6 +97,11 @@ typedef struct CB_AddOn
   AddOnCreateDirectory    CreateDirectory;
   AddOnDirectoryExists    DirectoryExists;
   AddOnRemoveDirectory    RemoveDirectory;
+
+  AddOnGetStreamChunksList  GetStreamChunksList;
+  AddOnOpenStream           OpenStream;
+  AddOnReadStream           ReadStream;
+  AddOnCloseStream          CloseStream;
 } CB_AddOnLib;
 
 typedef xbmc_codec_t (*CODECGetCodecByName)(const void* addonData, const char* strCodecName);

--- a/xbmc/addons/AddonCallbacks.h
+++ b/xbmc/addons/AddonCallbacks.h
@@ -98,10 +98,10 @@ typedef struct CB_AddOn
   AddOnDirectoryExists    DirectoryExists;
   AddOnRemoveDirectory    RemoveDirectory;
 
-  AddOnGetStreamPlaylist  GetStreamChunksList;
-  AddOnOpenStream           OpenStream;
-  AddOnReadStream           ReadStream;
-  AddOnCloseStream          CloseStream;
+  AddOnGetStreamPlaylist  GetStreamPlaylist;
+  AddOnOpenStream         OpenStream;
+  AddOnReadStream         ReadStream;
+  AddOnCloseStream        CloseStream;
 } CB_AddOnLib;
 
 typedef xbmc_codec_t (*CODECGetCodecByName)(const void* addonData, const char* strCodecName);

--- a/xbmc/addons/AddonCallbacksAddon.cpp
+++ b/xbmc/addons/AddonCallbacksAddon.cpp
@@ -32,6 +32,16 @@
 #include "utils/StringUtils.h"
 #include "utils/XMLUtils.h"
 
+#include <vector>
+#include <string>
+#include <climits>
+#include "utils/StringUtils.h"
+#include "cores/dvdplayer/DVDInputStreams/DVDFactoryInputStream.h"
+#include "cores/dvdplayer/DVDInputStreams/DVDInputStream.h"
+#include "playlists/PlayList.h"
+#include "playlists/PlayListM3U.h"
+#include "settings/Settings.h"
+
 using namespace XFILE;
 
 namespace ADDON
@@ -72,6 +82,11 @@ CAddonCallbacksAddon::CAddonCallbacksAddon(CAddon* addon)
   m_callbacks->CreateDirectory    = CreateDirectory;
   m_callbacks->DirectoryExists    = DirectoryExists;
   m_callbacks->RemoveDirectory    = RemoveDirectory;
+  
+  m_callbacks->GetStreamChunksList = GetStreamChunksList;
+  m_callbacks->OpenStream          = OpenStream;
+  m_callbacks->ReadStream          = ReadStream;
+  m_callbacks->CloseStream         = CloseStream;
 }
 
 CAddonCallbacksAddon::~CAddonCallbacksAddon()
@@ -525,6 +540,98 @@ bool CAddonCallbacksAddon::RemoveDirectory(const void* addonData, const char *st
     CFile::Delete(fileItems.Get(i)->GetPath());
 
   return CDirectory::Remove(strPath);
+}
+
+int CAddonCallbacksAddon::GetStreamPlaylist(const void* addonData, const char* strStreamUrl, void* strList, size_t uListSize)
+{
+  CAddonCallbacks* helper = (CAddonCallbacks*) addonData;
+  if (!helper)
+    return -2;
+  
+  // get the available bandwidth and  determine the most appropriate stream
+  int bandwidth = CSettings::Get().GetInt("network.bandwidth");
+  if(bandwidth <= 0)
+    bandwidth = INT_MAX;
+  std::string selected;
+  selected = PLAYLIST::CPlayListM3U::GetBestBandwidthStream(strStreamUrl, bandwidth);
+  if (selected.compare(strStreamUrl) != 0)
+    strStreamUrl = selected.c_str();
+
+  CFileItem item(strStreamUrl, false);
+  if (!item.IsType(".m3u8"))
+    return -2;
+
+  PLAYLIST::CPlayList* list = new PLAYLIST::CPlayListM3U;
+  list->Load(strStreamUrl);
+  if (!list->size())
+  {
+    delete (list);
+    return 0;
+  }
+
+  std::string t_strList;
+  bool first = true;
+  for (int elem=0; elem<list->size(); elem++)
+  {
+    CFileItemPtr playlistItem = list->operator[](elem);
+    CFileItem* name = playlistItem.get();
+    std::string strName = name->GetPath();
+    strName = StringUtils::Trim(strName);
+    if (first==true)
+      first = false;
+    else
+      t_strList.append("\n");
+    t_strList.append(strName);
+  }
+  delete (list);
+
+  size_t size = strlen(t_strList.c_str());
+  if (size>=uListSize)
+    return -1;
+  memcpy(strList, t_strList.c_str(), t_strList.size());
+  return size;
+}
+
+void* CAddonCallbacksAddon::OpenStream(const void* addonData, const char* strStreamUrl)
+{  
+  CAddonCallbacks* helper = (CAddonCallbacks*) addonData;
+  if (!helper)
+    return NULL;
+
+  CDVDInputStream *cInputStream = CDVDFactoryInputStream::CreateInputStream(NULL, strStreamUrl, "");
+  if (!cInputStream || cInputStream->IsStreamType(DVDSTREAM_TYPE_DVD) || cInputStream->IsStreamType(DVDSTREAM_TYPE_BLURAY) || cInputStream->IsStreamType(DVDSTREAM_TYPE_PVRMANAGER))
+    return NULL;
+
+  if (cInputStream->Open(strStreamUrl, "READ_NO_CACHE"))
+    return ((void*)cInputStream);
+  return NULL;
+}
+
+ssize_t CAddonCallbacksAddon::ReadStream(const void* addonData, void* stream, void* lpBuf, size_t uiBufSize)
+{
+  CAddonCallbacks* helper = (CAddonCallbacks*) addonData;
+  if (!helper)
+    return 0;
+
+  CDVDInputStream* cInputStream = (CDVDInputStream*)stream;
+  if (!cInputStream)
+    return 0;
+
+  return cInputStream->Read((uint8_t*)lpBuf, uiBufSize);
+}
+
+void CAddonCallbacksAddon::CloseStream(const void* addonData, void* stream)
+{
+  CAddonCallbacks* helper = (CAddonCallbacks*) addonData;
+  if (!helper)
+    return;
+
+  CDVDInputStream* cInputStream = (CDVDInputStream*)stream;
+  if (cInputStream)
+  {
+    cInputStream->Close();
+    delete cInputStream;
+  }
 }
 
 }; /* namespace ADDON */

--- a/xbmc/addons/AddonCallbacksAddon.cpp
+++ b/xbmc/addons/AddonCallbacksAddon.cpp
@@ -83,7 +83,7 @@ CAddonCallbacksAddon::CAddonCallbacksAddon(CAddon* addon)
   m_callbacks->DirectoryExists    = DirectoryExists;
   m_callbacks->RemoveDirectory    = RemoveDirectory;
   
-  m_callbacks->GetStreamChunksList = GetStreamChunksList;
+  m_callbacks->GetStreamPlaylist = GetStreamPlaylist;
   m_callbacks->OpenStream          = OpenStream;
   m_callbacks->ReadStream          = ReadStream;
   m_callbacks->CloseStream         = CloseStream;

--- a/xbmc/addons/AddonCallbacksAddon.h
+++ b/xbmc/addons/AddonCallbacksAddon.h
@@ -65,6 +65,12 @@ public:
   static bool DirectoryExists(const void* addonData, const char *strPath);
   static bool RemoveDirectory(const void* addonData, const char *strPath);
 
+  // stream operations
+  static int GetStreamPlaylist(const void* addonData, const char* strStreamUrl, void* strList, size_t uListSize);
+  static void* OpenStream(const void* addonData, const char* strStreamUrl);
+  static ssize_t ReadStream(const void* addonData, void* stream, void* lpBuf, size_t uiBufSize);
+  static void CloseStream(const void* addonData, void* stream);
+
 private:
   CB_AddOnLib  *m_callbacks; /*!< callback addresses */
   CAddon       *m_addon;     /*!< the add-on */

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFile.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFile.cpp
@@ -61,7 +61,7 @@ bool CDVDInputStreamFile::Open(const char* strFile, const std::string& content)
    * 2) Only buffer true internet filesystems (streams) (http, etc.)
    * 3) No buffer
    */
-  if (!URIUtils::IsOnDVD(strFile) && !URIUtils::IsBluray(strFile)) // Never cache these
+  if (!URIUtils::IsOnDVD(strFile) && !URIUtils::IsBluray(strFile) && content!="READ_NO_CACHE") // Never cache these
   {
     if (g_advancedSettings.m_networkBufferMode == 0 || g_advancedSettings.m_networkBufferMode == 2)
     {
@@ -73,7 +73,7 @@ bool CDVDInputStreamFile::Open(const char* strFile, const std::string& content)
       flags |= READ_CACHED; // In buffer mode 1 force cache for (almost) all files
     }
   }
-
+  
   if (!(flags & READ_CACHED))
     flags |= READ_NO_CACHE; // Make sure CFile honors our no-cache hint
 


### PR DESCRIPTION
New methods for Addons API:

-GetStreamPlaylist
-OpenStream
-ReadStream
-CloseStream 

This methods are needed for live stream recording (eg. using PVR IPTVSimple addon - under development - test phase ) and deep stream buffering.
