### PR TITLE
[confluence] increase button group height in the PVR group manager dialog

### DIFF
--- a/addons/skin.confluence/720p/DialogPVRGroupManager.xml
+++ b/addons/skin.confluence/720p/DialogPVRGroupManager.xml
@@ -409,7 +409,7 @@
 					<left>1070</left>
 					<top>165</top>
 					<width>200</width>
-					<height>175</height>
+					<height>225</height>
 					<itemgap>5</itemgap>
 					<align>center</align>
 					<orientation>vertical</orientation>


### PR DESCRIPTION
The "Add group" button (the first one in the list of buttons) is not visible by default because the list is too small and it starts out scrolled down. This confuses people.
