### PR TITLE
Commercial skipping notifications and toggle action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -370,6 +370,7 @@ lib/cpluff/stamp-h1
 /system/libcec.dll
 /system/pthreadVC2.dll
 /system/libxslt.dll
+/system/ssleay32.dll
 
 # /system/cdrip
 /system/cdrip/lame_enc.dll

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -13413,7 +13413,22 @@ msgctxt "#25010"
 msgid "Chapter %u"
 msgstr ""
 
-#empty strings from id 25011 to 29799
+#: xbmc/cores/dvdplayer/DVDPlayer.cpp
+msgctxt "#25011"
+msgid "Commercial"
+msgstr ""
+
+#: xbmc/cores/dvdplayer/DVDPlayer.cpp
+msgctxt "#25012"
+msgid "Auto-skip off"
+msgstr ""
+
+#: xbmc/cores/dvdplayer/DVDPlayer.cpp
+msgctxt "#25013"
+msgid "Auto-skip on"
+msgstr ""
+
+#empty strings from id 25014 to 29799
 #strings 29800 thru 29998 reserved strings used only in the default Project Mayhem III skin and not c++ code
 
 #: skin.confluence

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -16634,23 +16634,3 @@ msgstr ""
 msgctxt "#38016"
 msgid "%d fps"
 msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#38017"
-msgid "Automatic commercial skip"
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#38018"
-msgid "Automaticly skip commercials in a video's edit decision list"
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#38019"
-msgid "Display commercial notifications"
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#38020"
-msgid "Show notifications of commercials during playback (even if automatic skipping is disabled)"
-msgstr ""

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -13120,7 +13120,22 @@ msgctxt "#25010"
 msgid "Chapter %u"
 msgstr ""
 
-#empty strings from id 25011 to 29799
+#: xbmc/cores/dvdplayer/DVDPlayer.cpp
+msgctxt "#25011"
+msgid "Commercial"
+msgstr ""
+
+#: xbmc/cores/dvdplayer/DVDPlayer.cpp
+msgctxt "#25012"
+msgid "Auto-skip off"
+msgstr ""
+
+#: xbmc/cores/dvdplayer/DVDPlayer.cpp
+msgctxt "#25013"
+msgid "Auto-skip on"
+msgstr ""
+
+#empty strings from id 25014 to 29799
 #strings 29800 thru 29998 reserved strings used only in the default Project Mayhem III skin and not c++ code
 
 #: skin.confluence
@@ -16618,4 +16633,24 @@ msgstr ""
 #: system/settings/settings.xml
 msgctxt "#38016"
 msgid "%d fps"
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#38017"
+msgid "Disable commercial skip"
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#38018"
+msgid "Check this to disable automatic commercial skipping"
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#38019"
+msgid "Display commercial notifications"
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#38020"
+msgid "Show notifications of commercials during playback (even if automatic skipping is disabled)"
 msgstr ""

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -16637,12 +16637,12 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#38017"
-msgid "Disable commercial skip"
+msgid "Automatic commercial skip"
 msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#38018"
-msgid "Check this to disable automatic commercial skipping"
+msgid "Automaticly skip commercials in a video's edit decision list"
 msgstr ""
 
 #: system/settings/settings.xml

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -463,16 +463,6 @@
           <default>false</default>
           <control type="toggle" />
         </setting>
-        <setting id="videoplayer.commskipenabled" type="boolean" label="38017" help="38018">
-          <level>1</level>
-          <default>true</default>
-          <control type="toggle" />
-        </setting>
-        <setting id="videoplayer.commskipnotify" type="boolean" label="38019" help="38020">
-          <level>1</level>
-          <default>false</default>
-          <control type="toggle" />
-        </setting>
       </group>
       <group id="2">
         <setting id="videolibrary.updateonstartup" type="boolean" label="22000" help="36146">

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -463,6 +463,16 @@
           <default>false</default>
           <control type="toggle" />
         </setting>
+        <setting id="videoplayer.commskipenabled" type="boolean" label="38017" help="38018">
+          <level>1</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+        <setting id="videoplayer.commskipnotify" type="boolean" label="38019" help="38020">
+          <level>1</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
       </group>
       <group id="2">
         <setting id="videolibrary.updateonstartup" type="boolean" label="22000" help="36146">
@@ -1357,16 +1367,6 @@
           <control type="spinner" format="string">
             <formatlabel>14046</formatlabel>
           </control>
-        </setting>
-        <setting id="pvrplayback.commskipdisabled" type="boolean" label="38017" help="38018">
-          <level>1</level>
-          <default>false</default>
-          <control type="toggle" />
-        </setting>
-        <setting id="pvrplayback.commskipnotify" type="boolean" label="38019" help="38020">
-          <level>1</level>
-          <default>false</default>
-          <control type="toggle" />
         </setting>
       </group>
       <group id="3">

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1358,12 +1358,12 @@
             <formatlabel>14046</formatlabel>
           </control>
         </setting>
-        <setting id="pvrplayback.commskipdisabled" type="boolean" label="Commercial Skip Disabled" help="Check this to disable automatic commercial skipping">
+        <setting id="pvrplayback.commskipdisabled" type="boolean" label="38017" help="38018">
           <level>1</level>
           <default>false</default>
           <control type="toggle" />
         </setting>
-        <setting id="pvrplayback.commskipnotify" type="boolean" label="Display Commercial Notifications" help="Show commercial notifications during playback">
+        <setting id="pvrplayback.commskipnotify" type="boolean" label="38019" help="38020">
           <level>1</level>
           <default>false</default>
           <control type="toggle" />

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1358,6 +1358,16 @@
             <formatlabel>14046</formatlabel>
           </control>
         </setting>
+        <setting id="pvrplayback.commskipdisabled" type="boolean" label="Commercial Skip Disabled" help="Check this to disable automatic commercial skipping">
+          <level>1</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
+        <setting id="pvrplayback.commskipnotify" type="boolean" label="Display Commercial Notifications" help="Show commercial notifications during playback">
+          <level>1</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
       </group>
       <group id="3">
         <setting id="pvrplayback.fps" type="integer" label="19108" help="36261">

--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -257,6 +257,13 @@ bool CApplicationPlayer::SeekScene(bool bPlus)
   return (player && player->SeekScene(bPlus));
 }
 
+void CApplicationPlayer::ToggleCommSkip()
+{
+  std::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    player->ToggleCommSkip();
+}
+
 void CApplicationPlayer::SeekTime(int64_t iTime)
 {
   std::shared_ptr<IPlayer> player = GetInternal();

--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -257,6 +257,13 @@ bool CApplicationPlayer::SeekScene(bool bPlus)
   return (player && player->SeekScene(bPlus));
 }
 
+void CApplicationPlayer::ToggleCommSkip()
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    player->ToggleCommSkip();
+}
+
 void CApplicationPlayer::SeekTime(int64_t iTime)
 {
   std::shared_ptr<IPlayer> player = GetInternal();

--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -259,7 +259,7 @@ bool CApplicationPlayer::SeekScene(bool bPlus)
 
 void CApplicationPlayer::ToggleCommSkip()
 {
-  boost::shared_ptr<IPlayer> player = GetInternal();
+  std::shared_ptr<IPlayer> player = GetInternal();
   if (player)
     player->ToggleCommSkip();
 }

--- a/xbmc/ApplicationPlayer.h
+++ b/xbmc/ApplicationPlayer.h
@@ -139,6 +139,7 @@ public:
   int   SeekChapter(int iChapter);
   void  SeekPercentage(float fPercent = 0);
   bool  SeekScene(bool bPlus = true);
+  void  ToggleCommSkip();
   void  SeekTime(int64_t iTime = 0);
   void  SeekTimeRelative(int64_t iTime = 0);
   void  SetAudioStream(int iStream);

--- a/xbmc/addons/AddonVersion.cpp
+++ b/xbmc/addons/AddonVersion.cpp
@@ -100,11 +100,31 @@ namespace ADDON
     return (CompareComponent(mRevision.c_str(), other.mRevision.c_str()) < 0);
   }
 
+  bool AddonVersion::operator>(const AddonVersion & other) const
+  {
+    return !(*this <= other);
+  }
+
   bool AddonVersion::operator==(const AddonVersion& other) const
   {
     return mEpoch == other.mEpoch
       && CompareComponent(mUpstream.c_str(), other.mUpstream.c_str()) == 0
       && CompareComponent(mRevision.c_str(), other.mRevision.c_str()) == 0;
+  }
+
+  bool AddonVersion::operator!=(const AddonVersion & other) const
+  {
+    return !(*this == other);
+  }
+
+  bool AddonVersion::operator<=(const AddonVersion& other) const
+  {
+    return *this < other || *this == other;
+  }
+
+  bool AddonVersion::operator>=(const AddonVersion & other) const
+  {
+    return !(*this < other);
   }
 
   bool AddonVersion::empty() const

--- a/xbmc/addons/AddonVersion.h
+++ b/xbmc/addons/AddonVersion.h
@@ -19,7 +19,6 @@
  */
 
 #include <string>
-#include <boost/operators.hpp>
 
 namespace ADDON
 {
@@ -35,7 +34,8 @@ namespace ADDON
 
     See here for more info: http://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-Version
     */
-  class AddonVersion : public boost::totally_ordered<AddonVersion> {
+  class AddonVersion
+  {
   public:
     AddonVersion(const AddonVersion& other) { *this = other; }
     explicit AddonVersion(const std::string& version);
@@ -46,8 +46,12 @@ namespace ADDON
     const std::string &Revision() const { return mRevision; }
 
     AddonVersion& operator=(const AddonVersion& other);
-    bool operator<(const AddonVersion& other) const;
+    bool operator< (const AddonVersion& other) const;
+    bool operator> (const AddonVersion& other) const;
+    bool operator<=(const AddonVersion& other) const;
+    bool operator>=(const AddonVersion& other) const;
     bool operator==(const AddonVersion& other) const;
+    bool operator!=(const AddonVersion& other) const;
     std::string asString() const;
     bool empty() const;
 

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -145,6 +145,7 @@ public:
   virtual bool CanSeek() {return true;}
   virtual void Seek(bool bPlus = true, bool bLargeStep = false, bool bChapterOverride = false) = 0;
   virtual bool SeekScene(bool bPlus = true) {return false;}
+  virtual void ToggleCommSkip() {}
   virtual void SeekPercentage(float fPercent = 0){}
   virtual float GetPercentage(){ return 0;}
   virtual float GetCachePercentage(){ return 0;}

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -604,6 +604,8 @@ CDVDPlayer::CDVDPlayer(IPlayerCallback& callback)
   m_omxplayer_mode                     = false;
 #endif
 
+  m_SkipCommercials = g_advancedSettings.m_bEdlCommAutoSkip;
+
   CreatePlayers();
 }
 
@@ -1168,13 +1170,27 @@ void CDVDPlayer::Process()
     }
     CLog::Log(LOGDEBUG, "%s - Start position set to last stopped position: %d", __FUNCTION__, starttime);
   }
-  else if(m_Edl.InCut(0, &cut)
-      && (cut.action == CEdl::CUT || cut.action == CEdl::COMM_BREAK))
+  else if(m_Edl.InCut(0, &cut))
   {
-    starttime = cut.end;
-    CLog::Log(LOGDEBUG, "%s - Start position set to end of first cut or commercial break: %d", __FUNCTION__, starttime);
-    if(cut.action == CEdl::COMM_BREAK)
+    if (cut.action == CEdl::CUT)
     {
+      starttime = cut.end;
+      CLog::Log(LOGDEBUG, "%s - Start position set to end of first cut: %d", __FUNCTION__, starttime);
+    }
+    else if (cut.action == CEdl::COMM_BREAK)
+    {
+      if (m_SkipCommercials)
+      {
+        starttime = cut.end;
+        CLog::Log(LOGDEBUG, "%s - Start position set to end of first commercial break: %d", __FUNCTION__, starttime);
+      }
+
+      if (g_advancedSettings.m_bEdlCommNotify)
+      {
+        std::string strTimeString = StringUtils::SecondsToTimeString(cut.end / 1000, TIME_FORMAT_MM_SS);
+        CGUIDialogKaiToast::QueueNotification(g_localizeStrings.Get(25011), strTimeString);
+      }
+
       /*
        * Setup auto skip markers as if the commercial break had been skipped using standard
        * detection.
@@ -2181,13 +2197,24 @@ void CDVDPlayer::CheckAutoSceneSkip()
   &&      GetPlaySpeed() >= 0
   &&      cut.start > m_EdlAutoSkipMarkers.commbreak_end)
   {
-    CLog::Log(LOGDEBUG, "%s - Clock in commercial break [%s - %s]: %s. Automatically skipping to end of commercial break (only done once per break)",
-              __FUNCTION__, CEdl::MillisecondsToTimeString(cut.start).c_str(), CEdl::MillisecondsToTimeString(cut.end).c_str(),
-              CEdl::MillisecondsToTimeString(clock).c_str());
-    /*
-     * Seeking is NOT flushed so any content up to the demux point is retained when playing forwards.
-     */
-    m_messenger.Put(new CDVDMsgPlayerSeek(cut.end + 1, true, m_omxplayer_mode, true, false, true));
+    if (g_advancedSettings.m_bEdlCommNotify)
+    {
+      std::string strTimeString = StringUtils::SecondsToTimeString((cut.end - cut.start) / 1000, TIME_FORMAT_MM_SS);
+      CGUIDialogKaiToast::QueueNotification(g_localizeStrings.Get(25011), strTimeString);
+    }
+
+    if (m_SkipCommercials)
+    {
+      CLog::Log(LOGDEBUG, "%s - Clock in commercial break [%s - %s]: %s. Automatically skipping to end of commercial break (only done once per break)",
+                __FUNCTION__, CEdl::MillisecondsToTimeString(cut.start).c_str(), CEdl::MillisecondsToTimeString(cut.end).c_str(),
+                CEdl::MillisecondsToTimeString(clock).c_str());
+
+      /*
+       * Seeking is NOT flushed so any content up to the demux point is retained when playing forwards.
+       */
+      m_messenger.Put(new CDVDMsgPlayerSeek(cut.end + 1, true, m_omxplayer_mode, true, false, !g_advancedSettings.m_bEdlCommNotify, true));
+    }
+
     /*
      * Each commercial break is only skipped once so poorly detected commercial breaks can be
      * manually re-entered. Start and end are recorded to prevent looping and to allow seeking back
@@ -2196,6 +2223,16 @@ void CDVDPlayer::CheckAutoSceneSkip()
     m_EdlAutoSkipMarkers.commbreak_start = cut.start;
     m_EdlAutoSkipMarkers.commbreak_end   = cut.end;
     m_EdlAutoSkipMarkers.seek_to_start   = true; // Allow backwards Seek() to go directly to the start
+  }
+}
+
+void CDVDPlayer::ToggleCommSkip()
+{
+  m_SkipCommercials = !m_SkipCommercials;
+  if (g_advancedSettings.m_bEdlCommNotify)
+  {
+    CGUIDialogKaiToast::QueueNotification(g_localizeStrings.Get(25011), 
+                                          g_localizeStrings.Get(m_SkipCommercials ? 25013 : 25012));
   }
 }
 

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -605,7 +605,7 @@ CDVDPlayer::CDVDPlayer(IPlayerCallback& callback)
 #endif
 
   m_SkipCommercials = CSettings::Get().GetBool("videoplayer.commskipenabled");
-  m_NotifyCommercials = CSettings::Get().GetBool("videoplater.commskipnotify");
+  m_NotifyCommercials = CSettings::Get().GetBool("videoplayer.commskipnotify");
 
   CreatePlayers();
 }

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -604,8 +604,7 @@ CDVDPlayer::CDVDPlayer(IPlayerCallback& callback)
   m_omxplayer_mode                     = false;
 #endif
 
-  m_SkipCommercials = CSettings::Get().GetBool("videoplayer.commskipenabled");
-  m_NotifyCommercials = CSettings::Get().GetBool("videoplayer.commskipnotify");
+  m_SkipCommercials = g_advancedSettings.m_bEDLCommercialSkip;
 
   CreatePlayers();
 }
@@ -1186,7 +1185,7 @@ void CDVDPlayer::Process()
         CLog::Log(LOGDEBUG, "%s - Start position set to end of first commercial break: %d", __FUNCTION__, starttime);
       }
 
-      if (m_NotifyCommercials)
+      if (g_advancedSettings.m_bEDLCommercialNotify)
       {
         std::string strTimeString = StringUtils::SecondsToTimeString(cut.end / 1000, TIME_FORMAT_MM_SS);
         CGUIDialogKaiToast::QueueNotification(g_localizeStrings.Get(25011), strTimeString);
@@ -2198,7 +2197,7 @@ void CDVDPlayer::CheckAutoSceneSkip()
   &&      GetPlaySpeed() >= 0
   &&      cut.start > m_EdlAutoSkipMarkers.commbreak_end)
   {
-    if (m_NotifyCommercials)
+    if (g_advancedSettings.m_bEDLCommercialNotify)
     {
       std::string strTimeString = StringUtils::SecondsToTimeString((cut.end - cut.start) / 1000, TIME_FORMAT_MM_SS);
       CGUIDialogKaiToast::QueueNotification(g_localizeStrings.Get(25011), strTimeString);
@@ -2213,7 +2212,7 @@ void CDVDPlayer::CheckAutoSceneSkip()
       /*
        * Seeking is NOT flushed so any content up to the demux point is retained when playing forwards.
        */
-      m_messenger.Put(new CDVDMsgPlayerSeek(cut.end + 1, true, m_omxplayer_mode, true, false, !m_NotifyCommercials, true));
+      m_messenger.Put(new CDVDMsgPlayerSeek(cut.end + 1, true, m_omxplayer_mode, true, false, !g_advancedSettings.m_bEDLCommercialNotify, true));
     }
 
     /*
@@ -2230,7 +2229,7 @@ void CDVDPlayer::CheckAutoSceneSkip()
 void CDVDPlayer::ToggleCommSkip()
 {
   m_SkipCommercials = !m_SkipCommercials;
-  if (m_NotifyCommercials)
+  if (g_advancedSettings.m_bEDLCommercialNotify)
   {
     CGUIDialogKaiToast::QueueNotification(g_localizeStrings.Get(25011), 
                                           g_localizeStrings.Get(m_SkipCommercials ? 25013 : 25012));

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -1189,7 +1189,7 @@ void CDVDPlayer::Process()
       if (m_NotifyCommercials)
       {
         std::string strTimeString = StringUtils::SecondsToTimeString(cut.end / 1000, TIME_FORMAT_MM_SS);
-        CGUIDialogKaiToast::QueueNotification("Commercial", strTimeString);
+        CGUIDialogKaiToast::QueueNotification(g_localizeStrings.Get(25011), strTimeString);
       }
 
       /*
@@ -2201,7 +2201,7 @@ void CDVDPlayer::CheckAutoSceneSkip()
     if (m_NotifyCommercials)
     {
       std::string strTimeString = StringUtils::SecondsToTimeString((cut.end - cut.start) / 1000, TIME_FORMAT_MM_SS);
-      CGUIDialogKaiToast::QueueNotification("Commercial", strTimeString);
+      CGUIDialogKaiToast::QueueNotification(g_localizeStrings.Get(25011), strTimeString);
     }
 
     if (m_SkipCommercials)
@@ -2232,10 +2232,8 @@ void CDVDPlayer::ToggleCommSkip()
   m_SkipCommercials = !m_SkipCommercials;
   if (m_NotifyCommercials)
   {
-    if (m_SkipCommercials)
-      CGUIDialogKaiToast::QueueNotification("Commercial", "Auto Skip: ON");
-    else
-      CGUIDialogKaiToast::QueueNotification("Commercial", "Auto Skip: OFF");
+    CGUIDialogKaiToast::QueueNotification(g_localizeStrings.Get(25011), 
+                                          g_localizeStrings.Get(m_SkipCommercials ? 25013 : 25012));
   }
 }
 

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -604,8 +604,8 @@ CDVDPlayer::CDVDPlayer(IPlayerCallback& callback)
   m_omxplayer_mode                     = false;
 #endif
 
-  m_SkipCommercials = !CSettings::Get().GetBool("pvrplayback.commskipdisabled");
-  m_NotifyCommercials = CSettings::Get().GetBool("pvrplayback.commskipnotify");
+  m_SkipCommercials = CSettings::Get().GetBool("videoplayer.commskipenabled");
+  m_NotifyCommercials = CSettings::Get().GetBool("videoplater.commskipnotify");
 
   CreatePlayers();
 }

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -604,7 +604,7 @@ CDVDPlayer::CDVDPlayer(IPlayerCallback& callback)
   m_omxplayer_mode                     = false;
 #endif
 
-  m_SkipCommercials = g_advancedSettings.m_bEDLCommercialSkip;
+  m_SkipCommercials = g_advancedSettings.m_bEdlCommAutoSkip;
 
   CreatePlayers();
 }
@@ -1185,7 +1185,7 @@ void CDVDPlayer::Process()
         CLog::Log(LOGDEBUG, "%s - Start position set to end of first commercial break: %d", __FUNCTION__, starttime);
       }
 
-      if (g_advancedSettings.m_bEDLCommercialNotify)
+      if (g_advancedSettings.m_bEdlCommNotify)
       {
         std::string strTimeString = StringUtils::SecondsToTimeString(cut.end / 1000, TIME_FORMAT_MM_SS);
         CGUIDialogKaiToast::QueueNotification(g_localizeStrings.Get(25011), strTimeString);
@@ -2197,7 +2197,7 @@ void CDVDPlayer::CheckAutoSceneSkip()
   &&      GetPlaySpeed() >= 0
   &&      cut.start > m_EdlAutoSkipMarkers.commbreak_end)
   {
-    if (g_advancedSettings.m_bEDLCommercialNotify)
+    if (g_advancedSettings.m_bEdlCommNotify)
     {
       std::string strTimeString = StringUtils::SecondsToTimeString((cut.end - cut.start) / 1000, TIME_FORMAT_MM_SS);
       CGUIDialogKaiToast::QueueNotification(g_localizeStrings.Get(25011), strTimeString);
@@ -2212,7 +2212,7 @@ void CDVDPlayer::CheckAutoSceneSkip()
       /*
        * Seeking is NOT flushed so any content up to the demux point is retained when playing forwards.
        */
-      m_messenger.Put(new CDVDMsgPlayerSeek(cut.end + 1, true, m_omxplayer_mode, true, false, !g_advancedSettings.m_bEDLCommercialNotify, true));
+      m_messenger.Put(new CDVDMsgPlayerSeek(cut.end + 1, true, m_omxplayer_mode, true, false, !g_advancedSettings.m_bEdlCommNotify, true));
     }
 
     /*
@@ -2229,7 +2229,7 @@ void CDVDPlayer::CheckAutoSceneSkip()
 void CDVDPlayer::ToggleCommSkip()
 {
   m_SkipCommercials = !m_SkipCommercials;
-  if (g_advancedSettings.m_bEDLCommercialNotify)
+  if (g_advancedSettings.m_bEdlCommNotify)
   {
     CGUIDialogKaiToast::QueueNotification(g_localizeStrings.Get(25011), 
                                           g_localizeStrings.Get(m_SkipCommercials ? 25013 : 25012));

--- a/xbmc/cores/dvdplayer/DVDPlayer.h
+++ b/xbmc/cores/dvdplayer/DVDPlayer.h
@@ -226,6 +226,7 @@ public:
   virtual bool CanSeek();
   virtual void Seek(bool bPlus, bool bLargeStep, bool bChapterOverride);
   virtual bool SeekScene(bool bPlus = true);
+  virtual void ToggleCommSkip();
   virtual void SeekPercentage(float iPercent);
   virtual float GetPercentage();
   virtual float GetCachePercentage();
@@ -527,6 +528,7 @@ protected:
   CEvent m_ready;
 
   CEdl m_Edl;
+  bool m_SkipCommercials;
 
   struct SEdlAutoSkipMarkers {
 

--- a/xbmc/cores/dvdplayer/DVDPlayer.h
+++ b/xbmc/cores/dvdplayer/DVDPlayer.h
@@ -226,6 +226,7 @@ public:
   virtual bool CanSeek();
   virtual void Seek(bool bPlus, bool bLargeStep, bool bChapterOverride);
   virtual bool SeekScene(bool bPlus = true);
+  virtual void ToggleCommSkip();
   virtual void SeekPercentage(float iPercent);
   virtual float GetPercentage();
   virtual float GetCachePercentage();
@@ -527,6 +528,7 @@ protected:
   CEvent m_ready;
 
   CEdl m_Edl;
+  bool m_SkipCommercials, m_NotifyCommercials;
 
   struct SEdlAutoSkipMarkers {
 

--- a/xbmc/cores/dvdplayer/DVDPlayer.h
+++ b/xbmc/cores/dvdplayer/DVDPlayer.h
@@ -528,7 +528,7 @@ protected:
   CEvent m_ready;
 
   CEdl m_Edl;
-  bool m_SkipCommercials, m_NotifyCommercials;
+  bool m_SkipCommercials;
 
   struct SEdlAutoSkipMarkers {
 

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.cpp
@@ -336,6 +336,11 @@ void CDirectoryNode::AddQueuingFolder(CFileItemList& items) const
         pItem->GetVideoInfoTag()->m_type = MediaTypeSeason;
       }
       break;
+    case NODE_TYPE_MUSICVIDEOS_ALBUM:
+      pItem.reset(new CFileItem(g_localizeStrings.Get(15102)));  // "All Albums"
+      videoUrl.AppendPath("-1/");
+      pItem->SetPath(videoUrl.ToString());
+      break;
     default:
       break;
   }

--- a/xbmc/guilib/GUIEditControl.cpp
+++ b/xbmc/guilib/GUIEditControl.cpp
@@ -486,17 +486,17 @@ void CGUIEditControl::ProcessText(unsigned int currentTime)
     changed |= m_label2.SetMaxRect(m_clipRect.x1 + m_textOffset, m_posY, m_clipRect.Width() - m_textOffset, m_height);
 
     std::wstring text = GetDisplayedText();
-    std::string hint = m_hintInfo.GetLabel(GetParentID());
 
-    if (!HasFocus() && text.empty() && !hint.empty())
-      changed |= m_label2.SetText(hint);
-    else
+    if (!HasFocus() && text.empty())
     {
-      if (m_inputType != INPUT_TYPE_READONLY)
-        changed |= SetStyledText(text);
-      else
-        changed |= m_label2.SetTextW(text);
+      std::string hint = m_hintInfo.GetLabel(GetParentID());
+      if (!hint.empty())
+        changed |= m_label2.SetText(hint);
     }
+    else if (HasFocus() && m_inputType != INPUT_TYPE_READONLY)
+      changed |= SetStyledText(text);
+    else
+      changed |= m_label2.SetTextW(text);
 
     changed |= m_label2.SetAlign(align);
     changed |= m_label2.SetColor(GetTextColor());

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -250,6 +250,7 @@ static const ActionMapping actions[] =
         {"playpvrtv"             , ACTION_PVR_PLAY_TV},
         {"playpvrradio"          , ACTION_PVR_PLAY_RADIO},
         {"record"                , ACTION_RECORD},
+        {"togglecommskip"        , ACTION_TOGGLE_COMMSKIP},
 
         // Mouse actions
         {"leftclick"         , ACTION_MOUSE_LEFT_CLICK},

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -250,7 +250,7 @@ static const ActionMapping actions[] =
         {"playpvrtv"             , ACTION_PVR_PLAY_TV},
         {"playpvrradio"          , ACTION_PVR_PLAY_RADIO},
         {"record"                , ACTION_RECORD},
-        {"togglecommskip"         , ACTION_TOGGLE_COMMSKIP},
+        {"togglecommskip"        , ACTION_TOGGLE_COMMSKIP},
 
         // Mouse actions
         {"leftclick"         , ACTION_MOUSE_LEFT_CLICK},

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -250,6 +250,7 @@ static const ActionMapping actions[] =
         {"playpvrtv"             , ACTION_PVR_PLAY_TV},
         {"playpvrradio"          , ACTION_PVR_PLAY_RADIO},
         {"record"                , ACTION_RECORD},
+        {"togglecommskip"         , ACTION_TOGGLE_COMMSKIP},
 
         // Mouse actions
         {"leftclick"         , ACTION_MOUSE_LEFT_CLICK},

--- a/xbmc/input/Key.h
+++ b/xbmc/input/Key.h
@@ -352,6 +352,7 @@
 #define ACTION_TRIGGER_OSD            243 // show autoclosing OSD. Can b used in videoFullScreen.xml window id=2005
 #define ACTION_INPUT_TEXT             244
 #define ACTION_VOLUME_SET             245
+#define ACTION_TOGGLE_COMMSKIP        246
 
 // touch actions
 #define ACTION_TOUCH_TAP              401

--- a/xbmc/input/linux/LinuxInputDevices.cpp
+++ b/xbmc/input/linux/LinuxInputDevices.cpp
@@ -558,22 +558,27 @@ bool CLinuxInputDevice::KeyEvent(const struct input_event& levt, XBMC_Event& dev
  */
 bool CLinuxInputDevice::RelEvent(const struct input_event& levt, XBMC_Event& devt)
 {
+  bool motion = false;
+  bool wheel  = false;
+
   switch (levt.code)
   {
   case REL_X:
     m_mouseX += levt.value;
     devt.motion.xrel = levt.value;
     devt.motion.yrel = 0;
+    motion = true;
     break;
-
   case REL_Y:
     m_mouseY += levt.value;
     devt.motion.xrel = 0;
     devt.motion.yrel = levt.value;
+    motion = true;
     break;
-
-  case REL_Z:
   case REL_WHEEL:
+    wheel = (levt.value != 0); // process wheel event only when there was some delta
+    break;
+  case REL_Z:
   default:
     CLog::Log(LOGWARNING, "CLinuxInputDevice::RelEvent: Unknown rel event code: %d\n", levt.code);
     return false;
@@ -588,13 +593,35 @@ bool CLinuxInputDevice::RelEvent(const struct input_event& levt, XBMC_Event& dev
   m_mouseY = std::max(0, m_mouseY);
 
 
-  devt.type = XBMC_MOUSEMOTION;
-  devt.motion.type = XBMC_MOUSEMOTION;
-  devt.motion.x = m_mouseX;
-  devt.motion.y = m_mouseY;
-  devt.motion.state = 0;
-  devt.motion.which = m_deviceIndex;
+  if (motion)
+  {
+    devt.type = XBMC_MOUSEMOTION;
+    devt.motion.type = XBMC_MOUSEMOTION;
+    devt.motion.x = m_mouseX;
+    devt.motion.y = m_mouseY;
+    devt.motion.state = 0;
+    devt.motion.which = m_deviceIndex;
+  }
+  else if (wheel)
+  {
+     devt.type = XBMC_MOUSEBUTTONUP;
+     devt.button.state = XBMC_RELEASED;
+     devt.button.type = devt.type;
+     devt.button.x = m_mouseX;
+     devt.button.y = m_mouseY;
+     devt.button.button = (levt.value<0) ? XBMC_BUTTON_WHEELDOWN:XBMC_BUTTON_WHEELUP;
 
+     /* but WHEEL up enent to the queue */
+     m_equeue.push_back(devt);
+
+     /* prepare and return WHEEL down event */
+     devt.button.state = XBMC_PRESSED;
+     devt.type = XBMC_MOUSEBUTTONDOWN;
+  }
+  else
+  {
+     return false;
+  }
 
   return true;
 }
@@ -693,56 +720,64 @@ XBMC_Event CLinuxInputDevice::ReadEvent()
 
   XBMC_Event devt;
 
-  while (1)
+  if (m_equeue.empty())
   {
-    bzero(&levt, sizeof(levt));
-
-    bzero(&devt, sizeof(devt));
-    devt.type = XBMC_NOEVENT;
-
-    if(m_devicePreferredId == LI_DEVICE_NONE)
-      return devt;
-
-    readlen = read(m_fd, &levt, sizeof(levt));
-
-    if (readlen <= 0)
+    while (1)
     {
-      if (errno == ENODEV)
+      bzero(&levt, sizeof(levt));
+
+      bzero(&devt, sizeof(devt));
+      devt.type = XBMC_NOEVENT;
+
+      if(m_devicePreferredId == LI_DEVICE_NONE)
+        return devt;
+
+      readlen = read(m_fd, &levt, sizeof(levt));
+
+      if (readlen <= 0)
       {
-        CLog::Log(LOGINFO,"input device was unplugged %s",m_deviceName);
-        m_bUnplugged = true;
+        if (errno == ENODEV)
+        {
+          CLog::Log(LOGINFO,"input device was unplugged %s",m_deviceName);
+          m_bUnplugged = true;
+        }
+
+        break;
       }
 
-      break;
-    }
+      //printf("read event readlen = %d device name %s m_fileName %s\n", readlen, m_deviceName, m_fileName.c_str());
 
-    //printf("read event readlen = %d device name %s m_fileName %s\n", readlen, m_deviceName, m_fileName.c_str());
-
-    // sanity check if we realy read the event
-    if(readlen != sizeof(levt))
-    {
-      printf("CLinuxInputDevice: read error : %s\n", strerror(errno));
-      break;
-    }
-
-    if (!TranslateEvent(levt, devt))
-      continue;
-
-    /* Flush previous event with DIEF_FOLLOW? */
-    if (devt.type != XBMC_NOEVENT)
-    {
-      //printf("new event! type = %d\n", devt.type);
-      //printf("key: %d %d %d %c\n", devt.key.keysym.scancode, devt.key.keysym.sym, devt.key.keysym.mod, devt.key.keysym.unicode);
-
-      if (m_hasLeds && (m_keyMods != m_lastKeyMods))
+      // sanity check if we realy read the event
+      if(readlen != sizeof(levt))
       {
-        SetLed(LED_NUML, m_keyMods & XBMCKMOD_NUM);
-        SetLed(LED_CAPSL, m_keyMods & XBMCKMOD_CAPS);
-        m_lastKeyMods = m_keyMods;
+        printf("CLinuxInputDevice: read error : %s\n", strerror(errno));
+        break;
       }
 
-      break;
+      if (!TranslateEvent(levt, devt))
+        continue;
+
+      /* Flush previous event with DIEF_FOLLOW? */
+      if (devt.type != XBMC_NOEVENT)
+      {
+        //printf("new event! type = %d\n", devt.type);
+        //printf("key: %d %d %d %c\n", devt.key.keysym.scancode, devt.key.keysym.sym, devt.key.keysym.mod, devt.key.keysym.unicode);
+
+        if (m_hasLeds && (m_keyMods != m_lastKeyMods))
+        {
+          SetLed(LED_NUML, m_keyMods & XBMCKMOD_NUM);
+          SetLed(LED_CAPSL, m_keyMods & XBMCKMOD_CAPS);
+          m_lastKeyMods = m_keyMods;
+        }
+
+        break;
+      }
     }
+  }
+  else
+  {
+     devt = m_equeue.front();
+     m_equeue.pop_front();
   }
 
   return devt;

--- a/xbmc/input/linux/LinuxInputDevices.cpp
+++ b/xbmc/input/linux/LinuxInputDevices.cpp
@@ -750,7 +750,7 @@ XBMC_Event CLinuxInputDevice::ReadEvent()
       // sanity check if we realy read the event
       if(readlen != sizeof(levt))
       {
-        printf("CLinuxInputDevice: read error : %s\n", strerror(errno));
+        CLog::Log(LOGERROR,"CLinuxInputDevice: read error : %s\n", strerror(errno));
         break;
       }
 

--- a/xbmc/input/linux/LinuxInputDevices.h
+++ b/xbmc/input/linux/LinuxInputDevices.h
@@ -22,6 +22,7 @@
 
 #include <vector>
 #include <string>
+#include <deque>
 #include "windowing/XBMC_events.h"
 #include "input/XBMC_keyboard.h"
 #include "threads/SingleLock.h"
@@ -79,6 +80,7 @@ private:
   int m_deviceMaxAxis;
   bool m_bSkipNonKeyEvents;
   bool m_bUnplugged;
+  std::deque<XBMC_Event> m_equeue;
 };
 
 class CLinuxInputDevices

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -305,6 +305,8 @@ void CAdvancedSettings::Initialize()
   m_iEdlMaxStartGap = 5 * 60;              // 5 minutes.
   m_iEdlCommBreakAutowait = 0;             // Off by default
   m_iEdlCommBreakAutowind = 0;             // Off by default
+  m_bEdlCommAutoSkip = true;               // On by default
+  m_bEdlCommNotify = true;                 // On by default
 
   m_curlconnecttimeout = 10;
   m_curllowspeedtime = 20;
@@ -884,6 +886,8 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetInt(pElement, "maxstartgap", m_iEdlMaxStartGap, 0, 10 * 60);               // Between 0 and 10 minutes
     XMLUtils::GetInt(pElement, "commbreakautowait", m_iEdlCommBreakAutowait, 0, 10);        // Between 0 and 10 seconds
     XMLUtils::GetInt(pElement, "commbreakautowind", m_iEdlCommBreakAutowind, 0, 10);        // Between 0 and 10 seconds
+    XMLUtils::GetBoolean(pElement, "commautoskip", m_bEdlCommAutoSkip);
+    XMLUtils::GetBoolean(pElement, "commnotify", m_bEdlCommNotify);
   }
 
   // picture exclude regexps

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -350,6 +350,9 @@ void CAdvancedSettings::Initialize()
   m_bPVRAutoScanIconsUserSet       = false;
   m_iPVRNumericChannelSwitchTimeout = 1000;
 
+  m_bEDLCommercialSkip             = true;
+  m_bEDLCommercialNotify           = true;
+
   m_cacheMemBufferSize = 1024 * 1024 * 20;
   m_networkBufferMode = 0; // Default (buffer all internet streams/filesystems)
   // the following setting determines the readRate of a player data
@@ -1055,6 +1058,13 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetBoolean(pPVR, "channeliconsautoscan", m_bPVRChannelIconsAutoScan);
     XMLUtils::GetBoolean(pPVR, "autoscaniconsuserset", m_bPVRAutoScanIconsUserSet);
     XMLUtils::GetInt(pPVR, "numericchannelswitchtimeout", m_iPVRNumericChannelSwitchTimeout, 50, 60000);
+  }
+
+  TiXmlElement *pEDL = pRootElement->FirstChildElement("edl");
+  if (pEDL)
+  {
+    XMLUtils::GetBoolean(pEDL, "commercialskip", m_bEDLCommercialSkip);
+    XMLUtils::GetBoolean(pEDL, "commercialnotify", m_bEDLCommercialNotify);
   }
 
   TiXmlElement* pDatabase = pRootElement->FirstChildElement("videodatabase");

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -302,6 +302,8 @@ void CAdvancedSettings::Initialize()
   m_iEdlMaxStartGap = 5 * 60;              // 5 minutes.
   m_iEdlCommBreakAutowait = 0;             // Off by default
   m_iEdlCommBreakAutowind = 0;             // Off by default
+  m_bEdlCommAutoSkip = true;               // On by default
+  m_bEdlCommNotify = true;                 // On by default
 
   m_curlconnecttimeout = 10;
   m_curllowspeedtime = 20;
@@ -349,9 +351,6 @@ void CAdvancedSettings::Initialize()
   m_bPVRChannelIconsAutoScan       = true;
   m_bPVRAutoScanIconsUserSet       = false;
   m_iPVRNumericChannelSwitchTimeout = 1000;
-
-  m_bEDLCommercialSkip             = true;
-  m_bEDLCommercialNotify           = true;
 
   m_cacheMemBufferSize = 1024 * 1024 * 20;
   m_networkBufferMode = 0; // Default (buffer all internet streams/filesystems)
@@ -887,6 +886,8 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetInt(pElement, "maxstartgap", m_iEdlMaxStartGap, 0, 10 * 60);               // Between 0 and 10 minutes
     XMLUtils::GetInt(pElement, "commbreakautowait", m_iEdlCommBreakAutowait, 0, 10);        // Between 0 and 10 seconds
     XMLUtils::GetInt(pElement, "commbreakautowind", m_iEdlCommBreakAutowind, 0, 10);        // Between 0 and 10 seconds
+    XMLUtils::GetBoolean(pElement, "commautoskip", m_bEdlCommAutoSkip);
+    XMLUtils::GetBoolean(pElement, "commnotify", m_bEdlCommNotify);
   }
 
   // picture exclude regexps
@@ -1058,13 +1059,6 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetBoolean(pPVR, "channeliconsautoscan", m_bPVRChannelIconsAutoScan);
     XMLUtils::GetBoolean(pPVR, "autoscaniconsuserset", m_bPVRAutoScanIconsUserSet);
     XMLUtils::GetInt(pPVR, "numericchannelswitchtimeout", m_iPVRNumericChannelSwitchTimeout, 50, 60000);
-  }
-
-  TiXmlElement *pEDL = pRootElement->FirstChildElement("edl");
-  if (pEDL)
-  {
-    XMLUtils::GetBoolean(pEDL, "commercialskip", m_bEDLCommercialSkip);
-    XMLUtils::GetBoolean(pEDL, "commercialnotify", m_bEDLCommercialNotify);
   }
 
   TiXmlElement* pDatabase = pRootElement->FirstChildElement("videodatabase");

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -309,6 +309,8 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     int m_iEdlMaxStartGap;          // seconds
     int m_iEdlCommBreakAutowait;    // seconds
     int m_iEdlCommBreakAutowind;    // seconds
+    bool m_bEdlCommAutoSkip; /*!< @brief true to automatically skip commercial breaks in Edit Decision Lists by defeault */
+    bool m_bEdlCommNotify; /*!< @brief true to display a notification of EDL commercial breaks (even if Commercial skip is off */
 
     int m_curlconnecttimeout;
     int m_curllowspeedtime;

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -306,6 +306,8 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     int m_iEdlMaxStartGap;          // seconds
     int m_iEdlCommBreakAutowait;    // seconds
     int m_iEdlCommBreakAutowind;    // seconds
+    bool m_bEdlCommAutoSkip; /*!< @brief true to automatically skip commercial breaks in Edit Decision Lists by defeault */
+    bool m_bEdlCommNotify; /*!< @brief true to display a notification of EDL commercial breaks (even if Commercial skip is off */
 
     int m_curlconnecttimeout;
     int m_curllowspeedtime;
@@ -353,8 +355,6 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     bool m_bPVRChannelIconsAutoScan; /*!< @brief automatically scan user defined folder for channel icons when loading internal channel groups */
     bool m_bPVRAutoScanIconsUserSet; /*!< @brief mark channel icons populated by auto scan as "user set" */
     int m_iPVRNumericChannelSwitchTimeout; /*!< @brief time in ms before the numeric dialog auto closes when confirmchannelswitch is disabled */
-    bool m_bCommercialSkip; /*!< @brief true to automatically skip commercial breaks in Edit Decision Lists by defeault */
-    bool m_bCommercialNotify; /*!< @brief true to display a notification of EDL commercial breaks (even if Commercial skip is off */
 
     DatabaseSettings m_databaseMusic; // advanced music database setup
     DatabaseSettings m_databaseVideo; // advanced video database setup

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -353,6 +353,8 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     bool m_bPVRChannelIconsAutoScan; /*!< @brief automatically scan user defined folder for channel icons when loading internal channel groups */
     bool m_bPVRAutoScanIconsUserSet; /*!< @brief mark channel icons populated by auto scan as "user set" */
     int m_iPVRNumericChannelSwitchTimeout; /*!< @brief time in ms before the numeric dialog auto closes when confirmchannelswitch is disabled */
+    bool m_bCommercialSkip; /*!< @brief true to automatically skip commercial breaks in Edit Decision Lists by defeault */
+    bool m_bCommercialNotify; /*!< @brief true to display a notification of EDL commercial breaks (even if Commercial skip is off */
 
     DatabaseSettings m_databaseMusic; // advanced music database setup
     DatabaseSettings m_databaseVideo; // advanced video database setup

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -167,6 +167,11 @@ bool CGUIWindowFullScreen::OnAction(const CAction &action)
     }
     break;
 
+  case ACTION_TOGGLE_COMMSKIP:
+    g_application.m_pPlayer->ToggleCommSkip();
+    return true;
+    break;
+
   case ACTION_SHOW_OSD_TIME:
     m_bShowCurrentTime = !m_bShowCurrentTime;
     if(!m_bShowCurrentTime)

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -166,6 +166,11 @@ bool CGUIWindowFullScreen::OnAction(const CAction &action)
     }
     break;
 
+  case ACTION_TOGGLE_COMMSKIP:
+    g_application.m_pPlayer->ToggleCommSkip();
+    return true;
+    break;
+
   case ACTION_SHOW_OSD_TIME:
     m_bShowCurrentTime = !m_bShowCurrentTime;
     if(!m_bShowCurrentTime)


### PR DESCRIPTION
An implementation to addres this feature request from the forums: http://forum.kodi.tv/showthread.php?tid=208206

This adds a new action, TOGGLE_COMMSKIP which turns Commercial Skipping on/off for the current recording only (next record starts back at the default setting from settings.xml).

Also adds an option to display notifications of commercials and their lengths.
