### PR TITLE
[addons] force repository update in post-install/uninstall

### DIFF
--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -194,11 +194,20 @@ bool CRepository::Parse(const DirInfo& dir, VECADDONS &result)
   return false;
 }
 
+void CRepository::OnPostInstall(bool update, bool modal)
+{
+  // force refresh of addon repositories
+  CAddonInstaller::Get().UpdateRepos(true, false, true);
+}
+
 void CRepository::OnPostUnInstall()
 {
   CAddonDatabase database;
   database.Open();
   database.DeleteRepository(ID());
+
+  // force refresh of addon repositories
+  CAddonInstaller::Get().UpdateRepos(true, false, true);
 }
 
 CRepositoryUpdateJob::CRepositoryUpdateJob(const VECADDONS &repos)

--- a/xbmc/addons/Repository.h
+++ b/xbmc/addons/Repository.h
@@ -59,6 +59,7 @@ namespace ADDON
     static bool Parse(const DirInfo& dir, VECADDONS& addons);
     static std::string FetchChecksum(const std::string& url);
 
+    virtual void OnPostInstall(bool update, bool modal);
     virtual void OnPostUnInstall();
 
   private:


### PR DESCRIPTION
Fix empty repository and possible ghost entries after installing/uninstall of addon repositories. Ideally we would just call it on a the actual repository but i think this works for Isengard.
