### PR TITLE
fixed: Don't do GetLength() off-thread is it may be (b)locked by a pe…

### DIFF
--- a/xbmc/filesystem/FileCache.h
+++ b/xbmc/filesystem/FileCache.h
@@ -24,6 +24,7 @@
 #include "threads/CriticalSection.h"
 #include "File.h"
 #include "threads/Thread.h"
+#include <atomic>
 
 namespace XFILE
 {
@@ -77,6 +78,7 @@ namespace XFILE
     unsigned     m_writeRate;
     unsigned     m_writeRateActual;
     bool         m_cacheFull;
+    std::atomic<int64_t> m_fileSize;
     CCriticalSection m_sync;
   };
 


### PR DESCRIPTION
…nding read() (fixes #16046).

On Windows Read() for e.g. smb seems to block forever when the connection gets lost causing the filecache-thread to lockup and blocking any call to m_source. This is mainly a problem with GetLength() which is used all over the place. Fixed by storing the value of m_source GetLength() in the filecache thread and returning the stored value offthread. 

Not sure if this is safe enough for Isengard.
