### PR TITLE
Add dateAdded to musiclibrary and use it for sorting

### DIFF
--- a/xbmc/music/GUIViewStateMusic.cpp
+++ b/xbmc/music/GUIViewStateMusic.cpp
@@ -251,6 +251,7 @@ CGUIViewStateMusicDatabase::CGUIViewStateMusicDatabase(const CFileItemList& item
       AddSortMethod(SortByLabel, sortAttribute, 551, LABEL_MASKS(strTrackLeft, strTrackRight));
       AddSortMethod(SortByTime, 180, LABEL_MASKS("%T - %A", "%D"));  // Titel, Artist, Duration| empty, empty
       AddSortMethod(SortByRating, 563, LABEL_MASKS("%T - %A", "%R"));  // Title - Artist, Rating
+      AddSortMethod(SortByDateAdded, 570, LABEL_MASKS("%A - %T", "%a"));  // Title - Artist, DateAdded | empty, empty
 
       const CViewState *viewState = CViewStateSettings::Get().Get("musicnavsongs");
       SetSortMethod(viewState->m_sortDescription);
@@ -271,6 +272,7 @@ CGUIViewStateMusicDatabase::CGUIViewStateMusicDatabase(const CFileItemList& item
       AddSortMethod(SortByTime, 180, LABEL_MASKS("%T - %A", "%D"));  // Titel, Artist, Duration| empty, empty
       AddSortMethod(SortByRating, 563, LABEL_MASKS("%T - %A", "%R"));  // Title - Artist, Rating
       AddSortMethod(SortByYear, 562, LABEL_MASKS("%T - %A", "%Y")); // Title, Artist, Year
+      AddSortMethod(SortByDateAdded, 570, LABEL_MASKS("%A - %T", "%a"));  // Title - Artist, DateAdded | empty, empty
 
       const CViewState *viewState = CViewStateSettings::Get().Get("musicnavsongs");
       // the "All Albums" entries always default to SortByAlbum as this is most logical - user can always

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -497,6 +497,12 @@ private:
   CAlbum GetAlbumFromDataset(dbiplus::Dataset* pDS, int offset = 0, bool imageURL = false);
   CAlbum GetAlbumFromDataset(const dbiplus::sql_record* const record, int offset = 0, bool imageURL = false);
   CArtistCredit GetArtistCreditFromDataset(const dbiplus::sql_record* const record, int offset = 0);
+  /*! \brief Updates the dateAdded field in the song table for the file
+  with the given songId and the given path based on the files modification date
+  \param songId id of the song in the song table
+  \param strFileNameAndPath path to the file
+  */
+  void UpdateFileDateAdded(int songId, const std::string& strFileNameAndPath);
   void GetFileItemFromDataset(CFileItem* item, const CMusicDbUrl &baseUrl);
   void GetFileItemFromDataset(const dbiplus::sql_record* const record, CFileItem* item, const CMusicDbUrl &baseUrl);
   CSong GetAlbumInfoSongFromDataset(const dbiplus::sql_record* const record, int offset = 0);
@@ -541,6 +547,7 @@ private:
     song_strAlbumArtists,
     song_strAlbumReleaseType,
     song_mood,
+    song_dateAdded,
     song_enumCount // end of the enum, do not add past here
   } SongFields;
 

--- a/xbmc/music/Song.cpp
+++ b/xbmc/music/Song.cpp
@@ -76,6 +76,7 @@ CSong::CSong(CFileItem& item)
   bCompilation = tag.GetCompilation();
   embeddedArt = tag.GetCoverArtInfo();
   strFileName = tag.GetURL().empty() ? item.GetPath() : tag.GetURL();
+  dateAdded = tag.GetDateAdded();
   strThumb = item.GetUserMusicThumb(true);
   iStartOffset = item.m_lStartOffset;
   iEndOffset = item.m_lEndOffset;
@@ -121,6 +122,7 @@ void CSong::Serialize(CVariant& value) const
   value["rating"] = rating;
   value["timesplayed"] = iTimesPlayed;
   value["lastplayed"] = lastPlayed.IsValid() ? lastPlayed.GetAsDBDateTime() : "";
+  value["dateadded"] = dateAdded.IsValid() ? dateAdded.GetAsDBDateTime() : "";
   value["karaokenumber"] = (int64_t) iKaraokeNumber;
   value["albumid"] = idAlbum;
 }
@@ -146,6 +148,7 @@ void CSong::Clear()
   idSong = -1;
   iTimesPlayed = 0;
   lastPlayed.Reset();
+  dateAdded.Reset();
   iKaraokeNumber = 0;
   strKaraokeLyrEncoding.clear();
   iKaraokeDelay = 0;

--- a/xbmc/music/Song.h
+++ b/xbmc/music/Song.h
@@ -101,6 +101,7 @@ public:
   int iYear;
   int iTimesPlayed;
   CDateTime lastPlayed;
+  CDateTime dateAdded;
   int iStartOffset;
   int iEndOffset;
   bool bCompilation;

--- a/xbmc/music/tags/MusicInfoTag.cpp
+++ b/xbmc/music/tags/MusicInfoTag.cpp
@@ -115,6 +115,7 @@ const CMusicInfoTag& CMusicInfoTag::operator =(const CMusicInfoTag& tag)
   m_strLyrics = tag.m_strLyrics;
   m_cuesheet = tag.m_cuesheet;
   m_lastPlayed = tag.m_lastPlayed;
+  m_dateAdded = tag.m_dateAdded;
   m_bCompilation = tag.m_bCompilation;
   m_iDuration = tag.m_iDuration;
   m_iTrack = tag.m_iTrack;
@@ -266,6 +267,11 @@ int CMusicInfoTag::GetPlayCount() const
 const CDateTime &CMusicInfoTag::GetLastPlayed() const
 {
   return m_lastPlayed;
+}
+
+const CDateTime &CMusicInfoTag::GetDateAdded() const
+{
+  return m_dateAdded;
 }
 
 bool CMusicInfoTag::GetCompilation() const
@@ -429,6 +435,16 @@ void CMusicInfoTag::SetLastPlayed(const CDateTime& lastplayed)
   m_lastPlayed = lastplayed;
 }
 
+void CMusicInfoTag::SetDateAdded(const std::string& dateAdded)
+{
+  m_dateAdded.SetFromDBDateTime(dateAdded);
+}
+
+void CMusicInfoTag::SetDateAdded(const CDateTime& dateAdded)
+{
+  m_dateAdded = dateAdded;
+}
+
 void CMusicInfoTag::SetCompilation(bool compilation)
 {
   m_bCompilation = compilation;
@@ -551,6 +567,7 @@ void CMusicInfoTag::SetSong(const CSong& song)
   SetCueSheet(song.strCueSheet);
   SetPlayCount(song.iTimesPlayed);
   SetLastPlayed(song.lastPlayed);
+  SetDateAdded(song.dateAdded);
   SetCoverArtInfo(song.embeddedArt.size, song.embeddedArt.mime);
   m_rating = song.rating;
   m_strURL = song.strFileName;
@@ -598,6 +615,7 @@ void CMusicInfoTag::Serialize(CVariant& value) const
   value["rating"] = (int)(m_rating - '0');
   value["playcount"] = m_iTimesPlayed;
   value["lastplayed"] = m_lastPlayed.IsValid() ? m_lastPlayed.GetAsDBDateTime() : StringUtils::Empty;
+  value["dateadded"] = m_dateAdded.IsValid() ? m_dateAdded.GetAsDBDateTime() : StringUtils::Empty;
   value["lyrics"] = m_strLyrics;
   value["albumid"] = m_iAlbumId;
   value["compilationartist"] = m_bCompilation;
@@ -632,6 +650,7 @@ void CMusicInfoTag::ToSortable(SortItem& sortable, Field field) const
   case FieldRating:      sortable[FieldRating] = (float)(m_rating - '0'); break;
   case FieldPlaycount:   sortable[FieldPlaycount] = m_iTimesPlayed; break;
   case FieldLastPlayed:  sortable[FieldLastPlayed] = m_lastPlayed.IsValid() ? m_lastPlayed.GetAsDBDateTime() : StringUtils::Empty; break;
+  case FieldDateAdded:   sortable[FieldDateAdded] = m_dateAdded.IsValid() ? m_dateAdded.GetAsDBDateTime() : StringUtils::Empty; break;
   case FieldListeners:   sortable[FieldListeners] = m_listeners; break;
   case FieldId:          sortable[FieldId] = (int64_t)m_iDbId; break;
   default: break;
@@ -658,6 +677,7 @@ void CMusicInfoTag::Archive(CArchive& ar)
     ar << m_musicBrainzAlbumArtistID;
     ar << m_strMusicBrainzTRMID;
     ar << m_lastPlayed;
+    ar << m_dateAdded;
     ar << m_strComment;
     ar << m_strMood;
     ar << m_rating;
@@ -690,6 +710,7 @@ void CMusicInfoTag::Archive(CArchive& ar)
     ar >> m_musicBrainzAlbumArtistID;
     ar >> m_strMusicBrainzTRMID;
     ar >> m_lastPlayed;
+    ar >> m_dateAdded;
     ar >> m_strComment;
     ar >> m_strMood;
     ar >> m_rating;
@@ -726,6 +747,7 @@ void CMusicInfoTag::Clear()
   m_iTrack = 0;
   m_bLoaded = false;
   m_lastPlayed.Reset();
+  m_dateAdded.Reset();
   m_bCompilation = false;
   m_strComment.clear();
   m_strMood.clear();

--- a/xbmc/music/tags/MusicInfoTag.h
+++ b/xbmc/music/tags/MusicInfoTag.h
@@ -73,6 +73,7 @@ public:
   const std::string& GetLyrics() const;
   const std::string& GetCueSheet() const;
   const CDateTime& GetLastPlayed() const;
+  const CDateTime& GetDateAdded() const;
   bool  GetCompilation() const;
   char  GetRating() const;
   int  GetListeners() const;
@@ -116,6 +117,8 @@ public:
   void SetPlayCount(int playcount);
   void SetLastPlayed(const std::string& strLastPlayed);
   void SetLastPlayed(const CDateTime& strLastPlayed);
+  void SetDateAdded(const std::string& strLastPlayed);
+  void SetDateAdded(const CDateTime& strLastPlayed);
   void SetCompilation(bool compilation);
   void SetCoverArtInfo(size_t size, const std::string &mimeType);
   void SetReplayGain(const ReplayGain& aGain);
@@ -167,6 +170,7 @@ protected:
   std::string m_strLyrics;
   std::string m_cuesheet;
   CDateTime m_lastPlayed;
+  CDateTime m_dateAdded;
   bool m_bCompilation;
   int m_iDuration;
   int m_iTrack;     // consists of the disk number in the high 16 bits, the track number in the low 16bits

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -1180,7 +1180,7 @@ bool CGUIWindowMusicBase::CanContainFilter(const std::string &strDirectory) cons
 void CGUIWindowMusicBase::OnInitWindow()
 {
   CGUIMediaWindow::OnInitWindow();
-  if (CMediaSettings::Get().GetMusicNeedsUpdate() == 35)
+  if (CMediaSettings::Get().GetMusicNeedsUpdate() == 53)
   {
     if (g_infoManager.GetLibraryBool(LIBRARY_HAS_MUSIC) && !g_application.IsMusicScanning())
   {

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -274,6 +274,7 @@ void CAdvancedSettings::Initialize()
   m_prioritiseAPEv2tags = false;
   m_musicItemSeparator = " / ";
   m_videoItemSeparator = " / ";
+  m_iMusicLibraryDateAdded = 1; // prefer mtime over ctime and current time
 
   m_bVideoLibraryAllItemsOnBottom = false;
   m_iVideoLibraryRecentlyAddedItems = 25;
@@ -736,6 +737,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetString(pElement, "albumformat", m_strMusicLibraryAlbumFormat);
     XMLUtils::GetString(pElement, "albumformatright", m_strMusicLibraryAlbumFormatRight);
     XMLUtils::GetString(pElement, "itemseparator", m_musicItemSeparator);
+    XMLUtils::GetInt(pElement, "dateadded", m_iMusicLibraryDateAdded);
   }
 
   pElement = pRootElement->FirstChildElement("videolibrary");

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -265,6 +265,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     std::string m_fanartImages;
 
     int m_iMusicLibraryRecentlyAddedItems;
+    int m_iMusicLibraryDateAdded;
     bool m_bMusicLibraryAllItemsOnBottom;
     bool m_bMusicLibraryAlbumsSortByArtistThenYear;
     bool m_bMusicLibraryCleanOnUpdate;

--- a/xbmc/utils/DatabaseUtils.cpp
+++ b/xbmc/utils/DatabaseUtils.cpp
@@ -96,7 +96,7 @@ std::string DatabaseUtils::GetField(Field field, const MediaType &mediaType, Dat
     else if (field == FieldPath) return "songview.strPath";
     else if (field == FieldArtist || field == FieldAlbumArtist) return "songview.strArtists";
     else if (field == FieldGenre) return "songview.strGenre";
-    else if (field == FieldDateAdded && queryPart == DatabaseQueryPartOrderBy) return "songview.idSong";     // only used for order clauses
+    else if (field == FieldDateAdded && queryPart == DatabaseQueryPartOrderBy) return "songview.dateAdded";
   }
   else if (mediaType == MediaTypeArtist)
   {

--- a/xbmc/utils/FileUtils.h
+++ b/xbmc/utils/FileUtils.h
@@ -29,4 +29,10 @@ public:
   static bool RenameFile(const std::string &strFile);
   static bool RemoteAccessAllowed(const std::string &strPath);
   static unsigned int LoadFile(const std::string &filename, void* &outputBuffer);
+  /*! \brief Get the modified date of a file if its invalid it returns the creation date - this behavior changes when you set bUseLatestDate
+  \param strFileNameAndPath path to the file
+  \param bUseLatestDate use the newer datetime of the files mtime and ctime
+  \return Returns the file date, can return a invalid date if problems occure
+  */
+  static CDateTime GetModificationDate(const std::string& strFileNameAndPath, const bool& bUseLatestDate);
 };

--- a/xbmc/utils/LabelFormatter.cpp
+++ b/xbmc/utils/LabelFormatter.cpp
@@ -318,6 +318,8 @@ std::string CLabelFormatter::GetMaskContent(const CMaskString &mask, const CFile
   case 'a': // Date Added
     if (movie && movie->m_dateAdded.IsValid())
       value = movie->m_dateAdded.GetAsLocalizedDate();
+    if (music && music->GetDateAdded().IsValid())
+      value = music->GetDateAdded().GetAsLocalizedDate();
     break;
   case 'p': // Last played
     if (movie && movie->m_lastPlayed.IsValid())

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -52,6 +52,7 @@
 #include "storage/MediaManager.h"
 #include "utils/StringUtils.h"
 #include "guilib/LocalizeStrings.h"
+#include "utils/FileUtils.h"
 #include "utils/log.h"
 #include "TextureCache.h"
 #include "interfaces/AnnouncementManager.h"
@@ -856,72 +857,28 @@ void CVideoDatabase::UpdateFileDateAdded(int idFile, const std::string& strFileN
 {
   if (idFile < 0 || strFileNameAndPath.empty())
     return;
-    
-  std::string strSQL = "";
+
+  CDateTime dateAdded;
   try
   {
     if (NULL == m_pDB.get()) return;
     if (NULL == m_pDS.get()) return;
-
-    std::string file = strFileNameAndPath;
-    if (URIUtils::IsStack(strFileNameAndPath))
-      file = CStackDirectory::GetFirstStackedFile(strFileNameAndPath);
-
-    if (URIUtils::IsInArchive(file))
-      file = CURL(file).GetHostName();
-
-    CDateTime dateAdded;
-    // Skip looking at the files ctime/mtime if defined by the user through as.xml
-    if (g_advancedSettings.m_iVideoLibraryDateAdded > 0)
-    {
-      // Let's try to get the modification datetime
-      struct __stat64 buffer;
-      if (CFile::Stat(file, &buffer) == 0 && (buffer.st_mtime != 0 || buffer.st_ctime !=0))
-      {
-        time_t now = time(NULL);
-        time_t addedTime;
-        // Prefer the modification time if it's valid
-        if (g_advancedSettings.m_iVideoLibraryDateAdded == 1)
-        {
-          if (buffer.st_mtime != 0 && (time_t)buffer.st_mtime <= now)
-            addedTime = (time_t)buffer.st_mtime;
-          else
-            addedTime = (time_t)buffer.st_ctime;
-        }
-        // Use the newer of the creation and modification time
-        else
-        {
-          addedTime = max((time_t)buffer.st_ctime, (time_t)buffer.st_mtime);
-          // if the newer of the two dates is in the future, we try it with the older one
-          if (addedTime > now)
-            addedTime = min((time_t)buffer.st_ctime, (time_t)buffer.st_mtime);
-        }
-
-        // make sure the datetime does is not in the future
-        if (addedTime <= now)
-        {
-          struct tm *time;
-#ifdef HAVE_LOCALTIME_R
-          struct tm result = {};
-          time = localtime_r(&addedTime, &result);
-#else
-          time = localtime(&addedTime);
-#endif
-          if (time)
-            dateAdded = *time;
-        }
-      }
-    }
-
+     
+    // 1 prefering to use the files mtime(if it's valid) and only using the file's ctime if the mtime isn't valid
+    if (g_advancedSettings.m_iVideoLibraryDateAdded == 1)
+      dateAdded = CFileUtils::GetModificationDate(strFileNameAndPath, false);
+    //2 using the newer datetime of the file's mtime and ctime
+    else if (g_advancedSettings.m_iVideoLibraryDateAdded == 2)
+      dateAdded = CFileUtils::GetModificationDate(strFileNameAndPath, true);
+    //0 using the current datetime if non of the above matches or one returns an invalid datetime
     if (!dateAdded.IsValid())
       dateAdded = CDateTime::GetCurrentDateTime();
 
-    strSQL = PrepareSQL("update files set dateAdded='%s' where idFile=%d", dateAdded.GetAsDBDateTime().c_str(), idFile);
-    m_pDS->exec(strSQL.c_str());
+    m_pDS->exec(PrepareSQL("UPDATE files SET dateAdded='%s' WHERE idFile=%d", dateAdded.GetAsDBDateTime().c_str(), idFile));
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "%s unable to update dateadded for file (%s)", __FUNCTION__, strSQL.c_str());
+    CLog::Log(LOGERROR, "%s unable to update dateadded for file (%s) with date (%s)", __FUNCTION__, idFile, dateAdded.GetAsDBDateTime().c_str());
   }
 }
 


### PR DESCRIPTION
Well here is my first c++ effort. 

As suggested in http://forum.kodi.tv/showthread.php?tid=230191 and probably some other topics, this PR adds a new filter "date added" to the musiclibrary. And also stores the data in a field in the song table, the logic to get the date is exactly the same as the videolibrary uses.

I'm pretty sure there are some problems especially with the `CMusicDatabase::UpdateFileDateAdded` method as I tried to keep this along the lines of the VideoDatabase counterpart. So there is stil code for stacked items and archived. Please check if this is sane, I can't tell. I also tried to merge bot UpdateFileDateAdded, but my c++ is to bad for that.

I only tested this on windows, but if this gets wrong dates from your filesystem, it's likely the videolibrary also has this problem
