### PR TITLE
changed: Don't blindly enable filecache for any internet stream

### DIFF
--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFile.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFile.cpp
@@ -74,9 +74,6 @@ bool CDVDInputStreamFile::Open(const char* strFile, const std::string& content)
     }
   }
 
-  if (!(flags & READ_CACHED))
-    flags |= READ_NO_CACHE; // Make sure CFile honors our no-cache hint
-
   if (content == "video/mp4" ||
       content == "video/x-msvideo" ||
       content == "video/avi" ||

--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -235,18 +235,11 @@ bool CFile::Open(const CURL& file, const unsigned int flags)
 
     CURL url(URIUtils::SubstitutePath(file));
 
-    if (!(m_flags & READ_NO_CACHE))
+    if (m_flags & READ_CACHED)
     {
-      const std::string pathToUrl(url.Get());
-      if (URIUtils::IsInternetStream(url, true) && !CUtil::IsPicture(pathToUrl) )
-        m_flags |= READ_CACHED;
-
-      if (m_flags & READ_CACHED)
-      {
-        // for internet stream, if it contains multiple stream, file cache need handle it specially.
-        m_pFile = new CFileCache((m_flags & READ_MULTI_STREAM) == READ_MULTI_STREAM);
-        return m_pFile->Open(url);
-      }
+      // If it's hinted as multistream, tell filecache so it can use double-caching
+      m_pFile = new CFileCache(m_flags & READ_MULTI_STREAM);
+      return m_pFile->Open(url);
     }
 
     m_pFile = CFileFactory::CreateLoader(url);

--- a/xbmc/filesystem/File.h
+++ b/xbmc/filesystem/File.h
@@ -59,10 +59,7 @@ public:
 #define READ_CHUNKED   0x02
 
 /* use cache to access this file */
-#define READ_CACHED     0x04
-
-/* open without caching. regardless to file type. */
-#define READ_NO_CACHE  0x08
+#define READ_CACHED    0x04
 
 /* calcuate bitrate for file while reading */
 #define READ_BITRATE   0x10


### PR DESCRIPTION
If it is required for specific situations, it should be hinted there. This is probably a leftover of the Xbox-era when we used disk-cache by default. Since we use memory-cache now, doing this uses the full max. amount of configured memory (10MB by default) for each opened cached file, even if it's much smaller. Since any caching for audio/video is already handled in DVDPlayer, this should be dropped IMO as I can't think of any other files where this really helps (a lot).
