### PR TITLE
[guilib] add Container.SortOrder InfoLabel

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -2542,10 +2542,12 @@ msgctxt "#583"
 msgid "Remember views for different folders"
 msgstr ""
 
+#: xbmc/view/GUIViewState.cpp
 msgctxt "#584"
 msgid "Ascending"
 msgstr ""
 
+#: xbmc/view/GUIViewState.cpp
 msgctxt "#585"
 msgid "Descending"
 msgstr ""

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -429,6 +429,7 @@ const infomap mediacontainer[] = {{ "hasfiles",         CONTAINER_HASFILES },
                                   { "totaltime",        CONTAINER_TOTALTIME },
                                   { "hasthumb",         CONTAINER_HAS_THUMB },
                                   { "sortmethod",       CONTAINER_SORT_METHOD },
+                                  { "sortorder",        CONTAINER_SORT_ORDER },
                                   { "showplot",         CONTAINER_SHOWPLOT }};
 
 const infomap container_bools[] ={{ "onnext",           CONTAINER_MOVE_NEXT },
@@ -1801,14 +1802,18 @@ std::string CGUIInfoManager::GetLabel(int info, int contextWindow, std::string *
       break;
     }
   case CONTAINER_SORT_METHOD:
-    {
+  case CONTAINER_SORT_ORDER:
+  {
       CGUIWindow *window = GetWindowWithCondition(contextWindow, WINDOW_CONDITION_IS_MEDIA_WINDOW);
       if (window)
       {
         const CGUIViewState *viewState = ((CGUIMediaWindow*)window)->GetViewState();
         if (viewState)
-          strLabel = g_localizeStrings.Get(viewState->GetSortMethodLabel());
-    }
+          if (info == CONTAINER_SORT_METHOD)
+            strLabel = g_localizeStrings.Get(viewState->GetSortMethodLabel());
+          else if (info == CONTAINER_SORT_ORDER)
+            strLabel = g_localizeStrings.Get(viewState->GetSortOrderLabel());
+      }
     }
     break;
   case CONTAINER_NUM_PAGES:

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1120,11 +1120,6 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
           order = SortOrderDescending;
         return AddMultiInfo(GUIInfo(CONTAINER_SORT_DIRECTION, order));
       }
-      else if (prop.name == "sort")
-      {
-        if (StringUtils::EqualsNoCase(prop.param(), "songrating"))
-          return AddMultiInfo(GUIInfo(CONTAINER_SORT_METHOD, SortByRating));
-      }
     }
     else if (cat.name == "listitem")
     {

--- a/xbmc/guiinfo/GUIInfoLabels.h
+++ b/xbmc/guiinfo/GUIInfoLabels.h
@@ -293,6 +293,7 @@
 #define CONTAINER_CURRENT_PAGE      375
 #define CONTAINER_SHOWPLOT          376
 #define CONTAINER_TOTALTIME         377
+#define CONTAINER_SORT_ORDER        378
 
 #define MUSICPM_ENABLED             381
 #define MUSICPM_SONGSPLAYED         382

--- a/xbmc/view/GUIViewState.cpp
+++ b/xbmc/view/GUIViewState.cpp
@@ -203,6 +203,15 @@ SortOrder CGUIViewState::GetSortOrder() const
   return SortOrderAscending;
 }
 
+int CGUIViewState::GetSortOrderLabel() const
+{
+  if (m_currentSortMethod >= 0 && m_currentSortMethod < (int)m_sortMethods.size())
+    if (m_sortMethods[m_currentSortMethod].m_sortDescription.sortOrder == SortOrderAscending)
+      return 585;
+
+  return 584; // default sort order label 'Ascending'
+}
+
 int CGUIViewState::GetViewAsControl() const
 {
   return m_currentViewAsControl;

--- a/xbmc/view/GUIViewState.h
+++ b/xbmc/view/GUIViewState.h
@@ -42,6 +42,7 @@ public:
   SortDescription GetSortMethod() const;
   bool HasMultipleSortMethods() const;
   int GetSortMethodLabel() const;
+  int GetSortOrderLabel() const;
   void GetSortMethodLabelMasks(LABEL_MASKS& masks) const;
 
   SortOrder SetNextSortOrder();


### PR DESCRIPTION
Adds an InfoLabel "Container.SortOrder"
- Avoids the need for some workarounds  (using $INFO[Control.GetLabel(4)])
- bit more flexible (only returns "Ascending" / "Descending" without the "Order: " prefix)
- Consistent with Container.SortMethod InfoLabel

Also, I found some not-documented stuff when lookin through code I didnt hear off before:

Container.sortdirection(ascending/descending) [Boolean]
Container.sort(sorttype) [Boolean]
Container.listitemposition(..).xxx [InfoLabel]

The first one would allow a workaround (by using a $VAR[] for example) to do basically the same as this PR, but since I already was done when finding that I thaught setting up this PR doesnt hurt for a short discussion at least.

for the last one I found some related old forum thread, it´s in core since 6 years already :) http://forum.kodi.tv/showthread.php?tid=63144

Any opinion? The InfoLabels / Bools are probably something for the wiki? (and perhaps worth mentioning in "Skinning engine changes" thread? )

@ronie @mkortstiege
