### PR TITLE
[confluence] re-label Bookmarks dialog to Bookmarks / Chapters

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -1279,7 +1279,10 @@ msgctxt "#294"
 msgid "Create bookmark"
 msgstr ""
 
-#empty string with id 295
+#: skin.confluence/720p/VideoOSDBookmarks.xml
+msgctxt "#295"
+msgid "Chapters"
+msgstr ""
 
 msgctxt "#296"
 msgid "Clear bookmarks"
@@ -1289,6 +1292,9 @@ msgctxt "#297"
 msgid "Audio offset"
 msgstr ""
 
+#: skin.confluence/720p/VideoOSD.xml
+#: skin.confluence/720p/VideoOSDBookmarks.xml
+#: xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
 msgctxt "#298"
 msgid "Bookmarks"
 msgstr ""

--- a/addons/skin.confluence/720p/VideoOSDBookmarks.xml
+++ b/addons/skin.confluence/720p/VideoOSDBookmarks.xml
@@ -31,7 +31,7 @@
 			<width>720</width>
 			<height>30</height>
 			<font>font13_title</font>
-			<label>$LOCALIZE[298]</label>
+			<label>$LOCALIZE[298] / $LOCALIZE[295]</label>
 			<align>center</align>
 			<aligny>center</aligny>
 			<textcolor>selected</textcolor>


### PR DESCRIPTION
Since https://github.com/xbmc/xbmc/pull/6415 this dialog has a dual purpose.

This is the simple and quick solution to rename the string to include Chapters in the dialog title.

The best solution IMO would be to use a pop-up/fly-out like the subtitles button has, in this case a Bookmarks and a Chapters buttons would coexist there and clicking the relevant one would take you the a specific similar dialog with a few diffrences like the title and buttons inside.
The bookmarks dialog as it currently exists and a reused dialog for Chapters without the create/remove bookmarks buttons would be probably ideal way to properly support this.

However I messed up trying to do this as Im not very experienced in the skinning department.

@phil65 probably could do that in his sleep or even @ronie.

@MartijnKaijser this would be OK to include in Isengard and if later or instead a better alternative comes up that would be preferable.
