### PR TITLE
Strip whitespace from URLs for cURL 7.40+ compatibility

### DIFF
--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -825,6 +825,8 @@ void CCurlFile::ParseAndCorrectUrl(CURL &url2)
     m_url = url2.GetWithoutUserDetails();
   else
     m_url = url2.Get();
+
+  StringUtils::Trim(m_url);
 }
 
 void CCurlFile::SetStreamProxy(const std::string &proxy, ProxyType type)


### PR DESCRIPTION
Starting with version 7.40.0, cURL [rejects](https://github.com/bagder/curl/commit/178bd7db34f77e020fb8562890c5625ccbd67093) any URL containing `\r` and/or `\n` [for security reasons](http://curl.haxx.se/docs/adv_20150108B.html). This pull request contains a single change to `CurlFile.cpp` which causes whitespace to be stripped off URLs before they are passed to cURL.
