### PR TITLE
FIX: [droid] handle audio headsets

### DIFF
--- a/tools/android/packaging/xbmc/AndroidManifest.xml.in
+++ b/tools/android/packaging/xbmc/AndroidManifest.xml.in
@@ -11,6 +11,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.GET_TASKS" />
+    <uses-permission android:name="android.permission.BLUETOOTH" />
 
     <uses-feature android:name="android.hardware.screen.landscape" android:required="true" />
     <uses-feature android:name="android.hardware.touchscreen" android:required="false" />

--- a/xbmc/android/activity/XBMCApp.cpp
+++ b/xbmc/android/activity/XBMCApp.cpp
@@ -49,6 +49,7 @@
 #include "AppParamParser.h"
 #include "XbmcContext.h"
 #include <android/bitmap.h>
+#include "cores/AudioEngine/AEFactory.h"
 #include "android/jni/JNIThreading.h"
 #include "android/jni/BroadcastReceiver.h"
 #include "android/jni/Intent.h"
@@ -99,6 +100,7 @@ CJNIWakeLock *CXBMCApp::m_wakeLock = NULL;
 ANativeWindow* CXBMCApp::m_window = NULL;
 int CXBMCApp::m_batteryLevel = 0;
 bool CXBMCApp::m_hasFocus = false;
+bool CXBMCApp::m_headsetPlugged = false;
 CCriticalSection CXBMCApp::m_applicationsMutex;
 std::vector<androidPackage> CXBMCApp::m_applications;
 
@@ -158,12 +160,17 @@ void CXBMCApp::onResume()
   intentFilter.addAction("android.intent.action.BATTERY_CHANGED");
   intentFilter.addAction("android.intent.action.DREAMING_STOPPED");
   intentFilter.addAction("android.intent.action.SCREEN_ON");
+  intentFilter.addAction("android.intent.action.HEADSET_PLUG");
+  intentFilter.addAction("android.bluetooth.a2dp.profile.action.CONNECTION_STATE_CHANGED");
   registerReceiver(*this, intentFilter);
 
   if (!g_application.IsInScreenSaver())
     EnableWakeLock(true);
   else
     g_application.WakeUpScreenSaverAndDPMS();
+
+  CJNIAudioManager audioManager(getSystemService("audio"));
+  m_headsetPlugged = audioManager.isWiredHeadsetOn() || audioManager.isBluetoothA2dpOn();
 
   // Clear the applications cache. We could have installed/deinstalled apps
   {
@@ -349,6 +356,11 @@ bool CXBMCApp::ReleaseAudioFocus()
 bool CXBMCApp::HasFocus()
 {
   return m_hasFocus;
+}
+
+bool CXBMCApp::IsHeadsetPlugged()
+{
+  return m_headsetPlugged;
 }
 
 void CXBMCApp::run()
@@ -739,8 +751,24 @@ void CXBMCApp::onReceive(CJNIIntent intent)
   if (action == "android.intent.action.BATTERY_CHANGED")
     m_batteryLevel = intent.getIntExtra("level",-1);
   else if (action == "android.intent.action.DREAMING_STOPPED" || action == "android.intent.action.SCREEN_ON")
+  {
     if (HasFocus())
       g_application.WakeUpScreenSaverAndDPMS();
+  }
+  else if (action == "android.intent.action.HEADSET_PLUG" || action == "android.bluetooth.a2dp.profile.action.CONNECTION_STATE_CHANGED")
+  {
+    bool newstate;
+    if (action == "android.intent.action.HEADSET_PLUG")
+      newstate = (intent.getIntExtra("state", 0) != 0);
+    else
+      newstate = (intent.getIntExtra("android.bluetooth.profile.extra.STATE", 0) == 2 /* STATE_CONNECTED */);
+
+    if (newstate != m_headsetPlugged)
+    {
+      m_headsetPlugged = newstate;
+      CAEFactory::DeviceChange();
+    }
+  }
 }
 
 void CXBMCApp::onNewIntent(CJNIIntent intent)

--- a/xbmc/android/activity/XBMCApp.h
+++ b/xbmc/android/activity/XBMCApp.h
@@ -90,6 +90,7 @@ public:
   static int GetBatteryLevel();
   static bool EnableWakeLock(bool on);
   static bool HasFocus();
+  static bool IsHeadsetPlugged();
 
   static bool StartActivity(const std::string &package, const std::string &intent = std::string(), const std::string &dataType = std::string(), const std::string &dataURI = std::string());
   static std::vector <androidPackage> GetApplications();
@@ -138,6 +139,7 @@ private:
   static CJNIWakeLock *m_wakeLock;
   static int m_batteryLevel;
   static bool m_hasFocus;
+  static bool m_headsetPlugged;
   bool m_firstrun;
   bool m_exiting;
   pthread_t m_thread;

--- a/xbmc/android/jni/AudioManager.cpp
+++ b/xbmc/android/jni/AudioManager.cpp
@@ -80,6 +80,20 @@ int CJNIAudioManager::abandonAudioFocus(const CJNIAudioManagerAudioFocusChangeLi
                           "(Landroid/media/AudioManager$OnAudioFocusChangeListener;)I", listener.get_raw());
 }
 
+bool CJNIAudioManager::isBluetoothA2dpOn()
+{
+  return call_method<jboolean>(m_object,
+                               "isBluetoothA2dpOn",
+                               "()Z");
+}
+
+bool CJNIAudioManager::isWiredHeadsetOn()
+{
+  return call_method<jboolean>(m_object,
+                               "isWiredHeadsetOn",
+                               "()Z");
+}
+
 //////////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////////
 CJNIAudioManagerAudioFocusChangeListener* CJNIAudioManagerAudioFocusChangeListener::m_listenerInstance(NULL);

--- a/xbmc/android/jni/AudioManager.h
+++ b/xbmc/android/jni/AudioManager.h
@@ -51,6 +51,8 @@ public:
 
   int requestAudioFocus(const CJNIAudioManagerAudioFocusChangeListener &listener, int streamType, int durationHint);
   int abandonAudioFocus (const CJNIAudioManagerAudioFocusChangeListener &listener);
+  bool isBluetoothA2dpOn();
+  bool isWiredHeadsetOn();
 
   static void PopulateStaticFields();
   static int STREAM_MUSIC;

--- a/xbmc/android/jni/Intent.cpp
+++ b/xbmc/android/jni/Intent.cpp
@@ -65,6 +65,13 @@ int CJNIIntent::getIntExtra(const std::string &name, int defaultValue) const
     jcast<jhstring>(name), defaultValue);
 }
 
+std::string CJNIIntent::getStringExtra(const std::string &name) const
+{
+  return jcast<std::string>(call_method<jhstring>(m_object,
+    "getStringExtra", "(Ljava/lang/String;I)Ljava/lang/String;",
+    jcast<jhstring>(name)));
+}
+
 bool CJNIIntent::hasExtra(const std::string &name) const
 {
   return call_method<jboolean>(m_object,

--- a/xbmc/android/jni/Intent.h
+++ b/xbmc/android/jni/Intent.h
@@ -35,6 +35,7 @@ public:
   std::string getType() const ;
 
   int getIntExtra(const std::string &name, int defaultValue) const;
+  std::string getStringExtra(const std::string &name) const;
 
   bool hasExtra(const std::string &name) const;
   bool hasCategory(const std::string &category) const;

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
@@ -59,7 +59,6 @@ private:
 
   static CAEDeviceInfo m_info;
   AEAudioFormat      m_format;
-  AEAudioFormat      m_lastFormat;
   double             m_volume;
   volatile int       m_min_frames;
   int16_t           *m_alignedS16;


### PR DESCRIPTION
Properly only enable PCM stereo when a headset (bluetooth or wired) is connected

/cc @anssih @Montellese @MartijnKaijser 
