### PR TITLE
ADD: [keyboard] allow to map long key presses

### DIFF
--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -52,8 +52,11 @@
       <pageup>PageUp</pageup>
       <pagedown>PageDown</pagedown>
       <return>Select</return>
+      <return mod="long">ContextMenu</return>
       <enter>Select</enter>
+      <enter mod="long">ContextMenu</enter>
       <backspace>Back</backspace>
+      <backspace mod="long">ActivateWindow(Home)</backspace>
       <key id='65446'>Back</key>
       <m>ActivateWindow(PlayerControls)</m>
       <s>ActivateWindow(shutdownmenu)</s>

--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -35,6 +35,10 @@
 <!--                                                                                          -->
 <!--  Axis Ids / Analog Controls                                                              -->
 <!--   Coming soon.                                                                           -->
+<!--                                                                                          -->
+<!--  Long presses                                                                            -->
+<!--   A limitation is that if a single press is mapped in a section, a global "longpress"    -->
+<!--   will be ignored. The workaround is to duplicate the long mapping in the section.       -->
 <keymap>
   <global>
     <keyboard>
@@ -52,11 +56,11 @@
       <pageup>PageUp</pageup>
       <pagedown>PageDown</pagedown>
       <return>Select</return>
-      <return mod="long">ContextMenu</return>
+      <return mod="longpress">ContextMenu</return>
       <enter>Select</enter>
-      <enter mod="long">ContextMenu</enter>
+      <enter mod="longpress">ContextMenu</enter>
       <backspace>Back</backspace>
-      <backspace mod="long">ActivateWindow(Home)</backspace>
+      <backspace mod="longpress">ActivateWindow(Home)</backspace>
       <key id='65446'>Back</key>
       <m>ActivateWindow(PlayerControls)</m>
       <s>ActivateWindow(shutdownmenu)</s>

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -1195,11 +1195,15 @@ CAction CButtonTranslator::GetGlobalAction(const CKey &key)
   return GetAction(-1, key, true);
 }
 
-bool CButtonTranslator::IsPossibleLongpress(int window, const CKey &key)
+bool CButtonTranslator::HasLonpressMapping(int window, const CKey &key)
 {
   map<int, buttonMap>::const_iterator it = m_translatorMap.find(window);
   if (it == m_translatorMap.end())
+  {
+    if (window > -1)
+      return HasLonpressMapping(GetFallbackWindow(window), key);
     return false;
+  }
 
   uint32_t code = key.GetButtonCode();
   code |= CKey::MODIFIER_LONG;
@@ -1219,8 +1223,7 @@ bool CButtonTranslator::IsPossibleLongpress(int window, const CKey &key)
   }
 #endif
   if (window > -1)
-    return IsPossibleLongpress(GetFallbackWindow(window), key);
-
+    return HasLonpressMapping(GetFallbackWindow(window), key);
   return false;
 }
 
@@ -1632,7 +1635,7 @@ uint32_t CButtonTranslator::TranslateKeyboardButton(TiXmlElement *pButton)
         button_id |= CKey::MODIFIER_SUPER;
       else if (substr == "meta" || substr == "cmd")
         button_id |= CKey::MODIFIER_META;
-      else if (substr == "long")
+      else if (substr == "longpress")
         button_id |= CKey::MODIFIER_LONG;
       else
         CLog::Log(LOGERROR, "Keyboard Translator: Unknown key modifier %s in %s", substr.c_str(), strMod.c_str());

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -1195,6 +1195,35 @@ CAction CButtonTranslator::GetGlobalAction(const CKey &key)
   return GetAction(-1, key, true);
 }
 
+bool CButtonTranslator::IsPossibleLongpress(int window, const CKey &key)
+{
+  map<int, buttonMap>::const_iterator it = m_translatorMap.find(window);
+  if (it == m_translatorMap.end())
+    return false;
+
+  uint32_t code = key.GetButtonCode();
+  code |= CKey::MODIFIER_LONG;
+  buttonMap::const_iterator it2 = (*it).second.find(code);
+
+  if (it2 != (*it).second.end())
+    return true;
+
+#ifdef TARGET_POSIX
+  // Some buttoncodes changed in Hardy
+  if ((code & KEY_VKEY) == KEY_VKEY && (code & 0x0F00))
+  {
+    code &= ~0x0F00;
+    it2 = (*it).second.find(code);
+    if (it2 != (*it).second.end())
+      return true;
+  }
+#endif
+  if (window > -1)
+    return IsPossibleLongpress(GetFallbackWindow(window), key);
+
+  return false;
+}
+
 int CButtonTranslator::GetActionCode(int window, const CKey &key, std::string &strAction) const
 {
   uint32_t code = key.GetButtonCode();
@@ -1204,6 +1233,11 @@ int CButtonTranslator::GetActionCode(int window, const CKey &key, std::string &s
     return 0;
   buttonMap::const_iterator it2 = (*it).second.find(code);
   int action = 0;
+  if (it2 == (*it).second.end() && code & CKey::MODIFIER_LONG) // If long action not found, try short one
+  {
+    code &= ~CKey::MODIFIER_LONG;
+    it2 = (*it).second.find(code);
+  }
   if (it2 != (*it).second.end())
   {
     action = (*it2).second.id;
@@ -1598,6 +1632,8 @@ uint32_t CButtonTranslator::TranslateKeyboardButton(TiXmlElement *pButton)
         button_id |= CKey::MODIFIER_SUPER;
       else if (substr == "meta" || substr == "cmd")
         button_id |= CKey::MODIFIER_META;
+      else if (substr == "long")
+        button_id |= CKey::MODIFIER_LONG;
       else
         CLog::Log(LOGERROR, "Keyboard Translator: Unknown key modifier %s in %s", substr.c_str(), strMod.c_str());
      }

--- a/xbmc/input/ButtonTranslator.h
+++ b/xbmc/input/ButtonTranslator.h
@@ -78,6 +78,8 @@ public:
   static void GetActions(std::vector<std::string> &actionList);
   static void GetWindows(std::vector<std::string> &windowList);
 
+  bool IsPossibleLongpress(int window, const CKey &key);
+
   /*! \brief Obtain the action configured for a given window and key
    \param window the window id
    \param key the key to query the action for

--- a/xbmc/input/ButtonTranslator.h
+++ b/xbmc/input/ButtonTranslator.h
@@ -78,7 +78,12 @@ public:
   static void GetActions(std::vector<std::string> &actionList);
   static void GetWindows(std::vector<std::string> &windowList);
 
-  bool IsPossibleLongpress(int window, const CKey &key);
+  /*! \brief Finds out if a longpress mapping exists for this key
+   \param window id of the current window
+   \param key to search a mapping for
+   \return true if a longpress mapping exists
+   */
+  bool HasLonpressMapping(int window, const CKey &key);
 
   /*! \brief Obtain the action configured for a given window and key
    \param window the window id

--- a/xbmc/input/InputManager.cpp
+++ b/xbmc/input/InputManager.cpp
@@ -458,11 +458,30 @@ bool CInputManager::OnEvent(XBMC_Event& newEvent)
   switch (newEvent.type)
   {
   case XBMC_KEYDOWN:
+  {
     m_Keyboard.ProcessKeyDown(newEvent.key.keysym);
-    OnKey(m_Keyboard.TranslateKey(newEvent.key.keysym));
+    CKey key = m_Keyboard.TranslateKey(newEvent.key.keysym);
+    if (!CButtonTranslator::GetInstance().IsPossibleLongpress(g_windowManager.GetActiveWindowID(), key))
+    {
+      m_LastKey.Reset();
+      OnKey(key);
+    }
+    else
+    {
+      if (key.GetButtonCode() != m_LastKey.GetButtonCode() && key.GetButtonCode() & CKey::MODIFIER_LONG)
+      {
+        m_LastKey = key;  // OnKey is reentrant; need to do this before entering
+        OnKey(key);
+      }
+      m_LastKey = key;
+    }
     break;
+  }
   case XBMC_KEYUP:
     m_Keyboard.ProcessKeyUp();
+    if (m_LastKey.GetButtonCode() != KEY_INVALID && !(m_LastKey.GetButtonCode() & CKey::MODIFIER_LONG))
+      OnKey(m_LastKey);
+    m_LastKey.Reset();
     break;
   case XBMC_MOUSEBUTTONDOWN:
   case XBMC_MOUSEBUTTONUP:

--- a/xbmc/input/InputManager.cpp
+++ b/xbmc/input/InputManager.cpp
@@ -461,7 +461,7 @@ bool CInputManager::OnEvent(XBMC_Event& newEvent)
   {
     m_Keyboard.ProcessKeyDown(newEvent.key.keysym);
     CKey key = m_Keyboard.TranslateKey(newEvent.key.keysym);
-    if (!CButtonTranslator::GetInstance().IsPossibleLongpress(g_windowManager.GetActiveWindowID(), key))
+    if (!CButtonTranslator::GetInstance().HasLonpressMapping(g_windowManager.GetActiveWindowID(), key))
     {
       m_LastKey.Reset();
       OnKey(key);

--- a/xbmc/input/InputManager.h
+++ b/xbmc/input/InputManager.h
@@ -255,6 +255,7 @@ private:
 
   CKeyboardStat m_Keyboard;
   CMouseStat m_Mouse;
+  CKey m_LastKey;
 
 #if defined(HAS_LIRC) || defined(HAS_IRSERVERSUITE)
   CRemoteControl m_RemoteControl;

--- a/xbmc/input/Key.h
+++ b/xbmc/input/Key.h
@@ -513,6 +513,7 @@ public:
   CKey(uint32_t buttonCode, unsigned int held);
   CKey(uint8_t vkey, wchar_t unicode, char ascii, uint32_t modifiers, unsigned int held);
   CKey(const CKey& key);
+  void Reset();
 
   virtual ~CKey(void);
   CKey& operator=(const CKey& key);
@@ -542,12 +543,11 @@ public:
     MODIFIER_ALT   = 0x00040000,
     MODIFIER_RALT  = 0x00080000,
     MODIFIER_SUPER = 0x00100000,
-    MODIFIER_META  = 0X00200000
+    MODIFIER_META  = 0X00200000,
+    MODIFIER_LONG  = 0X01000000
   };
 
 private:
-  void Reset();
-
   uint32_t m_buttonCode;
   uint8_t  m_vkey;
   wchar_t  m_unicode;

--- a/xbmc/input/KeyboardStat.cpp
+++ b/xbmc/input/KeyboardStat.cpp
@@ -32,6 +32,8 @@
 #include "threads/SystemClock.h"
 #include "utils/log.h"
 
+#define HOLD_THRESHOLD 250
+
 using namespace std;
 using namespace PERIPHERALS;
 
@@ -159,6 +161,8 @@ CKey CKeyboardStat::TranslateKey(XBMC_keysym& keysym) const
   if (keysym == m_lastKeysym)
   {
     held = XbmcThreads::SystemClockMillis() - m_lastKeyTime;
+    if (held > HOLD_THRESHOLD)
+      modifiers |= CKey::MODIFIER_LONG;
   }
 
   // For all shift-X keys except shift-A to shift-Z and shift-F1 to shift-F24 the


### PR DESCRIPTION
This adds the possibility to map long presses to keyboard keys.
In the current state, only interesting for droid, really, as all remotes are keyboard there

/cc @Montellese @anssih @MartijnKaijser 
