### PR TITLE
[remote] map pageplus/pageminus to increase/decreasePAR

### DIFF
--- a/system/keymaps/remote.xml
+++ b/system/keymaps/remote.xml
@@ -203,8 +203,8 @@
       <language>AudioNextLanguage</language>
       <playlist>Playlist</playlist>
       <hash>AudioNextLanguage</hash>
-      <pageplus>SkipNext</pageplus>
-      <pageminus>SkipPrevious</pageminus>
+      <pageplus>IncreasePAR</pageplus>
+      <pageminus>DecreasePAR</pageminus>
     </remote>
   </FullscreenVideo>
   <VideoTimeSeek>


### PR DESCRIPTION
Being able to increase / decrease PAR (pixel aspect ratio) in fullscreen playback is more useful when playing a video than skipping chapters with these keys, since most remote controls already have dedicated buttons to skip chapters and ones that dont this wouldn't affect them as they dont even have such keys.

This is very helpful to help get rid or tweak any black bars on the fly from certain aspect ratio videos.
