### PR TITLE
[pvr] sort equal client channel numbers by name if not sub-channels

### DIFF
--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -341,7 +341,12 @@ struct sortByClientChannelNumber
   bool operator()(const PVRChannelGroupMember &channel1, const PVRChannelGroupMember &channel2) const
   {
     if (channel1.channel->ClientChannelNumber() == channel2.channel->ClientChannelNumber())
-      return channel1.channel->ClientSubChannelNumber() < channel2.channel->ClientSubChannelNumber();
+    {
+      if (channel1.channel->ClientSubChannelNumber() > 0 || channel2.channel->ClientSubChannelNumber() > 0)
+        return channel1.channel->ClientSubChannelNumber() < channel2.channel->ClientSubChannelNumber();
+      else
+        return channel1.channel->ChannelName() < channel2.channel->ChannelName();
+    }
     return channel1.channel->ClientChannelNumber() < channel2.channel->ClientChannelNumber();
   }
 };


### PR DESCRIPTION
If client channel numbers are used for ordering the channels and you have more than one backend, it's possible that you end up with different channels holding the same client channel number. In that case the channels are sorted by its sub channel number which is zero for normal channels. To have a nicely sorted list this changes extends the comparator to compare the names of the channels in case there is no sub-channel number.

@Jalle19 @opdenkamp mind taking a look
