### PR TITLE
[pvr] fix: delete of empty group with an invalid id ends up in deleting the wrong group

### DIFF
--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -544,7 +544,7 @@ bool CPVRChannelGroups::DeleteGroup(const CPVRChannelGroup &group)
     CSingleLock lock(m_critSection);
     for (std::vector<CPVRChannelGroupPtr>::iterator it = m_groups.begin(); !bFound && it != m_groups.end();)
     {
-      if ((*it)->GroupID() == group.GroupID())
+      if (*(*it) == group || (group.GroupID() > 0 && (*it)->GroupID() == group.GroupID()))
       {
         // update the selected group in the gui if it's deleted
         CPVRChannelGroupPtr selectedGroup = GetSelectedGroup();


### PR DESCRIPTION
If your backend holds an empty group and you import the channel groups for the first time (after a clear of the TV database or with a new setup) each of the groups won't hold a valid id because they are new to our database. As we delete empty groups after loading the related channels and these groups don't hold a valid id (-1) this will result in deleting the wrong group e.g. the first group with id -1 which is the internal "All channels" group. After that everything is screwed up.

This will add a check for a valid group id (> 0) to `CPVRChannelGroups::DeleteGroup` to prevent deleting the wrong group.

@Jalle19 @opdenkamp mind taking a look
