### PR TITLE
support saving skin settings as addon data instead of in guisettings.xml

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -85,6 +85,7 @@
 #include "settings/AdvancedSettings.h"
 #include "settings/DisplaySettings.h"
 #include "settings/MediaSettings.h"
+#include "settings/SkinSettings.h"
 #include "guilib/LocalizeStrings.h"
 #include "utils/CPUInfo.h"
 #include "utils/SeekHandler.h"
@@ -1614,7 +1615,13 @@ bool CApplication::LoadSkin(const SkinPtr& skin)
   if (!skin)
     return false;
 
+  // start/prepare the skin
   skin->Start();
+
+  // migrate any skin-specific settings that are still stored in guisettings.xml
+  CSkinSettings::Get().MigrateSettings(skin);
+
+  // check if the skin has been properly loaded and if it has a Home.xml
   if (!skin->HasSkinFile("Home.xml"))
     return false;
 
@@ -1740,6 +1747,9 @@ bool CApplication::LoadSkin(const SkinPtr& skin)
 void CApplication::UnloadSkin(bool forReload /* = false */)
 {
   CLog::Log(LOGINFO, "Unloading old skin %s...", forReload ? "for reload " : "");
+
+  if (g_SkinInfo != nullptr)
+    g_SkinInfo->SaveSettings();
 
   g_audioManager.Enable(false);
 

--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -498,9 +498,14 @@ bool CAddon::LoadUserSettings()
   return m_userSettingsLoaded;
 }
 
+bool CAddon::HasSettingsToSave() const
+{
+  return !m_settings.empty();
+}
+
 void CAddon::SaveSettings(void)
 {
-  if (m_settings.empty())
+  if (!HasSettingsToSave())
     return; // no settings to save
 
   // break down the path into directories

--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -222,6 +222,11 @@ protected:
    */
   virtual bool LoadUserSettings();
 
+  /* \brief Whether there are settings to be saved
+   \sa SaveSettings
+   */
+  virtual bool HasSettingsToSave() const;
+
   /*! \brief Parse settings from an XML document
    \param doc XML document to parse for settings
    \param loadDefaults if true, the default attribute is used and settings are reset prior to parsing, else the value attribute is used.

--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -114,13 +114,13 @@ public:
    \return true if the addon has settings, false otherwise
    \sa LoadSettings, LoadUserSettings, SaveSettings, HasUserSettings, GetSetting, UpdateSetting
    */
-  bool HasSettings();
+  virtual bool HasSettings();
 
   /*! \brief Check whether the user has configured this addon or not
    \return true if previously saved settings are found, false otherwise
    \sa LoadSettings, LoadUserSettings, SaveSettings, HasSettings, GetSetting, UpdateSetting
    */
-  bool HasUserSettings();
+  virtual bool HasUserSettings();
 
   /*! \brief Save any user configured settings
    \sa LoadSettings, LoadUserSettings, HasSettings, HasUserSettings, GetSetting, UpdateSetting
@@ -132,7 +132,7 @@ public:
    \param value the value that the setting should take
    \sa LoadSettings, LoadUserSettings, SaveSettings, HasSettings, HasUserSettings, GetSetting
    */
-  void UpdateSetting(const std::string& key, const std::string& value);
+  virtual void UpdateSetting(const std::string& key, const std::string& value);
 
   /*! \brief Retrieve a particular settings value
    If a previously configured user setting is available, we return it's value, else we return the default (if available)
@@ -220,7 +220,7 @@ protected:
    \return true if user settings exist, false otherwise
    \sa LoadSettings, SaveSettings, HasSettings, HasUserSettings, GetSetting, UpdateSetting
    */
-  bool LoadUserSettings();
+  virtual bool LoadUserSettings();
 
   /*! \brief Parse settings from an XML document
    \param doc XML document to parse for settings
@@ -228,13 +228,13 @@ protected:
    \return true if settings are loaded, false otherwise
    \sa SettingsToXML
    */
-  bool SettingsFromXML(const CXBMCTinyXML &doc, bool loadDefaults = false);
+  virtual bool SettingsFromXML(const CXBMCTinyXML &doc, bool loadDefaults = false);
 
   /*! \brief Parse settings into an XML document
    \param doc XML document to receive the settings
    \sa SettingsFromXML
    */
-  void SettingsToXML(CXBMCTinyXML &doc) const;
+  virtual void SettingsToXML(CXBMCTinyXML &doc) const;
 
   CXBMCTinyXML      m_addonXmlDoc;
   std::string       m_strLibName;

--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -230,7 +230,7 @@ protected:
    */
   virtual bool SettingsFromXML(const CXBMCTinyXML &doc, bool loadDefaults = false);
 
-  /*! \brief Parse settings into an XML document
+  /*! \brief Write settings into an XML document
    \param doc XML document to receive the settings
    \sa SettingsFromXML
    */

--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -20,22 +20,28 @@
 
 #include "Skin.h"
 #include "AddonManager.h"
+#include "ApplicationMessenger.h"
 #include "Util.h"
 #include "dialogs/GUIDialogKaiToast.h"
 #include "dialogs/GUIDialogYesNo.h"
+// fallback for new skin resolution code
+#include "filesystem/Directory.h"
 #include "filesystem/File.h"
 #include "filesystem/SpecialProtocol.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/WindowIDs.h"
 #include "settings/Settings.h"
 #include "settings/lib/Setting.h"
-#include "utils/URIUtils.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
-#include "ApplicationMessenger.h"
+#include "utils/URIUtils.h"
+#include "utils/XMLUtils.h"
 
-// fallback for new skin resolution code
-#include "filesystem/Directory.h"
+#define XML_SETTINGS      "settings"
+#define XML_SETTING       "setting"
+#define XML_ATTR_TYPE     "type"
+#define XML_ATTR_NAME     "name"
+#define XML_ATTR_ID       "id"
 
 using namespace std;
 using namespace XFILE;
@@ -44,6 +50,85 @@ std::shared_ptr<ADDON::CSkinInfo> g_SkinInfo;
 
 namespace ADDON
 {
+
+bool CSkinSetting::Serialize(TiXmlElement* parent) const
+{
+  if (parent == nullptr)
+    return false;
+
+  TiXmlElement setting(XML_SETTING);
+  setting.SetAttribute(XML_ATTR_ID, name.c_str());
+  setting.SetAttribute(XML_ATTR_TYPE, GetType());
+
+  if (!SerializeSetting(&setting))
+    return false;
+
+  parent->InsertEndChild(setting);
+
+  return true;
+}
+
+bool CSkinSetting::Deserialize(const TiXmlElement* element)
+{
+  if (element == nullptr)
+    return false;
+
+  name = XMLUtils::GetAttribute(element, XML_ATTR_ID);
+
+  // backwards compatibility for guisettings.xml
+  if (name.empty())
+    name = XMLUtils::GetAttribute(element, XML_ATTR_NAME);
+
+  return true;
+}
+
+bool CSkinSettingString::Deserialize(const TiXmlElement* element)
+{
+  value.clear();
+
+  if (!CSkinSetting::Deserialize(element))
+    return false;
+
+  if (element->FirstChild() != nullptr)
+    value = element->FirstChild()->Value();
+
+  return true;
+}
+
+bool CSkinSettingString::SerializeSetting(TiXmlElement* element) const
+{
+  if (element == nullptr)
+    return false;
+
+  TiXmlText xmlValue(value);
+  element->InsertEndChild(xmlValue);
+
+  return true;
+}
+
+bool CSkinSettingBool::Deserialize(const TiXmlElement* element)
+{
+  value = false;
+
+  if (!CSkinSetting::Deserialize(element))
+    return false;
+
+  if (element->FirstChild() != nullptr)
+    value = StringUtils::EqualsNoCase(element->FirstChild()->ValueStr(), "true");
+
+  return true;
+}
+
+bool CSkinSettingBool::SerializeSetting(TiXmlElement* element) const
+{
+  if (element == nullptr)
+    return false;
+
+  TiXmlText xmlValue(value ? "true" : "false");
+  element->InsertEndChild(xmlValue);
+
+  return true;
+}
 
 CSkinInfo::CSkinInfo(const AddonProps &props, const RESOLUTION_INFO &resolution)
   : CAddon(props), m_defaultRes(resolution), m_version(""), m_effectsSlowDown(1.f), m_debugging(false)
@@ -124,6 +209,9 @@ struct closestRes
 
 void CSkinInfo::Start()
 {
+  if (!LoadUserSettings())
+    CLog::Log(LOGWARNING, "CSkinInfo: failed to load skin settings");
+
   if (!m_resolutions.size())
   { // try falling back to whatever resolutions exist in the directory
     CFileItemList items;
@@ -484,6 +572,221 @@ void CSkinInfo::SettingOptionsStartupWindowsFiller(const CSetting *setting, std:
   // if the current value hasn't been properly set, set it to the first window in the list
   if (current < 0)
     current = list[0].second;
+}
+
+int CSkinInfo::TranslateString(const string &setting)
+{
+  // run through and see if we have this setting
+  for (const auto& it : m_strings)
+  {
+    if (StringUtils::EqualsNoCase(setting, it.second->name))
+      return it.first;
+  }
+
+  // didn't find it - insert it
+  CSkinSettingStringPtr skinString(new CSkinSettingString());
+  skinString->name = setting;
+
+  int number = m_bools.size() + m_strings.size();
+  m_strings.insert(std::pair<int, CSkinSettingStringPtr>(number, skinString));
+
+  return number;
+}
+
+const string& CSkinInfo::GetString(int setting) const
+{
+  const auto& it = m_strings.find(setting);
+  if (it != m_strings.end())
+    return it->second->value;
+
+  return StringUtils::Empty;
+}
+
+void CSkinInfo::SetString(int setting, const string &label)
+{
+  auto&& it = m_strings.find(setting);
+  if (it != m_strings.end())
+  {
+    it->second->value = label;
+    return;
+  }
+
+  CLog::Log(LOGFATAL, "%s: unknown setting (%d) requested", __FUNCTION__, setting);
+  assert(false);
+}
+
+int CSkinInfo::TranslateBool(const string &setting)
+{
+  // run through and see if we have this setting
+  for (const auto& it : m_bools)
+  {
+    if (StringUtils::EqualsNoCase(setting, it.second->name))
+      return it.first;
+  }
+
+  // didn't find it - insert it
+  CSkinSettingBoolPtr skinBool(new CSkinSettingBool());
+  skinBool->name = setting;
+
+  int number = m_bools.size() + m_strings.size();
+  m_bools.insert(std::pair<int, CSkinSettingBoolPtr>(number, skinBool));
+
+  return number;
+}
+
+bool CSkinInfo::GetBool(int setting) const
+{
+  const auto& it = m_bools.find(setting);
+  if (it != m_bools.end())
+    return it->second->value;
+
+  // default is to return false
+  return false;
+}
+
+void CSkinInfo::SetBool(int setting, bool set)
+{
+  auto&& it = m_bools.find(setting);
+  if (it != m_bools.end())
+  {
+    it->second->value = set;
+    return;
+  }
+
+  CLog::Log(LOGFATAL, "%s: unknown setting (%d) requested", __FUNCTION__, setting);
+  assert(false);
+}
+
+void CSkinInfo::Reset(const string &setting)
+{
+  // run through and see if we have this setting as a string
+  for (auto& it : m_strings)
+  {
+    if (StringUtils::EqualsNoCase(setting, it.second->name))
+    {
+      it.second->value.clear();
+      return;
+    }
+  }
+
+  // and now check for the skin bool
+  for (auto& it : m_bools)
+  {
+    if (StringUtils::EqualsNoCase(setting, it.second->name))
+    {
+      it.second->value = false;
+      return;
+    }
+  }
+}
+
+void CSkinInfo::Reset()
+{
+  // clear all the settings and strings from this skin.
+  for (auto& it : m_bools)
+    it.second->value = false;
+
+  for (auto& it : m_strings)
+    it.second->value.clear();
+}
+
+std::set<CSkinSettingPtr> CSkinInfo::ParseSettings(const TiXmlElement* rootElement)
+{
+  std::set<CSkinSettingPtr> settings;
+  if (rootElement == nullptr)
+    return settings;
+
+  const TiXmlElement *settingElement = rootElement->FirstChildElement(XML_SETTING);
+  while (settingElement != nullptr)
+  {
+    CSkinSettingPtr setting = ParseSetting(settingElement);
+    if (setting != nullptr)
+      settings.insert(setting);
+
+    settingElement = settingElement->NextSiblingElement(XML_SETTING);
+  }
+
+  return settings;
+}
+
+CSkinSettingPtr CSkinInfo::ParseSetting(const TiXmlElement* element)
+{
+  if (element == nullptr)
+    return CSkinSettingPtr();
+
+  std::string settingType = XMLUtils::GetAttribute(element, XML_ATTR_TYPE);
+  CSkinSettingPtr setting;
+  if (settingType == "string")
+    setting = CSkinSettingPtr(new CSkinSettingString());
+  else if (settingType == "bool")
+    setting = CSkinSettingPtr(new CSkinSettingBool());
+  else
+    return CSkinSettingPtr();
+
+  if (setting == nullptr)
+    return CSkinSettingPtr();
+
+  if (!setting->Deserialize(element))
+    return CSkinSettingPtr();
+
+  return setting;
+}
+
+bool CSkinInfo::HasSettingsToSave() const
+{
+  return !m_strings.empty() || !m_bools.empty();
+}
+
+bool CSkinInfo::SettingsFromXML(const CXBMCTinyXML &doc, bool loadDefaults /* = false */)
+{
+  const TiXmlElement *rootElement = doc.RootElement();
+  if (rootElement == nullptr || rootElement->ValueStr().compare(XML_SETTINGS) != 0)
+  {
+    CLog::Log(LOGWARNING, "CSkinInfo: no <skinsettings> tag found");
+    return false;
+  }
+
+  m_strings.clear();
+  m_bools.clear();
+
+  int number = 0;
+  std::set<CSkinSettingPtr> settings = ParseSettings(rootElement);
+  for (const auto& setting : settings)
+  {
+    if (setting->GetType() == "string")
+      m_strings.insert(std::pair<int, CSkinSettingStringPtr>(number++, std::dynamic_pointer_cast<CSkinSettingString>(setting)));
+    else if (setting->GetType() == "bool")
+      m_bools.insert(std::pair<int, CSkinSettingBoolPtr>(number++, std::dynamic_pointer_cast<CSkinSettingBool>(setting)));
+    else
+      CLog::Log(LOGWARNING, "CSkinInfo: ignoring setting of unknwon type \"%s\"", setting->GetType().c_str());
+  }
+
+  return true;
+}
+
+void CSkinInfo::SettingsToXML(CXBMCTinyXML &doc) const
+{
+  // add the <skinsettings> tag
+  TiXmlElement rootElement(XML_SETTINGS);
+  TiXmlNode *settingsNode = doc.InsertEndChild(rootElement);
+  if (settingsNode == NULL)
+  {
+    CLog::Log(LOGWARNING, "CSkinInfo: could not create <skinsettings> tag");
+    return;
+  }
+
+  TiXmlElement* settingsElement = settingsNode->ToElement();
+  for (const auto& it : m_bools)
+  {
+    if (!it.second->Serialize(settingsElement))
+      CLog::Log(LOGWARNING, "CSkinInfo: failed to save string setting \"%s\"", it.second->name.c_str());
+  }
+
+  for (const auto& it : m_strings)
+  {
+    if (!it.second->Serialize(settingsElement))
+      CLog::Log(LOGWARNING, "CSkinInfo: failed to save bool setting \"%s\"", it.second->name.c_str());
+  }
 }
 
 } /*namespace ADDON*/

--- a/xbmc/addons/Skin.h
+++ b/xbmc/addons/Skin.h
@@ -20,17 +20,76 @@
  *
  */
 
+#include <map>
+#include <set>
 #include <vector>
 
-#include "Addon.h"
+#include "addons/Addon.h"
 #include "guilib/GraphicContext.h" // needed for the RESOLUTION members
 #include "guilib/GUIIncludes.h"    // needed for the GUIInclude member
+
 #define CREDIT_LINE_LENGTH 50
 
 class CSetting;
 
 namespace ADDON
 {
+
+class CSkinSetting
+{
+public:
+  virtual ~CSkinSetting() { }
+
+  bool Serialize(TiXmlElement* parent) const;
+
+  virtual std::string GetType() const = 0;
+
+  virtual bool Deserialize(const TiXmlElement* element);
+
+  std::string name;
+
+protected:
+  virtual bool SerializeSetting(TiXmlElement* element) const = 0;
+};
+
+typedef std::shared_ptr<CSkinSetting> CSkinSettingPtr;
+
+class CSkinSettingString : public CSkinSetting
+{
+public:
+  virtual ~CSkinSettingString() { }
+
+  virtual std::string GetType() const { return "string"; }
+
+  virtual bool Deserialize(const TiXmlElement* element);
+
+  std::string value;
+
+protected:
+  virtual bool SerializeSetting(TiXmlElement* element) const;
+};
+
+typedef std::shared_ptr<CSkinSettingString> CSkinSettingStringPtr;
+
+class CSkinSettingBool : public CSkinSetting
+{
+public:
+  CSkinSettingBool()
+    : value(false)
+  { }
+  virtual ~CSkinSettingBool() { }
+
+  virtual std::string GetType() const { return "bool"; }
+
+  virtual bool Deserialize(const TiXmlElement* element);
+
+  bool value;
+
+protected:
+  virtual bool SerializeSetting(TiXmlElement* element) const;
+};
+
+typedef std::shared_ptr<CSkinSettingBool> CSkinSettingBoolPtr;
 
 class CSkinInfo : public CAddon
 {
@@ -118,6 +177,24 @@ public:
   static void SettingOptionsSkinThemesFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data);
   static void SettingOptionsStartupWindowsFiller(const CSetting *setting, std::vector< std::pair<std::string, int> > &list, int &current, void *data);
 
+  /*! \brief Don't handle skin settings like normal addon settings
+   */
+  virtual bool HasSettings() { return false; }
+  virtual bool HasUserSettings() { return false; }
+
+  int TranslateString(const std::string &setting);
+  const std::string& GetString(int setting) const;
+  void SetString(int setting, const std::string &label);
+
+  int TranslateBool(const std::string &setting);
+  bool GetBool(int setting) const;
+  void SetBool(int setting, bool set);
+
+  void Reset(const std::string &setting);
+  void Reset();
+
+  static std::set<CSkinSettingPtr> ParseSettings(const TiXmlElement* rootElement);
+
   virtual void OnPreInstall();
   virtual void OnPostInstall(bool update, bool modal);
 protected:
@@ -137,6 +214,13 @@ protected:
 
   bool LoadStartupWindows(const cp_extension_t *ext);
 
+  static CSkinSettingPtr ParseSetting(const TiXmlElement* element);
+
+  virtual bool HasSettingsDefinition() const { return false; }
+  virtual bool HasSettingsToSave() const;
+  virtual bool SettingsFromXML(const CXBMCTinyXML &doc, bool loadDefaults = false);
+  virtual void SettingsToXML(CXBMCTinyXML &doc) const;
+
   RESOLUTION_INFO m_defaultRes;
   std::vector<RESOLUTION_INFO> m_resolutions;
 
@@ -148,6 +232,10 @@ protected:
 
   std::vector<CStartupWindow> m_startupWindows;
   bool m_debugging;
+
+private:
+  std::map<int, CSkinSettingStringPtr> m_strings;
+  std::map<int, CSkinSettingBoolPtr> m_bools;
 };
 
 } /*namespace ADDON*/

--- a/xbmc/settings/SkinSettings.cpp
+++ b/xbmc/settings/SkinSettings.cpp
@@ -18,21 +18,16 @@
  *
  */
 
-#include <string.h>
-
 #include "SkinSettings.h"
 #include "GUIInfoManager.h"
+#include "addons/Skin.h"
 #include "settings/Settings.h"
 #include "threads/SingleLock.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
 #include "utils/XBMCTinyXML.h"
-#include "utils/XMLUtils.h"
 
 #define XML_SKINSETTINGS  "skinsettings"
-#define XML_SETTING       "setting"
-#define XML_ATTR_TYPE     "type"
-#define XML_ATTR_NAME     "name"
 
 using namespace std;
 
@@ -52,219 +47,89 @@ CSkinSettings& CSkinSettings::Get()
 
 int CSkinSettings::TranslateString(const string &setting)
 {
-  std::string settingName = StringUtils::Format("%s.%s", GetCurrentSkin().c_str(), setting.c_str());
-
-  CSingleLock lock(m_critical);
-  // run through and see if we have this setting
-  for (map<int, CSkinString>::const_iterator it = m_strings.begin(); it != m_strings.end(); ++it)
-  {
-    if (StringUtils::EqualsNoCase(settingName, it->second.name))
-      return it->first;
-  }
-
-  // didn't find it - insert it
-  CSkinString skinString;
-  skinString.name = settingName;
-
-  int number = m_bools.size() + m_strings.size();
-  m_strings.insert(pair<int, CSkinString>(number, skinString));
-  return number;
+  return g_SkinInfo->TranslateString(setting);
 }
 
 const string& CSkinSettings::GetString(int setting) const
 {
-  CSingleLock lock(m_critical);
-  map<int, CSkinString>::const_iterator it = m_strings.find(setting);
-  if (it != m_strings.end())
-    return it->second.value;
-
-  return StringUtils::Empty;
+  return g_SkinInfo->GetString(setting);
 }
 
 void CSkinSettings::SetString(int setting, const string &label)
 {
-  CSingleLock lock(m_critical);
-  map<int, CSkinString>::iterator it = m_strings.find(setting);
-  if (it != m_strings.end())
-  {
-    it->second.value = label;
-    return;
-  }
-
-  assert(false);
-  CLog::Log(LOGFATAL, "%s: unknown setting (%d) requested", __FUNCTION__, setting);
+  g_SkinInfo->SetString(setting, label);
 }
 
 int CSkinSettings::TranslateBool(const string &setting)
 {
-  string settingName = StringUtils::Format("%s.%s", GetCurrentSkin().c_str(), setting.c_str());
-
-  CSingleLock lock(m_critical);
-  // run through and see if we have this setting
-  for (map<int, CSkinBool>::const_iterator it = m_bools.begin(); it != m_bools.end(); ++it)
-  {
-    if (StringUtils::EqualsNoCase(settingName, it->second.name))
-      return it->first;
-  }
-
-  // didn't find it - insert it
-  CSkinBool skinBool;
-  skinBool.name = settingName;
-  skinBool.value = false;
-
-  int number = m_bools.size() + m_strings.size();
-  m_bools.insert(pair<int, CSkinBool>(number, skinBool));
-  return number;
+  return g_SkinInfo->TranslateBool(setting);
 }
 
 bool CSkinSettings::GetBool(int setting) const
 {
-  CSingleLock lock(m_critical);
-  map<int, CSkinBool>::const_iterator it = m_bools.find(setting);
-  if (it != m_bools.end())
-    return it->second.value;
-
-  // default is to return false
-  return false;
+  return g_SkinInfo->GetBool(setting);
 }
 
 void CSkinSettings::SetBool(int setting, bool set)
 {
-  CSingleLock lock(m_critical);
-  map<int, CSkinBool>::iterator it = m_bools.find(setting);
-  if (it != m_bools.end())
-  {
-    it->second.value = set;
-    return;
-  }
-
-  assert(false);
-  CLog::Log(LOGFATAL,"%s: unknown setting (%d) requested", __FUNCTION__, setting);
+  g_SkinInfo->SetBool(setting, set);
 }
 
 void CSkinSettings::Reset(const string &setting)
 {
-  string settingName = StringUtils::Format("%s.%s", GetCurrentSkin().c_str(), setting.c_str());
-
-  CSingleLock lock(m_critical);
-  // run through and see if we have this setting as a string
-  for (map<int, CSkinString>::iterator it = m_strings.begin(); it != m_strings.end(); ++it)
-  {
-    if (StringUtils::EqualsNoCase(settingName, it->second.name))
-    {
-      it->second.value.clear();
-      return;
-    }
-  }
-
-  // and now check for the skin bool
-  for (map<int, CSkinBool>::iterator it = m_bools.begin(); it != m_bools.end(); ++it)
-  {
-    if (StringUtils::EqualsNoCase(settingName, it->second.name))
-    {
-      it->second.value = false;
-      return;
-    }
-  }
+  g_SkinInfo->Reset(setting);
 }
 
 void CSkinSettings::Reset()
 {
-  string currentSkin = GetCurrentSkin() + ".";
-
-  CSingleLock lock(m_critical);
-  // clear all the settings and strings from this skin.
-  for (map<int, CSkinBool>::iterator it = m_bools.begin(); it != m_bools.end(); ++it)
-  {
-    if (StringUtils::StartsWithNoCase(it->second.name, currentSkin))
-      it->second.value = false;
-  }
-
-  for (map<int, CSkinString>::iterator it = m_strings.begin(); it != m_strings.end(); ++it)
-  {
-    if (StringUtils::StartsWithNoCase(it->second.name, currentSkin))
-      it->second.value.clear();
-  }
+  g_SkinInfo->Reset();
 
   g_infoManager.ResetCache();
 }
 
 bool CSkinSettings::Load(const TiXmlNode *settings)
 {
-  if (settings == NULL)
+  if (settings == nullptr)
     return false;
 
-  const TiXmlElement *pElement = settings->FirstChildElement(XML_SKINSETTINGS);
-  if (pElement == NULL)
+  const TiXmlElement *rootElement = settings->FirstChildElement(XML_SKINSETTINGS);
+  if (rootElement == nullptr)
   {
     CLog::Log(LOGWARNING, "CSkinSettings: no <skinsettings> tag found");
     return false;
   }
 
   CSingleLock lock(m_critical);
-  m_strings.clear();
-  m_bools.clear();
-
-  int number = 0;
-  const TiXmlElement *pChild = pElement->FirstChildElement(XML_SETTING);
-  while (pChild)
-  {
-    std::string settingName = XMLUtils::GetAttribute(pChild, XML_ATTR_NAME);
-    std::string settingType = XMLUtils::GetAttribute(pChild, XML_ATTR_TYPE);
-    if (settingType == "string")
-    { // string setting
-      CSkinString string;
-      string.name = settingName;
-      string.value = pChild->FirstChild() ? pChild->FirstChild()->Value() : "";
-      m_strings.insert(pair<int, CSkinString>(number++, string));
-    }
-    else
-    { // bool setting
-      CSkinBool setting;
-      setting.name = settingName;
-      setting.value = pChild->FirstChild() ? StringUtils::EqualsNoCase(pChild->FirstChild()->Value(), "true") : false;
-      m_bools.insert(pair<int, CSkinBool>(number++, setting));
-    }
-    pChild = pChild->NextSiblingElement(XML_SETTING);
-  }
+  m_settings.clear();
+  m_settings = ADDON::CSkinInfo::ParseSettings(rootElement);
 
   return true;
 }
 
 bool CSkinSettings::Save(TiXmlNode *settings) const
 {
-  if (settings == NULL)
+  if (settings == nullptr)
     return false;
 
   CSingleLock lock(m_critical);
+
+  if (m_settings.empty())
+    return true;
+
   // add the <skinsettings> tag
   TiXmlElement xmlSettingsElement(XML_SKINSETTINGS);
-  TiXmlNode *pSettingsNode = settings->InsertEndChild(xmlSettingsElement);
-  if (pSettingsNode == NULL)
+  TiXmlNode* settingsNode = settings->InsertEndChild(xmlSettingsElement);
+  if (settingsNode == nullptr)
   {
     CLog::Log(LOGWARNING, "CSkinSettings: could not create <skinsettings> tag");
     return false;
   }
 
-  for (map<int, CSkinBool>::const_iterator it = m_bools.begin(); it != m_bools.end(); ++it)
+  TiXmlElement* settingsElement = settingsNode->ToElement();
+  for (const auto& setting : m_settings)
   {
-    // Add a <setting type="bool" name="name">true/false</setting>
-    TiXmlElement xmlSetting(XML_SETTING);
-    xmlSetting.SetAttribute(XML_ATTR_TYPE, "bool");
-    xmlSetting.SetAttribute(XML_ATTR_NAME, (*it).second.name.c_str());
-    TiXmlText xmlBool((*it).second.value ? "true" : "false");
-    xmlSetting.InsertEndChild(xmlBool);
-    pSettingsNode->InsertEndChild(xmlSetting);
-  }
-  for (map<int, CSkinString>::const_iterator it = m_strings.begin(); it != m_strings.end(); ++it)
-  {
-    // Add a <setting type="string" name="name">string</setting>
-    TiXmlElement xmlSetting(XML_SETTING);
-    xmlSetting.SetAttribute(XML_ATTR_TYPE, "string");
-    xmlSetting.SetAttribute(XML_ATTR_NAME, (*it).second.name.c_str());
-    TiXmlText xmlLabel((*it).second.value);
-    xmlSetting.InsertEndChild(xmlLabel);
-    pSettingsNode->InsertEndChild(xmlSetting);
+    if (!setting->Serialize(settingsElement))
+      CLog::Log(LOGWARNING, "CSkinSettings: unable to save setting \"%s\"", setting->name.c_str());
   }
 
   return true;
@@ -273,11 +138,49 @@ bool CSkinSettings::Save(TiXmlNode *settings) const
 void CSkinSettings::Clear()
 {
   CSingleLock lock(m_critical);
-  m_strings.clear();
-  m_bools.clear();
+  m_settings.clear();
 }
 
-std::string CSkinSettings::GetCurrentSkin() const
+void CSkinSettings::MigrateSettings(const ADDON::SkinPtr& skin)
 {
-  return CSettings::Get().GetString("lookandfeel.skin");
+  if (skin == nullptr)
+    return;
+
+  CSingleLock lock(m_critical);
+
+  bool settingsMigrated = false;
+  const std::string& skinId = skin->ID();
+  std::set<ADDON::CSkinSettingPtr> settingsCopy(m_settings.begin(), m_settings.end());
+  for (const auto& setting : settingsCopy)
+  {
+    if (!StringUtils::StartsWith(setting->name, skinId + "."))
+      continue;
+
+    std::string settingName = setting->name.substr(skinId.size() + 1);
+
+    if (setting->GetType() == "string")
+    {
+      int settingNumber = skin->TranslateString(settingName);
+      if (settingNumber >= 0)
+        skin->SetString(settingNumber, std::dynamic_pointer_cast<ADDON::CSkinSettingString>(setting)->value);
+    }
+    else if (setting->GetType() == "bool")
+    {
+      int settingNumber = skin->TranslateBool(settingName);
+      if (settingNumber >= 0)
+        skin->SetBool(settingNumber, std::dynamic_pointer_cast<ADDON::CSkinSettingBool>(setting)->value);
+    }
+
+    m_settings.erase(setting);
+    settingsMigrated = true;
+  }
+
+  if (settingsMigrated)
+  {
+    // save the skin's settings
+    skin->SaveSettings();
+
+    // save the guisettings.xml
+    CSettings::Get().Save();
+  }
 }

--- a/xbmc/settings/SkinSettings.h
+++ b/xbmc/settings/SkinSettings.h
@@ -19,31 +19,14 @@
  *
  */
 
-#include <map>
+#include <set>
 #include <string>
 
+#include "addons/Skin.h"
 #include "settings/lib/ISubSettings.h"
 #include "threads/CriticalSection.h"
 
 class TiXmlNode;
-
-class CSkinString
-{
-public:
-  std::string name;
-  std::string value;
-};
-
-class CSkinBool
-{
-public:
-  CSkinBool()
-    : value(false)
-  { }
-
-  std::string name;
-  bool value;
-};
 
 class CSkinSettings : public ISubSettings
 {
@@ -53,6 +36,8 @@ public:
   virtual bool Load(const TiXmlNode *settings);
   virtual bool Save(TiXmlNode *settings) const;
   virtual void Clear();
+
+  void MigrateSettings(const ADDON::SkinPtr& skin);
 
   int TranslateString(const std::string &setting);
   const std::string& GetString(int setting) const;
@@ -71,10 +56,7 @@ protected:
   CSkinSettings& operator=(CSkinSettings const&);
   virtual ~CSkinSettings();
 
-  std::string GetCurrentSkin() const;
-
 private:
-  std::map<int, CSkinString> m_strings;
-  std::map<int, CSkinBool> m_bools;
   CCriticalSection m_critical;
+  std::set<ADDON::CSkinSettingPtr> m_settings;
 };


### PR DESCRIPTION
These commits change the location where skin settings are stored. Instead of saving all skin settings from all skins in `guisettings.xml` (and making it rather huge) the settings are now stored in the skin's `addon_data` folder in `settings.xml` like any other addon with two differences:
- skins don't require a `settings.xml` file with a definition for each setting
- the format of the generated `settings.xml` slightly differs from the one used by all other addons (due to the previous point)

The migration of existing skin settings happens whenever a skin is loaded. We then look for skin settings matching the loaded skin in `guisettings.xml` and transfer them to the skin-specific `settings.xml` file. This is done because not all skins with skin settings in `guisettings.xml` might still be installed. This also means that `guisettings.xml` is only really cleaned up when loading the different skins.
