### PR TITLE
[pvr] fix CPVRChannelGroup::OnSettingChanged won't get called

### DIFF
--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -57,6 +57,7 @@ CPVRChannelGroup::CPVRChannelGroup(void) :
     m_bHidden(false),
     m_iPosition(0)
 {
+  OnInit();
 }
 
 CPVRChannelGroup::CPVRChannelGroup(bool bRadio, unsigned int iGroupId, const std::string &strGroupName) :
@@ -74,6 +75,7 @@ CPVRChannelGroup::CPVRChannelGroup(bool bRadio, unsigned int iGroupId, const std
     m_bHidden(false),
     m_iPosition(0)
 {
+  OnInit();
 }
 
 CPVRChannelGroup::CPVRChannelGroup(const PVR_CHANNEL_GROUP &group) :
@@ -91,10 +93,12 @@ CPVRChannelGroup::CPVRChannelGroup(const PVR_CHANNEL_GROUP &group) :
     m_bHidden(false),
     m_iPosition(group.iPosition)
 {
+  OnInit();
 }
 
 CPVRChannelGroup::~CPVRChannelGroup(void)
 {
+  CSettings::Get().UnregisterCallback(this);
   Unload();
 }
 
@@ -120,7 +124,7 @@ std::pair<int, int> CPVRChannelGroup::PathIdToStorageId(uint64_t storageId)
 }
 
 CPVRChannelGroup::CPVRChannelGroup(const CPVRChannelGroup &group) :
-  m_strGroupName(group.m_strGroupName)
+m_strGroupName(group.m_strGroupName)
 {
   m_bRadio                      = group.m_bRadio;
   m_iGroupType                  = group.m_iGroupType;
@@ -136,6 +140,15 @@ CPVRChannelGroup::CPVRChannelGroup(const CPVRChannelGroup &group) :
   m_members                     = group.m_members;
   m_sortedMembers               = group.m_sortedMembers;
   m_iPosition                   = group.m_iPosition;
+  OnInit();
+}
+
+void CPVRChannelGroup::OnInit(void)
+{
+  CSettings::Get().RegisterCallback(this, {
+    "pvrmanager.backendchannelorder",
+    "pvrmanager.usebackendchannelnumbers"
+  });
 }
 
 bool CPVRChannelGroup::Load(void)

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -96,6 +96,26 @@ CPVRChannelGroup::CPVRChannelGroup(const PVR_CHANNEL_GROUP &group) :
   OnInit();
 }
 
+CPVRChannelGroup::CPVRChannelGroup(const CPVRChannelGroup &group) :
+    m_strGroupName(group.m_strGroupName)
+{
+  m_bRadio                      = group.m_bRadio;
+  m_iGroupType                  = group.m_iGroupType;
+  m_iGroupId                    = group.m_iGroupId;
+  m_bLoaded                     = group.m_bLoaded;
+  m_bChanged                    = group.m_bChanged;
+  m_bUsingBackendChannelOrder   = group.m_bUsingBackendChannelOrder;
+  m_bUsingBackendChannelNumbers = group.m_bUsingBackendChannelNumbers;
+  m_iLastWatched                = group.m_iLastWatched;
+  m_bHidden                     = group.m_bHidden;
+  m_bSelectedGroup              = group.m_bSelectedGroup;
+  m_bPreventSortAndRenumber     = group.m_bPreventSortAndRenumber;
+  m_members                     = group.m_members;
+  m_sortedMembers               = group.m_sortedMembers;
+  m_iPosition                   = group.m_iPosition;
+  OnInit();
+}
+
 CPVRChannelGroup::~CPVRChannelGroup(void)
 {
   CSettings::Get().UnregisterCallback(this);
@@ -121,26 +141,6 @@ PVRChannelGroupMember CPVRChannelGroup::EmptyMember = { CPVRChannelPtr(), 0, 0 }
 std::pair<int, int> CPVRChannelGroup::PathIdToStorageId(uint64_t storageId)
 {
   return std::make_pair(storageId >> 32, storageId & 0xFFFFFFFF);
-}
-
-CPVRChannelGroup::CPVRChannelGroup(const CPVRChannelGroup &group) :
-m_strGroupName(group.m_strGroupName)
-{
-  m_bRadio                      = group.m_bRadio;
-  m_iGroupType                  = group.m_iGroupType;
-  m_iGroupId                    = group.m_iGroupId;
-  m_bLoaded                     = group.m_bLoaded;
-  m_bChanged                    = group.m_bChanged;
-  m_bUsingBackendChannelOrder   = group.m_bUsingBackendChannelOrder;
-  m_bUsingBackendChannelNumbers = group.m_bUsingBackendChannelNumbers;
-  m_iLastWatched                = group.m_iLastWatched;
-  m_bHidden                     = group.m_bHidden;
-  m_bSelectedGroup              = group.m_bSelectedGroup;
-  m_bPreventSortAndRenumber     = group.m_bPreventSortAndRenumber;
-  m_members                     = group.m_members;
-  m_sortedMembers               = group.m_sortedMembers;
-  m_iPosition                   = group.m_iPosition;
-  OnInit();
 }
 
 void CPVRChannelGroup::OnInit(void)

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -446,6 +446,11 @@ namespace PVR
 
   protected:
     /*!
+     * @brief Init class
+     */
+    virtual void OnInit(void);
+
+    /*!
      * @brief Load the channels stored in the database.
      * @param bCompress If true, compress the database after storing the channels.
      * @return The amount of channels that were added.


### PR DESCRIPTION
As pointed out by @Jalle19 the settings callback method `CPVRChannelGroup::OnSettingChanged` won't get called because the class not registered in `CSettings` as a callback listener.

This will fixes the issue and register `CPVRChannelGroup` as a callback listener.
