### PR TITLE
[favourites] handle pictures via showpicture builtin

### DIFF
--- a/xbmc/filesystem/FavouritesDirectory.cpp
+++ b/xbmc/filesystem/FavouritesDirectory.cpp
@@ -201,6 +201,8 @@ std::string CFavouritesDirectory::GetExecutePath(const CFileItem &item, const st
       execute = StringUtils::Format("PlayMedia(%s)", StringUtils::Paramify(item.GetVideoInfoTag()->m_strFileNameAndPath).c_str());
     else if (item.IsMusicDb() && item.HasMusicInfoTag())
       execute = StringUtils::Format("PlayMedia(%s)", StringUtils::Paramify(item.GetMusicInfoTag()->GetURL()).c_str());
+    else if (item.IsPicture())
+      execute = StringUtils::Format("ShowPicture(%s)", StringUtils::Paramify(item.GetPath()).c_str());
     else
       execute = StringUtils::Format("PlayMedia(%s)", StringUtils::Paramify(item.GetPath()).c_str());
   }


### PR DESCRIPTION
`PlayMedia` does not handle pictures so use `ShowPicture` built-in one for images. Issue exists since v11 from what i can tell.
