### PR TITLE
[gui] fix activation of window if top most modal is dialog busy

### DIFF
--- a/xbmc/dialogs/GUIDialogBusy.cpp
+++ b/xbmc/dialogs/GUIDialogBusy.cpp
@@ -87,7 +87,7 @@ CGUIDialogBusy::CGUIDialogBusy(void)
   : CGUIDialog(WINDOW_DIALOG_BUSY, "DialogBusy.xml"), m_bLastVisible(false)
 {
   m_loadType = LOAD_ON_GUI_INIT;
-  m_bModal = true;
+  m_modalityType = DialogModalityType::SYSTEM_MODAL;
   m_bCanceled = false;
   m_progress = 0;
 }
@@ -100,7 +100,7 @@ void CGUIDialogBusy::Show_Internal()
 {
   m_bCanceled = false;
   m_active = true;
-  m_bModal = true;
+  m_modalityType = DialogModalityType::SYSTEM_MODAL;
   m_bLastVisible = true;
   m_closing = false;
   m_progress = 0;

--- a/xbmc/dialogs/GUIDialogProgress.cpp
+++ b/xbmc/dialogs/GUIDialogProgress.cpp
@@ -67,7 +67,7 @@ void CGUIDialogProgress::StartModal()
   // the main rendering thread (this should really be handled via
   // a thread message though IMO)
   m_active = true;
-  m_bModal = true;
+  m_modalityType = DialogModalityType::MODAL;
   m_closing = false;
   g_windowManager.RegisterDialog(this);
 

--- a/xbmc/guilib/GUIDialog.cpp
+++ b/xbmc/guilib/GUIDialog.cpp
@@ -30,7 +30,7 @@
 CGUIDialog::CGUIDialog(int id, const std::string &xmlFile)
     : CGUIWindow(id, xmlFile)
 {
-  m_bModal = true;
+  m_modalityType = DialogModalityType::MODAL;
   m_wasRunning = false;
   m_renderOrder = 1;
   m_autoClosing = false;
@@ -169,7 +169,7 @@ void CGUIDialog::DoModal_Internal(int iWindowID /*= WINDOW_INVALID */, const std
     return; // don't do anything
 
   m_closing = false;
-  m_bModal = true;
+  m_modalityType = DialogModalityType::MODAL;
   // set running before it's added to the window manager, else the auto-show code
   // could show it as well if we are in a different thread from
   // the main rendering thread (this should really be handled via
@@ -204,7 +204,7 @@ void CGUIDialog::Show_Internal()
   if (!g_windowManager.Initialized())
     return; // don't do anything
 
-  m_bModal = false;
+  m_modalityType = DialogModalityType::MODELESS;
 
   // set running before it's added to the window manager, else the auto-show code
   // could show it as well if we are in a different thread from

--- a/xbmc/guilib/GUIDialog.h
+++ b/xbmc/guilib/GUIDialog.h
@@ -28,6 +28,13 @@
 #include "GUIWindow.h"
 #include "WindowIDs.h"
 
+enum class DialogModalityType
+{
+  MODELESS,
+  MODAL,
+  SYSTEM_MODAL
+};
+
 /*!
  \ingroup winmsg
  \brief
@@ -51,7 +58,8 @@ public:
 
   virtual bool IsDialogRunning() const { return m_active; };
   virtual bool IsDialog() const { return true;};
-  virtual bool IsModalDialog() const { return m_bModal; };
+  virtual bool IsModalDialog() const { return m_modalityType == DialogModalityType::MODAL || m_modalityType == DialogModalityType::SYSTEM_MODAL; };
+  virtual DialogModalityType GetModalityType() const { return m_modalityType; };
 
   void SetAutoClose(unsigned int timeoutMs);
   void ResetAutoClose(void);
@@ -69,10 +77,10 @@ protected:
   virtual void OnDeinitWindow(int nextWindowID);
 
   bool m_wasRunning; ///< \brief true if we were running during the last DoProcess()
-  bool m_bModal;
   bool m_autoClosing;
   bool m_enableSound;
   unsigned int m_showStartTime;
   unsigned int m_showDuration;
   bool m_bAutoClosed;
+  DialogModalityType m_modalityType;
 };

--- a/xbmc/guilib/GUIWindow.h
+++ b/xbmc/guilib/GUIWindow.h
@@ -76,8 +76,6 @@ public:
 class CGUIWindow : public CGUIControlGroup, protected CCriticalSection
 {
 public:
-
-  enum WINDOW_TYPE { WINDOW = 0, MODAL_DIALOG, MODELESS_DIALOG, BUTTON_MENU, SUB_MENU };
   enum LOAD_TYPE { LOAD_EVERY_TIME, LOAD_ON_GUI_INIT, KEEP_IN_MEMORY };
 
   CGUIWindow(int id, const std::string &xmlFile);

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -782,7 +782,7 @@ void CGUIWindowManager::ActivateWindow_Internal(int iWindowID, const vector<stri
   // don't activate a window if there are active modal dialogs of type NORMAL
   if (!force && HasModalDialog({ DialogModalityType::MODAL }))
   {
-    CLog::Log(LOG_LEVEL_DEBUG, "Activate of window '%i' refused because there are active modal dialogs", iWindowID);
+    CLog::Log(LOGINFO, "Activate of window '%i' refused because there are active modal dialogs", iWindowID);
     g_audioManager.PlayActionSound(CAction(ACTION_ERROR));
     return;
   }

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -779,8 +779,8 @@ void CGUIWindowManager::ActivateWindow_Internal(int iWindowID, const vector<stri
     return;
   }
 
-  // don't activate a window if there are active modal dialogs
-  if (!force && HasModalDialog())
+  // don't activate a window if there are active modal dialogs of type NORMAL
+  if (!force && HasModalDialog({ DialogModalityType::MODAL }))
   {
     CLog::Log(LOG_LEVEL_DEBUG, "Activate of window '%i' refused because there are active modal dialogs", iWindowID);
     g_audioManager.PlayActionSound(CAction(ACTION_ERROR));
@@ -1132,15 +1132,25 @@ void CGUIWindowManager::RemoveDialog(int id)
   }
 }
 
-bool CGUIWindowManager::HasModalDialog() const
+bool CGUIWindowManager::HasModalDialog(const std::vector<DialogModalityType>& types) const
 {
   CSingleLock lock(g_graphicsContext);
   for (ciDialog it = m_activeDialogs.begin(); it != m_activeDialogs.end(); ++it)
   {
-    CGUIWindow *window = *it;
-    if (window->IsModalDialog())
-    { // have a modal window
-      if (!window->IsAnimating(ANIM_TYPE_WINDOW_CLOSE))
+    if ((*it)->IsDialog() &&
+        (*it)->IsModalDialog() &&
+        !(*it)->IsAnimating(ANIM_TYPE_WINDOW_CLOSE))
+    {
+      if (types.size() > 0)
+      {
+        CGUIDialog *dialog = static_cast<CGUIDialog*>(*it);
+        for (const auto &type : types)
+        {
+          if (dialog->GetModalityType() == type)
+            return true;
+        }
+      }
+      else
         return true;
     }
   }

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -37,6 +37,7 @@
 #include <list>
 
 class CGUIDialog;
+enum class DialogModalityType;
 
 #define WINDOW_ID_MASK 0xffff
 
@@ -146,7 +147,7 @@ public:
   int GetActiveWindow() const;
   int GetActiveWindowID();
   int GetFocusedWindow() const;
-  bool HasModalDialog() const;
+  bool HasModalDialog(const std::vector<DialogModalityType>& types = std::vector<DialogModalityType>()) const;
   bool HasDialogOnScreen() const;
   bool IsWindowActive(int id, bool ignoreClosing = true) const;
   bool IsWindowVisible(int id) const;


### PR DESCRIPTION
In some cases it happens that the busy dialog is already open before the window activation kicks in.
This will results in a refuse of the activation and some pain for different addon devs because they need to hack around that issue.

This is an attempt to overcome the root cause and adds a new condition to the check for open modals.

Related Trac ticket http://trac.kodi.tv/ticket/15960
