### PR TITLE
[fix] Do not run thumb extractor job on PVR recording item

### DIFF
--- a/xbmc/cores/dvdplayer/DVDFileInfo.cpp
+++ b/xbmc/cores/dvdplayer/DVDFileInfo.cpp
@@ -346,6 +346,12 @@ bool CDVDFileInfo::GetFileStreamDetails(CFileItem *pItem)
   if (!pInputStream)
     return false;
 
+  if (pInputStream->IsStreamType(DVDSTREAM_TYPE_PVRMANAGER))
+  {
+    delete pInputStream;
+    return false;
+  }
+
   if (pInputStream->IsStreamType(DVDSTREAM_TYPE_DVD) || !pInputStream->Open(playablePath.c_str(), ""))
   {
     delete pInputStream;


### PR DESCRIPTION
Fix/workaround for crash when opening PVR recording for playback with Isengard.
Seems thumb extractor job is in competiiton with GUI operation. Here as workaround this commit forbids the thumb extractor job for PVR item.

Program terminated with signal SIGSEGV, Segmentation fault.

Thread 23 (Thread 0x7fd34901f700 (LWP 6294)):
13 0x0000000000fda72d in PVR::CPVRClient::CloseStream (this=0x7fd318000c40) at PVRClient.cpp:1772
14 0x0000000000fe454e in PVR::CPVRClients::CloseStream (this=0x7fd328000ad0) at PVRClients.cpp:1538
15 0x0000000000c79fe1 in PVR::CPVRManager::CloseStream (this=0x237d3e0 PVR::CPVRManager::Get()::pvrManagerInstance) at PVRManager.cpp:1090
16 0x0000000000af502a in XFILE::CPVRFile::Open (this=0x7fd33005b7e0, url=...) at PVRFile.cpp:47
17 0x000000000095e7e7 in CDVDInputStreamPVRManager::Open (this=0x7fd3300cf6a0, strFile=0x7fd324af3428 "pvr://recordings/active/Default/UNE JOURNÉE PARTICULIÈRE (VM) (HD), TV (ARTE HD), 20150525_185317.pvr", content=...) at DVDInputStreamPVRManager.cpp:88
18 0x00000000018e3c00 in CDVDPlayer::OpenInputStream (this=this@entry=0x66538c0) at DVDPlayer.cpp:736
19 0x00000000018e5496 in CDVDPlayer::Process (this=0x66538c0) at DVDPlayer.cpp:1097
20 0x0000000001a502f8 in CThread::Action (this=0x66538d0) at Thread.cpp:221

Thread 1 (Thread 0x7fd32ffff700 (LWP 6223)):
6  0x0000000000fda1af in PVR::CPVRClient::ReadStream (this=0x7fd318000c40, lpBuf=lpBuf@entry=0x7fd31401df10, uiBufSize=uiBufSize@entry=32768) at PVRClient.cpp:1302
7  0x0000000000fe462c in PVR::CPVRClients::ReadStream (this=<optimized out>, lpBuf=lpBuf@entry=0x7fd31401df10, uiBufSize=uiBufSize@entry=32768) at PVRClients.cpp:1551
8  0x0000000000af4a86 in XFILE::CPVRFile::Read (this=<optimized out>, buffer=0x7fd31401df10, size=32768) at PVRFile.cpp:117
9  0x000000000095ddc9 in CDVDInputStreamPVRManager::Read (this=0x7fd314011f00, buf=<optimized out>, buf_size=<optimized out>) at DVDInputStreamPVRManager.cpp:177
10 0x0000000001724d92 in fill_buffer (s=0x7fd314003440) at libavformat/aviobuf.c:477
11 avio_read (s=0x7fd314003440, buf=0x7fd32fff62c8 "\035\b\240\025\323\177", buf@entry=0x7fd32fff6290 "G\002\320\020\310_\357\261|:\207\021\207)\222\270Q\006FE\217\367\366\352!;\"T\236s\036\312~\035q\273\376Nh\214U\217w\r1\215&\327\022\027pa`6\206J\035\b\240\025\323\177", size=132) at libavformat/aviobuf.c:564
12 0x0000000001724f04 in ffio_read_indirect (s=s@entry=0x7fd314003440, buf=buf@entry=0x7fd32fff6290 "G\002\320\020\310_\357\261|:\207\021\207)\222\270Q\006FE\217\367\366\352!;\"T\236s\036\312~\035q\273\376Nh\214U\217w\r1\215&\327\022\027pa`6\206J\035\b\240\025\323\177", size=size@entry=188, data=data@entry=0x7fd32fff6288) at libavformat/aviobuf.c:591
13 0x000000000179bafa in read_packet (data=0x7fd32fff6288, raw_packet_size=188, buf=0x7fd32fff6290 "G\002\320\020\310*\357\261|:\207\021\207)\222\270Q\006FE\217\367\366\352!;\"T\236s\036\312~\035q\273\376Nh\214U\217w\r1\215&\327\022\027pa`6\206J\035\b\240\025\323\177", s=0x7fd31400f340) at libavformat/mpegts.c:2321
14 handle_packets (ts=ts@entry=0x7fd31403ffe0, nb_packets=nb_packets@entry=0) at libavformat/mpegts.c:2388
15 0x000000000179bc0c in mpegts_read_packet (s=<optimized out>, pkt=0x7fd32fff64c0) at libavformat/mpegts.c:2664
16 0x0000000001817c12 in ff_read_packet (s=s@entry=0x7fd31400f340, pkt=pkt@entry=0x7fd32fff64c0) at libavformat/utils.c:665
17 0x0000000001818881 in read_frame_internal (s=s@entry=0x7fd31400f340, pkt=pkt@entry=0x7fd32fff6720) at libavformat/utils.c:1318
18 0x000000000181a722 in avformat_find_stream_info (ic=0x7fd31400f340, options=0x0) at libavformat/utils.c:3224
19 0x000000000094c131 in CDVDDemuxFFmpeg::Open (this=this@entry=0x7fd314011020, pInput=pInput@entry=0x7fd314011f00, streaminfo=streaminfo@entry=true, fileinfo=fileinfo@entry=true) at DVDDemuxFFmpeg.cpp:447
20 0x00000000009468f8 in CDVDFactoryDemuxer::CreateDemuxer (pInputStream=pInputStream@entry=0x7fd314011f00, fileinfo=fileinfo@entry=true) at DVDFactoryDemuxer.cpp:134
21 0x000000000091d3f5 in CDVDFileInfo::GetFileStreamDetails (pItem=pItem@entry=0x7fd3300710e0) at DVDFileInfo.cpp:355
22 0x0000000000861942 in CThumbExtractor::DoWork (this=0x7fd3300710c0) at VideoThumbLoader.cpp:135
23 0x0000000000f4fe59 in CJobWorker::Process (this=0x5a19950) at JobManager.cpp:68
