### PR TITLE
[backport] WIP: nonlinear stretch 16:9 setting for 4:3 video display

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -2779,6 +2779,11 @@ msgctxt "#643"
 msgid "Avoid clipping on ReplayGained files"
 msgstr ""
 
+#: system/settings/settings.xml
+msgctxt "#644"
+msgid "Stretch 16:9 - Nonlinear"
+msgstr ""
+
 #empty string with id 644
 
 msgctxt "#645"

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -587,6 +587,7 @@
               <option label="630">0</option> <!-- ViewModeNormal -->
               <option label="633">3</option> <!-- ViewModeWideZoom -->
               <option label="634">4</option> <!-- ViewModeStretch16x9 -->
+              <option label="644">7</option> <!-- ViewModeStretch16x9 - nonlinear -->
               <option label="631">1</option> <!-- ViewModeZoom -->
             </options>
           </constraints>

--- a/xbmc/cores/VideoRenderers/BaseRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/BaseRenderer.cpp
@@ -688,7 +688,8 @@ void CBaseRenderer::SetViewMode(int viewMode)
     CDisplaySettings::Get().SetNonLinearStretched(true);
   }
   else if ( CMediaSettings::Get().GetCurrentVideoSettings().m_ViewMode == ViewModeStretch16x9 ||
-           (is43 && CSettings::Get().GetInt("videoplayer.stretch43") == ViewModeStretch16x9))
+           (is43 && (CSettings::Get().GetInt("videoplayer.stretch43") == ViewModeStretch16x9 ||
+                     CSettings::Get().GetInt("videoplayer.stretch43") == ViewModeStretch16x9Nonlin)))
   { // stretch image to 16:9 ratio
     CDisplaySettings::Get().SetZoomAmount(1.0);
     if (res == RES_PAL_4x3 || res == RES_PAL60_4x3 || res == RES_NTSC_4x3 || res == RES_HDTV_480p_4x3)
@@ -701,6 +702,9 @@ void CBaseRenderer::SetViewMode(int viewMode)
       // incorrect behaviour, but it's what the users want, so...
       CDisplaySettings::Get().SetPixelRatio((screenWidth / screenHeight) * info.fPixelRatio / sourceFrameRatio);
     }
+    if (is43)
+      CDisplaySettings::Get().SetNonLinearStretched(CSettings::Get().GetInt("videoplayer.stretch43") == ViewModeStretch16x9Nonlin);
+
   }
   else  if (CMediaSettings::Get().GetCurrentVideoSettings().m_ViewMode == ViewModeOriginal)
   { // zoom image so that the height is the original size

--- a/xbmc/settings/VideoSettings.h
+++ b/xbmc/settings/VideoSettings.h
@@ -111,7 +111,8 @@ typedef enum {
   ViewModeWideZoom,
   ViewModeStretch16x9,
   ViewModeOriginal,
-  ViewModeCustom
+  ViewModeCustom,
+  ViewModeStretch16x9Nonlin
 } ViewMode;
 
 class CVideoSettings


### PR DESCRIPTION
This PR is the monkeywork to backport this improvement from notspiff's fork.
As a user that has many 4:3 source material, will certainly appreciate this and now that isengard has been branched gives the opportunity to test by other like minded users early on.

Saving non-linear stretch for all videos as default, screws up the ratio for all other videos that are not 4:3.
The alternative is to manually enable this option on each episode being played back.After once or twice you already fed up.

This option is a setup once and forget about it, just works.

Have tested this and works indeed as desired, perfect. thanks @notspiff

![nonlinearcomparison](https://cloud.githubusercontent.com/assets/3521959/8501954/716343ce-21a2-11e5-9e3f-f682ea21c9a5.png)
