### PR TITLE
[addons] fix segfault on invalid context item visibility condition

### DIFF
--- a/xbmc/addons/ContextItemAddon.cpp
+++ b/xbmc/addons/ContextItemAddon.cpp
@@ -66,7 +66,7 @@ std::string CContextItemAddon::GetLabel()
 
 bool CContextItemAddon::IsVisible(const CFileItemPtr& item) const
 {
-  return item && m_visCondition->Get(item.get());
+  return item && m_visCondition && m_visCondition->Get(item.get());
 }
 
 }


### PR DESCRIPTION
Can be null if extension point parsing fails.
