### PR TITLE
[cosmetics] some cleanup on spelling/capitalisation & xbmc -> kodi

### DIFF
--- a/tools/Linux/kodi-standalone.sh.in
+++ b/tools/Linux/kodi-standalone.sh.in
@@ -47,7 +47,7 @@ do
       CRASHCOUNT=$((CRASHCOUNT+1))
       if [ $(($CRASHCOUNT >= 3)) = "1" ]; then # Too many, bail out
         LOOP=0
-        echo "${APP} has exited uncleanly 3 times in the last ${DIFF} seconds."
+        echo "${APP} has exited in an unclean state 3 times in the last ${DIFF} seconds."
         echo "Something is probably wrong"
       fi
     fi

--- a/tools/Linux/kodi-xsession.desktop.in
+++ b/tools/Linux/kodi-xsession.desktop.in
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=@APP_NAME@
-Comment=This session will start @APP_NAME@ Media Center
+Comment=This session will start @APP_NAME@ media center
 Exec=@APP_NAME_LC@-standalone
 TryExec=@APP_NAME_LC@-standalone
 Type=Application

--- a/tools/Linux/kodi.desktop
+++ b/tools/Linux/kodi.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Version=1.0
-Name=Kodi Media Center
-GenericName=Media Center
+Name=Kodi media center
+GenericName=Media center
 Comment=Manage and view your media
 Exec=kodi
 Icon=kodi

--- a/tools/Linux/kodi.sh.in
+++ b/tools/Linux/kodi.sh.in
@@ -45,7 +45,7 @@ done
 
 migrate_home()
 {
-  [ "$(basename $0)" = "xbmc" ] && echo "WARNING: running ${bin_name} as "xbmc" is deprecated and will be removed in later versions, please switch to using the ${bin_name} binary"
+  [ "$(basename $0)" = "xbmc" ] && echo "WARNING: Running ${bin_name} as "xbmc" is deprecated and will be removed in later versions, please switch to using the ${bin_name} binary"
 
   #check if data migration is needed
   if [ -d "${HOME}/.xbmc" ] && [ ! -d "${USERDATA_DIR}" ]; then
@@ -127,7 +127,7 @@ print_crash_report()
     echo >> $FILE
   else
     echo "Logfile not found in the usual place." >> $FILE
-    echo "Please attach it seperately." >> $FILE
+    echo "Please attach it separately." >> $FILE
     echo "Use pastebin.com or similar for forums or IRC." >> $FILE
   fi
   echo >> $FILE

--- a/tools/Linux/packaging/README.debian
+++ b/tools/Linux/packaging/README.debian
@@ -1,12 +1,12 @@
---- How to build a XBMC debian package ---
+--- How to build a Kodi Debian package ---
 
 There are two available build methods:
 1.) debuild / debhelper
-  Requirements: debhelper, devscripts, all Xbmc build deps 
+  Requirements: debhelper, devscripts, all Kodi build deps 
       sudo apt-get install debhelper devscripts
-      sudo apt-get build-dep xbmc (if you have on of our repos/ppas added, else read docs/README.linux or docs/README.ubuntu)
+      sudo apt-get build-dep kodi (if you have on of our repos/ppas added, else read docs/README.linux or docs/README.ubuntu)
 
-  Result: debian package for your host distribution and architecture only
+  Result: Debian package for your host distribution and architecture only
   Recommended for local installs
 
   Example Usage: ./mk-debian-package.sh
@@ -16,11 +16,11 @@ There are two available build methods:
       For a comprehensive example how to setup pbuilder read: 
       https://wiki.ubuntu.com/PbuilderHowto
 
-  Result: debian package for arbitrary debian based distributions and architectures
+  Result: Debian package for arbitrary Debian based distributions and architectures.
   Recommended for hosting your own apt repository or (clean room) compile testing for various distributions
 
   Example Usage:
-  RELEASEV=13 \
+  RELEASEV=16 \
   DISTS=-"unstable" \
   ARCHS="i386 amd64" \
   BUILDER="pdebuild" \


### PR DESCRIPTION
While looking at  tools/Linux/kodi-standalone.sh.in and tools/Linux/kodi.sh.in for possible clews/reasons why starting kodi from minimal upstart script doesn't automatically create a core entry on crashlogs files, I stumbled on a few minors, this PR corrects these on this directory.
