### PR TITLE
[backport]Added detection for Windows 10 in systeminfo

### DIFF
--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -710,8 +710,14 @@ std::string CSysInfo::GetOsPrettyNameWithVersion(void)
       else
         osNameVer.append("Server 2012 R2");
       break;
+    case WindowsVersionWin10:
+      if (osvi.wProductType == VER_NT_WORKSTATION)
+        osNameVer.append("10");
+      else
+        osNameVer.append("Unknown future server version");
+      break;
     case WindowsVersionFuture:
-      osNameVer.append("Unknown Future Version");
+      osNameVer.append("Unknown future version");
       break;
     default:
       osNameVer.append("Unknown version");
@@ -897,6 +903,8 @@ CSysInfo::WindowsVersion CSysInfo::GetWindowsVersion()
         m_WinVer = WindowsVersionWin8;
       else if (osvi.dwMajorVersion == 6 && osvi.dwMinorVersion == 3) 
         m_WinVer = WindowsVersionWin8_1;
+      else if (osvi.dwMajorVersion == 10 && osvi.dwMinorVersion == 0)
+        m_WinVer = WindowsVersionWin10;
       /* Insert checks for new Windows versions here */
       else if ( (osvi.dwMajorVersion == 6 && osvi.dwMinorVersion > 3) || osvi.dwMajorVersion > 6)
         m_WinVer = WindowsVersionFuture;

--- a/xbmc/utils/SystemInfo.h
+++ b/xbmc/utils/SystemInfo.h
@@ -87,6 +87,7 @@ public:
     WindowsVersionWin7,         // Windows 7, Windows Server 2008 R2
     WindowsVersionWin8,         // Windows 8, Windows Server 2012
     WindowsVersionWin8_1,       // Windows 8.1
+    WindowsVersionWin10,        // windows 10
     /* Insert new Windows versions here, when they'll be known */
     WindowsVersionFuture = 100  // Future Windows version, not known to code
   };


### PR DESCRIPTION
had completely forgotten about this but with release next month it might be good to recognize it so we get proper logs.
