### PR TITLE
[omxplayer] Make unsupported when ac3transcode is enabled

### DIFF
--- a/xbmc/cores/omxplayer/OMXHelper.cpp
+++ b/xbmc/cores/omxplayer/OMXHelper.cpp
@@ -56,6 +56,12 @@ bool OMXPlayerUnsuitable(bool m_HasVideo, bool m_HasAudio, CDVDDemux* m_pDemuxer
     CLog::Log(LOGNOTICE, "%s OMXPlayer unsuitable due to audio sink", __func__);
     return true;
   }
+  // omxplayer doesn't handle ac3 transcode
+  if (CSettings::Get().GetBool("audiooutput.ac3transcode"))
+  {
+    CLog::Log(LOGNOTICE, "%s OMXPlayer unsuitable due to ac3transcode", __func__);
+    return true;
+  }
   if (m_pDemuxer)
   {
     // find video stream


### PR DESCRIPTION
omxplayer doesn't support ac3 transcode, so disable omxplayer
acceleration when the option is enabled.
