### PR TITLE
[mmalrenderer] Add sharpness control

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -7712,7 +7712,7 @@ msgstr ""
 
 #: xbmc/video/dialogs/GUIDialogVideoSettings.cpp
 msgctxt "#16313"
-msgid "VDPAU - Sharpness"
+msgid "Sharpness"
 msgstr ""
 
 #: xbmc/video/dialogs/GUIDialogVideoSettings.cpp

--- a/xbmc/cores/VideoRenderers/MMALRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/MMALRenderer.cpp
@@ -207,6 +207,7 @@ CMMALRenderer::CMMALRenderer()
   m_bConfigured = false;
   m_bMMALConfigured = false;
   m_iYV12RenderBuffer = 0;
+  m_sharpness = -2.0f;
 }
 
 CMMALRenderer::~CMMALRenderer()
@@ -376,6 +377,15 @@ void CMMALRenderer::RenderUpdate(bool clear, DWORD flags, DWORD alpha)
   // for sizing video playback on a layer other than the gles layer.
   if (m_RenderUpdateCallBackFn)
     (*m_RenderUpdateCallBackFn)(m_RenderUpdateCallBackCtx, m_sourceRect, m_destRect);
+
+  // if sharpness setting has changed, we should update it
+  if (m_sharpness != CMediaSettings::Get().GetCurrentVideoSettings().m_Sharpness)
+  {
+    m_sharpness = CMediaSettings::Get().GetCurrentVideoSettings().m_Sharpness;
+    char command[80], response[80];
+    sprintf(command, "scaling_sharpness %d", ((int)(50.0f * (m_sharpness + 1.0f) + 0.5f)));
+    vc_gencmd(response, sizeof response, command);
+  }
 
   if (m_format == RENDER_FMT_BYPASS)
     return;
@@ -563,7 +573,8 @@ bool CMMALRenderer::Supports(ERENDERFEATURE feature)
       feature == RENDERFEATURE_ZOOM            ||
       feature == RENDERFEATURE_ROTATION        ||
       feature == RENDERFEATURE_VERTICAL_SHIFT  ||
-      feature == RENDERFEATURE_PIXEL_RATIO)
+      feature == RENDERFEATURE_PIXEL_RATIO     ||
+      feature == RENDERFEATURE_SHARPNESS)
     return true;
 
   return false;

--- a/xbmc/cores/VideoRenderers/MMALRenderer.h
+++ b/xbmc/cores/VideoRenderers/MMALRenderer.h
@@ -105,6 +105,7 @@ protected:
   RENDER_STEREO_MODE        m_video_stereo_mode;
   RENDER_STEREO_MODE        m_display_stereo_mode;
   bool                      m_StereoInvert;
+  float                     m_sharpness;
 
   CCriticalSection m_sharedSection;
   MMAL_COMPONENT_T *m_vout;


### PR DESCRIPTION
This enables sharpness OSD control for mmalrenderer.

I've renamed the "VDPAU - Sharpness" to "Sharpness" as there didn't seem to be a reason for it not to be generic. It is connected to the generically named RENDERFEATURE_SHARPNESS.
