### PR TITLE
dvdplayer: add a method to avoid requeting HTTP Header

### DIFF
--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -413,6 +413,12 @@ public:
    */
   void FillInMimeType(bool lookup = true);
 
+  /*!
+   \brief Some sources do not support HTTP HEAD request to determine i.e. mime type
+   \return false if HEAD requests have to be avoided
+   */
+  bool ContentLookup() { return true; };
+
   /* general extra info about the contents of the item, not for display */
   void SetExtraInfo(const std::string& info) { m_extrainfo = info; };
   const std::string& GetExtraInfo() const { return m_extrainfo; };

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxVobsub.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxVobsub.cpp
@@ -62,7 +62,7 @@ bool CDVDDemuxVobsub::Open(const string& filename, int source, const string& sub
   }
 
   m_Input.reset(CDVDFactoryInputStream::CreateInputStream(NULL, vobsub, ""));
-  if(!m_Input.get() || !m_Input->Open(vobsub.c_str(), "video/x-vobsub"))
+  if(!m_Input.get() || !m_Input->Open(vobsub.c_str(), "video/x-vobsub", false))
     return false;
 
   m_Demuxer.reset(new CDVDDemuxFFmpeg());

--- a/xbmc/cores/dvdplayer/DVDFileInfo.cpp
+++ b/xbmc/cores/dvdplayer/DVDFileInfo.cpp
@@ -64,7 +64,7 @@ bool CDVDFileInfo::GetFileDuration(const std::string &path, int& duration)
   if (!input.get())
     return false;
 
-  if (!input->Open(path.c_str(), ""))
+  if (!input->Open(path.c_str(), "", true))
     return false;
 
   demux.reset(CDVDFactoryDemuxer::CreateDemuxer(input.get(), true));
@@ -120,7 +120,7 @@ bool CDVDFileInfo::ExtractThumb(const std::string &strPath,
     return false;
   }
 
-  if (!pInputStream->Open(strPath.c_str(), ""))
+  if (!pInputStream->Open(strPath.c_str(), "", true))
   {
     CLog::Log(LOGERROR, "InputStream: Error opening, %s", redactPath.c_str());
     if (pInputStream)
@@ -352,7 +352,7 @@ bool CDVDFileInfo::GetFileStreamDetails(CFileItem *pItem)
     return false;
   }
 
-  if (pInputStream->IsStreamType(DVDSTREAM_TYPE_DVD) || !pInputStream->Open(playablePath.c_str(), ""))
+  if (pInputStream->IsStreamType(DVDSTREAM_TYPE_DVD) || !pInputStream->Open(playablePath.c_str(), "", true))
   {
     delete pInputStream;
     return false;

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDFactoryInputStream.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDFactoryInputStream.cpp
@@ -39,9 +39,11 @@
 #include "utils/URIUtils.h"
 
 
-CDVDInputStream* CDVDFactoryInputStream::CreateInputStream(IDVDPlayer* pPlayer, const std::string& file, const std::string& content)
+CDVDInputStream* CDVDFactoryInputStream::CreateInputStream(IDVDPlayer* pPlayer, const std::string& file, const std::string& content, bool contentlookup)
 {
   CFileItem item(file.c_str(), false);
+
+  item.SetMimeType(content);
 
   if(item.IsDiscImage())
   {
@@ -101,7 +103,10 @@ CDVDInputStream* CDVDFactoryInputStream::CreateInputStream(IDVDPlayer* pPlayer, 
   {
     if (item.IsType(".m3u8"))
       return new CDVDInputStreamFFmpeg();
-    item.FillInMimeType();
+
+    if (contentlookup)
+      item.FillInMimeType();
+
     if (item.GetMimeType() == "application/vnd.apple.mpegurl")
       return new CDVDInputStreamFFmpeg();
   }

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDFactoryInputStream.h
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDFactoryInputStream.h
@@ -28,5 +28,5 @@ class IDVDPlayer;
 class CDVDFactoryInputStream
 {
 public:
-  static CDVDInputStream* CreateInputStream(IDVDPlayer* pPlayer, const std::string& file, const std::string& content);
+  static CDVDInputStream* CreateInputStream(IDVDPlayer* pPlayer, const std::string& file, const std::string& content, bool contentlookup = true);
 };

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStream.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStream.cpp
@@ -24,13 +24,14 @@
 CDVDInputStream::CDVDInputStream(DVDStreamType streamType)
 {
   m_streamType = streamType;
+  m_contentLookup = true;
 }
 
 CDVDInputStream::~CDVDInputStream()
 {
 }
 
-bool CDVDInputStream::Open(const char* strFile, const std::string &content)
+bool CDVDInputStream::Open(const char* strFile, const std::string &content, bool contentLookup)
 {
   CURL url(strFile);
 
@@ -41,6 +42,7 @@ bool CDVDInputStream::Open(const char* strFile, const std::string &content)
   m_strFileName = url.Get();
 
   m_content = content;
+  m_contentLookup = contentLookup;
   return true;
 }
 

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStream.h
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStream.h
@@ -149,7 +149,7 @@ public:
 
   CDVDInputStream(DVDStreamType m_streamType);
   virtual ~CDVDInputStream();
-  virtual bool Open(const char* strFileName, const std::string& content);
+  virtual bool Open(const char* strFileName, const std::string& content, bool contentLookup);
   virtual void Close() = 0;
   virtual int Read(uint8_t* buf, int buf_size) = 0;
   virtual int64_t Seek(int64_t offset, int whence) = 0;
@@ -180,6 +180,8 @@ public:
 
   void SetFileItem(const CFileItem& item);
 
+  bool ContentLookup() { return m_contentLookup; }
+
 protected:
   DVDStreamType m_streamType;
   std::string m_strFileName;
@@ -187,4 +189,5 @@ protected:
   BitstreamStats m_stats;
   std::string m_content;
   CFileItem m_item;
+  bool m_contentLookup;
 };

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -253,7 +253,7 @@ BLURAY_TITLE_INFO* CDVDInputStreamBluray::GetTitleFile(const std::string& filena
 }
 
 
-bool CDVDInputStreamBluray::Open(const char* strFile, const std::string& content)
+bool CDVDInputStreamBluray::Open(const char* strFile, const std::string& content, bool contentLookup)
 {
   if(m_player == NULL)
     return false;

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.h
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.h
@@ -48,7 +48,7 @@ class CDVDInputStreamBluray
 public:
   CDVDInputStreamBluray(IDVDPlayer* player);
   virtual ~CDVDInputStreamBluray();
-  virtual bool Open(const char* strFile, const std::string &content);
+  virtual bool Open(const char* strFile, const std::string &content, bool contentLookup);
   virtual void Close();
   virtual int Read(uint8_t* buf, int buf_size);
   virtual int64_t Seek(int64_t offset, int whence);

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFFmpeg.cpp
@@ -48,7 +48,7 @@ bool CDVDInputStreamFFmpeg::IsEOF()
     return false;
 }
 
-bool CDVDInputStreamFFmpeg::Open(const char* strFile, const std::string& content)
+bool CDVDInputStreamFFmpeg::Open(const char* strFile, const std::string& content, bool contentLookup)
 {
   CFileItem item(strFile, false);
   std::string selected;
@@ -66,7 +66,7 @@ bool CDVDInputStreamFFmpeg::Open(const char* strFile, const std::string& content
     }
   }
 
-  if (!CDVDInputStream::Open(strFile, content))
+  if (!CDVDInputStream::Open(strFile, content, contentLookup))
     return false;
 
   m_can_pause = true;

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFFmpeg.h
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFFmpeg.h
@@ -29,7 +29,7 @@ class CDVDInputStreamFFmpeg
 public:
   CDVDInputStreamFFmpeg();
   virtual ~CDVDInputStreamFFmpeg();
-  virtual bool Open(const char* strFile, const std::string &content);
+  virtual bool Open(const char* strFile, const std::string &content, bool contentLookup);
   virtual void Close();
   virtual int Read(uint8_t* buf, int buf_size);
   virtual int64_t Seek(int64_t offset, int whence);

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFile.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFile.cpp
@@ -43,9 +43,9 @@ bool CDVDInputStreamFile::IsEOF()
   return !m_pFile || m_eof;
 }
 
-bool CDVDInputStreamFile::Open(const char* strFile, const std::string& content)
+bool CDVDInputStreamFile::Open(const char* strFile, const std::string& content, bool contentLookup)
 {
-  if (!CDVDInputStream::Open(strFile, content))
+  if (!CDVDInputStream::Open(strFile, content, contentLookup))
     return false;
 
   m_pFile = new CFile();

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFile.h
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFile.h
@@ -27,7 +27,7 @@ class CDVDInputStreamFile : public CDVDInputStream
 public:
   CDVDInputStreamFile();
   virtual ~CDVDInputStreamFile();
-  virtual bool Open(const char* strFile, const std::string &content);
+  virtual bool Open(const char* strFile, const std::string &content, bool contentLookup);
   virtual void Close();
   virtual int Read(uint8_t* buf, int buf_size);
   virtual int64_t Seek(int64_t offset, int whence);

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamHttp.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamHttp.cpp
@@ -50,9 +50,9 @@ bool CDVDInputStreamHttp::IsEOF()
   return true;
 }
 
-bool CDVDInputStreamHttp::Open(const char* strFile, const std::string& content)
+bool CDVDInputStreamHttp::Open(const char* strFile, const std::string& content, bool contentLookup)
 {
-  if (!CDVDInputStream::Open(strFile, content)) return false;
+  if (!CDVDInputStream::Open(strFile, content, contentLookup)) return false;
 
   m_pFile = new CCurlFile();
   if (!m_pFile) return false;

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamHttp.h
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamHttp.h
@@ -33,7 +33,7 @@ class CDVDInputStreamHttp : public CDVDInputStream
 public:
   CDVDInputStreamHttp();
   virtual ~CDVDInputStreamHttp();
-  virtual bool Open(const char* strFile, const std::string& content);
+  virtual bool Open(const char* strFile, const std::string& content, bool contentLookup);
   virtual void Close();
   virtual int Read(uint8_t* buf, int buf_size);
   virtual int64_t Seek(int64_t offset, int whence);

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamMemory.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamMemory.cpp
@@ -40,9 +40,9 @@ bool CDVDInputStreamMemory::IsEOF()
   return false;
 }
 
-bool CDVDInputStreamMemory::Open(const char* strFile, const std::string& content)
+bool CDVDInputStreamMemory::Open(const char* strFile, const std::string& content, bool contentLookup)
 {
-  if (!CDVDInputStream::Open(strFile, content)) return false;
+  if (!CDVDInputStream::Open(strFile, content, contentLookup)) return false;
 
   return true;
 }

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamMemory.h
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamMemory.h
@@ -27,7 +27,7 @@ class CDVDInputStreamMemory : public CDVDInputStream
 public:
   CDVDInputStreamMemory();
   virtual ~CDVDInputStreamMemory();
-  virtual bool Open(const char* strFile, const std::string& content);
+  virtual bool Open(const char* strFile, const std::string& content, bool contentLookup);
   virtual void Close();
   virtual int Read(uint8_t* buf, int buf_size);
   virtual int64_t Seek(int64_t offset, int whence);

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -63,9 +63,9 @@ CDVDInputStreamNavigator::~CDVDInputStreamNavigator()
   Close();
 }
 
-bool CDVDInputStreamNavigator::Open(const char* strFile, const std::string& content)
+bool CDVDInputStreamNavigator::Open(const char* strFile, const std::string& content, bool contentLookup)
 {
-  if (!CDVDInputStream::Open(strFile, "video/x-dvd-mpeg"))
+  if (!CDVDInputStream::Open(strFile, "video/x-dvd-mpeg", contentLookup))
     return false;
 
   // load libdvdnav.dll

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.h
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.h
@@ -77,7 +77,7 @@ public:
   CDVDInputStreamNavigator(IDVDPlayer* player);
   virtual ~CDVDInputStreamNavigator();
 
-  virtual bool Open(const char* strFile, const std::string& content);
+  virtual bool Open(const char* strFile, const std::string& content, bool contentLookup);
   virtual void Close();
   virtual int Read(uint8_t* buf, int buf_size);
   virtual int64_t Seek(int64_t offset, int whence);

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamPVRManager.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamPVRManager.cpp
@@ -74,7 +74,7 @@ bool CDVDInputStreamPVRManager::IsEOF()
     return !m_pFile || m_eof;
 }
 
-bool CDVDInputStreamPVRManager::Open(const char* strFile, const std::string& content)
+bool CDVDInputStreamPVRManager::Open(const char* strFile, const std::string& content, bool contentLookup)
 {
   /* Open PVR File for both cases, to have access to ILiveTVInterface and
    * IRecordable
@@ -84,7 +84,7 @@ bool CDVDInputStreamPVRManager::Open(const char* strFile, const std::string& con
   m_pRecordable = ((CPVRFile*)m_pFile)->GetRecordable();
 
   CURL url(strFile);
-  if (!CDVDInputStream::Open(strFile, content)) return false;
+  if (!CDVDInputStream::Open(strFile, content, contentLookup)) return false;
   if (!m_pFile->Open(url))
   {
     delete m_pFile;
@@ -117,7 +117,7 @@ bool CDVDInputStreamPVRManager::Open(const char* strFile, const std::string& con
     else
       m_pOtherStream->SetFileItem(m_item);
 
-    if (!m_pOtherStream->Open(transFile.c_str(), content))
+    if (!m_pOtherStream->Open(transFile.c_str(), content, contentLookup))
     {
       CLog::Log(LOGERROR, "CDVDInputStreamPVRManager::Open - error opening [%s]", transFile.c_str());
       delete m_pFile;
@@ -132,6 +132,7 @@ bool CDVDInputStreamPVRManager::Open(const char* strFile, const std::string& con
 
   ResetScanTimeout((unsigned int) CSettings::Get().GetInt("pvrplayback.scantime") * 1000);
   m_content = content;
+  m_contentLookup = contentLookup;
   CLog::Log(LOGDEBUG, "CDVDInputStreamPVRManager::Open - stream opened: %s", transFile.c_str());
 
   return true;
@@ -373,7 +374,7 @@ bool CDVDInputStreamPVRManager::CloseAndOpen(const char* strFile)
 {
   Close();
 
-  if (Open(strFile, m_content))
+  if (Open(strFile, m_content, m_contentLookup))
   {
     return true;
   }

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamPVRManager.h
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamPVRManager.h
@@ -45,7 +45,7 @@ class CDVDInputStreamPVRManager
 public:
   CDVDInputStreamPVRManager(IDVDPlayer* pPlayer);
   virtual ~CDVDInputStreamPVRManager();
-  virtual bool Open(const char* strFile, const std::string &content);
+  virtual bool Open(const char* strFile, const std::string &content, bool contentLookup);
   virtual void Close();
   virtual int Read(uint8_t* buf, int buf_size);
   virtual int64_t Seek(int64_t offset, int whence);

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamRTMP.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamRTMP.cpp
@@ -135,7 +135,7 @@ static const struct {
  { NULL }
 };
 
-bool CDVDInputStreamRTMP::Open(const char* strFile, const std::string& content)
+bool CDVDInputStreamRTMP::Open(const char* strFile, const std::string& content, bool contentLookup)
 {
   if (m_sStreamPlaying)
   {
@@ -143,7 +143,7 @@ bool CDVDInputStreamRTMP::Open(const char* strFile, const std::string& content)
     m_sStreamPlaying = NULL;
   }
 
-  if (!m_rtmp || !CDVDInputStream::Open(strFile, "video/x-flv"))
+  if (!m_rtmp || !CDVDInputStream::Open(strFile, "video/x-flv", contentLookup))
     return false;
 
   CSingleLock lock(m_RTMPSection);

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamRTMP.h
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamRTMP.h
@@ -32,7 +32,7 @@ class CDVDInputStreamRTMP
 public:
   CDVDInputStreamRTMP();
   virtual ~CDVDInputStreamRTMP();
-  virtual bool    Open(const char* strFile, const std::string &content);
+  virtual bool    Open(const char* strFile, const std::string &content, bool contentLookup);
   virtual void    Close();
   virtual int     Read(uint8_t* buf, int buf_size);
   virtual int64_t Seek(int64_t offset, int whence);

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamStack.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamStack.cpp
@@ -46,9 +46,9 @@ bool CDVDInputStreamStack::IsEOF()
   return m_eof;
 }
 
-bool CDVDInputStreamStack::Open(const char* path, const std::string& content)
+bool CDVDInputStreamStack::Open(const char* path, const std::string& content, bool contentLookup)
 {
-  if (!CDVDInputStream::Open(path, content))
+  if (!CDVDInputStream::Open(path, content, contentLookup))
     return false;
 
   CStackDirectory dir;

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamStack.h
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamStack.h
@@ -29,7 +29,7 @@ public:
   CDVDInputStreamStack();
   virtual ~CDVDInputStreamStack();
 
-  virtual bool    Open(const char* path, const std::string &content);
+  virtual bool    Open(const char* path, const std::string &content, bool contentLookup);
   virtual void    Close();
   virtual int     Read(uint8_t* buf, int buf_size);
   virtual int64_t Seek(int64_t offset, int whence);

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -724,7 +724,7 @@ bool CDVDPlayer::OpenInputStream()
     m_filename = g_mediaManager.TranslateDevicePath("");
   }
 
-  m_pInputStream = CDVDFactoryInputStream::CreateInputStream(this, m_filename, m_mimetype);
+  m_pInputStream = CDVDFactoryInputStream::CreateInputStream(this, m_filename, m_mimetype, m_item.ContentLookup());
   if(m_pInputStream == NULL)
   {
     CLog::Log(LOGERROR, "CDVDPlayer::OpenInputStream - unable to create input stream for [%s]", m_filename.c_str());
@@ -733,7 +733,7 @@ bool CDVDPlayer::OpenInputStream()
   else
     m_pInputStream->SetFileItem(m_item);
 
-  if (!m_pInputStream->Open(m_filename.c_str(), m_mimetype))
+  if (!m_pInputStream->Open(m_filename.c_str(), m_mimetype, m_item.ContentLookup()))
   {
     CLog::Log(LOGERROR, "CDVDPlayer::OpenInputStream - error opening [%s]", m_filename.c_str());
     return false;

--- a/xbmc/cores/dvdplayer/DVDSubtitles/DVDSubtitleStream.cpp
+++ b/xbmc/cores/dvdplayer/DVDSubtitles/DVDSubtitleStream.cpp
@@ -45,7 +45,7 @@ bool CDVDSubtitleStream::Open(const string& strFile)
 {
   CDVDInputStream* pInputStream;
   pInputStream = CDVDFactoryInputStream::CreateInputStream(NULL, strFile, "");
-  if (pInputStream && pInputStream->Open(strFile.c_str(), ""))
+  if (pInputStream && pInputStream->Open(strFile.c_str(), "", false))
   {
     if (URIUtils::HasExtension(strFile, ".sub") && IsIncompatible(pInputStream))
     {

--- a/xbmc/cores/paplayer/DVDPlayerCodec.cpp
+++ b/xbmc/cores/paplayer/DVDPlayerCodec.cpp
@@ -87,7 +87,9 @@ bool DVDPlayerCodec::Init(const std::string &strFile, unsigned int filecache)
     return false;
   }
 
-  if (!m_pInputStream->Open(strFileToOpen.c_str(), m_strContentType))
+  // TODO:
+  // convey CFileItem::ContentLookup() into Open()
+  if (!m_pInputStream->Open(strFileToOpen.c_str(), m_strContentType, true))
   {
     CLog::Log(LOGERROR, "%s: Error opening file %s", __FUNCTION__, strFileToOpen.c_str());
     if (m_pInputStream)

--- a/xbmc/storage/MediaManager.cpp
+++ b/xbmc/storage/MediaManager.cpp
@@ -539,7 +539,7 @@ std::string CMediaManager::GetDiskUniqueId(const std::string& devicePath)
 
 
   CDVDInputStreamNavigator dvdNavigator(NULL);
-  dvdNavigator.Open(pathVideoTS.c_str(), "");
+  dvdNavigator.Open(pathVideoTS.c_str(), "", true);
   std::string labelString;
   dvdNavigator.GetDVDTitleString(labelString);
   std::string serialString;


### PR DESCRIPTION
This provides a means to instruct dvdplayer not to request HTTP header. dvdplayer clients pass a fileitem to dvdplayer::OpenFile. dvdplayer will use the information provided by fileItem (CFileItem::ContentLookup() ) to decode if further header requests will be done.
