### PR TITLE
[guilib] DialogKeyboard: Do not register input for buttons with id >= 500

### DIFF
--- a/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
+++ b/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
@@ -313,7 +313,8 @@ void CGUIDialogKeyboardGeneric::OnClickButton(int iButtonControl)
   else
   {
     const CGUIControl* pButton = GetControl(iButtonControl);
-    if (pButton)
+    // Do not register input for buttons with id >= 500
+    if (pButton && iButtonControl < 500)
     {
       Character(pButton->GetDescription());
       // reset the shift keys


### PR DESCRIPTION
Allows to add custom buttons to Keyboard dialog without sending input on each button press. (atm any custom button will add its label to the input label when clickin on it)
@ronie, @mkortstiege    
