### PR TITLE
ffmpeg: bump version (use branch release/2.6-xbmc)

### DIFF
--- a/tools/depends/target/ffmpeg/FFMPEG-VERSION
+++ b/tools/depends/target/ffmpeg/FFMPEG-VERSION
@@ -1,5 +1,5 @@
 LIBNAME=ffmpeg
 BASE_URL=https://github.com/xbmc/FFmpeg/archive
-VERSION=2.6.2-Isengard-beta
+VERSION=2.6.3-Isengard-rc
 ARCHIVE=$(LIBNAME)-$(VERSION).tar.gz
 


### PR DESCRIPTION
This bumps our internal ffmpeg. Rebased our patches onto: https://github.com/FFmpeg/FFmpeg/tree/release/2.6 

The branch approach was cherry-picked from fernetmenta and changed to match our infrastructure.
