### PR TITLE
Ffmpeg bump 27 master

### DIFF
--- a/tools/depends/target/ffmpeg/FFMPEG-VERSION
+++ b/tools/depends/target/ffmpeg/FFMPEG-VERSION
@@ -1,5 +1,5 @@
 LIBNAME=ffmpeg
 BASE_URL=https://github.com/xbmc/FFmpeg/archive
-VERSION=2.6.2-Isengard-beta
+VERSION=2.7.1-JUnknown-alpha
 ARCHIVE=$(LIBNAME)-$(VERSION).tar.gz
 

--- a/tools/depends/target/ffmpeg/Makefile
+++ b/tools/depends/target/ffmpeg/Makefile
@@ -45,6 +45,7 @@ ifeq ($(OS), osx)
   ffmpg_config += --disable-outdev=sdl
   ffmpg_config += --disable-decoder=mpeg_xvmc --enable-vda --disable-crystalhd
   ffmpg_config += --target-os=darwin
+  ffmpg_config += --disable-securetransport
 endif
 ifeq ($(findstring arm, $(CPU)), arm)
   ffmpg_config += --enable-pic --disable-armv5te --disable-armv6t2


### PR DESCRIPTION
This needs rebasing (after) 2.6 branch version is in master and backported to v15.

Then we can bump master to 2.7.
