### PR TITLE
FFmpeg: Bump to 2.6.3-Isengard-rc

### DIFF
--- a/tools/depends/target/ffmpeg/FFMPEG-VERSION
+++ b/tools/depends/target/ffmpeg/FFMPEG-VERSION
@@ -1,5 +1,5 @@
 LIBNAME=ffmpeg
 BASE_URL=https://github.com/xbmc/FFmpeg/archive
-VERSION=2.6.2-Isengard-beta
+VERSION=2.6.3-Isengard-rc
 ARCHIVE=$(LIBNAME)-$(VERSION).tar.gz
 


### PR DESCRIPTION
Isengard pick from: https://github.com/xbmc/xbmc/pull/7414

OpenELEC ships 2.6.3 since a longer time and it's only a stable upgrade with fixes that the ffmpeg people pulled into their 2.6 branch.
