### PR TITLE
[smartplaylist] fix musicvideo grouping by artist

### DIFF
--- a/xbmc/filesystem/SmartPlaylistDirectory.cpp
+++ b/xbmc/filesystem/SmartPlaylistDirectory.cpp
@@ -76,7 +76,7 @@ namespace XFILE
     items.SetSortIgnoreFolders((sorting.sortAttributes & SortAttributeIgnoreFolders) == SortAttributeIgnoreFolders);
 
     std::string option = !filter ? "xsp" : "filter";
-    const std::string& group = playlist.GetGroup();
+    std::string group = playlist.GetGroup();
     bool isGrouped = !group.empty() && !StringUtils::EqualsNoCase(group, "none") && !playlist.IsGroupMixed();
 
     // get all virtual folders and add them to the item list
@@ -232,6 +232,15 @@ namespace XFILE
         CVideoDbUrl videoUrl;
         if (!videoUrl.FromString(baseDir))
           return false;
+
+        // adjust the group in case we're retrieving a grouped playlist
+        // based on artists. This is needed because the video library
+        // is using the actorslink table for artists.
+        if (isGrouped && group == "artists")
+        {
+          group = "actors";
+          mvidPlaylist.SetGroup(group);
+        }
 
         // store the smartplaylist as JSON in the URL as well
         std::string xsp;

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -5953,8 +5953,6 @@ bool CVideoDatabase::GetItems(const std::string &strBaseDir, VIDEODB_CONTENT_TYP
     return GetCountriesNav(strBaseDir, items, mediaType, filter);
   else if (StringUtils::EqualsNoCase(itemType, "tags"))
     return GetTagsNav(strBaseDir, items, mediaType, filter);
-  else if (StringUtils::EqualsNoCase(itemType, "artists") && mediaType == VIDEODB_CONTENT_MUSICVIDEOS)
-    return GetActorsNav(strBaseDir, items, mediaType, filter);
   else if (StringUtils::EqualsNoCase(itemType, "albums") && mediaType == VIDEODB_CONTENT_MUSICVIDEOS)
     return GetMusicVideoAlbumsNav(strBaseDir, items, -1, filter);
 


### PR DESCRIPTION
This adjusts the playlists group type in case we're retrieving a grouped smartplaylist based on artists. This is needed because the video library is using the actorslink table for artists now. Currently we're returning a completely unfiltered list provided by `GetActorsNav()`.

The second commit is pure cosmetic and removes old/obsolete code.

@Montellese, as discussed i went the re-write route in SmartPlayList.cpp. I think it's less error prone.

Reported in http://forum.kodi.tv/showthread.php?tid=231171&pid=2044997#pid2044997
