### PR TITLE
[EPG] On EPG update, respect current epg grid viewport, do not blindly go to 'now'.

### DIFF
--- a/xbmc/epg/GUIEPGGridContainer.cpp
+++ b/xbmc/epg/GUIEPGGridContainer.cpp
@@ -944,7 +944,13 @@ void CGUIEPGGridContainer::UpdateItems()
     SetBlock(GetBlock(m_item->item, m_channelCursor));
 
   SetInvalid();
-  GoToNow();
+
+  // On initial update, go to "now", to the current block offset otherwise.
+  // (Do not jump away from the position the user currently might have selected.)
+  if (m_blockOffset == 0)
+    GoToNow();
+  else
+    ScrollToBlockOffset(m_blockOffset);
 }
 
 void CGUIEPGGridContainer::ChannelScroll(int amount)


### PR DESCRIPTION
"Everytime" I scrolled somewhere in the EPG grid more than (roughly) one or two hours in the future, sooner or later the view port of the grid was suddenly reset in a way that the currently playing events got visible and the events I was currently looking at vanished from view port. Very annoying behavior! As I get many EPG updates, this bug made the EPG grid almost unusable for me when it came to select something in the future to set up a new timer, for instance.

I suggest to backport this to Isengard as well.

@xhaggi what do you think?
