### PR TITLE
[backport] CPeripherals: update CGUIDialogPeripheralManager asynchronously to avoid deadlocks

### DIFF
--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -312,15 +312,7 @@ CPeripheral *CPeripherals::CreatePeripheral(CPeripheralBus &bus, const Periphera
 
 void CPeripherals::OnDeviceAdded(const CPeripheralBus &bus, const CPeripheral &peripheral)
 {
-  CGUIDialogPeripheralManager *dialog = (CGUIDialogPeripheralManager *)g_windowManager.GetWindow(WINDOW_DIALOG_PERIPHERAL_MANAGER);
-  if (dialog && dialog->IsActive())
-    dialog->Update();
-
-  // refresh settings (peripherals manager could be enabled now)
-  CGUIMessage msg(GUI_MSG_UPDATE, WINDOW_SETTINGS_SYSTEM, 0);
-  g_windowManager.SendThreadMessage(msg, WINDOW_SETTINGS_SYSTEM);
-
-  SetChanged();
+  OnDeviceChanged();
 
   // don't show a notification for devices detected during the initial scan
   if (bus.IsInitialised())
@@ -329,17 +321,22 @@ void CPeripherals::OnDeviceAdded(const CPeripheralBus &bus, const CPeripheral &p
 
 void CPeripherals::OnDeviceDeleted(const CPeripheralBus &bus, const CPeripheral &peripheral)
 {
-  CGUIDialogPeripheralManager *dialog = (CGUIDialogPeripheralManager *)g_windowManager.GetWindow(WINDOW_DIALOG_PERIPHERAL_MANAGER);
-  if (dialog && dialog->IsActive())
-    dialog->Update();
-
-  // refresh settings (peripherals manager could be disabled now)
-  CGUIMessage msg(GUI_MSG_UPDATE, WINDOW_SETTINGS_SYSTEM, 0);
-  g_windowManager.SendThreadMessage(msg, WINDOW_SETTINGS_SYSTEM);
-
-  SetChanged();
+  OnDeviceChanged();
 
   CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(35006), peripheral.DeviceName());
+}
+
+void CPeripherals::OnDeviceChanged()
+{
+  // refresh peripherals manager
+  CGUIMessage msgManager(GUI_MSG_UPDATE, WINDOW_DIALOG_PERIPHERAL_MANAGER, 0);
+  g_windowManager.SendThreadMessage(msgManager, WINDOW_DIALOG_PERIPHERAL_MANAGER);
+
+  // refresh settings (peripherals manager could be enabled/disabled now)
+  CGUIMessage msgSettings(GUI_MSG_UPDATE, WINDOW_SETTINGS_SYSTEM, 0);
+  g_windowManager.SendThreadMessage(msgSettings, WINDOW_SETTINGS_SYSTEM);
+
+  SetChanged();
 }
 
 bool CPeripherals::GetMappingForDevice(const CPeripheralBus &bus, PeripheralScanResult& result) const

--- a/xbmc/peripherals/Peripherals.h
+++ b/xbmc/peripherals/Peripherals.h
@@ -216,6 +216,8 @@ namespace PERIPHERALS
     bool GetMappingForDevice(const CPeripheralBus &bus, PeripheralScanResult& result) const;
     static void GetSettingsFromMappingsFile(TiXmlElement *xmlNode, std::map<std::string, PeripheralDeviceSetting> &m_settings);
 
+    void OnDeviceChanged();
+
     bool                                 m_bInitialised;
     bool                                 m_bIsStarted;
 #if !defined(HAVE_LIBCEC)

--- a/xbmc/peripherals/dialogs/GUIDialogPeripheralManager.cpp
+++ b/xbmc/peripherals/dialogs/GUIDialogPeripheralManager.cpp
@@ -19,11 +19,12 @@
  */
 
 #include "GUIDialogPeripheralManager.h"
-#include "GUIDialogPeripheralSettings.h"
-#include "guilib/GUIWindowManager.h"
-#include "peripherals/Peripherals.h"
 #include "FileItem.h"
+#include "GUIUserMessages.h"
+#include "guilib/GUIWindowManager.h"
 #include "input/Key.h"
+#include "peripherals/Peripherals.h"
+#include "peripherals/dialogs/GUIDialogPeripheralSettings.h"
 
 #define BUTTON_CLOSE     10
 #define BUTTON_SETTINGS  11
@@ -131,6 +132,13 @@ bool CGUIDialogPeripheralManager::OnMessage(CGUIMessage& message)
       return true;
     case GUI_MSG_CLICKED:
       return OnMessageClick(message);
+    case GUI_MSG_UPDATE:
+      if (IsActive())
+      {
+        Update();
+        return true;
+      }
+      break;
   }
 
   return CGUIDialog::OnMessage(message);


### PR DESCRIPTION
Backport of #7422 for Isengard.
