### PR TITLE
[gui] refactors modality handling for dialogs

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1724,7 +1724,8 @@ bool CApplication::LoadSkin(const SkinPtr& skin)
     for (unsigned int i = 0; i < currentModelessWindows.size(); i++)
     {
       CGUIDialog *dialog = (CGUIDialog *)g_windowManager.GetWindow(currentModelessWindows[i]);
-      if (dialog) dialog->Show();
+      if (dialog)
+        dialog->Open();
     }
     if (iCtrlID != -1)
     {
@@ -2494,7 +2495,7 @@ void CApplication::FrameMove(bool processEvents, bool processGUI)
       {
         if (!toast->IsDialogRunning())
         {
-          toast->Show();
+          toast->Open();
         }
       }
       g_graphicsContext.Unlock();
@@ -4448,7 +4449,7 @@ void CApplication::ShowVolumeBar(const CAction *action)
   CGUIDialog *volumeBar = (CGUIDialog *)g_windowManager.GetWindow(WINDOW_DIALOG_VOLUME_BAR);
   if (volumeBar)
   {
-    volumeBar->Show();
+    volumeBar->Open();
     if (action)
       volumeBar->OnAction(*action);
   }

--- a/xbmc/ApplicationMessenger.cpp
+++ b/xbmc/ApplicationMessenger.cpp
@@ -176,7 +176,7 @@ void CApplicationMessenger::SendMessage(ThreadMessage& message, bool wait)
   msg->strParam = message.strParam;
   msg->params = message.params;
 
-  if (msg->dwMessage == TMSG_DIALOG_DOMODAL)
+  if (msg->dwMessage == TMSG_GUI_DIALOG_OPEN)
     m_vecWindowMessages.push(msg);
   else
     m_vecMessages.push(msg);
@@ -673,33 +673,17 @@ void CApplicationMessenger::ProcessMessage(ThreadMessage *pMsg)
       break;
 
     // Window messages below here...
-    case TMSG_DIALOG_DOMODAL:  //doModel of window
-      {
-        CGUIDialog* pDialog = (CGUIDialog*)g_windowManager.GetWindow(pMsg->param1);
-        if (!pDialog) return ;
-        pDialog->DoModal();
-      }
-      break;
-
     case TMSG_NETWORKMESSAGE:
       {
         g_application.getNetwork().NetworkMessage((CNetwork::EMESSAGE)pMsg->param1, pMsg->param2);
       }
       break;
 
-    case TMSG_GUI_DO_MODAL:
+    case TMSG_GUI_DIALOG_OPEN:
       {
         CGUIDialog *pDialog = (CGUIDialog *)pMsg->lpVoid;
         if (pDialog)
-          pDialog->DoModal(pMsg->param1, pMsg->strParam);
-      }
-      break;
-
-    case TMSG_GUI_SHOW:
-      {
-        CGUIDialog *pDialog = (CGUIDialog *)pMsg->lpVoid;
-        if (pDialog)
-          pDialog->Show();
+          pDialog->Open();
       }
       break;
 
@@ -1226,15 +1210,6 @@ void CApplicationMessenger::Minimize(bool wait)
   SendMessage(tMsg, wait);
 }
 
-void CApplicationMessenger::DoModal(CGUIDialog *pDialog, int iWindowID, const std::string &param)
-{
-  ThreadMessage tMsg = {TMSG_GUI_DO_MODAL};
-  tMsg.lpVoid = pDialog;
-  tMsg.param1 = iWindowID;
-  tMsg.strParam = param;
-  SendMessage(tMsg, true);
-}
-
 void CApplicationMessenger::ExecOS(const std::string &command, bool waitExit)
 {
   ThreadMessage tMsg = {TMSG_EXECUTE_OS};
@@ -1249,12 +1224,13 @@ void CApplicationMessenger::UserEvent(int code)
   SendMessage(tMsg, false);
 }
 
-void CApplicationMessenger::Show(CGUIDialog *pDialog)
+void CApplicationMessenger::Open(CGUIDialog *pDialog)
 {
-  ThreadMessage tMsg = {TMSG_GUI_SHOW};
+  ThreadMessage tMsg = {TMSG_GUI_DIALOG_OPEN};
   tMsg.lpVoid = pDialog;
   SendMessage(tMsg, true);
 }
+
 
 void CApplicationMessenger::Close(CGUIWindow *window, bool forceClose, bool waitResult /*= true*/, int nextWindowID /*= 0*/, bool enableSound /*= true*/)
 {

--- a/xbmc/ApplicationMessenger.h
+++ b/xbmc/ApplicationMessenger.h
@@ -41,7 +41,6 @@ namespace MUSIC_INFO
 }
 
 // defines here
-#define TMSG_DIALOG_DOMODAL       100
 #define TMSG_EXECUTE_SCRIPT       102
 #define TMSG_EXECUTE_BUILT_IN     103
 #define TMSG_EXECUTE_OS           104
@@ -96,8 +95,7 @@ namespace MUSIC_INFO
 
 #define TMSG_NETWORKMESSAGE         500
 
-#define TMSG_GUI_DO_MODAL             600
-#define TMSG_GUI_SHOW                 601
+#define TMSG_GUI_DIALOG_OPEN          600
 #define TMSG_GUI_ACTIVATE_WINDOW      604
 #define TMSG_GUI_PYTHON_DIALOG        605
 #define TMSG_GUI_WINDOW_CLOSE         606
@@ -229,8 +227,7 @@ public:
 
   void NetworkMessage(int dwMessage, int dwParam = 0);
 
-  void DoModal(CGUIDialog *pDialog, int iWindowID, const std::string &param = "");
-  void Show(CGUIDialog *pDialog);
+  void Open(CGUIDialog *pDialog);
   void Close(CGUIWindow *window, bool forceClose, bool waitResult = true, int nextWindowID = 0, bool enableSound = true);
   void ActivateWindow(int windowID, const std::vector<std::string> &params, bool swappingWindows, bool force = false);
   void SendAction(const CAction &action, int windowID = WINDOW_INVALID, bool waitResult=true);

--- a/xbmc/PartyModeManager.cpp
+++ b/xbmc/PartyModeManager.cpp
@@ -105,7 +105,7 @@ bool CPartyModeManager::Enable(PartyModeContext context /*= PARTYMODECONTEXT_MUS
   pDialog->SetLine(0, CVariant{iLine0});
   pDialog->SetLine(1, CVariant{""});
   pDialog->SetLine(2, CVariant{""});
-  pDialog->StartModal();
+  pDialog->Open();
 
   ClearState();
   unsigned int time = XbmcThreads::SystemClockMillis();

--- a/xbmc/addons/AddonCallbacksGUI.cpp
+++ b/xbmc/addons/AddonCallbacksGUI.cpp
@@ -1883,7 +1883,7 @@ void CAddonCallbacksGUI::Dialog_TextViewer(const char *heading, const char *text
   CGUIDialogTextViewer* pDialog = (CGUIDialogTextViewer*)g_windowManager.GetWindow(WINDOW_DIALOG_TEXT_VIEWER);
   pDialog->SetHeading(heading);
   pDialog->SetText(text);
-  pDialog->DoModal();
+  pDialog->Open();
 }
 //@}
 
@@ -1901,7 +1901,7 @@ int CAddonCallbacksGUI::Dialog_Select(const char *heading, const char *entries[]
   if (selected > 0)
     pDialog->SetSelected(selected);
 
-  pDialog->DoModal();
+  pDialog->Open();
   return pDialog->GetSelectedLabel();
 }
 //@}

--- a/xbmc/addons/AddonStatusHandler.cpp
+++ b/xbmc/addons/AddonStatusHandler.cpp
@@ -102,10 +102,7 @@ void CAddonStatusHandler::Process()
       pDialog->SetHeading(CVariant{heading});
       pDialog->SetLine(1, CVariant{24070});
       pDialog->SetLine(2, CVariant{24073});
-
-      //send message and wait for user input
-      ThreadMessage tMsg = {TMSG_DIALOG_DOMODAL, WINDOW_DIALOG_YES_NO, g_windowManager.GetActiveWindow()};
-      CApplicationMessenger::Get().SendMessage(tMsg, true);
+      pDialog->Open();
 
       if (pDialog->IsConfirmed())
         CAddonMgr::Get().GetCallbackForType(m_addon->Type())->RequestRestart(m_addon, false);
@@ -119,10 +116,7 @@ void CAddonStatusHandler::Process()
 
     pDialog->SetHeading(CVariant{heading});
     pDialog->SetLine(1, CVariant{24074});
-
-    //send message and wait for user input
-    ThreadMessage tMsg = {TMSG_DIALOG_DOMODAL, WINDOW_DIALOG_OK, g_windowManager.GetActiveWindow()};
-    CApplicationMessenger::Get().SendMessage(tMsg, true);
+    pDialog->Open();
 
     CAddonMgr::Get().GetCallbackForType(m_addon->Type())->RequestRestart(m_addon, true);
   }
@@ -136,10 +130,7 @@ void CAddonStatusHandler::Process()
     pDialogYesNo->SetLine(1, CVariant{24070});
     pDialogYesNo->SetLine(2, CVariant{24072});
     pDialogYesNo->SetLine(3, CVariant{m_message});
-
-    //send message and wait for user input
-    ThreadMessage tMsg = {TMSG_DIALOG_DOMODAL, WINDOW_DIALOG_YES_NO, g_windowManager.GetActiveWindow()};
-    CApplicationMessenger::Get().SendMessage(tMsg, true);
+    pDialogYesNo->Open();
 
     if (!pDialogYesNo->IsConfirmed()) return;
 
@@ -163,10 +154,7 @@ void CAddonStatusHandler::Process()
     pDialog->SetLine(1, CVariant{24070});
     pDialog->SetLine(2, CVariant{24071});
     pDialog->SetLine(3, CVariant{m_message});
-
-    //send message and wait for user input
-    ThreadMessage tMsg = {TMSG_DIALOG_DOMODAL, WINDOW_DIALOG_OK, g_windowManager.GetActiveWindow()};
-    CApplicationMessenger::Get().SendMessage(tMsg, true);
+    pDialog->Open();
   }
 }
 

--- a/xbmc/addons/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/GUIDialogAddonInfo.cpp
@@ -300,7 +300,7 @@ void CGUIDialogAddonInfo::OnChangeLog()
     pDlgInfo->SetText(m_item->GetProperty("Addon.Changelog").asString());
 
   m_changelog = true;
-  pDlgInfo->DoModal();
+  pDlgInfo->Open();
   m_changelog = false;
 }
 
@@ -352,7 +352,7 @@ bool CGUIDialogAddonInfo::ShowForItem(const CFileItemPtr& item)
   if (!dialog->SetItem(item))
     return false;
 
-  dialog->DoModal(); 
+  dialog->Open(); 
   return true;
 }
 

--- a/xbmc/addons/GUIDialogAddonSettings.cpp
+++ b/xbmc/addons/GUIDialogAddonSettings.cpp
@@ -214,7 +214,7 @@ bool CGUIDialogAddonSettings::ShowAndGetInput(const AddonPtr &addon, bool saveTo
 
     pDialog->m_addon = addon;
     pDialog->m_saveToDisk = saveToDisk;
-    pDialog->DoModal();
+    pDialog->Open();
     ret = true;
   }
   else
@@ -336,7 +336,7 @@ bool CGUIDialogAddonSettings::ShowVirtualKeyboard(int iControl)
               if (selected == (int)i || (selected < 0 && StringUtils::EqualsNoCase(valuesVec[i], value)))
                 pDlg->SetSelected(i); // FIXME: the SetSelected() does not select "i", it always defaults to the first position
             }
-            pDlg->DoModal();
+            pDlg->Open();
             int iSelected = pDlg->GetSelectedLabel();
             if (iSelected >= 0)
             {

--- a/xbmc/addons/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/GUIWindowAddonBrowser.cpp
@@ -602,7 +602,7 @@ int CGUIWindowAddonBrowser::SelectAddonID(const vector<ADDON::TYPE> &types, vect
   }
   dialog->SetItems(&items);
   dialog->SetMultiSelection(multipleSelection);
-  dialog->DoModal();
+  dialog->Open();
 
   // if the "Get More" button has been pressed and we haven't shown the
   // installable addons so far show a list of installable addons

--- a/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
+++ b/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
@@ -345,7 +345,8 @@ void CExternalPlayer::Process()
       m_dialog->SetLine(3, CVariant{23106});
     }
 
-    if (!m_bAbortRequest) m_dialog->DoModal();
+    if (!m_bAbortRequest)
+      m_dialog->Open();
   }
 
   m_bIsPlaying = false;

--- a/xbmc/dialogs/GUIDialogBusy.cpp
+++ b/xbmc/dialogs/GUIDialogBusy.cpp
@@ -86,7 +86,7 @@ bool CGUIDialogBusy::WaitOnEvent(CEvent &event, unsigned int displaytime /* = 10
 }
 
 CGUIDialogBusy::CGUIDialogBusy(void)
-  : CGUIDialog(WINDOW_DIALOG_BUSY, "DialogBusy.xml", DialogModalityType::SYSTEM_MODAL),
+  : CGUIDialog(WINDOW_DIALOG_BUSY, "DialogBusy.xml", DialogModalityType::PARENTLESS_MODAL),
     m_bLastVisible(false)
 {
   m_loadType = LOAD_ON_GUI_INIT;

--- a/xbmc/dialogs/GUIDialogBusy.cpp
+++ b/xbmc/dialogs/GUIDialogBusy.cpp
@@ -67,7 +67,8 @@ bool CGUIDialogBusy::WaitOnEvent(CEvent &event, unsigned int displaytime /* = 10
     CGUIDialogBusy* dialog = (CGUIDialogBusy*)g_windowManager.GetWindow(WINDOW_DIALOG_BUSY);
     if (dialog)
     {
-      dialog->Show();
+      dialog->Open();
+
       while(!event.WaitMSec(1))
       {
         g_windowManager.ProcessRenderLoop(false);
@@ -77,6 +78,7 @@ bool CGUIDialogBusy::WaitOnEvent(CEvent &event, unsigned int displaytime /* = 10
           break;
         }
       }
+      
       dialog->Close();
     }
   }
@@ -84,10 +86,10 @@ bool CGUIDialogBusy::WaitOnEvent(CEvent &event, unsigned int displaytime /* = 10
 }
 
 CGUIDialogBusy::CGUIDialogBusy(void)
-  : CGUIDialog(WINDOW_DIALOG_BUSY, "DialogBusy.xml"), m_bLastVisible(false)
+  : CGUIDialog(WINDOW_DIALOG_BUSY, "DialogBusy.xml", DialogModalityType::SYSTEM_MODAL),
+    m_bLastVisible(false)
 {
   m_loadType = LOAD_ON_GUI_INIT;
-  m_modalityType = DialogModalityType::SYSTEM_MODAL;
   m_bCanceled = false;
   m_progress = 0;
 }
@@ -96,20 +98,15 @@ CGUIDialogBusy::~CGUIDialogBusy(void)
 {
 }
 
-void CGUIDialogBusy::Show_Internal()
+void CGUIDialogBusy::Open_Internal()
 {
   m_bCanceled = false;
-  m_active = true;
-  m_modalityType = DialogModalityType::SYSTEM_MODAL;
   m_bLastVisible = true;
-  m_closing = false;
   m_progress = 0;
-  g_windowManager.RegisterDialog(this);
 
-  // active this window...
-  CGUIMessage msg(GUI_MSG_WINDOW_INIT, 0, 0);
-  OnMessage(msg);
+  CGUIDialog::Open_Internal(false);
 }
+
 
 void CGUIDialogBusy::DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {

--- a/xbmc/dialogs/GUIDialogBusy.h
+++ b/xbmc/dialogs/GUIDialogBusy.h
@@ -57,7 +57,7 @@ public:
    */
   static bool WaitOnEvent(CEvent &event, unsigned int timeout = 100, bool allowCancel = true);
 protected:
-  virtual void Show_Internal(); // modeless'ish
+  virtual void Open_Internal();
   bool m_bCanceled;
   bool m_bLastVisible;
   float m_progress; ///< current progress

--- a/xbmc/dialogs/GUIDialogCache.cpp
+++ b/xbmc/dialogs/GUIDialogCache.cpp
@@ -81,7 +81,7 @@ void CGUIDialogCache::OpenDialog()
       m_pDlg->SetHeading(CVariant{m_strHeader});
 
     m_pDlg->SetLine(2, CVariant{m_strLinePrev});
-    m_pDlg->StartModal();
+    m_pDlg->Open();
   }
   bSentCancel = false;
 }

--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -684,7 +684,7 @@ int CGUIDialogContextMenu::ShowAndGetChoice(const CContextButtons &choices)
     pMenu->SetInitialVisibility();
     pMenu->SetupButtons();
     pMenu->PositionAtCurrentFocus();
-    pMenu->DoModal();
+    pMenu->Open();
     return pMenu->m_clickedButton;
   }
   return -1;

--- a/xbmc/dialogs/GUIDialogExtendedProgressBar.cpp
+++ b/xbmc/dialogs/GUIDialogExtendedProgressBar.cpp
@@ -59,7 +59,7 @@ void CGUIDialogProgressBarHandle::SetProgress(int currentItem, int itemCount)
 }
 
 CGUIDialogExtendedProgressBar::CGUIDialogExtendedProgressBar(void)
-  : CGUIDialog(WINDOW_DIALOG_EXT_PROGRESS, "DialogExtendedProgressBar.xml")
+  : CGUIDialog(WINDOW_DIALOG_EXT_PROGRESS, "DialogExtendedProgressBar.xml", DialogModalityType::MODELESS)
 {
   m_loadType        = LOAD_ON_GUI_INIT;
   m_iLastSwitchTime = 0;
@@ -74,7 +74,7 @@ CGUIDialogProgressBarHandle *CGUIDialogExtendedProgressBar::GetHandle(const stri
     m_handles.push_back(handle);
   }
 
-  Show();
+  Open();
 
   return handle;
 }

--- a/xbmc/dialogs/GUIDialogFileBrowser.cpp
+++ b/xbmc/dialogs/GUIDialogFileBrowser.cpp
@@ -629,7 +629,7 @@ bool CGUIDialogFileBrowser::ShowAndGetImage(const CFileItemList &items, const VE
   }
   browser->SetHeading(heading);
   browser->m_flipEnabled = flip?true:false;
-  browser->DoModal();
+  browser->Open();
   bool confirmed(browser->IsConfirmed());
   if (confirmed)
   {
@@ -706,7 +706,7 @@ bool CGUIDialogFileBrowser::ShowAndGetFile(const VECSOURCES &shares, const std::
   browser->m_rootDir.SetMask(strMask);
   browser->m_selectedPath = path;
   browser->m_addNetworkShareEnabled = false;
-  browser->DoModal();
+  browser->Open();
   bool confirmed(browser->IsConfirmed());
   if (confirmed)
     path = browser->m_selectedPath;
@@ -762,7 +762,7 @@ bool CGUIDialogFileBrowser::ShowAndGetFile(const std::string &directory, const s
   browser->m_rootDir.SetMask(strMask);
   browser->m_selectedPath = directory;
   browser->m_addNetworkShareEnabled = false;
-  browser->DoModal();
+  browser->Open();
   bool confirmed(browser->IsConfirmed());
   if (confirmed)
     path = browser->m_selectedPath;
@@ -795,7 +795,7 @@ bool CGUIDialogFileBrowser::ShowAndGetFileList(const VECSOURCES &shares, const s
   browser->m_browsingForFolders = 0;
   browser->m_rootDir.SetMask(mask);
   browser->m_addNetworkShareEnabled = false;
-  browser->DoModal();
+  browser->Open();
   bool confirmed(browser->IsConfirmed());
   if (confirmed)
   {
@@ -870,7 +870,7 @@ bool CGUIDialogFileBrowser::ShowAndGetSource(std::string &path, bool allowNetwor
   browser->m_browsingForFolders = 1;
   browser->m_addNetworkShareEnabled = allowNetworkShares;
   browser->m_selectedPath = "";
-  browser->DoModal();
+  browser->Open();
   bool confirmed = browser->IsConfirmed();
   if (confirmed)
     path = browser->m_selectedPath;
@@ -962,7 +962,7 @@ bool CGUIDialogFileBrowser::OnPopupMenu(int iItem)
         m_browsingForFolders = 1;
         m_addNetworkShareEnabled = true;
         m_selectedPath = newPath;
-        DoModal();
+        Open();
       }
     }
     else

--- a/xbmc/dialogs/GUIDialogGamepad.cpp
+++ b/xbmc/dialogs/GUIDialogGamepad.cpp
@@ -291,7 +291,7 @@ bool CGUIDialogGamepad::ShowAndVerifyInput(std::string& strToVerify, const std::
     pDialog->SetLine(2, CVariant{atoi(dlgLine2.c_str())});
 
   g_audioManager.Enable(false); // dont do sounds during pwd input
-  pDialog->DoModal();
+  pDialog->Open();
   g_audioManager.Enable(true);
 
   if (bGetUserInput && !pDialog->IsCanceled())

--- a/xbmc/dialogs/GUIDialogKaiToast.cpp
+++ b/xbmc/dialogs/GUIDialogKaiToast.cpp
@@ -30,7 +30,7 @@ CGUIDialogKaiToast::TOASTQUEUE CGUIDialogKaiToast::m_notifications;
 CCriticalSection CGUIDialogKaiToast::m_critical;
 
 CGUIDialogKaiToast::CGUIDialogKaiToast(void)
-: CGUIDialog(WINDOW_DIALOG_KAI_TOAST, "DialogKaiToast.xml")
+  : CGUIDialog(WINDOW_DIALOG_KAI_TOAST, "DialogKaiToast.xml", DialogModalityType::MODELESS)
 {
   m_loadType = LOAD_ON_GUI_INIT;
   m_timer = 0;

--- a/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
+++ b/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
@@ -467,9 +467,7 @@ bool CGUIDialogKeyboardGeneric::ShowAndGetInput(char_callback_t pCallback, const
   pKeyboard->SetHeading(heading);
   pKeyboard->SetHiddenInput(bHiddenInput);
   pKeyboard->SetText(initialString);
-  // do this using a thread message to avoid render() conflicts
-  ThreadMessage tMsg = {TMSG_DIALOG_DOMODAL, WINDOW_DIALOG_KEYBOARD, g_windowManager.GetActiveWindow()};
-  CApplicationMessenger::Get().SendMessage(tMsg, true);
+  pKeyboard->Open();
   pKeyboard->Close();
 
   // If have text - update this.

--- a/xbmc/dialogs/GUIDialogMediaFilter.cpp
+++ b/xbmc/dialogs/GUIDialogMediaFilter.cpp
@@ -184,7 +184,7 @@ void CGUIDialogMediaFilter::ShowAndEditMediaFilter(const std::string &path, CSma
   if (!dialog->SetPath(path))
     return;
 
-  dialog->DoModal();
+  dialog->Open();
 }
 
 void CGUIDialogMediaFilter::OnWindowLoaded()

--- a/xbmc/dialogs/GUIDialogMediaSource.cpp
+++ b/xbmc/dialogs/GUIDialogMediaSource.cpp
@@ -135,7 +135,7 @@ bool CGUIDialogMediaSource::ShowAndAddMediaSource(const std::string &type)
   dialog->Initialize();
   dialog->SetShare(CMediaSource());
   dialog->SetTypeOfMedia(type);
-  dialog->DoModal();
+  dialog->Open();
   bool confirmed(dialog->IsConfirmed());
   if (confirmed)
   { // yay, add this share
@@ -188,7 +188,7 @@ bool CGUIDialogMediaSource::ShowAndEditMediaSource(const std::string &type, cons
   dialog->Initialize();
   dialog->SetShare(share);
   dialog->SetTypeOfMedia(type, true);
-  dialog->DoModal();
+  dialog->Open();
   bool confirmed(dialog->IsConfirmed());
   if (confirmed)
   { // yay, add this share

--- a/xbmc/dialogs/GUIDialogMuteBug.cpp
+++ b/xbmc/dialogs/GUIDialogMuteBug.cpp
@@ -21,10 +21,8 @@
 #include "GUIDialogMuteBug.h"
 #include "Application.h"
 
-// the MuteBug is a true modeless dialog
-
 CGUIDialogMuteBug::CGUIDialogMuteBug(void)
-    : CGUIDialog(WINDOW_DIALOG_MUTE_BUG, "DialogMuteBug.xml")
+  : CGUIDialog(WINDOW_DIALOG_MUTE_BUG, "DialogMuteBug.xml", DialogModalityType::MODELESS)
 {
   m_loadType = LOAD_ON_GUI_INIT;
 }
@@ -35,7 +33,7 @@ CGUIDialogMuteBug::~CGUIDialogMuteBug(void)
 void CGUIDialogMuteBug::UpdateVisibility()
 {
   if (g_application.IsMuted() || g_application.GetVolume(false) <= VOLUME_MINIMUM)
-    Show();
+    Open();
   else
     Close();
 }

--- a/xbmc/dialogs/GUIDialogNumeric.cpp
+++ b/xbmc/dialogs/GUIDialogNumeric.cpp
@@ -658,7 +658,7 @@ bool CGUIDialogNumeric::ShowAndGetSeconds(std::string &timeString, const std::st
   time.wSecond = seconds - time.wHour * 3600 - time.wMinute * 60;
   pDialog->SetMode(INPUT_TIME_SECONDS, (void *)&time);
   pDialog->SetHeading(heading);
-  pDialog->DoModal();
+  pDialog->Open();
   if (!pDialog->IsConfirmed() || pDialog->IsCanceled())
     return false;
   pDialog->GetOutput(&time);
@@ -673,7 +673,7 @@ bool CGUIDialogNumeric::ShowAndGetTime(SYSTEMTIME &time, const std::string &head
   if (!pDialog) return false;
   pDialog->SetMode(INPUT_TIME, (void *)&time);
   pDialog->SetHeading(heading);
-  pDialog->DoModal();
+  pDialog->Open();
   if (!pDialog->IsConfirmed() || pDialog->IsCanceled())
     return false;
   pDialog->GetOutput(&time);
@@ -686,7 +686,7 @@ bool CGUIDialogNumeric::ShowAndGetDate(SYSTEMTIME &date, const std::string &head
   if (!pDialog) return false;
   pDialog->SetMode(INPUT_DATE, (void *)&date);
   pDialog->SetHeading(heading);
-  pDialog->DoModal();
+  pDialog->Open();
   if (!pDialog->IsConfirmed() || pDialog->IsCanceled())
     return false;
   pDialog->GetOutput(&date);
@@ -699,7 +699,7 @@ bool CGUIDialogNumeric::ShowAndGetIPAddress(std::string &IPAddress, const std::s
   if (!pDialog) return false;
   pDialog->SetMode(INPUT_IP_ADDRESS, (void *)&IPAddress);
   pDialog->SetHeading(heading);
-  pDialog->DoModal();
+  pDialog->Open();
   if (!pDialog->IsConfirmed() || pDialog->IsCanceled())
     return false;
   pDialog->GetOutput(&IPAddress);
@@ -716,7 +716,7 @@ bool CGUIDialogNumeric::ShowAndGetNumber(std::string& strInput, const std::strin
   if (iAutoCloseTimeoutMs)
     pDialog->SetAutoClose(iAutoCloseTimeoutMs);
 
-  pDialog->DoModal();
+  pDialog->Open();
 
   if (!pDialog->IsAutoClosed() && (!pDialog->IsConfirmed() || pDialog->IsCanceled()))
     return false;
@@ -791,7 +791,7 @@ bool CGUIDialogNumeric::ShowAndVerifyInput(std::string& strToVerify, const std::
   if (!bVerifyInput)
     strInput = strToVerify;
   pDialog->SetMode(INPUT_PASSWORD, (void *)&strInput);
-  pDialog->DoModal();
+  pDialog->Open();
 
   pDialog->GetOutput(&strInput);
 

--- a/xbmc/dialogs/GUIDialogOK.cpp
+++ b/xbmc/dialogs/GUIDialogOK.cpp
@@ -56,7 +56,7 @@ void CGUIDialogOK::ShowAndGetInput(CVariant heading, CVariant text)
     return;
   dialog->SetHeading(heading);
   dialog->SetText(text);
-  dialog->DoModal();
+  dialog->Open();
 }
 
 // \brief Show CGUIDialogOK dialog, then wait for user to dismiss it.
@@ -69,7 +69,7 @@ void CGUIDialogOK::ShowAndGetInput(CVariant heading, CVariant line0, CVariant li
   dialog->SetLine(0, line0);
   dialog->SetLine(1, line1);
   dialog->SetLine(2, line2);
-  dialog->DoModal();
+  dialog->Open();
 }
 
 int CGUIDialogOK::GetDefaultLabelID(int controlId) const

--- a/xbmc/dialogs/GUIDialogPlayEject.cpp
+++ b/xbmc/dialogs/GUIDialogPlayEject.cpp
@@ -129,7 +129,7 @@ bool CGUIDialogPlayEject::ShowAndGetInput(const CFileItem & item,
     pDialog->SetAutoClose(uiAutoCloseTime);
 
   // Display the dialog
-  pDialog->DoModal();
+  pDialog->Open();
 
   return pDialog->IsConfirmed();
 }

--- a/xbmc/dialogs/GUIDialogProgress.cpp
+++ b/xbmc/dialogs/GUIDialogProgress.cpp
@@ -68,7 +68,6 @@ void CGUIDialogProgress::StartModal()
   // the main rendering thread (this should really be handled via
   // a thread message though IMO)
   m_active = true;
-  m_modalityType = DialogModalityType::MODAL;
   m_closing = false;
   g_windowManager.RegisterDialog(this);
 

--- a/xbmc/dialogs/GUIDialogProgress.cpp
+++ b/xbmc/dialogs/GUIDialogProgress.cpp
@@ -56,27 +56,16 @@ void CGUIDialogProgress::SetCanCancel(bool bCanCancel)
   SetInvalid();
 }
 
-void CGUIDialogProgress::StartModal()
+void CGUIDialogProgress::Open()
 {
-  CSingleLock lock(g_graphicsContext);
-
   CLog::Log(LOGDEBUG, "DialogProgress::StartModal called %s", m_active ? "(already running)!" : "");
-  m_bCanceled = false;
 
-  // set running before it's routed, else the auto-show code
-  // could show it as well if we are in a different thread from
-  // the main rendering thread (this should really be handled via
-  // a thread message though IMO)
-  m_active = true;
-  m_closing = false;
-  g_windowManager.RegisterDialog(this);
-
-  // active this window...
-  ShowProgressBar(false);
-  CGUIMessage msg(GUI_MSG_WINDOW_INIT, 0, 0);
-  OnMessage(msg);
-
-  lock.Leave();
+  {
+    CSingleLock lock(g_graphicsContext);
+    ShowProgressBar(false);
+  }
+  
+  CGUIDialog::Open_Internal(false);
 
   while (m_active && IsAnimating(ANIM_TYPE_WINDOW_OPEN))
   {

--- a/xbmc/dialogs/GUIDialogProgress.h
+++ b/xbmc/dialogs/GUIDialogProgress.h
@@ -30,7 +30,7 @@ public:
   CGUIDialogProgress(void);
   virtual ~CGUIDialogProgress(void);
 
-  void StartModal();
+  void Open();
   virtual bool OnMessage(CGUIMessage& message);
   virtual bool OnBack(int actionID);
   virtual void OnWindowLoaded();

--- a/xbmc/dialogs/GUIDialogSeekBar.cpp
+++ b/xbmc/dialogs/GUIDialogSeekBar.cpp
@@ -27,7 +27,7 @@
 #define POPUP_SEEK_LABEL        402
 
 CGUIDialogSeekBar::CGUIDialogSeekBar(void)
-    : CGUIDialog(WINDOW_DIALOG_SEEK_BAR, "DialogSeekBar.xml")
+  : CGUIDialog(WINDOW_DIALOG_SEEK_BAR, "DialogSeekBar.xml", DialogModalityType::MODELESS)
 {
   m_loadType = LOAD_ON_GUI_INIT;    // the application class handles our resources
 }

--- a/xbmc/dialogs/GUIDialogSimpleMenu.cpp
+++ b/xbmc/dialogs/GUIDialogSimpleMenu.cpp
@@ -102,7 +102,7 @@ bool CGUIDialogSimpleMenu::ShowPlaySelection(CFileItem& item, const std::string&
     dialog->SetHeading(CVariant{25006}); // Select playback item
     dialog->SetItems(&items);
     dialog->SetUseDetails(true);
-    dialog->DoModal();
+    dialog->Open();
 
     CFileItemPtr item_new = dialog->GetSelectedItem();
     if (!item_new || dialog->GetSelectedLabel() < 0)

--- a/xbmc/dialogs/GUIDialogSlider.cpp
+++ b/xbmc/dialogs/GUIDialogSlider.cpp
@@ -111,7 +111,7 @@ void CGUIDialogSlider::ShowAndGetInput(const std::string &label, float value, fl
   // set the label and value
   slider->Initialize();
   slider->SetSlider(label, value, min, delta, max, callback, callbackData);
-  slider->DoModal();
+  slider->Open();
 }
 
 void CGUIDialogSlider::Display(int label, float value, float min, float delta, float max, ISliderCallback *callback)
@@ -125,5 +125,5 @@ void CGUIDialogSlider::Display(int label, float value, float min, float delta, f
   slider->Initialize();
   slider->SetAutoClose(1000);
   slider->SetSlider(g_localizeStrings.Get(label), value, min, delta, max, callback, NULL);
-  slider->Show();
+  slider->Open();
 }

--- a/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
@@ -561,7 +561,7 @@ bool CGUIDialogSmartPlaylistEditor::NewPlaylist(const std::string &type)
   editor->m_playlist = CSmartPlaylist();
   editor->m_mode = type;
   editor->Initialize();
-  editor->DoModal(g_windowManager.GetActiveWindow());
+  editor->Open();
   return !editor->m_cancelled;
 }
 
@@ -589,6 +589,6 @@ bool CGUIDialogSmartPlaylistEditor::EditPlaylist(const std::string &path, const 
   editor->m_playlist = playlist;
   editor->m_path = path;
   editor->Initialize();
-  editor->DoModal(g_windowManager.GetActiveWindow());
+  editor->Open();
   return !editor->m_cancelled;
 }

--- a/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
@@ -353,7 +353,7 @@ void CGUIDialogSmartPlaylistRule::OnBrowse()
   if (!m_rule.m_parameter.empty())
     pDialog->SetSelected(m_rule.m_parameter);
 
-  pDialog->DoModal();
+  pDialog->Open();
   if (pDialog->IsConfirmed())
   {
     const CFileItemList &items = pDialog->GetSelectedItems();
@@ -532,7 +532,7 @@ bool CGUIDialogSmartPlaylistRule::EditRule(CSmartPlaylistRule &rule, const std::
 
   editor->m_rule = rule;
   editor->m_type = type;
-  editor->DoModal(g_windowManager.GetActiveWindow());
+  editor->Open();
   rule = editor->m_rule;
   return !editor->m_cancelled;
 }

--- a/xbmc/dialogs/GUIDialogVolumeBar.cpp
+++ b/xbmc/dialogs/GUIDialogVolumeBar.cpp
@@ -24,7 +24,7 @@
 #define VOLUME_BAR_DISPLAY_TIME 1000L
 
 CGUIDialogVolumeBar::CGUIDialogVolumeBar(void)
-    : CGUIDialog(WINDOW_DIALOG_VOLUME_BAR, "DialogVolumeBar.xml")
+  : CGUIDialog(WINDOW_DIALOG_VOLUME_BAR, "DialogVolumeBar.xml", DialogModalityType::MODELESS)
 {
   m_loadType = LOAD_ON_GUI_INIT;
   SetAutoClose(VOLUME_BAR_DISPLAY_TIME);

--- a/xbmc/dialogs/GUIDialogYesNo.cpp
+++ b/xbmc/dialogs/GUIDialogYesNo.cpp
@@ -98,7 +98,7 @@ bool CGUIDialogYesNo::ShowAndGetInput(CVariant heading, CVariant line0, CVariant
   dialog->SetChoice(0, !noLabel.empty() ? noLabel : 106);
   dialog->SetChoice(1, !yesLabel.empty() ? yesLabel : 107);
   dialog->m_bCanceled = false;
-  dialog->DoModal();
+  dialog->Open();
 
   bCanceled = dialog->m_bCanceled;
   return (dialog->IsConfirmed()) ? true : false;
@@ -123,7 +123,7 @@ bool CGUIDialogYesNo::ShowAndGetInput(CVariant heading, CVariant text, bool &bCa
   dialog->m_bCanceled = false;
   dialog->SetChoice(0, !noLabel.empty() ? noLabel : 106);
   dialog->SetChoice(1, !yesLabel.empty() ? yesLabel : 107);
-  dialog->DoModal();
+  dialog->Open();
 
   bCanceled = dialog->m_bCanceled;
   return (dialog->IsConfirmed()) ? true : false;

--- a/xbmc/filesystem/MultiPathDirectory.cpp
+++ b/xbmc/filesystem/MultiPathDirectory.cpp
@@ -71,7 +71,7 @@ bool CMultiPathDirectory::GetDirectory(const CURL& url, CFileItemList &items)
         dlgProgress->SetLine(0, CVariant{15311});
         dlgProgress->SetLine(1, CVariant{""});
         dlgProgress->SetLine(2, CVariant{""});
-        dlgProgress->StartModal();
+        dlgProgress->Open();
         dlgProgress->ShowProgressBar(true);
         dlgProgress->SetProgressMax((int)vecPaths.size()*2);
         dlgProgress->Progress();

--- a/xbmc/filesystem/PluginDirectory.cpp
+++ b/xbmc/filesystem/PluginDirectory.cpp
@@ -503,7 +503,7 @@ bool CPluginDirectory::WaitOnScriptResult(const std::string &scriptPath, int scr
         progressBar->SetLine(1, CVariant{""});
         progressBar->SetLine(2, CVariant{""});
         progressBar->ShowProgressBar(false);
-        progressBar->StartModal();
+        progressBar->Open();
       }
     }
 

--- a/xbmc/filesystem/RarManager.cpp
+++ b/xbmc/filesystem/RarManager.cpp
@@ -99,7 +99,7 @@ public:
         if (!shown)
         {
           dlg->SetHeading(CVariant{heading});
-          dlg->StartModal();
+          dlg->Open();
         }
         if (progress >= 0)
         {

--- a/xbmc/filesystem/RarManager.cpp
+++ b/xbmc/filesystem/RarManager.cpp
@@ -175,7 +175,8 @@ bool CRarManager::CacheRarredFile(std::string& strPathInCache, const std::string
       pDialog->SetLine(0, CVariant{645});
       pDialog->SetLine(1, CVariant{URIUtils::GetFileName(strPathInRar)});
       pDialog->SetLine(2, CVariant{""});
-      pDialog->DoModal();
+      pDialog->Open();
+
       if (!pDialog->IsConfirmed())
         iRes = 2; // pretend to be canceled
     }

--- a/xbmc/guilib/GUIDialog.cpp
+++ b/xbmc/guilib/GUIDialog.cpp
@@ -27,10 +27,10 @@
 #include "ApplicationMessenger.h"
 #include "input/Key.h"
 
-CGUIDialog::CGUIDialog(int id, const std::string &xmlFile)
+CGUIDialog::CGUIDialog(int id, const std::string &xmlFile, DialogModalityType modalityType /* = DialogModalityType::MODAL */)
     : CGUIWindow(id, xmlFile)
 {
-  m_modalityType = DialogModalityType::MODAL;
+  m_modalityType = modalityType;
   m_wasRunning = false;
   m_renderOrder = 1;
   m_autoClosing = false;
@@ -136,7 +136,7 @@ void CGUIDialog::UpdateVisibility()
   if (m_visibleCondition)
   {
     if (m_visibleCondition->Get())
-      Show();
+      Open();
     else
       Close();
   }
@@ -159,88 +159,57 @@ void CGUIDialog::UpdateVisibility()
   }
 }
 
-void CGUIDialog::DoModal_Internal(int iWindowID /*= WINDOW_INVALID */, const std::string &param /* = "" */)
+void CGUIDialog::Open_Internal()
 {
-  //Lock graphic context here as it is sometimes called from non rendering threads
-  //maybe we should have a critical section per window instead??
-  CSingleLock lock(g_graphicsContext);
-
-  if (!g_windowManager.Initialized())
-    return; // don't do anything
-
-  m_closing = false;
-  m_modalityType = DialogModalityType::MODAL;
-  // set running before it's added to the window manager, else the auto-show code
-  // could show it as well if we are in a different thread from
-  // the main rendering thread (this should really be handled via
-  // a thread message though IMO)
-  m_active = true;
-  g_windowManager.RegisterDialog(this);
-
-  // active this window...
-  CGUIMessage msg(GUI_MSG_WINDOW_INIT, 0, 0, WINDOW_INVALID, iWindowID);
-  msg.SetStringParam(param);
-  OnMessage(msg);
-
-  if (!m_windowLoaded)
-    Close(true);
-
-  lock.Leave();
-
-  while (m_active && !g_application.m_bStop)
-  {
-    g_windowManager.ProcessRenderLoop();
-  }
+  CGUIDialog::Open_Internal(m_modalityType != DialogModalityType::MODELESS);
 }
 
-void CGUIDialog::Show_Internal()
+void CGUIDialog::Open_Internal(bool bProcessRenderLoop)
 {
-  //Lock graphic context here as it is sometimes called from non rendering threads
-  //maybe we should have a critical section per window instead??
+  // Lock graphic context here as it is sometimes called from non rendering threads
+  // maybe we should have a critical section per window instead??
   CSingleLock lock(g_graphicsContext);
 
-  if (m_active && !m_closing && !IsAnimating(ANIM_TYPE_WINDOW_CLOSE)) return;
-
-  if (!g_windowManager.Initialized())
-    return; // don't do anything
-
-  m_modalityType = DialogModalityType::MODELESS;
+  if (!g_windowManager.Initialized() ||
+      (m_active && !m_closing && !IsAnimating(ANIM_TYPE_WINDOW_CLOSE)))
+    return;
 
   // set running before it's added to the window manager, else the auto-show code
-  // could show it as well if we are in a different thread from
-  // the main rendering thread (this should really be handled via
-  // a thread message though IMO)
+  // could show it as well if we are in a different thread from the main rendering
+  // thread (this should really be handled via a thread message though IMO)
   m_active = true;
   m_closing = false;
   g_windowManager.RegisterDialog(this);
 
-  // active this window...
+  // active this window
   CGUIMessage msg(GUI_MSG_WINDOW_INIT, 0, 0);
   OnMessage(msg);
+
+  // process render loop
+  if (bProcessRenderLoop)
+  {
+    if (!m_windowLoaded)
+      Close(true);
+
+    lock.Leave();
+
+    while (m_active && !g_application.m_bStop)
+    {
+      g_windowManager.ProcessRenderLoop();
+    }
+  }
 }
 
-void CGUIDialog::DoModal(int iWindowID /*= WINDOW_INVALID */, const std::string &param)
+void CGUIDialog::Open()
 {
   if (!g_application.IsCurrentThread())
   {
     // make sure graphics lock is not held
     CSingleExit leaveIt(g_graphicsContext);
-    CApplicationMessenger::Get().DoModal(this, iWindowID, param);
+    CApplicationMessenger::Get().Open(this);
   }
   else
-    DoModal_Internal(iWindowID, param);
-}
-
-void CGUIDialog::Show()
-{
-  if (!g_application.IsCurrentThread())
-  {
-    // make sure graphics lock is not held
-    CSingleExit leaveIt(g_graphicsContext);
-    CApplicationMessenger::Get().Show(this);
-  }
-  else
-    Show_Internal();
+    Open_Internal();
 }
 
 void CGUIDialog::Render()

--- a/xbmc/guilib/GUIDialog.h
+++ b/xbmc/guilib/GUIDialog.h
@@ -32,7 +32,7 @@ enum class DialogModalityType
 {
   MODELESS,
   MODAL,
-  SYSTEM_MODAL
+  PARENTLESS_MODAL
 };
 
 /*!
@@ -57,7 +57,7 @@ public:
 
   virtual bool IsDialogRunning() const { return m_active; };
   virtual bool IsDialog() const { return true;};
-  virtual bool IsModalDialog() const { return m_modalityType == DialogModalityType::MODAL || m_modalityType == DialogModalityType::SYSTEM_MODAL; };
+  virtual bool IsModalDialog() const { return m_modalityType == DialogModalityType::MODAL || m_modalityType == DialogModalityType::PARENTLESS_MODAL; };
   virtual DialogModalityType GetModalityType() const { return m_modalityType; };
 
   void SetAutoClose(unsigned int timeoutMs);

--- a/xbmc/guilib/GUIDialog.h
+++ b/xbmc/guilib/GUIDialog.h
@@ -43,7 +43,7 @@ class CGUIDialog :
       public CGUIWindow
 {
 public:
-  CGUIDialog(int id, const std::string &xmlFile);
+  CGUIDialog(int id, const std::string &xmlFile, DialogModalityType modalityType = DialogModalityType::MODAL);
   virtual ~CGUIDialog(void);
 
   virtual bool OnAction(const CAction &action);
@@ -51,8 +51,7 @@ public:
   virtual void DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyregions);
   virtual void Render();
 
-  void DoModal(int iWindowID = WINDOW_INVALID, const std::string &param = ""); // modal
-  void Show(); // modeless
+  void Open();
   
   virtual bool OnBack(int actionID);
 
@@ -72,8 +71,8 @@ protected:
   virtual void OnWindowLoaded();
   virtual void UpdateVisibility();
 
-  virtual void DoModal_Internal(int iWindowID = WINDOW_INVALID, const std::string &param = ""); // modal
-  virtual void Show_Internal(); // modeless
+  virtual void Open_Internal();
+  virtual void Open_Internal(bool bProcessRenderLoop);
   virtual void OnDeinitWindow(int nextWindowID);
 
   bool m_wasRunning; ///< \brief true if we were running during the last DoProcess()

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -774,7 +774,7 @@ void CGUIWindowManager::ActivateWindow_Internal(int iWindowID, const vector<stri
     if (!pNewWindow->IsDialogRunning())
     {
       CSingleExit exitit(g_graphicsContext);
-      ((CGUIDialog *)pNewWindow)->DoModal(iWindowID, params.size() ? params[0] : "");
+      ((CGUIDialog *)pNewWindow)->Open();
     }
     return;
   }

--- a/xbmc/guilib/StereoscopicsManager.cpp
+++ b/xbmc/guilib/StereoscopicsManager.cpp
@@ -239,7 +239,7 @@ RENDER_STEREO_MODE CStereoscopicsManager::GetStereoModeByUserChoice(const std::s
     }
   }
 
-  pDlgSelect->DoModal();
+  pDlgSelect->Open();
 
   int iItem = pDlgSelect->GetSelectedLabel();
   if (iItem > -1 && pDlgSelect->IsConfirmed())
@@ -573,7 +573,7 @@ void CStereoscopicsManager::OnPlaybackStarted(void)
 
       int idx_select = pDlgSelect->Add( g_localizeStrings.Get(36531) ); // other / select
 
-      pDlgSelect->DoModal();
+      pDlgSelect->Open();
 
       if(pDlgSelect->IsConfirmed())
       {

--- a/xbmc/interfaces/legacy/Dialog.cpp
+++ b/xbmc/interfaces/legacy/Dialog.cpp
@@ -392,7 +392,7 @@ namespace XBMCAddon
       if (!line3.empty())
         pDialog->SetLine(2, CVariant{line3});
 
-      pDialog->StartModal();
+      pDialog->Open();
     }
 
     void DialogProgress::update(int percent, const String& line1, 

--- a/xbmc/interfaces/legacy/Dialog.cpp
+++ b/xbmc/interfaces/legacy/Dialog.cpp
@@ -42,12 +42,6 @@ namespace XBMCAddon
 {
   namespace xbmcgui
   {
-    static void XBMCWaitForThreadMessage(int message, int param1, int param2)
-    {
-      ThreadMessage tMsg = {(DWORD)message, param1, param2};
-      CApplicationMessenger::Get().SendMessage(tMsg, true);
-    }
-
     Dialog::~Dialog() {}
 
     bool Dialog::yesno(const String& heading, const String& line1, 
@@ -58,8 +52,7 @@ namespace XBMCAddon
                        int autoclose)
     {
       DelayedCallGuard dcguard(languageHook);
-      const int window = WINDOW_DIALOG_YES_NO;
-      CGUIDialogYesNo* pDialog = (CGUIDialogYesNo*)g_windowManager.GetWindow(window);
+      CGUIDialogYesNo* pDialog = (CGUIDialogYesNo*)g_windowManager.GetWindow(WINDOW_DIALOG_YES_NO);
       if (pDialog == NULL)
         throw WindowException("Error: Window is NULL, this is not possible :-)");
 
@@ -81,8 +74,7 @@ namespace XBMCAddon
       if (autoclose > 0)
         pDialog->SetAutoClose(autoclose);
 
-      //send message and wait for user input
-      XBMCWaitForThreadMessage(TMSG_DIALOG_DOMODAL, window, ACTIVE_WINDOW);
+      pDialog->Open();
 
       return pDialog->IsConfirmed();
     }
@@ -90,8 +82,7 @@ namespace XBMCAddon
     int Dialog::select(const String& heading, const std::vector<String>& list, int autoclose)
     {
       DelayedCallGuard dcguard(languageHook);
-      const int window = WINDOW_DIALOG_SELECT;
-      CGUIDialogSelect* pDialog= (CGUIDialogSelect*)g_windowManager.GetWindow(window);
+      CGUIDialogSelect* pDialog= (CGUIDialogSelect*)g_windowManager.GetWindow(WINDOW_DIALOG_SELECT);
       if (pDialog == NULL)
         throw WindowException("Error: Window is NULL, this is not possible :-)");
 
@@ -108,8 +99,7 @@ namespace XBMCAddon
       if (autoclose > 0)
         pDialog->SetAutoClose(autoclose);
 
-      //send message and wait for user input
-      XBMCWaitForThreadMessage(TMSG_DIALOG_DOMODAL, window, ACTIVE_WINDOW);
+      pDialog->Open();
 
       return pDialog->GetSelectedLabel();
     }
@@ -119,9 +109,7 @@ namespace XBMCAddon
                     const String& line3)
     {
       DelayedCallGuard dcguard(languageHook);
-      const int window = WINDOW_DIALOG_OK;
-
-      CGUIDialogOK* pDialog = (CGUIDialogOK*)g_windowManager.GetWindow(window);
+      CGUIDialogOK* pDialog = (CGUIDialogOK*)g_windowManager.GetWindow(WINDOW_DIALOG_OK);
       if (pDialog == NULL)
         throw WindowException("Error: Window is NULL, this is not possible :-)");
 
@@ -134,8 +122,7 @@ namespace XBMCAddon
       if (!line3.empty())
         pDialog->SetLine(2, CVariant{line3});
 
-      //send message and wait for user input
-      XBMCWaitForThreadMessage(TMSG_DIALOG_DOMODAL, window, ACTIVE_WINDOW);
+      pDialog->Open();
 
       return pDialog->IsConfirmed();
     }
@@ -152,9 +139,7 @@ namespace XBMCAddon
         pDialog->SetHeading(heading);
       if (!text.empty())
         pDialog->SetText(text);
-
-      //send message and wait for user input
-      XBMCWaitForThreadMessage(TMSG_DIALOG_DOMODAL, window, ACTIVE_WINDOW);
+      pDialog->Open();
     }
 
 

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -2673,7 +2673,7 @@ int CMusicDatabase::Cleanup(bool bShowProgress /* = true */)
       pDlgProgress->SetLine(1, CVariant{318});
       pDlgProgress->SetLine(2, CVariant{330});
       pDlgProgress->SetPercentage(0);
-      pDlgProgress->StartModal();
+      pDlgProgress->Open();
       pDlgProgress->ShowProgressBar(true);
     }
   }
@@ -2811,7 +2811,7 @@ bool CMusicDatabase::LookupCDDBInfo(bool bRequery/*=false*/)
     pDialogProgress->SetLine(1, CVariant{256});
     pDialogProgress->SetLine(2, CVariant{""});
     pDialogProgress->ShowProgressBar(false);
-    pDialogProgress->StartModal();
+    pDialogProgress->Open();
 
     // get cddb information
     if (!cddb.queryCDinfo(pCdInfo))
@@ -4659,7 +4659,7 @@ void CMusicDatabase::ExportToXML(const std::string &xmlFile, bool singleFiles, b
       progress->SetLine(1, CVariant{""});
       progress->SetLine(2, CVariant{""});
       progress->SetPercentage(0);
-      progress->StartModal();
+      progress->Open();
       progress->ShowProgressBar(true);
     }
 
@@ -4840,7 +4840,7 @@ void CMusicDatabase::ImportFromXML(const std::string &xmlFile)
       progress->SetLine(1, CVariant{330});
       progress->SetLine(2, CVariant{""});
       progress->SetPercentage(0);
-      progress->StartModal();
+      progress->Open();
       progress->ShowProgressBar(true);
     }
 
@@ -5020,7 +5020,7 @@ void CMusicDatabase::ExportKaraokeInfo(const std::string & outFile, bool asHTML)
       progress->SetLine(1, CVariant{""});
       progress->SetLine(2, CVariant{""});
       progress->SetPercentage(0);
-      progress->StartModal();
+      progress->Open();
       progress->ShowProgressBar(true);
     }
 
@@ -5112,7 +5112,7 @@ void CMusicDatabase::ImportKaraokeInfo(const std::string & inputFile)
       progress->SetLine(1, CVariant{""});
       progress->SetLine(2, CVariant{""});
       progress->SetPercentage(0);
-      progress->StartModal();
+      progress->Open();
       progress->ShowProgressBar(true);
     }
 

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -2839,7 +2839,7 @@ bool CMusicDatabase::LookupCDDBInfo(bool bRequery/*=false*/)
           pDlgSelect->Add(strTitle);
           i++;
         }
-        pDlgSelect->DoModal();
+        pDlgSelect->Open();
 
         // Has the user selected a match...
         int iSelectedCD = pDlgSelect->GetSelectedLabel();
@@ -2922,7 +2922,7 @@ void CMusicDatabase::DeleteCDDBInfo()
     }
 
     pDlg->Sort();
-    pDlg->DoModal();
+    pDlg->Open();
 
     // and wait till user selects one
     int iSelectedAlbum = pDlg->GetSelectedLabel();

--- a/xbmc/music/dialogs/GUIDialogMusicOverlay.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicOverlay.cpp
@@ -27,7 +27,7 @@
 #define CONTROL_LOGO_PIC    1
 
 CGUIDialogMusicOverlay::CGUIDialogMusicOverlay()
-    : CGUIDialog(WINDOW_DIALOG_MUSIC_OVERLAY, "MusicOverlay.xml")
+  : CGUIDialog(WINDOW_DIALOG_MUSIC_OVERLAY, "MusicOverlay.xml", DialogModalityType::MODELESS)
 {
   m_renderOrder = 0;
   m_loadType = KEEP_IN_MEMORY;

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -1149,7 +1149,7 @@ INFO_RET CMusicInfoScanner::DownloadAlbumInfo(const CAlbum& album, const ADDON::
         if (pDialog && bestRelevance < THRESHOLD)
         {
           pDlg->Sort(false);
-          pDlg->DoModal();
+          pDlg->Open();
 
           // and wait till user selects one
           if (pDlg->GetSelectedLabel() < 0)
@@ -1345,7 +1345,7 @@ INFO_RET CMusicInfoScanner::DownloadArtistInfo(const CArtist& artist, const ADDO
             item.m_idepth = i; // use this to hold the index of the album in the scraper
             pDlg->Add(&item);
           }
-          pDlg->DoModal();
+          pDlg->Open();
 
           // and wait till user selects one
           if (pDlg->GetSelectedLabel() < 0)

--- a/xbmc/music/karaoke/GUIDialogKaraokeSongSelector.cpp
+++ b/xbmc/music/karaoke/GUIDialogKaraokeSongSelector.cpp
@@ -250,21 +250,21 @@ void CGUIDialogKaraokeSongSelector::OnDeinitWindow(int nextWindowID)
 }
 
 
-void CGUIDialogKaraokeSongSelectorSmall::DoModal(unsigned int startcode, int iWindowID, const std::string & param)
+void CGUIDialogKaraokeSongSelectorSmall::Open(unsigned int startcode)
 {
   m_songSelected = false;
   m_selectedNumber = 0;
 
   OnButtonNumeric( startcode, false );
-  CGUIDialog::DoModal( iWindowID, param );
+  CGUIDialog::Open();
 }
 
 
-void CGUIDialogKaraokeSongSelectorLarge::DoModal(int iWindowID, const std::string & param)
+void CGUIDialogKaraokeSongSelectorLarge::Open()
 {
   m_songSelected = false;
   m_selectedNumber = 0;
 
   OnButtonNumeric( 0, false );
-  CGUIDialog::DoModal( iWindowID, param );
+  CGUIDialog::Open();
 }

--- a/xbmc/music/karaoke/GUIDialogKaraokeSongSelector.h
+++ b/xbmc/music/karaoke/GUIDialogKaraokeSongSelector.h
@@ -74,7 +74,7 @@ class CGUIDialogKaraokeSongSelectorSmall : public CGUIDialogKaraokeSongSelector
 {
   public:
     CGUIDialogKaraokeSongSelectorSmall();
-    void DoModal(unsigned int startcode, int iWindowID = WINDOW_INVALID, const std::string &param = "");
+    void Open(unsigned int startcode);
 };
 
 
@@ -83,5 +83,5 @@ class CGUIDialogKaraokeSongSelectorLarge : public CGUIDialogKaraokeSongSelector
 {
   public:
     CGUIDialogKaraokeSongSelectorLarge();
-    void DoModal(int iWindowID = WINDOW_INVALID, const std::string &param = "");
+    void Open();
 };

--- a/xbmc/music/karaoke/GUIWindowKaraokeLyrics.cpp
+++ b/xbmc/music/karaoke/GUIWindowKaraokeLyrics.cpp
@@ -66,7 +66,7 @@ bool CGUIWindowKaraokeLyrics::OnAction(const CAction &action)
   
     default:
       if ( CGUIDialogKaraokeSongSelector::GetKeyNumber( action.GetID() ) != -1 && songSelector && !songSelector->IsActive() )
-        songSelector->DoModal( CGUIDialogKaraokeSongSelector::GetKeyNumber( action.GetID() ) );
+        songSelector->Open( CGUIDialogKaraokeSongSelector::GetKeyNumber( action.GetID() ) );
 
       break;
   }

--- a/xbmc/music/karaoke/karaokelyricsmanager.cpp
+++ b/xbmc/music/karaoke/karaokelyricsmanager.cpp
@@ -155,7 +155,7 @@ void CKaraokeLyricsManager::ProcessSlow()
   CGUIDialogKaraokeSongSelectorLarge * selector =
       (CGUIDialogKaraokeSongSelectorLarge*)g_windowManager.GetWindow( WINDOW_DIALOG_KARAOKE_SELECTOR );
 
-  selector->DoModal();
+  selector->Open();
 }
 
 void CKaraokeLyricsManager::SetPaused(bool now_paused)

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -382,7 +382,7 @@ void CGUIWindowMusicBase::ShowArtistInfo(const CFileItem *pItem, bool bShowInfo 
     if (pDlgArtistInfo)
     {
       pDlgArtistInfo->SetArtist(artist, artist.strPath);
-      pDlgArtistInfo->DoModal();
+      pDlgArtistInfo->Open();
 
       if (pDlgArtistInfo->NeedRefresh())
       {
@@ -461,7 +461,7 @@ bool CGUIWindowMusicBase::ShowAlbumInfo(const CFileItem *pItem, bool bShowInfo /
     if (pDlgAlbumInfo)
     {
       pDlgAlbumInfo->SetAlbum(album, album.strPath);
-      pDlgAlbumInfo->DoModal();
+      pDlgAlbumInfo->Open();
 
       if (pDlgAlbumInfo->NeedRefresh())
       {
@@ -491,7 +491,7 @@ void CGUIWindowMusicBase::ShowSongInfo(CFileItem* pItem)
       return;
 
     dialog->SetSong(pItem);
-    dialog->DoModal(GetID());
+    dialog->Open();
     if (dialog->NeedsUpdate())
       Refresh(true); // update our file list
   }

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -364,7 +364,7 @@ void CGUIWindowMusicBase::ShowArtistInfo(const CFileItem *pItem, bool bShowInfo 
         m_dlgProgress->SetLine(0, CVariant{pItem->GetMusicInfoTag()->GetArtist()});
         m_dlgProgress->SetLine(1, CVariant{""});
         m_dlgProgress->SetLine(2, CVariant{""});
-        m_dlgProgress->StartModal();
+        m_dlgProgress->Open();
       }
 
       CMusicInfoScanner scanner;
@@ -441,7 +441,7 @@ bool CGUIWindowMusicBase::ShowAlbumInfo(const CFileItem *pItem, bool bShowInfo /
         m_dlgProgress->SetLine(0, CVariant{pItem->GetMusicInfoTag()->GetAlbum()});
         m_dlgProgress->SetLine(1, CVariant{StringUtils::Join(pItem->GetMusicInfoTag()->GetAlbumArtist(), g_advancedSettings.m_musicItemSeparator)});
         m_dlgProgress->SetLine(2, CVariant{""});
-        m_dlgProgress->StartModal();
+        m_dlgProgress->Open();
       }
 
       CMusicInfoScanner scanner;
@@ -1092,7 +1092,7 @@ void CGUIWindowMusicBase::OnRetrieveMusicInfo(CFileItemList& items)
         m_dlgProgress->SetLine(0, CVariant{505});
         m_dlgProgress->SetLine(1, CVariant{""});
         m_dlgProgress->SetLine(2, CVariant{url.GetWithoutUserDetails()});
-        m_dlgProgress->StartModal();
+        m_dlgProgress->Open();
         m_dlgProgress->ShowProgressBar(true);
         bProgressVisible = true;
       }

--- a/xbmc/music/windows/GUIWindowVisualisation.cpp
+++ b/xbmc/music/windows/GUIWindowVisualisation.cpp
@@ -203,7 +203,7 @@ EVENT_RESULT CGUIWindowVisualisation::OnMouseEvent(const CPoint &point, const CM
     if (pOSD)
     {
       pOSD->SetAutoClose(3000);
-      pOSD->DoModal();
+      pOSD->Open();
     }
     return EVENT_RESULT_HANDLED;
   }

--- a/xbmc/network/GUIDialogNetworkSetup.cpp
+++ b/xbmc/network/GUIDialogNetworkSetup.cpp
@@ -101,7 +101,7 @@ bool CGUIDialogNetworkSetup::ShowAndGetNetworkAddress(std::string &path)
   if (!dialog) return false;
   dialog->Initialize();
   dialog->SetPath(path);
-  dialog->DoModal();
+  dialog->Open();
   path = dialog->ConstructPath();
   return dialog->IsConfirmed();
 }

--- a/xbmc/network/WakeOnAccess.cpp
+++ b/xbmc/network/WakeOnAccess.cpp
@@ -211,7 +211,7 @@ public:
       if (m_dialog)
       {
         if (!m_dialog->IsActive())
-          m_dialog->StartModal();
+          m_dialog->Open();
 
         if (m_dialog->IsCanceled())
           return Canceled;

--- a/xbmc/network/upnp/UPnPPlayer.cpp
+++ b/xbmc/network/upnp/UPnPPlayer.cpp
@@ -192,7 +192,7 @@ static NPT_Result WaitOnEvent(CEvent& event, XbmcThreads::EndTime& timeout, CGUI
 
   if(dialog == NULL) {
     dialog = (CGUIDialogBusy*)g_windowManager.GetWindow(WINDOW_DIALOG_BUSY);
-    dialog->Show();
+    dialog->Open();
   }
 
   g_windowManager.ProcessRenderLoop(false);

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -721,6 +721,6 @@ void CPeripherals::OnSettingAction(const CSetting *setting)
   {
     CGUIDialogPeripheralManager *dialog = (CGUIDialogPeripheralManager *)g_windowManager.GetWindow(WINDOW_DIALOG_PERIPHERAL_MANAGER);
     if (dialog != NULL)
-      dialog->DoModal();
+      dialog->Open();
   }
 }

--- a/xbmc/peripherals/dialogs/GUIDialogPeripheralManager.cpp
+++ b/xbmc/peripherals/dialogs/GUIDialogPeripheralManager.cpp
@@ -96,7 +96,7 @@ bool CGUIDialogPeripheralManager::OpenSettingsDialog(void)
   if (dialog)
   {
     dialog->SetFileItem(GetCurrentListItem().get());
-    dialog->DoModal();
+    dialog->Open();
     return true;
   }
 

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -615,7 +615,7 @@ void CGUIWindowPictures::OnInfo(int itemNumber)
   if (pictureInfo)
   {
     pictureInfo->SetPicture(item.get());
-    pictureInfo->DoModal();
+    pictureInfo->Open();
   }
 }
 

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -239,7 +239,7 @@ void CGUIWindowPictures::OnPrepareFileItems(CFileItemList& items)
         m_dlgProgress->SetLine(0, CVariant{505});
         m_dlgProgress->SetLine(1, CVariant{""});
         m_dlgProgress->SetLine(2, CVariant{url.GetWithoutUserDetails()});
-        m_dlgProgress->StartModal();
+        m_dlgProgress->Open();
         m_dlgProgress->ShowProgressBar(true);
         bProgressVisible = true;
       }

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -762,7 +762,7 @@ bool CGUIWindowSlideShow::OnAction(const CAction &action)
       if (pictureInfo)
       {
         // no need to set the picture here, it's done in Render()
-        pictureInfo->DoModal();
+        pictureInfo->Open();
       }
     }
     break;

--- a/xbmc/powermanagement/PowerManager.cpp
+++ b/xbmc/powermanagement/PowerManager.cpp
@@ -170,7 +170,7 @@ bool CPowerManager::Powerdown()
   {
     CGUIDialogBusy* dialog = (CGUIDialogBusy*)g_windowManager.GetWindow(WINDOW_DIALOG_BUSY);
     if (dialog)
-      dialog->Show();
+      dialog->Open();
 
     return true;
   }
@@ -184,7 +184,7 @@ bool CPowerManager::Suspend()
   {
     CGUIDialogBusy* dialog = (CGUIDialogBusy*)g_windowManager.GetWindow(WINDOW_DIALOG_BUSY);
     if (dialog)
-      dialog->Show();
+      dialog->Open();
 
     return true;
   }
@@ -198,7 +198,7 @@ bool CPowerManager::Hibernate()
   {
     CGUIDialogBusy* dialog = (CGUIDialogBusy*)g_windowManager.GetWindow(WINDOW_DIALOG_BUSY);
     if (dialog)
-      dialog->Show();
+      dialog->Open();
 
     return true;
   }
@@ -215,7 +215,7 @@ bool CPowerManager::Reboot()
 
     CGUIDialogBusy* dialog = (CGUIDialogBusy*)g_windowManager.GetWindow(WINDOW_DIALOG_BUSY);
     if (dialog)
-      dialog->Show();
+      dialog->Open();
   }
 
   return success;

--- a/xbmc/profiles/ProfilesManager.cpp
+++ b/xbmc/profiles/ProfilesManager.cpp
@@ -300,7 +300,7 @@ bool CProfilesManager::DeleteProfile(size_t index)
   dlgYesNo->SetLine(0, CVariant{StringUtils::Format(str.c_str(), profile->getName().c_str())});
   dlgYesNo->SetLine(1, CVariant{""});
   dlgYesNo->SetLine(2, CVariant{""});
-  dlgYesNo->DoModal();
+  dlgYesNo->Open();
 
   if (!dlgYesNo->IsConfirmed())
     return false;

--- a/xbmc/profiles/dialogs/GUIDialogLockSettings.cpp
+++ b/xbmc/profiles/dialogs/GUIDialogLockSettings.cpp
@@ -82,7 +82,7 @@ bool CGUIDialogLockSettings::ShowAndGetLock(CProfile::CLock &locks, int buttonLa
   dialog->m_getUser = false;
   dialog->m_conditionalDetails = conditional;
   dialog->m_details = details;
-  dialog->DoModal();
+  dialog->Open();
 
   if (!dialog->m_changed)
     return false;
@@ -102,7 +102,7 @@ bool CGUIDialogLockSettings::ShowAndGetUserAndPassword(std::string &user, std::s
   dialog->m_user = user;
   dialog->m_url = url;
   dialog->m_saveUserDetails = saveUserDetails;
-  dialog->DoModal();
+  dialog->Open();
 
   if (!dialog->m_changed)
     return false;

--- a/xbmc/profiles/dialogs/GUIDialogProfileSettings.cpp
+++ b/xbmc/profiles/dialogs/GUIDialogProfileSettings.cpp
@@ -122,7 +122,7 @@ bool CGUIDialogProfileSettings::ShowForProfile(unsigned int iProfile, bool first
     dialog->m_locks = profile->GetLocks();
   }
 
-  dialog->DoModal();
+  dialog->Open();
   if (dialog->m_needsSaving)
   {
     if (iProfile >= CProfilesManager::Get().GetNumberOfProfiles())

--- a/xbmc/profiles/windows/GUIWindowSettingsProfile.cpp
+++ b/xbmc/profiles/windows/GUIWindowSettingsProfile.cpp
@@ -263,7 +263,7 @@ bool CGUIWindowSettingsProfile::GetAutoLoginProfileChoice(int &iProfile)
   dialog->Reset();
   dialog->SetItems(&items);
   dialog->SetSelected(autoLoginProfileId);
-  dialog->DoModal();
+  dialog->Open();
 
   if (dialog->IsButtonPressed() || dialog->GetSelectedLabel() < 0)
     return false; // user cancelled

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -209,7 +209,7 @@ void CPVRManager::OnSettingAction(const CSetting *setting)
     {
       CGUIDialogPVRChannelManager *dialog = (CGUIDialogPVRChannelManager *)g_windowManager.GetWindow(WINDOW_DIALOG_PVR_CHANNEL_MANAGER);
       if (dialog)
-        dialog->DoModal();
+        dialog->Open();
     }
   }
   else if (settingId == "pvrmanager.groupmanager")
@@ -218,7 +218,7 @@ void CPVRManager::OnSettingAction(const CSetting *setting)
     {
       CGUIDialogPVRGroupManager *dialog = (CGUIDialogPVRGroupManager *)g_windowManager.GetWindow(WINDOW_DIALOG_PVR_GROUP_MANAGER);
       if (dialog)
-        dialog->DoModal();
+        dialog->Open();
     }
   }
   else if (settingId == "pvrclient.menuhook")

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -772,7 +772,7 @@ void CPVRManager::ResetDatabase(bool bResetEPGOnly /* = false */)
   pDlgProgress->SetLine(0, CVariant{""});
   pDlgProgress->SetLine(1, CVariant{g_localizeStrings.Get(19186)}); // All data in the PVR database is being erased
   pDlgProgress->SetLine(2, CVariant{""});
-  pDlgProgress->StartModal();
+  pDlgProgress->Open();
   pDlgProgress->Progress();
 
   if (m_addons && m_addons->IsPlaying())

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -637,7 +637,7 @@ PVR_ERROR CPVRClients::DeleteAllRecordingsFromTrash()
       if (itrClients->second->SupportsRecordingsUndelete() && itrClients->second->GetRecordingsAmount(true) > 0)
         pDialog->Add(itrClients->second->GetBackendName());
     }
-    pDialog->DoModal();
+    pDialog->Open();
     selection = pDialog->GetSelectedLabel();
   }
 
@@ -878,7 +878,7 @@ void CPVRClients::ProcessMenuHooks(int iClientID, PVR_MENUHOOK_CAT cat, const CF
       {
         pDialog->Add(itrClients->second->GetBackendName());
       }
-      pDialog->DoModal();
+      pDialog->Open();
 
       int selection = pDialog->GetSelectedLabel();
       if (selection >= 0)
@@ -912,7 +912,7 @@ void CPVRClients::ProcessMenuHooks(int iClientID, PVR_MENUHOOK_CAT cat, const CF
       }
     if (hookIDs.size() > 1)
     {
-      pDialog->DoModal();
+      pDialog->Open();
       selection = pDialog->GetSelectedLabel();
     }
     if (selection >= 0)
@@ -959,7 +959,7 @@ void CPVRClients::StartChannelScan(void)
     for (unsigned int i = 0; i < possibleScanClients.size(); i++)
       pDialog->Add(possibleScanClients[i]->GetFriendlyName());
 
-    pDialog->DoModal();
+    pDialog->Open();
 
     int selection = pDialog->GetSelectedLabel();
     if (selection >= 0)

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -761,7 +761,7 @@ void CGUIDialogPVRChannelManager::SaveList(void)
   pDlgProgress->SetLine(0, CVariant{""});
   pDlgProgress->SetLine(1, CVariant{328});
   pDlgProgress->SetLine(2, CVariant{""});
-  pDlgProgress->StartModal();
+  pDlgProgress->Open();
   pDlgProgress->Progress();
   pDlgProgress->SetPercentage(0);
 

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -242,7 +242,7 @@ bool CGUIDialogPVRChannelManager::OnClickButtonRadioTV(CGUIMessage &message)
     pDialog->SetLine(0, CVariant{""});
     pDialog->SetLine(1, CVariant{19212});
     pDialog->SetLine(2, CVariant{20103});
-    pDialog->DoModal();
+    pDialog->Open();
 
     if (pDialog->IsConfirmed())
       SaveList();
@@ -433,7 +433,7 @@ bool CGUIDialogPVRChannelManager::OnClickButtonGroupManager(CGUIMessage &message
   pDlgInfo->SetRadio(m_bIsRadio);
 
   /* Open dialog window */
-  pDlgInfo->DoModal();
+  pDlgInfo->Open();
 
   Update();
   return true;
@@ -453,7 +453,7 @@ bool CGUIDialogPVRChannelManager::OnClickButtonNewChannel()
     PVR_CLIENT_ITR itr;
     for (itr = m_clientsWithSettingsList.begin() ; itr != m_clientsWithSettingsList.end(); ++itr)
       pDlgSelect->Add((*itr)->Name());
-    pDlgSelect->DoModal();
+    pDlgSelect->Open();
 
     iSelection = pDlgSelect->GetSelectedLabel();
   }
@@ -607,7 +607,7 @@ bool CGUIDialogPVRChannelManager::OnContextButton(int itemNumber, CONTEXT_BUTTON
 
     pDialog->SetHeading(CVariant{19211}); // Delete channel
     pDialog->SetText(CVariant{750});      // Are you sure?
-    pDialog->DoModal();
+    pDialog->Open();
 
     if (pDialog->IsConfirmed())
     {

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
@@ -293,7 +293,7 @@ void CGUIDialogPVRChannelsOSD::ShowInfo(int item)
     /* inform dialog about the file item and open dialog window */
     CFileItem *itemNow  = new CFileItem(epgnow);
     pDlgInfo->SetProgInfo(itemNow);
-    pDlgInfo->DoModal();
+    pDlgInfo->Open();
     delete itemNow; /* delete previuosly created FileItem */
   }
 

--- a/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
@@ -139,7 +139,7 @@ bool CGUIDialogPVRGroupManager::ActionButtonDeleteGroup(CGUIMessage &message)
     pDialog->SetLine(0, CVariant{""});
     pDialog->SetLine(1, CVariant{m_selectedGroup->GroupName()});
     pDialog->SetLine(2, CVariant{""});
-    pDialog->DoModal();
+    pDialog->Open();
 
     if (pDialog->IsConfirmed())
     {

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideOSD.cpp
@@ -133,7 +133,7 @@ void CGUIDialogPVRGuideOSD::ShowInfo(int item)
 
   /* inform dialog about the file item and open dialog window */
   pDlgInfo->SetProgInfo(pItem.get());
-  pDlgInfo->DoModal();
+  pDlgInfo->Open();
 }
 
 void CGUIDialogPVRGuideOSD::OnWindowLoaded()

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -233,7 +233,7 @@ bool CGUIWindowPVRBase::OpenGroupSelectionDialog(void)
   dialog->SetItems(&options);
   dialog->SetMultiSelection(false);
   dialog->SetSelected(m_group->GroupName());
-  dialog->DoModal();
+  dialog->Open();
 
   if (!dialog->IsConfirmed())
     return false;
@@ -310,7 +310,7 @@ bool CGUIWindowPVRBase::PlayFile(CFileItem *item, bool bPlayMinimized /* = false
           pDialog->SetLine(0, CVariant{""});
           pDialog->SetLine(1, CVariant{12021}); // Start from beginning
           pDialog->SetLine(2, CVariant{recording->m_strTitle});
-          pDialog->DoModal();
+          pDialog->Open();
 
           if (pDialog->IsConfirmed())
           {
@@ -363,7 +363,7 @@ bool CGUIWindowPVRBase::ShowTimerSettings(CFileItem *item)
     return false;
 
   pDlgInfo->SetTimer(item);
-  pDlgInfo->DoModal();
+  pDlgInfo->Open();
 
   return pDlgInfo->IsConfirmed();
 }
@@ -523,7 +523,7 @@ void CGUIWindowPVRBase::ShowRecordingInfo(CFileItem *item)
   if (item->IsPVRRecording() && pDlgInfo)
   {
     pDlgInfo->SetRecording(item);
-    pDlgInfo->DoModal();
+    pDlgInfo->Open();
   }
 }
 
@@ -568,7 +568,7 @@ void CGUIWindowPVRBase::ShowEPGInfo(CFileItem *item)
   if (tag && (!bHasChannel || g_PVRManager.CheckParentalLock(channel)) && pDlgInfo)
   {
     pDlgInfo->SetProgInfo(tag);
-    pDlgInfo->DoModal();
+    pDlgInfo->Open();
   }
 
   delete tag;
@@ -663,7 +663,7 @@ bool CGUIWindowPVRBase::ActionDeleteChannel(CFileItem *item)
   pDialog->SetLine(0, CVariant{""});
   pDialog->SetLine(1, CVariant{channel->ChannelName()});
   pDialog->SetLine(2, CVariant{""});
-  pDialog->DoModal();
+  pDialog->Open();
 
   /* prompt for the user's confirmation */
   if (!pDialog->IsConfirmed())
@@ -698,7 +698,7 @@ bool CGUIWindowPVRBase::ActionRecord(CFileItem *item)
     pDialog->SetLine(0, CVariant{""});
     pDialog->SetLine(1, CVariant{epgTag->Title()});
     pDialog->SetLine(2, CVariant{""});
-    pDialog->DoModal();
+    pDialog->Open();
 
     /* prompt for the user's confirmation */
     if (!pDialog->IsConfirmed())

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -354,7 +354,7 @@ bool CGUIWindowPVRChannels::OnContextButtonUpdateEpg(CFileItem *item, CONTEXT_BU
     pDialog->SetLine(0, CVariant{g_localizeStrings.Get(19252)});
     pDialog->SetLine(1, CVariant{channel->ChannelName()});
     pDialog->SetLine(2, CVariant{""});
-    pDialog->DoModal();
+    pDialog->Open();
 
     if (!pDialog->IsConfirmed())
       return bReturn;
@@ -374,7 +374,7 @@ void CGUIWindowPVRChannels::ShowChannelManager()
 {
   CGUIDialogPVRChannelManager *dialog = (CGUIDialogPVRChannelManager *)g_windowManager.GetWindow(WINDOW_DIALOG_PVR_CHANNEL_MANAGER);
   if (dialog)
-    dialog->DoModal();
+    dialog->Open();
 }
 
 void CGUIWindowPVRChannels::ShowGroupManager(void)
@@ -385,7 +385,7 @@ void CGUIWindowPVRChannels::ShowGroupManager(void)
     return;
 
   pDlgInfo->SetRadio(m_bRadio);
-  pDlgInfo->DoModal();
+  pDlgInfo->Open();
 
   return;
 }

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -336,7 +336,7 @@ bool CGUIWindowPVRRecordings::ActionDeleteRecording(CFileItem *item)
   pDialog->SetChoice(1, CVariant{117}); // Delete
 
   /* prompt for the user's confirmation */
-  pDialog->DoModal();
+  pDialog->Open();
   if (!pDialog->IsConfirmed())
     return bReturn;
 
@@ -409,7 +409,7 @@ bool CGUIWindowPVRRecordings::OnContextButtonDeleteAll(CFileItem *item, CONTEXT_
   pDialog->SetChoice(1, CVariant{117}); // Delete
 
   /* prompt for the user's confirmation */
-  pDialog->DoModal();
+  pDialog->Open();
   if (!pDialog->IsConfirmed())
     return bReturn;
 

--- a/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
@@ -153,7 +153,7 @@ void CGUIWindowPVRSearch::OnPrepareFileItems(CFileItemList &items)
     {
       dlgProgress->SetHeading(CVariant{194});
       dlgProgress->SetText(CVariant{m_searchfilter.m_strSearchTerm});
-      dlgProgress->StartModal();
+      dlgProgress->Open();
       dlgProgress->Progress();
     }
 

--- a/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
@@ -283,7 +283,7 @@ void CGUIWindowPVRSearch::OpenDialogSearch()
   m_searchfilter.m_bIsRadio = m_bRadio;
 
   /* Open dialog window */
-  dlgSearch->DoModal();
+  dlgSearch->Open();
 
   if (dlgSearch->IsConfirmed())
   {

--- a/xbmc/pvr/windows/GUIWindowPVRTimers.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRTimers.cpp
@@ -429,7 +429,7 @@ bool CGUIWindowPVRTimers::ShowTimerSettings(CFileItem *item)
   pDlgInfo->SetTimer(item);
 
   /* Open dialog window */
-  pDlgInfo->DoModal();
+  pDlgInfo->Open();
 
   /* Get modify flag from window and return it to caller */
   return pDlgInfo->IsConfirmed();

--- a/xbmc/settings/dialogs/GUIDialogContentSettings.cpp
+++ b/xbmc/settings/dialogs/GUIDialogContentSettings.cpp
@@ -206,7 +206,7 @@ bool CGUIDialogContentSettings::Show(ADDON::ScraperPtr& scraper, VIDEO::SScanSet
   }
 
   dialog->SetScanSettings(settings);
-  dialog->DoModal();
+  dialog->Open();
 
   bool confirmed = dialog->IsConfirmed();
   if (confirmed)

--- a/xbmc/settings/windows/GUIControlSettings.cpp
+++ b/xbmc/settings/windows/GUIControlSettings.cpp
@@ -289,7 +289,7 @@ bool CGUIControlListSetting::OnClick()
   dialog->SetHeading(CVariant{g_localizeStrings.Get(m_pSetting->GetLabel())});
   dialog->SetItems(&options);
   dialog->SetMultiSelection(control->CanMultiSelect());
-  dialog->DoModal();
+  dialog->Open();
 
   if (!dialog->IsConfirmed())
     return false;

--- a/xbmc/settings/windows/GUIWindowSettingsScreenCalibration.cpp
+++ b/xbmc/settings/windows/GUIWindowSettingsScreenCalibration.cpp
@@ -83,7 +83,7 @@ bool CGUIWindowSettingsScreenCalibration::OnAction(const CAction &action)
       pDialog->SetLine(1, CVariant{20327});
       pDialog->SetChoice(0, CVariant{222});
       pDialog->SetChoice(1, CVariant{186});
-      pDialog->DoModal();
+      pDialog->Open();
       if (pDialog->IsConfirmed())
       {
         g_graphicsContext.ResetScreenParameters(m_Res[m_iCurRes]);

--- a/xbmc/storage/AutorunMediaJob.cpp
+++ b/xbmc/storage/AutorunMediaJob.cpp
@@ -50,7 +50,7 @@ bool CAutorunMediaJob::DoWork()
   pDialog->Add(g_localizeStrings.Get(21334));
   pDialog->Add(g_localizeStrings.Get(21335));
 
-  pDialog->DoModal();
+  pDialog->Open();
 
   int selection = pDialog->GetSelectedLabel();
   if (selection >= 0)

--- a/xbmc/utils/AsyncFileCopy.cpp
+++ b/xbmc/utils/AsyncFileCopy.cpp
@@ -70,7 +70,7 @@ bool CAsyncFileCopy::Copy(const std::string &from, const std::string &to, const 
       dlg->SetLine(0, CVariant{url1.GetWithoutUserDetails()});
       dlg->SetLine(1, CVariant{url2.GetWithoutUserDetails()});
       dlg->SetPercentage(0);
-      dlg->StartModal();
+      dlg->Open();
     }
     // and update the dialog as we go
     if (dlg && dlg->IsDialogRunning())

--- a/xbmc/utils/FileUtils.cpp
+++ b/xbmc/utils/FileUtils.cpp
@@ -60,7 +60,7 @@ bool CFileUtils::DeleteItem(const CFileItemPtr &item, bool force)
     pDialog->SetLine(0, CVariant{125});
     pDialog->SetLine(1, CVariant{CURL(item->GetPath()).GetWithoutUserDetails()});
     pDialog->SetLine(2, CVariant{""});
-    pDialog->DoModal();
+    pDialog->Open();
     if (!pDialog->IsConfirmed()) return false;
   }
 

--- a/xbmc/utils/ProgressJob.cpp
+++ b/xbmc/utils/ProgressJob.cpp
@@ -108,7 +108,7 @@ void CProgressJob::ShowProgressDialog() const
     return;
 
   // show the progress dialog as a modal dialog with a progress bar
-  m_progressDialog->StartModal();
+  m_progressDialog->Open();
   m_progressDialog->ShowProgressBar(true);
 }
 

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -4077,7 +4077,7 @@ void CVideoDatabase::RemoveContentForPath(const std::string& strPath, CGUIDialog
       progress->SetLine(1, CVariant{313});
       progress->SetLine(2, CVariant{330});
       progress->SetPercentage(0);
-      progress->StartModal();
+      progress->Open();
       progress->ShowProgressBar(true);
     }
     vector< pair<int,string> > paths;
@@ -7663,7 +7663,7 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const se
         progress->SetLine(1, CVariant{313});
         progress->SetLine(2, CVariant{330});
         progress->SetPercentage(0);
-        progress->StartModal();
+        progress->Open();
         progress->ShowProgressBar(true);
       }
     }
@@ -8169,7 +8169,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFiles /* = 
       progress->SetLine(1, CVariant{""});
       progress->SetLine(2, CVariant{""});
       progress->SetPercentage(0);
-      progress->StartModal();
+      progress->Open();
       progress->ShowProgressBar(true);
     }
 
@@ -8658,7 +8658,7 @@ void CVideoDatabase::ImportFromXML(const std::string &path)
       progress->SetLine(1, CVariant{330});
       progress->SetLine(2, CVariant{""});
       progress->SetPercentage(0);
-      progress->StartModal();
+      progress->Open();
       progress->ShowProgressBar(true);
     }
 

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -8040,10 +8040,7 @@ std::vector<int> CVideoDatabase::CleanMediaType(const std::string &mediaType, co
               pDialog->SetText(CVariant{StringUtils::Format(g_localizeStrings.Get(15013).c_str(), sourceUrl.GetWithoutUserDetails().c_str())});
               pDialog->SetChoice(0, CVariant{15015});
               pDialog->SetChoice(1, CVariant{15014});
-
-              //send message and wait for user input
-              ThreadMessage tMsg = { TMSG_DIALOG_DOMODAL, WINDOW_DIALOG_YES_NO, g_windowManager.GetActiveWindow() };
-              CApplicationMessenger::Get().SendMessage(tMsg, true);
+              pDialog->Open();
 
               del = !pDialog->IsConfirmed();
             }

--- a/xbmc/video/VideoInfoDownloader.cpp
+++ b/xbmc/video/VideoInfoDownloader.cpp
@@ -68,7 +68,7 @@ void CVideoInfoDownloader::ShowErrorDialog(const ADDON::CScraperError &sce)
     CGUIDialogOK *pdlg = (CGUIDialogOK *)g_windowManager.GetWindow(WINDOW_DIALOG_OK);
     pdlg->SetHeading(CVariant{sce.Title()});
     pdlg->SetLine(0, CVariant{sce.Message()});
-    CApplicationMessenger::Get().DoModal(pdlg, WINDOW_DIALOG_OK);
+    pdlg->Open();
   }
 }
 

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -438,7 +438,7 @@ void CGUIDialogVideoInfo::OnSearch(std::string& strSearch)
     progress->SetLine(0, CVariant{strSearch});
     progress->SetLine(1, CVariant{""});
     progress->SetLine(2, CVariant{""});
-    progress->StartModal();
+    progress->Open();
     progress->Progress();
   }
   CFileItemList items;

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -459,7 +459,7 @@ void CGUIDialogVideoInfo::OnSearch(std::string& strSearch)
       pDlgSelect->Add(pItem->GetLabel());
     }
 
-    pDlgSelect->DoModal();
+    pDlgSelect->Open();
 
     int iItem = pDlgSelect->GetSelectedLabel();
     if (iItem < 0)
@@ -553,7 +553,7 @@ void CGUIDialogVideoInfo::OnSearchItemFound(const CFileItem* pItem)
   SetMovie(&item);
   // refresh our window entirely
   Close();
-  DoModal();
+  Open();
 }
 
 void CGUIDialogVideoInfo::ClearCastList()
@@ -586,7 +586,7 @@ void CGUIDialogVideoInfo::Play(bool resume)
     else if (!CGUIWindowVideoBase::ShowResumeMenu(movie)) 
     {
       // The Resume dialog was closed without any choice
-      DoModal();
+      Open();
       return;
     }
     pWindow->PlayMovie(&movie);
@@ -639,7 +639,7 @@ string CGUIDialogVideoInfo::ChooseArtType(const CFileItem &videoItem, map<string
   }
 
   dialog->SetItems(&items);
-  dialog->DoModal();
+  dialog->Open();
 
   if (dialog->IsButtonPressed())
   {
@@ -1188,7 +1188,7 @@ bool CGUIDialogVideoInfo::DeleteVideoItemFromDatabase(const CFileItemPtr &item, 
     pDialog->SetLine(1, CVariant{""});
   }
   pDialog->SetLine(2, CVariant{""});
-  pDialog->DoModal();
+  pDialog->Open();
 
   if (!pDialog->IsConfirmed())
     return false;
@@ -1351,7 +1351,7 @@ bool CGUIDialogVideoInfo::GetMoviesForSet(const CFileItem *setItem, CFileItemLis
   }
   dialog->SetSelected(selectedIndices);
   dialog->EnableButton(true, 186);
-  dialog->DoModal();
+  dialog->Open();
 
   if (dialog->IsConfirmed())
   {
@@ -1419,7 +1419,7 @@ bool CGUIDialogVideoInfo::GetSetForMovie(const CFileItem *movieItem, CFileItemPt
     }
   }
   dialog->EnableButton(true, 20468); // new set via button
-  dialog->DoModal();
+  dialog->Open();
 
   if (dialog->IsButtonPressed())
   { // creating new set
@@ -1518,7 +1518,7 @@ bool CGUIDialogVideoInfo::GetItemsForTag(const std::string &strHeading, const st
   dialog->SetHeading(CVariant{strHeading});
   dialog->SetItems(&listItems);
   dialog->EnableButton(true, 186);
-  dialog->DoModal();
+  dialog->Open();
 
   items.Copy(dialog->GetSelectedItems());
   return items.Size() > 0;
@@ -1866,7 +1866,7 @@ bool CGUIDialogVideoInfo::LinkMovieToTvShow(const CFileItemPtr &item, bool bRemo
     pDialog->Reset();
     pDialog->SetItems(&list);
     pDialog->SetHeading(CVariant{20356});
-    pDialog->DoModal();
+    pDialog->Open();
     iSelectedLabel = pDialog->GetSelectedLabel();
   }
 

--- a/xbmc/video/dialogs/GUIDialogVideoOverlay.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoOverlay.cpp
@@ -31,7 +31,7 @@
 
 
 CGUIDialogVideoOverlay::CGUIDialogVideoOverlay()
-    : CGUIDialog(WINDOW_DIALOG_VIDEO_OVERLAY, "VideoOverlay.xml")
+  : CGUIDialog(WINDOW_DIALOG_VIDEO_OVERLAY, "VideoOverlay.xml", DialogModalityType::MODELESS)
 {
   m_renderOrder = 0;
   m_loadType = KEEP_IN_MEMORY;

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -181,7 +181,7 @@ bool CGUIWindowFullScreen::OnAction(const CAction &action)
       if (pDialog)
       {
         CFileItem item(g_application.CurrentFileItem());
-        pDialog->DoModal();
+        pDialog->Open();
         return true;
       }
       break;
@@ -636,7 +636,7 @@ void CGUIWindowFullScreen::ToggleOSD()
     if (pOSD->IsDialogRunning())
       pOSD->Close();
     else
-      pOSD->DoModal();
+      pOSD->Open();
   }
 
   MarkDirtyRegion();
@@ -648,6 +648,6 @@ void CGUIWindowFullScreen::TriggerOSD()
   if (pOSD && !pOSD->IsDialogRunning())
   {
     pOSD->SetAutoClose(3000);
-    pOSD->DoModal();
+    pOSD->Open();
   }
 }

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -377,7 +377,7 @@ bool CGUIWindowVideoBase::ShowIMDB(CFileItem *item, const ScraperPtr &info2, boo
       movieDetails.m_strIMDBNumber = "xx"+movieDetails.m_strIMDBNumber;
     *item->GetVideoInfoTag() = movieDetails;
     pDlgInfo->SetMovie(item);
-    pDlgInfo->DoModal();
+    pDlgInfo->Open();
     needsRefresh = pDlgInfo->NeedRefresh();
     if (!needsRefresh)
       return pDlgInfo->HasUpdatedThumb();
@@ -482,7 +482,7 @@ bool CGUIWindowVideoBase::ShowIMDB(CFileItem *item, const ScraperPtr &info2, boo
           for (unsigned int i = 0; i < movielist.size(); ++i)
             pDlgSelect->Add(movielist[i].strTitle);
           pDlgSelect->EnableButton(true, 413); // manual
-          pDlgSelect->DoModal();
+          pDlgSelect->Open();
 
           // and wait till user selects one
           int iSelectedMovie = pDlgSelect->GetSelectedLabel();
@@ -636,7 +636,7 @@ bool CGUIWindowVideoBase::ShowIMDB(CFileItem *item, const ScraperPtr &info2, boo
 
         *item->GetVideoInfoTag() = movieDetails;
         pDlgInfo->SetMovie(item);
-        pDlgInfo->DoModal();
+        pDlgInfo->Open();
         item->SetArt("thumb", pDlgInfo->GetThumbnail());
         needsRefresh = pDlgInfo->NeedRefresh();
         listNeedsUpdating = true;
@@ -1146,7 +1146,7 @@ bool CGUIWindowVideoBase::OnPlayStackPart(int iItem)
   CGUIDialogFileStacking* dlg = (CGUIDialogFileStacking*)g_windowManager.GetWindow(WINDOW_DIALOG_FILESTACKING);
   if (!dlg) return true;
   dlg->SetNumberOfFiles(parts.Size());
-  dlg->DoModal();
+  dlg->Open();
   int selectedFile = dlg->GetSelectedFile();
   if (selectedFile > 0)
   {
@@ -1688,7 +1688,7 @@ void CGUIWindowVideoBase::AddToDatabase(int iItem)
     return;
   pSelect->SetItems(&items);
   pSelect->EnableButton(true, 531); // New Genre
-  pSelect->DoModal();
+  pSelect->Open();
   std::string strGenre;
   int iSelected = pSelect->GetSelectedLabel();
   if (iSelected >= 0)
@@ -1761,7 +1761,7 @@ void CGUIWindowVideoBase::OnSearch()
       pDlgSelect->Add(pItem->GetLabel());
     }
 
-    pDlgSelect->DoModal();
+    pDlgSelect->Open();
 
     int iItem = pDlgSelect->GetSelectedLabel();
     if (iItem < 0)

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -462,7 +462,7 @@ bool CGUIWindowVideoBase::ShowIMDB(CFileItem *item, const ScraperPtr &info2, boo
       pDlgProgress->SetLine(0, CVariant{movieName}); //don't use std::move as it's used further down
       pDlgProgress->SetLine(1, CVariant{""});
       pDlgProgress->SetLine(2, CVariant{""});
-      pDlgProgress->StartModal();
+      pDlgProgress->Open();
       pDlgProgress->Progress();
 
       // 4b. do the websearch
@@ -591,7 +591,7 @@ bool CGUIWindowVideoBase::ShowIMDB(CFileItem *item, const ScraperPtr &info2, boo
       pDlgProgress->SetLine(0, CVariant{movieName});
       pDlgProgress->SetLine(1, CVariant{scrUrl.strTitle});
       pDlgProgress->SetLine(2, CVariant{""});
-      pDlgProgress->StartModal();
+      pDlgProgress->Open();
       pDlgProgress->Progress();
       if (bHasInfo && movieDetails.m_iDbId != -1)
       {
@@ -1740,7 +1740,7 @@ void CGUIWindowVideoBase::OnSearch()
     m_dlgProgress->SetLine(0, CVariant{strSearch});
     m_dlgProgress->SetLine(1, CVariant{""});
     m_dlgProgress->SetLine(2, CVariant{""});
-    m_dlgProgress->StartModal();
+    m_dlgProgress->Open();
     m_dlgProgress->Progress();
   }
   CFileItemList items;

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -757,7 +757,7 @@ void CGUIWindowVideoNav::OnDeleteItem(CFileItemPtr pItem)
     std::string strLabel = StringUtils::Format(g_localizeStrings.Get(433).c_str(),pItem->GetLabel().c_str());
     pDialog->SetLine(1, CVariant{std::move(strLabel)});
     pDialog->SetLine(2, CVariant{""});
-    pDialog->DoModal();
+    pDialog->Open();
     if (pDialog->IsConfirmed())
     {
       CFileItemList items;
@@ -777,7 +777,7 @@ void CGUIWindowVideoNav::OnDeleteItem(CFileItemPtr pItem)
     pDialog->SetHeading(CVariant{432});
     pDialog->SetLine(1, CVariant{ StringUtils::Format(g_localizeStrings.Get(433).c_str(), pItem->GetLabel().c_str()) });
     pDialog->SetLine(2, CVariant{""});
-    pDialog->DoModal();
+    pDialog->Open();
     if (pDialog->IsConfirmed())
     {
       CVideoDatabaseDirectory dir;

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -1644,7 +1644,7 @@ bool CGUIMediaWindow::WaitForNetwork() const
   progress->SetHeading(CVariant{1040}); // Loading Directory
   progress->SetLine(1, CVariant{url.GetWithoutUserDetails()});
   progress->ShowProgressBar(false);
-  progress->StartModal();
+  progress->Open();
   while (!g_application.getNetwork().IsAvailable())
   {
     progress->Progress();

--- a/xbmc/windows/GUIWindowDebugInfo.cpp
+++ b/xbmc/windows/GUIWindowDebugInfo.cpp
@@ -37,7 +37,7 @@
 #include <climits>
 
 CGUIWindowDebugInfo::CGUIWindowDebugInfo(void)
-    : CGUIDialog(WINDOW_DEBUG_INFO, "")
+  : CGUIDialog(WINDOW_DEBUG_INFO, "", DialogModalityType::MODELESS)
 {
   m_needsScaling = false;
   m_layout = NULL;
@@ -51,7 +51,7 @@ CGUIWindowDebugInfo::~CGUIWindowDebugInfo(void)
 void CGUIWindowDebugInfo::UpdateVisibility()
 {
   if (LOG_LEVEL_DEBUG_FREEMEM <= g_advancedSettings.m_logLevel || g_SkinInfo->IsDebugging())
-    Show();
+    Open();
   else
     Close();
 }

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -1051,7 +1051,7 @@ void CGUIWindowFileManager::OnPopupMenu(int list, int item, bool bContextDriven 
       progress->SetHeading(CVariant{13394});
       for (int i=0; i < 3; i++)
         progress->SetLine(i, CVariant{""});
-      progress->StartModal();
+      progress->Open();
     }
 
     //  Calculate folder size for each selected item

--- a/xbmc/windows/GUIWindowPointer.cpp
+++ b/xbmc/windows/GUIWindowPointer.cpp
@@ -26,7 +26,7 @@
 #define ID_POINTER 10
 
 CGUIWindowPointer::CGUIWindowPointer(void)
-    : CGUIDialog(WINDOW_DIALOG_POINTER, "Pointer.xml")
+  : CGUIDialog(WINDOW_DIALOG_POINTER, "Pointer.xml", DialogModalityType::MODELESS)
 {
   m_pointer = 0;
   m_loadType = LOAD_ON_GUI_INIT;
@@ -60,7 +60,7 @@ void CGUIWindowPointer::UpdateVisibility()
   if(g_Windowing.HasCursor())
   {
     if (CInputManager::Get().IsMouseActive())
-      Show();
+      Open();
     else
       Close();
   }

--- a/xbmc/windows/GUIWindowScreensaverDim.cpp
+++ b/xbmc/windows/GUIWindowScreensaverDim.cpp
@@ -25,7 +25,7 @@
 #include <climits>
 
 CGUIWindowScreensaverDim::CGUIWindowScreensaverDim(void)
-    : CGUIDialog(WINDOW_SCREENSAVER_DIM, "")
+  : CGUIDialog(WINDOW_SCREENSAVER_DIM, "", DialogModalityType::MODELESS)
 {
   m_needsScaling = false;
   m_dimLevel = 100.0f;
@@ -44,7 +44,7 @@ void CGUIWindowScreensaverDim::UpdateVisibility()
   if (level)
   {
     m_dimLevel = level;
-    Show();
+    Open();
   }
   else
     Close();


### PR DESCRIPTION
This PR refactors the modality handling of dialogs out of the methods `CGUIDialog::DoModal` and `CGUIDialog::Show`. Now we specify the modality on a per dialog basis and the modality is not changed depending on the method call. Therefore I've dropped the methods  `DoModal` and `Show` and introduced a new method `CGUIDialog::Open` as a replacement.

@Montellese @mkortstiege @Paxxi mind taking a look.
