### PR TITLE
[ios/gl/gles] - Fix glstring possible bad access

### DIFF
--- a/xbmc/rendering/gl/RenderSystemGL.cpp
+++ b/xbmc/rendering/gl/RenderSystemGL.cpp
@@ -147,8 +147,15 @@ bool CRenderSystemGL::InitRenderSystem()
   }
 
   // Get our driver vendor and renderer
-  m_RenderVendor = (const char*) glGetString(GL_VENDOR);
-  m_RenderRenderer = (const char*) glGetString(GL_RENDERER);
+  const char* tmpVendor = (const char*) glGetString(GL_VENDOR);
+  m_RenderVendor.clear();
+  if (tmpVendor != NULL)
+    m_RenderVendor = tmpVendor;
+
+  const char* tmpRenderer = (const char*) glGetString(GL_RENDERER);
+  m_RenderRenderer.clear();
+  if (tmpRenderer != NULL)
+    m_RenderRenderer = tmpRenderer;
 
   // grab our capabilities
   if (glewIsSupported("GL_EXT_texture_compression_s3tc"))
@@ -164,7 +171,11 @@ bool CRenderSystemGL::InitRenderSystem()
   CheckOpenGLQuirks();
 	
   m_RenderExtensions  = " ";
-  m_RenderExtensions += (const char*) glGetString(GL_EXTENSIONS);
+
+  const char *tmpExtensions = (const char*) glGetString(GL_EXTENSIONS);
+  if (tmpExtensions != NULL)
+    m_RenderExtensions += tmpExtensions;
+
   m_RenderExtensions += " ";
 
   LogGraphicsInfo();

--- a/xbmc/rendering/gles/RenderSystemGLES.cpp
+++ b/xbmc/rendering/gles/RenderSystemGLES.cpp
@@ -88,11 +88,24 @@ bool CRenderSystemGLES::InitRenderSystem()
   }
   
   // Get our driver vendor and renderer
-  m_RenderVendor = (const char*) glGetString(GL_VENDOR);
-  m_RenderRenderer = (const char*) glGetString(GL_RENDERER);
+  const char *tmpVendor = (const char*) glGetString(GL_VENDOR);
+  m_RenderVendor.clear();
+  if (tmpVendor != NULL)
+    m_RenderVendor = tmpVendor;
+
+  const char *tmpRenderer = (const char*) glGetString(GL_RENDERER);
+  m_RenderRenderer.clear();
+  if (tmpRenderer != NULL)
+    m_RenderRenderer = tmpRenderer;
 
   m_RenderExtensions  = " ";
-  m_RenderExtensions += (const char*) glGetString(GL_EXTENSIONS);
+
+  const char *tmpExtensions = (const char*) glGetString(GL_EXTENSIONS);
+  if (tmpExtensions != NULL)
+  {
+    m_RenderExtensions += tmpExtensions;
+  }
+
   m_RenderExtensions += " ";
 
   LogGraphicsInfo();

--- a/xbmc/windowing/osx/WinSystemIOS.mm
+++ b/xbmc/windowing/osx/WinSystemIOS.mm
@@ -108,7 +108,13 @@ bool CWinSystemIOS::CreateNewWindow(const std::string& name, bool fullScreen, RE
   m_bWindowCreated = true;
 
   m_eglext  = " ";
-  m_eglext += (const char*) glGetString(GL_EXTENSIONS);
+
+  const char *tmpExtensions = (const char*) glGetString(GL_EXTENSIONS);
+  if (tmpExtensions != NULL)
+  {
+    m_eglext += tmpExtensions;
+  }
+
   m_eglext += " ";
 
   CLog::Log(LOGDEBUG, "EGL_EXTENSIONS:%s", m_eglext.c_str());


### PR DESCRIPTION
This one has a (maybe) funny story.

While showing Kodi to some other developers by using an iPhone4s attached to a projector via HDMI (tv-out mode) i had some sort of "Windows 98 presentation" issue (hint: https://www.youtube.com/watch?v=LfNQOOr9aR8 ).

My last famous words were "and now lets play a video" or something like that. It crashed in that very moment _doh_.

symbolicated crashreport: http://pastebin.com/ZtbfqFLz

Analyzing the logs i think this is some sort of race condition.

From the GLES documentation "If an error is generated, glGetString returns 0." <- this happens here.

For ios:
1. CreateNewWindow is called for starting the playback (i think because of renderer reconfiguration)
2. CreateNewWindow in the ios windowing tries to query the GL_EXTENSIONS and concatenates them to a member std::string
3. In some situations this seems to fail (maybe because some backend gl structure is not settled yet?)
4. std::string += NULL <- this results in the crash - when we were using StdString it wouldn't have crashed because constructing with NULL argument was fine.

I think this is a regression from the switch to std::string.

I found a couple of other places in gl and gles renderers where glGetString was called in a similar unguarded way. (ohh and i found alot of places where it already was done right with NULL check too!)

The reason why i have split this into 2 commits is that for iOS its not important to have m_eglext filled with the extensions. Those are only used when called from CWinSystemIOS::IsExtSupported with something like "EGL_*" as search string. Currently IsExtSupported is nowhere called in this way. So even in the error case where glGetString didn't return anything - this is non-fatal for now.

The other findings in gl/gles might result in unexpected behavior. The extension strings are not filled - which means that there are no extensions supported at all at this moment. While i didn't see any of those calls fail yet - i at least wanted to point it out.

So in the worst case i changed a crash&burn into a "no extensions available" case.

For iOS this fixes a real crash i have seen today. (and i am somehow obliged to fix for my honor ;) ).

IIRC @FernetMenta is already in athens (have fun there :) ) so i ping some others (ohh did i ping you? :p sorry hehe):

@popcornmix @koying <- do you happen to know what could make glGetString fail?

Beside that i PR the ios fix for isengard branch in a couple of minutes.
