### PR TITLE
[ios/windowing] - check the return code of glGetString - it can retur…

### DIFF
--- a/xbmc/windowing/osx/WinSystemIOS.mm
+++ b/xbmc/windowing/osx/WinSystemIOS.mm
@@ -108,7 +108,13 @@ bool CWinSystemIOS::CreateNewWindow(const std::string& name, bool fullScreen, RE
   m_bWindowCreated = true;
 
   m_eglext  = " ";
-  m_eglext += (const char*) glGetString(GL_EXTENSIONS);
+
+  const char *tmpExtensions = (const char*) glGetString(GL_EXTENSIONS);
+  if (tmpExtensions != NULL)
+  {
+    m_eglext += tmpExtensions;
+  }
+
   m_eglext += " ";
 
   CLog::Log(LOGDEBUG, "EGL_EXTENSIONS:%s", m_eglext.c_str());


### PR DESCRIPTION
…n 0 on error (and leads to crash if assigned to std::string afterwards).

Backport of #7430

this is against isengard branch
