### PR TITLE
Always show the keyboard or numeric input as the top most window

### DIFF
--- a/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
+++ b/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
@@ -87,6 +87,7 @@ void CGUIDialogKeyboardGeneric::OnInitWindow()
 
   // fill in the keyboard layouts
   m_currentLayout = 0;
+  m_renderOrder = INT_MAX;
   m_layouts.clear();
   const KeyboardLayouts& keyboardLayouts = CKeyboardLayoutManager::Get().GetLayouts();
   std::vector<CVariant> layoutNames = CSettings::Get().GetList("locale.keyboardlayouts");

--- a/xbmc/dialogs/GUIDialogNumeric.cpp
+++ b/xbmc/dialogs/GUIDialogNumeric.cpp
@@ -92,6 +92,7 @@ void CGUIDialogNumeric::OnInitWindow()
     data["title"] = control->GetDescription();
 
   data["value"] = GetOutput();
+  m_renderOrder = INT_MAX;
   ANNOUNCEMENT::CAnnouncementManager::Get().Announce(ANNOUNCEMENT::Input, "xbmc", "OnInputRequested", data);
 }
 


### PR DESCRIPTION
This is one possible solution to the keyboard or numeric dialog showing up in the background. This for example happens if a window has a zorder higher than 1 and an edit control tries to open the keyboard dialog.

Also described in http://trac.kodi.tv/ticket/16102 not sure if that solution would be better, please review.
