### PR TITLE
[Confluence] Fix for widget labels (labels out of sync)

### DIFF
--- a/addons/skin.confluence/720p/IncludesHomeRecentlyAdded.xml
+++ b/addons/skin.confluence/720p/IncludesHomeRecentlyAdded.xml
@@ -122,6 +122,7 @@
 							<align>center</align>
 							<aligny>center</aligny>
 							<label>$INFO[ListItem.Label]</label>
+							<visible>!Control.HasFocus(8000)</visible>
 						</control>
 						<control type="label">
 							<left>15</left>
@@ -383,6 +384,7 @@
 							<align>center</align>
 							<aligny>center</aligny>
 							<label>$INFO[ListItem.Label]</label>
+							<visible>!Control.HasFocus(8001)</visible>
 						</control>
 						<control type="label">
 							<left>20</left>
@@ -644,6 +646,7 @@
 							<align>center</align>
 							<aligny>center</aligny>
 							<label>$INFO[ListItem.Label]</label>
+							<visible>!Control.HasFocus(8002)</visible>
 						</control>
 						<control type="label">
 							<left>10</left>


### PR DESCRIPTION
To reproduce issue:
1) Focus a widget with a scrolling label
2) open shutdown dialog (DialogButtonMenu)
3) close it again
4) labels out of sync (before this commit it showed 2 labels on top of each other with different colors)

@ronie  
