### PR TITLE
[jsonrpc] Add PVR.SearchMissingChannelIcons method

### DIFF
--- a/xbmc/interfaces/json-rpc/JSONServiceDescription.cpp
+++ b/xbmc/interfaces/json-rpc/JSONServiceDescription.cpp
@@ -177,6 +177,7 @@ JsonRpcMethodMap CJSONServiceDescription::m_methodMaps[] = {
   { "PVR.GetRecordingDetails",                      CPVROperations::GetRecordingDetails },
   { "PVR.Record",                                   CPVROperations::Record },
   { "PVR.Scan",                                     CPVROperations::Scan },
+  { "PVR.SearchMissingChannelIcons",                CPVROperations::SearchMissingChannelIcons },
 
 // Profiles operations
   { "Profiles.GetProfiles",                         CProfilesOperations::GetProfiles},

--- a/xbmc/interfaces/json-rpc/PVROperations.cpp
+++ b/xbmc/interfaces/json-rpc/PVROperations.cpp
@@ -251,6 +251,17 @@ JSONRPC_STATUS CPVROperations::Scan(const std::string &method, ITransportLayer *
   return ACK;
 }
 
+JSONRPC_STATUS CPVROperations::SearchMissingChannelIcons(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)
+{
+  if (!g_PVRManager.IsStarted())
+    return FailedToExecute;
+
+  else
+    g_PVRManager.SearchMissingChannelIcons();
+
+  return ACK;
+}
+
 JSONRPC_STATUS CPVROperations::GetPropertyValue(const std::string &property, CVariant &result)
 {
   bool started = g_PVRManager.IsStarted();

--- a/xbmc/interfaces/json-rpc/PVROperations.h
+++ b/xbmc/interfaces/json-rpc/PVROperations.h
@@ -41,6 +41,7 @@ namespace JSONRPC
 
     static JSONRPC_STATUS Record(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result);
     static JSONRPC_STATUS Scan(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result);
+    static JSONRPC_STATUS SearchMissingChannelIcons(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result);
 
   private:
     static JSONRPC_STATUS GetPropertyValue(const std::string &property, CVariant &result);

--- a/xbmc/interfaces/json-rpc/schema/methods.json
+++ b/xbmc/interfaces/json-rpc/schema/methods.json
@@ -1893,6 +1893,14 @@
     "params": [ ],
     "returns":  "string"
   },
+  "PVR.SearchMissingChannelIcons": {
+    "type": "method",
+    "description": "Search for missing channel icons",
+    "transport": "Response",
+    "permission": "ControlPVR",
+    "params": [ ],
+    "returns":  "string"
+  },
   "Textures.GetTextures": {
     "type": "method",
     "description": "Retrieve all textures",


### PR DESCRIPTION
Dear all,

When creating an addon to download channel logos for the PVR section of Kodi (using thelogodb.com) I realised there is no way to re-scan the logo folder (from python) for missing logos. Currently for this to be accomplished through scripts PVR has to be restarted.
This PR adds the SearchMissingChannelIcons method from PVRManager to the json-rpc API, solving my issue.

Regards
