### PR TITLE
[cximage]: remove undefined operation on variable

### DIFF
--- a/lib/cximage-6.0/CxImage/ximadsp.cpp
+++ b/lib/cximage-6.0/CxImage/ximadsp.cpp
@@ -2794,7 +2794,8 @@ bool CxImage::Lut(BYTE* pLut)
 			// faster loop for full image
 			BYTE *iSrc=info.pImage;
 			for(unsigned long i=0; i < head.biSizeImage ; i++){
-				*iSrc++ = pLut[*iSrc];
+				*iSrc = pLut[*iSrc];
+				iSrc++;
 			}
 			return true;
 		}


### PR DESCRIPTION
ximadsp.cpp: In member function 'bool CxImage::Lut(BYTE_)':
ximadsp.cpp:2797:26: warning: operation on 'iSrc' may be undefined [-Wsequence-point]
     *iSrc++ = pLut[_iSrc];

Signed-off-by: Olaf Hering olaf@aepfle.de
