### PR TITLE
[builtin] Add PVR.SearchMissingChannelIcons

### DIFF
--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -233,8 +233,10 @@ const BUILT_IN commands[] = {
 #endif
   { "VideoLibrary.Search",        false,  "Brings up a search dialog which will search the library" },
   { "ToggleDebug",                false,  "Enables/disables debug mode" },
-  { "StartPVRManager",            false,  "(Re)Starts the PVR manager" },
-  { "StopPVRManager",             false,  "Stops the PVR manager" },
+  { "StartPVRManager",            false,  "(Re)Starts the PVR manager (Deprecated)" },
+  { "StopPVRManager",             false,  "Stops the PVR manager (Deprecated)" },
+  { "PVR.StartManager",            false,  "(Re)Starts the PVR manager" },
+  { "PVR.StopManager",             false,  "Stops the PVR manager" },
   { "PVR.SearchMissingChannelIcons", false,  "Search for missing channel icons" },
 #if defined(TARGET_ANDROID)
   { "StartAndroidActivity",       true,   "Launch an Android native app with the given package name.  Optional parms (in order): intent, dataType, dataURI." },
@@ -1845,11 +1847,21 @@ int CBuiltins::Execute(const std::string& execString)
     CSettings::Get().SetBool("debug.showloginfo", !debug);
     g_advancedSettings.SetDebugMode(!debug);
   }
+  //TODO deprecated. To be replaced by pvr.startmanager
   else if (execute == "startpvrmanager")
   {
     g_application.StartPVRManager();
   }
+  else if (execute == "pvr.startmanager")
+  {
+    g_application.StartPVRManager();
+  }
+  //TODO deprecated. To be replaced by pvr.stopmanager
   else if (execute == "stoppvrmanager")
+  {
+    g_application.StopPVRManager();
+  }
+  else if (execute == "pvr.stopmanager")
   {
     g_application.StopPVRManager();
   }

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -71,6 +71,7 @@
 #include "cores/IPlayer.h"
 #include "pvr/channels/PVRChannel.h"
 #include "pvr/recordings/PVRRecording.h"
+#include "pvr/PVRManager.h"
 
 #include "filesystem/PluginDirectory.h"
 #ifdef HAS_FILESYSTEM_RAR
@@ -234,6 +235,7 @@ const BUILT_IN commands[] = {
   { "ToggleDebug",                false,  "Enables/disables debug mode" },
   { "StartPVRManager",            false,  "(Re)Starts the PVR manager" },
   { "StopPVRManager",             false,  "Stops the PVR manager" },
+  { "PVR.SearchMissingChannelIcons", false,  "Search for missing channel icons" },
 #if defined(TARGET_ANDROID)
   { "StartAndroidActivity",       true,   "Launch an Android native app with the given package name.  Optional parms (in order): intent, dataType, dataURI." },
 #endif
@@ -1850,6 +1852,10 @@ int CBuiltins::Execute(const std::string& execString)
   else if (execute == "stoppvrmanager")
   {
     g_application.StopPVRManager();
+  }
+  else if (execute == "pvr.searchmissingchannelicons")
+  {
+    PVR::CPVRManager::Get().TriggerSearchMissingChannelIcons();
   }
   else if (execute == "startandroidactivity" && !params.empty())
   {


### PR DESCRIPTION
As the result of an early attempt to add this function as JSON-RPC method (see #7436) I decided to drop that PR in favor of a builtin function. By doing this change there is no need to remove any GUI elements from `CPVRChannelGroup::SearchAndSetChannelIcons` and I can still call it from python.

Thanks,

Regards
