### PR TITLE
[PVR] Ignore article & folders when sorting Timers

### DIFF
--- a/xbmc/pvr/windows/GUIViewStatePVR.cpp
+++ b/xbmc/pvr/windows/GUIViewStatePVR.cpp
@@ -78,8 +78,10 @@ void CGUIViewStateWindowPVRGuide::SaveViewState(void)
 
 CGUIViewStateWindowPVRTimers::CGUIViewStateWindowPVRTimers(const int windowId, const CFileItemList& items) : CGUIViewStatePVR(windowId, items)
 {
-  AddSortMethod(SortByLabel, 551, LABEL_MASKS("%L", "%I", "%L", ""));   // FileName, Size | Foldername, empty
-  AddSortMethod(SortByDate, 552, LABEL_MASKS("%L", "%J", "%L", "%J"));  // FileName, Date | Foldername, Date
+  int sortAttributes(CSettings::Get().GetBool("filelists.ignorethewhensorting") ? SortAttributeIgnoreArticle : SortAttributeNone);
+  sortAttributes |= SortAttributeIgnoreFolders;
+  AddSortMethod(SortByLabel, static_cast<SortAttribute>(sortAttributes), 551, LABEL_MASKS("%L", "%I", "%L", ""));   // FileName, Size | Foldername, empty
+  AddSortMethod(SortByDate, static_cast<SortAttribute>(sortAttributes), 552, LABEL_MASKS("%L", "%J", "%L", "%J"));  // FileName, Date | Foldername, Date
 
   // Default sorting
   SetSortMethod(SortByDate);


### PR DESCRIPTION
With the introduction of repeating timers which are handled as folders, Manual timers were always appearing at the bottom, sorted separately. This is confusing.

After discussing with @Ksooo ( http://forum.kodi.tv/showthread.php?tid=227026&pid=2047719#pid2047719 ), this pull request sorts 'repeating' and 'manual' timers together (both when sorting by date and by name) which should make them much easier to find in a long list.

The opportunity has also been taken to 'ignore articles' so there are less timers starting with 'T'.

![screenshot010](https://cloud.githubusercontent.com/assets/12870817/8575489/2bfe6732-2594-11e5-8eee-cbc1c387b21e.png)
