### PR TITLE
configure.ac: update verification of shairplay

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1593,9 +1593,10 @@ if test "x$use_airtunes" != "xno"; then
 
   if test "x$USE_AIRTUNES" != "x0"; then
     XB_FIND_SONAME([SHAIRPLAY], [shairplay], [USE_AIRTUNES])
-    AC_CHECK_MEMBERS([struct raop_callbacks_s.cls],,,
+    AC_CHECK_MEMBERS([struct raop_callbacks_s.audio_remote_control_id],
+                     AC_DEFINE([HAVE_LIBSHAIRPLAY],[1],["Define to 1 if you have libshairplay."]),
+                     USE_AIRTUNES=0,
                      [[#include <shairplay/raop.h>]])
-    AC_DEFINE([HAVE_LIBSHAIRPLAY],[1],["Define to 1 if you have libshairplay."])
   fi
 
   if test "x$USE_AIRTUNES" == "x0"; then


### PR DESCRIPTION
With commit 6f6a8e261b14a90e476519b165b5925641a5a5d9 a newer shairplay
is required. Catch old versions provided by the OS and disable shairplay
support in case its too old.

Signed-off-by: Olaf Hering olaf@aepfle.de
