### PR TITLE
Adjust return in GetModificationDate

### DIFF
--- a/xbmc/utils/FileUtils.cpp
+++ b/xbmc/utils/FileUtils.cpp
@@ -220,8 +220,6 @@ CDateTime CFileUtils::GetModificationDate(const std::string& strFileNameAndPath,
           dateAdded = *time;
       }
     }
-    
-    return dateAdded;
   }
   catch (...)
   {


### PR DESCRIPTION
Followup for commit 20b59ca2dbbf0cf49565d1484ec47294c72ce472.
As suggested by Sascha Woo have just a single return.

Signed-off-by: Olaf Hering olaf@aepfle.de
