### PR TITLE
[interfaces] intercept addon dialogs as CGUIDialogs and set special modality

### DIFF
--- a/xbmc/dialogs/GUIDialogBusy.cpp
+++ b/xbmc/dialogs/GUIDialogBusy.cpp
@@ -87,7 +87,7 @@ CGUIDialogBusy::CGUIDialogBusy(void)
   : CGUIDialog(WINDOW_DIALOG_BUSY, "DialogBusy.xml"), m_bLastVisible(false)
 {
   m_loadType = LOAD_ON_GUI_INIT;
-  m_modalityType = DialogModalityType::SYSTEM_MODAL;
+  m_modalityType = DialogModalityType::PARENTLESS_MODAL;
   m_bCanceled = false;
   m_progress = 0;
 }
@@ -100,7 +100,7 @@ void CGUIDialogBusy::Show_Internal()
 {
   m_bCanceled = false;
   m_active = true;
-  m_modalityType = DialogModalityType::SYSTEM_MODAL;
+  m_modalityType = DialogModalityType::PARENTLESS_MODAL;
   m_bLastVisible = true;
   m_closing = false;
   m_progress = 0;

--- a/xbmc/guilib/GUIDialog.h
+++ b/xbmc/guilib/GUIDialog.h
@@ -32,7 +32,7 @@ enum class DialogModalityType
 {
   MODELESS,
   MODAL,
-  SYSTEM_MODAL
+  PARENTLESS_MODAL
 };
 
 /*!
@@ -58,7 +58,7 @@ public:
 
   virtual bool IsDialogRunning() const { return m_active; };
   virtual bool IsDialog() const { return true;};
-  virtual bool IsModalDialog() const { return m_modalityType == DialogModalityType::MODAL || m_modalityType == DialogModalityType::SYSTEM_MODAL; };
+  virtual bool IsModalDialog() const { return m_modalityType == DialogModalityType::MODAL || m_modalityType == DialogModalityType::PARENTLESS_MODAL; };
   virtual DialogModalityType GetModalityType() const { return m_modalityType; };
 
   void SetAutoClose(unsigned int timeoutMs);

--- a/xbmc/interfaces/legacy/Window.h
+++ b/xbmc/interfaces/legacy/Window.h
@@ -178,8 +178,6 @@ namespace XBMCAddon
       SWIGHIDDENVIRTUAL void    OnDeinitWindow(int nextWindowID);
 
       SWIGHIDDENVIRTUAL bool    IsDialogRunning() const { XBMC_TRACE; return false; };
-      SWIGHIDDENVIRTUAL bool    IsDialog() const { XBMC_TRACE; return false; };
-      SWIGHIDDENVIRTUAL bool    IsModalDialog() const { XBMC_TRACE; return false; };
       SWIGHIDDENVIRTUAL bool    IsMediaWindow() const { XBMC_TRACE; return false; };
       SWIGHIDDENVIRTUAL void    dispose();
 

--- a/xbmc/interfaces/legacy/WindowDialog.cpp
+++ b/xbmc/interfaces/legacy/WindowDialog.cpp
@@ -20,7 +20,7 @@
 
 #include "WindowDialog.h"
 
-#include "guilib/GUIWindow.h"
+#include "guilib/GUIDialog.h"
 #include "guilib/GUIWindowManager.h"
 #include "WindowInterceptor.h"
 
@@ -32,7 +32,7 @@ namespace XBMCAddon
       Window(true), WindowDialogMixin(this)
     {
       CSingleLock lock(g_graphicsContext);
-      setWindow(new Interceptor<CGUIWindow>("CGUIWindow",this,getNextAvailableWindowId()));
+      setWindow(new InterceptorDialog<CGUIDialog>("CGUIDialog", this, getNextAvailableWindowId()));
     }
 
     WindowDialog::~WindowDialog() { deallocating(); }

--- a/xbmc/interfaces/legacy/WindowDialog.h
+++ b/xbmc/interfaces/legacy/WindowDialog.h
@@ -43,8 +43,6 @@ namespace XBMCAddon
       SWIGHIDDENVIRTUAL void OnDeinitWindow(int nextWindowID);
 
       SWIGHIDDENVIRTUAL bool IsDialogRunning() const { return WindowDialogMixin::IsDialogRunning(); }
-      SWIGHIDDENVIRTUAL bool IsModalDialog() const { XBMC_TRACE; return true; };
-      SWIGHIDDENVIRTUAL bool IsDialog() const { XBMC_TRACE; return true; };
 
       SWIGHIDDENVIRTUAL inline void show() { XBMC_TRACE; WindowDialogMixin::show(); }
       SWIGHIDDENVIRTUAL inline void close() { XBMC_TRACE; WindowDialogMixin::close(); }

--- a/xbmc/interfaces/legacy/WindowInterceptor.h
+++ b/xbmc/interfaces/legacy/WindowInterceptor.h
@@ -21,7 +21,9 @@
 #pragma once
 
 #include "guilib/GUIWindow.h"
+#include "guilib/GUIDialog.h"
 #include "Window.h"
+#include "WindowDialog.h"
 
 #include "threads/ThreadLocal.h"
 
@@ -168,30 +170,33 @@ namespace XBMCAddon
       virtual void OnDeinitWindow(int nextWindowID)
       { XBMC_TRACE; if(up()) P::OnDeinitWindow(nextWindowID); else checkedv(OnDeinitWindow(nextWindowID)); }
 
-      virtual bool    IsModalDialog() const { XBMC_TRACE; return checkedb(IsModalDialog()); };
-
+      virtual bool    IsModalDialog() const { XBMC_TRACE; return P::IsModalDialog(); };
       virtual bool    IsDialogRunning() const { XBMC_TRACE; return checkedb(IsDialogRunning()); };
-      virtual bool    IsDialog() const { XBMC_TRACE; return checkedb(IsDialog()); };
+      virtual bool    IsDialog() const { XBMC_TRACE; return P::IsDialog(); };
       virtual bool    IsMediaWindow() const { XBMC_TRACE; return checkedb(IsMediaWindow());; };
 
       virtual void    setActive(bool active) { XBMC_TRACE; P::m_active = active; }
       virtual bool    isActive() { XBMC_TRACE; return P::m_active; }
     };
 
-    template <class P /* extends CGUIWindow*/> class InterceptorDialog : 
+    template <class P /* extends CGUIDialog*/> class InterceptorDialog :
       public Interceptor<P>
     {
     public:
       InterceptorDialog(const char* specializedName,
-                        Window* _window, int windowid) : 
+                        WindowDialog* _window, int windowid) :
         Interceptor<P>(specializedName, _window, windowid)
-      { }
+      {
+        P::m_modalityType = DialogModalityType::PARENTLESS_MODAL;
+      }
                     
       InterceptorDialog(const char* specializedName,
-                  Window* _window, int windowid,
+                  WindowDialog* _window, int windowid,
                   const char* xmlfile) : 
-        Interceptor<P>(specializedName, _window, windowid,xmlfile)
-      { }
+        Interceptor<P>(specializedName, _window, windowid, xmlfile)
+      {
+        P::m_modalityType = DialogModalityType::PARENTLESS_MODAL;
+      }
     };
 
 #undef checkedb

--- a/xbmc/interfaces/legacy/WindowXML.cpp
+++ b/xbmc/interfaces/legacy/WindowXML.cpp
@@ -54,12 +54,12 @@ namespace XBMCAddon
 
 
     // TODO: This should be done with template specialization
-    class WindowXMLInterceptor : public InterceptorDialog<CGUIMediaWindow>
+    class WindowXMLInterceptor : public Interceptor<CGUIMediaWindow>
     {
       WindowXML* xwin;
     public:
       WindowXMLInterceptor(WindowXML* _window, int windowid,const char* xmlfile) :
-        InterceptorDialog<CGUIMediaWindow>("CGUIMediaWindow",_window,windowid,xmlfile), xwin(_window) 
+        Interceptor<CGUIMediaWindow>("CGUIMediaWindow",_window,windowid,xmlfile), xwin(_window) 
       { }
 
       virtual void AllocResources(bool forceLoad = false)


### PR DESCRIPTION
As reported by different addon devs the check for active modals while activating a new window seems to be a bit problematic and doesn't fit into different existing addons. To make things atm a bit easier for our addon devs, this will change the modality type of addon dialogs to PARENTLESS_MODAL which are left-out by our internal modal check in `CGUIWindowManager::ActivateWindow_Internal`.

Related discussions:
http://trac.kodi.tv/ticket/15960
https://github.com/xbmc/xbmc/pull/6828

To set the modality type for our legacy dialog `WindowDialog` I had to change the Interceptor implementation a bit. Now each addon dialog is a real `CGUIDialog` instead of a `CGUIWindow` like it was before.

@mkortstiege @Montellese mind taking a look at this.

@MartijnKaijser This should be backported if nobody cries.
