### PR TITLE
Remove git clean usage from binary-addons rule

### DIFF
--- a/tools/depends/xbmc-addons.include
+++ b/tools/depends/xbmc-addons.include
@@ -44,7 +44,7 @@ distclean:
 	rm -rf $(PLATFORM) .installed-$(PLATFORM) native
 
 .installed-$(PLATFORM): $(DEPS)
-	cd $(ADDON_PROJECT_DIR) && (git clean -xfd || rm -rf CMakeCache.txt CMakeFiles cmake_install.cmake build/*)
+	cd $(ADDON_PROJECT_DIR) && rm -rf CMakeCache.txt CMakeFiles cmake_install.cmake build/*
 	mkdir -p $(PLATFORM)
 ifeq ($(PREFIX),)
 	@echo


### PR DESCRIPTION
The usage of 'git clean' will wipe files belonging to the kodi source
tree under the following conditions:
- have a git controlled  parent directory, like $HOME
- have a work directory for kodi builds, like ~/rpmbuild
- read docs/README.linux to grasp the required steps to get bin-addons
- prepare kodi-master.tar and various addon.foo.tar with git archive
- attempt to do an offline build, like rpmbuild -ba kodi.spec
- in that kodi.spec do steps as outlined in section 4.4 of README.linux
- running the commands will wipe everything in project/cmake/addons

Steps to reproduce:

 $ mkdir $$
 $ cd $_
 $ git init
 $ mkdir kodi-version
 $ cd $_
 $ mkdir project
 $ cd $_
 $ touch a b c
 $ git clean -n -dfx
 Would remove a
 Would remove b
 Would remove c

The fix for this (valid) setup is to always have a fixed list of
files to remove and to not rely on git to do the wrong thing.

Signed-off-by: Olaf Hering olaf@aepfle.de
