### PR TITLE
[skinsettings][fix] Missing skinsetting tag is not an error and shouldn't be treated as o…

### DIFF
--- a/xbmc/settings/SkinSettings.cpp
+++ b/xbmc/settings/SkinSettings.cpp
@@ -93,10 +93,13 @@ bool CSkinSettings::Load(const TiXmlNode *settings)
     return false;
 
   const TiXmlElement *rootElement = settings->FirstChildElement(XML_SKINSETTINGS);
+  
+  //return true in the case skinsettings is missing. It just means that
+  //it's been migrated and it's not an error
   if (rootElement == nullptr)
   {
-    CLog::Log(LOGWARNING, "CSkinSettings: no <skinsettings> tag found");
-    return false;
+    CLog::Log(LOGDEBUG, "CSkinSettings: no <skinsettings> tag found");
+    return true;
   }
 
   CSingleLock lock(m_critical);


### PR DESCRIPTION
…ne, thought logging might still be useful but shouldn't be a warning as it's not really an issue.

This should fix the endless loop in #7359 
