### PR TITLE
Revert "[PVR] Series Recordings: Reduce PVR_ADDON_TIMERTYPE_VALUES_AR…

### DIFF
--- a/xbmc/addons/include/xbmc_pvr_types.h
+++ b/xbmc/addons/include/xbmc_pvr_types.h
@@ -71,7 +71,7 @@ struct DemuxPacket;
 #define PVR_ADDON_INPUT_FORMAT_STRING_LENGTH  32
 #define PVR_ADDON_EDL_LENGTH                  32
 #define PVR_ADDON_TIMERTYPE_ARRAY_SIZE        32
-#define PVR_ADDON_TIMERTYPE_VALUES_ARRAY_SIZE 64
+#define PVR_ADDON_TIMERTYPE_VALUES_ARRAY_SIZE 512
 #define PVR_ADDON_TIMERTYPE_STRING_LENGTH     64
 
 /* using the default avformat's MAX_STREAMS value to be safe */


### PR DESCRIPTION
…RAY_SIZE value, avoiding too large data structures."

This reverts commit 1bcdc418d4bc25fa2f96ac85b9633ffb78a506fe.
