### PR TITLE
[PVR] Transfer timer types using addon callback

### DIFF
--- a/addons/library.xbmc.pvr/libXBMC_pvr.h
+++ b/addons/library.xbmc.pvr/libXBMC_pvr.h
@@ -108,6 +108,10 @@ public:
       dlsym(m_libXBMC_pvr, "PVR_transfer_recording_entry");
     if (PVR_transfer_recording_entry == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
+    PVR_transfer_timer_type_entry = (void (*)(void* HANDLE, void* CB, const ADDON_HANDLE handle, const PVR_TIMER_TYPE *timertype))
+      dlsym(m_libXBMC_pvr, "PVR_transfer_timer_type_entry");
+    if (PVR_transfer_timer_type_entry == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+
     PVR_add_menu_hook = (void (*)(void* HANDLE, void* CB, PVR_MENUHOOK *hook))
       dlsym(m_libXBMC_pvr, "PVR_add_menu_hook");
     if (PVR_add_menu_hook == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
@@ -176,6 +180,16 @@ public:
   void TransferChannelEntry(const ADDON_HANDLE handle, const PVR_CHANNEL* entry)
   {
     return PVR_transfer_channel_entry(m_Handle, m_Callbacks, handle, entry);
+  }
+
+  /*!
+   * @brief Transfer a timer type entry from the add-on to XBMC
+   * @param handle The handle parameter that XBMC used when requesting the timer types list
+   * @param entry The entry to transfer to XBMC
+   */
+  void TransferTimerTypeEntry(const ADDON_HANDLE handle, const PVR_TIMER_TYPE* entry)
+  {
+    return PVR_transfer_timer_type_entry(m_Handle, m_Callbacks, handle, entry);
   }
 
   /*!
@@ -307,6 +321,7 @@ protected:
   void (*PVR_transfer_channel_entry)(void*, void*, const ADDON_HANDLE, const PVR_CHANNEL*);
   void (*PVR_transfer_timer_entry)(void*, void*, const ADDON_HANDLE, const PVR_TIMER*);
   void (*PVR_transfer_recording_entry)(void*, void*, const ADDON_HANDLE, const PVR_RECORDING*);
+  void (*PVR_transfer_timer_type_entry)(void*, void*, const ADDON_HANDLE, const PVR_TIMER_TYPE*);
   void (*PVR_add_menu_hook)(void*, void*, PVR_MENUHOOK*);
   void (*PVR_recording)(void*, void*, const char*, const char*, bool);
   void (*PVR_trigger_channel_update)(void*, void*);

--- a/lib/addons/library.xbmc.pvr/libXBMC_pvr.cpp
+++ b/lib/addons/library.xbmc.pvr/libXBMC_pvr.cpp
@@ -92,6 +92,14 @@ DLLEXPORT void PVR_transfer_recording_entry(void *hdl, void* cb, const ADDON_HAN
   ((CB_PVRLib*)cb)->TransferRecordingEntry(((AddonCB*)hdl)->addonData, handle, recording);
 }
 
+DLLEXPORT void PVR_transfer_timer_type_entry(void *hdl, void* cb, const ADDON_HANDLE handle, const PVR_TIMER_TYPE *timertype)
+{
+  if (cb == NULL)
+    return;
+
+  ((CB_PVRLib*)cb)->TransferTimerTypeEntry(((AddonCB*)hdl)->addonData, handle, timertype);
+}
+
 DLLEXPORT void PVR_add_menu_hook(void *hdl, void* cb, PVR_MENUHOOK *hook)
 {
   if (cb == NULL)

--- a/xbmc/addons/AddonCallbacks.h
+++ b/xbmc/addons/AddonCallbacks.h
@@ -366,6 +366,7 @@ typedef void (*PVRTransferEpgEntry)(void *userData, const ADDON_HANDLE handle, c
 typedef void (*PVRTransferChannelEntry)(void *userData, const ADDON_HANDLE handle, const PVR_CHANNEL *chan);
 typedef void (*PVRTransferTimerEntry)(void *userData, const ADDON_HANDLE handle, const PVR_TIMER *timer);
 typedef void (*PVRTransferRecordingEntry)(void *userData, const ADDON_HANDLE handle, const PVR_RECORDING *recording);
+typedef void (*PVRTransferTimerTypeEntry)(void *userData, const ADDON_HANDLE handle, const PVR_TIMER_TYPE *timerType);
 typedef void (*PVRAddMenuHook)(void *addonData, PVR_MENUHOOK *hook);
 typedef void (*PVRRecording)(void *addonData, const char *Name, const char *FileName, bool On);
 typedef void (*PVRTriggerChannelUpdate)(void *addonData);
@@ -386,6 +387,7 @@ typedef struct CB_PVRLib
   PVRTransferChannelEntry       TransferChannelEntry;
   PVRTransferTimerEntry         TransferTimerEntry;
   PVRTransferRecordingEntry     TransferRecordingEntry;
+  PVRTransferTimerTypeEntry     TransferTimerTypeEntry;
   PVRAddMenuHook                AddMenuHook;
   PVRRecording                  Recording;
   PVRTriggerChannelUpdate       TriggerChannelUpdate;

--- a/xbmc/addons/AddonCallbacksPVR.cpp
+++ b/xbmc/addons/AddonCallbacksPVR.cpp
@@ -49,6 +49,7 @@ CAddonCallbacksPVR::CAddonCallbacksPVR(CAddon* addon)
   m_callbacks->TransferChannelEntry       = PVRTransferChannelEntry;
   m_callbacks->TransferTimerEntry         = PVRTransferTimerEntry;
   m_callbacks->TransferRecordingEntry     = PVRTransferRecordingEntry;
+  m_callbacks->TransferTimerTypeEntry     = PVRTransferTimerTypeEntry;
   m_callbacks->AddMenuHook                = PVRAddMenuHook;
   m_callbacks->Recording                  = PVRRecording;
   m_callbacks->TriggerChannelUpdate       = PVRTriggerChannelUpdate;
@@ -193,6 +194,32 @@ void CAddonCallbacksPVR::PVRTransferRecordingEntry(void *addonData, const ADDON_
   /* transfer this entry to the recordings container */
   CPVRRecordingPtr transferRecording(new CPVRRecording(*recording, client->GetID()));
   xbmcRecordings->UpdateFromClient(transferRecording);
+}
+
+void CAddonCallbacksPVR::PVRTransferTimerTypeEntry(void *addonData, const ADDON_HANDLE handle, const PVR_TIMER_TYPE *timerType)
+{
+  if (!handle)
+  {
+    CLog::Log(LOGERROR, "PVR - %s - invalid handler data", __FUNCTION__);
+    return;
+  }
+
+  CPVRClient *client             = GetPVRClient(addonData);
+  CPVRTimerTypes *xbmcTimerTypes = static_cast<CPVRTimerTypes *>(handle->dataAddress);
+  if (!timerType || !client || !xbmcTimerTypes)
+  {
+    CLog::Log(LOGERROR, "PVR - %s - invalid handler data", __FUNCTION__);
+    return;
+  }
+
+  if (timerType->iId == PVR_TIMER_TYPE_NONE)
+    CLog::Log(LOGERROR, "PVR - invalid timer type supplied by add-on '%s'. Please contact the developer of this add-on: %s", client->GetFriendlyName().c_str(), client->Author().c_str());
+  else
+  {
+    /* transfer this entry to the timer types container */
+    CPVRTimerTypePtr transferTimerType(new CPVRTimerType(*timerType, client->GetID()));
+    xbmcTimerTypes->push_back(transferTimerType);
+  }
 }
 
 void CAddonCallbacksPVR::PVRTransferTimerEntry(void *addonData, const ADDON_HANDLE handle, const PVR_TIMER *timer)

--- a/xbmc/addons/AddonCallbacksPVR.h
+++ b/xbmc/addons/AddonCallbacksPVR.h
@@ -79,6 +79,14 @@ public:
   static void PVRTransferChannelEntry(void* addonData, const ADDON_HANDLE handle, const PVR_CHANNEL* entry);
 
   /*!
+   * @brief Transfer a timer type entry from the add-on to XBMC
+   * @param addonData A pointer to the add-on.
+   * @param handle The handle parameter that XBMC used when requesting the timer type list
+   * @param entry The entry to transfer to XBMC
+   */
+  static void PVRTransferTimerTypeEntry(void *addonData, const ADDON_HANDLE handle, const PVR_TIMER_TYPE *entry);
+
+  /*!
    * @brief Transfer a timer entry from the add-on to XBMC
    * @param addonData A pointer to the add-on.
    * @param handle The handle parameter that XBMC used when requesting the timers list

--- a/xbmc/addons/include/xbmc_pvr_dll.h
+++ b/xbmc/addons/include/xbmc_pvr_dll.h
@@ -332,12 +332,13 @@ extern "C"
 
   /*!
   * Retrieve the timer types supported by the backend.
-  * @param types out: The function has to write the definition of the supported timer types into this array.
+  * Timer type entries are added to XBMC by calling TransferTimerTypeEntry() on the callback.
+  * @param handle Handle to pass to the callback method.
   * @param typesCount in: The maximum size of the list, out: the actual size of the list. default: PVR_ADDON_TIMERTYPE_ARRAY_SIZE
   * @return PVR_ERROR_NO_ERROR if the types were successfully written to the array.
   * @remarks Required if bSupportsTimers is set to true. Return PVR_ERROR_NOT_IMPLEMENTED if this add-on won't provide this function.
   */
-  PVR_ERROR GetTimerTypes(PVR_TIMER_TYPE types[], int *typesCount);
+  PVR_ERROR GetTimerTypes(ADDON_HANDLE handle);
 
   //@}
   /** @name PVR timer methods

--- a/xbmc/addons/include/xbmc_pvr_types.h
+++ b/xbmc/addons/include/xbmc_pvr_types.h
@@ -497,7 +497,7 @@ extern "C" {
     PVR_ERROR    (__cdecl* SetRecordingLastPlayedPosition)(const PVR_RECORDING&, int);
     int          (__cdecl* GetRecordingLastPlayedPosition)(const PVR_RECORDING&);
     PVR_ERROR    (__cdecl* GetRecordingEdl)(const PVR_RECORDING&, PVR_EDL_ENTRY[], int*);
-    PVR_ERROR    (__cdecl* GetTimerTypes)(PVR_TIMER_TYPE[], int*);
+    PVR_ERROR    (__cdecl* GetTimerTypes)(ADDON_HANDLE);
     int          (__cdecl* GetTimersAmount)(void);
     PVR_ERROR    (__cdecl* GetTimers)(ADDON_HANDLE);
     PVR_ERROR    (__cdecl* AddTimer)(const PVR_TIMER&);

--- a/xbmc/pvr/timers/PVRTimerType.cpp
+++ b/xbmc/pvr/timers/PVRTimerType.cpp
@@ -125,6 +125,24 @@ bool CPVRTimerType::operator !=(const CPVRTimerType& right) const
 
 void CPVRTimerType::InitAttributeValues(const PVR_TIMER_TYPE &type)
 {
+  if (strlen(type.strDescription) == 0)
+  {
+    int id;
+    if (type.iAttributes & PVR_TIMER_TYPE_IS_REPEATING)
+    {
+      id = (type.iAttributes & PVR_TIMER_TYPE_IS_MANUAL)
+         ? 822  // "Repeating"
+         : 823; // "Repeating (Guide-based)"
+    }
+    else
+    {
+      id = (type.iAttributes & PVR_TIMER_TYPE_IS_MANUAL)
+         ? 820  // "One Time"
+         : 821; // "One Time (Guide-based)
+    }
+    m_strDescription.assign(g_localizeStrings.Get(id));
+  }
+
   InitPriorityValues(type);
   InitLifetimeValues(type);
   InitPreventDuplicateEpisodesValues(type);


### PR DESCRIPTION
Use callback method to transfer timer types list.
That allow to increase some limitations:
- Size of struct PVR_TIMER_TYPE
- Number of timer type

The new addon callback method is TransferTimerTypeEntry(). The usage is same as others collections (channels, recordings etc).
