### PR TITLE
[videodb] fix browsing tvshows genre/studios with masterlock enabled

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -4911,7 +4911,8 @@ bool CVideoDatabase::GetNavCommon(const std::string& strBaseDir, CFileItemList& 
         view_id    = "idShow";
         media_type = MediaTypeTvShow;
         // in order to make use of FieldPlaycount in smart playlists we need an extra join
-        extraJoin  = PrepareSQL("JOIN tvshow_view ON tvshow_view.idShow = tag_link.media_id");
+        if (StringUtils::EqualsNoCase(type, "tag"))
+          extraJoin  = PrepareSQL("JOIN tvshow_view ON tvshow_view.idShow = tag_link.media_id AND tag_link.media_type='tvshow'");
       }
       else if (idContent == VIDEODB_CONTENT_MUSICVIDEOS)
       {


### PR DESCRIPTION
This fixes tvshow genre and studio browsing after https://github.com/xbmc/xbmc/pull/7338.

After having a brief chat with @Montellese, i think this is the less intrusive fix we can do at this point. We really need to cleanup `GetCommonNav` and the other places where we do weird queries based on whether or not the current user has masterlock enabled.
