### PR TITLE
[guilib] - fix missing fadelabel text (introduced with #7323)

### DIFF
--- a/xbmc/guilib/GUIFadeLabelControl.cpp
+++ b/xbmc/guilib/GUIFadeLabelControl.cpp
@@ -35,7 +35,6 @@ CGUIFadeLabelControl::CGUIFadeLabelControl(int parentID, int controlID, float po
   m_scrollSpeed = labelInfo.scrollSpeed;  // save it for later
   m_resetOnLabelChange = resetOnLabelChange;
   m_shortText = true;
-  m_width = 0;
 }
 
 CGUIFadeLabelControl::CGUIFadeLabelControl(const CGUIFadeLabelControl &from)


### PR DESCRIPTION
Fixes missing text for fadelabels introduced in https://github.com/xbmc/xbmc/pull/7323
m_width already gets initialized in CGUIControl.
