### PR TITLE
[interfaces] fix render order of addon dialogs

### DIFF
--- a/xbmc/interfaces/legacy/Window.h
+++ b/xbmc/interfaces/legacy/Window.h
@@ -31,6 +31,11 @@ namespace XBMCAddon
 {
   namespace xbmcgui
   {
+    enum RenderOrder {
+      WINDOW = 0,
+      DIALOG = 1
+    };
+
     // Forward declare the interceptor as the AddonWindowInterceptor.h 
     // file needs to include the Window class because of the template
     class InterceptorBase;

--- a/xbmc/interfaces/legacy/WindowDialog.cpp
+++ b/xbmc/interfaces/legacy/WindowDialog.cpp
@@ -32,7 +32,10 @@ namespace XBMCAddon
       Window(true), WindowDialogMixin(this)
     {
       CSingleLock lock(g_graphicsContext);
-      setWindow(new Interceptor<CGUIWindow>("CGUIWindow",this,getNextAvailableWindowId()));
+      InterceptorBase* interceptor = new Interceptor<CGUIWindow>("CGUIWindow", this, getNextAvailableWindowId());
+      // set the render order to the dialog's default because this dialog is mapped to CGUIWindow instead of CGUIDialog
+      interceptor->SetRenderOrder(RenderOrder::DIALOG);
+      setWindow(interceptor);
     }
 
     WindowDialog::~WindowDialog() { deallocating(); }

--- a/xbmc/interfaces/legacy/WindowInterceptor.h
+++ b/xbmc/interfaces/legacy/WindowInterceptor.h
@@ -67,7 +67,9 @@ namespace XBMCAddon
 
       virtual CGUIWindow* get() = 0;
 
-      virtual void setActive(bool active) { } ;
+      virtual void SetRenderOrder(int renderOrder) { }
+
+      virtual void setActive(bool active) { }
       virtual bool isActive() { return false; }
       
       friend class ref;
@@ -173,6 +175,8 @@ namespace XBMCAddon
       virtual bool    IsDialogRunning() const { XBMC_TRACE; return checkedb(IsDialogRunning()); };
       virtual bool    IsDialog() const { XBMC_TRACE; return checkedb(IsDialog()); };
       virtual bool    IsMediaWindow() const { XBMC_TRACE; return checkedb(IsMediaWindow());; };
+
+      virtual void    SetRenderOrder(int renderOrder) { XBMC_TRACE; P::m_renderOrder = renderOrder; }
 
       virtual void    setActive(bool active) { XBMC_TRACE; P::m_active = active; }
       virtual bool    isActive() { XBMC_TRACE; return P::m_active; }

--- a/xbmc/interfaces/legacy/WindowXML.cpp
+++ b/xbmc/interfaces/legacy/WindowXML.cpp
@@ -494,6 +494,21 @@ namespace XBMCAddon
       g_windowManager.RemoveDialog(interceptor->GetID());
       WindowXML::OnDeinitWindow(nextWindowID);
     }
+
+    bool WindowXMLDialog::LoadXML(const String &strPath, const String &strLowerPath)
+    {
+      XBMC_TRACE;
+      if (WindowXML::LoadXML(strPath, strLowerPath))
+      {
+        // Set the render order to the dialog's default in case it's not specified in the skin xml
+        // because this dialog is mapped to CGUIMediaWindow instead of CGUIDialog.
+        // This must be done here, because the render order will be reset before loading the skin xml.
+        if (ref(window)->GetRenderOrder() == RenderOrder::WINDOW)
+          window->SetRenderOrder(RenderOrder::DIALOG);
+        return true;
+      }
+      return false;
+    }
   
   }
 

--- a/xbmc/interfaces/legacy/WindowXML.h
+++ b/xbmc/interfaces/legacy/WindowXML.h
@@ -238,6 +238,8 @@ namespace XBMCAddon
       SWIGHIDDENVIRTUAL bool    OnAction(const CAction &action);
       SWIGHIDDENVIRTUAL void    OnDeinitWindow(int nextWindowID);
 
+      SWIGHIDDENVIRTUAL bool    LoadXML(const String &strPath, const String &strPathLower);
+
       SWIGHIDDENVIRTUAL inline void show() { XBMC_TRACE; WindowDialogMixin::show(); }
       SWIGHIDDENVIRTUAL inline void close() { XBMC_TRACE; WindowDialogMixin::close(); }
 


### PR DESCRIPTION
As reported by @phil65 the render order (zorder) is wrong for addon dialogs. This will fixes the issue by setting the render order of the addon dialogs to the same value (1) like we have for our internal dialogs.

@phil65 it would be great if you could test this PR and if it works like expected we should backport it.

@MartijnKaijser ping you too because of the backport.
