### PR TITLE
[XBMC][ADDONS] Got rid of boost::totally_ordered from AddonVersion

### DIFF
--- a/xbmc/addons/AddonVersion.cpp
+++ b/xbmc/addons/AddonVersion.cpp
@@ -100,11 +100,31 @@ namespace ADDON
     return (CompareComponent(mRevision.c_str(), other.mRevision.c_str()) < 0);
   }
 
+  bool AddonVersion::operator>(const AddonVersion & other) const
+  {
+    return !(*this <= other);
+  }
+
   bool AddonVersion::operator==(const AddonVersion& other) const
   {
     return mEpoch == other.mEpoch
       && CompareComponent(mUpstream.c_str(), other.mUpstream.c_str()) == 0
       && CompareComponent(mRevision.c_str(), other.mRevision.c_str()) == 0;
+  }
+
+  bool AddonVersion::operator!=(const AddonVersion & other) const
+  {
+    return !(*this == other);
+  }
+
+  bool AddonVersion::operator<=(const AddonVersion& other) const
+  {
+    return *this < other || *this == other;
+  }
+
+  bool AddonVersion::operator>=(const AddonVersion & other) const
+  {
+    return !(*this < other);
   }
 
   bool AddonVersion::empty() const

--- a/xbmc/addons/AddonVersion.h
+++ b/xbmc/addons/AddonVersion.h
@@ -19,7 +19,6 @@
  */
 
 #include <string>
-#include <boost/operators.hpp>
 
 namespace ADDON
 {
@@ -35,7 +34,8 @@ namespace ADDON
 
     See here for more info: http://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-Version
     */
-  class AddonVersion : public boost::totally_ordered<AddonVersion> {
+  class AddonVersion
+  {
   public:
     AddonVersion(const AddonVersion& other) { *this = other; }
     explicit AddonVersion(const std::string& version);
@@ -46,8 +46,12 @@ namespace ADDON
     const std::string &Revision() const { return mRevision; }
 
     AddonVersion& operator=(const AddonVersion& other);
-    bool operator<(const AddonVersion& other) const;
+    bool operator< (const AddonVersion& other) const;
+    bool operator> (const AddonVersion& other) const;
+    bool operator<=(const AddonVersion& other) const;
+    bool operator>=(const AddonVersion& other) const;
     bool operator==(const AddonVersion& other) const;
+    bool operator!=(const AddonVersion& other) const;
     std::string asString() const;
     bool empty() const;
 


### PR DESCRIPTION
silly to use boost to avoid writing operators.
