### PR TITLE
[DirectoryNode] add 'All albums' option

### DIFF
--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.cpp
@@ -336,6 +336,11 @@ void CDirectoryNode::AddQueuingFolder(CFileItemList& items) const
         pItem->GetVideoInfoTag()->m_type = MediaTypeSeason;
       }
       break;
+    case NODE_TYPE_MUSICVIDEOS_ALBUM:
+      pItem.reset(new CFileItem(g_localizeStrings.Get(15102)));  // "All Albums"
+      videoUrl.AppendPath("-1/");
+      pItem->SetPath(videoUrl.ToString());
+      break;
     default:
       break;
   }


### PR DESCRIPTION
This is a pick/cleanup from https://github.com/xbmc/xbmc/pull/6871 apparently @sialivi is overwhelmed by git.

Adds the missing "All albums" option when browsing Music Videos by Artist
requested in http://forum.kodi.tv/showthread.php?tid=185443

Can backport to Isengard if desired.
