### PR TITLE
[pvr] Show ".." label when displaying children of repeating timers

### DIFF
--- a/xbmc/pvr/windows/GUIViewStatePVR.cpp
+++ b/xbmc/pvr/windows/GUIViewStatePVR.cpp
@@ -23,6 +23,7 @@
 #include "FileItem.h"
 #include "settings/Settings.h"
 #include "view/ViewStateSettings.h"
+#include "pvr/timers/PVRTimers.h"
 
 using namespace PVR;
 
@@ -89,6 +90,11 @@ CGUIViewStateWindowPVRTimers::CGUIViewStateWindowPVRTimers(const int windowId, c
 void CGUIViewStateWindowPVRTimers::SaveViewState(void)
 {
   SaveViewToDb("pvr://timers/", m_windowId, CViewStateSettings::Get().Get("pvrtimers"));
+}
+
+bool CGUIViewStateWindowPVRTimers::HideParentDirItems(void)
+{
+  return (CGUIViewState::HideParentDirItems() || CPVRTimersPath(m_items.GetPath()).IsTimersRoot());
 }
 
 CGUIViewStateWindowPVRSearch::CGUIViewStateWindowPVRSearch(const int windowId, const CFileItemList& items) : CGUIViewStatePVR(windowId, items)

--- a/xbmc/pvr/windows/GUIViewStatePVR.h
+++ b/xbmc/pvr/windows/GUIViewStatePVR.h
@@ -69,6 +69,7 @@ namespace PVR
 
   protected:
     virtual void SaveViewState();
+    virtual bool HideParentDirItems(void);
   };
 
   class CGUIViewStateWindowPVRSearch : public CGUIViewStatePVR


### PR DESCRIPTION
Show ".." ParentItem label when displaying children of repeating timers (whllst honoring the GUI Appearance Setting controlling this behaviour)

Add Override for HideParentIdrItems for PVRTimers window.  
Returns true when on the main timer view (path pvr://timers/tv/grouped) 
Else returns the base implementatino (which honors the "Show Parent Items" setting in Settings->Appearance->File Lists

As discussed here http://forum.kodi.tv/showthread.php?tid=227026&pid=2050534#pid2050534
@ksooo @metaron-uk
