### PR TITLE
[guilib] fix dirty regions because it evaluates always to true

### DIFF
--- a/xbmc/guilib/GUIEditControl.cpp
+++ b/xbmc/guilib/GUIEditControl.cpp
@@ -486,17 +486,17 @@ void CGUIEditControl::ProcessText(unsigned int currentTime)
     changed |= m_label2.SetMaxRect(m_clipRect.x1 + m_textOffset, m_posY, m_clipRect.Width() - m_textOffset, m_height);
 
     std::wstring text = GetDisplayedText();
-    std::string hint = m_hintInfo.GetLabel(GetParentID());
 
-    if (!HasFocus() && text.empty() && !hint.empty())
-      changed |= m_label2.SetText(hint);
-    else
+    if (!HasFocus() && text.empty())
     {
-      if (m_inputType != INPUT_TYPE_READONLY)
-        changed |= SetStyledText(text);
-      else
-        changed |= m_label2.SetTextW(text);
+      std::string hint = m_hintInfo.GetLabel(GetParentID());
+      if (!hint.empty())
+        changed |= m_label2.SetText(hint);
     }
+    else if (HasFocus() && m_inputType != INPUT_TYPE_READONLY)
+      changed |= SetStyledText(text);
+    else
+      changed |= m_label2.SetTextW(text);
 
     changed |= m_label2.SetAlign(align);
     changed |= m_label2.SetColor(GetTextColor());


### PR DESCRIPTION
Fix the issue reported by @FernetMenta at https://github.com/xbmc/xbmc/commit/c03ecbeff265d422cc503806023cc1b28050e7bb#commitcomment-12151646

@mkortstiege ping
