### PR TITLE
Add disabled textures for radio buttons and spin controls

### DIFF
--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -705,6 +705,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   CTextureInfo textureLeftFocus, textureRightFocus;
   CTextureInfo textureUp, textureDown;
   CTextureInfo textureUpFocus, textureDownFocus;
+  CTextureInfo textureUpDisabled, textureDownDisabled;
   CTextureInfo texture, borderTexture;
   CGUIInfoLabel textureFile;
   CTextureInfo textureCheckMark, textureCheckMarkNF;
@@ -712,6 +713,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   CTextureInfo textureAltFocus, textureAltNoFocus;
   CTextureInfo textureRadioOnFocus, textureRadioOnNoFocus;
   CTextureInfo textureRadioOffFocus, textureRadioOffNoFocus;
+  CTextureInfo textureRadioOnDisabled, textureRadioOffDisabled;
   CTextureInfo imageNoFocus, imageFocus;
   CTextureInfo textureProgressIndicator;
   CGUIInfoLabel texturePath;
@@ -888,6 +890,8 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   GetTexture(pControlNode, "texturedown", textureDown);
   GetTexture(pControlNode, "textureupfocus", textureUpFocus);
   GetTexture(pControlNode, "texturedownfocus", textureDownFocus);
+  GetTexture(pControlNode, "textureupdisabled", textureUpDisabled);
+  GetTexture(pControlNode, "texturedowndisabled", textureDownDisabled);
 
   GetTexture(pControlNode, "textureleft", textureLeft);
   GetTexture(pControlNode, "textureright", textureRight);
@@ -922,7 +926,8 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
     GetTexture(pControlNode, "textureradiooff", textureRadioOffFocus);
     textureRadioOffNoFocus = textureRadioOffFocus;
   }
-
+  GetTexture(pControlNode, "textureradioondisabled", textureRadioOnDisabled);
+  GetTexture(pControlNode, "textureradiooffdisabled", textureRadioOffDisabled);
   GetTexture(pControlNode, "texturesliderbackground", textureBackground);
   GetTexture(pControlNode, "texturesliderbar", textureBar);
   GetTexture(pControlNode, "texturesliderbarfocus", textureBarFocus);
@@ -1234,7 +1239,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
         parentID, id, posX, posY, width, height,
         textureFocus, textureNoFocus,
         labelInfo,
-        textureRadioOnFocus, textureRadioOnNoFocus, textureRadioOffFocus, textureRadioOffNoFocus);
+        textureRadioOnFocus, textureRadioOnNoFocus, textureRadioOffFocus, textureRadioOffNoFocus, textureRadioOnDisabled, textureRadioOffDisabled);
 
       ((CGUIRadioButtonControl *)control)->SetLabel(strLabel);
       ((CGUIRadioButtonControl *)control)->SetRadioDimensions(radioPosX, radioPosY, radioWidth, radioHeight);
@@ -1259,6 +1264,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
       control = new CGUISpinControl(
         parentID, id, posX, posY, width, height,
         textureUp, textureDown, textureUpFocus, textureDownFocus,
+        textureUpDisabled, textureDownDisabled,
         labelInfo, iType);
 
       ((CGUISpinControl *)control)->SetReverse(bReverse);
@@ -1450,7 +1456,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
       control = new CGUISpinControlEx(
         parentID, id, posX, posY, width, height, spinWidth, spinHeight,
         labelInfo, textureFocus, textureNoFocus, textureUp, textureDown, textureUpFocus, textureDownFocus,
-        labelInfo, iType);
+        textureUpDisabled, textureDownDisabled, labelInfo, iType);
 
       ((CGUISpinControlEx *)control)->SetSpinPosition(spinPosX);
       ((CGUISpinControlEx *)control)->SetText(strLabel);

--- a/xbmc/guilib/GUIRadioButtonControl.cpp
+++ b/xbmc/guilib/GUIRadioButtonControl.cpp
@@ -26,12 +26,15 @@ CGUIRadioButtonControl::CGUIRadioButtonControl(int parentID, int controlID, floa
     const CTextureInfo& textureFocus, const CTextureInfo& textureNoFocus,
     const CLabelInfo& labelInfo,
     const CTextureInfo& radioOnFocus, const CTextureInfo& radioOnNoFocus,
-    const CTextureInfo& radioOffFocus, const CTextureInfo& radioOffNoFocus)
+    const CTextureInfo& radioOffFocus, const CTextureInfo& radioOffNoFocus, 
+    const CTextureInfo& radioOnDisabled, const CTextureInfo& radioOffDisabled)
     : CGUIButtonControl(parentID, controlID, posX, posY, width, height, textureFocus, textureNoFocus, labelInfo)
     , m_imgRadioOnFocus(posX, posY, 16, 16, radioOnFocus)
     , m_imgRadioOnNoFocus(posX, posY, 16, 16, radioOnNoFocus)
     , m_imgRadioOffFocus(posX, posY, 16, 16, radioOffFocus)
     , m_imgRadioOffNoFocus(posX, posY, 16, 16, radioOffNoFocus)
+    , m_imgRadioOnDisabled(posX, posY, 16, 16, radioOnDisabled)
+    , m_imgRadioOffDisabled(posX, posY, 16, 16, radioOffDisabled)
 {
   m_radioPosX = 0;
   m_radioPosY = 0;
@@ -39,6 +42,8 @@ CGUIRadioButtonControl::CGUIRadioButtonControl(int parentID, int controlID, floa
   m_imgRadioOnNoFocus.SetAspectRatio(CAspectRatio::AR_KEEP);
   m_imgRadioOffFocus.SetAspectRatio(CAspectRatio::AR_KEEP);
   m_imgRadioOffNoFocus.SetAspectRatio(CAspectRatio::AR_KEEP);
+  m_imgRadioOnDisabled.SetAspectRatio(CAspectRatio::AR_KEEP);
+  m_imgRadioOffDisabled.SetAspectRatio(CAspectRatio::AR_KEEP);
   ControlType = GUICONTROL_RADIO;
 }
 
@@ -56,13 +61,17 @@ void CGUIRadioButtonControl::Render()
     else
       m_imgRadioOnNoFocus.Render();
   }
-  else
+  else if ( !IsSelected() && !IsDisabled() )
   {
     if (HasFocus())
       m_imgRadioOffFocus.Render();
     else
       m_imgRadioOffNoFocus.Render();
   }
+  else if ( IsSelected() && IsDisabled() )
+    m_imgRadioOnDisabled.Render();
+  else
+    m_imgRadioOffDisabled.Render();
 }
 
 void CGUIRadioButtonControl::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
@@ -83,6 +92,8 @@ void CGUIRadioButtonControl::Process(unsigned int currentTime, CDirtyRegionList 
   m_imgRadioOnNoFocus.Process(currentTime);
   m_imgRadioOffFocus.Process(currentTime);
   m_imgRadioOffNoFocus.Process(currentTime);
+  m_imgRadioOnDisabled.Process(currentTime);
+  m_imgRadioOffDisabled.Process(currentTime);
 
   CGUIButtonControl::Process(currentTime, dirtyregions);
 }
@@ -127,6 +138,8 @@ void CGUIRadioButtonControl::AllocResources()
   m_imgRadioOnNoFocus.AllocResources();
   m_imgRadioOffFocus.AllocResources();
   m_imgRadioOffNoFocus.AllocResources();
+  m_imgRadioOnDisabled.AllocResources();
+  m_imgRadioOffDisabled.AllocResources();
   SetPosition(m_posX, m_posY);
 }
 
@@ -137,6 +150,8 @@ void CGUIRadioButtonControl::FreeResources(bool immediately)
   m_imgRadioOnNoFocus.FreeResources(immediately);
   m_imgRadioOffFocus.FreeResources(immediately);
   m_imgRadioOffNoFocus.FreeResources(immediately);
+  m_imgRadioOnDisabled.FreeResources(immediately);
+  m_imgRadioOffDisabled.FreeResources(immediately);
 }
 
 void CGUIRadioButtonControl::DynamicResourceAlloc(bool bOnOff)
@@ -146,6 +161,8 @@ void CGUIRadioButtonControl::DynamicResourceAlloc(bool bOnOff)
   m_imgRadioOnNoFocus.DynamicResourceAlloc(bOnOff);
   m_imgRadioOffFocus.DynamicResourceAlloc(bOnOff);
   m_imgRadioOffNoFocus.DynamicResourceAlloc(bOnOff);
+  m_imgRadioOnDisabled.DynamicResourceAlloc(bOnOff);
+  m_imgRadioOffDisabled.DynamicResourceAlloc(bOnOff);
 }
 
 void CGUIRadioButtonControl::SetInvalid()
@@ -155,6 +172,8 @@ void CGUIRadioButtonControl::SetInvalid()
   m_imgRadioOnNoFocus.SetInvalid();
   m_imgRadioOffFocus.SetInvalid();
   m_imgRadioOffNoFocus.SetInvalid();
+  m_imgRadioOnDisabled.SetInvalid();
+  m_imgRadioOffDisabled.SetInvalid();
 }
 
 void CGUIRadioButtonControl::SetPosition(float posX, float posY)
@@ -166,6 +185,8 @@ void CGUIRadioButtonControl::SetPosition(float posX, float posY)
   m_imgRadioOnNoFocus.SetPosition(radioPosX, radioPosY);
   m_imgRadioOffFocus.SetPosition(radioPosX, radioPosY);
   m_imgRadioOffNoFocus.SetPosition(radioPosX, radioPosY);
+  m_imgRadioOnDisabled.SetPosition(radioPosX, radioPosY);
+  m_imgRadioOffDisabled.SetPosition(radioPosX, radioPosY);
 }
 
 void CGUIRadioButtonControl::SetRadioDimensions(float posX, float posY, float width, float height)
@@ -178,6 +199,8 @@ void CGUIRadioButtonControl::SetRadioDimensions(float posX, float posY, float wi
     m_imgRadioOnNoFocus.SetWidth(width);
     m_imgRadioOffFocus.SetWidth(width);
     m_imgRadioOffNoFocus.SetWidth(width);
+    m_imgRadioOnDisabled.SetWidth(width);
+    m_imgRadioOffDisabled.SetWidth(width);
   }
   if (height)
   {
@@ -185,6 +208,8 @@ void CGUIRadioButtonControl::SetRadioDimensions(float posX, float posY, float wi
     m_imgRadioOnNoFocus.SetHeight(height);
     m_imgRadioOffFocus.SetHeight(height);
     m_imgRadioOffNoFocus.SetHeight(height);
+    m_imgRadioOnDisabled.SetHeight(height);
+    m_imgRadioOffDisabled.SetHeight(height);
   }
   SetPosition(GetXPosition(), GetYPosition());
 }
@@ -218,6 +243,8 @@ bool CGUIRadioButtonControl::UpdateColors()
   changed |= m_imgRadioOnNoFocus.SetDiffuseColor(m_diffuseColor);
   changed |= m_imgRadioOffFocus.SetDiffuseColor(m_diffuseColor);
   changed |= m_imgRadioOffNoFocus.SetDiffuseColor(m_diffuseColor);
+  changed |= m_imgRadioOnDisabled.SetDiffuseColor(m_diffuseColor);
+  changed |= m_imgRadioOffDisabled.SetDiffuseColor(m_diffuseColor);
   return changed;
 }
 

--- a/xbmc/guilib/GUIRadioButtonControl.h
+++ b/xbmc/guilib/GUIRadioButtonControl.h
@@ -40,7 +40,8 @@ public:
                          const CTextureInfo& textureFocus, const CTextureInfo& textureNoFocus,
                          const CLabelInfo& labelInfo,
                          const CTextureInfo& radioOnFocus, const CTextureInfo& radioOnNoFocus,
-                         const CTextureInfo& radioOffFocus, const CTextureInfo& radioOffNoFocus);
+                         const CTextureInfo& radioOffFocus, const CTextureInfo& radioOffNoFocus,
+                         const CTextureInfo& radioOnDisabled, const CTextureInfo& radioOffDisabled);
 
   virtual ~CGUIRadioButtonControl(void);
   virtual CGUIRadioButtonControl *Clone() const { return new CGUIRadioButtonControl(*this); };
@@ -67,6 +68,8 @@ protected:
   CGUITexture m_imgRadioOnNoFocus;
   CGUITexture m_imgRadioOffFocus;
   CGUITexture m_imgRadioOffNoFocus;
+  CGUITexture m_imgRadioOnDisabled;
+  CGUITexture m_imgRadioOffDisabled;
   float m_radioPosX;
   float m_radioPosY;
   INFO::InfoPtr m_toggleSelect;

--- a/xbmc/guilib/GUISpinControl.h
+++ b/xbmc/guilib/GUISpinControl.h
@@ -44,7 +44,7 @@
 class CGUISpinControl : public CGUIControl
 {
 public:
-  CGUISpinControl(int parentID, int controlID, float posX, float posY, float width, float height, const CTextureInfo& textureUp, const CTextureInfo& textureDown, const CTextureInfo& textureUpFocus, const CTextureInfo& textureDownFocus, const CLabelInfo& labelInfo, int iType);
+  CGUISpinControl(int parentID, int controlID, float posX, float posY, float width, float height, const CTextureInfo& textureUp, const CTextureInfo& textureDown, const CTextureInfo& textureUpFocus, const CTextureInfo& textureDownFocus, const CTextureInfo& textureUpDisabled, const CTextureInfo& textureDownDisabled, const CLabelInfo& labelInfo, int iType);
   virtual ~CGUISpinControl(void);
   virtual CGUISpinControl *Clone() const { return new CGUISpinControl(*this); };
 
@@ -125,6 +125,8 @@ protected:
   CGUITexture m_imgspinDown;
   CGUITexture m_imgspinUpFocus;
   CGUITexture m_imgspinDownFocus;
+  CGUITexture m_imgspinUpDisabled;
+  CGUITexture m_imgspinDownDisabled;
   CGUILabel   m_label;
   bool m_bShowRange;
   char m_szTyped[10];

--- a/xbmc/guilib/GUISpinControlEx.cpp
+++ b/xbmc/guilib/GUISpinControlEx.cpp
@@ -21,8 +21,8 @@
 #include "GUISpinControlEx.h"
 #include "utils/StringUtils.h"
 
-CGUISpinControlEx::CGUISpinControlEx(int parentID, int controlID, float posX, float posY, float width, float height, float spinWidth, float spinHeight, const CLabelInfo& spinInfo, const CTextureInfo &textureFocus, const CTextureInfo &textureNoFocus, const CTextureInfo& textureUp, const CTextureInfo& textureDown, const CTextureInfo& textureUpFocus, const CTextureInfo& textureDownFocus, const CLabelInfo& labelInfo, int iType)
-    : CGUISpinControl(parentID, controlID, posX, posY, spinWidth, spinHeight, textureUp, textureDown, textureUpFocus, textureDownFocus, spinInfo, iType)
+CGUISpinControlEx::CGUISpinControlEx(int parentID, int controlID, float posX, float posY, float width, float height, float spinWidth, float spinHeight, const CLabelInfo& spinInfo, const CTextureInfo &textureFocus, const CTextureInfo &textureNoFocus, const CTextureInfo& textureUp, const CTextureInfo& textureDown, const CTextureInfo& textureUpFocus, const CTextureInfo& textureDownFocus, const CTextureInfo& textureUpDisabled, const CTextureInfo& textureDownDisabled, const CLabelInfo& labelInfo, int iType)
+    : CGUISpinControl(parentID, controlID, posX, posY, spinWidth, spinHeight, textureUp, textureDown, textureUpFocus, textureDownFocus, textureUpDisabled, textureDownDisabled, spinInfo, iType)
     , m_buttonControl(parentID, controlID, posX, posY, width, height, textureFocus, textureNoFocus, labelInfo)
 {
   ControlType = GUICONTROL_SPINEX;

--- a/xbmc/guilib/GUISpinControlEx.h
+++ b/xbmc/guilib/GUISpinControlEx.h
@@ -38,7 +38,7 @@
 class CGUISpinControlEx : public CGUISpinControl
 {
 public:
-  CGUISpinControlEx(int parentID, int controlID, float posX, float posY, float width, float height, float spinWidth, float spinHeight, const CLabelInfo& spinInfo, const CTextureInfo &textureFocus, const CTextureInfo &textureNoFocus, const CTextureInfo& textureUp, const CTextureInfo& textureDown, const CTextureInfo& textureUpFocus, const CTextureInfo& textureDownFocus, const CLabelInfo& labelInfo, int iType);
+  CGUISpinControlEx(int parentID, int controlID, float posX, float posY, float width, float height, float spinWidth, float spinHeight, const CLabelInfo& spinInfo, const CTextureInfo &textureFocus, const CTextureInfo &textureNoFocus, const CTextureInfo& textureUp, const CTextureInfo& textureDown, const CTextureInfo& textureUpFocus, const CTextureInfo& textureDownFocus, const CTextureInfo& textureUpDisabled, const CTextureInfo& textureDownDisabled, const CLabelInfo& labelInfo, int iType);
   virtual ~CGUISpinControlEx(void);
   virtual CGUISpinControlEx *Clone() const { return new CGUISpinControlEx(*this); };
 

--- a/xbmc/interfaces/legacy/Control.cpp
+++ b/xbmc/interfaces/legacy/Control.cpp
@@ -598,8 +598,9 @@ namespace XBMCAddon
                                            long _textOffsetX, long _textOffsetY,
                                            long alignment, const char* font, const char* _textColor,
                                            const char* _disabledColor, long angle,
-                                           const char* _shadowColor, const char* _focusedColor) :
-      strFont("font13"), textColor(0xffffffff), disabledColor(0x60ffffff),
+                                           const char* _shadowColor, const char* _focusedColor,
+                                           const char* disabledOnTexture, const char* disabledOffTexture) :
+      strFont("font13"), textColor(0xffffffff), disabledColor(0x60ffffff), 
       textOffsetX(_textOffsetX), textOffsetY(_textOffsetY), align(alignment), iAngle(angle),
       shadowColor(0), focusedColor(0xffffffff)
     {
@@ -727,7 +728,9 @@ namespace XBMCAddon
         CTextureInfo(strTextureRadioOnFocus),
         CTextureInfo(strTextureRadioOnNoFocus),
         CTextureInfo(strTextureRadioOffFocus),
-        CTextureInfo(strTextureRadioOffNoFocus));
+        CTextureInfo(strTextureRadioOffNoFocus),
+        CTextureInfo(strTextureRadioOnDisabled), 
+        CTextureInfo(strTextureRadioOffDisabled));
 
       CGUIRadioButtonControl* pGuiButtonControl =
         (CGUIRadioButtonControl*)pGUIControl;
@@ -943,16 +946,22 @@ namespace XBMCAddon
       strTextureDown = XBMCAddonUtils::getDefaultImage((char*)"listcontrol", (char*)"texturedown", (char*)"scroll-down.png");
       strTextureUpFocus = XBMCAddonUtils::getDefaultImage((char*)"listcontrol", (char*)"textureupfocus", (char*)"scroll-up-focus.png");
       strTextureDownFocus = XBMCAddonUtils::getDefaultImage((char*)"listcontrol", (char*)"texturedownfocus", (char*)"scroll-down-focus.png");
+      strTextureUpDisabled = XBMCAddonUtils::getDefaultImage((char*)"listcontrol", (char*)"textureupdisabled", (char*)"scroll-up.png");
+      strTextureDownDisabled = XBMCAddonUtils::getDefaultImage((char*)"listcontrol", (char*)"texturedowndisabled", (char*)"scroll-down.png");
     }
 
-    void ControlSpin::setTextures(const char* up, const char* down,
-                                  const char* upFocus,
-                                  const char* downFocus)
+    void ControlSpin::setTextures(const char* up, const char* down, 
+                                  const char* upFocus, 
+                                  const char* downFocus,
+                                  const char* upDisabled, 
+                                  const char* downDisabled)
     {
       strTextureUp = up;
       strTextureDown = down;
       strTextureUpFocus = upFocus;
       strTextureDownFocus = downFocus;
+      strTextureUpDisabled = upDisabled;
+      strTextureDownDisabled = downDisabled;
       /*
         PyXBMCGUILock();
         if (self->pGUIControl)

--- a/xbmc/interfaces/legacy/Control.h
+++ b/xbmc/interfaces/legacy/Control.h
@@ -328,13 +328,16 @@ namespace XBMCAddon
        */
       virtual void setTextures(const char* up, const char* down, 
                                const char* upFocus, 
-                               const char* downFocus);
+                               const char* downFocus,
+                               const char* upDisabled, const char* downDisabled);
 #ifndef SWIG
       color_t color;
       std::string strTextureUp;
       std::string strTextureDown;
       std::string strTextureUpFocus;
       std::string strTextureDownFocus;
+      std::string strTextureUpDisabled;
+      std::string strTextureDownDisabled;
 #endif
 
     private:
@@ -1350,13 +1353,14 @@ namespace XBMCAddon
       ControlRadioButton(long x, long y, long width, long height, const String& label,
                          const char* focusOnTexture = NULL, const char* noFocusOnTexture = NULL,
                          const char* focusOffTexture = NULL, const char* noFocusOffTexture = NULL,
-                         const char* focusTexture = NULL, const char* noFocusTexture = NULL, 
+                         const char* focusTexture = NULL, const char* noFocusTexture = NULL,
                          long textOffsetX = CONTROL_TEXT_OFFSET_X, 
                          long textOffsetY = CONTROL_TEXT_OFFSET_Y, 
                          long _alignment = (XBFONT_LEFT | XBFONT_CENTER_Y), 
                          const char* font = NULL, const char* textColor = NULL,
                          const char* disabledColor = NULL, long angle = 0,
-                         const char* shadowColor = NULL, const char* focusedColor = NULL);
+                         const char* shadowColor = NULL, const char* focusedColor = NULL,
+                         const char* disabledOnTexture = NULL, const char* disabledOffTexture = NULL);
 
       // setSelected() Method
       /**
@@ -1434,6 +1438,8 @@ namespace XBMCAddon
       std::string strTextureRadioOnNoFocus;
       std::string strTextureRadioOffFocus;
       std::string strTextureRadioOffNoFocus;
+      std::string strTextureRadioOnDisabled;
+      std::string strTextureRadioOffDisabled;
       color_t textColor;
       color_t disabledColor;
       int textOffsetX;


### PR DESCRIPTION
Supersedes #6943

Original PR description by @bryanbrazil:

> This pull request adds support for additional textures for radio buttons and spin controls when they >are disabled. For example, the following control options are available to skins:
> 
> radiobuttons:
> `<textureradioondisabled colordiffuse="disabled">radioon.png</textureradioondisabled>`
> `<textureradiooffdisabled colordiffuse="disabled">radiooff.png</textureradiooffdisabled>`
> 
> spin controls:
> `<textureupdisabled colordiffuse="disabled">upspincontrol.png</textureupdisabled>`
> `<texturedowndisabled colordiffuse="disabled">downspincontrol.png</texturedowndisabled>`
> 
> This is the first time I've touched any C++ code in about 13 years, so go easy on me. :) I built this >on my Windows 8 htpc and it seems to work as intended. I welcome any comments or suggestions. >The one area I wasn't too sure about is the legacy interface file Control.cpp. Some additional code >may be needed there.
> 
> Forum discussion link: http://forum.kodi.tv/showthread.php?tid=224145&pid=1981755#pid1981755
> 
> Thanks!

Rest of the discussion can be read on the original PR.
@bryanbrazil, please review the commits and make sure I rebased it right and didn't fraked up/missed something.
