### PR TITLE
[baserenderer] make ViewModeStretch16x9Nonlin fall in range

### DIFF
--- a/xbmc/cores/VideoRenderers/BaseRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/BaseRenderer.cpp
@@ -620,7 +620,7 @@ void CBaseRenderer::ManageDisplay()
 
 void CBaseRenderer::SetViewMode(int viewMode)
 {
-  if (viewMode < ViewModeNormal || viewMode > ViewModeCustom)
+  if (viewMode < ViewModeNormal || viewMode > ViewModeStretch16x9Nonlin)
     viewMode = ViewModeNormal;
 
   CMediaSettings::Get().GetCurrentVideoSettings().m_ViewMode = viewMode;


### PR DESCRIPTION
Fix according to @akva2 (notspiff) https://github.com/xbmc/xbmc/pull/7387#issuecomment-121216015 and https://github.com/xbmc/xbmc/pull/7387#issuecomment-121216189

Follow up from #7357 

Im confused why my tests this works perfectly but here we are @FernetMenta  please or @mkortstiege since the other already merged.
