### PR TITLE
[EPG] Misc. EPG window fixes

### DIFF
--- a/xbmc/epg/GUIEPGGridContainer.cpp
+++ b/xbmc/epg/GUIEPGGridContainer.cpp
@@ -637,6 +637,10 @@ bool CGUIEPGGridContainer::OnAction(const CAction &action)
       ScrollToBlockOffset(m_blockOffset - (12 * 60 / MINSPERBLOCK));
       return true;
 
+    case REMOTE_0:
+      GoToNow();
+      return true;
+
     case ACTION_PAGE_UP:
       if (m_channelOffset == 0)
       { // already on the first page, so move to the first item

--- a/xbmc/epg/GUIEPGGridContainer.cpp
+++ b/xbmc/epg/GUIEPGGridContainer.cpp
@@ -738,6 +738,9 @@ bool CGUIEPGGridContainer::OnMessage(CGUIMessage& message)
       case GUI_MSG_LABEL_BIND:
         if (message.GetPointer())
         {
+          /* Safe currently selected epg tag. Selection shall be restored after update. */
+          const CEpgInfoTagPtr prevSelectedEpgTag(GetSelectedEpgInfoTag());
+
           Reset();
           CFileItemList *items = (CFileItemList *)message.GetPointer();
 
@@ -810,6 +813,49 @@ bool CGUIEPGGridContainer::OnMessage(CGUIMessage& message)
           }
 
           UpdateItems();
+
+          m_channels = m_epgItemsPtr.size();
+
+          if (prevSelectedEpgTag)
+          {
+            // Grid index got recreated. Do cursors and offsets still point to the same epg tag?
+            if (prevSelectedEpgTag == GetSelectedEpgInfoTag())
+              return true;
+
+            int newChannelCursor = GetChannel(prevSelectedEpgTag);
+            if (newChannelCursor >= 0)
+            {
+              int newBlockCursor = GetBlock(prevSelectedEpgTag, newChannelCursor);
+              if (newBlockCursor >= 0)
+              {
+                if (newChannelCursor == m_channelCursor && newBlockCursor == m_blockCursor)
+                  return true;
+
+                if (newBlockCursor > 0 && newBlockCursor != m_blockCursor)
+                {
+                  SetInvalid();
+                  SetSelectedBlock(newBlockCursor);
+                }
+
+                if (newChannelCursor != m_channelCursor)
+                {
+                  SetInvalid();
+                  SetSelectedChannel(newChannelCursor);
+                }
+
+                if (newBlockCursor > 0)
+                  return true;
+              }
+            }
+          }
+
+          // Fallback. Goto now.
+          m_item = GetItem(m_channelCursor);
+          if (m_item)
+            SetBlock(GetBlock(m_item->item, m_channelCursor));
+
+          SetInvalid();
+          GoToNow();
           return true;
         }
         break;
@@ -941,14 +987,6 @@ void CGUIEPGGridContainer::UpdateItems()
   /******************************************* END ******************************************/
 
   CLog::Log(LOGDEBUG, "CGUIEPGGridContainer - %s completed successfully in %u ms", __FUNCTION__, (unsigned int)(XbmcThreads::SystemClockMillis()-tick));
-
-  m_channels = (int)m_epgItemsPtr.size();
-  m_item = GetItem(m_channelCursor);
-  if (m_item)
-    SetBlock(GetBlock(m_item->item, m_channelCursor));
-
-  SetInvalid();
-  GoToNow();
 }
 
 void CGUIEPGGridContainer::ChannelScroll(int amount)
@@ -1321,6 +1359,32 @@ void CGUIEPGGridContainer::SetSelectedChannel(int channelIndex)
   }
 }
 
+void CGUIEPGGridContainer::SetSelectedBlock(int blockIndex)
+{
+  if (blockIndex < 0)
+    return;
+
+  if (blockIndex - m_blockOffset <= 0)
+  {
+    ScrollToBlockOffset(0);
+    SetBlock(blockIndex);
+  }
+  else if (blockIndex - m_blockOffset < m_blocksPerPage && blockIndex - m_blockOffset >= 0)
+  {
+    SetBlock(blockIndex - m_blockOffset);
+  }
+  else if(blockIndex < m_blocks - m_blocksPerPage)
+  {
+    ScrollToBlockOffset(blockIndex - m_blocksPerPage + 1);
+    SetBlock(m_blocksPerPage - 1);
+  }
+  else
+  {
+    ScrollToBlockOffset(m_blocks - m_blocksPerPage);
+    SetBlock(blockIndex - (m_blocks - m_blocksPerPage));
+  }
+}
+
 int CGUIEPGGridContainer::GetSelectedItem() const
 {
   if (m_gridIndex.empty() ||
@@ -1338,6 +1402,67 @@ int CGUIEPGGridContainer::GetSelectedItem() const
     if (currentItem == m_programmeItems[i])
       return i;
   }
+  return -1;
+}
+
+CEpgInfoTagPtr CGUIEPGGridContainer::GetSelectedEpgInfoTag() const
+{
+  CEpgInfoTagPtr tag;
+
+  if (!m_gridIndex.empty() &&
+      !m_epgItemsPtr.empty() &&
+      m_channelCursor + m_channelOffset < m_channels &&
+      m_blockCursor + m_blockOffset < m_blocks)
+  {
+    CGUIListItemPtr currentItem(m_gridIndex[m_channelCursor + m_channelOffset][m_blockCursor + m_blockOffset].item);
+    if (currentItem)
+      tag = static_cast<CFileItem *>(currentItem.get())->GetEPGInfoTag();
+  }
+
+  return tag;
+}
+
+int CGUIEPGGridContainer::GetBlock(const CEpgInfoTagPtr &tag, int channel) const
+{
+  for (int block = 0; block < m_blocks; ++block)
+  {
+    CGUIListItemPtr item = m_gridIndex[channel + m_channelOffset][block].item;
+    if (item)
+    {
+      CEpgInfoTagPtr currentTag(static_cast<CFileItem *>(item.get())->GetEPGInfoTag());
+      if (currentTag == tag)
+        return (block - m_blockOffset >= 0) ? block - m_blockOffset : 0;
+    }
+  }
+
+  return -1;
+}
+
+int CGUIEPGGridContainer::GetChannel(const CEpgInfoTagPtr &tag) const
+{
+  if (tag->HasPVRChannel())
+  {
+    int channelId = tag->ChannelTag()->ChannelID();
+    for (int row = 0; row < m_channels; ++row)
+    {
+      for (int block = 0; block < m_blocks; ++block)
+      {
+        CGUIListItemPtr item = m_gridIndex[row][block].item;
+        if (item)
+        {
+          CEpgInfoTagPtr currentTag(static_cast<CFileItem *>(item.get())->GetEPGInfoTag());
+          if (currentTag->HasPVRChannel()) // Take care. Gap tags have no channel.
+          {
+            if (currentTag->ChannelTag()->ChannelID() == channelId)
+              return (row - m_channelOffset >= 0) ? row - m_channelOffset : 0;
+            else
+              break;
+          }
+        }
+      }
+    }
+  }
+
   return -1;
 }
 

--- a/xbmc/epg/GUIEPGGridContainer.h
+++ b/xbmc/epg/GUIEPGGridContainer.h
@@ -45,8 +45,10 @@ namespace EPG
     CGUIEPGGridContainer(int parentID, int controlID, float posX, float posY, float width, float height,
                          int scrollTime, int preloadItems, int minutesPerPage,
                          int rulerUnit, const CTextureInfo& progressIndicatorTexture);
+    CGUIEPGGridContainer(const CGUIEPGGridContainer &other);
+
     virtual ~CGUIEPGGridContainer(void);
-    virtual CGUIEPGGridContainer *Clone() const { return new CGUIEPGGridContainer(*this); };
+    virtual CGUIEPGGridContainer *Clone() const { return new CGUIEPGGridContainer(*this); }
 
     virtual bool OnAction(const CAction &action);
     virtual void OnDown();
@@ -63,7 +65,7 @@ namespace EPG
     virtual std::string GetDescription() const;
     const int GetNumChannels()   { return m_channels; };
     virtual int GetSelectedItem() const;
-    const int GetSelectedChannel() { return m_channelCursor + m_channelOffset; }
+    const int GetSelectedChannel() const;
     void SetSelectedChannel(int channelIndex);
     PVR::CPVRChannelPtr GetChannel(int iIndex);
     void SetSelectedBlock(int blockIndex);
@@ -95,8 +97,6 @@ namespace EPG
   protected:
     bool OnClick(int actionID);
     bool SelectItemFromPoint(const CPoint &point, bool justGrid = true);
-
-    void UpdateItems();
 
     void SetChannel(int channel);
     void SetBlock(int block);
@@ -171,11 +171,13 @@ namespace EPG
     void GetChannelCacheOffsets(int &cacheBefore, int &cacheAfter);
     void GetProgrammeCacheOffsets(int &cacheBefore, int &cacheAfter);
 
+  private:
+    void UpdateItems();
+
     EPG::CEpgInfoTagPtr GetSelectedEpgInfoTag() const;
     int GetBlock(const EPG::CEpgInfoTagPtr &tag, int channel) const;
     int GetChannel(const EPG::CEpgInfoTagPtr &tag) const;
 
-  private:
     int m_rulerUnit; //! number of blocks that makes up one element of the ruler
     int m_channels;
     int m_channelsPerPage;
@@ -224,5 +226,7 @@ namespace EPG
     int m_channelScrollLastTime;
     float m_channelScrollSpeed;
     float m_channelScrollOffset;
+
+    CCriticalSection m_critSection;
   };
 }

--- a/xbmc/epg/GUIEPGGridContainer.h
+++ b/xbmc/epg/GUIEPGGridContainer.h
@@ -66,6 +66,7 @@ namespace EPG
     const int GetSelectedChannel() { return m_channelCursor + m_channelOffset; }
     void SetSelectedChannel(int channelIndex);
     PVR::CPVRChannelPtr GetChannel(int iIndex);
+    void SetSelectedBlock(int blockIndex);
     virtual EVENT_RESULT OnMouseEvent(const CPoint &point, const CMouseEvent &event);
 
     virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
@@ -169,6 +170,10 @@ namespace EPG
 
     void GetChannelCacheOffsets(int &cacheBefore, int &cacheAfter);
     void GetProgrammeCacheOffsets(int &cacheBefore, int &cacheAfter);
+
+    EPG::CEpgInfoTagPtr GetSelectedEpgInfoTag() const;
+    int GetBlock(const EPG::CEpgInfoTagPtr &tag, int channel) const;
+    int GetChannel(const EPG::CEpgInfoTagPtr &tag) const;
 
   private:
     int m_rulerUnit; //! number of blocks that makes up one element of the ruler

--- a/xbmc/epg/GUIEPGGridContainer.h
+++ b/xbmc/epg/GUIEPGGridContainer.h
@@ -24,6 +24,7 @@
 #include "guilib/GUIControl.h"
 #include "guilib/GUIListItemLayout.h"
 #include "guilib/IGUIContainer.h"
+#include "threads/SystemClock.h"
 
 namespace EPG
 {
@@ -228,5 +229,7 @@ namespace EPG
     float m_channelScrollOffset;
 
     CCriticalSection m_critSection;
+
+    XbmcThreads::EndTime m_nextUpdateTimeout;
   };
 }

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -29,6 +29,7 @@
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "threads/SingleLock.h"
+#include "utils/log.h"
 #include "pvr/addons/PVRClients.h"
 #include "pvr/timers/PVRTimers.h"
 
@@ -46,6 +47,14 @@ CGUIWindowPVRGuide::CGUIWindowPVRGuide(bool bRadio) :
 CGUIWindowPVRGuide::~CGUIWindowPVRGuide(void)
 {
   delete m_cachedTimeline;
+}
+
+void CGUIWindowPVRGuide::OnInitWindow()
+{
+  if (m_guiState.get())
+    m_viewControl.SetCurrentView(m_guiState->GetViewAsControl(), false);
+
+  CGUIWindowPVRBase::OnInitWindow();
 }
 
 void CGUIWindowPVRGuide::ResetObservers(void)
@@ -121,6 +130,31 @@ void CGUIWindowPVRGuide::UpdateSelectedItemPath()
   }
   else
     CGUIWindowPVRBase::UpdateSelectedItemPath();
+}
+
+bool CGUIWindowPVRGuide::GetDirectory(const std::string &strDirectory, CFileItemList &items)
+{
+  switch (m_viewControl.GetCurrentControl())
+  {
+    case GUIDE_VIEW_TIMELINE:
+      GetViewTimelineItems(items);
+      break;
+    case GUIDE_VIEW_NOW:
+      GetViewNowItems(items);
+      break;
+    case GUIDE_VIEW_NEXT:
+      GetViewNextItems(items);
+      break;
+    case GUIDE_VIEW_CHANNEL:
+      GetViewChannelItems(items);
+      break;
+    default:
+      CLog::Log(LOGERROR, "CGUIWindowPVRGuide - %s - Unknown view control. Unable to fill item list.", __FUNCTION__);
+      break;
+  }
+
+  m_bUpdateRequired = false;
+  return true;
 }
 
 bool CGUIWindowPVRGuide::OnAction(const CAction &action)
@@ -270,7 +304,7 @@ bool CGUIWindowPVRGuide::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
       CGUIWindowPVRBase::OnContextButton(itemNumber, button);
 }
 
-void CGUIWindowPVRGuide::UpdateViewChannel()
+void CGUIWindowPVRGuide::GetViewChannelItems(CFileItemList &items)
 {
   CPVRChannelPtr currentChannel(g_PVRManager.GetCurrentChannel());
 
@@ -278,26 +312,24 @@ void CGUIWindowPVRGuide::UpdateViewChannel()
     SET_CONTROL_LABEL(CONTROL_LABEL_HEADER1, currentChannel->ChannelName().c_str());
   SET_CONTROL_LABEL(CONTROL_LABEL_HEADER2, GetGroup()->GroupName());
 
-  m_vecItems->Clear();
-  if (!currentChannel || g_PVRManager.GetCurrentEpg(*m_vecItems) == 0)
+  items.Clear();
+  if (!currentChannel || g_PVRManager.GetCurrentEpg(items) == 0)
   {
     CFileItemPtr item;
     item.reset(new CFileItem("pvr://guide/channel/empty.epg", false));
     item->SetLabel(g_localizeStrings.Get(19028));
     item->SetLabelPreformated(true);
-    m_vecItems->Add(item);
+    items.Add(item);
   }
-
-  m_viewControl.SetItems(*m_vecItems);
 }
 
-void CGUIWindowPVRGuide::UpdateViewNow()
+void CGUIWindowPVRGuide::GetViewNowItems(CFileItemList &items)
 {
   SET_CONTROL_LABEL(CONTROL_LABEL_HEADER1, g_localizeStrings.Get(19030));
   SET_CONTROL_LABEL(CONTROL_LABEL_HEADER2, GetGroup()->GroupName());
 
-  m_vecItems->Clear();
-  int iEpgItems = GetGroup()->GetEPGNow(*m_vecItems);
+  items.Clear();
+  int iEpgItems = GetGroup()->GetEPGNow(items);
 
   if (iEpgItems == 0)
   {
@@ -305,20 +337,17 @@ void CGUIWindowPVRGuide::UpdateViewNow()
     item.reset(new CFileItem("pvr://guide/now/empty.epg", false));
     item->SetLabel(g_localizeStrings.Get(19028));
     item->SetLabelPreformated(true);
-    m_vecItems->Add(item);
+    items.Add(item);
   }
-
-  m_viewControl.SetItems(*m_vecItems);
-  m_viewControl.SetSelectedItem(GetSelectedItemPath(m_bRadio));
 }
 
-void CGUIWindowPVRGuide::UpdateViewNext()
+void CGUIWindowPVRGuide::GetViewNextItems(CFileItemList &items)
 {
   SET_CONTROL_LABEL(CONTROL_LABEL_HEADER1, g_localizeStrings.Get(19031));
   SET_CONTROL_LABEL(CONTROL_LABEL_HEADER2, GetGroup()->GroupName());
 
-  m_vecItems->Clear();
-  int iEpgItems = GetGroup()->GetEPGNext(*m_vecItems);
+  items.Clear();
+  int iEpgItems = GetGroup()->GetEPGNext(items);
 
   if (iEpgItems)
   {
@@ -326,14 +355,11 @@ void CGUIWindowPVRGuide::UpdateViewNext()
     item.reset(new CFileItem("pvr://guide/next/empty.epg", false));
     item->SetLabel(g_localizeStrings.Get(19028));
     item->SetLabelPreformated(true);
-    m_vecItems->Add(item);
+    items.Add(item);
   }
-
-  m_viewControl.SetItems(*m_vecItems);
-  m_viewControl.SetSelectedItem(GetSelectedItemPath(m_bRadio));
 }
 
-void CGUIWindowPVRGuide::UpdateViewTimeline()
+void CGUIWindowPVRGuide::GetViewTimelineItems(CFileItemList &items)
 {
   CGUIEPGGridContainer* epgGridContainer = (CGUIEPGGridContainer*) GetControl(m_viewControl.GetCurrentControl());
   if (!epgGridContainer)
@@ -350,9 +376,9 @@ void CGUIWindowPVRGuide::UpdateViewTimeline()
     m_cachedChannelGroup->GetEPGAll(*m_cachedTimeline);
   }
 
-  m_vecItems->Clear();
-  m_vecItems->RemoveDiscCache(GetID());
-  m_vecItems->Assign(*m_cachedTimeline, false);
+  items.Clear();
+  items.RemoveDiscCache(GetID());
+  items.Assign(*m_cachedTimeline, false);
 
   CDateTime startDate(m_cachedChannelGroup->GetFirstEPGDate());
   CDateTime endDate(m_cachedChannelGroup->GetLastEPGDate());
@@ -374,36 +400,7 @@ void CGUIWindowPVRGuide::UpdateViewTimeline()
   SET_CONTROL_LABEL(CONTROL_LABEL_HEADER1, g_localizeStrings.Get(19032));
   SET_CONTROL_LABEL(CONTROL_LABEL_HEADER2, GetGroup()->GroupName());
 
-  m_viewControl.SetItems(*m_vecItems);
-
   epgGridContainer->SetChannel(GetSelectedItemPath(m_bRadio));
-}
-
-bool CGUIWindowPVRGuide::Update(const std::string &strDirectory, bool updateFilterPath /* = true */)
-{
-  CSingleLock lock(m_critSection);
-
-  CGUIWindowPVRBase::Update(strDirectory);
-
-  switch (m_viewControl.GetCurrentControl())
-  {
-    case GUIDE_VIEW_TIMELINE:
-      UpdateViewTimeline();
-      break;
-    case GUIDE_VIEW_NOW:
-      UpdateViewNow();
-      break;
-    case GUIDE_VIEW_NEXT:
-      UpdateViewNext();
-      break;
-    case GUIDE_VIEW_CHANNEL:
-      UpdateViewChannel();
-      break;
-  }
-
-  m_bUpdateRequired = false;
-
-  return true;
 }
 
 bool CGUIWindowPVRGuide::OnContextButtonBegin(CFileItem *item, CONTEXT_BUTTON button)

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -161,7 +161,6 @@ bool CGUIWindowPVRGuide::OnAction(const CAction &action)
 {
   switch (action.GetID())
   {
-    case REMOTE_0:
     case REMOTE_1:
     case REMOTE_2:
     case REMOTE_3:

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.h
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.h
@@ -33,16 +33,17 @@ namespace PVR
     CGUIWindowPVRGuide(bool bRadio);
     virtual ~CGUIWindowPVRGuide(void);
 
+    virtual void OnInitWindow();
     bool OnMessage(CGUIMessage& message);
     bool OnAction(const CAction &action);
     void GetContextButtons(int itemNumber, CContextButtons &buttons);
     bool OnContextButton(int itemNumber, CONTEXT_BUTTON button);
-    bool Update(const std::string &strDirectory, bool updateFilterPath = true);
     void ResetObservers(void);
     void UnregisterObservers(void);
 
   protected:
     void UpdateSelectedItemPath();
+    virtual bool GetDirectory(const std::string &strDirectory, CFileItemList &items);
 
   private:
     bool SelectPlayingFile(void);
@@ -55,10 +56,10 @@ namespace PVR
     bool OnContextButtonStartRecord(CFileItem *item, CONTEXT_BUTTON button);
     bool OnContextButtonStopRecord(CFileItem *item, CONTEXT_BUTTON button);
 
-    void UpdateViewChannel();
-    void UpdateViewNow();
-    void UpdateViewNext();
-    void UpdateViewTimeline();
+    void GetViewChannelItems(CFileItemList &items);
+    void GetViewNowItems(CFileItemList &items);
+    void GetViewNextItems(CFileItemList &items);
+    void GetViewTimelineItems(CFileItemList &items);
 
     CFileItemList      *m_cachedTimeline;
     CPVRChannelGroupPtr m_cachedChannelGroup;


### PR DESCRIPTION
Superseeds #7421

Commits:

(1a) fix epg grid init
- fixes: infamous error message "CGUIEPGGridContainer - UpdateItems - invalid start and end time set" that was for ages in (my) kodi.log
- cause: first epg grid update gets triggered during WindowPVRGuide::OnInitWindow() already, even before first WindowPVRGuide::Update(). start and end time are not set at that early stage.
- details
  *\* illustrated call stack: http://paste.ubuntu.com/11878995/
- fix: set start and end time at epg grid control in OnInitWindow() before calling bas class

(1b) fix epg grid update
- fixes: each guide WindowPVRGuide::Update() caused (up to) 4 epg grid updates. Interestingly, all of those messages except the last had an empty item list, causing multiple and senseless epg grid data resets. Only the last update message contained the correct number of list items and caused the correct grid update
- cause: design flaws in data retrieval logic of WindowPVRGuide in interference with MediaWindow base class implementation
- details 
  *\* WindowPVRGuide::Update() first calls base class
  *\* MediaWindow::Update() calls virtual GetDirectory(). WindowPVRGuide has no own GetDirectory() implementation. MediaWindow GetDirectory() returns empty item list which overwrites current m_vecItems. Subsequent (actually unwanted and unneeded) calls to ViewControl::SetItems() pass empty m_vecItems to the epg grid.
  *\* back in WindowPVRGuide::Update, m_vecItems is finally filled correctly and past to the epg grid
- fix: retrieve data in new WindowPVRGuide::GetDirectory() implementation, making WindowPVRGuide::Update() implementation obsolete

(2) fix epg window view jumping to "now" on every epg grid update 
- fixes: epg timeline window viewport jumps to "now" on every epg data update, can happen any time, depending on the frequency and amount of epg data updates. Very annoying for instance if you just scrolled 2 days into the future to setup a timer.
- cause: the jump to now was unconditionally coded into the epg update code of the epg grid container control
- fix: remember current selection on update start, restore the selection after update. Do only change view port if selection is no longer available (e.g. because the event got removed during update)

(3) feature. use remote key "0" in the epg grid container control to jump to 'now' 
- I just found it very useful after fixing the automatic jump to now bug to have the possibility to manually jump to 'now'

(4) fix: make epg grid container control thread save
- fixes random crashes of Kodi while in EPG window
- cause: epg grid control was not threadsafe, but got called from different threads (main and python lcdproc addon in my case)
- details
  *\* calls stacks: http://paste.ubuntu.com/11878966/

(5) reduce lagging of EPG window caused by huge amount of update events in a short time frame
- cause: observed up to 200 epg grid update events in a row in about 10 secs, EPG window is almost unusable during this time
- fix: limited number of update requests actually processed by the epg grifd control to 1 per 3 secs
- 3 secs is just an empiric value that greatly improves (but not completely fixes) lagging of the UI during updates for me
