### PR TITLE
fix building with --disable-webserver

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -104,12 +104,12 @@ NWAOBJSXBMC=	xbmc/threads/threads.a \
 
 
 ifeq (@USE_WEB_SERVER@,1)
+DIRECTORY_ARCHIVES += xbmc/interfaces/legacy/wsgi/legacy-wsgi.a
 DIRECTORY_ARCHIVES += xbmc/network/httprequesthandler/httprequesthandlers.a
 DIRECTORY_ARCHIVES += xbmc/network/httprequesthandler/python/httprequesthandlers-python.a
 endif
 
 DIRECTORY_ARCHIVES += xbmc/interfaces/legacy/legacy.a
-DIRECTORY_ARCHIVES += xbmc/interfaces/legacy/wsgi/legacy-wsgi.a
 DIRECTORY_ARCHIVES += xbmc/interfaces/python/python_binding.a
 
 ifeq (@USE_OPENGL@,1)

--- a/Makefile.in
+++ b/Makefile.in
@@ -52,6 +52,8 @@ DIRECTORY_ARCHIVES=$(DVDPLAYER_ARCHIVES) \
                    xbmc/interfaces/info/info.a \
                    xbmc/interfaces/interfaces.a \
                    xbmc/interfaces/json-rpc/json-rpc.a \
+                   xbmc/interfaces/legacy/legacy.a \
+                   xbmc/interfaces/python/python_binding.a \
                    xbmc/linux/linux.a \
                    xbmc/listproviders/listproviders.a \
                    xbmc/media/media.a \
@@ -108,9 +110,6 @@ DIRECTORY_ARCHIVES += xbmc/interfaces/legacy/wsgi/legacy-wsgi.a
 DIRECTORY_ARCHIVES += xbmc/network/httprequesthandler/httprequesthandlers.a
 DIRECTORY_ARCHIVES += xbmc/network/httprequesthandler/python/httprequesthandlers-python.a
 endif
-
-DIRECTORY_ARCHIVES += xbmc/interfaces/legacy/legacy.a
-DIRECTORY_ARCHIVES += xbmc/interfaces/python/python_binding.a
 
 ifeq (@USE_OPENGL@,1)
 DIRECTORY_ARCHIVES += xbmc/rendering/gl/rendering_gl.a

--- a/configure.ac
+++ b/configure.ac
@@ -2476,7 +2476,6 @@ OUTPUT_FILES="Makefile \
     xbmc/input/linux/Makefile \
     xbmc/interfaces/Makefile \
     xbmc/network/Makefile \
-    xbmc/network/httprequesthandler/python/Makefile \
     xbmc/network/upnp/Makefile \
     lib/libexif/Makefile \
     lib/cximage-6.0/Makefile \
@@ -2533,6 +2532,10 @@ OUTPUT_FILES="Makefile \
     tools/android/packaging/xbmc/src/org/xbmc/kodi/XBMCOnAudioFocusChangeListener.java \
     tools/android/packaging/xbmc/strings.xml \
     addons/xbmc.addon/addon.xml"
+
+if test "$use_webserver" = "yes"; then
+OUTPUT_FILES="$OUTPUT_FILES xbmc/network/httprequesthandler/python/Makefile"
+fi
 
 if test "$use_wayland" = "yes"; then
 OUTPUT_FILES="$OUTPUT_FILES xbmc/windowing/tests/wayland/Makefile"

--- a/xbmc/interfaces/legacy/wsgi/WsgiErrorStream.h
+++ b/xbmc/interfaces/legacy/wsgi/WsgiErrorStream.h
@@ -66,8 +66,6 @@ namespace XBMCAddon
 
       HTTPPythonRequest* m_request;
 #endif
-    };    
+    };
   }
 }
-
-

--- a/xbmc/interfaces/legacy/wsgi/WsgiInputStream.h
+++ b/xbmc/interfaces/legacy/wsgi/WsgiInputStream.h
@@ -93,8 +93,6 @@ namespace XBMCAddon
 
       HTTPPythonRequest* m_request;
 #endif
-    };    
+    };
   }
 }
-
-

--- a/xbmc/interfaces/legacy/wsgi/WsgiResponse.h
+++ b/xbmc/interfaces/legacy/wsgi/WsgiResponse.h
@@ -57,8 +57,6 @@ namespace XBMCAddon
 
       WsgiResponseBody m_body;
 #endif
-    };    
+    };
   }
 }
-
-

--- a/xbmc/interfaces/legacy/wsgi/WsgiResponseBody.h
+++ b/xbmc/interfaces/legacy/wsgi/WsgiResponseBody.h
@@ -42,8 +42,6 @@ namespace XBMCAddon
 #ifndef SWIG
       String m_data;
 #endif
-    };    
+    };
   }
 }
-
-

--- a/xbmc/utils/HttpRangeUtils.cpp
+++ b/xbmc/utils/HttpRangeUtils.cpp
@@ -18,13 +18,15 @@
  *
  */
 
+#include <algorithm>
+
 #include "HttpRangeUtils.h"
 #include "Util.h"
+#ifdef HAS_WEB_SERVER
 #include "network/httprequesthandler/IHTTPRequestHandler.h"
+#endif // HAS_WEB_SERVER
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
-
-#include <algorithm>
 
 #define HEADER_NEWLINE        "\r\n"
 #define HEADER_SEPARATOR      HEADER_NEWLINE HEADER_NEWLINE
@@ -370,6 +372,8 @@ std::string HttpRangeUtils::GenerateContentRangeHeaderValue(uint64_t start, uint
   return StringUtils::Format(CONTENT_RANGE_FORMAT_TOTAL_UNKNOWN, start, end);
 }
 
+#ifdef HAS_WEB_SERVER
+
 std::string HttpRangeUtils::GenerateMultipartBoundary()
 {
   static char chars[] = "-_1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
@@ -431,3 +435,5 @@ std::string HttpRangeUtils::GenerateMultipartBoundaryEnd(const std::string& mult
 
   return HEADER_NEWLINE HEADER_BOUNDARY + multipartBoundary + HEADER_BOUNDARY;
 }
+
+#endif // HAS_WEB_SERVER

--- a/xbmc/utils/HttpRangeUtils.h
+++ b/xbmc/utils/HttpRangeUtils.h
@@ -24,6 +24,8 @@
 #include <string>
 #include <vector>
 
+#include "system.h"
+
 class CHttpRange
 {
 public:
@@ -136,6 +138,7 @@ public:
   */
   static std::string GenerateContentRangeHeaderValue(uint64_t start, uint64_t end, uint64_t total);
 
+#ifdef HAS_WEB_SERVER
   /*!
    * \brief Generates a multipart boundary that can be used in ranged HTTP
    * responses.
@@ -195,5 +198,5 @@ public:
   * \return Multipart boundary end that can be used in a ranged HTTP response
   */
   static std::string GenerateMultipartBoundaryEnd(const std::string& multipartBoundary);
+#endif // HAS_WEB_SERVER
 };
-


### PR DESCRIPTION
These commits should fix building kodi on linux etc. with `--disable-webserver` and without libmicrohttpd headers installed. Only 0174299c5c077951762ba79f92203dd128fc7a33 and fe5252c2e94e08941c032faa79f977eb65a1d74a are absolutely necessary. The others are for consistency and cleanup.
