### PR TITLE
fix musicvideo artist artwork not being loaded from the musicdb (fixes #16120)

### DIFF
--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -436,7 +436,7 @@ bool CVideoThumbLoader::FillLibraryArt(CFileItem &item)
     m_videoDatabase->Open();
     if (m_videoDatabase->GetArtForItem(tag.m_iDbId, tag.m_type, artwork))
       SetArt(item, artwork);
-    else if (tag.m_type == MediaTypeArtist)
+    else if (tag.m_type == "actor" && !tag.m_artist.empty())
     { // we retrieve music video art from the music database (no backward compat)
       CMusicDatabase database;
       database.Open();


### PR DESCRIPTION
This fixes missing musicvideo artist artwork due to artists now being handled like actors in the database which also results in their `CVideoInfoTag::m_type` value being set to `actor` instead of `artist`.

This fixes http://trac.kodi.tv/ticket/16120.
