### PR TITLE
[gui] fix modality type of skin custom dialogs

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1833,7 +1833,7 @@ bool CApplication::LoadUserWindows()
           CGUIControlFactory::GetConditionalVisibility(pRootElement, visibleCondition);
 
           if (StringUtils::EqualsNoCase(strType, "dialog"))
-            pWindow = new CGUIDialog(id + WINDOW_HOME, skinFile);
+            pWindow = new CGUIDialog(id + WINDOW_HOME, skinFile, visibleCondition.empty() ? DialogModalityType::MODAL : DialogModalityType::MODELESS);
           else if (StringUtils::EqualsNoCase(strType, "submenu"))
             pWindow = new CGUIDialogSubMenu(id + WINDOW_HOME, skinFile);
           else if (StringUtils::EqualsNoCase(strType, "buttonmenu"))


### PR DESCRIPTION
As reported by @phil65 the behavior for skin's custom windows of type 'dialog' has been changed. Each custom window of type 'dialog' is now a MODAL dialog instead of a MODELESS. This is caused by the changes I've done to the modality handling of dialogs (#7428) where each `CGUIDialog` will have MODAL as its default modality type.
