### PR TITLE
[homescreen] update selection of recently added movies and tvshows/episodes

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -16922,3 +16922,33 @@ msgstr ""
 msgctxt "#38016"
 msgid "%d fps"
 msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#38017"
+msgid "Recently added TV shows"
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#38018"
+msgid "In progress and recently added TV shows"
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#38019"
+msgid "Show seen videos on homescreen"
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#38020"
+msgid "TV show preview on homescreen"
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#38021"
+msgid "When activated, it shows the seen movies and episodes/tvshows on the homescreen preview."
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#38022"
+msgid "The preview of TV shows on the homescreen have 4 possible options\n[recently added episodes] shows the recently added episodes\n[recently added TV shows] shows the recently added TV shows\n[in progress TV shows] shows the in progress TV shows\n[in progress and recently added TV shows] show the in progress TV shows, filled up with the recently added\n\nThe shown TV shows present the first unseen episode with the cover of the TV show."
+msgstr ""

--- a/addons/skin.confluence/720p/IncludesHomeRecentlyAdded.xml
+++ b/addons/skin.confluence/720p/IncludesHomeRecentlyAdded.xml
@@ -258,7 +258,7 @@
 					<top>220</top>
 					<height>20</height>
 					<width>480</width>
-					<label>20387</label>
+					<label>$INFO[Window.Property(LatestEpisode.Title)]</label>
 					<align>center</align>
 					<aligny>center</aligny>
 					<font>font12_title</font>
@@ -296,7 +296,7 @@
 							<top>10</top>
 							<width>220</width>
 							<height>155</height>
-							<aspectratio>scale</aspectratio>
+							<aspectratio>keep</aspectratio>
 							<texture background="true">$INFO[ListItem.Icon]</texture>
 							<bordertexture border="5">button-nofocus.png</bordertexture>
 							<bordersize>5</bordersize>
@@ -342,7 +342,7 @@
 							<top>10</top>
 							<width>220</width>
 							<height>155</height>
-							<aspectratio>scale</aspectratio>
+							<aspectratio>keep</aspectratio>
 							<texture background="true">$INFO[ListItem.Icon]</texture>
 							<bordertexture border="5">folder-focus.png</bordertexture>
 							<bordersize>5</bordersize>
@@ -353,7 +353,7 @@
 							<top>10</top>
 							<width>220</width>
 							<height>155</height>
-							<aspectratio>scale</aspectratio>
+							<aspectratio>keep</aspectratio>
 							<texture>$INFO[ListItem.Icon]</texture>
 							<bordertexture border="5">button-nofocus.png</bordertexture>
 							<bordersize>5</bordersize>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -465,6 +465,26 @@
         </setting>
       </group>
       <group id="2">
+        <setting id="videolibrary.showseeninhome" type="boolean" label="38019" help="38021">
+          <level>0</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+        <setting id="videolibrary.tvshowsinhome" type="integer" label="38020" help="38022">
+          <level>0</level>
+          <default>0</default> <!-- Recently added episodes -->
+          <constraints>
+            <options>
+              <option label="20387">0</option> <!-- Recently added episodes -->
+              <option label="38017">1</option> <!-- Recently added tvshows -->
+              <option label=  "626">2</option> <!-- In progress tvshows -->
+              <option label="38018">4</option> <!-- In progress and recently added tvshows -->
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+        </setting>
+      </group>
+      <group id="3">
         <setting id="videolibrary.updateonstartup" type="boolean" label="22000" help="36146">
           <level>1</level>
           <default>false</default>
@@ -476,7 +496,7 @@
           <control type="toggle" />
         </setting>
       </group>
-      <group id="3">
+      <group id="4">
         <setting id="videolibrary.cleanup" type="action" label="334" help="36148">
           <level>2</level>
           <control type="button" format="action" />

--- a/xbmc/settings/MediaSettings.cpp
+++ b/xbmc/settings/MediaSettings.cpp
@@ -37,6 +37,8 @@
 #include "utils/XMLUtils.h"
 #include "utils/Variant.h"
 #include "video/VideoDatabase.h"
+#include "guilib/GUIWindowManager.h"
+#include "utils/RecentlyAddedJob.h"
 
 using namespace std;
 
@@ -255,6 +257,10 @@ bool CMediaSettings::Save(TiXmlNode *settings) const
   XMLUtils::SetBoolean(playlistNode, "shuffle", m_videoPlaylistShuffle);
 
   XMLUtils::SetInt(pNode, "needsupdate", m_videoNeedsUpdate);
+
+  // send refesh for recently added videos
+  CGUIMessage reload(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_REFRESH_THUMBS, Video);
+  g_windowManager.SendThreadMessage(reload, 0);
 
   return true;
 }

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -702,6 +702,8 @@ void CSettings::InitializeISettingCallbacks()
   settingSet.insert("videolibrary.cleanup");
   settingSet.insert("videolibrary.import");
   settingSet.insert("videolibrary.export");
+  settingSet.insert("videolibrary.showseeninhome");
+  settingSet.insert("videolibrary.tvshowsinhome");
   m_settingsManager->RegisterCallback(&CMediaSettings::Get(), settingSet);
 
   settingSet.clear();

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -30,6 +30,11 @@
 #include "settings/lib/ISettingCallback.h"
 #include "threads/CriticalSection.h"
 
+#define SETTINGS_VIDEODB_TVSHOW_HOME_EPISODES                  0
+#define SETTINGS_VIDEODB_TVSHOW_HOME_RECENTLY_ADDED            1
+#define SETTINGS_VIDEODB_TVSHOW_HOME_INPROGRESS                2
+#define SETTINGS_VIDEODB_TVSHOW_HOME_INPROGRESS_RECENTLY_ADDED 4
+
 class CSetting;
 class CSettingList;
 class CSettingSection;

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -6440,6 +6440,27 @@ int CVideoDatabase::GetTvShowForEpisode(int idEpisode)
   return false;
 }
 
+/* select the first unseen expisode of a tvshow.
+ * when all seen, the first episode is selected.
+ */
+bool CVideoDatabase::GetNextEpisodeFromTvShow(const int idTvShow, CFileItemPtr& item)
+{
+  CFileItemList items;
+  std::string dbURL = StringUtils::Format("videodb://tvshows/titles/%i/-1/", idTvShow);
+  Filter filter;
+  filter.order = PrepareSQL("(playcount is NULL) desc, CASE WHEN c%u = -1 THEN cast(c%u as SIGNED) ELSE cast(c%u as SIGNED) END, CASE WHEN c%u = -1 THEN cast(c%u as SIGNED) ELSE cast(c%u as SIGNED) END, c%u desc",
+                            VIDEODB_ID_EPISODE_SORTSEASON, VIDEODB_ID_EPISODE_SEASON, VIDEODB_ID_EPISODE_SORTSEASON,
+                            VIDEODB_ID_EPISODE_SORTEPISODE, VIDEODB_ID_EPISODE_EPISODE, VIDEODB_ID_EPISODE_SORTEPISODE,
+                            VIDEODB_ID_EPISODE_SORTEPISODE);
+  filter.limit = "1";
+
+  if (!GetEpisodesByWhere(dbURL, filter, items) && items.Size() != 1)
+    return false;
+
+  item = items.Get(0);
+  return true;
+}
+
 int CVideoDatabase::GetSeasonForEpisode(int idEpisode)
 {
   char column[5];

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -24,6 +24,7 @@
 #include "Bookmark.h"
 #include "utils/SortUtils.h"
 #include "video/VideoDbUrl.h"
+#include "xbmc/FileItem.h"
 
 #include <memory>
 #include <set>
@@ -661,6 +662,8 @@ public:
 
   void GetEpisodesByPlot(const std::string& strSearch, CFileItemList& items);
   void GetMoviesByPlot(const std::string& strSearch, CFileItemList& items);
+
+  bool GetNextEpisodeFromTvShow(const int idTvShow, CFileItemPtr& item);
 
   bool LinkMovieToTvshow(int idMovie, int idShow, bool bRemove);
   bool IsLinkedToTvshow(int idMovie);

--- a/xbmc/windows/GUIWindowHome.cpp
+++ b/xbmc/windows/GUIWindowHome.cpp
@@ -26,6 +26,7 @@
 #include "interfaces/AnnouncementManager.h"
 #include "utils/log.h"
 #include "settings/AdvancedSettings.h"
+#include "settings/Settings.h"
 #include "utils/Variant.h"
 #include "guilib/GUIWindowManager.h"
 #include "Application.h"
@@ -102,6 +103,14 @@ void CGUIWindowHome::Announce(AnnouncementFlag flag, const char *sender, const c
       ra_flag |= Video;
     else if (flag & AudioLibrary)
       ra_flag |= Audio;
+  }
+
+  // OnUpdate from VideoLibrary and with home filter active, we have to update the video list
+  if (onUpdate && (flag & VideoLibrary) && (
+      !CSettings::Get().GetBool("videolibrary.showseeninhome") ||
+      CSettings::Get().GetInt("videolibrary.tvshowsinhome") != SETTINGS_VIDEODB_TVSHOW_HOME_EPISODES) )
+  {
+    ra_flag |= Video;
   }
 
   CGUIMessage reload(GUI_MSG_NOTIFY_ALL, GetID(), 0, GUI_MSG_REFRESH_THUMBS, ra_flag);


### PR DESCRIPTION
- movies+tvshows+musicvideos can filter out the seen one
- tvshows have now 4 selection modes (tvshows with recently added episodes, tvshows in )
- setup over videolibrary settings (defaults to the old behavior)

@ a native english speaker: please check my speelings
