### PR TITLE
[music node] Add Artists A-Z default music node

### DIFF
--- a/system/library/music/artista-z/0-9.xml
+++ b/system/library/music/artista-z/0-9.xml
@@ -1,0 +1,17 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<node order="27" type="filter">
+	<label>0-9</label>
+	<content>artists</content>
+	<rule field="artist" operator="startswith">
+		<value>1</value>
+		<value>2</value>
+		<value>3</value>
+		<value>4</value>
+		<value>5</value>
+		<value>6</value>
+		<value>7</value>
+		<value>8</value>
+		<value>9</value>
+		<value>0</value>
+	</rule>
+</node>

--- a/system/library/music/artista-z/a.xml
+++ b/system/library/music/artista-z/a.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<node order="1" type="filter">
+	<label>A</label>
+	<content>artists</content>
+	<rule field="artist" operator="startswith">
+		<value>A</value>
+	</rule>
+</node>

--- a/system/library/music/artista-z/b.xml
+++ b/system/library/music/artista-z/b.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<node order="2" type="filter">
+	<label>B</label>
+	<content>artists</content>
+	<rule field="artist" operator="startswith">
+		<value>B</value>
+	</rule>
+</node>

--- a/system/library/music/artista-z/c.xml
+++ b/system/library/music/artista-z/c.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<node order="3" type="filter">
+	<label>C</label>
+	<content>artists</content>
+	<rule field="artist" operator="startswith">
+		<value>C</value>
+	</rule>
+</node>

--- a/system/library/music/artista-z/d.xml
+++ b/system/library/music/artista-z/d.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<node order="4" type="filter">
+	<label>D</label>
+	<content>artists</content>
+	<rule field="artist" operator="startswith">
+		<value>D</value>
+	</rule>
+</node>

--- a/system/library/music/artista-z/e.xml
+++ b/system/library/music/artista-z/e.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<node order="5" type="filter">
+	<label>E</label>
+	<content>artists</content>
+	<rule field="artist" operator="startswith">
+		<value>E</value>
+	</rule>
+</node>

--- a/system/library/music/artista-z/f.xml
+++ b/system/library/music/artista-z/f.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<node order="6" type="filter">
+	<label>F</label>
+	<content>artists</content>
+	<rule field="artist" operator="startswith">
+		<value>F</value>
+	</rule>
+</node>

--- a/system/library/music/artista-z/g.xml
+++ b/system/library/music/artista-z/g.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<node order="7" type="filter">
+	<label>G</label>
+	<content>artists</content>
+	<rule field="artist" operator="startswith">
+		<value>G</value>
+	</rule>
+</node>

--- a/system/library/music/artista-z/h.xml
+++ b/system/library/music/artista-z/h.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<node order="8" type="filter">
+	<label>H</label>
+	<content>artists</content>
+	<rule field="artist" operator="startswith">
+		<value>H</value>
+	</rule>
+</node>

--- a/system/library/music/artista-z/i.xml
+++ b/system/library/music/artista-z/i.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<node order="9" type="filter">
+	<label>I</label>
+	<content>artists</content>
+	<rule field="artist" operator="startswith">
+		<value>I</value>
+	</rule>
+</node>

--- a/system/library/music/artista-z/index.xml
+++ b/system/library/music/artista-z/index.xml
@@ -1,0 +1,5 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<node order="14">
+	<label>Artist A-Z</label>
+	<icon>DefaultMusicArtists.png</icon>
+</node>

--- a/system/library/music/artista-z/j.xml
+++ b/system/library/music/artista-z/j.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<node order="10" type="filter">
+	<label>J</label>
+	<content>artists</content>
+	<rule field="artist" operator="startswith">
+		<value>J</value>
+	</rule>
+</node>

--- a/system/library/music/artista-z/k.xml
+++ b/system/library/music/artista-z/k.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<node order="11" type="filter">
+	<label>K</label>
+	<content>artists</content>
+	<rule field="artist" operator="startswith">
+		<value>K</value>
+	</rule>
+</node>

--- a/system/library/music/artista-z/l.xml
+++ b/system/library/music/artista-z/l.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<node order="12" type="filter">
+	<label>L</label>
+	<content>artists</content>
+	<rule field="artist" operator="startswith">
+		<value>L</value>
+	</rule>
+</node>

--- a/system/library/music/artista-z/m.xml
+++ b/system/library/music/artista-z/m.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<node order="13" type="filter">
+	<label>M</label>
+	<content>artists</content>
+	<rule field="artist" operator="startswith">
+		<value>M</value>
+	</rule>
+</node>

--- a/system/library/music/artista-z/n.xml
+++ b/system/library/music/artista-z/n.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<node order="14" type="filter">
+	<label>N</label>
+	<content>artists</content>
+	<rule field="artist" operator="startswith">
+		<value>N</value>
+	</rule>
+</node>

--- a/system/library/music/artista-z/o.xml
+++ b/system/library/music/artista-z/o.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<node order="15" type="filter">
+	<label>O</label>
+	<content>artists</content>
+	<rule field="artist" operator="startswith">
+		<value>O</value>
+	</rule>
+</node>

--- a/system/library/music/artista-z/p.xml
+++ b/system/library/music/artista-z/p.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<node order="16" type="filter">
+	<label>P</label>
+	<content>artists</content>
+	<rule field="artist" operator="startswith">
+		<value>P</value>
+	</rule>
+</node>

--- a/system/library/music/artista-z/q.xml
+++ b/system/library/music/artista-z/q.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<node order="17" type="filter">
+	<label>Q</label>
+	<content>artists</content>
+	<rule field="artist" operator="startswith">
+		<value>Q</value>
+	</rule>
+</node>

--- a/system/library/music/artista-z/r.xml
+++ b/system/library/music/artista-z/r.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<node order="18" type="filter">
+	<label>R</label>
+	<content>artists</content>
+	<rule field="artist" operator="startswith">
+		<value>R</value>
+	</rule>
+</node>

--- a/system/library/music/artista-z/s.xml
+++ b/system/library/music/artista-z/s.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<node order="19" type="filter">
+	<label>S</label>
+	<content>artists</content>
+	<rule field="artist" operator="startswith">
+		<value>S</value>
+	</rule>
+</node>

--- a/system/library/music/artista-z/t.xml
+++ b/system/library/music/artista-z/t.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<node order="20" type="filter">
+	<label>T</label>
+	<content>artists</content>
+	<rule field="artist" operator="startswith">
+		<value>T</value>
+	</rule>
+</node>

--- a/system/library/music/artista-z/u.xml
+++ b/system/library/music/artista-z/u.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<node order="21" type="filter">
+	<label>U</label>
+	<content>artists</content>
+	<rule field="artist" operator="startswith">
+		<value>U</value>
+	</rule>
+</node>

--- a/system/library/music/artista-z/v.xml
+++ b/system/library/music/artista-z/v.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<node order="22" type="filter">
+	<label>V</label>
+	<content>artists</content>
+	<rule field="artist" operator="startswith">
+		<value>V</value>
+	</rule>
+</node>

--- a/system/library/music/artista-z/w.xml
+++ b/system/library/music/artista-z/w.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<node order="23" type="filter">
+	<label>W</label>
+	<content>artists</content>
+	<rule field="artist" operator="startswith">
+		<value>W</value>
+	</rule>
+</node>

--- a/system/library/music/artista-z/x.xml
+++ b/system/library/music/artista-z/x.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<node order="24" type="filter">
+	<label>X</label>
+	<content>artists</content>
+	<rule field="artist" operator="startswith">
+		<value>X</value>
+	</rule>
+</node>

--- a/system/library/music/artista-z/y.xml
+++ b/system/library/music/artista-z/y.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<node order="25" type="filter">
+	<label>Y</label>
+	<content>artists</content>
+	<rule field="artist" operator="startswith">
+		<value>Y</value>
+	</rule>
+</node>

--- a/system/library/music/artista-z/z.xml
+++ b/system/library/music/artista-z/z.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<node order="26" type="filter">
+	<label>Z</label>
+	<content>artists</content>
+	<rule field="artist" operator="startswith">
+		<value>Z</value>
+	</rule>
+</node>


### PR DESCRIPTION
Here is a new default node to browse music Artists by their first letter. This will help anyone with a large collection and is a pretty standard for any good music player. If successful with this one I can extend to Albums which will finally make that node useful. I copied this from my working setup so hopefully I got my first Kodi PR correct...

![screenshot009](https://cloud.githubusercontent.com/assets/1050512/8706521/18280120-2b28-11e5-84b2-b927e070c7b9.png)

Ping @mkortstiege @night199uk @Montellese 
