### PR TITLE
don't mess with the long and short date formats defined in langinfo.xml

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -3299,7 +3299,7 @@ std::string CGUIInfoManager::GetMultiInfoLabel(const GUIInfo &info, int contextW
   else if (info.m_info == SYSTEM_DATE)
   {
     CDateTime time=CDateTime::GetCurrentDateTime();
-    return time.GetAsLocalizedDate(m_stringParameters[info.GetData1()],false);
+    return time.GetAsLocalizedDate(m_stringParameters[info.GetData1()]);
   }
   else if (info.m_info == CONTAINER_NUM_PAGES || info.m_info == CONTAINER_CURRENT_PAGE ||
            info.m_info == CONTAINER_NUM_ITEMS || info.m_info == CONTAINER_POSITION ||

--- a/xbmc/XBDateTime.cpp
+++ b/xbmc/XBDateTime.cpp
@@ -1264,12 +1264,12 @@ std::string CDateTime::GetAsLocalizedTime(const std::string &format, bool withSe
   return strOut;
 }
 
-std::string CDateTime::GetAsLocalizedDate(bool longDate/*=false*/, bool withShortNames/*=true*/) const
+std::string CDateTime::GetAsLocalizedDate(bool longDate/*=false*/) const
 {
-  return GetAsLocalizedDate(g_langInfo.GetDateFormat(longDate), withShortNames);
+  return GetAsLocalizedDate(g_langInfo.GetDateFormat(longDate));
 }
 
-std::string CDateTime::GetAsLocalizedDate(const std::string &strFormat, bool withShortNames/*=true*/) const
+std::string CDateTime::GetAsLocalizedDate(const std::string &strFormat) const
 {
   std::string strOut;
 
@@ -1332,7 +1332,7 @@ std::string CDateTime::GetAsLocalizedDate(const std::string &strFormat, bool wit
       {
         int wday = dateTime.wDayOfWeek;
         if (wday < 1 || wday > 7) wday = 7;
-        str = g_localizeStrings.Get(((withShortNames || c =='d') ? 40 : 10) + wday);
+        str = g_localizeStrings.Get((c =='d' ? 40 : 10) + wday);
       }
       strOut+=str;
     }
@@ -1364,7 +1364,7 @@ std::string CDateTime::GetAsLocalizedDate(const std::string &strFormat, bool wit
       {
         int wmonth = dateTime.wMonth;
         if (wmonth < 1 || wmonth > 12) wmonth = 12;
-        str = g_localizeStrings.Get(((withShortNames || c =='m') ? 50 : 20) + wmonth);
+        str = g_localizeStrings.Get((c =='m' ? 50 : 20) + wmonth);
       }
       strOut+=str;
     }

--- a/xbmc/XBDateTime.h
+++ b/xbmc/XBDateTime.h
@@ -193,8 +193,8 @@ public:
   std::string GetAsSaveString() const;
   std::string GetAsDBDateTime() const;
   std::string GetAsDBDate() const;
-  std::string GetAsLocalizedDate(bool longDate=false, bool withShortNames=true) const;
-  std::string GetAsLocalizedDate(const std::string &strFormat, bool withShortNames=true) const;
+  std::string GetAsLocalizedDate(bool longDate=false) const;
+  std::string GetAsLocalizedDate(const std::string &strFormat) const;
   std::string GetAsLocalizedTime(const std::string &format, bool withSeconds=true) const;
   std::string GetAsLocalizedDateTime(bool longDate=false, bool withSeconds=true) const;
   std::string GetAsRFC1123DateTime() const;

--- a/xbmc/epg/GUIEPGGridContainer.cpp
+++ b/xbmc/epg/GUIEPGGridContainer.cpp
@@ -798,14 +798,14 @@ bool CGUIEPGGridContainer::OnMessage(CGUIMessage& message)
           CDateTime ruler; ruler.SetFromUTCDateTime(m_gridStart);
           CDateTime rulerEnd; rulerEnd.SetFromUTCDateTime(m_gridEnd);
           CDateTimeSpan unit(0, 0, m_rulerUnit * MINSPERBLOCK, 0);
-          CGUIListItemPtr rulerItem(new CFileItem(ruler.GetAsLocalizedDate(true, true)));
+          CGUIListItemPtr rulerItem(new CFileItem(ruler.GetAsLocalizedDate(true)));
           rulerItem->SetProperty("DateLabel", true);
           m_rulerItems.push_back(rulerItem);
 
           for (; ruler < rulerEnd; ruler += unit)
           {
             CGUIListItemPtr rulerItem(new CFileItem(ruler.GetAsLocalizedTime("", false)));
-            rulerItem->SetLabel2(ruler.GetAsLocalizedDate(true, true));
+            rulerItem->SetLabel2(ruler.GetAsLocalizedDate(true));
             m_rulerItems.push_back(rulerItem);
           }
 


### PR DESCRIPTION
http://trac.kodi.tv/ticket/15993 brought to my attention that we allow each language to define a long and a short date format but then we go and mess it up in the code by allowing to force short day and month names instead of long even when using the long date format. IMO that doesn't make any sense at all and especially not for `System.Date` info label.

This removes the possibility to force short names and only allows to choose between the long and short date format.
