### PR TITLE
[PVR][backport] fix timer deletion

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRTimers.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRTimers.cpp
@@ -270,7 +270,7 @@ bool CGUIWindowPVRTimers::ActionDeleteTimer(CFileItem *item)
 {
   /* check if the timer tag is valid */
   CPVRTimerInfoTagPtr timerTag = item->GetPVRTimerInfoTag();
-  if (!timerTag || timerTag->m_iClientIndex < 0)
+  if (!timerTag || timerTag->m_state == PVR_TIMER_STATE_NEW)
     return false;
 
   /* show a confirmation dialog */


### PR DESCRIPTION
Value of ClientIndexId is not handle by kodi and should not be checked here.
