### PR TITLE
[PVR Addons] Fix XbmcStreamProperties::GetStreamData to actually return the stream found

### DIFF
--- a/xbmc/addons/include/xbmc_stream_utils.hpp
+++ b/xbmc/addons/include/xbmc_stream_utils.hpp
@@ -160,7 +160,7 @@ namespace ADDON
     {
       XbmcPvrStream *foundStream = GetStreamById(iPhysicalId);
       if (foundStream)
-        stream = foundStream;
+        *stream = *foundStream;
       else
       {
         stream->iIdentifier = -1;


### PR DESCRIPTION
I had already fixed this for helix. But seems it has never backported to xbmc repo.
