### PR TITLE
[isengard][confluence] fix overlapping mutebug on musicvisualization and OSD

### DIFF
--- a/addons/skin.confluence/720p/MusicOSD.xml
+++ b/addons/skin.confluence/720p/MusicOSD.xml
@@ -26,6 +26,7 @@
 			<onup>100</onup>
 			<ondown>100</ondown>
 			<animation effect="fade" time="150">VisibleChange</animation>
+			<animation effect="slide" start="0,0" end="-30,0" time="0" condition="Window.IsVisible(Mutebug)">conditional</animation>
 			<visible>![Window.IsVisible(AddonSettings) | Window.IsVisible(SelectDialog) | Window.IsVisible(VisualisationPresetList) | Window.IsVisible(PVROSDChannels) | Window.IsVisible(PVROSDGuide)]</visible>
 		</control>
 		<control type="slider" id="87">

--- a/addons/skin.confluence/720p/MusicVisualisation.xml
+++ b/addons/skin.confluence/720p/MusicVisualisation.xml
@@ -73,6 +73,7 @@
 				<textcolor>white</textcolor>
 				<shadowcolor>black</shadowcolor>
 				<label>$INFO[System.Time]</label>
+				<animation effect="slide" start="0,0" end="-30,0" time="0" condition="Window.IsVisible(Mutebug)">conditional</animation>
 				<animation effect="slide" start="0,0" end="-70,0" time="0" condition="Window.IsVisible(MusicOSD)">conditional</animation>
 			</control>
 			<control type="image">


### PR DESCRIPTION
backport of #7529

A picture = 1000 words

![capture](https://cloud.githubusercontent.com/assets/3521959/8727844/d72cc964-2bd9-11e5-8cbd-2d88ba31de2a.PNG)

@ronie @MartijnKaijser 
