### PR TITLE
[guilib] fix cursor not always shown in keyboard dialog (fixes #16134)

### DIFF
--- a/xbmc/guilib/GUIEditControl.cpp
+++ b/xbmc/guilib/GUIEditControl.cpp
@@ -493,7 +493,7 @@ void CGUIEditControl::ProcessText(unsigned int currentTime)
       if (!hint.empty())
         changed |= m_label2.SetText(hint);
     }
-    else if (HasFocus() && m_inputType != INPUT_TYPE_READONLY)
+    else if ((HasFocus() || GetParentID() == WINDOW_DIALOG_KEYBOARD) && m_inputType != INPUT_TYPE_READONLY)
       changed |= SetStyledText(text);
     else
       changed |= m_label2.SetTextW(text);
@@ -583,13 +583,10 @@ bool CGUIEditControl::SetStyledText(const std::wstring &text)
   }
 
   // show the cursor
-  if (HasFocus() || GetParentID() == WINDOW_DIALOG_KEYBOARD)
-  {
-    unsigned int ch = L'|';
-    if ((++m_cursorBlink % 64) > 32)
-      ch |= (3 << 16);
-    styled.insert(styled.begin() + m_cursorPos, ch);
-  }
+  unsigned int ch = L'|';
+  if ((++m_cursorBlink % 64) > 32)
+    ch |= (3 << 16);
+  styled.insert(styled.begin() + m_cursorPos, ch);
 
   return m_label2.SetStyledText(styled, colors);
 }


### PR DESCRIPTION
After introducing 708b2ed844d6d706f3bd536c03283e3c7410471a which fixes the dirty region issue, the changes introduced by c03ecbeff265d422cc503806023cc1b28050e7bb (new approach to always show the cursor for keyboard dialog) doesn't work anymore because `SetStyledText` is only called if the control has the focus and therefore the cursor code too.

This is an attempt to fix it.

Related trac ticket
- http://trac.kodi.tv/ticket/16134
