### PR TITLE
[guilib] fix first letter remains visible in keyboard dialog

### DIFF
--- a/xbmc/guilib/GUIEditControl.cpp
+++ b/xbmc/guilib/GUIEditControl.cpp
@@ -487,14 +487,16 @@ void CGUIEditControl::ProcessText(unsigned int currentTime)
 
     std::wstring text = GetDisplayedText();
 
-    if (!HasFocus() && text.empty())
+    if ((HasFocus() || GetParentID() == WINDOW_DIALOG_KEYBOARD) && m_inputType != INPUT_TYPE_READONLY)
+    {
+      changed |= SetStyledText(text);
+    }
+    else if (!HasFocus() && text.empty())
     {
       std::string hint = m_hintInfo.GetLabel(GetParentID());
       if (!hint.empty())
         changed |= m_label2.SetText(hint);
     }
-    else if ((HasFocus() || GetParentID() == WINDOW_DIALOG_KEYBOARD) && m_inputType != INPUT_TYPE_READONLY)
-      changed |= SetStyledText(text);
     else
       changed |= m_label2.SetTextW(text);
 


### PR DESCRIPTION
Follow-up of #7532 and should fix the reported issue

> "if you delete everything you type the first letter remains visible once you start typing it goes away."
> http://forum.kodi.tv/showthread.php?tid=231092&pid=2055348#pid2055348

@MilhouseVH could you please confirm if it works?
