### PR TITLE
SelectionStream: Use ctor instead of C++11 init

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayer.h
+++ b/xbmc/cores/dvdplayer/DVDPlayer.h
@@ -154,17 +154,27 @@ public:
 
 typedef struct SelectionStream
 {
-  StreamType   type = STREAM_NONE;
-  int          type_index = 0;
+  StreamType   type;
+  int          type_index;
   std::string  filename;
   std::string  filename2;  // for vobsub subtitles, 2 files are necessary (idx/sub)
   std::string  language;
   std::string  name;
-  CDemuxStream::EFlags flags = CDemuxStream::FLAG_NONE;
-  int          source = 0;
-  int          id = 0;
+  CDemuxStream::EFlags flags;
+  int          source;
+  int          id;
   std::string  codec;
-  int          channels = 0;
+  int          channels;
+
+  SelectionStream()
+  {
+    type = STREAM_NONE;
+    type_index = 0;
+    flags = CDemuxStream::FLAG_NONE;
+    source = 0;
+    id = 0;
+    channels = 0;
+  }
 } SelectionStream;
 
 typedef std::vector<SelectionStream> SelectionStreams;


### PR DESCRIPTION
If we would not do that - we would break Ubuntu 12.04.
