### PR TITLE
[addons] extend context menu system

### DIFF
--- a/Kodi.xcodeproj/project.pbxproj
+++ b/Kodi.xcodeproj/project.pbxproj
@@ -214,9 +214,6 @@
 		395C2A191A9F074C00EBC7AD /* Locale.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 395C2A171A9F074C00EBC7AD /* Locale.cpp */; };
 		395C2A1A1A9F074C00EBC7AD /* Locale.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 395C2A171A9F074C00EBC7AD /* Locale.cpp */; };
 		395C2A1B1A9F074C00EBC7AD /* Locale.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 395C2A171A9F074C00EBC7AD /* Locale.cpp */; };
-		395C2A1F1A9F96A700EBC7AD /* ContextItemAddon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 395C2A1D1A9F96A700EBC7AD /* ContextItemAddon.cpp */; };
-		395C2A201A9F96A700EBC7AD /* ContextItemAddon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 395C2A1D1A9F96A700EBC7AD /* ContextItemAddon.cpp */; };
-		395C2A211A9F96A700EBC7AD /* ContextItemAddon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 395C2A1D1A9F96A700EBC7AD /* ContextItemAddon.cpp */; };
 		395C2A241AA4C32100EBC7AD /* AudioDecoder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 395C2A221AA4C32100EBC7AD /* AudioDecoder.cpp */; };
 		395C2A251AA4C32100EBC7AD /* AudioDecoder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 395C2A221AA4C32100EBC7AD /* AudioDecoder.cpp */; };
 		395C2A261AA4C32100EBC7AD /* AudioDecoder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 395C2A221AA4C32100EBC7AD /* AudioDecoder.cpp */; };
@@ -888,6 +885,12 @@
 		DF527736151BAF4C00B5B63B /* WebSocketV13.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF52772F151BAF4C00B5B63B /* WebSocketV13.cpp */; };
 		DF527737151BAF4C00B5B63B /* WebSocketV8.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF527731151BAF4C00B5B63B /* WebSocketV8.cpp */; };
 		DF529BAE1741697B00523FB4 /* Environment.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF529BAC1741697B00523FB4 /* Environment.cpp */; };
+		DF54F7FE1B6580AD000FCBA4 /* ContextMenuItem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF54F7FC1B6580AC000FCBA4 /* ContextMenuItem.cpp */; };
+		DF54F7FF1B6580AD000FCBA4 /* ContextMenuItem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF54F7FC1B6580AC000FCBA4 /* ContextMenuItem.cpp */; };
+		DF54F8001B6580AD000FCBA4 /* ContextMenuItem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF54F7FC1B6580AC000FCBA4 /* ContextMenuItem.cpp */; };
+		DF54F8031B6580C8000FCBA4 /* ContextMenuAddon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF54F8011B6580C8000FCBA4 /* ContextMenuAddon.cpp */; };
+		DF54F8041B6580C8000FCBA4 /* ContextMenuAddon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF54F8011B6580C8000FCBA4 /* ContextMenuAddon.cpp */; };
+		DF54F8051B6580C8000FCBA4 /* ContextMenuAddon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF54F8011B6580C8000FCBA4 /* ContextMenuAddon.cpp */; };
 		DF56EF1F1A798A3F00CAAEFB /* HTTPFileHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF56EF1D1A798A3F00CAAEFB /* HTTPFileHandler.cpp */; };
 		DF56EF201A798A3F00CAAEFB /* HTTPFileHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF56EF1D1A798A3F00CAAEFB /* HTTPFileHandler.cpp */; };
 		DF56EF211A798A3F00CAAEFB /* HTTPFileHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF56EF1D1A798A3F00CAAEFB /* HTTPFileHandler.cpp */; };
@@ -3587,8 +3590,6 @@
 		395C2A101A9F072400EBC7AD /* ResourceFile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ResourceFile.h; sourceTree = "<group>"; };
 		395C2A171A9F074C00EBC7AD /* Locale.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Locale.cpp; sourceTree = "<group>"; };
 		395C2A181A9F074C00EBC7AD /* Locale.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Locale.h; sourceTree = "<group>"; };
-		395C2A1D1A9F96A700EBC7AD /* ContextItemAddon.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ContextItemAddon.cpp; sourceTree = "<group>"; };
-		395C2A1E1A9F96A700EBC7AD /* ContextItemAddon.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ContextItemAddon.h; sourceTree = "<group>"; };
 		395C2A221AA4C32100EBC7AD /* AudioDecoder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AudioDecoder.cpp; sourceTree = "<group>"; };
 		395C2A231AA4C32100EBC7AD /* AudioDecoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AudioDecoder.h; sourceTree = "<group>"; };
 		395F6DDB1A8133360088CC74 /* GUIDialogSimpleMenu.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GUIDialogSimpleMenu.cpp; sourceTree = "<group>"; };
@@ -4516,6 +4517,10 @@
 		DF527732151BAF4C00B5B63B /* WebSocketV8.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebSocketV8.h; sourceTree = "<group>"; };
 		DF529BAC1741697B00523FB4 /* Environment.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Environment.cpp; sourceTree = "<group>"; };
 		DF529BAD1741697B00523FB4 /* Environment.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Environment.h; sourceTree = "<group>"; };
+		DF54F7FC1B6580AC000FCBA4 /* ContextMenuItem.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ContextMenuItem.cpp; sourceTree = "<group>"; };
+		DF54F7FD1B6580AC000FCBA4 /* ContextMenuItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ContextMenuItem.h; sourceTree = "<group>"; };
+		DF54F8011B6580C8000FCBA4 /* ContextMenuAddon.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ContextMenuAddon.cpp; sourceTree = "<group>"; };
+		DF54F8021B6580C8000FCBA4 /* ContextMenuAddon.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ContextMenuAddon.h; sourceTree = "<group>"; };
 		DF56EF1D1A798A3F00CAAEFB /* HTTPFileHandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = HTTPFileHandler.cpp; sourceTree = "<group>"; };
 		DF56EF1E1A798A3F00CAAEFB /* HTTPFileHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HTTPFileHandler.h; sourceTree = "<group>"; };
 		DF56EF221A798A5E00CAAEFB /* HttpRangeUtils.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = HttpRangeUtils.cpp; sourceTree = "<group>"; };
@@ -5922,8 +5927,8 @@
 				395C2A231AA4C32100EBC7AD /* AudioDecoder.h */,
 				7CF34D9D1930264A00D543C5 /* AudioEncoder.cpp */,
 				7CF34D9E1930264A00D543C5 /* AudioEncoder.h */,
-				395C2A1D1A9F96A700EBC7AD /* ContextItemAddon.cpp */,
-				395C2A1E1A9F96A700EBC7AD /* ContextItemAddon.h */,
+				DF54F8011B6580C8000FCBA4 /* ContextMenuAddon.cpp */,
+				DF54F8021B6580C8000FCBA4 /* ContextMenuAddon.h */,
 				18B49FF61152BFA5001AF8A6 /* DllAddon.h */,
 				18B7C38612942090009E7A26 /* GUIDialogAddonInfo.cpp */,
 				18B7C38712942090009E7A26 /* GUIDialogAddonInfo.h */,
@@ -8265,6 +8270,8 @@
 				E38E14720D25F9F900618676 /* BackgroundInfoLoader.cpp */,
 				E38E14730D25F9F900618676 /* BackgroundInfoLoader.h */,
 				F5B413131065900C0035D105 /* config.h */,
+				DF54F7FC1B6580AC000FCBA4 /* ContextMenuItem.cpp */,
+				DF54F7FD1B6580AC000FCBA4 /* ContextMenuItem.h */,
 				395C29F91A9CD20C00EBC7AD /* ContextMenuManager.cpp */,
 				395C29FA1A9CD20C00EBC7AD /* ContextMenuManager.h */,
 				E38E167E0D25F9FA00618676 /* CueDocument.cpp */,
@@ -10281,6 +10288,7 @@
 				E38E20510D25F9FD00618676 /* PluginDirectory.cpp in Sources */,
 				E38E20520D25F9FD00618676 /* RarDirectory.cpp in Sources */,
 				E38E20530D25F9FD00618676 /* RarManager.cpp in Sources */,
+				DF54F7FE1B6580AD000FCBA4 /* ContextMenuItem.cpp in Sources */,
 				395C29C51A98A0E100EBC7AD /* ILanguageInvoker.cpp in Sources */,
 				E38E20580D25F9FD00618676 /* SmartPlaylistDirectory.cpp in Sources */,
 				E38E205B0D25F9FD00618676 /* StackDirectory.cpp in Sources */,
@@ -10867,6 +10875,7 @@
 				C84828C8156CFCD8005A996F /* GUIDialogPVRChannelManager.cpp in Sources */,
 				C84828C9156CFCD8005A996F /* GUIDialogPVRChannelsOSD.cpp in Sources */,
 				C84828CC156CFCD8005A996F /* GUIDialogPVRGroupManager.cpp in Sources */,
+				DF54F8031B6580C8000FCBA4 /* ContextMenuAddon.cpp in Sources */,
 				C84828CD156CFCD8005A996F /* GUIDialogPVRGuideInfo.cpp in Sources */,
 				C84828CE156CFCD8005A996F /* GUIDialogPVRGuideOSD.cpp in Sources */,
 				C84828CF156CFCD8005A996F /* GUIDialogPVRGuideSearch.cpp in Sources */,
@@ -11070,7 +11079,6 @@
 				7C1409A9184015C9009F9411 /* InfoExpression.cpp in Sources */,
 				AE32174218313ADF0003FAFC /* XSLTUtils.cpp in Sources */,
 				7C15DCBC1892481400FCE564 /* InfoBool.cpp in Sources */,
-				395C2A1F1A9F96A700EBC7AD /* ContextItemAddon.cpp in Sources */,
 				F5CC228B1814F7E9006B5E91 /* AESinkDARWINOSX.cpp in Sources */,
 				F5CC22EB1814FF3B006B5E91 /* ActiveAE.cpp in Sources */,
 				F5CC22EC1814FF3B006B5E91 /* ActiveAEBuffer.cpp in Sources */,
@@ -11575,6 +11583,7 @@
 				DFF0F28217528350002DA3A4 /* GUIControlFactory.cpp in Sources */,
 				DFF0F28317528350002DA3A4 /* GUIControlGroup.cpp in Sources */,
 				DFF0F28417528350002DA3A4 /* GUIControlGroupList.cpp in Sources */,
+				DF54F8001B6580AD000FCBA4 /* ContextMenuItem.cpp in Sources */,
 				DFF0F28517528350002DA3A4 /* GUIControlProfiler.cpp in Sources */,
 				DFF0F28617528350002DA3A4 /* GUIDialog.cpp in Sources */,
 				DFF0F28717528350002DA3A4 /* GUIEditControl.cpp in Sources */,
@@ -11740,7 +11749,6 @@
 				DFF0F32417528350002DA3A4 /* HTTPVfsHandler.cpp in Sources */,
 				DFF0F32517528350002DA3A4 /* HTTPWebinterfaceAddonsHandler.cpp in Sources */,
 				DFF0F32617528350002DA3A4 /* HTTPWebinterfaceHandler.cpp in Sources */,
-				395C2A211A9F96A700EBC7AD /* ContextItemAddon.cpp in Sources */,
 				DFF0F32717528350002DA3A4 /* IHTTPRequestHandler.cpp in Sources */,
 				DFF0F32817528350002DA3A4 /* NetworkLinux.cpp in Sources */,
 				DFF0F32917528350002DA3A4 /* ZeroconfBrowserOSX.cpp in Sources */,
@@ -11807,6 +11815,7 @@
 				DFF0F36117528350002DA3A4 /* PlayListM3U.cpp in Sources */,
 				DF4BF0191A4EF31F0053AC56 /* cc_decoder.c in Sources */,
 				DFF0F36217528350002DA3A4 /* PlayListPLS.cpp in Sources */,
+				DF54F8051B6580C8000FCBA4 /* ContextMenuAddon.cpp in Sources */,
 				DFF0F36317528350002DA3A4 /* PlayListURL.cpp in Sources */,
 				DFF0F36417528350002DA3A4 /* PlayListWPL.cpp in Sources */,
 				DFEA4B5B1B52721300562321 /* GUIDialogAudioDSPManager.cpp in Sources */,
@@ -12596,7 +12605,6 @@
 				E49912C9174E5DA000741B6D /* DirectoryNodeRecentlyAddedMusicVideos.cpp in Sources */,
 				E49912CA174E5DA000741B6D /* DirectoryNodeRoot.cpp in Sources */,
 				E49912CB174E5DA000741B6D /* DirectoryNodeSeasons.cpp in Sources */,
-				395C2A201A9F96A700EBC7AD /* ContextItemAddon.cpp in Sources */,
 				E49912CC174E5DA000741B6D /* DirectoryNodeTitleMovies.cpp in Sources */,
 				E49912CD174E5DA000741B6D /* DirectoryNodeTitleMusicVideos.cpp in Sources */,
 				DFDE5D521AE5658200EE53AD /* PictureScalingAlgorithm.cpp in Sources */,
@@ -12762,6 +12770,7 @@
 				E499137C174E5F0E00741B6D /* GUIDialogKaraokeSongSelector.cpp in Sources */,
 				E499137D174E5F0E00741B6D /* GUIWindowKaraokeLyrics.cpp in Sources */,
 				E499137E174E5F0E00741B6D /* karaokelyrics.cpp in Sources */,
+				DF54F8041B6580C8000FCBA4 /* ContextMenuAddon.cpp in Sources */,
 				E499137F174E5F0E00741B6D /* karaokelyricscdg.cpp in Sources */,
 				E4991380174E5F0E00741B6D /* karaokelyricsfactory.cpp in Sources */,
 				E4991381174E5F0E00741B6D /* karaokelyricsmanager.cpp in Sources */,
@@ -13213,6 +13222,7 @@
 				7CCDA187192753E30074CF51 /* PltTaskManager.cpp in Sources */,
 				7CCDA190192753E30074CF51 /* PltThreadTask.cpp in Sources */,
 				7CCDA199192753E30074CF51 /* PltUPnP.cpp in Sources */,
+				DF54F7FF1B6580AD000FCBA4 /* ContextMenuItem.cpp in Sources */,
 				7CCDA1A2192753E30074CF51 /* PltMediaConnect.cpp in Sources */,
 				7CCDA1AB192753E30074CF51 /* PltXbox360.cpp in Sources */,
 				7CCDA1B0192753E30074CF51 /* X_MS_MediaReceiverRegistrarSCPD.cpp in Sources */,

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -13103,7 +13103,7 @@ msgstr ""
 #. Used as the type name for context item addons
 #: xbmc/addons/Addons.cpp
 msgctxt "#24025"
-msgid "Context items"
+msgid "Context menus"
 msgstr ""
 
 #: xbmc/addons/Addon.cpp

--- a/addons/xbmc.python/contextitem.xsd
+++ b/addons/xbmc.python/contextitem.xsd
@@ -4,26 +4,30 @@
   <xs:element name="extension">
     <xs:complexType>
       <xs:sequence>
-        <xs:element name="item">
-          <xs:complexType>
-            <xs:sequence>
-            <xs:element name="label" type="xs:string"/>
-            <xs:element name="visible" type="xs:string"/>
-            <xs:element name="parent" type="xs:string"/>
-            </xs:sequence>
-          </xs:complexType>
-        </xs:element>
+        <xs:element name="menu" type="menuType" minOccurs="1" maxOccurs="unbounded"/>
       </xs:sequence>
       <xs:attribute name="point" type="xs:string" use="required"/>
       <xs:attribute name="id" type="simpleIdentifier"/>
-      <xs:attribute name="name" type="xs:string"/>
-      <xs:attribute name="library" type="xs:string" use="required"/>
     </xs:complexType>
   </xs:element>
+  <xs:complexType name="itemType">
+    <xs:sequence>
+      <xs:element name="label" type="xs:string"/>
+      <xs:element name="visible" type="xs:string"/>
+    </xs:sequence>
+    <xs:attribute name="library" type="xs:string" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="menuType">
+    <xs:sequence>
+      <xs:element name="label" type="xs:string" minOccurs="0"/>
+      <xs:element name="item" type="itemType" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="menu" type="menuType" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:string"/>
+  </xs:complexType>
   <xs:simpleType name="simpleIdentifier">
     <xs:restriction base="xs:string">
       <xs:pattern value="[^.]+"/>
     </xs:restriction>
   </xs:simpleType>
 </xs:schema>
-

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -211,6 +211,7 @@
     <ClCompile Include="..\..\xbmc\AutoSwitch.cpp" />
     <ClCompile Include="..\..\xbmc\BackgroundInfoLoader.cpp" />
     <ClCompile Include="..\..\xbmc\CompileInfo.cpp" />
+    <ClCompile Include="..\..\xbmc\ContextMenuItem.cpp" />
     <ClCompile Include="..\..\xbmc\ContextMenuManager.cpp" />
     <ClCompile Include="..\..\xbmc\contrib\kissfft\kiss_fft.c">
       <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">CompileAsCpp</CompileAs>
@@ -1725,6 +1726,7 @@
     <ClInclude Include="..\..\xbmc\Autorun.h" />
     <ClInclude Include="..\..\xbmc\AutoSwitch.h" />
     <ClInclude Include="..\..\xbmc\BackgroundInfoLoader.h" />
+    <ClInclude Include="..\..\xbmc\ContextMenuItem.h" />
     <ClInclude Include="..\..\xbmc\ContextMenuManager.h" />
     <ClInclude Include="..\..\xbmc\cores\dvdplayer\DVDDemuxers\DVDDemuxPVRClient.h" />
     <ClInclude Include="..\..\xbmc\cores\dvdplayer\DVDInputStreams\DVDInputStreamBluray.h" />

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -190,7 +190,7 @@
     <ClCompile Include="..\..\xbmc\addons\AddonDatabase.cpp" />
     <ClCompile Include="..\..\xbmc\addons\AddonInstaller.cpp" />
     <ClCompile Include="..\..\xbmc\addons\AddonVersion.cpp" />
-    <ClCompile Include="..\..\xbmc\addons\ContextItemAddon.cpp" />
+    <ClCompile Include="..\..\xbmc\addons\ContextMenuAddon.cpp" />
     <ClCompile Include="..\..\xbmc\addons\AudioDecoder.cpp" />
     <ClCompile Include="..\..\xbmc\addons\GUIDialogAddonInfo.cpp" />
     <ClCompile Include="..\..\xbmc\addons\GUIDialogAddonSettings.cpp" />
@@ -858,7 +858,7 @@
     <ClInclude Include="..\..\xbmc\addons\AddonCallbacksAudioDSP.h" />
     <ClInclude Include="..\..\xbmc\addons\AddonCallbacksCodec.h" />
     <ClInclude Include="..\..\xbmc\addons\AudioDecoder.h" />
-    <ClInclude Include="..\..\xbmc\addons\ContextItemAddon.h" />
+    <ClInclude Include="..\..\xbmc\addons\ContextMenuAddon.h" />
     <ClInclude Include="..\..\xbmc\addons\ImageResource.h" />
     <ClInclude Include="..\..\xbmc\addons\Webinterface.h" />
     <ClInclude Include="..\..\xbmc\addons\UISoundsResource.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -2227,6 +2227,7 @@
     <ClCompile Include="..\..\xbmc\AutoSwitch.cpp" />
     <ClCompile Include="..\..\xbmc\DynamicDll.cpp" />
     <ClCompile Include="..\..\xbmc\CueDocument.cpp" />
+    <ClCompile Include="..\..\xbmc\ContextMenuItem.cpp" />
     <ClCompile Include="..\..\xbmc\ContextMenuManager.cpp" />
     <ClCompile Include="..\..\xbmc\FileItem.cpp" />
     <ClCompile Include="..\..\xbmc\GUIInfoManager.cpp" />
@@ -5240,6 +5241,7 @@
     <ClInclude Include="..\..\xbmc\AutoSwitch.h" />
     <ClInclude Include="..\..\xbmc\DynamicDll.h" />
     <ClInclude Include="..\..\xbmc\CueDocument.h" />
+    <ClInclude Include="..\..\xbmc\ContextMenuItem.h" />
     <ClInclude Include="..\..\xbmc\ContextMenuManager.h" />
     <ClInclude Include="..\..\xbmc\FileItem.h" />
     <ClInclude Include="..\..\xbmc\GUIInfoManager.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -744,7 +744,7 @@
     <ClCompile Include="..\..\xbmc\addons\AudioEncoder.cpp">
       <Filter>addons</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\xbmc\addons\ContextItemAddon.cpp">
+    <ClCompile Include="..\..\xbmc\addons\ContextMenuAddon.cpp">
       <Filter>addons</Filter>
     </ClCompile>
     <ClCompile Include="..\..\xbmc\addons\Scraper.cpp">
@@ -3620,7 +3620,7 @@
     <ClInclude Include="..\..\xbmc\addons\AudioEncoder.h">
       <Filter>addons</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\xbmc\addons\ContextItemAddon.h">
+    <ClInclude Include="..\..\xbmc\addons\ContextMenuAddon.h">
       <Filter>addons</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\addons\DllAddon.h">

--- a/xbmc/ContextMenuItem.cpp
+++ b/xbmc/ContextMenuItem.cpp
@@ -21,7 +21,7 @@
 #include "ContextMenuItem.h"
 #include "addons/Addon.h"
 #include "addons/AddonManager.h"
-#include "addons/ContextItemAddon.h"
+#include "addons/ContextMenuAddon.h"
 #include "addons/IAddon.h"
 #include "interfaces/generic/ScriptInvocationManager.h"
 #include "interfaces/python/ContextItemAddonInvoker.h"

--- a/xbmc/ContextMenuItem.cpp
+++ b/xbmc/ContextMenuItem.cpp
@@ -1,0 +1,106 @@
+/*
+ *      Copyright (C) 2015 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "ContextMenuItem.h"
+#include "addons/Addon.h"
+#include "addons/AddonManager.h"
+#include "addons/ContextItemAddon.h"
+#include "addons/IAddon.h"
+#include "interfaces/generic/ScriptInvocationManager.h"
+#include "interfaces/python/ContextItemAddonInvoker.h"
+#include "interfaces/python/XBPython.h"
+#include "utils/StringUtils.h"
+#include <boost/lexical_cast.hpp>
+
+
+std::string CContextMenuItem::GetLabel() const
+{
+  if (!m_addon)
+    return "";
+
+  if (StringUtils::IsNaturalNumber(m_label))
+    return m_addon->GetString(boost::lexical_cast<int>(m_label.c_str()));
+
+  return m_label;
+}
+
+bool CContextMenuItem::IsVisible(const CFileItemPtr& item) const
+{
+  return IsGroup() || (item && m_condition && m_condition->Get(item.get()));
+}
+
+bool CContextMenuItem::IsParentOf(const CContextMenuItem& other) const
+{
+  return !m_groupId.empty() && (m_groupId == other.m_parent);
+}
+
+bool CContextMenuItem::IsGroup() const
+{
+  return !m_groupId.empty();
+}
+
+bool CContextMenuItem::Execute(const CFileItemPtr& item) const
+{
+  if (!item || !m_addon || m_library.empty() || IsGroup())
+    return false;
+
+  LanguageInvokerPtr invoker(new CContextItemAddonInvoker(&g_pythonParser, item));
+  return (CScriptInvocationManager::Get().ExecuteAsync(m_library, invoker, m_addon) != -1);
+}
+
+bool CContextMenuItem::operator==(const CContextMenuItem& other) const
+{
+  if (IsGroup() && other.IsGroup())
+    return (m_groupId == other.m_groupId && m_parent == other.m_parent);
+
+  return (IsGroup() == other.IsGroup())
+      && (m_parent == other.m_parent)
+      && (m_library == other.m_library)
+      && ((!m_addon && !other.m_addon) || (m_addon && other.m_addon && m_addon->ID() == other.m_addon->ID()));
+}
+
+std::string CContextMenuItem::ToString() const
+{
+  if (IsGroup())
+    return StringUtils::Format("CContextMenuItem[group, id=%s, parent=%s, addon=%s]",
+        m_groupId.c_str(), m_parent.c_str(), m_addon ? m_addon->ID().c_str() : "null");
+  else
+    return StringUtils::Format("CContextMenuItem[item, parent=%s, library=%s, addon=%s]",
+        m_parent.c_str(), m_library.c_str(), m_addon ? m_addon->ID().c_str() : "null");
+}
+
+CContextMenuItem CContextMenuItem::CreateGroup(const std::string& label, const std::string& parent, const std::string& groupId)
+{
+  CContextMenuItem menuItem;
+  menuItem.m_label = label;
+  menuItem.m_parent = parent;
+  menuItem.m_groupId = groupId;
+  return menuItem;
+}
+
+CContextMenuItem CContextMenuItem::CreateItem(const std::string& label, const std::string& parent, const std::string& library, const INFO::InfoPtr& condition)
+{
+  CContextMenuItem menuItem;
+  menuItem.m_label = label;
+  menuItem.m_parent = parent;
+  menuItem.m_library = library;
+  menuItem.m_condition = condition;
+  return menuItem;
+}

--- a/xbmc/ContextMenuItem.h
+++ b/xbmc/ContextMenuItem.h
@@ -1,0 +1,63 @@
+#pragma once
+/*
+ *      Copyright (C) 2015 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <map>
+#include "addons/ContextItemAddon.h"
+#include "addons/IAddon.h"
+#include "dialogs/GUIDialogContextMenu.h"
+
+namespace ADDON
+{
+  class CContextItemAddon;
+}
+
+class CContextMenuItem
+{
+public:
+  std::string GetLabel() const;
+  bool IsVisible(const CFileItemPtr& item) const;
+  bool IsParentOf(const CContextMenuItem& menuItem) const;
+  bool IsGroup() const;
+  bool Execute(const CFileItemPtr& item) const;
+  bool operator==(const CContextMenuItem& other) const;
+  std::string ToString() const;
+
+  static CContextMenuItem CreateGroup(
+    const std::string& label,
+    const std::string& parent,
+    const std::string& groupId);
+
+  static CContextMenuItem CreateItem(
+    const std::string& label,
+    const std::string& parent,
+    const std::string& library,
+    const INFO::InfoPtr& condition);
+
+  friend class ADDON::CContextItemAddon;
+
+private:
+  std::string m_label;
+  std::string m_parent;
+  std::string m_groupId;
+  std::string m_library;
+  INFO::InfoPtr m_condition;
+  ADDON::AddonPtr m_addon;
+};

--- a/xbmc/ContextMenuItem.h
+++ b/xbmc/ContextMenuItem.h
@@ -20,13 +20,13 @@
  */
 
 #include <map>
-#include "addons/ContextItemAddon.h"
+#include "addons/ContextMenuAddon.h"
 #include "addons/IAddon.h"
 #include "dialogs/GUIDialogContextMenu.h"
 
 namespace ADDON
 {
-  class CContextItemAddon;
+  class CContextMenuAddon;
 }
 
 class CContextMenuItem
@@ -51,7 +51,7 @@ public:
     const std::string& library,
     const INFO::InfoPtr& condition);
 
-  friend class ADDON::CContextItemAddon;
+  friend class ADDON::CContextMenuAddon;
 
 private:
   std::string m_label;

--- a/xbmc/ContextMenuManager.cpp
+++ b/xbmc/ContextMenuManager.cpp
@@ -22,7 +22,7 @@
 #include "ContextMenuItem.h"
 #include "addons/Addon.h"
 #include "addons/AddonManager.h"
-#include "addons/ContextItemAddon.h"
+#include "addons/ContextMenuAddon.h"
 #include "addons/IAddon.h"
 #include "interfaces/generic/ScriptInvocationManager.h"
 #include "interfaces/python/ContextItemAddonInvoker.h"
@@ -54,7 +54,7 @@ void CContextMenuManager::Init()
   VECADDONS addons;
   if (CAddonMgr::Get().GetAddons(ADDON_CONTEXT_ITEM, addons))
     for (const auto& addon : addons)
-      Register(std::static_pointer_cast<CContextItemAddon>(addon));
+      Register(std::static_pointer_cast<CContextMenuAddon>(addon));
 }
 
 void CContextMenuManager::Register(const ContextItemAddonPtr& cm)

--- a/xbmc/ContextMenuManager.cpp
+++ b/xbmc/ContextMenuManager.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "ContextMenuManager.h"
+#include "ContextMenuItem.h"
 #include "addons/Addon.h"
 #include "addons/AddonManager.h"
 #include "addons/ContextItemAddon.h"
@@ -26,10 +27,14 @@
 #include "interfaces/generic/ScriptInvocationManager.h"
 #include "interfaces/python/ContextItemAddonInvoker.h"
 #include "interfaces/python/XBPython.h"
+#include "utils/log.h"
 
 using namespace ADDON;
 
-typedef std::map<unsigned int, ContextItemAddonPtr>::value_type ValueType;
+typedef std::map<unsigned int, CContextMenuItem>::value_type ValueType;
+
+const CContextMenuItem CContextMenuManager::MAIN = CContextMenuItem::CreateGroup("", "", "kodi.core.main");
+const CContextMenuItem CContextMenuManager::MANAGE = CContextMenuItem::CreateGroup("", "", "kodi.core.manage");
 
 
 CContextMenuManager::CContextMenuManager()
@@ -46,20 +51,32 @@ CContextMenuManager& CContextMenuManager::Get()
 
 void CContextMenuManager::Init()
 {
-  //Make sure we load all context items on first usage...
   VECADDONS addons;
   if (CAddonMgr::Get().GetAddons(ADDON_CONTEXT_ITEM, addons))
-  {
     for (const auto& addon : addons)
       Register(std::static_pointer_cast<CContextItemAddon>(addon));
-  }
 }
 
 void CContextMenuManager::Register(const ContextItemAddonPtr& cm)
 {
   if (!cm)
     return;
-  m_contextAddons[m_iCurrentContextId++] = cm;
+
+  for (const auto& menuItem : cm->GetItems())
+  {
+    auto existing = std::find_if(m_items.begin(), m_items.end(),
+        [&](const ValueType& kv){ return kv.second == menuItem; });
+    if (existing != m_items.end())
+    {
+      if (!menuItem.GetLabel().empty())
+        m_items[existing->first] = menuItem;
+    }
+    else
+    {
+      m_items[m_iCurrentContextId] = menuItem;
+      ++m_iCurrentContextId;
+    }
+  }
 }
 
 bool CContextMenuManager::Unregister(const ContextItemAddonPtr& cm)
@@ -67,47 +84,75 @@ bool CContextMenuManager::Unregister(const ContextItemAddonPtr& cm)
   if (!cm)
     return false;
 
-  auto it = std::find_if(m_contextAddons.begin(), m_contextAddons.end(),
-      [&](const ValueType& value){ return value.second->ID() == cm->ID(); });
+  const auto menuItems = cm->GetItems();
 
-  if (it != m_contextAddons.end())
-  {
-    m_contextAddons.erase(it);
-    return true;
-  }
-  return false;
+  auto it = std::remove_if(m_items.begin(), m_items.end(),
+    [&](const Item& kv)
+    {
+      if (kv.second.IsGroup())
+        return false; //keep in case other items use them
+      return std::find(menuItems.begin(), menuItems.end(), kv.second) != menuItems.end();
+    }
+  );
+  m_items.erase(it, m_items.end());
+  return true;
 }
 
-ContextItemAddonPtr CContextMenuManager::GetContextItemByID(unsigned int id)
+bool CContextMenuManager::IsVisible(
+  const CContextMenuItem& menuItem, const CContextMenuItem& root, const CFileItemPtr& fileItem)
 {
-  auto it = m_contextAddons.find(id);
-  if (it != m_contextAddons.end())
-    return it->second;
-  return ContextItemAddonPtr();
+  if (menuItem.GetLabel().empty() || !root.IsParentOf(menuItem))
+    return false;
+
+  if (menuItem.IsGroup())
+    return std::any_of(m_items.begin(), m_items.end(),
+        [&](const ValueType& kv){ return menuItem.IsParentOf(kv.second) && kv.second.IsVisible(fileItem); });
+
+  return menuItem.IsVisible(fileItem);
 }
 
-void CContextMenuManager::AddVisibleItems(const CFileItemPtr& item, CContextButtons& list, const std::string& parent /* = "" */)
+void CContextMenuManager::AddVisibleItems(
+  const CFileItemPtr& item, CContextButtons& list, const CContextMenuItem& root /* = CContextMenuItem::MAIN */)
 {
   if (!item)
     return;
 
-  for (const auto& kv : m_contextAddons)
-  {
-    if (kv.second->GetParent() == parent && kv.second->IsVisible(item))
-      list.push_back(std::make_pair(kv.first, kv.second->GetLabel()));
-  }
+  for (const auto& kv : m_items)
+    if (IsVisible(kv.second, root, item))
+      list.push_back(std::make_pair(kv.first, kv.second.GetLabel()));
 }
+
 
 bool CContextMenuManager::Execute(unsigned int id, const CFileItemPtr& item)
 {
   if (!item)
     return false;
 
-  const ContextItemAddonPtr addon = GetContextItemByID(id);
-  if (!addon || !addon->IsVisible(item))
+  auto it = m_items.find(id);
+  if (it == m_items.end())
+  {
+    CLog::Log(LOGERROR, "CContextMenuManager: unknown button id '%u'", id);
     return false;
+  }
 
-  LanguageInvokerPtr invoker(new CContextItemAddonInvoker(&g_pythonParser, item));
-  return (CScriptInvocationManager::Get().ExecuteAsync(addon->LibPath(), invoker, addon) != -1);
+  CContextMenuItem menuItem = it->second;
+  if (menuItem.IsGroup())
+  {
+    CLog::Log(LOGDEBUG, "CContextMenuManager: showing group '%s'", menuItem.ToString().c_str());
+    CContextButtons choices;
+    AddVisibleItems(item, choices, menuItem);
+    if (choices.empty())
+    {
+      CLog::Log(LOGERROR, "CContextMenuManager: no items in group '%s'", menuItem.ToString().c_str());
+      return false;
+    }
+    int choice = CGUIDialogContextMenu::ShowAndGetChoice(choices);
+    if (choice == -1)
+      return false;
+
+    return Execute(choice, item);
+  }
+
+  return menuItem.Execute(item);
 }
 

--- a/xbmc/ContextMenuManager.cpp
+++ b/xbmc/ContextMenuManager.cpp
@@ -38,7 +38,7 @@ const CContextMenuItem CContextMenuManager::MANAGE = CContextMenuItem::CreateGro
 
 
 CContextMenuManager::CContextMenuManager()
-  : m_iCurrentContextId(CONTEXT_BUTTON_FIRST_ADDON)
+  : m_nextButtonId(CONTEXT_BUTTON_FIRST_ADDON)
 {
   Init();
 }
@@ -73,8 +73,8 @@ void CContextMenuManager::Register(const ContextItemAddonPtr& cm)
     }
     else
     {
-      m_items[m_iCurrentContextId] = menuItem;
-      ++m_iCurrentContextId;
+      m_items[m_nextButtonId] = menuItem;
+      ++m_nextButtonId;
     }
   }
 }

--- a/xbmc/ContextMenuManager.cpp
+++ b/xbmc/ContextMenuManager.cpp
@@ -123,7 +123,7 @@ void CContextMenuManager::AddVisibleItems(
 }
 
 
-bool CContextMenuManager::Execute(unsigned int id, const CFileItemPtr& item)
+bool CContextMenuManager::OnClick(unsigned int id, const CFileItemPtr& item)
 {
   if (!item)
     return false;
@@ -150,7 +150,7 @@ bool CContextMenuManager::Execute(unsigned int id, const CFileItemPtr& item)
     if (choice == -1)
       return false;
 
-    return Execute(choice, item);
+    return OnClick(choice, item);
   }
 
   return menuItem.Execute(item);

--- a/xbmc/ContextMenuManager.cpp
+++ b/xbmc/ContextMenuManager.cpp
@@ -117,9 +117,21 @@ void CContextMenuManager::AddVisibleItems(
   if (!item)
     return;
 
+  const int initialSize = list.size();
+
   for (const auto& kv : m_items)
     if (IsVisible(kv.second, root, item))
       list.push_back(std::make_pair(kv.first, kv.second.GetLabel()));
+
+  if (root == MAIN || root == MANAGE)
+  {
+    std::stable_sort(list.begin() + initialSize, list.end(),
+      [](const std::pair<int, std::string>& lhs, const std::pair<int, std::string>& rhs)
+      {
+        return lhs.second < rhs.second;
+      }
+    );
+  }
 }
 
 

--- a/xbmc/ContextMenuManager.h
+++ b/xbmc/ContextMenuManager.h
@@ -75,5 +75,5 @@ private:
     const CFileItemPtr& fileItem);
 
   std::map<unsigned int, CContextMenuItem> m_items;
-  unsigned int m_iCurrentContextId;
+  unsigned int m_nextButtonId;
 };

--- a/xbmc/ContextMenuManager.h
+++ b/xbmc/ContextMenuManager.h
@@ -20,14 +20,17 @@
  */
 
 #include <map>
+#include "ContextMenuItem.h"
 #include "addons/ContextItemAddon.h"
 #include "dialogs/GUIDialogContextMenu.h"
 
-#define CONTEXT_MENU_GROUP_MANAGE "kodi.core.manage"
 
 class CContextMenuManager
 {
 public:
+  static const CContextMenuItem MAIN;
+  static const CContextMenuItem MANAGE;
+
   static CContextMenuManager& Get();
 
   /*!
@@ -42,10 +45,12 @@ public:
    * \brief Adds all registered context item to the list.
    * \param item - the currently selected item.
    * \param list - the context menu.
-   * \param parent - the ID of the context menu. Empty string if the root menu.
-   * CONTEXT_MENU_GROUP_MANAGE if the 'manage' submenu.
+   * \param root - the context menu responsible for this call.
    */
-  void AddVisibleItems(const CFileItemPtr& item, CContextButtons& list, const std::string& parent = "");
+  void AddVisibleItems(
+    const CFileItemPtr& item,
+    CContextButtons& list,
+    const CContextMenuItem& root = MAIN);
 
   /*!
    * \brief Adds a context item to this manager.
@@ -65,14 +70,11 @@ private:
   virtual ~CContextMenuManager() {}
 
   void Init();
+  bool IsVisible(
+    const CContextMenuItem& menuItem,
+    const CContextMenuItem& root,
+    const CFileItemPtr& fileItem);
 
-  /*!
-   * \brief Get a context menu item by its assigned id.
-   * \param id - the button id of the context item.
-   * \return the addon or NULL if no item with given id is registered.
-   */
-  ADDON::ContextItemAddonPtr GetContextItemByID(const unsigned int id);
-
-  std::map<unsigned int, ADDON::ContextItemAddonPtr> m_contextAddons;
+  std::map<unsigned int, CContextMenuItem> m_items;
   unsigned int m_iCurrentContextId;
 };

--- a/xbmc/ContextMenuManager.h
+++ b/xbmc/ContextMenuManager.h
@@ -34,12 +34,11 @@ public:
   static CContextMenuManager& Get();
 
   /*!
-   * \brief Executes a context menu item.
-   * \param id - id of the context button to execute.
-   * \param item - the currently selected item.
-   * \return true if executed successfully, false otherwise
+   * \param id - id of the context button clicked on.
+   * \param item - the selected file item.
+   * \return true on success, otherwise false.
    */
-  bool Execute(unsigned int id, const CFileItemPtr& item);
+  bool OnClick(unsigned int id, const CFileItemPtr& item);
 
   /*!
    * \brief Adds all registered context item to the list.

--- a/xbmc/ContextMenuManager.h
+++ b/xbmc/ContextMenuManager.h
@@ -19,7 +19,7 @@
  *
  */
 
-#include <map>
+#include <vector>
 #include "ContextMenuItem.h"
 #include "addons/ContextMenuAddon.h"
 #include "dialogs/GUIDialogContextMenu.h"
@@ -74,6 +74,6 @@ private:
     const CContextMenuItem& root,
     const CFileItemPtr& fileItem);
 
-  std::map<unsigned int, CContextMenuItem> m_items;
+  std::vector<std::pair<unsigned int, CContextMenuItem>> m_items;
   unsigned int m_nextButtonId;
 };

--- a/xbmc/ContextMenuManager.h
+++ b/xbmc/ContextMenuManager.h
@@ -21,7 +21,7 @@
 
 #include <map>
 #include "ContextMenuItem.h"
-#include "addons/ContextItemAddon.h"
+#include "addons/ContextMenuAddon.h"
 #include "dialogs/GUIDialogContextMenu.h"
 
 

--- a/xbmc/Makefile.in
+++ b/xbmc/Makefile.in
@@ -4,6 +4,7 @@ SRCS=Application.cpp \
      Autorun.cpp \
      AutoSwitch.cpp \
      BackgroundInfoLoader.cpp \
+     ContextMenuItem.cpp \
      ContextMenuManager.cpp \
      CompileInfo.cpp \
      CueDocument.cpp \

--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -646,7 +646,7 @@ void OnEnabled(const std::string& id)
     std::static_pointer_cast<CService>(addon)->Start();
 
   if (CAddonMgr::Get().GetAddon(id, addon, ADDON_CONTEXT_ITEM))
-    CContextMenuManager::Get().Register(std::static_pointer_cast<CContextItemAddon>(addon));
+    CContextMenuManager::Get().Register(std::static_pointer_cast<CContextMenuAddon>(addon));
 }
 
 void OnDisabled(const std::string& id)
@@ -660,7 +660,7 @@ void OnDisabled(const std::string& id)
     std::static_pointer_cast<CService>(addon)->Stop();
 
   if (CAddonMgr::Get().GetAddon(id, addon, ADDON_CONTEXT_ITEM, false))
-    CContextMenuManager::Get().Unregister(std::static_pointer_cast<CContextItemAddon>(addon));
+    CContextMenuManager::Get().Unregister(std::static_pointer_cast<CContextMenuAddon>(addon));
 }
 
 void OnPreInstall(const AddonPtr& addon)
@@ -672,7 +672,7 @@ void OnPreInstall(const AddonPtr& addon)
     std::static_pointer_cast<CService>(localAddon)->Stop();
 
   if (CAddonMgr::Get().GetAddon(addon->ID(), localAddon, ADDON_CONTEXT_ITEM))
-    CContextMenuManager::Get().Unregister(std::static_pointer_cast<CContextItemAddon>(localAddon));
+    CContextMenuManager::Get().Unregister(std::static_pointer_cast<CContextMenuAddon>(localAddon));
 
   //Fallback to the pre-install callback in the addon.
   //BUG: If primary extension point have changed we're calling the wrong method.
@@ -686,7 +686,7 @@ void OnPostInstall(const AddonPtr& addon, bool update, bool modal)
     std::static_pointer_cast<CService>(localAddon)->Start();
 
   if (CAddonMgr::Get().GetAddon(addon->ID(), localAddon, ADDON_CONTEXT_ITEM))
-    CContextMenuManager::Get().Register(std::static_pointer_cast<CContextItemAddon>(localAddon));
+    CContextMenuManager::Get().Register(std::static_pointer_cast<CContextMenuAddon>(localAddon));
 
   addon->OnPostInstall(update, modal);
 }
@@ -698,7 +698,7 @@ void OnPreUnInstall(const AddonPtr& addon)
     std::static_pointer_cast<CService>(localAddon)->Stop();
 
   if (CAddonMgr::Get().GetAddon(addon->ID(), localAddon, ADDON_CONTEXT_ITEM))
-    CContextMenuManager::Get().Unregister(std::static_pointer_cast<CContextItemAddon>(localAddon));
+    CContextMenuManager::Get().Unregister(std::static_pointer_cast<CContextMenuAddon>(localAddon));
 
   addon->OnPreUnInstall();
 }

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -53,7 +53,7 @@
 #include "Repository.h"
 #include "Skin.h"
 #include "Service.h"
-#include "ContextItemAddon.h"
+#include "ContextMenuAddon.h"
 #include "Util.h"
 #include "addons/Webinterface.h"
 
@@ -193,7 +193,7 @@ AddonPtr CAddonMgr::Factory(const cp_extension_t *props)
     case ADDON_REPOSITORY:
       return AddonPtr(new CRepository(props));
     case ADDON_CONTEXT_ITEM:
-      return AddonPtr(new CContextItemAddon(props));
+      return AddonPtr(new CContextMenuAddon(props));
     default:
       break;
   }
@@ -871,7 +871,7 @@ AddonPtr CAddonMgr::AddonFromProps(AddonProps& addonProps)
     case ADDON_REPOSITORY:
       return AddonPtr(new CRepository(addonProps));
     case ADDON_CONTEXT_ITEM:
-      return AddonPtr(new CContextItemAddon(addonProps));
+      return AddonPtr(new CContextMenuAddon(addonProps));
     default:
       break;
   }

--- a/xbmc/addons/ContextItemAddon.h
+++ b/xbmc/addons/ContextItemAddon.h
@@ -23,14 +23,9 @@
 #include <memory>
 #include "Addon.h"
 
-class CFileItem;
-typedef std::shared_ptr<CFileItem> CFileItemPtr;
+class CContextMenuItem;
+typedef struct cp_cfg_element_t cp_cfg_element_t;
 
-namespace INFO
-{
-  class InfoBool;
-  typedef std::shared_ptr<InfoBool> InfoPtr;
-}
 
 namespace ADDON
 {
@@ -41,25 +36,11 @@ namespace ADDON
     CContextItemAddon(const AddonProps &props);
     virtual ~CContextItemAddon();
 
-    std::string GetLabel();
-
-    /*!
-     * \brief Get the parent category of this context item.
-     *
-     * \details Returns empty string if at root level or
-     * CONTEXT_MENU_GROUP_MANAGE when it should be in the 'manage' submenu.
-     */
-    const std::string& GetParent() const { return m_parent; }
-
-    /*!
-     * \brief Returns true if this contex menu should be visible for given item.
-     */
-    bool IsVisible(const CFileItemPtr& item) const;
+    std::vector<CContextMenuItem> GetItems();
 
   private:
-    std::string m_label;
-    std::string m_parent;
-    INFO::InfoPtr m_visCondition;
+    void ParseMenu(cp_cfg_element_t* elem, const std::string& parent, int& anonGroupCount);
+    std::vector<CContextMenuItem> m_items;
   };
 
   typedef std::shared_ptr<CContextItemAddon> ContextItemAddonPtr;

--- a/xbmc/addons/ContextMenuAddon.cpp
+++ b/xbmc/addons/ContextMenuAddon.cpp
@@ -18,7 +18,7 @@
  *
  */
 
-#include "ContextItemAddon.h"
+#include "ContextMenuAddon.h"
 #include "AddonManager.h"
 #include "ContextMenuManager.h"
 #include "ContextMenuItem.h"
@@ -32,14 +32,14 @@
 namespace ADDON
 {
 
-CContextItemAddon::CContextItemAddon(const AddonProps &props)
+CContextMenuAddon::CContextMenuAddon(const AddonProps &props)
   : CAddon(props)
 { }
 
-CContextItemAddon::~CContextItemAddon()
+CContextMenuAddon::~CContextMenuAddon()
 { }
 
-CContextItemAddon::CContextItemAddon(const cp_extension_t *ext)
+CContextMenuAddon::CContextMenuAddon(const cp_extension_t *ext)
   : CAddon(ext)
 {
   cp_cfg_element_t* menu = CAddonMgr::Get().GetExtElement(ext->configuration, "menu");
@@ -74,7 +74,7 @@ CContextItemAddon::CContextItemAddon(const cp_extension_t *ext)
   }
 }
 
-void CContextItemAddon::ParseMenu(cp_cfg_element_t* elem, const std::string& parent, int& anonGroupCount)
+void CContextMenuAddon::ParseMenu(cp_cfg_element_t* elem, const std::string& parent, int& anonGroupCount)
 {
   auto menuLabel = CAddonMgr::Get().GetExtValue(elem, "label");
   auto menuId = CAddonMgr::Get().GetExtValue(elem, "@id");
@@ -117,7 +117,7 @@ void CContextItemAddon::ParseMenu(cp_cfg_element_t* elem, const std::string& par
   }
 }
 
-std::vector<CContextMenuItem> CContextItemAddon::GetItems()
+std::vector<CContextMenuItem> CContextMenuAddon::GetItems()
 {
   //Return a copy which owns `this`
   std::vector<CContextMenuItem> ret = m_items;

--- a/xbmc/addons/ContextMenuAddon.h
+++ b/xbmc/addons/ContextMenuAddon.h
@@ -29,12 +29,12 @@ typedef struct cp_cfg_element_t cp_cfg_element_t;
 
 namespace ADDON
 {
-  class CContextItemAddon : public CAddon
+  class CContextMenuAddon : public CAddon
   {
   public:
-    CContextItemAddon(const cp_extension_t *ext);
-    CContextItemAddon(const AddonProps &props);
-    virtual ~CContextItemAddon();
+    CContextMenuAddon(const cp_extension_t *ext);
+    CContextMenuAddon(const AddonProps &props);
+    virtual ~CContextMenuAddon();
 
     std::vector<CContextMenuItem> GetItems();
 
@@ -43,5 +43,5 @@ namespace ADDON
     std::vector<CContextMenuItem> m_items;
   };
 
-  typedef std::shared_ptr<CContextItemAddon> ContextItemAddonPtr;
+  typedef std::shared_ptr<CContextMenuAddon> ContextItemAddonPtr;
 }

--- a/xbmc/addons/Makefile
+++ b/xbmc/addons/Makefile
@@ -11,7 +11,7 @@ SRCS=Addon.cpp \
      AddonStatusHandler.cpp \
      AddonVersion.cpp \
      AudioEncoder.cpp \
-     ContextItemAddon.cpp \
+     ContextMenuAddon.cpp \
      AudioDecoder.cpp \
      GUIDialogAddonInfo.cpp \
      GUIDialogAddonSettings.cpp \

--- a/xbmc/dialogs/GUIDialogFavourites.cpp
+++ b/xbmc/dialogs/GUIDialogFavourites.cpp
@@ -151,7 +151,7 @@ void CGUIDialogFavourites::OnPopupMenu(int item)
   else if (button == 5)
     OnSetThumb(item);
   else if (button >= CONTEXT_BUTTON_FIRST_ADDON)
-    CContextMenuManager::Get().Execute(button, itemPtr);
+    CContextMenuManager::Get().OnClick(button, itemPtr);
 }
 
 void CGUIDialogFavourites::OnMoveItem(int item, int amount)

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -1070,7 +1070,7 @@ int CGUIDialogVideoInfo::ManageVideoItem(const CFileItemPtr &item)
         break;
 
       default:
-        result = CContextMenuManager::Get().Execute(button, item);
+        result = CContextMenuManager::Get().OnClick(button, item);
         break;
     }
   }

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -1006,7 +1006,7 @@ int CGUIDialogVideoInfo::ManageVideoItem(const CFileItemPtr &item)
 
   buttons.Add(CONTEXT_BUTTON_DELETE, 646);
 
-  CContextMenuManager::Get().AddVisibleItems(item, buttons, CONTEXT_MENU_GROUP_MANAGE);
+  CContextMenuManager::Get().AddVisibleItems(item, buttons, CContextMenuManager::MANAGE);
 
   bool result = false;
   int button = CGUIDialogContextMenu::ShowAndGetChoice(buttons);

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -1617,7 +1617,7 @@ bool CGUIMediaWindow::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
     break;
   }
   if (button >= CONTEXT_BUTTON_FIRST_ADDON)
-    return CContextMenuManager::Get().Execute(button, m_vecItems->Get(itemNumber));
+    return CContextMenuManager::Get().OnClick(button, m_vecItems->Get(itemNumber));
   return false;
 }
 

--- a/xbmc/windows/GUIWindowLoginScreen.cpp
+++ b/xbmc/windows/GUIWindowLoginScreen.cpp
@@ -257,7 +257,7 @@ bool CGUIWindowLoginScreen::OnPopupMenu(int iItem)
     m_vecItems->Get(iItem)->Select(bSelect);
 
   if (choice >= CONTEXT_BUTTON_FIRST_ADDON)
-    return CContextMenuManager::Get().Execute(choice, pItem);
+    return CContextMenuManager::Get().OnClick(choice, pItem);
   return false;
 }
 


### PR DESCRIPTION
This extends the context menu functionality as discussed in the original PR, by allowing addons to:
1. Add multiple items with the same addon.
2. Add sub-menus, and arbitrary nested sub-menus and items.
3. Allow addons to hook into different core menus, and menus of other addons.

This deprecates the old xml definition. In the new scheme, definition must start with a `<menu id="menu-id">` element which defines menu the following elements should be added to. Addons using the old `<item>` can be ported by wrapping it in a `<menu id="kodi.core.main">` and moving the `library` attribute to the `<item>` element.

The new preferred way of adding a single top-level menu item is as follows: 

``` xml
<menu id="kodi.core.main">
  <item library="contextitem.py">
    <label>30000</label>
    <visible>true</visible>
  </item>
</menu>
```

Furthermore, menus may contain multiple nested menus an items. Example: creating a sub-menu with two items:

``` xml
<menu id="kodi.core.main">
  <menu>
    <label>Sub-menu</label>
    <item library="contextitem1.py">
      <label>Item 1</label>
      <visible>true</visible>
    </item>
    <item library="contextitem2.py">
      <label>Item 2</label>
      <visible>true</visible>
    </item>
</menu>
```

Similar to the two core menus `kodi.core.main` and `kodi.core.manage`, menus may be shared or conditionally extend by other addons. For example, if two addons defines

``` xml
<menu id="kodi.core.main">
  <menu id="context.menu.shared">
    <label>Shared</label>
    <item ...>...</item>
</menu>
```

using the same id, the two items will show in the same shared sub-menu.

TODO: VS/xcode files
