### PR TITLE
[addonbrowser] add 'look and feel' category

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -13866,7 +13866,10 @@ msgctxt "#24996"
 msgid "Dependencies"
 msgstr ""
 
-#empty string with id 24997
+#: xbmc/filesystem/AddonsDirectory.cpp
+msgctxt "#24997"
+msgid "Look and feel"
+msgstr ""
 
 #: xbmc/addons/CGUIViewStateAddonBrowser.cpp
 #: xbmc/filesystem/AddonsDirectory.cpp


### PR DESCRIPTION
It's getting crowded again, so this puts skins, GUI sounds, image collections, languages, screensavers and visualizations in a 'Look and Feel' category (feel free to bikeshed about the name) as I believe originally suggested by @da-anda.
