### PR TITLE
changed: For memory cache don't create a bigger cache than filesize

### DIFF
--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFile.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFile.cpp
@@ -53,6 +53,10 @@ bool CDVDInputStreamFile::Open(const char* strFile, const std::string& content, 
     return false;
 
   unsigned int flags = READ_TRUNCATED | READ_BITRATE | READ_CHUNKED;
+  
+  // If this file is audio and/or video (= not a subtitle) flag to caller
+  if (!CFileItem(strFile).IsSubtitle())
+    flags |= READ_AUDIO_VIDEO;
 
   /*
    * There are 4 buffer modes available (configurable in as.xml)

--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -244,7 +244,7 @@ bool CFile::Open(const CURL& file, const unsigned int flags)
       if (m_flags & READ_CACHED)
       {
         // for internet stream, if it contains multiple stream, file cache need handle it specially.
-        m_pFile = new CFileCache((m_flags & READ_MULTI_STREAM) == READ_MULTI_STREAM);
+        m_pFile = new CFileCache(m_flags);
         return m_pFile->Open(url);
       }
     }

--- a/xbmc/filesystem/File.h
+++ b/xbmc/filesystem/File.h
@@ -53,22 +53,25 @@ public:
 };
 
 /* indicate that caller can handle truncated reads, where function returns before entire buffer has been filled */
-#define READ_TRUNCATED 0x01
+#define READ_TRUNCATED    0x01
 
 /* indicate that that caller support read in the minimum defined chunk size, this disables internal cache then */
-#define READ_CHUNKED   0x02
+#define READ_CHUNKED      0x02
 
 /* use cache to access this file */
-#define READ_CACHED     0x04
+#define READ_CACHED       0x04
 
 /* open without caching. regardless to file type. */
-#define READ_NO_CACHE  0x08
+#define READ_NO_CACHE     0x08
 
 /* calcuate bitrate for file while reading */
-#define READ_BITRATE   0x10
+#define READ_BITRATE      0x10
 
-/* indicate the caller will seek between multiple streams in the file frequently */
+/* indicate to the caller we will seek between multiple streams in the file frequently */
 #define READ_MULTI_STREAM 0x20
+
+/* indicate to the caller file is audio and/or video (and e.g. may grow) */
+#define READ_AUDIO_VIDEO  0x40
 
 class CFileStreamBuffer;
 

--- a/xbmc/filesystem/FileCache.cpp
+++ b/xbmc/filesystem/FileCache.cpp
@@ -97,40 +97,25 @@ private:
 };
 
 
-CFileCache::CFileCache(bool useDoubleCache)
+CFileCache::CFileCache(const unsigned int flags)
   : CThread("FileCache")
+  , m_pCache(NULL)
+  , m_bDeleteCache(true)
   , m_seekPossible(0)
+  , m_nSeekResult(0)
+  , m_seekPos(0)
+  , m_readPos(0)
+  , m_writePos(0)
   , m_chunkSize(0)
   , m_writeRate(0)
   , m_writeRateActual(0)
   , m_cacheFull(false)
   , m_fileSize(0)
+  , m_flags(flags)
 {
-   m_bDeleteCache = true;
-   m_nSeekResult = 0;
-   m_seekPos = 0;
-   m_readPos = 0;
-   m_writePos = 0;
-   if (g_advancedSettings.m_cacheMemBufferSize == 0)
-     m_pCache = new CSimpleFileCache();
-   else
-   {
-     size_t front = g_advancedSettings.m_cacheMemBufferSize;
-     size_t back = std::max<size_t>( g_advancedSettings.m_cacheMemBufferSize / 4, 1024 * 1024);
-     if (useDoubleCache)
-     {
-       front = front / 2;
-       back = back / 2;
-     }
-     m_pCache = new CCircularCache(front, back);
-   }
-   if (useDoubleCache)
-   {
-     m_pCache = new CDoubleCache(m_pCache);
-   }
 }
 
-CFileCache::CFileCache(CCacheStrategy *pCache, bool bDeleteCache)
+CFileCache::CFileCache(CCacheStrategy *pCache, bool bDeleteCache /* = true */)
   : CThread("FileCacheStrategy")
   , m_seekPossible(0)
   , m_chunkSize(0)
@@ -156,7 +141,7 @@ CFileCache::~CFileCache()
   m_pCache = NULL;
 }
 
-void CFileCache::SetCacheStrategy(CCacheStrategy *pCache, bool bDeleteCache)
+void CFileCache::SetCacheStrategy(CCacheStrategy *pCache, bool bDeleteCache /* = true */)
 {
   if (m_bDeleteCache && m_pCache)
     delete m_pCache;
@@ -178,21 +163,7 @@ bool CFileCache::Open(const CURL& url)
 
   CLog::Log(LOGDEBUG,"CFileCache::Open - opening <%s> using cache", url.GetFileName().c_str());
 
-  if (!m_pCache)
-  {
-    CLog::Log(LOGERROR,"CFileCache::Open - no cache strategy defined");
-    return false;
-  }
-
   m_sourcePath = url.Get();
-
-  // open cache strategy
-  if (m_pCache->Open() != CACHE_RC_OK)
-  {
-    CLog::Log(LOGERROR,"CFileCache::Open - failed to open cache");
-    Close();
-    return false;
-  }
 
   // opening the source file.
   if (!m_source.Open(m_sourcePath, READ_NO_CACHE | READ_TRUNCATED | READ_CHUNKED))
@@ -209,6 +180,53 @@ bool CFileCache::Open(const CURL& url)
   m_chunkSize = CFile::GetChunkSize(m_source.GetChunkSize(), READ_CACHE_CHUNK_SIZE);
   m_fileSize = m_source.GetLength();
 
+  if (!m_pCache)
+  {
+    if (g_advancedSettings.m_cacheMemBufferSize == 0)
+    {
+      // Use cache on disk
+      m_pCache = new CSimpleFileCache();
+    }
+    else
+    {
+      size_t cacheSize;
+      if (m_fileSize > 0 && m_fileSize < g_advancedSettings.m_cacheMemBufferSize && !(m_flags & READ_AUDIO_VIDEO))
+      {
+        // NOTE: We don't need to take into account READ_MULTI_STREAM here as it's only used for audio/video
+        cacheSize = m_fileSize;
+      }
+      else
+      {
+        cacheSize = g_advancedSettings.m_cacheMemBufferSize;
+      }
+
+      size_t back = cacheSize / 4;
+      size_t front = cacheSize - back;
+      
+      if (m_flags & READ_MULTI_STREAM)
+      {
+        // READ_MULTI_STREAM requires double buffering, so use half the amount of memory for each buffer
+        front /= 2;
+        back /= 2;
+      }
+      m_pCache = new CCircularCache(front, back);
+    }
+
+    if (m_flags & READ_MULTI_STREAM)
+    {
+      // If READ_MULTI_STREAM flag is set: Double buffering is required
+      m_pCache = new CDoubleCache(m_pCache);
+    }
+  }
+
+  // open cache strategy
+  if (!m_pCache || m_pCache->Open() != CACHE_RC_OK)
+  {
+    CLog::Log(LOGERROR,"CFileCache::Open - failed to open cache");
+    Close();
+    return false;
+  }
+  
   m_readPos = 0;
   m_writePos = 0;
   m_writeRate = 1024 * 1024;

--- a/xbmc/filesystem/FileCache.h
+++ b/xbmc/filesystem/FileCache.h
@@ -32,11 +32,11 @@ namespace XFILE
   class CFileCache : public IFile, public CThread
   {
   public:
-    CFileCache(bool useDoubleCache=false);
-    CFileCache(CCacheStrategy *pCache, bool bDeleteCache=true);
+    CFileCache(const unsigned int flags);
+    CFileCache(CCacheStrategy *pCache, bool bDeleteCache = true);
     virtual ~CFileCache();
 
-    void SetCacheStrategy(CCacheStrategy *pCache, bool bDeleteCache=true);
+    void SetCacheStrategy(CCacheStrategy *pCache, bool bDeleteCache = true);
 
     // CThread methods
     virtual void Process();
@@ -79,6 +79,7 @@ namespace XFILE
     unsigned     m_writeRateActual;
     bool         m_cacheFull;
     std::atomic<int64_t> m_fileSize;
+    unsigned int m_flags;
     CCriticalSection m_sync;
   };
 


### PR DESCRIPTION
Previously we would always create a fullsized (=10MB by default) for every cached file, even for files of a few KB. This PR limits the created cachesize to the filesize (if known and only if not audio/video as they may grow). Furthermore I've slightly improved (and simplified) the calculation of the front and back buffer.
