### PR TITLE
dvdplayer: fix mimetype after 89538103d60f64106f8ad998427c7286a3766244

### DIFF
--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDFactoryInputStream.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDFactoryInputStream.cpp
@@ -105,7 +105,11 @@ CDVDInputStream* CDVDFactoryInputStream::CreateInputStream(IDVDPlayer* pPlayer, 
       return new CDVDInputStreamFFmpeg();
 
     if (contentlookup)
+    {
+      // request header
+      item.SetMimeType("");
       item.FillInMimeType();
+    }
 
     if (item.GetMimeType() == "application/vnd.apple.mpegurl")
       return new CDVDInputStreamFFmpeg();


### PR DESCRIPTION
force lookup if not explicitly suppressed.
