### PR TITLE
[dllloader] Fix logging of dlls without absolute path

### DIFF
--- a/xbmc/cores/DllLoader/LibraryLoader.cpp
+++ b/xbmc/cores/DllLoader/LibraryLoader.cpp
@@ -42,7 +42,7 @@ const char *LibraryLoader::GetName() const
   size_t pos = m_fileName.find_last_of('/');
   if (pos != std::string::npos)
     return &m_fileName.at(pos);
-  return "";
+  return m_fileName.c_str();
 }
 
 const char *LibraryLoader::GetFileName() const


### PR DESCRIPTION
There was a bug introduced in cac60cd9 where a filename without a slash is not printed at all.
The previous code would just return the filename.

It causes log to show 'DEBUG: Unloading:' rather than 'DEBUG: Unloading: libnfs.so.4'.
