### PR TITLE
[guilib] fix hint text not shown in keyboard dialog

### DIFF
--- a/xbmc/guilib/GUIEditControl.cpp
+++ b/xbmc/guilib/GUIEditControl.cpp
@@ -486,16 +486,16 @@ void CGUIEditControl::ProcessText(unsigned int currentTime)
     changed |= m_label2.SetMaxRect(m_clipRect.x1 + m_textOffset, m_posY, m_clipRect.Width() - m_textOffset, m_height);
 
     std::wstring text = GetDisplayedText();
+    std::string hint = m_hintInfo.GetLabel(GetParentID());
 
-    if ((HasFocus() || GetParentID() == WINDOW_DIALOG_KEYBOARD) && m_inputType != INPUT_TYPE_READONLY)
+    if (!HasFocus() && text.empty() && !hint.empty())
+    {
+      changed |= m_label2.SetText(hint);
+    }
+    else if ((HasFocus() || GetParentID() == WINDOW_DIALOG_KEYBOARD) &&
+             m_inputType != INPUT_TYPE_READONLY)
     {
       changed |= SetStyledText(text);
-    }
-    else if (!HasFocus() && text.empty())
-    {
-      std::string hint = m_hintInfo.GetLabel(GetParentID());
-      if (!hint.empty())
-        changed |= m_label2.SetText(hint);
     }
     else
       changed |= m_label2.SetTextW(text);


### PR DESCRIPTION
@MilhouseVH @MartijnKaijser could someone please test if the hint text is shown in the keyboard dialog. In Confluence add `<hinttext>Enter something</hinttext>` to the edit control at https://github.com/xbmc/xbmc/blob/master/addons/skin.confluence/720p/DialogKeyboard.xml#L31
