### PR TITLE
Bypass active AudioDSP-System

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -1167,7 +1167,8 @@ void CActiveAE::Configure(AEAudioFormat *desiredFmt)
 
         (*it)->m_resampleBuffers = new CActiveAEBufferPoolResample((*it)->m_inputBuffers->m_format, outputFormat, m_settings.resampleQuality);
         (*it)->m_resampleBuffers->m_forceResampler = (*it)->m_forceResampler;
-        if (useDSP)
+        (*it)->m_resampleBuffers->m_bypassDSP = (*it)->m_bypassDSP;
+        if (useDSP && !(*it)->m_resampleBuffers->m_bypassDSP)
           (*it)->m_resampleBuffers->SetExtraData((*it)->m_profile, (*it)->m_matrixEncoding, (*it)->m_audioServiceType);
         (*it)->m_resampleBuffers->Create(MAX_CACHE_LEVEL*1000, false, m_settings.stereoupmix, m_settings.normalizelevels, useDSP);
 
@@ -1288,6 +1289,11 @@ CActiveAEStream* CActiveAE::CreateStream(MsgStreamNew *streamMsg)
 
   if (streamMsg->options & AESTREAM_FORCE_RESAMPLE)
     stream->m_forceResampler = true;
+
+  if(streamMsg->options & AESTREAM_BYPASS_ADSP)
+  {
+    stream->m_bypassDSP = true;
+  }
 
   m_streams.push_back(stream);
 

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
@@ -157,6 +157,7 @@ CActiveAEBufferPoolResample::CActiveAEBufferPoolResample(AEAudioFormat inputForm
   m_normalize = true;
   m_useResampler = false;
   m_useDSP = false;
+  m_bypassDSP = false;
   m_changeResampler = false;
   m_changeDSP = false;
 }
@@ -201,7 +202,7 @@ bool CActiveAEBufferPoolResample::Create(unsigned int totaltime, bool remap, boo
    * The value m_streamId and address pointer m_processor are passed a pointers
    * to CActiveAEDSP::Get().CreateDSPs and set from it.
    */
-  if (useDSP || m_changeDSP)
+  if ((useDSP || m_changeDSP) && !m_bypassDSP)
   {
     m_dspFormat = m_inputFormat;
     m_useDSP = CActiveAEDSP::Get().CreateDSPs(m_streamId, m_processor, m_dspFormat, m_format, upmix, m_resampleQuality, m_MatrixEncoding, m_AudioServiceType, m_Profile);

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.h
@@ -118,6 +118,7 @@ public:
   bool m_empty;
   bool m_useResampler;
   bool m_useDSP;
+  bool m_bypassDSP;
   bool m_changeResampler;
   bool m_forceResampler;
   bool m_changeDSP;

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
@@ -53,6 +53,7 @@ CActiveAEStream::CActiveAEStream(AEAudioFormat *format)
   m_streamFreeBuffers = 0;
   m_streamIsBuffering = false;
   m_streamIsFlushed = false;
+  m_bypassDSP = false;
   m_streamSlave = NULL;
   m_leftoverBuffer = new uint8_t[m_format.m_frameSize];
   m_leftoverBytes = 0;

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.h
@@ -95,6 +95,7 @@ protected:
   int m_streamFreeBuffers;
   bool m_streamIsBuffering;
   bool m_streamIsFlushed;
+  bool m_bypassDSP;
   IAEStream *m_streamSlave;
   CCriticalSection m_streamLock;
   uint8_t *m_leftoverBuffer;

--- a/xbmc/cores/AudioEngine/Interfaces/AEStream.h
+++ b/xbmc/cores/AudioEngine/Interfaces/AEStream.h
@@ -34,7 +34,8 @@ enum AEStreamOptions
 {
   AESTREAM_FORCE_RESAMPLE = 0x01, /* force resample even if rates match */
   AESTREAM_PAUSED         = 0x02, /* create the stream paused */
-  AESTREAM_AUTOSTART      = 0x04  /* autostart the stream when enough data is buffered */
+  AESTREAM_AUTOSTART      = 0x04, /* autostart the stream when enough data is buffered */
+  AESTREAM_BYPASS_ADSP    = 0x08  /* if this option is set the ADSP-System is bypassed and raw stream will be passed through IAESink */
 };
 
 /**


### PR DESCRIPTION
This PR adds a option to MakeStream(...), which allows to bypass the active AudioDSP system. E.g. this can be used to send out unprocessed audio streams. I it with my adsp.xconvolver addon to send out the the test signals for measuring a room impulse response.

If you want @FernetMenta or @fritsch you can review it.
