### PR TITLE
dvdplayer: flush renderbuffers when flushing video player

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
@@ -435,6 +435,8 @@ void CDVDPlayerVideo::Process()
 
       m_stalled = true;
       m_started = false;
+
+      g_renderManager.DiscardBuffer();
     }
     else if (pMsg->IsType(CDVDMsg::VIDEO_NOSKIP))
     {


### PR DESCRIPTION
fixes long picture freeze (up to 10 sec) when switching from ff to play
