### PR TITLE
[win32] cmake: no need to check for install permissions (avoid creating unneeded directories)

### DIFF
--- a/project/cmake/addons/CMakeLists.txt
+++ b/project/cmake/addons/CMakeLists.txt
@@ -121,13 +121,15 @@ endif()
 # include check_target_platform() function
 include(${APP_ROOT}/project/cmake/scripts/common/check_target_platform.cmake)
 
-# check install permissions
 set(ADDON_INSTALL_DIR ${CMAKE_INSTALL_PREFIX})
-check_install_permissions(${CMAKE_INSTALL_PREFIX} can_write)
-if(NOT ${can_write} AND CMAKE_SYSTEM_NAME STREQUAL "Linux")
-  set(NEED_SUDO TRUE)
-  set(ADDON_INSTALL_DIR ${CMAKE_BINARY_DIR}/.install)
-  message(STATUS "NEED_SUDO: ${NEED_SUDO}")
+if(NOT WIN32)
+  # check install permissions
+  check_install_permissions(${CMAKE_INSTALL_PREFIX} can_write)
+  if(NOT ${can_write} AND CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    set(NEED_SUDO TRUE)
+    set(ADDON_INSTALL_DIR ${CMAKE_BINARY_DIR}/.install)
+    message(STATUS "NEED_SUDO: ${NEED_SUDO}")
+  endif()
 endif()
 
 ### prepare the build environment for the binary addons


### PR DESCRIPTION
This cleans up an issue on Windows introduced by 98bf72d090d374a0b164e73c18aec7e5d06f7f0f which added a check to see if cmake has the rights to write into the installation directory. On Windows this doesn't make any sense and results in creating directories in the installation directory which either end up in the installer (but they aren't installed) or in the `addons` directory during development resulting in some warning logs about addon directories without an `addon.xml`.
