### PR TITLE
[AudioDSP] Fix audio offset dialog slider popup has no label

### DIFF
--- a/xbmc/settings/dialogs/GUIDialogAudioDSPSettings.cpp
+++ b/xbmc/settings/dialogs/GUIDialogAudioDSPSettings.cpp
@@ -628,7 +628,7 @@ void CGUIDialogAudioDSPSettings::InitializeSettings()
     // audio delay setting
     if (SupportsAudioFeature(IPC_AUD_OFFSET))
     {
-      CSettingNumber *settingAudioDelay = AddSlider(groupInternal, SETTING_AUDIO_POST_PROC_AUDIO_DELAY, 297, 0, videoSettings.m_AudioDelay, 0, -g_advancedSettings.m_videoAudioDelayRange, 0.025f, g_advancedSettings.m_videoAudioDelayRange, -1, usePopup);
+      CSettingNumber *settingAudioDelay = AddSlider(groupInternal, SETTING_AUDIO_POST_PROC_AUDIO_DELAY, 297, 0, videoSettings.m_AudioDelay, 0, -g_advancedSettings.m_videoAudioDelayRange, 0.025f, g_advancedSettings.m_videoAudioDelayRange, 297, usePopup);
       static_cast<CSettingControlSlider*>(settingAudioDelay->GetControl())->SetFormatter(SettingFormatterDelay);
     }
     GetAudioDSPMenus(groupAddon, AE_DSP_MENUHOOK_POST_PROCESS);


### PR DESCRIPTION
@AchimTuran this fixes **issue 9** on http://forum.kodi.tv/showthread.php?tid=232628&pid=2057912#pid2057912

![screenshot022](https://cloud.githubusercontent.com/assets/3521959/8795712/15488a34-2f87-11e5-8e90-8a9c1a28517b.png)
Before
![screenshot021](https://cloud.githubusercontent.com/assets/3521959/8795744/676696e4-2f87-11e5-8daa-70cf8268d9e3.png)

After
![screenshot024](https://cloud.githubusercontent.com/assets/3521959/8795702/02a8c768-2f87-11e5-9ec1-1940864501e6.png)

The code for these dialogs seems to be almost duplicate of https://github.com/xbmc/xbmc/blob/ea251fd74bec3bbc7518da7517434028dabc739b/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp#L317-L321

No idea why this wasn't simply reused or extended I only mention it because Ide like to understand why it was done for subtitles delay also.

@mkortstiege @MartijnKaijser it works now.
