### PR TITLE
[guilib] fix modality handling of dialog slider (fixes #16140)

### DIFF
--- a/xbmc/dialogs/GUIDialogSlider.cpp
+++ b/xbmc/dialogs/GUIDialogSlider.cpp
@@ -101,6 +101,11 @@ void CGUIDialogSlider::OnWindowLoaded()
   CGUIDialog::OnWindowLoaded();
 }
 
+void CGUIDialogSlider::SetModalityType(DialogModalityType type)
+{
+  m_modalityType = type;
+}
+
 void CGUIDialogSlider::ShowAndGetInput(const std::string &label, float value, float min, float delta, float max, ISliderCallback *callback, void *callbackData)
 {
   // grab the slider dialog
@@ -111,6 +116,7 @@ void CGUIDialogSlider::ShowAndGetInput(const std::string &label, float value, fl
   // set the label and value
   slider->Initialize();
   slider->SetSlider(label, value, min, delta, max, callback, callbackData);
+  slider->SetModalityType(DialogModalityType::MODAL);
   slider->Open();
 }
 
@@ -125,5 +131,6 @@ void CGUIDialogSlider::Display(int label, float value, float min, float delta, f
   slider->Initialize();
   slider->SetAutoClose(1000);
   slider->SetSlider(g_localizeStrings.Get(label), value, min, delta, max, callback, NULL);
+  slider->SetModalityType(DialogModalityType::MODELESS);
   slider->Open();
 }

--- a/xbmc/dialogs/GUIDialogSlider.h
+++ b/xbmc/dialogs/GUIDialogSlider.h
@@ -31,6 +31,8 @@ public:
   virtual bool OnMessage(CGUIMessage& message);
   virtual bool OnAction(const CAction &action);
 
+  void SetModalityType(DialogModalityType type);
+
   /*! \brief Show the slider dialog and wait for the user to change the value
    Shows the slider until the user is happy with the adjusted value.  Calls back with each change to the callback function
    allowing changes to take place immediately.


### PR DESCRIPTION
As reported at http://trac.kodi.tv/ticket/16140 the slider dialog does not work if it's used as overlay. This happens because we only support one modality type per dialog and the slider dialog is the only one which breaks this rule and is used as modal and overlay at the same time. 

This PR will fix the issue by setting the modality type at runtime depending on the use-case.

@uNiversaI it would be nice if you could confirm that it works
@mkortstiege mind taking a look
