### PR TITLE
[settings] Fix broken network.bandwidth setting

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2885,7 +2885,7 @@
             <step>512</step>
             <maximum>102400</maximum>
           </constraints>
-          <control type="list" format="string">
+          <control type="spinner" format="string">
             <formatlabel>14048</formatlabel>
           </control>
         </setting>


### PR DESCRIPTION
ac556de2 made the 'Internet connection bandwidth limitation' setting be disabled as lists don't
support steps. Revert that part of change
