### PR TITLE
dvdplayer: fix clockspeed adjust for non-resampling modes

### DIFF
--- a/xbmc/cores/dvdplayer/DVDClock.cpp
+++ b/xbmc/cores/dvdplayer/DVDClock.cpp
@@ -169,7 +169,16 @@ bool CDVDClock::Update(double clock, double absolute, double limit, const char* 
   double was_absolute = SystemToAbsolute(m_startClock);
   double was_clock    = m_iDisc + absolute - was_absolute;
   lock.Leave();
-  if(std::abs(clock - was_clock) > limit)
+
+  double error = std::abs(clock - was_clock);
+
+  // skip minor updates while speed adjust is active
+  // -> adjusting buffer levels
+  if (m_speedAdjust != 0 && error < DVD_MSEC_TO_TIME(100))
+  {
+    return false;
+  }
+  else if (error > limit)
   {
     Discontinuity(clock, absolute);
 

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -1787,12 +1787,8 @@ void CDVDPlayer::HandlePlaySpeed()
         double adjust = -1.0; // a unique value
         if (m_clock.GetSpeedAdjust() == 0.0 && m_dvdPlayerAudio->GetLevel() < 5)
           adjust = -0.01;
-        else if (m_clock.GetSpeedAdjust() == 0.0 && m_dvdPlayerAudio->GetLevel() > 95)
-          adjust = 0.01;
 
         if (m_clock.GetSpeedAdjust() < 0 && m_dvdPlayerAudio->GetLevel() > 20)
-          adjust = 0.0;
-        else if (m_clock.GetSpeedAdjust() > 0 && m_dvdPlayerAudio->GetLevel() < 80)
           adjust = 0.0;
 
         if (adjust != -1.0)


### PR DESCRIPTION
fix audio drop-outs for pvr streams when buffer levels run low and resampling is not active
