### PR TITLE
[video] use action listener pattern for CPlayerController

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1249,6 +1249,7 @@ bool CApplication::Initialize()
 
   // register action listeners
   RegisterActionListener(&CSeekHandler::Get());
+  RegisterActionListener(&CPlayerController::Get());
 
   CLog::Log(LOGNOTICE, "initialize done");
 
@@ -2401,9 +2402,6 @@ bool CApplication::OnAction(const CAction &action)
       if (m_pPlayer->CanRecord())
         m_pPlayer->Record(!m_pPlayer->IsRecording());
     }
-
-    if (CPlayerController::Get().OnAction(action))
-      return true;
   }
 
 
@@ -3021,6 +3019,7 @@ void CApplication::Stop(int exitCode)
 
     // unregister action listeners
     UnregisterActionListener(&CSeekHandler::Get());
+    UnregisterActionListener(&CPlayerController::Get());
 
     // stop all remaining scripts; must be done after skin has been unloaded,
     // not before some windows still need it when deinitializing during skin

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -263,7 +263,6 @@ CApplication::CApplication(void)
   , m_progressTrackingVideoResumeBookmark(*new CBookmark)
   , m_progressTrackingItem(new CFileItem)
   , m_musicInfoScanner(new CMusicInfoScanner)
-  , m_playerController(new CPlayerController)
   , m_fallbackLanguageLoaded(false)
 {
   m_network = NULL;
@@ -332,7 +331,6 @@ CApplication::~CApplication(void)
 #endif
 
   delete m_dpms;
-  delete m_playerController;
   delete m_pInertialScrollingHandler;
   delete m_pPlayer;
 
@@ -2404,7 +2402,7 @@ bool CApplication::OnAction(const CAction &action)
         m_pPlayer->Record(!m_pPlayer->IsRecording());
     }
 
-    if (m_playerController->OnAction(action))
+    if (CPlayerController::Get().OnAction(action))
       return true;
   }
 

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -48,7 +48,6 @@ namespace MEDIA_DETECT
 {
   class CAutorun;
 }
-class CPlayerController;
 
 #include "cores/IPlayerCallback.h"
 #include "cores/playercorefactory/PlayerCoreFactory.h"
@@ -501,7 +500,6 @@ protected:
   bool InitDirectoriesWin32();
   void CreateUserDirs();
 
-  CPlayerController *m_playerController;
   CInertialScrollingHandler *m_pInertialScrollingHandler;
   CNetwork    *m_network;
 #ifdef HAS_PERFORMANCE_SAMPLE

--- a/xbmc/video/PlayerController.cpp
+++ b/xbmc/video/PlayerController.cpp
@@ -38,12 +38,18 @@
 #include "utils/StringUtils.h"
 
 CPlayerController::CPlayerController()
+  : m_sliderAction(0)
 {
-  m_sliderAction = 0;
 }
 
 CPlayerController::~CPlayerController()
 {
+}
+
+CPlayerController& CPlayerController::Get()
+{
+  static CPlayerController instance;
+  return instance;
 }
 
 bool CPlayerController::OnAction(const CAction &action)

--- a/xbmc/video/PlayerController.h
+++ b/xbmc/video/PlayerController.h
@@ -32,8 +32,7 @@
 class CPlayerController : public ISliderCallback
 {
 public:
-  CPlayerController();
-  virtual ~CPlayerController();
+  static CPlayerController& Get();
 
   /*! \brief Perform a player control action if appropriate.
   \param action the action to perform.
@@ -45,6 +44,12 @@ public:
    \sa CGUIDialogSlider
    */
   virtual void OnSliderChange(void *data, CGUISliderControl *slider);
+
+protected:
+  CPlayerController();
+  CPlayerController(const CPlayerController&);
+  CPlayerController& operator=(CPlayerController const&);
+  virtual ~CPlayerController();
 
 private:
   /*! \brief pop up a slider dialog for a particular action

--- a/xbmc/video/PlayerController.h
+++ b/xbmc/video/PlayerController.h
@@ -22,6 +22,7 @@
 
 #include "guilib/ISliderCallback.h"
 #include "input/Key.h"
+#include "interfaces/IActionListener.h"
 
 /*! \brief Player controller class to handle user actions.
 
@@ -29,7 +30,7 @@
  altering subtitles and audio tracks, changing aspect ratio, subtitle placement,
  and placement of the video on screen.
  */
-class CPlayerController : public ISliderCallback
+class CPlayerController : public ISliderCallback, public IActionListener
 {
 public:
   static CPlayerController& Get();
@@ -38,7 +39,7 @@ public:
   \param action the action to perform.
   \return true if the action is considered handled, false if it should be handled elsewhere.
   */
-  bool OnAction(const CAction &action);
+  virtual bool OnAction(const CAction &action);
 
   /*! \brief Callback from the slider dialog.
    \sa CGUIDialogSlider


### PR DESCRIPTION
As the title said this refactors `CPlayerController` to use the action listener interface/pattern and register/unregister it `CApplication`. It also change `CPlayerController` to be Singleton so we can drop the member from `CApplication`.

@Paxxi mind taking a look
