### PR TITLE
[dx11] CD3DTexture::SaveTexture - fixed an amount of memory to save c…

### DIFF
--- a/xbmc/guilib/D3DResource.cpp
+++ b/xbmc/guilib/D3DResource.cpp
@@ -351,8 +351,9 @@ void CD3DTexture::SaveTexture()
     if (SUCCEEDED(pContext->Map(texture, 0, D3D11_MAP_READ, 0, &res)))
     {
       m_pitch = res.RowPitch;
-      m_data = new unsigned char[res.RowPitch * m_height];
-      memcpy(m_data, res.pData, res.RowPitch * m_height);
+      unsigned int memUsage = GetMemoryUsage(res.RowPitch);
+      m_data = new unsigned char[memUsage];
+      memcpy(m_data, res.pData, memUsage);
       pContext->Unmap(texture, 0);
     }
     else
@@ -402,7 +403,15 @@ void CD3DTexture::OnResetDevice()
 
 unsigned int CD3DTexture::GetMemoryUsage(unsigned int pitch) const
 {
-  return pitch * m_height;
+  switch (m_format)
+  {
+  case DXGI_FORMAT_BC1_UNORM:
+  case DXGI_FORMAT_BC2_UNORM:
+  case DXGI_FORMAT_BC3_UNORM:
+    return pitch * m_height / 4;
+  default:
+    return pitch * m_height;
+  }
 }
 
 // static methods


### PR DESCRIPTION
…ompressed (DX1/3/5) texture.

see title.
