### PR TITLE
[Strings] Audio DSP string fixes

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -5247,7 +5247,7 @@ msgstr ""
 #: xbmc\video\dialogs\GUIDialogAudioSubtitleSettings.cpp
 #: xbmc\video\dialogs\GUIDialogVideoSettings.cpp
 msgctxt "#12376"
-msgid "Set as default for all videos"
+msgid "Set as default for all media"
 msgstr ""
 
 #: xbmc\video\dialogs\GUIDialogAudioSubtitleSettings.cpp
@@ -7379,7 +7379,7 @@ msgstr ""
 
 #: xbmc/settings/dialogs/GUIDialogAudioDSPManager.cpp
 msgctxt "#15040"
-msgid "Settings dialogue can be only used on OSD menu during playback!"
+msgid "The settings dialogue can only be opened from the OSD menu during playback"
 msgstr ""
 
 #: xbmc/settings/dialogs/GUIDialogAudioDSPSettings.cpp
@@ -7407,7 +7407,7 @@ msgstr ""
 
 #: xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSP.cpp
 msgctxt "#15049"
-msgid "The audio DSP manager has been enabled without any enabled DSP add-on. Enable at least one add-on in order to use the audio DSP functionality."
+msgid "The audio DSP manager has been enabled without any enabled DSP add-on. Enable at least one add-on in order to use the DSP functionality."
 msgstr ""
 
 #. Name of a list with amount of entries behind on GUI


### PR DESCRIPTION
This corrects only the issues with some setting labels and app messages you get when testing DSP implementation.
Maybe @jjd-uk can review.

@AchimTuran 

There is still the issue of strings which were re-introduced that had been removed and not checked for other issues here. I checked one by one comparing between my last records and what's in now but the more eyes the better.

String #24137 wasn't part of the last @AlwinEsch round of fixes we did together https://github.com/uNiversaI/kodi/blob/f97cd59e48670fcbb0311046ad7ea1f6d224572a/addons/resource.language.en_gb/resources/strings.po

```
#: xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSP.cpp
msgctxt "#24137"
msgid "Not allowed"
msgstr ""
```

This string #24138 was also not part and claimed to have been removed and was reintroduced at merge time see discussion https://github.com/AlwinEsch/kodi/commit/b9e21032a02e8b2b36c535fd9e69652b6a2cdbe3#commitcomment-11225312

This string #24138 is also displayed wrongly instead of [The DSP add-on is currently in use and can't be modified.](https://github.com/xbmc/xbmc/blob/d720811fc4ed9b1eea8d2e63999482a01b5c5c3f/addons/resource.language.en_gb/resources/strings.po#L13427-L13429) Issue already reported at http://forum.kodi.tv/showthread.php?tid=232628

```
#: xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSP.cpp
msgctxt "#24138"
msgid "DSP add-on is currently in use and can't be removed."
msgstr ""
```
