### PR TITLE
[dx11] Fix AMD deinterlacing

### DIFF
--- a/xbmc/cores/VideoRenderers/DXVAHD.cpp
+++ b/xbmc/cores/VideoRenderers/DXVAHD.cpp
@@ -110,7 +110,7 @@ bool CProcessorHD::PreInit()
 
   D3D11_VIDEO_PROCESSOR_CONTENT_DESC desc1;
   ZeroMemory(&desc1, sizeof(D3D11_VIDEO_PROCESSOR_CONTENT_DESC));
-  desc1.InputFrameFormat = D3D11_VIDEO_FRAME_FORMAT_PROGRESSIVE;
+  desc1.InputFrameFormat = D3D11_VIDEO_FRAME_FORMAT_INTERLACED_TOP_FIELD_FIRST;
   desc1.InputWidth = 640;
   desc1.InputHeight = 480;
   desc1.OutputWidth = 640;
@@ -153,7 +153,7 @@ bool CProcessorHD::InitProcessor()
 
   D3D11_VIDEO_PROCESSOR_CONTENT_DESC contentDesc;
   ZeroMemory(&contentDesc, sizeof(contentDesc));
-  contentDesc.InputFrameFormat = D3D11_VIDEO_FRAME_FORMAT_PROGRESSIVE;
+  contentDesc.InputFrameFormat = D3D11_VIDEO_FRAME_FORMAT_INTERLACED_TOP_FIELD_FIRST;
   contentDesc.InputWidth = m_width;
   contentDesc.InputHeight = m_height;
   contentDesc.OutputWidth = m_width;


### PR DESCRIPTION
AMD has two D3D11 video processors. If enumerator is called with progressive flag it will return a progressive processor without deinterlacing capabilities. Passing D3D11_VIDEO_FRAME_FORMAT_INTERLACED_TOP_FIELD_FIRST fixes it. Tested with afedchin's Isengard DX11 branch on AMD 6450, nVidia GT840M and Intel HD4400.

@afedchin please check
