### PR TITLE
[settings] support minimum/step/maximum in lists (not only spinners)

### DIFF
--- a/xbmc/settings/SettingControl.cpp
+++ b/xbmc/settings/SettingControl.cpp
@@ -58,7 +58,7 @@ bool CSettingControlCheckmark::SetFormat(const std::string &format)
   return format.empty() || StringUtils::EqualsNoCase(format, "boolean");
 }
 
-bool CSettingControlSpinner::Deserialize(const TiXmlNode *node, bool update /* = false */)
+bool CSettingControlFormattedRange::Deserialize(const TiXmlNode *node, bool update /* = false */)
 {
   if (!ISettingControl::Deserialize(node, update))
     return false;
@@ -215,7 +215,7 @@ bool CSettingControlButton::SetFormat(const std::string &format)
 
 bool CSettingControlList::Deserialize(const TiXmlNode *node, bool update /* = false */)
 {
-  if (!ISettingControl::Deserialize(node, update))
+  if (!CSettingControlFormattedRange::Deserialize(node, update))
     return false;
   
   XMLUtils::GetInt(node, SETTING_XML_ELM_CONTROL_HEADING, m_heading);

--- a/xbmc/settings/SettingControl.h
+++ b/xbmc/settings/SettingControl.h
@@ -61,20 +61,12 @@ public:
   virtual bool SetFormat(const std::string &format);
 };
 
-class CSettingControlSpinner : public ISettingControl
+class CSettingControlFormattedRange : public ISettingControl
 {
 public:
-  CSettingControlSpinner()
-    : m_formatLabel(-1),
-      m_formatString("%i"),
-      m_minimumLabel(-1)
-  { }
-  virtual ~CSettingControlSpinner() { }
+  virtual ~CSettingControlFormattedRange() { }
 
-  // implementation of ISettingControl
-  virtual std::string GetType() const { return "spinner"; }
   virtual bool Deserialize(const TiXmlNode *node, bool update = false);
-  virtual bool SetFormat(const std::string &format);
 
   int GetFormatLabel() const { return m_formatLabel; }
   void SetFormatLabel(int formatLabel) { m_formatLabel = formatLabel; }
@@ -84,9 +76,28 @@ public:
   void SetMinimumLabel(int minimumLabel) { m_minimumLabel = minimumLabel; }
 
 protected:
+  CSettingControlFormattedRange()
+    : m_formatLabel(-1),
+    m_formatString("%i"),
+    m_minimumLabel(-1)
+  { }
+
   int m_formatLabel;
   std::string m_formatString;
   int m_minimumLabel;
+};
+
+class CSettingControlSpinner : public CSettingControlFormattedRange
+{
+public:
+  CSettingControlSpinner() { }
+  virtual ~CSettingControlSpinner() { }
+
+  // implementation of ISettingControl
+  virtual std::string GetType() const { return "spinner"; }
+
+  // specialization of CSettingControlFormattedRange
+  virtual bool SetFormat(const std::string &format);
 };
 
 class CSettingControlEdit : public ISettingControl
@@ -161,7 +172,7 @@ protected:
   bool m_showMoreAddons;
 };
 
-class CSettingControlList : public ISettingControl
+class CSettingControlList : public CSettingControlFormattedRange
 {
 public:
   CSettingControlList()
@@ -173,6 +184,8 @@ public:
 
   // implementation of ISettingControl
   virtual std::string GetType() const { return "list"; }
+
+  // specialization of CSettingControlFormattedRange
   virtual bool Deserialize(const TiXmlNode *node, bool update = false);
   virtual bool SetFormat(const std::string &format);
   

--- a/xbmc/settings/windows/GUIControlSettings.cpp
+++ b/xbmc/settings/windows/GUIControlSettings.cpp
@@ -195,8 +195,8 @@ void CGUIControlSpinExSetting::FillControl()
       if (pSettingString->GetOptionsType() == SettingOptionsTypeDynamic)
       {
         DynamicStringSettingOptions options = pSettingString->UpdateDynamicOptions();
-        for (std::vector< std::pair<std::string, std::string> >::const_iterator option = options.begin(); option != options.end(); ++option)
-          m_pSpin->AddLabel(option->first, option->second);
+        for (const auto& option : options)
+          m_pSpin->AddLabel(option.first, option.second);
 
         m_pSpin->SetStringValue(pSettingString->GetValue());
       }
@@ -212,8 +212,8 @@ void CGUIControlSpinExSetting::FillIntegerSettingControl()
     case SettingOptionsTypeStatic:
     {
       const StaticIntegerSettingOptions& options = pSettingInt->GetOptions();
-      for (StaticIntegerSettingOptions::const_iterator it = options.begin(); it != options.end(); ++it)
-        m_pSpin->AddLabel(g_localizeStrings.Get(it->first), it->second);
+      for (const auto& option : options)
+        m_pSpin->AddLabel(g_localizeStrings.Get(option.first), option.second);
 
       break;
     }
@@ -221,8 +221,8 @@ void CGUIControlSpinExSetting::FillIntegerSettingControl()
     case SettingOptionsTypeDynamic:
     {
       DynamicIntegerSettingOptions options = pSettingInt->UpdateDynamicOptions();
-      for (DynamicIntegerSettingOptions::const_iterator option = options.begin(); option != options.end(); ++option)
-        m_pSpin->AddLabel(option->first, option->second);
+      for (const auto& option : options)
+        m_pSpin->AddLabel(option.first, option.second);
 
       break;
     }
@@ -412,11 +412,11 @@ bool CGUIControlListSetting::GetIntegerItems(const CSetting *setting, CFileItemL
 
     pSettingInt = static_cast<const CSettingInt*>(settingList->GetDefinition());
     std::vector<CVariant> list = CSettingUtils::GetList(settingList);
-    for (std::vector<CVariant>::const_iterator itValue = list.begin(); itValue != list.end(); ++itValue)
+    for (const auto& itValue : list)
     {
-      if (!itValue->isInteger())
+      if (!itValue.isInteger())
         return false;
-      values.insert((int)itValue->asInteger());
+      values.insert((int)itValue.asInteger());
     }
   }
   else
@@ -427,11 +427,11 @@ bool CGUIControlListSetting::GetIntegerItems(const CSetting *setting, CFileItemL
     case SettingOptionsTypeStatic:
     {
       const StaticIntegerSettingOptions& options = pSettingInt->GetOptions();
-      for (StaticIntegerSettingOptions::const_iterator it = options.begin(); it != options.end(); ++it)
+      for (const auto& option : options)
       {
-        CFileItemPtr pItem = GetItem(g_localizeStrings.Get(it->first), it->second);
+        CFileItemPtr pItem = GetItem(g_localizeStrings.Get(option.first), option.second);
 
-        if (values.find(it->second) != values.end())
+        if (values.find(option.second) != values.end())
           pItem->Select(true);
 
         items.Add(pItem);
@@ -442,11 +442,11 @@ bool CGUIControlListSetting::GetIntegerItems(const CSetting *setting, CFileItemL
     case SettingOptionsTypeDynamic:
     {
       DynamicIntegerSettingOptions options = const_cast<CSettingInt*>(pSettingInt)->UpdateDynamicOptions();
-      for (DynamicIntegerSettingOptions::const_iterator option = options.begin(); option != options.end(); ++option)
+      for (const auto& option : options)
       {
-        CFileItemPtr pItem = GetItem(option->first, option->second);
+        CFileItemPtr pItem = GetItem(option.first, option.second);
 
-        if (values.find(option->second) != values.end())
+        if (values.find(option.second) != values.end())
           pItem->Select(true);
 
         items.Add(pItem);
@@ -479,11 +479,11 @@ bool CGUIControlListSetting::GetStringItems(const CSetting *setting, CFileItemLi
 
     pSettingString = static_cast<const CSettingString*>(settingList->GetDefinition());
     std::vector<CVariant> list = CSettingUtils::GetList(settingList);
-    for (std::vector<CVariant>::const_iterator itValue = list.begin(); itValue != list.end(); ++itValue)
+    for (const auto& itValue : list)
     {
-      if (!itValue->isString())
+      if (!itValue.isString())
         return false;
-      values.insert(itValue->asString());
+      values.insert(itValue.asString());
     }
   }
   else
@@ -492,11 +492,11 @@ bool CGUIControlListSetting::GetStringItems(const CSetting *setting, CFileItemLi
   if (pSettingString->GetOptionsType() == SettingOptionsTypeDynamic)
   {
     DynamicStringSettingOptions options = const_cast<CSettingString*>(pSettingString)->UpdateDynamicOptions();
-    for (DynamicStringSettingOptions::const_iterator option = options.begin(); option != options.end(); ++option)
+    for (const auto& option : options)
     {
-      CFileItemPtr pItem = GetItem(option->first, option->second);
+      CFileItemPtr pItem = GetItem(option.first, option.second);
 
-      if (values.find(option->second) != values.end())
+      if (values.find(option.second) != values.end())
         pItem->Select(true);
 
       items.Add(pItem);
@@ -671,9 +671,9 @@ bool CGUIControlButtonSetting::GetPath(CSettingPath *pathSetting)
 
   VECSOURCES shares;
   const std::vector<std::string>& sources = pathSetting->GetSources();
-  for (std::vector<std::string>::const_iterator source = sources.begin(); source != sources.end(); ++source)
+  for (const auto& source : sources)
   {
-    VECSOURCES *sources = CMediaSourceSettings::Get().GetSources(*source);
+    VECSOURCES *sources = CMediaSourceSettings::Get().GetSources(source);
     if (sources != NULL)
       shares.insert(shares.end(), sources->begin(), sources->end());
   }


### PR DESCRIPTION
This is the proper fix / improvement for #7573 by supporting minimum/step/maximum not only in spinners but also in lists. To not duplicate a lot of code I added an additional base class `CSettingControlFormattedRange` used by `CSettingControlSpinner` and `CSettingControlList` and I refactored the integer/string options handling so that the same code can be used by `CGUIControlSpinExSetting` and `CGUIControlListSetting`.

This doesn't touch the settings library at all because it already supports this use case. Just the GUI integration was missing this part.
