### PR TITLE
[ios/codesign] - unsigned apps are not working on jailbroken iOS5.1 devices

### DIFF
--- a/tools/darwin/Support/Codesign.command
+++ b/tools/darwin/Support/Codesign.command
@@ -6,6 +6,7 @@ LIST_BINARY_EXTENSIONS="dylib so 0 vis pvr"
 export CODESIGN_ALLOCATE=`xcodebuild -find codesign_allocate`
 
 GEN_ENTITLEMENTS="$XBMC_DEPENDS_ROOT/buildtools-native/bin/gen_entitlements.py"
+LDID="$XBMC_DEPENDS_ROOT/buildtools-native/bin/ldid"
 
 if [ ! -f ${GEN_ENTITLEMENTS} ]; then
   echo "error: $GEN_ENTITLEMENTS not found. Codesign won't work."
@@ -17,6 +18,12 @@ if [ "${PLATFORM_NAME}" == "iphoneos" ]; then
   if [ -f "/Users/Shared/buildslave/keychain_unlock.sh" ]; then
     /Users/Shared/buildslave/keychain_unlock.sh
   fi
+
+  #do fake sign - needed for jailbroken ios5.1 devices for some reason
+  if [ -f ${LDID} ]; then
+    ${LDID} -S ${BUILT_PRODUCTS_DIR}/${WRAPPER_NAME}/${APP_NAME}
+  fi
+
   ${GEN_ENTITLEMENTS} "org.xbmc.kodi-ios" "${BUILT_PRODUCTS_DIR}/${WRAPPER_NAME}/${PROJECT_NAME}.xcent";
   codesign -v -f -s "iPhone Developer" --entitlements "${BUILT_PRODUCTS_DIR}/${WRAPPER_NAME}/${PROJECT_NAME}.xcent" "${BUILT_PRODUCTS_DIR}/${WRAPPER_NAME}/"
   

--- a/tools/depends/native/Makefile
+++ b/tools/depends/native/Makefile
@@ -14,7 +14,7 @@ NATIVE= m4-native gettext-native autoconf-native automake-native \
 
 
 ifeq ($(OS),ios)
-  NATIVE += dpkg-native xz-native tar-native fakeroot-native gen_entitlements-native
+  NATIVE += dpkg-native xz-native tar-native fakeroot-native gen_entitlements-native ldid-native
 endif
 
 ifeq ($(OS),osx)

--- a/tools/depends/native/ldid-native/Makefile
+++ b/tools/depends/native/ldid-native/Makefile
@@ -1,0 +1,32 @@
+include ../../Makefile.include
+PREFIX=$(NATIVEPREFIX)
+PLATFORM=$(NATIVEPLATFORM)
+DEPS= ../../Makefile.include Makefile
+
+# lib name, version
+LIBNAME=ldid
+VERSION=1.0.0
+SOURCE=$(LIBNAME)-$(VERSION)
+ARCHIVE=$(SOURCE).tar.gz
+
+CLEAN_FILES=$(ARCHIVE) $(PLATFORM)
+
+all: .installed-$(PLATFORM)
+
+$(TARBALLS_LOCATION)/$(ARCHIVE):
+	cd $(TARBALLS_LOCATION); $(RETRIEVE_TOOL) $(RETRIEVE_TOOL_FLAGS) $(BASE_URL)/$(ARCHIVE)
+
+$(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
+	rm -rf $(PLATFORM)/*; mkdir -p $(PLATFORM)
+	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
+
+.installed-$(PLATFORM):$(PLATFORM)
+	cp $(PLATFORM)/ldid $(NATIVEPREFIX)/bin
+	touch $@
+
+clean:
+	rm -r $(PLATFORM)
+	rm -f .installed-$(PLATFORM)
+
+distclean::
+	rm -rf $(PLATFORM) .installed-$(PLATFORM)


### PR DESCRIPTION
The jailbreak for iOS5.1 (which is years old by now) hasn't the codesign check removed. As of the latest bump in build slaves we removed the fake codesign at some point (because it was hard to access the needed osx keychain via jenkins in an automated way).

Now that isengard is out we have some ipad1 users (which are stuck at ios5.1) reporting that kodi won't open. I was able to reproduce it (luckily also have an ipad1 stuck at ios5.1) and found the cause.

This time i decided for a better approach for fakesigning. Instead of using a self signed cert we use the ldid tool which was developed by one of the jailbreak developers. It alters the binary in a way that it passes the codesign check on jailbroken ios5.1 devices.

The whole issue is not present in any later ios versions because the jailbreak developers removed the codesign check completely in those.

There is a workaround for isengard users on ios5.1 for now (the can apt-get install the ldid tool directly on the ipad and run it on the kodi binary once).

Will do a backport for isengard in a min.
