### PR TITLE
[ios/codesign] - unsigned apps are not working on jailbroken iOS5.1 devices

### DIFF
--- a/tools/darwin/Support/Codesign.command
+++ b/tools/darwin/Support/Codesign.command
@@ -6,6 +6,7 @@ LIST_BINARY_EXTENSIONS="dylib so 0 vis pvr"
 export CODESIGN_ALLOCATE=`xcodebuild -find codesign_allocate`
 
 GEN_ENTITLEMENTS="$XBMC_DEPENDS_ROOT/buildtools-native/bin/gen_entitlements.py"
+LDID="$XBMC_DEPENDS_ROOT/buildtools-native/bin/ldid"
 
 if [ ! -f ${GEN_ENTITLEMENTS} ]; then
   echo "error: $GEN_ENTITLEMENTS not found. Codesign won't work."
@@ -17,6 +18,12 @@ if [ "${PLATFORM_NAME}" == "iphoneos" ]; then
   if [ -f "/Users/Shared/buildslave/keychain_unlock.sh" ]; then
     /Users/Shared/buildslave/keychain_unlock.sh
   fi
+
+  #do fake sign - needed for jailbroken ios5.1 devices for some reason
+  if [ -f ${LDID} ]; then
+    ${LDID} -S ${BUILT_PRODUCTS_DIR}/${WRAPPER_NAME}/${APP_NAME}
+  fi
+
   ${GEN_ENTITLEMENTS} "org.xbmc.kodi-ios" "${BUILT_PRODUCTS_DIR}/${WRAPPER_NAME}/${PROJECT_NAME}.xcent";
   codesign -v -f -s "iPhone Developer" --entitlements "${BUILT_PRODUCTS_DIR}/${WRAPPER_NAME}/${PROJECT_NAME}.xcent" "${BUILT_PRODUCTS_DIR}/${WRAPPER_NAME}/"
   

--- a/tools/depends/native/Makefile
+++ b/tools/depends/native/Makefile
@@ -14,7 +14,7 @@ NATIVE= m4-native gettext-native autoconf-native automake-native \
 
 
 ifeq ($(OS),ios)
-  NATIVE += dpkg-native xz-native tar-native fakeroot-native gen_entitlements-native
+  NATIVE += dpkg-native xz-native tar-native fakeroot-native gen_entitlements-native ldid-native
 endif
 
 ifeq ($(OS),osx)

--- a/tools/depends/native/ldid-native/Makefile
+++ b/tools/depends/native/ldid-native/Makefile
@@ -1,0 +1,32 @@
+include ../../Makefile.include
+PREFIX=$(NATIVEPREFIX)
+PLATFORM=$(NATIVEPLATFORM)
+DEPS= ../../Makefile.include Makefile
+
+# lib name, version
+LIBNAME=ldid
+VERSION=1.0.0
+SOURCE=$(LIBNAME)-$(VERSION)
+ARCHIVE=$(SOURCE).tar.gz
+
+CLEAN_FILES=$(ARCHIVE) $(PLATFORM)
+
+all: .installed-$(PLATFORM)
+
+$(TARBALLS_LOCATION)/$(ARCHIVE):
+	cd $(TARBALLS_LOCATION); $(RETRIEVE_TOOL) $(RETRIEVE_TOOL_FLAGS) $(BASE_URL)/$(ARCHIVE)
+
+$(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
+	rm -rf $(PLATFORM)/*; mkdir -p $(PLATFORM)
+	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
+
+.installed-$(PLATFORM):$(PLATFORM)
+	cp $(PLATFORM)/ldid $(NATIVEPREFIX)/bin
+	touch $@
+
+clean:
+	rm -r $(PLATFORM)
+	rm -f .installed-$(PLATFORM)
+
+distclean::
+	rm -rf $(PLATFORM) .installed-$(PLATFORM)


### PR DESCRIPTION
This is the backport of #7594 against Isengard branch.

@MartijnKaijser i think its enough to have it in the next isengard release. In case there are more ipad1 users (and the support burdon increases to much) i leave the option open to do a special isengard_ios51 branch and do a 15.0-1 build.
