### PR TITLE
[PVR] Fix gui info time format for timeshift buffer start, buffer end, playing time

### DIFF
--- a/xbmc/pvr/PVRGUIInfo.cpp
+++ b/xbmc/pvr/PVRGUIInfo.cpp
@@ -263,15 +263,15 @@ void CPVRGUIInfo::UpdateTimeshift(void)
   CDateTime tmp;
   time_t iTimeshiftStartTime = g_PVRClients->GetBufferTimeStart();
   tmp.SetFromUTCDateTime(iTimeshiftStartTime);
-  std::string strTimeshiftStartTime = tmp.GetAsLocalizedTime("hh:mm", true);
+  std::string strTimeshiftStartTime = tmp.GetAsLocalizedTime("", false);
 
   time_t iTimeshiftEndTime = g_PVRClients->GetBufferTimeEnd();
   tmp.SetFromUTCDateTime(iTimeshiftEndTime);
-  std::string strTimeshiftEndTime = tmp.GetAsLocalizedTime("hh:mm", true);
+  std::string strTimeshiftEndTime = tmp.GetAsLocalizedTime("", false);
 
   time_t iTimeshiftPlayTime = g_PVRClients->GetPlayingTime();
   tmp.SetFromUTCDateTime(iTimeshiftPlayTime);
-  std::string strTimeshiftPlayTime = tmp.GetAsLocalizedTime("hh:mm:ss", true);
+  std::string strTimeshiftPlayTime = tmp.GetAsLocalizedTime("", true);
 
   CSingleLock lock(m_critSection);
   m_bIsTimeshifting = bIsTimeshifting;


### PR DESCRIPTION
Fix gui info time format for timeshift buffer start, buffer end, playing time. Currently time format is hard-wired to 12 hour clock (due to the non-capital "hh"s).

@FernetMenta fyi (and review)
