### PR TITLE
fix: high cpu usage when playing active recordings

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -4659,7 +4659,6 @@ bool CDVDPlayer::SwitchChannel(const CPVRChannelPtr &channel)
 bool CDVDPlayer::CachePVRStream(void) const
 {
   return m_pInputStream->IsStreamType(DVDSTREAM_TYPE_PVRMANAGER) &&
-      (!g_PVRManager.IsPlayingRecording() ||
-          (m_item.HasPVRRecordingInfoTag() && m_item.GetPVRRecordingInfoTag()->IsBeingRecorded()))&&
+      !g_PVRManager.IsPlayingRecording() &&
       g_advancedSettings.m_bPVRCacheInDvdPlayer;
 }


### PR DESCRIPTION
http://trac.kodi.tv/ticket/16141

Many calls to IsBeingRecorded() causes high cpu usage due to it's design.
(searching for a tag in the whole epg container every time)
https://github.com/opdenkamp/xbmc/commit/8d3a0a16fb8c3248d9f9aa05f63d9351a7523d81

IsBeingRecorded() is here actually useless (my opinion) as it differs between manual or epg based recordings. We could ask the pvr client for this instead?

This PR restores the old behavior, so CACHESTATE_PVR is dropped for active recordings, what is actually the advantage of using CACHESTATE_PVR for active recordings?

@Jalle19 @opdenkamp @FernetMenta 
