### PR TITLE
[osx/XBMCHelper] - compile XBMCHelper as 64bit

### DIFF
--- a/tools/EventClients/Clients/OSXRemote/XBMCHelper.xcodeproj/project.pbxproj
+++ b/tools/EventClients/Clients/OSXRemote/XBMCHelper.xcodeproj/project.pbxproj
@@ -188,6 +188,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CONFIGURATION_BUILD_DIR = ../../../darwin/runtime;
 				COPY_PHASE_STRIP = NO;
 				GCC_DYNAMIC_NO_PIC = NO;
@@ -202,7 +203,7 @@
 				PRODUCT_NAME = XBMCHelper;
 				SDKROOT = macosx;
 				STRIP_STYLE = debugging;
-				VALID_ARCHS = i386;
+				VALID_ARCHS = x86_64;
 			};
 			name = Debug;
 		};
@@ -210,6 +211,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CONFIGURATION_BUILD_DIR = ../../../darwin/runtime;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_MODEL_TUNING = G5;
@@ -220,7 +222,7 @@
 				PRODUCT_NAME = XBMCHelper;
 				SDKROOT = macosx;
 				STRIP_STYLE = debugging;
-				VALID_ARCHS = i386;
+				VALID_ARCHS = x86_64;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
As we already compile Kodi only in 64bit officially we might aswell switch the XBMCHelper (for the ir remotes) to 64bit.
