### PR TITLE
[PosixClog] - ensure that file decriptor for logfile is NULL'ed in th…

### DIFF
--- a/xbmc/utils/posix/PosixInterfaceForCLog.cpp
+++ b/xbmc/utils/posix/PosixInterfaceForCLog.cpp
@@ -40,6 +40,7 @@ CPosixInterfaceForCLog::~CPosixInterfaceForCLog()
 {
   if (m_file)
     fclose(m_file);
+  m_file = NULL;
 }
 
 bool CPosixInterfaceForCLog::OpenLogFile(const std::string &logFilename, const std::string &backupOldLogToFilename)


### PR DESCRIPTION
…e d'tor to minimize issues when static/global object destruction order results in CLog accesses past destruction of the CLog instance.

As discussed in the internal forum. @Paxxi 
