### PR TITLE
[ActiveAE] Added GetCurrentSinkFormat method

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -163,10 +163,22 @@ void CEngineStats::SetDSP(bool state)
   m_hasDSP = state;
 }
 
+void CEngineStats::SetCurrentSinkFormat(AEAudioFormat SinkFormat)
+{
+  CSingleLock lock(m_lock);
+  m_sinkFormat = SinkFormat;
+}
+
 bool CEngineStats::HasDSP()
 {
   CSingleLock lock(m_lock);
   return m_hasDSP;
+}
+
+AEAudioFormat CEngineStats::GetCurrentSinkFormat()
+{
+  CSingleLock lock(m_lock);
+  return m_sinkFormat;
 }
 
 CActiveAE::CActiveAE() :
@@ -1638,6 +1650,7 @@ bool CActiveAE::InitSink()
       m_sinkHasVolume = data->hasVolume;
       m_stats.SetSinkCacheTotal(data->cacheTotal);
       m_stats.SetSinkLatency(data->latency);
+      m_stats.SetCurrentSinkFormat(m_sinkFormat);
     }
     reply->Release();
   }
@@ -1646,6 +1659,9 @@ bool CActiveAE::InitSink()
     CLog::Log(LOGERROR, "ActiveAE::%s - failed to init", __FUNCTION__);
     m_stats.SetSinkCacheTotal(0);
     m_stats.SetSinkLatency(0);
+    AEAudioFormat invalidFormat;
+    invalidFormat.m_dataFormat = AE_FMT_INVALID;
+    m_stats.SetCurrentSinkFormat(invalidFormat);
     m_extError = true;
     return false;
   }
@@ -2493,6 +2509,11 @@ bool CActiveAE::HasDSP()
 {
   return m_stats.HasDSP();
 };
+
+AEAudioFormat CActiveAE::GetCurrentSinkFormat()
+{
+  return m_stats.GetCurrentSinkFormat();
+}
 
 void CActiveAE::OnLostDevice()
 {

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
@@ -183,10 +183,12 @@ public:
   int Discontinuity(bool reset = false);
   void SetSuspended(bool state);
   void SetDSP(bool state);
+  void SetCurrentSinkFormat(AEAudioFormat SinkFormat);
   void SetSinkCacheTotal(float time) { m_sinkCacheTotal = time; }
   void SetSinkLatency(float time) { m_sinkLatency = time; }
   bool IsSuspended();
   bool HasDSP();
+  AEAudioFormat GetCurrentSinkFormat();
   CCriticalSection *GetLock() { return &m_lock; }
 protected:
   int64_t m_playingPTS;
@@ -198,6 +200,7 @@ protected:
   AEDelayStatus m_sinkDelay;
   bool m_suspended;
   bool m_hasDSP;
+  AEAudioFormat m_sinkFormat;
   CCriticalSection m_lock;
 };
 
@@ -251,6 +254,7 @@ public:
   virtual void KeepConfiguration(unsigned int millis);
   virtual void DeviceChange();
   virtual bool HasDSP();
+  virtual AEAudioFormat GetCurrentSinkFormat();
 
   virtual void RegisterAudioCallback(IAudioCallback* pCallback);
   virtual void UnregisterAudioCallback();

--- a/xbmc/cores/AudioEngine/Interfaces/AE.h
+++ b/xbmc/cores/AudioEngine/Interfaces/AE.h
@@ -255,5 +255,12 @@ public:
    * Indicates if dsp addon system is active.
    */
   virtual bool HasDSP() { return false; };
+
+  /**
+   * Gets the currently used sink format.
+   *
+   * @return The current sink format.
+   */
+  virtual AEAudioFormat GetCurrentSinkFormat() = 0;
 };
 

--- a/xbmc/cores/AudioEngine/Utils/AEAudioFormat.h
+++ b/xbmc/cores/AudioEngine/Utils/AEAudioFormat.h
@@ -85,5 +85,17 @@ typedef struct AEAudioFormat{
             m_frameSize     ==  fmt.m_frameSize;
   }
  
+  AEAudioFormat& operator=(const AEAudioFormat& fmt)
+  {
+    m_dataFormat      = fmt.m_dataFormat;
+    m_sampleRate      = fmt.m_sampleRate;
+    m_encodedRate     = fmt.m_encodedRate;
+    m_channelLayout   = fmt.m_channelLayout;
+    m_frames          = fmt.m_frames;
+    m_frameSamples    = fmt.m_frameSamples;
+    m_frameSize       = fmt.m_frameSize;
+
+    return *this;
+  }
 } AEAudioFormat;
 


### PR DESCRIPTION
@FernetMenta  @fritsch 
This adds a get current sink format method, which I need to measure room impulse responses. This allows me to use all available speaker channels that the sink currently supports.
