### PR TITLE
Library.kodi.interfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,6 +159,8 @@ config.log
 /lib/addons/library.xbmc.codec/project/VS2010Express/Debug
 /lib/addons/library.xbmc.pvr/project/VS2010Express/Release
 /lib/addons/library.xbmc.pvr/project/VS2010Express/Debug
+/lib/addons/library.kodi.interfaces/project/VS2010Express/Debug
+/lib/addons/library.kodi.interfaces/project/VS2010Express/Release
 
 # /lib/cpluff/
 /lib/cpluff/ABOUT-NLS
@@ -934,6 +936,8 @@ lib/cpluff/stamp-h1
 /addons/library.kodi.guilib/libKODI_guilib.lib
 /addons/library.xbmc.pvr/libXBMC_pvr.dll
 /addons/library.xbmc.pvr/libXBMC_pvr.lib
+/addons/library.kodi.interfaces/libKODI_interfaces.dll
+/addons/library.kodi.interfaces/libKODI_interfaces.lib
 
 /pvr-addons
 /adsp-addons

--- a/addons/kodi.interfaces/addon.xml
+++ b/addons/kodi.interfaces/addon.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<addon id="kodi.interfaces" version="0.0.1" provider-name="Team KODI">
+  <backwards-compatibility abi="0.0.1"/>
+  <requires>
+    <import addon="xbmc.core" version="0.1.0"/>
+  </requires>
+</addon>

--- a/addons/library.kodi.interfaces/libKODI_interfaces.h
+++ b/addons/library.kodi.interfaces/libKODI_interfaces.h
@@ -1,0 +1,257 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2014 Team KODI
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <string>
+#include <vector>
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#ifdef BUILD_KODI_ADDON
+#else
+#endif
+#include "libXBMC_addon.h"
+
+#ifdef _WIN32
+#define INTERFACES_HELPER_DLL "\\library.kodi.interfaces\\libKODI_interfaces" ADDON_HELPER_EXT
+#else
+#define INTERFACES_HELPER_DLL_NAME "libKODI_interfaces-" ADDON_HELPER_ARCH ADDON_HELPER_EXT
+#define INTERFACES_HELPER_DLL "/library.kodi.interfaces/" INTERFACES_HELPER_DLL_NAME
+#endif
+
+class CAddonPythonInterpreter;
+
+class CHelper_libKODI_interfaces
+{
+public:
+  CHelper_libKODI_interfaces()
+  {
+    m_libKODI_interfaces = NULL;
+    m_Handle             = NULL;
+  }
+
+  ~CHelper_libKODI_interfaces(void)
+  {
+    if(m_libKODI_interfaces)
+    {
+      Interfaces_unregister_me(m_Handle, m_Callbacks);
+      dlclose(m_libKODI_interfaces);
+    }
+  }
+
+  /*!
+   * @brief Resolve all callback methods
+   * @param handle Pointer to the add-on
+   * @return True when all methods were resolved, false otherwise.
+   */
+  bool RegisterMe(void* handle)
+  {
+    m_Handle = handle;
+
+    std::string libBasePath;
+    libBasePath  = ((cb_array*)m_Handle)->libPath;
+    libBasePath += INTERFACES_HELPER_DLL;
+
+#if defined(ANDROID)
+      struct stat st;
+      if(stat(libBasePath.c_str(),&st) != 0)
+      {
+        std::string tempbin = getenv("XBMC_ANDROID_LIBS");
+        libBasePath = tempbin + "/" + INTERFACES_HELPER_DLL;
+      }
+#endif
+
+    m_libKODI_interfaces = dlopen(libBasePath.c_str(), RTLD_LAZY);
+    if (m_libKODI_interfaces == NULL)
+    {
+      fprintf(stderr, "Unable to load %s\n", dlerror());
+      return false;
+    }
+
+    Interfaces_register_me = (void* (*)(void *))
+      dlsym(m_libKODI_interfaces, "Interfaces_register_me");
+    if (Interfaces_register_me == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+
+    Interfaces_unregister_me = (void(*)(void*, void*))
+      dlsym(m_libKODI_interfaces, "Interfaces_unregister_me");
+    if (Interfaces_unregister_me == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+
+    Interfaces_Execute_Script_Sync = (int(*)(void*, void*, const char*, const char*, const char**, uint32_t, bool))
+      dlsym(m_libKODI_interfaces, "Interfaces_Execute_Script_Sync");
+    if (Interfaces_Execute_Script_Sync == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+
+    Interfaces_Execute_Script_Async = (int(*)(void*, void*, const char*, const char*, const char**))
+      dlsym(m_libKODI_interfaces, "Interfaces_Execute_Script_Async");
+    if (Interfaces_Execute_Script_Async == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+
+    Interfaces_Get_Python_Interpreter = (int(*)(void*, void*))
+      dlsym(m_libKODI_interfaces, "Interfaces_Get_Python_Interpreter");
+    if(Interfaces_Get_Python_Interpreter == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+
+    m_Callbacks = Interfaces_register_me(m_Handle);
+    return m_Callbacks != NULL;
+  }
+
+  /*!
+   * \brief Executes the given script asynchronously in a separate thread.
+   *
+   * \param script Path to the script to be executed
+   * \param addon (Optional) Addon to which the script belongs
+   * \param arguments (Optional) List of arguments passed to the script
+   * \return -1 if an error occurred, otherwise the ID of the script
+   */
+  int ExecuteScriptAsync( const std::string &Script, const std::string &AddonName=std::string(""), 
+                          const std::vector<std::string> &Arguments = std::vector<std::string>())
+  {
+    char **arguments = NULL;
+    if(Arguments.size() > 0)
+    {
+      arguments = new char*[Arguments.size() +1];
+      for(int strIdx = 0; strIdx < (int)Arguments.size(); strIdx++)
+      {
+        arguments[strIdx] = new char[Arguments.at(strIdx).size() +1];
+        strcpy(arguments[strIdx], Arguments.at(strIdx).c_str());
+      }
+      arguments[Arguments.size()] = NULL;
+    }
+
+    std::string addonName = AddonName;
+    if(addonName.empty() || addonName == "")
+    {
+      addonName = ""; // ToDo: Add addon name
+    }
+
+    int iRet = Interfaces_Execute_Script_Async(m_Handle, m_Callbacks, Script.c_str(), addonName.c_str(), (const char**)arguments);
+
+    if(arguments)
+    {
+      for(int strIdx = 0; strIdx < (int)Arguments.size(); strIdx++)
+      {
+        if(arguments[strIdx])
+        {
+          delete [] arguments[strIdx];
+          arguments[strIdx] = NULL;
+        }
+      }
+
+      delete [] arguments;
+    }
+
+    return iRet;
+  }
+
+  /*!
+   * \brief Executes the given script synchronously.
+   *
+   * \details The script is actually executed asynchronously but the calling
+   * thread is blocked until either the script has finished or the given timeout
+   * has expired. If the given timeout has expired the script's execution is
+   * stopped and depending on the specified wait behaviour we wait for the
+   * script's execution to finish or not.
+   *
+   * \param script Path to the script to be executed
+   * \param addon (Optional) Addon to which the script belongs
+   * \param arguments (Optional) List of arguments passed to the script
+   * \param timeout (Optional) Timeout (in milliseconds) for the script's execution
+   * \param waitShutdown (Optional) Whether to wait when having to forcefully stop the script's execution or not.
+   * \return -1 if an error occurred, 0 if the script terminated or ETIMEDOUT if the given timeout expired
+   */
+  int ExecuteScriptSync(const std::string &Script, const std::string &AddonName = std::string(""),
+                        const std::vector<std::string> &Arguments = std::vector<std::string>(), uint32_t TimeoutMs = 0, bool WaitShutdown = false)
+  {
+    char **arguments = NULL;
+    if(Arguments.size() > 0)
+    {
+      arguments = new char*[Arguments.size() +1];
+      for(int strIdx = 0; strIdx < (int)Arguments.size(); strIdx++)
+      {
+        arguments[strIdx] = new char[Arguments.at(strIdx).size() +1];
+        strcpy(arguments[strIdx], Arguments.at(strIdx).c_str());
+      }
+      arguments[Arguments.size()] = NULL;
+    }
+
+    std::string addonName = AddonName;
+    if(addonName.empty() || addonName == "")
+    {
+      addonName = ""; // ToDo: Add addon name
+    }
+
+    int iRet = Interfaces_Execute_Script_Sync(m_Handle, m_Callbacks, Script.c_str(), addonName.c_str(), (const char**)arguments, TimeoutMs, WaitShutdown);
+
+    if(arguments)
+    {
+      for(int strIdx = 0; strIdx < (int)Arguments.size(); strIdx++)
+      {
+        if(arguments[strIdx])
+        {
+          delete [] arguments[strIdx];
+          arguments[strIdx] = NULL;
+        }
+      }
+      
+      delete [] arguments;
+    }
+
+    return iRet;
+  }
+
+protected:
+  int   (*Interfaces_Execute_Script_Sync)(void *hdl, void *cb, const char *AddonName, const char *Script, const char **Arguments, uint32_t TimeoutMs, bool WaitShutdown);
+  int   (*Interfaces_Execute_Script_Async)(void *hdl, void *cb, const char *AddonName, const char *Script, const char **Arguments);
+  void  *(*Interfaces_register_me)(void *HANDLE);
+  void  (*Interfaces_unregister_me)(void* HANDLE, void* CB);
+  int   (*Interfaces_Get_Python_Interpreter)(void *hdl, void *cb);
+  
+private:
+  void *m_libKODI_interfaces;
+  void *m_Handle;
+  void *m_Callbacks;
+  struct cb_array
+  {
+    const char* libPath;
+  };
+};
+
+class CAddonPythonInterpreter
+{
+public:
+  CAddonPythonInterpreter(void *Addon, void *Callbacks, int InterpreterId);
+  virtual ~CAddonPythonInterpreter();
+
+  /**
+  * TODO
+  * @return true, when the Python Interpreter is active and usable. If something goes wrong the method returns false
+  *         and detailed error message is written to Kodi's log file.
+  */
+  virtual bool Activate();
+
+  /**
+  * TODO
+  * @return true, when the Python Interpreter is deactivated. If something goes wrong the method returns false
+  *         and detailed error message is written to Kodi's log file.
+  */
+  virtual bool Deactivate();
+
+private:
+  int   m_InterpreterId;
+  void  *m_AddonHandle;
+  void  *m_Callbacks;
+};

--- a/lib/addons/library.kodi.interfaces/Makefile.in
+++ b/lib/addons/library.kodi.interfaces/Makefile.in
@@ -1,0 +1,27 @@
+ARCH=@ARCH@
+INCLUDES=-I. -I../../../xbmc/addons/include -I../../../xbmc
+DEFINES+=
+CXXFLAGS=-fPIC
+LIBNAME=libKODI_interfaces
+OBJS=$(LIBNAME).o
+
+LIB_SHARED=../../../addons/library.kodi.interfaces/$(LIBNAME)-$(ARCH).so
+
+all: $(LIB_SHARED)
+
+$(LIB_SHARED): $(OBJS)
+ifeq ($(findstring osx,$(ARCH)), osx)
+	$(CXX) $(LDFLAGS) -Wl,-alias_list,@abs_top_srcdir@/xbmc/cores/DllLoader/exports/wrapper_mach_alias \
+	-bundle -undefined dynamic_lookup -o $@ \
+	@abs_top_srcdir@/xbmc/cores/DllLoader/exports/wrapper.o $(OBJS)
+else
+	$(CXX) $(CFLAGS) $(LDFLAGS) -shared -g -o $(LIB_SHARED) $(OBJS)
+endif
+
+CLEAN_FILES = \
+	$(LIB_SHARED) \
+
+DISTCLEAN_FILES= \
+	Makefile \
+
+include ../../../Makefile.include

--- a/lib/addons/library.kodi.interfaces/libKODI_interfaces.cpp
+++ b/lib/addons/library.kodi.interfaces/libKODI_interfaces.cpp
@@ -1,0 +1,150 @@
+/*
+ *      Copyright (C) 2013-2014 Team KODI
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <string>
+#include "../../../addons/library.kodi.interfaces/libKODI_interfaces.h"
+#include "addons/AddonCallbacks.h"
+
+#ifdef _WIN32
+#include <windows.h>
+#define DLLEXPORT __declspec(dllexport)
+#else
+#define DLLEXPORT
+#endif
+
+using namespace std;
+
+#define LIBRARY_NAME "libKODI_interfaces"
+
+extern "C"
+{
+
+DLLEXPORT void* Interfaces_register_me(void *hdl)
+{
+  CB_InterfacesLib *cb = NULL;
+  if (!hdl)
+  {
+    fprintf(stderr, "%s-ERROR: Interfaces_register_me is called with NULL handle !!!\n", LIBRARY_NAME);
+  }
+  else
+  {
+    cb = ((AddonCB*)hdl)->InterfacesLib_RegisterMe(((AddonCB*)hdl)->addonData);
+    if (!cb)
+      fprintf(stderr, "%s-ERROR: Interfaces_register_me can't get callback table from KODI !!!\n", LIBRARY_NAME);
+  }
+  return cb;
+}
+
+DLLEXPORT void Interfaces_unregister_me(void *hdl, void* cb)
+{
+  if (hdl && cb)
+  {
+    ((AddonCB*)hdl)->InterfacesLib_UnRegisterMe(((AddonCB*)hdl)->addonData, (CB_InterfacesLib*)cb);
+  }
+  else
+  {
+    fprintf(stderr, "%s-ERROR: Interfaces_unregister_me is called with NULL handle !!!\n", LIBRARY_NAME);
+  }
+}
+
+DLLEXPORT int Interfaces_Execute_Script_Sync(void *hdl, void* cb, const char *Script, const char *AddonName, const char **Arguments, uint32_t TimeoutMs, bool WaitShutdown)
+{
+  if(!hdl || !cb)
+  {
+    return -1;
+  }
+
+  return ((CB_InterfacesLib*)cb)->ExecuteScriptSync(hdl, AddonName, Script, Arguments, TimeoutMs, WaitShutdown);
+}
+
+DLLEXPORT int Interfaces_Execute_Script_Async(void *hdl, void* cb, const char *Script, const char *AddonName, const char **Arguments)
+{
+  if(!hdl || !cb)
+  {
+    return -1;
+  }
+
+  return ((CB_InterfacesLib*)cb)->ExecuteScriptAsync(hdl, AddonName, Script, Arguments);
+}
+
+DLLEXPORT int Interfaces_Get_Python_Interpreter(void *hdl, void* cb)
+{
+  if(!cb)
+  {
+    return -1;
+  }
+
+  return ((CB_InterfacesLib*)cb)->GetPythonInterpreter(hdl);
+}
+
+CAddonPythonInterpreter::CAddonPythonInterpreter(void *Addon, void *Callbacks, int InterpreterId)
+{
+  if(!Addon || !Callbacks)
+  {
+    // TODO: error message!
+  }
+
+  if(InterpreterId < 0)
+  {
+    // TODO: error message!
+  }
+  else
+  {
+    m_InterpreterId = InterpreterId;
+  }
+
+  m_Callbacks   = Callbacks;
+  m_AddonHandle = Addon;
+}
+
+CAddonPythonInterpreter::~CAddonPythonInterpreter()
+{
+  if(m_Callbacks && m_InterpreterId >= 0)
+  {
+    ((CB_InterfacesLib*)m_Callbacks)->DeactivatePythonInterpreter(m_AddonHandle, m_InterpreterId);
+  }
+}
+
+bool CAddonPythonInterpreter::Activate()
+{
+  if(!m_Callbacks)
+  {
+    // TODO: error message!
+    return false;
+  }
+
+  return ((CB_InterfacesLib*)m_Callbacks)->ActivatePythonInterpreter(m_AddonHandle, m_InterpreterId);
+}
+
+bool CAddonPythonInterpreter::Deactivate()
+{
+  if(!m_Callbacks)
+  {
+    // TODO: error message!
+    return false;
+  }
+
+  return ((CB_InterfacesLib*)m_Callbacks)->DeactivatePythonInterpreter(m_AddonHandle, m_InterpreterId);
+}
+
+};

--- a/lib/addons/library.kodi.interfaces/project/VS2010Express/libKODI_interfaces.vcxproj
+++ b/lib/addons/library.kodi.interfaces/project/VS2010Express/libKODI_interfaces.vcxproj
@@ -1,0 +1,84 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\libKODI_interfaces.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\..\..\..\addons\library.kodi.interfaces\libKODI_interfaces.h" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{0FF79243-6137-4DD1-A7E2-0C55362D7A64}</ProjectGuid>
+    <RootNamespace>KODI_ADSP</RootNamespace>
+    <Keyword>Win32Proj</Keyword>
+  </PropertyGroup>
+  <Import Project="$(SolutionDir)\XBMC.core-defaults.props" />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(SolutionDir)\XBMC.defaults.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\..\..\..\..\addons\library.kodi.interfaces\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Debug\</IntDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\..\..\..\..\addons\library.kodi.interfaces\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Release\</IntDir>
+    <IncludePath Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\..\..\..\..\addons\library.xbmc.addon\;$(IncludePath)</IncludePath>
+    <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\..\..\..\..\addons\library.xbmc.addon\;$(IncludePath)</IncludePath>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..\..\..\..\xbmc\;..\..\..\..\..\xbmc\addons\include\;..\..\..\..\..\addons\library.xbmc.addon\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;VDR_EXPORTS;_WIN32PC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+    </ClCompile>
+    <Link>
+      <OutputFile>..\..\..\..\..\addons\library.kodi.interfaces\$(ProjectName).dll</OutputFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..\..\..\..\xbmc\;..\..\..\..\..\xbmc\addons\include\;..\..\..\..\..\addons\library.xbmc.addon\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;HAS_SDL_OPENGL;HAS_SDL;_USRDLL;XBMC_VDR_EXPORTS;_WIN32PC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+    </ClCompile>
+    <Link>
+      <OutputFile>..\..\..\..\..\addons\library.kodi.interfaces\$(ProjectName).dll</OutputFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/lib/addons/library.kodi.interfaces/project/VS2010Express/libKODI_interfaces.vcxproj.filters
+++ b/lib/addons/library.kodi.interfaces/project/VS2010Express/libKODI_interfaces.vcxproj.filters
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{A463B136-5D8C-4995-A8D5-67FA2B90B6A8}</UniqueIdentifier>
+      <Extensions>cpp;c;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{EAFF7342-E9A9-4164-A40A-639A72C620DA}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\libKODI_interfaces.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\..\..\..\addons\library.kodi.interfaces\libKODI_interfaces.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/project/VS2010Express/XBMC for Windows.sln
+++ b/project/VS2010Express/XBMC for Windows.sln
@@ -68,6 +68,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Effects11", "..\..\lib\win3
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libKODI_adsp", "..\..\lib\addons\library.kodi.adsp\project\VS2010Express\libKODI_adsp.vcxproj", "{44F93C4D-85DD-4452-99BB-F1D196174024}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libKODI_interfaces", "..\..\lib\addons\library.kodi.interfaces\project\VS2010Express\libKODI_interfaces.vcxproj", "{0FF79243-6137-4DD1-A7E2-0C55362D7A64}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug Testsuite|Win32 = Debug Testsuite|Win32
@@ -238,6 +240,12 @@ Global
 		{44F93C4D-85DD-4452-99BB-F1D196174024}.Debug|Win32.Build.0 = Debug|Win32
 		{44F93C4D-85DD-4452-99BB-F1D196174024}.Release|Win32.ActiveCfg = Release|Win32
 		{44F93C4D-85DD-4452-99BB-F1D196174024}.Release|Win32.Build.0 = Release|Win32
+		{0FF79243-6137-4DD1-A7E2-0C55362D7A64}.Debug Testsuite|Win32.ActiveCfg = Debug|Win32
+		{0FF79243-6137-4DD1-A7E2-0C55362D7A64}.Debug Testsuite|Win32.Build.0 = Debug|Win32
+		{0FF79243-6137-4DD1-A7E2-0C55362D7A64}.Debug|Win32.ActiveCfg = Debug|Win32
+		{0FF79243-6137-4DD1-A7E2-0C55362D7A64}.Debug|Win32.Build.0 = Debug|Win32
+		{0FF79243-6137-4DD1-A7E2-0C55362D7A64}.Release|Win32.ActiveCfg = Release|Win32
+		{0FF79243-6137-4DD1-A7E2-0C55362D7A64}.Release|Win32.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -186,6 +186,7 @@
     <ClCompile Include="..\..\xbmc\addons\AddonCallbacksAudioDSP.cpp" />
     <ClCompile Include="..\..\xbmc\addons\AddonCallbacksCodec.cpp" />
     <ClCompile Include="..\..\xbmc\addons\AddonCallbacksGUI.cpp" />
+    <ClCompile Include="..\..\xbmc\addons\AddonCallbacksInterfaces.cpp" />
     <ClCompile Include="..\..\xbmc\addons\AddonCallbacksPVR.cpp" />
     <ClCompile Include="..\..\xbmc\addons\AddonDatabase.cpp" />
     <ClCompile Include="..\..\xbmc\addons\AddonInstaller.cpp" />
@@ -856,6 +857,7 @@
     <ClCompile Include="..\..\xbmc\DatabaseManager.cpp" />
     <ClInclude Include="..\..\xbmc\addons\AddonCallbacksAudioDSP.h" />
     <ClInclude Include="..\..\xbmc\addons\AddonCallbacksCodec.h" />
+    <ClInclude Include="..\..\xbmc\addons\AddonCallbacksInterfaces.h" />
     <ClInclude Include="..\..\xbmc\addons\AudioDecoder.h" />
     <ClInclude Include="..\..\xbmc\addons\ContextItemAddon.h" />
     <ClInclude Include="..\..\xbmc\addons\ImageResource.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -3146,6 +3146,9 @@
     <ClCompile Include="..\..\xbmc\messaging\ApplicationMessenger.cpp">
       <Filter>messaging</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\addons\AddonCallbacksInterfaces.cpp">
+      <Filter>addons</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\xbmc\win32\pch.h">
@@ -6079,6 +6082,9 @@
     </ClInclude>
     <ClInclude Include="..\..\xbmc\settings\dialogs\GUIDialogAudioDSPSettings.h">
       <Filter>settings\dialogs</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\addons\AddonCallbacksInterfaces.h">
+      <Filter>addons</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/xbmc/addons/AddonCallbacks.cpp
+++ b/xbmc/addons/AddonCallbacks.cpp
@@ -22,6 +22,7 @@
 #include "AddonCallbacks.h"
 #include "AddonCallbacksAddon.h"
 #include "AddonCallbacksAudioDSP.h"
+#include "AddonCallbacksInterfaces.h"
 #include "AddonCallbacksCodec.h"
 #include "AddonCallbacksGUI.h"
 #include "AddonCallbacksPVR.h"
@@ -33,26 +34,29 @@ namespace ADDON
 
 CAddonCallbacks::CAddonCallbacks(CAddon* addon)
 {
-  m_addon       = addon;
-  m_callbacks   = new AddonCB;
-  m_helperAddon = NULL;
-  m_helperADSP  = NULL;
-  m_helperGUI   = NULL;
-  m_helperPVR   = NULL;
-  m_helperCODEC = NULL;
+  m_addon             = addon;
+  m_callbacks         = new AddonCB;
+  m_helperAddon       = NULL;
+  m_helperADSP        = NULL;
+  m_helperInterfaces  = NULL;
+  m_helperGUI         = NULL;
+  m_helperPVR         = NULL;
+  m_helperCODEC       = NULL;
 
-  m_callbacks->libBasePath           = strdup(CSpecialProtocol::TranslatePath("special://xbmcbin/addons").c_str());
-  m_callbacks->addonData             = this;
-  m_callbacks->AddOnLib_RegisterMe   = CAddonCallbacks::AddOnLib_RegisterMe;
-  m_callbacks->AddOnLib_UnRegisterMe = CAddonCallbacks::AddOnLib_UnRegisterMe;
-  m_callbacks->ADSPLib_RegisterMe    = CAddonCallbacks::ADSPLib_RegisterMe;
-  m_callbacks->ADSPLib_UnRegisterMe  = CAddonCallbacks::ADSPLib_UnRegisterMe;
-  m_callbacks->CODECLib_RegisterMe   = CAddonCallbacks::CODECLib_RegisterMe;
-  m_callbacks->CODECLib_UnRegisterMe = CAddonCallbacks::CODECLib_UnRegisterMe;
-  m_callbacks->GUILib_RegisterMe     = CAddonCallbacks::GUILib_RegisterMe;
-  m_callbacks->GUILib_UnRegisterMe   = CAddonCallbacks::GUILib_UnRegisterMe;
-  m_callbacks->PVRLib_RegisterMe     = CAddonCallbacks::PVRLib_RegisterMe;
-  m_callbacks->PVRLib_UnRegisterMe   = CAddonCallbacks::PVRLib_UnRegisterMe;
+  m_callbacks->libBasePath                  = strdup(CSpecialProtocol::TranslatePath("special://xbmcbin/addons").c_str());
+  m_callbacks->addonData                    = this;
+  m_callbacks->AddOnLib_RegisterMe          = CAddonCallbacks::AddOnLib_RegisterMe;
+  m_callbacks->AddOnLib_UnRegisterMe        = CAddonCallbacks::AddOnLib_UnRegisterMe;
+  m_callbacks->ADSPLib_RegisterMe           = CAddonCallbacks::ADSPLib_RegisterMe;
+  m_callbacks->ADSPLib_UnRegisterMe         = CAddonCallbacks::ADSPLib_UnRegisterMe;
+  m_callbacks->InterfacesLib_RegisterMe     = CAddonCallbacks::InterfacesLib_RegisterMe;
+  m_callbacks->InterfacesLib_UnRegisterMe   = CAddonCallbacks::InterfacesLib_UnRegisterMe;
+  m_callbacks->CODECLib_RegisterMe          = CAddonCallbacks::CODECLib_RegisterMe;
+  m_callbacks->CODECLib_UnRegisterMe        = CAddonCallbacks::CODECLib_UnRegisterMe;
+  m_callbacks->GUILib_RegisterMe            = CAddonCallbacks::GUILib_RegisterMe;
+  m_callbacks->GUILib_UnRegisterMe          = CAddonCallbacks::GUILib_UnRegisterMe;
+  m_callbacks->PVRLib_RegisterMe            = CAddonCallbacks::PVRLib_RegisterMe;
+  m_callbacks->PVRLib_UnRegisterMe          = CAddonCallbacks::PVRLib_UnRegisterMe;
 }
 
 CAddonCallbacks::~CAddonCallbacks()
@@ -61,6 +65,8 @@ CAddonCallbacks::~CAddonCallbacks()
   m_helperAddon = NULL;
   delete m_helperADSP;
   m_helperADSP = NULL;
+  delete m_helperInterfaces;
+  m_helperInterfaces = NULL;
   delete m_helperCODEC;
   m_helperCODEC = NULL;
   delete m_helperGUI;
@@ -123,6 +129,34 @@ void CAddonCallbacks::ADSPLib_UnRegisterMe(void *addonData, CB_ADSPLib *cbTable)
   delete addon->m_helperADSP;
   addon->m_helperADSP = NULL;
 }
+
+
+CB_InterfacesLib* CAddonCallbacks::InterfacesLib_RegisterMe(void *addonData)
+{
+  CAddonCallbacks* addon = (CAddonCallbacks*) addonData;
+  if(addon == NULL)
+  {
+    CLog::Log(LOGERROR, "CAddonCallbacks - %s - called with a null pointer", __FUNCTION__);
+    return NULL;
+  }
+
+  addon->m_helperInterfaces = new CAddonCallbacksInterfaces(addon->m_addon);
+  return addon->m_helperInterfaces->GetCallbacks();
+}
+
+void CAddonCallbacks::InterfacesLib_UnRegisterMe(void *addonData, CB_InterfacesLib *cbTable)
+{
+  CAddonCallbacks* addon = (CAddonCallbacks*) addonData;
+  if(addon == NULL)
+  {
+    CLog::Log(LOGERROR, "CAddonCallbacks - %s - called with a null pointer", __FUNCTION__);
+    return;
+  }
+
+  delete addon->m_helperInterfaces;
+  addon->m_helperInterfaces = NULL;
+}
+
 
 CB_CODECLib* CAddonCallbacks::CODECLib_RegisterMe(void *addonData)
 {

--- a/xbmc/addons/AddonCallbacksInterfaces.cpp
+++ b/xbmc/addons/AddonCallbacksInterfaces.cpp
@@ -1,0 +1,125 @@
+/*
+ *      Copyright (C) 2014 Team KODI
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "AddonCallbacksInterfaces.h"
+#include "addons/AddonManager.h"
+#include "utils/log.h"
+#include "include/kodi_interfaces_types.h"
+#include "xbmc/interfaces/generic/ScriptInvocationManager.h"
+#include "xbmc/interfaces/python/XBPython.h"
+#include <vector>
+#include <string>
+
+using namespace std;
+
+namespace ADDON
+{
+
+CAddonCallbacksInterfaces::CAddonCallbacksInterfaces(CAddon* addon)
+{
+  m_addon     = addon;
+  m_callbacks = new CB_InterfacesLib;
+
+  // write KODI audio DSP specific add-on function addresses to callback table
+  m_callbacks->ExecuteScriptSync            = ExecuteScriptSync;
+  m_callbacks->ExecuteScriptAsync           = ExecuteScriptAsync;
+  m_callbacks->GetPythonInterpreter         = GetPythonInterpreter;
+  m_callbacks->ActivatePythonInterpreter    = ActivatePythonInterpreter;
+  m_callbacks->DeactivatePythonInterpreter  = DeactivatePythonInterpreter;
+}
+
+CAddonCallbacksInterfaces::~CAddonCallbacksInterfaces()
+{
+  /* delete the callback table */
+  delete m_callbacks;
+}
+
+int CAddonCallbacksInterfaces::ExecuteScriptSync(void *AddonData, const char *AddonName, const char *Script, const char **Arguments, uint32_t TimeoutMs, bool WaitShutdown)
+{
+  if(!AddonName || !Script)
+  {
+    CLog::Log(LOGERROR, "%s: Invalid input! AddonData, AddonName or Script is a NULL pointer!", __FUNCTION__);
+    return -1;
+  }
+
+  ADDON::AddonPtr addon;
+  if(!CAddonMgr::Get().GetAddon(AddonName, addon, ADDON_UNKNOWN))
+  {
+    CLog::Log(LOGERROR, "%s: Invalid input! Addon: %s not found!", __FUNCTION__, AddonName);
+    return -1;
+  }
+
+  vector<string> arguments;
+  if(Arguments)
+  {
+    for(unsigned int arg = 0; Arguments[arg]; arg++)
+    {
+      arguments.push_back(Arguments[arg]);
+    }
+  }
+
+  //return CScriptInvocationManager::Get().ExecuteSync(Script, ADDON::AddonPtr((ADDON::IAddon*)((AddonCB*)AddonData)->addonData), arguments, TimeoutMs, WaitShutdown);
+  return CScriptInvocationManager::Get().ExecuteSync(Script, addon, arguments, TimeoutMs, WaitShutdown);
+}
+
+int CAddonCallbacksInterfaces::ExecuteScriptAsync(void *AddonData, const char *AddonName, const char *Script, const char **Arguments)
+{
+  if(!AddonData || !AddonName || !Script)
+  {
+    CLog::Log(LOGERROR, "%s: Invalid input! AddonData, AddonName or Script is a NULL pointer!", __FUNCTION__);
+    return -1;
+  }
+
+  ADDON::AddonPtr addon;
+  if(!CAddonMgr::Get().GetAddon(AddonName, addon, ADDON_UNKNOWN))
+  {
+    CLog::Log(LOGERROR, "%s: Invalid input! Addon: %s not found!", __FUNCTION__, AddonName);
+    return -1;
+  }
+
+  vector<string> arguments;
+  if(Arguments)
+  {
+    for(unsigned int arg = 0; Arguments[arg]; arg++)
+    {
+      arguments.push_back(Arguments[arg]);
+    }
+  }
+
+  //return CScriptInvocationManager::Get().ExecuteAsync(Script, ADDON::AddonPtr((ADDON::IAddon*)((AddonCB*)AddonData)->addonData), arguments);
+  return CScriptInvocationManager::Get().ExecuteAsync(Script, addon, arguments);
+}
+
+int CAddonCallbacksInterfaces::GetPythonInterpreter(void *AddonData)
+{
+  return g_pythonParser.GetAddonInterpreter();
+}
+
+bool CAddonCallbacksInterfaces::ActivatePythonInterpreter(void *AddonData, int InterpreterId)
+{
+  return g_pythonParser.ActiveAddonInterpreter(InterpreterId);
+}
+
+bool CAddonCallbacksInterfaces::DeactivatePythonInterpreter(void *AddonData, int InterpreterId)
+{
+  return g_pythonParser.DeactiveAddonInterpreter(InterpreterId);
+}
+
+}; /* namespace ADDON */

--- a/xbmc/addons/AddonCallbacksInterfaces.h
+++ b/xbmc/addons/AddonCallbacksInterfaces.h
@@ -1,0 +1,79 @@
+#pragma once
+/*
+ *      Copyright (C) 2014 Team KODI
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "AddonCallbacks.h"
+#include "include/kodi_interfaces_types.h"
+
+namespace ADDON
+{
+
+/*!
+ * Callbacks for Kodi's AudioEngine.
+ */
+class CAddonCallbacksInterfaces
+{
+public:
+  CAddonCallbacksInterfaces(CAddon* Addon);
+  ~CAddonCallbacksInterfaces();
+
+  /*!
+   * @return The callback table.
+   */
+  CB_InterfacesLib *GetCallbacks() { return m_callbacks; }
+
+  /*!
+   * \brief Executes the given script asynchronously in a separate thread.
+   *
+   * \param script Path to the script to be executed
+   * \param addon (Optional) Addon to which the script belongs
+   * \param arguments (Optional) List of arguments passed to the script
+   * \return -1 if an error occurred, otherwise the ID of the script
+   */
+  static int ExecuteScriptSync(void *AddonData, const char *AddonName, const char *Script, const char **Arguments, uint32_t TimeoutMs, bool WaitShutdown);
+
+  /*!
+   * \brief Executes the given script synchronously.
+   *
+   * \details The script is actually executed asynchronously but the calling
+   * thread is blocked until either the script has finished or the given timeout
+   * has expired. If the given timeout has expired the script's execution is
+   * stopped and depending on the specified wait behaviour we wait for the
+   * script's execution to finish or not.
+   *
+   * \param script Path to the script to be executed
+   * \param addon (Optional) Addon to which the script belongs
+   * \param arguments (Optional) List of arguments passed to the script
+   * \param timeout (Optional) Timeout (in milliseconds) for the script's execution
+   * \param waitShutdown (Optional) Whether to wait when having to forcefully stop the script's execution or not.
+   * \return -1 if an error occurred, 0 if the script terminated or ETIMEDOUT if the given timeout expired
+   */
+  static int ExecuteScriptAsync(void *AddonData, const char *AddonName, const char *Script, const char **Arguments);
+
+  static int GetPythonInterpreter(void *AddonData);
+  static bool ActivatePythonInterpreter(void *AddonData, int InterpreterId);
+  static bool DeactivatePythonInterpreter(void *AddonData, int InterpreterId);
+
+private:
+  CB_InterfacesLib    *m_callbacks; /*!< callback addresses */
+  CAddon              *m_addon;     /*!< the addon */
+};
+
+}; /* namespace ADDON */

--- a/xbmc/addons/include/kodi_interfaces_types.h
+++ b/xbmc/addons/include/kodi_interfaces_types.h
@@ -1,0 +1,72 @@
+/*
+ *      Copyright (C) 2005-2015 Team KODI
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/*!
+ * Common data structures shared between KODI and KODI's binary add-ons
+ */
+
+#ifndef __INTERFACES_TYPES_H__
+#define __INTERFACES_TYPES_H__
+
+#ifdef TARGET_WINDOWS
+#include <windows.h>
+#else
+#ifndef __cdecl
+#define __cdecl
+#endif
+#ifndef __declspec
+#define __declspec(X)
+#endif
+#endif
+
+#include <cstddef>
+
+#undef ATTRIBUTE_PACKED
+#undef PRAGMA_PACK_BEGIN
+#undef PRAGMA_PACK_END
+
+#if defined(__GNUC__)
+#if __GNUC__ > 2 || (__GNUC__ == 2 && __GNUC_MINOR__ >= 95)
+#define ATTRIBUTE_PACKED __attribute__ ((packed))
+#define PRAGMA_PACK 0
+#endif
+#endif
+
+#if !defined(ATTRIBUTE_PACKED)
+#define ATTRIBUTE_PACKED
+#define PRAGMA_PACK 1
+#endif
+
+/* current Interfacese API version */
+#define KODI_INTERFACES_API_VERSION                 "0.0.1"
+
+/* min. Interfaces API version */
+#define KODI_INTERFACES_MIN_API_VERSION             "0.0.1"
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //__INTERFACES_TYPES_H__

--- a/xbmc/interfaces/generic/ScriptInvocationManager.cpp
+++ b/xbmc/interfaces/generic/ScriptInvocationManager.cpp
@@ -232,9 +232,7 @@ int CScriptInvocationManager::ExecuteAsync(const std::string &script, LanguageIn
   if (addon != NULL)
     invokerThread->SetAddon(addon);
 
-  CSingleLock lock(m_critSection);
-  invokerThread->SetId(m_nextId++);
-  lock.Leave();
+  invokerThread->SetId(GetNextScriptId());
 
   LanguageInvokerThread thread = { invokerThread, script, false };
   m_scripts.insert(make_pair(invokerThread->GetId(), thread));
@@ -333,6 +331,20 @@ bool CScriptInvocationManager::IsRunning(const std::string& scriptPath) const
   return IsRunning(it->second);
 }
 
+int CScriptInvocationManager::GetNextScriptId()
+{
+  CSingleLock lock(m_critSection);
+  int returnId = m_nextId++;
+  // only script IDs >= 0 are valid
+  if(m_nextId < 0)
+  {
+    m_nextId = 0;
+  }
+
+  lock.Leave();
+
+  return returnId;
+}
 void CScriptInvocationManager::OnScriptEnded(int scriptId)
 {
   if (scriptId < 0)

--- a/xbmc/interfaces/generic/ScriptInvocationManager.h
+++ b/xbmc/interfaces/generic/ScriptInvocationManager.h
@@ -104,6 +104,7 @@ public:
 
   bool IsRunning(int scriptId) const;
   bool IsRunning(const std::string& scriptPath) const;
+  int GetNextScriptId();
 
 protected:
   friend class CLanguageInvokerThread;

--- a/xbmc/interfaces/python/XBPython.h
+++ b/xbmc/interfaces/python/XBPython.h
@@ -26,6 +26,8 @@
 #include "threads/Thread.h"
 #include "interfaces/IAnnouncer.h"
 #include "interfaces/generic/ILanguageInvocationHandler.h"
+#include "addons/IAddon.h"
+#include <Python.h>
 
 #include <memory>
 #include <vector>
@@ -33,11 +35,21 @@
 class CPythonInvoker;
 class CVariant;
 
-typedef struct {
+typedef struct PyElem
+{
   int id;
   bool bDone;
-  CPythonInvoker* pyThread;
-}PyElem;
+  CPythonInvoker *pyThread;
+  PyThreadState  *addonPythonState; // this pointer is only used by binary add-ons to controll a full python interpreter
+
+  PyElem()
+  {
+    id = 0;
+    bDone = false;
+    pyThread = NULL;
+    addonPythonState = NULL;
+  };
+} PyElem;
 
 class LibraryLoader;
 
@@ -107,7 +119,21 @@ public:
   void UnregisterExtensionLib(LibraryLoader *pLib);
   void UnloadExtensionLibs();
 
+  // ------------------------------------------------------------------
+  //               Python Addon Interpreter methods
+  // ------------------------------------------------------------------
+  /**
+   * This method tries to get a new Python interpreter thread state, which can be used by dynamic linking to Python.dll.
+   * @return a new ScriptId.
+   */
+  int  GetAddonInterpreter();
+  bool DestroyAddonInterpreter(int Id);
+  bool ActiveAddonInterpreter(int Id);
+  bool DeactiveAddonInterpreter(int Id);
+  bool FinishAddonInterpreter(int Id);
+
 private:
+  bool InitInterpreter();
   void Finalize();
 
   CCriticalSection    m_critSection;


### PR DESCRIPTION
@Paxxi @fritsch @FernetMenta @jimfcarroll 
This new helper library adds python support to the binary add-ons. You can ignore the functions that directly tries to access our Python interpreter. In the final commit I will remove them, because I don't need them. It was only for a test.
