### PR TITLE
Change some Lirc mappings from 'mytv' to 'livetv'

### DIFF
--- a/system/Lircmap.xml
+++ b/system/Lircmap.xml
@@ -456,7 +456,7 @@
 		<mypictures>KEY_CAMERA</mypictures>
 		<mytv>KEY_TV</mytv>
 		<liveradio>KEY_RADIO</liveradio>
-		<mytv>KEY_TUNER</mytv>
+		<livetv>KEY_TUNER</livetv>
 		<one>KEY_1</one>
 		<two>KEY_2</two>
 		<three>KEY_3</three>
@@ -574,7 +574,7 @@
 		<myvideo>KEY_VIDEO</myvideo>
 		<mymusic>KEY_AUDIO</mymusic>
 		<mypictures>KEY_CAMERA</mypictures>
-		<mytv>KEY_TUNER</mytv>
+		<livetv>KEY_TUNER</livetv>
 		<mytv>KEY_TV</mytv>
 		<teletext>KEY_TEXT</teletext>
 		<one>KEY_NUMERIC_1</one>

--- a/system/Lircmap.xml
+++ b/system/Lircmap.xml
@@ -86,7 +86,7 @@
 		<power>KEY_POWER</power>
 		<myvideo>KEY_VIDEO</myvideo>
 		<mymusic>KEY_AUDIO</mymusic>
-		<mytv>LiveTV</mytv>
+		<livetv>LiveTV</livetv>
 		<guide>KEY_EPG</guide>
 		<one>KEY_1</one>
 		<two>KEY_2</two>


### PR DESCRIPTION
It looks like there may be other entries which also need changing. With my equipment I was only able to test a devinput device on OpenELEC with the following in .kodi/userdata/Lircmap.xml.

```
<lircmap>
    <remote device="devinput">
        <livetv>KEY_TUNER</livetv>
    </remote>
</lircmap>
```
