### PR TITLE
[Addons] Addon Browser->User Addons->All: Prefix addon name with addon type.

### DIFF
--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -494,8 +494,10 @@ void CAddonsDirectory::GenerateAddonListing(const CURL &path,
   for (const auto& addon : addons)
   {
     CURL itemPath = path;
+    // For lists containing items from mixed categories, prefix addon name with type for better readability.
+    bool addTypeToLabel = path.GetFileName() == "all" || path.GetHostName() == "search";
     itemPath.SetFileName(addon->ID());
-    CFileItemPtr pItem = FileItemFromAddon(addon, itemPath.Get(), false);
+    CFileItemPtr pItem = FileItemFromAddon(addon, itemPath.Get(), false, addTypeToLabel);
 
     AddonPtr installedAddon;
     if (CAddonMgr::Get().GetAddon(addon->ID(), installedAddon))
@@ -517,16 +519,19 @@ void CAddonsDirectory::GenerateAddonListing(const CURL &path,
   }
 }
 
-CFileItemPtr CAddonsDirectory::FileItemFromAddon(const AddonPtr &addon, const std::string& path, bool folder)
+CFileItemPtr CAddonsDirectory::FileItemFromAddon(const AddonPtr &addon, const std::string& path, bool folder /* = false */, bool addTypeToLabel /* = false */)
 {
   if (!addon)
     return CFileItemPtr();
 
   CFileItemPtr item(new CFileItem(path, folder));
 
-  std::string strLabel(addon->Name());
-  if (CURL(path).GetHostName() == "search")
+  std::string strLabel;
+  if (addTypeToLabel)
     strLabel = StringUtils::Format("%s - %s", TranslateType(addon->Type(), true).c_str(), addon->Name().c_str());
+  else
+    strLabel = addon->Name();
+
   item->SetLabel(strLabel);
   item->SetArt("thumb", addon->Icon());
   item->SetLabelPreformated(true);

--- a/xbmc/filesystem/AddonsDirectory.h
+++ b/xbmc/filesystem/AddonsDirectory.h
@@ -63,7 +63,7 @@ namespace XFILE
     static CFileItemPtr GetMoreItem(const std::string &content);
 
     static void GenerateAddonListing(const CURL &path, const ADDON::VECADDONS& addons, CFileItemList &items, const std::string label);
-    static CFileItemPtr FileItemFromAddon(const ADDON::AddonPtr &addon, const std::string& path, bool folder = false);
+    static CFileItemPtr FileItemFromAddon(const ADDON::AddonPtr &addon, const std::string& path, bool folder = false, bool addTypeToLabel = false);
   
     /*! \brief Returns true if `path` is a path or subpath of the repository directory, otherwise false */
     static bool IsRepoDirectory(const CURL& path);


### PR DESCRIPTION
I thought, prefixing items in "User Addons"->"All" with the addon type, like it is already done with items in "Search", could be a good idea to improve usability. ;-)

Example: Instead of
- Dim
- English 
- German

you now get
- Language Pack - English 
- Language Pack - German
- Screen Saver - Dim

@da-anda something for you?
