### PR TITLE
do not access m_pVideoCodec from dvdplayer thread

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/AMLCodec.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/AMLCodec.cpp
@@ -1867,9 +1867,7 @@ int CAMLCodec::Decode(uint8_t *pData, size_t iSize, double dts, double pts)
   if (m_old_pictcnt == m_cur_pictcnt)
     m_ready_event.WaitMSec(25);
 
-  // we must return VC_BUFFER or VC_PICTURE,
-  // default to VC_BUFFER.
-  int rtn = VC_BUFFER;
+  int rtn = 0;
   if (m_old_pictcnt != m_cur_pictcnt)
   {
     m_old_pictcnt++;

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodec.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodec.h
@@ -244,22 +244,6 @@ public:
    */
   virtual void SetSpeed(int iSpeed) {};
 
-  /*
-   * returns the number of demuxer bytes in any internal buffers
-   */
-  virtual int GetDataSize(void)
-  {
-    return 0;
-  }
-
-  /*
-   * returns the time in seconds for demuxer bytes in any internal buffers
-   */
-  virtual double GetTimeSize(void)
-  {
-    return 0;
-  }
-
   enum EFilterFlags {
     FILTER_NONE                =  0x0,
     FILTER_DEINTERLACE_YADIF   =  0x1,  /* use first deinterlace mode */

--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
@@ -809,34 +809,6 @@ void CDVDPlayerVideo::Flush()
   m_messageQueue.Put(new CDVDMsg(CDVDMsg::GENERAL_FLUSH), 1);
 }
 
-int CDVDPlayerVideo::GetLevel() const
-{
-  int level = m_messageQueue.GetLevel();
-
-  // fast exit, if the message queue is full, we do not care about the codec queue.
-  if (level == 100)
-    return level;
-
-  // Now for the harder choices, the message queue could be time or size based.
-  // In order to return the proper summed level, we need to know which.
-  if (m_messageQueue.IsDataBased())
-  {
-    int datasize = m_messageQueue.GetDataSize();
-    if (m_pVideoCodec)
-      datasize += m_pVideoCodec->GetDataSize();
-    return min(100, MathUtils::round_int((100.0 * datasize) / m_messageQueue.GetMaxDataSize()));
-  }
-  else
-  {
-    double timesize = m_messageQueue.GetTimeSize();
-    if (m_pVideoCodec)
-      timesize += m_pVideoCodec->GetTimeSize();
-    return min(100, MathUtils::round_int(100.0 * m_messageQueue.GetMaxTimeSize() * timesize));
-  }
-
-  return level;
-}
-
 #ifdef HAS_VIDEO_PLAYBACK
 void CDVDPlayerVideo::ProcessOverlays(DVDVideoPicture* pSource, double pts)
 {

--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.h
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.h
@@ -74,7 +74,7 @@ public:
   void WaitForBuffers()                             { m_messageQueue.WaitUntilEmpty(); }
   bool AcceptsData() const                          { return !m_messageQueue.IsFull(); }
   bool HasData() const                              { return m_messageQueue.GetDataSize() > 0; }
-  int  GetLevel() const;
+  int  GetLevel() const                             { return m_messageQueue.GetLevel(); }
   bool IsInited() const                             { return m_messageQueue.IsInited(); }
   void SendMessage(CDVDMsg* pMsg, int priority = 0) { m_messageQueue.Put(pMsg, priority); }
   void FlushMessages()                              { m_messageQueue.Flush(); }


### PR DESCRIPTION
This fixes access violations from time to time when switching channels using DMX_STREAM_CHANGE packets. This also aligns the CDVDPlayerVideo implementation with CDVDPlayerAudio.

Adding the backport label, @FernetMenta please remove if in your opinion this is too uncertain.
