### PR TITLE
dvdplayer - dispose ffmpeg hw decoder prior to opening a new one

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -353,7 +353,6 @@ void CDVDVideoCodecFFmpeg::Dispose()
     m_pCodecContext = NULL;
   }
   SAFE_RELEASE(m_pHardware);
-  DisposeHWDecoders();
 
   FilterClose();
 }
@@ -572,8 +571,6 @@ int CDVDVideoCodecFFmpeg::Decode(uint8_t* pData, int iSize, double dts, double p
 
   if(result & VC_FLUSHED)
     Reset();
-
-  DisposeHWDecoders();
 
   return result;
 }
@@ -919,17 +916,7 @@ void CDVDVideoCodecFFmpeg::SetCodecControl(int flags)
 
 void CDVDVideoCodecFFmpeg::SetHardware(IHardwareDecoder* hardware)
 {
-  if (m_pHardware)
-    m_disposeDecoders.push_back(m_pHardware);
+  SAFE_RELEASE(m_pHardware);
   m_pHardware = hardware;
   UpdateName();
-}
-
-void CDVDVideoCodecFFmpeg::DisposeHWDecoders()
-{
-  while (!m_disposeDecoders.empty())
-  {
-    m_disposeDecoders.back()->Release();
-    m_disposeDecoders.pop_back();
-  }
 }

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -97,6 +97,15 @@ enum PixelFormat CDVDVideoCodecFFmpeg::GetFormat( struct AVCodecContext * avctx
     return avcodec_default_get_format(avctx, fmt);
   }
 
+  // hardware decoder de-selected, restore standard ffmpeg
+  if (ctx->GetHardware())
+  {
+    ctx->SetHardware(NULL);
+    avctx->get_buffer2 = avcodec_default_get_buffer2;
+    avctx->slice_flags = 0;
+    avctx->hwaccel_context = 0;
+  }
+
   const PixelFormat * cur = fmt;
   while(*cur != PIX_FMT_NONE)
   {
@@ -157,15 +166,6 @@ enum PixelFormat CDVDVideoCodecFFmpeg::GetFormat( struct AVCodecContext * avctx
     }
 #endif
     cur++;
-  }
-
-  // hardware decoder de-selected, restore standard ffmpeg
-  if (ctx->GetHardware())
-  {
-    ctx->SetHardware(NULL);
-    avctx->get_buffer2     = avcodec_default_get_buffer2;
-    avctx->slice_flags     = 0;
-    avctx->hwaccel_context = 0;
   }
 
   ctx->m_decoderState = STATE_HW_FAILED;

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.h
@@ -82,7 +82,6 @@ protected:
   int  FilterOpen(const std::string& filters, bool scale);
   void FilterClose();
   int  FilterProcess(AVFrame* frame);
-  void DisposeHWDecoders();
 
   void UpdateName()
   {
@@ -117,7 +116,6 @@ protected:
   std::string m_name;
   int m_decoderState;
   IHardwareDecoder *m_pHardware;
-  std::vector<IHardwareDecoder*> m_disposeDecoders;
   int m_iLastKeyframe;
   double m_dts;
   bool   m_started;


### PR DESCRIPTION
@Memphiz this should fix the single codec issue reported in http://trac.kodi.tv/ticket/14978
