### PR TITLE
[PVR] Replace startTime=endTime=0 with bAnyTime boolean for Timers

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -3424,10 +3424,10 @@ msgctxt "#809"
 msgid "Any channel"
 msgstr ""
 
-#. Label of "Any time" radio button in PVR timer settings dialog
+#. Label of "Start any time" radio button in PVR timer settings dialog
 #: xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
 msgctxt "#810"
-msgid "Any time"
+msgid "Start any time"
 msgstr ""
 
 # Label of "Recording group" list in the PVR timer setting dialog
@@ -3468,7 +3468,13 @@ msgctxt "#816"
 msgid "Record only new episodes"
 msgstr ""
 
-#empty strings from id 817 to 819
+#. Label of "End any time" radio button in PVR timer settings dialog
+#: xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+msgctxt "#817"
+msgid "End any time"
+msgstr ""
+
+#empty strings from id 818 to 819
 
 #. Representation of a one-time timer.
 #: xbmc/pvr/addons/PVRClient.cpp

--- a/addons/xbmc.pvr/addon.xml
+++ b/addons/xbmc.pvr/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="xbmc.pvr" version="2.1.0" provider-name="Team-Kodi">
-  <backwards-compatibility abi="2.1.0"/>
+<addon id="xbmc.pvr" version="3.0.0" provider-name="Team-Kodi">
+  <backwards-compatibility abi="3.0.0"/>
   <requires>
     <import addon="xbmc.core" version="0.1.0"/>
   </requires>

--- a/xbmc/addons/include/xbmc_pvr_types.h
+++ b/xbmc/addons/include/xbmc_pvr_types.h
@@ -114,7 +114,7 @@ extern "C" {
 
   const unsigned int PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE           = 0x00000010; /*!< @brief this type supports enabling/disabling of the timer (PVR_TIMER.state SCHEDULED|DISBALED) */
   const unsigned int PVR_TIMER_TYPE_SUPPORTS_CHANNELS                 = 0x00000020; /*!< @brief this type supports channels (PVR_TIMER.iClientChannelUid) */
-  const unsigned int PVR_TIMER_TYPE_SUPPORTS_START_END_TIME           = 0x00000040; /*!< @brief this type supports start and end time (PVR_TIMER.startTime, PVR_TIMER.endTime) */
+  const unsigned int PVR_TIMER_TYPE_SUPPORTS_START_TIME               = 0x00000040; /*!< @brief this type supports a recording start time (PVR_TIMER.startTime) */
   const unsigned int PVR_TIMER_TYPE_SUPPORTS_TITLE_EPG_MATCH          = 0x00000080; /*!< @brief this type supports matching epg episode title using PVR_TIMER.strEpgSearchString */
   const unsigned int PVR_TIMER_TYPE_SUPPORTS_FULLTEXT_EPG_MATCH       = 0x00000100; /*!< @brief this type supports matching "more" epg data (not just episode title) using PVR_TIMER.strEpgSearchString. Setting FULLTEXT_EPG_MATCH implies TITLE_EPG_MATCH */
   const unsigned int PVR_TIMER_TYPE_SUPPORTS_FIRST_DAY                = 0x00000200; /*!< @brief this type supports a first day the timer gets active (PVR_TIMER.firstday) */
@@ -125,6 +125,9 @@ extern "C" {
   const unsigned int PVR_TIMER_TYPE_SUPPORTS_LIFETIME                 = 0x00004000; /*!< @brief this type supports recording lifetime (PVR_TIMER.iLifetime) */
   const unsigned int PVR_TIMER_TYPE_SUPPORTS_RECORDING_FOLDERS        = 0x00008000; /*!< @brief this type supports placing recordings in user defined folders (PVR_TIMER.strDirectory) */
   const unsigned int PVR_TIMER_TYPE_SUPPORTS_RECORDING_GROUP          = 0x00010000; /*!> @brief this type supports a list of recording groups (PVR_TIMER.iRecordingGroup) */
+  const unsigned int PVR_TIMER_TYPE_SUPPORTS_END_TIME                 = 0x00020000; /*!< @brief this type supports a recording end time (PVR_TIMER.endTime) */
+  const unsigned int PVR_TIMER_TYPE_SUPPORTS_START_ANYTIME            = 0x00040000; /*!< @brief enables an 'Any Time' over-ride option for startTime (using PVR_TIMER.bStartAnyTime) */
+  const unsigned int PVR_TIMER_TYPE_SUPPORTS_END_ANYTIME              = 0x00080000; /*!< @brief enables a separate 'Any Time' over-ride for endTime (using PVR_TIMER.bEndAnyTime) */
 
   /*!
    * @brief PVR timer weekdays (PVR_TIMER.iWeekdays values)
@@ -376,8 +379,10 @@ extern "C" {
     unsigned int    iParentClientIndex;                        /*!< @brief (optional) for timers scheduled by a repeating timer, the index of the repeating timer that scheduled this timer (it's PVR_TIMER.iClientIndex value). Use PVR_TIMER_NO_PARENT
                                                                     to indicate that this timer was no scheduled by a repeating timer. */
     int             iClientChannelUid;                         /*!< @brief (optional) unique identifier of the channel to record on. PVR_TIMER_ANY_CHANNEL will denote "any channel", not a specifoc one. */
-    time_t          startTime;                                 /*!< @brief (optional) start time of the recording in UTC. Instant timers that are sent to the add-on by Kodi will have this value set to 0. For repeatimg timers, 0 will indicate "any" time. */
-    time_t          endTime;                                   /*!< @brief (optional) end time of the recording in UTC. For repeating timers, 0 will indicate "any" time. */
+    time_t          startTime;                                 /*!< @brief (optional) start time of the recording in UTC. Instant timers that are sent to the add-on by Kodi will have this value set to 0.*/
+    time_t          endTime;                                   /*!< @brief (optional) end time of the recording in UTC. */
+    bool            bStartAnyTime;                             /*!< @brief (optional) for EPG based (not Manual) timers indicates startTime does not apply. Default = false */
+    bool            bEndAnyTime;                               /*!< @brief (optional) for EPG based (not Manual) timers indicates endTime does not apply. Default = false */
     PVR_TIMER_STATE state;                                     /*!< @brief (required) the state of this timer */
     unsigned int    iTimerType;                                /*!< @brief (required) the type of this timer. It is private to the addon and can be freely defined by the addon. The value must be greater than PVR_TIMER_TYPE_NONE.
                                                                     Kodi does not interpret this value (except for checking for PVR_TIMER_TYPE_NONE), but will pass the right id to the addon with every PVR_TIMER instance, thus the addon easily can determine

--- a/xbmc/addons/include/xbmc_pvr_types.h
+++ b/xbmc/addons/include/xbmc_pvr_types.h
@@ -78,10 +78,10 @@ struct DemuxPacket;
 #define PVR_STREAM_MAX_STREAMS 20
 
 /* current PVR API version */
-#define XBMC_PVR_API_VERSION "2.1.0"
+#define XBMC_PVR_API_VERSION "3.0.0"
 
 /* min. PVR API version */
-#define XBMC_PVR_MIN_API_VERSION "2.1.0"
+#define XBMC_PVR_MIN_API_VERSION "3.0.0"
 
 #ifdef __cplusplus
 extern "C" {

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -443,7 +443,7 @@ bool CPVRClient::GetAddonProperties(void)
         types_array[size].iAttributes = PVR_TIMER_TYPE_IS_MANUAL               |
                                         PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE |
                                         PVR_TIMER_TYPE_SUPPORTS_CHANNELS       |
-                                        PVR_TIMER_TYPE_SUPPORTS_START_END_TIME |
+                                        PVR_TIMER_TYPE_SUPPORTS_START_TIME     |
                                         PVR_TIMER_TYPE_SUPPORTS_PRIORITY       |
                                         PVR_TIMER_TYPE_SUPPORTS_LIFETIME       |
                                         PVR_TIMER_TYPE_SUPPORTS_RECORDING_FOLDERS;
@@ -456,7 +456,7 @@ bool CPVRClient::GetAddonProperties(void)
                                         PVR_TIMER_TYPE_IS_REPEATING            |
                                         PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE |
                                         PVR_TIMER_TYPE_SUPPORTS_CHANNELS       |
-                                        PVR_TIMER_TYPE_SUPPORTS_START_END_TIME |
+                                        PVR_TIMER_TYPE_SUPPORTS_START_TIME     |
                                         PVR_TIMER_TYPE_SUPPORTS_PRIORITY       |
                                         PVR_TIMER_TYPE_SUPPORTS_LIFETIME       |
                                         PVR_TIMER_TYPE_SUPPORTS_FIRST_DAY      |
@@ -471,7 +471,7 @@ bool CPVRClient::GetAddonProperties(void)
           types_array[size].iId         = size + 1;
           types_array[size].iAttributes = PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE |
                                           PVR_TIMER_TYPE_SUPPORTS_CHANNELS       |
-                                          PVR_TIMER_TYPE_SUPPORTS_START_END_TIME |
+                                          PVR_TIMER_TYPE_SUPPORTS_START_TIME     |
                                           PVR_TIMER_TYPE_SUPPORTS_PRIORITY       |
                                           PVR_TIMER_TYPE_SUPPORTS_LIFETIME       |
                                           PVR_TIMER_TYPE_SUPPORTS_RECORDING_FOLDERS;

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -302,6 +302,8 @@ void CPVRClient::WriteClientTimerInfo(const CPVRTimerInfoTag &xbmcTimer, PVR_TIM
   addonTimer.iWeekdays                 = xbmcTimer.m_iWeekdays;
   addonTimer.startTime                 = start - g_advancedSettings.m_iPVRTimeCorrection;
   addonTimer.endTime                   = end - g_advancedSettings.m_iPVRTimeCorrection;
+  addonTimer.bStartAnyTime             = xbmcTimer.m_bStartAnyTime;
+  addonTimer.bEndAnyTime               = xbmcTimer.m_bEndAnyTime;
   addonTimer.firstDay                  = firstDay - g_advancedSettings.m_iPVRTimeCorrection;
   addonTimer.iEpgUid                   = epgTag ? epgTag->UniqueBroadcastID() : -1;
   strncpy(addonTimer.strSummary, xbmcTimer.m_strSummary.c_str(), sizeof(addonTimer.strSummary) - 1);
@@ -444,6 +446,7 @@ bool CPVRClient::GetAddonProperties(void)
                                         PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE |
                                         PVR_TIMER_TYPE_SUPPORTS_CHANNELS       |
                                         PVR_TIMER_TYPE_SUPPORTS_START_TIME     |
+                                        PVR_TIMER_TYPE_SUPPORTS_END_TIME       |
                                         PVR_TIMER_TYPE_SUPPORTS_PRIORITY       |
                                         PVR_TIMER_TYPE_SUPPORTS_LIFETIME       |
                                         PVR_TIMER_TYPE_SUPPORTS_RECORDING_FOLDERS;
@@ -457,6 +460,7 @@ bool CPVRClient::GetAddonProperties(void)
                                         PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE |
                                         PVR_TIMER_TYPE_SUPPORTS_CHANNELS       |
                                         PVR_TIMER_TYPE_SUPPORTS_START_TIME     |
+                                        PVR_TIMER_TYPE_SUPPORTS_END_TIME       |
                                         PVR_TIMER_TYPE_SUPPORTS_PRIORITY       |
                                         PVR_TIMER_TYPE_SUPPORTS_LIFETIME       |
                                         PVR_TIMER_TYPE_SUPPORTS_FIRST_DAY      |
@@ -472,6 +476,7 @@ bool CPVRClient::GetAddonProperties(void)
           types_array[size].iAttributes = PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE |
                                           PVR_TIMER_TYPE_SUPPORTS_CHANNELS       |
                                           PVR_TIMER_TYPE_SUPPORTS_START_TIME     |
+                                          PVR_TIMER_TYPE_SUPPORTS_END_TIME       |
                                           PVR_TIMER_TYPE_SUPPORTS_PRIORITY       |
                                           PVR_TIMER_TYPE_SUPPORTS_LIFETIME       |
                                           PVR_TIMER_TYPE_SUPPORTS_RECORDING_FOLDERS;

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -45,7 +45,8 @@ using namespace PVR;
 #define SETTING_TMR_EPGSEARCH     "timer.epgsearch"
 #define SETTING_TMR_FULLTEXT      "timer.fulltext"
 #define SETTING_TMR_CHANNEL       "timer.channel"
-#define SETTING_TMR_ANYTIME       "timer.anytime"
+#define SETTING_TMR_START_ANYTIME "timer.startanytime"
+#define SETTING_TMR_END_ANYTIME   "timer.endanytime"
 #define SETTING_TMR_START_DAY     "timer.startday"
 #define SETTING_TMR_END_DAY       "timer.endday"
 #define SETTING_TMR_BEGIN         "timer.begin"
@@ -63,7 +64,8 @@ using namespace PVR;
 #define TYPE_DEP_VISIBI_COND_ID_POSTFIX     "visibi.typedep"
 #define TYPE_DEP_ENABLE_COND_ID_POSTFIX     "enable.typedep"
 #define CHANNEL_DEP_VISIBI_COND_ID_POSTFIX  "visibi.channeldep"
-#define ANYTIME_DEP_ENABLE_COND_ID_POSTFIX  "enable.anytimedep"
+#define START_ANYTIME_DEP_VISIBI_COND_ID_POSTFIX  "visibi.startanytimedep"
+#define END_ANYTIME_DEP_VISIBI_COND_ID_POSTFIX    "visibi.endanytimedep"
 
 #define ENTRY_ANY_CHANNEL (-1)
 
@@ -72,9 +74,9 @@ CGUIDialogPVRTimerSettings::CGUIDialogPVRTimerSettings() :
   m_bIsRadio(false),
   m_bIsNewTimer(true),
   m_bTimerActive(false),
-  m_bStartAnytime(true),
-  m_bEndAnytime(true),
   m_bFullTextEpgSearch(true),
+  m_bStartAnyTime(false),
+  m_bEndAnyTime(false),
   m_iWeekdays(PVR_WEEKDAY_NONE),
   m_iPreventDupEpisodes(0),
   m_iMarginStart(0),
@@ -110,14 +112,13 @@ void CGUIDialogPVRTimerSettings::SetTimer(CFileItem *item)
   m_timerType     = m_timerInfoTag->GetTimerType();
   m_bIsRadio      = m_timerInfoTag->m_bIsRadio;
   m_bIsNewTimer   = m_timerInfoTag->m_state == PVR_TIMER_STATE_NEW;
-  m_bStartAnytime = m_bIsNewTimer || m_timerInfoTag->IsStartAtAnyTime();
-  m_bEndAnytime   = m_bIsNewTimer || m_timerInfoTag->IsEndAtAnyTime();
   m_bTimerActive  = m_bIsNewTimer || m_timerInfoTag->IsActive();
+  m_bStartAnyTime = m_bIsNewTimer || m_timerInfoTag->m_bStartAnyTime;
+  m_bEndAnyTime   = m_bIsNewTimer || m_timerInfoTag->m_bEndAnyTime;
   m_strTitle      = m_timerInfoTag->m_strTitle;
 
-  const CDateTime now(CDateTime::GetCurrentDateTime());
-  m_startLocalTime    = m_timerInfoTag->IsStartAtAnyTime() ? now : m_timerInfoTag->StartAsLocalTime();
-  m_endLocalTime      = m_timerInfoTag->IsEndAtAnyTime()   ? now : m_timerInfoTag->EndAsLocalTime();
+  m_startLocalTime    = m_timerInfoTag->StartAsLocalTime();
+  m_endLocalTime      = m_timerInfoTag->EndAsLocalTime();
   m_timerStartTimeStr = m_startLocalTime.GetAsLocalizedTime("", false);
   m_timerEndTimeStr   = m_endLocalTime.GetAsLocalizedTime("", false);
   m_firstDayLocalTime = m_timerInfoTag->FirstDayAsLocalTime();
@@ -276,34 +277,39 @@ void CGUIDialogPVRTimerSettings::InitializeSettings()
   AddTypeDependentVisibilityCondition(setting, SETTING_TMR_WEEKDAYS);
   AddTypeDependentEnableCondition(setting, SETTING_TMR_WEEKDAYS);
 
-  // "Any time" (only for repeating timers)
-  setting = AddToggle(group, SETTING_TMR_ANYTIME, 810, 0, m_bStartAnytime);
-  AddTypeDependentVisibilityCondition(setting, SETTING_TMR_ANYTIME);
-  AddTypeDependentEnableCondition(setting, SETTING_TMR_ANYTIME);
+  // "Start any time" (only for repeating timers)
+  setting = AddToggle(group, SETTING_TMR_START_ANYTIME, 810, 0, m_bStartAnyTime);
+  AddTypeDependentVisibilityCondition(setting, SETTING_TMR_START_ANYTIME);
+  AddTypeDependentEnableCondition(setting, SETTING_TMR_START_ANYTIME);
 
   // Start day (day + month + year only, no hours, minutes)
   setting = AddSpinner(group, SETTING_TMR_START_DAY, 19128, 0, GetDateAsIndex(m_startLocalTime), DaysFiller);
   AddTypeDependentVisibilityCondition(setting, SETTING_TMR_START_DAY);
   AddTypeDependentEnableCondition(setting, SETTING_TMR_START_DAY);
-  AddAnytimeDependentVisibilityCondition(setting, SETTING_TMR_START_DAY);
+  AddStartAnytimeDependentVisibilityCondition(setting, SETTING_TMR_START_DAY);
 
   // Start time (hours + minutes only, no day, month, year)
   setting = AddButton(group, SETTING_TMR_BEGIN, 19126, 0);
   AddTypeDependentVisibilityCondition(setting, SETTING_TMR_BEGIN);
   AddTypeDependentEnableCondition(setting, SETTING_TMR_BEGIN);
-  AddAnytimeDependentVisibilityCondition(setting, SETTING_TMR_BEGIN);
+  AddStartAnytimeDependentVisibilityCondition(setting, SETTING_TMR_BEGIN);
+
+  // "End any time" (only for repeating timers)
+  setting = AddToggle(group, SETTING_TMR_END_ANYTIME, 817, 0, m_bEndAnyTime);
+  AddTypeDependentVisibilityCondition(setting, SETTING_TMR_END_ANYTIME);
+  AddTypeDependentEnableCondition(setting, SETTING_TMR_END_ANYTIME);
 
   // End day (day + month + year only, no hours, minutes)
   setting = AddSpinner(group, SETTING_TMR_END_DAY, 19129, 0, GetDateAsIndex(m_endLocalTime), DaysFiller);
   AddTypeDependentVisibilityCondition(setting, SETTING_TMR_END_DAY);
   AddTypeDependentEnableCondition(setting, SETTING_TMR_END_DAY);
-  AddAnytimeDependentVisibilityCondition(setting, SETTING_TMR_END_DAY);
+  AddEndAnytimeDependentVisibilityCondition(setting, SETTING_TMR_END_DAY);
 
   // End time (hours + minutes only, no day, month, year)
   setting = AddButton(group, SETTING_TMR_END, 19127, 0);
   AddTypeDependentVisibilityCondition(setting, SETTING_TMR_END);
   AddTypeDependentEnableCondition(setting, SETTING_TMR_END);
-  AddAnytimeDependentVisibilityCondition(setting, SETTING_TMR_END);
+  AddEndAnytimeDependentVisibilityCondition(setting, SETTING_TMR_END);
 
   // First day (only for repeating timers)
   setting = AddSpinner(group, SETTING_TMR_FIRST_DAY, 19084, 0, GetDateAsIndex(m_firstDayLocalTime), DaysFiller);
@@ -423,9 +429,13 @@ void CGUIDialogPVRTimerSettings::OnSettingChanged(const CSetting *setting)
     }
     m_iWeekdays = weekdays;
   }
-  else if (settingId == SETTING_TMR_ANYTIME)
+  else if (settingId == SETTING_TMR_START_ANYTIME)
   {
-    m_bStartAnytime = m_bEndAnytime = static_cast<const CSettingBool*>(setting)->GetValue();
+    m_bStartAnyTime = static_cast<const CSettingBool*>(setting)->GetValue();
+  }
+  else if (settingId == SETTING_TMR_END_ANYTIME)
+  {
+    m_bEndAnyTime = static_cast<const CSettingBool*>(setting)->GetValue();
   }
   else if (settingId == SETTING_TMR_START_DAY)
   {
@@ -541,28 +551,15 @@ void CGUIDialogPVRTimerSettings::Save()
     m_timerInfoTag->m_iClientId         = m_timerType->GetClientId();
   }
 
+  m_timerInfoTag->m_bStartAnyTime = m_bStartAnyTime;
+  m_timerInfoTag->m_bEndAnyTime = m_bEndAnyTime;
   // Begin and end time
-  bool bStartSet(false);
-  bool bEndSet(false);
-  if ((m_bStartAnytime || m_bEndAnytime) && m_timerType->IsRepeatingEpgBased())
-  {
-    if (m_bStartAnytime)
-    {
-      m_timerInfoTag->SetStartAtAnyTime();
-      bStartSet = true;
-    }
-    if (m_bEndAnytime)
-    {
-      m_timerInfoTag->SetEndAtAnyTime();
-      bEndSet = true;
-    }
-  }
-
   const CDateTime now(CDateTime::GetCurrentDateTime());
-  if (!bStartSet || !bEndSet)
+  if (!m_bStartAnyTime && !m_bEndAnyTime)
   {
-    if (m_timerType->SupportsStartEndTime() && // has start/end clock entry
-        m_timerType->IsRepeating())            // but no start/end day spinners
+    if (m_timerType->SupportsStartTime() &&    // has start clock entry
+        m_timerType->SupportsEndTime() &&      // and end clock entry
+        m_timerType->IsRepeating())            // but no associated start/end day spinners
     {
       if (m_endLocalTime < m_startLocalTime)   // And the end clock is earlier than the start clock
       {
@@ -589,13 +586,13 @@ void CGUIDialogPVRTimerSettings::Save()
     {
       CLog::Log(LOGWARNING, "CGUIDialogPVRTimerSettings::Save - Specified recording end time < start time: expect errors!");
     }
-
-    if (!bStartSet)
-      m_timerInfoTag->SetStartFromLocalTime(m_startLocalTime);
-
-    if (!bEndSet)
-      m_timerInfoTag->SetEndFromLocalTime(m_endLocalTime);
+    m_timerInfoTag->SetStartFromLocalTime(m_startLocalTime);
+    m_timerInfoTag->SetEndFromLocalTime(m_endLocalTime);
   }
+  else if (!m_bStartAnyTime)
+    m_timerInfoTag->SetStartFromLocalTime(m_startLocalTime);
+  else if (!m_bEndAnyTime)
+    m_timerInfoTag->SetEndFromLocalTime(m_endLocalTime);
 
   // Days of week (only for repeating timers)
   if (m_timerType->IsRepeating())
@@ -639,20 +636,14 @@ void CGUIDialogPVRTimerSettings::SetButtonLabels()
   BaseSettingControlPtr settingControl = GetSettingControl(SETTING_TMR_BEGIN);
   if (settingControl != NULL && settingControl->GetControl() != NULL)
   {
-    if (!m_bIsNewTimer && m_bStartAnytime)
-      SET_CONTROL_LABEL2(settingControl->GetID(), g_localizeStrings.Get(19161)); // "any time"
-    else
-      SET_CONTROL_LABEL2(settingControl->GetID(), m_timerStartTimeStr);
+    SET_CONTROL_LABEL2(settingControl->GetID(), m_timerStartTimeStr);
   }
 
   // timer end time
   settingControl = GetSettingControl(SETTING_TMR_END);
   if (settingControl != NULL && settingControl->GetControl() != NULL)
   {
-    if (!m_bIsNewTimer && m_bEndAnytime)
-      SET_CONTROL_LABEL2(settingControl->GetID(), g_localizeStrings.Get(19161)); // "any time"
-    else
-      SET_CONTROL_LABEL2(settingControl->GetID(), m_timerEndTimeStr);
+    SET_CONTROL_LABEL2(settingControl->GetID(), m_timerEndTimeStr);
   }
 
   // weekdays
@@ -1037,14 +1028,18 @@ bool CGUIDialogPVRTimerSettings::TypeSupportsCondition(const std::string &condit
       return entry->second->SupportsEnableDisable();
     else if (cond == SETTING_TMR_CHANNEL)
       return entry->second->SupportsChannels();
-    else if (cond == SETTING_TMR_ANYTIME)
-      return entry->second->IsRepeatingEpgBased();
-    else if (cond == SETTING_TMR_START_DAY ||
-             cond == SETTING_TMR_END_DAY)
-      return entry->second->SupportsStartEndTime() && !entry->second->IsRepeating();
-    else if ((cond == SETTING_TMR_BEGIN) ||
-             (cond == SETTING_TMR_END))
-      return entry->second->SupportsStartEndTime();
+    else if (cond == SETTING_TMR_START_ANYTIME)
+      return entry->second->SupportsStartAnyTime() && entry->second->IsEpgBased();
+    else if (cond == SETTING_TMR_END_ANYTIME)
+      return entry->second->SupportsEndAnyTime() && entry->second->IsEpgBased();
+    else if (cond == SETTING_TMR_START_DAY)
+      return entry->second->SupportsStartTime() && entry->second->IsOnetime();
+    else if (cond == SETTING_TMR_END_DAY)
+      return entry->second->SupportsEndTime() && entry->second->IsOnetime();
+    else if (cond == SETTING_TMR_BEGIN)
+      return entry->second->SupportsStartTime();
+    else if (cond == SETTING_TMR_END)
+      return entry->second->SupportsEndTime();
     else if (cond == SETTING_TMR_WEEKDAYS)
       return entry->second->SupportsWeekdays();
     else if (cond == SETTING_TMR_FIRST_DAY)
@@ -1072,15 +1067,15 @@ bool CGUIDialogPVRTimerSettings::TypeSupportsCondition(const std::string &condit
   return false;
 }
 
-void CGUIDialogPVRTimerSettings::AddAnytimeDependentVisibilityCondition(CSetting *setting, const std::string &identifier)
+void CGUIDialogPVRTimerSettings::AddStartAnytimeDependentVisibilityCondition(CSetting *setting, const std::string &identifier)
 {
   // Show or hide setting depending on value of setting "any time"
   std::string id(identifier);
-  id.append(ANYTIME_DEP_ENABLE_COND_ID_POSTFIX);
-  AddCondition(setting, id, AnytimeSetCondition, SettingDependencyTypeVisible, SETTING_TMR_ANYTIME);
+  id.append(START_ANYTIME_DEP_VISIBI_COND_ID_POSTFIX);
+  AddCondition(setting, id, StartAnytimeSetCondition, SettingDependencyTypeVisible, SETTING_TMR_START_ANYTIME);
 }
 
-bool CGUIDialogPVRTimerSettings::AnytimeSetCondition(const std::string &condition, const std::string &value, const CSetting *setting, void *data)
+bool CGUIDialogPVRTimerSettings::StartAnytimeSetCondition(const std::string &condition, const std::string &value, const CSetting *setting, void *data)
 {
   if (setting == NULL)
     return false;
@@ -1095,16 +1090,53 @@ bool CGUIDialogPVRTimerSettings::AnytimeSetCondition(const std::string &conditio
   if (!StringUtils::EqualsNoCase(value, "true"))
     return false;
 
-  // "any time" setting is only relevant for repeating epg-based timers.
-  if (!pThis->m_timerType->IsRepeatingEpgBased())
+  // "any time" setting is only relevant for epg-based timers.
+  if (!pThis->m_timerType->IsEpgBased())
     return true;
 
   std::string cond(condition);
-  cond.erase(cond.find(ANYTIME_DEP_ENABLE_COND_ID_POSTFIX));
+  cond.erase(cond.find(START_ANYTIME_DEP_VISIBI_COND_ID_POSTFIX));
 
   if ((cond == SETTING_TMR_START_DAY) ||
-      (cond == SETTING_TMR_END_DAY)   ||
-      (cond == SETTING_TMR_BEGIN)     ||
+      (cond == SETTING_TMR_BEGIN))
+  {
+    bool bAnytime = static_cast<const CSettingBool*>(setting)->GetValue();
+    return !bAnytime;
+  }
+  return false;
+}
+
+void CGUIDialogPVRTimerSettings::AddEndAnytimeDependentVisibilityCondition(CSetting *setting, const std::string &identifier)
+{
+  // Show or hide setting depending on value of setting "any time"
+  std::string id(identifier);
+  id.append(END_ANYTIME_DEP_VISIBI_COND_ID_POSTFIX);
+  AddCondition(setting, id, EndAnytimeSetCondition, SettingDependencyTypeVisible, SETTING_TMR_END_ANYTIME);
+}
+
+bool CGUIDialogPVRTimerSettings::EndAnytimeSetCondition(const std::string &condition, const std::string &value, const CSetting *setting, void *data)
+{
+  if (setting == NULL)
+    return false;
+
+  CGUIDialogPVRTimerSettings *pThis = static_cast<CGUIDialogPVRTimerSettings*>(data);
+  if (pThis == NULL)
+  {
+    CLog::Log(LOGERROR, "CGUIDialogPVRTimerSettings::AnytimeSetCondition - No dialog");
+    return false;
+  }
+
+  if (!StringUtils::EqualsNoCase(value, "true"))
+    return false;
+
+  // "any time" setting is only relevant for epg-based timers.
+  if (!pThis->m_timerType->IsEpgBased())
+    return true;
+
+  std::string cond(condition);
+  cond.erase(cond.find(END_ANYTIME_DEP_VISIBI_COND_ID_POSTFIX));
+
+  if ((cond == SETTING_TMR_END_DAY)   ||
       (cond == SETTING_TMR_END))
   {
     bool bAnytime = static_cast<const CSettingBool*>(setting)->GetValue();

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.h
@@ -96,8 +96,11 @@ namespace PVR
     static bool TypeSupportsCondition(
       const std::string &condition, const std::string &value, const CSetting *setting, void *data);
 
-    void AddAnytimeDependentVisibilityCondition(CSetting *setting, const std::string &identifier);
-    static bool AnytimeSetCondition(
+    void AddStartAnytimeDependentVisibilityCondition(CSetting *setting, const std::string &identifier);
+    static bool StartAnytimeSetCondition(
+      const std::string &condition, const std::string &value, const CSetting *setting, void *data);
+    void AddEndAnytimeDependentVisibilityCondition(CSetting *setting, const std::string &identifier);
+    static bool EndAnytimeSetCondition(
       const std::string &condition, const std::string &value, const CSetting *setting, void *data);
 
     typedef std::map<int, CPVRTimerTypePtr>  TypeEntriesMap;
@@ -137,14 +140,14 @@ namespace PVR
     bool                m_bIsRadio;
     bool                m_bIsNewTimer;
     bool                m_bTimerActive;
-    bool                m_bStartAnytime;
-    bool                m_bEndAnytime;
     std::string         m_strTitle;
     std::string         m_strEpgSearchString;
     bool                m_bFullTextEpgSearch;
     ChannelDescriptor   m_channel;
     CDateTime           m_startLocalTime;
     CDateTime           m_endLocalTime;
+    bool                m_bStartAnyTime;
+    bool                m_bEndAnyTime;
     unsigned int        m_iWeekdays;
     CDateTime           m_firstDayLocalTime;
     unsigned int        m_iPreventDupEpisodes;

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -58,6 +58,8 @@ CPVRTimerInfoTag::CPVRTimerInfoTag(bool bRadio /* = false */) :
   m_iGenreSubType       = 0;
   m_StartTime           = CDateTime::GetUTCDateTime();
   m_StopTime            = m_StartTime;
+  m_bStartAnyTime       = false;
+  m_bEndAnyTime         = false;
   m_state               = PVR_TIMER_STATE_NEW;
   m_FirstDay.SetValid(false);
   m_iTimerId            = 0;
@@ -96,6 +98,8 @@ CPVRTimerInfoTag::CPVRTimerInfoTag(const PVR_TIMER &timer, const CPVRChannelPtr 
   m_iChannelNumber      = channel ? g_PVRChannelGroups->GetGroupAll(channel->IsRadio())->GetChannelNumber(channel) : 0;
   m_StartTime           = timer.startTime + g_advancedSettings.m_iPVRTimeCorrection;
   m_StopTime            = timer.endTime + g_advancedSettings.m_iPVRTimeCorrection;
+  m_bStartAnyTime       = timer.bStartAnyTime;
+  m_bEndAnyTime         = timer.bEndAnyTime;
   m_iPreventDupEpisodes = timer.iPreventDuplicateEpisodes;
   m_iRecordingGroup     = timer.iRecordingGroup;
   m_FirstDay            = timer.firstDay + g_advancedSettings.m_iPVRTimeCorrection;
@@ -175,6 +179,8 @@ bool CPVRTimerInfoTag::operator ==(const CPVRTimerInfoTag& right) const
           m_iRecordingGroup     == right.m_iRecordingGroup &&
           m_StartTime           == right.m_StartTime &&
           m_StopTime            == right.m_StopTime &&
+          m_bStartAnyTime       == right.m_bStartAnyTime &&
+          m_bEndAnyTime         == right.m_bEndAnyTime &&
           m_FirstDay            == right.m_FirstDay &&
           m_iWeekdays           == right.m_iWeekdays &&
           m_iPriority           == right.m_iPriority &&
@@ -213,6 +219,8 @@ void CPVRTimerInfoTag::Serialize(CVariant &value) const
   value["preventduplicateepisodes"] = m_iPreventDupEpisodes;
   value["starttime"] = m_StartTime.IsValid() ? m_StartTime.GetAsDBDateTime() : "";
   value["endtime"] = m_StopTime.IsValid() ? m_StopTime.GetAsDBDateTime() : "";
+  value["startanytime"] = m_bStartAnyTime;
+  value["endanytime"] = m_bEndAnyTime;
   value["runtime"] = m_StartTime.IsValid() && m_StopTime.IsValid() ? (m_StopTime - m_StartTime).GetSecondsTotal() : 0;
   value["firstday"] = m_FirstDay.IsValid() ? m_FirstDay.GetAsDBDate() : "";
 
@@ -323,22 +331,28 @@ void CPVRTimerInfoTag::UpdateSummary(void)
   CSingleLock lock(m_critSection);
   m_strSummary.clear();
 
-  const std::string startDate(IsStartAtAnyTime() ?
-      g_localizeStrings.Get(807) /* "Any day" */ : StartAsLocalTime().GetAsLocalizedDate());
-  const std::string endDate(IsEndAtAnyTime() ?
-      g_localizeStrings.Get(807) /* "Any day" */ : EndAsLocalTime().GetAsLocalizedDate());
+  const std::string startDate(StartAsLocalTime().GetAsLocalizedDate());
+  const std::string endDate(EndAsLocalTime().GetAsLocalizedDate());
 
-  if ((m_iWeekdays != PVR_WEEKDAY_NONE) || (startDate == endDate))
+  if (m_bEndAnyTime)
+  {
+    m_strSummary = StringUtils::Format("%s %s %s",
+        m_iWeekdays != PVR_WEEKDAY_NONE ?
+          GetWeekdaysString().c_str() : startDate.c_str(), //for "Any day" set PVR_WEEKDAY_ALLDAYS
+        g_localizeStrings.Get(19107).c_str(), // "at"
+        m_bStartAnyTime ?
+          g_localizeStrings.Get(19161).c_str() /* "any time" */ : StartAsLocalTime().GetAsLocalizedTime("", false).c_str());
+  }
+  else if ((m_iWeekdays != PVR_WEEKDAY_NONE) || (startDate == endDate))
   {
     m_strSummary = StringUtils::Format("%s %s %s %s %s",
         m_iWeekdays != PVR_WEEKDAY_NONE ?
-          GetWeekdaysString().c_str() : (IsStartAtAnyTime() && IsEndAtAnyTime() && FirstDayAsLocalTime().IsValid()) ?
-            FirstDayAsLocalTime().GetAsLocalizedDate().c_str() : startDate.c_str(),
+          GetWeekdaysString().c_str() : startDate.c_str(), //for "Any day" set PVR_WEEKDAY_ALLDAYS
         g_localizeStrings.Get(19159).c_str(), // "from"
-        IsStartAtAnyTime() ?
+        m_bStartAnyTime ?
           g_localizeStrings.Get(19161).c_str() /* "any time" */ : StartAsLocalTime().GetAsLocalizedTime("", false).c_str(),
         g_localizeStrings.Get(19160).c_str(), // "to"
-        IsEndAtAnyTime() ?
+        m_bEndAnyTime ?
           g_localizeStrings.Get(19161).c_str() /* "any time" */ : EndAsLocalTime().GetAsLocalizedTime("", false).c_str());
   }
   else
@@ -346,11 +360,11 @@ void CPVRTimerInfoTag::UpdateSummary(void)
     m_strSummary = StringUtils::Format("%s %s %s %s %s %s",
         startDate.c_str(),
         g_localizeStrings.Get(19159).c_str(), // "from"
-        IsStartAtAnyTime() ?
+        m_bStartAnyTime ?
           g_localizeStrings.Get(19161).c_str() /* "any time" */ : StartAsLocalTime().GetAsLocalizedTime("", false).c_str(),
         g_localizeStrings.Get(19160).c_str(), // "to"
         endDate.c_str(),
-        IsEndAtAnyTime() ?
+        m_bEndAnyTime ?
           g_localizeStrings.Get(19161).c_str() /* "any time" */ : EndAsLocalTime().GetAsLocalizedTime("", false).c_str());
   }
 }
@@ -558,6 +572,8 @@ bool CPVRTimerInfoTag::UpdateEntry(const CPVRTimerInfoTagPtr &tag)
   m_iClientChannelUid   = tag->m_iClientChannelUid;
   m_StartTime           = tag->m_StartTime;
   m_StopTime            = tag->m_StopTime;
+  m_bStartAnyTime       = tag->m_bStartAnyTime;
+  m_bEndAnyTime         = tag->m_bEndAnyTime;
   m_FirstDay            = tag->m_FirstDay;
   m_iPriority           = tag->m_iPriority;
   m_iLifetime           = tag->m_iLifetime;
@@ -736,21 +752,6 @@ CDateTime CPVRTimerInfoTag::StartAsLocalTime(void) const
   return retVal;
 }
 
-bool CPVRTimerInfoTag::IsStartAtAnyTime(void) const
-{
-  time_t time = 0;
-  CDateTime start(m_StartTime);
-  start.GetAsTime(time);
-  return time == 0;
-}
-
-void CPVRTimerInfoTag::SetStartAtAnyTime(void)
-{
-  time_t time = 0;
-  CDateTime start(time);
-  SetStartFromUTC(start);
-}
-
 CDateTime CPVRTimerInfoTag::EndAsUTC(void) const
 {
   CDateTime retVal = m_StopTime;
@@ -762,21 +763,6 @@ CDateTime CPVRTimerInfoTag::EndAsLocalTime(void) const
   CDateTime retVal;
   retVal.SetFromUTCDateTime(m_StopTime);
   return retVal;
-}
-
-bool CPVRTimerInfoTag::IsEndAtAnyTime(void) const
-{
-  time_t time = 0;
-  CDateTime stop(m_StopTime);
-  stop.GetAsTime(time);
-  return time == 0;
-}
-
-void CPVRTimerInfoTag::SetEndAtAnyTime(void)
-{
-  time_t time = 0;
-  CDateTime stop(time);
-  SetEndFromUTC(stop);
 }
 
 CDateTime CPVRTimerInfoTag::FirstDayAsUTC(void) const

--- a/xbmc/pvr/timers/PVRTimerInfoTag.h
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.h
@@ -158,16 +158,10 @@ namespace PVR
     void SetStartFromUTC(CDateTime &start) { m_StartTime = start; }
     void SetStartFromLocalTime(CDateTime &start) { m_StartTime = start.GetAsUTCDateTime(); }
 
-    bool IsStartAtAnyTime(void) const;
-    void SetStartAtAnyTime(void);
-
     CDateTime EndAsUTC(void) const;
     CDateTime EndAsLocalTime(void) const;
     void SetEndFromUTC(CDateTime &end) { m_StopTime = end; }
     void SetEndFromLocalTime(CDateTime &end) { m_StopTime = end.GetAsUTCDateTime(); }
-
-    bool IsEndAtAnyTime(void) const;
-    void SetEndAtAnyTime(void);
 
     CDateTime FirstDayAsUTC(void) const;
     CDateTime FirstDayAsLocalTime(void) const;
@@ -236,6 +230,8 @@ namespace PVR
     int                   m_iClientIndex;        /*!< @brief index number of the tag, given by the backend, -1 for new */
     unsigned int          m_iParentClientIndex;  /*!< @brief for timers scheduled by repeated timers, the index number of the parent, given by the backend, PVR_TIMER_NO_PARENT for no parent */
     int                   m_iClientChannelUid;   /*!< @brief channel uid */
+    bool                  m_bStartAnyTime;       /*!< @brief Ignore start date and time clock. Record at 'Any Time' */
+    bool                  m_bEndAnyTime;         /*!< @brief Ignore end date and time clock. Record at 'Any Time' */
     int                   m_iPriority;           /*!< @brief priority of the timer */
     int                   m_iLifetime;           /*!< @brief lifetime of the timer in days */
     unsigned int          m_iWeekdays;           /*!< @brief bit based store of weekdays for repeating timers */

--- a/xbmc/pvr/timers/PVRTimerType.h
+++ b/xbmc/pvr/timers/PVRTimerType.h
@@ -168,7 +168,7 @@ namespace PVR
      * @brief Check whether this type supports start time and end time.
      * @return True if start time and end time values is supported, false otherwise.
      */
-    bool SupportsStartEndTime() const { return (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_START_END_TIME) > 0; }
+    bool SupportsStartEndTime() const { return (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_START_TIME) > 0; }
 
     /*!
      * @brief Check whether this type supports matching a search string against epg episode title.

--- a/xbmc/pvr/timers/PVRTimerType.h
+++ b/xbmc/pvr/timers/PVRTimerType.h
@@ -165,10 +165,27 @@ namespace PVR
     bool SupportsChannels() const { return (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_CHANNELS) > 0; }
 
     /*!
-     * @brief Check whether this type supports start time and end time.
-     * @return True if start time and end time values is supported, false otherwise.
+     * @brief Check whether this type supports start time.
+     * @return True if start time values are supported, false otherwise.
      */
-    bool SupportsStartEndTime() const { return (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_START_TIME) > 0; }
+    bool SupportsStartTime() const { return (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_START_TIME) > 0; }
+
+    /*!
+     * @brief Check whether this type supports end time.
+     * @return True if end time values are supported, false otherwise.
+     */
+    bool SupportsEndTime() const { return (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_END_TIME) > 0; }
+    /*!
+     * @brief Check whether this type supports start any time.
+     * @return True if start any time is supported, false otherwise.
+     */
+    bool SupportsStartAnyTime() const { return (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_START_ANYTIME) > 0; }
+
+    /*!
+     * @brief Check whether this type supports end any time.
+     * @return True if end any time is supported, false otherwise.
+     */
+    bool SupportsEndAnyTime() const { return (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_END_ANYTIME) > 0; }
 
     /*!
      * @brief Check whether this type supports matching a search string against epg episode title.


### PR DESCRIPTION
Allows startTime/endTime to be retained if AnyTime is turned on and back off again to see how this affects the shows a timer will record.
Also: Retains meaningfull 'startTime' based 'sort by date' order for timers with 'Any Time' selected.

**PVR Client Changes Requried**
In places where an addon currently sets 'startTime=endTime=0' to indicate Any Time, this should be removed and replaced by setting bAnyTime = true.
In places where 'startTime=endTime=0' is used to control backend recording rule settings, this should be replaced with something based on the bAnyTime state.

**Context**
This PR relies on the changes in PR https://github.com/xbmc/xbmc/pull/7626 which groups several API changes forming API 2.2.0.
- This PR should not be merged unless PR  https://github.com/xbmc/xbmc/pull/7626 has also been merged.
- The necessary supporting API change is contained in commit '[PVR] Add bAnyTime to API 2.2.0'. If this change is withdrawn from PR https://github.com/xbmc/xbmc/pull/7626 this PR will be closed.

**Comments**
Please make comments regarding the bAnyTime change itself here.
For comments regarding any of the other 2.2.0 API changes, please use https://github.com/xbmc/xbmc/pull/7626 
