### PR TITLE
[RFC] DX11 several optimizations of copying frames to/from gpu.

### DIFF
--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -1127,6 +1127,7 @@
     <ClInclude Include="..\..\xbmc\utils\uXstrings.h" />
     <ClInclude Include="..\..\xbmc\utils\Vector.h" />
     <ClInclude Include="..\..\xbmc\utils\win32\gpu_memcpy_sse4.h" />
+    <ClInclude Include="..\..\xbmc\utils\win32\memcpy_sse2.h" />
     <ClInclude Include="..\..\xbmc\utils\win32\Win32InterfaceForCLog.h" />
     <ClInclude Include="..\..\xbmc\utils\win32\Win32Log.h" />
     <ClInclude Include="..\..\xbmc\utils\XSLTUtils.h" />

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -1126,6 +1126,7 @@
     <ClInclude Include="..\..\xbmc\utils\Utf8Utils.h" />
     <ClInclude Include="..\..\xbmc\utils\uXstrings.h" />
     <ClInclude Include="..\..\xbmc\utils\Vector.h" />
+    <ClInclude Include="..\..\xbmc\utils\win32\gpu_memcpy_sse4.h" />
     <ClInclude Include="..\..\xbmc\utils\win32\Win32InterfaceForCLog.h" />
     <ClInclude Include="..\..\xbmc\utils\win32\Win32Log.h" />
     <ClInclude Include="..\..\xbmc\utils\XSLTUtils.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -6190,6 +6190,9 @@
     <ClInclude Include="..\..\xbmc\utils\win32\gpu_memcpy_sse4.h">
       <Filter>utils\win32</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\xbmc\utils\win32\memcpy_sse2.h">
+      <Filter>utils\win32</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\..\xbmc\win32\XBMC_PC.rc">

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -6187,6 +6187,9 @@
     <ClInclude Include="..\..\xbmc\video\jobs\VideoLibraryRefreshingJob.h">
       <Filter>video\jobs</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\xbmc\utils\win32\gpu_memcpy_sse4.h">
+      <Filter>utils\win32</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\..\xbmc\win32\XBMC_PC.rc">

--- a/xbmc/cores/VideoRenderers/DXVAHD.h
+++ b/xbmc/cores/VideoRenderers/DXVAHD.h
@@ -98,7 +98,7 @@ protected:
 
   unsigned int                    m_procIndex;
   D3D11_VIDEO_PROCESSOR_RATE_CONVERSION_CAPS m_rateCaps;
-  std::map<ID3D11VideoProcessorInputView*, ID3D11Texture2D*> m_mappedResource;
+  D3D11_TEXTURE2D_DESC            m_texDesc;
 };
 
 };

--- a/xbmc/cores/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoRenderers/RenderManager.cpp
@@ -991,10 +991,6 @@ int CXBMCRenderManager::AddVideoPicture(DVDVideoPicture& pic)
   {
     CDVDCodecUtils::CopyYUV422PackedPicture(&image, &pic);
   }
-  else if(pic.format == RENDER_FMT_DXVA)
-  {
-    CDVDCodecUtils::CopyDXVA2Picture(&image, &pic);
-  }
 #ifdef HAVE_LIBVDPAU
   else if(pic.format == RENDER_FMT_VDPAU
        || pic.format == RENDER_FMT_VDPAU_420)

--- a/xbmc/cores/VideoRenderers/WinRenderer.h
+++ b/xbmc/cores/VideoRenderers/WinRenderer.h
@@ -102,7 +102,10 @@ struct SVideoPlane
 
 struct YUVBuffer : SVideoBuffer
 {
-  YUVBuffer() : m_width(0), m_height(0), m_format(RENDER_FMT_NONE), m_activeplanes(0), m_locked(false) {}
+  YUVBuffer() : m_width(0), m_height(0), m_format(RENDER_FMT_NONE), m_activeplanes(0), m_locked(false), m_staging(nullptr)
+  {
+    memset(&m_sDesc, 0, sizeof(CD3D11_TEXTURE2D_DESC));
+  }
   ~YUVBuffer();
   bool Create(ERenderFormat format, unsigned int width, unsigned int height, bool dynamic);
   virtual void Release();
@@ -111,16 +114,21 @@ struct YUVBuffer : SVideoBuffer
   virtual void Clear();
   unsigned int GetActivePlanes() { return m_activeplanes; }
   virtual bool IsReadyToRender();
+  bool CopyFromDXVA(ID3D11VideoDecoderOutputView* pView);
 
   SVideoPlane planes[MAX_PLANES];
 
 private:
+  void PerformCopy();
+
   unsigned int     m_width;
   unsigned int     m_height;
   ERenderFormat    m_format;
   unsigned int     m_activeplanes;
   bool             m_locked;
   D3D11_MAP        m_mapType;
+  ID3D11Texture2D* m_staging;
+  CD3D11_TEXTURE2D_DESC m_sDesc;
 };
 
 struct DXVABuffer : SVideoBuffer
@@ -189,6 +197,7 @@ protected:
   void SelectPSVideoFilter();
   void UpdatePSVideoFilter();
   bool CreateIntermediateRenderTarget(unsigned int width, unsigned int height);
+  bool CopyDXVA2YUVBuffer(ID3D11VideoDecoderOutputView* pView, YUVBuffer *pBuf);
 
   void RenderProcessor(DWORD flags);
   int  m_iYV12RenderBuffer;

--- a/xbmc/cores/dvdplayer/DVDCodecs/DVDCodecUtils.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/DVDCodecUtils.h
@@ -37,7 +37,6 @@ public:
   static DVDVideoPicture* ConvertToYUV422PackedPicture(DVDVideoPicture *pSrc, ERenderFormat format);
   static bool CopyNV12Picture(YV12Image* pImage, DVDVideoPicture *pSrc);
   static bool CopyYUV422PackedPicture(YV12Image* pImage, DVDVideoPicture *pSrc);
-  static bool CopyDXVA2Picture(YV12Image* pImage, DVDVideoPicture *pSrc);
 
   static bool IsVP3CompatibleWidth(int width);
 

--- a/xbmc/utils/win32/gpu_memcpy_sse4.h
+++ b/xbmc/utils/win32/gpu_memcpy_sse4.h
@@ -1,0 +1,128 @@
+/*
+ *      Copyright (C) 2011-2015 Hendrik Leppkes
+ *      http://www.1f0.de
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *  Taken from the QuickSync decoder by Eric Gur
+ */
+
+#include <emmintrin.h>
+
+// gpu_memcpy is a memcpy style function that copied data very fast from a
+// GPU tiled memory (write back)
+// Performance tip: page offset (12 lsb) of both addresses should be different
+//  optimally use a 2K offset between them.
+inline void* gpu_memcpy(void* d, const void* s, size_t size)
+{
+    static const size_t regsInLoop = sizeof(size_t) * 2; // 8 or 16
+
+    if (d == nullptr || s == nullptr) return nullptr;
+
+    // If memory is not aligned, use memcpy
+    bool isAligned = (((size_t)(s) | (size_t)(d)) & 0xF) == 0;
+    if (!isAligned)
+    {
+        return memcpy(d, s, size);
+    }
+
+    __m128i xmm0, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7;
+#ifdef _M_X64
+    __m128i xmm8, xmm9, xmm10, xmm11, xmm12, xmm13, xmm14, xmm15;
+#endif
+
+    size_t reminder = size & (regsInLoop * sizeof(xmm0) - 1); // Copy 128 or 256 bytes every loop
+    size_t end = 0;
+
+    __m128i* pTrg = (__m128i*)d;
+    __m128i* pTrgEnd = pTrg + ((size - reminder) >> 4);
+    __m128i* pSrc = (__m128i*)s;
+    
+    // Make sure source is synced - doesn't hurt if not needed.
+    _mm_sfence();
+
+    while (pTrg < pTrgEnd)
+    {
+        // _mm_stream_load_si128 emits the Streaming SIMD Extensions 4 (SSE4.1) instruction MOVNTDQA
+        // Fastest method for copying GPU RAM. Available since Penryn (45nm Core 2 Duo/Quad)
+        xmm0  = _mm_stream_load_si128(pSrc);
+        xmm1  = _mm_stream_load_si128(pSrc + 1);
+        xmm2  = _mm_stream_load_si128(pSrc + 2);
+        xmm3  = _mm_stream_load_si128(pSrc + 3);
+        xmm4  = _mm_stream_load_si128(pSrc + 4);
+        xmm5  = _mm_stream_load_si128(pSrc + 5);
+        xmm6  = _mm_stream_load_si128(pSrc + 6);
+        xmm7  = _mm_stream_load_si128(pSrc + 7);
+#ifdef _M_X64 // Use all 16 xmm registers
+        xmm8  = _mm_stream_load_si128(pSrc + 8);
+        xmm9  = _mm_stream_load_si128(pSrc + 9);
+        xmm10 = _mm_stream_load_si128(pSrc + 10);
+        xmm11 = _mm_stream_load_si128(pSrc + 11);
+        xmm12 = _mm_stream_load_si128(pSrc + 12);
+        xmm13 = _mm_stream_load_si128(pSrc + 13);
+        xmm14 = _mm_stream_load_si128(pSrc + 14);
+        xmm15 = _mm_stream_load_si128(pSrc + 15);
+#endif
+        pSrc += regsInLoop;
+        // _mm_store_si128 emit the SSE2 intruction MOVDQA (aligned store)
+        _mm_store_si128(pTrg     , xmm0);
+        _mm_store_si128(pTrg +  1, xmm1);
+        _mm_store_si128(pTrg +  2, xmm2);
+        _mm_store_si128(pTrg +  3, xmm3);
+        _mm_store_si128(pTrg +  4, xmm4);
+        _mm_store_si128(pTrg +  5, xmm5);
+        _mm_store_si128(pTrg +  6, xmm6);
+        _mm_store_si128(pTrg +  7, xmm7);
+#ifdef _M_X64 // Use all 16 xmm registers
+        _mm_store_si128(pTrg +  8, xmm8);
+        _mm_store_si128(pTrg +  9, xmm9);
+        _mm_store_si128(pTrg + 10, xmm10);
+        _mm_store_si128(pTrg + 11, xmm11);
+        _mm_store_si128(pTrg + 12, xmm12);
+        _mm_store_si128(pTrg + 13, xmm13);
+        _mm_store_si128(pTrg + 14, xmm14);
+        _mm_store_si128(pTrg + 15, xmm15);
+#endif
+        pTrg += regsInLoop;
+    }
+
+    // Copy in 16 byte steps
+    if (reminder >= 16)
+    {
+        size = reminder;
+        reminder = size & 15;
+        end = size >> 4;
+        for (size_t i = 0; i < end; ++i)
+        {
+            pTrg[i] = _mm_stream_load_si128(pSrc + i);
+        }
+    }
+
+    // Copy last bytes - shouldn't happen as strides are modulu 16
+    if (reminder)
+    {
+        __m128i temp = _mm_stream_load_si128(pSrc + end);
+
+        char* ps = (char*)(&temp);
+        char* pt = (char*)(pTrg + end);
+
+        for (size_t i = 0; i < reminder; ++i)
+        {
+            pt[i] = ps[i];
+        }
+    }
+
+    return d;
+}

--- a/xbmc/utils/win32/memcpy_sse2.h
+++ b/xbmc/utils/win32/memcpy_sse2.h
@@ -1,0 +1,113 @@
+/*
+*      Copyright (C) 2005-2015 Team Kodi
+*      http://kodi.tv
+*
+*  This library is free software; you can redistribute it and/or
+*  modify it under the terms of the GNU Lesser General Public
+*  License as published by the Free Software Foundation; either
+*  version 2.1 of the License, or (at your option) any later version.
+*
+*  This library is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+*  Lesser General Public License for more details.
+*
+*  You should have received a copy of the GNU Lesser General Public
+*  License along with this library; if not, write to the Free Software
+*  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*
+*/
+
+#include <emmintrin.h>
+
+inline void* memcpy_aligned(void* dst, const void* src, size_t size)
+{
+  size_t i;
+  __m128i xmm1, xmm2, xmm3, xmm4;
+
+  // if memory is not aligned, use memcpy
+  if ((((size_t)(src) | (size_t)(dst)) & 0xF))
+    return memcpy(dst, src, size);
+
+  uint8_t* d = (uint8_t*)(dst);
+  uint8_t* s = (uint8_t*)(src);
+
+  for (i = 0; i < size - 63; i += 64)
+  {
+    xmm1 = _mm_load_si128((__m128i*)(s + i +  0));
+    xmm2 = _mm_load_si128((__m128i*)(s + i + 16));
+    xmm3 = _mm_load_si128((__m128i*)(s + i + 32));
+    xmm4 = _mm_load_si128((__m128i*)(s + i + 48));
+    _mm_stream_si128((__m128i*)(d + i +  0), xmm1);
+    _mm_stream_si128((__m128i*)(d + i + 16), xmm2);
+    _mm_stream_si128((__m128i*)(d + i + 32), xmm3);
+    _mm_stream_si128((__m128i*)(d + i + 48), xmm4);
+  }
+  for (; i < size; i += 16)
+  {
+    xmm1 = _mm_load_si128((__m128i*)(s + i));
+    _mm_stream_si128((__m128i*)(d + i), xmm1);
+  }
+  return dst;
+}
+
+inline void convert_yuv420_nv12(uint8_t *const src[], const int srcStride[], int height, int width, uint8_t *const dst[], const int dstStride[])
+{
+  __m128i xmm0, xmm1, xmm2, xmm3, xmm4;
+  _mm_sfence();
+
+  // Convert to NV12 - Luma
+  if (srcStride[0] == dstStride[0])
+    memcpy_aligned(dst[0], src[0], srcStride[0] * height);
+  else
+  {
+    for (size_t line = 0; line < height; ++line)
+    {
+      uint8_t * s = src[0] + srcStride[0] * line;
+      uint8_t * d = dst[0] + dstStride[0] * line;
+      memcpy_aligned(d, s, srcStride[0]);
+    }
+  }
+  // Convert to NV12 - Chroma
+  size_t chromaWidth = (width + 1) >> 1;
+  size_t chromaHeight = height >> 1;
+  for (size_t line = 0; line < chromaHeight; ++line)
+  {
+    size_t i;
+    uint8_t * u = src[1] + line * srcStride[1];
+    uint8_t * v = src[2] + line * srcStride[2];
+    uint8_t * d = dst[1] + line * dstStride[1];
+    for (i = 0; i < (chromaWidth - 31); i += 32)
+    {
+      xmm0 = _mm_load_si128((__m128i*)(v + i));
+      xmm1 = _mm_load_si128((__m128i*)(u + i));
+      xmm2 = _mm_load_si128((__m128i*)(v + i + 16));
+      xmm3 = _mm_load_si128((__m128i*)(u + i + 16));
+
+      xmm4 = xmm0;
+      xmm0 = _mm_unpacklo_epi8(xmm1, xmm0);
+      xmm4 = _mm_unpackhi_epi8(xmm1, xmm4);
+
+      xmm1 = xmm2;
+      xmm2 = _mm_unpacklo_epi8(xmm3, xmm2);
+      xmm1 = _mm_unpackhi_epi8(xmm3, xmm1);
+
+      _mm_stream_si128((__m128i *)(d + (i << 1) + 0), xmm0);
+      _mm_stream_si128((__m128i *)(d + (i << 1) + 16), xmm4);
+      _mm_stream_si128((__m128i *)(d + (i << 1) + 32), xmm2);
+      _mm_stream_si128((__m128i *)(d + (i << 1) + 48), xmm1);
+    }
+    for (; i < chromaWidth; i += 16)
+    {
+      xmm0 = _mm_load_si128((__m128i*)(v + i));
+      xmm1 = _mm_load_si128((__m128i*)(u + i));
+
+      xmm2 = xmm0;
+      xmm0 = _mm_unpacklo_epi8(xmm1, xmm0);
+      xmm2 = _mm_unpackhi_epi8(xmm1, xmm2);
+
+      _mm_stream_si128((__m128i *)(d + (i << 1) + 0), xmm0);
+      _mm_stream_si128((__m128i *)(d + (i << 1) + 16), xmm2);
+    }
+  }
+}


### PR DESCRIPTION
Set of improvements. For more info please see commit messages.
1. CopyDXVA2Picture - here is a comparsion between different methods of copying dxva FHD frame into sysmem.
   ![gpucopy](https://cloud.githubusercontent.com/assets/2063885/8908853/0bfaf4bc-3487-11e5-8023-97995d6a5a6f.jpg)
2. CProcessorHD::Convert  - here is a comparsion between old memcpy and new sse2 method (used FHD frame).
   ![dxvacopy](https://cloud.githubusercontent.com/assets/2063885/8908884/28334af8-3487-11e5-8601-2d9ad16873e1.jpg)

@fritsch @FernetMenta please take a look.
