### PR TITLE
[libsquish] use the appropriate ar/cxx/ranlib commands via the exported variable

### DIFF
--- a/tools/depends/native/libsquish-native/src/Makefile
+++ b/tools/depends/native/libsquish-native/src/Makefile
@@ -1,6 +1,10 @@
 
 include config
 
+AR_FOR_BUILD ?= ar
+CXX_FOR_BUILD ?= cxx
+RANLIB_FOR_BUILD ?= ranlib
+
 SRC = alpha.cpp clusterfit.cpp colourblock.cpp colourfit.cpp colourset.cpp maths.cpp rangefit.cpp singlecolourfit.cpp squish.cpp
 
 OBJ = $(SRC:%.cpp=%.o)
@@ -19,11 +23,11 @@ uninstall:
 	$(RM) $(INSTALL_DIR)/lib/libsquish.a
 
 $(LIB) : $(OBJ)
-	$(AR) cr $@ $?
-	ranlib $@
+	$(AR_FOR_BUILD) cr $@ $?
+	$(RANLIB_FOR_BUILD) $@
 
 %.o : %.cpp
-	$(CXX) $(CPPFLAGS) -I. $(CXXFLAGS) -o$@ -c $<
+	$(CXX_FOR_BUILD) $(CPPFLAGS) -I. $(CXXFLAGS) -o$@ -c $<
 
 clean :
 	$(RM) $(OBJ) $(LIB)


### PR DESCRIPTION
Avoids running into the following issue when ranlib is prefixed on cross hosts:

make -C native
make[1]: Entering directory '/var/tmp/paludis/build/media-kodi-15.0/work/xbmc-15.0-Isengard/tools/depends/native/libsquish-native/native'
x86_64-pc-linux-gnu-g++ -pipe -O2 -march=native -I. -O2 -DNDEBUG=1 -pipe -O2 -march=native -pipe -O2 -fPIC -DPIC -D_REENTRANT -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -std=gnu++11 -oalpha.o -c alpha.cpp
x86_64-pc-linux-gnu-g++ -pipe -O2 -march=native -I. -O2 -DNDEBUG=1 -pipe -O2 -march=native -pipe -O2 -fPIC -DPIC -D_REENTRANT -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -std=gnu++11 -oclusterfit.o -c clusterfit.cpp
x86_64-pc-linux-gnu-g++ -pipe -O2 -march=native -I. -O2 -DNDEBUG=1 -pipe -O2 -march=native -pipe -O2 -fPIC -DPIC -D_REENTRANT -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -std=gnu++11 -ocolourblock.o -c colourblock.cpp
x86_64-pc-linux-gnu-g++ -pipe -O2 -march=native -I. -O2 -DNDEBUG=1 -pipe -O2 -march=native -pipe -O2 -fPIC -DPIC -D_REENTRANT -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -std=gnu++11 -ocolourfit.o -c colourfit.cpp
x86_64-pc-linux-gnu-g++ -pipe -O2 -march=native -I. -O2 -DNDEBUG=1 -pipe -O2 -march=native -pipe -O2 -fPIC -DPIC -D_REENTRANT -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -std=gnu++11 -ocolourset.o -c colourset.cpp
x86_64-pc-linux-gnu-g++ -pipe -O2 -march=native -I. -O2 -DNDEBUG=1 -pipe -O2 -march=native -pipe -O2 -fPIC -DPIC -D_REENTRANT -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -std=gnu++11 -omaths.o -c maths.cpp
x86_64-pc-linux-gnu-g++ -pipe -O2 -march=native -I. -O2 -DNDEBUG=1 -pipe -O2 -march=native -pipe -O2 -fPIC -DPIC -D_REENTRANT -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -std=gnu++11 -orangefit.o -c rangefit.cpp
x86_64-pc-linux-gnu-g++ -pipe -O2 -march=native -I. -O2 -DNDEBUG=1 -pipe -O2 -march=native -pipe -O2 -fPIC -DPIC -D_REENTRANT -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -std=gnu++11 -osinglecolourfit.o -c singlecolourfit.cpp
x86_64-pc-linux-gnu-g++ -pipe -O2 -march=native -I. -O2 -DNDEBUG=1 -pipe -O2 -march=native -pipe -O2 -fPIC -DPIC -D_REENTRANT -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -std=gnu++11 -osquish.o -c squish.cpp
x86_64-pc-linux-gnu-ar cr libsquish.a alpha.o clusterfit.o colourblock.o colourfit.o colourset.o maths.o rangefit.o singlecolourfit.o squish.o
ranlib libsquish.a
Makefile:22: recipe for target 'libsquish.a' failed
make[1]: Leaving directory '/var/tmp/paludis/build/media-kodi-15.0/work/xbmc-15.0-Isengard/tools/depends/native/libsquish-native/native'
Makefile:36: recipe for target 'native/libsquish.a' failed
make: Leaving directory '/var/tmp/paludis/build/media-kodi-15.0/work/xbmc-15.0-Isengard/tools/depends/native/libsquish-native'
checking for SQUISH... no
make[1]: ranlib: Command not found
make[1]: **\* [libsquish.a] Error 127
make: **\* [native/libsquish.a] Error 2
configure: error: "squish not found"

Error:
- In program cave perform install --hooks --managed-output --output-exclusivity with-others =media/kodi-15.0:0::media --destination installed --replacing =media/kodi-15.0:0::installed --x-of-y 1 of 1:
- When installing 'media/kodi-15.0:0::media' replacing { 'media/kodi-15.0:0::installed' }:
- When running an ebuild command on 'media/kodi-15.0:0::media':
- Install failed for 'media/kodi-15.0:0::media' (paludis::ActionFailedError)

!!! ERROR in media/kodi-15.0::media:
!!! In econf at line 1429
!!! econf failed
