### PR TITLE
fix TestDatabaseUtils.GetField_MediaTypeSong unit test

### DIFF
--- a/xbmc/utils/DatabaseUtils.cpp
+++ b/xbmc/utils/DatabaseUtils.cpp
@@ -96,7 +96,7 @@ std::string DatabaseUtils::GetField(Field field, const MediaType &mediaType, Dat
     else if (field == FieldPath) return "songview.strPath";
     else if (field == FieldArtist || field == FieldAlbumArtist) return "songview.strArtists";
     else if (field == FieldGenre) return "songview.strGenre";
-    else if (field == FieldDateAdded && queryPart == DatabaseQueryPartOrderBy) return "songview.dateAdded";
+    else if (field == FieldDateAdded) return "songview.dateAdded";
   }
   else if (mediaType == MediaTypeArtist)
   {

--- a/xbmc/utils/test/TestDatabaseUtils.cpp
+++ b/xbmc/utils/test/TestDatabaseUtils.cpp
@@ -286,12 +286,7 @@ TEST(TestDatabaseUtils, GetField_MediaTypeSong)
                                    DatabaseQueryPartSelect);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
-  refstr = "songview.idSong";
-  varstr = DatabaseUtils::GetField(FieldDateAdded, MediaTypeSong,
-                                   DatabaseQueryPartOrderBy);
-  EXPECT_STREQ(refstr.c_str(), varstr.c_str());
-
-  refstr = "";
+  refstr = "songview.dateAdded";
   varstr = DatabaseUtils::GetField(FieldDateAdded, MediaTypeSong,
                                    DatabaseQueryPartSelect);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());


### PR DESCRIPTION
As pointed out by @notspiff the `TestDatabaseUtils.GetField_MediaTypeSong` has been broken by the recent addition of the date added field for songs. This fixes it.

Ideally the date added implementation in the music library would be extended to albums and artists by using the maximum date added value from all the matching songs like we do for tvshows using episodes. But that's out of the scope of this PR.
