### PR TITLE
[binary addons] fix/support ZIP packaging

### DIFF
--- a/project/cmake/addons/CMakeLists.txt
+++ b/project/cmake/addons/CMakeLists.txt
@@ -82,7 +82,16 @@ option(PACKAGE_ZIP "Prepare built addons for packaging" OFF)
 if(PACKAGE_ZIP)
   # needed for project installing
   list(APPEND BUILD_ARGS -DPACKAGE_ZIP=ON)
-  MESSAGE(STATUS "ZIP packaging enabled")
+
+  # figure out where to store the packaged ZIP archives
+  if(NOT PACKAGE_DIR)
+    set(PACKAGE_DIR "${BUILD_DIR}/zips")
+  else()
+    file(TO_CMAKE_PATH "${CMAKE_PREFIX_PATH}" CMAKE_PREFIX_PATH)
+  endif()
+  list(APPEND BUILD_ARGS -DPACKAGE_DIR=${PACKAGE_DIR})
+
+  MESSAGE(STATUS "ZIP packaging enabled (destination: ${PACKAGE_DIR}})")
 endif()
 
 if(CMAKE_TOOLCHAIN_FILE)

--- a/project/cmake/addons/CMakeLists.txt
+++ b/project/cmake/addons/CMakeLists.txt
@@ -146,6 +146,9 @@ include(prepare-env)
 ### add the depends subdirectory for any general dependencies
 add_subdirectory(depends)
 
+# add a custom target "package-addons" which will package and install all addons
+add_custom_target(package-addons)
+
 ### get and build all the binary addons
 # look for all the addons to be built
 file(GLOB_RECURSE addons ${PROJECT_SOURCE_DIR}/addons/*.txt)
@@ -280,6 +283,12 @@ foreach(addon ${addons})
               add_dependencies(${id} ${${id}_DEPS})
             endif()
           endif()
+
+          # create a forwarding target to the addon-package target
+          add_custom_target(package-${id}
+                    COMMAND ${CMAKE_COMMAND} --build ${BUILD_DIR}/${id}-prefix/src/${id}-build --target addon-package
+                    DEPENDS ${id})
+          add_dependencies(package-addons package-${id})
         else()
           message(FATAL_ERROR "${id}: invalid or missing addon source directory at ${SOURCE_DIR}")
         endif()

--- a/project/cmake/addons/README
+++ b/project/cmake/addons/README
@@ -48,6 +48,8 @@ specific paths:
   * PACKAGE_ZIP=ON means that the add-ons will be 'packaged' into a common folder,
     rather than being placed in <CMAKE_INSTALL_PREFIX>/lib/kodi/addons and
     <CMAKE_INSTALL_PREFIX>/share/kodi/addons.
+  * PACKAGE_DIR points to the directory where the ZIP archived addons will be
+    stored after they have been packaged (defaults to <BUILD_DIR>/zips)
   * ARCH_DEFINES specifies the platform-specific C/C++ preprocessor defines
     (defaults to empty).
 

--- a/project/cmake/addons/addons/audioencoder.flac/audioencoder.flac.txt
+++ b/project/cmake/addons/addons/audioencoder.flac/audioencoder.flac.txt
@@ -1,1 +1,1 @@
-audioencoder.flac https://github.com/xbmc/audioencoder.flac a5e2d12
+audioencoder.flac https://github.com/xbmc/audioencoder.flac 4603889

--- a/project/cmake/addons/addons/audioencoder.lame/audioencoder.lame.txt
+++ b/project/cmake/addons/addons/audioencoder.lame/audioencoder.lame.txt
@@ -1,1 +1,1 @@
-audioencoder.lame https://github.com/xbmc/audioencoder.lame b283cd5
+audioencoder.lame https://github.com/xbmc/audioencoder.lame 0f612d4

--- a/project/cmake/addons/addons/audioencoder.wav/audioencoder.wav.txt
+++ b/project/cmake/addons/addons/audioencoder.wav/audioencoder.wav.txt
@@ -1,1 +1,1 @@
-audioencoder.wav https://github.com/xbmc/audioencoder.wav 797c990
+audioencoder.wav https://github.com/xbmc/audioencoder.wav 77e1612

--- a/project/cmake/scripts/common/addon-helpers.cmake
+++ b/project/cmake/scripts/common/addon-helpers.cmake
@@ -10,10 +10,14 @@ add_custom_target(addon-package
                   COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target package)
 
 macro(add_cpack_workaround target version ext)
+  if(NOT PACKAGE_DIR)
+    set(PACKAGE_DIR "${CMAKE_INSTALL_PREFIX}/zips")
+  endif()
+
   add_custom_command(TARGET addon-package PRE_BUILD
                      COMMAND ${CMAKE_COMMAND} -E rename ${CMAKE_BINARY_DIR}/addon-${target}-${version}.${ext} ${CMAKE_BINARY_DIR}/${target}-${version}.${ext}
-                     COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_INSTALL_PREFIX}/zip
-                     COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/${target}-${version}.${ext} ${CMAKE_INSTALL_PREFIX}/zip)
+                     COMMAND ${CMAKE_COMMAND} -E make_directory ${PACKAGE_DIR}
+                     COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/${target}-${version}.${ext} ${PACKAGE_DIR})
 endmacro()
 
 # Grab the version from a given add-on's addon.xml

--- a/project/cmake/scripts/common/addon-helpers.cmake
+++ b/project/cmake/scripts/common/addon-helpers.cmake
@@ -11,7 +11,9 @@ add_custom_target(addon-package
 
 macro(add_cpack_workaround target version ext)
   add_custom_command(TARGET addon-package PRE_BUILD
-                     COMMAND ${CMAKE_COMMAND} -E rename addon-${target}-${version}.${ext} ${target}-${version}.${ext})
+                     COMMAND ${CMAKE_COMMAND} -E rename ${CMAKE_BINARY_DIR}/addon-${target}-${version}.${ext} ${CMAKE_BINARY_DIR}/${target}-${version}.${ext}
+                     COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_INSTALL_PREFIX}/zip
+                     COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/${target}-${version}.${ext} ${CMAKE_INSTALL_PREFIX}/zip)
 endmacro()
 
 # Grab the version from a given add-on's addon.xml

--- a/tools/buildsteps/win32/make-addons.bat
+++ b/tools/buildsteps/win32/make-addons.bat
@@ -6,6 +6,7 @@ SET EXITCODE=0
 
 SET install=false
 SET clean=false
+SET package=false
 SET addon=
 
 SETLOCAL EnableDelayedExpansion
@@ -14,9 +15,11 @@ FOR %%b IN (%*) DO (
     SET install=true
   ) ELSE ( IF %%b == clean (
     SET clean=true
+  ) ELSE ( IF %%b == package (
+    SET package=true
   ) ELSE (
     SET addon=!addon! %%b
-  ))
+  )))
 )
 SETLOCAL DisableDelayedExpansion
 
@@ -129,7 +132,17 @@ FOR %%a IN (%ADDONS_TO_MAKE%) DO (
     ECHO nmake %%a error level: %ERRORLEVEL% > %ERRORFILE%
     ECHO %%a >> %ADDONS_FAILURE_FILE%
   ) ELSE (
-    ECHO %%a >> %ADDONS_SUCCESS_FILE%
+    if %package% == true (
+      nmake package-%%a
+      IF ERRORLEVEL 1 (
+        ECHO nmake package-%%a error level: %ERRORLEVEL% > %ERRORFILE%
+        ECHO %%a >> %ADDONS_FAILURE_FILE%
+      ) ELSE (
+        ECHO %%a >> %ADDONS_SUCCESS_FILE%
+      )
+    ) ELSE (
+      ECHO %%a >> %ADDONS_SUCCESS_FILE%
+    )
   )
 )
 


### PR DESCRIPTION
These commits add/fix support for packaging built binary addons into a ZIP archive. Most of the functionality has already been provided by @notspiff and the rest I "stole" from his other cmake scripts after some kind pointers from him.
With these changes it is possible to extecute the `package-addons` or any of the `package-<addon-id>` targets on the generated build files to package all or a specific addon that has previously been built.

There are two things that need attention:
- The fixed path in https://github.com/xbmc/xbmc/compare/xbmc:master...Montellese:cmake_addons_packaging?expand=1#diff-b100f554dc9c53a628bcf373a545eda9R289 looks very ugly but I couldn't find a variable that would provide this path.
- Where should the generated ZIP files be copied/installed to? I used CMAKE_INSTALL_PREFIX for now (see https://github.com/xbmc/xbmc/compare/xbmc:master...Montellese:cmake_addons_packaging?expand=1#diff-88c873338ed1cc64c771fdefc1f40754R15) but I'm pretty sure that that's the wrong location for linux/depends. It's also not the proper location for win32 but it was the easiest for now. This will most likely only be something used by jenkins to upload the ZIP archives to our mirrors.

I had to bump the audioencoder addons because they were missing `include(CPack)`. @notspiff: Is there a reason why this include is not in `addon-helpers.cmake`?
