### PR TITLE
[osx] - reimplement Cocoa_GetVolumeNameFromMountPoint with a more cur…

### DIFF
--- a/xbmc/osx/CocoaInterface.mm
+++ b/xbmc/osx/CocoaInterface.mm
@@ -286,54 +286,32 @@ char* Cocoa_MountPoint2DeviceName(char *path)
 bool Cocoa_GetVolumeNameFromMountPoint(const std::string &mountPoint, std::string &volumeName)
 {
   CCocoaAutoPool pool;
-  unsigned i, count = 0;
-  struct statfs *buf = NULL;
-  std::string mountpoint, devicepath;
-
-  count = getmntinfo(&buf, 0);
-  for (i=0; i<count; i++)
+  NSFileManager *fm = [NSFileManager defaultManager];
+  NSArray *mountedVolumeUrls = [fm mountedVolumeURLsIncludingResourceValuesForKeys:@[ NSURLVolumeNameKey, NSURLPathKey ] options:0];
+  bool resolved = false;
+  
+  for (NSURL *volumeURL in mountedVolumeUrls)
   {
-    mountpoint = buf[i].f_mntonname;
-    if (mountpoint == mountPoint)
+    NSString *path;
+    BOOL success = [volumeURL getResourceValue:&path forKey:NSURLPathKey error:nil];
+    
+    if (success && path != nil)
     {
-      devicepath = buf[i].f_mntfromname;
-      break;
+      std::string mountpoint = [path UTF8String];
+      if (mountpoint == mountPoint)
+      {
+        NSString *name;
+        success = [volumeURL getResourceValue:&name forKey:NSURLVolumeNameKey error:nil];
+        if (success && name != nil)
+        {
+          volumeName = [name UTF8String];
+          resolved = true;
+          break;
+        }
+      }
     }
   }
-  if (devicepath.empty())
-  {
-    return false;
-  }
-
-  DASessionRef session = DASessionCreate(kCFAllocatorDefault);
-  if (!session)
-  {
-      return false;
-  }
-
-  DADiskRef disk = DADiskCreateFromBSDName(kCFAllocatorDefault, session, devicepath.c_str());
-  if (!disk)
-  {
-      CFRelease(session);
-      return false;
-  }
-
-  NSDictionary *dd = (NSDictionary*) DADiskCopyDescription(disk);
-  if (!dd)
-  {
-      CFRelease(session);
-      CFRelease(disk);
-      return false;
-  }
-
-  NSString *volumename = [dd objectForKey:(NSString*)kDADiskDescriptionVolumeNameKey];
-  volumeName = [volumename UTF8String];
-
-  CFRelease(session);		        
-  CFRelease(disk);		        
-  [dd release];
-
-  return true ;
+  return resolved;
 }
 
 /*


### PR DESCRIPTION
…rent version - should fix strange crashes on some system with mounted HDDs.

This fixes a crash which happend with the old code on some systems (didn't really investigate because i couldn't reproduce - seem to have something to do with the sort of mounted HDDs, USBsticks or Network shares).  The fix was confirmed by user.

Backport incoming
