### PR TITLE
AML: Fix AMLCodec video size on M8, M8B and M8M2

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/AMLCodec.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/AMLCodec.cpp
@@ -1440,6 +1440,7 @@ CAMLCodec::CAMLCodec() : CThread("CAMLCodec")
   m_dll = new DllLibAmCodec;
   m_dll->Load();
   am_private->m_dll = m_dll;
+  m_WindowAxis = amlGetWindowAxis();
 }
 
 
@@ -1680,12 +1681,19 @@ bool CAMLCodec::OpenDecoder(CDVDStreamInfo &hints)
   g_renderManager.RegisterRenderUpdateCallBack((const void*)this, RenderUpdateCallBack);
   g_renderManager.RegisterRenderFeaturesCallBack((const void*)this, RenderFeaturesCallBack);
 
-  m_display_rect = CRect(0, 0, CDisplaySettings::Get().GetCurrentResolutionInfo().iWidth, CDisplaySettings::Get().GetCurrentResolutionInfo().iHeight);
+  if ((aml_get_device_type() >= AML_DEVICE_TYPE_M8) && (aml_get_device_type() <= AML_DEVICE_TYPE_M8M2) && (!m_WindowAxis.bError))
+  {
+    m_display_rect = CRect(m_WindowAxis.iX, m_WindowAxis.iY, m_WindowAxis.iWidth, m_WindowAxis.iHeight);
+  }
+  else
+  {
+    m_display_rect = CRect(0, 0, CDisplaySettings::Get().GetCurrentResolutionInfo().iWidth, CDisplaySettings::Get().GetCurrentResolutionInfo().iHeight);
 
-  std::string strScaler;
-  SysfsUtils::GetString("/sys/class/ppmgr/ppscaler", strScaler);
-  if (strScaler.find("enabled") == std::string::npos)     // Scaler not enabled, use screen size
-    m_display_rect = CRect(0, 0, CDisplaySettings::Get().GetCurrentResolutionInfo().iScreenWidth, CDisplaySettings::Get().GetCurrentResolutionInfo().iScreenHeight);
+    std::string strScaler;
+    SysfsUtils::GetString("/sys/class/ppmgr/ppscaler", strScaler);
+    if (strScaler.find("enabled") == std::string::npos)     // Scaler not enabled, use screen size
+      m_display_rect = CRect(0, 0, CDisplaySettings::Get().GetCurrentResolutionInfo().iScreenWidth, CDisplaySettings::Get().GetCurrentResolutionInfo().iScreenHeight);
+  }
 
 /*
   // if display is set to 1080xxx, then disable deinterlacer for HD content
@@ -2215,7 +2223,12 @@ void CAMLCodec::SetVideoRect(const CRect &SrcRect, const CRect &DestRect)
   }
 
   // dest_rect
-  CRect dst_rect = DestRect;
+  CRect dst_rect;
+
+  if ((aml_get_device_type() >= AML_DEVICE_TYPE_M8) && (aml_get_device_type() <= AML_DEVICE_TYPE_M8M2) && (!m_WindowAxis.bError))
+    dst_rect = CRect(m_WindowAxis.iX, m_WindowAxis.iY, m_WindowAxis.iWidth, m_WindowAxis.iHeight);
+  else
+    dst_rect = DestRect;
   // handle orientation
   switch (am_private->video_rotation_degree)
   {
@@ -2227,7 +2240,10 @@ void CAMLCodec::SetVideoRect(const CRect &SrcRect, const CRect &DestRect)
     case 3:
       {
         int diff = (int) ((dst_rect.Height() - dst_rect.Width()) / 2);
-        dst_rect = CRect(DestRect.x1 - diff, DestRect.y1, DestRect.x2 + diff, DestRect.y2);
+        if ((aml_get_device_type() >= AML_DEVICE_TYPE_M8) && (aml_get_device_type() <= AML_DEVICE_TYPE_M8M2) && (!m_WindowAxis.bError))
+          dst_rect = CRect(m_WindowAxis.iX - diff, m_WindowAxis.iY, m_WindowAxis.iWidth + diff, m_WindowAxis.iHeight);
+        else
+          dst_rect = CRect(DestRect.x1 - diff, DestRect.y1, DestRect.x2 + diff, DestRect.y2);
       }
 
   }
@@ -2246,14 +2262,18 @@ void CAMLCodec::SetVideoRect(const CRect &SrcRect, const CRect &DestRect)
   }
 
   CRect gui, display;
-  gui = CRect(0, 0, CDisplaySettings::Get().GetCurrentResolutionInfo().iWidth, CDisplaySettings::Get().GetCurrentResolutionInfo().iHeight);
+
+  if ((aml_get_device_type() >= AML_DEVICE_TYPE_M8) && (aml_get_device_type() <= AML_DEVICE_TYPE_M8M2) && (!m_WindowAxis.bError))
+    gui = CRect(m_WindowAxis.iX, m_WindowAxis.iY, m_WindowAxis.iWidth, m_WindowAxis.iHeight);
+  else
+    gui = CRect(0, 0, CDisplaySettings::Get().GetCurrentResolutionInfo().iWidth, CDisplaySettings::Get().GetCurrentResolutionInfo().iHeight);
 
 #ifdef TARGET_ANDROID
   display = m_display_rect;
 #else
   display = gui;
 #endif
-  if (gui != display)
+  if (((gui != display) && ((aml_get_device_type() >= AML_DEVICE_TYPE_M1) && (aml_get_device_type() <= AML_DEVICE_TYPE_M6))) || (m_WindowAxis.bError))
   {
     float xscale = display.Width() / gui.Width();
     float yscale = display.Height() / gui.Height();
@@ -2261,10 +2281,25 @@ void CAMLCodec::SetVideoRect(const CRect &SrcRect, const CRect &DestRect)
       xscale /= 2.0;
     else if (m_stereo_mode == RENDER_STEREO_MODE_SPLIT_HORIZONTAL)
       yscale /= 2.0;
+
     dst_rect.x1 *= xscale;
     dst_rect.x2 *= xscale;
     dst_rect.y1 *= yscale;
     dst_rect.y2 *= yscale;
+  }
+  else
+  {
+    float xscale = 1;
+    float yscale = 1;
+    if (m_stereo_mode == RENDER_STEREO_MODE_SPLIT_VERTICAL)
+      xscale /= 2.0;
+    else if (m_stereo_mode == RENDER_STEREO_MODE_SPLIT_HORIZONTAL)
+      yscale /= 2.0;
+
+    dst_rect.x1 = m_WindowAxis.iX * xscale;
+    dst_rect.x2 = m_WindowAxis.iWidth * xscale;
+    dst_rect.y1 = m_WindowAxis.iY * yscale;
+    dst_rect.y2 = m_WindowAxis.iHeight * yscale;
   }
 
   if (m_stereo_mode == RENDER_STEREO_MODE_MONO)
@@ -2331,10 +2366,14 @@ void CAMLCodec::SetVideoRect(const CRect &SrcRect, const CRect &DestRect)
   CLog::Log(LOGDEBUG, "CAMLCodec::SetVideoRect:m_stereo_view(%d)", m_stereo_view);
 #endif
 
-  // goofy 0/1 based difference in aml axis coordinates.
-  // fix them.
-  dst_rect.x2--;
-  dst_rect.y2--;
+  // Not needed on M8 platforms
+  if ((aml_get_device_type() >= AML_DEVICE_TYPE_M1) && (aml_get_device_type() <= AML_DEVICE_TYPE_M6))
+  {
+    // goofy 0/1 based difference in aml axis coordinates.
+    // fix them.
+    dst_rect.x2--;
+    dst_rect.y2--;
+  }
 
   char video_axis[256] = {};
   sprintf(video_axis, "%d %d %d %d", (int)dst_rect.x1, (int)dst_rect.y1, (int)dst_rect.x2, (int)dst_rect.y2);

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/AMLCodec.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/AMLCodec.h
@@ -25,6 +25,7 @@
 #include "guilib/Geometry.h"
 #include "rendering/RenderSystem.h"
 #include "threads/Thread.h"
+#include "utils/AMLUtils.h"
 
 typedef struct am_private_t am_private_t;
 
@@ -79,6 +80,8 @@ private:
   int64_t          m_start_dts;
   int64_t          m_start_pts;
   CEvent           m_ready_event;
+
+  SAmlWindowAxis   m_WindowAxis;
 
   CRect            m_dst_rect;
   CRect            m_display_rect;

--- a/xbmc/utils/AMLUtils.cpp
+++ b/xbmc/utils/AMLUtils.cpp
@@ -302,6 +302,40 @@ int aml_axis_value(AML_DISPLAY_AXIS_PARAM param)
   return value[param];
 }
 
+SAmlWindowAxis amlGetWindowAxis()
+{
+  SAmlWindowAxis mWindowAxis;
+  std::string sWindowAxis;
+  if (!SysfsUtils::Has("/sys/class/graphics/fb0/window_axis"))
+  {
+    CLog::Log(LOGDEBUG, "amlGetWindowAxis: Cannot access /sys/class/graphics/fb0/window_axis");
+    mWindowAxis.bError = true;
+  }
+  else
+  {
+    SysfsUtils::GetString("/sys/class/graphics/fb0/window_axis", sWindowAxis);
+
+    int iStartValues = sWindowAxis.find('[') + 1;
+    int iEndValues = sWindowAxis.find(']');
+    sWindowAxis = sWindowAxis.substr(iStartValues, iEndValues - iStartValues);
+
+    sscanf(sWindowAxis.c_str(), "%d %d %d %d", &mWindowAxis.iX, &mWindowAxis.iY, &mWindowAxis.iWidth, &mWindowAxis.iHeight);
+    if ((mWindowAxis.iWidth > 0) && (mWindowAxis.iHeight > 0))
+    {
+      mWindowAxis.bError = false;
+      CLog::Log(LOGDEBUG, "amlGetWindowAxis: window_axis parsed OK; X: %d; Y: %d; Width: %d; Height: %d",
+                 mWindowAxis.iX, mWindowAxis.iY, mWindowAxis.iWidth, mWindowAxis.iHeight);
+    }
+    else
+    {
+      mWindowAxis.bError = true;
+      CLog::Log(LOGERROR, "amlGetWindowAxis: Error while parsing window_axis");
+    }
+  }
+
+  return mWindowAxis;
+}
+
 bool aml_mode_to_resolution(const char *mode, RESOLUTION_INFO *res)
 {
   if (!res)

--- a/xbmc/utils/AMLUtils.h
+++ b/xbmc/utils/AMLUtils.h
@@ -41,12 +41,22 @@ enum AML_DISPLAY_AXIS_PARAM
   AML_DISPLAY_AXIS_PARAM_HEIGHT
 };
 
+struct SAmlWindowAxis
+{
+  bool bError;
+  int iX;
+  int iY;
+  int iWidth;
+  int iHeight;
+};
+
 bool aml_present();
 bool aml_permissions();
 bool aml_hw3d_present();
 bool aml_wired_present();
 bool aml_support_hevc();
 enum AML_DEVICE_TYPE aml_get_device_type();
+SAmlWindowAxis amlGetWindowAxis();
 void aml_cpufreq_min(bool limit);
 void aml_cpufreq_max(bool limit);
 void aml_set_audio_passthrough(bool passthrough);


### PR DESCRIPTION
This patch is not finished yet, zoom option does not work for now (it is always set to stretch).

Patch is based on parsing /sys/class/graphics/fb0/window_axis sysfs node on M8 devices to properly display video when using amcodec as HW accelerator.

Fix is tested as is on S802, S805 and S812 and works properly, except zoom option. On that I'm still working.
