### PR TITLE
[pvr] fix missing return in CGUIWindowPVRBase::OnBack (fixes #16150)

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -111,7 +111,10 @@ bool CGUIWindowPVRBase::OnBack(int actionID)
   {
     // don't call CGUIMediaWindow as it will attempt to go to the parent folder which we don't want.
     if (GetPreviousWindow() != WINDOW_FULLSCREEN_LIVETV)
+    {
       g_windowManager.ActivateWindow(WINDOW_HOME);
+      return true;
+    }
     else
       return CGUIWindow::OnBack(actionID);
   }


### PR DESCRIPTION
Fixes the reported issue http://trac.kodi.tv/ticket/16150

> In Confluence, when you set the option "startup window" as "TV" there is a navigation bug. This primarily affects Android TV or other users using a remote that may have limited buttons on the remote. Steps to reproduce:
> 
> Set "TV" as the startup window with Confluence skin in settings->appearance->skin->startup window and restart Kodi. 
> 
>    At startup, Kodi will now default to the "Channels" view in TV. 
> 
>    Hit left on directional pad to open up left slide out sidebar. 
> 
>    Switch to "Guide" view, and the guide is now displayed. 
> 
>    Now hit 'back', which opens up the left slide out sidebar. 
> 
>   Hit 'back' again, which should take you to the main home screen. The home screen will flash on screen for an instant, then take you immediately back to the guide. 
> 
> This only happens with the "guide" and "search" views in TV and only when "TV" is the default startup window. In other views such as "channels", "recordings", or "timer" hitting the back button will take you back to the home screen. Confusing for users as they get stuck in the UI and can't exit.
