### PR TITLE
fix trac 16159 Yes (single) / Separate is doing reverse

### DIFF
--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -1593,7 +1593,7 @@ int CBuiltins::Execute(const std::string& execString)
     if (params.size() > 1)
       singleFile = StringUtils::EqualsNoCase(params[1], "true");
     else
-      singleFile = CGUIDialogYesNo::ShowAndGetInput(CVariant{iHeading}, CVariant{20426}, cancelled, CVariant{20428}, CVariant{20429});
+      singleFile = !CGUIDialogYesNo::ShowAndGetInput(CVariant{iHeading}, CVariant{20426}, cancelled, CVariant{20428}, CVariant{20429});
 
     if (cancelled)
         return -1;


### PR DESCRIPTION
This is my attempt to fix http://trac.kodi.tv/ticket/16159

Currently The yes button implies Export to single file and Button Separate Implies Export to Separate files. However when actually pressing these buttons you quickly realise the reverse is actually happening since you get prompted to select location for separate files and get asked if you wish to export artwork when selecting single...

This PR makes YES the export to Separate files and the single to single and single is selected by default.

Theres probably a better fix for this but idk this was calculated guesswork and I tested it to the point of seeing what you are prompted to do when pressing each button.

Ideally since we are using action labels on the yes/no buttons they would both be labelled Single /Separate and the dialog message wouldnt imply either If anyone knows please take over from here.

@xhaggi @MartijnKaijser @paxxi
