### PR TITLE
[xbmc][filemanager] Fixes a crash when trying do delete a file in filemanager

### DIFF
--- a/xbmc/utils/ProgressJob.cpp
+++ b/xbmc/utils/ProgressJob.cpp
@@ -179,10 +179,20 @@ void CProgressJob::MarkFinished()
   if (m_progress != NULL)
   {
     if (m_updateProgress)
+    {
       m_progress->MarkFinished();
+      //We don't own this pointer and it will be deleted after it's marked finished
+      //just set it to nullptr so we don't try to use it again
+      m_progress = nullptr;
+    }
   }
   else if (m_progressDialog != NULL && m_autoClose)
+  {
     m_progressDialog->Close();
+    //We don't own this pointer and it will be deleted after it's marked finished
+    //just set it to nullptr so we don't try to use it again
+    m_progressDialog = nullptr;
+  }
 }
 
 bool CProgressJob::IsCancelled() const


### PR DESCRIPTION
When we mark a progressdialog job as finished the pointer will
be deleted during an update. We did not set our pointers to nullptr
when doing this. The result was that we tried to call MarkFinished
on an already finished and deleted job and writing over some random
memory.
