### PR TITLE
[unittests] - fixed duplicate main function during linkage of unit tests

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -56,7 +56,7 @@ DIRECTORY_ARCHIVES=$(DVDPLAYER_ARCHIVES) \
                    xbmc/interfaces/python/python_binding.a \
                    xbmc/linux/linux.a \
                    xbmc/listproviders/listproviders.a \
-                   xbmc/main/main.a \
+                   xbmc/main/posix/MessagePrinter.a \
                    xbmc/media/media.a \
                    xbmc/messaging/messaging.a \
                    xbmc/music/dialogs/musicdialogs.a \

--- a/configure.ac
+++ b/configure.ac
@@ -2512,6 +2512,7 @@ OUTPUT_FILES="Makefile \
     xbmc/android/jni/Makefile \
     xbmc/utils/Makefile \
     xbmc/main/Makefile \
+    xbmc/main/posix/Makefile \
     tools/darwin/Configurations/App.xcconfig \
     tools/darwin/Configurations/Common.xcconfig \
     tools/darwin/packaging/ios/mkdeb-ios.sh \

--- a/tools/buildsteps/defaultenv
+++ b/tools/buildsteps/defaultenv
@@ -10,7 +10,7 @@ TARBALLS=${TARBALLS:-"/opt/xbmc-tarballs"}
 
 BINARY_ADDONS_ROOT=tools/depends/target
 BINARY_ADDONS="binary-addons"
-DEPLOYED_BINARY_ADDONS="-e addons"
+DEPLOYED_BINARY_ADDONS="-e /addons"
 
 #set platform defaults
 #$XBMC_PLATFORM_DIR matches the platform subdirs!

--- a/xbmc/main/posix/Makefile.in
+++ b/xbmc/main/posix/Makefile.in
@@ -1,0 +1,7 @@
+.SUFFIXES : .cpp 
+ 
+SRCS = MessagePrinter.cpp 
+LIB=MessagePrinter.a 
+ 
+include @abs_top_srcdir@/Makefile.include 
+-include $(patsubst %.cpp,%.P,$(patsubst %.c,%.P,$(SRCS)))


### PR DESCRIPTION
This should get our unit tests going again. Also it fixes bad clean of our source tree (which left xbmc/addons/addons.a and object files stale) because the exclude pattern also applied for xbmc/addons and not only the addons subdir (thx @wsnipex for the correct syntax).

I have compile tested this with and without unit tests already on jenkins and have now kicked a build for verifying the clean issue. Once it looks good i will merge this with out further jenkins torture.

This partly reverts: 3764f03911fce66685e7b130e2bdd94c0893c8e2
