### PR TITLE
dvdplayer - consider clock not last frame on screen when going rewind

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
@@ -1120,7 +1120,7 @@ int CDVDPlayerVideo::OutputPicture(const DVDVideoPicture* src, double pts)
       }
       return result | EOS_DROPPED;
     }
-    else if (pts_org < (renderPts - DVD_MSEC_TO_TIME(-1500 * m_speed)))
+    else if (pts_org < iPlayingClock)
     {
       return result | EOS_DROPPED;
     }


### PR DESCRIPTION
another fix for rw

@afedchin can you test again. while having written my last comment I noticed this issue. 
