### PR TITLE
[EPG] Jump to 'now' on init of EPG timeline view

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -54,6 +54,11 @@ void CGUIWindowPVRGuide::OnInitWindow()
   if (m_guiState.get())
     m_viewControl.SetCurrentView(m_guiState->GetViewAsControl(), false);
 
+  CGUIEPGGridContainer *epgGridContainer =
+    dynamic_cast<CGUIEPGGridContainer*>(GetControl(m_viewControl.GetCurrentControl()));
+  if (epgGridContainer)
+    epgGridContainer->GoToNow();
+
   CGUIWindowPVRBase::OnInitWindow();
 }
 


### PR DESCRIPTION
Since 18dc07deda274f0a35f7cecccb8792acfd8982fd, EPG timeline view does no longer suddenly (well, on every epg data update triggered in the background) jump to "now". That's good, but the window view port now even survives a close and reopen of the window. Users complain about that in the forum.

This PR simply adds jumping to "now" when the epg timeline window gets (re)activated.

This should be backported.

@xhaggi @Jalle19 what do you think?
