### PR TITLE
[PVR] Add Timer: show/hide EPG based TimerType based on EPG info being present

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -721,8 +721,9 @@ void CGUIDialogPVRTimerSettings::InitializeTypesList()
       if (type->IsReadOnly())
         continue;
 
-      // For new timers, skip one time epg-based types. Those cannot be created using this dialog (yet).
-      if (type->IsOnetimeEpgBased())
+      // For new timers, skip epg-based types if we don't have any EpgTag already associated
+      // (since there is no way to select an EPG item in this dialog).
+      if ((!m_timerInfoTag || !m_timerInfoTag->HasEpgInfoTag()) && type->IsEpgBased())
         continue;
     }
 


### PR DESCRIPTION
While implementing pvr.wmc changes for series recording i came across the situation that when "Add Timer" screen is launched from the Timer List, my Repeating Epg TimerType was available (eventhough there is no way on this screen to "select" an EPG item to associate).  Meanwhile my Single EpgBased TimerType was not shown.  

But when creating a custom timer from the EPG/Guide, EPG Data IS passed in, and so I expected both my Single and Repeating EPG Based timer types to be available here, but only the Repeating one was (as per above)

This turned out to be because the existing implementation always removes OneTimeEpgBased but never RepeatingEpgBased.

My change makes any EpgBased timer type be available/unavailable based on whether EpgInfo is present.  This means they are not shown when launched from the Timer List (and there is no way to choose any EPG info) but when created from the Guide they are both available.

Pings: @ksooo @metaron-uk @Jalle19 
