### PR TITLE
[guilib] revert fix label overlap in radiobutton control

### DIFF
--- a/xbmc/guilib/GUIRadioButtonControl.cpp
+++ b/xbmc/guilib/GUIRadioButtonControl.cpp
@@ -98,24 +98,6 @@ void CGUIRadioButtonControl::Process(unsigned int currentTime, CDirtyRegionList 
   CGUIButtonControl::Process(currentTime, dirtyregions);
 }
 
-void CGUIRadioButtonControl::ProcessText(unsigned int currentTime)
-{
-  bool changed = false;
-
-  if (m_bInvalidated)
-  {
-    changed |= m_label.SetMaxRect(m_posX, m_posY, m_width - m_imgRadioOnFocus.GetWidth(), m_height);
-    changed |= m_label.SetText(m_info.GetLabel(GetParentID()));
-  }
-
-  changed |= m_label.SetScrolling(HasFocus());
-  changed |= m_label.SetColor(GetTextColor());
-  changed |= m_label.Process(currentTime);
-
-  if (changed)
-    MarkDirtyRegion();
-}
-
 bool CGUIRadioButtonControl::OnAction(const CAction &action)
 {
   if (action.GetID() == ACTION_SELECT_ITEM)

--- a/xbmc/guilib/GUIRadioButtonControl.h
+++ b/xbmc/guilib/GUIRadioButtonControl.h
@@ -63,7 +63,6 @@ public:
   bool IsSelected() const { return m_bSelected; };
 protected:
   virtual bool UpdateColors();
-  virtual void ProcessText(unsigned int currentTime);
   CGUITexture m_imgRadioOnFocus;
   CGUITexture m_imgRadioOnNoFocus;
   CGUITexture m_imgRadioOffFocus;


### PR DESCRIPTION
This reverts commit ed01342cecc01deb4c53938f19b8db9d3fae7185 as it is
causing too much issues. RadioButtons are not exclusively used with
radio images and so the calculation for the label overlap fails.
