### PR TITLE
[pvr][fix] users are trapped in the splash screen while start into a pvr window + no connection to backend

### DIFF
--- a/addons/skin.confluence/720p/DialogProgress.xml
+++ b/addons/skin.confluence/720p/DialogProgress.xml
@@ -37,7 +37,7 @@
 			<font>font13</font>
 			<autoscroll time="3000" delay="4000" repeat="5000">true</autoscroll>
 		</control>
-		<control type="progress">
+		<control type="progress" id="20">
 			<description>Progressbar</description>
 			<left>30</left>
 			<top>148</top>

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1204,17 +1204,15 @@ bool CApplication::Initialize()
 #endif
       ADDON::CAddonMgr::Get().StartServices(false);
 
-      // let's start the PVR manager and decide if the PVR manager handle the startup window activation
-      if (StartPVRManager())
-        uiInitializationFinished = false;
-      else
-      {
-        int firstWindow = g_SkinInfo->GetFirstWindow();
-        // the startup window is considered part of the initialization as it most likely switches to the final window
-        uiInitializationFinished = firstWindow != WINDOW_STARTUP_ANIM;
+      // start the PVR manager
+      StartPVRManager();
 
-        g_windowManager.ActivateWindow(firstWindow);
-      }
+      // activate the configured start window
+      int firstWindow = g_SkinInfo->GetFirstWindow();
+      g_windowManager.ActivateWindow(firstWindow);
+
+      // the startup window is considered part of the initialization as it most likely switches to the final window
+      uiInitializationFinished = firstWindow != WINDOW_STARTUP_ANIM;
 
       CStereoscopicsManager::Get().Initialize();
       CApplicationMessenger::Get().SendMsg(TMSG_SETAUDIODSPSTATE, ACTIVE_AE_DSP_STATE_ON); // send a blocking message to active AudioDSP engine
@@ -1322,18 +1320,12 @@ bool CApplication::StartServer(enum ESERVERS eServer, bool bStart, bool bWait/* 
   return ret;
 }
 
-bool CApplication::StartPVRManager()
+void CApplication::StartPVRManager()
 {
   if (!CSettings::Get().GetBool("pvrmanager.enabled"))
-    return false;
+    return;
 
-  int firstWindowId = 0;
-  if (g_PVRManager.IsPVRWindow(g_SkinInfo->GetStartWindow()))
-    firstWindowId = g_SkinInfo->GetFirstWindow();
-
-  g_PVRManager.Start(true, firstWindowId);
-
-  return (firstWindowId > 0);
+  g_PVRManager.Start(true);
 }
 
 void CApplication::StopPVRManager()

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -151,11 +151,7 @@ public:
 
   bool StartServer(enum ESERVERS eServer, bool bStart, bool bWait = false);
 
-  /*!
-   * @brief Starts the PVR manager and decide if the manager should handle the startup window activation.
-   * @return true, if the startup window activation is handled by the pvr manager, otherwise false
-   */
-  bool StartPVRManager();
+  void StartPVRManager();
   void StopPVRManager();
   bool IsCurrentThread() const;
   void Stop(int exitCode);

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -94,8 +94,7 @@ CPVRManager::CPVRManager(void) :
     m_bFirstStart(true),
     m_bEpgsCreated(false),
     m_progressHandle(NULL),
-    m_managerState(ManagerStateStopped),
-    m_openWindowId(0)
+    m_managerState(ManagerStateStopped)
 {
   CAnnouncementManager::Get().AddAnnouncer(this);
   ResetProperties();
@@ -357,7 +356,6 @@ void CPVRManager::Cleanup(void)
   m_currentFile           = NULL;
   m_bIsSwitchingChannels  = false;
   m_outdatedAddons.clear();
-  m_openWindowId = 0;
   m_bEpgsCreated = false;
 
   for (unsigned int iJobPtr = 0; iJobPtr < m_pendingUpdates.size(); iJobPtr++)
@@ -391,24 +389,23 @@ void CPVRManager::ResetProperties(void)
 class CPVRManagerStartJob : public CJob
 {
 public:
-  CPVRManagerStartJob(int openWindowId = 0) :
-    m_openWindowId(openWindowId) {}
+  CPVRManagerStartJob() {}
   ~CPVRManagerStartJob(void) {}
 
   bool DoWork(void)
   {
-    g_PVRManager.Start(false, m_openWindowId);
+    g_PVRManager.Start(false);
     return true;
   }
 private:
   int m_openWindowId;
 };
 
-void CPVRManager::Start(bool bAsync /* = false */, int openWindowId /* = 0 */)
+void CPVRManager::Start(bool bAsync /* = false */)
 {
   if (bAsync)
   {
-    CPVRManagerStartJob *job = new CPVRManagerStartJob(openWindowId);
+    CPVRManagerStartJob *job = new CPVRManagerStartJob();
     CJobManager::GetInstance().AddJob(job, NULL);
     return;
   }
@@ -424,7 +421,6 @@ void CPVRManager::Start(bool bAsync /* = false */, int openWindowId /* = 0 */)
 
   ResetProperties();
   SetState(ManagerStateStarting);
-  m_openWindowId = openWindowId;
 
   /* create and open database */
   if (!m_database)
@@ -512,17 +508,6 @@ void CPVRManager::Process(void)
   CLog::Log(LOGDEBUG, "PVRManager - %s - entering main loop", __FUNCTION__);
   g_EpgContainer.Start();
 
-  /* activate startup window */
-  if (m_openWindowId > 0)
-  {
-    g_windowManager.ActivateWindow(m_openWindowId);
-    m_openWindowId = 0;
-
-    // let everyone know that the user interface is now ready for usage
-    CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UI_READY);
-    g_windowManager.SendThreadMessage(msg);
-  }
-
   bool bRestart(false);
   while (IsStarted() && m_addons && m_addons->HasConnectedClients() && !bRestart)
   {
@@ -565,11 +550,6 @@ void CPVRManager::Process(void)
   {
     CLog::Log(LOGNOTICE, "PVRManager - %s - no add-ons enabled anymore. restarting the pvrmanager", __FUNCTION__);
     CApplicationMessenger::Get().PostMsg(TMSG_SETPVRMANAGERSTATE, 1);
-  }
-  else
-  {
-    if (IsPVRWindow(g_windowManager.GetActiveWindow()))
-      g_windowManager.ActivateWindow(WINDOW_HOME);
   }
 }
 

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -149,9 +149,8 @@ namespace PVR
     /*!
      * @brief Start the PVRManager, which loads all PVR data and starts some threads to update the PVR data.
      * @param bAsync True to (re)start the manager from another thread
-     * @param openWindowId Window id to open after starting
      */
-    void Start(bool bAsync = false, int openWindowId = 0);
+    void Start(bool bAsync = false);
 
     /*!
      * @brief Stop the PVRManager and destroy all objects it created.
@@ -669,7 +668,6 @@ namespace PVR
     CCriticalSection                m_managerStateMutex;
     ManagerState                    m_managerState;
     CStopWatch                     *m_parentalTimer;
-    int                             m_openWindowId;
     std::map<std::string, std::string> m_outdatedAddons;
     static int                      m_pvrWindowIds[10];
   };

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -200,6 +200,32 @@ bool CGUIWindowPVRBase::OnMessage(CGUIMessage& message)
   return CGUIMediaWindow::OnMessage(message);
 }
 
+bool CGUIWindowPVRBase::IsValidMessage(CGUIMessage& message)
+{
+  bool bReturn = false;
+
+  // we need to protect the pvr windows against certain messages
+  // if the pvr manager is not started yet. we only want to support
+  // that the window can be loaded to show the user an info about
+  // the manager startup. Any other interactions with the windows
+  // would cause access violations.
+  switch (message.GetMessage())
+  {
+    // valid messages
+    case GUI_MSG_WINDOW_LOAD:
+    case GUI_MSG_WINDOW_INIT:
+    case GUI_MSG_WINDOW_DEINIT:
+      bReturn = true;
+      break;
+    default:
+      if (g_PVRManager.IsStarted())
+        bReturn = true;
+      break;
+  }
+
+  return bReturn;
+}
+
 bool CGUIWindowPVRBase::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
 {
   bool bReturn = false;

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -27,6 +27,7 @@
 #include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogYesNo.h"
 #include "dialogs/GUIDialogSelect.h"
+#include "dialogs/GUIDialogProgress.h"
 #include "filesystem/StackDirectory.h"
 #include "input/Key.h"
 #include "guilib/GUIMessage.h"
@@ -125,12 +126,48 @@ void CGUIWindowPVRBase::OnInitWindow(void)
 {
   if (!g_PVRManager.IsStarted() || !g_PVRClients->HasConnectedClients())
   {
-    g_windowManager.PreviousWindow();
-    CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Warning,
-        g_localizeStrings.Get(19045),
-        g_localizeStrings.Get(19044));
-    return;
+    // wait until the PVR manager has been started
+    CGUIDialogProgress* dialog = static_cast<CGUIDialogProgress*>(g_windowManager.GetWindow(WINDOW_DIALOG_PROGRESS));
+    if (dialog)
+    {
+      dialog->SetHeading(CVariant{19235});
+      dialog->SetText(CVariant{19045});
+      dialog->ShowProgressBar(false);
+      dialog->Open();
+
+      // do not block the gfx context while waiting
+      CSingleExit exit(g_graphicsContext);
+
+      CEvent event(true);
+      while(!event.WaitMSec(1))
+      {
+        if (g_PVRManager.IsStarted() && g_PVRClients->HasConnectedClients())
+          event.Set();
+
+        if (dialog->IsCanceled())
+        {
+          // return to previous window if canceled
+          dialog->Close();
+          g_windowManager.PreviousWindow();
+          return;
+        }
+
+        g_windowManager.ProcessRenderLoop(false);
+      }
+
+      dialog->Close();
+    }
   }
+
+  {
+    // set window group to playing group
+    CPVRChannelGroupPtr group = g_PVRManager.GetPlayingGroup(m_bRadio);
+    CSingleLock lock(m_critSection);
+    if (m_group != group)
+      m_viewControl.SetSelectedItem(0);
+    m_group = group;
+  }
+  SetProperty("IsRadio", m_bRadio ? "true" : "");
 
   m_vecItems->SetPath(GetDirectoryPath());
 
@@ -149,16 +186,6 @@ bool CGUIWindowPVRBase::OnMessage(CGUIMessage& message)
 {
   switch (message.GetMessage())
   {
-    case GUI_MSG_WINDOW_INIT:
-    {
-      CPVRChannelGroupPtr group = g_PVRManager.GetPlayingGroup(m_bRadio);
-      if (m_group != group)
-        m_viewControl.SetSelectedItem(0);
-      m_group = group;
-      SetProperty("IsRadio", m_bRadio ? "true" : "");
-    }
-    break;
-
     case GUI_MSG_CLICKED:
     {
       switch (message.GetSenderId())

--- a/xbmc/pvr/windows/GUIWindowPVRBase.h
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.h
@@ -98,6 +98,7 @@ namespace PVR
     virtual void ShowRecordingInfo(CFileItem *item);
     virtual bool UpdateEpgForChannel(CFileItem *item);
     virtual void UpdateSelectedItemPath();
+    virtual bool IsValidMessage(CGUIMessage& message);
     void CheckResumeRecording(CFileItem *item);
 
     /*!

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -168,6 +168,9 @@ bool CGUIWindowPVRChannels::OnAction(const CAction &action)
 
 bool CGUIWindowPVRChannels::OnMessage(CGUIMessage& message)
 {
+  if (!IsValidMessage(message))
+    return false;
+
   bool bReturn = false;
   switch (message.GetMessage())
   {

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -185,6 +185,9 @@ bool CGUIWindowPVRGuide::OnAction(const CAction &action)
 
 bool CGUIWindowPVRGuide::OnMessage(CGUIMessage& message)
 {
+  if (!IsValidMessage(message))
+    return false;
+  
   bool bReturn = false;
   switch (message.GetMessage())
   {

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -241,6 +241,9 @@ void CGUIWindowPVRRecordings::UpdateButtons(void)
 
 bool CGUIWindowPVRRecordings::OnMessage(CGUIMessage &message)
 {
+  if (!IsValidMessage(message))
+    return false;
+  
   bool bReturn = false;
   switch (message.GetMessage())
   {

--- a/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
@@ -173,6 +173,9 @@ void CGUIWindowPVRSearch::OnPrepareFileItems(CFileItemList &items)
 
 bool CGUIWindowPVRSearch::OnMessage(CGUIMessage &message)
 {
+  if (!IsValidMessage(message))
+    return false;
+  
   if (message.GetMessage() == GUI_MSG_CLICKED)
   {
     if (message.GetSenderId() == m_viewControl.GetCurrentControl())

--- a/xbmc/pvr/windows/GUIWindowPVRTimers.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRTimers.cpp
@@ -168,6 +168,9 @@ void CGUIWindowPVRTimers::UpdateButtons(void)
 
 bool CGUIWindowPVRTimers::OnMessage(CGUIMessage &message)
 {
+  if (!IsValidMessage(message))
+    return false;
+  
   bool bReturn = false;
   switch (message.GetMessage())
   {


### PR DESCRIPTION
![bildschirmfoto_2015-07-30_um_09 31 26](https://cloud.githubusercontent.com/assets/1878991/8980187/117c2076-36af-11e5-8284-15294a081b12.png)

This happens if you choose a PVR window as startup window and Kodi can't connect to the PVR backend. You are trapped in the splash screen and you need to kill the app and your GUI settings to reset the startup window configuration. It happens because the PVR Manager will handle the activation of the startup window after it has been started, but this fails (no connected clients). This PR will remove the startup window activation stuff from the PVR manager and let CApplication handle it like it's done for every other window. To activate a PVR window only if the PVR manager has been started, i've introduced a busy dialog into CGUIWindowPVRBase and wait until the manager has been started. You are able to cancel the waiting process and you'll be returned to the previous window (usually the home window).

The mouse pointer issue is related to the splash window issue we already addressed with #7650. 

@ksooo @Jalle19 mind taking a look and should we consider a backport?
