### PR TITLE
[pvr] fix missing epg observable message handling in pvr windows

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
@@ -35,10 +35,13 @@
 #include "pvr/PVRManager.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/windows/GUIWindowPVRBase.h"
+#include "epg/EpgContainer.h"
 
 using namespace PVR;
 using namespace EPG;
 using namespace KODI::MESSAGING;
+
+#define MAX_INVALIDATION_FREQUENCY 2000 // limit to one invalidation per X milliseconds
 
 #define CONTROL_LIST                  11
 
@@ -55,6 +58,8 @@ CGUIDialogPVRChannelsOSD::~CGUIDialogPVRChannelsOSD()
 
   if (IsObserving(g_infoManager))
     g_infoManager.UnregisterObserver(this);
+  if (IsObserving(g_EpgContainer))
+    g_EpgContainer.UnregisterObserver(this);
 }
 
 bool CGUIDialogPVRChannelsOSD::OnMessage(CGUIMessage& message)
@@ -82,6 +87,22 @@ bool CGUIDialogPVRChannelsOSD::OnMessage(CGUIMessage& message)
           ShowInfo(iItem);
           return true;
         }
+      }
+    }
+    break;
+  case GUI_MSG_REFRESH_LIST:
+    {
+      switch(message.GetParam1())
+      {
+        case ObservableMessageCurrentItem:
+          m_viewControl.SetItems(*m_vecItems);
+          return true;
+        case ObservableMessageEpg:
+        case ObservableMessageEpgContainer:
+        case ObservableMessageEpgActiveItem:
+          if (IsActive())
+            SetInvalid();
+          return true;
       }
     }
     break;
@@ -167,6 +188,8 @@ void CGUIDialogPVRChannelsOSD::Update()
 
   if (!IsObserving(g_infoManager))
     g_infoManager.RegisterObserver(this);
+  if (!IsObserving(g_EpgContainer))
+    g_EpgContainer.RegisterObserver(this);
 
   m_viewControl.SetCurrentView(DEFAULT_VIEW_LIST);
 
@@ -192,6 +215,18 @@ void CGUIDialogPVRChannelsOSD::Update()
   }
 
   g_graphicsContext.Unlock();
+}
+
+void CGUIDialogPVRChannelsOSD::SetInvalid()
+{
+  if (m_refreshTimeout.IsTimePast())
+  {
+    VECFILEITEMS items = m_vecItems->GetList();
+    for (VECFILEITEMS::iterator it = items.begin(); it != items.end(); ++it)
+      (*it)->SetInvalid();
+    CGUIDialog::SetInvalid();
+    m_refreshTimeout.Set(MAX_INVALIDATION_FREQUENCY);
+  }
 }
 
 void CGUIDialogPVRChannelsOSD::SaveControlStates()
@@ -325,12 +360,8 @@ CGUIControl *CGUIDialogPVRChannelsOSD::GetFirstFocusableControl(int id)
 
 void CGUIDialogPVRChannelsOSD::Notify(const Observable &obs, const ObservableMessage msg)
 {
-  if (msg == ObservableMessageCurrentItem)
-  {
-    g_graphicsContext.Lock();
-    m_viewControl.SetItems(*m_vecItems);
-    g_graphicsContext.Unlock();
-  }
+  CGUIMessage m(GUI_MSG_REFRESH_LIST, GetID(), 0, msg);
+  CApplicationMessenger::Get().SendGUIMessage(m);
 }
 
 void CGUIDialogPVRChannelsOSD::SaveSelectedItemPath(int iGroupID)

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.h
@@ -45,6 +45,7 @@ namespace PVR
     virtual void OnDeinitWindow(int nextWindowID);
     virtual void RestoreControlStates();
     virtual void SaveControlStates();
+    virtual void SetInvalid();
 
     void CloseOrSelect(unsigned int iItem);
     void GotoChannel(int iItem);
@@ -62,6 +63,7 @@ namespace PVR
     std::map<int, std::string> m_groupSelectedItemPaths;
     void SaveSelectedItemPath(int iGroupID);
     std::string GetLastSelectedItemPath(int iGroupID) const;
+    XbmcThreads::EndTime m_refreshTimeout;
   };
 }
 

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -51,6 +51,8 @@
 
 #include "cores/AudioEngine/DSPAddons/ActiveAEDSP.h"
 
+#define MAX_INVALIDATION_FREQUENCY 2000 // limit to one invalidation per X milliseconds
+
 using namespace PVR;
 using namespace EPG;
 using namespace KODI::MESSAGING;
@@ -231,10 +233,14 @@ bool CGUIWindowPVRBase::OnContextButtonActiveAEDSPSettings(CFileItem *item, CONT
 
 void CGUIWindowPVRBase::SetInvalid()
 {
-  VECFILEITEMS items = m_vecItems->GetList();
-  for (VECFILEITEMS::iterator it = items.begin(); it != items.end(); ++it)
-    (*it)->SetInvalid();
-  CGUIMediaWindow::SetInvalid();
+  if (m_refreshTimeout.IsTimePast())
+  {
+    VECFILEITEMS items = m_vecItems->GetList();
+    for (VECFILEITEMS::iterator it = items.begin(); it != items.end(); ++it)
+      (*it)->SetInvalid();
+    CGUIMediaWindow::SetInvalid();
+    m_refreshTimeout.Set(MAX_INVALIDATION_FREQUENCY);
+  }
 }
 
 bool CGUIWindowPVRBase::OpenGroupSelectionDialog(void)

--- a/xbmc/pvr/windows/GUIWindowPVRBase.h
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.h
@@ -118,5 +118,6 @@ namespace PVR
 
   private:
     CPVRChannelGroupPtr m_group;
+    XbmcThreads::EndTime m_refreshTimeout;
   };
 }

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -226,6 +226,8 @@ bool CGUIWindowPVRChannels::OnMessage(CGUIMessage& message)
       {
         case ObservableMessageChannelGroup:
         case ObservableMessageTimers:
+        case ObservableMessageEpg:
+        case ObservableMessageEpgContainer:
         case ObservableMessageEpgActiveItem:
         case ObservableMessageCurrentItem:
         {

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -299,6 +299,9 @@ bool CGUIWindowPVRRecordings::OnMessage(CGUIMessage &message)
       switch(message.GetParam1())
       {
         case ObservableMessageTimers:
+        case ObservableMessageEpg:
+        case ObservableMessageEpgContainer:
+        case ObservableMessageEpgActiveItem:
         case ObservableMessageCurrentItem:
         {
           if (IsActive())

--- a/xbmc/pvr/windows/GUIWindowPVRTimers.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRTimers.cpp
@@ -222,6 +222,9 @@ bool CGUIWindowPVRTimers::OnMessage(CGUIMessage &message)
       switch(message.GetParam1())
       {
         case ObservableMessageTimers:
+        case ObservableMessageEpg:
+        case ObservableMessageEpgContainer:
+        case ObservableMessageEpgActiveItem:
         case ObservableMessageCurrentItem:
         {
           if (IsActive())


### PR DESCRIPTION
This will adds some missing epg observable messages to the switch/case in PVR window's OnMessage() to solve the stale epg info issue which was mentioned by @FernetMenta some while ago.

I ran into this issue while I'm working on the pvr startup window PR and noticed that the EPG info was not updated while staying in the channel window. And as we link recordings + timers to an EPG info tag it make sense to add the same to these windows too. 

The messages will tigger a `SetInvalid()` which will refresh the listed items on the screen.

@opdenkamp or @Jalle19 mind taking a look.
