### PR TITLE
Change 'mytv' remote mapping to open the TV Shows node

### DIFF
--- a/system/keymaps/remote.xml
+++ b/system/keymaps/remote.xml
@@ -70,7 +70,7 @@
       <myvideo>ActivateWindow(MyVideos)</myvideo>
       <mymusic>ActivateWindow(MyMusic)</mymusic>
       <mypictures>ActivateWindow(MyPictures)</mypictures>
-      <mytv>ActivateWindow(TVChannels)</mytv>
+      <mytv>ActivateWindow(Videos,TvShows)</mytv>
       <guide>ActivateWindow(TVGuide)</guide>
       <livetv>ActivateWindow(TVChannels)</livetv>
       <liveradio>ActivateWindow(RadioChannels)</liveradio>


### PR DESCRIPTION
This is a follow on from https://github.com/xbmc/xbmc/pull/7616. It restores the mapping of `<mytv>` as it was before PVR was introduced.

The `<livetv>` button still opens the Live TV channels.
