### PR TITLE
[guilib] fix textbox textcolor not properly set

### DIFF
--- a/xbmc/guilib/GUITextBox.cpp
+++ b/xbmc/guilib/GUITextBox.cpp
@@ -240,7 +240,11 @@ void CGUITextBox::Render()
     {
       m_font->Begin();
       int current = offset;
-      m_colors.push_back(m_textColor);
+
+      // set the main text color
+      if (m_colors.size())
+        m_colors[0] = m_label.textColor;
+
       while (posY < m_posY + m_renderHeight && current < (int)m_lines.size())
       {
         uint32_t align = alignment;


### PR DESCRIPTION
Follow-up of https://github.com/xbmc/xbmc/pull/7205. This ensures proper color handling in textboxes.

@BigNoid, mind testing? I've verified that both colors (textcolor + color tag) are working but i'd like to have another +1. Thanks.
