### PR TITLE
[PVR] Season/Episode/Year/EpisodeName for Recordings (Scraper+Sort Order improvements)

### DIFF
--- a/addons/skin.confluence/720p/DialogPVRRecordingInfo.xml
+++ b/addons/skin.confluence/720p/DialogPVRRecordingInfo.xml
@@ -24,7 +24,7 @@
 			<width>650</width>
 			<height>30</height>
 			<font>font13_title</font>
-			<label>$INFO[ListItem.Title]</label>
+			<label>$INFO[ListItem.Title]$INFO[ListItem.EpisodeName, (,)]</label>
 			<align>center</align>
 			<aligny>center</aligny>
 			<textcolor>blue</textcolor>

--- a/addons/skin.confluence/720p/MyPVRRecordings.xml
+++ b/addons/skin.confluence/720p/MyPVRRecordings.xml
@@ -95,7 +95,7 @@
 						<selectedcolor>selected</selectedcolor>
 						<align>left</align>
 						<aligny>center</aligny>
-						<label>$INFO[ListItem.Label]</label>
+						<label>$INFO[ListItem.Label]$INFO[ListItem.EpisodeName, (,)]</label>
 					</control>
 					<control type="label">
 						<left>225</left>
@@ -172,7 +172,7 @@
 						<selectedcolor>selected</selectedcolor>
 						<align>left</align>
 						<aligny>center</aligny>
-						<label>$INFO[ListItem.Label]</label>
+						<label>$INFO[ListItem.Label]$INFO[ListItem.EpisodeName, (,)]</label>
 					</control>
 					<control type="label">
 						<left>225</left>
@@ -254,7 +254,7 @@
 					<top>230</top>
 					<width>290</width>
 					<height>25</height>
-					<label>$INFO[Container(50).ListItem.Title]</label>
+					<label>$INFO[Container(50).ListItem.Title]$INFO[ListItem.EpisodeName, (,)]</label>
 					<align>center</align>
 					<aligny>center</aligny>
 					<font>font13</font>

--- a/addons/xbmc.pvr/addon.xml
+++ b/addons/xbmc.pvr/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="xbmc.pvr" version="2.1.0" provider-name="Team-Kodi">
-  <backwards-compatibility abi="2.1.0"/>
+<addon id="xbmc.pvr" version="3.0.0" provider-name="Team-Kodi">
+  <backwards-compatibility abi="3.0.0"/>
   <requires>
     <import addon="xbmc.core" version="0.1.0"/>
   </requires>

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -4721,6 +4721,8 @@ std::string CGUIInfoManager::GetItemLabel(const CFileItem *item, int info, std::
         if (tag->Year() > 0)
           year = StringUtils::Format("%i", tag->Year());
       }
+      if (item->HasPVRRecordingInfoTag() && item->GetPVRRecordingInfoTag()->m_iYear > 0)
+          year = StringUtils::Format("%i", item->GetPVRRecordingInfoTag()->m_iYear);
       return year;
     }
   case LISTITEM_PREMIERED:
@@ -4944,6 +4946,11 @@ std::string CGUIInfoManager::GetItemLabel(const CFileItem *item, int info, std::
         iSeason = item->GetVideoInfoTag()->m_iSeason;
         iEpisode = item->GetVideoInfoTag()->m_iEpisode;
       }
+      else if (item->HasPVRRecordingInfoTag())
+      {
+        iSeason = item->GetPVRRecordingInfoTag()->m_iSeason;
+        iEpisode = item->GetPVRRecordingInfoTag()->m_iEpisode;
+      }
 
       if (iEpisode >= 0)
       {
@@ -4972,6 +4979,8 @@ std::string CGUIInfoManager::GetItemLabel(const CFileItem *item, int info, std::
         iSeason = item->GetPVRTimerInfoTag()->GetEpgInfoTag()->SeriesNumber();
       else if (item->HasVideoInfoTag())
         iSeason = item->GetVideoInfoTag()->m_iSeason;
+      else if (item->HasPVRRecordingInfoTag())
+        iSeason = item->GetPVRRecordingInfoTag()->m_iSeason;
 
       if (iSeason >= 0)
         return StringUtils::Format("%d", iSeason);
@@ -5381,6 +5390,8 @@ std::string CGUIInfoManager::GetItemLabel(const CFileItem *item, int info, std::
         return item->GetEPGInfoTag()->EpisodeName();
       if (item->HasPVRTimerInfoTag() && item->GetPVRTimerInfoTag()->HasEpgInfoTag())
         return item->GetPVRTimerInfoTag()->GetEpgInfoTag()->EpisodeName();
+      if (item->HasPVRRecordingInfoTag())
+        return item->GetPVRRecordingInfoTag()->EpisodeName();
       break;
     }
   case LISTITEM_TIMERTYPE:

--- a/xbmc/addons/include/xbmc_pvr_types.h
+++ b/xbmc/addons/include/xbmc_pvr_types.h
@@ -407,6 +407,11 @@ extern "C" {
   typedef struct PVR_RECORDING {
     char   strRecordingId[PVR_ADDON_NAME_STRING_LENGTH];  /*!< @brief (required) unique id of the recording on the client. */
     char   strTitle[PVR_ADDON_NAME_STRING_LENGTH];        /*!< @brief (required) the title of this recording */
+    char   strEpisodeName[PVR_ADDON_NAME_STRING_LENGTH];  /*!< @brief (optional) episode name (also known as subtitle) */
+    int    iSeriesNumber;                                 /*!< @brief (optional) series number (usually called season). Set to "0" for specials/pilot. For 'invalid' case see iEpisodeNumber */
+    int    iEpisodeNumber;                                /*!< @brief (optional) episode number within the "iSeriesNumber" season. To indicate that season/episode is 'invalid' set both to 0 */
+    int    iYear;                                         /*!< @brief (optional) year of first release (use to identify a specific movie re-make). Set to '0' for invalid. */
+
     char   strStreamURL[PVR_ADDON_URL_STRING_LENGTH];     /*!< @brief (required) stream URL to access this recording */
     char   strDirectory[PVR_ADDON_URL_STRING_LENGTH];     /*!< @brief (optional) directory of this recording on the client */
     char   strPlotOutline[PVR_ADDON_DESC_STRING_LENGTH];  /*!< @brief (optional) plot outline */

--- a/xbmc/addons/include/xbmc_pvr_types.h
+++ b/xbmc/addons/include/xbmc_pvr_types.h
@@ -78,10 +78,10 @@ struct DemuxPacket;
 #define PVR_STREAM_MAX_STREAMS 20
 
 /* current PVR API version */
-#define XBMC_PVR_API_VERSION "2.1.0"
+#define XBMC_PVR_API_VERSION "3.0.0"
 
 /* min. PVR API version */
-#define XBMC_PVR_MIN_API_VERSION "2.1.0"
+#define XBMC_PVR_MIN_API_VERSION "3.0.0"
 
 #ifdef __cplusplus
 extern "C" {

--- a/xbmc/pvr/recordings/PVRRecording.h
+++ b/xbmc/pvr/recordings/PVRRecording.h
@@ -223,6 +223,12 @@ namespace PVR
      */
     bool IsBeingRecorded(void) const;
 
+    /*!
+     * @brief Retrieve the recording Episode Name
+     * @note Returns a null string if no Episode Name was provided by the PVR client
+     */
+    std::string EpisodeName(void) const { return m_strShowTitle; };
+
   private:
     CDateTime m_recordingTime; /*!< start time of the recording */
     bool      m_bGotMetaData;
@@ -231,5 +237,6 @@ namespace PVR
 
     void UpdatePath(void);
     void DisplayError(PVR_ERROR err) const;
+    std::string MakeSeasonEpisode(int season, int episode);
   };
 }


### PR DESCRIPTION
A PVR client can now provide Title, Episode Name, Season, Episode & Year of first airing to PVR core as individual fields. This allows:
1. 'By File' now sorts in episode order. (Very useful if a series was recorded out of sequence)
2. ttvdb scraper now able to match TV Shows directly from the 'Recordings' source
3. Skins can decide where and how EpisodeName / Season / Episode / Year is displayed

**Skin Changes Required**
As 'EpisodeName' is now separate, the recordings list for TV shows makes little sense until it is added back in. Proposed confluence changes are included.

**PVR Client Changes Requried**
No changes to clients are essential other than the include file. Existing behaviour is unaffected.
To see benefits, EpisodeName/season/episode/year information must use the new variables.

**Context**
This PR relies on the changes in PR #7626 which groups several API changes forming API 3.0.0.
This PR should not be merged unless PR #7626 has also been merged.
The necessary supporting API change is contained in commit '[PVR] Add Recording scraper support to API'. If this change is withdrawn from PR #7626 this PR will be closed.

**Known Issues**
Currently IMDB scraper doesn't seem to match 'Year' correctly from the filename for some reason.
Skins will need to be updated for EpisodeName to be displayed.

**Comments**
Please make comments regarding the scraper support/sort order change itself here.
For comments regarding any of the other 3.0.0 API changes, please use #7626
This PR may eventually be subsumed into #7626 for final merge.
