### PR TITLE
CProgressJob: fix crash in DoModal after 658b0a21ed4a7443d6670fc6180d8dc2e9b2ca47

### DIFF
--- a/xbmc/utils/ProgressJob.cpp
+++ b/xbmc/utils/ProgressJob.cpp
@@ -82,9 +82,8 @@ bool CProgressJob::DoModal()
   // do the work
   bool result = DoWork();
 
-  // close the progress dialog
-  if (m_autoClose)
-    m_progressDialog->Close();
+  // mark the progress dialog as finished (will close it)
+  MarkFinished();
   m_modal = false;
 
   return result;

--- a/xbmc/utils/ProgressJob.cpp
+++ b/xbmc/utils/ProgressJob.cpp
@@ -181,8 +181,8 @@ void CProgressJob::MarkFinished()
     if (m_updateProgress)
     {
       m_progress->MarkFinished();
-      //We don't own this pointer and it will be deleted after it's marked finished
-      //just set it to nullptr so we don't try to use it again
+      // We don't own this pointer and it will be deleted after it's marked finished
+      // just set it to nullptr so we don't try to use it again
       m_progress = nullptr;
     }
   }

--- a/xbmc/utils/ProgressJob.cpp
+++ b/xbmc/utils/ProgressJob.cpp
@@ -187,12 +187,7 @@ void CProgressJob::MarkFinished()
     }
   }
   else if (m_progressDialog != NULL && m_autoClose)
-  {
     m_progressDialog->Close();
-    //We don't own this pointer and it will be deleted after it's marked finished
-    //just set it to nullptr so we don't try to use it again
-    m_progressDialog = nullptr;
-  }
 }
 
 bool CProgressJob::IsCancelled() const


### PR DESCRIPTION
This fixes a crash introduced by #7634 because in `CProgressJob::DoModal()` `m_progressDialog` is used after it has been reset to `nullptr` by a previous call to `MarkFinished()` (which is not under the control of `CProgressJob`). The reason given in #7634 as to why `m_progressDialog` has to be reset to `nullptr` is invalid because `CProgressDialog` is managed by the window manager and is not deleted until Kodi is shutdown.
