### PR TITLE
[python] add 'mediatype' info label and remove implicit sets

### DIFF
--- a/addons/xbmc.python/addon.xml
+++ b/addons/xbmc.python/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="xbmc.python" version="2.21.0" provider-name="Team-Kodi">
+<addon id="xbmc.python" version="2.22.0" provider-name="Team-Kodi">
   <backwards-compatibility abi="2.1.0"/>
   <requires>
     <import addon="xbmc.core" version="0.1.0"/>

--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -396,24 +396,12 @@ namespace XBMCAddon
           }
           else if (key == "dateadded")
             item->GetVideoInfoTag()->m_dateAdded.SetFromDBDateTime(value.c_str());
-        }
-
-        // For backward compatibility.
-        // FIXME: Remove this behaviour. It should be possible to set only tvshowtitle without
-        // having mediatype implicitly changed.
-        if (item->GetVideoInfoTag()->m_type == MediaTypeNone)
-        {
-          if (!item->GetVideoInfoTag()->m_strShowTitle.empty() && item->GetVideoInfoTag()->m_iSeason == -1)
+          else if (key == "mediatype")
           {
-            item->GetVideoInfoTag()->m_type = MediaTypeTvShow;
-          }
-          else if (item->GetVideoInfoTag()->m_iSeason > -1)
-          {
-            item->GetVideoInfoTag()->m_type = MediaTypeEpisode;
-          }
-          else if (!item->GetVideoInfoTag()->m_artist.empty())
-          {
-            item->GetVideoInfoTag()->m_type = MediaTypeMusicVideo;
+            if (MediaTypes::IsValidMediaType(value))
+              item->GetVideoInfoTag()->m_type = value;
+            else
+              CLog::Log(LOGWARNING, "Invalid media type \"%s\"", value.c_str());
           }
         }
       }

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -224,6 +224,7 @@ namespace XBMCAddon
        *     - votes         : string (12345 votes)
        *     - trailer       : string (/home/user/trailer.avi)
        *     - dateadded     : string (%Y-%m-%d %h:%m:%s = 2009-04-05 23:16:04)
+       *     - mediatype     : string - "video", "movie", "tvshow", "season", "episode" or "musicvideo"
        * - Music Values:
        *     - tracknumber   : integer (8)
        *     - discnumber    : integer (2)

--- a/xbmc/interfaces/python/PythonSwig.cpp.template
+++ b/xbmc/interfaces/python/PythonSwig.cpp.template
@@ -939,7 +939,7 @@ namespace PythonBindings
    // constants
    PyModule_AddStringConstant(module, (char*)"__author__", (char*)"Team Kodi <http://kodi.tv>");
    PyModule_AddStringConstant(module, (char*)"__date__", (char*)"${new Date().toString()}");
-   PyModule_AddStringConstant(module, (char*)"__version__", (char*)"2.21.0");
+   PyModule_AddStringConstant(module, (char*)"__version__", (char*)"2.22.0");
    PyModule_AddStringConstant(module, (char*)"__credits__", (char*)"Team Kodi");
    PyModule_AddStringConstant(module, (char*)"__platform__", (char*)"ALL");
 


### PR DESCRIPTION
Allows the media type to be set explicitly.

This removes the previously deprecated auto setting of type based on other info labels provided. 
