### PR TITLE
[gitignore] don't clean Makefile in xbmc/main/posix/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -583,6 +583,9 @@ lib/cpluff/stamp-h1
 /xbmc/peripherals/bus/Makefile
 /xbmc/peripherals/devices/Makefile
 
+# /xbmc/main/posix/
+xbmc/main/posix/Makefile
+
 #/xbmc/screensavers/
 /xbmc/screensavers/Makefile
 /xbmc/screensavers/rsxs-0.9/Makefile


### PR DESCRIPTION
Adjust gitignore after ebcb3abd3c481f6f6c9f71b357fdc48da8089f65
