### PR TITLE
[guilib] use label2 to display the radiobutton value instead of a texture

### DIFF
--- a/xbmc/guilib/GUIButtonControl.cpp
+++ b/xbmc/guilib/GUIButtonControl.cpp
@@ -266,14 +266,20 @@ void CGUIButtonControl::SetInvalid()
 
 void CGUIButtonControl::SetLabel(const string &label)
 { // NOTE: No fallback for buttons at this point
-  m_info.SetLabel(label, "", GetParentID());
-  SetInvalid();
+  if (m_info.GetLabel(GetParentID(), false) != label)
+  {
+    m_info.SetLabel(label, "", GetParentID());
+    SetInvalid();
+  }
 }
 
 void CGUIButtonControl::SetLabel2(const string &label2)
 { // NOTE: No fallback for buttons at this point
-  m_info2.SetLabel(label2, "", GetParentID());
-  SetInvalid();
+  if (m_info2.GetLabel(GetParentID(), false) != label2)
+  {
+    m_info2.SetLabel(label2, "", GetParentID());
+    SetInvalid();
+  }
 }
 
 void CGUIButtonControl::SetPosition(float posX, float posY)

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -1247,6 +1247,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
         textureRadioOnFocus, textureRadioOnNoFocus, textureRadioOffFocus, textureRadioOffNoFocus, textureRadioOnDisabled, textureRadioOffDisabled);
 
       ((CGUIRadioButtonControl *)control)->SetLabel(strLabel);
+      ((CGUIRadioButtonControl *)control)->SetLabel2(strLabel2);
       ((CGUIRadioButtonControl *)control)->SetRadioDimensions(radioPosX, radioPosY, radioWidth, radioHeight);
       ((CGUIRadioButtonControl *)control)->SetToggleSelect(toggleSelect);
       ((CGUIRadioButtonControl *)control)->SetClickActions(clickActions);

--- a/xbmc/guilib/GUIRadioButtonControl.cpp
+++ b/xbmc/guilib/GUIRadioButtonControl.cpp
@@ -20,6 +20,7 @@
 
 #include "GUIRadioButtonControl.h"
 #include "GUIInfoManager.h"
+#include "LocalizeStrings.h"
 #include "input/Key.h"
 
 CGUIRadioButtonControl::CGUIRadioButtonControl(int parentID, int controlID, float posX, float posY, float width, float height,
@@ -45,6 +46,7 @@ CGUIRadioButtonControl::CGUIRadioButtonControl(int parentID, int controlID, floa
   m_imgRadioOnDisabled.SetAspectRatio(CAspectRatio::AR_KEEP);
   m_imgRadioOffDisabled.SetAspectRatio(CAspectRatio::AR_KEEP);
   ControlType = GUICONTROL_RADIO;
+  m_useLabel2 = false;
 }
 
 CGUIRadioButtonControl::~CGUIRadioButtonControl(void)
@@ -87,13 +89,16 @@ void CGUIRadioButtonControl::Process(unsigned int currentTime, CDirtyRegionList 
       m_bSelected = selected;
     }
   }
-  
+
   m_imgRadioOnFocus.Process(currentTime);
   m_imgRadioOnNoFocus.Process(currentTime);
   m_imgRadioOffFocus.Process(currentTime);
   m_imgRadioOffNoFocus.Process(currentTime);
   m_imgRadioOnDisabled.Process(currentTime);
   m_imgRadioOffDisabled.Process(currentTime);
+
+  if (m_useLabel2)
+    SetLabel2(g_localizeStrings.Get(m_bSelected ? 16041 : 351));
 
   CGUIButtonControl::Process(currentTime, dirtyregions);
 }
@@ -193,6 +198,12 @@ void CGUIRadioButtonControl::SetRadioDimensions(float posX, float posY, float wi
     m_imgRadioOnDisabled.SetHeight(height);
     m_imgRadioOffDisabled.SetHeight(height);
   }
+
+  // use label2 to display the button value in case no
+  // dimensions were specified and there's no label2 yet.
+  if (GetLabel2().empty() && !width && !height)
+    m_useLabel2 = true;
+
   SetPosition(GetXPosition(), GetYPosition());
 }
 

--- a/xbmc/guilib/GUIRadioButtonControl.h
+++ b/xbmc/guilib/GUIRadioButtonControl.h
@@ -72,4 +72,5 @@ protected:
   float m_radioPosX;
   float m_radioPosY;
   INFO::InfoPtr m_toggleSelect;
+  bool m_useLabel2;
 };


### PR DESCRIPTION
This adds the abiity to use `<label2>` for displaying the actual radiobutton value in case `<radiowidth />` and `<radioheight />` are specified. An existing `<label2>` will override the button value. Second commit ensures we're only setting the labels in case the value changed.
