### PR TITLE
[PVR] API 3.0.0 Implementation of "Visibility Controls for timer types"

### DIFF
--- a/addons/xbmc.pvr/addon.xml
+++ b/addons/xbmc.pvr/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="xbmc.pvr" version="2.1.0" provider-name="Team-Kodi">
-  <backwards-compatibility abi="2.1.0"/>
+<addon id="xbmc.pvr" version="3.0.0" provider-name="Team-Kodi">
+  <backwards-compatibility abi="3.0.0"/>
   <requires>
     <import addon="xbmc.core" version="0.1.0"/>
   </requires>

--- a/xbmc/addons/include/xbmc_pvr_types.h
+++ b/xbmc/addons/include/xbmc_pvr_types.h
@@ -125,6 +125,8 @@ extern "C" {
   const unsigned int PVR_TIMER_TYPE_SUPPORTS_LIFETIME                 = 0x00004000; /*!< @brief this type supports recording lifetime (PVR_TIMER.iLifetime) */
   const unsigned int PVR_TIMER_TYPE_SUPPORTS_RECORDING_FOLDERS        = 0x00008000; /*!< @brief this type supports placing recordings in user defined folders (PVR_TIMER.strDirectory) */
   const unsigned int PVR_TIMER_TYPE_SUPPORTS_RECORDING_GROUP          = 0x00010000; /*!> @brief this type supports a list of recording groups (PVR_TIMER.iRecordingGroup) */
+  const unsigned int PVR_TIMER_TYPE_REQUIRES_EPG_TAG_ON_CREATE        = 0x00200000; /*!< @brief this type shold not appear on any create menus which don't provide an associated EPG tag */
+  const unsigned int PVR_TIMER_TYPE_FORBIDS_EPG_TAG_ON_CREATE         = 0x00400000; /*!< @brief this type should not appear on any create menus which provide an associated EPG tag */
 
   /*!
    * @brief PVR timer weekdays (PVR_TIMER.iWeekdays values)

--- a/xbmc/addons/include/xbmc_pvr_types.h
+++ b/xbmc/addons/include/xbmc_pvr_types.h
@@ -78,10 +78,10 @@ struct DemuxPacket;
 #define PVR_STREAM_MAX_STREAMS 20
 
 /* current PVR API version */
-#define XBMC_PVR_API_VERSION "2.1.0"
+#define XBMC_PVR_API_VERSION "3.0.0"
 
 /* min. PVR API version */
-#define XBMC_PVR_MIN_API_VERSION "2.1.0"
+#define XBMC_PVR_MIN_API_VERSION "3.0.0"
 
 #ifdef __cplusplus
 extern "C" {

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -721,8 +721,12 @@ void CGUIDialogPVRTimerSettings::InitializeTypesList()
       if (type->IsReadOnly())
         continue;
 
-      // For new timers, skip one time epg-based types. Those cannot be created using this dialog (yet).
-      if (type->IsOnetimeEpgBased())
+      // Drop TimerTypes that require EPGInfo, if none is populated
+      if (type->RequiresEpgTagOnCreate() && !m_timerInfoTag->HasEpgInfoTag())
+        continue;
+
+      // Drop TimerTypes that forbid EPGInfo, if it is populated
+      if (type->ForbidsEpgTagOnCreate() && m_timerInfoTag->HasEpgInfoTag())
         continue;
     }
 

--- a/xbmc/pvr/timers/PVRTimerType.h
+++ b/xbmc/pvr/timers/PVRTimerType.h
@@ -153,6 +153,18 @@ namespace PVR
     bool ForbidsNewInstances() const { return (m_iAttributes & PVR_TIMER_TYPE_FORBIDS_NEW_INSTANCES) > 0; }
 
     /*!
+     * @brief Check whether this timer type is forbidden when epg tag info is present.
+     * @return True if new instances are forbidden when epg info is present, false otherwise.
+     */
+    bool ForbidsEpgTagOnCreate() const { return (m_iAttributes & PVR_TIMER_TYPE_FORBIDS_EPG_TAG_ON_CREATE) > 0; }
+
+    /*!
+     * @brief Check whether this timer type requires epg tag info to be present.
+     * @return True if new instances require EPG info, false otherwise.
+     */
+    bool RequiresEpgTagOnCreate() const { return (m_iAttributes & PVR_TIMER_TYPE_REQUIRES_EPG_TAG_ON_CREATE) > 0; }
+
+    /*!
      * @brief Check whether this type supports the "enabling/disabling" of timers of its type.
      * @return True if "enabling/disabling" feature is supported, false otherwise.
      */


### PR DESCRIPTION
This is the implementation of one of the API 3.0.0 features from #7626 

New TimerType attributes that allow PVR addons to specify whether TimerTypes should be visible in the "Add Timer" window based on whether the EPG info is/isn't present.  This is the end result of discussion on #7660

The first 2 commits are the API bump/fields from #7626 and the 3rd commit is the actual PVR Core implementation.  This will likely be pulled together by @metaron-uk with whatever other API 3.0.0 changes are "good to go" into a new PR

**PVR Client Changes Requried**
PVR Clients that have implemented the new Kodi16 Series Recording changes and were relying on the previous hard coded behaviour that was hiding Single Guide Based timer types (but not Repeating Guide Based timer types) on creation, will need to be tweaked to specify the Forbid/Require attributes on their timer types as appropriate.  This is a minor change, so far only known to affect pvr.hts

**Context**
This PR relies on the changes in PR #7626 which groups several API changes forming API 3.0.0.
- This PR should not be merged unless PR #7626 has also been merged.
- The necessary supporting API change is contained in commit [[PVR] Menu visibility controls for timer types](https://github.com/metaron-uk/xbmc/commit/116414607facab6bf377de525135e69c38f0c043). If this change is withdrawn from PR #7626 this PR will be closed.

**Comments**
Please make comments regarding the TimerType Visibility change itself here.
For comments regarding any of the other 3.0.0 API changes, please use #7626

@metaron-uk @ksooo @xhaggi @Jalle19 @janbar 
