### PR TITLE
[python] deprecate thumb/icon methods and args in favour of setArt

### DIFF
--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -139,11 +139,10 @@ namespace XBMCAddon
         {
           std::string artName = it->first;
           StringUtils::ToLower(artName);
-          const std::string artFilename(it->second.c_str());
           if (artName == "icon")
-            item->SetIconImage(artFilename);
+            item->SetIconImage(it->second);
           else
-            item->SetArt(artName, artFilename);
+            item->SetArt(artName, it->second);
         }
       }
     }

--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -140,7 +140,10 @@ namespace XBMCAddon
           std::string artName = it->first;
           StringUtils::ToLower(artName);
           const std::string artFilename(it->second.c_str());
-          item->SetArt(artName, artFilename);
+          if (artName == "icon")
+            item->SetIconImage(artFilename);
+          else
+            item->SetArt(artName, artFilename);
         }
       }
     }

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -156,6 +156,7 @@ namespace XBMCAddon
        *     - clearart      : string - image filename
        *     - clearlogo     : string - image filename
        *     - landscape     : string - image filename
+       *     - icon          : string - image filename
        *
        * example:
        *   - self.list.getSelectedItem().setArt({ 'poster': 'poster.png', 'banner' : 'banner.png' })

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -57,8 +57,8 @@ namespace XBMCAddon
      * \n
      * label : [opt] string
      * label2 : [opt] string
-     * iconImage : [opt] string
-     * thumbnailImage : [opt] string
+     * iconImage : Deprecated. Use setArt
+     * thumbnailImage : Deprecated. Use setArt
      * path : [opt] string
      */
     class ListItem : public AddonClass
@@ -124,22 +124,12 @@ namespace XBMCAddon
       void setLabel2(const String& label);
 
       /**
-       * setIconImage(icon) -- Sets the listitem's icon image.\n
-       * \n
-       * icon            : string - image filename.\n
-       * \n
-       * example:
-       *   - self.list.getSelectedItem().setIconImage('emailread.png')
+       *  Deprecated. Use setArt
        */
       void setIconImage(const String& iconImage);
 
       /**
-       * setThumbnailImage(thumbFilename) -- Sets the listitem's thumbnail image.\n
-       * \n
-       * thumb           : string - image filename.\n
-       * \n
-       * example:
-       *   - self.list.getSelectedItem().setThumbnailImage('emailread.png')
+       * Deprecated. Use setArt
        */
       void setThumbnailImage(const String& thumbFilename);
 

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -52,6 +52,15 @@ namespace XBMCAddon
     // If it's a list of items then the items can be either a String or a Tuple.
     typedef Dictionary<InfoLabelValue> InfoLabelDict;
 
+    /**
+     * ListItem([label, label2, iconImage, thumbnailImage, path])\n
+     * \n
+     * label : [opt] string
+     * label2 : [opt] string
+     * iconImage : [opt] string
+     * thumbnailImage : [opt] string
+     * path : [opt] string
+     */
     class ListItem : public AddonClass
     {
     public:


### PR DESCRIPTION
We don't need 3 different ways to set a thumb:)
