### PR TITLE
[PVR] RecordingGroup default wasnt being populated on new timer

### DIFF
--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -365,6 +365,7 @@ void CPVRTimerInfoTag::SetTimerType(const CPVRTimerTypePtr &type)
     m_iPriority           = m_timerType->GetPriorityDefault();
     m_iLifetime           = m_timerType->GetLifetimeDefault();
     m_iPreventDupEpisodes = m_timerType->GetPreventDuplicateEpisodesDefault();
+    m_iRecordingGroup     = m_timerType->GetRecordingGroupDefault();
   }
 
   if (m_timerType && !m_timerType->IsRepeating())


### PR DESCRIPTION
I found that a call to GetRecordingGroupDefault() was missing in the CPVRTimerInfoTag::SetTimerType() function, causing this field to be blank on new timer rather than populated with the default as specified by the pvr addon

@ksooo @metaron-uk 
