### PR TITLE
FFmpeg: Bump to 2.7.2-Jarvis-alpha1

### DIFF
--- a/tools/depends/target/ffmpeg/FFMPEG-VERSION
+++ b/tools/depends/target/ffmpeg/FFMPEG-VERSION
@@ -1,5 +1,5 @@
 LIBNAME=ffmpeg
 BASE_URL=https://github.com/xbmc/FFmpeg/archive
-VERSION=2.7.1-JUnknown-alpha
+VERSION=2.7.2-Jarvis-alpha1
 ARCHIVE=$(LIBNAME)-$(VERSION).tar.gz
 


### PR DESCRIPTION
Rebase on 2.7 branch. We have 2.7.2 now. The vaapi reflist patch was incorporated upstream.
