### PR TITLE
FFmpeg: Bump to 2.6.4

### DIFF
--- a/tools/depends/target/ffmpeg/FFMPEG-VERSION
+++ b/tools/depends/target/ffmpeg/FFMPEG-VERSION
@@ -1,5 +1,5 @@
 LIBNAME=ffmpeg
 BASE_URL=https://github.com/xbmc/FFmpeg/archive
-VERSION=2.6.3-Isengard
+VERSION=2.6.4-Isengard
 ARCHIVE=$(LIBNAME)-$(VERSION).tar.gz
 


### PR DESCRIPTION
This solves several issues concerning hevc and swscale. Mostly minor things. Our VPS hevc cherry-pick was incorporated upstream.

This needs testing in the 15.1 testing thread to care for regressions.
