### PR TITLE
[pvr][fix] limit numeric dialog to fullscreen/visualisation window (fixes #16167)

### DIFF
--- a/xbmc/pvr/PVRActionListener.cpp
+++ b/xbmc/pvr/PVRActionListener.cpp
@@ -24,6 +24,7 @@
 #include "messaging/ApplicationMessenger.h"
 #include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
+#include "guilib/GUIWindowManager.h"
 #include "dialogs/GUIDialogNumeric.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
@@ -85,7 +86,9 @@ bool CPVRActionListener::OnAction(const CAction &action)
     case REMOTE_8:
     case REMOTE_9:
     {
-      if (g_application.IsFullScreen() && g_application.CurrentFileItem().IsLiveTV())
+      if (g_application.CurrentFileItem().IsLiveTV() &&
+          (g_windowManager.IsWindowActive(WINDOW_FULLSCREEN_VIDEO) ||
+           g_windowManager.IsWindowActive(WINDOW_VISUALISATION)))
       {
         if(g_PVRManager.IsPlaying())
         {


### PR DESCRIPTION
fixes http://trac.kodi.tv/ticket/16167

> My script uses two windows dialogs one a overlay & the other a EPG... I also have an onaction that detects keyboard or remote numerical input
> 
> Normally (prior to kodi 15) a user could press a number on remote or keyboard and it would change the channel in my script.
> 
> But with Kodi 15, when its playing a source with the pvr:// protocol any attempt to change the channel forces the kodi numerical input dialog to open, which interferes with myscript.
> 
> If I knew my way around kodi i'd look for the push that caused the problem... but I would suspect someone hardcoded a call to open the numerical display anytime a pvr:// source is playing...
> 
> I checked that this wasn't a skin issue by using multiple skins including the default install...
> 
> If you need more info let me know, Thanks again
