### PR TITLE
[PVR] API 3.0.0 Implementation of "Add maxRecordings to API"

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -3468,7 +3468,13 @@ msgctxt "#816"
 msgid "Record only new episodes"
 msgstr ""
 
-#empty strings from id 817 to 819
+# Label of "MaxRecordings" list in the PVR timer setting dialog
+#: xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+msgctxt "#817"
+msgid "Max recordings"
+msgstr ""
+
+#empty strings from id 818 to 819
 
 #. Representation of a one-time timer.
 #: xbmc/pvr/addons/PVRClient.cpp

--- a/addons/xbmc.pvr/addon.xml
+++ b/addons/xbmc.pvr/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="xbmc.pvr" version="2.1.0" provider-name="Team-Kodi">
-  <backwards-compatibility abi="2.1.0"/>
+<addon id="xbmc.pvr" version="3.0.0" provider-name="Team-Kodi">
+  <backwards-compatibility abi="3.0.0"/>
   <requires>
     <import addon="xbmc.core" version="0.1.0"/>
   </requires>

--- a/xbmc/addons/include/xbmc_pvr_types.h
+++ b/xbmc/addons/include/xbmc_pvr_types.h
@@ -126,7 +126,7 @@ extern "C" {
   const unsigned int PVR_TIMER_TYPE_SUPPORTS_LIFETIME                 = 0x00004000; /*!< @brief this type supports recording lifetime (PVR_TIMER.iLifetime) */
   const unsigned int PVR_TIMER_TYPE_SUPPORTS_RECORDING_FOLDERS        = 0x00008000; /*!< @brief this type supports placing recordings in user defined folders (PVR_TIMER.strDirectory) */
   const unsigned int PVR_TIMER_TYPE_SUPPORTS_RECORDING_GROUP          = 0x00010000; /*!> @brief this type supports a list of recording groups (PVR_TIMER.iRecordingGroup) */
-  const unsigned int PVR_TIMER_TYPE_SUPPORTS_MAX_RECORDINGS           = 0x00100000; /*!< @brief this type supports a 'maximum number of recordings' (PVR_TIMER.iMaxRecordings) */
+  const unsigned int PVR_TIMER_TYPE_SUPPORTS_MAX_RECORDINGS           = 0x00100000; /*!< @brief this type supports specifying a maximum recordings setting' (PVR_TIMER.iMaxRecordings) */
 
   /*!
    * @brief PVR timer weekdays (PVR_TIMER.iWeekdays values)
@@ -398,7 +398,7 @@ extern "C" {
     char            strSummary[PVR_ADDON_DESC_STRING_LENGTH];  /*!< @brief (optional) the summary for this timer */
     int             iPriority;                                 /*!< @brief (optional) the priority of this timer */
     int             iLifetime;                                 /*!< @brief (optional) lifetime of this timer in days. After this time period, the recording shall be automatically deleted by the backend */
-    int             iMaxRecordings;                            /*!< @brief (optional) the maximum number of recordings to make using this timer. */
+    int             iMaxRecordings;                            /*!< @brief (optional) integer ref to addon/backend defined list of maximum recording values */
     unsigned int    iRecordingGroup;                           /*!< @brief (optional) integer ref to addon/backend defined list of recording groups*/
     time_t          firstDay;                                  /*!< @brief (optional) the first day this timer is active, for repeating timers */
     unsigned int    iWeekdays;                                 /*!< @brief (optional) week days, for repeating timers */

--- a/xbmc/addons/include/xbmc_pvr_types.h
+++ b/xbmc/addons/include/xbmc_pvr_types.h
@@ -397,7 +397,7 @@ extern "C" {
     char            strDirectory[PVR_ADDON_URL_STRING_LENGTH]; /*!< @brief (optional) the (relative) directory where the recording will be stored in */
     char            strSummary[PVR_ADDON_DESC_STRING_LENGTH];  /*!< @brief (optional) the summary for this timer */
     int             iPriority;                                 /*!< @brief (optional) the priority of this timer */
-    int             iLifetime;                                 /*!< @brief (optional) lifetime of this timer in days. After this time period, the recording shall be automatically deleted by the backend */
+    int             iLifetime;                                 /*!< @brief (optional) integer ref to addon/backend defined list of lifetime values */
     int             iMaxRecordings;                            /*!< @brief (optional) integer ref to addon/backend defined list of maximum recording values */
     unsigned int    iRecordingGroup;                           /*!< @brief (optional) integer ref to addon/backend defined list of recording groups*/
     time_t          firstDay;                                  /*!< @brief (optional) the first day this timer is active, for repeating timers */

--- a/xbmc/addons/include/xbmc_pvr_types.h
+++ b/xbmc/addons/include/xbmc_pvr_types.h
@@ -72,6 +72,7 @@ struct DemuxPacket;
 #define PVR_ADDON_EDL_LENGTH                  32
 #define PVR_ADDON_TIMERTYPE_ARRAY_SIZE        32
 #define PVR_ADDON_TIMERTYPE_VALUES_ARRAY_SIZE 512
+#define PVR_ADDON_TIMERTYPE_VALUES_ARRAY_SIZE_SMALL 128
 #define PVR_ADDON_TIMERTYPE_STRING_LENGTH     64
 
 /* using the default avformat's MAX_STREAMS value to be safe */
@@ -125,6 +126,7 @@ extern "C" {
   const unsigned int PVR_TIMER_TYPE_SUPPORTS_LIFETIME                 = 0x00004000; /*!< @brief this type supports recording lifetime (PVR_TIMER.iLifetime) */
   const unsigned int PVR_TIMER_TYPE_SUPPORTS_RECORDING_FOLDERS        = 0x00008000; /*!< @brief this type supports placing recordings in user defined folders (PVR_TIMER.strDirectory) */
   const unsigned int PVR_TIMER_TYPE_SUPPORTS_RECORDING_GROUP          = 0x00010000; /*!> @brief this type supports a list of recording groups (PVR_TIMER.iRecordingGroup) */
+  const unsigned int PVR_TIMER_TYPE_SUPPORTS_MAX_RECORDINGS           = 0x00100000; /*!< @brief this type supports a 'maximum number of recordings' (PVR_TIMER.iMaxRecordings) */
 
   /*!
    * @brief PVR timer weekdays (PVR_TIMER.iWeekdays values)
@@ -366,6 +368,13 @@ extern "C" {
                                                             /*!< @brief (optional) Array containing the possible values of PVR_TMER.iRecordingGroup. Must be filled if iRecordingGroupSize > 0 */
     unsigned int iRecordingGroupDefault;                    /*!< @brief (optional) The default value for PVR_TIMER.iRecordingGroup. Must be filled in if PVR_TIMER.iRecordingGroupSize > 0 */
 
+    /* max recordings value definitions */
+    unsigned int iMaxRecordingsSize;                        /*!< @brief (required) Count of possible values of PVR_TIMER.iiMaxRecordings. 0 means max recordings are not supported by this timer type */
+    PVR_TIMER_TYPE_ATTRIBUTE_INT_VALUE
+      maxRecordings[PVR_ADDON_TIMERTYPE_VALUES_ARRAY_SIZE_SMALL];
+                                                            /*!< @brief (optional) Array containing the possible values of PVR_TMER.iMaxRecordings. If iMaxRecordingsSize = 0 "unlimited":50. Out of range values displayed as an integer */
+    int iMaxRecordingsDefault;                              /*!< @brief (optional) The default value for PVR_TIMER.iMaxRecordings. Must be filled in if PVR_TIMER.iMaxRecordingsSize > 0 */
+
   } ATTRIBUTE_PACKED PVR_TIMER_TYPE;
 
   /*!
@@ -389,6 +398,7 @@ extern "C" {
     char            strSummary[PVR_ADDON_DESC_STRING_LENGTH];  /*!< @brief (optional) the summary for this timer */
     int             iPriority;                                 /*!< @brief (optional) the priority of this timer */
     int             iLifetime;                                 /*!< @brief (optional) lifetime of this timer in days. After this time period, the recording shall be automatically deleted by the backend */
+    int             iMaxRecordings;                            /*!< @brief (optional) the maximum number of recordings to make using this timer. */
     unsigned int    iRecordingGroup;                           /*!< @brief (optional) integer ref to addon/backend defined list of recording groups*/
     time_t          firstDay;                                  /*!< @brief (optional) the first day this timer is active, for repeating timers */
     unsigned int    iWeekdays;                                 /*!< @brief (optional) week days, for repeating timers */

--- a/xbmc/addons/include/xbmc_pvr_types.h
+++ b/xbmc/addons/include/xbmc_pvr_types.h
@@ -78,10 +78,10 @@ struct DemuxPacket;
 #define PVR_STREAM_MAX_STREAMS 20
 
 /* current PVR API version */
-#define XBMC_PVR_API_VERSION "2.1.0"
+#define XBMC_PVR_API_VERSION "3.0.0"
 
 /* min. PVR API version */
-#define XBMC_PVR_MIN_API_VERSION "2.1.0"
+#define XBMC_PVR_MIN_API_VERSION "3.0.0"
 
 #ifdef __cplusplus
 extern "C" {

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -297,6 +297,7 @@ void CPVRClient::WriteClientTimerInfo(const CPVRTimerInfoTag &xbmcTimer, PVR_TIM
   strncpy(addonTimer.strDirectory, xbmcTimer.m_strDirectory.c_str(), sizeof(addonTimer.strDirectory) - 1);
   addonTimer.iPriority                 = xbmcTimer.m_iPriority;
   addonTimer.iLifetime                 = xbmcTimer.m_iLifetime;
+  addonTimer.iMaxRecordings            = xbmcTimer.m_iMaxRecordings;
   addonTimer.iPreventDuplicateEpisodes = xbmcTimer.m_iPreventDupEpisodes;
   addonTimer.iRecordingGroup           = xbmcTimer.m_iRecordingGroup;
   addonTimer.iWeekdays                 = xbmcTimer.m_iWeekdays;

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -57,6 +57,7 @@ using namespace PVR;
 #define SETTING_TMR_END_POST      "timer.endmargin"
 #define SETTING_TMR_PRIORITY      "timer.priority"
 #define SETTING_TMR_LIFETIME      "timer.lifetime"
+#define SETTING_TMR_MAX_REC       "timer.maxrecordings"
 #define SETTING_TMR_DIR           "timer.directory"
 #define SETTING_TMR_REC_GROUP     "timer.recgroup"
 
@@ -81,6 +82,7 @@ CGUIDialogPVRTimerSettings::CGUIDialogPVRTimerSettings() :
   m_iMarginEnd(0),
   m_iPriority(0),
   m_iLifetime(0),
+  m_iMaxRecordings(0),
   m_iRecordingGroup(0)
 {
   m_loadType = LOAD_EVERY_TIME;
@@ -138,6 +140,7 @@ void CGUIDialogPVRTimerSettings::SetTimer(CFileItem *item)
   m_iMarginEnd          = m_timerInfoTag->m_iMarginEnd;
   m_iPriority           = m_timerInfoTag->m_iPriority;
   m_iLifetime           = m_timerInfoTag->m_iLifetime;
+  m_iMaxRecordings      = m_timerInfoTag->m_iMaxRecordings;
   m_strDirectory        = m_timerInfoTag->m_strDirectory;
   m_iRecordingGroup     = m_timerInfoTag->m_iRecordingGroup;
 
@@ -334,6 +337,11 @@ void CGUIDialogPVRTimerSettings::InitializeSettings()
   AddTypeDependentVisibilityCondition(setting, SETTING_TMR_LIFETIME);
   AddTypeDependentEnableCondition(setting, SETTING_TMR_LIFETIME);
 
+  // MaxRecordings
+  setting = AddList(group, SETTING_TMR_MAX_REC, 817, 0, m_iMaxRecordings, MaxRecordingsFiller, 817);
+  AddTypeDependentVisibilityCondition(setting, SETTING_TMR_MAX_REC);
+  AddTypeDependentEnableCondition(setting, SETTING_TMR_MAX_REC);
+
   // Recording folder
   setting = AddEdit(group, SETTING_TMR_DIR, 19076, 0, m_strDirectory, true, false, 19104);
   AddTypeDependentVisibilityCondition(setting, SETTING_TMR_DIR);
@@ -458,6 +466,10 @@ void CGUIDialogPVRTimerSettings::OnSettingChanged(const CSetting *setting)
   else if (settingId == SETTING_TMR_LIFETIME)
   {
     m_iLifetime = static_cast<const CSettingInt*>(setting)->GetValue();
+  }
+  else if (settingId == SETTING_TMR_MAX_REC)
+  {
+    m_iMaxRecordings = static_cast<const CSettingInt*>(setting)->GetValue();
   }
   else if (settingId == SETTING_TMR_DIR)
   {
@@ -618,6 +630,9 @@ void CGUIDialogPVRTimerSettings::Save()
 
   // Lifetime
   m_timerInfoTag->m_iLifetime = m_iLifetime;
+
+  // MaxRecordings
+  m_timerInfoTag->m_iMaxRecordings = m_iMaxRecordings;
 
   // Recording folder
   m_timerInfoTag->m_strDirectory = m_strDirectory;
@@ -922,6 +937,20 @@ void CGUIDialogPVRTimerSettings::LifetimesFiller(
     CLog::Log(LOGERROR, "CGUIDialogPVRTimerSettings::LifetimesFiller - No dialog");
 }
 
+void CGUIDialogPVRTimerSettings::MaxRecordingsFiller(
+  const CSetting *setting, std::vector< std::pair<std::string, int> > &list, int &current, void *data)
+{
+  CGUIDialogPVRTimerSettings *pThis = static_cast<CGUIDialogPVRTimerSettings*>(data);
+  if (pThis)
+  {
+    list.clear();
+    pThis->m_timerType->GetMaxRecordingsValues(list);
+    current = pThis->m_iMaxRecordings;
+  }
+  else
+    CLog::Log(LOGERROR, "CGUIDialogPVRTimerSettings::MaxRecordingsFiller - No dialog");
+}
+
 void CGUIDialogPVRTimerSettings::RecordingGroupFiller(
   const CSetting *setting, std::vector< std::pair<std::string, int> > &list, int &current, void *data)
 {
@@ -1058,6 +1087,8 @@ bool CGUIDialogPVRTimerSettings::TypeSupportsCondition(const std::string &condit
       return entry->second->SupportsPriority();
     else if (cond == SETTING_TMR_LIFETIME)
       return entry->second->SupportsLifetime();
+	else if (cond == SETTING_TMR_MAX_REC)
+      return entry->second->SupportsMaxRecordings();
     else if (cond == SETTING_TMR_DIR)
       return entry->second->SupportsRecordingFolders();
     else if (cond == SETTING_TMR_REC_GROUP)

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.h
@@ -81,6 +81,8 @@ namespace PVR
       const CSetting *setting, std::vector< std::pair<std::string, int> > &list, int &current, void *data);
     static void LifetimesFiller(
       const CSetting *setting, std::vector< std::pair<std::string, int> > &list, int &current, void *data);
+    static void MaxRecordingsFiller(
+      const CSetting *setting, std::vector< std::pair<std::string, int> > &list, int &current, void *data);
     static void RecordingGroupFiller(
       const CSetting *setting, std::vector< std::pair<std::string, int> > &list, int &current, void *data);
 
@@ -152,6 +154,7 @@ namespace PVR
     unsigned int        m_iMarginEnd;
     int                 m_iPriority;
     int                 m_iLifetime;
+    int                 m_iMaxRecordings;
     std::string         m_strDirectory;
     unsigned int        m_iRecordingGroup;
   };

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -48,6 +48,7 @@ CPVRTimerInfoTag::CPVRTimerInfoTag(bool bRadio /* = false */) :
   m_iClientChannelUid   = PVR_INVALID_CHANNEL_UID;
   m_iPriority           = CSettings::Get().GetInt("pvrrecord.defaultpriority");
   m_iLifetime           = CSettings::Get().GetInt("pvrrecord.defaultlifetime");
+  m_iMaxRecordings      = 0;
   m_iPreventDupEpisodes = CSettings::Get().GetInt("pvrrecord.preventduplicateepisodes");
   m_iRecordingGroup     = 0;
   m_iChannelNumber      = 0;
@@ -102,6 +103,7 @@ CPVRTimerInfoTag::CPVRTimerInfoTag(const PVR_TIMER &timer, const CPVRChannelPtr 
   m_iWeekdays           = timer.iWeekdays;
   m_iPriority           = timer.iPriority;
   m_iLifetime           = timer.iLifetime;
+  m_iMaxRecordings      = timer.iMaxRecordings;
   m_iMarginStart        = timer.iMarginStart;
   m_iMarginEnd          = timer.iMarginEnd;
   m_genre               = StringUtils::Split(CEpg::ConvertGenreIdToString(timer.iGenreType, timer.iGenreSubType), g_advancedSettings.m_videoItemSeparator);
@@ -179,6 +181,7 @@ bool CPVRTimerInfoTag::operator ==(const CPVRTimerInfoTag& right) const
           m_iWeekdays           == right.m_iWeekdays &&
           m_iPriority           == right.m_iPriority &&
           m_iLifetime           == right.m_iLifetime &&
+          m_iMaxRecordings      == right.m_iMaxRecordings &&
           m_strFileNameAndPath  == right.m_strFileNameAndPath &&
           m_strTitle            == right.m_strTitle &&
           m_strEpgSearchString  == right.m_strEpgSearchString &&
@@ -300,6 +303,7 @@ void CPVRTimerInfoTag::Serialize(CVariant &value) const
   value["epgsearchstring"]   = m_strEpgSearchString;
   value["fulltextepgsearch"] = m_bFullTextEpgSearch;
   value["recordinggroup"]    = m_iRecordingGroup;
+  value["maxrecordings"]     = m_iMaxRecordings;
 }
 
 int CPVRTimerInfoTag::Compare(const CPVRTimerInfoTag &timer) const
@@ -364,6 +368,7 @@ void CPVRTimerInfoTag::SetTimerType(const CPVRTimerTypePtr &type)
   {
     m_iPriority           = m_timerType->GetPriorityDefault();
     m_iLifetime           = m_timerType->GetLifetimeDefault();
+    m_iMaxRecordings      = m_timerType->GetMaxRecordingsDefault();
     m_iPreventDupEpisodes = m_timerType->GetPreventDuplicateEpisodesDefault();
   }
 
@@ -561,6 +566,7 @@ bool CPVRTimerInfoTag::UpdateEntry(const CPVRTimerInfoTagPtr &tag)
   m_FirstDay            = tag->m_FirstDay;
   m_iPriority           = tag->m_iPriority;
   m_iLifetime           = tag->m_iLifetime;
+  m_iMaxRecordings      = tag->m_iMaxRecordings;
   m_state               = tag->m_state;
   m_iPreventDupEpisodes = tag->m_iPreventDupEpisodes;
   m_iRecordingGroup     = tag->m_iRecordingGroup;

--- a/xbmc/pvr/timers/PVRTimerInfoTag.h
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.h
@@ -238,6 +238,7 @@ namespace PVR
     int                   m_iClientChannelUid;   /*!< @brief channel uid */
     int                   m_iPriority;           /*!< @brief priority of the timer */
     int                   m_iLifetime;           /*!< @brief lifetime of the timer in days */
+    int                   m_iMaxRecordings;      /*!< @brief (optional) backend setting for maximum number of recordings to keep*/
     unsigned int          m_iWeekdays;           /*!< @brief bit based store of weekdays for repeating timers */
     unsigned int          m_iPreventDupEpisodes; /*!< @brief only record new episodes for repeating epg based timers */
     unsigned int          m_iRecordingGroup;     /*!< @brief (optional) if set, the addon/backend stores the recording to a group (sub-folder) */

--- a/xbmc/pvr/timers/PVRTimerType.cpp
+++ b/xbmc/pvr/timers/PVRTimerType.cpp
@@ -84,6 +84,7 @@ CPVRTimerType::CPVRTimerType() :
   m_iAttributes(PVR_TIMER_TYPE_ATTRIBUTE_NONE),
   m_iPriorityDefault(50),
   m_iLifetimeDefault(365),
+  m_iMaxRecordingsDefault(0),
   m_iPreventDupEpisodesDefault(0),
   m_iRecordingGroupDefault(0)
 {
@@ -112,6 +113,8 @@ bool CPVRTimerType::operator ==(const CPVRTimerType& right) const
           m_iPriorityDefault           == right.m_iPriorityDefault &&
           m_lifetimeValues             == right.m_lifetimeValues &&
           m_iLifetimeDefault           == right.m_iLifetimeDefault &&
+          m_maxRecordingsValues        == right.m_maxRecordingsValues &&
+          m_iMaxRecordingsDefault      == right.m_iMaxRecordingsDefault &&
           m_preventDupEpisodesValues   == right.m_preventDupEpisodesValues &&
           m_iPreventDupEpisodesDefault == right.m_iPreventDupEpisodesDefault &&
           m_recordingGroupValues       == right.m_recordingGroupValues &&
@@ -127,9 +130,9 @@ void CPVRTimerType::InitAttributeValues(const PVR_TIMER_TYPE &type)
 {
   InitPriorityValues(type);
   InitLifetimeValues(type);
+  InitMaxRecordingsValues(type);
   InitPreventDuplicateEpisodesValues(type);
   InitRecordingGroupValues(type);
-
 }
 
 void CPVRTimerType::InitPriorityValues(const PVR_TIMER_TYPE &type)
@@ -207,6 +210,33 @@ void CPVRTimerType::GetLifetimeValues(std::vector< std::pair<std::string, int> >
 {
   for (const auto &lifetime : m_lifetimeValues)
     list.push_back(lifetime);
+}
+
+void CPVRTimerType::InitMaxRecordingsValues(const PVR_TIMER_TYPE &type)
+{
+  if (type.iMaxRecordingsSize > 0)
+  {
+    for (unsigned int i = 0; i < type.iMaxRecordingsSize; ++i)
+    {
+      std::string strDescr(type.maxRecordings[i].strDescription);
+      if (strDescr.size() == 0)
+      {
+        // No description given by addon. Create one from value.
+        strDescr = StringUtils::Format("%s %d",
+                                       g_localizeStrings.Get(817).c_str(), // Max Recordings
+                                       type.maxRecordings[i].iValue);
+      }
+      m_maxRecordingsValues.push_back(std::make_pair(strDescr, type.maxRecordings[i].iValue));
+    }
+
+    m_iMaxRecordingsDefault = type.iMaxRecordingsDefault;
+  }
+}
+
+void CPVRTimerType::GetMaxRecordingsValues(std::vector< std::pair<std::string, int> > &list) const
+{
+  for (const auto &maxRecordings : m_maxRecordingsValues)
+    list.push_back(maxRecordings);
 }
 
 void CPVRTimerType::InitPreventDuplicateEpisodesValues(const PVR_TIMER_TYPE &type)

--- a/xbmc/pvr/timers/PVRTimerType.h
+++ b/xbmc/pvr/timers/PVRTimerType.h
@@ -220,6 +220,12 @@ namespace PVR
     bool SupportsLifetime() const { return (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_LIFETIME) > 0; }
 
     /*!
+     * @brief Check whether this type supports MaxRecordings for recordings.
+     * @return True if MaxRecordings is supported, false otherwise.
+     */
+    bool SupportsMaxRecordings() const { return (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_MAX_RECORDINGS) > 0; }
+
+    /*!
      * @brief Check whether this type supports user specified recording folders.
      * @return True if recording folders are supported, false otherwise.
      */
@@ -256,6 +262,18 @@ namespace PVR
     int GetLifetimeDefault() const { return m_iLifetimeDefault; }
 
     /*!
+     * @brief Obtain a list with all possible values for the MaxRecordings attribute.
+     * @param list out, the list with the values or an empty list, if MaxRecordings is not supported by this type.
+     */
+    void GetMaxRecordingsValues(std::vector< std::pair<std::string, int> > &list) const;
+
+    /*!
+     * @brief Obtain the default value for the MaxRecordings attribute.
+     * @return the default value.
+     */
+    int GetMaxRecordingsDefault() const { return m_iMaxRecordingsDefault; }
+
+    /*!
      * @brief Obtain a list with all possible values for the duplicate episode prevention attribute.
      * @param list out, the list with the values or an empty list, if duplicate episode prevention is not supported by this type.
      */
@@ -284,6 +302,7 @@ namespace PVR
     void InitAttributeValues(const PVR_TIMER_TYPE &type);
     void InitPriorityValues(const PVR_TIMER_TYPE &type);
     void InitLifetimeValues(const PVR_TIMER_TYPE &type);
+    void InitMaxRecordingsValues(const PVR_TIMER_TYPE &type);
     void InitPreventDuplicateEpisodesValues(const PVR_TIMER_TYPE &type);
     void InitRecordingGroupValues(const PVR_TIMER_TYPE &type);
 
@@ -295,6 +314,8 @@ namespace PVR
     int           m_iPriorityDefault;
     std::vector< std::pair<std::string, int> > m_lifetimeValues;
     int           m_iLifetimeDefault;
+    std::vector< std::pair<std::string, int> > m_maxRecordingsValues;
+    int           m_iMaxRecordingsDefault;
     std::vector< std::pair<std::string, int> > m_preventDupEpisodesValues;
     unsigned int  m_iPreventDupEpisodesDefault;
     std::vector< std::pair<std::string, int> > m_recordingGroupValues;


### PR DESCRIPTION
This is the implementation of one of the API 3.0.0 features from #7626

Add MaxRecordings field to PVRTimer - an (optional) field to limit a supported backend's number of recordings created for a timer.  This field appears directly below the (optional) Lifetime list 

The first 2 commits are the API bump/fields from #7626 and the 3rd commit is the actual PVR Core implementation. This will likely be pulled together by @metaron-uk with whatever other API 3.0.0 changes are "good to go" into a new PR

**PVR Client Changes Requried**
None, unless they wish to use the new field on their TimerTypes

**Context**
This PR relies on the changes in PR #7626 which groups several API changes forming API 3.0.0.
- This PR should not be merged unless PR #7626 has also been merged.
- The necessary supporting API change is contained in commit [[PVR] Add maxRecordings to API](https://github.com/metaron-uk/xbmc/commit/ffdd6dfc48428bd6557cb29c3d665c3aa5a9ab8b). If this change is withdrawn from PR #7626 this PR will be closed.

**Comments**
Please make comments regarding the MaxRecordings change itself here.
For comments regarding any of the other 3.0.0 API changes, please use #7626

@metaron-uk @ksooo @xhaggi @Jalle19 @janbar
