### PR TITLE
changed: Rename cache: to forward: as that's what it really is

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -2986,7 +2986,7 @@ void CDVDPlayer::GetGeneralInfo(std::string& strGeneralInfo)
       CSingleLock lock(m_StateSection);
       if(m_StateInput.cache_bytes >= 0)
       {
-        strBuf += StringUtils::Format(" cache:%s %2.0f%%"
+        strBuf += StringUtils::Format(" forward:%s %2.0f%%"
                                       , StringUtils::SizeToString(m_StateInput.cache_bytes).c_str()
                                       , m_StateInput.cache_level * 100);
         if(m_playSpeed == 0 || m_caching == CACHESTATE_FULL)
@@ -3022,7 +3022,7 @@ void CDVDPlayer::GetGeneralInfo(std::string& strGeneralInfo)
       CSingleLock lock(m_StateSection);
       if(m_StateInput.cache_bytes >= 0)
       {
-        strBuf += StringUtils::Format(" cache:%s %2.0f%%"
+        strBuf += StringUtils::Format(" forward:%s %2.0f%%"
                                       , StringUtils::SizeToString(m_StateInput.cache_bytes).c_str()
                                       , m_StateInput.cache_level * 100);
         if(m_playSpeed == 0 || m_caching == CACHESTATE_FULL)


### PR DESCRIPTION
This changes the cache: label in DVDPlayer's OSD info to forward:. This is more accurate as the "whole" cache also contains a back buffer which is not taken into account here. This should also reduce (hopefully) the amount of people nagging that their set cache size doesn't match with the value here.
