### PR TITLE
[gui] fix crash at destruction of CGUIWindowSplash

### DIFF
--- a/xbmc/windows/GUIWindowSplash.cpp
+++ b/xbmc/windows/GUIWindowSplash.cpp
@@ -28,6 +28,7 @@
 CGUIWindowSplash::CGUIWindowSplash(void) : CGUIWindow(WINDOW_SPLASH, "")
 {
   m_loadType = LOAD_ON_GUI_INIT;
+  m_image = nullptr;
 }
 
 CGUIWindowSplash::~CGUIWindowSplash(void)


### PR DESCRIPTION
should fixes the issue reported at https://github.com/xbmc/xbmc/pull/7650#issuecomment-127096274

We call `delete m_image` in the destructor with uninitialized `m_image` which causes the crash.

@MilhouseVH could you please confirm if it solves the issue.
@mkortstiege mind taking a look.
