### PR TITLE
[ios] - fix broken native keyboard on ios 5.1.1 devices (incompatibli…

### DIFF
--- a/xbmc/osx/ios/IOSKeyboardView.mm
+++ b/xbmc/osx/ios/IOSKeyboardView.mm
@@ -93,6 +93,10 @@ static CEvent keyboardFinishedEvent;
                                                  name:UIKeyboardDidHideNotification
                                                object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(keyboardDidChangeFrame:)
+                                                 name:UIKeyboardDidChangeFrameNotification 
+                                               object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(keyboardWillShow:)
                                                  name:UIKeyboardWillShowNotification
                                                object:nil];
@@ -174,6 +178,34 @@ static CEvent keyboardFinishedEvent;
   _confirmed = YES;
   [_textField resignFirstResponder];
   return YES;
+}
+
+- (void)keyboardDidChangeFrame:(id)sender
+{
+#if __IPHONE_8_0
+  // when compiled against ios 8.x sdk and runtime is ios
+  // 5.1.1 (f.e. ipad1 which has 5.1.1 as latest available ios version)
+  // there is an incompatibility which somehowe prevents us from getting
+  // notified about "keyboardDidHide". This makes the keyboard
+  // useless on those ios platforms.
+  // Instead we are called here with "DidChangeFrame" and
+  // and an invalid frame set (height, width == 0 and pos is inf).
+  // Lets detect this situation and treat this as "keyboard was hidden"
+  // message
+  if (CDarwinUtils::GetIOSVersion() < 6.0)
+  {
+    PRINT_SIGNATURE();
+
+    NSDictionary* info = [sender userInfo];
+    CGRect kbRect = [[info objectForKey:UIKeyboardFrameEndUserInfoKey] CGRectValue];
+//    LOG(@"keyboardWillShow: keyboard frame: %f %f %f %f", kbRect.origin.x, kbRect.origin.y, kbRect.size.width, kbRect.size.height);
+    if (kbRect.size.height == 0)
+    {
+      LOG(@"keyboardDidChangeFrame: working around missing keyboardDidHide Message on iOS 5.x");
+      [self keyboardDidHide:sender];
+    }
+  }
+#endif
 }
 
 - (void)keyboardDidHide:(id)sender


### PR DESCRIPTION
…ty with ios8 sdk and old deployment target).

Well this is a bug in the apple SDK combined with iOS 5.x runtime. Runtime just doesn't call the notification callback that tells us that keyboard was hidden. This leds to a non working native keyboard.

It instead fires a different callback with improper userinfo which we can use for detecting a hidden keyboard. Risk is low as its restricted to ios < 6.0 runtime. Backport incoming.
