### PR TITLE
Fix make-mingwlibs.bat with VS 2015

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -901,6 +901,7 @@ xbmc/main/posix/Makefile
 
 #/lib/win32/ffmpeg
 /lib/win32/ffmpeg/
+/lib/win32/FFmpeg*
 
 # lib/cximage-6.0/
 /lib/cximage-6.0/Makefile

--- a/tools/buildsteps/win32/make-mingwlibs.bat
+++ b/tools/buildsteps/win32/make-mingwlibs.bat
@@ -4,7 +4,10 @@ SETLOCAL
 rem batch file to compile mingw libs via BuildSetup
 SET WORKDIR=%WORKSPACE%
 rem set M$ env
-call "%VS120COMNTOOLS%vsvars32.bat" || exit /b 1
+
+SET VSCOMNTOOLS_PATH=%VS120COMNTOOLS%
+IF "%VSCOMNTOOLS%"=="" SET VSCOMNTOOLS_PATH=%VS140COMNTOOLS%
+call "%VSCOMNTOOLS_PATH%"vsvars32.bat || exit /b 1
 
 SET PROMPTLEVEL=prompt
 SET BUILDMODE=clean


### PR DESCRIPTION
Microsoft in their infinite wisdom puts the folder that contains ´vsvars32.bat` in different locations depending on which Visual Studio version is installed, and our script only looked for the VS 2013 version of the folder. Now it falls back on the VS 2015 location if the old one is not found.

Additionally I added a line to .gitignore to prevent SourceTree from going insane while ffmpeg is being compiled.

@Montellese by batch skills are close to zero but does this look okay?
