### PR TITLE
[pydocs] Listitem addStreamInfo example (must use lowercase dict keys)

### DIFF
--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -268,7 +268,7 @@ namespace XBMCAddon
        *     - language      : string (en)
        * 
        * example:
-       *   - self.list.getSelectedItem().addStreamInfo('video', { 'Codec': 'h264', 'Width' : 1280 })
+       *   - self.list.getSelectedItem().addStreamInfo('video', { 'codec': 'h264', 'width' : 1280 })
        */
       void addStreamInfo(const char* cType, const Properties& dictionary);
 


### PR DESCRIPTION
I have no ideia if pydocs are generated from this file but according to the wiki (http://kodi.wiki/view/Python_development) they are. In the example provided in the documentation for the addStreamInfo function from the Listitem class dictionary keys are not lowercase (and they should).

Don't know who is "responsible" for this... @MartijnKaijser ?

Regards

PS: pydocs are still using the old xbmc logo (http://mirrors.kodi.tv/docs/python-docs/15.x-isengard/)
