### PR TITLE
[pydocs] proper types in cast and castandrole (Listitem.setInfo())

### DIFF
--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -199,8 +199,8 @@ namespace XBMCAddon
        *     - watched       : depreciated - use playcount instead
        *     - playcount     : integer (2) - number of times this item has been played
        *     - overlay       : integer (2) - range is 0..8.  See GUIListItem.h for values
-       *     - cast          : list (Michal C. Hall)
-       *     - castandrole   : list (Michael C. Hall|Dexter)
+       *     - cast          : list (["Michal C. Hall","Jennifer Carpenter"]) - if provided a list of tuples cast will be interpreted as castandrole
+       *     - castandrole   : list of tuples ([("Michael C. Hall","Dexter"),("Jennifer Carpenter","Debra")])
        *     - director      : string (Dagur Kari)
        *     - mpaa          : string (PG-13)
        *     - plot          : string (Long Description)


### PR DESCRIPTION
Cast and castandrole documentation/examples are not totally correct for the setInfo function of the Listitem Class.
Cast uses a list of strings and the fallback is done to castandrole if a list of tuples is detected in the "cast" key. Castandrole uses a list of tuples and not a string separated by '|' as the example suggests (despite being referred as "list").

Regards

ping @MartijnKaijser 
