### PR TITLE
[Binary add-ons] Point audio encoders/decoders to master instead of SHA

### DIFF
--- a/project/cmake/addons/addons/audiodecoder.modplug/audiodecoder.modplug.txt
+++ b/project/cmake/addons/addons/audiodecoder.modplug/audiodecoder.modplug.txt
@@ -1,1 +1,1 @@
-audiodecoder.modplug https://github.com/notspiff/audiodecoder.modplug 5ae7349
+audiodecoder.modplug https://github.com/notspiff/audiodecoder.modplug master

--- a/project/cmake/addons/addons/audiodecoder.nosefart/audiodecoder.nosefart.txt
+++ b/project/cmake/addons/addons/audiodecoder.nosefart/audiodecoder.nosefart.txt
@@ -1,1 +1,1 @@
-audiodecoder.nosefart https://github.com/notspiff/audiodecoder.nosefart 936313f
+audiodecoder.nosefart https://github.com/notspiff/audiodecoder.nosefart master

--- a/project/cmake/addons/addons/audiodecoder.sidplay/audiodecoder.sidplay.txt
+++ b/project/cmake/addons/addons/audiodecoder.sidplay/audiodecoder.sidplay.txt
@@ -1,1 +1,1 @@
-audiodecoder.sidplay https://github.com/notspiff/audiodecoder.sidplay 27b2c05
+audiodecoder.sidplay https://github.com/notspiff/audiodecoder.sidplay master

--- a/project/cmake/addons/addons/audiodecoder.snesapu/audiodecoder.snesapu.txt
+++ b/project/cmake/addons/addons/audiodecoder.snesapu/audiodecoder.snesapu.txt
@@ -1,1 +1,1 @@
-audiodecoder.snesapu https://github.com/notspiff/audiodecoder.snesapu 399d1d3
+audiodecoder.snesapu https://github.com/notspiff/audiodecoder.snesapu master

--- a/project/cmake/addons/addons/audiodecoder.stsound/audiodecoder.stsound.txt
+++ b/project/cmake/addons/addons/audiodecoder.stsound/audiodecoder.stsound.txt
@@ -1,1 +1,1 @@
-audiodecoder.stsound https://github.com/notspiff/audiodecoder.stsound f6fbae9
+audiodecoder.stsound https://github.com/notspiff/audiodecoder.stsound master

--- a/project/cmake/addons/addons/audiodecoder.timidity/audiodecoder.timidity.txt
+++ b/project/cmake/addons/addons/audiodecoder.timidity/audiodecoder.timidity.txt
@@ -1,1 +1,1 @@
-audiodecoder.timidity https://github.com/notspiff/audiodecoder.timidity da5eb9a
+audiodecoder.timidity https://github.com/notspiff/audiodecoder.timidity master

--- a/project/cmake/addons/addons/audiodecoder.vgmstream/audiodecoder.vgmstream.txt
+++ b/project/cmake/addons/addons/audiodecoder.vgmstream/audiodecoder.vgmstream.txt
@@ -1,1 +1,1 @@
-audiodecoder.vgmstream https://github.com/notspiff/audiodecoder.vgmstream 7723f91
+audiodecoder.vgmstream https://github.com/notspiff/audiodecoder.vgmstream master

--- a/project/cmake/addons/addons/audioencoder.flac/audioencoder.flac.txt
+++ b/project/cmake/addons/addons/audioencoder.flac/audioencoder.flac.txt
@@ -1,1 +1,1 @@
-audioencoder.flac https://github.com/xbmc/audioencoder.flac 4603889
+audioencoder.flac https://github.com/xbmc/audioencoder.flac master

--- a/project/cmake/addons/addons/audioencoder.lame/audioencoder.lame.txt
+++ b/project/cmake/addons/addons/audioencoder.lame/audioencoder.lame.txt
@@ -1,1 +1,1 @@
-audioencoder.lame https://github.com/xbmc/audioencoder.lame 0f612d4
+audioencoder.lame https://github.com/xbmc/audioencoder.lame master

--- a/project/cmake/addons/addons/audioencoder.vorbis/audioencoder.vorbis.txt
+++ b/project/cmake/addons/addons/audioencoder.vorbis/audioencoder.vorbis.txt
@@ -1,1 +1,1 @@
-audioencoder.vorbis https://github.com/xbmc/audioencoder.vorbis 15d619d
+audioencoder.vorbis https://github.com/xbmc/audioencoder.vorbis master

--- a/project/cmake/addons/addons/audioencoder.wav/audioencoder.wav.txt
+++ b/project/cmake/addons/addons/audioencoder.wav/audioencoder.wav.txt
@@ -1,1 +1,1 @@
-audioencoder.wav https://github.com/xbmc/audioencoder.wav 77e1612
+audioencoder.wav https://github.com/xbmc/audioencoder.wav master

--- a/project/cmake/addons/addons/pvr.dvbviewer/pvr.dvbviewer.txt
+++ b/project/cmake/addons/addons/pvr.dvbviewer/pvr.dvbviewer.txt
@@ -1,1 +1,1 @@
-pvr.dvbviewer https://github.com/kodi-pvr/pvr.dvbviewer 65b8647
+pvr.dvbviewer https://github.com/kodi-pvr/pvr.dvbviewer master


### PR DESCRIPTION
To go in after https://github.com/xbmc/xbmc/pull/7570 and respective add-on PRs are merged.
