### PR TITLE
[gui] use a global enum to specify the default render orders

### DIFF
--- a/xbmc/addons/AddonCallbacksGUI.cpp
+++ b/xbmc/addons/AddonCallbacksGUI.cpp
@@ -2204,7 +2204,7 @@ void CGUIAddonWindowDialog::Show_Internal(bool show /* = true */)
 
     // this dialog is derived from GUiMediaWindow
     // make sure it is rendered last
-    m_renderOrder = 1;
+    m_renderOrder = RENDER_ORDER_DIALOG;
     while (m_bRunning && !g_application.m_bStop)
     {
       g_windowManager.ProcessRenderLoop();

--- a/xbmc/guilib/GUIDialog.cpp
+++ b/xbmc/guilib/GUIDialog.cpp
@@ -34,7 +34,7 @@ CGUIDialog::CGUIDialog(int id, const std::string &xmlFile, DialogModalityType mo
 {
   m_modalityType = modalityType;
   m_wasRunning = false;
-  m_renderOrder = 1;
+  m_renderOrder = RENDER_ORDER_DIALOG;
   m_autoClosing = false;
   m_showStartTime = 0;
   m_showDuration = 0;
@@ -225,7 +225,7 @@ void CGUIDialog::Render()
 void CGUIDialog::SetDefaults()
 {
   CGUIWindow::SetDefaults();
-  m_renderOrder = 1;
+  m_renderOrder = RENDER_ORDER_DIALOG;
 }
 
 void CGUIDialog::SetAutoClose(unsigned int timeoutMs)

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -63,7 +63,7 @@ CGUIWindow::CGUIWindow(int id, const std::string &xmlFile)
   m_loadType = LOAD_EVERY_TIME;
   m_closing = false;
   m_active = false;
-  m_renderOrder = 0;
+  m_renderOrder = RENDER_ORDER_WINDOW;
   m_dynamicResourceAlloc = true;
   m_previousWindow = WINDOW_INVALID;
   m_animationsEnabled = true;
@@ -958,7 +958,7 @@ bool CGUIWindow::OnMove(int fromControl, int moveAction)
 
 void CGUIWindow::SetDefaults()
 {
-  m_renderOrder = 0;
+  m_renderOrder = RENDER_ORDER_WINDOW;
   m_defaultAlways = false;
   m_defaultControl = 0;
   m_posX = m_posY = m_width = m_height = 0;

--- a/xbmc/guilib/GUIWindow.h
+++ b/xbmc/guilib/GUIWindow.h
@@ -36,6 +36,7 @@ class CFileItem; typedef std::shared_ptr<CFileItem> CFileItemPtr;
 
 #include "GUICallback.h"  // for GUIEvent
 
+#include <limits.h>
 #include <map>
 #include <vector>
 
@@ -50,6 +51,15 @@ class CFileItem; typedef std::shared_ptr<CFileItem> CFileItemPtr;
  GUIEventHandler<c, CGUIMessage&> selectedHandler(this, &m); \
  m_mapSelectedEvents[i] = selectedHandler; \
 } \
+
+enum RenderOrder {
+  RENDER_ORDER_WINDOW = 0,
+  RENDER_ORDER_DIALOG = 1,
+  RENDER_ORDER_WINDOW_SCREENSAVER = INT_MAX,
+  RENDER_ORDER_WINDOW_POINTER = INT_MAX - 1,
+  RENDER_ORDER_WINDOW_DEBUG = INT_MAX - 2,
+  RENDER_ORDER_DIALOG_TELETEXT = INT_MAX - 3
+};
 
 // forward
 class TiXmlNode;

--- a/xbmc/interfaces/legacy/Window.h
+++ b/xbmc/interfaces/legacy/Window.h
@@ -31,11 +31,6 @@ namespace XBMCAddon
 {
   namespace xbmcgui
   {
-    enum RenderOrder {
-      WINDOW = 0,
-      DIALOG = 1
-    };
-
     // Forward declare the interceptor as the AddonWindowInterceptor.h 
     // file needs to include the Window class because of the template
     class InterceptorBase;

--- a/xbmc/interfaces/legacy/WindowDialog.cpp
+++ b/xbmc/interfaces/legacy/WindowDialog.cpp
@@ -34,7 +34,7 @@ namespace XBMCAddon
       CSingleLock lock(g_graphicsContext);
       InterceptorBase* interceptor = new Interceptor<CGUIWindow>("CGUIWindow", this, getNextAvailableWindowId());
       // set the render order to the dialog's default because this dialog is mapped to CGUIWindow instead of CGUIDialog
-      interceptor->SetRenderOrder(RenderOrder::DIALOG);
+      interceptor->SetRenderOrder(RENDER_ORDER_DIALOG);
       setWindow(interceptor);
     }
 

--- a/xbmc/interfaces/legacy/WindowXML.cpp
+++ b/xbmc/interfaces/legacy/WindowXML.cpp
@@ -503,8 +503,8 @@ namespace XBMCAddon
         // Set the render order to the dialog's default in case it's not specified in the skin xml
         // because this dialog is mapped to CGUIMediaWindow instead of CGUIDialog.
         // This must be done here, because the render order will be reset before loading the skin xml.
-        if (ref(window)->GetRenderOrder() == RenderOrder::WINDOW)
-          window->SetRenderOrder(RenderOrder::DIALOG);
+        if (ref(window)->GetRenderOrder() == RENDER_ORDER_WINDOW)
+          window->SetRenderOrder(RENDER_ORDER_DIALOG);
         return true;
       }
       return false;

--- a/xbmc/music/dialogs/GUIDialogMusicOverlay.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicOverlay.cpp
@@ -29,7 +29,7 @@
 CGUIDialogMusicOverlay::CGUIDialogMusicOverlay()
   : CGUIDialog(WINDOW_DIALOG_MUSIC_OVERLAY, "MusicOverlay.xml", DialogModalityType::MODELESS)
 {
-  m_renderOrder = 0;
+  m_renderOrder = RENDER_ORDER_WINDOW;
   m_loadType = KEEP_IN_MEMORY;
 }
 
@@ -80,7 +80,7 @@ EVENT_RESULT CGUIDialogMusicOverlay::OnMouseEvent(const CPoint &point, const CMo
 void CGUIDialogMusicOverlay::SetDefaults()
 {
   CGUIDialog::SetDefaults();
-  m_renderOrder = 0;
+  m_renderOrder = RENDER_ORDER_WINDOW;
   SetVisibleCondition("skin.hasmusicoverlay");
 }
 

--- a/xbmc/video/dialogs/GUIDialogTeletext.cpp
+++ b/xbmc/video/dialogs/GUIDialogTeletext.cpp
@@ -33,7 +33,7 @@ CGUIDialogTeletext::CGUIDialogTeletext()
     : CGUIDialog(WINDOW_DIALOG_OSD_TELETEXT, "")
 {
   m_pTxtTexture = NULL;
-  m_renderOrder = INT_MAX - 3;
+  m_renderOrder = RENDER_ORDER_DIALOG_TELETEXT;
 }
 
 CGUIDialogTeletext::~CGUIDialogTeletext()

--- a/xbmc/video/dialogs/GUIDialogVideoOverlay.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoOverlay.cpp
@@ -33,7 +33,7 @@
 CGUIDialogVideoOverlay::CGUIDialogVideoOverlay()
   : CGUIDialog(WINDOW_DIALOG_VIDEO_OVERLAY, "VideoOverlay.xml", DialogModalityType::MODELESS)
 {
-  m_renderOrder = 0;
+  m_renderOrder = RENDER_ORDER_WINDOW;
   m_loadType = KEEP_IN_MEMORY;
 }
 
@@ -58,7 +58,7 @@ EVENT_RESULT CGUIDialogVideoOverlay::OnMouseEvent(const CPoint &point, const CMo
 void CGUIDialogVideoOverlay::SetDefaults()
 {
   CGUIDialog::SetDefaults();
-  m_renderOrder = 0;
+  m_renderOrder = RENDER_ORDER_WINDOW;
   SetVisibleCondition("skin.hasvideooverlay");
 }
 

--- a/xbmc/windows/GUIWindowDebugInfo.cpp
+++ b/xbmc/windows/GUIWindowDebugInfo.cpp
@@ -34,14 +34,12 @@
 #include "utils/Variant.h"
 #include "utils/StringUtils.h"
 
-#include <climits>
-
 CGUIWindowDebugInfo::CGUIWindowDebugInfo(void)
   : CGUIDialog(WINDOW_DEBUG_INFO, "", DialogModalityType::MODELESS)
 {
   m_needsScaling = false;
   m_layout = NULL;
-  m_renderOrder = INT_MAX - 2;
+  m_renderOrder = RENDER_ORDER_WINDOW_DEBUG;
 }
 
 CGUIWindowDebugInfo::~CGUIWindowDebugInfo(void)

--- a/xbmc/windows/GUIWindowPointer.cpp
+++ b/xbmc/windows/GUIWindowPointer.cpp
@@ -22,7 +22,6 @@
 #include "input/MouseStat.h"
 #include "input/InputManager.h"
 #include "windowing/WindowingFactory.h"
-#include <climits>
 #define ID_POINTER 10
 
 CGUIWindowPointer::CGUIWindowPointer(void)
@@ -32,7 +31,7 @@ CGUIWindowPointer::CGUIWindowPointer(void)
   m_loadType = LOAD_ON_GUI_INIT;
   m_needsScaling = false;
   m_active = false;
-  m_renderOrder = INT_MAX - 1;
+  m_renderOrder = RENDER_ORDER_WINDOW_POINTER;
 }
 
 CGUIWindowPointer::~CGUIWindowPointer(void)
@@ -76,7 +75,7 @@ void CGUIWindowPointer::OnWindowLoaded()
   CGUIWindow::OnWindowLoaded();
   DynamicResourceAlloc(false);
   m_pointer = 0;
-  m_renderOrder = INT_MAX - 1;
+  m_renderOrder = RENDER_ORDER_WINDOW_POINTER;
 }
 
 void CGUIWindowPointer::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)

--- a/xbmc/windows/GUIWindowScreensaverDim.cpp
+++ b/xbmc/windows/GUIWindowScreensaverDim.cpp
@@ -22,7 +22,6 @@
 #include "guilib/GraphicContext.h"
 #include "guilib/GUITexture.h"
 #include "Application.h"
-#include <climits>
 
 CGUIWindowScreensaverDim::CGUIWindowScreensaverDim(void)
   : CGUIDialog(WINDOW_SCREENSAVER_DIM, "", DialogModalityType::MODELESS)
@@ -31,7 +30,7 @@ CGUIWindowScreensaverDim::CGUIWindowScreensaverDim(void)
   m_dimLevel = 100.0f;
   m_animations.push_back(CAnimation::CreateFader(0, 100, 0, 1000, ANIM_TYPE_WINDOW_OPEN));
   m_animations.push_back(CAnimation::CreateFader(100, 0, 0, 1000, ANIM_TYPE_WINDOW_CLOSE));
-  m_renderOrder = INT_MAX;
+  m_renderOrder = RENDER_ORDER_WINDOW_SCREENSAVER;
 }
 
 CGUIWindowScreensaverDim::~CGUIWindowScreensaverDim(void)


### PR DESCRIPTION
This PR will introduce a new enum `RenderOrder` which holds the default values of the internal render orders for windows and dialogs and therefore get rid of the magic numbers all over the place.

@mkortstiege @Paxxi mind taking a look.
