### PR TITLE
[PVR] Conflence: Add EpisodeName to MyPVRChannels

### DIFF
--- a/addons/skin.confluence/720p/MyPVRChannels.xml
+++ b/addons/skin.confluence/720p/MyPVRChannels.xml
@@ -123,7 +123,7 @@
 					<scroll>true</scroll>
 					<align>center</align>
 					<aligny>center</aligny>
-					<label>[B]$INFO[Container(50).ListItem.Title][/B]</label>
+					<label>[B]$INFO[Container(50).ListItem.Title]$INFO[ListItem.EpisodeName, (,)][/B]</label>
 				</control>
 				<control type="label">
 					<left>0</left>


### PR DESCRIPTION
Most of conflence's PVR windows now include EpisodeName in brackets after Title. This is one that is still missing it:
![screenshot017](https://cloud.githubusercontent.com/assets/12870817/9107372/ae4fcbcc-3c1e-11e5-8277-f8ab04151a65.png)
With this change:
![screenshot018](https://cloud.githubusercontent.com/assets/12870817/9107371/ae4ba1dc-3c1e-11e5-8b08-75a0241057f5.png)
