### PR TITLE
[PVR] 'Confim channel switch' only for up/down, not ch+/-

### DIFF
--- a/system/Lircmap.xml
+++ b/system/Lircmap.xml
@@ -412,7 +412,7 @@
 	</remote>
 
 	<remote device="linux-input-layer">
-	<altname>cx23885_remote</altname>
+		<altname>cx23885_remote</altname>
 		<left>KEY_LEFT</left>
 		<right>KEY_RIGHT</right>
 		<up>KEY_UP</up>
@@ -438,8 +438,8 @@
 		<reverse>KEY_REWIND</reverse>
 		<volumeplus>KEY_VOLUMEUP</volumeplus>
 		<volumeminus>KEY_VOLUMEDOWN</volumeminus>
-		<channelplus>KEY_CHANNELUP</channelplus>
-		<channelminus>KEY_CHANNELDOWN</channelminus>
+		<pageplus>KEY_CHANNELUP</pageplus>
+		<pageminus>KEY_CHANNELDOWN</pageminus>
 		<skipplus>KEY_NEXTSONG</skipplus>
 		<skipplus>KEY_NEXT</skipplus>
 		<skipminus>KEY_PREVIOUSSONG</skipminus>
@@ -556,8 +556,8 @@
 		<reverse>KEY_REWIND</reverse>
 		<volumeplus>KEY_VOLUMEUP</volumeplus>
 		<volumeminus>KEY_VOLUMEDOWN</volumeminus>
-		<channelplus>KEY_CHANNELUP</channelplus>
-		<channelminus>KEY_CHANNELDOWN</channelminus>
+		<pageplus>KEY_CHANNELUP</pageplus>
+		<pageminus>KEY_CHANNELDOWN</pageminus>
 		<skipplus>KEY_NEXT</skipplus>
 		<skipminus>KEY_PREVIOUS</skipminus>
 		<title>KEY_EPG</title>

--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -529,16 +529,20 @@
     <keyboard>
       <left>StepBack</left>
       <right>StepForward</right>
-      <up>ChannelUp</up>
-      <down>ChannelDown</down>
+      <up>Up</up>
+      <down>Down</down>
+      <pageup>ChannelUp</pageup>
+      <pagedown>ChannelDown</pagedown>
     </keyboard>
   </FullscreenLiveTV>
   <FullscreenRadio>
     <keyboard>
       <left>StepBack</left>
       <right>StepForward</right>
-      <up>ChannelUp</up>
-      <down>ChannelDown</down>
+      <up>Up</up>
+      <down>Down</down>
+      <pageup>ChannelUp</pageup>
+      <pagedown>ChannelDown</pagedown>
     </keyboard>
   </FullscreenRadio>
   <PVROSDChannels>

--- a/system/keymaps/remote.xml
+++ b/system/keymaps/remote.xml
@@ -577,16 +577,20 @@
     <remote>
       <left>StepBack</left>
       <right>StepForward</right>
-      <up>ChannelUp</up>
-      <down>ChannelDown</down>
+      <up>Up</up>
+      <down>Down</down>
+      <pageplus>ChannelUp</pageplus>
+      <pageminus>ChannelDown</pageminus>
     </remote>
   </FullscreenLiveTV>
   <FullscreenRadio>
     <remote>
       <left>StepBack</left>
       <right>StepForward</right>
-      <up>ChannelUp</up>
-      <down>ChannelDown</down>
+      <up>Up</up>
+      <down>Down</down>
+      <pageplus>ChannelUp</pageplus>
+      <pageminus>ChannelDown</pageminus>
     </remote>
   </FullscreenRadio>
   <PVROSDChannels>

--- a/xbmc/cores/dvdplayer/DVDMessage.h
+++ b/xbmc/cores/dvdplayer/DVDMessage.h
@@ -68,6 +68,8 @@ public:
 
     PLAYER_CHANNEL_NEXT,            // switches to next playback channel
     PLAYER_CHANNEL_PREV,            // switches to previous playback channel
+    PLAYER_CHANNEL_PREVIEW_NEXT,    // switches to next channel preview (does not switch the channel)
+    PLAYER_CHANNEL_PREVIEW_PREV,    // switches to previous channel preview (does not switch the channel)
     PLAYER_CHANNEL_SELECT_NUMBER,   // switches to the channel with the provided channel number
     PLAYER_CHANNEL_SELECT,          // switches to the provided channel
     PLAYER_STARTED,                 // sent whenever a sub player has finished it's first frame after open


### PR DESCRIPTION
Requested in the forum: http://forum.kodi.tv/showthread.php?tid=196389 Makes perfect sense to me.

No changes to the existing feature, except for PVR context and only there, Channel+/Channel- will always switch the channel, regardless whether the feature "Confirm channel switch with OK" is active. 

Up/Down, however, when the feature "Confirm channel switch with OK" is active, will only flip through the channel previews, without switching the channel. If the feature is deactivated, Up/Down will also switch channels.

@xhaggi mind taking a look.
