### PR TITLE
[ios] - fix linkage for VTB framework for ios < 6 - fixes vtb on ios …

### DIFF
--- a/tools/darwin/Support/copyframeworks-ios.command
+++ b/tools/darwin/Support/copyframeworks-ios.command
@@ -75,12 +75,11 @@ chmod u+w "$TARGET_FRAMEWORKS/$(basename $a)"
 install_name_tool -change "$a" "$DYLIB_NAMEPATH/$(basename $a)" "$TARGET_BINARY"
 done
 
-if [ "$SDK_NAME" = "iphoneos6.0" ] ; then
 echo "Fixing $TARGET_BINARY VideoToolbox dylib name"
 VTB_SDK6=/System/Library/Frameworks/VideoToolbox.framework/VideoToolbox
 VTB_SDK5=/System/Library/PrivateFrameworks/VideoToolbox.framework/VideoToolbox
 install_name_tool -change "$VTB_SDK6" "$VTB_SDK5" "$TARGET_BINARY"
-fi
+
 
 echo "Package $EXTERNAL_LIBS/lib/python2.6"
 mkdir -p "$TARGET_CONTENTS/Frameworks/lib"


### PR DESCRIPTION
…5.x runtime.

Well tested by user, and by me (ios5.1, ios6.01, ios8.4). This was a regression from the latest SDK bump.
