### PR TITLE
fixed: can't set locale in right language and region

### DIFF
--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -263,7 +263,14 @@ void CLangInfo::CRegion::SetGlobalLocale()
   std::string strLocale;
   if (m_strRegionLocaleName.length() > 0)
   {
-    strLocale = m_strLangLocaleName + "_" + m_strRegionLocaleName;
+    std::string strLang, strRegion;
+    g_LangCodeExpander.ConvertToISO6391(m_strLangLocaleName, strLang);
+    g_LangCodeExpander.ConvertToISO6391(m_strRegionLocaleName, strRegion);
+#ifdef TARGET_WINDOWS
+    strLocale = strLang + "-" + strRegion;
+#else
+    strLocale = strLang + "_" + strRegion;
+#endif
 #ifdef TARGET_POSIX
     strLocale += ".UTF-8";
 #endif


### PR DESCRIPTION
Kodi can't sort by filename in right order with language other than english because set locale fail.
Two issue here:
1. `m_strLangLocaleName` and `m_strRegionLocaleName` is 3 char code, and need 2 char code here.
2. under windows, `std::locale(strLocale.c_str())` use string like `zh-cn`, not `zh_cn`.
