### PR TITLE
[SectionLoader] - remove logging in D'Tor

### DIFF
--- a/xbmc/SectionLoader.cpp
+++ b/xbmc/SectionLoader.cpp
@@ -132,7 +132,6 @@ void CSectionLoader::UnloadAll()
   while (it != g_sectionLoader.m_vecLoadedDLLs.end())
   {
     CDll& dll = *it;
-    CLog::Log(LOGDEBUG,"SECTION:UnloadAll(DLL: %s)", dll.m_strDllName.c_str());
     if (dll.m_pDll)
       DllLoaderContainer::ReleaseModule(dll.m_pDll);
     it = g_sectionLoader.m_vecLoadedDLLs.erase(it);


### PR DESCRIPTION
This removes a useless log from the sectionloader which crashes due to unforseeable destruction order of globals. It mostly seems to crash on osx for some reason.

Fact is - this log doesn't give any benefit - we don't care which DLLs or Libs are unloaded during shutdown of kodi.
