### PR TITLE
[gui] fix confirm state not reset in CGUIDialogSelect

### DIFF
--- a/xbmc/dialogs/GUIDialogSelect.cpp
+++ b/xbmc/dialogs/GUIDialogSelect.cpp
@@ -88,6 +88,8 @@ bool CGUIDialogSelect::OnMessage(CGUIMessage& message)
 
   case GUI_MSG_WINDOW_INIT:
     {
+      m_bButtonPressed = false;
+      m_bConfirmed = false;
       CGUIDialog::OnMessage(message);
       return true;
     }


### PR DESCRIPTION
Currently `IsConfirmed` returns wrong result after if was once confirmed and reset. No idea if anything is affected. 
