### PR TITLE
VDPAU / VAAPI: Use HEVC_MAIN GPU decoding (ffmpeg 2.8+)

### DIFF
--- a/tools/depends/target/ffmpeg/FFMPEG-VERSION
+++ b/tools/depends/target/ffmpeg/FFMPEG-VERSION
@@ -1,5 +1,5 @@
 LIBNAME=ffmpeg
 BASE_URL=https://github.com/xbmc/FFmpeg/archive
-VERSION=2.7.2-Jarvis-alpha1
+VERSION=2.8.0-Jarvis-alpha3
 ARCHIVE=$(LIBNAME)-$(VERSION).tar.gz
 

--- a/tools/depends/target/ffmpeg/Makefile
+++ b/tools/depends/target/ffmpeg/Makefile
@@ -44,7 +44,7 @@ ifeq ($(OS), ios)
 endif
 ifeq ($(OS), osx)
   ffmpg_config += --disable-outdev=sdl
-  ffmpg_config += --disable-decoder=mpeg_xvmc --enable-vda --disable-crystalhd
+  ffmpg_config += --disable-decoder=mpeg_xvmc --enable-vda --disable-crystalhd --disable-videotoolbox
   ffmpg_config += --target-os=darwin
   ffmpg_config += --disable-securetransport
 endif

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.cpp
@@ -564,6 +564,15 @@ bool CDecoder::Open(AVCodecContext* avctx, AVCodecContext* mainctx, const enum P
       }
       break;
     }
+#if VA_CHECK_VERSION(0,38,0)
+    case AV_CODEC_ID_HEVC:
+    {
+      profile = VAProfileHEVCMain;
+      if (!m_vaapiConfig.context->SupportsProfile(profile))
+        return false;
+      break;
+    }
+#endif
     case AV_CODEC_ID_WMV3:
       profile = VAProfileVC1Main;
       if (!m_vaapiConfig.context->SupportsProfile(profile))
@@ -586,7 +595,7 @@ bool CDecoder::Open(AVCodecContext* avctx, AVCodecContext* mainctx, const enum P
     return false;
   }
 
-  if(avctx->codec_id == AV_CODEC_ID_H264)
+  if (avctx->codec_id == AV_CODEC_ID_H264)
   {
     m_vaapiConfig.maxReferences = avctx->refs;
     if (m_vaapiConfig.maxReferences > 16)
@@ -594,6 +603,8 @@ bool CDecoder::Open(AVCodecContext* avctx, AVCodecContext* mainctx, const enum P
     if (m_vaapiConfig.maxReferences < 5)
       m_vaapiConfig.maxReferences = 5;
   }
+  else if (avctx->codec_id == AV_CODEC_ID_HEVC)
+    m_vaapiConfig.maxReferences = 16;
   else
     m_vaapiConfig.maxReferences = 2;
 


### PR DESCRIPTION
This implements the missing bits to use HEVC_MAIN decoding on nvidia GTX 960+ cards. This was tested by @philipl - We have to wait for ffmpeg 2.8 to land, so that we can use it. Furthermore an nvidia driver >= 355.06 is needed to use it properly.
