### PR TITLE
fixed: Watched icon not displayed if item is also resumable (fixes #15766)

### DIFF
--- a/addons/skin.confluence/720p/MyPVRRecordings.xml
+++ b/addons/skin.confluence/720p/MyPVRRecordings.xml
@@ -112,19 +112,18 @@
 					<control type="image">
 						<left>730</left>
 						<top>14</top>
-						<width>20</width>
-						<height>16</height>
-						<texture>$INFO[ListItem.Overlay]</texture>
-						<aspectratio>keep</aspectratio>
-						<visible>!ListItem.IsResumable</visible>
-					</control>
-					<control type="image">
-						<left>730</left>
-						<top>14</top>
 						<width>16</width>
 						<height>16</height>
 						<texture>OverlayWatching.png</texture>
 						<visible>ListItem.IsResumable</visible>
+					</control>
+					<control type="image">
+						<left>730</left>
+						<top>14</top>
+						<width>20</width>
+						<height>16</height>
+						<texture>$INFO[ListItem.Overlay]</texture>
+						<aspectratio>keep</aspectratio>
 					</control>
 				</itemlayout>
 				<focusedlayout height="40" width="760">
@@ -189,19 +188,18 @@
 					<control type="image">
 						<left>730</left>
 						<top>14</top>
-						<width>20</width>
-						<height>16</height>
-						<texture>$INFO[ListItem.Overlay]</texture>
-						<aspectratio>keep</aspectratio>
-						<visible>!ListItem.IsResumable</visible>
-					</control>
-					<control type="image">
-						<left>730</left>
-						<top>14</top>
 						<width>16</width>
 						<height>16</height>
 						<texture>OverlayWatching.png</texture>
 						<visible>ListItem.IsResumable</visible>
+					</control>
+					<control type="image">
+						<left>730</left>
+						<top>14</top>
+						<width>20</width>
+						<height>16</height>
+						<texture>$INFO[ListItem.Overlay]</texture>
+						<aspectratio>keep</aspectratio>
 					</control>
 				</focusedlayout>
 			</control>

--- a/addons/skin.confluence/720p/ViewsFileMode.xml
+++ b/addons/skin.confluence/720p/ViewsFileMode.xml
@@ -75,19 +75,19 @@
 					<control type="image">
 						<left>665</left>
 						<top>14</top>
-						<width>20</width>
-						<height>16</height>
-						<texture>$INFO[ListItem.Overlay]</texture>
-						<aspectratio>keep</aspectratio>
-						<visible>Window.IsVisible(Videos) + !ListItem.IsResumable</visible>
-					</control>
-					<control type="image">
-						<left>665</left>
-						<top>14</top>
 						<width>16</width>
 						<height>16</height>
 						<texture>OverlayWatching.png</texture>
 						<visible>Window.IsVisible(Videos) + ListItem.IsResumable</visible>
+					</control>
+					<control type="image">
+						<left>665</left>
+						<top>14</top>
+						<width>20</width>
+						<height>16</height>
+						<texture>$INFO[ListItem.Overlay]</texture>
+						<aspectratio>keep</aspectratio>
+						<visible>Window.IsVisible(Videos)</visible>
 					</control>
 				</itemlayout>
 				<focusedlayout height="40" width="580">
@@ -168,19 +168,19 @@
 					<control type="image">
 						<left>665</left>
 						<top>14</top>
-						<width>20</width>
-						<height>16</height>
-						<texture>$INFO[ListItem.Overlay]</texture>
-						<aspectratio>keep</aspectratio>
-						<visible>Window.IsVisible(Videos) + !ListItem.IsResumable</visible>
-					</control>
-					<control type="image">
-						<left>665</left>
-						<top>14</top>
 						<width>16</width>
 						<height>16</height>
 						<texture>OverlayWatching.png</texture>
 						<visible>Window.IsVisible(Videos) + ListItem.IsResumable</visible>
+					</control>
+ 					<control type="image">
+						<left>665</left>
+						<top>14</top>
+						<width>20</width>
+						<height>16</height>
+						<texture>$INFO[ListItem.Overlay]</texture>
+						<aspectratio>keep</aspectratio>
+						<visible>Window.IsVisible(Videos)</visible>
 					</control>
 				</focusedlayout>
 			</control>
@@ -575,19 +575,19 @@
 					<control type="image">
 						<left>1050</left>
 						<top>14</top>
-						<width>20</width>
-						<height>16</height>
-						<texture>$INFO[ListItem.Overlay]</texture>
-						<aspectratio>keep</aspectratio>
-						<visible>Window.IsVisible(Videos) + !ListItem.IsResumable</visible>
-					</control>
-					<control type="image">
-						<left>1050</left>
-						<top>14</top>
 						<width>16</width>
 						<height>16</height>
 						<texture>OverlayWatching.png</texture>
 						<visible>Window.IsVisible(Videos) + ListItem.IsResumable</visible>
+					</control>
+					<control type="image">
+						<left>1050</left>
+						<top>14</top>
+						<width>20</width>
+						<height>16</height>
+						<texture>$INFO[ListItem.Overlay]</texture>
+						<aspectratio>keep</aspectratio>
+						<visible>Window.IsVisible(Videos)</visible>
 					</control>
 				</itemlayout>
 				<focusedlayout height="40" width="1080">
@@ -676,19 +676,19 @@
 					<control type="image">
 						<left>1050</left>
 						<top>14</top>
-						<width>20</width>
-						<height>16</height>
-						<texture>$INFO[ListItem.Overlay]</texture>
-						<aspectratio>keep</aspectratio>
-						<visible>Window.IsVisible(Videos) + !ListItem.IsResumable</visible>
-					</control>
-					<control type="image">
-						<left>1050</left>
-						<top>14</top>
 						<width>16</width>
 						<height>16</height>
 						<texture>OverlayWatching.png</texture>
 						<visible>Window.IsVisible(Videos) + ListItem.IsResumable</visible>
+					</control>
+					<control type="image">
+						<left>1050</left>
+						<top>14</top>
+						<width>20</width>
+						<height>16</height>
+						<texture>$INFO[ListItem.Overlay]</texture>
+						<aspectratio>keep</aspectratio>
+						<visible>Window.IsVisible(Videos)</visible>
 					</control>
 				</focusedlayout>
 			</control>

--- a/addons/skin.confluence/720p/ViewsVideoLibrary.xml
+++ b/addons/skin.confluence/720p/ViewsVideoLibrary.xml
@@ -818,9 +818,17 @@
 					<control type="image">
 						<left>555</left>
 						<top>14</top>
-						<width>20</width>
+						<width>16</width>
 						<height>16</height>
-						<texture>$VAR[OverlayVar]</texture>
+						<texture>OverlayWatching.png</texture>
+						<visible>ListItem.IsResumable</visible>
+					</control>
+					<control type="image">
+						<left>555</left>
+						<top>14</top>
+						<width>16</width>
+						<height>16</height>
+						<texture>$INFO[ListItem.Overlay]</texture>
 						<aspectratio align="left">keep</aspectratio>
 					</control>
 				</itemlayout>
@@ -889,9 +897,17 @@
 					<control type="image">
 						<left>555</left>
 						<top>14</top>
-						<width>20</width>
+						<width>16</width>
 						<height>16</height>
-						<texture>$VAR[OverlayVar]</texture>
+						<texture>OverlayWatching.png</texture>
+						<visible>ListItem.IsResumable</visible>
+					</control>
+					<control type="image">
+						<left>555</left>
+						<top>14</top>
+						<width>16</width>
+						<height>16</height>
+						<texture>$INFO[ListItem.Overlay]</texture>
 						<aspectratio align="left">keep</aspectratio>
 					</control>
 				</focusedlayout>
@@ -1234,9 +1250,17 @@
 					<control type="image">
 						<left>555</left>
 						<top>14</top>
-						<width>20</width>
+						<width>16</width>
 						<height>16</height>
-						<texture>$VAR[OverlayVar]</texture>
+						<texture>OverlayWatching.png</texture>
+						<visible>ListItem.IsResumable</visible>
+					</control>
+					<control type="image">
+						<left>555</left>
+						<top>14</top>
+						<width>16</width>
+						<height>16</height>
+						<texture>$INFO[ListItem.Overlay]</texture>
 						<aspectratio align="left">keep</aspectratio>
 					</control>
 				</itemlayout>
@@ -1305,9 +1329,17 @@
 					<control type="image">
 						<left>555</left>
 						<top>14</top>
-						<width>20</width>
+						<width>16</width>
 						<height>16</height>
-						<texture>$VAR[OverlayVar]</texture>
+						<texture>OverlayWatching.png</texture>
+						<visible>ListItem.IsResumable</visible>
+					</control>
+					<control type="image">
+						<left>555</left>
+						<top>14</top>
+						<width>16</width>
+						<height>16</height>
+						<texture>$INFO[ListItem.Overlay]</texture>
 						<aspectratio align="left">keep</aspectratio>
 					</control>
 				</focusedlayout>
@@ -1595,21 +1627,20 @@
 					<control type="image">
 						<left>320</left>
 						<top>14</top>
-						<width>20</width>
-						<height>16</height>
-						<texture>$INFO[ListItem.Overlay]</texture>
-						<aspectratio>keep</aspectratio>
-						<visible>!ListItem.IsResumable</visible>
-					</control>
-					<control type="image">
-						<left>320</left>
-						<top>14</top>
 						<width>16</width>
 						<height>16</height>
 						<texture>OverlayWatching.png</texture>
 						<visible>ListItem.IsResumable</visible>
 					</control>
 				</itemlayout>
+					<control type="image">
+						<left>320</left>
+						<top>14</top>
+						<width>20</width>
+						<height>16</height>
+						<texture>$INFO[ListItem.Overlay]</texture>
+						<aspectratio>keep</aspectratio>
+					</control>
 				<focusedlayout height="40" width="345">
 					<control type="image">
 						<left>0</left>
@@ -1644,19 +1675,18 @@
 					<control type="image">
 						<left>320</left>
 						<top>14</top>
-						<width>20</width>
-						<height>16</height>
-						<texture>$INFO[ListItem.Overlay]</texture>
-						<aspectratio>keep</aspectratio>
-						<visible>!ListItem.IsResumable</visible>
-					</control>
-					<control type="image">
-						<left>320</left>
-						<top>14</top>
 						<width>16</width>
 						<height>16</height>
 						<texture>OverlayWatching.png</texture>
 						<visible>ListItem.IsResumable</visible>
+					</control>
+					<control type="image">
+						<left>320</left>
+						<top>14</top>
+						<width>20</width>
+						<height>16</height>
+						<texture>$INFO[ListItem.Overlay]</texture>
+						<aspectratio>keep</aspectratio>
 					</control>
 				</focusedlayout>
 			</control>

--- a/addons/skin.confluence/720p/includes.xml
+++ b/addons/skin.confluence/720p/includes.xml
@@ -21,10 +21,6 @@
 		<value condition="!ListItem.IsStereoscopic">$INFO[ListItem.VideoResolution,flagging/lists/,.png]</value>
 		<value>flagging/lists/3D.png</value>
 	</variable>
-	<variable name="OverlayVar">
-		<value condition="!ListItem.IsResumable">$INFO[ListItem.Overlay]</value>
-		<value>OverlayWatching.png</value>
-	</variable>
 	<variable name="BannerThumb">
 		<value condition="!IsEmpty(ListItem.Art(banner))">$INFO[ListItem.Art(banner)]</value>
 		<value>$INFO[ListItem.Icon]</value>


### PR DESCRIPTION
This fixes a rather old bug. The problem is for folks that use as.xml to prevent Kodi from deleting the resume bookmark when the item is considered watched, the watched icon (check-mark) is not displayed in the views that don't use the overlay (I believe it only worked properly in the thumbnail view). The reason is that the resumable-icon takes precedence over the watched-icon. Ideally we should probably no longer show the resumable-icon when an item is watched, but that can't be easily fixed afaik (and me not being a skin expert is not helping here). As an acceptable work around I've modified Confluence so that the watched-overlay-icon is shown on top of the resumable-icon.
