### PR TITLE
[backport][splash] handle splash as regular window

### DIFF
--- a/Kodi.xcodeproj/project.pbxproj
+++ b/Kodi.xcodeproj/project.pbxproj
@@ -272,6 +272,9 @@
 		3994427F1A8DD96F006C39E9 /* VideoLibraryQueue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3994427D1A8DD96F006C39E9 /* VideoLibraryQueue.cpp */; };
 		399442801A8DD96F006C39E9 /* VideoLibraryQueue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3994427D1A8DD96F006C39E9 /* VideoLibraryQueue.cpp */; };
 		399442811A8DD96F006C39E9 /* VideoLibraryQueue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3994427D1A8DD96F006C39E9 /* VideoLibraryQueue.cpp */; };
+		4260D5C71B67BB8F003F6F2D /* GUIWindowSplash.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4260D5C51B67BB8F003F6F2D /* GUIWindowSplash.cpp */; };
+		4260D5C81B67BB8F003F6F2D /* GUIWindowSplash.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4260D5C51B67BB8F003F6F2D /* GUIWindowSplash.cpp */; };
+		4260D5C91B67BB8F003F6F2D /* GUIWindowSplash.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4260D5C51B67BB8F003F6F2D /* GUIWindowSplash.cpp */; };
 		42DAC16E1A6E789E0066B4C8 /* PVRActionListener.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 42DAC16C1A6E789E0066B4C8 /* PVRActionListener.cpp */; };
 		42DAC16F1A6E789E0066B4C8 /* PVRActionListener.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 42DAC16C1A6E789E0066B4C8 /* PVRActionListener.cpp */; };
 		42DAC1701A6E789E0066B4C8 /* PVRActionListener.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 42DAC16C1A6E789E0066B4C8 /* PVRActionListener.cpp */; };
@@ -3607,6 +3610,8 @@
 		3994426A1A8DD920006C39E9 /* VideoLibraryScanningJob.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VideoLibraryScanningJob.h; sourceTree = "<group>"; };
 		3994427D1A8DD96F006C39E9 /* VideoLibraryQueue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VideoLibraryQueue.cpp; sourceTree = "<group>"; };
 		3994427E1A8DD96F006C39E9 /* VideoLibraryQueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VideoLibraryQueue.h; sourceTree = "<group>"; };
+		4260D5C51B67BB8F003F6F2D /* GUIWindowSplash.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GUIWindowSplash.cpp; sourceTree = "<group>"; };
+		4260D5C61B67BB8F003F6F2D /* GUIWindowSplash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GUIWindowSplash.h; sourceTree = "<group>"; };
 		42DAC16B1A6E780C0066B4C8 /* IActionListener.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IActionListener.h; sourceTree = "<group>"; };
 		42DAC16C1A6E789E0066B4C8 /* PVRActionListener.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PVRActionListener.cpp; sourceTree = "<group>"; };
 		42DAC16D1A6E789E0066B4C8 /* PVRActionListener.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PVRActionListener.h; sourceTree = "<group>"; };
@@ -6671,6 +6676,8 @@
 				E38E18260D25F9FA00618676 /* GUIWindowScreensaver.h */,
 				7C89619013B6A16F003631FE /* GUIWindowScreensaverDim.cpp */,
 				7C89619113B6A16F003631FE /* GUIWindowScreensaverDim.h */,
+				4260D5C51B67BB8F003F6F2D /* GUIWindowSplash.cpp */,
+				4260D5C61B67BB8F003F6F2D /* GUIWindowSplash.h */,
 				E38E18370D25F9FA00618676 /* GUIWindowStartup.cpp */,
 				E38E18380D25F9FA00618676 /* GUIWindowStartup.h */,
 				E38E18390D25F9FA00618676 /* GUIWindowSystemInfo.cpp */,
@@ -10590,6 +10597,7 @@
 				18B7C7C61294222E009E7A26 /* GUIIncludes.cpp in Sources */,
 				18B7C7C71294222E009E7A26 /* GUIInfoTypes.cpp in Sources */,
 				18B7C7C81294222E009E7A26 /* GUILabel.cpp in Sources */,
+				4260D5C71B67BB8F003F6F2D /* GUIWindowSplash.cpp in Sources */,
 				18B7C7C91294222E009E7A26 /* GUILabelControl.cpp in Sources */,
 				18B7C7CA1294222E009E7A26 /* GUIListContainer.cpp in Sources */,
 				18B7C7CB1294222E009E7A26 /* GUIListGroup.cpp in Sources */,
@@ -11559,6 +11567,7 @@
 				DFF0F2B817528350002DA3A4 /* imagefactory.cpp in Sources */,
 				DFF0F2B917528350002DA3A4 /* IWindowManagerCallback.cpp in Sources */,
 				DFF0F2BA17528350002DA3A4 /* JpegIO.cpp in Sources */,
+				4260D5C91B67BB8F003F6F2D /* GUIWindowSplash.cpp in Sources */,
 				DFF0F2BC17528350002DA3A4 /* LocalizeStrings.cpp in Sources */,
 				DFF0F2BD17528350002DA3A4 /* MatrixGLES.cpp in Sources */,
 				DFF0F2BE17528350002DA3A4 /* Shader.cpp in Sources */,
@@ -13024,6 +13033,7 @@
 				E499156A174E65AB00741B6D /* ButtonTranslator.cpp in Sources */,
 				E499156B174E65AB00741B6D /* InertialScrollingHandler.cpp in Sources */,
 				E499156D174E65AB00741B6D /* KeyboardStat.cpp in Sources */,
+				4260D5C81B67BB8F003F6F2D /* GUIWindowSplash.cpp in Sources */,
 				E499156E174E65AB00741B6D /* SDLJoystick.cpp in Sources */,
 				E499156F174E65AC00741B6D /* XBMC_keytable.cpp in Sources */,
 				E4991574174E661400741B6D /* WinEventsIOS.mm in Sources */,

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -1655,6 +1655,7 @@
     <ClCompile Include="..\..\xbmc\windows\GUIWindowPointer.cpp" />
     <ClCompile Include="..\..\xbmc\windows\GUIWindowScreensaver.cpp" />
     <ClCompile Include="..\..\xbmc\windows\GUIWindowScreensaverDim.cpp" />
+    <ClCompile Include="..\..\xbmc\windows\GUIWindowSplash.cpp" />
     <ClCompile Include="..\..\xbmc\windows\GUIWindowStartup.cpp" />
     <ClCompile Include="..\..\xbmc\windows\GUIWindowSystemInfo.cpp" />
     <ClCompile Include="..\..\xbmc\windows\GUIWindowWeather.cpp" />
@@ -2151,6 +2152,7 @@
     <ClInclude Include="..\..\xbmc\win32\IMMNotificationClient.h" />
     <ClInclude Include="..\..\xbmc\win32\pch.h" />
     <ClInclude Include="..\..\xbmc\win32\PlatformDefs.h" />
+    <ClInclude Include="..\..\xbmc\windows\GUIWindowSplash.h" />
     <ClInclude Include="..\..\xbmc\XBDateTime.h" />
     <ClInclude Include="..\..\xbmc\XbmcContext.h" />
     <ClInclude Include="..\..\xbmc\win32\PlatformInclude.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -3096,6 +3096,9 @@
     <ClCompile Include="..\..\xbmc\contrib\kissfft\kiss_fftr.c">
       <Filter>contrib\kissfft</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\windows\GUIWindowSplash.cpp">
+      <Filter>windows</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\xbmc\win32\pch.h">
@@ -5988,6 +5991,9 @@
     </ClInclude>
     <ClInclude Include="..\..\xbmc\contrib\kissfft\kiss_fftr.h">
       <Filter>contrib\kissfft</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\windows\GUIWindowSplash.h">
+      <Filter>windows</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/tools/android/packaging/xbmc/res/layout/activity_splash.xml
+++ b/tools/android/packaging/xbmc/res/layout/activity_splash.xml
@@ -10,7 +10,7 @@
         android:layout_centerHorizontal="true"
         android:adjustViewBounds="true"
         android:layout_alignParentTop="true" 
-        android:scaleType="center"
+        android:scaleType="centerCrop"
         android:src="@drawable/splash" />
 
     <RelativeLayout

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -823,6 +823,7 @@ bool CApplication::CreateGUI()
             info.iWidth,
             info.iHeight,
             info.strMode.c_str());
+
   g_windowManager.Initialize();
 
   return true;
@@ -1157,6 +1158,15 @@ bool CApplication::Initialize()
     g_windowManager.CreateWindows();
     /* window id's 3000 - 3100 are reserved for python */
 
+    // initialize splash window after splash screen disappears
+    // because we need a real window in the background which gets
+    // rendered while we load the main window or enter the master lock key
+    if (g_advancedSettings.m_splashImage)
+    {
+      SAFE_DELETE(m_splash);
+      g_windowManager.ActivateWindow(WINDOW_SPLASH);
+    }
+
     // Make sure we have at least the default skin
     string defaultSkin = ((const CSettingString*)CSettings::Get().GetSetting("lookandfeel.skin"))->GetDefault();
     if (!LoadSkin(CSettings::Get().GetString("lookandfeel.skin")) && !LoadSkin(defaultSkin))
@@ -1164,9 +1174,6 @@ bool CApplication::Initialize()
       CLog::Log(LOGERROR, "Default skin '%s' not found! Terminating..", defaultSkin.c_str());
       return false;
     }
-
-    if (g_advancedSettings.m_splashImage)
-      SAFE_DELETE(m_splash);
 
     if (CSettings::Get().GetBool("masterlock.startuplock") &&
         CProfilesManager::Get().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE &&
@@ -3891,6 +3898,9 @@ bool CApplication::OnMessage(CGUIMessage& message)
       }
       else if (message.GetParam1() == GUI_MSG_UI_READY)
       {
+        // remove splash window
+        g_windowManager.Delete(WINDOW_SPLASH);
+
         if (m_fallbackLanguageLoaded)
           CGUIDialogOK::ShowAndGetInput(24133, 24134);
 

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -341,7 +341,7 @@ bool CApplication::OnEvent(XBMC_Event& newEvent)
         CApplicationMessenger::Get().Quit();
       break;
     case XBMC_VIDEORESIZE:
-      if (!g_application.m_bInitializing &&
+      if (g_windowManager.Initialized() &&
           !g_advancedSettings.m_fullScreen)
       {
         g_Windowing.SetWindowResolution(newEvent.resize.w, newEvent.resize.h);

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -299,7 +299,6 @@ CApplication::CApplication(void)
   m_Autorun = new CAutorun();
 #endif
 
-  m_splash = NULL;
   m_threadID = 0;
   m_progressTrackingPlayCountUpdate = false;
   m_currentStackPosition = 0;
@@ -798,20 +797,7 @@ bool CApplication::CreateGUI()
     CDisplaySettings::Get().SetCurrentResolution(RES_DESKTOP, true);
 
   if (g_advancedSettings.m_splashImage)
-  {
-    std::string strUserSplash = "special://home/media/Splash.png";
-    if (CFile::Exists(strUserSplash))
-    {
-      CLog::Log(LOGINFO, "load user splash image: %s", CSpecialProtocol::TranslatePath(strUserSplash).c_str());
-      m_splash = new CSplash(strUserSplash);
-    }
-    else
-    {
-      CLog::Log(LOGINFO, "load default splash image: %s", CSpecialProtocol::TranslatePath("special://xbmc/media/Splash.png").c_str());
-      m_splash = new CSplash("special://xbmc/media/Splash.png");
-    }
-    m_splash->Show();
-  }
+    CSplash::Get().Show();
 
   // The key mappings may already have been loaded by a peripheral
   CLog::Log(LOGINFO, "load keymapping");
@@ -1162,10 +1148,7 @@ bool CApplication::Initialize()
     // because we need a real window in the background which gets
     // rendered while we load the main window or enter the master lock key
     if (g_advancedSettings.m_splashImage)
-    {
-      SAFE_DELETE(m_splash);
       g_windowManager.ActivateWindow(WINDOW_SPLASH);
-    }
 
     // Make sure we have at least the default skin
     string defaultSkin = ((const CSettingString*)CSettings::Get().GetSetting("lookandfeel.skin"))->GetDefault();

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -363,7 +363,6 @@ public:
 
   bool SwitchToFullScreen(bool force = false);
 
-  CSplash* GetSplash() { return m_splash; }
   void SetRenderGUI(bool renderGUI);
   bool GetRenderGUI() const { return m_renderGUI; };
 
@@ -444,7 +443,6 @@ protected:
   CFileItemPtr m_stackFileItemToUpdate;
 
   std::string m_prevMedia;
-  CSplash* m_splash;
   ThreadIdentifier m_threadID;       // application thread ID.  Used in applicationMessanger to know where we are firing a thread with delay from.
   bool m_bInitializing;
   bool m_bPlatformDirectories;

--- a/xbmc/ApplicationMessenger.cpp
+++ b/xbmc/ApplicationMessenger.cpp
@@ -40,7 +40,6 @@
 #include "guilib/GUIKeyboardFactory.h"
 #include "guilib/Resolution.h"
 #include "GUIInfoManager.h"
-#include "utils/Splash.h"
 #include "cores/VideoRenderers/RenderManager.h"
 #include "cores/AudioEngine/AEFactory.h"
 #include "music/tags/MusicInfoTag.h"
@@ -802,13 +801,6 @@ void CApplicationMessenger::ProcessMessage(ThreadMessage *pMsg)
         g_application.ShowVolumeBar(&action);
       }
       break;
-
-    case TMSG_SPLASH_MESSAGE:
-      {
-        if (g_application.GetSplash())
-          g_application.GetSplash()->Show(pMsg->strParam);
-      }
-      break;
       
     case TMSG_DISPLAY_SETUP:
     {
@@ -1330,18 +1322,6 @@ void CApplicationMessenger::ShowVolumeBar(bool up)
   ThreadMessage tMsg = {TMSG_VOLUME_SHOW};
   tMsg.param1 = up ? ACTION_VOLUME_UP : ACTION_VOLUME_DOWN;
   SendMessage(tMsg, false);
-}
-
-void CApplicationMessenger::SetSplashMessage(const std::string& message)
-{
-  ThreadMessage tMsg = {TMSG_SPLASH_MESSAGE};
-  tMsg.strParam = message;
-  SendMessage(tMsg, true);
-}
-
-void CApplicationMessenger::SetSplashMessage(int stringID)
-{
-  SetSplashMessage(g_localizeStrings.Get(stringID));
 }
 
 bool CApplicationMessenger::SetupDisplay()

--- a/xbmc/ApplicationMessenger.h
+++ b/xbmc/ApplicationMessenger.h
@@ -111,7 +111,6 @@ namespace MUSIC_INFO
 #define TMSG_CALLBACK             800
 
 #define TMSG_VOLUME_SHOW          900
-#define TMSG_SPLASH_MESSAGE       901
 
 #define TMSG_DISPLAY_SETUP      1000
 #define TMSG_DISPLAY_DESTROY    1001
@@ -250,9 +249,6 @@ public:
   std::vector<bool> GetInfoBooleans(const std::vector<std::string> &properties);
 
   void ShowVolumeBar(bool up);
-
-  void SetSplashMessage(const std::string& message);
-  void SetSplashMessage(int stringID);
 
   /*! \brief Used to enable/disable PVR system without waiting.
    \param onOff if true it becomes switched on otherwise off

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -67,6 +67,7 @@
 #include "windows/GUIWindowScreensaver.h"
 #include "windows/GUIWindowScreensaverDim.h"
 #include "pictures/GUIWindowSlideShow.h"
+#include "windows/GUIWindowSplash.h"
 #include "windows/GUIWindowStartup.h"
 #include "video/windows/GUIWindowFullScreen.h"
 #include "video/dialogs/GUIDialogVideoOSD.h"
@@ -164,6 +165,7 @@ CGUIWindowManager::~CGUIWindowManager(void)
 void CGUIWindowManager::Initialize()
 {
   m_tracker.SelectAlgorithm();
+
   m_initialized = true;
 
   LoadNotOnDemandWindows();
@@ -291,12 +293,14 @@ void CGUIWindowManager::CreateWindows()
   Add(new CGUIWindowScreensaver);
   Add(new CGUIWindowWeather);
   Add(new CGUIWindowStartup);
+  Add(new CGUIWindowSplash);
 }
 
 bool CGUIWindowManager::DestroyWindows()
 {
   try
   {
+    Delete(WINDOW_SPLASH);
     Delete(WINDOW_MUSIC_PLAYLIST);
     Delete(WINDOW_MUSIC_PLAYLIST_EDITOR);
     Delete(WINDOW_MUSIC_FILES);

--- a/xbmc/guilib/WindowIDs.h
+++ b/xbmc/guilib/WindowIDs.h
@@ -157,6 +157,7 @@
 #define WINDOW_DIALOG_VIDEO_OVERLAY       12904
 #define WINDOW_VIDEO_TIME_SEEK            12905 // virtual window for time seeking during fullscreen video
 
+#define WINDOW_SPLASH                     12997 // splash window
 #define WINDOW_START                      12998 // first window to load
 #define WINDOW_STARTUP_ANIM               12999 // for startup animations
 

--- a/xbmc/utils/Splash.cpp
+++ b/xbmc/utils/Splash.cpp
@@ -61,11 +61,12 @@ void CSplash::Show(const std::string& message)
   g_graphicsContext.Lock();
   g_graphicsContext.Clear();
 
-  RESOLUTION_INFO res(1280,720,0);
+  RESOLUTION_INFO res = g_graphicsContext.GetResInfo();
+
   g_graphicsContext.SetRenderingResolution(res, true);  
   if (!m_image)
   {
-    m_image = new CGUIImage(0, 0, 0, 0, 1280, 720, CTextureInfo(m_ImageName));
+    m_image = new CGUIImage(0, 0, 0, 0, res.iWidth, res.iHeight, CTextureInfo(m_ImageName));
     m_image->SetAspectRatio(CAspectRatio::AR_CENTER);
   }
 

--- a/xbmc/utils/Splash.cpp
+++ b/xbmc/utils/Splash.cpp
@@ -29,9 +29,10 @@
 
 using namespace XFILE;
 
-CSplash::CSplash(const std::string& imageName) : CThread("Splash"), m_ImageName(imageName)
+CSplash::CSplash(const std::string& imageName)
 {
-  fade = 0.5;
+  m_imageName = imageName;
+  m_fade = 0.5;
   m_messageLayout = NULL;
   m_image = NULL;
   m_layoutWasLoading = false;
@@ -40,16 +41,9 @@ CSplash::CSplash(const std::string& imageName) : CThread("Splash"), m_ImageName(
 
 CSplash::~CSplash()
 {
-  Stop();
   delete m_image;
   delete m_messageLayout;
 }
-
-void CSplash::OnStartup()
-{}
-
-void CSplash::OnExit()
-{}
 
 void CSplash::Show()
 {
@@ -62,11 +56,11 @@ void CSplash::Show(const std::string& message)
   g_graphicsContext.Clear();
 
   RESOLUTION_INFO res = g_graphicsContext.GetResInfo();
+  g_graphicsContext.SetRenderingResolution(res, true);
 
-  g_graphicsContext.SetRenderingResolution(res, true);  
   if (!m_image)
   {
-    m_image = new CGUIImage(0, 0, 0, 0, res.iWidth, res.iHeight, CTextureInfo(m_ImageName));
+    m_image = new CGUIImage(0, 0, 0, 0, g_graphicsContext.GetWidth(), g_graphicsContext.GetHeight(), CTextureInfo(m_imageName));
     m_image->SetAspectRatio(CAspectRatio::AR_CENTER);
   }
 
@@ -83,6 +77,7 @@ void CSplash::Show(const std::string& message)
     if (!m_layoutWasLoading)
     {
       // load arial font, white body, no shadow, size: 20, no additional styling
+
       CGUIFont *messageFont = g_fontManager.LoadTTF("__splash__", "arial.ttf", 0xFFFFFFFF, 0, 20, FONT_STYLE_NORMAL, false, 1.0f, 1.0f, &res);
       if (messageFont)
         m_messageLayout = new CGUITextLayout(messageFont, true, 0);
@@ -108,29 +103,4 @@ void CSplash::Show(const std::string& message)
   CDirtyRegionList dirty;
   g_graphicsContext.Flip(dirty);
   g_graphicsContext.Unlock();
-}
-
-void CSplash::Hide()
-{
-}
-
-void CSplash::Process()
-{
-  Show();
-}
-
-bool CSplash::Start()
-{
-  if (m_ImageName.empty() || !CFile::Exists(m_ImageName))
-  {
-    CLog::Log(LOGDEBUG, "Splash image %s not found", m_ImageName.c_str());
-    return false;
-  }
-  Create();
-  return true;
-}
-
-void CSplash::Stop()
-{
-  StopThread();
 }

--- a/xbmc/utils/Splash.cpp
+++ b/xbmc/utils/Splash.cpp
@@ -31,15 +31,11 @@ using namespace XFILE;
 
 CSplash::CSplash()
 {
-  m_messageLayout = NULL;
-  m_image = NULL;
-  m_layoutWasLoading = false;
 }
 
 CSplash::~CSplash()
 {
   delete m_image;
-  delete m_messageLayout;
 }
 
 CSplash& CSplash::Get()
@@ -49,11 +45,6 @@ CSplash& CSplash::Get()
 }
 
 void CSplash::Show()
-{
-  Show("");
-}
-
-void CSplash::Show(const std::string& message)
 {
   if (!m_image)
   {
@@ -77,33 +68,6 @@ void CSplash::Show(const std::string& message)
   m_image->AllocResources();
   m_image->Render();
   m_image->FreeResources();
-
-  // render message
-  if (!message.empty())
-  {
-    if (!m_layoutWasLoading)
-    {
-      // load arial font, white body, no shadow, size: 20, no additional styling
-
-      CGUIFont *messageFont = g_fontManager.LoadTTF("__splash__", "arial.ttf", 0xFFFFFFFF, 0, 20, FONT_STYLE_NORMAL, false, 1.0f, 1.0f, &res);
-      if (messageFont)
-        m_messageLayout = new CGUITextLayout(messageFont, true, 0);
-      m_layoutWasLoading = true;
-    }
-    if (m_messageLayout)
-    {
-      m_messageLayout->Update(message, 1150, false, true);
-
-      float textWidth, textHeight;
-      m_messageLayout->GetTextExtent(textWidth, textHeight);
-      // ideally place text in center of empty area below splash image
-      float y = 540 + m_image->GetTextureHeight() / 4 - textHeight / 2;
-      if (y + textHeight > 720) // make sure entire text is visible
-        y = 720 - textHeight;
-
-      m_messageLayout->RenderOutline(640, y, 0, 0xFF000000, XBFONT_CENTER_X, 1280);
-    }
-  }
 
   //show it on screen
   g_Windowing.EndRender();

--- a/xbmc/utils/Splash.cpp
+++ b/xbmc/utils/Splash.cpp
@@ -29,20 +29,23 @@
 
 using namespace XFILE;
 
-CSplash::CSplash(const std::string& imageName)
+CSplash::CSplash()
 {
-  m_imageName = imageName;
-  m_fade = 0.5;
   m_messageLayout = NULL;
   m_image = NULL;
   m_layoutWasLoading = false;
 }
 
-
 CSplash::~CSplash()
 {
   delete m_image;
   delete m_messageLayout;
+}
+
+CSplash& CSplash::Get()
+{
+  static CSplash instance;
+  return instance;
 }
 
 void CSplash::Show()
@@ -52,17 +55,21 @@ void CSplash::Show()
 
 void CSplash::Show(const std::string& message)
 {
+  if (!m_image)
+  {
+    std::string splashImage = "special://home/media/Splash.png";
+    if (!XFILE::CFile::Exists(splashImage))
+      splashImage = "special://xbmc/media/Splash.png";
+
+    m_image = new CGUIImage(0, 0, 0, 0, g_graphicsContext.GetWidth(), g_graphicsContext.GetHeight(), CTextureInfo(splashImage));
+    m_image->SetAspectRatio(CAspectRatio::AR_CENTER);
+  }
+
   g_graphicsContext.Lock();
   g_graphicsContext.Clear();
 
   RESOLUTION_INFO res = g_graphicsContext.GetResInfo();
   g_graphicsContext.SetRenderingResolution(res, true);
-
-  if (!m_image)
-  {
-    m_image = new CGUIImage(0, 0, 0, 0, g_graphicsContext.GetWidth(), g_graphicsContext.GetHeight(), CTextureInfo(m_imageName));
-    m_image->SetAspectRatio(CAspectRatio::AR_CENTER);
-  }
 
   //render splash image
   g_Windowing.BeginRender();

--- a/xbmc/utils/Splash.h
+++ b/xbmc/utils/Splash.h
@@ -22,7 +22,6 @@
 
 #include <string>
 
-class CGUITextLayout;
 class CGUIImage;
 
 class CSplash
@@ -31,7 +30,6 @@ public:
   static CSplash& Get();
 
   void Show();
-  void Show(const std::string& message);
 
 protected:
   CSplash();
@@ -40,9 +38,7 @@ protected:
   virtual ~CSplash();
 
 private:
-  CGUITextLayout* m_messageLayout;
   CGUIImage* m_image;
-  bool m_layoutWasLoading;
 #ifdef HAS_DX
   D3DGAMMARAMP newRamp;
   D3DGAMMARAMP oldRamp;

--- a/xbmc/utils/Splash.h
+++ b/xbmc/utils/Splash.h
@@ -21,32 +21,22 @@
  */
 
 #include <string>
-#include "threads/Thread.h"
 
 class CGUITextLayout;
 class CGUIImage;
 
-class CSplash : public CThread
+class CSplash
 {
 public:
   CSplash(const std::string& imageName);
   virtual ~CSplash();
 
-  bool Start();
-  void Stop();
-
-  // In case you don't want to use another thread
   void Show();
   void Show(const std::string& message);
-  void Hide();
 
 private:
-  virtual void Process();
-  virtual void OnStartup();
-  virtual void OnExit();
-
-  float fade;
-  std::string m_ImageName;
+  float m_fade;
+  std::string m_imageName;
 
   CGUITextLayout* m_messageLayout;
   CGUIImage* m_image;

--- a/xbmc/utils/Splash.h
+++ b/xbmc/utils/Splash.h
@@ -28,16 +28,18 @@ class CGUIImage;
 class CSplash
 {
 public:
-  CSplash(const std::string& imageName);
-  virtual ~CSplash();
+  static CSplash& Get();
 
   void Show();
   void Show(const std::string& message);
 
-private:
-  float m_fade;
-  std::string m_imageName;
+protected:
+  CSplash();
+  CSplash(const CSplash&);
+  CSplash& operator=(CSplash const&);
+  virtual ~CSplash();
 
+private:
   CGUITextLayout* m_messageLayout;
   CGUIImage* m_image;
   bool m_layoutWasLoading;

--- a/xbmc/windows/GUIWindowSplash.cpp
+++ b/xbmc/windows/GUIWindowSplash.cpp
@@ -1,0 +1,57 @@
+/*
+ *      Copyright (C) 2015 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "GUIWindowSplash.h"
+#include "filesystem/File.h"
+#include "filesystem/SpecialProtocol.h"
+#include "guilib/GUIImage.h"
+#include "guilib/GUIWindowManager.h"
+#include "utils/log.h"
+
+CGUIWindowSplash::CGUIWindowSplash(void) : CGUIWindow(WINDOW_SPLASH, "")
+{
+  m_loadType = LOAD_ON_GUI_INIT;
+  m_image = nullptr;
+}
+
+CGUIWindowSplash::~CGUIWindowSplash(void)
+{
+  delete m_image;
+}
+
+void CGUIWindowSplash::OnInitWindow()
+{
+  std::string splashImage = "special://home/media/Splash.png";
+  if (!XFILE::CFile::Exists(splashImage))
+    splashImage = "special://xbmc/media/Splash.png";
+
+  CLog::Log(LOGINFO, "load splash image: %s", CSpecialProtocol::TranslatePath(splashImage).c_str());
+
+  m_image = new CGUIImage(0, 0, 0, 0, g_graphicsContext.GetWidth(), g_graphicsContext.GetHeight(), CTextureInfo(splashImage));
+  m_image->SetAspectRatio(CAspectRatio::AR_CENTER);
+}
+
+void CGUIWindowSplash::Render()
+{
+  g_graphicsContext.SetRenderingResolution(g_graphicsContext.GetResInfo(), true);
+  m_image->AllocResources();
+  m_image->Render();
+  m_image->FreeResources();
+}

--- a/xbmc/windows/GUIWindowSplash.cpp
+++ b/xbmc/windows/GUIWindowSplash.cpp
@@ -51,6 +51,8 @@ void CGUIWindowSplash::OnInitWindow()
 void CGUIWindowSplash::Render()
 {
   g_graphicsContext.SetRenderingResolution(g_graphicsContext.GetResInfo(), true);
+  m_image->SetWidth(g_graphicsContext.GetWidth());
+  m_image->SetHeight(g_graphicsContext.GetHeight());
   m_image->AllocResources();
   m_image->Render();
   m_image->FreeResources();

--- a/xbmc/windows/GUIWindowSplash.h
+++ b/xbmc/windows/GUIWindowSplash.h
@@ -1,0 +1,39 @@
+#pragma once
+
+/*
+ *      Copyright (C) 2015 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "guilib/GUIWindow.h"
+
+class CGUITextLayout;
+class CGUIImage;
+
+class CGUIWindowSplash : public CGUIWindow
+{
+public:
+  CGUIWindowSplash(void);
+  virtual ~CGUIWindowSplash(void);
+  virtual bool OnAction(const CAction &action) { return false; };
+  virtual void Render();
+protected:
+  virtual void OnInitWindow();
+private:
+  CGUIImage* m_image;
+};

--- a/xbmc/windows/Makefile
+++ b/xbmc/windows/Makefile
@@ -6,6 +6,7 @@ SRCS=GUIMediaWindow.cpp \
      GUIWindowPointer.cpp \
      GUIWindowScreensaver.cpp \
      GUIWindowScreensaverDim.cpp \
+     GUIWindowSplash.cpp \
      GUIWindowStartup.cpp \
      GUIWindowSystemInfo.cpp \
      GUIWindowWeather.cpp \


### PR DESCRIPTION
backport of #7650 except that this use `CAspectRatio::AR_CENTER` instead of `CAspectRatio::AR_SCALE` to stay compatible with the current splash images.

@mkortstiege mind taking a look
