### PR TITLE
Movie sets use max rating over average rating

### DIFF
--- a/xbmc/utils/GroupUtils.cpp
+++ b/xbmc/utils/GroupUtils.cpp
@@ -94,7 +94,6 @@ bool GroupUtils::Group(GroupBy groupBy, const std::string &baseDir, const CFileI
       setInfo->m_strPath = pItem->GetPath();
       setInfo->m_strTitle = pItem->GetLabel();
 
-      int ratings = 0;
       int iWatched = 0; // have all the movies been played at least once?
       std::set<std::string> pathSet;
       for (std::set<CFileItemPtr>::const_iterator movie = set->second.begin(); movie != set->second.end(); ++movie)
@@ -103,8 +102,8 @@ bool GroupUtils::Group(GroupBy groupBy, const std::string &baseDir, const CFileI
         // handle rating
         if (movieInfo->m_fRating > 0.0f)
         {
-          ratings++;
-          setInfo->m_fRating += movieInfo->m_fRating;
+          if (movieInfo->m_fRating > setInfo->m_fRating)
+            setInfo->m_fRating = movieInfo->m_fRating;
         }
         
         // handle year
@@ -133,9 +132,6 @@ bool GroupUtils::Group(GroupBy groupBy, const std::string &baseDir, const CFileI
       }
       setInfo->m_basePath = XFILE::CMultiPathDirectory::ConstructMultiPath(pathSet);
 
-      if (ratings > 1)
-        pItem->GetVideoInfoTag()->m_fRating /= ratings;
-        
       setInfo->m_playCount = iWatched >= (int)set->second.size() ? (setInfo->m_playCount / set->second.size()) : 0;
       pItem->SetProperty("total", (int)set->second.size());
       pItem->SetProperty("watched", iWatched);


### PR DESCRIPTION
Issue arise during skinning, there's no option to set the max rating for movie collections/sets. It's averaged by default.

Average rating for a movie sets reduces the page ranking during sort by descending rating view. Most obvious if the library is over hundreds. if movies grouped by set setting is enabled, a good movie that should be displayed on the first page suddenly sorted to later page,

Like the logic behind why using max year instead of min year on line:112 of GroupUtils.cpp. I suppose public tends to prefer new over old, thus the decision to show max year instead of min year?

Anyway, a typical skinning approach is always show a new view for a movie-set. In that view individual movie's rating will be displayed (or not), but always sortable by rating. I believe a collection/set's rating should be set at the max. When users enter the movie-set view, they can decide for themselves which to select in that view.
