### PR TITLE
[python] Add setContentLookup method

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -425,6 +425,7 @@ void CFileItem::Initialize()
   m_iHasLock = 0;
   m_bCanQueue = true;
   m_specialSort = SortSpecialNone;
+  m_doContentLookup = true;
 }
 
 void CFileItem::Reset()

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -417,7 +417,13 @@ public:
    \brief Some sources do not support HTTP HEAD request to determine i.e. mime type
    \return false if HEAD requests have to be avoided
    */
-  bool ContentLookup() { return true; };
+  bool ContentLookup() { return m_doContentLookup; };
+
+  /*! 
+   *\brief Lookup via HTTP HEAD request might not be needed, use this setter to
+   * disable ContentLookup.
+   */
+  void SetContentLookup(bool enable) { m_doContentLookup = enable; };
 
   /* general extra info about the contents of the item, not for display */
   void SetExtraInfo(const std::string& info) { m_extrainfo = info; };
@@ -490,6 +496,7 @@ private:
   bool m_bLabelPreformated;
   std::string m_mimetype;
   std::string m_extrainfo;
+  bool m_doContentLookup;
   MUSIC_INFO::CMusicInfoTag* m_musicInfoTag;
   CVideoInfoTag* m_videoInfoTag;
   EPG::CEpgInfoTagPtr m_epgInfoTag;

--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -236,6 +236,12 @@ namespace XBMCAddon
       item->SetMimeType(mimetype);
     }
 
+    void ListItem::setContentLookup(bool enable)
+    {
+      LOCKGUI;
+      item->SetContentLookup(enable);
+    }
+
     String ListItem::getdescription()
     {
       return item->GetLabel();

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -341,9 +341,19 @@ namespace XBMCAddon
        * \n
        * mimetype           : string or unicode - mimetype.\n
        * \n
-       * *If known prehand, this can avoid Kodi doing HEAD requests to http servers to figure out file type.\n
+       * If known prehand, this can (but does not have to) avoid HEAD requests
+       * being sent to HTTP servers to figure out file type.\n
        */
       void setMimeType(const String& mimetype);
+
+      /**
+       * setContentLookup(enable) -- Enable or disable content lookup for item.
+       *
+       * If disabled, HEAD requests to e.g determine mime type will not be sent.
+       *
+       * enable : bool
+       */
+      void setContentLookup(bool enable);
 
       /**
        * setSubtitles() -- Sets subtitles for this listitem.\n


### PR DESCRIPTION
Allows plugins to control whether HEAD request can be sent
