### PR TITLE
[pvr] CPVRChannel::SetEpgId() should flag the record as changed

### DIFF
--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -808,8 +808,13 @@ int CPVRChannel::EpgID(void) const
 void CPVRChannel::SetEpgID(int iEpgId)
 {
   CSingleLock lock(m_critSection);
-  m_iEpgId = iEpgId;
-  SetChanged();
+
+  if (m_iEpgId != iEpgId)
+  {
+    m_iEpgId = iEpgId;
+    SetChanged();
+    m_bChanged = true;
+  }
 }
 
 bool CPVRChannel::EPGEnabled(void) const


### PR DESCRIPTION
In some edge cases related to disabling/enabling EPG database and performing "Clear data" of PVR and EPG databases in certain sequences, the iEpgId in the channels table in PVR database was being set to 0.  This then led to problems if EPG database was later enabled, where the PVR channel iEpgId could never find a match in the EPG database epg table and would then cause duplicating all channel entries in EPG database each time Kodi was started up.

This change sets the m_bChanged flag when this field is changed, which then ensures the existing code persists these changed Channel records to the PVR database.  With this change present, the iEpgId is never set to 0 in the database in the first place even when clearing databases with EPG database disabled.  I also forced the column value to 0 in the database, and ensured that with this fix in place, the channels in the PVR database are fixed up to hold the correct epgID.

I also added the logic to SetEpgID() that only applies the field change and sets the changed flags, if the value is different to that already stored.  But I do have to note that the SetChanged() funciton which toggles an Observable changed flag is now only being called if the EpgID passed in was different to that already stored, whereas previously it was called all the time.  This seems OK/correct to me, and is in line with other Setxxx() fields on PVRChannel, where the SetChanged() and m_bChanged are only set true if the field actually changed values.

Problem was uncovered here: https://github.com/xbmc/xbmc/pull/7734#issuecomment-128985946

Pings: @xhaggi
