### PR TITLE
[PVR] Fix timer type compat code. Solves a crash with MediaPortal addon.

### DIFF
--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -129,7 +129,7 @@ CPVRTimerInfoTag::CPVRTimerInfoTag(const PVR_TIMER &timer, const CPVRChannelPtr 
       unsigned int iMustHave    = PVR_TIMER_TYPE_ATTRIBUTE_NONE;
       unsigned int iMustNotHave = PVR_TIMER_TYPE_FORBIDS_NEW_INSTANCES;
 
-      if (timer.iWeekdays != PVR_WEEKDAY_NONE)
+      if (timer.iEpgUid == 0 && timer.iWeekdays != PVR_WEEKDAY_NONE)
         iMustHave |= PVR_TIMER_TYPE_IS_REPEATING;
       else
         iMustNotHave |= PVR_TIMER_TYPE_IS_REPEATING;


### PR DESCRIPTION
Should fix the problem reported in the forum. http://forum.kodi.tv/showthread.php?tid=227026&pid=2074363#pid2074363
