### PR TITLE
[pvr.dvbviewer] Change back to SHA or it will continue to fail

### DIFF
--- a/project/cmake/addons/addons/pvr.dvbviewer/pvr.dvbviewer.txt
+++ b/project/cmake/addons/addons/pvr.dvbviewer/pvr.dvbviewer.txt
@@ -1,1 +1,1 @@
-pvr.dvbviewer https://github.com/kodi-pvr/pvr.dvbviewer master
+pvr.dvbviewer https://github.com/kodi-pvr/pvr.dvbviewer 65b8647


### PR DESCRIPTION
https://github.com/kodi-pvr/pvr.dvbviewer/pull/17 for reason.
