### PR TITLE
[pvr] Backport PVRChannel SetEpgId fix

### DIFF
--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -807,8 +807,13 @@ int CPVRChannel::EpgID(void) const
 void CPVRChannel::SetEpgID(int iEpgId)
 {
   CSingleLock lock(m_critSection);
-  m_iEpgId = iEpgId;
-  SetChanged();
+
+  if (m_iEpgId != iEpgId)
+  {
+    m_iEpgId = iEpgId;
+    SetChanged();
+    m_bChanged = true;
+  }
 }
 
 bool CPVRChannel::EPGEnabled(void) const


### PR DESCRIPTION
Backport of #7762 as requested by @xhaggi

Ive done a basic test on Isengard and confirmed that EpgID  field on channel is not getting zero'ed out.  See the referenced PR for more details on the problem and fix
