### PR TITLE
[infomanager] add Container(id).CurrentItem / NumItems for grouplists

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -35,6 +35,7 @@
 #include "LangInfo.h"
 #include "utils/SystemInfo.h"
 #include "guilib/GUITextBox.h"
+#include "guilib/GUIControlGroupList.h"
 #include "pictures/GUIWindowSlideShow.h"
 #include "pictures/PictureInfoTag.h"
 #include "music/tags/MusicInfoTag.h"
@@ -3378,6 +3379,8 @@ std::string CGUIInfoManager::GetMultiInfoLabel(const GUIInfo &info, int contextW
     {
       if (control->IsContainer())
         return ((IGUIContainer *)control)->GetLabel(info.m_info);
+      else if (control->GetControlType() == CGUIControl::GUICONTROL_GROUPLIST)
+        return ((CGUIControlGroupList *)control)->GetLabel(info.m_info);
       else if (control->GetControlType() == CGUIControl::GUICONTROL_TEXTBOX)
         return ((CGUITextBox *)control)->GetLabel(info.m_info);
     }

--- a/xbmc/guilib/GUIControlGroup.cpp
+++ b/xbmc/guilib/GUIControlGroup.cpp
@@ -19,6 +19,8 @@
  */
 
 #include "GUIControlGroup.h"
+#include "guiinfo/GUIInfoLabels.h"
+#include "utils/StringUtils.h"
 
 #include <cassert>
 
@@ -551,6 +553,42 @@ void CGUIControlGroup::AddControl(CGUIControl *control, int position /* = -1*/)
   control->SetPushUpdates(m_pushedUpdates);
   AddLookup(control);
   SetInvalid();
+}
+
+std::string CGUIControlGroup::GetLabel(int info) const
+{
+  switch (info)
+  {
+  case CONTAINER_CURRENT_ITEM:
+    return StringUtils::Format("%i", GetSelectedItem());
+  case CONTAINER_NUM_ITEMS:
+    return StringUtils::Format("%i", GetNumItems());
+  default:
+    break;
+  }
+  return "";
+}
+
+int CGUIControlGroup::GetNumItems() const
+{
+  return std::count_if(m_children.begin(), m_children.end(), [&](const CGUIControl *child) {
+    return (child->IsVisible() && child->CanFocus());
+  });
+}
+
+int CGUIControlGroup::GetSelectedItem() const
+{
+  int index = 1;
+  for (const auto& child : m_children)
+  {
+    if (child->IsVisible() && child->CanFocus())
+    {
+      if (child->HasFocus())
+        return index;
+      index++;
+    }
+  }
+  return -1;
 }
 
 void CGUIControlGroup::AddLookup(CGUIControl *control)

--- a/xbmc/guilib/GUIControlGroup.h
+++ b/xbmc/guilib/GUIControlGroup.h
@@ -84,6 +84,10 @@ public:
 
   virtual bool IsGroup() const { return true; };
 
+  virtual std::string GetLabel(int info) const;
+  int GetNumItems() const;
+  int GetSelectedItem() const;
+
 #ifdef _DEBUG
   virtual void DumpTextureUse();
 #endif


### PR DESCRIPTION
This adds support for `Container(id).CurrentItem` and `Container(id).NumItems` within grouplist controls as requested in http://forum.kodi.tv/showthread.php?tid=224074&pid=2073436#pid2073436. An item is considered countable when visible and can focus.

/cc @BigNoid, @HitcherUK, @ronie
