### PR TITLE
[EPG] Fix: Respect view mode changes of EPG window when controlling number of epg data updates

### DIFF
--- a/xbmc/epg/GUIEPGGridContainer.cpp
+++ b/xbmc/epg/GUIEPGGridContainer.cpp
@@ -48,8 +48,6 @@ using namespace EPG;
 #define BLOCKJUMP    4 // how many blocks are jumped with each analogue scroll action
 #define BLOCK_SCROLL_OFFSET 60 / MINSPERBLOCK // how many blocks are jumped if we are at left/right edge of grid
 
-#define MAX_UPDATE_FREQUENCY 3000 // Do at maximum 1 grid data update in MAX_UPDATE_FREQUENCY milliseconds
-
 CGUIEPGGridContainer::CGUIEPGGridContainer(int parentID, int controlID, float posX, float posY, float width,
                                            float height, int scrollTime, int preloadItems, int timeBlocks, int rulerUnit,
                                            const CTextureInfo& progressIndicatorTexture)
@@ -162,8 +160,8 @@ CGUIEPGGridContainer::CGUIEPGGridContainer(const CGUIEPGGridContainer &other)
   m_channelScrollLastTime   = other.m_channelScrollLastTime;
   m_channelScrollSpeed      = other.m_channelScrollSpeed;
   m_channelScrollOffset     = other.m_channelScrollOffset;
-  m_nextUpdateTimeout       = other.m_nextUpdateTimeout;
 }
+
 CGUIEPGGridContainer::~CGUIEPGGridContainer(void)
 {
   Reset();
@@ -809,13 +807,8 @@ bool CGUIEPGGridContainer::OnMessage(CGUIMessage& message)
         return true;
 
       case GUI_MSG_LABEL_BIND:
-        if (m_nextUpdateTimeout.IsTimePast())
-        {
-          UpdateItems(static_cast<CFileItemList *>(message.GetPointer()));
-          m_nextUpdateTimeout.Set(MAX_UPDATE_FREQUENCY);
-          return true;
-        }
-        break;
+        UpdateItems(static_cast<CFileItemList *>(message.GetPointer()));
+        return true;
 
       case GUI_MSG_REFRESH_LIST:
         // update our list contents

--- a/xbmc/epg/GUIEPGGridContainer.h
+++ b/xbmc/epg/GUIEPGGridContainer.h
@@ -24,7 +24,6 @@
 #include "guilib/GUIControl.h"
 #include "guilib/GUIListItemLayout.h"
 #include "guilib/IGUIContainer.h"
-#include "threads/SystemClock.h"
 
 namespace EPG
 {
@@ -229,7 +228,5 @@ namespace EPG
     float m_channelScrollOffset;
 
     CCriticalSection m_critSection;
-
-    XbmcThreads::EndTime m_nextUpdateTimeout;
   };
 }

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -33,6 +33,8 @@
 #include "pvr/addons/PVRClients.h"
 #include "pvr/timers/PVRTimers.h"
 
+#define MAX_UPDATE_FREQUENCY 3000 // limit to maximum one update/refresh in x milliseconds
+
 using namespace PVR;
 using namespace EPG;
 
@@ -261,6 +263,7 @@ bool CGUIWindowPVRGuide::OnMessage(CGUIMessage& message)
     {
       // let's set the view mode first before update
       CGUIWindowPVRBase::OnMessage(message);
+      m_nextUpdateTimeout.SetExpired();
       Refresh(true);
       bReturn = true;
       break;
@@ -273,9 +276,12 @@ bool CGUIWindowPVRGuide::OnMessage(CGUIMessage& message)
         case ObservableMessageEpgContainer:
         {
           m_bUpdateRequired = true;
-          /* update the current window if the EPG timeline view is visible */
-          if (IsActive() && m_viewControl.GetCurrentControl() == GUIDE_VIEW_TIMELINE)
+          // do not allow more than MAX_UPDATE_FREQUENCY updates
+          if (IsActive() && m_nextUpdateTimeout.IsTimePast())
+          {
             Refresh(true);
+            m_nextUpdateTimeout.Set(MAX_UPDATE_FREQUENCY);
+          }
           bReturn = true;
           break;
         }

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.h
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.h
@@ -22,6 +22,7 @@
 
 #include "GUIWindowPVRBase.h"
 #include "epg/GUIEPGGridContainer.h"
+#include "threads/SystemClock.h"
 
 class CSetting;
 
@@ -65,5 +66,7 @@ namespace PVR
     CPVRChannelGroupPtr m_cachedChannelGroup;
 
     bool m_bUpdateRequired;
+
+    XbmcThreads::EndTime m_nextUpdateTimeout;
   };
 }


### PR DESCRIPTION
Switching EPG window view from "Channel" to "Time Line" ended up with an empty EPG timeline window (until next EPG data update arrived).

@xhaggi as we have code already reviewed internally, give me your +1, please.

Needs backport.
