### PR TITLE
[EPG] Fix: Respect view mode changes of EPG window when controlling number of epg data updates

### DIFF
--- a/xbmc/epg/GUIEPGGridContainer.cpp
+++ b/xbmc/epg/GUIEPGGridContainer.cpp
@@ -44,8 +44,6 @@ using namespace EPG;
 #define BLOCKJUMP    4 // how many blocks are jumped with each analogue scroll action
 #define BLOCK_SCROLL_OFFSET 60 / MINSPERBLOCK // how many blocks are jumped if we are at left/right edge of grid
 
-#define MAX_UPDATE_FREQUENCY 3000 // Do at maximum 1 grid data update in MAX_UPDATE_FREQUENCY milliseconds
-
 CGUIEPGGridContainer::CGUIEPGGridContainer(int parentID, int controlID, float posX, float posY, float width,
                                            float height, int scrollTime, int preloadItems, int timeBlocks, int rulerUnit,
                                            const CTextureInfo& progressIndicatorTexture)
@@ -158,8 +156,8 @@ CGUIEPGGridContainer::CGUIEPGGridContainer(const CGUIEPGGridContainer &other)
   m_channelScrollLastTime   = other.m_channelScrollLastTime;
   m_channelScrollSpeed      = other.m_channelScrollSpeed;
   m_channelScrollOffset     = other.m_channelScrollOffset;
-  m_nextUpdateTimeout       = other.m_nextUpdateTimeout;
 }
+
 CGUIEPGGridContainer::~CGUIEPGGridContainer(void)
 {
   Reset();
@@ -803,7 +801,7 @@ bool CGUIEPGGridContainer::OnMessage(CGUIMessage& message)
         return true;
 
       case GUI_MSG_LABEL_BIND:
-        if (message.GetPointer() && m_nextUpdateTimeout.IsTimePast())
+        if (message.GetPointer())
         {
           CSingleLock lock(m_critSection);
 
@@ -889,10 +887,7 @@ bool CGUIEPGGridContainer::OnMessage(CGUIMessage& message)
           {
             // Grid index got recreated. Do cursors and offsets still point to the same epg tag?
             if (prevSelectedEpgTag == GetSelectedEpgInfoTag())
-            {
-              m_nextUpdateTimeout.Set(MAX_UPDATE_FREQUENCY); // TODO ksooo: Refactor to have only one return statement.
               return true;
-            }
 
             int newChannelCursor = GetChannel(prevSelectedEpgTag);
             if (newChannelCursor >= 0)
@@ -901,10 +896,7 @@ bool CGUIEPGGridContainer::OnMessage(CGUIMessage& message)
               if (newBlockCursor >= 0)
               {
                 if (newChannelCursor == m_channelCursor && newBlockCursor == m_blockCursor)
-                {
-                  m_nextUpdateTimeout.Set(MAX_UPDATE_FREQUENCY); // TODO ksooo: Refactor to have only one return statement.
                   return true;
-                }
 
                 if (newBlockCursor > 0 && newBlockCursor != m_blockCursor)
                 {
@@ -919,10 +911,7 @@ bool CGUIEPGGridContainer::OnMessage(CGUIMessage& message)
                 }
 
                 if (newBlockCursor > 0)
-                {
-                  m_nextUpdateTimeout.Set(MAX_UPDATE_FREQUENCY); // TODO ksooo: Refactor to have only one return statement.
                   return true;
-                }
               }
             }
           }
@@ -935,7 +924,6 @@ bool CGUIEPGGridContainer::OnMessage(CGUIMessage& message)
           SetInvalid();
           GoToNow();
 
-          m_nextUpdateTimeout.Set(MAX_UPDATE_FREQUENCY); // TODO ksooo: Refactor to have only one return statement.
           return true;
         }
         break;

--- a/xbmc/epg/GUIEPGGridContainer.h
+++ b/xbmc/epg/GUIEPGGridContainer.h
@@ -24,7 +24,6 @@
 #include "guilib/GUIControl.h"
 #include "guilib/GUIListItemLayout.h"
 #include "guilib/IGUIContainer.h"
-#include "threads/SystemClock.h"
 
 namespace EPG
 {
@@ -229,7 +228,5 @@ namespace EPG
     float m_channelScrollOffset;
 
     CCriticalSection m_critSection;
-
-    XbmcThreads::EndTime m_nextUpdateTimeout;
   };
 }

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.h
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.h
@@ -22,6 +22,7 @@
 
 #include "GUIWindowPVRBase.h"
 #include "epg/GUIEPGGridContainer.h"
+#include "threads/SystemClock.h"
 
 class CSetting;
 
@@ -65,5 +66,7 @@ namespace PVR
     CPVRChannelGroupPtr m_cachedChannelGroup;
 
     bool m_bUpdateRequired;
+
+    XbmcThreads::EndTime m_nextUpdateTimeout;
   };
 }


### PR DESCRIPTION
Switching EPG window view from "Channel" to "Time Line" ended up with an empty EPG timeline window (until next EPG data update arrived).

@xhaggi as we have code already reviewed internally, give me your +1, please.

Backport of #7770.
