### PR TITLE
Revert "[osx/XBMCHelper] - compile XBMCHelper as 64bit"

### DIFF
--- a/tools/EventClients/Clients/OSXRemote/XBMCHelper.xcodeproj/project.pbxproj
+++ b/tools/EventClients/Clients/OSXRemote/XBMCHelper.xcodeproj/project.pbxproj
@@ -188,7 +188,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CONFIGURATION_BUILD_DIR = ../../../darwin/runtime;
 				COPY_PHASE_STRIP = NO;
 				GCC_DYNAMIC_NO_PIC = NO;
@@ -203,7 +202,7 @@
 				PRODUCT_NAME = XBMCHelper;
 				SDKROOT = macosx;
 				STRIP_STYLE = debugging;
-				VALID_ARCHS = x86_64;
+				VALID_ARCHS = i386;
 			};
 			name = Debug;
 		};
@@ -211,7 +210,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CONFIGURATION_BUILD_DIR = ../../../darwin/runtime;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_MODEL_TUNING = G5;
@@ -222,7 +220,7 @@
 				PRODUCT_NAME = XBMCHelper;
 				SDKROOT = macosx;
 				STRIP_STYLE = debugging;
-				VALID_ARCHS = x86_64;
+				VALID_ARCHS = i386;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Reverts xbmc/xbmc#7604

Based on the (poor) feedback of users i decided to revert this. I though i merged this into Isengard as well but it seems i didn't (good thing :D)

Taken from the related forum post (http://forum.kodi.tv/showthread.php?tid=232841):

-----snip----------
Ok - i will revert that change now - because without further feedback i assume that compiling XBMCHelper as 64bit binary makes it non-working. Better have it prevent powering off for some (or maybe only you? noone else reported this yet) then having lost the whole featureset that XBMCHelper provides (f.e. starting Kodi via remote which quiet some users seem to make use off).

 In the end this needs someone to ensure that XBMCHelper works when compiled as 64bit (low priority to me atm due to lack of any free time for kodi atm, every other osx dev is welcome to make XBMCHelper 64bit compatible though...) 
-----/snip----------
