### PR TITLE
[xbmc][applicationmessenger] Fix endless loop during shutdown.

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2509,7 +2509,7 @@ void CApplication::OnApplicationMessage(ThreadMessage* pMsg)
     switch (CSettings::Get().GetInt(CSettings::SETTING_POWERMANAGEMENT_SHUTDOWNSTATE))
     {
     case POWERSTATE_SHUTDOWN:
-      CApplicationMessenger::Get().PostMsg(TMSG_SHUTDOWN);
+      CApplicationMessenger::Get().PostMsg(TMSG_POWERDOWN);
       break;
 
     case POWERSTATE_SUSPEND:


### PR DESCRIPTION
accidentaly sent TMSG_SHUTDOWN instead of TMSG_POWERDOWN causing an endless loop
closes trac #16146
