### PR TITLE
[Database/Import] - present the user with removable and network share…

### DIFF
--- a/xbmc/settings/MediaSettings.cpp
+++ b/xbmc/settings/MediaSettings.cpp
@@ -369,6 +369,9 @@ void CMediaSettings::OnSettingAction(const CSetting *setting)
     std::string path;
     VECSOURCES shares;
     g_mediaManager.GetLocalDrives(shares);
+    g_mediaManager.GetNetworkLocations(shares);
+    g_mediaManager.GetRemovableDrives(shares);
+
     if (CGUIDialogFileBrowser::ShowAndGetFile(shares, "musicdb.xml", g_localizeStrings.Get(651) , path))
     {
       CMusicDatabase musicdatabase;
@@ -389,6 +392,9 @@ void CMediaSettings::OnSettingAction(const CSetting *setting)
     std::string path;
     VECSOURCES shares;
     g_mediaManager.GetLocalDrives(shares);
+    g_mediaManager.GetNetworkLocations(shares);
+    g_mediaManager.GetRemovableDrives(shares);
+
     if (CGUIDialogFileBrowser::ShowAndGetDirectory(shares, g_localizeStrings.Get(651) , path))
     {
       CVideoDatabase videodatabase;


### PR DESCRIPTION
…s aswell when importing a database - same as the export database dialog provides.

Well as the title says - the import file selection dialog only showed local drives (so you could export to a network share but not import from it).

@MartijnKaijser not sure if this is valid for backport at this stage...

Was not able to runtime test due to a strange crash in my debug environment (i hope its just something stale - i have no time for a recompile from scratch atm). But its straight forward (copied from the export code)
