### PR TITLE
[VIDEONAV] new controls to display lists of subs & audio

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3877,6 +3877,17 @@ void CApplication::UpdateFileState()
   }
 }
 
+void CApplication::SaveVideoSettings(const std::string &path)
+{
+  CVideoDatabase dbs;
+  if (dbs.Open())
+  {
+    CLog::Log(LOGDEBUG, "Saving settings for %s", path.c_str());
+    dbs.SetVideoSettings(path, CMediaSettings::Get().GetCurrentVideoSettings());
+    dbs.Close();
+  }
+}
+
 void CApplication::LoadVideoSettings(const CFileItem& item)
 {
   CVideoDatabase dbs;
@@ -4609,6 +4620,8 @@ void CApplication::ProcessSlow()
 
   // check for any idle curl connections
   g_curlInterface.CheckIdle();
+
+  // check for any idle myth sessions
 
 #ifdef HAS_KARAOKE
   if ( m_pKaraokeMgr )

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -184,6 +184,7 @@ public:
   void SaveFileState(bool bForeground = false);
   void UpdateFileState();
   void LoadVideoSettings(const CFileItem& item);
+  void SaveVideoSettings(const std::string &path);
   void StopPlaying();
   void Restart(bool bSamePosition = true);
   void DelayedPlayerRestart();

--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -107,6 +107,15 @@ PlayBackRet CApplicationPlayer::OpenFile(const CFileItem& item, const CPlayerOpt
   return iResult;
 }
 
+int CApplicationPlayer::PreloadFileInfo(const CFileItem& file, const CPlayerOptions &options)
+{
+  std::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    return player->PreloadFileInfo(file, options);
+  else 
+    return -1;
+}
+
 bool CApplicationPlayer::HasPlayer() const 
 { 
   std::shared_ptr<IPlayer> player = GetInternal();

--- a/xbmc/ApplicationPlayer.h
+++ b/xbmc/ApplicationPlayer.h
@@ -79,6 +79,7 @@ public:
   void SetPlaySpeed(int iSpeed, bool bApplicationMuted);
 
   // proxy calls
+  int   PreloadFileInfo(const CFileItem& file, const CPlayerOptions &options);
   void   AddSubtitle(const std::string& strSubPath);
   bool  CanPause();
   bool  CanRecord();

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -159,6 +159,8 @@ public:
   virtual bool IsRecording() { return false;};
   virtual bool Record(bool bOnOff) { return false;};
 
+  virtual int PreloadFileInfo(const CFileItem& file, const CPlayerOptions &options) { return -1;};
+
   virtual void  SetAVDelay(float fValue = 0.0f) { return; }
   virtual float GetAVDelay()                    { return 0.0f;};
 

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -649,9 +649,9 @@ bool CDVDPlayer::OpenFile(const CFileItem& file, const CPlayerOptions &options)
     m_CurrentVideo.lastdts = DVD_NOPTS_VALUE;
 
     m_PlayerOptions = options;
-    m_item     = file;
-    m_mimetype  = file.GetMimeType();
-    m_filename = file.GetPath();
+    m_item          = file;
+    m_mimetype      = file.GetMimeType();
+    m_filename      = file.GetPath();
 
     m_ready.Reset();
 
@@ -1106,6 +1106,34 @@ void CDVDPlayer::CheckBetterStream(CCurrentStream& current, CDemuxStream* stream
 
   if (IsBetterStream(current, stream))
     OpenStream(current, stream->iId, stream->source);
+}
+
+int CDVDPlayer::PreloadFileInfo(const CFileItem& file, const CPlayerOptions &options)
+{
+  m_bAbortRequest = false;
+  SetPlaySpeed(DVD_PLAYSPEED_NORMAL);
+
+  m_State.Clear();
+  memset(&m_SpeedState, 0, sizeof(m_SpeedState));
+  m_UpdateApplication = 0;
+  m_offset_pts = 0;
+  m_CurrentAudio.lastdts = DVD_NOPTS_VALUE;
+  m_CurrentVideo.lastdts = DVD_NOPTS_VALUE;
+
+  m_PlayerOptions = options;
+  m_item          = file;
+  m_mimetype      = file.GetMimeType();
+  m_filename      = file.GetPath();
+
+  m_ready.Reset();
+
+  //CGUIDialogBusy::WaitOnEvent(m_ready, g_advancedSettings.m_videoBusyDialogDelay_ms, false);
+
+  //FIXME: To be done in background thread
+  if (!OpenInputStream())
+    return -1;
+  else
+    return OpenDemuxStream();
 }
 
 void CDVDPlayer::Process()

--- a/xbmc/cores/dvdplayer/DVDPlayer.h
+++ b/xbmc/cores/dvdplayer/DVDPlayer.h
@@ -309,6 +309,7 @@ protected:
 
   virtual void OnStartup();
   virtual void OnExit();
+  virtual int  PreloadFileInfo(const CFileItem& file, const CPlayerOptions &options);
   virtual void Process();
 
   void CreatePlayers();

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -422,7 +422,23 @@ bool CGUIBaseContainer::OnMessage(CGUIMessage& message)
     }
     if (message.GetMessage() == GUI_MSG_ITEM_SELECT)
     {
+      // Set the selected item
+      //CLog::Log(LOGDEBUG,"CGUIBaseContainer::OnMessage : ITEM_SELECT");
       SelectItem(message.GetParam1());
+
+      return true;
+    }
+    else if (message.GetMessage() == GUI_MSG_FILEITEM_SELECT)
+    {
+      int sel = message.GetParam1();
+      // Force selection if index is out of range
+      if(sel<0 || sel>=m_items.size())
+        sel = 0;
+      //CLog::Log(LOGDEBUG,"CGUIBaseContainer::OnMessage : FILEITEM_SELECT %d", sel);
+      for (iItems it = m_items.begin(); it != m_items.end(); ++it)
+        (*it)->Select(false);
+      m_items[sel]->Select(true);
+
       return true;
     }
     else if (message.GetMessage() == GUI_MSG_SETFOCUS)
@@ -435,6 +451,8 @@ bool CGUIBaseContainer::OnMessage(CGUIMessage& message)
     }
     else if (message.GetMessage() == GUI_MSG_ITEM_SELECTED)
     {
+      // Return the selected item
+      //CLog::Log(LOGDEBUG,"CGUIBaseContainer::OnMessage : ITEM_SELECTED");
       message.SetParam1(GetSelectedItem());
       return true;
     }

--- a/xbmc/guilib/GUIMessage.h
+++ b/xbmc/guilib/GUIMessage.h
@@ -161,6 +161,11 @@
  */
 #define GUI_MSG_UI_READY       49
 
+/*!
+ \brief Select the given fileItem in the target containter
+ */
+#define GUI_MSG_FILEITEM_SELECT 50
+
 #define GUI_MSG_USER         1000
 
 /*!
@@ -333,6 +338,26 @@ do { \
 do { \
  CGUIMessage msg(GUI_MSG_CLICKED, id, parentID, action); \
  SendWindowMessage(msg); \
+} while(0)
+
+/*!
+\ingroup winmsg
+\brief Send message to select a fileItem in the given container.
+ */
+#define SELECT_FILEITEM(id, item) \
+do { \
+ CGUIMessage msg(GUI_MSG_FILEITEM_SELECT, GetID(), id, item, 0); \
+ OnMessage(msg); \
+} while(0)
+
+/*!
+\ingroup winmsg
+\brief Bind the given fileItem list with the given container.
+ */
+#define BIND_LABELS_TO_FILEITEMS(id, list) \
+do { \
+ CGUIMessage msg(GUI_MSG_LABEL_BIND, GetID(), id, 0, 0, list); \
+ OnMessage(msg); \
 } while(0)
 
 #include <string>

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.h
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.h
@@ -82,6 +82,10 @@ protected:
   static bool UpdateVideoItemSortTitle(const CFileItemPtr &pItem);
   static bool LinkMovieToTvShow(const CFileItemPtr &item, bool bRemove, CVideoDatabase &database);
 
+  // Utils to change the selected audio and subs
+  void SelectAudioStream(int iItem, bool m_isPlaying);
+  void SelectSubtitleStream(int iItem, bool m_isPlaying);
+
   /*! \brief Pop up a fanart chooser. Does not utilise remote URLs.
    \param videoItem the item to choose fanart for.
    */


### PR DESCRIPTION
This is a proposal for new controls in the DialogVideoInfo window to select subtitles and audio stream before the playback is started. 4 controls have been added, two spinners and two lists, for both subtitles selection and audio stream selection.
Information from the media file could eventually be loaded in a thread, as the PreloadFileInfo() operation is possibly time consuming. Feel free to comment this code, this is my first contribution to kodi development.
