### PR TITLE
[PVR] Fix: Timer settings dialog: Clear epg tag on save if timer is not/no longer epg-based.

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -631,6 +631,10 @@ void CGUIDialogPVRTimerSettings::Save()
 
   // Update summary
   m_timerInfoTag->UpdateSummary();
+
+  // Clear timer tag's epg tag if timer is not/no longer epg-based.
+  if (!m_timerType->IsEpgBased())
+    m_timerInfoTag->ClearEpgTag();
 }
 
 void CGUIDialogPVRTimerSettings::SetButtonLabels()


### PR DESCRIPTION
If "Add custom timer" is used to create a timer, then the epg tag of the currently selected epg entry is put into the newly created timer info tag. So far so good. If you then change timer type to "manual one-time" (or another non-epg-based type) in the timer settings dialog, the epg tag was not cleared when saving timer data back to the timer info tag. Some addons (like pvr.hts) always prefer the epg data over the manual timer data (start, stop, ...) that also might come with a PVR_TIMER instance. Thus, pvr.hts created a timer based on the epg data and ignored the actually valid manual data. A fix could also be done in the addon, but I thoight it would be better to fix this here, because other addons' logic could be the same as for pvr.hts.

@metaron-uk, @ryangribble any objections because of incompatibilities this might introduce for pvr.mathtv or pvr.wmc?
