### PR TITLE
[FontTTF] Fixed a blurry font  which is happening sometimes in some cases.

### DIFF
--- a/xbmc/guilib/GUIFontTTF.cpp
+++ b/xbmc/guilib/GUIFontTTF.cpp
@@ -839,10 +839,14 @@ void CGUIFontTTFBase::RenderCharacter(float posX, float posY, const Character *c
     float rx3 = (float)MathUtils::round_int(x[3]);
     x[1] = (float)MathUtils::truncate_int(x[1]);
     x[2] = (float)MathUtils::truncate_int(x[2]);
-    if (rx0 > x[0])
+    if (x[0] > 0.0f && rx0 > x[0])
       x[1] += 1;
-    if (rx3 > x[3])
+    else if (x[0] < 0.0f && rx0 < x[0])
+      x[1] -= 1;
+    if (x[3] > 0.0f && rx3 > x[3])
       x[2] += 1;
+    else if (x[3] < 0.0f && rx3 < x[3])
+      x[2] -= 1;
     x[0] = rx0;
     x[3] = rx3;
   }

--- a/xbmc/guilib/GUIFontTTFDX.cpp
+++ b/xbmc/guilib/GUIFontTTFDX.cpp
@@ -65,12 +65,6 @@ bool CGUIFontTTFDX::FirstBegin()
   if (!pContext)
     return false;
 
-  CGUIShaderDX* pGUIShader = g_Windowing.GetGUIShader();
-  ID3D11ShaderResourceView* resource = m_speedupTexture->GetShaderResource();
-  pGUIShader->Begin(SHADER_METHOD_RENDER_FONT);
-  pGUIShader->SetShaderViews(1, &resource);
-  g_Windowing.SetAlphaBlendEnable(true);
-
   return true;
 }
 
@@ -80,12 +74,25 @@ void CGUIFontTTFDX::LastEnd()
   if (!pContext)
     return;
 
+  typedef CGUIFontTTFBase::CTranslatedVertices trans;
+  bool transIsEmpty = std::all_of(m_vertexTrans.begin(), m_vertexTrans.end(),
+                                  [](trans& _) { return _.vertexBuffer->size <= 0; });
+  // no chars to render
+  if (m_vertex.empty() && transIsEmpty)
+    return;
+
   CGUIShaderDX* pGUIShader = g_Windowing.GetGUIShader();
+  pGUIShader->Begin(SHADER_METHOD_RENDER_FONT);
   CreateStaticIndexBuffer();
 
   unsigned int offset = 0;
   unsigned int stride = sizeof(SVertex);
 
+  // Set font texture as shader resource
+  ID3D11ShaderResourceView* resources[] = { m_speedupTexture->GetShaderResource() };
+  pGUIShader->SetShaderViews(1, resources);
+  // Enable alpha blend
+  g_Windowing.SetAlphaBlendEnable(true);
   // Set our static index buffer
   pContext->IASetIndexBuffer(m_staticIndexBuffer, DXGI_FORMAT_R16_UINT, 0);
   // Set the type of primitive that should be rendered from this vertex buffer, in this case triangles.
@@ -113,7 +120,7 @@ void CGUIFontTTFDX::LastEnd()
     }
   }
 
-  if (!m_vertexTrans.empty())
+  if (!transIsEmpty)
   {
     // Deal with the vertices that can be hardware clipped and therefore translated
 


### PR DESCRIPTION
see title

The caching font data mechanics allows have vertices with negative X coordinate. Here is an example of real vertices data for the same character:

**Char is not blurry**:

```
#float3(x,y,z),float4(r,g,b,a),float2(tu,tv)
"{+72, +124, +0}","{+0.89803928, +0.89803928, +0.89803928, +1}","{+0.13085938, +0.30000001}"
"{+77, +124, +0}","{+0.89803928, +0.89803928, +0.89803928, +1}","{+0.13574219, +0.30000001}"
"{+77, +138, +0}","{+0.89803928, +0.89803928, +0.89803928, +1}","{+0.13574219, +0.76666671}"
"{+72, +138, +0}","{+0.89803928, +0.89803928, +0.89803928, +1}","{+0.13085938, +0.76666671}"
```

**Char is blurry**:

```
#float3(x,y,z),float4(r,g,b,a),float2(tu,tv)
"{-159, +124, +0}","{+0.89803928, +0.89803928, +0.89803928, +1}","{+0.13085938, +0.30000001}"
"{-153, +124, +0}","{+0.89803928, +0.89803928, +0.89803928, +1}","{+0.13574219, +0.30000001}"
"{-153, +138, +0}","{+0.89803928, +0.89803928, +0.89803928, +1}","{+0.13574219, +0.76666671}"
"{-159, +138, +0}","{+0.89803928, +0.89803928, +0.89803928, +1}","{+0.13085938, +0.76666671}"
```

As can you see if vertex data has negative value of X coordinate the dimension of char is greater at 1 pixel - 6x14 instead of 5x14.

It would be helpful if some one can test this on linux
