### PR TITLE
[Util.cpp] sap stream was dropped by mistake during HDhomerun cleanup

### DIFF
--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -424,6 +424,9 @@ bool CUtil::IsLiveTV(const std::string& strFile)
   if (StringUtils::StartsWithNoCase(strFile, "pvr://channels"))
     return true;
 
+  if(StringUtils::StartsWithNoCase(strFile, "sap:"))
+    return true;
+
   return false;
 }
 


### PR DESCRIPTION
HDhomerun drop PR cleaned more than it should. I have no way to runtime test this.
