### PR TITLE
[confluence] fix music OSD alignment and improve visible conditions on OSD

### DIFF
--- a/addons/skin.confluence/720p/MusicOSD.xml
+++ b/addons/skin.confluence/720p/MusicOSD.xml
@@ -259,15 +259,26 @@
 				<onclick>PlayerControl(Random)</onclick>
 			</control>
 			<control type="image" id="2300">
-				<width>160</width>
+				<width>215</width>
 				<height>55</height>
 				<texture>-</texture>
-				<visible>!MusicPlayer.Content(LiveTV)</visible>
+				<visible>!MusicPlayer.Content(LiveTV) + Player.CanRecord</visible>
 			</control>
 			<control type="image" id="2400">
 				<width>215</width>
 				<texture>-</texture>
 				<visible>MusicPlayer.Content(LiveTV)</visible>
+			</control>
+			<control type="image" id="2500">
+				<width>270</width>
+				<height>55</height>
+				<texture>-</texture>
+				<visible>!MusicPlayer.Content(LiveTV) + !Player.CanRecord + !system.getbool(audiooutput.dspaddonsenabled)</visible>
+			</control>
+			<control type="image" id="2600">
+				<width>215</width>
+				<texture>-</texture>
+				<visible>system.getbool(audiooutput.dspaddonsenabled)</visible>
 			</control>
 			<control type="button" id="700">
 				<visible>system.getbool(audiooutput.dspaddonsenabled)</visible>
@@ -332,8 +343,7 @@
 				<texturefocus>OSDRecordOffFO.png</texturefocus>
 				<texturenofocus>OSDRecordOffNF.png</texturenofocus>
 				<onclick>PlayerControl(record)</onclick>
-				<enable>Player.CanRecord</enable>
-				<animation effect="fade" start="100" end="50" time="75" condition="!Player.CanRecord">Conditional</animation>
+				<visible>Player.CanRecord</visible>
 			</control>
 		</control>
 	</controls>

--- a/addons/skin.confluence/720p/VideoOSD.xml
+++ b/addons/skin.confluence/720p/VideoOSD.xml
@@ -174,12 +174,17 @@
 			<control type="image" id="2200">
 				<width>270</width>
 				<texture>-</texture>
-				<visible>!VideoPlayer.Content(LiveTV)</visible>
+				<visible>VideoPlayer.HasMenu + !VideoPlayer.Content(LiveTV)</visible>
 			</control>
 			<control type="image" id="2300">
 				<width>165</width>
 				<texture>-</texture>
 				<visible>VideoPlayer.Content(LiveTV)</visible>
+			</control>
+			<control type="image" id="2600">
+				<width>325</width>
+				<texture>-</texture>
+				<visible>!VideoPlayer.Content(LiveTV) + !VideoPlayer.HasMenu</visible>
 			</control>
 			<control type="button" id="255">
 				<enable>VideoPlayer.IsStereoscopic</enable>
@@ -250,9 +255,7 @@
 				<onup>1000</onup>
 				<ondown>1000</ondown>
 				<onclick>PlayerControl(ShowVideoMenu)</onclick>
-				<enable>VideoPlayer.HasMenu</enable>
-				<animation effect="fade" start="100" end="50" time="75" condition="!VideoPlayer.HasMenu">Conditional</animation>
-				<visible>!VideoPlayer.Content(LiveTV)</visible>
+				<visible>!VideoPlayer.Content(LiveTV) + VideoPlayer.HasMenu</visible>
 			</control>
 			<control type="togglebutton" id="353">
 				<width>55</width>
@@ -290,7 +293,7 @@
 			<animation effect="fade" time="150">VisibleChange</animation>
 			<animation effect="slide" start="0,0" end="0,80" time="0" condition="![VideoPlayer.HasSubtitles + VideoPlayer.SubtitlesEnabled]">Conditional</animation>
 			<animation effect="slide" start="0,0" end="0,40" time="0" condition="!VideoPlayer.HasSubtitles">Conditional</animation>
-			<animation effect="slide" start="0,0" end="55,0" time="0" condition="VideoPlayer.Content(LiveTV)">Conditional</animation>
+			<animation effect="slide" start="0,0" end="55,0" time="0" condition="![VideoPlayer.HasMenu | VideoPlayer.Content(LiveTV)]">Conditional</animation>
 			<right>145</right>
 			<bottom>45</bottom>
 			<width>256</width>


### PR DESCRIPTION
@da-anda @phil65 @ronie 

**MusicOSD** 
**1)** Had the alignment fix (tested) for player controls it was just too far left imo.
**2)** Also added visible condition that should allow the record button to become active/visible when the player can record stream **this change is untested** as I dont use PVR or any circumstances where `PlayerControl(record)` becomes selectable at all. **Please advise on this visible condition change** does it also need `Player.Recording`?

---

**Note 1:** There are MusicOSD buttons for accessing playlists that is never shown its part of skin textures but no used in skin, any idea why this is @ronie @phil65?

**Note 2:** Ive adjusted and added  **visible condition for the gap** so that the osd controls aligns on the left hand side irrespective if item is visible or invisible @phil65 please check

---

Before
![screenshot000](https://cloud.githubusercontent.com/assets/3521959/9223004/4813c9a6-40ee-11e5-8cb0-697d1110fa7c.png)

After - With conditional gap
![screenshot009](https://cloud.githubusercontent.com/assets/3521959/9225589/48b904a2-4102-11e5-98c8-ddea99fbd79d.png)

**VideoOSD** 
**1)** had visible condition applied to the DVD button, which is only usable when you are playing a DVD/DIsk which has menus `VideoPlayer.HasMenu` this was tested and seems to work as desired.

Before - playing a normal video
![screenshot001](https://cloud.githubusercontent.com/assets/3521959/9223065/cce66b52-40ee-11e5-97b1-c624b5b1b4ae.png)

After - playing a normal video
 ![screenshot005](https://cloud.githubusercontent.com/assets/3521959/9225570/1c05b9dc-4102-11e5-82d1-ea1d450f2e41.png)

After Playing normal video (subtitle submenu adjustment)
![screenshot006](https://cloud.githubusercontent.com/assets/3521959/9444145/f1409620-4a7c-11e5-9a10-2fe6a78ed3cb.png)

After - playing a DVD
![screenshot004](https://cloud.githubusercontent.com/assets/3521959/9223095/15b440b6-40ef-11e5-9ea7-1c8003777f6d.png)

After - playing a DVD (subtitle submenu normal position)
![screenshot007](https://cloud.githubusercontent.com/assets/3521959/9444256/78a8e6ee-4a7d-11e5-9803-1ddf270ac069.png)
