### PR TITLE
[xbmc][win32] Fixes side flyout appearing when using touch

### DIFF
--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -661,7 +661,8 @@ bool CGUIWindow::OnMessage(CGUIMessage& message)
     {
       CAction action(ACTION_GESTURE_NOTIFY, 0, (float)message.GetParam1(), (float)message.GetParam2(), 0, 0);
       EVENT_RESULT result = OnMouseAction(action);
-      message.SetParam1(result);
+      auto res = new int(result);
+      message.SetPointer(static_cast<void*>(res));
       return result != EVENT_RESULT_UNHANDLED;
     }
   case GUI_MSG_ADD_CONTROL:

--- a/xbmc/input/touch/generic/GenericTouchActionHandler.cpp
+++ b/xbmc/input/touch/generic/GenericTouchActionHandler.cpp
@@ -150,7 +150,15 @@ int CGenericTouchActionHandler::QuerySupportedGestures(float x, float y)
   if (!g_windowManager.SendMessage(msg))
     return 0;
 
-  return msg.GetParam1();
+  int result = 0;
+  if (msg.GetPointer())
+  {
+    int *p = static_cast<int*>(msg.GetPointer());
+    msg.SetPointer(nullptr);
+    result = *p;
+    delete p;
+  }
+  return result;
 }
 
 void CGenericTouchActionHandler::touch(uint8_t type, uint8_t button, uint16_t x, uint16_t y)


### PR DESCRIPTION
When querying for gesture capable controls the result was written over the x coordinate of the event and resent causing the flyout to think there's a mouseover.
closes trac #16173
