### PR TITLE
[coverity] Possible fix for coverity 1194411

### DIFF
--- a/lib/UnrarXLib/file.cpp
+++ b/lib/UnrarXLib/file.cpp
@@ -39,6 +39,7 @@ File::~File()
       Close();*/
   m_File.Close();
   delete &m_File;
+  delete m_File;
 }
 
 


### PR DESCRIPTION
This is a try at fixing coverity issue #1194411. The way I understand it, we're freeing the memory of the created *(new XFILE::CFile()) but not the outer m_file variable. I hope I'm right with this fix.

I wonder if it would suffice to just use "delete m_file" and whether that would cascade delete the memory we allocated from the constructor as well.
