### PR TITLE
[xbmc] volume adjustment fix for trac #16063

### DIFF
--- a/system/keymaps/joystick.Sony.PLAYSTATION(R)3.Controller.xml
+++ b/system/keymaps/joystick.Sony.PLAYSTATION(R)3.Controller.xml
@@ -93,8 +93,10 @@
       <button id="3">ActivateWindow(PlayerControls)</button>
       <axis id="1">AnalogSeekForward</axis>
       <axis id="2">AnalogSeekBack</axis>
-      <axis id="3">VolumeUp</axis>
-      <axis id="4">VolumeDown</axis>
+      <axis id="3" limit="+1">VolumeUp</axis>
+      <axis id="3" limit="-1">VolumeDown</axis>
+      <axis id="4" limit="+1">VolumeDown</axis>
+      <axis id="4" limit="-1">VolumeUp</axis>
       <axis trigger="true" rest="-32768" id="13">ScrollUp</axis>
       <axis trigger="true" rest="-32768" id="14">ScrollDown</axis>
       <button id="5">Up</button>

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2450,9 +2450,9 @@ bool CApplication::OnAction(const CAction &action)
         step *= action.GetRepeat() * 50; // 50 fps
 #endif
       if (action.GetID() == ACTION_VOLUME_UP)
-        volume += (float)fabs(action.GetAmount()) * action.GetAmount() * step;
+        volume += (float)(action.GetAmount() * action.GetAmount() * step);
       else if (action.GetID() == ACTION_VOLUME_DOWN)
-        volume -= (float)fabs(action.GetAmount()) * action.GetAmount() * step;
+        volume -= (float)(action.GetAmount() * action.GetAmount() * step);
       else
         volume = action.GetAmount() * step;
       if (volume != m_volumeLevel)


### PR DESCRIPTION
See [trac #16063](http://trac.kodi.tv/ticket/16063).

There's quite a few places where we can solve this problem, but am not sure which is the most correct one.

`CButtonTranslator` maps axis movements to actions. This part works correctly w.r.t. the keymap. Moving the right trigger axis upwards results in a VolumeUp action with positive amount. Moving this same trigger axis downwards results in a VolumeDown action with negative amount parameter. Negative times negative results in a volume up, hence the odd behavior we're seeing. The other axis is simply inverted due to the keymap.

But then, why do seeking movements work correctly, seeing as they are specified in a similar way in the keymap? Well, `CSeekHandler::Seek` determines the seek amount as `amount * amount * ...` which gets rid of the negative amount, and instead uses the action id to determine whether this seek goes forward or backward. The action handler for volume changes makes an effort to respect the negative amount on either action.

```
if (action.GetID() == ACTION_VOLUME_UP)
  volume += (float)fabs(action.GetAmount()) * action.GetAmount() * step;
else if (action.GetID() == ACTION_VOLUME_DOWN)
  volume -= (float)fabs(action.GetAmount()) * action.GetAmount() * step;
```

So how do we fix this? I can think of 3 ways:
1. Simply remove the `limit=x` from the keymap. Mapping the entire axis in both direction to VolumeUp is enough. When moving the axis left, the amount becomes negative and a VolumeDown is effectively applied. This would have to be synchronized among all keymaps, but requires no code changes. Downside is that we would still have a dissimilarity in the way seeking and volume changes are handled.
2. Change the handler for volume actions so that VolumeUp and VolumeDown disregard the sign of the amount to change the volume by. This makes sure seeking and volume changes are handled in a similar way w.r.t. negative amounts. Keymaps for joysticks that already used the workaround from 1) should be updated to reflect this.
3. Always consider the amount of axis movement to be positive on keymap entries that include a `limit=` attribute. I do think this makes sense. 

Personally I opted for option 2. Only the ps3 keymap seems to have used the workaround.
