### PR TITLE
add timer addition to PVR functions in json. 

### DIFF
--- a/xbmc/interfaces/json-rpc/JSONServiceDescription.cpp
+++ b/xbmc/interfaces/json-rpc/JSONServiceDescription.cpp
@@ -175,6 +175,7 @@ JsonRpcMethodMap CJSONServiceDescription::m_methodMaps[] = {
   { "PVR.GetTimerDetails",                          CPVROperations::GetTimerDetails },
   { "PVR.GetRecordings",                            CPVROperations::GetRecordings },
   { "PVR.GetRecordingDetails",                      CPVROperations::GetRecordingDetails },
+  { "PVR.AddTimer",                                 CPVROperations::AddTimer },
   { "PVR.Record",                                   CPVROperations::Record },
   { "PVR.Scan",                                     CPVROperations::Scan },
 

--- a/xbmc/interfaces/json-rpc/PVROperations.cpp
+++ b/xbmc/interfaces/json-rpc/PVROperations.cpp
@@ -338,6 +338,49 @@ JSONRPC_STATUS CPVROperations::GetTimerDetails(const std::string &method, ITrans
   return OK;
 }
 
+JSONRPC_STATUS CPVROperations::AddTimer(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)
+{
+	if (!g_PVRManager.IsStarted())
+		return FailedToExecute;
+
+	EpgSearchFilter filter;
+	filter.Reset();
+	filter.m_iUniqueBroadcastId=(int)parameterObject["broadcastid"].asInteger();
+
+	CFileItemList broadcasts;
+	int resultSize = g_EpgContainer.GetEPGSearch(broadcasts,filter);
+    
+    if (resultSize <= 0)
+        return InvalidParams;
+    else if (resultSize > 1)
+        return InternalError;
+
+    CFileItemPtr broadcast = broadcasts.Get(0);
+
+    CEpgInfoTagPtr epgTag = broadcast->GetEPGInfoTag();
+    if (!epgTag)
+        return InternalError;
+    
+    bool repeating =(bool)parameterObject["repeating"].asBoolean(false);
+
+    if (epgTag->Timer() == NULL)
+    {
+        CPVRTimerInfoTagPtr newTimer = CPVRTimerInfoTag::CreateFromEpg(epgTag,repeating);
+        if (newTimer)
+        {
+            CPVRTimers* timers = g_PVRTimers;
+            bool added = timers->AddTimer(newTimer);
+            if (added) {
+               HandleFileItem("timerid", false, "timerdetails", CFileItemPtr(new CFileItem(newTimer)), parameterObject, parameterObject["properties"], result, false);
+               return OK;
+            }
+        }
+        return FailedToExecute;
+    }
+    return FailedToExecute;
+    
+}
+
 JSONRPC_STATUS CPVROperations::GetRecordings(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)
 {
   if (!g_PVRManager.IsStarted())

--- a/xbmc/interfaces/json-rpc/PVROperations.h
+++ b/xbmc/interfaces/json-rpc/PVROperations.h
@@ -41,6 +41,7 @@ namespace JSONRPC
     static JSONRPC_STATUS GetRecordings(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result);
     static JSONRPC_STATUS GetRecordingDetails(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result);
 
+    static JSONRPC_STATUS AddTimer(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result);
     static JSONRPC_STATUS Record(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result);
     static JSONRPC_STATUS Scan(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result);
 

--- a/xbmc/interfaces/json-rpc/schema/methods.json
+++ b/xbmc/interfaces/json-rpc/schema/methods.json
@@ -1836,6 +1836,22 @@
       }
     }
   },
+  "PVR.AddTimer": {
+    "type": "method",
+    "description": "Adds a timer",
+    "transport": "Response",
+    "permission": "ControlPVR",
+    "params": [
+      { "name": "broadcastid", "$ref": "Library.Id", "required": true },
+      { "name": "repeating", "type": "boolean" },
+      { "name": "properties", "$ref": "PVR.Fields.Broadcast" }
+    ],
+    "returns": { "type": "object",
+      "properties": {
+        "timerdetails": { "$ref": "PVR.Details.Timer" }
+      }
+    }
+  },
   "PVR.GetRecordings": {
     "type": "method",
     "description": "Retrieves the recordings",

--- a/xbmc/interfaces/json-rpc/schema/types.json
+++ b/xbmc/interfaces/json-rpc/schema/types.json
@@ -780,6 +780,31 @@
       "enum": [ "thumbnail", "channeltype", "hidden", "locked", "channel", "lastplayed", "broadcastnow", "broadcastnext" ]
     }
   },
+  "PVR.Details.Broadcast": {
+    "extends": "Item.Details.Base",
+    "properties": {
+      "broadcastid": { "$ref": "Library.Id", "required": true },
+      "title": { "type": "string" },
+      "plot": { "type": "string" },
+      "plotoutline": { "type": "string" },
+      "starttime": { "type": "string" },
+      "endtime": { "type": "string" },
+      "runtime": { "type": "integer" },
+      "progress": { "type": "integer" },
+      "progresspercentage": { "type": "number" },
+      "genre": { "type": "string" },
+      "episodename": { "type": "string" },
+      "episodenum": { "type": "integer" },
+      "episodepart": { "type": "integer" },
+      "firstaired": { "type": "string" },
+      "hastimer": { "type": "boolean" },
+      "isactive": { "type": "boolean" },
+      "parentalrating": { "type": "integer" },
+      "wasactive": { "type": "boolean" },
+      "thumbnail": { "type": "string" },
+      "rating": { "type": "integer" }
+    }
+  },
   "PVR.Details.Channel": {
     "extends": "Item.Details.Base",
     "properties": {
@@ -818,31 +843,6 @@
                 "genre", "episodename", "episodenum", "episodepart",
                 "firstaired", "hastimer", "isactive", "parentalrating",
                 "wasactive", "thumbnail", "rating" ]
-    }
-  },
-  "PVR.Details.Broadcast": {
-    "extends": "Item.Details.Base",
-    "properties": {
-      "broadcastid": { "$ref": "Library.Id", "required": true },
-      "title": { "type": "string" },
-      "plot": { "type": "string" },
-      "plotoutline": { "type": "string" },
-      "starttime": { "type": "string" },
-      "endtime": { "type": "string" },
-      "runtime": { "type": "integer" },
-      "progress": { "type": "integer" },
-      "progresspercentage": { "type": "number" },
-      "genre": { "type": "string" },
-      "episodename": { "type": "string" },
-      "episodenum": { "type": "integer" },
-      "episodepart": { "type": "integer" },
-      "firstaired": { "type": "string" },
-      "hastimer": { "type": "boolean" },
-      "isactive": { "type": "boolean" },
-      "parentalrating": { "type": "integer" },
-      "wasactive": { "type": "boolean" },
-      "thumbnail": { "type": "string" },
-      "rating": { "type": "integer" }
     }
   },
   "PVR.TimerState": {
@@ -1365,6 +1365,13 @@
     "type": "string",
     "enum": [ "currentwindow", "currentcontrol", "skin", "fullscreen", "stereoscopicmode" ]
   },
+  "GUI.Stereoscopy.Mode": {
+    "type": "object",
+    "properties": {
+      "mode": { "type": "string", "required": true, "enum": [ "off", "split_vertical", "split_horizontal", "row_interleaved", "hardware_based", "anaglyph_cyan_red", "anaglyph_green_magenta", "anaglyph_yellow_blue", "monoscopic" ] },
+      "label": { "type": "string", "required": true }
+    }
+  },
   "GUI.Property.Value": {
     "type": "object",
     "properties": {
@@ -1387,13 +1394,6 @@
       },
       "fullscreen": { "type": "boolean" },
       "stereoscopicmode": { "$ref": "GUI.Stereoscopy.Mode" }
-    }
-  },
-  "GUI.Stereoscopy.Mode": {
-    "type": "object",
-    "properties": {
-      "mode": { "type": "string", "required": true, "enum": [ "off", "split_vertical", "split_horizontal", "row_interleaved", "hardware_based", "anaglyph_cyan_red", "anaglyph_green_magenta", "anaglyph_yellow_blue", "monoscopic" ] },
-      "label": { "type": "string", "required": true }
     }
   },
   "System.Property.Name": {
@@ -1638,6 +1638,18 @@
     "extends": "Setting.Details.SettingBase",
     "additionalProperties": false
   },
+  "Setting.Details.Setting": {
+    "type": [
+      { "$ref": "Setting.Details.SettingBool", "required": true },
+      { "$ref": "Setting.Details.SettingInt", "required": true },
+      { "$ref": "Setting.Details.SettingNumber", "required": true },
+      { "$ref": "Setting.Details.SettingString", "required": true },
+      { "$ref": "Setting.Details.SettingAction", "required": true },
+      { "$ref": "Setting.Details.SettingList", "required": true },
+      { "$ref": "Setting.Details.SettingPath", "required": true },
+      { "$ref": "Setting.Details.SettingAddon", "required": true }
+    ]
+  },  
   "Setting.Details.SettingList": {
     "extends": "Setting.Details.SettingBase",
     "properties": {
@@ -1665,18 +1677,6 @@
       "addontype": { "$ref": "Addon.Types", "required": true }
     },
     "additionalProperties": false
-  },
-  "Setting.Details.Setting": {
-    "type": [
-      { "$ref": "Setting.Details.SettingBool", "required": true },
-      { "$ref": "Setting.Details.SettingInt", "required": true },
-      { "$ref": "Setting.Details.SettingNumber", "required": true },
-      { "$ref": "Setting.Details.SettingString", "required": true },
-      { "$ref": "Setting.Details.SettingAction", "required": true },
-      { "$ref": "Setting.Details.SettingList", "required": true },
-      { "$ref": "Setting.Details.SettingPath", "required": true },
-      { "$ref": "Setting.Details.SettingAddon", "required": true }
-    ]
   },
   "Setting.Details.Group": {
     "type": "object",


### PR DESCRIPTION
Allows a timer to be added via json-rpc.
Also a little reordering of the definition of the json types and methods so that it does't error on startup (seems like the definitions need to be done before they are referenced by another element further down).
