### PR TITLE
[coverity] Fix #1126020

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
@@ -1968,31 +1968,9 @@ void CMixer::SetSharpness()
 
 EINTERLACEMETHOD CMixer::GetDeinterlacingMethod(bool log /* = false */)
 {
-  EINTERLACEMETHOD method = CMediaSettings::GetInstance().GetCurrentVideoSettings().m_InterlaceMethod;
-  if (method == VS_INTERLACEMETHOD_AUTO)
-  {
-    int deint = -1;
-//    if (m_config.outHeight >= 720)
-//      deint = g_advancedSettings.m_videoVDPAUdeintHD;
-//    else
-//      deint = g_advancedSettings.m_videoVDPAUdeintSD;
-
-    if (deint != -1)
-    {
-      if (m_config.vdpau->Supports(EINTERLACEMETHOD(deint)))
-      {
-        method = EINTERLACEMETHOD(deint);
-        if (log)
-          CLog::Log(LOGNOTICE, "CVDPAU::GetDeinterlacingMethod: set de-interlacing to %d",  deint);
-      }
-      else
-      {
-        if (log)
-          CLog::Log(LOGWARNING, "CVDPAU::GetDeinterlacingMethod: method for de-interlacing (advanced settings) not supported");
-      }
-    }
-  }
-  return method;
+  // XXX: Ideally, the deinterlacing method should be detected at runtime.
+  // See https://github.com/xbmc/xbmc/pull/7799 for discussion.
+  return CMediaSettings::GetInstance().GetCurrentVideoSettings().m_InterlaceMethod;
 }
 
 void CMixer::SetDeinterlacing()


### PR DESCRIPTION
This fixes coverity #1126020.

I boldly removed the dead code that wasn't doing anything anyway (the variable deint was set to -1 and doesn't change later in the function so the if statement never executes).

The code that introduced this was authored in April 2012, and such I doubt that anyone is still working on this part. See https://github.com/xbmc/xbmc/blame/master/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp#L1969
