### PR TITLE
[xbmc][appmessenger] Add the ability to open dialogyesno by sending a threadmessage.

### DIFF
--- a/Kodi.xcodeproj/project.pbxproj
+++ b/Kodi.xcodeproj/project.pbxproj
@@ -255,6 +255,9 @@
 		39B4F3701B96F845009B2D88 /* RepositoryUpdater.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 39B4F36E1B96F845009B2D88 /* RepositoryUpdater.cpp */; };
 		39B4F3711B96F845009B2D88 /* RepositoryUpdater.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 39B4F36E1B96F845009B2D88 /* RepositoryUpdater.cpp */; };
 		39B4F3721B96F845009B2D88 /* RepositoryUpdater.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 39B4F36E1B96F845009B2D88 /* RepositoryUpdater.cpp */; };
+		39BD2AD81B845D40004A5A15 /* DialogHelper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 39BD2AD71B845D40004A5A15 /* DialogHelper.cpp */; };
+		39BD2AD91B845D40004A5A15 /* DialogHelper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 39BD2AD71B845D40004A5A15 /* DialogHelper.cpp */; };
+		39BD2ADA1B845D40004A5A15 /* DialogHelper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 39BD2AD71B845D40004A5A15 /* DialogHelper.cpp */; };
 		4260D5C71B67BB8F003F6F2D /* GUIWindowSplash.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4260D5C51B67BB8F003F6F2D /* GUIWindowSplash.cpp */; };
 		4260D5C81B67BB8F003F6F2D /* GUIWindowSplash.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4260D5C51B67BB8F003F6F2D /* GUIWindowSplash.cpp */; };
 		4260D5C91B67BB8F003F6F2D /* GUIWindowSplash.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4260D5C51B67BB8F003F6F2D /* GUIWindowSplash.cpp */; };
@@ -3652,6 +3655,8 @@
 		3994427E1A8DD96F006C39E9 /* VideoLibraryQueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VideoLibraryQueue.h; sourceTree = "<group>"; };
 		39B4F36E1B96F845009B2D88 /* RepositoryUpdater.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RepositoryUpdater.cpp; sourceTree = "<group>"; };
 		39B4F36F1B96F845009B2D88 /* RepositoryUpdater.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RepositoryUpdater.h; sourceTree = "<group>"; };
+		39BD2AD61B845D40004A5A15 /* DialogHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DialogHelper.h; path = helpers/DialogHelper.h; sourceTree = "<group>"; };
+		39BD2AD71B845D40004A5A15 /* DialogHelper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DialogHelper.cpp; path = helpers/DialogHelper.cpp; sourceTree = "<group>"; };
 		4260D5C51B67BB8F003F6F2D /* GUIWindowSplash.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GUIWindowSplash.cpp; sourceTree = "<group>"; };
 		4260D5C61B67BB8F003F6F2D /* GUIWindowSplash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GUIWindowSplash.h; sourceTree = "<group>"; };
 		42DAC16B1A6E780C0066B4C8 /* IActionListener.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IActionListener.h; sourceTree = "<group>"; };
@@ -6453,6 +6458,15 @@
 			path = jobs;
 			sourceTree = "<group>";
 		};
+		39BD2AD51B845D1E004A5A15 /* helpers */ = {
+			isa = PBXGroup;
+			children = (
+				39BD2AD71B845D40004A5A15 /* DialogHelper.cpp */,
+				39BD2AD61B845D40004A5A15 /* DialogHelper.h */,
+			);
+			name = helpers;
+			sourceTree = "<group>";
+		};
 		430C880812D649B10098821A /* powermanagement */ = {
 			isa = PBXGroup;
 			children = (
@@ -7966,6 +7980,7 @@
 		DF4A3BAC1B4B0FC100F9CDC0 /* messaging */ = {
 			isa = PBXGroup;
 			children = (
+				39BD2AD51B845D1E004A5A15 /* helpers */,
 				DF4A3BAD1B4B0FC100F9CDC0 /* ApplicationMessenger.cpp */,
 				DF4A3BAE1B4B0FC100F9CDC0 /* ApplicationMessenger.h */,
 				DF4A3BAF1B4B0FC100F9CDC0 /* IMessageTarget.h */,
@@ -10744,6 +10759,7 @@
 				18B7C3841294203F009E7A26 /* AddonDatabase.cpp in Sources */,
 				18B7C38A12942090009E7A26 /* GUIDialogAddonInfo.cpp in Sources */,
 				18B7C38B12942090009E7A26 /* GUIViewStateAddonBrowser.cpp in Sources */,
+				39BD2AD81B845D40004A5A15 /* DialogHelper.cpp in Sources */,
 				18B7C392129420E5009E7A26 /* Settings.cpp in Sources */,
 				18B7C3A812942132009E7A26 /* AdvancedSettings.cpp in Sources */,
 				395C29DB1A98A11C00EBC7AD /* WsgiResponse.cpp in Sources */,
@@ -11514,6 +11530,7 @@
 				B5011E4319AF3B56005ADF89 /* PosixFile.cpp in Sources */,
 				DFF0F19E17528350002DA3A4 /* Edl.cpp in Sources */,
 				DFF0F19F17528350002DA3A4 /* ExternalPlayer.cpp in Sources */,
+				39BD2ADA1B845D40004A5A15 /* DialogHelper.cpp in Sources */,
 				DFF0F1A217528350002DA3A4 /* AudioDecoder.cpp in Sources */,
 				DFF0F1A317528350002DA3A4 /* CodecFactory.cpp in Sources */,
 				DFF0F1A417528350002DA3A4 /* DVDPlayerCodec.cpp in Sources */,
@@ -12967,6 +12984,7 @@
 				E49913B6174E5F3C00741B6D /* AirPlayServer.cpp in Sources */,
 				E49913B7174E5F3C00741B6D /* AirTunesServer.cpp in Sources */,
 				E49913B8174E5F3C00741B6D /* cddb.cpp in Sources */,
+				39BD2AD91B845D40004A5A15 /* DialogHelper.cpp in Sources */,
 				E49913B9174E5F3C00741B6D /* DNSNameCache.cpp in Sources */,
 				E49913BA174E5F3C00741B6D /* EventClient.cpp in Sources */,
 				E49913BB174E5F3C00741B6D /* EventPacket.cpp in Sources */,

--- a/Makefile.in
+++ b/Makefile.in
@@ -60,6 +60,7 @@ DIRECTORY_ARCHIVES=$(DVDPLAYER_ARCHIVES) \
                    xbmc/main/posix/MessagePrinter.a \
                    xbmc/media/media.a \
                    xbmc/messaging/messaging.a \
+				   xbmc/messaging/helpers/messagingHelpers.a \
                    xbmc/music/dialogs/musicdialogs.a \
                    xbmc/music/infoscanner/musicscanner.a \
                    xbmc/music/karaoke/karaoke.a \

--- a/Makefile.in
+++ b/Makefile.in
@@ -60,7 +60,7 @@ DIRECTORY_ARCHIVES=$(DVDPLAYER_ARCHIVES) \
                    xbmc/main/posix/MessagePrinter.a \
                    xbmc/media/media.a \
                    xbmc/messaging/messaging.a \
-				   xbmc/messaging/helpers/messagingHelpers.a \
+                   xbmc/messaging/helpers/messagingHelpers.a \
                    xbmc/music/dialogs/musicdialogs.a \
                    xbmc/music/infoscanner/musicscanner.a \
                    xbmc/music/karaoke/karaoke.a \

--- a/configure.ac
+++ b/configure.ac
@@ -2374,6 +2374,7 @@ OUTPUT_FILES="Makefile \
     xbmc/cores/omxplayer/Makefile \
     xbmc/cores/playercorefactory/Makefile \
     xbmc/messaging/Makefile \
+    xbmc/messaging/helpers/Makefile \
     xbmc/music/karaoke/Makefile \
     xbmc/osx/Makefile \
     xbmc/guilib/Makefile \

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -626,6 +626,7 @@
     <ClCompile Include="..\..\xbmc\MediaSource.cpp" />
     <ClCompile Include="..\..\xbmc\media\MediaType.cpp" />
     <ClCompile Include="..\..\xbmc\messaging\ApplicationMessenger.cpp" />
+    <ClCompile Include="..\..\xbmc\messaging\helpers\DialogHelper.cpp" />
     <ClCompile Include="..\..\xbmc\music\Album.cpp" />
     <ClCompile Include="..\..\xbmc\music\Artist.cpp" />
     <ClCompile Include="..\..\xbmc\music\CueInfoLoader.cpp" />
@@ -1045,6 +1046,7 @@
     <ClInclude Include="..\..\xbmc\main\win32\MessagePrinter.h" />
     <ClInclude Include="..\..\xbmc\media\MediaType.h" />
     <ClInclude Include="..\..\xbmc\messaging\ApplicationMessenger.h" />
+    <ClInclude Include="..\..\xbmc\messaging\helpers\DialogHelper.h" />
     <ClInclude Include="..\..\xbmc\messaging\IMessageTarget.h" />
     <ClInclude Include="..\..\xbmc\messaging\ThreadMessage.h" />
     <ClInclude Include="..\..\xbmc\music\CueInfoLoader.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -364,6 +364,9 @@
     <Filter Include="events\windows">
       <UniqueIdentifier>{87d4e872-1a96-49a2-9ef0-78dd9fc30da9}</UniqueIdentifier>
     </Filter>
+    <Filter Include="messaging\helpers">
+      <UniqueIdentifier>{b0eadc46-feeb-4aca-9898-590e6b8d29b3}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\xbmc\win32\pch.cpp">
@@ -3191,6 +3194,9 @@
     </ClCompile>
     <ClCompile Include="..\..\xbmc\guilib\Gif.cpp">
       <Filter>guilib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\xbmc\messaging\helpers\DialogHelper.cpp">
+      <Filter>messaging\helpers</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -6189,6 +6195,9 @@
     </ClInclude>
     <ClInclude Include="..\..\xbmc\guilib\Gif.h">
       <Filter>guilib</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\messaging\helpers\DialogHelper.h">
+      <Filter>messaging\helpers</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -60,6 +60,7 @@
 #include "input/InertialScrollingHandler.h"
 #include "messaging/ThreadMessage.h"
 #include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/DialogHelper.h"
 #include "SectionLoader.h"
 #include "cores/DllLoader/DllLoaderContainer.h"
 #include "GUIUserMessages.h"
@@ -149,7 +150,6 @@
 
 // Dialog includes
 #include "video/dialogs/GUIDialogVideoBookmarks.h"
-#include "dialogs/GUIDialogYesNo.h"
 #include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogKaiToast.h"
 #include "dialogs/GUIDialogSubMenu.h"
@@ -250,6 +250,8 @@ using namespace KODI::MESSAGING;
 using namespace ActiveAE;
 
 using namespace XbmcThreads;
+
+using KODI::MESSAGING::HELPERS::DialogResponse;
 
 // uncomment this if you want to use release libs in the debug build.
 // Atm this saves you 7 mb of memory
@@ -1569,8 +1571,8 @@ void CApplication::ReloadSkin(bool confirm/*=false*/)
        user as to whether they want to keep the current skin. */
     if (confirm && !m_skinReverting)
     {
-      bool cancelled;
-      if (!CGUIDialogYesNo::ShowAndGetInput(CVariant{13123}, CVariant{13111}, cancelled, CVariant{""}, CVariant{""}, 10000))
+      if (HELPERS::ShowYesNoDialogText(CVariant{13123}, CVariant{13111}, CVariant{""}, CVariant{""}, 10000) != 
+        DialogResponse::YES)
       {
         m_skinReverting = true;
         if (oldSkin.empty())

--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -33,6 +33,8 @@
 #include "filesystem/Directory.h"
 #include "filesystem/DirectoryFactory.h"
 #include "filesystem/File.h"
+#include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/DialogHelper.h"
 #include "profiles/ProfilesManager.h"
 #include "settings/Settings.h"
 #include "playlists/PlayList.h"
@@ -40,7 +42,6 @@
 #include "guilib/LocalizeStrings.h"
 #include "storage/MediaManager.h"
 #include "video/VideoDatabase.h"
-#include "dialogs/GUIDialogYesNo.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
@@ -52,6 +53,9 @@
 using namespace XFILE;
 using namespace PLAYLIST;
 using namespace MEDIA_DETECT;
+using namespace KODI::MESSAGING;
+
+using KODI::MESSAGING::HELPERS::DialogResponse;
 
 CAutorun::CAutorun()
 {
@@ -491,7 +495,9 @@ bool CAutorun::IsEnabled() const
 
 bool CAutorun::PlayDiscAskResume(const std::string& path)
 {
-  return PlayDisc(path, true, !CanResumePlayDVD(path) || CGUIDialogYesNo::ShowAndGetInput(CVariant{341}, CVariant{""}, CVariant{""}, CVariant{""}, CVariant{13404}, CVariant{12021}));
+  return PlayDisc(path, true, !CanResumePlayDVD(path) ||
+    HELPERS::ShowYesNoDialogText(CVariant{341}, CVariant{""}, CVariant{13404}, CVariant{12021}) == 
+    DialogResponse::YES);
 }
 
 bool CAutorun::CanResumePlayDVD(const std::string& path)

--- a/xbmc/addons/AddonCallbacksGUI.cpp
+++ b/xbmc/addons/AddonCallbacksGUI.cpp
@@ -20,6 +20,7 @@
 
 #include "Application.h"
 #include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/DialogHelper.h"
 #include "Addon.h"
 #include "AddonCallbacksGUI.h"
 #include "utils/log.h"
@@ -40,7 +41,6 @@
 #include "guilib/GUIKeyboardFactory.h"
 #include "dialogs/GUIDialogNumeric.h"
 #include "dialogs/GUIDialogOK.h"
-#include "dialogs/GUIDialogYesNo.h"
 #include "dialogs/GUIDialogFileBrowser.h"
 #include "dialogs/GUIDialogTextViewer.h"
 #include "dialogs/GUIDialogSelect.h"
@@ -51,6 +51,7 @@
 #define CONTROL_LABELFILES      12
 
 using namespace KODI::MESSAGING;
+using KODI::MESSAGING::HELPERS::DialogResponse;
 
 namespace ADDON
 {
@@ -1862,17 +1863,22 @@ void CAddonCallbacksGUI::Dialog_OK_ShowAndGetInputLineText(const char *heading, 
 //@{
 bool CAddonCallbacksGUI::Dialog_YesNo_ShowAndGetInputSingleText(const char *heading, const char *text, bool& bCanceled, const char *noLabel, const char *yesLabel)
 {
-  return CGUIDialogYesNo::ShowAndGetInput(CVariant{heading}, CVariant{text}, CVariant{bCanceled}, CVariant{noLabel}, CVariant{yesLabel});
+  DialogResponse result = HELPERS::ShowYesNoDialogText(heading, text, noLabel, yesLabel);
+  bCanceled = result == DialogResponse::CANCELLED;
+  return result == DialogResponse::YES;
 }
 
 bool CAddonCallbacksGUI::Dialog_YesNo_ShowAndGetInputLineText(const char *heading, const char *line0, const char *line1, const char *line2, const char *noLabel, const char *yesLabel)
 {
-  return CGUIDialogYesNo::ShowAndGetInput(CVariant{heading}, CVariant{line0}, CVariant{line1}, CVariant{line2}, CVariant{noLabel}, CVariant{yesLabel});
+  return HELPERS::ShowYesNoDialogLines(heading, line0, line1, line2, noLabel, yesLabel) ==
+    DialogResponse::YES;
 }
 
 bool CAddonCallbacksGUI::Dialog_YesNo_ShowAndGetInputLineButtonText(const char *heading, const char *line0, const char *line1, const char *line2, bool &bCanceled, const char *noLabel, const char *yesLabel)
 {
-  return CGUIDialogYesNo::ShowAndGetInput(CVariant{heading}, CVariant{line0}, CVariant{line1}, CVariant{line2}, bCanceled, CVariant{noLabel}, CVariant{yesLabel}, CGUIDialogYesNo::NO_TIMEOUT);
+  DialogResponse result = HELPERS::ShowYesNoDialogLines(heading, line0, line1, line2, noLabel, yesLabel);
+  bCanceled = result == DialogResponse::CANCELLED;
+  return result == DialogResponse::YES;
 }
 //@}
 

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -32,9 +32,9 @@
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/DialogHelper.h"
 #include "filesystem/FavouritesDirectory.h"
 #include "utils/JobManager.h"
-#include "dialogs/GUIDialogYesNo.h"
 #include "addons/AddonManager.h"
 #include "addons/Repository.h"
 #include "guilib/GUIWindowManager.h"      // for callback
@@ -49,6 +49,8 @@
 using namespace XFILE;
 using namespace ADDON;
 using namespace KODI::MESSAGING;
+
+using KODI::MESSAGING::HELPERS::DialogResponse;
 
 struct find_map : public std::binary_function<CAddonInstaller::JobMap::value_type, unsigned int, bool>
 {
@@ -172,9 +174,14 @@ bool CAddonInstaller::InstallModal(const std::string &addonID, ADDON::AddonPtr &
     return false;
 
   // if specified ask the user if he wants it installed
-  if (promptForInstall &&
-      !CGUIDialogYesNo::ShowAndGetInput(CVariant{24076}, CVariant{24100}, CVariant{addon->Name()}, CVariant{24101}))
-    return false;
+  if (promptForInstall)
+  {
+    if (HELPERS::ShowYesNoDialogLines(CVariant{24076}, CVariant{24100}, CVariant{addon->Name()}, CVariant{24101}) !=
+      DialogResponse::YES)
+    {
+      return false;
+    }
+  }
 
   if (!InstallOrUpdate(addonID, "", false, true))
     return false;

--- a/xbmc/addons/LanguageResource.cpp
+++ b/xbmc/addons/LanguageResource.cpp
@@ -21,11 +21,15 @@
 #include "LangInfo.h"
 #include "addons/AddonManager.h"
 #include "dialogs/GUIDialogKaiToast.h"
-#include "dialogs/GUIDialogYesNo.h"
 #include "guilib/GUIWindowManager.h"
 #include "settings/Settings.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
+#include "messaging/helpers/DialogHelper.h"
+
+using namespace KODI::MESSAGING;
+
+using KODI::MESSAGING::HELPERS::DialogResponse;
 
 #define LANGUAGE_ADDON_PREFIX   "resource.language."
 
@@ -109,7 +113,8 @@ bool CLanguageResource::IsInUse() const
 void CLanguageResource::OnPostInstall(bool update, bool modal)
 {
   if (IsInUse() ||
-     (!update && !modal && CGUIDialogYesNo::ShowAndGetInput(CVariant{Name()}, CVariant{24132})))
+     (!update && !modal && 
+       (HELPERS::ShowYesNoDialogText(CVariant{Name()}, CVariant{24132}) == DialogResponse::YES)))
   {
     CGUIDialogKaiToast *toast = (CGUIDialogKaiToast *)g_windowManager.GetWindow(WINDOW_DIALOG_KAI_TOAST);
     if (toast)

--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -30,6 +30,7 @@
 #include "dialogs/GUIDialogKaiToast.h"
 #include "filesystem/File.h"
 #include "filesystem/Directory.h"
+#include "messaging/helpers/DialogHelper.h"
 #include "settings/Settings.h"
 #include "utils/log.h"
 #include "utils/JobManager.h"
@@ -43,6 +44,9 @@
 
 using namespace XFILE;
 using namespace ADDON;
+using namespace KODI::MESSAGING;
+
+using KODI::MESSAGING::HELPERS::DialogResponse;
 
 AddonPtr CRepository::Clone() const
 {
@@ -249,12 +253,12 @@ bool CRepositoryUpdateJob::DoWork()
   //unnecessary HEAD requests being sent to server. icons and fanart rarely
   //change, and cannot change if there is no version bump.
   {
-    CTextureDatabase textureDB;
-    textureDB.Open();
-    textureDB.BeginMultipleExecute();
+  CTextureDatabase textureDB;
+  textureDB.Open();
+  textureDB.BeginMultipleExecute();
 
     for (const auto& addon : addons)
-    {
+  {
       if (!addon->Props().fanart.empty())
         textureDB.InvalidateCachedTexture(addon->Props().fanart);
       if (!addon->Props().icon.empty())
@@ -288,11 +292,14 @@ bool CRepositoryUpdateJob::DoWork()
       if (!addon->Props().broken.empty() && !brokenInDb)
       {
         //newly broken
-        std::string line = g_localizeStrings.Get(24096);
+        int line = 24096;
         if (addon->Props().broken == "DEPSNOTMET")
-          line = g_localizeStrings.Get(24104);
-        if (CGUIDialogYesNo::ShowAndGetInput(CVariant{addon->Name()}, CVariant{line}, CVariant{24097}, CVariant{""}))
+          line = 24104;
+        if (HELPERS::ShowYesNoDialogLines(CVariant{addon->Name()}, CVariant{line}, CVariant{24097}, CVariant{""}) 
+          == DialogResponse::YES)
+        {
           CAddonMgr::GetInstance().DisableAddon(addon->ID());
+        }
 
         CLog::Log(LOGDEBUG, "CRepositoryUpdateJob[%s] addon '%s' marked broken. reason: \"%s\"",
              m_repo->ID().c_str(), addon->ID().c_str(), addon->Props().broken.c_str());
@@ -304,8 +311,8 @@ bool CRepositoryUpdateJob::DoWork()
         //Unbroken
         CLog::Log(LOGDEBUG, "CRepositoryUpdateJob[%s] addon '%s' unbroken",
             m_repo->ID().c_str(), addon->ID().c_str());
-      }
     }
+  }
 
     //Update broken status
     database.BreakAddon(addon->ID(), addon->Props().broken);
@@ -342,21 +349,21 @@ CRepositoryUpdateJob::FetchStatus CRepositoryUpdateJob::FetchIfChanged(const std
   if (oldChecksum == checksum && !oldChecksum.empty())
     return STATUS_NOT_MODIFIED;
 
-  std::map<std::string, AddonPtr> uniqueAddons;
+    std::map<std::string, AddonPtr> uniqueAddons;
   for (auto it = m_repo->m_dirs.cbegin(); it != m_repo->m_dirs.cend(); ++it)
-  {
+    {
     if (ShouldCancel(m_repo->m_dirs.size() + std::distance(m_repo->m_dirs.cbegin(), it), total))
       return STATUS_ERROR;
 
-    VECADDONS addons;
-    if (!CRepository::Parse(*it, addons))
+      VECADDONS addons;
+      if (!CRepository::Parse(*it, addons))
     {
       CLog::Log(LOGERROR, "CRepositoryUpdateJob[%s] failed to read or parse "
           "directory '%s'", m_repo->ID().c_str(), it->info.c_str());
       return STATUS_ERROR;
+      }
+      MergeAddons(uniqueAddons, addons);
     }
-    MergeAddons(uniqueAddons, addons);
-  }
 
   for (const auto& kv : uniqueAddons)
     addons.push_back(kv.second);

--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -22,13 +22,14 @@
 #include "AddonManager.h"
 #include "Util.h"
 #include "dialogs/GUIDialogKaiToast.h"
-#include "dialogs/GUIDialogYesNo.h"
 // fallback for new skin resolution code
 #include "filesystem/Directory.h"
 #include "filesystem/File.h"
 #include "filesystem/SpecialProtocol.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/WindowIDs.h"
+#include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/DialogHelper.h"
 #include "settings/Settings.h"
 #include "settings/lib/Setting.h"
 #include "utils/log.h"
@@ -36,7 +37,6 @@
 #include "utils/URIUtils.h"
 #include "utils/XMLUtils.h"
 #include "utils/Variant.h"
-#include "messaging/ApplicationMessenger.h"
 
 #define XML_SETTINGS      "settings"
 #define XML_SETTING       "setting"
@@ -46,6 +46,8 @@
 
 using namespace XFILE;
 using namespace KODI::MESSAGING;
+
+using KODI::MESSAGING::HELPERS::DialogResponse;
 
 std::shared_ptr<ADDON::CSkinInfo> g_SkinInfo;
 
@@ -372,7 +374,8 @@ void CSkinInfo::OnPreInstall()
 
 void CSkinInfo::OnPostInstall(bool update, bool modal)
 {
-  if (IsInUse() || (!update && !modal && CGUIDialogYesNo::ShowAndGetInput(CVariant{Name()}, CVariant{24099})))
+  if (IsInUse() || (!update && !modal && 
+    HELPERS::ShowYesNoDialogText(CVariant{Name()}, CVariant{24099}) == DialogResponse::YES))
   {
     CGUIDialogKaiToast *toast = (CGUIDialogKaiToast *)g_windowManager.GetWindow(WINDOW_DIALOG_KAI_TOAST);
     if (toast)

--- a/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSP.cpp
+++ b/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSP.cpp
@@ -31,7 +31,6 @@ extern "C" {
 #include "cores/AudioEngine/Utils/AEUtil.h"
 
 #include "Application.h"
-#include "messaging/ApplicationMessenger.h"
 #include "guiinfo/GUIInfoLabels.h"
 #include "GUIUserMessages.h"
 #include "addons/AddonInstaller.h"
@@ -39,8 +38,9 @@ extern "C" {
 #include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogSelect.h"
 #include "dialogs/GUIDialogKaiToast.h"
-#include "dialogs/GUIDialogYesNo.h"
 #include "guilib/GUIWindowManager.h"
+#include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/DialogHelper.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/MediaSettings.h"
 #include "settings/MediaSourceSettings.h"
@@ -52,6 +52,8 @@ extern "C" {
 using namespace ADDON;
 using namespace ActiveAE;
 using namespace KODI::MESSAGING;
+
+using KODI::MESSAGING::HELPERS::DialogResponse;
 
 #define MIN_DSP_ARRAY_SIZE 4096
 
@@ -330,7 +332,8 @@ void CActiveAEDSP::OnSettingAction(const CSetting *setting)
   }
   else if (settingId == CSettings::SETTING_AUDIOOUTPUT_DSPRESETDB)
   {
-    if (CGUIDialogYesNo::ShowAndGetInput(19098, 36440, 750, 0))
+    if (HELPERS::ShowYesNoDialogLines(CVariant{19098}, CVariant{36440}, CVariant{750}) ==
+      DialogResponse::YES)
     {
       CDateTime::ResetTimezoneBias();
       ResetDatabase();

--- a/xbmc/dialogs/GUIDialogYesNo.cpp
+++ b/xbmc/dialogs/GUIDialogYesNo.cpp
@@ -21,6 +21,7 @@
 #include "GUIDialogYesNo.h"
 #include "guilib/GUIWindowManager.h"
 #include "input/Key.h"
+#include "messaging/helpers/DialogHelper.h"
 
 #define CONTROL_NO_BUTTON 10
 #define CONTROL_YES_BUTTON 11
@@ -85,7 +86,7 @@ bool CGUIDialogYesNo::ShowAndGetInput(CVariant heading, CVariant line0, CVariant
 
 bool CGUIDialogYesNo::ShowAndGetInput(CVariant heading, CVariant line0, CVariant line1, CVariant line2, bool &bCanceled, CVariant noLabel, CVariant yesLabel, unsigned int autoCloseTime)
 {
-  CGUIDialogYesNo *dialog = (CGUIDialogYesNo *)g_windowManager.GetWindow(WINDOW_DIALOG_YES_NO);
+  CGUIDialogYesNo *dialog = static_cast<CGUIDialogYesNo *>(g_windowManager.GetWindow(WINDOW_DIALOG_YES_NO));
   if (!dialog)
     return false;
 
@@ -112,7 +113,7 @@ bool CGUIDialogYesNo::ShowAndGetInput(CVariant heading, CVariant text)
 
 bool CGUIDialogYesNo::ShowAndGetInput(CVariant heading, CVariant text, bool &bCanceled, CVariant noLabel /* = "" */, CVariant yesLabel /* = "" */, unsigned int autoCloseTime)
 {
-  CGUIDialogYesNo *dialog = (CGUIDialogYesNo *)g_windowManager.GetWindow(WINDOW_DIALOG_YES_NO);
+  CGUIDialogYesNo *dialog = static_cast<CGUIDialogYesNo *>(g_windowManager.GetWindow(WINDOW_DIALOG_YES_NO));
   if (!dialog)
     return false;
 
@@ -127,6 +128,36 @@ bool CGUIDialogYesNo::ShowAndGetInput(CVariant heading, CVariant text, bool &bCa
 
   bCanceled = dialog->m_bCanceled;
   return (dialog->IsConfirmed()) ? true : false;
+}
+
+int CGUIDialogYesNo::ShowAndGetInput(const KODI::MESSAGING::HELPERS::DialogYesNoMessage& options)
+{
+  //Set default yes/no labels, these might be overwritten further down if specified
+  //by the caller
+  SetChoice(0, 106);
+  SetChoice(1, 107);
+  if (!options.heading.isNull())
+    SetHeading(options.heading);
+  if (!options.text.isNull())
+    SetText(options.text);
+  if (!options.noLabel.isNull())
+    SetChoice(0, options.noLabel);
+  if (!options.yesLabel.isNull())
+    SetChoice(1, options.yesLabel);
+  if (options.autoclose > 0)
+    SetAutoClose(options.autoclose);
+  
+  for (size_t i = 0; i < 3; ++i)
+  {
+    if (!options.lines[i].isNull())
+      SetLine(i, options.lines[i]);
+  }
+
+  Open();
+  if (m_bCanceled)
+    return -1;
+  
+  return IsConfirmed() ? 1 : 0;
 }
 
 int CGUIDialogYesNo::GetDefaultLabelID(int controlId) const

--- a/xbmc/dialogs/GUIDialogYesNo.h
+++ b/xbmc/dialogs/GUIDialogYesNo.h
@@ -20,9 +20,19 @@
  *
  */
 
-#include <string>
 #include "GUIDialogBoxBase.h"
 #include "utils/Variant.h"
+
+namespace KODI
+{
+  namespace MESSAGING
+  {
+    namespace HELPERS
+    {
+      struct DialogYesNoMessage;
+    }
+  }
+}
 
 class CGUIDialogYesNo :
       public CGUIDialogBoxBase
@@ -89,6 +99,17 @@ public:
    \return true if user selects Yes, otherwise false if user selects No.
    */
   static bool ShowAndGetInput(CVariant heading, CVariant text, bool &bCanceled, CVariant noLabel, CVariant yesLabel, unsigned int autoCloseTime);
+
+  /*!
+    \brief Open a Yes/No dialog and wait for input
+
+    \param[in] options  a struct of type DialogYesNoMessage containing
+                        the options to set for this dialog.
+
+    \returns -1 for cancelled, 0 for No and 1 for Yes
+    \sa KODI::MESSAGING::HELPERS::DialogYesNoMessage
+  */
+  int ShowAndGetInput(const KODI::MESSAGING::HELPERS::DialogYesNoMessage& options);
 
 protected:
   virtual int GetDefaultLabelID(int controlId) const;

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -23,6 +23,7 @@
 #include "GUIDialog.h"
 #include "Application.h"
 #include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/DialogHelper.h"
 #include "GUIPassword.h"
 #include "GUIInfoManager.h"
 #include "threads/SingleLock.h"
@@ -915,15 +916,33 @@ void CGUIWindowManager::OnApplicationMessage(ThreadMessage* pMsg)
   break;
 
   case TMSG_GUI_MESSAGE:
-  {
     if (pMsg->lpVoid)
     {
       CGUIMessage *message = static_cast<CGUIMessage *>(pMsg->lpVoid);
       SendMessage(*message, pMsg->param1);
       delete message;
     }
-  }
-  break;
+    break;
+
+  case TMSG_GUI_DIALOG_YESNO:
+    if (!pMsg->lpVoid && pMsg->param1 < 0 && pMsg->param2 < 0)
+      return;
+
+    auto dialog = static_cast<CGUIDialogYesNo*>(GetWindow(WINDOW_DIALOG_YES_NO));
+    if (!dialog)
+      return;
+
+    if (pMsg->lpVoid)
+      pMsg->SetResult(dialog->ShowAndGetInput(*static_cast<HELPERS::DialogYesNoMessage*>(pMsg->lpVoid)));
+    else
+    {
+      HELPERS::DialogYesNoMessage options;
+      options.heading = pMsg->param1;
+      options.text = pMsg->param2;
+      pMsg->SetResult(dialog->ShowAndGetInput(options));
+    }
+
+    break;
   }
 }
 

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -25,6 +25,7 @@
 #include "utils/SeekHandler.h"
 #include "Application.h"
 #include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/DialogHelper.h"
 #include "Autorun.h"
 #include "Builtins.h"
 #include "input/ButtonTranslator.h"
@@ -39,7 +40,6 @@
 #include "dialogs/GUIDialogKaiToast.h"
 #include "dialogs/GUIDialogNumeric.h"
 #include "dialogs/GUIDialogProgress.h"
-#include "dialogs/GUIDialogYesNo.h"
 #include "GUIUserMessages.h"
 #include "windows/GUIWindowLoginScreen.h"
 #include "video/windows/GUIWindowVideoBase.h"
@@ -116,6 +116,8 @@ using namespace KODI::MESSAGING;
 #ifdef HAS_DVD_DRIVE
 using namespace MEDIA_DETECT;
 #endif
+
+using KODI::MESSAGING::HELPERS::DialogResponse;
 
 typedef struct
 {
@@ -1594,7 +1596,11 @@ int CBuiltins::Execute(const std::string& execString)
     if (params.size() > 1)
       singleFile = StringUtils::EqualsNoCase(params[1], "true");
     else
-      singleFile = !CGUIDialogYesNo::ShowAndGetInput(CVariant{iHeading}, CVariant{20426}, cancelled, CVariant{20428}, CVariant{20429});
+    {
+      DialogResponse result = HELPERS::ShowYesNoDialogText(CVariant{iHeading}, CVariant{20426}, CVariant{20428}, CVariant{20429});
+      cancelled = result == DialogResponse::CANCELLED;
+      singleFile = result != DialogResponse::YES;
+    }
 
     if (cancelled)
         return -1;
@@ -1604,7 +1610,11 @@ int CBuiltins::Execute(const std::string& execString)
       if (params.size() > 2)
         thumbs = StringUtils::EqualsNoCase(params[2], "true");
       else
-        thumbs = CGUIDialogYesNo::ShowAndGetInput(CVariant{iHeading}, CVariant{20430}, cancelled, CVariant{""}, CVariant{""}, CGUIDialogYesNo::NO_TIMEOUT);
+      {
+        DialogResponse result = HELPERS::ShowYesNoDialogText(CVariant{iHeading}, CVariant{20430}, CVariant{20428}, CVariant{20429});
+        cancelled = result == DialogResponse::CANCELLED;
+        thumbs = result == DialogResponse::YES;
+      }
     }
 
     if (cancelled)
@@ -1615,7 +1625,11 @@ int CBuiltins::Execute(const std::string& execString)
       if (params.size() > 4)
         actorThumbs = StringUtils::EqualsNoCase(params[4], "true");
       else
-        actorThumbs = CGUIDialogYesNo::ShowAndGetInput(CVariant{iHeading}, CVariant{20436}, cancelled, CVariant{ "" }, CVariant{ "" }, CGUIDialogYesNo::NO_TIMEOUT);
+      {
+        DialogResponse result = HELPERS::ShowYesNoDialogText(CVariant{iHeading}, CVariant{20436});
+        cancelled = result == DialogResponse::CANCELLED;
+        actorThumbs = result == DialogResponse::YES;
+      }
     }
 
     if (cancelled)
@@ -1626,7 +1640,11 @@ int CBuiltins::Execute(const std::string& execString)
       if (params.size() > 3)
         overwrite = StringUtils::EqualsNoCase(params[3], "true");
       else
-        overwrite = CGUIDialogYesNo::ShowAndGetInput(CVariant{iHeading}, CVariant{20431}, cancelled, CVariant{ "" }, CVariant{ "" }, CGUIDialogYesNo::NO_TIMEOUT);
+      {
+        DialogResponse result = HELPERS::ShowYesNoDialogText(CVariant{iHeading}, CVariant{20431});
+        cancelled = result == DialogResponse::CANCELLED;
+        overwrite = result == DialogResponse::YES;
+      }
     }
 
     if (cancelled)

--- a/xbmc/messaging/ApplicationMessenger.h
+++ b/xbmc/messaging/ApplicationMessenger.h
@@ -113,6 +113,28 @@
 #define TMSG_GUI_ADDON_DIALOG             TMSG_MASK_WINDOWMANAGER + 6
 #define TMSG_GUI_MESSAGE                  TMSG_MASK_WINDOWMANAGER + 7
 
+/*!
+  \def TMSG_GUI_DIALOG_YESNO
+  \brief Message sent through CApplicationMessenger to open a yes/no dialog box
+
+  There's two ways to send this message, a short and concise way and a more
+  flexible way allowing more customization.
+
+  Option 1:
+  CApplicationMessenger::Get().SendMsg(TMSG_GUI_DIALOG_YESNO, 123, 456);
+  123: This is the string id for the heading
+  456: This is the string id for the text
+
+  Option 2:
+  \a HELPERS::DialogYesNoMessage options.
+  Fill in options
+  CApplicationMessenger::Get().SendMsg(TMSG_GUI_DIALOG_YESNO, -1, -1, static_cast<void*>(&options));
+
+  \returns -1 for cancelled, 0 for No and 1 for Yes
+  \sa HELPERS::DialogYesNoMessage
+*/
+#define TMSG_GUI_DIALOG_YESNO             TMSG_MASK_WINDOWMANAGER + 8
+
 
 #define TMSG_CALLBACK                     800
 
@@ -155,10 +177,10 @@ public:
 
   void Cleanup();
   // if a message has to be send to the gui, use MSG_TYPE_WINDOW instead
-  void SendMsg(uint32_t messageId);
-  void SendMsg(uint32_t messageId, int param1, int param2 = -1, void* payload = nullptr);
-  void SendMsg(uint32_t messageId, int param1, int param2, void* payload, std::string strParam);
-  void SendMsg(uint32_t messageId, int param1, int param2, void* payload, std::string strParam, std::vector<std::string> params);
+  int SendMsg(uint32_t messageId);
+  int SendMsg(uint32_t messageId, int param1, int param2 = -1, void* payload = nullptr);
+  int SendMsg(uint32_t messageId, int param1, int param2, void* payload, std::string strParam);
+  int SendMsg(uint32_t messageId, int param1, int param2, void* payload, std::string strParam, std::vector<std::string> params);
 
   void PostMsg(uint32_t messageId);
   void PostMsg(uint32_t messageId, int param1, int param2 = -1, void* payload = nullptr);
@@ -185,7 +207,7 @@ private:
   CApplicationMessenger const& operator=(CApplicationMessenger const&) = delete;
   ~CApplicationMessenger();
 
-  void SendMsg(ThreadMessage&& msg, bool wait);
+  int SendMsg(ThreadMessage&& msg, bool wait);
   void ProcessMessage(ThreadMessage *pMsg);
 
   std::queue<ThreadMessage*> m_vecMessages;

--- a/xbmc/messaging/ThreadMessage.h
+++ b/xbmc/messaging/ThreadMessage.h
@@ -71,7 +71,8 @@ public:
     lpVoid(other.lpVoid),
     strParam(other.strParam),
     params(other.params),
-    waitEvent(other.waitEvent)
+    waitEvent(other.waitEvent),
+    result(other.result)
   {
   }
 
@@ -82,7 +83,8 @@ public:
     lpVoid(other.lpVoid),
     strParam(std::move(other.strParam)),
     params(std::move(other.params)),
-    waitEvent(std::move(other.waitEvent))
+    waitEvent(std::move(other.waitEvent)),
+    result(std::move(other.result))
   {
   }
 
@@ -97,6 +99,7 @@ public:
     strParam = other.strParam;
     params = other.params;
     waitEvent = other.waitEvent;
+    result = other.result;
     return *this;
   }
 
@@ -111,6 +114,7 @@ public:
     strParam = std::move(other.strParam);
     params = std::move(other.params);
     waitEvent = std::move(other.waitEvent);
+    result = std::move(other.result);
     return *this;
   }
 
@@ -121,8 +125,17 @@ public:
   std::string strParam;
   std::vector<std::string> params;
 
+  void SetResult(int res)
+  {
+    //On posted messages result will be zero, since they can't
+    //retreive the response we silently ignore this to let message
+    //handlers not have to worry about it
+    if (result)
+      *result = res;
+  }
 protected:
   std::shared_ptr<CEvent> waitEvent;
+  std::shared_ptr<int> result;
 };
 }
 }

--- a/xbmc/messaging/helpers/DialogHelper.cpp
+++ b/xbmc/messaging/helpers/DialogHelper.cpp
@@ -1,0 +1,89 @@
+/*
+*      Copyright (C) 2005-2015 Team Kodi
+*      http://kodi.tv
+*
+*  This Program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2, or (at your option)
+*  any later version.
+*
+*  This Program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with Kodi; see the file COPYING.  If not, see
+*  <http://www.gnu.org/licenses/>.
+*
+*/
+
+#include "DialogHelper.h"
+#include "messaging/ApplicationMessenger.h"
+
+#include <utility>
+#include <cassert>
+
+namespace KODI
+{
+namespace MESSAGING
+{
+namespace HELPERS
+{
+DialogResponse ShowYesNoDialogText(CVariant heading, CVariant text, CVariant noLabel, CVariant yesLabel, uint32_t autoCloseTimeout)
+{
+  DialogYesNoMessage options;
+  options.heading = std::move(heading);
+  options.text = std::move(text);
+  options.noLabel = std::move(noLabel);
+  options.yesLabel = std::move(yesLabel);
+  options.autoclose = autoCloseTimeout;
+  
+  switch (CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_DIALOG_YESNO, -1, -1, static_cast<void*>(&options)))
+  {
+  case -1:
+    return DialogResponse::CANCELLED;
+  case 0:
+    return DialogResponse::NO;
+  case 1:
+    return DialogResponse::YES;
+  default:
+    //If we get here someone changed the return values without updating this code
+    assert(false);
+  }
+  //This is unreachable code but we need to return something to suppress warnings about
+  //no return
+  return DialogResponse::CANCELLED;
+}
+
+DialogResponse ShowYesNoDialogLines(CVariant heading, CVariant line0, CVariant line1, CVariant line2, CVariant noLabel, CVariant yesLabel, uint32_t autoCloseTimeout)
+{
+  DialogYesNoMessage options;
+  options.heading = std::move(heading);
+  options.lines[0] = std::move(line0);
+  options.lines[1] = std::move(line1);
+  options.lines[2] = std::move(line2);
+  options.noLabel = std::move(noLabel);
+  options.yesLabel = std::move(yesLabel);
+  options.autoclose = autoCloseTimeout;
+
+  switch (CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_DIALOG_YESNO, -1, -1, static_cast<void*>(&options)))
+  {
+  case -1:
+    return DialogResponse::CANCELLED;
+  case 0:
+    return DialogResponse::NO;
+  case 1:
+    return DialogResponse::YES;
+  default:
+    //If we get here someone changed the return values without updating this code
+    assert(false);
+  }
+  //This is unreachable code but we need to return something to suppress warnings about
+  //no return
+  return DialogResponse::CANCELLED;
+}
+
+}
+}
+}

--- a/xbmc/messaging/helpers/DialogHelper.h
+++ b/xbmc/messaging/helpers/DialogHelper.h
@@ -1,0 +1,98 @@
+#pragma once
+/*
+*      Copyright (C) 2005-2015 Team Kodi
+*      http://kodi.tv
+*
+*  This Program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2, or (at your option)
+*  any later version.
+*
+*  This Program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with Kodi; see the file COPYING.  If not, see
+*  <http://www.gnu.org/licenses/>.
+*
+*/
+
+#include "utils/Variant.h"
+
+#include <array>
+#include <string>
+
+namespace KODI
+{
+namespace MESSAGING
+{
+namespace HELPERS
+{
+
+enum class DialogResponse
+{
+  CANCELLED,
+  YES,
+  NO
+};
+
+/*! \struct DialogHelper.h "messaging/helpers/DialogHelper.h"
+    \brief Payload sent for message TMSG_GUI_DIALOG_YESNO
+
+    \sa ShowDialogText
+    \sa ShowDialogLines
+*/
+struct DialogYesNoMessage
+{
+  CVariant heading; //!< Heading to be displayed in the dialog box
+  CVariant text;  //!< Body text to be displayed, this is mutually exclusive with lines below
+  std::array<CVariant, 3> lines;  //!< Body text to be displayed, specified as three lines. This is mutually exclusive with the text above
+  CVariant yesLabel;  //!< Text to show on the yes button
+  CVariant noLabel; //!< Text to show on the no button
+  uint32_t autoclose{0}; //!< Time in milliseconds before autoclosing the dialog, 0 means don't autoclose
+};
+
+/*!
+  \brief This is a helper method to send a threadmessage to open a Yes/No dialog box
+
+  \param[in]  heading           The text to display as the dialog box header
+  \param[in]  text              The text to display in the dialog body
+  \param[in]  noLabel           The text to display on the No button
+                                defaults to No
+  \param[in]  yesLabel          The text to display on the Yes button
+                                defaults to Yes
+  \param[in]  autoCloseTimeout  The time before the dialog closes
+                                defaults to 0 show indefinitely
+  \return -1 on cancelled, 0 on no and 1 on yes
+  \sa ShowYesNoDialogLines
+  \sa CGUIDialogYesNo::ShowAndGetInput
+  \sa DialogYesNoMessage
+*/
+DialogResponse ShowYesNoDialogText(CVariant heading, CVariant text, CVariant noLabel = "", CVariant yesLabel = "", uint32_t autoCloseTimeout = 0);
+
+/*!
+  \brief This is a helper method to send a threadmessage to open a Yes/No dialog box
+  
+  \param[in]  heading           The text to display as the dialog box header
+  \param[in]  line0             The text to display on the first line
+  \param[in]  line1             The text to display on the second line
+  \param[in]  line2             The text to display on the third line
+  \param[in]  noLabel           The text to display on the No button
+                                defaults to No
+  \param[in]  yesLabel          The text to display on the Yes button
+                                defaults to Yes
+  \param[in]  autoCloseTimeout  The time before the dialog closes
+                                defaults to 0 show indefinitely
+  \return -1 on cancelled, 0 on no and 1 on yes
+  \sa ShowYesNoDialogText
+  \sa CGUIDialogYesNo::ShowAndGetInput
+  \sa DialogYesNoMessage
+*/
+DialogResponse ShowYesNoDialogLines(CVariant heading, CVariant line0, CVariant line1 = "",
+  CVariant line2 = "", CVariant noLabel = "", CVariant yesLabel = "", uint32_t autoCloseTimeout = 0);
+
+}
+}
+}

--- a/xbmc/messaging/helpers/Makefile.in
+++ b/xbmc/messaging/helpers/Makefile.in
@@ -1,0 +1,6 @@
+SRCS = DialogHelper.cpp
+
+LIB = messagingHelpers.a
+
+include @abs_top_srcdir@/Makefile.include
+-include $(patsubst %.cpp,%.P,$(patsubst %c,%.P,$(patsubst %.S,,$(SRCS))))

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -38,7 +38,6 @@
 #include "guilib/GUIWindowManager.h"
 #include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogProgress.h"
-#include "dialogs/GUIDialogYesNo.h"
 #include "dialogs/GUIDialogKaiToast.h"
 #include "dialogs/GUIDialogSelect.h"
 #include "filesystem/File.h"
@@ -67,13 +66,17 @@
 #include "playlists/SmartPlayList.h"
 #include "CueInfoLoader.h"
 #include "guiinfo/GUIInfoLabels.h"
+#include "messaging/helpers/DialogHelper.h"
 
 #include <utility>
 
 using namespace AUTOPTR;
 using namespace XFILE;
 using namespace MUSICDATABASEDIRECTORY;
+using namespace KODI::MESSAGING;
+
 using ADDON::AddonPtr;
+using KODI::MESSAGING::HELPERS::DialogResponse;
 
 #define RECENTLY_PLAYED_LIMIT 25
 #define MIN_FULL_SEARCH_LENGTH 3
@@ -2975,8 +2978,8 @@ void CMusicDatabase::Clean()
     CGUIDialogOK::ShowAndGetInput(CVariant{189}, CVariant{14057});
     return;
   }
-
-  if (CGUIDialogYesNo::ShowAndGetInput(CVariant{313}, CVariant{333}))
+  
+  if (HELPERS::ShowYesNoDialogText(CVariant{313}, CVariant{333}) == DialogResponse::YES)
   {
     CMusicDatabase musicdatabase;
     if (musicdatabase.Open())

--- a/xbmc/network/NetworkServices.cpp
+++ b/xbmc/network/NetworkServices.cpp
@@ -21,12 +21,12 @@
 #include "NetworkServices.h"
 #include "Application.h"
 #include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/DialogHelper.h"
 #ifdef TARGET_LINUX
 #include "Util.h"
 #endif
 #include "dialogs/GUIDialogKaiToast.h"
 #include "dialogs/GUIDialogOK.h"
-#include "dialogs/GUIDialogYesNo.h"
 #include "guilib/LocalizeStrings.h"
 #include "network/Network.h"
 
@@ -94,6 +94,8 @@ using namespace EVENTSERVER;
 #ifdef HAS_UPNP
 using namespace UPNP;
 #endif // HAS_UPNP
+
+using KODI::MESSAGING::HELPERS::DialogResponse;
 
 CNetworkServices::CNetworkServices()
 #ifdef HAS_WEB_SERVER
@@ -413,7 +415,7 @@ void CNetworkServices::OnSettingChanged(const CSetting *setting)
   {
     // okey we really don't need to restart, only deinit samba, but that could be damn hard if something is playing
     // TODO - General way of handling setting changes that require restart
-    if (CGUIDialogYesNo::ShowAndGetInput(CVariant{14038}, CVariant{14039}))
+    if (HELPERS::ShowYesNoDialogText(CVariant{14038}, CVariant{14039}) == DialogResponse::YES)
     {
       CSettings::GetInstance().Save();
       CApplicationMessenger::GetInstance().PostMsg(TMSG_RESTARTAPP);
@@ -755,9 +757,8 @@ bool CNetworkServices::StopEventServer(bool bWait, bool promptuser)
   {
     if (server->GetNumberOfClients() > 0)
     {
-      bool cancelled = false;
-      if (!CGUIDialogYesNo::ShowAndGetInput(CVariant{13140}, CVariant{13141}, cancelled, CVariant{""}, CVariant{""}, 10000)
-          || cancelled)
+      if (HELPERS::ShowYesNoDialogText(CVariant{13140}, CVariant{13141}, CVariant{""}, CVariant{""}, 10000) != 
+        DialogResponse::YES)
       {
         CLog::Log(LOGNOTICE, "ES: Not stopping event server");
         return false;

--- a/xbmc/network/upnp/UPnPPlayer.cpp
+++ b/xbmc/network/upnp/UPnPPlayer.cpp
@@ -35,13 +35,15 @@
 #include "video/VideoThumbLoader.h"
 #include "music/MusicThumbLoader.h"
 #include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/DialogHelper.h"
 #include "Application.h"
 #include "dialogs/GUIDialogBusy.h"
 #include "guilib/GUIWindowManager.h"
 #include "input/Key.h"
-#include "dialogs/GUIDialogYesNo.h"
 
 using namespace KODI::MESSAGING;
+
+using KODI::MESSAGING::HELPERS::DialogResponse;
 
 NPT_SET_LOCAL_LOGGER("xbmc.upnp.player")
 
@@ -605,10 +607,9 @@ bool CUPnPPlayer::OnAction(const CAction &action)
     case ACTION_STOP:
       if(IsPlaying())
       {
-        if(CGUIDialogYesNo::ShowAndGetInput(CVariant{37022}, CVariant{37023})) /* stop on remote system */
-          m_stopremote = true;
-        else
-          m_stopremote = false;
+        //stop on remote system
+        m_stopremote = HELPERS::ShowYesNoDialogText(CVariant{37022}, CVariant{37023}) == DialogResponse::YES;
+        
         return false; /* let normal code handle the action */
       }
     default:

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -20,6 +20,7 @@
 
 #include "Application.h"
 #include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/DialogHelper.h"
 #include "GUIInfoManager.h"
 #include "Util.h"
 #include "dialogs/GUIDialogOK.h"
@@ -27,7 +28,6 @@
 #include "dialogs/GUIDialogProgress.h"
 #include "dialogs/GUIDialogExtendedProgressBar.h"
 #include "dialogs/GUIDialogKaiToast.h"
-#include "dialogs/GUIDialogYesNo.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "music/tags/MusicInfoTag.h"
@@ -67,6 +67,8 @@ using namespace PVR;
 using namespace EPG;
 using namespace ANNOUNCEMENT;
 using namespace KODI::MESSAGING;
+
+using KODI::MESSAGING::HELPERS::DialogResponse;
 
 int CPVRManager::m_pvrWindowIds[10] = {
     WINDOW_TV_CHANNELS,
@@ -184,7 +186,7 @@ void CPVRManager::OnSettingAction(const CSetting *setting)
   else if (settingId == CSettings::SETTING_PVRMANAGER_RESETDB)
   {
     if (CheckParentalPIN(g_localizeStrings.Get(19262)) &&
-        CGUIDialogYesNo::ShowAndGetInput(CVariant{19098}, CVariant{19186}))
+      HELPERS::ShowYesNoDialogText(CVariant{19098}, CVariant{19186}) == DialogResponse::YES)
     {
       CDateTime::ResetTimezoneBias();
       ResetDatabase(false);
@@ -192,7 +194,7 @@ void CPVRManager::OnSettingAction(const CSetting *setting)
   }
   else if (settingId == CSettings::SETTING_EPG_RESETEPG)
   {
-    if (CGUIDialogYesNo::ShowAndGetInput(CVariant{19098}, CVariant{19188}))
+    if (HELPERS::ShowYesNoDialogText(CVariant{19098}, CVariant{19188}) == DialogResponse::YES)
     {
       CDateTime::ResetTimezoneBias();
       ResetDatabase(true);
@@ -1506,13 +1508,12 @@ bool CPVRManager::CanSystemPowerdown(bool bAskUser /*= true*/) const
         }
 
         // Inform user about PVR being busy. Ask if user wants to powerdown anyway.
-        bool bCanceled = false;
-        bReturn = CGUIDialogYesNo::ShowAndGetInput(CVariant{19685}, // "Confirm shutdown"
-                                                   CVariant{text},
-                                                   bCanceled,
-                                                   CVariant{222},   // "Cancel"
-                                                   CVariant{19696}, // "Shutdown anyway"
-                                                   10000); //This is a timeout and IS NOT a CVariant
+        bReturn = HELPERS::DialogResponse::YES == 
+          HELPERS::ShowYesNoDialogText(CVariant{19685}, // "Confirm shutdown"
+                                       CVariant{text},
+                                       CVariant{222}, // "Shutdown anyway",
+                                       CVariant{19696}, // "Cancel"
+                                       10000); // timeout value before closing
       }
       else
         bReturn = false; // do not powerdown (busy, but no user interaction requested).

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -20,7 +20,8 @@
 
 #include "Application.h"
 #include "PVRClient.h"
-#include "dialogs/GUIDialogYesNo.h"
+#include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/DialogHelper.h"
 #include "pvr/PVRManager.h"
 #include "pvr/addons/PVRClients.h"
 #include "epg/Epg.h"
@@ -37,10 +38,14 @@
 
 #include <assert.h>
 #include <memory>
+#include <algorithm>
 
 using namespace ADDON;
 using namespace PVR;
 using namespace EPG;
+using namespace KODI::MESSAGING;
+
+using KODI::MESSAGING::HELPERS::DialogResponse;
 
 #define DEFAULT_INFO_STRING_VALUE "unknown"
 
@@ -1943,10 +1948,10 @@ bool CPVRClient::Autoconfigure(void)
         std::string strLogLine(StringUtils::Format(g_localizeStrings.Get(19689).c_str(), (*it).GetName().c_str(), (*it).GetIP().c_str()));
         CLog::Log(LOGDEBUG, "%s - %s", __FUNCTION__, strLogLine.c_str());
 
-        if (!CGUIDialogYesNo::ShowAndGetInput(CVariant{19688}, // Scanning for PVR services
-                                              CVariant{strLogLine},
-                                              CVariant{19690}, // Do you want to use this service?
-                                              CVariant{""}))
+        if (DialogResponse::YES != 
+          HELPERS::ShowYesNoDialogLines(CVariant{19688}, // Scanning for PVR services
+                                        CVariant{strLogLine},
+                                        CVariant{19690})) // Do you want to use this service?
         {
           CLog::Log(LOGDEBUG, "%s - %s service found but not enabled by the user", __FUNCTION__, (*it).GetName().c_str());
           m_rejectedAvahiHosts.push_back(*it);

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -20,7 +20,8 @@
 
 #include "dialogs/GUIDialogKaiToast.h"
 #include "dialogs/GUIDialogOK.h"
-#include "dialogs/GUIDialogYesNo.h"
+#include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/DialogHelper.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "utils/log.h"
@@ -37,6 +38,9 @@
 
 using namespace PVR;
 using namespace EPG;
+using namespace KODI::MESSAGING;
+
+using KODI::MESSAGING::HELPERS::DialogResponse;
 
 CPVRTimerInfoTag::CPVRTimerInfoTag(bool bRadio /* = false */) :
   m_strTitle(g_localizeStrings.Get(19056)), // New Timer
@@ -528,7 +532,7 @@ bool CPVRTimerInfoTag::DeleteFromClient(bool bForce /* = false */ , bool bDelete
   if (error == PVR_ERROR_RECORDING_RUNNING)
   {
     // recording running. ask the user if it should be deleted anyway
-    if (!CGUIDialogYesNo::ShowAndGetInput(CVariant{122}, CVariant{19122}))
+    if (HELPERS::ShowYesNoDialogText(CVariant{122}, CVariant{19122}) != DialogResponse::YES)
       return false;
 
     error = g_PVRClients->DeleteTimer(*this, true, bDeleteSchedule);

--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -27,11 +27,12 @@
 #include <float.h>
 
 #include "DisplaySettings.h"
-#include "dialogs/GUIDialogYesNo.h"
 #include "guilib/GraphicContext.h"
 #include "guilib/gui3d.h"
 #include "guilib/LocalizeStrings.h"
 #include "guilib/StereoscopicsManager.h"
+#include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/DialogHelper.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/lib/Setting.h"
 #include "settings/Settings.h"
@@ -41,6 +42,10 @@
 #include "utils/Variant.h"
 #include "utils/XMLUtils.h"
 #include "windowing/WindowingFactory.h"
+
+using namespace KODI::MESSAGING;
+
+using KODI::MESSAGING::HELPERS::DialogResponse;
 
 // 0.1 second increments
 #define MAX_REFRESH_CHANGE_DELAY 200
@@ -257,8 +262,8 @@ bool CDisplaySettings::OnSettingChanging(const CSetting *setting)
     {
       if (!m_resolutionChangeAborted)
       {
-        bool cancelled = false;
-        if (!CGUIDialogYesNo::ShowAndGetInput(CVariant{13110}, CVariant{13111}, cancelled, CVariant{""}, CVariant{""}, 10000))
+        if (HELPERS::ShowYesNoDialogText(CVariant{13110}, CVariant{13111}, CVariant{""}, CVariant{""}, 10000) !=
+          DialogResponse::YES)
         {
           m_resolutionChangeAborted = true;
           return false;
@@ -278,8 +283,8 @@ bool CDisplaySettings::OnSettingChanging(const CSetting *setting)
 
     if (!m_resolutionChangeAborted)
     {
-      bool cancelled = false;
-      if (!CGUIDialogYesNo::ShowAndGetInput(CVariant{13110}, CVariant{13111}, cancelled, CVariant{""}, CVariant{""}, 10000))
+      if (HELPERS::ShowYesNoDialogText(CVariant{13110}, CVariant{13111}, CVariant{""}, CVariant{""}, 10000) !=
+        DialogResponse::YES)
       {
         m_resolutionChangeAborted = true;
         return false;

--- a/xbmc/settings/MediaSettings.cpp
+++ b/xbmc/settings/MediaSettings.cpp
@@ -27,9 +27,10 @@
 #include "PlayListPlayer.h"
 #include "dialogs/GUIDialogContextMenu.h"
 #include "dialogs/GUIDialogFileBrowser.h"
-#include "dialogs/GUIDialogYesNo.h"
 #include "interfaces/Builtins.h"
 #include "music/MusicDatabase.h"
+#include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/DialogHelper.h"
 #include "profiles/ProfilesManager.h"
 #include "settings/lib/Setting.h"
 #include "settings/Settings.h"
@@ -42,6 +43,10 @@
 #include "utils/Variant.h"
 #include "video/VideoDatabase.h"
 #include "cores/AudioEngine/DSPAddons/ActiveAEDSP.h"
+
+using namespace KODI::MESSAGING;
+
+using KODI::MESSAGING::HELPERS::DialogResponse;
 
 CMediaSettings::CMediaSettings()
 {
@@ -359,7 +364,7 @@ void CMediaSettings::OnSettingAction(const CSetting *setting)
   }
   else if (settingId == CSettings::SETTING_MUSICLIBRARY_CLEANUP)
   {
-    if (CGUIDialogYesNo::ShowAndGetInput(CVariant{313}, CVariant{333}))
+    if (HELPERS::ShowYesNoDialogText(CVariant{313}, CVariant{333}) == DialogResponse::YES)
       g_application.StartMusicCleanup(true);
   }
   else if (settingId == CSettings::SETTING_MUSICLIBRARY_EXPORT)
@@ -382,7 +387,7 @@ void CMediaSettings::OnSettingAction(const CSetting *setting)
   }
   else if (settingId == CSettings::SETTING_VIDEOLIBRARY_CLEANUP)
   {
-    if (CGUIDialogYesNo::ShowAndGetInput(CVariant{313}, CVariant{333}))
+    if (HELPERS::ShowYesNoDialogText(CVariant{313}, CVariant{333}) == DialogResponse::YES)
       g_application.StartVideoCleanup(true);
   }
   else if (settingId == CSettings::SETTING_VIDEOLIBRARY_EXPORT)

--- a/xbmc/utils/RssManager.cpp
+++ b/xbmc/utils/RssManager.cpp
@@ -21,9 +21,10 @@
 #include "RssManager.h"
 #include "addons/AddonInstaller.h"
 #include "addons/AddonManager.h"
-#include "dialogs/GUIDialogYesNo.h"
 #include "filesystem/File.h"
 #include "interfaces/Builtins.h"
+#include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/DialogHelper.h"
 #include "profiles/ProfilesManager.h"
 #include "settings/lib/Setting.h"
 #include "settings/Settings.h"
@@ -34,6 +35,9 @@
 #include "utils/Variant.h"
 
 using namespace XFILE;
+using namespace KODI::MESSAGING;
+
+using KODI::MESSAGING::HELPERS::DialogResponse;
 
 CRssManager::CRssManager()
 {
@@ -73,8 +77,11 @@ void CRssManager::OnSettingAction(const CSetting *setting)
     ADDON::CAddonMgr::GetInstance().GetAddon("script.rss.editor",addon);
     if (!addon)
     {
-      if (!CGUIDialogYesNo::ShowAndGetInput(CVariant{24076}, CVariant{24100}, CVariant{"RSS Editor"}, CVariant{24101}))
+      if (HELPERS::ShowYesNoDialogLines(CVariant{24076}, CVariant{24100}, CVariant{"RSS Editor"}, CVariant{24101}) !=
+        DialogResponse::YES)
+      {
         return;
+      }
       CAddonInstaller::GetInstance().InstallOrUpdate("script.rss.editor", "", false);
     }
     CBuiltins::Execute("RunScript(script.rss.editor)");

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -35,9 +35,10 @@
 #include "filesystem/File.h"
 #include "dialogs/GUIDialogExtendedProgressBar.h"
 #include "dialogs/GUIDialogProgress.h"
-#include "dialogs/GUIDialogYesNo.h"
 #include "dialogs/GUIDialogOK.h"
 #include "interfaces/AnnouncementManager.h"
+#include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/DialogHelper.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "utils/StringUtils.h"
@@ -54,6 +55,9 @@
 
 using namespace XFILE;
 using namespace ADDON;
+using namespace KODI::MESSAGING;
+
+using KODI::MESSAGING::HELPERS::DialogResponse;
 
 namespace VIDEO
 {
@@ -2051,7 +2055,7 @@ namespace VIDEO
       CGUIDialogOK::ShowAndGetInput(CVariant{20448}, CVariant{20449});
       return false;
     }
-    return CGUIDialogYesNo::ShowAndGetInput(CVariant{20448}, CVariant{20450});
+    return HELPERS::ShowYesNoDialogText(CVariant{20448}, CVariant{20450}) == DialogResponse::YES;
   }
 
   bool CVideoInfoScanner::ProgressCancelled(CGUIDialogProgress* progress, int heading, const std::string &line1)


### PR DESCRIPTION
So this is the continuation of the big appmessenger rewrite. Actually using it to get rid of our non-ui code calling directly into the ui and depending on it. Taking this one dialog at a time to keep the changes from ballooning and being unreviewable.
