### PR TITLE
[videodatabase] fix 'replace file names with library titles' for folders containing a single series

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -6668,19 +6668,21 @@ std::string CVideoDatabase::GetContentForPath(const std::string& strPath)
   {
     if (scraper->Content() == CONTENT_TVSHOWS)
     {
-      if (foundDirectly)
-        return "tvshows";
-
       // check for episodes or seasons.  Assumptions are:
       // 1. if episodes are in the path then we're in episodes.
       // 2. if no episodes are found, and content was set directly on this path, then we're in shows.
       // 3. if no episodes are found, and content was not set directly on this path, we're in seasons (assumes tvshows/seasons/episodes)
-      std::string sql = PrepareSQL("SELECT count(1) FROM episode_view WHERE strPath LIKE '%s%%' LIMIT 1", strPath.c_str());
+      std::string sql = "SELECT COUNT(*) FROM episode_view ";
+
+      if (foundDirectly)
+        sql += PrepareSQL("WHERE strPath = '%s'", strPath.c_str());
+      else
+        sql += PrepareSQL("WHERE strPath LIKE '%s%%'", strPath.c_str());
 
       m_pDS->query( sql.c_str() );
       if (m_pDS->num_rows() && m_pDS->fv(0).get_asInt() > 0)
         return "episodes";
-      return "seasons";
+      return foundDirectly ? "tvshows" : "seasons";
     }
     return TranslateContent(scraper->Content());
   }


### PR DESCRIPTION
Fixes an issue reported after https://github.com/xbmc/xbmc/pull/6969.

@ksooo, please give it a try.
