### PR TITLE
[guilib] add justify alignment for grouplist controls

### DIFF
--- a/xbmc/guilib/GUIControlGroupList.cpp
+++ b/xbmc/guilib/GUIControlGroupList.cpp
@@ -220,6 +220,9 @@ bool CGUIControlGroupList::OnMessage(CGUIMessage& message)
 
 void CGUIControlGroupList::ValidateOffset()
 {
+  // calculate item gap. this needs to be done
+  // before fetching the total size
+  CalculateItemGap();
   // calculate how many items we have on this page
   m_totalSize = GetTotalSize();
   // check our m_offset range
@@ -502,13 +505,33 @@ bool CGUIControlGroupList::IsLastFocusableControl(const CGUIControl *control) co
   return false;
 }
 
+void CGUIControlGroupList::CalculateItemGap()
+{
+  if (m_alignment & XBFONT_JUSTIFIED)
+  {
+    int itemsCount = 0;
+    float itemsSize = 0;
+    for (const auto& child : m_children)
+    {
+      if (child->IsVisible())
+      {
+        itemsSize += Size(child);
+        itemsCount++;
+      }
+    }
+
+    if (itemsCount > 0)
+      m_itemGap = (Size() - itemsSize) / itemsCount;
+  }
+}
+
 float CGUIControlGroupList::GetAlignOffset() const
 {
   if (m_totalSize < Size())
   {
     if (m_alignment & XBFONT_RIGHT)
       return Size() - m_totalSize;
-    if (m_alignment & XBFONT_CENTER_X)
+    if (m_alignment & (XBFONT_CENTER_X | XBFONT_JUSTIFIED))
       return (Size() - m_totalSize)*0.5f;
   }
   return 0.0f;

--- a/xbmc/guilib/GUIControlGroupList.h
+++ b/xbmc/guilib/GUIControlGroupList.h
@@ -68,6 +68,7 @@ protected:
   bool IsFirstFocusableControl(const CGUIControl *control) const;
   bool IsLastFocusableControl(const CGUIControl *control) const;
   void ValidateOffset();
+  void CalculateItemGap();
   inline float Size(const CGUIControl *control) const;
   void ScrollTo(float offset);
   float GetAlignOffset() const;


### PR DESCRIPTION
Adds justified alignment for grouplist controls. This is done by re-calculating the item gap size based on the actual control width and the amount of items. Needs testing.

/cc @BigNoid, @HitcherUK, @phil65 and @ronie
