### PR TITLE
Fix TexturePacker

### DIFF
--- a/project/BuildDependencies/scripts/0_package.list
+++ b/project/BuildDependencies/scripts/0_package.list
@@ -49,5 +49,5 @@ python-2.7.8-win32.7z
 sqlite-3.8.6-win32-vc120.7z
 swig-2.0.7-win32-1.7z
 taglib-1.9.1-win32-vc120.7z
-texturepacker-1.0.2-win32.7z
+texturepacker-1.0.3-win32.7z
 tinyxml-2.6.2_3-win32-vc120.7z

--- a/tools/depends/native/TexturePacker/src/Makefile.am
+++ b/tools/depends/native/TexturePacker/src/Makefile.am
@@ -25,11 +25,7 @@ TexturePacker_SOURCES =  md5.cpp \
   decoder/JPGDecoder.cpp \
   decoder/GifHelper.cpp \
   decoder/GIFDecoder.cpp \
-  XBTF.cpp \
-  XBTFReader.cpp
+  XBTF.cpp
 
 XBTF.cpp:
 	@cp @KODI_SRC_DIR@/xbmc/guilib/XBTF.cpp .
-
-XBTFReader.cpp:
-	@cp @KODI_SRC_DIR@/xbmc/guilib/XBTFReader.cpp .

--- a/tools/depends/native/TexturePacker/src/TexturePacker.cpp
+++ b/tools/depends/native/TexturePacker/src/TexturePacker.cpp
@@ -396,6 +396,8 @@ int createBundle(const std::string& InputDir, const std::string& OutputFile, dou
     }
     DecoderManager::FreeDecodedFrames(frames);
     file.SetLoop(0);
+
+    writer.UpdateFile(file);
   }
 
   if (!writer.UpdateHeader(dupes))

--- a/tools/depends/native/TexturePacker/src/Win32/TexturePacker.vcxproj
+++ b/tools/depends/native/TexturePacker/src/Win32/TexturePacker.vcxproj
@@ -99,7 +99,6 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\..\..\..\..\xbmc\guilib\XBTFReader.cpp" />
     <ClCompile Include="..\DecoderManager.cpp" />
     <ClCompile Include="..\decoder\GIFDecoder.cpp" />
     <ClCompile Include="..\decoder\GifHelper.cpp" />
@@ -112,7 +111,6 @@
     <ClCompile Include="..\XBTFWriter.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\..\..\..\..\xbmc\guilib\XBTFReader.h" />
     <ClInclude Include="..\cmdlineargs.h" />
     <ClInclude Include="..\DecoderManager.h" />
     <ClInclude Include="..\decoder\GIFDecoder.h" />

--- a/tools/depends/native/TexturePacker/src/Win32/TexturePacker.vcxproj
+++ b/tools/depends/native/TexturePacker/src/Win32/TexturePacker.vcxproj
@@ -47,7 +47,7 @@
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</LinkIncremental>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(VCInstallDir)include;$(VCInstallDir)atlmfc\include;$(WindowsSdkDir)include;$(FrameworkSDKDir)\include;..\..\..\..\..\..\project\BuildDependencies\include</IncludePath>
     <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(VCInstallDir)lib;$(VCInstallDir)atlmfc\lib;$(WindowsSdkDir)lib;$(FrameworkSDKDir)\lib;..\..\..\..\..\..\project\BuildDependencies\lib</LibraryPath>
-    <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(VCInstallDir)include;$(VCInstallDir)atlmfc\include;$(WindowsSdkDir)include;$(FrameworkSDKDir)\include;..\..\..\..\..\..\project\BuildDependencies\include</IncludePath>
+    <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(VCInstallDir)include;$(VCInstallDir)atlmfc\include;$(WindowsSdkDir)include;$(FrameworkSDKDir)\include;$(WindowsSDK_IncludePath);..\..\..\..\..\..\project\BuildDependencies\include</IncludePath>
     <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(VCInstallDir)lib;$(VCInstallDir)atlmfc\lib;$(WindowsSdkDir)lib;$(FrameworkSDKDir)\lib;..\..\..\..\..\..\project\BuildDependencies\lib</LibraryPath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">

--- a/tools/depends/native/TexturePacker/src/Win32/TexturePacker.vcxproj.filters
+++ b/tools/depends/native/TexturePacker/src/Win32/TexturePacker.vcxproj.filters
@@ -48,9 +48,6 @@
     <ClCompile Include="..\DecoderManager.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\..\..\xbmc\guilib\XBTFReader.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\cmdlineargs.h">
@@ -94,9 +91,6 @@
     </ClInclude>
     <ClInclude Include="..\DecoderManager.h">
       <Filter>Source Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\..\..\..\xbmc\guilib\XBTFReader.h">
-      <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/tools/depends/native/TexturePacker/src/XBTFWriter.cpp
+++ b/tools/depends/native/TexturePacker/src/XBTFWriter.cpp
@@ -18,12 +18,8 @@
  *
  */
 
-#include "XBTFWriter.h"
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
-#include "guilib/XBTF.h"
-#include "guilib/XBTFReader.h"
-#include "utils/EndianSwap.h"
 #if defined(TARGET_FREEBSD) || defined(TARGET_DARWIN)
 #include <stdlib.h>
 #elif !defined(TARGET_DARWIN)
@@ -31,35 +27,40 @@
 #endif
 #include <memory.h>
 
+#include "XBTFWriter.h"
+#include "guilib/XBTFReader.h"
+#include "utils/EndianSwap.h"
+
+
 #define WRITE_STR(str, size, file) fwrite(str, size, 1, file)
 #define WRITE_U32(i, file) { uint32_t _n = Endian_SwapLE32(i); fwrite(&_n, 4, 1, file); }
 #define WRITE_U64(i, file) { uint64_t _n = i; _n = Endian_SwapLE64(i); fwrite(&_n, 8, 1, file); }
 
-CXBTFWriter::CXBTFWriter(CXBTFReader& xbtfReader, const std::string& outputFile) : m_xbtfReader(xbtfReader)
+CXBTFWriter::CXBTFWriter(const std::string& outputFile)
+  : m_outputFile(outputFile),
+    m_file(nullptr),
+    m_data(nullptr),
+    m_size(0)
+{ }
+
+CXBTFWriter::~CXBTFWriter()
 {
-  m_outputFile = outputFile;
-  m_file = NULL;
-  m_data = NULL;
-  m_size = 0;
+  Close();
 }
 
 bool CXBTFWriter::Create()
 {
   m_file = fopen(m_outputFile.c_str(), "wb");
-  if (m_file == NULL)
-  {
+  if (m_file == nullptr)
     return false;
-  }
 
   return true;
 }
 
 bool CXBTFWriter::Close()
 {
-  if (m_file == NULL || m_data == NULL)
-  {
+  if (m_file == nullptr || m_data == nullptr)
     return false;
-  }
 
   fwrite(m_data, 1, m_size, m_file);
 
@@ -71,12 +72,12 @@ bool CXBTFWriter::Close()
 void CXBTFWriter::Cleanup()
 {
   free(m_data);
-  m_data = NULL;
+  m_data = nullptr;
   m_size = 0;
   if (m_file)
   {
     fclose(m_file);
-    m_file = NULL;
+    m_file = nullptr;
   }
 }
 
@@ -84,7 +85,7 @@ bool CXBTFWriter::AppendContent(unsigned char const* data, size_t length)
 {
   unsigned char *new_data = (unsigned char *)realloc(m_data, m_size + length);
 
-  if (new_data == NULL)
+  if (new_data == nullptr)
   { // OOM - cleanup and fail
     Cleanup();
     return false;
@@ -100,17 +101,16 @@ bool CXBTFWriter::AppendContent(unsigned char const* data, size_t length)
 
 bool CXBTFWriter::UpdateHeader(const std::vector<unsigned int>& dupes)
 {
-  if (m_file == NULL)
-  {
+  if (m_file == nullptr)
     return false;
-  }
 
-  uint64_t offset = m_xbtfReader.GetHeaderSize();
+  uint64_t headerSize = GetHeaderSize();
+  uint64_t offset = headerSize;
 
   WRITE_STR(XBTF_MAGIC.c_str(), 4, m_file);
   WRITE_STR(XBTF_VERSION.c_str(), 1, m_file);
 
-  std::vector<CXBTFFile> files = m_xbtfReader.GetFiles();
+  auto files = GetFiles();
   WRITE_U32(files.size(), m_file);
   for (size_t i = 0; i < files.size(); i++)
   {
@@ -121,7 +121,7 @@ bool CXBTFWriter::UpdateHeader(const std::vector<unsigned int>& dupes)
     for (std::string::iterator ch = path.begin(); ch != path.end(); ++ch)
       *ch = tolower(*ch);
 
-    WRITE_STR(path.c_str(), 256, m_file);
+    WRITE_STR(path.c_str(), CXBTFFile::MaximumPathLength, m_file);
     WRITE_U32(file.GetLoop(), m_file);
 
     std::vector<CXBTFFrame>& frames = file.GetFrames();
@@ -149,9 +149,9 @@ bool CXBTFWriter::UpdateHeader(const std::vector<unsigned int>& dupes)
 
   // Sanity check
   int64_t pos = ftell(m_file);
-  if (pos != (int64_t)m_xbtfReader.GetHeaderSize())
+  if (pos != static_cast<int64_t>(headerSize))
   {
-    printf("Expected header size (%" PRId64 ") != actual size (%" PRId64 ")\n", m_xbtfReader.GetHeaderSize(), pos);
+    printf("Expected header size (%" PRIu64 ") != actual size (%" PRId64 ")\n", headerSize, pos);
     return false;
   }
 

--- a/tools/depends/native/TexturePacker/src/XBTFWriter.h
+++ b/tools/depends/native/TexturePacker/src/XBTFWriter.h
@@ -25,12 +25,14 @@
 #include <string>
 #include <stdio.h>
 
-class CXBTFReader;
+#include "guilib/XBTF.h"
 
-class CXBTFWriter
+class CXBTFWriter : public CXBTFBase
 {
 public:
-  CXBTFWriter(CXBTFReader& xbtfReader, const std::string& outputFile);
+  CXBTFWriter(const std::string& outputFile);
+  ~CXBTFWriter();
+
   bool Create();
   bool Close();
   bool AppendContent(unsigned char const* data, size_t length);
@@ -39,7 +41,6 @@ public:
 private:
   void Cleanup();
 
-  CXBTFReader& m_xbtfReader;
   std::string m_outputFile;
   FILE* m_file;
   unsigned char *m_data;

--- a/xbmc/guilib/XBTF.cpp
+++ b/xbmc/guilib/XBTF.cpp
@@ -199,3 +199,55 @@ uint64_t CXBTFFile::GetHeaderSize() const
 
   return result;
 }
+
+uint64_t CXBTFBase::GetHeaderSize() const
+{
+  uint64_t result = XBTF_MAGIC.size() + XBTF_VERSION.size() +
+    sizeof(uint32_t) /* number of files */;
+
+  for (const auto& file : m_files)
+    result += file.second.GetHeaderSize();
+
+  return result;
+}
+
+bool CXBTFBase::Exists(const std::string& name) const
+{
+  CXBTFFile dummy;
+  return Get(name, dummy);
+}
+
+bool CXBTFBase::Get(const std::string& name, CXBTFFile& file) const
+{
+  const auto& iter = m_files.find(name);
+  if (iter == m_files.end())
+    return false;
+
+  file = iter->second;
+  return true;
+}
+
+std::vector<CXBTFFile> CXBTFBase::GetFiles() const
+{
+  std::vector<CXBTFFile> files;
+  files.reserve(m_files.size());
+
+  for (const auto& file : m_files)
+    files.push_back(file.second);
+
+  return files;
+}
+
+void CXBTFBase::AddFile(const CXBTFFile& file)
+{
+  m_files.insert(std::make_pair(file.GetPath(), file));
+}
+
+void CXBTFBase::UpdateFile(const CXBTFFile& file)
+{
+  auto&& it = m_files.find(file.GetPath());
+  if (it == m_files.end())
+    return;
+
+  it->second = file;
+}

--- a/xbmc/guilib/XBTF.h
+++ b/xbmc/guilib/XBTF.h
@@ -19,6 +19,7 @@
  *
  */
 
+#include <map>
 #include <string>
 #include <vector>
 
@@ -106,4 +107,23 @@ private:
   std::string m_path;
   uint32_t m_loop;
   std::vector<CXBTFFrame> m_frames;
+};
+
+class CXBTFBase
+{
+public:
+  virtual ~CXBTFBase() { }
+
+  uint64_t GetHeaderSize() const;
+
+  bool Exists(const std::string& name) const;
+  bool Get(const std::string& name, CXBTFFile& file) const;
+  std::vector<CXBTFFile> GetFiles() const;
+  void AddFile(const CXBTFFile& file);
+  void UpdateFile(const CXBTFFile& file);
+
+protected:
+  CXBTFBase() { }
+
+  std::map<std::string, CXBTFFile> m_files;
 };

--- a/xbmc/guilib/XBTFReader.cpp
+++ b/xbmc/guilib/XBTFReader.cpp
@@ -66,9 +66,9 @@ static bool ReadUInt64(FILE* file, uint64_t& value)
 }
 
 CXBTFReader::CXBTFReader()
-  : m_path(),
-    m_file(nullptr),
-    m_files()
+  : CXBTFBase(),
+    m_path(),
+    m_file(nullptr)
 { }
 
 CXBTFReader::~CXBTFReader()
@@ -208,33 +208,6 @@ time_t CXBTFReader::GetLastModificationTimestamp() const
   return fileStat.st_mtime;
 }
 
-uint64_t CXBTFReader::GetHeaderSize() const
-{
-  uint64_t result = XBTF_MAGIC.size() + XBTF_VERSION.size() +
-    sizeof(uint32_t) /* number of files */;
-
-  for (const auto& file : m_files)
-    result += file.second.GetHeaderSize();
-
-  return result;
-}
-
-bool CXBTFReader::Exists(const std::string& name) const
-{
-  CXBTFFile dummy;
-  return Get(name, dummy);
-}
-
-bool CXBTFReader::Get(const std::string& name, CXBTFFile& file) const
-{
-  const auto& iter = m_files.find(name);
-  if (iter == m_files.end())
-    return false;
-
-  file = iter->second;
-  return true;
-}
-
 bool CXBTFReader::Load(const CXBTFFrame& frame, unsigned char* buffer) const
 {
   if (m_file == nullptr)
@@ -251,20 +224,4 @@ bool CXBTFReader::Load(const CXBTFFrame& frame, unsigned char* buffer) const
     return false;
 
   return true;
-}
-
-std::vector<CXBTFFile> CXBTFReader::GetFiles() const
-{
-  std::vector<CXBTFFile> files;
-  files.reserve(m_files.size());
-
-  for (const auto& file : m_files)
-    files.push_back(file.second);
-
-  return files;
-}
-
-void CXBTFReader::AddFile(const CXBTFFile& file)
-{
-  m_files.insert(std::make_pair(file.GetPath(), file));
 }

--- a/xbmc/guilib/XBTFReader.h
+++ b/xbmc/guilib/XBTFReader.h
@@ -19,17 +19,15 @@
  *
  */
 
-#include <map>
 #include <memory>
 #include <string>
 #include <vector>
 
 #include <stdint.h>
 
-class CXBTFFile;
-class CXBTFFrame;
+#include "XBTF.h"
 
-class CXBTFReader
+class CXBTFReader : public CXBTFBase
 {
 public:
   CXBTFReader();
@@ -40,19 +38,12 @@ public:
   void Close();
 
   time_t GetLastModificationTimestamp() const;
-  uint64_t GetHeaderSize() const;
-
-  bool Exists(const std::string& name) const;
-  bool Get(const std::string& name, CXBTFFile& file) const;
-  std::vector<CXBTFFile> GetFiles() const;
-  void AddFile(const CXBTFFile& file);
 
   bool Load(const CXBTFFrame& frame, unsigned char* buffer) const;
 
 private:
   std::string m_path;
   FILE* m_file;
-  std::map<std::string, CXBTFFile> m_files;
 };
 
 typedef std::shared_ptr<CXBTFReader> CXBTFReaderPtr;


### PR DESCRIPTION
This should fix building and executing TexturePacker after #7694. On Win32 it didn't build because of new dependencies introduced by `CXBTFReader` which is why I split part of `CXBTFReader` into `CXBTFBase` and derived both `CXBTFReader` and `CXBTFWriter` from it. That way I can get rid of having to use `CXBTFReader` in `CXBTFWriter` (which is really ugly anyway).

Furthermore the TexturePacker is currently not writing the number of frames properly into the output file which results in Kodi not being able to read any files from an XBT created with the current state of TexturePacker.

I also made some cosmetic changes while editing `CXBTFWriter` like replacing `NULL` with `nullptr` etc.

Do I need to build and upload a new `TexturePacker.exe` for WIN32?
