### PR TITLE
[Confluence] - fix WindowOpen animation for Eventlog

### DIFF
--- a/addons/skin.confluence/720p/EventLog.xml
+++ b/addons/skin.confluence/720p/EventLog.xml
@@ -8,9 +8,6 @@
 	<controls>
 		<include>CommonBackground</include>
 		<include>ContentPanelBackgrounds</include>
-		<control type="group">
-			<include>Window_OpenClose_Animation</include>
-		</control>
 		<include>CommonPageCount</include>
 		<include>CommonNowPlaying</include>
 		<include>MainWindowMouseButtons</include>
@@ -27,6 +24,7 @@
 		</control>
 		<control type="group">
 			<visible>Control.IsVisible(570)</visible>
+			<include>Window_OpenClose_Animation</include>
 			<include>VisibleFadeEffect</include>
 			<control type="image">
 				<left>75</left>


### PR DESCRIPTION
the group containing the WindowOpen animation (and therefore its scope) does not contain any controls at the moment and a WindowOpen animation is missing for the main panel. This commit moves that animation include to the correct group so that animations are consistent again.
@ronie  
