### PR TITLE
[readme] add uuid-dev / crossguid to dependencies

### DIFF
--- a/docs/README.linux
+++ b/docs/README.linux
@@ -57,12 +57,17 @@ Build-Depends: autoconf, automake, autopoint, autotools-dev, cmake, curl,
   libtag1-dev (>= 1.8), libtiff-dev, libtinyxml-dev (>= 2.6.2), libtool, libudev-dev,
   libusb-dev, libva-dev, libvdpau-dev, libvorbis-dev, libxinerama-dev, libxml2-dev,
   libxmu-dev, libxrandr-dev, libxslt1-dev, libxt-dev, libyajl-dev (>=2.0), lsb-release,
-  nasm [!amd64], python-dev, python-imaging, python-support, swig, unzip, yasm, zip,
-  zlib1g-dev, uuid-dev
+  nasm [!amd64], python-dev, python-imaging, python-support, swig, unzip, uuid-dev, yasm, zip,
+  zlib1g-dev
   
-Note: For developers and anyone else who compiles frequently it is recommended to use ccache.
+[NOTICE] crossguid / libcrossguid-dev all Linux destributions.
+Kodi now requires crossguid which is not available in Ubuntu repositories at this time.
+We supply a Makefile in tools/depends/target/crossguid
+to make it easy to install into /usr/local.
+    $ make -C tools/depends/target/crossguid PREFIX=/usr/local/crossguid
 
-   $ sudo apt-get install ccache
+Note: For developers and anyone else who compiles frequently it is recommended to use ccache.
+    $ sudo apt-get install ccache
 
 -----------------------------------------------------------------------------
 3.1. Using the Kodi PPA to get all build dependencies (Debian/Ubuntu only)
@@ -75,18 +80,16 @@ Note: See README.ubuntu as well
 http://kodi.wiki/index.php?title=Official_Ubuntu_PPA
 
 Update apt:
-   $ sudo apt-get update
+    $ sudo apt-get update
 
 The command to get the build dependencies, used to compile the version on the PPA.
-
-   $ sudo apt-get build-dep kodi
+    $ sudo apt-get build-dep kodi
 
 -----------------------------------------------------------------------------
 4. How to compile
 -----------------------------------------------------------------------------
 
 To create the Kodi executable manually perform these steps:
-
 .0  $ ./bootstrap
 
 .1  $ ./configure <option1> <option2> PREFIX=<system prefix>... (See --help for available options)

--- a/docs/README.ubuntu
+++ b/docs/README.ubuntu
@@ -81,8 +81,7 @@ Tip: For those with multiple computers at home is to try out distcc
 -----------------------------------------------------------------------------
 
 For Ubuntu (all versions >= 7.04):
-
-    $ sudo apt-get install automake bison build-essential cmake curl cvs default-jre fp-compiler gawk gdc gettext git-core gperf libasound2-dev libass-dev libboost-dev libboost-thread-dev libbz2-dev libcap-dev libcdio-dev libcurl3 libcurl4-openssl-dev libdbus-1-dev libfontconfig-dev libfreetype6-dev libfribidi-dev libgif-dev libglew-dev libiso9660-dev libjasper-dev libjpeg-dev liblzo2-dev libmicrohttpd-dev libmodplug-dev libmpeg2-4-dev libmpeg3-dev libmysqlclient-dev libnfs-dev libogg-dev libpcre3-dev libplist-dev libpng-dev libpulse-dev libsdl2-dev libsmbclient-dev libsqlite3-dev libssh-dev libssl-dev libtiff-dev libtinyxml-dev libtool libudev-dev libusb-dev libva-dev libvdpau-dev libvorbis-dev libvorbisenc2 libxml2-dev libxmu-dev libxrandr-dev libxrender-dev libxslt1-dev libxt-dev libyajl-dev mesa-utils nasm pmount python-dev python-imaging python-sqlite swig unzip yasm zip zlib1g-dev
+    $ sudo apt-get install automake bison build-essential cmake curl cvs default-jre fp-compiler gawk gdc gettext git-core gperf libasound2-dev libass-dev libboost-dev libboost-thread-dev libbz2-dev libcap-dev libcdio-dev libcurl3 libcurl4-openssl-dev libdbus-1-dev libfontconfig-dev libfreetype6-dev libfribidi-dev libgif-dev libglew-dev libiso9660-dev libjasper-dev libjpeg-dev liblzo2-dev libmicrohttpd-dev libmodplug-dev libmpeg2-4-dev libmpeg3-dev libmysqlclient-dev libnfs-dev libogg-dev libpcre3-dev libplist-dev libpng-dev libpulse-dev libsdl2-dev libsmbclient-dev libsqlite3-dev libssh-dev libssl-dev libtiff-dev libtinyxml-dev libtool libudev-dev libusb-dev libva-dev libvdpau-dev libvorbis-dev libvorbisenc2 libxml2-dev libxmu-dev libxrandr-dev libxrender-dev libxslt1-dev libxt-dev libyajl-dev mesa-utils nasm pmount python-dev python-imaging python-sqlite swig unzip uuid-dev yasm zip zlib1g-dev
 
 For >= 10.10:
     $ sudo apt-get install autopoint libltdl-dev
@@ -105,14 +104,24 @@ In this case you will have to manually compile the latest version.
 
 For <= 12.04
 Kodi needs a new version of taglib other than what is available at this time.
-We supply a Makefile in lib/taglib to make it easy to install into /usr/local.
-    $ sudo apt-get remove libtag1-dev
+Use prepackaged from the Kodi build-depends PPA.
+0.  $ sudo apt-get install libtag1-dev
+
+We also supply a Makefile in lib/taglib to make it easy to install into /usr/local.
+1.  $ sudo apt-get remove libtag1-dev
     $ make -C lib/taglib
     $ sudo make -C lib/taglib install
+	
+[NOTICE] crossguid / libcrossguid-dev all Linux destributions.
+Kodi now requires crossguid which is not available in Ubuntu repositories at this time.
+If build-deps PPA doesnt provide a pre-packaged version for your dissee (1.) below.
 
-or use prepackaged from the Kodi PPA.
+Use prepackaged from the Kodi build-depends PPA.
+0.  $ sudo apt-get install libcrossguid-dev
 
-    $ sudo apt-get install libtag1-dev
+We also supply a Makefile in tools/depends/target/crossguid
+to make it easy to install into /usr/local.
+1.  $ make -C tools/depends/target/crossguid PREFIX=/usr/local/crossguid
 
 Unless you are proficient with how Linux libraries and versions work, do not
 try to provide it yourself, as you will likely mess up for other programs.


### PR DESCRIPTION
This add uuid-dev to readme.ubuntu dependencies and crossguid to further required dependencies how-to

@Montellese since he added uuid-dev this to readme.linux but not here.

@wsnipex Cant compile crossguid via make -C (see how I added in readme) it complains have to set prefix but of course it cant be set or am I missing something? Please let me know what the correct procedure is.

Also a Q what about crossguid in readme.linux needs to be added also no?
