### PR TITLE
fixed: setlocale issue other than windows

### DIFF
--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -263,13 +263,13 @@ void CLangInfo::CRegion::SetGlobalLocale()
   std::string strLocale;
   if (m_strRegionLocaleName.length() > 0)
   {
+#ifdef TARGET_WINDOWS
     std::string strLang, strRegion;
     g_LangCodeExpander.ConvertToISO6391(m_strLangLocaleName, strLang);
     g_LangCodeExpander.ConvertToISO6391(m_strRegionLocaleName, strRegion);
-#ifdef TARGET_WINDOWS
     strLocale = strLang + "-" + strRegion;
 #else
-    strLocale = strLang + "_" + strRegion;
+    strLocale = m_strLangLocaleName + "_" + m_strRegionLocaleName;
 #endif
 #ifdef TARGET_POSIX
     strLocale += ".UTF-8";


### PR DESCRIPTION
https://github.com/xbmc/xbmc/pull/7738 have a bug other than windows. That is: `m_strLangLocaleName` and `m_strRegionLocaleName`  is 3 char code only on windows, they are 2 char code on other os. and `g_LangCodeExpander.ConvertToISO6391` will return null string with 2 char region code input.

Note: still can't set locale in right language and region on android and ios.
1. android ndk only support "", "C", "C.UTF-8", "en_US.UTF-8", "POSIX", see: https://developer.android.com/ndk/guides/cpp-support.html and https://github.com/android/platform_bionic/blob/master/libc/bionic/locale.cpp
2. ios only support "", "C", "POSIX" by default. and here is a method to expand it (I don't know how to use in kodi): http://blog.163.com/sylar_lin/blog/static/19233209320136944412210/
