### PR TITLE
reloading the skin when changing themes must be done asynchronously

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1398,7 +1398,7 @@ void CApplication::OnSettingChanged(const CSetting *setting)
     if (!StringUtils::EqualsNoCase(colorTheme, CSettings::Get().GetString(CSettings::SETTING_LOOKANDFEEL_SKINCOLORS)))
       CSettings::Get().SetString(CSettings::SETTING_LOOKANDFEEL_SKINCOLORS, colorTheme);
     else
-      CApplicationMessenger::Get().SendMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr, "ReloadSkin");
+      CApplicationMessenger::Get().PostMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr, "ReloadSkin");
   }
   else if (settingId == CSettings::SETTING_LOOKANDFEEL_SKINZOOM)
   {


### PR DESCRIPTION
This was broken since the `CApplicationMessenger` refactor due to using the synchronous `SendMsg()` instead of the asynchronous `PostMsg()`, see https://github.com/xbmc/xbmc/commit/9e9396b073ba973b2847896a11244a9f37ecbaff#diff-63246197ac0f0ac89358c1155ad21d5bR1417.
