### PR TITLE
[mysql] Fix incomprehensible error message

### DIFF
--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -277,7 +277,7 @@ int MysqlDatabase::copy(const char *backup_name) {
       if ( (ret=query_with_reconnect(sql)) != MYSQL_OK )
       {
         mysql_free_result(res);
-        throw DbErrors("Can't copy schema for table '%s'\nError: %d", db.c_str(), ret);
+        throw DbErrors("Can't copy schema for table '%s'\nError: %d", row[0], ret);
       }
 
       // copy the table data


### PR DESCRIPTION
When a table can't be copied, we're displaying the database name not the name of the table.

See [here](http://forum.kodi.tv/showthread.php?tid=235154&pid=2081337#pid2081337).

Backport coming up...
