### PR TITLE
[guilib] remove <angle> support - use rotate animation instead

### DIFF
--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -854,8 +854,6 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   GetInfoColor(pControlNode, "invalidcolor", labelInfo.invalidColor, parentID);
   XMLUtils::GetFloat(pControlNode, "textoffsetx", labelInfo.offsetX);
   XMLUtils::GetFloat(pControlNode, "textoffsety", labelInfo.offsetY);
-  int angle = 0;  // use the negative angle to compensate for our vertically flipped cartesian plane
-  if (XMLUtils::GetInt(pControlNode, "angle", angle)) labelInfo.angle = (float)-angle;
   std::string strFont;
   if (XMLUtils::GetString(pControlNode, "font", strFont))
     labelInfo.font = g_fontManager.GetFont(strFont);

--- a/xbmc/guilib/GUIFadeLabelControl.cpp
+++ b/xbmc/guilib/GUIFadeLabelControl.cpp
@@ -195,7 +195,7 @@ void CGUIFadeLabelControl::Render()
     m_textLayout.Render(posX, posY, 0, m_label.textColor, m_label.shadowColor, m_label.align, m_width);
   }
   else
-    m_textLayout.RenderScrolling(m_posX, posY, 0, m_label.textColor, m_label.shadowColor, (m_label.align & ~3), m_width, m_scrollInfo);
+    m_textLayout.RenderScrolling(m_posX, posY, m_label.textColor, m_label.shadowColor, (m_label.align & ~3), m_width, m_scrollInfo);
   g_graphicsContext.RemoveTransform();
   CGUIControl::Render();
 }

--- a/xbmc/guilib/GUILabel.cpp
+++ b/xbmc/guilib/GUILabel.cpp
@@ -105,7 +105,7 @@ void CGUILabel::Render()
   bool renderSolid = (m_color == COLOR_DISABLED);
   bool overFlows = (m_renderRect.Width() + 0.5f < m_textLayout.GetTextWidth()); // 0.5f to deal with floating point rounding issues
   if (overFlows && m_scrolling && !renderSolid)
-    m_textLayout.RenderScrolling(m_renderRect.x1, m_renderRect.y1, m_label.angle, color, m_label.shadowColor, 0, m_renderRect.Width(), m_scrollInfo);
+    m_textLayout.RenderScrolling(m_renderRect.x1, m_renderRect.y1, color, m_label.shadowColor, 0, m_renderRect.Width(), m_scrollInfo);
   else
   {
     float posX = m_renderRect.x1;
@@ -120,13 +120,13 @@ void CGUILabel::Render()
         posX += m_renderRect.Width();
       else if (m_label.align & XBFONT_CENTER_X)
         posX += m_renderRect.Width() * 0.5f;
-      if (m_label.align & XBFONT_CENTER_Y) // need to pass a centered Y so that <angle> will rotate around the correct point.
+      if (m_label.align & XBFONT_CENTER_Y) // need to pass a centered Y so we rotate around the correct point.
         posY += m_renderRect.Height() * 0.5f;
       align = m_label.align;
     }
     else
       align |= XBFONT_TRUNCATED;
-    m_textLayout.Render(posX, posY, m_label.angle, color, m_label.shadowColor, align, m_overflowType == OVER_FLOW_CLIP ? m_textLayout.GetTextWidth() : m_renderRect.Width(), renderSolid);
+    m_textLayout.Render(posX, posY, color, m_label.shadowColor, align, m_overflowType == OVER_FLOW_CLIP ? m_textLayout.GetTextWidth() : m_renderRect.Width(), renderSolid);
   }
 }
 

--- a/xbmc/guilib/GUILabel.h
+++ b/xbmc/guilib/GUILabel.h
@@ -40,7 +40,6 @@ public:
     align = XBFONT_LEFT;
     offsetX = offsetY = 0;
     width = 0;
-    angle = 0;
     scrollSpeed = CScrollInfo::defaultSpeed;
   };
   bool UpdateColors()
@@ -67,7 +66,6 @@ public:
   float offsetX;
   float offsetY;
   float width;
-  float angle;
   CGUIFont *font;
   int scrollSpeed; 
   std::string scrollSuffix;

--- a/xbmc/guilib/GUIMultiSelectText.cpp
+++ b/xbmc/guilib/GUIMultiSelectText.cpp
@@ -137,11 +137,11 @@ void CGUIMultiSelectTextControl::Render()
   {
     CSelectableString &string = m_items[i];
     if (IsDisabled()) // all text is rendered with disabled color
-      string.m_text.Render(posX, posY, 0, m_label.disabledColor, m_label.shadowColor, m_label.align, 0, true);
+      string.m_text.Render(posX, posY, m_label.disabledColor, m_label.shadowColor, m_label.align, 0, true);
     else if (HasFocus() && string.m_selectable && num_selectable == m_selectedItem) // text is rendered with focusedcolor
-      string.m_text.Render(posX, posY, 0, m_label.focusedColor, m_label.shadowColor, m_label.align, 0);
+      string.m_text.Render(posX, posY, m_label.focusedColor, m_label.shadowColor, m_label.align, 0);
     else // text is rendered with textcolor
-      string.m_text.Render(posX, posY, 0, m_label.textColor, m_label.shadowColor, m_label.align, 0);
+      string.m_text.Render(posX, posY, m_label.textColor, m_label.shadowColor, m_label.align, 0);
     posX += string.m_length;
     if (string.m_selectable)
       num_selectable++;

--- a/xbmc/guilib/GUITextLayout.cpp
+++ b/xbmc/guilib/GUITextLayout.cpp
@@ -58,7 +58,7 @@ void CGUITextLayout::SetWrap(bool bWrap)
   m_wrap = bWrap;
 }
 
-void CGUITextLayout::Render(float x, float y, float angle, color_t color, color_t shadowColor, uint32_t alignment, float maxWidth, bool solid)
+void CGUITextLayout::Render(float x, float y, color_t color, color_t shadowColor, uint32_t alignment, float maxWidth, bool solid)
 {
   if (!m_font)
     return;
@@ -67,12 +67,6 @@ void CGUITextLayout::Render(float x, float y, float angle, color_t color, color_
   if (m_colors.size())
     m_colors[0] = color;
 
-  // render the text at the required location, angle, and size
-  if (angle)
-  {
-    static const float degrees_to_radians = 0.01745329252f;
-    g_graphicsContext.AddTransform(TransformMatrix::CreateZRotation(angle * degrees_to_radians, x, y, g_graphicsContext.GetScalingPixelRatio()));
-  }
   // center our text vertically
   if (alignment & XBFONT_CENTER_Y)
   {
@@ -93,8 +87,6 @@ void CGUITextLayout::Render(float x, float y, float angle, color_t color, color_
     y += m_font->GetLineHeight();
   }
   m_font->End();
-  if (angle)
-    g_graphicsContext.RemoveTransform();
 }
 
 bool CGUITextLayout::UpdateScrollinfo(CScrollInfo &scrollInfo)
@@ -108,7 +100,7 @@ bool CGUITextLayout::UpdateScrollinfo(CScrollInfo &scrollInfo)
 }
 
 
-void CGUITextLayout::RenderScrolling(float x, float y, float angle, color_t color, color_t shadowColor, uint32_t alignment, float maxWidth, const CScrollInfo &scrollInfo)
+void CGUITextLayout::RenderScrolling(float x, float y, color_t color, color_t shadowColor, uint32_t alignment, float maxWidth, const CScrollInfo &scrollInfo)
 {
   if (!m_font)
     return;
@@ -117,12 +109,6 @@ void CGUITextLayout::RenderScrolling(float x, float y, float angle, color_t colo
   if (m_colors.size())
     m_colors[0] = color;
 
-  // render the text at the required location, angle, and size
-  if (angle)
-  {
-    static const float degrees_to_radians = 0.01745329252f;
-    g_graphicsContext.AddTransform(TransformMatrix::CreateZRotation(angle * degrees_to_radians, x, y, g_graphicsContext.GetScalingPixelRatio()));
-  }
   // center our text vertically
   if (alignment & XBFONT_CENTER_Y)
   {
@@ -143,8 +129,6 @@ void CGUITextLayout::RenderScrolling(float x, float y, float angle, color_t colo
     y += m_font->GetLineHeight();
   }
   m_font->End();
-  if (angle)
-    g_graphicsContext.RemoveTransform();
 }
 
 void CGUITextLayout::RenderOutline(float x, float y, color_t color, color_t outlineColor, uint32_t alignment, float maxWidth)

--- a/xbmc/guilib/GUITextLayout.h
+++ b/xbmc/guilib/GUITextLayout.h
@@ -70,8 +70,8 @@ public:
   bool UpdateScrollinfo(CScrollInfo &scrollInfo);
 
   // main function to render strings
-  void Render(float x, float y, float angle, color_t color, color_t shadowColor, uint32_t alignment, float maxWidth, bool solid = false);
-  void RenderScrolling(float x, float y, float angle, color_t color, color_t shadowColor, uint32_t alignment, float maxWidth, const CScrollInfo &scrollInfo);
+  void Render(float x, float y, color_t color, color_t shadowColor, uint32_t alignment, float maxWidth, bool solid = false);
+  void RenderScrolling(float x, float y, color_t color, color_t shadowColor, uint32_t alignment, float maxWidth, const CScrollInfo &scrollInfo);
   void RenderOutline(float x, float y, color_t color, color_t outlineColor, uint32_t alignment, float maxWidth);
 
   /*! \brief Returns the precalculated width and height of the text to be rendered (in constant time).

--- a/xbmc/guilib/TransformMatrix.h
+++ b/xbmc/guilib/TransformMatrix.h
@@ -103,13 +103,6 @@ public:
     alpha = 1.0f;
     identity = (angle == 0);
   }
-  static TransformMatrix CreateZRotation(float angle, float x, float y, float ar = 1.0f)
-  { // angle about the Z axis, centered at x,y where our coordinate system has aspect ratio ar.
-    // Trans(x,y,0)*Scale(1/ar,1,1)*RotateZ(angle)*Scale(ar,1,1)*Trans(-x,-y,0)
-    TransformMatrix rot;
-    rot.SetZRotation(angle, x, y, ar);
-    return rot;
-  }
   void SetZRotation(float angle, float x, float y, float ar = 1.0f)
   { // angle about the Z axis, centered at x,y where our coordinate system has aspect ratio ar.
     // Trans(x,y,0)*Scale(1/ar,1,1)*RotateZ(angle)*Scale(ar,1,1)*Trans(-x,-y,0)

--- a/xbmc/interfaces/legacy/Control.cpp
+++ b/xbmc/interfaces/legacy/Control.cpp
@@ -286,7 +286,6 @@ namespace XBMCAddon
       label.align = align;
       label.offsetX = (float)textOffsetX;
       label.offsetY = (float)textOffsetY;
-      label.angle = (float)-iAngle;
       pGUIControl = new CGUIButtonControl(
         iParentId,
         iControlId,
@@ -719,7 +718,6 @@ namespace XBMCAddon
       label.align = align;
       label.offsetX = (float)textOffsetX;
       label.offsetY = (float)textOffsetY;
-      label.angle = (float)-iAngle;
       pGUIControl = new CGUIRadioButtonControl(
         iParentId,
         iControlId,
@@ -1018,7 +1016,6 @@ namespace XBMCAddon
       label.textColor = label.focusedColor = textColor;
       label.disabledColor = disabledColor;
       label.align = align;
-      label.angle = (float)-iAngle;
       pGUIControl = new CGUILabelControl(
         iParentId,
         iControlId,


### PR DESCRIPTION
This removes `<angle>` support. Follow up to https://github.com/xbmc/xbmc/commit/40df024b4dfe837025431e74e1610dc230ba2fab by @ronie which already handled the skin part.
