### PR TITLE
[WIP] [PVR] Timer Settings Dialog: First Day Defaults

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -612,7 +612,9 @@ void CGUIDialogPVRTimerSettings::Save()
   else
     m_timerInfoTag->m_iWeekdays = PVR_WEEKDAY_NONE;
 
-  // First day (only for repeating timers)
+  // First day (only for specifically supported types)
+  if (!m_timerType->SupportsFirstDay())
+    m_firstDayLocalTime.SetValid(false);
   m_timerInfoTag->SetFirstDayFromLocalTime(m_firstDayLocalTime);
 
   // "New episodes only" (only for repeating timers)

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -62,7 +62,7 @@ CPVRTimerInfoTag::CPVRTimerInfoTag(bool bRadio /* = false */) :
   m_bStartAnyTime       = false;
   m_bEndAnyTime         = false;
   m_state               = PVR_TIMER_STATE_SCHEDULED;
-  m_FirstDay.SetValid(false);
+  m_FirstDay            = m_StartTime;
   m_iTimerId            = 0;
 
   if (g_PVRClients->SupportsTimers(m_iClientId))
@@ -714,6 +714,7 @@ CPVRTimerInfoTagPtr CPVRTimerInfoTag::CreateFromEpg(const CEpgInfoTagPtr &tag, b
   newTag->m_channel            = channel;
   newTag->SetStartFromUTC(newStart);
   newTag->SetEndFromUTC(newEnd);
+  newTag->SetFirstDayFromUTC(newStart);
 
   CPVRTimerTypePtr timerType;
   if (bRepeating)


### PR DESCRIPTION
Default first day to EPG 'Start Time' or now() if not available

Currently when creating a new timer which uses 'FirstDay' this defaults to 1/1/1970 which makes little sense.
This change defaults instead to the day that the associated EPG entry starts, or 'today' if there is no EPG tag associated.
