### PR TITLE
[PVR] Timer settings dialog: Pre/post bugfix

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -316,11 +316,11 @@ void CGUIDialogPVRTimerSettings::InitializeSettings()
   AddTypeDependentEnableCondition(setting, SETTING_TMR_NEW_EPISODES);
 
   // Pre and post record time
-  setting = AddSpinner(group, SETTING_TMR_BEGIN_PRE, 813, 0, 0, m_iMarginStart, 1, 60, 14044);
+  setting = AddSpinner(group, SETTING_TMR_BEGIN_PRE, 813, 0, m_iMarginStart, 0, 1, 60, 14044);
   AddTypeDependentVisibilityCondition(setting, SETTING_TMR_BEGIN_PRE);
   AddTypeDependentEnableCondition(setting, SETTING_TMR_BEGIN_PRE);
 
-  setting = AddSpinner(group, SETTING_TMR_END_POST,  814, 0, 0, m_iMarginEnd,   1, 60, 14044);
+  setting = AddSpinner(group, SETTING_TMR_END_POST,  814, 0, m_iMarginEnd,   0, 1, 60, 14044);
   AddTypeDependentVisibilityCondition(setting, SETTING_TMR_END_POST);
   AddTypeDependentEnableCondition(setting, SETTING_TMR_END_POST);
 


### PR DESCRIPTION
'value' and 'min' parameters were exchanged in AddSpinner resulting in odd behaviour with non-zero initial values of Start and End Padding (seen when editing a previously created timer)

@janbar I know you mentioned this bug before
@ryangribble have you come across this while testing?
@ksooo I finally made the time to investigate this, and it turned out to be a two line change :)

 https://github.com/xbmc/xbmc/blob/master/xbmc/settings/dialogs/GUIDialogSettingsManualBase.h#L84 refers
