### PR TITLE
[guilib] GUIFontTTFDX: Fixed rendering of rotated text.

### DIFF
--- a/xbmc/guilib/GUIFontTTFDX.cpp
+++ b/xbmc/guilib/GUIFontTTFDX.cpp
@@ -65,6 +65,9 @@ bool CGUIFontTTFDX::FirstBegin()
   if (!pContext)
     return false;
 
+  CGUIShaderDX* pGUIShader = g_Windowing.GetGUIShader();
+  pGUIShader->Begin(SHADER_METHOD_RENDER_FONT);
+
   return true;
 }
 
@@ -81,13 +84,12 @@ void CGUIFontTTFDX::LastEnd()
   if (m_vertex.empty() && transIsEmpty)
     return;
 
-  CGUIShaderDX* pGUIShader = g_Windowing.GetGUIShader();
-  pGUIShader->Begin(SHADER_METHOD_RENDER_FONT);
   CreateStaticIndexBuffer();
 
   unsigned int offset = 0;
   unsigned int stride = sizeof(SVertex);
 
+  CGUIShaderDX* pGUIShader = g_Windowing.GetGUIShader();
   // Set font texture as shader resource
   ID3D11ShaderResourceView* resources[] = { m_speedupTexture->GetShaderResource() };
   pGUIShader->SetShaderViews(1, resources);


### PR DESCRIPTION
Issue is isntroduced in #7784
this partially reverts "optimization"
