### PR TITLE
[WIP] [musiclibrary] Custom label format conflicting with sort by

### DIFF
--- a/xbmc/music/GUIViewStateMusic.cpp
+++ b/xbmc/music/GUIViewStateMusic.cpp
@@ -187,7 +187,7 @@ CGUIViewStateMusicDatabase::CGUIViewStateMusicDatabase(const CFileItemList& item
       // artist
       AddSortMethod(SortByArtist, sortAttribute, 557, LABEL_MASKS("%F", "", strAlbumLeft, strAlbumRight));  // Filename, empty | Userdefined, Userdefined
       // year
-      AddSortMethod(SortByYear, 562, LABEL_MASKS("%F", "", strAlbumLeft, strAlbumRight));
+      AddSortMethod(SortByYear, 562, LABEL_MASKS("%F", "", strAlbumLeft + " - " + strAlbumRight, "%Y"));  // Filename, empty | Userdefined - Userdefined, Year
 
       const CViewState *viewState = CViewStateSettings::Get().Get("musicnavalbums");
       SetSortMethod(viewState->m_sortDescription);


### PR DESCRIPTION
This is more of a placeholder PR, so we can discuss the problem and find a real solution. I will then edit this to reflect whatever we choose as the best way.

This problem applies to almost all of the musiclibrary. Most some of the sortings are not showing the values they are sorting by. There are the ones, that use the user defined 
values:

```
std::string strTrackLeft=CSettings::Get().GetString(CSettings::SETTING_MUSICFILES_LIBRARYTRACKFORMAT);
  if (strTrackLeft.empty())
    strTrackLeft = CSettings::Get().GetString(CSettings::SETTING_MUSICFILES_TRACKFORMAT);
  std::string strTrackRight=CSettings::Get().GetString(CSettings::SETTING_MUSICFILES_LIBRARYTRACKFORMATRIGHT);
  if (strTrackRight.empty())
    strTrackRight = CSettings::Get().GetString(CSettings::SETTING_MUSICFILES_TRACKFORMATRIGHT);

  std::string strAlbumLeft = g_advancedSettings.m_strMusicLibraryAlbumFormat;
  if (strAlbumLeft.empty())
    strAlbumLeft = "%B"; // album
  std::string strAlbumRight = g_advancedSettings.m_strMusicLibraryAlbumFormatRight;
  if (strAlbumRight.empty())
    strAlbumRight = "%A"; // artist
```

```
AddSortMethod(SortByLabel, sortAttribute, 551, LABEL_MASKS(strTrackLeft, strTrackRight));
```

and there are the ones, that use a fixed format, which in some cases have the value that is sorted by in the right column.

```
AddSortMethod(SortByTitle, sortAttribute, 556, LABEL_MASKS("%T - %A", "%D"));  // Title, Artist, Duration| empty, empty
```

This is the album sort that I changed in the commit log. It might be bad, because the user has set `albumFormatRight` and will think it will show up on the right.
Before:
![screenshot 2015-08-17 20 38 01](https://cloud.githubusercontent.com/assets/5943908/9313177/c3a303a2-4521-11e5-9a97-2257de4542b1.png)

After:
![screenshot 2015-08-17 20 37 39](https://cloud.githubusercontent.com/assets/5943908/9313193/d2bcc94a-4521-11e5-8086-75f53128336c.png)

So how do we handle these cases? And shouldn't we commit on either using the user defined format or the fixed?
