### PR TITLE
CLangInfo: properly set the time format when setting/changing regions

### DIFF
--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -958,7 +958,12 @@ void CLangInfo::SetCurrentRegion(const std::string& strName)
   if (CSettings::GetInstance().GetString(CSettings::SETTING_LOCALE_LONGDATEFORMAT) == SETTING_REGIONAL_DEFAULT)
     SetLongDateFormat(m_currentRegion->m_strDateFormatLong);
   if (CSettings::GetInstance().GetString(CSettings::SETTING_LOCALE_USE24HOURCLOCK) == SETTING_REGIONAL_DEFAULT)
+  {
     Set24HourClock(m_currentRegion->m_strTimeFormat);
+
+    // update the time format
+    SetTimeFormat(CSettings::GetInstance().GetString(CSettings::SETTING_LOCALE_TIMEFORMAT));
+  }
   if (CSettings::GetInstance().GetString(CSettings::SETTING_LOCALE_TIMEFORMAT) == SETTING_REGIONAL_DEFAULT)
     SetTimeFormat(m_currentRegion->m_strTimeFormat);
   if (CSettings::GetInstance().GetString(CSettings::SETTING_LOCALE_TEMPERATUREUNIT) == SETTING_REGIONAL_DEFAULT)


### PR DESCRIPTION
This should fix the issue described in http://trac.kodi.tv/ticket/16195.
The problem is the order in which we load the date/time settings and the region. The settings like short/long date format, time format and 24 hour clock mode are loaded first and the region is loaded later (because it still depends on the language).

In the described case that means that due to the 24 hour clock mode being set to regional we don't know that information yet when loading the 24 hour clock mode setting because the region hasn't been set yet (but the logic doesn't know that) so it uses the default region's properties which is determined from the region's time format which is "hh:mm:ss" (without "xx") resulting in using 24 hour clock format (without AM/PM) instead of 12 hour clock format.

This can be fixed by making sure to set the time format when the proper region is being loaded and the 24 hour clock mode setting is set to regional.
