### PR TITLE
CApplication: improve skin reloading in case theme/color/font is not default

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1359,46 +1359,68 @@ void CApplication::OnSettingChanged(const CSetting *setting)
     return;
 
   const std::string &settingId = setting->GetId();
+  // check if we should ignore this change event due to changing skins in which case we have to
+  // change several settings and each one of them could lead to a complete skin reload which would
+  // result in multiple skin reloads. Therefore we manually specify to ignore specific settings
+  // which are going to be changed.
+  if (settingId == m_skinReloadSettingIgnore)
+  {
+    m_skinReloadSettingIgnore.clear();
+    return;
+  }
+
   if (settingId == CSettings::SETTING_LOOKANDFEEL_SKIN ||
       settingId == CSettings::SETTING_LOOKANDFEEL_FONT ||
+      settingId == CSettings::SETTING_LOOKANDFEEL_SKINTHEME ||
       settingId == CSettings::SETTING_LOOKANDFEEL_SKINCOLORS)
   {
-    // if the skin changes and the current theme is not the default one, reset
-    // the theme to the default value (which will also change lookandfeel.skincolors
-    // which in turn will reload the skin.  Similarly, if the current skin font is not
-    // the default, reset it as well.
-    if (settingId == CSettings::SETTING_LOOKANDFEEL_SKIN && CSettings::GetInstance().GetString(CSettings::SETTING_LOOKANDFEEL_SKINTHEME) != "SKINDEFAULT")
+    // if the skin changes and the current color/theme/font is not the default one, reset
+    // the it to the default value
+    if (settingId == CSettings::SETTING_LOOKANDFEEL_SKIN)
     {
-      CSettings::GetInstance().SetString(CSettings::SETTING_LOOKANDFEEL_SKINTHEME, "SKINDEFAULT");
-      return;
+      CSetting* skinRelatedSetting = CSettings::GetInstance().GetSetting(CSettings::SETTING_LOOKANDFEEL_SKINCOLORS);
+      if (!skinRelatedSetting->IsDefault())
+      {
+        m_skinReloadSettingIgnore = skinRelatedSetting->GetId();
+        skinRelatedSetting->Reset();
+      }
+
+      skinRelatedSetting = CSettings::GetInstance().GetSetting(CSettings::SETTING_LOOKANDFEEL_SKINTHEME);
+      if (!skinRelatedSetting->IsDefault())
+      {
+        m_skinReloadSettingIgnore = skinRelatedSetting->GetId();
+        skinRelatedSetting->Reset();
+      }
+
+      setting = CSettings::GetInstance().GetSetting(CSettings::SETTING_LOOKANDFEEL_FONT);
+      if (!setting->IsDefault())
+      {
+        m_skinReloadSettingIgnore = skinRelatedSetting->GetId();
+        skinRelatedSetting->Reset();
+      }
     }
-    if (settingId == CSettings::SETTING_LOOKANDFEEL_SKIN && CSettings::GetInstance().GetString(CSettings::SETTING_LOOKANDFEEL_FONT) != "Default")
+    else if (settingId == CSettings::SETTING_LOOKANDFEEL_SKINTHEME)
     {
-      CSettings::GetInstance().SetString(CSettings::SETTING_LOOKANDFEEL_FONT, "Default");
-      return;
+      CSettingString* skinColorsSetting = static_cast<CSettingString*>(CSettings::GetInstance().GetSetting(CSettings::SETTING_LOOKANDFEEL_SKINCOLORS));
+      m_skinReloadSettingIgnore = skinColorsSetting->GetId();
+
+      // we also need to adjust the skin color setting
+      std::string colorTheme = ((CSettingString*)setting)->GetValue();
+      URIUtils::RemoveExtension(colorTheme);
+      if (setting->IsDefault() || StringUtils::EqualsNoCase(colorTheme, "Textures"))
+        skinColorsSetting->Reset();
+      else
+        skinColorsSetting->SetValue(colorTheme);
     }
 
+    // reset the settings to ignore during changing skins
+    m_skinReloadSettingIgnore.clear();
+
+    // now we can finally reload skins
     std::string builtin("ReloadSkin");
     if (settingId == CSettings::SETTING_LOOKANDFEEL_SKIN && !m_skinReverting)
       builtin += "(confirm)";
     CApplicationMessenger::GetInstance().PostMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr, builtin);
-  }
-  else if (settingId == CSettings::SETTING_LOOKANDFEEL_SKINTHEME)
-  {
-    // also set the default color theme
-    std::string colorTheme = ((CSettingString*)setting)->GetValue();
-    URIUtils::RemoveExtension(colorTheme);
-    if (StringUtils::EqualsNoCase(colorTheme, "Textures"))
-      colorTheme = "defaults";
-
-    // check if we have to change the skin color
-    // if yes, it will trigger a call to ReloadSkin() in
-    // it's OnSettingChanged() callback
-    // if no we have to call ReloadSkin() ourselves
-    if (!StringUtils::EqualsNoCase(colorTheme, CSettings::GetInstance().GetString(CSettings::SETTING_LOOKANDFEEL_SKINCOLORS)))
-      CSettings::GetInstance().SetString(CSettings::SETTING_LOOKANDFEEL_SKINCOLORS, colorTheme);
-    else
-      CApplicationMessenger::GetInstance().PostMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr, "ReloadSkin");
   }
   else if (settingId == CSettings::SETTING_LOOKANDFEEL_SKINZOOM)
   {

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -413,6 +413,7 @@ protected:
   bool NotifyActionListeners(const CAction &action) const;
 
   bool m_skinReverting;
+  std::string m_skinReloadSettingIgnore;
 
   bool m_loggingIn;
 


### PR DESCRIPTION
This is an attempt at improving the logic in `CApplication::OnSettingChanged()` that is responsible for handling all the different skin related settings. The main issue is that changes to 4 different settings should result in reloading the skin:
- `lookandfeel.skin`
- `lookandfeel.font`
- `lookandfeel.skintheme`
- `lookandfeel.skincolors`

Where it gets complicated is with the dependencies:
- changing `lookandfeel.skin` might change `lookandfeel.font`, `lookandfeel.skintheme` and `lookandfeel.skincolors`
- changing `lookandfeel.skintheme` might change `lookandfeel.skincolors`

The fact that chaging a setting's value results in a call to the `OnSettingChanged()` implementation (even if it's called from an existing `OnSettingChanged()` implementation) makes it very difficult to keep track of the chain of changes invoked by changing a single setting due to dependencies. Ideally this would be handled by the settings system but that will be a major change.

In the case of skin settings this leads to reloading the skin multiple times unnecessarily. Therefore I'm falling back on a member variable in `CApplication` where I store the ID of a setting which should not be handled in the next `OnSettingChanged()` because I know which setting I'm changing and that it's callback handler will (most likely) be called.

So as an example when changing `lookandfeel.skin` what happens is
1. `CApplication::OnSettingChanged()` is called for `lookandfeel.skin`
2. `lookandfeel.skincolors` is reset to its default value
3. `CApplication::OnSettingChanged()` is called for `lookandfeel.skincolors` but is ignored
4. `lookandfeel.skintheme` is reset to its default value
5. `CApplication::OnSettingChanged()` is called for `lookandfeel.skintheme` but is ignored
6. `lookandfeel.font` is reset to its default value but nothing happens because it already is set to its default value
7. The skin is reloaded asynchronously

Furthermore as an improvement I've changed the code to make use of the setting's `Reset()` implementation to reset the setting's value to its default value instead of manually setting it's value to the default value. That way in case the default value changes in `settings.xml` it will automatically be handled correctly.

It also merges the handling of `lookandfeel.skintheme` with the handling of the other 3 skin related settings (especially their skin reloading logic).
