### PR TITLE
[Confluence] fix watched flag in media info 3 view

### DIFF
--- a/addons/skin.confluence/720p/ViewsVideoLibrary.xml
+++ b/addons/skin.confluence/720p/ViewsVideoLibrary.xml
@@ -1632,7 +1632,6 @@
 						<texture>OverlayWatching.png</texture>
 						<visible>ListItem.IsResumable</visible>
 					</control>
-				</itemlayout>
 					<control type="image">
 						<left>320</left>
 						<top>14</top>
@@ -1641,6 +1640,7 @@
 						<texture>$INFO[ListItem.Overlay]</texture>
 						<aspectratio>keep</aspectratio>
 					</control>
+				</itemlayout>
 				<focusedlayout height="40" width="345">
 					<control type="image">
 						<left>0</left>


### PR DESCRIPTION
backport of https://github.com/xbmc/xbmc/commit/3cd950c9a538e138ed5b2d638be0159e1a1e45cc for Isengard
