### PR TITLE
[lang] fix nb_no fallback

### DIFF
--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -801,6 +801,8 @@ std::string CAddonMgr::GetTranslatedString(const cp_cfg_element_t *root, const c
         translatedValues.insert(std::make_pair(lang, child.value != NULL ? child.value : ""));
       else if (lang == NULL || strcmp(lang, "en") == 0 || strcmp(lang, "en_GB") == 0)
         translatedValues.insert(std::make_pair("en_GB", child.value != NULL ? child.value : ""));
+      else if (strcmp(lang, "no") == 0)
+        translatedValues.insert(std::make_pair("nb_NO", child.value != NULL ? child.value : ""));
     }
   }
 


### PR DESCRIPTION
Can't believe I missed this; addon summaries and descriptions using the legacy language 'no' are currently not loaded as the ISO 639-1 part changed to 'nb'. Same for the 'foreign filter' in addon browser.

As far as I can tell from the original PR, no other languages was changed in this manner so I've added special cases for this language.

@Montellese 
