### PR TITLE
[guilib] fix double memory free in panel container

### DIFF
--- a/xbmc/guilib/GUIPanelContainer.cpp
+++ b/xbmc/guilib/GUIPanelContainer.cpp
@@ -54,8 +54,9 @@ void CGUIPanelContainer::Process(unsigned int currentTime, CDirtyRegionList &dir
   int cacheBefore, cacheAfter;
   GetCacheOffsets(cacheBefore, cacheAfter);
 
-  // Free memory not used on screen at the moment, do this first so there's more memory for the new items.
-  FreeMemory(CorrectOffset(offset - cacheBefore, 0), CorrectOffset(offset + cacheAfter + m_itemsPerPage + 1, 0));
+  // Free memory not used on screen
+  if ((int)m_items.size() > m_itemsPerPage + cacheBefore + cacheAfter)
+    FreeMemory(CorrectOffset(offset - cacheBefore, 0), CorrectOffset(offset + m_itemsPerPage + 1 + cacheAfter, 0));
 
   CPoint origin = CPoint(m_posX, m_posY) + m_renderOffset;
   float pos = (m_orientation == VERTICAL) ? origin.y : origin.x;
@@ -106,9 +107,6 @@ void CGUIPanelContainer::Render()
 
   int cacheBefore, cacheAfter;
   GetCacheOffsets(cacheBefore, cacheAfter);
-
-  // Free memory not used on screen at the moment, do this first so there's more memory for the new items.
-  FreeMemory(CorrectOffset(offset - cacheBefore, 0), CorrectOffset(offset + cacheAfter + m_itemsPerPage + 1, 0));
 
   if (g_graphicsContext.SetClipRegion(m_posX, m_posY, m_width, m_height))
   {


### PR DESCRIPTION
This fixes an issue where the last visible item in a panel container is not properly displayed when scrolling.

@HitcherUK, please test ;)
