### PR TITLE
[Confluence] Hide unused image when showing tracks

### DIFF
--- a/addons/skin.confluence/720p/DialogAlbumInfo.xml
+++ b/addons/skin.confluence/720p/DialogAlbumInfo.xml
@@ -482,14 +482,14 @@
 					<visible>!Control.IsVisible(50)</visible>
 				</control>
 				<control type="image">
-					<description>Actor image</description>
+					<description>Album cover</description>
 					<left>210</left>
 					<top>480</top>
 					<width>160</width>
 					<height>160</height>
 					<texture fallback="DefaultAlbumCover.png">$INFO[Container(50).Listitem.Icon]</texture>
 					<aspectratio>keep</aspectratio>
-					<visible>Control.IsVisible(50)</visible>
+					<visible>Control.IsVisible(50) + Container.Content(Artists)</visible>
 				</control>
 				<control type="panel" id="50">
 					<left>380</left>


### PR DESCRIPTION
This hides the image that is shown besides the tracks, only when viewing an album. Because there are no images for songs or something along the lines we could show here.

A real skinner might be able to remove that blank space that is now showing up. ;)

Old:
![old](https://cloud.githubusercontent.com/assets/5943908/9359443/6f68b5a4-4691-11e5-9e92-e87b66d76351.png)

New:
![new](https://cloud.githubusercontent.com/assets/5943908/9359446/74473528-4691-11e5-8c86-4e977a35c8a3.png)

PING @ronie 
