### PR TITLE
Updated addsong to check for iTrack aswell when checking for duplicates.

### DIFF
--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -649,10 +649,11 @@ int CMusicDatabase::AddSong(const int idAlbum,
                           idAlbum,
                           strMusicBrainzTrackID.c_str());
     else
-      strSQL = PrepareSQL("SELECT * FROM song WHERE idAlbum=%i AND strFileName='%s' AND strTitle='%s' AND strMusicBrainzTrackID IS NULL",
+      strSQL = PrepareSQL("SELECT * FROM song WHERE idAlbum=%i AND strFileName='%s' AND strTitle='%s' AND iTrack=%i AND strMusicBrainzTrackID IS NULL",
                           idAlbum,
                           strFileName.c_str(),
-                          strTitle.c_str());
+                          strTitle.c_str(),
+                          iTrack);
 
     if (!m_pDS->query(strSQL.c_str()))
       return -1;


### PR DESCRIPTION
Currently the code checks for idAlbum, strFileName and strTitle when adding a new song, for cases like the one reported in http://trac.kodi.tv/ticket/16114 this will result in overwriting the information of a song instead of adding it as a new one, which caused songs with the same name to be only added once (since idAlbum and strFileName are the same on a album when you have a cue / single wav/ape/flac file). This change adds iTrack when checking if that song has already been added. 
