### PR TITLE
[gui] fix CGUIDialogSelect::GetSelectedItem not returning the selected item

### DIFF
--- a/xbmc/dialogs/GUIDialogSelect.h
+++ b/xbmc/dialogs/GUIDialogSelect.h
@@ -63,7 +63,7 @@ protected:
   bool m_bButtonEnabled;
   int m_buttonString;
   bool m_bButtonPressed;
-  int m_iSelected;
+  CFileItemPtr m_selectedItem;
   bool m_useDetails;
   bool m_multiSelection;
 


### PR DESCRIPTION
Regression after e002a1b. `m_vecList` is cleared on deinit and therefore can't be used to get the selected item. This basically replaces `m_iSelected` to store the file item instead of the index (since we already store indices in `m_selectedItems`)

@xhaggi for re-review:)
