### PR TITLE
[infomanager] add Visualisation.HasPresets info bool

### DIFF
--- a/addons/skin.confluence/720p/MusicOSD.xml
+++ b/addons/skin.confluence/720p/MusicOSD.xml
@@ -308,6 +308,8 @@
 				<texturefocus>OSDPreFO.png</texturefocus>
 				<texturenofocus>OSDPreNF.png</texturenofocus>
 				<onclick>ActivateWindow(122)</onclick>
+				<enable>Visualisation.HasPresets</enable>
+				<animation effect="fade" start="100" end="50" time="75" condition="!Visualisation.HasPresets">Conditional</animation>
 			</control>
 			<control type="button" id="704">
 				<width>55</width>

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -622,6 +622,7 @@ const infomap listitem_labels[]= {{ "thumb",            LISTITEM_THUMB },
 
 const infomap visualisation[] =  {{ "locked",           VISUALISATION_LOCKED },
                                   { "preset",           VISUALISATION_PRESET },
+                                  { "haspresets",       VISUALISATION_HAS_PRESETS },
                                   { "name",             VISUALISATION_NAME },
                                   { "enabled",          VISUALISATION_ENABLED }};
 
@@ -2751,6 +2752,18 @@ bool CGUIInfoManager::GetBool(int condition1, int contextWindow, const CGUIListI
         bReturn = (epgTag && epgTag->IsActive() && epgTag->ChannelTag());
       }
       break;
+    case VISUALISATION_HAS_PRESETS:
+    {
+      CGUIMessage msg(GUI_MSG_GET_VISUALISATION, 0, 0);
+      g_windowManager.SendMessage(msg);
+      if (msg.GetPointer())
+      {
+        CVisualisation* viz = NULL;
+        viz = (CVisualisation*)msg.GetPointer();
+        bReturn = (viz && viz->HasPresets());
+      }
+    }
+    break;
     default: // default, use integer value different from 0 as true
       {
         int val;

--- a/xbmc/addons/Visualisation.cpp
+++ b/xbmc/addons/Visualisation.cpp
@@ -97,7 +97,7 @@ bool CVisualisation::Create(int x, int y, int w, int h, void *device)
       return false;
     }
 
-    GetPresets();
+    m_hasPresets = GetPresets();
 
     if (GetSubModules())
       m_pInfo->submodule = strdup(CSpecialProtocol::TranslatePath(m_submodules.front()).c_str());

--- a/xbmc/addons/Visualisation.h
+++ b/xbmc/addons/Visualisation.h
@@ -69,6 +69,7 @@ namespace ADDON
     void GetInfo(VIS_INFO *info);
     bool OnAction(VIS_ACTION action, void *param = NULL);
     bool UpdateTrack();
+    bool HasPresets() { return m_hasPresets; };
     bool HasSubModules() { return !m_submodules.empty(); }
     bool IsLocked();
     unsigned GetPreset();
@@ -106,6 +107,7 @@ namespace ADDON
     bool m_bWantsFreq;
     float m_fFreq[AUDIO_BUFFER_SIZE];         // Frequency data
     bool m_bCalculate_Freq;       // True if the vis wants freq data
+    bool m_hasPresets;
     std::unique_ptr<RFFT> m_transform;
 
     // track information

--- a/xbmc/guiinfo/GUIInfoLabels.h
+++ b/xbmc/guiinfo/GUIInfoLabels.h
@@ -319,6 +319,7 @@
 #define VISUALISATION_PRESET        401
 #define VISUALISATION_NAME          402
 #define VISUALISATION_ENABLED       403
+#define VISUALISATION_HAS_PRESETS   404
 
 #define STRING_IS_EMPTY             410
 #define STRING_COMPARE              411


### PR DESCRIPTION
Adds `Visualisation.HasPresets` info bool and disables the presets button in `Confluence` in case there are no presets available for the current visualization.

Follow up to https://github.com/xbmc/xbmc/pull/7863.

/cc @BigNoid, @HitcherUK, @phil65, @ronie, @vonH
