### PR TITLE
RFC - bring back fast channelswitch

### DIFF
--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -428,10 +428,6 @@ bool CDVDDemuxFFmpeg::Open(CDVDInputStream* pInput, bool streaminfo, bool filein
     m_checkvideo = true;
     skipCreateStreams = true;
   }
-  else if (!iformat || (strcmp(iformat->name, "mpegts") != 0))
-  {
-    m_streaminfo = true;
-  }
 
   // we need to know if this is matroska or avi later
   m_bMatroska = strncmp(m_pFormatContext->iformat->name, "matroska", 8) == 0;	// for "matroska.webm"


### PR DESCRIPTION
We need to upgrade to OpenELEC 5.95 in order to fix a problem.
When testing I found that the channel switching is up to 5sec again.

I know the code is there for a reason, so maybe we can discuss possibilities to bring it back again.
