### PR TITLE
[PVR] Timer settings dialog: Start/End display fix

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -1129,6 +1129,10 @@ bool CGUIDialogPVRTimerSettings::StartAnytimeSetCondition(const std::string &con
   if (!pThis->m_timerType->IsEpgBased())
     return true;
 
+  // If 'Start anytime' option isn't supported, don't hide start time
+  if (!pThis->m_timerType->SupportsStartAnyTime())
+    return true;
+
   std::string cond(condition);
   cond.erase(cond.find(START_ANYTIME_DEP_VISIBI_COND_ID_POSTFIX));
 
@@ -1166,6 +1170,10 @@ bool CGUIDialogPVRTimerSettings::EndAnytimeSetCondition(const std::string &condi
 
   // "any time" setting is only relevant for epg-based timers.
   if (!pThis->m_timerType->IsEpgBased())
+    return true;
+
+  // If 'End anytime' option isn't supported, don't hide end time
+  if (!pThis->m_timerType->SupportsEndAnyTime())
     return true;
 
   std::string cond(condition);

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -563,8 +563,14 @@ void CGUIDialogPVRTimerSettings::Save()
     m_timerInfoTag->m_iClientId         = m_timerType->GetClientId();
   }
 
-  m_timerInfoTag->m_bStartAnyTime = m_bStartAnyTime;
-  m_timerInfoTag->m_bEndAnyTime = m_bEndAnyTime;
+  if (m_timerType->SupportsStartAnyTime() && m_timerType->IsEpgBased()) // Start anytime toggle is displayed
+    m_timerInfoTag->m_bStartAnyTime = m_bStartAnyTime;
+  else
+    m_bStartAnyTime = false; // Assume start time change needs checking for
+  if (m_timerType->SupportsEndAnyTime() && m_timerType->IsEpgBased()) // End anytime toggle is displayed
+    m_timerInfoTag->m_bEndAnyTime = m_bEndAnyTime;
+  else
+    m_bEndAnyTime = false; // Assume end time change needs checking for
   // Begin and end time
   const CDateTime now(CDateTime::GetCurrentDateTime());
   if (!m_bStartAnyTime && !m_bEndAnyTime)


### PR DESCRIPTION
As reported by @janbar on the forum (http://forum.kodi.tv/showthread.php?tid=230145&pid=2087504#pid2087504 ) if a timer type does not support the 'Anytime' radio buttons, the start/end clocks are still hidden as the default is for timers to be created as 'bStartAnyTime == bEndAnyTime == true', which hides the clocks.

This change prevents bStartAnyTime == true / bEndAnyTime == true hiding the start/end clocks if the timer type doesn't support 'START_ANYTIME / END_ANYTIME' option.
