### PR TITLE
[CONTAINERART] Fix Container.Art property for artist directories

### DIFF
--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -1129,7 +1129,7 @@ bool CGUIWindowMusicBase::GetDirectory(const std::string &strDirectory, CFileIte
   CQueryParams params;
   CDirectoryNode::GetDatabaseInfo(items.GetPath(), params);
 
-  if (params.GetAlbumId())
+  if (params.GetAlbumId() > 0)
   {
     map<string, string> artistArt;
     if (m_musicdatabase.GetArtistArtForItem(params.GetAlbumId(), MediaTypeAlbum, artistArt))
@@ -1138,6 +1138,12 @@ bool CGUIWindowMusicBase::GetDirectory(const std::string &strDirectory, CFileIte
     map<string, string> albumArt;
     if (m_musicdatabase.GetArtForItem(params.GetAlbumId(), MediaTypeAlbum, albumArt))
       items.AppendArt(albumArt, MediaTypeAlbum);
+  }
+  if (params.GetArtistId() > 0)
+  {
+    map<string, string> artistArt;
+    if (m_musicdatabase.GetArtForItem(params.GetArtistId(), "artist", artistArt))
+      items.AppendArt(artistArt, MediaTypeArtist);
   }
 
   // add in the "New Playlist" item if we're in the playlists folder


### PR DESCRIPTION
As detailed in this thread:
http://forum.kodi.tv/showthread.php?tid=235413&pid=2087854#pid2087854

I believe there are some issues with the current _Container.Art(artist.fanart)_ property implementation.

The proposed patch adds a new method called in _CGUIWindowMusicBase::GetDirectory()_ to make the property functional for artists directories and fixes the _GetAlbumId()_ return value test
