### PR TITLE
[binary addons] Allow regex patterns in ADDONS_TO_BUILD

### DIFF
--- a/project/cmake/addons/CMakeLists.txt
+++ b/project/cmake/addons/CMakeLists.txt
@@ -178,8 +178,18 @@ foreach(addon ${addons})
     separate_arguments(def)
     list(GET def 0 id)
 
+    set(ADDON_FOUND FALSE)
+    # try to find a perfect match
     list(FIND ADDONS_TO_BUILD ${id} idx)
     if(idx GREATER -1 OR ADDONS_TO_BUILD STREQUAL "all")
+      set(ADDON_FOUND TRUE)
+    # Maybe we have a regex
+    elseif(id MATCHES "${ADDONS_TO_BUILD}")
+      message(STATUS "Pattern ${ADDONS_TO_BUILD} matches ${id}, building addon")
+      set(ADDON_FOUND TRUE)
+    endif()
+
+    if(ADDON_FOUND)
       get_filename_component(dir ${addon} PATH)
 
       # check if the addon has a platforms.txt

--- a/project/cmake/addons/README
+++ b/project/cmake/addons/README
@@ -27,8 +27,11 @@ are:
 The buildsystem uses the following variables (which can be passed into it when
 executing cmake with the -D<variable-name>=<value> option) to e.g. access
 specific paths:
-  * ADDONS_TO_BUILD is a quoted, space delimited list of <addon-id>s that
-    you want to build (default is "all").
+  * ADDONS_TO_BUILD has two variations, which are tested in order:
+     - a quoted, space delimited list of <addon-id>s that
+       you want to build (default is "all").
+     - a regular expression that every <addon-id> is matched against
+       e.g.: ADDONS_TO_BUILD=pvr.* to build all pvr addons
   * ADDON_SRC_PREFIX can be used to override the addon repository location.
     It must point to the locally available parent directory of the addon(s) to build
     <addon-id> will be appended to this path automatically


### PR DESCRIPTION
as requested by @garbear in https://github.com/garbear/xbmc/issues/38#event-390268441
