### PR TITLE
[guilib] add support for sorting dynamic directory listings from <content>

### DIFF
--- a/xbmc/interfaces/json-rpc/JSONUtils.h
+++ b/xbmc/interfaces/json-rpc/JSONUtils.h
@@ -101,88 +101,12 @@ namespace JSONRPC
       else
         sortAttributes = SortAttributeNone;
 
-      if (order == "ascending")
-        sortOrder = SortOrderAscending;
-      else if (order == "descending")
-        sortOrder = SortOrderDescending;
-      else
+      sortOrder = SortUtils::SortOrderFromString(order);
+      if (sortOrder == SortOrderNone)
         return false;
 
-      if (method == "none")
-        sortBy = SortByNone;
-      else if (method == "label")
-        sortBy = SortByLabel;
-      else if (method == "date")
-        sortBy = SortByDate;
-      else if (method == "size")
-        sortBy = SortBySize;
-      else if (method == "file")
-        sortBy = SortByFile;
-      else if (method == "path")
-        sortBy = SortByPath;
-      else if (method == "drivetype")
-        sortBy = SortByDriveType;
-      else if (method == "title")
-        sortBy = SortByTitle;
-      else if (method == "track")
-        sortBy = SortByTrackNumber;
-      else if (method == "time")
-        sortBy = SortByTime;
-      else if (method == "artist")
-        sortBy = SortByArtist;
-      else if (method == "album")
-        sortBy = SortByAlbum;
-      else if (method == "albumtype")
-        sortBy = SortByAlbumType;
-      else if (method == "genre")
-        sortBy = SortByGenre;
-      else if (method == "country")
-        sortBy = SortByCountry;
-      else if (method == "year")
-        sortBy = SortByYear;
-      else if (method == "rating")
-        sortBy = SortByRating;
-      else if (method == "votes")
-        sortBy = SortByVotes;
-      else if (method == "top250")
-        sortBy = SortByTop250;
-      else if (method == "programcount")
-        sortBy = SortByProgramCount;
-      else if (method == "playlist")
-        sortBy = SortByPlaylistOrder;
-      else if (method == "episode")
-        sortBy = SortByEpisodeNumber;
-      else if (method == "season")
-        sortBy = SortBySeason;
-      else if (method == "totalepisodes")
-        sortBy = SortByNumberOfEpisodes;
-      else if (method == "watchedepisodes")
-        sortBy = SortByNumberOfWatchedEpisodes;
-      else if (method == "tvshowstatus")
-        sortBy = SortByTvShowStatus;
-      else if (method == "tvshowtitle")
-        sortBy = SortByTvShowTitle;
-      else if (method == "sorttitle")
-        sortBy = SortBySortTitle;
-      else if (method == "productioncode")
-        sortBy = SortByProductionCode;
-      else if (method == "mpaa")
-        sortBy = SortByMPAA;
-      else if (method == "studio")
-        sortBy = SortByStudio;
-      else if (method == "dateadded")
-        sortBy = SortByDateAdded;
-      else if (method == "lastplayed")
-        sortBy = SortByLastPlayed;
-      else if (method == "playcount")
-        sortBy = SortByPlaycount;
-      else if (method == "listeners")
-        sortBy = SortByListeners;
-      else if (method == "bitrate")
-        sortBy = SortByBitrate;
-      else if (method == "random")
-        sortBy = SortByRandom;
-      else
+      sortBy = SortUtils::SortMethodFromString(method);
+      if (sortBy == SortByNone)
         return false;
 
       return true;

--- a/xbmc/listproviders/DirectoryProvider.cpp
+++ b/xbmc/listproviders/DirectoryProvider.cpp
@@ -22,7 +22,9 @@
 #include "filesystem/Directory.h"
 #include "filesystem/FavouritesDirectory.h"
 #include "guilib/GUIWindowManager.h"
+#include "settings/Settings.h"
 #include "utils/JobManager.h"
+#include "utils/SortUtils.h"
 #include "utils/XMLUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
@@ -44,11 +46,15 @@ using namespace KODI::MESSAGING;
 class CDirectoryJob : public CJob
 {
 public:
-  CDirectoryJob(const std::string &url, int limit, int parentID)
-  : m_url(url), m_limit(limit), m_parentID(parentID) {};
-  virtual ~CDirectoryJob() {};
+  CDirectoryJob(const std::string &url, SortDescription sort, int limit, int parentID)
+    : m_url(url),
+      m_sort(sort),
+      m_limit(limit),
+      m_parentID(parentID)
+  { }
+  virtual ~CDirectoryJob() { }
 
-  virtual const char* GetType() const { return "directory"; };
+  virtual const char* GetType() const { return "directory"; }
   virtual bool operator==(const CJob *job) const
   {
     if (strcmp(job->GetType(),GetType()) == 0)
@@ -65,6 +71,10 @@ public:
     CFileItemList items;
     if (CDirectory::GetDirectory(m_url, items, ""))
     {
+      // sort the items if necessary
+      if (m_sort.sortBy != SortByNone)
+        items.Sort(m_sort);
+
       // limit must not exceed the number of items
       int limit = (m_limit == 0) ? items.Size() : min((int) m_limit, items.Size());
       // convert to CGUIStaticItem's and set visibility and targets
@@ -129,6 +139,7 @@ public:
 private:
   std::string m_url;
   std::string m_target;
+  SortDescription m_sort;
   unsigned int m_limit;
   int m_parentID;
   std::vector<CGUIStaticItemPtr> m_items;
@@ -149,9 +160,19 @@ CDirectoryProvider::CDirectoryProvider(const TiXmlElement *element, int parentID
     const char *target = element->Attribute("target");
     if (target)
       m_target.SetLabel(target, "", parentID);
+
+    const char *sortMethod = element->Attribute("sortby");
+    if (sortMethod)
+      m_sortMethod.SetLabel(sortMethod, "", parentID);
+
+    const char *sortOrder = element->Attribute("sortorder");
+    if (sortOrder)
+      m_sortOrder.SetLabel(sortOrder, "", parentID);
+
     const char *limit = element->Attribute("limit");
     if (limit)
       m_limit.SetLabel(limit, "", parentID);
+
     m_url.SetLabel(element->FirstChild()->ValueStr(), "", parentID);
   }
 }
@@ -177,6 +198,7 @@ bool CDirectoryProvider::Update(bool forceRefresh)
 
   // update the URL & limit and fire off a new job if needed
   fireJob |= UpdateURL();
+  fireJob |= UpdateSort();
   fireJob |= UpdateLimit();
   if (fireJob)
     FireJob();
@@ -241,6 +263,8 @@ void CDirectoryProvider::Reset(bool immediately /* = false */)
     m_currentTarget.clear();
     m_currentUrl.clear();
     m_itemTypes.clear();
+    m_currentSort.sortBy = SortByNone;
+    m_currentSort.sortOrder = SortOrderAscending;
     m_currentLimit = 0;
     m_updateState = OK;
     RegisterListProvider(false);
@@ -293,7 +317,7 @@ void CDirectoryProvider::FireJob()
   CSingleLock lock(m_section);
   if (m_jobID)
     CJobManager::GetInstance().CancelJob(m_jobID);
-  m_jobID = CJobManager::GetInstance().AddJob(new CDirectoryJob(m_currentUrl, m_currentLimit, m_parentID), this);
+  m_jobID = CJobManager::GetInstance().AddJob(new CDirectoryJob(m_currentUrl, m_currentSort, m_currentLimit, m_parentID), this);
 }
 
 void CDirectoryProvider::RegisterListProvider(bool hasLibraryContent)
@@ -331,6 +355,25 @@ bool CDirectoryProvider::UpdateLimit()
     return false;
 
   m_currentLimit = value;
+
+  return true;
+}
+
+bool CDirectoryProvider::UpdateSort()
+{
+  SortBy sortMethod(SortUtils::SortMethodFromString(m_sortMethod.GetLabel(m_parentID, false)));
+  SortOrder sortOrder(SortUtils::SortOrderFromString(m_sortOrder.GetLabel(m_parentID, false)));
+  if (sortOrder == SortOrderNone)
+    sortOrder = SortOrderAscending;
+
+  if (sortMethod == m_currentSort.sortBy && sortOrder == m_currentSort.sortOrder)
+    return false;
+
+  m_currentSort.sortBy = sortMethod;
+  m_currentSort.sortOrder = sortOrder;
+
+  if (CSettings::GetInstance().GetBool(CSettings::SETTING_FILELISTS_IGNORETHEWHENSORTING))
+    m_currentSort.sortAttributes = static_cast<SortAttribute>(m_currentSort.sortAttributes | SortAttributeIgnoreArticle);
 
   return true;
 }

--- a/xbmc/listproviders/DirectoryProvider.h
+++ b/xbmc/listproviders/DirectoryProvider.h
@@ -70,9 +70,12 @@ private:
   unsigned int     m_jobID;
   CGUIInfoLabel    m_url;
   CGUIInfoLabel    m_target;
+  CGUIInfoLabel    m_sortMethod;
+  CGUIInfoLabel    m_sortOrder;
   CGUIInfoLabel    m_limit;
   std::string      m_currentUrl;
   std::string      m_currentTarget;   ///< \brief node.target property on the list as a whole
+  SortDescription  m_currentSort;
   unsigned int     m_currentLimit;
   std::vector<CGUIStaticItemPtr> m_items;
   std::vector<InfoTagType> m_itemTypes;
@@ -82,4 +85,5 @@ private:
   void RegisterListProvider(bool hasLibraryContent);
   bool UpdateURL();
   bool UpdateLimit();
+  bool UpdateSort();
 };

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -46,7 +46,6 @@ typedef struct
 {
   char string[17];
   Field field;
-  SortBy sort;
   CDatabaseQueryRule::FIELD_TYPE type;
   StringValidation::Validator validator;
   bool browseable;
@@ -54,67 +53,67 @@ typedef struct
 } translateField;
 
 static const translateField fields[] = {
-  { "none",              FieldNone,                    SortByNone,                     CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 231 },
-  { "filename",          FieldFilename,                SortByFile,                     CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 561 },
-  { "path",              FieldPath,                    SortByPath,                     CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 true,  573 },
-  { "album",             FieldAlbum,                   SortByAlbum,                    CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 true,  558 },
-  { "albumartist",       FieldAlbumArtist,             SortByNone,                     CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 true,  566 },
-  { "artist",            FieldArtist,                  SortByArtist,                   CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 true,  557 },
-  { "tracknumber",       FieldTrackNumber,             SortByTrackNumber,              CDatabaseQueryRule::NUMERIC_FIELD,  StringValidation::IsPositiveInteger,  false, 554 },
-  { "comment",           FieldComment,                 SortByNone,                     CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 569 },
-  { "review",            FieldReview,                  SortByNone,                     CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 183 },
-  { "themes",            FieldThemes,                  SortByNone,                     CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 21895 },
-  { "moods",             FieldMoods,                   SortByNone,                     CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 175 },
-  { "styles",            FieldStyles,                  SortByNone,                     CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 176 },
-  { "type",              FieldAlbumType,               SortByAlbumType,                CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 564 },
-  { "label",             FieldMusicLabel,              SortByNone,                     CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 21899 },
-  { "title",             FieldTitle,                   SortByTitle,                    CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 true,  556 },
-  { "sorttitle",         FieldSortTitle,               SortBySortTitle,                CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 171 },
-  { "year",              FieldYear,                    SortByYear,                     CDatabaseQueryRule::NUMERIC_FIELD,  StringValidation::IsPositiveInteger,  true,  562 },
-  { "time",              FieldTime,                    SortByTime,                     CDatabaseQueryRule::SECONDS_FIELD,  StringValidation::IsTime,             false, 180 },
-  { "playcount",         FieldPlaycount,               SortByPlaycount,                CDatabaseQueryRule::NUMERIC_FIELD,  StringValidation::IsPositiveInteger,  false, 567 },
-  { "lastplayed",        FieldLastPlayed,              SortByLastPlayed,               CDatabaseQueryRule::DATE_FIELD,     NULL,                                 false, 568 },
-  { "inprogress",        FieldInProgress,              SortByNone,                     CDatabaseQueryRule::BOOLEAN_FIELD,  NULL,                                 false, 575 },
-  { "rating",            FieldRating,                  SortByRating,                   CDatabaseQueryRule::NUMERIC_FIELD,  CSmartPlaylistRule::ValidateRating,   false, 563 },
-  { "votes",             FieldVotes,                   SortByVotes,                    CDatabaseQueryRule::TEXT_FIELD,     StringValidation::IsPositiveInteger,  false, 205 },
-  { "top250",            FieldTop250,                  SortByTop250,                   CDatabaseQueryRule::NUMERIC_FIELD,  NULL,                                 false, 13409 },
-  { "mpaarating",        FieldMPAA,                    SortByMPAA,                     CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 20074 },
-  { "dateadded",         FieldDateAdded,               SortByDateAdded,                CDatabaseQueryRule::DATE_FIELD,     NULL,                                 false, 570 },
-  { "genre",             FieldGenre,                   SortByGenre,                    CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 true,  515 },
-  { "plot",              FieldPlot,                    SortByNone,                     CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 207 },
-  { "plotoutline",       FieldPlotOutline,             SortByNone,                     CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 203 },
-  { "tagline",           FieldTagline,                 SortByNone,                     CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 202 },
-  { "set",               FieldSet,                     SortByNone,                     CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 true,  20457 },
-  { "director",          FieldDirector,                SortByNone,                     CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 true,  20339 },
-  { "actor",             FieldActor,                   SortByNone,                     CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 true,  20337 },
-  { "writers",           FieldWriter,                  SortByNone,                     CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 true,  20417 },
-  { "airdate",           FieldAirDate,                 SortByYear,                     CDatabaseQueryRule::DATE_FIELD,     NULL,                                 false, 20416 },
-  { "hastrailer",        FieldTrailer,                 SortByNone,                     CDatabaseQueryRule::BOOLEAN_FIELD,  NULL,                                 false, 20423 },
-  { "studio",            FieldStudio,                  SortByStudio,                   CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 true,  572 },
-  { "country",           FieldCountry,                 SortByCountry,                  CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 true,  574 },
-  { "tvshow",            FieldTvShowTitle,             SortByTvShowTitle,              CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 true,  20364 },
-  { "status",            FieldTvShowStatus,            SortByTvShowStatus,             CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 126 },
-  { "season",            FieldSeason,                  SortBySeason,                   CDatabaseQueryRule::NUMERIC_FIELD,  StringValidation::IsPositiveInteger,  false, 20373 },
-  { "episode",           FieldEpisodeNumber,           SortByEpisodeNumber,            CDatabaseQueryRule::NUMERIC_FIELD,  StringValidation::IsPositiveInteger,  false, 20359 },
-  { "numepisodes",       FieldNumberOfEpisodes,        SortByNumberOfEpisodes,         CDatabaseQueryRule::NUMERIC_FIELD,  StringValidation::IsPositiveInteger,  false, 20360 },
-  { "numwatched",        FieldNumberOfWatchedEpisodes, SortByNumberOfWatchedEpisodes,  CDatabaseQueryRule::NUMERIC_FIELD,  StringValidation::IsPositiveInteger,  false, 21457 },
-  { "videoresolution",   FieldVideoResolution,         SortByVideoResolution,          CDatabaseQueryRule::NUMERIC_FIELD,  NULL,                                 false, 21443 },
-  { "videocodec",        FieldVideoCodec,              SortByVideoCodec,               CDatabaseQueryRule::TEXTIN_FIELD,   NULL,                                 false, 21445 },
-  { "videoaspect",       FieldVideoAspectRatio,        SortByVideoAspectRatio,         CDatabaseQueryRule::NUMERIC_FIELD,  NULL,                                 false, 21374 },
-  { "audiochannels",     FieldAudioChannels,           SortByAudioChannels,            CDatabaseQueryRule::NUMERIC_FIELD,  NULL,                                 false, 21444 },
-  { "audiocodec",        FieldAudioCodec,              SortByAudioCodec,               CDatabaseQueryRule::TEXTIN_FIELD,   NULL,                                 false, 21446 },
-  { "audiolanguage",     FieldAudioLanguage,           SortByAudioLanguage,            CDatabaseQueryRule::TEXTIN_FIELD,   NULL,                                 false, 21447 },
-  { "subtitlelanguage",  FieldSubtitleLanguage,        SortBySubtitleLanguage,         CDatabaseQueryRule::TEXTIN_FIELD,   NULL,                                 false, 21448 },
-  { "random",            FieldRandom,                  SortByRandom,                   CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 590 },
-  { "playlist",          FieldPlaylist,                SortByPlaylistOrder,            CDatabaseQueryRule::PLAYLIST_FIELD, NULL,                                 true,  559 },
-  { "virtualfolder",     FieldVirtualFolder,           SortByNone,                     CDatabaseQueryRule::PLAYLIST_FIELD, NULL,                                 true,  614 },
-  { "tag",               FieldTag,                     SortByNone,                     CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 true,  20459 },
-  { "instruments",       FieldInstruments,             SortByNone,                     CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 21892 },
-  { "biography",         FieldBiography,               SortByNone,                     CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 21887 },
-  { "born",              FieldBorn,                    SortByNone,                     CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 21893 },
-  { "bandformed",        FieldBandFormed,              SortByNone,                     CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 21894 },
-  { "disbanded",         FieldDisbanded,               SortByNone,                     CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 21896 },
-  { "died",              FieldDied,                    SortByNone,                     CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 21897 }
+  { "none",              FieldNone,                    CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 231 },
+  { "filename",          FieldFilename,                CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 561 },
+  { "path",              FieldPath,                    CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 true,  573 },
+  { "album",             FieldAlbum,                   CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 true,  558 },
+  { "albumartist",       FieldAlbumArtist,             CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 true,  566 },
+  { "artist",            FieldArtist,                  CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 true,  557 },
+  { "tracknumber",       FieldTrackNumber,             CDatabaseQueryRule::NUMERIC_FIELD,  StringValidation::IsPositiveInteger,  false, 554 },
+  { "comment",           FieldComment,                 CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 569 },
+  { "review",            FieldReview,                  CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 183 },
+  { "themes",            FieldThemes,                  CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 21895 },
+  { "moods",             FieldMoods,                   CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 175 },
+  { "styles",            FieldStyles,                  CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 176 },
+  { "type",              FieldAlbumType,               CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 564 },
+  { "label",             FieldMusicLabel,              CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 21899 },
+  { "title",             FieldTitle,                   CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 true,  556 },
+  { "sorttitle",         FieldSortTitle,               CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 171 },
+  { "year",              FieldYear,                    CDatabaseQueryRule::NUMERIC_FIELD,  StringValidation::IsPositiveInteger,  true,  562 },
+  { "time",              FieldTime,                    CDatabaseQueryRule::SECONDS_FIELD,  StringValidation::IsTime,             false, 180 },
+  { "playcount",         FieldPlaycount,               CDatabaseQueryRule::NUMERIC_FIELD,  StringValidation::IsPositiveInteger,  false, 567 },
+  { "lastplayed",        FieldLastPlayed,              CDatabaseQueryRule::DATE_FIELD,     NULL,                                 false, 568 },
+  { "inprogress",        FieldInProgress,              CDatabaseQueryRule::BOOLEAN_FIELD,  NULL,                                 false, 575 },
+  { "rating",            FieldRating,                  CDatabaseQueryRule::NUMERIC_FIELD,  CSmartPlaylistRule::ValidateRating,   false, 563 },
+  { "votes",             FieldVotes,                   CDatabaseQueryRule::TEXT_FIELD,     StringValidation::IsPositiveInteger,  false, 205 },
+  { "top250",            FieldTop250,                  CDatabaseQueryRule::NUMERIC_FIELD,  NULL,                                 false, 13409 },
+  { "mpaarating",        FieldMPAA,                    CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 20074 },
+  { "dateadded",         FieldDateAdded,               CDatabaseQueryRule::DATE_FIELD,     NULL,                                 false, 570 },
+  { "genre",             FieldGenre,                   CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 true,  515 },
+  { "plot",              FieldPlot,                    CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 207 },
+  { "plotoutline",       FieldPlotOutline,             CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 203 },
+  { "tagline",           FieldTagline,                 CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 202 },
+  { "set",               FieldSet,                     CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 true,  20457 },
+  { "director",          FieldDirector,                CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 true,  20339 },
+  { "actor",             FieldActor,                   CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 true,  20337 },
+  { "writers",           FieldWriter,                  CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 true,  20417 },
+  { "airdate",           FieldAirDate,                 CDatabaseQueryRule::DATE_FIELD,     NULL,                                 false, 20416 },
+  { "hastrailer",        FieldTrailer,                 CDatabaseQueryRule::BOOLEAN_FIELD,  NULL,                                 false, 20423 },
+  { "studio",            FieldStudio,                  CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 true,  572 },
+  { "country",           FieldCountry,                 CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 true,  574 },
+  { "tvshow",            FieldTvShowTitle,             CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 true,  20364 },
+  { "status",            FieldTvShowStatus,            CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 126 },
+  { "season",            FieldSeason,                  CDatabaseQueryRule::NUMERIC_FIELD,  StringValidation::IsPositiveInteger,  false, 20373 },
+  { "episode",           FieldEpisodeNumber,           CDatabaseQueryRule::NUMERIC_FIELD,  StringValidation::IsPositiveInteger,  false, 20359 },
+  { "numepisodes",       FieldNumberOfEpisodes,        CDatabaseQueryRule::NUMERIC_FIELD,  StringValidation::IsPositiveInteger,  false, 20360 },
+  { "numwatched",        FieldNumberOfWatchedEpisodes, CDatabaseQueryRule::NUMERIC_FIELD,  StringValidation::IsPositiveInteger,  false, 21457 },
+  { "videoresolution",   FieldVideoResolution,         CDatabaseQueryRule::NUMERIC_FIELD,  NULL,                                 false, 21443 },
+  { "videocodec",        FieldVideoCodec,              CDatabaseQueryRule::TEXTIN_FIELD,   NULL,                                 false, 21445 },
+  { "videoaspect",       FieldVideoAspectRatio,        CDatabaseQueryRule::NUMERIC_FIELD,  NULL,                                 false, 21374 },
+  { "audiochannels",     FieldAudioChannels,           CDatabaseQueryRule::NUMERIC_FIELD,  NULL,                                 false, 21444 },
+  { "audiocodec",        FieldAudioCodec,              CDatabaseQueryRule::TEXTIN_FIELD,   NULL,                                 false, 21446 },
+  { "audiolanguage",     FieldAudioLanguage,           CDatabaseQueryRule::TEXTIN_FIELD,   NULL,                                 false, 21447 },
+  { "subtitlelanguage",  FieldSubtitleLanguage,        CDatabaseQueryRule::TEXTIN_FIELD,   NULL,                                 false, 21448 },
+  { "random",            FieldRandom,                  CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 590 },
+  { "playlist",          FieldPlaylist,                CDatabaseQueryRule::PLAYLIST_FIELD, NULL,                                 true,  559 },
+  { "virtualfolder",     FieldVirtualFolder,           CDatabaseQueryRule::PLAYLIST_FIELD, NULL,                                 true,  614 },
+  { "tag",               FieldTag,                     CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 true,  20459 },
+  { "instruments",       FieldInstruments,             CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 21892 },
+  { "biography",         FieldBiography,               CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 21887 },
+  { "born",              FieldBorn,                    CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 21893 },
+  { "bandformed",        FieldBandFormed,              CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 21894 },
+  { "disbanded",         FieldDisbanded,               CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 21896 },
+  { "died",              FieldDied,                    CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 21897 }
 };
 
 static const size_t NUM_FIELDS = sizeof(fields) / sizeof(translateField);
@@ -166,16 +165,16 @@ std::string CSmartPlaylistRule::TranslateField(int field) const
 
 SortBy CSmartPlaylistRule::TranslateOrder(const char *order)
 {
-  for (unsigned int i = 0; i < NUM_FIELDS; i++)
-    if (StringUtils::EqualsNoCase(order, fields[i].string)) return fields[i].sort;
-  return SortByNone;
+  return SortUtils::SortMethodFromString(order);
 }
 
 std::string CSmartPlaylistRule::TranslateOrder(SortBy order)
 {
-  for (unsigned int i = 0; i < NUM_FIELDS; i++)
-    if (order == fields[i].sort) return fields[i].string;
-  return "none";
+  std::string sortOrder = SortUtils::SortMethodToString(order);
+  if (sortOrder.empty())
+    return "none";
+
+  return sortOrder;
 }
 
 Field CSmartPlaylistRule::TranslateGroup(const char *group)

--- a/xbmc/utils/SortUtils.cpp
+++ b/xbmc/utils/SortUtils.cpp
@@ -925,3 +925,103 @@ int SortUtils::GetSortLabel(SortBy sortBy)
   }
   return 16018; // None
 }
+
+template<typename T>
+T TypeFromString(const std::map<std::string, T>& typeMap, const std::string& name, const T& defaultType)
+{
+  auto it = typeMap.find(name);
+  if (it == typeMap.end())
+    return defaultType;
+
+  return it->second;
+}
+
+template<typename T>
+const std::string& TypeToString(const std::map<std::string, T>& typeMap, const T& value)
+{
+  auto it = std::find_if(typeMap.begin(), typeMap.end(),
+    [&value](const std::pair<std::string, T>& pair)
+  {
+    return pair.second == value;
+  });
+
+  if (it == typeMap.end())
+    return StringUtils::Empty;
+
+  return it->first;
+}
+
+const std::map<std::string, SortBy> sortMethods = {
+  { "label",            SortByLabel },
+  { "date",             SortByDate },
+  { "size",             SortBySize },
+  { "file",             SortByFile },
+  { "path",             SortByPath },
+  { "drivetype",        SortByDriveType },
+  { "title",            SortByTitle },
+  { "track",            SortByTrackNumber },
+  { "time",             SortByTime },
+  { "artist",           SortByArtist },
+  { "artistyear",       SortByArtistThenYear },
+  { "album",            SortByAlbum },
+  { "albumtype",        SortByAlbumType },
+  { "genre",            SortByGenre },
+  { "country",          SortByCountry },
+  { "year",             SortByYear },
+  { "rating",           SortByRating },
+  { "votes",            SortByVotes },
+  { "top250",           SortByTop250 },
+  { "programcount",     SortByProgramCount },
+  { "playlist",         SortByPlaylistOrder },
+  { "episode",          SortByEpisodeNumber },
+  { "season",           SortBySeason },
+  { "totalepisodes",    SortByNumberOfEpisodes },
+  { "watchedepisodes",  SortByNumberOfWatchedEpisodes },
+  { "tvshowstatus",     SortByTvShowStatus },
+  { "tvshowtitle",      SortByTvShowTitle },
+  { "sorttitle",        SortBySortTitle },
+  { "productioncode",   SortByProductionCode },
+  { "mpaa",             SortByMPAA },
+  { "videoresolution",  SortByVideoResolution },
+  { "videocodec",       SortByVideoCodec },
+  { "videoaspectratio", SortByVideoAspectRatio },
+  { "audiochannels",    SortByAudioChannels },
+  { "audiocodec",       SortByAudioCodec },
+  { "audiolanguage",    SortByAudioLanguage },
+  { "subtitlelanguage", SortBySubtitleLanguage },
+  { "studio",           SortByStudio },
+  { "dateadded",        SortByDateAdded },
+  { "lastplayed",       SortByLastPlayed },
+  { "playcount",        SortByPlaycount },
+  { "listeners",        SortByListeners },
+  { "bitrate",          SortByBitrate },
+  { "random",           SortByRandom },
+  { "channel",          SortByChannel },
+  { "channelnumber",    SortByChannelNumber },
+  { "datetaken",        SortByDateTaken }
+};
+
+SortBy SortUtils::SortMethodFromString(const std::string& sortMethod)
+{
+  return TypeFromString<SortBy>(sortMethods, sortMethod, SortByNone);
+}
+
+const std::string& SortUtils::SortMethodToString(SortBy sortMethod)
+{
+  return TypeToString<SortBy>(sortMethods, sortMethod);
+}
+
+const std::map<std::string, SortOrder> sortOrders = {
+  { "ascending", SortOrderAscending },
+  { "descending", SortOrderDescending }
+};
+
+SortOrder SortUtils::SortOrderFromString(const std::string& sortOrder)
+{
+  return TypeFromString<SortOrder>(sortOrders, sortOrder, SortOrderNone);
+}
+
+const std::string& SortUtils::SortOrderToString(SortOrder sortOrder)
+{
+  return TypeToString<SortOrder>(sortOrders, sortOrder);
+}

--- a/xbmc/utils/SortUtils.h
+++ b/xbmc/utils/SortUtils.h
@@ -126,6 +126,11 @@ public:
   static SORT_METHOD TranslateOldSortMethod(SortBy sortBy, bool ignoreArticle);
   static SortDescription TranslateOldSortMethod(SORT_METHOD sortBy);
 
+  static SortBy SortMethodFromString(const std::string& sortMethod);
+  static const std::string& SortMethodToString(SortBy sortMethod);
+  static SortOrder SortOrderFromString(const std::string& sortOrder);
+  static const std::string& SortOrderToString(SortOrder sortOrder);
+
   /*! \brief retrieve the label id associated with a sort method for displaying in the UI.
    \param sortBy the sort method in question.
    \return the label id of the sort method.


### PR DESCRIPTION
The first three commits unify the code for translating `SortBy` and `SortOrder` enum values from and to strings by addind four helper methods to `SortUtils`.

The last commit adds support for `sortby` and `sortorder` attributes to the `<content>` element used by skins to access and include dynamic content as requested in the forum. It only works for content retrieved from a path / URL and not for static content (which is usually pre-sorted).
I haven't really tested this myself yet and I'm open to suggestions for the attribute names.

@mkortstiege @ronie @phil65 @BigNoid
