### PR TITLE
[BUILTINS] CancelAlarmclock didn't understand silent as a parameter and with the…

### DIFF
--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -1236,9 +1236,9 @@ int CBuiltins::Execute(const std::string& execString)
   }
   else if (execute == "cancelalarm")
   {
-    bool silent = false;
-    if (params.size() > 1 && StringUtils::EqualsNoCase(params[1], "true"))
-      silent = true;
+    bool silent = (params.size() > 1 &&
+        (StringUtils::EqualsNoCase(params[1], "true") ||
+         StringUtils::EqualsNoCase(params[1], "silent")));
     g_alarmClock.Stop(params[0],silent);
   }
   else if (execute == "playdvd")


### PR DESCRIPTION
… addition of event logging it started displaying a toast
