### PR TITLE
[binary addons] fix android by using TARGET_LINKER_FILE_NAME instead of TARGET_FILE_NAME

### DIFF
--- a/project/cmake/scripts/common/addon-helpers.cmake
+++ b/project/cmake/scripts/common/addon-helpers.cmake
@@ -45,8 +45,15 @@ macro (build_addon target prefix libs)
     SET_TARGET_PROPERTIES(${target} PROPERTIES PREFIX "lib")
   ENDIF(OS STREQUAL "android")
 
+  # get the library's location
   SET(LIBRARY_LOCATION $<TARGET_FILE:${target}>)
-  SET(LIBRARY_FILENAME $<TARGET_FILE_NAME:${target}>)
+  # get the library's filename
+  if("${CORE_SYSTEM_NAME}" STREQUAL "android")
+    # for android we need the filename without any version numbers
+    set(LIBRARY_FILENAME $<TARGET_LINKER_FILE_NAME:${target}>)
+  else()
+    SET(LIBRARY_FILENAME $<TARGET_FILE_NAME:${target}>)
+  endif()
 
   # if there's an addon.xml.in we need to generate the addon.xml
   IF(EXISTS ${PROJECT_SOURCE_DIR}/${target}/addon.xml.in)


### PR DESCRIPTION
Right now binary addons on android are broken because the used `TARGET_FILE_NAME` generator returns the binary addon's library file name with the trailing version number which is not supported on android. Therefore we need to use the `TARGET_LINKER_FILE_NAME` generator for android.
