### PR TITLE
[music] fix missing lyrics from tag when playing from musicdb url

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -3780,8 +3780,6 @@ std::string CGUIInfoManager::GetMusicLabel(int item)
       return StringUtils::Format("%s", m_audioInfo.audioCodecName.c_str());
     }
     break;
-  case MUSICPLAYER_LYRICS:
-    return GetItemLabel(m_currentFile, AddListItemProp("lyrics"));
   }
   return GetMusicTagLabel(item, m_currentFile);
 }

--- a/xbmc/music/MusicInfoLoader.cpp
+++ b/xbmc/music/MusicInfoLoader.cpp
@@ -107,14 +107,15 @@ bool CMusicInfoLoader::LoadAdditionalTagInfo(CFileItem* pItem)
 
   CLog::Log(LOGDEBUG, "Loading additional tag info for file %s", path.c_str());
 
-  // we load up the actual tag for this file
-  unique_ptr<IMusicInfoTagLoader> pLoader (CMusicInfoTagLoaderFactory::CreateLoader(*pItem));
+  // we load up the actual tag for this file in order to
+  // fetch the lyrics and add it to the current music info tag
+  CFileItem tempItem(path, false);
+  unique_ptr<IMusicInfoTagLoader> pLoader (CMusicInfoTagLoaderFactory::CreateLoader(tempItem));
   if (NULL != pLoader.get())
   {
     CMusicInfoTag tag;
     pLoader->Load(path, tag);
-    // then we set the fields from the file tags to the item
-    pItem->SetProperty("lyrics", tag.GetLyrics());
+    pItem->GetMusicInfoTag()->SetLyrics(tag.GetLyrics());
     pItem->SetProperty("hasfullmusictag", "true");
     return true;
   }


### PR DESCRIPTION
This fixes an issue where the lyrics from tags are not properly shown when playback was started from a `musicdb://` url.

This is caused by using the wrong item path when calling the infotag loader. While at it, I've removed the dupe property handling and injected the lyrics to the current item info tag instead.

http://trac.kodi.tv/ticket/16216

@Montellese, @Paxxi
