### PR TITLE
changed: When matching articles, ignore their case

### DIFF
--- a/xbmc/utils/SortUtils.cpp
+++ b/xbmc/utils/SortUtils.cpp
@@ -786,7 +786,7 @@ string SortUtils::RemoveArticles(const string &label)
   std::set<std::string> sortTokens = g_langInfo.GetSortTokens();
   for (std::set<std::string>::const_iterator token = sortTokens.begin(); token != sortTokens.end(); ++token)
   {
-    if (token->size() < label.size() && StringUtils::StartsWith(label, *token))
+    if (token->size() < label.size() && StringUtils::StartsWithNoCase(label, *token))
       return label.substr(token->size());
   }
 


### PR DESCRIPTION
I think most of our users (and until recently myself included) assume that the sort tokens that one can configure in as.xml are case insensitive. This is mainly an issue with file lists where the filenames may not always have the proper case.
