### PR TITLE
[win32] fix minimum required CMake version for generator expressions

### DIFF
--- a/project/cmake/addons/CMakeLists.txt
+++ b/project/cmake/addons/CMakeLists.txt
@@ -1,6 +1,11 @@
 project(kodi-addons)
 
-cmake_minimum_required(VERSION 2.8)
+if(WIN32)
+  # there seems to be a bug in the CMake generator implementation in CMake 2.8.x releases for WIN32
+  cmake_minimum_required(VERSION 3.0)
+else()
+  cmake_minimum_required(VERSION 2.8)
+endif()
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR})
 


### PR DESCRIPTION
As mentioned in https://github.com/xbmc/xbmc/pull/7570#issuecomment-129738126 I noticed that at least on WIN32 CMake 2.8.x releases don't properly handle CMake generator expressions (among other bugs) which results in odd problems when trying to build our binary addons with such a broken release. Therefore we should bump the minimum required CMake version to 3.0+ which seem to work fine.

I'm not 100% sure if this only affects WIN32 and I also don't know who/what relies on the cmake version we build as part of the native depends. If this affects other platforms as well we may have to bump the version of cmake we are building as part of the native depends.
