### PR TITLE
[pvr] timers: don't show grouped timers when turned off

### DIFF
--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -414,7 +414,8 @@ bool CPVRTimers::GetRootDirectory(const CPVRTimersPath &path, CFileItemList &ite
     for (const auto &timer : *tagsEntry.second)
     {
       if ((bRadio == timer->m_bIsRadio) &&
-          (!bGrouped || (timer->m_iParentClientIndex == PVR_TIMER_NO_PARENT)))
+          ((bGrouped && (timer->m_iParentClientIndex == PVR_TIMER_NO_PARENT)) ||
+          (!bGrouped && !timer->IsRepeating())))
       {
         item.reset(new CFileItem(timer));
         std::string strItemPath(


### PR DESCRIPTION
Current behavior of the timer listing seems a bit odd to me.

When grouped mode is on: only root timers are shown and the parents are in sub directories -> OK
When grouped mode is off: is the same as above plus all the parents are added in the root directory, now each parent is in the root directory AND in a sub directory, so we have it twice??

This PR will just show a flatted list without sub directories(= repeating timers) when grouped mode is off. (like it is in the recordings window)

@ksooo @Jalle19 
