### PR TITLE
Let configure pass on unknown architectures setting sane defaults

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -721,7 +721,8 @@ case $host in
      USE_STATIC_FFMPEG=1
      ;;
   *)
-     AC_MSG_ERROR(unsupported host ($host))
+    ARCH=$host_cpu"-"$host_os
+    AC_MSG_WARN([unsupported host ($host), guessing ARCH as $ARCH.])
 esac
 AC_SUBST([ARCH])
 

--- a/m4/xbmc_arch.m4
+++ b/m4/xbmc_arch.m4
@@ -27,7 +27,8 @@ case $build in
      AC_SUBST(NATIVE_ARCH_DEFINES, "-DTARGET_POSIX -DTARGET_LINUX -D_LINUX")
      ;;
   *)
-     AC_MSG_ERROR(unsupported native build platform: $build)
+     AC_MSG_WARN([unsupported native build platform: $build])
+     AC_SUBST(NATIVE_ARCH_DEFINES, "-DTARGET_POSIX -DTARGET_LINUX -D_LINUX")
 esac
 
 
@@ -70,7 +71,8 @@ case $host in
      AC_SUBST(ARCH_DEFINES, "-DTARGET_POSIX -DTARGET_LINUX -D_LINUX -DTARGET_ANDROID")
      ;;
   *)
-     AC_MSG_ERROR(unsupported build target: $host)
+     AC_MSG_WARN([unsupported native build platform: $build])
+     AC_SUBST(ARCH_DEFINES, "-DTARGET_POSIX -DTARGET_LINUX -D_LINUX")
 esac
 
 if test "$target_platform" = "target_android" ; then


### PR DESCRIPTION
This helps porting Kodi to new architectures while emitting warnings about
entering uncharted territory.
