### PR TITLE
arm64: Fix build breakages due to architecture specific guards

### DIFF
--- a/xbmc/cores/DllLoader/DllLoader.h
+++ b/xbmc/cores/DllLoader/DllLoader.h
@@ -23,7 +23,7 @@
 #include "coffldr.h"
 #include "LibraryLoader.h"
 
-#if defined(__linux__) && !defined(__powerpc__) && !defined(__arm__) && !defined(__mips__)
+#if defined(__linux__) && !defined(__powerpc__) && !defined(__arm__) && !defined(__mips__) && !defined(__aarch64__)
 #define USE_LDT_KEEPER
 #include "ldt_keeper.h"
 #endif

--- a/xbmc/cores/DllLoader/ldt_keeper.c
+++ b/xbmc/cores/DllLoader/ldt_keeper.c
@@ -19,7 +19,7 @@
  */
 
 //#ifndef __powerpc__
-#if !defined(__powerpc__) && !defined(__ppc__) && !defined(__arm__) && !defined(__mips__)
+#if !defined(__powerpc__) && !defined(__ppc__) && !defined(__arm__) && !defined(__mips__) && !defined(__aarch64__)
 
 #include "ldt_keeper.h"
 

--- a/xbmc/cores/VideoRenderers/LinuxRendererGL.h
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGL.h
@@ -323,7 +323,7 @@ protected:
 
 
 inline int NP2( unsigned x ) {
-#if defined(TARGET_POSIX) && !defined(__POWERPC__) && !defined(__PPC__) && !defined(__arm__) && !defined(__mips__)
+#if defined(TARGET_POSIX) && !defined(__POWERPC__) && !defined(__PPC__) && !defined(__arm__) && !defined(__mips__) && !defined(__aarch64__)
   // If there are any issues compiling this, just append a ' && 0'
   // to the above to make it '#if defined(TARGET_POSIX) && 0'
 

--- a/xbmc/threads/Atomics.cpp
+++ b/xbmc/threads/Atomics.cpp
@@ -106,7 +106,7 @@ long cas(volatile long *pAddr, long expectedVal, long swapVal)
 ///////////////////////////////////////////////////////////////////////////
 long long cas2(volatile long long* pAddr, long long expectedVal, long long swapVal)
 {
-#if defined(__ppc__) || defined(__powerpc__) || defined(__arm__)// PowerPC and ARM
+#if defined(__ppc__) || defined(__powerpc__) || defined(__arm__) || defined(__aarch64__) // PowerPC and ARM
 // Not available/required
 // Hack to allow compilation
   throw "cas2 is not implemented";

--- a/xbmc/utils/MathUtils.h
+++ b/xbmc/utils/MathUtils.h
@@ -35,7 +35,7 @@
 #if defined(__ppc__) || \
     defined(__powerpc__) || \
     defined(__mips__) || \
-    defined(__arm__)
+    defined(__arm__) || defined(__aarch64__)
   #define DISABLE_MATHUTILS_ASM_ROUND_INT
 #endif
 


### PR DESCRIPTION
It builds and does not break i386 build. The resulting binary has not been tested yet due to the lack of HW.

Origin: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=796532
