### PR TITLE
[pvr] fix high cpu usage when playing recordings, trac #16141

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -4705,7 +4705,6 @@ bool CDVDPlayer::SwitchChannel(const CPVRChannelPtr &channel)
 bool CDVDPlayer::CachePVRStream(void) const
 {
   return m_pInputStream->IsStreamType(DVDSTREAM_TYPE_PVRMANAGER) &&
-      (!g_PVRManager.IsPlayingRecording() ||
-          (m_item.HasPVRRecordingInfoTag() && m_item.GetPVRRecordingInfoTag()->IsBeingRecorded()))&&
+      (!g_PVRManager.IsPlayingRecording() || g_PVRManager.IsPlayingRecordingInProgress()) &&
       g_advancedSettings.m_bPVRCacheInDvdPlayer;
 }

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -1618,6 +1618,11 @@ bool CPVRManager::IsPlayingRecording(void) const
   return IsStarted() && m_addons && m_addons->IsPlayingRecording();
 }
 
+bool CPVRManager::IsPlayingRecordingInProgress(void) const
+{
+  return IsStarted() && m_addons && m_addons->IsPlayingRecordingInProgress();
+}
+
 bool CPVRManager::IsRunningChannelScan(void) const
 {
   return IsStarted() && m_addons && m_addons->IsRunningChannelScan();

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -522,6 +522,13 @@ namespace PVR
     bool IsPlayingRecording(void) const;
 
     /*!
+     * @brief Check if a recording in progress is playing.
+     * @return True if it's playing a recording in progress, false otherwise.
+     * This is only determined on playback start.
+     */
+    bool IsPlayingRecordingInProgress(void) const;
+
+    /*!
      * @return True when a channel scan is currently running, false otherwise.
      */
     bool IsRunningChannelScan(void) const;

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -303,6 +303,12 @@ namespace PVR
     bool IsPlayingRecording(void) const;
 
     /*!
+     * @return True if a recording in progress is playing, false otherwise.
+     * This is only determined on playback start.
+     */
+    bool IsPlayingRecordingInProgress(void) const;
+
+    /*!
      * @brief Open a stream from the given recording.
      * @param tag The recording to start playing.
      * @return True if the stream was opened successfully, false otherwise.
@@ -737,6 +743,7 @@ namespace PVR
     int                   m_playingClientId;          /*!< the ID of the client that is currently playing */
     bool                  m_bIsPlayingLiveTV;
     bool                  m_bIsPlayingRecording;
+    bool                  m_bIsRecordingInProgress;   /*!< true when we are playing a recording that is still in progress */
     DWORD                 m_scanStart;                /*!< scan start time to check for non present streams */
     std::string           m_strPlayingClientName;     /*!< the name client that is currenty playing a stream or an empty string if nothing is playing */
     ADDON::VECADDONS      m_addons;


### PR DESCRIPTION
This is an attempt to fix http://trac.kodi.tv/ticket/16141 

Many calls to IsBeingRecorded() causes high cpu usage due to it's design.
(searching for a tag in the whole epg container every time)

Only tvheadend users are affected at the moment as other pvr addons don't set an epg tag for recordings.
http://forum.kodi.tv/showthread.php?tid=234640

https://github.com/xbmc/xbmc/pull/7601 is rather a revert and can be closed.

@Jalle19 @FernetMenta @opdenkamp 
