### PR TITLE
[cleanup] dont search for ogg/vorbis/vorbisenc shared libs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1336,9 +1336,6 @@ fi
   fi
 fi
 
-XB_FIND_SONAME([OGG],         [ogg])
-XB_FIND_SONAME([VORBIS],      [vorbis])
-XB_FIND_SONAME([VORBISFILE],  [vorbisfile])
 XB_FIND_SONAME([ASS],         [ass])
 XB_FIND_SONAME([MPEG2],       [mpeg2])
 

--- a/xbmc/DllPaths_generated_android.h.in
+++ b/xbmc/DllPaths_generated_android.h.in
@@ -48,10 +48,6 @@
 #define DLL_PATH_LIBMPEG2      "@MPEG2_SONAME@"
 #define DLL_PATH_LIBSTAGEFRIGHTICS    "libXBMCvcodec_stagefrightICS-@ARCH@.so"
 
-/* cdrip */
-#define DLL_PATH_OGG           "@OGG_SONAME@"
-#define DLL_PATH_VORBIS        "@VORBIS_SONAME@"
-
 /* libbluray */
 #define DLL_PATH_LIBBLURAY     "@BLURAY_SONAME@"
 

--- a/xbmc/DllPaths_win32.h
+++ b/xbmc/DllPaths_win32.h
@@ -37,10 +37,6 @@
 #define DLL_PATH_LIBDVDNAV     "special://xbmcbin/system/players/dvdplayer/libdvdnav.dll"
 #define DLL_PATH_LIBRTMP       "special://xbmcbin/system/players/dvdplayer/librtmp.dll"
 
-/* cdrip */
-#define DLL_PATH_OGG           "special://xbmcbin/system/cdrip/ogg.dll"
-#define DLL_PATH_VORBIS        "special://xbmcbin/system/cdrip/vorbis.dll"
-
 /* libbluray */
 #define DLL_PATH_LIBBLURAY     "special://xbmcbin/system/players/dvdplayer/libbluray.dll"
 


### PR DESCRIPTION
.. and leftovers

EDIT: as libogg/vorbis are not really dlopened at runtime (anymore), this will allow distros to have them built static if they like.
