### PR TITLE
[osx] - fix crash on osx 10.7 when trying to resolve hdd names

### DIFF
--- a/xbmc/osx/DarwinUtils.h
+++ b/xbmc/osx/DarwinUtils.h
@@ -33,6 +33,7 @@ public:
   static const char *getIosPlatformString(void);
   static bool        IsAppleTV2(void);
   static bool        IsMavericks(void);
+  static bool        IsLion(void); 
   static bool        IsSnowLeopard(void);
   static bool        DeviceHasRetina(double &scale);
   static const char *GetOSReleaseString(void);

--- a/xbmc/osx/DarwinUtils.mm
+++ b/xbmc/osx/DarwinUtils.mm
@@ -212,6 +212,20 @@ bool CDarwinUtils::IsMavericks(void)
   return isMavericks == 1;
 }
 
+bool CDarwinUtils::IsLion(void)  
+{  
+  static int isLion = -1;  
+#if defined(TARGET_DARWIN_OSX)  
+  if (isLion == -1)  
+  {  
+    double appKitVersion = floor(NSAppKitVersionNumber);  
+    // everything lower 10.8 is 10.7.x because 10.7 is deployment target...  
+    isLion = (appKitVersion < NSAppKitVersionNumber10_8) ? 1 : 0;  
+  }  
+#endif  
+  return isLion == 1;  
+}
+
 bool CDarwinUtils::IsSnowLeopard(void)
 {
   static int isSnowLeopard = -1;

--- a/xbmc/storage/osx/DarwinStorageProvider.cpp
+++ b/xbmc/storage/osx/DarwinStorageProvider.cpp
@@ -29,6 +29,7 @@
 #include <DiskArbitration/DiskArbitration.h>
 #include <IOKit/storage/IOCDMedia.h>
 #include <IOKit/storage/IODVDMedia.h>
+#include "osx/DarwinUtils.h"  
 #endif
 #include "osx/CocoaInterface.h"
 
@@ -62,6 +63,9 @@ void CDarwinStorageProvider::GetLocalDrives(VECSOURCES &localDrives)
   share.strName = "Volumes";
   share.m_ignore = true;
   localDrives.push_back(share);
+  
+  if (CDarwinUtils::IsLion())  
+   return; //temp workaround for crash in Cocoa_GetVolumeNameFromMountPoint on 10.7.x  
 
   // This will pick up all local non-removable disks including the Root Disk.
   DASessionRef session = DASessionCreate(kCFAllocatorDefault);
@@ -106,6 +110,10 @@ void CDarwinStorageProvider::GetLocalDrives(VECSOURCES &localDrives)
 void CDarwinStorageProvider::GetRemovableDrives(VECSOURCES &removableDrives)
 {
 #if defined(TARGET_DARWIN_OSX)
+
+  if (CDarwinUtils::IsLion())  
+    return; //temp workaround for crash in Cocoa_GetVolumeNameFromMountPoint on 10.7.x  
+
   DASessionRef session = DASessionCreate(kCFAllocatorDefault);
   if (session)
   {


### PR DESCRIPTION
This is a regression since bumping osx sdk to 10.10 and deployment target to 10. The crash only happens on osx 10.7 when calling a sane API Function from the SDK.

I don't have any 10.7 mashine atm (but requested an os update for our unused mythic beast macmini). This is only a workaround for now so that the crash doesn't happen. I will investigate and try to develop a real fix once that macmini has osx 10.7 on it.

Sorry for the cluttered commits - i only have github webinterface at hand atm.

15.2 material!
