### PR TITLE
[video] fix title prompting in case the search returned no results

### DIFF
--- a/xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
+++ b/xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
@@ -197,9 +197,22 @@ bool CVideoLibraryRefreshingJob::Work(CVideoDatabase &db)
       }
     }
 
-    // if the URL is still empty there's nothing else we can do
+    // if the URL is still empty, check whether or not we're allowed
+    // to prompt and ask the user to input a new search title
     if (!hasDetails && scraperUrl.m_url.empty())
     {
+      if (m_showDialogs)
+      {
+        // ask the user to input a title to use
+        if (!CGUIKeyboardFactory::ShowAndGetInput(itemTitle, g_localizeStrings.Get(scraper->Content() == CONTENT_TVSHOWS ? 20357 : 16009), false))
+          return false;
+
+        // go through the whole process again
+        needsRefresh = true;
+        continue;
+      }
+
+      // nothing else we can do
       failure = true;
       break;
     }


### PR DESCRIPTION
This fixes an issue after 5149e6c1860427dfcb3c79174ee09112bad62a6e where the user is not prompted to input a new search title in case the initial lookup returned no results.

/cc @Montellese, @tamland
