### PR TITLE
[infomanager] add Container.Row/Column info label for panels

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -3385,6 +3385,7 @@ std::string CGUIInfoManager::GetMultiInfoLabel(const GUIInfo &info, int contextW
   }
   else if (info.m_info == CONTAINER_NUM_PAGES || info.m_info == CONTAINER_CURRENT_PAGE ||
            info.m_info == CONTAINER_NUM_ITEMS || info.m_info == CONTAINER_POSITION ||
+           info.m_info == CONTAINER_ROW || info.m_info == CONTAINER_COLUMN ||
            info.m_info == CONTAINER_CURRENT_ITEM)
   {
     const CGUIControl *control = NULL;

--- a/xbmc/guilib/GUIPanelContainer.cpp
+++ b/xbmc/guilib/GUIPanelContainer.cpp
@@ -21,6 +21,7 @@
 #include "GUIPanelContainer.h"
 #include "guiinfo/GUIInfoLabels.h"
 #include "input/Key.h"
+#include "utils/StringUtils.h"
 
 #include <cassert>
 
@@ -487,12 +488,24 @@ bool CGUIPanelContainer::SelectItemFromPoint(const CPoint &point)
   return true;
 }
 
+int CGUIPanelContainer::GetCurrentRow() const
+{
+  return m_itemsPerRow > 0 ? GetCursor() / m_itemsPerRow : 0;
+}
+
+int CGUIPanelContainer::GetCurrentColumn() const
+{
+  return GetCursor() % m_itemsPerRow;
+}
+
 bool CGUIPanelContainer::GetCondition(int condition, int data) const
-{ // probably only works vertically atm...
-  int row = GetCursor() / m_itemsPerRow;
-  int col = GetCursor() % m_itemsPerRow;
+{
+  int row = GetCurrentRow();
+  int col = GetCurrentColumn();
+
   if (m_orientation == HORIZONTAL)
     std::swap(row, col);
+
   switch (condition)
   {
   case CONTAINER_ROW:
@@ -502,6 +515,26 @@ bool CGUIPanelContainer::GetCondition(int condition, int data) const
   default:
     return CGUIBaseContainer::GetCondition(condition, data);
   }
+}
+
+std::string CGUIPanelContainer::GetLabel(int info) const
+{
+  int row = GetCurrentRow();
+  int col = GetCurrentColumn();
+
+  if (m_orientation == HORIZONTAL)
+    std::swap(row, col);
+
+  switch (info)
+  {
+  case CONTAINER_ROW:
+    return StringUtils::Format("%i", row);
+  case CONTAINER_COLUMN:
+    return StringUtils::Format("%i", col);
+  default:
+    return CGUIBaseContainer::GetLabel(info);
+  }
+  return StringUtils::Empty;
 }
 
 void CGUIPanelContainer::SelectItem(int item)

--- a/xbmc/guilib/GUIPanelContainer.h
+++ b/xbmc/guilib/GUIPanelContainer.h
@@ -47,6 +47,7 @@ public:
   virtual void OnUp();
   virtual void OnDown();
   virtual bool GetCondition(int condition, int data) const;
+  virtual std::string GetLabel(int info) const;
 protected:
   virtual bool MoveUp(bool wrapAround);
   virtual bool MoveDown(bool wrapAround);
@@ -64,6 +65,9 @@ protected:
   virtual void SelectItem(int item);
   virtual bool HasPreviousPage() const;
   virtual bool HasNextPage() const;
+
+  int GetCurrentRow() const;
+  int GetCurrentColumn() const;
 
   int m_itemsPerRow;
 };


### PR DESCRIPTION
This add `Container.Row/Column` info labels (analogous to the info bool ones) for panels.

/cc @BigNoid, @HitcherUK, @phil65, @ronie
