### PR TITLE
CVideoLibraryRefreshingJob: ditch m_showDialogs in favor of CProgressJob::DoModal/IsModal()

### DIFF
--- a/xbmc/video/VideoLibraryQueue.cpp
+++ b/xbmc/video/VideoLibraryQueue.cpp
@@ -125,9 +125,7 @@ void CVideoLibraryQueue::CleanLibraryModal(const std::set<int>& paths /* = std::
 
 void CVideoLibraryQueue::RefreshItem(CFileItemPtr item, bool ignoreNfo /* = false */, bool forceRefresh /* = true */, bool refreshAll /* = false */, const std::string& searchTitle /* = "" */)
 {
-  CVideoLibraryRefreshingJob* refreshingJob = new CVideoLibraryRefreshingJob(item, forceRefresh, refreshAll, ignoreNfo, searchTitle);
-  refreshingJob->SetShowDialogs(false);
-  AddJob(refreshingJob);
+  AddJob(new CVideoLibraryRefreshingJob(item, forceRefresh, refreshAll, ignoreNfo, searchTitle));
 }
 
 bool CVideoLibraryQueue::RefreshItemModal(CFileItemPtr item, bool forceRefresh /* = true */, bool refreshAll /* = false */)
@@ -138,9 +136,8 @@ bool CVideoLibraryQueue::RefreshItemModal(CFileItemPtr item, bool forceRefresh /
 
   m_modal = true;
   CVideoLibraryRefreshingJob refreshingJob(item, forceRefresh, refreshAll);
-  refreshingJob.SetShowDialogs(true);
 
-  bool result = refreshingJob.DoWork();
+  bool result = refreshingJob.DoModal();
   m_modal = false;
 
   return result;

--- a/xbmc/video/jobs/VideoLibraryProgressJob.cpp
+++ b/xbmc/video/jobs/VideoLibraryProgressJob.cpp
@@ -29,11 +29,8 @@ CVideoLibraryProgressJob::~CVideoLibraryProgressJob()
 
 bool CVideoLibraryProgressJob::DoWork()
 {
-  SetProgress(0.0f);
-
   bool result = CVideoLibraryJob::DoWork();
 
-  SetProgress(100.0f);
   MarkFinished();
 
   return result;

--- a/xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
+++ b/xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
@@ -142,10 +142,12 @@ bool CVideoLibraryRefreshingJob::Work(CVideoDatabase &db)
       // try to find a matching item
       MOVIELIST itemResultList;
       int result = infoDownloader.FindMovie(itemTitle, itemResultList, GetProgressDialog());
+
+      // close the progress dialog
+      MarkFinished();
+
       if (result > 0)
       {
-        MarkFinished();
-
         // there are multiple matches for the item
         if (!itemResultList.empty())
         {

--- a/xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
+++ b/xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
@@ -40,7 +40,6 @@
 CVideoLibraryRefreshingJob::CVideoLibraryRefreshingJob(CFileItemPtr item, bool forceRefresh, bool refreshAll, bool ignoreNfo /* = false */, const std::string& searchTitle /* = "" */)
   : CVideoLibraryProgressJob(nullptr),
     m_item(item),
-    m_showDialogs(false),
     m_forceRefresh(forceRefresh),
     m_refreshAll(refreshAll),
     m_ignoreNfo(ignoreNfo),
@@ -87,9 +86,6 @@ bool CVideoLibraryRefreshingJob::Work(CVideoDatabase &db)
   bool hasDetails = false;
   bool ignoreNfo = m_ignoreNfo;
 
-  if (m_showDialogs)
-    SetProgressDialog(static_cast<CGUIDialogProgress*>(g_windowManager.GetWindow(WINDOW_DIALOG_PROGRESS)));
-
   // run this in a loop in case we need to refresh again
   bool failure = false;
   do
@@ -106,7 +102,7 @@ bool CVideoLibraryRefreshingJob::Work(CVideoDatabase &db)
 
 
       // if we are performing a forced refresh ask the user to choose between using a valid NFO and a valid scraper
-      if (needsRefresh && m_showDialogs && !scraper->IsNoop() &&
+      if (needsRefresh && IsModal() && !scraper->IsNoop() &&
          (nfoResult == CNfoFile::URL_NFO || nfoResult == CNfoFile::COMBINED_NFO || nfoResult == CNfoFile::FULL_NFO))
       {
         int heading = 20159;
@@ -154,7 +150,7 @@ bool CVideoLibraryRefreshingJob::Work(CVideoDatabase &db)
         if (!itemResultList.empty())
         {
           // choose the first match
-          if (!m_showDialogs)
+          if (!IsModal())
             scraperUrl = itemResultList.at(0);
           else
           {
@@ -201,7 +197,7 @@ bool CVideoLibraryRefreshingJob::Work(CVideoDatabase &db)
     // to prompt and ask the user to input a new search title
     if (!hasDetails && scraperUrl.m_url.empty())
     {
-      if (m_showDialogs)
+      if (IsModal())
       {
         // ask the user to input a title to use
         if (!CGUIKeyboardFactory::ShowAndGetInput(itemTitle, g_localizeStrings.Get(scraper->Content() == CONTENT_TVSHOWS ? 20357 : 16009), false))
@@ -300,7 +296,7 @@ bool CVideoLibraryRefreshingJob::Work(CVideoDatabase &db)
       MarkFinished();
 
       // check if the user cancelled
-      if (!IsCancelled() && m_showDialogs)
+      if (!IsCancelled() && IsModal())
         CGUIDialogOK::ShowAndGetInput(195, itemTitle);
 
       return false;
@@ -325,7 +321,7 @@ bool CVideoLibraryRefreshingJob::Work(CVideoDatabase &db)
     break;
   } while (needsRefresh);
 
-  if (failure && m_showDialogs)
+  if (failure && IsModal())
     CGUIDialogOK::ShowAndGetInput(195, itemTitle);
 
   return true;

--- a/xbmc/video/jobs/VideoLibraryRefreshingJob.h
+++ b/xbmc/video/jobs/VideoLibraryRefreshingJob.h
@@ -47,15 +47,12 @@ public:
   virtual const char *GetType() const { return "VideoLibraryRefreshingJob"; }
   virtual bool operator==(const CJob* job) const;
 
-  void SetShowDialogs(bool showDialogs) { m_showDialogs = showDialogs; }
-
 protected:
   // implementation of CVideoLibraryJob
   virtual bool Work(CVideoDatabase &db);
 
 private:
   CFileItemPtr m_item;
-  bool m_showDialogs;
   bool m_forceRefresh;
   bool m_refreshAll;
   bool m_ignoreNfo;


### PR DESCRIPTION
This fixes the progress dialog not showing up when refreshing a video item in the GUI which has been broken since #7306.
Thanks to @tamland for reporting the issue.
