### PR TITLE
[video] add listitem audio/subtitle properties from streamdetails

### DIFF
--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -557,6 +557,27 @@ void CVideoThumbLoader::DetectAndAddMissingItemData(CFileItem &item)
 {
   if (item.m_bIsFolder) return;
 
+  if (item.HasVideoInfoTag())
+  {
+    CStreamDetails& details = item.GetVideoInfoTag()->m_streamDetails;
+
+    // add audio language properties
+    for (int i = 1; i <= details.GetAudioStreamCount(); i++)
+    {
+      std::string index = StringUtils::Format("%i", i);
+      item.SetProperty("AudioChannels." + index, details.GetAudioChannels(i));
+      item.SetProperty("AudioCodec."    + index, details.GetAudioCodec(i).c_str());
+      item.SetProperty("AudioLanguage." + index, details.GetAudioLanguage(i).c_str());
+    }
+
+    // add subtitle language properties
+    for (int i = 1; i <= details.GetSubtitleStreamCount(); i++)
+    {
+      std::string index = StringUtils::Format("%i", i);
+      item.SetProperty("SubtitleLanguage." + index, details.GetSubtitleLanguage(i).c_str());
+    }
+  }
+
   std::string stereoMode;
   // detect stereomode for videos
   if (item.HasVideoInfoTag())


### PR DESCRIPTION
This is a in-core replacement for `script.videolanguage`. Since we already know about the streamdetails there's no need to perform additional json look-ups just to fill those.

If available, the following audio and subtitle based properties will be filled from streamdetails:
- ListItem.Property(AudioCodec.[n])
- ListItem.Property(AudioLanguage.[n])
- ListItem.Property(AudioChannels.[n])
- ListItem.Property(SubtitleLanguage.[n])

Unlike the script this is setting the properties on the actual `ListItem`. Skins just need to replace `Window.Property` with `ListItem.Property`. After that the script dependency can be ditched.

/cc @BigNoid, @HitcherUK, @Montellese, @phil65, @ronie, @vonH
