### PR TITLE
[PVR][Confluence] Add EPG to search results window

### DIFF
--- a/addons/skin.confluence/720p/MyPVRSearch.xml
+++ b/addons/skin.confluence/720p/MyPVRSearch.xml
@@ -118,7 +118,7 @@
 					<left>0</left>
 					<top>55</top>
 					<width>1100</width>
-					<height>520</height>
+					<height>370</height>
 					<onup>50</onup>
 					<ondown>50</ondown>
 					<onleft>104</onleft>
@@ -191,7 +191,7 @@
 								<aligny>center</aligny>
 								<textcolor>grey2</textcolor>
 								<selectedcolor>selected</selectedcolor>
-								<info>ListItem.Label</info>
+								<label>$INFO[ListItem.Label]$INFO[ListItem.EpisodeName, (,)]</label>
 							</control>
 							<control type="label">
 								<left>750</left>
@@ -250,7 +250,7 @@
 								<textcolor>grey2</textcolor>
 								<selectedcolor>selected</selectedcolor>
 								<label>31510</label>
-								<visible>ListItem.HasTimer</visible>
+								<visible>ListItem.HasTimer + !ListItem.IsRecording</visible>
 							</control>
 							<control type="image">
 								<left>980</left>
@@ -336,7 +336,7 @@
 								<aligny>center</aligny>
 								<textcolor>white</textcolor>
 								<selectedcolor>selected</selectedcolor>
-								<info>ListItem.Label</info>
+								<label>$INFO[ListItem.Label]$INFO[ListItem.EpisodeName, (,)]</label>
 							</control>
 							<control type="label">
 								<left>750</left>
@@ -395,7 +395,7 @@
 								<textcolor>grey2</textcolor>
 								<selectedcolor>selected</selectedcolor>
 								<label>31510</label>
-								<visible>ListItem.HasTimer</visible>
+								<visible>ListItem.HasTimer + !ListItem.IsRecording</visible>
 							</control>
 							<control type="image">
 								<left>980</left>
@@ -412,7 +412,7 @@
 					<left>1105</left>
 					<top>50</top>
 					<width>25</width>
-					<height>520</height>
+					<height>370</height>
 					<texturesliderbackground border="0,14,0,14">ScrollBarV.png</texturesliderbackground>
 					<texturesliderbar border="0,14,0,14">ScrollBarV_bar.png</texturesliderbar>
 					<texturesliderbarfocus border="0,14,0,14">ScrollBarV_bar_focus.png</texturesliderbarfocus>
@@ -422,6 +422,74 @@
 					<onright>104</onright>
 					<showonepage>false</showonepage>
 					<orientation>vertical</orientation>
+				</control>
+				<control type="image">
+					<description>separator image</description>
+					<left>0</left>
+					<top>430</top>
+					<width>1100</width>
+					<height>1</height>
+					<colordiffuse>88FFFFFF</colordiffuse>
+					<texture>separator2.png</texture>
+				</control>
+				<control type="group">
+					<visible>!ListItem.HasEPG</visible>
+					<left>0</left>
+					<top>440</top>
+					<control type="label">
+						<left>0</left>
+						<top>0</top>
+						<width>1100</width>
+						<height>20</height>
+						<label>$LOCALIZE[19055]</label>
+						<font>font13</font>
+						<textcolor>white</textcolor>
+						<align>center</align>
+					</control>
+				</control>
+				<control type="group">
+					<visible>ListItem.HasEPG</visible>
+					<left>0</left>
+					<top>440</top>
+					<control type="image">
+						<left>62</left>
+						<top>6</top>
+						<width>130</width>
+						<height>130</height>
+						<texture background="true">$INFO[ListItem.Icon]</texture>
+						<aspectratio align="center" aligny="center">keep</aspectratio>
+					</control>
+					<control type="label">
+						<left>280</left>
+						<top>0</top>
+						<width>800</width>
+						<height>20</height>
+						<label>[B]$INFO[ListItem.EpgEventTitle]$INFO[ListItem.EpisodeName, (,)][/B]</label>
+						<font>font13</font>
+						<textcolor>white</textcolor>
+						<scroll>true</scroll>
+					</control>
+					<control type="label">
+						<left>280</left>
+						<top>25</top>
+						<width>800</width>
+						<height>20</height>
+						<label>$INFO[ListItem.StartTime]$INFO[ListItem.EndTime, - ]$INFO[ListItem.Season, • $LOCALIZE[20373] ]$INFO[ListItem.Episode, • $LOCALIZE[20359] ]$INFO[ListItem.Genre, • ]</label>
+						<font>font12</font>
+						<textcolor>grey</textcolor>
+					</control>
+					<control type="textbox">
+						<description>Plot value</description>
+						<left>280</left>
+						<top>57</top>
+						<width>800</width>
+						<height>63</height>
+						<font>font12</font>
+						<align>justify</align>
+						<textcolor>grey</textcolor>
+						<autoscroll delay="10000" time="3000" repeat="6000">true</autoscroll>
+						<label>$INFO[ListItem.Plot]</label>
+					</control>
 				</control>
 			</control>
 			<control type="label">


### PR DESCRIPTION
Inspired by the excellent new PVR Timers window with EPG data at the bottom, I've added the same to the PVR search results window:
![screenshot025](https://cloud.githubusercontent.com/assets/12870817/9567983/51fd9dc0-4f35-11e5-98a7-2abd5cb61525.png)

I've also added EpisodeName to the results, and stopped the 'Timer set' string appearing under the 'Recording' string.
pings: @ksooo @ronie
