### PR TITLE
[guilib] fix button label2 not updated after emptying

### DIFF
--- a/xbmc/guilib/GUIButtonControl.cpp
+++ b/xbmc/guilib/GUIButtonControl.cpp
@@ -146,6 +146,8 @@ void CGUIButtonControl::ProcessText(unsigned int currentTime)
   bool changed = m_label.SetMaxRect(m_posX, m_posY, renderWidth, m_height);
   changed |= m_label.SetText(m_info.GetLabel(m_parentID));
   changed |= m_label.SetScrolling(HasFocus());
+  changed |= m_label2.SetMaxRect(m_posX, m_posY, renderWidth, m_height);
+  changed |= m_label2.SetText(m_info2.GetLabel(m_parentID));
 
   // text changed - images need resizing
   if (m_minWidth && (m_label.GetRenderRect() != labelRenderRect))
@@ -162,8 +164,6 @@ void CGUIButtonControl::ProcessText(unsigned int currentTime)
   if (!m_info2.GetLabel(m_parentID).empty())
   {
     changed |= m_label2.SetAlign(XBFONT_RIGHT | (m_label.GetLabelInfo().align & XBFONT_CENTER_Y) | XBFONT_TRUNCATED);
-    changed |= m_label2.SetMaxRect(m_posX, m_posY, renderWidth, m_height);
-    changed |= m_label2.SetText(m_info2.GetLabel(m_parentID));
     changed |= m_label2.SetScrolling(HasFocus());
 
     // If overlapping was corrected - compare render rects to determine


### PR DESCRIPTION
This fixes button label2 not properly updated when emptied.

Thanks @tamland for reporting.
