### PR TITLE
[PVR] Search context menu crash fix + 'play recording' context option

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
@@ -70,6 +70,8 @@ void CGUIWindowPVRSearch::GetContextButtons(int itemNumber, CContextButtons &but
         }
       }
     }
+    if (pItem->GetEPGInfoTag()->HasRecording())
+      buttons.Add(CONTEXT_BUTTON_PLAY_ITEM, 19687);       /* Play recording */
 
     buttons.Add(CONTEXT_BUTTON_INFO, 19047);              /* Epg info button */
     if (pItem->GetEPGInfoTag()->HasPVRChannel() &&
@@ -99,6 +101,7 @@ bool CGUIWindowPVRSearch::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
       OnContextButtonInfo(pItem.get(), button) ||
       OnContextButtonStopRecord(pItem.get(), button) ||
       OnContextButtonStartRecord(pItem.get(), button) ||
+      OnContextButtonPlay(pItem.get(), button) ||
       CGUIWindowPVRBase::OnContextButton(itemNumber, button);
 }
 
@@ -243,6 +246,19 @@ bool CGUIWindowPVRSearch::OnContextButtonInfo(CFileItem *item, CONTEXT_BUTTON bu
     bReturn = true;
 
     ShowEPGInfo(item);
+  }
+
+  return bReturn;
+}
+
+bool CGUIWindowPVRSearch::OnContextButtonPlay(CFileItem *item, CONTEXT_BUTTON button)
+{
+  bool bReturn = false;
+
+  if (button == CONTEXT_BUTTON_PLAY_ITEM)
+  {
+    ActionPlayEpg(item, true /* play recording, not channel */);
+    bReturn = true;
   }
 
   return bReturn;

--- a/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
@@ -63,9 +63,11 @@ void CGUIWindowPVRSearch::GetContextButtons(int itemNumber, CContextButtons &but
       {
         if (pItem->GetEPGInfoTag()->StartAsLocalTime() < CDateTime::GetCurrentDateTime())
           buttons.Add(CONTEXT_BUTTON_STOP_RECORD, 19059); /* stop recording */
-        else if (pItem->GetPVRTimerInfoTag()->HasTimerType() &&
-                 !pItem->GetPVRTimerInfoTag()->GetTimerType()->IsReadOnly())
-          buttons.Add(CONTEXT_BUTTON_STOP_RECORD, 19060); /* delete timer */
+        else if (pItem->GetEPGInfoTag()->Timer()->HasTimerType())
+        {
+          if (!pItem->GetEPGInfoTag()->Timer()->GetTimerType()->IsReadOnly())
+            buttons.Add(CONTEXT_BUTTON_STOP_RECORD, 19060); /* delete timer */
+        }
       }
     }
 

--- a/xbmc/pvr/windows/GUIWindowPVRSearch.h
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.h
@@ -43,6 +43,7 @@ namespace PVR
   private:
     bool OnContextButtonClear(CFileItem *item, CONTEXT_BUTTON button);
     bool OnContextButtonInfo(CFileItem *item, CONTEXT_BUTTON button);
+    bool OnContextButtonPlay(CFileItem *item, CONTEXT_BUTTON button);
     bool OnContextButtonStartRecord(CFileItem *item, CONTEXT_BUTTON button);
     bool OnContextButtonStopRecord(CFileItem *item, CONTEXT_BUTTON button);
 


### PR DESCRIPTION
Part 1) - If a PVR Search returned an EPG entry with a timer, selecting the context menu would cause kodi to crash. The first commit fixes this.

Part 2) - The second commit adds a 'Play recording' context menu option if an EPG entry has an associated recording.

ping @ksooo
