### PR TITLE
[builtins] adds ToggleRegionVisualization builtin

### DIFF
--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -165,6 +165,7 @@
       <a mod="ctrl,shift">Notification(MCEKeypress, DVD audio, 3)</a>
       <k mod="ctrl,shift">ReloadKeymaps</k>
       <d mod="ctrl,shift">ToggleDebug</d>
+      <r mod="ctrl,shift">ToggleDirtyRegionVisualization</r>
     </keyboard>
   </global>
   <LoginScreen>

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -236,6 +236,7 @@ const BUILT_IN commands[] = {
 #endif
   { "VideoLibrary.Search",        false,  "Brings up a search dialog which will search the library" },
   { "ToggleDebug",                false,  "Enables/disables debug mode" },
+  { "ToggleDirtyRegionVisualization", false, "Enables/disables dirty-region visualization" },
   { "StartPVRManager",            false,  "(Re)Starts the PVR manager (Deprecated)" },
   { "StopPVRManager",             false,  "Stops the PVR manager (Deprecated)" },
   { "PVR.StartManager",            false,  "(Re)Starts the PVR manager" },
@@ -1854,6 +1855,10 @@ int CBuiltins::Execute(const std::string& execString)
     bool debug = CSettings::GetInstance().GetBool(CSettings::SETTING_DEBUG_SHOWLOGINFO);
     CSettings::GetInstance().SetBool(CSettings::SETTING_DEBUG_SHOWLOGINFO, !debug);
     g_advancedSettings.SetDebugMode(!debug);
+  }
+  else if (execute == "toggledirtyregionvisualization")
+  {
+    g_advancedSettings.ToggleDirtyRegionVisualization();
   }
   //TODO deprecated. To be replaced by pvr.startmanager
   else if (execute == "startpvrmanager")

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -384,6 +384,9 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
 
     void SetDebugMode(bool debug);
 
+    //! \brief Toggles dirty-region visualization
+    void ToggleDirtyRegionVisualization() { m_guiVisualizeDirtyRegions = !m_guiVisualizeDirtyRegions; };
+
     // runtime settings which cannot be set from advancedsettings.xml
     std::string m_pictureExtensions;
     std::string m_videoExtensions;


### PR DESCRIPTION
Adds new `ToggleDirtyRegions` builtin. This enables on-the-fly dirty-region visualization toggling without the need to restart Kodi.

Requested by @HitcherUK.
