### PR TITLE
[infomanager] add Container.Content info label

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -3411,6 +3411,20 @@ std::string CGUIInfoManager::GetMultiInfoLabel(const GUIInfo &info, int contextW
     if (window)
       return ((CGUIMediaWindow *)window)->CurrentDirectory().GetArt(m_stringParameters[info.GetData2()]);
   }
+  else if (info.m_info == CONTAINER_CONTENT)
+  {
+    CGUIWindow *window = NULL;
+    if (info.GetData1())
+    { // container specified
+      window = GetWindowWithCondition(contextWindow, 0);
+    }
+    else
+    { // no container specified - assume a mediawindow
+      window = GetWindowWithCondition(contextWindow, WINDOW_CONDITION_IS_MEDIA_WINDOW);
+    }
+    if (window)
+      return ((CGUIMediaWindow *)window)->CurrentDirectory().GetContent();
+  }
   else if (info.m_info == CONTROL_GET_LABEL)
   {
     CGUIWindow *window = GetWindowWithCondition(contextWindow, 0);


### PR DESCRIPTION
Makes `Container(id).Content` return the actual content type (eg. movies, tvshows, seasons ..). Currently it's only implemented as info bool.

Requested by @phil65
