### PR TITLE
[peripheral] Move initialisation after language init to fix notifcations

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -689,8 +689,6 @@ bool CApplication::Create()
     return false;
   }
 
-  g_peripherals.Initialise();
-
   // Create the Mouse, Keyboard, Remote, and Joystick devices
   // Initialize after loading settings to get joystick deadzone setting
   CInputManager::GetInstance().InitializeInputs();
@@ -1135,6 +1133,8 @@ bool CApplication::Initialize()
     StringUtils::Format(g_localizeStrings.Get(177).c_str(), g_sysinfo.GetAppName().c_str()),
     StringUtils::Format(g_localizeStrings.Get(178).c_str(), g_sysinfo.GetAppName().c_str()),
     "special://xbmc/media/icon256x256.png", EventLevelBasic)));
+
+  g_peripherals.Initialise();
 
   // Load curl so curl_global_init gets called before any service threads
   // are started. Unloading will have no effect as curl is never fully unloaded.


### PR DESCRIPTION
Lots of complaints on Isengard are master that CEC generates an empty notification popup on boot.
The problem is that peripherals are initialised before the language files are loaded so
g_localizeStrings.Get returns a blank string.

Move the periphal initialisation after the language initialisation to avoid this.
