### PR TITLE
Fix < menu > for Android and linux

### DIFF
--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -67,8 +67,8 @@
       <s>ActivateWindow(shutdownmenu)</s>
       <escape>PreviousMenu</escape>
       <i>Info</i>
-      <menu>Menu</menu>
-      <menu mod="longpress">ContextMenu</menu>
+      <menu>ContextMenu</menu>
+      <menu mod="longpress">Menu</menu>
       <c>ContextMenu</c>
       <space>Pause</space>
       <x>Stop</x>

--- a/system/keymaps/remote.xml
+++ b/system/keymaps/remote.xml
@@ -56,8 +56,8 @@
       <pageplus>PageUp</pageplus>
       <pageminus>PageDown</pageminus>
       <back>Back</back>
-      <menu>Menu</menu>
-      <menu mod="logpress">PreviousMenu</menu>
+      <menu>ContextMenu</menu>
+      <menu mod="longpress">Menu</menu>
       <contentsmenu>PreviousMenu</contentsmenu>
       <rootmenu>PreviousMenu</rootmenu>
       <title>ContextMenu</title>


### PR DESCRIPTION
Fix < menu > for Android and Linux. < menu > on Android and Linux normally defaulted to context menu, but this broke when < menu > was added to the global section of keyboard.xml (nearly all remotes on Android are seen as keyboards). This restores the previous behavior, while still adding a way to bring up the sidebar (which is the action ID "menu", not to be confused with "ContextMenu").
