### PR TITLE
[MusicLibrary] Include "Various artists" album artist in the artists list

### DIFF
--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -5517,10 +5517,7 @@ bool CMusicDatabase::GetFilter(CDbUrl &musicUrl, Filter &filter, SortDescription
                   " OR artistview.idArtist IN ";
 
       // and always show any artists linked to an album (may be different from above due to album artist tag)
-      strSQL +=   "(SELECT album_artist.idArtist FROM album_artist"; // All artists linked to an album
-      if (albumArtistsOnly)
-        strSQL += " JOIN album ON album.idAlbum = album_artist.idAlbum WHERE album.bCompilation = 0 ";            // then exclude those that have no extra artists
-      strSQL +=   ")";
+      strSQL += "(SELECT album_artist.idArtist FROM album_artist)"; // Includes compliation albums hence "Various artists"
     }
 
     // remove the null string


### PR DESCRIPTION
(Resubmitted #7928 after messing up the Git and commiting additional WIP by mistake).
Before Gotham the "Various artists" entry would appear in the artists list (when "include artists who appear only on compilations" is disabled). On the forum users have requested this is reinstated. See http://forum.kodi.tv/showthread.php?tid=223454 and http://forum.kodi.tv/showthread.php?tid=200797

It also seems inconsistent to exclude it as an album artist in this one view, since it does appear when listing the artists for a specific genre.

In testing I discovered that this change reveals some previously hidden (lost?) artists. That possibly elevates it to being a bug fix!!  MusicBrainz/Picard sometimes sets the compliation flag but also provides album artists, unless these artists appear on some other album then they are currently excluded from the artists list. That is not good behaviour.

When albumArtistsOnly is false then it is valid to exclude the fake (album) artist "Various artists" from the artists list because you are listing the song artists individually.

Looked back in the Git I have not be able to find a good reason to exclude it - in fact it simplifies the query. Anyone see a problem? A nice simple change, a good place to start my first PR.

@evilhamster, @Razzeee nothing new here. @Montellese any comments?
