### PR TITLE
carpc-touch-adjustment-support

### DIFF
--- a/xbmc/input/linux/LinuxInputDevices.cpp
+++ b/xbmc/input/linux/LinuxInputDevices.cpp
@@ -96,6 +96,7 @@ typedef unsigned long kernel_ulong_t;
 #include "LinuxInputDevices.h"
 #include "input/MouseStat.h"
 #include "utils/log.h"
+#include "settings/AdvancedSettings.h"
 
 #ifndef BITS_PER_LONG
 #define BITS_PER_LONG        (sizeof(long) * 8)
@@ -460,6 +461,13 @@ bool CLinuxInputDevice::KeyEvent(const struct input_event& levt, XBMC_Event& dev
 {
   int code = levt.code;
 
+  if((levt.code == BTN_TOUCH || levt.code == BTN_TOOL_FINGER || levt.code == BTN_MOUSE)
+      && levt.value == 1 && (levt.type == EV_ABS || g_advancedSettings.m_TouchMouse))
+  {
+    m_mouseX = g_graphicsContext.GetWidth() + 2;
+    m_mouseY = g_graphicsContext.GetHeight() + 2;
+  }
+
   /* map touchscreen and smartpad events to button mouse */
   if (code == BTN_TOUCH || code == BTN_TOOL_FINGER)
     code = BTN_MOUSE;
@@ -634,11 +642,19 @@ bool CLinuxInputDevice::AbsEvent(const struct input_event& levt, XBMC_Event& dev
   switch (levt.code)
   {
   case ABS_X:
-    m_mouseX = levt.value;
+    if(!g_advancedSettings.m_SwapAxes)
+      m_mouseX = (int)((float)levt.value * g_advancedSettings.m_xStretchFactor) + g_advancedSettings.m_xOffset; // stretch and shift touch x coordinates
+    else
+      m_mouseX = (int)((float)levt.value * g_advancedSettings.m_yStretchFactor) + g_advancedSettings.m_yOffset; // stretch and shift touch x coordinates wit y values
+    break;
+
     break;
 
   case ABS_Y:
-    m_mouseY = levt.value;
+    if(!g_advancedSettings.m_SwapAxes)
+      m_mouseY = (int)((float)levt.value * g_advancedSettings.m_yStretchFactor) + g_advancedSettings.m_yOffset; // stretch and shift touch y coordinates
+    else
+      m_mouseY = (int)((float)levt.value * g_advancedSettings.m_xStretchFactor) + g_advancedSettings.m_xOffset; // stretch and shift touch y coordinates with x values
     break;
   
   case ABS_MISC:

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -309,6 +309,15 @@ void CAdvancedSettings::Initialize()
   m_iEdlCommBreakAutowait = 0;             // Off by default
   m_iEdlCommBreakAutowind = 0;             // Off by default
 
+  // Touchscreen default values if no adjustment is necessarry
+  m_xOffset = 0;
+  m_yOffset= 0;
+  m_xStretchFactor = 1.0;
+  m_yStretchFactor = 1.0;
+  m_TouchMouse = 0;
+  m_SwapAxes = 0;
+  m_TouchConfines = 8;
+
   m_curlconnecttimeout = 10;
   m_curllowspeedtime = 20;
   m_curlretries = 2;
@@ -886,6 +895,19 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetInt(pElement, "maxstartgap", m_iEdlMaxStartGap, 0, 10 * 60);               // Between 0 and 10 minutes
     XMLUtils::GetInt(pElement, "commbreakautowait", m_iEdlCommBreakAutowait, 0, 10);        // Between 0 and 10 seconds
     XMLUtils::GetInt(pElement, "commbreakautowind", m_iEdlCommBreakAutowind, 0, 10);        // Between 0 and 10 seconds
+  }
+
+  // Touchscreencontroller allignment
+  pElement = pRootElement->FirstChildElement("touchscreen_allign");
+  if (pElement)
+  {
+    XMLUtils::GetInt(pElement, "x_offset", m_xOffset, 0, 1920);
+    XMLUtils::GetInt(pElement, "y_offset", m_yOffset, 0, 1920);
+    XMLUtils::GetFloat(pElement, "x_stretch_factor", m_xStretchFactor );
+    XMLUtils::GetFloat(pElement, "y_stretch_factor", m_yStretchFactor );
+    XMLUtils::GetBoolean(pElement, "touch_mouse", m_TouchMouse );
+    XMLUtils::GetBoolean(pElement, "swap_axes", m_SwapAxes );
+    XMLUtils::GetInt(pElement, "touch_confines", m_TouchConfines, 0, 1920);
   }
 
   // picture exclude regexps

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -344,6 +344,15 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     std::string m_cpuTempCmd;
     std::string m_gpuTempCmd;
 
+    // Touchscreen allignment advanced settings
+    int m_xOffset;
+    int m_yOffset;
+    float m_xStretchFactor;
+    float m_yStretchFactor;
+    bool m_TouchMouse;
+    bool m_SwapAxes;
+    int m_TouchConfines;
+
     /* PVR/TV related advanced settings */
     int m_iPVRTimeCorrection;     /*!< @brief correct all times (epg tags, timer tags, recording tags) by this amount of minutes. defaults to 0. */
     int m_iPVRInfoToggleInterval; /*!< @brief if there are more than 1 pvr gui info item available (e.g. multiple recordings active at the same time), use this toggle delay in milliseconds. defaults to 3000. */


### PR DESCRIPTION
This commit should enable a touchscreen to be alligned to a display if it do not exactly match.
By adding an offset and a stretch factor it is possible to allign the touch panel coordinate system to the display coordinates
depending on the panel orentation on some display/panels a transformation of x and y coordinates is necessarry
Aslo som panels provides mouse events instead of touch evnents therefor a flag is integrated to get a usable touch behaviour
everithing can be activeded if necessarry by creating a advancedsettings.xml

example of possible parameters:
<advancedsettings>
        <touchscreen_allign>
                <!-- Touchscreen x axsis offset from the upper left corner -->
                <x_offset>0</x_offset>
                <!-- Touchscreen y axsis offset from the upper left corner -->
                <y_offset>0</y_offset>
                <!-- Touchscreen x axis stretch factor if mouse position is not alligned with touched point-->
                <x_stretch_factor>1.44</x_stretch_factor>
                <!-- Touchscreen y axis stretch factor if mouse position is not alligned with touched point-->
                <y_stretch_factor>0.89</y_stretch_factor>
                <!--event xchange for touchscreens that gives back mouse when touch event is executed-->
                <touch_mouse>0</touch_mouse>
                <!-- swap axes if adjustment at x(y) axes results in an changed behaviour in y(x) axes-->
                <swap_axes>0</swap_axes>
                <!--confines define the range around the last touch point interpreted as same position-->
                <touch_confines>8</touch_confines>
        </touchscreen_allign>
</advancedsettings>
