### PR TITLE
[cec] Don't reopen connection when going to standby to avoid a deadlock

### DIFF
--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -191,6 +191,10 @@ void CPeripheralCecAdapter::Announce(AnnouncementFlag flag, const char *sender, 
   else if (flag == System && !strcmp(sender, "xbmc") && !strcmp(message, "OnWake"))
   {
     CLog::Log(LOGDEBUG, "%s - reconnecting to the CEC adapter after standby mode", __FUNCTION__);
+    {
+      CSingleLock lock(m_critSection);
+      m_bGoingToStandby = false;
+    }
     if (ReopenConnection())
     {
       bool bActivate(false);
@@ -1656,6 +1660,8 @@ bool CPeripheralCecAdapter::ReopenConnection(void)
   // stop running thread
   {
     CSingleLock lock(m_critSection);
+    if (m_bGoingToStandby)
+      return;
     m_iExitCode = EXITCODE_RESTARTAPP;
     CAnnouncementManager::GetInstance().RemoveAnnouncer(this);
     StopThread(false);


### PR DESCRIPTION
Hi everyone,

I'm using Kodi on a small Windows system connected to a TV, with PulseEight's HDMI-CEC adapter. The system is configured to go to sleep after a while of inactivity and resume when the HDMI is connected again.

Very often after waking up, the whole PC resumes fine, but Kodi is frozen. The clock still shows the time from when it went to sleep, CEC control is not working, waiting does not help, and when I press some keys, after a while the standard Windows "_application not responding_" dialog appears.

---

From a dump file, I have tracked this down to a deadlock in Kodi's CEC client implementation. Apparently the following is happening:
- [Main thread] `CAnnouncementManager` locks its `m_critSection`,
              announces "xbmc/OnSleep" to `CPeripheralCecAdapter`,
              which calls its `StopThread()`.
- [CECAdapter thread] Starts the shutdown process,
                    closes libcec handle.
- [libcec thread] Dispatches `CEC_ALERT_CONNECTION_LOST`,
                `CPeripheralCecAdapter` calls `ReopenConnection()`,
                locks its `m_critSection`,
                calls `CAnnouncementManager::RemoveAnnouncer()`.

Now the main thread holds `CAnnouncementManager::m_critSection`
and it is waiting for the "CECAdapter" thread to die,
but the "CECAdapter" thread is waiting for `CPeripheralCecAdapter::m_critSection`,
but that is locked by the libcec thread,
which is waiting for the `CAnnouncementManager::m_critSection`.

---

My proposed solution is to add an extra check to `ReopenConnection()` to not attempt to reopen the connection when going to standby and reset the related `m_bGoingToStandby` variable when waking up so that `ReopenConnection()` works again.

Thanks!
