### PR TITLE
touch panel to display adjustment

### DIFF
--- a/xbmc/input/MouseStat.cpp
+++ b/xbmc/input/MouseStat.cpp
@@ -22,6 +22,7 @@
 #include "input/Key.h"
 #include "utils/TimeUtils.h"
 #include "windowing/WindowingFactory.h"
+#include "settings/AdvancedSettings.h"
 
 CMouseStat::CMouseStat()
 {
@@ -287,7 +288,7 @@ bool CMouseStat::CButtonState::InClickRange(int x, int y) const
 {
   int dx = x - m_x;
   int dy = y - m_y;
-  return (unsigned int)(dx*dx + dy*dy) <= click_confines*click_confines;
+  return (unsigned int)(dx*dx + dy*dy) <= g_advancedSettings.m_confines*g_advancedSettings.m_confines;
 }
 
 CMouseStat::CButtonState::BUTTON_ACTION CMouseStat::CButtonState::Update(unsigned int time, int x, int y, bool down)

--- a/xbmc/input/MouseStat.h
+++ b/xbmc/input/MouseStat.h
@@ -151,9 +151,9 @@ private:
      */
     BUTTON_ACTION Update(unsigned int time, int x, int y, bool down);
   private:
-    static const unsigned int click_confines = 5;        ///< number of pixels that the pointer may move while the button is down to trigger a click
-    static const unsigned int short_click_time = 1000;   ///< time for mouse down/up to trigger a short click rather than a long click
-    static const unsigned int double_click_time = 500;   ///< time for mouse down following a short click to trigger a double click
+//    static const unsigned int click_confines = 8;	///< number of pixels that the pointer may move while the button is down to trigger a click
+    static const unsigned int short_click_time = 1000;   			///< time for mouse down/up to trigger a short click rather than a long click
+    static const unsigned int double_click_time = 500;   			///< time for mouse down following a short click to trigger a double click
 
     bool InClickRange(int x, int y) const;
 

--- a/xbmc/input/linux/LinuxInputDevices.cpp
+++ b/xbmc/input/linux/LinuxInputDevices.cpp
@@ -96,6 +96,7 @@ typedef unsigned long kernel_ulong_t;
 #include "LinuxInputDevices.h"
 #include "input/MouseStat.h"
 #include "utils/log.h"
+#include "settings/AdvancedSettings.h"
 
 #ifndef BITS_PER_LONG
 #define BITS_PER_LONG        (sizeof(long) * 8)
@@ -634,13 +635,13 @@ bool CLinuxInputDevice::AbsEvent(const struct input_event& levt, XBMC_Event& dev
   switch (levt.code)
   {
   case ABS_X:
-    m_mouseX = levt.value;
+    m_mouseX = (int)((float)levt.value * g_advancedSettings.m_xStretchFactor) + g_advancedSettings.m_xOffset; // stretch and shift touch x coordinates
     break;
 
   case ABS_Y:
-    m_mouseY = levt.value;
+    m_mouseY = (int)((float)levt.value * g_advancedSettings.m_yStretchFactor) + g_advancedSettings.m_yOffset; // stretch and shift touch y coordinates
     break;
-  
+
   case ABS_MISC:
     remoteStatus = levt.value & 0xFF;
     break;

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -314,6 +314,7 @@ void CAdvancedSettings::Initialize()
   m_yOffset= 0;
   m_xStretchFactor = 1.0;
   m_yStretchFactor = 1.0;
+  m_confines = 8;
 
   m_curlconnecttimeout = 10;
   m_curllowspeedtime = 20;
@@ -902,6 +903,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetInt(pElement, "y_offset", m_yOffset, 0, 1920);
     XMLUtils::GetFloat(pElement, "x_stretch_factor", m_xStretchFactor );
     XMLUtils::GetFloat(pElement, "y_stretch_factor", m_yStretchFactor );
+    XMLUtils::GetInt(pElement, "confines", m_confines );
   }
 
   // picture exclude regexps

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -309,6 +309,12 @@ void CAdvancedSettings::Initialize()
   m_iEdlCommBreakAutowait = 0;             // Off by default
   m_iEdlCommBreakAutowind = 0;             // Off by default
 
+  // Touchscreen default values if no adjustment is necessarry
+  m_xOffset = 0;
+  m_yOffset= 0;
+  m_xStretchFactor = 1.0;
+  m_yStretchFactor = 1.0;
+
   m_curlconnecttimeout = 10;
   m_curllowspeedtime = 20;
   m_curlretries = 2;
@@ -886,6 +892,16 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetInt(pElement, "maxstartgap", m_iEdlMaxStartGap, 0, 10 * 60);               // Between 0 and 10 minutes
     XMLUtils::GetInt(pElement, "commbreakautowait", m_iEdlCommBreakAutowait, 0, 10);        // Between 0 and 10 seconds
     XMLUtils::GetInt(pElement, "commbreakautowind", m_iEdlCommBreakAutowind, 0, 10);        // Between 0 and 10 seconds
+  }
+
+  // Touchscreencontroller allignment
+  pElement = pRootElement->FirstChildElement("touchscreen_allign");
+  if (pElement)
+  {
+    XMLUtils::GetInt(pElement, "x_offset", m_xOffset, 0, 1920);
+    XMLUtils::GetInt(pElement, "y_offset", m_yOffset, 0, 1920);
+    XMLUtils::GetFloat(pElement, "x_stretch_factor", m_xStretchFactor );
+    XMLUtils::GetFloat(pElement, "y_stretch_factor", m_yStretchFactor );
   }
 
   // picture exclude regexps

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -345,10 +345,11 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     std::string m_gpuTempCmd;
 
     // Touchscreen allignment advanced settings
-    int m_xOffset;
-    int m_yOffset;
-    float m_xStretchFactor;
-    float m_yStretchFactor;
+    int m_xOffset;		// x axis offset of touch panel coordinate origin
+    int m_yOffset;		// y axis offset of touch panel coordinate origin
+    float m_xStretchFactor;	// x axis stretch factor
+    float m_yStretchFactor;	// y axis stretch factor
+    int m_confines; 		// click or touch confines setting
 
     /* PVR/TV related advanced settings */
     int m_iPVRTimeCorrection;     /*!< @brief correct all times (epg tags, timer tags, recording tags) by this amount of minutes. defaults to 0. */

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -344,6 +344,12 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     std::string m_cpuTempCmd;
     std::string m_gpuTempCmd;
 
+    // Touchscreen allignment advanced settings
+    int m_xOffset;
+    int m_yOffset;
+    float m_xStretchFactor;
+    float m_yStretchFactor;
+
     /* PVR/TV related advanced settings */
     int m_iPVRTimeCorrection;     /*!< @brief correct all times (epg tags, timer tags, recording tags) by this amount of minutes. defaults to 0. */
     int m_iPVRInfoToggleInterval; /*!< @brief if there are more than 1 pvr gui info item available (e.g. multiple recordings active at the same time), use this toggle delay in milliseconds. defaults to 3000. */


### PR DESCRIPTION
2nd attempt with a clean version of a touch pane adjustment in case the panel coordinate system do not match the display coordinate.

with this adjustment it is possible to set an offset and a stretch factor for x and y axis of the touch panel.
settings are optional and can be mentioned in advancedsettings.xml

example of my 7inch isp panel (http://www.chalk-elec.com/?p=1712):
<touchscreen_allign>
   <!-- Touchscreen x axsis offset from the upper left corner -->
   <x_offset>0</x_offset>
   <!-- Touchscreen y axsis offset from the upper left corner -->
   <y_offset>0</y_offset>
   <!-- Touchscreen x axis stretch factor if mouse position is not alligned with touched point-->
   <x_stretch_factor>1.44</x_stretch_factor>
   <!-- Touchscreen y axis stretch factor if mouse position is not alligned with touched point-->
   <y_stretch_factor>0.89</y_stretch_factor>
</touchscreen_allign>
