### PR TITLE
Fix fileutils test that failed on windows

### DIFF
--- a/xbmc/utils/test/TestFileUtils.cpp
+++ b/xbmc/utils/test/TestFileUtils.cpp
@@ -37,7 +37,7 @@ TEST(TestFileUtils, DeleteItem_CFileItemPtr)
   item->SetPath(tmpfilepath);
   item->m_bIsFolder = false;
   item->Select(true);
-
+  tmpfile->Close();  //Close tmpfile before we try to delete it
   EXPECT_TRUE(CFileUtils::DeleteItem(item));
 }
 
@@ -46,6 +46,7 @@ TEST(TestFileUtils, DeleteItemString)
   XFILE::CFile *tmpfile;
 
   ASSERT_NE(nullptr, (tmpfile = XBMC_CREATETEMPFILE("")));
+  tmpfile->Close();  //Close tmpfile before we try to delete it
   EXPECT_TRUE(CFileUtils::DeleteItem(XBMC_TEMPFILEPATH(tmpfile)));
 }
 


### PR DESCRIPTION
I only tested this with win32, so this should be checked with every other build that is out there before merging.
