### PR TITLE
[CALSAHControlMonitor] ignore device re-enumeration on info events

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/alsa/ALSAHControlMonitor.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/alsa/ALSAHControlMonitor.cpp
@@ -125,13 +125,13 @@ int CALSAHControlMonitor::HCTLCallback(snd_hctl_elem_t *elem, unsigned int mask)
 
   if (mask & SND_CTL_EVENT_MASK_VALUE)
   {
-    CLog::Log(LOGDEBUG, "CALSAHControlMonitor - Monitored ALSA hctl value changed");
+    CLog::Log(LOGDEBUG, "CALSAHControlMonitor - Monitored ALSA hctl value changed with mask value of %u", mask);
 
-    /*
-     * Currently we just re-enumerate on any change.
+    /* Currently we just re-enumerate on any change.
      * Custom callbacks for handling other control monitoring may be implemented when needed.
-     */
-    CAEFactory::DeviceChange();
+     * We ignore pure INFO events for now. */
+    if (mask != (SND_CTL_EVENT_MASK_VALUE | SND_CTL_EVENT_MASK_INFO))
+      CAEFactory::DeviceChange();
   }
 
   return 0;


### PR DESCRIPTION
See http://forum.kodi.tv/showthread.php?tid=232113&pid=2053765#pid2053765

Essentially the issue is without this PR and each time a new file is played you get the complete device re-enumeration which is **70++ lines when playback starts and another 70++ lines when playback ends (140++ lines total per file) of device re-enumerations spammed on log per file played.**

With this PR it behaves better.and its works perfectly. Also added logging for the value that's triggering change without this PR it was always 3.

@fritsch said in last post I could PR this if I like (its his patch) and ping @anssih so best start this ball rolling after 1 + months (Since I like to solve this)
