### PR TITLE
[guilib] The output buffer of IImage::Decode should be a const pointe…

### DIFF
--- a/xbmc/guilib/JpegIO.cpp
+++ b/xbmc/guilib/JpegIO.cpp
@@ -340,7 +340,7 @@ bool CJpegIO::Read(unsigned char* buffer, unsigned int bufSize, unsigned int min
   }
 }
 
-bool CJpegIO::Decode(const unsigned char *pixels, unsigned int pitch, unsigned int format)
+bool CJpegIO::Decode(unsigned char* const pixels, unsigned int pitch, unsigned int format)
 {
   unsigned char *dst = (unsigned char*)pixels;
 

--- a/xbmc/guilib/JpegIO.h
+++ b/xbmc/guilib/JpegIO.h
@@ -42,7 +42,7 @@ public:
   static bool           CreateThumbnailFromSurface(unsigned char* buffer, unsigned int width, unsigned int height, unsigned int format, unsigned int pitch, const std::string& destFile);
   void           Close();
   // methods for the imagefactory
-  virtual bool   Decode(const unsigned char *pixels, unsigned int pitch, unsigned int format);
+  virtual bool   Decode(unsigned char* const pixels, unsigned int pitch, unsigned int format);
   virtual bool   LoadImageFromMemory(unsigned char* buffer, unsigned int bufSize, unsigned int width, unsigned int height);
   virtual bool   CreateThumbnailFromSurface(unsigned char* bufferin, unsigned int width, unsigned int height, unsigned int format, unsigned int pitch, const std::string& destFile, 
                                             unsigned char* &bufferout, unsigned int &bufferoutSize);

--- a/xbmc/guilib/cximage.cpp
+++ b/xbmc/guilib/cximage.cpp
@@ -65,7 +65,7 @@ bool CXImage::LoadImageFromMemory(unsigned char* buffer, unsigned int bufSize, u
   return true;
 }
 
-bool CXImage::Decode(const unsigned char *pixels, unsigned int pitch, unsigned int format)
+bool CXImage::Decode(unsigned char* const pixels, unsigned int pitch, unsigned int format)
 {
   if (m_image.width == 0 || m_image.height == 0 || !m_dll.IsLoaded())
     return false;

--- a/xbmc/guilib/cximage.h
+++ b/xbmc/guilib/cximage.h
@@ -29,7 +29,7 @@ public:
   ~CXImage();
 
   virtual bool LoadImageFromMemory(unsigned char* buffer, unsigned int bufSize, unsigned int width, unsigned int height);
-  virtual bool Decode(const unsigned char *pixels, unsigned int pitch, unsigned int format);
+  virtual bool Decode(unsigned char* const pixels, unsigned int pitch, unsigned int format);
   virtual bool CreateThumbnailFromSurface(unsigned char* bufferin, unsigned int width, unsigned int height, unsigned int format, unsigned int pitch, const std::string& destFile, 
                                           unsigned char* &bufferout, unsigned int &bufferoutSize);
   virtual void ReleaseThumbnailBuffer();

--- a/xbmc/guilib/iimage.h
+++ b/xbmc/guilib/iimage.h
@@ -43,7 +43,7 @@ public:
    \param format The format of the output buffer (JpegIO only)
    \return true if the image data could be decoded to the output buffer
    */
-  virtual bool Decode(const unsigned char *pixels, unsigned int pitch, unsigned int format)=0;
+  virtual bool Decode(unsigned char* const pixels, unsigned int pitch, unsigned int format)=0;
   /*!
    \brief Encodes an thumbnail from raw bits of given memory location
    \remarks Caller need to call ReleaseThumbnailBuffer() afterwards to free the output buffer


### PR DESCRIPTION
…r rather than a pointer to a const value.

Found because of @Paxxi ;)
