### PR TITLE
Fix: Disable unneeded flip of characters for hebrew/arabic languages

### DIFF
--- a/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
+++ b/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
@@ -411,8 +411,8 @@ BOOL CExternalPlayer::ExecuteAppW32(const char* strPath, const char* strSwitches
   si.wShowWindow = m_hideconsole ? SW_HIDE : SW_SHOW;
 
   std::wstring WstrPath, WstrSwitches;
-  g_charsetConverter.utf8ToW(strPath, WstrPath);
-  g_charsetConverter.utf8ToW(strSwitches, WstrSwitches);
+  g_charsetConverter.utf8ToW(strPath, WstrPath, false);
+  g_charsetConverter.utf8ToW(strSwitches, WstrSwitches, false);
 
   if (m_bAbortRequest) return false;
 


### PR DESCRIPTION
When calling to utf8ToW() function with bVisualBiDiFlip = true, the result contains hebrew/arabic characters in reverse order.
When bVisualBiDiFlip = false, the result contains hebrew/arabic characters in correct order, so this flip need to be disabled.
