### PR TITLE
DCADEC: Display real stream information - don't hide what we know

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1091,7 +1091,6 @@ PKG_CHECK_MODULES([GNUTLS], [gnutls], [have_gnutls=yes];AC_DEFINE([HAVE_GNUTLS],
 AC_CHECK_LIB([bz2],         [main],, AC_MSG_ERROR($missing_library))
 AC_CHECK_LIB([jpeg],        [main],, AC_MSG_ERROR($missing_library)) # check for cximage
 AC_CHECK_LIB([tiff],        [main],, AC_MSG_ERROR($missing_library))
-AC_CHECK_LIB([dcadec],      [main],, AC_MSG_ERROR($missing_library))
 if echo "$ARCH" | grep -q freebsd; then
 AC_CHECK_LIB([pthread],     [main],LIBS="-pthread $LIBS", AC_MSG_ERROR($missing_library))
 AC_CHECK_LIB([pthread],     [pthread_set_name_np],

--- a/tools/depends/target/libdcadec/Makefile
+++ b/tools/depends/target/libdcadec/Makefile
@@ -1,11 +1,27 @@
 -include ../../Makefile.include
-DEPS= ../../Makefile.include Makefile libdcadec_android.patch
+DEPS= Makefile
 
 # lib name, version
 LIBNAME=libdcadec
 VERSION=git-2a9186e3
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
+
+ifeq ($(CROSS_COMPILING), yes)
+  DEPS += ../../Makefile.include libdcadec_android.patch
+  EXTRA_FLAGS = CC="$(CC)" CFLAGS="$(CFLAGS)" LDFLAGS="$(LDFLAGS)" AR="$(AR)"
+else
+  ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+
+  ifeq ($(PLATFORM),)
+    PLATFORM = native
+    TARBALLS_LOCATION = $(ROOT_DIR)
+    BASE_URL := http://mirrors.kodi.tv/build-deps/sources
+    RETRIEVE_TOOL := curl -Ls --create-dirs -f -O
+    ARCHIVE_TOOL := tar --strip-components=1 -xf
+  endif
+endif
+
 
 # configuration settings
 
@@ -19,6 +35,12 @@ $(TARBALLS_LOCATION)/$(ARCHIVE):
 	cd $(TARBALLS_LOCATION); $(RETRIEVE_TOOL) $(RETRIEVE_TOOL_FLAGS) $(BASE_URL)/$(ARCHIVE)
 
 $(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
+ifeq ($(PREFIX),)
+	@echo
+	@echo "ERROR: please set PREFIX to the kodi install path e.g. make PREFIX=/usr/local"
+	@exit 1
+endif
+
 	rm -rf $(PLATFORM)/*; mkdir -p $(PLATFORM)
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
 ifeq ($(OS),android)
@@ -26,10 +48,10 @@ ifeq ($(OS),android)
 endif
 
 $(LIBDYLIB): $(PLATFORM)
-	$(MAKE) -C $(PLATFORM) PREFIX=$(PREFIX) CC="$(CC)" CFLAGS="$(CFLAGS)" LDFLAGS="$(LDFLAGS)" AR="$(AR)"
+	$(MAKE) -C $(PLATFORM) PREFIX=$(PREFIX) $(EXTRA_FLAGS)
 
 .installed-$(PLATFORM): $(LIBDYLIB)
-	$(MAKE) -C $(PLATFORM) PREFIX=$(PREFIX) CC="$(CC)" CFLAGS="$(CFLAGS)" LDFLAGS="$(LDFLAGS)" AR="$(AR)" install
+	$(MAKE) -C $(PLATFORM) PREFIX=$(PREFIX) $(EXTRA_FLAGS) install
 	touch $@
 
 clean:
@@ -37,4 +59,4 @@ clean:
 	rm -f .installed-$(PLATFORM)
 
 distclean::
-	rm -rf $(PLATFORM) .installed-$(PLATFORM)
+	rm -rf $(PLATFORM) .installed-$(PLATFORM) libdcadec-*.tar.gz

--- a/tools/depends/target/libdcadec/Makefile
+++ b/tools/depends/target/libdcadec/Makefile
@@ -1,4 +1,4 @@
-include ../../Makefile.include
+-include ../../Makefile.include
 DEPS= ../../Makefile.include Makefile libdcadec_android.patch
 
 # lib name, version

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -439,17 +439,14 @@ bool CDVDDemuxFFmpeg::Open(CDVDInputStream* pInput, bool streaminfo, bool filein
 
   if (m_streaminfo)
   {
-    if (CSettings::GetInstance().GetBool(CSettings::SETTING_AUDIOOUTPUT_SUPPORTSDTSHDCPUDECODING))
+    for (unsigned int i = 0; i < m_pFormatContext->nb_streams; i++)
     {
-      for (unsigned int i = 0; i < m_pFormatContext->nb_streams; i++)
+      AVStream *st = m_pFormatContext->streams[i];
+      if (st->codec->codec_type == AVMEDIA_TYPE_AUDIO && st->codec->codec_id == AV_CODEC_ID_DTS)
       {
-        AVStream *st = m_pFormatContext->streams[i];
-        if (st->codec->codec_type == AVMEDIA_TYPE_AUDIO && st->codec->codec_id == AV_CODEC_ID_DTS)
-        {
-          AVCodec* pCodec = avcodec_find_decoder_by_name("libdcadec");
-          if (pCodec)
-            st->codec->codec = pCodec;
-        }
+        AVCodec* pCodec = avcodec_find_decoder_by_name("libdcadec");
+        if (pCodec)
+          st->codec->codec = pCodec;
       }
     }
     /* to speed up dvd switches, only analyse very short */


### PR DESCRIPTION
Don't hide stream information depending on user setting concerning playback. It makes no sense to display DTS or 5.1 channels depending on user's output settings.
