### PR TITLE
Keep journal in memory and do not worry about synchronicity as the OS is handling it

### DIFF
--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -30,6 +30,9 @@
 #include "sqlitedataset.h"
 #include "DatabaseManager.h"
 #include "DbUrl.h"
+#if defined(TARGET_RASPBERRY_PI)
+#include "linux/RBP.h"
+#endif
 
 #ifdef HAS_MYSQL
 #include "mysqldataset.h"
@@ -493,8 +496,14 @@ bool CDatabase::Connect(const std::string &dbName, const DatabaseSettings &dbSet
     if (dbSettings.type == "sqlite3")
     {
       m_pDS->exec("PRAGMA cache_size=4096\n");
-      m_pDS->exec("PRAGMA synchronous='NORMAL'\n");
+      m_pDS->exec("PRAGMA synchronous='OFF'\n");
       m_pDS->exec("PRAGMA count_changes='OFF'\n");
+      bool memJournal = true;
+      #if defined(TARGET_RASPBERRY_PI)
+	memJournal = (g_RBP.GetArmMem() >= 384);
+      #endif
+     if (memJournal)
+         m_pDS->exec("PRAGMA journal_mode = 'MEMORY'\n");
     }
   }
   catch (DbErrors &error)


### PR DESCRIPTION
The SQLite pragma statements can be adjusted to provide better database performance. I believe that synchronous=OFF is safe, but using an in memory journal may not be if Kodi crashes.

Performance improvements look promising:

OSMC running Kodi 15.1

First run - 209
Second run - 204

OSMC running Kodi 15.1 with this patch

First run - 105
Second run - 95

This is without mmap'd sqlite (https://github.com/xbmc/xbmc/pull/7926). 
