### PR TITLE
fixed, AEDelayStatus is a struct, not a class

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.h
@@ -24,7 +24,7 @@
 #include "cores/AudioEngine/Sinks/osx/CoreAudioDevice.h"
 
 class AERingBuffer;
-class AEDelayStatus;
+struct AEDelayStatus;
 
 class CAESinkDARWINOSX : public IAESink
 {


### PR DESCRIPTION
Found on https://github.com/MrMC/mrmc/ - it's obviously a correct fix
