### PR TITLE
fix use of progress-dialog lines in wake-on-access class

### DIFF
--- a/xbmc/network/WakeOnAccess.cpp
+++ b/xbmc/network/WakeOnAccess.cpp
@@ -170,12 +170,6 @@ public:
       m_dialog->SetLine(0, CVariant{""});
       m_dialog->SetLine(1, CVariant{""});
       m_dialog->SetLine(2, CVariant{""});
-
-      int nest_level = NestDetect::Level();
-      if (nest_level > 1)
-      {
-        m_dialog->SetLine(2, CVariant{StringUtils::Format("Nesting:%d", nest_level)});
-      }
     }
   }
   ~ProgressDialogHelper ()
@@ -194,7 +188,7 @@ public:
 
     if (m_dialog)
     {
-      m_dialog->SetLine(1, CVariant{line1});
+      m_dialog->SetLine(0, CVariant{line1});
 
       m_dialog->SetPercentage(1); // avoid flickering by starting at 1% ..
     }


### PR DESCRIPTION
The display has had an error where a new message is meant to replace the previous but instead the effect has been that two lines were have been displayed simultaneously. Error was caused by misunderstanding how the progress-dialog class handled empty lines
