### PR TITLE
settings: fix method signatures of overriden virtual methods

### DIFF
--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -393,14 +393,14 @@ public:
   void UnregisterActionListener(IActionListener *listener);
 
 protected:
-  virtual bool OnSettingsSaving() const;
+  virtual bool OnSettingsSaving() const override;
 
-  virtual bool Load(const TiXmlNode *settings);
-  virtual bool Save(TiXmlNode *settings) const;
+  virtual bool Load(const TiXmlNode *settings) override;
+  virtual bool Save(TiXmlNode *settings) const override;
 
-  virtual void OnSettingChanged(const CSetting *setting);
-  virtual void OnSettingAction(const CSetting *setting);
-  virtual bool OnSettingUpdate(CSetting* &setting, const char *oldSettingId, const TiXmlNode *oldSettingNode);
+  virtual void OnSettingChanged(const CSetting *setting) override;
+  virtual void OnSettingAction(const CSetting *setting) override;
+  virtual bool OnSettingUpdate(CSetting* &setting, const char *oldSettingId, const TiXmlNode *oldSettingNode) override;
 
   bool LoadSkin(const std::string& skinID);
   bool LoadSkin(const std::shared_ptr<ADDON::CSkinInfo>& skin);

--- a/xbmc/GUIPassword.h
+++ b/xbmc/GUIPassword.h
@@ -87,7 +87,7 @@ public:
   void RemoveSourceLocks();
   bool IsDatabasePathUnlocked(const std::string& strPath, VECSOURCES& vecSources);
 
-  virtual void OnSettingAction(const CSetting *setting);
+  virtual void OnSettingAction(const CSetting *setting) override;
 
   bool bMasterUser;
   int iMasterLockRetriesLeft;

--- a/xbmc/LangInfo.h
+++ b/xbmc/LangInfo.h
@@ -63,10 +63,10 @@ public:
   virtual ~CLangInfo();
 
   // implementation of ISettingCallback
-  virtual void OnSettingChanged(const CSetting *setting);
+  virtual void OnSettingChanged(const CSetting *setting) override;
 
   // implementation of ISettingsHandler
-  virtual void OnSettingsLoaded();
+  virtual void OnSettingsLoaded() override;
 
   bool Load(const std::string& strLanguage);
 

--- a/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSP.h
+++ b/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSP.h
@@ -142,7 +142,7 @@ namespace ActiveAE
 
   /*! @name Settings and action callback methods */
   //@{
-    virtual void OnSettingAction(const CSetting *setting);
+    virtual void OnSettingAction(const CSetting *setting) override;
   //@}
 
   /*! @name Backend methods */

--- a/xbmc/cores/playercorefactory/PlayerCoreFactory.h
+++ b/xbmc/cores/playercorefactory/PlayerCoreFactory.h
@@ -60,7 +60,7 @@ class CPlayerCoreFactory : public ISettingsHandler
 public:
   static CPlayerCoreFactory& GetInstance();
 
-  virtual void OnSettingsLoaded();
+  virtual void OnSettingsLoaded() override;
 
   PLAYERCOREID GetPlayerCore(const std::string& strCoreName) const;
   CPlayerCoreConfig* GetPlayerConfig(const std::string& strCoreName) const;

--- a/xbmc/epg/EpgContainer.h
+++ b/xbmc/epg/EpgContainer.h
@@ -121,7 +121,7 @@ namespace EPG
      */
     virtual void Notify(const Observable &obs, const ObservableMessage msg);
 
-    virtual void OnSettingChanged(const CSetting *setting);
+    virtual void OnSettingChanged(const CSetting *setting) override;
 
     CEpg *CreateChannelEpg(PVR::CPVRChannelPtr channel);
 

--- a/xbmc/events/EventLog.h
+++ b/xbmc/events/EventLog.h
@@ -65,7 +65,7 @@ protected:
   CEventLog const& operator=(CEventLog const&);
 
   // implementation of ISettingCallback
-  virtual void OnSettingAction(const CSetting *setting);
+  virtual void OnSettingAction(const CSetting *setting) override;
 
 private:
   void SendMessage(const EventPtr& event, int message);

--- a/xbmc/guilib/GUIAudioManager.h
+++ b/xbmc/guilib/GUIAudioManager.h
@@ -54,8 +54,8 @@ public:
   CGUIAudioManager();
   ~CGUIAudioManager();
 
-  virtual void OnSettingChanged(const CSetting *setting);
-  virtual bool OnSettingUpdate(CSetting* &setting, const char *oldSettingId, const TiXmlNode *oldSettingNode);
+  virtual void OnSettingChanged(const CSetting *setting) override;
+  virtual bool OnSettingUpdate(CSetting* &setting, const char *oldSettingId, const TiXmlNode *oldSettingNode) override;
 
   void Initialize();
   void DeInitialize();

--- a/xbmc/guilib/GraphicContext.h
+++ b/xbmc/guilib/GraphicContext.h
@@ -78,7 +78,7 @@ public:
   CGraphicContext(void);
   virtual ~CGraphicContext(void);
 
-  virtual void OnSettingChanged(const CSetting *setting);
+  virtual void OnSettingChanged(const CSetting *setting) override;
 
   // the following two functions should wrap any
   // GL calls to maintain thread safety

--- a/xbmc/guilib/StereoscopicsManager.h
+++ b/xbmc/guilib/StereoscopicsManager.h
@@ -79,7 +79,7 @@ public:
    */
   CAction ConvertActionCommandToAction(const std::string &command, const std::string &parameter);
   std::string NormalizeStereoMode(const std::string &mode);
-  virtual void OnSettingChanged(const CSetting *setting);
+  virtual void OnSettingChanged(const CSetting *setting) override;
   virtual bool OnMessage(CGUIMessage &message);
   /*!
    * @brief Handle 3D specific cActions

--- a/xbmc/input/InputManager.h
+++ b/xbmc/input/InputManager.h
@@ -223,7 +223,7 @@ public:
    */
   int ExecuteBuiltin(const std::string& execute, const std::vector<std::string>& params);
 
-  virtual void OnSettingChanged(const CSetting *setting);
+  virtual void OnSettingChanged(const CSetting *setting) override;
 
 private:
 

--- a/xbmc/linux/LinuxTimezone.h
+++ b/xbmc/linux/LinuxTimezone.h
@@ -34,9 +34,9 @@ class CLinuxTimezone : public ISettingCallback, public ISettingsHandler
 public:
    CLinuxTimezone();
 
-   virtual void OnSettingChanged(const CSetting *setting);
+   virtual void OnSettingChanged(const CSetting *setting) override;
 
-   virtual void OnSettingsLoaded();
+   virtual void OnSettingsLoaded() override;
 
    std::string GetOSConfiguredTimezone();
 

--- a/xbmc/network/NetworkServices.h
+++ b/xbmc/network/NetworkServices.h
@@ -44,9 +44,9 @@ class CNetworkServices : public ISettingCallback
 public:
   static CNetworkServices& GetInstance();
   
-  virtual bool OnSettingChanging(const CSetting *setting);
-  virtual void OnSettingChanged(const CSetting *setting);
-  virtual bool OnSettingUpdate(CSetting* &setting, const char *oldSettingId, const TiXmlNode *oldSettingNode);
+  virtual bool OnSettingChanging(const CSetting *setting) override;
+  virtual void OnSettingChanged(const CSetting *setting) override;
+  virtual bool OnSettingUpdate(CSetting* &setting, const char *oldSettingId, const TiXmlNode *oldSettingNode) override;
 
   void Start();
   void Stop(bool bWait);

--- a/xbmc/network/WakeOnAccess.cpp
+++ b/xbmc/network/WakeOnAccess.cpp
@@ -633,6 +633,23 @@ void CWakeOnAccess::OnJobComplete(unsigned int jobID, bool success, CJob *job)
   }
 }
 
+void CWakeOnAccess::OnSettingChanged(const CSetting *setting)
+{
+  if (setting == nullptr)
+    return;
+
+  const std::string& settingId = setting->GetId();
+  if (settingId == CSettings::SETTING_POWERMANAGEMENT_WAKEONACCESS)
+  {
+    bool enabled = static_cast<const CSettingBool*>(setting)->GetValue();
+
+    SetEnabled(enabled);
+
+    if (enabled)
+      QueueMACDiscoveryForAllRemotes();
+  }
+}
+
 std::string CWakeOnAccess::GetSettingFile()
 {
   return CSpecialProtocol::TranslatePath("special://profile/wakeonlan.xml");
@@ -643,19 +660,6 @@ void CWakeOnAccess::OnSettingsLoaded()
   CSingleLock lock (m_entrylist_protect);
 
   LoadFromXML();
-}
-
-void CWakeOnAccess::OnSettingsSaved()
-{
-  bool enabled = CSettings::GetInstance().GetBool(CSettings::SETTING_POWERMANAGEMENT_WAKEONACCESS);
-
-  if (enabled != IsEnabled())
-  {
-    SetEnabled(enabled);
-
-    if (enabled)
-      QueueMACDiscoveryForAllRemotes();
-  }
 }
 
 void CWakeOnAccess::SetEnabled(bool enabled) 

--- a/xbmc/network/WakeOnAccess.h
+++ b/xbmc/network/WakeOnAccess.h
@@ -21,10 +21,11 @@
 #include "URL.h"
 #include "XBDateTime.h"
 #include "utils/Job.h"
+#include "settings/lib/ISettingCallback.h"
 #include "settings/lib/ISettingsHandler.h"
 #include <string>
 
-class CWakeOnAccess : private IJobCallback, public ISettingsHandler
+class CWakeOnAccess : private IJobCallback, public ISettingCallback, public ISettingsHandler
 {
 public:
   static CWakeOnAccess &GetInstance();
@@ -35,8 +36,8 @@ public:
   void QueueMACDiscoveryForAllRemotes();
 
   virtual void OnJobComplete(unsigned int jobID, bool success, CJob *job);
-  virtual void OnSettingsLoaded();
-  virtual void OnSettingsSaved();
+  virtual void OnSettingChanged(const CSetting *setting) override;
+  virtual void OnSettingsLoaded() override;
 
   // struct to keep per host settings
   struct WakeUpEntry

--- a/xbmc/network/upnp/UPnPSettings.h
+++ b/xbmc/network/upnp/UPnPSettings.h
@@ -28,7 +28,7 @@ class CUPnPSettings : public ISettingsHandler
 public:
   static CUPnPSettings& GetInstance();
   
-  virtual void OnSettingsUnloaded();
+  virtual void OnSettingsUnloaded() override;
 
   bool Load(const std::string &file);
   bool Save(const std::string &file) const;

--- a/xbmc/osx/XBMCHelper.h
+++ b/xbmc/osx/XBMCHelper.h
@@ -38,7 +38,7 @@ class XBMCHelper : public ISettingCallback
  public:
   static XBMCHelper& GetInstance();
 
-  virtual bool OnSettingChanging(const CSetting *setting);
+  virtual bool OnSettingChanging(const CSetting *setting) override;
 
   void Start();
   void Stop();

--- a/xbmc/peripherals/Peripherals.h
+++ b/xbmc/peripherals/Peripherals.h
@@ -209,8 +209,8 @@ namespace PERIPHERALS
 #endif
     }
     
-    virtual void OnSettingChanged(const CSetting *setting);
-    virtual void OnSettingAction(const CSetting *setting);
+    virtual void OnSettingChanged(const CSetting *setting) override;
+    virtual void OnSettingAction(const CSetting *setting) override;
 
     virtual void OnApplicationMessage(KODI::MESSAGING::ThreadMessage* pMsg) override;
     virtual int GetMessageMask() override;

--- a/xbmc/profiles/ProfilesManager.cpp
+++ b/xbmc/profiles/ProfilesManager.cpp
@@ -99,7 +99,7 @@ void CProfilesManager::OnSettingsLoaded()
   CDirectory::Create(URIUtils::AddFileToFolder(strDir,"mixed"));
 }
 
-void CProfilesManager::OnSettingsSaved()
+void CProfilesManager::OnSettingsSaved() const
 {
   // save mastercode
   Save();
@@ -189,7 +189,7 @@ bool CProfilesManager::Load(const std::string &file)
   return ret;
 }
 
-bool CProfilesManager::Save()
+bool CProfilesManager::Save() const
 {
   return Save(PROFILES_FILE);
 }

--- a/xbmc/profiles/ProfilesManager.h
+++ b/xbmc/profiles/ProfilesManager.h
@@ -33,9 +33,9 @@ class CProfilesManager : public ISettingsHandler
 public:
   static CProfilesManager& GetInstance();
 
-  virtual void OnSettingsLoaded();
-  virtual void OnSettingsSaved();
-  virtual void OnSettingsCleared();
+  virtual void OnSettingsLoaded() override;
+  virtual void OnSettingsSaved() const override;
+  virtual void OnSettingsCleared() override;
 
   bool Load();
   /*! \brief Load the user profile information from disk
@@ -46,7 +46,7 @@ public:
     */
   bool Load(const std::string &file);
 
-  bool Save();
+  bool Save() const;
   /*! \brief Save the user profile information to disk
     Saves the list of profiles to the profiles.xml file.
     \param file XML file to save.

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -119,8 +119,8 @@ namespace PVR
      */
     static CPVRManager &GetInstance();
 
-    virtual void OnSettingChanged(const CSetting *setting);
-    virtual void OnSettingAction(const CSetting *setting);
+    virtual void OnSettingChanged(const CSetting *setting) override;
+    virtual void OnSettingAction(const CSetting *setting) override;
 
     /*!
      * @brief Get the channel groups container.

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -271,7 +271,7 @@ namespace PVR
 
     //@}
 
-    virtual void OnSettingChanged(const CSetting *setting);
+    virtual void OnSettingChanged(const CSetting *setting) override;
 
     /*!
      * @brief Get a channel given it's EPG ID.

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -122,10 +122,10 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
 
     static CAdvancedSettings* getInstance();
 
-    virtual void OnSettingsLoaded();
-    virtual void OnSettingsUnloaded();
+    virtual void OnSettingsLoaded() override;
+    virtual void OnSettingsUnloaded() override;
 
-    virtual void OnSettingChanged(const CSetting *setting);
+    virtual void OnSettingChanged(const CSetting *setting) override;
 
     void Initialize();
     bool Initialized() { return m_initialized; };

--- a/xbmc/settings/DisplaySettings.h
+++ b/xbmc/settings/DisplaySettings.h
@@ -37,12 +37,12 @@ class CDisplaySettings : public ISettingCallback, public ISubSettings,
 public:
   static CDisplaySettings& GetInstance();
 
-  virtual bool Load(const TiXmlNode *settings);
-  virtual bool Save(TiXmlNode *settings) const;
-  virtual void Clear();
+  virtual bool Load(const TiXmlNode *settings) override;
+  virtual bool Save(TiXmlNode *settings) const override;
+  virtual void Clear() override;
 
-  virtual bool OnSettingChanging(const CSetting *setting);
-  virtual bool OnSettingUpdate(CSetting* &setting, const char *oldSettingId, const TiXmlNode *oldSettingNode);
+  virtual bool OnSettingChanging(const CSetting *setting) override;
+  virtual bool OnSettingUpdate(CSetting* &setting, const char *oldSettingId, const TiXmlNode *oldSettingNode) override;
 
   /*!
    \brief Returns the currently active resolution

--- a/xbmc/settings/MediaSettings.h
+++ b/xbmc/settings/MediaSettings.h
@@ -45,11 +45,11 @@ class CMediaSettings : public ISettingCallback, public ISettingsHandler, public 
 public:
   static CMediaSettings& GetInstance();
 
-  virtual bool Load(const TiXmlNode *settings);
-  virtual bool Save(TiXmlNode *settings) const;
+  virtual bool Load(const TiXmlNode *settings) override;
+  virtual bool Save(TiXmlNode *settings) const override;
 
-  virtual void OnSettingAction(const CSetting *setting);
-  virtual void OnSettingsLoaded();
+  virtual void OnSettingAction(const CSetting *setting) override;
+  virtual void OnSettingsLoaded() override;
 
   const CVideoSettings& GetDefaultVideoSettings() const { return m_defaultVideoSettings; }
   CVideoSettings& GetDefaultVideoSettings() { return m_defaultVideoSettings; }

--- a/xbmc/settings/MediaSourceSettings.h
+++ b/xbmc/settings/MediaSourceSettings.h
@@ -33,8 +33,8 @@ public:
 
   static std::string GetSourcesFile();
   
-  virtual void OnSettingsLoaded();
-  virtual void OnSettingsUnloaded();
+  virtual void OnSettingsLoaded() override;
+  virtual void OnSettingsUnloaded() override;
 
   bool Load();
   bool Load(const std::string &file);

--- a/xbmc/settings/SettingAddon.h
+++ b/xbmc/settings/SettingAddon.h
@@ -30,9 +30,9 @@ public:
   CSettingAddon(const std::string &id, const CSettingAddon &setting);
   virtual ~CSettingAddon() { }
 
-  virtual CSetting* Clone(const std::string &id) const;
+  virtual CSetting* Clone(const std::string &id) const override;
 
-  virtual bool Deserialize(const TiXmlNode *node, bool update = false);
+  virtual bool Deserialize(const TiXmlNode *node, bool update = false) override;
 
   ADDON::TYPE GetAddonType() const { return m_addonType; }
   void SetAddonType(ADDON::TYPE addonType) { m_addonType = addonType; }

--- a/xbmc/settings/SettingControl.h
+++ b/xbmc/settings/SettingControl.h
@@ -44,7 +44,7 @@ public:
   virtual ~CSettingControlCreator() { }
 
   // implementation of ISettingControlCreator
-  virtual ISettingControl* CreateControl(const std::string &controlType) const;
+  virtual ISettingControl* CreateControl(const std::string &controlType) const override;
 };
 
 class CSettingControlCheckmark : public ISettingControl
@@ -57,8 +57,8 @@ public:
   virtual ~CSettingControlCheckmark() { }
 
   // implementation of ISettingControl
-  virtual std::string GetType() const { return "toggle"; }
-  virtual bool SetFormat(const std::string &format);
+  virtual std::string GetType() const override { return "toggle"; }
+  virtual bool SetFormat(const std::string &format) override;
 };
 
 class CSettingControlFormattedRange : public ISettingControl
@@ -66,7 +66,7 @@ class CSettingControlFormattedRange : public ISettingControl
 public:
   virtual ~CSettingControlFormattedRange() { }
 
-  virtual bool Deserialize(const TiXmlNode *node, bool update = false);
+  virtual bool Deserialize(const TiXmlNode *node, bool update = false) override;
 
   int GetFormatLabel() const { return m_formatLabel; }
   void SetFormatLabel(int formatLabel) { m_formatLabel = formatLabel; }
@@ -94,10 +94,10 @@ public:
   virtual ~CSettingControlSpinner() { }
 
   // implementation of ISettingControl
-  virtual std::string GetType() const { return "spinner"; }
+  virtual std::string GetType() const override { return "spinner"; }
 
   // specialization of CSettingControlFormattedRange
-  virtual bool SetFormat(const std::string &format);
+  virtual bool SetFormat(const std::string &format) override;
 };
 
 class CSettingControlEdit : public ISettingControl
@@ -113,9 +113,9 @@ public:
   virtual ~CSettingControlEdit() { }
 
   // implementation of ISettingControl
-  virtual std::string GetType() const { return "edit"; }
-  virtual bool Deserialize(const TiXmlNode *node, bool update = false);
-  virtual bool SetFormat(const std::string &format);
+  virtual std::string GetType() const override { return "edit"; }
+  virtual bool Deserialize(const TiXmlNode *node, bool update = false) override;
+  virtual bool SetFormat(const std::string &format) override;
 
   bool IsHidden() const { return m_hidden; }
   void SetHidden(bool hidden) { m_hidden = hidden; }
@@ -144,9 +144,9 @@ public:
   virtual ~CSettingControlButton() { }
 
   // implementation of ISettingControl
-  virtual std::string GetType() const { return "button"; }
-  virtual bool Deserialize(const TiXmlNode *node, bool update = false);
-  virtual bool SetFormat(const std::string &format);
+  virtual std::string GetType() const override { return "button"; }
+  virtual bool Deserialize(const TiXmlNode *node, bool update = false) override;
+  virtual bool SetFormat(const std::string &format) override;
 
   int GetHeading() const { return m_heading; }
   void SetHeading(int heading) { m_heading = heading; }
@@ -183,11 +183,11 @@ public:
   virtual ~CSettingControlList() { }
 
   // implementation of ISettingControl
-  virtual std::string GetType() const { return "list"; }
+  virtual std::string GetType() const override { return "list"; }
 
   // specialization of CSettingControlFormattedRange
-  virtual bool Deserialize(const TiXmlNode *node, bool update = false);
-  virtual bool SetFormat(const std::string &format);
+  virtual bool Deserialize(const TiXmlNode *node, bool update = false) override;
+  virtual bool SetFormat(const std::string &format) override;
   
   int GetHeading() const { return m_heading; }
   void SetHeading(int heading) { m_heading = heading; }
@@ -218,9 +218,9 @@ public:
   virtual ~CSettingControlSlider() { }
 
   // implementation of ISettingControl
-  virtual std::string GetType() const { return "slider"; }
-  virtual bool Deserialize(const TiXmlNode *node, bool update = false);
-  virtual bool SetFormat(const std::string &format);
+  virtual std::string GetType() const override { return "slider"; }
+  virtual bool Deserialize(const TiXmlNode *node, bool update = false) override;
+  virtual bool SetFormat(const std::string &format) override;
 
   int GetHeading() const { return m_heading; }
   void SetHeading(int heading) { m_heading = heading; }
@@ -253,9 +253,9 @@ public:
   virtual ~CSettingControlRange() { }
 
   // implementation of ISettingControl
-  virtual std::string GetType() const { return "range"; }
-  virtual bool Deserialize(const TiXmlNode *node, bool update = false);
-  virtual bool SetFormat(const std::string &format);
+  virtual std::string GetType() const override { return "range"; }
+  virtual bool Deserialize(const TiXmlNode *node, bool update = false) override;
+  virtual bool SetFormat(const std::string &format) override;
 
   int GetFormatLabel() const { return m_formatLabel; }
   void SetFormatLabel(int formatLabel) { m_formatLabel = formatLabel; }
@@ -280,9 +280,8 @@ public:
   virtual ~CSettingControlTitle() { }
 
   // implementation of ISettingControl
-  virtual std::string GetType() const { return "title"; }
-  virtual bool Deserialize(const TiXmlNode *node, bool update = false);
-  virtual bool SetFormat(const std::string &format) { return true; }
+  virtual std::string GetType() const override { return "title"; }
+  virtual bool Deserialize(const TiXmlNode *node, bool update = false) override;
 
   bool IsSeparatorHidden() const { return m_separatorHidden; }
   void SetSeparatorHidden(bool hidden) { m_separatorHidden = hidden; }

--- a/xbmc/settings/SettingCreator.h
+++ b/xbmc/settings/SettingCreator.h
@@ -28,5 +28,5 @@ public:
   virtual ~CSettingCreator() { }
 
   // implementation of ISettingCreator
-  virtual CSetting* CreateSetting(const std::string &settingType, const std::string &settingId, CSettingsManager *settingsManager = NULL) const;
+  virtual CSetting* CreateSetting(const std::string &settingType, const std::string &settingId, CSettingsManager *settingsManager = NULL) const override;
 };

--- a/xbmc/settings/SettingPath.h
+++ b/xbmc/settings/SettingPath.h
@@ -31,10 +31,10 @@ public:
   CSettingPath(const std::string &id, const CSettingPath &setting);
   virtual ~CSettingPath() { }
 
-  virtual CSetting* Clone(const std::string &id) const;
+  virtual CSetting* Clone(const std::string &id) const override;
 
-  virtual bool Deserialize(const TiXmlNode *node, bool update = false);
-  virtual bool SetValue(const std::string &value);
+  virtual bool Deserialize(const TiXmlNode *node, bool update = false) override;
+  virtual bool SetValue(const std::string &value) override;
 
   bool Writable() const { return m_writable; }
   void SetWritable(bool writable) { m_writable = writable; }

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -622,6 +622,7 @@ void CSettings::Uninitialize()
   m_settingsManager->UnregisterCallback(&XBMCHelper::GetInstance());
 #endif
   m_settingsManager->UnregisterCallback(&ActiveAE::CActiveAEDSP::GetInstance());
+  m_settingsManager->UnregisterCallback(&CWakeOnAccess::GetInstance());
 
   // cleanup the settings manager
   m_settingsManager->Clear();
@@ -1208,6 +1209,10 @@ void CSettings::InitializeISettingCallbacks()
   settingSet.clear();
   settingSet.insert(CSettings::SETTING_GENERAL_ADDONUPDATES);
   m_settingsManager->RegisterCallback(&ADDON::CRepositoryUpdater::GetInstance(), settingSet);
+
+  settingSet.clear();
+  settingSet.insert(CSettings::SETTING_POWERMANAGEMENT_WAKEONACCESS);
+  m_settingsManager->RegisterCallback(&CWakeOnAccess::GetInstance(), settingSet);
 }
 
 bool CSettings::Reset()

--- a/xbmc/settings/SkinSettings.h
+++ b/xbmc/settings/SkinSettings.h
@@ -33,9 +33,9 @@ class CSkinSettings : public ISubSettings
 public:
   static CSkinSettings& GetInstance();
 
-  virtual bool Load(const TiXmlNode *settings);
-  virtual bool Save(TiXmlNode *settings) const;
-  virtual void Clear();
+  virtual bool Load(const TiXmlNode *settings) override;
+  virtual bool Save(TiXmlNode *settings) const override;
+  virtual void Clear() override;
 
   void MigrateSettings(const ADDON::SkinPtr& skin);
 

--- a/xbmc/settings/dialogs/GUIDialogSettingsBase.h
+++ b/xbmc/settings/dialogs/GUIDialogSettingsBase.h
@@ -86,8 +86,8 @@ protected:
   virtual void OnTimeout();
 
   // implementations of ISettingCallback
-  virtual void OnSettingChanged(const CSetting *setting);
-  virtual void OnSettingPropertyChanged(const CSetting *setting, const char *propertyName);
+  virtual void OnSettingChanged(const CSetting *setting) override;
+  virtual void OnSettingPropertyChanged(const CSetting *setting, const char *propertyName) override;
 
   // new virtual methods
   virtual bool AllowResettingSettings() const { return true; }

--- a/xbmc/settings/dialogs/GUIDialogSettingsManagerBase.cpp
+++ b/xbmc/settings/dialogs/GUIDialogSettingsManagerBase.cpp
@@ -62,7 +62,7 @@ void CGUIDialogSettingsManagerBase::FreeSettingsControls()
   m_settingsManager->UnregisterCallback(this);
 }
 
-ISettingControl* CGUIDialogSettingsManagerBase::CreateControl(const std::string &controlType)
+ISettingControl* CGUIDialogSettingsManagerBase::CreateControl(const std::string &controlType) const
 {
   assert(m_settingsManager != NULL);
 

--- a/xbmc/settings/dialogs/GUIDialogSettingsManagerBase.h
+++ b/xbmc/settings/dialogs/GUIDialogSettingsManagerBase.h
@@ -37,7 +37,7 @@ protected:
   virtual void FreeSettingsControls();
 
   // implementation of ISettingControlCreator
-  virtual ISettingControl* CreateControl(const std::string &controlType);
+  virtual ISettingControl* CreateControl(const std::string &controlType) const override;
 
   CSettingsManager *m_settingsManager;
 };

--- a/xbmc/settings/lib/ISettingsHandler.h
+++ b/xbmc/settings/lib/ISettingsHandler.h
@@ -52,7 +52,7 @@ public:
 
    This callback can be used to trigger saving other settings.
    */
-  virtual void OnSettingsSaved() { }
+  virtual void OnSettingsSaved() const { }
   /*!
    \brief Setting values have been unloaded.
 

--- a/xbmc/settings/lib/Setting.h
+++ b/xbmc/settings/lib/Setting.h
@@ -81,7 +81,7 @@ public:
 
   virtual CSetting* Clone(const std::string &id) const = 0;
 
-  virtual bool Deserialize(const TiXmlNode *node, bool update = false);
+  virtual bool Deserialize(const TiXmlNode *node, bool update = false) override;
 
   virtual int GetType() const = 0;
   virtual bool FromString(const std::string &value) = 0;
@@ -115,11 +115,11 @@ public:
 
 protected:
   // implementation of ISettingCallback
-  virtual bool OnSettingChanging(const CSetting *setting);
-  virtual void OnSettingChanged(const CSetting *setting);
-  virtual void OnSettingAction(const CSetting *setting);
-  virtual bool OnSettingUpdate(CSetting* &setting, const char *oldSettingId, const TiXmlNode *oldSettingNode);
-  virtual void OnSettingPropertyChanged(const CSetting *setting, const char *propertyName);
+  virtual bool OnSettingChanging(const CSetting *setting) override;
+  virtual void OnSettingChanged(const CSetting *setting) override;
+  virtual void OnSettingAction(const CSetting *setting) override;
+  virtual bool OnSettingUpdate(CSetting* &setting, const char *oldSettingId, const TiXmlNode *oldSettingNode) override;
+  virtual void OnSettingPropertyChanged(const CSetting *setting, const char *propertyName) override;
 
   void Copy(const CSetting &setting);
 
@@ -154,16 +154,16 @@ public:
   CSettingList(const std::string &id, const CSettingList &setting);
   virtual ~CSettingList();
 
-  virtual CSetting* Clone(const std::string &id) const;
+  virtual CSetting* Clone(const std::string &id) const override;
 
-  virtual bool Deserialize(const TiXmlNode *node, bool update = false);
+  virtual bool Deserialize(const TiXmlNode *node, bool update = false) override;
 
-  virtual int GetType() const { return SettingTypeList; }
-  virtual bool FromString(const std::string &value);
-  virtual std::string ToString() const;
-  virtual bool Equals(const std::string &value) const;
-  virtual bool CheckValidity(const std::string &value) const;
-  virtual void Reset();
+  virtual int GetType() const override { return SettingTypeList; }
+  virtual bool FromString(const std::string &value) override;
+  virtual std::string ToString() const override;
+  virtual bool Equals(const std::string &value) const override;
+  virtual bool CheckValidity(const std::string &value) const override;
+  virtual void Reset() override;
   
   int GetElementType() const;
   const CSetting* GetDefinition() const { return m_definition; }
@@ -211,16 +211,16 @@ public:
   CSettingBool(const std::string &id, int label, bool value, CSettingsManager *settingsManager = NULL);
   virtual ~CSettingBool() { }
 
-  virtual CSetting* Clone(const std::string &id) const;
+  virtual CSetting* Clone(const std::string &id) const override;
 
-  virtual bool Deserialize(const TiXmlNode *node, bool update = false);
+  virtual bool Deserialize(const TiXmlNode *node, bool update = false) override;
 
-  virtual int GetType() const { return SettingTypeBool; }
-  virtual bool FromString(const std::string &value);
-  virtual std::string ToString() const;
-  virtual bool Equals(const std::string &value) const;
-  virtual bool CheckValidity(const std::string &value) const;
-  virtual void Reset() { SetValue(m_default); }
+  virtual int GetType() const override { return SettingTypeBool; }
+  virtual bool FromString(const std::string &value) override;
+  virtual std::string ToString() const override;
+  virtual bool Equals(const std::string &value) const override;
+  virtual bool CheckValidity(const std::string &value) const override;
+  virtual void Reset() override { SetValue(m_default); }
 
   bool GetValue() const { CSharedLock lock(m_critical); return m_value; }
   bool SetValue(bool value);
@@ -250,17 +250,17 @@ public:
   CSettingInt(const std::string &id, int label, int value, const StaticIntegerSettingOptions &options, CSettingsManager *settingsManager = NULL);
   virtual ~CSettingInt() { }
 
-  virtual CSetting* Clone(const std::string &id) const;
+  virtual CSetting* Clone(const std::string &id) const override;
 
-  virtual bool Deserialize(const TiXmlNode *node, bool update = false);
+  virtual bool Deserialize(const TiXmlNode *node, bool update = false) override;
 
-  virtual int GetType() const { return SettingTypeInteger; }
-  virtual bool FromString(const std::string &value);
-  virtual std::string ToString() const;
-  virtual bool Equals(const std::string &value) const;
-  virtual bool CheckValidity(const std::string &value) const;
+  virtual int GetType() const override { return SettingTypeInteger; }
+  virtual bool FromString(const std::string &value) override;
+  virtual std::string ToString() const override;
+  virtual bool Equals(const std::string &value) const override;
+  virtual bool CheckValidity(const std::string &value) const override;
   virtual bool CheckValidity(int value) const;
-  virtual void Reset() { SetValue(m_default); }
+  virtual void Reset() override { SetValue(m_default); }
 
   int GetValue() const { CSharedLock lock(m_critical); return m_value; }
   bool SetValue(int value);
@@ -320,17 +320,17 @@ public:
   CSettingNumber(const std::string &id, int label, float value, float minimum, float step, float maximum, CSettingsManager *settingsManager = NULL);
   virtual ~CSettingNumber() { }
 
-  virtual CSetting* Clone(const std::string &id) const;
+  virtual CSetting* Clone(const std::string &id) const override;
 
-  virtual bool Deserialize(const TiXmlNode *node, bool update = false);
+  virtual bool Deserialize(const TiXmlNode *node, bool update = false) override;
 
-  virtual int GetType() const { return SettingTypeNumber; }
-  virtual bool FromString(const std::string &value);
-  virtual std::string ToString() const;
-  virtual bool Equals(const std::string &value) const;
-  virtual bool CheckValidity(const std::string &value) const;
+  virtual int GetType() const override { return SettingTypeNumber; }
+  virtual bool FromString(const std::string &value) override;
+  virtual std::string ToString() const override;
+  virtual bool Equals(const std::string &value) const override;
+  virtual bool CheckValidity(const std::string &value) const override;
   virtual bool CheckValidity(double value) const;
-  virtual void Reset() { SetValue(m_default); }
+  virtual void Reset() override { SetValue(m_default); }
 
   double GetValue() const { CSharedLock lock(m_critical); return m_value; }
   bool SetValue(double value);
@@ -368,16 +368,16 @@ public:
   CSettingString(const std::string &id, int label, const std::string &value, CSettingsManager *settingsManager = NULL);
   virtual ~CSettingString() { }
 
-  virtual CSetting* Clone(const std::string &id) const;
+  virtual CSetting* Clone(const std::string &id) const override;
 
-  virtual bool Deserialize(const TiXmlNode *node, bool update = false);
+  virtual bool Deserialize(const TiXmlNode *node, bool update = false) override;
 
-  virtual int GetType() const { return SettingTypeString; }
-  virtual bool FromString(const std::string &value) { return SetValue(value); }
-  virtual std::string ToString() const { return m_value; }
-  virtual bool Equals(const std::string &value) const { return m_value == value; }
-  virtual bool CheckValidity(const std::string &value) const;
-  virtual void Reset() { SetValue(m_default); }
+  virtual int GetType() const override { return SettingTypeString; }
+  virtual bool FromString(const std::string &value) override { return SetValue(value); }
+  virtual std::string ToString() const override { return m_value; }
+  virtual bool Equals(const std::string &value) const override { return m_value == value; }
+  virtual bool CheckValidity(const std::string &value) const override;
+  virtual void Reset() override { SetValue(m_default); }
 
   virtual const std::string& GetValue() const { CSharedLock lock(m_critical); return m_value; }
   virtual bool SetValue(const std::string &value);
@@ -430,18 +430,18 @@ public:
   CSettingAction(const std::string &id, const CSettingAction &setting);
   virtual ~CSettingAction() { }
 
-  virtual CSetting* Clone(const std::string &id) const;
+  virtual CSetting* Clone(const std::string &id) const override;
 
-  virtual bool Deserialize(const TiXmlNode *node, bool update = false);
+  virtual bool Deserialize(const TiXmlNode *node, bool update = false) override;
 
-  virtual int GetType() const { return SettingTypeAction; }
-  virtual bool FromString(const std::string &value) { return false; }
-  virtual std::string ToString() const { return ""; }
-  virtual bool Equals(const std::string &value) const { return false; }
-  virtual bool CheckValidity(const std::string &value) const { return false; }
-  virtual void Reset() { }
+  virtual int GetType() const override { return SettingTypeAction; }
+  virtual bool FromString(const std::string &value) override { return false; }
+  virtual std::string ToString() const override { return ""; }
+  virtual bool Equals(const std::string &value) const override { return false; }
+  virtual bool CheckValidity(const std::string &value) const override { return false; }
+  virtual void Reset() override { }
 
   // this needs to be public so it can be triggered when activated
   // by the user in the GUI.
-  virtual void OnSettingAction(const CSetting *setting) { return CSetting::OnSettingAction(this); }
+  virtual void OnSettingAction(const CSetting *setting) override { return CSetting::OnSettingAction(this); }
 };

--- a/xbmc/settings/lib/SettingSection.h
+++ b/xbmc/settings/lib/SettingSection.h
@@ -47,7 +47,7 @@ public:
   ~CSettingGroup();
 
   // implementation of ISetting
-  virtual bool Deserialize(const TiXmlNode *node, bool update = false);
+  virtual bool Deserialize(const TiXmlNode *node, bool update = false) override;
 
   /*!
    \brief Gets the full list of settings belonging to the setting group.
@@ -98,7 +98,7 @@ public:
   ~CSettingCategory();
 
   // implementation of ISetting
-  virtual bool Deserialize(const TiXmlNode *node, bool update = false);
+  virtual bool Deserialize(const TiXmlNode *node, bool update = false) override;
 
   /*!
    \brief Gets the full list of setting groups belonging to the setting
@@ -153,7 +153,7 @@ public:
   ~CSettingSection();
 
   // implementation of ISetting
-  virtual bool Deserialize(const TiXmlNode *node, bool update = false);
+  virtual bool Deserialize(const TiXmlNode *node, bool update = false) override;
 
   /*!
    \brief Gets the full list of setting categories belonging to the setting

--- a/xbmc/settings/lib/SettingsManager.h
+++ b/xbmc/settings/lib/SettingsManager.h
@@ -57,10 +57,10 @@ public:
   virtual ~CSettingsManager();
 
   // implementation of ISettingCreator
-  virtual CSetting* CreateSetting(const std::string &settingType, const std::string &settingId, CSettingsManager *settingsManager = NULL) const;
+  virtual CSetting* CreateSetting(const std::string &settingType, const std::string &settingId, CSettingsManager *settingsManager = NULL) const override;
 
   // implementation of ISettingControlCreator
-  virtual ISettingControl* CreateControl(const std::string &controlType) const;
+  virtual ISettingControl* CreateControl(const std::string &controlType) const override;
 
   /*!
    \brief Initializes the settings manager using the setting definitions
@@ -86,7 +86,7 @@ public:
    \param root XML node
    \return True if the setting values were successfully saved, false otherwise
    */
-  virtual bool Save(TiXmlNode *root) const;
+  virtual bool Save(TiXmlNode *root) const override;
   /*!
    \brief Unloads the previously loaded setting values.
 
@@ -396,22 +396,22 @@ public:
 
 private:
   // implementation of ISettingCallback
-  virtual bool OnSettingChanging(const CSetting *setting);
-  virtual void OnSettingChanged(const CSetting *setting);
-  virtual void OnSettingAction(const CSetting *setting);
-  virtual bool OnSettingUpdate(CSetting* &setting, const char *oldSettingId, const TiXmlNode *oldSettingNode);
-  virtual void OnSettingPropertyChanged(const CSetting *setting, const char *propertyName);
+  virtual bool OnSettingChanging(const CSetting *setting) override;
+  virtual void OnSettingChanged(const CSetting *setting) override;
+  virtual void OnSettingAction(const CSetting *setting) override;
+  virtual bool OnSettingUpdate(CSetting* &setting, const char *oldSettingId, const TiXmlNode *oldSettingNode) override;
+  virtual void OnSettingPropertyChanged(const CSetting *setting, const char *propertyName) override;
 
   // implementation of ISettingsHandler
-  virtual bool OnSettingsLoading();
-  virtual void OnSettingsLoaded();
-  virtual void OnSettingsUnloaded();
-  virtual bool OnSettingsSaving() const;
-  virtual void OnSettingsSaved() const;
-  virtual void OnSettingsCleared();
+  virtual bool OnSettingsLoading() override;
+  virtual void OnSettingsLoaded() override;
+  virtual void OnSettingsUnloaded() override;
+  virtual bool OnSettingsSaving() const override;
+  virtual void OnSettingsSaved() const override;
+  virtual void OnSettingsCleared() override;
 
   // implementation of ISubSettings
-  virtual bool Load(const TiXmlNode *settings);
+  virtual bool Load(const TiXmlNode *settings) override;
 
   bool Serialize(TiXmlNode *parent) const;
   bool Deserialize(const TiXmlNode *node, bool &updated, std::map<std::string, CSetting*> *loadedSettings = NULL);

--- a/xbmc/utils/CharsetConverter.h
+++ b/xbmc/utils/CharsetConverter.h
@@ -35,7 +35,7 @@ class CCharsetConverter : public ISettingCallback
 public:
   CCharsetConverter();
 
-  virtual void OnSettingChanged(const CSetting* setting);
+  virtual void OnSettingChanged(const CSetting* setting) override;
 
   static void reset();
   static void resetSystemCharset();

--- a/xbmc/utils/RssManager.h
+++ b/xbmc/utils/RssManager.h
@@ -44,10 +44,10 @@ class CRssManager : public ISettingCallback, public ISettingsHandler
 public:
   static CRssManager& GetInstance();
 
-  virtual void OnSettingsLoaded();
-  virtual void OnSettingsUnloaded();
+  virtual void OnSettingsLoaded() override;
+  virtual void OnSettingsUnloaded() override;
 
-  virtual void OnSettingAction(const CSetting *setting);
+  virtual void OnSettingAction(const CSetting *setting) override;
 
   void Start();
   void Stop();

--- a/xbmc/utils/SeekHandler.h
+++ b/xbmc/utils/SeekHandler.h
@@ -42,7 +42,7 @@ public:
 
   static void SettingOptionsSeekStepsFiller(const CSetting *setting, std::vector< std::pair<std::string, int> > &list, int &current, void *data);
   
-  virtual void OnSettingChanged(const CSetting *setting);
+  virtual void OnSettingChanged(const CSetting *setting) override;
   virtual bool OnAction(const CAction &action);
 
   void Seek(bool forward, float amount, float duration = 0, bool analogSeek = false, SeekType type = SEEK_TYPE_VIDEO);

--- a/xbmc/utils/SystemInfo.h
+++ b/xbmc/utils/SystemInfo.h
@@ -95,8 +95,8 @@ public:
   CSysInfo(void);
   virtual ~CSysInfo();
 
-  virtual bool Load(const TiXmlNode *settings);
-  virtual bool Save(TiXmlNode *settings) const;
+  virtual bool Load(const TiXmlNode *settings) override;
+  virtual bool Save(TiXmlNode *settings) const override;
 
   char MD5_Sign[32 + 1];
 

--- a/xbmc/utils/Weather.h
+++ b/xbmc/utils/Weather.h
@@ -161,8 +161,8 @@ protected:
   virtual std::string BusyInfo(int info) const;
   virtual void OnJobComplete(unsigned int jobID, bool success, CJob *job);
 
-  virtual void OnSettingChanged(const CSetting *setting);
-  virtual void OnSettingAction(const CSetting *setting);
+  virtual void OnSettingChanged(const CSetting *setting) override;
+  virtual void OnSettingAction(const CSetting *setting) override;
 
 private:
 

--- a/xbmc/view/ViewStateSettings.h
+++ b/xbmc/view/ViewStateSettings.h
@@ -36,9 +36,9 @@ class CViewStateSettings : public ISubSettings
 public:
   static CViewStateSettings& GetInstance();
 
-  virtual bool Load(const TiXmlNode *settings);
-  virtual bool Save(TiXmlNode *settings) const;
-  virtual void Clear();
+  virtual bool Load(const TiXmlNode *settings) override;
+  virtual bool Save(TiXmlNode *settings) const override;
+  virtual void Clear() override;
 
   const CViewState* Get(const std::string &viewState) const;
   CViewState* Get(const std::string &viewState);

--- a/xbmc/windowing/X11/WinSystemX11.h
+++ b/xbmc/windowing/X11/WinSystemX11.h
@@ -40,7 +40,7 @@
 
 class IDispResource;
 
-class CWinSystemX11 : public CWinSystemBase, public ISettingCallback
+class CWinSystemX11 : public CWinSystemBase
 {
 public:
   CWinSystemX11();


### PR DESCRIPTION
Thanks to https://github.com/MrMC/mrmc/commit/9cfeda3e86fccb910f6bdca2affd3887acc8ff34 I've looked into all the method signatures of overriden virtual methods in the settings library and fixed one of them. To be able to let the compiler do this work for us in the future I've added the `override` keywoard to all overriden methods I could find.

Furthermore I've noticed that `CWinSystemX11` derived from `ISettingCallback` but doesn't override any of its virtual methods so I've removed it. Last but not least I've noticed that `CWakeOnAccess` uses the `OnSettingsSaved()` callback of `ISettinsHandler` to "monitor" the wake on access setting value which is not reliable. Therefore I've changed it to use `ISettingCallback::OnSettingChanged()` on that specific setting.
