### PR TITLE
[strings]  DTS -DTS-HD settings description, include relationship to DCADEC setting.

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -16999,7 +16999,7 @@ msgstr ""
 #. Description of setting "System -> Audio output -> DTS capable receiver" with label #254
 #: system/settings/settings.xml
 msgctxt "#36366"
-msgid "Select this option if your receiver is capable of decoding DTS streams."
+msgid "Select this option if your receiver is capable of decoding DTS streams. Note: Enabling this will disable \"Support 8 channel DTS-HD audio decoding\" option"
 msgstr ""
 
 #: system/settings/darwin_osx.xml
@@ -17022,7 +17022,7 @@ msgstr ""
 #. Description of setting "System -> Audio output -> DTS-HD capable receiver" with label #347
 #: system/settings/settings.xml
 msgctxt "#36370"
-msgid "Select this option if your receiver is capable of decoding DTS-HD streams."
+msgid "Select this option if your receiver is capable of decoding DTS-HD streams. Note: Enabling this will disable \"Support 8 channel DTS-HD audio decoding\" option"
 msgstr ""
 
 #. Description of setting "System -> Audio output -> Audio output device" with label #545


### PR DESCRIPTION
Following addition of DCADEC. @jjd-uk @da-anda

Description reads:
Enables decoding of high quality DTS-HD audio streams. Note: This increases CPU load and **is only available when DTS and DTS-HD audio passthrough are disabled.**

The problem is that **existent users that only upgrade Kodi and already have a their audio passthough enabled**, will see this new option on settings but cant enable it or read its settings description, since this new option is conditional of DTS and DTS-HD being disabled.

New users dont have this problem since by default passthrough is disabled, but since we cant reset everyone's settings, this is the sane and logical thing to do is to add a note to passthough descriptions to tell current users they aren't going mad and what is going on.
