### PR TITLE
[DVDDemuxFFmpeg] Ignore extradata for unknown stream types

### DIFF
--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1300,7 +1300,7 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int iId)
     if (langTag)
       strncpy(stream->language, langTag->value, 3);
 
-    if( pStream->codec->extradata && pStream->codec->extradata_size > 0 )
+    if( stream->type != STREAM_NONE && pStream->codec->extradata && pStream->codec->extradata_size > 0 )
     {
       stream->ExtraSize = pStream->codec->extradata_size;
       stream->ExtraData = new uint8_t[pStream->codec->extradata_size];


### PR DESCRIPTION
https://github.com/xbianonpi/xbian/issues/765 has a file with 250M of AVMEDIA_TYPE_ATTACHMENT which fails to play on pi.
Don't bother allocating and copying the data as we won't do anything with it
