### PR TITLE
addon installer: cleanup unused parameters and code

### DIFF
--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -668,7 +668,7 @@ bool CLangInfo::SetLanguage(bool& fallback, const std::string &strLanguage /* = 
           // try to get the proper language addon by its name from all available language addons
           if (ADDON::CLanguageResource::FindLanguageAddonByName(language, newLanguage, languageAddons))
           {
-            if (CAddonInstaller::GetInstance().Install(newLanguage, true, "", false, false))
+            if (CAddonInstaller::GetInstance().InstallOrUpdate(newLanguage, "", false, false))
             {
               CLog::Log(LOGINFO, "CLangInfo: successfully installed language addon \"%s\" matching current language \"%s\"", newLanguage.c_str(), language.c_str());
               foundMatchingAddon = true;

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -704,7 +704,7 @@ bool CAddonInstallJob::Install(const std::string &installFrom, const AddonPtr& r
       const AddonVersion &version = it->second.first;
       bool optional = it->second.second;
       AddonPtr dependency;
-      bool haveAddon = CAddonMgr::GetInstance().GetAddon(addonID, dependency);
+      bool haveAddon = CAddonMgr::GetInstance().GetAddon(addonID, dependency, ADDON_UNKNOWN, false);
       if ((haveAddon && !dependency->MeetsVersion(version)) || (!haveAddon && !optional))
       {
         // we have it but our version isn't good enough, or we don't have it and we need it

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -850,11 +850,6 @@ void CAddonInstallJob::ReportInstallError(const std::string& addonID, const std:
   CEventLog::GetInstance().Add(activity, !IsModal(), false);
 }
 
-std::string CAddonInstallJob::AddonID() const
-{
-  return m_addon ? m_addon->ID() : "";
-}
-
 CAddonUnInstallJob::CAddonUnInstallJob(const AddonPtr &addon)
   : m_addon(addon)
 { }

--- a/xbmc/addons/AddonInstaller.h
+++ b/xbmc/addons/AddonInstaller.h
@@ -125,12 +125,11 @@ private:
   /*! \brief Install an addon from a repository or zip
    \param addon the AddonPtr describing the addon
    \param hash the hash to verify the install. Defaults to "".
-   \param update whether this is an update of an existing addon, or a new install. Defaults to false.
    \param referer string to use for referer for http fetch. Defaults to "".
    \param background whether to install in the background or not. Defaults to true.
    \return true on successful install, false on failure.
    */
-  bool DoInstall(const ADDON::AddonPtr &addon, const std::string &hash = "", bool update = false, const std::string &referer = "", bool background = true, bool modal = false);
+  bool DoInstall(const ADDON::AddonPtr &addon, const std::string &hash = "", const std::string &referer = "", bool background = true, bool modal = false);
 
   /*! \brief Check whether dependencies of an addon exist or are installable.
    Iterates through the addon's dependencies, checking they're installed or installable.
@@ -153,7 +152,7 @@ private:
 class CAddonInstallJob : public CFileOperationJob
 {
 public:
-  CAddonInstallJob(const ADDON::AddonPtr &addon, const std::string &hash = "", bool update = false, const std::string &referer = "");
+  CAddonInstallJob(const ADDON::AddonPtr &addon, const std::string &hash = "", const std::string &referer = "");
 
   virtual bool DoWork();
 

--- a/xbmc/addons/AddonInstaller.h
+++ b/xbmc/addons/AddonInstaller.h
@@ -55,14 +55,13 @@ public:
 
   /*! \brief Install an addon if it is available in a repository
    \param addonID the addon ID of the item to install
-   \param force whether to force the install even if the addon is already installed (eg for updating). Defaults to false.
    \param referer string to use for referer for http fetch. Set to previous version when updating, parent when fetching a dependency
    \param background whether to install in the background or not. Defaults to true.
    \param modal whether to show a modal dialog when not installing in background
    \return true on successful install, false on failure.
    \sa DoInstall
    */
-  bool Install(const std::string &addonID, bool force = false, const std::string &referer="", bool background = true, bool modal = false);
+  bool InstallOrUpdate(const std::string &addonID, const std::string &referer="", bool background = true, bool modal = false);
 
   /*! \brief Install an addon from the given zip path
    \param path the zip file to install from

--- a/xbmc/addons/AddonInstaller.h
+++ b/xbmc/addons/AddonInstaller.h
@@ -157,11 +157,6 @@ public:
 
   virtual bool DoWork();
 
-  /*! \brief return the id of the addon being installed
-   \return id of the installing addon
-   */
-  std::string AddonID() const;
-
   /*! \brief Find which repository hosts an add-on
    *  \param addon The add-on to find the repository for
    *  \return The hosting repository

--- a/xbmc/addons/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/GUIDialogAddonInfo.cpp
@@ -198,13 +198,13 @@ void CGUIDialogAddonInfo::UpdateControls()
 void CGUIDialogAddonInfo::OnUpdate()
 {
   std::string referer = StringUtils::Format("Referer=%s-%s.zip",m_localAddon->ID().c_str(),m_localAddon->Version().asString().c_str());
-  CAddonInstaller::GetInstance().Install(m_addon->ID(), true, referer); // force install
+  CAddonInstaller::GetInstance().InstallOrUpdate(m_addon->ID(), referer);
   Close();
 }
 
 void CGUIDialogAddonInfo::OnInstall()
 {
-  CAddonInstaller::GetInstance().Install(m_addon->ID());
+  CAddonInstaller::GetInstance().InstallOrUpdate(m_addon->ID());
   Close();
 }
 

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -311,7 +311,7 @@ bool CPVRManager::UpgradeOutdatedAddons(void)
   for (std::map<std::string, std::string>::iterator it = outdatedAddons.begin(); it != outdatedAddons.end(); ++it)
   {
     CLog::Log(LOGINFO, "PVR - updating add-on '%s'", it->first.c_str());
-    CAddonInstaller::GetInstance().Install(it->first, true, it->second, false);
+    CAddonInstaller::GetInstance().InstallOrUpdate(it->first, it->second, false);
   }
 
   // reload

--- a/xbmc/utils/RssManager.cpp
+++ b/xbmc/utils/RssManager.cpp
@@ -75,7 +75,7 @@ void CRssManager::OnSettingAction(const CSetting *setting)
     {
       if (!CGUIDialogYesNo::ShowAndGetInput(CVariant{24076}, CVariant{24100}, CVariant{"RSS Editor"}, CVariant{24101}))
         return;
-      CAddonInstaller::GetInstance().Install("script.rss.editor", true, "", false);
+      CAddonInstaller::GetInstance().InstallOrUpdate("script.rss.editor", "", false);
     }
     CBuiltins::Execute("RunScript(script.rss.editor)");
   }


### PR DESCRIPTION
Just trying to kill off some complexity. Removes the `update` and `force` parameters which are logically never used (every call is a "force" install).

Also, one fix where dependency installing ignores the disable state (probably not an issue as required deps should not be disabled in the first place)
