### PR TITLE
CImageResource: adjust IsAllowed() to also accept directory paths to be able browse directories for multiimage controls

### DIFF
--- a/xbmc/addons/ImageResource.cpp
+++ b/xbmc/addons/ImageResource.cpp
@@ -56,6 +56,10 @@ void CImageResource::OnPreUnInstall()
 
 bool CImageResource::IsAllowed(const std::string &file) const
 {
+  // check if the file path points to a directory
+  if (URIUtils::HasSlashAtEnd(file, true))
+    return true;
+
   std::string ext = URIUtils::GetExtension(file);
   return file.empty() ||
          StringUtils::EqualsNoCase(ext, ".png") ||


### PR DESCRIPTION
This change allows to access `resource://resource.image.foo/` paths pointing to a directory to be able to list/browse sub-directories. This is needed for `multiimage` controls to work which is currently not possible as reported at http://forum.kodi.tv/showthread.php?tid=238224.
