### PR TITLE
[music] set musicbrainzid for VA and filter using that. 

### DIFF
--- a/xbmc/music/Artist.h
+++ b/xbmc/music/Artist.h
@@ -142,3 +142,5 @@ private:
 typedef std::vector<CArtist> VECARTISTS;
 typedef std::vector<CArtistCredit> VECARTISTCREDITS;
 
+const std::string VA_MUSICBRAINZARTISTID = "89ad4ac3-39f7-470e-963a-56509c546377";
+

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -5528,8 +5528,7 @@ bool CMusicDatabase::GetFilter(CDbUrl &musicUrl, Filter &filter, SortDescription
     // and the various artist entry if applicable
     if (!albumArtistsOnly)
     {
-      std::string strVariousArtists = g_localizeStrings.Get(340);
-      strSQL += PrepareSQL(" and artistview.strArtist <> '%s'", strVariousArtists.c_str());
+      strSQL += PrepareSQL(" AND (artistview.strMusicBrainzArtistID is NULL OR artistview.strMusicBrainzArtistID <> '%s')", VA_MUSICBRAINZARTISTID.c_str());
     }
 
     filter.AppendWhere(strSQL);

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -715,6 +715,8 @@ void CMusicInfoScanner::FileItemsToAlbums(CFileItemList& items, VECALBUMS& album
       {
         std::string strJoinPhrase = (it == --common.end() ? "" : g_advancedSettings.m_musicItemSeparator);
         CArtistCredit artistCredit(*it, strJoinPhrase);
+        if (it->compare(g_localizeStrings.Get(340)) == 0)
+          artistCredit.SetMusicBrainzArtistID(VA_MUSICBRAINZARTISTID);
         album.artistCredits.push_back(artistCredit);
       }
       album.bCompilation = compilation;


### PR DESCRIPTION
In #7938 there where some discussion about localization in regards to the VA string and when excluding VA albums. This PR always adds the 89ad4ac3-39f7-470e-963a-56509c546377 (https://musicbrainz.org/artist/89ad4ac3-39f7-470e-963a-56509c546377) as the VA mbid (this part of the code only affect music without musicbrainz tags in the first place). Then we can filter using this ID in GetFilter (when filtering out VA). 

More of a bug fix to avoid problems, than a long term solution to the problem. Any comments?
