### PR TITLE
addon installer: remove referer code

### DIFF
--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -668,7 +668,7 @@ bool CLangInfo::SetLanguage(bool& fallback, const std::string &strLanguage /* = 
           // try to get the proper language addon by its name from all available language addons
           if (ADDON::CLanguageResource::FindLanguageAddonByName(language, newLanguage, languageAddons))
           {
-            if (CAddonInstaller::GetInstance().InstallOrUpdate(newLanguage, "", false, false))
+            if (CAddonInstaller::GetInstance().InstallOrUpdate(newLanguage, false, false))
             {
               CLog::Log(LOGINFO, "CLangInfo: successfully installed language addon \"%s\" matching current language \"%s\"", newLanguage.c_str(), language.c_str());
               foundMatchingAddon = true;

--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -204,7 +204,7 @@ public:
   virtual void OnPostInstall(bool update, bool modal) {};
   virtual void OnPreUnInstall() {};
   virtual void OnPostUnInstall() {};
-  virtual bool CanInstall(const std::string& referer) { return true; }
+  virtual bool CanInstall() { return true; }
 protected:
   friend class CAddonCallbacksAddon;
 

--- a/xbmc/addons/AddonInstaller.h
+++ b/xbmc/addons/AddonInstaller.h
@@ -55,13 +55,12 @@ public:
 
   /*! \brief Install an addon if it is available in a repository
    \param addonID the addon ID of the item to install
-   \param referer string to use for referer for http fetch. Set to previous version when updating, parent when fetching a dependency
    \param background whether to install in the background or not. Defaults to true.
    \param modal whether to show a modal dialog when not installing in background
    \return true on successful install, false on failure.
    \sa DoInstall
    */
-  bool InstallOrUpdate(const std::string &addonID, const std::string &referer="", bool background = true, bool modal = false);
+  bool InstallOrUpdate(const std::string &addonID, bool background = true, bool modal = false);
 
   /*! \brief Install an addon from the given zip path
    \param path the zip file to install from
@@ -124,11 +123,10 @@ private:
   /*! \brief Install an addon from a repository or zip
    \param addon the AddonPtr describing the addon
    \param hash the hash to verify the install. Defaults to "".
-   \param referer string to use for referer for http fetch. Defaults to "".
    \param background whether to install in the background or not. Defaults to true.
    \return true on successful install, false on failure.
    */
-  bool DoInstall(const ADDON::AddonPtr &addon, const std::string &hash = "", const std::string &referer = "", bool background = true, bool modal = false);
+  bool DoInstall(const ADDON::AddonPtr &addon, const std::string &hash = "", bool background = true, bool modal = false);
 
   /*! \brief Check whether dependencies of an addon exist or are installable.
    Iterates through the addon's dependencies, checking they're installed or installable.
@@ -151,7 +149,7 @@ private:
 class CAddonInstallJob : public CFileOperationJob
 {
 public:
-  CAddonInstallJob(const ADDON::AddonPtr &addon, const std::string &hash = "", const std::string &referer = "");
+  CAddonInstallJob(const ADDON::AddonPtr &addon, const std::string &hash = "");
 
   virtual bool DoWork();
 
@@ -192,7 +190,6 @@ private:
   ADDON::AddonPtr m_addon;
   std::string m_hash;
   bool m_update;
-  std::string m_referer;
 };
 
 class CAddonUnInstallJob : public CFileOperationJob

--- a/xbmc/addons/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/GUIDialogAddonInfo.cpp
@@ -197,13 +197,15 @@ void CGUIDialogAddonInfo::UpdateControls()
 
 void CGUIDialogAddonInfo::OnUpdate()
 {
-  std::string referer = StringUtils::Format("Referer=%s-%s.zip",m_localAddon->ID().c_str(),m_localAddon->Version().asString().c_str());
-  CAddonInstaller::GetInstance().InstallOrUpdate(m_addon->ID(), referer);
+  CAddonInstaller::GetInstance().InstallOrUpdate(m_addon->ID());
   Close();
 }
 
 void CGUIDialogAddonInfo::OnInstall()
 {
+  if (!g_passwordManager.CheckMenuLock(WINDOW_ADDON_BROWSER))
+    return;
+
   CAddonInstaller::GetInstance().InstallOrUpdate(m_addon->ID());
   Close();
 }

--- a/xbmc/addons/IAddon.h
+++ b/xbmc/addons/IAddon.h
@@ -127,7 +127,7 @@ namespace ADDON
     virtual void OnPostInstall(bool update, bool modal) =0;
     virtual void OnPreUnInstall() =0;
     virtual void OnPostUnInstall() =0;
-    virtual bool CanInstall(const std::string& referer) =0;
+    virtual bool CanInstall() =0;
 
   protected:
     virtual bool LoadSettings(bool bForce = false) =0;

--- a/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSP.cpp
+++ b/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSP.cpp
@@ -259,16 +259,16 @@ bool CActiveAEDSP::InstallAddonAllowed(const std::string &strAddonId) const
          m_usedProcessesCnt == 0;
 }
 
-void CActiveAEDSP::MarkAsOutdated(const std::string& strAddonId, const std::string& strReferer)
+void CActiveAEDSP::MarkAsOutdated(const std::string& strAddonId)
 {
   if (IsActivated() && CSettings::GetInstance().GetInt(CSettings::SETTING_GENERAL_ADDONUPDATES) == AUTO_UPDATES_ON)
   {
     CSingleLock lock(m_critSection);
-    m_outdatedAddons.insert(make_pair(strAddonId, strReferer));
+    m_outdatedAddons.push_back(strAddonId);
   }
 }
 
-bool CActiveAEDSP::HasOutdatedAddons(std::map<std::string, std::string> &outdatedAddons)
+bool CActiveAEDSP::HasOutdatedAddons(std::vector<std::string> &outdatedAddons)
 {
   CSingleLock lock(m_critSection);
   if (!m_outdatedAddons.empty())

--- a/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSP.h
+++ b/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSP.h
@@ -122,16 +122,15 @@ namespace ActiveAE
     /*!
      * @brief Mark an add-on as outdated so it will be upgrade when it's possible again
      * @param strAddonId The add-on to mark as outdated
-     * @param strReferer The referer to use when downloading
      */
-    void MarkAsOutdated(const std::string& strAddonId, const std::string& strReferer);
+    void MarkAsOutdated(const std::string& strAddonId);
 
     /*!
      * @brief Mark an add-on as outdated so it will be upgrade when it's possible again
      * @param outdatedAddons The generated list of outdated add-on's
      * @return True when outdated addons are present.
      */
-    bool HasOutdatedAddons(std::map<std::string, std::string> &outdatedAddons);
+    bool HasOutdatedAddons(std::vector<std::string> &outdatedAddons);
 
     /*!
      * @brief Get the audio dsp database pointer.
@@ -468,7 +467,7 @@ namespace ActiveAE
     unsigned int            m_activeProcessId;                          /*!< The currently active audio stream id of a playing file source */
     bool                    m_isValidAudioDSPSettings;                  /*!< if settings load was successfull it becomes true */
     AE_DSP_MODELIST         m_modes[AE_DSP_MODE_TYPE_MAX];              /*!< list of currently used dsp processing calls */
-    std::map<std::string, std::string> m_outdatedAddons;
+    std::vector<std::string> m_outdatedAddons;
   };
   //@}
 }

--- a/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSPAddon.cpp
+++ b/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSPAddon.cpp
@@ -101,14 +101,14 @@ void CActiveAEDSPAddon::OnPostUnInstall()
     CActiveAEDSP::GetInstance().Activate(true);
 }
 
-bool CActiveAEDSPAddon::CanInstall(const std::string &referer)
+bool CActiveAEDSPAddon::CanInstall()
 {
   if (!CActiveAEDSP::GetInstance().InstallAddonAllowed(ID()))
   {
-    CActiveAEDSP::GetInstance().MarkAsOutdated(ID(), referer);
+    CActiveAEDSP::GetInstance().MarkAsOutdated(ID());
     return false;
   }
-  return CAddon::CanInstall(referer);
+  return CAddon::CanInstall();
 }
 
 void CActiveAEDSPAddon::ResetProperties(int iClientId /* = AE_DSP_INVALID_ADDON_ID */)

--- a/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSPAddon.h
+++ b/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSPAddon.h
@@ -51,7 +51,7 @@ namespace ActiveAE
     virtual void OnPostInstall(bool restart, bool update);
     virtual void OnPreUnInstall();
     virtual void OnPostUnInstall();
-    virtual bool CanInstall(const std::string &referer);
+    virtual bool CanInstall();
 
     /** @name Audio DSP add-on methods */
     //@{

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -182,9 +182,8 @@ namespace PVR
     /*!
      * @brief Mark an add-on as outdated so it will be upgrade when it's possible again
      * @param strAddonId The add-on to mark as outdated
-     * @param strReferer The referer to use when downloading
      */
-    void MarkAsOutdated(const std::string& strAddonId, const std::string& strReferer);
+    void MarkAsOutdated(const std::string& strAddonId);
 
     /*!
      * @return True when updated, false when the pvr manager failed to load after the attempt
@@ -679,7 +678,7 @@ namespace PVR
     CCriticalSection                m_managerStateMutex;
     ManagerState                    m_managerState;
     CStopWatch                     *m_parentalTimer;
-    std::map<std::string, std::string> m_outdatedAddons;
+    std::vector<std::string>        m_outdatedAddons;
     static int                      m_pvrWindowIds[10];
   };
 

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -127,14 +127,14 @@ void CPVRClient::OnPostUnInstall()
     PVR::CPVRManager::GetInstance().Start(true);
 }
 
-bool CPVRClient::CanInstall(const std::string &referer)
+bool CPVRClient::CanInstall()
 {
   if (!PVR::CPVRManager::GetInstance().InstallAddonAllowed(ID()))
   {
-    PVR::CPVRManager::GetInstance().MarkAsOutdated(ID(), referer);
+    PVR::CPVRManager::GetInstance().MarkAsOutdated(ID());
     return false;
   }
-  return CAddon::CanInstall(referer);
+  return CAddon::CanInstall();
 }
 
 void CPVRClient::ResetProperties(int iClientId /* = PVR_INVALID_CLIENT_ID */)

--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -69,7 +69,7 @@ namespace PVR
     virtual void OnPostInstall(bool update, bool modal);
     virtual void OnPreUnInstall();
     virtual void OnPostUnInstall();
-    virtual bool CanInstall(const std::string &referer);
+    virtual bool CanInstall();
     bool NeedsConfiguration(void) const { return m_bNeedsConfiguration; }
 
     /** @name PVR add-on methods */

--- a/xbmc/utils/RssManager.cpp
+++ b/xbmc/utils/RssManager.cpp
@@ -74,15 +74,10 @@ void CRssManager::OnSettingAction(const CSetting *setting)
   if (settingId == CSettings::SETTING_LOOKANDFEEL_RSSEDIT)
   {
     ADDON::AddonPtr addon;
-    ADDON::CAddonMgr::GetInstance().GetAddon("script.rss.editor",addon);
-    if (!addon)
+    if (!ADDON::CAddonMgr::GetInstance().GetAddon("script.rss.editor", addon))
     {
-      if (HELPERS::ShowYesNoDialogLines(CVariant{24076}, CVariant{24100}, CVariant{"RSS Editor"}, CVariant{24101}) !=
-        DialogResponse::YES)
-      {
+      if (!CAddonInstaller::GetInstance().InstallModal("script.rss.editor", addon))
         return;
-      }
-      CAddonInstaller::GetInstance().InstallOrUpdate("script.rss.editor", "", false);
     }
     CBuiltins::Execute("RunScript(script.rss.editor)");
   }


### PR DESCRIPTION
Doesn't appear to be used for anything.

There is one change here: the language migration will now bypass master pin. This didn't make any sense to me as it is a kind of update (which are allowed without pin) and it's required update.

cc @Montellese @notspiff 
