### PR TITLE
[PVR] PVR Addon API 4.0.0

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -3603,11 +3603,10 @@ msgstr ""
 
 #empty strings from id 838 to 839
 
-#. Message in a dialog when a user wants to delete a repeating timer
+#. Message in a dialog when a user wants to delete a timer that was scheduled by a repeating timer
 #: xbmc/pvr/windows/GUIWindowPVRBase.cpp
-#: xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
 msgctxt "#840"
-msgid "You are about to delete a repeating timer. Do you also want to delete all timers currently scheduled by this timer?"
+msgid "Do you only want to delete this timer or also the repeating timer that has scheduled it?"
 msgstr ""
 
 #. Label of a context menu entry to create a new recording timer with advanced configuration options
@@ -3635,7 +3634,19 @@ msgctxt "#844"
 msgid "Deactivate"
 msgstr ""
 
-#empty strings from id 845 to 849
+#. Message in a dialog when a user wants to delete a repeating timer
+#: xbmc/pvr/windows/GUIWindowPVRBase.cpp
+msgctxt "#845"
+msgid "Are you sure you want to delete this repeating timer and all timers it has scheduled?"
+msgstr ""
+
+#. Message in a dialog when a user wants to delete a non-repeating timer
+#: xbmc/pvr/windows/GUIWindowPVRBase.cpp
+msgctxt "#846"
+msgid "Are you sure you want to delete this timer?"
+msgstr ""
+
+#empty strings from id 847 to 849
 
 msgctxt "#850"
 msgid "Invalid port number entered"

--- a/addons/xbmc.pvr/addon.xml
+++ b/addons/xbmc.pvr/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="xbmc.pvr" version="3.0.0" provider-name="Team-Kodi">
-  <backwards-compatibility abi="3.0.0"/>
+<addon id="xbmc.pvr" version="4.0.0" provider-name="Team-Kodi">
+  <backwards-compatibility abi="4.0.0"/>
   <requires>
     <import addon="xbmc.core" version="0.1.0"/>
   </requires>

--- a/xbmc/addons/include/xbmc_pvr_dll.h
+++ b/xbmc/addons/include/xbmc_pvr_dll.h
@@ -373,12 +373,10 @@ extern "C"
    * Delete a timer on the backend.
    * @param timer The timer to delete.
    * @param bForceDelete Set to true to delete a timer that is currently recording a program.
-   * @param bDeleteScheduled For repeating timers, set to true to not only delete the repeating timer itself, but also all
-            timers scheduled by the repeating timer. For non-repeating timers, this parameter will be ignored.
    * @return PVR_ERROR_NO_ERROR if the timer has been deleted successfully.
    * @remarks Required if bSupportsTimers is set to true. Return PVR_ERROR_NOT_IMPLEMENTED if this add-on won't provide this function.
    */
-  PVR_ERROR DeleteTimer(const PVR_TIMER& timer, bool bForceDelete, bool bDeleteScheduled);
+  PVR_ERROR DeleteTimer(const PVR_TIMER& timer, bool bForceDelete);
 
   /*!
    * Update the timer information on the backend.

--- a/xbmc/addons/include/xbmc_pvr_types.h
+++ b/xbmc/addons/include/xbmc_pvr_types.h
@@ -94,9 +94,14 @@ extern "C" {
   const unsigned int PVR_TIMER_TYPE_NONE = 0; /*!< @brief "Null" value for a numeric timer type. */
 
   /*!
+   * @brief special PVR_TIMER.iClientIndex value to indicate that a timer has not (yet) a valid client index.
+   */
+  const unsigned int PVR_TIMER_NO_CLIENT_INDEX = 0; /*!< @brief timer has not (yet) a valid client index. */
+
+  /*!
    * @brief special PVR_TIMER.iParentClientIndex value to indicate that a timer has no parent.
    */
-  const unsigned int PVR_TIMER_NO_PARENT = 0; /*!< @brief timer has no parent; it was not scheduled by a repeating timer. */
+  const unsigned int PVR_TIMER_NO_PARENT = PVR_TIMER_NO_CLIENT_INDEX; /*!< @brief timer has no parent; it was not scheduled by a repeating timer. */
 
   /*!
    * @brief special PVR_TIMER.iClientChannelUid value to indicate "any channel". Useful for some repeating timer types.
@@ -386,7 +391,8 @@ extern "C" {
    * @brief Representation of a timer event.
    */
   typedef struct PVR_TIMER {
-    unsigned int    iClientIndex;                              /*!< @brief (required) the index of this timer given by the client */
+    unsigned int    iClientIndex;                              /*!< @brief (required) the index of this timer given by the client. PVR_TIMER_NO_CLIENT_INDEX indicates that the index was not yet set by the client, for example for new timers created by
+                                                                    Kodi and passed the first time to the client. A valid index must be greater than PVR_TIMER_NO_CLIENT_INDEX. */
     unsigned int    iParentClientIndex;                        /*!< @brief (optional) for timers scheduled by a repeating timer, the index of the repeating timer that scheduled this timer (it's PVR_TIMER.iClientIndex value). Use PVR_TIMER_NO_PARENT
                                                                     to indicate that this timer was no scheduled by a repeating timer. */
     int             iClientChannelUid;                         /*!< @brief (optional) unique identifier of the channel to record on. PVR_TIMER_ANY_CHANNEL will denote "any channel", not a specifoc one. */

--- a/xbmc/addons/include/xbmc_pvr_types.h
+++ b/xbmc/addons/include/xbmc_pvr_types.h
@@ -523,7 +523,7 @@ extern "C" {
     int          (__cdecl* GetTimersAmount)(void);
     PVR_ERROR    (__cdecl* GetTimers)(ADDON_HANDLE);
     PVR_ERROR    (__cdecl* AddTimer)(const PVR_TIMER&);
-    PVR_ERROR    (__cdecl* DeleteTimer)(const PVR_TIMER&, bool, bool);
+    PVR_ERROR    (__cdecl* DeleteTimer)(const PVR_TIMER&, bool);
     PVR_ERROR    (__cdecl* UpdateTimer)(const PVR_TIMER&);
     bool         (__cdecl* OpenLiveStream)(const PVR_CHANNEL&);
     void         (__cdecl* CloseLiveStream)(void);

--- a/xbmc/addons/include/xbmc_pvr_types.h
+++ b/xbmc/addons/include/xbmc_pvr_types.h
@@ -104,6 +104,11 @@ extern "C" {
   const unsigned int PVR_TIMER_NO_PARENT = PVR_TIMER_NO_CLIENT_INDEX; /*!< @brief timer has no parent; it was not scheduled by a repeating timer. */
 
   /*!
+   * @brief special PVR_TIMER.iEpgUid value to indicate that a timer has no EPG event uid.
+   */
+  const unsigned int PVR_TIMER_NO_EPG_UID = 0; /*!< @brief timer has no EPG event uid. */
+
+  /*!
    * @brief special PVR_TIMER.iClientChannelUid value to indicate "any channel". Useful for some repeating timer types.
    */
   const int PVR_TIMER_ANY_CHANNEL = -1; /*!< @brief denotes "any channel", not a specific one. */
@@ -417,7 +422,7 @@ extern "C" {
     unsigned int    iWeekdays;                                 /*!< @brief (optional) week days, for repeating timers */
     unsigned int    iPreventDuplicateEpisodes;                 /*!< @brief (optional) 1 if backend should only record new episodes in case of a repeating epg-based timer, 0 if all episodes shall be recorded (no duplicate detection). Actual algorithm for
                                                                     duplicate detection is defined by the backend. Addons may define own values for different duplicate detection algorithms, thus this is not just a bool.*/
-    int             iEpgUid;                                   /*!< @brief (optional) epg event id. If set iClientChannelUid, strTitle, strSummary, startTime, endTime, iGenreType, iGenreSubType will be ignored */
+    unsigned int    iEpgUid;                                   /*!< @brief (optional) epg event id. Use PVR_TIMER_NO_EPG_UID to state that there is no EPG event id available for this timer. Values greater than PVR_TIMER_NO_EPG_UID represent a valid epg event id. */
     unsigned int    iMarginStart;                              /*!< @brief (optional) if set, the backend starts the recording iMarginStart minutes before startTime. */
     unsigned int    iMarginEnd;                                /*!< @brief (optional) if set, the backend ends the recording iMarginEnd minutes after endTime. */
     int             iGenreType;                                /*!< @brief (optional) genre type */

--- a/xbmc/addons/include/xbmc_pvr_types.h
+++ b/xbmc/addons/include/xbmc_pvr_types.h
@@ -79,10 +79,10 @@ struct DemuxPacket;
 #define PVR_STREAM_MAX_STREAMS 20
 
 /* current PVR API version */
-#define XBMC_PVR_API_VERSION "3.0.0"
+#define XBMC_PVR_API_VERSION "4.0.0"
 
 /* min. PVR API version */
-#define XBMC_PVR_MIN_API_VERSION "3.0.0"
+#define XBMC_PVR_MIN_API_VERSION "4.0.0"
 
 #ifdef __cplusplus
 extern "C" {

--- a/xbmc/epg/Epg.cpp
+++ b/xbmc/epg/Epg.cpp
@@ -260,7 +260,7 @@ CEpgInfoTagPtr CEpg::GetTag(const CDateTime &StartTime) const
   return CEpgInfoTagPtr();
 }
 
-CEpgInfoTagPtr CEpg::GetTag(int uniqueID) const
+CEpgInfoTagPtr CEpg::GetTag(unsigned int uniqueID) const
 {
   CEpgInfoTagPtr retval;
   CSingleLock lock(m_critSection);

--- a/xbmc/epg/Epg.h
+++ b/xbmc/epg/Epg.h
@@ -209,7 +209,7 @@ namespace EPG
      * @param uniqueID The unique ID of the event to find.
      * @return The found tag or an empty tag if it wasn't found.
      */
-    CEpgInfoTagPtr GetTag(int uniqueID) const;
+    CEpgInfoTagPtr GetTag(unsigned int uniqueID) const;
 
     /*!
      * @brief Update an entry in this EPG.

--- a/xbmc/epg/EpgContainer.cpp
+++ b/xbmc/epg/EpgContainer.cpp
@@ -383,7 +383,7 @@ CEpg *CEpgContainer::GetById(int iEpgId) const
   return epgEntry != m_epgs.end() ? epgEntry->second : NULL;
 }
 
-CEpgInfoTagPtr CEpgContainer::GetTagById(int iBroadcastId) const
+CEpgInfoTagPtr CEpgContainer::GetTagById(unsigned int iBroadcastId) const
 {
   CEpgInfoTagPtr retval;
   CSingleLock lock(m_critSection);

--- a/xbmc/epg/EpgContainer.h
+++ b/xbmc/epg/EpgContainer.h
@@ -164,7 +164,7 @@ namespace EPG
      * @param iBroadcastId The event id to get
      * @return The requested event, or an empty tag when not found
      */
-    virtual CEpgInfoTagPtr GetTagById(int iBroadcastId) const;
+    virtual CEpgInfoTagPtr GetTagById(unsigned int iBroadcastId) const;
 
     /*!
      * @brief Get an EPG table given a PVR channel.

--- a/xbmc/epg/EpgDatabase.cpp
+++ b/xbmc/epg/EpgDatabase.cpp
@@ -227,7 +227,10 @@ int CEpgDatabase::Get(CEpg &epg)
         CDateTime firstAired(iFirstAired);
         newTag->m_firstAired = firstAired;
 
-        newTag->m_iUniqueBroadcastID = m_pDS->fv("iBroadcastUid").get_asInt();
+        int iBroadcastUID = m_pDS->fv("iBroadcastUid").get_asInt();
+        // Compat: null value for broadcast uid changed from numerical -1 to 0 with PVR Addon API v4.0.0
+        newTag->m_iUniqueBroadcastID = iBroadcastUID == -1 ? PVR_TIMER_NO_EPG_UID : iBroadcastUID;
+
         newTag->m_iBroadcastId       = m_pDS->fv("idBroadcast").get_asInt();
         newTag->m_strTitle           = m_pDS->fv("sTitle").get_asString().c_str();
         newTag->m_strPlotOutline     = m_pDS->fv("sPlotOutline").get_asString().c_str();

--- a/xbmc/epg/EpgInfoTag.cpp
+++ b/xbmc/epg/EpgInfoTag.cpp
@@ -51,7 +51,7 @@ CEpgInfoTag::CEpgInfoTag(void) :
     m_iSeriesNumber(0),
     m_iEpisodeNumber(0),
     m_iEpisodePart(0),
-    m_iUniqueBroadcastID(-1),
+    m_iUniqueBroadcastID(0),
     m_iYear(0),
     m_epg(NULL)
 {
@@ -67,7 +67,7 @@ CEpgInfoTag::CEpgInfoTag(CEpg *epg, PVR::CPVRChannelPtr pvrChannel, const std::s
     m_iSeriesNumber(0),
     m_iEpisodeNumber(0),
     m_iEpisodePart(0),
-    m_iUniqueBroadcastID(-1),
+    m_iUniqueBroadcastID(0),
     m_iYear(0),
     m_strIconPath(strIconPath),
     m_epg(epg),
@@ -86,7 +86,7 @@ CEpgInfoTag::CEpgInfoTag(const EPG_TAG &data) :
     m_iSeriesNumber(0),
     m_iEpisodeNumber(0),
     m_iEpisodePart(0),
-    m_iUniqueBroadcastID(-1),
+    m_iUniqueBroadcastID(0),
     m_epg(NULL)
 {
   m_startTime = (data.startTime + g_advancedSettings.m_iPVRTimeCorrection);
@@ -289,12 +289,12 @@ CEpgInfoTagPtr CEpgInfoTag::GetPreviousEvent(void) const
   return GetTable()->GetPreviousEvent(*this);
 }
 
-void CEpgInfoTag::SetUniqueBroadcastID(int iUniqueBroadcastID)
+void CEpgInfoTag::SetUniqueBroadcastID(unsigned int iUniqueBroadcastID)
 {
   m_iUniqueBroadcastID = iUniqueBroadcastID;
 }
 
-int CEpgInfoTag::UniqueBroadcastID(void) const
+unsigned int CEpgInfoTag::UniqueBroadcastID(void) const
 {
   return m_iUniqueBroadcastID;
 }

--- a/xbmc/epg/EpgInfoTag.h
+++ b/xbmc/epg/EpgInfoTag.h
@@ -143,13 +143,13 @@ namespace EPG
      * @brief Change the unique broadcast ID of this event.
      * @param iUniqueBroadcastId The new unique broadcast ID.
      */
-    void SetUniqueBroadcastID(int iUniqueBroadcastID);
+    void SetUniqueBroadcastID(unsigned int iUniqueBroadcastID);
 
     /*!
      * @brief Get the unique broadcast ID.
      * @return The unique broadcast ID.
      */
-    int UniqueBroadcastID(void) const;
+    unsigned int UniqueBroadcastID(void) const;
 
     /*!
      * @brief Get the event's database ID.
@@ -432,7 +432,7 @@ namespace EPG
     int                      m_iSeriesNumber;      /*!< series number */
     int                      m_iEpisodeNumber;     /*!< episode number */
     int                      m_iEpisodePart;       /*!< episode part number */
-    int                      m_iUniqueBroadcastID; /*!< unique broadcast ID */
+    unsigned int             m_iUniqueBroadcastID; /*!< unique broadcast ID */
     std::string              m_strTitle;           /*!< title */
     std::string              m_strPlotOutline;     /*!< plot outline */
     std::string              m_strPlot;            /*!< plot */

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -1222,7 +1222,7 @@ PVR_ERROR CPVRClient::AddTimer(const CPVRTimerInfoTag &timer)
   return retVal;
 }
 
-PVR_ERROR CPVRClient::DeleteTimer(const CPVRTimerInfoTag &timer, bool bForce /* = false */, bool bDeleteSchedule /* = false */)
+PVR_ERROR CPVRClient::DeleteTimer(const CPVRTimerInfoTag &timer, bool bForce /* = false */)
 {
   if (!m_bReadyToUse)
     return PVR_ERROR_REJECTED;
@@ -1236,7 +1236,7 @@ PVR_ERROR CPVRClient::DeleteTimer(const CPVRTimerInfoTag &timer, bool bForce /* 
     PVR_TIMER tag;
     WriteClientTimerInfo(timer, tag);
 
-    retVal = m_pStruct->DeleteTimer(tag, bForce, bDeleteSchedule);
+    retVal = m_pStruct->DeleteTimer(tag, bForce);
 
     LogError(retVal, __FUNCTION__);
   }

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -313,7 +313,7 @@ void CPVRClient::WriteClientTimerInfo(const CPVRTimerInfoTag &xbmcTimer, PVR_TIM
   addonTimer.bStartAnyTime             = xbmcTimer.m_bStartAnyTime;
   addonTimer.bEndAnyTime               = xbmcTimer.m_bEndAnyTime;
   addonTimer.firstDay                  = firstDay - g_advancedSettings.m_iPVRTimeCorrection;
-  addonTimer.iEpgUid                   = epgTag ? epgTag->UniqueBroadcastID() : -1;
+  addonTimer.iEpgUid                   = epgTag ? epgTag->UniqueBroadcastID() : PVR_TIMER_NO_EPG_UID;
   strncpy(addonTimer.strSummary, xbmcTimer.m_strSummary.c_str(), sizeof(addonTimer.strSummary) - 1);
   addonTimer.iMarginStart              = xbmcTimer.m_iMarginStart;
   addonTimer.iMarginEnd                = xbmcTimer.m_iMarginEnd;

--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -365,10 +365,9 @@ namespace PVR
      * @brief Delete a timer on the backend.
      * @param timer The timer to delete.
      * @param bForce Set to true to delete a timer that is currently recording a program.
-     * @param bDeleteSchedule Set to true to delete the complete timer schedule instead of the given timer only.
      * @return PVR_ERROR_NO_ERROR if the timer has been deleted successfully.
      */
-    PVR_ERROR DeleteTimer(const CPVRTimerInfoTag &timer, bool bForce = false, bool bDeleteSchedule = false);
+    PVR_ERROR DeleteTimer(const CPVRTimerInfoTag &timer, bool bForce = false);
 
     /*!
      * @brief Rename a timer on the server.

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -489,13 +489,13 @@ PVR_ERROR CPVRClients::UpdateTimer(const CPVRTimerInfoTag &timer)
   return error;
 }
 
-PVR_ERROR CPVRClients::DeleteTimer(const CPVRTimerInfoTag &timer, bool bForce, bool bDeleteSchedule)
+PVR_ERROR CPVRClients::DeleteTimer(const CPVRTimerInfoTag &timer, bool bForce)
 {
   PVR_ERROR error(PVR_ERROR_UNKNOWN);
   PVR_CLIENT client;
 
   if (GetConnectedClient(timer.m_iClientId, client))
-    error = client->DeleteTimer(timer, bForce, bDeleteSchedule);
+    error = client->DeleteTimer(timer, bForce);
 
   return error;
 }

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -356,11 +356,10 @@ namespace PVR
      * @brief Delete a timer from the backend.
      * @param timer The timer to delete.
      * @param bForce Also delete when currently recording if true.
-     * @param bDeleteSchedule Also delete schedule instead of single timer.
      * @param error An error if it occured.
      * @return True if the timer was deleted successfully, false otherwise.
      */
-    PVR_ERROR DeleteTimer(const CPVRTimerInfoTag &timer, bool bForce, bool bDeleteSchedule);
+    PVR_ERROR DeleteTimer(const CPVRTimerInfoTag &timer, bool bForce);
 
     /*!
      * @brief Rename a timer on the backend.

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
@@ -88,36 +88,11 @@ bool CGUIDialogPVRGuideInfo::ActionCancelTimer(CFileItemPtr timer)
   if (!timer || !timer->HasPVRTimerInfoTag())
     return bReturn;
 
-  bool bDelete(false);
-  bool bDeleteScheduled(false);
-
-  if (timer->GetPVRTimerInfoTag()->IsRepeating())
-  {
-    // prompt user for confirmation for deleting the complete repeating timer, including scheduled timers.
-    bool bCancel(false);
-    bDeleteScheduled = CGUIDialogYesNo::ShowAndGetInput(
-                                                        CVariant{122}, // "Confirm delete"
-                                                        CVariant{840}, // "You are about to delete a repeating timer. Do you also want to delete all timers currently scheduled by this timer?"
-                                                        CVariant{""},
-                                                        CVariant{timer->GetPVRTimerInfoTag()->Title()},
-                                                        bCancel);
-    bDelete = !bCancel;
-  }
-  else
-  {
-    // prompt user for confirmation for deleting the timer
-    bDelete = CGUIDialogYesNo::ShowAndGetInput(
-                                               CVariant{122}, // "Confirm delete"
-                                               CVariant{19040}, // Timer
-                                               CVariant{""},
-                                               CVariant{timer->GetPVRTimerInfoTag()->Title()});
-    bDeleteScheduled = false;
-  }
-
-  if (bDelete)
+  bool bDeleteSchedule(false);
+  if (CGUIWindowPVRBase::ConfirmDeleteTimer(timer.get(), bDeleteSchedule))
   {
     Close();
-    bReturn = CPVRTimers::DeleteTimer(*timer, false, bDeleteScheduled);
+    bReturn = CPVRTimers::DeleteTimer(*timer, false, bDeleteSchedule);
   }
 
   return bReturn;

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -114,7 +114,7 @@ void CGUIDialogPVRTimerSettings::SetTimer(CFileItem *item)
   // Copy data we need from tag. Do not modify the tag itself until Save()!
   m_timerType     = m_timerInfoTag->GetTimerType();
   m_bIsRadio      = m_timerInfoTag->m_bIsRadio;
-  m_bIsNewTimer   = m_timerInfoTag->m_iClientIndex == -1;
+  m_bIsNewTimer   = m_timerInfoTag->m_iClientIndex == PVR_TIMER_NO_CLIENT_INDEX;
   m_bTimerActive  = m_bIsNewTimer || m_timerInfoTag->IsActive();
   m_bStartAnyTime = m_bIsNewTimer || m_timerInfoTag->m_bStartAnyTime;
   m_bEndAnyTime   = m_bIsNewTimer || m_timerInfoTag->m_bEndAnyTime;

--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -187,7 +187,7 @@ void CPVRRecording::Reset(void)
   m_bGotMetaData       = false;
   m_iRecordingId       = 0;
   m_bIsDeleted         = false;
-  m_iEpgEventId        = -1;
+  m_iEpgEventId        = 0;
   m_iSeason            = -1;
   m_iEpisode           = -1;
 

--- a/xbmc/pvr/recordings/PVRRecording.h
+++ b/xbmc/pvr/recordings/PVRRecording.h
@@ -209,7 +209,7 @@ namespace PVR
     /*!
      * @return Broadcast id of the EPG event associated with this recording
      */
-    int EpgEvent(void) const { return m_iEpgEventId; }
+    unsigned int EpgEvent(void) const { return m_iEpgEventId; }
 
     /*!
      * @return Get the channel on which this recording is/was running
@@ -230,10 +230,10 @@ namespace PVR
     std::string EpisodeName(void) const { return m_strShowTitle; };
 
   private:
-    CDateTime m_recordingTime; /*!< start time of the recording */
-    bool      m_bGotMetaData;
-    bool      m_bIsDeleted;    /*!< set if entry is a deleted recording which can be undelete */
-    int       m_iEpgEventId;   /*!< epg broadcast id associated with this recording */
+    CDateTime    m_recordingTime; /*!< start time of the recording */
+    bool         m_bGotMetaData;
+    bool         m_bIsDeleted;    /*!< set if entry is a deleted recording which can be undelete */
+    unsigned int m_iEpgEventId;   /*!< epg broadcast id associated with this recording */
 
     void UpdatePath(void);
     void DisplayError(PVR_ERROR err) const;

--- a/xbmc/pvr/recordings/PVRRecordings.cpp
+++ b/xbmc/pvr/recordings/PVRRecordings.cpp
@@ -513,7 +513,7 @@ void CPVRRecordings::UpdateFromClient(const CPVRRecordingPtr &tag)
 void CPVRRecordings::UpdateEpgTags(void)
 {
   CSingleLock lock(m_critSection);
-  int iEpgEvent;
+  unsigned int iEpgEvent;
   for (PVR_RECORDINGMAP_ITR it = m_recordings.begin(); it != m_recordings.end(); ++it)
   {
     iEpgEvent = it->second->EpgEvent();

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -48,7 +48,7 @@ CPVRTimerInfoTag::CPVRTimerInfoTag(bool bRadio /* = false */) :
   m_bFullTextEpgSearch(false)
 {
   m_iClientId           = g_PVRClients->GetFirstConnectedClientID();
-  m_iClientIndex        = -1;
+  m_iClientIndex        = PVR_TIMER_NO_CLIENT_INDEX;
   m_iParentClientIndex  = PVR_TIMER_NO_PARENT;
   m_iClientChannelUid   = PVR_INVALID_CHANNEL_UID;
   m_iPriority           = CSettings::GetInstance().GetInt(CSettings::SETTING_PVRRECORD_DEFAULTPRIORITY);
@@ -99,6 +99,10 @@ CPVRTimerInfoTag::CPVRTimerInfoTag(const PVR_TIMER &timer, const CPVRChannelPtr 
 {
   m_iClientId           = iClientId;
   m_iClientIndex        = timer.iClientIndex;
+
+  if (m_iClientIndex == PVR_TIMER_NO_CLIENT_INDEX)
+    CLog::Log(LOGERROR, "%s: invalid client index supplied by client %d (must be > 0)!", __FUNCTION__, m_iClientId);
+
   m_iParentClientIndex  = timer.iParentClientIndex;
   m_iClientChannelUid   = channel ? channel->UniqueID() : (timer.iClientChannelUid > 0) ? timer.iClientChannelUid : PVR_INVALID_CHANNEL_UID;
   m_iChannelNumber      = channel ? g_PVRChannelGroups->GetGroupAll(channel->IsRadio())->GetChannelNumber(channel) : 0;
@@ -383,7 +387,7 @@ void CPVRTimerInfoTag::SetTimerType(const CPVRTimerTypePtr &type)
   CSingleLock lock(m_critSection);
   m_timerType = type;
 
-  if (m_timerType && m_iClientIndex == -1)
+  if (m_timerType && m_iClientIndex == PVR_TIMER_NO_CLIENT_INDEX)
   {
     m_iPriority           = m_timerType->GetPriorityDefault();
     m_iLifetime           = m_timerType->GetLifetimeDefault();
@@ -707,7 +711,7 @@ CPVRTimerInfoTagPtr CPVRTimerInfoTag::CreateFromEpg(const CEpgInfoTagPtr &tag, b
   /* set the timer data */
   CDateTime newStart = tag->StartAsUTC();
   CDateTime newEnd = tag->EndAsUTC();
-  newTag->m_iClientIndex       = -1;
+  newTag->m_iClientIndex       = PVR_TIMER_NO_CLIENT_INDEX;
   newTag->m_iParentClientIndex = PVR_TIMER_NO_PARENT;
   newTag->m_strTitle           = tag->Title().empty() ? channel->ChannelName() : tag->Title();
   newTag->m_iChannelNumber     = channel->ChannelNumber();

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -144,12 +144,12 @@ CPVRTimerInfoTag::CPVRTimerInfoTag(const PVR_TIMER &timer, const CPVRChannelPtr 
       unsigned int iMustHave    = PVR_TIMER_TYPE_ATTRIBUTE_NONE;
       unsigned int iMustNotHave = PVR_TIMER_TYPE_FORBIDS_NEW_INSTANCES;
 
-      if (timer.iEpgUid == 0 && timer.iWeekdays != PVR_WEEKDAY_NONE)
+      if (timer.iEpgUid == PVR_TIMER_NO_EPG_UID && timer.iWeekdays != PVR_WEEKDAY_NONE)
         iMustHave |= PVR_TIMER_TYPE_IS_REPEATING;
       else
         iMustNotHave |= PVR_TIMER_TYPE_IS_REPEATING;
 
-      if (timer.iEpgUid == 0)
+      if (timer.iEpgUid == PVR_TIMER_NO_EPG_UID)
         iMustHave |= PVR_TIMER_TYPE_IS_MANUAL;
       else
         iMustNotHave |= PVR_TIMER_TYPE_IS_MANUAL;

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -527,16 +527,16 @@ bool CPVRTimerInfoTag::AddToClient(void) const
   return true;
 }
 
-bool CPVRTimerInfoTag::DeleteFromClient(bool bForce /* = false */ , bool bDeleteSchedule /* = false */ ) const
+bool CPVRTimerInfoTag::DeleteFromClient(bool bForce /* = false */) const
 {
-  PVR_ERROR error = g_PVRClients->DeleteTimer(*this, bForce, bDeleteSchedule);
+  PVR_ERROR error = g_PVRClients->DeleteTimer(*this, bForce);
   if (error == PVR_ERROR_RECORDING_RUNNING)
   {
     // recording running. ask the user if it should be deleted anyway
     if (HELPERS::ShowYesNoDialogText(CVariant{122}, CVariant{19122}) != DialogResponse::YES)
       return false;
 
-    error = g_PVRClients->DeleteTimer(*this, true, bDeleteSchedule);
+    error = g_PVRClients->DeleteTimer(*this, true);
   }
 
   if (error != PVR_ERROR_NO_ERROR)

--- a/xbmc/pvr/timers/PVRTimerInfoTag.h
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.h
@@ -196,7 +196,7 @@ namespace PVR
 
     /* Client control functions */
     bool AddToClient() const;
-    bool DeleteFromClient(bool bForce = false, bool bDeleteSchedule = false) const;
+    bool DeleteFromClient(bool bForce = false) const;
     bool RenameOnClient(const std::string &strNewName);
     bool UpdateOnClient();
 

--- a/xbmc/pvr/timers/PVRTimerInfoTag.h
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.h
@@ -227,7 +227,7 @@ namespace PVR
     std::string           m_strSummary;          /*!< @brief summary string with the time to show inside a GUI list */
     PVR_TIMER_STATE       m_state;               /*!< @brief the state of this timer */
     int                   m_iClientId;           /*!< @brief ID of the backend */
-    int                   m_iClientIndex;        /*!< @brief index number of the tag, given by the backend, -1 for new */
+    unsigned int          m_iClientIndex;        /*!< @brief index number of the tag, given by the backend, PVR_TIMER_NO_CLIENT_INDEX for new */
     unsigned int          m_iParentClientIndex;  /*!< @brief for timers scheduled by repeated timers, the index number of the parent, given by the backend, PVR_TIMER_NO_PARENT for no parent */
     int                   m_iClientChannelUid;   /*!< @brief channel uid */
     bool                  m_bStartAnyTime;       /*!< @brief Ignore start date and time clock. Record at 'Any Time' */

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -493,7 +493,7 @@ bool CPVRTimers::DeleteTimersOnChannel(const CPVRChannelPtr &channel, bool bDele
         if (bDeleteActiveItem && bDeleteRepeatingItem && bChannelsMatch)
         {
           CLog::Log(LOGDEBUG,"PVRTimers - %s - deleted timer %d on client %d", __FUNCTION__, (*timerIt)->m_iClientIndex, (*timerIt)->m_iClientId);
-          bReturn = (*timerIt)->DeleteFromClient(true, false) || bReturn;
+          bReturn = (*timerIt)->DeleteFromClient(true) || bReturn;
           SetChanged();
         }
       }
@@ -588,11 +588,22 @@ bool CPVRTimers::DeleteTimer(const CFileItem &item, bool bForce /* = false */, b
     return false;
   }
 
-  const CPVRTimerInfoTagPtr tag = item.GetPVRTimerInfoTag();
+  CPVRTimerInfoTagPtr tag = item.GetPVRTimerInfoTag();
   if (!tag)
     return false;
 
-  return tag->DeleteFromClient(bForce, bDeleteSchedule);
+  if (bDeleteSchedule)
+  {
+    /* delete the repeating timer that scheduled this timer. */
+    tag = g_PVRTimers->GetByClient(tag->m_iClientId, tag->GetTimerScheduleId());
+    if (!tag)
+    {
+      CLog::Log(LOGERROR, "PVRTimers - %s - unable to obtain parent timer for given timer", __FUNCTION__);
+      return false;
+    }
+  }
+
+  return tag->DeleteFromClient(bForce);
 }
 
 bool CPVRTimers::RenameTimer(CFileItem &item, const std::string &strNewName)

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -521,7 +521,7 @@ bool CPVRTimers::InstantTimer(const CPVRChannelPtr &channel)
   {
     newTimer.reset(new CPVRTimerInfoTag);
     /* set the timer data */
-    newTimer->m_iClientIndex      = -1;
+    newTimer->m_iClientIndex      = PVR_TIMER_NO_CLIENT_INDEX;
     newTimer->m_strTitle          = channel->ChannelName();
     newTimer->m_strSummary        = g_localizeStrings.Get(19056);
     newTimer->m_iChannelNumber    = channel->ChannelNumber();

--- a/xbmc/pvr/windows/GUIWindowPVRBase.h
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.h
@@ -75,6 +75,17 @@ namespace PVR
     static std::string GetSelectedItemPath(bool bRadio);
     static void SetSelectedItemPath(bool bRadio, const std::string &path);
 
+    /*!
+     * @brief Open a dialog to confirm timer delete.
+     * @param item the timer to delete.
+     * @param bDeleteSchedule in: ignored
+     *                        out, for one shot timer scheduled by a repeating timer: true to also delete the
+     *                             repeating timer that has scheduled this timer, false to only delete the one shot timer.
+     *                        out, for one shot timer not scheduled by a repeating timer: ignored
+     * @return true, to proceed with delete, false otherwise.
+     */
+    static bool ConfirmDeleteTimer(CFileItem *item, bool &bDeleteSchedule);
+
   protected:
     CGUIWindowPVRBase(bool bRadio, int id, const std::string &xmlFile);
 
@@ -99,17 +110,6 @@ namespace PVR
     virtual void UpdateSelectedItemPath();
     virtual bool IsValidMessage(CGUIMessage& message);
     void CheckResumeRecording(CFileItem *item);
-
-    /*!
-     * @brief Open a dialog to confirm timer delete.
-     * @param item the timer to delete.
-     * @param bDeleteSchedule in: ignored
-     *                        out, for timer schedules: true to delete the timers currently
-     *                             scheduled by the timer schedule, false otherwise.
-     *                        out, for one shot timers: ignored
-     * @return true, if the timer shall be deleted, false otherwise.
-     */
-    static bool ConfirmDeleteTimer(CFileItem *item, bool &bDeleteSchedule);
 
     static std::map<bool, std::string> m_selectedItemPaths;
 

--- a/xbmc/pvr/windows/GUIWindowPVRTimers.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRTimers.cpp
@@ -294,7 +294,7 @@ bool CGUIWindowPVRTimers::OnContextButtonDelete(CFileItem *item, CONTEXT_BUTTON 
 
     bool bDeleteSchedule(false);
     if (ConfirmDeleteTimer(item, bDeleteSchedule))
-      g_PVRTimers->DeleteTimer(*item, false, bDeleteSchedule);
+      CPVRTimers::DeleteTimer(*item, false, bDeleteSchedule);
   }
 
   return bReturn;
@@ -361,7 +361,7 @@ bool CGUIWindowPVRTimers::ActionDeleteTimer(CFileItem *item)
     return false;
 
   /* delete the timer */
-  bool bReturn = g_PVRTimers->DeleteTimer(*item, false, bDeleteSchedule);
+  bool bReturn = CPVRTimers::DeleteTimer(*item, false, bDeleteSchedule);
 
   if (bReturn && (m_vecItems->GetObjectCount() == 0))
   {

--- a/xbmc/pvr/windows/GUIWindowPVRTimers.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRTimers.cpp
@@ -353,7 +353,7 @@ bool CGUIWindowPVRTimers::ActionDeleteTimer(CFileItem *item)
 {
   /* check if the timer tag is valid */
   CPVRTimerInfoTagPtr timerTag = item->GetPVRTimerInfoTag();
-  if (!timerTag || (timerTag->m_iClientIndex == -1))
+  if (!timerTag || (timerTag->m_iClientIndex == PVR_TIMER_NO_CLIENT_INDEX))
     return false;
 
   bool bDeleteSchedule(false);


### PR DESCRIPTION
This PR contains cleanup changes for the PVR Addon API, including the related Kodi core changes

Remove parameter bDeleteScheduled from function DeleteTimer
- Rational: Parameter is not needed, functionality can easily be implemented in Kodi core
- Core changes: Implement "on delete of a child of a repeating timer offer to delete the repeating timer including all children or just the child. Requested by @da-anda in #7079 and in the forum. Remove "on delete of a repeating timer offer to keep the children of that timer". Functionality was considered senseless by several users in the forum. ;-)

Introduce constant PVR_TIMER_NO_CLIENT_INDEX
- Rational: Magic numbers "everywhere" in the core and in the addons, signed/unsigned problems, bugs (-1 vs. 0 as null value)
- Core changes: No functional changes. Use the new constant instead of magic numbers. Change data types signed<->unsigned to align Kodi core and PVR Addon API data types.

Changed type of PVR_TIMER.iEpgUid to unsigned int. Introduce constant PVR_TIMER_NO_EPG_UID
- Rational: EPG event ids in PVR_RECORDING and EPG_TAG are represented as unsigned int, but in PVR_TIMER as int. Magic numbers "everywhere" in the core and in the addons, signed/unsigned problems, bugs (-1 vs. 0 as null value).
- Core changes: No functional changes. Use the new constant instead of magic numbers. Change data types signed<->unsigned to align Kodi core and PVR Addon API data types.

Please note that this PR does not solve all "magic number" problems we have with the current API and that it is not my attention to achieve this with this PR. So, please, refrain from pulling in other problems, not related to PVR_TIMER.iClientIndex and PVR_TIMER.iEpgUid, into this PR. ;-)

I will open PRs for bumping all PVR addons to version 4.0.0, including the necessary code changes, the next days.

@metaron-uk, @ryangribble, @janbar, for your information, feedback welcome.
@Jalle19 mind doing the review? 
