### PR TITLE
[Confluence] Home screen: Make system.date label wider

### DIFF
--- a/addons/skin.confluence/720p/Home.xml
+++ b/addons/skin.confluence/720p/Home.xml
@@ -1209,7 +1209,7 @@
 			<description>Date label</description>
 			<right>20</right>
 			<top>35</top>
-			<width>200</width>
+			<width>300</width>
 			<height>15</height>
 			<align>right</align>
 			<aligny>center</aligny>


### PR DESCRIPTION
Regression introduced by #7522.

Before:
![screenshot001](https://cloud.githubusercontent.com/assets/3226626/9790846/8f265484-57d8-11e5-950f-fc914febcb0e.png)

After:
![screenshot002](https://cloud.githubusercontent.com/assets/3226626/9790850/95913b54-57d8-11e5-836b-92b3a7b630b7.png)

@Montellese as discussed. Good to go?
