### PR TITLE
[xbmc][utils] Remove auto_aptr

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayCodecSSA.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayCodecSSA.cpp
@@ -19,15 +19,15 @@
  */
 
 #include "DVDOverlayCodecSSA.h"
+#include <memory>
+
 #include "DVDOverlaySSA.h"
 #include "DVDStreamInfo.h"
 #include "DVDCodecs/DVDCodecs.h"
 #include "DVDClock.h"
 #include "Util.h"
-#include "utils/AutoPtrHandle.h"
 #include "utils/StringUtils.h"
 
-using namespace AUTOPTR;
 
 CDVDOverlayCodecSSA::CDVDOverlayCodecSSA() : CDVDOverlayCodec("SSA Subtitle Decoder")
 {
@@ -90,7 +90,7 @@ int CDVDOverlayCodecSSA::Decode(DemuxPacket *pPacket)
     {
       line = lines[i];
       StringUtils::Trim(line);
-      auto_aptr<char> layer(new char[line.length()+1]);
+      std::unique_ptr<char[]> layer(new char[line.length() + 1]);
 
       if(sscanf(line.c_str(), "%*[^:]:%[^,],%d:%d:%d%*c%d,%d:%d:%d%*c%d"
                             , layer.get(), &sh, &sm, &ss, &sc, &eh,&em, &es, &ec) != 9)

--- a/xbmc/filesystem/FileCache.cpp
+++ b/xbmc/filesystem/FileCache.cpp
@@ -32,8 +32,8 @@
 
 #include <cassert>
 #include <algorithm>
+#include <memory>
 
-using namespace AUTOPTR;
 using namespace XFILE;
 
 #define READ_CACHE_CHUNK_SIZE (64*1024)
@@ -249,7 +249,7 @@ void CFileCache::Process()
   }
 
   // create our read buffer
-  auto_aptr<char> buffer(new char[m_chunkSize]);
+  std::unique_ptr<char[]> buffer(new char[m_chunkSize]);
   if (buffer.get() == NULL)
   {
     CLog::Log(LOGERROR, "%s - failed to allocate read buffer", __FUNCTION__);

--- a/xbmc/network/cddb.cpp
+++ b/xbmc/network/cddb.cpp
@@ -42,12 +42,12 @@
 #include "utils/log.h"
 #include "utils/SystemInfo.h"
 
+#include <memory>
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <netdb.h>
 
 using namespace MEDIA_DETECT;
-using namespace AUTOPTR;
 using namespace CDDB;
 
 //-------------------------------------------------------------------------------------------------------------------
@@ -133,7 +133,7 @@ bool Xcddb::closeSocket()
 //-------------------------------------------------------------------------------------------------------------------
 bool Xcddb::Send( const void *buffer, int bytes )
 {
-  auto_aptr<char> tmp_buffer (new char[bytes + 10]);
+  std::unique_ptr<char[]> tmp_buffer(new char[bytes + 10]);
   strcpy(tmp_buffer.get(), (const char*)buffer);
   tmp_buffer.get()[bytes] = '.';
   tmp_buffer.get()[bytes + 1] = 0x0d;

--- a/xbmc/utils/AutoPtrHandle.h
+++ b/xbmc/utils/AutoPtrHandle.h
@@ -65,46 +65,4 @@ protected:
   SOCKET m_hSocket;
 };
 
-/*
- * This template class is very similar to the standard "unique_ptr", but it is
- * used for *array* pointers rather than *object* pointers, i.e. the pointer
- * passed to it must have been allocated with "new[]", and "auto_aptr" will
- * delete it with "delete[]".
- *
- * Class released under GPL and was taken from:
- * http://userpage.fu-berlin.de/~mbayer/tools/html2text.html
- */
-template <class T>
-class auto_aptr
-{
-
-public:
-
-  // Constructor/copy/destroy
-
-  explicit auto_aptr(T *x = 0) : p(x) {}
-  auto_aptr(const auto_aptr<T> &x) : p(x.p) { ((auto_aptr<T> *) &x)->p = 0; }
-  auto_aptr<T>& operator=(const auto_aptr<T> &x)
-  { delete[] p; p = x.p; ((auto_aptr<T> *) &x)->p = 0; return *this; }
-  // Extension: "operator=(T *)" is identical to "auto_aptr::reset(T *)".
-  void operator=(T *x) { delete[] p; p = x; }
-  ~auto_aptr() { delete[] p; }
-
-  // Members
-
-  T &operator[](size_t idx) const { if (!p) abort(); return p[idx]; }
-T *get() const { return (T *) p; }
-  T *release() { T *tmp = p; p = 0; return tmp; }
-  void reset(T *x = 0) { delete[] p; p = x; }
-
-  // These would make a nice extension, but are not provided by many other
-  // implementations.
-  //operator const void *() const { return p; }
-  //int operator!() const { return p == 0; }
-
-private:
-  T *p;
-};
-
-
 }


### PR DESCRIPTION
std::unique_ptr handles this just fine by specifying [] in the template type
