### PR TITLE
CMusicInfoTag: copy some missing information in SetArtist/SetAlbum/SetSong()

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1425,6 +1425,7 @@ void CFileItem::SetFromAlbum(const CAlbum &album)
   m_bIsFolder = true;
   m_strLabel2 = StringUtils::Join(album.artist, g_advancedSettings.m_musicItemSeparator);
   GetMusicInfoTag()->SetAlbum(album);
+  SetArt(album.art);
   m_bIsAlbum = true;
   CMusicDatabase::SetPropertiesFromAlbum(*this,album);
   FillInMimeType(false);

--- a/xbmc/music/tags/MusicInfoTag.cpp
+++ b/xbmc/music/tags/MusicInfoTag.cpp
@@ -582,10 +582,10 @@ void CMusicInfoTag::SetArtist(const CArtist& artist)
   SetArtist(artist.strArtist);
   SetAlbumArtist(artist.strArtist);
   SetGenre(artist.genre);
-  m_dateAdded = artist.dateAdded;
-  m_iDbId = artist.idArtist;
-  m_type = MediaTypeArtist;
-  m_bLoaded = true;
+  SetDateAdded(artist.dateAdded);
+  SetDatabaseId(artist.idArtist, MediaTypeArtist);
+
+  SetLoaded();
 }
 
 void CMusicInfoTag::SetAlbum(const CAlbum& album)
@@ -602,11 +602,11 @@ void CMusicInfoTag::SetAlbum(const CAlbum& album)
   stTime.wYear = album.iYear;
   SetReleaseDate(stTime);
   SetAlbumReleaseType(album.releaseType);
-  m_dateAdded = album.dateAdded;
-  m_iTimesPlayed = album.iTimesPlayed;
-  m_iDbId = album.idAlbum;
-  m_type = MediaTypeAlbum;
-  m_bLoaded = true;
+  SetDateAdded(album.dateAdded);
+  SetPlayCount(album.iTimesPlayed);
+  SetDatabaseId(album.idAlbum, MediaTypeAlbum);
+
+  SetLoaded();
 }
 
 void CMusicInfoTag::SetSong(const CSong& song)
@@ -623,23 +623,23 @@ void CMusicInfoTag::SetSong(const CSong& song)
   SetLastPlayed(song.lastPlayed);
   SetDateAdded(song.dateAdded);
   SetCoverArtInfo(song.embeddedArt.size, song.embeddedArt.mime);
-  m_rating = song.rating;
-  m_strURL = song.strFileName;
+  SetRating(song.rating);
+  SetURL(song.strFileName);
   SYSTEMTIME stTime;
   stTime.wYear = song.iYear;
   SetReleaseDate(stTime);
-  m_iTrack = song.iTrack;
-  m_iDuration = song.iDuration;
-  m_iDbId = song.idSong;
-  m_type = MediaTypeSong;
-  m_bLoaded = true;
-  m_iTimesPlayed = song.iTimesPlayed;
-  m_iAlbumId = song.idAlbum;
+  SetTrackNumber(song.iTrack);
+  SetDuration(song.iDuration);
+  SetPlayCount(song.iTimesPlayed);
+  SetAlbumId(song.idAlbum);
+  SetDatabaseId(song.idSong, MediaTypeSong);
 
   if (song.replayGain.Get(ReplayGain::TRACK).Valid())
     m_replayGain.Set(ReplayGain::TRACK, song.replayGain.Get(ReplayGain::TRACK));
   if (song.replayGain.Get(ReplayGain::ALBUM).Valid())
     m_replayGain.Set(ReplayGain::ALBUM, song.replayGain.Get(ReplayGain::ALBUM));
+
+  SetLoaded();
 }
 
 void CMusicInfoTag::Serialize(CVariant& value) const

--- a/xbmc/music/tags/MusicInfoTag.cpp
+++ b/xbmc/music/tags/MusicInfoTag.cpp
@@ -581,7 +581,9 @@ void CMusicInfoTag::SetArtist(const CArtist& artist)
 {
   SetArtist(artist.strArtist);
   SetAlbumArtist(artist.strArtist);
+  SetMusicBrainzArtistID({ artist.strMusicBrainzArtistID });
   SetGenre(artist.genre);
+  SetMood(StringUtils::Join(artist.moods, g_advancedSettings.m_musicItemSeparator));
   SetDateAdded(artist.dateAdded);
   SetDatabaseId(artist.idArtist, MediaTypeArtist);
 
@@ -595,7 +597,9 @@ void CMusicInfoTag::SetAlbum(const CAlbum& album)
   SetAlbum(album.strAlbum);
   SetTitle(album.strAlbum);
   SetAlbumArtist(album.artist);
+  SetMusicBrainzAlbumID(album.strMusicBrainzAlbumID);
   SetGenre(album.genre);
+  SetMood(StringUtils::Join(album.moods, g_advancedSettings.m_musicItemSeparator));
   SetRating('0' + album.iRating);
   SetCompilation(album.bCompilation);
   SYSTEMTIME stTime;
@@ -604,6 +608,7 @@ void CMusicInfoTag::SetAlbum(const CAlbum& album)
   SetAlbumReleaseType(album.releaseType);
   SetDateAdded(album.dateAdded);
   SetPlayCount(album.iTimesPlayed);
+  SetCompilation(album.bCompilation);
   SetDatabaseId(album.idAlbum, MediaTypeAlbum);
 
   SetLoaded();
@@ -631,6 +636,8 @@ void CMusicInfoTag::SetSong(const CSong& song)
   SetTrackNumber(song.iTrack);
   SetDuration(song.iDuration);
   SetPlayCount(song.iTimesPlayed);
+  SetMood(song.strMood);
+  SetCompilation(song.bCompilation);
   SetAlbumId(song.idAlbum);
   SetDatabaseId(song.idSong, MediaTypeSong);
 


### PR DESCRIPTION
While investigating http://trac.kodi.tv/ticket/16232 I noticed that quite a few details available in `CArtist`, `CAlbum` and `CSong` aren't copied to `CMusicInfoTag` in `SetArtist()`, `SetAlbum()` and `SetSong()` so I added all that I think are safe (wasn't sure about copying the path).
