### PR TITLE
AESinkPULSE: Emulate periodSize as ALSA to stop fragmentation

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
@@ -444,6 +444,7 @@ CAESinkPULSE::CAESinkPULSE()
   m_Context = NULL;
   m_IsStreamPaused = false;
   m_volume_needs_update = false;
+  m_periodSize = 0;
   pa_cvolume_init(&m_Volume);
 }
 
@@ -464,6 +465,7 @@ bool CAESinkPULSE::Initialize(AEAudioFormat &format, std::string &device)
   m_Channels = 0;
   m_Stream = NULL;
   m_Context = NULL;
+  m_periodSize = 0;
 
   if (!SetupContext(NULL, &m_Context, &m_MainLoop))
   {
@@ -643,6 +645,7 @@ bool CAESinkPULSE::Initialize(AEAudioFormat &format, std::string &device)
   {
     unsigned int packetSize = a->minreq;
     m_BufferSize = a->tlength;
+    m_periodSize = a->minreq;
 
     format.m_frames = packetSize / frameSize;
   }
@@ -690,6 +693,7 @@ void CAESinkPULSE::Deinitialize()
   CSingleLock lock(m_sec);
   m_IsAllocated = false;
   m_passthrough = false;
+  m_periodSize = 0;
 
   if (m_Stream)
     Drain();
@@ -767,8 +771,8 @@ unsigned int CAESinkPULSE::AddPackets(uint8_t **data, unsigned int frames, unsig
   unsigned int available = frames * m_format.m_frameSize;
   unsigned int length = 0;
   void *buffer = data[0]+offset*m_format.m_frameSize;
-  // revisit me after Gotham - should use a callback for the write function
-  while ((length = pa_stream_writable_size(m_Stream)) == 0)
+  // care a bit for fragmentation
+  while ((length = pa_stream_writable_size(m_Stream)) < m_periodSize)
     pa_threaded_mainloop_wait(m_MainLoop);
 
   length =  std::min((unsigned int)length, available);
@@ -781,8 +785,9 @@ unsigned int CAESinkPULSE::AddPackets(uint8_t **data, unsigned int frames, unsig
     CLog::Log(LOGERROR, "CPulseAudioDirectSound::AddPackets - pa_stream_write failed\n");
     return 0;
   }
+  unsigned int res = (unsigned int)(length / m_format.m_frameSize);
 
-  return (unsigned int)(length / m_format.m_frameSize);
+  return res;
 }
 
 void CAESinkPULSE::Drain()

--- a/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.h
@@ -70,6 +70,7 @@ private:
   pa_stream *m_Stream; 
   pa_cvolume m_Volume;
   bool m_volume_needs_update;
+  uint32_t m_periodSize;
 
   pa_context *m_Context;
   pa_threaded_mainloop *m_MainLoop;


### PR DESCRIPTION
After debugging the PA sink yesterday with @FernetMenta I have seen that PA might fully fragment and therefore cause higher load in audio engine. This introduces a concept like in the AESinkALSA to eat periodSize samples at once.
