### PR TITLE
AML: EGLNativeTypeAmlAndroid: Implement 480cvbs/i/p and 576cvbs/i/p modes

### DIFF
--- a/xbmc/utils/AMLUtils.cpp
+++ b/xbmc/utils/AMLUtils.cpp
@@ -302,6 +302,18 @@ int aml_axis_value(AML_DISPLAY_AXIS_PARAM param)
   return value[param];
 }
 
+bool aml_IsHdmiConnected()
+{
+  int hpd_state;
+  SysfsUtils::GetInt("/sys/class/amhdmitx/amhdmitx0/hpd_state", hpd_state);
+  if (hpd_state == 2);
+  {
+    return 1;
+  }
+
+  return 0;
+}
+
 bool aml_mode_to_resolution(const char *mode, RESOLUTION_INFO *res)
 {
   if (!res)
@@ -327,6 +339,42 @@ bool aml_mode_to_resolution(const char *mode, RESOLUTION_INFO *res)
     res->iScreenWidth = aml_axis_value(AML_DISPLAY_AXIS_PARAM_WIDTH);
     res->iScreenHeight= aml_axis_value(AML_DISPLAY_AXIS_PARAM_HEIGHT);
     res->fRefreshRate = 60;
+    res->dwFlags = D3DPRESENTFLAG_PROGRESSIVE;
+  }
+  else if ((StringUtils::EqualsNoCase(fromMode, "480cvbs")) || (StringUtils::EqualsNoCase(fromMode, "480i")))
+  {
+    res->iWidth = 720;
+    res->iHeight= 480;
+    res->iScreenWidth = 720;
+    res->iScreenHeight= 480;
+    res->fRefreshRate = 60;
+    res->dwFlags = D3DPRESENTFLAG_INTERLACED;
+  }
+  else if ((StringUtils::EqualsNoCase(fromMode, "576cvbs")) || (StringUtils::EqualsNoCase(fromMode, "576i")))
+  {
+    res->iWidth = 720;
+    res->iHeight= 576;
+    res->iScreenWidth = 720;
+    res->iScreenHeight= 576;
+    res->fRefreshRate = 50;
+    res->dwFlags = D3DPRESENTFLAG_INTERLACED;
+  }
+  else if (StringUtils::EqualsNoCase(fromMode, "480p"))
+  {
+    res->iWidth = 720;
+    res->iHeight= 480;
+    res->iScreenWidth = 720;
+    res->iScreenHeight= 480;
+    res->fRefreshRate = 60;
+    res->dwFlags = D3DPRESENTFLAG_PROGRESSIVE;
+  }
+  else if (StringUtils::EqualsNoCase(fromMode, "576p"))
+  {
+    res->iWidth = 720;
+    res->iHeight= 576;
+    res->iScreenWidth = 720;
+    res->iScreenHeight= 576;
+    res->fRefreshRate = 50;
     res->dwFlags = D3DPRESENTFLAG_PROGRESSIVE;
   }
   else if (StringUtils::EqualsNoCase(fromMode, "720p"))

--- a/xbmc/utils/AMLUtils.h
+++ b/xbmc/utils/AMLUtils.h
@@ -50,4 +50,5 @@ enum AML_DEVICE_TYPE aml_get_device_type();
 void aml_cpufreq_min(bool limit);
 void aml_cpufreq_max(bool limit);
 void aml_set_audio_passthrough(bool passthrough);
+bool aml_IsHdmiConnected();
 bool aml_mode_to_resolution(const char *mode, RESOLUTION_INFO *res);

--- a/xbmc/windowing/egl/EGLNativeTypeAmlAndroid.cpp
+++ b/xbmc/windowing/egl/EGLNativeTypeAmlAndroid.cpp
@@ -76,6 +76,32 @@ bool CEGLNativeTypeAmlAndroid::SetNativeResolution(const RESOLUTION_INFO &res)
       switch(res.iScreenWidth)
       {
         default:
+        case 720:
+          if (!aml_IsHdmiConnected())
+          {
+            if (res.iScreenHeight == 480)
+              return SetDisplayResolution("480cvbs");
+            else
+              return SetDisplayResolution("576cvbs");
+          }
+          else
+          {
+            if (res.iScreenHeight == 480)
+            {
+              if (res.dwFlags & D3DPRESENTFLAG_INTERLACED)
+                return SetDisplayResolution("480i");
+              else
+                return SetDisplayResolution("480p");
+            }
+            else
+            {
+              if (res.dwFlags & D3DPRESENTFLAG_INTERLACED)
+                return SetDisplayResolution("576i");
+              else
+                return SetDisplayResolution("576p");
+            }
+          }
+          break;
         case 1280:
           return SetDisplayResolution("720p");
           break;


### PR DESCRIPTION
This should fix video size issues on 720x480 (NTSC) and 720x576 (PAL) too. What I was not able to test is 480i/p/576i/p on device with component output (when hdmi is not connected but component is) because I don't have any device with component output :smile: )
