### PR TITLE
[adsp] fix startup crash and startup add-on checks, improve loops

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -9602,7 +9602,17 @@ msgctxt "#19272"
 msgid "You need a tuner, backend software, and an add-on for the backend to be able to use PVR. Please visit http://kodi.wiki/view/PVR to learn more."
 msgstr ""
 
-#empty strings from id 19273 to 19274
+#. Header on DialogOK
+#: xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSP.cpp
+msgctxt "#19273"
+msgid "No audio DSP add-ons could be found"
+msgstr ""
+
+#. DialogOK for no installed ADSP add-on available
+#: xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSP.cpp
+msgctxt "#19274"
+msgid "You need a add-on installed for the process of audio DSP signal. System becomes disabled."
+msgstr ""
 
 #: xbmc/pvr/timers/PVRTimerInfoTag.cpp
 msgctxt "#19275"

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -662,9 +662,6 @@ bool CApplication::Create()
     return false;
   }
 
-  // start AudioDSP engine with a blocking message
-  CApplicationMessenger::GetInstance().SendMsg(TMSG_SETAUDIODSPSTATE, ACTIVE_AE_DSP_STATE_ON);
-
   // restore AE's previous volume state
   SetHardwareVolume(m_volumeLevel);
   CAEFactory::SetMute     (m_muted);

--- a/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSP.cpp
+++ b/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSP.cpp
@@ -194,7 +194,7 @@ void CActiveAEDSP::TriggerModeUpdate(bool bAsync /* = true */)
     return;
   }
 
-  for (unsigned int i = 0; i < AE_DSP_MODE_TYPE_MAX; i++)
+  for (unsigned int i = 0; i < AE_DSP_MODE_TYPE_MAX; ++i)
   {
     m_modes[i].clear();
     m_databaseDSP.GetModes(m_modes[i], i);
@@ -231,7 +231,7 @@ void CActiveAEDSP::Deactivate(void)
     m_databaseDSP.Close();
 
   /* destroy all addons */
-  for (AE_DSP_ADDONMAP_ITR itr = m_addonMap.begin(); itr != m_addonMap.end(); itr++)
+  for (AE_DSP_ADDONMAP_ITR itr = m_addonMap.begin(); itr != m_addonMap.end(); ++itr)
     itr->second->Destroy();
 
   m_addonMap.clear();
@@ -240,7 +240,7 @@ void CActiveAEDSP::Deactivate(void)
 void CActiveAEDSP::Cleanup(void)
 {
   CActiveAEDSPProcessPtr tmp;
-  for (int i = 0; i < AE_DSP_STREAM_MAX_STREAMS; i++)
+  for (unsigned int i = 0; i < AE_DSP_STREAM_MAX_STREAMS; ++i)
     m_usedProcesses[i] = tmp;
 
   m_isActive                  = false;
@@ -248,7 +248,7 @@ void CActiveAEDSP::Cleanup(void)
   m_isValidAudioDSPSettings  = false;
   m_outdatedAddons.clear();
 
-  for (unsigned int i = 0; i < AE_DSP_MODE_TYPE_MAX; i++)
+  for (unsigned int i = 0; i < AE_DSP_MODE_TYPE_MAX; ++i)
     m_modes[i].clear();
 }
 
@@ -358,8 +358,8 @@ bool CActiveAEDSP::IsInUse(const std::string &strAddonId) const
 {
   CSingleLock lock(m_critSection);
 
-  for (AE_DSP_ADDONMAP_CITR itr = m_addonMap.begin(); itr != m_addonMap.end(); itr++)
-    if (itr->second->Enabled() && itr->second->ID() == strAddonId)
+  for (AE_DSP_ADDONMAP_CITR citr = m_addonMap.begin(); citr != m_addonMap.end(); ++citr)
+    if (citr->second->Enabled() && citr->second->ID() == strAddonId)
       return true;
   return false;
 }
@@ -374,9 +374,11 @@ int CActiveAEDSP::GetAudioDSPAddonId(const AddonPtr &addon) const
 {
   CSingleLock lock(m_critUpdateSection);
 
-  for (AE_DSP_ADDONMAP_CITR itr = m_addonMap.begin(); itr != m_addonMap.end(); itr++)
-    if (itr->second->ID() == addon->ID())
-      return itr->first;
+  for (AE_DSP_ADDONMAP_CITR citr = m_addonMap.begin(); citr != m_addonMap.end(); ++citr)
+  {
+    if (citr->second->ID() == addon->ID())
+      return citr->first;
+  }
 
   return -1;
 }
@@ -536,7 +538,7 @@ bool CActiveAEDSP::CreateDSPs(unsigned int &streamId, CActiveAEDSPProcessPtr &pr
   }
   else
   {
-    for (int i = 0; i < AE_DSP_STREAM_MAX_STREAMS; i++)
+    for (unsigned int i = 0; i < AE_DSP_STREAM_MAX_STREAMS; ++i)
     {
       /* find a free position */
       if (m_usedProcesses[i] == NULL)
@@ -578,7 +580,7 @@ void CActiveAEDSP::DestroyDSPs(unsigned int streamId)
   {
     m_usedProcesses[streamId]->Destroy();
     m_usedProcesses[streamId] = CActiveAEDSPProcessPtr();
-    m_usedProcessesCnt--;
+    --m_usedProcessesCnt;
   }
   if (m_usedProcessesCnt == 0)
   {
@@ -652,7 +654,7 @@ bool CActiveAEDSP::UpdateAndInitialiseAudioDSPAddons(bool bInitialiseAllAudioDSP
   if (map.size() == 0)
     return false;
 
-  for (unsigned iAddonPtr = 0; iAddonPtr < map.size(); iAddonPtr++)
+  for (unsigned iAddonPtr = 0; iAddonPtr < map.size(); ++iAddonPtr)
   {
     const AddonPtr dspAddon = map.at(iAddonPtr);
     bool bEnabled = dspAddon->Enabled() &&
@@ -718,13 +720,13 @@ bool CActiveAEDSP::UpdateAndInitialiseAudioDSPAddons(bool bInitialiseAllAudioDSP
   if (disableAddons.size() > 0)
   {
     CSingleLock lock(m_critUpdateSection);
-    for (VECADDONS::iterator it = disableAddons.begin(); it != disableAddons.end(); it++)
+    for (VECADDONS::iterator itr = disableAddons.begin(); itr != disableAddons.end(); ++itr)
     {
       /* disable in the add-on db */
-      CAddonMgr::GetInstance().DisableAddon((*it)->ID());
+      CAddonMgr::GetInstance().DisableAddon((*itr)->ID());
 
       /* remove from the audio dsp add-on list */
-      VECADDONS::iterator addonPtr = std::find(m_addons.begin(), m_addons.end(), *it);
+      VECADDONS::iterator addonPtr = std::find(m_addons.begin(), m_addons.end(), *itr);
       if (addonPtr != m_addons.end())
         m_addons.erase(addonPtr);
     }
@@ -736,6 +738,7 @@ bool CActiveAEDSP::UpdateAndInitialiseAudioDSPAddons(bool bInitialiseAllAudioDSP
 bool CActiveAEDSP::UpdateAddons(void)
 {
   VECADDONS addons;
+  AE_DSP_ADDON dspAddon;
   bool bReturn(CAddonMgr::GetInstance().GetAddons(ADDON_ADSPDLL, addons, true));
   size_t usableAddons;
 
@@ -748,15 +751,15 @@ bool CActiveAEDSP::UpdateAddons(void)
   usableAddons = m_addons.size();
 
   /* handle "new" addons which aren't yet in the db - these have to be added first */
-  for (unsigned iAddonPtr = 0; iAddonPtr < m_addons.size(); iAddonPtr++)
+  for (VECADDONS::const_iterator itr = addons.begin(); itr != addons.end(); ++itr)
   {
-    const AddonPtr dspAddon = m_addons.at(iAddonPtr);
+    dspAddon = std::dynamic_pointer_cast<CActiveAEDSPAddon>(*itr);
 
     bool newRegistration = false;
     if (RegisterAudioDSPAddon(dspAddon, &newRegistration) < 0 || newRegistration)
     {
       CAddonMgr::GetInstance().DisableAddon(dspAddon->ID());
-      usableAddons--;
+      --usableAddons;
     }
   }
 
@@ -926,9 +929,11 @@ int CActiveAEDSP::EnabledAudioDSPAddonAmount(void) const
   int iReturn(0);
   CSingleLock lock(m_critUpdateSection);
 
-  for (AE_DSP_ADDONMAP_CITR itr = m_addonMap.begin(); itr != m_addonMap.end(); itr++)
-    if (itr->second->Enabled())
+  for (AE_DSP_ADDONMAP_CITR citr = m_addonMap.begin(); citr != m_addonMap.end(); ++citr)
+  {
+    if (citr->second->Enabled())
       ++iReturn;
+  }
 
   return iReturn;
 }
@@ -943,11 +948,11 @@ int CActiveAEDSP::GetEnabledAudioDSPAddons(AE_DSP_ADDONMAP &addons) const
   int iReturn(0);
   CSingleLock lock(m_critUpdateSection);
 
-  for (AE_DSP_ADDONMAP_CITR itr = m_addonMap.begin(); itr != m_addonMap.end(); itr++)
+  for (AE_DSP_ADDONMAP_CITR citr = m_addonMap.begin(); citr != m_addonMap.end(); ++citr)
   {
-    if (itr->second->Enabled())
+    if (citr->second->Enabled())
     {
-      addons.insert(std::make_pair(itr->second->GetID(), itr->second));
+      addons.insert(std::make_pair(citr->second->GetID(), citr->second));
       ++iReturn;
     }
   }
@@ -960,9 +965,11 @@ int CActiveAEDSP::ReadyAudioDSPAddonAmount(void) const
   int iReturn(0);
   CSingleLock lock(m_critUpdateSection);
 
-  for (AE_DSP_ADDONMAP_CITR itr = m_addonMap.begin(); itr != m_addonMap.end(); itr++)
-    if (itr->second->ReadyToUse())
+  for (AE_DSP_ADDONMAP_CITR citr = m_addonMap.begin(); citr != m_addonMap.end(); ++citr)
+  {
+    if (citr->second->ReadyToUse())
       ++iReturn;
+  }
 
   return iReturn;
 }
@@ -982,9 +989,12 @@ bool CActiveAEDSP::IsReadyAudioDSPAddon(const AddonPtr &addon)
 {
   CSingleLock lock(m_critUpdateSection);
 
-  for (AE_DSP_ADDONMAP_CITR itr = m_addonMap.begin(); itr != m_addonMap.end(); itr++)
-    if (itr->second->ID() == addon->ID())
-      return itr->second->ReadyToUse();
+  for (AE_DSP_ADDONMAP_CITR citr = m_addonMap.begin(); citr != m_addonMap.end(); ++citr)
+  {
+    if (citr->second->ID() == addon->ID())
+      return citr->second->ReadyToUse();
+  }
+
   return false;
 }
 
@@ -993,11 +1003,11 @@ int CActiveAEDSP::GetReadyAddons(AE_DSP_ADDONMAP &addons) const
   int iReturn(0);
   CSingleLock lock(m_critSection);
 
-  for (AE_DSP_ADDONMAP_CITR itr = m_addonMap.begin(); itr != m_addonMap.end(); itr++)
+  for (AE_DSP_ADDONMAP_CITR citr = m_addonMap.begin(); citr != m_addonMap.end(); ++citr)
   {
-    if (itr->second->ReadyToUse())
+    if (citr->second->ReadyToUse())
     {
-      addons.insert(std::make_pair(itr->second->GetID(), itr->second));
+      addons.insert(std::make_pair(citr->second->GetID(), citr->second));
       ++iReturn;
     }
   }
@@ -1030,10 +1040,10 @@ bool CActiveAEDSP::GetAudioDSPAddon(int iAddonId, AE_DSP_ADDON &addon) const
 
   CSingleLock lock(m_critUpdateSection);
 
-  AE_DSP_ADDONMAP_CITR itr = m_addonMap.find(iAddonId);
-  if (itr != m_addonMap.end())
+  AE_DSP_ADDONMAP_CITR citr = m_addonMap.find(iAddonId);
+  if (citr != m_addonMap.end())
   {
-    addon = itr->second;
+    addon = citr->second;
     bReturn = true;
   }
 
@@ -1043,11 +1053,11 @@ bool CActiveAEDSP::GetAudioDSPAddon(int iAddonId, AE_DSP_ADDON &addon) const
 bool CActiveAEDSP::GetAudioDSPAddon(const std::string &strId, AddonPtr &addon) const
 {
   CSingleLock lock(m_critUpdateSection);
-  for (AE_DSP_ADDONMAP_CITR itr = m_addonMap.begin(); itr != m_addonMap.end(); itr++)
+  for (AE_DSP_ADDONMAP_CITR citr = m_addonMap.begin(); citr != m_addonMap.end(); ++citr)
   {
-    if (itr->second->ID() == strId)
+    if (citr->second->ID() == strId)
     {
-      addon = itr->second;
+      addon = citr->second;
       return true;
     }
   }
@@ -1059,13 +1069,13 @@ bool CActiveAEDSP::GetAudioDSPAddon(const std::string &strId, AddonPtr &addon) c
 //@{
 bool CActiveAEDSP::HaveMenuHooks(AE_DSP_MENUHOOK_CAT cat, int iDSPAddonID)
 {
-  for (AE_DSP_ADDONMAP_CITR itr = m_addonMap.begin(); itr != m_addonMap.end(); itr++)
+  for (AE_DSP_ADDONMAP_CITR citr = m_addonMap.begin(); citr != m_addonMap.end(); ++citr)
   {
-    if (itr->second->ReadyToUse())
+    if (citr->second->ReadyToUse())
     {
-      if (itr->second->HaveMenuHooks(cat))
+      if (citr->second->HaveMenuHooks(cat))
       {
-        if (iDSPAddonID > 0 && itr->second->GetID() == iDSPAddonID)
+        if (iDSPAddonID > 0 && citr->second->GetID() == iDSPAddonID)
           return true;
         else if (iDSPAddonID < 0)
           return true;
@@ -1073,7 +1083,7 @@ bool CActiveAEDSP::HaveMenuHooks(AE_DSP_MENUHOOK_CAT cat, int iDSPAddonID)
       else if (cat == AE_DSP_MENUHOOK_SETTING)
       {
         AddonPtr addon;
-        if (CAddonMgr::GetInstance().GetAddon(itr->second->ID(), addon) && addon->HasSettings())
+        if (CAddonMgr::GetInstance().GetAddon(citr->second->ID(), addon) && addon->HasSettings())
           return true;
       }
     }
@@ -1093,7 +1103,7 @@ bool CActiveAEDSP::GetMenuHooks(int iDSPAddonID, AE_DSP_MENUHOOK_CAT cat, AE_DSP
   if (GetReadyAudioDSPAddon(iDSPAddonID, addon) && addon->HaveMenuHooks(cat))
   {
     AE_DSP_MENUHOOKS *addonhooks = addon->GetMenuHooks();
-    for (unsigned int i = 0; i < addonhooks->size(); i++)
+    for (unsigned int i = 0; i < addonhooks->size(); ++i)
     {
       if (cat == AE_DSP_MENUHOOK_ALL || addonhooks->at(i).category == cat)
       {

--- a/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSPAddon.cpp
+++ b/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSPAddon.cpp
@@ -374,7 +374,7 @@ bool CActiveAEDSPAddon::HaveMenuHooks(AE_DSP_MENUHOOK_CAT cat) const
 {
   if (m_bReadyToUse && m_menuhooks.size() > 0)
   {
-    for (unsigned int i = 0; i < m_menuhooks.size(); i++)
+    for (unsigned int i = 0; i < m_menuhooks.size(); ++i)
     {
       if (m_menuhooks[i].category == cat || m_menuhooks[i].category == AE_DSP_MENUHOOK_ALL)
         return true;

--- a/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSPDatabase.cpp
+++ b/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSPDatabase.cpp
@@ -94,7 +94,7 @@ void CActiveAEDSPDatabase::CreateTables()
     CLog::Log(LOGERROR, "Audio DSP - %s - failed to get add-ons from the add-on manager", __FUNCTION__);
   else
   {
-    for (IVECADDONS it = addons.begin(); it != addons.end(); it++)
+    for (IVECADDONS it = addons.begin(); it != addons.end(); ++it)
       CAddonMgr::GetInstance().DisableAddon(it->get()->ID());
   }
 }
@@ -175,7 +175,7 @@ bool CActiveAEDSPDatabase::PersistModes(std::vector<CActiveAEDSPModePtr> &modes,
 {
   bool bReturn(true);
 
-  for (unsigned int iModePtr = 0; iModePtr < modes.size(); iModePtr++)
+  for (unsigned int iModePtr = 0; iModePtr < modes.size(); ++iModePtr)
   {
     CActiveAEDSPModePtr member = modes.at(iModePtr);
     if (!member->IsInternal() && (member->IsChanged() || member->IsNew()))

--- a/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSPProcess.cpp
+++ b/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSPProcess.cpp
@@ -61,7 +61,7 @@ CActiveAEDSPProcess::CActiveAEDSPProcess(AE_DSP_STREAM_ID streamId)
    * If a bigger size is neeeded it becomes reallocated during DSP processing.
    */
   m_processArraySize = MIN_DSP_ARRAY_SIZE;
-  for (int i = 0; i < AE_DSP_CH_MAX; i++)
+  for (int i = 0; i < AE_DSP_CH_MAX; ++i)
   {
     m_processArray[0][i] = (float*)calloc(m_processArraySize, sizeof(float));
     m_processArray[1][i] = (float*)calloc(m_processArraySize, sizeof(float));
@@ -79,7 +79,7 @@ CActiveAEDSPProcess::~CActiveAEDSPProcess()
   }
 
   /* Clear the buffer arrays */
-  for (int i = 0; i < AE_DSP_CH_MAX; i++)
+  for (int i = 0; i < AE_DSP_CH_MAX; ++i)
   {
     if(m_processArray[0][i])
       free(m_processArray[0][i]);
@@ -316,7 +316,7 @@ bool CActiveAEDSPProcess::Create(const AEAudioFormat &inputFormat, const AEAudio
     const AE_DSP_MODELIST listInputResample = CActiveAEDSP::GetInstance().GetAvailableModes(AE_DSP_MODE_TYPE_INPUT_RESAMPLE);
     if (listInputResample.size() == 0)
       CLog::Log(LOGDEBUG, "  | - no input resample addon present or enabled");
-    for (unsigned int i = 0; i < listInputResample.size(); i++)
+    for (unsigned int i = 0; i < listInputResample.size(); ++i)
     {
       /// For resample only one call is allowed. Use first one and ignore everything else.
       CActiveAEDSPModePtr pMode = listInputResample[i].first;
@@ -369,7 +369,7 @@ bool CActiveAEDSPProcess::Create(const AEAudioFormat &inputFormat, const AEAudio
     /*!
      * Now init all other dsp relavant addons
      */
-    for (AE_DSP_ADDONMAP_ITR itr = addonMap.begin(); itr != addonMap.end(); itr++)
+    for (AE_DSP_ADDONMAP_ITR itr = addonMap.begin(); itr != addonMap.end(); ++itr)
     {
       AE_DSP_ADDON addon = itr->second;
       int id = addon->GetID();
@@ -389,7 +389,7 @@ bool CActiveAEDSPProcess::Create(const AEAudioFormat &inputFormat, const AEAudio
       }
     }
 
-    for (AE_DSP_ADDONMAP_ITR itr = m_usedMap.begin(); itr != m_usedMap.end(); itr++)
+    for (AE_DSP_ADDONMAP_ITR itr = m_usedMap.begin(); itr != m_usedMap.end(); ++itr)
     {
       AE_DSP_ADDON addon = itr->second;
       if (addon->SupportsInputInfoProcess())
@@ -406,11 +406,11 @@ bool CActiveAEDSPProcess::Create(const AEAudioFormat &inputFormat, const AEAudio
      */
     CLog::Log(LOGDEBUG, "  ---- DSP active pre process modes ---");
     const AE_DSP_MODELIST listPreProcess = CActiveAEDSP::GetInstance().GetAvailableModes(AE_DSP_MODE_TYPE_PRE_PROCESS);
-    for (unsigned int i = 0; i < listPreProcess.size(); i++)
+    for (unsigned int i = 0; i < listPreProcess.size(); ++i)
     {
       CActiveAEDSPModePtr pMode = listPreProcess[i].first;
       AE_DSP_ADDON        addon = listPreProcess[i].second;
-      int                   id  = addon->GetID();
+      int                    id = addon->GetID();
 
       if (m_usedMap.find(id) == m_usedMap.end())
         continue;
@@ -436,7 +436,7 @@ bool CActiveAEDSPProcess::Create(const AEAudioFormat &inputFormat, const AEAudio
      */
     CLog::Log(LOGDEBUG, "  ---- DSP active master process modes ---");
     const AE_DSP_MODELIST listMasterProcess = CActiveAEDSP::GetInstance().GetAvailableModes(AE_DSP_MODE_TYPE_MASTER_PROCESS);
-    for (unsigned int i = 0; i < listMasterProcess.size(); i++)
+    for (unsigned int i = 0; i < listMasterProcess.size(); ++i)
     {
       CActiveAEDSPModePtr pMode = listMasterProcess[i].first;
       AE_DSP_ADDON        addon = listMasterProcess[i].second;
@@ -469,7 +469,7 @@ bool CActiveAEDSPProcess::Create(const AEAudioFormat &inputFormat, const AEAudio
     if (modeID == AE_DSP_MASTER_MODE_ID_INVALID)
       modeID = AE_DSP_MASTER_MODE_ID_PASSOVER;
 
-    for (unsigned int ptr = 0; ptr < m_addons_MasterProc.size(); ptr++)
+    for (unsigned int ptr = 0; ptr < m_addons_MasterProc.size(); ++ptr)
     {
       CActiveAEDSPModePtr mode = m_addons_MasterProc.at(ptr).pMode;
       if (mode->ModeID() == modeID)
@@ -510,7 +510,7 @@ bool CActiveAEDSPProcess::Create(const AEAudioFormat &inputFormat, const AEAudio
      */
     CLog::Log(LOGDEBUG, "  ---- DSP active post process modes ---");
     const AE_DSP_MODELIST listPostProcess = CActiveAEDSP::GetInstance().GetAvailableModes(AE_DSP_MODE_TYPE_POST_PROCESS);
-    for (unsigned int i = 0; i < listPostProcess.size(); i++)
+    for (unsigned int i = 0; i < listPostProcess.size(); ++i)
     {
       CActiveAEDSPModePtr pMode = listPostProcess[i].first;
       AE_DSP_ADDON        addon = listPostProcess[i].second;
@@ -545,7 +545,7 @@ bool CActiveAEDSPProcess::Create(const AEAudioFormat &inputFormat, const AEAudio
       const AE_DSP_MODELIST listOutputResample = CActiveAEDSP::GetInstance().GetAvailableModes(AE_DSP_MODE_TYPE_OUTPUT_RESAMPLE);
       if (listOutputResample.size() == 0)
         CLog::Log(LOGDEBUG, "  | - no final post resample addon present or enabled, becomes performed by KODI");
-      for (unsigned int i = 0; i < listOutputResample.size(); i++)
+      for (unsigned int i = 0; i < listOutputResample.size(); ++i)
       {
         /// For resample only one call is allowed. Use first one and ignore everything else.
         CActiveAEDSPModePtr pMode = listOutputResample[i].first;
@@ -822,7 +822,7 @@ void CActiveAEDSPProcess::Destroy()
   if (!CActiveAEDSP::GetInstance().IsActivated())
     return;
 
-  for (AE_DSP_ADDONMAP_ITR itr = m_usedMap.begin(); itr != m_usedMap.end(); itr++)
+  for (AE_DSP_ADDONMAP_ITR itr = m_usedMap.begin(); itr != m_usedMap.end(); ++itr)
   {
     itr->second->StreamDestroy(&m_addon_Handles[itr->first]);
   }
@@ -1051,7 +1051,7 @@ bool CActiveAEDSPProcess::MasterModeChange(int iModeID, AE_DSP_STREAMTYPE iStrea
   else
   {
     CActiveAEDSPModePtr mode;
-    for (unsigned int ptr = 0; ptr < m_addons_MasterProc.size(); ptr++)
+    for (unsigned int ptr = 0; ptr < m_addons_MasterProc.size(); ++ptr)
     {
       mode = m_addons_MasterProc.at(ptr).pMode;
       if (mode->ModeID() == iModeID && mode->IsEnabled())
@@ -1105,7 +1105,7 @@ bool CActiveAEDSPProcess::MasterModeChange(int iModeID, AE_DSP_STREAMTYPE iStrea
 void CActiveAEDSPProcess::ClearArray(float **array, unsigned int samples)
 {
   unsigned int presentFlag = 1;
-  for (int i = 0; i < AE_DSP_CH_MAX; i++)
+  for (int i = 0; i < AE_DSP_CH_MAX; ++i)
   {
     if (m_addonSettings.lOutChannelPresentFlags & presentFlag)
       memset(array[i], 0, samples*sizeof(float));
@@ -1232,7 +1232,7 @@ bool CActiveAEDSPProcess::Process(CSampleBuffer *in, CSampleBuffer *out)
       m_NewStreamType = AE_DSP_ASTREAM_INVALID;
     }
 
-    for (AE_DSP_ADDONMAP_ITR itr = m_usedMap.begin(); itr != m_usedMap.end(); itr++)
+    for (AE_DSP_ADDONMAP_ITR itr = m_usedMap.begin(); itr != m_usedMap.end(); ++itr)
     {
       AE_DSP_ERROR err = itr->second->StreamInitialize(&m_addon_Handles[itr->first], &m_addonSettings);
       if (err != AE_DSP_ERROR_NO_ERROR)
@@ -1278,7 +1278,7 @@ bool CActiveAEDSPProcess::Process(CSampleBuffer *in, CSampleBuffer *out)
    * Can be used to have unchanged input stream..
    * All DSP addons allowed todo this.
    */
-  for (unsigned int i = 0; i < m_addons_InputProc.size(); i++)
+  for (unsigned int i = 0; i < m_addons_InputProc.size(); ++i)
   {
     if (!m_addons_InputProc[i].pAddon->InputProcess(&m_addons_InputProc[i].handle, (const float **)lastOutArray, frames))
     {
@@ -1310,7 +1310,7 @@ bool CActiveAEDSPProcess::Process(CSampleBuffer *in, CSampleBuffer *out)
    * DSP pre processing
    * All DSP addons allowed todo this and order of it set on settings.
    */
-  for (unsigned int i = 0; i < m_addons_PreProc.size(); i++)
+  for (unsigned int i = 0; i < m_addons_PreProc.size(); ++i)
   {
     startTime = CurrentHostCounter();
 
@@ -1374,7 +1374,7 @@ bool CActiveAEDSPProcess::Process(CSampleBuffer *in, CSampleBuffer *out)
    * or frequency/volume corrections, speaker distance handling, equalizer... .
    * All DSP addons allowed todo this and order of it set on settings.
    */
-  for (unsigned int i = 0; i < m_addons_PostProc.size(); i++)
+  for (unsigned int i = 0; i < m_addons_PostProc.size(); ++i)
   {
     startTime = CurrentHostCounter();
 
@@ -1448,7 +1448,7 @@ bool CActiveAEDSPProcess::RecheckProcessArray(unsigned int inputFrames)
       framesOut = framesNeeded;
   }
 
-  for (unsigned int i = 0; i < m_addons_PreProc.size(); i++)
+  for (unsigned int i = 0; i < m_addons_PreProc.size(); ++i)
   {
     framesNeeded = m_addons_PreProc[i].pAddon->PreProcessNeededSamplesize(&m_addons_PreProc[i].handle, m_addons_PreProc[i].iAddonModeNumber);
     if (framesNeeded > framesOut)
@@ -1462,7 +1462,7 @@ bool CActiveAEDSPProcess::RecheckProcessArray(unsigned int inputFrames)
       framesOut = framesNeeded;
   }
 
-  for (unsigned int i = 0; i < m_addons_PostProc.size(); i++)
+  for (unsigned int i = 0; i < m_addons_PostProc.size(); ++i)
   {
     framesNeeded = m_addons_PostProc[i].pAddon->PostProcessNeededSamplesize(&m_addons_PostProc[i].handle, m_addons_PostProc[i].iAddonModeNumber);
     if (framesNeeded > framesOut)
@@ -1489,7 +1489,7 @@ bool CActiveAEDSPProcess::RecheckProcessArray(unsigned int inputFrames)
 bool CActiveAEDSPProcess::ReallocProcessArray(unsigned int requestSize)
 {
   m_processArraySize = requestSize + MIN_DSP_ARRAY_SIZE / 10;
-  for (int i = 0; i < AE_DSP_CH_MAX; i++)
+  for (int i = 0; i < AE_DSP_CH_MAX; ++i)
   {
     m_processArray[0][i] = (float*)realloc(m_processArray[0][i], m_processArraySize*sizeof(float));
     m_processArray[1][i] = (float*)realloc(m_processArray[1][i], m_processArraySize*sizeof(float));
@@ -1523,7 +1523,7 @@ void CActiveAEDSPProcess::CalculateCPUUsage(unsigned int iTime)
       m_addon_InputResample.iLastTime = 0;
     }
 
-    for (unsigned int i = 0; i < m_addons_PreProc.size(); i++)
+    for (unsigned int i = 0; i < m_addons_PreProc.size(); ++i)
     {
       m_addons_PreProc[i].pMode->SetCPUUsage((float)(m_addons_PreProc[i].iLastTime)*dTFactor);
       m_addons_PreProc[i].iLastTime = 0;
@@ -1535,7 +1535,7 @@ void CActiveAEDSPProcess::CalculateCPUUsage(unsigned int iTime)
       m_addons_MasterProc[m_activeMode].iLastTime = 0;
     }
 
-    for (unsigned int i = 0; i < m_addons_PostProc.size(); i++)
+    for (unsigned int i = 0; i < m_addons_PostProc.size(); ++i)
     {
       m_addons_PostProc[i].pMode->SetCPUUsage((float)(m_addons_PostProc[i].iLastTime)*dTFactor);
       m_addons_PostProc[i].iLastTime = 0;
@@ -1691,13 +1691,13 @@ float CActiveAEDSPProcess::GetDelay()
   if (m_addon_InputResample.pAddon)
     delay += m_addon_InputResample.pAddon->InputResampleGetDelay(&m_addon_InputResample.handle);
 
-  for (unsigned int i = 0; i < m_addons_PreProc.size(); i++)
+  for (unsigned int i = 0; i < m_addons_PreProc.size(); ++i)
     delay += m_addons_PreProc[i].pAddon->PreProcessGetDelay(&m_addons_PreProc[i].handle, m_addons_PreProc[i].iAddonModeNumber);
 
   if (m_addons_MasterProc[m_activeMode].pAddon)
     delay += m_addons_MasterProc[m_activeMode].pAddon->MasterProcessGetDelay(&m_addons_MasterProc[m_activeMode].handle);
 
-  for (unsigned int i = 0; i < m_addons_PostProc.size(); i++)
+  for (unsigned int i = 0; i < m_addons_PostProc.size(); ++i)
     delay += m_addons_PostProc[i].pAddon->PostProcessGetDelay(&m_addons_PostProc[i].handle, m_addons_PostProc[i].iAddonModeNumber);
 
   if (m_addon_OutputResample.pAddon)
@@ -1749,14 +1749,14 @@ void CActiveAEDSPProcess::GetActiveModes(AE_DSP_MODE_TYPE type, std::vector<CAct
     modes.push_back(m_addon_InputResample.pMode);
 
   if (type == AE_DSP_MODE_TYPE_UNDEFINED || type == AE_DSP_MODE_TYPE_PRE_PROCESS)
-    for (unsigned int i = 0; i < m_addons_PreProc.size(); i++)
+    for (unsigned int i = 0; i < m_addons_PreProc.size(); ++i)
       modes.push_back(m_addons_PreProc[i].pMode);
 
   if (m_addons_MasterProc[m_activeMode].pAddon != NULL && (type == AE_DSP_MODE_TYPE_UNDEFINED || type == AE_DSP_MODE_TYPE_MASTER_PROCESS))
     modes.push_back(m_addons_MasterProc[m_activeMode].pMode);
 
   if (type == AE_DSP_MODE_TYPE_UNDEFINED || type == AE_DSP_MODE_TYPE_POST_PROCESS)
-    for (unsigned int i = 0; i < m_addons_PostProc.size(); i++)
+    for (unsigned int i = 0; i < m_addons_PostProc.size(); ++i)
       modes.push_back(m_addons_PostProc[i].pMode);
 
   if (m_addon_OutputResample.pAddon != NULL && (type == AE_DSP_MODE_TYPE_UNDEFINED || type == AE_DSP_MODE_TYPE_OUTPUT_RESAMPLE))
@@ -1767,7 +1767,7 @@ void CActiveAEDSPProcess::GetAvailableMasterModes(AE_DSP_STREAMTYPE streamType, 
 {
   CSingleLock lock(m_critSection);
 
-  for (unsigned int i = 0; i < m_addons_MasterProc.size(); i++)
+  for (unsigned int i = 0; i < m_addons_MasterProc.size(); ++i)
   {
     if (m_addons_MasterProc[i].pMode->SupportStreamType(streamType))
       modes.push_back(m_addons_MasterProc[i].pMode);
@@ -1845,7 +1845,7 @@ bool CActiveAEDSPProcess::IsMenuHookModeActive(AE_DSP_MENUHOOK_CAT category, int
 
   if (addons)
   {
-    for (unsigned int i = 0; i < addons->size(); i++)
+    for (unsigned int i = 0; i < addons->size(); ++i)
     {
       if (addons->at(i).iAddonModeNumber > 0 &&
           addons->at(i).pMode->AddonID() == iAddonId &&

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -478,13 +478,22 @@ bool CAddonsDirectory::GetDirectory(const CURL& url, CFileItemList &items)
     OrphanedAddons(path, items);
     return true;
   }
-  //Pvr hardcodes this view so keep for compatibility
-  else if (endpoint == "disabled" && path.GetFileName() == "xbmc.pvrclient")
+  // PVR & adsp hardcodes this view so keep for compatibility
+  else if (endpoint == "disabled")
   {
     VECADDONS addons;
-    if (CAddonMgr::GetInstance().GetAddons(ADDON_PVRDLL, addons, false))
+    ADDON::TYPE type;
+
+    if (path.GetFileName() == "xbmc.pvrclient")
+      type = ADDON_PVRDLL;
+    else if (path.GetFileName() == "kodi.adsp")
+      type = ADDON_ADSPDLL;
+    else
+      type = ADDON_UNKNOWN;
+
+    if (type != ADDON_UNKNOWN && CAddonMgr::GetInstance().GetAddons(type, addons, false))
     {
-      CAddonsDirectory::GenerateAddonListing(path, addons, items, TranslateType(ADDON_PVRDLL, true));
+      CAddonsDirectory::GenerateAddonListing(path, addons, items, TranslateType(type, true));
       return true;
     }
     return false;


### PR DESCRIPTION
This changes fix a crash of kodi if dsp system is enabled.

The `CApplicationMessenger::GetInstance().SendMsg(TMSG_SETAUDIODSPSTATE, ACTIVE_AE_DSP_STATE_ON);` was called two times on kodi's start and on one place it becomes removed in this request.

Also is a check added to prevent a activate/deactivate if already in this state.

Further is the place with wrong labels reported on #7562 removed, is not needed and was to report dsp enabled with no add-ons installed and to inform system becomes disabled.

On the last patch I'm unsure what is better, is about the add-on folder name which becomes selected if nothing is enabled.
What is better?
"addons://user/kodi.adsp" (Which is currently used from me)
or
"addons://" (To have everything)

This need also be fixed on PVR system and after I know the best folder name comes a other request for there.
