### PR TITLE
[pvr] fix invalid memory access in PVRGUIInfo

### DIFF
--- a/xbmc/pvr/PVRGUIInfo.cpp
+++ b/xbmc/pvr/PVRGUIInfo.cpp
@@ -68,10 +68,15 @@ void CPVRGUIInfo::ResetProperties(void)
   m_iRecordingTimerAmount       = 0;
   m_iCurrentActiveClient        = 0;
   m_strPlayingClientName        .clear();
+  m_strBackendName              .clear();
+  m_strBackendVersion           .clear();
+  m_strBackendHost              .clear();
   m_strBackendTimers            .clear();
   m_strBackendRecordings        .clear();
   m_strBackendDeletedRecordings .clear();
   m_strBackendChannels          .clear();
+  m_iBackendDiskTotal           = 0;
+  m_iBackendDiskUsed            = 0;
   m_iTimerInfoToggleStart       = 0;
   m_iTimerInfoToggleCurrent     = 0;
   m_ToggleShowInfo.SetInfinite();
@@ -87,6 +92,8 @@ void CPVRGUIInfo::ResetProperties(void)
 
   ResetPlayingTag();
   ClearQualityInfo(m_qualityInfo);
+
+  m_updateBackendCacheRequested = false;
 }
 
 void CPVRGUIInfo::ClearQualityInfo(PVR_SIGNAL_STATUS &qualityInfo)
@@ -173,6 +180,9 @@ void CPVRGUIInfo::Process(void)
   /* updated on request */
   g_PVRTimers->RegisterObserver(this);
   UpdateTimersCache();
+
+  /* update the backend cache once initially */
+  m_updateBackendCacheRequested = true;
 
   while (!g_application.m_bStop && !m_bStop)
   {
@@ -478,10 +488,8 @@ int CPVRGUIInfo::TranslateIntInfo(DWORD dwInfo) const
     iReturn = (int) ((float) m_qualityInfo.iSNR / 0xFFFF * 100);
   else if (dwInfo == PVR_BACKEND_DISKSPACE_PROGR)
   {
-    const auto &backend = GetCurrentActiveBackend();
-
-    if (backend.diskTotal > 0)
-      iReturn = static_cast<int>(100 * backend.diskUsed / backend.diskTotal);
+    if (m_iBackendDiskTotal > 0)
+      iReturn = static_cast<int>(100 * m_iBackendDiskUsed / m_iBackendDiskTotal);
     else
       iReturn = 0xFF;
   }
@@ -576,7 +584,7 @@ void CPVRGUIInfo::CharInfoBackendNumber(std::string &strValue) const
 
 void CPVRGUIInfo::CharInfoTotalDiskSpace(std::string &strValue) const
 {
-  strValue = StringUtils::SizeToString(GetCurrentActiveBackend().diskTotal).c_str();
+  strValue = StringUtils::SizeToString(m_iBackendDiskTotal).c_str();
 }
 
 void CPVRGUIInfo::CharInfoVideoBR(std::string &strValue) const
@@ -632,39 +640,28 @@ void CPVRGUIInfo::CharInfoFrontendStatus(std::string &strValue) const
 
 void CPVRGUIInfo::CharInfoBackendName(std::string &strValue) const
 {
-  const std::string &backendName = GetCurrentActiveBackend().name;
-
-  if (backendName.empty())
-    strValue = g_localizeStrings.Get(13205);
-  else
-    strValue = backendName;
+  m_updateBackendCacheRequested = true;
+  strValue = m_strBackendName;
 }
 
 void CPVRGUIInfo::CharInfoBackendVersion(std::string &strValue) const
 {
-  const std::string &backendVersion = GetCurrentActiveBackend().version;
-
-  if (backendVersion.empty())
-    strValue = g_localizeStrings.Get(13205);
-  else
-    strValue = backendVersion;
+  m_updateBackendCacheRequested = true;
+  strValue = m_strBackendVersion;
 }
 
 void CPVRGUIInfo::CharInfoBackendHost(std::string &strValue) const
 {
-  const std::string &backendHost = GetCurrentActiveBackend().host;
-
-  if (backendHost.empty())
-    strValue = g_localizeStrings.Get(13205);
-  else
-    strValue = backendHost;
+  m_updateBackendCacheRequested = true;
+  strValue = m_strBackendHost;
 }
 
 void CPVRGUIInfo::CharInfoBackendDiskspace(std::string &strValue) const
 {
-  const auto &backend = GetCurrentActiveBackend();
-  auto diskTotal = backend.diskTotal;
-  auto diskUsed = backend.diskUsed;
+  m_updateBackendCacheRequested = true;
+
+  auto diskTotal = m_iBackendDiskTotal;
+  auto diskUsed = m_iBackendDiskUsed;
 
   if (diskTotal > 0)
   {
@@ -678,34 +675,26 @@ void CPVRGUIInfo::CharInfoBackendDiskspace(std::string &strValue) const
 
 void CPVRGUIInfo::CharInfoBackendChannels(std::string &strValue) const
 {
-  if (m_strBackendChannels.empty())
-    strValue = g_localizeStrings.Get(13205);
-  else
-    strValue = m_strBackendChannels;
+  m_updateBackendCacheRequested = true;
+  strValue = m_strBackendChannels;
 }
 
 void CPVRGUIInfo::CharInfoBackendTimers(std::string &strValue) const
 {
-  if (m_strBackendTimers.empty())
-    strValue = g_localizeStrings.Get(13205);
-  else
-    strValue = m_strBackendTimers;
+  m_updateBackendCacheRequested = true;
+  strValue = m_strBackendTimers;
 }
 
 void CPVRGUIInfo::CharInfoBackendRecordings(std::string &strValue) const
 {
-  if (m_strBackendRecordings.empty())
-    strValue = g_localizeStrings.Get(13205);
-  else
-    strValue = m_strBackendRecordings;
+  m_updateBackendCacheRequested = true;
+  strValue = m_strBackendRecordings;
 }
 
 void CPVRGUIInfo::CharInfoBackendDeletedRecordings(std::string &strValue) const
 {
-  if (m_strBackendDeletedRecordings.empty())
-    strValue = g_localizeStrings.Get(13205); /* Unknown */
-  else
-    strValue = m_strBackendDeletedRecordings;
+  m_updateBackendCacheRequested = true;
+  strValue = m_strBackendDeletedRecordings;
 }
 
 void CPVRGUIInfo::CharInfoPlayingClientName(std::string &strValue) const
@@ -753,48 +742,59 @@ void CPVRGUIInfo::UpdateBackendCache(void)
 {
   CSingleLock lock(m_critSection);
 
-  // Update the backend information for all backends once per iteration
-  if (m_iCurrentActiveClient == 0)
+  // Update the backend information for all backends if
+  // an update has been requested
+  if (m_iCurrentActiveClient == 0 && m_updateBackendCacheRequested)
   {
     std::vector<SBackend> backendProperties;
     {
       CSingleExit exit(m_critSection);
       backendProperties = g_PVRClients->GetBackendProperties();
     }
+
     m_backendProperties = backendProperties;
+    m_updateBackendCacheRequested = false;
   }
 
-  // Get the properties for the currently active backend
-  const auto &backend = GetCurrentActiveBackend();
+  // Store some defaults
+  m_strBackendName = g_localizeStrings.Get(13205);
+  m_strBackendVersion = g_localizeStrings.Get(13205);
+  m_strBackendHost = g_localizeStrings.Get(13205);
+  m_strBackendChannels = g_localizeStrings.Get(13205);
+  m_strBackendTimers = g_localizeStrings.Get(13205);
+  m_strBackendRecordings = g_localizeStrings.Get(13205);
+  m_strBackendDeletedRecordings = g_localizeStrings.Get(13205);
+  m_iBackendDiskTotal = 0;
+  m_iBackendDiskUsed = 0;
 
-  if (backend.numChannels >= 0)
-    m_strBackendChannels = StringUtils::Format("%i", backend.numChannels);
-  else
-    m_strBackendChannels = g_localizeStrings.Get(161);
+  // Update with values from the current client when we have at least one
+  if (!m_backendProperties.empty())
+  {
+    const auto &backend = m_backendProperties[m_iCurrentActiveClient];
 
-  if (backend.numTimers >= 0)
-    m_strBackendTimers = StringUtils::Format("%i", backend.numTimers);
-  else
-    m_strBackendTimers = g_localizeStrings.Get(161);
+    m_strBackendName = backend.name;
+    m_strBackendVersion = backend.version;
+    m_strBackendHost = backend.host;
 
-  if (backend.numRecordings >= 0)
-    m_strBackendRecordings = StringUtils::Format("%i", backend.numRecordings);
-  else
-    m_strBackendRecordings = g_localizeStrings.Get(161);
+    if (backend.numChannels >= 0)
+      m_strBackendChannels = StringUtils::Format("%i", backend.numChannels);
 
-  if (backend.numDeletedRecordings >= 0)
-    m_strBackendDeletedRecordings = StringUtils::Format("%i", backend.numDeletedRecordings);
-  else
-    m_strBackendDeletedRecordings = g_localizeStrings.Get(161);
+    if (backend.numTimers >= 0)
+      m_strBackendTimers = StringUtils::Format("%i", backend.numTimers);
+
+    if (backend.numRecordings >= 0)
+      m_strBackendRecordings = StringUtils::Format("%i", backend.numRecordings);
+
+    if (backend.numDeletedRecordings >= 0)
+      m_strBackendDeletedRecordings = StringUtils::Format("%i", backend.numDeletedRecordings);
+
+    m_iBackendDiskTotal = backend.diskTotal;
+    m_iBackendDiskUsed = backend.diskUsed;
+  }
 
   // Update the current active client, eventually wrapping around
   if (++m_iCurrentActiveClient >= m_backendProperties.size())
     m_iCurrentActiveClient = 0;
-}
-
-const SBackend& CPVRGUIInfo::GetCurrentActiveBackend() const
-{
-  return m_backendProperties[m_iCurrentActiveClient];
 }
 
 void CPVRGUIInfo::UpdateTimersCache(void)

--- a/xbmc/pvr/PVRGUIInfo.h
+++ b/xbmc/pvr/PVRGUIInfo.h
@@ -26,6 +26,8 @@
 #include "threads/Thread.h"
 #include "utils/Observer.h"
 
+#include <atomic>
+
 namespace EPG
 {
   class CEpgInfoTag;
@@ -102,8 +104,6 @@ namespace PVR
     void UpdateNextTimer(void);
     void UpdateTimeshift(void);
 
-    const SBackend& GetCurrentActiveBackend() const;
-
     bool TimerInfoToggle(void);
     void UpdateTimersToggle(void);
     void ToggleShowInfo(void);
@@ -163,10 +163,15 @@ namespace PVR
     unsigned int                    m_iRecordingTimerAmount;
     unsigned int                    m_iCurrentActiveClient;
     std::string                     m_strPlayingClientName;
+    std::string                     m_strBackendName;
+    std::string                     m_strBackendVersion;
+    std::string                     m_strBackendHost;
     std::string                     m_strBackendTimers;
     std::string                     m_strBackendRecordings;
     std::string                     m_strBackendDeletedRecordings;
     std::string                     m_strBackendChannels;
+    long long                       m_iBackendDiskTotal;
+    long long                       m_iBackendDiskUsed;
     unsigned int                    m_iDuration;
 
     bool                            m_bHasNonRecordingTimers;
@@ -195,5 +200,13 @@ namespace PVR
     std::string                     m_strTimeshiftPlayTime;
 
     CCriticalSection                m_critSection;
+
+    /**
+     * The various backend-related fields will only be updated when this
+     * flag is set. This is done to limit the amount of unnecessary
+     * backend querying when we're not displaying any of the queried
+     * information.
+     */
+    mutable std::atomic<bool>       m_updateBackendCacheRequested;
   };
 }


### PR DESCRIPTION
Some skins allow access to PVR windows before the manager has been started, which results in a segmentation fault since we have no "current backend" to display information for. This fixes it by storing the GUI values as members instead of trying to get them directly from the stored "backend".

@ksooo @xhaggi 

Needs backport.
