### PR TITLE
AdjustRefreshrate: Switch to higher resolution depending on source dims

### DIFF
--- a/xbmc/cores/VideoRenderers/BaseRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/BaseRenderer.cpp
@@ -20,6 +20,7 @@
 
 #include "system.h"
 
+#include <cstdlib> // std::abs(int) prototype
 #include <algorithm>
 #include "BaseRenderer.h"
 #include "settings/DisplaySettings.h"
@@ -222,10 +223,19 @@ void CBaseRenderer::FindResolutionFromFpsMatch(float fps, float& weight)
 RESOLUTION CBaseRenderer::FindClosestResolution(float fps, float multiplier, RESOLUTION current, float& weight)
 {
   RESOLUTION_INFO curr = g_graphicsContext.GetResInfo(current);
+  RESOLUTION orig_res  = CDisplaySettings::GetInstance().GetCurrentResolution();
+
+  if (orig_res <= RES_DESKTOP)
+    orig_res = RES_DESKTOP;
+
+  RESOLUTION_INFO orig = g_graphicsContext.GetResInfo(orig_res);
 
   float fRefreshRate = fps;
 
   float last_diff = fRefreshRate;
+
+  int curr_diff = std::abs((int) m_sourceWidth - curr.iScreenWidth);
+  int loop_diff = 0;
 
   // Find closest refresh rate
   for (size_t i = (int)RES_DESKTOP; i < CDisplaySettings::GetInstance().ResolutionInfoSize(); i++)
@@ -239,7 +249,24 @@ RESOLUTION CBaseRenderer::FindClosestResolution(float fps, float multiplier, RES
     ||  info.iScreen       != curr.iScreen
     ||  (info.dwFlags & D3DPRESENTFLAG_MODEMASK) != (curr.dwFlags & D3DPRESENTFLAG_MODEMASK)
     ||  info.fRefreshRate < (fRefreshRate * multiplier / 1.001) - 0.001)
-      continue;
+    {
+      // evaluate all higher modes and evalute them
+      // concerning dimension and refreshrate weight
+      // skip lower resolutions
+      if (((int) m_sourceWidth < orig.iScreenWidth) // orig res large enough
+      || (info.iScreenWidth < orig.iScreenWidth) // new res is smaller
+      || (info.dwFlags & D3DPRESENTFLAG_MODEMASK) != (curr.dwFlags & D3DPRESENTFLAG_MODEMASK)) // don't switch to interlaced modes
+      {
+        continue;
+      }
+    }
+
+    // Allow switching to larger resolution:
+    // e.g. if m_sourceWidth == 3840 and we have a 3840 mode - use this one
+    // if it has a matching fps mode, which is evaluated below
+
+    loop_diff = std::abs((int) m_sourceWidth - info.iScreenWidth);
+    curr_diff = std::abs((int) m_sourceWidth - curr.iScreenWidth);
 
     // For 3D choose the closest refresh rate 
     if(CONF_FLAGS_STEREO_MODE_MASK(m_iFlags))
@@ -260,12 +287,30 @@ RESOLUTION CBaseRenderer::FindClosestResolution(float fps, float multiplier, RES
       int c_weight = MathUtils::round_int(RefreshWeight(curr.fRefreshRate, fRefreshRate * multiplier) * 1000.0);
       int i_weight = MathUtils::round_int(RefreshWeight(info.fRefreshRate, fRefreshRate * multiplier) * 1000.0);
 
+      RESOLUTION current_bak = current;
+      RESOLUTION_INFO curr_bak = curr;
+
       // Closer the better, prefer higher refresh rate if the same
       if ((i_weight <  c_weight)
       ||  (i_weight == c_weight && info.fRefreshRate > curr.fRefreshRate))
       {
         current = (RESOLUTION)i;
         curr    = info;
+      }
+      // use case 1080p50 vs 3840x2160@25 for 3840@25 content
+      // prefer the higher resolution of 3840
+      if (i_weight == c_weight && (loop_diff < curr_diff))
+      {
+        current = (RESOLUTION)i;
+        curr    = info;
+      }
+      // same as above but iterating with 3840@25 set and overwritten
+      // by e.g. 1080@50 - restore backup in that case
+      // to give priority to the better matching width
+      if (i_weight == c_weight && (loop_diff > curr_diff))
+      {
+        current = current_bak;
+        curr    = curr_bak;
       }
     }
   }


### PR DESCRIPTION
v2: Unify logging
v3: incorporate width difference into decision

This implements a long requested feature. Consider the use case, that you are using a HDMI 1.4b hdmi out to a 4k@30p TV. As additinionally our GUI upscaling method is of low quality and as you want to watch content > 30 hz, you are running your TV at 1080p50/60.

Now the requested feature was:
- Switch to a 4k mode if content is 4k and in the supported refreshrate range that is supported by the TV.

That is what this PR does. Additionally it takes care that 3840x2160 content is displayed at 3840x2160 content and larger content is displayed at 4096x1744 if available.

Content that cannot be display without sever frame skipping, e.g. 3840x2160@60p will be rendered at the max resolution supporting this refreshrate, e.g. 1080p60.

This was tested by forum user fab67. Discussion was done with @FernetMenta in advance. Algorithm and code was shown and discussed @paxxi on IRC.
