### PR TITLE
[pvr] fix/improve RDS parts

### DIFF
--- a/addons/skin.confluence/720p/DialogPVRRadioRDSInfo.xml
+++ b/addons/skin.confluence/720p/DialogPVRRadioRDSInfo.xml
@@ -870,7 +870,7 @@
 			</control>
 		</control>
 
-		<control type="group">
+		<control type="group" id="70">
 			<description>Radio text info list</description>
 			<left>40</left>
 			<top>455</top>

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1356,11 +1356,8 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
     else if (cat.name == "rds")
     {
       if (prop.name == "getline")
-      {
-        std::string cat = prop.param(0);
-        StringUtils::ToLower(cat);
-        return AddMultiInfo(GUIInfo(RDS_GET_RADIOTEXT_LINE, atoi(cat.c_str())));
-      }
+        return AddMultiInfo(GUIInfo(RDS_GET_RADIOTEXT_LINE, atoi(prop.param(0).c_str())));
+
       for (size_t i = 0; i < sizeof(rds) / sizeof(infomap); i++)
       {
         if (prop.name == rds[i].str)

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -3947,7 +3947,7 @@ std::string CGUIInfoManager::GetRadioRDSLabel(int item)
 
   case RDS_ALBUM_TRACKNUMBER:
     {
-      if (!tag.GetAlbumTrackNumber() > 0)
+      if (tag.GetAlbumTrackNumber() > 0)
         return StringUtils::Format("%i", tag.GetAlbumTrackNumber());
       break;
     }

--- a/xbmc/cores/dvdplayer/DVDPlayerRadioRDS.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerRadioRDS.cpp
@@ -24,7 +24,7 @@
 /*
  * The RDS decoder bases partly on the source of the VDR radio plugin.
  * http://www.egal-vdr.de/plugins/
- * and reworked a bit with references from SPB 490, IEC62106 
+ * and reworked a bit with references from SPB 490, IEC62106
  * and several other documents.
  *
  * A lot more information is sendet which is currently unused and partly
@@ -321,7 +321,7 @@ enum {
 };
 
 /* page 71, Annex D, table D.1 in the standard and Annex N */
-const char *piCountryCodes_A[15][7]=
+static const char *piCountryCodes_A[15][7]=
 {
   // 0   1    2    3    4    5    6
   {"US","__","AI","BO","GT","__","__"}, // 1
@@ -341,7 +341,7 @@ const char *piCountryCodes_A[15][7]=
   {"__","GL","BS","GY","__","VG","PM"}  // F
 };
 
-const char *piCountryCodes_D[15][7]=
+static const char *piCountryCodes_D[15][7]=
 {
   // 0   1    2    3    4    5    6
   {"CM","NA","SL","__","__","__","__"}, // 1
@@ -361,7 +361,7 @@ const char *piCountryCodes_D[15][7]=
   {"MW","NG","__","__","__","__","__"}  // F
 };
 
-const char *piCountryCodes_E[15][7]=
+static const char *piCountryCodes_E[15][7]=
 {
   // 0   1    2    3    4    5    6
   {"DE","GR","MA","__","MD","__","__"},
@@ -381,7 +381,7 @@ const char *piCountryCodes_E[15][7]=
   {"EG","FR","NO","BY","BA","__","__"}  // F
 };
 
-const char *piCountryCodes_F[15][7]=
+static const char *piCountryCodes_F[15][7]=
 {
   // 0   1    2    3    4    5    6
   {"AU","KI","KW","LA","__","__","__"}, // 1
@@ -402,7 +402,7 @@ const char *piCountryCodes_F[15][7]=
 };
 
 /* see page 84, Annex J in the standard */
-const std::string piRDSLanguageCodes[128]=
+static const std::string piRDSLanguageCodes[128]=
 {
   // 0      1      2      3      4      5      6      7      8      9      A      B      C      D      E      F
   "___", "alb", "bre", "cat", "hrv", "wel", "cze", "dan", "ger", "eng", "spa", "epo", "est", "baq", "fae", "fre", // 0
@@ -418,23 +418,23 @@ const std::string piRDSLanguageCodes[128]=
 /* ----------------------------------------------------------------------------------------------------------- */
 
 #define EntityChars 56
-const char *entitystr[EntityChars]  = { "&apos;",   "&amp;",    "&quot;",  "&gt",      "&lt",      "&copy;",   "&times;", "&nbsp;",
-                                        "&Auml;",   "&auml;",   "&Ouml;",  "&ouml;",   "&Uuml;",   "&uuml;",   "&szlig;", "&deg;",
-                                        "&Agrave;", "&Aacute;", "&Acirc;", "&Atilde;", "&agrave;", "&aacute;", "&acirc;", "&atilde;",
-                                        "&Egrave;", "&Eacute;", "&Ecirc;", "&Euml;",   "&egrave;", "&eacute;", "&ecirc;", "&euml;",
-                                        "&Igrave;", "&Iacute;", "&Icirc;", "&Iuml;",   "&igrave;", "&iacute;", "&icirc;", "&iuml;",
-                                        "&Ograve;", "&Oacute;", "&Ocirc;", "&Otilde;", "&ograve;", "&oacute;", "&ocirc;", "&otilde;",
-                                        "&Ugrave;", "&Uacute;", "&Ucirc;", "&Ntilde;", "&ugrave;", "&uacute;", "&ucirc;", "&ntilde;" };
-const char *entitychar[EntityChars] = { "'",        "&",        "\"",      ">",        "<",         "c",        "*",      " ",
-                                        "Ä",        "ä",        "Ö",       "ö",        "Ü",         "ü",        "ß",      "°",
-                                        "À",        "Á",        "Â",       "Ã",        "à",         "á",        "â",      "ã",
-                                        "È",        "É",        "Ê",       "Ë",        "è",         "é",        "ê",      "ë",
-                                        "Ì",        "Í",        "Î",       "Ï",        "ì",         "í",        "î",      "ï",
-                                        "Ò",        "Ó",        "Ô",       "Õ",        "ò",         "ó",        "ô",      "õ",
-                                        "Ù",        "Ú",        "Û",       "Ñ",        "ù",         "ú",        "û",      "ñ" };
+static const char *entitystr[EntityChars]  = { "&apos;",   "&amp;",    "&quot;",  "&gt",      "&lt",      "&copy;",   "&times;", "&nbsp;",
+                                               "&Auml;",   "&auml;",   "&Ouml;",  "&ouml;",   "&Uuml;",   "&uuml;",   "&szlig;", "&deg;",
+                                               "&Agrave;", "&Aacute;", "&Acirc;", "&Atilde;", "&agrave;", "&aacute;", "&acirc;", "&atilde;",
+                                               "&Egrave;", "&Eacute;", "&Ecirc;", "&Euml;",   "&egrave;", "&eacute;", "&ecirc;", "&euml;",
+                                               "&Igrave;", "&Iacute;", "&Icirc;", "&Iuml;",   "&igrave;", "&iacute;", "&icirc;", "&iuml;",
+                                               "&Ograve;", "&Oacute;", "&Ocirc;", "&Otilde;", "&ograve;", "&oacute;", "&ocirc;", "&otilde;",
+                                               "&Ugrave;", "&Uacute;", "&Ucirc;", "&Ntilde;", "&ugrave;", "&uacute;", "&ucirc;", "&ntilde;" };
+static const char *entitychar[EntityChars] = { "'",        "&",        "\"",      ">",        "<",         "c",        "*",      " ",
+                                               "Ä",        "ä",        "Ö",       "ö",        "Ü",         "ü",        "ß",      "°",
+                                               "À",        "Á",        "Â",       "Ã",        "à",         "á",        "â",      "ã",
+                                               "È",        "É",        "Ê",       "Ë",        "è",         "é",        "ê",      "ë",
+                                               "Ì",        "Í",        "Î",       "Ï",        "ì",         "í",        "î",      "ï",
+                                               "Ò",        "Ó",        "Ô",       "Õ",        "ò",         "ó",        "ô",      "õ",
+                                               "Ù",        "Ú",        "Û",       "Ñ",        "ù",         "ú",        "û",      "ñ" };
 
 // RDS-Chartranslation: 0x80..0xff
-unsigned char sRDSAddChar[128] =
+static unsigned char sRDSAddChar[128] =
 {
   0xe1, 0xe0, 0xe9, 0xe8, 0xed, 0xec, 0xf3, 0xf2,
   0xfa, 0xf9, 0xd1, 0xc7, 0x8c, 0xdf, 0x8e, 0x8f,
@@ -454,7 +454,7 @@ unsigned char sRDSAddChar[128] =
   0xfe, 0xf9, 0xfa, 0xfb, 0xfc, 0xfd, 0xfe, 0xff
 };
 
-char *rds_entitychar(char *text)
+static char *rds_entitychar(char *text)
 {
   int i = 0, l, lof, lre, space;
   char *temp;
@@ -481,23 +481,25 @@ char *rds_entitychar(char *text)
         memmove(text+lof+1+lre, "       ", l-1);
     }
     else
-      i++;
+      ++i;
   }
 
   return text;
 }
 
-unsigned short crc16_ccitt(const unsigned char *daten, int len, bool skipfirst)
+static unsigned short crc16_ccitt(const unsigned char *data, int len, bool skipfirst)
 {
   // CRC16-CCITT: x^16 + x^12 + x^5 + 1
   // with start 0xffff and result invers
-  register unsigned short crc = 0xffff;
+  unsigned short crc = 0xffff;
 
-  if (skipfirst) daten++;
+  if (skipfirst)
+    ++data;
+
   while (len--)
   {
     crc = (crc >> 8) | (crc << 8);
-    crc ^= *daten++;
+    crc ^= *data++;
     crc ^= (crc & 0xff) >> 4;
     crc ^= (crc << 8) << 4;
     crc ^= ((crc & 0xff) << 4) << 1;
@@ -583,7 +585,7 @@ void CDVDRadioRDSData::ResetRDSCache()
 
   m_PS_Present = false;
   m_PS_Index = 0;
-  for (int i = 0; i < PS_TEXT_ENTRIES; i++)
+  for (int i = 0; i < PS_TEXT_ENTRIES; ++i)
   {
     memset(m_PS_Text[i], 0x20, 8);
     m_PS_Text[i][8] = 0;
@@ -608,7 +610,7 @@ void CDVDRadioRDSData::ResetRDSCache()
   m_RT_MaxSize = 4;
   m_RT_NewItem = false;
   m_RT_Index = 0;
-  for (int i = 0; i < 5; i++)
+  for (int i = 0; i < 5; ++i)
     memset(m_RT_Text[i], 0, RT_MEL);
   m_RT.clear();
 
@@ -714,12 +716,12 @@ std::string CDVDRadioRDSData::GetRadioText(unsigned int line)
   {
     std::string temp = "";
     int ind = (m_PS_Index == 0) ? 11 : m_PS_Index - 1;
-    for (int i = ind+1; i < PS_TEXT_ENTRIES; i++)
+    for (int i = ind+1; i < PS_TEXT_ENTRIES; ++i)
     {
       temp += m_PS_Text[i];
       temp += ' ';
     }
-    for (int i = 0; i <= ind; i++)
+    for (int i = 0; i <= ind; ++i)
     {
       temp += m_PS_Text[i];
       temp += ' ';
@@ -744,7 +746,7 @@ void CDVDRadioRDSData::SetRadioStyle(std::string genre)
 
 void CDVDRadioRDSData::ProcessUECP(const unsigned char *data, unsigned int len)
 {
-  for (unsigned int i = 0; i < len; i++)
+  for (unsigned int i = 0; i < len; ++i)
   {
     if (data[i] == UECP_DATA_START)                               //!< Start
     {
@@ -882,13 +884,13 @@ unsigned int CDVDRadioRDSData::DecodePS(uint8_t *msgElement)
 {
   uint8_t *text = msgElement+3;
 
-  for (int i = 0; i < 8; i++)
+  for (int i = 0; i < 8; ++i)
   {
     if (text[i] <= 0xfe)
       m_PS_Text[m_PS_Index][i] = (text[i] >= 0x80) ? sRDSAddChar[text[i]-0x80] : text[i]; //!< additional rds-character, see RBDS-Standard, Annex E
   }
 
-  m_PS_Index++;
+  ++m_PS_Index;
   if (m_PS_Index >= PS_TEXT_ENTRIES)
     m_PS_Index = 0;
 
@@ -1048,7 +1050,7 @@ unsigned int CDVDRadioRDSData::DecodePTYN(uint8_t *msgElement)
   // decode Text
   uint8_t *text = msgElement+3;
 
-  for (int i = 0; i < 8; i++)
+  for (int i = 0; i < 8; ++i)
   {
     if (text[i] <= 0xfe)
       m_PTYN[i] = (text[i] >= 0x80) ? sRDSAddChar[text[i]-0x80] : text[i];
@@ -1096,7 +1098,7 @@ unsigned int CDVDRadioRDSData::DecodeRT(uint8_t *msgElement, unsigned int len)
   {
     m_RT.clear();
     m_RT_Index = 0;
-    for (int i = 0; i < 5; i++)
+    for (int i = 0; i < 5; ++i)
       memset(m_RT_Text[i], 0, RT_MEL);
   }
   else
@@ -1108,7 +1110,7 @@ unsigned int CDVDRadioRDSData::DecodeRT(uint8_t *msgElement, unsigned int len)
     //! byte 4 = RT-Status bitcodet (0=AB-flagcontrol, 1-4=Transmission-Number, 5+6=Buffer-Config, ingnored, always 0x01 ?)
     char temptext[RT_MEL];
     memset(temptext, 0x0, RT_MEL);
-    for (unsigned int i = 1, ii = 0; i < msgLength; i++)
+    for (unsigned int i = 1, ii = 0; i < msgLength; ++i)
     {
       if (msgElement[UECP_ME_DATA+i] <= 0xfe) // additional rds-character, see RBDS-Standard, Annex E
         temptext[ii++] = (msgElement[UECP_ME_DATA+i] >= 0x80) ? sRDSAddChar[msgElement[UECP_ME_DATA+i]-0x80] : msgElement[UECP_ME_DATA+i];
@@ -1118,7 +1120,7 @@ unsigned int CDVDRadioRDSData::DecodeRT(uint8_t *msgElement, unsigned int len)
 
     // check repeats
     bool repeat = false;
-    for (int ind = 0; ind < m_RT_MaxSize; ind++)
+    for (int ind = 0; ind < m_RT_MaxSize; ++ind)
     {
       if (memcmp(m_RT_Text[ind], temptext, RT_MEL) == 0)
         repeat = true;
@@ -1135,7 +1137,7 @@ unsigned int CDVDRadioRDSData::DecodeRT(uint8_t *msgElement, unsigned int len)
       if ((int)m_RT.size() > m_RT_MaxSize)
         m_RT.pop_back();
 
-      m_RT_Index++;
+      ++m_RT_Index;
       if (m_RT_Index >= m_RT_MaxSize)
         m_RT_Index = 0;
     }
@@ -1253,7 +1255,7 @@ unsigned int CDVDRadioRDSData::DecodeRTPlus(uint8_t *msgElement, unsigned int le
   // save info
   MUSIC_INFO::CMusicInfoTag *currentMusic = g_application.CurrentFileItem().GetMusicInfoTag();
 
-  for (int i = 0; i < 2; i++)
+  for (int i = 0; i < 2; ++i)
   {
     if (rtp_start[i]+rtp_len[i]+1 >= RT_MEL)  // length-error
     {
@@ -1636,8 +1638,8 @@ unsigned int CDVDRadioRDSData::DecodeSlowLabelingCodes(uint8_t *msgElement)
         CLog::Log(LOGERROR, "Radio RDS - %s - invalid language code %i", __FUNCTION__, slowLabellingCode);
       break;
 
-    case VARCODE_TMC_IDENT:      // TMC identification
-    case VARCODE_PAGING_IDENT:      // Paging identification
+    case VARCODE_TMC_IDENT:           // TMC identification
+    case VARCODE_PAGING_IDENT:        // Paging identification
     case VARCODE_OWN_BROADCASTER:
     case VARCODE_EWS_CHANNEL_IDENT:
     default:

--- a/xbmc/pvr/channels/PVRRadioRDSInfoTag.cpp
+++ b/xbmc/pvr/channels/PVRRadioRDSInfoTag.cpp
@@ -372,7 +372,6 @@ const std::string CPVRRadioRDSInfoTag::GetInfoNews() const
   for (unsigned i = 0; i < m_strInfoNews.size(); i++)
   {
     std::string tmpStr = m_strInfoNews[i];
-    tmpStr.insert(0, "- ");
     tmpStr.insert(tmpStr.end(),'\n');
     retStr += tmpStr;
   }
@@ -417,7 +416,6 @@ const std::string CPVRRadioRDSInfoTag::GetInfoNewsLocal() const
   for (unsigned i = 0; i < m_strInfoNewsLocal.size(); i++)
   {
     std::string tmpStr = m_strInfoNewsLocal[i];
-    tmpStr.insert(0, "- ");
     tmpStr.insert(tmpStr.end(),'\n');
     retStr += tmpStr;
   }
@@ -462,7 +460,6 @@ const std::string CPVRRadioRDSInfoTag::GetInfoSport() const
   for (unsigned i = 0; i < m_strInfoSport.size(); i++)
   {
     std::string tmpStr = m_strInfoSport[i];
-    tmpStr.insert(0, "- ");
     tmpStr.insert(tmpStr.end(),'\n');
     retStr += tmpStr;
   }
@@ -507,7 +504,6 @@ const std::string CPVRRadioRDSInfoTag::GetInfoStock() const
   for (unsigned i = 0; i < m_strInfoStock.size(); i++)
   {
     std::string tmpStr = m_strInfoStock[i];
-    tmpStr.insert(0, "- ");
     tmpStr.insert(tmpStr.end(),'\n');
     retStr += tmpStr;
   }
@@ -551,7 +547,6 @@ const std::string CPVRRadioRDSInfoTag::GetInfoWeather() const
   for (unsigned i = 0; i < m_strInfoWeather.size(); i++)
   {
     std::string tmpStr = m_strInfoWeather[i];
-    tmpStr.insert(0, "- ");
     tmpStr.insert(tmpStr.end(),'\n');
     retStr += tmpStr;
   }
@@ -595,7 +590,6 @@ const std::string CPVRRadioRDSInfoTag::GetInfoLottery() const
   for (unsigned i = 0; i < m_strInfoLottery.size(); i++)
   {
     std::string tmpStr = m_strInfoLottery[i];
-    tmpStr.insert(0, "- ");
     tmpStr.insert(tmpStr.end(),'\n');
     retStr += tmpStr;
   }
@@ -639,7 +633,6 @@ const std::string CPVRRadioRDSInfoTag::GetEditorialStaff() const
   for (unsigned i = 0; i < m_strEditorialStaff.size(); i++)
   {
     std::string tmpStr = m_strEditorialStaff[i];
-    tmpStr.insert(0, "- ");
     tmpStr.insert(tmpStr.end(),'\n');
     retStr += tmpStr;
   }
@@ -683,7 +676,6 @@ const std::string CPVRRadioRDSInfoTag::GetInfoHoroscope() const
   for (unsigned i = 0; i < m_strInfoHoroscope.size(); i++)
   {
     std::string tmpStr = m_strInfoHoroscope[i];
-    tmpStr.insert(0, "- ");
     tmpStr.insert(tmpStr.end(),'\n');
     retStr += tmpStr;
   }
@@ -727,7 +719,6 @@ const std::string CPVRRadioRDSInfoTag::GetInfoCinema() const
   for (unsigned i = 0; i < m_strInfoCinema.size(); i++)
   {
     std::string tmpStr = m_strInfoCinema[i];
-    tmpStr.insert(0, "- ");
     tmpStr.insert(tmpStr.end(),'\n');
     retStr += tmpStr;
   }
@@ -771,7 +762,6 @@ const std::string CPVRRadioRDSInfoTag::GetInfoOther() const
   for (unsigned i = 0; i < m_strInfoOther.size(); i++)
   {
     std::string tmpStr = m_strInfoOther[i];
-    tmpStr.insert(0, "- ");
     tmpStr.insert(tmpStr.end(),'\n');
     retStr += tmpStr;
   }

--- a/xbmc/pvr/channels/PVRRadioRDSInfoTag.cpp
+++ b/xbmc/pvr/channels/PVRRadioRDSInfoTag.cpp
@@ -340,7 +340,7 @@ void CPVRRadioRDSInfoTag::SetInfoNews(const std::string& strNews)
   std::string tmpStr = Trim(strNews);
   g_charsetConverter.unknownToUTF8(tmpStr);
 
-  for (unsigned i = 0; i < m_strInfoNews.size(); i++)
+  for (unsigned i = 0; i < m_strInfoNews.size(); ++i)
   {
     if (m_strInfoNews[i].compare(tmpStr) == 0)
       return;
@@ -369,7 +369,7 @@ const std::deque<std::string>& CPVRRadioRDSInfoTag::GetInfoNewsDeque() const
 const std::string CPVRRadioRDSInfoTag::GetInfoNews() const
 {
   std::string retStr = "";
-  for (unsigned i = 0; i < m_strInfoNews.size(); i++)
+  for (unsigned i = 0; i < m_strInfoNews.size(); ++i)
   {
     std::string tmpStr = m_strInfoNews[i];
     tmpStr.insert(tmpStr.end(),'\n');
@@ -384,7 +384,7 @@ void CPVRRadioRDSInfoTag::SetInfoNewsLocal(const std::string& strNews)
   std::string tmpStr = Trim(strNews);
   g_charsetConverter.unknownToUTF8(tmpStr);
 
-  for (unsigned i = 0; i < m_strInfoNewsLocal.size(); i++)
+  for (unsigned i = 0; i < m_strInfoNewsLocal.size(); ++i)
   {
     if (m_strInfoNewsLocal[i].compare(tmpStr) == 0)
       return;
@@ -413,7 +413,7 @@ const std::deque<std::string>& CPVRRadioRDSInfoTag::GetInfoNewsLocalDeque() cons
 const std::string CPVRRadioRDSInfoTag::GetInfoNewsLocal() const
 {
   std::string retStr = "";
-  for (unsigned i = 0; i < m_strInfoNewsLocal.size(); i++)
+  for (unsigned i = 0; i < m_strInfoNewsLocal.size(); ++i)
   {
     std::string tmpStr = m_strInfoNewsLocal[i];
     tmpStr.insert(tmpStr.end(),'\n');
@@ -428,7 +428,7 @@ void CPVRRadioRDSInfoTag::SetInfoSport(const std::string& strSport)
   std::string tmpStr = Trim(strSport);
   g_charsetConverter.unknownToUTF8(tmpStr);
 
-  for (unsigned i = 0; i < m_strInfoSport.size(); i++)
+  for (unsigned i = 0; i < m_strInfoSport.size(); ++i)
   {
     if (m_strInfoSport[i].compare(tmpStr) == 0)
       return;
@@ -457,7 +457,7 @@ const std::deque<std::string>& CPVRRadioRDSInfoTag::GetInfoSportDeque() const
 const std::string CPVRRadioRDSInfoTag::GetInfoSport() const
 {
   std::string retStr = "";
-  for (unsigned i = 0; i < m_strInfoSport.size(); i++)
+  for (unsigned i = 0; i < m_strInfoSport.size(); ++i)
   {
     std::string tmpStr = m_strInfoSport[i];
     tmpStr.insert(tmpStr.end(),'\n');
@@ -472,7 +472,7 @@ void CPVRRadioRDSInfoTag::SetInfoStock(const std::string& strStock)
   std::string tmpStr = Trim(strStock);
   g_charsetConverter.unknownToUTF8(tmpStr);
 
-  for (unsigned i = 0; i < m_strInfoStock.size(); i++)
+  for (unsigned i = 0; i < m_strInfoStock.size(); ++i)
   {
     if (m_strInfoStock[i].compare(tmpStr) == 0)
       return;
@@ -501,7 +501,7 @@ const std::deque<std::string>& CPVRRadioRDSInfoTag::GetInfoStockDeque() const
 const std::string CPVRRadioRDSInfoTag::GetInfoStock() const
 {
   std::string retStr = "";
-  for (unsigned i = 0; i < m_strInfoStock.size(); i++)
+  for (unsigned i = 0; i < m_strInfoStock.size(); ++i)
   {
     std::string tmpStr = m_strInfoStock[i];
     tmpStr.insert(tmpStr.end(),'\n');
@@ -516,7 +516,7 @@ void CPVRRadioRDSInfoTag::SetInfoWeather(const std::string& strWeather)
   std::string tmpStr = Trim(strWeather);
   g_charsetConverter.unknownToUTF8(tmpStr);
 
-  for (unsigned i = 0; i < m_strInfoWeather.size(); i++)
+  for (unsigned i = 0; i < m_strInfoWeather.size(); ++i)
   {
     if (m_strInfoWeather[i].compare(tmpStr) == 0)
       return;
@@ -544,7 +544,7 @@ const std::deque<std::string>& CPVRRadioRDSInfoTag::GetInfoWeatherDeque() const
 const std::string CPVRRadioRDSInfoTag::GetInfoWeather() const
 {
   std::string retStr = "";
-  for (unsigned i = 0; i < m_strInfoWeather.size(); i++)
+  for (unsigned i = 0; i < m_strInfoWeather.size(); ++i)
   {
     std::string tmpStr = m_strInfoWeather[i];
     tmpStr.insert(tmpStr.end(),'\n');
@@ -559,7 +559,7 @@ void CPVRRadioRDSInfoTag::SetInfoLottery(const std::string& strLottery)
   std::string tmpStr = Trim(strLottery);
   g_charsetConverter.unknownToUTF8(tmpStr);
 
-  for (unsigned i = 0; i < m_strInfoLottery.size(); i++)
+  for (unsigned i = 0; i < m_strInfoLottery.size(); ++i)
   {
     if (m_strInfoLottery[i].compare(tmpStr) == 0)
       return;
@@ -587,7 +587,7 @@ const std::deque<std::string>& CPVRRadioRDSInfoTag::GetInfoLotteryDeque() const
 const std::string CPVRRadioRDSInfoTag::GetInfoLottery() const
 {
   std::string retStr = "";
-  for (unsigned i = 0; i < m_strInfoLottery.size(); i++)
+  for (unsigned i = 0; i < m_strInfoLottery.size(); ++i)
   {
     std::string tmpStr = m_strInfoLottery[i];
     tmpStr.insert(tmpStr.end(),'\n');
@@ -602,7 +602,7 @@ void CPVRRadioRDSInfoTag::SetEditorialStaff(const std::string& strEditorialStaff
   std::string tmpStr = Trim(strEditorialStaff);
   g_charsetConverter.unknownToUTF8(tmpStr);
 
-  for (unsigned i = 0; i < m_strEditorialStaff.size(); i++)
+  for (unsigned i = 0; i < m_strEditorialStaff.size(); ++i)
   {
     if (m_strEditorialStaff[i].compare(tmpStr) == 0)
       return;
@@ -630,7 +630,7 @@ const std::deque<std::string>& CPVRRadioRDSInfoTag::GetEditorialStaffDeque() con
 const std::string CPVRRadioRDSInfoTag::GetEditorialStaff() const
 {
   std::string retStr = "";
-  for (unsigned i = 0; i < m_strEditorialStaff.size(); i++)
+  for (unsigned i = 0; i < m_strEditorialStaff.size(); ++i)
   {
     std::string tmpStr = m_strEditorialStaff[i];
     tmpStr.insert(tmpStr.end(),'\n');
@@ -645,7 +645,7 @@ void CPVRRadioRDSInfoTag::SetInfoHoroscope(const std::string& strHoroscope)
   std::string tmpStr = Trim(strHoroscope);
   g_charsetConverter.unknownToUTF8(tmpStr);
 
-  for (unsigned i = 0; i < m_strInfoHoroscope.size(); i++)
+  for (unsigned i = 0; i < m_strInfoHoroscope.size(); ++i)
   {
     if (m_strInfoHoroscope[i].compare(tmpStr) == 0)
       return;
@@ -673,7 +673,7 @@ const std::deque<std::string>& CPVRRadioRDSInfoTag::GetInfoHoroscopeDeque() cons
 const std::string CPVRRadioRDSInfoTag::GetInfoHoroscope() const
 {
   std::string retStr = "";
-  for (unsigned i = 0; i < m_strInfoHoroscope.size(); i++)
+  for (unsigned i = 0; i < m_strInfoHoroscope.size(); ++i)
   {
     std::string tmpStr = m_strInfoHoroscope[i];
     tmpStr.insert(tmpStr.end(),'\n');
@@ -688,7 +688,7 @@ void CPVRRadioRDSInfoTag::SetInfoCinema(const std::string& strCinema)
   std::string tmpStr = Trim(strCinema);
   g_charsetConverter.unknownToUTF8(tmpStr);
 
-  for (unsigned i = 0; i < m_strInfoCinema.size(); i++)
+  for (unsigned i = 0; i < m_strInfoCinema.size(); ++i)
   {
     if (m_strInfoCinema[i].compare(tmpStr) == 0)
       return;
@@ -716,7 +716,7 @@ const std::deque<std::string>& CPVRRadioRDSInfoTag::GetInfoCinemaDeque() const
 const std::string CPVRRadioRDSInfoTag::GetInfoCinema() const
 {
   std::string retStr = "";
-  for (unsigned i = 0; i < m_strInfoCinema.size(); i++)
+  for (unsigned i = 0; i < m_strInfoCinema.size(); ++i)
   {
     std::string tmpStr = m_strInfoCinema[i];
     tmpStr.insert(tmpStr.end(),'\n');
@@ -731,7 +731,7 @@ void CPVRRadioRDSInfoTag::SetInfoOther(const std::string& strOther)
   std::string tmpStr = Trim(strOther);
   g_charsetConverter.unknownToUTF8(tmpStr);
 
-  for (unsigned i = 0; i < m_strInfoOther.size(); i++)
+  for (unsigned i = 0; i < m_strInfoOther.size(); ++i)
   {
     if (m_strInfoOther[i].compare(tmpStr) == 0)
       return;
@@ -759,7 +759,7 @@ const std::deque<std::string>& CPVRRadioRDSInfoTag::GetInfoOtherDeque() const
 const std::string CPVRRadioRDSInfoTag::GetInfoOther() const
 {
   std::string retStr = "";
-  for (unsigned i = 0; i < m_strInfoOther.size(); i++)
+  for (unsigned i = 0; i < m_strInfoOther.size(); ++i)
   {
     std::string tmpStr = m_strInfoOther[i];
     tmpStr.insert(tmpStr.end(),'\n');


### PR DESCRIPTION
This patches removing a wrongly added "!" on GUIInfoManager and on RDS info dialog was a id missing, without them was the following text on end of dialog missing before.

![bildschirmfoto4](https://cloud.githubusercontent.com/assets/6879739/9833726/a0db576c-59a2-11e5-9476-5a78d7c18a11.png)

Also the compiler warning from RDS part of DVD player becomes fixed, thanks @mkortstiege . Further are also the loops changed to the use of `++i`. 

Also changed there the tables and class independent functions to use as static. Is this OK?
