### PR TITLE
ffmpeg: Bump to 2.8.0-Jarvis-alpha3-HEVC

### DIFF
--- a/tools/depends/target/ffmpeg/FFMPEG-VERSION
+++ b/tools/depends/target/ffmpeg/FFMPEG-VERSION
@@ -1,5 +1,5 @@
 LIBNAME=ffmpeg
 BASE_URL=https://github.com/xbmc/FFmpeg/archive
-VERSION=2.8.0-Jarvis-alpha3
+VERSION=2.8.0-Jarvis-alpha3-HEVC
 ARCHIVE=$(LIBNAME)-$(VERSION).tar.gz
 


### PR DESCRIPTION
This fixes issues with parsing HEVC files.
