### PR TITLE
[addons] improve downgrading/version changing support

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -5798,6 +5798,7 @@ msgctxt "#13204"
 msgid "Last loaded profile:"
 msgstr ""
 
+#: xbmc/addons/GUIDialogAddonInfo.cpp
 #: xbmc/music/karaoke/GUIDialogKaraokeSongSelector.cpp
 #: xbmc/peripherals/devices/Peripheral.cpp
 #: xbmc/peripherals/bus/PeripheralBus.cpp
@@ -11974,7 +11975,17 @@ msgctxt "#21337"
 msgid "Never"
 msgstr ""
 
-#empty strings from id 21338 to 21358
+#: xbmc/addons/GUIDialogAddonInfo.cpp
+msgctxt "#21338"
+msgid "Select version"
+msgstr ""
+
+#: xbmc/addons/GUIDialogAddonInfo.cpp
+msgctxt "#21339"
+msgid "Version %s"
+msgstr ""
+
+#empty strings from id 21340 to 21358
 
 #: xbmc/dialogs/GUIDialogFileBrowser.cpp
 msgctxt "#21359"

--- a/xbmc/addons/AddonDatabase.cpp
+++ b/xbmc/addons/AddonDatabase.cpp
@@ -765,6 +765,11 @@ bool CAddonDatabase::HasDisabledAddons()
   return false;
 }
 
+bool CAddonDatabase::BlacklistAddon(const std::string& addonID)
+{
+  return BlacklistAddon(addonID, "");
+}
+
 bool CAddonDatabase::BlacklistAddon(const std::string& addonID,
                                     const std::string& version)
 {
@@ -773,7 +778,8 @@ bool CAddonDatabase::BlacklistAddon(const std::string& addonID,
     if (NULL == m_pDB.get()) return false;
     if (NULL == m_pDS.get()) return false;
 
-    std::string sql = PrepareSQL("insert into blacklist(id, addonID, version) values(NULL, '%s', '%s')", addonID.c_str(),version.c_str());
+    std::string sql = PrepareSQL("INSERT OR REPLACE INTO blacklist(id, addonID, version) "
+        "VALUES(NULL, '%s', '%s')", addonID.c_str(), version.c_str());
     m_pDS->exec(sql);
 
     return true;
@@ -788,8 +794,13 @@ bool CAddonDatabase::BlacklistAddon(const std::string& addonID,
 bool CAddonDatabase::IsAddonBlacklisted(const std::string& addonID,
                                         const std::string& version)
 {
-  std::string where = PrepareSQL("addonID='%s' and version='%s'",addonID.c_str(),version.c_str());
+  std::string where = PrepareSQL("addonID='%s' and (version='%s' OR version='')",addonID.c_str(),version.c_str());
   return !GetSingleValue("blacklist","addonID",where).empty();
+}
+
+bool CAddonDatabase::RemoveAddonFromBlacklist(const std::string& addonID)
+{
+  return RemoveAddonFromBlacklist(addonID, "");
 }
 
 bool CAddonDatabase::RemoveAddonFromBlacklist(const std::string& addonID,

--- a/xbmc/addons/AddonDatabase.cpp
+++ b/xbmc/addons/AddonDatabase.cpp
@@ -300,29 +300,6 @@ bool CAddonDatabase::GetAddon(const std::string& id, AddonPtr& addon)
   return false;
 }
 
-bool CAddonDatabase::GetRepoForAddon(const std::string& addonID, std::string& repo)
-{
-  try
-  {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS2.get()) return false;
-
-    std::string sql = PrepareSQL("select repo.addonID from repo join addonlinkrepo on repo.id=addonlinkrepo.idRepo join addon on addonlinkrepo.idAddon=addon.id where addon.addonID like '%s'", addonID.c_str()); 
-    m_pDS2->query(sql.c_str());
-    if (!m_pDS2->eof())
-    {
-      repo = m_pDS2->fv(0).get_asString();
-      m_pDS2->close();
-      return true;
-    }
-  }
-  catch (...)
-  {
-    CLog::Log(LOGERROR, "%s failed for addon %s", __FUNCTION__, addonID.c_str());
-  }
-  return false;
-}
-
 bool CAddonDatabase::GetAddon(int id, AddonPtr &addon)
 {
   try

--- a/xbmc/addons/AddonDatabase.h
+++ b/xbmc/addons/AddonDatabase.h
@@ -49,12 +49,6 @@ public:
   /*! \brief grab the (largest) add-on version for an add-on */
   ADDON::AddonVersion GetAddonVersion(const std::string &id);
 
-  /*! \brief Grab the repository from which a given addon came
-   \param addonID - the id of the addon in question
-   \param repo [out] - the id of the repository
-   \return true if a repo was found, false otherwise.
-   */
-  bool GetRepoForAddon(const std::string& addonID, std::string& repo);
   int AddRepository(const std::string& id, const ADDON::VECADDONS& addons, const std::string& checksum, const ADDON::AddonVersion& version);
   void DeleteRepository(const std::string& id);
   void DeleteRepository(int id);

--- a/xbmc/addons/AddonDatabase.h
+++ b/xbmc/addons/AddonDatabase.h
@@ -34,10 +34,17 @@ public:
   int GetAddonId(const ADDON::AddonPtr& item);
   int AddAddon(const ADDON::AddonPtr& item, int idRepo);
   bool GetAddon(const std::string& addonID, ADDON::AddonPtr& addon);
+
+  /*! \brief Get an addon with a specific version and repository. */
+  bool GetAddon(const std::string& addonID, const ADDON::AddonVersion& version, const std::string& repoId, ADDON::AddonPtr& addon);
+
   bool GetAddons(ADDON::VECADDONS& addons, const ADDON::TYPE &type = ADDON::ADDON_UNKNOWN);
 
   /*! Get the addon IDs that has been set to disabled */
   bool GetDisabled(std::vector<std::string>& addons);
+
+  bool GetAvailableVersions(const std::string& addonId,
+      std::vector<std::pair<ADDON::AddonVersion, std::string>>& versionsInfo);
 
   /*! \brief grab the (largest) add-on version for an add-on */
   ADDON::AddonVersion GetAddonVersion(const std::string &id);

--- a/xbmc/addons/AddonDatabase.h
+++ b/xbmc/addons/AddonDatabase.h
@@ -114,8 +114,10 @@ public:
    \sa BreakAddon */
   std::string IsAddonBroken(const std::string &addonID);
 
+  bool BlacklistAddon(const std::string& addonID);
   bool BlacklistAddon(const std::string& addonID, const std::string& version);
   bool IsAddonBlacklisted(const std::string& addonID, const std::string& version);
+  bool RemoveAddonFromBlacklist(const std::string& addonID);
   bool RemoveAddonFromBlacklist(const std::string& addonID,
                                 const std::string& version);
 

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -202,6 +202,25 @@ bool CAddonInstaller::InstallOrUpdate(const std::string &addonID, bool backgroun
   return DoInstall(addon, hash, background, modal);
 }
 
+void CAddonInstaller::Install(const std::string& addonId, const AddonVersion& version, const std::string& repoId)
+{
+  CLog::Log(LOGDEBUG, "CAddonInstaller: intalling '%s' version '%s' from repository '%s'",
+      addonId.c_str(), version.asString().c_str(), repoId.c_str());
+
+  AddonPtr addon;
+  CAddonDatabase database;
+
+  if (!database.Open() || !database.GetAddon(addonId, version, repoId, addon))
+    return;
+
+  AddonPtr repo;
+  if (!CAddonMgr::GetInstance().GetAddon(repoId, repo, ADDON_REPOSITORY))
+    return;
+
+  std::string hash = std::static_pointer_cast<CRepository>(repo)->GetAddonHash(addon);
+  DoInstall(addon, hash, true, false);
+}
+
 bool CAddonInstaller::DoInstall(const AddonPtr &addon, const std::string &hash /* = "" */, bool background /* = true */, bool modal /* = false */)
 {
   // check whether we already have the addon installing

--- a/xbmc/addons/AddonInstaller.h
+++ b/xbmc/addons/AddonInstaller.h
@@ -99,6 +99,12 @@ public:
   void OnJobComplete(unsigned int jobID, bool success, CJob* job);
   void OnJobProgress(unsigned int jobID, unsigned int progress, unsigned int total, const CJob *job);
 
+  /*! \brief Find which repository hosts an add-on
+   *  \param addon The add-on to find the repository for
+   *  \return The hosting repository
+   */
+  static ADDON::AddonPtr GetRepoForAddon(const std::string& addonId);
+
   class CDownloadJob
   {
   public:
@@ -149,15 +155,9 @@ private:
 class CAddonInstallJob : public CFileOperationJob
 {
 public:
-  CAddonInstallJob(const ADDON::AddonPtr &addon, const std::string &hash = "");
+  CAddonInstallJob(const ADDON::AddonPtr &addon, const ADDON::AddonPtr &repo, const std::string &hash = "");
 
   virtual bool DoWork();
-
-  /*! \brief Find which repository hosts an add-on
-   *  \param addon The add-on to find the repository for
-   *  \return The hosting repository
-   */
-  static ADDON::AddonPtr GetRepoForAddon(const ADDON::AddonPtr& addon);
 
   /*! \brief Find the add-on and itshash for the given add-on ID
    *  \param addonID ID of the add-on to find
@@ -165,7 +165,7 @@ public:
    *  \param hash Hash of the add-on
    *  \return True if the add-on and its hash were found, false otherwise.
    */
-  static bool GetAddonWithHash(const std::string& addonID, ADDON::AddonPtr& addon, std::string& hash);
+  static bool GetAddonWithHash(const std::string& addonID, const std::string &repoID, ADDON::AddonPtr& addon, std::string& hash);
 
 private:
   void OnPreInstall();
@@ -188,6 +188,7 @@ private:
   void ReportInstallError(const std::string& addonID, const std::string& fileName, const std::string& message = "");
 
   ADDON::AddonPtr m_addon;
+  ADDON::AddonPtr m_repo;
   std::string m_hash;
   bool m_update;
 };

--- a/xbmc/addons/AddonInstaller.h
+++ b/xbmc/addons/AddonInstaller.h
@@ -69,6 +69,9 @@ public:
    */
   bool InstallFromZip(const std::string &path);
 
+   /*! Install an addon with a specific version and repository */
+  void Install(const std::string& addonId, const ADDON::AddonVersion& version, const std::string& repoId);
+
   /*! \brief Check whether dependencies of an addon exist or are installable.
   Iterates through the addon's dependencies, checking they're installed or installable.
   Each dependency must also satisfies CheckDependencies in turn.

--- a/xbmc/addons/AddonInstaller.h
+++ b/xbmc/addons/AddonInstaller.h
@@ -99,11 +99,11 @@ public:
   void OnJobComplete(unsigned int jobID, bool success, CJob* job);
   void OnJobProgress(unsigned int jobID, unsigned int progress, unsigned int total, const CJob *job);
 
-  /*! \brief Find which repository hosts an add-on
+  /*! \brief Get the repository which hosts the most recent version of add-on
    *  \param addon The add-on to find the repository for
-   *  \return The hosting repository
+   *  \param repo [out] The hosting repository
    */
-  static ADDON::AddonPtr GetRepoForAddon(const std::string& addonId);
+  static bool GetRepoForAddon(const std::string& addonId, ADDON::RepositoryPtr& repo);
 
   class CDownloadJob
   {

--- a/xbmc/addons/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/GUIDialogAddonInfo.cpp
@@ -348,6 +348,7 @@ void CGUIDialogAddonInfo::OnRollback()
   if ((choice=dlg->ShowAndGetChoice(buttons)) > -1)
   {
     // blacklist everything newer
+    //FIXME: broken. never been possible to have multiple versions in the blacklist
     for (unsigned int j=choice+1;j<m_rollbackVersions.size();++j)
       database.BlacklistAddon(m_localAddon->ID(),m_rollbackVersions[j]);
     std::string path = "special://home/addons/packages/";

--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -172,11 +172,12 @@ bool CRepository::Parse(const DirInfo& dir, VECADDONS &result)
     file = url.Get();
   }
 
+  VECADDONS addons;
   CXBMCTinyXML doc;
   if (doc.LoadFile(file) && doc.RootElement() &&
-      CAddonMgr::GetInstance().AddonsFromRepoXML(doc.RootElement(), result))
+      CAddonMgr::GetInstance().AddonsFromRepoXML(doc.RootElement(), addons))
   {
-    for (IVECADDONS i = result.begin(); i != result.end(); ++i)
+    for (IVECADDONS i = addons.begin(); i != addons.end(); ++i)
     {
       AddonPtr addon = *i;
       if (dir.zipped)
@@ -195,6 +196,7 @@ bool CRepository::Parse(const DirInfo& dir, VECADDONS &result)
         SET_IF_NOT_EMPTY(addon->Props().changelog,URIUtils::AddFileToFolder(dir.datadir,addon->ID()+"/changelog.txt"))
         SET_IF_NOT_EMPTY(addon->Props().fanart,URIUtils::AddFileToFolder(dir.datadir,addon->ID()+"/fanart.jpg"))
       }
+      result.push_back(addon);
     }
     return true;
   }
@@ -204,20 +206,6 @@ bool CRepository::Parse(const DirInfo& dir, VECADDONS &result)
 
 CRepositoryUpdateJob::CRepositoryUpdateJob(const RepositoryPtr& repo) : m_repo(repo) {}
 
-void MergeAddons(std::map<std::string, AddonPtr> &addons, const VECADDONS &new_addons)
-{
-  for (VECADDONS::const_iterator it = new_addons.begin(); it != new_addons.end(); ++it)
-  {
-    std::map<std::string, AddonPtr>::iterator existing = addons.find((*it)->ID());
-    if (existing != addons.end())
-    { // already got it - replace if we have a newer version
-      if (existing->second->Version() < (*it)->Version())
-        existing->second = *it;
-    }
-    else
-      addons.insert(make_pair((*it)->ID(), *it));
-  }
-}
 
 bool CRepositoryUpdateJob::DoWork()
 {
@@ -349,25 +337,18 @@ CRepositoryUpdateJob::FetchStatus CRepositoryUpdateJob::FetchIfChanged(const std
   if (oldChecksum == checksum && !oldChecksum.empty())
     return STATUS_NOT_MODIFIED;
 
-  std::map<std::string, AddonPtr> uniqueAddons;
   for (auto it = m_repo->m_dirs.cbegin(); it != m_repo->m_dirs.cend(); ++it)
   {
     if (ShouldCancel(m_repo->m_dirs.size() + std::distance(m_repo->m_dirs.cbegin(), it), total))
       return STATUS_ERROR;
 
-    VECADDONS addons;
     if (!CRepository::Parse(*it, addons))
     {
       CLog::Log(LOGERROR, "CRepositoryUpdateJob[%s] failed to read or parse "
           "directory '%s'", m_repo->ID().c_str(), it->info.c_str());
       return STATUS_ERROR;
     }
-    MergeAddons(uniqueAddons, addons);
   }
-
-
-  for (const auto& kv : uniqueAddons)
-    addons.push_back(kv.second);
 
   SetProgress(total, total);
   return STATUS_OK;


### PR DESCRIPTION
This adds various client changes needed to support having multiple versions in the same repository and for installing specific versions from specific repositories.

On the gui side it changes the 'update' functionality in the info dialog to show a list of available versions and repositories which can be installed. Note that requires server side support. Currently there is only one version kept in the official repository.
