### PR TITLE
settings: default to visualization.spectrum, not visualization.glspectrum

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1835,7 +1835,7 @@
       <group id="5">
         <setting id="musicplayer.visualisation" type="addon" label="250" help="36273">
           <level>0</level>
-          <default>visualization.glspectrum</default>
+          <default>visualization.spectrum</default>
           <constraints>
             <addontype>xbmc.player.musicviz</addontype>
             <allowempty>true</allowempty>


### PR DESCRIPTION
Thanks to @notspiff for fixing the default value of the `musicplayer.visualisation` setting. `visualization.glspectrum` doesn't exist anymore and is now part of `visualization.spectrum`.
