### PR TITLE
videodb: allow calling SetDetailsForSeason() for "All seasons"

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -2343,7 +2343,7 @@ bool CVideoDatabase::UpdateDetailsForTvShow(int idTvShow, const CVideoInfoTag &d
 int CVideoDatabase::SetDetailsForSeason(const CVideoInfoTag& details, const std::map<std::string,
     std::string> &artwork, int idShow, int idSeason /* = -1 */)
 {
-  if (idShow < 0 || details.m_iSeason < 0)
+  if (idShow < 0 || details.m_iSeason < -1)
     return -1;
 
    try


### PR DESCRIPTION
I noticed this one as part of my media import work. Right now it's not possible to call `CVideoDatabase::SetDetailsForSeason()` for `All seasons` which has the season number -1.
