### PR TITLE
UPnP: add support for video's countries through xbmc:country

### DIFF
--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.cpp
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.cpp
@@ -173,6 +173,8 @@ PLT_Didl::ConvertFilterToMask(const NPT_String& filter)
             mask |= PLT_FILTER_MASK_XBMC_ARTWORK;
         } else if (NPT_String::CompareN(s+i, PLT_FILTER_FIELD_XBMC_UNIQUE_IDENTIFIER, len, true) == 0) {
             mask |= PLT_FILTER_MASK_XBMC_UNIQUE_IDENTIFIER;
+        } else if (NPT_String::CompareN(s + i, PLT_FILTER_FIELD_XBMC_COUNTRY, len, true) == 0) {
+          mask |= PLT_FILTER_MASK_XBMC_COUNTRY;
         }
 
         if (next_comma < 0) {

--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.h
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.h
@@ -100,6 +100,7 @@
 #define PLT_FILTER_MASK_XBMC_VOTES                  NPT_UINT64_C(0x0000400000000000)
 #define PLT_FILTER_MASK_XBMC_ARTWORK                NPT_UINT64_C(0x0000800000000000)
 #define PLT_FILTER_MASK_XBMC_UNIQUE_IDENTIFIER      NPT_UINT64_C(0x0001000000000000)
+#define PLT_FILTER_MASK_XBMC_COUNTRY                NPT_UINT64_C(0x0002000000000000)
 
 #define PLT_FILTER_FIELD_TITLE                      "dc:title"
 #define PLT_FILTER_FIELD_CREATOR                    "dc:creator"
@@ -150,6 +151,7 @@
 #define PLT_FILTER_FIELD_XBMC_VOTES                 "xbmc:votes"
 #define PLT_FILTER_FIELD_XBMC_ARTWORK               "xbmc:artwork"
 #define PLT_FILTER_FIELD_XBMC_UNIQUE_IDENTIFIER     "xbmc:uniqueidentifier"
+#define PLT_FILTER_FIELD_XBMC_COUNTRY               "xbmc:country"
 
 extern const char* didl_header;
 extern const char* didl_footer;

--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp
@@ -261,6 +261,7 @@ PLT_MediaObject::Reset()
     m_XbmcInfo.votes = "";
     m_XbmcInfo.artwork.Clear();
     m_XbmcInfo.unique_identifier = "";
+    m_XbmcInfo.countries.Clear();
 
     m_Didl = "";
 
@@ -604,6 +605,16 @@ PLT_MediaObject::ToDidl(NPT_UInt64 mask, NPT_String& didl)
         didl += "<xbmc:uniqueidentifier>";
         PLT_Didl::AppendXmlEscape(didl, m_XbmcInfo.unique_identifier);
         didl += "</xbmc:uniqueidentifier>";
+    }
+
+    // country
+    if (mask & PLT_FILTER_MASK_XBMC_COUNTRY) {
+      for (NPT_List<NPT_String>::Iterator it =
+        m_XbmcInfo.countries.GetFirstItem(); it; ++it) {
+        didl += "<xbmc:country>";
+        PLT_Didl::AppendXmlEscape(didl, (*it));
+        didl += "</xbmc:country>";
+      }
     }
 
     // class is required

--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.h
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.h
@@ -170,6 +170,7 @@ typedef struct {
   NPT_String votes;
   PLT_Artworks artwork;
   NPT_String unique_identifier;
+  NPT_List<NPT_String> countries;
 } PLT_XbmcInfo;
 
 typedef struct {

--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
@@ -70,7 +70,7 @@ typedef struct PLT_CapabilitiesData {
 typedef NPT_Reference<PLT_CapabilitiesData> PLT_CapabilitiesDataReference;
 
 // explicitely specify res otherwise WMP won't return a URL!
-#define PLT_DEFAULT_FILTER  "dc:date,dc:description,upnp:longDescription,upnp:genre,res,res@duration,res@size,upnp:albumArtURI,upnp:rating,upnp:lastPlaybackPosition,upnp:lastPlaybackTime,upnp:playbackCount,upnp:originalTrackNumber,upnp:episodeNumber,upnp:programTitle,upnp:seriesTitle,upnp:album,upnp:artist,upnp:author,upnp:director,dc:publisher,searchable,childCount,dc:title,dc:creator,upnp:actor,res@resolution,upnp:episodeCount,upnp:episodeSeason,xbmc:dateadded,xbmc:rating,xbmc:votes,xbmc:artwork,xbmc:uniqueidentifier"
+#define PLT_DEFAULT_FILTER  "dc:date,dc:description,upnp:longDescription,upnp:genre,res,res@duration,res@size,upnp:albumArtURI,upnp:rating,upnp:lastPlaybackPosition,upnp:lastPlaybackTime,upnp:playbackCount,upnp:originalTrackNumber,upnp:episodeNumber,upnp:programTitle,upnp:seriesTitle,upnp:album,upnp:artist,upnp:author,upnp:director,dc:publisher,searchable,childCount,dc:title,dc:creator,upnp:actor,res@resolution,upnp:episodeCount,upnp:episodeSeason,xbmc:dateadded,xbmc:rating,xbmc:votes,xbmc:artwork,xbmc:uniqueidentifier,xbmc:country"
 
 /*----------------------------------------------------------------------
 |   PLT_MediaContainerListener

--- a/lib/libUPnP/patches/0036-platinum-add-xbmc-country-for-countries.patch
+++ b/lib/libUPnP/patches/0036-platinum-add-xbmc-country-for-countries.patch
@@ -1,0 +1,103 @@
+From 2f0e4019673a92b3c1e01fd2447bd05e7b231423 Mon Sep 17 00:00:00 2001
+From: montellese <montellese@xbmc.org>
+Date: Sun, 8 Mar 2015 23:49:24 +0100
+Subject: [PATCH 1/3] platinum: add xbmc:country for countries
+
+---
+ lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.cpp   |  2 ++
+ lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.h     |  2 ++
+ .../Platinum/Source/Devices/MediaServer/PltMediaItem.cpp      | 11 +++++++++++
+ .../Platinum/Source/Devices/MediaServer/PltMediaItem.h        |  1 +
+ .../Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h |  2 +-
+ 5 files changed, 17 insertions(+), 1 deletion(-)
+
+diff --git a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.cpp b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.cpp
+index b58aa50..0f24ab3 100644
+--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.cpp
++++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.cpp
+@@ -173,6 +173,8 @@ PLT_Didl::ConvertFilterToMask(const NPT_String& filter)
+             mask |= PLT_FILTER_MASK_XBMC_ARTWORK;
+         } else if (NPT_String::CompareN(s+i, PLT_FILTER_FIELD_XBMC_UNIQUE_IDENTIFIER, len, true) == 0) {
+             mask |= PLT_FILTER_MASK_XBMC_UNIQUE_IDENTIFIER;
++        } else if (NPT_String::CompareN(s + i, PLT_FILTER_FIELD_XBMC_COUNTRY, len, true) == 0) {
++          mask |= PLT_FILTER_MASK_XBMC_COUNTRY;
+         }
+ 
+         if (next_comma < 0) {
+diff --git a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.h b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.h
+index fe1de45..49b92d0 100644
+--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.h
++++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.h
+@@ -100,6 +100,7 @@
+ #define PLT_FILTER_MASK_XBMC_VOTES                  NPT_UINT64_C(0x0000400000000000)
+ #define PLT_FILTER_MASK_XBMC_ARTWORK                NPT_UINT64_C(0x0000800000000000)
+ #define PLT_FILTER_MASK_XBMC_UNIQUE_IDENTIFIER      NPT_UINT64_C(0x0001000000000000)
++#define PLT_FILTER_MASK_XBMC_COUNTRY                NPT_UINT64_C(0x0002000000000000)
+ 
+ #define PLT_FILTER_FIELD_TITLE                      "dc:title"
+ #define PLT_FILTER_FIELD_CREATOR                    "dc:creator"
+@@ -150,6 +151,7 @@
+ #define PLT_FILTER_FIELD_XBMC_VOTES                 "xbmc:votes"
+ #define PLT_FILTER_FIELD_XBMC_ARTWORK               "xbmc:artwork"
+ #define PLT_FILTER_FIELD_XBMC_UNIQUE_IDENTIFIER     "xbmc:uniqueidentifier"
++#define PLT_FILTER_FIELD_XBMC_COUNTRY               "xbmc:country"
+ 
+ extern const char* didl_header;
+ extern const char* didl_footer;
+diff --git a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp
+index f937df2..2e7d32b 100644
+--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp
++++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp
+@@ -261,6 +261,7 @@ PLT_MediaObject::Reset()
+     m_XbmcInfo.votes = "";
+     m_XbmcInfo.artwork.Clear();
+     m_XbmcInfo.unique_identifier = "";
++    m_XbmcInfo.countries.Clear();
+ 
+     m_Didl = "";
+ 
+@@ -606,6 +607,16 @@ PLT_MediaObject::ToDidl(NPT_UInt64 mask, NPT_String& didl)
+         didl += "</xbmc:uniqueidentifier>";
+     }
+ 
++    // country
++    if (mask & PLT_FILTER_MASK_XBMC_COUNTRY) {
++      for (NPT_List<NPT_String>::Iterator it =
++        m_XbmcInfo.countries.GetFirstItem(); it; ++it) {
++        didl += "<xbmc:country>";
++        PLT_Didl::AppendXmlEscape(didl, (*it));
++        didl += "</xbmc:country>";
++      }
++    }
++
+     // class is required
+     didl += "<upnp:class";
+ 	if (!m_ObjectClass.friendly_name.IsEmpty()) {
+diff --git a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.h b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.h
+index 6461b81..0efd505 100644
+--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.h
++++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.h
+@@ -170,6 +170,7 @@ typedef struct {
+   NPT_String votes;
+   PLT_Artworks artwork;
+   NPT_String unique_identifier;
++  NPT_List<NPT_String> countries;
+ } PLT_XbmcInfo;
+ 
+ typedef struct {
+diff --git a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
+index 8fb23dd..9b25d58 100644
+--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
++++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
+@@ -70,7 +70,7 @@ typedef struct PLT_CapabilitiesData {
+ typedef NPT_Reference<PLT_CapabilitiesData> PLT_CapabilitiesDataReference;
+ 
+ // explicitely specify res otherwise WMP won't return a URL!
+-#define PLT_DEFAULT_FILTER  "dc:date,dc:description,upnp:longDescription,upnp:genre,res,res@duration,res@size,upnp:albumArtURI,upnp:rating,upnp:lastPlaybackPosition,upnp:lastPlaybackTime,upnp:playbackCount,upnp:originalTrackNumber,upnp:episodeNumber,upnp:programTitle,upnp:seriesTitle,upnp:album,upnp:artist,upnp:author,upnp:director,dc:publisher,searchable,childCount,dc:title,dc:creator,upnp:actor,res@resolution,upnp:episodeCount,upnp:episodeSeason,xbmc:dateadded,xbmc:rating,xbmc:votes,xbmc:artwork,xbmc:uniqueidentifier"
++#define PLT_DEFAULT_FILTER  "dc:date,dc:description,upnp:longDescription,upnp:genre,res,res@duration,res@size,upnp:albumArtURI,upnp:rating,upnp:lastPlaybackPosition,upnp:lastPlaybackTime,upnp:playbackCount,upnp:originalTrackNumber,upnp:episodeNumber,upnp:programTitle,upnp:seriesTitle,upnp:album,upnp:artist,upnp:author,upnp:director,dc:publisher,searchable,childCount,dc:title,dc:creator,upnp:actor,res@resolution,upnp:episodeCount,upnp:episodeSeason,xbmc:dateadded,xbmc:rating,xbmc:votes,xbmc:artwork,xbmc:uniqueidentifier,xbmc:country"
+ 
+ /*----------------------------------------------------------------------
+ |   PLT_MediaContainerListener
+-- 
+1.9.5.msysgit.0
+

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -317,6 +317,8 @@ PopulateObjectFromTag(CVideoInfoTag&         tag,
     object.m_XbmcInfo.rating = tag.m_fRating;
     object.m_XbmcInfo.votes = tag.m_strVotes.c_str();
     object.m_XbmcInfo.unique_identifier = tag.m_strIMDBNumber.c_str();
+    for (const auto& country : tag.m_country)
+      object.m_XbmcInfo.countries.Add(country.c_str());
 
     for (unsigned int index = 0; index < tag.m_genre.size(); index++)
       object.m_Affiliation.genres.Add(tag.m_genre.at(index).c_str());
@@ -826,6 +828,8 @@ PopulateTagFromObject(CVideoInfoTag&         tag,
     tag.m_fRating = object.m_XbmcInfo.rating;
     tag.m_strVotes = object.m_XbmcInfo.votes;
     tag.m_strIMDBNumber = object.m_XbmcInfo.unique_identifier;
+    for (unsigned int index = 0; index < object.m_XbmcInfo.countries.GetItemCount(); index++)
+      tag.m_country.push_back(object.m_XbmcInfo.countries.GetItem(index)->GetChars());
 
     for (unsigned int index = 0; index < object.m_Affiliation.genres.GetItemCount(); index++)
     {


### PR DESCRIPTION
This adds support for an `xbmc:country` tag in the DIDL-Lite of a media item sent over UPnP.
