### PR TITLE
Enable editing of userrating from the frontend

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -2474,6 +2474,7 @@ msgstr ""
 
 #: xbmc/dialogs/GUIDialogMediaFilter.cpp
 #: xbmc/playlists/SmartPlaylist.cpp
+#: xbmc/video/dialogs/GUIDialogVideoInfo.cpp
 msgctxt "#563"
 msgid "Rating"
 msgstr ""
@@ -18102,7 +18103,7 @@ msgstr ""
 #. Used for the viewstate selection
 #: xbmc/video/GUIViewStateVideo.xml
 msgctxt "#38018"
-msgid "User rating"
+msgid "My rating"
 msgstr ""
 
 #. Setting #38019 "Settings -> System -> Audio output -> Support 8 channel DTS-HD audio decoding"
@@ -18115,4 +18116,15 @@ msgstr ""
 #: system/settings/settings.xml
 msgctxt "#38020"
 msgid "Enables decoding of high quality DTS-HD audio streams. Note: This increases CPU load and is only available when DTS and DTS-HD audio passthrough are disabled."
+msgstr ""
+
+#. Used for the viewstate selection
+#: xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+msgctxt "#38022"
+msgid "No rating"
+msgstr ""
+
+#. Used in Confluence
+msgctxt "#38023"
+msgid "Set my rating"
 msgstr ""

--- a/addons/skin.confluence/720p/DialogSongInfo.xml
+++ b/addons/skin.confluence/720p/DialogSongInfo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
-	<defaultcontrol always="true">10</defaultcontrol>
+	<defaultcontrol always="true">12</defaultcontrol>
 	<coordinates>
 		<left>185</left>
 		<top>105</top>
@@ -201,34 +201,6 @@
 						<aspectratio align="left">keep</aspectratio>
 						<texture>LeftRating/$INFO[ListItem.StarRating]</texture>
 					</control>
-					<control type="button" id="14">
-						<description>Decrease Rating</description>
-						<left>160</left>
-						<top>5</top>
-						<width>33</width>
-						<height>22</height>
-						<onclick>DecreaseRating</onclick>
-						<texturenofocus>scroll-down-2.png</texturenofocus>
-						<texturefocus>scroll-down-focus-2.png</texturefocus>
-						<onleft>15</onleft>
-						<onright>15</onright>
-						<ondown>9000</ondown>
-						<onup>9000</onup>
-					</control>
-					<control type="button" id="15">
-						<description>Increase Rating</description>
-						<left>193</left>
-						<top>5</top>
-						<width>33</width>
-						<height>22</height>
-						<onclick>IncreaseRating</onclick>
-						<texturenofocus>scroll-up-2.png</texturenofocus>
-						<texturefocus>scroll-up-focus-2.png</texturefocus>
-						<onleft>14</onleft>
-						<onright>14</onright>
-						<ondown>9000</ondown>
-						<onup>9000</onup>
-					</control>
 				</control>
 				<control type="label">
 					<description>Comment Title</description>
@@ -254,53 +226,23 @@
 				</control>
 			</control>
 			<control type="group" id="9000">
-				<left>40</left>
+				<left>140</left>
 				<top>445</top>
-				<control type="button" id="10">
-					<description>Ok button</description>
-					<left>0</left>
-					<top>0</top>
-					<width>200</width>
-					<height>40</height>
-					<label>186</label>
-					<font>font12_title</font>
-					<align>center</align>
-					<onleft>13</onleft>
-					<onright>11</onright>
-					<onup>14</onup>
-					<ondown>14</ondown>
-				</control>
-				<control type="button" id="11">
-					<description>Cancel button</description>
-					<left>210</left>
-					<top>0</top>
-					<width>200</width>
-					<height>40</height>
-					<label>222</label>
-					<font>font12_title</font>
-					<align>center</align>
-					<onleft>10</onleft>
-					<onright>12</onright>
-					<onup>14</onup>
-					<ondown>14</ondown>
-				</control>
 				<control type="button" id="12">
 					<description>Album Info button</description>
-					<left>420</left>
+					<left>0</left>
 					<top>0</top>
 					<width>200</width>
 					<height>40</height>
 					<label>10523</label>
 					<font>font12_title</font>
 					<align>center</align>
-					<onleft>11</onleft>
+					<onleft>7</onleft>
 					<onright>13</onright>
-					<onup>14</onup>
-					<ondown>14</ondown>
 				</control>
 				<control type="button" id="13">
 					<description>Get Thumb button</description>
-					<left>630</left>
+					<left>210</left>
 					<top>0</top>
 					<width>200</width>
 					<height>40</height>
@@ -308,9 +250,19 @@
 					<font>font12_title</font>
 					<align>center</align>
 					<onleft>12</onleft>
-					<onright>10</onright>
-					<onup>14</onup>
-					<ondown>14</ondown>
+					<onright>7</onright>
+				</control>
+				<control type="button" id="7">
+					<description>Set my rating</description>
+					<left>420</left>
+					<top>0</top>
+					<width>200</width>
+					<height>40</height>
+					<label>38023</label>
+					<font>font12_title</font>
+					<align>center</align>
+					<onleft>13</onleft>
+					<onright>12</onright>
 				</control>
 			</control>
 		</control>

--- a/addons/skin.confluence/720p/DialogVideoInfo.xml
+++ b/addons/skin.confluence/720p/DialogVideoInfo.xml
@@ -178,9 +178,9 @@
 					</control>
 					<control type="list" id="49">
 						<left>290</left>
-						<top>20</top>
+						<top>-4</top>
 						<width>740</width>
-						<height>330</height>
+						<height>390</height>
 						<onleft>49</onleft>
 						<onright>49</onright>
 						<onup>9000</onup>
@@ -292,6 +292,12 @@
 								<visible>!IsEmpty(ListItem.Duration)</visible>
 							</item>
 							<item>
+								<label>$LOCALIZE[38018]:</label>
+								<label2>$INFO[ListItem.Userrating]</label2>
+								<onclick>noop</onclick>
+								<visible>!IsEmpty(ListItem.Userrating)</visible>
+							</item>
+							<item>
 								<label>$LOCALIZE[563]:</label>
 								<label2>$INFO[ListItem.RatingAndVotes]</label2>
 								<onclick>noop</onclick>
@@ -325,7 +331,7 @@
 					</control>
 					<control type="image">
 						<left>290</left>
-						<top>370</top>
+						<top>382</top>
 						<width>740</width>
 						<height>4</height>
 						<aspectratio>stretch</aspectratio>
@@ -454,6 +460,12 @@
 								<visible>!IsEmpty(ListItem.Year)</visible>
 							</item>
 							<item>
+								<label>$LOCALIZE[38018]:</label>
+								<label2>$INFO[ListItem.Userrating]</label2>
+								<onclick>noop</onclick>
+								<visible>!IsEmpty(ListItem.Userrating)</visible>
+							</item>
+							<item>
 								<label>$LOCALIZE[563]:</label>
 								<label2>$INFO[ListItem.RatingAndVotes]</label2>
 								<onclick>noop</onclick>
@@ -503,9 +515,9 @@
 					</control>
 					<control type="list" id="49">
 						<left>390</left>
-						<top>20</top>
+						<top>0</top>
 						<width>640</width>
-						<height>330</height>
+						<height>360</height>
 						<onleft>49</onleft>
 						<onright>49</onright>
 						<onup>9000</onup>
@@ -627,6 +639,12 @@
 								<label2>$INFO[ListItem.Duration] $LOCALIZE[12391]</label2>
 								<onclick>noop</onclick>
 								<visible>!IsEmpty(ListItem.Duration)</visible>
+							</item>
+							<item>
+								<label>$LOCALIZE[38018]:</label>
+								<label2>$INFO[ListItem.Userrating]</label2>
+								<onclick>noop</onclick>
+								<visible>!IsEmpty(ListItem.Userrating)</visible>
 							</item>
 							<item>
 								<label>$LOCALIZE[563]:</label>
@@ -786,6 +804,12 @@
 								<label2>$INFO[ListItem.Duration] $LOCALIZE[12391]</label2>
 								<onclick>noop</onclick>
 								<visible>!IsEmpty(ListItem.Duration)</visible>
+							</item>
+							<item>
+								<label>$LOCALIZE[38018]:</label>
+								<label2>$INFO[ListItem.Userrating]</label2>
+								<onclick>noop</onclick>
+								<visible>!IsEmpty(ListItem.Userrating)</visible>
 							</item>
 							<item>
 								<label>$LOCALIZE[15311]</label>
@@ -982,6 +1006,11 @@
 						<label>20410</label>
 						<onclick>PlayMedia($INFO[ListItem.Trailer],1)</onclick>
 						<visible>!IsEmpty(ListItem.Trailer) + Skin.HasSetting(WindowedTrailer)</visible>
+					</control>
+					<control type="button" id="7">
+						<description>Set my rating</description>
+						<include>ButtonInfoDialogsCommonValues</include>
+						<label>38023</label>
 					</control>
 					<control type="button" id="100">
 						<description>Fetch TvTunes stuff</description>

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2217,16 +2217,16 @@ bool CApplication::OnAction(const CAction &action)
     if (tag)
     {
       *m_itemCurrentFile->GetMusicInfoTag() = *tag;
-      char rating = tag->GetRating();
+      char rating = tag->GetUserrating();
       bool needsUpdate(false);
       if (rating > '0' && action.GetID() == ACTION_DECREASE_RATING)
       {
-        m_itemCurrentFile->GetMusicInfoTag()->SetRating(rating - 1);
+        m_itemCurrentFile->GetMusicInfoTag()->SetUserrating(rating - 1);
         needsUpdate = true;
       }
       else if (rating < '5' && action.GetID() == ACTION_INCREASE_RATING)
       {
-        m_itemCurrentFile->GetMusicInfoTag()->SetRating(rating + 1);
+        m_itemCurrentFile->GetMusicInfoTag()->SetUserrating(rating + 1);
         needsUpdate = true;
       }
       if (needsUpdate)
@@ -2234,7 +2234,7 @@ bool CApplication::OnAction(const CAction &action)
         CMusicDatabase db;
         if (db.Open())      // OpenForWrite() ?
         {
-          db.SetSongRating(m_itemCurrentFile->GetPath(), m_itemCurrentFile->GetMusicInfoTag()->GetRating());
+          db.SetSongUserrating(m_itemCurrentFile->GetPath(), m_itemCurrentFile->GetMusicInfoTag()->GetUserrating());
           db.Close();
         }
         // send a message to all windows to tell them to update the fileitem (eg playlistplayer, media windows)

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -5198,9 +5198,9 @@ std::string CGUIInfoManager::GetItemLabel(const CFileItem *item, int info, std::
       std::string rating;
       if (item->HasVideoInfoTag() && item->GetVideoInfoTag()->m_fRating > 0.f) // movie rating
         rating = StringUtils::Format("%.1f", item->GetVideoInfoTag()->m_fRating);
-      else if (item->HasMusicInfoTag() && item->GetMusicInfoTag()->GetRating() > '0')
+      else if (item->HasMusicInfoTag() && item->GetMusicInfoTag()->GetUserrating() > '0')
       { // song rating.  Images will probably be better than numbers for this in the long run
-        rating.assign(1, item->GetMusicInfoTag()->GetRating());
+        rating.assign(1, item->GetMusicInfoTag()->GetUserrating());
       }
       return rating;
     }
@@ -5813,7 +5813,7 @@ std::string CGUIInfoManager::GetItemImage(const CFileItem *item, int info, std::
     {
       if (item->HasMusicInfoTag())
       {
-        return StringUtils::Format("songrating%c.png", item->GetMusicInfoTag()->GetRating());
+        return StringUtils::Format("songrating%c.png", item->GetMusicInfoTag()->GetUserrating());
       }
     }
     break;
@@ -5826,7 +5826,7 @@ std::string CGUIInfoManager::GetItemImage(const CFileItem *item, int info, std::
       }
       else if (item->HasMusicInfoTag())
       { // song rating.
-        rating = StringUtils::Format("rating%c.png", item->GetMusicInfoTag()->GetRating());
+        rating = StringUtils::Format("rating%c.png", item->GetMusicInfoTag()->GetUserrating());
       }
       return rating;
     }

--- a/xbmc/addons/Visualisation.cpp
+++ b/xbmc/addons/Visualisation.cpp
@@ -225,7 +225,7 @@ bool CVisualisation::OnAction(VIS_ACTION action, void *param)
         track.discNumber  = tag->GetDiscNumber();
         track.duration    = tag->GetDuration();
         track.year        = tag->GetYear();
-        track.rating      = tag->GetRating();
+        track.rating      = tag->GetUserrating();
 
         return m_pStruct->OnAction(action, &track);
       }

--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -451,7 +451,7 @@ namespace XBMCAddon
           else if (key == "title")
             item->GetMusicInfoTag()->SetTitle(value);
           else if (key == "rating")
-            item->GetMusicInfoTag()->SetRating(value[0]);
+            item->GetMusicInfoTag()->SetUserrating(value[0]);
           else if (key == "lyrics")
             item->GetMusicInfoTag()->SetLyrics(value);
           else if (key == "lastplayed")

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -1689,7 +1689,7 @@ CSong CMusicDatabase::GetSongFromDataset(const dbiplus::sql_record* const record
   song.iStartOffset = record->at(offset + song_iStartOffset).get_asInt();
   song.iEndOffset = record->at(offset + song_iEndOffset).get_asInt();
   song.strMusicBrainzTrackID = record->at(offset + song_strMusicBrainzTrackID).get_asString();
-  song.rating = record->at(offset + song_rating).get_asChar();
+  song.rating = record->at(offset + song_userrating).get_asChar();
   song.strComment = record->at(offset + song_comment).get_asString();
   song.strMood = record->at(offset + song_mood).get_asString();
   song.iKaraokeNumber = record->at(offset + song_iKarNumber).get_asInt();
@@ -1728,7 +1728,7 @@ void CMusicDatabase::GetFileItemFromDataset(const dbiplus::sql_record* const rec
   item->SetProperty("item_start", item->m_lStartOffset);
   item->m_lEndOffset = record->at(song_iEndOffset).get_asInt();
   item->GetMusicInfoTag()->SetMusicBrainzTrackID(record->at(song_strMusicBrainzTrackID).get_asString());
-  item->GetMusicInfoTag()->SetRating(record->at(song_rating).get_asChar());
+  item->GetMusicInfoTag()->SetUserrating(record->at(song_userrating).get_asChar());
   item->GetMusicInfoTag()->SetComment(record->at(song_comment).get_asString());
   item->GetMusicInfoTag()->SetMood(record->at(song_mood).get_asString());
   item->GetMusicInfoTag()->SetPlayCount(record->at(song_iTimesPlayed).get_asInt());
@@ -4450,7 +4450,7 @@ bool CMusicDatabase::GetPaths(std::set<std::string> &paths)
   return false;
 }
 
-bool CMusicDatabase::SetSongRating(const std::string &filePath, char rating)
+bool CMusicDatabase::SetSongUserrating(const std::string &filePath, char rating)
 {
   try
   {

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -191,7 +191,7 @@ public:
   bool GetSongsByPath(const std::string& strPath, MAPSONGS& songs, bool bAppendToMap = false);
   bool Search(const std::string& search, CFileItemList &items);
   bool RemoveSongsFromPath(const std::string &path, MAPSONGS& songs, bool exact=true);
-  bool SetSongRating(const std::string &filePath, char rating);
+  bool SetSongUserrating(const std::string &filePath, char rating);
   int  GetSongByArtistAndAlbumAndTitle(const std::string& strArtist, const std::string& strAlbum, const std::string& strTitle);
 
   /////////////////////////////////////////////////
@@ -537,7 +537,7 @@ private:
     song_iStartOffset,
     song_iEndOffset,
     song_lastplayed,
-    song_rating,
+    song_userrating,
     song_comment,
     song_idAlbum,
     song_strAlbum,

--- a/xbmc/music/Song.cpp
+++ b/xbmc/music/Song.cpp
@@ -73,7 +73,7 @@ CSong::CSong(CFileItem& item)
   strComment = tag.GetComment();
   strCueSheet = tag.GetCueSheet();
   strMood = tag.GetMood();
-  rating = tag.GetRating();
+  rating = tag.GetUserrating();
   iYear = stTime.wYear;
   iTrack = tag.GetTrackAndDiscNumber();
   iDuration = tag.GetDuration();

--- a/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
@@ -152,7 +152,7 @@ void CGUIDialogMusicInfo::SetAlbum(const CAlbum& album, const std::string &path)
   m_albumItem->GetMusicInfoTag()->SetArtist(m_album.GetAlbumArtist());
   m_albumItem->GetMusicInfoTag()->SetYear(m_album.iYear);
   m_albumItem->GetMusicInfoTag()->SetLoaded(true);
-  m_albumItem->GetMusicInfoTag()->SetRating('0' + m_album.iRating);
+  m_albumItem->GetMusicInfoTag()->SetUserrating('0' + m_album.iRating);
   m_albumItem->GetMusicInfoTag()->SetGenre(m_album.genre);
   m_albumItem->GetMusicInfoTag()->SetDatabaseId(m_album.idAlbum, MediaTypeAlbum);
   CMusicDatabase::SetPropertiesFromAlbum(*m_albumItem,m_album);

--- a/xbmc/music/dialogs/GUIDialogSongInfo.h
+++ b/xbmc/music/dialogs/GUIDialogSongInfo.h
@@ -42,10 +42,11 @@ protected:
   virtual void OnInitWindow();
   bool DownloadThumbnail(const std::string &thumbFile);
   void OnGetThumb();
-  void SetRating(char rating);
+  void SetUserrating(char rating);
+  void OnSetUserrating();
 
   CFileItemPtr m_song;
-  char m_startRating;
+  char m_startUserrating;
   bool m_cancelled;
   bool m_needsUpdate;
   long m_albumId;

--- a/xbmc/music/tags/MusicInfoTag.cpp
+++ b/xbmc/music/tags/MusicInfoTag.cpp
@@ -274,7 +274,7 @@ const std::string &CMusicInfoTag::GetCueSheet() const
   return m_cuesheet;
 }
 
-char CMusicInfoTag::GetRating() const
+char CMusicInfoTag::GetUserrating() const
 {
   return m_rating;
 }
@@ -463,7 +463,7 @@ void CMusicInfoTag::SetLyrics(const std::string& lyrics)
   m_strLyrics = lyrics;
 }
 
-void CMusicInfoTag::SetRating(char rating)
+void CMusicInfoTag::SetUserrating(char rating)
 {
   m_rating = rating;
 }
@@ -628,7 +628,7 @@ void CMusicInfoTag::SetAlbum(const CAlbum& album)
   SetMusicBrainzAlbumID(album.strMusicBrainzAlbumID);
   SetGenre(album.genre);
   SetMood(StringUtils::Join(album.moods, g_advancedSettings.m_musicItemSeparator));
-  SetRating('0' + album.iRating);
+  SetUserrating('0' + album.iRating);
   SetCompilation(album.bCompilation);
   SYSTEMTIME stTime;
   stTime.wYear = album.iYear;
@@ -667,7 +667,7 @@ void CMusicInfoTag::SetSong(const CSong& song)
   SetLastPlayed(song.lastPlayed);
   SetDateAdded(song.dateAdded);
   SetCoverArtInfo(song.embeddedArt.size, song.embeddedArt.mime);
-  SetRating(song.rating);
+  SetUserrating(song.rating);
   SetURL(song.strFileName);
   SYSTEMTIME stTime;
   stTime.wYear = song.iYear;

--- a/xbmc/music/tags/MusicInfoTag.h
+++ b/xbmc/music/tags/MusicInfoTag.h
@@ -80,7 +80,7 @@ public:
   const CDateTime& GetLastPlayed() const;
   const CDateTime& GetDateAdded() const;
   bool  GetCompilation() const;
-  char  GetRating() const;
+  char  GetUserrating() const;
   int  GetListeners() const;
   int  GetPlayCount() const;
   const EmbeddedArtInfo &GetCoverArtInfo() const;
@@ -121,7 +121,7 @@ public:
   void SetMood(const std::string& mood);
   void SetLyrics(const std::string& lyrics);
   void SetCueSheet(const std::string& cueSheet);
-  void SetRating(char rating);
+  void SetUserrating(char rating);
   void SetListeners(int listeners);
   void SetPlayCount(int playcount);
   void SetLastPlayed(const std::string& strLastPlayed);

--- a/xbmc/music/tags/TagLoaderTagLib.cpp
+++ b/xbmc/music/tags/TagLoaderTagLib.cpp
@@ -503,8 +503,8 @@ bool CTagLoaderTagLib::ParseID3v2Tag(ID3v2::Tag *id3v2, EmbeddedArt *art, CMusic
         
         // @xbmc.org ratings trump others (of course)
         if      (popFrame->email() == "ratings@xbmc.org")
-          tag.SetRating(popFrame->rating() / 51 + '0');
-        else if (tag.GetRating() == '0')
+          tag.SetUserrating(popFrame->rating() / 51 + '0');
+        else if (tag.GetUserrating() == '0')
         {
           if (popFrame->email() != "Windows Media Player 9 Series" &&
               popFrame->email() != "Banshee" &&
@@ -512,7 +512,7 @@ bool CTagLoaderTagLib::ParseID3v2Tag(ID3v2::Tag *id3v2, EmbeddedArt *art, CMusic
               popFrame->email() != "quodlibet@lists.sacredchao.net" &&
               popFrame->email() != "rating@winamp.com")
             CLog::Log(LOGDEBUG, "unrecognized ratings schema detected: %s", popFrame->email().toCString(true));
-          tag.SetRating(POPMtoXBMC(popFrame->rating()));
+          tag.SetUserrating(POPMtoXBMC(popFrame->rating()));
         }
       }
     else if (g_advancedSettings.m_logLevel == LOG_LEVEL_MAX)
@@ -674,7 +674,7 @@ bool CTagLoaderTagLib::ParseXiphComment(Ogg::XiphComment *xiph, EmbeddedArt *art
       // So, that's what we'll support for now.
       int iRating = it->second.front().toInt();
       if (iRating > 0 && iRating <= 100)
-        tag.SetRating((iRating / 20) + '0');
+        tag.SetUserrating((iRating / 20) + '0');
     }
     else if (it->first == "METADATA_BLOCK_PICTURE")
     {

--- a/xbmc/utils/DatabaseUtils.cpp
+++ b/xbmc/utils/DatabaseUtils.cpp
@@ -507,7 +507,7 @@ int DatabaseUtils::GetField(Field field, const MediaType &mediaType, bool asInde
     else if (field == FieldStartOffset) return CMusicDatabase::song_iStartOffset;
     else if (field == FieldEndOffset) return CMusicDatabase::song_iEndOffset;
     else if (field == FieldLastPlayed) return CMusicDatabase::song_lastplayed;
-    else if (field == FieldRating) return CMusicDatabase::song_rating;
+    else if (field == FieldRating) return CMusicDatabase::song_userrating;
     else if (field == FieldComment) return CMusicDatabase::song_comment;
     else if (field == FieldMoods) return CMusicDatabase::song_mood;
     else if (field == FieldAlbum) return CMusicDatabase::song_strAlbum;

--- a/xbmc/utils/LabelFormatter.cpp
+++ b/xbmc/utils/LabelFormatter.cpp
@@ -250,8 +250,8 @@ std::string CLabelFormatter::GetMaskContent(const CMaskString &mask, const CFile
       value = item->m_dateTime.GetAsLocalizedTime("", false);
     break;
   case 'R': // rating
-    if (music && music->GetRating() != '0')
-      value.assign(1, music->GetRating());
+    if (music && music->GetUserrating() != '0')
+      value.assign(1, music->GetUserrating());
     else if (movie && movie->m_fRating != 0.f)
       value = StringUtils::Format("%.1f", movie->m_fRating);
     break;
@@ -439,7 +439,7 @@ void CLabelFormatter::FillMusicMaskContent(const char mask, const std::string &v
     tag->SetDuration(StringUtils::TimeStringToSeconds(value));
     break;
   case 'R': // rating
-    tag->SetRating(value[0]);
+    tag->SetUserrating(value[0]);
     break;
   }
 }

--- a/xbmc/utils/RecentlyAddedJob.cpp
+++ b/xbmc/utils/RecentlyAddedJob.cpp
@@ -232,7 +232,7 @@ bool CRecentlyAddedJob::UpdateMusic()
         }
       }
 
-      strRating = StringUtils::Format("%c", item->GetMusicInfoTag()->GetRating());
+      strRating = StringUtils::Format("%c", item->GetMusicInfoTag()->GetUserrating());
       
       home->SetProperty("LatestSong." + value + ".Title"   , item->GetMusicInfoTag()->GetTitle());
       home->SetProperty("LatestSong." + value + ".Year"    , item->GetMusicInfoTag()->GetYear());

--- a/xbmc/utils/test/TestDatabaseUtils.cpp
+++ b/xbmc/utils/test/TestDatabaseUtils.cpp
@@ -56,7 +56,7 @@ public:
     song_iStartOffset = CMusicDatabase::song_iStartOffset;
     song_iEndOffset = CMusicDatabase::song_iEndOffset;
     song_lastplayed = CMusicDatabase::song_lastplayed;
-    song_rating = CMusicDatabase::song_rating;
+    song_userrating = CMusicDatabase::song_userrating;
     song_comment = CMusicDatabase::song_comment;
     song_strAlbum = CMusicDatabase::song_strAlbum;
     song_strPath = CMusicDatabase::song_strPath;
@@ -88,7 +88,7 @@ public:
   int song_iStartOffset;
   int song_iEndOffset;
   int song_lastplayed;
-  int song_rating;
+  int song_userrating;
   int song_comment;
   int song_strAlbum;
   int song_strPath;
@@ -911,7 +911,7 @@ TEST(TestDatabaseUtils, GetFieldIndex_MediaTypeSong)
   varindex = DatabaseUtils::GetFieldIndex(FieldLastPlayed, MediaTypeSong);
   EXPECT_EQ(refindex, varindex);
 
-  refindex = a.song_rating;
+  refindex = a.song_userrating;
   varindex = DatabaseUtils::GetFieldIndex(FieldRating, MediaTypeSong);
   EXPECT_EQ(refindex, varindex);
 

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -1145,6 +1145,15 @@ void CVideoInfoTag::SetNamedSeasons(std::map<int, std::string> namedSeasons)
   m_namedSeasons = std::move(namedSeasons);
 }
 
+void CVideoInfoTag::SetUserrating(int userrating)
+{
+  //This value needs to be between 0-10 - 0 will unset the userrating
+  userrating = std::max(userrating, 0);
+  userrating = std::min(userrating, 10);
+
+  m_iUserRating = userrating;
+}
+
 std::string CVideoInfoTag::Trim(std::string &&value)
 {
   return StringUtils::Trim(value);

--- a/xbmc/video/VideoInfoTag.h
+++ b/xbmc/video/VideoInfoTag.h
@@ -126,6 +126,7 @@ public:
   void SetShowLink(std::vector<std::string> showLink);
   void SetUniqueId(std::string uniqueId);
   void SetNamedSeasons(std::map<int, std::string> namedSeasons);
+  void SetUserrating(int userrating);
 
   std::string m_basePath; // the base path of the video, for folder-based lookups
   int m_parentPathID;      // the parent path id where the base path of the video lies

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.h
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.h
@@ -37,6 +37,7 @@ public:
   bool NeedRefresh() const;
   bool RefreshAll() const;
   bool HasUpdatedThumb() const { return m_hasUpdatedThumb; };
+  bool HasUpdatedUserrating() const { return m_hasUpdatedUserrating; };
 
   std::string GetThumbnail() const;
   virtual CFileItemPtr GetCurrentListItem(int offset = 0) { return m_movieItem; }
@@ -68,6 +69,7 @@ protected:
   virtual void OnInitWindow();
   void Update();
   void SetLabel(int iControl, const std::string& strLabel);
+  void SetUserrating(int userrating);
 
   // link cast to movies
   void ClearCastList();
@@ -77,6 +79,7 @@ protected:
   void Play(bool resume = false);
   void OnGetArt();
   void OnGetFanart();
+  void OnSetUserrating();
   void PlayTrailer();
 
   static bool UpdateVideoItemSortTitle(const CFileItemPtr &pItem);
@@ -93,4 +96,6 @@ protected:
   bool m_bRefresh;
   bool m_bRefreshAll;
   bool m_hasUpdatedThumb;
+  bool m_hasUpdatedUserrating;
+  int m_startUserrating;
 };

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -377,6 +377,8 @@ bool CGUIWindowVideoBase::ShowIMDB(CFileItemPtr item, const ScraperPtr &info2, b
     *item->GetVideoInfoTag() = movieDetails;
     pDlgInfo->SetMovie(item.get());
     pDlgInfo->Open();
+    if (pDlgInfo->HasUpdatedUserrating())
+      return true;
     needsRefresh = pDlgInfo->NeedRefresh();
     if (!needsRefresh)
       return pDlgInfo->HasUpdatedThumb();


### PR DESCRIPTION
This adds the logic to increase and decrease userrating from the videoinfo. The videoinfo dialog can now have an up and down control and editing this will edit the userrating. It will also refresh the listing, if the userrating got changed.

Still needs some more testing, as I've only tested movies so far.

I have added a modified `DialogVideoInfo.xml` that needs to be removed before this can be merged.
Maybe one of our skinners can do a real replacement for it, otherwise I would like it to go in without that.
