### PR TITLE
UPnP: add support for video's user ratings through xbmc:userrating

### DIFF
--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.cpp
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.cpp
@@ -175,6 +175,8 @@ PLT_Didl::ConvertFilterToMask(const NPT_String& filter)
             mask |= PLT_FILTER_MASK_XBMC_UNIQUE_IDENTIFIER;
         } else if (NPT_String::CompareN(s + i, PLT_FILTER_FIELD_XBMC_COUNTRY, len, true) == 0) {
           mask |= PLT_FILTER_MASK_XBMC_COUNTRY;
+        } else if (NPT_String::CompareN(s + i, PLT_FILTER_FIELD_XBMC_USERRATING, len, true) == 0) {
+          mask |= PLT_FILTER_MASK_XBMC_USERRATING;
         }
 
         if (next_comma < 0) {

--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.h
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.h
@@ -101,6 +101,7 @@
 #define PLT_FILTER_MASK_XBMC_ARTWORK                NPT_UINT64_C(0x0000800000000000)
 #define PLT_FILTER_MASK_XBMC_UNIQUE_IDENTIFIER      NPT_UINT64_C(0x0001000000000000)
 #define PLT_FILTER_MASK_XBMC_COUNTRY                NPT_UINT64_C(0x0002000000000000)
+#define PLT_FILTER_MASK_XBMC_USERRATING             NPT_UINT64_C(0x0004000000000000)
 
 #define PLT_FILTER_FIELD_TITLE                      "dc:title"
 #define PLT_FILTER_FIELD_CREATOR                    "dc:creator"
@@ -152,6 +153,7 @@
 #define PLT_FILTER_FIELD_XBMC_ARTWORK               "xbmc:artwork"
 #define PLT_FILTER_FIELD_XBMC_UNIQUE_IDENTIFIER     "xbmc:uniqueidentifier"
 #define PLT_FILTER_FIELD_XBMC_COUNTRY               "xbmc:country"
+#define PLT_FILTER_FIELD_XBMC_USERRATING            "xbmc:userrating"
 
 extern const char* didl_header;
 extern const char* didl_footer;

--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp
@@ -262,6 +262,7 @@ PLT_MediaObject::Reset()
     m_XbmcInfo.artwork.Clear();
     m_XbmcInfo.unique_identifier = "";
     m_XbmcInfo.countries.Clear();
+    m_XbmcInfo.user_rating = 0;
 
     m_Didl = "";
 
@@ -615,6 +616,13 @@ PLT_MediaObject::ToDidl(NPT_UInt64 mask, NPT_String& didl)
         PLT_Didl::AppendXmlEscape(didl, (*it));
         didl += "</xbmc:country>";
       }
+    }
+
+    // user rating
+    if (mask & PLT_FILTER_MASK_XBMC_USERRATING) {
+      didl += "<xbmc:userrating>";
+      didl += NPT_String::FromInteger(m_XbmcInfo.user_rating);
+      didl += "</xbmc:userrating>";
     }
 
     // class is required

--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.h
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.h
@@ -171,6 +171,7 @@ typedef struct {
   PLT_Artworks artwork;
   NPT_String unique_identifier;
   NPT_List<NPT_String> countries;
+  NPT_Int32 user_rating;
 } PLT_XbmcInfo;
 
 typedef struct {

--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
@@ -70,7 +70,7 @@ typedef struct PLT_CapabilitiesData {
 typedef NPT_Reference<PLT_CapabilitiesData> PLT_CapabilitiesDataReference;
 
 // explicitely specify res otherwise WMP won't return a URL!
-#define PLT_DEFAULT_FILTER  "dc:date,dc:description,upnp:longDescription,upnp:genre,res,res@duration,res@size,upnp:albumArtURI,upnp:rating,upnp:lastPlaybackPosition,upnp:lastPlaybackTime,upnp:playbackCount,upnp:originalTrackNumber,upnp:episodeNumber,upnp:programTitle,upnp:seriesTitle,upnp:album,upnp:artist,upnp:author,upnp:director,dc:publisher,searchable,childCount,dc:title,dc:creator,upnp:actor,res@resolution,upnp:episodeCount,upnp:episodeSeason,xbmc:dateadded,xbmc:rating,xbmc:votes,xbmc:artwork,xbmc:uniqueidentifier,xbmc:country"
+#define PLT_DEFAULT_FILTER  "dc:date,dc:description,upnp:longDescription,upnp:genre,res,res@duration,res@size,upnp:albumArtURI,upnp:rating,upnp:lastPlaybackPosition,upnp:lastPlaybackTime,upnp:playbackCount,upnp:originalTrackNumber,upnp:episodeNumber,upnp:programTitle,upnp:seriesTitle,upnp:album,upnp:artist,upnp:author,upnp:director,dc:publisher,searchable,childCount,dc:title,dc:creator,upnp:actor,res@resolution,upnp:episodeCount,upnp:episodeSeason,xbmc:dateadded,xbmc:rating,xbmc:votes,xbmc:artwork,xbmc:uniqueidentifier,xbmc:country,xbmc:userrating"
 
 /*----------------------------------------------------------------------
 |   PLT_MediaContainerListener

--- a/lib/libUPnP/patches/0037-platinum-add-xbmc-userrating-for-user-ratings.patch
+++ b/lib/libUPnP/patches/0037-platinum-add-xbmc-userrating-for-user-ratings.patch
@@ -1,0 +1,100 @@
+From 6a10f12a22b3210beb18d09b11315cdd87a8c6eb Mon Sep 17 00:00:00 2001
+From: montellese <montellese@xbmc.org>
+Date: Mon, 14 Sep 2015 08:40:15 +0200
+Subject: [PATCH 1/3] platinum: add xbmc:userrating for user ratings
+
+---
+ lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.cpp       | 2 ++
+ lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.h         | 2 ++
+ lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp  | 8 ++++++++
+ lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.h    | 1 +
+ .../Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h     | 2 +-
+ 5 files changed, 14 insertions(+), 1 deletion(-)
+
+diff --git a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.cpp b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.cpp
+index 0f24ab3..b1ba66f 100644
+--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.cpp
++++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.cpp
+@@ -175,6 +175,8 @@ PLT_Didl::ConvertFilterToMask(const NPT_String& filter)
+             mask |= PLT_FILTER_MASK_XBMC_UNIQUE_IDENTIFIER;
+         } else if (NPT_String::CompareN(s + i, PLT_FILTER_FIELD_XBMC_COUNTRY, len, true) == 0) {
+           mask |= PLT_FILTER_MASK_XBMC_COUNTRY;
++        } else if (NPT_String::CompareN(s + i, PLT_FILTER_FIELD_XBMC_USERRATING, len, true) == 0) {
++          mask |= PLT_FILTER_MASK_XBMC_USERRATING;
+         }
+ 
+         if (next_comma < 0) {
+diff --git a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.h b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.h
+index 49b92d0..1705f9c 100644
+--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.h
++++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.h
+@@ -101,6 +101,7 @@
+ #define PLT_FILTER_MASK_XBMC_ARTWORK                NPT_UINT64_C(0x0000800000000000)
+ #define PLT_FILTER_MASK_XBMC_UNIQUE_IDENTIFIER      NPT_UINT64_C(0x0001000000000000)
+ #define PLT_FILTER_MASK_XBMC_COUNTRY                NPT_UINT64_C(0x0002000000000000)
++#define PLT_FILTER_MASK_XBMC_USERRATING             NPT_UINT64_C(0x0004000000000000)
+ 
+ #define PLT_FILTER_FIELD_TITLE                      "dc:title"
+ #define PLT_FILTER_FIELD_CREATOR                    "dc:creator"
+@@ -152,6 +153,7 @@
+ #define PLT_FILTER_FIELD_XBMC_ARTWORK               "xbmc:artwork"
+ #define PLT_FILTER_FIELD_XBMC_UNIQUE_IDENTIFIER     "xbmc:uniqueidentifier"
+ #define PLT_FILTER_FIELD_XBMC_COUNTRY               "xbmc:country"
++#define PLT_FILTER_FIELD_XBMC_USERRATING            "xbmc:userrating"
+ 
+ extern const char* didl_header;
+ extern const char* didl_footer;
+diff --git a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp
+index 2e7d32b..01ef6e9 100644
+--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp
++++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp
+@@ -262,6 +262,7 @@ PLT_MediaObject::Reset()
+     m_XbmcInfo.artwork.Clear();
+     m_XbmcInfo.unique_identifier = "";
+     m_XbmcInfo.countries.Clear();
++    m_XbmcInfo.user_rating = 0;
+ 
+     m_Didl = "";
+ 
+@@ -617,6 +618,13 @@ PLT_MediaObject::ToDidl(NPT_UInt64 mask, NPT_String& didl)
+       }
+     }
+ 
++    // user rating
++    if (mask & PLT_FILTER_MASK_XBMC_USERRATING) {
++      didl += "<xbmc:userrating>";
++      didl += NPT_String::FromInteger(m_XbmcInfo.user_rating);
++      didl += "</xbmc:userrating>";
++    }
++
+     // class is required
+     didl += "<upnp:class";
+ 	if (!m_ObjectClass.friendly_name.IsEmpty()) {
+diff --git a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.h b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.h
+index 0efd505..98d47d8 100644
+--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.h
++++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.h
+@@ -171,6 +171,7 @@ typedef struct {
+   PLT_Artworks artwork;
+   NPT_String unique_identifier;
+   NPT_List<NPT_String> countries;
++  NPT_Int32 user_rating;
+ } PLT_XbmcInfo;
+ 
+ typedef struct {
+diff --git a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
+index 9b25d58..e52fb5a 100644
+--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
++++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
+@@ -70,7 +70,7 @@ typedef struct PLT_CapabilitiesData {
+ typedef NPT_Reference<PLT_CapabilitiesData> PLT_CapabilitiesDataReference;
+ 
+ // explicitely specify res otherwise WMP won't return a URL!
+-#define PLT_DEFAULT_FILTER  "dc:date,dc:description,upnp:longDescription,upnp:genre,res,res@duration,res@size,upnp:albumArtURI,upnp:rating,upnp:lastPlaybackPosition,upnp:lastPlaybackTime,upnp:playbackCount,upnp:originalTrackNumber,upnp:episodeNumber,upnp:programTitle,upnp:seriesTitle,upnp:album,upnp:artist,upnp:author,upnp:director,dc:publisher,searchable,childCount,dc:title,dc:creator,upnp:actor,res@resolution,upnp:episodeCount,upnp:episodeSeason,xbmc:dateadded,xbmc:rating,xbmc:votes,xbmc:artwork,xbmc:uniqueidentifier,xbmc:country"
++#define PLT_DEFAULT_FILTER  "dc:date,dc:description,upnp:longDescription,upnp:genre,res,res@duration,res@size,upnp:albumArtURI,upnp:rating,upnp:lastPlaybackPosition,upnp:lastPlaybackTime,upnp:playbackCount,upnp:originalTrackNumber,upnp:episodeNumber,upnp:programTitle,upnp:seriesTitle,upnp:album,upnp:artist,upnp:author,upnp:director,dc:publisher,searchable,childCount,dc:title,dc:creator,upnp:actor,res@resolution,upnp:episodeCount,upnp:episodeSeason,xbmc:dateadded,xbmc:rating,xbmc:votes,xbmc:artwork,xbmc:uniqueidentifier,xbmc:country,xbmc:userrating"
+ 
+ /*----------------------------------------------------------------------
+ |   PLT_MediaContainerListener
+-- 
+1.9.5.msysgit.0
+

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -319,6 +319,7 @@ PopulateObjectFromTag(CVideoInfoTag&         tag,
     object.m_XbmcInfo.unique_identifier = tag.m_strIMDBNumber.c_str();
     for (const auto& country : tag.m_country)
       object.m_XbmcInfo.countries.Add(country.c_str());
+    object.m_XbmcInfo.user_rating = tag.m_iUserRating;
 
     for (unsigned int index = 0; index < tag.m_genre.size(); index++)
       object.m_Affiliation.genres.Add(tag.m_genre.at(index).c_str());
@@ -830,6 +831,7 @@ PopulateTagFromObject(CVideoInfoTag&         tag,
     tag.m_strIMDBNumber = object.m_XbmcInfo.unique_identifier;
     for (unsigned int index = 0; index < object.m_XbmcInfo.countries.GetItemCount(); index++)
       tag.m_country.push_back(object.m_XbmcInfo.countries.GetItem(index)->GetChars());
+    tag.m_iUserRating = object.m_XbmcInfo.user_rating;
 
     for (unsigned int index = 0; index < object.m_Affiliation.genres.GetItemCount(); index++)
     {


### PR DESCRIPTION
This is a follow-up of #8045 for the recently added video user ratings. It needs to go in after #8045.
