### PR TITLE
Use SWS_BILINEAR (workaround segfaults and better quality)

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/DVDCodecUtils.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/DVDCodecUtils.cpp
@@ -270,7 +270,7 @@ DVDVideoPicture* CDVDCodecUtils::ConvertToYUV422PackedPicture(DVDVideoPicture *p
 
         struct SwsContext *ctx = sws_getContext(pSrc->iWidth, pSrc->iHeight, PIX_FMT_YUV420P,
                                                            pPicture->iWidth, pPicture->iHeight, (AVPixelFormat)dstformat,
-                                                           SWS_FAST_BILINEAR | SwScaleCPUFlags(), NULL, NULL, NULL);
+                                                           SWS_BILINEAR | SwScaleCPUFlags(), NULL, NULL, NULL);
         sws_scale(ctx, src, srcStride, 0, pSrc->iHeight, dst, dstStride);
         sws_freeContext(ctx);
       }


### PR DESCRIPTION
By chance I stumbled up on a 7840x4320 file that - while rescaling with sws produced a nice issue in asm code. Most likely cause of missing alignment: https://trac.ffmpeg.org/ticket/4850#comment:1

As we changed our default for fanart / posters recently. This fixes the segfault bug and improves the preview picture quality.

Update: Crashes also on ARM.
