### PR TITLE
[music] Removed refresh on artist/album info

### DIFF
--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -343,10 +343,11 @@ void CGUIWindowMusicBase::ShowArtistInfo(const CFileItem *pItem, bool bShowInfo 
       return;
 
   m_musicdatabase.GetArtistPath(params.GetArtistId(), artist.strPath);
+  bool refresh = false;
   while (1)
   {
-    // Check if we have the information in the database first
-    if (!m_musicdatabase.HasArtistBeenScraped(params.GetArtistId()))
+    // Check if the entry should be refreshed (Only happens if a user pressed refresh)
+    if (refresh)
     {
       if (!CProfilesManager::GetInstance().GetCurrentProfile().canWriteDatabases() && !g_passwordManager.bMasterUser)
         break; // should display a dialog saying no permissions
@@ -387,6 +388,7 @@ void CGUIWindowMusicBase::ShowArtistInfo(const CFileItem *pItem, bool bShowInfo 
       if (pDlgArtistInfo->NeedRefresh())
       {
         m_musicdatabase.ClearArtistLastScrapedTime(params.GetArtistId());
+        refresh = true;
         continue;
       } 
       else if (pDlgArtistInfo->HasUpdatedThumb()) 
@@ -414,9 +416,11 @@ bool CGUIWindowMusicBase::ShowAlbumInfo(const CFileItem *pItem, bool bShowInfo /
     return false;
 
   m_musicdatabase.GetAlbumPath(params.GetAlbumId(), album.strPath);
+  bool refresh = false;
   while (1)
   {
-    if (!m_musicdatabase.HasAlbumBeenScraped(params.GetAlbumId()))
+    // Check if the entry should be refreshed (Only happens if a user pressed refresh)
+    if (refresh)
     {
       if (!CProfilesManager::GetInstance().GetCurrentProfile().canWriteDatabases() && !g_passwordManager.bMasterUser)
       {
@@ -466,6 +470,7 @@ bool CGUIWindowMusicBase::ShowAlbumInfo(const CFileItem *pItem, bool bShowInfo /
       if (pDlgAlbumInfo->NeedRefresh())
       {
         m_musicdatabase.ClearAlbumLastScrapedTime(params.GetAlbumId());
+        refresh = true;
         continue;
       }
       else if (pDlgAlbumInfo->HasUpdatedThumb())


### PR DESCRIPTION
There is a problem (thread about it: http://forum.kodi.tv/showthread.php?tid=238853) where when you check for artist/album information and the scraper can't find any information it will get stuck in a loop where you get to reenter the name of the album and/or artist and unless you change the album and/or artist to something the scraper can find it will never show the information page for the album or artist. Since you need to be able to get to the information page to be able to select "get thumb", you are unable to set (or change in the case one was found locally during scanning) for an item that the scraper can't find. 

This change does the following change, it disables refresh when showing the information page (for an artist and/or album that hasn't been scraped). The advantage with doing it like this is that just checking the information on an artist and/or album wont change any information without a direct action from the user. 

@Razzeee @DaveTBlake @zag2me 
What do you think?
