### PR TITLE
Update .gitignore for bootstrapped addons definition files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -293,6 +293,7 @@ lib/cpluff/stamp-h1
 /project/cmake/addons/*.error
 /project/cmake/addons/.failure
 /project/cmake/addons/.success
+/project/cmake/addons/addons
 /project/cmake/addons/build
 /project/cmake/addons/depends/build
 /project/cmake/addons/output


### PR DESCRIPTION
After running .\tools\buildsteps\win32\bootstrap-addons.bat on windows, the addon definition files/repo are flagged by git status.  Update .gitignore to ignore these bootstrapped files
