### PR TITLE
[music] When adding a new music directory, ask the user about the con…

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -11843,11 +11843,13 @@ msgid "Remote fanart"
 msgstr ""
 
 #: xbmc/video/windows/GUIWindowVideoBase.cpp
+#: xbmc/music/windows/GUIWindowMusicBase.cpp
 msgctxt "#20442"
 msgid "Change content"
 msgstr ""
 
 #: xbmc/video/windows/GUIWindowVideoBase.cpp
+#: xbmc/music/windows/GUIWindowMusicBase.cpp
 msgctxt "#20443"
 msgid "Do you want to refresh information for all items within this path?"
 msgstr ""

--- a/xbmc/dialogs/GUIDialogMediaSource.cpp
+++ b/xbmc/dialogs/GUIDialogMediaSource.cpp
@@ -23,6 +23,7 @@
 #include "guilib/GUIKeyboardFactory.h"
 #include "GUIDialogFileBrowser.h"
 #include "video/windows/GUIWindowVideoBase.h"
+#include "music/windows/GUIWindowMusicBase.h"
 #include "guilib/GUIWindowManager.h"
 #include "input/Key.h"
 #include "Util.h"
@@ -389,11 +390,13 @@ void CGUIDialogMediaSource::OnOK()
   {
     m_confirmed = true;
     Close();
-    if (m_type == "video" && !URIUtils::IsLiveTV(share.strPath) && 
-        !StringUtils::StartsWithNoCase(share.strPath, "rss://") &&
+    if (!StringUtils::StartsWithNoCase(share.strPath, "rss://") &&
         !StringUtils::StartsWithNoCase(share.strPath, "upnp://"))
     {
-      CGUIWindowVideoBase::OnAssignContent(share.strPath);
+      if (m_type == "video" && !URIUtils::IsLiveTV(share.strPath))
+        CGUIWindowVideoBase::OnAssignContent(share.strPath);
+      else if (m_type == "music")
+        CGUIWindowMusicBase::OnAssignContent(share.strPath);
     }
   }
 

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -368,6 +368,7 @@ public:
   /////////////////////////////////////////////////
   bool SetScraperForPath(const std::string& strPath, const ADDON::ScraperPtr& info);
   bool GetScraperForPath(const std::string& strPath, ADDON::ScraperPtr& info, const ADDON::TYPE &type);
+  bool GetScraperForPath(const std::string & strPath, ADDON::ScraperPtr & info, const ADDON::TYPE & type, CONTENT_TYPE & content);
   
   /*! \brief Check whether a given scraper is in use.
    \param scraperID the scraper to check for.
@@ -457,6 +458,12 @@ public:
    \sa GetArtForItem
    */
   std::string GetArtistArtForItem(int mediaId, const std::string &mediaType, const std::string &artType);
+
+  /*! \brief Converts a Vfs to an absolute path
+  \param the path that will be translated for e.g. musicdb://albums/1
+  \return the absolute path for e.g. on windows E:/Music
+  */
+  std::string TranslateVfsToPath(std::string path);
 
 protected:
   std::map<std::string, int> m_artistCache;

--- a/xbmc/music/windows/GUIWindowMusicBase.h
+++ b/xbmc/music/windows/GUIWindowMusicBase.h
@@ -49,6 +49,13 @@ public:
   void OnItemInfo(CFileItem *pItem, bool bShowInfo = false);
 
   void DoScan(const std::string &strPath);
+
+  /*! \brief Prompt the user for assigning content to a path.
+  Based on changes, we then call OnUnassignContent, update or refresh scraper information in the database
+  and optionally start a scan
+  \param path the path to assign content for
+  */
+  static void OnAssignContent(const std::string &path);
 protected:
   virtual void OnInitWindow();
   /*!

--- a/xbmc/settings/dialogs/GUIDialogContentSettings.cpp
+++ b/xbmc/settings/dialogs/GUIDialogContentSettings.cpp
@@ -437,8 +437,12 @@ void CGUIDialogContentSettings::FillContentTypes()
 
   if (m_content == CONTENT_ALBUMS || m_content == CONTENT_ARTISTS)
   {
-    FillContentTypes(m_content);
-    labels.push_back(std::make_pair(ADDON::TranslateContent(m_content, true), m_content));
+    FillContentTypes(CONTENT_ALBUMS);
+    FillContentTypes(CONTENT_ARTISTS);
+
+    labels.push_back(std::make_pair(ADDON::TranslateContent(CONTENT_ALBUMS, true), CONTENT_ALBUMS));
+    labels.push_back(std::make_pair(ADDON::TranslateContent(CONTENT_ARTISTS, true), CONTENT_ARTISTS));
+    // We might want to add CONTENT_NONE later, but it's not capable of handling this now
   }
   else
   {


### PR DESCRIPTION
…tent and if he wants to scan it

https://github.com/xbmc/xbmc/pull/8048#issuecomment-140036382 is now obsolete.

This will show the GUIDialogContentSettings (scraper selection), when an user is adding a new directory as music source.
Only tested on windows so far, will need tests on all platforms, as I changed a bunch of path handling stuff.

Kind of technical details:
- This converts VFS paths in the content table to absolute paths
- Disables the context menu entry for genres and folders that might contain albums/artists (just set these when you setup the folders)
- One central place for the GUIDialogContentSettings call handled like in the videodb
- Users can now select at will if they want to use an artist or album scraper
- After the scraper is set, it will ask if you want to scan
