### PR TITLE
[Fix]CMusicInfoTag: Remove duplicated setters added in #8012

### DIFF
--- a/xbmc/music/tags/MusicInfoTag.cpp
+++ b/xbmc/music/tags/MusicInfoTag.cpp
@@ -608,7 +608,6 @@ void CMusicInfoTag::SetAlbum(const CAlbum& album)
   SetAlbumReleaseType(album.releaseType);
   SetDateAdded(album.dateAdded);
   SetPlayCount(album.iTimesPlayed);
-  SetCompilation(album.bCompilation);
   SetDatabaseId(album.idAlbum, MediaTypeAlbum);
 
   SetLoaded();
@@ -635,7 +634,6 @@ void CMusicInfoTag::SetSong(const CSong& song)
   SetReleaseDate(stTime);
   SetTrackNumber(song.iTrack);
   SetDuration(song.iDuration);
-  SetPlayCount(song.iTimesPlayed);
   SetMood(song.strMood);
   SetCompilation(song.bCompilation);
   SetAlbumId(song.idAlbum);


### PR DESCRIPTION
Somehow in the merge of #8012 playcount and compilation values are now set twice, athough not obvious from the diff listing. Remove the duplicated lines of code. Look at full view of code to see it is duplicates that are removed.

@Montellese you may want to help this fix happen.
