### PR TITLE
[PVR] API enhancements (TimerType EPG Series restriction)

### DIFF
--- a/addons/xbmc.pvr/addon.xml
+++ b/addons/xbmc.pvr/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="xbmc.pvr" version="4.0.0" provider-name="Team-Kodi">
-  <backwards-compatibility abi="4.0.0"/>
+<addon id="xbmc.pvr" version="4.1.0" provider-name="Team-Kodi">
+  <backwards-compatibility abi="4.1.0"/>
   <requires>
     <import addon="xbmc.core" version="0.1.0"/>
   </requires>

--- a/xbmc/addons/include/xbmc_epg_types.h
+++ b/xbmc/addons/include/xbmc_epg_types.h
@@ -61,6 +61,10 @@
 /* Set EPGTAG.iGenreType to EPG_GENRE_USE_STRING to transfer genre strings to XBMC */
 #define EPG_GENRE_USE_STRING                          0x100
 
+/* EPG_TAG.iFlags values */
+const unsigned int EPG_TAG_FLAG_UNDEFINED =           0x00000000; /*!< @brief nothing special to say about this entry */
+const unsigned int EPG_TAG_FLAG_IS_SERIES =           0x00000001; /*!< @brief this EPG entry is part of a series */
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -94,6 +98,7 @@ extern "C" {
     int           iEpisodeNumber;      /*!< @brief (optional) episode number */
     int           iEpisodePartNumber;  /*!< @brief (optional) episode part number */
     const char *  strEpisodeName;      /*!< @brief (optional) episode name */
+    unsigned int  iFlags;              /*!< @brief (optional) bit field of independent flags associated with the EPG entry */
   } ATTRIBUTE_PACKED EPG_TAG;
 
 #ifdef __cplusplus

--- a/xbmc/addons/include/xbmc_pvr_types.h
+++ b/xbmc/addons/include/xbmc_pvr_types.h
@@ -142,6 +142,7 @@ extern "C" {
   const unsigned int PVR_TIMER_TYPE_SUPPORTS_MAX_RECORDINGS           = 0x00100000; /*!< @brief this type supports specifying a maximum recordings setting' (PVR_TIMER.iMaxRecordings) */
   const unsigned int PVR_TIMER_TYPE_REQUIRES_EPG_TAG_ON_CREATE        = 0x00200000; /*!< @brief this type shold not appear on any create menus which don't provide an associated EPG tag */
   const unsigned int PVR_TIMER_TYPE_FORBIDS_EPG_TAG_ON_CREATE         = 0x00400000; /*!< @brief this type should not appear on any create menus which provide an associated EPG tag */
+  const unsigned int PVR_TIMER_TYPE_REQUIRES_EPG_SERIES_ON_CREATE     = 0x00800000; /*!< @brief this type should not appear on any create menus unless associated with an EPG tag with 'series' attributes (EPG_TAG.iFlags & EPG_TAG_FLAG_IS_SERIES || EPG_TAG.iSeriesNumber > 0 || EPG_TAG.iEpisodeNumber > 0 || EPG_TAG.iEpisodePartNumber > 0). Implies PVR_TIMER_TYPE_REQUIRES_EPG_TAG_ON_CREATE */
 
   /*!
    * @brief PVR timer weekdays (PVR_TIMER.iWeekdays values)

--- a/xbmc/addons/include/xbmc_pvr_types.h
+++ b/xbmc/addons/include/xbmc_pvr_types.h
@@ -79,10 +79,10 @@ struct DemuxPacket;
 #define PVR_STREAM_MAX_STREAMS 20
 
 /* current PVR API version */
-#define XBMC_PVR_API_VERSION "4.0.0"
+#define XBMC_PVR_API_VERSION "4.1.0"
 
 /* min. PVR API version */
-#define XBMC_PVR_MIN_API_VERSION "4.0.0"
+#define XBMC_PVR_MIN_API_VERSION "4.1.0"
 
 #ifdef __cplusplus
 extern "C" {

--- a/xbmc/epg/EpgDatabase.cpp
+++ b/xbmc/epg/EpgDatabase.cpp
@@ -79,7 +79,8 @@ void CEpgDatabase::CreateTables(void)
         "iSeriesId       integer, "
         "iEpisodeId      integer, "
         "iEpisodePart    integer, "
-        "sEpisodeName    varchar(128)"
+        "sEpisodeName    varchar(128), "
+        "iFlags          integer"
       ")"
   );
   CLog::Log(LOGDEBUG, "EpgDB - %s - creating table 'lastepgscan'", __FUNCTION__);
@@ -113,6 +114,11 @@ void CEpgDatabase::UpdateTables(int iVersion)
     m_pDS->exec("ALTER TABLE epgtags ADD sWriter varchar(255);");
     m_pDS->exec("ALTER TABLE epgtags ADD iYear integer;");
     m_pDS->exec("ALTER TABLE epgtags ADD sIMDBNumber varchar(50);");
+  }
+
+  if (iVersion < 11)
+  {
+    m_pDS->exec("ALTER TABLE epgtags ADD iFlags integer;");
   }
 }
 
@@ -252,6 +258,7 @@ int CEpgDatabase::Get(CEpg &epg)
         newTag->m_strEpisodeName     = m_pDS->fv("sEpisodeName").get_asString().c_str();
         newTag->m_iSeriesNumber      = m_pDS->fv("iSeriesId").get_asInt();
         newTag->m_strIconPath        = m_pDS->fv("sIconPath").get_asString().c_str();
+        newTag->m_iFlags             = m_pDS->fv("iFlags").get_asInt();
 
         epg.AddEntry(*newTag);
         ++iReturn;
@@ -358,14 +365,14 @@ int CEpgDatabase::Persist(const CEpgInfoTag &tag, bool bSingleUpdate /* = true *
     strQuery = PrepareSQL("REPLACE INTO epgtags (idEpg, iStartTime, "
         "iEndTime, sTitle, sPlotOutline, sPlot, sOriginalTitle, sCast, sDirector, sWriter, iYear, sIMDBNumber, "
         "sIconPath, iGenreType, iGenreSubType, sGenre, iFirstAired, iParentalRating, iStarRating, bNotify, iSeriesId, "
-        "iEpisodeId, iEpisodePart, sEpisodeName, iBroadcastUid) "
-        "VALUES (%u, %u, %u, '%s', '%s', '%s', '%s', '%s', '%s', '%s', %i, '%s', '%s', %i, %i, '%s', %u, %i, %i, %i, %i, %i, %i, '%s', %i);",
+        "iEpisodeId, iEpisodePart, sEpisodeName, iFlags, iBroadcastUid) "
+        "VALUES (%u, %u, %u, '%s', '%s', '%s', '%s', '%s', '%s', '%s', %i, '%s', '%s', %i, %i, '%s', %u, %i, %i, %i, %i, %i, %i, '%s', %i, %i);",
         tag.EpgID(), iStartTime, iEndTime,
         tag.Title(true).c_str(), tag.PlotOutline(true).c_str(), tag.Plot(true).c_str(),
         tag.OriginalTitle(true).c_str(), tag.Cast().c_str(), tag.Director().c_str(), tag.Writer().c_str(), tag.Year(), tag.IMDBNumber().c_str(),
         tag.Icon().c_str(), tag.GenreType(), tag.GenreSubType(), strGenre.c_str(),
         iFirstAired, tag.ParentalRating(), tag.StarRating(), tag.Notify(),
-        tag.SeriesNumber(), tag.EpisodeNumber(), tag.EpisodePart(), tag.EpisodeName().c_str(),
+        tag.SeriesNumber(), tag.EpisodeNumber(), tag.EpisodePart(), tag.EpisodeName().c_str(), tag.Flags(),
         tag.UniqueBroadcastID());
   }
   else
@@ -373,14 +380,14 @@ int CEpgDatabase::Persist(const CEpgInfoTag &tag, bool bSingleUpdate /* = true *
     strQuery = PrepareSQL("REPLACE INTO epgtags (idEpg, iStartTime, "
         "iEndTime, sTitle, sPlotOutline, sPlot, sOriginalTitle, sCast, sDirector, sWriter, iYear, sIMDBNumber, "
         "sIconPath, iGenreType, iGenreSubType, sGenre, iFirstAired, iParentalRating, iStarRating, bNotify, iSeriesId, "
-        "iEpisodeId, iEpisodePart, sEpisodeName, iBroadcastUid, idBroadcast) "
-        "VALUES (%u, %u, %u, '%s', '%s', '%s', '%s', '%s', '%s', '%s', %i, '%s', '%s', %i, %i, '%s', %u, %i, %i, %i, %i, %i, %i, '%s', %i, %i);",
+        "iEpisodeId, iEpisodePart, sEpisodeName, iFlags, iBroadcastUid, idBroadcast) "
+        "VALUES (%u, %u, %u, '%s', '%s', '%s', '%s', '%s', '%s', '%s', %i, '%s', '%s', %i, %i, '%s', %u, %i, %i, %i, %i, %i, %i, '%s', %i, %i, %i);",
         tag.EpgID(), iStartTime, iEndTime,
         tag.Title(true).c_str(), tag.PlotOutline(true).c_str(), tag.Plot(true).c_str(),
         tag.OriginalTitle(true).c_str(), tag.Cast().c_str(), tag.Director().c_str(), tag.Writer().c_str(), tag.Year(), tag.IMDBNumber().c_str(),
         tag.Icon().c_str(), tag.GenreType(), tag.GenreSubType(), strGenre.c_str(),
         iFirstAired, tag.ParentalRating(), tag.StarRating(), tag.Notify(),
-        tag.SeriesNumber(), tag.EpisodeNumber(), tag.EpisodePart(), tag.EpisodeName().c_str(),
+        tag.SeriesNumber(), tag.EpisodeNumber(), tag.EpisodePart(), tag.EpisodeName().c_str(), tag.Flags(),
         tag.UniqueBroadcastID(), iBroadcastId);
   }
 

--- a/xbmc/epg/EpgDatabase.h
+++ b/xbmc/epg/EpgDatabase.h
@@ -57,7 +57,7 @@ namespace EPG
      * @brief Get the minimal database version that is required to operate correctly.
      * @return The minimal database version.
      */
-    virtual int GetSchemaVersion(void) const { return 10; };
+    virtual int GetSchemaVersion(void) const { return 11; };
 
     /*!
      * @brief Get the default sqlite database filename.

--- a/xbmc/epg/EpgInfoTag.cpp
+++ b/xbmc/epg/EpgInfoTag.cpp
@@ -53,7 +53,8 @@ CEpgInfoTag::CEpgInfoTag(void) :
     m_iEpisodePart(0),
     m_iUniqueBroadcastID(0),
     m_iYear(0),
-    m_epg(NULL)
+    m_epg(NULL),
+    m_iFlags(EPG_TAG_FLAG_UNDEFINED)
 {
 }
 
@@ -71,6 +72,7 @@ CEpgInfoTag::CEpgInfoTag(CEpg *epg, PVR::CPVRChannelPtr pvrChannel, const std::s
     m_iYear(0),
     m_strIconPath(strIconPath),
     m_epg(epg),
+    m_iFlags(EPG_TAG_FLAG_UNDEFINED),
     m_pvrChannel(pvrChannel)
 {
   UpdatePath();
@@ -100,6 +102,7 @@ CEpgInfoTag::CEpgInfoTag(const EPG_TAG &data) :
   m_iEpisodePart = data.iEpisodePartNumber;
   m_iStarRating = data.iStarRating;
   m_iYear = data.iYear;
+  m_iFlags = data.iFlags;
 
   SetGenre(data.iGenreType, data.iGenreSubType, data.strGenreDescription);
 
@@ -169,7 +172,8 @@ bool CEpgInfoTag::operator ==(const CEpgInfoTag& right) const
           m_strIconPath        == right.m_strIconPath &&
           m_strFileNameAndPath == right.m_strFileNameAndPath &&
           m_startTime          == right.m_startTime &&
-          m_endTime            == right.m_endTime);
+          m_endTime            == right.m_endTime &&
+          m_iFlags             == right.m_iFlags);
 }
 
 bool CEpgInfoTag::operator !=(const CEpgInfoTag& right) const
@@ -211,6 +215,7 @@ void CEpgInfoTag::Serialize(CVariant &value) const
   value["recording"] = recording ? recording->m_strFileNameAndPath : "";
   value["isactive"] = IsActive();
   value["wasactive"] = WasActive();
+  value["isseries"] = IsSeries();
 }
 
 CDateTime CEpgInfoTag::GetCurrentPlayingTime() const
@@ -605,7 +610,8 @@ bool CEpgInfoTag::Update(const CEpgInfoTag &tag, bool bUpdateBroadcastId /* = tr
         m_iUniqueBroadcastID != tag.m_iUniqueBroadcastID ||
         EpgID()              != tag.EpgID() ||
         m_genre              != tag.m_genre ||
-        m_strIconPath        != tag.m_strIconPath
+        m_strIconPath        != tag.m_strIconPath ||
+        m_iFlags             != tag.m_iFlags
     );
     if (bUpdateBroadcastId)
       bChanged |= (m_iBroadcastId != tag.m_iBroadcastId);
@@ -629,6 +635,7 @@ bool CEpgInfoTag::Update(const CEpgInfoTag &tag, bool bUpdateBroadcastId /* = tr
       m_iGenreType         = tag.m_iGenreType;
       m_iGenreSubType      = tag.m_iGenreSubType;
       m_epg                = tag.m_epg;
+      m_iFlags             = tag.m_iFlags;
 
       {
         CSingleLock lock(m_critSection);

--- a/xbmc/epg/EpgInfoTag.h
+++ b/xbmc/epg/EpgInfoTag.h
@@ -403,6 +403,11 @@ namespace EPG
      */
     bool Update(const CEpgInfoTag &tag, bool bUpdateBroadcastId = true);
 
+    /*!
+     * @brief status function to extract IsSeries boolean from EPG iFlags bitfield
+     */
+    bool IsSeries() const { return (m_iFlags & EPG_TAG_FLAG_IS_SERIES) > 0; }
+
   private:
 
     /*!
@@ -421,6 +426,11 @@ namespace EPG
      * @brief Get current time, taking timeshifting into account.
      */
     CDateTime GetCurrentPlayingTime(void) const;
+
+    /*!
+     *  @brief Return the m_iFlags as an unsigned int bitfield (for database use).
+     */
+    unsigned int Flags() const { return m_iFlags; }
 
     bool                     m_bNotify;            /*!< notify on start */
 
@@ -453,6 +463,8 @@ namespace EPG
     PVR::CPVRTimerInfoTagPtr m_timer;
 
     CEpg *                   m_epg;                /*!< the schedule that this event belongs to */
+
+    unsigned int             m_iFlags;             /*!< the flags applicable to this EPG entry */
 
     CCriticalSection         m_critSection;
     PVR::CPVRChannelPtr      m_pvrChannel;

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -737,6 +737,10 @@ void CGUIDialogPVRTimerSettings::InitializeTypesList()
       if (type->RequiresEpgTagOnCreate() && !m_timerInfoTag->HasEpgInfoTag())
         continue;
 
+      // Drop TimerTypes without 'Series' EPG attributes if none are set
+      if (type->RequiresEpgSeriesOnCreate() && !m_timerInfoTag->HasSeriesEpgInfoTag())
+        continue;
+
       // Drop TimerTypes that forbid EPGInfo, if it is populated
       if (type->ForbidsEpgTagOnCreate() && m_timerInfoTag->HasEpgInfoTag())
         continue;

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -879,6 +879,18 @@ bool CPVRTimerInfoTag::HasEpgInfoTag(void) const
   return m_epgTag != NULL;
 }
 
+bool CPVRTimerInfoTag::HasSeriesEpgInfoTag(void) const
+{
+  if (m_epgTag &&
+      (m_epgTag->IsSeries() ||
+       m_epgTag->SeriesNumber() > 0 ||
+       m_epgTag->EpisodeNumber() > 0 ||
+       m_epgTag->EpisodePart() > 0))
+    return true;
+  else
+    return false;
+}
+
 void CPVRTimerInfoTag::ClearEpgTag(void)
 {
   CEpgInfoTagPtr deletedTag;

--- a/xbmc/pvr/timers/PVRTimerInfoTag.h
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.h
@@ -103,6 +103,11 @@ namespace PVR
      */
     bool HasEpgInfoTag() const;
 
+    /*!
+     * @return True if this timer has corresponding epg info tag with series attributes, false otherwise
+     */
+    bool HasSeriesEpgInfoTag() const;
+
     int ChannelNumber(void) const;
     std::string ChannelName(void) const;
     std::string ChannelIcon(void) const;

--- a/xbmc/pvr/timers/PVRTimerType.h
+++ b/xbmc/pvr/timers/PVRTimerType.h
@@ -162,7 +162,14 @@ namespace PVR
      * @brief Check whether this timer type requires epg tag info to be present.
      * @return True if new instances require EPG info, false otherwise.
      */
-    bool RequiresEpgTagOnCreate() const { return (m_iAttributes & PVR_TIMER_TYPE_REQUIRES_EPG_TAG_ON_CREATE) > 0; }
+    bool RequiresEpgTagOnCreate() const { return (m_iAttributes & (PVR_TIMER_TYPE_REQUIRES_EPG_TAG_ON_CREATE |
+                                                                   PVR_TIMER_TYPE_REQUIRES_EPG_SERIES_ON_CREATE)) > 0; }
+
+    /*!
+     * @brief Check whether this timer type requires epg tag info including series attributes to be present.
+     * @return True if new instances require an EPG tag with series attributes, false otherwise.
+     */
+    bool RequiresEpgSeriesOnCreate() const { return (m_iAttributes & PVR_TIMER_TYPE_REQUIRES_EPG_SERIES_ON_CREATE) > 0; }
 
     /*!
      * @brief Check whether this type supports the "enabling/disabling" of timers of its type.


### PR DESCRIPTION
This is a cut down version of #8032 containing only the Epg "IsSeries" flag, and the ability to enforce that a TimerType is only applicable when an EPG item has "IsSeries" set.  

The desire is to get this into Jarvis because without it, backend errors occur for users of pvr.wmc addon as mentioned in this forum thread http://forum.kodi.tv/showthread.php?tid=227026&pid=2100875#pid2100875 and PR #8032 

The first 5 commits are cherry picked straight from @metaron-uk 's pull request, and the final commit is me responding to the requested modifications by @ksooo 

Summary of changes:
- Implement iFlags attribute on EPG item (including storage in EPG Database).  Currently only IsSeries flag is supported, but more will be added down the track, as concrete use cases arise
- Implement TimerType attribute PVR_TIMER_TYPE_REQUIRES_EPG_SERIES_ON_CREATE and logic to hide TimerTypes with this attribute dependent on EPG IsSeries() property
  
  @ksooo, @metaron-uk , @krustyreturns, @janbar, @glenn-1990, @Jalle19, @opdenkamp, @FernetMenta, @xhaggi 
