### PR TITLE
[PVR] Fix empty VideoPlayer.Plot when playing recorded TV

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -4370,6 +4370,14 @@ std::string CGUIInfoManager::GetVideoLabel(int item)
       }
     }
   }
+  else if (m_currentFile->HasPVRRecordingInfoTag())
+  {
+    switch (item)
+    {
+    case VIDEOPLAYER_PLOT:
+      return m_currentFile->GetPVRRecordingInfoTag()->m_strPlot;
+    }
+  }
   else if (m_currentFile->HasVideoInfoTag())
   {
     switch (item)


### PR DESCRIPTION
This something that has been asked about on the forums (http://forum.kodi.tv/archive/index.php?thread-219946.html) and by me so I have tried to see if I could code it myself. Hopefully I've done it right this time not like #7737 and #7742 

@ksooo, can you take a look please, fingers crossed I'm not wasting more of your time.
