### PR TITLE
[Isengard] DXVA rewind fix

### DIFF
--- a/xbmc/cores/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoRenderers/RenderManager.cpp
@@ -1226,11 +1226,12 @@ void CXBMCRenderManager::DiscardBuffer()
   m_presentevent.notifyAll();
 }
 
-bool CXBMCRenderManager::GetStats(double &sleeptime, double &pts, int &bufferLevel)
+bool CXBMCRenderManager::GetStats(double &sleeptime, double &pts, int &queued, int &discard)
 {
   CSingleLock lock(m_presentlock);
   sleeptime = m_sleeptime;
   pts = m_presentpts;
-  bufferLevel = m_queued.size() + m_discard.size();
+  queued = m_queued.size();
+  discard  = m_discard.size();
   return true;
 }

--- a/xbmc/cores/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoRenderers/RenderManager.h
@@ -186,7 +186,7 @@ public:
    * Can be called by player for lateness detection. This is done best by
    * looking at the end of the queue.
    */
-  bool GetStats(double &sleeptime, double &pts, int &bufferLevel);
+  bool GetStats(double &sleeptime, double &pts, int &queued, int &discard);
 
   /**
    * Video player call this on flush in oder to discard any queued frames

--- a/xbmc/cores/VideoRenderers/WinRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/WinRenderer.cpp
@@ -1337,7 +1337,7 @@ CRenderInfo CWinRenderer::GetRenderInfo()
   CRenderInfo info;
   info.formats = m_formats;
   info.max_buffer_size = NUM_BUFFERS;
-  if (m_format == RENDER_FMT_DXVA && m_processor)
+  if (m_renderMethod == RENDER_DXVA && m_processor)
     info.optimal_buffer_size = m_processor->Size();
   else
     info.optimal_buffer_size = 3;
@@ -1353,7 +1353,7 @@ void CWinRenderer::ReleaseBuffer(int idx)
 bool CWinRenderer::NeedBufferForRef(int idx)
 {
   // check if processor wants to keep past frames
-  if (m_format == RENDER_FMT_DXVA && m_processor)
+  if (m_renderMethod == RENDER_DXVA && m_processor)
   {
     DXVABuffer** buffers = (DXVABuffer**)m_VideoBuffers;
 


### PR DESCRIPTION
The main problem is:
1) The DXVA processor allows (and requires for de-interlacing) a set of past frames. This causes the bufferLevel greater than 0.
3) DVDPlayerVideo drops any frame if bufferLevel is greater than 0 on rewind, so the renderer doesn't receive any new frame which causes freezing picture when DXVA processor is used.

This changes behavior DVDPlayerVideo to do not consider the discard queue before dropping frame on rewind.

This also fixes usage of the dxva processor size event if HW decoder is not used.

@FernetMenta ping
