### PR TITLE
CMusicInfoTag: Add missing MBID values when set from artist, album and song.…

### DIFF
--- a/xbmc/music/Album.cpp
+++ b/xbmc/music/Album.cpp
@@ -166,14 +166,31 @@ void CAlbum::MergeScrapedAlbum(const CAlbum& source, bool override /* = true */)
   infoSongs = source.infoSongs;
 }
 
-std::string CAlbum::GetArtistString() const
-{
-  return StringUtils::Join(artist, g_advancedSettings.m_musicItemSeparator);
-}
-
 std::string CAlbum::GetGenreString() const
 {
   return StringUtils::Join(genre, g_advancedSettings.m_musicItemSeparator);
+}
+
+const std::vector<std::string> CAlbum::GetAlbumArtist() const
+{
+  //Get artist names as vector from artist credits
+  std::vector<std::string> albumartists;
+  for (VECARTISTCREDITS::const_iterator artistCredit = artistCredits.begin(); artistCredit != artistCredits.end(); ++artistCredit)
+  {
+    albumartists.push_back(artistCredit->GetArtist());
+  }
+  return albumartists;
+}
+
+const std::vector<std::string> CAlbum::GetMusicBrainzAlbumArtistID() const
+{
+  //Get artist MusicBrainz IDs as vector from artist credits
+  std::vector<std::string> muisicBrainzID;
+  for (VECARTISTCREDITS::const_iterator artistCredit = artistCredits.begin(); artistCredit != artistCredits.end(); ++artistCredit)
+  {
+    muisicBrainzID.push_back(artistCredit->GetMusicBrainzArtistID());
+  }
+  return muisicBrainzID;
 }
 
 std::string CAlbum::GetReleaseType() const

--- a/xbmc/music/Album.h
+++ b/xbmc/music/Album.h
@@ -70,7 +70,15 @@ public:
     releaseType = Album;
   }
 
-  std::string GetArtistString() const;
+  /*! \brief Get album artist names from the vector of artistcredits objects
+  \return album artist names as a vector of strings
+  */
+  const std::vector<std::string> GetAlbumArtist() const;
+  
+  /*! \brief Get album artist MusicBrainz IDs from the vector of artistcredits objects
+  \return album artist MusicBrainz IDs as a vector of strings
+  */
+  const std::vector<std::string> GetMusicBrainzAlbumArtistID() const;
   std::string GetGenreString() const;
 
   typedef enum ReleaseType {

--- a/xbmc/music/Song.cpp
+++ b/xbmc/music/Song.cpp
@@ -160,6 +160,27 @@ void CSong::Clear()
   bCompilation = false;
   embeddedArt.clear();
 }
+const std::vector<std::string> CSong::GetArtist() const
+{
+  //Get artist names as vector from artist credits
+  std::vector<std::string> songartists;
+  for (VECARTISTCREDITS::const_iterator artistCredit = artistCredits.begin(); artistCredit != artistCredits.end(); ++artistCredit)
+  {
+    songartists.push_back(artistCredit->GetArtist());
+  }
+  return songartists;
+}
+
+const std::vector<std::string> CSong::GetMusicBrainzArtistID() const
+{
+  //Get artist MusicBrainz IDs as vector from artist credits
+  std::vector<std::string> muisicBrainzID;
+  for (VECARTISTCREDITS::const_iterator artistCredit = artistCredits.begin(); artistCredit != artistCredits.end(); ++artistCredit)
+  {
+    muisicBrainzID.push_back(artistCredit->GetMusicBrainzArtistID());
+  }
+  return muisicBrainzID;
+}
 
 bool CSong::HasArt() const
 {

--- a/xbmc/music/Song.h
+++ b/xbmc/music/Song.h
@@ -72,6 +72,16 @@ public:
     return false;
   }
 
+  /*! \brief Get artist names from the vector of artistcredits objects
+  \return artist names as a vector of strings
+  */
+  const std::vector<std::string> GetArtist() const;
+  
+  /*! \brief Get artist MusicBrainz IDs from the vector of artistcredits objects
+  \return artist MusicBrainz IDs as a vector of strings
+  */
+  const std::vector<std::string> GetMusicBrainzArtistID() const;
+
   /*! \brief whether this song has art associated with it
    Tests both the strThumb and embeddedArt members.
    */

--- a/xbmc/music/tags/MusicInfoTag.cpp
+++ b/xbmc/music/tags/MusicInfoTag.cpp
@@ -582,6 +582,7 @@ void CMusicInfoTag::SetArtist(const CArtist& artist)
   SetArtist(artist.strArtist);
   SetAlbumArtist(artist.strArtist);
   SetMusicBrainzArtistID({ artist.strMusicBrainzArtistID });
+  SetMusicBrainzAlbumArtistID({ artist.strMusicBrainzArtistID });
   SetGenre(artist.genre);
   SetMood(StringUtils::Join(artist.moods, g_advancedSettings.m_musicItemSeparator));
   SetDateAdded(artist.dateAdded);
@@ -592,11 +593,16 @@ void CMusicInfoTag::SetArtist(const CArtist& artist)
 
 void CMusicInfoTag::SetAlbum(const CAlbum& album)
 {
-  SetArtist(album.artist);
+  //Set all artist infomation from album artist credits and artist description
+  SetArtistDesc(album.strArtistDesc);
+  SetArtist(album.GetAlbumArtist());
+  SetMusicBrainzArtistID(album.GetMusicBrainzAlbumArtistID());
+  SetAlbumArtistDesc(album.strArtistDesc);
+  SetAlbumArtist(album.GetAlbumArtist());
+  SetMusicBrainzAlbumArtistID(album.GetMusicBrainzAlbumArtistID());
   SetAlbumId(album.idAlbum);
   SetAlbum(album.strAlbum);
   SetTitle(album.strAlbum);
-  SetAlbumArtist(album.artist);
   SetMusicBrainzAlbumID(album.strMusicBrainzAlbumID);
   SetGenre(album.genre);
   SetMood(StringUtils::Join(album.moods, g_advancedSettings.m_musicItemSeparator));
@@ -617,9 +623,12 @@ void CMusicInfoTag::SetSong(const CSong& song)
 {
   SetTitle(song.strTitle);
   SetGenre(song.genre);
-  SetArtist(song.artist);
+  //Set all artist infomation from song artist credits and artist description
+  SetArtistDesc(song.strArtistDesc);
+  SetArtist(song.GetArtist());
+  SetMusicBrainzArtistID(song.GetMusicBrainzArtistID());
   SetAlbum(song.strAlbum);
-  SetAlbumArtist(song.albumArtist);
+  SetAlbumArtist(song.albumArtist); //Only have album artist in song as vector, no desc or MBID
   SetMusicBrainzTrackID(song.strMusicBrainzTrackID);
   SetComment(song.strComment);
   SetCueSheet(song.strCueSheet);


### PR DESCRIPTION
After #8012 and #8071 I noticed that CMUSICInfoTag::SetArtist, SetAlbum and SetSong did not fully allow for artist credits. So while artist was being set as a string vector, the description and related MBIDs were not all being set. It also seems more robust to get artist names as well as musicbrainz IDs from the artist credits rather than names from the vector.

For historic reasons artist information (for song and album)  is stored as a decriptive string (how the user wants the concatonated names to be displayed), vector of strings (original design) and a vector of artist credits (inc MBID). This duplication is vulnerable to inconsistencies. I beleive it would be better to replace the string vector with a method that extracts artist names from the artist credits. I have created those methods here (for song and album), but not removed the public artist vector because it would mean call changes in more places. But I would suggest I do this in another PR if I have support from the experienced devs.

@Montellese this is an addition to the previous fixes, so have a look please.
@evilhamster you may have a view on this after the ARTISTS tag changes you did.

But I feel that what I have done here could just be merged, it is the greater method change that I propose we do sepeartely that could need some discussion.
