### PR TITLE
AdjustRefreshrate: Don't switch to bogus AVR introduced modes

### DIFF
--- a/xbmc/cores/VideoRenderers/BaseRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/BaseRenderer.cpp
@@ -254,7 +254,8 @@ RESOLUTION CBaseRenderer::FindClosestResolution(float fps, float multiplier, RES
       // concerning dimension and refreshrate weight
       // skip lower resolutions
       if (((int) m_sourceWidth < orig.iScreenWidth) // orig res large enough
-      || (info.iScreenWidth < orig.iScreenWidth) // new res is smaller
+      || (info.iScreenWidth < orig.iScreenWidth) // new width would be smaller
+      || (info.iScreenHeight < orig.iScreenHeight) // new height would be smaller
       || (info.dwFlags & D3DPRESENTFLAG_MODEMASK) != (curr.dwFlags & D3DPRESENTFLAG_MODEMASK)) // don't switch to interlaced modes
       {
         continue;


### PR DESCRIPTION
On AVRs with modes like:

```
<mode id="0xef" name="2880x576" w="2880" h="576" hz="50.00000" current="false" preferred="false"/>
<mode id="0xf0" name="2880x480" w="2880" h="480" hz="60.00000" current="false" preferred="false"/>
<mode id="0xf1" name="2880x480" w="2880" h="480" hz="59.94006" current="false" preferred="false"/>
```

the new code for also switching resolutions would have taken those into account, as it ignored the iScreenHeight when finding the new matching resolution.
