### PR TITLE
[guilib] Clean up dialognumeric a bit and get rid of the void*

### DIFF
--- a/xbmc/dialogs/GUIDialogNumeric.cpp
+++ b/xbmc/dialogs/GUIDialogNumeric.cpp
@@ -19,6 +19,9 @@
  */
 
 #include "GUIDialogNumeric.h"
+
+#include <cassert>
+
 #include "guilib/GUILabelControl.h"
 #include "utils/md5.h"
 #include "guilib/GUIWindowManager.h"
@@ -41,16 +44,15 @@
 
 
 CGUIDialogNumeric::CGUIDialogNumeric(void)
-    : CGUIDialog(WINDOW_DIALOG_NUMERIC, "DialogNumeric.xml")
+  : CGUIDialog(WINDOW_DIALOG_NUMERIC, "DialogNumeric.xml")
+  , m_bConfirmed{false}
+  , m_bCanceled{false}
+  , m_mode{INPUT_PASSWORD}
+  , m_block{0}
+  , m_lastblock{0}
+  , m_dirty{false}
 {
-  m_bConfirmed = false;
-  m_bCanceled = false;
-
-  m_mode = INPUT_PASSWORD;
-  m_block = 0;
-  m_lastblock = 0;
   memset(&m_datetime, 0, sizeof(SYSTEMTIME));
-  m_dirty = false;
   m_loadType = KEEP_IN_MEMORY;
 }
 
@@ -89,10 +91,10 @@ void CGUIDialogNumeric::OnInitWindow()
   }
 
   const CGUIControl *control = GetControl(CONTROL_HEADING_LABEL);
-  if (control != NULL)
+  if (control != nullptr)
     data["title"] = control->GetDescription();
 
-  data["value"] = GetOutput();
+  data["value"] = GetOutputString();
   ANNOUNCEMENT::CAnnouncementManager::GetInstance().Announce(ANNOUNCEMENT::Input, "xbmc", "OnInputRequested", data);
 }
 
@@ -117,24 +119,34 @@ bool CGUIDialogNumeric::OnAction(const CAction &action)
   else if (action.GetID() >= REMOTE_0 && action.GetID() <= REMOTE_9)
     OnNumber(action.GetID() - REMOTE_0);
   else if (action.GetID() >= KEY_VKEY && action.GetID() < KEY_ASCII)
-  { // input from the keyboard (vkey, not ascii)
-    BYTE b = action.GetID() & 0xFF;
-    if (b == XBMCVK_LEFT) OnPrevious();
-    else if (b == XBMCVK_RIGHT) OnNext();
-    else if (b == XBMCVK_RETURN || b == XBMCVK_NUMPADENTER) OnOK();
-    else if (b == XBMCVK_BACK) OnBackSpace();
-    else if (b == XBMCVK_ESCAPE) OnCancel();
+  { 
+    // input from the keyboard (vkey, not ascii)
+    uint8_t b = action.GetID() & 0xFF;
+    if (b == XBMCVK_LEFT)
+      OnPrevious();
+    else if (b == XBMCVK_RIGHT)
+      OnNext();
+    else if (b == XBMCVK_RETURN || b == XBMCVK_NUMPADENTER)
+      OnOK();
+    else if (b == XBMCVK_BACK)
+      OnBackSpace();
+    else if (b == XBMCVK_ESCAPE)
+      OnCancel();
   }
   else if (action.GetID() >= KEY_ASCII) // FIXME make it KEY_UNICODE
   { // input from the keyboard
-    if (action.GetUnicode() == 10 || action.GetUnicode() == 13) OnOK(); // enter
-    else if (action.GetUnicode() == 8) OnBackSpace(); // backspace
-    else if (action.GetUnicode() == 27) OnCancel(); // escape
+    if (action.GetUnicode() == 10 || action.GetUnicode() == 13)
+      OnOK(); // enter
+    else if (action.GetUnicode() == 8)
+      OnBackSpace(); // backspace
+    else if (action.GetUnicode() == 27)
+      OnCancel(); // escape
     else if (action.GetUnicode() >= 48 && action.GetUnicode() < 58)  // number
       OnNumber(action.GetUnicode() - 48);
   }
   else
     return CGUIDialog::OnAction(action);
+
   return true;
 }
 
@@ -205,13 +217,13 @@ void CGUIDialogNumeric::OnBackSpace()
 {
   if (!m_dirty && m_block)
   {
-    m_block--;
+    --m_block;
     return;
   }
   if (m_mode == INPUT_NUMBER || m_mode == INPUT_PASSWORD)
   { // just go back one character
     if (!m_number.empty())
-      m_number.erase(m_number.size() - 1);
+      m_number.erase(m_number.length() - 1);
   }
   else if (m_mode == INPUT_IP_ADDRESS)
   {
@@ -219,7 +231,7 @@ void CGUIDialogNumeric::OnBackSpace()
       m_ip[m_block] /= 10;
     else if (m_block)
     {
-      m_block--;
+      --m_block;
       m_dirty = false;
     }
   }
@@ -306,14 +318,9 @@ void CGUIDialogNumeric::FrameMove()
   unsigned int start = 0;
   unsigned int end = 0;
   if (m_mode == INPUT_PASSWORD)
-  {
-    for (unsigned int i=0; i < m_number.size(); i++)
-      strLabel += '*';
-  }
+    strLabel.assign(m_number.length(), '*');
   else if (m_mode == INPUT_NUMBER)
-  { // simple - just render text directly
     strLabel = m_number;
-  }
   else if (m_mode == INPUT_TIME)
   { // format up the time
     strLabel = StringUtils::Format("%2d:%02d", m_datetime.wHour, m_datetime.wMinute);
@@ -349,234 +356,41 @@ void CGUIDialogNumeric::FrameMove()
   CGUIDialog::FrameMove();
 }
 
-void CGUIDialogNumeric::OnNumber(unsigned int num)
+void CGUIDialogNumeric::OnNumber(uint32_t num)
 {
   ResetAutoClose();
 
-  if (m_mode == INPUT_NUMBER || m_mode == INPUT_PASSWORD)
+  switch (m_mode)
   {
+  case INPUT_NUMBER:
+  case INPUT_PASSWORD:
     m_number += num + '0';
-  }
-  else if (m_mode == INPUT_TIME)
-  {
-    if (m_block == 0) // hour
-    {
-      if (m_dirty) // have input the first digit
-      {
-        if (m_datetime.wHour < 2 || num < 4)
-        {
-          m_datetime.wHour *= 10;
-          m_datetime.wHour += num;
-        }
-        else
-          m_datetime.wHour = num;
-        m_block = 1;             // move to minutes
-        m_dirty = false;
-      }
-      else  // this is the first digit
-      {
-        m_datetime.wHour = num;
-        if (num > 2)
-        {
-          m_block = 1;             // move to minutes
-          m_dirty = false;
-        }
-        else
-          m_dirty = true;
-      }
-    }
-    else  // minute
-    {
-      if (m_dirty) // have input the first digit
-      {
-        m_datetime.wMinute *= 10;
-        m_datetime.wMinute += num;
-        m_block = 0;             // move to hours
-        m_dirty = false;
-      }
-      else  // this is the first digit
-      {
-        m_datetime.wMinute = num;
-        if (num > 5)
-        {
-          m_block = 0;           // move to hours
-          m_dirty = false;
-        }
-        else
-          m_dirty = true;
-      }
-    }
-  }
-  else if (m_mode == INPUT_TIME_SECONDS)
-  {
-    if (m_block == 0) // hour
-    {
-      if (m_dirty) // have input the first digit
-      {
-        m_datetime.wHour *= 10;
-        m_datetime.wHour += num;
-        m_block = 1;             // move to minutes - allows up to 99 hours
-        m_dirty = false;
-      }
-      else  // this is the first digit
-      {
-        m_datetime.wHour = num;
-        m_dirty = true;
-      }
-    }
-    else if (m_block == 1) // minute
-    {
-      if (m_dirty) // have input the first digit
-      {
-        m_datetime.wMinute *= 10;
-        m_datetime.wMinute += num;
-        m_block = 2;             // move to seconds - allows up to 99 minutes
-        m_dirty = false;
-      }
-      else  // this is the first digit
-      {
-        m_datetime.wMinute = num;
-        if (num > 5)
-        {
-          m_block = 2;           // move to seconds
-          m_dirty = false;
-        }
-        else
-          m_dirty = true;
-      }
-    }
-    else  // seconds
-    {
-      if (m_dirty) // have input the first digit
-      {
-        m_datetime.wSecond *= 10;
-        m_datetime.wSecond += num;
-        m_block = 0;             // move to hours
-        m_dirty = false;
-      }
-      else  // this is the first digit
-      {
-        m_datetime.wSecond = num;
-        if (num > 5)
-        {
-          m_block = 0;           // move to hours
-          m_dirty = false;
-        }
-        else
-          m_dirty = true;
-      }
-    }
-  }
-  else if (m_mode == INPUT_DATE)
-  {
-    if (m_block == 0) // day of month
-    {
-      if (m_dirty && (m_datetime.wDay < 3 || num < 2))
-      {
-        m_datetime.wDay *= 10;
-        m_datetime.wDay += num;
-      }
-      else
-        m_datetime.wDay = num;
-      if (m_datetime.wDay > 3)
-      {
-        m_block = 1;             // move to months
-        m_dirty = false;
-      }
-      else
-        m_dirty = true;
-    }
-    else if (m_block == 1)  // months
-    {
-      if (m_dirty && num < 3)
-      {
-        m_datetime.wMonth *= 10;
-        m_datetime.wMonth += num;
-      }
-      else
-        m_datetime.wMonth = num;
-      if (m_datetime.wMonth > 1)
-      {
-        VerifyDate(false);
-        m_block = 2;             // move to year
-        m_dirty = false;
-      }
-      else
-        m_dirty = true;
-    }
-    else // year
-    {
-      if (m_dirty && m_datetime.wYear < 1000)  // have taken input
-      {
-        m_datetime.wYear *= 10;
-        m_datetime.wYear += num;
-      }
-      else
-        m_datetime.wYear = num;
-      if (m_datetime.wYear > 1000)
-      {
-        VerifyDate(true);
-        m_block = 0;        // move to day of month
-        m_dirty = false;
-      }
-      else
-        m_dirty = true;
-    }
-  }
-  else if (m_mode == INPUT_IP_ADDRESS)
-  {
-    if (m_dirty && ((m_ip[m_block] < 25) || (m_ip[m_block] == 25 && num < 6) || !(m_block==0 && num==0)))
-    {
-      m_ip[m_block] *= 10;
-      m_ip[m_block] += num;
-    }
-    else
-      m_ip[m_block] = num;
-    if (m_ip[m_block] > 25 || (m_ip[m_block] == 0 && num == 0))
-    {
-      m_block++;
-      if (m_block > 3) m_block = 0;
-      m_dirty = false;
-    }
-    else
-      m_dirty = true;
+    break;
+  case INPUT_TIME:
+    HandleInputTime(num);
+    break;
+  case INPUT_TIME_SECONDS:
+    HandleInputSeconds(num);
+    break;
+  case INPUT_DATE:
+    HandleInputDate(num);
+    break;
+  case INPUT_IP_ADDRESS:
+    HandleInputIP(num);
+    break;
   }
 }
 
-void CGUIDialogNumeric::SetMode(INPUT_MODE mode, void *initial)
+void CGUIDialogNumeric::SetMode(INPUT_MODE mode, const SYSTEMTIME &initial)
 {
   m_mode = mode;
   m_block = 0;
   m_lastblock = 0;
   if (m_mode == INPUT_TIME || m_mode == INPUT_TIME_SECONDS || m_mode == INPUT_DATE)
   {
-    m_datetime = *(SYSTEMTIME *)initial;
+    m_datetime = initial;
     m_lastblock = (m_mode != INPUT_TIME) ? 2 : 1;
   }
-  else if (m_mode == INPUT_IP_ADDRESS)
-  {
-    m_lastblock = 3;
-    m_ip[0] = m_ip[1] = m_ip[2] = m_ip[3] = 0;
-    // copy ip string into numeric form
-    std::string ip = *(std::string *)initial;
-    unsigned int block = 0;
-    for (unsigned int i=0; i < ip.size(); i++)
-    {
-      if (ip[i] == '.')
-      {
-        block++;
-        if (block > m_lastblock)
-          break;
-      }
-      else if (isdigit(ip[i]))
-      {
-        m_ip[block] *= 10;
-        m_ip[block] += ip[i] - '0';
-      }
-    }
-  }
-  else if (m_mode == INPUT_NUMBER || m_mode == INPUT_PASSWORD)
-    m_number = *(std::string *)initial;
 }
 
 void CGUIDialogNumeric::SetMode(INPUT_MODE mode, const std::string &initial)
@@ -592,7 +406,7 @@ void CGUIDialogNumeric::SetMode(INPUT_MODE mode, const std::string &initial)
       // check if we have a pure number
       if (initial.find_first_not_of("0123456789") == std::string::npos)
       {
-        long seconds = strtol(initial.c_str(), NULL, 10);
+        long seconds = strtol(initial.c_str(), nullptr, 10);
         dateTime = seconds;
       }
       else
@@ -600,7 +414,7 @@ void CGUIDialogNumeric::SetMode(INPUT_MODE mode, const std::string &initial)
         std::string tmp = initial;
         // if we are handling seconds and if the string only contains
         // "mm:ss" we need to add dummy "hh:" to get "hh:mm:ss"
-        if (m_mode == INPUT_TIME_SECONDS && tmp.size() <= 5)
+        if (m_mode == INPUT_TIME_SECONDS && tmp.length() <= 5)
           tmp = "00:" + tmp;
         dateTime.SetFromDBTime(tmp);
       }
@@ -618,33 +432,49 @@ void CGUIDialogNumeric::SetMode(INPUT_MODE mode, const std::string &initial)
     dateTime.GetAsSystemTime(m_datetime);
     m_lastblock = (m_mode == INPUT_DATE) ? 2 : 1;
   }
-  else
-    SetMode(mode, (void*)&initial);
-}
-
-void CGUIDialogNumeric::GetOutput(void *output) const
-{
-  if (!output) return;
-  if (m_mode == INPUT_TIME || m_mode == INPUT_TIME_SECONDS || m_mode == INPUT_DATE)
-    memcpy(output, &m_datetime, sizeof(m_datetime));
   else if (m_mode == INPUT_IP_ADDRESS)
-    *(std::string *)output = StringUtils::Format("%d.%d.%d.%d", m_ip[0], m_ip[1], m_ip[2], m_ip[3]);
+  {
+    auto blocks = StringUtils::Split(initial, '.');
+    if (blocks.size() != 4)
+      return;
+
+    for (size_t i = 0; i < blocks.size(); ++i)
+    {
+      if (blocks[i].length() > 3)
+        return;
+
+      m_ip[i] = static_cast<uint8_t>(atoi(blocks[i].c_str()));
+    }
+  }
   else if (m_mode == INPUT_NUMBER || m_mode == INPUT_PASSWORD)
-    *(std::string *)output = m_number;
+    m_number = initial;
 }
 
-std::string CGUIDialogNumeric::GetOutput() const
+SYSTEMTIME CGUIDialogNumeric::GetOutput() const
 {
-  std::string output;
-  if (m_mode == INPUT_DATE)
-    output = StringUtils::Format("%02i/%02i/%04i", m_datetime.wDay, m_datetime.wMonth, m_datetime.wYear);
-  else if (m_mode == INPUT_TIME)
-    output = StringUtils::Format("%i:%02i", m_datetime.wHour, m_datetime.wMinute);
-  else if (m_mode == INPUT_TIME_SECONDS)
-    output = StringUtils::Format("%i:%02i:%02i", m_datetime.wHour, m_datetime.wMinute, m_datetime.wSecond);
-  else
-    GetOutput(&output);
-  return output;
+  assert(m_mode == INPUT_TIME || m_mode == INPUT_TIME_SECONDS || m_mode == INPUT_DATE);
+  return m_datetime;
+}
+
+std::string CGUIDialogNumeric::GetOutputString() const
+{
+  switch (m_mode)
+  {
+  case INPUT_DATE:
+    return StringUtils::Format("%02i/%02i/%04i", m_datetime.wDay, m_datetime.wMonth, m_datetime.wYear);
+  case INPUT_TIME:
+    return StringUtils::Format("%i:%02i", m_datetime.wHour, m_datetime.wMinute);
+  case INPUT_TIME_SECONDS:
+    return StringUtils::Format("%i:%02i:%02i", m_datetime.wHour, m_datetime.wMinute, m_datetime.wSecond);
+  case INPUT_IP_ADDRESS:
+    return StringUtils::Format("%d.%d.%d.%d", m_ip[0], m_ip[1], m_ip[2], m_ip[3]);
+  case INPUT_NUMBER:
+  case INPUT_PASSWORD:
+    return m_number;
+  }
+  
+  //should never get here
+  return std::string();
 }
 
 bool CGUIDialogNumeric::ShowAndGetSeconds(std::string &timeString, const std::string &heading)
@@ -656,12 +486,12 @@ bool CGUIDialogNumeric::ShowAndGetSeconds(std::string &timeString, const std::st
   time.wHour = seconds / 3600;
   time.wMinute = (seconds - time.wHour * 3600) / 60;
   time.wSecond = seconds - time.wHour * 3600 - time.wMinute * 60;
-  pDialog->SetMode(INPUT_TIME_SECONDS, (void *)&time);
+  pDialog->SetMode(INPUT_TIME_SECONDS, time);
   pDialog->SetHeading(heading);
   pDialog->Open();
   if (!pDialog->IsConfirmed() || pDialog->IsCanceled())
     return false;
-  pDialog->GetOutput(&time);
+  time = pDialog->GetOutput();
   seconds = time.wHour * 3600 + time.wMinute * 60 + time.wSecond;
   timeString = StringUtils::SecondsToTimeString(seconds);
   return true;
@@ -671,12 +501,12 @@ bool CGUIDialogNumeric::ShowAndGetTime(SYSTEMTIME &time, const std::string &head
 {
   CGUIDialogNumeric *pDialog = (CGUIDialogNumeric *)g_windowManager.GetWindow(WINDOW_DIALOG_NUMERIC);
   if (!pDialog) return false;
-  pDialog->SetMode(INPUT_TIME, (void *)&time);
+  pDialog->SetMode(INPUT_TIME, time);
   pDialog->SetHeading(heading);
   pDialog->Open();
   if (!pDialog->IsConfirmed() || pDialog->IsCanceled())
     return false;
-  pDialog->GetOutput(&time);
+  time = pDialog->GetOutput();
   return true;
 }
 
@@ -684,12 +514,12 @@ bool CGUIDialogNumeric::ShowAndGetDate(SYSTEMTIME &date, const std::string &head
 {
   CGUIDialogNumeric *pDialog = (CGUIDialogNumeric *)g_windowManager.GetWindow(WINDOW_DIALOG_NUMERIC);
   if (!pDialog) return false;
-  pDialog->SetMode(INPUT_DATE, (void *)&date);
+  pDialog->SetMode(INPUT_DATE, date);
   pDialog->SetHeading(heading);
   pDialog->Open();
   if (!pDialog->IsConfirmed() || pDialog->IsCanceled())
     return false;
-  pDialog->GetOutput(&date);
+  date = pDialog->GetOutput();
   return true;
 }
 
@@ -697,12 +527,12 @@ bool CGUIDialogNumeric::ShowAndGetIPAddress(std::string &IPAddress, const std::s
 {
   CGUIDialogNumeric *pDialog = (CGUIDialogNumeric *)g_windowManager.GetWindow(WINDOW_DIALOG_NUMERIC);
   if (!pDialog) return false;
-  pDialog->SetMode(INPUT_IP_ADDRESS, (void *)&IPAddress);
+  pDialog->SetMode(INPUT_IP_ADDRESS, IPAddress);
   pDialog->SetHeading(heading);
   pDialog->Open();
   if (!pDialog->IsConfirmed() || pDialog->IsCanceled())
     return false;
-  pDialog->GetOutput(&IPAddress);
+  IPAddress = pDialog->GetOutputString();
   return true;
 }
 
@@ -712,7 +542,7 @@ bool CGUIDialogNumeric::ShowAndGetNumber(std::string& strInput, const std::strin
   CGUIDialogNumeric *pDialog = (CGUIDialogNumeric *)g_windowManager.GetWindow(WINDOW_DIALOG_NUMERIC);
   pDialog->SetHeading( strHeading );
 
-  pDialog->SetMode(INPUT_NUMBER, (void *)&strInput);
+  pDialog->SetMode(INPUT_NUMBER, strInput);
   if (iAutoCloseTimeoutMs)
     pDialog->SetAutoClose(iAutoCloseTimeoutMs);
 
@@ -720,7 +550,7 @@ bool CGUIDialogNumeric::ShowAndGetNumber(std::string& strInput, const std::strin
 
   if (!pDialog->IsAutoClosed() && (!pDialog->IsConfirmed() || pDialog->IsCanceled()))
     return false;
-  pDialog->GetOutput(&strInput);
+  strInput = pDialog->GetOutputString();
   return true;
 }
 
@@ -790,10 +620,10 @@ bool CGUIDialogNumeric::ShowAndVerifyInput(std::string& strToVerify, const std::
   std::string strInput;
   if (!bVerifyInput)
     strInput = strToVerify;
-  pDialog->SetMode(INPUT_PASSWORD, (void *)&strInput);
+  pDialog->SetMode(INPUT_PASSWORD, strInput);
   pDialog->Open();
 
-  pDialog->GetOutput(&strInput);
+  strInput = pDialog->GetOutputString();
 
   if (!pDialog->IsConfirmed() || pDialog->IsCanceled())
   {
@@ -873,5 +703,201 @@ void CGUIDialogNumeric::OnCancel()
   m_bConfirmed = false;
   m_bCanceled = true;
   Close();
+}
+
+void CGUIDialogNumeric::HandleInputIP(uint32_t num)
+{
+  if (m_dirty && ((m_ip[m_block] < 25) || (m_ip[m_block] == 25 && num < 6) || !(m_block == 0 && num == 0)))
+  {
+    m_ip[m_block] *= 10;
+    m_ip[m_block] += num;
+  }
+  else
+    m_ip[m_block] = num;
+
+  if (m_ip[m_block] > 25 || (m_ip[m_block] == 0 && num == 0))
+  {
+    ++m_block;
+    if (m_block > 3) 
+      m_block = 0;
+    m_dirty = false;
+  }
+  else
+    m_dirty = true;
+}
+
+void CGUIDialogNumeric::HandleInputDate(uint32_t num)
+{ 
+  if (m_block == 0) // day of month
+  {
+    if (m_dirty && (m_datetime.wDay < 3 || num < 2))
+    {
+      m_datetime.wDay *= 10;
+      m_datetime.wDay += num;
+    }
+    else
+      m_datetime.wDay = num;
+
+    if (m_datetime.wDay > 3)
+    {
+      m_block = 1;             // move to months
+      m_dirty = false;
+    }
+    else
+      m_dirty = true;
+  }
+  else if (m_block == 1)  // months
+  {
+    if (m_dirty && num < 3)
+    {
+      m_datetime.wMonth *= 10;
+      m_datetime.wMonth += num;
+    }
+    else
+      m_datetime.wMonth = num;
+
+    if (m_datetime.wMonth > 1)
+    {
+      VerifyDate(false);
+      m_block = 2;             // move to year
+      m_dirty = false;
+    }
+    else
+      m_dirty = true;
+  }
+  else // year
+  {
+    if (m_dirty && m_datetime.wYear < 1000)  // have taken input
+    {
+      m_datetime.wYear *= 10;
+      m_datetime.wYear += num;
+    }
+    else
+      m_datetime.wYear = num;
+
+    if (m_datetime.wYear > 1000)
+    {
+      VerifyDate(true);
+      m_block = 0;        // move to day of month
+      m_dirty = false;
+    }
+    else
+      m_dirty = true;
+  }
+}
+
+void CGUIDialogNumeric::HandleInputSeconds(uint32_t num)
+{ 
+  if (m_block == 0) // hour
+  {
+    if (m_dirty) // have input the first digit
+    {
+      m_datetime.wHour *= 10;
+      m_datetime.wHour += num;
+      m_block = 1;             // move to minutes - allows up to 99 hours
+      m_dirty = false;
+    }
+    else  // this is the first digit
+    {
+      m_datetime.wHour = num;
+      m_dirty = true;
+    }
+  }
+  else if (m_block == 1) // minute
+  {
+    if (m_dirty) // have input the first digit
+    {
+      m_datetime.wMinute *= 10;
+      m_datetime.wMinute += num;
+      m_block = 2;             // move to seconds - allows up to 99 minutes
+      m_dirty = false;
+    }
+    else  // this is the first digit
+    {
+      m_datetime.wMinute = num;
+      if (num > 5)
+      {
+        m_block = 2;           // move to seconds
+        m_dirty = false;
+      }
+      else
+        m_dirty = true;
+    }
+  }
+  else  // seconds
+  {
+    if (m_dirty) // have input the first digit
+    {
+      m_datetime.wSecond *= 10;
+      m_datetime.wSecond += num;
+      m_block = 0;             // move to hours
+      m_dirty = false;
+    }
+    else  // this is the first digit
+    {
+      m_datetime.wSecond = num;
+      if (num > 5)
+      {
+        m_block = 0;           // move to hours
+        m_dirty = false;
+      }
+      else
+        m_dirty = true;
+    }
+  }
+}
+
+void CGUIDialogNumeric::HandleInputTime(uint32_t num)
+{ 
+  if (m_block == 0) // hour
+  {
+    if (m_dirty) // have input the first digit
+    {
+      if (m_datetime.wHour < 2 || num < 4)
+      {
+        m_datetime.wHour *= 10;
+        m_datetime.wHour += num;
+      }
+      else
+        m_datetime.wHour = num;
+
+      m_block = 1;             // move to minutes
+      m_dirty = false;
+    }
+    else  // this is the first digit
+    {
+      m_datetime.wHour = num;
+
+      if (num > 2)
+      {
+        m_block = 1;             // move to minutes
+        m_dirty = false;
+      }
+      else
+        m_dirty = true;
+    }
+  }
+  else  // minute
+  {
+    if (m_dirty) // have input the first digit
+    {
+      m_datetime.wMinute *= 10;
+      m_datetime.wMinute += num;
+      m_block = 0;             // move to hours
+      m_dirty = false;
+    }
+    else  // this is the first digit
+    {
+      m_datetime.wMinute = num;
+
+      if (num > 5)
+      {
+        m_block = 0;           // move to hours
+        m_dirty = false;
+      }
+      else
+        m_dirty = true;
+    }
+  }
 }
 

--- a/xbmc/dialogs/GUIDialogNumeric.h
+++ b/xbmc/dialogs/GUIDialogNumeric.h
@@ -20,6 +20,7 @@
  *
  */
 
+#include <cstdint>
 #include "guilib/GUIDialog.h"
 
 class CGUIDialogNumeric :
@@ -43,10 +44,10 @@ public:
   static bool ShowAndVerifyInput(std::string& strPassword, const std::string& strHeading, bool bGetUserInput);
 
   void SetHeading(const std::string &strHeading);
-  void SetMode(INPUT_MODE mode, void *initial);
+  void SetMode(INPUT_MODE mode, const SYSTEMTIME &initial);
   void SetMode(INPUT_MODE mode, const std::string &initial);
-  void GetOutput(void *output) const;
-  std::string GetOutput() const;
+  SYSTEMTIME GetOutput() const;
+  std::string GetOutputString() const;
 
   static bool ShowAndGetTime(SYSTEMTIME &time, const std::string &heading);
   static bool ShowAndGetDate(SYSTEMTIME &date, const std::string &heading);
@@ -58,7 +59,7 @@ protected:
   virtual void OnInitWindow();
   virtual void OnDeinitWindow(int nextWindowID);
 
-  void OnNumber(unsigned int num);
+  void OnNumber(uint32_t num);
   void VerifyDate(bool checkYear);
   void OnNext();
   void OnPrevious();
@@ -66,14 +67,19 @@ protected:
   void OnOK();
   void OnCancel();
 
+  void HandleInputIP(uint32_t num);
+  void HandleInputDate(uint32_t num);
+  void HandleInputSeconds(uint32_t num);
+  void HandleInputTime(uint32_t num);
+
   bool m_bConfirmed;
   bool m_bCanceled;
 
   INPUT_MODE m_mode;                // the current input mode
   SYSTEMTIME m_datetime;            // for time and date modes
-  WORD m_ip[4];                     // for ip address mode
-  unsigned int m_block;             // for time, date, and IP methods.
-  unsigned int m_lastblock;
+  uint8_t m_ip[4];                  // for ip address mode
+  uint32_t m_block;             // for time, date, and IP methods.
+  uint32_t m_lastblock;
   bool m_dirty;                     // true if the current block has been changed.
   std::string m_number;              ///< for number or password input
 };


### PR DESCRIPTION
What the title says, Coverity gives us warnings about the use of void\* and there's really no good reason we're using it here today.
