### PR TITLE
[Confluence] cleanup

### DIFF
--- a/addons/skin.confluence/720p/AddonBrowser.xml
+++ b/addons/skin.confluence/720p/AddonBrowser.xml
@@ -2,7 +2,6 @@
 <window>
 	<defaultcontrol always="true">50</defaultcontrol>
 	<menucontrol>9000</menucontrol>
-	<allowoverlay>no</allowoverlay>
 	<onload condition="!Skin.HasSetting(FirstTimeRun)">ActivateWindow(1112)</onload>
 	<views>50,51,550,551</views>
 	<controls>

--- a/addons/skin.confluence/720p/DialogAlbumInfo.xml
+++ b/addons/skin.confluence/720p/DialogAlbumInfo.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
 	<defaultcontrol always="true">5</defaultcontrol>
-	<allowoverlay>no</allowoverlay>
 	<controls>
 		<control type="group">
 			<visible>!Window.IsVisible(FileBrowser)</visible>

--- a/addons/skin.confluence/720p/DialogAudioDSPManager.xml
+++ b/addons/skin.confluence/720p/DialogAudioDSPManager.xml
@@ -3,7 +3,6 @@
 	<zorder>1</zorder>
 	<defaultcontrol>9000</defaultcontrol>
 	<include>dialogeffect</include>
-	<allowoverlay>no</allowoverlay>
 	<coordinates>
 		<left>40</left>
 		<top>40</top>

--- a/addons/skin.confluence/720p/DialogPVRChannelManager.xml
+++ b/addons/skin.confluence/720p/DialogPVRChannelManager.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
 	<defaultcontrol always="true">20</defaultcontrol>
-	<allowoverlay>no</allowoverlay>
 	<coordinates>
 		<left>80</left>
 		<top>65</top>

--- a/addons/skin.confluence/720p/DialogVideoInfo.xml
+++ b/addons/skin.confluence/720p/DialogVideoInfo.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
 	<defaultcontrol always="true">8</defaultcontrol>
-	<allowoverlay>no</allowoverlay>
 	<controls>
 		<control type="group">
 			<visible>!Window.IsVisible(FileBrowser)</visible>

--- a/addons/skin.confluence/720p/EventLog.xml
+++ b/addons/skin.confluence/720p/EventLog.xml
@@ -2,7 +2,6 @@
 <window>
 	<defaultcontrol always="true">570</defaultcontrol>
 	<menucontrol>9000</menucontrol>
-	<allowoverlay>no</allowoverlay>
 	<onload condition="!Skin.HasSetting(FirstTimeRun)">ActivateWindow(1112)</onload>
 	<views>570</views>
 	<controls>

--- a/addons/skin.confluence/720p/FileBrowser.xml
+++ b/addons/skin.confluence/720p/FileBrowser.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
 	<defaultcontrol always="true">450</defaultcontrol>
-	<allowoverlay>no</allowoverlay>
 	<coordinates>
 		<left>0</left>
 		<top>0</top>

--- a/addons/skin.confluence/720p/FileManager.xml
+++ b/addons/skin.confluence/720p/FileManager.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
 	<defaultcontrol>20</defaultcontrol>
-	<allowoverlay>no</allowoverlay>
 	<controls>
 		<include>CommonBackground</include>
 		<control type="image">

--- a/addons/skin.confluence/720p/Home.xml
+++ b/addons/skin.confluence/720p/Home.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
 	<defaultcontrol always="true">9000</defaultcontrol>
-	<allowoverlay>no</allowoverlay>
 	<onunload condition="Container(9000).Hasfocus(10) | Container(9000).Hasfocus(11) | ControlGroup(9010).HasFocus | ControlGroup(9016).HasFocus | ControlGroup(9017).HasFocus">SetProperty(VideosDirectLink,True)</onunload>
 	<onunload condition="ControlGroup(9011).HasFocus">SetProperty(MusicDirectLink,True)</onunload>
 	<onunload condition="Control.HasFocus(9000) + Container(9000).Hasfocus(2)">ClearProperty(VideosDirectLink)</onunload>

--- a/addons/skin.confluence/720p/LoginScreen.xml
+++ b/addons/skin.confluence/720p/LoginScreen.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
 	<defaultcontrol always="true">52</defaultcontrol>
-	<allowoverlay>no</allowoverlay>
 	<coordinates>
 		<left>0</left>
 		<top>0</top>

--- a/addons/skin.confluence/720p/MusicVisualisation.xml
+++ b/addons/skin.confluence/720p/MusicVisualisation.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
 	<defaultcontrol>-</defaultcontrol>
-	<allowoverlay>no</allowoverlay>
 	<controls>
 		<control type="visualisation" id="2">
 			<!-- FIX ME Music Visualization needs to have an id of 2 in this window to be able to lock or change preset -->

--- a/addons/skin.confluence/720p/MyMusicNav.xml
+++ b/addons/skin.confluence/720p/MyMusicNav.xml
@@ -2,7 +2,6 @@
 <window>
 	<defaultcontrol always="true">50</defaultcontrol>
 	<menucontrol>9000</menucontrol>
-	<allowoverlay>no</allowoverlay>
 	<onload condition="!Skin.HasSetting(FirstTimeRun)">ActivateWindow(1112)</onload>
 	<views>50,51,500,550,551,509,506,511,512,513</views>
 	<controls>

--- a/addons/skin.confluence/720p/MyMusicPlaylist.xml
+++ b/addons/skin.confluence/720p/MyMusicPlaylist.xml
@@ -2,7 +2,6 @@
 <window>
 	<defaultcontrol always="true">50</defaultcontrol>
 	<menucontrol>9000</menucontrol>
-	<allowoverlay>no</allowoverlay>
 	<onload condition="!Skin.HasSetting(FirstTimeRun)">ActivateWindow(1112)</onload>
 	<views>50,51,506</views>
 	<controls>

--- a/addons/skin.confluence/720p/MyMusicPlaylistEditor.xml
+++ b/addons/skin.confluence/720p/MyMusicPlaylistEditor.xml
@@ -2,7 +2,6 @@
 <window>
 	<defaultcontrol always="true">6</defaultcontrol>
 	<menucontrol>9000</menucontrol>
-	<allowoverlay>no</allowoverlay>
 	<controls>
 		<include>CommonBackground</include>
 		<control type="group">

--- a/addons/skin.confluence/720p/MyPVRChannels.xml
+++ b/addons/skin.confluence/720p/MyPVRChannels.xml
@@ -2,7 +2,6 @@
 <window>
 	<defaultcontrol always="true">50</defaultcontrol>
 	<menucontrol>9000</menucontrol>
-	<allowoverlay>no</allowoverlay>
 	<views>50,51</views>
 	<controls>
 		<include>CommonBackground</include>

--- a/addons/skin.confluence/720p/MyPVRGuide.xml
+++ b/addons/skin.confluence/720p/MyPVRGuide.xml
@@ -2,7 +2,6 @@
 <window>
 	<defaultcontrol always="true">10</defaultcontrol>
 	<menucontrol>9000</menucontrol>
-	<allowoverlay>no</allowoverlay>
 	<views>10,11,12,13</views>
 	<controls>
 		<include>CommonBackground</include>

--- a/addons/skin.confluence/720p/MyPVRRecordings.xml
+++ b/addons/skin.confluence/720p/MyPVRRecordings.xml
@@ -2,7 +2,6 @@
 <window>
 	<defaultcontrol always="true">50</defaultcontrol>
 	<menucontrol>9000</menucontrol>
-	<allowoverlay>no</allowoverlay>
 	<views>50</views>
 	<controls>
 		<include>CommonBackground</include>

--- a/addons/skin.confluence/720p/MyPVRSearch.xml
+++ b/addons/skin.confluence/720p/MyPVRSearch.xml
@@ -2,7 +2,6 @@
 <window>
 	<defaultcontrol always="true">50</defaultcontrol>
 	<menucontrol>9000</menucontrol>
-	<allowoverlay>no</allowoverlay>
 	<views>50</views>
 	<controls>
 		<include>CommonBackground</include>

--- a/addons/skin.confluence/720p/MyPVRTimers.xml
+++ b/addons/skin.confluence/720p/MyPVRTimers.xml
@@ -2,7 +2,6 @@
 <window>
 	<defaultcontrol always="true">50</defaultcontrol>
 	<menucontrol>9000</menucontrol>
-	<allowoverlay>no</allowoverlay>
 	<views>50</views>
 	<controls>
 		<include>CommonBackground</include>

--- a/addons/skin.confluence/720p/MyPics.xml
+++ b/addons/skin.confluence/720p/MyPics.xml
@@ -2,7 +2,6 @@
 <window>
 	<defaultcontrol always="true">50</defaultcontrol>
 	<menucontrol>9000</menucontrol>
-	<allowoverlay>no</allowoverlay>
 	<onload condition="!Skin.HasSetting(FirstTimeRun)">ActivateWindow(1112)</onload>
 	<views>50,51,550,551,500,514,510</views>
 	<controls>

--- a/addons/skin.confluence/720p/MyPrograms.xml
+++ b/addons/skin.confluence/720p/MyPrograms.xml
@@ -2,7 +2,6 @@
 <window>
 	<defaultcontrol always="true">50</defaultcontrol>
 	<menucontrol>9000</menucontrol>
-	<allowoverlay>no</allowoverlay>
 	<onload condition="!Skin.HasSetting(FirstTimeRun)">ActivateWindow(1112)</onload>
 	<views>50,51,500,550,551</views>
 	<controls>

--- a/addons/skin.confluence/720p/MyVideoNav.xml
+++ b/addons/skin.confluence/720p/MyVideoNav.xml
@@ -2,7 +2,6 @@
 <window>
 	<defaultcontrol always="true">50</defaultcontrol>
 	<menucontrol>9000</menucontrol>
-	<allowoverlay>no</allowoverlay>
 	<views>50,51,500,550,551,560,501,508,504,503,515,505,511</views>
 	<onload condition="!Skin.HasSetting(FirstTimeRun)">ActivateWindow(1112)</onload>
 	<controls>

--- a/addons/skin.confluence/720p/MyVideoPlaylist.xml
+++ b/addons/skin.confluence/720p/MyVideoPlaylist.xml
@@ -2,7 +2,6 @@
 <window>
 	<defaultcontrol always="true">50</defaultcontrol>
 	<menucontrol>9000</menucontrol>
-	<allowoverlay>no</allowoverlay>
 	<onload condition="!Skin.HasSetting(FirstTimeRun)">ActivateWindow(1112)</onload>
 	<views>50,51</views>
 	<controls>

--- a/addons/skin.confluence/720p/MyWeather.xml
+++ b/addons/skin.confluence/720p/MyWeather.xml
@@ -2,7 +2,6 @@
 <window>
 	<defaultcontrol always="true">50</defaultcontrol>
 	<menucontrol>9000</menucontrol>
-	<allowoverlay>no</allowoverlay>
 	<onload condition="!Skin.HasSetting(FirstTimeRun)">ActivateWindow(1112)</onload>
 	<controls>
 		<include>CommonBackground</include>

--- a/addons/skin.confluence/720p/Settings.xml
+++ b/addons/skin.confluence/720p/Settings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
 	<defaultcontrol always="true">9000</defaultcontrol>
-	<allowoverlay>no</allowoverlay>
 	<controls>
 		<include>CommonBackground</include>
 		<control type="image">

--- a/addons/skin.confluence/720p/SettingsCategory.xml
+++ b/addons/skin.confluence/720p/SettingsCategory.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
 	<defaultcontrol>3</defaultcontrol>
-	<allowoverlay>no</allowoverlay>
 	<controls>
 		<include>CommonBackground</include>
 		<control type="image">

--- a/addons/skin.confluence/720p/SettingsProfile.xml
+++ b/addons/skin.confluence/720p/SettingsProfile.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
 	<defaultcontrol always="true">9000</defaultcontrol>
-	<allowoverlay>no</allowoverlay>
 	<controls>
 		<include>CommonBackground</include>
 		<control type="image">

--- a/addons/skin.confluence/720p/SettingsSystemInfo.xml
+++ b/addons/skin.confluence/720p/SettingsSystemInfo.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
 	<defaultcontrol always="true">95</defaultcontrol>
-	<allowoverlay>no</allowoverlay>
 	<controls>
 		<include>CommonBackground</include>
 		<control type="image">

--- a/addons/skin.confluence/720p/SmartPlaylistEditor.xml
+++ b/addons/skin.confluence/720p/SmartPlaylistEditor.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
 	<defaultcontrol always="true">22</defaultcontrol>
-	<allowoverlay>no</allowoverlay>
 	<coordinates>
 		<left>240</left>
 		<top>22</top>

--- a/addons/skin.confluence/720p/SmartPlaylistRule.xml
+++ b/addons/skin.confluence/720p/SmartPlaylistRule.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
 	<defaultcontrol always="true">9001</defaultcontrol>
-	<allowoverlay>no</allowoverlay>
 	<coordinates>
 		<left>240</left>
 		<top>220</top>

--- a/addons/skin.confluence/720p/Startup.xml
+++ b/addons/skin.confluence/720p/Startup.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
 	<defaultcontrol always="true">10</defaultcontrol>
-	<allowoverlay>no</allowoverlay>
 	<controls>
 		<control type="button" id="10">
 			<description>trigger</description>

--- a/addons/skin.confluence/720p/script-NextAired-TVGuide.xml
+++ b/addons/skin.confluence/720p/script-NextAired-TVGuide.xml
@@ -7,7 +7,6 @@
 	<onload>ClearProperty(TVGuide.FridayList,Home)</onload>
 	<onload>ClearProperty(TVGuide.SaturdayList,Home)</onload>
 	<onload>ClearProperty(TVGuide.SundayList,Home)</onload>
-	<allowoverlay>no</allowoverlay>
 	<controls>
 		<include>CommonBackground</include>
 		<control type="group">

--- a/addons/skin.confluence/720p/script-cu-lrclyrics-main.xml
+++ b/addons/skin.confluence/720p/script-cu-lrclyrics-main.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
-	<allowoverlay>no</allowoverlay>
 	<coordinates>
 		<left>680</left>
 		<top>0</top>

--- a/addons/skin.confluence/720p/script-globalsearch-main.xml
+++ b/addons/skin.confluence/720p/script-globalsearch-main.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
-	<allowoverlay>no</allowoverlay>
 	<coordinates>
 		<left>0</left>
 		<top>0</top>


### PR DESCRIPTION
these tags are now obsolete as we've removed the music and video overlays.

@phil65 @BigNoid @HitcherUK
