### PR TITLE
Partly revert "renderer: fix subtitle (text) positions for alignment …

### DIFF
--- a/xbmc/cores/VideoRenderers/OverlayRendererGUI.cpp
+++ b/xbmc/cores/VideoRenderers/OverlayRendererGUI.cpp
@@ -181,7 +181,7 @@ void COverlayText::Render(OVERLAY::SRenderState &state)
   float width_max = (float) res.Overscan.right - res.Overscan.left;
 
   if (m_subalign == SUBTITLE_ALIGN_MANUAL
-  ||  m_subalign == SUBTITLE_ALIGN_BOTTOM_OUTSIDE
+  ||  m_subalign == SUBTITLE_ALIGN_TOP_OUTSIDE
   ||  m_subalign == SUBTITLE_ALIGN_BOTTOM_INSIDE)
     y -= m_height;
 


### PR DESCRIPTION
…outside video, consider height of text"

This reverts commit 74ad4c1b21da1245edd05846a4bae6132dbb4485.

Fixes the subtitle regression mentioned here:
http://forum.kodi.tv/showthread.php?tid=238108&pid=2100412#pid2100412

@FernetMenta 
