### PR TITLE
Check if charsetSetting is null before trying to get data from it.

### DIFF
--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -577,7 +577,7 @@ void CLangInfo::SetDefaults()
 std::string CLangInfo::GetGuiCharSet() const
 {
   CSettingString* charsetSetting = static_cast<CSettingString*>(CSettings::GetInstance().GetSetting(CSettings::SETTING_LOCALE_CHARSET));
-  if (charsetSetting->IsDefault())
+  if (charsetSetting == NULL || charsetSetting->IsDefault())
     return m_strGuiCharSet;
 
   return charsetSetting->GetValue();


### PR DESCRIPTION
If it is use the default value.

Fixes http://forum.kodi.tv/showthread.php?tid=229292&pid=2109962#pid2109962
But will reset your profiles.xml if it is not valid xml.
