### PR TITLE
FIX: proper casting of file time TZ adjustment

### DIFF
--- a/xbmc/linux/XTimeUtils.cpp
+++ b/xbmc/linux/XTimeUtils.cpp
@@ -88,7 +88,7 @@ BOOL FileTimeToLocalFileTime(const FILETIME* lpFileTime, LPFILETIME lpLocalFileT
   FileTimeToTimeT(lpFileTime, &ft);
   localtime_r(&ft, &tm_ft);
 
-  l.QuadPart += tm_ft.tm_gmtoff * 10000000;
+  l.QuadPart += (ULONGLONG)tm_ft.tm_gmtoff * 10000000;
 
   lpLocalFileTime->dwLowDateTime = l.u.LowPart;
   lpLocalFileTime->dwHighDateTime = l.u.HighPart;


### PR DESCRIPTION
Regression from
https://github.com/xbmc/xbmc/commit/6e0fefdbfd60e5ff0f12e1711df011d8428629ca

/cc @MartijnKaijser 
