### PR TITLE
[databse] Get rid of unnecessary .c_str() calls

### DIFF
--- a/xbmc/TextureDatabase.cpp
+++ b/xbmc/TextureDatabase.cpp
@@ -259,7 +259,7 @@ bool CTextureDatabase::GetCachedTexture(const std::string &url, CTextureDetails 
     if (NULL == m_pDS.get()) return false;
 
     std::string sql = PrepareSQL("SELECT id, cachedurl, lasthashcheck, imagehash, width, height FROM texture JOIN sizes ON (texture.id=sizes.idtexture AND sizes.size=1) WHERE url='%s'", url.c_str());
-    m_pDS->query(sql.c_str());
+    m_pDS->query(sql);
     if (!m_pDS->eof())
     { // have some information
       details.id = m_pDS->fv(0).get_asInt();
@@ -295,7 +295,7 @@ bool CTextureDatabase::GetTextures(CVariant &items, const Filter &filter)
       return false;
 
     sql = PrepareSQL(sql, !filter.fields.empty() ? filter.fields.c_str() : "*") + sqlFilter;
-    if (!m_pDS->query(sql.c_str()))
+    if (!m_pDS->query(sql))
       return false;
 
     while (!m_pDS->eof())
@@ -343,16 +343,16 @@ bool CTextureDatabase::AddCachedTexture(const std::string &url, const CTextureDe
     if (NULL == m_pDS.get()) return false;
 
     std::string sql = PrepareSQL("DELETE FROM texture WHERE url='%s'", url.c_str());
-    m_pDS->exec(sql.c_str());
+    m_pDS->exec(sql);
 
     std::string date = details.updateable ? CDateTime::GetCurrentDateTime().GetAsDBDateTime() : "";
     sql = PrepareSQL("INSERT INTO texture (id, url, cachedurl, imagehash, lasthashcheck) VALUES(NULL, '%s', '%s', '%s', '%s')", url.c_str(), details.file.c_str(), details.hash.c_str(), date.c_str());
-    m_pDS->exec(sql.c_str());
+    m_pDS->exec(sql);
     int textureID = (int)m_pDS->lastinsertid();
 
     // set the size information
     sql = PrepareSQL("INSERT INTO sizes (idtexture, size, usecount, lastusetime, width, height) VALUES(%u, 1, 1, CURRENT_TIMESTAMP, %u, %u)", textureID, details.width, details.height);
-    m_pDS->exec(sql.c_str());
+    m_pDS->exec(sql);
   }
   catch (...)
   {
@@ -375,7 +375,7 @@ bool CTextureDatabase::ClearCachedTexture(int id, std::string &cacheFile)
     if (NULL == m_pDS.get()) return false;
 
     std::string sql = PrepareSQL("select cachedurl from texture where id=%u", id);
-    m_pDS->query(sql.c_str());
+    m_pDS->query(sql);
 
     if (!m_pDS->eof())
     { // have some information
@@ -383,7 +383,7 @@ bool CTextureDatabase::ClearCachedTexture(int id, std::string &cacheFile)
       m_pDS->close();
       // remove it
       sql = PrepareSQL("delete from texture where id=%u", id);
-      m_pDS->exec(sql.c_str());
+      m_pDS->exec(sql);
       return true;
     }
     m_pDS->close();
@@ -413,7 +413,7 @@ std::string CTextureDatabase::GetTextureForPath(const std::string &url, const st
       return "";
 
     std::string sql = PrepareSQL("select texture from path where url='%s' and type='%s'", url.c_str(), type.c_str());
-    m_pDS->query(sql.c_str());
+    m_pDS->query(sql);
 
     if (!m_pDS->eof())
     { // have some information
@@ -441,19 +441,19 @@ void CTextureDatabase::SetTextureForPath(const std::string &url, const std::stri
       return;
 
     std::string sql = PrepareSQL("select id from path where url='%s' and type='%s'", url.c_str(), type.c_str());
-    m_pDS->query(sql.c_str());
+    m_pDS->query(sql);
     if (!m_pDS->eof())
     { // update
       int pathID = m_pDS->fv(0).get_asInt();
       m_pDS->close();
       sql = PrepareSQL("update path set texture='%s' where id=%u", texture.c_str(), pathID);
-      m_pDS->exec(sql.c_str());
+      m_pDS->exec(sql);
     }
     else
     { // add the texture
       m_pDS->close();
       sql = PrepareSQL("insert into path (id, url, type, texture) values(NULL, '%s', '%s', '%s')", url.c_str(), type.c_str(), texture.c_str());
-      m_pDS->exec(sql.c_str());
+      m_pDS->exec(sql);
     }
   }
   catch (...)
@@ -471,7 +471,7 @@ void CTextureDatabase::ClearTextureForPath(const std::string &url, const std::st
     if (NULL == m_pDS.get()) return;
 
     std::string sql = PrepareSQL("DELETE FROM path WHERE url='%s' and type='%s'", url.c_str(), type.c_str());
-    m_pDS->exec(sql.c_str());
+    m_pDS->exec(sql);
   }
   catch (...)
   {

--- a/xbmc/addons/AddonDatabase.cpp
+++ b/xbmc/addons/AddonDatabase.cpp
@@ -141,23 +141,23 @@ int CAddonDatabase::AddAddon(const AddonPtr& addon,
                                addon->ID().c_str(), addon->Version().asString().c_str(),
                                addon->Author().c_str(),addon->Disclaimer().c_str(),
                                addon->MinVersion().asString().c_str());
-    m_pDS->exec(sql.c_str());
+    m_pDS->exec(sql);
     int idAddon = (int)m_pDS->lastinsertid();
 
     sql = PrepareSQL("insert into addonlinkrepo (idRepo, idAddon) values (%i,%i)",idRepo,idAddon);
-    m_pDS->exec(sql.c_str());
+    m_pDS->exec(sql);
 
     const InfoMap &info = addon->ExtraInfo();
     for (InfoMap::const_iterator i = info.begin(); i != info.end(); ++i)
     {
       sql = PrepareSQL("insert into addonextra(id, key, value) values (%i, '%s', '%s')", idAddon, i->first.c_str(), i->second.c_str());
-      m_pDS->exec(sql.c_str());
+      m_pDS->exec(sql);
     }
     const ADDONDEPS &deps = addon->GetDeps();
     for (ADDONDEPS::const_iterator i = deps.begin(); i != deps.end(); ++i)
     {
       sql = PrepareSQL("insert into dependencies(id, addon, version, optional) values (%i, '%s', '%s', %i)", idAddon, i->first.c_str(), i->second.first.asString().c_str(), i->second.second ? 1 : 0);
-      m_pDS->exec(sql.c_str());
+      m_pDS->exec(sql);
     }
     return idAddon;
   }
@@ -180,7 +180,7 @@ AddonVersion CAddonDatabase::GetAddonVersion(const std::string &id)
     // so we want to retrieve the latest version.  Order by version won't work as the database
     // won't know that 1.10 > 1.2, so grab them all and order outside
     std::string sql = PrepareSQL("select version from addon where addonID='%s'",id.c_str());
-    m_pDS2->query(sql.c_str());
+    m_pDS2->query(sql);
 
     if (m_pDS2->eof())
       return maxversion;
@@ -273,7 +273,7 @@ bool CAddonDatabase::GetAddon(const std::string& id, AddonPtr& addon)
     // so we want to retrieve the latest version.  Order by version won't work as the database
     // won't know that 1.10 > 1.2, so grab them all and order outside
     std::string sql = PrepareSQL("select id,version from addon where addonID='%s'",id.c_str());
-    m_pDS2->query(sql.c_str());
+    m_pDS2->query(sql);
 
     if (m_pDS2->eof())
       return false;
@@ -321,7 +321,7 @@ bool CAddonDatabase::GetAddon(int id, AddonPtr &addon)
 
     sql += PrepareSQL(" WHERE addon.id=%i", id);
 
-    m_pDS2->query(sql.c_str());
+    m_pDS2->query(sql);
     if (!m_pDS2->eof())
     {
       const dbiplus::query_data &data = m_pDS2->get_result_set().records;
@@ -385,7 +385,7 @@ bool CAddonDatabase::GetAddons(VECADDONS& addons, const ADDON::TYPE &type /* = A
         sql += PrepareSQL(" AND a.type = '%s'", strType.c_str());
     }
 
-    m_pDS->query(sql.c_str());
+    m_pDS->query(sql);
     while (!m_pDS->eof())
     {
       AddonPtr addon;
@@ -411,7 +411,7 @@ void CAddonDatabase::DeleteRepository(const std::string& id)
     if (NULL == m_pDS.get()) return;
 
     std::string sql = PrepareSQL("select id from repo where addonID='%s'",id.c_str());
-    m_pDS->query(sql.c_str());
+    m_pDS->query(sql);
     if (!m_pDS->eof())
       DeleteRepository(m_pDS->fv(0).get_asInt());
   }
@@ -429,15 +429,15 @@ void CAddonDatabase::DeleteRepository(int idRepo)
     if (NULL == m_pDS.get()) return;
 
     std::string sql = PrepareSQL("delete from repo where id=%i",idRepo);
-    m_pDS->exec(sql.c_str());
+    m_pDS->exec(sql);
     sql = PrepareSQL("delete from addon where id in (select idAddon from addonlinkrepo where idRepo=%i)",idRepo);
-    m_pDS->exec(sql.c_str());
+    m_pDS->exec(sql);
     sql = PrepareSQL("delete from addonextra where id in (select idAddon from addonlinkrepo where idRepo=%i)",idRepo);
-    m_pDS->exec(sql.c_str());
+    m_pDS->exec(sql);
     sql = PrepareSQL("delete from dependencies where id in (select idAddon from addonlinkrepo where idRepo=%i)",idRepo);
-    m_pDS->exec(sql.c_str());
+    m_pDS->exec(sql);
     sql = PrepareSQL("delete from addonlinkrepo where idRepo=%i",idRepo);
-    m_pDS->exec(sql.c_str());
+    m_pDS->exec(sql);
 
   }
   catch (...)
@@ -463,7 +463,7 @@ int CAddonDatabase::AddRepository(const std::string& id, const VECADDONS& addons
     CDateTime time = CDateTime::GetCurrentDateTime();
     sql = PrepareSQL("insert into repo (id,addonID,checksum,lastcheck,version) values (NULL,'%s','%s','%s','%s')",
                      id.c_str(), checksum.c_str(), time.GetAsDBDateTime().c_str(), version.asString().c_str());
-    m_pDS->exec(sql.c_str());
+    m_pDS->exec(sql);
     idRepo = (int)m_pDS->lastinsertid();
     for (unsigned int i=0;i<addons.size();++i)
       AddAddon(addons[i],idRepo);
@@ -487,7 +487,7 @@ int CAddonDatabase::GetRepoChecksum(const std::string& id, std::string& checksum
     if (NULL == m_pDS.get()) return -1;
 
     std::string strSQL = PrepareSQL("select * from repo where addonID='%s'",id.c_str());
-    m_pDS->query(strSQL.c_str());
+    m_pDS->query(strSQL);
     if (!m_pDS->eof())
     {
       checksum = m_pDS->fv("checksum").get_asString();
@@ -511,7 +511,7 @@ std::pair<CDateTime, ADDON::AddonVersion> CAddonDatabase::LastChecked(const std:
     if (m_pDB.get() != nullptr && m_pDS.get() != nullptr)
     {
       std::string strSQL = PrepareSQL("select * from repo where addonID='%s'",id.c_str());
-      m_pDS->query(strSQL.c_str());
+      m_pDS->query(strSQL);
       if (!m_pDS->eof())
       {
         date.SetFromDBDateTime(m_pDS->fv("lastcheck").get_asString());
@@ -537,7 +537,7 @@ bool CAddonDatabase::SetLastChecked(const std::string& id,
 
     std::string sql = PrepareSQL("UPDATE repo SET lastcheck='%s', version='%s' WHERE addonID='%s'",
                                  time.c_str(), version.asString().c_str(), id.c_str());
-    m_pDS->exec(sql.c_str());
+    m_pDS->exec(sql);
 
     return true;
   }
@@ -557,7 +557,7 @@ bool CAddonDatabase::GetRepositoryContent(const std::string& id, VECADDONS& addo
 
     std::string query = PrepareSQL("select id from repo where addonID='%s'"
         " AND checksum != '' and lastcheck != ''", id.c_str());
-    m_pDS->query(query.c_str());
+    m_pDS->query(query);
     if (m_pDS->eof())
       return false;
 
@@ -566,7 +566,7 @@ bool CAddonDatabase::GetRepositoryContent(const std::string& id, VECADDONS& addo
         "WHERE addonlinkrepo.idRepo=%i GROUP BY addon.addonID",
         m_pDS->fv(0).get_asInt());
 
-    m_pDS->query(query.c_str());
+    m_pDS->query(query);
     while (!m_pDS->eof())
     {
       AddonPtr addon;
@@ -594,7 +594,7 @@ bool CAddonDatabase::Search(const std::string& search, VECADDONS& addons)
     strSQL=PrepareSQL("SELECT addonID FROM addon WHERE name LIKE '%%%s%%' OR summary LIKE '%%%s%%' OR description LIKE '%%%s%%'", search.c_str(), search.c_str(), search.c_str());
     CLog::Log(LOGDEBUG, "%s query: %s", __FUNCTION__, strSQL.c_str());
 
-    if (!m_pDS->query(strSQL.c_str())) return false;
+    if (!m_pDS->query(strSQL)) return false;
     if (m_pDS->num_rows() == 0) return false;
 
     while (!m_pDS->eof())
@@ -697,7 +697,7 @@ bool CAddonDatabase::IsAddonDisabled(const std::string &addonID)
     if (NULL == m_pDS.get()) return false;
 
     std::string sql = PrepareSQL("select id from disabled where addonID='%s'", addonID.c_str());
-    m_pDS->query(sql.c_str());
+    m_pDS->query(sql);
     bool ret = !m_pDS->eof(); // in the disabled table -> disabled
     m_pDS->close();
     return ret;
@@ -717,7 +717,7 @@ bool CAddonDatabase::GetDisabled(std::vector<std::string>& addons)
     if (NULL == m_pDS.get()) return false;
 
     std::string sql = PrepareSQL("SELECT addonID FROM disabled");
-    m_pDS->query(sql.c_str());
+    m_pDS->query(sql);
     while (!m_pDS->eof())
     {
       addons.push_back(m_pDS->fv(0).get_asString());
@@ -882,7 +882,7 @@ bool CAddonDatabase::IsSystemAddonRegistered(const std::string &addonID)
       return false;
 
     std::string sql = PrepareSQL("select id from system where addonID='%s'", addonID.c_str());
-    m_pDS->query(sql.c_str());
+    m_pDS->query(sql);
     bool ret = !m_pDS->eof();
     m_pDS->close();
     return ret;

--- a/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSPDatabase.cpp
+++ b/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSPDatabase.cpp
@@ -212,7 +212,7 @@ bool CActiveAEDSPDatabase::AddUpdateMode(CActiveAEDSPMode &mode)
     if (NULL == m_pDS.get()) return false;
     std::string strSQL = PrepareSQL("SELECT * FROM modes WHERE modes.iAddonId=%i AND modes.iAddonModeNumber=%i AND modes.iType=%i", mode.AddonID(), mode.AddonModeNumber(), mode.ModeType());
 
-    m_pDS->query( strSQL.c_str() );
+    m_pDS->query( strSQL );
     if (m_pDS->num_rows() > 0)
     {
       /* get user selected settings */
@@ -245,7 +245,7 @@ bool CActiveAEDSPDatabase::AddUpdateMode(CActiveAEDSPMode &mode)
         mode.AddonModeName().c_str(),
         (mode.HasSettingsDialog() ? 1 : 0),
         mode.AddonID(), mode.AddonModeNumber(), mode.ModeType());
-		bReturn = m_pDS->exec(strSQL.c_str());
+		bReturn = m_pDS->exec(strSQL);
     }
     else
     { // add the items
@@ -283,7 +283,7 @@ bool CActiveAEDSPDatabase::AddUpdateMode(CActiveAEDSPMode &mode)
         mode.AddonID(),
         mode.AddonModeNumber(),
         (mode.HasSettingsDialog() ? 1 : 0));
-      bReturn = m_pDS->exec(strSQL.c_str());
+      bReturn = m_pDS->exec(strSQL);
     }
   }
   catch (...)
@@ -307,7 +307,7 @@ int CActiveAEDSPDatabase::GetModes(AE_DSP_MODELIST &results, int modeType)
 
   std::string strQuery=PrepareSQL("SELECT * FROM modes WHERE modes.iType=%i ORDER BY iPosition", modeType);
 
-  m_pDS->query( strQuery.c_str() );
+  m_pDS->query( strQuery );
   if (m_pDS->num_rows() > 0)
   {
     try
@@ -384,7 +384,7 @@ bool CActiveAEDSPDatabase::GetActiveDSPSettings(const CFileItem &item, CAudioSet
     URIUtils::Split(item.GetPath(), strPath, strFileName);
     std::string strSQL=PrepareSQL("SELECT * FROM settings WHERE settings.strPath='%s' and settings.strFileName='%s'", strPath.c_str() , strFileName.c_str());
 
-    m_pDS->query( strSQL.c_str() );
+    m_pDS->query( strSQL );
     if (m_pDS->num_rows() > 0)
     { // get the audio dsp settings info
       settings.m_MasterStreamTypeSel      = m_pDS->fv("MasterStreamTypeSel").get_asInt();
@@ -418,7 +418,7 @@ void CActiveAEDSPDatabase::SetActiveDSPSettings(const CFileItem &item, const CAu
     std::string strPath, strFileName;
     URIUtils::Split(item.GetPath(), strPath, strFileName);
     std::string strSQL = StringUtils::Format("select * from settings WHERE settings.strPath='%s' and settings.strFileName='%s'", strPath.c_str() , strFileName.c_str());
-    m_pDS->query( strSQL.c_str() );
+    m_pDS->query( strSQL );
     if (m_pDS->num_rows() > 0)
     {
       m_pDS->close();
@@ -436,7 +436,7 @@ void CActiveAEDSPDatabase::SetActiveDSPSettings(const CFileItem &item, const CAu
           setting.m_MasterModes[setting.m_MasterStreamType][setting.m_MasterStreamBase],
           strPath.c_str(),
           strFileName.c_str());
-      m_pDS->exec(strSQL.c_str());
+      m_pDS->exec(strSQL);
       return ;
     }
     else
@@ -458,7 +458,7 @@ void CActiveAEDSPDatabase::SetActiveDSPSettings(const CFileItem &item, const CAu
                            setting.m_MasterStreamType,
                            setting.m_MasterStreamBase,
                            setting.m_MasterModes[setting.m_MasterStreamType][setting.m_MasterStreamBase]);
-      m_pDS->exec(strSQL.c_str());
+      m_pDS->exec(strSQL);
     }
   }
   catch (...)

--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -148,7 +148,7 @@ std::string CDatabase::GetSingleValue(const std::string &query, std::unique_ptr<
     if (!m_pDB.get() || !ds.get())
       return ret;
 
-    if (ds->query(query.c_str()) && ds->num_rows() > 0)
+    if (ds->query(query) && ds->num_rows() > 0)
       ret = ds->fv(0).get_asString();
 
     ds->close();
@@ -219,7 +219,7 @@ bool CDatabase::ExecuteQuery(const std::string &strQuery)
   {
     if (NULL == m_pDB.get()) return bReturn;
     if (NULL == m_pDS.get()) return bReturn;
-    m_pDS->exec(strQuery.c_str());
+    m_pDS->exec(strQuery);
     bReturn = true;
   }
   catch (...)
@@ -242,7 +242,7 @@ bool CDatabase::ResultQuery(const std::string &strQuery)
 
     std::string strPreparedQuery = PrepareSQL(strQuery.c_str());
 
-    bReturn = m_pDS->query(strPreparedQuery.c_str());
+    bReturn = m_pDS->query(strPreparedQuery);
   }
   catch (...)
   {
@@ -606,7 +606,7 @@ bool CDatabase::Compress(bool bForce /* =true */)
           iCount = -1;
         m_pDS->close();
         std::string strSQL=PrepareSQL("update version set iCompressCount=%i\n",++iCount);
-        m_pDS->exec(strSQL.c_str());
+        m_pDS->exec(strSQL);
         if (iCount != 0)
           return true;
       }
@@ -683,7 +683,7 @@ bool CDatabase::CreateDatabase()
     CLog::Log(LOGINFO, "creating version table");
     m_pDS->exec("CREATE TABLE version (idVersion integer, iCompressCount integer)\n");
     std::string strSQL=PrepareSQL("INSERT INTO version (idVersion,iCompressCount) values(%i,0)\n", GetSchemaVersion());
-    m_pDS->exec(strSQL.c_str());
+    m_pDS->exec(strSQL);
 
     CreateTables();
     CreateAnalytics();
@@ -701,7 +701,7 @@ bool CDatabase::CreateDatabase()
 void CDatabase::UpdateVersionNumber()
 {
   std::string strSQL=PrepareSQL("UPDATE version SET idVersion=%i\n", GetSchemaVersion());
-  m_pDS->exec(strSQL.c_str());
+  m_pDS->exec(strSQL);
 }
 
 bool CDatabase::BuildSQL(const std::string &strQuery, const Filter &filter, std::string &strSQL)

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -1597,7 +1597,7 @@ void MysqlDataset::open(const std::string &sql) {
 void MysqlDataset::open() {
   if (select_sql.size())
   {
-    query(select_sql.c_str());
+    query(select_sql);
   }
   else
   {

--- a/xbmc/dbwrappers/sqlitedataset.cpp
+++ b/xbmc/dbwrappers/sqlitedataset.cpp
@@ -706,7 +706,7 @@ void SqliteDataset::open(const std::string &sql) {
 
 void SqliteDataset::open() {
   if (select_sql.size()) {
-    query(select_sql.c_str()); 
+    query(select_sql); 
   }
   else {
     ds_state = dsInactive;

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -407,7 +407,7 @@ void CMusicDatabase::SaveCuesheet(const std::string& fullSongPath, const std::st
       return;
 
     strSQL = PrepareSQL("SELECT * FROM cue WHERE idPath=%i AND strFileName='%s'", idPath, strFileName.c_str());
-    m_pDS->query(strSQL.c_str());
+    m_pDS->query(strSQL);
     if (m_pDS->num_rows() == 0)
     {
       if (strCuesheet.empty())
@@ -432,7 +432,7 @@ void CMusicDatabase::SaveCuesheet(const std::string& fullSongPath, const std::st
       }
     }
     m_pDS->close();
-    m_pDS->exec(strSQL.c_str());
+    m_pDS->exec(strSQL);
     m_cueCache.insert(CueCache::value_type(fullSongPath, strCuesheet));
   }
   catch (...)
@@ -467,7 +467,7 @@ std::string CMusicDatabase::LoadCuesheet(const std::string& fullSongPath)
       return strCuesheet;
 
     strSQL = PrepareSQL("select strCuesheet from cue where idPath=%i AND strFileName='%s'", idPath, strFileName.c_str());
-    m_pDS->query(strSQL.c_str());
+    m_pDS->query(strSQL);
 
     if (0 < m_pDS->num_rows())
       strCuesheet = m_pDS->get_sql_record()->at(0).get_asString();
@@ -660,7 +660,7 @@ int CMusicDatabase::AddSong(const int idAlbum,
                           strTitle.c_str(),
                           iTrack);
 
-    if (!m_pDS->query(strSQL.c_str()))
+    if (!m_pDS->query(strSQL))
       return -1;
 
     if (m_pDS->num_rows() == 0)
@@ -686,7 +686,7 @@ int CMusicDatabase::AddSong(const int idAlbum,
       else
         strSQL += PrepareSQL(",%i,%i,%i,NULL,'%c','%s', '%s')",
                       iTimesPlayed, iStartOffset, iEndOffset, rating, strComment.c_str(), strMood.c_str());
-      m_pDS->exec(strSQL.c_str());
+      m_pDS->exec(strSQL);
       idSong = (int)m_pDS->lastinsertid();
     }
     else
@@ -744,7 +744,7 @@ bool CMusicDatabase::GetSong(int idSong, CSong& song)
                                  " LEFT JOIN songartistview ON songview.idSong = songartistview.idSong "
                                  " WHERE songview.idSong = %i", idSong);
 
-    if (!m_pDS->query(strSQL.c_str())) return false;
+    if (!m_pDS->query(strSQL)) return false;
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound == 0)
     {
@@ -865,7 +865,7 @@ int CMusicDatabase::AddAlbum(const std::string& strAlbum, const std::string& str
       strSQL = PrepareSQL("SELECT * FROM album WHERE strArtists LIKE '%s' AND strAlbum LIKE '%s' AND strMusicBrainzAlbumID IS NULL",
                           strArtist.c_str(),
                           strAlbum.c_str());
-    m_pDS->query(strSQL.c_str());
+    m_pDS->query(strSQL);
 
     if (m_pDS->num_rows() == 0)
     {
@@ -888,7 +888,7 @@ int CMusicDatabase::AddAlbum(const std::string& strAlbum, const std::string& str
                           year,
                           bCompilation,
                           CAlbum::ReleaseTypeToString(releaseType).c_str());
-      m_pDS->exec(strSQL.c_str());
+      m_pDS->exec(strSQL);
 
       return (int)m_pDS->lastinsertid();
     }
@@ -921,7 +921,7 @@ int CMusicDatabase::AddAlbum(const std::string& strAlbum, const std::string& str
                           bCompilation,
                           CAlbum::ReleaseTypeToString(releaseType).c_str(),
                           idAlbum);
-      m_pDS->exec(strSQL.c_str());
+      m_pDS->exec(strSQL);
       DeleteAlbumArtistsByAlbum(idAlbum);
       DeleteAlbumGenresByAlbum(idAlbum);
       return idAlbum;
@@ -1008,7 +1008,7 @@ bool CMusicDatabase::GetAlbum(int idAlbum, CAlbum& album, bool getSongs /* = tru
     }
 
     CLog::Log(LOGDEBUG, "%s", sql.c_str());
-    if (!m_pDS->query(sql.c_str())) return false;
+    if (!m_pDS->query(sql)) return false;
     if (m_pDS->num_rows() == 0)
     {
       m_pDS->close();
@@ -1113,13 +1113,13 @@ int CMusicDatabase::AddGenre(const std::string& strGenre1)
 
 
     strSQL=PrepareSQL("select * from genre where strGenre like '%s'", strGenre.c_str());
-    m_pDS->query(strSQL.c_str());
+    m_pDS->query(strSQL);
     if (m_pDS->num_rows() == 0)
     {
       m_pDS->close();
       // doesnt exists, add it
       strSQL=PrepareSQL("insert into genre (idGenre, strGenre) values( NULL, '%s' )", strGenre.c_str());
-      m_pDS->exec(strSQL.c_str());
+      m_pDS->exec(strSQL);
 
       int idGenre = (int)m_pDS->lastinsertid();
       m_genreCache.insert(std::pair<std::string, int>(strGenre1, idGenre));
@@ -1180,7 +1180,7 @@ int CMusicDatabase::AddArtist(const std::string& strArtist, const std::string& s
       // 1.a) Match on a MusicBrainz ID
       strSQL = PrepareSQL("SELECT * FROM artist WHERE strMusicBrainzArtistID = '%s'",
                           strMusicBrainzArtistID.c_str());
-      m_pDS->query(strSQL.c_str());
+      m_pDS->query(strSQL);
       if (m_pDS->num_rows() > 0)
       {
         int idArtist = (int)m_pDS->fv("idArtist").get_asInt();
@@ -1189,7 +1189,7 @@ int CMusicDatabase::AddArtist(const std::string& strArtist, const std::string& s
         if (update)
         {
           strSQL = PrepareSQL( "UPDATE artist SET strArtist = '%s' WHERE idArtist = %i", strArtist.c_str(), idArtist);
-          m_pDS->exec(strSQL.c_str());
+          m_pDS->exec(strSQL);
           m_pDS->close();
         }
         return idArtist;
@@ -1200,7 +1200,7 @@ int CMusicDatabase::AddArtist(const std::string& strArtist, const std::string& s
       // 1.b) No match on MusicBrainz ID. Look for a previously added artist with no MusicBrainz ID
       //     and update that if it exists.
       strSQL = PrepareSQL("SELECT * FROM artist WHERE strArtist LIKE '%s' AND strMusicBrainzArtistID IS NULL", strArtist.c_str());
-      m_pDS->query(strSQL.c_str());
+      m_pDS->query(strSQL);
       if (m_pDS->num_rows() > 0)
       {
         int idArtist = (int)m_pDS->fv("idArtist").get_asInt();
@@ -1210,7 +1210,7 @@ int CMusicDatabase::AddArtist(const std::string& strArtist, const std::string& s
                             strArtist.c_str(),
                             strMusicBrainzArtistID.c_str(),
                             idArtist);
-        m_pDS->exec(strSQL.c_str());
+        m_pDS->exec(strSQL);
         return idArtist;
       }
 
@@ -1223,7 +1223,7 @@ int CMusicDatabase::AddArtist(const std::string& strArtist, const std::string& s
       strSQL = PrepareSQL("SELECT * FROM artist WHERE strArtist LIKE '%s'",
                           strArtist.c_str());
 
-      m_pDS->query(strSQL.c_str());
+      m_pDS->query(strSQL);
       if (m_pDS->num_rows() > 0)
       {
         int idArtist = (int)m_pDS->fv("idArtist").get_asInt();
@@ -1242,7 +1242,7 @@ int CMusicDatabase::AddArtist(const std::string& strArtist, const std::string& s
                           strArtist.c_str(),
                           strMusicBrainzArtistID.c_str());
 
-    m_pDS->exec(strSQL.c_str());
+    m_pDS->exec(strSQL);
     int idArtist = (int)m_pDS->lastinsertid();
     return idArtist;
   }
@@ -1311,7 +1311,7 @@ bool CMusicDatabase::GetArtist(int idArtist, CArtist &artist, bool fetchAll /* =
     else
       strSQL = PrepareSQL("SELECT * FROM artistview WHERE artistview.idArtist = %i", idArtist);
 
-    if (!m_pDS->query(strSQL.c_str())) return false;
+    if (!m_pDS->query(strSQL)) return false;
     if (m_pDS->num_rows() == 0)
     {
       m_pDS->close();
@@ -1439,7 +1439,7 @@ bool CMusicDatabase::GetAlbumsByArtist(int idArtist, bool includeFeatured, std::
       strPrepSQL += " AND boolFeatured = 0";
     
     strSQL=PrepareSQL(strPrepSQL, idArtist);
-    if (!m_pDS->query(strSQL.c_str())) 
+    if (!m_pDS->query(strSQL)) 
       return false;
     if (m_pDS->num_rows() == 0)
     {
@@ -1473,7 +1473,7 @@ bool CMusicDatabase::GetArtistsByAlbum(int idAlbum, bool includeFeatured, std::v
       strPrepSQL += " AND boolFeatured = 0";
 
     strSQL=PrepareSQL(strPrepSQL, idAlbum);
-    if (!m_pDS->query(strSQL.c_str())) 
+    if (!m_pDS->query(strSQL)) 
       return false;
     if (m_pDS->num_rows() == 0)
     {
@@ -1507,7 +1507,7 @@ bool CMusicDatabase::GetSongsByArtist(int idArtist, bool includeFeatured, std::v
       strPrepSQL += " AND boolFeatured = 0";
 
     strSQL=PrepareSQL(strPrepSQL, idArtist);
-    if (!m_pDS->query(strSQL.c_str())) 
+    if (!m_pDS->query(strSQL)) 
       return false;
     if (m_pDS->num_rows() == 0)
     {
@@ -1541,7 +1541,7 @@ bool CMusicDatabase::GetArtistsBySong(int idSong, bool includeFeatured, std::vec
       strPrepSQL += " AND boolFeatured = 0";
     
     strSQL=PrepareSQL(strPrepSQL, idSong);
-    if (!m_pDS->query(strSQL.c_str())) 
+    if (!m_pDS->query(strSQL)) 
       return false;
     if (m_pDS->num_rows() == 0)
     {
@@ -1569,7 +1569,7 @@ bool CMusicDatabase::GetGenresByAlbum(int idAlbum, std::vector<int>& genres)
   try
   {
     std::string strSQL = PrepareSQL("select idGenre from album_genre where idAlbum = %i ORDER BY iOrder ASC", idAlbum);
-    if (!m_pDS->query(strSQL.c_str()))
+    if (!m_pDS->query(strSQL))
       return false;
     if (m_pDS->num_rows() == 0)
     {
@@ -1598,7 +1598,7 @@ bool CMusicDatabase::GetGenresBySong(int idSong, std::vector<int>& genres)
   try
   {
     std::string strSQL = PrepareSQL("select idGenre from song_genre where idSong = %i ORDER BY iOrder ASC", idSong);
-    if (!m_pDS->query(strSQL.c_str()))
+    if (!m_pDS->query(strSQL))
       return false;
     if (m_pDS->num_rows() == 0)
     {
@@ -1641,13 +1641,13 @@ int CMusicDatabase::AddPath(const std::string& strPath1)
       return it->second;
 
     strSQL=PrepareSQL( "select * from path where strPath='%s'", strPath.c_str());
-    m_pDS->query(strSQL.c_str());
+    m_pDS->query(strSQL);
     if (m_pDS->num_rows() == 0)
     {
       m_pDS->close();
       // doesnt exists, add it
       strSQL=PrepareSQL("insert into path (idPath, strPath) values( NULL, '%s' )", strPath.c_str());
-      m_pDS->exec(strSQL.c_str());
+      m_pDS->exec(strSQL);
 
       int idPath = (int)m_pDS->lastinsertid();
       m_pathCache.insert(std::pair<std::string, int>(strPath, idPath));
@@ -1888,7 +1888,7 @@ int CMusicDatabase::GetAlbumIdByPath(const std::string& strPath)
   try
   {
     std::string strSQL=PrepareSQL("select distinct idAlbum from song join path on song.idPath = path.idPath where path.strPath='%s'", strPath.c_str());
-    m_pDS->query(strSQL.c_str());
+    m_pDS->query(strSQL);
     if (m_pDS->eof())
       return -1;
 
@@ -1913,7 +1913,7 @@ int CMusicDatabase::GetSongByArtistAndAlbumAndTitle(const std::string& strArtist
                                 "where strArtists like '%s' and strAlbum like '%s' and "
                                 "strTitle like '%s'",strArtist.c_str(),strAlbum.c_str(),strTitle.c_str());
 
-    if (!m_pDS->query(strSQL.c_str())) return false;
+    if (!m_pDS->query(strSQL)) return false;
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound == 0)
     {
@@ -1950,7 +1950,7 @@ bool CMusicDatabase::SearchArtists(const std::string& search, CFileItemList &art
                                 "where strArtist like '%s%%' and strArtist <> '%s' "
                                 , search.c_str(), strVariousArtists.c_str() );
 
-    if (!m_pDS->query(strSQL.c_str())) return false;
+    if (!m_pDS->query(strSQL)) return false;
     if (m_pDS->num_rows() == 0)
     {
       m_pDS->close();
@@ -1999,7 +1999,7 @@ bool CMusicDatabase::GetTop100(const std::string& strBaseDir, CFileItemList& ite
                       "limit 100";
 
     CLog::Log(LOGDEBUG, "%s query: %s", __FUNCTION__, strSQL.c_str());
-    if (!m_pDS->query(strSQL.c_str())) return false;
+    if (!m_pDS->query(strSQL)) return false;
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound == 0)
     {
@@ -2042,7 +2042,7 @@ bool CMusicDatabase::GetTop100Albums(VECALBUMS& albums)
                     "limit 100 ";
 
     CLog::Log(LOGDEBUG, "%s query: %s", __FUNCTION__, strSQL.c_str());
-    if (!m_pDS->query(strSQL.c_str())) return false;
+    if (!m_pDS->query(strSQL)) return false;
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound == 0)
     {
@@ -2079,7 +2079,7 @@ bool CMusicDatabase::GetTop100AlbumSongs(const std::string& strBaseDir, CFileIte
 
     std::string strSQL = StringUtils::Format("select * from songview join albumview on (songview.idAlbum = albumview.idAlbum) where albumview.idAlbum in (select song.idAlbum from song where song.iTimesPlayed>0 group by idAlbum order by sum(song.iTimesPlayed) desc limit 100) order by albumview.idAlbum in (select song.idAlbum from song where song.iTimesPlayed>0 group by idAlbum order by sum(song.iTimesPlayed) desc limit 100)");
     CLog::Log(LOGDEBUG,"GetTop100AlbumSongs() query: %s", strSQL.c_str());
-    if (!m_pDS->query(strSQL.c_str())) return false;
+    if (!m_pDS->query(strSQL)) return false;
 
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound == 0)
@@ -2119,7 +2119,7 @@ bool CMusicDatabase::GetRecentlyPlayedAlbums(VECALBUMS& albums)
 
     std::string strSQL = StringUtils::Format("select distinct albumview.* from song join albumview on albumview.idAlbum=song.idAlbum where song.lastplayed IS NOT NULL order by song.lastplayed desc limit %i", RECENTLY_PLAYED_LIMIT);
     CLog::Log(LOGDEBUG, "%s query: %s", __FUNCTION__, strSQL.c_str());
-    if (!m_pDS->query(strSQL.c_str())) return false;
+    if (!m_pDS->query(strSQL)) return false;
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound == 0)
     {
@@ -2156,7 +2156,7 @@ bool CMusicDatabase::GetRecentlyPlayedAlbumSongs(const std::string& strBaseDir, 
 
     std::string strSQL = StringUtils::Format("select * from songview join albumview on (songview.idAlbum = albumview.idAlbum) where albumview.idAlbum in (select distinct albumview.idAlbum from albumview join song on albumview.idAlbum=song.idAlbum where song.lastplayed IS NOT NULL order by song.lastplayed desc limit %i)", g_advancedSettings.m_iMusicLibraryRecentlyAddedItems);
     CLog::Log(LOGDEBUG,"GetRecentlyPlayedAlbumSongs() query: %s", strSQL.c_str());
-    if (!m_pDS->query(strSQL.c_str())) return false;
+    if (!m_pDS->query(strSQL)) return false;
 
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound == 0)
@@ -2197,7 +2197,7 @@ bool CMusicDatabase::GetRecentlyAddedAlbums(VECALBUMS& albums, unsigned int limi
     std::string strSQL = StringUtils::Format("select * from albumview where strAlbum != '' order by idAlbum desc limit %u", limit ? limit : g_advancedSettings.m_iMusicLibraryRecentlyAddedItems);
 
     CLog::Log(LOGDEBUG, "%s query: %s", __FUNCTION__, strSQL.c_str());
-    if (!m_pDS->query(strSQL.c_str())) return false;
+    if (!m_pDS->query(strSQL)) return false;
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound == 0)
     {
@@ -2236,7 +2236,7 @@ bool CMusicDatabase::GetRecentlyAddedAlbumSongs(const std::string& strBaseDir, C
     std::string strSQL;
     strSQL = PrepareSQL("SELECT songview.* FROM (SELECT idAlbum FROM albumview ORDER BY idAlbum DESC LIMIT %u) AS recentalbums JOIN songview ON songview.idAlbum=recentalbums.idAlbum", limit ? limit : g_advancedSettings.m_iMusicLibraryRecentlyAddedItems);
     CLog::Log(LOGDEBUG,"GetRecentlyAddedAlbumSongs() query: %s", strSQL.c_str());
-    if (!m_pDS->query(strSQL.c_str())) return false;
+    if (!m_pDS->query(strSQL)) return false;
 
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound == 0)
@@ -2276,7 +2276,7 @@ void CMusicDatabase::IncrementPlayCount(const CFileItem& item)
     int idSong = GetSongIDFromPath(item.GetPath());
 
     std::string sql=PrepareSQL("UPDATE song SET iTimesPlayed=iTimesPlayed+1, lastplayed=CURRENT_TIMESTAMP where idSong=%i", idSong);
-    m_pDS->exec(sql.c_str());
+    m_pDS->exec(sql);
   }
   catch (...)
   {
@@ -2299,7 +2299,7 @@ bool CMusicDatabase::GetSongsByPath(const std::string& strPath1, MAPSONGS& songs
     if (NULL == m_pDS.get()) return false;
 
     std::string strSQL=PrepareSQL("select * from songview where strPath='%s'", strPath.c_str() );
-    if (!m_pDS->query(strSQL.c_str())) return false;
+    if (!m_pDS->query(strSQL)) return false;
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound == 0)
     {
@@ -2370,7 +2370,7 @@ bool CMusicDatabase::SearchSongs(const std::string& search, CFileItemList &items
     else
       strSQL=PrepareSQL("select * from songview where strTitle like '%s%%' limit 1000", search.c_str());
 
-    if (!m_pDS->query(strSQL.c_str())) return false;
+    if (!m_pDS->query(strSQL)) return false;
     if (m_pDS->num_rows() == 0) return false;
 
     std::string songLabel = g_localizeStrings.Get(179); // Song
@@ -2406,7 +2406,7 @@ bool CMusicDatabase::SearchAlbums(const std::string& search, CFileItemList &albu
     else
       strSQL=PrepareSQL("select * from albumview where strAlbum like '%s%%'", search.c_str());
 
-    if (!m_pDS->query(strSQL.c_str())) return false;
+    if (!m_pDS->query(strSQL)) return false;
 
     std::string albumLabel(g_localizeStrings.Get(558)); // Album
     while (!m_pDS->eof())
@@ -2439,7 +2439,7 @@ bool CMusicDatabase::CleanupSongsByIds(const std::string &strSongIds)
     if (NULL == m_pDS.get()) return false;
     // ok, now find all idSong's
     std::string strSQL=PrepareSQL("select * from song join path on song.idPath = path.idPath where song.idSong in %s", strSongIds.c_str());
-    if (!m_pDS->query(strSQL.c_str())) return false;
+    if (!m_pDS->query(strSQL)) return false;
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound == 0)
     {
@@ -2474,7 +2474,7 @@ bool CMusicDatabase::CleanupSongsByIds(const std::string &strSongIds)
       std::string strSongsToDelete = "(" + StringUtils::Join(songsToDelete, ",") + ")";
       // ok, now delete these songs + all references to them from the linked tables
       strSQL = "delete from song where idSong in " + strSongsToDelete;
-      m_pDS->exec(strSQL.c_str());
+      m_pDS->exec(strSQL);
       m_pDS->close();
     }
     return true;
@@ -2495,7 +2495,7 @@ bool CMusicDatabase::CleanupSongs()
     for (int i=0;;i+=iLIMIT)
     {
       std::string strSQL=PrepareSQL("select song.idSong from song order by song.idSong limit %i offset %i",iLIMIT,i);
-      if (!m_pDS->query(strSQL.c_str())) return false;
+      if (!m_pDS->query(strSQL)) return false;
       int iRowsFound = m_pDS->num_rows();
       // keep going until no rows are left!
       if (iRowsFound == 0)
@@ -2531,7 +2531,7 @@ bool CMusicDatabase::CleanupAlbums()
     // This must be run AFTER songs have been cleaned up
     // delete albums with no reference to songs
     std::string strSQL = "select * from album where album.idAlbum not in (select idAlbum from song)";
-    if (!m_pDS->query(strSQL.c_str())) return false;
+    if (!m_pDS->query(strSQL)) return false;
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound == 0)
     {
@@ -2550,7 +2550,7 @@ bool CMusicDatabase::CleanupAlbums()
     std::string strAlbumIds = "(" + StringUtils::Join(albumIds, ",") + ")";
     // ok, now we can delete them and the references in the linked tables
     strSQL = "delete from album where idAlbum in " + strAlbumIds;
-    m_pDS->exec(strSQL.c_str());
+    m_pDS->exec(strSQL);
     return true;
   }
   catch (...)
@@ -2574,7 +2574,7 @@ bool CMusicDatabase::CleanupPaths()
 
     // grab all paths that aren't immediately connected with a song
     std::string sql = "select * from path where idPath not in (select idPath from song)";
-    if (!m_pDS->query(sql.c_str())) return false;
+    if (!m_pDS->query(sql)) return false;
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound == 0)
     {
@@ -2588,7 +2588,7 @@ bool CMusicDatabase::CleanupPaths()
       // anything that isn't a parent path of a song path is to be deleted
       std::string path = m_pDS->fv("strPath").get_asString();
       std::string sql = PrepareSQL("select count(idPath) from songpaths where SUBSTR(strPath,1,%i)='%s'", StringUtils::utf8_strlen(path.c_str()), path.c_str());
-      if (m_pDS2->query(sql.c_str()) && m_pDS2->num_rows() == 1 && m_pDS2->fv(0).get_asInt() == 0)
+      if (m_pDS2->query(sql) && m_pDS2->num_rows() == 1 && m_pDS2->fv(0).get_asInt() == 0)
         pathIds.push_back(m_pDS->fv("idPath").get_asString()); // nothing found, so delete
       m_pDS2->close();
       m_pDS->next();
@@ -2599,7 +2599,7 @@ bool CMusicDatabase::CleanupPaths()
     {
       // do the deletion, and drop our temp table
       std::string deleteSQL = "DELETE FROM path WHERE idPath IN (" + StringUtils::Join(pathIds, ",") + ")";
-      m_pDS->exec(deleteSQL.c_str());
+      m_pDS->exec(deleteSQL);
     }
     m_pDS->exec("drop table songpaths");
     return true;
@@ -2649,7 +2649,7 @@ bool CMusicDatabase::CleanupGenres()
     // Must be executed AFTER the song, song_genre, album and album_genre tables have been cleaned.
     std::string strSQL = "delete from genre where idGenre not in (select idGenre from song_genre) and";
     strSQL += " idGenre not in (select idGenre from album_genre)";
-    m_pDS->exec(strSQL.c_str());
+    m_pDS->exec(strSQL);
     return true;
   }
   catch (...)
@@ -3112,7 +3112,7 @@ bool CMusicDatabase::GetYearsNav(const std::string& strBaseDir, CFileItemList& i
 
     // run query
     CLog::Log(LOGDEBUG, "%s query: %s", __FUNCTION__, strSQL.c_str());
-    if (!m_pDS->query(strSQL.c_str()))
+    if (!m_pDS->query(strSQL))
       return false;
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound == 0)
@@ -3195,7 +3195,7 @@ bool CMusicDatabase::GetCommonNav(const std::string &strBaseDir, const std::stri
     
     // run query
     CLog::Log(LOGDEBUG, "%s query: %s", __FUNCTION__, strSQL.c_str());
-    if (!m_pDS->query(strSQL.c_str()))
+    if (!m_pDS->query(strSQL))
       return false;
     
     int iRowsFound = m_pDS->num_rows();
@@ -3351,7 +3351,7 @@ bool CMusicDatabase::GetArtistsByWhere(const std::string& strBaseDir, const Filt
 
     // run query
     CLog::Log(LOGDEBUG, "%s query: %s", __FUNCTION__, strSQL.c_str());
-    if (!m_pDS->query(strSQL.c_str())) return false;
+    if (!m_pDS->query(strSQL)) return false;
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound == 0)
     {
@@ -3431,7 +3431,7 @@ bool CMusicDatabase::GetAlbumFromSong(int idSong, CAlbum &album)
     if (NULL == m_pDS.get()) return false;
 
     std::string strSQL = PrepareSQL("select albumview.* from song join albumview on song.idAlbum = albumview.idAlbum where song.idSong='%i'", idSong);
-    if (!m_pDS->query(strSQL.c_str())) return false;
+    if (!m_pDS->query(strSQL)) return false;
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound != 1)
     {
@@ -3511,7 +3511,7 @@ bool CMusicDatabase::GetAlbumsByWhere(const std::string &baseDir, const Filter &
     CLog::Log(LOGDEBUG, "%s query: %s", __FUNCTION__, strSQL.c_str());
     // run query
     unsigned int time = XbmcThreads::SystemClockMillis();
-    if (!m_pDS->query(strSQL.c_str()))
+    if (!m_pDS->query(strSQL))
       return false;
     CLog::Log(LOGDEBUG, "%s - query took %i ms",
               __FUNCTION__, XbmcThreads::SystemClockMillis() - time); time = XbmcThreads::SystemClockMillis();
@@ -3623,7 +3623,7 @@ bool CMusicDatabase::GetSongsByWhere(const std::string &baseDir, const Filter &f
 
     CLog::Log(LOGDEBUG, "%s query = %s", __FUNCTION__, strSQL.c_str());
     // run query
-    if (!m_pDS->query(strSQL.c_str()))
+    if (!m_pDS->query(strSQL))
       return false;
 
     int iRowsFound = m_pDS->num_rows();
@@ -3760,7 +3760,7 @@ void CMusicDatabase::UpdateTables(int version)
       {
         std::string originalPath = *it;
         std::string path = CLegacyPathTranslation::TranslateMusicDbPath(originalPath);
-        m_pDS->exec(PrepareSQL("UPDATE content SET strPath='%s' WHERE strPath='%s'", path.c_str(), originalPath.c_str()).c_str());
+        m_pDS->exec(PrepareSQL("UPDATE content SET strPath='%s' WHERE strPath='%s'", path.c_str(), originalPath.c_str()));
       }
     }
   }
@@ -3841,7 +3841,7 @@ void CMusicDatabase::UpdateTables(int version)
     m_pDS->exec("ALTER TABLE song_artist ADD strArtist text\n");
     // populate these
     std::string sql = "select idArtist,strArtist from artist";
-    m_pDS->query(sql.c_str());
+    m_pDS->query(sql);
     while (!m_pDS->eof())
     {
       m_pDS2->exec(PrepareSQL("UPDATE song_artist SET strArtist='%s' where idArtist=%i", m_pDS->fv(1).get_asString().c_str(), m_pDS->fv(0).get_asInt()));
@@ -3962,7 +3962,7 @@ unsigned int CMusicDatabase::GetSongIDs(const Filter &filter, std::vector<std::p
     if (!CDatabase::BuildSQL(strSQL, filter, strSQL))
       return false;
 
-    if (!m_pDS->query(strSQL.c_str())) return 0;
+    if (!m_pDS->query(strSQL)) return 0;
     songIDs.clear();
     if (m_pDS->num_rows() == 0)
     {
@@ -3996,7 +3996,7 @@ int CMusicDatabase::GetSongsCount(const Filter &filter)
     if (!CDatabase::BuildSQL(strSQL, filter, strSQL))
       return false;
 
-    if (!m_pDS->query(strSQL.c_str())) return false;
+    if (!m_pDS->query(strSQL)) return false;
     if (m_pDS->num_rows() == 0)
     {
       m_pDS->close();
@@ -4025,7 +4025,7 @@ bool CMusicDatabase::GetAlbumPath(int idAlbum, std::string& path)
     path.clear();
 
     std::string strSQL=PrepareSQL("select strPath from song join path on song.idPath = path.idPath where song.idAlbum=%ld", idAlbum);
-    if (!m_pDS2->query(strSQL.c_str())) return false;
+    if (!m_pDS2->query(strSQL)) return false;
     int iRowsFound = m_pDS2->num_rows();
     if (iRowsFound == 0)
     {
@@ -4080,7 +4080,7 @@ bool CMusicDatabase::GetArtistPath(int idArtist, std::string &basePath)
                                  " GROUP BY song.idPath", idArtist);
 
     // run query
-    if (!m_pDS2->query(strSQL.c_str())) return false;
+    if (!m_pDS2->query(strSQL)) return false;
     int iRowsFound = m_pDS2->num_rows();
     if (iRowsFound == 0)
     {
@@ -4131,7 +4131,7 @@ int CMusicDatabase::GetArtistByName(const std::string& strArtist)
     std::string strSQL=PrepareSQL("select idArtist from artist where artist.strArtist like '%s'", strArtist.c_str());
 
     // run query
-    if (!m_pDS->query(strSQL.c_str())) return false;
+    if (!m_pDS->query(strSQL)) return false;
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound != 1)
     {
@@ -4162,7 +4162,7 @@ int CMusicDatabase::GetAlbumByName(const std::string& strAlbum, const std::strin
     else
       strSQL=PrepareSQL("SELECT album.idAlbum FROM album WHERE album.strAlbum LIKE '%s' AND album.strArtists LIKE '%s'", strAlbum.c_str(),strArtist.c_str());
     // run query
-    if (!m_pDS->query(strSQL.c_str())) return false;
+    if (!m_pDS->query(strSQL)) return false;
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound != 1)
     {
@@ -4208,7 +4208,7 @@ int CMusicDatabase::GetGenreByName(const std::string& strGenre)
     std::string strSQL;
     strSQL=PrepareSQL("select idGenre from genre where genre.strGenre like '%s'", strGenre.c_str());
     // run query
-    if (!m_pDS->query(strSQL.c_str())) return false;
+    if (!m_pDS->query(strSQL)) return false;
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound != 1)
     {
@@ -4244,7 +4244,7 @@ bool CMusicDatabase::GetRandomSong(CFileItem* item, int& idSong, const Filter &f
 
     CLog::Log(LOGDEBUG, "%s query = %s", __FUNCTION__, strSQL.c_str());
     // run query
-    if (!m_pDS->query(strSQL.c_str()))
+    if (!m_pDS->query(strSQL))
       return false;
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound != 1)
@@ -4316,7 +4316,7 @@ bool CMusicDatabase::SetPathHash(const std::string &path, const std::string &has
     if (idPath < 0) return false;
 
     std::string strSQL=PrepareSQL("update path set strHash='%s' where idPath=%ld", hash.c_str(), idPath);
-    m_pDS->exec(strSQL.c_str());
+    m_pDS->exec(strSQL);
 
     return true;
   }
@@ -4336,7 +4336,7 @@ bool CMusicDatabase::GetPathHash(const std::string &path, std::string &hash)
     if (NULL == m_pDS.get()) return false;
 
     std::string strSQL=PrepareSQL("select strHash from path where strPath='%s'", path.c_str());
-    m_pDS->query(strSQL.c_str());
+    m_pDS->query(strSQL);
     if (m_pDS->num_rows() == 0)
       return false;
     hash = m_pDS->fv("strHash").get_asString();
@@ -4393,7 +4393,7 @@ bool CMusicDatabase::RemoveSongsFromPath(const std::string &path1, MAPSONGS& son
     else
       where = PrepareSQL(" where SUBSTR(strPath,1,%i)='%s'", StringUtils::utf8_strlen(path.c_str()), path.c_str());
     std::string sql = "select * from songview" + where;
-    if (!m_pDS->query(sql.c_str())) return false;
+    if (!m_pDS->query(sql)) return false;
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound > 0)
     {
@@ -4414,11 +4414,11 @@ bool CMusicDatabase::RemoveSongsFromPath(const std::string &path1, MAPSONGS& son
 
       // and delete all songs, and anything linked to them
       sql = "delete from song where idSong in (" + StringUtils::Join(songIds, ",") + ")";
-      m_pDS->exec(sql.c_str());
+      m_pDS->exec(sql);
     }
     // and remove the path as well (it'll be re-added later on with the new hash if it's non-empty)
     sql = "delete from path" + where;
-    m_pDS->exec(sql.c_str());
+    m_pDS->exec(sql);
     return iRowsFound > 0;
   }
   catch (...)
@@ -4472,7 +4472,7 @@ bool CMusicDatabase::SetSongRating(const std::string &filePath, char rating)
     if (-1 == songID) return false;
 
     std::string sql = PrepareSQL("update song set rating='%c' where idSong = %i", rating, songID);
-    m_pDS->exec(sql.c_str());
+    m_pDS->exec(sql);
     return true;
   }
   catch (...)
@@ -4503,7 +4503,7 @@ int CMusicDatabase::GetSongIDFromPath(const std::string &filePath)
     URIUtils::AddSlashAtEnd(strPath);
 
     std::string sql = PrepareSQL("select idSong from song join path on song.idPath = path.idPath where song.strFileName='%s' and path.strPath='%s'", strFileName.c_str(), strPath.c_str());
-    if (!m_pDS->query(sql.c_str())) return -1;
+    if (!m_pDS->query(sql)) return -1;
 
     if (m_pDS->num_rows() == 0)
     {
@@ -4541,12 +4541,12 @@ bool CMusicDatabase::SetScraperForPath(const std::string& strPath, const ADDON::
 
     // wipe old settings
     std::string strSQL = PrepareSQL("delete from content where strPath='%s'",strPath.c_str());
-    m_pDS->exec(strSQL.c_str());
+    m_pDS->exec(strSQL);
 
     // insert new settings
     strSQL = PrepareSQL("insert into content (strPath, strScraperPath, strContent, strSettings) values ('%s','%s','%s','%s')",
       strPath.c_str(), scraper->ID().c_str(), ADDON::TranslateContent(scraper->Content()).c_str(), scraper->GetPathSettings().c_str());
-    m_pDS->exec(strSQL.c_str());
+    m_pDS->exec(strSQL);
 
     return true;
   }
@@ -4565,7 +4565,7 @@ bool CMusicDatabase::GetScraperForPath(const std::string& strPath, ADDON::Scrape
     if (NULL == m_pDS.get()) return false;
 
     std::string strSQL = PrepareSQL("select * from content where strPath='%s'",strPath.c_str());
-    m_pDS->query(strSQL.c_str());
+    m_pDS->query(strSQL);
     if (m_pDS->eof()) // no info set for path - fallback logic commencing
     {
       CQueryParams params;
@@ -4573,27 +4573,27 @@ bool CMusicDatabase::GetScraperForPath(const std::string& strPath, ADDON::Scrape
       if (params.GetGenreId() != -1) // check genre
       {
         strSQL = PrepareSQL("select * from content where strPath='musicdb://genres/%i/'",params.GetGenreId());
-        m_pDS->query(strSQL.c_str());
+        m_pDS->query(strSQL);
       }
       if (m_pDS->eof() && params.GetAlbumId() != -1) // check album
       {
         strSQL = PrepareSQL("select * from content where strPath='musicdb://albums/%i/'",params.GetAlbumId());
-        m_pDS->query(strSQL.c_str());
+        m_pDS->query(strSQL);
         if (m_pDS->eof()) // general albums setting
         {
           strSQL = PrepareSQL("select * from content where strPath='musicdb://albums/'");
-          m_pDS->query(strSQL.c_str());
+          m_pDS->query(strSQL);
         }
       }
       if (m_pDS->eof() && params.GetArtistId() != -1) // check artist
       {
         strSQL = PrepareSQL("select * from content where strPath='musicdb://artists/%i/'",params.GetArtistId());
-        m_pDS->query(strSQL.c_str());
+        m_pDS->query(strSQL);
 
         if (m_pDS->eof()) // general artist setting
         {
           strSQL = PrepareSQL("select * from content where strPath='musicdb://artists/'");
-          m_pDS->query(strSQL.c_str());
+          m_pDS->query(strSQL);
         }
       }
     }
@@ -4655,7 +4655,7 @@ bool CMusicDatabase::ScraperInUse(const std::string &scraperID) const
     if (NULL == m_pDS.get()) return false;
 
     std::string sql = PrepareSQL("select count(1) from content where strScraperPath='%s'",scraperID.c_str());
-    if (!m_pDS->query(sql.c_str()) || m_pDS->num_rows() == 0)
+    if (!m_pDS->query(sql) || m_pDS->num_rows() == 0)
       return false;
     bool found = m_pDS->fv(0).get_asInt() > 0;
     m_pDS->close();
@@ -4720,7 +4720,7 @@ void CMusicDatabase::ExportToXML(const std::string &xmlFile, bool singleFiles, b
     // find all albums
     std::vector<int> albumIds;
     std::string sql = "select idAlbum FROM album WHERE lastScraped IS NOT NULL";
-    m_pDS->query(sql.c_str());
+    m_pDS->query(sql);
 
     int total = m_pDS->num_rows();
     int current = 0;
@@ -4811,7 +4811,7 @@ void CMusicDatabase::ExportToXML(const std::string &xmlFile, bool singleFiles, b
     // find all artists
     std::vector<int> artistIds;
     std::string artistSQL = "SELECT idArtist FROM artist where lastScraped IS NOT NULL";
-    m_pDS->query(artistSQL.c_str());
+    m_pDS->query(artistSQL);
     total = m_pDS->num_rows();
     current = 0;
     artistIds.reserve(total);
@@ -5021,13 +5021,13 @@ void CMusicDatabase::AddKaraokeData(int idSong, int iKaraokeNumber)
     if (iKaraokeNumber > 0)
     {
       std::string strSQL = PrepareSQL("UPDATE karaokedata SET idSong=%i WHERE iKaraNumber=%i", idSong, iKaraokeNumber);
-      m_pDS->exec(strSQL.c_str());
+      m_pDS->exec(strSQL);
       return;
     }
 
     // Get the maximum number allocated
     strSQL=PrepareSQL( "SELECT MAX(iKaraNumber) FROM karaokedata" );
-    if (!m_pDS->query(strSQL.c_str())) return;
+    if (!m_pDS->query(strSQL)) return;
 
     int iKaraokeNumber = g_advancedSettings.m_karaokeStartIndex;
 
@@ -5038,7 +5038,7 @@ void CMusicDatabase::AddKaraokeData(int idSong, int iKaraokeNumber)
     strSQL=PrepareSQL( "INSERT INTO karaokedata (iKaraNumber, idSong, iKaraDelay, strKaraEncoding, strKaralyrics) "
         "VALUES( %i, %i, 0, NULL, NULL)", iKaraokeNumber, idSong );
 
-    m_pDS->exec(strSQL.c_str());
+    m_pDS->exec(strSQL);
   }
   catch (...)
   {
@@ -5056,7 +5056,7 @@ bool CMusicDatabase::GetSongByKaraokeNumber(int number, CSong & song)
 
     std::string strSQL=PrepareSQL("SELECT * FROM karaokedata where iKaraNumber=%ld", number);
 
-    if (!m_pDS->query(strSQL.c_str())) return false;
+    if (!m_pDS->query(strSQL)) return false;
     if (m_pDS->num_rows() == 0)
     {
       m_pDS->close();
@@ -5086,7 +5086,7 @@ void CMusicDatabase::ExportKaraokeInfo(const std::string & outFile, bool asHTML)
     // find all karaoke songs
     std::string sql = "SELECT * FROM songview WHERE iKaraNumber > 0 ORDER BY strFileName";
 
-    m_pDS->query(sql.c_str());
+    m_pDS->query(sql);
 
     int total = m_pDS->num_rows();
     int current = 0;
@@ -5267,7 +5267,7 @@ void CMusicDatabase::ImportKaraokeInfo(const std::string & inputFile)
         std::string strSQL=PrepareSQL("select idSong from songview "
                      "where strArtists like '%s' and strTitle like '%s'", artist, title );
 
-        if ( !m_pDS->query(strSQL.c_str()) )
+        if ( !m_pDS->query(strSQL) )
         {
             RollbackTransaction();
             if (progress)
@@ -5286,7 +5286,7 @@ void CMusicDatabase::ImportKaraokeInfo(const std::string & inputFile)
 
         int lResult = m_pDS->fv(0).get_asInt();
         strSQL = PrepareSQL("UPDATE karaokedata SET iKaraNumber=%i WHERE idSong=%i", num, lResult );
-        m_pDS->exec(strSQL.c_str());
+        m_pDS->exec(strSQL);
 
         if ( progress && (offset * 100 / buf.size()) != lastpercentage )
         {
@@ -5325,7 +5325,7 @@ bool CMusicDatabase::SetKaraokeSongDelay(int idSong, int delay)
     if (NULL == m_pDS.get()) return false;
 
     std::string strSQL = PrepareSQL("UPDATE karaokedata SET iKaraDelay=%i WHERE idSong=%i", delay, idSong);
-    m_pDS->exec(strSQL.c_str());
+    m_pDS->exec(strSQL);
 
     return true;
   }
@@ -5444,19 +5444,19 @@ void CMusicDatabase::SetArtForItem(int mediaId, const std::string &mediaType, co
       return;
 
     std::string sql = PrepareSQL("SELECT art_id FROM art WHERE media_id=%i AND media_type='%s' AND type='%s'", mediaId, mediaType.c_str(), artType.c_str());
-    m_pDS->query(sql.c_str());
+    m_pDS->query(sql);
     if (!m_pDS->eof())
     { // update
       int artId = m_pDS->fv(0).get_asInt();
       m_pDS->close();
       sql = PrepareSQL("UPDATE art SET url='%s' where art_id=%d", url.c_str(), artId);
-      m_pDS->exec(sql.c_str());
+      m_pDS->exec(sql);
     }
     else
     { // insert
       m_pDS->close();
       sql = PrepareSQL("INSERT INTO art(media_id, media_type, type, url) VALUES (%d, '%s', '%s', '%s')", mediaId, mediaType.c_str(), artType.c_str(), url.c_str());
-      m_pDS->exec(sql.c_str());
+      m_pDS->exec(sql);
     }
   }
   catch (...)
@@ -5473,7 +5473,7 @@ bool CMusicDatabase::GetArtForItem(int mediaId, const std::string &mediaType, st
     if (NULL == m_pDS2.get()) return false; // using dataset 2 as we're likely called in loops on dataset 1
 
     std::string sql = PrepareSQL("SELECT type,url FROM art WHERE media_id=%i AND media_type='%s'", mediaId, mediaType.c_str());
-    m_pDS2->query(sql.c_str());
+    m_pDS2->query(sql);
     while (!m_pDS2->eof())
     {
       art.insert(std::make_pair(m_pDS2->fv(0).get_asString(), m_pDS2->fv(1).get_asString()));
@@ -5503,7 +5503,7 @@ bool CMusicDatabase::GetArtistArtForItem(int mediaId, const std::string &mediaTy
     if (NULL == m_pDS2.get()) return false; // using dataset 2 as we're likely called in loops on dataset 1
 
     std::string sql = PrepareSQL("SELECT type,url FROM art WHERE media_id=(SELECT idArtist from %s_artist WHERE id%s=%i AND iOrder=0) AND media_type='artist'", mediaType.c_str(), mediaType.c_str(), mediaId);
-    m_pDS2->query(sql.c_str());
+    m_pDS2->query(sql);
     while (!m_pDS2->eof())
     {
       art.insert(std::make_pair(m_pDS2->fv(0).get_asString(), m_pDS2->fv(1).get_asString()));

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -126,7 +126,7 @@ void CVideoDatabase::CreateTables()
     columns += StringUtils::Format(",c%02d text", i);
 
   columns += ", idSet integer, userrating integer)";
-  m_pDS->exec(columns.c_str());
+  m_pDS->exec(columns);
 
   CLog::Log(LOGINFO, "create actor table");
   m_pDS->exec("CREATE TABLE actor ( actor_id INTEGER PRIMARY KEY, name TEXT, art_urls TEXT )");
@@ -147,7 +147,7 @@ void CVideoDatabase::CreateTables()
     columns += StringUtils::Format(",c%02d text", i);
 
   columns += ", userrating integer)";
-  m_pDS->exec(columns.c_str());
+  m_pDS->exec(columns);
 
   CLog::Log(LOGINFO, "create episode table");
   columns = "CREATE TABLE episode ( idEpisode integer primary key, idFile integer";
@@ -162,7 +162,7 @@ void CVideoDatabase::CreateTables()
     columns += column;
   }
   columns += ", idShow integer, userrating integer)";
-  m_pDS->exec(columns.c_str());
+  m_pDS->exec(columns);
 
   CLog::Log(LOGINFO, "create tvshowlinkpath table");
   m_pDS->exec("CREATE TABLE tvshowlinkpath (idShow integer, idPath integer)\n");
@@ -180,7 +180,7 @@ void CVideoDatabase::CreateTables()
     columns += StringUtils::Format(",c%02d text", i);
 
   columns += ", userrating integer)";
-  m_pDS->exec(columns.c_str());
+  m_pDS->exec(columns);
 
   CLog::Log(LOGINFO, "create streaminfo table");
   m_pDS->exec("CREATE TABLE streamdetails (idFile integer, iStreamType integer, "
@@ -248,9 +248,9 @@ void CVideoDatabase::CreateAnalytics()
   m_pDS->exec("CREATE UNIQUE INDEX ix_episode_file_1 on episode (idEpisode, idFile)");
   m_pDS->exec("CREATE UNIQUE INDEX id_episode_file_2 on episode (idFile, idEpisode)");
   std::string createColIndex = StringUtils::Format("CREATE INDEX ix_episode_season_episode on episode (c%02d, c%02d)", VIDEODB_ID_EPISODE_SEASON, VIDEODB_ID_EPISODE_EPISODE);
-  m_pDS->exec(createColIndex.c_str());
+  m_pDS->exec(createColIndex);
   createColIndex = StringUtils::Format("CREATE INDEX ix_episode_bookmark on episode (c%02d)", VIDEODB_ID_EPISODE_BOOKMARK);
-  m_pDS->exec(createColIndex.c_str());
+  m_pDS->exec(createColIndex);
   m_pDS->exec("CREATE INDEX ix_episode_show1 on episode(idEpisode,idShow)");
   m_pDS->exec("CREATE INDEX ix_episode_show2 on episode(idShow,idEpisode)");
 
@@ -364,7 +364,7 @@ void CVideoDatabase::CreateViews()
                                       VIDEODB_ID_TV_TITLE, VIDEODB_ID_TV_GENRE,
                                       VIDEODB_ID_TV_STUDIOS, VIDEODB_ID_TV_PREMIERED,
                                       VIDEODB_ID_TV_MPAA, VIDEODB_ID_EPISODE_SEASON);
-  m_pDS->exec(episodeview.c_str());
+  m_pDS->exec(episodeview);
 
   CLog::Log(LOGINFO, "create tvshowcounts");
   std::string tvshowcounts = PrepareSQL("CREATE VIEW tvshowcounts AS SELECT "
@@ -380,7 +380,7 @@ void CVideoDatabase::CreateViews()
                                        "      LEFT JOIN files ON"
                                        "        files.idFile=episode.idFile "
                                        "    GROUP BY tvshow.idShow");
-  m_pDS->exec(tvshowcounts.c_str());
+  m_pDS->exec(tvshowcounts);
 
   CLog::Log(LOGINFO, "create tvshow_view");
   std::string tvshowview = PrepareSQL("CREATE VIEW tvshow_view AS SELECT "
@@ -397,7 +397,7 @@ void CVideoDatabase::CreateViews()
                                      "  INNER JOIN tvshowcounts ON"
                                      "    tvshow.idShow = tvshowcounts.idShow "
                                      "GROUP BY tvshow.idShow");
-  m_pDS->exec(tvshowview.c_str());
+  m_pDS->exec(tvshowview);
 
   CLog::Log(LOGINFO, "create season_view");
   std::string seasonview = PrepareSQL("CREATE VIEW season_view AS SELECT "
@@ -423,7 +423,7 @@ void CVideoDatabase::CreateViews()
                                      VIDEODB_ID_TV_TITLE, VIDEODB_ID_TV_PLOT, VIDEODB_ID_TV_PREMIERED,
                                      VIDEODB_ID_TV_GENRE, VIDEODB_ID_TV_STUDIOS, VIDEODB_ID_TV_MPAA,
                                      VIDEODB_ID_EPISODE_AIRED, VIDEODB_ID_EPISODE_SEASON);
-  m_pDS->exec(seasonview.c_str());
+  m_pDS->exec(seasonview);
 
   CLog::Log(LOGINFO, "create musicvideo_view");
   m_pDS->exec("CREATE VIEW musicvideo_view AS SELECT"
@@ -482,7 +482,7 @@ int CVideoDatabase::GetPathId(const std::string& strPath)
     URIUtils::AddSlashAtEnd(strPath1);
 
     strSQL=PrepareSQL("select idPath from path where strPath='%s'",strPath1.c_str());
-    m_pDS->query(strSQL.c_str());
+    m_pDS->query(strSQL);
     if (!m_pDS->eof())
       idPath = m_pDS->fv("path.idPath").get_asInt();
 
@@ -572,7 +572,7 @@ bool CVideoDatabase::GetPathsLinkedToTvShow(int idShow, std::vector<std::string>
   try
   {
     sql = PrepareSQL("SELECT strPath FROM path JOIN tvshowlinkpath ON tvshowlinkpath.idPath=path.idPath WHERE idShow=%i", idShow);
-    m_pDS->query(sql.c_str());
+    m_pDS->query(sql);
     while (!m_pDS->eof())
     {
       paths.push_back(m_pDS->fv(0).get_asString());
@@ -597,12 +597,12 @@ bool CVideoDatabase::GetPathsForTvShow(int idShow, std::set<int>& paths)
 
     // add base path
     strSQL = PrepareSQL("SELECT strPath FROM tvshow_view WHERE idShow=%i", idShow);
-    if (m_pDS->query(strSQL.c_str()))
+    if (m_pDS->query(strSQL))
       paths.insert(GetPathId(m_pDS->fv(0).get_asString()));
 
     // add all other known paths
     strSQL = PrepareSQL("SELECT DISTINCT idPath FROM files JOIN episode ON episode.idFile=files.idFile WHERE episode.idShow=%i",idShow);
-    m_pDS->query(strSQL.c_str());
+    m_pDS->query(strSQL);
     while (!m_pDS->eof())
     {
       paths.insert(m_pDS->fv(0).get_asInt());
@@ -622,7 +622,7 @@ int CVideoDatabase::RunQuery(const std::string &sql)
 {
   unsigned int time = XbmcThreads::SystemClockMillis();
   int rows = -1;
-  if (m_pDS->query(sql.c_str()))
+  if (m_pDS->query(sql))
   {
     rows = m_pDS->num_rows();
     if (rows == 0)
@@ -647,7 +647,7 @@ bool CVideoDatabase::GetSubPaths(const std::string &basepath, std::vector<std::p
                      " AND idPath NOT IN (SELECT idPath FROM files WHERE strFileName LIKE 'index.bdmv')"
                      , StringUtils::utf8_strlen(path.c_str()), path.c_str());
 
-    m_pDS->query(sql.c_str());
+    m_pDS->query(sql);
     while (!m_pDS->eof())
     {
       subpaths.push_back(make_pair(m_pDS->fv(0).get_asInt(), m_pDS->fv(1).get_asString()));
@@ -698,7 +698,7 @@ int CVideoDatabase::AddPath(const std::string& strPath, const std::string &paren
       else
         strSQL=PrepareSQL("insert into path (idPath, strPath, idParentPath) values (NULL, '%s', %i)", strPath1.c_str(), idParentPath);
     }
-    m_pDS->exec(strSQL.c_str());
+    m_pDS->exec(strSQL);
     idPath = (int)m_pDS->lastinsertid();
     return idPath;
   }
@@ -717,7 +717,7 @@ bool CVideoDatabase::GetPathHash(const std::string &path, std::string &hash)
     if (NULL == m_pDS.get()) return false;
 
     std::string strSQL=PrepareSQL("select strHash from path where strPath='%s'", path.c_str());
-    m_pDS->query(strSQL.c_str());
+    m_pDS->query(strSQL);
     if (m_pDS->num_rows() == 0)
       return false;
     hash = m_pDS->fv("strHash").get_asString();
@@ -762,7 +762,7 @@ bool CVideoDatabase::GetSourcePath(const std::string &path, std::string &sourceP
                                         "path.idPath = %i AND "
                                         "path.strContent IS NOT NULL AND path.strContent != '' AND "
                                         "path.strScraper IS NOT NULL AND path.strScraper != ''", idPath);
-      if (m_pDS->query(strSQL.c_str()) && !m_pDS->eof())
+      if (m_pDS->query(strSQL) && !m_pDS->eof())
       {
         settings.parent_name_root = settings.parent_name = m_pDS->fv(0).get_asBool();
         settings.recurse = m_pDS->fv(1).get_asInt();
@@ -781,7 +781,7 @@ bool CVideoDatabase::GetSourcePath(const std::string &path, std::string &sourceP
     while (URIUtils::GetParentPath(strPath1, strParent))
     {
       std::string strSQL = PrepareSQL("SELECT path.strContent, path.strScraper, path.scanRecursive, path.useFolderNames, path.noUpdate, path.exclude FROM path WHERE strPath = '%s'", strParent.c_str());
-      if (m_pDS->query(strSQL.c_str()) && !m_pDS->eof())
+      if (m_pDS->query(strSQL) && !m_pDS->eof())
       {
         std::string strContent = m_pDS->fv(0).get_asString();
         std::string strScraper = m_pDS->fv(1).get_asString();
@@ -832,7 +832,7 @@ int CVideoDatabase::AddFile(const std::string& strFileNameAndPath)
 
     std::string strSQL=PrepareSQL("select idFile from files where strFileName='%s' and idPath=%i", strFileName.c_str(),idPath);
 
-    m_pDS->query(strSQL.c_str());
+    m_pDS->query(strSQL);
     if (m_pDS->num_rows() > 0)
     {
       idFile = m_pDS->fv("idFile").get_asInt() ;
@@ -842,7 +842,7 @@ int CVideoDatabase::AddFile(const std::string& strFileNameAndPath)
     m_pDS->close();
 
     strSQL=PrepareSQL("insert into files (idFile, idPath, strFileName) values(NULL, %i, '%s')", idPath, strFileName.c_str());
-    m_pDS->exec(strSQL.c_str());
+    m_pDS->exec(strSQL);
     idFile = (int)m_pDS->lastinsertid();
     return idFile;
   }
@@ -905,7 +905,7 @@ bool CVideoDatabase::SetPathHash(const std::string &path, const std::string &has
     if (idPath < 0) return false;
 
     std::string strSQL=PrepareSQL("update path set strHash='%s' where idPath=%ld", hash.c_str(), idPath);
-    m_pDS->exec(strSQL.c_str());
+    m_pDS->exec(strSQL);
 
     return true;
   }
@@ -927,12 +927,12 @@ bool CVideoDatabase::LinkMovieToTvshow(int idMovie, int idShow, bool bRemove)
     if (bRemove) // delete link
     {
       std::string strSQL=PrepareSQL("delete from movielinktvshow where idMovie=%i and idShow=%i", idMovie, idShow);
-      m_pDS->exec(strSQL.c_str());
+      m_pDS->exec(strSQL);
       return true;
     }
 
     std::string strSQL=PrepareSQL("insert into movielinktvshow (idShow,idMovie) values (%i,%i)", idShow,idMovie);
-    m_pDS->exec(strSQL.c_str());
+    m_pDS->exec(strSQL);
 
     return true;
   }
@@ -952,7 +952,7 @@ bool CVideoDatabase::IsLinkedToTvshow(int idMovie)
     if (NULL == m_pDS.get()) return false;
 
     std::string strSQL=PrepareSQL("select * from movielinktvshow where idMovie=%i", idMovie);
-    m_pDS->query(strSQL.c_str());
+    m_pDS->query(strSQL);
     if (m_pDS->eof())
     {
       m_pDS->close();
@@ -978,7 +978,7 @@ bool CVideoDatabase::GetLinksToTvShow(int idMovie, std::vector<int>& ids)
     if (NULL == m_pDS.get()) return false;
 
     std::string strSQL=PrepareSQL("select * from movielinktvshow where idMovie=%i", idMovie);
-    m_pDS2->query(strSQL.c_str());
+    m_pDS2->query(strSQL);
     while (!m_pDS2->eof())
     {
       ids.push_back(m_pDS2->fv(1).get_asInt());
@@ -1012,7 +1012,7 @@ int CVideoDatabase::GetFileId(const std::string& strFilenameAndPath)
     {
       std::string strSQL;
       strSQL=PrepareSQL("select idFile from files where strFileName='%s' and idPath=%i", strFileName.c_str(),idPath);
-      m_pDS->query(strSQL.c_str());
+      m_pDS->query(strSQL);
       if (m_pDS->num_rows() > 0)
       {
         int idFile = m_pDS->fv("files.idFile").get_asInt();
@@ -1074,7 +1074,7 @@ int CVideoDatabase::GetMovieId(const std::string& strFilenameAndPath)
       strSQL=PrepareSQL("select idMovie from movie where idFile=%i", idFile);
 
     CLog::Log(LOGDEBUG, "%s (%s), query = %s", __FUNCTION__, CURL::GetRedacted(strFilenameAndPath).c_str(), strSQL.c_str());
-    m_pDS->query(strSQL.c_str());
+    m_pDS->query(strSQL);
     if (m_pDS->num_rows() > 0)
       idMovie = m_pDS->fv("idMovie").get_asInt();
     m_pDS->close();
@@ -1107,14 +1107,14 @@ int CVideoDatabase::GetTvShowId(const std::string& strPath)
     int iFound=0;
 
     strSQL=PrepareSQL("select idShow from tvshowlinkpath where tvshowlinkpath.idPath=%i",idPath);
-    m_pDS->query(strSQL.c_str());
+    m_pDS->query(strSQL);
     if (!m_pDS->eof())
       iFound = 1;
 
     while (iFound == 0 && URIUtils::GetParentPath(strPath1, strParent))
     {
       strSQL=PrepareSQL("SELECT idShow FROM path INNER JOIN tvshowlinkpath ON tvshowlinkpath.idPath=path.idPath WHERE strPath='%s'",strParent.c_str());
-      m_pDS->query(strSQL.c_str());
+      m_pDS->query(strSQL);
       if (!m_pDS->eof())
       {
         int idShow = m_pDS->fv("idShow").get_asInt();
@@ -1156,7 +1156,7 @@ int CVideoDatabase::GetEpisodeId(const std::string& strFilenameAndPath, int idEp
     std::string strSQL=PrepareSQL("select idEpisode from episode where idFile=%i", idFile);
 
     CLog::Log(LOGDEBUG, "%s (%s), query = %s", __FUNCTION__, CURL::GetRedacted(strFilenameAndPath).c_str(), strSQL.c_str());
-    pDS->query(strSQL.c_str());
+    pDS->query(strSQL);
     if (pDS->num_rows() > 0)
     {
       if (idEpisode == -1)
@@ -1207,7 +1207,7 @@ int CVideoDatabase::GetMusicVideoId(const std::string& strFilenameAndPath)
     std::string strSQL=PrepareSQL("select idMVideo from musicvideo where idFile=%i", idFile);
 
     CLog::Log(LOGDEBUG, "%s (%s), query = %s", __FUNCTION__, CURL::GetRedacted(strFilenameAndPath).c_str(), strSQL.c_str());
-    m_pDS->query(strSQL.c_str());
+    m_pDS->query(strSQL);
     int idMVideo=-1;
     if (m_pDS->num_rows() > 0)
       idMVideo = m_pDS->fv("idMVideo").get_asInt();
@@ -1238,7 +1238,7 @@ int CVideoDatabase::AddMovie(const std::string& strFilenameAndPath)
         return -1;
       UpdateFileDateAdded(idFile, strFilenameAndPath);
       std::string strSQL=PrepareSQL("insert into movie (idMovie, idFile) values (NULL, %i)", idFile);
-      m_pDS->exec(strSQL.c_str());
+      m_pDS->exec(strSQL);
       idMovie = (int)m_pDS->lastinsertid();
     }
 
@@ -1313,7 +1313,7 @@ int CVideoDatabase::AddEpisode(int idShow, const std::string& strFilenameAndPath
     UpdateFileDateAdded(idFile, strFilenameAndPath);
 
     std::string strSQL=PrepareSQL("insert into episode (idEpisode, idFile, idShow) values (NULL, %i, %i)", idFile, idShow);
-    m_pDS->exec(strSQL.c_str());
+    m_pDS->exec(strSQL);
     return (int)m_pDS->lastinsertid();
   }
   catch (...)
@@ -1338,7 +1338,7 @@ int CVideoDatabase::AddMusicVideo(const std::string& strFilenameAndPath)
         return -1;
       UpdateFileDateAdded(idFile, strFilenameAndPath);
       std::string strSQL=PrepareSQL("insert into musicvideo (idMVideo, idFile) values (NULL, %i)", idFile);
-      m_pDS->exec(strSQL.c_str());
+      m_pDS->exec(strSQL);
       idMVideo = (int)m_pDS->lastinsertid();
     }
 
@@ -1360,13 +1360,13 @@ int CVideoDatabase::AddToTable(const std::string& table, const std::string& firs
     if (NULL == m_pDS.get()) return -1;
 
     std::string strSQL = PrepareSQL("select %s from %s where %s like '%s'", firstField.c_str(), table.c_str(), secondField.c_str(), value.substr(0, 255).c_str());
-    m_pDS->query(strSQL.c_str());
+    m_pDS->query(strSQL);
     if (m_pDS->num_rows() == 0)
     {
       m_pDS->close();
       // doesnt exists, add it
       strSQL = PrepareSQL("insert into %s (%s, %s) values(NULL, '%s')", table.c_str(), firstField.c_str(), secondField.c_str(), value.substr(0, 255).c_str());
-      m_pDS->exec(strSQL.c_str());
+      m_pDS->exec(strSQL);
       int id = (int)m_pDS->lastinsertid();
       return id;
     }
@@ -1414,13 +1414,13 @@ int CVideoDatabase::AddActor(const std::string& name, const std::string& thumbUR
     StringUtils::Trim(trimmedName);
 
     std::string strSQL=PrepareSQL("select actor_id from actor where name like '%s'", trimmedName.substr(0, 255).c_str());
-    m_pDS->query(strSQL.c_str());
+    m_pDS->query(strSQL);
     if (m_pDS->num_rows() == 0)
     {
       m_pDS->close();
       // doesnt exists, add it
       strSQL=PrepareSQL("insert into actor (actor_id, name, art_urls) values(NULL, '%s', '%s')", trimmedName.substr(0,255).c_str(), thumbURLs.c_str());
-      m_pDS->exec(strSQL.c_str());
+      m_pDS->exec(strSQL);
       idActor = (int)m_pDS->lastinsertid();
     }
     else
@@ -1431,7 +1431,7 @@ int CVideoDatabase::AddActor(const std::string& name, const std::string& thumbUR
       if (!thumbURLs.empty())
       {
         strSQL=PrepareSQL("update actor set art_urls = '%s' where actor_id = %i", thumbURLs.c_str(), idActor);
-        m_pDS->exec(strSQL.c_str());
+        m_pDS->exec(strSQL);
       }
     }
     // add artwork
@@ -1655,16 +1655,16 @@ void CVideoDatabase::DeleteDetailsForTvShow(int idTvShow)
 
     std::string strSQL;
     strSQL=PrepareSQL("DELETE from genre_link WHERE media_id=%i AND media_type='tvshow'", idTvShow);
-    m_pDS->exec(strSQL.c_str());
+    m_pDS->exec(strSQL);
 
     strSQL=PrepareSQL("DELETE FROM actor_link WHERE media_id=%i AND media_type='tvshow'", idTvShow);
-    m_pDS->exec(strSQL.c_str());
+    m_pDS->exec(strSQL);
 
     strSQL=PrepareSQL("DELETE FROM director_link WHERE media_id=%i AND media_type='tvshow'", idTvShow);
-    m_pDS->exec(strSQL.c_str());
+    m_pDS->exec(strSQL);
 
     strSQL=PrepareSQL("DELETE FROM studio_link WHERE media_id=%i AND media_type='tvshow'", idTvShow);
-    m_pDS->exec(strSQL.c_str());
+    m_pDS->exec(strSQL);
 
     // remove all info other than the id
     // we do this due to the way we have the link between the file + movie tables.
@@ -1676,7 +1676,7 @@ void CVideoDatabase::DeleteDetailsForTvShow(int idTvShow)
     strSQL = "update tvshow set ";
     strSQL += StringUtils::Join(ids, ", ");
     strSQL += PrepareSQL(" where idShow=%i", idTvShow);
-    m_pDS->exec(strSQL.c_str());
+    m_pDS->exec(strSQL);
   }
   catch (...)
   {
@@ -1733,7 +1733,7 @@ void CVideoDatabase::GetMusicVideosByArtist(const std::string& strArtist, CFileI
       strSQL=PrepareSQL("select distinct * from musicvideo_view join actor_link on actor_link.media_id=musicvideo_view.idMVideo AND actor_link.media_type='musicvideo' join actor on actor.actor_id=actor_link.actor_id");
     else
       strSQL=PrepareSQL("select * from musicvideo_view join actor_link on actor_link.media_id=musicvideo_view.idMVideo AND actor_link.media_type='musicvideo' join actor on actor.actor_id=actor_link.actor_id where actor.name='%s'", strArtist.c_str());
-    m_pDS->query( strSQL.c_str() );
+    m_pDS->query( strSQL );
 
     while (!m_pDS->eof())
     {
@@ -1762,7 +1762,7 @@ bool CVideoDatabase::GetMovieInfo(const std::string& strFilenameAndPath, CVideoI
     if (idMovie < 0) return false;
 
     std::string sql = PrepareSQL("select * from movie_view where idMovie=%i", idMovie);
-    if (!m_pDS->query(sql.c_str()))
+    if (!m_pDS->query(sql))
       return false;
     details = GetDetailsForMovie(m_pDS, true);
     return !details.IsEmpty();
@@ -1784,7 +1784,7 @@ bool CVideoDatabase::GetTvShowInfo(const std::string& strPath, CVideoInfoTag& de
     if (idTvShow < 0) return false;
 
     std::string sql = PrepareSQL("SELECT * FROM tvshow_view WHERE idShow=%i GROUP BY idShow", idTvShow);
-    if (!m_pDS->query(sql.c_str()))
+    if (!m_pDS->query(sql))
       return false;
     details = GetDetailsForTvShow(m_pDS, true, item);
     return !details.IsEmpty();
@@ -1807,7 +1807,7 @@ bool CVideoDatabase::GetSeasonInfo(int idSeason, CVideoInfoTag& details)
       return false;
 
     std::string sql = PrepareSQL("SELECT idShow FROM seasons WHERE idSeason=%i", idSeason);
-    if (!m_pDS->query(sql.c_str()))
+    if (!m_pDS->query(sql))
       return false;
 
     int idShow = -1;
@@ -1850,7 +1850,7 @@ bool CVideoDatabase::GetEpisodeInfo(const std::string& strFilenameAndPath, CVide
     if (idEpisode < 0) return false;
 
     std::string sql = PrepareSQL("select * from episode_view where idEpisode=%i",idEpisode);
-    if (!m_pDS->query(sql.c_str()))
+    if (!m_pDS->query(sql))
       return false;
     details = GetDetailsForEpisode(m_pDS, true);
     return !details.IsEmpty();
@@ -1872,7 +1872,7 @@ bool CVideoDatabase::GetMusicVideoInfo(const std::string& strFilenameAndPath, CV
     if (idMVideo < 0) return false;
 
     std::string sql = PrepareSQL("select * from musicvideo_view where idMVideo=%i", idMVideo);
-    if (!m_pDS->query(sql.c_str()))
+    if (!m_pDS->query(sql))
       return false;
     details = GetDetailsForMusicVideo(m_pDS, true);
     return !details.IsEmpty();
@@ -1922,7 +1922,7 @@ bool CVideoDatabase::GetFileInfo(const std::string& strFilenameAndPath, CVideoIn
                                 "JOIN path ON path.idPath = files.idPath "
                                 "LEFT JOIN bookmark ON bookmark.idFile = files.idFile AND bookmark.type = %i "
                                 "WHERE files.idFile = %i", CBookmark::RESUME, idFile);
-    if (!m_pDS->query(sql.c_str()))
+    if (!m_pDS->query(sql))
       return false;
 
     details.m_iFileId = m_pDS->fv("files.idFile").get_asInt();
@@ -2081,7 +2081,7 @@ int CVideoDatabase::SetDetailsForMovie(const std::string& strFilenameAndPath, co
     if (!details.m_strIMDBNumber.empty() && details.m_iYear)
     { // query DB for any movies matching imdbid and year
       std::string strSQL = PrepareSQL("SELECT files.playCount, files.lastPlayed FROM movie INNER JOIN files ON files.idFile=movie.idFile WHERE movie.c%02d='%s' AND movie.c%02d=%i AND movie.idMovie!=%i AND files.playCount > 0", VIDEODB_ID_IDENT, details.m_strIMDBNumber.c_str(), VIDEODB_ID_YEAR, details.m_iYear, idMovie);
-      m_pDS->query(strSQL.c_str());
+      m_pDS->query(strSQL);
 
       if (!m_pDS->eof())
       {
@@ -2094,7 +2094,7 @@ int CVideoDatabase::SetDetailsForMovie(const std::string& strFilenameAndPath, co
 
         // update with playCount and lastPlayed
         strSQL = PrepareSQL("update files set playCount=%i,lastPlayed='%s' where idFile=%i", playCount, lastPlayed.GetAsDBDateTime().c_str(), idFile);
-        m_pDS->exec(strSQL.c_str());
+        m_pDS->exec(strSQL);
       }
 
       m_pDS->close();
@@ -2111,7 +2111,7 @@ int CVideoDatabase::SetDetailsForMovie(const std::string& strFilenameAndPath, co
     else
       sql += ", userrating = NULL";
     sql += PrepareSQL(" where idMovie=%i", idMovie);
-    m_pDS->exec(sql.c_str());
+    m_pDS->exec(sql);
     CommitTransaction();
 
     return idMovie;
@@ -2235,7 +2235,7 @@ int CVideoDatabase::SetDetailsForMovieSet(const CVideoInfoTag& details, const st
 
     // and insert the new row
     std::string sql = PrepareSQL("UPDATE sets SET strSet='%s' WHERE idSet=%i", details.m_strTitle.c_str(), idSet);
-    m_pDS->exec(sql.c_str());
+    m_pDS->exec(sql);
     CommitTransaction();
 
     return idSet;
@@ -2363,7 +2363,7 @@ int CVideoDatabase::SetDetailsForSeason(const CVideoInfoTag& details, const std:
 
     // and insert the new row
     std::string sql = PrepareSQL("UPDATE seasons SET season=%i WHERE idSeason=%i", details.m_iSeason, idSeason);
-    m_pDS->exec(sql.c_str());
+    m_pDS->exec(sql);
     CommitTransaction();
 
     return idSeason;
@@ -2420,7 +2420,7 @@ int CVideoDatabase::SetDetailsForEpisode(const std::string& strFilenameAndPath, 
     if (details.m_iEpisode != -1 && details.m_iSeason != -1)
     { // query DB for any episodes matching idShow, Season and Episode
       std::string strSQL = PrepareSQL("SELECT files.playCount, files.lastPlayed FROM episode INNER JOIN files ON files.idFile=episode.idFile WHERE episode.c%02d=%i AND episode.c%02d=%i AND episode.idShow=%i AND episode.idEpisode!=%i AND files.playCount > 0", VIDEODB_ID_EPISODE_SEASON, details.m_iSeason, VIDEODB_ID_EPISODE_EPISODE, details.m_iEpisode, idShow, idEpisode);
-      m_pDS->query(strSQL.c_str());
+      m_pDS->query(strSQL);
 
       if (!m_pDS->eof())
       {
@@ -2433,7 +2433,7 @@ int CVideoDatabase::SetDetailsForEpisode(const std::string& strFilenameAndPath, 
 
         // update with playCount and lastPlayed
         strSQL = PrepareSQL("update files set playCount=%i,lastPlayed='%s' where idFile=%i", playCount, lastPlayed.GetAsDBDateTime().c_str(), idFile);
-        m_pDS->exec(strSQL.c_str());
+        m_pDS->exec(strSQL);
       }
 
       m_pDS->close();
@@ -2445,7 +2445,7 @@ int CVideoDatabase::SetDetailsForEpisode(const std::string& strFilenameAndPath, 
     else
       sql += ", userrating = NULL";
     sql += PrepareSQL(" where idEpisode=%i", idEpisode);
-    m_pDS->exec(sql.c_str());
+    m_pDS->exec(sql);
     CommitTransaction();
 
     return idEpisode;
@@ -2522,7 +2522,7 @@ int CVideoDatabase::SetDetailsForMusicVideo(const std::string& strFilenameAndPat
     else
       sql += ", userrating = NULL";
     sql += PrepareSQL(" where idMVideo=%i", idMVideo);
-    m_pDS->exec(sql.c_str());
+    m_pDS->exec(sql);
     CommitTransaction();
 
     return idMVideo;
@@ -2626,7 +2626,7 @@ void CVideoDatabase::GetFilePathById(int idMovie, std::string &filePath, VIDEODB
     if (iType ==VIDEODB_CONTENT_MUSICVIDEOS)
       strSQL=PrepareSQL("SELECT path.strPath, files.strFileName FROM path INNER JOIN files ON path.idPath=files.idPath INNER JOIN musicvideo ON files.idFile=musicvideo.idFile WHERE musicvideo.idMVideo=%i ORDER BY strFilename", idMovie );
 
-    m_pDS->query( strSQL.c_str() );
+    m_pDS->query( strSQL );
     if (!m_pDS->eof())
     {
       if (iType != VIDEODB_CONTENT_TVSHOWS)
@@ -2671,7 +2671,7 @@ void CVideoDatabase::GetBookMarksForFile(const std::string& strFilenameAndPath, 
       if (NULL == m_pDS.get()) return ;
 
       std::string strSQL=PrepareSQL("select * from bookmark where idFile=%i and type=%i order by timeInSeconds", idFile, (int)type);
-      m_pDS->query( strSQL.c_str() );
+      m_pDS->query( strSQL );
       while (!m_pDS->eof())
       {
         CBookmark bookmark;
@@ -2685,7 +2685,7 @@ void CVideoDatabase::GetBookMarksForFile(const std::string& strFilenameAndPath, 
         if (type == CBookmark::EPISODE)
         {
           std::string strSQL2=PrepareSQL("select c%02d, c%02d from episode where c%02d=%i order by c%02d, c%02d", VIDEODB_ID_EPISODE_EPISODE, VIDEODB_ID_EPISODE_SEASON, VIDEODB_ID_EPISODE_BOOKMARK, m_pDS->fv("idBookmark").get_asInt(), VIDEODB_ID_EPISODE_SORTSEASON, VIDEODB_ID_EPISODE_SORTEPISODE);
-          m_pDS2->query(strSQL2.c_str());
+          m_pDS2->query(strSQL2);
           bookmark.episodeNumber = m_pDS2->fv(0).get_asInt();
           bookmark.seasonNumber = m_pDS2->fv(1).get_asInt();
           m_pDS2->close();
@@ -2727,7 +2727,7 @@ void CVideoDatabase::DeleteResumeBookMark(const std::string &strFilenameAndPath)
   try
   {
     std::string sql = PrepareSQL("delete from bookmark where idFile=%i and type=%i", fileID, CBookmark::RESUME);
-    m_pDS->exec(sql.c_str());
+    m_pDS->exec(sql);
   }
   catch(...)
   {
@@ -2740,7 +2740,7 @@ void CVideoDatabase::GetEpisodesByFile(const std::string& strFilenameAndPath, st
   try
   {
     std::string strSQL = PrepareSQL("select * from episode_view where idFile=%i order by c%02d, c%02d asc", GetFileId(strFilenameAndPath), VIDEODB_ID_EPISODE_SORTSEASON, VIDEODB_ID_EPISODE_SORTEPISODE);
-    m_pDS->query(strSQL.c_str());
+    m_pDS->query(strSQL);
     while (!m_pDS->eof())
     {
       episodes.push_back(GetDetailsForEpisode(m_pDS));
@@ -2782,7 +2782,7 @@ void CVideoDatabase::AddBookMarkToFile(const std::string& strFilenameAndPath, co
     if (type != CBookmark::EPISODE)
     {
       // get current id
-      m_pDS->query( strSQL.c_str() );
+      m_pDS->query( strSQL );
       if (m_pDS->num_rows() != 0)
         idBookmark = m_pDS->get_field_value("idBookmark").get_asInt();
       m_pDS->close();
@@ -2793,7 +2793,7 @@ void CVideoDatabase::AddBookMarkToFile(const std::string& strFilenameAndPath, co
     else
       strSQL=PrepareSQL("insert into bookmark (idBookmark, idFile, timeInSeconds, totalTimeInSeconds, thumbNailImage, player, playerState, type) values(NULL,%i,%f,%f,'%s','%s','%s', %i)", idFile, bookmark.timeInSeconds, bookmark.totalTimeInSeconds, bookmark.thumbNailImage.c_str(), bookmark.player.c_str(), bookmark.playerState.c_str(), (int)type);
 
-    m_pDS->exec(strSQL.c_str());
+    m_pDS->exec(strSQL);
   }
   catch (...)
   {
@@ -2816,16 +2816,16 @@ void CVideoDatabase::ClearBookMarkOfFile(const std::string& strFilenameAndPath, 
     double maxtime = bookmark.timeInSeconds + 0.5f;
     std::string strSQL = PrepareSQL("select idBookmark from bookmark where idFile=%i and type=%i and playerState like '%s' and player like '%s' and (timeInSeconds between %f and %f)", idFile, type, bookmark.playerState.c_str(), bookmark.player.c_str(), mintime, maxtime);
 
-    m_pDS->query( strSQL.c_str() );
+    m_pDS->query( strSQL );
     if (m_pDS->num_rows() != 0)
     {
       int idBookmark = m_pDS->get_field_value("idBookmark").get_asInt();
       strSQL=PrepareSQL("delete from bookmark where idBookmark=%i",idBookmark);
-      m_pDS->exec(strSQL.c_str());
+      m_pDS->exec(strSQL);
       if (type == CBookmark::EPISODE)
       {
         strSQL=PrepareSQL("update episode set c%02d=-1 where idFile=%i and c%02d=%i", VIDEODB_ID_EPISODE_BOOKMARK, idFile, VIDEODB_ID_EPISODE_BOOKMARK, idBookmark);
-        m_pDS->exec(strSQL.c_str());
+        m_pDS->exec(strSQL);
       }
     }
 
@@ -2856,11 +2856,11 @@ void CVideoDatabase::ClearBookMarksOfFile(int idFile, CBookmark::EType type /*= 
     if (NULL == m_pDS.get()) return ;
 
     std::string strSQL=PrepareSQL("delete from bookmark where idFile=%i and type=%i", idFile, (int)type);
-    m_pDS->exec(strSQL.c_str());
+    m_pDS->exec(strSQL);
     if (type == CBookmark::EPISODE)
     {
       strSQL=PrepareSQL("update episode set c%02d=-1 where idFile=%i", VIDEODB_ID_EPISODE_BOOKMARK, idFile);
-      m_pDS->exec(strSQL.c_str());
+      m_pDS->exec(strSQL);
     }
   }
   catch (...)
@@ -2875,7 +2875,7 @@ bool CVideoDatabase::GetBookMarkForEpisode(const CVideoInfoTag& tag, CBookmark& 
   try
   {
     std::string strSQL = PrepareSQL("select bookmark.* from bookmark join episode on episode.c%02d=bookmark.idBookmark where episode.idEpisode=%i", VIDEODB_ID_EPISODE_BOOKMARK, tag.m_iDbId);
-    m_pDS->query( strSQL.c_str() );
+    m_pDS->query( strSQL );
     if (!m_pDS->eof())
     {
       bookmark.timeInSeconds = m_pDS->fv("timeInSeconds").get_asDouble();
@@ -2907,12 +2907,12 @@ void CVideoDatabase::AddBookMarkForEpisode(const CVideoInfoTag& tag, const CBook
     int idFile = GetFileId(tag.m_strFileNameAndPath);
     // delete the current episode for the selected episode number
     std::string strSQL = PrepareSQL("delete from bookmark where idBookmark in (select c%02d from episode where c%02d=%i and c%02d=%i and idFile=%i)", VIDEODB_ID_EPISODE_BOOKMARK, VIDEODB_ID_EPISODE_SEASON, tag.m_iSeason, VIDEODB_ID_EPISODE_EPISODE, tag.m_iEpisode, idFile);
-    m_pDS->exec(strSQL.c_str());
+    m_pDS->exec(strSQL);
 
     AddBookMarkToFile(tag.m_strFileNameAndPath, bookmark, CBookmark::EPISODE);
     int idBookmark = (int)m_pDS->lastinsertid();
     strSQL = PrepareSQL("update episode set c%02d=%i where c%02d=%i and c%02d=%i and idFile=%i", VIDEODB_ID_EPISODE_BOOKMARK, idBookmark, VIDEODB_ID_EPISODE_SEASON, tag.m_iSeason, VIDEODB_ID_EPISODE_EPISODE, tag.m_iEpisode, idFile);
-    m_pDS->exec(strSQL.c_str());
+    m_pDS->exec(strSQL);
   }
   catch (...)
   {
@@ -2925,9 +2925,9 @@ void CVideoDatabase::DeleteBookMarkForEpisode(const CVideoInfoTag& tag)
   try
   {
     std::string strSQL = PrepareSQL("delete from bookmark where idBookmark in (select c%02d from episode where idEpisode=%i)", VIDEODB_ID_EPISODE_BOOKMARK, tag.m_iDbId);
-    m_pDS->exec(strSQL.c_str());
+    m_pDS->exec(strSQL);
     strSQL = PrepareSQL("update episode set c%02d=-1 where idEpisode=%i", VIDEODB_ID_EPISODE_BOOKMARK, tag.m_iDbId);
-    m_pDS->exec(strSQL.c_str());
+    m_pDS->exec(strSQL);
   }
   catch (...)
   {
@@ -2966,7 +2966,7 @@ void CVideoDatabase::DeleteMovie(int idMovie, bool bKeepId /* = false */)
         InvalidatePathHash(path);
 
       std::string strSQL = PrepareSQL("delete from movie where idMovie=%i", idMovie);
-      m_pDS->exec(strSQL.c_str());
+      m_pDS->exec(strSQL);
     }
 
     // TODO: move this below CommitTransaction() once UPnP doesn't rely on this anymore
@@ -3006,7 +3006,7 @@ void CVideoDatabase::DeleteTvShow(int idTvShow, bool bKeepId /* = false */)
     GetPathsForTvShow(idTvShow, paths);
 
     std::string strSQL=PrepareSQL("SELECT episode.idEpisode FROM episode WHERE episode.idShow=%i",idTvShow);
-    m_pDS2->query(strSQL.c_str());
+    m_pDS2->query(strSQL);
     while (!m_pDS2->eof())
     {
       DeleteEpisode(m_pDS2->fv(0).get_asInt(), bKeepId);
@@ -3016,13 +3016,13 @@ void CVideoDatabase::DeleteTvShow(int idTvShow, bool bKeepId /* = false */)
     DeleteDetailsForTvShow(idTvShow);
 
     strSQL=PrepareSQL("delete from seasons where idShow=%i", idTvShow);
-    m_pDS->exec(strSQL.c_str());
+    m_pDS->exec(strSQL);
 
     // keep tvshow table and movielink table so we can update data in place
     if (!bKeepId)
     {
       strSQL=PrepareSQL("delete from tvshow where idShow=%i", idTvShow);
-      m_pDS->exec(strSQL.c_str());
+      m_pDS->exec(strSQL);
 
       for (std::set<int>::const_iterator i = paths.begin(); i != paths.end(); ++i)
       {
@@ -3063,7 +3063,7 @@ void CVideoDatabase::DeleteSeason(int idSeason, bool bKeepId /* = false */)
     std::string strSQL = PrepareSQL("SELECT episode.idEpisode FROM episode "
                                     "JOIN seasons ON seasons.idSeason = %d AND episode.idShow = seasons.idShow AND episode.c%02d = seasons.season ",
                                    idSeason, VIDEODB_ID_EPISODE_SEASON);
-    m_pDS2->query(strSQL.c_str());
+    m_pDS2->query(strSQL);
     while (!m_pDS2->eof())
     {
       DeleteEpisode(m_pDS2->fv(0).get_asInt(), bKeepId);
@@ -3112,7 +3112,7 @@ void CVideoDatabase::DeleteEpisode(int idEpisode, bool bKeepId /* = false */)
         InvalidatePathHash(path);
 
       std::string strSQL = PrepareSQL("delete from episode where idEpisode=%i", idEpisode);
-      m_pDS->exec(strSQL.c_str());
+      m_pDS->exec(strSQL);
     }
 
   }
@@ -3151,7 +3151,7 @@ void CVideoDatabase::DeleteMusicVideo(int idMVideo, bool bKeepId /* = false */)
         InvalidatePathHash(path);
 
       std::string strSQL = PrepareSQL("delete from musicvideo where idMVideo=%i", idMVideo);
-      m_pDS->exec(strSQL.c_str());
+      m_pDS->exec(strSQL);
     }
 
     //TODO: move this below CommitTransaction() once UPnP doesn't rely on this anymore
@@ -3194,9 +3194,9 @@ void CVideoDatabase::DeleteSet(int idSet)
 
     std::string strSQL;
     strSQL=PrepareSQL("delete from sets where idSet = %i", idSet);
-    m_pDS->exec(strSQL.c_str());
+    m_pDS->exec(strSQL);
     strSQL=PrepareSQL("update movie set idSet = null where idSet = %i", idSet);
-    m_pDS->exec(strSQL.c_str());
+    m_pDS->exec(strSQL);
   }
   catch (...)
   {
@@ -3235,7 +3235,7 @@ void CVideoDatabase::DeleteTag(int idTag, VIDEODB_CONTENT_TYPE mediaType)
       return;
 
     std::string strSQL = PrepareSQL("DELETE FROM tag_link WHERE tag_id = %i AND media_type = '%s'", idTag, type.c_str());
-    m_pDS->exec(strSQL.c_str());
+    m_pDS->exec(strSQL);
   }
   catch (...)
   {
@@ -3346,7 +3346,7 @@ bool CVideoDatabase::GetStreamDetails(CVideoInfoTag& tag) const
   try
   {
     std::string strSQL = PrepareSQL("SELECT * FROM streamdetails WHERE idFile = %i", tag.m_iFileId);
-    pDS->query(strSQL.c_str());
+    pDS->query(strSQL);
 
     while (!pDS->eof())
     {
@@ -3437,7 +3437,7 @@ bool CVideoDatabase::GetResumePoint(CVideoInfoTag& tag)
     else
     {
       std::string strSQL=PrepareSQL("select timeInSeconds, totalTimeInSeconds from bookmark where idFile=%i and type=%i order by timeInSeconds", tag.m_iFileId, CBookmark::RESUME);
-      m_pDS2->query( strSQL.c_str() );
+      m_pDS2->query( strSQL );
       if (!m_pDS2->eof())
       {
         tag.m_resumePoint.timeInSeconds = m_pDS2->fv(0).get_asDouble();
@@ -3507,7 +3507,7 @@ CVideoInfoTag CVideoDatabase::GetDetailsForMovie(const dbiplus::sql_record* cons
     {
       std::string strSQL = PrepareSQL("select c%02d from tvshow where idShow=%i",
                          VIDEODB_ID_TV_TITLE,links[i]);
-      m_pDS2->query(strSQL.c_str());
+      m_pDS2->query(strSQL);
       if (!m_pDS2->eof())
         details.m_showLink.push_back(m_pDS2->fv(0).get_asString());
     }
@@ -3623,7 +3623,7 @@ CVideoInfoTag CVideoDatabase::GetDetailsForEpisode(const dbiplus::sql_record* co
     castTime += XbmcThreads::SystemClockMillis() - time; time = XbmcThreads::SystemClockMillis();
     details.m_strPictureURL.Parse();
     std::string strSQL = PrepareSQL("select * from bookmark join episode on episode.c%02d=bookmark.idBookmark where episode.idEpisode=%i and bookmark.type=%i", VIDEODB_ID_EPISODE_BOOKMARK,details.m_iDbId,CBookmark::EPISODE);
-    m_pDS2->query(strSQL.c_str());
+    m_pDS2->query(strSQL);
     if (!m_pDS2->eof())
       details.m_fEpBookmark = m_pDS2->fv("bookmark.timeInSeconds").get_asFloat();
     m_pDS2->close();
@@ -3770,7 +3770,7 @@ bool CVideoDatabase::GetVideoSettings(int idFile, CVideoSettings &settings)
     if (NULL == m_pDS.get()) return false;
 
     std::string strSQL=PrepareSQL("select * from settings where settings.idFile = '%i'", idFile);
-    m_pDS->query( strSQL.c_str() );
+    m_pDS->query( strSQL );
 
     if (m_pDS->num_rows() > 0)
     { // get the video settings info
@@ -3822,7 +3822,7 @@ void CVideoDatabase::SetVideoSettings(const std::string& strFilenameAndPath, con
     if (idFile < 0)
       return;
     std::string strSQL = PrepareSQL("select * from settings where idFile=%i", idFile);
-    m_pDS->query( strSQL.c_str() );
+    m_pDS->query( strSQL );
     if (m_pDS->num_rows() > 0)
     {
       m_pDS->close();
@@ -3839,7 +3839,7 @@ void CVideoDatabase::SetVideoSettings(const std::string& strFilenameAndPath, con
       std::string strSQL2;
       strSQL2=PrepareSQL("ResumeTime=%i,StereoMode=%i,StereoInvert=%i where idFile=%i\n", setting.m_ResumeTime, setting.m_StereoMode, setting.m_StereoInvert, idFile);
       strSQL += strSQL2;
-      m_pDS->exec(strSQL.c_str());
+      m_pDS->exec(strSQL);
       return ;
     }
     else
@@ -3858,7 +3858,7 @@ void CVideoDatabase::SetVideoSettings(const std::string& strFilenameAndPath, con
                            setting.m_ResumeTime,
                            setting.m_Sharpness, setting.m_NoiseReduction, setting.m_CustomNonLinStretch, setting.m_PostProcess, setting.m_ScalingMethod,
                            setting.m_DeinterlaceMode, setting.m_StereoMode, setting.m_StereoInvert);
-      m_pDS->exec(strSQL.c_str());
+      m_pDS->exec(strSQL);
     }
   }
   catch (...)
@@ -3885,7 +3885,7 @@ void CVideoDatabase::SetArtForItem(int mediaId, const MediaType &mediaType, cons
       return;
 
     std::string sql = PrepareSQL("SELECT art_id,url FROM art WHERE media_id=%i AND media_type='%s' AND type='%s'", mediaId, mediaType.c_str(), artType.c_str());
-    m_pDS->query(sql.c_str());
+    m_pDS->query(sql);
     if (!m_pDS->eof())
     { // update
       int artId = m_pDS->fv(0).get_asInt();
@@ -3894,14 +3894,14 @@ void CVideoDatabase::SetArtForItem(int mediaId, const MediaType &mediaType, cons
       if (oldUrl != url)
       {
         sql = PrepareSQL("UPDATE art SET url='%s' where art_id=%d", url.c_str(), artId);
-        m_pDS->exec(sql.c_str());
+        m_pDS->exec(sql);
       }
     }
     else
     { // insert
       m_pDS->close();
       sql = PrepareSQL("INSERT INTO art(media_id, media_type, type, url) VALUES (%d, '%s', '%s', '%s')", mediaId, mediaType.c_str(), artType.c_str(), url.c_str());
-      m_pDS->exec(sql.c_str());
+      m_pDS->exec(sql);
     }
   }
   catch (...)
@@ -3918,7 +3918,7 @@ bool CVideoDatabase::GetArtForItem(int mediaId, const MediaType &mediaType, std:
     if (NULL == m_pDS2.get()) return false; // using dataset 2 as we're likely called in loops on dataset 1
 
     std::string sql = PrepareSQL("SELECT type,url FROM art WHERE media_id=%i AND media_type='%s'", mediaId, mediaType.c_str());
-    m_pDS2->query(sql.c_str());
+    m_pDS2->query(sql);
     while (!m_pDS2->eof())
     {
       art.insert(make_pair(m_pDS2->fv(0).get_asString(), m_pDS2->fv(1).get_asString()));
@@ -3963,7 +3963,7 @@ bool CVideoDatabase::GetTvShowSeasons(int showId, std::map<int, int> &seasons)
 
     // get all seasons for this show
     std::string sql = PrepareSQL("select idSeason,season from seasons where idShow=%i", showId);
-    m_pDS2->query(sql.c_str());
+    m_pDS2->query(sql);
 
     seasons.clear();
     while (!m_pDS2->eof())
@@ -4046,7 +4046,7 @@ bool CVideoDatabase::GetStackTimes(const std::string &filePath, std::vector<int>
     if (NULL == m_pDS.get()) return false;
     // ok, now obtain the settings for this file
     std::string strSQL=PrepareSQL("select times from stacktimes where idFile=%i\n", idFile);
-    m_pDS->query( strSQL.c_str() );
+    m_pDS->query( strSQL );
     if (m_pDS->num_rows() > 0)
     { // get the video settings info
       int timeTotal = 0;
@@ -4139,11 +4139,11 @@ void CVideoDatabase::RemoveContentForPath(const std::string& strPath, CGUIDialog
       else
       {
         std::string strSQL = PrepareSQL("select files.strFilename from files join movie on movie.idFile=files.idFile where files.idPath=%i", i->first);
-        m_pDS2->query(strSQL.c_str());
+        m_pDS2->query(strSQL);
         if (m_pDS2->eof())
         {
           strSQL = PrepareSQL("select files.strFilename from files join musicvideo on musicvideo.idFile=files.idFile where files.idPath=%i", i->first);
-          m_pDS2->query(strSQL.c_str());
+          m_pDS2->query(strSQL);
           bMvidsChecked = true;
         }
         while (!m_pDS2->eof())
@@ -4159,7 +4159,7 @@ void CVideoDatabase::RemoveContentForPath(const std::string& strPath, CGUIDialog
           if (m_pDS2->eof() && !bMvidsChecked)
           {
             strSQL =PrepareSQL("select files.strFilename from files join musicvideo on musicvideo.idFile=files.idFile where files.idPath=%i", i->first);
-            m_pDS2->query(strSQL.c_str());
+            m_pDS2->query(strSQL);
             bMvidsChecked = true;
           }
         }
@@ -4214,7 +4214,7 @@ void CVideoDatabase::SetScraperForPath(const std::string& filePath, const Scrape
       std::string content = TranslateContent(scraper->Content());
       strSQL=PrepareSQL("update path set strContent='%s', strScraper='%s', scanRecursive=%i, useFolderNames=%i, strSettings='%s', noUpdate=%i, exclude=0 where idPath=%i", content.c_str(), scraper->ID().c_str(),settings.recurse,settings.parent_name,scraper->GetPathSettings().c_str(),settings.noupdate, idPath);
     }
-    m_pDS->exec(strSQL.c_str());
+    m_pDS->exec(strSQL);
   }
   catch (...)
   {
@@ -4230,7 +4230,7 @@ bool CVideoDatabase::ScraperInUse(const std::string &scraperID) const
     if (NULL == m_pDS.get()) return false;
 
     std::string sql = PrepareSQL("select count(1) from path where strScraper='%s'", scraperID.c_str());
-    if (!m_pDS->query(sql.c_str()) || m_pDS->num_rows() == 0)
+    if (!m_pDS->query(sql) || m_pDS->num_rows() == 0)
       return false;
     bool found = m_pDS->fv(0).get_asInt() > 0;
     m_pDS->close();
@@ -4317,7 +4317,7 @@ void CVideoDatabase::UpdateTables(int iVersion)
   {
     // drop duplicates in tvshow table, and update tvshowlinkpath accordingly
     std::string sql = PrepareSQL("SELECT tvshow.idShow,idPath,c%02d,c%02d,c%02d FROM tvshow JOIN tvshowlinkpath ON tvshow.idShow = tvshowlinkpath.idShow", VIDEODB_ID_TV_TITLE, VIDEODB_ID_TV_PREMIERED, VIDEODB_ID_TV_IDENT);
-    m_pDS->query(sql.c_str());
+    m_pDS->query(sql);
     std::vector<CShowItem> shows;
     while (!m_pDS->eof())
     {
@@ -4702,7 +4702,7 @@ int CVideoDatabase::GetPlayCount(int iFileId)
 
     std::string strSQL = PrepareSQL("select playCount from files WHERE idFile=%i", iFileId);
     int count = 0;
-    if (m_pDS->query(strSQL.c_str()))
+    if (m_pDS->query(strSQL))
     {
       // there should only ever be one row returned
       if (m_pDS->num_rows() == 1)
@@ -4742,7 +4742,7 @@ void CVideoDatabase::UpdateFanart(const CFileItem &item, VIDEODB_CONTENT_TYPE ty
 
   try
   {
-    m_pDS->exec(exec.c_str());
+    m_pDS->exec(exec);
 
     if (type == VIDEODB_CONTENT_TVSHOWS)
       AnnounceUpdate(MediaTypeTvShow, item.GetVideoInfoTag()->m_iDbId);
@@ -4792,7 +4792,7 @@ void CVideoDatabase::SetPlayCount(const CFileItem &item, int count, const CDateT
         strSQL = PrepareSQL("update files set playCount=NULL,lastPlayed='%s' where idFile=%i", date.GetAsDBDateTime().c_str(), id);
     }
 
-    m_pDS->exec(strSQL.c_str());
+    m_pDS->exec(strSQL);
 
     // We only need to announce changes to video items in the library
     if (item.HasVideoInfoTag() && item.GetVideoInfoTag()->m_iDbId > 0)
@@ -4853,7 +4853,7 @@ void CVideoDatabase::UpdateMovieTitle(int idMovie, const std::string& strNewMovi
     {
       CLog::Log(LOGINFO, "Changing Movie set:id:%i New Title:%s", idMovie, strNewMovieTitle.c_str());
       std::string strSQL = PrepareSQL("UPDATE sets SET strSet='%s' WHERE idSet=%i", strNewMovieTitle.c_str(), idMovie );
-      m_pDS->exec(strSQL.c_str());
+      m_pDS->exec(strSQL);
     }
 
     if (!content.empty())
@@ -5453,7 +5453,7 @@ bool CVideoDatabase::GetPeopleNav(const std::string& strBaseDir, CFileItemList& 
 
     // run query
     unsigned int time = XbmcThreads::SystemClockMillis();
-    if (!m_pDS->query(strSQL.c_str())) return false;
+    if (!m_pDS->query(strSQL)) return false;
     CLog::Log(LOGDEBUG, "%s -  query took %i ms",
               __FUNCTION__, XbmcThreads::SystemClockMillis() - time); time = XbmcThreads::SystemClockMillis();
     int iRowsFound = m_pDS->num_rows();
@@ -6477,7 +6477,7 @@ int CVideoDatabase::GetTvShowForEpisode(int idEpisode)
 
     // make sure we use m_pDS2, as this is called in loops using m_pDS
     std::string strSQL=PrepareSQL("select idShow from episode where idEpisode=%i", idEpisode);
-    m_pDS2->query( strSQL.c_str() );
+    m_pDS2->query( strSQL );
 
     int result=-1;
     if (!m_pDS2->eof())
@@ -6525,7 +6525,7 @@ bool CVideoDatabase::HasContent(VIDEODB_CONTENT_TYPE type)
       sql = "select count(1) from tvshow";
     else if (type == VIDEODB_CONTENT_MUSICVIDEOS)
       sql = "select count(1) from musicvideo";
-    m_pDS->query( sql.c_str() );
+    m_pDS->query( sql );
 
     if (!m_pDS->eof())
       result = (m_pDS->fv(0).get_asInt() > 0);
@@ -6572,7 +6572,7 @@ ScraperPtr CVideoDatabase::GetScraperForPath(const std::string& strPath, SScanSe
     if (idPath > -1)
     {
       std::string strSQL=PrepareSQL("select path.strContent,path.strScraper,path.scanRecursive,path.useFolderNames,path.strSettings,path.noUpdate,path.exclude from path where path.idPath=%i",idPath);
-      m_pDS->query( strSQL.c_str() );
+      m_pDS->query( strSQL );
     }
 
     int iFound = 1;
@@ -6622,7 +6622,7 @@ ScraperPtr CVideoDatabase::GetScraperForPath(const std::string& strPath, SScanSe
         iFound++;
 
         std::string strSQL=PrepareSQL("select path.strContent,path.strScraper,path.scanRecursive,path.useFolderNames,path.strSettings,path.noUpdate, path.exclude from path where strPath='%s'",strParent.c_str());
-        m_pDS->query(strSQL.c_str());
+        m_pDS->query(strSQL);
 
         CONTENT_TYPE content = CONTENT_NONE;
         if (!m_pDS->eof())
@@ -6718,7 +6718,7 @@ std::string CVideoDatabase::GetContentForPath(const std::string& strPath)
       else
         sql += PrepareSQL("WHERE strPath LIKE '%s%%'", strPath.c_str());
 
-      m_pDS->query( sql.c_str() );
+      m_pDS->query( sql );
       if (m_pDS->num_rows() && m_pDS->fv(0).get_asInt() > 0)
         return "episodes";
       return foundDirectly ? "tvshows" : "seasons";
@@ -6741,7 +6741,7 @@ void CVideoDatabase::GetMovieGenresByName(const std::string& strSearch, CFileIte
       strSQL=PrepareSQL("SELECT genre.genre_id, genre.name, path.strPath FROM genre INNER JOIN genre_link ON genre_link.genre_id = genre.genre_id INNER JOIN movie ON (genre_link.media_type='movie' = genre_link.media_id=movie.idMovie) INNER JOIN files ON files.idFile=movie.idFile INNER JOIN path ON path.idPath=files.idPath WHERE genre.name LIKE '%%%s%%'",strSearch.c_str());
     else
       strSQL=PrepareSQL("SELECT DISTINCT genre.genre_id, genre.name FROM genre INNER JOIN genre_link ON genre_link.genre_id=genre.genre_id WHERE genre_link.media_type='movie' AND name LIKE '%%%s%%'", strSearch.c_str());
-    m_pDS->query( strSQL.c_str() );
+    m_pDS->query( strSQL );
 
     while (!m_pDS->eof())
     {
@@ -6781,7 +6781,7 @@ void CVideoDatabase::GetMovieCountriesByName(const std::string& strSearch, CFile
       strSQL=PrepareSQL("SELECT country.country_id, country.name, path.strPath FROM country INNER JOIN country_link ON country_link.country_id=country.country_id INNER JOIN movie ON country_link.media_id=movie.idMovie INNER JOIN files ON files.idFile=movie.idFile INNER JOIN path ON path.idPath=files.idPath WHERE country_link.media_type='movie' AND country.name LIKE '%%%s%%'", strSearch.c_str());
     else
       strSQL=PrepareSQL("SELECT DISTINCT country.country_id, country.name FROM country INNER JOIN country_link ON country_link.country_id=country.country_id WHERE country_link.media_type='movie' AND name like '%%%s%%'", strSearch.c_str());
-    m_pDS->query( strSQL.c_str() );
+    m_pDS->query( strSQL );
 
     while (!m_pDS->eof())
     {
@@ -6821,7 +6821,7 @@ void CVideoDatabase::GetTvShowGenresByName(const std::string& strSearch, CFileIt
       strSQL=PrepareSQL("SELECT genre.genre_id, genre.name, path.strPath FROM genre INNER JOIN genre_link ON genre_link.genre_id=genre.genre_id INNER JOIN tvshow ON genre_link.media_id=tvshow.idShow INNER JOIN tvshowlinkpath ON tvshowlinkpath.idShow=tvshow.idShow INNER JOIN path ON path.idPath=tvshowlinkpath.idPath WHERE genre_link.media_type='tvshow' AND genre.name LIKE '%%%s%%'", strSearch.c_str());
     else
       strSQL=PrepareSQL("SELECT DISTINCT genre.genre_id, genre.name FROM genre INNER JOIN genre_link ON genre_link.genre_id=genre.genre_id WHERE genre_link.media_type='tvshow' AND name LIKE '%%%s%%'", strSearch.c_str());
-    m_pDS->query( strSQL.c_str() );
+    m_pDS->query( strSQL );
 
     while (!m_pDS->eof())
     {
@@ -6860,7 +6860,7 @@ void CVideoDatabase::GetMovieActorsByName(const std::string& strSearch, CFileIte
       strSQL=PrepareSQL("SELECT actor.actor_id, actor.name, path.strPath FROM actor INNER JOIN actor_link ON actor_link.actor_id=actor.actor_id INNER JOIN movie ON actor_link.media_id=movie.idMovie INNER JOIN files ON files.idFile=movie.idFile INNER JOIN path ON path.idPath=files.idPath WHERE actor_link.media_type='movie' AND actor.name LIKE '%%%s%%'", strSearch.c_str());
     else
       strSQL=PrepareSQL("SELECT DISTINCT actor.actor_id, actor.name FROM actor INNER JOIN actor_link ON actor_link.actor_id=actor.actor_id INNER JOIN movie ON actor_link.media_id=movie.idMovie WHERE actor_link.media_type='movie' AND actor.name LIKE '%%%s%%'", strSearch.c_str());
-    m_pDS->query( strSQL.c_str() );
+    m_pDS->query( strSQL );
 
     while (!m_pDS->eof())
     {
@@ -6899,7 +6899,7 @@ void CVideoDatabase::GetTvShowsActorsByName(const std::string& strSearch, CFileI
       strSQL=PrepareSQL("SELECT actor.actor_id, actor.name, path.strPath FROM actor INNER JOIN actor_link ON actor_link.actor_id=actor.actor_id INNER JOIN tvshow ON actor_link.media_id=tvshow.idShow INNER JOIN tvshowlinkpath ON tvshowlinkpath.idPath=tvshow.idShow INNER JOIN path ON path.idPath=tvshowlinkpath.idPath WHERE actor_link.media_type='tvshow' AND actor.name LIKE '%%%s%%'", strSearch.c_str());
     else
       strSQL=PrepareSQL("SELECT DISTINCT actor.actor_id, actor.name FROM actor INNER JOIN actor_link ON actor_link.actor_id=actor.actor_id INNER JOIN tvshow ON actor_link.media_id=tvshow.idShow WHERE actor_link.media_type='tvshow' AND actor.name LIKE '%%%s%%'",strSearch.c_str());
-    m_pDS->query( strSQL.c_str() );
+    m_pDS->query( strSQL );
 
     while (!m_pDS->eof())
     {
@@ -6941,7 +6941,7 @@ void CVideoDatabase::GetMusicVideoArtistsByName(const std::string& strSearch, CF
       strSQL=PrepareSQL("SELECT actor.actor_id, actor.name, path.strPath FROM actor INNER JOIN actor_link ON actor_link.actor_id=actor.actor_id INNER JOIN musicvideo ON actor_link.media_id=musicvideo.idMVideo INNER JOIN files ON files.idFile=musicvideo.idFile INNER JOIN path ON path.idPath=files.idPath WHERE actor_link.media_type='musicvideo' "+strLike, strSearch.c_str());
     else
       strSQL=PrepareSQL("SELECT DISTINCT actor.actor_id, actor.name from actor INNER JOIN actor_link ON actor_link.actor_id=actor.actor_id WHERE actor_link.media_type='musicvideo' "+strLike,strSearch.c_str());
-    m_pDS->query( strSQL.c_str() );
+    m_pDS->query( strSQL );
 
     while (!m_pDS->eof())
     {
@@ -6980,7 +6980,7 @@ void CVideoDatabase::GetMusicVideoGenresByName(const std::string& strSearch, CFi
       strSQL=PrepareSQL("SELECT genre.genre_id, genre.name, path.strPath FROM genre INNER JOIN genre_link ON genre_link.genre_id=genre.genre_id INNER JOIN musicvideo ON genre_link.media_id=musicvideo.idMVideo INNER JOIN files ON files.idFile=musicvideo.idFile INNER JOIN path ON path.idPath=files.idPath WHERE genre_link.media_type='musicvideo' AND genre.name LIKE '%%%s%%'", strSearch.c_str());
     else
       strSQL=PrepareSQL("SELECT DISTINCT genre.genre_id, genre.name FROM genre INNER JOIN genre_link ON genre_link.genre_id=genre.genre_id WHERE genre_link.media_type='musicvideo' AND genre.name LIKE '%%%s%%'", strSearch.c_str());
-    m_pDS->query( strSQL.c_str() );
+    m_pDS->query( strSQL );
 
     while (!m_pDS->eof())
     {
@@ -7028,7 +7028,7 @@ void CVideoDatabase::GetMusicVideoAlbumsByName(const std::string& strSearch, CFi
     if (!strSearch.empty())
       strSQL += PrepareSQL(" WHERE musicvideo.c%02d like '%%%s%%'",VIDEODB_ID_MUSICVIDEO_ALBUM, strSearch.c_str());
 
-    m_pDS->query( strSQL.c_str() );
+    m_pDS->query( strSQL );
 
     while (!m_pDS->eof())
     {
@@ -7073,7 +7073,7 @@ void CVideoDatabase::GetMusicVideosByAlbum(const std::string& strSearch, CFileIt
       strSQL = PrepareSQL("SELECT musicvideo.idMVideo, musicvideo.c%02d,musicvideo.c%02d, path.strPath FROM musicvideo INNER JOIN files ON files.idFile=musicvideo.idFile INNER JOIN path ON path.idPath=files.idPath WHERE musicvideo.c%02d LIKE '%%%s%%'", VIDEODB_ID_MUSICVIDEO_ALBUM, VIDEODB_ID_MUSICVIDEO_TITLE, VIDEODB_ID_MUSICVIDEO_ALBUM, strSearch.c_str());
     else
       strSQL = PrepareSQL("select musicvideo.idMVideo,musicvideo.c%02d,musicvideo.c%02d from musicvideo where musicvideo.c%02d like '%%%s%%'",VIDEODB_ID_MUSICVIDEO_ALBUM,VIDEODB_ID_MUSICVIDEO_TITLE,VIDEODB_ID_MUSICVIDEO_ALBUM,strSearch.c_str());
-    m_pDS->query( strSQL.c_str() );
+    m_pDS->query( strSQL );
 
     while (!m_pDS->eof())
     {
@@ -7192,7 +7192,7 @@ unsigned int CVideoDatabase::GetMusicVideoIDs(const std::string& strWhere, std::
     if (!strWhere.empty())
       strSQL += " where " + strWhere;
 
-    if (!m_pDS->query(strSQL.c_str())) return 0;
+    if (!m_pDS->query(strSQL)) return 0;
     songIDs.clear();
     if (m_pDS->num_rows() == 0)
     {
@@ -7230,7 +7230,7 @@ bool CVideoDatabase::GetRandomMusicVideo(CFileItem* item, int& idSong, const std
     strSQL += PrepareSQL(" order by RANDOM() limit 1");
     CLog::Log(LOGDEBUG, "%s query = %s", __FUNCTION__, strSQL.c_str());
     // run query
-    if (!m_pDS->query(strSQL.c_str()))
+    if (!m_pDS->query(strSQL))
       return false;
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound != 1)
@@ -7275,7 +7275,7 @@ int CVideoDatabase::GetMatchingMusicVideo(const std::string& strArtist, const st
       else
         strSQL = PrepareSQL("select musicvideo.idMVideo from musicvideo join actor_link on actor_link.media_id=musicvideo.idMVideo AND actor_link.media_type='musicvideo' join actor on actor.actor_id=actor_link.actor_id where musicvideo.c%02d like '%s' and musicvideo.c%02d like '%s' and actor.name like '%s'",VIDEODB_ID_MUSICVIDEO_ALBUM,strAlbum.c_str(),VIDEODB_ID_MUSICVIDEO_TITLE,strTitle.c_str(),strArtist.c_str());
     }
-    m_pDS->query( strSQL.c_str() );
+    m_pDS->query( strSQL );
 
     if (m_pDS->eof())
       return -1;
@@ -7311,7 +7311,7 @@ void CVideoDatabase::GetMoviesByName(const std::string& strSearch, CFileItemList
       strSQL = PrepareSQL("SELECT movie.idMovie, movie.c%02d, path.strPath, movie.idSet FROM movie INNER JOIN files ON files.idFile=movie.idFile INNER JOIN path ON path.idPath=files.idPath WHERE movie.c%02d LIKE '%%%s%%'", VIDEODB_ID_TITLE, VIDEODB_ID_TITLE, strSearch.c_str());
     else
       strSQL = PrepareSQL("select movie.idMovie,movie.c%02d, movie.idSet from movie where movie.c%02d like '%%%s%%'",VIDEODB_ID_TITLE,VIDEODB_ID_TITLE,strSearch.c_str());
-    m_pDS->query( strSQL.c_str() );
+    m_pDS->query( strSQL );
 
     while (!m_pDS->eof())
     {
@@ -7356,7 +7356,7 @@ void CVideoDatabase::GetTvShowsByName(const std::string& strSearch, CFileItemLis
       strSQL = PrepareSQL("SELECT tvshow.idShow, tvshow.c%02d, path.strPath FROM tvshow INNER JOIN tvshowlinkpath ON tvshowlinkpath.idShow=tvshow.idShow INNER JOIN path ON path.idPath=tvshowlinkpath.idPath WHERE tvshow.c%02d LIKE '%%%s%%'", VIDEODB_ID_TV_TITLE, VIDEODB_ID_TV_TITLE, strSearch.c_str());
     else
       strSQL = PrepareSQL("select tvshow.idShow,tvshow.c%02d from tvshow where tvshow.c%02d like '%%%s%%'",VIDEODB_ID_TV_TITLE,VIDEODB_ID_TV_TITLE,strSearch.c_str());
-    m_pDS->query( strSQL.c_str() );
+    m_pDS->query( strSQL );
 
     while (!m_pDS->eof())
     {
@@ -7397,7 +7397,7 @@ void CVideoDatabase::GetEpisodesByName(const std::string& strSearch, CFileItemLi
       strSQL = PrepareSQL("SELECT episode.idEpisode, episode.c%02d, episode.c%02d, episode.idShow, tvshow.c%02d, path.strPath FROM episode INNER JOIN tvshow ON tvshow.idShow=episode.idShow INNER JOIN files ON files.idFile=episode.idFile INNER JOIN path ON path.idPath=files.idPath WHERE episode.c%02d LIKE '%%%s%%'", VIDEODB_ID_EPISODE_TITLE, VIDEODB_ID_EPISODE_SEASON, VIDEODB_ID_TV_TITLE, VIDEODB_ID_EPISODE_TITLE, strSearch.c_str());
     else
       strSQL = PrepareSQL("SELECT episode.idEpisode, episode.c%02d, episode.c%02d, episode.idShow, tvshow.c%02d FROM episode INNER JOIN tvshow ON tvshow.idShow=episode.idShow WHERE episode.c%02d like '%%%s%%'", VIDEODB_ID_EPISODE_TITLE, VIDEODB_ID_EPISODE_SEASON, VIDEODB_ID_TV_TITLE, VIDEODB_ID_EPISODE_TITLE, strSearch.c_str());
-    m_pDS->query( strSQL.c_str() );
+    m_pDS->query( strSQL );
 
     while (!m_pDS->eof())
     {
@@ -7440,7 +7440,7 @@ void CVideoDatabase::GetMusicVideosByName(const std::string& strSearch, CFileIte
       strSQL = PrepareSQL("SELECT musicvideo.idMVideo, musicvideo.c%02d, path.strPath FROM musicvideo INNER JOIN files ON files.idFile=musicvideo.idFile INNER JOIN path ON path.idPath=files.idPath WHERE musicvideo.c%02d LIKE '%%%s%%'", VIDEODB_ID_MUSICVIDEO_TITLE, VIDEODB_ID_MUSICVIDEO_TITLE, strSearch.c_str());
     else
       strSQL = PrepareSQL("select musicvideo.idMVideo,musicvideo.c%02d from musicvideo where musicvideo.c%02d like '%%%s%%'",VIDEODB_ID_MUSICVIDEO_TITLE,VIDEODB_ID_MUSICVIDEO_TITLE,strSearch.c_str());
-    m_pDS->query( strSQL.c_str() );
+    m_pDS->query( strSQL );
 
     while (!m_pDS->eof())
     {
@@ -7487,7 +7487,7 @@ void CVideoDatabase::GetEpisodesByPlot(const std::string& strSearch, CFileItemLi
       strSQL = PrepareSQL("SELECT episode.idEpisode, episode.c%02d, episode.c%02d, episode.idShow, tvshow.c%02d, path.strPath FROM episode INNER JOIN tvshow ON tvshow.idShow=episode.idShow INNER JOIN files ON files.idFile=episode.idFile INNER JOIN path ON path.idPath=files.idPath WHERE episode.c%02d LIKE '%%%s%%'", VIDEODB_ID_EPISODE_TITLE, VIDEODB_ID_EPISODE_SEASON, VIDEODB_ID_TV_TITLE, VIDEODB_ID_EPISODE_PLOT, strSearch.c_str());
     else
       strSQL = PrepareSQL("SELECT episode.idEpisode, episode.c%02d, episode.c%02d, episode.idShow, tvshow.c%02d FROM episode INNER JOIN tvshow ON tvshow.idShow=episode.idShow WHERE episode.c%02d LIKE '%%%s%%'", VIDEODB_ID_EPISODE_TITLE, VIDEODB_ID_EPISODE_SEASON, VIDEODB_ID_TV_TITLE, VIDEODB_ID_EPISODE_PLOT, strSearch.c_str());
-    m_pDS->query( strSQL.c_str() );
+    m_pDS->query( strSQL );
 
     while (!m_pDS->eof())
     {
@@ -7527,7 +7527,7 @@ void CVideoDatabase::GetMoviesByPlot(const std::string& strSearch, CFileItemList
     else
       strSQL = PrepareSQL("SELECT movie.idMovie, movie.c%02d FROM movie WHERE (movie.c%02d LIKE '%%%s%%' OR movie.c%02d LIKE '%%%s%%' OR movie.c%02d LIKE '%%%s%%')", VIDEODB_ID_TITLE, VIDEODB_ID_PLOT, strSearch.c_str(), VIDEODB_ID_PLOTOUTLINE, strSearch.c_str(), VIDEODB_ID_TAGLINE, strSearch.c_str());
 
-    m_pDS->query( strSQL.c_str() );
+    m_pDS->query( strSQL );
 
     while (!m_pDS->eof())
     {
@@ -7569,7 +7569,7 @@ void CVideoDatabase::GetMovieDirectorsByName(const std::string& strSearch, CFile
     else
       strSQL = PrepareSQL("SELECT DISTINCT director_link.actor_id, actor.name FROM actor INNER JOIN director_link ON director_link.actor_id=actor.actor_id INNER JOIN movie ON director_link.media_id=movie.idMovie WHERE director_link.media_type='movie' AND actor.name like '%%%s%%'", strSearch.c_str());
 
-    m_pDS->query( strSQL.c_str() );
+    m_pDS->query( strSQL );
 
     while (!m_pDS->eof())
     {
@@ -7610,7 +7610,7 @@ void CVideoDatabase::GetTvShowsDirectorsByName(const std::string& strSearch, CFi
     else
       strSQL = PrepareSQL("SELECT DISTINCT director_link.actor_id, actor.name FROM actor INNER JOIN director_link ON director_link.actor_id=actor.actor_id INNER JOIN tvshow ON director_link.media_id=tvshow.idShow WHERE director_link.media_type='tvshow' AND actor.name LIKE '%%%s%%'", strSearch.c_str());
 
-    m_pDS->query( strSQL.c_str() );
+    m_pDS->query( strSQL );
 
     while (!m_pDS->eof())
     {
@@ -7651,7 +7651,7 @@ void CVideoDatabase::GetMusicVideoDirectorsByName(const std::string& strSearch, 
     else
       strSQL = PrepareSQL("SELECT DISTINCT director_link.actor_id, actor.name FROM actor INNER JOIN director_link ON director_link.actor_id=actor.actor_id INNER JOIN musicvideo ON director_link.media_id=musicvideo.idMVideo WHERE director_link.media_type='musicvideo' AND actor.name LIKE '%%%s%%'", strSearch.c_str());
 
-    m_pDS->query( strSQL.c_str() );
+    m_pDS->query( strSQL );
 
     while (!m_pDS->eof())
     {
@@ -7702,7 +7702,7 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const st
       sql += PrepareSQL(" AND path.idPath IN (%s)", strPaths.substr(1).c_str());
     }
 
-    m_pDS->query(sql.c_str());
+    m_pDS->query(sql);
     if (m_pDS->num_rows() == 0) return;
 
     if (handle)
@@ -7818,7 +7818,7 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const st
 
       CLog::Log(LOGDEBUG, "%s: Cleaning files table", __FUNCTION__);
       sql = "DELETE FROM files WHERE idFile IN " + filesToDelete;
-      m_pDS->exec(sql.c_str());
+      m_pDS->exec(sql);
     }
 
     if (!movieIDs.empty())
@@ -7830,7 +7830,7 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const st
 
       CLog::Log(LOGDEBUG, "%s: Cleaning movie table", __FUNCTION__);
       sql = "DELETE FROM movie WHERE idMovie IN " + moviesToDelete;
-      m_pDS->exec(sql.c_str());
+      m_pDS->exec(sql);
     }
 
     if (!episodeIDs.empty())
@@ -7842,7 +7842,7 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const st
 
       CLog::Log(LOGDEBUG, "%s: Cleaning episode table", __FUNCTION__);
       sql = "DELETE FROM episode WHERE idEpisode IN " + episodesToDelete;
-      m_pDS->exec(sql.c_str());
+      m_pDS->exec(sql);
     }
 
     CLog::Log(LOGDEBUG, "%s: Cleaning paths that don't exist and have content set...", __FUNCTION__);
@@ -7851,7 +7851,7 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const st
                    "AND (strSettings IS NULL OR strSettings = '') "
                    "AND (strHash IS NULL OR strHash = '') "
                    "AND (exclude IS NULL OR exclude != 1))";
-    m_pDS->query(sql.c_str());
+    m_pDS->query(sql);
     std::string strIds;
     while (!m_pDS->eof())
     {
@@ -7871,16 +7871,16 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const st
     if (!strIds.empty())
     {
       sql = PrepareSQL("DELETE FROM path WHERE idPath IN (%s)", StringUtils::TrimRight(strIds, ",").c_str());
-      m_pDS->exec(sql.c_str());
+      m_pDS->exec(sql);
       sql = "DELETE FROM tvshowlinkpath WHERE NOT EXISTS (SELECT 1 FROM path WHERE path.idPath = tvshowlinkpath.idPath)";
-      m_pDS->exec(sql.c_str());
+      m_pDS->exec(sql);
     }
 
     CLog::Log(LOGDEBUG, "%s: Cleaning tvshow table", __FUNCTION__);
 
     std::string tvshowsToDelete;
     sql = "SELECT idShow FROM tvshow WHERE NOT EXISTS (SELECT 1 FROM tvshowlinkpath WHERE tvshowlinkpath.idShow = tvshow.idShow)";
-    m_pDS->query(sql.c_str());
+    m_pDS->query(sql);
     while (!m_pDS->eof())
     {
       tvshowIDs.push_back(m_pDS->fv(0).get_asInt());
@@ -7891,7 +7891,7 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const st
     if (!tvshowsToDelete.empty())
     {
       sql = "DELETE FROM tvshow WHERE idShow IN (" + StringUtils::TrimRight(tvshowsToDelete, ",") + ")";
-      m_pDS->exec(sql.c_str());
+      m_pDS->exec(sql);
     }
 
     if (!musicVideoIDs.empty())
@@ -7903,7 +7903,7 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const st
 
       CLog::Log(LOGDEBUG, "%s: Cleaning musicvideo table", __FUNCTION__);
       sql = "DELETE FROM musicvideo WHERE idMVideo IN " + musicVideosToDelete;
-      m_pDS->exec(sql.c_str());
+      m_pDS->exec(sql);
     }
 
     CLog::Log(LOGDEBUG, "%s: Cleaning path table", __FUNCTION__);
@@ -7919,32 +7919,32 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const st
                                   "AND NOT EXISTS (SELECT 1 FROM episode WHERE episode.c%02d = path.idPath) "
                                   "AND NOT EXISTS (SELECT 1 FROM musicvideo WHERE musicvideo.c%02d = path.idPath)"
                 , VIDEODB_ID_PARENTPATHID, VIDEODB_ID_EPISODE_PARENTPATHID, VIDEODB_ID_MUSICVIDEO_PARENTPATHID );
-    m_pDS->exec(sql.c_str());
+    m_pDS->exec(sql);
 
     CLog::Log(LOGDEBUG, "%s: Cleaning genre table", __FUNCTION__);
     sql = "DELETE FROM genre "
             "WHERE NOT EXISTS (SELECT 1 FROM genre_link WHERE genre_link.genre_id = genre.genre_id)";
-    m_pDS->exec(sql.c_str());
+    m_pDS->exec(sql);
 
     CLog::Log(LOGDEBUG, "%s: Cleaning country table", __FUNCTION__);
     sql = "DELETE FROM country WHERE NOT EXISTS (SELECT 1 FROM country_link WHERE country_link.country_id = country.country_id)";
-    m_pDS->exec(sql.c_str());
+    m_pDS->exec(sql);
 
     CLog::Log(LOGDEBUG, "%s: Cleaning actor table of actors, directors and writers", __FUNCTION__);
     sql = "DELETE FROM actor "
             "WHERE NOT EXISTS (SELECT 1 FROM actor_link WHERE actor_link.actor_id = actor.actor_id) "
               "AND NOT EXISTS (SELECT 1 FROM director_link WHERE director_link.actor_id = actor.actor_id) "
               "AND NOT EXISTS (SELECT 1 FROM writer_link WHERE writer_link.actor_id = actor.actor_id)";
-    m_pDS->exec(sql.c_str());
+    m_pDS->exec(sql);
 
     CLog::Log(LOGDEBUG, "%s: Cleaning studio table", __FUNCTION__);
     sql = "DELETE FROM studio "
             "WHERE NOT EXISTS (SELECT 1 FROM studio_link WHERE studio_link.studio_id = studio.studio_id)";
-    m_pDS->exec(sql.c_str());
+    m_pDS->exec(sql);
 
     CLog::Log(LOGDEBUG, "%s: Cleaning set table", __FUNCTION__);
     sql = "DELETE FROM sets WHERE NOT EXISTS (SELECT 1 FROM movie WHERE movie.idSet = sets.idSet)";
-    m_pDS->exec(sql.c_str());
+    m_pDS->exec(sql);
 
     CommitTransaction();
 
@@ -8031,7 +8031,7 @@ std::vector<int> CVideoDatabase::CleanMediaType(const std::string &mediaType, co
 
   // map of parent path ID to boolean pair (if not exists and user choice)
   std::map<int, std::pair<bool, bool> > sourcePathsDeleteDecisions;
-  m_pDS2->query(sql.c_str());
+  m_pDS2->query(sql);
   while (!m_pDS2->eof())
   {
     bool del = true;
@@ -8193,7 +8193,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFiles /* = 
     // find all movies
     std::string sql = "select * from movie_view";
 
-    m_pDS->query(sql.c_str());
+    m_pDS->query(sql);
 
     if (progress)
     {
@@ -8318,7 +8318,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFiles /* = 
     // find all musicvideos
     sql = "select * from musicvideo_view";
 
-    m_pDS->query(sql.c_str());
+    m_pDS->query(sql);
 
     total = m_pDS->num_rows();
     current = 0;
@@ -8404,7 +8404,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFiles /* = 
 
     // repeat for all tvshows
     sql = "SELECT * FROM tvshow_view";
-    m_pDS->query(sql.c_str());
+    m_pDS->query(sql);
 
     total = m_pDS->num_rows();
     current = 0;
@@ -8515,7 +8515,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFiles /* = 
 
       // now save the episodes from this show
       sql = PrepareSQL("select * from episode_view where idShow=%i order by strFileName, idEpisode",tvshow.m_iDbId);
-      pDS->query(sql.c_str());
+      pDS->query(sql);
       std::string showDir(item.GetPath());
 
       while (!pDS->eof())
@@ -8992,7 +8992,7 @@ bool CVideoDatabase::SetSingleValue(const std::string &table, const std::string 
     sql = PrepareSQL("UPDATE %s SET %s='%s'", table.c_str(), fieldName.c_str(), strValue.c_str());
     if (!conditionName.empty())
       sql += PrepareSQL(" WHERE %s=%u", conditionName.c_str(), conditionValue);
-    if (m_pDS->exec(sql.c_str()) == 0)
+    if (m_pDS->exec(sql) == 0)
       return true;
   }
   catch (...)
@@ -9340,7 +9340,7 @@ bool CVideoDatabase::SetVideoUserRating(int dbId, int rating, const MediaType& m
     else if (mediaType == MediaTypeTvShow)
       sql = PrepareSQL("UPDATE tvshow SET userrating=%i WHERE idShow = %i", rating, dbId);
 
-    m_pDS->exec(sql.c_str());
+    m_pDS->exec(sql);
     return true;
   }
   catch (...)

--- a/xbmc/view/ViewDatabase.cpp
+++ b/xbmc/view/ViewDatabase.cpp
@@ -89,7 +89,7 @@ void CViewDatabase::UpdateTables(int version)
       m_pDS->close();
 
       for (std::vector< std::pair<int, std::string> >::const_iterator it = paths.begin(); it != paths.end(); ++it)
-        m_pDS->exec(PrepareSQL("UPDATE view SET path='%s' WHERE idView=%d", it->second.c_str(), it->first).c_str());
+        m_pDS->exec(PrepareSQL("UPDATE view SET path='%s' WHERE idView=%d", it->second.c_str(), it->first));
     }
   }
   if (version < 6)
@@ -140,7 +140,7 @@ bool CViewDatabase::GetViewState(const std::string &path, int window, CViewState
       sql = PrepareSQL("select * from view where window = %i and path='%s'", window, path1.c_str());
     else
       sql = PrepareSQL("select * from view where window = %i and path='%s' and skin='%s'", window, path1.c_str(), skin.c_str());
-    m_pDS->query(sql.c_str());
+    m_pDS->query(sql);
 
     if (!m_pDS->eof())
     { // have some information
@@ -172,21 +172,21 @@ bool CViewDatabase::SetViewState(const std::string &path, int window, const CVie
     if (path1.empty()) path1 = "root://";
 
     std::string sql = PrepareSQL("select idView from view where window = %i and path='%s' and skin='%s'", window, path1.c_str(), skin.c_str());
-    m_pDS->query(sql.c_str());
+    m_pDS->query(sql);
     if (!m_pDS->eof())
     { // update the view
       int idView = m_pDS->fv("idView").get_asInt();
       m_pDS->close();
       sql = PrepareSQL("update view set viewMode=%i,sortMethod=%i,sortOrder=%i,sortAttributes=%i where idView=%i",
         state.m_viewMode, (int)state.m_sortDescription.sortBy, (int)state.m_sortDescription.sortOrder, (int)state.m_sortDescription.sortAttributes, idView);
-      m_pDS->exec(sql.c_str());
+      m_pDS->exec(sql);
     }
     else
     { // add the view
       m_pDS->close();
       sql = PrepareSQL("insert into view (idView, path, window, viewMode, sortMethod, sortOrder, sortAttributes, skin) values(NULL, '%s', %i, %i, %i, %i, %i, '%s')",
         path1.c_str(), window, state.m_viewMode, (int)state.m_sortDescription.sortBy, (int)state.m_sortDescription.sortOrder, (int)state.m_sortDescription.sortAttributes, skin.c_str());
-      m_pDS->exec(sql.c_str());
+      m_pDS->exec(sql);
     }
   }
   catch (...)
@@ -204,7 +204,7 @@ bool CViewDatabase::ClearViewStates(int windowID)
     if (NULL == m_pDS.get()) return false;
 
     std::string sql = PrepareSQL("delete from view where window = %i", windowID);
-    m_pDS->exec(sql.c_str());
+    m_pDS->exec(sql);
   }
   catch (...)
   {


### PR DESCRIPTION
Remove .c_str() when calling exec and query as they take a const std::string&
