### PR TITLE
[xbmc] Change formatting to cppformat instead of sprintf/snprintf style form…

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -29,6 +29,7 @@ DVDPLAYER_ARCHIVES=xbmc/cores/dvdplayer/DVDPlayer.a \
 DIRECTORY_ARCHIVES=$(DVDPLAYER_ARCHIVES) \
                    xbmc/addons/addons.a \
                    xbmc/cdrip/cdrip.a \
+                   xbmc/contrib/cppformat/cppformat.a \
                    xbmc/contrib/kissfft/kissfft.a \
                    xbmc/cores/AudioEngine/audioengine.a \
                    xbmc/cores/DllLoader/dllloader.a \

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -699,7 +699,7 @@ msgstr ""
 
 #: xbmc/settings/windows/GUIWindowSettingsCategory.cpp
 msgctxt "#168"
-msgid "%s- %s"
+msgid "{0:s}- {1:s}"
 msgstr ""
 
 #: system/settings/settings.xml
@@ -746,13 +746,13 @@ msgstr ""
 #. <application name> successfully started
 #: xbmc/Application.cpp
 msgctxt "#177"
-msgid "%s successfully started"
+msgid "{0:s} successfully started"
 msgstr ""
 
 #. <application name> has been successfully started.
 #: xbmc/Application.cpp
 msgctxt "#178"
-msgid "%s has been successfully started."
+msgid "{0:s} has been successfully started."
 msgstr ""
 
 #: xbmc/media/MediaTypes.cpp
@@ -845,7 +845,7 @@ msgid "Select movie:"
 msgstr ""
 
 msgctxt "#197"
-msgid "Querying %s information"
+msgid "Querying {0:s} information"
 msgstr ""
 
 msgctxt "#198"
@@ -1059,7 +1059,7 @@ msgid "Display mode"
 msgstr ""
 
 msgctxt "#241"
-msgid "Full screen #%d"
+msgid "Full screen #{0:d}"
 msgstr ""
 
 msgctxt "#242"
@@ -1076,7 +1076,7 @@ msgid "Full screen"
 msgstr ""
 
 msgctxt "#245"
-msgid "Sizing: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1) (VShift: %2.2f)"
+msgid "Sizing: ({0:d},{1:d})->({2:d},{3:d}) (Zoom x{4:2.2f}) AR:{5:2.2f}:1 (Pixels: {6:2.2f}:1) (VShift: {7:2.2f})"
 msgstr ""
 
 msgctxt "#246"
@@ -1238,7 +1238,7 @@ msgid "Please check the XML files"
 msgstr ""
 
 msgctxt "#282"
-msgid "Found %i items"
+msgid "Found {0:d} items"
 msgstr ""
 
 #: xbmc/filesystem/AddonsDirectory.cpp
@@ -1314,7 +1314,7 @@ msgid "Bookmarks"
 msgstr ""
 
 msgctxt "#299"
-msgid "Bookmark %i"
+msgid "Bookmark {0:d}"
 msgstr ""
 
 msgctxt "#300"
@@ -1369,7 +1369,7 @@ msgstr ""
 #. Keyboard layout name e.g. "English QWERTY"
 #: xbmc/input/KeyboardLayout.cpp
 msgctxt "#311"
-msgid "%s %s"
+msgid "{0:s} {1:s}"
 msgstr ""
 
 msgctxt "#312"
@@ -1923,12 +1923,12 @@ msgid "Remove movie from library"
 msgstr ""
 
 msgctxt "#433"
-msgid "Would you really like to remove '%s' from library?"
+msgid "Would you really like to remove '{0:s}' from library?"
 msgstr ""
 
 #. From <wind dir.> at <speed> <unit>
 msgctxt "#434"
-msgid "From %s at %i %s"
+msgid "From {0:s} at {1:d} {2:s}"
 msgstr ""
 
 #: xbmc/Application.cpp
@@ -2323,7 +2323,7 @@ msgid "Enter genre"
 msgstr ""
 
 msgctxt "#534"
-msgid "View: %s"
+msgid "View: {0:s}"
 msgstr ""
 
 msgctxt "#535"
@@ -2393,7 +2393,7 @@ msgstr ""
 
 #: xbmc/windows/GUIMediaWindow.cpp
 msgctxt "#550"
-msgid "Sort by: %s"
+msgid "Sort by: {0:s}"
 msgstr ""
 
 #: xbmc/view/GUIViewState.cpp
@@ -3244,7 +3244,7 @@ msgstr ""
 #strings 768 and 769 reserved for more subtitle colours
 
 msgctxt "#770"
-msgid "Error %i: share not available"
+msgid "Error {0:d}: share not available"
 msgstr ""
 
 #empty string with id 771
@@ -3391,7 +3391,7 @@ msgstr ""
 #. Label of progess bar which shows the available/total space of pvr backend
 #: xbmc/pvr/PVRGUIInfo.cpp
 msgctxt "#802"
-msgid "%s of %s available"
+msgid "{0:s} of {1:s} available"
 msgstr ""
 
 #. Label of list control for choosing the timer type (one time, repeating, ...) in PVR timer settings dialog
@@ -3755,7 +3755,7 @@ msgstr ""
 
 #: xbmc/dialogs/GUIDialogMediaSource.cpp
 msgctxt "#1020"
-msgid "Add %s source"
+msgid "Add {0:s} source"
 msgstr ""
 
 #: xbmc/dialogs/GUIDialogMediaSource.cpp
@@ -3796,7 +3796,7 @@ msgstr ""
 
 #: xbmc/dialogs/GUIDialogMediaSource.cpp
 msgctxt "#1028"
-msgid "Edit %s source"
+msgid "Edit {0:s} source"
 msgstr ""
 
 msgctxt "#1029"
@@ -3856,11 +3856,11 @@ msgid "Loading directory"
 msgstr ""
 
 msgctxt "#1041"
-msgid "Retrieved %i items"
+msgid "Retrieved {0:d} items"
 msgstr ""
 
 msgctxt "#1042"
-msgid "Retrieved %i of %i items"
+msgid "Retrieved {0:d} of {1:d} items"
 msgstr ""
 
 #: xbmc/addons/Addon.cpp
@@ -4123,7 +4123,7 @@ msgstr ""
 #. Filter movies/tvshows/music/episodes/artists/musicvideos/albums/songs
 #: xbmc/dialogs/GUIDialogMediaFilter.cpp
 msgctxt "#1275"
-msgid "Filter %s"
+msgid "Filter {0:s}"
 msgstr ""
 
 #empty strings from id 1276 to 1299
@@ -4549,7 +4549,7 @@ msgstr ""
 #. Notification message indicating an add-on error. "<Add-on name> error".
 #: xbmc/interfaces/python/PythonInvoker.cpp
 msgctxt "#2102"
-msgid "%s error"
+msgid "{0:s} error"
 msgstr ""
 
 #. Fallback message indicating an add-on error.
@@ -5018,7 +5018,7 @@ msgstr ""
 #: xbmc\pvr\windows\GUIWindowPVRRecordings.cpp
 #: xbmc\video\windows\GUIWindowVideoBase.cpp
 msgctxt "#12022"
-msgid "Resume from %s"
+msgid "Resume from {0:s}"
 msgstr ""
 
 #empty strings from id 12023 to 12309
@@ -5307,7 +5307,7 @@ msgstr ""
 #. time format with meridiem (xx) e.g. "HH:mm:ss xx"
 #: xbmc/LangInfo.cpp
 msgctxt "#12382"
-msgid "%s xx"
+msgid "{0:s} xx"
 msgstr ""
 
 #: system/settings/settings.xml
@@ -5534,7 +5534,7 @@ msgstr ""
 
 #: xbmc/network/WakeOnAccess.cpp
 msgctxt "#13027"
-msgid "Wake-on-LAN (%s)"
+msgid "Wake-on-LAN ({0:s})"
 msgstr ""
 
 #: xbmc/network/WakeOnAccess.cpp
@@ -5569,17 +5569,17 @@ msgstr ""
 
 #: xbmc/network/WakeOnAccess.cpp
 msgctxt "#13034"
-msgid "Updated for %s"
+msgid "Updated for {0:s}"
 msgstr ""
 
 #: xbmc/network/WakeOnAccess.cpp
 msgctxt "#13035"
-msgid "Found for %s"
+msgid "Found for {0:s}"
 msgstr ""
 
 #: xbmc/network/WakeOnAccess.cpp
 msgctxt "#13036"
-msgid "Failed for %s"
+msgid "Failed for {0:s}"
 msgstr ""
 
 #empty strings from id 13037 to 13049
@@ -5763,7 +5763,7 @@ msgstr ""
 
 #: unknown
 msgctxt "#13172"
-msgid "After %i secs"
+msgid "After {0:d} secs"
 msgstr ""
 
 #: unknown
@@ -5788,7 +5788,7 @@ msgstr ""
 
 #: xbmc\profiles\ProfilesManager.cpp
 msgctxt "#13201"
-msgid "Delete profile '%s'?"
+msgid "Delete profile '{0:s}'?"
 msgstr ""
 
 #empty strings from id 13202 to 13203
@@ -5825,7 +5825,7 @@ msgid "Alarm clock interval (in minutes)"
 msgstr ""
 
 msgctxt "#13210"
-msgid "Started, alarm in %im"
+msgid "Started, alarm in {0:d}m"
 msgstr ""
 
 msgctxt "#13211"
@@ -5833,17 +5833,17 @@ msgid "Alarm!"
 msgstr ""
 
 msgctxt "#13212"
-msgid "Cancelled with %im%is left"
+msgid "Cancelled with {0:d}m{1:d}s left"
 msgstr ""
 
 #. minutes (left from countdown)
 msgctxt "#13213"
-msgid "%2.0fm"
+msgid "{0:2.0f}m"
 msgstr ""
 
 #. seconds (left from countdown)
 msgctxt "#13214"
-msgid "%2.0fs"
+msgid "{0:2.0f}s"
 msgstr ""
 
 #empty strings from id 13215 to 13248
@@ -6087,15 +6087,15 @@ msgid "Karaoke"
 msgstr ""
 
 msgctxt "#13328"
-msgid "%s not found"
+msgid "{0:s} not found"
 msgstr ""
 
 msgctxt "#13329"
-msgid "Error opening %s"
+msgid "Error opening {0:s}"
 msgstr ""
 
 msgctxt "#13330"
-msgid "Unable to load %s"
+msgid "Unable to load {0:s}"
 msgstr ""
 
 msgctxt "#13331"
@@ -6338,7 +6338,7 @@ msgstr ""
 #: xbmc/dialogs/GUIDialogMediaFilter.cpp
 #: xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
 msgctxt "#13401"
-msgid "Browse for %s"
+msgid "Browse for {0:s}"
 msgstr ""
 
 msgctxt "#13402"
@@ -6364,7 +6364,7 @@ msgid "Picture information"
 msgstr ""
 
 msgctxt "#13407"
-msgid "%s presets"
+msgid "{0:s} presets"
 msgstr ""
 
 msgctxt "#13408"
@@ -6681,19 +6681,19 @@ msgid "Off"
 msgstr ""
 
 msgctxt "#13552"
-msgid "%.1f second"
+msgid "{0:.1f} second"
 msgstr ""
 
 msgctxt "#13553"
-msgid "%.1f seconds"
+msgid "{0:.1f} seconds"
 msgstr ""
 
 msgctxt "#13554"
-msgid "%d Minute"
+msgid "{0:d} Minute"
 msgstr ""
 
 msgctxt "#13555"
-msgid "%d Minutes"
+msgid "{0:d} Minutes"
 msgstr ""
 
 #. Label of a setting that allows to select the skip step sizes to use for skipping
@@ -6947,39 +6947,39 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#14044"
-msgid "%i min"
+msgid "{0:d} min"
 msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#14045"
-msgid "%i sec"
+msgid "{0:d} sec"
 msgstr ""
 
 #: system/settings/darwin.xml
 #: system/settings/settings.xml
 msgctxt "#14046"
-msgid "%i ms"
+msgid "{0:d} ms"
 msgstr ""
 
 #: system/settings/settings.xml
 #: xbmc/video/dialogs/GUIDialogVideoSettings.cpp
 msgctxt "#14047"
-msgid "%i %%"
+msgid "{0:d} %"
 msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#14048"
-msgid "%i kbps"
+msgid "{0:d} kbps"
 msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#14049"
-msgid "%i kb"
+msgid "{0:d} kb"
 msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#14050"
-msgid "%i.0 dB"
+msgid "{0:d}.0 dB"
 msgstr ""
 
 msgctxt "#14051"
@@ -6996,7 +6996,7 @@ msgstr ""
 
 #: xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
 msgctxt "#14054"
-msgid "%2.1f dB"
+msgid "{0:2.1f} dB"
 msgstr ""
 
 msgctxt "#14055"
@@ -7310,7 +7310,7 @@ msgstr ""
 #. Label to show the currently active/displayed event level in the event log window
 #: xbmc/event/windows/GUIWindowEventLog.cpp
 msgctxt "#14119"
-msgid "Level: %s"
+msgid "Level: {0:s}"
 msgstr ""
 
 #. Label for the option to show/hide higher level events in the event log window
@@ -7374,7 +7374,7 @@ msgstr ""
 #: xbmc/music/MusicDatabase.cpp
 #: xbmc/video/VideoDatabase.cpp
 msgctxt "#15011"
-msgid "%i Items failed to export"
+msgid "{0:d} Items failed to export"
 msgstr ""
 
 #: xbmc/video/VideoDatabase.cpp
@@ -7384,7 +7384,7 @@ msgstr ""
 
 #: xbmc/video/VideoDatabase.cpp
 msgctxt "#15013"
-msgid "What would you like to do with media items from %s"
+msgid "What would you like to do with media items from {0:s}"
 msgstr ""
 
 #: xbmc/video/VideoDatabase.cpp
@@ -7645,13 +7645,13 @@ msgstr ""
 #. Audio DSP process chain indication
 #: xbmc/settings/dialogs/GUIDialogAudioDSPSettings.cpp
 msgctxt "#15082"
-msgid "Resampling to %i Hz"
+msgid "Resampling to {0:d} Hz"
 msgstr ""
 
 #. Audio DSP process chain indication
 #: xbmc/settings/dialogs/GUIDialogAudioDSPSettings.cpp
 msgctxt "#15083"
-msgid "Final resampling to %i Hz"
+msgid "Final resampling to {0:d} Hz"
 msgstr ""
 
 #. Audio DSP process chain indication
@@ -8339,17 +8339,17 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#17997"
-msgid "%i MByte"
+msgid "{0:d} MByte"
 msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#17998"
-msgid "%i hours"
+msgid "{0:d} hours"
 msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#17999"
-msgid "%i days"
+msgid "{0:d} days"
 msgstr ""
 
 #empty strings from id 18000 to 18999
@@ -8440,7 +8440,7 @@ msgstr ""
 
 #: unused
 msgctxt "#19016"
-msgid "PVR backend %i - %s"
+msgid "PVR backend {0:d} - {1:s}"
 msgstr ""
 
 #: xbmc/dialogs/GUIDialogMediaSource.cpp
@@ -8544,7 +8544,7 @@ msgid "Already started recording on this channel"
 msgstr ""
 
 msgctxt "#19035"
-msgid "%s couldn't be played. Check the log for more information about this message."
+msgid "{0:s} couldn't be played. Check the log for more information about this message."
 msgstr ""
 
 #: xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -8777,7 +8777,7 @@ msgid "First day"
 msgstr ""
 
 msgctxt "#19085"
-msgid "Unknown channel %u"
+msgid "Unknown channel {0:d}"
 msgstr ""
 
 msgctxt "#19086"
@@ -9281,12 +9281,12 @@ msgstr ""
 
 #: xbmc/addons/addoncallbackspvr.cpp
 msgctxt "#19197"
-msgid "Recording started on: %s"
+msgid "Recording started on: {0:s}"
 msgstr ""
 
 #: xbmc/addons/addoncallbackspvr.cpp
 msgctxt "#19198"
-msgid "Recording finished on: %s"
+msgid "Recording finished on: {0:s}"
 msgstr ""
 
 #: system/settings/settings.xml
@@ -10221,7 +10221,7 @@ msgstr ""
 
 #: xbmc/pvr/addons/PVRClients.cpp
 msgctxt "#19689"
-msgid "%s service found at %s"
+msgid "{0:s} service found at {1:s}"
 msgstr ""
 
 #: xbmc/pvr/addons/PVRClient.cpp
@@ -10232,25 +10232,25 @@ msgstr ""
 #. Text for shutdown confirmation dialog.
 #: xbmc/pvr/PVRManager.cpp
 msgctxt "#19691"
-msgid "PVR is currently recording '%s' on channel '%s'."
+msgid "PVR is currently recording '{0:s}' on channel '{1:s}'."
 msgstr ""
 
 #. Text for shutdown confirmation dialog
 #: xbmc/pvr/PVRManager.cpp
 msgctxt "#19692"
-msgid "PVR will start recording '%s' on channel '%s' in %s."
+msgid "PVR will start recording '{0:s}' on channel '{1:s}' in {2:s}."
 msgstr ""
 
 #. Text for shutdown confirmation dialog
 #: xbmc/pvr/PVRManager.cpp
 msgctxt "#19693"
-msgid "Daily wakeup is due in %s."
+msgid "Daily wakeup is due in {0:s}."
 msgstr ""
 
 #. Text for shutdown confirmation dialog
 #: xbmc/pvr/PVRManager.cpp
 msgctxt "#19694"
-msgid "%d minutes"
+msgid "{0:d} minutes"
 msgstr ""
 
 #. Text for shutdown confirmation dialog
@@ -10386,13 +10386,13 @@ msgstr ""
 
 #: xbmc/LangInfo.cpp
 msgctxt "#20035"
-msgid "Regional (%s)"
+msgid "Regional ({0:s})"
 msgstr ""
 
 #. Used for date/time format settings like "10:00:00 (HH:mm:ss)"
 #: xbmc/LangInfo.cpp
 msgctxt "#20036"
-msgid "%s (%s)"
+msgid "{0:s} ({1:s})"
 msgstr ""
 
 msgctxt "#20037"
@@ -10436,7 +10436,7 @@ msgid "Leave master mode"
 msgstr ""
 
 msgctxt "#20047"
-msgid "Create profile '%s'?"
+msgid "Create profile '{0:s}'?"
 msgstr ""
 
 #: xbmc/profiles/dialogs/GUIDialogProfileSettings.cpp
@@ -10704,7 +10704,7 @@ msgstr ""
 
 #: xbmc/windows/GUIWindowLoginScreen.cpp
 msgctxt "#20112"
-msgid "Last login: %s"
+msgid "Last login: {0:s}"
 msgstr ""
 
 #: xbmc/windows/GUIWindowLoginScreen.cpp
@@ -10714,7 +10714,7 @@ msgstr ""
 
 #: xbmc/windows/GUIWindowLoginScreen.cpp
 msgctxt "#20114"
-msgid "Profile %i / %i"
+msgid "Profile {0:d} / {1:d}"
 msgstr ""
 
 #: xbmc/windows/GUIWindowLoginScreen.cpp
@@ -10819,7 +10819,7 @@ msgid "Unable to mount memory unit"
 msgstr ""
 
 msgctxt "#20139"
-msgid "In port %i, slot %i"
+msgid "In port {0:d}, slot {1:d}"
 msgstr ""
 
 msgctxt "#20140"
@@ -10848,7 +10848,7 @@ msgid "Shutdown interval (in minutes)"
 msgstr ""
 
 msgctxt "#20146"
-msgid "Started, shutdown in %im"
+msgid "Started, shutdown in {0:d}m"
 msgstr ""
 
 msgctxt "#20147"
@@ -10872,7 +10872,7 @@ msgid "Cancel shutdown timer"
 msgstr ""
 
 msgctxt "#20152"
-msgid "Lock preferences for %s"
+msgid "Lock preferences for {0:s}"
 msgstr ""
 
 #: xbmc/dialogs/GUIDialogFileBrowser.cpp
@@ -11230,23 +11230,23 @@ msgid "Sort by: ID"
 msgstr ""
 
 msgctxt "#20317"
-msgid "Scanning movies using %s"
+msgid "Scanning movies using {0:s}"
 msgstr ""
 
 msgctxt "#20318"
-msgid "Scanning music videos using %s"
+msgid "Scanning music videos using {0:s}"
 msgstr ""
 
 msgctxt "#20319"
-msgid "Scanning TV shows using %s"
+msgid "Scanning TV shows using {0:s}"
 msgstr ""
 
 msgctxt "#20320"
-msgid "Scanning artists using %s"
+msgid "Scanning artists using {0:s}"
 msgstr ""
 
 msgctxt "#20321"
-msgid "Scanning albums using %s"
+msgid "Scanning albums using {0:s}"
 msgstr ""
 
 #empty string with id 20322
@@ -11265,7 +11265,7 @@ msgid "Calibration reset"
 msgstr ""
 
 msgctxt "#20326"
-msgid "This will reset the calibration values for %s"
+msgid "This will reset the calibration values for {0:s}"
 msgstr ""
 
 msgctxt "#20327"
@@ -11417,7 +11417,7 @@ msgstr ""
 
 #: xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeSeasons.cpp
 msgctxt "#20358"
-msgid "Season %i"
+msgid "Season {0:d}"
 msgstr ""
 
 #: xbmc/media/MediaTypes.cpp
@@ -11892,11 +11892,11 @@ msgid "Tags"
 msgstr ""
 
 msgctxt "#20460"
-msgid "Add %s"
+msgid "Add {0:s}"
 msgstr ""
 
 msgctxt "#20461"
-msgid "Remove %s"
+msgid "Remove {0:s}"
 msgstr ""
 
 msgctxt "#20462"
@@ -11904,11 +11904,11 @@ msgid "New tag..."
 msgstr ""
 
 msgctxt "#20463"
-msgid "A tag with the name '%s' already exists."
+msgid "A tag with the name '{0:s}' already exists."
 msgstr ""
 
 msgctxt "#20464"
-msgid "Select %s"
+msgid "Select {0:s}"
 msgstr ""
 
 msgctxt "#20465"
@@ -11920,7 +11920,7 @@ msgid "Select movie set"
 msgstr ""
 
 msgctxt "#20467"
-msgid "No set (remove from %s)"
+msgid "No set (remove from {0:s})"
 msgstr ""
 
 msgctxt "#20468"
@@ -11928,7 +11928,7 @@ msgid "Add movie to a new set"
 msgstr ""
 
 msgctxt "#20469"
-msgid "Keep current set (%s)"
+msgid "Keep current set ({0:s})"
 msgstr ""
 
 #: system/settings/settings.xml
@@ -11971,7 +11971,7 @@ msgstr ""
 
 #: xbmc/peripherals/devices/peripheralcecadapter.cpp
 msgctxt "#21336"
-msgid "Connecting to: %s"
+msgid "Connecting to: {0:s}"
 msgstr ""
 
 #. Used in the add-on browser under "Last updated" when a repository has never been updated
@@ -11987,7 +11987,7 @@ msgstr ""
 
 #: xbmc/addons/GUIDialogAddonInfo.cpp
 msgctxt "#21339"
-msgid "Version %s"
+msgid "Version {0:s}"
 msgstr ""
 
 #empty strings from id 21340 to 21358
@@ -12336,7 +12336,7 @@ msgstr ""
 
 #: xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
 msgctxt "#21436"
-msgid "%i items"
+msgid "{0:d} items"
 msgstr ""
 
 msgctxt "#21437"
@@ -12344,7 +12344,7 @@ msgid "New smart playlist..."
 msgstr ""
 
 msgctxt "#21438"
-msgid "%c Drive"
+msgid "{0:c} Drive"
 msgstr ""
 
 msgctxt "#21439"
@@ -12482,26 +12482,26 @@ msgstr ""
 #. Filter (media data) from float value to float value
 #: xbmc/dialogs/GUIDialogMediaFilter.cpp
 msgctxt "#21467"
-msgid "%.1f to %.1f"
+msgid "{0:.1f} to {1:.1f}"
 msgstr ""
 
 #. Filter (media data) from int value to int value
 #: xbmc/dialogs/GUIDialogMediaFilter.cpp
 msgctxt "#21468"
-msgid "%d to %d"
+msgid "{0:d} to {1:d}"
 msgstr ""
 
 #. Filter (media data) from string value to string value
 #: xbmc/dialogs/GUIDialogMediaFilter.cpp
 #: xbmc/settings/SettingControl.cpp
 msgctxt "#21469"
-msgid "%s to %s"
+msgid "{0:s} to {1:s}"
 msgstr ""
 
 #. Field (e.g. "Genre") [count]
 #: xbmc/dialogs/GUIDialogMediaFilter.cpp
 msgctxt "#21470"
-msgid "%s [%d]"
+msgid "{0:s} [{1:d}]"
 msgstr ""
 
 #. One of the values valid for "Videos -> Library -> Select first unwatched TV show season / episode" with label #21416
@@ -12919,15 +12919,15 @@ msgid "DNS suffix"
 msgstr ""
 
 msgctxt "#22003"
-msgid "%2.3fs"
+msgid "{0:2.3f}s"
 msgstr ""
 
 msgctxt "#22004"
-msgid "Delayed by: %2.3fs"
+msgid "Delayed by: {0:2.3f}s"
 msgstr ""
 
 msgctxt "#22005"
-msgid "Ahead by: %2.3fs"
+msgid "Ahead by: {0:2.3f}s"
 msgstr ""
 
 msgctxt "#22006"
@@ -13117,11 +13117,11 @@ msgid "Activate teletext"
 msgstr ""
 
 msgctxt "#23051"
-msgid "Part %i"
+msgid "Part {0:d}"
 msgstr ""
 
 msgctxt "#23052"
-msgid "Buffering %i bytes"
+msgid "Buffering {0:d} bytes"
 msgstr ""
 
 msgctxt "#23053"
@@ -13364,7 +13364,7 @@ msgstr ""
 
 #: xbmc/addons/GUIViewStateAddonBrowser.cpp
 msgctxt "#24042"
-msgid "Downloading %i%%"
+msgid "Downloading {0:d}%"
 msgstr ""
 
 #: xbmc/addons/GUIViewStateAddonBrowser.cpp
@@ -13387,7 +13387,7 @@ msgstr ""
 
 #: xbmc/addons/GUIDialogAddonInfo.cpp
 msgctxt "#24046"
-msgid "%s is used by the following installed add-on(s)"
+msgid "{0:s} is used by the following installed add-on(s)"
 msgstr ""
 
 #: xbmc\addons\GUIDialogAddonInfo.cpp
@@ -13441,13 +13441,13 @@ msgstr ""
 #. Used in the Add-on Manager to specify last update time
 #: xbmc/addons/GUIViewStateAddonBrowser.cpp
 msgctxt "#24056"
-msgid "Last updated %s"
+msgid "Last updated {0:s}"
 msgstr ""
 
 #. Used as a title in the progress dialog when installing an add-on
 #: xbmc/addons/AddonInstaller.cpp
 msgctxt "#24057"
-msgid "Installing %s..."
+msgid "Installing {0:s}..."
 msgstr ""
 
 #. Used as a text in the progress dialog when installing an add-on
@@ -13630,10 +13630,10 @@ msgctxt "#24092"
 msgid "Checking for add-on updates"
 msgstr ""
 
-#. Used as a text in the progress dialog when checking for add-on updates. %s contains repository name
+#. Used as a text in the progress dialog when checking for add-on updates. {0:s} contains repository name
 #: xbmc/addons/Repository.cpp
 msgctxt "#24093"
-msgid "Checking %s..."
+msgid "Checking {0:s}..."
 msgstr ""
 
 #: xbmc/addons/guidialogaddoninfo.cpp
@@ -13709,7 +13709,7 @@ msgstr ""
 
 #: xbmc/dialogs/GUIDialogSubtitles.cpp
 msgctxt "#24108"
-msgid "%d subtitles found"
+msgid "{0:d} subtitles found"
 msgstr ""
 
 #: xbmc/dialogs/GUIDialogSubtitles.cpp
@@ -13893,13 +13893,13 @@ msgstr ""
 #. The dependency on <addon id> version <addon version> coult not be satisfied.
 #: xbmc/addons/AddonInstaller.cpp
 msgctxt "#24142"
-msgid "The dependency on %s version %s could not be satisfied."
+msgid "The dependency on {0:s} version {1:s} could not be satisfied."
 msgstr ""
 
 #. Installing the addon from zip file located at <path to zip file> failed due to an invalid structure.
 #: xbmc/addons/AddonInstaller.cpp
 msgctxt "#24143"
-msgid "Installing the Add-on from zip file located at %s failed due to an invalid structure."
+msgid "Installing the Add-on from zip file located at {0:s} failed due to an invalid structure."
 msgstr ""
 
 #. Used as an event log description for add-ons that have been uninstalled
@@ -13925,7 +13925,7 @@ msgstr ""
 #: xbmc/music/infoscanner/MusicInfoScanner.cpp
 #: xbmc/video/VideoInfoScanner.cpp
 msgctxt "#24147"
-msgid "Failed to scan %s: %s"
+msgid "Failed to scan {0:s}: {1:s}"
 msgstr ""
 
 #empty strings from id 24148 to 24990
@@ -14006,12 +14006,12 @@ msgstr ""
 
 #: xbmc/filesystem/BlurayDirectory.cpp
 msgctxt "#25004"
-msgid "Play main title: %d"
+msgid "Play main title: {0:d}"
 msgstr ""
 
 #: xbmc/filesystem/BlurayDirectory.cpp
 msgctxt "#25005"
-msgid "Title: %d"
+msgid "Title: {0:d}"
 msgstr ""
 
 #: xbmc\video\windows\GUIWindowVideoBase.cpp
@@ -14021,7 +14021,7 @@ msgstr ""
 
 #: xbmc/filesystem/BlurayDirectory.cpp
 msgctxt "#25007"
-msgid "Chapters: %u - duration: %s"
+msgid "Chapters: {0:d} - duration: {1:s}"
 msgstr ""
 
 #: xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -14036,7 +14036,7 @@ msgstr ""
 
 #: xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
 msgctxt "#25010"
-msgid "Chapter %u"
+msgid "Chapter {0:d}"
 msgstr ""
 
 #empty strings from id 25011 to 29800
@@ -14671,7 +14671,7 @@ msgid "Translate text"
 msgstr ""
 
 msgctxt "#33033"
-msgid "Map list %s category"
+msgid "Map list {0:s} category"
 msgstr ""
 
 msgctxt "#33034"
@@ -14691,19 +14691,19 @@ msgid "Weekend"
 msgstr ""
 
 msgctxt "#33038"
-msgid "%s day"
+msgid "{0:s} day"
 msgstr ""
 
 #. Used in the media source dialog. Will result in "SAP Streams"
 #: dialogs/GUIDialogMediaSource.cpp
 msgctxt "#33039"
-msgid "%s streams"
+msgid "{0:s} streams"
 msgstr ""
 
 #. Used in the media source dialog. Will result in "HDHomerun Devices"
 #: dialogs/GUIDialogMediaSource.cpp
 msgctxt "#33040"
-msgid "%s devices"
+msgid "{0:s} devices"
 msgstr ""
 
 #empty strings from id 33041 to 33048
@@ -15458,7 +15458,7 @@ msgstr ""
 
 #: xbmc/peripherals/devices/peripheralcecadapter.cpp
 msgctxt "#36040"
-msgid "Detected version of libCEC interface (%x) is lower than the supported version %x."
+msgid "Detected version of libCEC interface ({0:x}) is lower than the supported version {1:x}."
 msgstr ""
 
 #: xbmc/video/dialogs/guidialogvideoinfo.cpp
@@ -18096,10 +18096,10 @@ msgctxt "#38015"
 msgid "Unlimited"
 msgstr ""
 
-#. Used to format framerate values. %d will be replaced with the according number/integer, like "24 fps", "50 fps"
+#. Used to format framerate values. {0:d} will be replaced with the according number/integer, like "24 fps", "50 fps"
 #: system/settings/settings.xml
 msgctxt "#38016"
-msgid "%d fps"
+msgid "{0:d} fps"
 msgstr ""
 
 #. Description of setting #14111 Settings -> Video -> Discs -> Blu-ray region code

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -215,6 +215,8 @@
     <ClCompile Include="..\..\xbmc\CompileInfo.cpp" />
     <ClCompile Include="..\..\xbmc\ContextMenuItem.cpp" />
     <ClCompile Include="..\..\xbmc\ContextMenuManager.cpp" />
+    <ClCompile Include="..\..\xbmc\contrib\cppformat\format.cc" />
+    <ClCompile Include="..\..\xbmc\contrib\cppformat\posix.cc" />
     <ClCompile Include="..\..\xbmc\contrib\kissfft\kiss_fft.c">
       <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">CompileAsCpp</CompileAs>
       <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">CompileAsCpp</CompileAs>
@@ -902,6 +904,8 @@
     <ClInclude Include="..\..\xbmc\ApplicationPlayer.h" />
     <ClInclude Include="..\..\xbmc\AppParamParser.h" />
     <ClInclude Include="..\..\xbmc\CompileInfo.h" />
+    <ClInclude Include="..\..\xbmc\contrib\cppformat\format.h" />
+    <ClInclude Include="..\..\xbmc\contrib\cppformat\posix.h" />
     <ClInclude Include="..\..\xbmc\contrib\kissfft\kiss_fft.h" />
     <ClInclude Include="..\..\xbmc\contrib\kissfft\kiss_fftr.h" />
     <ClInclude Include="..\..\xbmc\contrib\kissfft\_kiss_fft_guts.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -370,6 +370,9 @@
     <Filter Include="interfaces\builtins">
       <UniqueIdentifier>{248ffbc4-43f5-4aaf-b259-2dd4f840fcef}</UniqueIdentifier>
     </Filter>
+    <Filter Include="contrib\cppformat">
+      <UniqueIdentifier>{d60b8d87-672a-4500-99fe-a66861305cb6}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\xbmc\win32\pch.cpp">
@@ -3257,6 +3260,12 @@
     </ClCompile>
     <ClCompile Include="..\..\xbmc\addons\AddonCallbacksAudioEngine.cpp">
       <Filter>addons</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\xbmc\contrib\cppformat\format.cc">
+      <Filter>contrib\cppformat</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\xbmc\contrib\cppformat\posix.cc">
+      <Filter>contrib\cppformat</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -6321,6 +6330,12 @@
     </ClInclude>
     <ClInclude Include="..\..\xbmc\utils\ScopeGuard.h">
       <Filter>utils</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\contrib\cppformat\format.h">
+      <Filter>contrib\cppformat</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\contrib\cppformat\posix.h">
+      <Filter>contrib\cppformat</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/xbmc/contrib/cppformat/LICENSE.rst
+++ b/xbmc/contrib/cppformat/LICENSE.rst
@@ -1,0 +1,23 @@
+Copyright (c) 2012 - 2015, Victor Zverovich
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/xbmc/contrib/cppformat/Makefile
+++ b/xbmc/contrib/cppformat/Makefile
@@ -1,0 +1,6 @@
+SRCS=posix.cc format.cc
+
+LIB=cppformat.a
+
+include ../../../Makefile.include
+-include $(patsubst %.cpp,%.P,$(patsubst %.c,%.P,$(SRCS)))

--- a/xbmc/contrib/cppformat/format.cc
+++ b/xbmc/contrib/cppformat/format.cc
@@ -1,0 +1,1324 @@
+/*
+ Formatting library for C++
+
+ Copyright (c) 2012 - 2015, Victor Zverovich
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "format.h"
+
+#include <string.h>
+
+#include <cctype>
+#include <cerrno>
+#include <climits>
+#include <cmath>
+#include <cstdarg>
+
+#if defined(_WIN32) && defined(__MINGW32__)
+# include <cstring>
+#endif
+
+#if FMT_USE_WINDOWS_H
+# if defined(NOMINMAX) || defined(FMT_WIN_MINMAX)
+#  include <windows.h>
+# else
+#  define NOMINMAX
+#  include <windows.h>
+#  undef NOMINMAX
+# endif
+#endif
+
+using fmt::internal::Arg;
+
+// Check if exceptions are disabled.
+#if __GNUC__ && !__EXCEPTIONS
+# define FMT_EXCEPTIONS 0
+#endif
+#if _MSC_VER && !_HAS_EXCEPTIONS
+# define FMT_EXCEPTIONS 0
+#endif
+#ifndef FMT_EXCEPTIONS
+# define FMT_EXCEPTIONS 1
+#endif
+
+#if FMT_EXCEPTIONS
+# define FMT_TRY try
+# define FMT_CATCH(x) catch (x)
+#else
+# define FMT_TRY if (true)
+# define FMT_CATCH(x) if (false)
+#endif
+
+#ifndef FMT_THROW
+# if FMT_EXCEPTIONS
+#  define FMT_THROW(x) throw x
+# else
+#  define FMT_THROW(x) assert(false)
+# endif
+#endif
+
+#ifdef FMT_HEADER_ONLY
+# define FMT_FUNC inline
+#else
+# define FMT_FUNC
+#endif
+
+#if _MSC_VER
+# pragma warning(push)
+# pragma warning(disable: 4127)  // conditional expression is constant
+# pragma warning(disable: 4702)  // unreachable code
+// Disable deprecation warning for strerror. The latter is not called but
+// MSVC fails to detect it.
+# pragma warning(disable: 4996)
+#endif
+
+// Dummy implementations of strerror_r and strerror_s called if corresponding
+// system functions are not available.
+static inline fmt::internal::Null<> strerror_r(int, char *, ...) {
+  return fmt::internal::Null<>();
+}
+static inline fmt::internal::Null<> strerror_s(char *, std::size_t, ...) {
+  return fmt::internal::Null<>();
+}
+
+namespace fmt {
+namespace {
+
+#ifndef _MSC_VER
+# define FMT_SNPRINTF snprintf
+#else  // _MSC_VER
+inline int fmt_snprintf(char *buffer, size_t size, const char *format, ...) {
+  va_list args;
+  va_start(args, format);
+  int result = vsnprintf_s(buffer, size, _TRUNCATE, format, args);
+  va_end(args);
+  return result;
+}
+# define FMT_SNPRINTF fmt_snprintf
+#endif  // _MSC_VER
+
+#if defined(_WIN32) && defined(__MINGW32__) && !defined(__NO_ISOCEXT)
+# define FMT_SWPRINTF snwprintf
+#else
+# define FMT_SWPRINTF swprintf
+#endif // defined(_WIN32) && defined(__MINGW32__) && !defined(__NO_ISOCEXT)
+
+// Checks if a value fits in int - used to avoid warnings about comparing
+// signed and unsigned integers.
+template <bool IsSigned>
+struct IntChecker {
+  template <typename T>
+  static bool fits_in_int(T value) {
+    unsigned max = INT_MAX;
+    return value <= max;
+  }
+  static bool fits_in_int(bool) { return true; }
+};
+
+template <>
+struct IntChecker<true> {
+  template <typename T>
+  static bool fits_in_int(T value) {
+    return value >= INT_MIN && value <= INT_MAX;
+  }
+};
+
+const char RESET_COLOR[] = "\x1b[0m";
+
+typedef void (*FormatFunc)(fmt::Writer &, int, fmt::StringRef);
+
+// Portable thread-safe version of strerror.
+// Sets buffer to point to a string describing the error code.
+// This can be either a pointer to a string stored in buffer,
+// or a pointer to some static immutable string.
+// Returns one of the following values:
+//   0      - success
+//   ERANGE - buffer is not large enough to store the error message
+//   other  - failure
+// Buffer should be at least of size 1.
+int safe_strerror(
+    int error_code, char *&buffer, std::size_t buffer_size) FMT_NOEXCEPT {
+  FMT_ASSERT(buffer != 0 && buffer_size != 0, "invalid buffer");
+
+  class StrError {
+   private:
+    int error_code_;
+    char *&buffer_;
+    std::size_t buffer_size_;
+
+    // A noop assignment operator to avoid bogus warnings.
+    void operator=(const StrError &) {}
+
+    // Handle the result of XSI-compliant version of strerror_r.
+    int handle(int result) {
+      // glibc versions before 2.13 return result in errno.
+      return result == -1 ? errno : result;
+    }
+
+    // Handle the result of GNU-specific version of strerror_r.
+    int handle(char *message) {
+      // If the buffer is full then the message is probably truncated.
+      if (message == buffer_ && strlen(buffer_) == buffer_size_ - 1)
+        return ERANGE;
+      buffer_ = message;
+      return 0;
+    }
+
+    // Handle the case when strerror_r is not available.
+    int handle(fmt::internal::Null<>) {
+      return fallback(strerror_s(buffer_, buffer_size_, error_code_));
+    }
+
+    // Fallback to strerror_s when strerror_r is not available.
+    int fallback(int result) {
+      // If the buffer is full then the message is probably truncated.
+      return result == 0 && strlen(buffer_) == buffer_size_ - 1 ?
+            ERANGE : result;
+    }
+
+    // Fallback to strerror if strerror_r and strerror_s are not available.
+    int fallback(fmt::internal::Null<>) {
+      errno = 0;
+      buffer_ = strerror(error_code_);
+      return errno;
+    }
+
+   public:
+    StrError(int err_code, char *&buf, std::size_t buf_size)
+      : error_code_(err_code), buffer_(buf), buffer_size_(buf_size) {}
+
+    int run() {
+      strerror_r(0, 0, "");  // Suppress a warning about unused strerror_r.
+      return handle(strerror_r(error_code_, buffer_, buffer_size_));
+    }
+  };
+  return StrError(error_code, buffer, buffer_size).run();
+}
+
+void format_error_code(fmt::Writer &out, int error_code,
+                       fmt::StringRef message) FMT_NOEXCEPT {
+  // Report error code making sure that the output fits into
+  // INLINE_BUFFER_SIZE to avoid dynamic memory allocation and potential
+  // bad_alloc.
+  out.clear();
+  static const char SEP[] = ": ";
+  static const char ERROR_STR[] = "error ";
+  fmt::internal::IntTraits<int>::MainType ec_value = error_code;
+  // Subtract 2 to account for terminating null characters in SEP and ERROR_STR.
+  std::size_t error_code_size = sizeof(SEP) + sizeof(ERROR_STR) - 2;
+  error_code_size += fmt::internal::count_digits(ec_value);
+  if (message.size() <= fmt::internal::INLINE_BUFFER_SIZE - error_code_size)
+    out << message << SEP;
+  out << ERROR_STR << error_code;
+  assert(out.size() <= fmt::internal::INLINE_BUFFER_SIZE);
+}
+
+void report_error(FormatFunc func,
+    int error_code, fmt::StringRef message) FMT_NOEXCEPT {
+  fmt::MemoryWriter full_message;
+  func(full_message, error_code, message);
+  // Use Writer::data instead of Writer::c_str to avoid potential memory
+  // allocation.
+  std::fwrite(full_message.data(), full_message.size(), 1, stderr);
+  std::fputc('\n', stderr);
+}
+
+// IsZeroInt::visit(arg) returns true iff arg is a zero integer.
+class IsZeroInt : public fmt::internal::ArgVisitor<IsZeroInt, bool> {
+ public:
+  template <typename T>
+  bool visit_any_int(T value) { return value == 0; }
+};
+
+// Parses an unsigned integer advancing s to the end of the parsed input.
+// This function assumes that the first character of s is a digit.
+template <typename Char>
+int parse_nonnegative_int(const Char *&s) {
+  assert('0' <= *s && *s <= '9');
+  unsigned value = 0;
+  do {
+    unsigned new_value = value * 10 + (*s++ - '0');
+    // Check if value wrapped around.
+    if (new_value < value) {
+      value = UINT_MAX;
+      break;
+    }
+    value = new_value;
+  } while ('0' <= *s && *s <= '9');
+  if (value > INT_MAX)
+    FMT_THROW(fmt::FormatError("number is too big"));
+  return value;
+}
+
+template <typename Char>
+inline bool is_name_start(Char c) {
+  return ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z') || '_' == c;
+}
+
+inline void require_numeric_argument(const Arg &arg, char spec) {
+  if (arg.type > Arg::LAST_NUMERIC_TYPE) {
+    std::string message =
+        fmt::format("format specifier '{}' requires numeric argument", spec);
+    FMT_THROW(fmt::FormatError(message));
+  }
+}
+
+template <typename Char>
+void check_sign(const Char *&s, const Arg &arg) {
+  char sign = static_cast<char>(*s);
+  require_numeric_argument(arg, sign);
+  if (arg.type == Arg::UINT || arg.type == Arg::ULONG_LONG) {
+    FMT_THROW(fmt::FormatError(fmt::format(
+      "format specifier '{}' requires signed argument", sign)));
+  }
+  ++s;
+}
+
+// Checks if an argument is a valid printf width specifier and sets
+// left alignment if it is negative.
+class WidthHandler : public fmt::internal::ArgVisitor<WidthHandler, unsigned> {
+ private:
+  fmt::FormatSpec &spec_;
+
+  FMT_DISALLOW_COPY_AND_ASSIGN(WidthHandler);
+
+ public:
+  explicit WidthHandler(fmt::FormatSpec &spec) : spec_(spec) {}
+
+  void report_unhandled_arg() {
+    FMT_THROW(fmt::FormatError("width is not integer"));
+  }
+
+  template <typename T>
+  unsigned visit_any_int(T value) {
+    typedef typename fmt::internal::IntTraits<T>::MainType UnsignedType;
+    UnsignedType width = value;
+    if (fmt::internal::is_negative(value)) {
+      spec_.align_ = fmt::ALIGN_LEFT;
+      width = 0 - width;
+    }
+    if (width > INT_MAX)
+      FMT_THROW(fmt::FormatError("number is too big"));
+    return static_cast<unsigned>(width);
+  }
+};
+
+class PrecisionHandler :
+    public fmt::internal::ArgVisitor<PrecisionHandler, int> {
+ public:
+  void report_unhandled_arg() {
+    FMT_THROW(fmt::FormatError("precision is not integer"));
+  }
+
+  template <typename T>
+  int visit_any_int(T value) {
+    if (!IntChecker<std::numeric_limits<T>::is_signed>::fits_in_int(value))
+      FMT_THROW(fmt::FormatError("number is too big"));
+    return static_cast<int>(value);
+  }
+};
+
+// Converts an integer argument to an integral type T for printf.
+template <typename T>
+class ArgConverter : public fmt::internal::ArgVisitor<ArgConverter<T>, void> {
+ private:
+  fmt::internal::Arg &arg_;
+  wchar_t type_;
+
+  FMT_DISALLOW_COPY_AND_ASSIGN(ArgConverter);
+
+ public:
+  ArgConverter(fmt::internal::Arg &arg, wchar_t type)
+    : arg_(arg), type_(type) {}
+
+  template <typename U>
+  void visit_any_int(U value) {
+    bool is_signed = type_ == 'd' || type_ == 'i';
+    using fmt::internal::Arg;
+    if (sizeof(T) <= sizeof(int)) {
+      // Extra casts are used to silence warnings.
+      if (is_signed) {
+        arg_.type = Arg::INT;
+        arg_.int_value = static_cast<int>(static_cast<T>(value));
+      } else {
+        arg_.type = Arg::UINT;
+        arg_.uint_value = static_cast<unsigned>(
+            static_cast<typename fmt::internal::MakeUnsigned<T>::Type>(value));
+      }
+    } else {
+      if (is_signed) {
+        arg_.type = Arg::LONG_LONG;
+        arg_.long_long_value =
+            static_cast<typename fmt::internal::MakeUnsigned<U>::Type>(value);
+      } else {
+        arg_.type = Arg::ULONG_LONG;
+        arg_.ulong_long_value =
+            static_cast<typename fmt::internal::MakeUnsigned<U>::Type>(value);
+      }
+    }
+  }
+};
+
+// Converts an integer argument to char for printf.
+class CharConverter : public fmt::internal::ArgVisitor<CharConverter, void> {
+ private:
+  fmt::internal::Arg &arg_;
+
+  FMT_DISALLOW_COPY_AND_ASSIGN(CharConverter);
+
+ public:
+  explicit CharConverter(fmt::internal::Arg &arg) : arg_(arg) {}
+
+  template <typename T>
+  void visit_any_int(T value) {
+    arg_.type = Arg::CHAR;
+    arg_.int_value = static_cast<char>(value);
+  }
+};
+}  // namespace
+
+namespace internal {
+
+template <typename Impl, typename Char>
+class BasicArgFormatter : public ArgVisitor<Impl, void> {
+ private:
+  BasicWriter<Char> &writer_;
+  FormatSpec &spec_;
+
+  FMT_DISALLOW_COPY_AND_ASSIGN(BasicArgFormatter);
+
+ protected:
+  BasicWriter<Char> &writer() { return writer_; }
+  const FormatSpec &spec() const { return spec_; }
+
+ public:
+  BasicArgFormatter(BasicWriter<Char> &w, FormatSpec &s)
+  : writer_(w), spec_(s) {}
+
+  template <typename T>
+  void visit_any_int(T value) { writer_.write_int(value, spec_); }
+
+  template <typename T>
+  void visit_any_double(T value) { writer_.write_double(value, spec_); }
+
+  void visit_bool(bool value) {
+    if (spec_.type_) {
+      writer_.write_int(value, spec_);
+      return;
+    }
+    const char *str_value = value ? "true" : "false";
+    Arg::StringValue<char> str = { str_value, strlen(str_value) };
+    writer_.write_str(str, spec_);
+  }
+
+  void visit_char(int value) {
+    if (spec_.type_ && spec_.type_ != 'c') {
+      spec_.flags_ |= CHAR_FLAG;
+      writer_.write_int(value, spec_);
+      return;
+    }
+    if (spec_.align_ == ALIGN_NUMERIC || spec_.flags_ != 0)
+      FMT_THROW(FormatError("invalid format specifier for char"));
+    typedef typename BasicWriter<Char>::CharPtr CharPtr;
+    Char fill = internal::CharTraits<Char>::cast(spec_.fill());
+    CharPtr out = CharPtr();
+    if (spec_.width_ > 1) {
+      out = writer_.grow_buffer(spec_.width_);
+      if (spec_.align_ == ALIGN_RIGHT) {
+        std::fill_n(out, spec_.width_ - 1, fill);
+        out += spec_.width_ - 1;
+      } else if (spec_.align_ == ALIGN_CENTER) {
+        out = writer_.fill_padding(out, spec_.width_, 1, fill);
+      } else {
+        std::fill_n(out + 1, spec_.width_ - 1, fill);
+      }
+    } else {
+      out = writer_.grow_buffer(1);
+    }
+    *out = internal::CharTraits<Char>::cast(value);
+  }
+
+  void visit_string(Arg::StringValue<char> value) {
+    writer_.write_str(value, spec_);
+  }
+
+  using ArgVisitor<Impl, void>::visit_wstring;
+
+  void visit_wstring(Arg::StringValue<Char> value) {
+    writer_.write_str(value, spec_);
+  }
+
+  void visit_pointer(const void *value) {
+    if (spec_.type_ && spec_.type_ != 'p')
+      report_unknown_type(spec_.type_, "pointer");
+    spec_.flags_ = HASH_FLAG;
+    spec_.type_ = 'x';
+    writer_.write_int(reinterpret_cast<uintptr_t>(value), spec_);
+  }
+};
+
+// An argument formatter.
+template <typename Char>
+class ArgFormatter : public BasicArgFormatter<ArgFormatter<Char>, Char> {
+ private:
+  BasicFormatter<Char> &formatter_;
+  const Char *format_;
+
+ public:
+  ArgFormatter(BasicFormatter<Char> &f, FormatSpec &s, const Char *fmt)
+  : BasicArgFormatter<ArgFormatter<Char>, Char>(f.writer(), s),
+    formatter_(f), format_(fmt) {}
+
+  void visit_custom(Arg::CustomValue c) {
+    c.format(&formatter_, c.value, &format_);
+  }
+};
+
+template <typename Char>
+class PrintfArgFormatter :
+    public BasicArgFormatter<PrintfArgFormatter<Char>, Char> {
+ public:
+  PrintfArgFormatter(BasicWriter<Char> &w, FormatSpec &s)
+  : BasicArgFormatter<PrintfArgFormatter<Char>, Char>(w, s) {}
+
+  void visit_char(int value) {
+    const FormatSpec &fmt_spec = this->spec();
+    BasicWriter<Char> &w = this->writer();
+    if (fmt_spec.type_ && fmt_spec.type_ != 'c')
+      w.write_int(value, fmt_spec);
+    typedef typename BasicWriter<Char>::CharPtr CharPtr;
+    CharPtr out = CharPtr();
+    if (fmt_spec.width_ > 1) {
+      Char fill = ' ';
+      out = w.grow_buffer(fmt_spec.width_);
+      if (fmt_spec.align_ != ALIGN_LEFT) {
+        std::fill_n(out, fmt_spec.width_ - 1, fill);
+        out += fmt_spec.width_ - 1;
+      } else {
+        std::fill_n(out + 1, fmt_spec.width_ - 1, fill);
+      }
+    } else {
+      out = w.grow_buffer(1);
+    }
+    *out = static_cast<Char>(value);
+  }
+
+  void visit_custom(Arg::CustomValue c) {
+    BasicFormatter<Char> formatter(ArgList(), this->writer());
+    const char *format = "}";
+    c.format(&formatter, c.value, &format);
+  }
+};
+}  // namespace internal
+}  // namespace fmt
+
+FMT_FUNC void fmt::SystemError::init(
+    int err_code, CStringRef format_str, ArgList args) {
+  error_code_ = err_code;
+  MemoryWriter w;
+  internal::format_system_error(w, err_code, format(format_str, args));
+  std::runtime_error &base = *this;
+  base = std::runtime_error(w.str());
+}
+
+template <typename T>
+int fmt::internal::CharTraits<char>::format_float(
+    char *buffer, std::size_t size, const char *format,
+    unsigned width, int precision, T value) {
+  if (width == 0) {
+    return precision < 0 ?
+        FMT_SNPRINTF(buffer, size, format, value) :
+        FMT_SNPRINTF(buffer, size, format, precision, value);
+  }
+  return precision < 0 ?
+      FMT_SNPRINTF(buffer, size, format, width, value) :
+      FMT_SNPRINTF(buffer, size, format, width, precision, value);
+}
+
+template <typename T>
+int fmt::internal::CharTraits<wchar_t>::format_float(
+    wchar_t *buffer, std::size_t size, const wchar_t *format,
+    unsigned width, int precision, T value) {
+  if (width == 0) {
+    return precision < 0 ?
+        FMT_SWPRINTF(buffer, size, format, value) :
+        FMT_SWPRINTF(buffer, size, format, precision, value);
+  }
+  return precision < 0 ?
+      FMT_SWPRINTF(buffer, size, format, width, value) :
+      FMT_SWPRINTF(buffer, size, format, width, precision, value);
+}
+
+template <typename T>
+const char fmt::internal::BasicData<T>::DIGITS[] =
+    "0001020304050607080910111213141516171819"
+    "2021222324252627282930313233343536373839"
+    "4041424344454647484950515253545556575859"
+    "6061626364656667686970717273747576777879"
+    "8081828384858687888990919293949596979899";
+
+#define FMT_POWERS_OF_10(factor) \
+  factor * 10, \
+  factor * 100, \
+  factor * 1000, \
+  factor * 10000, \
+  factor * 100000, \
+  factor * 1000000, \
+  factor * 10000000, \
+  factor * 100000000, \
+  factor * 1000000000
+
+template <typename T>
+const uint32_t fmt::internal::BasicData<T>::POWERS_OF_10_32[] = {
+  0, FMT_POWERS_OF_10(1)
+};
+
+template <typename T>
+const uint64_t fmt::internal::BasicData<T>::POWERS_OF_10_64[] = {
+  0,
+  FMT_POWERS_OF_10(1),
+  FMT_POWERS_OF_10(fmt::ULongLong(1000000000)),
+  // Multiply several constants instead of using a single long long constant
+  // to avoid warnings about C++98 not supporting long long.
+  fmt::ULongLong(1000000000) * fmt::ULongLong(1000000000) * 10
+};
+
+FMT_FUNC void fmt::internal::report_unknown_type(char code, const char *type) {
+  (void)type;
+  if (std::isprint(static_cast<unsigned char>(code))) {
+    FMT_THROW(fmt::FormatError(
+        fmt::format("unknown format code '{}' for {}", code, type)));
+  }
+  FMT_THROW(fmt::FormatError(
+      fmt::format("unknown format code '\\x{:02x}' for {}",
+        static_cast<unsigned>(code), type)));
+}
+
+#if FMT_USE_WINDOWS_H
+
+FMT_FUNC fmt::internal::UTF8ToUTF16::UTF8ToUTF16(fmt::StringRef s) {
+  static const char ERROR_MSG[] = "cannot convert string from UTF-8 to UTF-16";
+  if (s.size() > INT_MAX)
+    FMT_THROW(WindowsError(ERROR_INVALID_PARAMETER, ERROR_MSG));
+  int s_size = static_cast<int>(s.size());
+  int length = MultiByteToWideChar(
+      CP_UTF8, MB_ERR_INVALID_CHARS, s.data(), s_size, 0, 0);
+  if (length == 0)
+    FMT_THROW(WindowsError(GetLastError(), ERROR_MSG));
+  buffer_.resize(length + 1);
+  length = MultiByteToWideChar(
+    CP_UTF8, MB_ERR_INVALID_CHARS, s.data(), s_size, &buffer_[0], length);
+  if (length == 0)
+    FMT_THROW(WindowsError(GetLastError(), ERROR_MSG));
+  buffer_[length] = 0;
+}
+
+FMT_FUNC fmt::internal::UTF16ToUTF8::UTF16ToUTF8(fmt::WStringRef s) {
+  if (int error_code = convert(s)) {
+    FMT_THROW(WindowsError(error_code,
+        "cannot convert string from UTF-16 to UTF-8"));
+  }
+}
+
+FMT_FUNC int fmt::internal::UTF16ToUTF8::convert(fmt::WStringRef s) {
+  if (s.size() > INT_MAX)
+    return ERROR_INVALID_PARAMETER;
+  int s_size = static_cast<int>(s.size());
+  int length = WideCharToMultiByte(CP_UTF8, 0, s.data(), s_size, 0, 0, 0, 0);
+  if (length == 0)
+    return GetLastError();
+  buffer_.resize(length + 1);
+  length = WideCharToMultiByte(
+    CP_UTF8, 0, s.data(), s_size, &buffer_[0], length, 0, 0);
+  if (length == 0)
+    return GetLastError();
+  buffer_[length] = 0;
+  return 0;
+}
+
+FMT_FUNC void fmt::WindowsError::init(
+    int err_code, CStringRef format_str, ArgList args) {
+  error_code_ = err_code;
+  MemoryWriter w;
+  internal::format_windows_error(w, err_code, format(format_str, args));
+  std::runtime_error &base = *this;
+  base = std::runtime_error(w.str());
+}
+
+FMT_FUNC void fmt::internal::format_windows_error(
+    fmt::Writer &out, int error_code,
+    fmt::StringRef message) FMT_NOEXCEPT {
+  class String {
+   private:
+    LPWSTR str_;
+
+   public:
+    String() : str_() {}
+    ~String() { LocalFree(str_); }
+    LPWSTR *ptr() { return &str_; }
+    LPCWSTR c_str() const { return str_; }
+  };
+  FMT_TRY {
+    String system_message;
+    if (FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER |
+        FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, 0,
+        error_code, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+        reinterpret_cast<LPWSTR>(system_message.ptr()), 0, 0)) {
+      UTF16ToUTF8 utf8_message;
+      if (utf8_message.convert(system_message.c_str()) == ERROR_SUCCESS) {
+        out << message << ": " << utf8_message;
+        return;
+      }
+    }
+  } FMT_CATCH(...) {}
+  format_error_code(out, error_code, message);
+}
+
+#endif  // FMT_USE_WINDOWS_H
+
+FMT_FUNC void fmt::internal::format_system_error(
+    fmt::Writer &out, int error_code,
+    fmt::StringRef message) FMT_NOEXCEPT {
+  FMT_TRY {
+    MemoryBuffer<char, INLINE_BUFFER_SIZE> buffer;
+    buffer.resize(INLINE_BUFFER_SIZE);
+    for (;;) {
+      char *system_message = &buffer[0];
+      int result = safe_strerror(error_code, system_message, buffer.size());
+      if (result == 0) {
+        out << message << ": " << system_message;
+        return;
+      }
+      if (result != ERANGE)
+        break;  // Can't get error message, report error code instead.
+      buffer.resize(buffer.size() * 2);
+    }
+  } FMT_CATCH(...) {}
+  format_error_code(out, error_code, message);
+}
+
+template <typename Char>
+void fmt::internal::ArgMap<Char>::init(const ArgList &args) {
+  if (!map_.empty())
+    return;
+  typedef internal::NamedArg<Char> NamedArg;
+  const NamedArg *named_arg = 0;
+  bool use_values =
+      args.type(ArgList::MAX_PACKED_ARGS - 1) == internal::Arg::NONE;
+  if (use_values) {
+    for (unsigned i = 0;/*nothing*/; ++i) {
+      internal::Arg::Type arg_type = args.type(i);
+      switch (arg_type) {
+      case internal::Arg::NONE:
+        return;
+      case internal::Arg::NAMED_ARG:
+        named_arg = static_cast<const NamedArg*>(args.values_[i].pointer);
+        map_.insert(Pair(named_arg->name, *named_arg));
+        break;
+      default:
+        /*nothing*/;
+      }
+    }
+    return;
+  }
+  for (unsigned i = 0; i != ArgList::MAX_PACKED_ARGS; ++i) {
+    internal::Arg::Type arg_type = args.type(i);
+    if (arg_type == internal::Arg::NAMED_ARG) {
+      named_arg = static_cast<const NamedArg*>(args.args_[i].pointer);
+      map_.insert(Pair(named_arg->name, *named_arg));
+    }
+  }
+  for (unsigned i = ArgList::MAX_PACKED_ARGS;/*nothing*/; ++i) {
+    switch (args.args_[i].type) {
+    case internal::Arg::NONE:
+      return;
+    case internal::Arg::NAMED_ARG:
+      named_arg = static_cast<const NamedArg*>(args.args_[i].pointer);
+      map_.insert(Pair(named_arg->name, *named_arg));
+      break;
+    default:
+      /*nothing*/;
+    }
+  }
+}
+
+template <typename Char>
+void fmt::internal::FixedBuffer<Char>::grow(std::size_t) {
+  FMT_THROW(std::runtime_error("buffer overflow"));
+}
+
+template <typename Char>
+template <typename StrChar>
+void fmt::BasicWriter<Char>::write_str(
+    const Arg::StringValue<StrChar> &s, const FormatSpec &spec) {
+  // Check if StrChar is convertible to Char.
+  internal::CharTraits<Char>::convert(StrChar());
+  if (spec.type_ && spec.type_ != 's')
+    internal::report_unknown_type(spec.type_, "string");
+  const StrChar *str_value = s.value;
+  std::size_t str_size = s.size;
+  if (str_size == 0) {
+    if (!str_value)
+      FMT_THROW(FormatError("string pointer is null"));
+    if (*str_value)
+      str_size = std::char_traits<StrChar>::length(str_value);
+  }
+  std::size_t precision = spec.precision_;
+  if (spec.precision_ >= 0 && precision < str_size)
+    str_size = spec.precision_;
+  write_str(str_value, str_size, spec);
+}
+
+template <typename Char>
+inline Arg fmt::BasicFormatter<Char>::get_arg(
+  BasicStringRef<Char> arg_name, const char *&error) {
+  if (check_no_auto_index(error)) {
+    map_.init(args());
+    const Arg *arg = map_.find(arg_name);
+    if (arg)
+      return *arg;
+    error = "argument not found";
+  }
+  return Arg();
+}
+
+template <typename Char>
+inline Arg fmt::BasicFormatter<Char>::parse_arg_index(const Char *&s) {
+  const char *error = 0;
+  Arg arg = *s < '0' || *s > '9' ?
+        next_arg(error) : get_arg(parse_nonnegative_int(s), error);
+  if (error) {
+    FMT_THROW(FormatError(
+                *s != '}' && *s != ':' ? "invalid format string" : error));
+  }
+  return arg;
+}
+
+template <typename Char>
+inline Arg fmt::BasicFormatter<Char>::parse_arg_name(const Char *&s) {
+  assert(is_name_start(*s));
+  const Char *start = s;
+  Char c;
+  do {
+    c = *++s;
+  } while (is_name_start(c) || ('0' <= c && c <= '9'));
+  const char *error = 0;
+  Arg arg = get_arg(fmt::BasicStringRef<Char>(start, s - start), error);
+  if (error)
+    FMT_THROW(fmt::FormatError(error));
+  return arg;
+}
+
+FMT_FUNC Arg fmt::internal::FormatterBase::do_get_arg(
+    unsigned arg_index, const char *&error) {
+  Arg arg = args_[arg_index];
+  switch (arg.type) {
+  case Arg::NONE:
+    error = "argument index out of range";
+    break;
+  case Arg::NAMED_ARG:
+    arg = *static_cast<const internal::Arg*>(arg.pointer);
+  default:
+    /*nothing*/;
+  }
+  return arg;
+}
+
+inline Arg fmt::internal::FormatterBase::next_arg(const char *&error) {
+  if (next_arg_index_ >= 0)
+    return do_get_arg(next_arg_index_++, error);
+  error = "cannot switch from manual to automatic argument indexing";
+  return Arg();
+}
+
+inline bool fmt::internal::FormatterBase::check_no_auto_index(
+    const char *&error) {
+  if (next_arg_index_ > 0) {
+    error = "cannot switch from automatic to manual argument indexing";
+    return false;
+  }
+  next_arg_index_ = -1;
+  return true;
+}
+
+inline Arg fmt::internal::FormatterBase::get_arg(
+    unsigned arg_index, const char *&error) {
+  return check_no_auto_index(error) ? do_get_arg(arg_index, error) : Arg();
+}
+
+template <typename Char>
+void fmt::internal::PrintfFormatter<Char>::parse_flags(
+    FormatSpec &spec, const Char *&s) {
+  for (;;) {
+    switch (*s++) {
+      case '-':
+        spec.align_ = ALIGN_LEFT;
+        break;
+      case '+':
+        spec.flags_ |= SIGN_FLAG | PLUS_FLAG;
+        break;
+      case '0':
+        spec.fill_ = '0';
+        break;
+      case ' ':
+        spec.flags_ |= SIGN_FLAG;
+        break;
+      case '#':
+        spec.flags_ |= HASH_FLAG;
+        break;
+      default:
+        --s;
+        return;
+    }
+  }
+}
+
+template <typename Char>
+Arg fmt::internal::PrintfFormatter<Char>::get_arg(
+    const Char *s, unsigned arg_index) {
+  (void)s;
+  const char *error = 0;
+  Arg arg = arg_index == UINT_MAX ?
+    next_arg(error) : FormatterBase::get_arg(arg_index - 1, error);
+  if (error)
+    FMT_THROW(FormatError(!*s ? "invalid format string" : error));
+  return arg;
+}
+
+template <typename Char>
+unsigned fmt::internal::PrintfFormatter<Char>::parse_header(
+  const Char *&s, FormatSpec &spec) {
+  unsigned arg_index = UINT_MAX;
+  Char c = *s;
+  if (c >= '0' && c <= '9') {
+    // Parse an argument index (if followed by '$') or a width possibly
+    // preceded with '0' flag(s).
+    unsigned value = parse_nonnegative_int(s);
+    if (*s == '$') {  // value is an argument index
+      ++s;
+      arg_index = value;
+    } else {
+      if (c == '0')
+        spec.fill_ = '0';
+      if (value != 0) {
+        // Nonzero value means that we parsed width and don't need to
+        // parse it or flags again, so return now.
+        spec.width_ = value;
+        return arg_index;
+      }
+    }
+  }
+  parse_flags(spec, s);
+  // Parse width.
+  if (*s >= '0' && *s <= '9') {
+    spec.width_ = parse_nonnegative_int(s);
+  } else if (*s == '*') {
+    ++s;
+    spec.width_ = WidthHandler(spec).visit(get_arg(s));
+  }
+  return arg_index;
+}
+
+template <typename Char>
+void fmt::internal::PrintfFormatter<Char>::format(
+    BasicWriter<Char> &writer, BasicCStringRef<Char> format_str) {
+  const Char *start = format_str.c_str();
+  const Char *s = start;
+  while (*s) {
+    Char c = *s++;
+    if (c != '%') continue;
+    if (*s == c) {
+      write(writer, start, s);
+      start = ++s;
+      continue;
+    }
+    write(writer, start, s - 1);
+
+    FormatSpec spec;
+    spec.align_ = ALIGN_RIGHT;
+
+    // Parse argument index, flags and width.
+    unsigned arg_index = parse_header(s, spec);
+
+    // Parse precision.
+    if (*s == '.') {
+      ++s;
+      if ('0' <= *s && *s <= '9') {
+        spec.precision_ = parse_nonnegative_int(s);
+      } else if (*s == '*') {
+        ++s;
+        spec.precision_ = PrecisionHandler().visit(get_arg(s));
+      }
+    }
+
+    Arg arg = get_arg(s, arg_index);
+    if (spec.flag(HASH_FLAG) && IsZeroInt().visit(arg))
+      spec.flags_ &= ~HASH_FLAG;
+    if (spec.fill_ == '0') {
+      if (arg.type <= Arg::LAST_NUMERIC_TYPE)
+        spec.align_ = ALIGN_NUMERIC;
+      else
+        spec.fill_ = ' ';  // Ignore '0' flag for non-numeric types.
+    }
+
+    // Parse length and convert the argument to the required type.
+    switch (*s++) {
+    case 'h':
+      if (*s == 'h')
+        ArgConverter<signed char>(arg, *++s).visit(arg);
+      else
+        ArgConverter<short>(arg, *s).visit(arg);
+      break;
+    case 'l':
+      if (*s == 'l')
+        ArgConverter<fmt::LongLong>(arg, *++s).visit(arg);
+      else
+        ArgConverter<long>(arg, *s).visit(arg);
+      break;
+    case 'j':
+      ArgConverter<intmax_t>(arg, *s).visit(arg);
+      break;
+    case 'z':
+      ArgConverter<size_t>(arg, *s).visit(arg);
+      break;
+    case 't':
+      ArgConverter<ptrdiff_t>(arg, *s).visit(arg);
+      break;
+    case 'L':
+      // printf produces garbage when 'L' is omitted for long double, no
+      // need to do the same.
+      break;
+    default:
+      --s;
+      ArgConverter<int>(arg, *s).visit(arg);
+    }
+
+    // Parse type.
+    if (!*s)
+      FMT_THROW(FormatError("invalid format string"));
+    spec.type_ = static_cast<char>(*s++);
+    if (arg.type <= Arg::LAST_INTEGER_TYPE) {
+      // Normalize type.
+      switch (spec.type_) {
+      case 'i': case 'u':
+        spec.type_ = 'd';
+        break;
+      case 'c':
+        // TODO: handle wchar_t
+        CharConverter(arg).visit(arg);
+        break;
+      }
+    }
+
+    start = s;
+
+    // Format argument.
+    internal::PrintfArgFormatter<Char>(writer, spec).visit(arg);
+  }
+  write(writer, start, s);
+}
+
+template <typename Char>
+const Char *fmt::BasicFormatter<Char>::format(
+    const Char *&format_str, const Arg &arg) {
+  const Char *s = format_str;
+  FormatSpec spec;
+  if (*s == ':') {
+    if (arg.type == Arg::CUSTOM) {
+      arg.custom.format(this, arg.custom.value, &s);
+      return s;
+    }
+    ++s;
+    // Parse fill and alignment.
+    if (Char c = *s) {
+      const Char *p = s + 1;
+      spec.align_ = ALIGN_DEFAULT;
+      do {
+        switch (*p) {
+          case '<':
+            spec.align_ = ALIGN_LEFT;
+            break;
+          case '>':
+            spec.align_ = ALIGN_RIGHT;
+            break;
+          case '=':
+            spec.align_ = ALIGN_NUMERIC;
+            break;
+          case '^':
+            spec.align_ = ALIGN_CENTER;
+            break;
+        }
+        if (spec.align_ != ALIGN_DEFAULT) {
+          if (p != s) {
+            if (c == '}') break;
+            if (c == '{')
+              FMT_THROW(FormatError("invalid fill character '{'"));
+            s += 2;
+            spec.fill_ = c;
+          } else ++s;
+          if (spec.align_ == ALIGN_NUMERIC)
+            require_numeric_argument(arg, '=');
+          break;
+        }
+      } while (--p >= s);
+    }
+
+    // Parse sign.
+    switch (*s) {
+      case '+':
+        check_sign(s, arg);
+        spec.flags_ |= SIGN_FLAG | PLUS_FLAG;
+        break;
+      case '-':
+        check_sign(s, arg);
+        spec.flags_ |= MINUS_FLAG;
+        break;
+      case ' ':
+        check_sign(s, arg);
+        spec.flags_ |= SIGN_FLAG;
+        break;
+    }
+
+    if (*s == '#') {
+      require_numeric_argument(arg, '#');
+      spec.flags_ |= HASH_FLAG;
+      ++s;
+    }
+
+    // Parse zero flag.
+    if (*s == '0') {
+      require_numeric_argument(arg, '0');
+      spec.align_ = ALIGN_NUMERIC;
+      spec.fill_ = '0';
+      ++s;
+    }
+    
+    // Parse width.
+    if ('0' <= *s && *s <= '9') {
+      spec.width_ = parse_nonnegative_int(s);
+    } else if (*s == '{') {
+      ++s;
+      Arg width_arg = is_name_start(*s) ?
+            parse_arg_name(s) : parse_arg_index(s);
+      if (*s++ != '}')
+        FMT_THROW(FormatError("invalid format string"));
+      ULongLong value = 0;
+      switch (width_arg.type) {
+      case Arg::INT:
+        if (width_arg.int_value < 0)
+          FMT_THROW(FormatError("negative width"));
+        value = width_arg.int_value;
+        break;
+      case Arg::UINT:
+        value = width_arg.uint_value;
+        break;
+      case Arg::LONG_LONG:
+        if (width_arg.long_long_value < 0)
+          FMT_THROW(FormatError("negative width"));
+        value = width_arg.long_long_value;
+        break;
+      case Arg::ULONG_LONG:
+        value = width_arg.ulong_long_value;
+        break;
+      default:
+        FMT_THROW(FormatError("width is not integer"));
+      }
+      if (value > INT_MAX)
+        FMT_THROW(FormatError("number is too big"));
+      spec.width_ = static_cast<int>(value);
+    }
+
+    // Parse precision.
+    if (*s == '.') {
+      ++s;
+      spec.precision_ = 0;
+      if ('0' <= *s && *s <= '9') {
+        spec.precision_ = parse_nonnegative_int(s);
+      } else if (*s == '{') {
+        ++s;
+        Arg precision_arg =
+            is_name_start(*s) ? parse_arg_name(s) : parse_arg_index(s);
+        if (*s++ != '}')
+          FMT_THROW(FormatError("invalid format string"));
+        ULongLong value = 0;
+        switch (precision_arg.type) {
+          case Arg::INT:
+            if (precision_arg.int_value < 0)
+              FMT_THROW(FormatError("negative precision"));
+            value = precision_arg.int_value;
+            break;
+          case Arg::UINT:
+            value = precision_arg.uint_value;
+            break;
+          case Arg::LONG_LONG:
+            if (precision_arg.long_long_value < 0)
+              FMT_THROW(FormatError("negative precision"));
+            value = precision_arg.long_long_value;
+            break;
+          case Arg::ULONG_LONG:
+            value = precision_arg.ulong_long_value;
+            break;
+          default:
+            FMT_THROW(FormatError("precision is not integer"));
+        }
+        if (value > INT_MAX)
+          FMT_THROW(FormatError("number is too big"));
+        spec.precision_ = static_cast<int>(value);
+      } else {
+        FMT_THROW(FormatError("missing precision specifier"));
+      }
+      if (arg.type <= Arg::LAST_INTEGER_TYPE || arg.type == Arg::POINTER) {
+        FMT_THROW(FormatError(
+            fmt::format("precision not allowed in {} format specifier",
+            arg.type == Arg::POINTER ? "pointer" : "integer")));
+      }
+    }
+
+    // Parse type.
+    if (*s != '}' && *s)
+      spec.type_ = static_cast<char>(*s++);
+  }
+
+  if (*s++ != '}')
+    FMT_THROW(FormatError("missing '}' in format string"));
+
+  // Format argument.
+  internal::ArgFormatter<Char>(*this, spec, s - 1).visit(arg);
+  return s;
+}
+
+template <typename Char>
+void fmt::BasicFormatter<Char>::format(BasicCStringRef<Char> format_str) {
+  const Char *s = format_str.c_str();
+  const Char *start = s;
+  while (*s) {
+    Char c = *s++;
+    if (c != '{' && c != '}') continue;
+    if (*s == c) {
+      write(writer_, start, s);
+      start = ++s;
+      continue;
+    }
+    if (c == '}')
+      FMT_THROW(FormatError("unmatched '}' in format string"));
+    write(writer_, start, s - 1);
+    Arg arg = is_name_start(*s) ? parse_arg_name(s) : parse_arg_index(s);
+    start = s = format(s, arg);
+  }
+  write(writer_, start, s);
+}
+
+FMT_FUNC void fmt::report_system_error(
+    int error_code, fmt::StringRef message) FMT_NOEXCEPT {
+  report_error(internal::format_system_error, error_code, message);
+}
+
+#if FMT_USE_WINDOWS_H
+FMT_FUNC void fmt::report_windows_error(
+    int error_code, fmt::StringRef message) FMT_NOEXCEPT {
+  report_error(internal::format_windows_error, error_code, message);
+}
+#endif
+
+FMT_FUNC void fmt::print(std::FILE *f, CStringRef format_str, ArgList args) {
+  MemoryWriter w;
+  w.write(format_str, args);
+  std::fwrite(w.data(), 1, w.size(), f);
+}
+
+FMT_FUNC void fmt::print(CStringRef format_str, ArgList args) {
+  print(stdout, format_str, args);
+}
+
+FMT_FUNC void fmt::print(std::ostream &os, CStringRef format_str, ArgList args) {
+  MemoryWriter w;
+  w.write(format_str, args);
+  os.write(w.data(), w.size());
+}
+
+FMT_FUNC void fmt::print_colored(Color c, CStringRef format, ArgList args) {
+  char escape[] = "\x1b[30m";
+  escape[3] = '0' + static_cast<char>(c);
+  std::fputs(escape, stdout);
+  print(format, args);
+  std::fputs(RESET_COLOR, stdout);
+}
+
+FMT_FUNC int fmt::fprintf(std::FILE *f, CStringRef format, ArgList args) {
+  MemoryWriter w;
+  printf(w, format, args);
+  std::size_t size = w.size();
+  return std::fwrite(w.data(), 1, size, f) < size ? -1 : static_cast<int>(size);
+}
+
+#ifndef FMT_HEADER_ONLY
+
+template struct fmt::internal::BasicData<void>;
+
+// Explicit instantiations for char.
+
+template void fmt::internal::FixedBuffer<char>::grow(std::size_t);
+
+template const char *fmt::BasicFormatter<char>::format(
+    const char *&format_str, const fmt::internal::Arg &arg);
+
+template void fmt::BasicFormatter<char>::format(CStringRef format);
+
+template void fmt::internal::PrintfFormatter<char>::format(
+  BasicWriter<char> &writer, CStringRef format);
+
+template int fmt::internal::CharTraits<char>::format_float(
+    char *buffer, std::size_t size, const char *format,
+    unsigned width, int precision, double value);
+
+template int fmt::internal::CharTraits<char>::format_float(
+    char *buffer, std::size_t size, const char *format,
+    unsigned width, int precision, long double value);
+
+// Explicit instantiations for wchar_t.
+
+template void fmt::internal::FixedBuffer<wchar_t>::grow(std::size_t);
+
+template const wchar_t *fmt::BasicFormatter<wchar_t>::format(
+    const wchar_t *&format_str, const fmt::internal::Arg &arg);
+
+template void fmt::BasicFormatter<wchar_t>::format(
+    BasicCStringRef<wchar_t> format);
+
+template void fmt::internal::PrintfFormatter<wchar_t>::format(
+    BasicWriter<wchar_t> &writer, WCStringRef format);
+
+template int fmt::internal::CharTraits<wchar_t>::format_float(
+    wchar_t *buffer, std::size_t size, const wchar_t *format,
+    unsigned width, int precision, double value);
+
+template int fmt::internal::CharTraits<wchar_t>::format_float(
+    wchar_t *buffer, std::size_t size, const wchar_t *format,
+    unsigned width, int precision, long double value);
+
+#endif  // FMT_HEADER_ONLY
+
+#if _MSC_VER
+# pragma warning(pop)
+#endif

--- a/xbmc/contrib/cppformat/format.h
+++ b/xbmc/contrib/cppformat/format.h
@@ -1,0 +1,3014 @@
+/*
+ Formatting library for C++
+
+ Copyright (c) 2012 - 2015, Victor Zverovich
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef FMT_FORMAT_H_
+#define FMT_FORMAT_H_
+
+#include <stdint.h>
+
+#include <cassert>
+#include <cmath>
+#include <cstddef>  // for std::ptrdiff_t
+#include <cstdio>
+#include <algorithm>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <sstream>
+#include <map>
+
+#if _SECURE_SCL
+# include <iterator>
+#endif
+
+#ifdef _MSC_VER
+# include <intrin.h>  // _BitScanReverse, _BitScanReverse64
+
+namespace fmt {
+namespace internal {
+# pragma intrinsic(_BitScanReverse)
+inline uint32_t clz(uint32_t x) {
+  unsigned long r = 0;
+  _BitScanReverse(&r, x);
+  return 31 - r;
+}
+# define FMT_BUILTIN_CLZ(n) fmt::internal::clz(n)
+
+# ifdef _WIN64
+#  pragma intrinsic(_BitScanReverse64)
+# endif
+
+inline uint32_t clzll(uint64_t x) {
+  unsigned long r = 0;
+# ifdef _WIN64
+  _BitScanReverse64(&r, x);
+# else
+  // Scan the high 32 bits.
+  if (_BitScanReverse(&r, static_cast<uint32_t>(x >> 32)))
+    return 63 - (r + 32);
+
+  // Scan the low 32 bits.
+  _BitScanReverse(&r, static_cast<uint32_t>(x));
+# endif
+  return 63 - r;
+}
+# define FMT_BUILTIN_CLZLL(n) fmt::internal::clzll(n)
+}
+}
+#endif
+
+#ifdef __GNUC__
+# define FMT_GCC_VERSION (__GNUC__ * 100 + __GNUC_MINOR__)
+# define FMT_GCC_EXTENSION __extension__
+# if FMT_GCC_VERSION >= 406
+#  pragma GCC diagnostic push
+// Disable the warning about "long long" which is sometimes reported even
+// when using __extension__.
+#  pragma GCC diagnostic ignored "-Wlong-long"
+// Disable the warning about declaration shadowing because it affects too
+// many valid cases.
+#  pragma GCC diagnostic ignored "-Wshadow"
+# endif
+# if __cplusplus >= 201103L || defined __GXX_EXPERIMENTAL_CXX0X__
+#  define FMT_HAS_GXX_CXX11 1
+# endif
+#else
+# define FMT_GCC_EXTENSION
+#endif
+
+#ifdef __clang__
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wdocumentation"
+#endif
+
+#ifdef __GNUC_LIBSTD__
+# define FMT_GNUC_LIBSTD_VERSION (__GNUC_LIBSTD__ * 100 + __GNUC_LIBSTD_MINOR__)
+#endif
+
+#ifdef __has_feature
+# define FMT_HAS_FEATURE(x) __has_feature(x)
+#else
+# define FMT_HAS_FEATURE(x) 0
+#endif
+
+#ifdef __has_builtin
+# define FMT_HAS_BUILTIN(x) __has_builtin(x)
+#else
+# define FMT_HAS_BUILTIN(x) 0
+#endif
+
+#ifdef __has_cpp_attribute
+# define FMT_HAS_CPP_ATTRIBUTE(x) __has_cpp_attribute(x)
+#else
+# define FMT_HAS_CPP_ATTRIBUTE(x) 0
+#endif
+
+#ifndef FMT_USE_VARIADIC_TEMPLATES
+// Variadic templates are available in GCC since version 4.4
+// (http://gcc.gnu.org/projects/cxx0x.html) and in Visual C++
+// since version 2013.
+# define FMT_USE_VARIADIC_TEMPLATES \
+   (FMT_HAS_FEATURE(cxx_variadic_templates) || \
+       (FMT_GCC_VERSION >= 404 && FMT_HAS_GXX_CXX11) || _MSC_VER >= 1800)
+#endif
+
+#ifndef FMT_USE_RVALUE_REFERENCES
+// Don't use rvalue references when compiling with clang and an old libstdc++
+// as the latter doesn't provide std::move.
+# if defined(FMT_GNUC_LIBSTD_VERSION) && FMT_GNUC_LIBSTD_VERSION <= 402
+#  define FMT_USE_RVALUE_REFERENCES 0
+# else
+#  define FMT_USE_RVALUE_REFERENCES \
+    (FMT_HAS_FEATURE(cxx_rvalue_references) || \
+        (FMT_GCC_VERSION >= 403 && FMT_HAS_GXX_CXX11) || _MSC_VER >= 1600)
+# endif
+#endif
+
+#if FMT_USE_RVALUE_REFERENCES
+# include <utility>  // for std::move
+#endif
+
+// Define FMT_USE_NOEXCEPT to make C++ Format use noexcept (C++11 feature).
+#ifndef FMT_NOEXCEPT
+# if FMT_USE_NOEXCEPT || FMT_HAS_FEATURE(cxx_noexcept) || \
+   (FMT_GCC_VERSION >= 408 && FMT_HAS_GXX_CXX11)
+#  define FMT_NOEXCEPT noexcept
+# else
+#  define FMT_NOEXCEPT throw()
+# endif
+#endif
+
+// A macro to disallow the copy constructor and operator= functions
+// This should be used in the private: declarations for a class
+#if FMT_USE_DELETED_FUNCTIONS || FMT_HAS_FEATURE(cxx_deleted_functions) || \
+  (FMT_GCC_VERSION >= 404 && FMT_HAS_GXX_CXX11) || _MSC_VER >= 1800
+# define FMT_DELETED_OR_UNDEFINED  = delete
+# define FMT_DISALLOW_COPY_AND_ASSIGN(TypeName) \
+    TypeName(const TypeName&) = delete; \
+    TypeName& operator=(const TypeName&) = delete
+#else
+# define FMT_DELETED_OR_UNDEFINED
+# define FMT_DISALLOW_COPY_AND_ASSIGN(TypeName) \
+    TypeName(const TypeName&); \
+    TypeName& operator=(const TypeName&)
+#endif
+
+#ifndef FMT_ASSERT
+# define FMT_ASSERT(condition, message) assert((condition) && message)
+#endif
+
+namespace fmt {
+
+// Fix the warning about long long on older versions of GCC
+// that don't support the diagnostic pragma.
+FMT_GCC_EXTENSION typedef long long LongLong;
+FMT_GCC_EXTENSION typedef unsigned long long ULongLong;
+
+#if FMT_USE_RVALUE_REFERENCES
+using std::move;
+#endif
+
+template <typename Char>
+class BasicWriter;
+
+typedef BasicWriter<char> Writer;
+typedef BasicWriter<wchar_t> WWriter;
+
+template <typename Char>
+class BasicFormatter;
+
+template <typename Char, typename T>
+void format(BasicFormatter<Char> &f, const Char *&format_str, const T &value);
+
+/**
+  \rst
+  A string reference. It can be constructed from a C string or ``std::string``.
+  
+  You can use one of the following typedefs for common character types:
+
+  +------------+-------------------------+
+  | Type       | Definition              |
+  +============+=========================+
+  | StringRef  | BasicStringRef<char>    |
+  +------------+-------------------------+
+  | WStringRef | BasicStringRef<wchar_t> |
+  +------------+-------------------------+
+
+  This class is most useful as a parameter type to allow passing
+  different types of strings to a function, for example::
+
+    template <typename... Args>
+    std::string format(StringRef format_str, const Args & ... args);
+
+    format("{}", 42);
+    format(std::string("{}"), 42);
+  \endrst
+ */
+template <typename Char>
+class BasicStringRef {
+ private:
+  const Char *data_;
+  std::size_t size_;
+
+ public:
+  /** Constructs a string reference object from a C string and a size. */
+  BasicStringRef(const Char *s, std::size_t size) : data_(s), size_(size) {}
+
+  /**
+    \rst
+    Constructs a string reference object from a C string computing
+    the size with ``std::char_traits<Char>::length``.
+    \endrst
+   */
+  BasicStringRef(const Char *s)
+    : data_(s), size_(std::char_traits<Char>::length(s)) {}
+
+  /**
+    \rst
+    Constructs a string reference from an ``std::string`` object.
+    \endrst
+   */
+  BasicStringRef(const std::basic_string<Char> &s)
+  : data_(s.c_str()), size_(s.size()) {}
+
+  /**
+    \rst
+    Converts a string reference to an ``std::string`` object.
+    \endrst
+   */
+  std::basic_string<Char> to_string() const {
+    return std::basic_string<Char>(data_, size_);
+  }
+
+  /** Returns the pointer to a C string. */
+  const Char *data() const { return data_; }
+
+  /** Returns the string size. */
+  std::size_t size() const { return size_; }
+
+  friend bool operator==(BasicStringRef lhs, BasicStringRef rhs) {
+    return lhs.data_ == rhs.data_;
+  }
+  friend bool operator!=(BasicStringRef lhs, BasicStringRef rhs) {
+    return lhs.data_ != rhs.data_;
+  }
+  friend bool operator<(BasicStringRef lhs, BasicStringRef rhs) {
+    return std::lexicographical_compare(
+          lhs.data_, lhs.data_ + lhs.size_, rhs.data_, rhs.data_ + rhs.size_);
+  }
+};
+
+typedef BasicStringRef<char> StringRef;
+typedef BasicStringRef<wchar_t> WStringRef;
+
+/**
+  \rst
+  A reference to a null terminated string. It can be constructed from a C
+  string or ``std::string``.
+
+  You can use one of the following typedefs for common character types:
+
+  +-------------+--------------------------+
+  | Type        | Definition               |
+  +=============+==========================+
+  | CStringRef  | BasicCStringRef<char>    |
+  +-------------+--------------------------+
+  | WCStringRef | BasicCStringRef<wchar_t> |
+  +-------------+--------------------------+
+
+  This class is most useful as a parameter type to allow passing
+  different types of strings to a function, for example::
+
+    template <typename... Args>
+    std::string format(CStringRef format_str, const Args & ... args);
+
+    format("{}", 42);
+    format(std::string("{}"), 42);
+  \endrst
+ */
+template <typename Char>
+class BasicCStringRef {
+ private:
+  const Char *data_;
+
+ public:
+  /** Constructs a string reference object from a C string. */
+  BasicCStringRef(const Char *s) : data_(s) {}
+
+  /**
+    \rst
+    Constructs a string reference from an ``std::string`` object.
+    \endrst
+   */
+  BasicCStringRef(const std::basic_string<Char> &s) : data_(s.c_str()) {}
+
+  /** Returns the pointer to a C string. */
+  const Char *c_str() const { return data_; }
+};
+
+typedef BasicCStringRef<char> CStringRef;
+typedef BasicCStringRef<wchar_t> WCStringRef;
+
+/**
+  A formatting error such as invalid format string.
+*/
+class FormatError : public std::runtime_error {
+ public:
+  explicit FormatError(CStringRef message)
+  : std::runtime_error(message.c_str()) {}
+};
+
+namespace internal {
+// The number of characters to store in the MemoryBuffer object itself
+// to avoid dynamic memory allocation.
+enum { INLINE_BUFFER_SIZE = 500 };
+
+#if _SECURE_SCL
+// Use checked iterator to avoid warnings on MSVC.
+template <typename T>
+inline stdext::checked_array_iterator<T*> make_ptr(T *ptr, std::size_t size) {
+  return stdext::checked_array_iterator<T*>(ptr, size);
+}
+#else
+template <typename T>
+inline T *make_ptr(T *ptr, std::size_t) { return ptr; }
+#endif
+}  // namespace internal
+
+/**
+  \rst
+  A buffer supporting a subset of ``std::vector``'s operations.
+  \endrst
+ */
+template <typename T>
+class Buffer {
+ private:
+  FMT_DISALLOW_COPY_AND_ASSIGN(Buffer);
+
+ protected:
+  T *ptr_;
+  std::size_t size_;
+  std::size_t capacity_;
+
+  Buffer(T *ptr = 0, std::size_t capacity = 0)
+    : ptr_(ptr), size_(0), capacity_(capacity) {}
+
+  /**
+    \rst
+    Increases the buffer capacity to hold at least *size* elements updating
+    ``ptr_`` and ``capacity_``.
+    \endrst
+   */
+  virtual void grow(std::size_t size) = 0;
+
+ public:
+  virtual ~Buffer() {}
+
+  /** Returns the size of this buffer. */
+  std::size_t size() const { return size_; }
+
+  /** Returns the capacity of this buffer. */
+  std::size_t capacity() const { return capacity_; }
+
+  /**
+    Resizes the buffer. If T is a POD type new elements may not be initialized.
+   */
+  void resize(std::size_t new_size) {
+    if (new_size > capacity_)
+      grow(new_size);
+    size_ = new_size;
+  }
+
+  /**
+    \rst
+    Reserves space to store at least *capacity* elements.
+    \endrst
+   */
+  void reserve(std::size_t capacity) {
+    if (capacity > capacity_)
+      grow(capacity);
+  }
+
+  void clear() FMT_NOEXCEPT { size_ = 0; }
+
+  void push_back(const T &value) {
+    if (size_ == capacity_)
+      grow(size_ + 1);
+    ptr_[size_++] = value;
+  }
+
+  /** Appends data to the end of the buffer. */
+  template <typename U>
+  void append(const U *begin, const U *end);
+
+  T &operator[](std::size_t index) { return ptr_[index]; }
+  const T &operator[](std::size_t index) const { return ptr_[index]; }
+};
+
+template <typename T>
+template <typename U>
+void Buffer<T>::append(const U *begin, const U *end) {
+  std::ptrdiff_t num_elements = end - begin;
+  if (size_ + num_elements > capacity_)
+    grow(size_ + num_elements);
+  std::copy(begin, end, internal::make_ptr(ptr_, capacity_) + size_);
+  size_ += num_elements;
+}
+
+namespace internal {
+
+// A memory buffer for POD types with the first SIZE elements stored in
+// the object itself.
+template <typename T, std::size_t SIZE, typename Allocator = std::allocator<T> >
+class MemoryBuffer : private Allocator, public Buffer<T> {
+ private:
+  T data_[SIZE];
+
+  // Free memory allocated by the buffer.
+  void free() {
+    if (this->ptr_ != data_) this->deallocate(this->ptr_, this->capacity_);
+  }
+
+ protected:
+  void grow(std::size_t size);
+
+ public:
+  explicit MemoryBuffer(const Allocator &alloc = Allocator())
+      : Allocator(alloc), Buffer<T>(data_, SIZE) {}
+  ~MemoryBuffer() { free(); }
+
+#if FMT_USE_RVALUE_REFERENCES
+ private:
+  // Move data from other to this buffer.
+  void move(MemoryBuffer &other) {
+    Allocator &this_alloc = *this, &other_alloc = other;
+    this_alloc = std::move(other_alloc);
+    this->size_ = other.size_;
+    this->capacity_ = other.capacity_;
+    if (other.ptr_ == other.data_) {
+      this->ptr_ = data_;
+      std::copy(other.data_,
+                other.data_ + this->size_, make_ptr(data_, this->capacity_));
+    } else {
+      this->ptr_ = other.ptr_;
+      // Set pointer to the inline array so that delete is not called
+      // when freeing.
+      other.ptr_ = other.data_;
+    }
+  }
+
+ public:
+  MemoryBuffer(MemoryBuffer &&other) {
+    move(other);
+  }
+
+  MemoryBuffer &operator=(MemoryBuffer &&other) {
+    assert(this != &other);
+    free();
+    move(other);
+    return *this;
+  }
+#endif
+
+  // Returns a copy of the allocator associated with this buffer.
+  Allocator get_allocator() const { return *this; }
+};
+
+template <typename T, std::size_t SIZE, typename Allocator>
+void MemoryBuffer<T, SIZE, Allocator>::grow(std::size_t size) {
+  std::size_t new_capacity =
+      (std::max)(size, this->capacity_ + this->capacity_ / 2);
+  T *new_ptr = this->allocate(new_capacity);
+  // The following code doesn't throw, so the raw pointer above doesn't leak.
+  std::copy(this->ptr_,
+            this->ptr_ + this->size_, make_ptr(new_ptr, new_capacity));
+  std::size_t old_capacity = this->capacity_;
+  T *old_ptr = this->ptr_;
+  this->capacity_ = new_capacity;
+  this->ptr_ = new_ptr;
+  // deallocate may throw (at least in principle), but it doesn't matter since
+  // the buffer already uses the new storage and will deallocate it in case
+  // of exception.
+  if (old_ptr != data_)
+    this->deallocate(old_ptr, old_capacity);
+}
+
+// A fixed-size buffer.
+template <typename Char>
+class FixedBuffer : public fmt::Buffer<Char> {
+ public:
+  FixedBuffer(Char *array, std::size_t size) : fmt::Buffer<Char>(array, size) {}
+
+ protected:
+  void grow(std::size_t size);
+};
+
+#ifndef _MSC_VER
+// Portable version of signbit.
+inline int getsign(double x) {
+  // When compiled in C++11 mode signbit is no longer a macro but a function
+  // defined in namespace std and the macro is undefined.
+# ifdef signbit
+  return signbit(x);
+# else
+  return std::signbit(x);
+# endif
+}
+
+// Portable version of isinf.
+# ifdef isinf
+inline int isinfinity(double x) { return isinf(x); }
+inline int isinfinity(long double x) { return isinf(x); }
+# else
+inline int isinfinity(double x) { return std::isinf(x); }
+inline int isinfinity(long double x) { return std::isinf(x); }
+# endif
+#else
+inline int getsign(double value) {
+  if (value < 0) return 1;
+  if (value == value) return 0;
+  int dec = 0, sign = 0;
+  char buffer[2];  // The buffer size must be >= 2 or _ecvt_s will fail.
+  _ecvt_s(buffer, sizeof(buffer), value, 0, &dec, &sign);
+  return sign;
+}
+inline int isinfinity(double x) { return !_finite(x); }
+inline int isinfinity(long double x) {
+  return !_finite(static_cast<double>(x));
+}
+#endif
+
+template <typename Char>
+class BasicCharTraits {
+ public:
+#if _SECURE_SCL
+  typedef stdext::checked_array_iterator<Char*> CharPtr;
+#else
+  typedef Char *CharPtr;
+#endif
+  static Char cast(wchar_t value) { return static_cast<Char>(value); }
+};
+
+template <typename Char>
+class CharTraits;
+
+template <>
+class CharTraits<char> : public BasicCharTraits<char> {
+ private:
+  // Conversion from wchar_t to char is not allowed.
+  static char convert(wchar_t);
+
+ public:
+  static char convert(char value) { return value; }
+
+  // Formats a floating-point number.
+  template <typename T>
+  static int format_float(char *buffer, std::size_t size,
+      const char *format, unsigned width, int precision, T value);
+};
+
+template <>
+class CharTraits<wchar_t> : public BasicCharTraits<wchar_t> {
+ public:
+  static wchar_t convert(char value) { return value; }
+  static wchar_t convert(wchar_t value) { return value; }
+
+  template <typename T>
+  static int format_float(wchar_t *buffer, std::size_t size,
+      const wchar_t *format, unsigned width, int precision, T value);
+};
+
+// Checks if a number is negative - used to avoid warnings.
+template <bool IsSigned>
+struct SignChecker {
+  template <typename T>
+  static bool is_negative(T value) { return value < 0; }
+};
+
+template <>
+struct SignChecker<false> {
+  template <typename T>
+  static bool is_negative(T) { return false; }
+};
+
+// Returns true if value is negative, false otherwise.
+// Same as (value < 0) but doesn't produce warnings if T is an unsigned type.
+template <typename T>
+inline bool is_negative(T value) {
+  return SignChecker<std::numeric_limits<T>::is_signed>::is_negative(value);
+}
+
+// Selects uint32_t if FitsIn32Bits is true, uint64_t otherwise.
+template <bool FitsIn32Bits>
+struct TypeSelector { typedef uint32_t Type; };
+
+template <>
+struct TypeSelector<false> { typedef uint64_t Type; };
+
+template <typename T>
+struct IntTraits {
+  // Smallest of uint32_t and uint64_t that is large enough to represent
+  // all values of T.
+  typedef typename
+    TypeSelector<std::numeric_limits<T>::digits <= 32>::Type MainType;
+};
+
+// MakeUnsigned<T>::Type gives an unsigned type corresponding to integer type T.
+template <typename T>
+struct MakeUnsigned { typedef T Type; };
+
+#define FMT_SPECIALIZE_MAKE_UNSIGNED(T, U) \
+  template <> \
+  struct MakeUnsigned<T> { typedef U Type; }
+
+FMT_SPECIALIZE_MAKE_UNSIGNED(char, unsigned char);
+FMT_SPECIALIZE_MAKE_UNSIGNED(signed char, unsigned char);
+FMT_SPECIALIZE_MAKE_UNSIGNED(short, unsigned short);
+FMT_SPECIALIZE_MAKE_UNSIGNED(int, unsigned);
+FMT_SPECIALIZE_MAKE_UNSIGNED(long, unsigned long);
+FMT_SPECIALIZE_MAKE_UNSIGNED(LongLong, ULongLong);
+
+void report_unknown_type(char code, const char *type);
+
+// Static data is placed in this class template to allow header-only
+// configuration.
+template <typename T = void>
+struct BasicData {
+  static const uint32_t POWERS_OF_10_32[];
+  static const uint64_t POWERS_OF_10_64[];
+  static const char DIGITS[];
+};
+
+typedef BasicData<> Data;
+
+#if FMT_GCC_VERSION >= 400 || FMT_HAS_BUILTIN(__builtin_clz)
+# define FMT_BUILTIN_CLZ(n) __builtin_clz(n)
+#endif
+
+#if FMT_GCC_VERSION >= 400 || FMT_HAS_BUILTIN(__builtin_clzll)
+# define FMT_BUILTIN_CLZLL(n) __builtin_clzll(n)
+#endif
+
+#ifdef FMT_BUILTIN_CLZLL
+// Returns the number of decimal digits in n. Leading zeros are not counted
+// except for n == 0 in which case count_digits returns 1.
+inline unsigned count_digits(uint64_t n) {
+  // Based on http://graphics.stanford.edu/~seander/bithacks.html#IntegerLog10
+  // and the benchmark https://github.com/localvoid/cxx-benchmark-count-digits.
+  unsigned t = (64 - FMT_BUILTIN_CLZLL(n | 1)) * 1233 >> 12;
+  return t - (n < Data::POWERS_OF_10_64[t]) + 1;
+}
+#else
+// Fallback version of count_digits used when __builtin_clz is not available.
+inline unsigned count_digits(uint64_t n) {
+  unsigned count = 1;
+  for (;;) {
+    // Integer division is slow so do it for a group of four digits instead
+    // of for every digit. The idea comes from the talk by Alexandrescu
+    // "Three Optimization Tips for C++". See speed-test for a comparison.
+    if (n < 10) return count;
+    if (n < 100) return count + 1;
+    if (n < 1000) return count + 2;
+    if (n < 10000) return count + 3;
+    n /= 10000u;
+    count += 4;
+  }
+}
+#endif
+
+#ifdef FMT_BUILTIN_CLZ
+// Optional version of count_digits for better performance on 32-bit platforms.
+inline unsigned count_digits(uint32_t n) {
+  uint32_t t = (32 - FMT_BUILTIN_CLZ(n | 1)) * 1233 >> 12;
+  return t - (n < Data::POWERS_OF_10_32[t]) + 1;
+}
+#endif
+
+// Formats a decimal unsigned integer value writing into buffer.
+template <typename UInt, typename Char>
+inline void format_decimal(Char *buffer, UInt value, unsigned num_digits) {
+  buffer += num_digits;
+  while (value >= 100) {
+    // Integer division is slow so do it for a group of two digits instead
+    // of for every digit. The idea comes from the talk by Alexandrescu
+    // "Three Optimization Tips for C++". See speed-test for a comparison.
+    unsigned index = (value % 100) * 2;
+    value /= 100;
+    *--buffer = Data::DIGITS[index + 1];
+    *--buffer = Data::DIGITS[index];
+  }
+  if (value < 10) {
+    *--buffer = static_cast<char>('0' + value);
+    return;
+  }
+  unsigned index = static_cast<unsigned>(value * 2);
+  *--buffer = Data::DIGITS[index + 1];
+  *--buffer = Data::DIGITS[index];
+}
+
+#ifndef _WIN32
+# define FMT_USE_WINDOWS_H 0
+#elif !defined(FMT_USE_WINDOWS_H)
+# define FMT_USE_WINDOWS_H 1
+#endif
+
+// Define FMT_USE_WINDOWS_H to 0 to disable use of windows.h.
+// All the functionality that relies on it will be disabled too.
+#if FMT_USE_WINDOWS_H
+// A converter from UTF-8 to UTF-16.
+// It is only provided for Windows since other systems support UTF-8 natively.
+class UTF8ToUTF16 {
+ private:
+  MemoryBuffer<wchar_t, INLINE_BUFFER_SIZE> buffer_;
+
+ public:
+  explicit UTF8ToUTF16(StringRef s);
+  operator WStringRef() const { return WStringRef(&buffer_[0], size()); }
+  size_t size() const { return buffer_.size() - 1; }
+  const wchar_t *c_str() const { return &buffer_[0]; }
+  std::wstring str() const { return std::wstring(&buffer_[0], size()); }
+};
+
+// A converter from UTF-16 to UTF-8.
+// It is only provided for Windows since other systems support UTF-8 natively.
+class UTF16ToUTF8 {
+ private:
+  MemoryBuffer<char, INLINE_BUFFER_SIZE> buffer_;
+
+ public:
+  UTF16ToUTF8() {}
+  explicit UTF16ToUTF8(WStringRef s);
+  operator StringRef() const { return StringRef(&buffer_[0], size()); }
+  size_t size() const { return buffer_.size() - 1; }
+  const char *c_str() const { return &buffer_[0]; }
+  std::string str() const { return std::string(&buffer_[0], size()); }
+
+  // Performs conversion returning a system error code instead of
+  // throwing exception on conversion error. This method may still throw
+  // in case of memory allocation error.
+  int convert(WStringRef s);
+};
+
+void format_windows_error(fmt::Writer &out, int error_code,
+                          fmt::StringRef message) FMT_NOEXCEPT;
+#endif
+
+void format_system_error(fmt::Writer &out, int error_code,
+                         fmt::StringRef message) FMT_NOEXCEPT;
+
+// A formatting argument value.
+struct Value {
+  template <typename Char>
+  struct StringValue {
+    const Char *value;
+    std::size_t size;
+  };
+
+  typedef void (*FormatFunc)(
+      void *formatter, const void *arg, void *format_str_ptr);
+
+  struct CustomValue {
+    const void *value;
+    FormatFunc format;
+  };
+
+  union {
+    int int_value;
+    unsigned uint_value;
+    LongLong long_long_value;
+    ULongLong ulong_long_value;
+    double double_value;
+    long double long_double_value;
+    const void *pointer;
+    StringValue<char> string;
+    StringValue<signed char> sstring;
+    StringValue<unsigned char> ustring;
+    StringValue<wchar_t> wstring;
+    CustomValue custom;
+  };
+
+  enum Type {
+    NONE, NAMED_ARG,
+    // Integer types should go first,
+    INT, UINT, LONG_LONG, ULONG_LONG, BOOL, CHAR, LAST_INTEGER_TYPE = CHAR,
+    // followed by floating-point types.
+    DOUBLE, LONG_DOUBLE, LAST_NUMERIC_TYPE = LONG_DOUBLE,
+    CSTRING, STRING, WSTRING, POINTER, CUSTOM
+  };
+};
+
+// A formatting argument. It is a POD type to allow storage in
+// internal::MemoryBuffer.
+struct Arg : Value {
+  Type type;
+};
+
+template <typename Char>
+struct NamedArg;
+
+template <typename T = void>
+struct Null {};
+
+// A helper class template to enable or disable overloads taking wide
+// characters and strings in MakeValue.
+template <typename T, typename Char>
+struct WCharHelper {
+  typedef Null<T> Supported;
+  typedef T Unsupported;
+};
+
+template <typename T>
+struct WCharHelper<T, wchar_t> {
+  typedef T Supported;
+  typedef Null<T> Unsupported;
+};
+
+template <typename T>
+class IsConvertibleToInt {
+ private:
+  typedef char yes[1];
+  typedef char no[2];
+
+  static const T &get();
+
+  static yes &convert(fmt::ULongLong);
+  static no &convert(...);
+  
+ public:
+  enum { value = (sizeof(convert(get())) == sizeof(yes)) };
+};
+
+#define FMT_CONVERTIBLE_TO_INT(Type) \
+  template <> \
+  class IsConvertibleToInt<Type> { \
+   public: \
+    enum { value = 1 }; \
+  }
+
+// Silence warnings about convering float to int.
+FMT_CONVERTIBLE_TO_INT(float);
+FMT_CONVERTIBLE_TO_INT(double);
+FMT_CONVERTIBLE_TO_INT(long double);
+
+template<bool B, class T = void>
+struct EnableIf {};
+
+template<class T>
+struct EnableIf<true, T> { typedef T type; };
+
+template<bool B, class T, class F>
+struct Conditional { typedef T type; };
+
+template<class T, class F>
+struct Conditional<false, T, F> { typedef F type; };
+
+// A helper function to suppress bogus "conditional expression is constant"
+// warnings.
+inline bool check(bool value) { return value; }
+
+// Makes an Arg object from any type.
+template <typename Char>
+class MakeValue : public Arg {
+ private:
+  // The following two methods are private to disallow formatting of
+  // arbitrary pointers. If you want to output a pointer cast it to
+  // "void *" or "const void *". In particular, this forbids formatting
+  // of "[const] volatile char *" which is printed as bool by iostreams.
+  // Do not implement!
+  template <typename T>
+  MakeValue(const T *value);
+  template <typename T>
+  MakeValue(T *value);
+
+  // The following methods are private to disallow formatting of wide
+  // characters and strings into narrow strings as in
+  //   fmt::format("{}", L"test");
+  // To fix this, use a wide format string: fmt::format(L"{}", L"test").
+  MakeValue(typename WCharHelper<wchar_t, Char>::Unsupported);
+  MakeValue(typename WCharHelper<wchar_t *, Char>::Unsupported);
+  MakeValue(typename WCharHelper<const wchar_t *, Char>::Unsupported);
+  MakeValue(typename WCharHelper<const std::wstring &, Char>::Unsupported);
+  MakeValue(typename WCharHelper<WStringRef, Char>::Unsupported);
+
+  void set_string(StringRef str) {
+    string.value = str.data();
+    string.size = str.size();
+  }
+
+  void set_string(WStringRef str) {
+    wstring.value = str.data();
+    wstring.size = str.size();
+  }
+
+  // Formats an argument of a custom type, such as a user-defined class.
+  template <typename T>
+  static void format_custom_arg(
+      void *formatter, const void *arg, void *format_str_ptr) {
+    format(*static_cast<BasicFormatter<Char>*>(formatter),
+           *static_cast<const Char**>(format_str_ptr),
+           *static_cast<const T*>(arg));
+  }
+
+ public:
+  MakeValue() {}
+
+#define FMT_MAKE_VALUE_(Type, field, TYPE, rhs) \
+  MakeValue(Type value) { field = rhs; } \
+  static uint64_t type(Type) { return Arg::TYPE; }
+
+#define FMT_MAKE_VALUE(Type, field, TYPE) \
+  FMT_MAKE_VALUE_(Type, field, TYPE, value)
+
+  FMT_MAKE_VALUE(bool, int_value, BOOL)
+  FMT_MAKE_VALUE(short, int_value, INT)
+  FMT_MAKE_VALUE(unsigned short, uint_value, UINT)
+  FMT_MAKE_VALUE(int, int_value, INT)
+  FMT_MAKE_VALUE(unsigned, uint_value, UINT)
+
+  MakeValue(long value) {
+    // To minimize the number of types we need to deal with, long is
+    // translated either to int or to long long depending on its size.
+    if (check(sizeof(long) == sizeof(int)))
+      int_value = static_cast<int>(value);
+    else
+      long_long_value = value;
+  }
+  static uint64_t type(long) {
+    return sizeof(long) == sizeof(int) ? Arg::INT : Arg::LONG_LONG;
+  }
+
+  MakeValue(unsigned long value) {
+    if (check(sizeof(unsigned long) == sizeof(unsigned)))
+      uint_value = static_cast<unsigned>(value);
+    else
+      ulong_long_value = value;
+  }
+  static uint64_t type(unsigned long) {
+    return sizeof(unsigned long) == sizeof(unsigned) ?
+          Arg::UINT : Arg::ULONG_LONG;
+  }
+
+  FMT_MAKE_VALUE(LongLong, long_long_value, LONG_LONG)
+  FMT_MAKE_VALUE(ULongLong, ulong_long_value, ULONG_LONG)
+  FMT_MAKE_VALUE(float, double_value, DOUBLE)
+  FMT_MAKE_VALUE(double, double_value, DOUBLE)
+  FMT_MAKE_VALUE(long double, long_double_value, LONG_DOUBLE)
+  FMT_MAKE_VALUE(signed char, int_value, CHAR)
+  FMT_MAKE_VALUE(unsigned char, int_value, CHAR)
+  FMT_MAKE_VALUE(char, int_value, CHAR)
+
+  MakeValue(typename WCharHelper<wchar_t, Char>::Supported value) {
+    int_value = value;
+  }
+  static uint64_t type(wchar_t) { return Arg::CHAR; }
+
+#define FMT_MAKE_STR_VALUE(Type, TYPE) \
+  MakeValue(Type value) { set_string(value); } \
+  static uint64_t type(Type) { return Arg::TYPE; }
+
+  FMT_MAKE_VALUE(char *, string.value, CSTRING)
+  FMT_MAKE_VALUE(const char *, string.value, CSTRING)
+  FMT_MAKE_VALUE(const signed char *, sstring.value, CSTRING)
+  FMT_MAKE_VALUE(const unsigned char *, ustring.value, CSTRING)
+  FMT_MAKE_STR_VALUE(const std::string &, STRING)
+  FMT_MAKE_STR_VALUE(StringRef, STRING)
+  FMT_MAKE_VALUE_(CStringRef, string.value, CSTRING, value.c_str())
+
+#define FMT_MAKE_WSTR_VALUE(Type, TYPE) \
+  MakeValue(typename WCharHelper<Type, Char>::Supported value) { \
+    set_string(value); \
+  } \
+  static uint64_t type(Type) { return Arg::TYPE; }
+
+  FMT_MAKE_WSTR_VALUE(wchar_t *, WSTRING)
+  FMT_MAKE_WSTR_VALUE(const wchar_t *, WSTRING)
+  FMT_MAKE_WSTR_VALUE(const std::wstring &, WSTRING)
+  FMT_MAKE_WSTR_VALUE(WStringRef, WSTRING)
+
+  FMT_MAKE_VALUE(void *, pointer, POINTER)
+  FMT_MAKE_VALUE(const void *, pointer, POINTER)
+
+  template <typename T>
+  MakeValue(const T &value,
+            typename EnableIf<!IsConvertibleToInt<T>::value, int>::type = 0) {
+    custom.value = &value;
+    custom.format = &format_custom_arg<T>;
+  }
+
+  template <typename T>
+  MakeValue(const T &value,
+            typename EnableIf<IsConvertibleToInt<T>::value, int>::type = 0) {
+    int_value = value;
+  }
+
+  template <typename T>
+  static uint64_t type(const T &) {
+    return IsConvertibleToInt<T>::value ? Arg::INT : Arg::CUSTOM;
+  }
+
+  // Additional template param `Char_` is needed here because make_type always
+  // uses MakeValue<char>.
+  template <typename Char_>
+  MakeValue(const NamedArg<Char_> &value) { pointer = &value; }
+
+  template <typename Char_>
+  static uint64_t type(const NamedArg<Char_> &) { return Arg::NAMED_ARG; }
+};
+
+template <typename Char>
+struct NamedArg : Arg {
+  BasicStringRef<Char> name;
+
+  template <typename T>
+  NamedArg(BasicStringRef<Char> argname, const T &value)
+  : Arg(MakeValue<Char>(value)), name(argname) {
+    type = static_cast<internal::Arg::Type>(MakeValue<Char>::type(value));
+  }
+};
+
+#define FMT_DISPATCH(call) static_cast<Impl*>(this)->call
+
+// An argument visitor.
+// To use ArgVisitor define a subclass that implements some or all of the
+// visit methods with the same signatures as the methods in ArgVisitor,
+// for example, visit_int(int).
+// Specify the subclass name as the Impl template parameter. Then calling
+// ArgVisitor::visit for some argument will dispatch to a visit method
+// specific to the argument type. For example, if the argument type is
+// double then visit_double(double) method of a subclass will be called.
+// If the subclass doesn't contain a method with this signature, then
+// a corresponding method of ArgVisitor will be called.
+//
+// Example:
+//  class MyArgVisitor : public ArgVisitor<MyArgVisitor, void> {
+//   public:
+//    void visit_int(int value) { print("{}", value); }
+//    void visit_double(double value) { print("{}", value ); }
+//  };
+//
+// ArgVisitor uses the curiously recurring template pattern:
+// http://en.wikipedia.org/wiki/Curiously_recurring_template_pattern
+template <typename Impl, typename Result>
+class ArgVisitor {
+ public:
+  void report_unhandled_arg() {}
+
+  Result visit_unhandled_arg() {
+    FMT_DISPATCH(report_unhandled_arg());
+    return Result();
+  }
+
+  Result visit_int(int value) {
+    return FMT_DISPATCH(visit_any_int(value));
+  }
+  Result visit_long_long(LongLong value) {
+    return FMT_DISPATCH(visit_any_int(value));
+  }
+  Result visit_uint(unsigned value) {
+    return FMT_DISPATCH(visit_any_int(value));
+  }
+  Result visit_ulong_long(ULongLong value) {
+    return FMT_DISPATCH(visit_any_int(value));
+  }
+  Result visit_bool(bool value) {
+    return FMT_DISPATCH(visit_any_int(value));
+  }
+  Result visit_char(int value) {
+    return FMT_DISPATCH(visit_any_int(value));
+  }
+  template <typename T>
+  Result visit_any_int(T) {
+    return FMT_DISPATCH(visit_unhandled_arg());
+  }
+
+  Result visit_double(double value) {
+    return FMT_DISPATCH(visit_any_double(value));
+  }
+  Result visit_long_double(long double value) {
+    return FMT_DISPATCH(visit_any_double(value));
+  }
+  template <typename T>
+  Result visit_any_double(T) {
+    return FMT_DISPATCH(visit_unhandled_arg());
+  }
+
+  Result visit_string(Arg::StringValue<char>) {
+    return FMT_DISPATCH(visit_unhandled_arg());
+  }
+  Result visit_wstring(Arg::StringValue<wchar_t>) {
+    return FMT_DISPATCH(visit_unhandled_arg());
+  }
+  Result visit_pointer(const void *) {
+    return FMT_DISPATCH(visit_unhandled_arg());
+  }
+  Result visit_custom(Arg::CustomValue) {
+    return FMT_DISPATCH(visit_unhandled_arg());
+  }
+
+  Result visit(const Arg &arg) {
+    switch (arg.type) {
+    default:
+      FMT_ASSERT(false, "invalid argument type");
+      return Result();
+    case Arg::INT:
+      return FMT_DISPATCH(visit_int(arg.int_value));
+    case Arg::UINT:
+      return FMT_DISPATCH(visit_uint(arg.uint_value));
+    case Arg::LONG_LONG:
+      return FMT_DISPATCH(visit_long_long(arg.long_long_value));
+    case Arg::ULONG_LONG:
+      return FMT_DISPATCH(visit_ulong_long(arg.ulong_long_value));
+    case Arg::BOOL:
+      return FMT_DISPATCH(visit_bool(arg.int_value != 0));
+    case Arg::CHAR:
+      return FMT_DISPATCH(visit_char(arg.int_value));
+    case Arg::DOUBLE:
+      return FMT_DISPATCH(visit_double(arg.double_value));
+    case Arg::LONG_DOUBLE:
+      return FMT_DISPATCH(visit_long_double(arg.long_double_value));
+    case Arg::CSTRING: {
+      Arg::StringValue<char> str = arg.string;
+      str.size = 0;
+      return FMT_DISPATCH(visit_string(str));
+    }
+    case Arg::STRING:
+      return FMT_DISPATCH(visit_string(arg.string));
+    case Arg::WSTRING:
+      return FMT_DISPATCH(visit_wstring(arg.wstring));
+    case Arg::POINTER:
+      return FMT_DISPATCH(visit_pointer(arg.pointer));
+    case Arg::CUSTOM:
+      return FMT_DISPATCH(visit_custom(arg.custom));
+    }
+  }
+};
+
+class RuntimeError : public std::runtime_error {
+ protected:
+  RuntimeError() : std::runtime_error("") {}
+};
+
+template <typename Impl, typename Char>
+class BasicArgFormatter;
+
+template <typename Char>
+class PrintfArgFormatter;
+
+template <typename Char>
+class ArgMap;
+}  // namespace internal
+
+/** An argument list. */
+class ArgList {
+ private:
+  // To reduce compiled code size per formatting function call, types of first
+  // MAX_PACKED_ARGS arguments are passed in the types_ field.
+  uint64_t types_;
+  union {
+    // If the number of arguments is less than MAX_PACKED_ARGS, the argument
+    // values are stored in values_, otherwise they are stored in args_.
+    // This is done to reduce compiled code size as storing larger objects
+    // may require more code (at least on x86-64) even if the same amount of
+    // data is actually copied to stack. It saves ~10% on the bloat test.
+    const internal::Value *values_;
+    const internal::Arg *args_;
+  };
+
+  internal::Arg::Type type(unsigned index) const {
+    unsigned shift = index * 4;
+    uint64_t mask = 0xf;
+    return static_cast<internal::Arg::Type>(
+          (types_ & (mask << shift)) >> shift);
+  }
+
+  template <typename Char>
+  friend class internal::ArgMap;
+
+ public:
+  // Maximum number of arguments with packed types.
+  enum { MAX_PACKED_ARGS = 16 };
+
+  ArgList() : types_(0) {}
+
+  ArgList(ULongLong types, const internal::Value *values)
+  : types_(types), values_(values) {}
+  ArgList(ULongLong types, const internal::Arg *args)
+  : types_(types), args_(args) {}
+
+  /** Returns the argument at specified index. */
+  internal::Arg operator[](unsigned index) const {
+    using internal::Arg;
+    Arg arg;
+    bool use_values = type(MAX_PACKED_ARGS - 1) == Arg::NONE;
+    if (index < MAX_PACKED_ARGS) {
+      Arg::Type arg_type = type(index);
+      internal::Value &val = arg;
+      if (arg_type != Arg::NONE)
+        val = use_values ? values_[index] : args_[index];
+      arg.type = arg_type;
+      return arg;
+    }
+    if (use_values) {
+      // The index is greater than the number of arguments that can be stored
+      // in values, so return a "none" argument.
+      arg.type = Arg::NONE;
+      return arg;
+    }
+    for (unsigned i = MAX_PACKED_ARGS; i <= index; ++i) {
+      if (args_[i].type == Arg::NONE)
+        return args_[i];
+    }
+    return args_[index];
+  }
+};
+
+struct FormatSpec;
+
+namespace internal {
+
+template <typename Char>
+class ArgMap {
+ private:
+  typedef std::map<fmt::BasicStringRef<Char>, internal::Arg> MapType;
+  typedef typename MapType::value_type Pair;
+
+  MapType map_;
+
+ public:
+  void init(const ArgList &args);
+
+  const internal::Arg* find(const fmt::BasicStringRef<Char> &name) const {
+    typename MapType::const_iterator it = map_.find(name);
+    return it != map_.end() ? &it->second : 0;
+  }
+};
+
+class FormatterBase {
+ private:
+  ArgList args_;
+  int next_arg_index_;
+
+  // Returns the argument with specified index.
+  Arg do_get_arg(unsigned arg_index, const char *&error);
+
+ protected:
+  const ArgList &args() const { return args_; }
+
+  explicit FormatterBase(const ArgList &args) {
+    args_ = args;
+    next_arg_index_ = 0;
+  }
+
+  // Returns the next argument.
+  Arg next_arg(const char *&error);
+
+  // Checks if manual indexing is used and returns the argument with
+  // specified index.
+  Arg get_arg(unsigned arg_index, const char *&error);
+
+  bool check_no_auto_index(const char *&error);
+
+  template <typename Char>
+  void write(BasicWriter<Char> &w, const Char *start, const Char *end) {
+    if (start != end)
+      w << BasicStringRef<Char>(start, end - start);
+  }
+};
+
+// A printf formatter.
+template <typename Char>
+class PrintfFormatter : private FormatterBase {
+ private:
+  void parse_flags(FormatSpec &spec, const Char *&s);
+
+  // Returns the argument with specified index or, if arg_index is equal
+  // to the maximum unsigned value, the next argument.
+  Arg get_arg(const Char *s,
+      unsigned arg_index = (std::numeric_limits<unsigned>::max)());
+
+  // Parses argument index, flags and width and returns the argument index.
+  unsigned parse_header(const Char *&s, FormatSpec &spec);
+
+ public:
+  explicit PrintfFormatter(const ArgList &args) : FormatterBase(args) {}
+  void format(BasicWriter<Char> &writer, BasicCStringRef<Char> format_str);
+};
+}  // namespace internal
+
+// A formatter.
+template <typename Char>
+class BasicFormatter : private internal::FormatterBase {
+ private:
+  BasicWriter<Char> &writer_;
+  internal::ArgMap<Char> map_;
+  
+  FMT_DISALLOW_COPY_AND_ASSIGN(BasicFormatter);
+
+  using FormatterBase::get_arg;
+
+  // Checks if manual indexing is used and returns the argument with
+  // specified name.
+  internal::Arg get_arg(BasicStringRef<Char> arg_name, const char *&error);
+
+  // Parses argument index and returns corresponding argument.
+  internal::Arg parse_arg_index(const Char *&s);
+
+  // Parses argument name and returns corresponding argument.
+  internal::Arg parse_arg_name(const Char *&s);
+
+ public:
+  BasicFormatter(const ArgList &args, BasicWriter<Char> &w)
+    : FormatterBase(args), writer_(w) {}
+
+  BasicWriter<Char> &writer() { return writer_; }
+
+  void format(BasicCStringRef<Char> format_str);
+
+  const Char *format(const Char *&format_str, const internal::Arg &arg);
+};
+
+enum Alignment {
+  ALIGN_DEFAULT, ALIGN_LEFT, ALIGN_RIGHT, ALIGN_CENTER, ALIGN_NUMERIC
+};
+
+// Flags.
+enum {
+  SIGN_FLAG = 1, PLUS_FLAG = 2, MINUS_FLAG = 4, HASH_FLAG = 8,
+  CHAR_FLAG = 0x10  // Argument has char type - used in error reporting.
+};
+
+// An empty format specifier.
+struct EmptySpec {};
+
+// A type specifier.
+template <char TYPE>
+struct TypeSpec : EmptySpec {
+  Alignment align() const { return ALIGN_DEFAULT; }
+  unsigned width() const { return 0; }
+  int precision() const { return -1; }
+  bool flag(unsigned) const { return false; }
+  char type() const { return TYPE; }
+  char fill() const { return ' '; }
+};
+
+// A width specifier.
+struct WidthSpec {
+  unsigned width_;
+  // Fill is always wchar_t and cast to char if necessary to avoid having
+  // two specialization of WidthSpec and its subclasses.
+  wchar_t fill_;
+
+  WidthSpec(unsigned width, wchar_t fill) : width_(width), fill_(fill) {}
+
+  unsigned width() const { return width_; }
+  wchar_t fill() const { return fill_; }
+};
+
+// An alignment specifier.
+struct AlignSpec : WidthSpec {
+  Alignment align_;
+
+  AlignSpec(unsigned width, wchar_t fill, Alignment align = ALIGN_DEFAULT)
+  : WidthSpec(width, fill), align_(align) {}
+
+  Alignment align() const { return align_; }
+
+  int precision() const { return -1; }
+};
+
+// An alignment and type specifier.
+template <char TYPE>
+struct AlignTypeSpec : AlignSpec {
+  AlignTypeSpec(unsigned width, wchar_t fill) : AlignSpec(width, fill) {}
+
+  bool flag(unsigned) const { return false; }
+  char type() const { return TYPE; }
+};
+
+// A full format specifier.
+struct FormatSpec : AlignSpec {
+  unsigned flags_;
+  int precision_;
+  char type_;
+
+  FormatSpec(
+    unsigned width = 0, char type = 0, wchar_t fill = ' ')
+  : AlignSpec(width, fill), flags_(0), precision_(-1), type_(type) {}
+
+  bool flag(unsigned f) const { return (flags_ & f) != 0; }
+  int precision() const { return precision_; }
+  char type() const { return type_; }
+};
+
+// An integer format specifier.
+template <typename T, typename SpecT = TypeSpec<0>, typename Char = char>
+class IntFormatSpec : public SpecT {
+ private:
+  T value_;
+
+ public:
+  IntFormatSpec(T val, const SpecT &spec = SpecT())
+  : SpecT(spec), value_(val) {}
+
+  T value() const { return value_; }
+};
+
+// A string format specifier.
+template <typename Char>
+class StrFormatSpec : public AlignSpec {
+ private:
+  const Char *str_;
+
+ public:
+  template <typename FillChar>
+  StrFormatSpec(const Char *str, unsigned width, FillChar fill)
+  : AlignSpec(width, fill), str_(str) {
+    internal::CharTraits<Char>::convert(FillChar());
+  }
+
+  const Char *str() const { return str_; }
+};
+
+/**
+  Returns an integer format specifier to format the value in base 2.
+ */
+IntFormatSpec<int, TypeSpec<'b'> > bin(int value);
+
+/**
+  Returns an integer format specifier to format the value in base 8.
+ */
+IntFormatSpec<int, TypeSpec<'o'> > oct(int value);
+
+/**
+  Returns an integer format specifier to format the value in base 16 using
+  lower-case letters for the digits above 9.
+ */
+IntFormatSpec<int, TypeSpec<'x'> > hex(int value);
+
+/**
+  Returns an integer formatter format specifier to format in base 16 using
+  upper-case letters for the digits above 9.
+ */
+IntFormatSpec<int, TypeSpec<'X'> > hexu(int value);
+
+/**
+  \rst
+  Returns an integer format specifier to pad the formatted argument with the
+  fill character to the specified width using the default (right) numeric
+  alignment.
+
+  **Example**::
+
+    MemoryWriter out;
+    out << pad(hex(0xcafe), 8, '0');
+    // out.str() == "0000cafe"
+
+  \endrst
+ */
+template <char TYPE_CODE, typename Char>
+IntFormatSpec<int, AlignTypeSpec<TYPE_CODE>, Char> pad(
+    int value, unsigned width, Char fill = ' ');
+
+#define FMT_DEFINE_INT_FORMATTERS(TYPE) \
+inline IntFormatSpec<TYPE, TypeSpec<'b'> > bin(TYPE value) { \
+  return IntFormatSpec<TYPE, TypeSpec<'b'> >(value, TypeSpec<'b'>()); \
+} \
+ \
+inline IntFormatSpec<TYPE, TypeSpec<'o'> > oct(TYPE value) { \
+  return IntFormatSpec<TYPE, TypeSpec<'o'> >(value, TypeSpec<'o'>()); \
+} \
+ \
+inline IntFormatSpec<TYPE, TypeSpec<'x'> > hex(TYPE value) { \
+  return IntFormatSpec<TYPE, TypeSpec<'x'> >(value, TypeSpec<'x'>()); \
+} \
+ \
+inline IntFormatSpec<TYPE, TypeSpec<'X'> > hexu(TYPE value) { \
+  return IntFormatSpec<TYPE, TypeSpec<'X'> >(value, TypeSpec<'X'>()); \
+} \
+ \
+template <char TYPE_CODE> \
+inline IntFormatSpec<TYPE, AlignTypeSpec<TYPE_CODE> > pad( \
+    IntFormatSpec<TYPE, TypeSpec<TYPE_CODE> > f, unsigned width) { \
+  return IntFormatSpec<TYPE, AlignTypeSpec<TYPE_CODE> >( \
+      f.value(), AlignTypeSpec<TYPE_CODE>(width, ' ')); \
+} \
+ \
+/* For compatibility with older compilers we provide two overloads for pad, */ \
+/* one that takes a fill character and one that doesn't. In the future this */ \
+/* can be replaced with one overload making the template argument Char      */ \
+/* default to char (C++11). */ \
+template <char TYPE_CODE, typename Char> \
+inline IntFormatSpec<TYPE, AlignTypeSpec<TYPE_CODE>, Char> pad( \
+    IntFormatSpec<TYPE, TypeSpec<TYPE_CODE>, Char> f, \
+    unsigned width, Char fill) { \
+  return IntFormatSpec<TYPE, AlignTypeSpec<TYPE_CODE>, Char>( \
+      f.value(), AlignTypeSpec<TYPE_CODE>(width, fill)); \
+} \
+ \
+inline IntFormatSpec<TYPE, AlignTypeSpec<0> > pad( \
+    TYPE value, unsigned width) { \
+  return IntFormatSpec<TYPE, AlignTypeSpec<0> >( \
+      value, AlignTypeSpec<0>(width, ' ')); \
+} \
+ \
+template <typename Char> \
+inline IntFormatSpec<TYPE, AlignTypeSpec<0>, Char> pad( \
+   TYPE value, unsigned width, Char fill) { \
+ return IntFormatSpec<TYPE, AlignTypeSpec<0>, Char>( \
+     value, AlignTypeSpec<0>(width, fill)); \
+}
+
+FMT_DEFINE_INT_FORMATTERS(int)
+FMT_DEFINE_INT_FORMATTERS(long)
+FMT_DEFINE_INT_FORMATTERS(unsigned)
+FMT_DEFINE_INT_FORMATTERS(unsigned long)
+FMT_DEFINE_INT_FORMATTERS(LongLong)
+FMT_DEFINE_INT_FORMATTERS(ULongLong)
+
+/**
+  \rst
+  Returns a string formatter that pads the formatted argument with the fill
+  character to the specified width using the default (left) string alignment.
+
+  **Example**::
+
+    std::string s = str(MemoryWriter() << pad("abc", 8));
+    // s == "abc     "
+
+  \endrst
+ */
+template <typename Char>
+inline StrFormatSpec<Char> pad(
+    const Char *str, unsigned width, Char fill = ' ') {
+  return StrFormatSpec<Char>(str, width, fill);
+}
+
+inline StrFormatSpec<wchar_t> pad(
+    const wchar_t *str, unsigned width, char fill = ' ') {
+  return StrFormatSpec<wchar_t>(str, width, fill);
+}
+
+// Generates a comma-separated list with results of applying f to
+// numbers 0..n-1.
+# define FMT_GEN(n, f) FMT_GEN##n(f)
+# define FMT_GEN1(f)  f(0)
+# define FMT_GEN2(f)  FMT_GEN1(f),  f(1)
+# define FMT_GEN3(f)  FMT_GEN2(f),  f(2)
+# define FMT_GEN4(f)  FMT_GEN3(f),  f(3)
+# define FMT_GEN5(f)  FMT_GEN4(f),  f(4)
+# define FMT_GEN6(f)  FMT_GEN5(f),  f(5)
+# define FMT_GEN7(f)  FMT_GEN6(f),  f(6)
+# define FMT_GEN8(f)  FMT_GEN7(f),  f(7)
+# define FMT_GEN9(f)  FMT_GEN8(f),  f(8)
+# define FMT_GEN10(f) FMT_GEN9(f),  f(9)
+# define FMT_GEN11(f) FMT_GEN10(f), f(10)
+# define FMT_GEN12(f) FMT_GEN11(f), f(11)
+# define FMT_GEN13(f) FMT_GEN12(f), f(12)
+# define FMT_GEN14(f) FMT_GEN13(f), f(13)
+# define FMT_GEN15(f) FMT_GEN14(f), f(14)
+
+namespace internal {
+inline uint64_t make_type() { return 0; }
+
+template <typename T>
+inline uint64_t make_type(const T &arg) { return MakeValue<char>::type(arg); }
+
+template <unsigned N>
+struct ArgArray {
+  // Computes the argument array size by adding 1 to N, which is the number of
+  // arguments, if N is zero, because array of zero size is invalid, or if N
+  // is greater than ArgList::MAX_PACKED_ARGS to accommodate for an extra
+  // argument that marks the end of the list.
+  enum { SIZE = N + (N == 0 || N >= ArgList::MAX_PACKED_ARGS ? 1 : 0) };
+
+  typedef typename Conditional<
+    (N < ArgList::MAX_PACKED_ARGS), Value, Arg>::type Type[SIZE];
+};
+
+#if FMT_USE_VARIADIC_TEMPLATES
+template <typename Arg, typename... Args>
+inline uint64_t make_type(const Arg &first, const Args & ... tail) {
+  return make_type(first) | (make_type(tail...) << 4);
+}
+
+inline void do_set_types(Arg *) {}
+
+template <typename T, typename... Args>
+inline void do_set_types(Arg *args, const T &arg, const Args & ... tail) {
+  args->type = static_cast<Arg::Type>(MakeValue<T>::type(arg));
+  do_set_types(args + 1, tail...);
+}
+
+template <typename... Args>
+inline void set_types(Arg *array, const Args & ... args) {
+  if (check(sizeof...(Args) > ArgList::MAX_PACKED_ARGS))
+    do_set_types(array, args...);
+  array[sizeof...(Args)].type = Arg::NONE;
+}
+
+template <typename... Args>
+inline void set_types(Value *, const Args & ...) {
+  // Do nothing as types are passed separately from values.
+}
+
+template <typename Char, typename Value>
+inline void store_args(Value *) {}
+
+template <typename Char, typename Arg, typename T, typename... Args>
+inline void store_args(Arg *args, const T &arg, const Args & ... tail) {
+  // Assign only the Value subobject of Arg and don't overwrite type (if any)
+  // that is assigned by set_types.
+  Value &value = *args;
+  value = MakeValue<Char>(arg);
+  store_args<Char>(args + 1, tail...);
+}
+
+template <typename Char, typename... Args>
+ArgList make_arg_list(typename ArgArray<sizeof...(Args)>::Type array,
+                      const Args & ... args) {
+  if (check(sizeof...(Args) >= ArgList::MAX_PACKED_ARGS))
+    set_types(array, args...);
+  store_args<Char>(array, args...);
+  return ArgList(make_type(args...), array);
+}
+#else
+
+struct ArgType {
+  uint64_t type;
+
+  ArgType() : type(0) {}
+
+  template <typename T>
+  ArgType(const T &arg) : type(make_type(arg)) {}
+};
+
+# define FMT_ARG_TYPE_DEFAULT(n) ArgType t##n = ArgType()
+
+inline uint64_t make_type(FMT_GEN15(FMT_ARG_TYPE_DEFAULT)) {
+  return t0.type | (t1.type << 4) | (t2.type << 8) | (t3.type << 12) |
+      (t4.type << 16) | (t5.type << 20) | (t6.type << 24) | (t7.type << 28) |
+      (t8.type << 32) | (t9.type << 36) | (t10.type << 40) | (t11.type << 44) |
+      (t12.type << 48) | (t13.type << 52) | (t14.type << 56);
+}
+#endif
+}  // namespace internal
+
+# define FMT_MAKE_TEMPLATE_ARG(n) typename T##n
+# define FMT_MAKE_ARG_TYPE(n) T##n
+# define FMT_MAKE_ARG(n) const T##n &v##n
+# define FMT_MAKE_REF_char(n) fmt::internal::MakeValue<char>(v##n)
+# define FMT_MAKE_REF_wchar_t(n) fmt::internal::MakeValue<wchar_t>(v##n)
+
+#if FMT_USE_VARIADIC_TEMPLATES
+// Defines a variadic function returning void.
+# define FMT_VARIADIC_VOID(func, arg_type) \
+  template <typename... Args> \
+  void func(arg_type arg0, const Args & ... args) { \
+    typename fmt::internal::ArgArray<sizeof...(Args)>::Type array; \
+    func(arg0, fmt::internal::make_arg_list<Char>(array, args...)); \
+  }
+
+// Defines a variadic constructor.
+# define FMT_VARIADIC_CTOR(ctor, func, arg0_type, arg1_type) \
+  template <typename... Args> \
+  ctor(arg0_type arg0, arg1_type arg1, const Args & ... args) { \
+    typename fmt::internal::ArgArray<sizeof...(Args)>::Type array; \
+    func(arg0, arg1, fmt::internal::make_arg_list<Char>(array, args...)); \
+  }
+
+#else
+
+# define FMT_MAKE_REF(n) fmt::internal::MakeValue<Char>(v##n)
+# define FMT_MAKE_REF2(n) v##n
+
+// Defines a wrapper for a function taking one argument of type arg_type
+// and n additional arguments of arbitrary types.
+# define FMT_WRAP1(func, arg_type, n) \
+  template <FMT_GEN(n, FMT_MAKE_TEMPLATE_ARG)> \
+  inline void func(arg_type arg1, FMT_GEN(n, FMT_MAKE_ARG)) { \
+    const fmt::internal::ArgArray<n>::Type array = {FMT_GEN(n, FMT_MAKE_REF)}; \
+    func(arg1, fmt::ArgList( \
+      fmt::internal::make_type(FMT_GEN(n, FMT_MAKE_REF2)), array)); \
+  }
+
+// Emulates a variadic function returning void on a pre-C++11 compiler.
+# define FMT_VARIADIC_VOID(func, arg_type) \
+  inline void func(arg_type arg) { func(arg, fmt::ArgList()); } \
+  FMT_WRAP1(func, arg_type, 1) FMT_WRAP1(func, arg_type, 2) \
+  FMT_WRAP1(func, arg_type, 3) FMT_WRAP1(func, arg_type, 4) \
+  FMT_WRAP1(func, arg_type, 5) FMT_WRAP1(func, arg_type, 6) \
+  FMT_WRAP1(func, arg_type, 7) FMT_WRAP1(func, arg_type, 8) \
+  FMT_WRAP1(func, arg_type, 9) FMT_WRAP1(func, arg_type, 10)
+
+# define FMT_CTOR(ctor, func, arg0_type, arg1_type, n) \
+  template <FMT_GEN(n, FMT_MAKE_TEMPLATE_ARG)> \
+  ctor(arg0_type arg0, arg1_type arg1, FMT_GEN(n, FMT_MAKE_ARG)) { \
+    const fmt::internal::ArgArray<n>::Type array = {FMT_GEN(n, FMT_MAKE_REF)}; \
+    func(arg0, arg1, fmt::ArgList( \
+      fmt::internal::make_type(FMT_GEN(n, FMT_MAKE_REF2)), array)); \
+  }
+
+// Emulates a variadic constructor on a pre-C++11 compiler.
+# define FMT_VARIADIC_CTOR(ctor, func, arg0_type, arg1_type) \
+  FMT_CTOR(ctor, func, arg0_type, arg1_type, 1) \
+  FMT_CTOR(ctor, func, arg0_type, arg1_type, 2) \
+  FMT_CTOR(ctor, func, arg0_type, arg1_type, 3) \
+  FMT_CTOR(ctor, func, arg0_type, arg1_type, 4) \
+  FMT_CTOR(ctor, func, arg0_type, arg1_type, 5) \
+  FMT_CTOR(ctor, func, arg0_type, arg1_type, 6) \
+  FMT_CTOR(ctor, func, arg0_type, arg1_type, 7) \
+  FMT_CTOR(ctor, func, arg0_type, arg1_type, 8) \
+  FMT_CTOR(ctor, func, arg0_type, arg1_type, 9) \
+  FMT_CTOR(ctor, func, arg0_type, arg1_type, 10)
+#endif
+
+// Generates a comma-separated list with results of applying f to pairs
+// (argument, index).
+#define FMT_FOR_EACH1(f, x0) f(x0, 0)
+#define FMT_FOR_EACH2(f, x0, x1) \
+  FMT_FOR_EACH1(f, x0), f(x1, 1)
+#define FMT_FOR_EACH3(f, x0, x1, x2) \
+  FMT_FOR_EACH2(f, x0 ,x1), f(x2, 2)
+#define FMT_FOR_EACH4(f, x0, x1, x2, x3) \
+  FMT_FOR_EACH3(f, x0, x1, x2), f(x3, 3)
+#define FMT_FOR_EACH5(f, x0, x1, x2, x3, x4) \
+  FMT_FOR_EACH4(f, x0, x1, x2, x3), f(x4, 4)
+#define FMT_FOR_EACH6(f, x0, x1, x2, x3, x4, x5) \
+  FMT_FOR_EACH5(f, x0, x1, x2, x3, x4), f(x5, 5)
+#define FMT_FOR_EACH7(f, x0, x1, x2, x3, x4, x5, x6) \
+  FMT_FOR_EACH6(f, x0, x1, x2, x3, x4, x5), f(x6, 6)
+#define FMT_FOR_EACH8(f, x0, x1, x2, x3, x4, x5, x6, x7) \
+  FMT_FOR_EACH7(f, x0, x1, x2, x3, x4, x5, x6), f(x7, 7)
+#define FMT_FOR_EACH9(f, x0, x1, x2, x3, x4, x5, x6, x7, x8) \
+  FMT_FOR_EACH8(f, x0, x1, x2, x3, x4, x5, x6, x7), f(x8, 8)
+#define FMT_FOR_EACH10(f, x0, x1, x2, x3, x4, x5, x6, x7, x8, x9) \
+  FMT_FOR_EACH9(f, x0, x1, x2, x3, x4, x5, x6, x7, x8), f(x9, 9)
+
+/**
+ An error returned by an operating system or a language runtime,
+ for example a file opening error.
+*/
+class SystemError : public internal::RuntimeError {
+ private:
+  void init(int err_code, CStringRef format_str, ArgList args);
+
+ protected:
+  int error_code_;
+
+  typedef char Char;  // For FMT_VARIADIC_CTOR.
+
+  SystemError() {}
+
+ public:
+  /**
+   \rst
+   Constructs a :class:`fmt::SystemError` object with the description
+   of the form
+
+   .. parsed-literal::
+     *<message>*: *<system-message>*
+
+   where *<message>* is the formatted message and *<system-message>* is
+   the system message corresponding to the error code.
+   *error_code* is a system error code as given by ``errno``.
+   If *error_code* is not a valid error code such as -1, the system message
+   may look like "Unknown error -1" and is platform-dependent.
+   
+   **Example**::
+
+     // This throws a SystemError with the description
+     //   cannot open file 'madeup': No such file or directory
+     // or similar (system message may vary).
+     const char *filename = "madeup";
+     std::FILE *file = std::fopen(filename, "r");
+     if (!file)
+       throw fmt::SystemError(errno, "cannot open file '{}'", filename);
+   \endrst
+  */
+  SystemError(int error_code, CStringRef message) {
+    init(error_code, message, ArgList());
+  }
+  FMT_VARIADIC_CTOR(SystemError, init, int, CStringRef)
+
+  int error_code() const { return error_code_; }
+};
+
+/**
+  \rst
+  This template provides operations for formatting and writing data into
+  a character stream. The output is stored in a buffer provided by a subclass
+  such as :class:`fmt::BasicMemoryWriter`.
+
+  You can use one of the following typedefs for common character types:
+
+  +---------+----------------------+
+  | Type    | Definition           |
+  +=========+======================+
+  | Writer  | BasicWriter<char>    |
+  +---------+----------------------+
+  | WWriter | BasicWriter<wchar_t> |
+  +---------+----------------------+
+
+  \endrst
+ */
+template <typename Char>
+class BasicWriter {
+ private:
+  // Output buffer.
+  Buffer<Char> &buffer_;
+
+  FMT_DISALLOW_COPY_AND_ASSIGN(BasicWriter);
+
+  typedef typename internal::CharTraits<Char>::CharPtr CharPtr;
+
+#if _SECURE_SCL
+  // Returns pointer value.
+  static Char *get(CharPtr p) { return p.base(); }
+#else
+  static Char *get(Char *p) { return p; }
+#endif
+
+  // Fills the padding around the content and returns the pointer to the
+  // content area.
+  static CharPtr fill_padding(CharPtr buffer,
+      unsigned total_size, std::size_t content_size, wchar_t fill);
+
+  // Grows the buffer by n characters and returns a pointer to the newly
+  // allocated area.
+  CharPtr grow_buffer(std::size_t n) {
+    std::size_t size = buffer_.size();
+    buffer_.resize(size + n);
+    return internal::make_ptr(&buffer_[size], n);
+  }
+
+  // Writes an unsigned decimal integer.
+  template <typename UInt>
+  Char *write_unsigned_decimal(UInt value, unsigned prefix_size = 0) {
+    unsigned num_digits = internal::count_digits(value);
+    Char *ptr = get(grow_buffer(prefix_size + num_digits));
+    internal::format_decimal(ptr + prefix_size, value, num_digits);
+    return ptr;
+  }
+
+  // Writes a decimal integer.
+  template <typename Int>
+  void write_decimal(Int value) {
+    typename internal::IntTraits<Int>::MainType abs_value = value;
+    if (internal::is_negative(value)) {
+      abs_value = 0 - abs_value;
+      *write_unsigned_decimal(abs_value, 1) = '-';
+    } else {
+      write_unsigned_decimal(abs_value, 0);
+    }
+  }
+
+  // Prepare a buffer for integer formatting.
+  CharPtr prepare_int_buffer(unsigned num_digits,
+      const EmptySpec &, const char *prefix, unsigned prefix_size) {
+    unsigned size = prefix_size + num_digits;
+    CharPtr p = grow_buffer(size);
+    std::copy(prefix, prefix + prefix_size, p);
+    return p + size - 1;
+  }
+
+  template <typename Spec>
+  CharPtr prepare_int_buffer(unsigned num_digits,
+    const Spec &spec, const char *prefix, unsigned prefix_size);
+
+  // Formats an integer.
+  template <typename T, typename Spec>
+  void write_int(T value, Spec spec);
+
+  // Formats a floating-point number (double or long double).
+  template <typename T>
+  void write_double(T value, const FormatSpec &spec);
+
+  // Writes a formatted string.
+  template <typename StrChar>
+  CharPtr write_str(
+      const StrChar *s, std::size_t size, const AlignSpec &spec);
+
+  template <typename StrChar>
+  void write_str(
+      const internal::Arg::StringValue<StrChar> &str, const FormatSpec &spec);
+
+  // This following methods are private to disallow writing wide characters
+  // and strings to a char stream. If you want to print a wide string as a
+  // pointer as std::ostream does, cast it to const void*.
+  // Do not implement!
+  void operator<<(typename internal::WCharHelper<wchar_t, Char>::Unsupported);
+  void operator<<(
+      typename internal::WCharHelper<const wchar_t *, Char>::Unsupported);
+
+  // Appends floating-point length specifier to the format string.
+  // The second argument is only used for overload resolution.
+  void append_float_length(Char *&format_ptr, long double) {
+    *format_ptr++ = 'L';
+  }
+
+  template<typename T>
+  void append_float_length(Char *&, T) {}
+
+  template <typename Impl, typename Char_>
+  friend class internal::BasicArgFormatter;
+
+  friend class internal::PrintfArgFormatter<Char>;
+
+ protected:
+  /**
+    Constructs a ``BasicWriter`` object.
+   */
+  explicit BasicWriter(Buffer<Char> &b) : buffer_(b) {}
+
+ public:
+  /**
+    \rst
+    Destroys a ``BasicWriter`` object.
+    \endrst
+   */
+  virtual ~BasicWriter() {}
+
+  /**
+    Returns the total number of characters written.
+   */
+  std::size_t size() const { return buffer_.size(); }
+
+  /**
+    Returns a pointer to the output buffer content. No terminating null
+    character is appended.
+   */
+  const Char *data() const FMT_NOEXCEPT { return &buffer_[0]; }
+
+  /**
+    Returns a pointer to the output buffer content with terminating null
+    character appended.
+   */
+  const Char *c_str() const {
+    std::size_t size = buffer_.size();
+    buffer_.reserve(size + 1);
+    buffer_[size] = '\0';
+    return &buffer_[0];
+  }
+
+  /**
+    \rst
+    Returns the content of the output buffer as an `std::string`.
+    \endrst
+   */
+  std::basic_string<Char> str() const {
+    return std::basic_string<Char>(&buffer_[0], buffer_.size());
+  }
+
+  /**
+    \rst
+    Writes formatted data.
+    
+    *args* is an argument list representing arbitrary arguments.
+
+    **Example**::
+
+       MemoryWriter out;
+       out.write("Current point:\n");
+       out.write("({:+f}, {:+f})", -3.14, 3.14);
+
+    This will write the following output to the ``out`` object:
+
+    .. code-block:: none
+
+       Current point:
+       (-3.140000, +3.140000)
+
+    The output can be accessed using :func:`data()`, :func:`c_str` or
+    :func:`str` methods.
+
+    See also :ref:`syntax`.
+    \endrst
+   */
+  void write(BasicCStringRef<Char> format, ArgList args) {
+    BasicFormatter<Char>(args, *this).format(format);
+  }
+  FMT_VARIADIC_VOID(write, BasicCStringRef<Char>)
+
+  BasicWriter &operator<<(int value) {
+    write_decimal(value);
+    return *this;
+  }
+  BasicWriter &operator<<(unsigned value) {
+    return *this << IntFormatSpec<unsigned>(value);
+  }
+  BasicWriter &operator<<(long value) {
+    write_decimal(value);
+    return *this;
+  }
+  BasicWriter &operator<<(unsigned long value) {
+    return *this << IntFormatSpec<unsigned long>(value);
+  }
+  BasicWriter &operator<<(LongLong value) {
+    write_decimal(value);
+    return *this;
+  }
+
+  /**
+    \rst
+    Formats *value* and writes it to the stream.
+    \endrst
+   */
+  BasicWriter &operator<<(ULongLong value) {
+    return *this << IntFormatSpec<ULongLong>(value);
+  }
+
+  BasicWriter &operator<<(double value) {
+    write_double(value, FormatSpec());
+    return *this;
+  }
+
+  /**
+    \rst
+    Formats *value* using the general format for floating-point numbers
+    (``'g'``) and writes it to the stream.
+    \endrst
+   */
+  BasicWriter &operator<<(long double value) {
+    write_double(value, FormatSpec());
+    return *this;
+  }
+
+  /**
+    Writes a character to the stream.
+   */
+  BasicWriter &operator<<(char value) {
+    buffer_.push_back(value);
+    return *this;
+  }
+
+  BasicWriter &operator<<(
+      typename internal::WCharHelper<wchar_t, Char>::Supported value) {
+    buffer_.push_back(value);
+    return *this;
+  }
+
+  /**
+    \rst
+    Writes *value* to the stream.
+    \endrst
+   */
+  BasicWriter &operator<<(fmt::BasicStringRef<Char> value) {
+    const Char *str = value.data();
+    buffer_.append(str, str + value.size());
+    return *this;
+  }
+
+  BasicWriter &operator<<(
+      typename internal::WCharHelper<StringRef, Char>::Supported value) {
+    const char *str = value.data();
+    buffer_.append(str, str + value.size());
+    return *this;
+  }
+
+  template <typename T, typename Spec, typename FillChar>
+  BasicWriter &operator<<(IntFormatSpec<T, Spec, FillChar> spec) {
+    internal::CharTraits<Char>::convert(FillChar());
+    write_int(spec.value(), spec);
+    return *this;
+  }
+
+  template <typename StrChar>
+  BasicWriter &operator<<(const StrFormatSpec<StrChar> &spec) {
+    const StrChar *s = spec.str();
+    write_str(s, std::char_traits<Char>::length(s), spec);
+    return *this;
+  }
+
+  void clear() FMT_NOEXCEPT { buffer_.clear(); }
+};
+
+template <typename Char>
+template <typename StrChar>
+typename BasicWriter<Char>::CharPtr BasicWriter<Char>::write_str(
+      const StrChar *s, std::size_t size, const AlignSpec &spec) {
+  CharPtr out = CharPtr();
+  if (spec.width() > size) {
+    out = grow_buffer(spec.width());
+    Char fill = internal::CharTraits<Char>::cast(spec.fill());
+    if (spec.align() == ALIGN_RIGHT) {
+      std::fill_n(out, spec.width() - size, fill);
+      out += spec.width() - size;
+    } else if (spec.align() == ALIGN_CENTER) {
+      out = fill_padding(out, spec.width(), size, fill);
+    } else {
+      std::fill_n(out + size, spec.width() - size, fill);
+    }
+  } else {
+    out = grow_buffer(size);
+  }
+  std::copy(s, s + size, out);
+  return out;
+}
+
+template <typename Char>
+typename BasicWriter<Char>::CharPtr
+  BasicWriter<Char>::fill_padding(
+    CharPtr buffer, unsigned total_size,
+    std::size_t content_size, wchar_t fill) {
+  std::size_t padding = total_size - content_size;
+  std::size_t left_padding = padding / 2;
+  Char fill_char = internal::CharTraits<Char>::cast(fill);
+  std::fill_n(buffer, left_padding, fill_char);
+  buffer += left_padding;
+  CharPtr content = buffer;
+  std::fill_n(buffer + content_size, padding - left_padding, fill_char);
+  return content;
+}
+
+template <typename Char>
+template <typename Spec>
+typename BasicWriter<Char>::CharPtr
+  BasicWriter<Char>::prepare_int_buffer(
+    unsigned num_digits, const Spec &spec,
+    const char *prefix, unsigned prefix_size) {
+  unsigned width = spec.width();
+  Alignment align = spec.align();
+  Char fill = internal::CharTraits<Char>::cast(spec.fill());
+  if (spec.precision() > static_cast<int>(num_digits)) {
+    // Octal prefix '0' is counted as a digit, so ignore it if precision
+    // is specified.
+    if (prefix_size > 0 && prefix[prefix_size - 1] == '0')
+      --prefix_size;
+    unsigned number_size = prefix_size + spec.precision();
+    AlignSpec subspec(number_size, '0', ALIGN_NUMERIC);
+    if (number_size >= width)
+      return prepare_int_buffer(num_digits, subspec, prefix, prefix_size);
+    buffer_.reserve(width);
+    unsigned fill_size = width - number_size;
+    if (align != ALIGN_LEFT) {
+      CharPtr p = grow_buffer(fill_size);
+      std::fill(p, p + fill_size, fill);
+    }
+    CharPtr result = prepare_int_buffer(
+        num_digits, subspec, prefix, prefix_size);
+    if (align == ALIGN_LEFT) {
+      CharPtr p = grow_buffer(fill_size);
+      std::fill(p, p + fill_size, fill);
+    }
+    return result;
+  }
+  unsigned size = prefix_size + num_digits;
+  if (width <= size) {
+    CharPtr p = grow_buffer(size);
+    std::copy(prefix, prefix + prefix_size, p);
+    return p + size - 1;
+  }
+  CharPtr p = grow_buffer(width);
+  CharPtr end = p + width;
+  if (align == ALIGN_LEFT) {
+    std::copy(prefix, prefix + prefix_size, p);
+    p += size;
+    std::fill(p, end, fill);
+  } else if (align == ALIGN_CENTER) {
+    p = fill_padding(p, width, size, fill);
+    std::copy(prefix, prefix + prefix_size, p);
+    p += size;
+  } else {
+    if (align == ALIGN_NUMERIC) {
+      if (prefix_size != 0) {
+        p = std::copy(prefix, prefix + prefix_size, p);
+        size -= prefix_size;
+      }
+    } else {
+      std::copy(prefix, prefix + prefix_size, end - size);
+    }
+    std::fill(p, end - size, fill);
+    p = end;
+  }
+  return p - 1;
+}
+
+template <typename Char>
+template <typename T, typename Spec>
+void BasicWriter<Char>::write_int(T value, Spec spec) {
+  unsigned prefix_size = 0;
+  typedef typename internal::IntTraits<T>::MainType UnsignedType;
+  UnsignedType abs_value = value;
+  char prefix[4] = "";
+  if (internal::is_negative(value)) {
+    prefix[0] = '-';
+    ++prefix_size;
+    abs_value = 0 - abs_value;
+  } else if (spec.flag(SIGN_FLAG)) {
+    prefix[0] = spec.flag(PLUS_FLAG) ? '+' : ' ';
+    ++prefix_size;
+  }
+  switch (spec.type()) {
+  case 0: case 'd': {
+    unsigned num_digits = internal::count_digits(abs_value);
+    CharPtr p = prepare_int_buffer(
+      num_digits, spec, prefix, prefix_size) + 1 - num_digits;
+    internal::format_decimal(get(p), abs_value, num_digits);
+    break;
+  }
+  case 'x': case 'X': {
+    UnsignedType n = abs_value;
+    if (spec.flag(HASH_FLAG)) {
+      prefix[prefix_size++] = '0';
+      prefix[prefix_size++] = spec.type();
+    }
+    unsigned num_digits = 0;
+    do {
+      ++num_digits;
+    } while ((n >>= 4) != 0);
+    Char *p = get(prepare_int_buffer(
+      num_digits, spec, prefix, prefix_size));
+    n = abs_value;
+    const char *digits = spec.type() == 'x' ?
+        "0123456789abcdef" : "0123456789ABCDEF";
+    do {
+      *p-- = digits[n & 0xf];
+    } while ((n >>= 4) != 0);
+    break;
+  }
+  case 'b': case 'B': {
+    UnsignedType n = abs_value;
+    if (spec.flag(HASH_FLAG)) {
+      prefix[prefix_size++] = '0';
+      prefix[prefix_size++] = spec.type();
+    }
+    unsigned num_digits = 0;
+    do {
+      ++num_digits;
+    } while ((n >>= 1) != 0);
+    Char *p = get(prepare_int_buffer(num_digits, spec, prefix, prefix_size));
+    n = abs_value;
+    do {
+      *p-- = '0' + (n & 1);
+    } while ((n >>= 1) != 0);
+    break;
+  }
+  case 'o': {
+    UnsignedType n = abs_value;
+    if (spec.flag(HASH_FLAG))
+      prefix[prefix_size++] = '0';
+    unsigned num_digits = 0;
+    do {
+      ++num_digits;
+    } while ((n >>= 3) != 0);
+    Char *p = get(prepare_int_buffer(num_digits, spec, prefix, prefix_size));
+    n = abs_value;
+    do {
+      *p-- = '0' + (n & 7);
+    } while ((n >>= 3) != 0);
+    break;
+  }
+  default:
+    internal::report_unknown_type(
+      spec.type(), spec.flag(CHAR_FLAG) ? "char" : "integer");
+    break;
+  }
+}
+
+template <typename Char>
+template <typename T>
+void BasicWriter<Char>::write_double(
+    T value, const FormatSpec &spec) {
+  // Check type.
+  char type = spec.type();
+  bool upper = false;
+  switch (type) {
+  case 0:
+    type = 'g';
+    break;
+  case 'e': case 'f': case 'g': case 'a':
+    break;
+  case 'F':
+#ifdef _MSC_VER
+    // MSVC's printf doesn't support 'F'.
+    type = 'f';
+#endif
+    // Fall through.
+  case 'E': case 'G': case 'A':
+    upper = true;
+    break;
+  default:
+    internal::report_unknown_type(type, "double");
+    break;
+  }
+
+  char sign = 0;
+  // Use getsign instead of value < 0 because the latter is always
+  // false for NaN.
+  if (internal::getsign(static_cast<double>(value))) {
+    sign = '-';
+    value = -value;
+  } else if (spec.flag(SIGN_FLAG)) {
+    sign = spec.flag(PLUS_FLAG) ? '+' : ' ';
+  }
+
+  if (value != value) {
+    // Format NaN ourselves because sprintf's output is not consistent
+    // across platforms.
+    std::size_t nan_size = 4;
+    const char *nan = upper ? " NAN" : " nan";
+    if (!sign) {
+      --nan_size;
+      ++nan;
+    }
+    CharPtr out = write_str(nan, nan_size, spec);
+    if (sign)
+      *out = sign;
+    return;
+  }
+
+  if (internal::isinfinity(value)) {
+    // Format infinity ourselves because sprintf's output is not consistent
+    // across platforms.
+    std::size_t inf_size = 4;
+    const char *inf = upper ? " INF" : " inf";
+    if (!sign) {
+      --inf_size;
+      ++inf;
+    }
+    CharPtr out = write_str(inf, inf_size, spec);
+    if (sign)
+      *out = sign;
+    return;
+  }
+
+  std::size_t offset = buffer_.size();
+  unsigned width = spec.width();
+  if (sign) {
+    buffer_.reserve(buffer_.size() + (std::max)(width, 1u));
+    if (width > 0)
+      --width;
+    ++offset;
+  }
+
+  // Build format string.
+  enum { MAX_FORMAT_SIZE = 10}; // longest format: %#-*.*Lg
+  Char format[MAX_FORMAT_SIZE];
+  Char *format_ptr = format;
+  *format_ptr++ = '%';
+  unsigned width_for_sprintf = width;
+  if (spec.flag(HASH_FLAG))
+    *format_ptr++ = '#';
+  if (spec.align() == ALIGN_CENTER) {
+    width_for_sprintf = 0;
+  } else {
+    if (spec.align() == ALIGN_LEFT)
+      *format_ptr++ = '-';
+    if (width != 0)
+      *format_ptr++ = '*';
+  }
+  if (spec.precision() >= 0) {
+    *format_ptr++ = '.';
+    *format_ptr++ = '*';
+  }
+
+  append_float_length(format_ptr, value);
+  *format_ptr++ = type;
+  *format_ptr = '\0';
+
+  // Format using snprintf.
+  Char fill = internal::CharTraits<Char>::cast(spec.fill());
+  for (;;) {
+    std::size_t buffer_size = buffer_.capacity() - offset;
+#if _MSC_VER
+    // MSVC's vsnprintf_s doesn't work with zero size, so reserve
+    // space for at least one extra character to make the size non-zero.
+    // Note that the buffer's capacity will increase by more than 1.
+    if (buffer_size == 0) {
+      buffer_.reserve(offset + 1);
+      buffer_size = buffer_.capacity() - offset;
+    }
+#endif
+    Char *start = &buffer_[offset];
+    int n = internal::CharTraits<Char>::format_float(
+        start, buffer_size, format, width_for_sprintf, spec.precision(), value);
+    if (n >= 0 && offset + n < buffer_.capacity()) {
+      if (sign) {
+        if ((spec.align() != ALIGN_RIGHT && spec.align() != ALIGN_DEFAULT) ||
+            *start != ' ') {
+          *(start - 1) = sign;
+          sign = 0;
+        } else {
+          *(start - 1) = fill;
+        }
+        ++n;
+      }
+      if (spec.align() == ALIGN_CENTER &&
+          spec.width() > static_cast<unsigned>(n)) {
+        width = spec.width();
+        CharPtr p = grow_buffer(width);
+        std::copy(p, p + n, p + (width - n) / 2);
+        fill_padding(p, spec.width(), n, fill);
+        return;
+      }
+      if (spec.fill() != ' ' || sign) {
+        while (*start == ' ')
+          *start++ = fill;
+        if (sign)
+          *(start - 1) = sign;
+      }
+      grow_buffer(n);
+      return;
+    }
+    // If n is negative we ask to increase the capacity by at least 1,
+    // but as std::vector, the buffer grows exponentially.
+    buffer_.reserve(n >= 0 ? offset + n + 1 : buffer_.capacity() + 1);
+  }
+}
+
+/**
+  \rst
+  This class template provides operations for formatting and writing data
+  into a character stream. The output is stored in a memory buffer that grows
+  dynamically.
+
+  You can use one of the following typedefs for common character types
+  and the standard allocator:
+
+  +---------------+-----------------------------------------------------+
+  | Type          | Definition                                          |
+  +===============+=====================================================+
+  | MemoryWriter  | BasicMemoryWriter<char, std::allocator<char>>       |
+  +---------------+-----------------------------------------------------+
+  | WMemoryWriter | BasicMemoryWriter<wchar_t, std::allocator<wchar_t>> |
+  +---------------+-----------------------------------------------------+
+
+  **Example**::
+
+     MemoryWriter out;
+     out << "The answer is " << 42 << "\n";
+     out.write("({:+f}, {:+f})", -3.14, 3.14);
+
+  This will write the following output to the ``out`` object:
+
+  .. code-block:: none
+
+     The answer is 42
+     (-3.140000, +3.140000)
+
+  The output can be converted to an ``std::string`` with ``out.str()`` or
+  accessed as a C string with ``out.c_str()``.
+  \endrst
+ */
+template <typename Char, typename Allocator = std::allocator<Char> >
+class BasicMemoryWriter : public BasicWriter<Char> {
+ private:
+  internal::MemoryBuffer<Char, internal::INLINE_BUFFER_SIZE, Allocator> buffer_;
+
+ public:
+  explicit BasicMemoryWriter(const Allocator& alloc = Allocator())
+    : BasicWriter<Char>(buffer_), buffer_(alloc) {}
+
+#if FMT_USE_RVALUE_REFERENCES
+  /**
+    \rst
+    Constructs a :class:`fmt::BasicMemoryWriter` object moving the content
+    of the other object to it.
+    \endrst
+   */
+  BasicMemoryWriter(BasicMemoryWriter &&other)
+    : BasicWriter<Char>(buffer_), buffer_(std::move(other.buffer_)) {
+  }
+
+  /**
+    \rst
+    Moves the content of the other ``BasicMemoryWriter`` object to this one.
+    \endrst
+   */
+  BasicMemoryWriter &operator=(BasicMemoryWriter &&other) {
+    buffer_ = std::move(other.buffer_);
+    return *this;
+  }
+#endif
+};
+
+typedef BasicMemoryWriter<char> MemoryWriter;
+typedef BasicMemoryWriter<wchar_t> WMemoryWriter;
+
+/**
+  \rst
+  This class template provides operations for formatting and writing data
+  into a fixed-size array. For writing into a dynamically growing buffer
+  use :class:`fmt::BasicMemoryWriter`.
+  
+  Any write method will throw ``std::runtime_error`` if the output doesn't fit
+  into the array.
+
+  You can use one of the following typedefs for common character types:
+
+  +--------------+---------------------------+
+  | Type         | Definition                |
+  +==============+===========================+
+  | ArrayWriter  | BasicArrayWriter<char>    |
+  +--------------+---------------------------+
+  | WArrayWriter | BasicArrayWriter<wchar_t> |
+  +--------------+---------------------------+
+  \endrst
+ */
+template <typename Char>
+class BasicArrayWriter : public BasicWriter<Char> {
+ private:
+  internal::FixedBuffer<Char> buffer_;
+
+ public:
+  /**
+   \rst
+   Constructs a :class:`fmt::BasicArrayWriter` object for *array* of the
+   given size.
+   \endrst
+   */
+  BasicArrayWriter(Char *array, std::size_t size)
+    : BasicWriter<Char>(buffer_), buffer_(array, size) {}
+
+  /**
+   \rst
+   Constructs a :class:`fmt::BasicArrayWriter` object for *array* of the
+   size known at compile time.
+   \endrst
+   */
+  template <std::size_t SIZE>
+  explicit BasicArrayWriter(Char (&array)[SIZE])
+    : BasicWriter<Char>(buffer_), buffer_(array, SIZE) {}
+};
+
+typedef BasicArrayWriter<char> ArrayWriter;
+typedef BasicArrayWriter<wchar_t> WArrayWriter;
+
+// Formats a value.
+template <typename Char, typename T>
+void format(BasicFormatter<Char> &f, const Char *&format_str, const T &value) {
+  std::basic_ostringstream<Char> os;
+  os << value;
+  std::basic_string<Char> str = os.str();
+  internal::Arg arg = internal::MakeValue<Char>(str);
+  arg.type = static_cast<internal::Arg::Type>(
+        internal::MakeValue<Char>::type(str));
+  format_str = f.format(format_str, arg);
+}
+
+// Reports a system error without throwing an exception.
+// Can be used to report errors from destructors.
+void report_system_error(int error_code, StringRef message) FMT_NOEXCEPT;
+
+#if FMT_USE_WINDOWS_H
+
+/** A Windows error. */
+class WindowsError : public SystemError {
+ private:
+  void init(int error_code, CStringRef format_str, ArgList args);
+
+ public:
+  /**
+   \rst
+   Constructs a :class:`fmt::WindowsError` object with the description
+   of the form
+
+   .. parsed-literal::
+     *<message>*: *<system-message>*
+
+   where *<message>* is the formatted message and *<system-message>* is the
+   system message corresponding to the error code.
+   *error_code* is a Windows error code as given by ``GetLastError``.
+   If *error_code* is not a valid error code such as -1, the system message
+   will look like "error -1".
+
+   **Example**::
+
+     // This throws a WindowsError with the description
+     //   cannot open file 'madeup': The system cannot find the file specified.
+     // or similar (system message may vary).
+     const char *filename = "madeup";
+     LPOFSTRUCT of = LPOFSTRUCT();
+     HFILE file = OpenFile(filename, &of, OF_READ);
+     if (file == HFILE_ERROR) {
+       throw fmt::WindowsError(GetLastError(),
+                               "cannot open file '{}'", filename);
+     }
+   \endrst
+  */
+  WindowsError(int error_code, CStringRef message) {
+    init(error_code, message, ArgList());
+  }
+  FMT_VARIADIC_CTOR(WindowsError, init, int, CStringRef)
+};
+
+// Reports a Windows error without throwing an exception.
+// Can be used to report errors from destructors.
+void report_windows_error(int error_code, StringRef message) FMT_NOEXCEPT;
+
+#endif
+
+enum Color { BLACK, RED, GREEN, YELLOW, BLUE, MAGENTA, CYAN, WHITE };
+
+/**
+  Formats a string and prints it to stdout using ANSI escape sequences
+  to specify color (experimental).
+  Example:
+    PrintColored(fmt::RED, "Elapsed time: {0:.2f} seconds") << 1.23;
+ */
+void print_colored(Color c, CStringRef format, ArgList args);
+
+/**
+  \rst
+  Formats arguments and returns the result as a string.
+
+  **Example**::
+
+    std::string message = format("The answer is {}", 42);
+  \endrst
+*/
+inline std::string format(CStringRef format_str, ArgList args) {
+  MemoryWriter w;
+  w.write(format_str, args);
+  return w.str();
+}
+
+inline std::wstring format(WCStringRef format_str, ArgList args) {
+  WMemoryWriter w;
+  w.write(format_str, args);
+  return w.str();
+}
+
+/**
+  \rst
+  Prints formatted data to the file *f*.
+
+  **Example**::
+
+    print(stderr, "Don't {}!", "panic");
+  \endrst
+ */
+void print(std::FILE *f, CStringRef format_str, ArgList args);
+
+/**
+  \rst
+  Prints formatted data to ``stdout``.
+
+  **Example**::
+
+    print("Elapsed time: {0:.2f} seconds", 1.23);
+  \endrst
+ */
+void print(CStringRef format_str, ArgList args);
+
+/**
+  \rst
+  Prints formatted data to the stream *os*.
+
+  **Example**::
+
+    print(cerr, "Don't {}!", "panic");
+  \endrst
+ */
+void print(std::ostream &os, CStringRef format_str, ArgList args);
+
+template <typename Char>
+void printf(BasicWriter<Char> &w, BasicCStringRef<Char> format, ArgList args) {
+  internal::PrintfFormatter<Char>(args).format(w, format);
+}
+
+/**
+  \rst
+  Formats arguments and returns the result as a string.
+
+  **Example**::
+
+    std::string message = fmt::sprintf("The answer is %d", 42);
+  \endrst
+*/
+inline std::string sprintf(CStringRef format, ArgList args) {
+  MemoryWriter w;
+  printf(w, format, args);
+  return w.str();
+}
+
+/**
+  \rst
+  Prints formatted data to the file *f*.
+
+  **Example**::
+
+    fmt::fprintf(stderr, "Don't %s!", "panic");
+  \endrst
+ */
+int fprintf(std::FILE *f, CStringRef format, ArgList args);
+
+/**
+  \rst
+  Prints formatted data to ``stdout``.
+
+  **Example**::
+
+    fmt::printf("Elapsed time: %.2f seconds", 1.23);
+  \endrst
+ */
+inline int printf(CStringRef format, ArgList args) {
+  return fprintf(stdout, format, args);
+}
+
+/**
+  Fast integer formatter.
+ */
+class FormatInt {
+ private:
+  // Buffer should be large enough to hold all digits (digits10 + 1),
+  // a sign and a null character.
+  enum {BUFFER_SIZE = std::numeric_limits<ULongLong>::digits10 + 3};
+  mutable char buffer_[BUFFER_SIZE];
+  char *str_;
+
+  // Formats value in reverse and returns the number of digits.
+  char *format_decimal(ULongLong value) {
+    char *buffer_end = buffer_ + BUFFER_SIZE - 1;
+    while (value >= 100) {
+      // Integer division is slow so do it for a group of two digits instead
+      // of for every digit. The idea comes from the talk by Alexandrescu
+      // "Three Optimization Tips for C++". See speed-test for a comparison.
+      unsigned index = (value % 100) * 2;
+      value /= 100;
+      *--buffer_end = internal::Data::DIGITS[index + 1];
+      *--buffer_end = internal::Data::DIGITS[index];
+    }
+    if (value < 10) {
+      *--buffer_end = static_cast<char>('0' + value);
+      return buffer_end;
+    }
+    unsigned index = static_cast<unsigned>(value * 2);
+    *--buffer_end = internal::Data::DIGITS[index + 1];
+    *--buffer_end = internal::Data::DIGITS[index];
+    return buffer_end;
+  }
+
+  void FormatSigned(LongLong value) {
+    ULongLong abs_value = static_cast<ULongLong>(value);
+    bool negative = value < 0;
+    if (negative)
+      abs_value = 0 - abs_value;
+    str_ = format_decimal(abs_value);
+    if (negative)
+      *--str_ = '-';
+  }
+
+ public:
+  explicit FormatInt(int value) { FormatSigned(value); }
+  explicit FormatInt(long value) { FormatSigned(value); }
+  explicit FormatInt(LongLong value) { FormatSigned(value); }
+  explicit FormatInt(unsigned value) : str_(format_decimal(value)) {}
+  explicit FormatInt(unsigned long value) : str_(format_decimal(value)) {}
+  explicit FormatInt(ULongLong value) : str_(format_decimal(value)) {}
+
+  /**
+    Returns the number of characters written to the output buffer.
+   */
+  std::size_t size() const { return buffer_ - str_ + BUFFER_SIZE - 1; }
+
+  /**
+    Returns a pointer to the output buffer content. No terminating null
+    character is appended.
+   */
+  const char *data() const { return str_; }
+
+  /**
+    Returns a pointer to the output buffer content with terminating null
+    character appended.
+   */
+  const char *c_str() const {
+    buffer_[BUFFER_SIZE - 1] = '\0';
+    return str_;
+  }
+
+  /**
+    \rst
+    Returns the content of the output buffer as an ``std::string``.
+    \endrst
+   */
+  std::string str() const { return std::string(str_, size()); }
+};
+
+// Formats a decimal integer value writing into buffer and returns
+// a pointer to the end of the formatted string. This function doesn't
+// write a terminating null character.
+template <typename T>
+inline void format_decimal(char *&buffer, T value) {
+  typename internal::IntTraits<T>::MainType abs_value = value;
+  if (internal::is_negative(value)) {
+    *buffer++ = '-';
+    abs_value = 0 - abs_value;
+  }
+  if (abs_value < 100) {
+    if (abs_value < 10) {
+      *buffer++ = static_cast<char>('0' + abs_value);
+      return;
+    }
+    unsigned index = static_cast<unsigned>(abs_value * 2);
+    *buffer++ = internal::Data::DIGITS[index];
+    *buffer++ = internal::Data::DIGITS[index + 1];
+    return;
+  }
+  unsigned num_digits = internal::count_digits(abs_value);
+  internal::format_decimal(buffer, abs_value, num_digits);
+  buffer += num_digits;
+}
+
+/**
+  \rst
+  Returns a named argument for formatting functions.
+
+  **Example**::
+
+    print("Elapsed time: {s:.2f} seconds", arg("s", 1.23));
+
+  \endrst
+ */
+template <typename T>
+inline internal::NamedArg<char> arg(StringRef name, const T &arg) {
+  return internal::NamedArg<char>(name, arg);
+}
+
+template <typename T>
+inline internal::NamedArg<wchar_t> arg(WStringRef name, const T &arg) {
+  return internal::NamedArg<wchar_t>(name, arg);
+}
+
+// The following two functions are deleted intentionally to disable
+// nested named arguments as in ``format("{}", arg("a", arg("b", 42)))``.
+template <typename Char>
+void arg(StringRef, const internal::NamedArg<Char>&) FMT_DELETED_OR_UNDEFINED;
+template <typename Char>
+void arg(WStringRef, const internal::NamedArg<Char>&) FMT_DELETED_OR_UNDEFINED;
+}
+
+#if FMT_GCC_VERSION
+// Use the system_header pragma to suppress warnings about variadic macros
+// because suppressing -Wvariadic-macros with the diagnostic pragma doesn't
+// work. It is used at the end because we want to suppress as little warnings
+// as possible.
+# pragma GCC system_header
+#endif
+
+// This is used to work around VC++ bugs in handling variadic macros.
+#define FMT_EXPAND(args) args
+
+// Returns the number of arguments.
+// Based on https://groups.google.com/forum/#!topic/comp.std.c/d-6Mj5Lko_s.
+#define FMT_NARG(...) FMT_NARG_(__VA_ARGS__, FMT_RSEQ_N())
+#define FMT_NARG_(...) FMT_EXPAND(FMT_ARG_N(__VA_ARGS__))
+#define FMT_ARG_N(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, N, ...) N
+#define FMT_RSEQ_N() 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0
+
+#define FMT_CONCAT(a, b) a##b
+#define FMT_FOR_EACH_(N, f, ...) \
+  FMT_EXPAND(FMT_CONCAT(FMT_FOR_EACH, N)(f, __VA_ARGS__))
+#define FMT_FOR_EACH(f, ...) \
+  FMT_EXPAND(FMT_FOR_EACH_(FMT_NARG(__VA_ARGS__), f, __VA_ARGS__))
+
+#define FMT_ADD_ARG_NAME(type, index) type arg##index
+#define FMT_GET_ARG_NAME(type, index) arg##index
+
+#if FMT_USE_VARIADIC_TEMPLATES
+# define FMT_VARIADIC_(Char, ReturnType, func, call, ...) \
+  template <typename... Args> \
+  ReturnType func(FMT_FOR_EACH(FMT_ADD_ARG_NAME, __VA_ARGS__), \
+      const Args & ... args) { \
+    typename fmt::internal::ArgArray<sizeof...(Args)>::Type array; \
+    call(FMT_FOR_EACH(FMT_GET_ARG_NAME, __VA_ARGS__), \
+      fmt::internal::make_arg_list<Char>(array, args...)); \
+  }
+#else
+// Defines a wrapper for a function taking __VA_ARGS__ arguments
+// and n additional arguments of arbitrary types.
+# define FMT_WRAP(Char, ReturnType, func, call, n, ...) \
+  template <FMT_GEN(n, FMT_MAKE_TEMPLATE_ARG)> \
+  inline ReturnType func(FMT_FOR_EACH(FMT_ADD_ARG_NAME, __VA_ARGS__), \
+      FMT_GEN(n, FMT_MAKE_ARG)) { \
+    fmt::internal::ArgArray<n>::Type arr = {FMT_GEN(n, FMT_MAKE_REF_##Char)}; \
+    call(FMT_FOR_EACH(FMT_GET_ARG_NAME, __VA_ARGS__), fmt::ArgList( \
+      fmt::internal::make_type(FMT_GEN(n, FMT_MAKE_REF2)), arr)); \
+  }
+
+# define FMT_VARIADIC_(Char, ReturnType, func, call, ...) \
+  inline ReturnType func(FMT_FOR_EACH(FMT_ADD_ARG_NAME, __VA_ARGS__)) { \
+    call(FMT_FOR_EACH(FMT_GET_ARG_NAME, __VA_ARGS__), fmt::ArgList()); \
+  } \
+  FMT_WRAP(Char, ReturnType, func, call, 1, __VA_ARGS__) \
+  FMT_WRAP(Char, ReturnType, func, call, 2, __VA_ARGS__) \
+  FMT_WRAP(Char, ReturnType, func, call, 3, __VA_ARGS__) \
+  FMT_WRAP(Char, ReturnType, func, call, 4, __VA_ARGS__) \
+  FMT_WRAP(Char, ReturnType, func, call, 5, __VA_ARGS__) \
+  FMT_WRAP(Char, ReturnType, func, call, 6, __VA_ARGS__) \
+  FMT_WRAP(Char, ReturnType, func, call, 7, __VA_ARGS__) \
+  FMT_WRAP(Char, ReturnType, func, call, 8, __VA_ARGS__) \
+  FMT_WRAP(Char, ReturnType, func, call, 9, __VA_ARGS__) \
+  FMT_WRAP(Char, ReturnType, func, call, 10, __VA_ARGS__) \
+  FMT_WRAP(Char, ReturnType, func, call, 11, __VA_ARGS__) \
+  FMT_WRAP(Char, ReturnType, func, call, 12, __VA_ARGS__) \
+  FMT_WRAP(Char, ReturnType, func, call, 13, __VA_ARGS__) \
+  FMT_WRAP(Char, ReturnType, func, call, 14, __VA_ARGS__) \
+  FMT_WRAP(Char, ReturnType, func, call, 15, __VA_ARGS__)
+#endif  // FMT_USE_VARIADIC_TEMPLATES
+
+/**
+  \rst
+  Defines a variadic function with the specified return type, function name
+  and argument types passed as variable arguments to this macro.
+
+  **Example**::
+
+    void print_error(const char *file, int line, const char *format,
+                     fmt::ArgList args) {
+      fmt::print("{}: {}: ", file, line);
+      fmt::print(format, args);
+    }
+    FMT_VARIADIC(void, print_error, const char *, int, const char *)
+
+  ``FMT_VARIADIC`` is used for compatibility with legacy C++ compilers that
+  don't implement variadic templates. You don't have to use this macro if
+  you don't need legacy compiler support and can use variadic templates
+  directly::
+
+    template <typename... Args>
+    void print_error(const char *file, int line, const char *format,
+                     const Args & ... args) {
+      fmt::print("{}: {}: ", file, line);
+      fmt::print(format, args...);
+    }
+  \endrst
+ */
+#define FMT_VARIADIC(ReturnType, func, ...) \
+  FMT_VARIADIC_(char, ReturnType, func, return func, __VA_ARGS__)
+
+#define FMT_VARIADIC_W(ReturnType, func, ...) \
+  FMT_VARIADIC_(wchar_t, ReturnType, func, return func, __VA_ARGS__)
+
+#define FMT_CAPTURE_ARG_(id, index) ::fmt::arg(#id, id)
+
+#define FMT_CAPTURE_ARG_W_(id, index) ::fmt::arg(L###id, id)
+
+/**
+  \rst
+  Convenient macro to capture the arguments' names and values into several
+  ``fmt::arg(name, value)``.
+
+  **Example**::
+
+    int x = 1, y = 2;
+    print("point: ({x}, {y})", FMT_CAPTURE(x, y));
+    // same as:
+    // print("point: ({x}, {y})", arg("x", x), arg("y", y));
+
+  \endrst
+ */
+#define FMT_CAPTURE(...) FMT_FOR_EACH(FMT_CAPTURE_ARG_, __VA_ARGS__)
+
+#define FMT_CAPTURE_W(...) FMT_FOR_EACH(FMT_CAPTURE_ARG_W_, __VA_ARGS__)
+
+namespace fmt {
+FMT_VARIADIC(std::string, format, CStringRef)
+FMT_VARIADIC_W(std::wstring, format, WCStringRef)
+FMT_VARIADIC(void, print, CStringRef)
+FMT_VARIADIC(void, print, std::FILE *, CStringRef)
+FMT_VARIADIC(void, print, std::ostream &, CStringRef)
+FMT_VARIADIC(void, print_colored, Color, CStringRef)
+FMT_VARIADIC(std::string, sprintf, CStringRef)
+FMT_VARIADIC(int, printf, CStringRef)
+FMT_VARIADIC(int, fprintf, std::FILE *, CStringRef)
+}
+
+// Restore warnings.
+#if FMT_GCC_VERSION >= 406
+# pragma GCC diagnostic pop
+#endif
+
+#ifdef __clang__
+# pragma clang diagnostic pop
+#endif
+
+#ifdef FMT_HEADER_ONLY
+# include "format.cc"
+#endif
+
+#endif  // FMT_FORMAT_H_

--- a/xbmc/contrib/cppformat/posix.cc
+++ b/xbmc/contrib/cppformat/posix.cc
@@ -1,0 +1,253 @@
+/*
+ A C++ interface to POSIX functions.
+
+ Copyright (c) 2014 - 2015, Victor Zverovich
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Disable bogus MSVC warnings.
+#ifndef _CRT_SECURE_NO_WARNINGS
+# define _CRT_SECURE_NO_WARNINGS
+#endif
+
+#include "posix.h"
+
+#include <limits.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+
+#ifndef _WIN32
+# include <unistd.h>
+#else
+# include <windows.h>
+# include <io.h>
+
+# define O_CREAT _O_CREAT
+# define O_TRUNC _O_TRUNC
+
+# ifndef S_IRUSR
+#  define S_IRUSR _S_IREAD
+# endif
+
+# ifndef S_IWUSR
+#  define S_IWUSR _S_IWRITE
+# endif
+
+# ifdef __MINGW32__
+#  define _SH_DENYNO 0x40
+#  undef fileno
+# endif
+
+#endif  // _WIN32
+
+namespace {
+#ifdef _WIN32
+// Return type of read and write functions.
+typedef int RWResult;
+
+// On Windows the count argument to read and write is unsigned, so convert
+// it from size_t preventing integer overflow.
+inline unsigned convert_rwcount(std::size_t count) {
+  return count <= UINT_MAX ? static_cast<unsigned>(count) : UINT_MAX;
+}
+#else
+// Return type of read and write functions.
+typedef ssize_t RWResult;
+
+inline std::size_t convert_rwcount(std::size_t count) { return count; }
+#endif
+}
+
+fmt::BufferedFile::~BufferedFile() FMT_NOEXCEPT {
+  if (file_ && FMT_SYSTEM(fclose(file_)) != 0)
+    fmt::report_system_error(errno, "cannot close file");
+}
+
+fmt::BufferedFile::BufferedFile(
+    fmt::CStringRef filename, fmt::CStringRef mode) {
+  FMT_RETRY_VAL(file_, FMT_SYSTEM(fopen(filename.c_str(), mode.c_str())), 0);
+  if (!file_)
+    throw SystemError(errno, "cannot open file {}", filename);
+}
+
+void fmt::BufferedFile::close() {
+  if (!file_)
+    return;
+  int result = FMT_SYSTEM(fclose(file_));
+  file_ = 0;
+  if (result != 0)
+    throw SystemError(errno, "cannot close file");
+}
+
+// A macro used to prevent expansion of fileno on broken versions of MinGW.
+#define FMT_ARGS
+
+int fmt::BufferedFile::fileno() const {
+  int fd = FMT_POSIX_CALL(fileno FMT_ARGS(file_));
+  if (fd == -1)
+    throw SystemError(errno, "cannot get file descriptor");
+  return fd;
+}
+
+fmt::File::File(fmt::CStringRef path, int oflag) {
+  int mode = S_IRUSR | S_IWUSR;
+#if defined(_WIN32) && !defined(__MINGW32__)
+  fd_ = -1;
+  FMT_POSIX_CALL(sopen_s(&fd_, path.c_str(), oflag, _SH_DENYNO, mode));
+#else
+  FMT_RETRY(fd_, FMT_POSIX_CALL(open(path.c_str(), oflag, mode)));
+#endif
+  if (fd_ == -1)
+    throw SystemError(errno, "cannot open file {}", path);
+}
+
+fmt::File::~File() FMT_NOEXCEPT {
+  // Don't retry close in case of EINTR!
+  // See http://linux.derkeiler.com/Mailing-Lists/Kernel/2005-09/3000.html
+  if (fd_ != -1 && FMT_POSIX_CALL(close(fd_)) != 0)
+    fmt::report_system_error(errno, "cannot close file");
+}
+
+void fmt::File::close() {
+  if (fd_ == -1)
+    return;
+  // Don't retry close in case of EINTR!
+  // See http://linux.derkeiler.com/Mailing-Lists/Kernel/2005-09/3000.html
+  int result = FMT_POSIX_CALL(close(fd_));
+  fd_ = -1;
+  if (result != 0)
+    throw SystemError(errno, "cannot close file");
+}
+
+fmt::LongLong fmt::File::size() const {
+#ifdef _WIN32
+  // Use GetFileSize instead of GetFileSizeEx for the case when _WIN32_WINNT
+  // is less than 0x0500 as is the case with some default MinGW builds.
+  // Both functions support large file sizes.
+  DWORD size_upper = 0;
+  HANDLE handle = reinterpret_cast<HANDLE>(_get_osfhandle(fd_));
+  DWORD size_lower = FMT_SYSTEM(GetFileSize(handle, &size_upper));
+  if (size_lower == INVALID_FILE_SIZE) {
+    DWORD error = GetLastError();
+    if (error != NO_ERROR)
+      throw WindowsError(GetLastError(), "cannot get file size");
+  }
+  fmt::ULongLong long_size = size_upper;
+  return (long_size << sizeof(DWORD) * CHAR_BIT) | size_lower;
+#else
+  typedef struct stat Stat;
+  Stat file_stat = Stat();
+  if (FMT_POSIX_CALL(fstat(fd_, &file_stat)) == -1)
+    throw SystemError(errno, "cannot get file attributes");
+  FMT_STATIC_ASSERT(sizeof(fmt::LongLong) >= sizeof(file_stat.st_size),
+      "return type of File::size is not large enough");
+  return file_stat.st_size;
+#endif
+}
+
+std::size_t fmt::File::read(void *buffer, std::size_t count) {
+  RWResult result = 0;
+  FMT_RETRY(result, FMT_POSIX_CALL(read(fd_, buffer, convert_rwcount(count))));
+  if (result < 0)
+    throw SystemError(errno, "cannot read from file");
+  return result;
+}
+
+std::size_t fmt::File::write(const void *buffer, std::size_t count) {
+  RWResult result = 0;
+  FMT_RETRY(result, FMT_POSIX_CALL(write(fd_, buffer, convert_rwcount(count))));
+  if (result < 0)
+    throw SystemError(errno, "cannot write to file");
+  return result;
+}
+
+fmt::File fmt::File::dup(int fd) {
+  // Don't retry as dup doesn't return EINTR.
+  // http://pubs.opengroup.org/onlinepubs/009695399/functions/dup.html
+  int new_fd = FMT_POSIX_CALL(dup(fd));
+  if (new_fd == -1)
+    throw SystemError(errno, "cannot duplicate file descriptor {}", fd);
+  return File(new_fd);
+}
+
+void fmt::File::dup2(int fd) {
+  int result = 0;
+  FMT_RETRY(result, FMT_POSIX_CALL(dup2(fd_, fd)));
+  if (result == -1) {
+    throw SystemError(errno,
+      "cannot duplicate file descriptor {} to {}", fd_, fd);
+  }
+}
+
+void fmt::File::dup2(int fd, ErrorCode &ec) FMT_NOEXCEPT {
+  int result = 0;
+  FMT_RETRY(result, FMT_POSIX_CALL(dup2(fd_, fd)));
+  if (result == -1)
+    ec = ErrorCode(errno);
+}
+
+void fmt::File::pipe(File &read_end, File &write_end) {
+  // Close the descriptors first to make sure that assignments don't throw
+  // and there are no leaks.
+  read_end.close();
+  write_end.close();
+  int fds[2] = {};
+#ifdef _WIN32
+  // Make the default pipe capacity same as on Linux 2.6.11+.
+  enum { DEFAULT_CAPACITY = 65536 };
+  int result = FMT_POSIX_CALL(pipe(fds, DEFAULT_CAPACITY, _O_BINARY));
+#else
+  // Don't retry as the pipe function doesn't return EINTR.
+  // http://pubs.opengroup.org/onlinepubs/009696799/functions/pipe.html
+  int result = FMT_POSIX_CALL(pipe(fds));
+#endif
+  if (result != 0)
+    throw SystemError(errno, "cannot create pipe");
+  // The following assignments don't throw because read_fd and write_fd
+  // are closed.
+  read_end = File(fds[0]);
+  write_end = File(fds[1]);
+}
+
+fmt::BufferedFile fmt::File::fdopen(const char *mode) {
+  // Don't retry as fdopen doesn't return EINTR.
+  FILE *f = FMT_POSIX_CALL(fdopen(fd_, mode));
+  if (!f)
+    throw SystemError(errno, "cannot associate stream with file descriptor");
+  BufferedFile file(f);
+  fd_ = -1;
+  return file;
+}
+
+long fmt::getpagesize() {
+#ifdef _WIN32
+  SYSTEM_INFO si;
+  GetSystemInfo(&si);
+  return si.dwPageSize;
+#else
+  long size = FMT_POSIX_CALL(sysconf(_SC_PAGESIZE));
+  if (size < 0)
+    throw SystemError(errno, "cannot get memory page size");
+  return size;
+#endif
+}

--- a/xbmc/contrib/cppformat/posix.h
+++ b/xbmc/contrib/cppformat/posix.h
@@ -1,0 +1,340 @@
+/*
+ A C++ interface to POSIX functions.
+
+ Copyright (c) 2014 - 2015, Victor Zverovich
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef FMT_POSIX_H_
+#define FMT_POSIX_H_
+
+#ifdef __MINGW32__
+// Workaround MinGW bug https://sourceforge.net/p/mingw/bugs/2024/.
+# undef __STRICT_ANSI__
+#endif
+
+#include <errno.h>
+#include <fcntl.h>  // for O_RDONLY
+#include <stdio.h>
+
+#include <cstddef>
+
+#include "format.h"
+
+#ifndef FMT_POSIX
+# if defined(_WIN32) && !defined(__MINGW32__)
+// Fix warnings about deprecated symbols.
+#  define FMT_POSIX(call) _##call
+# else
+#  define FMT_POSIX(call) call
+# endif
+#endif
+
+// Calls to system functions are wrapped in FMT_SYSTEM for testability.
+#ifdef FMT_SYSTEM
+# define FMT_POSIX_CALL(call) FMT_SYSTEM(call)
+#else
+# define FMT_SYSTEM(call) call
+# ifdef _WIN32
+// Fix warnings about deprecated symbols.
+#  define FMT_POSIX_CALL(call) ::_##call
+# else
+#  define FMT_POSIX_CALL(call) ::call
+# endif
+#endif
+
+#if FMT_GCC_VERSION >= 407
+# define FMT_UNUSED __attribute__((unused))
+#else
+# define FMT_UNUSED
+#endif
+
+#if FMT_USE_STATIC_ASSERT || FMT_HAS_CPP_ATTRIBUTE(cxx_static_assert) || \
+  (FMT_GCC_VERSION >= 403 && FMT_HAS_GXX_CXX11) || _MSC_VER >= 1600
+# define FMT_STATIC_ASSERT(cond, message) static_assert(cond, message)
+#else
+# define FMT_CONCAT_(a, b) FMT_CONCAT(a, b)
+# define FMT_STATIC_ASSERT(cond, message) \
+  typedef int FMT_CONCAT_(Assert, __LINE__)[(cond) ? 1 : -1] FMT_UNUSED
+#endif
+
+// Retries the expression while it evaluates to error_result and errno
+// equals to EINTR.
+#ifndef _WIN32
+# define FMT_RETRY_VAL(result, expression, error_result) \
+  do { \
+    result = (expression); \
+  } while (result == error_result && errno == EINTR)
+#else
+# define FMT_RETRY_VAL(result, expression, error_result) result = (expression)
+#endif
+
+#define FMT_RETRY(result, expression) FMT_RETRY_VAL(result, expression, -1)
+
+namespace fmt {
+
+// An error code.
+class ErrorCode {
+ private:
+  int value_;
+
+ public:
+  explicit ErrorCode(int value = 0) FMT_NOEXCEPT : value_(value) {}
+
+  int get() const FMT_NOEXCEPT { return value_; }
+};
+
+// A buffered file.
+class BufferedFile {
+ private:
+  FILE *file_;
+
+  friend class File;
+
+  explicit BufferedFile(FILE *f) : file_(f) {}
+
+ public:
+  // Constructs a BufferedFile object which doesn't represent any file.
+  BufferedFile() FMT_NOEXCEPT : file_(0) {}
+
+  // Destroys the object closing the file it represents if any.
+  ~BufferedFile() FMT_NOEXCEPT;
+
+#if !FMT_USE_RVALUE_REFERENCES
+  // Emulate a move constructor and a move assignment operator if rvalue
+  // references are not supported.
+
+ private:
+  // A proxy object to emulate a move constructor.
+  // It is private to make it impossible call operator Proxy directly.
+  struct Proxy {
+    FILE *file;
+  };
+
+public:
+  // A "move constructor" for moving from a temporary.
+  BufferedFile(Proxy p) FMT_NOEXCEPT : file_(p.file) {}
+
+  // A "move constructor" for for moving from an lvalue.
+  BufferedFile(BufferedFile &f) FMT_NOEXCEPT : file_(f.file_) {
+    f.file_ = 0;
+  }
+
+  // A "move assignment operator" for moving from a temporary.
+  BufferedFile &operator=(Proxy p) {
+    close();
+    file_ = p.file;
+    return *this;
+  }
+
+  // A "move assignment operator" for moving from an lvalue.
+  BufferedFile &operator=(BufferedFile &other) {
+    close();
+    file_ = other.file_;
+    other.file_ = 0;
+    return *this;
+  }
+
+  // Returns a proxy object for moving from a temporary:
+  //   BufferedFile file = BufferedFile(...);
+  operator Proxy() FMT_NOEXCEPT {
+    Proxy p = {file_};
+    file_ = 0;
+    return p;
+  }
+
+#else
+ private:
+  FMT_DISALLOW_COPY_AND_ASSIGN(BufferedFile);
+
+ public:
+  BufferedFile(BufferedFile &&other) FMT_NOEXCEPT : file_(other.file_) {
+    other.file_ = 0;
+  }
+
+  BufferedFile& operator=(BufferedFile &&other) {
+    close();
+    file_ = other.file_;
+    other.file_ = 0;
+    return *this;
+  }
+#endif
+
+  // Opens a file.
+  BufferedFile(CStringRef filename, CStringRef mode);
+
+  // Closes the file.
+  void close();
+
+  // Returns the pointer to a FILE object representing this file.
+  FILE *get() const FMT_NOEXCEPT { return file_; }
+
+  // We place parentheses around fileno to workaround a bug in some versions
+  // of MinGW that define fileno as a macro.
+  int (fileno)() const;
+
+  void print(CStringRef format_str, const ArgList &args) {
+    fmt::print(file_, format_str, args);
+  }
+  FMT_VARIADIC(void, print, CStringRef)
+};
+
+// A file. Closed file is represented by a File object with descriptor -1.
+// Methods that are not declared with FMT_NOEXCEPT may throw
+// fmt::SystemError in case of failure. Note that some errors such as
+// closing the file multiple times will cause a crash on Windows rather
+// than an exception. You can get standard behavior by overriding the
+// invalid parameter handler with _set_invalid_parameter_handler.
+class File {
+ private:
+  int fd_;  // File descriptor.
+
+  // Constructs a File object with a given descriptor.
+  explicit File(int fd) : fd_(fd) {}
+
+ public:
+  // Possible values for the oflag argument to the constructor.
+  enum {
+    RDONLY = FMT_POSIX(O_RDONLY), // Open for reading only.
+    WRONLY = FMT_POSIX(O_WRONLY), // Open for writing only.
+    RDWR   = FMT_POSIX(O_RDWR)    // Open for reading and writing.
+  };
+
+  // Constructs a File object which doesn't represent any file.
+  File() FMT_NOEXCEPT : fd_(-1) {}
+
+  // Opens a file and constructs a File object representing this file.
+  File(CStringRef path, int oflag);
+
+#if !FMT_USE_RVALUE_REFERENCES
+  // Emulate a move constructor and a move assignment operator if rvalue
+  // references are not supported.
+
+ private:
+  // A proxy object to emulate a move constructor.
+  // It is private to make it impossible call operator Proxy directly.
+  struct Proxy {
+    int fd;
+  };
+
+ public:
+  // A "move constructor" for moving from a temporary.
+  File(Proxy p) FMT_NOEXCEPT : fd_(p.fd) {}
+
+  // A "move constructor" for for moving from an lvalue.
+  File(File &other) FMT_NOEXCEPT : fd_(other.fd_) {
+    other.fd_ = -1;
+  }
+
+  // A "move assignment operator" for moving from a temporary.
+  File &operator=(Proxy p) {
+    close();
+    fd_ = p.fd;
+    return *this;
+  }
+
+  // A "move assignment operator" for moving from an lvalue.
+  File &operator=(File &other) {
+    close();
+    fd_ = other.fd_;
+    other.fd_ = -1;
+    return *this;
+  }
+
+  // Returns a proxy object for moving from a temporary:
+  //   File file = File(...);
+  operator Proxy() FMT_NOEXCEPT {
+    Proxy p = {fd_};
+    fd_ = -1;
+    return p;
+  }
+
+#else
+ private:
+  FMT_DISALLOW_COPY_AND_ASSIGN(File);
+
+ public:
+  File(File &&other) FMT_NOEXCEPT : fd_(other.fd_) {
+    other.fd_ = -1;
+  }
+
+  File& operator=(File &&other) {
+    close();
+    fd_ = other.fd_;
+    other.fd_ = -1;
+    return *this;
+  }
+#endif
+
+  // Destroys the object closing the file it represents if any.
+  ~File() FMT_NOEXCEPT;
+
+  // Returns the file descriptor.
+  int descriptor() const FMT_NOEXCEPT { return fd_; }
+
+  // Closes the file.
+  void close();
+
+  // Returns the file size.
+  LongLong size() const;
+
+  // Attempts to read count bytes from the file into the specified buffer.
+  std::size_t read(void *buffer, std::size_t count);
+
+  // Attempts to write count bytes from the specified buffer to the file.
+  std::size_t write(const void *buffer, std::size_t count);
+
+  // Duplicates a file descriptor with the dup function and returns
+  // the duplicate as a file object.
+  static File dup(int fd);
+
+  // Makes fd be the copy of this file descriptor, closing fd first if
+  // necessary.
+  void dup2(int fd);
+
+  // Makes fd be the copy of this file descriptor, closing fd first if
+  // necessary.
+  void dup2(int fd, ErrorCode &ec) FMT_NOEXCEPT;
+
+  // Creates a pipe setting up read_end and write_end file objects for reading
+  // and writing respectively.
+  static void pipe(File &read_end, File &write_end);
+
+  // Creates a BufferedFile object associated with this file and detaches
+  // this File object from the file.
+  BufferedFile fdopen(const char *mode);
+};
+
+// Returns the memory page size.
+long getpagesize();
+}  // namespace fmt
+
+#if !FMT_USE_RVALUE_REFERENCES
+namespace std {
+// For compatibility with C++98.
+inline fmt::BufferedFile &move(fmt::BufferedFile &f) { return f; }
+inline fmt::File &move(fmt::File &f) { return f; }
+}
+#endif
+
+#endif  // FMT_POSIX_H_

--- a/xbmc/guilib/GUIMoverControl.h
+++ b/xbmc/guilib/GUIMoverControl.h
@@ -41,10 +41,6 @@
 #define DIRECTION_LEFT 3
 #define DIRECTION_RIGHT 4
 
-// normal alignment is TOP LEFT 0 = topleft, 1 = topright
-#define ALIGN_RIGHT   1
-#define ALIGN_BOTTOM  2
-
 /*!
  \ingroup controls
  \brief

--- a/xbmc/interfaces/json-rpc/JSONServiceDescription.cpp
+++ b/xbmc/interfaces/json-rpc/JSONServiceDescription.cpp
@@ -1415,7 +1415,7 @@ bool CJSONServiceDescription::prepareDescription(std::string &description, CVari
 
   if (description.at(0) != '{')
   {
-    description = StringUtils::Format("{%s}", description.c_str());
+    description = StringUtils::Format("{{{:s}}}", description);
   }
 
   descriptionObject = CJSONVariantParser::Parse((const unsigned char *)description.c_str(), description.size());

--- a/xbmc/rendering/dx/RenderSystemDX.cpp
+++ b/xbmc/rendering/dx/RenderSystemDX.cpp
@@ -36,6 +36,7 @@
 #include "utils/log.h"
 #include "win32/WIN32Util.h"
 #include "win32/dxerr.h"
+#include "utils/CharsetConverter.h"
 
 #pragma comment(lib, "d3d11.lib")
 #pragma comment(lib, "dxgi.lib")
@@ -628,7 +629,8 @@ bool CRenderSystemDX::CreateDevice()
     CLog::Log(LOGDEBUG, "%s - on adapter %S (VendorId: %#x DeviceId: %#x) with feature level %#x.", __FUNCTION__, 
                         m_adapterDesc.Description, m_adapterDesc.VendorId, m_adapterDesc.DeviceId, m_featureLevel);
 
-    m_RenderRenderer = StringUtils::Format("%S", m_adapterDesc.Description);
+    std::wstring renderer = StringUtils::Format(L"%S", m_adapterDesc.Description);
+    g_charsetConverter.wToUTF8(renderer, m_RenderRenderer);
     IDXGIFactory2* dxgiFactory2 = nullptr;
     m_dxgiFactory->QueryInterface(__uuidof(IDXGIFactory2), reinterpret_cast<void**>(&dxgiFactory2));
     m_RenderVersion = StringUtils::Format("DirectX %s (FL %d.%d)", 
@@ -1548,7 +1550,10 @@ std::string CRenderSystemDX::GetErrorDescription(HRESULT hr)
   DXGetErrorDescription(hr, buff, 1024);
   std::wstring error(DXGetErrorString(hr));
   std::wstring descr(buff);
-  return StringUtils::Format("%X - %ls (%ls)", hr, error.c_str(), descr.c_str());
+  std::wstring errMsgW = StringUtils::Format(L"%X - %s (%s)", hr, error.c_str(), descr.c_str());
+  std::string errMsg;
+  g_charsetConverter.wToUTF8(errMsgW, errMsg);
+  return errMsg;
 }
 
 void CRenderSystemDX::SetStereoMode(RENDER_STEREO_MODE mode, RENDER_STEREO_VIEW view)

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -29,6 +29,7 @@
 //------------------------------------------------------------------------
 
 #include <guid.h>
+#include <cppformat/format.h>
 
 #include "StringUtils.h"
 #include "CharsetConverter.h"
@@ -220,7 +221,8 @@ static const wchar_t unicode_uppers[] = {
   (wchar_t)0xFF32, (wchar_t)0xFF33, (wchar_t)0xFF34, (wchar_t)0xFF35, (wchar_t)0xFF36, (wchar_t)0xFF37, (wchar_t)0xFF38, (wchar_t)0xFF39, (wchar_t)0xFF3A
 };
 
-std::string StringUtils::Format(const char *fmt, ...)
+
+std::string StringUtils::FormatLegacy(const char *fmt, ...)
 {
   va_list args;
   va_start(args, fmt);
@@ -274,7 +276,7 @@ std::string StringUtils::FormatV(const char *fmt, va_list args)
   return ""; // unreachable
 }
 
-std::wstring StringUtils::Format(const wchar_t *fmt, ...)
+std::wstring StringUtils::FormatLegacy(const wchar_t *fmt, ...)
 {
   va_list args;
   va_start(args, fmt);

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -1,7 +1,7 @@
 #pragma once
 /*
- *      Copyright (C) 2005-2013 Team XBMC
- *      http://xbmc.org
+ *      Copyright (C) 2005-2015 Team Kodi
+ *      http://kodi.tv
  *
  *  This Program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -33,9 +33,24 @@
 #include <stdint.h>
 #include <string>
 #include <vector>
-
+#include "contrib/cppformat/format.h"
 #include "XBDateTime.h"
 #include "utils/params_check_macros.h"
+
+namespace
+{
+template<typename T>
+T Adaptor(T value) 
+{
+  return value;
+}
+
+template<typename T>
+T const * Adaptor(std::basic_string<T> const& value) 
+{
+  return value.c_str();
+}
+}
 
 class StringUtils
 {
@@ -51,9 +66,28 @@ public:
   \param ... variable number of value type arguments
   \return Formatted string
   */
-  static std::string Format(PRINTF_FORMAT_STRING const char *fmt, ...) PARAM1_PRINTF_FORMAT;
+  template<typename... Args>
+  static std::string Format(const std::string& fmt, const Args&... args)
+  {
+    auto result = fmt::format(fmt, args...);
+    if (result == fmt)
+      result = FormatLegacy(fmt.c_str(), Adaptor(args)...);
+
+    return result;
+  }
+  template<typename... Args>
+  static std::wstring Format(const std::wstring& fmt, const Args&... args)
+  {
+    auto result = fmt::format(fmt, args...);
+    if (result == fmt)
+      result = FormatLegacy(fmt.c_str(), Adaptor(args)...);
+
+    return result;
+  }
+
+  static std::string FormatLegacy(PRINTF_FORMAT_STRING const char *fmt, ...) PARAM1_PRINTF_FORMAT;
   static std::string FormatV(PRINTF_FORMAT_STRING const char *fmt, va_list args);
-  static std::wstring Format(PRINTF_FORMAT_STRING const wchar_t *fmt, ...);
+  static std::wstring FormatLegacy(PRINTF_FORMAT_STRING const wchar_t *fmt, ...);
   static std::wstring FormatV(PRINTF_FORMAT_STRING const wchar_t *fmt, va_list args);
   static void ToUpper(std::string &str);
   static void ToUpper(std::wstring &str);

--- a/xbmc/video/videosync/VideoSyncD3D.cpp
+++ b/xbmc/video/videosync/VideoSyncD3D.cpp
@@ -30,6 +30,7 @@
 #include "guilib/GraphicContext.h"
 #include "win32/dxerr.h"
 #include "utils/StringUtils.h"
+#include "utils/CharsetConverter.h"
 
 void CVideoSyncD3D::OnDestroyDevice()
 {
@@ -152,7 +153,10 @@ std::string CVideoSyncD3D::GetErrorDescription(HRESULT hr)
   DXGetErrorDescription(hr, buff, 1024);
   std::wstring error(DXGetErrorString(hr));
   std::wstring descr(buff);
-  return StringUtils::Format("%ls: %ls", error.c_str(), descr.c_str());
+  std::wstring errMsgW = StringUtils::Format(L"%s: %s", error.c_str(), descr.c_str());
+  std::string errMsg;
+  g_charsetConverter.wToUTF8(errMsgW, errMsg);
+  return errMsg;
 }
 
 #endif


### PR DESCRIPTION
…atting

Groundwork, still passes most formatting through the old method as the strings aren't updated yet
Updated language addon to use the positional parameters
To avoid packaging troubles and since the library is only 5 files I decided to stick it in contrib as kissfft
