### PR TITLE
XRandR: Properly enumerate interlaced modes

### DIFF
--- a/xbmc/windowing/X11/WinSystemX11.cpp
+++ b/xbmc/windowing/X11/WinSystemX11.cpp
@@ -431,9 +431,6 @@ void CWinSystemX11::UpdateResolutions()
       res.fRefreshRate = mode.hz;
       res.bFullScreen  = true;
 
-      if (mode.h > 0 && ((float)mode.w / (float)mode.h >= 1.59))
-        res.dwFlags |= D3DPRESENTFLAG_WIDESCREEN;
-
       g_graphicsContext.ResetOverscan(res);
       CDisplaySettings::GetInstance().AddResolutionInfo(res);
     }

--- a/xbmc/windowing/X11/WinSystemX11.cpp
+++ b/xbmc/windowing/X11/WinSystemX11.cpp
@@ -399,10 +399,14 @@ void CWinSystemX11::UpdateResolutions()
                 mode.id.c_str(), mode.name.c_str(), mode.hz, mode.w, mode.h);
       RESOLUTION_INFO res;
       res.iScreen = 0; // not used by X11
+      res.dwFlags = 0;
       res.iWidth  = mode.w;
       res.iHeight = mode.h;
       res.iScreenWidth  = mode.w;
       res.iScreenHeight = mode.h;
+      if (mode.IsInterlaced())
+        res.dwFlags |= D3DPRESENTFLAG_INTERLACED;
+
       if (!m_bIsRotated)
       {
         res.iWidth  = mode.w;
@@ -428,9 +432,7 @@ void CWinSystemX11::UpdateResolutions()
       res.bFullScreen  = true;
 
       if (mode.h > 0 && ((float)mode.w / (float)mode.h >= 1.59))
-        res.dwFlags = D3DPRESENTFLAG_WIDESCREEN;
-      else
-        res.dwFlags = 0;
+        res.dwFlags |= D3DPRESENTFLAG_WIDESCREEN;
 
       g_graphicsContext.ResetOverscan(res);
       CDisplaySettings::GetInstance().AddResolutionInfo(res);

--- a/xbmc/windowing/X11/XRandR.h
+++ b/xbmc/windowing/X11/XRandR.h
@@ -33,32 +33,36 @@ class XMode
 {
 public:
   XMode()
-    {
-      id="";
-      name="";
-      hz=0.0f;
-      isPreferred=false;
-      isCurrent=false;
-      w=h=0;
-    }
+  {
+    id="";
+    name="";
+    hz=0.0f;
+    isPreferred=false;
+    isCurrent=false;
+    w=h=0;
+  }
   bool operator==(XMode& mode) const
-    {
-      if (id!=mode.id)
-        return false;
-      if (name!=mode.name)
-        return false;
-      if (hz!=mode.hz)
-        return false;
-      if (isPreferred!=mode.isPreferred)
-        return false;
-      if (isCurrent!=mode.isCurrent)
-        return false;
-      if (w!=mode.w)
-        return false;
-      if (h!=mode.h)
-        return false;
-      return true;
-    }
+  {
+    if (id != mode.id)
+      return false;
+    if (name != mode.name)
+      return false;
+    if (hz != mode.hz)
+      return false;
+    if (isPreferred != mode.isPreferred)
+      return false;
+    if (isCurrent != mode.isCurrent)
+      return false;
+    if (w != mode.w)
+      return false;
+    if (h != mode.h)
+      return false;
+    return true;
+  }
+  bool IsInterlaced()
+  {
+    return name.back() == 'i';
+  }
   std::string id;
   std::string name;
   float hz;
@@ -72,11 +76,11 @@ class XOutput
 {
 public:
   XOutput()
-    {
-      name="";
-      isConnected=false;
-      w=h=x=y=wmm=hmm=0;
-    }
+  {
+    name = "";
+    isConnected = false;
+    w = h = x = y = wmm = hmm = 0;
+  }
   std::string name;
   bool isConnected;
   int screen;
@@ -98,8 +102,8 @@ public:
   bool Query(bool force=false, bool ignoreoff=true);
   bool Query(bool force, int screennum, bool ignoreoff=true);
   std::vector<XOutput> GetModes(void);
-  XMode   GetCurrentMode(const std::string& outputName);
-  XMode   GetPreferredMode(const std::string& outputName);
+  XMode GetCurrentMode(const std::string& outputName);
+  XMode GetPreferredMode(const std::string& outputName);
   XOutput *GetOutput(const std::string& outputName);
   bool SetMode(XOutput output, XMode mode);
   void LoadCustomModeLinesToAllOutputs(void);


### PR DESCRIPTION
On linux and X11 modes that are interlaced have an additional "i" attached. This helps that we don't switch between interlaced and progressive resolutions with the resolution switching in place.
