### PR TITLE
correct offset by read ahead bytes when using SEEK_CUR/use ID3v2Tag instead of tag 

### DIFF
--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -1051,7 +1051,8 @@ CFileStreamBuffer::pos_type CFileStreamBuffer::seekoff(
   std::ios_base::openmode mode)
 {
   // calculate relative offset
-  off_type pos  = m_file->GetPosition() - (egptr() - gptr());
+  off_type aheadbytes  = (egptr() - gptr());
+  off_type pos  = m_file->GetPosition() - aheadbytes;
   off_type offset2;
   if(way == std::ios_base::cur)
     offset2 = offset;
@@ -1080,7 +1081,7 @@ CFileStreamBuffer::pos_type CFileStreamBuffer::seekoff(
 
   int64_t position = -1;
   if(way == std::ios_base::cur)
-    position = m_file->Seek(offset, SEEK_CUR);
+    position = m_file->Seek(offset - aheadbytes, SEEK_CUR);
   else if(way == std::ios_base::end)
     position = m_file->Seek(offset, SEEK_END);
   else

--- a/xbmc/music/tags/TagLoaderTagLib.cpp
+++ b/xbmc/music/tags/TagLoaderTagLib.cpp
@@ -218,7 +218,11 @@ bool CTagLoaderTagLib::Load(const std::string& strFileName, CMusicInfoTag& tag, 
   else if (aiffFile)
     id3v2 = aiffFile->tag();
   else if (wavFile)
+#if TAGLIB_MAJOR_VERSION > 1 || TAGLIB_MINOR_VERSION > 8
+    id3v2 = wavFile->ID3v2Tag();
+#else
     id3v2 = wavFile->tag();
+#endif
   else if (wvFile)
     ape = wvFile->APETag(false);
   else if (mpcFile)


### PR DESCRIPTION
for underlying file even when seekoff is called with relative offset,
because the underlying file is used to do buffered reads and is therefore at another
position (Usually the buffer size is around 0x10000).
This fix might also help with bug #16158
There is written more in http://forum.kodi.tv/showthread.php?tid=239373, without the fix chunks after the data-chunk in riff-files cannot be found...
