### PR TITLE
[cleanup] get rid of unused window allow overlay code

### DIFF
--- a/xbmc/addons/AddonCallbacksGUI.cpp
+++ b/xbmc/addons/AddonCallbacksGUI.cpp
@@ -2179,12 +2179,8 @@ CGUIAddonWindowDialog::~CGUIAddonWindowDialog(void)
 bool CGUIAddonWindowDialog::OnMessage(CGUIMessage &message)
 {
   if (message.GetMessage() == GUI_MSG_WINDOW_DEINIT)
-  {
-    CGUIWindow *pWindow = g_windowManager.GetWindow(g_windowManager.GetActiveWindow());
-    if (pWindow)
-      g_windowManager.ShowOverlay(pWindow->GetOverlayState());
     return CGUIWindow::OnMessage(message);
-  }
+  
   return CGUIAddonWindow::OnMessage(message);
 }
 

--- a/xbmc/guilib/GUIDialog.cpp
+++ b/xbmc/guilib/GUIDialog.cpp
@@ -91,10 +91,6 @@ bool CGUIDialog::OnMessage(CGUIMessage& message)
   {
   case GUI_MSG_WINDOW_DEINIT:
     {
-      CGUIWindow *pWindow = g_windowManager.GetWindow(g_windowManager.GetActiveWindow());
-      if (pWindow)
-        g_windowManager.ShowOverlay(pWindow->GetOverlayState());
-
       CGUIWindow::OnMessage(message);
       return true;
     }

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -55,7 +55,6 @@ CGUIWindow::CGUIWindow(int id, const std::string &xmlFile)
   SetID(id);
   SetProperty("xmlfile", xmlFile);
   m_lastControlID = 0;
-  m_overlayState = OVERLAY_STATE_PARENT_WINDOW;   // Use parent or previous window's state
   m_isDialog = false;
   m_needsScaling = true;
   m_windowLoaded = false;
@@ -268,12 +267,6 @@ bool CGUIWindow::Load(TiXmlElement* pRootElement)
         }
         pControl = pControl->NextSiblingElement();
       }
-    }
-    else if (strValue == "allowoverlay")
-    {
-      bool overlay = false;
-      if (XMLUtils::GetBoolean(pRootElement, "allowoverlay", overlay))
-        m_overlayState = overlay ? OVERLAY_STATE_SHOWN : OVERLAY_STATE_HIDDEN;
     }
 
     pChild = pChild->NextSiblingElement();
@@ -555,7 +548,6 @@ void CGUIWindow::OnInitWindow()
   RestoreControlStates();
   SetInitialVisibility();
   QueueAnimation(ANIM_TYPE_WINDOW_OPEN);
-  g_windowManager.ShowOverlay(m_overlayState);
 
   if (!m_manualRunActions)
   {
@@ -1004,7 +996,6 @@ void CGUIWindow::SetDefaults()
   m_defaultAlways = false;
   m_defaultControl = 0;
   m_posX = m_posY = m_width = m_height = 0;
-  m_overlayState = OVERLAY_STATE_PARENT_WINDOW;   // Use parent or previous window's state
   m_previousWindow = WINDOW_INVALID;
   m_animations.clear();
   m_origins.clear();

--- a/xbmc/guilib/GUIWindow.h
+++ b/xbmc/guilib/GUIWindow.h
@@ -164,10 +164,6 @@ public:
                                                    // versions of UpdateVisibility, and are deemed visible if they're in
                                                    // the window manager's active list.
 
-  enum OVERLAY_STATE { OVERLAY_STATE_PARENT_WINDOW=0, OVERLAY_STATE_SHOWN, OVERLAY_STATE_HIDDEN };
-
-  OVERLAY_STATE GetOverlayState() const { return m_overlayState; };
-
   virtual bool IsAnimating(ANIMATION_TYPE animType);
   void DisableAnimations();
 
@@ -241,7 +237,6 @@ protected:
   void LoadControl(TiXmlElement* pControl, CGUIControlGroup *pGroup, const CRect &rect);
 
   std::vector<int> m_idRange;
-  OVERLAY_STATE m_overlayState;
   RESOLUTION_INFO m_coordsRes; // resolution that the window coordinates are in.
   bool m_needsScaling;
   bool m_windowLoaded;  // true if the window's xml file has been loaded

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -154,7 +154,6 @@ using namespace KODI::MESSAGING;
 CGUIWindowManager::CGUIWindowManager(void)
 {
   m_pCallback = NULL;
-  m_bShowOverlay = true;
   m_iNested = 0;
   m_initialized = false;
 }
@@ -677,9 +676,6 @@ void CGUIWindowManager::PreviousWindow()
   // tell our info manager which window we are going to
   g_infoManager.SetNextWindow(previousWindow);
 
-  // set our overlay state (enables out animations on window change)
-  HideOverlay(pNewWindow->GetOverlayState());
-
   // deinitialize our window
   CloseWindowSync(pCurrentWindow);
 
@@ -796,9 +792,6 @@ void CGUIWindowManager::ActivateWindow_Internal(int iWindowID, const std::vector
   }
 
   g_infoManager.SetNextWindow(iWindowID);
-
-  // set our overlay state
-  HideOverlay(pNewWindow->GetOverlayState());
 
   // deactivate any window
   int currentWindow = GetActiveWindow();
@@ -1481,26 +1474,6 @@ void CGUIWindowManager::UnloadNotOnDemandWindows()
       pWindow->FreeResources(true);
     }
   }
-}
-
-bool CGUIWindowManager::IsOverlayAllowed() const
-{
-  if (GetActiveWindow() == WINDOW_FULLSCREEN_VIDEO ||
-      GetActiveWindow() == WINDOW_SCREENSAVER)
-    return false;
-  return m_bShowOverlay;
-}
-
-void CGUIWindowManager::ShowOverlay(CGUIWindow::OVERLAY_STATE state)
-{
-  if (state != CGUIWindow::OVERLAY_STATE_PARENT_WINDOW)
-    m_bShowOverlay = state == CGUIWindow::OVERLAY_STATE_SHOWN;
-}
-
-void CGUIWindowManager::HideOverlay(CGUIWindow::OVERLAY_STATE state)
-{
-  if (state == CGUIWindow::OVERLAY_STATE_HIDDEN)
-    m_bShowOverlay = false;
 }
 
 void CGUIWindowManager::AddToWindowHistory(int newWindowID)

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -169,7 +169,6 @@ public:
   bool IsWindowActive(const std::string &xmlFile, bool ignoreClosing = true) const;
   bool IsWindowVisible(const std::string &xmlFile) const;
   bool IsWindowTopMost(const std::string &xmlFile) const;
-  bool IsOverlayAllowed() const;
   /*! \brief Checks if the given window is an addon window.
    *
    * \return true if the given window is an addon window, otherwise false.
@@ -180,7 +179,6 @@ public:
    * \return true if the given window is a python window, otherwise false.
    */
   bool IsPythonWindow(int id) const { return (id >= WINDOW_PYTHON_START && id <= WINDOW_PYTHON_END); };
-  void ShowOverlay(CGUIWindow::OVERLAY_STATE state);
   void GetActiveModelessWindows(std::vector<int> &ids);
 #ifdef _DEBUG
   void DumpTextureUse();
@@ -190,7 +188,6 @@ private:
 
   void LoadNotOnDemandWindows();
   void UnloadNotOnDemandWindows();
-  void HideOverlay(CGUIWindow::OVERLAY_STATE state);
   void AddToWindowHistory(int newWindowID);
   void ClearWindowHistory();
   void CloseWindowSync(CGUIWindow *window, int nextWindowID = 0);
@@ -224,7 +221,6 @@ private:
   CCriticalSection m_critSection;
   std::vector <IMsgTargetCallback*> m_vecMsgTargets;
 
-  bool m_bShowOverlay;
   int  m_iNested;
   bool m_initialized;
 

--- a/xbmc/interfaces/legacy/Window.cpp
+++ b/xbmc/interfaces/legacy/Window.cpp
@@ -455,20 +455,6 @@ namespace XBMCAddon
       XBMC_TRACE;
       switch (message.GetMessage())
       {
-      case GUI_MSG_WINDOW_DEINIT:
-        {
-          g_windowManager.ShowOverlay(ref(window)->OVERLAY_STATE_SHOWN);
-        }
-        break;
-
-      case GUI_MSG_WINDOW_INIT:
-        {
-          ref(window)->OnMessage(message);
-          g_windowManager.ShowOverlay(ref(window)->OVERLAY_STATE_HIDDEN);
-          return true;
-        }
-        break;
-
       case GUI_MSG_CLICKED:
         {
           int iControl=message.GetSenderId();

--- a/xbmc/interfaces/legacy/WindowXML.cpp
+++ b/xbmc/interfaces/legacy/WindowXML.cpp
@@ -473,12 +473,8 @@ namespace XBMCAddon
     {
       XBMC_TRACE;
       if (message.GetMessage() == GUI_MSG_WINDOW_DEINIT)
-      {
-        CGUIWindow *pWindow = g_windowManager.GetWindow(g_windowManager.GetActiveWindow());
-        if (pWindow)
-          g_windowManager.ShowOverlay(pWindow->GetOverlayState());
         return A(CGUIWindow::OnMessage(message));
-      }
+
       return WindowXML::OnMessage(message);
     }
 

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -261,8 +261,6 @@ void CGUIWindowSlideShow::OnDeinitWindow(int nextWindowID)
   if (nextWindowID != WINDOW_PICTURES)
     m_ImageLib.Unload();
 
-  g_windowManager.ShowOverlay(OVERLAY_STATE_SHOWN);
-
   if (nextWindowID != WINDOW_FULLSCREEN_VIDEO)
   {
     // wait for any outstanding picture loads
@@ -934,8 +932,6 @@ bool CGUIWindowSlideShow::OnMessage(CGUIMessage& message)
       CGUIWindow::OnMessage(message);
       if (message.GetParam1() != WINDOW_PICTURES)
         m_ImageLib.Load();
-
-      g_windowManager.ShowOverlay(OVERLAY_STATE_HIDDEN);
 
       // turn off slideshow if we only have 1 image
       if (m_slides->Size() <= 1)

--- a/xbmc/settings/windows/GUIWindowSettingsScreenCalibration.cpp
+++ b/xbmc/settings/windows/GUIWindowSettingsScreenCalibration.cpp
@@ -142,7 +142,6 @@ bool CGUIWindowSettingsScreenCalibration::OnMessage(CGUIMessage& message)
       CDisplaySettings::GetInstance().UpdateCalibrations();
       CSettings::GetInstance().Save();
       g_graphicsContext.SetCalibrating(false);
-      g_windowManager.ShowOverlay(OVERLAY_STATE_SHOWN);
       // reset our screen resolution to what it was initially
       g_graphicsContext.SetVideoResolution(CDisplaySettings::GetInstance().GetCurrentResolution());
       // Inform the player so we can update the resolution
@@ -156,7 +155,6 @@ bool CGUIWindowSettingsScreenCalibration::OnMessage(CGUIMessage& message)
   case GUI_MSG_WINDOW_INIT:
     {
       CGUIWindow::OnMessage(message);
-      g_windowManager.ShowOverlay(OVERLAY_STATE_HIDDEN);
       g_graphicsContext.SetCalibrating(true);
 
       // Get the allowable resolutions that we can calibrate...

--- a/xbmc/windows/GUIWindowScreensaver.cpp
+++ b/xbmc/windows/GUIWindowScreensaver.cpp
@@ -122,8 +122,6 @@ bool CGUIWindowScreensaver::OnMessage(CGUIMessage& message)
 //      RESOLUTION res = g_graphicsContext.GetVideoResolution();
  //     g_graphicsContext.SetVideoResolution(res, FALSE);
 
-      // enable the overlay
-      g_windowManager.ShowOverlay(OVERLAY_STATE_SHOWN);
     }
     break;
 
@@ -154,8 +152,6 @@ bool CGUIWindowScreensaver::OnMessage(CGUIMessage& message)
 //      RESOLUTION res = g_graphicsContext.GetVideoResolution();
 //      g_graphicsContext.SetVideoResolution(res, TRUE);
 
-      // disable the overlay
-      g_windowManager.ShowOverlay(OVERLAY_STATE_HIDDEN);
       return true;
     }
   case GUI_MSG_CHECK_LOCK:


### PR DESCRIPTION
There are some left-overs in our core after we removed the music/video overlay windows. This PR will cleanup it as an addition to the cleanup for confluence done by @ronie in #8084.

@mkortstiege mind taking a look please
@phil65 as a hint for you
