### PR TITLE
New touchscreen keymap

### DIFF
--- a/system/keymaps/touchscreen.xml
+++ b/system/keymaps/touchscreen.xml
@@ -11,31 +11,10 @@
       <swipe direction="right">SwipeRight</swipe>
       <swipe direction="up">SwipeUp</swipe>
       <swipe direction="down">SwipeDown</swipe>
+      <swipe direction="up" pointers="3">SwitchPlayer</swipe>
+      <swipe direction="down" pointers="3">ActivateWindow(PlayerControls)</swipe>
     </touch>
   </global>
-  <FullScreenVideo>
-    <touch>
-      <swipe direction="left">StepBack</swipe>
-      <swipe direction="right">StepForward</swipe>
-      <swipe direction="up">ChapterOrBigStepForward</swipe>
-      <swipe direction="down">ChapterOrBigStepBack</swipe>
-      <swipe direction="left" pointers="2">Seek(-7)</swipe>
-    </touch>
-  </FullScreenVideo>
-  <Visualisation>
-    <touch>
-      <swipe direction="left">StepBack</swipe>
-      <swipe direction="right">StepForward</swipe>
-      <swipe direction="up">SkipNext</swipe>
-      <swipe direction="down">SkipPrevious</swipe>
-    </touch>
-  </Visualisation>
-  <SlideShow>
-    <touch>
-      <zoom>ZoomGesture</zoom>
-      <rotate>RotateGesture</rotate>
-    </touch>
-  </SlideShow>
   <MyFiles>
     <touch>
       <tap>Select</tap>
@@ -43,6 +22,46 @@
       <swipe direction="right">Highlight</swipe>
     </touch>
   </MyFiles>
+  <FullScreenVideo>
+    <touch>
+      <swipe direction="left">StepBack</swipe>
+      <swipe direction="right">StepForward</swipe>
+      <swipe direction="up">ChapterOrBigStepForward</swipe>
+      <swipe direction="down">ChapterOrBigStepBack</swipe>
+      <swipe direction="left" pointers="2">Seek(-7)</swipe>
+      <swipe direction="up" pointers="2">SkipNext</swipe>
+      <swipe direction="down" pointers="2">SkipPrevious</swipe>
+      <tap pointers="2">Playlist</tap>
+      <tap pointers="3">PlayPause</tap>
+    </touch>
+  </FullScreenVideo>
+  <PlayerControls>
+    <touch>
+      <swipe direction="down" pointers="3">Back</swipe>
+    </touch>
+  </PlayerControls>
+  <Visualisation>
+    <touch>
+      <swipe direction="left">StepBack</swipe>
+      <swipe direction="right">StepForward</swipe>
+      <swipe direction="up">SkipNext</swipe>
+      <swipe direction="down">SkipPrevious</swipe>
+      <swipe direction="up" pointers="2">SkipNext</swipe>
+      <swipe direction="down" pointers="2">SkipPrevious</swipe>
+      <tap pointers="2">Playlist</tap>
+      <tap pointers="3">PlayPause</tap>
+    </touch>
+  </Visualisation>
+  <SlideShow>
+    <touch>
+      <zoom>ZoomGesture</zoom>
+      <rotate>RotateGesture</rotate>
+      <swipe direction="right" pointers="2">PreviousPicture</swipe> <!-- right/left are flipped here to make picture flipping feel more natural on touch screens. Two pointers are used in order to avoid conflicting with the panning gesture on zoomed-in images. -->
+      <swipe direction="left" pointers="2">NextPicture</swipe>
+      <tap pointers="2">Pause</tap>
+      <tap pointers="3">Info</tap>
+    </touch>
+  </SlideShow>
   <ScreenCalibration>
     <touch>
       <swipe direction="up">Up</swipe>
@@ -52,4 +71,33 @@
       <tap pointers="1">NextCalibration</tap>
     </touch>
   </ScreenCalibration>
+  <VideoMenu>
+    <touch>
+      <swipe direction="up" pointers="2">SkipNext</swipe>
+      <swipe direction="down" pointers="2">SkipPrevious</swipe>
+    </touch>
+  </VideoMenu>
+  <ContextMenu>
+    <touch>
+      <swipe direction="left" pointers="3">Back</swipe> <!-- backs out of "switch player" -->
+      <swipe direction="right" pointers="3">Back</swipe>
+    </touch>
+  </ContextMenu>
+  <PictureInfo>
+    <touch>
+      <tap pointers="3">Back</tap>
+    </touch>
+  </PictureInfo>
+  <FullScreenLiveTV>
+    <touch>
+      <swipe direction="up">Up</swipe>
+      <swipe direction="down">Down</swipe>
+    </touch>
+  </FullScreenLiveTV>
+  <FullScreenRadio>
+    <touch>
+      <swipe direction="up">ChannelUp</swipe>
+      <swipe direction="down">ChannelDown</swipe>
+    </touch>
+  </FullScreenRadio>
 </keymap>


### PR DESCRIPTION
Some improvements to the default touchscreen keymap. Note that three finger tap and three finger swipe are iOS only at the moment. 

I tried to get some [community feedback on this](http://forum.kodi.tv/showthread.php?tid=238578). I'm very open to any additional suggestions or changes.
## Touch screen controls

_(changes are shown in bold)_
### Global:
- **Three finger swipe up - Switch Player, for use with UPnP targets/casting/beaming. (iOS only)**
- **Three finger swipe down - Player Controls, which allow playback control even if you are not in fullscreen. Useful for the above UPnP target playing/casting/beaming, but can also be used for any background playback. (iOS only)**
- Long press - Context menu or Back
- Two finger swipe left - Back
### File manager:
- Tap - select
- Swipe left or right on an item - Highlight
### Full screen video:
- Swipe left - skip step back
- Swipe right - skip step forward
- Swipe up - Next chapter or +10m
- Swipe down - Previous chapter or -10m
- Two finger swipe left - Small step back (-7 seconds)
- **Two finger swipe up - Skip next, if in a playlist or "play next automatically" is enabled**
- **Two finger swipe down - Skip previous, if in a playlist or "play next automatically" is enabled**
- **Two finger tap - Playlist window**
- **Three finger tap - PlayPause**
- Long press - Exit fullscreen playback (playback continues in background)
### Full screen live TV/radio playback (PVR):
- Swipe left - skip step back (if supported by backend)
- Swipe right - skip step forward (if supported by backend)
- Long press - Exit fullscreen playback (playback continues in background)
- **Swipe up - Channel up**
- **Swipe down - Channel down**
- **Two finger tap - Playlist window** (if supported by backend)
- **Three finger tap - PlayPause**
### Full screen music playback (visualization):
- Swipe left - skip step back
- Swipe right - skip step forward
- Long press - Exit fullscreen playback (playback continues in background)
- **Swipe up - Skip next**
- **Swipe down - Skip previous**
- **Two finger swipe up - Skip next**
- **Two finger swipe down - Skip previous**
- **Two finger tap - Playlist window**
- **Three finger tap - PlayPause**
### Slide show:
- Pinch-to-zoom - zoom
- Pan (sliding around while a single finger is on screen) - pan around a zoomed-in picture
- Rotate (two fingers in a rotate gesture) - rotate picture
- **Two finger swipe right - Previous picture**
- **Two finger swipe left - Next picture**
- **Two finger tap - Playlist window**
