### PR TITLE
Fix Linux touchscreen support

### DIFF
--- a/xbmc/input/linux/LinuxInputDevices.cpp
+++ b/xbmc/input/linux/LinuxInputDevices.cpp
@@ -276,6 +276,7 @@ typedef enum
   LI_CAPS_KEYS    = 1,
   LI_CAPS_BUTTONS = 2,
   LI_CAPS_AXES    = 4,
+  LI_CAPS_ABS     = 8
 } LinuxInputCapsType;
 
 static char remoteStatus = 0xFF; // paired, battery OK
@@ -470,6 +471,23 @@ bool CLinuxInputDevice::KeyEvent(const struct input_event& levt, XBMC_Event& dev
     /* ignore repeat events for buttons */
     if (levt.value == 2)
       return false;
+
+    /* touch devices tend to send the key event before the coordinates, so we
+       cannot rely on m_mouseX and m_mouseY already having the correct values */
+    if (m_deviceCaps & LI_CAPS_ABS)
+    {
+      struct input_absinfo absinfo;
+
+      if (ioctl(m_fd, EVIOCGABS(ABS_X), &absinfo) == 0)
+      {
+        m_mouseX = absinfo.value;
+      }
+
+      if (ioctl(m_fd, EVIOCGABS(ABS_Y), &absinfo) == 0)
+      {
+        m_mouseY = absinfo.value;
+      }
+    }
 
     devt.type = levt.value ? XBMC_MOUSEBUTTONDOWN : XBMC_MOUSEBUTTONUP;
     devt.button.state = levt.value ? XBMC_PRESSED : XBMC_RELEASED;
@@ -953,6 +971,12 @@ void CLinuxInputDevice::GetInfo(int fd)
   {
     m_deviceCaps |= LI_CAPS_AXES;
     m_deviceMaxAxis = std::max(num_rels, num_abs) - 1;
+  }
+
+  /* Absolute X,Y coordinates */
+  if (num_abs >= 2 && num_rels == 0)
+  {
+    m_deviceCaps |= LI_CAPS_ABS;
   }
 
   /* Decide which primary input device to be. */


### PR DESCRIPTION
Touch devices tend to send a key event first and coordinates later.

```
Event: type 1 (EV_KEY), code 330 (BTN_TOUCH), value 1
Event: type 3 (EV_ABS), code 0 (ABS_X), value 45
Event: type 3 (EV_ABS), code 1 (ABS_Y), value 27
```

This does not go along well with the XBMC mouse handling code that
expects to already have the coordinates when processing the EV_KEY.
When it concerns a device with absolute coordinates, fetch the current coordinates with ioctl() as workaround.
