### PR TITLE
[network] CNetWork::IsAvailable: Remove parameter 'wait', because the…

### DIFF
--- a/xbmc/filesystem/DirectoryFactory.cpp
+++ b/xbmc/filesystem/DirectoryFactory.cpp
@@ -174,7 +174,7 @@ IDirectory* CDirectoryFactory::Create(const CURL& url)
   if (url.IsProtocol("resource")) return new CResourceDirectory();
   if (url.IsProtocol("events")) return new CEventsDirectory();
 
-  bool networkAvailable = g_application.getNetwork().IsAvailable(true); // true to wait for the network (if possible)
+  bool networkAvailable = g_application.getNetwork().IsAvailable();
   if (networkAvailable)
   {
     if (url.IsProtocol("ftp") || url.IsProtocol("ftps")) return new CFTPDirectory();

--- a/xbmc/network/Network.cpp
+++ b/xbmc/network/Network.cpp
@@ -243,15 +243,8 @@ bool CNetwork::HasInterfaceForIP(unsigned long address)
    return false;
 }
 
-bool CNetwork::IsAvailable(bool wait /*= false*/)
+bool CNetwork::IsAvailable(void)
 {
-  if (wait)
-  {
-    // NOTE: Not implemented in linuxport branch as 99.9% of the time
-    //       we have the network setup already.  Trunk code has a busy
-    //       wait for 5 seconds here.
-  }
-
   std::vector<CNetworkInterface*>& ifaces = GetInterfaceList();
   return (ifaces.size() != 0);
 }

--- a/xbmc/network/Network.h
+++ b/xbmc/network/Network.h
@@ -123,7 +123,7 @@ public:
    bool HasInterfaceForIP(unsigned long address);
 
    // Return true if there's at least one defined network interface
-   bool IsAvailable(bool wait = false);
+   bool IsAvailable(void);
 
    // Return true if there's at least one interface which is connected
    bool IsConnected(void);

--- a/xbmc/utils/RssReader.cpp
+++ b/xbmc/utils/RssReader.cpp
@@ -143,7 +143,7 @@ void CRssReader::Process()
 
     // we wait for the network to come up
     if ((url.IsProtocol("http") || url.IsProtocol("https")) &&
-        !g_application.getNetwork().IsAvailable(true))
+        !g_application.getNetwork().IsAvailable())
     {
       CLog::Log(LOGWARNING, "RSS: No network connection");
       strXML = "<rss><item><title>"+g_localizeStrings.Get(15301)+"</title></item></rss>";

--- a/xbmc/utils/Weather.cpp
+++ b/xbmc/utils/Weather.cpp
@@ -75,7 +75,7 @@ CWeatherJob::CWeatherJob(int location)
 bool CWeatherJob::DoWork()
 {
   // wait for the network
-  if (!g_application.getNetwork().IsAvailable(true))
+  if (!g_application.getNetwork().IsAvailable())
     return false;
 
   AddonPtr addon;


### PR DESCRIPTION
…re is no implementation behind.
