### PR TITLE
LinuxInputDevice: add support for multi-touch devices

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -158,6 +158,8 @@ DIRECTORY_ARCHIVES += xbmc/storage/android/storage_android.a
 DIRECTORY_ARCHIVES += xbmc/windowing/X11/windowing_X11.a
 else
 DIRECTORY_ARCHIVES += xbmc/input/linux/input_linux.a
+DIRECTORY_ARCHIVES += xbmc/input/touch/input_touch.a
+DIRECTORY_ARCHIVES += xbmc/input/touch/generic/input_touch_generic.a
 DIRECTORY_ARCHIVES += xbmc/network/linux/network_linux.a
 DIRECTORY_ARCHIVES += xbmc/powermanagement/linux/powermanagement_linux.a
 DIRECTORY_ARCHIVES += xbmc/storage/linux/storage_linux.a

--- a/xbmc/input/linux/LinuxInputDevices.h
+++ b/xbmc/input/linux/LinuxInputDevices.h
@@ -26,6 +26,8 @@
 #include "windowing/XBMC_events.h"
 #include "input/XBMC_keyboard.h"
 #include "threads/SingleLock.h"
+#include "input/touch/ITouchInputHandler.h"
+#include "input/touch/generic/IGenericTouchGestureDetector.h"
 
 struct KeymapEntry
 {
@@ -60,6 +62,8 @@ private:
   XBMCMod UpdateModifiers(XBMC_Event& devt);
   bool GetKeymapEntry(KeymapEntry& entry);
   int KeyboardGetSymbol(unsigned short value);
+  bool mtAbsEvent(const struct input_event& levt);
+  bool mtSynEvent(const struct input_event& levt);
 
   int m_fd;
   int m_vt_fd;
@@ -81,6 +85,10 @@ private:
   bool m_bSkipNonKeyEvents;
   bool m_bUnplugged;
   std::deque<XBMC_Event> m_equeue;
+  int m_mt_currentSlot;
+  int m_mt_x[TOUCH_MAX_POINTERS];
+  int m_mt_y[TOUCH_MAX_POINTERS];
+  TouchInput m_mt_event[TOUCH_MAX_POINTERS];
 };
 
 class CLinuxInputDevices

--- a/xbmc/input/touch/ITouchInputHandler.h
+++ b/xbmc/input/touch/ITouchInputHandler.h
@@ -28,6 +28,7 @@
  * \brief Touch input event
  */
 typedef enum {
+  TouchInputUnchanged = 0,
   TouchInputAbort,
   TouchInputDown,
   TouchInputUp,

--- a/xbmc/windowing/WinEventsLinux.cpp
+++ b/xbmc/windowing/WinEventsLinux.cpp
@@ -79,4 +79,9 @@ size_t CWinEventsLinux::GetQueueSize()
   return m_devices.Size();
 }
 
+void CWinEventsLinux::MessagePush(XBMC_Event *ev)
+{
+  g_application.OnEvent(*ev);
+}
+
 #endif

--- a/xbmc/windowing/WinEventsLinux.h
+++ b/xbmc/windowing/WinEventsLinux.h
@@ -31,6 +31,7 @@ public:
   CWinEventsLinux();
   bool MessagePump();
   size_t GetQueueSize();
+  void MessagePush(XBMC_Event *ev);
   void RefreshDevices();
   void Notify(const Observable &obs, const ObservableMessage msg)
   {


### PR DESCRIPTION
Adds support for multi-touch devices on Linux.
Support is limited to devices that are capable of tracking identifiable contacts, and use the type B events described in: https://www.kernel.org/doc/Documentation/input/multi-touch-protocol.txt

Only tested with the rpi-ft5406 touch screen.
