### PR TITLE
[dx11] A set of fixes for DirectX.

### DIFF
--- a/system/shaders/testshader.fx
+++ b/system/shaders/testshader.fx
@@ -27,6 +27,6 @@ technique11 TEST_T
 {
   pass P0
   {
-    SetPixelShader( CompileShader( ps_4_0_level_9_3, TEST() ) );
+    SetPixelShader( CompileShader( ps_4_0_level_9_1, TEST() ) );
   }
 };

--- a/xbmc/cores/VideoRenderers/DXVAHD.cpp
+++ b/xbmc/cores/VideoRenderers/DXVAHD.cpp
@@ -341,8 +341,8 @@ bool CProcessorHD::OpenProcessor()
   cs.Usage         = 0;                                          // 0 - Playback, 1 - Processing
   cs.RGB_Range     = 0;                                          // 0 - Full (0-255), 1 - Limited (16-235)
   cs.YCbCr_Matrix  = m_flags & CONF_FLAGS_YUVCOEF_BT709 ? 1 : 0; // 0 - BT.601, 1 - BT.709
-  cs.YCbCr_xvYCC   = m_flags & CONF_FLAGS_YUV_FULLRANGE ? 1 : 0; // 0 - Conventional YCbCr, 1 - xvYCC
-  cs.Nominal_Range = 0;                                          // 2 - Full luminance range [0-255], 1 - Studio luminance range [16-235], 0 - driver defaults
+  cs.YCbCr_xvYCC   = 1;                                          // 0 - Conventional YCbCr, 1 - xvYCC
+  cs.Nominal_Range = m_flags & CONF_FLAGS_YUV_FULLRANGE ? 2 : 1; // 2 - Full luminance range [0-255], 1 - Studio luminance range [16-235], 0 - driver defaults
   m_pVideoContext->VideoProcessorSetStreamColorSpace(m_pVideoProcessor, DEFAULT_STREAM_INDEX, &cs);
 
   // Output background color (black)
@@ -698,10 +698,10 @@ bool CProcessorHD::Render(CRect src, CRect dst, ID3D11Resource* target, ID3D11Vi
   // Output color space
   D3D11_VIDEO_PROCESSOR_COLOR_SPACE colorSpace = {};
   colorSpace.Usage         = 0;  // 0 - playback, 1 - video processing
-  colorSpace.RGB_Range     = g_Windowing.UseLimitedColor() ? 1 : 0;  // 0 - 0-255, 1 - 16-235
+  colorSpace.RGB_Range     = 0;  // 0 - 0-255, 1 - 16-235
   colorSpace.YCbCr_Matrix  = 1;  // 0 - BT.601, 1 = BT.709
   colorSpace.YCbCr_xvYCC   = 1;  // 0 - Conventional YCbCr, 1 - xvYCC
-  colorSpace.Nominal_Range = 0;  // 2 - 0-255, 1 = 16-235, 0 - undefined
+  colorSpace.Nominal_Range = g_Windowing.UseLimitedColor() ? 1 : 2;  // 2 - 0-255, 1 = 16-235, 0 - undefined
 
   m_pVideoContext->VideoProcessorSetOutputColorSpace(m_pVideoProcessor, &colorSpace);
 

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DXVA.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DXVA.cpp
@@ -489,8 +489,9 @@ bool CDXVAContext::GetConfig(const D3D11_VIDEO_DECODER_DESC *format, D3D11_VIDEO
   return true;
 }
 
-bool CDXVAContext::CreateSurfaces(D3D11_VIDEO_DECODER_DESC format, unsigned int count, unsigned int alignment, ID3D11Texture2D **texture, ID3D11VideoDecoderOutputView **surfaces)
+bool CDXVAContext::CreateSurfaces(D3D11_VIDEO_DECODER_DESC format, unsigned int count, unsigned int alignment, ID3D11VideoDecoderOutputView **surfaces)
 {
+  HRESULT hr = S_OK;
   ID3D11Device* pDevice = g_Windowing.Get3D11Device();
 
   CD3D11_TEXTURE2D_DESC texDesc(format.OutputFormat, 
@@ -498,9 +499,10 @@ bool CDXVAContext::CreateSurfaces(D3D11_VIDEO_DECODER_DESC format, unsigned int 
                                 FFALIGN(format.SampleHeight, alignment), 
                                 count, 1, D3D11_BIND_DECODER);
 
-  if (FAILED(pDevice->CreateTexture2D(&texDesc, NULL, texture)))
+  ID3D11Texture2D *texture = nullptr;
+  if (FAILED(pDevice->CreateTexture2D(&texDesc, NULL, &texture)))
   {
-    CLog::Log(LOGNOTICE, "%s - failed creating decoder texture array", __FUNCTION__);
+    CLog::Log(LOGERROR, "%s - failed creating decoder texture array", __FUNCTION__);
     return false;
   }
 
@@ -509,17 +511,26 @@ bool CDXVAContext::CreateSurfaces(D3D11_VIDEO_DECODER_DESC format, unsigned int 
   vdovDesc.Texture2D.ArraySlice = 0;
   vdovDesc.ViewDimension = D3D11_VDOV_DIMENSION_TEXTURE2D;
 
-  for (unsigned i = 0; i < count; ++i)
+  size_t i;
+  for (i = 0; i < count; ++i)
   {
     vdovDesc.Texture2D.ArraySlice = D3D11CalcSubresource(0, i, texDesc.MipLevels);
-    if (FAILED(m_service->CreateVideoDecoderOutputView(*texture, &vdovDesc, &surfaces[i])))
+    hr = m_service->CreateVideoDecoderOutputView(texture, &vdovDesc, &surfaces[i]);
+    if (FAILED(hr))
     {
-      CLog::Log(LOGNOTICE, "%s - failed creating surfaces", __FUNCTION__);
-      return false;
+      CLog::Log(LOGERROR, "%s - failed creating surfaces", __FUNCTION__);
+      break;
     }
-
   }
-  return true;
+  SAFE_RELEASE(texture);
+
+  if (FAILED(hr))
+  {
+    for (size_t j = 0; j < i; ++j)
+      SAFE_RELEASE(surfaces[j]);
+  }
+
+  return SUCCEEDED(hr);
 }
 
 bool CDXVAContext::CreateDecoder(D3D11_VIDEO_DECODER_DESC *format, const D3D11_VIDEO_DECODER_CONFIG *config, CDXVADecoderWrapper **decoder)
@@ -753,7 +764,6 @@ CDecoder::CDecoder()
   m_context          = (dxva_context*)calloc(1, sizeof(dxva_context));
   m_context->cfg     = reinterpret_cast<DXVA2_ConfigPictureDecode*>(calloc(1, sizeof(DXVA2_ConfigPictureDecode)));
   m_context->surface = reinterpret_cast<IDirect3DSurface9**>(calloc(32, sizeof(IDirect3DSurface9*)));
-  m_viewResource = nullptr;
   m_surface_alignment = 16;
   g_Windowing.Register(this);
 }
@@ -792,7 +802,6 @@ void CDecoder::Close()
     m_dxva_context->Release(this);
   }
   m_dxva_context = nullptr;
-  SAFE_RELEASE(m_viewResource);
 }
 
 static bool CheckH264L41(AVCodecContext *avctx)
@@ -1110,7 +1119,7 @@ bool CDecoder::OpenDecoder()
   CLog::Log(LOGDEBUG, "DXVA - allocating %d surfaces with format %d", m_context->surface_count, m_format.OutputFormat);
 
   if (!m_dxva_context->CreateSurfaces(m_format, m_context->surface_count, m_surface_alignment, 
-                                      &m_viewResource, reinterpret_cast<ID3D11VideoDecoderOutputView**>(m_context->surface)))
+                                      reinterpret_cast<ID3D11VideoDecoderOutputView**>(m_context->surface)))
     return false;
 
   for(unsigned i = 0; i < m_context->surface_count; i++)

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DXVA.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DXVA.h
@@ -112,7 +112,7 @@ public:
   static bool EnsureContext(CDXVAContext **ctx, CDecoder *decoder);
   bool GetInputAndTarget(int codec, GUID &inGuid, DXGI_FORMAT &outFormat);
   bool GetConfig(const D3D11_VIDEO_DECODER_DESC *format, D3D11_VIDEO_DECODER_CONFIG &config);
-  bool CreateSurfaces(D3D11_VIDEO_DECODER_DESC format, unsigned int count, unsigned int alignment, ID3D11Texture2D **texture, ID3D11VideoDecoderOutputView **surfaces);
+  bool CreateSurfaces(D3D11_VIDEO_DECODER_DESC format, unsigned int count, unsigned int alignment, ID3D11VideoDecoderOutputView **surfaces);
   bool CreateDecoder(D3D11_VIDEO_DECODER_DESC *format, const D3D11_VIDEO_DECODER_CONFIG *config, CDXVADecoderWrapper **decoder);
   void Release(CDecoder *decoder);
   ID3D11VideoContext* GetVideoContext() { return m_vcontext; }
@@ -186,7 +186,6 @@ protected:
   unsigned int                 m_surface_alignment;
   CCriticalSection             m_section;
   CEvent                       m_event;
-  ID3D11Texture2D*             m_viewResource;
 };
 
 };


### PR DESCRIPTION
1. Fixes color range when DXVA processor is used for rendering.
2. Fixes a possible segfault in video drivers when driver supports only FL9.1/9.2
3. Re-factoring: see commit details.
