### PR TITLE
Revert "[pvr] changed: also use CACHESTATE_PVR in dvdplayer when play…

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -4784,7 +4784,6 @@ bool CDVDPlayer::SwitchChannel(const CPVRChannelPtr &channel)
 bool CDVDPlayer::CachePVRStream(void) const
 {
   return m_pInputStream->IsStreamType(DVDSTREAM_TYPE_PVRMANAGER) &&
-      (!g_PVRManager.IsPlayingRecording() ||
-          (m_item.HasPVRRecordingInfoTag() && m_item.GetPVRRecordingInfoTag()->IsBeingRecorded()))&&
+      !g_PVRManager.IsPlayingRecording() &&
       g_advancedSettings.m_bPVRCacheInDvdPlayer;
 }


### PR DESCRIPTION
…ing a recording that's still running"

This reverts commit 78901e2ffb03f6b3723293c8e4598d3a08aa7e0a.

As discussed here: https://github.com/xbmc/xbmc/pull/7905#issuecomment-143214649

@Glenn-1990 mind testing this?
