### PR TITLE
[confluence] Added 'Hide border on the bottom of the screen" option

### DIFF
--- a/addons/skin.confluence/720p/FileManager.xml
+++ b/addons/skin.confluence/720p/FileManager.xml
@@ -5,6 +5,7 @@
 	<controls>
 		<include>CommonBackground</include>
 		<control type="image">
+			<visible>!Skin.HasSetting(HideFloorBorder)</visible>
 			<left>0</left>
 			<top>100r</top>
 			<width>1280</width>
@@ -54,6 +55,7 @@
 				<texture border="20">ContentPanel.png</texture>
 			</control>
 			<control type="image">
+				<visible>!Skin.HasSetting(HideFloorBorder)</visible>
 				<left>0</left>
 				<top>612</top>
 				<width>610</width>

--- a/addons/skin.confluence/720p/Home.xml
+++ b/addons/skin.confluence/720p/Home.xml
@@ -9,6 +9,7 @@
 	<controls>
 		<include>CommonBackground</include>
 		<control type="image">
+			<visible>!Skin.HasSetting(HideFloorBorder)</visible>
 			<left>0</left>
 			<top>90r</top>
 			<width>1280</width>

--- a/addons/skin.confluence/720p/IncludesBackgroundBuilding.xml
+++ b/addons/skin.confluence/720p/IncludesBackgroundBuilding.xml
@@ -72,6 +72,7 @@
 	</include>
 	<include name="ContentPanelBackgrounds">
 		<control type="image">
+			<visible>!Skin.HasSetting(HideFloorBorder)</visible>
 			<left>0</left>
 			<top>100r</top>
 			<width>1280</width>
@@ -93,6 +94,7 @@
 					<texture border="15">ContentPanel.png</texture>
 				</control>
 				<control type="image">
+					<visible>!Skin.HasSetting(HideFloorBorder)</visible>
 					<left>50</left>
 					<top>652</top>
 					<width>750</width>
@@ -111,6 +113,7 @@
 					<texture border="15">ContentPanel.png</texture>
 				</control>
 				<control type="image">
+					<visible>!Skin.HasSetting(HideFloorBorder)</visible>
 					<left>50</left>
 					<top>652</top>
 					<width>640</width>
@@ -125,6 +128,7 @@
 					<texture border="15">ContentPanel.png</texture>
 				</control>
 				<control type="image">
+					<visible>!Skin.HasSetting(HideFloorBorder)</visible>
 					<left>700</left>
 					<top>652</top>
 					<width>530</width>
@@ -143,6 +147,7 @@
 					<texture border="15">ContentPanel.png</texture>
 				</control>
 				<control type="image">
+					<visible>!Skin.HasSetting(HideFloorBorder)</visible>
 					<left>50</left>
 					<top>652</top>
 					<width>840</width>
@@ -157,6 +162,7 @@
 					<texture border="15">ContentPanel.png</texture>
 				</control>
 				<control type="image">
+					<visible>!Skin.HasSetting(HideFloorBorder)</visible>
 					<left>900</left>
 					<top>652</top>
 					<width>330</width>
@@ -175,6 +181,7 @@
 					<texture border="15">ContentPanel.png</texture>
 				</control>
 				<control type="image">
+					<visible>!Skin.HasSetting(HideFloorBorder)</visible>
 					<left>50</left>
 					<top>652</top>
 					<width>1180</width>
@@ -193,6 +200,7 @@
 					<texture border="15">ContentPanel.png</texture>
 				</control>
 				<control type="image">
+					<visible>!Skin.HasSetting(HideFloorBorder)</visible>
 					<left>50</left>
 					<top>652</top>
 					<width>640</width>
@@ -207,6 +215,7 @@
 					<texture border="15">ContentPanel.png</texture>
 				</control>
 				<control type="image">
+					<visible>!Skin.HasSetting(HideFloorBorder)</visible>
 					<left>700</left>
 					<top>652</top>
 					<width>550</width>
@@ -225,6 +234,7 @@
 					<texture border="15">ContentPanel.png</texture>
 				</control>
 				<control type="image">
+					<visible>!Skin.HasSetting(HideFloorBorder)</visible>
 					<left>75</left>
 					<top>652</top>
 					<width>1130</width>
@@ -243,6 +253,7 @@
 					<texture border="15">ContentPanel.png</texture>
 				</control>
 				<control type="image">
+					<visible>!Skin.HasSetting(HideFloorBorder)</visible>
 					<left>50</left>
 					<top>652</top>
 					<width>490</width>
@@ -257,6 +268,7 @@
 					<texture border="15">ContentPanel.png</texture>
 				</control>
 				<control type="image">
+					<visible>!Skin.HasSetting(HideFloorBorder)</visible>
 					<left>550</left>
 					<top>652</top>
 					<width>680</width>
@@ -275,6 +287,7 @@
 					<texture border="15">ContentPanel.png</texture>
 				</control>
 				<control type="image">
+					<visible>!Skin.HasSetting(HideFloorBorder)</visible>
 					<left>50</left>
 					<top>652</top>
 					<width>400</width>
@@ -289,6 +302,7 @@
 					<texture border="15">ContentPanel.png</texture>
 				</control>
 				<control type="image">
+					<visible>!Skin.HasSetting(HideFloorBorder)</visible>
 					<left>460</left>
 					<top>652</top>
 					<width>770</width>

--- a/addons/skin.confluence/720p/LoginScreen.xml
+++ b/addons/skin.confluence/720p/LoginScreen.xml
@@ -11,6 +11,7 @@
 		<control type="group">
 			<include>Window_OpenClose_Animation</include>
 			<control type="image">
+				<visible>!Skin.HasSetting(HideFloorBorder)</visible>
 				<left>0</left>
 				<top>100r</top>
 				<width>1280</width>
@@ -37,6 +38,7 @@
 				<texture border="10">ContentPanel.png</texture>
 			</control>
 			<control type="image">
+				<visible>!Skin.HasSetting(HideFloorBorder)</visible>
 				<left>265</left>
 				<top>652</top>
 				<width>750</width>

--- a/addons/skin.confluence/720p/MyPVRChannels.xml
+++ b/addons/skin.confluence/720p/MyPVRChannels.xml
@@ -7,6 +7,7 @@
 	<controls>
 		<include>CommonBackground</include>
 		<control type="image">
+			<visible>!Skin.HasSetting(HideFloorBorder)</visible>
 			<left>0</left>
 			<top>100r</top>
 			<width>1280</width>
@@ -46,6 +47,7 @@
 				</control>
 			</control>
 			<control type="image">
+				<visible>!Skin.HasSetting(HideFloorBorder)</visible>
 				<left>50</left>
 				<top>652</top>
 				<width>450</width>
@@ -60,6 +62,7 @@
 				<texture border="15">ContentPanel.png</texture>
 			</control>
 			<control type="image">
+				<visible>!Skin.HasSetting(HideFloorBorder)</visible>
 				<left>510</left>
 				<top>652</top>
 				<width>730</width>

--- a/addons/skin.confluence/720p/MyPVRGuide.xml
+++ b/addons/skin.confluence/720p/MyPVRGuide.xml
@@ -7,6 +7,7 @@
 	<controls>
 		<include>CommonBackground</include>
 		<control type="image">
+			<visible>!Skin.HasSetting(HideFloorBorder)</visible>
 			<left>0</left>
 			<top>100r</top>
 			<width>1280</width>
@@ -38,6 +39,7 @@
 						<texture border="15">ContentPanel.png</texture>
 					</control>
 					<control type="image">
+						<visible>!Skin.HasSetting(HideFloorBorder)</visible>
 						<left>55</left>
 						<top>652</top>
 						<width>1170</width>

--- a/addons/skin.confluence/720p/MyPVRRecordings.xml
+++ b/addons/skin.confluence/720p/MyPVRRecordings.xml
@@ -7,6 +7,7 @@
 	<controls>
 		<include>CommonBackground</include>
 		<control type="image">
+			<visible>!Skin.HasSetting(HideFloorBorder)</visible>
 			<left>0</left>
 			<top>100r</top>
 			<width>1280</width>
@@ -28,6 +29,7 @@
 					<texture border="15">ContentPanel.png</texture>
 				</control>
 				<control type="image">
+					<visible>!Skin.HasSetting(HideFloorBorder)</visible>
 					<left>50</left>
 					<top>652</top>
 					<width>840</width>
@@ -42,6 +44,7 @@
 					<texture border="15">ContentPanel.png</texture>
 				</control>
 				<control type="image">
+					<visible>!Skin.HasSetting(HideFloorBorder)</visible>
 					<left>900</left>
 					<top>652</top>
 					<width>330</width>

--- a/addons/skin.confluence/720p/MyPVRSearch.xml
+++ b/addons/skin.confluence/720p/MyPVRSearch.xml
@@ -7,6 +7,7 @@
 	<controls>
 		<include>CommonBackground</include>
 		<control type="image">
+			<visible>!Skin.HasSetting(HideFloorBorder)</visible>
 			<left>0</left>
 			<top>100r</top>
 			<width>1280</width>
@@ -38,6 +39,7 @@
 						<texture border="15">ContentPanel.png</texture>
 					</control>
 					<control type="image">
+						<visible>!Skin.HasSetting(HideFloorBorder)</visible>
 						<left>55</left>
 						<top>652</top>
 						<width>1170</width>

--- a/addons/skin.confluence/720p/MyPVRTimers.xml
+++ b/addons/skin.confluence/720p/MyPVRTimers.xml
@@ -7,6 +7,7 @@
 	<controls>
 		<include>CommonBackground</include>
 		<control type="image">
+			<visible>!Skin.HasSetting(HideFloorBorder)</visible>
 			<left>0</left>
 			<top>100r</top>
 			<width>1280</width>
@@ -38,6 +39,7 @@
 						<texture border="15">ContentPanel.png</texture>
 					</control>
 					<control type="image">
+						<visible>!Skin.HasSetting(HideFloorBorder)</visible>
 						<left>55</left>
 						<top>652</top>
 						<width>1170</width>

--- a/addons/skin.confluence/720p/MyWeather.xml
+++ b/addons/skin.confluence/720p/MyWeather.xml
@@ -7,6 +7,7 @@
 	<controls>
 		<include>CommonBackground</include>
 		<control type="multiimage">
+			<visible>!Skin.HasSetting(HideFloorBorder)</visible>
 			<left>0</left>
 			<top>0</top>
 			<width>1280</width>
@@ -72,6 +73,7 @@
 					<texture border="20">ContentPanel.png</texture>
 				</control>
 				<control type="image">
+					<visible>!Skin.HasSetting(HideFloorBorder)</visible>
 					<left>0</left>
 					<top>612</top>
 					<width>500</width>
@@ -429,6 +431,7 @@
 					<texture border="20">ContentPanel.png</texture>
 				</control>
 				<control type="image">
+					<visible>!Skin.HasSetting(HideFloorBorder)</visible>
 					<left>0</left>
 					<top>612</top>
 					<width>650</width>

--- a/addons/skin.confluence/720p/Settings.xml
+++ b/addons/skin.confluence/720p/Settings.xml
@@ -5,6 +5,7 @@
 	<controls>
 		<include>CommonBackground</include>
 		<control type="image">
+			<visible>!Skin.HasSetting(HideFloorBorder)</visible>
 			<left>0</left>
 			<top>100r</top>
 			<width>1280</width>
@@ -32,6 +33,7 @@
 				<texture border="15">ContentPanel.png</texture>
 			</control>
 			<control type="image">
+				<visible>!Skin.HasSetting(HideFloorBorder)</visible>
 				<left>5</left>
 				<top>625</top>
 				<width>1090</width>

--- a/addons/skin.confluence/720p/SettingsCategory.xml
+++ b/addons/skin.confluence/720p/SettingsCategory.xml
@@ -5,6 +5,7 @@
 	<controls>
 		<include>CommonBackground</include>
 		<control type="image">
+			<visible>!Skin.HasSetting(HideFloorBorder)</visible>
 			<left>0</left>
 			<top>100r</top>
 			<width>1280</width>
@@ -31,6 +32,7 @@
 				<texture border="15">ContentPanel.png</texture>
 			</control>
 			<control type="image">
+				<visible>!Skin.HasSetting(HideFloorBorder)</visible>
 				<left>5</left>
 				<top>625</top>
 				<width>1090</width>

--- a/addons/skin.confluence/720p/SettingsProfile.xml
+++ b/addons/skin.confluence/720p/SettingsProfile.xml
@@ -5,6 +5,7 @@
 	<controls>
 		<include>CommonBackground</include>
 		<control type="image">
+			<visible>!Skin.HasSetting(HideFloorBorder)</visible>
 			<left>0</left>
 			<top>100r</top>
 			<width>1280</width>
@@ -32,6 +33,7 @@
 				<texture border="15">ContentPanel.png</texture>
 			</control>
 			<control type="image">
+				<visible>!Skin.HasSetting(HideFloorBorder)</visible>
 				<left>5</left>
 				<top>625</top>
 				<width>1090</width>

--- a/addons/skin.confluence/720p/SettingsSystemInfo.xml
+++ b/addons/skin.confluence/720p/SettingsSystemInfo.xml
@@ -5,6 +5,7 @@
 	<controls>
 		<include>CommonBackground</include>
 		<control type="image">
+			<visible>!Skin.HasSetting(HideFloorBorder)</visible>
 			<left>0</left>
 			<top>100r</top>
 			<width>1280</width>
@@ -32,6 +33,7 @@
 				<texture border="15">ContentPanel.png</texture>
 			</control>
 			<control type="image">
+				<visible>!Skin.HasSetting(HideFloorBorder)</visible>
 				<left>5</left>
 				<top>625</top>
 				<width>1090</width>

--- a/addons/skin.confluence/720p/SkinSettings.xml
+++ b/addons/skin.confluence/720p/SkinSettings.xml
@@ -4,6 +4,7 @@
 	<controls>
 		<include>CommonBackground</include>
 		<control type="image">
+			<visible>!Skin.HasSetting(HideFloorBorder)</visible>
 			<left>0</left>
 			<top>100r</top>
 			<width>1280</width>
@@ -57,6 +58,7 @@
 				<texture border="15">ContentPanel.png</texture>
 			</control>
 			<control type="image">
+				<visible>!Skin.HasSetting(HideFloorBorder)</visible>
 				<left>5</left>
 				<top>625</top>
 				<width>1090</width>
@@ -685,6 +687,18 @@
 						<texturenofocus>MenuItemNF.png</texturenofocus>
 						<onclick>Skin.SetImage(CustomBackgroundPath)</onclick>
 						<enable>Skin.HasSetting(UseCustomBackground)</enable>
+					</control>
+					<control type="radiobutton" id="313">
+						<width>750</width>
+						<height>40</height>
+						<font>font13</font>
+						<label>31961</label>
+						<textcolor>grey2</textcolor>
+						<focusedcolor>white</focusedcolor>
+						<texturefocus>MenuItemFO.png</texturefocus>
+						<texturenofocus>MenuItemNF.png</texturenofocus>
+						<onclick>Skin.ToggleSetting(HideFloorBorder)</onclick>
+						<selected>Skin.HasSetting(HideFloorBorder)</selected>
 					</control>
 				</control>
 				<control type="group">

--- a/addons/skin.confluence/720p/script-NextAired-TVGuide.xml
+++ b/addons/skin.confluence/720p/script-NextAired-TVGuide.xml
@@ -98,6 +98,7 @@
 			</control>
 		</control>
 		<control type="image">
+			<visible>!Skin.HasSetting(HideFloorBorder)</visible>
 			<left>0</left>
 			<top>100r</top>
 			<width>1280</width>
@@ -155,6 +156,7 @@
 					<texture border="15">ContentPanel.png</texture>
 				</control>
 				<control type="image">
+					<visible>!Skin.HasSetting(HideFloorBorder)</visible>
 					<left>0</left>
 					<top>592</top>
 					<width>300</width>
@@ -198,6 +200,7 @@
 					<texture border="15">ContentPanel.png</texture>
 				</control>
 				<control type="image">
+					<visible>!Skin.HasSetting(HideFloorBorder)</visible>
 					<left>0</left>
 					<top>592</top>
 					<width>300</width>
@@ -241,6 +244,7 @@
 					<texture border="15">ContentPanel.png</texture>
 				</control>
 				<control type="image">
+					<visible>!Skin.HasSetting(HideFloorBorder)</visible>
 					<left>0</left>
 					<top>592</top>
 					<width>300</width>
@@ -284,6 +288,7 @@
 					<texture border="15">ContentPanel.png</texture>
 				</control>
 				<control type="image">
+					<visible>!Skin.HasSetting(HideFloorBorder)</visible>
 					<left>0</left>
 					<top>592</top>
 					<width>300</width>
@@ -327,6 +332,7 @@
 					<texture border="15">ContentPanel.png</texture>
 				</control>
 				<control type="image">
+					<visible>!Skin.HasSetting(HideFloorBorder)</visible>
 					<left>0</left>
 					<top>592</top>
 					<width>300</width>
@@ -370,6 +376,7 @@
 					<texture border="15">ContentPanel.png</texture>
 				</control>
 				<control type="image">
+					<visible>!Skin.HasSetting(HideFloorBorder)</visible>
 					<left>0</left>
 					<top>592</top>
 					<width>300</width>
@@ -413,6 +420,7 @@
 					<texture border="15">ContentPanel.png</texture>
 				</control>
 				<control type="image">
+					<visible>!Skin.HasSetting(HideFloorBorder)</visible>
 					<left>0</left>
 					<top>592</top>
 					<width>300</width>

--- a/addons/skin.confluence/language/resource.language.en_gb/strings.po
+++ b/addons/skin.confluence/language/resource.language.en_gb/strings.po
@@ -713,3 +713,7 @@ msgstr ""
 msgctxt "#31960"
 msgid "RADIO"
 msgstr ""
+
+msgctxt "#31961"
+msgid "Hide border on the bottom of the screen"
+msgstr ""

--- a/system/peripherals.xml
+++ b/system/peripherals.xml
@@ -16,7 +16,7 @@
     <setting key="send_inactive_source" type="bool" value="1" label="36025" order="5" />
     <setting key="cec_standby_screensaver" type="bool" value="0" label="36009" order="6" />
     <setting key="cec_wake_screensaver" type="bool" value="1" label="36010" order="7" />
-    <setting key="standby_pc_on_tv_standby" type="enum" value="13011" label="36029" order="8" lvalues="36028|13005|13011" />
+    <setting key="standby_pc_on_tv_standby" type="enum" value="13011" label="36029" order="8" lvalues="36028|13005|13011|13009|36043|36045" />
     <setting key="standby_tv_on_pc_standby" type="bool" value="1" label="36026" order="9" />
     <setting key="use_tv_menu_language" type="bool" value="1" label="36018" order="10" />
     <setting key="pause_playback_on_deactivate" type="bool" value="1" label="36033" configurable="0" />


### PR DESCRIPTION
[confluence] Added 'Hide border on the bottom of the screen" option
Hides gray background for RSS feed (floor.png) and hides a mirror
reflection on it (ContentPanelMirror.png)

Screens are taken through VNC, sorry for JPEG artifacts somewhere.

(Home screen, footer is hidden, RSS is disabled)
![home_greyline_disabled](https://cloud.githubusercontent.com/assets/2893566/10112412/a0d2afc2-63e3-11e5-9384-1bf7a6ad5900.JPG)
(Home screen, footer is hidden, RSS is enabled)
![home_greyline_disabled_rss_enabled](https://cloud.githubusercontent.com/assets/2893566/10112413/a0d2b3d2-63e3-11e5-93f3-e176e884cc42.JPG)
(Settings screen, footer is hidden)
![settings_greyline_disable](https://cloud.githubusercontent.com/assets/2893566/10112410/a0cfb880-63e3-11e5-9c48-5906d8937a84.JPG)
(Home screen, footer is shown (by default))
![home_greyline_enabled](https://cloud.githubusercontent.com/assets/2893566/10112411/a0d1c2d8-63e3-11e5-96a3-3375bffd4536.JPG)
(Settings screen, footer is shown (by default))
![settings_greyline_enable](https://cloud.githubusercontent.com/assets/2893566/10112414/a0d33adc-63e3-11e5-8b40-321ded4bb86f.JPG)
