### PR TITLE
dvdplayer: fix non DVB subs after 5c0d694fa769f311bc5e14dec04c260267a…

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayCodecFFmpeg.cpp
@@ -243,14 +243,17 @@ CDVDOverlay* CDVDOverlayCodecFFmpeg::GetOverlay()
     m_height = m_pCodecContext->height;
     m_width  = m_pCodecContext->width;
 
-    // ETSI EN 300 743 V1.3.1
-    // 5.3.1
-    // Absence of a DDS in a stream implies that the stream is coded in accordance with EN 300 743 (V1.2.1) [5] and that a
-    // display width of 720 pixels and a display height of 576 lines may be assumed.
-    if (!m_height && !m_width)
+    if (m_pCodecContext->codec_id == AV_CODEC_ID_DVB_SUBTITLE)
     {
-      m_width = 720;
-      m_height = 576;
+      // ETSI EN 300 743 V1.3.1
+      // 5.3.1
+      // Absence of a DDS in a stream implies that the stream is coded in accordance with EN 300 743 (V1.2.1) [5] and that a
+      // display width of 720 pixels and a display height of 576 lines may be assumed.
+      if (!m_height && !m_width)
+      {
+        m_width = 720;
+        m_height = 576;
+      }
     }
 
     RENDER_STEREO_MODE render_stereo_mode = g_graphicsContext.GetStereoMode();


### PR DESCRIPTION
see title

@ace20022 @jspdr does this fix the issue

@Jalle19 could you test if 1080i still works with this patch?
