### PR TITLE
[PVR] Fix for recording associations

### DIFF
--- a/xbmc/epg/EpgContainer.cpp
+++ b/xbmc/epg/EpgContainer.cpp
@@ -175,9 +175,6 @@ void CEpgContainer::Start(bool bAsync)
 
   LoadFromDB();
 
-  if (g_PVRManager.IsStarted())
-    g_PVRManager.Recordings()->UpdateEpgTags();
-
   CSingleLock lock(m_critSection);
   if (!m_bStop)
   {
@@ -618,8 +615,6 @@ bool CEpgContainer::UpdateEPG(bool bOnlyPending /* = false */)
       m_updateEvent.Set();
     }
 
-    g_PVRManager.Recordings()->UpdateEpgTags();
-
     if (bShowProgress && !bOnlyPending)
       CloseProgressDialog();
 
@@ -675,6 +670,9 @@ bool CEpgContainer::UpdateEPG(bool bOnlyPending /* = false */)
   }
   else
   {
+    if (g_PVRManager.IsStarted())
+      g_PVRManager.Recordings()->UpdateEpgTags();
+
     CSingleLock lock(m_critSection);
     CDateTime::GetCurrentDateTime().GetAsUTCDateTime().GetAsTime(m_iNextEpgUpdate);
     m_iNextEpgUpdate += g_advancedSettings.m_iEpgUpdateCheckInterval;


### PR DESCRIPTION
For a while now I have been investigating problems with the association between Recordings and EPG guide entries (currently implemented for pvr.mythtv and pvr.hts), as they didn't seem to be working reliably. (Often the 'play' Icon didn't appear, especially on my RPi / RPI2).

These fixes now provide reliably working EPG 'play' icons on my RPi (openelec based test build using kodi master) and core2 x86 kodi master gentoo system (using my 'test' branch of pvr.mythtv).

The following changes are included:
1. Check for EPG associations after client EPG update in the correct place in the EPG update sequence (This is why it wasn't working reliably IMO).
2. Only check for EPG associations after client EPG update (not after EPG DB load and after client EPG update). We always check for a client update after DB load anyhow, so this way existing associations are only looked for once. As this requires a non-optimized EPG database search for each recording association, doing it the minimal number of times is better, even if this is a background task
3. Stop clearing the m_Recordings map in CPVRRecordings::UpdateFromClients. (Allows  existing recordings to be recognized instead of always being identified as 'new'). This might also solve a small memory leak if 'new' recordings were always reserving new memory space. I haven't seen any adverse symptoms associated with deleting this Clear() call (209bc86), but don't know why it was added in the first place, so might have missed something.
4. Only update recording EPG associations if they have changed, been added, or this is a new recording. (Deleted recordings seem to remove the association/reference without extra changes, probably as a result of deleting the shared pointer to the recording. I haven't investigated this in detail but it seems to work without immediately obvious nasty side effects)
5. Targeted debug logging to help other PVR clients implementing the 'Recording<->EPG association' feature.

As this also affects Isengard, IMO a backport (or even simply application or the patch to the Isengard branch?) might be a good idea as well.

Pings: @ksooo @opdenkamp @ryangribble @janbar 
