### PR TITLE
[PVR] Dont confirm timer add

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
@@ -67,17 +67,13 @@ bool CGUIDialogPVRGuideInfo::ActionStartTimer(const CEpgInfoTagPtr &tag)
   if (!channel || !g_PVRManager.CheckParentalLock(channel))
     return false;
 
-  // prompt user for confirmation of channel record
-  if (CGUIDialogYesNo::ShowAndGetInput(CVariant{264} /* "Record" */, CVariant{tag->Title()}))
-  {
-    Close();
+  Close();
 
-    CPVRTimerInfoTagPtr newTimer = CPVRTimerInfoTag::CreateFromEpg(tag);
-    if (newTimer)
-      bReturn = CPVRTimers::AddTimer(newTimer);
-    else
-      bReturn = false;
-  }
+  CPVRTimerInfoTagPtr newTimer = CPVRTimerInfoTag::CreateFromEpg(tag);
+  if (newTimer)
+    bReturn = CPVRTimers::AddTimer(newTimer);
+  else
+    bReturn = false;
 
   return bReturn;
 }

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -448,7 +448,7 @@ bool CGUIWindowPVRBase::ShowTimerSettings(CFileItem *item)
   return pDlgInfo->IsConfirmed();
 }
 
-bool CGUIWindowPVRBase::StartRecordFile(CFileItem *item, bool bAdvanced)
+bool CGUIWindowPVRBase::AddTimer(CFileItem *item, bool bAdvanced)
 {
   if (!item->HasEPGInfoTag())
     return false;

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -483,11 +483,6 @@ bool CGUIWindowPVRBase::AddTimer(CFileItem *item, bool bAdvanced)
   }
   else
   {
-    // ask for confirmation before starting a timer
-    if (!CGUIDialogYesNo::ShowAndGetInput(
-        CVariant{264} /* "Record" */, CVariant{tag->PVRChannelName()}, CVariant{""}, CVariant{tag->Title()}))
-      return false;
-  
     CPVRTimerInfoTagPtr newTimer = CPVRTimerInfoTag::CreateFromEpg(tag);
 
     if (newTimer)
@@ -769,21 +764,6 @@ bool CGUIWindowPVRBase::ActionRecord(CFileItem *item)
 
   if (epgTag->Timer() == NULL)
   {
-    /* create a confirmation dialog */
-    CGUIDialogYesNo* pDialog = (CGUIDialogYesNo*) g_windowManager.GetWindow(WINDOW_DIALOG_YES_NO);
-    if (!pDialog)
-      return bReturn;
-
-    pDialog->SetHeading(CVariant{264});
-    pDialog->SetLine(0, CVariant{""});
-    pDialog->SetLine(1, CVariant{epgTag->Title()});
-    pDialog->SetLine(2, CVariant{""});
-    pDialog->Open();
-
-    /* prompt for the user's confirmation */
-    if (!pDialog->IsConfirmed())
-      return bReturn;
-
     CPVRTimerInfoTagPtr newTimer = CPVRTimerInfoTag::CreateFromEpg(epgTag);
     if (newTimer)
     {

--- a/xbmc/pvr/windows/GUIWindowPVRBase.h
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.h
@@ -102,7 +102,7 @@ namespace PVR
     virtual bool PlayRecording(CFileItem *item, bool bPlayMinimized = false, bool bCheckResume = true);
     virtual bool PlayFile(CFileItem *item, bool bPlayMinimized = false, bool bCheckResume = true);
     virtual bool ShowTimerSettings(CFileItem *item);
-    virtual bool StartRecordFile(CFileItem *item, bool bAdvanced = false);
+    virtual bool AddTimer(CFileItem *item, bool bAdvanced = false);
     virtual bool StopRecordFile(CFileItem *item);
     virtual void ShowEPGInfo(CFileItem *item);
     virtual void ShowRecordingInfo(CFileItem *item);

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -492,7 +492,7 @@ bool CGUIWindowPVRGuide::OnContextButtonStartRecord(CFileItem *item, CONTEXT_BUT
   if ((button == CONTEXT_BUTTON_START_RECORD) ||
       (button == CONTEXT_BUTTON_ADVANCED_RECORD))
   {
-    StartRecordFile(item, button == CONTEXT_BUTTON_ADVANCED_RECORD);
+    AddTimer(item, button == CONTEXT_BUTTON_ADVANCED_RECORD);
     bReturn = true;
   }
 

--- a/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
@@ -272,7 +272,7 @@ bool CGUIWindowPVRSearch::OnContextButtonStartRecord(CFileItem *item, CONTEXT_BU
   if ((button == CONTEXT_BUTTON_START_RECORD) ||
       (button == CONTEXT_BUTTON_ADVANCED_RECORD))
   {
-    StartRecordFile(item, button == CONTEXT_BUTTON_ADVANCED_RECORD);
+    AddTimer(item, button == CONTEXT_BUTTON_ADVANCED_RECORD);
     bReturn = true;
   }
 


### PR DESCRIPTION
When a user adds a timer, for example using context menu on a selected EPG entry, a dialog pops up, asking for confirmation to add the timer. This makes perfect sense when deleting a timer, but for creation imo this is nonsense and I'm backed by different people in the forum. This PR removes this confirmation dialogs. :-)

The first commit just renames a member function to reflect what is actually does.

@xhaggi what do you think?
