### PR TITLE
[PVR] Search window fixes

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
@@ -121,15 +121,21 @@ bool CGUIWindowPVRSearch::OnContextButton(const CFileItem &item, CONTEXT_BUTTON 
         m_searchfilter.m_strSearchTerm = "\"" + item.GetEPGInfoTag()->Title() + "\"";
       else if (item.IsPVRChannel())
       {
-        CEpgInfoTagPtr tag(item.GetPVRChannelInfoTag()->GetEPGNow());
+        const CEpgInfoTagPtr tag(item.GetPVRChannelInfoTag()->GetEPGNow());
         if (tag)
           m_searchfilter.m_strSearchTerm = "\"" + tag->Title() + "\"";
       }
       else if (item.IsUsablePVRRecording())
         m_searchfilter.m_strSearchTerm = "\"" + item.GetPVRRecordingInfoTag()->m_strTitle + "\"";
       else if (item.IsPVRTimer())
-        m_searchfilter.m_strSearchTerm = "\"" + item.GetPVRTimerInfoTag()->m_strTitle + "\"";
-
+      {
+        const CPVRTimerInfoTagPtr info(item.GetPVRTimerInfoTag());
+        const CEpgInfoTagPtr tag(info->GetEpgInfoTag());
+        if (tag)
+          m_searchfilter.m_strSearchTerm = "\"" + tag->Title() + "\"";
+        else
+          m_searchfilter.m_strSearchTerm = "\"" + info->m_strTitle + "\"";
+      }
       m_bSearchConfirmed = true;
       Refresh(true);
       bReturn = true;

--- a/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
@@ -150,20 +150,19 @@ bool CGUIWindowPVRSearch::OnContextButton(const CFileItem &item, CONTEXT_BUTTON 
 
 void CGUIWindowPVRSearch::OnPrepareFileItems(CFileItemList &items)
 {
-  items.Clear();
-
-  CFileItemPtr item(new CFileItem("pvr://guide/searchresults/search/", true));
-  item->SetLabel(g_localizeStrings.Get(19140));
-  item->SetLabelPreformated(true);
-  item->SetSpecialSort(SortSpecialOnTop);
-  items.Add(item);
+  bool bAddSpecialSearchItem = items.IsEmpty();
 
   if (m_bSearchConfirmed)
   {
+    m_bSearchConfirmed = false;
+
+    items.Clear();
+    bAddSpecialSearchItem = true;
+
     CGUIDialogProgress* dlgProgress = (CGUIDialogProgress*)g_windowManager.GetWindow(WINDOW_DIALOG_PROGRESS);
     if (dlgProgress)
     {
-      dlgProgress->SetHeading(CVariant{194});
+      dlgProgress->SetHeading(CVariant{194}); // "Searching..."
       dlgProgress->SetText(CVariant{m_searchfilter.m_strSearchTerm});
       dlgProgress->Open();
       dlgProgress->Progress();
@@ -176,10 +175,17 @@ void CGUIWindowPVRSearch::OnPrepareFileItems(CFileItemList &items)
       dlgProgress->Close();
 
     if (items.IsEmpty())
-    {
-      CGUIDialogOK::ShowAndGetInput(CVariant{194}, CVariant{284});
-      m_bSearchConfirmed = false;
-    }
+      CGUIDialogOK::ShowAndGetInput(CVariant{194},  // "Searching..."
+                                    CVariant{284}); // "No results found"
+  }
+
+  if (bAddSpecialSearchItem)
+  {
+    CFileItemPtr item(new CFileItem("pvr://guide/searchresults/search/", true));
+    item->SetLabel(g_localizeStrings.Get(19140)); // "Search..."
+    item->SetLabelPreformated(true);
+    item->SetSpecialSort(SortSpecialOnTop);
+    items.Add(item);
   }
 }
 


### PR DESCRIPTION
- Fix "Find similar program" for timers to prefer EPG tag title over timer title. Although containing often the EPG title of the broadcasting, a timer title can be completely unrelated to the broadcast as it is freely editable by the user.
- Fixed OnPrepareFileItems only to search if requested to do so and not just a simple window refresh is ongoing. Before, every CGUIWindow::Refresh triggered a search. For example, selecting "Find similar" in timer's context menu resulted in two calls to OnPrepareFileItems. First call did a search with previous search data (if present), second call did a search with the current data. Two dialogs popped up, first "Searchig ... <old stuff>" then "Searching ... <new stuff>" ... All weird.

@xhaggi mind taking a look.
