### PR TITLE
[PVR] Timers: Relax handling of read-only timers a bit.

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -1026,6 +1026,13 @@ bool CGUIDialogPVRTimerSettings::TypeReadOnlyCondition(const std::string &condit
       return false;
   }
 
+  /* Always enable enable/disable, if supported by the timer type. */
+  if (pThis->m_timerType->SupportsEnableDisable())
+  {
+    if (cond == SETTING_TMR_ACTIVE)
+      return true;
+  }
+
   // Let the PVR client decide...
   int idx = static_cast<const CSettingInt*>(setting)->GetValue();
   const auto entry = pThis->m_typeEntries.find(idx);

--- a/xbmc/pvr/windows/GUIWindowPVRTimers.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRTimers.cpp
@@ -86,8 +86,7 @@ void CGUIWindowPVRTimers::GetContextButtons(int itemNumber, CContextButtons &but
 
     buttons.Add(CONTEXT_BUTTON_FIND, 19003);            /* Find similar program */
 
-    if (pItem->GetPVRTimerInfoTag()->HasTimerType() &&
-        !pItem->GetPVRTimerInfoTag()->GetTimerType()->IsReadOnly())
+    if (pItem->GetPVRTimerInfoTag()->HasTimerType())
     {
       if (pItem->GetPVRTimerInfoTag()->GetTimerType()->SupportsEnableDisable())
       {
@@ -97,12 +96,15 @@ void CGUIWindowPVRTimers::GetContextButtons(int itemNumber, CContextButtons &but
           buttons.Add(CONTEXT_BUTTON_ACTIVATE, 844);    /* deactivate timer */
       }
 
-      buttons.Add(CONTEXT_BUTTON_DELETE, 117);          /* delete */
-      buttons.Add(CONTEXT_BUTTON_EDIT, 19057);          /* edit timer */
+      if (!pItem->GetPVRTimerInfoTag()->GetTimerType()->IsReadOnly())
+      {
+        buttons.Add(CONTEXT_BUTTON_DELETE, 117);          /* delete */
+        buttons.Add(CONTEXT_BUTTON_EDIT, 19057);          /* edit timer */
 
-      // As epg-based timers will get it's title from the epg tag, they should not be renamable.
-      if (pItem->GetPVRTimerInfoTag()->IsManual())
-        buttons.Add(CONTEXT_BUTTON_RENAME, 118);        /* rename */
+        // As epg-based timers will get it's title from the epg tag, they should not be renamable.
+        if (pItem->GetPVRTimerInfoTag()->IsManual())
+          buttons.Add(CONTEXT_BUTTON_RENAME, 118);        /* rename */
+      }
     }
 
     buttons.Add(CONTEXT_BUTTON_ADD, 19056);             /* new timer */


### PR DESCRIPTION
Allow to activate/deactivate a timer even it is flagged read-only. Makes sense as with the read-only timer type attribute we want to prevent editing of timer data and delete of the timer, but not timer state changes.
