### PR TITLE
[guilib] parse <depth> tag for constants

### DIFF
--- a/xbmc/guilib/GUIIncludes.cpp
+++ b/xbmc/guilib/GUIIncludes.cpp
@@ -82,6 +82,7 @@ CGUIIncludes::CGUIIncludes()
   m_constantNodes.insert("timeperimage");
   m_constantNodes.insert("fadetime");
   m_constantNodes.insert("pauseatend");
+  m_constantNodes.insert("depth");
 }
 
 CGUIIncludes::~CGUIIncludes()


### PR DESCRIPTION
This adds constants support for the recently added `<depth>`tag. Without this change constants can't be used
