### PR TITLE
Stereoscopic depth for Confluence

### DIFF
--- a/addons/skin.confluence/720p/AddonBrowser.xml
+++ b/addons/skin.confluence/720p/AddonBrowser.xml
@@ -23,33 +23,10 @@
 		<include>MainWindowMouseButtons</include>
 		<include>BehindDialogFadeOut</include>
 		<include>ScrollOffsetLabel</include>
-		<control type="image">
-			<description>Section header image</description>
-			<left>20</left>
-			<top>3</top>
-			<width>35</width>
-			<height>35</height>
-			<aspectratio>keep</aspectratio>
-			<texture>icon_addons.png</texture>
-		</control>
-		<control type="grouplist">
-			<left>65</left>
-			<top>5</top>
-			<width>1000</width>
-			<height>30</height>
-			<orientation>horizontal</orientation>
-			<align>left</align>
-			<itemgap>5</itemgap>
-			<control type="label">
-				<include>WindowTitleCommons</include>
-				<label>$LOCALIZE[24001]</label>
-			</control>
-			<control type="label">
-				<include>WindowTitleCommons</include>
-				<label>[COLOR=blue] - [/COLOR]$INFO[Container.FolderName]</label>
-				<visible>!IsEmpty(Container.FolderName)</visible>
-			</control>
-		</control>
+		<include name="CommonWindowHeader">
+			<param name="Icon" value="icon_addons" />
+			<param name="Label" value="$LOCALIZE[24001]" />
+		</include>
 		<control type="group">
 			<left>-250</left>
 			<include>SideBladeLeft</include>
@@ -155,6 +132,5 @@
 				<aligny>center</aligny>
 			</control>
 		</control>
-		<include>Clock</include>
 	</controls>
 </window>

--- a/addons/skin.confluence/720p/AddonBrowser.xml
+++ b/addons/skin.confluence/720p/AddonBrowser.xml
@@ -18,8 +18,11 @@
 			<!-- view id = 551 -->
 			<include>AddonInfoThumbView1</include>
 		</control>
-		<include>CommonPageCount</include>
-		<include>CommonNowPlaying</include>
+		<control type="group">
+			<depth>DepthFooter</depth>
+			<include>CommonPageCount</include>
+			<include>CommonNowPlaying</include>
+		</control>
 		<include>MainWindowMouseButtons</include>
 		<include>BehindDialogFadeOut</include>
 		<include>ScrollOffsetLabel</include>

--- a/addons/skin.confluence/720p/DialogAlbumInfo.xml
+++ b/addons/skin.confluence/720p/DialogAlbumInfo.xml
@@ -3,13 +3,14 @@
 	<defaultcontrol always="true">5</defaultcontrol>
 	<controls>
 		<control type="group">
+			<depth>DepthSideBlade</depth>
 			<visible>!Window.IsVisible(FileBrowser)</visible>
 			<animation effect="slide" start="1100,0" end="0,0" time="300" tween="quadratic" easing="out">WindowOpen</animation>
 			<animation effect="slide" start="0,0" end="1100,0" time="300" tween="quadratic" easing="out">WindowClose</animation>
 			<control type="image">
 				<left>180</left>
 				<top>0</top>
-				<width>1100</width>
+				<width>1120</width>
 				<height>720</height>
 				<texture border="15,0,0,0" flipx="true">MediaBladeSub.png</texture>
 			</control>
@@ -537,6 +538,9 @@
 				</control>
 			</control>
 		</control>
-		<include>Clock</include>
+		<control type="group">
+			<depth>DepthSideBlade</depth>
+			<include>Clock</include>
+		</control>
 	</controls>
 </window>

--- a/addons/skin.confluence/720p/DialogBusy.xml
+++ b/addons/skin.confluence/720p/DialogBusy.xml
@@ -8,6 +8,7 @@
 	</coordinates>
 	<controls>
 		<control type="group">
+			<depth>DepthDialog+</depth>
 			<left>1070</left>
 			<top>640</top>
 			<control type="image">

--- a/addons/skin.confluence/720p/DialogExtendedProgressBar.xml
+++ b/addons/skin.confluence/720p/DialogExtendedProgressBar.xml
@@ -5,6 +5,7 @@
 	<animation effect="slide" start="0,0" end="0,-70" delay="300" time="75">WindowClose</animation>
 	<controls>
 		<control type="group">
+			<depth>DepthDialog+</depth>
 			<left>720</left>
 			<top>0</top>
 			<animation effect="slide" end="0,-80" time="150" condition="Window.IsVisible(FullscreenVideo) | Window.IsVisible(Visualisation)">conditional</animation>

--- a/addons/skin.confluence/720p/DialogFavourites.xml
+++ b/addons/skin.confluence/720p/DialogFavourites.xml
@@ -7,12 +7,13 @@
 	</coordinates>
 	<controls>
 		<control type="group">
+			<depth>DepthSideBlade</depth>
 			<animation effect="slide" start="400,0" end="0,0" time="300" tween="quadratic" easing="out">WindowOpen</animation>
 			<animation effect="slide" start="0,0" end="400,0" time="300" tween="quadratic" easing="out">WindowClose</animation>
 			<control type="image">
 				<left>400r</left>
 				<top>0</top>
-				<width>400</width>
+				<width>420</width>
 				<height>720</height>
 				<texture border="15,0,0,0" flipx="true">HomeBladeSub.png</texture>
 			</control>

--- a/addons/skin.confluence/720p/DialogKaiToast.xml
+++ b/addons/skin.confluence/720p/DialogKaiToast.xml
@@ -8,6 +8,7 @@
 	</coordinates>
 	<controls>
 		<control type="group">
+			<depth>DepthMax</depth>
 			<animation effect="slide" start="0,0" end="-190,0" time="150" condition="Window.IsVisible(BusyDialog)">conditional</animation>
 			<control type="image">
 				<left>0</left>

--- a/addons/skin.confluence/720p/DialogKaraokeSongSelector.xml
+++ b/addons/skin.confluence/720p/DialogKaraokeSongSelector.xml
@@ -4,6 +4,7 @@
 	<animation effect="slide" start="0,0" end="0,-40" delay="300" time="75">WindowClose</animation>
 	<controls>
 		<control type="group">
+			<depth>DepthDialog-</depth>
 			<left>100</left>
 			<top>0</top>
 			<control type="image">

--- a/addons/skin.confluence/720p/DialogKeyboard.xml
+++ b/addons/skin.confluence/720p/DialogKeyboard.xml
@@ -2,6 +2,7 @@
 <window>
 	<defaultcontrol always="true">300</defaultcontrol>
 	<include>dialogeffect</include>
+	<depth>DepthDialog+</depth>
 	<coordinates>
 		<left>205</left>
 		<top>120</top>

--- a/addons/skin.confluence/720p/DialogNumeric.xml
+++ b/addons/skin.confluence/720p/DialogNumeric.xml
@@ -2,6 +2,7 @@
 <window>
 	<defaultcontrol always="true">21</defaultcontrol>
 	<include>dialogeffect</include>
+	<depth>DepthDialog+</depth>
 	<coordinates>
 		<left>420</left>
 		<top>175</top>

--- a/addons/skin.confluence/720p/DialogOK.xml
+++ b/addons/skin.confluence/720p/DialogOK.xml
@@ -6,6 +6,7 @@
 		<top>230</top>
 	</coordinates>
 	<include>dialogeffect</include>
+	<depth>DepthDialog+</depth>
 	<controls>
 		<include name="DialogBackgroundCommons">
 			<param name="DialogBackgroundWidth" value="610" />

--- a/addons/skin.confluence/720p/DialogPVRGroupManager.xml
+++ b/addons/skin.confluence/720p/DialogPVRGroupManager.xml
@@ -3,13 +3,14 @@
 	<defaultcontrol always="true">29</defaultcontrol>
 	<controls>
 		<control type="group">
+			<depth>DepthSideBlade</depth>
 			<visible>!Window.IsVisible(FileBrowser)</visible>
 			<animation effect="slide" start="1150,0" end="0,0" time="300" tween="quadratic" easing="out">WindowOpen</animation>
 			<animation effect="slide" start="0,0" end="1150,0" time="300" tween="quadratic" easing="out">WindowClose</animation>
 			<control type="image">
 				<left>50</left>
 				<top>0</top>
-				<width>1230</width>
+				<width>1250</width>
 				<height>720</height>
 				<texture border="15,0,0,0" flipx="true">MediaBladeSub.png</texture>
 			</control>
@@ -479,7 +480,10 @@
 				</control>
 			</control>
 		</control>
-		<include>Clock</include>
+		<control type="group">
+			<depth>DepthSideBlade</depth>
+			<include>Clock</include>
+		</control>
 		<control type="label" id="20">
 			<description>Fake Label used to pass on name label</description>
 			<visible>false</visible>

--- a/addons/skin.confluence/720p/DialogProgress.xml
+++ b/addons/skin.confluence/720p/DialogProgress.xml
@@ -6,6 +6,7 @@
 		<top>230</top>
 	</coordinates>
 	<include>dialogeffect</include>
+	<depth>DepthDialog+</depth>
 	<controls>
 		<include name="DialogBackgroundCommons">
 			<param name="DialogBackgroundWidth" value="610" />

--- a/addons/skin.confluence/720p/DialogSeekBar.xml
+++ b/addons/skin.confluence/720p/DialogSeekBar.xml
@@ -4,6 +4,7 @@
 	<visible>Player.Seeking | Player.DisplayAfterSeek | Player.Paused | Player.Forwarding | Player.Rewinding</visible>
 	<animation effect="fade" start="0" end="100" time="150">WindowOpen</animation>
 	<animation effect="fade" start="100" end="0" time="150">WindowClose</animation>
+	<depth>DepthOSD</depth>
 	<controls>
 		<control type="group">
 			<visible>player.chaptercount + Window.IsVisible(FullScreenVideo)</visible>

--- a/addons/skin.confluence/720p/DialogSelect.xml
+++ b/addons/skin.confluence/720p/DialogSelect.xml
@@ -6,6 +6,7 @@
 		<top>75</top>
 	</coordinates>
 	<include>dialogeffect</include>
+	<depth>DepthDialog+</depth>
 	<controls>
 		<control type="group">
 			<animation effect="slide" start="0,0" end="0,46" time="0" condition="[Control.IsVisible(3) + !IntegerGreaterThan(Container(3).NumItems,4)] | [Control.IsVisible(6) + !IntegerGreaterThan(Container(6).NumItems,2)]">Conditional</animation>

--- a/addons/skin.confluence/720p/DialogSlider.xml
+++ b/addons/skin.confluence/720p/DialogSlider.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
+	<depth>DepthDialog+</depth>
 	<defaultcontrol>11</defaultcontrol>
 	<animation effect="slide" start="0,-80" end="0,0" time="75">WindowOpen</animation>
 	<animation effect="slide" start="0,0" end="0,-80" time="75">WindowClose</animation>

--- a/addons/skin.confluence/720p/DialogSubtitles.xml
+++ b/addons/skin.confluence/720p/DialogSubtitles.xml
@@ -6,6 +6,7 @@
 	</coordinates>
 	<controls>
 		<control type="group" id="250">
+			<depth>DepthDialog-</depth>
 			<animation effect="slide" start="0,0" end="900,0" time="375" tween="quadratic" easing="out">WindowClose</animation>
 			<animation type="Conditional" condition="Control.HasFocus(150) | Control.HasFocus(160)" reversible="true">
 				<effect type="slide" end="-250,0" time="300" />

--- a/addons/skin.confluence/720p/DialogTextViewer.xml
+++ b/addons/skin.confluence/720p/DialogTextViewer.xml
@@ -3,12 +3,13 @@
 	<defaultcontrol>61</defaultcontrol>
 	<controls>
 		<control type="group">
+			<depth>DepthDialog-</depth>
 			<animation effect="slide" start="1100,0" end="0,0" time="300" tween="quadratic" easing="out">WindowOpen</animation>
 			<animation effect="slide" start="0,0" end="1100,0" time="300" tween="quadratic" easing="out">WindowClose</animation>
 			<control type="image">
 				<left>180</left>
 				<top>0</top>
-				<width>1100</width>
+				<width>1120</width>
 				<height>720</height>
 				<texture border="15,0,0,0" flipx="true">MediaBladeSub.png</texture>
 			</control>
@@ -76,6 +77,9 @@
 				</control>
 			</control>
 		</control>
-		<include>Clock</include>
+		<control type="group">
+			<depth>DepthDialog-</depth>
+			<include>Clock</include>
+		</control>
 	</controls>
 </window>

--- a/addons/skin.confluence/720p/DialogVideoInfo.xml
+++ b/addons/skin.confluence/720p/DialogVideoInfo.xml
@@ -3,13 +3,14 @@
 	<defaultcontrol always="true">8</defaultcontrol>
 	<controls>
 		<control type="group">
+			<depth>DepthSideBlade</depth>
 			<visible>!Window.IsVisible(FileBrowser)</visible>
 			<animation effect="slide" start="1100,0" end="0,0" time="300" tween="quadratic" easing="out">WindowOpen</animation>
 			<animation effect="slide" start="0,0" end="1100,0" time="300" tween="quadratic" easing="out">WindowClose</animation>
 			<control type="image">
 				<left>180</left>
 				<top>0</top>
-				<width>1100</width>
+				<width>1120</width>
 				<height>720</height>
 				<texture border="15,0,0,0" flipx="true">MediaBladeSub.png</texture>
 			</control>
@@ -992,6 +993,9 @@
 				</control>
 			</control>
 		</control>
-		<include>Clock</include>
+		<control type="group">
+			<depth>DepthSideBlade</depth>
+			<include>Clock</include>
+		</control>
 	</controls>
 </window>

--- a/addons/skin.confluence/720p/DialogVolumeBar.xml
+++ b/addons/skin.confluence/720p/DialogVolumeBar.xml
@@ -5,6 +5,7 @@
 	<animation effect="slide" start="0,0" end="0,-40" delay="300" time="75">WindowClose</animation>
 	<controls>
 		<control type="group">
+			<depth>DepthMax</depth>
 			<left>820</left>
 			<top>0</top>
 			<control type="image">

--- a/addons/skin.confluence/720p/DialogYesNo.xml
+++ b/addons/skin.confluence/720p/DialogYesNo.xml
@@ -6,6 +6,7 @@
 		<top>230</top>
 	</coordinates>
 	<include>dialogeffect</include>
+	<depth>DepthDialog+</depth>
 	<controls>
 		<include name="DialogBackgroundCommons">
 			<param name="DialogBackgroundWidth" value="610" />

--- a/addons/skin.confluence/720p/EventLog.xml
+++ b/addons/skin.confluence/720p/EventLog.xml
@@ -7,8 +7,11 @@
 	<controls>
 		<include>CommonBackground</include>
 		<include>ContentPanelBackgrounds</include>
-		<include>CommonPageCount</include>
-		<include>CommonNowPlaying</include>
+		<control type="group">
+			<depth>DepthFooter</depth>
+			<include>CommonPageCount</include>
+			<include>CommonNowPlaying</include>
+		</control>
 		<include>MainWindowMouseButtons</include>
 		<include>BehindDialogFadeOut</include>
 		<include>ScrollOffsetLabel</include>

--- a/addons/skin.confluence/720p/EventLog.xml
+++ b/addons/skin.confluence/720p/EventLog.xml
@@ -12,15 +12,6 @@
 		<include>MainWindowMouseButtons</include>
 		<include>BehindDialogFadeOut</include>
 		<include>ScrollOffsetLabel</include>
-		<control type="image">
-			<description>Section header image</description>
-			<left>20</left>
-			<top>3</top>
-			<width>35</width>
-			<height>35</height>
-			<aspectratio>keep</aspectratio>
-			<texture>icon_events.png</texture>
-		</control>
 		<control type="group">
 			<visible>Control.IsVisible(570)</visible>
 			<include>Window_OpenClose_Animation</include>
@@ -188,19 +179,10 @@
 				<visible>Control.IsVisible(570)</visible>
 			</control>
 		</control>
-		<control type="grouplist">
-			<left>65</left>
-			<top>5</top>
-			<width>1000</width>
-			<height>30</height>
-			<orientation>horizontal</orientation>
-			<align>left</align>
-			<itemgap>5</itemgap>
-			<control type="label">
-				<include>WindowTitleCommons</include>
-				<label>$LOCALIZE[14111]</label>
-			</control>
-		</control>
+		<include name="CommonWindowHeader">
+			<param name="Icon" value="icon_events" />
+			<param name="Label" value="$LOCALIZE[14111]" />
+		</include>
 		<control type="group">
 			<left>-250</left>
 			<include>SideBladeLeft</include>
@@ -261,6 +243,5 @@
 				<include>CommonNowPlaying_Controls</include>
 			</control>
 		</control>
-		<include>Clock</include>
 	</controls>
 </window>

--- a/addons/skin.confluence/720p/FileBrowser.xml
+++ b/addons/skin.confluence/720p/FileBrowser.xml
@@ -7,6 +7,7 @@
 	</coordinates>
 	<controls>
 		<control type="group">
+			<depth>DepthDialog+</depth>
 			<left>360</left>
 			<animation effect="slide" start="700,0" end="0,0" time="300" tween="quadratic" easing="out" condition="![Window.IsVisible(MovieInformation) | Window.IsVisible(MusicInformation)]">WindowOpen</animation>
 			<animation effect="slide" start="-180,0" end="0,0" time="300" tween="quadratic" easing="out" condition="[Window.IsVisible(MovieInformation) | Window.IsVisible(MusicInformation)]">WindowOpen</animation>
@@ -346,6 +347,9 @@
 				</control>
 			</control>
 		</control>
-		<include>Clock</include>
+		<control type="group">
+			<depth>DepthDialog+</depth>
+			<include>Clock</include>
+		</control>
 	</controls>
 </window>

--- a/addons/skin.confluence/720p/FileManager.xml
+++ b/addons/skin.confluence/720p/FileManager.xml
@@ -360,29 +360,32 @@
 				</focusedlayout>
 			</control>
 		</control>
-		<control type="label">
-			<description>number of files/pages in left list text label</description>
-			<left>40</left>
-			<top>53r</top>
-			<width>570</width>
-			<font>font12</font>
-			<align>left</align>
-			<scroll>true</scroll>
-			<textcolor>grey</textcolor>
-			<shadowcolor>black</shadowcolor>
-			<label>([COLOR=blue]$INFO[Container(20).NumItems][/COLOR]) $LOCALIZE[31025] - $LOCALIZE[31024] ([COLOR=blue]$INFO[Container(20).CurrentPage]/$INFO[Container(20).NumPages][/COLOR])</label>
-		</control>
-		<control type="label">
-			<description>number of files/pages in left list text label</description>
-			<right>40</right>
-			<top>53r</top>
-			<width>570</width>
-			<font>font12</font>
-			<align>right</align>
-			<scroll>true</scroll>
-			<textcolor>grey</textcolor>
-			<shadowcolor>black</shadowcolor>
-			<label>([COLOR=blue]$INFO[Container(21).NumItems][/COLOR]) $LOCALIZE[31025] - $LOCALIZE[31024] ([COLOR=blue]$INFO[Container(21).CurrentPage]/$INFO[Container(21).NumPages][/COLOR])</label>
+		<control type="group">
+			<depth>DepthFooter</depth>
+			<control type="label">
+				<description>number of files/pages in left list text label</description>
+				<left>40</left>
+				<top>53r</top>
+				<width>570</width>
+				<font>font12</font>
+				<align>left</align>
+				<scroll>true</scroll>
+				<textcolor>grey</textcolor>
+				<shadowcolor>black</shadowcolor>
+				<label>([COLOR=blue]$INFO[Container(20).NumItems][/COLOR]) $LOCALIZE[31025] - $LOCALIZE[31024] ([COLOR=blue]$INFO[Container(20).CurrentPage]/$INFO[Container(20).NumPages][/COLOR])</label>
+			</control>
+			<control type="label">
+				<description>number of files/pages in left list text label</description>
+				<right>40</right>
+				<top>53r</top>
+				<width>570</width>
+				<font>font12</font>
+				<align>right</align>
+				<scroll>true</scroll>
+				<textcolor>grey</textcolor>
+				<shadowcolor>black</shadowcolor>
+				<label>([COLOR=blue]$INFO[Container(21).NumItems][/COLOR]) $LOCALIZE[31025] - $LOCALIZE[31024] ([COLOR=blue]$INFO[Container(21).CurrentPage]/$INFO[Container(21).NumPages][/COLOR])</label>
+			</control>
 		</control>
 		<control type="group" id="10">
 			<left>595</left>

--- a/addons/skin.confluence/720p/FileManager.xml
+++ b/addons/skin.confluence/720p/FileManager.xml
@@ -12,28 +12,6 @@
 			<animation effect="slide" start="0,10" end="0,0" time="150" condition="Window.Previous(Home)">WindowOpen</animation>
 			<animation effect="slide" start="0,0" end="0,10" time="150" condition="Window.Next(Home)">WindowClose</animation>
 		</control>
-		<control type="image">
-			<description>Section header image</description>
-			<left>20</left>
-			<top>3</top>
-			<width>35</width>
-			<height>35</height>
-			<aspectratio>keep</aspectratio>
-			<texture>icon_system.png</texture>
-		</control>
-		<control type="grouplist">
-			<left>65</left>
-			<top>5</top>
-			<width>1000</width>
-			<height>30</height>
-			<orientation>horizontal</orientation>
-			<align>left</align>
-			<itemgap>5</itemgap>
-			<control type="label">
-				<include>WindowTitleCommons</include>
-				<label>$LOCALIZE[7]</label>
-			</control>
-		</control>
 		<control type="group">
 			<left>30</left>
 			<top>40</top>
@@ -463,6 +441,9 @@
 				<texture>icon_home.png</texture>
 			</control>
 		</control>
-		<include>Clock</include>
+		<include name="CommonWindowHeader">
+			<param name="Icon" value="icon_system" />
+			<param name="Label" value="$LOCALIZE[7]" />
+		</include>
 	</controls>
 </window>

--- a/addons/skin.confluence/720p/Home.xml
+++ b/addons/skin.confluence/720p/Home.xml
@@ -8,28 +8,20 @@
 	<controls>
 		<include>CommonBackground</include>
 		<control type="image">
-			<left>0</left>
-			<top>90r</top>
-			<width>1280</width>
+			<depth>DepthFloor</depth>
+			<left>-20</left>
+			<top></top>
+			<bottom>0</bottom>
+			<width>1320</width>
 			<height>90</height>
 			<texture>floor.png</texture>
-			<animation effect="fade" time="200" condition="Window.Previous(Home)">WindowOpen</animation>
-			<animation effect="fade" time="200" condition="Window.Next(Home)">WindowClose</animation>
-		</control>
-		<control type="image">
-			<description>LOGO</description>
-			<left>10</left>
-			<top>5</top>
-			<width>120</width>
-			<height>49</height>
-			<aspectratio aligny="top" align="left">keep</aspectratio>
-			<texture>kodi-logo.png</texture>
-			<include>VisibleFadeEffect</include>
-			<include>Window_OpenClose_Animation</include>
-			<visible>!Skin.HasSetting(homepageWeatherinfo)</visible>
+			<animation effect="rotatex" end="45" time="0" center="620,0" condition="true">Conditional</animation>
+			<animation effect="slide" time="200" condition="Window.Previous(Home)">WindowOpen</animation>
+			<animation effect="slide" time="200" condition="Window.Next(Home)">WindowClose</animation>
 		</control>
 		<!-- Music Info -->
 		<control type="group">
+			<depth>DepthMenu</depth>
 			<left>0</left>
 			<top>60</top>
 			<visible>Player.HasAudio + !Skin.HasSetting(homepageMusicinfo) + IsEmpty(Window(videolibrary).Property(PlayingBackgroundMedia))</visible>
@@ -88,6 +80,7 @@
 		</control>
 		<!-- LiveTV Info -->
 		<control type="group">
+			<depth>DepthMenu</depth>
 			<left>490r</left>
 			<top>70</top>
 			<visible>Container(9000).HasFocus(12) + [PVR.IsRecording | PVR.HasNonRecordingTimer]</visible>
@@ -232,6 +225,7 @@
 		</control>
 		<!-- Video Info -->
 		<control type="group">
+			<depth>DepthMenu</depth>
 			<left>0</left>
 			<top>50</top>
 			<visible>Player.HasVideo + !Skin.HasSetting(homepageVideoinfo) + IsEmpty(Window(videolibrary).Property(PlayingBackgroundMedia))</visible>
@@ -455,6 +449,7 @@
 			<visible>false</visible>
 		</control>
 		<control type="group">
+			<depth>DepthMenu-</depth>
 			<description>Controls for currently playing media</description>
 			<left>545r</left>
 			<top>370</top>
@@ -739,6 +734,7 @@
 			</control>
 		</control>
 		<control type="group">
+			<depth>DepthMenu</depth>
 			<top>400</top>
 			<animation type="WindowOpen" reversible="false">
 				<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="225" />
@@ -749,6 +745,7 @@
 				<effect type="fade" start="100" end="0" time="225" />
 			</animation>
 			<control type="group" id="9001">
+				<depth>DepthMenu-</depth>
 				<left>0</left>
 				<top>70</top>
 				<onup>9000</onup>
@@ -1005,21 +1002,22 @@
 				</content>
 			</control>
 			<control type="image">
-				<left>0</left>
+				<left>-10</left>
 				<top>6</top>
-				<width>128</width>
+				<width>138</width>
 				<height>63</height>
 				<texture>SideFade.png</texture>
 			</control>
 			<control type="image">
 				<left>128r</left>
 				<top>6</top>
-				<width>128</width>
+				<width>138</width>
 				<height>63</height>
 				<texture flipx="true">SideFade.png</texture>
 			</control>
 		</control>
 		<control type="group" id="9002">
+			<depth>DepthMenu</depth>
 			<onup>9001</onup>
 			<ondown>20</ondown>
 			<control type="fixedlist" id="700">
@@ -1072,6 +1070,7 @@
 			</control>
 		</control>
 		<control type="group">
+			<depth>DepthMenu-</depth>
 			<left>0</left>
 			<top>33r</top>
 			<visible>system.getbool(lookandfeel.enablerssfeeds)</visible>
@@ -1098,6 +1097,7 @@
 			</control>
 		</control>
 		<control type="group" id="10">
+			<depth>DepthFooter</depth>
 			<left>20</left>
 			<top>55r</top>
 			<include>Window_OpenClose_Animation</include>
@@ -1153,89 +1153,104 @@
 			</control>
 		</control>
 		<control type="group">
-			<left>20</left>
-			<top>0</top>
-			<visible>Skin.HasSetting(homepageWeatherinfo) + !IsEmpty(Weather.Plugin)</visible>
-			<include>Window_OpenClose_Animation</include>
+			<depth>DepthHeader</depth>
 			<control type="image">
-				<description>Weather image</description>
-				<left>0</left>
-				<top>0</top>
-				<width>60</width>
-				<height>60</height>
-				<aspectratio>keep</aspectratio>
-				<texture>$INFO[Weather.Conditions]</texture>
-			</control>
-			<control type="label">
-				<description>Location label</description>
-				<left>65</left>
+				<description>LOGO</description>
+				<left>10</left>
 				<top>5</top>
-				<width>500</width>
+				<width>120</width>
+				<height>49</height>
+				<aspectratio aligny="top" align="left">keep</aspectratio>
+				<texture>kodi-logo.png</texture>
+				<include>VisibleFadeEffect</include>
+				<include>Window_OpenClose_Animation</include>
+				<visible>!Skin.HasSetting(homepageWeatherinfo)</visible>
+			</control>
+			<control type="group">
+				<left>20</left>
+				<top>0</top>
+				<visible>Skin.HasSetting(homepageWeatherinfo) + !IsEmpty(Weather.Plugin)</visible>
+				<include>Window_OpenClose_Animation</include>
+				<control type="image">
+					<description>Weather image</description>
+					<left>0</left>
+					<top>0</top>
+					<width>60</width>
+					<height>60</height>
+					<aspectratio>keep</aspectratio>
+					<texture>$INFO[Weather.Conditions]</texture>
+				</control>
+				<control type="label">
+					<description>Location label</description>
+					<left>65</left>
+					<top>5</top>
+					<width>500</width>
+					<height>15</height>
+					<align>left</align>
+					<aligny>center</aligny>
+					<font>font10</font>
+					<textcolor>white</textcolor>
+					<shadowcolor>black</shadowcolor>
+					<label>$INFO[Window(Weather).Property(Location)]</label>
+				</control>
+				<control type="grouplist">
+					<left>65</left>
+					<top>20</top>
+					<width>1000</width>
+					<height>30</height>
+					<orientation>horizontal</orientation>
+					<align>left</align>
+					<itemgap>0</itemgap>
+					<control type="label">
+						<description>Temp label</description>
+						<width min="0" max="300">auto</width>
+						<height>30</height>
+						<align>left</align>
+						<aligny>center</aligny>
+						<font>font28_title</font>
+						<textcolor>white</textcolor>
+						<shadowcolor>black</shadowcolor>
+						<label>[B]$INFO[Window(Weather).Property(Current.Temperature)][/B]</label>
+					</control>
+					<control type="label">
+						<description>Temp Units</description>
+						<width min="0" max="100">auto</width>
+						<height>22</height>
+						<font>font10</font>
+						<aligny>center</aligny>
+						<label>$INFO[System.TemperatureUnits]</label>
+						<textcolor>white</textcolor>
+						<shadowcolor>black</shadowcolor>
+						<visible>!IsEmpty(Window(Weather).Property(Current.Temperature))</visible>
+					</control>
+					<control type="label">
+						<description>Conditions Label</description>
+						<width>500</width>
+						<height>22</height>
+						<font>font10</font>
+						<aligny>center</aligny>
+						<label>$INFO[Window(Weather).Property(Current.Condition),  ]</label>
+						<textcolor>grey2</textcolor>
+						<shadowcolor>black</shadowcolor>
+					</control>
+				</control>
+			</control>
+			<include>Clock</include>
+			<control type="label">
+				<description>Date label</description>
+				<right>20</right>
+				<top>35</top>
+				<width>300</width>
 				<height>15</height>
-				<align>left</align>
+				<align>right</align>
 				<aligny>center</aligny>
 				<font>font10</font>
 				<textcolor>white</textcolor>
 				<shadowcolor>black</shadowcolor>
-				<label>$INFO[Window(Weather).Property(Location)]</label>
+				<label>$INFO[System.Date]</label>
+				<include>Window_OpenClose_Animation</include>
+				<animation effect="slide" start="0,0" end="-40,0" time="75" condition="Window.IsVisible(Mutebug)">conditional</animation>
 			</control>
-			<control type="grouplist">
-				<left>65</left>
-				<top>20</top>
-				<width>1000</width>
-				<height>30</height>
-				<orientation>horizontal</orientation>
-				<align>left</align>
-				<itemgap>0</itemgap>
-				<control type="label">
-					<description>Temp label</description>
-					<width min="0" max="300">auto</width>
-					<height>30</height>
-					<align>left</align>
-					<aligny>center</aligny>
-					<font>font28_title</font>
-					<textcolor>white</textcolor>
-					<shadowcolor>black</shadowcolor>
-					<label>[B]$INFO[Window(Weather).Property(Current.Temperature)][/B]</label>
-				</control>
-				<control type="label">
-					<description>Temp Units</description>
-					<width min="0" max="100">auto</width>
-					<height>22</height>
-					<font>font10</font>
-					<aligny>center</aligny>
-					<label>$INFO[System.TemperatureUnits]</label>
-					<textcolor>white</textcolor>
-					<shadowcolor>black</shadowcolor>
-					<visible>!IsEmpty(Window(Weather).Property(Current.Temperature))</visible>
-				</control>
-				<control type="label">
-					<description>Conditions Label</description>
-					<width>500</width>
-					<height>22</height>
-					<font>font10</font>
-					<aligny>center</aligny>
-					<label>$INFO[Window(Weather).Property(Current.Condition),  ]</label>
-					<textcolor>grey2</textcolor>
-					<shadowcolor>black</shadowcolor>
-				</control>
-			</control>
-		</control>
-		<include>Clock</include>
-		<control type="label">
-			<description>Date label</description>
-			<right>20</right>
-			<top>35</top>
-			<width>300</width>
-			<height>15</height>
-			<align>right</align>
-			<aligny>center</aligny>
-			<font>font10</font>
-			<textcolor>white</textcolor>
-			<shadowcolor>black</shadowcolor>
-			<label>$INFO[System.Date]</label>
-			<include>Window_OpenClose_Animation</include>
-			<animation effect="slide" start="0,0" end="-40,0" time="75" condition="Window.IsVisible(Mutebug)">conditional</animation>
 		</control>
 	</controls>
 </window>

--- a/addons/skin.confluence/720p/IncludesBackgroundBuilding.xml
+++ b/addons/skin.confluence/720p/IncludesBackgroundBuilding.xml
@@ -2,32 +2,26 @@
 <includes>
 	<include name="CommonBackground">
 		<control type="image">
+			<depth>DepthBackground</depth>
 			<description>Normal Default Background Image</description>
-			<left>0</left>
-			<top>0</top>
-			<width>1280</width>
-			<height>720</height>
+			<include>BackgroundDimensions</include>
 			<aspectratio>scale</aspectratio>
 			<texture fallback="special://skin/backgrounds/SKINDEFAULT.jpg">$INFO[Skin.CurrentTheme,special://skin/backgrounds/,.jpg]</texture>
 			<visible>![Skin.HasSetting(UseCustomBackground) + !IsEmpty(Skin.String(CustomBackgroundPath))]</visible>
 			<include>VisibleFadeEffect</include>
 		</control>
 		<control type="image">
+			<depth>DepthBackground</depth>
 			<description>User Set Background Image</description>
-			<left>0</left>
-			<top>0</top>
-			<width>1280</width>
-			<height>720</height>
+			<include>BackgroundDimensions</include>
 			<aspectratio>scale</aspectratio>
 			<texture>$INFO[Skin.String(CustomBackgroundPath)]</texture>
 			<visible>Skin.HasSetting(UseCustomBackground) + !IsEmpty(Skin.String(CustomBackgroundPath))</visible>
 			<include>VisibleFadeEffect</include>
 		</control>
 		<control type="image">
-			<left>0</left>
-			<top>0</top>
-			<width>1280</width>
-			<height>720</height>
+			<depth>DepthBackground</depth>
+			<include>BackgroundDimensions</include>
 			<aspectratio>scale</aspectratio>
 			<texture background="true">$INFO[ListItem.Art(fanart)]</texture>
 			<include>backgroundfade</include>
@@ -37,10 +31,7 @@
 			<visible>![Player.HasVideo + !Skin.HasSetting(ShowBackgroundVideo)]</visible>
 		</control>
 		<control type="image">
-			<left>0</left>
-			<top>0</top>
-			<width>1280</width>
-			<height>720</height>
+			<include>BackgroundDimensions</include>
 			<texture>special://skin/backgrounds/media-overlay.jpg</texture>
 			<visible>[Player.HasVideo + !Skin.HasSetting(ShowBackgroundVideo)] + !Window.IsVisible(TVChannels) + !Window.IsVisible(RadioChannels)</visible>
 			<include>VisibleFadeEffect</include>
@@ -54,6 +45,7 @@
 			<visible>IsEmpty(Window(videolibrary).Property(PlayingBackgroundMedia))</visible>
 		</control>
 		<control type="videowindow">
+			<depth>DepthBackground</depth>
 			<left>0</left>
 			<top>0</top>
 			<width>1280</width>
@@ -61,9 +53,10 @@
 			<visible>Player.HasVideo + !Skin.HasSetting(ShowBackgroundVideo) + !Window.IsVisible(TVChannels) + !Window.IsVisible(RadioChannels)</visible>
 		</control>
 		<control type="image">
-			<left>0</left>
+			<depth>DepthBackground</depth>
+			<left>-20</left>
 			<top>-40</top>
-			<width>1280</width>
+			<width>1320</width>
 			<height>120</height>
 			<texture flipy="true" border="1">HomeNowPlayingBack.png</texture>
 			<visible>[Player.HasVideo + !Skin.HasSetting(ShowBackgroundVideo)] | [Player.HasAudio + ![Skin.HasSetting(ShowBackgroundVis) | !IsEmpty(Window(videolibrary).Property(PlayingBackgroundMedia))]] | [!Skin.HasSetting(HideBackGroundFanart) + !IsEmpty(ListItem.Property(Fanart_Image))]</visible>
@@ -72,11 +65,14 @@
 	</include>
 	<include name="ContentPanelBackgrounds">
 		<control type="image">
-			<left>0</left>
-			<top>100r</top>
-			<width>1280</width>
+			<depth>DepthFloor</depth>
+			<left>-20</left>
+			<top></top>
+			<bottom>0</bottom>
+			<width>1320</width>
 			<height>100</height>
 			<texture>floor.png</texture>
+			<animation effect="rotatex" end="45" time="0" center="620,0" condition="true">Conditional</animation>
 			<animation effect="slide" start="0,10" end="0,0" time="150" condition="Window.Previous(Home)">WindowOpen</animation>
 			<animation effect="slide" start="0,0" end="0,10" time="150" condition="Window.Next(Home)">WindowClose</animation>
 		</control>

--- a/addons/skin.confluence/720p/IncludesHomeRecentlyAdded.xml
+++ b/addons/skin.confluence/720p/IncludesHomeRecentlyAdded.xml
@@ -2,6 +2,7 @@
 <includes>
 	<include name="HomeRecentlyAddedInfo">
 		<control type="group" id="9003">
+			<depth>DepthMenu</depth>
 			<onup>20</onup>
 			<ondown condition="System.HasAddon(script.globalsearch)">608</ondown>
 			<ondown condition="!System.HasAddon(script.globalsearch)">603</ondown>

--- a/addons/skin.confluence/720p/IncludesPVR.xml
+++ b/addons/skin.confluence/720p/IncludesPVR.xml
@@ -2,6 +2,7 @@
 <includes>
 	<include name="PVRHeader">
 		<control type="group">
+			<depth>DepthHeader</depth>
 			<control type="image">
 				<description>Section header image</description>
 				<left>20</left>

--- a/addons/skin.confluence/720p/IncludesPVR.xml
+++ b/addons/skin.confluence/720p/IncludesPVR.xml
@@ -1,74 +1,77 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <includes>
 	<include name="PVRHeader">
-		<control type="image">
-			<description>Section header image</description>
-			<left>20</left>
-			<top>3</top>
-			<width>35</width>
-			<height>35</height>
-			<aspectratio>keep</aspectratio>
-			<texture>icon_video.png</texture>
-		</control>
-		<control type="grouplist">
-			<left>65</left>
-			<top>5</top>
-			<width>1000</width>
-			<height>30</height>
-			<orientation>horizontal</orientation>
-			<align>left</align>
-			<itemgap>5</itemgap>
-			<control type="label">
-				<include>WindowTitleCommons</include>
-				<label>$LOCALIZE[19020]</label>
-				<visible>IsEmpty(Window.Property(IsRadio))</visible>
+		<control type="group">
+			<control type="image">
+				<description>Section header image</description>
+				<left>20</left>
+				<top>3</top>
+				<width>35</width>
+				<height>35</height>
+				<aspectratio>keep</aspectratio>
+				<texture>icon_video.png</texture>
 			</control>
-			<control type="label">
-				<include>WindowTitleCommons</include>
-				<label>$LOCALIZE[19021]</label>
-				<visible>!IsEmpty(Window.Property(IsRadio))</visible>
+			<control type="grouplist">
+				<left>65</left>
+				<top>5</top>
+				<width>1000</width>
+				<height>30</height>
+				<orientation>horizontal</orientation>
+				<align>left</align>
+				<itemgap>5</itemgap>
+				<control type="label">
+					<include>WindowTitleCommons</include>
+					<label>$LOCALIZE[19020]</label>
+					<visible>IsEmpty(Window.Property(IsRadio))</visible>
+				</control>
+				<control type="label">
+					<include>WindowTitleCommons</include>
+					<label>$LOCALIZE[19021]</label>
+					<visible>!IsEmpty(Window.Property(IsRadio))</visible>
+				</control>
+				<control type="label">
+					<include>WindowTitleCommons</include>
+					<label>[COLOR=blue] - [/COLOR]$LOCALIZE[19019]</label>
+					<visible>Window.IsActive(TVChannels) | Window.IsActive(RadioChannels)</visible>
+				</control>
+				<control type="label">
+					<include>WindowTitleCommons</include>
+					<label>[COLOR=blue] - [/COLOR]$LOCALIZE[22020]</label>
+					<visible>Window.IsActive(TVGuide) | Window.IsActive(RadioGuide)</visible>
+				</control>
+				<control type="label">
+					<include>WindowTitleCommons</include>
+					<label>[COLOR=blue] - [/COLOR]$LOCALIZE[19017]</label>
+					<visible>Window.IsActive(TVRecordings) | Window.IsActive(RadioRecordings)</visible>
+				</control>
+				<control type="label">
+					<include>WindowTitleCommons</include>
+					<label>[COLOR=blue] - [/COLOR]$LOCALIZE[19040]</label>
+					<visible>Window.IsActive(TVTimers) | Window.IsActive(RadioTimers)</visible>
+				</control>
+				<control type="label">
+					<include>WindowTitleCommons</include>
+					<label>[COLOR=blue] - [/COLOR]$LOCALIZE[137]</label>
+					<visible>Window.IsActive(TVSearch) | Window.IsActive(RadioSearch)</visible>
+				</control>
+				<control type="label">
+					<include>WindowTitleCommons</include>
+					<label>$INFO[Control.GetLabel(29),[COLOR=blue] - [/COLOR]]</label>
+				</control>
+				<control type="label">
+					<include>WindowTitleCommons</include>
+					<label>$INFO[Control.GetLabel(30),[COLOR=blue] - [/COLOR]]</label>
+				</control>
 			</control>
-			<control type="label">
-				<include>WindowTitleCommons</include>
-				<label>[COLOR=blue] - [/COLOR]$LOCALIZE[19019]</label>
-				<visible>Window.IsActive(TVChannels) | Window.IsActive(RadioChannels)</visible>
+			<control type="label" id="29">
+				<description>Empty so we can pass the values up one level</description>
+				<visible>False</visible>
 			</control>
-			<control type="label">
-				<include>WindowTitleCommons</include>
-				<label>[COLOR=blue] - [/COLOR]$LOCALIZE[22020]</label>
-				<visible>Window.IsActive(TVGuide) | Window.IsActive(RadioGuide)</visible>
+			<control type="label" id="30">
+				<description>Empty so we can pass the values up one level</description>
+				<visible>False</visible>
 			</control>
-			<control type="label">
-				<include>WindowTitleCommons</include>
-				<label>[COLOR=blue] - [/COLOR]$LOCALIZE[19017]</label>
-				<visible>Window.IsActive(TVRecordings) | Window.IsActive(RadioRecordings)</visible>
-			</control>
-			<control type="label">
-				<include>WindowTitleCommons</include>
-				<label>[COLOR=blue] - [/COLOR]$LOCALIZE[19040]</label>
-				<visible>Window.IsActive(TVTimers) | Window.IsActive(RadioTimers)</visible>
-			</control>
-			<control type="label">
-				<include>WindowTitleCommons</include>
-				<label>[COLOR=blue] - [/COLOR]$LOCALIZE[137]</label>
-				<visible>Window.IsActive(TVSearch) | Window.IsActive(RadioSearch)</visible>
-			</control>
-			<control type="label">
-				<include>WindowTitleCommons</include>
-				<label>$INFO[Control.GetLabel(29),[COLOR=blue] - [/COLOR]]</label>
-			</control>
-			<control type="label">
-				<include>WindowTitleCommons</include>
-				<label>$INFO[Control.GetLabel(30),[COLOR=blue] - [/COLOR]]</label>
-			</control>
-		</control>
-		<control type="label" id="29">
-			<description>Empty so we can pass the values up one level</description>
-			<visible>False</visible>
-		</control>
-		<control type="label" id="30">
-			<description>Empty so we can pass the values up one level</description>
-			<visible>False</visible>
+			<include>Clock</include>
 		</control>
 	</include>
 	<include name="PVRSideBlade">

--- a/addons/skin.confluence/720p/LoginScreen.xml
+++ b/addons/skin.confluence/720p/LoginScreen.xml
@@ -210,21 +210,24 @@
 				</control>
 			</control>
 		</control>
-		<include>Clock</include>
-		<control type="label">
-			<description>Date label</description>
-			<right>20</right>
-			<top>35</top>
-			<width>200</width>
-			<height>15</height>
-			<align>right</align>
-			<aligny>center</aligny>
-			<font>font10</font>
-			<textcolor>white</textcolor>
-			<shadowcolor>black</shadowcolor>
-			<label>$INFO[System.Date]</label>
-			<include>Window_OpenClose_Animation</include>
-			<animation effect="slide" start="0,0" end="-40,0" time="75" condition="Window.IsVisible(Mutebug)">conditional</animation>
+		<control type="group">
+			<depth>DepthHeader</depth>
+			<include>Clock</include>
+			<control type="label">
+				<description>Date label</description>
+				<right>20</right>
+				<top>35</top>
+				<width>200</width>
+				<height>15</height>
+				<align>right</align>
+				<aligny>center</aligny>
+				<font>font10</font>
+				<textcolor>white</textcolor>
+				<shadowcolor>black</shadowcolor>
+				<label>$INFO[System.Date]</label>
+				<include>Window_OpenClose_Animation</include>
+				<animation effect="slide" start="0,0" end="-40,0" time="75" condition="Window.IsVisible(Mutebug)">conditional</animation>
+			</control>
 		</control>
 	</controls>
 </window>

--- a/addons/skin.confluence/720p/MusicOSD.xml
+++ b/addons/skin.confluence/720p/MusicOSD.xml
@@ -3,6 +3,7 @@
 	<defaultcontrol always="true">100</defaultcontrol>
 	<onload condition="!MusicPlayer.Content(LiveTV)">SetFocus(602)</onload>
 	<include>dialogeffect</include>
+	<depth>DepthOSD</depth>
 	<coordinates>
 		<left>0</left>
 		<top>0</top>
@@ -29,6 +30,7 @@
 			<visible>![Window.IsVisible(AddonSettings) | Window.IsVisible(SelectDialog) | Window.IsVisible(VisualisationPresetList) | Window.IsVisible(PVROSDChannels) | Window.IsVisible(PVROSDGuide) | Window.IsVisible(PVRRadioRDSInfo) | Window.IsVisible(OSDAudioDSPSettings) | Window.IsVisible(Addon)]</visible>
 		</control>
 		<control type="slider" id="87">
+			<depth>DepthOSD+</depth>
 			<description>Seek Slider</description>
 			<left>430</left>
 			<top>82r</top>

--- a/addons/skin.confluence/720p/MusicVisualisation.xml
+++ b/addons/skin.confluence/720p/MusicVisualisation.xml
@@ -16,6 +16,7 @@
 			<top>0</top>
 			<width>1280</width>
 			<height>720</height>
+			<aspectratio>scale</aspectratio>
 			<texture background="true">$INFO[Player.Art(fanart)]</texture>
 			<colordiffuse>AAFFFFFF</colordiffuse>
 			<visible>!IsEmpty(Player.Art(fanart)) + !Skin.HasSetting(HideVisualizationFanart)</visible>
@@ -23,12 +24,13 @@
 		</control>
 		<!-- media infos -->
 		<control type="group">
+			<depth>DepthOSD</depth>
 			<animation effect="fade" time="150">VisibleChange</animation>
 			<visible>[Player.ShowInfo | Window.IsActive(MusicOSD)] + ![Window.IsVisible(AddonSettings) | Window.IsVisible(SelectDialog) | Window.IsVisible(VisualisationPresetList) | Window.IsVisible(PVROSDChannels) | Window.IsVisible(PVROSDGuide) | Window.IsVisible(PVRRadioRDSInfo) | Window.IsVisible(OSDAudioDSPSettings) | Window.IsVisible(Addon)]</visible>
 			<control type="image">
-				<left>0</left>
+				<left>-20</left>
 				<top>-150</top>
-				<width>1280</width>
+				<width>1320</width>
 				<height>256</height>
 				<texture flipy="true" border="1">HomeNowPlayingBack.png</texture>
 			</control>
@@ -76,13 +78,14 @@
 				<animation effect="slide" start="0,0" end="-70,0" time="0" condition="Window.IsVisible(MusicOSD)">conditional</animation>
 			</control>
 			<control type="image">
-				<left>0</left>
+				<left>-20</left>
 				<top>230r</top>
-				<width>1280</width>
+				<width>1320</width>
 				<height>230</height>
 				<texture border="1">HomeNowPlayingBack.png</texture>
 			</control>
 			<control type="image">
+				<depth>DepthOSDPopout</depth>
 				<description>cover image</description>
 				<left>20</left>
 				<top>250r</top>
@@ -287,6 +290,7 @@
 		</control>
 		<!-- codec & viz infos -->
 		<control type="group" id="0">
+			<depth>DepthOSD+</depth>
 			<left>0</left>
 			<top>50</top>
 			<visible>Player.ShowCodec + ![Window.IsVisible(script-cu-lrclyrics-main.xml) | Window.IsVisible(VisualisationSettings) | Window.IsVisible(VisualisationPresetList) | Window.IsVisible(PVROSDChannels) | Window.IsVisible(PVROSDGuide) | Window.IsVisible(PVRRadioRDSInfo) | Window.IsVisible(OSDAudioDSPSettings) | Window.IsVisible(Addon)]</visible>

--- a/addons/skin.confluence/720p/MyMusicNav.xml
+++ b/addons/skin.confluence/720p/MyMusicNav.xml
@@ -30,8 +30,11 @@
 			<!-- view id = 551 -->
 			<include>AddonInfoThumbView1</include>
 		</control>
-		<include>CommonPageCount</include>
-		<include>CommonNowPlaying</include>
+		<control type="group">
+			<depth>DepthFooter</depth>
+			<include>CommonPageCount</include>
+			<include>CommonNowPlaying</include>
+		</control>
 		<include>MainWindowMouseButtons</include>
 		<include>BehindDialogFadeOut</include>
 		<include>ScrollOffsetLabel</include>

--- a/addons/skin.confluence/720p/MyMusicNav.xml
+++ b/addons/skin.confluence/720p/MyMusicNav.xml
@@ -35,33 +35,10 @@
 		<include>MainWindowMouseButtons</include>
 		<include>BehindDialogFadeOut</include>
 		<include>ScrollOffsetLabel</include>
-		<control type="image">
-			<description>Section header image</description>
-			<left>20</left>
-			<top>3</top>
-			<width>35</width>
-			<height>35</height>
-			<aspectratio>keep</aspectratio>
-			<texture>icon_music.png</texture>
-		</control>
-		<control type="grouplist">
-			<left>65</left>
-			<top>5</top>
-			<width>1000</width>
-			<height>30</height>
-			<orientation>horizontal</orientation>
-			<align>left</align>
-			<itemgap>5</itemgap>
-			<control type="label">
-				<include>WindowTitleCommons</include>
-				<label>$LOCALIZE[10516]</label>
-			</control>
-			<control type="label">
-				<include>WindowTitleCommons</include>
-				<label>[COLOR=blue] - [/COLOR]$INFO[Container.FolderName]</label>
-				<visible>!IsEmpty(Container.FolderName)</visible>
-			</control>
-		</control>
+		<include name="CommonWindowHeader">
+			<param name="Icon" value="icon_music" />
+			<param name="Label" value="$LOCALIZE[10516]" />
+		</include>
 		<control type="group">
 			<left>-250</left>
 			<include>SideBladeLeft</include>
@@ -171,6 +148,5 @@
 				<include>CommonNowPlaying_Controls</include>
 			</control>
 		</control>
-		<include>Clock</include>
 	</controls>
 </window>

--- a/addons/skin.confluence/720p/MyMusicPlaylist.xml
+++ b/addons/skin.confluence/720p/MyMusicPlaylist.xml
@@ -21,33 +21,10 @@
 		<include>MainWindowMouseButtons</include>
 		<include>BehindDialogFadeOut</include>
 		<include>ScrollOffsetLabel</include>
-		<control type="image">
-			<description>Section header image</description>
-			<left>20</left>
-			<top>3</top>
-			<width>35</width>
-			<height>35</height>
-			<aspectratio>keep</aspectratio>
-			<texture>icon_music.png</texture>
-		</control>
-		<control type="grouplist">
-			<left>65</left>
-			<top>5</top>
-			<width>1000</width>
-			<height>30</height>
-			<orientation>horizontal</orientation>
-			<align>left</align>
-			<itemgap>5</itemgap>
-			<control type="label">
-				<include>WindowTitleCommons</include>
-				<label>$LOCALIZE[10517]</label>
-			</control>
-			<control type="label">
-				<include>WindowTitleCommons</include>
-				<label>[COLOR=blue] - [/COLOR]$INFO[Container.FolderName]</label>
-				<visible>!IsEmpty(Container.FolderName)</visible>
-			</control>
-		</control>
+		<include name="CommonWindowHeader">
+			<param name="Icon" value="icon_music" />
+			<param name="Label" value="$LOCALIZE[10517]" />
+		</include>
 		<control type="group">
 			<left>-250</left>
 			<include>SideBladeLeft</include>
@@ -113,6 +90,5 @@
 				<include>CommonNowPlaying_Controls</include>
 			</control>
 		</control>
-		<include>Clock</include>
 	</controls>
 </window>

--- a/addons/skin.confluence/720p/MyMusicPlaylist.xml
+++ b/addons/skin.confluence/720p/MyMusicPlaylist.xml
@@ -16,8 +16,11 @@
 			<!-- view id = 506 -->
 			<include>MusicInfoListView</include>
 		</control>
-		<include>CommonPageCount</include>
-		<include>CommonNowPlaying</include>
+		<control type="group">
+			<depth>DepthFooter</depth>
+			<include>CommonPageCount</include>
+			<include>CommonNowPlaying</include>
+		</control>
 		<include>MainWindowMouseButtons</include>
 		<include>BehindDialogFadeOut</include>
 		<include>ScrollOffsetLabel</include>

--- a/addons/skin.confluence/720p/MyMusicPlaylistEditor.xml
+++ b/addons/skin.confluence/720p/MyMusicPlaylistEditor.xml
@@ -396,33 +396,9 @@
 				</focusedlayout>
 			</control>
 		</control>
-		<control type="image">
-			<description>Section header image</description>
-			<left>20</left>
-			<top>3</top>
-			<width>35</width>
-			<height>35</height>
-			<aspectratio>keep</aspectratio>
-			<texture>icon_music.png</texture>
-		</control>
-		<control type="grouplist">
-			<left>65</left>
-			<top>5</top>
-			<width>1000</width>
-			<height>30</height>
-			<orientation>horizontal</orientation>
-			<align>left</align>
-			<itemgap>5</itemgap>
-			<control type="label">
-				<include>WindowTitleCommons</include>
-				<label>$LOCALIZE[10503]</label>
-			</control>
-			<control type="label">
-				<include>WindowTitleCommons</include>
-				<label>[COLOR=blue] - [/COLOR]$INFO[Container.FolderName]</label>
-				<visible>!IsEmpty(Container.FolderName)</visible>
-			</control>
-		</control>
-		<include>Clock</include>
+		<include name="CommonWindowHeader">
+			<param name="Icon" value="icon_music" />
+			<param name="Label" value="$LOCALIZE[10503]" />
+		</include>
 	</controls>
 </window>

--- a/addons/skin.confluence/720p/MyPVRChannels.xml
+++ b/addons/skin.confluence/720p/MyPVRChannels.xml
@@ -497,6 +497,7 @@
 					<orientation>vertical</orientation>
 				</control>
 				<control type="label">
+					<depth>DepthFooter</depth>
 					<animation effect="slide" start="0,0" end="-90,0" time="0" condition="system.getbool(input.enablemouse)">Conditional</animation>
 					<description>Page Count Label</description>
 					<right>40</right>
@@ -726,6 +727,7 @@
 					<orientation>vertical</orientation>
 				</control>
 				<control type="label">
+					<depth>DepthFooter</depth>
 					<animation effect="slide" start="0,0" end="-90,0" time="0" condition="system.getbool(input.enablemouse)">Conditional</animation>
 					<description>Page Count Label</description>
 					<right>40</right>
@@ -827,7 +829,10 @@
 				</control>
 			</control>
 		</control>
-		<include>CommonNowPlaying</include>
+		<control type="group">
+			<depth>DepthFooter</depth>
+			<include>CommonNowPlaying</include>
+		</control>
 		<include>BehindDialogFadeOut</include>
 		<include>ScrollOffsetLabel</include>
 		<control type="image">

--- a/addons/skin.confluence/720p/MyPVRChannels.xml
+++ b/addons/skin.confluence/720p/MyPVRChannels.xml
@@ -841,6 +841,5 @@
 			<visible>Window.IsActive(FileBrowser) | Window.IsActive(PVRGuideInfo) | Window.IsActive(PVRRecordingInfo) | Window.IsActive(PVRTimerSetting) | Window.IsActive(PVRGroupManager) | Window.IsActive(PVRGuideSearch)</visible>
 		</control>
 		<include>PVRSideBlade</include>
-		<include>Clock</include>
 	</controls>
 </window>

--- a/addons/skin.confluence/720p/MyPVRGuide.xml
+++ b/addons/skin.confluence/720p/MyPVRGuide.xml
@@ -69,6 +69,5 @@
 			<visible>Window.IsActive(FileBrowser) | Window.IsActive(PVRGuideInfo) | Window.IsActive(PVRRecordingInfo) | Window.IsActive(PVRTimerSetting) | Window.IsActive(PVRGroupManager) | Window.IsActive(PVRGuideSearch)</visible>
 		</control>
 		<include>PVRSideBlade</include>
-		<include>Clock</include>
 	</controls>
 </window>

--- a/addons/skin.confluence/720p/MyPVRGuide.xml
+++ b/addons/skin.confluence/720p/MyPVRGuide.xml
@@ -55,7 +55,10 @@
 			<include>PVRGuideViewNext</include>
 			<include>PVRGuideViewChannel</include>
 		</control>
-		<include>CommonNowPlaying</include>
+		<control type="group">
+			<depth>DepthFooter</depth>
+			<include>CommonNowPlaying</include>
+		</control>
 		<include>BehindDialogFadeOut</include>
 		<include>ScrollOffsetLabel</include>
 		<control type="image">

--- a/addons/skin.confluence/720p/MyPVRRecordings.xml
+++ b/addons/skin.confluence/720p/MyPVRRecordings.xml
@@ -219,6 +219,7 @@
 				<orientation>vertical</orientation>
 			</control>
 			<control type="label">
+				<depth>DepthFooter</depth>
 				<animation effect="slide" start="0,0" end="-90,0" time="0" condition="system.getbool(input.enablemouse)">Conditional</animation>
 				<description>Page Count Label</description>
 				<right>40</right>
@@ -296,7 +297,10 @@
 					<info>PVR.backenddiskspaceprogr</info><visible>!IntegerGreaterThan(PVR.backenddiskspaceprogr,100)</visible></control>
 			</control>
 		</control>
-		<include>CommonNowPlaying</include>
+		<control type="group">
+			<depth>DepthFooter</depth>
+			<include>CommonNowPlaying</include>
+		</control>
 		<include>BehindDialogFadeOut</include>
 		<include>ScrollOffsetLabel</include>
 		<control type="image">

--- a/addons/skin.confluence/720p/MyPVRRecordings.xml
+++ b/addons/skin.confluence/720p/MyPVRRecordings.xml
@@ -310,6 +310,5 @@
 			<visible>Window.IsActive(FileBrowser) | Window.IsActive(PVRGuideInfo) | Window.IsActive(PVRRecordingInfo) | Window.IsActive(PVRTimerSetting) | Window.IsActive(PVRGroupManager) | Window.IsActive(PVRGuideSearch)</visible>
 		</control>
 		<include>PVRSideBlade</include>
-		<include>Clock</include>
 	</controls>
 </window>

--- a/addons/skin.confluence/720p/MyPVRSearch.xml
+++ b/addons/skin.confluence/720p/MyPVRSearch.xml
@@ -520,6 +520,5 @@
 			<visible>Window.IsActive(FileBrowser) | Window.IsActive(PVRGuideInfo) | Window.IsActive(PVRRecordingInfo) | Window.IsActive(PVRTimerSetting) | Window.IsActive(PVRGroupManager) | Window.IsActive(PVRGuideSearch)</visible>
 		</control>
 		<include>PVRSideBlade</include>
-		<include>Clock</include>
 	</controls>
 </window>

--- a/addons/skin.confluence/720p/MyPVRSearch.xml
+++ b/addons/skin.confluence/720p/MyPVRSearch.xml
@@ -492,6 +492,7 @@
 				</control>
 			</control>
 			<control type="label">
+				<depth>DepthFooter</depth>
 				<animation effect="slide" start="0,0" end="-90,0" time="0" condition="system.getbool(input.enablemouse)">Conditional</animation>
 				<description>Page Count Label</description>
 				<right>40</right>
@@ -506,7 +507,10 @@
 				<label>([COLOR=blue]$INFO[Container(50).NumItems][/COLOR]) $LOCALIZE[31025] - $LOCALIZE[31024] ([COLOR=blue]$INFO[Container(50).CurrentPage]/$INFO[Container(50).NumPages][/COLOR])</label>
 			</control>
 		</control>
-		<include>CommonNowPlaying</include>
+		<control type="group">
+			<depth>DepthFooter</depth>
+			<include>CommonNowPlaying</include>
+		</control>
 		<include>BehindDialogFadeOut</include>
 		<include>ScrollOffsetLabel</include>
 		<control type="image">

--- a/addons/skin.confluence/720p/MyPVRTimers.xml
+++ b/addons/skin.confluence/720p/MyPVRTimers.xml
@@ -449,6 +449,5 @@
 			<visible>Window.IsActive(FileBrowser) | Window.IsActive(PVRGuideInfo) | Window.IsActive(PVRRecordingInfo) | Window.IsActive(PVRTimerSetting) | Window.IsActive(PVRGroupManager) | Window.IsActive(PVRGuideSearch)</visible>
 		</control>
 		<include>PVRSideBlade</include>
-		<include>Clock</include>
 	</controls>
 </window>

--- a/addons/skin.confluence/720p/MyPVRTimers.xml
+++ b/addons/skin.confluence/720p/MyPVRTimers.xml
@@ -420,6 +420,7 @@
 				</control>
 			</control>
 			<control type="label">
+				<depth>DepthFooter</depth>
 				<animation effect="slide" start="0,0" end="-90,0" time="0" condition="system.getbool(input.enablemouse)">Conditional</animation>
 				<description>Page Count Label</description>
 				<right>40</right>
@@ -435,7 +436,10 @@
 				<include>Window_OpenClose_Animation</include>
 			</control>
 		</control>
-		<include>CommonNowPlaying</include>
+		<control type="group">
+			<depth>DepthFooter</depth>
+			<include>CommonNowPlaying</include>
+		</control>
 		<include>BehindDialogFadeOut</include>
 		<include>ScrollOffsetLabel</include>
 		<control type="image">

--- a/addons/skin.confluence/720p/MyPics.xml
+++ b/addons/skin.confluence/720p/MyPics.xml
@@ -36,8 +36,11 @@
 			<!-- view id = 551 -->
 			<include>AddonInfoThumbView1</include>
 		</control>
-		<include>CommonPageCount</include>
-		<include>CommonNowPlaying</include>
+		<control type="group">
+			<depth>DepthFooter</depth>
+			<include>CommonPageCount</include>
+			<include>CommonNowPlaying</include>
+		</control>
 		<include>MainWindowMouseButtons</include>
 		<include>BehindDialogFadeOut</include>
 		<include>ScrollOffsetLabel</include>

--- a/addons/skin.confluence/720p/MyPics.xml
+++ b/addons/skin.confluence/720p/MyPics.xml
@@ -41,33 +41,10 @@
 		<include>MainWindowMouseButtons</include>
 		<include>BehindDialogFadeOut</include>
 		<include>ScrollOffsetLabel</include>
-		<control type="image">
-			<description>Section header image</description>
-			<left>20</left>
-			<top>3</top>
-			<width>35</width>
-			<height>35</height>
-			<aspectratio>keep</aspectratio>
-			<texture>icon_pictures.png</texture>
-		</control>
-		<control type="grouplist">
-			<left>65</left>
-			<top>5</top>
-			<width>1000</width>
-			<height>30</height>
-			<orientation>horizontal</orientation>
-			<align>left</align>
-			<itemgap>5</itemgap>
-			<control type="label">
-				<include>WindowTitleCommons</include>
-				<label>$LOCALIZE[1]</label>
-			</control>
-			<control type="label">
-				<include>WindowTitleCommons</include>
-				<label>[COLOR=blue] - [/COLOR]$INFO[Container.FolderName]</label>
-				<visible>!IsEmpty(Container.FolderName)</visible>
-			</control>
-		</control>
+		<include name="CommonWindowHeader">
+			<param name="Icon" value="icon_pictures" />
+			<param name="Label" value="$LOCALIZE[1]" />
+		</include>
 		<control type="group">
 			<left>-250</left>
 			<include>SideBladeLeft</include>
@@ -155,6 +132,5 @@
 				<include>CommonNowPlaying_Controls</include>
 			</control>
 		</control>
-		<include>Clock</include>
 	</controls>
 </window>

--- a/addons/skin.confluence/720p/MyPrograms.xml
+++ b/addons/skin.confluence/720p/MyPrograms.xml
@@ -25,33 +25,10 @@
 		<include>MainWindowMouseButtons</include>
 		<include>BehindDialogFadeOut</include>
 		<include>ScrollOffsetLabel</include>
-		<control type="image">
-			<description>Section header image</description>
-			<left>20</left>
-			<top>3</top>
-			<width>35</width>
-			<height>35</height>
-			<aspectratio>keep</aspectratio>
-			<texture>icon_addons.png</texture>
-		</control>
-		<control type="grouplist">
-			<left>65</left>
-			<top>5</top>
-			<width>1000</width>
-			<height>30</height>
-			<orientation>horizontal</orientation>
-			<align>left</align>
-			<itemgap>5</itemgap>
-			<control type="label">
-				<include>WindowTitleCommons</include>
-				<label>$LOCALIZE[0]</label>
-			</control>
-			<control type="label">
-				<include>WindowTitleCommons</include>
-				<label>[COLOR=blue] - [/COLOR]$INFO[Container.FolderName]</label>
-				<visible>!IsEmpty(Container.FolderName)</visible>
-			</control>
-		</control>
+		<include name="CommonWindowHeader">
+			<param name="Icon" value="icon_addons" />
+			<param name="Label" value="$LOCALIZE[0]" />
+		</include>
 		<control type="group">
 			<left>-250</left>
 			<include>SideBladeLeft</include>
@@ -113,6 +90,5 @@
 				<include>CommonNowPlaying_Controls</include>
 			</control>
 		</control>
-		<include>Clock</include>
 	</controls>
 </window>

--- a/addons/skin.confluence/720p/MyPrograms.xml
+++ b/addons/skin.confluence/720p/MyPrograms.xml
@@ -20,8 +20,11 @@
 			<!-- view id = 551 -->
 			<include>AddonInfoThumbView1</include>
 		</control>
-		<include>CommonPageCount</include>
-		<include>CommonNowPlaying</include>
+		<control type="group">
+			<depth>DepthFooter</depth>
+			<include>CommonPageCount</include>
+			<include>CommonNowPlaying</include>
+		</control>
 		<include>MainWindowMouseButtons</include>
 		<include>BehindDialogFadeOut</include>
 		<include>ScrollOffsetLabel</include>

--- a/addons/skin.confluence/720p/MyVideoNav.xml
+++ b/addons/skin.confluence/720p/MyVideoNav.xml
@@ -36,8 +36,11 @@
 			<!-- view id = 560 -->
 			<include>LiveTVView1</include>
 		</control>
-		<include>CommonPageCount</include>
-		<include>CommonNowPlaying</include>
+		<control type="group">
+			<depth>DepthFooter</depth>
+			<include>CommonPageCount</include>
+			<include>CommonNowPlaying</include>
+		</control>
 		<include>MainWindowMouseButtons</include>
 		<include>BehindDialogFadeOut</include>
 		<include>ScrollOffsetLabel</include>

--- a/addons/skin.confluence/720p/MyVideoNav.xml
+++ b/addons/skin.confluence/720p/MyVideoNav.xml
@@ -41,33 +41,10 @@
 		<include>MainWindowMouseButtons</include>
 		<include>BehindDialogFadeOut</include>
 		<include>ScrollOffsetLabel</include>
-		<control type="image">
-			<description>Section header image</description>
-			<left>20</left>
-			<top>3</top>
-			<width>35</width>
-			<height>35</height>
-			<aspectratio>keep</aspectratio>
-			<texture>icon_video.png</texture>
-		</control>
-		<control type="grouplist">
-			<left>65</left>
-			<top>5</top>
-			<width>1000</width>
-			<height>30</height>
-			<orientation>horizontal</orientation>
-			<align>left</align>
-			<itemgap>5</itemgap>
-			<control type="label">
-				<include>WindowTitleCommons</include>
-				<label>$LOCALIZE[3]</label>
-			</control>
-			<control type="label">
-				<include>WindowTitleCommons</include>
-				<label>[COLOR=blue] - [/COLOR]$INFO[Container.FolderName]</label>
-				<visible>!IsEmpty(Container.FolderName)</visible>
-			</control>
-		</control>
+		<include name="CommonWindowHeader">
+			<param name="Icon" value="icon_video" />
+			<param name="Label" value="$LOCALIZE[3]" />
+		</include>
 		<control type="group">
 			<left>-250</left>
 			<include>SideBladeLeft</include>
@@ -193,6 +170,5 @@
 				<include>CommonNowPlaying_Controls</include>
 			</control>
 		</control>
-		<include>Clock</include>
 	</controls>
 </window>

--- a/addons/skin.confluence/720p/MyVideoPlaylist.xml
+++ b/addons/skin.confluence/720p/MyVideoPlaylist.xml
@@ -19,33 +19,10 @@
 		<include>MainWindowMouseButtons</include>
 		<include>BehindDialogFadeOut</include>
 		<include>ScrollOffsetLabel</include>
-		<control type="image">
-			<description>Section header image</description>
-			<left>20</left>
-			<top>3</top>
-			<width>35</width>
-			<height>35</height>
-			<aspectratio>keep</aspectratio>
-			<texture>icon_video.png</texture>
-		</control>
-		<control type="grouplist">
-			<left>65</left>
-			<top>5</top>
-			<width>1000</width>
-			<height>30</height>
-			<orientation>horizontal</orientation>
-			<align>left</align>
-			<itemgap>5</itemgap>
-			<control type="label">
-				<include>WindowTitleCommons</include>
-				<label>$LOCALIZE[10522]</label>
-			</control>
-			<control type="label">
-				<include>WindowTitleCommons</include>
-				<label>[COLOR=blue] - [/COLOR]$INFO[Container.FolderName]</label>
-				<visible>!IsEmpty(Container.FolderName)</visible>
-			</control>
-		</control>
+		<include name="CommonWindowHeader">
+			<param name="Icon" value="icon_video" />
+			<param name="Label" value="$LOCALIZE[10522]" />
+		</include>
 		<control type="group">
 			<left>-250</left>
 			<include>SideBladeLeft</include>
@@ -111,6 +88,5 @@
 				<include>CommonNowPlaying_Controls</include>
 			</control>
 		</control>
-		<include>Clock</include>
 	</controls>
 </window>

--- a/addons/skin.confluence/720p/MyVideoPlaylist.xml
+++ b/addons/skin.confluence/720p/MyVideoPlaylist.xml
@@ -14,8 +14,11 @@
 			<!-- view id = 51 -->
 			<include>FullWidthList</include>
 		</control>
-		<include>CommonPageCount</include>
-		<include>CommonNowPlaying</include>
+		<control type="group">
+			<depth>DepthFooter</depth>
+			<include>CommonPageCount</include>
+			<include>CommonNowPlaying</include>
+		</control>
 		<include>MainWindowMouseButtons</include>
 		<include>BehindDialogFadeOut</include>
 		<include>ScrollOffsetLabel</include>

--- a/addons/skin.confluence/720p/MyWeather.xml
+++ b/addons/skin.confluence/720p/MyWeather.xml
@@ -18,28 +18,10 @@
 			<visible>Skin.HasSetting(ShowWeatherFanart) + !IsEmpty(Skin.String(WeatherFanartDir))</visible>
 			<animation effect="fade" time="150">WindowClose</animation>
 		</control>
-		<control type="image">
-			<description>Section header image</description>
-			<left>20</left>
-			<top>3</top>
-			<width>35</width>
-			<height>35</height>
-			<aspectratio>keep</aspectratio>
-			<texture>icon_weather.png</texture>
-		</control>
-		<control type="grouplist">
-			<left>65</left>
-			<top>5</top>
-			<width>1000</width>
-			<height>30</height>
-			<orientation>horizontal</orientation>
-			<align>left</align>
-			<itemgap>5</itemgap>
-			<control type="label">
-				<include>WindowTitleCommons</include>
-				<label>$LOCALIZE[8]</label>
-			</control>
-		</control>
+		<include name="CommonWindowHeader">
+			<param name="Icon" value="icon_weather" />
+			<param name="Label" value="$LOCALIZE[8]" />
+		</include>
 		<control type="image">
 			<left>0</left>
 			<top>100r</top>
@@ -599,6 +581,5 @@
 				<include>CommonNowPlaying_Controls</include>
 			</control>
 		</control>
-		<include>Clock</include>
 	</controls>
 </window>

--- a/addons/skin.confluence/720p/MyWeather.xml
+++ b/addons/skin.confluence/720p/MyWeather.xml
@@ -6,10 +6,9 @@
 	<controls>
 		<include>CommonBackground</include>
 		<control type="multiimage">
-			<left>0</left>
-			<top>0</top>
-			<width>1280</width>
-			<height>720</height>
+			<depth>DepthBackground</depth>
+			<include>BackgroundDimensions</include>
+			<aspectratio>scale</aspectratio>
 			<imagepath background="true">$INFO[Skin.String(WeatherFanartDir)]$INFO[Window(Weather).Property(Current.FanartCode)]</imagepath>
 			<timeperimage>10000</timeperimage>
 			<randomize>true</randomize>
@@ -128,40 +127,43 @@
 						<aligny>center</aligny>
 						<textcolor>grey2</textcolor>
 					</control>
-					<control type="label">
-						<description>current temp Value</description>
-						<left>15</left>
-						<top>185</top>
-						<width>180</width>
-						<height>40</height>
-						<font>WeatherTemp</font>
-						<align>right</align>
-						<aligny>top</aligny>
-						<label>$INFO[Window.Property(Current.Temperature)]</label>
-						<textcolor>white</textcolor>
-						<shadowcolor>black</shadowcolor>
-					</control>
-					<control type="label">
-						<description>current temp Value Units</description>
-						<left>200</left>
-						<top>206</top>
-						<width>100</width>
-						<height>40</height>
-						<font>font16</font>
-						<align>left</align>
-						<aligny>top</aligny>
-						<label>[B]$INFO[System.TemperatureUnits][/B]</label>
-						<textcolor>white</textcolor>
-						<shadowcolor>black</shadowcolor>
-					</control>
-					<control type="image">
-						<description>current weather icon</description>
-						<left>260</left>
-						<top>145</top>
-						<width>200</width>
-						<height>200</height>
-						<info>Window.Property(Current.ConditionIcon)</info>
-						<aspectratio>keep</aspectratio>
+					<control type="group">
+						<depth>DepthContent+</depth>
+						<control type="label">
+							<description>current temp Value</description>
+							<left>15</left>
+							<top>185</top>
+							<width>180</width>
+							<height>40</height>
+							<font>WeatherTemp</font>
+							<align>right</align>
+							<aligny>top</aligny>
+							<label>$INFO[Window.Property(Current.Temperature)]</label>
+							<textcolor>white</textcolor>
+							<shadowcolor>black</shadowcolor>
+						</control>
+						<control type="label">
+							<description>current temp Value Units</description>
+							<left>200</left>
+							<top>206</top>
+							<width>100</width>
+							<height>40</height>
+							<font>font16</font>
+							<align>left</align>
+							<aligny>top</aligny>
+							<label>[B]$INFO[System.TemperatureUnits][/B]</label>
+							<textcolor>white</textcolor>
+							<shadowcolor>black</shadowcolor>
+						</control>
+						<control type="image">
+							<description>current weather icon</description>
+							<left>260</left>
+							<top>145</top>
+							<width>200</width>
+							<height>200</height>
+							<info>Window.Property(Current.ConditionIcon)</info>
+							<aspectratio>keep</aspectratio>
+						</control>
 					</control>
 					<control type="label">
 						<description>current condition label</description>
@@ -433,7 +435,10 @@
 				</control>
 			</control>
 		</control>
-		<include>CommonNowPlaying</include>
+		<control type="group">
+			<depth>DepthFooter</depth>
+			<include>CommonNowPlaying</include>
+		</control>
 		<include>MainWindowMouseButtons</include>
 		<control type="group">
 			<left>-250</left>

--- a/addons/skin.confluence/720p/Settings.xml
+++ b/addons/skin.confluence/720p/Settings.xml
@@ -246,28 +246,9 @@
 		<include>CommonNowPlaying</include>
 		<include>MainWindowMouseButtons</include>
 		<include>BehindDialogFadeOut</include>
-		<control type="image">
-			<description>Section header image</description>
-			<left>20</left>
-			<top>3</top>
-			<width>35</width>
-			<height>35</height>
-			<aspectratio>keep</aspectratio>
-			<texture>icon_system.png</texture>
-		</control>
-		<control type="grouplist">
-			<left>65</left>
-			<top>5</top>
-			<width>1000</width>
-			<height>30</height>
-			<orientation>horizontal</orientation>
-			<align>left</align>
-			<itemgap>5</itemgap>
-			<control type="label">
-				<include>WindowTitleCommons</include>
-				<label>$LOCALIZE[5]</label>
-			</control>
-		</control>
-		<include>Clock</include>
+		<include name="CommonWindowHeader">
+			<param name="Icon" value="icon_system" />
+			<param name="Label" value="$LOCALIZE[5]" />
+		</include>
 	</controls>
 </window>

--- a/addons/skin.confluence/720p/Settings.xml
+++ b/addons/skin.confluence/720p/Settings.xml
@@ -243,7 +243,10 @@
 				<shadowcolor>black</shadowcolor>
 			</control>
 		</control>
-		<include>CommonNowPlaying</include>
+		<control type="group">
+			<depth>DepthFooter</depth>
+			<include>CommonNowPlaying</include>
+		</control>
 		<include>MainWindowMouseButtons</include>
 		<include>BehindDialogFadeOut</include>
 		<include name="CommonWindowHeader">

--- a/addons/skin.confluence/720p/SettingsCategory.xml
+++ b/addons/skin.confluence/720p/SettingsCategory.xml
@@ -274,7 +274,10 @@
 			<font>-</font>
 			<visible>false</visible>
 		</control>
-		<include>CommonNowPlaying</include>
+		<control type="group">
+			<depth>DepthFooter</depth>
+			<include>CommonNowPlaying</include>
+		</control>
 		<include>MainWindowMouseButtons</include>
 		<include name="CommonWindowHeader">
 			<param name="Icon" value="icon_system" />

--- a/addons/skin.confluence/720p/SettingsCategory.xml
+++ b/addons/skin.confluence/720p/SettingsCategory.xml
@@ -276,32 +276,10 @@
 		</control>
 		<include>CommonNowPlaying</include>
 		<include>MainWindowMouseButtons</include>
-		<control type="image">
-			<description>Section header image</description>
-			<left>20</left>
-			<top>3</top>
-			<width>35</width>
-			<height>35</height>
-			<aspectratio>keep</aspectratio>
-			<texture>icon_system.png</texture>
-		</control>
-		<control type="grouplist">
-			<left>65</left>
-			<top>5</top>
-			<width>1000</width>
-			<height>30</height>
-			<orientation>horizontal</orientation>
-			<align>left</align>
-			<itemgap>5</itemgap>
-			<control type="label">
-				<include>WindowTitleCommons</include>
-				<label>$LOCALIZE[5]</label>
-			</control>
-			<control type="label">
-				<include>WindowTitleCommons</include>
-				<label>[COLOR=blue] - [/COLOR]$INFO[Control.GetLabel(2)]</label>
-			</control>
-		</control>
-		<include>Clock</include>
+		<include name="CommonWindowHeader">
+			<param name="Icon" value="icon_system" />
+			<param name="Label" value="$LOCALIZE[5]" />
+			<param name="ShowLabel2" value="true" />
+		</include>
 	</controls>
 </window>

--- a/addons/skin.confluence/720p/SettingsProfile.xml
+++ b/addons/skin.confluence/720p/SettingsProfile.xml
@@ -373,7 +373,10 @@
 				</control>
 			</control>
 		</control>
-		<include>CommonNowPlaying</include>
+		<control type="group">
+			<depth>DepthFooter</depth>
+			<include>CommonNowPlaying</include>
+		</control>
 		<include>MainWindowMouseButtons</include>
 		<include>BehindDialogFadeOut</include>
 		<include name="CommonWindowHeader">

--- a/addons/skin.confluence/720p/SettingsProfile.xml
+++ b/addons/skin.confluence/720p/SettingsProfile.xml
@@ -376,28 +376,9 @@
 		<include>CommonNowPlaying</include>
 		<include>MainWindowMouseButtons</include>
 		<include>BehindDialogFadeOut</include>
-		<control type="image">
-			<description>Section header image</description>
-			<left>20</left>
-			<top>3</top>
-			<width>35</width>
-			<height>35</height>
-			<aspectratio>keep</aspectratio>
-			<texture>icon_system.png</texture>
-		</control>
-		<control type="grouplist">
-			<left>65</left>
-			<top>5</top>
-			<width>1000</width>
-			<height>30</height>
-			<orientation>horizontal</orientation>
-			<align>left</align>
-			<itemgap>5</itemgap>
-			<control type="label">
-				<include>WindowTitleCommons</include>
-				<label>$LOCALIZE[13200]</label>
-			</control>
-		</control>
-		<include>Clock</include>
+		<include name="CommonWindowHeader">
+			<param name="Icon" value="icon_system" />
+			<param name="Label" value="$LOCALIZE[13200]" />
+		</include>
 	</controls>
 </window>

--- a/addons/skin.confluence/720p/SettingsSystemInfo.xml
+++ b/addons/skin.confluence/720p/SettingsSystemInfo.xml
@@ -368,28 +368,9 @@
 		</control>
 		<include>CommonNowPlaying</include>
 		<include>MainWindowMouseButtons</include>
-		<control type="image">
-			<description>Section header image</description>
-			<left>20</left>
-			<top>3</top>
-			<width>35</width>
-			<height>35</height>
-			<aspectratio>keep</aspectratio>
-			<texture>icon_system.png</texture>
-		</control>
-		<control type="grouplist">
-			<left>65</left>
-			<top>5</top>
-			<width>1000</width>
-			<height>30</height>
-			<orientation>horizontal</orientation>
-			<align>left</align>
-			<itemgap>5</itemgap>
-			<control type="label">
-				<include>WindowTitleCommons</include>
-				<label>$LOCALIZE[130]</label>
-			</control>
-		</control>
-		<include>Clock</include>
+		<include name="CommonWindowHeader">
+			<param name="Icon" value="icon_system" />
+			<param name="Label" value="$LOCALIZE[130]" />
+		</include>
 	</controls>
 </window>

--- a/addons/skin.confluence/720p/SkinSettings.xml
+++ b/addons/skin.confluence/720p/SkinSettings.xml
@@ -11,33 +11,10 @@
 			<texture>floor.png</texture>
 			<include>VisibleFadeEffect</include>
 		</control>
-		<control type="image">
-			<description>Section header image</description>
-			<left>20</left>
-			<top>3</top>
-			<width>35</width>
-			<height>35</height>
-			<aspectratio>keep</aspectratio>
-			<texture>icon_system.png</texture>
-		</control>
-		<control type="grouplist">
-			<left>65</left>
-			<top>5</top>
-			<width>1000</width>
-			<height>30</height>
-			<orientation>horizontal</orientation>
-			<align>left</align>
-			<itemgap>5</itemgap>
-			<control type="label">
-				<include>WindowTitleCommons</include>
-				<label>$LOCALIZE[20077]</label>
-			</control>
-			<control type="label">
-				<include>WindowTitleCommons</include>
-				<label>[COLOR=blue] - [/COLOR]$INFO[Container.FolderName]</label>
-				<visible>!IsEmpty(Container.FolderName)</visible>
-			</control>
-		</control>
+		<include name="CommonWindowHeader">
+			<param name="Icon" value="icon_system" />
+			<param name="Label" value="$LOCALIZE[20077]" />
+		</include>
 		<control type="group">
 			<left>90</left>
 			<top>30</top>
@@ -1049,6 +1026,5 @@
 		<include>CommonNowPlaying</include>
 		<include>MainWindowMouseButtons</include>
 		<include>BehindDialogFadeOut</include>
-		<include>Clock</include>
 	</controls>
 </window>

--- a/addons/skin.confluence/720p/VideoFullScreen.xml
+++ b/addons/skin.confluence/720p/VideoFullScreen.xml
@@ -4,12 +4,13 @@
 	<controls>
 		<!-- media infos -->
 		<control type="group" id="1">
+			<depth>DepthOSD</depth>
 			<visible>[Player.ShowInfo | Window.IsActive(VideoOSD)] + ![Window.IsVisible(OSDVideoSettings) | Window.IsVisible(OSDAudioSettings) | Window.IsVisible(OSDAudioDSPSettings) | Window.IsVisible(VideoBookmarks) | Window.IsVisible(PVROSDChannels) | Window.IsVisible(PVROSDGuide) | Window.IsVisible(SliderDialog)]</visible>
 			<animation effect="fade" time="150">VisibleChange</animation>
 			<control type="image" id="1">
-				<left>0</left>
+				<left>-20</left>
 				<top>-150</top>
-				<width>1280</width>
+				<width>1320</width>
 				<height>256</height>
 				<texture flipy="true" border="1">HomeNowPlayingBack.png</texture>
 			</control>
@@ -57,13 +58,14 @@
 				<animation effect="slide" start="0,0" end="-70,0" time="0" condition="Window.IsVisible(VideoOSD)">conditional</animation>
 			</control>
 			<control type="image" id="1">
-				<left>0</left>
+				<left>-20</left>
 				<top>230r</top>
-				<width>1280</width>
+				<width>1320</width>
 				<height>230</height>
 				<texture border="1">HomeNowPlayingBack.png</texture>
 			</control>
 			<control type="image" id="1">
+				<depth>DepthOSDPopout</depth>
 				<description>cover image</description>
 				<left>20</left>
 				<top>260r</top>
@@ -76,6 +78,7 @@
 				<visible>![VideoPlayer.Content(Movies) | VideoPlayer.Content(LiveTV)]</visible>
 			</control>
 			<control type="image" id="1">
+				<depth>DepthOSDPopout</depth>
 				<description>Movie cover image</description>
 				<left>20</left>
 				<top>350r</top>
@@ -88,6 +91,7 @@
 				<visible>VideoPlayer.Content(Movies)</visible>
 			</control>
 			<control type="image" id="1">
+				<depth>DepthOSDPopout</depth>
 				<description>PIcon image</description>
 				<left>20</left>
 				<top>200r</top>
@@ -391,6 +395,7 @@
 		</control>
 		<!-- codec info -->
 		<control type="group" id="0">
+			<depth>DepthOSD+</depth>
 			<left>0</left>
 			<top>20</top>
 			<animation effect="fade" time="150">VisibleChange</animation>
@@ -437,6 +442,7 @@
 			</control>
 		</control>
 		<control type="group">
+			<depth>DepthOSD+</depth>
 			<visible>Player.ShowCodec + VideoPlayer.Content(LiveTV) + system.getbool(pvrplayback.signalquality)</visible>
 			<top>185</top>
 			<control type="image">

--- a/addons/skin.confluence/720p/VideoOSD.xml
+++ b/addons/skin.confluence/720p/VideoOSD.xml
@@ -3,6 +3,7 @@
 	<defaultcontrol always="true">100</defaultcontrol>
 	<onload condition="!VideoPlayer.Content(LiveTV)">SetFocus(202)</onload>
 	<include>dialogeffect</include>
+	<depth>DepthOSD</depth>
 	<coordinates>
 		<left>0</left>
 		<top>0</top>
@@ -29,6 +30,7 @@
 			<visible>![Window.IsVisible(SliderDialog) | Window.IsVisible(OSDVideoSettings) | Window.IsVisible(OSDAudioSettings) | Window.IsVisible(OSDAudioDSPSettings) | Window.IsVisible(VideoBookmarks)]</visible>
 		</control>
 		<control type="slider" id="87">
+			<depth>DepthOSD+</depth>
 			<description>Seek Slider</description>
 			<left>430</left>
 			<top>82r</top>
@@ -283,6 +285,7 @@
 			<visible>Control.HasFocus(410) | Control.HasFocus(250) | ControlGroup(400).HasFocus</visible>
 		</control>
 		<control type="grouplist" id="400">
+			<depth>DepthOSD+</depth>
 			<visible>![Window.IsVisible(SliderDialog) | Window.IsVisible(OSDVideoSettings) | Window.IsVisible(OSDAudioSettings) | Window.IsVisible(OSDAudioDSPSettings) | Window.IsVisible(VideoBookmarks)]</visible>
 			<animation effect="fade" time="150">VisibleChange</animation>
 			<animation effect="slide" start="0,0" end="0,80" time="0" condition="![VideoPlayer.HasSubtitles + VideoPlayer.SubtitlesEnabled]">Conditional</animation>
@@ -404,6 +407,7 @@
 			<visible>Control.HasFocus(520) | Control.HasFocus(255) | ControlGroup(500).HasFocus</visible>
 		</control>
 		<control type="grouplist" id="500">
+			<depth>DepthOSD+</depth>
 			<visible>videoplayer.isstereoscopic + ![Window.IsVisible(SliderDialog) | Window.IsVisible(OSDVideoSettings) | Window.IsVisible(OSDAudioSettings) | Window.IsVisible(OSDAudioDSPSettings) | Window.IsVisible(VideoBookmarks) | Window.IsVisible(PVROSDChannels) | Window.IsVisible(PVROSDGuide)] + [Control.HasFocus(255) | ControlGroup(500).HasFocus | Control.HasFocus(520)]</visible>
 			<animation effect="fade" time="150">VisibleChange</animation>
 			<animation effect="slide" start="0,0" end="55,0" time="0" condition="VideoPlayer.Content(LiveTV)">Conditional</animation>

--- a/addons/skin.confluence/720p/ViewsFileMode.xml
+++ b/addons/skin.confluence/720p/ViewsFileMode.xml
@@ -201,6 +201,7 @@
 				<visible>Control.IsVisible(50)</visible>
 			</control>
 			<control type="group">
+				<depth>DepthContent-</depth>
 				<left>850</left>
 				<top>100</top>
 				<visible>Control.IsVisible(50)</visible>

--- a/addons/skin.confluence/720p/ViewsMusicLibrary.xml
+++ b/addons/skin.confluence/720p/ViewsMusicLibrary.xml
@@ -261,6 +261,7 @@
 			<left>0</left>
 			<top>450</top>
 			<control type="fixedlist" id="509">
+				<depth>DepthContent-</depth>
 				<visible>Container.Content(Albums)</visible>
 				<hitrect x="0" y="-10" w="1280" h="190" />
 				<left>-80</left>
@@ -313,6 +314,7 @@
 				</itemlayout>
 				<focusedlayout height="200" width="160">
 					<control type="image">
+						<depth>DepthContentPopout</depth>
 						<left>-2</left>
 						<top>16</top>
 						<width>168</width>
@@ -326,6 +328,7 @@
 						<animation reversible="false" effect="zoom" end="-2,16,168,168" start="-12,-4,198,198" time="150">unfocus</animation>
 					</control>
 					<control type="image">
+						<depth>DepthContentPopout</depth>
 						<left>180</left>
 						<top>325</top>
 						<width>35</width>
@@ -344,6 +347,7 @@
 				</focusedlayout>
 			</control>
 			<control type="scrollbar" id="60">
+				<depth>DepthContent</depth>
 				<left>310</left>
 				<top>195</top>
 				<width>660</width>

--- a/addons/skin.confluence/720p/ViewsPVRGuide.xml
+++ b/addons/skin.confluence/720p/ViewsPVRGuide.xml
@@ -671,6 +671,7 @@
 				</control>
 			</control>
 			<control type="label">
+				<depth>DepthFooter</depth>
 				<animation effect="slide" start="0,0" end="-90,0" time="0" condition="system.getbool(input.enablemouse)">Conditional</animation>
 				<description>Page Count Label</description>
 				<right>40</right>
@@ -1049,6 +1050,7 @@
 				</control>
 			</control>
 			<control type="label">
+				<depth>DepthFooter</depth>
 				<animation effect="slide" start="0,0" end="-90,0" time="0" condition="system.getbool(input.enablemouse)">Conditional</animation>
 				<description>Page Count Label</description>
 				<right>40</right>
@@ -1374,6 +1376,7 @@
 				</control>
 			</control>
 			<control type="label">
+				<depth>DepthFooter</depth>
 				<animation effect="slide" start="0,0" end="-90,0" time="0" condition="system.getbool(input.enablemouse)">Conditional</animation>
 				<description>Page Count Label</description>
 				<right>40</right>

--- a/addons/skin.confluence/720p/ViewsPictures.xml
+++ b/addons/skin.confluence/720p/ViewsPictures.xml
@@ -7,6 +7,7 @@
 			<left>0</left>
 			<top>440</top>
 			<control type="wraplist" id="510">
+				<depth>DepthContent+</depth>
 				<left>-25</left>
 				<top>5</top>
 				<width>1330</width>
@@ -44,6 +45,7 @@
 				</itemlayout>
 				<focusedlayout height="200" width="190">
 					<control type="image">
+						<depth>DepthContentPopout</depth>
 						<left>15</left>
 						<top>40</top>
 						<width>160</width>
@@ -57,6 +59,7 @@
 						<animation reversible="false" effect="zoom" end="15,40,160,160" start="-10,-5,210,210" time="150">unfocus</animation>
 					</control>
 					<control type="image">
+						<depth>DepthContentPopout</depth>
 						<left>25</left>
 						<top>50</top>
 						<width>140</width>

--- a/addons/skin.confluence/720p/ViewsVideoLibrary.xml
+++ b/addons/skin.confluence/720p/ViewsVideoLibrary.xml
@@ -42,6 +42,7 @@
 				</itemlayout>
 				<focusedlayout height="310" width="218">
 					<control type="image">
+						<depth>DepthContentPopout</depth>
 						<left>-2</left>
 						<top>36</top>
 						<width>222</width>
@@ -54,6 +55,7 @@
 						<animation reversible="false" effect="zoom" end="-2,36,222,318" start="-28,0,284,390" time="150">unfocus</animation>
 					</control>
 					<control type="image">
+						<depth>DepthContentPopout</depth>
 						<left>6</left>
 						<top>44</top>
 						<width>170</width>
@@ -64,6 +66,7 @@
 						<animation reversible="false" effect="zoom" end="6,44,170,180" start="-24,4,240,250" time="150">unfocus</animation>
 					</control>
 					<control type="image">
+						<depth>DepthContentPopout</depth>
 						<left>185</left>
 						<top>310</top>
 						<width>35</width>
@@ -309,6 +312,7 @@
 			<left>0</left>
 			<top>460</top>
 			<control type="fixedlist" id="508">
+				<depth>DepthContent-</depth>
 				<visible>Container.Content(Movies) | Container.Content(TVShows) | Container.Content(Sets)</visible>
 				<hitrect x="0" y="-10" w="1280" h="190" />
 				<left>-20</left>
@@ -361,6 +365,7 @@
 				</itemlayout>
 				<focusedlayout height="310" width="120">
 					<control type="image">
+						<depth>DepthContentPopout</depth>
 						<left>-2</left>
 						<top>16</top>
 						<width>128</width>
@@ -374,6 +379,7 @@
 						<animation reversible="false" effect="zoom" end="-2,16,128,168" start="-12,-10,148,198" time="150">unfocus</animation>
 					</control>
 					<control type="image">
+						<depth>DepthContentPopout</depth>
 						<left>2</left>
 						<top>180</top>
 						<width>120</width>
@@ -385,6 +391,7 @@
 						<texture background="true" flipy="true" diffuse="diffuse_mirror2.png">$VAR[PosterThumb]</texture>
 					</control>
 					<control type="image">
+						<depth>DepthContentPopout</depth>
 						<left>90</left>
 						<top>150</top>
 						<width>35</width>
@@ -403,6 +410,7 @@
 				</focusedlayout>
 			</control>
 			<control type="scrollbar" id="60">
+				<depth>DepthContent</depth>
 				<left>310</left>
 				<top>185</top>
 				<width>660</width>

--- a/addons/skin.confluence/720p/ViewsWeather.xml
+++ b/addons/skin.confluence/720p/ViewsWeather.xml
@@ -374,6 +374,7 @@
 				<visible>Control.IsVisible(51)</visible>
 			</control>
 			<control type="label">
+				<depth>DepthFooter</depth>
 				<animation effect="slide" start="0,0" end="-90,0" time="0" condition="system.getbool(input.enablemouse)">Conditional</animation>
 				<description>number of files/pages</description>
 				<left>90</left>
@@ -1098,6 +1099,7 @@
 				<visible>Control.IsVisible(52)</visible>
 			</control>
 			<control type="label">
+				<depth>DepthFooter</depth>
 				<animation effect="slide" start="0,0" end="-90,0" time="0" condition="system.getbool(input.enablemouse)">Conditional</animation>
 				<description>number of files/pages</description>
 				<right>40</right>

--- a/addons/skin.confluence/720p/includes.xml
+++ b/addons/skin.confluence/720p/includes.xml
@@ -1414,4 +1414,46 @@
 		<font>font13</font>
 		<focusedcolor>black</focusedcolor>
 	</include>
+	<include name="CommonWindowHeader">
+		<param name="Icon" default="icon_home" />
+		<param name="Label" default="" />
+		<param name="ShowLabel2" default="False" />
+		<definition>
+			<control type="group">
+				<control type="image">
+					<description>Section header image</description>
+					<left>20</left>
+					<top>3</top>
+					<width>35</width>
+					<height>35</height>
+					<aspectratio>keep</aspectratio>
+					<texture>$PARAM[Icon].png</texture>
+				</control>
+				<control type="grouplist">
+					<left>65</left>
+					<top>5</top>
+					<width>1000</width>
+					<height>30</height>
+					<orientation>horizontal</orientation>
+					<align>left</align>
+					<itemgap>5</itemgap>
+					<control type="label">
+						<include>WindowTitleCommons</include>
+						<label>$PARAM[Label]</label>
+					</control>
+					<control type="label">
+						<include>WindowTitleCommons</include>
+						<label>[COLOR=blue] - [/COLOR]$INFO[Container.FolderName]</label>
+						<visible>!IsEmpty(Container.FolderName)</visible>
+					</control>
+					<control type="label">
+						<include>WindowTitleCommons</include>
+						<label>[COLOR=blue] - [/COLOR]$INFO[Control.GetLabel(2)]</label>
+						<visible>$PARAM[ShowLabel2]</visible>
+					</control>
+				</control>
+				<include>Clock</include>
+			</control>
+		</definition>
+	</include>
 </includes>

--- a/addons/skin.confluence/720p/includes.xml
+++ b/addons/skin.confluence/720p/includes.xml
@@ -14,8 +14,30 @@
 	<include file="IncludesHomeMenuItems.xml" />
 	<include file="IncludesPVR.xml" />
 	<include file="IncludesBackgroundBuilding.xml" />
+	<!-- CONSTANTS -->
 	<constant name="FanartCrossfadeTime">500</constant>
 	<constant name="IconCrossfadeTime">400</constant>
+	<constant name="DepthDialog">0.50</constant>
+	<constant name="DepthDialog+">0.52</constant>
+	<constant name="DepthDialog-">0.48</constant>
+	<constant name="DepthMax">0.54</constant>
+	<constant name="DepthOSD">0.40</constant>
+	<constant name="DepthOSD+">0.44</constant>
+	<constant name="DepthOSD-">0.36</constant>
+	<constant name="DepthOSDPopout">0.48</constant>
+	<constant name="DepthContent">0</constant>
+	<constant name="DepthContent+">0.08</constant>
+	<constant name="DepthContent-">-0.08</constant>
+	<constant name="DepthContentPopout">0.15</constant>
+	<constant name="DepthMenu">0.08</constant>
+	<constant name="DepthMenu+">0.14</constant>
+	<constant name="DepthMenu-">0.00</constant>
+	<constant name="DepthHeader">0.08</constant>
+	<constant name="DepthFooter">0.08</constant>
+	<constant name="DepthBackground">-0.80</constant>
+	<constant name="DepthFloor">-0.20</constant>
+	<constant name="DepthSideBlade">0.15</constant>
+	<!-- VARIABLES -->
 	<variable name="MediaInfoOverlayVar">
 		<value condition="ListItem.IsCollection">flagging/video/Set.png</value>
 		<value condition="!ListItem.IsStereoscopic">$INFO[ListItem.VideoResolution,flagging/lists/,.png]</value>
@@ -86,6 +108,7 @@
 		<value condition="!IsEmpty(Window.Property(IsRadio))">$LOCALIZE[19199] - $LOCALIZE[19024]</value>
 		<value>$LOCALIZE[19199] - $LOCALIZE[19023]</value>
 	</variable>
+	<!-- INCLUDES -->
 	<include name="AlbumInfoPanel">
 		<control type="panel" id="50">
 			<left>$PARAM[panel-left]</left>
@@ -305,6 +328,7 @@
 		<pulseonselect>false</pulseonselect>
 	</include>
 	<include name="SideBladeLeft">
+		<depth>DepthSideBlade</depth>
 		<animation effect="slide" start="0,0" end="250,0" time="300" tween="quadratic" easing="out" condition="[ControlGroup(9000).HasFocus | Control.HasFocus(9001) | Control.HasFocus(8999)] + ![Window.IsActive(PVRGuideInfo) | Window.IsActive(PVRRadioRDSInfo)]">Conditional</animation>
 		<animation effect="slide" start="0,0" end="-300,0" time="300" tween="quadratic" easing="out" condition="ControlGroup(9000).HasFocus | Control.HasFocus(9001)">WindowClose</animation>
 		<animation effect="slide" start="0,0" end="-50,0" time="225" tween="quadratic" easing="out" condition="![ControlGroup(9000).HasFocus | Control.HasFocus(9001)]">WindowClose</animation>
@@ -331,9 +355,9 @@
 			<texturenofocus>HasSub.png</texturenofocus>
 		</control>
 		<control type="image">
-			<left>0</left>
+			<left>-20</left>
 			<top>0</top>
-			<width>260</width>
+			<width>280</width>
 			<height>720</height>
 			<texture border="0,0,10,0">MediaBladeSub.png</texture>
 		</control>
@@ -1071,6 +1095,7 @@
 	</include>
 	<include name="ScrollOffsetLabel">
 		<control type="group">
+			<depth>DepthSideBlade</depth>
 			<visible>Container.Scrolling + [StringCompare(Container.SortMethod,$LOCALIZE[551]) | StringCompare(Container.SortMethod,$LOCALIZE[561]) | StringCompare(Container.SortMethod,$LOCALIZE[558]) | StringCompare(Container.SortMethod,$LOCALIZE[557]) | StringCompare(Container.SortMethod,$LOCALIZE[556])]</visible>
 			<animation effect="slide" start="0,0" end="0,-60" time="75">Visible</animation>
 			<animation effect="slide" start="0,-60" end="0,0" delay="300" time="75">Hidden</animation>
@@ -1397,6 +1422,7 @@
 		<animation effect="fade" time="200">WindowClose</animation>
 	</include>
 	<include name="dialogeffect">
+		<depth>DepthDialog</depth>
 		<animation effect="fade" time="200">WindowOpen</animation>
 		<animation effect="fade" time="200">WindowClose</animation>
 	</include>
@@ -1420,6 +1446,7 @@
 		<param name="ShowLabel2" default="False" />
 		<definition>
 			<control type="group">
+				<depth>DepthHeader</depth>
 				<control type="image">
 					<description>Section header image</description>
 					<left>20</left>
@@ -1455,5 +1482,10 @@
 				<include>Clock</include>
 			</control>
 		</definition>
+	</include>
+	<include name="BackgroundDimensions">
+		<width>1280</width>
+		<height>720</height>
+		<animation effect="zoom" center="auto" end="101,101" time="0" condition="IntegerGreaterThan(System.StereoscopicMode,0)">conditional</animation>
 	</include>
 </includes>

--- a/addons/skin.confluence/720p/script-cu-lrclyrics-main.xml
+++ b/addons/skin.confluence/720p/script-cu-lrclyrics-main.xml
@@ -6,6 +6,7 @@
 	</coordinates>
 	<controls>
 		<control type="group">
+			<depth>DepthOSDPopout</depth>
 			<animation effect="slide" start="600,0" end="0,0" time="300" tween="quadratic" easing="out" condition="!Player.ShowCodec">WindowOpen</animation>
 			<animation effect="slide" start="600,0" end="0,0" time="300" delay="300" tween="quadratic" easing="out" condition="Player.ShowCodec">WindowOpen</animation>
 			<animation effect="slide" start="0,0" end="600,0" time="150" tween="quadratic" easing="out">WindowClose</animation>


### PR DESCRIPTION
This PR adds subtile stereoscopic depth to Confluence. OSD and dialogues will pop out of the screen so that they stay on top of random objects from videos that also pop out. The popout effect is using ~60% of the possible depth which should be enough for everage movie scenes. It won't cover all cases ofc, but it'll be way to extreme if we'd go all the way for main UI elements. The main content area stays at level 0, which means that while you're browsing in GUI your eye can focus directly to the screen without hurting your eyes. The downside of this is, that a potentially playing movie in background will cause distractions on transparent areas. To compensate for that I pushed back the video background panel, but this doesn't seem to have an effect atm. Maybe @afedchin could have a look.

This PR depends on #8146 as it uses constants for the depths values for easy tweaking.

@ronie @phil65 @BigNoid please review. To simplify some things I created an include for the common global header (breadcrumb + clock) - not sure you like that, but I hope so.
