### PR TITLE
[xbmc][library] Fix export library

### DIFF
--- a/xbmc/interfaces/builtins/LibraryBuiltins.cpp
+++ b/xbmc/interfaces/builtins/LibraryBuiltins.cpp
@@ -106,7 +106,7 @@ static int ExportLibrary(const std::vector<std::string>& params)
       thumbs = StringUtils::EqualsNoCase(params[2], "true");
     else
     {
-      HELPERS::DialogResponse result = HELPERS::ShowYesNoDialogText(CVariant{iHeading}, CVariant{20430}, CVariant{20428}, CVariant{20429});
+      HELPERS::DialogResponse result = HELPERS::ShowYesNoDialogText(CVariant{iHeading}, CVariant{20430}); 
       cancelled = result == HELPERS::DialogResponse::CANCELLED;
       thumbs = result == HELPERS::DialogResponse::YES;
     }
@@ -147,7 +147,7 @@ static int ExportLibrary(const std::vector<std::string>& params)
 
   if (params.size() > 2)
     path=params[2];
-  if (singleFile || !path.empty() ||
+  if (singleFile && !path.empty() ||
       CGUIDialogFileBrowser::ShowAndGetDirectory(shares, g_localizeStrings.Get(661),
                                                  path, true))
   {

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -8182,7 +8182,7 @@ void CVideoDatabase::DumpToDummyFiles(const std::string &path)
   }
 }
 
-void CVideoDatabase::ExportToXML(const std::string &path, bool singleFiles /* = false */, bool images /* = false */, bool actorThumbs /* false */, bool overwrite /*=false*/)
+void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = true */, bool images /* = false */, bool actorThumbs /* false */, bool overwrite /*=false*/)
 {
   int iFailCount = 0;
   CGUIDialogProgress *progress=NULL;
@@ -8208,7 +8208,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFiles /* = 
     std::string moviesDir = URIUtils::AddFileToFolder(exportRoot, "movies");
     std::string musicvideosDir = URIUtils::AddFileToFolder(exportRoot, "musicvideos");
     std::string tvshowsDir = URIUtils::AddFileToFolder(exportRoot, "tvshows");
-    if (!singleFiles)
+    if (singleFile)
     {
       images = true;
       overwrite = false;
@@ -8246,7 +8246,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFiles /* = 
     TiXmlDeclaration decl("1.0", "UTF-8", "yes");
     xmlDoc.InsertEndChild(decl);
     TiXmlNode *pMain = NULL;
-    if (singleFiles)
+    if (!singleFile)
       pMain = &xmlDoc;
     else
     {
@@ -8262,7 +8262,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFiles /* = 
       if (StringUtils::StartsWith(movie.m_strTrailer, movie.m_strPath))
         movie.m_strTrailer = movie.m_strTrailer.substr(movie.m_strPath.size());
       std::map<std::string, std::string> artwork;
-      if (GetArtForItem(movie.m_iDbId, movie.m_type, artwork) && !singleFiles)
+      if (GetArtForItem(movie.m_iDbId, movie.m_type, artwork) && singleFile)
       {
         TiXmlElement additionalNode("art");
         for (std::map<std::string, std::string>::const_iterator i = artwork.begin(); i != artwork.end(); ++i)
@@ -8270,7 +8270,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFiles /* = 
         movie.Save(pMain, "movie", true, &additionalNode);
       }
       else
-        movie.Save(pMain, "movie", !singleFiles);
+        movie.Save(pMain, "movie", singleFile);
 
       // reset old skip state
       bool bSkip = false;
@@ -8289,7 +8289,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFiles /* = 
       }
 
       CFileItem item(movie.m_strFileNameAndPath,false);
-      if (singleFiles && CUtil::SupportsWriteFileOperations(movie.m_strFileNameAndPath))
+      if (!singleFile && CUtil::SupportsWriteFileOperations(movie.m_strFileNameAndPath))
       {
         if (!item.Exists(false))
         {
@@ -8318,7 +8318,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFiles /* = 
           }
         }
       }
-      if (singleFiles)
+      if (!singleFile)
       {
         xmlDoc.Clear();
         TiXmlDeclaration decl("1.0", "UTF-8", "yes");
@@ -8327,7 +8327,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFiles /* = 
 
       if (images && !bSkip)
       {
-        if (!singleFiles)
+        if (singleFile)
         {
           std::string strFileName(movie.m_strTitle);
           if (movie.m_iYear > 0)
@@ -8340,7 +8340,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFiles /* = 
           CTextureCache::GetInstance().Export(i->second, savedThumb, overwrite);
         }
         if (actorThumbs)
-          ExportActorThumbs(actorsDir, movie, singleFiles, overwrite);
+          ExportActorThumbs(actorsDir, movie, !singleFile, overwrite);
       }
       m_pDS->next();
       current++;
@@ -8359,7 +8359,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFiles /* = 
     {
       CVideoInfoTag movie = GetDetailsForMusicVideo(m_pDS, true);
       std::map<std::string, std::string> artwork;
-      if (GetArtForItem(movie.m_iDbId, movie.m_type, artwork) && !singleFiles)
+      if (GetArtForItem(movie.m_iDbId, movie.m_type, artwork) && singleFile)
       {
         TiXmlElement additionalNode("art");
         for (std::map<std::string, std::string>::const_iterator i = artwork.begin(); i != artwork.end(); ++i)
@@ -8367,7 +8367,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFiles /* = 
         movie.Save(pMain, "musicvideo", true, &additionalNode);
       }
       else
-        movie.Save(pMain, "musicvideo", !singleFiles);
+        movie.Save(pMain, "musicvideo", singleFile);
 
       // reset old skip state
       bool bSkip = false;
@@ -8386,7 +8386,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFiles /* = 
       }
 
       CFileItem item(movie.m_strFileNameAndPath,false);
-      if (singleFiles && CUtil::SupportsWriteFileOperations(movie.m_strFileNameAndPath))
+      if (!singleFile && CUtil::SupportsWriteFileOperations(movie.m_strFileNameAndPath))
       {
         if (!item.Exists(false))
         {
@@ -8408,7 +8408,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFiles /* = 
           }
         }
       }
-      if (singleFiles)
+      if (!singleFile)
       {
         xmlDoc.Clear();
         TiXmlDeclaration decl("1.0", "UTF-8", "yes");
@@ -8416,7 +8416,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFiles /* = 
       }
       if (images && !bSkip)
       {
-        if (!singleFiles)
+        if (singleFile)
         {
           std::string strFileName(StringUtils::Join(movie.m_artist, g_advancedSettings.m_videoItemSeparator) + "." + movie.m_strTitle);
           if (movie.m_iYear > 0)
@@ -8449,7 +8449,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFiles /* = 
       GetTvShowSeasonArt(tvshow.m_iDbId, seasonArt);
 
       std::map<std::string, std::string> artwork;
-      if (GetArtForItem(tvshow.m_iDbId, tvshow.m_type, artwork) && !singleFiles)
+      if (GetArtForItem(tvshow.m_iDbId, tvshow.m_type, artwork) && singleFile)
       {
         TiXmlElement additionalNode("art");
         for (std::map<std::string, std::string>::const_iterator i = artwork.begin(); i != artwork.end(); ++i)
@@ -8465,7 +8465,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFiles /* = 
         tvshow.Save(pMain, "tvshow", true, &additionalNode);
       }
       else
-        tvshow.Save(pMain, "tvshow", !singleFiles);
+        tvshow.Save(pMain, "tvshow", singleFile);
 
       // reset old skip state
       bool bSkip = false;
@@ -8484,7 +8484,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFiles /* = 
       }
 
       CFileItem item(tvshow.m_strPath, true);
-      if (singleFiles && CUtil::SupportsWriteFileOperations(tvshow.m_strPath))
+      if (!singleFile && CUtil::SupportsWriteFileOperations(tvshow.m_strPath))
       {
         if (!item.Exists(false))
         {
@@ -8506,7 +8506,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFiles /* = 
           }
         }
       }
-      if (singleFiles)
+      if (!singleFile)
       {
         xmlDoc.Clear();
         TiXmlDeclaration decl("1.0", "UTF-8", "yes");
@@ -8514,7 +8514,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFiles /* = 
       }
       if (images && !bSkip)
       {
-        if (!singleFiles)
+        if (singleFile)
           item.SetPath(GetSafeFile(tvshowsDir, tvshow.m_strTitle));
 
         for (std::map<std::string, std::string>::const_iterator i = artwork.begin(); i != artwork.end(); ++i)
@@ -8524,7 +8524,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFiles /* = 
         }
 
         if (actorThumbs)
-          ExportActorThumbs(actorsDir, tvshow, singleFiles, overwrite);
+          ExportActorThumbs(actorsDir, tvshow, !singleFile, overwrite);
 
         // export season thumbs
         for (std::map<int, std::map<std::string, std::string> >::const_iterator i = seasonArt.begin(); i != seasonArt.end(); ++i)
@@ -8554,24 +8554,24 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFiles /* = 
       {
         CVideoInfoTag episode = GetDetailsForEpisode(pDS, true);
         std::map<std::string, std::string> artwork;
-        if (GetArtForItem(episode.m_iDbId, MediaTypeEpisode, artwork) && !singleFiles)
+        if (GetArtForItem(episode.m_iDbId, MediaTypeEpisode, artwork) && singleFile)
         {
           TiXmlElement additionalNode("art");
           for (std::map<std::string, std::string>::const_iterator i = artwork.begin(); i != artwork.end(); ++i)
             XMLUtils::SetString(&additionalNode, i->first.c_str(), i->second);
           episode.Save(pMain->LastChild(), "episodedetails", true, &additionalNode);
         }
-        else if (!singleFiles)
-          episode.Save(pMain->LastChild(), "episodedetails", !singleFiles);
+        else if (singleFile)
+          episode.Save(pMain->LastChild(), "episodedetails", singleFile);
         else
-          episode.Save(pMain, "episodedetails", !singleFiles);
+          episode.Save(pMain, "episodedetails", singleFile);
         pDS->next();
         // multi-episode files need dumping to the same XML
-        while (singleFiles && !pDS->eof() &&
+        while (!singleFile && !pDS->eof() &&
                episode.m_iFileId == pDS->fv("idFile").get_asInt())
         {
           episode = GetDetailsForEpisode(pDS, true);
-          episode.Save(pMain, "episodedetails", !singleFiles);
+          episode.Save(pMain, "episodedetails", singleFile);
           pDS->next();
         }
 
@@ -8579,7 +8579,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFiles /* = 
         bool bSkip = false;
 
         CFileItem item(episode.m_strFileNameAndPath, false);
-        if (singleFiles && CUtil::SupportsWriteFileOperations(episode.m_strFileNameAndPath))
+        if (!singleFile && CUtil::SupportsWriteFileOperations(episode.m_strFileNameAndPath))
         {
           if (!item.Exists(false))
           {
@@ -8601,7 +8601,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFiles /* = 
             }
           }
         }
-        if (singleFiles)
+        if (!singleFile)
         {
           xmlDoc.Clear();
           TiXmlDeclaration decl("1.0", "UTF-8", "yes");
@@ -8610,7 +8610,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFiles /* = 
 
         if (images && !bSkip)
         {
-          if (!singleFiles)
+          if (singleFile)
           {
             std::string epName = StringUtils::Format("s%02ie%02i.avi", episode.m_iSeason, episode.m_iEpisode);
             item.SetPath(URIUtils::AddFileToFolder(showDir, epName));
@@ -8621,7 +8621,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFiles /* = 
             CTextureCache::GetInstance().Export(i->second, savedThumb, overwrite);
           }
           if (actorThumbs)
-            ExportActorThumbs(actorsDir, episode, singleFiles, overwrite);
+            ExportActorThumbs(actorsDir, episode, !singleFile, overwrite);
         }
       }
       pDS->close();
@@ -8630,13 +8630,13 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFiles /* = 
     }
     m_pDS->close();
 
-    if (singleFiles && progress)
+    if (!singleFile && progress)
     {
       progress->SetPercentage(100);
       progress->Progress();
     }
 
-    if (!singleFiles)
+    if (singleFile)
     {
       // now dump path info
       std::set<std::string> paths;
@@ -8662,7 +8662,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFiles /* = 
       xmlDoc.SaveFile(xmlFile);
     }
     CVariant data;
-    if (!singleFiles)
+    if (singleFile)
     {
       data["root"] = exportRoot;
       data["file"] = xmlFile;

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -732,7 +732,7 @@ public:
    */
   void UpdateFileDateAdded(int idFile, const std::string& strFileNameAndPath);
 
-  void ExportToXML(const std::string &path, bool singleFiles = false, bool images=false, bool actorThumbs=false, bool overwrite=false);
+  void ExportToXML(const std::string &path, bool singleFile = true, bool images=false, bool actorThumbs=false, bool overwrite=false);
   void ExportActorThumbs(const std::string &path, const CVideoInfoTag& tag, bool singleFiles, bool overwrite=false);
   void ImportFromXML(const std::string &path);
   void DumpToDummyFiles(const std::string &path);


### PR DESCRIPTION
Fix c/p error on dialogs and renamed singleFiles variable in videolibrary as it was somewhat confusingly named compared to the dialog options
