### PR TITLE
Improve virtual keyboard layout for English

### DIFF
--- a/system/keyboardlayouts/english.xml
+++ b/system/keyboardlayouts/english.xml
@@ -8,14 +8,14 @@ Default font lacks support for all characters
     <keyboard>
       <row>1234567890</row>
       <row>qwertyuiop</row>
-      <row>asdfghjkl</row>
-      <row>zxcvbnm</row>
+      <row>asdfghjkl:</row>
+      <row>zxcvbnm./@</row>
     </keyboard>
     <keyboard modifiers="shift">
       <row>1234567890</row>
       <row>QWERTYUIOP</row>
-      <row>ASDFGHJKL</row>
-      <row>ZXCVBNM</row>
+      <row>ASDFGHJKL:</row>
+      <row>ZXCVBNM./@</row>
     </keyboard>
     <keyboard modifiers="symbol,shift+symbol">
       <row>)!@#$%^&amp;*(</row>
@@ -29,13 +29,13 @@ Default font lacks support for all characters
       <row>1234567890</row>
       <row>azertyuiop</row>
       <row>qsdfghjklm</row>
-      <row>wxcvbn</row>
+      <row>wxcvbn:./@</row>
     </keyboard>
     <keyboard modifiers="shift">
       <row>1234567890</row>
       <row>AZERTYUIOP</row>
       <row>QSDFGHJKLM</row>
-      <row>WXCVBN</row>
+      <row>WXCVBN:./@</row>
     </keyboard>
     <keyboard modifiers="symbol,shift+symbol">
       <row>)!@#$%^&amp;*(</row>
@@ -49,13 +49,13 @@ Default font lacks support for all characters
       <row>0123456789</row>
       <row>abcdefghij</row>
       <row>klmnopqrst</row>
-      <row>uvwxyz</row>
+      <row>uvwxyz:./@</row>
     </keyboard>
     <keyboard modifiers="shift">
       <row>0123456789</row>
       <row>ABCDEFGHIJ</row>
       <row>KLMNOPQRST</row>
-      <row>UVWXYZ</row>
+      <row>UVWXYZ:./@</row>
     </keyboard>
     <keyboard modifiers="symbol,shift+symbol">
       <row>)!@#$%^&amp;*(</row>


### PR DESCRIPTION
Previously discussed:

https://github.com/xbmc/xbmc/pull/6843

There were some objections, some request for comments from the community, but in the end nothing better got suggested other than the more simplified layout that was then added to OpenELEC:

https://github.com/OpenELEC/OpenELEC.tv/pull/4217

So far the OpenELEC change has been very positive and hasn't caused any issues, as previously feared. I'm hoping that is enough to push this through.

Other language or alternative layouts are welcome to suggest their own changes. I think it is a fair argument that their changes will be different for different areas/people/localization/whatever. In the long run, a contextually sensitive row would be better (context specific to URL entry, e-mail entry, title entry, etc), but this is the best we can do with the current code, and makes using the on-screen-keyboard much nicer (oh god, the URLs!).
