### PR TITLE
[guilib] only consider visible controls within grouplists for Container.Position

### DIFF
--- a/xbmc/guilib/GUIControlGroupList.cpp
+++ b/xbmc/guilib/GUIControlGroupList.cpp
@@ -81,15 +81,17 @@ void CGUIControlGroupList::Process(unsigned int currentTime, CDirtyRegionList &d
       g_graphicsContext.SetOrigin(m_posX + pos - m_scroller.GetValue(), m_posY);
     control->DoProcess(currentTime, dirtyregions);
 
-    if (IsControlOnScreen(pos, control))
-    {
-      if (control->HasFocus())
-        m_focusedPosition = index;
-      index++;
-    }
-
     if (control->IsVisible())
+    {
+      if (IsControlOnScreen(pos, control))
+      {
+        if (control->HasFocus())
+          m_focusedPosition = index;
+        index++;
+      }
+
       pos += Size(control) + m_itemGap;
+    }
     g_graphicsContext.RestoreOrigin();
   }
   CGUIControl::Process(currentTime, dirtyregions);


### PR DESCRIPTION
This fixes an issue reported by @HitcherUK where hidden controls are considered valid when checking via `Container.Position` in grouplist controls. Fix is already confirmed working as intended.
