### PR TITLE
[videothumbloader] skip thumb extraction for bluray items

### DIFF
--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -87,6 +87,8 @@ bool CThumbExtractor::DoWork()
 {
   if (m_item.IsLiveTV()
   ||  URIUtils::IsUPnP(m_item.GetPath())
+  ||  URIUtils::IsBluray(m_item.GetPath())
+  ||  m_item.IsBDFile()
   ||  m_item.IsDVD()
   ||  m_item.IsDiscImage()
   ||  m_item.IsDVDFile(false, true)


### PR DESCRIPTION
Skip over bluray items, extracting thumbs for those will wail anyways.

/cc @ace20022 since i am not 100% sure about chapter thumbs.
