### PR TITLE
[EPG][PVR] Guide window: Show channels without EPG data

### DIFF
--- a/xbmc/epg/GUIEPGGridContainer.cpp
+++ b/xbmc/epg/GUIEPGGridContainer.cpp
@@ -977,7 +977,7 @@ void CGUIEPGGridContainer::UpdateItems(CFileItemList *items)
     {
       CFileItemPtr item = m_gridIndex[row][block].item;
 
-      if (item != m_gridIndex[row][block+1].item)
+      if ((item != m_gridIndex[row][block+1].item) || (!item && block == m_blocks - 1))
       {
         if (!item)
         {

--- a/xbmc/epg/GUIEPGGridContainer.cpp
+++ b/xbmc/epg/GUIEPGGridContainer.cpp
@@ -982,6 +982,7 @@ void CGUIEPGGridContainer::UpdateItems(CFileItemList *items)
         if (!item)
         {
           CEpgInfoTagPtr gapTag(CEpgInfoTag::CreateDefaultTag());
+          gapTag->SetPVRChannel(m_channelItems[row]->GetPVRChannelInfoTag());
           CFileItemPtr gapItem(new CFileItem(gapTag));
           for (int i = block ; i > block - itemSize; i--)
           {
@@ -1486,6 +1487,19 @@ int CGUIEPGGridContainer::GetSelectedItem() const
 const int CGUIEPGGridContainer::GetSelectedChannel() const
 {
   return m_channelCursor + m_channelOffset;
+}
+
+CFileItemPtr CGUIEPGGridContainer::GetSelectedChannelItem() const
+{
+  CFileItemPtr item;
+
+  if (!m_gridIndex.empty() &&
+      !m_epgItemsPtr.empty() &&
+      m_channelCursor + m_channelOffset < m_channels &&
+      m_blockCursor + m_blockOffset < m_blocks)
+    item = m_gridIndex[m_channelCursor + m_channelOffset][m_blockCursor + m_blockOffset].item;
+
+  return item;
 }
 
 CEpgInfoTagPtr CGUIEPGGridContainer::GetSelectedEpgInfoTag() const

--- a/xbmc/epg/GUIEPGGridContainer.h
+++ b/xbmc/epg/GUIEPGGridContainer.h
@@ -67,6 +67,7 @@ namespace EPG
     virtual int GetSelectedItem() const;
     const int GetSelectedChannel() const;
     void SetSelectedChannel(int channelIndex);
+    CFileItemPtr GetSelectedChannelItem() const;
     PVR::CPVRChannelPtr GetChannel(int iIndex);
     void SetSelectedBlock(int blockIndex);
     virtual EVENT_RESULT OnMouseEvent(const CPoint &point, const CMouseEvent &event);

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -392,9 +392,10 @@ namespace PVR
     /*!
      * @brief Get all EPG tables.
      * @param results The fileitem list to store the results in.
+     * @param bIncludeChannelsWithoutEPG, for channels without EPG data, put an empty EPG tag associated with the channel into results
      * @return The amount of entries that were added.
      */
-    int GetEPGAll(CFileItemList &results) const;
+    int GetEPGAll(CFileItemList &results, bool bIncludeChannelsWithoutEPG = false) const;
 
     /*!
      * @brief Get all entries that are active now.

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -250,6 +250,31 @@ bool CGUIWindowPVRGuide::OnMessage(CGUIMessage& message)
               break;
           }
         }
+        else if (iItem == -1)
+        {
+          /* process actions */
+          switch (message.GetParam1())
+          {
+            case ACTION_SELECT_ITEM:
+            case ACTION_MOUSE_LEFT_CLICK:
+            case ACTION_PLAY:
+            {
+              // EPG "gap" selected => switch to associated channel.
+              CGUIEPGGridContainer *epgGridContainer =
+                dynamic_cast<CGUIEPGGridContainer*>(GetControl(m_viewControl.GetCurrentControl()));
+              if (epgGridContainer)
+              {
+                CFileItemPtr item(epgGridContainer->GetSelectedChannelItem());
+                if (item)
+                {
+                  ActionPlayEpg(item.get(), false);
+                  bReturn = true;
+                }
+              }
+              break;
+            }
+          }
+        }
       }
       else if (message.GetSenderId() == CONTROL_BTNVIEWASICONS)
       {

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -387,7 +387,7 @@ void CGUIWindowPVRGuide::GetViewTimelineItems(CFileItemList &items)
 
     m_cachedTimeline->Clear();
     m_cachedChannelGroup = group;
-    m_cachedChannelGroup->GetEPGAll(*m_cachedTimeline);
+    m_cachedChannelGroup->GetEPGAll(*m_cachedTimeline, true);
   }
 
   items.Clear();


### PR DESCRIPTION
- Show channels without EPG data in PVR Guide window
- When selecting an EPG "gap" (usually labeled "no information available"), switch to the associated channel

Feature was requested here: http://forum.kodi.tv/showthread.php?tid=239713
