### PR TITLE
FIX: [droid] use renderer resolution when available

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -815,11 +815,25 @@ bool CApplication::CreateGUI()
 
 bool CApplication::InitWindow()
 {
+  RESOLUTION res = CDisplaySettings::Get().GetCurrentResolution();
+
 #ifdef TARGET_DARWIN_OSX
   // force initial window creation to be windowed, if fullscreen, it will switch to it below
   // fixes the white screen of death if starting fullscreen and switching to windowed.
   bool bFullScreen = false;
   if (!g_Windowing.CreateNewWindow(CSysInfo::GetAppName(), bFullScreen, CDisplaySettings::Get().GetResolutionInfo(RES_WINDOW), OnEvent))
+  {
+    CLog::Log(LOGFATAL, "CApplication::Create: Unable to create window");
+    return false;
+  }
+#elif defined(TARGET_ANDROID)
+  // We might come from a refresh rate switch destroying the native window; use the renderer resolution
+  if (g_graphicsContext.GetVideoResolution() != RES_INVALID)
+    res = g_graphicsContext.GetVideoResolution();
+  RESOLUTION_INFO res_info = CDisplaySettings::Get().GetResolutionInfo(res);
+
+  bool bFullScreen = res != RES_WINDOW;
+  if (!g_Windowing.CreateNewWindow(CSysInfo::GetAppName(), bFullScreen, res_info, OnEvent))
   {
     CLog::Log(LOGFATAL, "CApplication::Create: Unable to create window");
     return false;
@@ -839,7 +853,7 @@ bool CApplication::InitWindow()
     return false;
   }
   // set GUI res and force the clear of the screen
-  g_graphicsContext.SetVideoResolution(CDisplaySettings::Get().GetCurrentResolution());
+  g_graphicsContext.SetVideoResolution(res);
   return true;
 }
 


### PR DESCRIPTION
When switching refresh rate, the native window is destroyed and
recreated, so use the rendere resolution if available to avoid being
reset to the setting resolution

Backport of #8142 
