### PR TITLE
[airplay] - restore ios 9 music streaming capability

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -4088,7 +4088,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#1268"
-msgid "iOS 8 compatibility mode"
+msgid "Enable AirPlay Video and Picture support"
 msgstr ""
 
 msgctxt "#1269"
@@ -17698,7 +17698,7 @@ msgstr ""
 #. Description of setting "Services -> AirPlay -> iOS 8 compatibility mode" with label #1268
 #: system/settings/settings.xml
 msgctxt "#36549"
-msgid "Use iOS8 compatible AirPlay support. If you have trouble with older iOS devices detecting this application as a valid target try switching this off. This option requires a restart to take effect!"
+msgid "Enables support for receving videos and pictures via AirPlay. This needs to be disabled when using iOS 9 or later clients to restore music streaming via AirPlay. Videos and Pictures are only supported for iOS clients using iOS 8.x and older."
 msgstr ""
 
 #. Name of a setting

--- a/project/BuildDependencies/scripts/0_package.list
+++ b/project/BuildDependencies/scripts/0_package.list
@@ -35,7 +35,7 @@ libpng-1.5.13-win32.7z
 librtmp-20150114-git-a107ce-win32.7z
 libsdl-1.2.10-win32.7z
 libsdl_image-1.2.14-win32.7z
-libshairplay-068f138-win32.7z
+libshairplay-52fd9db-win32.7z
 libssh-0.5.0-1-win32.zip
 libvorbis-vc100-1.3.1-win32.7z
 libxml2-2.7.8_1-win32.7z

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2413,7 +2413,7 @@
             <hidden>true</hidden>
           </control>
         </setting>
-        <setting id="services.airplayios8compat" type="boolean" parent="services.airplay" label="1268" help="36549">
+        <setting id="services.airplayvideosupport" type="boolean" parent="services.airplay" label="1268" help="36549">
           <level>3</level>
           <default>true</default>
           <dependencies>

--- a/tools/depends/target/libshairplay/Makefile
+++ b/tools/depends/target/libshairplay/Makefile
@@ -3,7 +3,7 @@ DEPS= ../../Makefile.include
 
 # lib name, version
 LIBNAME=shairplay
-VERSION=0f41ade
+VERSION=498bc5b
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.bz2
 

--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -1047,7 +1047,7 @@ int CAirPlayServer::CTCPClient::ProcessRequest( std::string& responseHeader,
       }
       else //if we are not playing and get the stop request - we just wanna stop picture streaming
       {
-        CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_ACTION, -1, -1, static_cast<void*>(new CAction(ACTION_PREVIOUS_MENU)));
+        CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_ACTION, WINDOW_SLIDESHOW, -1, static_cast<void*>(new CAction(ACTION_STOP)));
       }
     }
     ClearPhotoAssetCache();

--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -987,7 +987,7 @@ int CAirPlayServer::CTCPClient::ProcessRequest( std::string& responseHeader,
       CApplicationMessenger::GetInstance().PostMsg(TMSG_MEDIA_PLAY, -1, -1, static_cast<void*>(l));
 
       // allow starting the player paused in ios8 mode (needed by camera roll app)
-      if (CSettings::GetInstance().GetBool(CSettings::SETTING_SERVICES_AIRPLAYIOS8COMPAT) && !startPlayback)
+      if (!startPlayback)
       {
         CApplicationMessenger::GetInstance().SendMsg(TMSG_MEDIA_PAUSE);
         g_application.m_pPlayer->SeekPercentage(position * 100.0f);

--- a/xbmc/network/NetworkServices.cpp
+++ b/xbmc/network/NetworkServices.cpp
@@ -594,18 +594,11 @@ bool CNetworkServices::StartAirPlayServer()
   txt.push_back(std::make_pair("model", "Xbmc,1"));
   txt.push_back(std::make_pair("srcvers", AIRPLAY_SERVER_VERSION_STR));
 
-  if (CSettings::GetInstance().GetBool(CSettings::SETTING_SERVICES_AIRPLAYIOS8COMPAT))
-  {
-    // for ios8 clients we need to announce mirroring support
-    // else we won't get video urls anymore.
-    // We also announce photo caching support (as it seems faster and
-    // we have implemented it anyways). 
-    txt.push_back(std::make_pair("features", "0x20F7"));
-  }
-  else
-  {
-    txt.push_back(std::make_pair("features", "0x77"));
-  }
+  // for ios8 clients we need to announce mirroring support
+  // else we won't get video urls anymore.
+  // We also announce photo caching support (as it seems faster and
+  // we have implemented it anyways).
+  txt.push_back(std::make_pair("features", "0x20F7"));
 
   CZeroconf::GetInstance()->PublishService("servers.airplay", "_airplay._tcp", CSysInfo::GetDeviceName(), g_advancedSettings.m_airPlayPort, txt);
 #endif // HAS_ZEROCONF

--- a/xbmc/network/NetworkServices.cpp
+++ b/xbmc/network/NetworkServices.cpp
@@ -263,6 +263,22 @@ bool CNetworkServices::OnSettingChanging(const CSetting *setting)
         return false;
     }
   }
+  else if (settingId == CSettings::SETTING_SERVICES_AIRPLAYVIDEOSUPPORT)
+  {
+    if (((CSettingBool*)setting)->GetValue())
+    {
+      if (!StartAirPlayServer())
+      {
+        CGUIDialogOK::ShowAndGetInput(CVariant{1273}, CVariant{33100});
+        return false;
+      }
+    }
+    else
+    {
+      if (!StopAirPlayServer(true))
+        return false;
+    }
+  }
   else if (settingId == CSettings::SETTING_SERVICES_AIRPLAYPASSWORD ||
            settingId == CSettings::SETTING_SERVICES_USEAIRPLAYPASSWORD)
   {
@@ -554,6 +570,9 @@ bool CNetworkServices::StopWebserver()
 
 bool CNetworkServices::StartAirPlayServer()
 {
+  if (!CSettings::GetInstance().GetBool(CSettings::SETTING_SERVICES_AIRPLAYVIDEOSUPPORT))
+    return true;
+
 #ifdef HAS_AIRPLAY
   if (!g_application.getNetwork().IsAvailable() || !CSettings::GetInstance().GetBool(CSettings::SETTING_SERVICES_AIRPLAY))
     return false;

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -337,7 +337,7 @@ const std::string CSettings::SETTING_SERVICES_AIRPLAY = "services.airplay";
 const std::string CSettings::SETTING_SERVICES_AIRPLAYVOLUMECONTROL = "services.airplayvolumecontrol";
 const std::string CSettings::SETTING_SERVICES_USEAIRPLAYPASSWORD = "services.useairplaypassword";
 const std::string CSettings::SETTING_SERVICES_AIRPLAYPASSWORD = "services.airplaypassword";
-const std::string CSettings::SETTING_SERVICES_AIRPLAYIOS8COMPAT = "services.airplayios8compat";
+const std::string CSettings::SETTING_SERVICES_AIRPLAYVIDEOSUPPORT = "services.airplayvideosupport";
 const std::string CSettings::SETTING_SMB_WINSSERVER = "smb.winsserver";
 const std::string CSettings::SETTING_SMB_WORKGROUP = "smb.workgroup";
 const std::string CSettings::SETTING_VIDEOSCREEN_MONITOR = "videoscreen.monitor";
@@ -1145,6 +1145,7 @@ void CSettings::InitializeISettingCallbacks()
   settingSet.insert(CSettings::SETTING_SERVICES_ZEROCONF);
   settingSet.insert(CSettings::SETTING_SERVICES_AIRPLAY);
   settingSet.insert(CSettings::SETTING_SERVICES_AIRPLAYVOLUMECONTROL);
+  settingSet.insert(CSettings::SETTING_SERVICES_AIRPLAYVIDEOSUPPORT);
   settingSet.insert(CSettings::SETTING_SERVICES_USEAIRPLAYPASSWORD);
   settingSet.insert(CSettings::SETTING_SERVICES_AIRPLAYPASSWORD);
   settingSet.insert(CSettings::SETTING_SERVICES_UPNPSERVER);

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -294,7 +294,7 @@ public:
   static const std::string SETTING_SERVICES_AIRPLAYVOLUMECONTROL;
   static const std::string SETTING_SERVICES_USEAIRPLAYPASSWORD;
   static const std::string SETTING_SERVICES_AIRPLAYPASSWORD;
-  static const std::string SETTING_SERVICES_AIRPLAYIOS8COMPAT;
+  static const std::string SETTING_SERVICES_AIRPLAYVIDEOSUPPORT;
   static const std::string SETTING_SMB_WINSSERVER;
   static const std::string SETTING_SMB_WORKGROUP;
   static const std::string SETTING_VIDEOSCREEN_MONITOR;


### PR DESCRIPTION
This 
1. Removes the ios8 compat setting and makes ios8 compat behavior the default one
2. Adds a setting which allows the user to disable video/pictures airplay capabilities which defaults to on
3. By disabling the new setting from 2. and in combination with the bumped libshairplay from this PR all ios9 users can restore at least music streaming features.

Though ios9 users will loose any sort of metadata when streaming music (no progress/duration info, no album thumb, no artist, no album, no title). Thats as far as we can get atm for ios9 clients.

@MartijnKaijser is it a problem to reuse those language ids? I guess until the language addons are synced users would get the old text for this setting - right?
