### PR TITLE
[depends] update cmake to 3.3.2

### DIFF
--- a/tools/depends/native/cmake-native/Makefile
+++ b/tools/depends/native/cmake-native/Makefile
@@ -3,7 +3,7 @@ PLATFORM=$(NATIVEPLATFORM)
 DEPS= ../../Makefile.include.in Makefile
 
 APPNAME=cmake
-VERSION=2.8.12
+VERSION=3.3.2
 SOURCE=$(APPNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
 


### PR DESCRIPTION
Request contains a for Chromium CEF needed update which require the final version 2.8.12.2 of cmake in 2. series.

EDIT: This request change to use the newest CMake version for depends.

The second patch contains a temporary change to use URL from CMake direct for test build (https://cmake.org/files/v3.3/cmake-3.3.2.tar.gz). If it is ok then need this be added to Kodi's web storage.

The newest Version of CMake is 3.3.2, I think to compatibility with older system versions is better to stay in 2. What do you think?
