### PR TITLE
Align video and music sort types on file listings to each other

### DIFF
--- a/xbmc/music/GUIViewStateMusic.cpp
+++ b/xbmc/music/GUIViewStateMusic.cpp
@@ -487,6 +487,10 @@ CGUIViewStateWindowMusicNav::CGUIViewStateWindowMusicNav(const CFileItemList& it
     else
     {
       AddSortMethod(SortByLabel, 551, LABEL_MASKS("%F", "%D", "%L", ""));  // Filename, Duration | Foldername, empty
+      AddSortMethod(SortBySize, 553, LABEL_MASKS("%F", "%I", "%L", "%I"));  // Filename, Size | Foldername, Size
+      AddSortMethod(SortByDate, 552, LABEL_MASKS("%F", "%J", "%L", "%J"));  // Filename, Date | Foldername, Date
+      AddSortMethod(SortByFile, 561, LABEL_MASKS("%F", "%I", "%L", ""));  // Filename, Size | Label, empty
+
       SetSortMethod(SortByLabel);
     }
     SetViewAsControl(DEFAULT_VIEW_LIST);


### PR DESCRIPTION
This removes one redundant search type from video file lists and aligns the music file lists to the ones in video.

As @hitcher asked for this

@Montellese or @mkortstiege for review probably
