### PR TITLE
remove "Settings" context menu button from music and pictures views

### DIFF
--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -905,7 +905,6 @@ void CGUIWindowMusicBase::GetNonContextButtons(CContextButtons &buttons)
     buttons.Add(CONTEXT_BUTTON_GOTO_ROOT, 20128);
   if (ActiveAE::CActiveAEDSP::GetInstance().IsProcessing())
     buttons.Add(CONTEXT_BUTTON_ACTIVE_ADSP_SETTINGS, 15047);
-  buttons.Add(CONTEXT_BUTTON_SETTINGS, 5);
 }
 
 bool CGUIWindowMusicBase::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
@@ -986,10 +985,6 @@ bool CGUIWindowMusicBase::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
 
   case CONTEXT_BUTTON_ACTIVE_ADSP_SETTINGS:
     g_windowManager.ActivateWindow(WINDOW_DIALOG_AUDIO_DSP_OSD_SETTINGS);
-    return true;
-
-  case CONTEXT_BUTTON_SETTINGS:
-    g_windowManager.ActivateWindow(WINDOW_SETTINGS_MYMUSIC);
     return true;
 
   case CONTEXT_BUTTON_RIP_CD:

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -500,8 +500,6 @@ void CGUIWindowPictures::GetContextButtons(int itemNumber, CContextButtons &butt
     }
   }
   CGUIMediaWindow::GetContextButtons(itemNumber, buttons);
-  if (item && !item->GetProperty("pluginreplacecontextitems").asBoolean())
-    buttons.Add(CONTEXT_BUTTON_SETTINGS, 5);                  // Settings
 
   CContextMenuManager::GetInstance().AddVisibleItems(item, buttons);
 }
@@ -537,9 +535,6 @@ bool CGUIWindowPictures::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
     return true;
   case CONTEXT_BUTTON_RENAME:
     OnRenameItem(itemNumber);
-    return true;
-  case CONTEXT_BUTTON_SETTINGS:
-    g_windowManager.ActivateWindow(WINDOW_SETTINGS_MYPICTURES);
     return true;
   case CONTEXT_BUTTON_GOTO_ROOT:
     Update("");


### PR DESCRIPTION
As discussed this removes the "Settings" context menu item from music and pictures views because it is really confusing especially on addons which also have an "Add-on settings" context menu item.
