### PR TITLE
[Music]Fix More artists than MBID in song and album

### DIFF
--- a/xbmc/music/Album.cpp
+++ b/xbmc/music/Album.cpp
@@ -54,21 +54,19 @@ CAlbum::CAlbum(const CFileItem& item)
   artist = tag.GetAlbumArtist();
   std::vector<std::string> musicBrainAlbumArtistHints = tag.GetMusicBrainzAlbumArtistHints();
   strArtistDesc = tag.GetAlbumArtistDesc();
-
+  size_t artistsize = (tag.GetMusicBrainzAlbumArtistID().size() > artist.size()) ? tag.GetMusicBrainzAlbumArtistID().size() : artist.size();
   if (!tag.GetMusicBrainzAlbumArtistID().empty())
   { // have musicbrainz artist info, so use it
     for (size_t i = 0; i < tag.GetMusicBrainzAlbumArtistID().size(); i++)
     {
       std::string artistId = tag.GetMusicBrainzAlbumArtistID()[i];
       std::string artistName;
-
       /*
          We try and get the mbrainzid <-> name matching from the hints and match on the same index.
          If not found, we try and use the mbrainz <-> name matching from the artists fields
          If still not found, try and use the same index of the albumartist field.
          If still not found, use the mbrainzid and hope we later on can update that entry
          */
-
       if (i < musicBrainAlbumArtistHints.size())
         artistName = musicBrainAlbumArtistHints[i];
       else if (!tag.GetMusicBrainzArtistID().empty() && !tag.GetArtist().empty())
@@ -91,19 +89,17 @@ CAlbum::CAlbum(const CFileItem& item)
       if (artistName.empty())
         artistName = artistId;
 
-      std::string strJoinPhrase = (i == tag.GetMusicBrainzAlbumArtistID().size()-1) ? "" : g_advancedSettings.m_musicItemSeparator;
+      std::string strJoinPhrase = (i == artistsize - 1) ? "" : g_advancedSettings.m_musicItemSeparator;
       CArtistCredit artistCredit(artistName, tag.GetMusicBrainzAlbumArtistID()[i], strJoinPhrase);
       artistCredits.push_back(artistCredit);
     }
   }
-  else
-  { // no musicbrainz info, so fill in directly
-    for (std::vector<std::string>::const_iterator it = tag.GetAlbumArtist().begin(); it != tag.GetAlbumArtist().end(); ++it)
-    {
-      std::string strJoinPhrase = (it == --tag.GetAlbumArtist().end() ? "" : g_advancedSettings.m_musicItemSeparator);
-      CArtistCredit artistCredit(*it, "", strJoinPhrase);
-      artistCredits.push_back(artistCredit);
-    }
+  //Fill in directly those artists with no matching Musicbrainz ID
+  for (size_t i = artistCredits.size(); i < artist.size(); i++)
+  {
+    std::string strJoinPhrase = (i == artist.size() - 1) ? "" : g_advancedSettings.m_musicItemSeparator;
+    CArtistCredit artistCredit(artist[i], "", strJoinPhrase);
+    artistCredits.push_back(artistCredit);
   }
   iYear = stTime.wYear;
   bCompilation = tag.GetCompilation();

--- a/xbmc/music/Song.cpp
+++ b/xbmc/music/Song.cpp
@@ -36,6 +36,7 @@ CSong::CSong(CFileItem& item)
   artist = tag.GetArtist();
   std::vector<std::string> musicBrainArtistHints = tag.GetMusicBrainzArtistHints();
   strArtistDesc = tag.GetArtistDesc();
+  size_t artistsize = (tag.GetMusicBrainzArtistID().size() > artist.size()) ? tag.GetMusicBrainzArtistID().size() : artist.size();
   if (!tag.GetMusicBrainzArtistID().empty())
   { // have musicbrainz artist info, so use it
     for (size_t i = 0; i < tag.GetMusicBrainzArtistID().size(); i++)
@@ -53,20 +54,19 @@ CSong::CSong(CFileItem& item)
         artistName = (i < artist.size()) ? artist[i] : artist[0];
       if (artistName.empty())
         artistName = artistId;
-      std::string strJoinPhrase = (i == tag.GetMusicBrainzArtistID().size()-1) ? "" : g_advancedSettings.m_musicItemSeparator;
+      std::string strJoinPhrase = (i == artistsize - 1) ? "" : g_advancedSettings.m_musicItemSeparator;
       CArtistCredit artistCredit(artistName, artistId, strJoinPhrase);
       artistCredits.push_back(artistCredit);
     }
   }
-  else
-  { // no musicbrainz info, so fill in directly
-    for (std::vector<std::string>::const_iterator it = tag.GetArtist().begin(); it != tag.GetArtist().end(); ++it)
-    {
-      std::string strJoinPhrase = (it == --tag.GetArtist().end() ? "" : g_advancedSettings.m_musicItemSeparator);
-      CArtistCredit artistCredit(*it, "", strJoinPhrase);
-      artistCredits.push_back(artistCredit);
-    }
+  //Fill in directly those artists with no matching Musicbrainz ID
+  for (size_t i = artistCredits.size(); i < artist.size(); i++)
+  {
+    std::string strJoinPhrase = (i == artist.size() - 1) ? "" : g_advancedSettings.m_musicItemSeparator;
+    CArtistCredit artistCredit(artist[i], "", strJoinPhrase);
+    artistCredits.push_back(artistCredit);
   }
+
   strAlbum = tag.GetAlbum();
   albumArtist = tag.GetAlbumArtist();
   strMusicBrainzTrackID = tag.GetMusicBrainzTrackID();


### PR DESCRIPTION
With #7281 and #7486 handling of ARTISTS tag was added and the issue of having more Musicbrainz ID than artists was resolved. But it did not cover the situation of having more artists than MBID. This PR fixes that omission.

There are some situations where the tagged music files may have more ARTIST or ALBUMARTIST tags than MUSICBRAINZ_ARTISTID or  MUSICBRAINZ_ALBUMARTISTID tags, for example the artist has a non-European name. It those cases it is desireable to have all artist names added to the library even if some do not have MBID.  This is dicussed on the forum http://forum.kodi.tv/showthread.php?tid=235259&pid=2128357#pid2128357 (around post 185)

@evilhamster have a look at this addition to your original changes please.

It is an interim fix, while in the longer term handling artist alias names would remove the user need for more artists than MBID. For simplicity we assume that where there are more artist names than MBID, the extra names are at the end.
