### PR TITLE
[gui] fix missing path param in CGUIDialog::Open() after 447ec5b

### DIFF
--- a/xbmc/dialogs/GUIDialogBusy.cpp
+++ b/xbmc/dialogs/GUIDialogBusy.cpp
@@ -98,13 +98,13 @@ CGUIDialogBusy::~CGUIDialogBusy(void)
 {
 }
 
-void CGUIDialogBusy::Open_Internal()
+void CGUIDialogBusy::Open_Internal(const std::string &param /* = "" */)
 {
   m_bCanceled = false;
   m_bLastVisible = true;
   m_progress = 0;
 
-  CGUIDialog::Open_Internal(false);
+  CGUIDialog::Open_Internal(false, param);
 }
 
 

--- a/xbmc/dialogs/GUIDialogBusy.h
+++ b/xbmc/dialogs/GUIDialogBusy.h
@@ -57,7 +57,7 @@ public:
    */
   static bool WaitOnEvent(CEvent &event, unsigned int timeout = 100, bool allowCancel = true);
 protected:
-  virtual void Open_Internal();
+  virtual void Open_Internal(const std::string &param = "");
   bool m_bCanceled;
   bool m_bLastVisible;
   float m_progress; ///< current progress

--- a/xbmc/dialogs/GUIDialogProgress.cpp
+++ b/xbmc/dialogs/GUIDialogProgress.cpp
@@ -61,7 +61,7 @@ void CGUIDialogProgress::SetCanCancel(bool bCanCancel)
   SetInvalid();
 }
 
-void CGUIDialogProgress::Open()
+void CGUIDialogProgress::Open(const std::string &param /* = "" */)
 {
   CLog::Log(LOGDEBUG, "DialogProgress::Open called %s", m_active ? "(already running)!" : "");
 
@@ -70,7 +70,7 @@ void CGUIDialogProgress::Open()
     ShowProgressBar(false);
   }
   
-  CGUIDialog::Open_Internal(false);
+  CGUIDialog::Open_Internal(false, param);
 
   while (m_active && IsAnimating(ANIM_TYPE_WINDOW_OPEN))
   {

--- a/xbmc/dialogs/GUIDialogProgress.h
+++ b/xbmc/dialogs/GUIDialogProgress.h
@@ -30,7 +30,7 @@ public:
   CGUIDialogProgress(void);
   virtual ~CGUIDialogProgress(void);
 
-  void Open();
+  void Open(const std::string &param = "");
   virtual bool OnMessage(CGUIMessage& message);
   virtual bool OnBack(int actionID);
   virtual void OnWindowLoaded();

--- a/xbmc/guilib/GUIDialog.cpp
+++ b/xbmc/guilib/GUIDialog.cpp
@@ -157,12 +157,12 @@ void CGUIDialog::UpdateVisibility()
   }
 }
 
-void CGUIDialog::Open_Internal()
+void CGUIDialog::Open_Internal(const std::string &param /* = "" */)
 {
-  CGUIDialog::Open_Internal(m_modalityType != DialogModalityType::MODELESS);
+  CGUIDialog::Open_Internal(m_modalityType != DialogModalityType::MODELESS, param);
 }
 
-void CGUIDialog::Open_Internal(bool bProcessRenderLoop)
+void CGUIDialog::Open_Internal(bool bProcessRenderLoop, const std::string &param /* = "" */)
 {
   // Lock graphic context here as it is sometimes called from non rendering threads
   // maybe we should have a critical section per window instead??
@@ -181,6 +181,7 @@ void CGUIDialog::Open_Internal(bool bProcessRenderLoop)
 
   // active this window
   CGUIMessage msg(GUI_MSG_WINDOW_INIT, 0, 0);
+  msg.SetStringParam(param);
   OnMessage(msg);
 
   // process render loop
@@ -198,16 +199,16 @@ void CGUIDialog::Open_Internal(bool bProcessRenderLoop)
   }
 }
 
-void CGUIDialog::Open()
+void CGUIDialog::Open(const std::string &param /* = "" */)
 {
   if (!g_application.IsCurrentThread())
   {
     // make sure graphics lock is not held
     CSingleExit leaveIt(g_graphicsContext);
-    CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_DIALOG_OPEN, -1, -1, static_cast<void*>(this));
+    CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_DIALOG_OPEN, -1, -1, static_cast<void*>(this), param);
   }
   else
-    Open_Internal();
+    Open_Internal(param);
 }
 
 void CGUIDialog::Render()

--- a/xbmc/guilib/GUIDialog.h
+++ b/xbmc/guilib/GUIDialog.h
@@ -51,7 +51,7 @@ public:
   virtual void DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyregions);
   virtual void Render();
 
-  void Open();
+  void Open(const std::string &param = "");
   
   virtual bool OnBack(int actionID);
 
@@ -71,8 +71,8 @@ protected:
   virtual void OnWindowLoaded();
   virtual void UpdateVisibility();
 
-  virtual void Open_Internal();
-  virtual void Open_Internal(bool bProcessRenderLoop);
+  virtual void Open_Internal(const std::string &param = "");
+  virtual void Open_Internal(bool bProcessRenderLoop, const std::string &param = "");
   virtual void OnDeinitWindow(int nextWindowID);
 
   bool m_wasRunning; ///< \brief true if we were running during the last DoProcess()

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -778,7 +778,7 @@ void CGUIWindowManager::ActivateWindow_Internal(int iWindowID, const std::vector
     if (!pNewWindow->IsDialogRunning())
     {
       CSingleExit exitit(g_graphicsContext);
-      ((CGUIDialog *)pNewWindow)->Open();
+      ((CGUIDialog *)pNewWindow)->Open(params.size() > 0 ? params[0] : "");
     }
     return;
   }
@@ -842,12 +842,12 @@ void CGUIWindowManager::OnApplicationMessage(ThreadMessage* pMsg)
   case TMSG_GUI_DIALOG_OPEN:  
   {
     if (pMsg->lpVoid)
-      static_cast<CGUIDialog*>(pMsg->lpVoid)->Open();
+      static_cast<CGUIDialog*>(pMsg->lpVoid)->Open(pMsg->strParam);
     else
     {
       CGUIDialog* pDialog = static_cast<CGUIDialog*>(GetWindow(pMsg->param1));
       if (pDialog)
-        pDialog->Open();
+        pDialog->Open(pMsg->strParam);
     }
   }
   break;


### PR DESCRIPTION
As pointed out by @jmarshallnz (thanks for that :smile:) at https://github.com/xbmc/xbmc/commit/447ec5b191a5bf8228580f0b5bfdcf120757d84c#commitcomment-13699848 this will fix the missing path parameter in `CGUIDialog` if called by `ActivateWindow(dialog_id, /some/path/here)` e.g. for `CGUIDialogSmartPlaylistEditor`.

@mkortstiege mind taking a look.
