### PR TITLE
Fixed crash on scanning incomplete id3v2 tags

### DIFF
--- a/xbmc/music/tags/TagLoaderTagLib.cpp
+++ b/xbmc/music/tags/TagLoaderTagLib.cpp
@@ -25,6 +25,7 @@
 #include <taglib/id3v1tag.h>
 #include <taglib/id3v2tag.h>
 #include <taglib/apetag.h>
+#include <taglib/asftag.h>
 #include <taglib/xiphcomment.h>
 #include <taglib/id3v1genres.h>
 
@@ -76,7 +77,6 @@ CTagLoaderTagLib::CTagLoaderTagLib()
 
 CTagLoaderTagLib::~CTagLoaderTagLib()
 {
-  
 }
 
 static const std::vector<std::string> StringListToVectorString(const StringList& stringList)
@@ -92,10 +92,691 @@ bool CTagLoaderTagLib::Load(const std::string& strFileName, MUSIC_INFO::CMusicIn
   return Load(strFileName, tag, "", art);
 }
 
+
+template<>
+bool CTagLoaderTagLib::ParseTag(ASF::Tag *asf, EmbeddedArt *art, CMusicInfoTag& tag)
+{
+  if (!asf)
+    return false;
+
+  ReplayGain replayGainInfo;
+  tag.SetTitle(asf->title().to8Bit(true));
+  const ASF::AttributeListMap& attributeListMap = asf->attributeListMap();
+  for (ASF::AttributeListMap::ConstIterator it = attributeListMap.begin(); it != attributeListMap.end(); ++it)
+  {
+    if (it->first == "Author")
+      SetArtist(tag, GetASFStringList(it->second));
+    else if (it->first == "WM/AlbumArtist")
+      SetAlbumArtist(tag, GetASFStringList(it->second));
+    else if (it->first == "WM/AlbumTitle")
+      tag.SetAlbum(it->second.front().toString().to8Bit(true));
+    else if (it->first == "WM/TrackNumber" ||
+             it->first == "WM/Track")
+    {
+      if (it->second.front().type() == ASF::Attribute::DWordType)
+        tag.SetTrackNumber(it->second.front().toUInt());
+      else
+        tag.SetTrackNumber(atoi(it->second.front().toString().toCString(true)));
+    }
+    else if (it->first == "WM/PartOfSet")
+      tag.SetDiscNumber(atoi(it->second.front().toString().toCString(true)));
+    else if (it->first == "WM/Genre")
+      SetGenre(tag, GetASFStringList(it->second));
+    else if (it->first == "WM/Mood")
+      tag.SetMood(it->second.front().toString().to8Bit(true));
+    else if (it->first == "WM/AlbumArtistSortOrder")
+    {} // Known unsupported, supress warnings
+    else if (it->first == "WM/ArtistSortOrder")
+    {} // Known unsupported, supress warnings
+    else if (it->first == "WM/Script")
+    {} // Known unsupported, supress warnings
+    else if (it->first == "WM/Year")
+      tag.SetYear(atoi(it->second.front().toString().toCString(true)));
+    else if (it->first == "MusicBrainz/Artist Id")
+      tag.SetMusicBrainzArtistID(SplitMBID(GetASFStringList(it->second)));
+    else if (it->first == "MusicBrainz/Album Id")
+      tag.SetMusicBrainzAlbumID(it->second.front().toString().to8Bit(true));
+    else if (it->first == "MusicBrainz/Album Artist")
+      SetAlbumArtist(tag, GetASFStringList(it->second));
+    else if (it->first == "MusicBrainz/Album Artist Id")
+      tag.SetMusicBrainzAlbumArtistID(SplitMBID(GetASFStringList(it->second)));
+    else if (it->first == "MusicBrainz/Track Id")
+      tag.SetMusicBrainzTrackID(it->second.front().toString().to8Bit(true));
+    else if (it->first == "MusicBrainz/Album Status")
+    {}
+    else if (it->first == "MusicBrainz/Album Type")
+    {}
+    else if (it->first == "MusicIP/PUID")
+    {}
+    else if (it->first == "replaygain_track_gain")
+      replayGainInfo.ParseGain(ReplayGain::TRACK, it->second.front().toString().toCString(true));
+    else if (it->first == "replaygain_album_gain")
+      replayGainInfo.ParseGain(ReplayGain::ALBUM, it->second.front().toString().toCString(true));
+    else if (it->first == "replaygain_track_peak")
+      replayGainInfo.ParsePeak(ReplayGain::TRACK, it->second.front().toString().toCString(true));
+    else if (it->first == "replaygain_album_peak")
+      replayGainInfo.ParsePeak(ReplayGain::ALBUM, it->second.front().toString().toCString(true));
+    else if (it->first == "WM/Picture")
+    { // picture
+      ASF::Picture pic = it->second.front().toPicture();
+      tag.SetCoverArtInfo(pic.picture().size(), pic.mimeType().toCString());
+      if (art)
+        art->set((const uint8_t *)pic.picture().data(), pic.picture().size(), pic.mimeType().toCString());
+    }
+    else if (g_advancedSettings.m_logLevel == LOG_LEVEL_MAX)
+      CLog::Log(LOGDEBUG, "unrecognized ASF tag name: %s", it->first.toCString(true));
+  }
+  // artist may be specified in the ContentDescription block rather than using the 'Author' attribute.
+  if (tag.GetArtist().empty())
+    tag.SetArtist(asf->artist().toCString(true));
+
+  tag.SetReplayGain(replayGainInfo);
+  tag.SetLoaded(true);
+  return true;
+}
+
+char CTagLoaderTagLib::POPMtoXBMC(int popm)
+{
+  // Ratings:
+  // FROM: http://thiagoarrais.com/repos/banshee/src/Core/Banshee.Core/Banshee.Streaming/StreamRatingTagger.cs
+  // The following schemes are used by the other POPM-compatible players:
+  // WMP/Vista: "Windows Media Player 9 Series" ratings:
+  //   1 = 1, 2 = 64, 3=128, 4=196 (not 192), 5=255
+  // MediaMonkey: "no@email" ratings:
+  //   0.5=26, 1=51, 1.5=76, 2=102, 2.5=128,
+  //   3=153, 3.5=178, 4=204, 4.5=230, 5=255
+  // Quod Libet: "quodlibet@lists.sacredchao.net" ratings
+  //   (but that email can be changed):
+  //   arbitrary scale from 0-255
+  if (popm == 0) return '0';
+  if (popm < 0x40) return '1';
+  if (popm < 0x80) return '2';
+  if (popm < 0xc0) return '3';
+  if (popm < 0xff) return '4';
+  return '5';
+}
+
+template<>
+bool CTagLoaderTagLib::ParseTag(ID3v1::Tag *id3v1, EmbeddedArt *art, CMusicInfoTag& tag)
+{
+  if (!id3v1) return false;
+  tag.SetTitle(id3v1->title().to8Bit(true));
+  tag.SetArtist(id3v1->artist().to8Bit(true));
+  tag.SetAlbum(id3v1->album().to8Bit(true));
+  tag.SetComment(id3v1->comment().to8Bit(true));
+  tag.SetGenre(id3v1->genre().to8Bit(true));
+  tag.SetYear(id3v1->year());
+  tag.SetTrackNumber(id3v1->track());
+  return true;
+}
+
+template<>
+bool CTagLoaderTagLib::ParseTag(ID3v2::Tag *id3v2, MUSIC_INFO::EmbeddedArt *art, MUSIC_INFO::CMusicInfoTag& tag)
+{
+  if (!id3v2) return false;
+  ReplayGain replayGainInfo;
+
+  ID3v2::AttachedPictureFrame *pictures[3] = {};
+  const ID3v2::FrameListMap& frameListMap = id3v2->frameListMap();
+  for (ID3v2::FrameListMap::ConstIterator it = frameListMap.begin(); it != frameListMap.end(); ++it)
+  {
+    if      (it->first == "TPE1")   SetArtist(tag, GetID3v2StringList(it->second));
+    else if (it->first == "TALB")   tag.SetAlbum(it->second.front()->toString().to8Bit(true));
+    else if (it->first == "TPE2")   SetAlbumArtist(tag, GetID3v2StringList(it->second));
+    else if (it->first == "TIT2")   tag.SetTitle(it->second.front()->toString().to8Bit(true));
+    else if (it->first == "TCON")   SetGenre(tag, GetID3v2StringList(it->second));
+    else if (it->first == "TRCK")   tag.SetTrackNumber(strtol(it->second.front()->toString().toCString(true), NULL, 10));
+    else if (it->first == "TPOS")   tag.SetDiscNumber(strtol(it->second.front()->toString().toCString(true), NULL, 10));
+    else if (it->first == "TYER")   tag.SetYear(strtol(it->second.front()->toString().toCString(true), NULL, 10));
+    else if (it->first == "TCMP")   tag.SetCompilation((strtol(it->second.front()->toString().toCString(true), NULL, 10) == 0) ? false : true);
+    else if (it->first == "TENC")   {} // EncodedBy
+    else if (it->first == "TCOP")   {} // Copyright message
+    else if (it->first == "TDRC")   tag.SetYear(strtol(it->second.front()->toString().toCString(true), NULL, 10));
+    else if (it->first == "TDRL")   tag.SetYear(strtol(it->second.front()->toString().toCString(true), NULL, 10));
+    else if (it->first == "TDTG")   {} // Tagging time
+    else if (it->first == "TLAN")   {} // Languages
+    else if (it->first == "TMOO")   tag.SetMood(it->second.front()->toString().to8Bit(true));
+    else if (it->first == "USLT")
+      // Loop through any lyrics frames. Could there be multiple frames, how to choose?
+      for (ID3v2::FrameList::ConstIterator lt = it->second.begin(); lt != it->second.end(); ++lt)
+      {
+        ID3v2::UnsynchronizedLyricsFrame *lyricsFrame = dynamic_cast<ID3v2::UnsynchronizedLyricsFrame *> (*lt);
+        if (lyricsFrame)
+          tag.SetLyrics(lyricsFrame->text().to8Bit(true));
+      }
+    else if (it->first == "COMM")
+      // Loop through and look for the main (no description) comment
+      for (ID3v2::FrameList::ConstIterator ct = it->second.begin(); ct != it->second.end(); ++ct)
+      {
+        ID3v2::CommentsFrame *commentsFrame = dynamic_cast<ID3v2::CommentsFrame *> (*ct);
+        if (commentsFrame && commentsFrame->description().isEmpty())
+          tag.SetComment(commentsFrame->text().to8Bit(true));
+      }
+    else if (it->first == "TXXX")
+      // Loop through and process the UserTextIdentificationFrames
+      for (ID3v2::FrameList::ConstIterator ut = it->second.begin(); ut != it->second.end(); ++ut)
+      {
+        ID3v2::UserTextIdentificationFrame *frame = dynamic_cast<ID3v2::UserTextIdentificationFrame *> (*ut);
+        if (!frame) continue;
+
+        // First field is the same as the description
+        StringList stringList = frame->fieldList();
+        stringList.erase(stringList.begin());
+        String desc = frame->description().upper();
+        if      (desc == "MUSICBRAINZ ARTIST ID")
+          tag.SetMusicBrainzArtistID(SplitMBID(StringListToVectorString(stringList)));
+        else if (desc == "MUSICBRAINZ ALBUM ID")
+          tag.SetMusicBrainzAlbumID(stringList.front().to8Bit(true));
+        else if (desc == "MUSICBRAINZ ALBUM ARTIST ID")
+          tag.SetMusicBrainzAlbumArtistID(SplitMBID(StringListToVectorString(stringList)));
+        else if (desc == "MUSICBRAINZ ALBUM ARTIST")
+          SetAlbumArtist(tag, StringListToVectorString(stringList));
+        else if (desc == "REPLAYGAIN_TRACK_GAIN")
+          replayGainInfo.ParseGain(ReplayGain::TRACK, stringList.front().toCString(true));
+        else if (desc == "REPLAYGAIN_ALBUM_GAIN")
+          replayGainInfo.ParseGain(ReplayGain::ALBUM, stringList.front().toCString(true));
+        else if (desc == "REPLAYGAIN_TRACK_PEAK")
+          replayGainInfo.ParsePeak(ReplayGain::TRACK, stringList.front().toCString(true));
+        else if (desc == "REPLAYGAIN_ALBUM_PEAK")
+          replayGainInfo.ParsePeak(ReplayGain::ALBUM, stringList.front().toCString(true));
+        else if (desc == "ALBUMARTIST" || desc == "ALBUM ARTIST")
+          SetAlbumArtist(tag, StringListToVectorString(stringList));
+        else if (desc == "ARTISTS")
+        {
+          if (id3v2->header()->majorVersion() < 4)
+            tag.SetMusicBrainzArtistHints(StringListToVectorString(TagLib::StringList::split(stringList.front(), TagLib::String("/"))));
+          else
+            tag.SetMusicBrainzArtistHints(StringListToVectorString(stringList));
+        }
+        else if (desc == "ALBUMARTISTS" || desc == "ALBUM ARTISTS")
+        {
+          if (id3v2->header()->majorVersion() < 4)
+            tag.SetMusicBrainzAlbumArtistHints(StringListToVectorString(TagLib::StringList::split(stringList.front(), TagLib::String("/"))));
+          else
+            tag.SetMusicBrainzAlbumArtistHints(StringListToVectorString(stringList));
+        }
+        else if (desc == "MOOD")
+          tag.SetMood(stringList.front().to8Bit(true));
+        else if (g_advancedSettings.m_logLevel == LOG_LEVEL_MAX)
+          CLog::Log(LOGDEBUG, "unrecognized user text tag detected: TXXX:%s", frame->description().toCString(true));
+      }
+    else if (it->first == "UFID")
+      // Loop through any UFID frames and set them
+      for (ID3v2::FrameList::ConstIterator ut = it->second.begin(); ut != it->second.end(); ++ut)
+      {
+        ID3v2::UniqueFileIdentifierFrame *ufid = reinterpret_cast<ID3v2::UniqueFileIdentifierFrame*> (*ut);
+        if (ufid->owner() == "http://musicbrainz.org")
+        {
+          // MusicBrainz pads with a \0, but the spec requires binary, be cautious
+          char cUfid[64];
+          int max_size = std::min((int)ufid->identifier().size(), 63);
+          strncpy(cUfid, ufid->identifier().data(), max_size);
+          cUfid[max_size] = '\0';
+          tag.SetMusicBrainzTrackID(cUfid);
+        }
+      }
+    else if (it->first == "APIC")
+      // Loop through all pictures and store the frame pointers for the picture types we want
+      for (ID3v2::FrameList::ConstIterator pi = it->second.begin(); pi != it->second.end(); ++pi)
+      {
+        ID3v2::AttachedPictureFrame *pictureFrame = dynamic_cast<ID3v2::AttachedPictureFrame *> (*pi);
+        if (!pictureFrame) continue;
+
+        if      (pictureFrame->type() == ID3v2::AttachedPictureFrame::FrontCover) pictures[0] = pictureFrame;
+        else if (pictureFrame->type() == ID3v2::AttachedPictureFrame::Other)      pictures[1] = pictureFrame;
+        else if (pi == it->second.begin())                                        pictures[2] = pictureFrame;
+      }
+    else if (it->first == "POPM")
+      // Loop through and process ratings
+      for (ID3v2::FrameList::ConstIterator ct = it->second.begin(); ct != it->second.end(); ++ct)
+      {
+        ID3v2::PopularimeterFrame *popFrame = dynamic_cast<ID3v2::PopularimeterFrame *> (*ct);
+        if (!popFrame) continue;
+
+        // @xbmc.org ratings trump others (of course)
+        if      (popFrame->email() == "ratings@xbmc.org")
+          tag.SetUserrating(popFrame->rating() / 51 + '0');
+        else if (tag.GetUserrating() == '0')
+        {
+          if (popFrame->email() != "Windows Media Player 9 Series" &&
+              popFrame->email() != "Banshee" &&
+              popFrame->email() != "no@email" &&
+              popFrame->email() != "quodlibet@lists.sacredchao.net" &&
+              popFrame->email() != "rating@winamp.com")
+            CLog::Log(LOGDEBUG, "unrecognized ratings schema detected: %s", popFrame->email().toCString(true));
+          tag.SetUserrating(POPMtoXBMC(popFrame->rating()));
+        }
+      }
+    else if (g_advancedSettings.m_logLevel == LOG_LEVEL_MAX)
+      CLog::Log(LOGDEBUG, "unrecognized ID3 frame detected: %c%c%c%c", it->first[0], it->first[1], it->first[2], it->first[3]);
+  } // for
+
+  // Process the extracted picture frames; 0 = CoverArt, 1 = Other, 2 = First Found picture
+  for (int i = 0; i < 3; ++i)
+    if (pictures[i])
+    {
+      std::string  mime =            pictures[i]->mimeType().to8Bit(true);
+      TagLib::uint size =            pictures[i]->picture().size();
+      tag.SetCoverArtInfo(size, mime);
+      if (art)
+        art->set((const uint8_t*)pictures[i]->picture().data(), size, mime);
+
+      // Stop after we find the first picture for now.
+      break;
+    }
+
+  tag.SetReplayGain(replayGainInfo);
+  return true;
+}
+
+template<>
+bool CTagLoaderTagLib::ParseTag(APE::Tag *ape, EmbeddedArt *art, CMusicInfoTag& tag)
+{
+  if (!ape)
+    return false;
+
+  ReplayGain replayGainInfo;
+  const APE::ItemListMap itemListMap = ape->itemListMap();
+  for (APE::ItemListMap::ConstIterator it = itemListMap.begin(); it != itemListMap.end(); ++it)
+  {
+    if (it->first == "ARTIST")
+      SetArtist(tag, StringListToVectorString(it->second.toStringList()));
+    else if (it->first == "ARTISTS")
+      tag.SetMusicBrainzArtistHints(StringListToVectorString(it->second.toStringList()));
+    else if (it->first == "ALBUMARTIST" || it->first == "ALBUM ARTIST")
+      SetAlbumArtist(tag, StringListToVectorString(it->second.toStringList()));
+    else if (it->first == "ALBUMARTISTS" || it->first == "ALBUM ARTISTS")
+      tag.SetMusicBrainzAlbumArtistHints(StringListToVectorString(it->second.toStringList()));
+    else if (it->first == "ALBUM")
+      tag.SetAlbum(it->second.toString().to8Bit(true));
+    else if (it->first == "TITLE")
+      tag.SetTitle(it->second.toString().to8Bit(true));
+    else if (it->first == "TRACKNUMBER" || it->first == "TRACK")
+      tag.SetTrackNumber(it->second.toString().toInt());
+    else if (it->first == "DISCNUMBER" || it->first == "DISC")
+      tag.SetDiscNumber(it->second.toString().toInt());
+    else if (it->first == "YEAR")
+      tag.SetYear(it->second.toString().toInt());
+    else if (it->first == "GENRE")
+      SetGenre(tag, StringListToVectorString(it->second.toStringList()));
+    else if (it->first == "COMMENT")
+      tag.SetComment(it->second.toString().to8Bit(true));
+    else if (it->first == "CUESHEET")
+      tag.SetCueSheet(it->second.toString().to8Bit(true));
+    else if (it->first == "ENCODEDBY")
+    {}
+    else if (it->first == "COMPILATION")
+      tag.SetCompilation(it->second.toString().toInt() == 1);
+    else if (it->first == "LYRICS")
+      tag.SetLyrics(it->second.toString().to8Bit(true));
+    else if (it->first == "REPLAYGAIN_TRACK_GAIN")
+      replayGainInfo.ParseGain(ReplayGain::TRACK, it->second.toString().toCString(true));
+    else if (it->first == "REPLAYGAIN_ALBUM_GAIN")
+      replayGainInfo.ParseGain(ReplayGain::ALBUM, it->second.toString().toCString(true));
+    else if (it->first == "REPLAYGAIN_TRACK_PEAK")
+      replayGainInfo.ParsePeak(ReplayGain::TRACK, it->second.toString().toCString(true));
+    else if (it->first == "REPLAYGAIN_ALBUM_PEAK")
+      replayGainInfo.ParsePeak(ReplayGain::ALBUM, it->second.toString().toCString(true));
+    else if (it->first == "MUSICBRAINZ_ARTISTID")
+      tag.SetMusicBrainzArtistID(SplitMBID(StringListToVectorString(it->second.toStringList())));
+    else if (it->first == "MUSICBRAINZ_ALBUMARTISTID")
+      tag.SetMusicBrainzAlbumArtistID(SplitMBID(StringListToVectorString(it->second.toStringList())));
+    else if (it->first == "MUSICBRAINZ_ALBUMARTIST")
+      SetAlbumArtist(tag, StringListToVectorString(it->second.toStringList()));
+    else if (it->first == "MUSICBRAINZ_ALBUMID")
+      tag.SetMusicBrainzAlbumID(it->second.toString().to8Bit(true));
+    else if (it->first == "MUSICBRAINZ_TRACKID")
+      tag.SetMusicBrainzTrackID(it->second.toString().to8Bit(true));
+    else if (g_advancedSettings.m_logLevel == LOG_LEVEL_MAX)
+      CLog::Log(LOGDEBUG, "unrecognized APE tag: %s", it->first.toCString(true));
+  }
+
+  tag.SetReplayGain(replayGainInfo);
+  return true;
+}
+
+template<>
+bool CTagLoaderTagLib::ParseTag(Ogg::XiphComment *xiph, EmbeddedArt *art, CMusicInfoTag& tag)
+{
+  if (!xiph)
+    return false;
+
+  FLAC::Picture pictures[3];
+  ReplayGain replayGainInfo;
+
+  const Ogg::FieldListMap& fieldListMap = xiph->fieldListMap();
+  for (Ogg::FieldListMap::ConstIterator it = fieldListMap.begin(); it != fieldListMap.end(); ++it)
+  {
+    if (it->first == "ARTIST")
+      SetArtist(tag, StringListToVectorString(it->second));
+    else if (it->first == "ARTISTS")
+      tag.SetMusicBrainzArtistHints(StringListToVectorString(it->second));
+    else if (it->first == "ALBUMARTIST" || it->first == "ALBUM ARTIST")
+      SetAlbumArtist(tag, StringListToVectorString(it->second));
+    else if (it->first == "ALBUMARTISTS" || it->first == "ALBUM ARTISTS")
+      tag.SetMusicBrainzAlbumArtistHints(StringListToVectorString(it->second));
+    else if (it->first == "ALBUM")
+      tag.SetAlbum(it->second.front().to8Bit(true));
+    else if (it->first == "TITLE")
+      tag.SetTitle(it->second.front().to8Bit(true));
+    else if (it->first == "TRACKNUMBER")
+      tag.SetTrackNumber(it->second.front().toInt());
+    else if (it->first == "DISCNUMBER")
+      tag.SetDiscNumber(it->second.front().toInt());
+    else if (it->first == "YEAR")
+      tag.SetYear(it->second.front().toInt());
+    else if (it->first == "DATE")
+      tag.SetYear(it->second.front().toInt());
+    else if (it->first == "GENRE")
+      SetGenre(tag, StringListToVectorString(it->second));
+    else if (it->first == "COMMENT")
+      tag.SetComment(it->second.front().to8Bit(true));
+    else if (it->first == "CUESHEET")
+      tag.SetCueSheet(it->second.front().to8Bit(true));
+    else if (it->first == "ENCODEDBY")
+    {}
+    else if (it->first == "ENSEMBLE")
+    {}
+    else if (it->first == "COMPILATION")
+      tag.SetCompilation(it->second.front().toInt() == 1);
+    else if (it->first == "LYRICS")
+      tag.SetLyrics(it->second.front().to8Bit(true));
+    else if (it->first == "REPLAYGAIN_TRACK_GAIN")
+      replayGainInfo.ParseGain(ReplayGain::TRACK, it->second.front().toCString(true));
+    else if (it->first == "REPLAYGAIN_ALBUM_GAIN")
+      replayGainInfo.ParseGain(ReplayGain::ALBUM, it->second.front().toCString(true));
+    else if (it->first == "REPLAYGAIN_TRACK_PEAK")
+      replayGainInfo.ParsePeak(ReplayGain::TRACK, it->second.front().toCString(true));
+    else if (it->first == "REPLAYGAIN_ALBUM_PEAK")
+      replayGainInfo.ParsePeak(ReplayGain::ALBUM, it->second.front().toCString(true));
+    else if (it->first == "MUSICBRAINZ_ARTISTID")
+      tag.SetMusicBrainzArtistID(SplitMBID(StringListToVectorString(it->second)));
+    else if (it->first == "MUSICBRAINZ_ALBUMARTISTID")
+      tag.SetMusicBrainzAlbumArtistID(SplitMBID(StringListToVectorString(it->second)));
+    else if (it->first == "MUSICBRAINZ_ALBUMARTIST")
+      SetAlbumArtist(tag, StringListToVectorString(it->second));
+    else if (it->first == "MUSICBRAINZ_ALBUMID")
+      tag.SetMusicBrainzAlbumID(it->second.front().to8Bit(true));
+    else if (it->first == "MUSICBRAINZ_TRACKID")
+      tag.SetMusicBrainzTrackID(it->second.front().to8Bit(true));
+    else if (it->first == "RATING")
+    {
+      // Vorbis ratings are a mess because the standard forgot to mention anything about them.
+      // If you want to see how emotive the issue is and the varying standards, check here:
+      // http://forums.winamp.com/showthread.php?t=324512
+      // The most common standard in that thread seems to be a 0-100 scale for 1-5 stars.
+      // So, that's what we'll support for now.
+      int iRating = it->second.front().toInt();
+      if (iRating > 0 && iRating <= 100)
+        tag.SetUserrating((iRating / 20) + '0');
+    }
+    else if (it->first == "METADATA_BLOCK_PICTURE")
+    {
+      const char* b64 = it->second.front().toCString();
+      std::string decoded_block = Base64::Decode(b64, it->second.front().size());
+      ByteVector bv(decoded_block.data(), decoded_block.size());
+      TagLib::FLAC::Picture* pictureFrame = new TagLib::FLAC::Picture(bv);
+
+      if      (pictureFrame->type() == FLAC::Picture::FrontCover) pictures[0].parse(bv);
+      else if (pictureFrame->type() == FLAC::Picture::Other)      pictures[1].parse(bv);
+
+      delete pictureFrame;
+    }
+    else if (it->first == "COVERART")
+    {
+      const char* b64 = it->second.front().toCString();
+      std::string decoded_block = Base64::Decode(b64, it->second.front().size());
+      ByteVector bv(decoded_block.data(), decoded_block.size());
+      pictures[2].setData(bv);
+      // Assume jpeg
+      if (pictures[2].mimeType().isEmpty())
+        pictures[2].setMimeType("image/jpeg");
+    }
+    else if (it->first == "COVERARTMIME")
+    {
+      pictures[2].setMimeType(it->second.front());
+    }
+    else if (g_advancedSettings.m_logLevel == LOG_LEVEL_MAX)
+      CLog::Log(LOGDEBUG, "unrecognized XipComment name: %s", it->first.toCString(true));
+  }
+
+  // Process the extracted picture frames; 0 = CoverArt, 1 = Other, 2 = COVERART/COVERARTMIME
+  for (int i = 0; i < 3; ++i)
+    if (pictures[i].data().size())
+    {
+      std::string mime = pictures[i].mimeType().toCString();
+      if (mime.compare(0, 6, "image/") != 0)
+        continue;
+      TagLib::uint size =            pictures[i].data().size();
+      tag.SetCoverArtInfo(size, mime);
+      if (art)
+        art->set((const uint8_t*)pictures[i].data().data(), size, mime);
+
+      break;
+    }
+
+  tag.SetReplayGain(replayGainInfo);
+  return true;
+}
+
+template<>
+bool CTagLoaderTagLib::ParseTag(MP4::Tag *mp4, EmbeddedArt *art, CMusicInfoTag& tag)
+{
+  if (!mp4)
+    return false;
+
+  ReplayGain replayGainInfo;
+  MP4::ItemListMap& itemListMap = mp4->itemListMap();
+  for (MP4::ItemListMap::ConstIterator it = itemListMap.begin(); it != itemListMap.end(); ++it)
+  {
+    if (it->first == "\251nam")
+      tag.SetTitle(it->second.toStringList().front().to8Bit(true));
+    else if (it->first == "\251ART")
+      SetArtist(tag, StringListToVectorString(it->second.toStringList()));
+    else if (it->first == "----:com.apple.iTunes:ARTISTS")
+      tag.SetMusicBrainzArtistHints(StringListToVectorString(it->second.toStringList()));
+    else if (it->first == "\251alb")
+      tag.SetAlbum(it->second.toStringList().front().to8Bit(true));
+    else if (it->first == "aART")
+      SetAlbumArtist(tag, StringListToVectorString(it->second.toStringList()));
+    else if (it->first == "----:com.apple.iTunes:ALBUMARTISTS")
+      tag.SetMusicBrainzAlbumArtistHints(StringListToVectorString(it->second.toStringList()));
+    else if (it->first == "\251gen")
+      SetGenre(tag, StringListToVectorString(it->second.toStringList()));
+    else if (it->first == "\251cmt")
+      tag.SetComment(it->second.toStringList().front().to8Bit(true));
+    else if (it->first == "cpil")
+      tag.SetCompilation(it->second.toBool());
+    else if (it->first == "trkn")
+      tag.SetTrackNumber(it->second.toIntPair().first);
+    else if (it->first == "disk")
+      tag.SetDiscNumber(it->second.toIntPair().first);
+    else if (it->first == "\251day")
+      tag.SetYear(it->second.toStringList().front().toInt());
+    else if (it->first == "----:com.apple.iTunes:replaygain_track_gain")
+      replayGainInfo.ParseGain(ReplayGain::TRACK, it->second.toStringList().front().toCString());
+    else if (it->first == "----:com.apple.iTunes:replaygain_album_gain")
+      replayGainInfo.ParseGain(ReplayGain::ALBUM, it->second.toStringList().front().toCString());
+    else if (it->first == "----:com.apple.iTunes:replaygain_track_peak")
+      replayGainInfo.ParsePeak(ReplayGain::TRACK, it->second.toStringList().front().toCString());
+    else if (it->first == "----:com.apple.iTunes:replaygain_album_peak")
+      replayGainInfo.ParsePeak(ReplayGain::ALBUM, it->second.toStringList().front().toCString());
+    else if (it->first == "----:com.apple.iTunes:MusicBrainz Artist Id")
+      tag.SetMusicBrainzArtistID(SplitMBID(StringListToVectorString(it->second.toStringList())));
+    else if (it->first == "----:com.apple.iTunes:MusicBrainz Album Artist Id")
+      tag.SetMusicBrainzAlbumArtistID(SplitMBID(StringListToVectorString(it->second.toStringList())));
+    else if (it->first == "----:com.apple.iTunes:MusicBrainz Album Artist")
+      SetAlbumArtist(tag, StringListToVectorString(it->second.toStringList()));
+    else if (it->first == "----:com.apple.iTunes:MusicBrainz Album Id")
+      tag.SetMusicBrainzAlbumID(it->second.toStringList().front().to8Bit(true));
+    else if (it->first == "----:com.apple.iTunes:MusicBrainz Track Id")
+      tag.SetMusicBrainzTrackID(it->second.toStringList().front().to8Bit(true));
+    else if (it->first == "covr")
+    {
+      MP4::CoverArtList coverArtList = it->second.toCoverArtList();
+      for (MP4::CoverArtList::ConstIterator pt = coverArtList.begin(); pt != coverArtList.end(); ++pt)
+      {
+        std::string mime;
+        switch (pt->format())
+        {
+          case MP4::CoverArt::PNG:
+            mime = "image/png";
+            break;
+          case MP4::CoverArt::JPEG:
+            mime = "image/jpeg";
+            break;
+          default:
+            break;
+        }
+        if (mime.empty())
+          continue;
+        tag.SetCoverArtInfo(pt->data().size(), mime);
+        if (art)
+          art->set((const uint8_t *)pt->data().data(), pt->data().size(), mime);
+        break; // one is enough
+      }
+    }
+  }
+
+  if (mp4->comment() != String::null)
+    tag.SetComment(mp4->comment().toCString(true));
+
+  tag.SetReplayGain(replayGainInfo);
+  return true;
+}
+
+template<>
+bool CTagLoaderTagLib::ParseTag(Tag *generic, EmbeddedArt *art, CMusicInfoTag& tag)
+{
+  if (!generic)
+    return false;
+
+  PropertyMap properties = generic->properties();
+  for (PropertyMap::ConstIterator it = properties.begin(); it != properties.end(); ++it)
+  {
+    if (it->first == "ARTIST")
+      SetArtist(tag, StringListToVectorString(it->second));
+    else if (it->first == "ALBUM")
+      tag.SetAlbum(it->second.front().to8Bit(true));
+    else if (it->first == "TITLE")
+      tag.SetTitle(it->second.front().to8Bit(true));
+    else if (it->first == "TRACKNUMBER")
+      tag.SetTrackNumber(it->second.front().toInt());
+    else if (it->first == "YEAR")
+      tag.SetYear(it->second.front().toInt());
+    else if (it->first == "GENRE")
+      SetGenre(tag, StringListToVectorString(it->second));
+    else if (it->first == "COMMENT")
+      tag.SetComment(it->second.front().to8Bit(true));
+  }
+
+  return true;
+}
+
+void CTagLoaderTagLib::SetFlacArt(FLAC::File *flacFile, EmbeddedArt *art, CMusicInfoTag &tag)
+{
+  FLAC::Picture *cover[2] = {};
+  List<FLAC::Picture *> pictures = flacFile->pictureList();
+  for (List<FLAC::Picture *>::ConstIterator i = pictures.begin(); i != pictures.end(); ++i)
+  {
+    FLAC::Picture *picture = *i;
+    if (picture->type() == FLAC::Picture::FrontCover)
+      cover[0] = picture;
+    else // anything else is taken as second priority
+      cover[1] = picture;
+  }
+  for (unsigned int i = 0; i < 2; i++)
+  {
+    if (cover[i])
+    {
+      tag.SetCoverArtInfo(cover[i]->data().size(), cover[i]->mimeType().to8Bit(true));
+      if (art)
+        art->set((const uint8_t*)cover[i]->data().data(), cover[i]->data().size(), cover[i]->mimeType().to8Bit(true));
+      return; // one is enough
+    }
+  }
+}
+
+const std::vector<std::string> CTagLoaderTagLib::GetASFStringList(const List<ASF::Attribute>& list)
+{
+  std::vector<std::string> values;
+  for (List<ASF::Attribute>::ConstIterator at = list.begin(); at != list.end(); ++at)
+    values.push_back(at->toString().to8Bit(true));
+  return values;
+}
+
+const std::vector<std::string> CTagLoaderTagLib::GetID3v2StringList(const ID3v2::FrameList& frameList)
+{
+  const ID3v2::TextIdentificationFrame *frame = dynamic_cast<ID3v2::TextIdentificationFrame *>(frameList.front());
+  if (frame)
+    return StringListToVectorString(frame->fieldList());
+  return std::vector<std::string>();
+}
+
+
+void CTagLoaderTagLib::SetArtist(CMusicInfoTag &tag, const std::vector<std::string> &values)
+{
+  if (values.size() == 1)
+    tag.SetArtist(values[0]);
+  else
+    tag.SetArtist(values);
+}
+
+const std::vector<std::string> CTagLoaderTagLib::SplitMBID(const std::vector<std::string> &values)
+{
+  if (values.empty() || values.size() > 1)
+    return values;
+
+  // Picard, and other taggers use a heap of different separators.  We use a regexp to detect
+  // MBIDs to make sure we hit them all...
+  std::vector<std::string> ret;
+  std::string value = values[0];
+  StringUtils::ToLower(value);
+  CRegExp reg;
+  if (reg.RegComp("([[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{12})"))
+  {
+    int pos = -1;
+    while ((pos = reg.RegFind(value, pos+1)) > -1)
+      ret.push_back(reg.GetMatch(1));
+  }
+  return ret;
+}
+
+void CTagLoaderTagLib::SetAlbumArtist(CMusicInfoTag &tag, const std::vector<std::string> &values)
+{
+  if (values.size() == 1)
+    tag.SetAlbumArtist(values[0]);
+  else
+    tag.SetAlbumArtist(values);
+}
+
+void CTagLoaderTagLib::SetGenre(CMusicInfoTag &tag, const std::vector<std::string> &values)
+{
+  /*
+   TagLib doesn't resolve ID3v1 genre numbers in the case were only
+   a number is specified, thus this workaround.
+   */
+  std::vector<std::string> genres;
+  for (std::vector<std::string>::const_iterator i = values.begin(); i != values.end(); ++i)
+  {
+    std::string genre = *i;
+    if (StringUtils::IsNaturalNumber(genre))
+    {
+      int number = strtol(i->c_str(), NULL, 10);
+      if (number >= 0 && number < 256)
+        genre = ID3v1::genre(number).to8Bit(true);
+    }
+    genres.push_back(genre);
+  }
+  if (genres.size() == 1)
+    tag.SetGenre(genres[0]);
+  else
+    tag.SetGenre(genres);
+}
+
 bool CTagLoaderTagLib::Load(const std::string& strFileName, CMusicInfoTag& tag, const std::string& fallbackFileExtension, MUSIC_INFO::EmbeddedArt *art /* = NULL */)
-{  
+{
   std::string strExtension = URIUtils::GetExtension(strFileName);
-  StringUtils::ToLower(strExtension);
   StringUtils::TrimLeft(strExtension, ".");
 
   if (strExtension.empty())
@@ -103,16 +784,16 @@ bool CTagLoaderTagLib::Load(const std::string& strFileName, CMusicInfoTag& tag, 
     strExtension = fallbackFileExtension;
     if (strExtension.empty())
       return false;
-    StringUtils::ToLower(strExtension);
   }
 
+  StringUtils::ToLower(strExtension);
   TagLibVFSStream*           stream = new TagLibVFSStream(strFileName, true);
   if (!stream)
   {
     CLog::Log(LOGERROR, "could not create TagLib VFS stream for: %s", strFileName.c_str());
     return false;
   }
-  
+
   ID3v1::Tag::setStringHandler(&ID3v1StringHandler);
   ID3v2::Tag::setLatin1StringHandler(&ID3v2StringHandler);
   TagLib::File*              file = NULL;
@@ -143,8 +824,8 @@ bool CTagLoaderTagLib::Load(const std::string& strFileName, CMusicInfoTag& tag, 
     file = itFile = new IT::File(stream);
   else if (strExtension == "mod" || strExtension == "module" || strExtension == "nst" || strExtension == "wow")
     file = modFile = new Mod::File(stream);
-  else if (strExtension == "mp4" || strExtension == "m4a" || 
-           strExtension == "m4r" || strExtension == "m4b" || 
+  else if (strExtension == "mp4" || strExtension == "m4a" ||
+           strExtension == "m4r" || strExtension == "m4b" ||
            strExtension == "m4p" || strExtension == "3g2")
     file = mp4File = new MP4::File(stream);
   else if (strExtension == "mpc")
@@ -234,19 +915,19 @@ bool CTagLoaderTagLib::Load(const std::string& strFileName, CMusicInfoTag& tag, 
     tag.SetDuration(file->audioProperties()->length());
 
   if (asf)
-    ParseASF(asf, art, tag);
+    ParseTag(asf, art, tag);
   if (id3v1)
-    ParseID3v1Tag(id3v1, art, tag);
+    ParseTag(id3v1, art, tag);
   if (id3v2)
-    ParseID3v2Tag(id3v2, art, tag);
+    ParseTag(id3v2, art, tag);
   if (generic)
-    ParseGenericTag(generic, art, tag);
+    ParseTag(generic, art, tag);
   if (mp4)
-    ParseMP4Tag(mp4, art, tag);
+    ParseTag(mp4, art, tag);
   if (xiph) // xiph tags override id3v2 tags in badly tagged FLACs
-    ParseXiphComment(xiph, art, tag);
+    ParseTag(xiph, art, tag);
   if (ape && (!id3v2 || g_advancedSettings.m_prioritiseAPEv2tags)) // ape tags override id3v2 if we're prioritising them
-    ParseAPETag(ape, art, tag);
+    ParseTag(ape, art, tag);
 
   // art for flac files is outside the tag
   if (flacFile)
@@ -258,678 +939,7 @@ bool CTagLoaderTagLib::Load(const std::string& strFileName, CMusicInfoTag& tag, 
 
   delete file;
   delete stream;
-  
-  return true;
-}
-
-bool CTagLoaderTagLib::ParseASF(ASF::Tag *asf, EmbeddedArt *art, CMusicInfoTag& tag)
-{
-  if (!asf)
-    return false;
-
-  ReplayGain replayGainInfo;
-  tag.SetTitle(asf->title().to8Bit(true));
-  const ASF::AttributeListMap& attributeListMap = asf->attributeListMap();
-  for (ASF::AttributeListMap::ConstIterator it = attributeListMap.begin(); it != attributeListMap.end(); ++it)
-  {
-    if (it->first == "Author")
-      SetArtist(tag, GetASFStringList(it->second));
-    else if (it->first == "WM/AlbumArtist")
-      SetAlbumArtist(tag, GetASFStringList(it->second));
-    else if (it->first == "WM/AlbumTitle")
-      tag.SetAlbum(it->second.front().toString().to8Bit(true));
-    else if (it->first == "WM/TrackNumber" ||
-             it->first == "WM/Track")
-    {
-      if (it->second.front().type() == ASF::Attribute::DWordType)
-        tag.SetTrackNumber(it->second.front().toUInt());
-      else
-        tag.SetTrackNumber(atoi(it->second.front().toString().toCString(true)));
-    }
-    else if (it->first == "WM/PartOfSet")
-      tag.SetDiscNumber(atoi(it->second.front().toString().toCString(true)));
-    else if (it->first == "WM/Genre")
-      SetGenre(tag, GetASFStringList(it->second));
-    else if (it->first == "WM/Mood")
-      tag.SetMood(it->second.front().toString().to8Bit(true));
-    else if (it->first == "WM/AlbumArtistSortOrder")
-    {} // Known unsupported, supress warnings
-    else if (it->first == "WM/ArtistSortOrder")
-    {} // Known unsupported, supress warnings
-    else if (it->first == "WM/Script")
-    {} // Known unsupported, supress warnings
-    else if (it->first == "WM/Year")
-      tag.SetYear(atoi(it->second.front().toString().toCString(true)));
-    else if (it->first == "MusicBrainz/Artist Id")
-      tag.SetMusicBrainzArtistID(SplitMBID(GetASFStringList(it->second)));
-    else if (it->first == "MusicBrainz/Album Id")
-      tag.SetMusicBrainzAlbumID(it->second.front().toString().to8Bit(true));
-    else if (it->first == "MusicBrainz/Album Artist")
-      SetAlbumArtist(tag, GetASFStringList(it->second));
-    else if (it->first == "MusicBrainz/Album Artist Id")
-      tag.SetMusicBrainzAlbumArtistID(SplitMBID(GetASFStringList(it->second)));
-    else if (it->first == "MusicBrainz/Track Id")
-      tag.SetMusicBrainzTrackID(it->second.front().toString().to8Bit(true));
-    else if (it->first == "MusicBrainz/Album Status")
-    {}
-    else if (it->first == "MusicBrainz/Album Type")
-    {}
-    else if (it->first == "MusicIP/PUID")
-    {}
-    else if (it->first == "replaygain_track_gain")
-      replayGainInfo.ParseGain(ReplayGain::TRACK, it->second.front().toString().toCString(true));
-    else if (it->first == "replaygain_album_gain")
-      replayGainInfo.ParseGain(ReplayGain::ALBUM, it->second.front().toString().toCString(true));
-    else if (it->first == "replaygain_track_peak")
-      replayGainInfo.ParsePeak(ReplayGain::TRACK, it->second.front().toString().toCString(true));
-    else if (it->first == "replaygain_album_peak")
-      replayGainInfo.ParsePeak(ReplayGain::ALBUM, it->second.front().toString().toCString(true));
-    else if (it->first == "WM/Picture")
-    { // picture
-      ASF::Picture pic = it->second.front().toPicture();
-      tag.SetCoverArtInfo(pic.picture().size(), pic.mimeType().toCString());
-      if (art)
-        art->set((const uint8_t *)pic.picture().data(), pic.picture().size(), pic.mimeType().toCString());
-    }
-    else if (g_advancedSettings.m_logLevel == LOG_LEVEL_MAX)
-      CLog::Log(LOGDEBUG, "unrecognized ASF tag name: %s", it->first.toCString(true));
-  }
-  // artist may be specified in the ContentDescription block rather than using the 'Author' attribute.
-  if (tag.GetArtist().empty())
-    tag.SetArtist(asf->artist().toCString(true));
-
-  tag.SetReplayGain(replayGainInfo);
-  tag.SetLoaded(true);
-  return true;
-}
-
-char POPMtoXBMC(int popm)
-{
-  // Ratings:
-  // FROM: http://thiagoarrais.com/repos/banshee/src/Core/Banshee.Core/Banshee.Streaming/StreamRatingTagger.cs
-  // The following schemes are used by the other POPM-compatible players:
-  // WMP/Vista: "Windows Media Player 9 Series" ratings:
-  //   1 = 1, 2 = 64, 3=128, 4=196 (not 192), 5=255
-  // MediaMonkey: "no@email" ratings:
-  //   0.5=26, 1=51, 1.5=76, 2=102, 2.5=128,
-  //   3=153, 3.5=178, 4=204, 4.5=230, 5=255
-  // Quod Libet: "quodlibet@lists.sacredchao.net" ratings
-  //   (but that email can be changed):
-  //   arbitrary scale from 0-255
-  if (popm == 0) return '0';
-  if (popm < 0x40) return '1';
-  if (popm < 0x80) return '2';
-  if (popm < 0xc0) return '3';
-  if (popm < 0xff) return '4';
-  return '5';
-}
-
-bool CTagLoaderTagLib::ParseID3v1Tag(ID3v1::Tag *id3v1, EmbeddedArt *art, CMusicInfoTag& tag)
-{
-  if (!id3v1) return false;
-  tag.SetTitle(id3v1->title().to8Bit(true));
-  tag.SetArtist(id3v1->artist().to8Bit(true));
-  tag.SetAlbum(id3v1->album().to8Bit(true));
-  tag.SetComment(id3v1->comment().to8Bit(true));
-  tag.SetGenre(id3v1->genre().to8Bit(true));
-  tag.SetYear(id3v1->year());
-  tag.SetTrackNumber(id3v1->track());
-  return true;
-}
-
-bool CTagLoaderTagLib::ParseID3v2Tag(ID3v2::Tag *id3v2, EmbeddedArt *art, CMusicInfoTag& tag)
-{
-  //  tag.SetURL(strFile);
-  if (!id3v2) return false;
-
-  ReplayGain replayGainInfo;
-
-  ID3v2::AttachedPictureFrame *pictures[3] = {};
-  const ID3v2::FrameListMap& frameListMap = id3v2->frameListMap();
-  for (ID3v2::FrameListMap::ConstIterator it = frameListMap.begin(); it != frameListMap.end(); ++it)
-  {
-    if      (it->first == "TPE1")   SetArtist(tag, GetID3v2StringList(it->second));
-    else if (it->first == "TALB")   tag.SetAlbum(it->second.front()->toString().to8Bit(true));
-    else if (it->first == "TPE2")   SetAlbumArtist(tag, GetID3v2StringList(it->second));
-    else if (it->first == "TIT2")   tag.SetTitle(it->second.front()->toString().to8Bit(true));
-    else if (it->first == "TCON")   SetGenre(tag, GetID3v2StringList(it->second));
-    else if (it->first == "TRCK")   tag.SetTrackNumber(strtol(it->second.front()->toString().toCString(true), NULL, 10));
-    else if (it->first == "TPOS")   tag.SetDiscNumber(strtol(it->second.front()->toString().toCString(true), NULL, 10));
-    else if (it->first == "TYER")   tag.SetYear(strtol(it->second.front()->toString().toCString(true), NULL, 10));
-    else if (it->first == "TCMP")   tag.SetCompilation((strtol(it->second.front()->toString().toCString(true), NULL, 10) == 0) ? false : true);
-    else if (it->first == "TENC")   {} // EncodedBy
-    else if (it->first == "TCOP")   {} // Copyright message
-    else if (it->first == "TDRC")   tag.SetYear(strtol(it->second.front()->toString().toCString(true), NULL, 10));
-    else if (it->first == "TDRL")   tag.SetYear(strtol(it->second.front()->toString().toCString(true), NULL, 10));
-    else if (it->first == "TDTG")   {} // Tagging time
-    else if (it->first == "TLAN")   {} // Languages
-    else if (it->first == "TMOO")   tag.SetMood(it->second.front()->toString().to8Bit(true));
-    else if (it->first == "USLT")
-      // Loop through any lyrics frames. Could there be multiple frames, how to choose?
-      for (ID3v2::FrameList::ConstIterator lt = it->second.begin(); lt != it->second.end(); ++lt)
-      {
-        ID3v2::UnsynchronizedLyricsFrame *lyricsFrame = dynamic_cast<ID3v2::UnsynchronizedLyricsFrame *> (*lt);
-        if (lyricsFrame)           
-          tag.SetLyrics(lyricsFrame->text().to8Bit(true));
-      }
-    else if (it->first == "COMM")
-      // Loop through and look for the main (no description) comment
-      for (ID3v2::FrameList::ConstIterator ct = it->second.begin(); ct != it->second.end(); ++ct)
-      {
-        ID3v2::CommentsFrame *commentsFrame = dynamic_cast<ID3v2::CommentsFrame *> (*ct);
-        if (commentsFrame && commentsFrame->description().isEmpty())
-          tag.SetComment(commentsFrame->text().to8Bit(true));
-      }
-    else if (it->first == "TXXX")
-      // Loop through and process the UserTextIdentificationFrames
-      for (ID3v2::FrameList::ConstIterator ut = it->second.begin(); ut != it->second.end(); ++ut)
-      {
-        ID3v2::UserTextIdentificationFrame *frame = dynamic_cast<ID3v2::UserTextIdentificationFrame *> (*ut);
-        if (!frame) continue;
-        
-        // First field is the same as the description
-        StringList stringList = frame->fieldList(); 
-        stringList.erase(stringList.begin());
-        String desc = frame->description().upper();
-        if      (desc == "MUSICBRAINZ ARTIST ID")
-          tag.SetMusicBrainzArtistID(SplitMBID(StringListToVectorString(stringList)));
-        else if (desc == "MUSICBRAINZ ALBUM ID")
-          tag.SetMusicBrainzAlbumID(stringList.front().to8Bit(true));
-        else if (desc == "MUSICBRAINZ ALBUM ARTIST ID")
-          tag.SetMusicBrainzAlbumArtistID(SplitMBID(StringListToVectorString(stringList)));
-        else if (desc == "MUSICBRAINZ ALBUM ARTIST")
-          SetAlbumArtist(tag, StringListToVectorString(stringList));
-        else if (desc == "REPLAYGAIN_TRACK_GAIN")
-          replayGainInfo.ParseGain(ReplayGain::TRACK, stringList.front().toCString(true));
-        else if (desc == "REPLAYGAIN_ALBUM_GAIN")
-          replayGainInfo.ParseGain(ReplayGain::ALBUM, stringList.front().toCString(true));
-        else if (desc == "REPLAYGAIN_TRACK_PEAK")
-          replayGainInfo.ParsePeak(ReplayGain::TRACK, stringList.front().toCString(true));
-        else if (desc == "REPLAYGAIN_ALBUM_PEAK")
-          replayGainInfo.ParsePeak(ReplayGain::ALBUM, stringList.front().toCString(true));
-        else if (desc == "ALBUMARTIST" || desc == "ALBUM ARTIST")
-          SetAlbumArtist(tag, StringListToVectorString(stringList));
-        else if (desc == "ARTISTS")
-        {
-          if (id3v2->header()->majorVersion() < 4)
-            tag.SetMusicBrainzArtistHints(StringListToVectorString(TagLib::StringList::split(stringList.front(), TagLib::String("/"))));
-          else
-            tag.SetMusicBrainzArtistHints(StringListToVectorString(stringList));
-        }
-        else if (desc == "ALBUMARTISTS" || desc == "ALBUM ARTISTS")
-        {
-          if (id3v2->header()->majorVersion() < 4)
-            tag.SetMusicBrainzAlbumArtistHints(StringListToVectorString(TagLib::StringList::split(stringList.front(), TagLib::String("/"))));
-          else
-            tag.SetMusicBrainzAlbumArtistHints(StringListToVectorString(stringList));
-        }
-        else if (desc == "MOOD")
-          tag.SetMood(stringList.front().to8Bit(true));
-        else if (g_advancedSettings.m_logLevel == LOG_LEVEL_MAX)
-          CLog::Log(LOGDEBUG, "unrecognized user text tag detected: TXXX:%s", frame->description().toCString(true));
-      }
-    else if (it->first == "UFID")
-      // Loop through any UFID frames and set them
-      for (ID3v2::FrameList::ConstIterator ut = it->second.begin(); ut != it->second.end(); ++ut)
-      {
-        ID3v2::UniqueFileIdentifierFrame *ufid = reinterpret_cast<ID3v2::UniqueFileIdentifierFrame*> (*ut);
-        if (ufid->owner() == "http://musicbrainz.org")
-        {
-          // MusicBrainz pads with a \0, but the spec requires binary, be cautious
-          char cUfid[64];
-          int max_size = std::min((int)ufid->identifier().size(), 63);
-          strncpy(cUfid, ufid->identifier().data(), max_size);
-          cUfid[max_size] = '\0';
-          tag.SetMusicBrainzTrackID(cUfid);
-        }
-      }
-    else if (it->first == "APIC")
-      // Loop through all pictures and store the frame pointers for the picture types we want
-      for (ID3v2::FrameList::ConstIterator pi = it->second.begin(); pi != it->second.end(); ++pi)
-      {
-        ID3v2::AttachedPictureFrame *pictureFrame = dynamic_cast<ID3v2::AttachedPictureFrame *> (*pi);
-        if (!pictureFrame) continue;
-        
-        if      (pictureFrame->type() == ID3v2::AttachedPictureFrame::FrontCover) pictures[0] = pictureFrame;
-        else if (pictureFrame->type() == ID3v2::AttachedPictureFrame::Other)      pictures[1] = pictureFrame;
-        else if (pi == it->second.begin())                                        pictures[2] = pictureFrame;
-      }
-    else if (it->first == "POPM")
-      // Loop through and process ratings
-      for (ID3v2::FrameList::ConstIterator ct = it->second.begin(); ct != it->second.end(); ++ct)
-      {
-        ID3v2::PopularimeterFrame *popFrame = dynamic_cast<ID3v2::PopularimeterFrame *> (*ct);
-        if (!popFrame) continue;
-        
-        // @xbmc.org ratings trump others (of course)
-        if      (popFrame->email() == "ratings@xbmc.org")
-          tag.SetUserrating(popFrame->rating() / 51 + '0');
-        else if (tag.GetUserrating() == '0')
-        {
-          if (popFrame->email() != "Windows Media Player 9 Series" &&
-              popFrame->email() != "Banshee" &&
-              popFrame->email() != "no@email" &&
-              popFrame->email() != "quodlibet@lists.sacredchao.net" &&
-              popFrame->email() != "rating@winamp.com")
-            CLog::Log(LOGDEBUG, "unrecognized ratings schema detected: %s", popFrame->email().toCString(true));
-          tag.SetUserrating(POPMtoXBMC(popFrame->rating()));
-        }
-      }
-    else if (g_advancedSettings.m_logLevel == LOG_LEVEL_MAX)
-      CLog::Log(LOGDEBUG, "unrecognized ID3 frame detected: %c%c%c%c", it->first[0], it->first[1], it->first[2], it->first[3]);
-  } // for
-
-  // Process the extracted picture frames; 0 = CoverArt, 1 = Other, 2 = First Found picture
-  for (int i = 0; i < 3; ++i)
-    if (pictures[i])
-    {
-      std::string  mime =            pictures[i]->mimeType().to8Bit(true);
-      TagLib::uint size =            pictures[i]->picture().size();
-      tag.SetCoverArtInfo(size, mime);
-      if (art)
-        art->set((const uint8_t*)pictures[i]->picture().data(), size, mime);
-      
-      // Stop after we find the first picture for now.
-      break;
-    }
-
-  tag.SetReplayGain(replayGainInfo);
-  return true;
-}
-
-bool CTagLoaderTagLib::ParseAPETag(APE::Tag *ape, EmbeddedArt *art, CMusicInfoTag& tag)
-{
-  if (!ape)
-    return false;
-
-  ReplayGain replayGainInfo;
-  const APE::ItemListMap itemListMap = ape->itemListMap();
-  for (APE::ItemListMap::ConstIterator it = itemListMap.begin(); it != itemListMap.end(); ++it)
-  {
-    if (it->first == "ARTIST")
-      SetArtist(tag, StringListToVectorString(it->second.toStringList()));
-    else if (it->first == "ARTISTS")
-      tag.SetMusicBrainzArtistHints(StringListToVectorString(it->second.toStringList()));
-    else if (it->first == "ALBUMARTIST" || it->first == "ALBUM ARTIST")
-      SetAlbumArtist(tag, StringListToVectorString(it->second.toStringList()));
-    else if (it->first == "ALBUMARTISTS" || it->first == "ALBUM ARTISTS")
-      tag.SetMusicBrainzAlbumArtistHints(StringListToVectorString(it->second.toStringList()));
-    else if (it->first == "ALBUM")
-      tag.SetAlbum(it->second.toString().to8Bit(true));
-    else if (it->first == "TITLE")
-      tag.SetTitle(it->second.toString().to8Bit(true));
-    else if (it->first == "TRACKNUMBER" || it->first == "TRACK")
-      tag.SetTrackNumber(it->second.toString().toInt());
-    else if (it->first == "DISCNUMBER" || it->first == "DISC")
-      tag.SetDiscNumber(it->second.toString().toInt());
-    else if (it->first == "YEAR")
-      tag.SetYear(it->second.toString().toInt());
-    else if (it->first == "GENRE")
-      SetGenre(tag, StringListToVectorString(it->second.toStringList()));
-    else if (it->first == "COMMENT")
-      tag.SetComment(it->second.toString().to8Bit(true));
-    else if (it->first == "CUESHEET")
-      tag.SetCueSheet(it->second.toString().to8Bit(true));
-    else if (it->first == "ENCODEDBY")
-    {}
-    else if (it->first == "COMPILATION")
-      tag.SetCompilation(it->second.toString().toInt() == 1);
-    else if (it->first == "LYRICS")
-      tag.SetLyrics(it->second.toString().to8Bit(true));
-    else if (it->first == "REPLAYGAIN_TRACK_GAIN")
-      replayGainInfo.ParseGain(ReplayGain::TRACK, it->second.toString().toCString(true));
-    else if (it->first == "REPLAYGAIN_ALBUM_GAIN")
-      replayGainInfo.ParseGain(ReplayGain::ALBUM, it->second.toString().toCString(true));
-    else if (it->first == "REPLAYGAIN_TRACK_PEAK")
-      replayGainInfo.ParsePeak(ReplayGain::TRACK, it->second.toString().toCString(true));
-    else if (it->first == "REPLAYGAIN_ALBUM_PEAK")
-      replayGainInfo.ParsePeak(ReplayGain::ALBUM, it->second.toString().toCString(true));
-    else if (it->first == "MUSICBRAINZ_ARTISTID")
-      tag.SetMusicBrainzArtistID(SplitMBID(StringListToVectorString(it->second.toStringList())));
-    else if (it->first == "MUSICBRAINZ_ALBUMARTISTID")
-      tag.SetMusicBrainzAlbumArtistID(SplitMBID(StringListToVectorString(it->second.toStringList())));
-    else if (it->first == "MUSICBRAINZ_ALBUMARTIST")
-      SetAlbumArtist(tag, StringListToVectorString(it->second.toStringList()));
-    else if (it->first == "MUSICBRAINZ_ALBUMID")
-      tag.SetMusicBrainzAlbumID(it->second.toString().to8Bit(true));
-    else if (it->first == "MUSICBRAINZ_TRACKID")
-      tag.SetMusicBrainzTrackID(it->second.toString().to8Bit(true));
-    else if (g_advancedSettings.m_logLevel == LOG_LEVEL_MAX)
-      CLog::Log(LOGDEBUG, "unrecognized APE tag: %s", it->first.toCString(true));
-  }
-
-  tag.SetReplayGain(replayGainInfo);
-  return true;
-}
-
-bool CTagLoaderTagLib::ParseXiphComment(Ogg::XiphComment *xiph, EmbeddedArt *art, CMusicInfoTag& tag)
-{
-  if (!xiph)
-    return false;
-
-  FLAC::Picture pictures[3];
-  ReplayGain replayGainInfo;
-
-  const Ogg::FieldListMap& fieldListMap = xiph->fieldListMap();
-  for (Ogg::FieldListMap::ConstIterator it = fieldListMap.begin(); it != fieldListMap.end(); ++it)
-  {
-    if (it->first == "ARTIST")
-      SetArtist(tag, StringListToVectorString(it->second));
-    else if (it->first == "ARTISTS")
-      tag.SetMusicBrainzArtistHints(StringListToVectorString(it->second));
-    else if (it->first == "ALBUMARTIST" || it->first == "ALBUM ARTIST")
-      SetAlbumArtist(tag, StringListToVectorString(it->second));
-    else if (it->first == "ALBUMARTISTS" || it->first == "ALBUM ARTISTS")
-      tag.SetMusicBrainzAlbumArtistHints(StringListToVectorString(it->second));
-    else if (it->first == "ALBUM")
-      tag.SetAlbum(it->second.front().to8Bit(true));
-    else if (it->first == "TITLE")
-      tag.SetTitle(it->second.front().to8Bit(true));
-    else if (it->first == "TRACKNUMBER")
-      tag.SetTrackNumber(it->second.front().toInt());
-    else if (it->first == "DISCNUMBER")
-      tag.SetDiscNumber(it->second.front().toInt());
-    else if (it->first == "YEAR")
-      tag.SetYear(it->second.front().toInt());
-    else if (it->first == "DATE")
-      tag.SetYear(it->second.front().toInt());
-    else if (it->first == "GENRE")
-      SetGenre(tag, StringListToVectorString(it->second));
-    else if (it->first == "COMMENT")
-      tag.SetComment(it->second.front().to8Bit(true));
-    else if (it->first == "CUESHEET")
-      tag.SetCueSheet(it->second.front().to8Bit(true));
-    else if (it->first == "ENCODEDBY")
-    {}
-    else if (it->first == "ENSEMBLE")
-    {}
-    else if (it->first == "COMPILATION")
-      tag.SetCompilation(it->second.front().toInt() == 1);
-    else if (it->first == "LYRICS")
-      tag.SetLyrics(it->second.front().to8Bit(true));
-    else if (it->first == "REPLAYGAIN_TRACK_GAIN")
-      replayGainInfo.ParseGain(ReplayGain::TRACK, it->second.front().toCString(true));
-    else if (it->first == "REPLAYGAIN_ALBUM_GAIN")
-      replayGainInfo.ParseGain(ReplayGain::ALBUM, it->second.front().toCString(true));
-    else if (it->first == "REPLAYGAIN_TRACK_PEAK")
-      replayGainInfo.ParsePeak(ReplayGain::TRACK, it->second.front().toCString(true));
-    else if (it->first == "REPLAYGAIN_ALBUM_PEAK")
-      replayGainInfo.ParsePeak(ReplayGain::ALBUM, it->second.front().toCString(true));
-    else if (it->first == "MUSICBRAINZ_ARTISTID")
-      tag.SetMusicBrainzArtistID(SplitMBID(StringListToVectorString(it->second)));
-    else if (it->first == "MUSICBRAINZ_ALBUMARTISTID")
-      tag.SetMusicBrainzAlbumArtistID(SplitMBID(StringListToVectorString(it->second)));
-    else if (it->first == "MUSICBRAINZ_ALBUMARTIST")
-      SetAlbumArtist(tag, StringListToVectorString(it->second));
-    else if (it->first == "MUSICBRAINZ_ALBUMID")
-      tag.SetMusicBrainzAlbumID(it->second.front().to8Bit(true));
-    else if (it->first == "MUSICBRAINZ_TRACKID")
-      tag.SetMusicBrainzTrackID(it->second.front().to8Bit(true));
-    else if (it->first == "RATING")
-    {
-      // Vorbis ratings are a mess because the standard forgot to mention anything about them.
-      // If you want to see how emotive the issue is and the varying standards, check here:
-      // http://forums.winamp.com/showthread.php?t=324512
-      // The most common standard in that thread seems to be a 0-100 scale for 1-5 stars.
-      // So, that's what we'll support for now.
-      int iRating = it->second.front().toInt();
-      if (iRating > 0 && iRating <= 100)
-        tag.SetUserrating((iRating / 20) + '0');
-    }
-    else if (it->first == "METADATA_BLOCK_PICTURE")
-    {
-      const char* b64 = it->second.front().toCString();
-      std::string decoded_block = Base64::Decode(b64, it->second.front().size());
-      ByteVector bv(decoded_block.data(), decoded_block.size());
-      TagLib::FLAC::Picture* pictureFrame = new TagLib::FLAC::Picture(bv);
-
-      if      (pictureFrame->type() == FLAC::Picture::FrontCover) pictures[0].parse(bv);
-      else if (pictureFrame->type() == FLAC::Picture::Other)      pictures[1].parse(bv);
-      
-      delete pictureFrame;
-    }
-    else if (it->first == "COVERART")
-    {
-      const char* b64 = it->second.front().toCString();
-      std::string decoded_block = Base64::Decode(b64, it->second.front().size());
-      ByteVector bv(decoded_block.data(), decoded_block.size());
-      pictures[2].setData(bv);
-      // Assume jpeg
-      if (pictures[2].mimeType().isEmpty())
-        pictures[2].setMimeType("image/jpeg");
-    }
-    else if (it->first == "COVERARTMIME")
-    {
-      pictures[2].setMimeType(it->second.front());
-    }
-    else if (g_advancedSettings.m_logLevel == LOG_LEVEL_MAX)
-      CLog::Log(LOGDEBUG, "unrecognized XipComment name: %s", it->first.toCString(true));
-  }
-
-  // Process the extracted picture frames; 0 = CoverArt, 1 = Other, 2 = COVERART/COVERARTMIME
-  for (int i = 0; i < 3; ++i)
-    if (pictures[i].data().size())
-    {
-      std::string mime = pictures[i].mimeType().toCString();
-      if (mime.compare(0, 6, "image/") != 0)
-        continue;
-      TagLib::uint size =            pictures[i].data().size();
-      tag.SetCoverArtInfo(size, mime);
-      if (art)
-        art->set((const uint8_t*)pictures[i].data().data(), size, mime);
-
-      break;
-    }
-
-  tag.SetReplayGain(replayGainInfo);
-  return true;
-}
-
-bool CTagLoaderTagLib::ParseMP4Tag(MP4::Tag *mp4, EmbeddedArt *art, CMusicInfoTag& tag)
-{
-  if (!mp4)
-    return false;
-
-  ReplayGain replayGainInfo;
-  MP4::ItemListMap& itemListMap = mp4->itemListMap();
-  for (MP4::ItemListMap::ConstIterator it = itemListMap.begin(); it != itemListMap.end(); ++it)
-  {
-    if (it->first == "\251nam")
-      tag.SetTitle(it->second.toStringList().front().to8Bit(true));
-    else if (it->first == "\251ART")
-      SetArtist(tag, StringListToVectorString(it->second.toStringList()));
-    else if (it->first == "----:com.apple.iTunes:ARTISTS")
-      tag.SetMusicBrainzArtistHints(StringListToVectorString(it->second.toStringList()));
-    else if (it->first == "\251alb")
-      tag.SetAlbum(it->second.toStringList().front().to8Bit(true));
-    else if (it->first == "aART")
-      SetAlbumArtist(tag, StringListToVectorString(it->second.toStringList()));
-    else if (it->first == "----:com.apple.iTunes:ALBUMARTISTS")
-      tag.SetMusicBrainzAlbumArtistHints(StringListToVectorString(it->second.toStringList()));
-    else if (it->first == "\251gen")
-      SetGenre(tag, StringListToVectorString(it->second.toStringList()));
-    else if (it->first == "\251cmt")
-      tag.SetComment(it->second.toStringList().front().to8Bit(true));
-    else if (it->first == "cpil")
-      tag.SetCompilation(it->second.toBool());
-    else if (it->first == "trkn")
-      tag.SetTrackNumber(it->second.toIntPair().first);
-    else if (it->first == "disk")
-      tag.SetDiscNumber(it->second.toIntPair().first);
-    else if (it->first == "\251day")
-      tag.SetYear(it->second.toStringList().front().toInt());
-    else if (it->first == "----:com.apple.iTunes:replaygain_track_gain")
-      replayGainInfo.ParseGain(ReplayGain::TRACK, it->second.toStringList().front().toCString());
-    else if (it->first == "----:com.apple.iTunes:replaygain_album_gain")
-      replayGainInfo.ParseGain(ReplayGain::ALBUM, it->second.toStringList().front().toCString());
-    else if (it->first == "----:com.apple.iTunes:replaygain_track_peak")
-      replayGainInfo.ParsePeak(ReplayGain::TRACK, it->second.toStringList().front().toCString());
-    else if (it->first == "----:com.apple.iTunes:replaygain_album_peak")
-      replayGainInfo.ParsePeak(ReplayGain::ALBUM, it->second.toStringList().front().toCString());
-    else if (it->first == "----:com.apple.iTunes:MusicBrainz Artist Id")
-      tag.SetMusicBrainzArtistID(SplitMBID(StringListToVectorString(it->second.toStringList())));
-    else if (it->first == "----:com.apple.iTunes:MusicBrainz Album Artist Id")
-      tag.SetMusicBrainzAlbumArtistID(SplitMBID(StringListToVectorString(it->second.toStringList())));
-    else if (it->first == "----:com.apple.iTunes:MusicBrainz Album Artist")
-      SetAlbumArtist(tag, StringListToVectorString(it->second.toStringList()));
-    else if (it->first == "----:com.apple.iTunes:MusicBrainz Album Id")
-      tag.SetMusicBrainzAlbumID(it->second.toStringList().front().to8Bit(true));
-    else if (it->first == "----:com.apple.iTunes:MusicBrainz Track Id")
-      tag.SetMusicBrainzTrackID(it->second.toStringList().front().to8Bit(true));
-    else if (it->first == "covr")
-    {
-      MP4::CoverArtList coverArtList = it->second.toCoverArtList();
-      for (MP4::CoverArtList::ConstIterator pt = coverArtList.begin(); pt != coverArtList.end(); ++pt)
-      {
-        std::string mime;
-        switch (pt->format())
-        {
-          case MP4::CoverArt::PNG:
-            mime = "image/png";
-            break;
-          case MP4::CoverArt::JPEG:
-            mime = "image/jpeg";
-            break;
-          default:
-            break;
-        }
-        if (mime.empty())
-          continue;
-        tag.SetCoverArtInfo(pt->data().size(), mime);
-        if (art)
-          art->set((const uint8_t *)pt->data().data(), pt->data().size(), mime);
-        break; // one is enough
-      }
-    }
-  }
-
-  tag.SetReplayGain(replayGainInfo);
-  return true;
-}
-
-bool CTagLoaderTagLib::ParseGenericTag(Tag *generic, EmbeddedArt *art, CMusicInfoTag& tag)
-{
-  if (!generic)
-    return false;
-
-  PropertyMap properties = generic->properties();
-  for (PropertyMap::ConstIterator it = properties.begin(); it != properties.end(); ++it)
-  {
-    if (it->first == "ARTIST")
-      SetArtist(tag, StringListToVectorString(it->second));
-    else if (it->first == "ALBUM")
-      tag.SetAlbum(it->second.front().to8Bit(true));
-    else if (it->first == "TITLE")
-      tag.SetTitle(it->second.front().to8Bit(true));
-    else if (it->first == "TRACKNUMBER")
-      tag.SetTrackNumber(it->second.front().toInt());
-    else if (it->first == "YEAR")
-      tag.SetYear(it->second.front().toInt());
-    else if (it->first == "GENRE")
-      SetGenre(tag, StringListToVectorString(it->second));
-    else if (it->first == "COMMENT")
-      tag.SetComment(it->second.front().to8Bit(true));
-  }
 
   return true;
 }
 
-void CTagLoaderTagLib::SetFlacArt(FLAC::File *flacFile, EmbeddedArt *art, CMusicInfoTag &tag)
-{
-  FLAC::Picture *cover[2] = {};
-  List<FLAC::Picture *> pictures = flacFile->pictureList();
-  for (List<FLAC::Picture *>::ConstIterator i = pictures.begin(); i != pictures.end(); ++i)
-  {
-    FLAC::Picture *picture = *i;
-    if (picture->type() == FLAC::Picture::FrontCover)
-      cover[0] = picture;
-    else // anything else is taken as second priority
-      cover[1] = picture;
-  }
-  for (unsigned int i = 0; i < 2; i++)
-  {
-    if (cover[i])
-    {
-      tag.SetCoverArtInfo(cover[i]->data().size(), cover[i]->mimeType().to8Bit(true));
-      if (art)
-        art->set((const uint8_t*)cover[i]->data().data(), cover[i]->data().size(), cover[i]->mimeType().to8Bit(true));
-      return; // one is enough
-    }
-  }
-}
-
-const std::vector<std::string> CTagLoaderTagLib::GetASFStringList(const List<ASF::Attribute>& list)
-{
-  std::vector<std::string> values;
-  for (List<ASF::Attribute>::ConstIterator at = list.begin(); at != list.end(); ++at)
-    values.push_back(at->toString().to8Bit(true));
-  return values;
-}
-
-const std::vector<std::string> CTagLoaderTagLib::GetID3v2StringList(const ID3v2::FrameList& frameList) const
-{
-  const ID3v2::TextIdentificationFrame *frame = dynamic_cast<ID3v2::TextIdentificationFrame *>(frameList.front());
-  if (frame)
-    return StringListToVectorString(frame->fieldList());
-  return std::vector<std::string>();
-}
-
-void CTagLoaderTagLib::SetArtist(CMusicInfoTag &tag, const std::vector<std::string> &values)
-{
-  if (values.size() == 1)
-    tag.SetArtist(values[0]);
-  else
-    tag.SetArtist(values);
-}
-
-const std::vector<std::string> CTagLoaderTagLib::SplitMBID(const std::vector<std::string> &values)
-{
-  if (values.empty() || values.size() > 1)
-    return values;
-
-  // Picard, and other taggers use a heap of different separators.  We use a regexp to detect
-  // MBIDs to make sure we hit them all...
-  std::vector<std::string> ret;
-  std::string value = values[0];
-  StringUtils::ToLower(value);
-  CRegExp reg;
-  if (reg.RegComp("([[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{12})"))
-  {
-    int pos = -1;
-    while ((pos = reg.RegFind(value, pos+1)) > -1)
-      ret.push_back(reg.GetMatch(1));
-  }
-  return ret;
-}
-
-void CTagLoaderTagLib::SetAlbumArtist(CMusicInfoTag &tag, const std::vector<std::string> &values)
-{
-  if (values.size() == 1)
-    tag.SetAlbumArtist(values[0]);
-  else
-    tag.SetAlbumArtist(values);
-}
-
-void CTagLoaderTagLib::SetGenre(CMusicInfoTag &tag, const std::vector<std::string> &values)
-{
-  /*
-   TagLib doesn't resolve ID3v1 genre numbers in the case were only
-   a number is specified, thus this workaround.
-   */
-  std::vector<std::string> genres;
-  for (std::vector<std::string>::const_iterator i = values.begin(); i != values.end(); ++i)
-  {
-    std::string genre = *i;
-    if (StringUtils::IsNaturalNumber(genre))
-    {
-      int number = strtol(i->c_str(), NULL, 10);
-      if (number >= 0 && number < 256)
-        genre = ID3v1::genre(number).to8Bit(true);
-    }
-    genres.push_back(genre);
-  }
-  if (genres.size() == 1)
-    tag.SetGenre(genres[0]);
-  else
-    tag.SetGenre(genres);
-}

--- a/xbmc/music/tags/TagLoaderTagLib.cpp
+++ b/xbmc/music/tags/TagLoaderTagLib.cpp
@@ -170,6 +170,8 @@ bool CTagLoaderTagLib::ParseTag(ASF::Tag *asf, EmbeddedArt *art, CMusicInfoTag& 
   if (tag.GetArtist().empty())
     tag.SetArtist(asf->artist().toCString(true));
 
+  if (asf->comment() != String::null)
+    tag.SetComment(asf->comment().toCString(true));
   tag.SetReplayGain(replayGainInfo);
   tag.SetLoaded(true);
   return true;
@@ -220,6 +222,10 @@ bool CTagLoaderTagLib::ParseTag(ID3v2::Tag *id3v2, MUSIC_INFO::EmbeddedArt *art,
   const ID3v2::FrameListMap& frameListMap = id3v2->frameListMap();
   for (ID3v2::FrameListMap::ConstIterator it = frameListMap.begin(); it != frameListMap.end(); ++it)
   {
+    // It is possible that the taglist is empty. In that case no useable values can be extracted.
+    // and we should skip the tag.
+    if (it->second.isEmpty()) continue;
+
     if      (it->first == "TPE1")   SetArtist(tag, GetID3v2StringList(it->second));
     else if (it->first == "TALB")   tag.SetAlbum(it->second.front()->toString().to8Bit(true));
     else if (it->first == "TPE2")   SetAlbumArtist(tag, GetID3v2StringList(it->second));
@@ -261,6 +267,7 @@ bool CTagLoaderTagLib::ParseTag(ID3v2::Tag *id3v2, MUSIC_INFO::EmbeddedArt *art,
 
         // First field is the same as the description
         StringList stringList = frame->fieldList();
+        if (stringList.size() == 1) continue;
         stringList.erase(stringList.begin());
         String desc = frame->description().upper();
         if      (desc == "MUSICBRAINZ ARTIST ID")
@@ -554,6 +561,9 @@ bool CTagLoaderTagLib::ParseTag(Ogg::XiphComment *xiph, EmbeddedArt *art, CMusic
 
       break;
     }
+
+  if (xiph->comment() != String::null)
+    tag.SetComment(xiph->comment().toCString(true));
 
   tag.SetReplayGain(replayGainInfo);
   return true;
@@ -942,4 +952,3 @@ bool CTagLoaderTagLib::Load(const std::string& strFileName, CMusicInfoTag& tag, 
 
   return true;
 }
-

--- a/xbmc/music/tags/TagLoaderTagLib.h
+++ b/xbmc/music/tags/TagLoaderTagLib.h
@@ -56,24 +56,21 @@ public:
   CTagLoaderTagLib();
   virtual ~CTagLoaderTagLib();
   virtual bool                   Load(const std::string& strFileName, MUSIC_INFO::CMusicInfoTag& tag, MUSIC_INFO::EmbeddedArt *art = NULL);
-
   bool                           Load(const std::string& strFileName, MUSIC_INFO::CMusicInfoTag& tag, const std::string& fallbackFileExtension, MUSIC_INFO::EmbeddedArt *art = NULL);
 
-  const std::vector<std::string> SplitMBID(const std::vector<std::string> &values);
+  static const std::vector<std::string> SplitMBID(const std::vector<std::string> &values);
+protected:
+  static void SetArtist(MUSIC_INFO::CMusicInfoTag &tag, const std::vector<std::string> &values);
+  static void SetAlbumArtist(MUSIC_INFO::CMusicInfoTag &tag, const std::vector<std::string> &values);
+  static void SetGenre(MUSIC_INFO::CMusicInfoTag &tag, const std::vector<std::string> &values);
+  static char POPMtoXBMC(int popm);
+
+template<typename T>
+   static bool ParseTag(T *tag, MUSIC_INFO::EmbeddedArt *art, MUSIC_INFO::CMusicInfoTag& infoTag);
 private:
   bool                           Open(const std::string& strFileName, bool readOnly);
-  const std::vector<std::string> GetASFStringList(const TagLib::List<TagLib::ASF::Attribute>& list);
-  const std::vector<std::string> GetID3v2StringList(const TagLib::ID3v2::FrameList& frameList) const;
-
-  bool                           ParseAPETag(TagLib::APE::Tag *ape, MUSIC_INFO::EmbeddedArt *art, MUSIC_INFO::CMusicInfoTag& tag);
-  bool                           ParseASF(TagLib::ASF::Tag *asf, MUSIC_INFO::EmbeddedArt *art, MUSIC_INFO::CMusicInfoTag& tag);
-  bool                           ParseID3v1Tag(TagLib::ID3v1::Tag *id3v1, MUSIC_INFO::EmbeddedArt *art, MUSIC_INFO::CMusicInfoTag& tag);
-  bool                           ParseID3v2Tag(TagLib::ID3v2::Tag *id3v2, MUSIC_INFO::EmbeddedArt *art, MUSIC_INFO::CMusicInfoTag& tag);
-  bool                           ParseXiphComment(TagLib::Ogg::XiphComment *id3v2, MUSIC_INFO::EmbeddedArt *art, MUSIC_INFO::CMusicInfoTag& tag);
-  bool                           ParseMP4Tag(TagLib::MP4::Tag *mp4, MUSIC_INFO::EmbeddedArt *art, MUSIC_INFO::CMusicInfoTag& tag);
-  bool                           ParseGenericTag(TagLib::Tag *generic, MUSIC_INFO::EmbeddedArt *art, MUSIC_INFO::CMusicInfoTag& tag);
+  static const std::vector<std::string> GetASFStringList(const TagLib::List<TagLib::ASF::Attribute>& list);
+  static const std::vector<std::string> GetID3v2StringList(const TagLib::ID3v2::FrameList& frameList);
   void                           SetFlacArt(TagLib::FLAC::File *flacFile, MUSIC_INFO::EmbeddedArt *art, MUSIC_INFO::CMusicInfoTag &tag);
-  void                           SetArtist(MUSIC_INFO::CMusicInfoTag &tag, const std::vector<std::string> &values);
-  void                           SetAlbumArtist(MUSIC_INFO::CMusicInfoTag &tag, const std::vector<std::string> &values);
-  void                           SetGenre(MUSIC_INFO::CMusicInfoTag &tag, const std::vector<std::string> &values);
 };
+

--- a/xbmc/music/tags/test/TestTagLoaderTagLib.cpp
+++ b/xbmc/music/tags/test/TestTagLoaderTagLib.cpp
@@ -102,7 +102,8 @@ const char *tags[] = { "APIC", "ASPI", "COMM", "COMR", "ENCR", "EQU2",
 };
 
 
-// This test exposes a bug in taglib library (#671) so for now we will not run it for all tag types
+// This test exposes a bug in taglib library (#670) so for now we will not run it for all tag types
+// See https://github.com/taglib/taglib/issues/670 for details.
 typedef ::testing::Types<ID3v2::Tag, ID3v1::Tag, ASF::Tag, APE::Tag, Ogg::XiphComment> EmptyPropertiesTagTypes;
 template <typename T>
 class EmptyTagParser : public ::testing::Test, public CTagLoaderTagLib {

--- a/xbmc/music/tags/test/TestTagLoaderTagLib.cpp
+++ b/xbmc/music/tags/test/TestTagLoaderTagLib.cpp
@@ -20,6 +20,155 @@
 
 #include "gtest/gtest.h"
 #include "music/tags/TagLoaderTagLib.h"
+#include "music/tags/MusicInfoTag.h"
+#include <taglib/tpropertymap.h>
+#include <taglib/id3v1tag.h>
+#include <taglib/id3v2tag.h>
+#include <taglib/apetag.h>
+#include <taglib/xiphcomment.h>
+#include <taglib/id3v1genres.h>
+
+using namespace TagLib;
+using namespace MUSIC_INFO;
+
+template <typename T>
+class TestTagParser : public ::testing::Test, public CTagLoaderTagLib {
+   public:
+     T value_;
+
+     virtual void SetUp() {
+       // Configure a basic tag..
+       value_.setTitle ("title");
+       value_.setArtist ("artist");
+       value_.setAlbum ("album");
+       value_.setComment("comment");
+       value_.setGenre("Jazz");
+       value_.setYear (1985);
+       value_.setTrack (2);
+     }
+};
+
+
+typedef ::testing::Types<ID3v2::Tag, ID3v1::Tag, ASF::Tag, APE::Tag, Ogg::XiphComment, MP4::Tag> TagTypes;
+TYPED_TEST_CASE(TestTagParser, TagTypes);
+
+TYPED_TEST(TestTagParser, ParsesBasicTag) {
+  // Create a basic tag
+  TypeParam *tg  = &this->value_;
+  CMusicInfoTag tag;
+  EXPECT_TRUE(CTagLoaderTagLib::ParseTag<TypeParam>(tg, NULL, tag));
+
+  EXPECT_EQ(1985, tag.GetYear());
+  EXPECT_EQ(2, tag.GetTrackNumber());
+  EXPECT_EQ(1u, tag.GetArtist().size());
+  if (tag.GetArtist().size() > 0) EXPECT_EQ("artist", tag.GetArtist().front());
+  EXPECT_EQ("album", tag.GetAlbum());
+  EXPECT_EQ("comment", tag.GetComment());
+  EXPECT_EQ(1u, tag.GetGenre().size());
+  if (tag.GetGenre().size() > 0) EXPECT_EQ("Jazz", tag.GetGenre().front());
+  EXPECT_EQ("title", tag.GetTitle());
+}
+
+
+TYPED_TEST(TestTagParser, HandleNullTag) {
+  // A Null tag should not parse, and not break us either
+  CMusicInfoTag tag;
+  EXPECT_FALSE(CTagLoaderTagLib::ParseTag<TypeParam>(NULL, NULL, tag));
+}
+
+template<typename T, size_t N>
+T * end(T (&ra)[N]) {
+      return ra + N;
+}
+
+const char *tags[] = { "APIC", "ASPI", "COMM", "COMR", "ENCR", "EQU2",
+  "ETCO", "GEOB", "GRID", "LINK", "MCDI", "MLLT", "OWNE", "PRIV", "PCNT",
+  "POPM", "POSS", "RBUF", "RVA2", "RVRB", "SEEK", "SIGN", "SYLT",
+  "SYTC", "TALB", "TBPM", "TCOM", "TCON", "TCOP", "TDEN", "TDLY", "TDOR",
+  "TDRC", "TDRL", "TDTG", "TENC", "TEXT", "TFLT", "TIPL", "TIT1", "TIT2",
+  "TIT3", "TKEY", "TLAN", "TLEN", "TMCL", "TMED", "TMOO", "TOAL", "TOFN",
+  "TOLY", "TOPE", "TOWN", "TPE1", "TPE2", "TPE3", "TPE4", "TPOS", "TPRO",
+  "TPUB", "TRCK", "TRSN", "TRSO", "TSOA", "TSOP", "TSOT", "TSRC", "TSSE",
+  "TSST", "TXXX", "UFID", "USER", "USLT", "WCOM", "WCOP", "WOAF", "WOAR",
+  "WOAS", "WORS", "WPAY", "WPUB", "WXXX",  "ARTIST", "ARTISTS",
+  "ALBUMARTIST" , "ALBUM ARTIST", "ALBUMARTISTS" , "ALBUM ARTISTS", "ALBUM",
+  "TITLE", "TRACKNUMBER" "TRACK", "DISCNUMBER" "DISC", "YEAR", "GENRE",
+  "COMMENT", "CUESHEET", "ENCODEDBY", "COMPILATION", "LYRICS",
+  "REPLAYGAIN_TRACK_GAIN", "REPLAYGAIN_ALBUM_GAIN", "REPLAYGAIN_TRACK_PEAK",
+  "REPLAYGAIN_ALBUM_PEAK", "MUSICBRAINZ_ARTISTID",
+  "MUSICBRAINZ_ALBUMARTISTID", "RATING", "MUSICBRAINZ_ALBUMARTIST",
+  "MUSICBRAINZ_ALBUMID", "MUSICBRAINZ_TRACKID", "METADATA_BLOCK_PICTURE",
+  "COVERART"
+};
+
+
+// This test exposes a bug in taglib library (#671) so for now we will not run it for all tag types
+typedef ::testing::Types<ID3v2::Tag, ID3v1::Tag, ASF::Tag, APE::Tag, Ogg::XiphComment> EmptyPropertiesTagTypes;
+template <typename T>
+class EmptyTagParser : public ::testing::Test, public CTagLoaderTagLib {
+  public:
+    T value_;
+};
+TYPED_TEST_CASE(EmptyTagParser, EmptyPropertiesTagTypes);
+
+TYPED_TEST(EmptyTagParser, EmptyProperties) {
+  TypeParam *tg  = &this->value_;
+  CMusicInfoTag tag;
+  PropertyMap props;
+  int tagcount = end(tags) - tags;
+  for(int i = 0; i < tagcount; i++) {
+    props.insert(tags[i], StringList());
+  }
+
+  // Even though all the properties are empty, we shouldn't
+  // crash
+  EXPECT_TRUE(CTagLoaderTagLib::ParseTag<TypeParam>(tg, NULL, tag));
+}
+
+
+
+TYPED_TEST(TestTagParser, FooProperties) {
+  TypeParam *tg  = &this->value_;
+  CMusicInfoTag tag;
+  PropertyMap props;
+  int tagcount = end(tags) - tags;
+  for(int i = 0; i < tagcount; i++) {
+    props.insert(tags[i], String("foo"));
+  }
+  tg->setProperties(props);
+
+  EXPECT_TRUE(CTagLoaderTagLib::ParseTag<TypeParam>(tg, NULL, tag));
+  EXPECT_EQ(0, tag.GetYear());
+  EXPECT_EQ(0, tag.GetTrackNumber());
+  EXPECT_EQ(1u, tag.GetArtist().size());
+  if (tag.GetArtist().size() > 0) EXPECT_EQ("foo", tag.GetArtist().front());
+  EXPECT_EQ("foo", tag.GetAlbum());
+  EXPECT_EQ("foo", tag.GetComment());
+  if (tag.GetGenre().size() > 0) EXPECT_EQ("foo", tag.GetGenre().front());
+  EXPECT_EQ("foo", tag.GetTitle());
+}
+
+class TestCTagLoaderTagLib : public ::testing::Test, public CTagLoaderTagLib {};
+TEST_F(TestCTagLoaderTagLib, SetGenre)
+{
+  CMusicInfoTag tag, tag2;
+  const char *genre_nr[] = {"0", "2", "4"};
+  const char *names[] = { "Jazz", "Funk", "Ska" };
+  std::vector<std::string> genres(genre_nr, end(genre_nr));
+  std::vector<std::string> named_genre(names, end(names));
+
+  CTagLoaderTagLib::SetGenre(tag, genres);
+  EXPECT_EQ(3u, tag.GetGenre().size());
+  EXPECT_EQ("Blues", tag.GetGenre()[0]);
+  EXPECT_EQ("Country", tag.GetGenre()[1]);
+  EXPECT_EQ("Disco", tag.GetGenre()[2]);
+
+  CTagLoaderTagLib::SetGenre(tag2, named_genre);
+  EXPECT_EQ(3u, tag2.GetGenre().size());
+  for(int i = 0; i < 3; i++)
+    EXPECT_EQ(names[i], tag2.GetGenre()[i]);
+
+}
 
 TEST(TestTagLoaderTagLib, SplitMBID)
 {


### PR DESCRIPTION
- Slight refactor for testability
- Add a set of unit tests
- Fixes crash on bad id3v2 tags
- Contains fix for build break introduced by atv2 support removal (see: e09e81b)

Note, that the "big" change is really just a re-order, as the template requires a specialization before it can be used.

The unit tests exposed a bug in the taglib library.
