### PR TITLE
CGUIDialogSelect: fix focusing the first selected item when opening the dialog

### DIFF
--- a/xbmc/dialogs/GUIDialogSelect.cpp
+++ b/xbmc/dialogs/GUIDialogSelect.cpp
@@ -56,7 +56,6 @@ bool CGUIDialogSelect::OnMessage(CGUIMessage& message)
   case GUI_MSG_WINDOW_DEINIT:
     {
       CGUIDialogBoxBase::OnMessage(message);
-      m_viewControl.Clear();
 
       m_bButtonEnabled = false;
       m_useDetails = false;
@@ -335,6 +334,13 @@ void CGUIDialogSelect::OnInitWindow()
 
   // if nothing is selected, focus first item
   m_viewControl.SetSelectedItem(std::max(GetSelectedLabel(), 0));
+}
+
+void CGUIDialogSelect::OnDeinitWindow(int nextWindowID)
+{
+  m_viewControl.Clear();
+
+  CGUIDialogBoxBase::OnDeinitWindow(nextWindowID);
 }
 
 void CGUIDialogSelect::OnWindowUnload()

--- a/xbmc/dialogs/GUIDialogSelect.cpp
+++ b/xbmc/dialogs/GUIDialogSelect.cpp
@@ -312,15 +312,14 @@ void CGUIDialogSelect::OnInitWindow()
 {
   m_viewControl.SetItems(*m_vecList);
   m_selectedItems.clear();
-  if (!m_selectedItem)
+  for(int i = 0 ; i < m_vecList->Size(); i++)
   {
-    for(int i = 0 ; i < m_vecList->Size(); i++)
+    auto item = m_vecList->Get(i);
+    if (item->IsSelected())
     {
-      if (m_vecList->Get(i)->IsSelected())
-      {
-        m_selectedItem = m_vecList->Get(i);
-        break;
-      }
+      m_selectedItems.push_back(i);
+      if (m_selectedItem == nullptr)
+        m_selectedItem = item;
     }
   }
   m_viewControl.SetCurrentView(m_useDetails ? CONTROL_DETAILS : CONTROL_LIST);

--- a/xbmc/dialogs/GUIDialogSelect.h
+++ b/xbmc/dialogs/GUIDialogSelect.h
@@ -56,6 +56,7 @@ protected:
   virtual CGUIControl *GetFirstFocusableControl(int id);
   virtual void OnWindowLoaded();
   virtual void OnInitWindow();
+  virtual void OnDeinitWindow(int nextWindowID);
   virtual void OnWindowUnload();
   void SetupButton();
 

--- a/xbmc/guilib/GUIListContainer.cpp
+++ b/xbmc/guilib/GUIListContainer.cpp
@@ -116,6 +116,7 @@ bool CGUIListContainer::OnMessage(CGUIMessage& message)
     if (message.GetMessage() == GUI_MSG_LABEL_RESET)
     {
       SetCursor(0);
+      SetOffset(0);
     }
   }
   return CGUIBaseContainer::OnMessage(message);


### PR DESCRIPTION
This should fix `CGUIDialogSelect` not focusing the first selected item when opening the dialog with at least one "pre-selected" item. The current logic cleans the list of selected items and then tries to set the focus on the first selected item but since the list has just been cleared that's obviously not going to work.

~~This does NOT fix the problem that the item list remembers the last scroll/offset position of the list (even if it was a completely different list).~~
