### PR TITLE
[pvr] reset changed flag for channels after storing them to db

### DIFF
--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -562,7 +562,13 @@ bool CPVRDatabase::PersistChannels(CPVRChannelGroup &group)
   for (PVR_CHANNEL_GROUP_MEMBERS::iterator it = group.m_members.begin(); it != group.m_members.end(); ++it)
   {
     if (it->second.channel->IsChanged() || it->second.channel->IsNew())
-      bReturn &= Persist(*it->second.channel);
+    {
+      if (Persist(*it->second.channel))
+      {
+        it->second.channel->Persisted();
+        bReturn = true;
+      }
+    }
   }
 
   bReturn &= CommitInsertQueries();

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -731,6 +731,12 @@ bool CPVRChannel::IsChanged() const
   return m_bChanged;
 }
 
+void CPVRChannel::Persisted()
+{
+  CSingleLock lock(m_critSection);
+  m_bChanged = false;
+}
+
 int CPVRChannel::UniqueID(void) const
 {
   return m_iUniqueId;

--- a/xbmc/pvr/channels/PVRChannel.h
+++ b/xbmc/pvr/channels/PVRChannel.h
@@ -250,6 +250,11 @@ namespace PVR
     bool IsEmpty() const;
 
     bool IsChanged() const;
+
+    /*!
+     * @brief reset changed flag after persist
+     */
+    void Persisted();
     //@}
 
     /*! @name Client related channel methods


### PR DESCRIPTION
reset the changed flag or pvr will always consider it dirty and persist it on every update
