### PR TITLE
[guilib] scrollbar not reading custom hitrect specified

### DIFF
--- a/xbmc/guilib/GUIScrollBarControl.cpp
+++ b/xbmc/guilib/GUIScrollBarControl.cpp
@@ -275,13 +275,6 @@ bool CGUIScrollBar::UpdateBarSize()
   return changed;
 }
 
-bool CGUIScrollBar::HitTest(const CPoint &point) const
-{
-  if (m_guiBackground.HitTest(point)) return true;
-  if (m_guiBarNoFocus.HitTest(point)) return true;
-  return false;
-}
-
 void CGUIScrollBar::SetFromPosition(const CPoint &point)
 {
   float fPercent;

--- a/xbmc/guilib/GUIScrollBarControl.h
+++ b/xbmc/guilib/GUIScrollBarControl.h
@@ -62,7 +62,6 @@ public:
   virtual std::string GetDescription() const;
   virtual bool IsVisible() const;
 protected:
-  virtual bool HitTest(const CPoint &point) const;
   virtual EVENT_RESULT OnMouseEvent(const CPoint &point, const CMouseEvent &event);
   virtual bool UpdateColors();
   bool UpdateBarSize();


### PR DESCRIPTION
This removes the static `HitTest()` override and enables modifying the actual hitrect via tag. @phil65 for testing please.
