### PR TITLE
Clear the cached source listing when removing a video/music source

### DIFF
--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -1450,6 +1450,7 @@ void CGUIWindowMusicBase::OnRemoveSource(int iItem)
     database.RemoveSongsFromPath(m_vecItems->Get(iItem)->GetPath(), songs, false);
     database.CleanupOrphanedItems();
     g_infoManager.ResetLibraryBools();
+    m_vecItems->RemoveDiscCache(GetID());
   }
 }
 

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -1001,7 +1001,9 @@ bool CGUIWindowVideoNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
     if (button == CONTEXT_BUTTON_REMOVE_SOURCE && !item->IsPlugin()
         && !item->IsLiveTV() &&!item->IsRSS() && !URIUtils::IsUPnP(item->GetPath()))
     {
-      OnUnAssignContent(item->GetPath(), 20375, 20340);
+      // if the source has been properly removed, remove the cached source list because the list has changed
+      if (OnUnAssignContent(item->GetPath(), 20375, 20340))
+        m_vecItems->RemoveDiscCache(GetID());
     }
     Refresh();
     return true;


### PR DESCRIPTION
This fixes a bug that when removing a video or music source in the GUI and loading the source list takes longer than a second (and is therefore cached to disk) the source entry doesn't vanish from the list because it just reloads the cached list. The change manually removes the cached list after having successfully deleted a source which results in re-fetching the actual source list afterwards.
