### PR TITLE
[pvr] Fix errors after switching from using backend channel numbers to using kodi channel numbers and vica versa

### DIFF
--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -489,11 +489,11 @@ CFileItemPtr CPVRChannelGroup::GetByChannelNumber(unsigned int iChannelNumber, u
   CFileItemPtr retval;
   CSingleLock lock(m_critSection);
 
-  for (PVR_CHANNEL_GROUP_MEMBERS::const_iterator it = m_members.begin(); !retval && it != m_members.end(); ++it)
+  for (PVR_CHANNEL_GROUP_SORTED_MEMBERS::const_iterator it = m_sortedMembers.begin(); !retval && it != m_sortedMembers.end(); ++it)
   {
-    if (it->second.iChannelNumber == iChannelNumber &&
-        (iSubChannelNumber == 0 || iSubChannelNumber == it->second.iSubChannelNumber))
-      retval = CFileItemPtr(new CFileItem(it->second.channel));
+    if ((*it).iChannelNumber == iChannelNumber &&
+        (iSubChannelNumber == 0 || iSubChannelNumber == (*it).iSubChannelNumber))
+      retval = CFileItemPtr(new CFileItem((*it).channel));
   }
 
   if (!retval)


### PR DESCRIPTION
When switching between "use backend channel numbers" and "use kodi backend numbers" and not restarting kodi after that, one might have ended up with switching to the wrong channel or to no channel at all for certain channels, if the backend version numbers have "gaps". This PR fixes this.

@negge mind taking a look (We talked about this bug at DevCon).
