### PR TITLE
[Fix] Restore music file view display of extracted tag data and sort criteria

### DIFF
--- a/xbmc/music/GUIViewStateMusic.cpp
+++ b/xbmc/music/GUIViewStateMusic.cpp
@@ -160,7 +160,7 @@ CGUIViewStateMusicDatabase::CGUIViewStateMusicDatabase(const CFileItemList& item
   case NODE_TYPE_YEAR_ALBUM:
     {
       // album
-      AddSortMethod(SortByAlbum, sortAttribute, 558, LABEL_MASKS("%F", "", strAlbum, "%B"));  // Filename, empty | Userdefined, Album
+      AddSortMethod(SortByAlbum, sortAttribute, 558, LABEL_MASKS("%F", "", strAlbum, "%A"));  // Filename, empty | Userdefined (default=%B), Artist
       // artist
       AddSortMethod(SortByArtist, sortAttribute, 557, LABEL_MASKS("%F", "", strAlbum, "%A"));  // Filename, empty | Userdefined, Artist
       // artist / year
@@ -447,14 +447,30 @@ CGUIViewStateWindowMusicNav::CGUIViewStateWindowMusicNav(const CFileItemList& it
     }
     else
     {
-      AddSortMethod(SortByLabel, 551, LABEL_MASKS("%F", "%D", "%L", ""));  // Filename, Duration | Foldername, empty
+      //In navigation of music files tag data is scanned whenever present and can be used as sort criteria
+      //hence sort methods available are similar to song node (not the same as only tag data)
+      //Unfortunately anything here appears at all levels of file navigation even if no song files there.
+      std::string strTrackLeft = CSettings::GetInstance().GetString(CSettings::SETTING_MUSICFILES_LIBRARYTRACKFORMAT);
+      if (strTrackLeft.empty())
+          strTrackLeft = CSettings::GetInstance().GetString(CSettings::SETTING_MUSICFILES_TRACKFORMAT);
+      AddSortMethod(SortByLabel, 551, LABEL_MASKS(strTrackLeft, "%D", "%L", ""),  // Userdefined, Duration | FolderName, empty
+        CSettings::GetInstance().GetBool(CSettings::SETTING_FILELISTS_IGNORETHEWHENSORTING) ? SortAttributeIgnoreArticle : SortAttributeNone);
       AddSortMethod(SortBySize, 553, LABEL_MASKS("%F", "%I", "%L", "%I"));  // Filename, Size | Foldername, Size
       AddSortMethod(SortByDate, 552, LABEL_MASKS("%F", "%J", "%L", "%J"));  // Filename, Date | Foldername, Date
       AddSortMethod(SortByFile, 561, LABEL_MASKS("%F", "%I", "%L", ""));  // Filename, Size | Label, empty
+      AddSortMethod(SortByTrackNumber, 554, LABEL_MASKS(strTrackLeft, "%D"));  // Userdefined, Duration| empty, empty
+      AddSortMethod(SortByTitle, sortAttribute, 556, LABEL_MASKS("%T - %A", "%D"));  // Title, Artist, Duration| empty, empty
+      AddSortMethod(SortByAlbum, sortAttribute, 558, LABEL_MASKS("%B - %T - %A", "%D"));  // Album, Title, Artist, Duration| empty, empty
+      AddSortMethod(SortByArtist, sortAttribute, 557, LABEL_MASKS("%A - %T", "%D"));  // Artist, Title, Duration| empty, empty
+      AddSortMethod(SortByArtistThenYear, sortAttribute, 578, LABEL_MASKS("%A(%Y) - %T", "%D"));  // Artist(year), Title, Duration| empty, empty
+      AddSortMethod(SortByTime, 180, LABEL_MASKS("%T - %A", "%D"));  // Titel, Artist, Duration| empty, empty
+      AddSortMethod(SortByYear, 562, LABEL_MASKS("%T - %A", "%Y")); // Title, Artist, Year
 
       SetSortMethod(SortByLabel);
     }
-    SetViewAsControl(DEFAULT_VIEW_LIST);
+    const CViewState *viewState = CViewStateSettings::GetInstance().Get("musicnavsongs");
+    SetViewAsControl(viewState->m_viewMode);
+    SetSortOrder(viewState->m_sortDescription.sortOrder);
 
     SetSortOrder(SortOrderAscending);
   }

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -287,6 +287,10 @@ bool CGUIWindowMusicNav::GetDirectory(const std::string &strDirectory, CFileItem
       OnRetrieveMusicInfo(items);
   }
 
+  //Navigating music files so default content to "songs" unless in sources folder.
+  //This content allows view type to include media info so that file tag data can be displayed
+  if (!URIUtils::IsSourcesPath(strDirectory))
+    items.SetContent("songs");
   // update our content in the info manager
   if (StringUtils::StartsWithNoCase(strDirectory, "videodb://") || items.IsVideoDb())
   {

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -690,7 +690,7 @@ bool CGUIMediaWindow::GetDirectory(const std::string &strDirectory, CFileItemLis
   // TODO: Do we want to limit the directories we apply the video ones to?
   if (iWindow == WINDOW_VIDEO_NAV)
     regexps = g_advancedSettings.m_videoExcludeFromListingRegExps;
-  if (iWindow == WINDOW_MUSIC_FILES)
+  if (iWindow == WINDOW_MUSIC_FILES || iWindow == WINDOW_MUSIC_NAV)
     regexps = g_advancedSettings.m_audioExcludeFromListingRegExps;
   if (iWindow == WINDOW_PICTURES)
     regexps = g_advancedSettings.m_pictureExcludeFromListingRegExps;


### PR DESCRIPTION
With changes of #8011 (unifying the music windows) the music file view was broken. The facility to display and sort by the tag data that is intrinsic to music files was inadvertantly lost.

See http://forum.kodi.tv/showthread.php?tid=235259&pid=2129282#pid2129282 for screen shots and discussion of this issue.  This change restores this functionality with some minor alterations.

a) Sorting and display of "Listeners" has been removed as this data has been deprecated.
b) Sort criteria include various music file tag data e.g. artist, title etc. as well as file name, size etc. that were not previously supported.

@notspiff thanks for the hints. @jjd_uk hope you are glad to see this back, on behalf of many others. @Montellese, @evilhamster please check over as this is a new area of Kodi for me. @Razzeee I hope this eases your "funny feeling" about listeners even if you don't like display of tag data in file view.
