### PR TITLE
Strip trailing newlines from URLs in NFO files for cURL 7.40+ compatibility

### DIFF
--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -2014,6 +2014,7 @@ namespace VIDEO
         scrUrl = m_nfoReader.ScraperUrl();
         info = m_nfoReader.GetScraperInfo();
 
+        StringUtils::RemoveCRLF(scrUrl.m_url[0].m_url);
         CLog::Log(LOGDEBUG, "VideoInfoScanner: Fetching url '%s' using %s scraper (content: '%s')",
           scrUrl.m_url[0].m_url.c_str(), info->Name().c_str(), TranslateContent(info->Content()).c_str());
 


### PR DESCRIPTION
Starting with version 7.40.0, cURL [rejects](https://github.com/bagder/curl/commit/178bd7db34f77e020fb8562890c5625ccbd67093) any URL containing `\r` and/or `\n` [for security reasons](http://curl.haxx.se/docs/adv_20150108B.html). If a movie scraper's URL regex is overly greedy (e.g. `http://www.filmweb.pl/.*`), it causes **everything** (including the newline) following the actual URL to be treated as a part of it and thus the scraper stops working when used with cURL 7.40+.

While it's the scrapers that should really be fixed, including a "safety net" in Kodi code will transparently fix broken scrapers and prevent enigmatic error messages (_URL using bad/illegal format or missing URL_) from popping up in the logs.

This pull request is a spin-off of #7343.
