### PR TITLE
[Readme]  Useful links, add bug tracker link

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ See [docs/README.xxx] (https://github.com/xbmc/xbmc/tree/master/docs) for specif
 ##### Useful links
 
 * [Kodi wiki] (http://kodi.wiki/)
+* [Kodi bug tracker] (http://trac.kodi.tv)
 * [Kodi community forums] (http://forum.kodi.tv/)
 * [Kodi website] (http://kodi.tv)
 


### PR DESCRIPTION
Any users seeing this readme, dont have to be confused about the place
where to post bug reports and have a link there here also.

Just adding bugtracker link to readme.

This is a lot of text for one link... TL/DR :smile:  :-1: 

---

xexe in forums (xe- in IRC) mentioned it and I agreed things can always
be clearer and this may not be the most idea solution as there's always a better way to do something.

For xexe/xe- (being a user like you here, I have to look at the project as a whole like seing a whole person not just a body part.)

Even though wiki is the main goto place (hence first link on useful links) that other links serve a dual purpose. Its a redirection facilitation mainly.

2) Not everyone looking, may need to goto central place like wiki and find their way from there, options are good and we are not overwhelming anyone.

1) All users types can see the project has specialized areas to deal with the specific topics, while also --to some level, provide a notion of the interaction/relationship between these places.

This is how I see these places:
Github is a place for development and contributing and following said development.
Wiki is a place where all related information is collated and organized.
Forums a place for discussion and reaching all manners of developers (not just Kodi but also associated projects) in the only interactive manner most users have. and also fill bug reports.
Trac a place to fill bugs for Kodi ONLY.
Main website is the face of the project and where you get first impressions and even get redirected to downloads and basic info.

So none are exclusive imo and all should be visible.
