### PR TITLE
[binary addons] improve bootstrap buildsystem to support arbitrary meta repositories

### DIFF
--- a/project/cmake/addons/bootstrap/CMakeLists.txt
+++ b/project/cmake/addons/bootstrap/CMakeLists.txt
@@ -20,10 +20,12 @@ get_filename_component(BUILD_DIR "${BUILD_DIR}" ABSOLUTE)
 
 # make sure that the repositories to build have been specified
 if(NOT REPOSITORY_TO_BUILD)
+  set(REPOSITORY_TO_BUILD_DEFAULT ON)
   set(REPOSITORY_TO_BUILD "all")
   set(REPOSITORY_REVISION "")
   message(STATUS "Bootstrapping all repositories")
 else()
+  set(REPOSITORY_TO_BUILD_DEFAULT OFF)
   message(STATUS "Bootstrapping following repository: ${REPOSITORY_TO_BUILD}")
 endif()
 
@@ -37,7 +39,25 @@ endif()
 
 include(ExternalProject)
 
+function(bootstrap_repo repo_id repo_url repo_revision)
+  message(STATUS "Bootstrapping addons from ${repo_id} (${repo_url} ${repo_revision})...")
+  externalproject_add(${repo_id}
+                      GIT_REPOSITORY ${repo_url}
+                      GIT_TAG ${repo_revision}
+                      PREFIX ${BUILD_DIR}/${repo_id}
+                      CONFIGURE_COMMAND ""
+                      BUILD_COMMAND ""
+                      INSTALL_COMMAND ${CMAKE_COMMAND}
+                                      -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}
+                                      -DPROJECT_SOURCE_DIR=<SOURCE_DIR>
+                                      -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+                                      -DADDONS_TO_BUILD=${ADDONS_TO_BUILD}
+                                      -P ${PROJECT_SOURCE_DIR}/bootstrap.cmake
+                      )
+endfunction()
+
 # look for all addons repository definitions
+set(REPOSITORY_TO_BUILD_FOUND OFF)
 file(GLOB repos repositories/*.txt)
 foreach(repo ${repos})
   file(STRINGS ${repo} repo_definition)
@@ -46,6 +66,8 @@ foreach(repo ${repos})
 
   list(FIND REPOSITORY_TO_BUILD ${repo_id} idx)
   if(idx GREATER -1 OR REPOSITORY_TO_BUILD STREQUAL "all")
+    set(REPOSITORY_TO_BUILD_FOUND ON)
+
     # get the URL of the repository
     list(GET repo_definition 1 repo_url)
 
@@ -56,20 +78,18 @@ foreach(repo ${repos})
       set(repo_revision "${REPOSITORY_REVISION}")
     endif()
 
-    message(STATUS "Bootstrapping addons from ${repo_id} (${repo_url} ${repo_revision})...")
-    externalproject_add(${repo_id}
-                        GIT_REPOSITORY ${repo_url}
-                        GIT_TAG ${repo_revision}
-                        PREFIX ${BUILD_DIR}/${repo_id}
-                        CONFIGURE_COMMAND ""
-                        BUILD_COMMAND ""
-                        INSTALL_COMMAND ${CMAKE_COMMAND}
-                                        -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}
-                                        -DPROJECT_SOURCE_DIR=<SOURCE_DIR>
-                                        -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
-                                        -DADDONS_TO_BUILD=${ADDONS_TO_BUILD}
-                                        -P ${PROJECT_SOURCE_DIR}/bootstrap.cmake
-                        )
-    
+    bootstrap_repo(${repo_id} ${repo_url} ${repo_revision})
   endif()
 endforeach()
+
+# if we have been asked to bootstrap a specific repository (not the default one) and
+# it couldn't be found in the predefined repository definitions we assume that it's a
+# URL to a specific repository
+if(NOT REPOSITORY_TO_BUILD_DEFAULT AND NOT REPOSITORY_TO_BUILD_FOUND)
+  # default to the master branch if no revision has been provided
+  if(NOT REPOSITORY_REVISION)
+    set(REPOSITORY_REVISION "master")
+  endif()
+
+  bootstrap_repo(binary-addons-custom ${REPOSITORY_TO_BUILD} ${REPOSITORY_REVISION})
+endif()

--- a/project/cmake/addons/depends/common/kodi-platform/deps.txt
+++ b/project/cmake/addons/depends/common/kodi-platform/deps.txt
@@ -1,3 +1,2 @@
-kodi
 tinyxml
 platform

--- a/project/cmake/scripts/common/addon-helpers.cmake
+++ b/project/cmake/scripts/common/addon-helpers.cmake
@@ -15,9 +15,8 @@ macro(add_cpack_workaround target version ext)
   endif()
 
   add_custom_command(TARGET addon-package PRE_BUILD
-                     COMMAND ${CMAKE_COMMAND} -E rename ${CMAKE_BINARY_DIR}/addon-${target}-${version}.${ext} ${CMAKE_BINARY_DIR}/${target}-${version}.${ext}
                      COMMAND ${CMAKE_COMMAND} -E make_directory ${PACKAGE_DIR}
-                     COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/${target}-${version}.${ext} ${PACKAGE_DIR})
+                     COMMAND ${CMAKE_COMMAND} -E copy ${CPACK_PACKAGE_DIRECTORY}/addon-${target}-${version}.${ext} ${PACKAGE_DIR}/${target}-${version}.${ext})
 endmacro()
 
 # Grab the version from a given add-on's addon.xml

--- a/project/cmake/scripts/common/addon-helpers.cmake
+++ b/project/cmake/scripts/common/addon-helpers.cmake
@@ -82,6 +82,19 @@ macro (build_addon target prefix libs)
     # Pack files together to create an archive
     INSTALL(DIRECTORY ${target} DESTINATION ./ COMPONENT ${target}-${${prefix}_VERSION} PATTERN "addon.xml.in" EXCLUDE)
     IF(WIN32)
+      if(NOT CPACK_PACKAGE_DIRECTORY)
+        # determine the temporary path
+        file(TO_CMAKE_PATH "$ENV{TEMP}" WIN32_TEMP_PATH)
+        string(LENGTH "${WIN32_TEMP_PATH}" WIN32_TEMP_PATH_LENGTH)
+        string(LENGTH "${PROJECT_BINARY_DIR}" PROJECT_BINARY_DIR_LENGTH)
+
+        # check if the temporary path is shorter than the default packaging directory path
+        if(WIN32_TEMP_PATH_LENGTH GREATER 0 AND WIN32_TEMP_PATH_LENGTH LESS PROJECT_BINARY_DIR_LENGTH)
+          # set the directory used by CPack for packaging to the temp directory
+          set(CPACK_PACKAGE_DIRECTORY ${WIN32_TEMP_PATH})
+        endif()
+      endif()
+
       # in case of a VC++ project the installation location contains a $(Configuration) VS variable
       # we replace it with ${CMAKE_BUILD_TYPE} (which doesn't cover the case when the build configuration
       # is changed within Visual Studio)

--- a/tools/buildsteps/win32/bootstrap-addons.bat
+++ b/tools/buildsteps/win32/bootstrap-addons.bat
@@ -42,11 +42,13 @@ SET ADDONS_DEFINITION_PATH=%ADDONS_PATH%\addons
 IF %clean% == true (
   rem remove the build directory if it exists
   IF EXIST "%BOOTSTRAP_BUILD_PATH%" (
+    ECHO Cleaning build directory...
     RMDIR "%BOOTSTRAP_BUILD_PATH%" /S /Q > NUL
   )
 
   rem clean the addons definition path if it exists
   IF EXIST "%ADDONS_DEFINITION_PATH%" (
+    ECHO Cleaning bootstrapped addons...
     RMDIR "%ADDONS_DEFINITION_PATH%" /S /Q > NUL
   )
 

--- a/tools/buildsteps/win32/bootstrap-addons.bat
+++ b/tools/buildsteps/win32/bootstrap-addons.bat
@@ -23,7 +23,12 @@ call "%VS120COMNTOOLS%..\..\VC\bin\vcvars32.bat"
 SET WORKDIR=%WORKSPACE%
 
 IF "%WORKDIR%" == "" (
-  SET WORKDIR=%CD%\..\..\..
+  rem resolve the relative path
+  SETLOCAL EnableDelayedExpansion
+  PUSHD ..\..\..
+  SET WORKDIR=!CD!
+  POPD
+  SETLOCAL DisableDelayedExpansion
 )
 
 rem setup some paths that we need later

--- a/tools/buildsteps/win32/make-addons.bat
+++ b/tools/buildsteps/win32/make-addons.bat
@@ -58,11 +58,13 @@ DEL /F %ADDONS_FAILURE_FILE% > NUL 2>&1
 IF %clean% == true (
   rem remove the build directory if it exists
   IF EXIST "%ADDONS_BUILD_PATH%" (
+    ECHO Cleaning build directory...
     RMDIR "%ADDONS_BUILD_PATH%" /S /Q > NUL
   )
 
   rem remove the build directory if it exists
   IF EXIST "%ADDON_DEPENDS_PATH%" (
+    ECHO Cleaning dependencies...
     RMDIR "%ADDON_DEPENDS_PATH%" /S /Q > NUL
   )
 

--- a/tools/buildsteps/win32/make-addons.bat
+++ b/tools/buildsteps/win32/make-addons.bat
@@ -29,7 +29,12 @@ call "%VS120COMNTOOLS%..\..\VC\bin\vcvars32.bat"
 SET WORKDIR=%WORKSPACE%
 
 IF "%WORKDIR%" == "" (
-  SET WORKDIR=%CD%\..\..\..
+  rem resolve the relative path
+  SETLOCAL EnableDelayedExpansion
+  PUSHD ..\..\..
+  SET WORKDIR=!CD!
+  POPD
+  SETLOCAL DisableDelayedExpansion
 )
 
 rem setup some paths that we need later


### PR DESCRIPTION
Right now the binary addons bootstrap buildsystem only supports bootstrapping addons from a meta repository that is defined in `project/cmake/addons/bootstrap/repositories/` using the name of the definition file (right now only `binary-addons`). But to be able to test unmerged addon updates we need to be able to bootstrap from arbitrary meta repositories. Therefore I've added the logic that if the specified meta repository (through the `REPOSITORY_TO_BUILD` parameter) is not found in the list of pre-defined meta repositories it is considered an external meta repository and handled like an URL to the git repository.

This is a necessary step for the jenkins integration of binary addons and their repositories.
