### PR TITLE
only pause jobs on foreground playback

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3534,15 +3534,6 @@ PlayBackRet CApplication::PlayFile(const CFileItem& item, bool bRestart)
   PlayBackRet iResult;
   if (m_pPlayer->HasPlayer())
   {
-    /* When playing video pause any low priority jobs, they will be unpaused  when playback stops.
-     * This should speed up player startup for files on internet filesystems (eg. webdav) and
-     * increase performance on low powered systems (Atom/ARM).
-     */
-    if (item.IsVideo())
-    {
-      CJobManager::GetInstance().PauseJobs();
-    }
-
     // don't hold graphicscontext here since player
     // may wait on another thread, that requires gfx
     CSingleExit ex(g_graphicsContext);
@@ -4611,7 +4602,7 @@ void CApplication::ProcessSlow()
 
   // Temporarely pause pausable jobs when viewing video/picture
   int currentWindow = g_windowManager.GetActiveWindow();
-  if (CurrentFileItem().IsVideo() || CurrentFileItem().IsPicture() || currentWindow == WINDOW_FULLSCREEN_VIDEO || currentWindow == WINDOW_SLIDESHOW)
+  if (m_bPlaybackStarting || currentWindow == WINDOW_FULLSCREEN_VIDEO || currentWindow == WINDOW_SLIDESHOW)
   {
     CJobManager::GetInstance().PauseJobs();
   }


### PR DESCRIPTION
Currently ThumbLoader, PictureThumbLoader and TextureCache are paused, i.e no thumbs are extracted and shown when playing video/pictures in the background. If you ask me it makes no sense to pause these things as long as the foreground action is navigating the ui and background action is playing, so this changes it to only pause when in fullscreen. This would also fix a regression introduced by #8131.
