### PR TITLE
FFmpeg: Bump to 2.8.1-Jarvis-alpha4-HEVC

### DIFF
--- a/tools/depends/target/ffmpeg/FFMPEG-VERSION
+++ b/tools/depends/target/ffmpeg/FFMPEG-VERSION
@@ -1,5 +1,5 @@
 LIBNAME=ffmpeg
 BASE_URL=https://github.com/xbmc/FFmpeg/archive
-VERSION=2.8.0-Jarvis-alpha3-HEVC
+VERSION=2.8.1-Jarvis-alpha4-HEVC
 ARCHIVE=$(LIBNAME)-$(VERSION).tar.gz
 


### PR DESCRIPTION
Rebase on ffmpeg upstream 2.8.1.

One patch was dropped as it was cherry-picked from upstream before.
