### PR TITLE
[PVR] Some context menu cleanup

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -9526,13 +9526,7 @@ msgctxt "#19254"
 msgid "Guide update failed for channel"
 msgstr ""
 
-msgctxt "#19255"
-msgid "Start recording"
-msgstr ""
-
-msgctxt "#19256"
-msgid "Stop recording"
-msgstr ""
+#empty strings from id 19255 to 19256
 
 msgctxt "#19257"
 msgid "Lock channel"

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -1164,6 +1164,11 @@ msgctxt "#263"
 msgid "Allow remote control via HTTP"
 msgstr ""
 
+#. Label of a context menu entry to start/schedule a recording
+#: xbmc/music/windows/GUIWindowMusicBase.cpp
+#: xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
+#: xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+#: xbmc/pvr/windows/GUIWindowPVRSearch.cpp
 msgctxt "#264"
 msgid "Record"
 msgstr ""
@@ -3603,12 +3608,7 @@ msgctxt "#840"
 msgid "Do you only want to delete this timer or also the repeating timer that has scheduled it?"
 msgstr ""
 
-#. Label of a context menu entry to create a new recording timer with advanced configuration options
-#: xbmc/pvr/windows/GUIWindowPVRGuide.cpp
-#: xbmc/pvr/windows/GUIWindowPVRSearch.cpp
-msgctxt "#841"
-msgid "Add custom timer"
-msgstr ""
+#empty string with id 841
 
 #. Label of the option to switch between hierarchical and flat timer view (in confluence sideblade).
 #: skin.confluence
@@ -8655,6 +8655,9 @@ msgctxt "#19060"
 msgid "Delete timer"
 msgstr ""
 
+#. Label of a context menu entry to open the timer settings dialog
+#: xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+#: xbmc/pvr/windows/GUIWindowPVRSearch.cpp
 msgctxt "#19061"
 msgid "Add timer"
 msgstr ""

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
@@ -245,10 +245,7 @@ void CGUIDialogPVRGuideInfo::OnInitWindow()
   if (!match || !match->HasPVRTimerInfoTag())
   {
     /* no timer present on this tag */
-    if (tag->StartAsLocalTime() < CDateTime::GetCurrentDateTime())
-      SET_CONTROL_LABEL(CONTROL_BTN_RECORD, 264);    // Record
-    else
-      SET_CONTROL_LABEL(CONTROL_BTN_RECORD, 19061);  // Add timer
+    SET_CONTROL_LABEL(CONTROL_BTN_RECORD, 264);      // Record
   }
   else
   {

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -82,7 +82,7 @@ void CGUIWindowPVRChannels::GetContextButtons(int itemNumber, CContextButtons &b
 
   buttons.Add(CONTEXT_BUTTON_INFO, 19047);                                          /* channel info */
   buttons.Add(CONTEXT_BUTTON_FIND, 19003);                                          /* find similar program */
-  buttons.Add(CONTEXT_BUTTON_RECORD_ITEM, channel->IsRecording() ? 19256 : 19255);  /* start/stop recording on channel */
+  buttons.Add(CONTEXT_BUTTON_RECORD_ITEM, !channel->IsRecording() ? 264 : 19059);   /* record / stop recording */
 
   if (g_PVRClients->HasMenuHooks(pItem->GetPVRChannelInfoTag()->ClientID(), PVR_MENUHOOK_CHANNEL))
     buttons.Add(CONTEXT_BUTTON_MENU_HOOKS, 19195);                                  /* PVR client specific action */

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -98,11 +98,8 @@ void CGUIWindowPVRGuide::GetContextButtons(int itemNumber, CContextButtons &butt
   }
   else if (pItem->HasEPGInfoTag() && pItem->GetEPGInfoTag()->EndAsLocalTime() > CDateTime::GetCurrentDateTime())
   {
-    if (pItem->GetEPGInfoTag()->StartAsLocalTime() < CDateTime::GetCurrentDateTime())
-      buttons.Add(CONTEXT_BUTTON_START_RECORD, 264);   /* record */
-
-    buttons.Add(CONTEXT_BUTTON_START_RECORD, 19061);   /* add timer */
-    buttons.Add(CONTEXT_BUTTON_ADVANCED_RECORD, 841);  /* add custom timer */
+    buttons.Add(CONTEXT_BUTTON_START_RECORD, 264);      /* record */
+    buttons.Add(CONTEXT_BUTTON_ADVANCED_RECORD, 19061); /* add timer */
   }
 
   buttons.Add(CONTEXT_BUTTON_INFO, 19047);              /* epg info */

--- a/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
@@ -54,11 +54,8 @@ void CGUIWindowPVRSearch::GetContextButtons(int itemNumber, CContextButtons &but
     {
       if (!pItem->GetEPGInfoTag()->HasTimer())
       {
-        if (pItem->GetEPGInfoTag()->StartAsLocalTime() < CDateTime::GetCurrentDateTime())
-          buttons.Add(CONTEXT_BUTTON_START_RECORD, 264);   /* record */
-
-        buttons.Add(CONTEXT_BUTTON_START_RECORD, 19061);   /* add timer */
-        buttons.Add(CONTEXT_BUTTON_ADVANCED_RECORD, 841);  /* add custom timer */
+        buttons.Add(CONTEXT_BUTTON_START_RECORD, 264);      /* record */
+        buttons.Add(CONTEXT_BUTTON_ADVANCED_RECORD, 19061); /* add timer */
       }
       else
       {

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -1548,7 +1548,8 @@ void CGUIMediaWindow::GetContextButtons(int itemNumber, CContextButtons &buttons
   // TODO: FAVOURITES Conditions on masterlock and localisation
   if (!item->IsParentFolder() && !item->IsPath("add") && !item->IsPath("newplaylist://") &&
       !URIUtils::IsProtocol(item->GetPath(), "newsmartplaylist") && !URIUtils::IsProtocol(item->GetPath(), "newtag") &&
-      !URIUtils::PathStarts(item->GetPath(), "addons://more/") && !URIUtils::IsProtocol(item->GetPath(), "musicsearch"))
+      !URIUtils::PathStarts(item->GetPath(), "addons://more/") && !URIUtils::IsProtocol(item->GetPath(), "musicsearch") &&
+      !URIUtils::PathStarts(item->GetPath(), "pvr://guide/") && !URIUtils::PathStarts(item->GetPath(), "pvr://timers/"))
   {
     if (XFILE::CFavouritesDirectory::IsFavourite(item.get(), GetID()))
       buttons.Add(CONTEXT_BUTTON_ADD_FAVOURITE, 14077);     // Remove Favourite


### PR DESCRIPTION
1st commit
- as discussed at DevCon, "Add timer" everywhere was renamed to "Record", "Add custom timer" to just "Add timer". Functionality behind is unchanged. "Record will schedule a one-time epg-based timer that will fire instantly or later, dependent on the start time of the selected epg-event. "Add timer" will open the timer settings dialog with a recurring epg-based timer preselected for creation.

![screenshot004](https://cloud.githubusercontent.com/assets/3226626/10467551/b1d5beca-71fa-11e5-901e-e788e723898e.png)

2nd commit
- cleanup record/stop recording to use always the same string resources, eliminating duplicates we had so far.

@da-anda, @kib  good to go?
