### PR TITLE
[pvr] fix playback of recordings when an exact duplicate exists.

### DIFF
--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -428,10 +428,10 @@ void CPVRRecording::UpdatePath(void)
     if (!strSeasonEpisode.empty())
       strSeasonEpisode = StringUtils::Format(" %s", strSeasonEpisode.c_str());
 
-    m_strFileNameAndPath = StringUtils::Format("pvr://" PVR_RECORDING_BASE_PATH "/%s/%s%s%s%s%s, TV%s, %s.pvr",
+    m_strFileNameAndPath = StringUtils::Format("pvr://" PVR_RECORDING_BASE_PATH "/%s/%s%s%s%s%s%s, TV%s, %s.pvr",
       m_bIsDeleted ? PVR_RECORDING_DELETED_PATH : PVR_RECORDING_ACTIVE_PATH, strDirectory.c_str(),
       strTitle.c_str(), strSeasonEpisode.c_str(), strYear.c_str(), strSubtitle.c_str(),
-      strChannel.c_str(), strDatetime.c_str());
+      strChannel.c_str(), strDatetime.c_str(), m_strRecordingId.c_str());
   }
 }
 


### PR DESCRIPTION
This happens if one for some reason records a show twice, stopping
in between (which creates two separate recordings).

@ksooo should we backport this? The issue is relatively rare but it inevitable prevents playback of any duplicate recordings.
