### PR TITLE
Keyboard layout: Czech QWERTZ

### DIFF
--- a/system/keyboardlayouts/czech.xml
+++ b/system/keyboardlayouts/czech.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+Please use English language names instead.
+Default font lacks support for all characters
+-->
+<keyboardlayouts>
+  <layout language="Czech" layout="QWERTZ">
+    <keyboard>
+      <row>ťěščřžýáíéó(</row>
+      <row>qwertzuiopú)</row>
+      <row>asdfghjklůď_</row>
+      <row>/yxcvbnmň:.-</row>
+    </keyboard>
+    <keyboard modifiers="shift">
+      <row>ŤĚŠČŘŽÝÁÍÉÓ(</row>
+      <row>QWERTZUIOPÚ)</row>
+      <row>ASDFGHJKLŮĎ_</row>
+      <row>\YXCVBNMŇ:.-</row>
+    </keyboard>
+    <keyboard modifiers="symbol,shift+symbol">
+      <row>1234567890%</row>
+      <row>+@#$~^&amp;*{}=</row>
+      <row>[]()/"'`;!</row>
+      <row>\|&lt;&gt;,.?:-_</row>
+    </keyboard>
+  </layout>
+</keyboardlayouts>


### PR DESCRIPTION
Hello,

I've added a keyboard layout for Czech language which, I believe, makes the best effort (or is very close to) at allocating keys. There are many ways to do this because:
- Some of the special czech characters share keys with other characters (SK)
- Some of the special czech characters are typed using a combination of keys (CK).

I devised several layouts but eventually, I only decided for one that:
- Tries to position characters just as they would appear on a genuine mainstream czech keyboard (or as close to the positions as possible).
- Tries to position CK characters close to their base letters.
- Has a specially formed layout with the `symbol` modifier because of numbers.

Preview:

| 01 | 02 | 03 | 04 | 05 | 06 | 07 | 08 | 09 | 10 | 11 | 12 |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Ť | Ě | Š | Č | Ř | Ž | Ý | Á | Í | É | Ó | ( |
| Q | W | E | R | T | Z | U | I | O | P | Ú | ) |
| A | S | D | F | G | H | J | K | L | Ů | Ď | _ |
| / | Y | X | C | V | B | N | M | Ň | : | . | - |

Notes:
- Successfully tested with `Kodi v15.1 “Isengard”` on Mac OS X.
