### PR TITLE
[Confluence] Add 'Events' to Home screen's 'System' submenu.

### DIFF
--- a/addons/skin.confluence/720p/IncludesHomeMenuItems.xml
+++ b/addons/skin.confluence/720p/IncludesHomeMenuItems.xml
@@ -198,7 +198,13 @@
 			<label>130</label>
 			<onclick>ActivateWindow(SystemInfo)</onclick>
 		</control>
-		<control type="image" id="90126">
+		<control type="button" id="90126">
+			<include>ButtonHomeSubCommonValues</include>
+			<label>14111</label>
+			<onclick>ActivateWindow(EventLog,events://,return)</onclick>
+			<visible>system.getbool(eventlog.enabled)</visible>
+		</control>
+		<control type="image" id="90127">
 			<width>35</width>
 			<height>35</height>
 			<texture border="0,0,0,3">HomeSubEnd.png</texture>


### PR DESCRIPTION
As discussed at DevCon, this adds an entry 'Events' to Confluence home screen, 'System' submenu. The new entry is only visible, if "Settings->System->Logging->Enable event logging" is checked. When the new entry gets selected, the event log window opens, like if started directly from "Settings->System->Logging->Show event log"

![screenshot003](https://cloud.githubusercontent.com/assets/3226626/10494565/420bfa74-72b7-11e5-9e19-295f39d70a86.png)

@ronie, @Montellese mind taking a look.
