### PR TITLE
Fix two crash-and-burns

### DIFF
--- a/xbmc/addons/AddonCallbacksAddon.cpp
+++ b/xbmc/addons/AddonCallbacksAddon.cpp
@@ -210,13 +210,12 @@ bool CAddonCallbacksAddon::GetAddonSetting(void *addonData, const char *strSetti
               type == "folder"   || type == "action"    ||
               type == "music"    || type == "pictures"  ||
               type == "programs" || type == "fileenum"  ||
-              type == "file")
+              type == "file"     || type == "labelenum")
           {
             strcpy((char*) settingValue, addonHelper->m_addon->GetSetting(id).c_str());
             return true;
           }
-          else if (type == "number" || type == "enum" ||
-                   type == "labelenum")
+          else if (type == "number" || type == "enum")
           {
             *(int*) settingValue = (int) atoi(addonHelper->m_addon->GetSetting(id).c_str());
             return true;

--- a/xbmc/cores/DllLoader/Win32DllLoader.cpp
+++ b/xbmc/cores/DllLoader/Win32DllLoader.cpp
@@ -31,6 +31,8 @@
 #include "exports/emu_kernel32.h"
 #include "exports/emu_msvcrt.h"
 
+#include <limits>
+
 extern "C" FILE _iob[];
 extern "C" FARPROC WINAPI dllWin32GetProcAddress(HMODULE hModule, LPCSTR function);
 
@@ -424,10 +426,14 @@ bool Win32DllLoader::ResolveOrdinal(const char *dllName, unsigned long ordinal, 
 
 extern "C" FARPROC __stdcall dllWin32GetProcAddress(HMODULE hModule, LPCSTR function)
 {
-  // first check whether this function is one of the ones we need to wrap
-  void *fixup = NULL;
-  if (FunctionNeedsWrapping(win32_exports, function, &fixup))
-    return (FARPROC)fixup;
+  // if the high-order word is zero, then lpProcName is the function's ordinal value
+  if (reinterpret_cast<uintptr_t>(function) > std::numeric_limits<WORD>::max())
+  {
+    // first check whether this function is one of the ones we need to wrap
+    void *fixup = NULL;
+    if (FunctionNeedsWrapping(win32_exports, function, &fixup))
+      return (FARPROC)fixup;
+  }
 
   // Nope
   return GetProcAddress(hModule, function);

--- a/xbmc/filesystem/ZipManager.cpp
+++ b/xbmc/filesystem/ZipManager.cpp
@@ -100,6 +100,11 @@ bool CZipManager::GetZipList(const CURL& url, std::vector<SZipEntry>& items)
   // Don't need to look in the last 18 bytes (ECDREC_SIZE-4)
   // But as we need to do overlapping between blocks (3 bytes),
   // we start the search at ECDREC_SIZE-1 from the end of file
+  if (fileSize < ECDREC_SIZE - 1)
+  {
+    CLog::Log(LOGERROR, "ZipManager: Invalid zip file length: %lld", fileSize);
+    return false;
+  }
   int searchSize = (int) std::min(static_cast<int64_t>(65557), fileSize-ECDREC_SIZE+1);
   int blockSize = (int) std::min(1024, searchSize);
   int nbBlock = searchSize / blockSize;


### PR DESCRIPTION
Here's two fixes that i've been carrying for a while in my retroplayer branch

Isengard doesn't require the [dllLoader] fix, because this feature (using a function's ordinal value) isn't used.

EDIT: Added a third fix, `[addonlib]` (maybe not a crash-and-burn, but an unsafe cast is performed later)
