### PR TITLE
[guilib] add ability to visualize control hitrects

### DIFF
--- a/xbmc/guilib/GUIButtonControl.cpp
+++ b/xbmc/guilib/GUIButtonControl.cpp
@@ -155,7 +155,7 @@ void CGUIButtonControl::ProcessText(unsigned int currentTime)
   if (m_minWidth && m_width != renderWidth)
   {
     CRect rect(m_posX, m_posY, renderWidth, m_height);
-    SetHitRect(rect);
+    SetHitRect(rect, m_hitColor);
   }
 
   // render the second label if it exists

--- a/xbmc/guilib/GUIControl.cpp
+++ b/xbmc/guilib/GUIControl.cpp
@@ -24,6 +24,7 @@
 #include "utils/log.h"
 #include "GUIWindowManager.h"
 #include "GUIControlProfiler.h"
+#include "GUITexture.h"
 #include "input/MouseStat.h"
 #include "input/InputManager.h"
 #include "input/Key.h"
@@ -185,7 +186,15 @@ void CGUIControl::DoRender()
       g_graphicsContext.SetStereoFactor(m_stereo);
 
     GUIPROFILER_RENDER_BEGIN(this);
+
+    if (m_hitColor != 0xFFFFFFFF)
+    {
+      color_t color = g_graphicsContext.MergeAlpha(m_hitColor);
+      CGUITexture::DrawQuad(g_graphicsContext.generateAABB(m_hitRect), color);
+    }
+
     Render();
+
     GUIPROFILER_RENDER_END(this);
 
     if (hasStereo)
@@ -908,9 +917,10 @@ void CGUIControl::SaveStates(std::vector<CControlState> &states)
   // empty for now - do nothing with the majority of controls
 }
 
-void CGUIControl::SetHitRect(const CRect &rect)
+void CGUIControl::SetHitRect(const CRect &rect, const CGUIInfoColor &color)
 {
   m_hitRect = rect;
+  m_hitColor = color;
 }
 
 void CGUIControl::SetCamera(const CPoint &camera)

--- a/xbmc/guilib/GUIControl.h
+++ b/xbmc/guilib/GUIControl.h
@@ -163,7 +163,7 @@ public:
   bool IsVisibleFromSkin() const { return m_visibleFromSkinCondition; };
   virtual bool IsDisabled() const;
   virtual void SetPosition(float posX, float posY);
-  virtual void SetHitRect(const CRect &rect);
+  virtual void SetHitRect(const CRect &rect, const CGUIInfoColor &color);
   virtual void SetCamera(const CPoint &camera);
   virtual void SetStereoFactor(const float &factor);
   bool SetColorDiffuse(const CGUIInfoColor &color);
@@ -326,6 +326,7 @@ protected:
   float m_height;
   float m_width;
   CRect m_hitRect;
+  CGUIInfoColor m_hitColor;
   CGUIInfoColor m_diffuseColor;
   int m_controlID;
   int m_parentID;

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -760,6 +760,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   CLabelInfo labelInfo;
   CLabelInfo spinInfo;
 
+  CGUIInfoColor hitColor(0xFFFFFFFF);
   CGUIInfoColor textColor3;
   CGUIInfoColor headlineColor;
 
@@ -821,6 +822,8 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
 
   hitRect.SetRect(posX, posY, posX + width, posY + height);
   GetHitRect(pControlNode, hitRect);
+
+  GetInfoColor(pControlNode, "hitrectcolor", hitColor, parentID);
 
   GetActions(pControlNode, "onup",    actions[ACTION_MOVE_UP]);
   GetActions(pControlNode, "ondown",  actions[ACTION_MOVE_DOWN]);
@@ -1485,7 +1488,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   // things that apply to all controls
   if (control)
   {
-    control->SetHitRect(hitRect);
+    control->SetHitRect(hitRect, hitColor);
     control->SetVisibleCondition(visibleCondition, allowHiddenFocus);
     control->SetEnableCondition(enableCondition);
     control->SetAnimations(animations);


### PR DESCRIPTION
This adds the ability to visualize hitrects for controls. When visible and there's a <hitrectcolor> tag, it will paint a colored rectangle over the actual control. Colors can be specified in AARRGGBB format or with a name from the color theme.

Example: `<hitrectcolor>4033FF99</hitrectcolor>` added to a scrollbar control ..

![screenshot000](https://cloud.githubusercontent.com/assets/475281/10525588/d2e11d58-7385-11e5-88bf-de39b868e737.png)

/cc @BigNoid, @HitcherUK, @phil65, @ronie, @vonH 
