### PR TITLE
[PVR] Fix search window init regression

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
@@ -156,7 +156,6 @@ void CGUIWindowPVRSearch::OnPrepareFileItems(CFileItemList &items)
   {
     m_bSearchConfirmed = false;
 
-    items.Clear();
     bAddSpecialSearchItem = true;
 
     CGUIDialogProgress* dlgProgress = (CGUIDialogProgress*)g_windowManager.GetWindow(WINDOW_DIALOG_PROGRESS);


### PR DESCRIPTION
Fix PVR search window init regression introduced by https://github.com/xbmc/xbmc/commit/b8d1957211f59f8f32bcb8a0317d832df43cfbda 
No search results at all were displayed after this. :-(
