### PR TITLE
remove skin backward compatibility

### DIFF
--- a/addons/xbmc.gui/addon.xml
+++ b/addons/xbmc.gui/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="xbmc.gui" version="5.10.0" provider-name="Team-Kodi">
-  <backwards-compatibility abi="5.9.0"/>
+  <backwards-compatibility abi="5.10.0"/>
   <requires>
     <import addon="xbmc.core" version="0.1.0"/>
   </requires>


### PR DESCRIPTION
there's been too many changes in jarvis (new / removed / merged windows / etc..) to be compatible with isengard skins anymore.

i'd like to merge this at the start of the first beta window.
