### PR TITLE
[texture] redact username/password when texture loading fails

### DIFF
--- a/xbmc/guilib/Texture.cpp
+++ b/xbmc/guilib/Texture.cpp
@@ -274,7 +274,7 @@ bool CBaseTexture::LoadFromFileInternal(const std::string& texturePath, unsigned
     pImage = ImageFactory::CreateFallbackLoader(texturePath);
     if (!LoadIImage(pImage, (unsigned char *)buf.get(), buf.size(), width, height))
     {
-      CLog::Log(LOGDEBUG, "%s - Load of %s failed.", __FUNCTION__, texturePath.c_str());
+      CLog::Log(LOGDEBUG, "%s - Load of %s failed.", __FUNCTION__, CURL::GetRedacted(texturePath).c_str());
       delete pImage;
       return false;
     }


### PR DESCRIPTION
Ensure we're not logging username/password in case the texture loading fails. Happens eg. when loading channel unavailable logos from tvh and most likely others.
