### PR TITLE
[PVR] EpgContainer: use shared_ptr to manage CEpg pointers

### DIFF
--- a/xbmc/epg/Epg.h
+++ b/xbmc/epg/Epg.h
@@ -27,6 +27,8 @@
 #include "EpgInfoTag.h"
 #include "EpgSearchFilter.h"
 
+#include <memory>
+
 namespace PVR
 {
   class CPVRChannel;
@@ -35,7 +37,9 @@ namespace PVR
 /** EPG container for CEpgInfoTag instances */
 namespace EPG
 {
-  typedef std::map<unsigned int, CEpg*> EPGMAP;
+  class CEpg;
+  typedef std::shared_ptr<CEpg> CEpgPtr;
+  typedef std::map<unsigned int, CEpgPtr> EPGMAP;
 
   class CEpg : public Observable
   {

--- a/xbmc/epg/EpgContainer.h
+++ b/xbmc/epg/EpgContainer.h
@@ -123,7 +123,7 @@ namespace EPG
 
     virtual void OnSettingChanged(const CSetting *setting) override;
 
-    CEpg *CreateChannelEpg(PVR::CPVRChannelPtr channel);
+    CEpgPtr CreateChannelEpg(PVR::CPVRChannelPtr channel);
 
     /*!
      * @brief Get all EPG tables and apply a filter.
@@ -157,7 +157,7 @@ namespace EPG
      * @param iEpgId The database ID of the table.
      * @return The table or NULL if it wasn't found.
      */
-    virtual CEpg *GetById(int iEpgId) const;
+    virtual CEpgPtr GetById(int iEpgId) const;
 
     /*!
      * @brief Get the EPG event with the given event id
@@ -171,7 +171,7 @@ namespace EPG
      * @param channel The channel to get the EPG table for.
      * @return The table or NULL if it wasn't found.
      */
-    virtual CEpg *GetByChannel(const PVR::CPVRChannel &channel) const;
+    virtual CEpgPtr GetByChannel(const PVR::CPVRChannel &channel) const;
 
     /*!
      * @brief Notify EPG table observers when the currently active tag changed.

--- a/xbmc/epg/EpgDatabase.h
+++ b/xbmc/epg/EpgDatabase.h
@@ -20,6 +20,7 @@
  */
 
 #include <map>
+#include <memory>
 
 #include "XBDateTime.h"
 #include "dbwrappers/Database.h"
@@ -29,6 +30,7 @@
 namespace EPG
 {
   class CEpg;
+  typedef std::shared_ptr<CEpg> CEpgPtr;
   class CEpgInfoTag;
   class CEpgContainer;
 

--- a/xbmc/interfaces/json-rpc/PVROperations.cpp
+++ b/xbmc/interfaces/json-rpc/PVROperations.cpp
@@ -163,8 +163,8 @@ JSONRPC_STATUS CPVROperations::GetBroadcasts(const std::string &method, ITranspo
   if (channel == NULL)
     return InvalidParams;
 
-  CEpg *channelEpg = channel->GetEPG();
-  if (channelEpg == NULL)
+  CEpgPtr channelEpg = channel->GetEPG();
+  if (!channelEpg)
     return InternalError;
 
   CFileItemList programFull;

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -148,7 +148,7 @@ bool CPVRChannel::Delete(void)
     return bReturn;
 
   /* delete the EPG table */
-  CEpg *epg = GetEPG();
+  CEpgPtr epg = GetEPG();
   if (epg)
   {
     CPVRChannelPtr empty;
@@ -162,7 +162,7 @@ bool CPVRChannel::Delete(void)
   return bReturn;
 }
 
-CEpg *CPVRChannel::GetEPG(void) const
+CEpgPtr CPVRChannel::GetEPG(void) const
 {
   int iEpgId(-1);
   {
@@ -543,7 +543,7 @@ void CPVRChannel::UpdateEncryptionName(void)
 
 int CPVRChannel::GetEPG(CFileItemList &results) const
 {
-  CEpg *epg = GetEPG();
+  CEpgPtr epg = GetEPG();
   if (!epg)
   {
     CLog::Log(LOGDEBUG, "PVR - %s - cannot get EPG for channel '%s'",
@@ -556,7 +556,7 @@ int CPVRChannel::GetEPG(CFileItemList &results) const
 
 bool CPVRChannel::ClearEPG() const
 {
-  CEpg *epg = GetEPG();
+  CEpgPtr epg = GetEPG();
   if (epg)
     epg->Clear();
 
@@ -565,7 +565,7 @@ bool CPVRChannel::ClearEPG() const
 
 CEpgInfoTagPtr CPVRChannel::GetEPGNow() const
 {
-  CEpg *epg = GetEPG();
+  CEpgPtr epg = GetEPG();
   if (epg)
     return epg->GetTagNow();
 
@@ -575,7 +575,7 @@ CEpgInfoTagPtr CPVRChannel::GetEPGNow() const
 
 CEpgInfoTagPtr CPVRChannel::GetEPGNext() const
 {
-  CEpg *epg = GetEPG();
+  CEpgPtr epg = GetEPG();
   if (epg)
     return epg->GetTagNext();
 

--- a/xbmc/pvr/channels/PVRChannel.h
+++ b/xbmc/pvr/channels/PVRChannel.h
@@ -35,6 +35,7 @@ class CVariant;
 namespace EPG
 {
   class CEpg;
+  typedef std::shared_ptr<CEpg> CEpgPtr;
   class CEpgInfoTag;
   typedef std::shared_ptr<CEpgInfoTag> CEpgInfoTagPtr;
 
@@ -391,7 +392,7 @@ namespace PVR
      * @brief Get the EPG table for this channel.
      * @return The EPG for this channel.
      */
-    EPG::CEpg *GetEPG(void) const;
+    EPG::CEpgPtr GetEPG(void) const;
 
     /*!
      * @brief Get the EPG table for this channel.

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -1068,7 +1068,6 @@ int CPVRChannelGroup::GetEPGSearch(CFileItemList &results, const EpgSearchFilter
 int CPVRChannelGroup::GetEPGNowOrNext(CFileItemList &results, bool bGetNext) const
 {
   int iInitialSize = results.Size();
-  CEpg* epg;
   CEpgInfoTagPtr epgNext;
   CPVRChannelPtr channel;
   CSingleLock lock(m_critSection);
@@ -1076,7 +1075,7 @@ int CPVRChannelGroup::GetEPGNowOrNext(CFileItemList &results, bool bGetNext) con
   for (PVR_CHANNEL_GROUP_SORTED_MEMBERS::const_iterator it = m_sortedMembers.begin(); it != m_sortedMembers.end(); ++it)
   {
     channel = (*it).channel;
-    epg = channel->GetEPG();
+    CEpgPtr epg = channel->GetEPG();
     if (epg && !channel->IsHidden())
     {
       epgNext = bGetNext ? epg->GetTagNext() : epg->GetTagNow();
@@ -1097,7 +1096,6 @@ int CPVRChannelGroup::GetEPGNowOrNext(CFileItemList &results, bool bGetNext) con
 int CPVRChannelGroup::GetEPGAll(CFileItemList &results, bool bIncludeChannelsWithoutEPG /* = false */) const
 {
   int iInitialSize = results.Size();
-  CEpg* epg;
   CEpgInfoTagPtr epgTag;
   CPVRChannelPtr channel;
   CSingleLock lock(m_critSection);
@@ -1109,8 +1107,8 @@ int CPVRChannelGroup::GetEPGAll(CFileItemList &results, bool bIncludeChannelsWit
     {
       int iAdded = 0;
 
-      epg = channel->GetEPG();
-      if (epg != NULL)
+      CEpgPtr epg = channel->GetEPG();
+      if (epg)
       {
         // XXX channel pointers aren't set in some occasions. this works around the issue, but is not very nice
         epg->SetChannel(channel);
@@ -1133,14 +1131,14 @@ int CPVRChannelGroup::GetEPGAll(CFileItemList &results, bool bIncludeChannelsWit
 CDateTime CPVRChannelGroup::GetEPGDate(EpgDateType epgDateType) const
 {
   CDateTime date;
-  CEpg* epg;
+  CEpgPtr epg;
   CPVRChannelPtr channel;
   CSingleLock lock(m_critSection);
 
   for (PVR_CHANNEL_GROUP_MEMBERS::const_iterator it = m_members.begin(); it != m_members.end(); ++it)
   {
     channel = it->second.channel;
-    if (!channel->IsHidden() && (epg = channel->GetEPG()) != NULL)
+    if (!channel->IsHidden() && (epg = channel->GetEPG()))
     {
       CDateTime epgDate;
       switch (epgDateType)

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
@@ -317,7 +317,7 @@ void CPVRChannelGroupInternal::CreateChannelEpg(CPVRChannelPtr channel, bool bFo
   CSingleLock lock(channel->m_critSection);
   if (!channel->m_bEPGCreated || bForce)
   {
-    CEpg *epg = g_EpgContainer.CreateChannelEpg(channel);
+    CEpgPtr epg = g_EpgContainer.CreateChannelEpg(channel);
     if (epg)
     {
       channel->m_bEPGCreated = true;

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -774,7 +774,7 @@ void CPVRTimers::UpdateEpgEvent(CPVRTimerInfoTagPtr timer)
     return;
 
   /* try to get the EPG table */
-  CEpg *epg = channel->GetEPG();
+  CEpgPtr epg = channel->GetEPG();
   if (!epg)
     return;
 

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -793,7 +793,7 @@ bool CGUIWindowPVRBase::UpdateEpgForChannel(CFileItem *item)
 {
   CPVRChannelPtr channel(item->GetPVRChannelInfoTag());
 
-  CEpg *epg = channel->GetEPG();
+  CEpgPtr epg = channel->GetEPG();
   if (!epg)
     return false;
 


### PR DESCRIPTION
This fixes a crash that can occur when one thread is inside
PersistAll() and the other is inside DeleteEpg().  The former does not
lock the mutex, as it operates on a std::map copy with CEpg pointers.
These CEpg instances however are deleted by the other thread.

Background information:

CEpgContainer::m_critSection protects the std::map m_epgs which
contains CEpg pointers.  All access to m_epgs must be protected with
m_critSection.  What the authors of that code didn't consider: if a
CEpg pointer escapes that protected code section, it can be
invalidated at any time.  Which implies: it is illegal to leak CEpg
pointers out of CEpgContainer::m_critSection protection!

That, however, is what commit 2ba1c43 implements, and what has been
done wrong many times before, for example GetById() and GetByChannel()
leak those pointers, explicitly.  All of that is wrong, and each one
of them can crash Kodi.

So what this commit does is ensure that all CEpg instances remain
valid as long as somebody is still holding a pointer, by wrapping all
CEpg pointers in std::shared_ptr.

See https://github.com/xbmc/xbmc/pull/8238 for my previous attempt to get this merged; I was asked to re-request the pull in the master branch instead of fixing this crash bug in the stable branch.
