### PR TITLE
Revert "[pvr] fix playback of recordings when an exact duplicate exists"

### DIFF
--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -428,10 +428,10 @@ void CPVRRecording::UpdatePath(void)
     if (!strSeasonEpisode.empty())
       strSeasonEpisode = StringUtils::Format(" %s", strSeasonEpisode.c_str());
 
-    m_strFileNameAndPath = StringUtils::Format("pvr://" PVR_RECORDING_BASE_PATH "/%s/%s%s%s%s%s%s, TV%s, %s.pvr",
+    m_strFileNameAndPath = StringUtils::Format("pvr://" PVR_RECORDING_BASE_PATH "/%s/%s%s%s%s%s, TV%s, %s.pvr",
       m_bIsDeleted ? PVR_RECORDING_DELETED_PATH : PVR_RECORDING_ACTIVE_PATH, strDirectory.c_str(),
       strTitle.c_str(), strSeasonEpisode.c_str(), strYear.c_str(), strSubtitle.c_str(),
-      strChannel.c_str(), strDatetime.c_str(), m_strRecordingId.c_str());
+      strChannel.c_str(), strDatetime.c_str());
   }
 }
 


### PR DESCRIPTION
This reverts commit 3f09b51f8c6ff720ffae84dd1501035049756519. See https://github.com/xbmc/xbmc/pull/8219#issuecomment-149003594 for explanation.
