### PR TITLE
FIX: Only handle 3D bitmap subs in TAB

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayCodecFFmpeg.cpp
@@ -257,17 +257,12 @@ CDVDOverlay* CDVDOverlayCodecFFmpeg::GetOverlay()
     }
 
     RENDER_STEREO_MODE render_stereo_mode = g_graphicsContext.GetStereoMode();
-    if (render_stereo_mode != RENDER_STEREO_MODE_OFF)
+    if (render_stereo_mode == RENDER_STEREO_MODE_SPLIT_HORIZONTAL)
     {
       if (rect.h > m_height / 2)
       {
         m_height /= 2;
         rect.h /= 2;
-      }
-      else if (rect.w > m_width / 2)
-      {
-        m_width /= 2;
-        rect.w /= 2;
       }
     }
 


### PR DESCRIPTION
3D bitmap subs cannot be detected in SBS, and there is always the option
to play with Kodi 3D disabled

/cc @FernetMenta @da-anda @popcornmix 
