### PR TITLE
FIX: [droid] idiot-proof framerate detection

### DIFF
--- a/xbmc/windowing/egl/EGLNativeTypeAndroid.cpp
+++ b/xbmc/windowing/egl/EGLNativeTypeAndroid.cpp
@@ -141,8 +141,9 @@ static float currentRefreshRate()
   if (window)
   {
     float preferredRate = window.getAttributes().getpreferredRefreshRate();
-    if (preferredRate > 1.0)
+    if (preferredRate > 20.0 && preferredRate < 61.0)
     {
+      CLog::Log(LOGDEBUG, "CEGLNativeTypeAndroid: Preferred refresh rate: %f", preferredRate);
       return preferredRate;
     }
     CJNIView view(window.getDecorView());
@@ -151,7 +152,11 @@ static float currentRefreshRate()
       if (display)
       {
         float reportedRate = display.getRefreshRate();
-        return reportedRate;
+        if (reportedRate > 20.0 && reportedRate < 61.0)
+        {
+          CLog::Log(LOGDEBUG, "CEGLNativeTypeAndroid: Current display refresh rate: %f", reportedRate);
+          return reportedRate;
+        }
       }
     }
   }


### PR DESCRIPTION
Some buggy FW return bogus values. Trap them
