### PR TITLE
ADD: "Import All" setting: add all videos to the library, even if there is no scrapper data

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -11934,7 +11934,15 @@ msgctxt "#20470"
 msgid "Use movie sets for single movies"
 msgstr ""
 
-#empty strings from id 20471 to 21329
+msgctxt "#20471"
+msgid "Import all videos"
+msgstr ""
+
+msgctxt "#20472"
+msgid "Import all videos, even if no scrapper data is available"
+msgstr ""
+
+#empty strings from id 20473 to 21329
 #up to 21329 is reserved for the video db !! !
 
 #: system/settings/settings.xml

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -481,6 +481,14 @@
           <default>false</default>
           <control type="toggle" />
         </setting>
+        <setting id="videolibrary.importall" type="boolean" label="20471" help="20472">
+          <level>1</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
       </group>
       <group id="2">
         <setting id="videolibrary.updateonstartup" type="boolean" label="22000" help="36146">

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -139,6 +139,7 @@ const std::string CSettings::SETTING_VIDEOLIBRARY_GROUPMOVIESETS = "videolibrary
 const std::string CSettings::SETTING_VIDEOLIBRARY_GROUPSINGLEITEMSETS = "videolibrary.groupsingleitemsets";
 const std::string CSettings::SETTING_VIDEOLIBRARY_UPDATEONSTARTUP = "videolibrary.updateonstartup";
 const std::string CSettings::SETTING_VIDEOLIBRARY_BACKGROUNDUPDATE = "videolibrary.backgroundupdate";
+const std::string CSettings::SETTING_VIDEOLIBRARY_IMPORTALL = "videolibrary.importall";
 const std::string CSettings::SETTING_VIDEOLIBRARY_CLEANUP = "videolibrary.cleanup";
 const std::string CSettings::SETTING_VIDEOLIBRARY_EXPORT = "videolibrary.export";
 const std::string CSettings::SETTING_VIDEOLIBRARY_IMPORT = "videolibrary.import";
@@ -1031,6 +1032,7 @@ void CSettings::InitializeISettingCallbacks()
   settingSet.insert(CSettings::SETTING_VIDEOLIBRARY_FLATTENTVSHOWS);
   settingSet.insert(CSettings::SETTING_VIDEOLIBRARY_REMOVE_DUPLICATES);
   settingSet.insert(CSettings::SETTING_VIDEOLIBRARY_GROUPMOVIESETS);
+  settingSet.insert(CSettings::SETTING_VIDEOLIBRARY_IMPORTALL);
   settingSet.insert(CSettings::SETTING_VIDEOLIBRARY_CLEANUP);
   settingSet.insert(CSettings::SETTING_VIDEOLIBRARY_IMPORT);
   settingSet.insert(CSettings::SETTING_VIDEOLIBRARY_EXPORT);

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -96,6 +96,7 @@ public:
   static const std::string SETTING_VIDEOLIBRARY_GROUPSINGLEITEMSETS;
   static const std::string SETTING_VIDEOLIBRARY_UPDATEONSTARTUP;
   static const std::string SETTING_VIDEOLIBRARY_BACKGROUNDUPDATE;
+  static const std::string SETTING_VIDEOLIBRARY_IMPORTALL;
   static const std::string SETTING_VIDEOLIBRARY_CLEANUP;
   static const std::string SETTING_VIDEOLIBRARY_EXPORT;
   static const std::string SETTING_VIDEOLIBRARY_IMPORT;

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -2462,7 +2462,7 @@ int CVideoDatabase::SetDetailsForEpisode(const std::string& strFilenameAndPath, 
 
     SetArtForItem(idEpisode, MediaTypeEpisode, artwork);
 
-    if (details.m_iEpisode != -1 && details.m_iSeason != -1)
+    if (!(details.m_iSeason == 0 && details.m_iEpisode == 0)) // Special episodes
     { // query DB for any episodes matching idShow, Season and Episode
       std::string strSQL = PrepareSQL("SELECT files.playCount, files.lastPlayed "
                                       "FROM episode INNER JOIN files ON files.idFile=episode.idFile "


### PR DESCRIPTION
Problem is that if a scrapper is set but a file match fails, nothing is imported,
so the user has no idea the scrapper failed.

This still imports the file as a generic video.

Use cases:
- Scrapper failed to recognize filename
- Use "dummy show" as category of random files, with just a tvshow.nfo

/cc @Montellese 

Note: This is a very old feature in my tree. I incidentally had a user asking for the exact same request, so I now PR it, but I might have difficulties finding back my own logic ;)
