### PR TITLE
[confluence] remove old weather fanart directory selection

### DIFF
--- a/addons/skin.confluence/720p/MyWeather.xml
+++ b/addons/skin.confluence/720p/MyWeather.xml
@@ -577,12 +577,6 @@
 					<onclick>Skin.ToggleSetting(ShowWeatherFanart)</onclick>
 					<selected>!Skin.HasSetting(ShowWeatherFanart)</selected>
 				</control>
-				<control type="button" id="251">
-					<include>ButtonCommonValues</include>
-					<label>31317</label>
-					<onclick>Skin.SetPath(WeatherFanartDir)</onclick>
-					<enable>Skin.HasSetting(ShowWeatherFanart)</enable>
-				</control>
 				<include>CommonNowPlaying_Controls</include>
 			</control>
 		</control>


### PR DESCRIPTION
Related to http://trac.kodi.tv/ticket/16314#comment:4

The `resource.images.weatherfanart.*` even thought they dont work for me, is the **current** supported method

Because I was using https://github.com/xbmc/xbmc/blob/master/addons/skin.confluence/720p/MyWeather.xml#L580-L585 it may very well be cause for **crashes**, no idea still testing that.

I didnt remove https://github.com/xbmc/xbmc/blob/master/addons/skin.confluence/720p/MyWeather.xml#L573-L579 here because currently the `resource.images.weatherfanart.*` with master alpha4 and default confluence doesnt load any fanart images, so idk if the radio button still applies to that or not.

@ronie lets see if this ping works.
