### PR TITLE
[Confluence] update weatherfanart support for jarvis

### DIFF
--- a/addons/skin.confluence/720p/MyWeather.xml
+++ b/addons/skin.confluence/720p/MyWeather.xml
@@ -9,12 +9,12 @@
 			<depth>DepthBackground</depth>
 			<include>BackgroundDimensions</include>
 			<aspectratio>scale</aspectratio>
-			<imagepath background="true">$INFO[Skin.String(WeatherFanartDir)]$INFO[Window(Weather).Property(Current.FanartCode)]</imagepath>
+			<imagepath background="true">resource://resource.images.weatherfanart.multi/$INFO[Window(Weather).Property(Current.FanartCode)]</imagepath>
 			<timeperimage>10000</timeperimage>
 			<randomize>true</randomize>
 			<fadetime>1000</fadetime>
 			<include>VisibleFadeEffect</include>
-			<visible>Skin.HasSetting(ShowWeatherFanart) + !IsEmpty(Skin.String(WeatherFanartDir))</visible>
+			<visible>System.HasAddon(resource.images.weatherfanart.multi)</visible>
 			<animation effect="fade" time="150">WindowClose</animation>
 		</control>
 		<include name="CommonWindowHeader">
@@ -559,19 +559,6 @@
 					<onclick>ActivateWindow(MyWeatherSettings)</onclick>
 					<textwidth>235</textwidth>
 					<include>ButtonCommonValues</include>
-				</control>
-				<control type="radiobutton" id="250">
-					<description>Fanart Toggle</description>
-					<include>ButtonCommonValues</include>
-					<label>31307</label>
-					<onclick>Skin.ToggleSetting(ShowWeatherFanart)</onclick>
-					<selected>!Skin.HasSetting(ShowWeatherFanart)</selected>
-				</control>
-				<control type="button" id="251">
-					<include>ButtonCommonValues</include>
-					<label>31317</label>
-					<onclick>Skin.SetPath(WeatherFanartDir)</onclick>
-					<enable>Skin.HasSetting(ShowWeatherFanart)</enable>
 				</control>
 				<include>CommonNowPlaying_Controls</include>
 			</control>

--- a/addons/skin.confluence/720p/MyWeather.xml
+++ b/addons/skin.confluence/720p/MyWeather.xml
@@ -553,16 +553,6 @@
 					<include>ButtonCommonValues</include>
 					<label>103</label>
 				</control>
-				<control type="button" id="5">
-					<description>Custom Weather Script Button</description>
-					<label>$INFO[Skin.String(WeatherScript_Label)]</label>
-					<onclick>SetFocus(50)</onclick>
-					<onclick>RunScript($INFO[Skin.String(WeatherScript_Path)])</onclick>
-					<onclick>SetFocus(50)</onclick>
-					<textwidth>235</textwidth>
-					<include>ButtonCommonValues</include>
-					<visible>Skin.HasSetting(WeatherScript_Enable) + !IsEmpty(Skin.String(WeatherScript_Label))</visible>
-				</control>
 				<control type="button" id="4">
 					<description>Settings button</description>
 					<label>5</label>


### PR DESCRIPTION
confluence supports weather fanart by manually downloading, installing and configuration using the instructions found in a sticky on the forum.

far from ideal imo. let's make things a bit easier, since we can use image resources in jarvis.
