### PR TITLE
[videos] fix default select action after #8169 (thanks anaconda)

### DIFF
--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -673,7 +673,7 @@ bool CGUIWindowVideoBase::OnFileAction(int iItem, int action)
   case SELECT_ACTION_PLAY_OR_RESUME:
     return OnResumeItem(iItem);
   case SELECT_ACTION_INFO:
-    if (OnInfo(iItem))
+    if (OnItemInfo(iItem))
       return true;
     break;
   case SELECT_ACTION_MORE:


### PR DESCRIPTION
This fixes a regression introduced with #8169 reported by @MilhouseVH in https://github.com/xbmc/xbmc/pull/8169#issuecomment-150026313. The configured default select action should work as intended now.

Thanks @anaconda.
