### PR TITLE
[Conluence] fix 2D radiobutton state - trac #16335

### DIFF
--- a/addons/skin.confluence/720p/VideoOSD.xml
+++ b/addons/skin.confluence/720p/VideoOSD.xml
@@ -483,7 +483,7 @@
 				<texturefocus border="25,5,25,5">SubMenuBack-MiddleFO.png</texturefocus>
 				<texturenofocus border="25,5,25,5">SubMenuBack-MiddleNF.png</texturenofocus>
 				<onclick>StereoModeToMono</onclick>
-				<selected>StringCompare(System.StereoscopicMode,8)</selected>
+				<selected>StringCompare(System.StereoscopicMode,9)</selected>
 				<pulseonselect>false</pulseonselect>
 			</control>
 			<control type="image" id="549">


### PR DESCRIPTION
the 2D radiobutton was not enabled when 'watch as 2D' was selected.
see http://trac.kodi.tv/ticket/16335

a better way to prevent this kind of breakage in the future was suggested by @anaconda https://github.com/anaconda/xbmc/commit/22e5d850c14bef7ba4469bbd312fcc5d484a1196
