### PR TITLE
[PVR] Context menu cleanup, step 3

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -8383,12 +8383,11 @@ msgctxt "#19002"
 msgid "or use phrases to find an exact match, like \"The wizard of Oz\"."
 msgstr ""
 
-#. Label of the button / context menu entry to find similar programs in the PVR EPG data
+#. Label of a button / context menu entry to find similar programs (matching a given epg event)
 #: skin.confluence
 #: xbmc/pvr/windows/GUIWindowPVRChannels.cpp
 #: xbmc/pvr/windows/GUIWindowPVRGuide.cpp
 #: xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
-#: xbmc/pvr/windows/GUIWindowPVRTimers.cpp
 msgctxt "#19003"
 msgid "Find similar"
 msgstr ""
@@ -8657,15 +8656,15 @@ msgctxt "#19055"
 msgid "No information available"
 msgstr ""
 
+#. Label for a new timer
+#: xbmc/pvr/timers/PVRTimers.cpp
+#: xbmc/pvr/timers/PVRTimerInfoTag.cpp
+#: xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
 msgctxt "#19056"
 msgid "New timer"
 msgstr ""
 
-#. Label for a context menu entry to open timer settings dialog
-#: xbmc/pvr/windows/GUIWindowPVRTimers.cpp
-msgctxt "#19057"
-msgid "Edit settings"
-msgstr ""
+# empty string with id 19057
 
 msgctxt "#19058"
 msgid "Timer enabled"
@@ -12435,8 +12434,9 @@ msgctxt "#21449"
 msgid "Remote control sends keyboard presses"
 msgstr ""
 
-#. Label of setting "Appearance -> Skin -> Edit"
+#. Label for controls used to edit something (e.g. setting "Appearance -> Skin -> Edit" or a context menu entry to open timer settings dialog)
 #: system/settings/settings.xml
+#: xbmc/pvr/windows/GUIWindowPVRTimers.cpp
 msgctxt "#21450"
 msgid "Edit"
 msgstr ""

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -80,8 +80,12 @@ void CGUIWindowPVRChannels::GetContextButtons(int itemNumber, CContextButtons &b
   if (ActiveAE::CActiveAEDSP::GetInstance().IsProcessing())
     buttons.Add(CONTEXT_BUTTON_ACTIVE_ADSP_SETTINGS, 15047);                        /* Audio DSP settings */
 
-  buttons.Add(CONTEXT_BUTTON_INFO, 19047);                                          /* Programme information */
-  buttons.Add(CONTEXT_BUTTON_FIND, 19003);                                          /* Find similar */
+  if (channel->GetEPGNow())
+  {
+    buttons.Add(CONTEXT_BUTTON_INFO, 19047);                                        /* Programme information */
+    buttons.Add(CONTEXT_BUTTON_FIND, 19003);                                        /* Find similar */
+  }
+
   buttons.Add(CONTEXT_BUTTON_RECORD_ITEM, !channel->IsRecording() ? 264 : 19059);   /* Record / Stop recording */
 
   if (g_PVRClients->HasMenuHooks(pItem->GetPVRChannelInfoTag()->ClientID(), PVR_MENUHOOK_CHANNEL))

--- a/xbmc/pvr/windows/GUIWindowPVRTimers.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRTimers.cpp
@@ -73,18 +73,10 @@ void CGUIWindowPVRTimers::GetContextButtons(int itemNumber, CContextButtons &but
     return;
   CFileItemPtr pItem = m_vecItems->Get(itemNumber);
 
-  /* Check for a empty file item list, means only a
-     file item with the name "Add timer..." is present */
-  if (URIUtils::PathEquals(pItem->GetPath(), CPVRTimersPath::PATH_ADDTIMER))
-  {
-    buttons.Add(CONTEXT_BUTTON_ADD, 19056);             /* New timer */
-  }
-  else
+  if (!URIUtils::PathEquals(pItem->GetPath(), CPVRTimersPath::PATH_ADDTIMER))
   {
     if (pItem->GetPVRTimerInfoTag()->GetEpgInfoTag())
       buttons.Add(CONTEXT_BUTTON_INFO, 19047);          /* Programme information */
-
-    buttons.Add(CONTEXT_BUTTON_FIND, 19003);            /* Find similar */
 
     if (pItem->GetPVRTimerInfoTag()->HasTimerType())
     {
@@ -99,15 +91,13 @@ void CGUIWindowPVRTimers::GetContextButtons(int itemNumber, CContextButtons &but
       if (!pItem->GetPVRTimerInfoTag()->GetTimerType()->IsReadOnly())
       {
         buttons.Add(CONTEXT_BUTTON_DELETE, 117);        /* Delete */
-        buttons.Add(CONTEXT_BUTTON_EDIT, 19057);        /* Edit settings */
+        buttons.Add(CONTEXT_BUTTON_EDIT, 21450);        /* Edit */
 
         // As epg-based timers will get it's title from the epg tag, they should not be renamable.
         if (pItem->GetPVRTimerInfoTag()->IsManual())
           buttons.Add(CONTEXT_BUTTON_RENAME, 118);      /* Rename */
       }
     }
-
-    buttons.Add(CONTEXT_BUTTON_ADD, 19056);             /* New timer */
 
     if (g_PVRClients->HasMenuHooks(pItem->GetPVRTimerInfoTag()->m_iClientId, PVR_MENUHOOK_TIMER))
       buttons.Add(CONTEXT_BUTTON_MENU_HOOKS, 19195);    /* PVR client specific action */


### PR DESCRIPTION
Misc improvements for PVR context menus, most of them discussed here: https://github.com/xbmc/xbmc/pull/8269#discussion_r42595579

Timer window
- Renamed "Edit settings" to "Edit"
- Removed "Find similar" and "New timer"

Channel window
- Show "Programme information" and "Find similar" only, if channel has an active epg event.
