### PR TITLE
[droid] fix crashing on addon installation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1125,7 +1125,7 @@ int main() {
   )])
 AC_LANG_POP([C++])
 
-if test "${target_platform}" = "target_linux" || test "${target_platform}" = "target_raspberry_pi"; then
+if test "${target_platform}" = "target_linux" || test "${target_platform}" = "target_raspberry_pi" || test "${target_platform}" = "target_android"; then
   PKG_CHECK_MODULES([UUID], [uuid],, AC_MSG_ERROR(libuuid not found))
 fi
 
@@ -1141,9 +1141,6 @@ AC_LINK_IFELSE(
   [AC_MSG_ERROR(crossguid not found)])
 LIBS="$SAVED_LIBS"
 AC_LANG_POP([C++])
-if test "${target_platform}" = "target_android"; then
-  CXXFLAGS="$CXXFLAGS -DGUID_ANDROID"
-fi
 
 PKG_CHECK_MODULES([YAJL], [yajl >= 2],
   [INCLUDES="$INCLUDES $YAJL_CFLAGS"; LIBS="$LIBS $YAJL_LIBS"; YAJL_FOUND="true"],

--- a/tools/depends/target/Makefile
+++ b/tools/depends/target/Makefile
@@ -35,7 +35,8 @@ ifeq ($(OS),osx)
 endif
 
 ifeq ($(OS),android)
-  DEPENDS += mdnsresponder android-sources-ics google-breakpad
+  DEPENDS += mdnsresponder android-sources-ics google-breakpad libuuid
+  CROSSGUID_DEPS = libuuid
 endif
 
 DEPENDS := $(filter-out $(EXCLUDED_DEPENDS),$(DEPENDS))
@@ -63,6 +64,7 @@ ifeq ($(OS),linux)
   endif
   DEPENDS += alsa-lib
   ALSA_LIB = alsa-lib
+  CROSSGUID_DEPS = libuuid
 endif
 
 .PHONY: $(DEPENDS)
@@ -97,9 +99,7 @@ libsdl2: $(LINUX_SYSTEM_LIBS)
 libxslt: libgcrypt
 ffmpeg: $(ICONV) $(ZLIB) bzip2 libvorbis $(FFMPEG_DEPENDS)
 libcec: platform
-ifeq ($(OS),linux)
-crossguid: libuuid
-endif
+crossguid: $(CROSSGUID_DEPS)
 
 .installed-$(PLATFORM): $(DEPENDS)
 	touch $@

--- a/tools/depends/target/crossguid/Makefile
+++ b/tools/depends/target/crossguid/Makefile
@@ -26,9 +26,6 @@ endif
 
 # define specifying the native GUID implementation to use
 GUID_PLATFORM_DEFINE=GUID_LIBUUID
-ifeq ($(OS),android)
-	GUID_PLATFORM_DEFINE=GUID_ANDROID
-endif
 ifeq ($(OS),osx)
 	GUID_PLATFORM_DEFINE=GUID_CFUUID
 endif

--- a/tools/depends/target/libuuid/Makefile
+++ b/tools/depends/target/libuuid/Makefile
@@ -1,21 +1,15 @@
 include ../../Makefile.include
 DEPS= ../../Makefile.include Makefile
 
+# We use uuid from e2fsprogs since this easily cross-compiles on android, while util-linux does not.
 # lib name, version
 LIBNAME=libuuid
-VERSION=2.20.0
-SOURCE=util-linux-2.20.1
-ARCHIVE=$(SOURCE).tar.gz
+VERSION=1.42.13
+SOURCE=e2fsprogs-1.42.13
+ARCHIVE=$(SOURCE).tar.xz
 
-# configuration settings
-CONFIGURE=echo "scanf_cv_type_modifier=as" > config.cache; \
-	  ./configure --prefix=$(PREFIX) --cache-file=config.cache \
-	              --disable-shared --disable-mount --disable-fsck --disable-partx --disable-libblkid \
-                      --disable-libmount --disable-mountpoint --disable-nls --disable-rpath --disable-agetty \
-                      --disable-cramfs --disable-switch_root --disable-pivot_root --disable-fallocate \
-                      --disable-unshare --disable-rename --disable-schedutils --disable-wall --without-ncurses
 
-LIBDYLIB=$(PLATFORM)/libuuid/src/.libs/$(LIBNAME).a
+LIBDYLIB=$(PLATFORM)/lib/$(LIBNAME).a
 
 all: .installed-$(PLATFORM)
 
@@ -25,17 +19,17 @@ $(TARBALLS_LOCATION)/$(ARCHIVE):
 $(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
 	rm -rf $(PLATFORM)/*; mkdir -p $(PLATFORM)
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
-	cd $(PLATFORM); $(CONFIGURE)
+	cd $(PLATFORM); ./configure --prefix=$(PREFIX) --disable-fsck
 
 $(LIBDYLIB): $(PLATFORM)
-	$(MAKE) -C $(PLATFORM)/libuuid
+	cd $(PLATFORM)/lib/uuid ; $(MAKE) -j1
 
 .installed-$(PLATFORM): $(LIBDYLIB)
-	$(MAKE) -C $(PLATFORM)/libuuid install
+	cd $(PLATFORM)/lib/uuid ; $(MAKE) -j1 install
 	touch $@
 
 clean:
-	$(MAKE) -C $(PLATFORM)/libuuid clean
+	$(MAKE) -C $(PLATFORM) clean
 	rm -f .installed-$(PLATFORM)
 
 distclean::

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -1081,11 +1081,7 @@ void StringUtils::WordToDigits(std::string &word)
 
 std::string StringUtils::CreateUUID()
 {
-#if !defined(TARGET_ANDROID)
   static GuidGenerator guidGenerator;
-#else
-  static GuidGenerator guidGenerator(xbmc_jnienv());
-#endif
   auto guid = guidGenerator.newGuid();
 
   std::stringstream strGuid; strGuid << guid;


### PR DESCRIPTION
Crossguid uses a jni based implementation on droid that is crashing all over and corrupting the stack.
This PR switches droid to use libuuid instead, just like linux.
Since our libuuid in depends doesn't cross compile on droid, we switch to an easier one from e2fsprogs.
Only tested on droid..

@Montellese, @koying ping
