### PR TITLE
[strings] improve pop up message and warn of undesired effects

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -5298,7 +5298,7 @@ msgstr ""
 #: xbmc\video\dialogs\GUIDialogAudioSubtitleSettings.cpp
 #: xbmc\video\dialogs\GUIDialogVideoSettings.cpp
 msgctxt "#12377"
-msgid "This will reset any previously saved values. Are you sure?"
+msgid "This will save selected values as default for all media.[CR]Changing the 'View mode' or 'Pixel ratio' can have undesired effect on some files aspect ratio on playback.[CR]Would you like to proceed?"
 msgstr ""
 
 #: system/settings/settings.xml


### PR DESCRIPTION
This PR attempts to solve 2 issues: as a follow up from #7583 and a result of the discussion had in https://github.com/xbmc/xbmc/pull/7583#discussion_r35238887 with **da-anda**

**Backstory:** A while back, I spent weeks trying to find out why some files aspect ratio was suddenly wrong on playback and a very long time fixing it and finally realised this was caused by saving incorrect pixel ratio (which automatically changes view mode to Custom to all files...

---

**_Notes:**_ The proposed message is somewhat long and can indeed be improved, but I feel, it should reflect the correct result you cause by saying yes and warn the user about any unintended side effects pixle ration and view mode can cause.

I could not make this more clear unfortunately, sorry in advance.

---

@da-anda and @jjd-uk for kind suggestion on improving message.

On video OSD press `Set as default for all media` and you get a yes/no dialog with a message.

**Issue 1)**  Misleading and incorrect message

**Current message**
![screenshot014](https://cloud.githubusercontent.com/assets/3521959/10699058/0eebf49a-79ac-11e5-9095-6f460a9cea8e.png)

**You are not in fact resetting any previous saved values** but rather overwriting any previous saved values with any values you changed for all video media.

Issue 2) When these changed values include Settings Like **View mode** or **Pixel ratio** changes and you indeed save these settings for all media, this changes the aspect ration of files on playback and can cause unintended side effects like black bars or other issues appearing where none existed for some files.

**Proposed Message**
![screenshot015](https://cloud.githubusercontent.com/assets/3521959/10699418/939ae154-79ae-11e5-8f7e-f59376116a53.png)
