### PR TITLE
[python] Fixed getRegion dateshort format without leading zero

### DIFF
--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -420,6 +420,13 @@ namespace XBMCAddon
           result = g_langInfo.GetDateFormat(false);
           StringUtils::Replace(result, "MM", "%m");
           StringUtils::Replace(result, "DD", "%d");
+#ifdef TARGET_WINDOWS
+          StringUtils::Replace(result, "M", "%#m");
+          StringUtils::Replace(result, "D", "%#d");
+#else
+          StringUtils::Replace(result, "M", "%-m");
+          StringUtils::Replace(result, "D", "%-d");
+#endif
           StringUtils::Replace(result, "YYYY", "%Y");
         }
       else if (strcmpi(id, "tempunit") == 0)


### PR DESCRIPTION
Currently xbmc.getRegion('dateshort') returns a bad strftime format when locale.shortdateformat has the month and or date without a leading zero e.g. YYYY-M-D would become %Y-M-D.

Linux and OS X strftime has %-m and %-d.
~~Windows has to fallback to YYYY-MM-DD i.e. with leading zeros.~~
EDIT: The Windows equivalent is %#m and %#d.

EDIT: Platforms tested:
- [x] Linux
- [x] Windows
- [x] Android
- [x] Mac OS X
- [x] iOS
