### PR TITLE
[GUIDialogVideoSettings] assign specific & improved message to Video OSD

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -5287,7 +5287,12 @@ msgctxt "#12373"
 msgid "Settings & file manager"
 msgstr ""
 
-#empty strings from id 12374 to 12375
+#empty strings with id 12374
+
+#: xbmc\video\dialogs\GUIDialogVideoSettings.cpp
+msgctxt "#12375"
+msgid "The selected values will be saved as default for all media, and affect how they are played back. Are you sure?"
+msgstr ""
 
 #: xbmc\settings\dialogs\GUIDialogAudioDSPSettings.cpp
 #: xbmc\video\dialogs\GUIDialogAudioSubtitleSettings.cpp
@@ -5296,10 +5301,10 @@ msgctxt "#12376"
 msgid "Set as default for all media"
 msgstr ""
 
+#: xbmc\settings\dialogs\GUIDialogAudioDSPSettings.cpp
 #: xbmc\video\dialogs\GUIDialogAudioSubtitleSettings.cpp
-#: xbmc\video\dialogs\GUIDialogVideoSettings.cpp
 msgctxt "#12377"
-msgid "This will reset any previously saved values. Are you sure?"
+msgid "The selected values will be saved as default for all media. Are you sure?"
 msgstr ""
 
 #: system/settings/settings.xml

--- a/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
@@ -172,7 +172,7 @@ void CGUIDialogVideoSettings::Save()
     return;
 
   // prompt user if they are sure
-  if (CGUIDialogYesNo::ShowAndGetInput(CVariant(12376), CVariant(12377)))
+  if (CGUIDialogYesNo::ShowAndGetInput(CVariant(12376), CVariant(12375)))
   { // reset the settings
     CVideoDatabase db;
     if (!db.Open())


### PR DESCRIPTION
This PR attempts to solve 2 issues: as a follow up from #7583 and a result of the discussion had in https://github.com/xbmc/xbmc/pull/7583#discussion_r35238887 with **da-anda**

**Backstory:** A while back, After spending weeks trying to find out why some files aspect ratio was suddenly wrong on playback and a long time fixing it —I realised this was caused by saving a pixel ratio to all media (which automatically changed view mode to Custom and and resulted on some files black bars showing or odd aspect ratio on other files, and depending on what you changed and saved some options seem like they had no effect http://trac.kodi.tv/ticket/15476)

---

**_Notes:**_ The proposed message should reflect the correct result caused by saying yes to  `Set as default for all media`and make more obvious or indicate to user on video OSD that pixel ratio and view mode changes, zoom level affect aspect ratio, as this causes mayhem if used improperly.

I tried making this as clear as possible, sorry in advance if its not. 

---

@da-anda and @jjd-uk for review @MartijnKaijser are you OK with this solution?
On video OSD press `Set as default for all media` and you get a yes/no dialog with a message.

**Issue 1)**  Misleading or improper message

**Current message for Audio / Video and DSP OSD**
![screenshot014](https://cloud.githubusercontent.com/assets/3521959/10699058/0eebf49a-79ac-11e5-9095-6f460a9cea8e.png)

**You are not in fact resetting any previous saved values** but rather overwriting any previous saved values with any values you changed for all video media.

Issue 2) When these changed values include settings like **View mode** or **Pixel ratio** changes and you indeed save these settings for all media, this changes the aspect ratio for all video media on playback and can cause unintended side effects and user isnt properly informed by reading a vague message or may not be aware of implications.

**Proposed specific Video OSD Message**
![screenshot021](https://cloud.githubusercontent.com/assets/3521959/10709357/0b6a517e-7a22-11e5-8a22-1584ecb5f67b.png)

**Audio / DSP OSD** will show a more informative message instead.
![screenshot017](https://cloud.githubusercontent.com/assets/3521959/10709361/4a19c2ce-7a22-11e5-9c64-7600a2d1ad4d.png)
