### PR TITLE
[videos] default to play select action in case there's no information…

### DIFF
--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -738,7 +738,10 @@ bool CGUIWindowVideoBase::OnItemInfo(int iItem)
 
   OnItemInfo(item.get(), scraper);
 
-  return true;
+  // Return whether or not we have information to display.
+  // Note: This will cause the default select action to start
+  // playback in case it's set to "Show information".
+  return item->HasVideoInfoTag();
 }
 
 void CGUIWindowVideoBase::OnRestartItem(int iItem)


### PR DESCRIPTION
This fixes the issue reported in http://trac.kodi.tv/ticket/16189 where the default default select action fails for un-scraped items when set to `Show information`. In case there's no information or we're unable to fetch from the scraper, we now skip to select action `Play`.

@Montellese for review please. 
