### PR TITLE
Fix music navigation generic content "songs" setting

### DIFF
--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -287,10 +287,6 @@ bool CGUIWindowMusicNav::GetDirectory(const std::string &strDirectory, CFileItem
       OnRetrieveMusicInfo(items);
   }
 
-  //Navigating music files so default content to "songs" unless in sources folder.
-  //This content allows view type to include media info so that file tag data can be displayed
-  if (!URIUtils::IsSourcesPath(strDirectory))
-    items.SetContent("songs");
   // update our content in the info manager
   if (StringUtils::StartsWithNoCase(strDirectory, "videodb://") || items.IsVideoDb())
   {
@@ -315,6 +311,8 @@ bool CGUIWindowMusicNav::GetDirectory(const std::string &strDirectory, CFileItem
       items.SetContent("albums");
     else if (node == VIDEODATABASEDIRECTORY::NODE_TYPE_TAGS)
       items.SetContent("tags");
+    else
+      items.SetContent("");
   }
   else if (StringUtils::StartsWithNoCase(strDirectory, "musicdb://") || items.IsMusicDb())
   {
@@ -342,12 +340,15 @@ bool CGUIWindowMusicNav::GetDirectory(const std::string &strDirectory, CFileItem
       items.SetContent("genres");
     else if (node == NODE_TYPE_YEAR)
       items.SetContent("years");
+    else
+      items.SetContent("");
   }
   else if (URIUtils::PathEquals(strDirectory, "special://musicplaylists/"))
     items.SetContent("playlists");
   else if (URIUtils::PathEquals(strDirectory, "plugin://music/"))
     items.SetContent("plugins");
-  else if (items.IsPlayList())
+  else if (items.IsPlayList() || 
+          (!items.IsSourcesPath() && !items.IsVirtualDirectoryRoot() && !items.IsLibraryFolder()))
     items.SetContent("songs");
 
   return bResult;


### PR DESCRIPTION
Follow up to #8205 that in restoring the file view music tag data display and sort criteria has itself caused other issues.

When navigating music files we want view type to include media info so that file tag data can be displayed in file view. For this the content needs to be "songs". This original functionality was broken by #8011 when deprecating the use of CGUIViewStateWindowMusicSong to make music more like video. The initial attempt to restore that feature set content to "songs" too generically, this does so in a more limited way avoiding `IsSourcesPath`, `IsVirtualDirectoryRoot` and `IsLibraryFolder`.

Thanks for help with this @Montellese and @mkortstiege; song file view behaviour should be same as before @jjd-uk but could be worth a test. @MartijnKaijser this could fix your scraper errors if you would test it too.
