### PR TITLE
CHG: [droid] decouple kodi and system audio volumes

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1581,15 +1581,9 @@ bool CApplication::Load(const TiXmlNode *settings)
   const TiXmlElement *audioElement = settings->FirstChildElement("audio");
   if (audioElement != NULL)
   {
-#ifndef TARGET_ANDROID
     XMLUtils::GetBoolean(audioElement, "mute", m_muted);
     if (!XMLUtils::GetFloat(audioElement, "fvolumelevel", m_volumeLevel, VOLUME_MINIMUM, VOLUME_MAXIMUM))
       m_volumeLevel = VOLUME_MAXIMUM;
-#else
-    // Use system volume settings
-    m_volumeLevel = CXBMCApp::GetSystemVolume();
-    m_muted = (m_volumeLevel == 0);
-#endif
   }
 
   return true;

--- a/xbmc/android/activity/XBMCApp.cpp
+++ b/xbmc/android/activity/XBMCApp.cpp
@@ -753,8 +753,10 @@ void CXBMCApp::onNewIntent(CJNIIntent intent)
 
 void CXBMCApp::onVolumeChanged(int volume)
 {
-  CApplicationMessenger::GetInstance().PostMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(
-                                       new CAction(ACTION_VOLUME_SET, static_cast<float>(volume))));
+  // System volume was used; Reset Kodi volume to 100% if it'not, already
+  if (g_application.GetVolume(false) != 1.0)
+    CApplicationMessenger::GetInstance().PostMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(
+                                                 new CAction(ACTION_VOLUME_SET, static_cast<float>(CXBMCApp::GetMaxSystemVolume()))));
 }
 
 void CXBMCApp::onAudioFocusChange(int focusChange)

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -364,23 +364,6 @@ void CAESinkAUDIOTRACK::Drain()
   m_frames_written = 0;
 }
 
-bool CAESinkAUDIOTRACK::HasVolume()
-{
-  return true;
-}
-
-void  CAESinkAUDIOTRACK::SetVolume(float scale)
-{
-  // Ignore in passthrough
-  if (m_passthrough)
-    return;
-
-  if (!m_at_jni)
-    return;
-
-  CXBMCApp::SetSystemVolume(scale);
-}
-
 void CAESinkAUDIOTRACK::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)
 {
   m_info.m_channels.Reset();

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
@@ -45,8 +45,6 @@ public:
   virtual double       GetCacheTotal   ();
   virtual unsigned int AddPackets      (uint8_t **data, unsigned int frames, unsigned int offset);
   virtual void         Drain           ();
-  virtual bool         HasVolume       ();
-  virtual void         SetVolume       (float scale);
   static void          EnumerateDevicesEx(AEDeviceInfoList &list, bool force = false);
 
 protected:


### PR DESCRIPTION
As the name says, this decouples the android system volume and the kodi one.
So users can use whatever volume they want, but they are not in sync anymore, thus removing the "double volume bar" effect.

Additionally, I reset the kodi volume to 100% if the system volume is used, with the assumption that users will use one, not both.

/cc @MartijnKaijser @Montellese 

@MrMC / @davilla I see you're commenting on some Kodi PR. If you are still into android (which I doubt ;) ), your comments are most welcome. I'm feeling a bit alone ;)
Just tell me if you accept to be pinged or not. 
