### PR TITLE
CGUIDialogAudioDSPSettings: fix duplication of "Are you sure?" in dialog message:

### DIFF
--- a/xbmc/settings/dialogs/GUIDialogAudioDSPSettings.cpp
+++ b/xbmc/settings/dialogs/GUIDialogAudioDSPSettings.cpp
@@ -379,7 +379,7 @@ void CGUIDialogAudioDSPSettings::Save()
     return;
 
   // prompt user if they are sure
-  if (!CGUIDialogYesNo::ShowAndGetInput(12376, 750, 0, 12377))
+  if (!CGUIDialogYesNo::ShowAndGetInput(CVariant{12376}, CVariant{12377}))
     return;
 
   // reset the settings


### PR DESCRIPTION
When testing https://github.com/xbmc/xbmc/pull/8283 the  DSP dialog message I see that this shows **Are you sure?** twice.

Current dialog.
![screenshot024](https://cloud.githubusercontent.com/assets/3521959/10716184/58d126a2-7b28-11e5-8223-be9b1df06907.png)

This PR makes fixes this message and falls in line with [GUIDialogVideoSettings](https://github.com/xbmc/xbmc/blob/f42c66f130805765b0c30d947980d5f2af847cde/xbmc/video/dialogs/GUIDialogVideoSettings.cpp#L175) and [GUIDialogAudioSubtitleSettings](https://github.com/xbmc/xbmc/blob/f42c66f130805765b0c30d947980d5f2af847cde/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp#L244) implementation.

This seems to be a no brainer and I didnt compile to confirm as it seems obvious it will work as intended. I can test and conform soon as Im near my htpc.

@MartijnKaijser and @AchimTuran I suppose for review/merge
