### PR TITLE
[Screensaver] Allow Dim screensaver to animate when closing

### DIFF
--- a/xbmc/windows/GUIWindowScreensaverDim.cpp
+++ b/xbmc/windows/GUIWindowScreensaverDim.cpp
@@ -28,6 +28,7 @@ CGUIWindowScreensaverDim::CGUIWindowScreensaverDim(void)
 {
   m_needsScaling = false;
   m_dimLevel = 100.0f;
+  m_newDimLevel = 100.0f;
   m_animations.push_back(CAnimation::CreateFader(0, 100, 0, 1000, ANIM_TYPE_WINDOW_OPEN));
   m_animations.push_back(CAnimation::CreateFader(100, 0, 0, 1000, ANIM_TYPE_WINDOW_CLOSE));
   m_renderOrder = RENDER_ORDER_WINDOW_SCREENSAVER;
@@ -39,8 +40,8 @@ CGUIWindowScreensaverDim::~CGUIWindowScreensaverDim(void)
 
 void CGUIWindowScreensaverDim::UpdateVisibility()
 {
-  m_dimLevel = g_application.GetDimScreenSaverLevel();
-  if (m_dimLevel)
+  m_newDimLevel = g_application.GetDimScreenSaverLevel();
+  if (m_newDimLevel)
     Open();
   else
     Close();
@@ -48,6 +49,8 @@ void CGUIWindowScreensaverDim::UpdateVisibility()
 
 void CGUIWindowScreensaverDim::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
+  if (m_newDimLevel != m_dimLevel && !IsAnimating(ANIM_TYPE_WINDOW_CLOSE))
+    m_dimLevel = m_newDimLevel;
   CGUIDialog::Process(currentTime, dirtyregions);
   m_renderRegion.SetRect(0, 0, (float)g_graphicsContext.GetWidth(), (float)g_graphicsContext.GetHeight());
 }

--- a/xbmc/windows/GUIWindowScreensaverDim.h
+++ b/xbmc/windows/GUIWindowScreensaverDim.h
@@ -34,4 +34,5 @@ protected:
   virtual void UpdateVisibility();
 private:
   float m_dimLevel;
+  float m_newDimLevel;
 };


### PR DESCRIPTION
Just PR'ing this so it's not forgotten - should have gone into 15.2.

Fix for screensaver remaining dim on skin reload has a side effect after #8179 of stopping the animation during closing the screensaver.

We need to ensure the dim level is only reset when animation finishes
