### PR TITLE
[guiinfo] Fixed LISTITEM_ISRECORDING for epg event items ...

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -5896,9 +5896,9 @@ bool CGUIInfoManager::GetItemBool(const CGUIListItem *item, int condition) const
       {
         CEpgInfoTagPtr epgTag = pItem->GetEPGInfoTag();
 
-        // Check if the tag has a currently active recording associated
-        if (epgTag->HasRecording() && epgTag->IsActive())
-          return true;
+        // Check if the tag has a currently recording timer associated
+        if (epgTag->HasTimer())
+          return epgTag->Timer()->IsRecording();
 
         // Search all timers for something that matches the tag
         CFileItemPtr timer = g_PVRTimers->GetTimerForEpgTag(pItem);


### PR DESCRIPTION
... in case there is an aborted recording for the selected epg event.

Problem reported here: http://forum.kodi.tv/showthread.php?tid=227026&pid=2143017#pid2143017

@Jalle19 or @xhaggi mind taking a look.
