### PR TITLE
add Skin.SelectBool builtin

### DIFF
--- a/xbmc/interfaces/builtins/SkinBuiltins.cpp
+++ b/xbmc/interfaces/builtins/SkinBuiltins.cpp
@@ -25,7 +25,9 @@
 #include "Application.h"
 #include "dialogs/GUIDialogFileBrowser.h"
 #include "dialogs/GUIDialogNumeric.h"
+#include "dialogs/GUIDialogSelect.h"
 #include "guilib/GUIKeyboardFactory.h"
+#include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "MediaSource.h"
 #include "settings/MediaSourceSettings.h"
@@ -94,6 +96,47 @@ static int SetAddon(const std::vector<std::string>& params)
   if (types.size() > 0 && CGUIWindowAddonBrowser::SelectAddonID(types, result, true) == 1)
   {
     CSkinSettings::GetInstance().SetString(string, result);
+    CSettings::GetInstance().Save();
+  }
+
+  return 0;
+}
+
+/*! \brief Select and set a skin bool setting.
+ *  \param params The parameters.
+ *  \details params[0] = Names of skin settings.
+ */
+static int SelectBool(const std::vector<std::string>& params)
+{
+  std::vector<std::pair<std::string, std::string>> settings;
+
+  CGUIDialogSelect* pDlgSelect = (CGUIDialogSelect*)g_windowManager.GetWindow(WINDOW_DIALOG_SELECT);
+  pDlgSelect->Reset();
+  pDlgSelect->SetHeading(CVariant{g_localizeStrings.Get(424)});
+
+  for (unsigned int i = 0 ; i < params.size() ; i++)
+  {
+    std::vector<std::string> values = StringUtils::Split(params[i], '|');
+    std::string label = g_localizeStrings.Get(atoi(values[0].c_str()));
+    settings.push_back(std::make_pair(label,values[1].c_str()));
+    pDlgSelect->Add(label);
+  }
+
+  pDlgSelect->Open();
+
+  if(pDlgSelect->IsConfirmed())
+  {
+    unsigned int iItem = pDlgSelect->GetSelectedItem();
+
+    for (unsigned int i = 0 ; i < settings.size() ; i++)
+    {
+      std::string item = settings[i].second;
+      int setting = CSkinSettings::GetInstance().TranslateBool(item);
+      if (i == iItem)
+        CSkinSettings::GetInstance().SetBool(setting, true);
+      else
+        CSkinSettings::GetInstance().SetBool(setting, false);
+    }
     CSettings::GetInstance().Save();
   }
 
@@ -402,6 +445,7 @@ CBuiltins::CommandMap CSkinBuiltins::GetOperations() const
            {"skin.reset",         {"Resets a skin setting to default", 1, SkinReset}},
            {"skin.resetsettings", {"Resets all skin settings", 0, SkinResetAll}},
            {"skin.setaddon",      {"Prompts and set an addon", 2, SetAddon}},
+           {"skin.selectbool",    {"Prompts and set a skin setting", 1, SelectBool}},
            {"skin.setbool",       {"Sets a skin setting on", 1, SetBool}},
            {"skin.setfile",       {"Prompts and sets a file", 1, SetFile}},
            {"skin.setimage",      {"Prompts and sets a skin image", 1, SetImage}},


### PR DESCRIPTION
currently skins can't use a togglebutton (or select dialog) for a skin setting to toggle between several options.

this allows skins to use  a select dialog to select between multiple skin setting options.

example:
Skin.SelectBool(31411|RecentWidget, 31412|RandomWidget, 31413|InProgressWidget)

usual warning applies: me no speak c++
@mkortstiege for review?
