### PR TITLE
FIX: don't show size for non-file items

### DIFF
--- a/xbmc/filesystem/AndroidAppDirectory.cpp
+++ b/xbmc/filesystem/AndroidAppDirectory.cpp
@@ -69,6 +69,7 @@ bool CAndroidAppDirectory::GetDirectory(const CURL& url, CFileItemList &items)
       pItem->SetPath(path);
       pItem->SetLabel((*i).packageLabel);
       pItem->SetArt("thumb", path+".png");
+      pItem->m_dwSize = -1;  // No size
       items.Add(pItem);
     }
     return true;

--- a/xbmc/filesystem/MusicDatabaseDirectory.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory.cpp
@@ -45,6 +45,8 @@ bool CMusicDatabaseDirectory::GetDirectory(const CURL& url, CFileItemList &items
 {
   std::string path = CLegacyPathTranslation::TranslateMusicDbPath(url);
   items.SetPath(path);
+  items.m_dwSize = -1;  // No size
+
   std::unique_ptr<CDirectoryNode> pNode(CDirectoryNode::ParseURL(path));
 
   if (!pNode.get())

--- a/xbmc/filesystem/VideoDatabaseDirectory.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory.cpp
@@ -46,6 +46,7 @@ bool CVideoDatabaseDirectory::GetDirectory(const CURL& url, CFileItemList &items
 {
   std::string path = CLegacyPathTranslation::TranslateVideoDbPath(url);
   items.SetPath(path);
+  items.m_dwSize = -1;  // No size
   std::unique_ptr<CDirectoryNode> pNode(CDirectoryNode::ParseURL(path));
 
   if (!pNode.get())

--- a/xbmc/utils/LabelFormatter.cpp
+++ b/xbmc/utils/LabelFormatter.cpp
@@ -238,7 +238,7 @@ std::string CLabelFormatter::GetMaskContent(const CMaskString &mask, const CFile
     }
     break;
   case 'I': // size
-    if( !item->m_bIsFolder || item->m_dwSize != 0 )
+    if( (item->m_bIsFolder && item->m_dwSize != 0) || item->m_dwSize >= 0 )
       value = StringUtils::SizeToString(item->m_dwSize);
     break;
   case 'J': // date


### PR DESCRIPTION
This to avoid "0B" to appear in "false" file lists like android apps

See the screenshots in https://github.com/xbmc/xbmc/pull/8300 to understand what I mean

/cc @Montellese @MartijnKaijser 
