### PR TITLE
[confluence]fix 3D/subtitles menu alignment when VideoPlayer.HasMenu is not visible

### DIFF
--- a/addons/skin.confluence/720p/VideoOSD.xml
+++ b/addons/skin.confluence/720p/VideoOSD.xml
@@ -177,7 +177,7 @@
 				<visible>VideoPlayer.HasMenu + !VideoPlayer.Content(LiveTV)</visible>
 			</control>
 			<control type="image" id="2300">
-				<width>165</width>
+				<width>160</width>
 				<texture>-</texture>
 				<visible>VideoPlayer.Content(LiveTV)</visible>
 			</control>
@@ -294,6 +294,7 @@
 			<animation effect="slide" start="0,0" end="0,80" time="0" condition="![VideoPlayer.HasSubtitles + VideoPlayer.SubtitlesEnabled]">Conditional</animation>
 			<animation effect="slide" start="0,0" end="0,40" time="0" condition="!VideoPlayer.HasSubtitles">Conditional</animation>
 			<animation effect="slide" start="0,0" end="55,0" time="0" condition="![VideoPlayer.HasMenu | VideoPlayer.Content(LiveTV)]">Conditional</animation>
+			<animation effect="slide" start="0,0" end="55,0" time="0" condition="!VideoPlayer.HasMenu + VideoPlayer.Content(LiveTV)">Conditional</animation>
 			<right>145</right>
 			<bottom>45</bottom>
 			<width>256</width>

--- a/addons/skin.confluence/720p/VideoOSD.xml
+++ b/addons/skin.confluence/720p/VideoOSD.xml
@@ -413,6 +413,7 @@
 			<depth>DepthOSD+</depth>
 			<visible>videoplayer.isstereoscopic + ![Window.IsVisible(SliderDialog) | Window.IsVisible(OSDVideoSettings) | Window.IsVisible(OSDAudioSettings) | Window.IsVisible(OSDAudioDSPSettings) | Window.IsVisible(VideoBookmarks) | Window.IsVisible(PVROSDChannels) | Window.IsVisible(PVROSDGuide)] + [Control.HasFocus(255) | ControlGroup(500).HasFocus | Control.HasFocus(520)]</visible>
 			<animation effect="fade" time="150">VisibleChange</animation>
+			<animation effect="slide" start="0,0" end="55,0" time="0" condition="![VideoPlayer.HasMenu | VideoPlayer.Content(LiveTV)]">Conditional</animation>
 			<animation effect="slide" start="0,0" end="55,0" time="0" condition="VideoPlayer.Content(LiveTV)">Conditional</animation>
 			<right>200</right>
 			<bottom>45</bottom>


### PR DESCRIPTION
and hopefully keep alignment it when VideoPlayer.HasMenu is also visible
and videoplayer.isstereoscopic is also visible i.e. if a disc has menu and the content is 3d

I dont use 3d but I found some 3d file on system from a bug report and found the alignment was off 
I'll admit Im not 100% sure but in the way I was able to test it works, 

Before
![screenshot028](https://cloud.githubusercontent.com/assets/3521959/10773801/6c499308-7cf5-11e5-94d2-ffb75eea35a7.png)

after
![screenshot027](https://cloud.githubusercontent.com/assets/3521959/10773660/932170e6-7cf4-11e5-98ae-9dc06c8e7c77.png)

@HitcherUK if you dont mind.
