### PR TITLE
[globals] remove macro XBMC_GLOBAL

### DIFF
--- a/xbmc/guilib/GraphicContext.h
+++ b/xbmc/guilib/GraphicContext.h
@@ -296,6 +296,6 @@ private:
  \brief
  */
 
-XBMC_GLOBAL(CGraphicContext,g_graphicsContext);
-
+XBMC_GLOBAL_REF(CGraphicContext,g_graphicsContext);
+#define g_graphicsContext XBMC_GLOBAL_USE(CGraphicContext)
 #endif

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -400,4 +400,5 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     void setExtraLogLevel(const std::vector<CVariant> &components);
 };
 
-XBMC_GLOBAL(CAdvancedSettings,g_advancedSettings);
+XBMC_GLOBAL_REF(CAdvancedSettings,g_advancedSettings);
+#define g_advancedSettings XBMC_GLOBAL_USE(CAdvancedSettings)

--- a/xbmc/utils/CharsetConverter.h
+++ b/xbmc/utils/CharsetConverter.h
@@ -173,6 +173,6 @@ private:
   class CInnerConverter;
 };
 
-XBMC_GLOBAL(CCharsetConverter,g_charsetConverter);
-
+XBMC_GLOBAL_REF(CCharsetConverter,g_charsetConverter);
+#define g_charsetConverter XBMC_GLOBAL_USE(CCharsetConverter)
 #endif

--- a/xbmc/utils/GlobalsHandling.h
+++ b/xbmc/utils/GlobalsHandling.h
@@ -212,13 +212,3 @@ namespace xbmcutil
  * #define g_variable XBMC_GLOBAL_USE(classname)
  */
 #define XBMC_GLOBAL_USE(classname) (*(xbmcutil::GlobalsSingleton<classname>::getQuick()))
-
-/**
- * For pattern (1) above, you can use the following macro. WARNING: This should only 
- * be used when the global in question is never accessed, directly or indirectly, from
- * a static method called (again, directly or indirectly) during startup or shutdown.
- */
-#define XBMC_GLOBAL(classname,g_variable) \
-  XBMC_GLOBAL_REF(classname,g_variable); \
-  static classname & g_variable = (*(g_variable##Ref.get()))
-


### PR DESCRIPTION
This silents the globals `defined but not used` compiler warnings. Even though it's a hack and we're going to get rid of all those globals, I'd like to get this one in so we do not miss actual compiler warnings.

/cc @FernetMenta, @Montellese
