### PR TITLE
[guilib] fix togglebutton not properly resizing when using the altlabel

### DIFF
--- a/xbmc/guilib/GUIToggleButtonControl.cpp
+++ b/xbmc/guilib/GUIToggleButtonControl.cpp
@@ -38,14 +38,8 @@ CGUIToggleButtonControl::~CGUIToggleButtonControl(void)
 void CGUIToggleButtonControl::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
   // ask our infoManager whether we are selected or not...
-  bool selected = m_bSelected;
   if (m_toggleSelect)
-    selected = m_toggleSelect->Get();
-  if (selected != m_bSelected)
-  {
-    MarkDirtyRegion();
-    m_bSelected = selected;
-  }
+    m_bSelected = m_toggleSelect->Get();
 
   if (m_bSelected)
   {
@@ -54,9 +48,25 @@ void CGUIToggleButtonControl::Process(unsigned int currentTime, CDirtyRegionList
     m_selectButton.SetVisible(IsVisible());
     m_selectButton.SetEnabled(!IsDisabled());
     m_selectButton.SetPulseOnSelect(m_pulseOnSelect);
+    ProcessToggle(currentTime);
     m_selectButton.DoProcess(currentTime, dirtyregions);
   }
-  CGUIButtonControl::Process(currentTime, dirtyregions);
+  else
+    CGUIButtonControl::Process(currentTime, dirtyregions);
+}
+
+void CGUIToggleButtonControl::ProcessToggle(unsigned int currentTime)
+{
+  bool changed = false;
+
+  changed |= m_label.SetMaxRect(m_posX, m_posY, GetWidth(), m_height);
+  changed |= m_label.SetText(GetDescription());
+  changed |= m_label.SetColor(GetTextColor());
+  changed |= m_label.SetScrolling(HasFocus());
+  changed |= m_label.Process(currentTime);
+
+  if (changed)
+    MarkDirtyRegion();
 }
 
 void CGUIToggleButtonControl::Render()
@@ -137,12 +147,6 @@ bool CGUIToggleButtonControl::UpdateColors()
   changed |= m_selectButton.UpdateColors();
 
   return changed;
-}
-
-void CGUIToggleButtonControl::SetLabel(const std::string &strLabel)
-{
-  CGUIButtonControl::SetLabel(strLabel);
-  m_selectButton.SetLabel(strLabel);
 }
 
 void CGUIToggleButtonControl::SetAltLabel(const std::string &label)

--- a/xbmc/guilib/GUIToggleButtonControl.h
+++ b/xbmc/guilib/GUIToggleButtonControl.h
@@ -52,7 +52,6 @@ public:
   virtual void SetWidth(float width);
   virtual void SetHeight(float height);
   virtual void SetMinWidth(float minWidth);
-  void SetLabel(const std::string& strLabel);
   void SetAltLabel(const std::string& label);
   virtual std::string GetDescription() const;
   void SetToggleSelect(const std::string &toggleSelect);
@@ -63,5 +62,9 @@ protected:
   virtual void OnClick();
   CGUIButtonControl m_selectButton;
   INFO::InfoPtr m_toggleSelect;
+
+private:
+  void ProcessToggle(unsigned int currentTime);
+  std::string m_altLabel;
 };
 #endif


### PR DESCRIPTION
This fixes an issue where auto-width toggle button controls fail to properly resize when the altlabel is used.

@HitcherUK, since I've slightly modified it since you tested, it would be cool if you could give it another try.
