### PR TITLE
[make] silent ar compiler warnings

### DIFF
--- a/Makefile.include.in
+++ b/Makefile.include.in
@@ -1,5 +1,5 @@
 AR=@AR@
-ARFLAGS=crus
+ARFLAGS=crs
 RM=rm -rf
 SHELL=@SHELL@
 ARCH=@ARCH@


### PR DESCRIPTION
In recent gnu binutils `ar` operates in deterministic mode by default. This is rendering the 'u' option useless and is causing `ar: `u' modifier ignored since `D' is the default (see `U')` compiler warnings.

/cc @FernetMenta, @Memphiz, @wsnipex 
