### PR TITLE
Fix unit tests on linux/os-x

### DIFF
--- a/xbmc/music/tags/TagLoaderTagLib.cpp
+++ b/xbmc/music/tags/TagLoaderTagLib.cpp
@@ -372,6 +372,10 @@ bool CTagLoaderTagLib::ParseTag(ID3v2::Tag *id3v2, MUSIC_INFO::EmbeddedArt *art,
       break;
     }
 
+
+  if (id3v2->comment() != String::null)
+    tag.SetComment(id3v2->comment().toCString(true));
+
   tag.SetReplayGain(replayGainInfo);
   return true;
 }

--- a/xbmc/music/tags/test/TestTagLoaderTagLib.cpp
+++ b/xbmc/music/tags/test/TestTagLoaderTagLib.cpp
@@ -35,17 +35,6 @@ template <typename T>
 class TestTagParser : public ::testing::Test, public CTagLoaderTagLib {
    public:
      T value_;
-
-     virtual void SetUp() {
-       // Configure a basic tag..
-       value_.setTitle ("title");
-       value_.setArtist ("artist");
-       value_.setAlbum ("album");
-       value_.setComment("comment");
-       value_.setGenre("Jazz");
-       value_.setYear (1985);
-       value_.setTrack (2);
-     }
 };
 
 
@@ -55,6 +44,15 @@ TYPED_TEST_CASE(TestTagParser, TagTypes);
 TYPED_TEST(TestTagParser, ParsesBasicTag) {
   // Create a basic tag
   TypeParam *tg  = &this->value_;
+  // Configure a basic tag..
+  tg->setTitle ("title");
+  tg->setArtist ("artist");
+  tg->setAlbum ("album");
+  tg->setComment("comment");
+  tg->setGenre("Jazz");
+  tg->setYear (1985);
+  tg->setTrack (2);
+
   CMusicInfoTag tag;
   EXPECT_TRUE(CTagLoaderTagLib::ParseTag<TypeParam>(tg, NULL, tag));
 


### PR DESCRIPTION
- Older tag lib libraries handle tag types differently
- Added missing comment setter for ID3v2
