### PR TITLE
Text should only be changeable when viewing the keyboard.

### DIFF
--- a/xbmc/guilib/GUIEditControl.cpp
+++ b/xbmc/guilib/GUIEditControl.cpp
@@ -116,7 +116,7 @@ bool CGUIEditControl::OnAction(const CAction &action)
 {
   ValidateCursor();
 
-  if (m_inputType != INPUT_TYPE_READONLY)
+  if (m_inputType != INPUT_TYPE_READONLY && GetParentID() == WINDOW_DIALOG_KEYBOARD)
   {
     if (action.GetID() == ACTION_BACKSPACE)
     {
@@ -490,7 +490,7 @@ void CGUIEditControl::ProcessText(unsigned int currentTime)
     {
       changed |= m_label2.SetText(hint);
     }
-    else if ((HasFocus() || GetParentID() == WINDOW_DIALOG_KEYBOARD) &&
+    else if (GetParentID() == WINDOW_DIALOG_KEYBOARD &&
              m_inputType != INPUT_TYPE_READONLY)
     {
       changed |= SetStyledText(text);


### PR DESCRIPTION
@phil65 

```
The gain from being instantly able to type with a keyboard doesnt outweigh the downsides of those controls for remotes (overriding onback, requiring to press left/right a lot of times to move focus across that control)
Remotes should be the primary input method we should focus on.
This problem becomes very obvious in some of the PVR dialogs with a lot of edit controls (Timer dialog and search dialog if I am not mistaken)

Imo we should kill that control type and make everything a button which opens DialogKeyboard.
```

Not sure if this is sane the way I did it and I think it might also create discussion. So here is a PR to start this, even if K****\* is still far away.
