### PR TITLE
Lower "Thread start" logging level

### DIFF
--- a/xbmc/threads/Thread.cpp
+++ b/xbmc/threads/Thread.cpp
@@ -123,7 +123,7 @@ THREADFUNC CThread::staticThread(void* data)
 
   pThread->SetThreadInfo();
 
-  LOG(LOGNOTICE,"Thread %s start, auto delete: %s", name.c_str(), (autodelete ? "true" : "false"));
+  LOG(LOGDEBUG,"Thread %s start, auto delete: %s", name.c_str(), (autodelete ? "true" : "false"));
 
   currentThread.set(pThread);
   pThread->m_StartEvent.Set();


### PR DESCRIPTION
Thread starting probably doesn't need to be NOTICEd by everyone; it's log junk at best, and can occasionally get ugly. Dropped to DEBUG to match the "Thread terminating" message.

The ugliness that I have stumbled upon is that this message, and one other that is covered by #8316, can be logged profusely with a frequently changing plugin path powering a multiimage control.
