### PR TITLE
DialogContentSettings remove scraper list and replace with a button that opens up a list

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -18087,3 +18087,13 @@ msgstr ""
 msgctxt "#38023"
 msgid "Set my rating"
 msgstr ""
+
+#: \xbmc\settings\dialogs\GUIDialogContentSettings.cpp
+msgctxt "#38024"
+msgid "Information provider selection"
+msgstr ""
+
+#: \xbmc\settings\dialogs\GUIDialogContentSettings.cpp
+msgctxt "#38025"
+msgid "Choose information provider"
+msgstr ""

--- a/addons/skin.confluence/720p/DialogContentSettings.xml
+++ b/addons/skin.confluence/720p/DialogContentSettings.xml
@@ -3,7 +3,7 @@
 	<defaultcontrol always="true">20</defaultcontrol>
 	<coordinates>
 		<left>240</left>
-		<top>20</top>
+		<top>90</top>
 	</coordinates>
 	<include>dialogeffect</include>
 	<controls>
@@ -11,207 +11,47 @@
 			<animation effect="fade" start="100" end="0" time="150" condition="Window.IsActive(AddonSettings)">Conditional</animation>
 			<include name="DialogBackgroundCommons">
 				<param name="DialogBackgroundWidth" value="800" />
-				<param name="DialogBackgroundHeight" value="680" />
+				<param name="DialogBackgroundHeight" value="535" />
 				<param name="DialogHeaderWidth" value="720" />
 				<param name="DialogHeaderLabel" value="$LOCALIZE[20333]" />
 				<param name="DialogHeaderId" value="1" />
 				<param name="CloseButtonLeft" value="710" />
 				<param name="CloseButtonNav" value="10" />
 			</include>
-			<control type="label">
-				<description>Content Picker Header</description>
-				<left>30</left>
-				<top>60</top>
-				<width>320</width>
-				<height>40</height>
-				<font>font12</font>
-				<label>$LOCALIZE[20344]</label>
-				<align>center</align>
-				<aligny>center</aligny>
-				<textcolor>blue</textcolor>
-				<shadowcolor>black</shadowcolor>
-			</control>
-			<control type="spincontrolex" id="20">
+			<control type="button" id="20">
 				<description>Content Picker</description>
 				<left>30</left>
-				<top>100</top>
-				<width>320</width>
+				<top>60</top>
+				<width>740</width>
 				<height>40</height>
-				<texturefocus border="5">button-focus.png</texturefocus>
-				<texturenofocus border="5">button-nofocus.png</texturenofocus>
-				<font>-</font>
-				<label>-</label>
-				<reverse>yes</reverse>
 				<onup>28</onup>
-				<ondown>5</ondown>
-				<onleft>60</onleft>
-				<onright>21</onright>
+				<ondown>21</ondown>
+				<font>font13</font>
 			</control>
-			<control type="label">
-				<description>Content Picker label</description>
-				<left>35</left>
-				<top>100</top>
-				<width>280</width>
+			<control type="button" id="21">
+				<description>Information Provider Button</description>
+				<left>30</left>
+				<top>105</top>
+				<width>740</width>
 				<height>40</height>
-				<font>font13_title</font>
-				<label>$INFO[Control.GetLabel(20)]</label>
-				<align>left</align>
-				<aligny>center</aligny>
-				<textcolor>white</textcolor>
-				<shadowcolor>black</shadowcolor>
+				<onup>20</onup>
+				<ondown>22</ondown>
+				<font>font13</font>
 			</control>
-			<control type="label">
-				<description>Used Scraper Header</description>
+			<control type="button" id="22">
+				<description>Scraper Settings Button</description>
 				<left>30</left>
 				<top>150</top>
-				<width>320</width>
-				<height>20</height>
-				<font>font12</font>
-				<label>$LOCALIZE[31312]</label>
-				<align>center</align>
-				<aligny>center</aligny>
-				<textcolor>blue</textcolor>
-				<shadowcolor>black</shadowcolor>
-			</control>
-			<control type="image">
-				<description>Used Scraper Image</description>
-				<left>30</left>
-				<top>175</top>
-				<width>320</width>
-				<height>130</height>
-				<aspectratio>keep</aspectratio>
-				<texture>$INFO[ListItem.Icon]</texture>
-			</control>
-			<control type="label">
-				<description>Used Scaper Label</description>
-				<left>30</left>
-				<top>315</top>
-				<width>320</width>
-				<height>30</height>
-				<font>font13</font>
-				<label>[B]$INFO[ListItem.Label][/B]</label>
-				<align>center</align>
-				<aligny>center</aligny>
-				<textcolor>selected</textcolor>
-				<shadowcolor>black</shadowcolor>
-			</control>
-			<control type="image">
-				<left>370</left>
-				<top>60</top>
-				<width>5</width>
-				<height>280</height>
-				<aspectratio>stretch</aspectratio>
-				<texture>separator_vertical.png</texture>
-			</control>
-			<control type="label">
-				<description>Scraper List Header</description>
-				<left>400</left>
-				<top>60</top>
-				<width>360</width>
+				<width>740</width>
 				<height>40</height>
-				<font>font12</font>
-				<label>$LOCALIZE[31313]</label>
-				<align>center</align>
-				<aligny>center</aligny>
-				<textcolor>blue</textcolor>
-				<shadowcolor>black</shadowcolor>
-			</control>
-			<control type="list" id="21">
-				<left>400</left>
-				<top>100</top>
-				<width>360</width>
-				<height>241</height>
+				<label>- $LOCALIZE[5]</label>
 				<onup>21</onup>
-				<onleft>20</onleft>
-				<onright>60</onright>
-				<ondown>21</ondown>
-				<pagecontrol>60</pagecontrol>
-				<scrolltime>200</scrolltime>
-				<itemlayout height="45">
-					<control type="image">
-						<left>0</left>
-						<top>0</top>
-						<width>360</width>
-						<height>40</height>
-						<texture border="5">button-nofocus.png</texture>
-					</control>
-					<control type="image">
-						<left>5</left>
-						<top>5</top>
-						<width>35</width>
-						<height>30</height>
-						<texture>$INFO[Listitem.Icon]</texture>
-					</control>
-					<control type="label">
-						<left>50</left>
-						<top>0</top>
-						<width>290</width>
-						<height>40</height>
-						<font>font13</font>
-						<align>left</align>
-						<aligny>center</aligny>
-						<textcolor>grey2</textcolor>
-						<selectedcolor>selected</selectedcolor>
-						<info>ListItem.Label</info>
-					</control>
-				</itemlayout>
-				<focusedlayout height="45">
-					<control type="image">
-						<left>0</left>
-						<top>0</top>
-						<width>360</width>
-						<height>40</height>
-						<visible>!Control.HasFocus(21)</visible>
-						<texture border="5">button-nofocus.png</texture>
-					</control>
-					<control type="image">
-						<left>0</left>
-						<top>0</top>
-						<width>360</width>
-						<height>40</height>
-						<visible>Control.HasFocus(21)</visible>
-						<texture border="5">button-focus2.png</texture>
-					</control>
-					<control type="image">
-						<left>5</left>
-						<top>5</top>
-						<width>35</width>
-						<height>30</height>
-						<texture>$INFO[Listitem.Icon]</texture>
-					</control>
-					<control type="label">
-						<left>50</left>
-						<top>0</top>
-						<width>290</width>
-						<height>40</height>
-						<font>font13</font>
-						<align>left</align>
-						<aligny>center</aligny>
-						<textcolor>white</textcolor>
-						<selectedcolor>selected</selectedcolor>
-						<info>ListItem.Label</info>
-					</control>
-				</focusedlayout>
-			</control>
-			<control type="scrollbar" id="60">
-				<left>760</left>
-				<top>100</top>
-				<width>25</width>
-				<height>240</height>
-				<texturesliderbackground border="0,14,0,14">ScrollBarV.png</texturesliderbackground>
-				<texturesliderbar border="0,14,0,14">ScrollBarV_bar.png</texturesliderbar>
-				<texturesliderbarfocus border="0,14,0,14">ScrollBarV_bar_focus.png</texturesliderbarfocus>
-				<textureslidernib>ScrollBarNib.png</textureslidernib>
-				<textureslidernibfocus>ScrollBarNib.png</textureslidernibfocus>
-				<onleft>21</onleft>
-				<onright>20</onright>
-				<showonepage>true</showonepage>
-				<orientation>vertical</orientation>
+				<ondown>5</ondown>
 			</control>
 			<control type="label">
 				<description>Scanning Options Header</description>
 				<left>30</left>
-				<top>350</top>
+				<top>205</top>
 				<width>740</width>
 				<height>20</height>
 				<font>font12</font>
@@ -224,11 +64,11 @@
 			<control type="grouplist" id="5">
 				<description>control area</description>
 				<left>30</left>
-				<top>380</top>
+				<top>235</top>
 				<width>740</width>
 				<height>220</height>
 				<itemgap>4</itemgap>
-				<onup>20</onup>
+				<onup>22</onup>
 				<ondown>28</ondown>
 				<onleft>5</onleft>
 				<onright>5</onright>
@@ -250,10 +90,10 @@
 				<texturefocus border="5">button-focus2.png</texturefocus>
 			</control>
 			<control type="group" id="9001">
-				<top>615</top>
+				<top>470</top>
 				<control type="button" id="28">
 					<description>OK Button</description>
-					<left>300</left>
+					<left>195</left>
 					<top>0</top>
 					<width>200</width>
 					<height>40</height>
@@ -261,14 +101,14 @@
 					<aligny>center</aligny>
 					<font>font12_title</font>
 					<label>186</label>
-					<onleft>22</onleft>
+					<onleft>29</onleft>
 					<onright>29</onright>
 					<onup>5</onup>
 					<ondown>20</ondown>
 				</control>
 				<control type="button" id="29">
 					<description>Cancel Button</description>
-					<left>510</left>
+					<left>405</left>
 					<top>0</top>
 					<width>200</width>
 					<height>40</height>
@@ -277,21 +117,6 @@
 					<font>font12_title</font>
 					<label>222</label>
 					<onleft>28</onleft>
-					<onright>22</onright>
-					<onup>5</onup>
-					<ondown>20</ondown>
-				</control>
-				<control type="button" id="22">
-					<description>Settings Button</description>
-					<left>90</left>
-					<top>0</top>
-					<width>200</width>
-					<height>40</height>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font12_title</font>
-					<label>5</label>
-					<onleft>29</onleft>
 					<onright>28</onright>
 					<onup>5</onup>
 					<ondown>20</ondown>

--- a/xbmc/addons/GUIWindowAddonBrowser.h
+++ b/xbmc/addons/GUIWindowAddonBrowser.h
@@ -36,7 +36,7 @@ public:
 
   /*! \brief Popup a selection dialog with a list of addons of the given type
    \param type the type of addon wanted
-   \param addonID [out] the addon ID of the selected item
+   \param addonID [in/out] the addon ID of the (pre) selected item
    \param showNone whether there should be a "None" item in the list (defaults to false)
    \param showDetails whether to show details of the addons or not
    \param showInstalled whether installed addons should be in the list
@@ -48,7 +48,7 @@ public:
   static int SelectAddonID(const std::vector<ADDON::TYPE> &types, std::string &addonID, bool showNone = false, bool showDetails = true, bool showInstalled = true, bool showInstallable = false, bool showMore = true);
   /*! \brief Popup a selection dialog with a list of addons of the given type
    \param type the type of addon wanted
-   \param addonIDs [out] array of selected addon IDs
+   \param addonIDs [in/out] array of (pre) selected addon IDs
    \param showNone whether there should be a "None" item in the list (defaults to false)
    \param showDetails whether to show details of the addons or not
    \param multipleSelection allow selection of multiple addons, if set to true showNone will automaticly switch to false

--- a/xbmc/settings/dialogs/GUIDialogContentSettings.cpp
+++ b/xbmc/settings/dialogs/GUIDialogContentSettings.cpp
@@ -27,24 +27,23 @@
 #include <limits.h>
 
 #include "GUIDialogContentSettings.h"
-#include "FileItem.h"
-#include "addons/AddonManager.h"
 #include "addons/GUIDialogAddonSettings.h"
+#include "addons/GUIWindowAddonBrowser.h"
 #include "filesystem/AddonsDirectory.h"
 #include "dialogs/GUIDialogKaiToast.h"
+#include "dialogs/GUIDialogSelect.h"
 #include "guilib/GUIWindowManager.h"
-#include "input/Key.h"
 #include "interfaces/builtins/Builtins.h"
 #include "settings/lib/Setting.h"
-#include "settings/lib/SettingDependency.h"
 #include "settings/lib/SettingsManager.h"
 #include "utils/log.h"
+#include "utils/StringUtils.h"
 #include "video/VideoInfoScanner.h"
 
-#define CONTROL_CONTENT_TYPE       20
-#define CONTROL_SCRAPER_LIST       21
-#define CONTROL_SCRAPER_SETTINGS   22
-#define CONTROL_START              30
+#define CONTROL_CONTENT_TYPE_BUTTON     20
+#define CONTROL_SCRAPER_LIST_BUTTON     21
+#define CONTROL_SCRAPER_SETTINGS        22
+#define CONTROL_START                   30
 
 #define SETTING_SCAN_RECURSIVE        "scanrecursive"
 #define SETTING_USE_DIRECTORY_NAMES   "usedirectorynames"
@@ -53,6 +52,11 @@
 #define SETTING_NO_UPDATING           "noupdating"
 
 using namespace ADDON;
+
+bool ByAddonName(const AddonPtr& lhs, const AddonPtr& rhs)
+{
+  return StringUtils::CompareNoCase(lhs->Name(), rhs->Name()) < 0;
+}
 
 CGUIDialogContentSettings::CGUIDialogContentSettings()
   : CGUIDialogSettingsManualBase(WINDOW_DIALOG_CONTENT_SETTINGS, "DialogContentSettings.xml"),
@@ -70,6 +74,7 @@ CGUIDialogContentSettings::CGUIDialogContentSettings()
 
 CGUIDialogContentSettings::~CGUIDialogContentSettings()
 {
+  m_scraper = nullptr;
   delete m_vecItems;
 }
 
@@ -79,7 +84,6 @@ bool CGUIDialogContentSettings::OnMessage(CGUIMessage &message)
   {
     case GUI_MSG_WINDOW_DEINIT:
     {
-      m_scrapers.clear();
       m_vecItems->Clear();
 
       break;
@@ -89,46 +93,85 @@ bool CGUIDialogContentSettings::OnMessage(CGUIMessage &message)
     {
       int iControl = message.GetSenderId();
 
-      if (iControl == CONTROL_CONTENT_TYPE)
+      if (iControl == CONTROL_CONTENT_TYPE_BUTTON)
       {
-        CGUIMessage msg(GUI_MSG_ITEM_SELECTED, GetID(), CONTROL_CONTENT_TYPE);
-        OnMessage(msg);
-        m_content = static_cast<CONTENT_TYPE>(msg.GetParam1());
-        SetupView();
-      }
-      else if (iControl == CONTROL_SCRAPER_LIST)
-      {
-        // we handle only select actions
-        int action = message.GetParam1();
-        if (action != ACTION_SELECT_ITEM && action != ACTION_MOUSE_LEFT_CLICK)
-          break;
-
-        CGUIMessage msg(GUI_MSG_ITEM_SELECTED, GetID(), CONTROL_SCRAPER_LIST);
-        OnMessage(msg);
-        int iSelected = msg.GetParam1();
-        if (iSelected == m_vecItems->Size() - 1)
-        { // Get More... item, path 'addons://more/<content>'
-          // This is tricky - ideally we want to completely save the state of this dialog,
-          // close it while linking to the addon manager, then reopen it on return.
-          // For now, we just close the dialog + send the GetPath() to open the addons window
-          std::string content = m_vecItems->Get(iSelected)->GetPath().substr(14);
-          OnCancel();
-          Close();
-          CBuiltins::GetInstance().Execute("ActivateWindow(AddonBrowser,addons://all/xbmc.metadata.scraper." + content + ",return)");
-          return true;
+        std::vector<std::pair<std::string, int>> labels;
+        if (m_content == CONTENT_ALBUMS || m_content == CONTENT_ARTISTS)
+        {
+          labels.push_back(std::make_pair(ADDON::TranslateContent(m_content, true), m_content));
         }
+        else
+        {
+          labels.push_back(std::make_pair(ADDON::TranslateContent(CONTENT_NONE, true), CONTENT_NONE));
+          labels.push_back(std::make_pair(ADDON::TranslateContent(CONTENT_MOVIES, true), CONTENT_MOVIES));
+          labels.push_back(std::make_pair(ADDON::TranslateContent(CONTENT_TVSHOWS, true), CONTENT_TVSHOWS));
+          labels.push_back(std::make_pair(ADDON::TranslateContent(CONTENT_MUSICVIDEOS, true), CONTENT_MUSICVIDEOS));
+        }
+        std::sort(labels.begin(), labels.end());
 
-        AddonPtr last = m_scraper;
-        m_scraper = std::dynamic_pointer_cast<CScraper>(m_scrapers[m_content][iSelected]);
-        m_lastSelected[m_content] = m_scraper;
+        CGUIDialogSelect *dialog = (CGUIDialogSelect *)g_windowManager.GetWindow(WINDOW_DIALOG_SELECT);
+        if (dialog)
+        {
+          dialog->SetHeading(CVariant{ 20344 }); //Label "This directory contains"
 
-        if (m_scraper != last)
+          int iIndex = 0;
+          int iSelected = 0;
+          for (const auto &label : labels)
+          {
+            dialog->Add(label.first);
+
+            if (m_content == label.second)
+              iSelected = iIndex;
+            iIndex++;
+          }
+
+          dialog->SetSelected(iSelected);
+
+          dialog->Open();
+          // Selected item has not changes - in case of cancel or the user selecting the same item
+          if (dialog->GetSelectedLabel() == iSelected)
+            return true;
+          for (const auto &label : labels)
+          {
+            if (dialog->GetSelectedLabelText() == label.first)
+            {
+              m_content = static_cast<CONTENT_TYPE>(label.second);
+              break;
+            }
+          }
+
+          AddonPtr scraperAddon;
+          CAddonMgr::GetInstance().GetDefault(ADDON::ScraperTypeFromContent(m_content), scraperAddon);
+          m_scraper = std::dynamic_pointer_cast<CScraper>(scraperAddon);
+
           SetupView();
+          SET_CONTROL_LABEL2(CONTROL_CONTENT_TYPE_BUTTON, dialog->GetSelectedLabelText());
+          SET_CONTROL_FOCUS(CONTROL_CONTENT_TYPE_BUTTON, 0);
+        }
+      }
+      else if (iControl == CONTROL_SCRAPER_LIST_BUTTON)
+      {
+        ADDON::TYPE type = ADDON::ScraperTypeFromContent(m_content);
+        std::string selectedAddonId = m_scraper->ID();
 
-        if (m_scraper != last)
-          m_needsSaving = true;
-        CONTROL_ENABLE_ON_CONDITION(CONTROL_SCRAPER_SETTINGS, m_scraper->HasSettings());
-        SET_CONTROL_FOCUS(CONTROL_START, 0);
+        if (CGUIWindowAddonBrowser::SelectAddonID(type, selectedAddonId, false) == 1)
+        {
+          AddonPtr last = m_scraper;
+
+          AddonPtr scraperAddon;
+          CAddonMgr::GetInstance().GetAddon(selectedAddonId, scraperAddon);
+          m_scraper = std::dynamic_pointer_cast<CScraper>(scraperAddon);
+
+          SET_CONTROL_LABEL2(CONTROL_SCRAPER_LIST_BUTTON, m_scraper->Name());
+
+          if (m_scraper != last)
+            SetupView();
+
+          if (m_scraper != last)
+            m_needsSaving = true;
+          CONTROL_ENABLE_ON_CONDITION(CONTROL_SCRAPER_SETTINGS, m_scraper->HasSettings());
+          SET_CONTROL_FOCUS(CONTROL_SCRAPER_LIST_BUTTON, 0);
+        }
       }
       else if (iControl == CONTROL_SCRAPER_SETTINGS)
       {
@@ -264,13 +307,8 @@ bool CGUIDialogContentSettings::Show(ADDON::ScraperPtr& scraper, VIDEO::SScanSet
 
 void CGUIDialogContentSettings::OnInitWindow()
 {
-  m_lastSelected.clear();
-
-  // save our current scraper (if any)
-  if (m_scraper != NULL)
-    m_lastSelected[m_content] = m_scraper;
-
-  FillContentTypes();
+  SET_CONTROL_LABEL(CONTROL_CONTENT_TYPE_BUTTON, 20344);
+  SET_CONTROL_LABEL(CONTROL_SCRAPER_LIST_BUTTON, 38025);
   m_needsSaving = false;
 
   CGUIDialogSettingsManualBase::OnInitWindow();
@@ -332,31 +370,32 @@ void CGUIDialogContentSettings::OnCancel()
 
 void CGUIDialogContentSettings::SetupView()
 {
-  CGUIMessage msgReset(GUI_MSG_LABEL_RESET, GetID(), CONTROL_SCRAPER_LIST);
-  OnMessage(msgReset);
+  SET_CONTROL_LABEL2(CONTROL_CONTENT_TYPE_BUTTON, ADDON::TranslateContent(m_content, true));
 
   m_vecItems->Clear();
   if (m_content == CONTENT_NONE)
   {
     m_showScanSettings = false;
-    SET_CONTROL_HIDDEN(CONTROL_SCRAPER_LIST);
+    SET_CONTROL_HIDDEN(CONTROL_SCRAPER_LIST_BUTTON);
     CONTROL_DISABLE(CONTROL_SCRAPER_SETTINGS);
   }
   else
   {
-    FillScraperList();
-    SET_CONTROL_VISIBLE(CONTROL_SCRAPER_LIST);
+    SET_CONTROL_VISIBLE(CONTROL_SCRAPER_LIST_BUTTON);
     if (m_scraper != NULL && m_scraper->Enabled())
     {
+      SET_CONTROL_LABEL2(CONTROL_SCRAPER_LIST_BUTTON, m_scraper->Name());
+
       m_showScanSettings = true;
       if (m_scraper && m_scraper->Supports(m_content) && m_scraper->HasSettings())
         CONTROL_ENABLE(CONTROL_SCRAPER_SETTINGS);
     }
     else
+    {
+      SET_CONTROL_LABEL2(CONTROL_SCRAPER_LIST_BUTTON, 231); //Set label2 to "None"
       CONTROL_DISABLE(CONTROL_SCRAPER_SETTINGS);
+    }
   }
-
-  SET_CONTROL_VISIBLE(CONTROL_CONTENT_TYPE);
 
   CGUIDialogSettingsManualBase::SetupView();
 }
@@ -429,107 +468,4 @@ void CGUIDialogContentSettings::InitializeSettings()
       AddToggle(group, SETTING_EXCLUDE, 20380, 0, m_exclude, false, !m_showScanSettings);
       break;
   }
-}
-
-void CGUIDialogContentSettings::FillContentTypes()
-{
-  std::vector< std::pair<std::string, int> > labels;
-
-  if (m_content == CONTENT_ALBUMS || m_content == CONTENT_ARTISTS)
-  {
-    FillContentTypes(m_content);
-    labels.push_back(std::make_pair(ADDON::TranslateContent(m_content, true), m_content));
-  }
-  else
-  {
-    FillContentTypes(CONTENT_MOVIES);
-    FillContentTypes(CONTENT_TVSHOWS);
-    FillContentTypes(CONTENT_MUSICVIDEOS);
-
-    labels.push_back(std::make_pair(ADDON::TranslateContent(CONTENT_MOVIES, true), CONTENT_MOVIES));
-    labels.push_back(std::make_pair(ADDON::TranslateContent(CONTENT_TVSHOWS, true), CONTENT_TVSHOWS));
-    labels.push_back(std::make_pair(ADDON::TranslateContent(CONTENT_MUSICVIDEOS, true), CONTENT_MUSICVIDEOS));
-    labels.push_back(std::make_pair(ADDON::TranslateContent(CONTENT_NONE, true), CONTENT_NONE));
-  }
-
-  SET_CONTROL_LABELS(CONTROL_CONTENT_TYPE, m_content, &labels);
-}
-
-void CGUIDialogContentSettings::FillContentTypes(CONTENT_TYPE content)
-{
-  // grab all scrapers which support this content-type
-  VECADDONS addons;
-  TYPE type = ADDON::ScraperTypeFromContent(content);
-  if (!CAddonMgr::GetInstance().GetAddons(type, addons))
-    return;
-
-  AddonPtr addon;
-  std::string defaultID;
-  if (CAddonMgr::GetInstance().GetDefault(type, addon))
-    defaultID = addon->ID();
-
-  for (IVECADDONS it = addons.begin(); it != addons.end(); ++it)
-  {
-    bool isDefault = ((*it)->ID() == defaultID);
-    std::map<CONTENT_TYPE, VECADDONS>::iterator iter = m_scrapers.find(content);
-
-    AddonPtr scraper = (*it)->Clone();
-
-    if (m_scraper != NULL && m_scraper->ID() == (*it)->ID())
-    { // don't overwrite preconfigured scraper
-      scraper = m_scraper;
-    }
-
-    if (iter != m_scrapers.end())
-    {
-      if (isDefault)
-        iter->second.insert(iter->second.begin(), scraper);
-      else
-        iter->second.push_back(scraper);
-    }
-    else
-    {
-      VECADDONS vec;
-      vec.push_back(scraper);
-      m_scrapers.insert(std::make_pair(content,vec));
-    }
-  }
-}
-
-void CGUIDialogContentSettings::FillScraperList()
-{
-  int iIndex = 0;
-  int selectedIndex = 0;
-
-  if (m_lastSelected.find(m_content) != m_lastSelected.end())
-    m_scraper = std::dynamic_pointer_cast<CScraper>(m_lastSelected[m_content]);
-  else
-  {
-    AddonPtr scraperAddon;
-    CAddonMgr::GetInstance().GetDefault(ADDON::ScraperTypeFromContent(m_content), scraperAddon);
-    m_scraper = std::dynamic_pointer_cast<CScraper>(scraperAddon);
-  }
-
-  for (IVECADDONS iter = m_scrapers.find(m_content)->second.begin(); iter != m_scrapers.find(m_content)->second.end(); ++iter)
-  {
-    CFileItemPtr item(new CFileItem((*iter)->Name()));
-    item->SetPath((*iter)->ID());
-    item->SetArt("thumb", (*iter)->Icon());
-    if (m_scraper && (*iter)->ID() == m_scraper->ID())
-    {
-      item->Select(true);
-      selectedIndex = iIndex;
-    }
-    m_vecItems->Add(item);
-
-    iIndex++;
-  }
-
-  // add the "Get More..." item
-  m_vecItems->Add(XFILE::CAddonsDirectory::GetMoreItem(ADDON::TranslateContent(m_content)));
-
-  CGUIMessage msg(GUI_MSG_LABEL_BIND, GetID(), CONTROL_SCRAPER_LIST, 0, 0, m_vecItems);
-  OnMessage(msg);
-  CGUIMessage msg2(GUI_MSG_ITEM_SELECT, GetID(), CONTROL_SCRAPER_LIST, selectedIndex);
-  OnMessage(msg2);
 }

--- a/xbmc/settings/dialogs/GUIDialogContentSettings.h
+++ b/xbmc/settings/dialogs/GUIDialogContentSettings.h
@@ -80,13 +80,18 @@ protected:
   virtual void InitializeSettings();
 
 private:
-  void FillContentTypes();
-  void FillContentTypes(CONTENT_TYPE content);
-  void FillScraperList();
-
   bool m_needsSaving;
+  /*!
+  * @brief The currently selected content type
+  */
   CONTENT_TYPE m_content;
+  /*!
+  * @brief The selected content type at dialog creation
+  */
   CONTENT_TYPE m_originalContent;
+  /*!
+  * @brief The currently selected scraper
+  */
   ADDON::ScraperPtr m_scraper;
 
   bool m_showScanSettings;
@@ -96,7 +101,5 @@ private:
   bool m_exclude;
   bool m_noUpdating;
   
-  std::map<CONTENT_TYPE, ADDON::VECADDONS> m_scrapers;
-  std::map<CONTENT_TYPE, ADDON::AddonPtr> m_lastSelected;
   CFileItemList* m_vecItems;
 };


### PR DESCRIPTION
Here is a redesign of the scraper content settings dialog. Thanks to @mkortstiege @HitcherUK and @phil65 for contributing.
I was able to remove a lot of old now unneeded code.

![screenshot 2015-10-30 01 10 35](https://cloud.githubusercontent.com/assets/5943908/10835512/8706d066-7ea3-11e5-9178-1fc92344c5a1.png)

![screenshot 2015-10-30 01 10 44](https://cloud.githubusercontent.com/assets/5943908/10835511/870678b4-7ea3-11e5-9a42-9403510d6649.png)
