### PR TITLE
ADD: [droid] move activity to front when playback is started

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3346,6 +3346,10 @@ PlayBackRet CApplication::PlayFile(const CFileItem& item, bool bRestart)
   if (item.IsStack())
     return PlayStack(item, bRestart);
 
+  // If video, bring us to front
+  if (item.IsVideo())
+    g_Windowing.BringToFront();
+
   CPlayerOptions options;
 
   if( item.HasProperty("StartPercent") )

--- a/xbmc/android/activity/XBMCApp.cpp
+++ b/xbmc/android/activity/XBMCApp.cpp
@@ -482,6 +482,15 @@ int CXBMCApp::android_printf(const char *format, ...)
   return result;
 }
 
+void CXBMCApp::BringToFront()
+{
+  if (!m_hasFocus)
+  {
+    CLog::Log(LOGERROR, "CXBMCApp::BringToFront");
+    StartActivity(getPackageName());
+  }
+}
+
 int CXBMCApp::GetDPI()
 {
   if (m_activity == NULL || m_activity->assetManager == NULL)

--- a/xbmc/android/activity/XBMCApp.h
+++ b/xbmc/android/activity/XBMCApp.h
@@ -89,6 +89,7 @@ public:
   static const ANativeWindow** GetNativeWindow(int timeout);
   static int SetBuffersGeometry(int width, int height, int format);
   static int android_printf(const char *format, ...);
+  static void BringToFront();
   
   static int GetBatteryLevel();
   static bool EnableWakeLock(bool on);

--- a/xbmc/android/jni/Context.cpp
+++ b/xbmc/android/jni/Context.cpp
@@ -161,6 +161,12 @@ CJNIApplicationInfo CJNIContext::getApplicationInfo()
     "getApplicationInfo", "()Landroid/content/pm/ApplicationInfo;");
 }
 
+std::string CJNIContext::getPackageName()
+{
+  return jcast<std::string>(call_method<jhstring>(m_context,
+    "getPackageName", "()Ljava/lang/String;"));
+}
+
 std::string CJNIContext::getPackageResourcePath()
 {
   return jcast<std::string>(call_method<jhstring>(m_context,

--- a/xbmc/android/jni/Context.h
+++ b/xbmc/android/jni/Context.h
@@ -47,6 +47,7 @@ public:
   static CJNIIntent getIntent();
   static CJNIClassLoader getClassLoader();
   static CJNIApplicationInfo getApplicationInfo();
+  static std::string getPackageName();
   static std::string getPackageResourcePath();
   static CJNIFile getCacheDir();
   static CJNIFile getDir(const std::string &path, int mode);

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -81,6 +81,7 @@ public:
   virtual bool Restore() { return false; }
   virtual bool Hide() { return false; }
   virtual bool Show(bool raise = true) { return false; }
+  virtual bool BringToFront() { return false; }
 
   // notifications
   virtual void OnMove(int x, int y) {}

--- a/xbmc/windowing/egl/EGLNativeType.h
+++ b/xbmc/windowing/egl/EGLNativeType.h
@@ -146,6 +146,9 @@ public:
     framebuffer */
   virtual bool  ShowWindow(bool show) = 0;
 
+/*! \brief Bring the current window to front */
+  virtual bool  BringToFront() = 0;
+
 protected:
   XBNativeDisplayType  m_nativeDisplay;
   XBNativeWindowType   m_nativeWindow;

--- a/xbmc/windowing/egl/EGLNativeTypeAmlogic.h
+++ b/xbmc/windowing/egl/EGLNativeTypeAmlogic.h
@@ -46,6 +46,7 @@ public:
   virtual bool  GetPreferredResolution(RESOLUTION_INFO *res) const;
 
   virtual bool  ShowWindow(bool show);
+  virtual bool  BringToFront() { return false; }
 
 protected:
   bool SetDisplayResolution(const char *resolution);

--- a/xbmc/windowing/egl/EGLNativeTypeAndroid.cpp
+++ b/xbmc/windowing/egl/EGLNativeTypeAndroid.cpp
@@ -225,3 +225,8 @@ bool CEGLNativeTypeAndroid::ShowWindow(bool show)
 {
   return false;
 }
+
+bool CEGLNativeTypeAndroid::BringToFront()
+{
+  CXBMCApp::BringToFront();
+}

--- a/xbmc/windowing/egl/EGLNativeTypeAndroid.h
+++ b/xbmc/windowing/egl/EGLNativeTypeAndroid.h
@@ -46,4 +46,6 @@ public:
   virtual bool  GetPreferredResolution(RESOLUTION_INFO *res) const;
 
   virtual bool  ShowWindow(bool show);
+  virtual bool  BringToFront();
+
 };

--- a/xbmc/windowing/egl/EGLNativeTypeIMX.h
+++ b/xbmc/windowing/egl/EGLNativeTypeIMX.h
@@ -51,6 +51,7 @@ public:
   virtual bool  GetPreferredResolution(RESOLUTION_INFO *res) const;
 
   virtual bool  ShowWindow(bool show);
+  virtual bool  BringToFront() { return false; }
 
 protected:
   bool m_readonly;

--- a/xbmc/windowing/egl/EGLNativeTypeRaspberryPI.h
+++ b/xbmc/windowing/egl/EGLNativeTypeRaspberryPI.h
@@ -52,6 +52,8 @@ public:
   virtual bool  GetPreferredResolution(RESOLUTION_INFO *res) const;
 
   virtual bool  ShowWindow(bool show);
+  virtual bool  BringToFront() { return false; }
+
 #if defined(TARGET_RASPBERRY_PI)
 private:
   DllBcmHost                    *m_DllBcmHost;

--- a/xbmc/windowing/egl/EGLWrapper.cpp
+++ b/xbmc/windowing/egl/EGLWrapper.cpp
@@ -202,6 +202,14 @@ bool CEGLWrapper::ShowWindow(bool show)
   return m_nativeTypes->ShowWindow(show);
 }
 
+bool CEGLWrapper::BringToFront()
+{
+  if (!m_nativeTypes)
+    return false;
+
+  return m_nativeTypes->BringToFront();
+}
+
 bool CEGLWrapper::GetQuirks(int *quirks)
 {
   if (!m_nativeTypes || !quirks)

--- a/xbmc/windowing/egl/EGLWrapper.h
+++ b/xbmc/windowing/egl/EGLWrapper.h
@@ -41,6 +41,7 @@ public:
   bool SetNativeResolution(RESOLUTION_INFO& res);
   bool ProbeResolutions(std::vector<RESOLUTION_INFO> &resolutions);
   bool ShowWindow(bool show);
+  bool BringToFront();
   bool GetQuirks(int *quirks);
   bool GetPreferredResolution(RESOLUTION_INFO *res);
   bool GetNativeResolution(RESOLUTION_INFO *res);

--- a/xbmc/windowing/egl/WinSystemEGL.cpp
+++ b/xbmc/windowing/egl/WinSystemEGL.cpp
@@ -502,6 +502,11 @@ bool CWinSystemEGL::Show(bool raise)
   return m_egl->ShowWindow(true);
 }
 
+bool CWinSystemEGL::BringToFront()
+{
+  return m_egl->BringToFront();
+}
+
 void CWinSystemEGL::Register(IDispResource *resource)
 {
   CSingleLock lock(m_resourceSection);

--- a/xbmc/windowing/egl/WinSystemEGL.h
+++ b/xbmc/windowing/egl/WinSystemEGL.h
@@ -56,6 +56,8 @@ public:
   virtual bool  Restore() ;
   virtual bool  Hide();
   virtual bool  Show(bool raise = true);
+  virtual bool  BringToFront();
+
   virtual void  Register(IDispResource *resource);
   virtual void  Unregister(IDispResource *resource);
 


### PR DESCRIPTION
On Android, this brings the app in the foreground if a video is launched when minimized

/cc @FernetMenta @MartijnKaijser @da-anda 
