### PR TITLE
[udevprovider] Fix mounting raw filesystems on non partition disks and add support for 'change' udev event

### DIFF
--- a/xbmc/storage/linux/UDevProvider.cpp
+++ b/xbmc/storage/linux/UDevProvider.cpp
@@ -254,14 +254,15 @@ bool CUDevProvider::PumpDriveChangeEvents(IStorageEventsCallback *callback)
       else if (mountpoint)
         label = URIUtils::GetFileName(mountpoint);
 
-      if (!strcmp(action, "add") && !strcmp(devtype, "partition"))
+      const char *fs_usage = udev_device_get_property_value(dev, "ID_FS_USAGE");
+      if (strcmp(action, "add") == 0 && (fs_usage && strcmp(fs_usage, "filesystem") == 0))
       {
         CLog::Log(LOGNOTICE, "UDev: Added %s", mountpoint);
         if (callback)
           callback->OnStorageAdded(label, mountpoint);
         changed = true;
       }
-      if (!strcmp(action, "remove") && !strcmp(devtype, "partition"))
+      if (strcmp(action, "remove") == 0 && (fs_usage && strcmp(fs_usage, "filesystem") == 0))
       {
         CLog::Log(LOGNOTICE, "UDev: Removed %s", mountpoint);
         if (callback)

--- a/xbmc/storage/linux/UDevProvider.cpp
+++ b/xbmc/storage/linux/UDevProvider.cpp
@@ -269,6 +269,25 @@ bool CUDevProvider::PumpDriveChangeEvents(IStorageEventsCallback *callback)
           callback->OnStorageSafelyRemoved(label);
         changed = true;
       }
+      if (strcmp(action, "change") == 0 && strcmp(devtype, "disk") == 0)
+      {
+        const char *media_change = udev_device_get_property_value(dev, "DISK_MEDIA_CHANGE");
+        const char *eject_request = udev_device_get_property_value(dev, "DISK_EJECT_REQUEST");
+        if (media_change && strcmp(media_change, "1") == 0)
+        {
+          CLog::Log(LOGNOTICE, "UDev: Changed / Added %s", mountpoint);
+          if (callback)
+            callback->OnStorageAdded(label, mountpoint);
+          changed = true;
+        }
+        if (eject_request && strcmp(eject_request, "1") == 0)
+        {
+          CLog::Log(LOGNOTICE, "UDev: Changed / Removed %s", mountpoint);
+          if (callback)
+            callback->OnStorageSafelyRemoved(label);
+          changed = true;
+        }
+      }
     }
     udev_device_unref(dev);
   }


### PR DESCRIPTION
OSMC is transitioning to UDevil and we noticed that sometimes DVD insertion and removal events are not triggering properly. This patch fixes strcmp() evaluation so that PumpDriveChangeEvents() reacts to DVD changes properly. The result is that Files list wasn't updating automatically. 

We then test for udev_label. If it's empty, we can assume the disc was removed; otherwise it has been added. This to make sure we don't get both the insertion and removal toasts when something changes. 

ping @stefansaraev, as OE is using udevil for some time already.

CC @DBMandrake
