### PR TITLE
Add Audio and Subtitle Track Count to Smart Playlist selections

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -12598,7 +12598,12 @@ msgctxt "#21480"
 msgid "Use"
 msgstr ""
 
-#empty strings from id 21481 to 21601
+#: xbmc/playlist/SmartPlayList.cpp
+msgctxt "#21481"
+msgid "Audio Track Count"
+msgstr ""
+
+#empty strings from id 21482 to 21601
 
 #: xbmc/Util.cpp
 msgctxt "#21602"

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -12600,10 +12600,15 @@ msgstr ""
 
 #: xbmc/playlist/SmartPlayList.cpp
 msgctxt "#21481"
-msgid "Audio Track Count"
+msgid "Audio track count"
 msgstr ""
 
-#empty strings from id 21482 to 21601
+#: xbmc/playlist/SmartPlayList.cpp
+msgctxt "#21482"
+msgid "Subtitle track count"
+msgstr ""
+
+#empty strings from id 21483 to 21601
 
 #: xbmc/Util.cpp
 msgctxt "#21602"

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -103,7 +103,8 @@ static const translateField fields[] = {
   { "audiochannels",     FieldAudioChannels,           CDatabaseQueryRule::NUMERIC_FIELD,  NULL,                                 false, 21444 },
   { "audiocodec",        FieldAudioCodec,              CDatabaseQueryRule::TEXTIN_FIELD,   NULL,                                 false, 21446 },
   { "audiolanguage",     FieldAudioLanguage,           CDatabaseQueryRule::TEXTIN_FIELD,   NULL,                                 false, 21447 },
-  { "audiocount",        FieldAudioCount,              CDatabaseQueryRule::NUMERIC_FIELD,  NULL,                                 false, 21481 }, 
+  { "audiocount",        FieldAudioCount,              CDatabaseQueryRule::NUMERIC_FIELD,  StringValidation::IsPositiveInteger,  false, 21481 }, 
+  { "subtitlecount",     FieldSubtitleCount,           CDatabaseQueryRule::NUMERIC_FIELD,  StringValidation::IsPositiveInteger,  false, 21482 },
   { "subtitlelanguage",  FieldSubtitleLanguage,        CDatabaseQueryRule::TEXTIN_FIELD,   NULL,                                 false, 21448 },
   { "random",            FieldRandom,                  CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 590 },
   { "playlist",          FieldPlaylist,                CDatabaseQueryRule::PLAYLIST_FIELD, NULL,                                 true,  559 },
@@ -432,6 +433,7 @@ std::vector<Field> CSmartPlaylistRule::GetFields(const std::string &type)
     fields.push_back(FieldVideoResolution);
     fields.push_back(FieldAudioChannels);
     fields.push_back(FieldAudioCount);
+    fields.push_back(FieldSubtitleCount);
     fields.push_back(FieldVideoCodec);
     fields.push_back(FieldAudioCodec);
     fields.push_back(FieldAudioLanguage);
@@ -853,7 +855,9 @@ std::string CSmartPlaylistRule::FormatWhereClause(const std::string &negate, con
   else if (m_field == FieldVideoAspectRatio)
     query = negate + " EXISTS (SELECT 1 FROM streamdetails WHERE streamdetails.idFile = " + table + ".idFile AND fVideoAspect " + parameter + ")";
   else if (m_field == FieldAudioCount)
-    query = negate + " EXISTS (SELECT 1 FROM streamdetails WHERE streamdetails.idFile = " + table + ".idFile AND streamdetails.iStreamType=1 GROUP BY streamdetails.idFile HAVING COUNT(streamdetails.iStreamType) " + parameter + ")";
+    query = db.PrepareSQL(negate + " EXISTS (SELECT 1 FROM streamdetails WHERE streamdetails.idFile = " + table + ".idFile AND streamdetails.iStreamtype = %i GROUP BY streamdetails.idFile HAVING COUNT(streamdetails.iStreamType) " + parameter + ")",CStreamDetail::AUDIO);
+  else if (m_field == FieldSubtitleCount)
+    query = db.PrepareSQL(negate + " EXISTS (SELECT 1 FROM streamdetails WHERE streamdetails.idFile = " + table + ".idFile AND streamdetails.iStreamType = %i GROUP BY streamdetails.idFile HAVING COUNT(streamdetails.iStreamType) " + parameter + ")",CStreamDetail::SUBTITLE);
   if (m_field == FieldPlaycount && strType != "songs" && strType != "albums" && strType != "tvshows")
   { // playcount IS stored as NULL OR number IN video db
     if ((m_operator == OPERATOR_EQUALS && param == "0") ||

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -103,6 +103,7 @@ static const translateField fields[] = {
   { "audiochannels",     FieldAudioChannels,           CDatabaseQueryRule::NUMERIC_FIELD,  NULL,                                 false, 21444 },
   { "audiocodec",        FieldAudioCodec,              CDatabaseQueryRule::TEXTIN_FIELD,   NULL,                                 false, 21446 },
   { "audiolanguage",     FieldAudioLanguage,           CDatabaseQueryRule::TEXTIN_FIELD,   NULL,                                 false, 21447 },
+  { "audiocount",        FieldAudioCount,              CDatabaseQueryRule::NUMERIC_FIELD,  NULL,                                 false, 21481 }, 
   { "subtitlelanguage",  FieldSubtitleLanguage,        CDatabaseQueryRule::TEXTIN_FIELD,   NULL,                                 false, 21448 },
   { "random",            FieldRandom,                  CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 590 },
   { "playlist",          FieldPlaylist,                CDatabaseQueryRule::PLAYLIST_FIELD, NULL,                                 true,  559 },
@@ -430,6 +431,7 @@ std::vector<Field> CSmartPlaylistRule::GetFields(const std::string &type)
   {
     fields.push_back(FieldVideoResolution);
     fields.push_back(FieldAudioChannels);
+    fields.push_back(FieldAudioCount);
     fields.push_back(FieldVideoCodec);
     fields.push_back(FieldAudioCodec);
     fields.push_back(FieldAudioLanguage);
@@ -850,6 +852,8 @@ std::string CSmartPlaylistRule::FormatWhereClause(const std::string &negate, con
     query = negate + " EXISTS (SELECT 1 FROM streamdetails WHERE streamdetails.idFile = " + table + ".idFile AND strSubtitleLanguage " + parameter + ")";
   else if (m_field == FieldVideoAspectRatio)
     query = negate + " EXISTS (SELECT 1 FROM streamdetails WHERE streamdetails.idFile = " + table + ".idFile AND fVideoAspect " + parameter + ")";
+  else if (m_field == FieldAudioCount)
+    query = negate + " EXISTS (SELECT 1 FROM streamdetails WHERE streamdetails.idFile = " + table + ".idFile AND streamdetails.iStreamType=1 GROUP BY streamdetails.idFile HAVING COUNT(streamdetails.iStreamType) " + parameter + ")";
   if (m_field == FieldPlaycount && strType != "songs" && strType != "albums" && strType != "tvshows")
   { // playcount IS stored as NULL OR number IN video db
     if ((m_operator == OPERATOR_EQUALS && param == "0") ||

--- a/xbmc/utils/DatabaseUtils.h
+++ b/xbmc/utils/DatabaseUtils.h
@@ -60,6 +60,7 @@ typedef enum {
   FieldRandom,
   FieldDateTaken,
   FieldAudioCount,
+  FieldSubtitleCount,
 
   // fields retrievable from the database
   FieldId,

--- a/xbmc/utils/DatabaseUtils.h
+++ b/xbmc/utils/DatabaseUtils.h
@@ -59,6 +59,7 @@ typedef enum {
   FieldVirtualFolder,
   FieldRandom,
   FieldDateTaken,
+  FieldAudioCount,
 
   // fields retrievable from the database
   FieldId,


### PR DESCRIPTION
This adds a new Smart Playlist Rule field named "audiocount" which can be used to locate video files that have a specific number of audio tracks.

I'm a big fan of commentary tracks, and using the existing GUI to locate movies or TV show episodes that have commentaries is almost impossible -- one must be using a skin that supports that info and displays it in navigation.  And even then, one must scroll through the library to locate the files.

This addition makes it simple -- just make a playlist for Movies or Episodes that contain more than 1 audio tracks.   Such as:

```
<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
<smartplaylist type="episodes">
    <name>Test</name>
    <match>all</match>
    <rule field="audiocount" operator="greaterthan">
        <value>1</value>
    </rule>
    <order direction="ascending">tvshowtitle</order>
</smartplaylist>
```
