### PR TITLE
[strings] fix incorrect kai message string on dvd mount and generalise it instead

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -5514,17 +5514,17 @@ msgstr ""
 
 #: xbmc\storage\MediaManager.cpp
 msgctxt "#13021"
-msgid "Mounted removable hard drive"
+msgid "Mounted removable storage device"
 msgstr ""
 
 #: xbmc\storage\MediaManager.cpp
 msgctxt "#13022"
-msgid "Unsafe device removal"
+msgid "Unsafe storage device removal"
 msgstr ""
 
 #: xbmc\storage\MediaManager.cpp
 msgctxt "#13023"
-msgid "Successfully removed device"
+msgid "Successfully removed storage device"
 msgstr ""
 
 msgctxt "#13024"


### PR DESCRIPTION
While looking at https://github.com/xbmc/xbmc/pull/8334 I reminded myself the mount message/.
This message apparently applies to all devices, like Optical Media and USB devices inserted/mounted events.

looking at https://github.com/xbmc/xbmc/blob/master/xbmc/storage/MediaManager.cpp#L689 however one needs a message that covers all cases and is unspecific enough

Clearly its not a hard drive I promise.
![screenshot033](https://cloud.githubusercontent.com/assets/3521959/10882967/c092faba-8166-11e5-9fb3-fdbc78babf09.png)

The unmounting one is fine however.
![screenshot034](https://cloud.githubusercontent.com/assets/3521959/10882968/c09687c0-8166-11e5-8b4e-162f3b6ed303.png)
