### PR TITLE
[confluence][DialogkaiToast] align kai dialog to bottom of screen

### DIFF
--- a/addons/skin.confluence/720p/DialogKaiToast.xml
+++ b/addons/skin.confluence/720p/DialogKaiToast.xml
@@ -4,7 +4,7 @@
 	<animation effect="fade" start="100" end="0" time="150">WindowClose</animation>
 	<coordinates>
 		<left>860</left>
-		<top>640</top>
+		<top>655</top>
 	</coordinates>
 	<controls>
 		<control type="group">


### PR DESCRIPTION
Small cosmetic improvement that's annoyed me for a long time

**Before**

![screenshot033](https://cloud.githubusercontent.com/assets/3521959/10884302/3601710c-816f-11e5-84ad-f8a2c8386c05.png)
![screenshot039](https://cloud.githubusercontent.com/assets/3521959/10884340/804c83aa-816f-11e5-9a5f-58539761ac48.png)

**After**
![screenshot042](https://cloud.githubusercontent.com/assets/3521959/10884519/51c1448e-8170-11e5-9856-8ed5e6904e49.png)

![screenshot037](https://cloud.githubusercontent.com/assets/3521959/10884386/b8a8c9ca-816f-11e5-8328-5451c492fc8c.png)
