### PR TITLE
Add missing numeric input for PVR

### DIFF
--- a/system/keymaps/remote.xml
+++ b/system/keymaps/remote.xml
@@ -606,6 +606,16 @@
       <rootmenu>Close</rootmenu>
       <start>Close</start>
       <playlist>Close</playlist>
+      <zero>Number0</zero>
+      <one>Number1</one>
+      <two>number2</two>
+      <three>number3</three>
+      <four>number4</four>
+      <five>number5</five>
+      <six>number6</six>
+      <seven>number7</seven>
+      <eight>number8</eight>
+      <nine>number9</nine>
     </remote>
   </PVROSDChannels>
   <PVROSDGuide>
@@ -616,8 +626,60 @@
       <rootmenu>Close</rootmenu>
       <start>Close</start>
       <guide>Close</guide>
+      <zero>Number0</zero>
+      <one>Number1</one>
+      <two>number2</two>
+      <three>number3</three>
+      <four>number4</four>
+      <five>number5</five>
+      <six>number6</six>
+      <seven>number7</seven>
+      <eight>number8</eight>
+      <nine>number9</nine>
     </remote>
   </PVROSDGuide>
+  <TVChannels>
+    <remote>
+      <zero>Number0</zero>
+      <one>Number1</one>
+      <two>number2</two>
+      <three>number3</three>
+      <four>number4</four>
+      <five>number5</five>
+      <six>number6</six>
+      <seven>number7</seven>
+      <eight>number8</eight>
+      <nine>number9</nine>
+    </remote>
+  </TVChannels>
+  <TVGuide>
+    <remote>
+      <zero>Number0</zero>
+      <one>Number1</one>
+      <two>number2</two>
+      <three>number3</three>
+      <four>number4</four>
+      <five>number5</five>
+      <six>number6</six>
+      <seven>number7</seven>
+      <eight>number8</eight>
+      <nine>number9</nine>
+    </remote>
+  </TVGuide>
+  <RadioChannels>
+    <remote>
+      <zero>Number0</zero>
+      <one>Number1</one>
+      <two>number2</two>
+      <three>number3</three>
+      <four>number4</four>
+      <five>number5</five>
+      <six>number6</six>
+      <seven>number7</seven>
+      <eight>number8</eight>
+      <nine>number9</nine>
+    </remote>
+  </RadioChannels>
   <MyTVSettings>
     <remote>
       <back>PreviousMenu</back>


### PR DESCRIPTION
Some PVR windows did not get numeric input and were incorrectly defaulting to jumpSMS. I'm guessing this was simply missed when PVR windows were changed, and this should restore the intended behavior.
