### PR TITLE
Fix missing artist display in music player #16356

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -4132,10 +4132,10 @@ std::string CGUIInfoManager::GetMusicTagLabel(int info, const CFileItem *item)
     if (tag.GetAlbum().size()) { return tag.GetAlbum(); }
     break;
   case MUSICPLAYER_ARTIST:
-    if (tag.GetArtist().size()) { return tag.GetArtistString(); }
+    if (tag.GetArtistString().size()) { return tag.GetArtistString(); }
     break;
   case MUSICPLAYER_ALBUM_ARTIST:
-    if (tag.GetAlbumArtist().size()) { return tag.GetAlbumArtistString(); }
+    if (tag.GetAlbumArtistString().size()) { return tag.GetAlbumArtistString(); }
     break;
   case MUSICPLAYER_YEAR:
     if (tag.GetYear()) { return tag.GetYearString(); }


### PR DESCRIPTION
Artist went awol, as reported in ticket 16356. A result of a mistake in #8158 when removing the artist vector from CSong and CArtist. 

As a reminder we still have situations that don't use the artist credits vector but just pass an artist description string, so when getting artist string to display (from CSong, CAlbum or CMusicInfoTag) we need to use GetArtistString method.

Easy fixed. @Razzeee  and @ronie will you check this out please all the same. @evilhamster if you are around.
