### PR TITLE
[guilib] fix togglebutton label not rendered properly

### DIFF
--- a/xbmc/guilib/GUIToggleButtonControl.cpp
+++ b/xbmc/guilib/GUIToggleButtonControl.cpp
@@ -149,6 +149,12 @@ bool CGUIToggleButtonControl::UpdateColors()
   return changed;
 }
 
+void CGUIToggleButtonControl::SetLabel(const std::string &label)
+{
+  CGUIButtonControl::SetLabel(label);
+  m_selectButton.SetLabel(label);
+}
+
 void CGUIToggleButtonControl::SetAltLabel(const std::string &label)
 {
   if (label.size())

--- a/xbmc/guilib/GUIToggleButtonControl.h
+++ b/xbmc/guilib/GUIToggleButtonControl.h
@@ -52,6 +52,7 @@ public:
   virtual void SetWidth(float width);
   virtual void SetHeight(float height);
   virtual void SetMinWidth(float minWidth);
+  virtual void SetLabel(const std::string& label);
   void SetAltLabel(const std::string& label);
   virtual std::string GetDescription() const;
   void SetToggleSelect(const std::string &toggleSelect);


### PR DESCRIPTION
This fixes an issue where the selected label of a toggle button fails to properly render. Regression was introduced in https://github.com/xbmc/xbmc/pull/8310. Issue was reported on the forums: See http://forum.kodi.tv/showthread.php?tid=246163

/cc @HitcherUK, @ronie
