### PR TITLE
[iimage] Prevent possible access violations, especially for gifs.

### DIFF
--- a/xbmc/guilib/Gif.cpp
+++ b/xbmc/guilib/Gif.cpp
@@ -542,6 +542,9 @@ bool Gif::Decode(unsigned char* const pixels, unsigned int pitch, unsigned int f
     || format != XB_FMT_A8R8G8B8 || !m_numFrames)
     return false;
 
+  if (m_frames.empty() || !m_frames[0]->m_pImage)
+    return false;
+
   const unsigned char *src = m_frames[0]->m_pImage;
   unsigned char* dst = pixels;
 

--- a/xbmc/guilib/Gif.cpp
+++ b/xbmc/guilib/Gif.cpp
@@ -548,17 +548,23 @@ bool Gif::Decode(unsigned char* const pixels, unsigned int width, unsigned int h
   const unsigned char *src = m_frames[0]->m_pImage;
   unsigned char* dst = pixels;
 
-  if (pitch == m_pitch)
+  unsigned int copyHeight = std::min(m_height, height);
+  unsigned int copyPitch = std::min(m_pitch, pitch);
+
+  if (pitch == m_pitch && copyHeight == m_height)
+  {
     memcpy(dst, src, m_imageSize);
+  }
   else
   {
-    for (unsigned int y = 0; y < m_height; y++)
+    for (unsigned int y = 0; y < copyHeight; y++)
     {
-      memcpy(dst, src, m_pitch);
+      memcpy(dst, src, copyPitch);
       src += m_pitch;
       dst += pitch;
     }
   }
+
   return true;
 }
 

--- a/xbmc/guilib/Gif.cpp
+++ b/xbmc/guilib/Gif.cpp
@@ -367,7 +367,7 @@ bool Gif::ExtractFrames(unsigned int count)
     {
       CLog::Log(LOGDEBUG, "Gif::ExtractFrames(): Illegal frame dimensions: width: %d, height: %d, left: %d, top: %d instead of (%d,%d)",
         frame->m_width, frame->m_height, frame->m_left, frame->m_top, m_width, m_height);
-      return false;
+      continue;
     }
 
     if (imageDesc.ColorMap)

--- a/xbmc/guilib/Gif.cpp
+++ b/xbmc/guilib/Gif.cpp
@@ -363,7 +363,8 @@ bool Gif::ExtractFrames(unsigned int count)
     frame->m_left = imageDesc.Left;
 
     if (frame->m_top + frame->m_height > m_height || frame->m_left + frame->m_width > m_width
-      || !frame->m_width || !frame->m_height)
+      || !frame->m_width || !frame->m_height
+      || frame->m_width > m_width || frame->m_height > m_height)
     {
       CLog::Log(LOGDEBUG, "Gif::ExtractFrames(): Illegal frame dimensions: width: %d, height: %d, left: %d, top: %d instead of (%d,%d)",
         frame->m_width, frame->m_height, frame->m_left, frame->m_top, m_width, m_height);

--- a/xbmc/guilib/Gif.cpp
+++ b/xbmc/guilib/Gif.cpp
@@ -535,7 +535,7 @@ bool Gif::LoadImageFromMemory(unsigned char* buffer, unsigned int bufSize, unsig
   return true;
 }
 
-bool Gif::Decode(unsigned char* const pixels, unsigned int pitch, unsigned int format)
+bool Gif::Decode(unsigned char* const pixels, unsigned int width, unsigned int height, unsigned int pitch, unsigned int format)
 {
   if (m_width == 0 || m_height == 0
     || !m_dll.IsLoaded() || !m_gif

--- a/xbmc/guilib/Gif.h
+++ b/xbmc/guilib/Gif.h
@@ -74,7 +74,7 @@ public:
   bool LoadGif(const char* file);
 
   virtual bool LoadImageFromMemory(unsigned char* buffer, unsigned int bufSize, unsigned int width, unsigned int height);
-  virtual bool Decode(unsigned char* const pixels, unsigned int pitch, unsigned int format);
+  virtual bool Decode(unsigned char* const pixels, unsigned int width, unsigned int height, unsigned int pitch, unsigned int format);
   virtual bool CreateThumbnailFromSurface(unsigned char* bufferin, unsigned int width, unsigned int height, unsigned int format, unsigned int pitch, const std::string& destFile,
                                           unsigned char* &bufferout, unsigned int &bufferoutSize);
   bool IsAnimated(const char* file);

--- a/xbmc/guilib/JpegIO.cpp
+++ b/xbmc/guilib/JpegIO.cpp
@@ -340,7 +340,7 @@ bool CJpegIO::Read(unsigned char* buffer, unsigned int bufSize, unsigned int min
   }
 }
 
-bool CJpegIO::Decode(unsigned char* const pixels, unsigned int pitch, unsigned int format)
+bool CJpegIO::Decode(unsigned char* const pixels, unsigned int width, unsigned int height, unsigned int pitch, unsigned int format)
 {
   unsigned char *dst = (unsigned char*)pixels;
 
@@ -416,7 +416,7 @@ bool CJpegIO::CreateThumbnailFromMemory(unsigned char* buffer, unsigned int bufS
   pitch = Width() * 3;
   sourceBuf = new unsigned char [Height() * pitch];
 
-  if (!Decode(sourceBuf,pitch,XB_FMT_RGB8))
+  if (!Decode(sourceBuf, Width(), Height(),pitch,XB_FMT_RGB8))
   {
     delete [] sourceBuf;
     return false;

--- a/xbmc/guilib/JpegIO.cpp
+++ b/xbmc/guilib/JpegIO.cpp
@@ -343,6 +343,8 @@ bool CJpegIO::Read(unsigned char* buffer, unsigned int bufSize, unsigned int min
 bool CJpegIO::Decode(unsigned char* const pixels, unsigned int width, unsigned int height, unsigned int pitch, unsigned int format)
 {
   unsigned char *dst = (unsigned char*)pixels;
+  unsigned int copyWidth = std::min(m_width, width);
+  unsigned int copyHeight = std::min(m_height, height);
 
   struct my_error_mgr jerr;
   m_cinfo.err = jpeg_std_error(&jerr.pub);
@@ -359,7 +361,7 @@ bool CJpegIO::Decode(unsigned char* const pixels, unsigned int width, unsigned i
 
     if (format == XB_FMT_RGB8)
     {
-      while (m_cinfo.output_scanline < m_height)
+      while (m_cinfo.output_scanline < copyHeight)
       {
         jpeg_read_scanlines(&m_cinfo, &dst, 1);
         dst += pitch;
@@ -368,12 +370,12 @@ bool CJpegIO::Decode(unsigned char* const pixels, unsigned int width, unsigned i
     else if (format == XB_FMT_A8R8G8B8)
     {
       unsigned char* row = new unsigned char[m_width * 3];
-      while (m_cinfo.output_scanline < m_height)
+      while (m_cinfo.output_scanline < copyHeight)
       {
         jpeg_read_scanlines(&m_cinfo, &row, 1);
         unsigned char *src2 = row;
         unsigned char *dst2 = dst;
-        for (unsigned int x = 0; x < m_width; x++, src2 += 3)
+        for (unsigned int x = 0; x < copyWidth; x++, src2 += 3)
         {
           *dst2++ = src2[2];
           *dst2++ = src2[1];

--- a/xbmc/guilib/JpegIO.h
+++ b/xbmc/guilib/JpegIO.h
@@ -42,7 +42,7 @@ public:
   static bool           CreateThumbnailFromSurface(unsigned char* buffer, unsigned int width, unsigned int height, unsigned int format, unsigned int pitch, const std::string& destFile);
   void           Close();
   // methods for the imagefactory
-  virtual bool   Decode(unsigned char* const pixels, unsigned int pitch, unsigned int format);
+  virtual bool   Decode(unsigned char* const pixels, unsigned int width, unsigned int height, unsigned int pitch, unsigned int format);
   virtual bool   LoadImageFromMemory(unsigned char* buffer, unsigned int bufSize, unsigned int width, unsigned int height);
   virtual bool   CreateThumbnailFromSurface(unsigned char* bufferin, unsigned int width, unsigned int height, unsigned int format, unsigned int pitch, const std::string& destFile, 
                                             unsigned char* &bufferout, unsigned int &bufferoutSize);

--- a/xbmc/guilib/Texture.cpp
+++ b/xbmc/guilib/Texture.cpp
@@ -311,7 +311,7 @@ bool CBaseTexture::LoadIImage(IImage *pImage, unsigned char* buffer, unsigned in
     if (pImage->Width() > 0 && pImage->Height() > 0)
     {
       Allocate(pImage->Width(), pImage->Height(), XB_FMT_A8R8G8B8);
-      if (pImage->Decode(m_pixels, GetPitch(), XB_FMT_A8R8G8B8))
+      if (pImage->Decode(m_pixels, GetWidth(), GetRows(), GetPitch(), XB_FMT_A8R8G8B8))
       {
         if (pImage->Orientation())
           m_orientation = pImage->Orientation() - 1;

--- a/xbmc/guilib/cximage.cpp
+++ b/xbmc/guilib/cximage.cpp
@@ -65,7 +65,7 @@ bool CXImage::LoadImageFromMemory(unsigned char* buffer, unsigned int bufSize, u
   return true;
 }
 
-bool CXImage::Decode(unsigned char* const pixels, unsigned int pitch, unsigned int format)
+bool CXImage::Decode(unsigned char* const pixels, unsigned int width, unsigned int height, unsigned int pitch, unsigned int format)
 {
   if (m_image.width == 0 || m_image.height == 0 || !m_dll.IsLoaded())
     return false;

--- a/xbmc/guilib/cximage.cpp
+++ b/xbmc/guilib/cximage.cpp
@@ -20,6 +20,7 @@
  */
 #include "cximage.h"
 #include "utils/log.h"
+#include <algorithm>
 
 CXImage::CXImage(const std::string& strMimeType): m_strMimeType(strMimeType), m_thumbnailbuffer(NULL)
 {
@@ -70,17 +71,20 @@ bool CXImage::Decode(unsigned char* const pixels, unsigned int width, unsigned i
   if (m_image.width == 0 || m_image.height == 0 || !m_dll.IsLoaded())
     return false;
 
+  unsigned int copyWidth = std::min(m_width, width);
+  unsigned int copyHeight = std::min(m_height, height);
+
   unsigned int dstPitch = pitch;
   unsigned int srcPitch = ((m_image.width + 1)* 3 / 4) * 4; // bitmap row length is aligned to 4 bytes
 
   unsigned char *dst = (unsigned char*)pixels;
   unsigned char *src = m_image.texture + (m_height - 1) * srcPitch;
 
-  for (unsigned int y = 0; y < m_height; y++)
+  for (unsigned int y = 0; y < copyHeight; y++)
   {
     unsigned char *dst2 = dst;
     unsigned char *src2 = src;
-    for (unsigned int x = 0; x < m_width; x++, dst2 += 4, src2 += 3)
+    for (unsigned int x = 0; x < copyWidth; x++, dst2 += 4, src2 += 3)
     {
       dst2[0] = src2[0];
       dst2[1] = src2[1];
@@ -96,12 +100,12 @@ bool CXImage::Decode(unsigned char* const pixels, unsigned int width, unsigned i
     dst = (unsigned char*)pixels + 3;
     src = m_image.alpha + (m_height - 1) * m_width;
 
-    for (unsigned int y = 0; y < m_height; y++)
+    for (unsigned int y = 0; y < copyHeight; y++)
     {
       unsigned char *dst2 = dst;
       unsigned char *src2 = src;
 
-      for (unsigned int x = 0; x < m_width; x++,  dst2+=4, src2++)
+      for (unsigned int x = 0; x < copyWidth; x++,  dst2+=4, src2++)
         *dst2 = *src2;
       src -= m_width;
       dst += dstPitch;

--- a/xbmc/guilib/cximage.h
+++ b/xbmc/guilib/cximage.h
@@ -29,7 +29,7 @@ public:
   ~CXImage();
 
   virtual bool LoadImageFromMemory(unsigned char* buffer, unsigned int bufSize, unsigned int width, unsigned int height);
-  virtual bool Decode(unsigned char* const pixels, unsigned int pitch, unsigned int format);
+  virtual bool Decode(unsigned char* const pixels, unsigned int width, unsigned int height, unsigned int pitch, unsigned int format);
   virtual bool CreateThumbnailFromSurface(unsigned char* bufferin, unsigned int width, unsigned int height, unsigned int format, unsigned int pitch, const std::string& destFile, 
                                           unsigned char* &bufferout, unsigned int &bufferoutSize);
   virtual void ReleaseThumbnailBuffer();

--- a/xbmc/guilib/iimage.h
+++ b/xbmc/guilib/iimage.h
@@ -43,7 +43,7 @@ public:
    \param format The format of the output buffer (JpegIO only)
    \return true if the image data could be decoded to the output buffer
    */
-  virtual bool Decode(unsigned char* const pixels, unsigned int pitch, unsigned int format)=0;
+  virtual bool Decode(unsigned char* const pixels, unsigned int width, unsigned int height, unsigned int pitch, unsigned int format)=0;
   /*!
    \brief Encodes an thumbnail from raw bits of given memory location
    \remarks Caller need to call ReleaseThumbnailBuffer() afterwards to free the output buffer


### PR DESCRIPTION
@fritsch fyi
The cximage and jpegio commits are debatable. There seems to be a convention that the LoadIImage(...) implementation already scales the image, however the pitch and the height of a texture could be changed afterwards under rare circumstances.
