### PR TITLE
[builddep] fix build Ubuntu 16.4 Xenial

### DIFF
--- a/tools/depends/target/libgpg-error/Makefile
+++ b/tools/depends/target/libgpg-error/Makefile
@@ -3,7 +3,7 @@ DEPS= ../../Makefile.include Makefile
 
 # lib name, version
 LIBNAME=libgpg-error
-VERSION=1.12
+VERSION=1.20
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.bz2
 

--- a/tools/depends/target/libgpg-error/Makefile
+++ b/tools/depends/target/libgpg-error/Makefile
@@ -27,6 +27,14 @@ $(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
 	cd $(PLATFORM); $(CONFIGURE)
 
 $(LIBDYLIB): $(PLATFORM)
+ifeq ($(OS),osx)
+	$(MAKE) -C $(PLATFORM)/src gen-posix-lock-obj
+	$(PLATFORM)/src/gen-posix-lock-obj > $(PLATFORM)/src/syscfg/tmp.h
+	mv $(PLATFORM)/src/syscfg/tmp.h $(PLATFORM)/src/syscfg/$$(awk 'NR==1 {print $$2}' $(PLATFORM)/src/syscfg/tmp.h)
+endif
+ifeq ($(OS),android)
+	cp $(PLATFORM)/src/syscfg/lock-obj-pub.arm-unknown-linux-androideabi.h $(PLATFORM)/src/syscfg/lock-obj-pub.linux-android.h
+endif
 	$(MAKE) -C $(PLATFORM)
 
 .installed-$(PLATFORM): $(LIBDYLIB)

--- a/tools/depends/target/libssh/Makefile
+++ b/tools/depends/target/libssh/Makefile
@@ -23,6 +23,7 @@ $(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
 	cd $(PLATFORM); patch -p0 < ../ntohl.patch
 	cd $(PLATFORM); patch -p0 < ../md5.patch
 	cd $(PLATFORM); patch -p1 < ../darwin.patch
+	cd $(PLATFORM); patch -p0 < ../fix-gcc-5-compile.patch
 	sed -ie "s|-fstack-protector|-fno-stack-protector|" "$(PLATFORM)/cmake/Modules/DefineCompilerFlags.cmake"
 	sed -ie "s|add_subdirectory(examples)||" "$(PLATFORM)/CMakeLists.txt"
 	cd $(PLATFORM)/build; $(CMAKE) -DWITH_STATIC_LIB=1 -DWITH_EXAMPLES=0 -DTHREADS_PTHREAD_ARG=0 -DWITH_GSSAPI=0 VERBOSE=1 ..

--- a/tools/depends/target/libssh/fix-gcc-5-compile.patch
+++ b/tools/depends/target/libssh/fix-gcc-5-compile.patch
@@ -1,0 +1,55 @@
+--- include/libssh/pki_priv.h	2015-11-05 09:39:40.011875890 +0100
++++ include/libssh/pki_priv.h	2015-11-05 09:39:34.151849945 +0100
+@@ -29,7 +29,7 @@
+ #define ECDSA_HEADER_END "-----END EC PRIVATE KEY-----"
+ 
+ #define ssh_pki_log(...) \
+-    _ssh_pki_log(__FUNCTION__, __VA_ARGS__)
++    _ssh_pki_log(__extension__ __FUNCTION__, __VA_ARGS__)
+ void _ssh_pki_log(const char *function,
+                   const char *format, ...) PRINTF_ATTRIBUTE(2, 3);
+ 
+--- include/libssh/priv.h	2015-11-05 09:39:40.011875890 +0100
++++ include/libssh/priv.h	2015-11-05 09:41:01.272239916 +0100
+@@ -179,7 +179,7 @@
+                       const char *function,
+                       const char *buffer);
+ #define SSH_LOG(priority, ...) \
+-    _ssh_log(priority, __FUNCTION__, __VA_ARGS__)
++    _ssh_log(priority, __extension__ __FUNCTION__, __VA_ARGS__)
+ 
+ /* LEGACY */
+ void ssh_log_common(struct ssh_common_struct *common,
+@@ -197,18 +197,18 @@
+ };
+ 
+ #define ssh_set_error(error, code, ...) \
+-    _ssh_set_error(error, code, __FUNCTION__, __VA_ARGS__)
++    _ssh_set_error(error, code, __extension__ __FUNCTION__, __VA_ARGS__)
+ void _ssh_set_error(void *error,
+                     int code,
+                     const char *function,
+                     const char *descr, ...) PRINTF_ATTRIBUTE(4, 5);
+ 
+ #define ssh_set_error_oom(error) \
+-    _ssh_set_error_oom(error, __FUNCTION__)
++    _ssh_set_error_oom(error, __extension__ __FUNCTION__)
+ void _ssh_set_error_oom(void *error, const char *function);
+ 
+ #define ssh_set_error_invalid(error) \
+-    _ssh_set_error_invalid(error, __FUNCTION__)
++    _ssh_set_error_invalid(error, __extension__ __FUNCTION__)
+ void _ssh_set_error_invalid(void *error, const char *function);
+ 
+ 
+--- src/auth.c	2014-12-27 11:30:13.000000000 +0100
++++ src/auth.c	2015-11-05 09:42:41.732698584 +0100
+@@ -1548,7 +1548,7 @@
+          * This should not happen
+          */
+         rc = SSH_AUTH_ERROR;
+-        ssh_set_error(session,SSH_FATAL,"Invalid state in %s", __FUNCTION__);
++        ssh_set_error(session,SSH_FATAL,"Invalid state in %s", __extension__ __FUNCTION__);
+     }
+     return rc;
+ }


### PR DESCRIPTION
The following build dependencies changes fix build on the the next Ubuntu Version 16.4 (Xenial) which use GCC 5 and bring compile errors on libssh and libgpg-error.

Also added temporary  libgpg-error-1.20.tar.bz2 for upload to sources storage.

[edit] temporary file removed, due to correct link with related home page (thanks @fritsch )

https://www.gnupg.org/(fr)/download/index.html#libgpg-error 
