### PR TITLE
[addons] ensure we have a valid libname (fixes #16361)

### DIFF
--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -419,6 +419,7 @@ void CAddon::BuildLibName(const cp_extension_t *extension)
       case ADDON_VIZ:
         {
           // if library attribute isn't present, look for a system-dependent one
+          m_strLibName = CAddonMgr::GetInstance().GetExtValue(extension->configuration, "@library");
           if (m_strLibName.empty())
             m_strLibName = CAddonMgr::GetInstance().GetPlatformLibraryName(extension->configuration);
         }


### PR DESCRIPTION
Fixes a regression introduced in f32483d60161df8bad9e090551b0e533d4d28f84 leading to non-working addons like eg. the python screensaver as reported in http://trac.kodi.tv/ticket/16361.

I am not entirely sure if this is what you had in mind @garbear, so please check ;)

/cc @ronie, @tamland 
