### PR TITLE
[music] don't use the directory cache when cleaning the database (fix…

### DIFF
--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -2559,7 +2559,7 @@ bool CMusicDatabase::CleanupSongsByIds(const std::string &strSongIds)
         URIUtils::RemoveSlashAtEnd(strFileName);
       }
 
-      if (!CFile::Exists(strFileName))
+      if (!CFile::Exists(strFileName, false))
       { // file no longer exists, so add to deletion list
         songsToDelete.push_back(m_pDS->fv("song.idSong").get_asString());
       }


### PR DESCRIPTION
This changes the musicdb cleaning to bypass the directory cache when doing the actual `CFile::Exists()` lookup (just as we do for the video library). Should fix http://trac.kodi.tv/ticket/16354

/cc @DaveTBlake, @evilhamster, @Razzeee
