### PR TITLE
Fix missing artist names in legacy Python music interface

### DIFF
--- a/xbmc/interfaces/legacy/InfoTagMusic.cpp
+++ b/xbmc/interfaces/legacy/InfoTagMusic.cpp
@@ -54,12 +54,12 @@ namespace XBMCAddon
 
     String InfoTagMusic::getArtist()
     {
-      return StringUtils::Join(infoTag->GetArtist(), g_advancedSettings.m_musicItemSeparator);
+      return infoTag->GetArtistString();
     }
 
     String InfoTagMusic::getAlbumArtist()
     {
-      return StringUtils::Join(infoTag->GetAlbumArtist(), g_advancedSettings.m_musicItemSeparator);
+      return infoTag->GetAlbumArtistString();
     }
 
     String InfoTagMusic::getAlbum()

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -5307,7 +5307,7 @@ void CMusicDatabase::ImportFromXML(const std::string &xmlFile)
         CAlbum importedAlbum;
         importedAlbum.Load(entry);
         strTitle = importedAlbum.strAlbum;
-        int idAlbum = GetAlbumByName(importedAlbum.strAlbum, importedAlbum.GetAlbumArtist());
+        int idAlbum = GetAlbumByName(importedAlbum.strAlbum, importedAlbum.GetAlbumArtistString());
         if (idAlbum > -1)
         {
           CAlbum album;
@@ -5399,7 +5399,7 @@ void CMusicDatabase::SetPropertiesForFileItem(CFileItem& item)
   int idAlbum = item.GetMusicInfoTag()->GetAlbumId();
   if (idAlbum <= 0)
     idAlbum = GetAlbumByName(item.GetMusicInfoTag()->GetAlbum(),
-                             item.GetMusicInfoTag()->GetArtist());
+                             item.GetMusicInfoTag()->GetArtistString());
   if (idAlbum > -1)
   {
     CAlbum album;

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -549,16 +549,16 @@ void CGUIWindowMusicNav::GetContextButtons(int itemNumber, CContextButtons &butt
         // 4. specific per album
         buttons.Add(CONTEXT_BUTTON_SET_CONTENT, 20195);
       }
-      if (item->HasMusicInfoTag() && item->GetMusicInfoTag()->GetArtist().size() > 0)
+      if (item->HasMusicInfoTag() && !item->GetMusicInfoTag()->GetArtistString().empty())
       {
         CVideoDatabase database;
         database.Open();
         if (database.GetMatchingMusicVideo(item->GetMusicInfoTag()->GetArtistString()) > -1)
           buttons.Add(CONTEXT_BUTTON_GO_TO_ARTIST, 20400);
       }
-      if (item->HasMusicInfoTag() && item->GetMusicInfoTag()->GetArtist().size() > 0 &&
-        item->GetMusicInfoTag()->GetAlbum().size() > 0 &&
-        item->GetMusicInfoTag()->GetTitle().size() > 0)
+      if (item->HasMusicInfoTag() && !item->GetMusicInfoTag()->GetArtistString().empty() &&
+         !item->GetMusicInfoTag()->GetAlbum().empty() &&
+         !item->GetMusicInfoTag()->GetTitle().empty())
       {
         CVideoDatabase database;
         database.Open();


### PR DESCRIPTION
A few more places that need to use `CMusicInfoTag.GetArtistString()` and `GetAlbumArtistString()`  after the addition of processing for ARTISTS tag #7486 and the tidy-up that removed the artist vector from CSong and CArtist in #8158.

@ronie thanks for spotting the missing artist name from Python (see #8339). I had overlooked the legacy folder software. In #8306 I removed a temp fix (for JSON) that was also helping legacy addons. I hope I have finally cracked it!!

This tidy-up has been painful because it has been tricky to spot all the places that were splitting the string from the strArtists field of the song and albums tables, sometimes only to re-join it immediately, rather than getting the full artist list from the song_artist, album_artist and artist tables. They can now differ in content, so it is important that we sort this out. The MusicInfoTag artist vector only gets populated when a) scanned from the tags or b) when queried from the artist table. If we only fetch the desc string then only that gets stored.

CC: @Razzeee , @evilhamster 
