### PR TITLE
[EPG,PVR] Fix deadlock caused by Noitifyobservers call while holding instance's mutex

### DIFF
--- a/xbmc/epg/Epg.cpp
+++ b/xbmc/epg/Epg.cpp
@@ -392,6 +392,8 @@ bool CEpg::UpdateEntries(const CEpg &epg, bool bStoreInDb /* = true */)
   m_bUpdateLastScanTime = true;
 
   SetChanged(true);
+  lock.Leave();
+
   NotifyObservers(ObservableMessageEpg);
 
   return true;


### PR DESCRIPTION
Call stacks: http://paste.ubuntu.com/13115054/

BTW: Checked that all other calls to NotifyObservers in xbmc/epg and xbmc/pvr are okay.

@Jalle19 @xhaggi mind taking a look
