### PR TITLE
Fix inversion of export library dialogs, fix #16317, fix #16358

### DIFF
--- a/xbmc/dialogs/GUIDialogYesNo.cpp
+++ b/xbmc/dialogs/GUIDialogYesNo.cpp
@@ -146,6 +146,7 @@ int CGUIDialogYesNo::ShowAndGetInput(const KODI::MESSAGING::HELPERS::DialogYesNo
     SetChoice(1, options.yesLabel);
   if (options.autoclose > 0)
     SetAutoClose(options.autoclose);
+  m_bCanceled = false;
   
   for (size_t i = 0; i < 3; ++i)
   {

--- a/xbmc/interfaces/builtins/LibraryBuiltins.cpp
+++ b/xbmc/interfaces/builtins/LibraryBuiltins.cpp
@@ -89,7 +89,7 @@ static int ExportLibrary(const std::vector<std::string>& params)
   bool cancelled=false;
 
   if (params.size() > 1)
-    singleFile = StringUtils::EqualsNoCase(params[1], "true");
+    singleFile = StringUtils::EqualsNoCase(params[1], "false");
   else
   {
     HELPERS::DialogResponse result = HELPERS::ShowYesNoDialogText(CVariant{iHeading}, CVariant{20426}, CVariant{20428}, CVariant{20429});
@@ -100,7 +100,7 @@ static int ExportLibrary(const std::vector<std::string>& params)
   if (cancelled)
     return -1;
 
-  if (singleFile)
+  if (!singleFile)
   {
     if (params.size() > 2)
       thumbs = StringUtils::EqualsNoCase(params[2], "true");
@@ -130,7 +130,7 @@ static int ExportLibrary(const std::vector<std::string>& params)
   if (cancelled)
     return -1;
 
-  if (singleFile)
+  if (!singleFile)
   {
     if (params.size() > 3)
       overwrite = StringUtils::EqualsNoCase(params[3], "true");
@@ -147,7 +147,7 @@ static int ExportLibrary(const std::vector<std::string>& params)
 
   if (params.size() > 2)
     path=params[2];
-  if ((singleFile && !path.empty()) ||
+  if (!singleFile || !path.empty() ||
       CGUIDialogFileBrowser::ShowAndGetDirectory(shares, g_localizeStrings.Get(661),
                                                  path, true))
   {


### PR DESCRIPTION
Seems to have been inverted by https://github.com/xbmc/xbmc/pull/7800/files#diff-cc6ead21ea518ad3638e13347df6cad4L1597

http://forum.kodi.tv/showthread.php?tid=243558

Closes http://trac.kodi.tv/ticket/16317, http://trac.kodi.tv/ticket/16358
