### PR TITLE
 [PVR] Fix: Do not try to update read-only timers.

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRTimers.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRTimers.cpp
@@ -408,28 +408,3 @@ bool CGUIWindowPVRTimers::ShowNewTimerDialog(void)
 
   return bReturn;
 }
-
-bool CGUIWindowPVRTimers::ShowTimerSettings(CFileItem *item)
-{
-  /* Check item is TV timer information tag */
-  if (!item->IsPVRTimer())
-  {
-    CLog::Log(LOGERROR, "CGUIWindowPVRTimers: Can't open timer settings dialog, no timer info tag!");
-    return false;
-  }
-
-  /* Load timer settings dialog */
-  CGUIDialogPVRTimerSettings* pDlgInfo = (CGUIDialogPVRTimerSettings*)g_windowManager.GetWindow(WINDOW_DIALOG_PVR_TIMER_SETTING);
-
-  if (!pDlgInfo)
-    return false;
-
-  /* inform dialog about the file item */
-  pDlgInfo->SetTimer(item);
-
-  /* Open dialog window */
-  pDlgInfo->Open();
-
-  /* Get modify flag from window and return it to caller */
-  return pDlgInfo->IsConfirmed();
-}

--- a/xbmc/pvr/windows/GUIWindowPVRTimers.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRTimers.cpp
@@ -302,7 +302,7 @@ bool CGUIWindowPVRTimers::OnContextButtonEdit(CFileItem *item, CONTEXT_BUTTON bu
     if (!item->HasPVRTimerInfoTag())
       return bReturn;
 
-    if (ShowTimerSettings(item))
+    if (ShowTimerSettings(item) && !item->GetPVRTimerInfoTag()->GetTimerType()->IsReadOnly())
       g_PVRTimers->UpdateTimer(*item);
   }
 
@@ -381,7 +381,7 @@ bool CGUIWindowPVRTimers::ActionShowTimer(CFileItem *item)
   }
   else
   {
-    if (ShowTimerSettings(item))
+    if (ShowTimerSettings(item) && !item->GetPVRTimerInfoTag()->GetTimerType()->IsReadOnly())
     {
       /* Update timer on pvr backend */
       bReturn = g_PVRTimers->UpdateTimer(*item);

--- a/xbmc/pvr/windows/GUIWindowPVRTimers.h
+++ b/xbmc/pvr/windows/GUIWindowPVRTimers.h
@@ -49,7 +49,6 @@ namespace PVR
   private:
     bool ActionDeleteTimer(CFileItem *item);
     bool ActionShowTimer(CFileItem *item);
-    bool ShowTimerSettings(CFileItem *item);
     bool ShowNewTimerDialog(void);
 
     bool OnContextButtonActivate(CFileItem *item, CONTEXT_BUTTON button);


### PR DESCRIPTION
Fixes the error dialog that popped up after closing the timer settings dialog of a child of a repeating timer with OK instead of Cancel. Reason is that children of repeating timer created by pvr.hts are read-only (due to tvheadend limitations) and Kodi was trying to update these timers.

@da-anda mind testing this?
