### PR TITLE
Localize common artwork types - fixes trac #16107

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -10386,7 +10386,19 @@ msgctxt "#20019"
 msgid "Choose thumbnail"
 msgstr ""
 
-#empty strings from id 20020 to 20022
+#. Name of an artwork type
+#: xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+msgctxt "#20020"
+msgid "Banner"
+msgstr ""
+
+#. Name of an artwork type
+#: xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+msgctxt "#20021"
+msgid "Poster"
+msgstr ""
+
+#empty string with id 20022
 #string id 20022 will always be set to an empty string (LocalizeStrings.cpp)
 
 msgctxt "#20023"

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -633,7 +633,16 @@ std::string CGUIDialogVideoInfo::ChooseArtType(const CFileItem &videoItem, std::
   {
     std::string type = *i;
     CFileItemPtr item(new CFileItem(type, "false"));
-    item->SetLabel(type);
+    if (type == "banner")
+      item->SetLabel(g_localizeStrings.Get(20020));
+    else if (type == "fanart")
+      item->SetLabel(g_localizeStrings.Get(20445));
+    else if (type == "poster")
+      item->SetLabel(g_localizeStrings.Get(20021));
+    else if (type == "thumb")
+      item->SetLabel(g_localizeStrings.Get(21371));
+    else
+      item->SetLabel(type);
     if (videoItem.HasArt(type))
       item->SetArt("thumb", videoItem.GetArt(type));
     items.Add(item);


### PR DESCRIPTION
![art](https://cloud.githubusercontent.com/assets/687265/11008699/ae5f6fee-84d2-11e5-94fe-14946439a474.jpg)
the artwork names in the 'choose art' dialog aren't localized.
this might be inconvenient for non-english users.

while this solution is not perfect, ie users can add arbitrary artwork types to the database,
it at least handles the most common artwork types. 
