### PR TITLE
[touch/filemanager] - workaround for the non-working touch input in t…

### DIFF
--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -309,6 +309,10 @@ bool CGUIWindowFileManager::OnMessage(CGUIMessage& message)
       }
     }
     break;
+  // prevent touch/gesture unfocussing ..
+  case GUI_MSG_GESTURE_NOTIFY:
+  case GUI_MSG_UNFOCUS_ALL:
+    return true;
   }
   return CGUIWindow::OnMessage(message);
 }


### PR DESCRIPTION
…he filemanager window.

This is a workaround for the non-working touch controls in the FileManager window. Basically you can't enter any directories in there.

As said - this is only a workaround and also only works partially. While the FileManager window is now usable with touch input again - in confluence for example the home and back buttons at the lower screen are not working. The real cause has to do with wrong evaluation order of messages/actions or with badly tracked focus state.

On touch we basically send a mouse move, then fire the action to be done on the selected item which has focus (focused by the mouse move) and then send an unfocus_all message. Strangly this doesn't work in the FIleManager window. There we see the mouse move, then the unfocus_all and then the SELECT_ITEM message (the latter then checks for the focused control and gets none and so it does nothing). Either that OR the order is correct but during the SELECT_ITEM handler there is no focused control reported.

I have informed @mkortstiege and @Paxxi about it a while back and also provided a branch for reproduction with mouse input here:

https://github.com/Memphiz/xbmc/commits/reproduce_touch_issue

No clue who else is into that messaging/gui focus stuff. For jarvis we need a working filemanager with touch input - either the real cause can be tracked down and fixed or this workround needs to go in.

Just for dissociation. I am not the developer who will track down the real cause (i missed to much in the last couple weeks and others are much quicker with this).
