### PR TITLE
Screensaver fps limitation

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1944,6 +1944,10 @@ void CApplication::Render()
         else if (lowfps)
           singleFrameTime = 200;  // 5 fps, <=200 ms latency to wake up
       }
+      if (m_bScreenSave==true)  // Limit fps to 1 when screensaver is active. Reduce CPU load a lot - for 24/7 devices (Rpi etc.)
+      {
+				singleFrameTime = 1000;
+	  	}
 
     }
   }


### PR DESCRIPTION
Reduce fps when screensaver is active. Helps with CPU usage (therefore power consuption) for 24/7 devices like Rpi etc., where expecting usage is only part of a day.
