### PR TITLE
[addons] fix clearing of blacklist state on uninstall

### DIFF
--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -726,13 +726,6 @@ void OnPreUnInstall(const AddonPtr& addon)
   if (CAddonMgr::GetInstance().GetAddon(addon->ID(), localAddon, ADDON_CONTEXT_ITEM))
     CContextMenuManager::GetInstance().Unregister(std::static_pointer_cast<CContextMenuAddon>(localAddon));
 
-  if (CAddonMgr::GetInstance().GetAddon(addon->ID(), localAddon, ADDON_REPOSITORY))
-  {
-    CAddonDatabase database;
-    database.Open();
-    database.DeleteRepository(addon->ID());
-  }
-
   addon->OnPreUnInstall();
 }
 

--- a/xbmc/addons/AddonDatabase.cpp
+++ b/xbmc/addons/AddonDatabase.cpp
@@ -917,3 +917,10 @@ bool CAddonDatabase::IsSystemAddonRegistered(const std::string &addonID)
   }
   return false;
 }
+
+void CAddonDatabase::OnPostUnInstall(const std::string& addonId)
+{
+  DisableAddon(addonId, false);
+  RemoveAddonFromBlacklist(addonId);
+  DeleteRepository(addonId);
+}

--- a/xbmc/addons/AddonDatabase.h
+++ b/xbmc/addons/AddonDatabase.h
@@ -157,6 +157,9 @@ public:
   */
   bool IsSystemAddonRegistered(const std::string &addonID);
 
+  /*! Clear internal fields that shouldn't be kept around indefinitely */
+  void OnPostUnInstall(const std::string& addonId);
+
 protected:
   virtual void CreateTables();
   virtual void CreateAnalytics();

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -896,6 +896,9 @@ bool CAddonUnInstallJob::DoWork()
     addon = m_addon;
   CEventLog::GetInstance().Add(EventPtr(new CAddonManagementEvent(addon, 24144)));
 
+  CAddonMgr::GetInstance().OnPostUnInstall(m_addon->ID());
+  database.OnPostUnInstall(m_addon->ID());
+
   ADDON::OnPostUnInstall(m_addon);
   return true;
 }

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -625,10 +625,8 @@ bool CAddonInstallJob::DoWork()
 
   ADDON::OnPostInstall(m_addon, m_update, IsModal());
 
-  //Clear addon from the disabled table
-  CAddonDatabase database;
-  database.Open();
-  database.DisableAddon(m_addon->ID(), false);
+  //Enable it if it was previously disabled
+  CAddonMgr::GetInstance().EnableAddon(m_addon->ID());
 
   // and we're done!
   MarkFinished();

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -646,7 +646,6 @@ void CAddonMgr::FindAddons()
 void CAddonMgr::UnregisterAddon(const std::string& ID)
 {
   CSingleLock lock(m_critSection);
-  m_disabled.erase(ID);
   if (m_cpluff && m_cp_context)
   {
     m_cpluff->uninstall_plugin(m_cp_context, ID.c_str());
@@ -654,6 +653,13 @@ void CAddonMgr::UnregisterAddon(const std::string& ID)
     lock.Leave();
     NotifyObservers(ObservableMessageAddons);
   }
+}
+
+void CAddonMgr::OnPostUnInstall(const std::string& id)
+{
+  CSingleLock lock(m_critSection);
+  m_disabled.erase(id);
+  m_updateBlacklist.erase(id);
 }
 
 bool CAddonMgr::RemoveFromUpdateBlacklist(const std::string& id)

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -268,6 +268,7 @@ void CAddonMgr::UnregisterAddonMgrCallback(TYPE type)
 
 bool CAddonMgr::Init()
 {
+  CSingleLock lock(m_critSection);
   m_cpluff = new DllLibCPluff;
   m_cpluff->Load();
 

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -112,6 +112,9 @@ namespace ADDON
     void FindAddons();
     void UnregisterAddon(const std::string& ID);
 
+    /*! Hook for clearing internal state after uninstall. */
+    void OnPostUnInstall(const std::string& id);
+
     /*! \brief Disable an addon. Returns true on success, false on failure. */
     bool DisableAddon(const std::string& ID);
 


### PR DESCRIPTION
Currently it leaves stale entries in db, which leads to a bad state being loaded again if it's later re-install.
