### PR TITLE
Music file view content as "files" and still have "media info" view type

### DIFF
--- a/addons/skin.confluence/720p/ViewsMusicLibrary.xml
+++ b/addons/skin.confluence/720p/ViewsMusicLibrary.xml
@@ -16,7 +16,7 @@
 				<viewtype label="$LOCALIZE[544]">list</viewtype>
 				<pagecontrol>60</pagecontrol>
 				<scrolltime>200</scrolltime>
-				<visible>Window.IsVisible(MusicPlaylist) |  Container.Content(Songs) | Container.Content(Albums)</visible>
+				<visible>Container.Content(Files) | Window.IsVisible(MusicPlaylist) |  Container.Content(Songs) | Container.Content(Albums)</visible>
 				<itemlayout height="40" width="780">
 					<control type="image">
 						<left>0</left>

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -347,8 +347,7 @@ bool CGUIWindowMusicNav::GetDirectory(const std::string &strDirectory, CFileItem
     items.SetContent("playlists");
   else if (URIUtils::PathEquals(strDirectory, "plugin://music/"))
     items.SetContent("plugins");
-  else if (items.IsPlayList() || 
-          (!items.IsSourcesPath() && !items.IsVirtualDirectoryRoot() && !items.IsLibraryFolder()))
+  else if (items.IsPlayList())
     items.SetContent("songs");
 
   return bResult;


### PR DESCRIPTION
Restore content to "files" when in music file view, but still have "media info" view type available so that music file tag data can be displayed when it is available.

This is follow up to #8205 and #8287, the previous attempts to restore the original file view functionality that was broken by #8011 when deprecating the use of CGUIViewStateWindowMusicSong to make music more like video.  One aspect of the previous fixes, setting content = "songs" when in file view, was causing problems with skins, and as it turned out there was a more simple way to restore the "media info" view type that it was trying to achieve.

@mkortstiege your overview of this appreciated. 
@HitcherUK, @ronie, @jeroenpardon  and any other skinners like to ensure this works OK. 
@jjd-uk please check that file view is behaving as it should.
