### PR TITLE
[pydocs] Fix small typo in xbmc.log() example

### DIFF
--- a/xbmc/interfaces/legacy/ModuleXbmc.h
+++ b/xbmc/interfaces/legacy/ModuleXbmc.h
@@ -50,7 +50,7 @@ namespace XBMCAddon
      *           See pydocs for valid values for level.\n
      *           
      *           example:
-     *             - xbmc.log(msg='This is a test string.', level=xbmc.LOGDEBUG));
+     *             - xbmc.log(msg='This is a test string.', level=xbmc.LOGDEBUG);
      */
     void log(const char* msg, int level = lLOGNOTICE);
 


### PR DESCRIPTION
This fix a minimal typo in the example provided in the documentation for the xbmc.log function.

ping @MartijnKaijser 
