### PR TITLE
[PVR] Next recording recording widget fix

### DIFF
--- a/xbmc/pvr/timers/PVRTimerInfoTag.h
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.h
@@ -127,6 +127,15 @@ namespace PVR
         || m_state == PVR_TIMER_STATE_ERROR;
     }
 
+    /*!
+     * @return True if this timer won't result in a recording because it is broken for some reason, false otherwise
+     */
+    bool IsBroken(void) const
+    {
+      return m_state == PVR_TIMER_STATE_CONFLICT_NOK
+        || m_state == PVR_TIMER_STATE_ERROR;
+    }
+
     bool IsRecording(void) const { return m_state == PVR_TIMER_STATE_RECORDING; }
 
     /*!

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -306,7 +306,7 @@ CFileItemPtr CPVRTimers::GetNextActiveTimer(void) const
     for (VecTimerInfoTag::const_iterator timerIt = it->second->begin(); timerIt != it->second->end(); ++timerIt)
     {
       CPVRTimerInfoTagPtr current = *timerIt;
-      if (current->IsActive() && !current->IsRecording() && !current->IsRepeating())
+      if (current->IsActive() && !current->IsRecording() && !current->IsRepeating() && !current->IsBroken())
       {
         CFileItemPtr fileItem(new CFileItem(current));
         return fileItem;


### PR DESCRIPTION
Two problems related to the PVR 'Next recording' and 'Currently In Progress' widget

1) Next Recording widget currently includes things which are active but won't be recorded due to an error or a conflict. This is misleading (see http://forum.kodi.tv/showthread.php?tid=246623 and http://trac.kodi.tv/ticket/16374)

2) Currently Recording includes 'Repeating' timers as well as their children, resulting in duplication if they both have status 'Recording in progress'. (Not part of the original discussion thread but another bugbear of mine and related to the same widget. Seems to match similar !IsRepeating conditions in other parts of the code. Reproducible with latest pvr.mythtv client) - spun off as https://github.com/xbmc/xbmc/pull/8400

**Potential concerns with my current approach:**
1) Assumes that the following states aren't really 'active'. Does this work with all PVR clients? : 
PVR_TIMER_STATE_CONFLICT_NOK, - the original reported problem
PVR_TIMER_STATE_ERROR - assumed to be a similar 'won't record but ought to' state

2) Introduces a new 'IsBroken' timerInfoTag call. It would be simpler just to remove these states from 'IsActive', but IsActive is used in xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp to set the current timer Active/Inactive status which the user can then toggle using the menu. A 'broken' active status won't be fixed simply by telling the backend to 'fix it'.

I won't be around later today (Sunday 15th) to check this PR for comments, but will check back on Mon/Tues etc....
pings: @ksooo @opdenkamp @xhaggi @FernetMenta 
