### PR TITLE
[PVR] Timerdialog fixes

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -923,6 +923,21 @@ void CGUIDialogPVRTimerSettings::PrioritiesFiller(
     list.clear();
     pThis->m_timerType->GetPriorityValues(list);
     current = pThis->m_iPriority;
+
+    auto it = list.begin();
+    while (it != list.end())
+    {
+      if (it->second == current)
+        break; // value already in list
+
+      ++it;
+    }
+
+    if (it == list.end())
+    {
+      // PVR backend supplied value is not in the list of predefined values. Insert it.
+      list.insert(it, std::make_pair(StringUtils::Format("%d", current), current));
+    }
   }
   else
     CLog::Log(LOGERROR, "CGUIDialogPVRTimerSettings::PrioritiesFiller - No dialog");
@@ -937,6 +952,21 @@ void CGUIDialogPVRTimerSettings::LifetimesFiller(
     list.clear();
     pThis->m_timerType->GetLifetimeValues(list);
     current = pThis->m_iLifetime;
+
+    auto it = list.begin();
+    while (it != list.end())
+    {
+      if (it->second == current)
+        break; // value already in list
+
+      ++it;
+    }
+
+    if (it == list.end())
+    {
+      // PVR backend supplied value is not in the list of predefined values. Insert it.
+      list.insert(it, std::make_pair(StringUtils::Format(g_localizeStrings.Get(17999).c_str(), current) /* %i days */, current));
+    }
   }
   else
     CLog::Log(LOGERROR, "CGUIDialogPVRTimerSettings::LifetimesFiller - No dialog");
@@ -951,6 +981,21 @@ void CGUIDialogPVRTimerSettings::MaxRecordingsFiller(
     list.clear();
     pThis->m_timerType->GetMaxRecordingsValues(list);
     current = pThis->m_iMaxRecordings;
+
+    auto it = list.begin();
+    while (it != list.end())
+    {
+      if (it->second == current)
+        break; // value already in list
+
+      ++it;
+    }
+
+    if (it == list.end())
+    {
+      // PVR backend supplied value is not in the list of predefined values. Insert it.
+      list.insert(it, std::make_pair(StringUtils::Format("%d", current), current));
+    }
   }
   else
     CLog::Log(LOGERROR, "CGUIDialogPVRTimerSettings::MaxRecordingsFiller - No dialog");

--- a/xbmc/pvr/timers/PVRTimerType.cpp
+++ b/xbmc/pvr/timers/PVRTimerType.cpp
@@ -222,9 +222,7 @@ void CPVRTimerType::InitMaxRecordingsValues(const PVR_TIMER_TYPE &type)
       if (strDescr.size() == 0)
       {
         // No description given by addon. Create one from value.
-        strDescr = StringUtils::Format("%s %d",
-                                       g_localizeStrings.Get(817).c_str(), // Max Recordings
-                                       type.maxRecordings[i].iValue);
+        strDescr = StringUtils::Format("%d", type.maxRecordings[i].iValue);
       }
       m_maxRecordingsValues.push_back(std::make_pair(strDescr, type.maxRecordings[i].iValue));
     }


### PR DESCRIPTION
The label for max recordings was: "Max recordings: End any time %d"..
now -> "Max recordings: %d"

When the backend sends an non standard integer value for lifetime, priority or max recordings, the setting stays empty. We should add the missing value instead (like start and end margin)
The pvr add-on can not add all the possible integer values to the valueslist as it would be huge, that's why we should handle this.

@ksooo @Jalle19 
