### PR TITLE
[confluence] filter entry swap control type radiobutton for togglebutton

### DIFF
--- a/addons/skin.confluence/720p/MyMusicNav.xml
+++ b/addons/skin.confluence/720p/MyMusicNav.xml
@@ -92,7 +92,7 @@
 					<include>ButtonCommonValues</include>
 					<label>587</label>
 				</control>
-				<control type="radiobutton" id="98">
+				<control type="togglebutton" id="98">
 					<visible>Container.CanFilterAdvanced</visible>
 					<description>Filter</description>
 					<include>ButtonCommonValues</include>

--- a/addons/skin.confluence/720p/MyPics.xml
+++ b/addons/skin.confluence/720p/MyPics.xml
@@ -98,7 +98,7 @@
 					<include>ButtonCommonValues</include>
 					<label>587</label>
 				</control>
-				<control type="radiobutton" id="20">
+				<control type="togglebutton" id="20">
 					<visible>Container.CanFilterAdvanced</visible>
 					<description>Filter</description>
 					<include>ButtonCommonValues</include>

--- a/addons/skin.confluence/720p/MyPrograms.xml
+++ b/addons/skin.confluence/720p/MyPrograms.xml
@@ -82,7 +82,7 @@
 					<include>ButtonCommonValues</include>
 					<label>587</label>
 				</control>
-				<control type="radiobutton" id="20">
+				<control type="togglebutton" id="20">
 					<visible>Container.CanFilterAdvanced</visible>
 					<description>Filter</description>
 					<include>ButtonCommonValues</include>

--- a/addons/skin.confluence/720p/MyVideoNav.xml
+++ b/addons/skin.confluence/720p/MyVideoNav.xml
@@ -98,7 +98,7 @@
 					<include>ButtonCommonValues</include>
 					<label>587</label>
 				</control>
-				<control type="radiobutton" id="98">
+				<control type="togglebutton" id="98">
 					<visible>Container.CanFilterAdvanced</visible>
 					<description>Filter</description>
 					<include>ButtonCommonValues</include>


### PR DESCRIPTION
This should be straight forward, the filter button on side menu in some views is a radiobutton control type and the radio button never really becomes active, this looks slight odd to me.

Using a togglebutton control type instead, it behaves same as before and brings up the same dialog type and looks slightly cleaner.

![screenshot063](https://cloud.githubusercontent.com/assets/3521959/11169541/ae03f6fa-8bb2-11e5-9dd1-50a0e573f609.png)
