### PR TITLE
FFMpeg: Bump to 2.8.2-Jarvis-beta2

### DIFF
--- a/tools/depends/target/ffmpeg/FFMPEG-VERSION
+++ b/tools/depends/target/ffmpeg/FFMPEG-VERSION
@@ -1,5 +1,5 @@
 LIBNAME=ffmpeg
 BASE_URL=https://github.com/xbmc/FFmpeg/archive
-VERSION=2.8.1-Jarvis-alpha4-HEVC
+VERSION=2.8.2-Jarvis-beta2
 ARCHIVE=$(LIBNAME)-$(VERSION).tar.gz
 


### PR DESCRIPTION
This bumps ffmpeg to version 2.8.2+ using the 2.8 stable branch. It adds a commit already upstream done by @FernetMenta to fix one problem @MartijnKaijser had with UHD files.

Thanks much
