### PR TITLE
Fix AddonManager for raspberry-pi

### DIFF
--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -934,7 +934,7 @@ bool CAddonMgr::PlatformSupportsAddon(const cp_plugin_info_t *plugin) const
 #if defined(TARGET_FREEBSD)
         || *platform == "freebsd"
 #endif
-        )
+        || *platform == "rbpi")
 #elif defined(TARGET_WINDOWS) && defined(HAS_DX)
       if (*platform == "windx" || *platform == "windows")
 #elif defined(TARGET_DARWIN_OSX)


### PR DESCRIPTION
Missing platform for raspberry-bi , fix for load addons
