### PR TITLE
[MySQL] Workaround MySQL 5.7.x query optimiser changes

### DIFF
--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -27,6 +27,7 @@
 #include "system.h" // for GetLastError()
 #include "network/WakeOnAccess.h"
 #include "Util.h"
+#include "utils/StringUtils.h"
 
 #ifdef HAS_MYSQL
 #include "mysqldataset.h"
@@ -111,10 +112,39 @@ void MysqlDatabase::configure_connection() {
   char sqlcmd[512];
   int ret;
 
-  // MySQL 5.7.5+: http://mysqlserverteam.com/mysql-5-7-only_full_group_by-improved-recognizing-functional-dependencies-enabled-by-default
+  // MySQL 5.7.5+: See #8393
   strcpy(sqlcmd, "SET SESSION sql_mode = (SELECT REPLACE(@@SESSION.sql_mode,'ONLY_FULL_GROUP_BY',''))");
   if ((ret = mysql_real_query(conn, sqlcmd, strlen(sqlcmd))) != MYSQL_OK)
     throw DbErrors("Can't disable sql_mode ONLY_FULL_GROUP_BY: '%s' (%d)", db.c_str(), ret);
+
+  // MySQL 5.7.6+: See #8393
+  strcpy(sqlcmd, "SELECT @@SESSION.optimizer_switch");
+  if ((ret = mysql_real_query(conn, sqlcmd, strlen(sqlcmd))) != MYSQL_OK)
+    throw DbErrors("Can't query optimizer_switch: '%s' (%d)", db.c_str(), ret);
+
+  MYSQL_RES* res = mysql_store_result(conn);
+  MYSQL_ROW row;
+
+  if (res)
+  {
+    if ((row = mysql_fetch_row(res)) != NULL)
+    {
+      std::string column = row[0];
+      std::vector<std::string> split = StringUtils::Split(column, ',');
+
+      for (std::vector<std::string>::iterator itIn = split.begin(); itIn != split.end(); ++itIn)
+      {
+        if (StringUtils::Trim(*itIn) == "derived_merge=on")
+        {
+          strcpy(sqlcmd, "SET SESSION optimizer_switch = 'derived_merge=off'");
+          if ((ret = mysql_real_query(conn, sqlcmd, strlen(sqlcmd))) != MYSQL_OK)
+            throw DbErrors("Can't set optimizer_switch = '%s': '%s' (%d)", StringUtils::Trim(*itIn).c_str(), db.c_str(), ret);
+          break;
+        }
+      }
+    }
+    mysql_free_result(res);
+  }
 }
 
 int MysqlDatabase::connect(bool create_new) {

--- a/xbmc/dbwrappers/mysqldataset.h
+++ b/xbmc/dbwrappers/mysqldataset.h
@@ -85,6 +85,7 @@ public:
 
   bool in_transaction() {return _in_transaction;};
   int query_with_reconnect(const char* query);
+  void configure_connection();
 
 private:
 


### PR DESCRIPTION
See error reported on [forum](http://forum.kodi.tv/showthread.php?tid=247907).

I'm pretty certain the error being reported is caused by the OP using a version of MySQL Server (v5.7.5+) that has `ONLY_FULL_GROUP_BY` enabled by default (see [blog post](http://mysqlserverteam.com/mysql-5-7-only_full_group_by-improved-recognizing-functional-dependencies-enabled-by-default) for details).

Rather than update, review, and re-test all of our queries to accommodate this MySQL specific change, I've opted for the "brutal" approach and disabled the `ONLY_FULL_GROUP_BY` option upon connection (ie. per session) so that the old behaviour is restored without any further server (re-)configuration or modification/re-testing of queries etc.

The only other option appears to be rewriting/fixing the existing queries - if this is the preferred solution then I'll close this PR.

I have tested this change on MySQL v5.5.21 where I _enabled_ `ONLY_FULL_GROUP_BY` (per session) and previously working queries then started to fail with the same `1055` error.

Disabling this option has no effect on my server - it does basically nothing - but should fix the problem for users with MySQL v5.7.5+. It appears that `sql_mode` is supported by [MariaDB](https://mariadb.com/kb/en/mariadb/sql_mode/) so this change should work on that server too.

Ideally this should go into Jarvis (backport?)
