### PR TITLE
AE Pulse: Ignore volume changes on corked sinks

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
@@ -181,7 +181,7 @@ static void SinkInputInfoCallback(pa_context *c, const pa_sink_input_info *i, in
   if (!p || !p->IsInitialized())
     return;
 
-  if(i && i->has_volume)
+  if(i && i->has_volume && !i->corked)
     p->UpdateInternalVolume(&(i->volume));
 }
 


### PR DESCRIPTION
Fixes a rare issue where corked streams have valid but broken volume,
causing kodi to come up with volume set to 0.0.

Tracked down on IRC by me with the help of Btbn that already runs pulseaudio 7.x. As the comment says: it's a rare issue - but a nerving one.

Thanks much @btbn for testing the possible solutions.
