### PR TITLE
enable online scraping for music by default

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1658,7 +1658,7 @@
       <group id="2">
         <setting id="musiclibrary.downloadinfo" type="boolean" label="20192" help="36256">
           <level>0</level>
-          <default>false</default>
+          <default>true</default>
           <control type="toggle" />
         </setting>
         <setting id="musiclibrary.albumsscraper" type="addon" label="20193" help="36257">


### PR DESCRIPTION
no idea why we shouldn't really.

from a skinners pov, it's not possible to create a nice view for artists / albums
if we don't have any additional info to show.
