### PR TITLE
[PVR] Fix Timer Status UI inconsistencies

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -1344,6 +1344,8 @@ msgstr ""
 #: system/peripherals.xml
 #: xbmc/filesystem/AddonsDirectory.cpp
 #: system/settings/settings.xml
+#. Label of active/inactive radiobutton in PVR timer settings dialog
+#: xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
 msgctxt "#305"
 msgid "Enabled"
 msgstr ""
@@ -3527,23 +3529,11 @@ msgstr ""
 
 #empty string with id 824
 
-#. Representation of PVR timer state "disabled"
-#: xbmc/pvr/timers/PVRTimerInfoTag.cpp
-msgctxt "#825"
-msgid "Inactive"
-msgstr ""
+#empty string with id 825
 
-#. Notification text to announce that a timer was activated
-#: xbmc/pvr/timers/PVRTimerInfoTag.cpp
-msgctxt "#826"
-msgid "Timer activated"
-msgstr ""
+#empty string with id 826
 
-#. Notification text to announce that a timer was deactivated
-#: xbmc/pvr/timers/PVRTimerInfoTag.cpp
-msgctxt "#827"
-msgid "Timer deactivated"
-msgstr ""
+#empty string with id 827
 
 #. Text for notification that a repeating timer has been deleted
 #: xbmc/pvr/timers/PVRTimers.cpp
@@ -5630,6 +5620,7 @@ msgstr ""
 
 #: xbmc/peripherals/bus/PeripheralBus.cpp
 #: system/settings/settings.xml
+#: xbmc/pvr/timers/PVRTimerInfoTag.cpp
 msgctxt "#13106"
 msgid "Disabled"
 msgstr ""
@@ -8671,8 +8662,14 @@ msgctxt "#19056"
 msgid "New timer"
 msgstr ""
 
-# empty string with id 19057
+#. Notification text to announce that a timer was disabled
+#: xbmc/pvr/timers/PVRTimerInfoTag.cpp
+msgctxt "#19057"
+msgid "Timer disabled"
+msgstr ""
 
+#. Notification text to announce that a timer was enabled
+#: xbmc/pvr/timers/PVRTimerInfoTag.cpp
 msgctxt "#19058"
 msgid "Timer enabled"
 msgstr ""
@@ -8753,8 +8750,7 @@ msgctxt "#19073"
 msgid "Delay channel switch"
 msgstr ""
 
-#. Label of active/inactive radiobutton in PVR timer settings dialog
-#: xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+#: addons/skin.confluence/720p/DialogPVRChannelManager.xml
 msgctxt "#19074"
 msgid "Active"
 msgstr ""

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -237,7 +237,7 @@ void CGUIDialogPVRTimerSettings::InitializeSettings()
   AddTypeDependentEnableCondition(setting, SETTING_TMR_TYPE);
 
   // Timer enabled/disabled
-  setting = AddToggle(group, SETTING_TMR_ACTIVE, 19074, 0, m_bTimerActive);
+  setting = AddToggle(group, SETTING_TMR_ACTIVE, 305, 0, m_bTimerActive);
   AddTypeDependentVisibilityCondition(setting, SETTING_TMR_ACTIVE);
   AddTypeDependentEnableCondition(setting, SETTING_TMR_ACTIVE);
 

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -420,7 +420,7 @@ std::string CPVRTimerInfoTag::GetStatus() const
   else if (m_state == PVR_TIMER_STATE_ERROR)
     strReturn = g_localizeStrings.Get(257);
   else if (m_state == PVR_TIMER_STATE_DISABLED)
-    strReturn = g_localizeStrings.Get(825);
+    strReturn = g_localizeStrings.Get(13106);
 
   return strReturn;
 }
@@ -808,7 +808,7 @@ void CPVRTimerInfoTag::GetNotificationText(std::string &strText) const
     break;
   case PVR_TIMER_STATE_SCHEDULED:
     if (IsRepeating())
-      stringID = 826; // Timer activated
+      stringID = 19058; // Timer enabled
     else
       stringID = 19225; // Recording scheduled
     break;
@@ -826,7 +826,7 @@ void CPVRTimerInfoTag::GetNotificationText(std::string &strText) const
     stringID = 19278; // Recording error
     break;
   case PVR_TIMER_STATE_DISABLED:
-    stringID = 827; // Timer deactivated
+    stringID = 19057; // Timer disabled
     break;
   default:
     break;


### PR DESCRIPTION
Use Enabled/Disabled to identify if a timer should to do something or not
Affects:
- Timer Settings dialogue (was 'Active')
- Timer List 'Status' column (was 'Enabled/Inactive')
- Timer enabled/disabled announcements (was Timer activated/deactivated)

UI only. No change to PVR function or API variable names.

@ksooo @ronie 

Before:
![screenshot033](https://cloud.githubusercontent.com/assets/12870817/11194088/16e4446e-8ca2-11e5-827c-ee51c16ca4a4.png)
![screenshot034](https://cloud.githubusercontent.com/assets/12870817/11194089/16e6aeca-8ca2-11e5-8b17-ec960fd562a3.png)

After:
![screenshot035](https://cloud.githubusercontent.com/assets/12870817/11194141/593622ba-8ca2-11e5-93f5-59ef46134722.png)
![screenshot036](https://cloud.githubusercontent.com/assets/12870817/11194143/59609ebe-8ca2-11e5-96a1-08d02ab30001.png)
