### PR TITLE
[PVR] Remove repeating timers from Recording lists

### DIFF
--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -362,7 +362,7 @@ std::vector<CFileItemPtr> CPVRTimers::GetActiveRecordings(void) const
     for (VecTimerInfoTag::const_iterator timerIt = it->second->begin(); timerIt != it->second->end(); ++timerIt)
     {
       CPVRTimerInfoTagPtr current = *timerIt;
-      if (current->IsRecording())
+      if (current->IsRecording() && !current->IsRepeating())
       {
         CFileItemPtr fileItem(new CFileItem(current));
         tags.push_back(fileItem);


### PR DESCRIPTION
Part 1) 
Stops a repeating timer with status 'Recording' appearing in currently recording widget along with its currently recording child timer.

Part 2) (not written yet)
Echo up child timer status for 'Recording', 'Conflict NOK' and 'Error' in that order, replacing any other status for a timer 'folder'. (Currently the client _can_ do this, but apparently the API spec doesn't allow for it). Anyhow, doing it in Kodi core seems like a better idea. - Now postponed to a future PR, see request from @ksooo below.

Spin-off from https://github.com/xbmc/xbmc/pull/8386
