### PR TITLE
OpenGL texture mipmapping

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -18880,7 +18880,19 @@ msgctxt "#36618"
 msgid "Add-ons will be given access to personal data stored on this device. By allowing, you agree that you are solely responsible for any loss of data, unwanted behaviour, or damage to your device. Proceed?"
 msgstr ""
 
-#empty strings from id 36619 to 36899
+#. Label of a setting, allow the user to specifiy high quality downscaling of pictures
+#: system/settings/settings.xml
+msgctxt "#36619"
+msgid "High quality downscaling"
+msgstr ""
+
+#. Description of setting "Pictures -> Slideshow -> High Quality Downscaling" with label #36619
+#: system/settings/settings.xml
+msgctxt "#36620"
+msgid "Enable high quality downscaling of pictures (uses more memory and has moderate performance impact)."
+msgstr ""
+
+#empty strings from id 36621 to 36899
 
 #: xbmc/media/MediaType.cpp
 msgctxt "#36900"

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -611,6 +611,11 @@
           <default>false</default>
           <control type="toggle" />
         </setting>
+        <setting id="slideshow.highqualitydownscaling" type="boolean" label="36619" help="36620">
+            <level>1</level>
+            <default>false</default>
+            <control type="toggle" />
+        </setting>
       </group>
     </category>
     <category id="language" label="14218" help="38106">

--- a/xbmc/guilib/D3DResource.h
+++ b/xbmc/guilib/D3DResource.h
@@ -122,6 +122,7 @@ public:
   UINT GetWidth()  const { return m_width; }
   UINT GetHeight() const { return m_height; }
   DXGI_FORMAT GetFormat() const { return m_format; }
+  void GenerateMipmaps();
 
   // static methods
   static void DrawQuad(const CPoint points[4], color_t color, CD3DTexture *texture, const CRect *texCoords,

--- a/xbmc/guilib/Texture.cpp
+++ b/xbmc/guilib/Texture.cpp
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2005-2013 Team XBMC
+ *      Copyright (C) 2005-2015 Team XBMC
  *      http://xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify
@@ -43,7 +43,8 @@
 /*                                                                      */
 /************************************************************************/
 CBaseTexture::CBaseTexture(unsigned int width, unsigned int height, unsigned int format)
- : m_hasAlpha( true )
+ : m_hasAlpha( true ),
+   m_mipmapping( false )
 {
   m_pixels = NULL;
   m_loadedToGPU = false;
@@ -432,4 +433,14 @@ unsigned int CBaseTexture::GetBlockSize() const
 bool CBaseTexture::HasAlpha() const
 {
   return m_hasAlpha;
+}
+
+void CBaseTexture::SetMipmapping()
+{
+  m_mipmapping = true;
+}
+
+bool CBaseTexture::IsMipmapped() const
+{
+  return m_mipmapping;
 }

--- a/xbmc/guilib/Texture.h
+++ b/xbmc/guilib/Texture.h
@@ -78,6 +78,9 @@ public:
 
   bool HasAlpha() const;
 
+  void SetMipmapping();
+  bool IsMipmapped() const;
+
   virtual void CreateTextureObject() = 0;
   virtual void DestroyTextureObject() = 0;
   virtual void LoadToGPU() = 0;
@@ -131,6 +134,7 @@ protected:
   unsigned int m_format;
   int m_orientation;
   bool m_hasAlpha;
+  bool m_mipmapping;
 };
 
 #if defined(HAS_OMXPLAYER)

--- a/xbmc/guilib/TextureDX.cpp
+++ b/xbmc/guilib/TextureDX.cpp
@@ -94,12 +94,12 @@ void CDXTexture::LoadToGPU()
     if (m_format != XB_FMT_RGB8)
     {
       // this is faster way to create texture with initial data instead of create empty and then copy to it
-      m_texture.Create(m_textureWidth, m_textureHeight, 1, usage, GetFormat(), m_pixels, GetPitch());
+      m_texture.Create(m_textureWidth, m_textureHeight, IsMipmapped() ? 0 : 1, usage, GetFormat(), m_pixels, GetPitch());
       if (m_texture.Get() != nullptr)
         needUpdate = false;
     }
     else
-      m_texture.Create(m_textureWidth, m_textureHeight, 1, usage, GetFormat());
+      m_texture.Create(m_textureWidth, m_textureHeight, IsMipmapped() ? 0 : 1, usage, GetFormat());
 
     if (m_texture.Get() == nullptr)
     {
@@ -120,7 +120,7 @@ void CDXTexture::LoadToGPU()
       m_texture.Release();
       usage = D3D11_USAGE_DYNAMIC;
 
-      m_texture.Create(m_textureWidth, m_textureHeight, 1, usage, GetFormat(), m_pixels, GetPitch());
+      m_texture.Create(m_textureWidth, m_textureHeight, IsMipmapped() ? 0 : 1, usage, GetFormat(), m_pixels, GetPitch());
       if (m_texture.Get() == nullptr)
       {
         CLog::Log(LOGDEBUG, "CDXTexture::CDXTexture: Error creating new texture for size %d x %d.", m_textureWidth, m_textureHeight);
@@ -180,6 +180,8 @@ void CDXTexture::LoadToGPU()
       CLog::Log(LOGERROR, __FUNCTION__" - failed to lock texture.");
     }
     m_texture.UnlockRect(0);
+    if (usage != D3D11_USAGE_STAGING && IsMipmapped())
+      m_texture.GenerateMipmaps();
   }
   _aligned_free(m_pixels);
   m_pixels = nullptr;

--- a/xbmc/guilib/TexturePi.cpp
+++ b/xbmc/guilib/TexturePi.cpp
@@ -93,6 +93,10 @@ void CPiTexture::LoadToGPU()
     // Bind the texture object
     glBindTexture(GL_TEXTURE_2D, m_texture);
 
+    if (IsMipmapped()) {
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+      glGenerateMipmap(GL_TEXTURE_2D);
+    }
     m_loadedToGPU = true;
     return;
   }

--- a/xbmc/pictures/SlideShowPicture.cpp
+++ b/xbmc/pictures/SlideShowPicture.cpp
@@ -118,6 +118,10 @@ void CSlideShowPic::SetTexture_Internal(int iSlideNumber, CBaseTexture* pTexture
   m_pImage = pTexture;
   m_fWidth = (float)pTexture->GetWidth();
   m_fHeight = (float)pTexture->GetHeight();
+  if (CSettings::GetInstance().GetBool(CSettings::SETTING_SLIDESHOW_HIGHQUALITYDOWNSCALING))
+  { // activate mipmapping when high quality downscaling is 'on'
+    pTexture->SetMipmapping();
+  }
   // reset our counter
   m_iCounter = 0;
   // initialize our transistion effect

--- a/xbmc/rendering/dx/RenderSystemDX.cpp
+++ b/xbmc/rendering/dx/RenderSystemDX.cpp
@@ -675,9 +675,15 @@ bool CRenderSystemDX::CreateDevice()
   // Second, no wrap sampler modes for textures are allowed - we are using clamp everywhere
   // At feature levels 10_0, 10_1 and 11_0, the display device unconditionally supports the use of 2D textures with dimensions that are not powers of two.
   // so, setup caps NPOT
-  m_renderCaps |= RENDER_CAPS_NPOT;
+  m_renderCaps |= m_featureLevel > D3D_FEATURE_LEVEL_9_3 ? RENDER_CAPS_NPOT : 0;
   if ((m_renderCaps & RENDER_CAPS_DXT) != 0)
-    m_renderCaps |= RENDER_CAPS_DXT_NPOT;
+  {
+    if (m_featureLevel > D3D_FEATURE_LEVEL_9_3 ||
+      (!IsFormatSupport(DXGI_FORMAT_BC1_UNORM, D3D11_FORMAT_SUPPORT_MIP_AUTOGEN)
+      && !IsFormatSupport(DXGI_FORMAT_BC2_UNORM, D3D11_FORMAT_SUPPORT_MIP_AUTOGEN)
+      && !IsFormatSupport(DXGI_FORMAT_BC3_UNORM, D3D11_FORMAT_SUPPORT_MIP_AUTOGEN)))
+      m_renderCaps |= RENDER_CAPS_DXT_NPOT;
+  }
 
   // Temporary - allow limiting the caps to debug a texture problem
   if (g_advancedSettings.m_RestrictCapsMask != 0)

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -303,6 +303,7 @@ const std::string CSettings::SETTING_PICTURES_DISPLAYRESOLUTION = "pictures.disp
 const std::string CSettings::SETTING_SLIDESHOW_STAYTIME = "slideshow.staytime";
 const std::string CSettings::SETTING_SLIDESHOW_DISPLAYEFFECTS = "slideshow.displayeffects";
 const std::string CSettings::SETTING_SLIDESHOW_SHUFFLE = "slideshow.shuffle";
+const std::string CSettings::SETTING_SLIDESHOW_HIGHQUALITYDOWNSCALING = "slideshow.highqualitydownscaling";
 const std::string CSettings::SETTING_WEATHER_CURRENTLOCATION = "weather.currentlocation";
 const std::string CSettings::SETTING_WEATHER_ADDON = "weather.addon";
 const std::string CSettings::SETTING_WEATHER_ADDONSETTINGS = "weather.addonsettings";

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -260,6 +260,7 @@ public:
   static const std::string SETTING_SLIDESHOW_STAYTIME;
   static const std::string SETTING_SLIDESHOW_DISPLAYEFFECTS;
   static const std::string SETTING_SLIDESHOW_SHUFFLE;
+  static const std::string SETTING_SLIDESHOW_HIGHQUALITYDOWNSCALING;
   static const std::string SETTING_WEATHER_CURRENTLOCATION;
   static const std::string SETTING_WEATHER_ADDON;
   static const std::string SETTING_WEATHER_ADDONSETTINGS;


### PR DESCRIPTION
This PR adds high quality downscaling (by OpenGL mipmapping) for picture browsing / slideshow mode via a new UI option.

Tested on my Macs (2010 iMac and 2009 Mini). Mipmapping really makes a huge difference in terms of reducing visible aliasing for down-sampled high frequencies (like e.g. hair) when browsing pictures. I noticed users on the forums complaining about "pixelated pictures", so this PR should make them happy.

Cropped screen capture from my iMac in Kodi (no mipmapping):
![Image Alt](https://dl.dropboxusercontent.com/u/36282383/test_no_mipmapping.png)

Mipmapping enabled:
![Image Alt](https://dl.dropboxusercontent.com/u/36282383/test_mipmapping.png)

4x zoom of small area (no mipmapping):
![Image Alt](https://dl.dropboxusercontent.com/u/36282383/test_no_mipmapping_zoom.png)

Mipmapping enabled:
![Image Alt](https://dl.dropboxusercontent.com/u/36282383/test_mipmapping_zoom.png)
