### PR TITLE
New keymappings for keyboard-like remotes

### DIFF
--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -123,6 +123,7 @@
       <browser_stop/>
       <browser_search/>
       <browser_favorites>ActivateWindow(Favourites)</browser_favorites>
+      <favorites>ActivateWindow(Favourites)</favorites>
       <browser_home>ActivateWindow(Home)</browser_home>
       <volume_mute>Mute</volume_mute>
       <volume_down>VolumeDown</volume_down>

--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -129,6 +129,7 @@
       <browser_search/>
       <browser_favorites>ActivateWindow(Favourites)</browser_favorites>
       <favorites>ActivateWindow(Favourites)</favorites>
+      <config>ActivateWindow(Settings)</config>
       <browser_home>ActivateWindow(Home)</browser_home>
       <homepage>ActivateWindow(Home)</homepage>
       <volume_mute>Mute</volume_mute>

--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -304,6 +304,7 @@
       <i>Info</i>
       <o>CodecInfo</o>
       <z>AspectRatio</z>
+      <zoom>AspectRatio</zoom>
       <t>ShowSubtitles</t>
       <t mod="ctrl">SubtitleAlign</t>
       <l>NextSubtitle</l>
@@ -474,6 +475,7 @@
       <i>Info</i>
       <o>CodecInfo</o>
       <z>AspectRatio</z>
+      <zoom>AspectRatio</zoom>
       <t>ShowSubtitles</t>
       <l>NextSubtitle</l>
       <a>AudioDelay</a>

--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -151,6 +151,7 @@
       <f mod="ctrl">SkipNext</f>          <!-- Skip -->
       <b mod="ctrl">SkipPrevious</b>      <!-- Replay -->
       <d mod="ctrl">Info</d>              <!-- MCE Details -->
+      <r mod="ctrl">Record</r>            <!-- Record -->
       <f10>VolumeUp</f10>                 <!-- MCE Vol up -->
       <f9>VolumeDown</f9>                 <!-- MCE Vol down -->
       <f8>Mute</f8>                       <!-- MCE mute -->

--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -116,6 +116,11 @@
       <j>ActivateWindow(RadioChannels)</j>
       <k>ActivateWindow(TVRecordings)</k>
       <b>ActivateWindow(TVTimers)</b>
+      <!-- PVR -->
+      <red>ActivateWindow(TVChannels)</red>
+      <green>ActivateWindow(MyVideos)</green>
+      <yellow>ActivateWindow(MyMusic)</yellow>
+      <blue>ActivateWindow(MyPictures)</blue>
       <!-- Multimedia keyboard keys -->
       <browser_back>Back</browser_back>
       <browser_forward/>
@@ -214,6 +219,10 @@
       <delete>Delete</delete>
       <r>Rename</r>
       <k>PreviousMenu</k>
+      <red>Red</red>
+      <green>Green</green>
+      <yellow>Yellow</yellow>
+      <blue>Blue</blue>
     </keyboard>
   </MyTVRecordings>
   <MyTVTimers>
@@ -221,6 +230,10 @@
       <delete>Delete</delete>
       <r>Rename</r>
       <b>PreviousMenu</b>
+      <red>Red</red>
+      <green>Green</green>
+      <yellow>Yellow</yellow>
+      <blue>Blue</blue>
     </keyboard>
   </MyTVTimers>
   <MyRadioChannels>
@@ -233,12 +246,20 @@
     <keyboard>
       <delete>Delete</delete>
       <r>Rename</r>
+      <red>Red</red>
+      <green>Green</green>
+      <yellow>Yellow</yellow>
+      <blue>Blue</blue>
     </keyboard>
   </MyRadioRecordings>
   <MyRadioTimers>
     <keyboard>
       <delete>Delete</delete>
       <r>Rename</r>
+      <red>Red</red>
+      <green>Green</green>
+      <yellow>Yellow</yellow>
+      <blue>Blue</blue>
     </keyboard>
   </MyRadioTimers>
   <TVGuide>
@@ -572,6 +593,10 @@
     <keyboard>
       <v>Back</v>
       <text>Back</text>
+      <red>Red</red>
+      <green>Green</green>
+      <yellow>Yellow</yellow>
+      <blue>Blue</blue>
     </keyboard>
   </Teletext>
   <Favourites>
@@ -660,9 +685,13 @@
   <Addon>
     <keyboard>
       <f1>Red</f1>
+      <red>Red</red>
       <f2>Green</f2>
+      <green>Green</green>
       <f3>Yellow</f3>
+      <yellow>Yellow</yellow>
       <f4>Blue</f4>
+      <blue>Blue</blue>
     </keyboard>
   </Addon>
 </keymap>

--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -152,6 +152,7 @@
       <b mod="ctrl">SkipPrevious</b>      <!-- Replay -->
       <d mod="ctrl">Info</d>              <!-- MCE Details -->
       <r mod="ctrl">Record</r>            <!-- Record -->
+      <f4 mod="alt">PreviousMenu</f4>     <!-- Exit -->
       <f10>VolumeUp</f10>                 <!-- MCE Vol up -->
       <f9>VolumeDown</f9>                 <!-- MCE Vol down -->
       <f8>Mute</f8>                       <!-- MCE mute -->

--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -130,6 +130,7 @@
       <browser_favorites>ActivateWindow(Favourites)</browser_favorites>
       <favorites>ActivateWindow(Favourites)</favorites>
       <browser_home>ActivateWindow(Home)</browser_home>
+      <homepage>ActivateWindow(Home)</homepage>
       <volume_mute>Mute</volume_mute>
       <volume_down>VolumeDown</volume_down>
       <volume_up>VolumeUp</volume_up>

--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -316,6 +316,7 @@
       <escape>Fullscreen</escape>
       <c>Playlist</c>
       <v>ActivateWindow(Teletext)</v>
+      <text>ActivateWindow(Teletext)</text>
       <up mod="ctrl">SubtitleShiftUp</up>
       <down mod="ctrl">SubtitleShiftDown</down>
       <pageup>SkipNext</pageup>
@@ -364,6 +365,7 @@
       <i>Info</i>
       <p>ActivateWindow(VisualisationPresetList)</p>
       <v>Addon.Default.OpenSettings(xbmc.player.musicviz)</v>
+      <text>Addon.Default.OpenSettings(xbmc.player.musicviz)</text>
       <n>ActivateWindow(MusicPlaylist)</n>
       <left>StepBack</left>
       <right>StepForward</right>
@@ -388,6 +390,7 @@
       <o>CodecInfo</o>
       <p>ActivateWindow(VisualisationPresetList)</p>
       <v>Addon.Default.OpenSettings(xbmc.player.musicviz)</v>
+      <text>Addon.Default.OpenSettings(xbmc.player.musicviz)</text>
       <n>ActivateWindow(MusicPlaylist)</n>
     </keyboard>
   </MusicOSD>
@@ -402,6 +405,7 @@
       <o>CodecInfo</o>
       <p>ActivateWindow(VisualisationPresetList)</p>
       <v>Back</v>
+      <text>Back</text>
       <n>ActivateWindow(MusicPlaylist)</n>
     </keyboard>
   </VisualisationSettings>
@@ -416,6 +420,7 @@
       <o>CodecInfo</o>
       <p>Back</p>
       <v>Back</v>
+      <text>Back</text>
       <n>ActivateWindow(MusicPlaylist)</n>
     </keyboard>
   </VisualisationPresetList>
@@ -565,6 +570,7 @@
   <Teletext>
     <keyboard>
       <v>Back</v>
+      <text>Back</text>
     </keyboard>
   </Teletext>
   <Favourites>

--- a/system/keymaps/mouse.xml
+++ b/system/keymaps/mouse.xml
@@ -29,4 +29,11 @@
       <wheeldown>NextPicture</wheeldown>
     </mouse>
   </SlideShow>
+  <FullscreenVideo>
+    <mouse>
+      <rightclick>Info</rightclick>
+    </mouse>
+  </FullscreenVideo>
+
+
 </keymap>

--- a/xbmc/input/XBMC_keysym.h
+++ b/xbmc/input/XBMC_keysym.h
@@ -224,6 +224,7 @@ typedef enum {
   XBMCK_GREEN       = 0x148,
   XBMCK_YELLOW      = 0x149,
   XBMCK_BLUE        = 0x14a,
+  XBMCK_ZOOM        = 0x14b,
 
   // Add any other keys here
 

--- a/xbmc/input/XBMC_keysym.h
+++ b/xbmc/input/XBMC_keysym.h
@@ -228,6 +228,7 @@ typedef enum {
   XBMCK_TEXT        = 0x14c,
   XBMCK_FAVORITES   = 0x14d,
   XBMCK_HOMEPAGE    = 0x14e,
+  XBMCK_CONFIG      = 0x14f,
 
   // Add any other keys here
 

--- a/xbmc/input/XBMC_keysym.h
+++ b/xbmc/input/XBMC_keysym.h
@@ -225,6 +225,7 @@ typedef enum {
   XBMCK_YELLOW      = 0x149,
   XBMCK_BLUE        = 0x14a,
   XBMCK_ZOOM        = 0x14b,
+  XBMCK_TEXT        = 0x14c,
 
   // Add any other keys here
 

--- a/xbmc/input/XBMC_keysym.h
+++ b/xbmc/input/XBMC_keysym.h
@@ -226,6 +226,7 @@ typedef enum {
   XBMCK_BLUE        = 0x14a,
   XBMCK_ZOOM        = 0x14b,
   XBMCK_TEXT        = 0x14c,
+  XBMCK_FAVORITES   = 0x14d,
 
   // Add any other keys here
 

--- a/xbmc/input/XBMC_keysym.h
+++ b/xbmc/input/XBMC_keysym.h
@@ -227,6 +227,7 @@ typedef enum {
   XBMCK_ZOOM        = 0x14b,
   XBMCK_TEXT        = 0x14c,
   XBMCK_FAVORITES   = 0x14d,
+  XBMCK_HOMEPAGE    = 0x14e,
 
   // Add any other keys here
 

--- a/xbmc/input/XBMC_keytable.cpp
+++ b/xbmc/input/XBMC_keytable.cpp
@@ -242,6 +242,7 @@ static const XBMCKEYTABLE XBMCKeyTable[] =
 , { XBMCK_TEXT,                   0,    0, XBMCVK_TEXT,          "text" }
 , { XBMCK_FAVORITES,              0,    0, XBMCVK_FAVORITES,     "favorites" }
 , { XBMCK_HOMEPAGE ,              0,    0, XBMCVK_HOMEPAGE,      "homepage" }
+, { XBMCK_CONFIG,                 0,    0, XBMCVK_CONFIG,        "config" }
 };
 
 static int XBMCKeyTableSize = sizeof(XBMCKeyTable)/sizeof(XBMCKEYTABLE);

--- a/xbmc/input/XBMC_keytable.cpp
+++ b/xbmc/input/XBMC_keytable.cpp
@@ -241,6 +241,7 @@ static const XBMCKEYTABLE XBMCKeyTable[] =
 , { XBMCK_ZOOM,                   0,    0, XBMCVK_ZOOM,          "zoom" }
 , { XBMCK_TEXT,                   0,    0, XBMCVK_TEXT,          "text" }
 , { XBMCK_FAVORITES,              0,    0, XBMCVK_FAVORITES,     "favorites" }
+, { XBMCK_HOMEPAGE ,              0,    0, XBMCVK_HOMEPAGE,      "homepage" }
 };
 
 static int XBMCKeyTableSize = sizeof(XBMCKeyTable)/sizeof(XBMCKEYTABLE);

--- a/xbmc/input/XBMC_keytable.cpp
+++ b/xbmc/input/XBMC_keytable.cpp
@@ -239,6 +239,7 @@ static const XBMCKEYTABLE XBMCKeyTable[] =
 , { XBMCK_YELLOW,                 0,    0, XBMCVK_YELLOW,        "yellow" }
 , { XBMCK_BLUE,                   0,    0, XBMCVK_BLUE,          "blue" }
 , { XBMCK_ZOOM,                   0,    0, XBMCVK_ZOOM,          "zoom" }
+, { XBMCK_TEXT,                   0,    0, XBMCVK_TEXT,          "text" }
 };
 
 static int XBMCKeyTableSize = sizeof(XBMCKeyTable)/sizeof(XBMCKEYTABLE);

--- a/xbmc/input/XBMC_keytable.cpp
+++ b/xbmc/input/XBMC_keytable.cpp
@@ -240,6 +240,7 @@ static const XBMCKEYTABLE XBMCKeyTable[] =
 , { XBMCK_BLUE,                   0,    0, XBMCVK_BLUE,          "blue" }
 , { XBMCK_ZOOM,                   0,    0, XBMCVK_ZOOM,          "zoom" }
 , { XBMCK_TEXT,                   0,    0, XBMCVK_TEXT,          "text" }
+, { XBMCK_FAVORITES,              0,    0, XBMCVK_FAVORITES,     "favorites" }
 };
 
 static int XBMCKeyTableSize = sizeof(XBMCKeyTable)/sizeof(XBMCKEYTABLE);

--- a/xbmc/input/XBMC_keytable.cpp
+++ b/xbmc/input/XBMC_keytable.cpp
@@ -238,6 +238,7 @@ static const XBMCKEYTABLE XBMCKeyTable[] =
 , { XBMCK_GREEN,                  0,    0, XBMCVK_GREEN,         "green" }
 , { XBMCK_YELLOW,                 0,    0, XBMCVK_YELLOW,        "yellow" }
 , { XBMCK_BLUE,                   0,    0, XBMCVK_BLUE,          "blue" }
+, { XBMCK_ZOOM,                   0,    0, XBMCVK_ZOOM,          "zoom" }
 };
 
 static int XBMCKeyTableSize = sizeof(XBMCKeyTable)/sizeof(XBMCKEYTABLE);

--- a/xbmc/input/XBMC_vkeys.h
+++ b/xbmc/input/XBMC_vkeys.h
@@ -219,6 +219,7 @@ typedef enum {
   XBMCVK_ZOOM           = 0xE7,
   XBMCVK_TEXT           = 0xE8,
   XBMCVK_FAVORITES      = 0xE9,
+  XBMCVK_HOMEPAGE       = 0xEA,
 
   XBMCVK_LAST           = 0xFF
 } XBMCVKey;

--- a/xbmc/input/XBMC_vkeys.h
+++ b/xbmc/input/XBMC_vkeys.h
@@ -217,6 +217,7 @@ typedef enum {
   XBMCVK_YELLOW         = 0xE5,
   XBMCVK_BLUE           = 0xE6,
   XBMCVK_ZOOM           = 0xE7,
+  XBMCVK_TEXT           = 0xE8,
 
   XBMCVK_LAST           = 0xFF
 } XBMCVKey;

--- a/xbmc/input/XBMC_vkeys.h
+++ b/xbmc/input/XBMC_vkeys.h
@@ -216,6 +216,7 @@ typedef enum {
   XBMCVK_GREEN          = 0xE4,
   XBMCVK_YELLOW         = 0xE5,
   XBMCVK_BLUE           = 0xE6,
+  XBMCVK_ZOOM           = 0xE7,
 
   XBMCVK_LAST           = 0xFF
 } XBMCVKey;

--- a/xbmc/input/XBMC_vkeys.h
+++ b/xbmc/input/XBMC_vkeys.h
@@ -218,6 +218,7 @@ typedef enum {
   XBMCVK_BLUE           = 0xE6,
   XBMCVK_ZOOM           = 0xE7,
   XBMCVK_TEXT           = 0xE8,
+  XBMCVK_FAVORITES      = 0xE9,
 
   XBMCVK_LAST           = 0xFF
 } XBMCVKey;

--- a/xbmc/input/XBMC_vkeys.h
+++ b/xbmc/input/XBMC_vkeys.h
@@ -220,6 +220,7 @@ typedef enum {
   XBMCVK_TEXT           = 0xE8,
   XBMCVK_FAVORITES      = 0xE9,
   XBMCVK_HOMEPAGE       = 0xEA,
+  XBMCVK_CONFIG         = 0xEB,
 
   XBMCVK_LAST           = 0xFF
 } XBMCVKey;

--- a/xbmc/input/linux/LinuxInputDevices.cpp
+++ b/xbmc/input/linux/LinuxInputDevices.cpp
@@ -267,6 +267,7 @@ KeyMap keyMap[] = {
   { KEY_SEARCH        , XBMCK_BROWSER_SEARCH},
   { KEY_FILE          , XBMCK_LAUNCH_FILE_BROWSER},
   { KEY_SELECT        , XBMCK_RETURN      },
+  { KEY_CONFIG        , XBMCK_CONFIG      },
   // The Little Black Box Remote Additions
   { 384               , XBMCK_LEFT        }, // Red
   { 378               , XBMCK_RIGHT       }, // Green

--- a/xbmc/input/linux/LinuxInputDevices.cpp
+++ b/xbmc/input/linux/LinuxInputDevices.cpp
@@ -256,6 +256,7 @@ KeyMap keyMap[] = {
   { KEY_QUESTION      , XBMCK_HELP        },
   { KEY_BACK          , XBMCK_BACKSPACE   },
   { KEY_ZOOM          , XBMCK_ZOOM        },
+  { KEY_TEXT          , XBMCK_TEXT        },
   // The Little Black Box Remote Additions
   { 384               , XBMCK_LEFT        }, // Red
   { 378               , XBMCK_RIGHT       }, // Green

--- a/xbmc/input/linux/LinuxInputDevices.cpp
+++ b/xbmc/input/linux/LinuxInputDevices.cpp
@@ -257,6 +257,7 @@ KeyMap keyMap[] = {
   { KEY_BACK          , XBMCK_BACKSPACE   },
   { KEY_ZOOM          , XBMCK_ZOOM        },
   { KEY_TEXT          , XBMCK_TEXT        },
+  { KEY_FAVORITES     , XBMCK_FAVORITES   },
   // The Little Black Box Remote Additions
   { 384               , XBMCK_LEFT        }, // Red
   { 378               , XBMCK_RIGHT       }, // Green

--- a/xbmc/input/linux/LinuxInputDevices.cpp
+++ b/xbmc/input/linux/LinuxInputDevices.cpp
@@ -258,6 +258,10 @@ KeyMap keyMap[] = {
   { KEY_ZOOM          , XBMCK_ZOOM        },
   { KEY_TEXT          , XBMCK_TEXT        },
   { KEY_FAVORITES     , XBMCK_FAVORITES   },
+  { KEY_RED           , XBMCK_RED         },
+  { KEY_GREEN         , XBMCK_GREEN       },
+  { KEY_YELLOW        , XBMCK_YELLOW      },
+  { KEY_BLUE          , XBMCK_BLUE        },
   // The Little Black Box Remote Additions
   { 384               , XBMCK_LEFT        }, // Red
   { 378               , XBMCK_RIGHT       }, // Green

--- a/xbmc/input/linux/LinuxInputDevices.cpp
+++ b/xbmc/input/linux/LinuxInputDevices.cpp
@@ -264,6 +264,7 @@ KeyMap keyMap[] = {
   { KEY_BLUE          , XBMCK_BLUE        },
   { KEY_HOMEPAGE      , XBMCK_HOMEPAGE    },
   { KEY_MAIL          , XBMCK_LAUNCH_MAIL },
+  { KEY_SEARCH        , XBMCK_BROWSER_SEARCH},
   // The Little Black Box Remote Additions
   { 384               , XBMCK_LEFT        }, // Red
   { 378               , XBMCK_RIGHT       }, // Green

--- a/xbmc/input/linux/LinuxInputDevices.cpp
+++ b/xbmc/input/linux/LinuxInputDevices.cpp
@@ -262,13 +262,12 @@ KeyMap keyMap[] = {
   { KEY_GREEN         , XBMCK_GREEN       },
   { KEY_YELLOW        , XBMCK_YELLOW      },
   { KEY_BLUE          , XBMCK_BLUE        },
+  { KEY_HOMEPAGE      , XBMCK_HOMEPAGE    },
   // The Little Black Box Remote Additions
   { 384               , XBMCK_LEFT        }, // Red
   { 378               , XBMCK_RIGHT       }, // Green
   { 381               , XBMCK_UP          }, // Yellow
   { 366               , XBMCK_DOWN        }, // Blue
-  // Rii i7 Home button / wetek openelec remote (code 172)
-  { KEY_HOMEPAGE      , XBMCK_HOME        },
 };
 
 typedef enum

--- a/xbmc/input/linux/LinuxInputDevices.cpp
+++ b/xbmc/input/linux/LinuxInputDevices.cpp
@@ -263,6 +263,7 @@ KeyMap keyMap[] = {
   { KEY_YELLOW        , XBMCK_YELLOW      },
   { KEY_BLUE          , XBMCK_BLUE        },
   { KEY_HOMEPAGE      , XBMCK_HOMEPAGE    },
+  { KEY_MAIL          , XBMCK_LAUNCH_MAIL },
   // The Little Black Box Remote Additions
   { 384               , XBMCK_LEFT        }, // Red
   { 378               , XBMCK_RIGHT       }, // Green

--- a/xbmc/input/linux/LinuxInputDevices.cpp
+++ b/xbmc/input/linux/LinuxInputDevices.cpp
@@ -266,6 +266,7 @@ KeyMap keyMap[] = {
   { KEY_MAIL          , XBMCK_LAUNCH_MAIL },
   { KEY_SEARCH        , XBMCK_BROWSER_SEARCH},
   { KEY_FILE          , XBMCK_LAUNCH_FILE_BROWSER},
+  { KEY_SELECT        , XBMCK_RETURN      },
   // The Little Black Box Remote Additions
   { 384               , XBMCK_LEFT        }, // Red
   { 378               , XBMCK_RIGHT       }, // Green

--- a/xbmc/input/linux/LinuxInputDevices.cpp
+++ b/xbmc/input/linux/LinuxInputDevices.cpp
@@ -265,6 +265,7 @@ KeyMap keyMap[] = {
   { KEY_HOMEPAGE      , XBMCK_HOMEPAGE    },
   { KEY_MAIL          , XBMCK_LAUNCH_MAIL },
   { KEY_SEARCH        , XBMCK_BROWSER_SEARCH},
+  { KEY_FILE          , XBMCK_LAUNCH_FILE_BROWSER},
   // The Little Black Box Remote Additions
   { 384               , XBMCK_LEFT        }, // Red
   { 378               , XBMCK_RIGHT       }, // Green

--- a/xbmc/input/linux/LinuxInputDevices.cpp
+++ b/xbmc/input/linux/LinuxInputDevices.cpp
@@ -255,6 +255,7 @@ KeyMap keyMap[] = {
   { KEY_PRINT         , XBMCK_PRINT       },
   { KEY_QUESTION      , XBMCK_HELP        },
   { KEY_BACK          , XBMCK_BACKSPACE   },
+  { KEY_ZOOM          , XBMCK_ZOOM        },
   // The Little Black Box Remote Additions
   { 384               , XBMCK_LEFT        }, // Red
   { 378               , XBMCK_RIGHT       }, // Green


### PR DESCRIPTION
This adds some keymappings found on some remotes which acts as keyboards. all the eventcodes comes from kernel and the mappings are similiar to the the correspondending keyboard buttons
