### PR TITLE
[PVR] Context Menu Crash Fix (trac #16229)

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -91,7 +91,7 @@ void CGUIWindowPVRChannels::GetContextButtons(int itemNumber, CContextButtons &b
   if (ActiveAE::CActiveAEDSP::GetInstance().IsProcessing())
     buttons.Add(CONTEXT_BUTTON_ACTIVE_ADSP_SETTINGS, 15047);                        /* Audio DSP settings */
 
-  if (g_PVRClients->HasMenuHooks(pItem->GetPVRChannelInfoTag()->ClientID(), PVR_MENUHOOK_CHANNEL))
+  if (g_PVRClients->HasMenuHooks(channel->ClientID(), PVR_MENUHOOK_CHANNEL))
     buttons.Add(CONTEXT_BUTTON_MENU_HOOKS, 19195);                                  /* PVR client specific action */
 
   // Add parent buttons before the Manage button

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -118,9 +118,10 @@ void CGUIWindowPVRRecordings::GetContextButtons(int itemNumber, CContextButtons 
 
   bool isDeletedRecording = false;
 
-  if (pItem->HasPVRRecordingInfoTag())
+  CPVRRecordingPtr recording(pItem->GetPVRRecordingInfoTag());
+  if (recording)
   {
-    isDeletedRecording = pItem->GetPVRRecordingInfoTag()->IsDeleted();
+    isDeletedRecording = recording->IsDeleted();
 
     buttons.Add(CONTEXT_BUTTON_INFO, 19053);        /* Recording Information */
     if (!isDeletedRecording)
@@ -147,9 +148,9 @@ void CGUIWindowPVRRecordings::GetContextButtons(int itemNumber, CContextButtons 
       buttons.Add(CONTEXT_BUTTON_MARK_UNWATCHED, 16104); /* Mark as unwatched */
       buttons.Add(CONTEXT_BUTTON_MARK_WATCHED, 16103);   /* Mark as watched */
     }
-    if (pItem->HasPVRRecordingInfoTag())
+    if (recording)
     {
-      if (pItem->GetPVRRecordingInfoTag()->m_playCount > 0)
+      if (recording->m_playCount > 0)
         buttons.Add(CONTEXT_BUTTON_MARK_UNWATCHED, 16104); /* Mark as unwatched */
       else
         buttons.Add(CONTEXT_BUTTON_MARK_WATCHED, 16103);   /* Mark as watched */
@@ -163,10 +164,10 @@ void CGUIWindowPVRRecordings::GetContextButtons(int itemNumber, CContextButtons 
   if (ActiveAE::CActiveAEDSP::GetInstance().IsProcessing())
     buttons.Add(CONTEXT_BUTTON_ACTIVE_ADSP_SETTINGS, 15047);  /* Audio DSP settings */
 
-  if (pItem->HasPVRRecordingInfoTag())
+  if (recording)
   {
-    if ((!isDeletedRecording && g_PVRClients->HasMenuHooks(pItem->GetPVRRecordingInfoTag()->m_iClientId, PVR_MENUHOOK_RECORDING)) ||
-        (isDeletedRecording && g_PVRClients->HasMenuHooks(pItem->GetPVRRecordingInfoTag()->m_iClientId, PVR_MENUHOOK_DELETED_RECORDING)))
+    if ((!isDeletedRecording && g_PVRClients->HasMenuHooks(recording->m_iClientId, PVR_MENUHOOK_RECORDING)) ||
+        (isDeletedRecording && g_PVRClients->HasMenuHooks(recording->m_iClientId, PVR_MENUHOOK_DELETED_RECORDING)))
       buttons.Add(CONTEXT_BUTTON_MENU_HOOKS, 19195);      /* PVR client specific action */
   }
 

--- a/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
@@ -50,29 +50,35 @@ void CGUIWindowPVRSearch::GetContextButtons(int itemNumber, CContextButtons &but
 
   buttons.Add(CONTEXT_BUTTON_CLEAR, 19232);               /* Clear search results */
 
-  if (pItem->HasEPGInfoTag())
+  CEpgInfoTagPtr epg(pItem->GetEPGInfoTag());
+  if (epg)
   {
     buttons.Add(CONTEXT_BUTTON_INFO, 19047);              /* Programme information */
 
-    if (pItem->GetEPGInfoTag()->HasTimer())
+    CPVRTimerInfoTagPtr timer(epg->Timer());
+    if (timer)
     {
-      if (pItem->GetEPGInfoTag()->Timer()->IsRecording())
+      if (timer->IsRecording())
         buttons.Add(CONTEXT_BUTTON_STOP_RECORD, 19059);   /* Stop recording */
-      else if (pItem->GetEPGInfoTag()->Timer()->HasTimerType() &&
-               !pItem->GetEPGInfoTag()->Timer()->GetTimerType()->IsReadOnly())
-        buttons.Add(CONTEXT_BUTTON_DELETE_TIMER, 19060);  /* Delete timer */
+      else
+      {
+        CPVRTimerTypePtr timerType(timer->GetTimerType());
+        if (timerType && !timerType->IsReadOnly())
+          buttons.Add(CONTEXT_BUTTON_DELETE_TIMER, 19060);  /* Delete timer */
+      }
     }
-    else if (pItem->GetEPGInfoTag()->EndAsLocalTime() > CDateTime::GetCurrentDateTime())
+    else if (epg->EndAsLocalTime() > CDateTime::GetCurrentDateTime())
     {
       buttons.Add(CONTEXT_BUTTON_START_RECORD, 264);      /* Record */
       buttons.Add(CONTEXT_BUTTON_ADD_TIMER, 19061);       /* Add timer */
     }
 
-    if (pItem->GetEPGInfoTag()->HasRecording())
+    if (epg->HasRecording())
       buttons.Add(CONTEXT_BUTTON_PLAY_ITEM, 19687);       /* Play recording */
 
-    if (pItem->GetEPGInfoTag()->HasPVRChannel() &&
-        g_PVRClients->HasMenuHooks(pItem->GetEPGInfoTag()->ChannelTag()->ClientID(), PVR_MENUHOOK_EPG))
+    CPVRChannelPtr channel(epg->ChannelTag());
+    if (channel &&
+        g_PVRClients->HasMenuHooks(channel->ClientID(), PVR_MENUHOOK_EPG))
       buttons.Add(CONTEXT_BUTTON_MENU_HOOKS, 19195);      /* PVR client specific action */
   }
 

--- a/xbmc/pvr/windows/GUIWindowPVRTimers.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRTimers.cpp
@@ -75,36 +75,41 @@ void CGUIWindowPVRTimers::GetContextButtons(int itemNumber, CContextButtons &but
 
   if (!URIUtils::PathEquals(pItem->GetPath(), CPVRTimersPath::PATH_ADDTIMER))
   {
-    if (pItem->GetPVRTimerInfoTag()->GetEpgInfoTag())
-      buttons.Add(CONTEXT_BUTTON_INFO, 19047);          /* Programme information */
-
-    if (pItem->GetPVRTimerInfoTag()->HasTimerType())
+    CPVRTimerInfoTagPtr timer(pItem->GetPVRTimerInfoTag());
+    if (timer)
     {
-      if (pItem->GetPVRTimerInfoTag()->GetTimerType()->SupportsEnableDisable())
+      if (timer->HasEpgInfoTag())
+        buttons.Add(CONTEXT_BUTTON_INFO, 19047);          /* Programme information */
+
+      CPVRTimerTypePtr timerType(timer->GetTimerType());
+      if (timerType)
       {
-        if (pItem->GetPVRTimerInfoTag()->m_state == PVR_TIMER_STATE_DISABLED)
-          buttons.Add(CONTEXT_BUTTON_ACTIVATE, 843);    /* Activate */
-        else
-          buttons.Add(CONTEXT_BUTTON_ACTIVATE, 844);    /* Deactivate */
+        if (timerType->SupportsEnableDisable())
+        {
+          if (timer->m_state == PVR_TIMER_STATE_DISABLED)
+            buttons.Add(CONTEXT_BUTTON_ACTIVATE, 843);    /* Activate */
+          else
+            buttons.Add(CONTEXT_BUTTON_ACTIVATE, 844);    /* Deactivate */
+        }
+
+        if (!timerType->IsReadOnly())
+        {
+          buttons.Add(CONTEXT_BUTTON_EDIT, 21450);        /* Edit */
+
+          // As epg-based timers will get it's title from the epg tag, they should not be renamable.
+          if (timer->IsManual())
+            buttons.Add(CONTEXT_BUTTON_RENAME, 118);      /* Rename */
+
+          if (timer->IsRecording())
+            buttons.Add(CONTEXT_BUTTON_STOP_RECORD, 19059); /* Stop recording */
+          else
+            buttons.Add(CONTEXT_BUTTON_DELETE, 117);        /* Delete */
+        }
       }
 
-      if (!pItem->GetPVRTimerInfoTag()->GetTimerType()->IsReadOnly())
-      {
-        buttons.Add(CONTEXT_BUTTON_EDIT, 21450);        /* Edit */
-
-        // As epg-based timers will get it's title from the epg tag, they should not be renamable.
-        if (pItem->GetPVRTimerInfoTag()->IsManual())
-          buttons.Add(CONTEXT_BUTTON_RENAME, 118);      /* Rename */
-
-        if (pItem->GetPVRTimerInfoTag()->IsRecording())
-          buttons.Add(CONTEXT_BUTTON_STOP_RECORD, 19059); /* Stop recording */
-        else
-          buttons.Add(CONTEXT_BUTTON_DELETE, 117);        /* Delete */
-      }
+      if (g_PVRClients->HasMenuHooks(timer->m_iClientId, PVR_MENUHOOK_TIMER))
+        buttons.Add(CONTEXT_BUTTON_MENU_HOOKS, 19195);    /* PVR client specific action */
     }
-
-    if (g_PVRClients->HasMenuHooks(pItem->GetPVRTimerInfoTag()->m_iClientId, PVR_MENUHOOK_TIMER))
-      buttons.Add(CONTEXT_BUTTON_MENU_HOOKS, 19195);    /* PVR client specific action */
   }
 
   CGUIWindowPVRBase::GetContextButtons(itemNumber, buttons);


### PR DESCRIPTION
Prevents PVR background threads changing the underlying PVR data while a context menu is constructed based on its content (intended as a fix for http://trac.kodi.tv/ticket/16229)

I'm not a threads/lock expert by any means, but this thread http://forum.kodi.tv/archive/index.php?thread-127957.html makes me think I've got the right end of the stick.

AFAIK PVR is the only area where the data a context menu is based on can be changed while the menu is being constructed (by pvr clients requesting to update recordings/epg/timers etc...)

pings: @ksooo @xhaggi @janbar @opdenkamp 
