### PR TITLE
[PVR] Fix for blank Currently In Prog Recordings

### DIFF
--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -380,7 +380,7 @@ int CPVRTimers::AmountActiveRecordings(void) const
 
   for (MapTags::const_iterator it = m_tags.begin(); it != m_tags.end(); ++it)
     for (VecTimerInfoTag::const_iterator timerIt = it->second->begin(); timerIt != it->second->end(); ++timerIt)
-      if ((*timerIt)->IsRecording())
+      if ((*timerIt)->IsRecording() && !(*timerIt)->IsRepeating())
         ++iReturn;
 
   return iReturn;


### PR DESCRIPTION
(part of PR#8400 which got missed)

I just discovered that you now get blank entries for repeating timers which are recording.
This fixes it....
Oops.

:blush:

ping: @ksooo 
