### PR TITLE
show an ok dialog instead of the addon update dialog when no available versions

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -12039,7 +12039,17 @@ msgctxt "#21340"
 msgid "Auto-update"
 msgstr ""
 
-#empty strings from id 21341 to 21358
+#: xbmc/addons/GUIDialogAddonInfo.cpp
+msgctxt "#21341"
+msgid "No updates available"
+msgstr ""
+
+#: xbmc/addons/GUIDialogAddonInfo.cpp
+msgctxt "#21342"
+msgid "There are currently no updates available for this add-on."
+msgstr ""
+
+#empty strings from id 21343 to 21358
 
 #: xbmc/dialogs/GUIDialogFileBrowser.cpp
 msgctxt "#21359"

--- a/xbmc/addons/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/GUIDialogAddonInfo.cpp
@@ -246,6 +246,12 @@ void CGUIDialogAddonInfo::OnUpdate()
     }
   }
 
+  if (versions.empty())
+  {
+    CGUIDialogOK::ShowAndGetInput(CVariant{21341}, CVariant{21342});
+    return;
+  }
+
   auto* dialog = static_cast<CGUIDialogSelect*>(g_windowManager.GetWindow(WINDOW_DIALOG_SELECT));
   dialog->Reset();
   dialog->SetHeading(CVariant{21338});


### PR DESCRIPTION
Fixes broken navigation when the list is empty. As discussed in #8167
