### PR TITLE
[gui] move cancel button in select dialog to core

### DIFF
--- a/addons/skin.confluence/720p/DialogSelect.xml
+++ b/addons/skin.confluence/720p/DialogSelect.xml
@@ -97,7 +97,7 @@
 				<height>460</height>
 				<onup>3</onup>
 				<ondown>3</ondown>
-				<onleft>99</onleft>
+				<onleft>7</onleft>
 				<onright>61</onright>
 				<pagecontrol>61</pagecontrol>
 				<scrolltime>200</scrolltime>
@@ -162,7 +162,7 @@
 				<height>460</height>
 				<onup>6</onup>
 				<ondown>6</ondown>
-				<onleft>99</onleft>
+				<onleft>7</onleft>
 				<onright>61</onright>
 				<pagecontrol>61</pagecontrol>
 				<scrolltime>200</scrolltime>
@@ -310,16 +310,15 @@
 						<focusedcolor>white</focusedcolor>
 						<align>center</align>
 					</control>
-					<control type="button" id="99">
+					<control type="button" id="7">
 						<description>Cancel button</description>
 						<width>200</width>
 						<height>40</height>
-						<label>222</label>
+						<label>-</label>
 						<font>font12_title</font>
 						<textcolor>white</textcolor>
 						<focusedcolor>white</focusedcolor>
 						<align>center</align>
-						<onclick>Dialog.Close(selectdialog)</onclick>
 					</control>
 				</control>
 			</control>

--- a/xbmc/addons/AddonCallbacksGUI.cpp
+++ b/xbmc/addons/AddonCallbacksGUI.cpp
@@ -1908,7 +1908,7 @@ int CAddonCallbacksGUI::Dialog_Select(const char *heading, const char *entries[]
     pDialog->SetSelected(selected);
 
   pDialog->Open();
-  return pDialog->GetSelectedLabel();
+  return pDialog->GetSelectedItem();
 }
 //@}
 

--- a/xbmc/addons/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/GUIDialogAddonInfo.cpp
@@ -285,7 +285,7 @@ void CGUIDialogAddonInfo::OnUpdate()
   {
     Close();
 
-    auto selected = versions.at(dialog->GetSelectedLabel());
+    auto selected = versions.at(dialog->GetSelectedItem());
 
     //turn auto updating off if downgrading
     if (selected.first < m_localAddon->Version())

--- a/xbmc/addons/GUIDialogAddonSettings.cpp
+++ b/xbmc/addons/GUIDialogAddonSettings.cpp
@@ -337,7 +337,7 @@ bool CGUIDialogAddonSettings::ShowVirtualKeyboard(int iControl)
                 pDlg->SetSelected(i); // FIXME: the SetSelected() does not select "i", it always defaults to the first position
             }
             pDlg->Open();
-            int iSelected = pDlg->GetSelectedLabel();
+            int iSelected = pDlg->GetSelectedItem();
             if (iSelected >= 0)
             {
               if (setting->Attribute("lvalues"))

--- a/xbmc/dialogs/GUIDialogSelect.cpp
+++ b/xbmc/dialogs/GUIDialogSelect.cpp
@@ -195,12 +195,12 @@ void CGUIDialogSelect::SetItems(const CFileItemList& pList)
   m_vecList->Copy(pList);
 }
 
-int CGUIDialogSelect::GetSelectedLabel() const
+int CGUIDialogSelect::GetSelectedItem() const
 {
   return m_selectedItems.size() > 0 ? m_selectedItems[0] : -1;
 }
 
-const CFileItemPtr CGUIDialogSelect::GetSelectedItem() const
+const CFileItemPtr CGUIDialogSelect::GetSelectedFileItem() const
 {
   if (m_selectedItem)
     return m_selectedItem;
@@ -331,7 +331,7 @@ void CGUIDialogSelect::OnInitWindow()
   CGUIDialogBoxBase::OnInitWindow();
 
   // if nothing is selected, select first item
-  m_viewControl.SetSelectedItem(std::max(GetSelectedLabel(), 0));
+  m_viewControl.SetSelectedItem(std::max(GetSelectedItem(), 0));
 }
 
 void CGUIDialogSelect::OnDeinitWindow(int nextWindowID)

--- a/xbmc/dialogs/GUIDialogSelect.cpp
+++ b/xbmc/dialogs/GUIDialogSelect.cpp
@@ -24,35 +24,35 @@
 #include "guilib/LocalizeStrings.h"
 #include "utils/StringUtils.h"
 
-#define CONTROL_HEADING       1
-#define CONTROL_LIST          3
-#define CONTROL_NUMBEROFFILES 2
-#define CONTROL_BUTTON        5
-#define CONTROL_DETAILS       6
-#define CONTROL_CANCEL_BUTTON 7
+#define CONTROL_HEADING         1
+#define CONTROL_NUMBER_OF_ITEMS 2
+#define CONTROL_SIMPLE_LIST     3
+#define CONTROL_DETAILED_LIST   6
+#define CONTROL_EXTRA_BUTTON    5
+#define CONTROL_CANCEL_BUTTON   7
 
 CGUIDialogSelect::CGUIDialogSelect(void)
-    : CGUIDialogBoxBase(WINDOW_DIALOG_SELECT, "DialogSelect.xml")
+    : CGUIDialogBoxBase(WINDOW_DIALOG_SELECT, "DialogSelect.xml"),
+    m_bButtonEnabled(false),
+    m_bButtonPressed(false),
+    m_buttonLabel(-1),
+    m_selectedItem(nullptr),
+    m_useDetails(false),
+    m_multiSelection(false),
+    m_selectedItems(),
+    m_vecList(new CFileItemList())
 {
-  m_bButtonEnabled = false;
-  m_bButtonPressed = false;
   m_bConfirmed = false;
-  m_buttonString = -1;
-  m_useDetails = false;
-  m_vecList = new CFileItemList;
-  m_multiSelection = false;
-  m_selectedItem = nullptr;
   m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIDialogSelect::~CGUIDialogSelect(void)
 {
-  delete m_vecList;
 }
 
 bool CGUIDialogSelect::OnMessage(CGUIMessage& message)
 {
-  switch ( message.GetMessage() )
+  switch (message.GetMessage())
   {
   case GUI_MSG_WINDOW_DEINIT:
     {
@@ -75,11 +75,7 @@ bool CGUIDialogSelect::OnMessage(CGUIMessage& message)
             m_selectedItem = item;
         }
       }
-
       m_vecList->Clear();
-
-      m_buttonString = -1;
-      SET_CONTROL_LABEL(CONTROL_BUTTON, "");
       return true;
     }
     break;
@@ -97,13 +93,13 @@ bool CGUIDialogSelect::OnMessage(CGUIMessage& message)
   case GUI_MSG_CLICKED:
     {
       int iControl = message.GetSenderId();
-      if (m_viewControl.HasControl(CONTROL_LIST))
+      if (m_viewControl.HasControl(CONTROL_SIMPLE_LIST))
       {
         int iAction = message.GetParam1();
         if (ACTION_SELECT_ITEM == iAction || ACTION_MOUSE_LEFT_CLICK == iAction)
         {
           int iSelected = m_viewControl.GetSelectedItem();
-          if(iSelected >= 0 && iSelected < (int)m_vecList->Size())
+          if (iSelected >= 0 && iSelected < m_vecList->Size())
           {
             CFileItemPtr item(m_vecList->Get(iSelected));
             if (m_multiSelection)
@@ -119,7 +115,7 @@ bool CGUIDialogSelect::OnMessage(CGUIMessage& message)
           }
         }
       }
-      if (CONTROL_BUTTON == iControl)
+      if (iControl == CONTROL_EXTRA_BUTTON)
       {
         m_selectedItem = nullptr;
         m_bButtonPressed = true;
@@ -137,23 +133,21 @@ bool CGUIDialogSelect::OnMessage(CGUIMessage& message)
     break;
   case GUI_MSG_SETFOCUS:
     {
-      // make sure the additional button is focused in case the list is empty
-      // (otherwise it is impossible to navigate to the additional button)
-      if (m_vecList->IsEmpty() && m_bButtonEnabled &&
-          m_viewControl.HasControl(message.GetControlId()))
+      if (m_viewControl.HasControl(message.GetControlId()))
       {
-        SET_CONTROL_FOCUS(CONTROL_BUTTON, 0);
-        return true;
-      }
-      if (m_vecList->IsEmpty() && m_viewControl.HasControl(message.GetControlId()))
-      {
-        SET_CONTROL_FOCUS(CONTROL_CANCEL_BUTTON, 0);
-        return true;
-      }
-      if (m_viewControl.HasControl(message.GetControlId()) && m_viewControl.GetCurrentControl() != message.GetControlId())
-      {
-        m_viewControl.SetFocused();
-        return true;
+        if (m_vecList->IsEmpty())
+        {
+          if (m_bButtonEnabled)
+            SET_CONTROL_FOCUS(CONTROL_EXTRA_BUTTON, 0);
+          else
+            SET_CONTROL_FOCUS(CONTROL_CANCEL_BUTTON, 0);
+          return true;
+        }
+        if (m_viewControl.GetCurrentControl() != message.GetControlId())
+        {
+          m_viewControl.SetFocused();
+          return true;
+        }
       }
     }
     break;
@@ -173,7 +167,6 @@ bool CGUIDialogSelect::OnBack(int actionID)
 void CGUIDialogSelect::Reset()
 {
   m_bButtonEnabled = false;
-  m_buttonString = -1;
   m_bButtonPressed = false;
   m_useDetails = false;
   m_multiSelection = false;
@@ -214,23 +207,15 @@ const CFileItemPtr CGUIDialogSelect::GetSelectedItem() const
   return CFileItemPtr(new CFileItem);
 }
 
-const std::string& CGUIDialogSelect::GetSelectedLabelText() const
-{
-  return GetSelectedItem()->GetLabel();
-}
-
 const std::vector<int>& CGUIDialogSelect::GetSelectedItems() const
 {
   return m_selectedItems;
 }
 
-void CGUIDialogSelect::EnableButton(bool enable, int string)
+void CGUIDialogSelect::EnableButton(bool enable, int label)
 {
   m_bButtonEnabled = enable;
-  m_buttonString = string;
-
-  if (IsActive())
-    SetupButton();
+  m_buttonLabel = label;
 }
 
 bool CGUIDialogSelect::IsButtonPressed()
@@ -262,9 +247,6 @@ void CGUIDialogSelect::SetSelected(int iSelected)
 
 void CGUIDialogSelect::SetSelected(const std::string &strSelectedLabel)
 {
-  if (strSelectedLabel.empty())
-    return;
-
   for (int index = 0; index < m_vecList->Size(); index++)
   {
     if (strSelectedLabel == m_vecList->Get(index)->GetLabel())
@@ -277,20 +259,14 @@ void CGUIDialogSelect::SetSelected(const std::string &strSelectedLabel)
 
 void CGUIDialogSelect::SetSelected(std::vector<int> selectedIndexes)
 {
-  if (selectedIndexes.empty())
-    return;
-
-  for (std::vector<int>::const_iterator it = selectedIndexes.begin(); it != selectedIndexes.end(); ++it)
-    SetSelected(*it);
+  for (auto i : selectedIndexes)
+    SetSelected(i);
 }
 
 void CGUIDialogSelect::SetSelected(const std::vector<std::string> &selectedLabels)
 {
-  if (selectedLabels.empty())
-    return;
-
-  for (std::vector<std::string>::const_iterator it = selectedLabels.begin(); it != selectedLabels.end(); ++it)
-    SetSelected(*it);
+  for (const auto& label : selectedLabels)
+    SetSelected(label);
 }
 
 void CGUIDialogSelect::SetUseDetails(bool useDetails)
@@ -315,8 +291,8 @@ void CGUIDialogSelect::OnWindowLoaded()
   CGUIDialogBoxBase::OnWindowLoaded();
   m_viewControl.Reset();
   m_viewControl.SetParentWindow(GetID());
-  m_viewControl.AddView(GetControl(CONTROL_LIST));
-  m_viewControl.AddView(GetControl(CONTROL_DETAILS));
+  m_viewControl.AddView(GetControl(CONTROL_SIMPLE_LIST));
+  m_viewControl.AddView(GetControl(CONTROL_DETAILED_LIST));
 }
 
 void CGUIDialogSelect::OnInitWindow()
@@ -333,28 +309,34 @@ void CGUIDialogSelect::OnInitWindow()
         m_selectedItem = item;
     }
   }
-  m_viewControl.SetCurrentView(m_useDetails ? CONTROL_DETAILS : CONTROL_LIST);
+  m_viewControl.SetCurrentView(m_useDetails ? CONTROL_DETAILED_LIST : CONTROL_SIMPLE_LIST);
 
-  std::string items = StringUtils::Format("%i %s", m_vecList->Size(), g_localizeStrings.Get(127).c_str());
-  SET_CONTROL_LABEL(CONTROL_NUMBEROFFILES, items);
+  SET_CONTROL_LABEL(CONTROL_NUMBER_OF_ITEMS, StringUtils::Format("%i %s",
+      m_vecList->Size(), g_localizeStrings.Get(127).c_str()));
   
   if (m_multiSelection)
     EnableButton(true, 186);
 
-  SET_CONTROL_VISIBLE(CONTROL_CANCEL_BUTTON);
-  SET_CONTROL_LABEL(CONTROL_CANCEL_BUTTON, g_localizeStrings.Get(222));
+  if (m_bButtonEnabled)
+  {
+    SET_CONTROL_LABEL(CONTROL_EXTRA_BUTTON, g_localizeStrings.Get(m_buttonLabel));
+    SET_CONTROL_VISIBLE(CONTROL_EXTRA_BUTTON);
+  }
+  else
+    SET_CONTROL_HIDDEN(CONTROL_EXTRA_BUTTON);
 
-  SetupButton();
+  SET_CONTROL_LABEL(CONTROL_CANCEL_BUTTON, g_localizeStrings.Get(222));
+  SET_CONTROL_VISIBLE(CONTROL_CANCEL_BUTTON);
+
   CGUIDialogBoxBase::OnInitWindow();
 
-  // if nothing is selected, focus first item
+  // if nothing is selected, select first item
   m_viewControl.SetSelectedItem(std::max(GetSelectedLabel(), 0));
 }
 
 void CGUIDialogSelect::OnDeinitWindow(int nextWindowID)
 {
   m_viewControl.Clear();
-
   CGUIDialogBoxBase::OnDeinitWindow(nextWindowID);
 }
 
@@ -362,15 +344,4 @@ void CGUIDialogSelect::OnWindowUnload()
 {
   CGUIDialogBoxBase::OnWindowUnload();
   m_viewControl.Reset();
-}
-
-void CGUIDialogSelect::SetupButton()
-{
-  if (m_bButtonEnabled)
-  {
-    SET_CONTROL_LABEL(CONTROL_BUTTON, g_localizeStrings.Get(m_buttonString));
-    SET_CONTROL_VISIBLE(CONTROL_BUTTON);
-  }
-  else
-    SET_CONTROL_HIDDEN(CONTROL_BUTTON);
 }

--- a/xbmc/dialogs/GUIDialogSelect.cpp
+++ b/xbmc/dialogs/GUIDialogSelect.cpp
@@ -29,6 +29,7 @@
 #define CONTROL_NUMBEROFFILES 2
 #define CONTROL_BUTTON        5
 #define CONTROL_DETAILS       6
+#define CONTROL_CANCEL_BUTTON 7
 
 CGUIDialogSelect::CGUIDialogSelect(void)
     : CGUIDialogBoxBase(WINDOW_DIALOG_SELECT, "DialogSelect.xml")
@@ -126,6 +127,12 @@ bool CGUIDialogSelect::OnMessage(CGUIMessage& message)
           m_bConfirmed = true;
         Close();
       }
+      else if (iControl == CONTROL_CANCEL_BUTTON)
+      {
+        m_selectedItem = nullptr;
+        m_bConfirmed = false;
+        Close();
+      }
     }
     break;
   case GUI_MSG_SETFOCUS:
@@ -136,6 +143,11 @@ bool CGUIDialogSelect::OnMessage(CGUIMessage& message)
           m_viewControl.HasControl(message.GetControlId()))
       {
         SET_CONTROL_FOCUS(CONTROL_BUTTON, 0);
+        return true;
+      }
+      if (m_vecList->IsEmpty() && m_viewControl.HasControl(message.GetControlId()))
+      {
+        SET_CONTROL_FOCUS(CONTROL_CANCEL_BUTTON, 0);
         return true;
       }
       if (m_viewControl.HasControl(message.GetControlId()) && m_viewControl.GetCurrentControl() != message.GetControlId())
@@ -328,6 +340,9 @@ void CGUIDialogSelect::OnInitWindow()
   
   if (m_multiSelection)
     EnableButton(true, 186);
+
+  SET_CONTROL_VISIBLE(CONTROL_CANCEL_BUTTON);
+  SET_CONTROL_LABEL(CONTROL_CANCEL_BUTTON, g_localizeStrings.Get(222));
 
   SetupButton();
   CGUIDialogBoxBase::OnInitWindow();

--- a/xbmc/dialogs/GUIDialogSelect.h
+++ b/xbmc/dialogs/GUIDialogSelect.h
@@ -26,24 +26,22 @@
 class CFileItem;
 class CFileItemList;
 
-class CGUIDialogSelect :
-      public CGUIDialogBoxBase
+class CGUIDialogSelect : public CGUIDialogBoxBase
 {
 public:
   CGUIDialogSelect(void);
   virtual ~CGUIDialogSelect(void);
-  virtual bool OnMessage(CGUIMessage& message);
-  virtual bool OnBack(int actionID);
+  virtual bool OnMessage(CGUIMessage& message) override;
+  virtual bool OnBack(int actionID) override;
 
   void Reset();
   int  Add(const std::string& strLabel);
   int  Add(const CFileItem& item);
   void SetItems(const CFileItemList& items);
   int GetSelectedLabel() const;
-  const std::string& GetSelectedLabelText() const;
   const CFileItemPtr GetSelectedItem() const;
   const std::vector<int>& GetSelectedItems() const;
-  void EnableButton(bool enable, int string);
+  void EnableButton(bool enable, int label);
   bool IsButtonPressed();
   void Sort(bool bSortOrder = true);
   void SetSelected(int iSelected);
@@ -52,22 +50,23 @@ public:
   void SetSelected(const std::vector<std::string> &selectedLabels);
   void SetUseDetails(bool useDetails);
   void SetMultiSelection(bool multiSelection);
-protected:
-  virtual CGUIControl *GetFirstFocusableControl(int id);
-  virtual void OnWindowLoaded();
-  virtual void OnInitWindow();
-  virtual void OnDeinitWindow(int nextWindowID);
-  virtual void OnWindowUnload();
-  void SetupButton();
 
+protected:
+  virtual CGUIControl *GetFirstFocusableControl(int id) override;
+  virtual void OnWindowLoaded() override;
+  virtual void OnInitWindow() override;
+  virtual void OnDeinitWindow(int nextWindowID) override;
+  virtual void OnWindowUnload() override;
+
+private:
   bool m_bButtonEnabled;
-  int m_buttonString;
   bool m_bButtonPressed;
+  int m_buttonLabel;
   CFileItemPtr m_selectedItem;
   bool m_useDetails;
   bool m_multiSelection;
 
   std::vector<int> m_selectedItems;
-  CFileItemList* m_vecList;
+  std::unique_ptr<CFileItemList> m_vecList;
   CGUIViewControl m_viewControl;
 };

--- a/xbmc/dialogs/GUIDialogSelect.h
+++ b/xbmc/dialogs/GUIDialogSelect.h
@@ -38,8 +38,8 @@ public:
   int  Add(const std::string& strLabel);
   int  Add(const CFileItem& item);
   void SetItems(const CFileItemList& items);
-  int GetSelectedLabel() const;
-  const CFileItemPtr GetSelectedItem() const;
+  const CFileItemPtr GetSelectedFileItem() const;
+  int GetSelectedItem() const;
   const std::vector<int>& GetSelectedItems() const;
   void EnableButton(bool enable, int label);
   bool IsButtonPressed();

--- a/xbmc/dialogs/GUIDialogSimpleMenu.cpp
+++ b/xbmc/dialogs/GUIDialogSimpleMenu.cpp
@@ -104,8 +104,8 @@ bool CGUIDialogSimpleMenu::ShowPlaySelection(CFileItem& item, const std::string&
     dialog->SetUseDetails(true);
     dialog->Open();
 
-    CFileItemPtr item_new = dialog->GetSelectedItem();
-    if (!item_new || dialog->GetSelectedLabel() < 0)
+    CFileItemPtr item_new = dialog->GetSelectedFileItem();
+    if (!item_new || dialog->GetSelectedItem() < 0)
     {
       CLog::Log(LOGDEBUG, "CGUIWindowVideoBase::ShowPlaySelection - User aborted %s", directory.c_str());
       break;

--- a/xbmc/guilib/StereoscopicsManager.cpp
+++ b/xbmc/guilib/StereoscopicsManager.cpp
@@ -242,7 +242,7 @@ RENDER_STEREO_MODE CStereoscopicsManager::GetStereoModeByUserChoice(const std::s
 
   pDlgSelect->Open();
 
-  int iItem = pDlgSelect->GetSelectedLabel();
+  int iItem = pDlgSelect->GetSelectedItem();
   if (iItem > -1 && pDlgSelect->IsConfirmed())
     mode = (RENDER_STEREO_MODE) selectableModes[iItem];
   else
@@ -578,7 +578,7 @@ void CStereoscopicsManager::OnPlaybackStarted(void)
 
       if(pDlgSelect->IsConfirmed())
       {
-        int iItem = pDlgSelect->GetSelectedLabel();
+        int iItem = pDlgSelect->GetSelectedItem();
         if      (iItem == idx_preferred) mode = preferred;
         else if (iItem == idx_mono)      mode = RENDER_STEREO_MODE_MONO;
         else if (iItem == idx_playing)   mode = RENDER_STEREO_MODE_AUTO;

--- a/xbmc/interfaces/legacy/Dialog.cpp
+++ b/xbmc/interfaces/legacy/Dialog.cpp
@@ -103,7 +103,7 @@ namespace XBMCAddon
 
       pDialog->Open();
 
-      return pDialog->GetSelectedLabel();
+      return pDialog->GetSelectedItem();
     }
 
 

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -2991,7 +2991,7 @@ bool CMusicDatabase::LookupCDDBInfo(bool bRequery/*=false*/)
         pDlgSelect->Open();
 
         // Has the user selected a match...
-        int iSelectedCD = pDlgSelect->GetSelectedLabel();
+        int iSelectedCD = pDlgSelect->GetSelectedItem();
         if (iSelectedCD >= 0)
         {
           // ...query cddb for the inexact match
@@ -3074,14 +3074,14 @@ void CMusicDatabase::DeleteCDDBInfo()
     pDlg->Open();
 
     // and wait till user selects one
-    int iSelectedAlbum = pDlg->GetSelectedLabel();
+    int iSelectedAlbum = pDlg->GetSelectedItem();
     if (iSelectedAlbum < 0)
     {
       mapCDDBIds.erase(mapCDDBIds.begin(), mapCDDBIds.end());
       return ;
     }
 
-    std::string strSelectedAlbum = pDlg->GetSelectedItem()->GetLabel();
+    std::string strSelectedAlbum = pDlg->GetSelectedFileItem()->GetLabel();
     std::map<ULONG, std::string>::iterator it;
     for (it = mapCDDBIds.begin();it != mapCDDBIds.end();++it)
     {

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -3081,7 +3081,7 @@ void CMusicDatabase::DeleteCDDBInfo()
       return ;
     }
 
-    std::string strSelectedAlbum = pDlg->GetSelectedLabelText();
+    std::string strSelectedAlbum = pDlg->GetSelectedItem()->GetLabel();
     std::map<ULONG, std::string>::iterator it;
     for (it = mapCDDBIds.begin();it != mapCDDBIds.end();++it)
     {

--- a/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
@@ -641,7 +641,7 @@ void CGUIDialogMusicInfo::OnSetUserrating()
 
     dialog->Open();
 
-    int iItem = dialog->GetSelectedLabel();
+    int iItem = dialog->GetSelectedItem();
     if (iItem < 0)
       return;
 

--- a/xbmc/music/dialogs/GUIDialogSongInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogSongInfo.cpp
@@ -345,7 +345,7 @@ void CGUIDialogSongInfo::OnSetUserrating()
 
     dialog->Open();
 
-    int iItem = dialog->GetSelectedLabel();
+    int iItem = dialog->GetSelectedItem();
     if (iItem < 0)
       return;
 

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -1171,7 +1171,7 @@ INFO_RET CMusicInfoScanner::DownloadAlbumInfo(const CAlbum& album, const ADDON::
           pDlg->Open();
 
           // and wait till user selects one
-          if (pDlg->GetSelectedLabel() < 0)
+          if (pDlg->GetSelectedItem() < 0)
           { // none chosen
             if (!pDlg->IsButtonPressed())
               return INFO_CANCELLED;
@@ -1197,7 +1197,7 @@ INFO_RET CMusicInfoScanner::DownloadAlbumInfo(const CAlbum& album, const ADDON::
 
             return DownloadAlbumInfo(newAlbum, info, albumInfo, pDialog);
           }
-          iSelectedAlbum = pDlg->GetSelectedItem()->m_idepth;
+          iSelectedAlbum = pDlg->GetSelectedFileItem()->m_idepth;
         }
       }
       else
@@ -1367,7 +1367,7 @@ INFO_RET CMusicInfoScanner::DownloadArtistInfo(const CArtist& artist, const ADDO
           pDlg->Open();
 
           // and wait till user selects one
-          if (pDlg->GetSelectedLabel() < 0)
+          if (pDlg->GetSelectedItem() < 0)
           { // none chosen
             if (!pDlg->IsButtonPressed())
               return INFO_CANCELLED;
@@ -1387,7 +1387,7 @@ INFO_RET CMusicInfoScanner::DownloadArtistInfo(const CArtist& artist, const ADDO
             newArtist.strArtist = strNewArtist;
             return DownloadArtistInfo(newArtist, info, artistInfo, pDialog);
           }
-          iSelectedArtist = pDlg->GetSelectedItem()->m_idepth;
+          iSelectedArtist = pDlg->GetSelectedFileItem()->m_idepth;
         }
       }
     }

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -739,7 +739,7 @@ void CPeripherals::OnSettingAction(const CSetting *setting)
       pDialog->SetSelected(iPos);
       pDialog->Open();
 
-      iPos = pDialog->IsConfirmed() ? pDialog->GetSelectedLabel() : -1;
+      iPos = pDialog->IsConfirmed() ? pDialog->GetSelectedItem() : -1;
 
       if (iPos >= 0)
       {

--- a/xbmc/profiles/windows/GUIWindowSettingsProfile.cpp
+++ b/xbmc/profiles/windows/GUIWindowSettingsProfile.cpp
@@ -265,9 +265,9 @@ bool CGUIWindowSettingsProfile::GetAutoLoginProfileChoice(int &iProfile)
   dialog->SetSelected(autoLoginProfileId);
   dialog->Open();
 
-  if (dialog->IsButtonPressed() || dialog->GetSelectedLabel() < 0)
+  if (dialog->IsButtonPressed() || dialog->GetSelectedItem() < 0)
     return false; // user cancelled
-  iProfile = dialog->GetSelectedLabel() - 1;
+  iProfile = dialog->GetSelectedItem() - 1;
 
   return true;
 }

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -669,7 +669,7 @@ PVR_ERROR CPVRClients::DeleteAllRecordingsFromTrash()
         pDialog->Add(itrClients->second->GetBackendName());
     }
     pDialog->Open();
-    selection = pDialog->GetSelectedLabel();
+    selection = pDialog->GetSelectedItem();
   }
 
   if (selection == 0)
@@ -911,7 +911,7 @@ void CPVRClients::ProcessMenuHooks(int iClientID, PVR_MENUHOOK_CAT cat, const CF
       }
       pDialog->Open();
 
-      int selection = pDialog->GetSelectedLabel();
+      int selection = pDialog->GetSelectedItem();
       if (selection >= 0)
       {
         itrClients = clients.begin();
@@ -944,7 +944,7 @@ void CPVRClients::ProcessMenuHooks(int iClientID, PVR_MENUHOOK_CAT cat, const CF
     if (hookIDs.size() > 1)
     {
       pDialog->Open();
-      selection = pDialog->GetSelectedLabel();
+      selection = pDialog->GetSelectedItem();
     }
     if (selection >= 0)
       client->CallMenuHook(hooks->at(hookIDs.at(selection)), item);
@@ -992,7 +992,7 @@ void CPVRClients::StartChannelScan(void)
 
     pDialog->Open();
 
-    int selection = pDialog->GetSelectedLabel();
+    int selection = pDialog->GetSelectedItem();
     if (selection >= 0)
       scanClient = possibleScanClients[selection];
   }

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -457,7 +457,7 @@ bool CGUIDialogPVRChannelManager::OnClickButtonNewChannel()
       pDlgSelect->Add((*itr)->Name());
     pDlgSelect->Open();
 
-    iSelection = pDlgSelect->GetSelectedLabel();
+    iSelection = pDlgSelect->GetSelectedItem();
   }
 
   if (iSelection >= 0 && iSelection < (int)m_clientsWithSettingsList.size())

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -324,7 +324,7 @@ bool CGUIWindowPVRBase::OpenGroupSelectionDialog(void)
   if (!dialog->IsConfirmed())
     return false;
 
-  const CFileItemPtr item = dialog->GetSelectedItem();
+  const CFileItemPtr item = dialog->GetSelectedFileItem();
   if (!item)
     return false;
 

--- a/xbmc/settings/dialogs/GUIDialogContentSettings.cpp
+++ b/xbmc/settings/dialogs/GUIDialogContentSettings.cpp
@@ -129,23 +129,18 @@ bool CGUIDialogContentSettings::OnMessage(CGUIMessage &message)
 
           dialog->Open();
           // Selected item has not changes - in case of cancel or the user selecting the same item
-          if (dialog->GetSelectedLabel() == iSelected)
+          if (!dialog->IsConfirmed() || dialog->GetSelectedItem() == iSelected)
             return true;
-          for (const auto &label : labels)
-          {
-            if (dialog->GetSelectedLabelText() == label.first)
-            {
-              m_content = static_cast<CONTENT_TYPE>(label.second);
-              break;
-            }
-          }
+
+          auto selected = labels.at(dialog->GetSelectedItem());
+          m_content = static_cast<CONTENT_TYPE>(selected.second);
 
           AddonPtr scraperAddon;
           CAddonMgr::GetInstance().GetDefault(ADDON::ScraperTypeFromContent(m_content), scraperAddon);
           m_scraper = std::dynamic_pointer_cast<CScraper>(scraperAddon);
 
           SetupView();
-          SET_CONTROL_LABEL2(CONTROL_CONTENT_TYPE_BUTTON, dialog->GetSelectedLabelText());
+          SET_CONTROL_LABEL2(CONTROL_CONTENT_TYPE_BUTTON, selected.first);
           SET_CONTROL_FOCUS(CONTROL_CONTENT_TYPE_BUTTON, 0);
         }
       }

--- a/xbmc/storage/AutorunMediaJob.cpp
+++ b/xbmc/storage/AutorunMediaJob.cpp
@@ -52,7 +52,7 @@ bool CAutorunMediaJob::DoWork()
 
   pDialog->Open();
 
-  int selection = pDialog->GetSelectedLabel();
+  int selection = pDialog->GetSelectedItem();
   if (selection >= 0)
   {
     std::string strAction = StringUtils::Format("ActivateWindow(%s, %s)", GetWindowString(selection), m_path.c_str());

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -462,7 +462,7 @@ void CGUIDialogVideoInfo::OnSearch(std::string& strSearch)
 
     pDlgSelect->Open();
 
-    int iItem = pDlgSelect->GetSelectedLabel();
+    int iItem = pDlgSelect->GetSelectedItem();
     if (iItem < 0)
       return;
 
@@ -662,7 +662,7 @@ std::string CGUIDialogVideoInfo::ChooseArtType(const CFileItem &videoItem, std::
     return strArtworkName;
   }
 
-  return dialog->GetSelectedItem()->GetProperty("type").asString();
+  return dialog->GetSelectedFileItem()->GetProperty("type").asString();
 }
 
 void CGUIDialogVideoInfo::OnGetArt()
@@ -887,7 +887,7 @@ void CGUIDialogVideoInfo::OnSetUserrating()
 
     dialog->Open();
 
-    int iItem = dialog->GetSelectedLabel();
+    int iItem = dialog->GetSelectedItem();
     if (iItem < 0)
       return;
 
@@ -1517,7 +1517,7 @@ bool CGUIDialogVideoInfo::GetSetForMovie(const CFileItem *movieItem, CFileItemPt
   }
   else if (dialog->IsConfirmed())
   {
-    selectedSet = dialog->GetSelectedItem();
+    selectedSet = dialog->GetSelectedFileItem();
     return (selectedSet != NULL);
   }
   else
@@ -1945,7 +1945,7 @@ bool CGUIDialogVideoInfo::LinkMovieToTvShow(const CFileItemPtr &item, bool bRemo
     pDialog->SetItems(list);
     pDialog->SetHeading(CVariant{20356});
     pDialog->Open();
-    iSelectedLabel = pDialog->GetSelectedLabel();
+    iSelectedLabel = pDialog->GetSelectedItem();
   }
 
   if (iSelectedLabel > -1 && iSelectedLabel < list.Size())

--- a/xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
+++ b/xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
@@ -166,7 +166,7 @@ bool CVideoLibraryRefreshingJob::Work(CVideoDatabase &db)
             selectDialog->Open();
 
             // check if the user has chosen one of the results
-            int selectedItem = selectDialog->GetSelectedLabel();
+            int selectedItem = selectDialog->GetSelectedItem();
             if (selectedItem >= 0)
               scraperUrl = itemResultList.at(selectedItem);
             // the user hasn't chosen one of the results and but has chosen to manually enter a title to use

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -927,7 +927,7 @@ bool CGUIWindowVideoBase::OnPlayStackPart(int iItem)
   if (!pDialog->IsConfirmed())
     return false;
 
-  int selectedFile = pDialog->GetSelectedLabel();
+  int selectedFile = pDialog->GetSelectedItem();
   if (selectedFile >= 0)
   {
     // ISO stack
@@ -1471,7 +1471,7 @@ void CGUIWindowVideoBase::AddToDatabase(int iItem)
   pSelect->EnableButton(true, 531); // New Genre
   pSelect->Open();
   std::string strGenre;
-  int iSelected = pSelect->GetSelectedLabel();
+  int iSelected = pSelect->GetSelectedItem();
   if (iSelected >= 0)
     strGenre = items[iSelected]->GetLabel();
   else if (!pSelect->IsButtonPressed())
@@ -1544,7 +1544,7 @@ void CGUIWindowVideoBase::OnSearch()
 
     pDlgSelect->Open();
 
-    int iItem = pDlgSelect->GetSelectedLabel();
+    int iItem = pDlgSelect->GetSelectedItem();
     if (iItem < 0)
       return;
 


### PR DESCRIPTION
This allows the cancel button to be focused so that navigation doesn't break when the list is empty. 
