### PR TITLE
Fix context menu for "Add music..." item to remove "Scan to library" option

### DIFF
--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -464,8 +464,11 @@ void CGUIWindowMusicNav::GetContextButtons(int itemNumber, CContextButtons &butt
       // Add the scan button(s)
       if (g_application.IsMusicScanning())
         buttons.Add(CONTEXT_BUTTON_STOP_SCANNING, 13353); // Stop Scanning
-      else if (CProfilesManager::GetInstance().GetCurrentProfile().canWriteDatabases() ||
-               g_passwordManager.bMasterUser)
+      else if (!inPlaylists && !m_vecItems->IsInternetStream() &&
+        !item->IsPath("add") && !item->IsParentFolder() &&
+        !item->IsPlugin() &&
+        !StringUtils::StartsWithNoCase(item->GetPath(), "addons://") &&
+        (CProfilesManager::GetInstance().GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser))
       {
         buttons.Add(CONTEXT_BUTTON_SCAN, 13352);
       }


### PR DESCRIPTION
This fixes a bug in music file view, introduced in #8011 with the removeal of CGUIWindowMusicSongs, that incorrectly allows "Scan to library" to appear on context menu for the "Add music.." item just like the other items.

Easy fixed for Jarvis, but there are other context menu issues in this area....

Isengard showed 2 context menu buttons for the "Add music..." item - "Settings" and "Go to root". "Settings" was removed by #8190, and there was dicsussion on IRC that "Go to root" does not belong on a context menu for any items since it is not contextual.

My view is that "Go to root" is useful for navigation, but needs a better string, and there was some agreement that it could be better on the side bar than context menu. None of these things are addressed by this PR (at the moment).

However since #8011 "Go to root" does not behave in the same way as it did in Isengard. In library view, where also available, as in Isengard it takes you to the music library "root" main screen. From file view in Isengard it took you to the root music source screen, but now both places go to the library screen.

The view seems to be remove the context button, it should never be there in the first place. But if so, do we add "Goto root"  to the side bar, and how to detect which of  the different "roots" between file view and library view. 
