### PR TITLE
[dbwrapers] Include database name in error message

### DIFF
--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -97,6 +97,7 @@ int MysqlDatabase::setErr(int err_code, const char * qry) {
       snprintf(err, 256, "Undefined MySQL error: Code (%d)", err_code);
       error = err;
   }
+  error = "[" + db + "] " + error;
   error += "\nQuery: ";
   error += qry;
   error += "\n";

--- a/xbmc/dbwrappers/sqlitedataset.cpp
+++ b/xbmc/dbwrappers/sqlitedataset.cpp
@@ -192,6 +192,7 @@ int SqliteDatabase::setErr(int err_code, const char * qry){
     break;
   default : error = "Undefined SQLite error";
   }
+  error = "[" + db + "] " + error;
   error += "\nQuery: ";
   error += qry;
   error += "\n";


### PR DESCRIPTION
When a query fails, include the name of the database being queried in the error message.

This additional information would have prevented [this](http://forum.kodi.tv/showthread.php?tid=247985&pid=2168033#pid2168033) wild goose chase where the database causing the problem is misidentified, resulting in data loss (users mistake, but still...).

Witht this PR, instead of an ambiguous error (because the `version` table happens to exist in multiple databases):

```
21:03:18 T:139745276340352   ERROR: SQL: The table does not exist
                                            Query: SELECT idVersion FROM version
```

we would have (with MySQL):

```
21:03:18 T:139745276340352   ERROR: SQL: [MyVideos99] The table does not exist
                                            Query: SELECT idVersion FROM version
```

and with SQLite:

```
21:24:45 T:140011543644288   ERROR: SQL: [Textures13.db] SQL error or missing database
                                            Query: SELECT idVersion FROM version
```

which is much less likely to be misunderstood.
