### PR TITLE
[gui] remove "Switch media" from context menu

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -2340,11 +2340,6 @@ msgctxt "#522"
 msgid "Remove source"
 msgstr ""
 
-#: xbmc/windows/GUIWindowFileManager.cpp
-msgctxt "#523"
-msgid "Switch media"
-msgstr ""
-
 msgctxt "#524"
 msgid "Select playlist"
 msgstr ""

--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -648,27 +648,6 @@ void CGUIDialogContextMenu::ClearDefault(const std::string &strType)
   SetDefault(strType, "");
 }
 
-void CGUIDialogContextMenu::SwitchMedia(const std::string& strType, const std::string& strPath)
-{
-  // create menu
-  CContextButtons choices;
-  if (strType != "music")
-    choices.Add(WINDOW_MUSIC_FILES, 2);
-  if (strType != "video")
-    choices.Add(WINDOW_VIDEO_FILES, 3);
-  if (strType != "pictures")
-    choices.Add(WINDOW_PICTURES, 1);
-  if (strType != "files")
-    choices.Add(WINDOW_FILES, 7);
-
-  int window = ShowAndGetChoice(choices);
-  if (window >= 0)
-  {
-    CUtil::DeleteDirectoryCache();
-    g_windowManager.ChangeActiveWindow(window, strPath);
-  }
-}
-
 int CGUIDialogContextMenu::ShowAndGetChoice(const CContextButtons &choices)
 {
   if (choices.empty())

--- a/xbmc/dialogs/GUIDialogContextMenu.h
+++ b/xbmc/dialogs/GUIDialogContextMenu.h
@@ -57,7 +57,6 @@ enum CONTEXT_BUTTON { CONTEXT_BUTTON_CANCELLED = 0,
                       CONTEXT_BUTTON_VIEW_SLIDESHOW,
                       CONTEXT_BUTTON_RECURSIVE_SLIDESHOW,
                       CONTEXT_BUTTON_REFRESH_THUMBS,
-                      CONTEXT_BUTTON_SWITCH_MEDIA,
                       CONTEXT_BUTTON_MOVE_ITEM,
                       CONTEXT_BUTTON_MOVE_HERE,
                       CONTEXT_BUTTON_CANCEL_MOVE,
@@ -173,7 +172,6 @@ public:
   virtual void SetPosition(float posX, float posY);
 
   static bool SourcesMenu(const std::string &strType, const CFileItemPtr& item, float posX, float posY);
-  static void SwitchMedia(const std::string& strType, const std::string& strPath);
 
   static void GetContextButtons(const std::string &type, const CFileItemPtr& item, CContextButtons &buttons);
   static bool OnContextButton(const std::string &type, const CFileItemPtr& item, CONTEXT_BUTTON button);

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -488,7 +488,6 @@ void CGUIWindowPictures::GetContextButtons(int itemNumber, CContextButtons &butt
       else
       {
         buttons.Add(CONTEXT_BUTTON_GOTO_ROOT, 20128);
-        buttons.Add(CONTEXT_BUTTON_SWITCH_MEDIA, 523);
       }
     }
   }
@@ -531,9 +530,6 @@ bool CGUIWindowPictures::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
     return true;
   case CONTEXT_BUTTON_GOTO_ROOT:
     Update("");
-    return true;
-  case CONTEXT_BUTTON_SWITCH_MEDIA:
-    CGUIDialogContextMenu::SwitchMedia("pictures", m_vecItems->GetPath());
     return true;
   default:
     break;

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -1010,7 +1010,6 @@ void CGUIWindowFileManager::OnPopupMenu(int list, int item, bool bContextDriven 
   if (item >= 0 && pItem->m_bIsFolder && !pItem->IsParentFolder())
     choices.Add(CONTROL_BTNCALCSIZE, 13393);
   choices.Add(CONTROL_BTNGOTOROOT, 20128);
-  choices.Add(CONTROL_BTNSWITCHMEDIA, 523);
   if (CJobManager::GetInstance().IsProcessing("filemanager"))
     choices.Add(CONTROL_BTNCANCELJOB, 167);
 
@@ -1078,11 +1077,6 @@ void CGUIWindowFileManager::OnPopupMenu(int list, int item, bool bContextDriven 
   if (btnid == CONTROL_BTNGOTOROOT)
   {
     Update(list,"");
-    return;
-  }
-  if (btnid == CONTROL_BTNSWITCHMEDIA)
-  {
-    CGUIDialogContextMenu::SwitchMedia("files", m_vecItems[list]->GetPath());
     return;
   }
   if (btnid == CONTROL_BTNCANCELJOB)


### PR DESCRIPTION
This removes "Switch media" from context menu in pictures and filemanager.
Reasons:
- It is not context-sensitive so only sane option would be sidebar. (up to the skinners)
- Selection of options is "fixed" and incomplete (no PVR for example)
- atm it´s only implemented for two areas (filemanager and pictures), the other areas do not contain this context menu option. Feels very weird that you cannot always switch back.

if people really want this in context menu (I doubt it) then they could come up with a more powerful implementation by creating some small contextmenu add-on.
