### PR TITLE
FIX: allow to delete a default key binding

### DIFF
--- a/system/keymaps/gamepad.xml
+++ b/system/keymaps/gamepad.xml
@@ -18,9 +18,10 @@
 <!--       <obc45>Stop</obc45>         -->
 <!--    </universalremote>            -->
 
-<!-- Note that the action can be a built-in function.                 -->
-<!--  eg <B>ActivateWindow(MyMusic)</B>                         -->
-<!-- would automatically go to My Music on the press of the B button. -->
+<!-- Note that the action can be a built-in function.                                         -->
+<!--  eg <B>ActivateWindow(MyMusic)</B>                                                       -->
+<!-- would automatically go to My Music on the press of the B button.                         -->
+<!-- An empty action removes the corresponding mapping from the default keymap                -->
 
 <!-- Joysticks / Gamepads:                                                                    -->
 <!--   See the sample PS3 controller configuration below for the format.                      -->

--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -18,9 +18,10 @@
 <!--       <obc45>Stop</obc45>         -->
 <!--    </universalremote>            -->
 
-<!-- Note that the action can be a built-in function.                 -->
-<!--  eg <B>ActivateWindow(MyMusic)</B>                         -->
-<!-- would automatically go to My Music on the press of the B button. -->
+<!-- Note that the action can be a built-in function.                                         -->
+<!--  eg <B>ActivateWindow(MyMusic)</B>                                                       -->
+<!-- would automatically go to My Music on the press of the B button.                         -->
+<!-- An empty action removes the corresponding mapping from the default keymap                -->
 
 <!-- Joysticks / Gamepads:                                                                    -->
 <!--   See the sample PS3 controller configuration below for the format.                      -->

--- a/system/keymaps/remote.xml
+++ b/system/keymaps/remote.xml
@@ -18,9 +18,10 @@
 <!--       <obc45>Stop</obc45>         -->
 <!--    </universalremote>            -->
 
-<!-- Note that the action can be a built-in function.                 -->
-<!--  eg <B>ActivateWindow(MyMusic)</B>                         -->
-<!-- would automatically go to My Music on the press of the B button. -->
+<!-- Note that the action can be a built-in function.                                         -->
+<!--  eg <B>ActivateWindow(MyMusic)</B>                                                       -->
+<!-- would automatically go to My Music on the press of the B button.                         -->
+<!-- An empty action removes the corresponding mapping from the default keymap                -->
 
 <!-- Joysticks / Gamepads:                                                                    -->
 <!--   See the sample PS3 controller configuration below for the format.                      -->

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -1325,8 +1325,20 @@ void CButtonTranslator::MapWindowActions(TiXmlNode *pWindow, int windowID)
         else if (type == "appcommand")
             buttonCode = TranslateAppCommand(pButton->Value());
 
-        if (buttonCode && pButton->FirstChild())
-          MapAction(buttonCode, pButton->FirstChild()->Value(), map);
+        if (buttonCode)
+        {
+          if (pButton->FirstChild() && pButton->FirstChild()->Value()[0])
+            MapAction(buttonCode, pButton->FirstChild()->Value(), map);
+          else
+          {
+            buttonMap::iterator it = map.find(buttonCode);
+            while (it != map.end())
+            {
+              map.erase(it);
+              it = map.find(buttonCode);
+            }
+          }
+        }
         pButton = pButton->NextSiblingElement();
       }
 


### PR DESCRIPTION
Some default actions might not be to everyone's liking (especially the longpress ones), and custom keymaps are merged.
This allows to delete a default keymap in a custom keymap with an empty action, 
e.g. `<up mod="longpress"></up>`

/cc @da-anda @sraue @mkortstiege 
