### PR TITLE
[AMLCodec] Add support for libamcodec.so

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/AMLCodec.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/AMLCodec.cpp
@@ -103,8 +103,12 @@ public:
 
 class DllLibAmCodec : public DllDynamic, DllLibamCodecInterface
 {
-  // libamcodec is static linked into libamplayer.so
-  DECLARE_DLL_WRAPPER(DllLibAmCodec, "libamplayer.so")
+  // libamcodec is static linked into libamcodec.so (older versions use libamplayer.so)
+  public:
+  DllLibAmCodec() : DllDynamic("libamcodec.so") {
+    if(!CanLoad())
+      SetFile("libamplayer.so");
+  }
 
   DEFINE_METHOD1(int, codec_init,               (codec_para_t *p1))
   DEFINE_METHOD1(int, codec_close,              (codec_para_t *p1))


### PR DESCRIPTION
The Makefiles of version `2015-01-20-4a5990f135` (latest) of the Amlogic
buildroot package will link `libamcodec` into `libamcodec.so` instead
of `libamplayer.so`.

The buildroot package can be found at:
    http://openlinux.amlogic.com/wiki/index.php/Arm/Buildroot

The relevant file inside the archive is:
    buildroot/package/multimedia/aml_libs/src/amcodec/Makefile (line 26)

We now check if `libamcodec.so` can be loaded, and if not, we'll use
`libamplayer.so` instead for backwards compatibility with devices
running an older version.
