### PR TITLE
Revert "Added: HttpProxy parameter for setting proxies on stream urls."

### DIFF
--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -806,8 +806,6 @@ void CCurlFile::ParseAndCorrectUrl(CURL &url2)
           m_seekable = false;
         else if (name == "accept-charset")
           SetAcceptCharset(value);
-        else if (name == "httpproxy")
-          SetStreamProxy(value, PROXY_HTTP);
         else if (name == "sslcipherlist")
           m_cipherlist = value;
         else if (name == "connection-timeout")
@@ -825,17 +823,6 @@ void CCurlFile::ParseAndCorrectUrl(CURL &url2)
     m_url = url2.GetWithoutUserDetails();
   else
     m_url = url2.Get();
-}
-
-void CCurlFile::SetStreamProxy(const std::string &proxy, ProxyType type)
-{
-  CURL url(proxy);
-  m_proxy = url.GetWithoutUserDetails();
-  m_proxyuserpass = url.GetUserName();
-  if (!url.GetPassWord().empty())
-    m_proxyuserpass += ":" + url.GetPassWord();
-  m_proxytype = type;
-  CLog::Log(LOGDEBUG, "Overriding proxy from URL parameter: %s, type %d", m_proxy.c_str(), proxyType2CUrlProxyType[m_proxytype]);
 }
 
 bool CCurlFile::Post(const std::string& strURL, const std::string& strPostData, std::string& strHTML)

--- a/xbmc/filesystem/CurlFile.h
+++ b/xbmc/filesystem/CurlFile.h
@@ -75,7 +75,6 @@ namespace XFILE
       void SetProxy(const std::string &proxy)                    { m_proxy = proxy; }
       void SetProxyUserPass(const std::string &proxyuserpass)    { m_proxyuserpass = proxyuserpass; }
       void SetProxyType(ProxyType proxytype)                     { m_proxytype = proxytype; }
-      void SetStreamProxy(const std::string &proxy, ProxyType type);
       void SetCustomRequest(const std::string &request)          { m_customrequest = request; }
       void UseOldHttpVersion(bool bUse)                          { m_useOldHttpVersion = bUse; }
       void SetContentEncoding(const std::string& encoding)       { m_contentencoding = encoding; }


### PR DESCRIPTION
This reverts commit 9e271e661857c5dd6faa872a22f59bf42339733f.
because of security issues. Account information must not be exposed
this way.

for reference: #8418
