### PR TITLE
Fix artist names when list cached, and with prioritised APE tags

### DIFF
--- a/xbmc/music/tags/MusicInfoTag.cpp
+++ b/xbmc/music/tags/MusicInfoTag.cpp
@@ -343,10 +343,10 @@ void CMusicInfoTag::SetArtist(const std::string& strArtist)
   }
 }
 
-void CMusicInfoTag::SetArtist(const std::vector<std::string>& artists)
+void CMusicInfoTag::SetArtist(const std::vector<std::string>& artists, bool FillDesc /* = false*/)
 {
   m_artist = artists;
-  if (m_strArtistDesc.empty()) 
+  if (m_strArtistDesc.empty() || FillDesc) 
   { 
     SetArtistDesc(StringUtils::Join(artists, g_advancedSettings.m_musicItemSeparator));
   }
@@ -381,10 +381,10 @@ void CMusicInfoTag::SetAlbumArtist(const std::string& strAlbumArtist)
   }
 }
 
-void CMusicInfoTag::SetAlbumArtist(const std::vector<std::string>& albumArtists)
+void CMusicInfoTag::SetAlbumArtist(const std::vector<std::string>& albumArtists, bool FillDesc /* = false*/)
 {
   m_albumArtist = albumArtists;
-  if (m_strAlbumArtistDesc.empty()) 
+  if (m_strAlbumArtistDesc.empty() || FillDesc) 
     SetAlbumArtistDesc(StringUtils::Join(albumArtists, g_advancedSettings.m_musicItemSeparator));
 }
 
@@ -764,8 +764,10 @@ void CMusicInfoTag::Archive(CArchive& ar)
     ar << m_strURL;
     ar << m_strTitle;
     ar << m_artist;
+    ar << m_strArtistDesc;
     ar << m_strAlbum;
     ar << m_albumArtist;
+    ar << m_strAlbumArtistDesc;
     ar << m_genre;
     ar << m_iDuration;
     ar << m_iTrack;
@@ -797,8 +799,10 @@ void CMusicInfoTag::Archive(CArchive& ar)
     ar >> m_strURL;
     ar >> m_strTitle;
     ar >> m_artist;
+    ar >> m_strArtistDesc;
     ar >> m_strAlbum;
     ar >> m_albumArtist;
+    ar >> m_strAlbumArtistDesc;
     ar >> m_genre;
     ar >> m_iDuration;
     ar >> m_iTrack;

--- a/xbmc/music/tags/MusicInfoTag.h
+++ b/xbmc/music/tags/MusicInfoTag.h
@@ -90,12 +90,12 @@ public:
   void SetURL(const std::string& strURL);
   void SetTitle(const std::string& strTitle);
   void SetArtist(const std::string& strArtist);
-  void SetArtist(const std::vector<std::string>& artists);
+  void SetArtist(const std::vector<std::string>& artists, bool FillDesc = false);
   void SetArtistDesc(const std::string& strArtistDesc);
   void SetAlbum(const std::string& strAlbum);
   void SetAlbumId(const int iAlbumId);
   void SetAlbumArtist(const std::string& strAlbumArtist);
-  void SetAlbumArtist(const std::vector<std::string>& albumArtists);
+  void SetAlbumArtist(const std::vector<std::string>& albumArtists, bool FillDesc = false);
   void SetAlbumArtistDesc(const std::string& strAlbumArtistDesc);
   void SetGenre(const std::string& strGenre);
   void SetGenre(const std::vector<std::string>& genres);

--- a/xbmc/music/tags/TagLoaderTagLib.cpp
+++ b/xbmc/music/tags/TagLoaderTagLib.cpp
@@ -733,7 +733,9 @@ void CTagLoaderTagLib::SetArtist(CMusicInfoTag &tag, const std::vector<std::stri
   if (values.size() == 1)
     tag.SetArtist(values[0]);
   else
-    tag.SetArtist(values);
+    // Fill both artist vector and artist desc from tag value.
+    // Note desc may not be empty as it could have been set by previous parsing of ID3v2 before APE
+    tag.SetArtist(values, true); 
 }
 
 const std::vector<std::string> CTagLoaderTagLib::SplitMBID(const std::vector<std::string> &values)
@@ -761,7 +763,9 @@ void CTagLoaderTagLib::SetAlbumArtist(CMusicInfoTag &tag, const std::vector<std:
   if (values.size() == 1)
     tag.SetAlbumArtist(values[0]);
   else
-    tag.SetAlbumArtist(values);
+    // Fill both artist vector and artist desc from tag value.
+    // Note desc may not be empty as it could have been set by previous parsing of ID3v2 before APE
+    tag.SetAlbumArtist(values, true);
 }
 
 void CTagLoaderTagLib::SetGenre(CMusicInfoTag &tag, const std::vector<std::string> &values)


### PR DESCRIPTION
Fixing a couple of niggles following the processing of ARTISTS tag #7281 and the subsequent changes to artist variable in Song and Album #8158.

Artist name was being lost when the album list was cached, so when caching of the album list  happened going back up from a list of songs to a list of albums the artist names wasn't showing. In CMusicInfotag both artistDesc and albumArtistDesc needed archiving.

There was also inconsistent tag processing behaviour with music files with both ID3v2 and APE tags, when `prioritiseapetags` set. This is discussed here http://forum.kodi.tv/showthread.php?tid=248791 
In this case the tags are parsed twice, and artist desc set from ID3v2 tags needs to be overwritten by that in APE tags.

@Razzeee have a look.  @evilhamster if you are around? Needs to go into Jarvis.
