### PR TITLE
[music] Listeners should not be able to hold a negative value

### DIFF
--- a/xbmc/music/tags/MusicInfoTag.cpp
+++ b/xbmc/music/tags/MusicInfoTag.cpp
@@ -18,6 +18,8 @@
  *
  */
 
+#include <algorithm>
+
 #include "MusicInfoTag.h"
 #include "music/Album.h"
 #include "music/Artist.h"
@@ -470,7 +472,7 @@ void CMusicInfoTag::SetUserrating(char rating)
 
 void CMusicInfoTag::SetListeners(int listeners)
 {
- m_listeners = listeners;
+  m_listeners = std::max(listeners, 0);
 }
 
 void CMusicInfoTag::SetPlayCount(int playcount)
@@ -865,6 +867,7 @@ void CMusicInfoTag::Clear()
   m_coverArt.clear();
   m_replayGain = ReplayGain();
   m_albumReleaseType = CAlbum::Album;
+  m_listeners = 0;
 }
 
 void CMusicInfoTag::AppendArtist(const std::string &artist)


### PR DESCRIPTION
Not sure if this field is used anymore, but if it is, it shouldn't show up as a negative value.

(Yes, I finally got that annoyed by that negative value in my debugger)
