### PR TITLE
make LOGDEBUG default for addons

### DIFF
--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -75,7 +75,7 @@ namespace XBMCAddon
     {
       // check for a valid loglevel
       if (level < LOGDEBUG || level > LOGNONE)
-        level = LOGNOTICE;
+        level = LOGDEBUG;
       CLog::Log(level, "%s", msg);
     }
 
@@ -555,6 +555,6 @@ namespace XBMCAddon
     int getISO_639_2(){ return CLangCodeExpander::ISO_639_2; }
     int getENGLISH_NAME() { return CLangCodeExpander::ENGLISH_NAME; }
 
-    const int lLOGNOTICE = LOGNOTICE;
+    const int lLOGDEBUG = LOGDEBUG;
   }
 }

--- a/xbmc/interfaces/legacy/ModuleXbmc.h
+++ b/xbmc/interfaces/legacy/ModuleXbmc.h
@@ -32,13 +32,13 @@ namespace XBMCAddon
   {
 #ifndef SWIG
     // This is a bit of a hack to get around a SWIG problem
-    extern const int lLOGNOTICE;
+    extern const int lLOGDEBUG;
 #endif
 
     /**
      * log(msg[, level]) -- Write a string to XBMC's log file and the debug window.\n
      *     msg            : string - text to output.\n
-     *     level          : [opt] integer - log level to ouput at. (default=LOGNOTICE)\n
+     *     level          : [opt] integer - log level to ouput at. (default=LOGDEBUG)\n
      *     \n
      * *Note, You can use the above as keywords for arguments and skip certain optional arguments.\n
      *        Once you use a keyword, all following arguments require the keyword.\n
@@ -52,7 +52,7 @@ namespace XBMCAddon
      *           example:
      *             - xbmc.log(msg='This is a test string.', level=xbmc.LOGDEBUG);
      */
-    void log(const char* msg, int level = lLOGNOTICE);
+    void log(const char* msg, int level = lLOGDEBUG);
 
     /**
      * Shutdown() -- Shutdown the htpc.


### PR DESCRIPTION
addons should only use the LOGDEBUG level for logging, so let's make it the default.

@jimfcarroll for review
