### PR TITLE
[PVR] Mark Created ChannnelGroups as Loaded on Persist (extra fix #16365)

### DIFF
--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -894,6 +894,10 @@ bool CPVRChannelGroup::Persist(void)
   if (!HasChanges() || (!m_bLoaded && m_iGroupId != -1))
     return bReturn;
 
+  // Mark newly created groups as loaded so future updates will also be persisted...
+  if (m_iGroupId == -1)
+    m_bLoaded = true;
+
   if (CPVRDatabase *database = GetPVRDatabase())
   {
     CLog::Log(LOGDEBUG, "CPVRChannelGroup - %s - persisting channel group '%s' with %d channels",


### PR DESCRIPTION
https://github.com/xbmc/xbmc/pull/8439 changed 'Persist' so it will save a newly created group.

The problem is this happens before any channels are added to the group.
When you click 'OK' after subsequently adding channels to the group, it now has a channel_id.
As the group isn't marked as 'loaded', the new changes aren't persisted.

When you subsequently restart kodi, your newly created group has no channels, so it isn't loaded...

This PR marks user created groups as 'loaded' on first 'persist' which means you can't use the 'loaded' flag to indicate stuff exclusively pulled from the database anymore, but I don't see anything doing that. 

I considered trying something 'more correct' but modifying the persist logic on load looked like it would be too complex / invasive.

pings: @ksooo @Jalle19 
