### PR TITLE
[webserver] - fixed possible directory traversal bug due to insuffici…

### DIFF
--- a/xbmc/network/httprequesthandler/HTTPWebinterfaceHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPWebinterfaceHandler.cpp
@@ -121,5 +121,12 @@ bool CHTTPWebinterfaceHandler::ResolveAddon(const std::string &url, ADDON::Addon
   // append the path within the addon to the path of the addon
   addonPath = URIUtils::AddFileToFolder(addonPath, path);
 
+  // ensure that we don't have a directory traversal hack here
+  // by checking if the resolved absolute path is inside the addon path
+  std::string realPath = URIUtils::GetRealPath(addonPath);
+  std::string realAddonPath = URIUtils::GetRealPath(addon->Path());
+  if (!URIUtils::IsInPath(realPath, realAddonPath))
+    return false;
+
   return true;
 }


### PR DESCRIPTION
…ent url checking

As pointed out by forum member ChessSpider the security fix here:

https://github.com/xbmc/xbmc/commit/bdff099c024521941cb0956fe01d99ab52a65335

was accidently removed again here:

https://github.com/xbmc/xbmc/commit/12917d556ab25defdba5264e93622df9e60bee66

Allowing to access any possible file from our webserver.

@Montellese one sanity check please

thx to ChessSpider for reporting it in.
