### PR TITLE
[PVR] Allow timer creation for EPG in recent past

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -744,6 +744,10 @@ void CGUIDialogPVRTimerSettings::InitializeTypesList()
       // Drop TimerTypes that forbid EPGInfo, if it is populated
       if (type->ForbidsEpgTagOnCreate() && m_timerInfoTag->HasEpgInfoTag())
         continue;
+
+      // Drop TimerTypes that aren't repeating if end time is in the past
+      if (!type->IsRepeating() && m_timerInfoTag->EndAsLocalTime() < CDateTime::GetCurrentDateTime())
+        continue;
     }
 
     m_typeEntries.insert(std::make_pair(idx++, type));

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -702,7 +702,7 @@ CPVRTimerInfoTagPtr CPVRTimerInfoTag::CreateFromEpg(const CEpgInfoTagPtr &tag, b
   }
 
   /* check if the epg end date is in the future */
-  if (tag->EndAsLocalTime() < CDateTime::GetCurrentDateTime())
+  if (tag->EndAsLocalTime() < CDateTime::GetCurrentDateTime() && !bRepeating)
   {
     CLog::Log(LOGERROR, "%s - end time is in the past", __FUNCTION__);
     return CPVRTimerInfoTagPtr();

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -101,9 +101,10 @@ void CGUIWindowPVRGuide::GetContextButtons(int itemNumber, CContextButtons &butt
           buttons.Add(CONTEXT_BUTTON_DELETE_TIMER, 19060);  /* Delete timer */
       }
     }
-    else if (epg->EndAsLocalTime() > CDateTime::GetCurrentDateTime())
+    else
     {
-      buttons.Add(CONTEXT_BUTTON_START_RECORD, 264);      /* Record */
+      if (epg->EndAsLocalTime() > CDateTime::GetCurrentDateTime())
+        buttons.Add(CONTEXT_BUTTON_START_RECORD, 264);      /* Record */
       buttons.Add(CONTEXT_BUTTON_ADD_TIMER, 19061);       /* Add timer */
     }
 

--- a/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
@@ -67,9 +67,10 @@ void CGUIWindowPVRSearch::GetContextButtons(int itemNumber, CContextButtons &but
           buttons.Add(CONTEXT_BUTTON_DELETE_TIMER, 19060);  /* Delete timer */
       }
     }
-    else if (epg->EndAsLocalTime() > CDateTime::GetCurrentDateTime())
+    else
     {
-      buttons.Add(CONTEXT_BUTTON_START_RECORD, 264);      /* Record */
+      if (epg->EndAsLocalTime() > CDateTime::GetCurrentDateTime())
+        buttons.Add(CONTEXT_BUTTON_START_RECORD, 264);      /* Record */
       buttons.Add(CONTEXT_BUTTON_ADD_TIMER, 19061);       /* Add timer */
     }
 


### PR DESCRIPTION
This has been on my wish list for a while. As I was just in that bit of code...

**Scenario**
You have just finished watching a show. "My that was good", you think, "I want to record the series."
"No, problem, Kodi can do that for me": Navigate to the PVR EPG, select the show which has just finished, press the context menu and.... ARRRGH, why can't I set a timer!
So you think 'Find Similar...' should solve it....: Err, by default on RPi I only have 3 days of EPG loaded for performance reasons. The next showing is in 7 days time, so there are no matching search results.... ARRRGH!

**The Solution**
This PR enables the 'Add Timer' context menu option for EPG entries in the past. In order to prevent creation of potentially invalid one shot timers, it excludes all timer types which aren't repeating from the list of selectable timer types.

Tested (briefly) and works with: pvr.mythtv & pvr.tvheadend on x86.

Obviously I would like to have this in Jarvis, but Kxxxx will do ;-). Probably needs a bit more testing as I'm not 100% sure it will play nice with all the pvr backends. 

pings: @ksooo @ryangribble @janbar ... will post a link on the forum so this gets a wider audience.
