### PR TITLE
Set the XBox 360 X button action to ContextMenu in an addon

### DIFF
--- a/system/keymaps/joystick.Microsoft.Xbox.360.Controller.xml
+++ b/system/keymaps/joystick.Microsoft.Xbox.360.Controller.xml
@@ -600,10 +600,10 @@
   </ContextMenu>
   <Scripts>
     <joystick family="Xbox 360 Controller (Windows)">
-      <button id="3">Info</button>
+      <button id="3">ContextMenu</button>
     </joystick>
     <joystick family="Xbox 360 Controller (xpad)">
-      <button id="3">Info</button>
+      <button id="3">ContextMenu</button>
     </joystick>
   </Scripts>
   <Settings>


### PR DESCRIPTION
This addresses http://trac.kodi.tv/ticket/16393

In an addon the X button on an XBox 360 controller is mapped to Info but this rarely (ever?) does anything useful. This change maps the X button to ContextMenu instead.

NB I have limited experience of working with controllers so i will not merge this myself. Someone more knowledgable than I about the user interface should make the decision.
