### PR TITLE
added: addon callback for listing a directory

### DIFF
--- a/addons/library.xbmc.addon/libXBMC_addon.h
+++ b/addons/library.xbmc.addon/libXBMC_addon.h
@@ -27,6 +27,8 @@
 #include <stdint.h>
 #include <stdarg.h>
 
+struct VFSDirEntry;
+
 #ifdef _WIN32                   // windows
 #ifndef _SSIZE_T_DEFINED
 typedef intptr_t      ssize_t;
@@ -264,6 +266,14 @@ namespace ADDON
       XBMC_remove_directory = (bool (*)(void* HANDLE, void* CB, const char* strPath))
         dlsym(m_libXBMC_addon, "XBMC_remove_directory");
       if (XBMC_remove_directory == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+
+      XBMC_get_directory = (bool (*)(void* HANDLE, void* CB, const char* strPath, const char* mask, VFSDirEntry** items, unsigned int* num_items))
+        dlsym(m_libXBMC_addon, "XBMC_get_directory");
+      if (XBMC_get_directory == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+
+      XBMC_free_directory = (void (*)(void* HANDLE, void* CB, VFSDirEntry* items, unsigned int num_items))
+        dlsym(m_libXBMC_addon, "XBMC_free_directory");
+      if (XBMC_free_directory == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
       m_Callbacks = XBMC_register_me(m_Handle);
       return m_Callbacks != NULL;
@@ -564,6 +574,29 @@ namespace ADDON
       return XBMC_remove_directory(m_Handle, m_Callbacks, strPath);
     }
 
+    /*!
+     * @brief Lists a directory.
+     * @param strPath Path to the directory.
+     * @param mask File mask
+     * @param items The directory entries
+     * @param num_items Number of entries in directory
+     * @return True if listing was successful, false otherwise.
+     */
+    bool GetDirectory(const char *strPath, const char* mask, VFSDirEntry** items, unsigned int* num_items)
+    {
+      return XBMC_get_directory(m_Handle, m_Callbacks, strPath, mask, items, num_items);
+    }
+
+    /*!
+     * @brief Free a directory list
+     * @param items The directory entries
+     * @param num_items Number of entries in directory
+     */
+    void FreeDirectory(VFSDirEntry* items, unsigned int num_items)
+    {
+      return XBMC_free_directory(m_Handle, m_Callbacks, items, num_items);
+    }
+
   protected:
     void* (*XBMC_register_me)(void *HANDLE);
     void (*XBMC_unregister_me)(void *HANDLE, void* CB);
@@ -594,7 +627,8 @@ namespace ADDON
     bool (*XBMC_create_directory)(void *HANDLE, void* CB, const char* strPath);
     bool (*XBMC_directory_exists)(void *HANDLE, void* CB, const char* strPath);
     bool (*XBMC_remove_directory)(void *HANDLE, void* CB, const char* strPath);
-
+    bool (*XBMC_get_directory)(void *HANDLE, void* CB, const char* strPath, const char* mask, VFSDirEntry** items, unsigned int* num_items);
+    void (*XBMC_free_directory)(void *HANDLE, void* CB, VFSDirEntry* items, unsigned int num_items);
   private:
     void *m_libXBMC_addon;
     void *m_Handle;

--- a/lib/addons/library.xbmc.addon/libXBMC_addon.cpp
+++ b/lib/addons/library.xbmc.addon/libXBMC_addon.cpp
@@ -276,4 +276,20 @@ DLLEXPORT bool XBMC_remove_directory(void *hdl, void* cb, const char *strPath)
   return ((CB_AddOnLib*)cb)->RemoveDirectory(((AddonCB*)hdl)->addonData, strPath);
 }
 
+DLLEXPORT bool XBMC_get_directory(void *hdl, void* cb, const char *strPath, const char* mask, VFSDirEntry** items, unsigned int* num_items)
+{
+  if (cb == NULL)
+    return false;
+
+  return ((CB_AddOnLib*)cb)->GetDirectory(((AddonCB*)hdl)->addonData, strPath, mask, items, num_items);
+}
+
+DLLEXPORT void XBMC_free_directory(void *hdl, void* cb, VFSDirEntry* items, unsigned int num_items)
+{
+  if (cb == NULL)
+    return;
+
+  ((CB_AddOnLib*)cb)->FreeDirectory(((AddonCB*)hdl)->addonData, items, num_items);
+}
+
 };

--- a/xbmc/addons/AddonCallbacks.h
+++ b/xbmc/addons/AddonCallbacks.h
@@ -37,6 +37,8 @@ typedef intptr_t ssize_t;
 #endif // !_SSIZE_T_DEFINED
 #endif // TARGET_WINDOWS
 
+struct VFSDirEntry;
+
 typedef void (*AddOnLogCallback)(void *addonData, const ADDON::addon_log_t loglevel, const char *msg);
 typedef void (*AddOnQueueNotification)(void *addonData, const ADDON::queue_msg_t type, const char *msg);
 typedef bool (*AddOnWakeOnLan)(const char* mac);
@@ -65,6 +67,8 @@ typedef bool (*AddOnCanOpenDirectory)(const void* addonData, const char* strURL)
 typedef bool (*AddOnCreateDirectory)(const void* addonData, const char *strPath);
 typedef bool (*AddOnDirectoryExists)(const void* addonData, const char *strPath);
 typedef bool (*AddOnRemoveDirectory)(const void* addonData, const char *strPath);
+typedef bool (*AddOnGetDirectory)(const void* addonData, const char *strPath, const char* mask, VFSDirEntry** items, unsigned int* num_items);
+typedef void (*AddOnFreeDirectory)(const void* addonData, VFSDirEntry* items, unsigned int num_items);
 
 typedef struct CB_AddOn
 {
@@ -96,6 +100,8 @@ typedef struct CB_AddOn
   AddOnCreateDirectory    CreateDirectory;
   AddOnDirectoryExists    DirectoryExists;
   AddOnRemoveDirectory    RemoveDirectory;
+  AddOnGetDirectory       GetDirectory;
+  AddOnFreeDirectory      FreeDirectory;
 } CB_AddOnLib;
 
 typedef xbmc_codec_t (*CODECGetCodecByName)(const void* addonData, const char* strCodecName);

--- a/xbmc/addons/AddonCallbacksAddon.h
+++ b/xbmc/addons/AddonCallbacksAddon.h
@@ -21,6 +21,8 @@
 
 #include "AddonCallbacks.h"
 
+struct VFSDirEntry;
+
 namespace ADDON
 {
 
@@ -64,6 +66,8 @@ public:
   static bool CreateDirectory(const void* addonData, const char *strPath);
   static bool DirectoryExists(const void* addonData, const char *strPath);
   static bool RemoveDirectory(const void* addonData, const char *strPath);
+  static bool GetDirectory(const void* addondata, const char* strPath, const char* mask, VFSDirEntry** items, unsigned int* num_items);
+  static void FreeDirectory(const void* addondata, VFSDirEntry* items, unsigned int num_items);
 
 private:
   CB_AddOnLib  *m_callbacks; /*!< callback addresses */

--- a/xbmc/addons/addon-bindings.mk
+++ b/xbmc/addons/addon-bindings.mk
@@ -14,6 +14,7 @@ BINDINGS+=xbmc/addons/include/xbmc_pvr_dll.h
 BINDINGS+=xbmc/addons/include/xbmc_pvr_types.h
 BINDINGS+=xbmc/addons/include/xbmc_scr_dll.h
 BINDINGS+=xbmc/addons/include/xbmc_scr_types.h
+BINDINGS+=xbmc/addons/include/kodi_vfs_types.h
 BINDINGS+=xbmc/addons/include/xbmc_vis_dll.h
 BINDINGS+=xbmc/addons/include/xbmc_vis_types.h
 BINDINGS+=xbmc/addons/include/xbmc_stream_utils.hpp

--- a/xbmc/addons/include/kodi_vfs_types.h
+++ b/xbmc/addons/include/kodi_vfs_types.h
@@ -1,0 +1,32 @@
+/*
+ *      Copyright (C) 2015 Team Kodi
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Kodi; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include <stdint.h>
+
+extern "C"
+{
+  struct VFSDirEntry
+  {
+    char* label;             //!< item label
+    char* path;              //!< item path
+    bool folder;             //!< Item is a folder
+    uint64_t size;           //!< Size of file represented by item
+  };
+}


### PR DESCRIPTION
This give add-ons the opportunity to list vfs paths. Code is extracted from my vfs addon work. I have not actually tested this incarnation but it should work just fine (i have tested the _code_ extensively).

Likely intefers with your work @AlwinEsch, i can rebase it after your stuff lands if you prefer no problem.
