### PR TITLE
[PVR] Timer update: Fix handling of timers with 'start at any time'

### DIFF
--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -143,11 +143,11 @@ bool CPVRTimers::UpdateEntries(const CPVRTimers &timers)
         UpdateEpgEvent(newTimer);
 
         VecTimerInfoTag* addEntry = NULL;
-        MapTags::iterator itr = m_tags.find(newTimer->StartAsUTC());
+        MapTags::iterator itr = m_tags.find(newTimer->m_bStartAnyTime ? CDateTime() : newTimer->StartAsUTC());
         if (itr == m_tags.end())
         {
           addEntry = new VecTimerInfoTag;
-          m_tags.insert(std::make_pair(newTimer->StartAsUTC(), addEntry));
+          m_tags.insert(std::make_pair(newTimer->m_bStartAnyTime ? CDateTime() : newTimer->StartAsUTC(), addEntry));
         }
         else
         {
@@ -198,7 +198,8 @@ bool CPVRTimers::UpdateEntries(const CPVRTimers &timers)
         bChanged = true;
         bAddedOrDeleted = true;
       }
-      else if (timer->StartAsUTC() != it->first)
+      else if ((timer->m_bStartAnyTime && it->first != CDateTime()) ||
+               (!timer->m_bStartAnyTime && timer->StartAsUTC() != it->first))
       {
         /* timer start has changed */
         CLog::Log(LOGDEBUG,"PVRTimers - %s - changed start time timer %d on client %d",
@@ -230,11 +231,11 @@ bool CPVRTimers::UpdateEntries(const CPVRTimers &timers)
   for (VecTimerInfoTag::const_iterator timerIt = timersToMove.begin(); timerIt != timersToMove.end(); ++timerIt)
   {
     VecTimerInfoTag* addEntry = NULL;
-    MapTags::const_iterator itr = m_tags.find((*timerIt)->StartAsUTC());
+    MapTags::const_iterator itr = m_tags.find((*timerIt)->m_bStartAnyTime ? CDateTime() : (*timerIt)->StartAsUTC());
     if (itr == m_tags.end())
     {
       addEntry = new VecTimerInfoTag;
-      m_tags.insert(std::make_pair((*timerIt)->StartAsUTC(), addEntry));
+      m_tags.insert(std::make_pair((*timerIt)->m_bStartAnyTime ? CDateTime() : (*timerIt)->StartAsUTC(), addEntry));
     }
     else
     {
@@ -277,11 +278,11 @@ bool CPVRTimers::UpdateFromClient(const CPVRTimerInfoTagPtr &timer)
   {
     tag = CPVRTimerInfoTagPtr(new CPVRTimerInfoTag());
     VecTimerInfoTag* addEntry = NULL;
-    MapTags::iterator itr = m_tags.find(timer->StartAsUTC());
+    MapTags::iterator itr = m_tags.find(timer->m_bStartAnyTime ? CDateTime() : timer->StartAsUTC());
     if (itr == m_tags.end())
     {
       addEntry = new VecTimerInfoTag;
-      m_tags.insert(std::make_pair(timer->StartAsUTC(), addEntry));
+      m_tags.insert(std::make_pair(timer->m_bStartAnyTime ? CDateTime() : timer->StartAsUTC(), addEntry));
     }
     else
     {


### PR DESCRIPTION
Regression introduced with https://github.com/xbmc/xbmc/commit/5d8f88cdfcc0b56785b136fcb894a0c9016af532

For timers with start time set to "any time", the startTime value must not be used to organize internal timer data structures as this field has no defined value for those timers.

Result is (for instance with pvr.hts and at least one repeating timer activated which has start and end time set to "any time") reorganizing kodi internal timer data structures every one second and notifying observers, e.g. timer and recording window about "timer reset" changes. 

=> https://github.com/xbmc/xbmc/blob/master/xbmc/pvr/timers/PVRTimers.cpp#L255

Those windows will update itself (redraw item list etc.) upon receive of this notification which is exposed to the end user as "wildly" jumping item selection etc. in timer and recordings pvr window, at worst every 3 second.

https://github.com/xbmc/xbmc/blob/master/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp#L315

@Jalle19 Good to go? This could be done nicer, yeah, but I want to keep changes minimalistic. I promise to come up with a proper refactoring for K*****. ;-)
