### PR TITLE
ffmpeg: Bump to 2.8.3-Jarvis-beta3

### DIFF
--- a/tools/depends/target/ffmpeg/FFMPEG-VERSION
+++ b/tools/depends/target/ffmpeg/FFMPEG-VERSION
@@ -1,5 +1,5 @@
 LIBNAME=ffmpeg
 BASE_URL=https://github.com/xbmc/FFmpeg/archive
-VERSION=2.8.2-Jarvis-beta2
+VERSION=2.8.3-Jarvis-beta3
 ARCHIVE=$(LIBNAME)-$(VERSION).tar.gz
 


### PR DESCRIPTION
This rebases on upstream 2.8.3 stable version. The patches temporarily added by @afedchin are dropped after discussion with master. They will immediately come back when they are going into upstream.
