### PR TITLE
Addon enabled status fix

### DIFF
--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -154,8 +154,6 @@ public:
   AddonProps& Props() { return m_props; }
   const std::string ID() const { return m_props.id; }
   const std::string Name() const { return m_props.name; }
-  /*! This lies. Ask CAddonMgr */
-  bool Enabled() const { return true; }
   virtual bool IsInUse() const { return false; };
   const AddonVersion Version() const { return m_props.version; }
   const AddonVersion MinVersion() const { return m_props.minversion; }

--- a/xbmc/addons/IAddon.h
+++ b/xbmc/addons/IAddon.h
@@ -96,7 +96,6 @@ namespace ADDON
     virtual AddonProps& Props() =0;
     virtual const std::string ID() const =0;
     virtual const std::string Name() const =0;
-    virtual bool Enabled() const =0;
     virtual bool IsInUse() const =0;
     virtual const AddonVersion Version() const =0;
     virtual const AddonVersion MinVersion() const =0;

--- a/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSPProcess.cpp
+++ b/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSPProcess.cpp
@@ -322,7 +322,7 @@ bool CActiveAEDSPProcess::Create(const AEAudioFormat &inputFormat, const AEAudio
       /// For resample only one call is allowed. Use first one and ignore everything else.
       CActiveAEDSPModePtr pMode = listInputResample[i].first;
       AE_DSP_ADDON        addon = listInputResample[i].second;
-      if (addon->Enabled() && addon->SupportsInputResample() && pMode->IsEnabled())
+      if (!CAddonMgr::GetInstance().IsAddonDisabled(addon->ID()) && addon->SupportsInputResample() && pMode->IsEnabled())
       {
         ADDON_HANDLE_STRUCT handle;
         AE_DSP_ERROR err = addon->StreamCreate(&m_addonSettings, &m_addonStreamProperties, &handle);
@@ -374,7 +374,7 @@ bool CActiveAEDSPProcess::Create(const AEAudioFormat &inputFormat, const AEAudio
     {
       AE_DSP_ADDON addon = itr->second;
       int id = addon->GetID();
-      if (addon->Enabled() && id != foundInputResamplerId)
+      if (!CAddonMgr::GetInstance().IsAddonDisabled(addon->ID()) && id != foundInputResamplerId)
       {
         ADDON_HANDLE_STRUCT handle;
         AE_DSP_ERROR err = addon->StreamCreate(&m_addonSettings, &m_addonStreamProperties, &handle);
@@ -415,7 +415,7 @@ bool CActiveAEDSPProcess::Create(const AEAudioFormat &inputFormat, const AEAudio
 
       if (m_usedMap.find(id) == m_usedMap.end())
         continue;
-      if (addon->Enabled() && addon->SupportsPreProcess() && pMode->IsEnabled() &&
+      if (!CAddonMgr::GetInstance().IsAddonDisabled(addon->ID()) && addon->SupportsPreProcess() && pMode->IsEnabled() &&
           addon->StreamIsModeSupported(&m_addon_Handles[id], pMode->ModeType(), pMode->AddonModeNumber(), pMode->ModeID()))
       {
         CLog::Log(LOGDEBUG, "  | - %i - %s (%s)", i, pMode->AddonModeName().c_str(), addon->GetAudioDSPName().c_str());
@@ -445,7 +445,7 @@ bool CActiveAEDSPProcess::Create(const AEAudioFormat &inputFormat, const AEAudio
 
       if (m_usedMap.find(id) == m_usedMap.end())
         continue;
-      if (addon->Enabled() && addon->SupportsMasterProcess() && pMode->IsEnabled() &&
+      if (!CAddonMgr::GetInstance().IsAddonDisabled(addon->ID()) && addon->SupportsMasterProcess() && pMode->IsEnabled() &&
           addon->StreamIsModeSupported(&m_addon_Handles[id], pMode->ModeType(), pMode->AddonModeNumber(), pMode->ModeID()))
       {
         CLog::Log(LOGDEBUG, "  | - %i - %s (%s)", i, pMode->AddonModeName().c_str(), addon->GetAudioDSPName().c_str());
@@ -520,7 +520,7 @@ bool CActiveAEDSPProcess::Create(const AEAudioFormat &inputFormat, const AEAudio
       if (m_usedMap.find(id) == m_usedMap.end())
         continue;
 
-      if (addon->Enabled() && addon->SupportsPostProcess() && pMode->IsEnabled() &&
+      if (!CAddonMgr::GetInstance().IsAddonDisabled(addon->ID()) && addon->SupportsPostProcess() && pMode->IsEnabled() &&
           addon->StreamIsModeSupported(&m_addon_Handles[id], pMode->ModeType(), pMode->AddonModeNumber(), pMode->ModeID()))
       {
         CLog::Log(LOGDEBUG, "  | - %i - %s (%s)", i, pMode->AddonModeName().c_str(), addon->GetAudioDSPName().c_str());
@@ -554,7 +554,7 @@ bool CActiveAEDSPProcess::Create(const AEAudioFormat &inputFormat, const AEAudio
         int                    id = addon->GetID();
 
         if (m_usedMap.find(id) != m_usedMap.end() &&
-            addon->Enabled() && addon->SupportsOutputResample() && pMode->IsEnabled() &&
+            !CAddonMgr::GetInstance().IsAddonDisabled(addon->ID()) && addon->SupportsOutputResample() && pMode->IsEnabled() &&
             addon->StreamIsModeSupported(&m_addon_Handles[id], pMode->ModeType(), pMode->AddonModeNumber(), pMode->ModeID()))
         {
           int outSamplerate = addon->OutputResampleSampleRate(&m_addon_Handles[id]);

--- a/xbmc/settings/dialogs/GUIDialogContentSettings.cpp
+++ b/xbmc/settings/dialogs/GUIDialogContentSettings.cpp
@@ -249,7 +249,7 @@ bool CGUIDialogContentSettings::Show(ADDON::ScraperPtr& scraper, VIDEO::SScanSet
     dialog->SetContent(content != CONTENT_NONE ? content : scraper->Content());
     dialog->SetScraper(scraper);
     // toast selected but disabled scrapers
-    if (!scraper->Enabled())
+    if (CAddonMgr::GetInstance().IsAddonDisabled(scraper->ID()))
       CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, g_localizeStrings.Get(24024), scraper->Name(), 2000, true);
   }
 
@@ -382,7 +382,7 @@ void CGUIDialogContentSettings::SetupView()
   else
   {
     SET_CONTROL_VISIBLE(CONTROL_SCRAPER_LIST_BUTTON);
-    if (m_scraper != NULL && m_scraper->Enabled())
+    if (m_scraper != NULL && !CAddonMgr::GetInstance().IsAddonDisabled(m_scraper->ID()))
     {
       SET_CONTROL_LABEL2(CONTROL_SCRAPER_LIST_BUTTON, m_scraper->Name());
 


### PR DESCRIPTION
I think this bug is there since ages. If we ask and addon with CAddon::Enabled() for his enabled status we always get true as return value!
According to [CAddon.h](https://github.com/xbmc/xbmc/blob/master/xbmc/addons/Addon.h#L157) this method lies ;-)

We should ask CAddonMgr for the right status. I found this bug during a ADSP debugging session.

Currently I have a very minimalistic Kodi installation here. Only AudioDSP is working and I have no scrappers or PVR add-ons installed. Please confirm that all is working. Maybe @FernetMenta, @ksooo or @opdenkamp could test this with PVR. I also heared that @tamland worked on AddonManager. Maybe you could also help.

~~The addon status calls in [ActiveAEDSP.cpp](https://github.com/xbmc/xbmc/blob/master/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSP.cpp) will be handled in https://github.com/xbmc/xbmc/pull/8456.~~

According to what I said at DevCon 2015 in Prague I want to quote this:
If you merge this PR "…random fucking shit…"¹ can happen.
¹Team Kodi DevCon 2015 in Prague at the Church Bell Tower, Keith Harrington

**Edit**:
All Enabled status requests are handled in this PR.
