### PR TITLE
[adsp] Only start AudioDSP if it is requested

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1189,7 +1189,6 @@ bool CApplication::Initialize()
       uiInitializationFinished = firstWindow != WINDOW_STARTUP_ANIM;
 
       CStereoscopicsManager::GetInstance().Initialize();
-      CApplicationMessenger::GetInstance().SendMsg(TMSG_SETAUDIODSPSTATE, ACTIVE_AE_DSP_STATE_ON, ACTIVE_AE_DSP_SYNC_ACTIVATE); // send a blocking message to active AudioDSP engine
     }
 
   }


### PR DESCRIPTION
@AlwinEsch
I found this issue during our debugging session. Is it really needed to start AudioDSP even if it is not used?
Currently this PR is here to remind us and needs more tests.
