### PR TITLE
[AE] Fix create AE stream with invalid data format

### DIFF
--- a/xbmc/cores/AudioEngine/AEFactory.cpp
+++ b/xbmc/cores/AudioEngine/AEFactory.cpp
@@ -273,6 +273,11 @@ void CAEFactory::Shutdown()
 IAEStream *CAEFactory::MakeStream(enum AEDataFormat dataFormat, unsigned int sampleRate, 
   unsigned int encodedSampleRate, CAEChannelInfo channelLayout, unsigned int options)
 {
+  if (dataFormat == AE_FMT_INVALID || dataFormat == AE_FMT_MAX)
+  {
+    return NULL;
+  }
+
   if(AE)
     return AE->MakeStream(dataFormat, sampleRate, encodedSampleRate, channelLayout, options);
 


### PR DESCRIPTION
If we create a audio stream with AE_FMT_INVALID or AE_FMT_MAX we receive a "valid" IAEStream object!

@Fritsch, @FernetMenta or @AlwinEsch 
Where is the best place to check this values? In CAEFactory or directly in CActiveAE?
