### PR TITLE
[skin.confluence] Fix main menu player controls

### DIFF
--- a/addons/skin.confluence/720p/Home.xml
+++ b/addons/skin.confluence/720p/Home.xml
@@ -685,7 +685,8 @@
 						<onup>9003</onup>
 						<ondown>9000</ondown>
 						<onclick>ActivateWindow(PVRRadioRDSInfo)</onclick>
-						<visible>RDS.HasRadiotextPlus</visible>
+						<enable>RDS.HasRadiotextPlus</enable>
+						<animation effect="fade" start="100" end="30" time="75" condition="!RDS.HasRadiotextPlus">Conditional</animation>
 					</control>
 					<control type="button" id="606">
 						<left>160</left>


### PR DESCRIPTION
when playing live TV.
Instead of hiding the 'PVR Radio RDS Info' button when it's not enabled we now fade it in the same way as the 'Play/Pause' button.

Before -

![screenshot002](https://cloud.githubusercontent.com/assets/133808/11478449/fbc46a72-9784-11e5-93a6-6e4e361b5669.png)

After -

![screenshot003](https://cloud.githubusercontent.com/assets/133808/11478455/0374895a-9785-11e5-85fe-8ac37373a74e.png)

As reported on the forums -
http://forum.kodi.tv/showthread.php?tid=249798

@ronie @MartijnKaijser 
