### PR TITLE
[events] fix removal of events (fixes #16403)

### DIFF
--- a/xbmc/events/EventLog.cpp
+++ b/xbmc/events/EventLog.cpp
@@ -173,18 +173,10 @@ void CEventLog::AddWithNotification(const EventPtr& eventPtr, bool withSound)
 
 void CEventLog::Remove(const EventPtr& eventPtr)
 {
-  if (eventPtr == nullptr || eventPtr->GetIdentifier().empty())
+  if (eventPtr == nullptr)
     return;
 
-  CSingleLock lock(m_critical);
-  const auto& itEvent = m_eventsMap.find(eventPtr->GetIdentifier());
-  if (itEvent == m_eventsMap.end())
-    return;
-
-  m_eventsMap.erase(itEvent);
-  std::remove_if(m_events.begin(), m_events.end(), [eventPtr](const EventPtr& otherEvent) { return eventPtr == otherEvent; });
-
-  SendMessage(eventPtr, GUI_MSG_EVENT_REMOVED);
+  Remove(eventPtr->GetIdentifier());
 }
 
 void CEventLog::Remove(const std::string& eventPtrIdentifier)
@@ -199,7 +191,7 @@ void CEventLog::Remove(const std::string& eventPtrIdentifier)
 
   EventPtr eventPtr = itEvent->second;
   m_eventsMap.erase(itEvent);
-  std::remove_if(m_events.begin(), m_events.end(), [eventPtr](const EventPtr& otherEvent) { return eventPtr == otherEvent; });
+  m_events.erase(std::remove(m_events.begin(), m_events.end(), eventPtr), m_events.end());
 
   SendMessage(eventPtr, GUI_MSG_EVENT_REMOVED);
 }


### PR DESCRIPTION
This should fix the crash when trying to clear the event log or delete a single event through the context menu. A classic case of using `std::remove_if()` without `erase()`.
