### PR TITLE
[addons] add support for pre-gzipped addons.xml in repositories

### DIFF
--- a/addons/repository.xbmc.org/addon.xml
+++ b/addons/repository.xbmc.org/addon.xml
@@ -9,8 +9,8 @@
 	<extension point="xbmc.addon.repository"
 		name="Official XBMC.org Add-on Repository">
 		<dir minversion="15.9.0">
-			<info compressed="true">http://mirrors.kodi.tv/addons/jarvis/addons.xml</info>
-			<checksum>http://mirrors.kodi.tv/addons/jarvis/addons.xml.md5</checksum>
+			<info>http://mirrors.kodi.tv/addons/jarvis/addons.xml.gz</info>
+			<checksum>http://mirrors.kodi.tv/addons/jarvis/addons.xml.gz.md5</checksum>
 			<datadir zip="true">http://mirrors.kodi.tv/addons/jarvis</datadir>
 			<hashes>true</hashes>
 		</dir>

--- a/xbmc/addons/Repository.h
+++ b/xbmc/addons/Repository.h
@@ -59,6 +59,8 @@ namespace ADDON
 
   private:
     CRepository(const CRepository &rhs);
+
+    static bool FetchIndex(const std::string& url, VECADDONS& addons);
   };
 
   typedef std::shared_ptr<CRepository> RepositoryPtr;

--- a/xbmc/filesystem/ZipFile.h
+++ b/xbmc/filesystem/ZipFile.h
@@ -44,7 +44,12 @@ namespace XFILE
     virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
     virtual void Close();
 
+    //NOTE: gzip doesn't work. use DecompressGzip() instead
     int UnpackFromMemory(std::string& strDest, const std::string& strInput, bool isGZ=false);
+
+    /*! Decompress gzip encoded buffer in-memory */
+    static bool DecompressGzip(const std::string& in, std::string& out);
+
   private:
     bool InitDecompress();
     bool FillBuffer();


### PR DESCRIPTION
As discussed in forums and irc/slack this allows us to gzip addons.xml on mirrors.

With the current addons.xml it saves us ~70% bandwidth compared uncompressed.
