### PR TITLE
Fix DPMS detection for X11 without GLX

### DIFF
--- a/xbmc/powermanagement/DPMSSupport.cpp
+++ b/xbmc/powermanagement/DPMSSupport.cpp
@@ -103,7 +103,7 @@ bool DPMSSupport::DisablePowerSaving()
 
 ///////// Platform-specific support
 
-#if defined(HAS_GLX)
+#if defined(HAVE_X11)
 //// X Windows
 
 // Here's a sad story: our Windows-inspired BOOL type from linux/PlatformDefs.h


### PR DESCRIPTION
There is completely invalid ifdef, because code does not depend on GLX but depends on X11.
Many ARM devices with proprietary video drivers do not have GLX but instead use EGL. There is no reason to leave these devices without DPMS
