### PR TITLE
Fix missing disc number from music file view

### DIFF
--- a/xbmc/music/tags/MusicInfoTag.cpp
+++ b/xbmc/music/tags/MusicInfoTag.cpp
@@ -672,7 +672,7 @@ void CMusicInfoTag::SetSong(const CSong& song)
   SYSTEMTIME stTime;
   stTime.wYear = song.iYear;
   SetReleaseDate(stTime);
-  SetTrackNumber(song.iTrack);
+  SetTrackAndDiscNumber(song.iTrack);
   SetDuration(song.iDuration);
   SetMood(song.strMood);
   SetCompilation(song.bCompilation);


### PR DESCRIPTION
@scott967 spotted that disc number was not displayed in file view when  musicfiles.trackformat set to  [%S/%N ]%A - %T, and the first bracket was missing too. This was because disc number was not being set in `CMusicIfoTag.SetSong`.

CSong.iTrack holds both track and disc number, but when #8012 changed to using setters rather than value directly only track number was set.
