### PR TITLE
[Confluence] - fix navigation for SideBar NowPlaying controls

### DIFF
--- a/addons/skin.confluence/720p/includes.xml
+++ b/addons/skin.confluence/720p/includes.xml
@@ -808,164 +808,45 @@
 			<description>Fake Button to fix Player Controls Navigation</description>
 			<visible>false</visible>
 		</control>
-		<control type="group" id="9006">
-			<width>250</width>
+		<control type="group" id="90060">
 			<height>45</height>
 			<visible>VideoPlayer.Content(LiveTV)</visible>
 			<include>VisibleFadeEffect</include>
-			<control type="button" id="600">
-				<left>5</left>
-				<top>2</top>
-				<width>39</width>
-				<height>39</height>
-				<label>-</label>
-				<texturefocus>OSDChannelUPFO.png</texturefocus>
-				<texturenofocus>OSDChannelUPNF.png</texturenofocus>
-				<onleft>50</onleft>
-				<onright>601</onright>
-				<onup>610</onup>
-				<ondown>611</ondown>
-				<onclick>ChannelDown</onclick>
-			</control>
-			<control type="button" id="601">
-				<left>45</left>
-				<top>2</top>
-				<width>39</width>
-				<height>39</height>
-				<label>-</label>
-				<texturefocus>OSDChannelDownFO.png</texturefocus>
-				<texturenofocus>OSDChannelDownNF.png</texturenofocus>
-				<onleft>600</onleft>
-				<onright>603</onright>
-				<onup>610</onup>
-				<ondown>611</ondown>
-				<onclick>ChannelUp</onclick>
-			</control>
-			<control type="button" id="603">
-				<left>85</left>
-				<top>2</top>
-				<width>39</width>
-				<height>39</height>
-				<label>-</label>
-				<texturefocus>OSDStopFO.png</texturefocus>
-				<texturenofocus>OSDStopNF.png</texturenofocus>
-				<onleft>601</onleft>
-				<onright>604</onright>
-				<onup>610</onup>
-				<ondown>611</ondown>
-				<onclick>down</onclick>
-				<onclick>PlayerControl(Stop)</onclick>
-			</control>
-			<control type="togglebutton" id="604">
-				<left>125</left>
-				<top>2</top>
-				<width>39</width>
-				<height>39</height>
-				<label>-</label>
-				<texturefocus>OSDPauseFO.png</texturefocus>
-				<texturenofocus>OSDPauseNF.png</texturenofocus>
-				<usealttexture>Player.Paused | Player.Forwarding | Player.Rewinding</usealttexture>
-				<alttexturefocus>OSDPlayFO.png</alttexturefocus>
-				<alttexturenofocus>OSDPlayNF.png</alttexturenofocus>
-				<onleft>603</onleft>
-				<onright>605</onright>
-				<onup>610</onup>
-				<ondown>606</ondown>
-				<onback>50</onback>
-				<onclick>PlayerControl(Play)</onclick>
-				<enable>Player.PauseEnabled</enable>
-				<animation effect="fade" start="100" end="30" time="75" condition="!Player.PauseEnabled">Conditional</animation>
-			</control>
-			<control type="button" id="605">
-				<left>165</left>
-				<top>2</top>
-				<width>39</width>
-				<height>39</height>
-				<label>-</label>
-				<texturefocus>OSDRecordOffFO.png</texturefocus>
-				<texturenofocus>OSDRecordOffNF.png</texturenofocus>
-				<onleft>604</onleft>
-				<onright>606</onright>
-				<onup>610</onup>
-				<ondown>611</ondown>
-				<onclick>PlayerControl(record)</onclick>
-				<enable>Player.CanRecord</enable>
-				<animation effect="fade" start="100" end="30" time="75" condition="!Player.CanRecord">Conditional</animation>
-			</control>
-			<control type="button" id="606">
-				<left>205</left>
-				<top>2</top>
-				<width>39</width>
-				<height>39</height>
-				<label>-</label>
-				<visible>RDS.HasRadiotextPlus</visible>
-				<texturefocus>OSDRadioRDSFO.png</texturefocus>
-				<texturenofocus>OSDRadioRDSNF.png</texturenofocus>
-				<onleft>605</onleft>
+			<control type="grouplist" id="9006">
+				<width>250</width>
+				<height>45</height>
+				<itemgap>1</itemgap>
+				<orientation>horizontal</orientation>
 				<onright>50</onright>
-				<onup>610</onup>
-				<ondown>611</ondown>
-				<onclick>ActivateWindow(PVRRadioRDSInfo)</onclick>
-			</control>
-			<control type="button" id="606">
-				<left>205</left>
-				<top>2</top>
-				<width>39</width>
-				<height>39</height>
-				<label>-</label>
-				<visible>!RDS.HasRadiotextPlus</visible>
-				<texturefocus>OSDChannelListFO.png</texturefocus>
-				<texturenofocus>OSDChannelListNF.png</texturenofocus>
-				<onleft>605</onleft>
-				<onright>50</onright>
-				<onup>610</onup>
-				<ondown>611</ondown>
-				<onclick>ActivateWindow(PVRGuideInfo)</onclick>
-			</control>
-		</control>
-		<control type="group" id="9005">
-			<visible>Player.HasMedia</visible>
-			<visible>!VideoPlayer.Content(LiveTV)</visible>
-			<include>VisibleFadeEffect</include>
-			<width>250</width>
-			<height>45</height>
-			<defaultcontrol always="true">603</defaultcontrol>
-			<control type="button" id="600">
-				<left>5</left>
-				<top>2</top>
-				<width>39</width>
-				<height>39</height>
-				<label>-</label>
-				<texturefocus>OSDPrevTrackFO.png</texturefocus>
-				<texturenofocus>OSDPrevTrackNF.png</texturenofocus>
-				<onleft>50</onleft>
-				<onright>606</onright>
-				<onup>610</onup>
-				<ondown>611</ondown>
 				<onback>50</onback>
-				<onclick>PlayerControl(Previous)</onclick>
-			</control>
-			<control type="button" id="606">
-				<left>45</left>
-				<top>2</top>
-				<width>39</width>
-				<height>39</height>
-				<label>-</label>
-				<texturefocus>OSDRewindFO.png</texturefocus>
-				<texturenofocus>OSDRewindNF.png</texturenofocus>
-				<onleft>600</onleft>
-				<onright>603</onright>
 				<onup>610</onup>
 				<ondown>611</ondown>
-				<onback>50</onback>
-				<onclick>PlayerControl(Rewind)</onclick>
-				<visible>Window.IsVisible(MusicPlaylist) | Window.IsVisible(VideoPlaylist) | Player.HasVideo</visible>
-			</control>
-			<control type="group">
-				<animation effect="slide" start="0,0" end="40,0" time="0" condition="Window.IsVisible(MusicPlaylist) | Window.IsVisible(VideoPlaylist) | Player.HasVideo">Conditional</animation>
-				<control type="togglebutton" id="603">
-					<left>45</left>
-					<top>2</top>
+				<control type="button" id="600">
+					<width>39</width>
+					<height>39</height>
+					<label>-</label>
+					<texturefocus>OSDChannelUPFO.png</texturefocus>
+					<texturenofocus>OSDChannelUPNF.png</texturenofocus>
+					<onclick>ChannelDown</onclick>
+				</control>
+				<control type="button" id="601">
+					<width>39</width>
+					<height>39</height>
+					<label>-</label>
+					<texturefocus>OSDChannelDownFO.png</texturefocus>
+					<texturenofocus>OSDChannelDownNF.png</texturenofocus>
+					<onclick>ChannelUp</onclick>
+				</control>
+				<control type="button" id="603">
+					<width>39</width>
+					<height>39</height>
+					<label>-</label>
+					<texturefocus>OSDStopFO.png</texturefocus>
+					<texturenofocus>OSDStopNF.png</texturenofocus>
+					<onclick>down</onclick>
+					<onclick>PlayerControl(Stop)</onclick>
+				</control>
+				<control type="togglebutton" id="604">
 					<width>39</width>
 					<height>39</height>
 					<label>-</label>
@@ -974,89 +855,125 @@
 					<usealttexture>Player.Paused | Player.Forwarding | Player.Rewinding</usealttexture>
 					<alttexturefocus>OSDPlayFO.png</alttexturefocus>
 					<alttexturenofocus>OSDPlayNF.png</alttexturenofocus>
-					<onleft>606</onleft>
-					<onright>601</onright>
-					<onup>610</onup>
-					<ondown>611</ondown>
-					<onback>50</onback>
+					<onclick>PlayerControl(Play)</onclick>
+					<enable>Player.PauseEnabled</enable>
+					<animation effect="fade" start="100" end="30" time="75" condition="!Player.PauseEnabled">Conditional</animation>
+				</control>
+				<control type="button" id="605">
+					<width>39</width>
+					<height>39</height>
+					<label>-</label>
+					<texturefocus>OSDRecordOffFO.png</texturefocus>
+					<texturenofocus>OSDRecordOffNF.png</texturenofocus>
+					<onclick>PlayerControl(record)</onclick>
+					<enable>Player.CanRecord</enable>
+					<animation effect="fade" start="100" end="30" time="75" condition="!Player.CanRecord">Conditional</animation>
+				</control>
+				<control type="button" id="606">
+					<width>39</width>
+					<height>39</height>
+					<label>-</label>
+					<visible>RDS.HasRadiotextPlus</visible>
+					<texturefocus>OSDRadioRDSFO.png</texturefocus>
+					<texturenofocus>OSDRadioRDSNF.png</texturenofocus>
+					<onclick>ActivateWindow(PVRRadioRDSInfo)</onclick>
+				</control>
+				<control type="button" id="622">
+					<width>39</width>
+					<height>39</height>
+					<label>-</label>
+					<visible>!RDS.HasRadiotextPlus</visible>
+					<texturefocus>OSDChannelListFO.png</texturefocus>
+					<texturenofocus>OSDChannelListNF.png</texturenofocus>
+					<onclick>ActivateWindow(PVRGuideInfo)</onclick>
+				</control>
+			</control>
+		</control>
+		<control type="group" id="90050">
+			<visible>Player.HasMedia</visible>
+			<visible>!VideoPlayer.Content(LiveTV)</visible>
+			<include>VisibleFadeEffect</include>
+			<height>45</height>
+			<control type="grouplist" id="9005">
+				<width>250</width>
+				<height>45</height>
+				<itemgap>1</itemgap>
+				<orientation>horizontal</orientation>
+				<onright>50</onright>
+				<onback>50</onback>
+				<onup>610</onup>
+				<ondown>611</ondown>
+				<defaultcontrol always="true">603</defaultcontrol>
+				<control type="button" id="700">
+					<width>39</width>
+					<height>39</height>
+					<label>-</label>
+					<texturefocus>OSDPrevTrackFO.png</texturefocus>
+					<texturenofocus>OSDPrevTrackNF.png</texturenofocus>
+					<onclick>PlayerControl(Previous)</onclick>
+				</control>
+				<control type="button" id="706">
+					<width>39</width>
+					<height>39</height>
+					<label>-</label>
+					<texturefocus>OSDRewindFO.png</texturefocus>
+					<texturenofocus>OSDRewindNF.png</texturenofocus>
+					<onclick>PlayerControl(Rewind)</onclick>
+					<visible>Window.IsVisible(MusicPlaylist) | Window.IsVisible(VideoPlaylist) | Player.HasVideo</visible>
+				</control>
+				<control type="togglebutton" id="703">
+					<width>39</width>
+					<height>39</height>
+					<label>-</label>
+					<texturefocus>OSDPauseFO.png</texturefocus>
+					<texturenofocus>OSDPauseNF.png</texturenofocus>
+					<usealttexture>Player.Paused | Player.Forwarding | Player.Rewinding</usealttexture>
+					<alttexturefocus>OSDPlayFO.png</alttexturefocus>
+					<alttexturenofocus>OSDPlayNF.png</alttexturenofocus>
 					<onclick>PlayerControl(Play)</onclick>
 				</control>
-				<control type="button" id="601">
-					<left>85</left>
-					<top>2</top>
+				<control type="button" id="701">
 					<width>39</width>
 					<height>39</height>
 					<label>-</label>
 					<texturefocus>OSDStopFO.png</texturefocus>
 					<texturenofocus>OSDStopNF.png</texturenofocus>
-					<onleft>603</onleft>
-					<onright>607</onright>
-					<onup>610</onup>
-					<ondown>611</ondown>
-					<onback>50</onback>
 					<onclick>down</onclick>
 					<onclick>PlayerControl(Stop)</onclick>
 				</control>
-				<control type="button" id="607">
-					<left>125</left>
-					<top>2</top>
+				<control type="button" id="707">
 					<width>39</width>
 					<height>39</height>
 					<label>-</label>
 					<texturefocus>OSDForwardFO.png</texturefocus>
 					<texturenofocus>OSDForwardNF.png</texturenofocus>
-					<onleft>601</onleft>
-					<onright>602</onright>
-					<onup>610</onup>
-					<ondown>611</ondown>
-					<onback>50</onback>
 					<onclick>PlayerControl(Forward)</onclick>
 					<visible>Window.IsVisible(MusicPlaylist) | Window.IsVisible(VideoPlaylist) | Player.HasVideo</visible>
 				</control>
-				<control type="button" id="602">
-					<left>125</left>
-					<top>2</top>
+				<control type="button" id="702">
 					<width>39</width>
 					<height>39</height>
 					<label>-</label>
 					<texturefocus>OSDNextTrackFO.png</texturefocus>
 					<texturenofocus>OSDNextTrackNF.png</texturenofocus>
-					<onleft>607</onleft>
-					<onright>604</onright>
-					<onup>610</onup>
-					<ondown>611</ondown>
-					<onback>50</onback>
 					<onclick>PlayerControl(Next)</onclick>
-					<animation effect="slide" start="0,0" end="40,0" time="0" condition="Window.IsVisible(MusicPlaylist) | Window.IsVisible(VideoPlaylist) | Player.HasVideo">Conditional</animation>
 				</control>
-			</control>
-			<control type="group">
-				<visible>!Window.IsVisible(MusicPlaylist) + !Window.IsVisible(VideoPlaylist) + !Player.HasVideo</visible>
-				<control type="button" id="604">
-					<left>165</left>
-					<top>2</top>
+				<control type="button" id="704">
 					<width>39</width>
 					<height>39</height>
 					<label>-</label>
 					<texturefocus>-</texturefocus>
 					<texturenofocus>-</texturenofocus>
 					<onclick>PlayerControl(Repeat)</onclick>
-					<onleft>602</onleft>
-					<onright>605</onright>
-					<onup>610</onup>
-					<ondown>611</ondown>
-					<onback>50</onback>
+					<visible>!Window.IsVisible(MusicPlaylist) + !Window.IsVisible(VideoPlaylist) + !Player.HasVideo</visible>
 				</control>
-				<control type="image">
-					<left>165</left>
-					<top>2</top>
+				<control type="image" id="713">
 					<width>39</width>
 					<height>39</height>
 					<texture>$VAR[PlayerControlsRepeatImageVar]</texture>
+					<visible>!Window.IsVisible(MusicPlaylist) + !Window.IsVisible(VideoPlaylist) + !Player.HasVideo</visible>
 				</control>
-				<control type="togglebutton" id="605">
-					<left>205</left>
-					<top>2</top>
+				<control type="togglebutton" id="705">
 					<width>39</width>
 					<height>39</height>
 					<label>-</label>
@@ -1066,11 +983,7 @@
 					<alttexturefocus>OSDRandomOnFO.png</alttexturefocus>
 					<alttexturenofocus>OSDRandomOnNF.png</alttexturenofocus>
 					<onclick>PlayerControl(Random)</onclick>
-					<onleft>604</onleft>
-					<onright>50</onright>
-					<onup>610</onup>
-					<ondown>611</ondown>
-					<onback>50</onback>
+					<visible>!Window.IsVisible(MusicPlaylist) + !Window.IsVisible(VideoPlaylist) + !Player.HasVideo</visible>
 				</control>
 			</control>
 		</control>


### PR DESCRIPTION
Navigation for Sidebar NowPlaying controls was broken (noticeable when pressing right while very right button has focus), probably because of duplicate ids.
Also, < onback > tag was also not consistently applied I think.
I also took that as an opportunity to convert those two control groups (default + PVR) to a grouplist, which should be more error-prone and easier to maintain (less code).
