### PR TITLE
android: fix event source evaluation (no touch events on stylus devices)

### DIFF
--- a/xbmc/android/activity/EventLoop.cpp
+++ b/xbmc/android/activity/EventLoop.cpp
@@ -160,19 +160,12 @@ int32_t CEventLoop::processInput(AInputEvent* event)
       rtn = m_inputHandler->onKeyboardEvent(event);
       break;
     case AINPUT_EVENT_TYPE_MOTION:
-      switch(source)
-      {
-        case AINPUT_SOURCE_TOUCHSCREEN:
-          rtn = m_inputHandler->onTouchEvent(event);
-          break;
-        case AINPUT_SOURCE_MOUSE:
-          rtn = m_inputHandler->onMouseEvent(event);
-          break;
-        case AINPUT_SOURCE_GAMEPAD:
-        case AINPUT_SOURCE_JOYSTICK:
-          rtn = m_inputHandler->onJoyStickMotionEvent(event);
-          break;
-      }
+      if (source & AINPUT_SOURCE_TOUCHSCREEN)
+        rtn = m_inputHandler->onTouchEvent(event);
+      else if (source & AINPUT_SOURCE_MOUSE)
+        rtn = m_inputHandler->onMouseEvent(event);
+      else if (source & (AINPUT_SOURCE_GAMEPAD | AINPUT_SOURCE_JOYSTICK))
+        rtn = m_inputHandler->onJoyStickMotionEvent(event);
       break;
   }
 


### PR DESCRIPTION
When evaluating the source of android input events we need to check the source
parameter flagwise and not absolute. The reason is that e.g. for touch events
the source parameter could be built out of multiple flags.

E.g.: source = AINPUT_SOURCE_TOUCHSCREEN | AINPUT_SOURCE_STYLUS

This ends up that xbmc is not responding to any touch events. Thus e.g. for
stylus enalbed android devices xbmc does not work without this patch.

Change-Id: I3445b9c934426a5373bcaccc5c4b0c43ee0e56d5
Signed-off-by: Danilo Krummrich danilokrummrich@gmail.com
