### PR TITLE
[bugfix] fast startup fail to execute wakeup

### DIFF
--- a/xbmc/network/WakeOnAccess.cpp
+++ b/xbmc/network/WakeOnAccess.cpp
@@ -445,7 +445,7 @@ bool CWakeOnAccess::FindOrTouchHostEntry (const std::string& hostName, WakeUpEnt
     {
       CDateTime now = CDateTime::GetCurrentDateTime();
 
-      if (now > server.nextWake)
+      if (now >= server.nextWake)
       {
         result = server;
         need_wakeup = true;


### PR DESCRIPTION
Initial wakeup could be skipped if Kodi boots fast and MySQL is attempted within the same second that WakeOnAccess was initialized.
ref http://forum.kodi.tv/showthread.php?tid=124340&pid=2177215#pid2177215
