### PR TITLE
fix saving of skin settings when switching profiles

### DIFF
--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -377,7 +377,7 @@ public:
 
   ReplayGainSettings& GetReplayGainSettings() { return m_replayGainSettings; }
 
-  void SetLoggingIn(bool loggingIn) { m_loggingIn = loggingIn; }
+  void SetLoggingIn(bool switchingProfiles);
   
   /*!
    \brief Register an action listener.
@@ -413,7 +413,8 @@ protected:
   bool m_skinReverting;
   std::string m_skinReloadSettingIgnore;
 
-  bool m_loggingIn;
+  bool m_saveSkinOnUnloading;
+  bool m_autoExecScriptExecuted;
 
 #if defined(TARGET_DARWIN_IOS)
   friend class CWinEventsIOS;

--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -707,7 +707,7 @@ bool CSkinInfo::SettingsFromXML(const CXBMCTinyXML &doc, bool loadDefaults /* = 
   const TiXmlElement *rootElement = doc.RootElement();
   if (rootElement == nullptr || rootElement->ValueStr().compare(XML_SETTINGS) != 0)
   {
-    CLog::Log(LOGWARNING, "CSkinInfo: no <skinsettings> tag found");
+    CLog::Log(LOGWARNING, "CSkinInfo: no <settings> tag found");
     return false;
   }
 
@@ -736,7 +736,7 @@ void CSkinInfo::SettingsToXML(CXBMCTinyXML &doc) const
   TiXmlNode *settingsNode = doc.InsertEndChild(rootElement);
   if (settingsNode == NULL)
   {
-    CLog::Log(LOGWARNING, "CSkinInfo: could not create <skinsettings> tag");
+    CLog::Log(LOGWARNING, "CSkinInfo: could not create <settings> tag");
     return;
   }
 

--- a/xbmc/profiles/ProfilesManager.cpp
+++ b/xbmc/profiles/ProfilesManager.cpp
@@ -30,6 +30,7 @@
 #include "GUIInfoManager.h"
 #include "PasswordManager.h"
 #include "Util.h"
+#include "addons/Skin.h"
 #include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogYesNo.h"
 #include "filesystem/Directory.h"
@@ -236,6 +237,10 @@ bool CProfilesManager::LoadProfile(size_t index)
   // check if the profile is already active
   if (m_currentProfile == index)
     return true;
+
+  // save any settings of the currently used skin
+  if (g_SkinInfo != nullptr)
+    g_SkinInfo->SaveSettings();
 
   // unload any old settings
   CSettings::GetInstance().Unload();

--- a/xbmc/windows/GUIWindowLoginScreen.cpp
+++ b/xbmc/windows/GUIWindowLoginScreen.cpp
@@ -310,6 +310,9 @@ void CGUIWindowLoginScreen::LoadProfile(unsigned int profile)
   // reload the add-ons, or we will first load all add-ons from the master account without checking disabled status
   ADDON::CAddonMgr::GetInstance().ReInit();
 
+  // let CApplication know that we are logging into a new profile
+  g_application.SetLoggingIn(true);
+
   if (!g_application.LoadLanguage(true))
   {
     CLog::Log(LOGFATAL, "CGUIWindowLoginScreen: unable to load language for profile \"%s\"", CProfilesManager::GetInstance().GetCurrentProfile().getName().c_str());
@@ -317,7 +320,6 @@ void CGUIWindowLoginScreen::LoadProfile(unsigned int profile)
   }
 
   g_weatherManager.Refresh();
-  g_application.SetLoggingIn(true);
 
 #ifdef HAS_JSONRPC
   JSONRPC::CJSONRPC::Initialize();


### PR DESCRIPTION
I had a few minutes to take another stab at the issue that skin settings are saved in the wrong profile when switching profiles (see http://trac.kodi.tv/ticket/16203). I haven't had the time to test all use cases (normally switching skins, switching skins but aborting, switching profiles with same skin, switching profiles with different skins, ...) but from a few quick tests it looked better than it is right now.

I've split the existing `m_loggingIn` flag in `CApplication` into two variables, one called `m_autoExecScriptExecuted` which is what `m_loggingIn` has been used for up until now and a new `m_saveSkinOnUnloading` to handle the problem at hand.

I'm not 100% happy with the approach because I couldn't find a good place to reset the flag that decides whether a skin's settings should be saved in `CApplication::UnloadSkin()`. I tried to reset it when the `GUI_MSG_UI_READY` has been sent but depending on timing it didn't work out all the time.
