### PR TITLE
Player.GetItem return art when play from JSON same as GUI

### DIFF
--- a/xbmc/interfaces/json-rpc/PlayerOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlayerOperations.cpp
@@ -35,6 +35,7 @@
 #include "GUIInfoManager.h"
 #include "epg/EpgInfoTag.h"
 #include "music/MusicDatabase.h"
+#include "music/MusicThumbLoader.h"
 #include "pvr/PVRManager.h"
 #include "pvr/channels/PVRChannel.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
@@ -196,6 +197,11 @@ JSONRPC_STATUS CPlayerOperations::GetItem(const std::string &method, ITransportL
             fileItem->SetFromMusicInfoTag(*currentMusicTag);
             if (fileItem->GetLabel().empty())
               fileItem->SetLabel(originalLabel);
+            if (!fileItem->HasArt("thumb"))
+            {
+              CMusicThumbLoader loader;
+              loader.LoadItem(fileItem.get());
+            }
           }
           fileItem->SetPath(g_application.CurrentFileItem().GetPath());
         }


### PR DESCRIPTION
There has been a long standing issue that when playback of  non-library music files is started from JSON, subsequent calls to GetItem do not return the same art work as would be retruned when playback is started from GUI.

This is a simple fix to this issue. It has been discussed elsewhere that a redesign of how playback is started could be a better solution, giving one code path  rather than the 3 or 4 different routes with each loading meta-data in different ways. Unfortunately  I am not in a position to undertake such an endevour at this time, but having at least understood how the current mess could be modified to work more consistently I thought it useful to implement a simple "sticking plaster" fix immediately.

Non-library files do not have fan art, but during playback either embedded cover art or a folder.jpg image in the parent folder is displayed if it exists. The same is displayed by the GUI when in file view.  In both cases it is `CGUIInfoManager::SetCurrentSong` that calls the thumb loader to set this for the FileItem, so it is the GUI code not the playback code path that sets this value. When playback started by JSON this fix causes replicates the way art is set by GUIInfoManager.

This could be back-ported to Jarvis, giving users of remote apps or web interface some more consistent behaviour when playing music, but I guess it as waited this long maybe it doesn't matter?

@Montellese sorry not the redesign of playback you would like. @Tolriq for JSON useage, and @Razzeee.
