### PR TITLE
Disable ratings button for plugins

### DIFF
--- a/addons/skin.confluence/720p/DialogVideoInfo.xml
+++ b/addons/skin.confluence/720p/DialogVideoInfo.xml
@@ -1011,6 +1011,7 @@
 						<description>Set my rating</description>
 						<include>ButtonInfoDialogsCommonValues</include>
 						<label>38023</label>
+						<visible>Control.IsEnabled(7)</visible>
 					</control>
 				</control>
 			</control>

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -229,6 +229,8 @@ void CGUIDialogVideoInfo::OnInitWindow()
 
   CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_REFRESH, (CProfilesManager::GetInstance().GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser) && !StringUtils::StartsWithNoCase(m_movieItem->GetVideoInfoTag()->m_strIMDBNumber, "xx"));
   CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_GET_THUMB, (CProfilesManager::GetInstance().GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser) && !StringUtils::StartsWithNoCase(m_movieItem->GetVideoInfoTag()->m_strIMDBNumber.c_str() + 2, "plugin"));
+  // Disable video user rating button for plugins as they don't have tables to save this
+  CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_USERRATING, !m_movieItem->IsPlugin());
 
   VIDEODB_CONTENT_TYPE type = (VIDEODB_CONTENT_TYPE)m_movieItem->GetVideoContentType();
   if (type == VIDEODB_CONTENT_TVSHOWS || type == VIDEODB_CONTENT_MOVIES)


### PR DESCRIPTION
This disables (and then hides) the "Set my rating" buttons for plugins, as they can't handle it.

We also need to come up with a way of disabling it for seasons, but I haven't found anything that works so far.
