### PR TITLE
update guilib api to 5.10.0

### DIFF
--- a/addons/library.kodi.guilib/libKODI_guilib.h
+++ b/addons/library.kodi.guilib/libKODI_guilib.h
@@ -36,10 +36,10 @@ typedef void* GUIHANDLE;
 #endif
 
 /* current ADDONGUI API version */
-#define KODI_GUILIB_API_VERSION "5.8.0"
+#define KODI_GUILIB_API_VERSION "5.10.0"
 
 /* min. ADDONGUI API version */
-#define KODI_GUILIB_MIN_API_VERSION "5.8.0"
+#define KODI_GUILIB_MIN_API_VERSION "5.10.0"
 
 #define ADDON_ACTION_PREVIOUS_MENU          10
 #define ADDON_ACTION_CLOSE_DIALOG           51


### PR DESCRIPTION
xbmc.gui api is at 5.10.0, looks like we forgot to update it here as well.
