### PR TITLE
[configure] make sure the top kodi src dir is always in INCLUDES

### DIFF
--- a/Makefile.include.in
+++ b/Makefile.include.in
@@ -37,6 +37,7 @@ CFLAGS+=@CFLAGS@
 CFLAGS_FOR_BUILD+=@CFLAGS_FOR_BUILD@
 LDFLAGS+=@LDFLAGS@
 LDFLAGS_FOR_BUILD+=@LDFLAGS_FOR_BUILD@
+INCLUDES+=-I@abs_top_srcdir@
 INCLUDES+=-I@abs_top_srcdir@/lib
 INCLUDES+=-I@abs_top_srcdir@/xbmc
 INCLUDES+=-I@abs_top_srcdir@/xbmc/addons/include

--- a/configure.ac
+++ b/configure.ac
@@ -911,9 +911,6 @@ AC_CHECK_TYPES([char16_t, char32_t])
 AC_CHECK_SIZEOF([wchar_t])
 AC_LANG_POP([C++])
 
-# Add top source directory for all builds so we can use config.h
-INCLUDES="-I\$(abs_top_srcdir) $INCLUDES" 
-
 # Check inotify availability
 AC_CHECK_HEADER([sys/inotify.h], AC_DEFINE([HAVE_INOTIFY],[1],[Define if we have inotify]),)
 


### PR DESCRIPTION
on some linux distros the make sort function seems to remove $(abs_top_srcdir), leading to compile errors.
