### PR TITLE
add defaultcontrol support to grouplists

### DIFF
--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -1136,6 +1136,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
 
       control = new CGUIControlGroupList(
         parentID, id, posX, posY, width, height, buttonGap, pageControl, orientation, useControlCoords, labelInfo.align, scroller);
+      ((CGUIControlGroup *)control)->SetDefaultControl(defaultControl, defaultAlways);
       ((CGUIControlGroup *)control)->SetRenderFocusedLast(renderFocusedLast);
       ((CGUIControlGroupList *)control)->SetMinSize(minWidth, minHeight);
     }


### PR DESCRIPTION
allow skins to define a default control inside a grouplist.

this was already available for group controls and containers, just not for grouplists.
