### PR TITLE
VideoPlayer: realtime streams do require special treatment, audio mus…

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
@@ -92,6 +92,7 @@ public:
     disabled = false;
     changes = 0;
     flags = FLAG_NONE;
+    realtime = false;
   }
 
   virtual ~CDemuxStream()
@@ -117,6 +118,7 @@ public:
   int level;   // encoder level of the stream reported by the decoder. used to qualify hw decoders.
   StreamType type;
   int source;
+  bool realtime;
 
   int iDuration; // in mseconds
   void* pPrivate; // private pointer for the demuxer

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1300,6 +1300,7 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int iId)
     stream->codec_fourcc = pStream->codec->codec_tag;
     stream->profile = pStream->codec->profile;
     stream->level   = pStream->codec->level;
+    stream->realtime = m_pInput->IsRealtime();
 
     stream->source = STREAM_SOURCE_DEMUX;
     stream->pPrivate = pStream;

--- a/xbmc/cores/VideoPlayer/DVDStreamInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDStreamInfo.cpp
@@ -39,6 +39,7 @@ void CDVDStreamInfo::Clear()
 {
   codec = AV_CODEC_ID_NONE;
   type = STREAM_NONE;
+  realtime = false;
   software = false;
   codec_tag  = 0;
   flags = 0;
@@ -80,6 +81,7 @@ bool CDVDStreamInfo::Equal(const CDVDStreamInfo& right, bool withextradata)
 {
   if( codec     != right.codec
   ||  type      != right.type
+  ||  realtime  != right.realtime
   ||  codec_tag != right.codec_tag
   ||  flags     != right.flags
   ||  filename  != right.filename)
@@ -138,6 +140,7 @@ void CDVDStreamInfo::Assign(const CDVDStreamInfo& right, bool withextradata)
 {
   codec = right.codec;
   type = right.type;
+  realtime = right.realtime;
   codec_tag = right.codec_tag;
   flags = right.flags;
   filename = right.filename;
@@ -195,6 +198,7 @@ void CDVDStreamInfo::Assign(const CDemuxStream& right, bool withextradata)
 
   codec = right.codec;
   type = right.type;
+  realtime = right.realtime;
   codec_tag = right.codec_fourcc;
   profile   = right.profile;
   level     = right.level;

--- a/xbmc/cores/VideoPlayer/DVDStreamInfo.h
+++ b/xbmc/cores/VideoPlayer/DVDStreamInfo.h
@@ -50,6 +50,7 @@ public:
 
   AVCodecID codec;
   StreamType type;
+  bool realtime;
   int flags;
   bool software;  //force software decoding
   std::string filename;

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
@@ -125,6 +125,8 @@ bool CVideoPlayerAudio::OpenStream(CDVDStreamInfo &hints)
 {
   CLog::Log(LOGNOTICE, "Finding audio codec for: %i", hints.codec);
   bool allowpassthrough = !CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_USEDISPLAYASCLOCK);
+  if (hints.realtime)
+    allowpassthrough = false;
   CDVDAudioCodec* codec = CDVDFactoryCodec::CreateAudioCodec(hints, allowpassthrough);
   if(!codec)
   {
@@ -174,6 +176,9 @@ void CVideoPlayerAudio::OpenStream(CDVDStreamInfo &hints, CDVDAudioCodec* codec)
   m_setsynctype = SYNC_DISCON;
   if (CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_USEDISPLAYASCLOCK))
     m_setsynctype = SYNC_RESAMPLE;
+  else if (hints.realtime)
+    m_setsynctype = SYNC_RESAMPLE;
+
   m_prevsynctype = -1;
 
   m_prevskipped = false;
@@ -653,6 +658,8 @@ bool CVideoPlayerAudio::SwitchCodecIfNeeded()
 {
   CLog::Log(LOGDEBUG, "CVideoPlayerAudio: Sample rate changed, checking for passthrough");
   bool allowpassthrough = !CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_USEDISPLAYASCLOCK);
+  if (m_streaminfo.realtime)
+    allowpassthrough = false;
   CDVDAudioCodec *codec = CDVDFactoryCodec::CreateAudioCodec(m_streaminfo, allowpassthrough);
   if (!codec || codec->NeedPassthrough() == m_pAudioCodec->NeedPassthrough()) {
     // passthrough state has not changed


### PR DESCRIPTION
…t be capable of accepting speed adjustments

for the time being this disables raw passthrough for realtime streams because they do not allow speed adjustments which is a requirement for those kind of streams to play properly. If s.b. adds the required capabilities to raw audio, we can enable it.
Note that transcoding still works for spdif users. Means that they most likely even notice the change.
