### PR TITLE
Fix Custom Music Node/Playlist Rule Based Queries

### DIFF
--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -3401,7 +3401,10 @@ bool CMusicDatabase::GetArtistsNav(const std::string& strBaseDir, CFileItemList&
     else if (idSong > 0)
       musicUrl.AddOption("songid", idSong);
 
-    musicUrl.AddOption("albumartistsonly", albumArtistsOnly);
+    // Override albumArtistsOnly parameter (usually externally set to SETTING_MUSICLIBRARY_SHOWCOMPILATIONARTISTS)
+    // when local option already present in muscic URL thus allowing it to be an option in custom nodes
+    if (!musicUrl.HasOption("albumartistsonly"))
+      musicUrl.AddOption("albumartistsonly", albumArtistsOnly);
 
     bool result = GetArtistsByWhere(musicUrl.ToString(), filter, items, sortDescription, countOnly);
     CLog::Log(LOGDEBUG,"Time to retrieve artists from dataset = %i", XbmcThreads::SystemClockMillis() - time);

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -758,7 +758,11 @@ std::string CSmartPlaylistRule::FormatWhereClause(const std::string &negate, con
     table = "artistview";
 
     if (m_field == FieldGenre)
-      query = negate + " EXISTS (SELECT DISTINCT song_artist.idArtist FROM song_artist, song_genre, genre WHERE song_artist.idArtist = " + GetField(FieldId, strType) + " AND song_artist.idSong = song_genre.idSong AND song_genre.idGenre = genre.idGenre AND genre.strGenre" + parameter + ")";
+    {
+      query = negate + " (EXISTS (SELECT DISTINCT song_artist.idArtist FROM song_artist, song_genre, genre WHERE song_artist.idArtist = " + GetField(FieldId, strType) + " AND song_artist.idSong = song_genre.idSong AND song_genre.idGenre = genre.idGenre AND genre.strGenre" + parameter + ")";
+      query += " OR ";
+      query += "EXISTS (SELECT DISTINCT album_artist.idArtist FROM album_artist, album_genre, genre WHERE album_artist.idArtist = " + GetField(FieldId, strType) + " AND album_artist.idAlbum = album_genre.idAlbum AND album_genre.idGenre = genre.idGenre AND genre.strGenre" + parameter + "))";
+    }
   }
   else if (strType == "movies")
   {


### PR DESCRIPTION
Fixing a couple of glitches in the way rule based music queries (as used by filter type custom nodes and smart playlists) are constructed.

First is an improvement of when `albumartistonly` flag is present in the musicURL  letting it override the default setting. This means that regardless of the global setting that is being applied to the default nodes, the user can create custom nodes that show either all artists or just the album artists (in combination with other criteria).

The second is a mistake when the node/playlist rule is limiting an "artists" type of list to a genre. The query needs to look at both album_artist/album_genre tables as well as song_artist/song_genre, in the same way that the default nodes do. I tripped over this here http://forum.kodi.tv/showthread.php?tid=235785, now I have the knowledge to fix it.

Say I have songs with "Classical" genre and "Tchaikovsky" in the ALBUMARTIST tag but not ARTIST. before this fix Tchaikovsky would incorrectly appear in a list of artists that has rule "isnot" "Classical", but fail to be listed in one that has rule "is" "Classical" - all up the wrong way!

Would be nice to sqweek this into Jarvis, could that be OK?
@Razzeee, any sign of @evilhamster and maybe @zag2me might like the node stuff.
