### PR TITLE
Prevent taglib from crashing kodi

### DIFF
--- a/xbmc/music/tags/TagLoaderTagLib.cpp
+++ b/xbmc/music/tags/TagLoaderTagLib.cpp
@@ -837,54 +837,61 @@ bool CTagLoaderTagLib::Load(const std::string& strFileName, CMusicInfoTag& tag, 
   TagLib::RIFF::WAV::File *  wavFile = NULL;
   TagLib::RIFF::AIFF::File * aiffFile = NULL;
 
-  if (strExtension == "ape")
-    file = apeFile = new APE::File(stream);
-  else if (strExtension == "asf" || strExtension == "wmv" || strExtension == "wma")
-    file = asfFile = new ASF::File(stream);
-  else if (strExtension == "flac")
-    file = flacFile = new FLAC::File(stream, ID3v2::FrameFactory::instance());
-  else if (strExtension == "it")
-    file = itFile = new IT::File(stream);
-  else if (strExtension == "mod" || strExtension == "module" || strExtension == "nst" || strExtension == "wow")
-    file = modFile = new Mod::File(stream);
-  else if (strExtension == "mp4" || strExtension == "m4a" ||
-           strExtension == "m4r" || strExtension == "m4b" ||
-           strExtension == "m4p" || strExtension == "3g2")
-    file = mp4File = new MP4::File(stream);
-  else if (strExtension == "mpc")
-    file = mpcFile = new MPC::File(stream);
-  else if (strExtension == "mp3" || strExtension == "aac")
-    file = mpegFile = new MPEG::File(stream, ID3v2::FrameFactory::instance());
-  else if (strExtension == "s3m")
-    file = s3mFile = new S3M::File(stream);
-  else if (strExtension == "tta")
-    file = ttaFile = new TrueAudio::File(stream, ID3v2::FrameFactory::instance());
-  else if (strExtension == "wv")
-    file = wvFile = new WavPack::File(stream);
-  else if (strExtension == "aif" || strExtension == "aiff")
-    file = aiffFile = new RIFF::AIFF::File(stream);
-  else if (strExtension == "wav")
-    file = wavFile = new RIFF::WAV::File(stream);
-  else if (strExtension == "xm")
-    file = xmFile = new XM::File(stream);
-  else if (strExtension == "ogg")
-    file = oggVorbisFile = new Ogg::Vorbis::File(stream);
-  else if (strExtension == "oga") // Leave this madness until last - oga container can have Vorbis or FLAC
+  try
   {
-    file = oggFlacFile = new Ogg::FLAC::File(stream);
-    if (!file || !file->isValid())
-    {
-      delete file;
-      oggFlacFile = NULL;
+    if (strExtension == "ape")
+      file = apeFile = new APE::File(stream);
+    else if (strExtension == "asf" || strExtension == "wmv" || strExtension == "wma")
+      file = asfFile = new ASF::File(stream);
+    else if (strExtension == "flac")
+      file = flacFile = new FLAC::File(stream, ID3v2::FrameFactory::instance());
+    else if (strExtension == "it")
+      file = itFile = new IT::File(stream);
+    else if (strExtension == "mod" || strExtension == "module" || strExtension == "nst" || strExtension == "wow")
+      file = modFile = new Mod::File(stream);
+    else if (strExtension == "mp4" || strExtension == "m4a" ||
+             strExtension == "m4r" || strExtension == "m4b" ||
+             strExtension == "m4p" || strExtension == "3g2")
+      file = mp4File = new MP4::File(stream);
+    else if (strExtension == "mpc")
+      file = mpcFile = new MPC::File(stream);
+    else if (strExtension == "mp3" || strExtension == "aac")
+      file = mpegFile = new MPEG::File(stream, ID3v2::FrameFactory::instance());
+    else if (strExtension == "s3m")
+      file = s3mFile = new S3M::File(stream);
+    else if (strExtension == "tta")
+      file = ttaFile = new TrueAudio::File(stream, ID3v2::FrameFactory::instance());
+    else if (strExtension == "wv")
+      file = wvFile = new WavPack::File(stream);
+    else if (strExtension == "aif" || strExtension == "aiff")
+      file = aiffFile = new RIFF::AIFF::File(stream);
+    else if (strExtension == "wav")
+      file = wavFile = new RIFF::WAV::File(stream);
+    else if (strExtension == "xm")
+      file = xmFile = new XM::File(stream);
+    else if (strExtension == "ogg")
       file = oggVorbisFile = new Ogg::Vorbis::File(stream);
+    else if (strExtension == "oga") // Leave this madness until last - oga container can have Vorbis or FLAC
+    {
+      file = oggFlacFile = new Ogg::FLAC::File(stream);
+      if (!file || !file->isValid())
+      {
+        delete file;
+        oggFlacFile = NULL;
+        file = oggVorbisFile = new Ogg::Vorbis::File(stream);
+      }
     }
+  }
+  catch (const std::exception& ex)
+  {
+    CLog::Log(LOGERROR, "Taglib exception: %s", ex.what());
   }
 
   if (!file || !file->isOpen())
   {
     delete file;
     delete stream;
-    CLog::Log(LOGDEBUG, "file could not be opened for tag reading");
+    CLog::Log(LOGDEBUG, "file %s could not be opened for tag reading", strFileName.c_str());
     return false;
   }
 


### PR DESCRIPTION
We should guard against weird files and taglib failing to parse files.
This logs the error and we will fail more graciously, as the scan for example won't terminate mid process.

Edit: Review with https://github.com/xbmc/xbmc/pull/8524/files?w=0 please
