### PR TITLE
don't use cached results for dir checks

### DIFF
--- a/xbmc/interfaces/legacy/ModuleXbmcvfs.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmcvfs.cpp
@@ -57,7 +57,7 @@ namespace XBMCAddon
     {
       DelayedCallGuard dg;
       if (URIUtils::HasSlashAtEnd(path, true))
-        return XFILE::CDirectory::Exists(path);
+        return XFILE::CDirectory::Exists(path, false);
       return XFILE::CFile::Exists(path, false);
     }      
 


### PR DESCRIPTION
using cached results is causing issues for addons:
http://forum.kodi.tv/showthread.php?tid=215495&pid=1899282#pid1899282

we're not using cache when checking for files, can't think of a reason why we should for directories.

@tamland for review
