### PR TITLE
[linux] fix building on i386

### DIFF
--- a/xbmc/linux/PlatformDefs.h
+++ b/xbmc/linux/PlatformDefs.h
@@ -161,11 +161,7 @@
 #define __int64   long long
 #define __uint64  unsigned long long
 
-#if defined(__x86_64__) || defined(__powerpc__) || defined(__ppc__) || defined (__arm__) || defined(__mips__) // should this be powerpc64 only?
 #define __stdcall
-#else /* !__x86_64__ */
-#define __stdcall   __attribute__((__stdcall__))
-#endif /* __x86_64__ */
 #define __cdecl
 #define WINBASEAPI
 #define NTAPI       __stdcall


### PR DESCRIPTION
since the videoplayer merge building on linux i386 is broken with error such as these:

> In file included from /usr/include/GL/gl.h:2055:0,
>                  from /«PKGBUILDDIR»/xbmc/system_gl.h:34,
>                  from OverlayRendererGL.h:23,
>                  from OverlayRenderer.cpp:39:
> /usr/include/GL/glext.h:460:90: error: conflicting declaration of C function 'void glBlendColor(GLfloat, GLfloat, GLfloat, GLfloat)'
>  GLAPI void APIENTRY glBlendColor (GLfloat red, GLfloat green, GLfloat blue, GLfloat alpha);
>                                                                                           ^
> In file included from /«PKGBUILDDIR»/xbmc/system_gl.h:34:0,
>                  from OverlayRendererGL.h:23,
>                  from OverlayRenderer.cpp:39:
> /usr/include/GL/gl.h:1635:23: note: previous declaration 'void glBlendColor(GLclampf, GLclampf, GLclampf, GLclampf)'
>  GLAPI void GLAPIENTRY glBlendColor( GLclampf red, GLclampf green,
>                        ^

I have no idea why i386 was special cased with for the win32 calling convention. It has worked for a long time though, so maybe someone knows what the reason was?
@notspiff maybe?
