### PR TITLE
[pvr] allow file handling in kodi self, if add-on use also demuxing

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDFactoryDemuxer.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDFactoryDemuxer.cpp
@@ -96,8 +96,10 @@ CDVDDemux* CDVDFactoryDemuxer::CreateDemuxer(CDVDInputStream* pInputStream, bool
 
     if(pOtherStream)
     {
-      /* Used for MediaPortal PVR addon (uses PVR otherstream for playback of rtsp streams) */
-      if (pOtherStream->IsStreamType(DVDSTREAM_TYPE_FFMPEG))
+      /* Used for MediaPortal PVR addon (uses PVR otherstream for playback of rtsp streams)
+         and to allow usage if from addon defined on structure PVR_CHANNEL with strStreamURL. */
+      if (pOtherStream->IsStreamType(DVDSTREAM_TYPE_FFMPEG) ||
+          pOtherStream->IsStreamType(DVDSTREAM_TYPE_FILE))
       {
         std::unique_ptr<CDVDDemuxFFmpeg> demuxer(new CDVDDemuxFFmpeg());
         if(demuxer->Open(pOtherStream, streaminfo))


### PR DESCRIPTION
This change allow the usage of demuxing inside Kodi itself if the URL becomes defined on related channel.

If add-on support demuxing and on structure PVR_CHANNEL the strStreamURL is defined override the URL the use from him and ffmpeg does it.

Is required to allow on pvr.demo both ways for the work. Has not seen direct problems for other add-ons with them, but need to check.
