### PR TITLE
[mysql] Querying optimizer_switch needs to be non-fatal

### DIFF
--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -118,34 +118,36 @@ void MysqlDatabase::configure_connection() {
   if ((ret = mysql_real_query(conn, sqlcmd, strlen(sqlcmd))) != MYSQL_OK)
     throw DbErrors("Can't disable sql_mode ONLY_FULL_GROUP_BY: '%s' (%d)", db.c_str(), ret);
 
-  // MySQL 5.7.6+: See #8393
+  // MySQL 5.7.6+: See #8393. Non-fatal if error, as not supported by MySQL 5.0.x
   strcpy(sqlcmd, "SELECT @@SESSION.optimizer_switch");
-  if ((ret = mysql_real_query(conn, sqlcmd, strlen(sqlcmd))) != MYSQL_OK)
-    throw DbErrors("Can't query optimizer_switch: '%s' (%d)", db.c_str(), ret);
-
-  MYSQL_RES* res = mysql_store_result(conn);
-  MYSQL_ROW row;
-
-  if (res)
+  if ((ret = mysql_real_query(conn, sqlcmd, strlen(sqlcmd))) == MYSQL_OK)
   {
-    if ((row = mysql_fetch_row(res)) != NULL)
-    {
-      std::string column = row[0];
-      std::vector<std::string> split = StringUtils::Split(column, ',');
+    MYSQL_RES* res = mysql_store_result(conn);
+    MYSQL_ROW row;
 
-      for (std::vector<std::string>::iterator itIn = split.begin(); itIn != split.end(); ++itIn)
+    if (res)
+    {
+      if ((row = mysql_fetch_row(res)) != NULL)
       {
-        if (StringUtils::Trim(*itIn) == "derived_merge=on")
+        std::string column = row[0];
+        std::vector<std::string> split = StringUtils::Split(column, ',');
+
+        for (std::vector<std::string>::iterator itIn = split.begin(); itIn != split.end(); ++itIn)
         {
-          strcpy(sqlcmd, "SET SESSION optimizer_switch = 'derived_merge=off'");
-          if ((ret = mysql_real_query(conn, sqlcmd, strlen(sqlcmd))) != MYSQL_OK)
-            throw DbErrors("Can't set optimizer_switch = '%s': '%s' (%d)", StringUtils::Trim(*itIn).c_str(), db.c_str(), ret);
-          break;
+          if (StringUtils::Trim(*itIn) == "derived_merge=on")
+          {
+            strcpy(sqlcmd, "SET SESSION optimizer_switch = 'derived_merge=off'");
+            if ((ret = mysql_real_query(conn, sqlcmd, strlen(sqlcmd))) != MYSQL_OK)
+              throw DbErrors("Can't set optimizer_switch = '%s': '%s' (%d)", StringUtils::Trim(*itIn).c_str(), db.c_str(), ret);
+            break;
+          }
         }
       }
+      mysql_free_result(res);
     }
-    mysql_free_result(res);
   }
+  else
+    CLog::Log(LOGWARNING, "Unable to query optimizer_switch: '%s' (%d)", db.c_str(), ret);
 }
 
 int MysqlDatabase::connect(bool create_new) {


### PR DESCRIPTION
The `optimizer_switch` system variable isn't supported by really crusty versions of MySQL, eg. v5.0.33 as it seems to have been backported only as far as [v5.1](http://lists.mysql.com/commits/67226).

Some of our users [are using](http://forum.kodi.tv/showthread.php?tid=251399&pid=2183450#pid2183450) these really old versions with no option to update.

Needs Jarvis backport.
