### PR TITLE
don't toggle DisplayAfterSeek on ShowTime builtin command

### DIFF
--- a/addons/skin.confluence/720p/DialogSeekBar.xml
+++ b/addons/skin.confluence/720p/DialogSeekBar.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
 	<defaultcontrol>1</defaultcontrol>
-	<visible>Player.Seeking | Player.DisplayAfterSeek | Player.Paused | Player.Forwarding | Player.Rewinding</visible>
+	<visible>Player.Seeking | Player.DisplayAfterSeek | Player.Paused | Player.Forwarding | Player.Rewinding | Player.ShowTime</visible>
 	<animation effect="fade" start="0" end="100" time="150">WindowOpen</animation>
 	<animation effect="fade" start="100" end="0" time="150">WindowClose</animation>
 	<depth>DepthOSD</depth>

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -179,8 +179,6 @@ bool CGUIWindowFullScreen::OnAction(const CAction &action)
 
   case ACTION_SHOW_OSD_TIME:
     m_bShowCurrentTime = !m_bShowCurrentTime;
-    if(!m_bShowCurrentTime)
-      g_infoManager.SetDisplayAfterSeek(0); //Force display off
     g_infoManager.SetShowTime(m_bShowCurrentTime);
     return true;
     break;
@@ -368,8 +366,6 @@ EVENT_RESULT CGUIWindowFullScreen::OnMouseEvent(const CPoint &point, const CMous
 void CGUIWindowFullScreen::FrameMove()
 {
   if (g_application.m_pPlayer->GetPlaySpeed() != 1)
-    g_infoManager.SetDisplayAfterSeek();
-  if (m_bShowCurrentTime)
     g_infoManager.SetDisplayAfterSeek();
 
   if (!g_application.m_pPlayer->HasPlayer()) return;


### PR DESCRIPTION
when a user uses the ShowTime action, we (correctly) toggle the Player.ShowTime infobool
but we also toggle Player.DisplayAfterSeek for some reason?

this causes the skin to display an incorrect label in the SeekBar dialog.

if the only reason for the DisplayAfterSeek toggle is to trigger the visibility of the SeekBar dialog
then this commit will fix the ticket.

http://trac.kodi.tv/ticket/16434
