### PR TITLE
[PeripheralBus] add CEC IMX adapter as known type and set no polling.

### DIFF
--- a/xbmc/peripherals/PeripheralTypes.h
+++ b/xbmc/peripherals/PeripheralTypes.h
@@ -45,6 +45,7 @@ namespace PERIPHERALS
 #ifdef TARGET_ANDROID
     PERIPHERAL_BUS_ANDROID,
 #endif
+    PERIPHERAL_BUS_IMX,
   };
 
   enum PeripheralFeature
@@ -168,6 +169,8 @@ namespace PERIPHERALS
         return "pci";
       case PERIPHERAL_BUS_RPI:
         return "rpi";
+      case PERIPHERAL_BUS_IMX:
+        return "imx";
       case PERIPHERAL_BUS_CEC:
         return "cec";
       case PERIPHERAL_BUS_ADDON:
@@ -192,6 +195,8 @@ namespace PERIPHERALS
         return PERIPHERAL_BUS_PCI;
       else if (strTypeLowerCase == "rpi")
         return PERIPHERAL_BUS_RPI;
+      else if (strTypeLowerCase == "imx")
+        return PERIPHERAL_BUS_IMX;
       else if (strTypeLowerCase == "cec")
         return PERIPHERAL_BUS_CEC;
       else if (strTypeLowerCase == "addon")

--- a/xbmc/peripherals/bus/virtual/PeripheralBusCEC.cpp
+++ b/xbmc/peripherals/bus/virtual/PeripheralBusCEC.cpp
@@ -102,6 +102,12 @@ bool CPeripheralBusCEC::PerformDeviceScan(PeripheralScanResults &results)
       /** the Pi's adapter cannot be removed, no need to rescan */
       m_bNeedsPolling = false;
       break;
+#if defined(HAS_IMXVPU)
+    case ADAPTERTYPE_IMX:
+      result.m_mappedBusType = PERIPHERAL_BUS_IMX;
+      m_bNeedsPolling = false;
+      break;
+#endif
     default:
       break;
     }


### PR DESCRIPTION
- that eliminates extensive periodic /sys walkthrough

(this is reused Lars's commit e59d7e028288464e6890141a830e4a83d4b9d065)
((on single cpu this was blocking 1-3 vsync ticks each period of /sys rescan (5000ms)))
