### PR TITLE
FIX: [droid] mouse handling regression

### DIFF
--- a/xbmc/android/activity/EventLoop.cpp
+++ b/xbmc/android/activity/EventLoop.cpp
@@ -24,6 +24,8 @@
 
 #include <dlfcn.h>
 
+#define IS_FROM_SOURCE(v, s) ((v & s) == s)
+
 CEventLoop::CEventLoop(android_app* application)
   : m_enabled(false),
     m_application(application),
@@ -143,7 +145,7 @@ int32_t CEventLoop::processInput(AInputEvent* event)
   switch(type)
   {
     case AINPUT_EVENT_TYPE_KEY:
-      if (source & AINPUT_SOURCE_GAMEPAD || source & AINPUT_SOURCE_JOYSTICK)
+      if (IS_FROM_SOURCE(source, AINPUT_SOURCE_GAMEPAD) || IS_FROM_SOURCE(source, AINPUT_SOURCE_JOYSTICK))
       {
         if (m_inputHandler->onJoyStickKeyEvent(event))
           return true;
@@ -151,11 +153,11 @@ int32_t CEventLoop::processInput(AInputEvent* event)
       rtn = m_inputHandler->onKeyboardEvent(event);
       break;
     case AINPUT_EVENT_TYPE_MOTION:
-      if (source & AINPUT_SOURCE_TOUCHSCREEN)
+      if (IS_FROM_SOURCE(source, AINPUT_SOURCE_TOUCHSCREEN))
         rtn = m_inputHandler->onTouchEvent(event);
-      else if (source & AINPUT_SOURCE_MOUSE)
+      else if (IS_FROM_SOURCE(source, AINPUT_SOURCE_MOUSE))
         rtn = m_inputHandler->onMouseEvent(event);
-      else if (source & (AINPUT_SOURCE_GAMEPAD | AINPUT_SOURCE_JOYSTICK))
+      else if (IS_FROM_SOURCE(source, AINPUT_SOURCE_GAMEPAD) || IS_FROM_SOURCE(source, AINPUT_SOURCE_JOYSTICK))
         rtn = m_inputHandler->onJoyStickMotionEvent(event);
       break;
   }

--- a/xbmc/android/activity/EventLoop.cpp
+++ b/xbmc/android/activity/EventLoop.cpp
@@ -24,9 +24,6 @@
 
 #include <dlfcn.h>
 
-typeof(AMotionEvent_getAxisValue) *p_AMotionEvent_getAxisValue;
-typeof(AMotionEvent_getButtonState) *p_AMotionEvent_getButtonState;
-
 CEventLoop::CEventLoop(android_app* application)
   : m_enabled(false),
     m_application(application),
@@ -48,12 +45,6 @@ void CEventLoop::run(IActivityHandler &activityHandler, IInputHandler &inputHand
 
   m_activityHandler = &activityHandler;
   m_inputHandler = &inputHandler;
-
-  // missing in early NDKs, is present in r9b+
-  p_AMotionEvent_getAxisValue = (typeof(AMotionEvent_getAxisValue)*) dlsym(RTLD_DEFAULT, "AMotionEvent_getAxisValue");
-  // missing in NDK
-  p_AMotionEvent_getButtonState = (typeof(AMotionEvent_getButtonState)*) dlsym(RTLD_DEFAULT, "AMotionEvent_getButtonState");
-  CXBMCApp::android_printf("CEventLoop: AMotionEvent_getAxisValue: %p, AMotionEvent_getButtonState: %p", p_AMotionEvent_getAxisValue, p_AMotionEvent_getButtonState);
 
   CXBMCApp::android_printf("CEventLoop: starting event loop");
   while (1)


### PR DESCRIPTION
Fixes a regression where mouse is handled as touch.

The various "AINPUT_SOURCE_*" have a class as the last byte, and mouse and touch have the same, so testing != 0 is not enough.

/cc @Montellese 
