### PR TITLE
[Win32File] Fix invalid assert expression

### DIFF
--- a/xbmc/filesystem/win32/Win32File.cpp
+++ b/xbmc/filesystem/win32/Win32File.cpp
@@ -247,7 +247,7 @@ ssize_t CWin32File::Write(const void* lpBuf, size_t uiBufSize)
     if (!WriteFile(m_hFile, dummyBuf.get(), 0, &bytesWritten, NULL))
       return -1;
 
-    assert(bytesWritten != 0);
+    assert(bytesWritten == 0);
     return 0;
   }
 


### PR DESCRIPTION
Zero byte file write under windows triggers an invalid assert and stops Kodi.
