### PR TITLE
FFMpeg: Bump to 2.8.4-Jarvis-beta4

### DIFF
--- a/tools/depends/target/ffmpeg/FFMPEG-VERSION
+++ b/tools/depends/target/ffmpeg/FFMPEG-VERSION
@@ -1,5 +1,5 @@
 LIBNAME=ffmpeg
 BASE_URL=https://github.com/xbmc/FFmpeg/archive
-VERSION=2.8.3-Jarvis-beta3
+VERSION=2.8.4-Jarvis-beta4
 ARCHIVE=$(LIBNAME)-$(VERSION).tar.gz
 


### PR DESCRIPTION
This bumps ffmpeg.

Changelog:
- Fernet's analyzing patch was pushed upstream
- A special workaround for handbrake mp3's was added which should make a lot mp3 audio tracks working again. This bug was filed by us.
