### PR TITLE
[EPG] Timeline view init: Fix selection of currently playing channel

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -79,10 +79,10 @@ void CGUIWindowPVRBase::SetSelectedItemPath(bool bRadio, const std::string &path
 
 std::string CGUIWindowPVRBase::GetSelectedItemPath(bool bRadio)
 {
-  if (!m_selectedItemPaths.at(bRadio).empty())
-    return m_selectedItemPaths.at(bRadio);
-  else if (g_PVRManager.IsPlaying())
+  if (g_PVRManager.IsPlaying())
     return g_application.CurrentFile();
+  else if (!m_selectedItemPaths.at(bRadio).empty())
+    return m_selectedItemPaths.at(bRadio);
 
   return "";
 }

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.h
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.h
@@ -25,6 +25,11 @@
 
 class CSetting;
 
+namespace EPG
+{
+  class CGUIEPGGridContainer;
+}
+
 namespace PVR
 {
   class CGUIWindowPVRGuide : public CGUIWindowPVRBase
@@ -61,6 +66,8 @@ namespace PVR
     void GetViewNowItems(CFileItemList &items);
     void GetViewNextItems(CFileItemList &items);
     void GetViewTimelineItems(CFileItemList &items);
+
+    void UpdateViewTimelineGroup(EPG::CGUIEPGGridContainer* epgGridContainer, const CPVRChannelGroupPtr& group);
 
     CFileItemList      *m_cachedTimeline;
     CPVRChannelGroupPtr m_cachedChannelGroup;


### PR DESCRIPTION
If you start kodi, open epg window,  close it, tune to a channel, and open epg windo again, everything is fine - playing channel and event is selected in the epg grid (at least, after #8567)

But,  if you start kodi and do not open the epg window before tuning to a channel and then opening the epg window, first channel gets selected in epg grid. This PR fixes this bug.

@MartijnKaijser you reported this bug internally
@jalle19 @xhaggi mind taking a look
