### PR TITLE
Check for .nomedia file inside tv show folders

### DIFF
--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -511,6 +511,11 @@ namespace VIDEO
 
   INFO_RET CVideoInfoScanner::RetrieveInfoForTvShow(CFileItem *pItem, bool bDirNames, ScraperPtr &info2, bool useLocal, CScraperUrl* pURL, bool fetchEpisodes, CGUIDialogProgress* pDlgProgress)
   {
+    if (pItem->m_bIsFolder && IsExcluded(pItem->GetPath()))
+    {
+      CLog::Log(LOGWARNING, "Skipping show '%s' with '.nomedia' file in its directory, it won't be added to the library.", CURL::GetRedacted(pItem->GetPath()).c_str());
+      return INFO_NOT_NEEDED;
+    }
     long idTvShow = -1;
     if (pItem->m_bIsFolder)
       idTvShow = m_database.GetTvShowId(pItem->GetPath());


### PR DESCRIPTION
Previousy, only the base source folder was checked for a .nomedia file, which was rather pointless since you'd simply not add a source if you didn't want it in your library.

Now the actual TV show folders are also checked, so you can add a `.nomedia` file inside the folder of a TV show to exclude it from being added to the library.

Related forum post where I reported the issue: http://forum.kodi.tv/showthread.php?tid=251714
