### PR TITLE
[PVR] CDVDInputStreamPVRManager: Don't leak credentials

### DIFF
--- a/xbmc/cores/FFmpeg.cpp
+++ b/xbmc/cores/FFmpeg.cpp
@@ -24,6 +24,7 @@
 #include "utils/StringUtils.h"
 #include "threads/Thread.h"
 #include "settings/AdvancedSettings.h"
+#include "URL.h"
 #include <map>
 
 /* callback for the ffmpeg lock manager */
@@ -116,8 +117,18 @@ void ff_avutil_log(void* ptr, int level, const char* format, va_list va)
   int pos, start = 0;
   while( (pos = buffer.find_first_of('\n', start)) >= 0 )
   {
-    if(pos>start)
-      CLog::Log(type, "%s%s", prefix.c_str(), buffer.substr(start, pos-start).c_str());
+    if(pos > start)
+    {
+      std::vector<std::string> toLog = StringUtils::Split(buffer.substr(start, pos - start), "from '");
+      if (toLog.size() > 1)
+      {
+       size_t pos = toLog[1].find_first_of('\'');
+       std::string url = CURL::GetRedacted(toLog[1].substr(0, pos - 1));
+       toLog[0] += url + toLog[1].substr(pos);
+      }
+
+      CLog::Log(type, "%s%s", prefix.c_str(), toLog[0].c_str());
+    }
     start = pos+1;
   }
   buffer.erase(0, start);

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamPVRManager.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamPVRManager.cpp
@@ -114,18 +114,18 @@ bool CDVDInputStreamPVRManager::Open()
   if(transFile.substr(0, 6) != "pvr://")
   {
     m_isOtherStreamHack = true;
-    
+
     m_item.SetPath(transFile);
     m_pOtherStream = CDVDFactoryInputStream::CreateInputStream(m_pPlayer, m_item);
     if (!m_pOtherStream)
     {
-      CLog::Log(LOGERROR, "CDVDInputStreamPVRManager::Open - unable to create input stream for [%s]", transFile.c_str());
+      CLog::Log(LOGERROR, "CDVDInputStreamPVRManager::Open - unable to create input stream for [%s]", CURL::GetRedacted(transFile).c_str());
       return false;
     }
 
     if (!m_pOtherStream->Open())
     {
-      CLog::Log(LOGERROR, "CDVDInputStreamPVRManager::Open - error opening [%s]", transFile.c_str());
+      CLog::Log(LOGERROR, "CDVDInputStreamPVRManager::Open - error opening [%s]", CURL::GetRedacted(transFile).c_str());
       delete m_pFile;
       m_pFile = NULL;
       m_pLiveTV = NULL;
@@ -137,7 +137,7 @@ bool CDVDInputStreamPVRManager::Open()
   }
 
   ResetScanTimeout((unsigned int) CSettings::GetInstance().GetInt(CSettings::SETTING_PVRPLAYBACK_SCANTIME) * 1000);
-  CLog::Log(LOGDEBUG, "CDVDInputStreamPVRManager::Open - stream opened: %s", transFile.c_str());
+  CLog::Log(LOGDEBUG, "CDVDInputStreamPVRManager::Open - stream opened: %s", CURL::GetRedacted(transFile).c_str());
 
   return true;
 }


### PR DESCRIPTION
Found while testing non-working mpegts streams.

@fritsch, @FernetMenta, there's still one log line leaking credentials I can't find with my grep-fu:

<code>INFO: ffmpeg[7F3F41FFB700]: Input #0, mpegts, from  'http://USERNAME:PASSWORD@IP:port/bla-bla-bla...':</code>

Any idea where it's located?
