### PR TITLE
FFMpeg: Bump to 2.8.4-Jarvis-beta4

### DIFF
--- a/tools/depends/target/ffmpeg/FFMPEG-VERSION
+++ b/tools/depends/target/ffmpeg/FFMPEG-VERSION
@@ -1,5 +1,5 @@
 LIBNAME=ffmpeg
 BASE_URL=https://github.com/xbmc/FFmpeg/archive
-VERSION=2.8.3-Jarvis-beta3
+VERSION=2.8.4-Jarvis-beta4
 ARCHIVE=$(LIBNAME)-$(VERSION).tar.gz
 


### PR DESCRIPTION
Backport of: https://github.com/xbmc/xbmc/pull/8577
