### PR TITLE
Remove some long-presses and some notes cleanup

### DIFF
--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -1,45 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- This file contains the mapping of keys (gamepad, remote, and keyboard) to actions within XBMC -->
-<!-- The <global> section is a fall through - they will only be used if the button is not          -->
-<!-- used in the current window's section.  Note that there is only handling                       -->
-<!-- for a single action per button at this stage.                                                 -->
-<!-- For joystick/gamepad configuration under linux/win32, see below as it differs from xbox       -->
-<!-- gamepads.                                                                                     -->
-
-<!-- The format is:                      -->
-<!--    <device>                         -->
-<!--      <button>action</button>        -->
-<!--    </device>                        -->
-
-<!-- To map keys from other remotes using the RCA protocol, you may add <universalremote> blocks -->
-<!-- In this case, the tags used are <obc#> where # is the original button code (OBC) of the key -->
-<!-- You set it up by adding a <universalremote> block to the window or <global> section:       -->
-<!--    <universalremote>             -->
-<!--       <obc45>Stop</obc45>         -->
-<!--    </universalremote>            -->
-
-<!-- Note that the action can be a built-in function.                                         -->
-<!--  eg <B>ActivateWindow(MyMusic)</B>                                                       -->
-<!-- would automatically go to My Music on the press of the B button.                         -->
-<!-- An empty action removes the corresponding mapping from the default keymap                -->
-
-<!-- Joysticks / Gamepads:                                                                    -->
-<!--   See the sample PS3 controller configuration below for the format.                      -->
-<!--                                                                                          -->
-<!--  Joystick Name:                                                                          -->
-<!--   Do 'cat /proc/bus/input/devices' or see your xbmc log file  to find the names of       -->
-<!--   detected joysticks. The name used in the configuration should match the detected name. -->
-<!--                                                                                          -->
-<!--  Button Ids:                                                                             -->
-<!--   'id' is the button ID used by SDL. Joystick button ids of connected joysticks appear   -->
-<!--   in xbmc.log when they are pressed. Use your log to map custom buttons to actions.      -->
-<!--                                                                                          -->
-<!--  Axis Ids / Analog Controls                                                              -->
-<!--   Coming soon.                                                                           -->
-<!--                                                                                          -->
-<!--  Long presses                                                                            -->
-<!--   A limitation is that if a single press is mapped in a section, a global "longpress"    -->
-<!--   will be ignored. The workaround is to duplicate the long mapping in the section.       -->
+<!-- This file contains the mapping of keyboard keys to actions within Kodi.              -->
+<!--                                                                                      -->
+<!-- The format is:                                                                       -->
+<!--  <window>                                                                            -->
+<!--    <device>                                                                          -->
+<!--      <button>action</button>                                                         -->
+<!--    </device>                                                                         -->
+<!--  </window>                                                                           -->
+<!--                                                                                      -->
+<!-- The <global> section is a fall through - they will only be used if the button is     -->
+<!-- not used in the current window's section.                                            -->
+<!--                                                                                      -->
+<!-- Actions can be built-in functions.                                                   -->
+<!--  eg <B>ActivateWindow(MyMusic)</B>                                                   -->
+<!-- would automatically go to Music on the press of the B button.                        -->
+<!--                                                                                      -->
+<!--  Long presses                                                                        -->
+<!--   A limitation is that if a single press is mapped in a section, a global "longpress"-->
+<!--   will be ignored. The workaround is to duplicate the long mapping in the section.   -->
+<!--                                                                                      -->
+<!-- An empty action removes the corresponding mapping from default and parent keymaps.   -->
+<!-- This is different from a "noop" action, which disables a button.                     -->
+<!--                                                                                      -->
+<!-- More documentation on keymaps can be found on http://kodi.wiki/view/keymaps          -->
 <keymap>
   <global>
     <keyboard>
@@ -61,7 +44,6 @@
       <enter>Select</enter>
       <enter mod="longpress">ContextMenu</enter>
       <backspace>Back</backspace>
-      <backspace mod="longpress">ActivateWindow(Home)</backspace>
       <browser_back>Back</browser_back>
       <browser_back mod="longpress">ActivateWindow(Home)</browser_back>
       <key id='65446'>Back</key>
@@ -174,7 +156,7 @@
       <t mod="ctrl">ActivateWindow(TVChannels)</t>  <!-- MCE Live TV  -->
       <t mod="ctrl,shift">ActivateWindow(TVChannels)</t>  <!-- MCE My TV -->
       <a mod="ctrl">ActivateWindow(RadioChannels)</a>  <!-- MCE My Radio -->
-      <!-- MCE keypresses without an obvious use in XBMC -->
+      <!-- MCE keypresses without an obvious use in Kodi -->
       <u mod="ctrl">Notification(MCEKeypress, DVD subtitle, 3)</u>
       <a mod="ctrl,shift">Notification(MCEKeypress, DVD audio, 3)</a>
       <k mod="ctrl,shift">ReloadKeymaps</k>
@@ -202,10 +184,6 @@
       <down>Down</down>
       <return>Select</return>
       <enter>Select</enter>
-      <left mod="longpress">Backspace</left>
-      <right mod="longpress">Number0</right> <!-- first entry creates a space -->
-      <up mod="longpress">Shift</up>
-      <down mod="longpress">Symbols</down>
       <backspace>Backspace</backspace>
       <browser_back>Backspace</browser_back>
       <browser_back mod="longpress">PreviousMenu</browser_back>
@@ -277,6 +255,7 @@
       <m>Move</m>
       <r>Rename</r>
       <play_pause mod="longpress">Highlight</play_pause>
+      <backspace mod="longpress">ActivateWindow(Home)</backspace>
     </keyboard>
   </MyFiles>
   <MyMusicPlaylist>
@@ -285,6 +264,7 @@
       <delete>Delete</delete>
       <u>MoveItemUp</u>
       <d>MoveItemDown</d>
+      <backspace mod="longpress">ActivateWindow(Home)</backspace>
     </keyboard>
   </MyMusicPlaylist>
   <MyMusicPlaylistEditor>
@@ -292,6 +272,7 @@
       <u>MoveItemUp</u>
       <d>MoveItemDown</d>
       <delete>Delete</delete>
+      <backspace mod="longpress">ActivateWindow(Home)</backspace>
     </keyboard>
   </MyMusicPlaylistEditor>
   <MyMusicFiles>
@@ -299,12 +280,14 @@
       <n>Playlist</n>
       <q>Queue</q>
       <delete>Delete</delete>
+      <backspace mod="longpress">ActivateWindow(Home)</backspace>
     </keyboard>
   </MyMusicFiles>
   <MyMusicLibrary>
     <keyboard>
       <n>Playlist</n>
       <q>Queue</q>
+      <backspace mod="longpress">ActivateWindow(Home)</backspace>
     </keyboard>
   </MyMusicLibrary>
   <FullscreenVideo>
@@ -470,6 +453,7 @@
       <return>Rotate</return>
       <enter>Rotate</enter>
       <r>Rotate</r>
+      <backspace mod="longpress">ActivateWindow(Home)</backspace>
     </keyboard>
   </SlideShow>
   <ScreenCalibration>
@@ -538,6 +522,7 @@
       <delete>Delete</delete>
       <n>Playlist</n>
       <w>ToggleWatched</w>
+      <backspace mod="longpress">ActivateWindow(Home)</backspace>
     </keyboard>
   </MyVideoLibrary>
   <MyVideoFiles>
@@ -545,6 +530,7 @@
       <n>Playlist</n>
       <q>Queue</q>
       <w>ToggleWatched</w>
+      <backspace mod="longpress">ActivateWindow(Home)</backspace>
     </keyboard>
   </MyVideoFiles>
   <MyVideoPlaylist>
@@ -553,11 +539,13 @@
       <delete>Delete</delete>
       <u>MoveItemUp</u>
       <d>MoveItemDown</d>
+      <backspace mod="longpress">ActivateWindow(Home)</backspace>
     </keyboard>
   </MyVideoPlaylist>
   <MyPictures>
     <keyboard>
       <delete>Delete</delete>
+      <backspace mod="longpress">ActivateWindow(Home)</backspace>
     </keyboard>
   </MyPictures>
   <ContextMenu>
@@ -566,20 +554,17 @@
       <menu>Back</menu>
     </keyboard>
   </ContextMenu>
-  <Scripts>
-    <keyboard>
-      <i>info</i>
-    </keyboard>
-  </Scripts>
   <MusicInformation>
     <keyboard>
       <i>Back</i>
       <d mod="ctrl">Back</d>
+      <backspace mod="longpress">ActivateWindow(Home)</backspace>
     </keyboard>
   </MusicInformation>
   <MovieInformation>
     <keyboard>
       <i>Back</i>
+      <backspace mod="longpress">ActivateWindow(Home)</backspace>
     </keyboard>
   </MovieInformation>
   <PictureInfo>
@@ -590,6 +575,7 @@
       <d mod="ctrl">Back</d>
       <o>Back</o>
       <space>Pause</space>
+      <backspace mod="longpress">ActivateWindow(Home)</backspace>
     </keyboard>
   </PictureInfo>
   <Teletext>
@@ -608,6 +594,7 @@
       <browser_back>Close</browser_back>
       <u>MoveItemUp</u>
       <d>MoveItemDown</d>
+      <backspace mod="longpress">ActivateWindow(Home)</backspace>
     </keyboard>
   </Favourites>
   <NumericInput>
@@ -668,6 +655,7 @@
   <FileBrowser>
     <keyboard>
       <space>Highlight</space>
+      <backspace mod="longpress">ActivateWindow(Home)</backspace>
     </keyboard>
   </FileBrowser>
   <ShutdownMenu>
@@ -678,11 +666,13 @@
   <AddonInformation>
     <keyboard>
       <i>Back</i>
+      <backspace mod="longpress">ActivateWindow(Home)</backspace>
     </keyboard>
   </AddonInformation>
   <AddonSettings>
     <keyboard>
       <delete>Delete</delete>
+      <backspace mod="longpress">ActivateWindow(Home)</backspace>
     </keyboard>
   </AddonSettings>
   <Addon>
@@ -695,6 +685,27 @@
       <yellow>Yellow</yellow>
       <f4>Blue</f4>
       <blue>Blue</blue>
+      <backspace mod="longpress">ActivateWindow(Home)</backspace>
     </keyboard>
   </Addon>
+  <Programs>
+    <keyboard>
+      <backspace mod="longpress">ActivateWindow(Home)</backspace>
+    </keyboard>
+  </Programs>
+  <Settings>
+    <keyboard>
+      <backspace mod="longpress">ActivateWindow(Home)</backspace>
+    </keyboard>
+  </Settings>
+  <MediaFilter>
+    <keyboard>
+      <backspace mod="longpress">ActivateWindow(Home)</backspace>
+    </keyboard>
+  </MediaFilter>
+  <Weather>
+    <keyboard>
+      <backspace mod="longpress">ActivateWindow(Home)</backspace>
+    </keyboard>
+  </Weather>
 </keymap>


### PR DESCRIPTION
This removes the arrow long-presses on the virtual keyboard, as well as creating a temp work-around for the long-press on back/backspace for Jarvis. I also removed commented notes in the keymap file that didn't apply to keyboards. They were leftover from when the keymap filewas for all input devices.
