### PR TITLE
[udevprovider] handle 'change' events only for optical drives

### DIFF
--- a/xbmc/storage/linux/UDevProvider.cpp
+++ b/xbmc/storage/linux/UDevProvider.cpp
@@ -269,7 +269,8 @@ bool CUDevProvider::PumpDriveChangeEvents(IStorageEventsCallback *callback)
       }
       if (strcmp(action, "change") == 0)
       {
-        if (mountpoint)
+        const char *optical = udev_device_get_property_value(dev, "ID_CDROM");
+        if (mountpoint && (optical && strcmp(optical, "1") == 0))
         {
           CLog::Log(LOGNOTICE, "UDev: Changed / Added %s", mountpoint);
           if (callback)


### PR DESCRIPTION
user reported on forum, that he gets unexpected change events for his fixed disks. so let's play safe

@samnazarko could you pls test if your use case is still ok?
