### PR TITLE
[pvr][fix] wrong selected channel item in PVR windows

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -79,12 +79,7 @@ void CGUIWindowPVRBase::SetSelectedItemPath(bool bRadio, const std::string &path
 
 std::string CGUIWindowPVRBase::GetSelectedItemPath(bool bRadio)
 {
-  if (!m_selectedItemPaths.at(bRadio).empty())
-    return m_selectedItemPaths.at(bRadio);
-  else if (g_PVRManager.IsPlaying())
-    return g_application.CurrentFile();
-
-  return "";
+  return m_selectedItemPaths.at(bRadio);
 }
 
 void CGUIWindowPVRBase::Notify(const Observable &obs, const ObservableMessage msg)
@@ -838,7 +833,8 @@ void CGUIWindowPVRBase::UpdateButtons(void)
 
 void CGUIWindowPVRBase::UpdateSelectedItemPath()
 {
-  m_selectedItemPaths.at(m_bRadio) = m_viewControl.GetSelectedItemPath();
+  if (!m_viewControl.GetSelectedItemPath().empty())
+    m_selectedItemPaths.at(m_bRadio) = m_viewControl.GetSelectedItemPath();
 }
 
 bool CGUIWindowPVRBase::ConfirmDeleteTimer(CFileItem *item, bool &bDeleteSchedule)

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -146,6 +146,55 @@ void CGUIWindowPVRGuide::UpdateSelectedItemPath()
     CGUIWindowPVRBase::UpdateSelectedItemPath();
 }
 
+bool CGUIWindowPVRGuide::Update(const std::string &strDirectory, bool updateFilterPath /* = true */)
+{
+  bool bReturn = CGUIWindowPVRBase::Update(strDirectory, updateFilterPath);
+
+  switch (m_viewControl.GetCurrentControl())
+  {
+    case GUIDE_VIEW_TIMELINE: {
+      CGUIEPGGridContainer* epgGridContainer = (CGUIEPGGridContainer*) GetControl(m_viewControl.GetCurrentControl());
+      if (epgGridContainer)
+        epgGridContainer->SetChannel(GetSelectedItemPath(m_bRadio));
+      break;
+    }
+    default:
+      break;
+  }
+
+  return bReturn;
+}
+
+void CGUIWindowPVRGuide::UpdateButtons(void)
+{
+  CGUIWindowPVRBase::UpdateButtons();
+  switch (m_viewControl.GetCurrentControl())
+  {
+    case GUIDE_VIEW_TIMELINE: {
+      SET_CONTROL_LABEL(CONTROL_LABEL_HEADER1, g_localizeStrings.Get(19032));
+      break;
+    }
+    case GUIDE_VIEW_NOW: {
+      SET_CONTROL_LABEL(CONTROL_LABEL_HEADER1, g_localizeStrings.Get(19030));
+      break;
+    }
+    case GUIDE_VIEW_NEXT: {
+      SET_CONTROL_LABEL(CONTROL_LABEL_HEADER1, g_localizeStrings.Get(19031));
+      break;
+    }
+    case GUIDE_VIEW_CHANNEL: {
+      CPVRChannelPtr currentChannel(g_PVRManager.GetCurrentChannel());
+      if (currentChannel)
+        SET_CONTROL_LABEL(CONTROL_LABEL_HEADER1, currentChannel->ChannelName().c_str());
+      break;
+    }
+    default:
+      break;
+  }
+
+  SET_CONTROL_LABEL(CONTROL_LABEL_HEADER2, GetGroup()->GroupName());
+}
+
 bool CGUIWindowPVRGuide::GetDirectory(const std::string &strDirectory, CFileItemList &items)
 {
   switch (m_viewControl.GetCurrentControl())
@@ -353,11 +402,6 @@ bool CGUIWindowPVRGuide::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
 void CGUIWindowPVRGuide::GetViewChannelItems(CFileItemList &items)
 {
   CPVRChannelPtr currentChannel(g_PVRManager.GetCurrentChannel());
-
-  if (currentChannel)
-    SET_CONTROL_LABEL(CONTROL_LABEL_HEADER1, currentChannel->ChannelName().c_str());
-  SET_CONTROL_LABEL(CONTROL_LABEL_HEADER2, GetGroup()->GroupName());
-
   items.Clear();
   if (!currentChannel || g_PVRManager.GetCurrentEpg(items) == 0)
   {
@@ -371,9 +415,6 @@ void CGUIWindowPVRGuide::GetViewChannelItems(CFileItemList &items)
 
 void CGUIWindowPVRGuide::GetViewNowItems(CFileItemList &items)
 {
-  SET_CONTROL_LABEL(CONTROL_LABEL_HEADER1, g_localizeStrings.Get(19030));
-  SET_CONTROL_LABEL(CONTROL_LABEL_HEADER2, GetGroup()->GroupName());
-
   items.Clear();
   int iEpgItems = GetGroup()->GetEPGNow(items);
 
@@ -389,9 +430,6 @@ void CGUIWindowPVRGuide::GetViewNowItems(CFileItemList &items)
 
 void CGUIWindowPVRGuide::GetViewNextItems(CFileItemList &items)
 {
-  SET_CONTROL_LABEL(CONTROL_LABEL_HEADER1, g_localizeStrings.Get(19031));
-  SET_CONTROL_LABEL(CONTROL_LABEL_HEADER2, GetGroup()->GroupName());
-
   items.Clear();
   int iEpgItems = GetGroup()->GetEPGNext(items);
 
@@ -442,11 +480,6 @@ void CGUIWindowPVRGuide::GetViewTimelineItems(CFileItemList &items)
     startDate = maxPastDate;
 
   epgGridContainer->SetStartEnd(startDate, endDate);
-
-  SET_CONTROL_LABEL(CONTROL_LABEL_HEADER1, g_localizeStrings.Get(19032));
-  SET_CONTROL_LABEL(CONTROL_LABEL_HEADER2, GetGroup()->GroupName());
-
-  epgGridContainer->SetChannel(GetSelectedItemPath(m_bRadio));
 }
 
 bool CGUIWindowPVRGuide::OnContextButtonBegin(CFileItem *item, CONTEXT_BUTTON button)

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.h
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.h
@@ -40,6 +40,8 @@ namespace PVR
     bool OnContextButton(int itemNumber, CONTEXT_BUTTON button);
     void ResetObservers(void);
     void UnregisterObservers(void);
+    bool Update(const std::string &strDirectory, bool updateFilterPath = true);
+    void UpdateButtons(void);
 
   protected:
     void UpdateSelectedItemPath();


### PR DESCRIPTION
This is a follow-up for #8582 and will fix the root cause of the issue reported by @MartijnKaijser.

@ksooo after your refactoring of the guide window, where you moved all the stuff from `Update()` to `GetDirectory()`, you forget to check which stuff needs to be executed after the items are assigned to the view control. This is the reason why the first channel is selected at the first access because `epgGridContainer->SetChannel()` has no effect if called before the items are populated to the control. This will be fixed by the second commit.

I've also moved the `SET_CONTROL_LABEL` stuff from `GetDirectory()` to `UpdateButtons()` where this stuff should be life in.
