### PR TITLE
[settings] Remove DTS-HD from general settings

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -17003,7 +17003,7 @@ msgstr ""
 #. Description of setting "System -> Audio output -> DTS capable receiver" with label #254
 #: system/settings/settings.xml
 msgctxt "#36366"
-msgid "Select this option if your receiver is capable of decoding DTS streams. Note: Enabling this will disable \"Support 8 channel DTS-HD audio decoding\" option"
+msgid "Select this option if your receiver is capable of decoding DTS streams.
 msgstr ""
 
 #: system/settings/darwin_osx.xml
@@ -17026,7 +17026,7 @@ msgstr ""
 #. Description of setting "System -> Audio output -> DTS-HD capable receiver" with label #347
 #: system/settings/settings.xml
 msgctxt "#36370"
-msgid "Select this option if your receiver is capable of decoding DTS-HD streams. Note: Enabling this will disable \"Support 8 channel DTS-HD audio decoding\" option"
+msgid "Select this option if your receiver is capable of decoding DTS-HD streams."
 msgstr ""
 
 #. Description of setting "System -> Audio output -> Audio output device" with label #545
@@ -18129,18 +18129,6 @@ msgstr ""
 #: xbmc/video/GUIViewStateVideo.xml
 msgctxt "#38018"
 msgid "My rating"
-msgstr ""
-
-#. Setting #38019 "Settings -> System -> Audio output -> Support 8 channel DTS-HD audio decoding"
-#: system/settings/settings.xml
-msgctxt "#38019"
-msgid "Support 8 channel DTS-HD audio decoding"
-msgstr ""
-
-#. Description of setting #38019 Settings -> System -> Audio output -> Support 8 channel DTS-HD audio decoding
-#: system/settings/settings.xml
-msgctxt "#38020"
-msgid "Enables decoding of high quality DTS-HD audio streams. Note: This increases CPU load and is only available when DTS and DTS-HD audio passthrough are disabled."
 msgstr ""
 
 #empty string with id 38021

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2574,22 +2574,6 @@
           </constraints>
           <control type="list" format="string" />
         </setting>
-        <setting id="audiooutput.supportdtshdcpudecoding" type="boolean" label="38019" help="38020">
-          <level>2</level>
-          <default>false</default>
-          <control type="toggle" />
-          <dependencies>
-            <dependency type="enable">
-            <or>
-              <condition setting="audiooutput.passthrough" operator="is">false</condition>
-              <and>
-                <condition setting="audiooutput.dtshdpassthrough" operator="is">false</condition>
-                <condition setting="audiooutput.dtspassthrough" operator="is">false</condition>
-              </and>
-            </or>
-            </dependency>
-          </dependencies>
-        </setting>
       </group>
       <group id="2">
         <setting id="audiooutput.dspaddonsenabled" type="boolean" label="36441" help="36438">

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
@@ -25,6 +25,7 @@
 #include "../../DVDStreamInfo.h"
 #include "utils/log.h"
 #include "settings/AdvancedSettings.h"
+#include "DVDCodecs/DVDCodecs.h"
 extern "C" {
 #include "libavutil/opt.h"
 }
@@ -56,8 +57,14 @@ bool CDVDAudioCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options
 {
   AVCodec* pCodec = NULL;
   m_bOpenedCodec = false;
+  bool allowdtshddecode = true;
 
-  if (hints.codec == AV_CODEC_ID_DTS && CSettings::GetInstance().GetBool(CSettings::SETTING_AUDIOOUTPUT_SUPPORTSDTSHDCPUDECODING))
+  // set any special options
+  for(std::vector<CDVDCodecOption>::iterator it = options.m_keys.begin(); it != options.m_keys.end(); ++it)
+    if (it->m_name == "allowdtshddecode")
+      allowdtshddecode = atoi(it->m_value.c_str());
+
+  if (hints.codec == AV_CODEC_ID_DTS && allowdtshddecode)
     pCodec = avcodec_find_decoder_by_name("libdcadec");
 
   if (!pCodec)

--- a/xbmc/cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.cpp
@@ -331,10 +331,13 @@ CDVDVideoCodec* CDVDFactoryCodec::CreateVideoCodec(CDVDStreamInfo &hint, const C
   return NULL;
 }
 
-CDVDAudioCodec* CDVDFactoryCodec::CreateAudioCodec(CDVDStreamInfo &hint, bool allowpassthrough)
+CDVDAudioCodec* CDVDFactoryCodec::CreateAudioCodec(CDVDStreamInfo &hint, bool allowpassthrough, bool allowdtshddecode)
 {
   CDVDAudioCodec* pCodec = NULL;
   CDVDCodecOptions options;
+
+  if (!allowdtshddecode)
+    options.m_keys.push_back(CDVDCodecOption("allowdtshddecode", "0"));
 
   // we don't use passthrough if "sync playback to display" is enabled
   if (allowpassthrough)

--- a/xbmc/cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.h
@@ -37,7 +37,7 @@ class CDVDFactoryCodec
 {
 public:
   static CDVDVideoCodec* CreateVideoCodec(CDVDStreamInfo &hint, const CRenderInfo &info = CRenderInfo());
-  static CDVDAudioCodec* CreateAudioCodec(CDVDStreamInfo &hint, bool allowpassthrough = true);
+  static CDVDAudioCodec* CreateAudioCodec(CDVDStreamInfo &hint, bool allowpassthrough = true, bool allowdtshddecode = true);
   static CDVDOverlayCodec* CreateOverlayCodec(CDVDStreamInfo &hint );
 
   static CDVDAudioCodec* OpenCodec(CDVDAudioCodec* pCodec, CDVDStreamInfo &hint, CDVDCodecOptions &options );

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.h
@@ -109,6 +109,7 @@ protected:
   //! codec changes, in which case we may want to switch passthrough on/off.
   bool SwitchCodecIfNeeded();
   float GetCurrentAttenuation()                         { return m_dvdAudio.GetCurrentAttenuation(); }
+  bool AllowDTSHDDecode();
 
   CDVDMessageQueue m_messageQueue;
   CDVDMessageQueue& m_messageParent;

--- a/xbmc/cores/omxplayer/OMXAudioCodecOMX.cpp
+++ b/xbmc/cores/omxplayer/OMXAudioCodecOMX.cpp
@@ -27,6 +27,7 @@
 #include "cores/AudioEngine/Utils/AEUtil.h"
 #include "cores/AudioEngine/AEFactory.h"
 #include "settings/Settings.h"
+#include "linux/RBP.h"
 
 // the size of the audio_render output port buffers
 #define AUDIO_DECODE_OUTPUT_BUFFER (32*1024)
@@ -66,7 +67,7 @@ bool COMXAudioCodecOMX::Open(CDVDStreamInfo &hints)
   AVCodec* pCodec = NULL;
   m_bOpenedCodec = false;
 
-  if (hints.codec == AV_CODEC_ID_DTS && CSettings::GetInstance().GetBool(CSettings::SETTING_AUDIOOUTPUT_SUPPORTSDTSHDCPUDECODING))
+  if (hints.codec == AV_CODEC_ID_DTS && g_RBP.RasberryPiVersion() > 1)
     pCodec = avcodec_find_decoder_by_name("libdcadec");
 
   if (!pCodec)

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -365,7 +365,6 @@ const std::string CSettings::SETTING_AUDIOOUTPUT_EAC3PASSTHROUGH = "audiooutput.
 const std::string CSettings::SETTING_AUDIOOUTPUT_DTSPASSTHROUGH = "audiooutput.dtspassthrough";
 const std::string CSettings::SETTING_AUDIOOUTPUT_TRUEHDPASSTHROUGH = "audiooutput.truehdpassthrough";
 const std::string CSettings::SETTING_AUDIOOUTPUT_DTSHDPASSTHROUGH = "audiooutput.dtshdpassthrough";
-const std::string CSettings::SETTING_AUDIOOUTPUT_SUPPORTSDTSHDCPUDECODING = "audiooutput.supportdtshdcpudecoding";
 const std::string CSettings::SETTING_INPUT_PERIPHERALS = "input.peripherals";
 const std::string CSettings::SETTING_INPUT_ENABLEMOUSE = "input.enablemouse";
 const std::string CSettings::SETTING_INPUT_ENABLEJOYSTICK = "input.enablejoystick";

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -322,7 +322,6 @@ public:
   static const std::string SETTING_AUDIOOUTPUT_DTSPASSTHROUGH;
   static const std::string SETTING_AUDIOOUTPUT_TRUEHDPASSTHROUGH;
   static const std::string SETTING_AUDIOOUTPUT_DTSHDPASSTHROUGH;
-  static const std::string SETTING_AUDIOOUTPUT_SUPPORTSDTSHDCPUDECODING;
   static const std::string SETTING_INPUT_PERIPHERALS;
   static const std::string SETTING_INPUT_ENABLEMOUSE;
   static const std::string SETTING_INPUT_ENABLEJOYSTICK;


### PR DESCRIPTION
Changes to enabled by default with explicit platforms excluded.
See discussion here: https://github.com/xbmc/xbmc/pull/8486
