### PR TITLE
[addons] move addon system settings to regular settings window

### DIFF
--- a/Kodi.xcodeproj/project.pbxproj
+++ b/Kodi.xcodeproj/project.pbxproj
@@ -159,6 +159,8 @@
 		384718D81325BA04000486D6 /* XBDateTime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 384718D61325BA04000486D6 /* XBDateTime.cpp */; };
 		38F4E57013CCCB3B00664821 /* Implementation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 38F4E56C13CCCB3B00664821 /* Implementation.cpp */; };
 		391416BF1B4A3EFA00BBF0AA /* guiinfo in Resources */ = {isa = PBXBuildFile; fileRef = 391416BE1B4A3EFA00BBF0AA /* guiinfo */; };
+		39520F911C3174EE00272121 /* AddonSystemSettings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 39520F8F1C3174EE00272121 /* AddonSystemSettings.cpp */; };
+		39520F921C3174EE00272121 /* AddonSystemSettings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 39520F8F1C3174EE00272121 /* AddonSystemSettings.cpp */; };
 		395897151AAD94F00033D27C /* KeyboardLayoutManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 395897131AAD94F00033D27C /* KeyboardLayoutManager.cpp */; };
 		395897161AAD94F00033D27C /* KeyboardLayoutManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 395897131AAD94F00033D27C /* KeyboardLayoutManager.cpp */; };
 		395C29BC1A94733100EBC7AD /* Key.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 395C29BA1A94733100EBC7AD /* Key.cpp */; };
@@ -2563,6 +2565,8 @@
 		38F4E56D13CCCB3B00664821 /* README.platform */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = README.platform; sourceTree = "<group>"; };
 		38F4E56E13CCCB3B00664821 /* ThreadLocal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ThreadLocal.h; sourceTree = "<group>"; };
 		391416BE1B4A3EFA00BBF0AA /* guiinfo */ = {isa = PBXFileReference; lastKnownFileType = folder; name = guiinfo; path = xbmc/guiinfo; sourceTree = SOURCE_ROOT; };
+		39520F8F1C3174EE00272121 /* AddonSystemSettings.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AddonSystemSettings.cpp; sourceTree = "<group>"; };
+		39520F901C3174EE00272121 /* AddonSystemSettings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AddonSystemSettings.h; sourceTree = "<group>"; };
 		395897131AAD94F00033D27C /* KeyboardLayoutManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = KeyboardLayoutManager.cpp; sourceTree = "<group>"; };
 		395897141AAD94F00033D27C /* KeyboardLayoutManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KeyboardLayoutManager.h; sourceTree = "<group>"; };
 		395938731AC28F5A0053A590 /* EmbeddedArt.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EmbeddedArt.h; sourceTree = "<group>"; };
@@ -4944,6 +4948,8 @@
 				18B49FF51152BFA5001AF8A6 /* AddonManager.h */,
 				F52BFFDA115D5574004B1D66 /* AddonStatusHandler.cpp */,
 				F52BFFD9115D5574004B1D66 /* AddonStatusHandler.h */,
+				39520F8F1C3174EE00272121 /* AddonSystemSettings.cpp */,
+				39520F901C3174EE00272121 /* AddonSystemSettings.h */,
 				18B700DF13A6A5750009C1AF /* AddonVersion.cpp */,
 				18B700E013A6A5750009C1AF /* AddonVersion.h */,
 				395C2A221AA4C32100EBC7AD /* AudioDecoder.cpp */,
@@ -9803,6 +9809,7 @@
 				F5E1053F140AA38100175026 /* PeripheralHID.cpp in Sources */,
 				F5E10540140AA38100175026 /* PeripheralNIC.cpp in Sources */,
 				F5E10541140AA38100175026 /* PeripheralNyxboard.cpp in Sources */,
+				39520F911C3174EE00272121 /* AddonSystemSettings.cpp in Sources */,
 				F5E10542140AA38100175026 /* PeripheralTuner.cpp in Sources */,
 				F5E10544140AA38100175026 /* GUIDialogPeripheralSettings.cpp in Sources */,
 				F5E10547140AA38100175026 /* Peripherals.cpp in Sources */,
@@ -10347,6 +10354,7 @@
 				E49911C0174E5D2500741B6D /* DVDAudioCodecFFmpeg.cpp in Sources */,
 				E49911C3174E5D2500741B6D /* DVDAudioCodecPassthrough.cpp in Sources */,
 				DF14CF7F1A77782E00396CC9 /* InputManager.cpp in Sources */,
+				39520F921C3174EE00272121 /* AddonSystemSettings.cpp in Sources */,
 				E49911C6174E5D2500741B6D /* DVDOverlayCodec.cpp in Sources */,
 				E49911C8174E5D2500741B6D /* DVDOverlayCodecFFmpeg.cpp in Sources */,
 				E49911C9174E5D2500741B6D /* DVDOverlayCodecSSA.cpp in Sources */,

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -5365,25 +5365,7 @@ msgctxt "#12395"
 msgid "Battery level"
 msgstr ""
 
-#. Used on the button to toggle add-on update mode in the Add-on Manager.
-#: xbmc/addons/GUIWindowAddonBrowser.cpp
-msgctxt "#12396"
-msgid "Auto updates: On"
-msgstr ""
-
-#. Used on the button to toggle add-on update mode in the Add-on Manager.
-#: xbmc/addons/GUIWindowAddonBrowser.cpp
-msgctxt "#12397"
-msgid "Auto updates: Notify"
-msgstr ""
-
-#. Used on the button to toggle add-on update mode in the Add-on Manager.
-#: xbmc/addons/GUIWindowAddonBrowser.cpp
-msgctxt "#12398"
-msgid "Auto updates: Never"
-msgstr ""
-
-#empty strings from id 12399 to 12599
+#empty strings from id 12396 to 12599
 
 #: xbmc/guilib/WindowIDs.h
 msgctxt "#12600"
@@ -13986,22 +13968,19 @@ msgctxt "#24993"
 msgid "Information providers"
 msgstr ""
 
-#: xbmc/addons/CGUIViewStateAddonBrowser.cpp
-#: xbmc/filesystem/AddonsDirectory.cpp
+#: system/settings/settings.xml
 msgctxt "#24994"
 msgid "Running"
 msgstr ""
 
-#: xbmc/addons/CGUIViewStateAddonBrowser.cpp
 #: xbmc/filesystem/AddonsDirectory.cpp
 msgctxt "#24995"
-msgid "Orphaned dependencies"
+msgid "Orphaned"
 msgstr ""
 
-#: xbmc/addons/CGUIViewStateAddonBrowser.cpp
-#: xbmc/filesystem/AddonsDirectory.cpp
+#: system/settings/settings.xml
 msgctxt "#24996"
-msgid "Dependencies"
+msgid "Manage dependencies"
 msgstr ""
 
 #: xbmc/filesystem/AddonsDirectory.cpp
@@ -17757,7 +17736,64 @@ msgctxt "#36603"
 msgid "This category contains the settings for how video output is handled."
 msgstr ""
 
-#empty strings from id 36604 to 36899
+#: system/settings/settings.xml
+msgctxt "#36605"
+msgid "Updates"
+msgstr ""
+
+#. Option for setting "System -> Add-ons -> Updates"
+#: system/settings/settings.xml
+msgctxt "#36606"
+msgid "Install updates automatically"
+msgstr ""
+
+#. Option for setting "System -> Add-ons -> Updates"
+#: system/settings/settings.xml
+msgctxt "#36607"
+msgid "Notify, but don't install updates"
+msgstr ""
+
+#. Option for setting "System -> Add-ons -> Updates"
+#: system/settings/settings.xml
+msgctxt "#36608"
+msgid "Never check for updates"
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#36609"
+msgid "Show notifications"
+msgstr ""
+
+#. Description of settings category "System -> Add-ons"
+#: system/settings/settings.xml
+msgctxt "#36610"
+msgid "This category contains settings for the add-on system."
+msgstr ""
+
+#. Description of setting "System -> Add-ons -> Updates" with label #36605
+#: system/settings/settings.xml
+msgctxt "#36611"
+msgid "Change how auto updating of add-ons are handled."
+msgstr ""
+
+#. Description of setting "System -> Add-ons -> Show notifications" with label #36609
+#: system/settings/settings.xml
+msgctxt "#36612"
+msgid "Show notification when an add-on have been updated."
+msgstr ""
+
+#. Description of setting "System -> Add-ons -> Manage dependencies" with label #24996
+msgctxt "#36613"
+msgid "Manage modules and support libraries that have been automatically installed as a dependency to other add-ons. Items listed as \"Orphaned\" are no longer required by any add-ons and are safe to uninstall."
+msgstr ""
+
+#. Description of setting "System -> Add-ons -> Running" with label #24994
+#: system/settings/settings.xml
+msgctxt "#36614"
+msgid "Show add-ons that are currently running in the background."
+msgstr ""
+
+#empty strings from id 36615 to 36899
 
 #: xbmc/media/MediaType.cpp
 msgctxt "#36900"

--- a/addons/skin.confluence/720p/AddonBrowser.xml
+++ b/addons/skin.confluence/720p/AddonBrowser.xml
@@ -97,6 +97,11 @@
 					<include>ButtonCommonValues</include>
 					<label>24034</label>
 				</control>
+				<control type="button" id="5">
+					<description>Settings shortcut</description>
+					<include>ButtonCommonValues</include>
+					<label>10004</label>
+				</control>
 				<include>CommonNowPlaying_Controls</include>
 			</control>
 			<control type="label">

--- a/addons/skin.confluence/720p/AddonBrowser.xml
+++ b/addons/skin.confluence/720p/AddonBrowser.xml
@@ -82,17 +82,6 @@
 					<align>center</align>
 					<aligny>center</aligny>
 				</control>
-				<control type="button" id="5">
-					<description>addon-updates</description>
-					<textwidth>235</textwidth>
-					<include>ButtonCommonValues</include>
-					<label>24063</label>
-				</control>
-				<control type="radiobutton" id="6">
-					<description>No notifications</description>
-					<include>ButtonCommonValues</include>
-					<label>25000</label>
-				</control>
 				<control type="radiobutton" id="7">
 					<description>Hide foreign</description>
 					<include>ButtonCommonValues</include>

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -190,6 +190,7 @@
     <ClCompile Include="..\..\xbmc\addons\AddonCallbacksPVR.cpp" />
     <ClCompile Include="..\..\xbmc\addons\AddonDatabase.cpp" />
     <ClCompile Include="..\..\xbmc\addons\AddonInstaller.cpp" />
+    <ClCompile Include="..\..\xbmc\addons\AddonSystemSettings.cpp" />
     <ClCompile Include="..\..\xbmc\addons\AddonVersion.cpp" />
     <ClCompile Include="..\..\xbmc\addons\ContextMenuAddon.cpp" />
     <ClCompile Include="..\..\xbmc\addons\AudioDecoder.cpp" />
@@ -1799,6 +1800,7 @@
     <ClInclude Include="..\..\xbmc\addons\AddonCallbacksPVR.h" />
     <ClInclude Include="..\..\xbmc\addons\AddonDatabase.h" />
     <ClInclude Include="..\..\xbmc\addons\AddonInstaller.h" />
+    <ClInclude Include="..\..\xbmc\addons\AddonSystemSettings.h" />
     <ClInclude Include="..\..\xbmc\addons\AddonVersion.h" />
     <ClInclude Include="..\..\xbmc\addons\DllLibCPluff.h" />
     <ClInclude Include="..\..\xbmc\addons\DllPVRClient.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -1566,6 +1566,9 @@
     <ClCompile Include="..\..\xbmc\addons\AddonInstaller.cpp">
       <Filter>addons</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\addons\AddonSystemSettings.cpp">
+      <Filter>addons</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\xbmc\epg\Epg.cpp">
       <Filter>epg</Filter>
     </ClCompile>
@@ -4616,6 +4619,9 @@
       <Filter>utils</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\addons\AddonInstaller.h">
+      <Filter>addons</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\addons\AddonSystemSettings.h">
       <Filter>addons</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\epg\EpgSearchFilter.h">

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2889,6 +2889,40 @@
         </setting>
       </group>
     </category>
+    <category id="addons" label="24001" help="36610">
+      <group id="1">
+        <setting id="general.addonupdates" type="integer" label="36605" help="36611">
+          <level>0</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="36606">0</option> <!-- AUTO_UPDATES_ON -->
+              <option label="36607">1</option> <!-- AUTO_UPDATES_NOTIFY -->
+              <option label="36608">2</option> <!-- AUTO_UPDATES_NEVER -->
+            </options>
+          </constraints>
+          <control type="list" format="string" />
+        </setting>
+        <setting id="general.addonnotifications" type="boolean" label="36609" help="36612">
+          <level>0</level>
+          <default>true</default>
+          <control type="toggle" />
+          <dependencies>
+            <dependency type="enable" setting="general.addonupdates">0</dependency>
+          </dependencies>
+        </setting>
+      </group>
+      <group id="2">
+        <setting id="addons.managedependencies" type="action" label="24996" help="36613">
+          <level>2</level>
+          <control type="button" format="action" />
+        </setting>
+        <setting id="addons.showrunning" type="action" label="24994" help="36614">
+          <level>2</level>
+          <control type="button" format="action" />
+        </setting>
+      </group>
+    </category>
     <category id="logging" label="14092" help="36391">
       <group id="1">
         <setting id="eventlog.enabled" type="boolean" label="14112" help="36460">
@@ -3127,22 +3161,6 @@
     </category>
     <category id="general" label="" help="36412">
       <group id="1">
-        <setting id="general.addonupdates" type="integer" label="0" help="36413">
-          <level>4</level>
-          <default>0</default>
-          <constraints>
-            <options>
-              <option label="12396">0</option> <!-- AUTO_UPDATES_ON -->
-              <option label="12397">1</option> <!-- AUTO_UPDATES_NOTIFY -->
-              <option label="12398">2</option> <!-- AUTO_UPDATES_NEVER -->
-            </options>
-          </constraints>
-          <control type="list" format="string" />
-        </setting>
-        <setting id="general.addonnotifications" type="boolean" label="0" help="36414">
-          <level>4</level>
-          <default>true</default>
-        </setting>
         <setting id="general.addonforeignfilter" type="boolean" label="0" help="36415">
           <level>4</level>
           <default>false</default>

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -619,7 +619,7 @@ bool CAddonInstallJob::DoWork()
   // run any post-install guff
   CEventLog::GetInstance().Add(
     EventPtr(new CAddonManagementEvent(m_addon, m_update ? 24065 : 24064)),
-    !IsModal() && CSettings::GetInstance().GetBool(CSettings::SETTING_GENERAL_ADDONNOTIFICATIONS), false);
+    !IsModal() && CSettings::GetInstance().GetBool(CSettings::SETTING_ADDONS_NOTIFICATIONS), false);
 
   ADDON::OnPostInstall(m_addon, m_update, IsModal());
 

--- a/xbmc/addons/AddonInstaller.h
+++ b/xbmc/addons/AddonInstaller.h
@@ -29,13 +29,6 @@
 
 class CAddonDatabase;
 
-enum {
-  AUTO_UPDATES_ON = 0,
-  AUTO_UPDATES_NOTIFY,
-  AUTO_UPDATES_NEVER,
-  AUTO_UPDATES_MAX
-};
-
 class CAddonInstaller : public IJobCallback
 {
 public:

--- a/xbmc/addons/AddonSystemSettings.cpp
+++ b/xbmc/addons/AddonSystemSettings.cpp
@@ -1,0 +1,51 @@
+/*
+ *      Copyright (C) 2015 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "addons/AddonManager.h"
+#include "addons/AddonSystemSettings.h"
+#include "addons/RepositoryUpdater.h"
+#include "guilib/GUIWindowManager.h"
+#include "settings/Settings.h"
+
+
+namespace ADDON
+{
+
+CAddonSystemSettings& CAddonSystemSettings::GetInstance()
+{
+  static CAddonSystemSettings inst;
+  return inst;
+}
+
+void  CAddonSystemSettings::OnSettingAction(const CSetting* setting)
+{
+  if (setting->GetId() == CSettings::SETTING_ADDONS_MANAGE_DEPENDENCIES)
+  {
+    std::vector<std::string> params{"addons://dependencies/", "return"};
+    g_windowManager.ActivateWindow(WINDOW_ADDON_BROWSER, params);
+  }
+  else if (setting->GetId() == CSettings::SETTING_ADDONS_SHOW_RUNNING)
+  {
+    std::vector<std::string> params{"addons://running/", "return"};
+    g_windowManager.ActivateWindow(WINDOW_ADDON_BROWSER, params);
+  }
+};
+
+}

--- a/xbmc/addons/AddonSystemSettings.h
+++ b/xbmc/addons/AddonSystemSettings.h
@@ -1,0 +1,46 @@
+#pragma once
+/*
+ *      Copyright (C) 2015 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "settings/lib/ISettingCallback.h"
+
+
+namespace ADDON
+{
+
+const int AUTO_UPDATES_ON = 0;
+const int AUTO_UPDATES_NOTIFY = 1;
+const int AUTO_UPDATES_NEVER = 2;
+
+class CAddonSystemSettings : public ISettingCallback
+{
+public:
+  static CAddonSystemSettings& GetInstance();
+  void OnSettingAction(const CSetting* setting) override;
+
+private:
+  CAddonSystemSettings() = default;
+  CAddonSystemSettings(const CAddonSystemSettings&) = default;
+  CAddonSystemSettings& operator=(const CAddonSystemSettings&) = default;
+  CAddonSystemSettings(CAddonSystemSettings&&);
+  CAddonSystemSettings& operator=(CAddonSystemSettings&&);
+  virtual ~CAddonSystemSettings() = default;
+};
+};

--- a/xbmc/addons/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/GUIDialogAddonInfo.cpp
@@ -22,6 +22,7 @@
 
 #include "addons/AddonInstaller.h"
 #include "addons/AddonManager.h"
+#include "addons/AddonSystemSettings.h"
 #include "AddonDatabase.h"
 #include "FileItem.h"
 #include "filesystem/Directory.h"
@@ -188,7 +189,7 @@ void CGUIDialogAddonInfo::UpdateControls()
 
   CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_UPDATE, isInstalled);
 
-  bool autoUpdatesOn = CSettings::GetInstance().GetInt(CSettings::SETTING_GENERAL_ADDONUPDATES) == AUTO_UPDATES_ON;
+  bool autoUpdatesOn = CSettings::GetInstance().GetInt(CSettings::SETTING_ADDONS_AUTOUPDATES) == AUTO_UPDATES_ON;
   CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_AUTOUPDATE, isInstalled && autoUpdatesOn);
   SET_CONTROL_SELECTED(GetID(), CONTROL_BTN_AUTOUPDATE, isInstalled && autoUpdatesOn &&
       !CAddonMgr::GetInstance().IsBlacklisted(m_localAddon->ID()));

--- a/xbmc/addons/GUIViewStateAddonBrowser.cpp
+++ b/xbmc/addons/GUIViewStateAddonBrowser.cpp
@@ -98,13 +98,6 @@ VECSOURCES& CGUIViewStateAddonBrowser::GetSources()
     share.strName = g_localizeStrings.Get(137);
     m_sources.push_back(share);
   }
-  {
-    CMediaSource share;
-    share.strPath = "addons://manage/";
-    share.m_iDriveType = CMediaSource::SOURCE_TYPE_LOCAL;
-    share.strName = g_localizeStrings.Get(24992);
-    m_sources.push_back(share);
-  }
 
   return CGUIViewState::GetSources();
 }

--- a/xbmc/addons/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/GUIWindowAddonBrowser.cpp
@@ -47,6 +47,7 @@
 
 #include <utility>
 
+#define CONTROL_SETTINGS 5
 #define CONTROL_FOREIGNFILTER 7
 #define CONTROL_BROKENFILTER  8
 #define CONTROL_CHECK_FOR_UPDATES  9
@@ -104,6 +105,11 @@ bool CGUIWindowAddonBrowser::OnMessage(CGUIMessage& message)
       else if (iControl == CONTROL_CHECK_FOR_UPDATES)
       {
         CRepositoryUpdater::GetInstance().CheckForUpdates(true);
+        return true;
+      }
+      else if (iControl == CONTROL_SETTINGS)
+      {
+        g_windowManager.ActivateWindow(WINDOW_SETTINGS_SYSTEM, "addons");
         return true;
       }
       else if (m_viewControl.HasControl(iControl))  // list/thumb control
@@ -257,6 +263,7 @@ void CGUIWindowAddonBrowser::UpdateButtons()
   SET_CONTROL_SELECTED(GetID(),CONTROL_FOREIGNFILTER, CSettings::GetInstance().GetBool(CSettings::SETTING_GENERAL_ADDONFOREIGNFILTER));
   SET_CONTROL_SELECTED(GetID(),CONTROL_BROKENFILTER, CSettings::GetInstance().GetBool(CSettings::SETTING_GENERAL_ADDONBROKENFILTER));
   CONTROL_ENABLE(CONTROL_CHECK_FOR_UPDATES);
+  CONTROL_ENABLE(CONTROL_SETTINGS);
 
   bool allowFilter = CAddonsDirectory::IsRepoDirectory(CURL(m_vecItems->GetPath()));
   CONTROL_ENABLE_ON_CONDITION(CONTROL_FOREIGNFILTER, allowFilter);

--- a/xbmc/addons/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/GUIWindowAddonBrowser.cpp
@@ -20,6 +20,7 @@
 
 #include "GUIWindowAddonBrowser.h"
 #include "addons/AddonManager.h"
+#include "AddonSystemSettings.h"
 #include "addons/RepositoryUpdater.h"
 #include "GUIDialogAddonInfo.h"
 #include "GUIDialogAddonSettings.h"
@@ -46,8 +47,6 @@
 
 #include <utility>
 
-#define CONTROL_AUTOUPDATE    5
-#define CONTROL_SHUTUP        6
 #define CONTROL_FOREIGNFILTER 7
 #define CONTROL_BROKENFILTER  8
 #define CONTROL_CHECK_FOR_UPDATES  9
@@ -88,23 +87,7 @@ bool CGUIWindowAddonBrowser::OnMessage(CGUIMessage& message)
   case GUI_MSG_CLICKED:
     {
       int iControl = message.GetSenderId();
-      if (iControl == CONTROL_AUTOUPDATE)
-      {
-        const CGUIControl *control = GetControl(CONTROL_AUTOUPDATE);
-        if (control && control->GetControlType() == CGUIControl::GUICONTROL_BUTTON)
-          CSettings::GetInstance().SetInt(CSettings::SETTING_GENERAL_ADDONUPDATES, (CSettings::GetInstance().GetInt(CSettings::SETTING_GENERAL_ADDONUPDATES)+1) % AUTO_UPDATES_MAX);
-        else
-          CSettings::GetInstance().SetInt(CSettings::SETTING_GENERAL_ADDONUPDATES, (CSettings::GetInstance().GetInt(CSettings::SETTING_GENERAL_ADDONUPDATES) == 0) ? 1 : 0);
-        UpdateButtons();
-        return true;
-      }
-      else if (iControl == CONTROL_SHUTUP)
-      {
-        CSettings::GetInstance().ToggleBool(CSettings::SETTING_GENERAL_ADDONNOTIFICATIONS);
-        CSettings::GetInstance().Save();
-        return true;
-      }
-      else if (iControl == CONTROL_FOREIGNFILTER)
+      if (iControl == CONTROL_FOREIGNFILTER)
       {
         CSettings::GetInstance().ToggleBool(CSettings::SETTING_GENERAL_ADDONFOREIGNFILTER);
         CSettings::GetInstance().Save();
@@ -271,28 +254,6 @@ bool CGUIWindowAddonBrowser::OnClick(int iItem, const std::string &player)
 
 void CGUIWindowAddonBrowser::UpdateButtons()
 {
-  const CGUIControl *control = GetControl(CONTROL_AUTOUPDATE);
-  if (control && control->GetControlType() == CGUIControl::GUICONTROL_BUTTON)
-  { // set label
-    CSettingInt *setting = (CSettingInt *)CSettings::GetInstance().GetSetting(CSettings::SETTING_GENERAL_ADDONUPDATES);
-    if (setting)
-    {
-      const StaticIntegerSettingOptions& options = setting->GetOptions();
-      for (StaticIntegerSettingOptions::const_iterator it = options.begin(); it != options.end(); ++it)
-      {
-        if (it->second == setting->GetValue())
-        {
-          SET_CONTROL_LABEL(CONTROL_AUTOUPDATE, it->first);
-          break;
-        }
-      }
-    }
-  }
-  else
-  { // old skin with toggle button - set on if auto updates are on
-    SET_CONTROL_SELECTED(GetID(),CONTROL_AUTOUPDATE, CSettings::GetInstance().GetInt(CSettings::SETTING_GENERAL_ADDONUPDATES) == AUTO_UPDATES_ON);
-  }
-  SET_CONTROL_SELECTED(GetID(),CONTROL_SHUTUP, CSettings::GetInstance().GetBool(CSettings::SETTING_GENERAL_ADDONNOTIFICATIONS));
   SET_CONTROL_SELECTED(GetID(),CONTROL_FOREIGNFILTER, CSettings::GetInstance().GetBool(CSettings::SETTING_GENERAL_ADDONFOREIGNFILTER));
   SET_CONTROL_SELECTED(GetID(),CONTROL_BROKENFILTER, CSettings::GetInstance().GetBool(CSettings::SETTING_GENERAL_ADDONBROKENFILTER));
   CONTROL_ENABLE(CONTROL_CHECK_FOR_UPDATES);

--- a/xbmc/addons/Makefile
+++ b/xbmc/addons/Makefile
@@ -10,6 +10,7 @@ SRCS=Addon.cpp \
      AddonInstaller.cpp \
      AddonManager.cpp \
      AddonStatusHandler.cpp \
+     AddonSystemSettings.cpp \
      AddonVersion.cpp \
      AudioEncoder.cpp \
      ContextMenuAddon.cpp \

--- a/xbmc/addons/RepositoryUpdater.cpp
+++ b/xbmc/addons/RepositoryUpdater.cpp
@@ -23,6 +23,7 @@
 #include "GUIUserMessages.h"
 #include "addons/AddonInstaller.h"
 #include "addons/AddonManager.h"
+#include "addons/AddonSystemSettings.h"
 #include "dialogs/GUIDialogExtendedProgressBar.h"
 #include "dialogs/GUIDialogKaiToast.h"
 #include "events/AddonManagementEvent.h"
@@ -63,7 +64,7 @@ void CRepositoryUpdater::OnJobComplete(unsigned int jobID, bool success, CJob* j
     CLog::Log(LOGDEBUG, "CRepositoryUpdater: done.");
     m_doneEvent.Set();
 
-    if (CSettings::GetInstance().GetInt(CSettings::SETTING_GENERAL_ADDONUPDATES) == AUTO_UPDATES_NOTIFY)
+    if (CSettings::GetInstance().GetInt(CSettings::SETTING_ADDONS_AUTOUPDATES) == AUTO_UPDATES_NOTIFY)
     {
       VECADDONS hasUpdate = CAddonMgr::GetInstance().GetOutdated();
       if (!hasUpdate.empty())
@@ -82,7 +83,7 @@ void CRepositoryUpdater::OnJobComplete(unsigned int jobID, bool success, CJob* j
       }
     }
 
-    if (CSettings::GetInstance().GetInt(CSettings::SETTING_GENERAL_ADDONUPDATES) == AUTO_UPDATES_ON)
+    if (CSettings::GetInstance().GetInt(CSettings::SETTING_ADDONS_AUTOUPDATES) == AUTO_UPDATES_ON)
       CAddonInstaller::GetInstance().InstallUpdates();
 
     ScheduleUpdate();
@@ -154,7 +155,7 @@ void CRepositoryUpdater::OnTimeout()
 
 void CRepositoryUpdater::OnSettingChanged(const CSetting* setting)
 {
-  if (setting->GetId() == CSettings::SETTING_GENERAL_ADDONUPDATES)
+  if (setting->GetId() == CSettings::SETTING_ADDONS_AUTOUPDATES)
     ScheduleUpdate();
 }
 
@@ -186,7 +187,7 @@ void CRepositoryUpdater::ScheduleUpdate()
   CSingleLock lock(m_criticalSection);
   m_timer.Stop(true);
 
-  if (CSettings::GetInstance().GetInt(CSettings::SETTING_GENERAL_ADDONUPDATES) == AUTO_UPDATES_NEVER)
+  if (CSettings::GetInstance().GetInt(CSettings::SETTING_ADDONS_AUTOUPDATES) == AUTO_UPDATES_NEVER)
     return;
 
   if (!CAddonMgr::GetInstance().HasAddons(ADDON_REPOSITORY))

--- a/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSP.cpp
+++ b/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSP.cpp
@@ -28,6 +28,7 @@ extern "C" {
 
 #include "ActiveAEDSPProcess.h"
 #include "addons/AddonInstaller.h"
+#include "addons/AddonSystemSettings.h"
 #include "addons/GUIDialogAddonSettings.h"
 #include "Application.h"
 #include "cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.h"
@@ -228,7 +229,7 @@ bool CActiveAEDSP::InstallAddonAllowed(const std::string &strAddonId) const
 
 void CActiveAEDSP::MarkAsOutdated(const std::string& strAddonId)
 {
-  if (IsActivated() && CSettings::GetInstance().GetInt(CSettings::SETTING_GENERAL_ADDONUPDATES) == AUTO_UPDATES_ON)
+  if (IsActivated() && CSettings::GetInstance().GetInt(CSettings::SETTING_ADDONS_AUTOUPDATES) == AUTO_UPDATES_ON)
   {
     CSingleLock lock(m_critSection);
     m_outdatedAddons.push_back(strAddonId);

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -24,6 +24,7 @@
 #include <utility>
 
 #include "addons/AddonInstaller.h"
+#include "addons/AddonSystemSettings.h"
 #include "Application.h"
 #include "dialogs/GUIDialogExtendedProgressBar.h"
 #include "dialogs/GUIDialogKaiToast.h"
@@ -282,7 +283,7 @@ bool CPVRManager::InstallAddonAllowed(const std::string& strAddonId) const
 
 void CPVRManager::MarkAsOutdated(const std::string& strAddonId)
 {
-  if (IsStarted() && CSettings::GetInstance().GetInt(CSettings::SETTING_GENERAL_ADDONUPDATES) == AUTO_UPDATES_ON)
+  if (IsStarted() && CSettings::GetInstance().GetInt(CSettings::SETTING_ADDONS_AUTOUPDATES) == ADDON::AUTO_UPDATES_ON)
   {
     CSingleLock lock(m_critSection);
     m_outdatedAddons.push_back(strAddonId);

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -26,6 +26,7 @@
 #include "LangInfo.h"
 #include "Util.h"
 #include "events/EventLog.h"
+#include "addons/AddonSystemSettings.h"
 #include "addons/RepositoryUpdater.h"
 #include "addons/Skin.h"
 #include "cores/AudioEngine/AEFactory.h"
@@ -402,8 +403,10 @@ const std::string CSettings::SETTING_CACHEDVD_DVDROM = "cachedvd.dvdrom";
 const std::string CSettings::SETTING_CACHEDVD_LAN = "cachedvd.lan";
 const std::string CSettings::SETTING_CACHEUNKNOWN_INTERNET = "cacheunknown.internet";
 const std::string CSettings::SETTING_SYSTEM_PLAYLISTSPATH = "system.playlistspath";
-const std::string CSettings::SETTING_GENERAL_ADDONUPDATES = "general.addonupdates";
-const std::string CSettings::SETTING_GENERAL_ADDONNOTIFICATIONS = "general.addonnotifications";
+const std::string CSettings::SETTING_ADDONS_AUTOUPDATES = "general.addonupdates";
+const std::string CSettings::SETTING_ADDONS_NOTIFICATIONS = "general.addonnotifications";
+const std::string CSettings::SETTING_ADDONS_SHOW_RUNNING = "addons.showrunning";
+const std::string CSettings::SETTING_ADDONS_MANAGE_DEPENDENCIES = "addons.managedependencies";
 const std::string CSettings::SETTING_GENERAL_ADDONFOREIGNFILTER = "general.addonforeignfilter";
 const std::string CSettings::SETTING_GENERAL_ADDONBROKENFILTER = "general.addonbrokenfilter";
 
@@ -1196,8 +1199,13 @@ void CSettings::InitializeISettingCallbacks()
   m_settingsManager->RegisterCallback(&ActiveAE::CActiveAEDSP::GetInstance(), settingSet);
 
   settingSet.clear();
-  settingSet.insert(CSettings::SETTING_GENERAL_ADDONUPDATES);
+  settingSet.insert(CSettings::SETTING_ADDONS_AUTOUPDATES);
   m_settingsManager->RegisterCallback(&ADDON::CRepositoryUpdater::GetInstance(), settingSet);
+
+  settingSet.clear();
+  settingSet.insert(CSettings::SETTING_ADDONS_SHOW_RUNNING);
+  settingSet.insert(CSettings::SETTING_ADDONS_MANAGE_DEPENDENCIES);
+  m_settingsManager->RegisterCallback(&ADDON::CAddonSystemSettings::GetInstance(), settingSet);
 
   settingSet.clear();
   settingSet.insert(CSettings::SETTING_POWERMANAGEMENT_WAKEONACCESS);

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -359,8 +359,10 @@ public:
   static const std::string SETTING_CACHEDVD_LAN;
   static const std::string SETTING_CACHEUNKNOWN_INTERNET;
   static const std::string SETTING_SYSTEM_PLAYLISTSPATH;
-  static const std::string SETTING_GENERAL_ADDONUPDATES;
-  static const std::string SETTING_GENERAL_ADDONNOTIFICATIONS;
+  static const std::string SETTING_ADDONS_AUTOUPDATES;
+  static const std::string SETTING_ADDONS_NOTIFICATIONS;
+  static const std::string SETTING_ADDONS_SHOW_RUNNING;
+  static const std::string SETTING_ADDONS_MANAGE_DEPENDENCIES;
   static const std::string SETTING_GENERAL_ADDONFOREIGNFILTER;
   static const std::string SETTING_GENERAL_ADDONBROKENFILTER;
 

--- a/xbmc/settings/windows/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/windows/GUIWindowSettingsCategory.cpp
@@ -212,15 +212,13 @@ void CGUIWindowSettingsCategory::Save()
 
 void CGUIWindowSettingsCategory::FocusCategory(const std::string& categoryId)
 {
-  for (int i = 0; i < m_categories.size(); ++i)
+  auto category = std::find_if(m_categories.cbegin(), m_categories.cend(),
+    [&categoryId](const CSettingCategory* category) { return category->GetId() == categoryId; });
+  if (category == m_categories.end())
   {
-    if (m_categories[i]->GetId() == categoryId)
-    {
-      m_iCategory = i;
-      SET_CONTROL_FOCUS(CONTROL_SETTINGS_START_BUTTONS + m_iCategory, 0);
-      CreateSettings();
-      return;
-    }
+    CLog::Log(LOGERROR, "CGUIWindowSettingsCategory: asked to focus unknown category '%s'.", categoryId.c_str());
+    return;
   }
-  CLog::Log(LOGERROR, "CGUIWindowSettingsCategory: asked to focus unknown category '%s'.", categoryId.c_str());
+
+  SET_CONTROL_FOCUS(CONTROL_SETTINGS_START_BUTTONS + std::distance(m_categories.cbegin(), category), 0);
 }

--- a/xbmc/settings/windows/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/windows/GUIWindowSettingsCategory.cpp
@@ -27,6 +27,7 @@
 #include "settings/DisplaySettings.h"
 #include "settings/Settings.h"
 #include "settings/lib/SettingSection.h"
+#include "utils/log.h"
 #include "view/ViewStateSettings.h"
 
 #define SETTINGS_PICTURES               WINDOW_SETTINGS_MYPICTURES - WINDOW_SETTINGS_START
@@ -91,6 +92,10 @@ bool CGUIWindowSettingsCategory::OnMessage(CGUIMessage &message)
       m_iSection = (int)message.GetParam2() - (int)CGUIDialogSettingsManagerBase::GetID();
       CGUIDialogSettingsManagerBase::OnMessage(message);
       m_returningFromSkinLoad = false;
+
+      if (!message.GetStringParam(0).empty())
+        FocusCategory(message.GetStringParam(0));
+
       return true;
     }
     
@@ -203,4 +208,19 @@ CSettingSection* CGUIWindowSettingsCategory::GetSection()
 void CGUIWindowSettingsCategory::Save()
 {
   m_settings.Save();
+}
+
+void CGUIWindowSettingsCategory::FocusCategory(const std::string& categoryId)
+{
+  for (int i = 0; i < m_categories.size(); ++i)
+  {
+    if (m_categories[i]->GetId() == categoryId)
+    {
+      m_iCategory = i;
+      SET_CONTROL_FOCUS(CONTROL_SETTINGS_START_BUTTONS + m_iCategory, 0);
+      CreateSettings();
+      return;
+    }
+  }
+  CLog::Log(LOGERROR, "CGUIWindowSettingsCategory: asked to focus unknown category '%s'.", categoryId.c_str());
 }

--- a/xbmc/settings/windows/GUIWindowSettingsCategory.h
+++ b/xbmc/settings/windows/GUIWindowSettingsCategory.h
@@ -46,7 +46,9 @@ protected:
   virtual int GetSettingLevel() const;
   virtual CSettingSection* GetSection();
   virtual void Save();
-  
+
+  void FocusCategory(const std::string& categoryId);
+
   CSettings& m_settings;
   int m_iSection;
   bool m_returningFromSkinLoad; // true if we are returning from loading the skin


### PR DESCRIPTION
This moves addon related settings to one common area and will allow more settings to added in the future (and without requiring skin changes). Currently it moves notifications/auto update settings from side menu, and, 'administrative' functionality from the 'system' directory.

Todo:
Something to 'ease' the transition for user? (e.g a link to settings from addon browser. Unfortunately it doesn't seem possibly programmically open a settings category atm.)
