### PR TITLE
[mmalcodec] Reduce buffering in codec

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.h
@@ -118,8 +118,6 @@ protected:
   // Components
   MMAL_INTERLACETYPE_T m_interlace_mode;
   EINTERLACEMETHOD  m_interlace_method;
-  double            m_demuxerPts;
-  double            m_decoderPts;
   int               m_speed;
 
   CCriticalSection m_sharedSection;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.h
@@ -123,6 +123,8 @@ protected:
   bool SendCodecConfigData();
 
   CDVDStreamInfo    m_hints;
+  float             m_fps;
+  unsigned          m_num_decoded;
   // Components
   MMAL_INTERLACETYPE_T m_interlace_mode;
   EINTERLACEMETHOD  m_interlace_method;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.h
@@ -118,6 +118,8 @@ protected:
   // Components
   MMAL_INTERLACETYPE_T m_interlace_mode;
   EINTERLACEMETHOD  m_interlace_method;
+  double            m_demuxerPts;
+  double            m_decoderPts;
   int               m_speed;
 
   CCriticalSection m_sharedSection;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.h
@@ -131,7 +131,6 @@ protected:
   double            m_demuxerPts;
   double            m_decoderPts;
   int               m_speed;
-  bool              m_preroll;
 
   CCriticalSection m_sharedSection;
   MMAL_COMPONENT_T *m_dec;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.h
@@ -64,13 +64,6 @@ private:
 
 class CMMALVideo : public CDVDVideoCodec
 {
-  typedef struct mmal_demux_packet {
-    uint8_t *buff;
-    int size;
-    double dts;
-    double pts;
-  } mmal_demux_packet;
-
 public:
   CMMALVideo();
   virtual ~CMMALVideo();
@@ -109,9 +102,6 @@ protected:
   bool              m_finished;
   float             m_aspect_ratio;
   const char        *m_pFormatName;
-
-  std::queue<mmal_demux_packet> m_demux_queue;
-  unsigned           m_demux_queue_length;
 
   // mmal output buffers (video frames)
   pthread_mutex_t   m_output_mutex;


### PR DESCRIPTION
By default the GPU on Pi will swallow large amounts of data. It has about 2MB of buffer on input to decoder as well as various message passing queues.

This provokes problems with videoplayer and live streams (e.g. TV), as it tries to estimate buffering from internal queue lengths which can rapidly change due to the downstream buffering.

This issue in particular provoked these changes:
http://forum.kodi.tv/showthread.php?tid=248578

There is now a new firmware control to limit the buffering in codec. We also remove the demux queue and limit the number of message passing buffers.

This was reported to have fixed the issue.
