### PR TITLE
fixed: leftover kodi prefix in include path

### DIFF
--- a/xbmc/addons/include/kodi_audiodec_types.h
+++ b/xbmc/addons/include/kodi_audiodec_types.h
@@ -22,7 +22,7 @@
 
 #include <stdint.h>
 #ifdef BUILD_KODI_ADDON
-#include "kodi/AEChannelData.h"
+#include "AEChannelData.h"
 #else
 #include "cores/AudioEngine/Utils/AEChannelData.h"
 #endif


### PR DESCRIPTION
This include still has the kodi/ prefix
