### PR TITLE
[keymaps] remote.xml: virtualkeyboard: back now maps to 'back', not 'backspace' anymore

### DIFF
--- a/system/keymaps/remote.xml
+++ b/system/keymaps/remote.xml
@@ -386,7 +386,7 @@
   </MyVideoPlaylist>
   <VirtualKeyboard>
     <remote>
-      <back>BackSpace</back>
+      <back>Back</back>
       <star>Shift</star>
       <hash>Symbols</hash>
       <zero>Number0</zero>
@@ -427,7 +427,7 @@
       <eight>Number8</eight>
       <nine>Number9</nine>
       <enter>Enter</enter>
-      <back>BackSpace</back>
+      <back>Back</back>
     </remote>
   </NumericInput>
   <Weather>


### PR DESCRIPTION
This makes it (finally) possible to cancel the virtual keyboard dialog using the "back" remote control key. Before, there was simply no(!) way for this.

See also https://github.com/xbmc/xbmc/pull/8617#issuecomment-165769797 ff.
