### PR TITLE
FFmpeg: Bump to 2.8.4-Jarvis-rc1-mp3

### DIFF
--- a/tools/depends/target/ffmpeg/FFMPEG-VERSION
+++ b/tools/depends/target/ffmpeg/FFMPEG-VERSION
@@ -1,5 +1,5 @@
 LIBNAME=ffmpeg
 BASE_URL=https://github.com/xbmc/FFmpeg/archive
-VERSION=2.8.4-Jarvis-rc1
+VERSION=2.8.4-Jarvis-rc1-mp3
 ARCHIVE=$(LIBNAME)-$(VERSION).tar.gz
 


### PR DESCRIPTION
This adds another patch to resolve the handbrake mp3s ... it was picked from upstream. Root cause should be fixed in handbrake 0.10.3
