### PR TITLE
AdjustRefreshRate: Take more digits into account when deciding matching fps

### DIFF
--- a/xbmc/guilib/Resolution.cpp
+++ b/xbmc/guilib/Resolution.cpp
@@ -256,8 +256,8 @@ RESOLUTION CResolutionUtils::FindClosestResolution(float fps, int width, bool is
     }
     else
     {
-      int c_weight = MathUtils::round_int(RefreshWeight(curr.fRefreshRate, fRefreshRate * multiplier) * 1000.0);
-      int i_weight = MathUtils::round_int(RefreshWeight(info.fRefreshRate, fRefreshRate * multiplier) * 1000.0);
+      int c_weight = MathUtils::round_int(RefreshWeight(curr.fRefreshRate, fRefreshRate * multiplier) * 10000.0);
+      int i_weight = MathUtils::round_int(RefreshWeight(info.fRefreshRate, fRefreshRate * multiplier) * 10000.0);
 
       RESOLUTION current_bak = current;
       RESOLUTION_INFO curr_bak = curr;


### PR DESCRIPTION
Found a user, that has a 1920x1080@59.54 hz resolution and also a 1920x1200@59.94 resolution. As the resolution switching code only takes the width into account this user ended up with 1920x1200. Height cannot be taken easily into account cause some movies are 1920x800. Therefore I train to maintain the original aspect_ratio with some tolerances, e.g. allow switching to 4096x2160 for a 4096 video even if the desktop res was 1920x1080 before.
