### PR TITLE
Fix compile error on msvs2013

### DIFF
--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -177,7 +177,7 @@
     </Manifest>
     <FxCompile />
     <PostBuildEvent>
-      <Command>copy “$(WindowsSdkDir)redist\d3d\x86\D3DCompile*.DLL” “$(TargetDir)”</Command>
+      <Command>copy "$(WindowsSdkDir)redist\d3d\x86\D3DCompile*.DLL" "$(TargetDir)"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/xbmc/input/InputCodingTableBasePY.cpp
+++ b/xbmc/input/InputCodingTableBasePY.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
 *      Copyright (C) 2005-2013 Team Kodi
 *      http://kodi.tv
 *


### PR DESCRIPTION
The following msg was posted when compile InputCodingTableBasePY.cpp on msvs2013
"The file contains a character that cannot be represented in the current code page (936)...".

And copy command in release configuration is not correct.
