### PR TITLE
[PVR] Add 'override' to all overridden PVR window member functions to…

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRChannels.h
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.h
@@ -29,14 +29,14 @@ namespace PVR
     CGUIWindowPVRChannels(bool bRadio);
     virtual ~CGUIWindowPVRChannels(void) {};
 
-    bool OnMessage(CGUIMessage& message);
-    void GetContextButtons(int itemNumber, CContextButtons &buttons);
-    bool OnContextButton(int itemNumber, CONTEXT_BUTTON button);
-    bool Update(const std::string &strDirectory, bool updateFilterPath = true);
-    void UpdateButtons(void);
-    void ResetObservers(void);
+    virtual bool OnMessage(CGUIMessage& message) override;
+    virtual void GetContextButtons(int itemNumber, CContextButtons &buttons) override;
+    virtual bool OnContextButton(int itemNumber, CONTEXT_BUTTON button) override;
+    virtual bool Update(const std::string &strDirectory, bool updateFilterPath = true) override;
+    virtual void UpdateButtons(void) override;
+    virtual void ResetObservers(void) override;
     void UnregisterObservers(void);
-    bool OnAction(const CAction &action);
+    virtual bool OnAction(const CAction &action) override;
 
   protected:
     virtual std::string GetDirectoryPath(void) override;

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.h
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.h
@@ -33,20 +33,20 @@ namespace PVR
     CGUIWindowPVRGuide(bool bRadio);
     virtual ~CGUIWindowPVRGuide(void);
 
-    virtual void OnInitWindow();
-    bool OnMessage(CGUIMessage& message);
-    bool OnAction(const CAction &action);
-    void GetContextButtons(int itemNumber, CContextButtons &buttons);
-    bool OnContextButton(int itemNumber, CONTEXT_BUTTON button);
-    void ResetObservers(void);
+    virtual void OnInitWindow() override;
+    virtual bool OnMessage(CGUIMessage& message) override;
+    virtual bool OnAction(const CAction &action) override;
+    virtual void GetContextButtons(int itemNumber, CContextButtons &buttons) override;
+    virtual bool OnContextButton(int itemNumber, CONTEXT_BUTTON button) override;
+    virtual void ResetObservers(void) override;
     void UnregisterObservers(void);
-    bool Update(const std::string &strDirectory, bool updateFilterPath = true);
-    void UpdateButtons(void);
+    virtual bool Update(const std::string &strDirectory, bool updateFilterPath = true) override;
+    virtual void UpdateButtons(void) override;
 
   protected:
-    void UpdateSelectedItemPath();
+    virtual void UpdateSelectedItemPath() override;
     virtual std::string GetDirectoryPath(void) override { return ""; }
-    virtual bool GetDirectory(const std::string &strDirectory, CFileItemList &items);
+    virtual bool GetDirectory(const std::string &strDirectory, CFileItemList &items) override;
 
   private:
     bool SelectPlayingFile(void);

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.h
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.h
@@ -34,19 +34,19 @@ namespace PVR
 
     static std::string GetResumeString(const CFileItem& item);
 
-    void OnWindowLoaded();
-    bool OnMessage(CGUIMessage& message);
-    bool OnAction(const CAction &action);
-    void GetContextButtons(int itemNumber, CContextButtons &buttons);
-    bool OnContextButton(int itemNumber, CONTEXT_BUTTON button);
-    bool Update(const std::string &strDirectory, bool updateFilterPath = true);
-    void UpdateButtons(void);
+    virtual void OnWindowLoaded() override;
+    virtual bool OnMessage(CGUIMessage& message) override;
+    virtual bool OnAction(const CAction &action) override;
+    virtual void GetContextButtons(int itemNumber, CContextButtons &buttons) override;
+    virtual bool OnContextButton(int itemNumber, CONTEXT_BUTTON button) override;
+    virtual bool Update(const std::string &strDirectory, bool updateFilterPath = true) override;
+    virtual void UpdateButtons(void) override;
     void UnregisterObservers(void);
-    void ResetObservers(void);
+    virtual void ResetObservers(void) override;
 
   protected:
     virtual std::string GetDirectoryPath(void) override;
-    void OnPrepareFileItems(CFileItemList &items);
+    virtual void OnPrepareFileItems(CFileItemList &items) override;
 
   private:
     bool ActionDeleteRecording(CFileItem *item);

--- a/xbmc/pvr/windows/GUIWindowPVRSearch.h
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.h
@@ -30,14 +30,14 @@ namespace PVR
     CGUIWindowPVRSearch(bool bRadio);
     virtual ~CGUIWindowPVRSearch(void) {};
 
-    bool OnMessage(CGUIMessage& message);
-    void OnWindowLoaded();
-    void GetContextButtons(int itemNumber, CContextButtons &buttons);
-    bool OnContextButton(int itemNumber, CONTEXT_BUTTON button);
-    bool OnContextButton(const CFileItem &item, CONTEXT_BUTTON button);
+    virtual bool OnMessage(CGUIMessage& message)  override;
+    virtual void OnWindowLoaded() override;
+    virtual void GetContextButtons(int itemNumber, CContextButtons &buttons) override;
+    virtual bool OnContextButton(int itemNumber, CONTEXT_BUTTON button) override;
+    virtual bool OnContextButton(const CFileItem &item, CONTEXT_BUTTON button) override;
 
   protected:
-    void OnPrepareFileItems(CFileItemList &items);
+    virtual void OnPrepareFileItems(CFileItemList &items) override;
     virtual std::string GetDirectoryPath(void) override { return ""; }
 
   private:


### PR DESCRIPTION
… silence llvm (xcode) warnings.

These warnings popped up after https://github.com/xbmc/xbmc/commit/6ebec9604645715b76d482ccc261c4c95fdc203f. Seems, that if you add 'override' to one member function of a class, llvm starts complaining about the rest if 'override' is missing'.

@Memphiz your take on this?
