### PR TITLE
Fix tabs vs spaces in autobuild.sh

### DIFF
--- a/tools/depends/target/ffmpeg/autobuild.sh
+++ b/tools/depends/target/ffmpeg/autobuild.sh
@@ -153,8 +153,8 @@ CFLAGS="$CFLAGS" CXXFLAGS="$CXXFLAGS" LDFLAGS="$LDFLAGS" \
 	--enable-libvorbis \
 	--enable-muxer=ogg \
 	--enable-encoder=libvorbis \
-        --enable-encoder=png \
-        --enable-encoder=mjpeg \
+	--enable-encoder=png \
+	--enable-encoder=mjpeg \
 	--enable-nonfree \
 	--enable-pthreads \
 	--enable-zlib \


### PR DESCRIPTION
Fix up: https://github.com/xbmc/xbmc/pull/8583

Thx to @FernetMenta 

Hark the harold whitespace sings ... glory to the 8 space tab!
