### PR TITLE
FIX: [droid] handle video rotation

### DIFF
--- a/xbmc/android/jni/MediaFormat.cpp
+++ b/xbmc/android/jni/MediaFormat.cpp
@@ -40,6 +40,7 @@ std::string CJNIMediaFormat::KEY_IS_ADTS;
 std::string CJNIMediaFormat::KEY_CHANNEL_MASK;
 std::string CJNIMediaFormat::KEY_AAC_PROFILE;
 std::string CJNIMediaFormat::KEY_FLAC_COMPRESSION_LEVEL;
+std::string CJNIMediaFormat::KEY_ROTATION;
 const char *CJNIMediaFormat::m_classname = "android/media/MediaFormat";
 
 void CJNIMediaFormat::PopulateStaticFields()
@@ -62,6 +63,11 @@ void CJNIMediaFormat::PopulateStaticFields()
     KEY_CHANNEL_MASK    = jcast<std::string>(get_static_field<jhstring>(clazz, "KEY_CHANNEL_MASK"));
     KEY_AAC_PROFILE     = jcast<std::string>(get_static_field<jhstring>(clazz, "KEY_AAC_PROFILE"));
     KEY_FLAC_COMPRESSION_LEVEL = jcast<std::string>(get_static_field<jhstring>(clazz, "KEY_FLAC_COMPRESSION_LEVEL"));
+
+    if(GetSDKVersion() >= 23)
+    {
+      KEY_ROTATION = jcast<std::string>(get_static_field<jhstring>(clazz, "KEY_ROTATION"));
+    }
   }
 }
 

--- a/xbmc/android/jni/MediaFormat.h
+++ b/xbmc/android/jni/MediaFormat.h
@@ -60,6 +60,7 @@ public:
   static std::string KEY_CHANNEL_MASK;
   static std::string KEY_AAC_PROFILE;
   static std::string KEY_FLAC_COMPRESSION_LEVEL;
+  static std::string KEY_ROTATION;
 
 private:
   CJNIMediaFormat();

--- a/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
@@ -628,6 +628,21 @@ void CLinuxRendererGLES::RenderUpdateVideo(bool clear, DWORD flags, DWORD alpha)
         break;
       }
 
+      // Handle orientation
+      switch (m_renderOrientation)
+      {
+        case 90:
+        case 270:
+        {
+          int diff = (int) ((dstRect.Height() - dstRect.Width()) / 2);
+          dstRect = CRect(dstRect.x1 - diff, dstRect.y1, dstRect.x2 + diff, dstRect.y2);
+          break;
+        }
+
+        default:
+          break;
+      }
+
       mci->RenderUpdate(srcRect, dstRect);
     }
   }

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -347,6 +347,12 @@ bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
     return false;
   }
 
+  if (hints.orientation && m_render_surface && CJNIMediaFormat::GetSDKVersion() < 23)
+  {
+    CLog::Log(LOGERROR, "CDVDVideoCodecAndroidMediaCodec::Open - %s\n", "Surface does not support orientation before API 23");
+    return false;
+  }
+
   m_drop = false;
   m_hints = hints;
 
@@ -904,6 +910,11 @@ bool CDVDVideoCodecAndroidMediaCodec::ConfigureMediaCodec(void)
     m_mime.c_str(), m_hints.width, m_hints.height);
   // some android devices forget to default the demux input max size
   mediaformat.setInteger(CJNIMediaFormat::KEY_MAX_INPUT_SIZE, 0);
+  if (CJNIMediaFormat::GetSDKVersion() >= 23 && m_render_surface)
+  {
+    // Handle rotation
+    mediaformat.setInteger(CJNIMediaFormat::KEY_ROTATION, m_hints.orientation);
+  }
 
   // handle codec extradata
   if (m_hints.extrasize)


### PR DESCRIPTION
Handle rotate with surface on API >= 23 and fallback to non-surface otherwise.

/cc @da-anda 

Note: Backport-needed = backport to master ;)
