### PR TITLE
do not hold graphicsContext lock during rendering

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1922,8 +1922,6 @@ void CApplication::Render()
     }
   }
 
-  CSingleLock lock(g_graphicsContext);
-
   if (g_graphicsContext.IsFullScreenVideo() && m_pPlayer->IsPlaying() && vsync_mode == VSYNC_VIDEO)
     g_Windowing.SetVSync(true);
   else if (vsync_mode == VSYNC_ALWAYS)
@@ -1980,8 +1978,6 @@ void CApplication::Render()
     g_infoManager.UpdateFPS();
     m_lastRenderTime = now;
   }
-
-  lock.Leave();
 
   if (g_graphicsContext.IsFullScreenVideo())
   {

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1849,22 +1849,6 @@ bool CApplication::LoadUserWindows()
   return true;
 }
 
-bool CApplication::RenderNoPresent()
-{
-  MEASURE_FUNCTION;
-
-// DXMERGE: This may have been important?
-//  g_graphicsContext.AcquireCurrentContext();
-
-  g_graphicsContext.Lock();
-  
-  bool hasRendered = g_windowManager.Render();
-
-  g_graphicsContext.Unlock();
-
-  return hasRendered;
-}
-
 float CApplication::GetDimScreenSaverLevel() const
 {
   if (!m_bScreenSave || !m_screenSaver ||
@@ -1962,21 +1946,18 @@ void CApplication::Render()
     if (g_graphicsContext.GetStereoMode())
     {
       g_graphicsContext.SetStereoView(RENDER_STEREO_VIEW_LEFT);
-      if (RenderNoPresent())
-        hasRendered = true;
+      hasRendered |= g_windowManager.Render();
 
       if (g_graphicsContext.GetStereoMode() != RENDER_STEREO_MODE_MONO)
       {
         g_graphicsContext.SetStereoView(RENDER_STEREO_VIEW_RIGHT);
-        if (RenderNoPresent())
-          hasRendered = true;
+        hasRendered |= g_windowManager.Render();
       }
       g_graphicsContext.SetStereoView(RENDER_STEREO_VIEW_OFF);
     }
     else
     {
-      if (RenderNoPresent())
-        hasRendered = true;
+      hasRendered |= g_windowManager.Render();
     }
     // execute post rendering actions (finalize window closing)
     g_windowManager.AfterRender();

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -138,7 +138,6 @@ public:
   virtual bool Initialize() override;
   virtual void FrameMove(bool processEvents, bool processGUI = true) override;
   virtual void Render() override;
-  virtual bool RenderNoPresent();
   virtual void Preflight();
   virtual bool Create() override;
   virtual bool Cleanup() override;

--- a/xbmc/addons/AddonCallbacksGUI.cpp
+++ b/xbmc/addons/AddonCallbacksGUI.cpp
@@ -2249,9 +2249,7 @@ void CGUIAddonRenderingControl::Render()
 {
   if (CBRender)
   {
-    g_graphicsContext.BeginPaint();
     CBRender(m_clientHandle);
-    g_graphicsContext.EndPaint();
   }
 }
 

--- a/xbmc/addons/Visualisation.cpp
+++ b/xbmc/addons/Visualisation.cpp
@@ -153,7 +153,6 @@ void CVisualisation::AudioData(const float* pAudioData, int iAudioDataLength, fl
 void CVisualisation::Render()
 {
   // ask visz. to render itself
-  g_graphicsContext.BeginPaint();
   if (Initialized())
   {
     try
@@ -165,7 +164,6 @@ void CVisualisation::Render()
       HandleException(e, "m_pStruct->Render (CVisualisation::Render)");
     }
   }
-  g_graphicsContext.EndPaint();
 }
 
 void CVisualisation::Stop()

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
@@ -550,8 +550,6 @@ void CLinuxRendererGL::RenderUpdate(bool clear, DWORD flags, DWORD alpha)
 
   ManageDisplay();
 
-  g_graphicsContext.BeginPaint();
-
   if (clear)
   {
     //draw black bars when video is not transparent, clear the entire backbuffer when it is
@@ -600,8 +598,6 @@ void CLinuxRendererGL::RenderUpdate(bool clear, DWORD flags, DWORD alpha)
   VerifyGLState();
   glEnable(GL_BLEND);
   glFlush();
-
-  g_graphicsContext.EndPaint();
 }
 
 void CLinuxRendererGL::ClearBackBuffer()
@@ -1871,7 +1867,6 @@ void CLinuxRendererGL::DeleteYV12Texture(int index)
   if( fields[FIELD_FULL][0].id == 0 ) return;
 
   /* finish up all textures, and delete them */
-  g_graphicsContext.BeginPaint();  //FIXME
   for(int f = 0;f<MAX_FIELDS;f++)
   {
     for(int p = 0;p<MAX_PLANES;p++)
@@ -1884,7 +1879,6 @@ void CLinuxRendererGL::DeleteYV12Texture(int index)
       }
     }
   }
-  g_graphicsContext.EndPaint();
 
   for(int p = 0;p<MAX_PLANES;p++)
   {
@@ -2145,7 +2139,6 @@ void CLinuxRendererGL::DeleteNV12Texture(int index)
   if( fields[FIELD_FULL][0].id == 0 ) return;
 
   // finish up all textures, and delete them
-  g_graphicsContext.BeginPaint();  //FIXME
   for(int f = 0;f<MAX_FIELDS;f++)
   {
     for(int p = 0;p<2;p++)
@@ -2161,7 +2154,6 @@ void CLinuxRendererGL::DeleteNV12Texture(int index)
     }
     fields[f][2].id = 0;
   }
-  g_graphicsContext.EndPaint();
 
   for(int p = 0;p<2;p++)
   {
@@ -2244,7 +2236,6 @@ void CLinuxRendererGL::DeleteYUV422PackedTexture(int index)
   if( fields[FIELD_FULL][0].id == 0 ) return;
 
   // finish up all textures, and delete them
-  g_graphicsContext.BeginPaint();  //FIXME
   for(int f = 0;f<MAX_FIELDS;f++)
   {
     if( fields[f][0].id )
@@ -2258,7 +2249,6 @@ void CLinuxRendererGL::DeleteYUV422PackedTexture(int index)
     fields[f][1].id = 0;
     fields[f][2].id = 0;
   }
-  g_graphicsContext.EndPaint();
 
   if (pbo[0])
   {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -447,8 +447,6 @@ void CLinuxRendererGLES::RenderUpdate(bool clear, DWORD flags, DWORD alpha)
 
   ManageDisplay();
 
-  g_graphicsContext.BeginPaint();
-
   m_iLastRenderBuffer = index;
 
   if (clear)
@@ -483,8 +481,6 @@ void CLinuxRendererGLES::RenderUpdate(bool clear, DWORD flags, DWORD alpha)
 
   VerifyGLState();
   glEnable(GL_BLEND);
-
-  g_graphicsContext.EndPaint();
 }
 
 void CLinuxRendererGLES::RenderUpdateVideo(bool clear, DWORD flags, DWORD alpha)
@@ -1364,7 +1360,6 @@ void CLinuxRendererGLES::DeleteYV12Texture(int index)
   if( fields[FIELD_FULL][0].id == 0 ) return;
 
   /* finish up all textures, and delete them */
-  g_graphicsContext.BeginPaint();  //FIXME
   for(int f = 0;f<MAX_FIELDS;f++)
   {
     for(int p = 0;p<MAX_PLANES;p++)
@@ -1377,7 +1372,6 @@ void CLinuxRendererGLES::DeleteYV12Texture(int index)
       }
     }
   }
-  g_graphicsContext.EndPaint();
 
   for(int p = 0;p<MAX_PLANES;p++)
   {
@@ -1727,7 +1721,6 @@ void CLinuxRendererGLES::DeleteNV12Texture(int index)
   if( fields[FIELD_FULL][0].id == 0 ) return;
 
   // finish up all textures, and delete them
-  g_graphicsContext.BeginPaint();  //FIXME
   for(int f = 0;f<MAX_FIELDS;f++)
   {
     for(int p = 0;p<2;p++)
@@ -1743,7 +1736,6 @@ void CLinuxRendererGLES::DeleteNV12Texture(int index)
     }
     fields[f][2].id = 0;
   }
-  g_graphicsContext.EndPaint();
 
   for(int p = 0;p<2;p++)
   {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -1045,6 +1045,8 @@ float CRenderManager::GetMaximumFPS()
 
 void CRenderManager::Render(bool clear, DWORD flags, DWORD alpha, bool gui)
 {
+  CSingleExit exitLock(g_graphicsContext);
+  
   CSharedLock lock(m_sharedSection);
 
   if (m_renderState != STATE_CONFIGURED)
@@ -1105,7 +1107,6 @@ bool CRenderManager::IsVideoLayer()
 /* simple present method */
 void CRenderManager::PresentSingle(bool clear, DWORD flags, DWORD alpha)
 {
-  CSingleLock lock(g_graphicsContext);
   SPresent& m = m_Queue[m_presentsource];
 
   if (m.presentfield == FS_BOT)
@@ -1120,7 +1121,6 @@ void CRenderManager::PresentSingle(bool clear, DWORD flags, DWORD alpha)
  * we just render the two fields right after eachother */
 void CRenderManager::PresentFields(bool clear, DWORD flags, DWORD alpha)
 {
-  CSingleLock lock(g_graphicsContext);
   SPresent& m = m_Queue[m_presentsource];
 
   if(m_presentstep == PRESENT_FRAME)
@@ -1141,7 +1141,6 @@ void CRenderManager::PresentFields(bool clear, DWORD flags, DWORD alpha)
 
 void CRenderManager::PresentBlend(bool clear, DWORD flags, DWORD alpha)
 {
-  CSingleLock lock(g_graphicsContext);
   SPresent& m = m_Queue[m_presentsource];
 
   if( m.presentfield == FS_BOT )

--- a/xbmc/guilib/GUIVideoControl.cpp
+++ b/xbmc/guilib/GUIVideoControl.cpp
@@ -60,7 +60,6 @@ void CGUIVideoControl::Render()
       CRect old = g_graphicsContext.GetScissors();
       CRect region = GetRenderRegion();
       region.Intersect(old);
-      g_graphicsContext.BeginPaint();
       g_graphicsContext.SetScissors(region);
 #ifdef HAS_IMXVPU
       g_graphicsContext.Clear((16 << 16)|(8 << 8)|16);
@@ -68,7 +67,6 @@ void CGUIVideoControl::Render()
       g_graphicsContext.Clear(0);
 #endif
       g_graphicsContext.SetScissors(old);
-      g_graphicsContext.EndPaint();
     }
     else
       g_application.m_pPlayer->Render(false, alpha);

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -1049,7 +1049,7 @@ void CGUIWindowManager::RenderEx() const
 bool CGUIWindowManager::Render()
 {
   assert(g_application.IsCurrentThread());
-  CSingleLock lock(g_graphicsContext);
+  CSingleExit lock(g_graphicsContext);
 
   CDirtyRegionList dirtyRegions = m_tracker.GetDirtyRegions();
 

--- a/xbmc/guilib/GraphicContext.cpp
+++ b/xbmc/guilib/GraphicContext.cpp
@@ -973,16 +973,6 @@ float CGraphicContext::GetFPS() const
   return 60.0f;
 }
 
-void CGraphicContext::BeginPaint(bool lock)
-{
-  if (lock) Lock();
-}
-
-void CGraphicContext::EndPaint(bool lock)
-{
-  if (lock) Unlock();
-}
-
 bool CGraphicContext::IsFullScreenRoot () const
 {
   return m_bFullScreenRoot;

--- a/xbmc/guilib/GraphicContext.h
+++ b/xbmc/guilib/GraphicContext.h
@@ -77,11 +77,6 @@ public:
 
   virtual void OnSettingChanged(const CSetting *setting) override;
 
-  // the following two functions should wrap any
-  // GL calls to maintain thread safety
-  void BeginPaint(bool lock=true);
-  void EndPaint(bool lock=true);
-
   int GetWidth() const { return m_iScreenWidth; }
   int GetHeight() const { return m_iScreenHeight; }
   float GetFPS() const;

--- a/xbmc/pictures/SlideShowPicture.cpp
+++ b/xbmc/pictures/SlideShowPicture.cpp
@@ -829,7 +829,6 @@ void CSlideShowPic::Render(float *x, float *y, CBaseTexture* pTexture, color_t c
   }
 
 #elif defined(HAS_GL)
-  g_graphicsContext.BeginPaint();
   if (pTexture)
   {
     int unit = 0;
@@ -908,9 +907,7 @@ void CSlideShowPic::Render(float *x, float *y, CBaseTexture* pTexture, color_t c
   glVertex3f(x[3], y[3], 0);
 
   glEnd();
-  g_graphicsContext.EndPaint();
 #elif defined(HAS_GLES)
-  g_graphicsContext.BeginPaint();
   if (pTexture)
   {
     pTexture->LoadToGPU();
@@ -976,8 +973,6 @@ void CSlideShowPic::Render(float *x, float *y, CBaseTexture* pTexture, color_t c
   glDisableVertexAttribArray(tex0Loc);
 
   g_Windowing.DisableGUIShader();
-
-  g_graphicsContext.EndPaint();
 #else
 // SDL render
   g_Windowing.BlitToScreen(m_pImage, NULL, NULL);

--- a/xbmc/rendering/gl/RenderSystemGL.cpp
+++ b/xbmc/rendering/gl/RenderSystemGL.cpp
@@ -441,8 +441,6 @@ void CRenderSystemGL::SetCameraPosition(const CPoint &camera, int screenWidth, i
   if (!m_bRenderCreated)
     return;
 
-  g_graphicsContext.BeginPaint();
-
   CPoint offset = camera - CPoint(screenWidth*0.5f, screenHeight*0.5f);
 
 
@@ -457,8 +455,6 @@ void CRenderSystemGL::SetCameraPosition(const CPoint &camera, int screenWidth, i
   glMatrixProject->LoadIdentity();
   glMatrixProject->Frustum( (-w - offset.x)*0.5f, (w - offset.x)*0.5f, (-h + offset.y)*0.5f, (h + offset.y)*0.5f, h, 100*h);
   glMatrixProject.Load();
-
-  g_graphicsContext.EndPaint();
 }
 
 void CRenderSystemGL::Project(float &x, float &y, float &z)

--- a/xbmc/rendering/gles/RenderSystemGLES.cpp
+++ b/xbmc/rendering/gles/RenderSystemGLES.cpp
@@ -406,8 +406,6 @@ void CRenderSystemGLES::SetCameraPosition(const CPoint &camera, int screenWidth,
   if (!m_bRenderCreated)
     return;
   
-  g_graphicsContext.BeginPaint();
-  
   CPoint offset = camera - CPoint(screenWidth*0.5f, screenHeight*0.5f);
   
   float w = (float)m_viewPort[2]*0.5f;
@@ -421,8 +419,6 @@ void CRenderSystemGLES::SetCameraPosition(const CPoint &camera, int screenWidth,
   glMatrixProject->LoadIdentity();
   glMatrixProject->Frustum( (-w - offset.x)*0.5f, (w - offset.x)*0.5f, (-h + offset.y)*0.5f, (h + offset.y)*0.5f, h, 100*h);
   glMatrixProject.Load();
-
-  g_graphicsContext.EndPaint();
 }
 
 void CRenderSystemGLES::Project(float &x, float &y, float &z)

--- a/xbmc/utils/Screenshot.cpp
+++ b/xbmc/utils/Screenshot.cpp
@@ -40,6 +40,7 @@
 
 #include "filesystem/File.h"
 #include "guilib/GraphicContext.h"
+#include "guilib/GUIWindowManager.h"
 
 #include "utils/JobManager.h"
 #include "utils/URIUtils.h"
@@ -77,7 +78,7 @@ bool CScreenshotSurface::capture()
 #elif defined(HAS_DX)
   g_graphicsContext.Lock();
 
-  g_application.RenderNoPresent();
+  g_windowManager.Render();
   g_Windowing.FinishCommandList();
 
   ID3D11DeviceContext* pImdContext = g_Windowing.GetImmediateContext();
@@ -133,7 +134,7 @@ bool CScreenshotSurface::capture()
 #elif defined(HAS_GL) || defined(HAS_GLES)
 
   g_graphicsContext.BeginPaint();
-  g_application.RenderNoPresent();
+  g_windowManager.Render();
 #ifndef HAS_GLES
   glReadBuffer(GL_BACK);
 #endif

--- a/xbmc/utils/Screenshot.cpp
+++ b/xbmc/utils/Screenshot.cpp
@@ -76,7 +76,8 @@ bool CScreenshotSurface::capture()
   if (!m_buffer)
     return false;
 #elif defined(HAS_DX)
-  g_graphicsContext.Lock();
+
+  CSingleLock lock(g_graphicsContext);
 
   g_windowManager.Render();
   g_Windowing.FinishCommandList();
@@ -129,11 +130,9 @@ bool CScreenshotSurface::capture()
   }
   SAFE_RELEASE(pRTTexture);
 
-  g_graphicsContext.Unlock();
-
 #elif defined(HAS_GL) || defined(HAS_GLES)
 
-  g_graphicsContext.BeginPaint();
+  CSingleLock lock(g_graphicsContext);
   g_windowManager.Render();
 #ifndef HAS_GLES
   glReadBuffer(GL_BACK);
@@ -153,7 +152,6 @@ bool CScreenshotSurface::capture()
 #else
   glReadPixels(viewport[0], viewport[1], viewport[2], viewport[3], GL_BGRA, GL_UNSIGNED_BYTE, (GLvoid*)surface);
 #endif
-  g_graphicsContext.EndPaint();
 
   //make a new buffer and copy the read image to it with the Y axis inverted
   m_buffer = new unsigned char[m_stride * m_height];


### PR DESCRIPTION
graphicsContext lock is one of our most critical and responsible for many deadlocks. There are many cases where it is not used correctly. One of those cases is that it was used to protect calls to the gfx layer like glXX. No need for a lock here because only the render thread is allowed to call those. The application design is as follows:
- manipulate some graphics object, can be done by any thread
- render thread calls FrameMove(), this prepares the actual render method like copying system memory to GPU (PBOs). FrameMove() grabs the gfx lock
- Render(), this calls the graphics layer functions like OpenGL, GLES, DX used to draw to the back buffer

One important thing we recently learned from Intel Mesa devs: An implementation is free to block in any of those function calls. Blocking in swapBuffers (what we assumed) is not mandatory. Now we don't want to hold the graphicsContext lock while blocking i.e. 41ms in glClear().
