### PR TITLE
VideoPlayer: add setting for double/triple buffers

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -15512,7 +15512,10 @@ msgctxt "#36042"
 msgid "Use limited colour range (16-235)"
 msgstr ""
 
-#empty string with id 36043
+#: system/settings/settings.xml
+msgctxt "#36043"
+msgid "Number of buffers used by graphics driver"
+msgstr ""
 
 #. Name of an action to perform on a specific event, like changing the CEC source away from Kodi
 #: xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -17717,7 +17720,13 @@ msgctxt "#36551"
 msgid "Defines the strength of the stereoscopic 3D effect in the GUI. This is done by controlling the depth of perception within the GUI, so the higher the value, the more elements will pop out of the screen. [Zero] Disables the stereoscopic 3D effect of the GUI.[CR]For a good visual experience, the value should be higher for small screens and lower for large screens. Note: this is not supported by all skins."
 msgstr ""
 
-#empty strings from id 36552 to 36599
+#. Description of setting "System -> Video output -> NoOfBuffers" with label #36043
+#: system/settings/settings.xml
+msgctxt "#36552"
+msgid "Select if graphics driver uses double or triple buffering."
+msgstr ""
+
+#empty strings from id 36553 to 36599
 
 #. Description of setting "System -> Video output -> Dither" with label #36099
 #: system/settings/settings.xml

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2421,6 +2421,19 @@
           </updates>
           <control type="list" format="string" />
         </setting>
+        <setting id="videoscreen.noofbuffers" type="integer" label="36043" help="36552">
+          <level>2</level>
+          <default>3</default> <!-- triple buffers -->
+          <constraints>
+            <minimum>2</minimum>
+            <step>1</step>
+            <maximum>3</maximum>
+          </constraints>
+          <updates>
+            <update type="change" />
+          </updates>
+          <control type="list" format="string" />
+        </setting>
         <setting id="videoscreen.guicalibration" type="action" label="214" help="36357">
           <level>1</level>
           <control type="button" format="action" />

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -1158,10 +1158,15 @@ void CRenderManager::PresentBlend(bool clear, DWORD flags, DWORD alpha)
 
 void CRenderManager::UpdateDisplayLatency()
 {
-  float refresh = g_graphicsContext.GetFPS();
+  float fps = g_graphicsContext.GetFPS();
+  float refresh = fps;
   if (g_graphicsContext.GetVideoResolution() == RES_WINDOW)
     refresh = 0; // No idea about refresh rate when windowed, just get the default latency
   m_displayLatency = (double) g_advancedSettings.GetDisplayLatency(refresh);
+
+  int buffers = CSettings::GetInstance().GetInt(CSettings::SETTING_VIDEOSCREEN_NOOFBUFFERS);
+  m_displayLatency += (buffers - 1) / fps;
+
   //CLog::Log(LOGDEBUG, "CRenderManager::UpdateDisplayLatency - Latency set to %1.0f msec", m_displayLatency * 1000.0f);
 }
 

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -340,6 +340,7 @@ const std::string CSettings::SETTING_VIDEOSCREEN_BLANKDISPLAYS = "videoscreen.bl
 const std::string CSettings::SETTING_VIDEOSCREEN_STEREOSCOPICMODE = "videoscreen.stereoscopicmode";
 const std::string CSettings::SETTING_VIDEOSCREEN_PREFEREDSTEREOSCOPICMODE = "videoscreen.preferedstereoscopicmode";
 const std::string CSettings::SETTING_VIDEOSCREEN_VSYNC = "videoscreen.vsync";
+const std::string CSettings::SETTING_VIDEOSCREEN_NOOFBUFFERS = "videoscreen.noofbuffers";
 const std::string CSettings::SETTING_VIDEOSCREEN_GUICALIBRATION = "videoscreen.guicalibration";
 const std::string CSettings::SETTING_VIDEOSCREEN_TESTPATTERN = "videoscreen.testpattern";
 const std::string CSettings::SETTING_VIDEOSCREEN_LIMITEDRANGE = "videoscreen.limitedrange";

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -297,6 +297,7 @@ public:
   static const std::string SETTING_VIDEOSCREEN_STEREOSCOPICMODE;
   static const std::string SETTING_VIDEOSCREEN_PREFEREDSTEREOSCOPICMODE;
   static const std::string SETTING_VIDEOSCREEN_VSYNC;
+  static const std::string SETTING_VIDEOSCREEN_NOOFBUFFERS;
   static const std::string SETTING_VIDEOSCREEN_GUICALIBRATION;
   static const std::string SETTING_VIDEOSCREEN_TESTPATTERN;
   static const std::string SETTING_VIDEOSCREEN_LIMITEDRANGE;


### PR DESCRIPTION
The number of buffers influence a/v sync. Although we request double buffering when when creating a GL context, an implementation is free to use more buffers. I set the default to 3 because to my knowledge most systems use triple buffering by default.
