### PR TITLE
[guilib] remove double call to UpdateButtons()

### DIFF
--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -823,8 +823,6 @@ bool CGUIMediaWindow::Update(const std::string &strDirectory, bool updateFilterP
   // Filter and group the items if necessary
   OnFilterItems(GetProperty("filter").asString());
 
-  UpdateButtons();
-
   strSelectedItem = m_history.GetSelectedItem(m_vecItems->GetPath());
 
   bool bSelectedFound = false;


### PR DESCRIPTION
UpdateButtons() already gets called at the very end of OnFilterItems(), so I guess there is no need to do it a second time?
@Razzeee @Montellese        
