### PR TITLE
[guilib] MyPics: set content to "images" when entering sources

### DIFF
--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -302,9 +302,11 @@ bool CGUIWindowPictures::GetDirectory(const std::string &strDirectory, CFileItem
     return false;
 
   std::string label;
-  if (items.GetLabel().empty() && m_rootDir.IsSource(items.GetPath(), CMediaSourceSettings::GetInstance().GetSources("pictures"), &label)) 
+  if (items.GetLabel().empty() && m_rootDir.IsSource(items.GetPath(), CMediaSourceSettings::GetInstance().GetSources("pictures"), &label))
     items.SetLabel(label);
 
+  if (items.GetContent().empty() && !items.IsVirtualDirectoryRoot())
+    items.SetContent("images");
   return true;
 }
 


### PR DESCRIPTION
To be consistent, the root node in pictures section should have a different content type compared to when entering one of the sources. With this PR, content type is set to "images" when entering one of the source folders.
@Razzeee @ronie     
