### PR TITLE
DVDDemuxFFmpeg: Support HTTP proxies with the new http_proxy option

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -634,6 +634,8 @@ AVDictionary *CDVDDemuxFFmpeg::GetFFMpegOptionsFromURL(const CURL &url)
         av_dict_set(&options, "user-agent", value.c_str(), 0);
         hasUserAgent = true;
       }
+      else if (name == "httpproxy")
+        av_dict_set(&options, "http_proxy", value.c_str(), 0);
       else if (name != "auth" && name != "encoding")
         // all other protocol options can be added as http header.
         headers.append(it->first).append(": ").append(value).append("\r\n");


### PR DESCRIPTION
Since c48122d7, FFmpeg has supported the http_proxy option for the
HTTP protocol.

Previously, CDVDDemuxFFmpeg would pass Kodi httpproxy CURL protocol
option through as a HTTP header, which the server would (hopefully
ignore. With this change, if Kodi is built with an older version of
FFmpeg, FFmpeg will simply ignore the option - which is an
improvement over sending spurious HTTP headers.
