### PR TITLE
[addons] cleanup state properties

### DIFF
--- a/xbmc/addons/AddonDatabase.cpp
+++ b/xbmc/addons/AddonDatabase.cpp
@@ -628,7 +628,6 @@ void CAddonDatabase::SetPropertiesFromAddon(const AddonPtr& addon,
 {
   pItem->SetProperty("Addon.ID", addon->ID());
   pItem->SetProperty("Addon.Type", TranslateType(addon->Type(),true));
-  pItem->SetProperty("Addon.intType", TranslateType(addon->Type()));
   pItem->SetProperty("Addon.Name", addon->Name());
   pItem->SetProperty("Addon.Version", addon->Version().asString());
   pItem->SetProperty("Addon.Summary", addon->Summary());

--- a/xbmc/addons/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/GUIDialogAddonInfo.cpp
@@ -489,31 +489,7 @@ bool CGUIDialogAddonInfo::SetItem(const CFileItemPtr& item)
 
   CAddonDatabase database;
   database.Open();
-  database.GetAddon(item->GetProperty("Addon.ID").asString(),m_addon);
-
-  if (TranslateType(item->GetProperty("Addon.intType").asString()) == ADDON_REPOSITORY)
-  {
-    CAddonDatabase database;
-    database.Open();
-    VECADDONS addons;
-    if (m_addon)
-      database.GetRepositoryContent(m_addon->ID(), addons);
-    else if (m_localAddon) // sanity
-      database.GetRepositoryContent(m_localAddon->ID(), addons);
-    int tot=0;
-    for (int i = ADDON_UNKNOWN+1;i<ADDON_MAX;++i)
-    {
-      int num=0;
-      for (unsigned int j=0;j<addons.size();++j)
-      {
-        if (addons[j]->Type() == (TYPE)i)
-          ++num;
-      }
-      m_item->SetProperty("Repo." + TranslateType((TYPE)i), num);
-      tot += num;
-    }
-    m_item->SetProperty("Repo.Addons", tot);
-  }
+  database.GetAddon(item->GetProperty("Addon.ID").asString(), m_addon);
   return true;
 }
 

--- a/xbmc/addons/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/GUIDialogAddonInfo.cpp
@@ -448,8 +448,7 @@ void CGUIDialogAddonInfo::OnChangeLog()
   {
     pDlgInfo->SetText(g_localizeStrings.Get(13413));
     CFileItemList items;
-    if (m_localAddon && 
-        !m_item->GetProperty("Addon.UpdateAvail").asBoolean())
+    if (m_localAddon && !m_item->GetProperty("Addon.HasUpdate").asBoolean())
     {
       items.Add(CFileItemPtr(new CFileItem(m_localAddon->ChangeLog(),false)));
     }
@@ -483,15 +482,10 @@ bool CGUIDialogAddonInfo::ShowForItem(const CFileItemPtr& item)
 bool CGUIDialogAddonInfo::SetItem(const CFileItemPtr& item)
 {
   *m_item = *item;
-
-  // grab the local addon, if it's available
   m_localAddon.reset();
   m_addon.reset();
-  if (CAddonMgr::GetInstance().GetAddon(item->GetProperty("Addon.ID").asString(), m_localAddon)) // sets m_localAddon if installed regardless of enabled state
-    m_item->SetProperty("Addon.Enabled", "true");
-  else
-    m_item->SetProperty("Addon.Enabled", "false");
-  m_item->SetProperty("Addon.Installed", m_localAddon ? "true" : "false");
+
+  CAddonMgr::GetInstance().GetAddon(item->GetProperty("Addon.ID").asString(), m_localAddon, ADDON_UNKNOWN, false);
 
   CAddonDatabase database;
   database.Open();

--- a/xbmc/addons/GUIDialogAddonInfo.h
+++ b/xbmc/addons/GUIDialogAddonInfo.h
@@ -55,7 +55,7 @@ private:
   void OnUpdate();
   void OnInstall();
   void OnUninstall();
-  void OnEnable(bool enable);
+  void OnEnableDisable();
   void OnSettings();
   void OnChangeLog();
   void OnSelect();
@@ -82,6 +82,7 @@ private:
   CFileItemPtr m_item;
   ADDON::AddonPtr m_addon;
   ADDON::AddonPtr m_localAddon;
+  bool m_addonEnabled;
   unsigned int m_jobid;
   bool m_changelog;
 };


### PR DESCRIPTION
This makes the Installed, Enabled and HasUpdate properties available for all list items, and
removes some existing (undocumented) properties that shouldn't be exposed (see individual commits).
