### PR TITLE
[fix][pvr] wrong group if channel switched by its internal id

### DIFF
--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -704,13 +704,14 @@ bool CPVRManager::ChannelSwitchById(unsigned int iChannelId)
   CSingleLock lock(m_critSection);
 
   CPVRChannelPtr channel = m_channelGroups->GetChannelById(iChannelId);
-  if (!channel)
+  if (channel)
   {
-    CLog::Log(LOGERROR, "PVRManager - %s - cannot find channel with id %d", __FUNCTION__, iChannelId);
-    return false;
+    SetPlayingGroup(channel);
+    return PerformChannelSwitch(channel, false);
   }
 
-  return PerformChannelSwitch(channel, false);
+  CLog::Log(LOGERROR, "PVRManager - %s - cannot find channel with id %d", __FUNCTION__, iChannelId);
+  return false;
 }
 
 bool CPVRManager::ChannelUpDown(unsigned int *iNewChannelNumber, bool bPreview, bool bUp)
@@ -1009,6 +1010,20 @@ void CPVRManager::SetPlayingGroup(CPVRChannelGroupPtr group)
     m_channelGroups->Get(group->IsRadio())->SetSelectedGroup(group);
 }
 
+void CPVRManager::SetPlayingGroup(const CPVRChannelPtr &channel)
+{
+  CPVRChannelGroupPtr group = m_channelGroups->GetSelectedGroup(channel->IsRadio());
+  if (!group || !group->IsGroupMember(channel))
+  {
+    // The channel we'll switch to is not part of the current selected group.
+    // Set the first group as the selected group where the channel is a member.
+    CPVRChannelGroups *channelGroups = m_channelGroups->Get(channel->IsRadio());
+    std::vector<CPVRChannelGroupPtr> groups = channelGroups->GetGroupsByChannel(channel, true);
+    if (!groups.empty())
+      channelGroups->SetSelectedGroup(groups.front());
+  }
+}
+
 CPVRChannelGroupPtr CPVRManager::GetPlayingGroup(bool bRadio /* = false */)
 {
   if (m_channelGroups)
@@ -1043,33 +1058,34 @@ bool CPVRChannelGroupsUpdateJob::DoWork(void)
   return g_PVRChannelGroups->Update(false);
 }
 
-bool CPVRManager::OpenLiveStream(const CFileItem &channel)
+bool CPVRManager::OpenLiveStream(const CFileItem &fileItem)
 {
   bool bReturn(false);
-  if (!channel.HasPVRChannelInfoTag())
+  if (!fileItem.HasPVRChannelInfoTag())
     return bReturn;
 
   CLog::Log(LOGDEBUG,"PVRManager - %s - opening live stream on channel '%s'",
-      __FUNCTION__, channel.GetPVRChannelInfoTag()->ChannelName().c_str());
+      __FUNCTION__, fileItem.GetPVRChannelInfoTag()->ChannelName().c_str());
 
   // check if we're allowed to play this file
-  if (IsParentalLocked(channel.GetPVRChannelInfoTag()))
+  if (IsParentalLocked(fileItem.GetPVRChannelInfoTag()))
     return bReturn;
 
-  if ((bReturn = m_addons->OpenStream(channel.GetPVRChannelInfoTag(), false)) != false)
+  if ((bReturn = m_addons->OpenStream(fileItem.GetPVRChannelInfoTag(), false)) != false)
   {
     CSingleLock lock(m_critSection);
     if(m_currentFile)
       delete m_currentFile;
-    m_currentFile = new CFileItem(channel);
+    m_currentFile = new CFileItem(fileItem);
 
-    // set channel as selected item
-    if (channel.HasPVRChannelInfoTag())
-      CGUIWindowPVRBase::SetSelectedItemPath(channel.GetPVRChannelInfoTag()->IsRadio(), channel.GetPVRChannelInfoTag()->Path());
-
-    CPVRChannelPtr playingChannel(m_addons->GetPlayingChannel());
-    if (playingChannel)
-      UpdateLastWatched(playingChannel);
+    CPVRChannelPtr channel(m_addons->GetPlayingChannel());
+    if (channel)
+    {
+      SetPlayingGroup(channel);
+      UpdateLastWatched(channel);
+      // set channel as selected item
+      CGUIWindowPVRBase::SetSelectedItemPath(channel->IsRadio(), channel->Path());
+    }
   }
 
   return bReturn;

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -106,6 +106,12 @@ namespace PVR
      */
     void UpdateLastWatched(const CPVRChannelPtr &channel);
 
+    /*!
+     * @brief Set the playing group to the first group the channel is in if the given channel is not part of the current playing group
+     * @param channel The channel
+     */
+    void SetPlayingGroup(const CPVRChannelPtr &channel);
+
   public:
     /*!
      * @brief Stop the PVRManager and destroy all objects it created.
@@ -328,10 +334,10 @@ namespace PVR
 
     /*!
      * @brief Open a stream from the given channel.
-     * @param channel The channel to open.
+     * @param fileItem The file item with the channel to open.
      * @return True if the stream was opened, false otherwise.
      */
-    bool OpenLiveStream(const CFileItem &channel);
+    bool OpenLiveStream(const CFileItem &fileItem);
 
     /*!
      * @brief Open a stream from the given recording.

--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -173,6 +173,17 @@ CPVRChannelGroupPtr CPVRChannelGroups::GetById(int iGroupId) const
   return empty;
 }
 
+std::vector<CPVRChannelGroupPtr> CPVRChannelGroups::GetGroupsByChannel(const CPVRChannelPtr channel, bool bExcludeHidden /* = false */) const
+{
+  std::vector<CPVRChannelGroupPtr> groups;
+  for (CPVRChannelGroupPtr group : m_groups)
+  {
+    if ((!bExcludeHidden || !group->IsHidden()) && group->IsGroupMember(channel))
+      groups.push_back(group);
+  }
+  return groups;
+}
+
 CPVRChannelGroupPtr CPVRChannelGroups::GetByName(const std::string &strName) const
 {
   CSingleLock lock(m_critSection);

--- a/xbmc/pvr/channels/PVRChannelGroups.h
+++ b/xbmc/pvr/channels/PVRChannelGroups.h
@@ -86,6 +86,14 @@ namespace PVR
     CPVRChannelGroupPtr GetById(int iGroupId) const;
 
     /*!
+     * @brief Get all groups the given channel is a member.
+     * @param channel The channel.
+     * @param bExcludeHidden Whenever to exclude hidden channel groups.
+     * @return A list of groups the channel is a member.
+     */
+    std::vector<CPVRChannelGroupPtr> GetGroupsByChannel(const CPVRChannelPtr channel, bool bExcludeHidden = false) const;
+
+    /*!
      * @brief Get a group given it's name.
      * @param strName The name.
      * @return The group or NULL if it wan't found.


### PR DESCRIPTION
As a follow-up for #8660 this PR will fix the issue that the wrong group remains selected if you select a channel by its internal id (e.g. with JSON-RPC) which is not a member of the currently selected group.

With this PR it'll check if the channel you want to switch to is part of the current selected group and if not it'll find the first visible group the channel is in and select that group before switching the channel.

@FernetMenta as mentioned by you.

> I think that GetPlayingGroup even returns incorrect values if a channel was selected by json-rpc.

@ksooo or @Jalle19 mind taking a look.
