### PR TITLE
VideoPlayer: implement drain for video codecs

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.cpp
@@ -195,12 +195,6 @@ CDVDVideoCodec* CDVDFactoryCodec::CreateVideoCodec(CDVDStreamInfo &hint, const C
 #endif
   CLog::Log(LOGDEBUG, "CDVDFactoryCodec: compiled in hardware support: %s", hwSupport.c_str());
 
-  if (hint.stills && (hint.codec == AV_CODEC_ID_MPEG2VIDEO || hint.codec == AV_CODEC_ID_MPEG1VIDEO))
-  {
-     // If dvd is an mpeg2 and hint.stills
-     if ( (pCodec = OpenCodec(new CDVDVideoCodecLibMpeg2(), hint, options)) ) return pCodec;
-  }
-
 #if defined(HAS_LIBAMCODEC)
   // amcodec can handle dvd playback.
   if (!hint.software && CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_USEAMCODEC))

--- a/xbmc/cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.cpp
@@ -82,7 +82,7 @@ CDVDVideoCodec* CDVDFactoryCodec::OpenCodec(CDVDVideoCodec* pCodec, CDVDStreamIn
   {
     CLog::Log(LOGERROR, "FactoryCodec - Video: Failed with exception");
   }
-  return NULL;
+  return nullptr;
 }
 
 CDVDAudioCodec* CDVDFactoryCodec::OpenCodec(CDVDAudioCodec* pCodec, CDVDStreamInfo &hints, CDVDCodecOptions &options )
@@ -104,7 +104,7 @@ CDVDAudioCodec* CDVDFactoryCodec::OpenCodec(CDVDAudioCodec* pCodec, CDVDStreamIn
   {
     CLog::Log(LOGERROR, "FactoryCodec - Audio: Failed with exception");
   }
-  return NULL;
+  return nullptr;
 }
 
 CDVDOverlayCodec* CDVDFactoryCodec::OpenCodec(CDVDOverlayCodec* pCodec, CDVDStreamInfo &hints, CDVDCodecOptions &options )
@@ -126,192 +126,45 @@ CDVDOverlayCodec* CDVDFactoryCodec::OpenCodec(CDVDOverlayCodec* pCodec, CDVDStre
   {
     CLog::Log(LOGERROR, "FactoryCodec - Audio: Failed with exception");
   }
-  return NULL;
+  return nullptr;
 }
 
 
 CDVDVideoCodec* CDVDFactoryCodec::CreateVideoCodec(CDVDStreamInfo &hint, const CRenderInfo &info, IVPClockCallback* clock)
 {
-  CDVDVideoCodec* pCodec = NULL;
+  CDVDVideoCodec* pCodec = nullptr;
   CDVDCodecOptions options;
 
-  if(info.formats.empty())
+  if (info.formats.empty())
     options.m_formats.push_back(RENDER_FMT_YUV420P);
   else
     options.m_formats = info.formats;
 
   options.m_opaque_pointer = info.opaque_pointer;
 
-  //when support for a hardware decoder is not compiled in
-  //only print it if it's actually available on the platform
-  std::string hwSupport;
-#if defined(TARGET_DARWIN_OSX)
-  hwSupport += "VDADecoder:yes ";
-#endif
-#if defined(HAVE_VIDEOTOOLBOXDECODER) && defined(TARGET_DARWIN)
-  hwSupport += "VideoToolBoxDecoder:yes ";
-#elif defined(TARGET_DARWIN)
-  hwSupport += "VideoToolBoxDecoder:no ";
-#endif
-#if defined(HAS_LIBAMCODEC)
-  hwSupport += "AMCodec:yes ";
-#else
-  hwSupport += "AMCodec:no ";
-#endif
-#if defined(TARGET_ANDROID)
-  hwSupport += "MediaCodec:yes ";
-#else
-  hwSupport += "MediaCodec:no ";
-#endif
-#if defined(HAVE_LIBOPENMAX)
-  hwSupport += "OpenMax:yes ";
-#elif defined(TARGET_POSIX)
-  hwSupport += "OpenMax:no ";
-#endif
-#if defined(HAVE_LIBVDPAU) && defined(TARGET_POSIX)
-  hwSupport += "VDPAU:yes ";
-#elif defined(TARGET_POSIX) && !defined(TARGET_DARWIN)
-  hwSupport += "VDPAU:no ";
-#endif
-#if defined(TARGET_WINDOWS) && defined(HAS_DX)
-  hwSupport += "DXVA:yes ";
-#elif defined(TARGET_WINDOWS)
-  hwSupport += "DXVA:no ";
-#endif
-#if defined(HAVE_LIBVA) && defined(TARGET_POSIX)
-  hwSupport += "VAAPI:yes ";
-#elif defined(TARGET_POSIX) && !defined(TARGET_DARWIN)
-  hwSupport += "VAAPI:no ";
-#endif
-#if defined(HAS_IMXVPU)
-  hwSupport += "iMXVPU:yes ";
-#else
-  hwSupport += "iMXVPU:no ";
-#endif
-#if defined(HAS_MMAL)
-  hwSupport += "MMAL:yes ";
-#else
-  hwSupport += "MMAL:no ";
-#endif
-  CLog::Log(LOGDEBUG, "CDVDFactoryCodec: compiled in hardware support: %s", hwSupport.c_str());
-
-#if defined(HAS_LIBAMCODEC)
-  // amcodec can handle dvd playback.
-  if (!hint.software && CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_USEAMCODEC))
-  {
-    switch(hint.codec)
-    {
-      case AV_CODEC_ID_MPEG4:
-      case AV_CODEC_ID_MSMPEG4V2:
-      case AV_CODEC_ID_MSMPEG4V3:
-        // Avoid h/w decoder for SD; Those files might use features
-        // not supported and can easily be soft-decoded
-        if (hint.width <= 800)
-          break;
-      default:
-        if ( (pCodec = OpenCodec(new CDVDVideoCodecAmlogic(clock), hint, options)) ) return pCodec;
-    }
-  }
-#endif
-
-#if defined(HAS_IMXVPU)
   if (!hint.software)
   {
-    if ( (pCodec = OpenCodec(new CDVDVideoCodecIMX(), hint, options)) ) return pCodec;
+#if defined(HAS_IMXVPU)
+    pCodec = OpenCodec(new CDVDVideoCodecIMX(), hint, options);
+#elif defined(HAS_LIBAMCODEC)
+    pCodec = OpenCodec(new CDVDVideoCodecAmlogic(clock), hint, options);
+#elif defined(HAVE_VIDEOTOOLBOXDECODER)
+    pCodec = OpenCodec(new CDVDVideoCodecVideoToolBox(), hint, options);
+#elif defined(TARGET_ANDROID)
+    pCodec = OpenCodec(new CDVDVideoCodecAndroidMediaCodec(), hint, options);
+#elif defined(HAVE_LIBOPENMAX)
+    pCodec = OpenCodec(new CDVDVideoCodecOpenMax(), hint, options);
+#elif defined(HAS_MMAL)
+    pCodec = OpenCodec(new CMMALVideo(), hint, options);
+#endif
+    if (pCodec)
+      return pCodec;
   }
-#endif
-
-#if defined(TARGET_DARWIN_OSX)
-  if (!hint.software && CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_USEVDA) && !g_advancedSettings.m_useFfmpegVda)
-  {
-    if (hint.codec == AV_CODEC_ID_H264 && !hint.ptsinvalid)
-    {
-      if ( (pCodec = OpenCodec(new CDVDVideoCodecVDA(), hint, options)) ) return pCodec;
-    }
-  }
-#endif
-
-#if defined(HAVE_VIDEOTOOLBOXDECODER)
-  if (!hint.software && CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_USEVIDEOTOOLBOX))
-  {
-    if (g_sysinfo.HasVideoToolBoxDecoder())
-    {
-      switch(hint.codec)
-      {
-        case AV_CODEC_ID_H264:
-          if (hint.codec == AV_CODEC_ID_H264 && hint.ptsinvalid)
-            break;
-          if ( (pCodec = OpenCodec(new CDVDVideoCodecVideoToolBox(), hint, options)) ) return pCodec;
-          break;
-        default:
-          break;
-      }
-    }
-  }
-#endif
-
-#if defined(TARGET_ANDROID)
-  if (!hint.software && CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_USEMEDIACODECSURFACE))
-  {
-    switch(hint.codec)
-    {
-      case AV_CODEC_ID_MPEG4:
-      case AV_CODEC_ID_MSMPEG4V2:
-      case AV_CODEC_ID_MSMPEG4V3:
-        // Avoid h/w decoder for SD; Those files might use features
-        // not supported and can easily be soft-decoded
-        if (hint.width <= 800)
-          break;
-      default:
-        CLog::Log(LOGINFO, "MediaCodec (Surface) Video Decoder...");
-        if ( (pCodec = OpenCodec(new CDVDVideoCodecAndroidMediaCodec(true), hint, options)) ) return pCodec;
-    }
-  }
-  if (!hint.software && CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_USEMEDIACODEC))
-  {
-    switch(hint.codec)
-    {
-      case AV_CODEC_ID_MPEG4:
-      case AV_CODEC_ID_MSMPEG4V2:
-      case AV_CODEC_ID_MSMPEG4V3:
-        // Avoid h/w decoder for SD; Those files might use features
-        // not supported and can easily be soft-decoded
-        if (hint.width <= 800)
-          break;
-      default:
-        CLog::Log(LOGINFO, "MediaCodec Video Decoder...");
-        if ( (pCodec = OpenCodec(new CDVDVideoCodecAndroidMediaCodec(false), hint, options)) ) return pCodec;
-    }
-  }
-#endif
-
-#if defined(HAVE_LIBOPENMAX)
-    if (CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_USEOMX) && !hint.software )
-    {
-      if (hint.codec == AV_CODEC_ID_H264 || hint.codec == AV_CODEC_ID_MPEG2VIDEO || hint.codec == AV_CODEC_ID_VC1)
-      {
-        if ( (pCodec = OpenCodec(new CDVDVideoCodecOpenMax(), hint, options)) ) return pCodec;
-      }
-    }
-#endif
-
-#if defined(HAS_MMAL)
-    if (CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_USEMMAL) && !hint.software )
-    {
-      if (hint.codec == AV_CODEC_ID_H264 || hint.codec == AV_CODEC_ID_H263 || hint.codec == AV_CODEC_ID_MPEG4 ||
-          hint.codec == AV_CODEC_ID_MPEG1VIDEO || hint.codec == AV_CODEC_ID_MPEG2VIDEO ||
-          hint.codec == AV_CODEC_ID_VP6 || hint.codec == AV_CODEC_ID_VP6F || hint.codec == AV_CODEC_ID_VP6A || hint.codec == AV_CODEC_ID_VP8 ||
-          hint.codec == AV_CODEC_ID_THEORA || hint.codec == AV_CODEC_ID_MJPEG || hint.codec == AV_CODEC_ID_MJPEGB || hint.codec == AV_CODEC_ID_VC1 || hint.codec == AV_CODEC_ID_WMV3)
-      {
-        if ( (pCodec = OpenCodec(new CMMALVideo(), hint, options)) ) return pCodec;
-      }
-    }
-#endif
 
   // try to decide if we want to try halfres decoding
 #if !defined(TARGET_POSIX) && !defined(TARGET_WINDOWS)
   float pixelrate = (float)hint.width*hint.height*hint.fpsrate/hint.fpsscale;
-  if( pixelrate > 1400.0f*720.0f*30.0f )
+  if (pixelrate > 1400.0f*720.0f*30.0f)
   {
     CLog::Log(LOGINFO, "CDVDFactoryCodec - High video resolution detected %dx%d, trying half resolution decoding ", hint.width, hint.height);
     options.m_keys.push_back(CDVDCodecOption("lowres","1"));
@@ -320,9 +173,11 @@ CDVDVideoCodec* CDVDFactoryCodec::CreateVideoCodec(CDVDStreamInfo &hint, const C
 
   std::string value = StringUtils::Format("%d", info.max_buffer_size);
   options.m_keys.push_back(CDVDCodecOption("surfaces", value));
-  if( (pCodec = OpenCodec(new CDVDVideoCodecFFmpeg(), hint, options)) ) return pCodec;
+  pCodec = OpenCodec(new CDVDVideoCodecFFmpeg(), hint, options);
+  if (pCodec)
+    return pCodec;
 
-  return NULL;
+  return nullptr;;
 }
 
 CDVDAudioCodec* CDVDFactoryCodec::CreateAudioCodec(CDVDStreamInfo &hint, bool allowpassthrough, bool allowdtshddecode)
@@ -345,7 +200,7 @@ CDVDAudioCodec* CDVDFactoryCodec::CreateAudioCodec(CDVDStreamInfo &hint, bool al
   if (pCodec)
     return pCodec;
 
-  return NULL;
+  return nullptr;
 }
 
 CDVDOverlayCodec* CDVDFactoryCodec::CreateOverlayCodec( CDVDStreamInfo &hint )
@@ -358,28 +213,33 @@ CDVDOverlayCodec* CDVDFactoryCodec::CreateOverlayCodec( CDVDStreamInfo &hint )
     case AV_CODEC_ID_TEXT:
     case AV_CODEC_ID_SUBRIP:
       pCodec = OpenCodec(new CDVDOverlayCodecText(), hint, options);
-      if( pCodec ) return pCodec;
+      if (pCodec)
+        return pCodec;
       break;
 
     case AV_CODEC_ID_SSA:
     case AV_CODEC_ID_ASS:
       pCodec = OpenCodec(new CDVDOverlayCodecSSA(), hint, options);
-      if( pCodec ) return pCodec;
+      if (pCodec)
+        return pCodec;
 
       pCodec = OpenCodec(new CDVDOverlayCodecText(), hint, options);
-      if( pCodec ) return pCodec;
+      if (pCodec)
+        return pCodec;
       break;
 
     case AV_CODEC_ID_MOV_TEXT:
       pCodec = OpenCodec(new CDVDOverlayCodecTX3G(), hint, options);
-      if( pCodec ) return pCodec;
+      if (pCodec)
+        return pCodec;
       break;
 
     default:
       pCodec = OpenCodec(new CDVDOverlayCodecFFmpeg(), hint, options);
-      if( pCodec ) return pCodec;
+      if (pCodec)
+        return pCodec;
       break;
   }
 
-  return NULL;
+  return nullptr;
 }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h
@@ -142,12 +142,13 @@ struct DVDVideoUserData
 #define DVP_FLAG_ALLOCATED          0x00000004  //< Set to indicate that this has allocated data
 #define DVP_FLAG_INTERLACED         0x00000008  //< Set to indicate that this frame is interlaced
 
-#define DVP_FLAG_NOSKIP             0x00000010  //< indicate this picture should never be dropped
-#define DVP_FLAG_DROPPED            0x00000020  //< indicate that this picture has been dropped in decoder stage, will have no data
+#define DVP_FLAG_DROPPED            0x00000010  //< indicate that this picture has been dropped in decoder stage, will have no data
 
 #define DVD_CODEC_CTRL_SKIPDEINT    0x01000000  //< indicate that this picture was requested to have been dropped in deint stage
 #define DVD_CODEC_CTRL_NO_POSTPROC  0x02000000  //< see GetCodecStats
-#define DVD_CODEC_CTRL_DRAIN        0x04000000  //< see GetCodecStats
+#define DVD_CODEC_CTRL_HURRY        0x04000000  //< see GetCodecStats
+#define DVD_CODEC_CTRL_DROP         0x08000000  //< this frame is going to be dropped in output
+#define DVD_CODEC_CTRL_DRAIN        0x10000000  //< squeeze out pictured without feeding new packets
 
 // DVP_FLAG 0x00000100 - 0x00000f00 is in use by libmpeg2!
 
@@ -305,12 +306,20 @@ public:
    *                  if speed is not normal the codec can switch off
    *                  postprocessing and de-interlacing
    *
-   * DVD_CODEC_CTRL_DRAIN :
+   * DVD_CODEC_CTRL_HURRY :
    *                  codecs may do postprocessing and de-interlacing.
    *                  If video buffers in RenderManager are about to run dry,
    *                  this is signaled to codec. Codec can wait for post-proc
    *                  to be finished instead of returning empty and getting another
    *                  packet.
+   *
+   * DVD_CODEC_CTRL_DRAIN :
+   *                  instruct decoder to deliver last pictures without requesting
+   *                  new packets
+   *
+   * DVD_CODEC_CTRL_DROP :
+   *                  this packet is going to be dropped. decoder is free to use it
+   *                  for decoding
    *
    */
   virtual void SetCodecControl(int flags) {}

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
@@ -28,6 +28,7 @@
 #include "utils/BitstreamConverter.h"
 #include "utils/log.h"
 #include "threads/Atomics.h"
+#include "settings/Settings.h"
 
 #define __MODULE_NAME__ "DVDVideoCodecAmlogic"
 
@@ -62,6 +63,11 @@ CDVDVideoCodecAmlogic::~CDVDVideoCodecAmlogic()
 
 bool CDVDVideoCodecAmlogic::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
 {
+  if (!CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_USEAMCODEC))
+    return false;
+  if (hints.stills)
+    return false;
+
   if (!aml_permissions())
   {
     CLog::Log(LOGERROR, "AML: no proper permission, please contact the device vendor. Skipping codec...");
@@ -116,6 +122,8 @@ bool CDVDVideoCodecAmlogic::Open(CDVDStreamInfo &hints, CDVDCodecOptions &option
     case AV_CODEC_ID_MPEG4:
     case AV_CODEC_ID_MSMPEG4V2:
     case AV_CODEC_ID_MSMPEG4V3:
+      if (hints.width <= 800)
+        return false;
       m_pFormatName = "am-mpeg4";
       break;
     case AV_CODEC_ID_H263:

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -49,6 +49,7 @@
 #include "platform/android/jni/Surface.h"
 #include "platform/android/jni/SurfaceTexture.h"
 #include "platform/android/activity/AndroidFeatures.h"
+#include "settings/Settings.h"
 
 #include <GLES2/gl2.h>
 #include <GLES2/gl2ext.h>
@@ -346,7 +347,10 @@ bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
     CLog::Log(LOGERROR, "CDVDVideoCodecAndroidMediaCodec::Open - %s\n", "null size, cannot handle");
     return false;
   }
+  else if (hints.stills)
+    return false;
 
+  m_render_surface = CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_USEMEDIACODECSURFACE);
   m_drop = false;
   m_hints = hints;
 
@@ -357,6 +361,8 @@ bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
       m_formatname = "amc-mpeg2";
       break;
     case AV_CODEC_ID_MPEG4:
+      if (hints.width <= 800)
+        return false;
       m_mime = "video/mp4v-es";
       m_formatname = "amc-mpeg4";
       break;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -653,6 +653,9 @@ bool CDVDVideoCodecFFmpeg::GetPictureCommon(DVDVideoPicture* pDvdVideoPicture)
   pDvdVideoPicture->iFlags |= m_pFrame->interlaced_frame ? DVP_FLAG_INTERLACED : 0;
   pDvdVideoPicture->iFlags |= m_pFrame->top_field_first ? DVP_FLAG_TOP_FIELD_FIRST: 0;
 
+  if (m_codecControlFlags & DVD_CODEC_CTRL_DROP)
+    pDvdVideoPicture->iFlags |= DVP_FLAG_DROPPED;
+
   pDvdVideoPicture->chroma_position = m_pCodecContext->chroma_sample_location;
   pDvdVideoPicture->color_primaries = m_pCodecContext->color_primaries;
   pDvdVideoPicture->color_transfer = m_pCodecContext->color_trc;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -122,7 +122,8 @@ enum AVPixelFormat CDVDVideoCodecFFmpeg::GetFormat( struct AVCodecContext * avct
     }
 #endif
 #ifdef HAS_DX
-  if(DXVA::CDecoder::Supports(*cur) && CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_USEDXVA2))
+  if(DXVA::CDecoder::Supports(*cur) && CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_USEDXVA2) &&
+     !ctx->m_hints.dvd && !ctx->m_hints.stills)
   {
     CLog::Log(LOGNOTICE, "CDVDVideoCodecFFmpeg::GetFormat - Creating DXVA(%ix%i)", avctx->width, avctx->height);
     DXVA::CDecoder* dec = new DXVA::CDecoder();

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -474,6 +474,10 @@ int CDVDVideoCodecFFmpeg::Decode(uint8_t* pData, int iSize, double dts, double p
     int result = 0;
     if (pData == NULL)
       result = FilterProcess(NULL);
+    if (m_codecControlFlags & DVD_CODEC_CTRL_DRAIN)
+    {
+      result &= VC_PICTURE;
+    }
     if (result)
       return result;
   }
@@ -577,7 +581,7 @@ int CDVDVideoCodecFFmpeg::Decode(uint8_t* pData, int iSize, double dts, double p
   int result;
   if (m_pHardware)
     result = m_pHardware->Decode(m_pCodecContext, m_pFrame);
-  else if (m_pFilterGraph)
+  else if (m_pFilterGraph && !(m_codecControlFlags & DVD_CODEC_CTRL_DRAIN))
     result = FilterProcess(m_pFrame);
   else
     result = VC_PICTURE | VC_BUFFER;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.h
@@ -44,16 +44,17 @@ public:
   class IHardwareDecoder : public IDVDResourceCounted<IHardwareDecoder>
   {
     public:
-             IHardwareDecoder() {}
+    IHardwareDecoder() {}
     virtual ~IHardwareDecoder() {};
-    virtual bool Open      (AVCodecContext* avctx, AVCodecContext* mainctx, const enum AVPixelFormat, unsigned int surfaces) = 0;
-    virtual int  Decode    (AVCodecContext* avctx, AVFrame* frame) = 0;
+    virtual bool Open(AVCodecContext* avctx, AVCodecContext* mainctx, const enum AVPixelFormat, unsigned int surfaces) = 0;
+    virtual int  Decode(AVCodecContext* avctx, AVFrame* frame) = 0;
     virtual bool GetPicture(AVCodecContext* avctx, AVFrame* frame, DVDVideoPicture* picture) = 0;
-    virtual int  Check     (AVCodecContext* avctx) = 0;
-    virtual void Reset     () {}
+    virtual int  Check(AVCodecContext* avctx) = 0;
+    virtual void Reset() {}
     virtual unsigned GetAllowedReferences() { return 0; }
     virtual bool CanSkipDeint() {return false; }
     virtual const std::string Name() = 0;
+    virtual void SetCodecControl(int flags) {};
   };
 
   CDVDVideoCodecFFmpeg();

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
@@ -444,6 +444,8 @@ bool CDVDVideoCodecIMX::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
     CLog::Log(LOGNOTICE, "iMX VPU : software decoding forced - video dimensions out of spec: %d %d.", hints.width, hints.height);
     return false;
   }
+  else if (hints.stills)
+    return false;
 
   g_IMXContext.RequireConfiguration();
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecOpenMax.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecOpenMax.cpp
@@ -51,6 +51,9 @@ CDVDVideoCodecOpenMax::~CDVDVideoCodecOpenMax()
 
 bool CDVDVideoCodecOpenMax::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
 {
+  if (hints.stills)
+    return false;
+
   // we always qualify even if DVDFactoryCodec does this too.
   if (CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_USEOMX) && !hints.software)
   {

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecVideoToolBox.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecVideoToolBox.cpp
@@ -1054,6 +1054,8 @@ bool CDVDVideoCodecVideoToolBox::Open(CDVDStreamInfo &hints, CDVDCodecOptions &o
     return false;
   if (hints.ptsinvalid)
     return false;
+  if (hints.codec != AV_CODEC_ID_H264)
+    return false;
 
   if (CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_USEVIDEOTOOLBOX) && !hints.software)
   {

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecVideoToolBox.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecVideoToolBox.cpp
@@ -31,6 +31,7 @@
 #include "settings/AdvancedSettings.h"
 #include "utils/log.h"
 #include "utils/TimeUtils.h"
+#include "utils/SystemInfo.h"
 #include "platform/darwin/DarwinUtils.h"
 
 extern "C" {
@@ -1045,6 +1046,15 @@ bool CDVDVideoCodecVideoToolBox::HandleDyLoad()
 
 bool CDVDVideoCodecVideoToolBox::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
 {
+  if (!CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_USEVIDEOTOOLBOX))
+    return false;
+  if (!g_sysinfo.HasVideoToolBoxDecoder())
+    return false;
+  if (hints.stills)
+    return false;
+  if (hints.ptsinvalid)
+    return false;
+
   if (CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_USEVIDEOTOOLBOX) && !hints.software)
   {
     int width  = hints.width;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
@@ -858,14 +858,6 @@ static bool CheckCompatibility(AVCodecContext *avctx)
     return false;
   }
 
-  // there are many corrupt mpeg2 rips from dvd's which don't
-  // follow profile spec properly, they go corrupt on hw, so
-  // keep those running in software for the time being.
-  if (avctx->codec_id  == AV_CODEC_ID_MPEG2VIDEO
-  &&  avctx->height    <= 576
-  &&  avctx->width     <= 720)
-    return false;
-
   // Check for hardware limited to H264 L4.1 (ie Bluray).
 
   // No advanced settings: autodetect.

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
@@ -126,6 +126,7 @@ CMMALVideo::CMMALVideo()
   m_speed = DVD_PLAYSPEED_NORMAL;
   m_fps = 0.0f;
   m_num_decoded = 0;
+  m_codecControlFlags = 0;
 }
 
 CMMALVideo::~CMMALVideo()
@@ -867,7 +868,7 @@ int CMMALVideo::Decode(uint8_t* pData, int iSize, double dts, double pts)
   }
 
   if (g_advancedSettings.CanLogComponent(LOGVIDEO))
-    CLog::Log(LOGDEBUG, "%s::%s - ret(%x) pics(%d) inputs(%d) slept(%d) queued(%.2f) (%.2f:%.2f) full(%d)", CLASSNAME, __func__, ret, m_output_ready.size(), mmal_queue_length(m_dec_input_pool->queue), slept, queued*1e-6, m_demuxerPts*1e-6, m_decoderPts*1e-6, full);
+    CLog::Log(LOGDEBUG, "%s::%s - ret(%x) pics(%d) inputs(%d) slept(%d) queued(%.2f) (%.2f:%.2f) full(%d) flags(%x)", CLASSNAME, __func__, ret, m_output_ready.size(), mmal_queue_length(m_dec_input_pool->queue), slept, queued*1e-6, m_demuxerPts*1e-6, m_decoderPts*1e-6, full, m_codecControlFlags);
 
   return ret;
 }
@@ -931,6 +932,7 @@ void CMMALVideo::Reset(void)
   }
   m_decoderPts = DVD_NOPTS_VALUE;
   m_demuxerPts = DVD_NOPTS_VALUE;
+  m_codecControlFlags = 0;
 }
 
 void CMMALVideo::SetSpeed(int iSpeed)
@@ -1040,4 +1042,10 @@ bool CMMALVideo::GetCodecStats(double &pts, int &droppedPics)
   CSingleLock lock(m_sharedSection);
   droppedPics= -1;
   return false;
+}
+
+void CMMALVideo::SetCodecControl(int flags)
+{
+  CSingleLock lock(m_sharedSection);
+  m_codecControlFlags = flags;
 }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.h
@@ -105,7 +105,8 @@ protected:
   const char        *m_pFormatName;
 
   // mmal output buffers (video frames)
-  pthread_mutex_t   m_output_mutex;
+  CCriticalSection m_output_mutex;
+  XbmcThreads::ConditionVariable m_output_cond;
   std::queue<CMMALVideoBuffer*> m_output_ready;
 
   // initialize mmal and get decoder component

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.h
@@ -79,6 +79,7 @@ public:
   virtual void SetDropState(bool bDrop);
   virtual const char* GetName(void) { return m_pFormatName ? m_pFormatName:"mmal-xxx"; }
   virtual bool GetCodecStats(double &pts, int &droppedPics);
+  virtual void SetCodecControl(int flags);
   virtual void SetSpeed(int iSpeed);
 
   // MMAL decoder callback routines.
@@ -121,6 +122,7 @@ protected:
   double            m_demuxerPts;
   double            m_decoderPts;
   int               m_speed;
+  int               m_codecControlFlags;
 
   CCriticalSection m_sharedSection;
   MMAL_COMPONENT_T *m_dec;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
@@ -759,6 +759,11 @@ void CDecoder::FFReleaseBuffer(uint8_t *data)
   IHardwareDecoder::Release();
 }
 
+void CDecoder::SetCodecControl(int flags)
+{
+  m_codecControl = flags & (DVD_CODEC_CTRL_DRAIN | DVD_CODEC_CTRL_HURRY);
+}
+
 int CDecoder::Decode(AVCodecContext* avctx, AVFrame* pFrame)
 {
   int result = Check(avctx);
@@ -770,7 +775,7 @@ int CDecoder::Decode(AVCodecContext* avctx, AVFrame* pFrame)
   if (!m_vaapiConfigured)
     return VC_ERROR;
 
-  if(pFrame)
+  if (pFrame)
   { // we have a new frame from decoder
 
     VASurfaceID surf = (VASurfaceID)(uintptr_t)pFrame->data[3];
@@ -791,7 +796,7 @@ int CDecoder::Decode(AVCodecContext* avctx, AVFrame* pFrame)
     m_bufferStats.IncDecoded();
     m_vaapiOutput.m_dataPort.SendOutMessage(COutputDataProtocol::NEWFRAME, &pic, sizeof(pic));
 
-    m_codecControl = pic.DVDPic.iFlags & (DVD_CODEC_CTRL_DRAIN | DVD_CODEC_CTRL_NO_POSTPROC);
+    m_codecControl = pic.DVDPic.iFlags & (DVD_CODEC_CTRL_HURRY | DVD_CODEC_CTRL_NO_POSTPROC);
   }
 
   int retval = 0;
@@ -812,8 +817,13 @@ int CDecoder::Decode(AVCodecContext* avctx, AVFrame* pFrame)
 
   while (!retval)
   {
+    bool drain = (m_codecControl & DVD_CODEC_CTRL_DRAIN);
+    // if all pics are drained, break the loop by setting VC_BUFFER
+    if (drain && decoded <= 0 && processed <= 0 && render <= 0)
+      drain = false;
+
     // first fill the buffers to keep vaapi busy
-    if (decoded < 2 && processed < 3 && m_videoSurfaces.HasFree())
+    if (decoded < 2 && processed < 3 && m_videoSurfaces.HasFree() && !drain)
     {
       retval |= VC_BUFFER;
     }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.h
@@ -424,6 +424,7 @@ public:
 
   virtual int  Check(AVCodecContext* avctx);
   virtual const std::string Name() { return "vaapi"; }
+  virtual void SetCodecControl(int flags);
 
   bool Supports(EINTERLACEMETHOD method);
   EINTERLACEMETHOD AutoInterlaceMethod();

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDPAU.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDPAU.h
@@ -133,7 +133,7 @@ public:
   uint64_t latency;         // time decoder has waited for a frame, ideally there is no latency
   int codecFlags;
   bool canSkipDeint;
-  int processCmd;
+  bool draining;
 
   void IncDecoded() { CSingleLock l(m_sec); decodedPics++;}
   void DecDecoded() { CSingleLock l(m_sec); decodedPics--;}
@@ -145,10 +145,10 @@ public:
   void Get(uint16_t &decoded, uint16_t &processed, uint16_t &render) {CSingleLock l(m_sec); decoded = decodedPics, processed=processedPics, render=renderPics;}
   void SetParams(uint64_t time, int flags) { CSingleLock l(m_sec); latency = time; codecFlags = flags; }
   void GetParams(uint64_t &lat, int &flags) { CSingleLock l(m_sec); lat = latency; flags = codecFlags; }
-  void SetCmd(int cmd) { CSingleLock l(m_sec); processCmd = cmd; }
-  void GetCmd(int &cmd) { CSingleLock l(m_sec); cmd = processCmd; processCmd = 0; }
   void SetCanSkipDeint(bool canSkip) { CSingleLock l(m_sec); canSkipDeint = canSkip; }
   bool CanSkipDeint() { CSingleLock l(m_sec); if (canSkipDeint) return true; else return false;}
+  void SetDraining(bool drain) { CSingleLock l(m_sec); draining = drain; }
+  bool IsDraining() { CSingleLock l(m_sec); if (draining) return true; else return false;}
 private:
   CCriticalSection m_sec;
 };
@@ -568,6 +568,7 @@ public:
 
   virtual int  Check(AVCodecContext* avctx);
   virtual const std::string Name() { return "vdpau"; }
+  virtual void SetCodecControl(int flags);
 
   bool Supports(VdpVideoMixerFeature feature);
   bool Supports(EINTERLACEMETHOD method);

--- a/xbmc/cores/VideoPlayer/DVDMessage.h
+++ b/xbmc/cores/VideoPlayer/DVDMessage.h
@@ -85,6 +85,7 @@ public:
 
     VIDEO_NOSKIP,                   // next pictures is not to be skipped by the video renderer
     VIDEO_SET_ASPECT,               // set aspectratio of video
+    VIDEO_DRAIN,                    // wait for decoder to output last frame
 
     // audio related messages
 

--- a/xbmc/cores/VideoPlayer/DVDMessageQueue.cpp
+++ b/xbmc/cores/VideoPlayer/DVDMessageQueue.cpp
@@ -28,13 +28,13 @@ CDVDMessageQueue::CDVDMessageQueue(const std::string &owner) : m_hEvent(true), m
 {
   m_iDataSize     = 0;
   m_bAbortRequest = false;
-  m_bInitialized  = false;
-  m_bCaching      = false;
+  m_bInitialized = false;
+  m_bCaching = false;
 
-  m_TimeBack      = DVD_NOPTS_VALUE;
-  m_TimeFront     = DVD_NOPTS_VALUE;
-  m_TimeSize      = 1.0 / 4.0; /* 4 seconds */
-  m_iMaxDataSize  = 0;
+  m_TimeBack = DVD_NOPTS_VALUE;
+  m_TimeFront = DVD_NOPTS_VALUE;
+  m_TimeSize = 1.0 / 4.0; /* 4 seconds */
+  m_iMaxDataSize = 0;
 }
 
 CDVDMessageQueue::~CDVDMessageQueue()
@@ -45,18 +45,18 @@ CDVDMessageQueue::~CDVDMessageQueue()
 
 void CDVDMessageQueue::Init()
 {
-  m_iDataSize     = 0;
+  m_iDataSize = 0;
   m_bAbortRequest = false;
-  m_bInitialized  = true;
-  m_TimeBack      = DVD_NOPTS_VALUE;
-  m_TimeFront     = DVD_NOPTS_VALUE;
+  m_bInitialized = true;
+  m_TimeBack = DVD_NOPTS_VALUE;
+  m_TimeFront = DVD_NOPTS_VALUE;
 }
 
 void CDVDMessageQueue::Flush(CDVDMsg::Message type)
 {
   CSingleLock lock(m_section);
 
-  for(SList::iterator it = m_list.begin(); it != m_list.end();)
+  for (SList::iterator it = m_list.begin(); it != m_list.end();)
   {
     if (it->message->IsType(type) ||  type == CDVDMsg::NONE)
       it = m_list.erase(it);
@@ -67,7 +67,7 @@ void CDVDMessageQueue::Flush(CDVDMsg::Message type)
   if (type == CDVDMsg::DEMUXER_PACKET ||  type == CDVDMsg::NONE)
   {
     m_iDataSize = 0;
-    m_TimeBack  = DVD_NOPTS_VALUE;
+    m_TimeBack = DVD_NOPTS_VALUE;
     m_TimeFront = DVD_NOPTS_VALUE;
   }
 }
@@ -87,8 +87,8 @@ void CDVDMessageQueue::End()
 
   Flush(CDVDMsg::NONE);
 
-  m_bInitialized  = false;
-  m_iDataSize     = 0;
+  m_bInitialized = false;
+  m_iDataSize = 0;
   m_bAbortRequest = false;
 }
 
@@ -121,14 +121,15 @@ MsgQueueReturnCode CDVDMessageQueue::Put(CDVDMsg* pMsg, int priority)
   if (pMsg->IsType(CDVDMsg::DEMUXER_PACKET) && priority == 0)
   {
     DemuxPacket* packet = ((CDVDMsgDemuxerPacket*)pMsg)->GetPacket();
-    if(packet)
+    if (packet)
     {
       m_iDataSize += packet->iSize;
-      if     (packet->dts != DVD_NOPTS_VALUE)
+      if (packet->dts != DVD_NOPTS_VALUE)
         m_TimeFront = packet->dts;
-      else if(packet->pts != DVD_NOPTS_VALUE)
+      else if (packet->pts != DVD_NOPTS_VALUE)
         m_TimeFront = packet->pts;
-      if(m_TimeBack == DVD_NOPTS_VALUE)
+
+      if (m_TimeBack == DVD_NOPTS_VALUE)
         m_TimeBack = m_TimeFront;
     }
   }
@@ -156,7 +157,7 @@ MsgQueueReturnCode CDVDMessageQueue::Get(CDVDMsg** pMsg, unsigned int iTimeoutIn
 
   while (!m_bAbortRequest)
   {
-    if(!m_list.empty() && m_list.back().priority >= priority && !m_bCaching)
+    if (!m_list.empty() && m_list.back().priority >= priority && !m_bCaching)
     {
       DVDMessageListItem& item(m_list.back());
       priority = item.priority;
@@ -164,12 +165,12 @@ MsgQueueReturnCode CDVDMessageQueue::Get(CDVDMsg** pMsg, unsigned int iTimeoutIn
       if (item.message->IsType(CDVDMsg::DEMUXER_PACKET) && item.priority == 0)
       {
         DemuxPacket* packet = ((CDVDMsgDemuxerPacket*)item.message)->GetPacket();
-        if(packet)
+        if (packet)
         {
           m_iDataSize -= packet->iSize;
-          if     (packet->dts != DVD_NOPTS_VALUE)
+          if (packet->dts != DVD_NOPTS_VALUE)
             m_TimeBack = packet->dts;
-          else if(packet->pts != DVD_NOPTS_VALUE)
+          else if (packet->pts != DVD_NOPTS_VALUE)
             m_TimeBack = packet->pts;
         }
       }
@@ -198,11 +199,11 @@ MsgQueueReturnCode CDVDMessageQueue::Get(CDVDMsg** pMsg, unsigned int iTimeoutIn
     }
   }
 
-  if (m_bAbortRequest) return MSGQ_ABORT;
+  if (m_bAbortRequest)
+    return MSGQ_ABORT;
 
   return (MsgQueueReturnCode)ret;
 }
-
 
 unsigned CDVDMessageQueue::GetPacketCount(CDVDMsg::Message type)
 {
@@ -223,23 +224,23 @@ unsigned CDVDMessageQueue::GetPacketCount(CDVDMsg::Message type)
 
 void CDVDMessageQueue::WaitUntilEmpty()
 {
-    CLog::Log(LOGNOTICE, "CDVDMessageQueue(%s)::WaitUntilEmpty", m_owner.c_str());
-    CDVDMsgGeneralSynchronize* msg = new CDVDMsgGeneralSynchronize(40000, 0);
-    Put(msg->Acquire());
-    msg->Wait(&m_bAbortRequest, 0);
-    msg->Release();
+  CLog::Log(LOGNOTICE, "CDVDMessageQueue(%s)::WaitUntilEmpty", m_owner.c_str());
+  CDVDMsgGeneralSynchronize* msg = new CDVDMsgGeneralSynchronize(40000, 0);
+  Put(msg->Acquire());
+  msg->Wait(&m_bAbortRequest, 0);
+  msg->Release();
 }
 
 int CDVDMessageQueue::GetLevel() const
 {
   CSingleLock lock(m_section);
 
-  if(m_iDataSize > m_iMaxDataSize)
+  if (m_iDataSize > m_iMaxDataSize)
     return 100;
-  if(m_iDataSize == 0)
+  if (m_iDataSize == 0)
     return 0;
 
-  if(IsDataBased())
+  if (IsDataBased())
     return std::min(100, 100 * m_iDataSize / m_iMaxDataSize);
 
   int level = std::min(100, MathUtils::round_int(100.0 * m_TimeSize * (m_TimeFront - m_TimeBack) / DVD_TIME_BASE ));
@@ -258,7 +259,7 @@ int CDVDMessageQueue::GetTimeSize() const
 {
   CSingleLock lock(m_section);
 
-  if(IsDataBased())
+  if (IsDataBased())
     return 0;
   else
     return (int)((m_TimeFront - m_TimeBack) / DVD_TIME_BASE);

--- a/xbmc/cores/VideoPlayer/DVDMessageQueue.cpp
+++ b/xbmc/cores/VideoPlayer/DVDMessageQueue.cpp
@@ -242,7 +242,16 @@ int CDVDMessageQueue::GetLevel() const
   if(IsDataBased())
     return std::min(100, 100 * m_iDataSize / m_iMaxDataSize);
 
-  return std::min(100, MathUtils::round_int(100.0 * m_TimeSize * (m_TimeFront - m_TimeBack) / DVD_TIME_BASE ));
+  int level = std::min(100, MathUtils::round_int(100.0 * m_TimeSize * (m_TimeFront - m_TimeBack) / DVD_TIME_BASE ));
+
+  // if we added lots of packets with NOPTS, make sure that the queue is not signalled empty
+  if (level == 0 && m_iDataSize != 0)
+  {
+    CLog::Log(LOGNOTICE, "CDVDMessageQueue::GetLevel() - can't determine level");
+    return 1;
+  }
+
+  return level;
 }
 
 int CDVDMessageQueue::GetTimeSize() const

--- a/xbmc/cores/VideoPlayer/DVDMessageQueue.h
+++ b/xbmc/cores/VideoPlayer/DVDMessageQueue.h
@@ -31,20 +31,21 @@ struct DVDMessageListItem
 {
   DVDMessageListItem(CDVDMsg* msg, int prio)
   {
-    message  = msg->Acquire();
+    message = msg->Acquire();
     priority = prio;
   }
   DVDMessageListItem()
   {
-    message  = NULL;
+    message = NULL;
     priority = 0;
   }
   DVDMessageListItem(const DVDMessageListItem& item)
   {
-    if(item.message)
+    if (item.message)
       message = item.message->Acquire();
     else
       message = NULL;
+
     priority = item.priority;
   }
  ~DVDMessageListItem()
@@ -55,28 +56,29 @@ struct DVDMessageListItem
 
   DVDMessageListItem& operator=(const DVDMessageListItem& item)
   {
-    if(message)
+    if (message)
       message->Release();
-    if(item.message)
+    if (item.message)
       message = item.message->Acquire();
     else
       message = NULL;
+
     priority = item.priority;
     return *this;
   }
 
   CDVDMsg* message;
-  int      priority;
+  int priority;
 };
 
 enum MsgQueueReturnCode
 {
-  MSGQ_OK               = 1,
-  MSGQ_TIMEOUT          = 0,
-  MSGQ_ABORT            = -1, // negative for legacy, not an error actually
-  MSGQ_NOT_INITIALIZED  = -2,
-  MSGQ_INVALID_MSG      = -3,
-  MSGQ_OUT_OF_MEMORY    = -4
+  MSGQ_OK = 1,
+  MSGQ_TIMEOUT = 0,
+  MSGQ_ABORT = -1, // negative for legacy, not an error actually
+  MSGQ_NOT_INITIALIZED = -2,
+  MSGQ_INVALID_MSG = -3,
+  MSGQ_OUT_OF_MEMORY = -4
 };
 
 #define MSGQ_IS_ERROR(c)    (c < 0)
@@ -87,10 +89,10 @@ public:
   CDVDMessageQueue(const std::string &owner);
   virtual ~CDVDMessageQueue();
 
-  void  Init();
-  void  Flush(CDVDMsg::Message message = CDVDMsg::DEMUXER_PACKET);
-  void  Abort();
-  void  End();
+  void Init();
+  void Flush(CDVDMsg::Message message = CDVDMsg::DEMUXER_PACKET);
+  void Abort();
+  void End();
 
   MsgQueueReturnCode Put(CDVDMsg* pMsg, int priority = 0);
 
@@ -106,21 +108,21 @@ public:
     return Get(pMsg, iTimeoutInMilliSeconds, priority);
   }
 
-  int GetDataSize() const               { return m_iDataSize; }
+  int GetDataSize() const { return m_iDataSize; }
   int GetTimeSize() const;
   unsigned GetPacketCount(CDVDMsg::Message type);
-  bool ReceivedAbortRequest()           { return m_bAbortRequest; }
+  bool ReceivedAbortRequest() { return m_bAbortRequest; }
   void WaitUntilEmpty();
 
   // non messagequeue related functions
-  bool IsFull() const                   { return GetLevel() == 100; }
-  int  GetLevel() const;
+  bool IsFull() const { return GetLevel() == 100; }
+  int GetLevel() const;
 
   void SetMaxDataSize(int iMaxDataSize) { m_iMaxDataSize = iMaxDataSize; }
-  void SetMaxTimeSize(double sec)       { m_TimeSize  = 1.0 / std::max(1.0, sec); }
-  int GetMaxDataSize() const            { return m_iMaxDataSize; }
-  double GetMaxTimeSize() const         { return m_TimeSize; }
-  bool IsInited() const                 { return m_bInitialized; }
+  void SetMaxTimeSize(double sec) { m_TimeSize  = 1.0 / std::max(1.0, sec); }
+  int GetMaxDataSize() const { return m_iMaxDataSize; }
+  double GetMaxTimeSize() const { return m_TimeSize; }
+  bool IsInited() const { return m_bInitialized; }
   bool IsDataBased() const;
 
 private:

--- a/xbmc/cores/VideoPlayer/DVDStreamInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDStreamInfo.cpp
@@ -44,6 +44,7 @@ void CDVDStreamInfo::Clear()
   codec_tag  = 0;
   flags = 0;
   filename.clear();
+  dvd = false;
 
   if( extradata && extrasize ) free(extradata);
 
@@ -143,6 +144,7 @@ void CDVDStreamInfo::Assign(const CDVDStreamInfo& right, bool withextradata)
   codec_tag = right.codec_tag;
   flags = right.flags;
   filename = right.filename;
+  dvd = right.dvd;
 
   if( extradata && extrasize ) free(extradata);
 

--- a/xbmc/cores/VideoPlayer/DVDStreamInfo.h
+++ b/xbmc/cores/VideoPlayer/DVDStreamInfo.h
@@ -54,6 +54,7 @@ public:
   int flags;
   bool software;  //force software decoding
   std::string filename;
+  bool dvd;
 
 
   // VIDEO

--- a/xbmc/cores/VideoPlayer/IVideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/IVideoPlayer.h
@@ -145,7 +145,7 @@ public:
   float GetRelativeUsage() { return 0.0f; }
   virtual bool OpenStream(CDVDStreamInfo &hint) = 0;
   virtual void CloseStream(bool bWaitForBuffers) = 0;
-  virtual bool StepFrame() = 0;
+  virtual bool StepFrame() { return false; };
   virtual void Flush(bool sync) = 0;
   virtual void WaitForBuffers() = 0;
   virtual bool AcceptsData() const = 0;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -1801,11 +1801,11 @@ void CVideoPlayer::HandlePlaySpeed()
         (m_CurrentAudio.id < 0 || m_CurrentAudio.syncState != IDVDStreamPlayer::SYNC_STARTING))
       SetCaching(CACHESTATE_PLAY);
 
-    // handle situation that we get no data on one stream
+    // handle exceptions
     if (m_CurrentAudio.id >= 0 && m_CurrentVideo.id >= 0)
     {
-      if ((!m_VideoPlayerAudio->AcceptsData() && m_CurrentVideo.syncState == IDVDStreamPlayer::SYNC_STARTING) ||
-          (!m_VideoPlayerVideo->AcceptsData() && m_CurrentAudio.syncState == IDVDStreamPlayer::SYNC_STARTING))
+      if ((!m_VideoPlayerAudio->AcceptsData() || !m_VideoPlayerVideo->AcceptsData()) &&
+          m_cachingTimer.IsTimePast())
       {
         SetCaching(CACHESTATE_DONE);
       }
@@ -2809,6 +2809,8 @@ void CVideoPlayer::SetCaching(ECacheState state)
     m_streamPlayerSpeed = DVD_PLAYSPEED_PAUSE;
 
     m_pInputStream->ResetScanTimeout((unsigned int) CSettings::GetInstance().GetInt(CSettings::SETTING_PVRPLAYBACK_SCANTIME) * 1000);
+
+    m_cachingTimer.Set(5000);
   }
 
   if (state == CACHESTATE_PLAY ||

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -3518,12 +3518,11 @@ bool CVideoPlayer::OpenVideoStream(CDVDStreamInfo& hint, bool reset)
   {
     /* set aspect ratio as requested by navigator for dvd's */
     float aspect = static_cast<CDVDInputStreamNavigator*>(m_pInputStream)->GetVideoAspectRatio();
-    if(aspect != 0.0)
+    if (aspect != 0.0)
     {
       hint.aspect = aspect;
       hint.forced_aspect = true;
     }
-    hint.software = true;
   }
   else if (m_pInputStream && m_pInputStream->IsStreamType(DVDSTREAM_TYPE_PVRMANAGER))
   {

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -3534,6 +3534,7 @@ bool CVideoPlayer::OpenVideoStream(CDVDStreamInfo& hint, bool reset)
       hint.aspect = aspect;
       hint.forced_aspect = true;
     }
+    hint.dvd = true;
   }
   else if (m_pInputStream && m_pInputStream->IsStreamType(DVDSTREAM_TYPE_PVRMANAGER))
   {

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -431,6 +431,7 @@ protected:
   bool m_bAbortRequest;
 
   ECacheState  m_caching;
+  XbmcThreads::EndTime m_cachingTimer;
   CFileItem    m_item;
   XbmcThreads::EndTime m_ChannelEntryTimeOut;
 

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -114,6 +114,7 @@ public:
   void* stream; // pointer or integer, identifying stream playing. if it changes stream changed
   int changes; // remembered counter from stream to track codec changes
   bool inited;
+  unsigned int packets;
   IDVDStreamPlayer::ESyncState syncState;
   double starttime;
   double cachetime;
@@ -142,6 +143,7 @@ public:
     stream = NULL;
     changes = 0;
     inited = false;
+    packets = 0;
     syncState = IDVDStreamPlayer::SYNC_STARTING;
     starttime = DVD_NOPTS_VALUE;
     startpts = DVD_NOPTS_VALUE;

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -285,12 +285,8 @@ bool CVideoPlayerVideo::AcceptsData() const
 void CVideoPlayerVideo::OnStartup()
 {
   m_iDroppedFrames = 0;
-
-  m_crop.x1 = m_crop.x2 = 0.0f;
-  m_crop.y1 = m_crop.y2 = 0.0f;
-
   m_FlipTimeStamp = m_pClock->GetAbsoluteClock();
-  m_FlipTimePts   = 0.0;
+  m_FlipTimePts = 0.0;
 }
 
 void CVideoPlayerVideo::Process()
@@ -766,18 +762,6 @@ void CVideoPlayerVideo::SetSpeed(int speed)
     m_messageQueue.Put( new CDVDMsgInt(CDVDMsg::PLAYER_SETSPEED, speed), 1 );
   else
     m_speed = speed;
-}
-
-bool CVideoPlayerVideo::StepFrame()
-{
-#if 0
-  // sadly this doesn't work for now, audio player must
-  // drop packets at the same rate as we play frames
-  m_iNrOfPicturesNotToSkip++;
-  return true;
-#else
-  return false;
-#endif
 }
 
 void CVideoPlayerVideo::Flush(bool sync)

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.h
@@ -37,6 +37,11 @@ class CDemuxStreamVideo;
 
 #define VIDEO_PICTURE_QUEUE_SIZE 1
 
+#define EOS_ABORT 1
+#define EOS_DROPPED 2
+#define EOS_VERYLATE 4
+#define EOS_BUFFER_LEVEL 8
+
 class CDroppingStats
 {
 public:
@@ -67,74 +72,55 @@ public:
   bool OpenStream(CDVDStreamInfo &hint);
   void CloseStream(bool bWaitForBuffers);
 
-  bool StepFrame();
   void Flush(bool sync);
-
-  // waits until all available data has been rendered
-  // just waiting for packetqueue should be enough for video
-  void WaitForBuffers()                             { m_messageQueue.WaitUntilEmpty(); }
   bool AcceptsData() const;
-  bool HasData() const                              { return m_messageQueue.GetDataSize() > 0; }
-  int  GetLevel() const                             { return m_messageQueue.GetLevel(); }
-  bool IsInited() const                             { return m_messageQueue.IsInited(); }
+  bool HasData() const { return m_messageQueue.GetDataSize() > 0; }
+  int  GetLevel() const { return m_messageQueue.GetLevel(); }
+  bool IsInited() const { return m_messageQueue.IsInited(); }
   void SendMessage(CDVDMsg* pMsg, int priority = 0) { m_messageQueue.Put(pMsg, priority); }
-  void FlushMessages()                              { m_messageQueue.Flush(); }
+  void FlushMessages() { m_messageQueue.Flush(); }
 
-  void EnableSubtitle(bool bEnable)                 { m_bRenderSubs = bEnable; }
-  bool IsSubtitleEnabled()                          { return m_bRenderSubs; }
-
-  void EnableFullscreen(bool bEnable)               { m_bAllowFullscreen = bEnable; }
-
-  double GetDelay()                                { return m_iVideoDelay; }
-  void SetDelay(double delay)                      { m_iVideoDelay = delay; }
-
-  double GetSubtitleDelay()                                { return m_iSubtitleDelay; }
-  void SetSubtitleDelay(double delay)                      { m_iSubtitleDelay = delay; }
-
-  bool IsStalled() const                            { return m_stalled; }
-  bool IsEOS()                                      { return false; }
-  bool SubmittedEOS() const                         { return false; }
-
+  void EnableSubtitle(bool bEnable) { m_bRenderSubs = bEnable; }
+  bool IsSubtitleEnabled() { return m_bRenderSubs; }
+  void EnableFullscreen(bool bEnable) { m_bAllowFullscreen = bEnable; }
+  double GetDelay() { return m_iVideoDelay; }
+  void SetDelay(double delay) { m_iVideoDelay = delay; }
+  double GetSubtitleDelay() { return m_iSubtitleDelay; }
+  void SetSubtitleDelay(double delay) { m_iSubtitleDelay = delay; }
+  bool IsStalled() const { return m_stalled; }
+  bool IsEOS() { return false; }
+  bool SubmittedEOS() const { return false; }
   double GetCurrentPts();
-
   double GetOutputDelay(); /* returns the expected delay, from that a packet is put in queue */
   int GetDecoderFreeSpace() { return 0; }
   std::string GetPlayerInfo();
   int GetVideoBitrate();
   std::string GetStereoMode();
-
   void SetSpeed(int iSpeed);
 
   // IVPClockCallback interface
   virtual double GetInterpolatedClock();
 
-  // classes
   CDVDOverlayContainer* m_pOverlayContainer;
-
   CDVDClock* m_pClock;
 
 protected:
+
   virtual void OnStartup();
   virtual void OnExit();
   virtual void Process();
 
-#define EOS_ABORT 1
-#define EOS_DROPPED 2
-#define EOS_VERYLATE 4
-#define EOS_BUFFER_LEVEL 8
-
-  void AutoCrop(DVDVideoPicture* pPicture);
-  void AutoCrop(DVDVideoPicture *pPicture, RECT &crop);
-  CRect m_crop;
-
   int OutputPicture(const DVDVideoPicture* src, double pts);
-#ifdef HAS_VIDEO_PLAYBACK
   void ProcessOverlays(DVDVideoPicture* pSource, double pts);
-#endif
   void OpenStream(CDVDStreamInfo &hint, CDVDVideoCodec* codec);
 
-  CDVDMessageQueue m_messageQueue;
-  CDVDMessageQueue& m_messageParent;
+  // waits until all available data has been rendered
+  // just waiting for packetqueue should be enough for video
+  void WaitForBuffers()  { m_messageQueue.WaitUntilEmpty(); }
+
+  void ResetFrameRateCalc();
+  void CalcFrameRate();
+  int CalcDropRequirement(double pts, bool updateOnly);
 
   double m_iVideoDelay;
   double m_iSubtitleDelay;
@@ -145,36 +131,29 @@ protected:
   int m_iDroppedFrames;
   int m_iDroppedRequest;
 
-  void   ResetFrameRateCalc();
-  void   CalcFrameRate();
-  int    CalcDropRequirement(double pts, bool updateOnly);
-
   double m_fFrameRate;       //framerate of the video currently playing
-  bool   m_bCalcFrameRate;  //if we should calculate the framerate from the timestamps
+  bool m_bCalcFrameRate;     //if we should calculate the framerate from the timestamps
   double m_fStableFrameRate; //place to store calculated framerates
-  int    m_iFrameRateCount;  //how many calculated framerates we stored in m_fStableFrameRate
-  bool   m_bAllowDrop;       //we can't drop frames until we've calculated the framerate
-  int    m_iFrameRateErr;    //how many frames we couldn't calculate the framerate, we give up after a while
-  int    m_iFrameRateLength; //how many seconds we should measure the framerate
+  int m_iFrameRateCount;     //how many calculated framerates we stored in m_fStableFrameRate
+  bool m_bAllowDrop;         //we can't drop frames until we've calculated the framerate
+  int m_iFrameRateErr;       //how many frames we couldn't calculate the framerate, we give up after a while
+  int m_iFrameRateLength;    //how many seconds we should measure the framerate
                              //this is increased exponentially from CVideoPlayerVideo::CalcFrameRate()
 
-  bool   m_bFpsInvalid;      // needed to ignore fps (e.g. dvd stills)
-
+  bool m_bFpsInvalid;        // needed to ignore fps (e.g. dvd stills)
   bool m_bAllowFullscreen;
   bool m_bRenderSubs;
-
   float m_fForcedAspectRatio;
-
   int m_iNrOfPicturesNotToSkip;
   int m_speed;
-
   bool m_stalled;
   IDVDStreamPlayer::ESyncState m_syncState;
   std::string m_codecname;
 
   BitstreamStats m_videoStats;
 
-  // classes
+  CDVDMessageQueue m_messageQueue;
+  CDVDMessageQueue& m_messageParent;
   CDVDStreamInfo m_hints;
   CDVDVideoCodec* m_pVideoCodec;
   DVDVideoPicture* m_pTempOverlayPicture;

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.h
@@ -109,6 +109,7 @@ protected:
   virtual void OnStartup();
   virtual void OnExit();
   virtual void Process();
+  bool ProcessDecoderOutput(int &decoderState, double &frametime, double &pts);
 
   int OutputPicture(const DVDVideoPicture* src, double pts);
   void ProcessOverlays(DVDVideoPicture* pSource, double pts);
@@ -161,5 +162,6 @@ protected:
   std::list<DVDMessageListItem> m_packets;
   CDroppingStats m_droppingStats;
   CRenderManager& m_renderManager;
+  DVDVideoPicture m_picture;
 };
 


### PR DESCRIPTION
Video codecs are supposed to react on DVD_CODEC_CTRL_DRAIN flag appropriately. If this flag is set by VideoPlayer via SetCodecControl(), codecs should submit remaining pics. Player will call codec again until codec signals empty by returning VC_BUFFER. codec should no block longer than 100ms.

This makes libmpeg2 obsolete. All codecs supporting drain can handle still frames.
