### PR TITLE
Limit Kodi PVR actions to PVR WIndows

### DIFF
--- a/xbmc/pvr/PVRActionListener.cpp
+++ b/xbmc/pvr/PVRActionListener.cpp
@@ -87,8 +87,8 @@ bool CPVRActionListener::OnAction(const CAction &action)
     case REMOTE_9:
     {
       if (g_application.CurrentFileItem().IsLiveTV() &&
-          (g_windowManager.IsWindowActive(WINDOW_FULLSCREEN_VIDEO) ||
-           g_windowManager.IsWindowActive(WINDOW_VISUALISATION)))
+          (g_windowManager.IsWindowActive(WINDOW_DIALOG_PVR_OSD_CHANNELS) ||
+           g_windowManager.IsWindowActive(WINDOW_DIALOG_PVR_OSD_GUIDE)))
       {
         if(g_PVRManager.IsPlaying())
         {


### PR DESCRIPTION
Some plugins and scripts use custom controls while viewing pvr:// content. Prior code forced input dialog to popup on any numeric keypress (regardless of whether or not it was the users intentions to change the pvr channel). Limiting the dialog to PVR windows IMO is a better alternative to full screen video because it predicts the user's needs?
