### PR TITLE
[fix][pvr] don't populate hidden groups over json-rpc

### DIFF
--- a/xbmc/interfaces/json-rpc/PVROperations.cpp
+++ b/xbmc/interfaces/json-rpc/PVROperations.cpp
@@ -72,7 +72,7 @@ JSONRPC_STATUS CPVROperations::GetChannelGroups(const std::string &method, ITran
 
   int start, end;
 
-  std::vector<CPVRChannelGroupPtr> groupList = channelGroups->GetMembers();
+  std::vector<CPVRChannelGroupPtr> groupList = channelGroups->GetMembers(true);
   HandleLimits(parameterObject, result, groupList.size(), start, end);
   for (int index = start; index < end; index++)
     FillChannelGroupDetails(groupList.at(index), parameterObject, result["channelgroups"], true);

--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -394,10 +394,15 @@ CPVRChannelGroupPtr CPVRChannelGroups::GetLastPlayedGroup(int iChannelID /* = -1
   return group;
 }
 
-std::vector<CPVRChannelGroupPtr> CPVRChannelGroups::GetMembers() const
+std::vector<CPVRChannelGroupPtr> CPVRChannelGroups::GetMembers(bool bExcludeHidden /* = false */) const
 {
   CSingleLock lock(m_critSection);
-  std::vector<CPVRChannelGroupPtr> groups(m_groups.begin(), m_groups.end());
+  std::vector<CPVRChannelGroupPtr> groups;
+  for (CPVRChannelGroupPtr group : m_groups)
+  {
+    if (!bExcludeHidden || !group->IsHidden())
+      groups.push_back(group);
+  }
   return groups;
 }
 

--- a/xbmc/pvr/channels/PVRChannelGroups.h
+++ b/xbmc/pvr/channels/PVRChannelGroups.h
@@ -118,9 +118,10 @@ namespace PVR
     /*!
      * @brief Get the list of groups.
      * @param groups The list to store the results in.
+     * @param bExcludeHidden Whenever to exclude hidden channel groups.
      * @return The amount of items that were added.
      */
-    std::vector<CPVRChannelGroupPtr> GetMembers() const;
+    std::vector<CPVRChannelGroupPtr> GetMembers(bool bExcludeHidden = false) const;
 
     /*!
      * @brief Get the list of groups.


### PR DESCRIPTION
Another issue I've noticed while testing with our android remote "Kore" is that we populate all groups over json-rpc not only the visible groups. This PR will fix that issue.

@ksooo or @Jalle19 Mind taking a look.
