### PR TITLE
[fix][pvr] prevent numeric dialog from being opened if python modal is present

### DIFF
--- a/xbmc/pvr/PVRActionListener.cpp
+++ b/xbmc/pvr/PVRActionListener.cpp
@@ -90,6 +90,11 @@ bool CPVRActionListener::OnAction(const CAction &action)
           (g_windowManager.IsWindowActive(WINDOW_FULLSCREEN_VIDEO) ||
            g_windowManager.IsWindowActive(WINDOW_VISUALISATION)))
       {
+        // do not consume action if a python modal is the top most dialog
+        // as a python modal can't return that it consumed the action.
+        if (g_windowManager.IsPythonWindow(g_windowManager.GetTopMostModalDialogID()))
+          return false;
+
         if(g_PVRManager.IsPlaying())
         {
           // pvr client addon


### PR DESCRIPTION
This is a follow-up for #8692 and fixes http://trac.kodi.tv/ticket/16452.

> Some plugins and scripts use custom controls while viewing pvr:// content. Prior code forced input dialog to popup on any numeric keypress (regardless of whether or not it was the users intentions to change the pvr channel). Limiting the dialog to PVR windows IMO is a better alternative to full screen video because it predicts the user's needs?

The root cause is that an addon can't handle if a custom modal dialog consumed the action (e.g. the key-press) because `Window::onAction(Action* action)` is a void method and therefore we delegate it to the underlaying window which is the fullscreen window.

This workaround the root cause by checking if an active modal is prevent and therefore prevent the numeric dialog from being opened.

@ksooo or @Jalle19 mind taking a look.
