### PR TITLE
VideoPlayer: drop draining demuxer on cell change - fixes audio corru…

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -459,16 +459,6 @@ int CDVDInputStreamNavigator::ProcessBlock(uint8_t* dest_buffer, int* read)
         // information only when necessary and update the decoding/displaying
         // accordingly.
 
-        // this may lead to a discontinuity, but it's also the end of the
-        // vobunit, so make sure everything in demuxer is output
-        if(m_holdmode == HOLDMODE_NONE)
-        {
-          CLog::Log(LOGDEBUG, "DVDNAV_CELL_CHANGE (HOLDING)");
-          m_holdmode = HOLDMODE_HELD;
-          iNavresult = NAVRESULT_HOLD;
-          break;
-        }
-
         uint32_t pos, len;
 
         m_dll.dvdnav_current_title_info(m_dvdnav, &m_iTitle, &m_iPart);

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -3967,9 +3967,6 @@ int CVideoPlayer::OnDVDNavResult(void* pData, int iMessage)
 
         if (m_dvd.state != DVDSTATE_STILL)
           m_dvd.state = DVDSTATE_NORMAL;
-
-        if( m_VideoPlayerVideo->IsInited() )
-          m_VideoPlayerVideo->SendMessage(new CDVDMsg(CDVDMsg::VIDEO_NOSKIP));
       }
       break;
     case DVDNAV_NAV_PACKET:


### PR DESCRIPTION
fixes: http://forum.kodi.tv/showthread.php?tid=230117

draining demuxer on cell change is wrong because it can split and corrupt a data packet.
