### PR TITLE
FIX: [renderer] hide meaningless skips from users

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -1424,7 +1424,8 @@ void CRenderManager::PrepareNextRender()
     while(m_queued.front() != idx)
     {
       requeue(m_discard, m_queued);
-      m_QueueSkip++;
+      if (m_format != RENDER_FMT_AML)  // skips scares users ;)
+        m_QueueSkip++;
     }
 
     m_presentstep   = PRESENT_FLIP;


### PR DESCRIPTION
skips mean nothing on aml/linux

@FernetMenta is this acceptable?
