### PR TITLE
[fix][pvr] m_gridIndex array index out of bound

### DIFF
--- a/xbmc/epg/GUIEPGGridContainer.h
+++ b/xbmc/epg/GUIEPGGridContainer.h
@@ -94,6 +94,7 @@ namespace EPG
     void SetStartEnd(CDateTime start, CDateTime end);
     void SetChannel(const PVR::CPVRChannelPtr &channel);
     void SetChannel(const std::string &channel);
+    void ResetCoordinates();
 
   protected:
     bool OnClick(int actionID);

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -451,6 +451,10 @@ void CGUIWindowPVRGuide::GetViewTimelineItems(CFileItemList &items)
 
   CPVRChannelGroupPtr group = GetGroup();
 
+  // group change detected reset grid coordinate
+  if (*m_cachedChannelGroup != *group)
+    epgGridContainer->ResetCoordinates();
+
   if (m_bUpdateRequired || m_cachedTimeline->IsEmpty() || *m_cachedChannelGroup != *group)
   {
     m_bUpdateRequired = false;


### PR DESCRIPTION
As reported by @afedchin and @fritsch this fixes different array index out of bound exceptions while accessing `CGUIEPGGridContainer::m_gridIndex` by reset some members before update the grid.

How to reproduce:
Show EPG for all channels, focus last row in the grid, then switch to group with less than 6 channels.
And by using the mouse to switch the group to get the second out of bound exception.
