### PR TITLE
Analogue audio ala Frodo

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -18153,3 +18153,14 @@ msgstr ""
 msgctxt "#38025"
 msgid "Choose information provider"
 msgstr ""
+
+#: system/settings/rbp.xml
+msgctxt "#38122"
+msgid "Use analogue amplifier"
+msgstr ""
+
+#: system/settings/rbp.xml
+msgctxt "#38123"
+msgid "Use Raspberry Pi embedded analogue amplifier for stereo 3.5mm output jack"
+msgstr ""
+

--- a/system/settings/rbp.xml
+++ b/system/settings/rbp.xml
@@ -72,6 +72,13 @@
       </group>
     </category>
     <category id="audiooutput">
+      <group id="0">
+        <setting id="audiooutput.useanalogamplifier" type="boolean" label="38122" help="38123">
+          <level>0</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
+      </group>
       <group id="1">
         <setting id="audiooutput.processquality">
           <default>101</default> <!-- AE_QUALITY_GPU -->

--- a/xbmc/cores/AudioEngine/Sinks/AESinkPi.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPi.cpp
@@ -492,6 +492,43 @@ void CAESinkPi::Drain()
   CLog::Log(LOGDEBUG, "%s:%s delay:%dms now:%dms", CLASSNAME, __func__, delay, (int)(status.GetDelay() * 1000.0));
 }
 
+bool CAESinkPi::HasVolume()
+{
+  return CSettings::GetInstance().GetBool(CSettings::SETTING_AUDIOOUTPUT_USEANALOGAMPLIFIER);
+}
+
+static void SetHardwareVolume(COMXCoreComponent& render, float volume_)
+{
+  OMX_AUDIO_CONFIG_VOLUMETYPE volume;
+  OMX_INIT_STRUCTURE(volume);
+
+  volume.nPortIndex = render.GetInputPort();
+  volume.bLinear    = OMX_TRUE;
+  volume.sVolume.nValue = (int)(volume_ * 100.0 + 0.5);
+
+  OMX_ERRORTYPE omx_err = render.SetConfig(OMX_IndexConfigAudioVolume, &volume);
+  if(omx_err != OMX_ErrorNone)
+  {
+    CLog::Log(LOGERROR, "%s - error setting OMX_IndexConfigAudioVolume, error 0x%08x\n", __func__, omx_err);
+  }
+  CLog::Log(LOGDEBUG, "%s - hardwareVolume=%d\n", __func__, volume.sVolume.nValue );
+}
+
+void CAESinkPi::SetVolume(float volume)
+{
+  CLog::Log(LOGDEBUG, "%s:%s volume=%.2f", CLASSNAME, __func__, volume);
+
+  if (m_omx_render.IsInitialized())
+  {
+    SetHardwareVolume(m_omx_render, volume);
+  }
+
+  if (m_omx_render_slave.IsInitialized())
+  {
+    SetHardwareVolume(m_omx_render_slave, volume);
+  }
+}
+
 void CAESinkPi::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)
 {
   m_info.m_channels.Reset();

--- a/xbmc/cores/AudioEngine/Sinks/AESinkPi.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPi.h
@@ -45,6 +45,9 @@ public:
   virtual unsigned int AddPackets      (uint8_t **data, unsigned int frames, unsigned int offset);
   virtual void         Drain           ();
 
+  virtual bool         HasVolume();
+  virtual void         SetVolume(float volume);
+
   static void          EnumerateDevicesEx(AEDeviceInfoList &list, bool force = false);
 private:
   void                 SetAudioDest();

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -344,6 +344,7 @@ const std::string CSettings::SETTING_VIDEOSCREEN_GUICALIBRATION = "videoscreen.g
 const std::string CSettings::SETTING_VIDEOSCREEN_TESTPATTERN = "videoscreen.testpattern";
 const std::string CSettings::SETTING_VIDEOSCREEN_LIMITEDRANGE = "videoscreen.limitedrange";
 const std::string CSettings::SETTING_AUDIOOUTPUT_AUDIODEVICE = "audiooutput.audiodevice";
+const std::string CSettings::SETTING_AUDIOOUTPUT_USEANALOGAMPLIFIER = "audiooutput.useanalogamplifier";
 const std::string CSettings::SETTING_AUDIOOUTPUT_CHANNELS = "audiooutput.channels";
 const std::string CSettings::SETTING_AUDIOOUTPUT_CONFIG = "audiooutput.config";
 const std::string CSettings::SETTING_AUDIOOUTPUT_SAMPLERATE = "audiooutput.samplerate";
@@ -1064,6 +1065,7 @@ void CSettings::InitializeISettingCallbacks()
   settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_TRUEHDPASSTHROUGH);
   settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_DTSHDPASSTHROUGH);
   settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_AUDIODEVICE);
+  settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_USEANALOGAMPLIFIER);
   settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_PASSTHROUGHDEVICE);
   settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_STREAMSILENCE);
   settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_MAINTAINORIGINALVOLUME);

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -301,6 +301,7 @@ public:
   static const std::string SETTING_VIDEOSCREEN_TESTPATTERN;
   static const std::string SETTING_VIDEOSCREEN_LIMITEDRANGE;
   static const std::string SETTING_AUDIOOUTPUT_AUDIODEVICE;
+  static const std::string SETTING_AUDIOOUTPUT_USEANALOGAMPLIFIER;
   static const std::string SETTING_AUDIOOUTPUT_CHANNELS;
   static const std::string SETTING_AUDIOOUTPUT_CONFIG;
   static const std::string SETTING_AUDIOOUTPUT_SAMPLERATE;


### PR DESCRIPTION
XBMC Frodo and earlier on Raspberry Pi being controlled from UPnP controllers from a smartphone allows playing music and changing volume directly from controller. After Frodo user has to set audio to maximum volume to get an audible sound from the analogue output. This is done because analogue audio output has limited dynamic range of about 11 bits. Users are advised changing volume on amplifier.

As result of this choice users have to select music and then search for remote from the amplifier or walk to it to change the volume. It is rather awkward. This simple action could be difficult to fulfil if amplifier is hidden somewhere in the room away from the sight.

This behavior also dramatically different from behavior of other DLNA renderers, where the user can directly change the volume from a controller.

This pull request provides an option to handle analogue audio output as in Frodo and before. This option is available from System Settings > System >Audio Output > Use analogue amplifier. This option is switched off by default.
