### PR TITLE
Fix cached folders JSON playlist play item failure

### DIFF
--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -226,7 +226,7 @@ bool CFile::Open(const CURL& file, const unsigned int flags)
       url2.SetOptions("");
     if (url2.IsProtocol("zip"))
       url2.SetOptions("");
-    if (!g_directoryCache.FileExists(url2.Get(), bPathInCache) )
+    if (!g_directoryCache.FileExists(url2.GetFileName(), bPathInCache) )
     {
       if (bPathInCache)
         return false;


### PR DESCRIPTION
This attempts to fix ticket http://trac.kodi.tv/ticket/16469 crucial for the Jarvis release.

The bug occurs when using JSON to add music to a playlist and then play it, but I found that it can be difficult to reproduce as it depends on the contents of the directory cache. @Joethefox identified that was conected to #8288, but  @arnova  and I think that it is most likely the increase in cache size simply made the occurence more likely rather than be the underlying cause.

I think it is down to calling `g_directoryCache.FileExists` with a full url e.g. `"musicdb://songs/26124.mp3?albumid=1884"`, and that the option part at the end causes subsequent CFileItemList::Contains call to fail to find the file name in cache. 

I will start a build so that this can be well tested before merge, especially as I found the bug so hard to reproduce on demand. 
