### PR TITLE
[confluence][fix] get rid of view (ID: 51) in pvr channel window which cause issues with viewtypes

### DIFF
--- a/addons/skin.confluence/720p/MyPVRChannels.xml
+++ b/addons/skin.confluence/720p/MyPVRChannels.xml
@@ -2,7 +2,7 @@
 <window>
 	<defaultcontrol always="true">50</defaultcontrol>
 	<menucontrol>9000</menucontrol>
-	<views>50,51</views>
+	<views>50</views>
 	<controls>
 		<include>CommonBackground</include>
 		<control type="image">
@@ -18,7 +18,7 @@
 			<include>Window_OpenClose_Animation</include>
 			<include>VisibleFadeEffect</include>
 			<control type="group">
-				<visible>Control.IsVisible(50)</visible>
+				<visible>![!IsEmpty(Window.Property(IsRadio)) + System.GetBool(PVRPlayback.EnableRadioRDS) + !Skin.HasSetting(HideEPGwithRDS)]</visible>
 				<control type="image">
 					<left>50</left>
 					<top>60</top>
@@ -28,7 +28,7 @@
 				</control>
 			</control>
 			<control type="group">
-				<visible>Control.IsVisible(51)</visible>
+				<visible>!IsEmpty(Window.Property(IsRadio)) + System.GetBool(PVRPlayback.EnableRadioRDS) + !Skin.HasSetting(HideEPGwithRDS)</visible>
 				<control type="image">
 					<left>50</left>
 					<top>60</top>
@@ -72,7 +72,6 @@
 			<description>Small Media Window</description>
 			<left>530</left>
 			<top>80</top>
-			<visible>Control.IsVisible(50) | Control.IsVisible(51)</visible>
 			<include>VisibleFadeEffect</include>
 			<include>Window_OpenClose_Animation</include>
 			<control type="image">
@@ -138,7 +137,6 @@
 		<control type="group">
 			<include>Window_OpenClose_Animation</include>
 			<description>TV Channels group</description>
-			<visible>Control.IsVisible(50) | Control.IsVisible(51)</visible>
 			<include>VisibleFadeEffect</include>
 			<control type="group">
 				<left>530</left>
@@ -219,85 +217,6 @@
 				</control>
 			</control>
 			<control type="group">
-				<left>70</left>
-				<top>490</top>
-				<visible>Control.IsVisible(51)</visible>
-				<control type="label">
-					<left>0</left>
-					<top>0</top>
-					<width>415</width>
-					<height>20</height>
-					<font>font13</font>
-					<textcolor>white</textcolor>
-					<shadowcolor>black</shadowcolor>
-					<scroll>true</scroll>
-					<align>center</align>
-					<aligny>center</aligny>
-					<label>[B]$INFO[Container(51).ListItem.Title][/B]</label>
-				</control>
-				<control type="label">
-					<left>0</left>
-					<top>22</top>
-					<width>60</width>
-					<height>20</height>
-					<align>right</align>
-					<aligny>center</aligny>
-					<font>font10_title</font>
-					<textcolor>blue</textcolor>
-					<visible>Container(51).ListItem.HasEpg</visible>
-					<label>$INFO[Container(51).ListItem.StartTime]</label>
-				</control>
-				<control type="progress">
-					<description>Progressbar</description>
-					<left>65</left>
-					<top>30</top>
-					<width>275</width>
-					<height>8</height>
-					<visible>Container(51).ListItem.HasEpg</visible>
-					<info>Container(51).ListItem.Progress</info>
-				</control>
-				<control type="label">
-					<left>345</left>
-					<top>22</top>
-					<width>80</width>
-					<height>20</height>
-					<align>left</align>
-					<aligny>center</aligny>
-					<font>font10_title</font>
-					<textcolor>blue</textcolor>
-					<visible>Container(51).ListItem.HasEpg</visible>
-					<label>$INFO[Container(51).ListItem.EndTime]</label>
-				</control>
-				<control type="textbox">
-					<description>Plot Value for TVShow</description>
-					<left>0</left>
-					<top>50</top>
-					<width>415</width>
-					<height>74</height>
-					<font>font13</font>
-					<align>justify</align>
-					<textcolor>white</textcolor>
-					<shadowcolor>black</shadowcolor>
-					<pagecontrol>-</pagecontrol>
-					<label>$INFO[Container(51).ListItem.Plot]</label>
-					<autoscroll time="2000" delay="3000" repeat="5000">true</autoscroll>
-				</control>
-				<control type="label">
-					<left>0</left>
-					<top>140</top>
-					<width>400</width>
-					<height>20</height>
-					<font>font12</font>
-					<textcolor>grey2</textcolor>
-					<align>right</align>
-					<aligny>center</aligny>
-					<scroll>false</scroll>
-					<visible>!IsEmpty(Container(51).ListItem.NextTitle)</visible>
-					<label>$LOCALIZE[19031]: $INFO[Container(51).ListItem.NextTitle]</label>
-				</control>
-			</control>
-			<control type="group">
-				<visible>Control.IsVisible(50)</visible>
 				<control type="list" id="50">
 					<left>70</left>
 					<top>85</top>
@@ -310,7 +229,6 @@
 					<viewtype label="535">list</viewtype>
 					<pagecontrol>70</pagecontrol>
 					<scrolltime>200</scrolltime>
-					<visible>!Control.IsVisible(51)</visible>
 					<itemlayout height="60" width="390">
 						<control type="image">
 							<left>0</left>
@@ -523,236 +441,6 @@
 					<align>right</align>
 					<aligny>center</aligny>
 					<label>([COLOR=blue]$INFO[Container(50).NumItems][/COLOR]) $LOCALIZE[19019] - $LOCALIZE[31024] ([COLOR=blue]$INFO[Container(50).CurrentPage]/$INFO[Container(50).NumPages][/COLOR])</label>
-					<include>Window_OpenClose_Animation</include>
-				</control>
-			</control>
-			<control type="group">
-				<visible>Control.IsVisible(51)</visible>
-				<control type="list" id="51">
-					<left>70</left>
-					<top>85</top>
-					<width>390</width>
-					<height>361</height>
-					<onleft>100</onleft>
-					<onright>70</onright>
-					<onup>51</onup>
-					<ondown>51</ondown>
-					<viewtype label="535">list</viewtype>
-					<pagecontrol>70</pagecontrol>
-					<scrolltime>200</scrolltime>
-					<visible>!IsEmpty(Window.Property(IsRadio)) + system.getbool(pvrplayback.enableradiords) + !Skin.HasSetting(HideEPGwithRDS)</visible>
-					<itemlayout height="60" width="390">
-						<control type="image">
-							<left>0</left>
-							<top>0</top>
-							<width>390</width>
-							<height>61</height>
-							<texture border="2">MenuItemNF.png</texture>
-							<include>VisibleFadeEffect</include>
-						</control>
-						<control type="label">
-							<left>5</left>
-							<top>-4</top>
-							<width>40</width>
-							<height>35</height>
-							<font>font12</font>
-							<align>left</align>
-							<aligny>center</aligny>
-							<textcolor>grey</textcolor>
-							<selectedcolor>grey</selectedcolor>
-							<info>ListItem.ChannelNumberLabel</info>
-						</control>
-						<control type="label">
-							<left>50</left>
-							<top>0</top>
-							<width>270</width>
-							<height>25</height>
-							<font>font13</font>
-							<textcolor>white</textcolor>
-							<selectedcolor>selected</selectedcolor>
-							<align>left</align>
-							<aligny>center</aligny>
-							<label>$INFO[ListItem.Label]</label>
-						</control>
-						<control type="label">
-							<left>50</left>
-							<top>25</top>
-							<width>330</width>
-							<height>20</height>
-							<font>font12</font>
-							<textcolor>grey</textcolor>
-							<selectedcolor>grey</selectedcolor>
-							<align>left</align>
-							<aligny>center</aligny>
-							<label>$INFO[ListItem.Title]</label>
-							<visible>IsEmpty(Listitem.Icon)</visible>
-						</control>
-						<control type="label">
-							<left>50</left>
-							<top>25</top>
-							<width>280</width>
-							<height>20</height>
-							<font>font12</font>
-							<textcolor>grey</textcolor>
-							<selectedcolor>grey</selectedcolor>
-							<align>left</align>
-							<aligny>center</aligny>
-							<label>$INFO[ListItem.Title]</label>
-							<visible>!IsEmpty(Listitem.Icon)</visible>
-						</control>
-						<control type="progress">
-							<description>Progressbar</description>
-							<left>50</left>
-							<top>48</top>
-							<width>280</width>
-							<height>6</height>
-							<colordiffuse>88FFFFFF</colordiffuse>
-							<visible>ListItem.HasEpg</visible>
-							<info>ListItem.Progress</info>
-						</control>
-						<control type="image">
-							<left>340</left>
-							<top>4</top>
-							<width>50</width>
-							<height>50</height>
-							<texture>$INFO[ListItem.Icon]</texture>
-							<aspectratio>keep</aspectratio>
-						</control>
-						<control type="image">
-							<left>5</left>
-							<top>37</top>
-							<width>30</width>
-							<height>20</height>
-							<texture>PVR-IsRecording.png</texture>
-							<visible>ListItem.IsRecording</visible>
-						</control>
-					</itemlayout>
-					<focusedlayout height="60" width="390">
-						<control type="image">
-							<left>0</left>
-							<top>0</top>
-							<width>390</width>
-							<height>61</height>
-							<texture border="2">MenuItemNF.png</texture>
-							<visible>!Control.HasFocus(51)</visible>
-							<include>VisibleFadeEffect</include>
-						</control>
-						<control type="image">
-							<left>0</left>
-							<top>0</top>
-							<width>390</width>
-							<height>61</height>
-							<texture border="2">MenuItemFO.png</texture>
-							<visible>Control.HasFocus(51)</visible>
-							<include>VisibleFadeEffect</include>
-						</control>
-						<control type="label">
-							<left>5</left>
-							<top>-4</top>
-							<width>40</width>
-							<height>35</height>
-							<font>font12</font>
-							<align>left</align>
-							<aligny>center</aligny>
-							<textcolor>grey</textcolor>
-							<selectedcolor>grey</selectedcolor>
-							<info>ListItem.ChannelNumberLabel</info>
-						</control>
-						<control type="label">
-							<left>50</left>
-							<top>0</top>
-							<width>270</width>
-							<height>25</height>
-							<font>font13</font>
-							<textcolor>white</textcolor>
-							<selectedcolor>selected</selectedcolor>
-							<align>left</align>
-							<aligny>center</aligny>
-							<label>$INFO[ListItem.Label]</label>
-						</control>
-						<control type="label">
-							<left>50</left>
-							<top>25</top>
-							<width>330</width>
-							<height>20</height>
-							<font>font12</font>
-							<textcolor>grey</textcolor>
-							<selectedcolor>grey</selectedcolor>
-							<align>left</align>
-							<aligny>center</aligny>
-							<label>$INFO[ListItem.Title]</label>
-							<visible>IsEmpty(Listitem.Icon)</visible>
-						</control>
-						<control type="label">
-							<left>50</left>
-							<top>25</top>
-							<width>280</width>
-							<height>20</height>
-							<font>font12</font>
-							<textcolor>grey</textcolor>
-							<selectedcolor>grey</selectedcolor>
-							<align>left</align>
-							<aligny>center</aligny>
-							<label>$INFO[ListItem.Title]</label>
-							<visible>!IsEmpty(Listitem.Icon)</visible>
-						</control>
-						<control type="progress">
-							<description>Progressbar</description>
-							<left>50</left>
-							<top>48</top>
-							<width>280</width>
-							<height>6</height>
-							<colordiffuse>88FFFFFF</colordiffuse>
-							<visible>ListItem.HasEpg</visible>
-							<info>ListItem.Progress</info>
-						</control>
-						<control type="image">
-							<left>340</left>
-							<top>4</top>
-							<width>50</width>
-							<height>50</height>
-							<texture>$INFO[ListItem.Icon]</texture>
-							<aspectratio>keep</aspectratio>
-						</control>
-						<control type="image">
-							<left>5</left>
-							<top>37</top>
-							<width>30</width>
-							<height>20</height>
-							<texture>PVR-IsRecording.png</texture>
-							<visible>ListItem.IsRecording</visible>
-						</control>
-					</focusedlayout>
-				</control>
-				<control type="scrollbar" id="70">
-					<left>465</left>
-					<top>85</top>
-					<width>25</width>
-					<height>360</height>
-					<texturesliderbackground border="0,14,0,14">ScrollBarV.png</texturesliderbackground>
-					<texturesliderbar border="0,14,0,14">ScrollBarV_bar.png</texturesliderbar>
-					<texturesliderbarfocus border="0,14,0,14">ScrollBarV_bar_focus.png</texturesliderbarfocus>
-					<textureslidernib>ScrollBarNib.png</textureslidernib>
-					<textureslidernibfocus>ScrollBarNib.png</textureslidernibfocus>
-					<onleft>51</onleft>
-					<onright>61</onright>
-					<showonepage>false</showonepage>
-					<orientation>vertical</orientation>
-				</control>
-				<control type="label">
-					<depth>DepthFooter</depth>
-					<animation effect="slide" start="0,0" end="-90,0" time="0" condition="system.getbool(input.enablemouse)">Conditional</animation>
-					<description>Page Count Label</description>
-					<right>40</right>
-					<top>53r</top>
-					<width>500</width>
-					<height>20</height>
-					<font>font12</font>
-					<textcolor>grey</textcolor>
-					<scroll>false</scroll>
-					<align>right</align>
-					<aligny>center</aligny>
-					<label>([COLOR=blue]$INFO[Container(51).NumItems][/COLOR]) $LOCALIZE[19019] - $LOCALIZE[31024] ([COLOR=blue]$INFO[Container(51).CurrentPage]/$INFO[Container(51).NumPages][/COLOR])</label>
 					<include>Window_OpenClose_Animation</include>
 				</control>
 			</control>


### PR DESCRIPTION
#6174 introduced a new list view type (ID: 51) which does not work properly and in my opinion is 100% identical with the default list view type (ID: 50). This view type leads to an empty list after #8678 was merged (see https://github.com/xbmc/xbmc/pull/8678#issuecomment-167885879)

@AlwinEsch I can't test it because of missing RDS on my TV channels, could you please provide some screenshots/explanation of what you want to achieve with your changes to the PVR channel window?
