### PR TITLE
Joystick Bugfixes

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -716,10 +716,6 @@ bool CApplication::CreateGUI()
   sdlFlags |= SDL_INIT_VIDEO;
 #endif
 
-#if defined(HAS_SDL_JOYSTICK) && !defined(TARGET_WINDOWS)
-  sdlFlags |= SDL_INIT_JOYSTICK;
-#endif
-
   //depending on how it's compiled, SDL periodically calls XResetScreenSaver when it's fullscreen
   //this might bring the monitor out of standby, so we have to disable it explicitly
   //by passing 0 for overwrite to setsenv, the user can still override this by setting the environment variable

--- a/xbmc/input/InputManager.cpp
+++ b/xbmc/input/InputManager.cpp
@@ -424,6 +424,14 @@ bool CInputManager::Process(int windowId, float frameTime)
   ProcessGamepad(windowId);
   ProcessEventServer(windowId, frameTime);
   ProcessPeripherals(frameTime);
+
+#if defined(HAS_SDL_JOYSTICK)
+  if (m_ShallSetJoystickEnabled)
+  {
+    m_Joystick.SetEnabled(m_ShallSetJoystickEnabled == 1);
+    m_ShallSetJoystickEnabled = 0;
+  }
+#endif
   
   return true;
 }
@@ -860,7 +868,10 @@ void CInputManager::OnSettingChanged(const CSetting *setting)
 
 #if defined(HAS_SDL_JOYSTICK)
   if (settingId == CSettings::SETTING_INPUT_ENABLEJOYSTICK)
-    m_Joystick.SetEnabled(dynamic_cast<const CSettingBool*>(setting)->GetValue() &&
-    PERIPHERALS::CPeripheralImon::GetCountOfImonsConflictWithDInput() == 0);
+  {
+    m_ShallSetJoystickEnabled = dynamic_cast<const CSettingBool*>(setting)->GetValue() &&
+      PERIPHERALS::CPeripheralImon::GetCountOfImonsConflictWithDInput() == 0;
+    m_ShallSetJoystickEnabled = m_ShallSetJoystickEnabled ? 1 : -1;
+  }
 #endif
 }

--- a/xbmc/input/InputManager.h
+++ b/xbmc/input/InputManager.h
@@ -45,7 +45,7 @@ class CKey;
 class CInputManager : public ISettingCallback
 {
 private:
-  CInputManager() { }
+  CInputManager() : m_ShallSetJoystickEnabled(0) { }
   CInputManager(const CInputManager&);
   CInputManager const& operator=(CInputManager const&);
   virtual ~CInputManager() { };
@@ -268,4 +268,5 @@ private:
 #if defined(HAS_SDL_JOYSTICK) 
   CJoystick m_Joystick;
 #endif
+  int m_ShallSetJoystickEnabled;
 };

--- a/xbmc/input/SDLJoystick.cpp
+++ b/xbmc/input/SDLJoystick.cpp
@@ -54,6 +54,15 @@ void CJoystick::Initialize()
   if (!IsEnabled())
     return;
 
+  if (SDL_WasInit(SDL_INIT_JOYSTICK) !=  0)
+  {
+    SDL_QuitSubSystem(SDL_INIT_JOYSTICK);
+    if (SDL_WasInit(SDL_INIT_JOYSTICK) !=  0)
+    {
+      CLog::Log(LOGERROR, "Joystick subsystem still initialized!");
+    }
+  }
+
   if(SDL_InitSubSystem(SDL_INIT_JOYSTICK) != 0)
   {
     CLog::Log(LOGERROR, "(Re)start joystick subsystem failed : %s",SDL_GetError());


### PR DESCRIPTION
Made two bugfixes concerning Joystick support
When enabling Joystick support in GUI while running, no Joysticks are found, restart was needed.
Disabling Joystick support via jsonrpc caused kodi to crash immediately (SegFault), because the CJoystick class is not thread safe.
