### PR TITLE
[guilib] add defaulticons for addonmanager root

### DIFF
--- a/xbmc/addons/GUIViewStateAddonBrowser.cpp
+++ b/xbmc/addons/GUIViewStateAddonBrowser.cpp
@@ -65,6 +65,7 @@ VECSOURCES& CGUIViewStateAddonBrowser::GetSources()
     CMediaSource share;
     share.strPath = "addons://user/";
     share.m_iDriveType = CMediaSource::SOURCE_TYPE_LOCAL;
+    share.m_strThumbnailImage = "DefaultAddonsInstalled.png";
     share.strName = g_localizeStrings.Get(24998);
     m_sources.push_back(share);
   }
@@ -73,6 +74,7 @@ VECSOURCES& CGUIViewStateAddonBrowser::GetSources()
     CMediaSource share;
     share.strPath = "addons://outdated/";
     share.m_iDriveType = CMediaSource::SOURCE_TYPE_LOCAL;
+    share.m_strThumbnailImage = "DefaultAddonsUpdates.png";
     share.strName = g_localizeStrings.Get(24043); // "Available updates"
     m_sources.push_back(share);
   }
@@ -81,6 +83,7 @@ VECSOURCES& CGUIViewStateAddonBrowser::GetSources()
     CMediaSource share;
     share.strPath = "addons://repos/";
     share.m_iDriveType = CMediaSource::SOURCE_TYPE_LOCAL;
+    share.m_strThumbnailImage = "DefaultAddonsRepo.png";
     share.strName = g_localizeStrings.Get(24033);
     m_sources.push_back(share);
   }
@@ -88,6 +91,7 @@ VECSOURCES& CGUIViewStateAddonBrowser::GetSources()
     CMediaSource share;
     share.strPath = "addons://install/";
     share.m_iDriveType = CMediaSource::SOURCE_TYPE_LOCAL;
+    share.m_strThumbnailImage = "DefaultAddonsZip.png";
     share.strName = g_localizeStrings.Get(24041);
     m_sources.push_back(share);
   }
@@ -95,6 +99,7 @@ VECSOURCES& CGUIViewStateAddonBrowser::GetSources()
     CMediaSource share;
     share.strPath = "addons://search/";
     share.m_iDriveType = CMediaSource::SOURCE_TYPE_LOCAL;
+    share.m_strThumbnailImage = "DefaultAddonsSearch.png";
     share.strName = g_localizeStrings.Get(137);
     m_sources.push_back(share);
   }


### PR DESCRIPTION
this adds listitem.icon to the listitems in addonmanager root. Naming of the defaultimages is up for discussion.

@tamland 

Would also need confluence adjustments. @ronie , @HitcherUK , opinions?

EDIT: actually, confluence also doesnt look too bad without adjustments. 
