### PR TITLE
Implement filecache retry logic

### DIFF
--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -60,6 +60,10 @@ curl_proxytype proxyType2CUrlProxyType[] = {
   CURLPROXY_SOCKS5_HOSTNAME,
 };
 
+#define FILLBUFFER_OK         0
+#define FILLBUFFER_NO_DATA    1
+#define FILLBUFFER_FAIL       2
+
 // curl calls this routine to debug
 extern "C" int debug_callback(CURL_HANDLE *handle, curl_infotype info, char *output, size_t size, void *data)
 {
@@ -256,6 +260,7 @@ CCurlFile::CReadState::CReadState()
   m_cancelled = false;
   m_bFirstLoop = true;
   m_sendRange = true;
+  m_bLastError = false;
   m_readBuffer = 0;
   m_isPaused = false;
   m_curlHeaderList = NULL;
@@ -286,7 +291,7 @@ bool CCurlFile::CReadState::Seek(int64_t pos)
     int len = m_buffer.getMaxReadSize();
     m_filePos += len;
     m_buffer.SkipBytes(len);
-    if(!FillBuffer(m_bufferSize))
+    if (FillBuffer(m_bufferSize) != FILLBUFFER_OK)
     {
       if(!m_buffer.SkipBytes(-len))
         CLog::Log(LOGERROR, "%s - Failed to restore position after failed fill", __FUNCTION__);
@@ -346,7 +351,7 @@ long CCurlFile::CReadState::Connect(unsigned int size)
   m_stillRunning = 1;
 
   // (Try to) fill buffer
-  if (!FillBuffer(1))
+  if (FillBuffer(1) != FILLBUFFER_OK)
   {
     // Check response code
     long response;
@@ -1130,7 +1135,7 @@ bool CCurlFile::CReadState::ReadString(char *szLine, int iLineLength)
 {
   unsigned int want = (unsigned int)iLineLength;
 
-  if((m_fileSize == 0 || m_filePos < m_fileSize) && !FillBuffer(want))
+  if((m_fileSize == 0 || m_filePos < m_fileSize) && FillBuffer(want) != FILLBUFFER_OK)
     return false;
 
   // ensure only available data is considered
@@ -1454,8 +1459,15 @@ int CCurlFile::Stat(const CURL& url, struct __stat64* buffer)
 ssize_t CCurlFile::CReadState::Read(void* lpBuf, size_t uiBufSize)
 {
   /* only request 1 byte, for truncated reads (only if not eof) */
-  if((m_fileSize == 0 || m_filePos < m_fileSize) && !FillBuffer(1))
-    return 0;
+  if (m_fileSize == 0 || m_filePos < m_fileSize)
+  {
+    int8_t result = FillBuffer(1);
+    if (result == FILLBUFFER_FAIL)
+      return -1; // Fatal error
+
+    if (result == FILLBUFFER_NO_DATA)
+      return 0;
+  }
 
   /* ensure only available data is considered */
   unsigned int want = (unsigned int)XMIN(m_buffer.getMaxReadSize(), uiBufSize);
@@ -1478,7 +1490,7 @@ ssize_t CCurlFile::CReadState::Read(void* lpBuf, size_t uiBufSize)
 }
 
 /* use to attempt to fill the read buffer up to requested number of bytes */
-bool CCurlFile::CReadState::FillBuffer(unsigned int want)
+int8_t CCurlFile::CReadState::FillBuffer(unsigned int want)
 {
   int retry = 0;
   fd_set fdread;
@@ -1490,7 +1502,7 @@ bool CCurlFile::CReadState::FillBuffer(unsigned int want)
   while ((unsigned int)m_buffer.getMaxReadSize() < want && m_buffer.getMaxWriteSize() > 0 )
   {
     if (m_cancelled)
-      return false;
+      return FILLBUFFER_NO_DATA;
 
     /* if there is data in overflow buffer, try to use that first */
     if (m_overflowSize)
@@ -1514,18 +1526,19 @@ bool CCurlFile::CReadState::FillBuffer(unsigned int want)
       {
         /* if we still have stuff in buffer, we are fine */
         if (m_buffer.getMaxReadSize())
-          return true;
+          return FILLBUFFER_OK;
 
-        /* verify that we are actually okey */
+        // check for errors
         int msgs;
-        CURLcode CURLresult = CURLE_OK;
         CURLMsg* msg;
+        bool bRetryNow = true;
+        bool bError = false;
         while ((msg = g_curlInterface.multi_info_read(m_multiHandle, &msgs)))
         {
           if (msg->msg == CURLMSG_DONE)
           {
             if (msg->data.result == CURLE_OK)
-              return true;
+              return FILLBUFFER_OK;
 
             long httpCode = 0;
             if (msg->data.result == CURLE_HTTP_RETURNED_ERROR)
@@ -1541,13 +1554,15 @@ bool CCurlFile::CReadState::FillBuffer(unsigned int want)
               CLog::Log(LOGERROR, "CCurlFile::FillBuffer - Failed: %s(%d)", g_curlInterface.easy_strerror(msg->data.result), msg->data.result);
             }
 
-            // We need to check the result here as we don't want to retry on every error
             if ( (msg->data.result == CURLE_OPERATION_TIMEDOUT ||
                   msg->data.result == CURLE_PARTIAL_FILE       ||
                   msg->data.result == CURLE_COULDNT_CONNECT    ||
                   msg->data.result == CURLE_RECV_ERROR)        &&
                   !m_bFirstLoop)
-              CURLresult = msg->data.result;
+            {
+              bRetryNow = false; // Leave it to caller whether the operation is retried
+              bError = true;
+            }
             else if ( (msg->data.result == CURLE_HTTP_RANGE_ERROR              ||
                        httpCode == 416 /* = Requested Range Not Satisfiable */ ||
                        httpCode == 406 /* = Not Acceptable (fixes issues with non compliant HDHomerun servers */) &&
@@ -1555,18 +1570,22 @@ bool CCurlFile::CReadState::FillBuffer(unsigned int want)
                        m_filePos == 0                                 &&
                        m_sendRange)
             {
-              // If server returns a range or http error, retry with range disabled
-              CURLresult = msg->data.result;
+              // If server returns a (possible) range error, disable range and retry (handled below)
+              bRetryNow = true;
+              bError = true;
               m_sendRange = false;
             }
             else
-              return false;
+            {
+              // For all other errors, abort the operation
+              return FILLBUFFER_FAIL;
+            }
           }
         }
 
-        // Don't retry when we didn't "see" any error
-        if (CURLresult == CURLE_OK)
-          return false;
+        // Check for an actual error, if not, just return no-data
+        if (!bError && !m_bLastError)
+          return FILLBUFFER_NO_DATA;
 
         // Close handle
         if (m_multiHandle && m_easyHandle)
@@ -1577,37 +1596,34 @@ bool CCurlFile::CReadState::FillBuffer(unsigned int want)
         free(m_overflowBuffer);
         m_overflowBuffer = NULL;
         m_overflowSize = 0;
+        m_bLastError = true; // Flag error for the next run
 
-        // If we got here something is wrong
-        if (++retry > g_advancedSettings.m_curlretries)
+        // Retry immediately or leave it up to the caller?
+        if (retry < g_advancedSettings.m_curlretries || (bRetryNow && retry == 0))
         {
-          CLog::Log(LOGERROR, "CCurlFile::FillBuffer - Reconnect failed!");
-          // Reset the rest of the variables like we would in Disconnect()
-          m_filePos = 0;
-          m_fileSize = 0;
-          m_bufferSize = 0;
+          retry++;
 
-          return false;
+          // Connect + seek to current position (again)
+          SetResume();
+          g_curlInterface.multi_add_handle(m_multiHandle, m_easyHandle);
+
+          CLog::Log(LOGWARNING, "CCurlFile::FillBuffer - Reconnect, (re)try %i", retry);
+
+          // Return to the beginning of the loop:
+          continue;
         }
 
-        CLog::Log(LOGNOTICE, "CCurlFile::FillBuffer - Reconnect, (re)try %i", retry);
-
-        // Progressive sleep. TODO: Find a better optimum for this?
-        Sleep( (retry - 1) * 1000);
-
-        // Connect + seek to current position (again)
-        SetResume();
-        g_curlInterface.multi_add_handle(m_multiHandle, m_easyHandle);
-
-        // Return to the beginning of the loop:
-        continue;
+        return FILLBUFFER_NO_DATA; // We failed but flag no data to caller, so it can retry the operation
       }
-      return false;
+      return FILLBUFFER_FAIL;
     }
 
     // We've finished out first loop
     if(m_bFirstLoop && m_buffer.getMaxReadSize() > 0)
       m_bFirstLoop = false;
+
+    // No error this run
+    m_bLastError = false;
 
     switch (result)
     {
@@ -1674,7 +1690,7 @@ bool CCurlFile::CReadState::FillBuffer(unsigned int want)
           CLog::Log(LOGERROR, "CCurlFile::FillBuffer - Failed with socket error:%s", str);
 #endif
 
-          return false;
+          return FILLBUFFER_FAIL;
         }
       }
       break;
@@ -1689,12 +1705,12 @@ bool CCurlFile::CReadState::FillBuffer(unsigned int want)
       default:
       {
         CLog::Log(LOGERROR, "CCurlFile::FillBuffer - Multi perform failed with code %d, aborting", result);
-        return false;
+        return FILLBUFFER_FAIL;
       }
       break;
     }
   }
-  return true;
+  return FILLBUFFER_OK;
 }
 
 void CCurlFile::CReadState::SetReadBuffer(const void* lpBuf, int64_t uiBufSize)

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -1451,7 +1451,7 @@ int CCurlFile::Stat(const CURL& url, struct __stat64* buffer)
   return 0;
 }
 
-unsigned int CCurlFile::CReadState::Read(void* lpBuf, size_t uiBufSize)
+ssize_t CCurlFile::CReadState::Read(void* lpBuf, size_t uiBufSize)
 {
   /* only request 1 byte, for truncated reads (only if not eof) */
   if((m_fileSize == 0 || m_filePos < m_fileSize) && !FillBuffer(1))

--- a/xbmc/filesystem/CurlFile.h
+++ b/xbmc/filesystem/CurlFile.h
@@ -123,6 +123,7 @@ namespace XFILE
           bool            m_bFirstLoop;
           bool            m_isPaused;
           bool            m_sendRange;
+          bool            m_bLastError;
 
           char*           m_readBuffer;
 
@@ -141,7 +142,7 @@ namespace XFILE
           bool         Seek(int64_t pos);
           ssize_t      Read(void* lpBuf, size_t uiBufSize);
           bool         ReadString(char *szLine, int iLineLength);
-          bool         FillBuffer(unsigned int want);
+          int8_t       FillBuffer(unsigned int want);
           void         SetReadBuffer(const void* lpBuf, int64_t uiBufSize);
 
           void         SetResume(void);

--- a/xbmc/filesystem/CurlFile.h
+++ b/xbmc/filesystem/CurlFile.h
@@ -124,6 +124,7 @@ namespace XFILE
           bool            m_isPaused;
           bool            m_sendRange;
           bool            m_bLastError;
+          bool            m_bRetry;
 
           char*           m_readBuffer;
 
@@ -194,6 +195,7 @@ namespace XFILE
       bool            m_multisession;
       bool            m_skipshout;
       bool            m_postdataset;
+      bool            m_allowRetry;
 
       CRingBuffer     m_buffer;           // our ringhold buffer
       char *          m_overflowBuffer;   // in the rare case we would overflow the above buffer

--- a/xbmc/filesystem/CurlFile.h
+++ b/xbmc/filesystem/CurlFile.h
@@ -139,7 +139,7 @@ namespace XFILE
           size_t HeaderCallback(void *ptr, size_t size, size_t nmemb);
 
           bool         Seek(int64_t pos);
-          unsigned int Read(void* lpBuf, size_t uiBufSize);
+          ssize_t      Read(void* lpBuf, size_t uiBufSize);
           bool         ReadString(char *szLine, int iLineLength);
           bool         FillBuffer(unsigned int want);
           void         SetReadBuffer(const void* lpBuf, int64_t uiBufSize);

--- a/xbmc/filesystem/FileCache.cpp
+++ b/xbmc/filesystem/FileCache.cpp
@@ -313,7 +313,8 @@ void CFileCache::Process()
 
       if (m_seekEvent.WaitMSec(100))
       {
-        m_seekEvent.Set();
+        if (!m_bStop)
+          m_seekEvent.Set();
         break;
       }
     }
@@ -343,8 +344,11 @@ void CFileCache::Process()
         CLog::Log(LOGDEBUG, "CFileCache::Process - Source read didn't return any data! Will retry.");
 
         // Wait a bit:
-        if (m_seekEvent.WaitMSec(2000))
-          m_seekEvent.Set(); // hack so that later we realize seek is needed
+        if (m_seekEvent.WaitMSec(5000))
+        {
+          if (!m_bStop)
+            m_seekEvent.Set(); // hack so that later we realize seek is needed
+        }
 
         // and retry:
         continue; // while (!m_bStop)
@@ -359,7 +363,8 @@ void CFileCache::Process()
         if (AbortableWait(m_seekEvent) == WAIT_SIGNALED)
         {
           m_pCache->ClearEndOfInput();
-          m_seekEvent.Set(); // hack so that later we realize seek is needed
+          if (!m_bStop)
+            m_seekEvent.Set(); // hack so that later we realize seek is needed
         }
         else
           break; // while (!m_bStop)
@@ -406,7 +411,8 @@ void CFileCache::Process()
       // check if seek was asked. otherwise if cache is full we'll freeze.
       if (m_seekEvent.WaitMSec(0))
       {
-        m_seekEvent.Set(); // make sure we get the seek event later.
+        if (!m_bStop)
+          m_seekEvent.Set(); // make sure we get the seek event later.
         break;
       }
     }

--- a/xbmc/filesystem/FileCache.cpp
+++ b/xbmc/filesystem/FileCache.cpp
@@ -176,7 +176,10 @@ bool CFileCache::Open(const CURL& url)
     return false;
   }
 
-  m_source.IoControl(IOCTRL_SET_CACHE,this);
+  m_source.IoControl(IOCTRL_SET_CACHE, this);
+
+  bool retry = false;
+  m_source.IoControl(IOCTRL_SET_RETRY, &retry); // We already handle retrying ourselves
 
   // check if source can seek
   m_seekPossible = m_source.IoControl(IOCTRL_SEEK_POSSIBLE, NULL);

--- a/xbmc/filesystem/IFileTypes.h
+++ b/xbmc/filesystem/IFileTypes.h
@@ -64,11 +64,12 @@ struct SCacheStatus
 };
 
 typedef enum {
-  IOCTRL_NATIVE        = 1, /**< SNativeIoControl structure, containing what should be passed to native ioctrl */
-  IOCTRL_SEEK_POSSIBLE = 2, /**< return 0 if known not to work, 1 if it should work */
-  IOCTRL_CACHE_STATUS  = 3, /**< SCacheStatus structure */
-  IOCTRL_CACHE_SETRATE = 4, /**< unsigned int with speed limit for caching in bytes per second */
-  IOCTRL_SET_CACHE    = 8, /** <CFileCache */
+  IOCTRL_NATIVE        = 1,  /**< SNativeIoControl structure, containing what should be passed to native ioctrl */
+  IOCTRL_SEEK_POSSIBLE = 2,  /**< return 0 if known not to work, 1 if it should work */
+  IOCTRL_CACHE_STATUS  = 3,  /**< SCacheStatus structure */
+  IOCTRL_CACHE_SETRATE = 4,  /**< unsigned int with speed limit for caching in bytes per second */
+  IOCTRL_SET_CACHE     = 8,  /**< CFileCache */
+  IOCTRL_SET_RETRY     = 16, /**< Enable/disable retry within the protocol handler (if supported) */
 } EIoControl;
 
 enum CURLOPTIONTYPE

--- a/xbmc/filesystem/SMBFile.cpp
+++ b/xbmc/filesystem/SMBFile.cpp
@@ -64,7 +64,6 @@ bool CSMB::IsFirstInit = true;
 
 CSMB::CSMB()
 {
-  m_IdleTimeout = 0;
   m_context = NULL;
 #ifdef TARGET_POSIX
   m_OpenConnections = 0;

--- a/xbmc/filesystem/SMBFile.cpp
+++ b/xbmc/filesystem/SMBFile.cpp
@@ -304,6 +304,7 @@ CSMBFile::CSMBFile()
   smb.Init();
   m_fd = -1;
   smb.AddActiveConnection();
+  m_allowRetry = true;
 }
 
 CSMBFile::~CSMBFile()
@@ -514,7 +515,7 @@ ssize_t CSMBFile::Read(void *lpBuf, size_t uiBufSize)
 
   ssize_t bytesRead = smbc_read(m_fd, lpBuf, (int)uiBufSize);
 
-  if ( bytesRead < 0 && errno == EINVAL )
+  if (m_allowRetry && bytesRead < 0 && errno == EINVAL )
   {
     CLog::Log(LOGERROR, "%s - Error( %" PRIdS ", %d, %s ) - Retrying", __FUNCTION__, bytesRead, errno, strerror(errno));
     bytesRead = smbc_read(m_fd, lpBuf, (int)uiBufSize);
@@ -641,4 +642,18 @@ std::string CSMBFile::GetAuthenticatedPath(const CURL &url)
   CURL authURL(url);
   CPasswordManager::GetInstance().AuthenticateURL(authURL);
   return smb.URLEncode(authURL);
+}
+
+int CSMBFile::IoControl(EIoControl request, void* param)
+{
+  if (request == IOCTRL_SEEK_POSSIBLE)
+    return 1;
+
+  if (request == IOCTRL_SET_RETRY)
+  {
+    m_allowRetry = *(bool*) param;
+    return 0;
+  }
+
+  return -1;
 }

--- a/xbmc/filesystem/SMBFile.h
+++ b/xbmc/filesystem/SMBFile.h
@@ -89,7 +89,8 @@ public:
   virtual bool OpenForWrite(const CURL& url, bool bOverWrite = false);
   virtual bool Delete(const CURL& url);
   virtual bool Rename(const CURL& url, const CURL& urlnew);
-  virtual int  GetChunkSize() {return 1;}
+  virtual int GetChunkSize() { return 1; }
+  virtual int IoControl(EIoControl request, void* param);
 
 protected:
   CURL m_url;
@@ -97,6 +98,6 @@ protected:
   std::string GetAuthenticatedPath(const CURL &url);
   int64_t m_fileSize;
   int m_fd;
+  bool m_allowRetry;
 };
 }
-

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -318,7 +318,7 @@ void CAdvancedSettings::Initialize()
 
   m_curlconnecttimeout = 10;
   m_curllowspeedtime = 20;
-  m_curlretries = 2;
+  m_curlretries = 0;
   m_curlDisableIPV6 = false;      //Certain hardware/OS combinations have trouble
                                   //with ipv6.
 

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -318,7 +318,7 @@ void CAdvancedSettings::Initialize()
 
   m_curlconnecttimeout = 10;
   m_curllowspeedtime = 20;
-  m_curlretries = 0;
+  m_curlretries = 2;
   m_curlDisableIPV6 = false;      //Certain hardware/OS combinations have trouble
                                   //with ipv6.
 


### PR DESCRIPTION
This PR implements retry logic for our filecache. Especially poor (wifi) connections benefit from this. Previously we would simply (silently) abort in case a single Read() failed.

With this we simply retry a read, as long as we have data in our cache. This PR also adjusts Curl's fillbuffer retry logic to properly support Read() retries. This also disables CFileCurl's internal retry logic which could cause long waits (hangs) on exit when .e.g a connection timeout occurred.
