### PR TITLE
Tests: Fix up TestTextureUtils.cpp after 932b0d2cec13970bf1f1e78cb6642e3890ce9d68

### DIFF
--- a/xbmc/test/TestTextureUtils.cpp
+++ b/xbmc/test/TestTextureUtils.cpp
@@ -35,12 +35,12 @@ typedef struct
   const char *out;
 } TestFiles;
 
-const TestFiles test_files[] = {{ "/path/to/image/file.jpg", "", "", "image://%2fpath%2fto%2fimage%2ffile.jpg/" },
-                                { "/path/to/image/file.jpg", "", "size=thumb", "image://%2fpath%2fto%2fimage%2ffile.jpg/transform?size=thumb" },
-                                { "/path/to/video/file.mkv", "video", "", "image://video@%2fpath%2fto%2fvideo%2ffile.mkv/" },
-                                { "/path/to/music/file.mp3", "music", "", "image://music@%2fpath%2fto%2fmusic%2ffile.mp3/" },
-                                { "image://%2fpath%2fto%2fimage%2ffile.jpg/", "", "", "image://%2fpath%2fto%2fimage%2ffile.jpg/" },
-                                { "image://%2fpath%2fto%2fimage%2ffile.jpg/transform?size=thumb", "", "size=thumb", "image://%2fpath%2fto%2fimage%2ffile.jpg/transform?size=thumb" }};
+const TestFiles test_files[] = {{ "/path/to/image/file.jpg", "", "", "image://%2Fpath%2Fto%2Fimage%2Ffile.jpg/" },
+                                { "/path/to/image/file.jpg", "", "size=thumb", "image://%2Fpath%2Fto%2Fimage%2Ffile.jpg/transform?size=thumb" },
+                                { "/path/to/video/file.mkv", "video", "", "image://video@%2Fpath%2Fto%2Fvideo%2Ffile.mkv/" },
+                                { "/path/to/music/file.mp3", "music", "", "image://music@%2Fpath%2Fto%2Fmusic%2Ffile.mp3/" },
+                                { "image://%2Fpath%2Fto%2Fimage%2Ffile.jpg/", "", "", "image://%2Fpath%2Fto%2Fimage%2Ffile.jpg/" },
+                                { "image://%2Fpath%2Fto%2Fimage%2Ffile.jpg/transform?size=thumb", "", "size=thumb", "image://%2Fpath%2Fto%2Fimage%2Ffile.jpg/transform?size=thumb" }};
 
 
 class TestTextureUtils :

--- a/xbmc/utils/test/TestURIUtils.cpp
+++ b/xbmc/utils/test/TestURIUtils.cpp
@@ -452,7 +452,7 @@ TEST_F(TestURIUtils, CreateArchivePath)
 {
   std::string ref, var;
 
-  ref = "zip://%2fpath%2fto%2f/file";
+  ref = "zip://%2Fpath%2Fto%2F/file";
   var = URIUtils::CreateArchivePath("zip", CURL("/path/to/"), "file").Get();
   EXPECT_STREQ(ref.c_str(), var.c_str());
 }

--- a/xbmc/utils/test/TestURIUtils.cpp
+++ b/xbmc/utils/test/TestURIUtils.cpp
@@ -314,7 +314,7 @@ TEST_F(TestURIUtils, IsISO9660)
 
 TEST_F(TestURIUtils, IsLiveTV)
 {
-  EXPECT_TRUE(URIUtils::IsLiveTV("pvr://path/to/file"));
+  EXPECT_TRUE(URIUtils::IsLiveTV("whatever://path/to/file.pvr"));
 }
 
 TEST_F(TestURIUtils, IsMultiPath)


### PR DESCRIPTION
Fix up tests after: 932b0d2cec13970bf1f1e78cb6642e3890ce9d68

Wait a moment, will look for the PVR one, too.
