### PR TITLE
added #include <stdlib.h> to allow compilation in Xcode 7 for iOS 9 (…

### DIFF
--- a/xbmc/linux/XFileUtils.cpp
+++ b/xbmc/linux/XFileUtils.cpp
@@ -18,6 +18,7 @@
  *
  */
 
+#include <stdlib.h>
 #include "system.h"
 #include "PlatformInclude.h"
 #include "XFileUtils.h"


### PR DESCRIPTION
Xcode 7 complains about the "free" directive being ambiguous when compiling for iOS 9.  Added "#include <stdlib.h>" fixed that
