### PR TITLE
[PVR] Echo up important Status info to Timer Rules

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -9553,7 +9553,17 @@ msgctxt "#19254"
 msgid "Guide update failed for channel"
 msgstr ""
 
-#empty strings from id 19255 to 19256
+#. for a timer rule, the number of child timers which are currently scheduled to record. For use in "status" fields.
+#: xbmc/pvr/timers/PVRTimerInfoTag.cpp
+msgctxt "#19255"
+msgid "%d scheduled"
+msgstr ""
+
+#. for a timer rule or timer to indicate this item has completed the intended recordings. For use in "status" fields.
+#: xbmc/pvr/timers/PVRTimerInfoTag.cpp
+msgctxt "#19256"
+msgid "Completed"
+msgstr ""
 
 msgctxt "#19257"
 msgid "Lock channel"

--- a/xbmc/pvr/timers/PVRTimerInfoTag.h
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.h
@@ -114,7 +114,22 @@ namespace PVR
     std::string ChannelIcon(void) const;
     CPVRChannelPtr ChannelTag(void) const;
 
+    /*!
+     * @brief updates this timer excluding the state of any children. See UpdateChildState/ResetChildState.
+     * @return true if the timer was updated successfully
+     */
     bool UpdateEntry(const CPVRTimerInfoTagPtr &tag);
+
+    /*!
+     * @brief merge in the state of this child timer. Run for each child after using ResetChildState.
+     * @return true if the child timer's state was merged successfully
+     */
+    bool UpdateChildState(const CPVRTimerInfoTagPtr &childTimer);
+
+    /*!
+     * @brief reset the state of children related to this timer. Run UpdateChildState for all children afterwards.
+     */
+    void ResetChildState();
 
     void UpdateEpgEvent(bool bClear = false);
 
@@ -269,5 +284,10 @@ namespace PVR
     CDateTime             m_StopTime;  /*!< stop time */
     CDateTime             m_FirstDay;  /*!< if it is a manual repeating timer the first date it starts */
     CPVRTimerTypePtr      m_timerType; /*!< the type of this timer */
+
+    unsigned int          m_iActiveChildTimers;   /*!< @brief Number of active timers which have this timer as their m_iParentClientIndex */
+    bool                  m_bHasChildConflictNOK; /*!< @brief Has at least one child timer with status PVR_TIMER_STATE_CONFLICT_NOK */
+    bool                  m_bHasChildRecording;   /*!< @brief Has at least one child timer with status PVR_TIMER_STATE_RECORDING */
+    bool                  m_bHasChildErrors;      /*!< @brief Has at least one child timer with status PVR_TIMER_STATE_ERROR */
   };
 }

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -125,6 +125,7 @@ bool CPVRTimers::UpdateEntries(const CPVRTimers &timers)
         {
           bChanged = true;
           UpdateEpgEvent(existingTimer);
+          existingTimer->ResetChildState();
 
           if (bStateChanged && g_PVRManager.IsStarted())
           {
@@ -247,6 +248,21 @@ bool CPVRTimers::UpdateEntries(const CPVRTimers &timers)
     addEntry->push_back(*timerIt);
     UpdateEpgEvent(*timerIt);
   }
+
+  /* update child information for all parent timers */
+  for (const auto &tagsEntry : m_tags)
+  {
+    for (const auto &timersEntry : *tagsEntry.second)
+    {
+      if (timersEntry->GetTimerRuleId() != PVR_TIMER_NO_PARENT)
+      {
+        const CPVRTimerInfoTagPtr parentTimer(GetByClient(timersEntry->m_iClientId, timersEntry->GetTimerRuleId()));
+        if (parentTimer)
+          parentTimer->UpdateChildState(timersEntry);
+      }
+    }
+  }
+
 
   m_bIsUpdating = false;
   if (bChanged)


### PR DESCRIPTION
- Number of 'Will Record' Child Timers
- Presence of InProg Child Timers
- Presence of Conflict_NOK or Error Child Timers

Also adds 'Completed' status as distinct from 'Enabled'
![screenshot037](https://cloud.githubusercontent.com/assets/12870817/12071357/93f10002-b09f-11e5-93b2-eef4388a54db.png)

No sure how this will play with all existing pvr clients, but I can't see it breaking anything.
Small tweaks may need to be made to the reported status of 'Timer Rules' in each client to get it to work fully as intended. I'm hoping the logic is sound so it should just 'work'.

If a client already echos up 'Conflict / Error / Recording' status the behaviour should be unchanged. 
Only a status of 'NEW' or 'SCHEDULED' and in the case of recording in prog, 'COMPLETED' will be replaced with the new information based on child timer states.
(I made some changes to pvr.mythtv to get 'COMPLETED' to work as shown which I will PR if this is accepted)

I'm a little uncomfortable about putting the child timer status reset in CPVRTimerInfoTag::UpdateEntry and the updates in CPVRTimers::UpdateEntries. Happy to move it all to CPVRTimers::UpdateEntries if there are strong opinions.

pings: @ksooo, @ryangribble, @janbar, @jalle19
