### PR TITLE
[cec] Fix reconnecting to P8 cec adapter upon libcec callback CEC_ALERT_CONNECTION_LOST

### DIFF
--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -32,6 +32,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "pictures/GUIWindowSlideShow.h"
 #include "settings/AdvancedSettings.h"
+#include "utils/JobManager.h"
 #include "utils/log.h"
 #include "utils/Variant.h"
 
@@ -734,7 +735,12 @@ int CPeripheralCecAdapter::CecAlert(void *cbParam, const libcec_alert alert, con
   }
 
   if (bReopenConnection)
-    adapter->ReopenConnection();
+  {
+    // Reopen the connection asynchronously. Otherwise a deadlock may occure.
+    // Reconnect means destruction and recreation of our libcec instance, but libcec
+    // calls this callback function synchronously and must not be destroyed meanwhile.
+    adapter->ReopenConnection(true);
+  }
 
   return 1;
 }
@@ -1667,8 +1673,35 @@ void CPeripheralCecAdapter::OnDeviceRemoved(void)
   m_bDeviceRemoved = true;
 }
 
-bool CPeripheralCecAdapter::ReopenConnection(void)
+namespace PERIPHERALS
 {
+
+class CPeripheralCecAdapterReopenJob : public CJob
+{
+public:
+  CPeripheralCecAdapterReopenJob(CPeripheralCecAdapter *adapter)
+    : m_adapter(adapter) {}
+  virtual ~CPeripheralCecAdapterReopenJob() {}
+
+  bool DoWork(void)
+  {
+    return m_adapter->ReopenConnection(false);
+  }
+
+private:
+  CPeripheralCecAdapter *m_adapter;
+};
+
+};
+
+bool CPeripheralCecAdapter::ReopenConnection(bool bAsync /* = false */)
+{
+  if (bAsync)
+  {
+    CJobManager::GetInstance().AddJob(new CPeripheralCecAdapterReopenJob(this), nullptr, CJob::PRIORITY_NORMAL);
+    return true;
+  }
+
   // stop running thread
   {
     CSingleLock lock(m_critSection);

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.h
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.h
@@ -68,6 +68,7 @@ namespace CEC
 namespace PERIPHERALS
 {
   class CPeripheralCecAdapterUpdateThread;
+  class CPeripheralCecAdapterReopenJob;
 
   typedef struct
   {
@@ -86,6 +87,7 @@ namespace PERIPHERALS
   class CPeripheralCecAdapter : public CPeripheralHID, public ANNOUNCEMENT::IAnnouncer, private CThread
   {
     friend class CPeripheralCecAdapterUpdateThread;
+    friend class CPeripheralCecAdapterReopenJob;
 
   public:
     CPeripheralCecAdapter(const PeripheralScanResult& scanResult);
@@ -121,7 +123,7 @@ namespace PERIPHERALS
     bool IsRunning(void) const;
 
     bool OpenConnection(void);
-    bool ReopenConnection(void);
+    bool ReopenConnection(bool bAsync = false);
 
     void SetConfigurationFromSettings(void);
     void SetConfigurationFromLibCEC(const CEC::libcec_configuration &config);


### PR DESCRIPTION
Bug is easy to reproduce:

1) attach gdb to Kodi
2) wait ~ 20secs (yeah just wait)
3) detach gdb from Kodi
=> cec remote control no longer works

Reason: On continue of Kodi process, https://github.com/Pulse-Eight/libcec/blob/master/src/libcec/CECProcessor.cpp#L79 fires, Kodi tries to reconnect to the adpater https://github.com/xbmc/xbmc/blob/master/xbmc/peripherals/devices/PeripheralCecAdapter.cpp#L737 and this does not work. Callstack: http://paste.ubuntu.com/14368047/

Solution: Kodi has to reopen the connection asynchronously.

Runtime-tested. Works as it should now.

@opdenkamp please take a look. 
