### PR TITLE
[VideoPlayer] [DVD menus] Fix two cases of invisible dvd overlays

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxSPU.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxSPU.cpp
@@ -104,7 +104,7 @@ CDVDOverlaySpu* CDVDDemuxSPU::AddData(uint8_t* data, int iSize, double pts)
     else pSPUData->iNeededSize = iSize;
 
     // set presentation time stamp
-    if (pts > 0) pSPUData->pts = pts;
+    pSPUData->pts = pts;
   }
 
   // allocate data if not already done ( done in blocks off 16384 bytes )

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -560,12 +560,6 @@ int CDVDInputStreamNavigator::ProcessBlock(uint8_t* dest_buffer, int* read)
 
         m_iTime = (int) ( m_dll.dvdnav_convert_time( &(pci->pci_gi.e_eltm) ) + m_iCellStart ) / 90;
 
-        if (m_bCheckButtons)
-        {
-          CheckButtons();
-          m_bCheckButtons = false;
-        }
-
         iNavresult = m_pVideoPlayer->OnDVDNavResult((void*)pci, DVDNAV_NAV_PACKET);
       }
       break;
@@ -691,9 +685,9 @@ int CDVDInputStreamNavigator::GetCurrentButton()
 
 void CDVDInputStreamNavigator::CheckButtons()
 {
-  if (m_dvdnav)
+  if (m_dvdnav && m_bCheckButtons)
   {
-
+    m_bCheckButtons = false;
     pci_t* pci = m_dll.dvdnav_get_current_nav_pci(m_dvdnav);
     int iCurrentButton = GetCurrentButton();
 

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.h
@@ -142,11 +142,11 @@ public:
   bool GetDVDTitleString(std::string& titleStr);
   bool GetDVDSerialString(std::string& serialStr);
 
+  void CheckButtons();
+
 protected:
 
   int ProcessBlock(uint8_t* buffer, int* read);
-
-  void CheckButtons();
 
   /**
    * XBMC     : the audio stream id we use in xbmc

--- a/xbmc/cores/VideoPlayer/DVDOverlayContainer.cpp
+++ b/xbmc/cores/VideoPlayer/DVDOverlayContainer.cpp
@@ -172,6 +172,8 @@ void CDVDOverlayContainer::UpdateOverlayInfo(CDVDInputStreamNavigator* pStream, 
 {
   CSingleLock lock(*this);
 
+  pStream->CheckButtons();
+
   //Update any forced overlays.
   for(VecOverlays::iterator it = m_overlays.begin(); it != m_overlays.end(); ++it )
   {


### PR DESCRIPTION
this PR fixes two types of invisible menu overlays:

a) because there has been a discontinuity, and PTS has shifted so that the overlay display start/end timestamp interval is outside current PTS
b) because sometimes there's an error in DVD navigation and the CheckButtons function in DVD navigator doesn't do it's job because it's called too soon, before the player has actually received the packets containing the overlays. 

Examples proving the issues can be provided upon request.
