### PR TITLE
[VideoRendererGles] - render video with full color range on gles systems

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -876,6 +876,7 @@ void CLinuxRendererGLES::RenderSinglePass(int index, int field)
     pYUVShader->SetField(0);
 
   pYUVShader->SetMatrices(glMatrixProject.Get(), glMatrixModview.Get());
+  pYUVShader->SetForceLimitedColorRange(false);
   pYUVShader->Enable();
 
   GLubyte idx[4] = {0, 1, 3, 2};        //determines order of triangle strip

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShader.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShader.cpp
@@ -289,7 +289,7 @@ bool BaseYUV2RGBGLSLShader::OnEnabled()
 
   GLfloat matrix[4][4];
   // keep video levels
-  CalculateYUVMatrixGL(matrix, m_flags, m_format, m_black, m_contrast, true);
+  CalculateYUVMatrixGL(matrix, m_flags, m_format, m_black, m_contrast, m_forceLimitedColorRange);
 
   glUniformMatrix4fv(m_hMatrix, 1, GL_FALSE, (GLfloat*)matrix);
 #if HAS_GLES == 2

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShader.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShader.h
@@ -46,6 +46,7 @@ namespace Shaders {
     : virtual public CShaderProgram
   {
   public:
+    BaseYUV2RGBShader() : m_forceLimitedColorRange(true) {};
     virtual ~BaseYUV2RGBShader()      {};
     virtual void SetField(int field)  {};
     virtual void SetWidth(int width)  {};
@@ -63,6 +64,10 @@ namespace Shaders {
     virtual void SetMatrices(GLfloat *p, GLfloat *m) {};
     virtual void SetAlpha(GLfloat alpha)             {};
 #endif
+    void SetForceLimitedColorRange(bool forceLimitedColorRange) { m_forceLimitedColorRange = forceLimitedColorRange; }
+
+  protected:
+    bool  m_forceLimitedColorRange;
   };
 
 


### PR DESCRIPTION
This fixes a regression for gles video rendering introduced in https://github.com/xbmc/xbmc/commit/c4a136d22f5be60793edc3aa7ba79474c0677812 which results in video level colors when using glsl rendering on gles platforms. (washed out blacks ...)

As discussed this is only the quick fix to get former behavior back - until someone can implement a proper gles rendering output stage.
