### PR TITLE
[library.kodi/librariy.xbmc] - fixed dylib names for osx/ios and don'…

### DIFF
--- a/addons/library.xbmc.addon/libXBMC_addon.h
+++ b/addons/library.xbmc.addon/libXBMC_addon.h
@@ -52,6 +52,7 @@ typedef intptr_t      ssize_t;
 #else
 #define ADDON_HELPER_ARCH       "x86-osx"
 #endif
+#define ADDON_HELPER_EXT        ".dylib"
 #else                           // linux
 #if defined(__x86_64__)
 #define ADDON_HELPER_ARCH       "x86_64-linux"
@@ -66,9 +67,9 @@ typedef intptr_t      ssize_t;
 #else
 #define ADDON_HELPER_ARCH       "i486-linux"
 #endif
+#define ADDON_HELPER_EXT        ".so"
 #endif
 #include <dlfcn.h>              // linux+osx
-#define ADDON_HELPER_EXT        ".so"
 #define ADDON_DLL_NAME "libXBMC_addon-" ADDON_HELPER_ARCH ADDON_HELPER_EXT
 #define ADDON_DLL "/library.xbmc.addon/" ADDON_DLL_NAME
 #endif

--- a/lib/addons/library.kodi.adsp/Makefile.in
+++ b/lib/addons/library.kodi.adsp/Makefile.in
@@ -5,15 +5,17 @@ CXXFLAGS=-fPIC
 LIBNAME=libKODI_adsp
 OBJS=$(LIBNAME).o
 
+ifeq ($(findstring osx,$(ARCH)), osx)
+LIB_SHARED=../../../addons/library.kodi.adsp/$(LIBNAME)-$(ARCH).dylib
+else
 LIB_SHARED=../../../addons/library.kodi.adsp/$(LIBNAME)-$(ARCH).so
+endif
 
 all: $(LIB_SHARED)
 
 $(LIB_SHARED): $(OBJS)
 ifeq ($(findstring osx,$(ARCH)), osx)
-	$(CXX) $(LDFLAGS) -Wl,-alias_list,@abs_top_srcdir@/xbmc/cores/DllLoader/exports/wrapper_mach_alias \
-	-bundle -undefined dynamic_lookup -o $@ \
-	@abs_top_srcdir@/xbmc/cores/DllLoader/exports/wrapper.o $(OBJS)
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) -dynamiclib -o $@ $(OBJS)
 else
 	$(CXX) $(CFLAGS) $(LDFLAGS) -shared -g -o $(LIB_SHARED) $(OBJS)
 endif

--- a/lib/addons/library.kodi.audioengine/Makefile.in
+++ b/lib/addons/library.kodi.audioengine/Makefile.in
@@ -5,15 +5,17 @@ CXXFLAGS=-fPIC
 LIBNAME=libKODI_audioengine
 OBJS=$(LIBNAME).o
 
+ifeq ($(findstring osx,$(ARCH)), osx)
+LIB_SHARED=../../../addons/library.kodi.audioengine/$(LIBNAME)-$(ARCH).dylib
+else
 LIB_SHARED=../../../addons/library.kodi.audioengine/$(LIBNAME)-$(ARCH).so
+endif
 
 all: $(LIB_SHARED)
 
 $(LIB_SHARED): $(OBJS)
 ifeq ($(findstring osx,$(ARCH)), osx)
-	$(CXX) $(LDFLAGS) -Wl,-alias_list,@abs_top_srcdir@/xbmc/cores/DllLoader/exports/wrapper_mach_alias \
-	-bundle -undefined dynamic_lookup -o $@ \
-	@abs_top_srcdir@/xbmc/cores/DllLoader/exports/wrapper.o $(OBJS)
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) -dynamiclib -o $@ $(OBJS)
 else
 	$(CXX) $(CFLAGS) $(LDFLAGS) -shared -g -o $(LIB_SHARED) $(OBJS)
 endif

--- a/lib/addons/library.kodi.guilib/Makefile.in
+++ b/lib/addons/library.kodi.guilib/Makefile.in
@@ -6,7 +6,13 @@ LIBNAME=libKODI_guilib
 OBJS=$(LIBNAME).o
 
 LIB_INTERFACE=../../../addons/library.kodi.guilib/libKODI_guilib.h
+
+ifeq ($(findstring osx,$(ARCH)), osx)
+LIB_SHARED=../../../addons/library.kodi.guilib/$(LIBNAME)-$(ARCH).dylib
+else
 LIB_SHARED=../../../addons/library.kodi.guilib/$(LIBNAME)-$(ARCH).so
+endif
+
 GENERATED_ADDON_GUILIB = ../../../addons/kodi.guilib/addon.xml
 LIB_VERSION := $(shell sed -n 's/.*KODI_GUILIB_API_VERSION\s*"\(.*\)"/\1/p' $(LIB_INTERFACE))
 LIB_VERSION_MIN := $(shell sed -n 's/.*KODI_GUILIB_MIN_API_VERSION\s*"\(.*\)"/\1/p' $(LIB_INTERFACE))
@@ -15,9 +21,7 @@ all: $(LIB_SHARED) $(GENERATED_ADDON_GUILIB)
 
 $(LIB_SHARED): $(OBJS) $(LIB_INTERFACE)
 ifeq ($(findstring osx,$(ARCH)), osx)
-	$(CXX) $(LDFLAGS) -Wl,-alias_list,@abs_top_srcdir@/xbmc/cores/DllLoader/exports/wrapper_mach_alias \
-	-bundle -undefined dynamic_lookup -o $@ \
-	@abs_top_srcdir@/xbmc/cores/DllLoader/exports/wrapper.o $(OBJS)
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) -dynamiclib -o $@ $(OBJS)
 else
 	$(CXX) $(CFLAGS) $(LDFLAGS) -shared -g -o $(LIB_SHARED) $(OBJS)
 endif

--- a/lib/addons/library.xbmc.addon/Makefile.in
+++ b/lib/addons/library.xbmc.addon/Makefile.in
@@ -5,15 +5,17 @@ CXXFLAGS=-fPIC
 LIBNAME=libXBMC_addon
 OBJS=$(LIBNAME).o
 
+ifeq ($(findstring osx,$(ARCH)), osx)
+LIB_SHARED=../../../addons/library.xbmc.addon/$(LIBNAME)-$(ARCH).dylib
+else
 LIB_SHARED=../../../addons/library.xbmc.addon/$(LIBNAME)-$(ARCH).so
+endif
 
 all: $(LIB_SHARED)
 
 $(LIB_SHARED): $(OBJS)
 ifeq ($(findstring osx,$(ARCH)), osx)
-	$(CXX) $(LDFLAGS) -Wl,-alias_list,@abs_top_srcdir@/xbmc/cores/DllLoader/exports/wrapper_mach_alias \
-	-bundle -undefined dynamic_lookup -o $@ \
-	@abs_top_srcdir@/xbmc/cores/DllLoader/exports/wrapper.o $(OBJS)
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) -dynamiclib -o $@ $(OBJS)
 else
 	$(CXX) $(CFLAGS) $(LDFLAGS) -shared -g -o $(LIB_SHARED) $(OBJS)
 endif

--- a/lib/addons/library.xbmc.codec/Makefile.in
+++ b/lib/addons/library.xbmc.codec/Makefile.in
@@ -5,15 +5,17 @@ CXXFLAGS=-fPIC
 LIBNAME=libXBMC_codec
 OBJS=$(LIBNAME).o
 
+ifeq ($(findstring osx,$(ARCH)), osx)
+LIB_SHARED=../../../addons/library.xbmc.codec/$(LIBNAME)-$(ARCH).dylib
+else
 LIB_SHARED=../../../addons/library.xbmc.codec/$(LIBNAME)-$(ARCH).so
+endif
 
 all: $(LIB_SHARED)
 
 $(LIB_SHARED): $(OBJS)
 ifeq ($(findstring osx,$(ARCH)), osx)
-	$(CXX) $(LDFLAGS) -Wl,-alias_list,@abs_top_srcdir@/xbmc/cores/DllLoader/exports/wrapper_mach_alias \
-	-bundle -undefined dynamic_lookup -o $@ \
-	@abs_top_srcdir@/xbmc/cores/DllLoader/exports/wrapper.o $(OBJS)
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) -dynamiclib -o $@ $(OBJS)
 else
 	$(CXX) $(CFLAGS) $(LDFLAGS) -shared -g -o $(LIB_SHARED) $(OBJS)
 endif

--- a/lib/addons/library.xbmc.pvr/Makefile.in
+++ b/lib/addons/library.xbmc.pvr/Makefile.in
@@ -5,15 +5,17 @@ CXXFLAGS=-fPIC
 LIBNAME=libXBMC_pvr
 OBJS=$(LIBNAME).o
 
+ifeq ($(findstring osx,$(ARCH)), osx)
+LIB_SHARED=../../../addons/library.xbmc.pvr/$(LIBNAME)-$(ARCH).dylib
+else
 LIB_SHARED=../../../addons/library.xbmc.pvr/$(LIBNAME)-$(ARCH).so
+endif
 
 all: $(LIB_SHARED)
 
 $(LIB_SHARED): $(OBJS)
 ifeq ($(findstring osx,$(ARCH)), osx)
-	$(CXX) $(LDFLAGS) -Wl,-alias_list,@abs_top_srcdir@/xbmc/cores/DllLoader/exports/wrapper_mach_alias \
-	-bundle -undefined dynamic_lookup -o $@ \
-	@abs_top_srcdir@/xbmc/cores/DllLoader/exports/wrapper.o $(OBJS)
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) -dynamiclib -o $@ $(OBJS)
 else
 	$(CXX) $(CFLAGS) $(LDFLAGS) -shared -g -o $(LIB_SHARED) $(OBJS)
 endif


### PR DESCRIPTION
…t wrap our addon libraries.

Backport from MrMC https://github.com/MrMC/mrmc/commit/33d38edff51332bc393888d05cfba53f83ad5ed1#diff-25bb87ae2148a0a2abba0a8a4296b5bf

This basically makes our libraries proper dylibs on osx/ios and removes the fs wrapping which is not what we want for these libraries. Thx to @MrMC for finding that one.
