### PR TITLE
[stereoscopicmanager] Ensure we don't have a stale value of videoplayer stereoscopic mode

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -3562,6 +3562,8 @@ bool CVideoPlayer::OpenVideoStream(CDVDStreamInfo& hint, bool reset)
   if (hint.stereo_mode.empty())
     hint.stereo_mode = CStereoscopicsManager::GetInstance().DetectStereoModeByString(m_item.GetPath());
 
+  SelectionStream& s = m_SelectionStreams.Get(STREAM_VIDEO, 0);
+
   if(hint.flags & AV_DISPOSITION_ATTACHED_PIC)
     return false;
 
@@ -3588,6 +3590,10 @@ bool CVideoPlayer::OpenVideoStream(CDVDStreamInfo& hint, bool reset)
 
     if (!player->OpenStream(hint))
       return false;
+
+    s.stereo_mode = static_cast<IDVDStreamPlayerVideo*>(player)->GetStereoMode();
+    if (s.stereo_mode == "mono")
+      s.stereo_mode = "";
 
     static_cast<IDVDStreamPlayerVideo*>(player)->SetSpeed(m_streamPlayerSpeed);
     m_CurrentVideo.syncState = IDVDStreamPlayer::SYNC_STARTING;

--- a/xbmc/guilib/StereoscopicsManager.h
+++ b/xbmc/guilib/StereoscopicsManager.h
@@ -92,6 +92,8 @@ private:
   void ApplyStereoMode(const RENDER_STEREO_MODE &mode, bool notify = true);
   void OnPlaybackStarted(void);
   void OnPlaybackStopped(void);
+  std::string GetVideoStereoMode();
+  bool IsVideoStereoscopic();
 
   RENDER_STEREO_MODE m_stereoModeSetByUser;
   RENDER_STEREO_MODE m_lastStereoModeSetByUser;


### PR DESCRIPTION
Switching to 3D mode doesn't always work. There is a race condition when
CStereoscopicsManager::OnPlaybackStarted is called whether the stereo mode
read from infoManager is valid or not.

Ensuring the stereo_mode in VideoPlayer is valid at start of playback and
that infoManager is up to date avoids this issue.
