### PR TITLE
fix to use the selected player after PR 8525

### DIFF
--- a/xbmc/cores/playercorefactory/PlayerCoreFactory.cpp
+++ b/xbmc/cores/playercorefactory/PlayerCoreFactory.cpp
@@ -120,14 +120,12 @@ void CPlayerCoreFactory::GetPlayers(const CFileItem& item, std::vector<std::stri
   // Also push these players in case it is NOT audio either
   if (item.IsVideo() || !item.IsAudio())
   {
-    if (std::find(players.begin(), players.end(), "videodefaultplayer") != players.end())
+    int idx = GetPlayerIndex("videodefaultplayer");
+    if (idx > -1)
     {
-      unsigned int eVideoDefault = GetPlayerIndex("videodefaultplayer");
-      if (eVideoDefault > 0)
-      {
-        CLog::Log(LOGDEBUG, "CPlayerCoreFactory::GetPlayers: adding videodefaultplayer");
-        players.push_back("videodefaultplayer");
-      }
+      std::string eVideoDefault = GetPlayerName(idx);
+      CLog::Log(LOGDEBUG, "CPlayerCoreFactory::GetPlayers: adding videodefaultplayer (%s)", eVideoDefault.c_str());
+      players.push_back(eVideoDefault);
     }
     GetPlayers(players, false, true);  // Video-only players
     GetPlayers(players, true, true);   // Audio & video players
@@ -137,14 +135,12 @@ void CPlayerCoreFactory::GetPlayers(const CFileItem& item, std::vector<std::stri
   // Pushback all audio players in case we don't know the type
   if (item.IsAudio())
   {
-    if (std::find(players.begin(), players.end(), "videodefaultplayer") != players.end())
+    int idx = GetPlayerIndex("audiodefaultplayer");
+    if (idx > -1)
     {
-      unsigned int eAudioDefault = GetPlayerIndex("audiodefaultplayer");
-      if (eAudioDefault > 0)
-      {
-        CLog::Log(LOGDEBUG, "CPlayerCoreFactory::GetPlayers: adding audiodefaultplayer");
-        players.push_back("audiodefaultplayer");
-      }
+      std::string eAudioDefault = GetPlayerName(idx);
+      CLog::Log(LOGDEBUG, "CPlayerCoreFactory::GetPlayers: adding audiodefaultplayer (%s)", eAudioDefault.c_str());
+        players.push_back(eAudioDefault);
     }
     GetPlayers(players, true, false); // Audio-only players
     GetPlayers(players, true, true);  // Audio & video players
@@ -175,6 +171,15 @@ int CPlayerCoreFactory::GetPlayerIndex(const std::string& strCoreName) const
     CLog::Log(LOGWARNING, "CPlayerCoreFactory::GetPlayer(%s): no such player: %s", strCoreName.c_str(), strRealCoreName.c_str());
   }
   return -1;
+}
+
+std::string CPlayerCoreFactory::GetPlayerName(size_t idx) const
+{
+  CSingleLock lock(m_section);
+  if (m_vecPlayerConfigs.empty() || idx > m_vecPlayerConfigs.size())
+    return "";
+
+  return m_vecPlayerConfigs[idx]->m_name;
 }
 
 void CPlayerCoreFactory::GetPlayers(std::vector<std::string>&players, std::string &type) const

--- a/xbmc/cores/playercorefactory/PlayerCoreFactory.h
+++ b/xbmc/cores/playercorefactory/PlayerCoreFactory.h
@@ -65,6 +65,7 @@ protected:
   CPlayerCoreFactory& operator=(CPlayerCoreFactory const&);
   virtual ~CPlayerCoreFactory();
   int GetPlayerIndex(const std::string& strCoreName) const;
+  std::string GetPlayerName(size_t idx) const;
 
   bool LoadConfiguration(const std::string &file, bool clear);
 

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -671,7 +671,7 @@ bool CGUIWindowVideoBase::OnFileAction(int iItem, int action, std::string player
     }
     break;
   case SELECT_ACTION_PLAY_OR_RESUME:
-    return OnResumeItem(iItem);
+    return OnResumeItem(iItem, player);
   case SELECT_ACTION_INFO:
     if (OnItemInfo(iItem))
       return true;
@@ -744,9 +744,9 @@ bool CGUIWindowVideoBase::OnItemInfo(int iItem)
   return item->HasVideoInfoTag();
 }
 
-void CGUIWindowVideoBase::OnRestartItem(int iItem)
+void CGUIWindowVideoBase::OnRestartItem(int iItem, const std::string &player)
 {
-  CGUIMediaWindow::OnClick(iItem);
+  CGUIMediaWindow::OnClick(iItem, player);
 }
 
 std::string CGUIWindowVideoBase::GetResumeString(const CFileItem &item)
@@ -786,7 +786,7 @@ bool CGUIWindowVideoBase::ShowResumeMenu(CFileItem &item)
   return true;
 }
 
-bool CGUIWindowVideoBase::OnResumeItem(int iItem)
+bool CGUIWindowVideoBase::OnResumeItem(int iItem, const std::string &player)
 {
   if (iItem < 0 || iItem >= m_vecItems->Size()) return true;
   CFileItemPtr item = m_vecItems->Get(iItem);
@@ -794,7 +794,7 @@ bool CGUIWindowVideoBase::OnResumeItem(int iItem)
   if (item->m_bIsFolder)
   {
     // resuming directories isn't supported yet. play.
-    PlayItem(iItem);
+    PlayItem(iItem, player);
     return true;
   }
 
@@ -808,10 +808,10 @@ bool CGUIWindowVideoBase::OnResumeItem(int iItem)
     int value = CGUIDialogContextMenu::ShowAndGetChoice(choices);
     if (value < 0)
       return true;
-    return OnFileAction(iItem, value, "");
+    return OnFileAction(iItem, value, player);
   }
 
-  return OnFileAction(iItem, SELECT_ACTION_PLAY, "");
+  return OnFileAction(iItem, SELECT_ACTION_PLAY, player);
 }
 
 void CGUIWindowVideoBase::GetContextButtons(int itemNumber, CContextButtons &buttons)
@@ -1183,7 +1183,7 @@ bool CGUIWindowVideoBase::OnPlayMedia(int iItem, const std::string &player)
     }
   }
 
-  PlayMovie(&item);
+  PlayMovie(&item, player);
 
   return true;
 }
@@ -1202,7 +1202,7 @@ bool CGUIWindowVideoBase::OnPlayAndQueueMedia(const CFileItemPtr &item, std::str
   return CGUIMediaWindow::OnPlayAndQueueMedia(movieItem, player);
 }
 
-void CGUIWindowVideoBase::PlayMovie(const CFileItem *item)
+void CGUIWindowVideoBase::PlayMovie(const CFileItem *item, const std::string &player)
 {
   CFileItemPtr movieItem(new CFileItem(*item));
 
@@ -1216,7 +1216,7 @@ void CGUIWindowVideoBase::PlayMovie(const CFileItem *item)
     m_thumbLoader.StopAsync();
 
   // play movie...
-  g_playlistPlayer.Play(0, "");
+  g_playlistPlayer.Play(0, player);
 
   if(!g_application.m_pPlayer->IsPlayingVideo())
     m_thumbLoader.Load(*m_vecItems);
@@ -1277,7 +1277,7 @@ void CGUIWindowVideoBase::LoadPlayList(const std::string& strPlayList, int iPlay
   }
 }
 
-void CGUIWindowVideoBase::PlayItem(int iItem)
+void CGUIWindowVideoBase::PlayItem(int iItem, const std::string &player)
 {
   // restrictions should be placed in the appropiate window code
   // only call the base code if the item passes since this clears
@@ -1317,7 +1317,7 @@ void CGUIWindowVideoBase::PlayItem(int iItem)
   else
   {
     // single item, play it
-    OnClick(iItem);
+    OnClick(iItem, player);
   }
 }
 

--- a/xbmc/video/windows/GUIWindowVideoBase.h
+++ b/xbmc/video/windows/GUIWindowVideoBase.h
@@ -44,7 +44,7 @@ public:
   virtual bool OnMessage(CGUIMessage& message) override;
   virtual bool OnAction(const CAction &action) override;
 
-  void PlayMovie(const CFileItem *item);
+  void PlayMovie(const CFileItem *item, const std::string &player = "");
   static void GetResumeItemOffset(const CFileItem *item, int& startoffset, int& partNumber);
   static bool HasResumeItemOffset(const CFileItem *item);
 
@@ -117,9 +117,9 @@ protected:
    */
   bool OnFileAction(int item, int action, std::string player);
 
-  void OnRestartItem(int iItem);
-  bool OnResumeItem(int iItem);
-  void PlayItem(int iItem);
+  void OnRestartItem(int iItem, const std::string &player = "");
+  bool OnResumeItem(int iItem, const std::string &player = "");
+  void PlayItem(int iItem, const std::string &player = "");
   virtual bool OnPlayMedia(int iItem, const std::string &player = "") override;
   virtual bool OnPlayAndQueueMedia(const CFileItemPtr &item, std::string player = "") override;
   void LoadPlayList(const std::string& strPlayList, int iPlayList = PLAYLIST_VIDEO);


### PR DESCRIPTION
this should solve two issues after PR 8525
- the player selected in the contextmenu "Play using..." it's never used
- the default player set with <defaultplayer> in advancedsettings.xml it's ignored

@FernetMenta 
