### PR TITLE
GUIInfoManager: Move SetCurrentItem into a background job

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -114,6 +114,20 @@ using namespace PVR;
 using namespace INFO;
 using namespace EPG;
 
+class CSetCurrentItemJob : public CJob
+{
+  CFileItem &m_itemCurrentFile;
+public:
+  CSetCurrentItemJob(CFileItem &item) : m_itemCurrentFile(item) { }
+  ~CSetCurrentItemJob(void) {}
+
+  bool DoWork(void)
+  {
+    g_infoManager.SetCurrentItem(m_itemCurrentFile, true);
+    return true;
+  }
+};
+
 CGUIInfoManager::CGUIInfoManager(void) :
     Observable()
 {
@@ -4594,8 +4608,15 @@ void CGUIInfoManager::ResetCurrentItem()
   m_currentMovieDuration = "";
 }
 
-void CGUIInfoManager::SetCurrentItem(CFileItem &item)
+void CGUIInfoManager::SetCurrentItem(CFileItem &item, bool blocking /*= false */)
 {
+  if (!blocking)
+  {
+    CSetCurrentItemJob *job = new CSetCurrentItemJob(item);
+    CJobManager::GetInstance().AddJob(job, NULL);
+    return;
+  }
+
   ResetCurrentItem();
 
   if (item.IsAudio())

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -151,7 +151,10 @@ public:
   std::string GetDate(bool bNumbersOnly = false);
   std::string GetDuration(TIME_FORMAT format = TIME_FORMAT_GUESS) const;
 
-  void SetCurrentItem(CFileItem &item);
+  /*! \brief Set currently playing file item
+   \param blocking whether to run in current thread (true) or background thread (false)
+   */
+  void SetCurrentItem(CFileItem &item, bool blocking = false);
   void ResetCurrentItem();
   // Current song stuff
   /// \brief Retrieves tag info (if necessary) and fills in our current song path.


### PR DESCRIPTION
This often takes several hundred milliseconds on a Pi2 and can cause timeouts on renderer configure
