### PR TITLE
VideoPlayer: fix and cleanup ffmpeg sw deinterlacing

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h
@@ -149,6 +149,7 @@ struct DVDVideoUserData
 #define DVD_CODEC_CTRL_HURRY        0x04000000  //< see GetCodecStats
 #define DVD_CODEC_CTRL_DROP         0x08000000  //< this frame is going to be dropped in output
 #define DVD_CODEC_CTRL_DRAIN        0x10000000  //< squeeze out pictured without feeding new packets
+#define DVD_CODEC_CTRL_ROTATE       0x20000000  //< rotate if renderer does not support it
 
 // DVP_FLAG 0x00000100 - 0x00000f00 is in use by libmpeg2!
 
@@ -238,20 +239,6 @@ public:
    * DVD_PLAYSPEED_PAUSE and friends.
    */
   virtual void SetSpeed(int iSpeed) {};
-
-  enum EFilterFlags {
-    FILTER_NONE                =  0x0,
-    FILTER_DEINTERLACE_YADIF   =  0x1,  //< use first deinterlace mode
-    FILTER_DEINTERLACE_ANY     =  0xf,  //< use any deinterlace mode
-    FILTER_DEINTERLACE_FLAGGED = 0x10,  //< only deinterlace flagged frames
-    FILTER_DEINTERLACE_HALFED  = 0x20,  //< do half rate deinterlacing
-    FILTER_ROTATE              = 0x40,  //< rotate image according to the codec hints
-  };
-
-  /**
-   * set the type of filters that should be applied at decoding stage if possible
-   */
-  virtual unsigned int SetFilters(unsigned int filters) { return 0; }
 
   /**
    * should return codecs name

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.h
@@ -67,7 +67,6 @@ public:
   bool GetPictureCommon(DVDVideoPicture* pDvdVideoPicture);
   virtual bool GetPicture(DVDVideoPicture* pDvdVideoPicture);
   virtual void SetDropState(bool bDrop);
-  virtual unsigned int SetFilters(unsigned int filters);
   virtual const char* GetName() { return m_name.c_str(); }; // m_name is never changed after open
   virtual unsigned GetConvergeCount();
   virtual unsigned GetAllowedReferences();
@@ -83,6 +82,7 @@ protected:
   int  FilterOpen(const std::string& filters, bool scale);
   void FilterClose();
   int  FilterProcess(AVFrame* frame);
+  void SetFilters();
 
   void UpdateName()
   {

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -445,6 +445,8 @@ void CVideoPlayerVideo::Process()
         codecControl |= DVD_CODEC_CTRL_NO_POSTPROC;
       if (bPacketDrop)
         codecControl |= DVD_CODEC_CTRL_DROP;
+      if (!m_renderManager.Supports(RENDERFEATURE_ROTATION))
+        codecControl |= DVD_CODEC_CTRL_ROTATE;
       m_pVideoCodec->SetCodecControl(codecControl);
       if (iDropDirective & EOS_DROPPED)
       {
@@ -469,28 +471,6 @@ void CVideoPlayerVideo::Process()
       // both frames will be dropped in that case instead of just the first
       // decoder still needs to provide an empty image structure, with correct flags
       m_pVideoCodec->SetDropState(bRequestDrop);
-
-      // ask codec to do deinterlacing if possible
-      EDEINTERLACEMODE mDeintMode = CMediaSettings::GetInstance().GetCurrentVideoSettings().m_DeinterlaceMode;
-      EINTERLACEMETHOD mInt = m_renderManager.AutoInterlaceMethod(CMediaSettings::GetInstance().GetCurrentVideoSettings().m_InterlaceMethod);
-
-      unsigned int mFilters = 0;
-
-      if (mDeintMode != VS_DEINTERLACEMODE_OFF)
-      {
-        if (mInt == VS_INTERLACEMETHOD_DEINTERLACE)
-          mFilters = CDVDVideoCodec::FILTER_DEINTERLACE_ANY;
-        else if(mInt == VS_INTERLACEMETHOD_DEINTERLACE_HALF)
-          mFilters = CDVDVideoCodec::FILTER_DEINTERLACE_ANY | CDVDVideoCodec::FILTER_DEINTERLACE_HALFED;
-
-        if (mDeintMode == VS_DEINTERLACEMODE_AUTO && mFilters)
-          mFilters |=  CDVDVideoCodec::FILTER_DEINTERLACE_FLAGGED;
-      }
-
-      if (!m_renderManager.Supports(RENDERFEATURE_ROTATION))
-        mFilters |= CDVDVideoCodec::FILTER_ROTATE;
-
-      mFilters = m_pVideoCodec->SetFilters(mFilters);
 
       int iDecoderState = m_pVideoCodec->Decode(pPacket->pData, pPacket->iSize, pPacket->dts, pPacket->pts);
 


### PR DESCRIPTION
This moves ffmpeg specific functions like SetFilters to the right place. sw decoding serves as fallback for hw decoding, hence deinterlacing needs to be engaged even if some hw decoder specific method was chosen in settings.

@Voyager1 this makes the change in win renderer we discussed obsolete.
