### PR TITLE
stereoscopicmanager: Avoid additional hdmi mode changes when switching to 3D

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2581,7 +2581,7 @@ void CApplication::OnApplicationMessage(ThreadMessage* pMsg)
     break;
 
   case TMSG_SETVIDEORESOLUTION:
-    g_graphicsContext.SetVideoResolution(static_cast<RESOLUTION>(pMsg->param1), pMsg->param2 == 1);
+    g_graphicsContext.SetVideoResolution(static_cast<RESOLUTION>(pMsg->param1), (pMsg->param2 & 1) != 0, (pMsg->param2 & 2) != 0);
     break;
 
   case TMSG_TOGGLEFULLSCREEN:

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1683,7 +1683,6 @@ bool CApplication::LoadSkin(const SkinPtr& skin)
   g_windowManager.AddMsgTarget(&g_playlistPlayer);
   g_windowManager.AddMsgTarget(&g_infoManager);
   g_windowManager.AddMsgTarget(&g_fontManager);
-  g_windowManager.AddMsgTarget(&CStereoscopicsManager::GetInstance());
   g_windowManager.SetCallback(*this);
   g_windowManager.Initialize();
   CTextureCache::GetInstance().Initialize();
@@ -3586,6 +3585,7 @@ PlayBackRet CApplication::PlayFile(const CFileItem& item, std::string player, bo
 
 void CApplication::OnPlayBackEnded()
 {
+  CStereoscopicsManager::GetInstance().PlaybackStopped();
   CSingleLock lock(m_playStateMutex);
   CLog::LogF(LOGDEBUG,"play state was %d, starting %d", m_ePlayState, m_bPlaybackStarting);
   m_ePlayState = PLAY_STATE_ENDED;
@@ -3628,6 +3628,7 @@ void CApplication::OnPlayBackStarted()
 
   CGUIMessage msg(GUI_MSG_PLAYBACK_STARTED, 0, 0);
   g_windowManager.SendThreadMessage(msg);
+  CStereoscopicsManager::GetInstance().PlaybackStarted();
 }
 
 void CApplication::OnQueueNextItem()
@@ -3648,6 +3649,8 @@ void CApplication::OnQueueNextItem()
 
 void CApplication::OnPlayBackStopped()
 {
+  CStereoscopicsManager::GetInstance().PlaybackStopped();
+
   CSingleLock lock(m_playStateMutex);
   CLog::LogF(LOGDEBUG, "play state was %d, starting %d", m_ePlayState, m_bPlaybackStarting);
   m_ePlayState = PLAY_STATE_STOPPED;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -3562,6 +3562,24 @@ bool CVideoPlayer::OpenVideoStream(CDVDStreamInfo& hint, bool reset)
   if (hint.stereo_mode.empty())
     hint.stereo_mode = CStereoscopicsManager::GetInstance().DetectStereoModeByString(m_item.GetPath());
 
+  SelectionStream& s = m_SelectionStreams.Get(STREAM_VIDEO, 0);
+  switch(CMediaSettings::GetInstance().GetCurrentVideoSettings().m_StereoMode)
+  {
+    case RENDER_STEREO_MODE_SPLIT_VERTICAL:
+      s.stereo_mode = "left_right";
+      break;
+    case RENDER_STEREO_MODE_SPLIT_HORIZONTAL:
+      s.stereo_mode = "top_bottom";
+      break;
+    default:
+      s.stereo_mode = hint.stereo_mode;
+      break;
+  }
+  if (CMediaSettings::GetInstance().GetCurrentVideoSettings().m_StereoInvert)
+    s.stereo_mode = RenderManager::GetStereoModeInvert(s.stereo_mode);
+  if (s.stereo_mode == "mono")
+    s.stereo_mode = "";
+
   if(hint.flags & AV_DISPOSITION_ATTACHED_PIC)
     return false;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -1172,7 +1172,7 @@ void CRenderManager::UpdateResolution()
       if (CSettings::GetInstance().GetInt(CSettings::SETTING_VIDEOPLAYER_ADJUSTREFRESHRATE) != ADJUST_REFRESHRATE_OFF && m_fps > 0.0f)
       {
         RESOLUTION res = CResolutionUtils::ChooseBestResolution(m_fps, m_width, CONF_FLAGS_STEREO_MODE_MASK(m_flags));
-        g_graphicsContext.SetVideoResolution(res, true);
+        g_graphicsContext.SetVideoResolution(res, true, true);
         UpdateDisplayLatency();
       }
       m_bTriggerUpdateResolution = false;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -1172,7 +1172,7 @@ void CRenderManager::UpdateResolution()
       if (CSettings::GetInstance().GetInt(CSettings::SETTING_VIDEOPLAYER_ADJUSTREFRESHRATE) != ADJUST_REFRESHRATE_OFF && m_fps > 0.0f)
       {
         RESOLUTION res = CResolutionUtils::ChooseBestResolution(m_fps, m_width, CONF_FLAGS_STEREO_MODE_MASK(m_flags));
-        g_graphicsContext.SetVideoResolution(res);
+        g_graphicsContext.SetVideoResolution(res, true);
         UpdateDisplayLatency();
       }
       m_bTriggerUpdateResolution = false;

--- a/xbmc/guilib/GraphicContext.cpp
+++ b/xbmc/guilib/GraphicContext.cpp
@@ -369,19 +369,19 @@ bool CGraphicContext::IsValidResolution(RESOLUTION res)
 }
 
 // call SetVideoResolutionInternal and ensure its done from mainthread
-void CGraphicContext::SetVideoResolution(RESOLUTION res, bool forceUpdate)
+void CGraphicContext::SetVideoResolution(RESOLUTION res, bool forceUpdate /*= false*/, bool switch3d /*= false*/)
 {
   if (g_application.IsCurrentThread())
   {
-    SetVideoResolutionInternal(res, forceUpdate);
+    SetVideoResolutionInternal(res, forceUpdate, switch3d);
   }
   else
   {
-    CApplicationMessenger::GetInstance().SendMsg(TMSG_SETVIDEORESOLUTION, res, forceUpdate ? 1 : 0);
+    CApplicationMessenger::GetInstance().SendMsg(TMSG_SETVIDEORESOLUTION, res, (forceUpdate ? 1 : 0) + (switch3d ? 2 : 0));
   }
 }
 
-void CGraphicContext::SetVideoResolutionInternal(RESOLUTION res, bool forceUpdate)
+void CGraphicContext::SetVideoResolutionInternal(RESOLUTION res, bool forceUpdate, bool switch3d)
 {
   RESOLUTION lastRes = m_Resolution;
 

--- a/xbmc/guilib/GraphicContext.h
+++ b/xbmc/guilib/GraphicContext.h
@@ -153,7 +153,7 @@ public:
   void SetCameraPosition(const CPoint &camera);
   void SetStereoView(RENDER_STEREO_VIEW view);
   RENDER_STEREO_VIEW GetStereoView()  { return m_stereoView; }
-  void SetStereoMode(RENDER_STEREO_MODE mode) { m_nextStereoMode = mode; }
+  void SetStereoMode(RENDER_STEREO_MODE mode);
   RENDER_STEREO_MODE GetStereoMode()  { return m_stereoMode; }
   void RestoreCameraPosition();
   void SetStereoFactor(float factor);
@@ -278,7 +278,7 @@ private:
   std::stack<UITransform> m_transforms;
   RENDER_STEREO_VIEW m_stereoView;
   RENDER_STEREO_MODE m_stereoMode;
-  RENDER_STEREO_MODE m_nextStereoMode;
+  RENDER_STEREO_MODE m_lastStereoMode;
 
   CRect m_scissors;
 };

--- a/xbmc/guilib/GraphicContext.h
+++ b/xbmc/guilib/GraphicContext.h
@@ -98,7 +98,7 @@ public:
   bool IsCalibrating() const;
   void SetCalibrating(bool bOnOff);
   bool IsValidResolution(RESOLUTION res);
-  void SetVideoResolution(RESOLUTION res, bool forceUpdate = false);
+  void SetVideoResolution(RESOLUTION res, bool forceUpdate = false, bool switch3d = false);
   RESOLUTION GetVideoResolution() const;
   void ResetOverscan(RESOLUTION res, OVERSCAN &overscan);
   void ResetOverscan(RESOLUTION_INFO &resinfo);
@@ -266,7 +266,7 @@ private:
   void UpdateCameraPosition(const CPoint &camera, const float &factor);
   // this method is indirectly called by the public SetVideoResolution
   // it only works when called from mainthread (thats what SetVideoResolution ensures)
-  void SetVideoResolutionInternal(RESOLUTION res, bool forceUpdate);
+  void SetVideoResolutionInternal(RESOLUTION res, bool forceUpdate, bool switch3d);
   RESOLUTION_INFO m_windowResolution;
   std::stack<CPoint> m_cameras;
   std::stack<CPoint> m_origins;

--- a/xbmc/guilib/StereoscopicsManager.cpp
+++ b/xbmc/guilib/StereoscopicsManager.cpp
@@ -391,22 +391,6 @@ void CStereoscopicsManager::OnSettingChanged(const CSetting *setting)
   }
 }
 
-bool CStereoscopicsManager::OnMessage(CGUIMessage &message)
-{
-  switch (message.GetMessage())
-  {
-  case GUI_MSG_PLAYBACK_STARTED:
-    OnPlaybackStarted();
-    break;
-  case GUI_MSG_PLAYBACK_STOPPED:
-  case GUI_MSG_PLAYLISTPLAYER_STOPPED:
-    OnPlaybackStopped();
-    break;
-  }
-
-  return false;
-}
-
 bool CStereoscopicsManager::OnAction(const CAction &action)
 {
   RENDER_STEREO_MODE mode = GetStereoMode();
@@ -516,7 +500,7 @@ bool CStereoscopicsManager::IsVideoStereoscopic()
   return !GetVideoStereoMode().empty();
 }
 
-void CStereoscopicsManager::OnPlaybackStarted(void)
+void CStereoscopicsManager::PlaybackStarted(void)
 {
   STEREOSCOPIC_PLAYBACK_MODE playbackMode = (STEREOSCOPIC_PLAYBACK_MODE) CSettings::GetInstance().GetInt(CSettings::SETTING_VIDEOPLAYER_STEREOSCOPICPLAYBACKMODE);
   RENDER_STEREO_MODE mode = GetStereoMode();
@@ -613,7 +597,7 @@ void CStereoscopicsManager::OnPlaybackStarted(void)
   }
 }
 
-void CStereoscopicsManager::OnPlaybackStopped(void)
+void CStereoscopicsManager::PlaybackStopped(void)
 {
   RENDER_STEREO_MODE mode = GetStereoMode();
   if (CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_QUITSTEREOMODEONSTOP) && mode != RENDER_STEREO_MODE_OFF)

--- a/xbmc/guilib/StereoscopicsManager.h
+++ b/xbmc/guilib/StereoscopicsManager.h
@@ -92,6 +92,8 @@ private:
   void ApplyStereoMode(const RENDER_STEREO_MODE &mode, bool notify = true);
   void OnPlaybackStarted(void);
   void OnPlaybackStopped(void);
+  std::string GetVideoStereoMode();
+  bool IsVideoStereoscopic();
 
   RENDER_STEREO_MODE m_stereoModeSetByUser;
   RENDER_STEREO_MODE m_lastStereoModeSetByUser;

--- a/xbmc/guilib/StereoscopicsManager.h
+++ b/xbmc/guilib/StereoscopicsManager.h
@@ -41,8 +41,7 @@ enum STEREOSCOPIC_PLAYBACK_MODE
   STEREOSCOPIC_PLAYBACK_MODE_IGNORE = 100,
 };
 
-class CStereoscopicsManager : public ISettingCallback,
-                              public IMsgTargetCallback
+class CStereoscopicsManager : public ISettingCallback
 {
 public:
   CStereoscopicsManager(void);
@@ -80,18 +79,17 @@ public:
   CAction ConvertActionCommandToAction(const std::string &command, const std::string &parameter);
   std::string NormalizeStereoMode(const std::string &mode);
   virtual void OnSettingChanged(const CSetting *setting) override;
-  virtual bool OnMessage(CGUIMessage &message) override;
   /*!
    * @brief Handle 3D specific cActions
    * @param action The action to process
    * @return True if action could be handled, false otherwise.
    */
   bool OnAction(const CAction &action);
+  void PlaybackStarted(void);
+  void PlaybackStopped(void);
 
 private:
   void ApplyStereoMode(const RENDER_STEREO_MODE &mode, bool notify = true);
-  void OnPlaybackStarted(void);
-  void OnPlaybackStopped(void);
   std::string GetVideoStereoMode();
   bool IsVideoStereoscopic();
 


### PR DESCRIPTION
Currently when playing and then stopping a 3D video we switch from:
1080p60 2D -> (play) -> 1080p60 3D -> 1080p24 3D -> (stop) -> 1080p60 3D -> 1080p60 2D

when the desired sequence is:
1080p60 2D -> (play) -> 1080p24 3D -> (stop) -> 1080p60 2D

This tries to avoid the two unnecessary hdmi mode switches.
