### PR TITLE
threads: fix waitforever when using CSharedSection

### DIFF
--- a/xbmc/threads/SharedSection.h
+++ b/xbmc/threads/SharedSection.h
@@ -40,11 +40,11 @@ public:
 
   inline void lock() { CSingleLock l(sec); while (sharedCount) cond.wait(l); sec.lock(); }
   inline bool try_lock() { return (sec.try_lock() ? ((sharedCount == 0) ? true : (sec.unlock(), false)) : false); }
-  inline void unlock() { sec.unlock(); }
+  inline void unlock() { cond.notify(); sec.unlock(); }
 
   inline void lock_shared() { CSingleLock l(sec); sharedCount++; }
   inline bool try_lock_shared() { return (sec.try_lock() ? sharedCount++, sec.unlock(), true : false); }
-  inline void unlock_shared() { CSingleLock l(sec); sharedCount--; if (!sharedCount) { cond.notifyAll(); } }
+  inline void unlock_shared() { CSingleLock l(sec); sharedCount--; if (!sharedCount) { cond.notify(); } }
 };
 
 class CSharedLock : public XbmcThreads::SharedLock<CSharedSection>


### PR DESCRIPTION
@jimfcarroll this is a nice one:

Assume 3 threads involved
- thread 1 takes the shared lock
- thread 2 wants to take exclusive lock
- thread 3 wants to take exclusive lock
- thread 2 and thread 3 waiting for cond to signal
- thread 1 exits and signals
- thread 2 gets the lock
- thread 3 waits forever on cond to signal
