### PR TITLE
guiinfomanager: Use a copy for background job

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -116,9 +116,9 @@ using namespace EPG;
 
 class CSetCurrentItemJob : public CJob
 {
-  CFileItem &m_itemCurrentFile;
+  CFileItem m_itemCurrentFile;
 public:
-  CSetCurrentItemJob(CFileItem &item) : m_itemCurrentFile(item) { }
+  CSetCurrentItemJob(CFileItem item) : m_itemCurrentFile(item) { }
   ~CSetCurrentItemJob(void) {}
 
   bool DoWork(void)


### PR DESCRIPTION
A backtrace suggests that the item refrenced by m_itemCurrentFile may have been destroyed, so work on a copy.
