### PR TITLE
VideoPlayer: drop shared lock from dvd clock

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDClock.h
+++ b/xbmc/cores/VideoPlayer/DVDClock.h
@@ -21,7 +21,6 @@
  */
 
 #include "system.h"
-#include "threads/SharedSection.h"
 #include "threads/CriticalSection.h"
 
 #define DVD_TIME_BASE 1000000
@@ -77,7 +76,7 @@ protected:
   static int64_t AbsoluteToSystem(double absolute);
   double SystemToPlaying(int64_t system);
 
-  CSharedSection m_critSection;
+  CCriticalSection m_critSection;
   int64_t m_systemUsed;
   int64_t m_startClock;
   int64_t m_pauseClock;


### PR DESCRIPTION
Protecting a method that is only a few statements like GetClock with a shared lock makes no sense. A shared lock is more expensive than a single lock.
