### PR TITLE
fix lockmgr callback

### DIFF
--- a/xbmc/cores/FFmpeg.cpp
+++ b/xbmc/cores/FFmpeg.cpp
@@ -20,7 +20,7 @@
 
 #include "cores/FFmpeg.h"
 #include "utils/log.h"
-#include "threads/SharedSection.h"
+#include "threads/CriticalSection.h"
 #include "utils/StringUtils.h"
 #include "threads/Thread.h"
 #include "settings/AdvancedSettings.h"
@@ -30,14 +30,14 @@
 /* callback for the ffmpeg lock manager */
 int ffmpeg_lockmgr_cb(void **mutex, enum AVLockOp operation)
 {
-  CSharedSection **lock = (CSharedSection **)mutex;
+  CCriticalSection **lock = (CCriticalSection **)mutex;
 
   switch (operation)
   {
     case AV_LOCK_CREATE:
     {
       *lock = NULL;
-      *lock = new CSharedSection();
+      *lock = new CCriticalSection();
       if (*lock == NULL)
         return 1;
       break;


### PR DESCRIPTION
this function is useless. a shared lock used without an exclusive lock does not protect anything.

EDIT: changed CSharedSection to CCriticalSection
