### PR TITLE
[videoplayer] Add video stream selection to core

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -18241,3 +18241,9 @@ msgstr ""
 msgctxt "#38031"
 msgid "Video stream"
 msgstr ""
+
+#. Label for an option to select the angle to play if current disc has more than one angle
+#: xbmc\video\dialogs\GUIDialogVideoSettings.cpp
+msgctxt "#38032"
+msgid "Angle"
+msgstr ""

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -18235,3 +18235,9 @@ msgstr ""
 msgctxt "#38030"
 msgid "This option uses frame-packing to output full resolution for 3D through HDMI.[CR]Enabling this improves quality of Multiview Video Coding (MVC) videos, but may not be supported by all displays."
 msgstr ""
+
+#. Label for an option to select the video stream to play if current video has more than one video stream
+#: xbmc\video\dialogs\GUIDialogVideoSettings.cpp
+msgctxt "#38031"
+msgid "Video stream"
+msgstr ""

--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -509,11 +509,11 @@ void CApplicationPlayer::OnNothingToQueueNotify()
     player->OnNothingToQueueNotify();
 }
 
-void CApplicationPlayer::GetVideoStreamInfo(SPlayerVideoStreamInfo &info)
+void CApplicationPlayer::GetVideoStreamInfo(int streamId, SPlayerVideoStreamInfo &info)
 {
   std::shared_ptr<IPlayer> player = GetInternal();
   if (player)
-    player->GetVideoStreamInfo(info);
+    player->GetVideoStreamInfo(streamId, info);
 }
 
 void CApplicationPlayer::GetAudioStreamInfo(int index, SPlayerAudioStreamInfo &info)
@@ -540,6 +540,31 @@ int  CApplicationPlayer::GetAudioStreamCount()
   std::shared_ptr<IPlayer> player = GetInternal();
   if (player)
     return player->GetAudioStreamCount();
+  else
+    return 0;
+}
+
+int CApplicationPlayer::GetVideoStream()
+{
+  if (!m_videoStreamUpdate.IsTimePast())
+    return m_iVideoStream;
+
+  std::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+  {
+    m_iVideoStream = player->GetVideoStream();
+    m_videoStreamUpdate.Set(1000);
+    return m_iVideoStream;
+  }
+  else
+    return 0;
+}
+
+int CApplicationPlayer::GetVideoStreamCount()
+{
+  std::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    return player->GetVideoStreamCount();
   else
     return 0;
 }
@@ -598,6 +623,18 @@ void CApplicationPlayer::SetTotalTime(int64_t time)
   std::shared_ptr<IPlayer> player = GetInternal();
   if (player)
     player->SetTotalTime(time);
+}
+
+void CApplicationPlayer::SetVideoStream(int iStream)
+{
+  std::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+  {
+    player->SetVideoStream(iStream);
+    m_iVideoStream = iStream;
+    m_videoStreamUpdate.Set(1000);
+    CMediaSettings::GetInstance().GetCurrentVideoSettings().m_VideoStream = iStream;
+  }
 }
 
 void CApplicationPlayer::AddSubtitle(const std::string& strSubPath)

--- a/xbmc/ApplicationPlayer.h
+++ b/xbmc/ApplicationPlayer.h
@@ -58,6 +58,8 @@ class CApplicationPlayer
   // cache player state
   XbmcThreads::EndTime m_audioStreamUpdate;
   int m_iAudioStream;
+  XbmcThreads::EndTime m_videoStreamUpdate;
+  int m_iVideoStream;
   XbmcThreads::EndTime m_subtitleStreamUpdate;
   int m_iSubtitleStream;
   
@@ -140,7 +142,9 @@ public:
   int64_t GetDisplayTime() const;
   int64_t GetTotalTime() const;
   void  GetVideoInfo(std::string& strVideoInfo);
-  void  GetVideoStreamInfo(SPlayerVideoStreamInfo &info);
+  int   GetVideoStream();
+  int   GetVideoStreamCount();
+  void  GetVideoStreamInfo(int streamId, SPlayerVideoStreamInfo &info);
   bool  HasAudio() const;
   bool  HasMenu() const;
   bool  HasVideo() const;
@@ -177,6 +181,7 @@ public:
   void  SetSubtitleVisible(bool bVisible);
   void  SetTime(int64_t time);
   void  SetTotalTime(int64_t time);
+  void  SetVideoStream(int iStream);
   void  SetVolume(float volume);
   bool  SwitchChannel(const PVR::CPVRChannelPtr &channel);
   void  ToFFRW(int iSpeed = 0);

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -4883,7 +4883,7 @@ void CGUIInfoManager::UpdateAVInfo()
       SPlayerVideoStreamInfo video;
       SPlayerAudioStreamInfo audio;
 
-      g_application.m_pPlayer->GetVideoStreamInfo(video);
+      g_application.m_pPlayer->GetVideoStreamInfo(CURRENT_STREAM, video);
       g_application.m_pPlayer->GetAudioStreamInfo(CURRENT_STREAM, audio);
 
       m_videoInfo = video;

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -288,6 +288,11 @@ public:
   virtual void SetAudioStream(int iStream){};
   virtual void GetAudioStreamInfo(int index, SPlayerAudioStreamInfo &info){};
 
+  virtual int GetVideoStream() const { return -1; }
+  virtual int GetVideoStreamCount() const { return 0; }
+  virtual void GetVideoStreamInfo(int streamId, SPlayerVideoStreamInfo &info) {}
+  virtual void SetVideoStream(int iStream) {}
+
   virtual TextCacheStruct_t* GetTeletextCache() { return NULL; };
   virtual void LoadPage(int p, int sp, unsigned char* buffer) {};
 
@@ -334,7 +339,6 @@ public:
    its not available in the underlaying decoder (airtunes for example)
    */
   virtual void SetTotalTime(int64_t time) { }
-  virtual void GetVideoStreamInfo(SPlayerVideoStreamInfo &info){};
   virtual int GetSourceBitrate(){ return 0;}
   virtual bool GetStreamDetails(CStreamDetails &details){ return false;}
   virtual void ToFFRW(int iSpeed = 0){};

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -111,6 +111,15 @@ void CDemuxStreamVideoFFmpeg::GetStreamInfo(std::string& strInfo)
   strInfo = temp;
 }
 
+void CDemuxStreamVideoFFmpeg::GetStreamName(std::string& strInfo)
+{
+  if (!m_stream) return;
+  if (!m_description.empty())
+    strInfo = m_description;
+  else
+    CDemuxStream::GetStreamName(strInfo);
+}
+
 void CDemuxStreamSubtitleFFmpeg::GetStreamInfo(std::string& strInfo)
 {
   if(!m_stream) return;
@@ -1224,6 +1233,9 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int iId)
             }
           }
         }
+        if (av_dict_get(pStream->metadata, "title", NULL, 0))
+          st->m_description = av_dict_get(pStream->metadata, "title", NULL, 0)->value;
+
         break;
       }
     case AVMEDIA_TYPE_DATA:

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
@@ -43,7 +43,10 @@ public:
     : m_parent(parent)
     , m_stream(stream)
   {}
+  std::string      m_description;
+
   virtual void GetStreamInfo(std::string& strInfo);
+  virtual void GetStreamName(std::string& strInfo);
 };
 
 

--- a/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
@@ -410,6 +410,7 @@ bool CDVDFileInfo::DemuxerToStreamDetails(CDVDInputStream *pInputStream, CDVDDem
       pDemux->GetStreamCodecName(iStream, p->m_strCodec);
       p->m_iDuration = pDemux->GetStreamLength();
       p->m_strStereoMode = ((CDemuxStreamVideo *)stream)->stereo_mode;
+      p->m_strLanguage = ((CDemuxStreamVideo *)stream)->language;
 
       // stack handling
       if (URIUtils::IsStack(path))

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -1098,6 +1098,44 @@ int CDVDInputStreamNavigator::GetAudioStreamCount()
   }
 }
 
+
+int CDVDInputStreamNavigator::GetAngleCount()
+{
+  if (!m_dvdnav) return 0;
+
+  int number_of_angles;
+  int current_angle;
+  dvdnav_status_t status = m_dll.dvdnav_get_angle_info(m_dvdnav, &current_angle, &number_of_angles);
+
+  if (status == DVDNAV_STATUS_OK)
+    return number_of_angles;
+  else
+    return -1;
+}
+
+int CDVDInputStreamNavigator::GetActiveAngle()
+{
+  if (!m_dvdnav) return 0;
+
+  int number_of_angles;
+  int current_angle;
+  dvdnav_status_t status = m_dll.dvdnav_get_angle_info(m_dvdnav, &current_angle, &number_of_angles);
+
+  if (status == DVDNAV_STATUS_OK)
+    return current_angle;
+  else
+    return -1;
+}
+
+bool CDVDInputStreamNavigator::SetAngle(int angle)
+{
+  if (!m_dvdnav) return 0;
+
+  dvdnav_status_t status = m_dll.dvdnav_angle_change(m_dvdnav, angle);
+
+  return (status == DVDNAV_STATUS_OK);
+}
+
 bool CDVDInputStreamNavigator::GetCurrentButtonInfo(CDVDOverlaySpu* pOverlayPicture, CDVDDemuxSPU* pSPU, int iButtonType)
 {
   int alpha[2][4];
@@ -1482,4 +1520,11 @@ int64_t CDVDInputStreamNavigator::GetChapterPos(int ch)
       return chapter->second;
   }
   return 0;
+}
+
+void CDVDInputStreamNavigator::GetVideoResolution(uint32_t* width, uint32_t* height)
+{
+  if (!m_dvdnav) return;
+
+  dvdnav_status_t status = m_dll.dvdnav_get_video_resolution(m_dvdnav, width, height);
 }

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.h
@@ -120,6 +120,9 @@ public:
 
   int GetActiveAudioStream();
   int GetAudioStreamCount();
+  int GetAngleCount();
+  int GetActiveAngle();
+  bool SetAngle(int angle);
   bool SetActiveAudioStream(int iId);
   bool GetAudioStreamInfo(const int iId, DVDNavStreamInfo &info);
 
@@ -130,6 +133,7 @@ public:
   int GetChapterCount() { return m_iPartCount; } // the number of parts in the current title
   void GetChapterName(std::string& name, int idx=-1) {};
   int64_t GetChapterPos(int ch=-1);
+  void GetVideoResolution(uint32_t * width, uint32_t * height);
   bool SeekChapter(int iChapter);
 
   int GetTotalTime(); // the total time in milli seconds

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DllDvdNav.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DllDvdNav.h
@@ -102,12 +102,14 @@ public:
   virtual dvdnav_status_t dvdnav_get_state(dvdnav_t *self, dvd_state_t *save_state)=0;
   virtual dvdnav_status_t dvdnav_set_state(dvdnav_t *self, dvd_state_t *save_state)=0;
   virtual dvdnav_status_t dvdnav_get_angle_info(dvdnav_t *self, int32_t *current_angle,int32_t *number_of_angles)=0;
+  virtual dvdnav_status_t dvdnav_angle_change(dvdnav_t *self, int32_t angle) = 0;
   virtual dvdnav_status_t dvdnav_mouse_activate(dvdnav_t *self, pci_t *pci, int32_t x, int32_t y)=0;
   virtual dvdnav_status_t dvdnav_mouse_select(dvdnav_t *self, pci_t *pci, int32_t x, int32_t y)=0;
   virtual dvdnav_status_t dvdnav_get_title_string(dvdnav_t *self, const char **title_str)=0;
   virtual dvdnav_status_t dvdnav_get_serial_string(dvdnav_t *self, const char **serial_str)=0;
   virtual uint32_t dvdnav_describe_title_chapters(dvdnav_t* self, uint32_t title, uint64_t** times, uint64_t* duration)=0;
   virtual void dvdnav_free(void* pdata) = 0;
+  virtual int dvdnav_get_video_resolution(dvdnav_t* self, uint32_t* width, uint32_t* height)=0;
 };
 
 #if (defined USE_STATIC_LIBDVDNAV)
@@ -305,12 +307,14 @@ class DllDvdNav : public DllDynamic, DllDvdNavInterface
   DEFINE_METHOD2(dvdnav_status_t, dvdnav_get_state, (dvdnav_t *p1, dvd_state_t *p2))
   DEFINE_METHOD2(dvdnav_status_t, dvdnav_set_state, (dvdnav_t *p1, dvd_state_t *p2))
   DEFINE_METHOD3(dvdnav_status_t, dvdnav_get_angle_info, (dvdnav_t *p1, int32_t *p2,int32_t *p3))
+  DEFINE_METHOD2(dvdnav_status_t, dvdnav_angle_change, (dvdnav_t *p1, int32_t p2))
   DEFINE_METHOD4(dvdnav_status_t, dvdnav_mouse_activate, (dvdnav_t *p1, pci_t *p2, int32_t p3, int32_t p4))
   DEFINE_METHOD4(dvdnav_status_t, dvdnav_mouse_select, (dvdnav_t *p1, pci_t *p2, int32_t p3, int32_t p4))
   DEFINE_METHOD2(dvdnav_status_t, dvdnav_get_title_string, (dvdnav_t *p1, const char **p2))
   DEFINE_METHOD2(dvdnav_status_t, dvdnav_get_serial_string, (dvdnav_t *p1, const char **p2))
   DEFINE_METHOD4(uint32_t, dvdnav_describe_title_chapters, (dvdnav_t* p1, uint32_t p2, uint64_t** p3, uint64_t* p4))
   DEFINE_METHOD1(void, dvdnav_free, (void *p1))
+  DEFINE_METHOD3(int, dvdnav_get_video_resolution, (dvdnav_t* p1, uint32_t* p2, uint32_t* p3))
   BEGIN_METHOD_RESOLVE()
     RESOLVE_METHOD(dvdnav_open)
     RESOLVE_METHOD(dvdnav_close)
@@ -367,12 +371,14 @@ class DllDvdNav : public DllDynamic, DllDvdNavInterface
     RESOLVE_METHOD(dvdnav_get_state)
     RESOLVE_METHOD(dvdnav_set_state)
     RESOLVE_METHOD(dvdnav_get_angle_info)
+    RESOLVE_METHOD(dvdnav_angle_change)
     RESOLVE_METHOD(dvdnav_mouse_activate)
     RESOLVE_METHOD(dvdnav_mouse_select)
     RESOLVE_METHOD(dvdnav_get_title_string)
     RESOLVE_METHOD(dvdnav_get_serial_string)
     RESOLVE_METHOD(dvdnav_describe_title_chapters)
     RESOLVE_METHOD(dvdnav_free)
+    RESOLVE_METHOD(dvdnav_get_video_resolution)
 END_METHOD_RESOLVE()
 };
 

--- a/xbmc/cores/VideoPlayer/DVDMessage.h
+++ b/xbmc/cores/VideoPlayer/DVDMessage.h
@@ -57,6 +57,7 @@ public:
     // player core related messages (cVideoPlayer.cpp)
 
     PLAYER_SET_AUDIOSTREAM,         //
+    PLAYER_SET_VIDEOSTREAM,         //
     PLAYER_SET_SUBTITLESTREAM,      //
     PLAYER_SET_SUBTITLESTREAM_VISIBLE, //
     PLAYER_SET_STATE,               // restore the VideoPlayer to a certain state
@@ -182,6 +183,15 @@ class CDVDMsgPlayerSetAudioStream : public CDVDMsg
 public:
   CDVDMsgPlayerSetAudioStream(int streamId) : CDVDMsg(PLAYER_SET_AUDIOSTREAM) { m_streamId = streamId; }
   int GetStreamId()                     { return m_streamId; }
+private:
+  int m_streamId;
+};
+
+class CDVDMsgPlayerSetVideoStream : public CDVDMsg
+{
+public:
+  CDVDMsgPlayerSetVideoStream(int streamId) : CDVDMsg(PLAYER_SET_VIDEOSTREAM) { m_streamId = streamId; }
+  int GetStreamId() const { return m_streamId; }
 private:
   int m_streamId;
 };

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -312,6 +312,9 @@ public:
 
 static bool PredicateVideoPriority(const SelectionStream& lh, const SelectionStream& rh)
 {
+  PREDICATE_RETURN(lh.type_index == CMediaSettings::GetInstance().GetCurrentVideoSettings().m_VideoStream
+                 , rh.type_index == CMediaSettings::GetInstance().GetCurrentVideoSettings().m_VideoStream);
+
   PREDICATE_RETURN(lh.flags & CDemuxStream::FLAG_DEFAULT
                  , rh.flags & CDemuxStream::FLAG_DEFAULT);
   return false;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -354,7 +354,7 @@ int CSelectionStreams::IndexOf(StreamType type, int source, int id) const
     return -1;
 }
 
-int CSelectionStreams::IndexOf(StreamType type, CVideoPlayer& p) const
+int CSelectionStreams::IndexOf(StreamType type, const CVideoPlayer& p) const
 {
   if (p.m_pInputStream && p.m_pInputStream->IsStreamType(DVDSTREAM_TYPE_DVD))
   {
@@ -2500,6 +2500,25 @@ void CVideoPlayer::HandleMessages()
           }
         }
       }
+      else if (pMsg->IsType(CDVDMsg::PLAYER_SET_VIDEOSTREAM))
+      {
+        CDVDMsgPlayerSetVideoStream* pMsg2 = (CDVDMsgPlayerSetVideoStream*)pMsg;
+
+        SelectionStream& st = m_SelectionStreams.Get(STREAM_VIDEO, pMsg2->GetStreamId());
+        if (st.source != STREAM_SOURCE_NONE)
+        {
+          if (st.source == STREAM_SOURCE_NAV && m_pInputStream && m_pInputStream->IsStreamType(DVDSTREAM_TYPE_DVD))
+          {
+            // Maybe multi angle?
+          }
+          else
+          {
+            CloseStream(m_CurrentVideo, false);
+            OpenStream(m_CurrentVideo, st.id, st.source);
+            m_messenger.Put(new CDVDMsgPlayerSeek((int)GetTime(), true, true, true, true, true));
+          }
+        }
+      }
       else if (pMsg->IsType(CDVDMsg::PLAYER_SET_SUBTITLESTREAM))
       {
         CDVDMsgPlayerSetSubtitleStream* pMsg2 = (CDVDMsgPlayerSetSubtitleStream*)pMsg;
@@ -3196,8 +3215,11 @@ void CVideoPlayer::UpdateStreamInfos()
   std::string retVal;
 
   // video
+  streamId = GetVideoStream();
+
+  if (streamId >= 0 && streamId < GetVideoStreamCount())
   {
-    SelectionStream& s = m_SelectionStreams.Get(STREAM_VIDEO, 0);
+    SelectionStream& s = m_SelectionStreams.Get(STREAM_VIDEO, streamId);
     s.bitrate = m_VideoPlayerVideo->GetVideoBitrate();
     s.aspect_ratio = m_renderManager.GetAspectRatio();
     CRect viewRect;
@@ -3276,6 +3298,22 @@ int CVideoPlayer::GetAudioStream()
 void CVideoPlayer::SetAudioStream(int iStream)
 {
   m_messenger.Put(new CDVDMsgPlayerSetAudioStream(iStream));
+  SynchronizeDemuxer(100);
+}
+
+int CVideoPlayer::GetVideoStreamCount() const
+{
+  return m_SelectionStreams.Count(STREAM_VIDEO);
+}
+
+int CVideoPlayer::GetVideoStream() const
+{
+  return m_SelectionStreams.IndexOf(STREAM_VIDEO, *this);
+}
+
+void CVideoPlayer::SetVideoStream(int iStream)
+{
+  m_messenger.Put(new CDVDMsgPlayerSetVideoStream(iStream));
   SynchronizeDemuxer(100);
 }
 
@@ -4432,11 +4470,16 @@ double CVideoPlayer::GetQueueTime()
   return std::max(a, v) * 8000.0 / 100;
 }
 
-void CVideoPlayer::GetVideoStreamInfo(SPlayerVideoStreamInfo &info)
+void CVideoPlayer::GetVideoStreamInfo(int streamId, SPlayerVideoStreamInfo &info)
 {
   CSingleLock lock(m_SelectionStreams.m_section);
+  if (streamId == CURRENT_STREAM)
+    streamId = GetVideoStream();
 
-  SelectionStream& s = m_SelectionStreams.Get(STREAM_VIDEO, 0);
+  if (streamId < 0 || streamId > GetVideoStreamCount() - 1)
+    return;
+
+  SelectionStream& s = m_SelectionStreams.Get(STREAM_VIDEO, streamId);
   if (s.language.length() > 0)
     info.language = s.language;
 

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -361,8 +361,8 @@ int CSelectionStreams::IndexOf(StreamType type, const CVideoPlayer& p) const
     int id = -1;
     if(type == STREAM_AUDIO)
       id = ((CDVDInputStreamNavigator*)p.m_pInputStream)->GetActiveAudioStream();
-    else if(type == STREAM_VIDEO)
-      id = p.m_CurrentVideo.id;
+    else if (type == STREAM_VIDEO)
+      id = ((CDVDInputStreamNavigator*)p.m_pInputStream)->GetActiveAngle();
     else if(type == STREAM_SUBTITLE)
       id = ((CDVDInputStreamNavigator*)p.m_pInputStream)->GetActiveSubtitleStream();
 
@@ -461,6 +461,27 @@ void CSelectionStreams::Update(CDVDInputStream* input, CDVDDemux* demuxer, std::
       nav->GetSubtitleStreamInfo(i, info);
       s.name     = info.name;
       s.language = g_LangCodeExpander.ConvertToISO6392T(info.language);
+      Update(s);
+    }
+
+    count = nav->GetAngleCount();
+    uint32_t width = 0;
+    uint32_t height = 0;
+    int aspect = nav->GetVideoAspectRatio();
+    nav->GetVideoResolution(&width, &height);
+    for (int i = 1; i <= count; i++)
+    {
+      SelectionStream s;
+      s.source = source;
+      s.type = STREAM_VIDEO;
+      s.id = i;
+      s.flags = CDemuxStream::FLAG_NONE;
+      s.filename = filename;
+      s.channels = 0;
+      s.aspect_ratio = aspect;
+      s.width = (int)width;
+      s.height = (int)height;
+      s.name = StringUtils::Format("%s %i", g_localizeStrings.Get(38032).c_str(), i);
       Update(s);
     }
   }
@@ -2509,7 +2530,12 @@ void CVideoPlayer::HandleMessages()
         {
           if (st.source == STREAM_SOURCE_NAV && m_pInputStream && m_pInputStream->IsStreamType(DVDSTREAM_TYPE_DVD))
           {
-            // Maybe multi angle?
+            CDVDInputStreamNavigator* pStream = (CDVDInputStreamNavigator*)m_pInputStream;
+            if (pStream->SetAngle(st.id))
+            {
+              m_dvd.iSelectedVideoStream = st.id;
+              m_messenger.Put(new CDVDMsgPlayerSeek((int)GetTime(), true, true, true, true, true));
+            }
           }
           else
           {

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -198,7 +198,7 @@ public:
   CCriticalSection m_section;
 
   int              IndexOf (StreamType type, int source, int id) const;
-  int              IndexOf (StreamType type, CVideoPlayer& p) const;
+  int              IndexOf (StreamType type, const CVideoPlayer& p) const;
   int              Count   (StreamType type) const { return IndexOf(type, STREAM_SOURCE_NONE, -1) + 1; }
   int              CountSource(StreamType type, StreamSource source) const;
   SelectionStream& Get     (StreamType type, int index);
@@ -267,6 +267,11 @@ public:
   virtual int GetAudioStream();
   virtual void SetAudioStream(int iStream);
 
+  virtual int GetVideoStream() const override;
+  virtual int GetVideoStreamCount() const override;
+  virtual void GetVideoStreamInfo(int streamId, SPlayerVideoStreamInfo &info) override;
+  virtual void SetVideoStream(int iStream);
+
   virtual TextCacheStruct_t* GetTeletextCache();
   virtual void LoadPage(int p, int sp, unsigned char* buffer);
 
@@ -288,7 +293,6 @@ public:
   virtual bool HasMenu();
 
   virtual int GetSourceBitrate();
-  virtual void GetVideoStreamInfo(SPlayerVideoStreamInfo &info);
   virtual bool GetStreamDetails(CStreamDetails &details);
   virtual void GetAudioStreamInfo(int index, SPlayerAudioStreamInfo &info);
   virtual void UpdateStreamInfos();

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -485,6 +485,7 @@ protected:
       state                =  DVDSTATE_NORMAL;
       iSelectedSPUStream   = -1;
       iSelectedAudioStream = -1;
+      iSelectedVideoStream = -1;
       iDVDStillTime        =  0;
       iDVDStillStartTime   =  0;
       syncClock = false;
@@ -496,6 +497,7 @@ protected:
     unsigned int iDVDStillStartTime; // time in ticks when we started the still
     int iSelectedSPUStream;   // mpeg stream id, or -1 if disabled
     int iSelectedAudioStream; // mpeg stream id, or -1 if disabled
+    int iSelectedVideoStream; // mpeg stream id or angle, -1 if disabled
   } m_dvd;
 
   friend class CVideoPlayerVideo;

--- a/xbmc/guilib/StereoscopicsManager.cpp
+++ b/xbmc/guilib/StereoscopicsManager.cpp
@@ -505,7 +505,7 @@ std::string CStereoscopicsManager::GetVideoStereoMode()
   if (g_application.m_pPlayer->IsPlaying())
   {
     SPlayerVideoStreamInfo videoInfo;
-    g_application.m_pPlayer->GetVideoStreamInfo(videoInfo);
+    g_application.m_pPlayer->GetVideoStreamInfo(CURRENT_STREAM, videoInfo);
     playerMode = videoInfo.stereoMode;
   }
   return playerMode;

--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -551,6 +551,8 @@ namespace XBMCAddon
             video->m_iDuration = strtol(value.c_str(), NULL, 10);
           else if (key == "stereomode")
             video->m_strStereoMode = value;
+          else if (key == "language")
+            video->m_strLanguage = value;
         }
         item->GetVideoInfoTag()->m_streamDetails.AddStream(video);
       }

--- a/xbmc/settings/VideoSettings.cpp
+++ b/xbmc/settings/VideoSettings.cpp
@@ -54,6 +54,7 @@ CVideoSettings::CVideoSettings()
   m_ResumeTime = 0;
   m_StereoMode = 0;
   m_StereoInvert = false;
+  m_VideoStream = -1;
 
 }
 
@@ -84,5 +85,6 @@ bool CVideoSettings::operator!=(const CVideoSettings &right) const
   if (m_ResumeTime != right.m_ResumeTime) return true;
   if (m_StereoMode != right.m_StereoMode) return true;
   if (m_StereoInvert != right.m_StereoInvert) return true;
+  if (m_VideoStream != right.m_VideoStream) return true;
   return false;
 }

--- a/xbmc/settings/VideoSettings.h
+++ b/xbmc/settings/VideoSettings.h
@@ -60,6 +60,7 @@ public:
   int m_ResumeTime;
   int m_StereoMode;
   bool m_StereoInvert;
+  int m_VideoStream;
 
 private:
 };

--- a/xbmc/utils/StreamDetails.cpp
+++ b/xbmc/utils/StreamDetails.cpp
@@ -53,6 +53,7 @@ void CStreamDetailVideo::Archive(CArchive& ar)
     ar << m_iWidth;
     ar << m_iDuration;
     ar << m_strStereoMode;
+    ar << m_strLanguage;
   }
   else
   {
@@ -62,6 +63,7 @@ void CStreamDetailVideo::Archive(CArchive& ar)
     ar >> m_iWidth;
     ar >> m_iDuration;
     ar >> m_strStereoMode;
+    ar >> m_strLanguage;
   }
 }
 void CStreamDetailVideo::Serialize(CVariant& value) const
@@ -72,6 +74,7 @@ void CStreamDetailVideo::Serialize(CVariant& value) const
   value["width"] = m_iWidth;
   value["duration"] = m_iDuration;
   value["stereomode"] = m_strStereoMode;
+  value["language"] = m_strLanguage;
 }
 
 bool CStreamDetailVideo::IsWorseThan(CStreamDetail *that)
@@ -265,6 +268,15 @@ CStreamDetail *CStreamDetails::NewStream(CStreamDetail::StreamType type)
     AddStream(retVal);
 
   return retVal;
+}
+
+std::string CStreamDetails::GetVideoLanguage(int idx) const
+{
+  CStreamDetailVideo *item = (CStreamDetailVideo*)GetNthStream(CStreamDetail::VIDEO, idx);
+  if (item)
+    return item->m_strLanguage;
+  else
+    return "";
 }
 
 int CStreamDetails::GetStreamCount(CStreamDetail::StreamType type) const

--- a/xbmc/utils/StreamDetails.h
+++ b/xbmc/utils/StreamDetails.h
@@ -62,6 +62,7 @@ public:
   int m_iDuration;
   std::string m_strCodec;
   std::string m_strStereoMode;
+  std::string m_strLanguage;
 };
 
 class CStreamDetailAudio : public CStreamDetail
@@ -116,6 +117,7 @@ public:
   int GetVideoDuration(int idx = 0) const;
   void SetVideoDuration(int idx, const int duration);
   std::string GetStereoMode(int idx = 0) const;
+  std::string GetVideoLanguage(int idx = 0) const;
 
   std::string GetAudioCodec(int idx = 0) const;
   std::string GetAudioLanguage(int idx = 0) const;

--- a/xbmc/utils/test/TestStreamDetails.cpp
+++ b/xbmc/utils/test/TestStreamDetails.cpp
@@ -35,6 +35,7 @@ TEST(TestStreamDetails, General)
   video->m_iDuration = 30;
   video->m_strCodec = "h264";
   video->m_strStereoMode = "left_right";
+  video->m_strLanguage = "eng";
 
   audio->m_iChannels = 2;
   audio->m_strCodec = "aac";

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -971,9 +971,12 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
         XMLUtils::GetInt(nodeDetail, "durationinseconds", p->m_iDuration);
         if (XMLUtils::GetString(nodeDetail, "stereomode", value))
           p->m_strStereoMode = StringUtils::Trim(value);
+        if (XMLUtils::GetString(nodeDetail, "language", value))
+          p->m_strLanguage = StringUtils::Trim(value);
 
         StringUtils::ToLower(p->m_strCodec);
         StringUtils::ToLower(p->m_strStereoMode);
+        StringUtils::ToLower(p->m_strLanguage);
         m_streamDetails.AddStream(p);
       }
       nodeDetail = NULL;

--- a/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
@@ -195,7 +195,7 @@ void CGUIDialogVideoSettings::InitializeSettings()
 {
   CGUIDialogSettingsManualBase::InitializeSettings();
 
-  CSettingCategory *category = AddCategory("audiosubtitlesettings", -1);
+  CSettingCategory *category = AddCategory("videosettings", -1);
   if (category == NULL)
   {
     CLog::Log(LOGERROR, "CGUIDialogVideoSettings: unable to setup settings");

--- a/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
@@ -36,6 +36,8 @@
 #include "utils/Variant.h"
 #include "video/VideoDatabase.h"
 #include "Application.h"
+#include "utils/LangCodeExpander.h"
+#include "utils/StringUtils.h"
 
 #define SETTING_VIDEO_VIEW_MODE           "video.viewmode"
 #define SETTING_VIDEO_ZOOM                "video.zoom"
@@ -59,6 +61,7 @@
 
 #define SETTING_VIDEO_MAKE_DEFAULT        "video.save"
 #define SETTING_VIDEO_CALIBRATION         "video.calibration"
+#define SETTING_VIDEO_STREAM              "video.stream"
 
 CGUIDialogVideoSettings::CGUIDialogVideoSettings()
     : CGUIDialogSettingsManualBase(WINDOW_DIALOG_VIDEO_OSD_SETTINGS, "VideoOSDSettings.xml"),
@@ -85,6 +88,16 @@ void CGUIDialogVideoSettings::OnSettingChanged(const CSetting *setting)
   else if (settingId == SETTING_VIDEO_SCALINGMETHOD)
     videoSettings.m_ScalingMethod = static_cast<ESCALINGMETHOD>(static_cast<const CSettingInt*>(setting)->GetValue());
 #ifdef HAS_VIDEO_PLAYBACK
+  else if (settingId == SETTING_VIDEO_STREAM)
+  {
+    m_videoStream = static_cast<const CSettingInt*>(setting)->GetValue();
+    // only change the video stream if a different one has been asked for
+    if (g_application.m_pPlayer->GetVideoStream() != m_videoStream)
+    {
+      videoSettings.m_VideoStream = m_videoStream;
+      g_application.m_pPlayer->SetVideoStream(m_videoStream);    // Set the video stream to the one selected
+    }
+  }
   else if (settingId == SETTING_VIDEO_VIEW_MODE)
   {
     videoSettings.m_ViewMode = static_cast<const CSettingInt*>(setting)->GetValue();
@@ -203,6 +216,12 @@ void CGUIDialogVideoSettings::InitializeSettings()
   }
 
   // get all necessary setting groups
+  CSettingGroup *groupVideoStream = AddGroup(category);
+  if (groupVideoStream == NULL)
+  {
+    CLog::Log(LOGERROR, "CGUIDialogVideoSettings: unable to setup settings");
+    return;
+  }
   CSettingGroup *groupVideo = AddGroup(category);
   if (groupVideo == NULL)
   {
@@ -320,6 +339,8 @@ void CGUIDialogVideoSettings::InitializeSettings()
   AddSpinner(groupVideo, SETTING_VIDEO_SCALINGMETHOD, 16300, 0, static_cast<int>(videoSettings.m_ScalingMethod), entries);
 
 #ifdef HAS_VIDEO_PLAYBACK
+  AddVideoStreams(groupVideoStream, SETTING_VIDEO_STREAM);
+
   if (g_application.m_pPlayer->Supports(RENDERFEATURE_STRETCH) || g_application.m_pPlayer->Supports(RENDERFEATURE_PIXEL_RATIO))
   {
     entries.clear();
@@ -361,3 +382,59 @@ void CGUIDialogVideoSettings::InitializeSettings()
   AddButton(groupSaveAsDefault, SETTING_VIDEO_MAKE_DEFAULT, 12376, 0);
   AddButton(groupSaveAsDefault, SETTING_VIDEO_CALIBRATION, 214, 0);
 }
+
+void CGUIDialogVideoSettings::AddVideoStreams(CSettingGroup *group, const std::string &settingId)
+{
+  if (group == NULL || settingId.empty())
+    return;
+
+  m_videoStream = g_application.m_pPlayer->GetVideoStream();
+  if (m_videoStream < 0)
+    m_videoStream = 0;
+
+  AddList(group, settingId, 38031, 0, m_videoStream, VideoStreamsOptionFiller, 38031);
+}
+
+void CGUIDialogVideoSettings::VideoStreamsOptionFiller(const CSetting *setting, std::vector< std::pair<std::string, int> > &list, int &current, void *data)
+{
+  int videoStreamCount = g_application.m_pPlayer->GetVideoStreamCount();
+
+  // cycle through each video stream and add it to our list control
+  for (int i = 0; i < videoStreamCount; ++i)
+  {
+    std::string strItem;
+    std::string strLanguage;
+
+    SPlayerVideoStreamInfo info;
+    g_application.m_pPlayer->GetVideoStreamInfo(i, info);
+
+    g_LangCodeExpander.Lookup(info.language, strLanguage);
+
+    if (!info.name.empty())
+    {
+      if (!strLanguage.empty())
+        strItem = StringUtils::Format("%s - %s", strLanguage.c_str(), info.name.c_str());
+      else
+        strItem = info.name;
+    }
+    else if (!strLanguage.empty())
+    {      
+        strItem = strLanguage;
+    }
+
+    if (info.videoCodecName.empty())
+      strItem += StringUtils::Format(" (%ix%i)", info.width, info.height);
+    else
+      strItem += StringUtils::Format(" (%s, %ix%i)", info.videoCodecName.c_str(), info.width, info.height);
+
+    strItem += StringUtils::Format(" (%i/%i)", i + 1, videoStreamCount);
+    list.push_back(make_pair(strItem, i));
+  }
+
+  if (list.empty())
+  {
+    list.push_back(make_pair(g_localizeStrings.Get(231), -1));
+    current = -1;
+  }
+}
+

--- a/xbmc/video/dialogs/GUIDialogVideoSettings.h
+++ b/xbmc/video/dialogs/GUIDialogVideoSettings.h
@@ -33,6 +33,9 @@ protected:
   virtual void OnSettingChanged(const CSetting *setting);
   virtual void OnSettingAction(const CSetting *setting);
 
+  void AddVideoStreams(CSettingGroup *group, const std::string & settingId);
+  static void VideoStreamsOptionFiller(const CSetting *setting, std::vector< std::pair<std::string, int> > &list, int &current, void *data);
+
   // specialization of CGUIDialogSettingsBase
   virtual bool AllowResettingSettings() const { return false; }
   virtual void Save();
@@ -42,5 +45,6 @@ protected:
   virtual void InitializeSettings();
 
 private:
+  int m_videoStream;
   bool m_viewModeChanged;
 };

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -453,7 +453,7 @@ void CGUIWindowFullScreen::FrameMove()
     }
     // show sizing information
     SPlayerVideoStreamInfo info;
-    g_application.m_pPlayer->GetVideoStreamInfo(info);
+    g_application.m_pPlayer->GetVideoStreamInfo(CURRENT_STREAM,info);
     {
       // Splitres scaling factor
       float xscale = (float)res.iScreenWidth  / (float)res.iWidth;


### PR DESCRIPTION
This pr replaces a part of pr #8514
Remaining tasks
- [x] adapt default video stream opening
- [x] save video stream selection
- [x] Add angle selection for dvds

~~\- [ ] Handle different stream lengths (at least don't crash/freeze)~~ (cf. https://github.com/xbmc/xbmc/pull/8840)
