### PR TITLE
fix multi-part stack selection of correct part

### DIFF
--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -946,7 +946,7 @@ bool CGUIWindowVideoBase::OnPlayStackPart(int iItem)
         else if (value != SELECT_ACTION_PLAY)
           return false; // if not selected PLAY, then we changed our mind so return
       }
-      stack->m_lStartPartNumber = selectedFile;
+      stack->m_lStartPartNumber = selectedFile + 1;
     }
     // regular stack
     else


### PR DESCRIPTION
As title says. 

Rest of multi-part ISO stack code is assuming a start at 1 (not 0) but the the selection dialog was recently changed and the first value is now 0... This simple fix resolves it elegantly.

For reference: a multi-part ISO stack allows to put multi-disc sets into 1 stack if you name them as follows movie.disc1.iso, movie.disc2.iso, movie.disc3.iso etc. Upon playback one has to choose the part to play.
