### PR TITLE
fix build-tools deprecation

### DIFF
--- a/docs/README.android
+++ b/docs/README.android
@@ -120,7 +120,7 @@ install some android packages using the Android SDK Manager:
 
     $ cd <android-sdk>/tools
     $ ./android update sdk -u -t platform,platform-tool
-    $ ./android update sdk -u -t build-tools-20.0.0
+    $ ./android update sdk --all -u -t build-tools-20.0.0
 --------------------------------------------------------------------
 3.4. Setup the Android toolchain
 --------------------------------------------------------------------


### PR DESCRIPTION
The build-tools package has been deprecated and is otherwise excluded from the list - i.e. nothing is installed. '--all' will pull in all packages.
