### PR TITLE
[lang] move addon language file handing to CLocalizeStrings

### DIFF
--- a/xbmc/ContextMenuItem.cpp
+++ b/xbmc/ContextMenuItem.cpp
@@ -27,19 +27,7 @@
 #include "interfaces/python/ContextItemAddonInvoker.h"
 #include "interfaces/python/XBPython.h"
 #include "utils/StringUtils.h"
-#include <boost/lexical_cast.hpp>
 
-
-std::string CContextMenuItem::GetLabel() const
-{
-  if (!m_addon)
-    return "";
-
-  if (StringUtils::IsNaturalNumber(m_label))
-    return m_addon->GetString(boost::lexical_cast<int>(m_label.c_str()));
-
-  return m_label;
-}
 
 bool CContextMenuItem::IsVisible(const CFileItemPtr& item) const
 {

--- a/xbmc/ContextMenuItem.h
+++ b/xbmc/ContextMenuItem.h
@@ -32,7 +32,7 @@ namespace ADDON
 class CContextMenuItem
 {
 public:
-  std::string GetLabel() const;
+  const std::string& GetLabel() const { return m_label; }
   bool IsVisible(const CFileItemPtr& item) const;
   bool IsParentOf(const CContextMenuItem& menuItem) const;
   bool IsGroup() const;

--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -714,6 +714,17 @@ bool CLangInfo::SetLanguage(bool& fallback, const std::string &strLanguage /* = 
     return false;
   }
 
+  ADDON::VECADDONS addons;
+  if (ADDON::CAddonMgr::GetInstance().GetInstalledAddons(addons))
+  {
+    auto locale = CSettings::GetInstance().GetString(CSettings::SETTING_LOCALE_LANGUAGE);
+    for (const auto& addon : addons)
+    {
+      auto path = URIUtils::AddFileToFolder(addon->Path(), "resources/language/");
+      g_localizeStrings.LoadAddonStrings(path, locale, addon->ID());
+    }
+  }
+
   if (reloadServices)
   {
     // also tell our weather and skin to reload as these are localized

--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -278,8 +278,6 @@ CAddon::CAddon(const cp_extension_t *ext)
   BuildProfilePath();
   m_userSettingsPath = URIUtils::AddFileToFolder(Profile(), "settings.xml");
   m_hasSettings = true;
-  m_hasStrings = false;
-  m_checkedStrings = false;
   m_settingsLoaded = false;
   m_userSettingsLoaded = false;
 }
@@ -288,8 +286,6 @@ CAddon::CAddon(const cp_plugin_info_t *plugin)
   : m_props(plugin)
 {
   m_hasSettings = false;
-  m_hasStrings = false;
-  m_checkedStrings = true;
   m_settingsLoaded = false;
   m_userSettingsLoaded = false;
 }
@@ -302,8 +298,6 @@ CAddon::CAddon(const AddonProps &props)
   BuildProfilePath();
   m_userSettingsPath = URIUtils::AddFileToFolder(Profile(), "settings.xml");
   m_hasSettings = true;
-  m_hasStrings = false;
-  m_checkedStrings = false;
   m_settingsLoaded = false;
   m_userSettingsLoaded = false;
 }
@@ -319,8 +313,6 @@ CAddon::CAddon(const CAddon &rhs)
   BuildProfilePath();
   m_userSettingsPath = URIUtils::AddFileToFolder(Profile(), "settings.xml");
   m_strLibName  = rhs.m_strLibName;
-  m_hasStrings  = false;
-  m_checkedStrings  = false;
 }
 
 AddonPtr CAddon::Clone() const
@@ -437,33 +429,6 @@ void CAddon::BuildLibName(const cp_extension_t *extension)
       }
     }
   }
-}
-
-/**
- * Language File Handling
- */
-bool CAddon::LoadStrings()
-{
-  // Path where the language strings reside
-  std::string chosenPath = URIUtils::AddFileToFolder(m_props.path, "resources/language/");
-
-  m_hasStrings = m_strings.Load(chosenPath, CSettings::GetInstance().GetString(CSettings::SETTING_LOCALE_LANGUAGE));
-  return m_checkedStrings = true;
-}
-
-void CAddon::ClearStrings()
-{
-  // Unload temporary language strings
-  m_strings.Clear();
-  m_hasStrings = false;
-}
-
-std::string CAddon::GetString(uint32_t id)
-{
-  if (!m_hasStrings && ! m_checkedStrings && !LoadStrings())
-     return "";
-
-  return m_strings.Get(id);
 }
 
 /**

--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -144,7 +144,6 @@ public:
   virtual std::string GetSetting(const std::string& key);
 
   TiXmlElement* GetSettingsXML();
-  virtual std::string GetString(uint32_t id);
 
   // properties
   TYPE Type() const { return m_props.type; }
@@ -252,11 +251,6 @@ private:
   std::string        m_userSettingsPath;
   void BuildProfilePath();
 
-  virtual bool LoadStrings();
-  virtual void ClearStrings();
-
-  bool m_hasStrings;
-  bool m_checkedStrings;
   bool m_hasSettings;
 
   std::string m_profile;

--- a/xbmc/addons/AddonCallbacksAddon.cpp
+++ b/xbmc/addons/AddonCallbacksAddon.cpp
@@ -278,10 +278,8 @@ char* CAddonCallbacksAddon::GetLocalizedString(const void* addonData, long dwCod
   CAddonCallbacksAddon* addonHelper = helper->GetHelperAddon();
 
   std::string string;
-  if (dwCode >= 30000 && dwCode <= 30999)
-    string = addonHelper->m_addon->GetString(dwCode).c_str();
-  else if (dwCode >= 32000 && dwCode <= 32999)
-    string = addonHelper->m_addon->GetString(dwCode).c_str();
+  if ((dwCode >= 30000 && dwCode <= 30999) || (dwCode >= 32000 && dwCode <= 32999))
+    string = g_localizeStrings.GetAddonString(addonHelper->m_addon->ID(), dwCode).c_str();
   else
     string = g_localizeStrings.Get(dwCode).c_str();
 

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -646,15 +646,6 @@ bool CAddonMgr::SetDefault(const TYPE &type, const std::string &addonID)
   return true;
 }
 
-std::string CAddonMgr::GetString(const std::string &id, const int number)
-{
-  AddonPtr addon;
-  if (GetAddon(id, addon))
-    return addon->GetString(number);
-
-  return "";
-}
-
 void CAddonMgr::FindAddons()
 {
   {

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -122,8 +122,6 @@ namespace ADDON
     /*! Returns true if there is any addon with available updates, otherwise false */
     bool HasAvailableUpdates();
 
-    std::string GetString(const std::string &id, const int number);
-
     std::string GetTranslatedString(const cp_cfg_element_t *root, const char *tag);
     static AddonPtr AddonFromProps(AddonProps& props);
     void FindAddons();

--- a/xbmc/addons/ContextMenuAddon.cpp
+++ b/xbmc/addons/ContextMenuAddon.cpp
@@ -63,11 +63,12 @@ CContextMenuAddon::CContextMenuAddon(const cp_extension_t *ext)
       std::string parent = CAddonMgr::GetInstance().GetExtValue(item, "parent") == "kodi.core.manage"
           ? CContextMenuManager::MANAGE.m_groupId : CContextMenuManager::MAIN.m_groupId;
 
-      CContextMenuItem menuItem = CContextMenuItem::CreateItem(
-        CAddonMgr::GetInstance().GetExtValue(item, "label"),
-        parent,
-        LibPath(),
-        g_infoManager.Register(visCondition, 0));
+      auto label = CAddonMgr::GetInstance().GetExtValue(item, "label");
+      if (StringUtils::IsNaturalNumber(label))
+        label = g_localizeStrings.GetAddonString(ID(), atoi(label.c_str()));
+
+      CContextMenuItem menuItem = CContextMenuItem::CreateItem(label, parent,LibPath(),
+          g_infoManager.Register(visCondition, 0));
 
       m_items.push_back(menuItem);
     }
@@ -76,8 +77,10 @@ CContextMenuAddon::CContextMenuAddon(const cp_extension_t *ext)
 
 void CContextMenuAddon::ParseMenu(cp_cfg_element_t* elem, const std::string& parent, int& anonGroupCount)
 {
-  auto menuLabel = CAddonMgr::GetInstance().GetExtValue(elem, "label");
   auto menuId = CAddonMgr::GetInstance().GetExtValue(elem, "@id");
+  auto menuLabel = CAddonMgr::GetInstance().GetExtValue(elem, "label");
+  if (StringUtils::IsNaturalNumber(menuLabel))
+    menuLabel = g_localizeStrings.GetAddonString(ID(), atoi(menuLabel.c_str()));
 
   if (menuId.empty())
   {
@@ -99,17 +102,16 @@ void CContextMenuAddon::ParseMenu(cp_cfg_element_t* elem, const std::string& par
   {
     for (const auto& item : items)
     {
-      auto label = CAddonMgr::GetInstance().GetExtValue(item, "label");
       auto visCondition = CAddonMgr::GetInstance().GetExtValue(item, "visible");
       auto library = CAddonMgr::GetInstance().GetExtValue(item, "@library");
+      auto label = CAddonMgr::GetInstance().GetExtValue(item, "label");
+      if (StringUtils::IsNaturalNumber(label))
+        label = g_localizeStrings.GetAddonString(ID(), atoi(label.c_str()));
 
       if (!label.empty() && !library.empty() && !visCondition.empty())
       {
-        auto menu = CContextMenuItem::CreateItem(
-          label,
-          menuId,
-          URIUtils::AddFileToFolder(Path(), library),
-          g_infoManager.Register(visCondition, 0));
+        auto menu = CContextMenuItem::CreateItem(label, menuId,
+            URIUtils::AddFileToFolder(Path(), library), g_infoManager.Register(visCondition, 0));
 
         m_items.push_back(menu);
       }

--- a/xbmc/addons/GUIDialogAddonSettings.cpp
+++ b/xbmc/addons/GUIDialogAddonSettings.cpp
@@ -324,7 +324,7 @@ bool CGUIDialogAddonSettings::ShowVirtualKeyboard(int iControl)
               {
                 if (i == (unsigned int)atoi(value.c_str()))
                   selected = i;
-                std::string localized = m_addon->GetString(atoi(valuesVec[i].c_str()));
+                std::string localized = g_localizeStrings.GetAddonString(m_addon->ID(), atoi(valuesVec[i].c_str()));
                 if (localized.empty())
                   localized = g_localizeStrings.Get(atoi(valuesVec[i].c_str()));
                 valuesVec[i] = localized;
@@ -730,7 +730,7 @@ void CGUIDialogAddonSettings::CreateControls()
               int selected = atoi(value.c_str());
               if (selected >= 0 && selected < (int)valuesVec.size())
               {
-                std::string label = m_addon->GetString(atoi(valuesVec[selected].c_str()));
+                std::string label = g_localizeStrings.GetAddonString(m_addon->ID(), atoi(valuesVec[selected].c_str()));
                 if (label.empty())
                   label = g_localizeStrings.Get(atoi(valuesVec[selected].c_str()));
                 ((CGUIButtonControl *)pControl)->SetLabel2(label);
@@ -784,7 +784,7 @@ void CGUIDialogAddonSettings::CreateControls()
             iAdd = atoi(entryVec[i].c_str());
           if (!lvalues.empty())
           {
-            std::string replace = m_addon->GetString(atoi(valuesVec[i].c_str()));
+            std::string replace = g_localizeStrings.GetAddonString(m_addon->ID(),atoi(valuesVec[i].c_str()));
             if (replace.empty())
               replace = g_localizeStrings.Get(atoi(valuesVec[i].c_str()));
             ((CGUISpinControlEx *)pControl)->AddLabel(replace, iAdd);
@@ -835,7 +835,7 @@ void CGUIDialogAddonSettings::CreateControls()
 
         std::string valueformat;
         if (setting->Attribute("valueformat"))
-          valueformat = m_addon->GetString(atoi(setting->Attribute("valueformat")));
+          valueformat = g_localizeStrings.GetAddonString(m_addon->ID(), atoi(setting->Attribute("valueformat")));
         for (int i = 0; i < elements; i++)
         {
           std::string valuestring;
@@ -1102,7 +1102,7 @@ std::string CGUIDialogAddonSettings::GetString(const char *value, bool subSettin
     return "";
   std::string prefix(subSetting ? "- " : "");
   if (StringUtils::IsNaturalNumber(value))
-    return prefix + m_addon->GetString(atoi(value));
+    return prefix + g_localizeStrings.GetAddonString(m_addon->ID(), atoi(value));
   return prefix + value;
 }
 

--- a/xbmc/addons/IAddon.h
+++ b/xbmc/addons/IAddon.h
@@ -116,7 +116,6 @@ namespace ADDON
     virtual void UpdateSetting(const std::string& key, const std::string& value) =0;
     virtual std::string GetSetting(const std::string& key) =0;
     virtual TiXmlElement* GetSettingsXML() =0;
-    virtual std::string GetString(uint32_t id) =0;
     virtual const ADDONDEPS &GetDeps() const =0;
     virtual AddonVersion GetDependencyVersion(const std::string &dependencyID) const =0;
     virtual bool MeetsVersion(const AddonVersion &version) const =0;
@@ -135,8 +134,6 @@ namespace ADDON
 
   private:
     friend class CAddonMgr;
-    virtual bool LoadStrings() =0;
-    virtual void ClearStrings() =0;
   };
 };
 

--- a/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSP.cpp
+++ b/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSP.cpp
@@ -421,7 +421,7 @@ bool CActiveAEDSP::TranslateCharInfo(DWORD dwInfo, std::string &strValue) const
       if (modeId == AE_DSP_MASTER_MODE_ID_PASSOVER || modeId >= AE_DSP_MASTER_MODE_ID_INTERNAL_TYPES)
         strValue = g_localizeStrings.Get(activeMaster->ModeName());
       else if (CActiveAEDSP::GetInstance().GetAudioDSPAddon(activeMaster->AddonID(), addon))
-        strValue = addon->GetString(activeMaster->ModeName());
+        strValue = g_localizeStrings.GetAddonString(addon->ID(), activeMaster->ModeName());
     }
     break;
   case ADSP_MASTER_INFO:

--- a/xbmc/guilib/GUIInfoTypes.cpp
+++ b/xbmc/guilib/GUIInfoTypes.cpp
@@ -276,9 +276,9 @@ std::string AddonReplacer(const std::string &str)
 {
   // assumes "addon.id #####"
   size_t length = str.find(" ");
-  std::string id = str.substr(0, length);
+  std::string addonid = str.substr(0, length);
   int stringid = atoi(str.substr(length + 1).c_str());
-  return CAddonMgr::GetInstance().GetString(id, stringid);
+  return g_localizeStrings.GetAddonString(addonid, stringid);
 }
 
 std::string NumberReplacer(const std::string &str)

--- a/xbmc/guilib/LocalizeStrings.cpp
+++ b/xbmc/guilib/LocalizeStrings.cpp
@@ -58,6 +58,7 @@ static bool LoadXML(const std::string &filename, std::map<uint32_t, LocStr>& str
     return false;
   }
 
+  const auto originalSize = strings.size();
   const TiXmlElement *pChild = pRootElement->FirstChildElement("string");
   while (pChild)
   {
@@ -71,6 +72,7 @@ static bool LoadXML(const std::string &filename, std::map<uint32_t, LocStr>& str
     }
     pChild = pChild->NextSiblingElement("string");
   }
+  CLog::Log(LOGDEBUG, "LocalizeStrings: loaded %i strings from file %s", strings.size() - originalSize, filename.c_str());
   return true;
 }
 
@@ -134,7 +136,7 @@ static bool LoadPO(const std::string &filename, std::map<uint32_t, LocStr>& stri
     }
   }
 
-  CLog::Log(LOGDEBUG, "POParser: loaded %i strings from file %s", counter, filename.c_str());
+  CLog::Log(LOGDEBUG, "LocalizeStrings: loaded %i strings from file %s", counter, filename.c_str());
   return true;
 }
 
@@ -163,20 +165,13 @@ static bool LoadStr2Mem(const std::string &pathname_in, const std::string &langu
     }
 
     if (!exists)
-    {
-      CLog::Log(LOGDEBUG,
-          "LocalizeStrings: no translation available in currently set gui language, at path %s",
-          pathname.c_str());
       return false;
-    }
   }
 
   bool useSourceLang = StringUtils::EqualsNoCase(language, LANGUAGE_DEFAULT) || StringUtils::EqualsNoCase(language, LANGUAGE_OLD_DEFAULT);
   if (LoadPO(URIUtils::AddFileToFolder(pathname, "strings.po"), strings, encoding, offset, useSourceLang))
     return true;
 
-  CLog::Log(LOGDEBUG, "LocalizeStrings: no strings.po file exist at %s, fallback to strings.xml",
-      pathname.c_str());
   return LoadXML(URIUtils::AddFileToFolder(pathname, "strings.xml"), strings, encoding, offset);
 }
 

--- a/xbmc/guilib/LocalizeStrings.cpp
+++ b/xbmc/guilib/LocalizeStrings.cpp
@@ -30,6 +30,156 @@
 #include "threads/SingleLock.h"
 #include "utils/StringUtils.h"
 
+
+/*! \brief Tries to load ids and strings from a strings.xml file to the `strings` map..
+ * It should only be called from the LoadStr2Mem function to try a PO file first.
+ \param pathname The directory name, where we look for the strings file.
+ \param strings [out] The resulting strings map.
+ \param encoding Encoding of the strings.
+ \param offset An offset value to place strings from the id value.
+ \return false if no strings.xml file was loaded.
+ */
+static bool LoadXML(const std::string &filename, std::map<uint32_t, LocStr>& strings,
+    std::string &encoding, uint32_t offset = 0)
+{
+  CXBMCTinyXML xmlDoc;
+  if (!xmlDoc.LoadFile(filename))
+  {
+    CLog::Log(LOGDEBUG, "unable to load %s: %s at line %d", filename.c_str(), xmlDoc.ErrorDesc(), xmlDoc.ErrorRow());
+    return false;
+  }
+
+  TiXmlElement* pRootElement = xmlDoc.RootElement();
+  if (!pRootElement || pRootElement->NoChildren() ||
+      pRootElement->ValueStr()!="strings")
+  {
+    CLog::Log(LOGERROR, "%s Doesn't contain <strings>", filename.c_str());
+    return false;
+  }
+
+  const TiXmlElement *pChild = pRootElement->FirstChildElement("string");
+  while (pChild)
+  {
+    // Load old style language file with id as attribute
+    const char* attrId=pChild->Attribute("id");
+    if (attrId && !pChild->NoChildren())
+    {
+      uint32_t id = atoi(attrId) + offset;
+      if (strings.find(id) == strings.end())
+        strings[id].strTranslated = pChild->FirstChild()->Value();
+    }
+    pChild = pChild->NextSiblingElement("string");
+  }
+  return true;
+}
+
+/*! \brief Tries to load ids and strings from a strings.po file to the `strings` map.
+ * It should only be called from the LoadStr2Mem function to have a fallback.
+ \param pathname The directory name, where we look for the strings file.
+ \param strings [out] The resulting strings map.
+ \param encoding Encoding of the strings. For PO files we only use utf-8.
+ \param offset An offset value to place strings from the id value.
+ \param bSourceLanguage If we are loading the source English strings.po.
+ \return false if no strings.po file was loaded.
+ */
+static bool LoadPO(const std::string &filename, std::map<uint32_t, LocStr>& strings,
+    std::string &encoding, uint32_t offset = 0 , bool bSourceLanguage = false)
+{
+  CPODocument PODoc;
+  if (!PODoc.LoadFile(filename))
+    return false;
+
+  int counter = 0;
+
+  while ((PODoc.GetNextEntry()))
+  {
+    uint32_t id;
+    if (PODoc.GetEntryType() == ID_FOUND)
+    {
+      bool bStrInMem = strings.find((id = PODoc.GetEntryID()) + offset) != strings.end();
+      PODoc.ParseEntry(bSourceLanguage);
+
+      if (bSourceLanguage && !PODoc.GetMsgid().empty())
+      {
+        if (bStrInMem && (strings[id + offset].strOriginal.empty() ||
+                          PODoc.GetMsgid() == strings[id + offset].strOriginal))
+          continue;
+        else if (bStrInMem)
+          CLog::Log(LOGDEBUG,
+              "POParser: id:%i was recently re-used in the English string file, which is not yet "
+                  "changed in the translated file. Using the English string instead", id);
+        strings[id + offset].strTranslated = PODoc.GetMsgid();
+        counter++;
+      }
+      else if (!bSourceLanguage && !bStrInMem && !PODoc.GetMsgstr().empty())
+      {
+        strings[id + offset].strTranslated = PODoc.GetMsgstr();
+        strings[id + offset].strOriginal = PODoc.GetMsgid();
+        counter++;
+      }
+    }
+    else if (PODoc.GetEntryType() == MSGID_FOUND)
+    {
+      // TODO: implement reading of non-id based string entries from the PO files.
+      // These entries would go into a separate memory map, using hash codes for fast look-up.
+      // With this memory map we can implement using gettext(), ngettext(), pgettext() calls,
+      // so that we don't have to use new IDs for new strings. Even we can start converting
+      // the ID based calls to normal gettext calls.
+    }
+    else if (PODoc.GetEntryType() == MSGID_PLURAL_FOUND)
+    {
+      // TODO: implement reading of non-id based pluralized string entries from the PO files.
+      // We can store the pluralforms for each language, in the langinfo.xml files.
+    }
+  }
+
+  CLog::Log(LOGDEBUG, "POParser: loaded %i strings from file %s", counter, filename.c_str());
+  return true;
+}
+
+/*! \brief Loads language ids and strings to memory map `strings`.
+ * It tries to load a strings.po file first. If doesn't exist, it loads a strings.xml file instead.
+ \param pathname The directory name, where we look for the strings file.
+ \param language We load the strings for this language. Fallback language is always English.
+ \param strings [out] The resulting strings map.
+ \param encoding Encoding of the strings. For PO files we only use utf-8.
+ \param offset An offset value to place strings from the id value.
+ \return false if no strings.po or strings.xml file was loaded.
+ */
+static bool LoadStr2Mem(const std::string &pathname_in, const std::string &language,
+    std::map<uint32_t, LocStr>& strings,  std::string &encoding, uint32_t offset = 0 )
+{
+  std::string pathname = CSpecialProtocol::TranslatePathConvertCase(pathname_in + language);
+  if (!XFILE::CDirectory::Exists(pathname))
+  {
+    bool exists = false;
+    std::string lang;
+    // check if there's a language addon using the old language naming convention
+    if (ADDON::CLanguageResource::FindLegacyLanguage(language, lang))
+    {
+      pathname = CSpecialProtocol::TranslatePathConvertCase(pathname_in + lang);
+      exists = XFILE::CDirectory::Exists(pathname);
+    }
+
+    if (!exists)
+    {
+      CLog::Log(LOGDEBUG,
+          "LocalizeStrings: no translation available in currently set gui language, at path %s",
+          pathname.c_str());
+      return false;
+    }
+  }
+
+  bool useSourceLang = StringUtils::EqualsNoCase(language, LANGUAGE_DEFAULT) || StringUtils::EqualsNoCase(language, LANGUAGE_OLD_DEFAULT);
+  if (LoadPO(URIUtils::AddFileToFolder(pathname, "strings.po"), strings, encoding, offset, useSourceLang))
+    return true;
+
+  CLog::Log(LOGDEBUG, "LocalizeStrings: no strings.po file exist at %s, fallback to strings.xml",
+      pathname.c_str());
+  return LoadXML(URIUtils::AddFileToFolder(pathname, "strings.xml"), strings, encoding, offset);
+}
+
+
 CLocalizeStrings::CLocalizeStrings(void)
 {
 
@@ -61,7 +211,7 @@ bool CLocalizeStrings::LoadSkinStrings(const std::string& path, const std::strin
   ClearSkinStrings();
   // load the skin strings in.
   std::string encoding;
-  if (!LoadStr2Mem(path, language, encoding))
+  if (!LoadStr2Mem(path, language, m_strings, encoding))
   {
     if (StringUtils::EqualsNoCase(language, LANGUAGE_DEFAULT)) // no fallback, nothing to do
       return false;
@@ -69,129 +219,8 @@ bool CLocalizeStrings::LoadSkinStrings(const std::string& path, const std::strin
 
   // load the fallback
   if (!StringUtils::EqualsNoCase(language, LANGUAGE_DEFAULT))
-    LoadStr2Mem(path, LANGUAGE_DEFAULT, encoding);
+    LoadStr2Mem(path, LANGUAGE_DEFAULT, m_strings, encoding);
 
-  return true;
-}
-
-bool CLocalizeStrings::LoadStr2Mem(const std::string &pathname_in, const std::string &language,
-                                   std::string &encoding, uint32_t offset /* = 0 */)
-{
-  std::string pathname = CSpecialProtocol::TranslatePathConvertCase(pathname_in + language);
-  if (!XFILE::CDirectory::Exists(pathname))
-  {
-    bool exists = false;
-    std::string lang;
-    // check if there's a language addon using the old language naming convention
-    if (ADDON::CLanguageResource::FindLegacyLanguage(language, lang))
-    {
-      pathname = CSpecialProtocol::TranslatePathConvertCase(pathname_in + lang);
-      exists = XFILE::CDirectory::Exists(pathname);
-    }
-
-    if (!exists)
-    {
-      CLog::Log(LOGDEBUG,
-                "LocalizeStrings: no translation available in currently set gui language, at path %s",
-                pathname.c_str());
-      return false;
-    }
-  }
-
-  if (LoadPO(URIUtils::AddFileToFolder(pathname, "strings.po"), encoding, offset,
-             StringUtils::EqualsNoCase(language, LANGUAGE_DEFAULT) || StringUtils::EqualsNoCase(language, LANGUAGE_OLD_DEFAULT)))
-    return true;
-
-  CLog::Log(LOGDEBUG, "LocalizeStrings: no strings.po file exist at %s, fallback to strings.xml",
-            pathname.c_str());
-  return LoadXML(URIUtils::AddFileToFolder(pathname, "strings.xml"), encoding, offset);
-}
-
-bool CLocalizeStrings::LoadPO(const std::string &filename, std::string &encoding,
-                              uint32_t offset /* = 0 */, bool bSourceLanguage)
-{
-  CPODocument PODoc;
-  if (!PODoc.LoadFile(filename))
-    return false;
-
-  int counter = 0;
-
-  while ((PODoc.GetNextEntry()))
-  {
-    uint32_t id;
-    if (PODoc.GetEntryType() == ID_FOUND)
-    {
-      bool bStrInMem = m_strings.find((id = PODoc.GetEntryID()) + offset) != m_strings.end();
-      PODoc.ParseEntry(bSourceLanguage);
-
-      if (bSourceLanguage && !PODoc.GetMsgid().empty())
-      {
-        if (bStrInMem && (m_strings[id + offset].strOriginal.empty() ||
-            PODoc.GetMsgid() == m_strings[id + offset].strOriginal))
-          continue;
-        else if (bStrInMem)
-          CLog::Log(LOGDEBUG,
-                    "POParser: id:%i was recently re-used in the English string file, which is not yet "
-                    "changed in the translated file. Using the English string instead", id);
-        m_strings[id + offset].strTranslated = PODoc.GetMsgid();
-        counter++;
-      }
-      else if (!bSourceLanguage && !bStrInMem && !PODoc.GetMsgstr().empty())
-      {
-        m_strings[id + offset].strTranslated = PODoc.GetMsgstr();
-        m_strings[id + offset].strOriginal = PODoc.GetMsgid();
-        counter++;
-      }
-    }
-    else if (PODoc.GetEntryType() == MSGID_FOUND)
-    {
-      // TODO: implement reading of non-id based string entries from the PO files.
-      // These entries would go into a separate memory map, using hash codes for fast look-up.
-      // With this memory map we can implement using gettext(), ngettext(), pgettext() calls,
-      // so that we don't have to use new IDs for new strings. Even we can start converting
-      // the ID based calls to normal gettext calls.
-    }
-    else if (PODoc.GetEntryType() == MSGID_PLURAL_FOUND)
-    {
-      // TODO: implement reading of non-id based pluralized string entries from the PO files.
-      // We can store the pluralforms for each language, in the langinfo.xml files.
-    }
-  }
-
-  CLog::Log(LOGDEBUG, "POParser: loaded %i strings from file %s", counter, filename.c_str());
-  return true;
-}
-
-bool CLocalizeStrings::LoadXML(const std::string &filename, std::string &encoding, uint32_t offset /* = 0 */)
-{
-  CXBMCTinyXML xmlDoc;
-  if (!xmlDoc.LoadFile(filename))
-  {
-    CLog::Log(LOGDEBUG, "unable to load %s: %s at line %d", filename.c_str(), xmlDoc.ErrorDesc(), xmlDoc.ErrorRow());
-    return false;
-  }
-
-  TiXmlElement* pRootElement = xmlDoc.RootElement();
-  if (!pRootElement || pRootElement->NoChildren() ||
-       pRootElement->ValueStr()!="strings")
-  {
-    CLog::Log(LOGERROR, "%s Doesn't contain <strings>", filename.c_str());
-    return false;
-  }
-
-  const TiXmlElement *pChild = pRootElement->FirstChildElement("string");
-  while (pChild)
-  {
-    // Load old style language file with id as attribute
-    const char* attrId=pChild->Attribute("id");
-    if (attrId && !pChild->NoChildren())
-    {
-      uint32_t id = atoi(attrId) + offset;
-      if (m_strings.find(id) == m_strings.end())
-        m_strings[id].strTranslated = pChild->FirstChild()->Value();
-    }
-    pChild = pChild->NextSiblingElement("string");
-  }
   return true;
 }
 
@@ -203,17 +232,17 @@ bool CLocalizeStrings::Load(const std::string& strPathName, const std::string& s
   CSingleLock lock(m_critSection);
   Clear();
 
-  if (!LoadStr2Mem(strPathName, strLanguage, encoding))
+  if (!LoadStr2Mem(strPathName, strLanguage, m_strings, encoding))
   {
     // try loading the fallback
-    if (!bLoadFallback || !LoadStr2Mem(strPathName, LANGUAGE_DEFAULT, encoding))
+    if (!bLoadFallback || !LoadStr2Mem(strPathName, LANGUAGE_DEFAULT, m_strings, encoding))
       return false;
 
     bLoadFallback = false;
   }
 
   if (bLoadFallback)
-    LoadStr2Mem(strPathName, LANGUAGE_DEFAULT, encoding);
+    LoadStr2Mem(strPathName, LANGUAGE_DEFAULT, m_strings, encoding);
 
   // fill in the constant strings
   m_strings[20022].strTranslated = "";

--- a/xbmc/guilib/LocalizeStrings.cpp
+++ b/xbmc/guilib/LocalizeStrings.cpp
@@ -186,16 +186,6 @@ CLocalizeStrings::~CLocalizeStrings(void)
 
 }
 
-std::string CLocalizeStrings::ToUTF8(const std::string& strEncoding, const std::string& str)
-{
-  if (strEncoding.empty())
-    return str;
-
-  std::string ret;
-  g_charsetConverter.ToUtf8(strEncoding, str, ret);
-  return ret;
-}
-
 void CLocalizeStrings::ClearSkinStrings()
 {
   // clear the skin strings

--- a/xbmc/guilib/LocalizeStrings.h
+++ b/xbmc/guilib/LocalizeStrings.h
@@ -29,6 +29,7 @@
  */
 
 #include "threads/CriticalSection.h"
+#include "threads/SharedSection.h"
 
 #include <map>
 #include <string>
@@ -56,8 +57,10 @@ public:
   virtual ~CLocalizeStrings(void);
   bool Load(const std::string& strPathName, const std::string& strLanguage);
   bool LoadSkinStrings(const std::string& path, const std::string& language);
+  bool LoadAddonStrings(const std::string& path, const std::string& language, const std::string& addonId);
   void ClearSkinStrings();
   const std::string& Get(uint32_t code) const;
+  std::string GetAddonString(const std::string& addonId, uint32_t code);
   void Clear();
 
 protected:
@@ -65,10 +68,12 @@ protected:
 
   static std::string ToUTF8(const std::string &encoding, const std::string &str);
   std::map<uint32_t, LocStr> m_strings;
+  std::map<std::string, std::map<uint32_t, LocStr>> m_addonStrings;
   typedef std::map<uint32_t, LocStr>::const_iterator ciStrings;
   typedef std::map<uint32_t, LocStr>::iterator       iStrings;
 
   CCriticalSection m_critSection;
+  CSharedSection m_addonStringsMutex;
 };
 
 /*!

--- a/xbmc/guilib/LocalizeStrings.h
+++ b/xbmc/guilib/LocalizeStrings.h
@@ -71,7 +71,7 @@ protected:
   typedef std::map<uint32_t, LocStr>::const_iterator ciStrings;
   typedef std::map<uint32_t, LocStr>::iterator       iStrings;
 
-  CCriticalSection m_critSection;
+  CSharedSection m_stringsMutex;
   CSharedSection m_addonStringsMutex;
 };
 

--- a/xbmc/guilib/LocalizeStrings.h
+++ b/xbmc/guilib/LocalizeStrings.h
@@ -63,37 +63,6 @@ public:
 protected:
   void Clear(uint32_t start, uint32_t end);
 
-  /*! \brief Loads language ids and strings to memory map m_strings.
-   * It tries to load a strings.po file first. If doesn't exist, it loads a strings.xml file instead.
-   \param pathname The directory name, where we look for the strings file.
-   \param language We load the strings for this language. Fallback language is always English.
-   \param encoding Encoding of the strings. For PO files we only use utf-8.
-   \param offset An offset value to place strings from the id value.
-   \return false if no strings.po or strings.xml file was loaded.
-   */
-  bool LoadStr2Mem(const std::string &pathname, const std::string &language,
-                   std::string &encoding, uint32_t offset = 0);
-
-  /*! \brief Tries to load ids and strings from a strings.po file to m_strings map.
-   * It should only be called from the LoadStr2Mem function to have a fallback.
-   \param pathname The directory name, where we look for the strings file.
-   \param encoding Encoding of the strings. For PO files we only use utf-8.
-   \param offset An offset value to place strings from the id value.
-   \param bSourceLanguage If we are loading the source English strings.po.
-   \return false if no strings.po file was loaded.
-   */
-  bool LoadPO(const std::string &filename, std::string &encoding, uint32_t offset = 0,
-              bool bSourceLanguage = false);
-
-  /*! \brief Tries to load ids and strings from a strings.xml file to m_strings map.
-   * It should only be called from the LoadStr2Mem function to try a PO file first.
-   \param pathname The directory name, where we look for the strings file.
-   \param encoding Encoding of the strings.
-   \param offset An offset value to place strings from the id value.
-   \return false if no strings.xml file was loaded.
-   */
-  bool LoadXML(const std::string &filename, std::string &encoding, uint32_t offset = 0);
-
   static std::string ToUTF8(const std::string &encoding, const std::string &str);
   std::map<uint32_t, LocStr> m_strings;
   typedef std::map<uint32_t, LocStr>::const_iterator ciStrings;

--- a/xbmc/guilib/LocalizeStrings.h
+++ b/xbmc/guilib/LocalizeStrings.h
@@ -66,7 +66,6 @@ public:
 protected:
   void Clear(uint32_t start, uint32_t end);
 
-  static std::string ToUTF8(const std::string &encoding, const std::string &str);
   std::map<uint32_t, LocStr> m_strings;
   std::map<std::string, std::map<uint32_t, LocStr>> m_addonStrings;
   typedef std::map<uint32_t, LocStr>::const_iterator ciStrings;

--- a/xbmc/interfaces/legacy/Addon.cpp
+++ b/xbmc/interfaces/legacy/Addon.cpp
@@ -63,7 +63,7 @@ namespace XBMCAddon
 
     String Addon::getLocalizedString(int id)
     {
-      return pAddon->GetString(id);
+      return g_localizeStrings.GetAddonString(pAddon->ID(), id);
     }
 
     String Addon::getSetting(const char* id)

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -937,7 +937,7 @@ void CPVRClients::ProcessMenuHooks(int iClientID, PVR_MENUHOOK_CAT cat, const CF
     for (unsigned int i = 0; i < hooks->size(); i++)
       if (hooks->at(i).category == cat || hooks->at(i).category == PVR_MENUHOOK_ALL)
       {
-        pDialog->Add(client->GetString(hooks->at(i).iLocalizedStringId));
+        pDialog->Add(g_localizeStrings.GetAddonString(client->ID(), hooks->at(i).iLocalizedStringId));
         hookIDs.push_back(i);
       }
     if (hookIDs.size() > 1)

--- a/xbmc/settings/dialogs/GUIDialogAudioDSPManager.cpp
+++ b/xbmc/settings/dialogs/GUIDialogAudioDSPManager.cpp
@@ -563,7 +563,7 @@ bool CGUIDialogAudioDSPManager::OnContextButton(int itemNumber, CONTEXT_BUTTON b
     {
       CGUIDialogTextViewer* pDlgInfo = (CGUIDialogTextViewer*)g_windowManager.GetWindow(WINDOW_DIALOG_TEXT_VIEWER);
       pDlgInfo->SetHeading(g_localizeStrings.Get(15062) + " - " + pItem->GetProperty("Name").asString());
-      pDlgInfo->SetText(addon->GetString((uint32_t)pItem->GetProperty("Help").asInteger()));
+      pDlgInfo->SetText(g_localizeStrings.GetAddonString(addon->ID(), (uint32_t)pItem->GetProperty("Help").asInteger()));
       pDlgInfo->Open();
     }
   }
@@ -970,12 +970,12 @@ CFileItem *CGUIDialogAudioDSPManager::helper_CreateModeListItem(CActiveAEDSPMode
     return pItem;
   }
 
-  std::string modeName = addon->GetString(ModePointer->ModeName());
+  std::string modeName = g_localizeStrings.GetAddonString(addon->ID(), ModePointer->ModeName());
 
   std::string description;
   if (ModePointer->ModeDescription() > -1)
   {
-    description = addon->GetString(ModePointer->ModeDescription());
+    description = g_localizeStrings.GetAddonString(addon->ID(), ModePointer->ModeDescription());
   }
   else
   {
@@ -1066,7 +1066,7 @@ int CGUIDialogAudioDSPManager::helper_GetDialogId(CActiveAEDSPModePtr &ModePoint
     if (dialogId == 0)
       CLog::Log(LOGERROR, "DSP Dialog Manager - %s - Present marked settings dialog of mode %s on addon %s not found",
                             __FUNCTION__,
-                            Addon->GetString(ModePointer->ModeName()).c_str(),
+                            g_localizeStrings.GetAddonString(Addon->ID(), ModePointer->ModeName()).c_str(),
                             AddonName.c_str());
   }
 

--- a/xbmc/settings/dialogs/GUIDialogAudioDSPSettings.cpp
+++ b/xbmc/settings/dialogs/GUIDialogAudioDSPSettings.cpp
@@ -507,7 +507,7 @@ void CGUIDialogAudioDSPSettings::InitializeSettings()
       }
       else if (CActiveAEDSP::GetInstance().GetAudioDSPAddon(m_MasterModes[m_streamTypeUsed][i]->AddonID(), addon))
       {
-        m_ModeList.push_back(make_pair(addon->GetString(m_MasterModes[m_streamTypeUsed][i]->ModeName()), modeId));
+        m_ModeList.push_back(make_pair(g_localizeStrings.GetAddonString(addon->ID(), m_MasterModes[m_streamTypeUsed][i]->ModeName()), modeId));
         if (!AddonMasterModeSetupPresent)
           AddonMasterModeSetupPresent = m_MasterModes[m_streamTypeUsed][i]->HasSettingsDialog();
       }
@@ -760,7 +760,7 @@ void CGUIDialogAudioDSPSettings::InitializeSettings()
             break;
           case AE_DSP_MODE_TYPE_MASTER_PROCESS:
             group = AddGroup(category, 15084, -1, true, true);
-            label = addon->GetString(m_ActiveModes[i]->ModeName());
+            label = g_localizeStrings.GetAddonString(addon->ID(), m_ActiveModes[i]->ModeName());
             break;
           case AE_DSP_MODE_TYPE_PRE_PROCESS:
             if (!foundPreProcess)
@@ -768,7 +768,7 @@ void CGUIDialogAudioDSPSettings::InitializeSettings()
               foundPreProcess = true;
               group = AddGroup(category, 15085, -1, true, true);
             }
-            label = addon->GetString(m_ActiveModes[i]->ModeName());
+            label = g_localizeStrings.GetAddonString(addon->ID(), m_ActiveModes[i]->ModeName());
             break;
           case AE_DSP_MODE_TYPE_POST_PROCESS:
             if (!foundPostProcess)
@@ -776,11 +776,11 @@ void CGUIDialogAudioDSPSettings::InitializeSettings()
               foundPostProcess = true;
               group = AddGroup(category, 15086, -1, true, true);
             }
-            label = addon->GetString(m_ActiveModes[i]->ModeName());
+            label = g_localizeStrings.GetAddonString(addon->ID(), m_ActiveModes[i]->ModeName());
             break;
           default:
           {
-            label += addon->GetString(m_ActiveModes[i]->ModeName());
+            label += g_localizeStrings.GetAddonString(addon->ID(), m_ActiveModes[i]->ModeName());
             label += " - ";
             label += addon->GetFriendlyName();
           }
@@ -919,7 +919,7 @@ std::string CGUIDialogAudioDSPSettings::GetSettingsLabel(CSetting *pSetting)
         ptr = strtol(settingId.substr(19).c_str(), NULL, 0);
 
       if (ptr >= 0 && CActiveAEDSP::GetInstance().GetAudioDSPAddon(m_Menus[ptr].addonId, addon))
-        return addon->GetString(m_Menus[ptr].hook.iLocalizedStringId);
+        return g_localizeStrings.GetAddonString(addon->ID(), m_Menus[ptr].hook.iLocalizedStringId);
     }
   }
 
@@ -959,7 +959,7 @@ void CGUIDialogAudioDSPSettings::GetAudioDSPMenus(CSettingGroup *group, AE_DSP_M
     AE_DSP_ADDON addon;
     if (CActiveAEDSP::GetInstance().GetAudioDSPAddon(m_Menus[i].addonId, addon) && category == m_Menus[i].hook.category)
     {
-      std::string modeName = addon->GetString(m_Menus[i].hook.iLocalizedStringId);
+      std::string modeName = g_localizeStrings.GetAddonString(addon->ID(), m_Menus[i].hook.iLocalizedStringId);
       if (modeName.empty())
         modeName = g_localizeStrings.Get(15041);
 

--- a/xbmc/utils/ScraperParser.cpp
+++ b/xbmc/utils/ScraperParser.cpp
@@ -180,7 +180,7 @@ void CScraperParser::ReplaceBuffers(std::string& strDest)
     std::string strInfo = strDest.substr(iIndex+10, iEnd - iIndex - 10);
     std::string strReplace;
     if (m_scraper)
-      strReplace = m_scraper->GetString(strtol(strInfo.c_str(),NULL,10));
+      strReplace = g_localizeStrings.GetAddonString(m_scraper->ID(), strtol(strInfo.c_str(),NULL,10));
     strDest.replace(strDest.begin()+iIndex,strDest.begin()+iEnd+1,strReplace);
     iIndex += strReplace.length();
   }


### PR DESCRIPTION
Currently strings are cached in the caddon instances. Since most of these instances have a very short lifetime, this causes language files to constantly getting reloaded and destroyed. E.g every time settings are opened, or an addon that uses strings is run, it's reloaded.

This move all language file handling for addons to the global string loader so that they can be loaded only once on startup.
