### PR TITLE
Backport fix context menu for "Add music..." item to remove "Scan to library" option

### DIFF
--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -470,8 +470,11 @@ void CGUIWindowMusicNav::GetContextButtons(int itemNumber, CContextButtons &butt
       // Add the scan button(s)
       if (g_application.IsMusicScanning())
         buttons.Add(CONTEXT_BUTTON_STOP_SCANNING, 13353); // Stop Scanning
-      else if (CProfilesManager::GetInstance().GetCurrentProfile().canWriteDatabases() ||
-               g_passwordManager.bMasterUser)
+      else if (!inPlaylists && !m_vecItems->IsInternetStream() &&
+        !item->IsPath("add") && !item->IsParentFolder() &&
+        !item->IsPlugin() &&
+        !StringUtils::StartsWithNoCase(item->GetPath(), "addons://") &&
+        (CProfilesManager::GetInstance().GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser))
       {
         buttons.Add(CONTEXT_BUTTON_SCAN, 13352);
       }


### PR DESCRIPTION
Backport of #8420 for Jarvis. 

This fixes a bug in music file view, introduced in #8011 with the removeal of CGUIWindowMusicSongs, that incorrectly allows "Scan to library" to appear on context menu for the "Add music.." item just like the other items.
