### PR TITLE
[ApplicationPlayer] - add SetTime and SetTotalTime to ApplicationPlay…

### DIFF
--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -586,6 +586,20 @@ void CApplicationPlayer::SetSubtitleVisible(bool bVisible)
   }
 }
 
+void CApplicationPlayer::SetTime(int64_t time)
+{
+  std::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    return player->SetTime(time);
+}
+
+void CApplicationPlayer::SetTotalTime(int64_t time)
+{
+  std::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    player->SetTotalTime(time);
+}
+
 void CApplicationPlayer::AddSubtitle(const std::string& strSubPath)
 {
   std::shared_ptr<IPlayer> player = GetInternal();

--- a/xbmc/ApplicationPlayer.h
+++ b/xbmc/ApplicationPlayer.h
@@ -72,7 +72,6 @@ public:
   void ClosePlayerGapless(std::string &playername);
   void CreatePlayer(const std::string &player, IPlayerCallback& callback);
   std::string GetCurrentPlayer();
-  std::shared_ptr<IPlayer> GetInternal() const;
   int  GetPlaySpeed() const;
   bool HasPlayer() const;
   PlayBackRet OpenFile(const CFileItem& item, const CPlayerOptions& options);
@@ -181,4 +180,7 @@ public:
   void  SetVolume(float volume);
   bool  SwitchChannel(const PVR::CPVRChannelPtr &channel);
   void  ToFFRW(int iSpeed = 0);
+  
+  protected:
+    std::shared_ptr<IPlayer> GetInternal() const;
 };

--- a/xbmc/ApplicationPlayer.h
+++ b/xbmc/ApplicationPlayer.h
@@ -176,6 +176,8 @@ public:
   void  SetSubtitle(int iStream);
   void  SetSubTitleDelay(float fValue = 0.0f);
   void  SetSubtitleVisible(bool bVisible);
+  void  SetTime(int64_t time);
+  void  SetTotalTime(int64_t time);
   void  SetVolume(float volume);
   bool  SwitchChannel(const PVR::CPVRChannelPtr &channel);
   void  ToFFRW(int iSpeed = 0);

--- a/xbmc/network/AirTunesServer.cpp
+++ b/xbmc/network/AirTunesServer.cpp
@@ -415,11 +415,8 @@ void CAirTunesServer::AudioOutputFunctions::audio_set_progress(void *cls, void *
   duration /= m_sampleRate;
   position /= m_sampleRate;
 
-  if (g_application.m_pPlayer->GetInternal())
-  {
-    g_application.m_pPlayer->GetInternal()->SetTime(position * 1000);
-    g_application.m_pPlayer->GetInternal()->SetTotalTime(duration * 1000);
-  }
+  g_application.m_pPlayer->SetTime(position * 1000);
+  g_application.m_pPlayer->SetTotalTime(duration * 1000);
 }
 
 void CAirTunesServer::SetupRemoteControl()


### PR DESCRIPTION
…er and make use of it in AirTunesServer - gets rid of the direct use of the player object by calling GetInternal on g_application m_pPlayer ... (and its thread safe now).

@FernetMenta that?
