### PR TITLE
Fix Http server default port on all platforms

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2103,6 +2103,9 @@
             <step>1</step>
             <maximum>65535</maximum>
           </constraints>
+          <updates>
+            <update type="change" />
+          </updates>
           <control type="edit" format="integer" />
         </setting>
         <setting id="services.webserverusername" type="string" parent="services.webserver" label="1048" help="36330">

--- a/xbmc/network/NetworkServices.cpp
+++ b/xbmc/network/NetworkServices.cpp
@@ -455,6 +455,13 @@ bool CNetworkServices::OnSettingUpdate(CSetting* &setting, const char *oldSettin
         !CSettings::GetInstance().GetString(CSettings::SETTING_SERVICES_WEBSERVERPASSWORD).empty())
       return true;
   }
+  if (settingId == CSettings::SETTING_SERVICES_WEBSERVERPORT)
+  {
+    // if webserverport is default but webserver is activated then treat it as altered
+    // and don't change the port to new value
+    if (CSettings::GetInstance().GetBool(CSettings::SETTING_SERVICES_WEBSERVER))
+      return true;
+  }
   return false;
 }
 

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -906,11 +906,6 @@ void CSettings::InitializeDefaults()
 
   if (g_application.IsStandAlone())
     ((CSettingInt*)m_settingsManager->GetSetting(CSettings::SETTING_POWERMANAGEMENT_SHUTDOWNSTATE))->SetDefault(POWERSTATE_SHUTDOWN);
-
-#if defined(HAS_WEB_SERVER)
-  if (CUtil::CanBindPrivileged())
-    ((CSettingInt*)m_settingsManager->GetSetting(CSettings::SETTING_SERVICES_WEBSERVERPORT))->SetDefault(80);
-#endif
 }
 
 void CSettings::InitializeOptionFillers()


### PR DESCRIPTION
Use 8080 from default settings.xml

@Montellese and surely other.

This brings Kodi on par with what the Wiki says : http://kodi.wiki/index.php?title=Windows_FAQ

Another solution would be to keep 8080 for all platforms but I have no history of the choices about port numbers.

Should be backported to Jarvis obviously
