### PR TITLE
[PVR] Fix 'dancing' OSD progress bar while switching channels.

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -2300,15 +2300,14 @@ bool CGUIInfoManager::GetInt(int &value, int info, int contextWindow, const CGUI
           switch( info )
           {
           case PLAYER_PROGRESS:
-            if (IsPlayerChannelPreviewActive())
             {
-              CEpgInfoTagPtr tag(GetEpgInfoTag());
+              const CEpgInfoTagPtr tag(GetEpgInfoTag());
               if (tag)
-                value = tag->ProgressPercentage();
+                value = static_cast<int>(tag->ProgressPercentage());
+              else
+                value = static_cast<int>(g_application.GetPercentage());
+              break;
             }
-            else
-              value = (int)(g_application.GetPercentage());
-            break;
           case PLAYER_PROGRESS_CACHE:
             value = (int)(g_application.GetCachePercentage());
             break;


### PR DESCRIPTION
Problem reported here: http://forum.kodi.tv/showthread.php?tid=255057

PVR Manager reports the new channel as playing (in my setup) roughly a second before VideoPlayer actually starts playing the new channel (due to caching VideoPlayer does before playing, I guess). During this time <code>IsPlayerPreviewActive</code> returns false and therefore progress for the old channel reported by <code>g_application.GetPercentage()</code> is drawn in the OSD, resulting in the "dancing" progressbar reported in the forum. 

@xhaggi mind taking a look
