### PR TITLE
[PVR] Fix 'dancing' OSD progress bar while switching channels.

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -2295,15 +2295,14 @@ bool CGUIInfoManager::GetInt(int &value, int info, int contextWindow, const CGUI
           switch( info )
           {
           case PLAYER_PROGRESS:
-            if (IsPlayerChannelPreviewActive())
             {
-              CEpgInfoTagPtr tag(GetEpgInfoTag());
+              const CEpgInfoTagPtr tag(GetEpgInfoTag());
               if (tag)
-                value = tag->ProgressPercentage();
+                value = static_cast<int>(tag->ProgressPercentage());
+              else
+                value = static_cast<int>(g_application.GetPercentage());
+              break;
             }
-            else
-              value = (int)(g_application.GetPercentage());
-            break;
           case PLAYER_PROGRESS_CACHE:
             value = (int)(g_application.GetCachePercentage());
             break;


### PR DESCRIPTION
Problem reported here: http://forum.kodi.tv/showthread.php?tid=255057

backport of #8844

@xhaggi mind taking a look
