### PR TITLE
[guiinfo] fix content types for plugins

### DIFF
--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -349,7 +349,8 @@ bool CGUIWindowMusicNav::GetDirectory(const std::string &strDirectory, CFileItem
     items.SetContent("plugins");
   else if (items.IsAddonsPath())
     items.SetContent("addons");
-  else if (!items.IsSourcesPath() && !items.IsVirtualDirectoryRoot() && !items.IsLibraryFolder())
+  else if (!items.IsSourcesPath() && !items.IsVirtualDirectoryRoot() &&
+           !items.IsLibraryFolder() && !items.IsPlugin())
     items.SetContent("files");
 
   return bResult;

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -296,7 +296,7 @@ bool CGUIWindowPictures::GetDirectory(const std::string &strDirectory, CFileItem
   if (items.GetLabel().empty() && m_rootDir.IsSource(items.GetPath(), CMediaSourceSettings::GetInstance().GetSources("pictures"), &label))
     items.SetLabel(label);
 
-  if (items.GetContent().empty() && !items.IsVirtualDirectoryRoot())
+  if (items.GetContent().empty() && !items.IsVirtualDirectoryRoot() && !items.IsPlugin())
     items.SetContent("images");
   return true;
 }

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -511,7 +511,7 @@ void CGUIWindowVideoNav::LoadVideoInfo(CFileItemList &items, CVideoDatabase &dat
   if (content.empty())
   {
     content = database.GetContentForPath(items.GetPath());
-    items.SetContent(content.empty() ? "files" : content);
+    items.SetContent((content.empty() && !items.IsPlugin()) ? "files" : content);
   }
 
   /*


### PR DESCRIPTION
At the moment plugins cannot choose an empty content type because it gets overridden for each window (with "images" for pics, and "files" for music and video)
Since an empty content type seems to be valid (it´s used when there are just virtual nodes in the listing), plugin writers should be able to make use of it.

A nicer solution would probably be to introduce a new content type container.content(nodes) for these instead of an empty content type, but that´s out of scope for this PR.

Since this may break plug-ins to some extent we should probably send a message to all plug-in authors and make them aware of that change (and our content type handling in general).

Would be nice to get some testing since changes in this area often led to regressions in the past.  ( @ronie or @HitcherUK perhaps?)
@xhaggi for code.           
