### PR TITLE
[osx] - fix trac ticket 16508 - xcode cleanup

### DIFF
--- a/Kodi.xcodeproj/project.pbxproj
+++ b/Kodi.xcodeproj/project.pbxproj
@@ -11329,23 +11329,6 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_VERSION = "";
 				GENERATE_PROFILING_CODE = NO;
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					$SRCROOT,
-					xbmc,
-					xbmc/linux,
-					xbmc/osx,
-					xbmc/cores/VideoPlayer,
-					lib,
-					lib/ffmpeg,
-					addons/library.xbmc.addon,
-					$XBMC_DEPENDS/include,
-					$XBMC_DEPENDS/include/libcec,
-					$XBMC_DEPENDS/include/mysql,
-					$XBMC_DEPENDS/include/freetype2,
-					$XBMC_DEPENDS/include/python2.7,
-					$XBMC_DEPENDS/include/libxml2,
-				);
 				INFOPLIST_FILE = $SRCROOT/xbmc/platform/darwin/osx/Info.plist;
 				INSTALL_PATH = /usr/local/bin;
 				LIBRARY_SEARCH_PATHS = (
@@ -11388,23 +11371,6 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_UNROLL_LOOPS = YES;
 				GCC_VERSION = "";
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					$SRCROOT,
-					xbmc,
-					xbmc/linux,
-					xbmc/osx,
-					xbmc/cores/VideoPlayer,
-					lib,
-					lib/ffmpeg,
-					addons/library.xbmc.addon,
-					$XBMC_DEPENDS/include,
-					$XBMC_DEPENDS/include/libcec,
-					$XBMC_DEPENDS/include/mysql,
-					$XBMC_DEPENDS/include/freetype2,
-					$XBMC_DEPENDS/include/python2.7,
-					$XBMC_DEPENDS/include/libxml2,
-				);
 				INFOPLIST_FILE = $SRCROOT/xbmc/platform/darwin/osx/Info.plist;
 				INSTALL_PATH = /usr/local/bin;
 				LIBRARY_SEARCH_PATHS = (
@@ -11496,22 +11462,6 @@
 					"\"$(SDKROOT)$(SYSTEM_LIBRARY_DIR)/PrivateFrameworks\"",
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu99;
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					$SRCROOT,
-					xbmc,
-					xbmc/linux,
-					xbmc/osx,
-					xbmc/cores/VideoPlayer,
-					lib,
-					addons/library.xbmc.addon,
-					$XBMC_DEPENDS/include,
-					$XBMC_DEPENDS/include/libcec,
-					$XBMC_DEPENDS/include/mysql,
-					$XBMC_DEPENDS/include/freetype2,
-					$XBMC_DEPENDS/include/python2.7,
-					$XBMC_DEPENDS/include/libxml2,
-				);
 				INFOPLIST_FILE = "$(SRCROOT)/xbmc/platform/darwin/ios/Info.plist";
 				INSTALL_PATH = "$(HOME)/Library/Bundles";
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -11537,22 +11487,6 @@
 					"\"$(SDKROOT)$(SYSTEM_LIBRARY_DIR)/PrivateFrameworks\"",
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu99;
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					$SRCROOT,
-					xbmc,
-					xbmc/linux,
-					xbmc/osx,
-					xbmc/cores/VideoPlayer,
-					lib,
-					addons/library.xbmc.addon,
-					$XBMC_DEPENDS/include,
-					$XBMC_DEPENDS/include/libcec,
-					$XBMC_DEPENDS/include/mysql,
-					$XBMC_DEPENDS/include/freetype2,
-					$XBMC_DEPENDS/include/python2.7,
-					$XBMC_DEPENDS/include/libxml2,
-				);
 				INFOPLIST_FILE = "$(SRCROOT)/xbmc/platform/darwin/ios/Info.plist";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/Kodi.xcodeproj/project.pbxproj
+++ b/Kodi.xcodeproj/project.pbxproj
@@ -11346,7 +11346,7 @@
 					$XBMC_DEPENDS/include/python2.7,
 					$XBMC_DEPENDS/include/libxml2,
 				);
-				INFOPLIST_FILE = $SRCROOT/xbmc/osx/Info.plist;
+				INFOPLIST_FILE = $SRCROOT/xbmc/platform/darwin/osx/Info.plist;
 				INSTALL_PATH = /usr/local/bin;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
@@ -11405,7 +11405,7 @@
 					$XBMC_DEPENDS/include/python2.7,
 					$XBMC_DEPENDS/include/libxml2,
 				);
-				INFOPLIST_FILE = $SRCROOT/xbmc/osx/Info.plist;
+				INFOPLIST_FILE = $SRCROOT/xbmc/platform/darwin/osx/Info.plist;
 				INSTALL_PATH = /usr/local/bin;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",

--- a/tools/darwin/Configurations/App.xcconfig.in
+++ b/tools/darwin/Configurations/App.xcconfig.in
@@ -20,7 +20,7 @@
 
 XBMC_DEPENDS_ROOT = @DEPENDS_ROOT_FOR_XCODE@
 
-HEADER_SEARCH_PATHS = $(inherited) $SRCROOT xbmc xbmc/linux xbmc/platform xbmc/platform/darwin xbmc/osx xbmc/cores/VideoPlayer lib $XBMC_DEPENDS/include $XBMC_DEPENDS/include/libcec $XBMC_DEPENDS/include/mysql $XBMC_DEPENDS/include/freetype2 $XBMC_DEPENDS/include/python2.7
+HEADER_SEARCH_PATHS = $(inherited) $SRCROOT xbmc xbmc/linux xbmc/cores/VideoPlayer lib addons/library.xbmc.addon $XBMC_DEPENDS/include $XBMC_DEPENDS/include/libcec $XBMC_DEPENDS/include/mysql $XBMC_DEPENDS/include/freetype2 $XBMC_DEPENDS/include/python2.7 $XBMC_DEPENDS/include/libxml2
 
 LIBRARY_SEARCH_PATHS = $(inherited) $(SRCROOT) $(SRCROOT)/xbmc/interfaces/json-rpc "$(SRCROOT)/xbmc/interfaces/python" "$(SRCROOT)/xbmc/interfaces/legacy"
 FRAMEWORK_SEARCH_PATHS = $(inherited) "$(SDKROOT)/System/Library/PrivateFrameworks/" "$(SDKROOT)/System/Library/Frameworks/"

--- a/tools/darwin/Support/copyframeworks-osx.command
+++ b/tools/darwin/Support/copyframeworks-osx.command
@@ -70,7 +70,7 @@ cp -f "$TARGET_BUILD_DIR/$APP_NAME" "$TARGET_BINARY"
 echo "Creating icon"
 iconutil -c icns --output "$TARGET_CONTENTS/Resources/kodi.icns" "$SRCROOT/tools/darwin/packaging/media/osx/icon.iconset"
 
-cp -f "$SRCROOT/xbmc/osx/Info.plist" "$TARGET_CONTENTS/"
+cp -f "$SRCROOT/xbmc/platform/darwin/osx/Info.plist" "$TARGET_CONTENTS/"
 
 # Copy all of XBMC's dylib dependencies and rename their locations to inside the Framework
 echo "Checking $TARGET_BINARY dylib dependencies"

--- a/xbmc/windowing/osx/WinSystemIOS.mm
+++ b/xbmc/windowing/osx/WinSystemIOS.mm
@@ -46,7 +46,7 @@
 #import <OpenGLES/ES2/glext.h>
 #import <QuartzCore/CADisplayLink.h>
 
-#import "ios/XBMCController.h"
+#import "platform/darwin/ios/XBMCController.h"
 #import "platform/darwin/ios/IOSScreenManager.h"
 #include "platform/darwin/DarwinUtils.h"
 #import <dlfcn.h>


### PR DESCRIPTION
This fixes some wrong pathes in the xcode project (leftover from the platform move) - also removes header pathes from the xcode project as we want to use thos from the xcconfig file.
