### PR TITLE
Add keep type for settings updates.

### DIFF
--- a/xbmc/settings/lib/Setting.cpp
+++ b/xbmc/settings/lib/Setting.cpp
@@ -189,6 +189,13 @@ void CSetting::SetEnabled(bool enabled)
   OnSettingPropertyChanged(this, "enabled");
 }
 
+void CSetting::SetChanged(bool changed, bool notify /* = false*/)
+{
+  m_changed = changed;
+  if (notify)
+    OnSettingChanged(this);
+}
+
 bool CSetting::IsVisible() const
 {
   if (!ISetting::IsVisible())

--- a/xbmc/settings/lib/Setting.h
+++ b/xbmc/settings/lib/Setting.h
@@ -96,6 +96,7 @@ public:
   void SetHelp(int help) { m_help = help; }
   bool IsEnabled() const;
   void SetEnabled(bool enabled);
+  void SetChanged(bool changed, bool notify = false);
   bool IsDefault() const { return !m_changed; }
   const std::string& GetParent() const { return m_parentSetting; }
   void SetParent(const std::string& parentSetting) { m_parentSetting = parentSetting; }

--- a/xbmc/settings/lib/SettingUpdate.cpp
+++ b/xbmc/settings/lib/SettingUpdate.cpp
@@ -69,6 +69,8 @@ bool CSettingUpdate::setType(const std::string &type)
     m_type = SettingUpdateTypeChange;
   else if (StringUtils::EqualsNoCase(type, "rename"))
     m_type = SettingUpdateTypeRename;
+  else if (StringUtils::EqualsNoCase(type, "keep"))
+    m_type = SettingUpdateTypeKeep;
   else
     return false;
 

--- a/xbmc/settings/lib/SettingUpdate.h
+++ b/xbmc/settings/lib/SettingUpdate.h
@@ -26,7 +26,8 @@ class TiXmlNode;
 typedef enum {
   SettingUpdateTypeNone   = 0,
   SettingUpdateTypeRename,
-  SettingUpdateTypeChange
+  SettingUpdateTypeChange,
+  SettingUpdateTypeKeep
 } SettingUpdateType;
 
 class CSettingUpdate

--- a/xbmc/settings/lib/SettingsManager.cpp
+++ b/xbmc/settings/lib/SettingsManager.cpp
@@ -1020,6 +1020,10 @@ bool CSettingsManager::UpdateSetting(const TiXmlNode *node, CSetting *setting, c
   bool updated = false;
   const char *oldSetting = NULL;
   const TiXmlNode *oldSettingNode = NULL;
+  if (update.GetType() == SettingUpdateTypeKeep) {
+    setting->SetChanged(true);
+    return true;
+  }
   if (update.GetType() == SettingUpdateTypeRename)
   {
     if (update.GetValue().empty())


### PR DESCRIPTION
Allow previous default value to be kept with default flag removed, while still allowing new value for fresh install and new users.

Follow up from discussion on https://github.com/xbmc/xbmc/pull/8843

@Montellese for review : Not sure you'll want me to keep the notify param, I added it for possible future usage and cleaner code but can remove if you want.
