### PR TITLE
rename MediaTypes helper class to CMediaTypes

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -2930,7 +2930,7 @@ std::string CFileItem::GetBaseMoviePath(bool bUseFolderNames) const
 
   if (bUseFolderNames &&
      (!m_bIsFolder || URIUtils::IsInArchive(m_strPath) ||
-     (HasVideoInfoTag() && GetVideoInfoTag()->m_iDbId > 0 && !MediaTypes::IsContainer(GetVideoInfoTag()->m_type))))
+     (HasVideoInfoTag() && GetVideoInfoTag()->m_iDbId > 0 && !CMediaTypes::IsContainer(GetVideoInfoTag()->m_type))))
   {
     std::string name2(strMovieName);
     URIUtils::GetParentPath(name2,strMovieName);

--- a/xbmc/filesystem/SmartPlaylistDirectory.cpp
+++ b/xbmc/filesystem/SmartPlaylistDirectory.cpp
@@ -102,7 +102,7 @@ namespace XFILE
       CVideoDatabase db;
       if (db.Open())
       {
-        MediaType mediaType = MediaTypes::FromString(playlist.GetType());
+        MediaType mediaType = CMediaTypes::FromString(playlist.GetType());
 
         std::string baseDir = strBaseDir;
         if (strBaseDir.empty())
@@ -161,7 +161,7 @@ namespace XFILE
         if (playlist.GetType() == "mixed" || playlist.GetType().empty())
           plist.SetType("songs");
 
-        MediaType mediaType = MediaTypes::FromString(plist.GetType());
+        MediaType mediaType = CMediaTypes::FromString(plist.GetType());
 
         std::string baseDir = strBaseDir;
         if (strBaseDir.empty())

--- a/xbmc/interfaces/json-rpc/AudioLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/AudioLibrary.cpp
@@ -730,9 +730,9 @@ JSONRPC_STATUS CAudioLibrary::GetAdditionalDetails(const CVariant &parameterObje
     return OK;
 
   CMusicDatabase musicdb;
-  if (MediaTypes::IsMediaType(items.GetContent(), MediaTypeAlbum))
+  if (CMediaTypes::IsMediaType(items.GetContent(), MediaTypeAlbum))
     return GetAdditionalAlbumDetails(parameterObject, items, musicdb);
-  else if (MediaTypes::IsMediaType(items.GetContent(), MediaTypeSong))
+  else if (CMediaTypes::IsMediaType(items.GetContent(), MediaTypeSong))
     return GetAdditionalSongDetails(parameterObject, items, musicdb);
 
   return OK;

--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -408,7 +408,7 @@ namespace XBMCAddon
             item->GetVideoInfoTag()->m_dateAdded.SetFromDBDateTime(value.c_str());
           else if (key == "mediatype")
           {
-            if (MediaTypes::IsValidMediaType(value))
+            if (CMediaTypes::IsValidMediaType(value))
               item->GetVideoInfoTag()->m_type = value;
             else
               CLog::Log(LOGWARNING, "Invalid media type \"%s\"", value.c_str());

--- a/xbmc/media/MediaType.cpp
+++ b/xbmc/media/MediaType.cpp
@@ -25,34 +25,33 @@
 #include "guilib/LocalizeStrings.h"
 #include "utils/StringUtils.h"
 
-
-static std::map<std::string, MediaTypes::MediaTypeInfo> fillDefaultMediaTypes()
+static std::map<std::string, CMediaTypes::MediaTypeInfo> fillDefaultMediaTypes()
 {
-  std::map<std::string, MediaTypes::MediaTypeInfo> mediaTypes;
+  std::map<std::string, CMediaTypes::MediaTypeInfo> mediaTypes;
 
-  mediaTypes.insert(std::make_pair(MediaTypeMusic,            MediaTypes::MediaTypeInfo(MediaTypeMusic,           MediaTypeMusic,               true,  36914, 36915,   249,   249)));
-  mediaTypes.insert(std::make_pair(MediaTypeArtist,           MediaTypes::MediaTypeInfo(MediaTypeArtist,          MediaTypeArtist "s",          true,  36916, 36917,   557,   133)));
-  mediaTypes.insert(std::make_pair(MediaTypeAlbum,            MediaTypes::MediaTypeInfo(MediaTypeAlbum,           MediaTypeAlbum "s",           true,  36918, 36919,   558,   132)));
-  mediaTypes.insert(std::make_pair(MediaTypeSong,             MediaTypes::MediaTypeInfo(MediaTypeSong,            MediaTypeSong "s",            false, 36920, 36921,   172,   134)));
-  mediaTypes.insert(std::make_pair(MediaTypeVideo,            MediaTypes::MediaTypeInfo(MediaTypeVideo,           MediaTypeVideo "s",           true,  36912, 36913,   291,     3)));
-  mediaTypes.insert(std::make_pair(MediaTypeVideoCollection,  MediaTypes::MediaTypeInfo(MediaTypeVideoCollection, MediaTypeVideoCollection "s", true,  36910, 36911, 20141, 20434)));
-  mediaTypes.insert(std::make_pair(MediaTypeMusicVideo,       MediaTypes::MediaTypeInfo(MediaTypeMusicVideo,      MediaTypeMusicVideo "s",      false, 36908, 36909, 20391, 20389)));
-  mediaTypes.insert(std::make_pair(MediaTypeMovie,            MediaTypes::MediaTypeInfo(MediaTypeMovie,           MediaTypeMovie "s",           false, 36900, 36901, 20338, 20342)));
-  mediaTypes.insert(std::make_pair(MediaTypeTvShow,           MediaTypes::MediaTypeInfo(MediaTypeTvShow,          MediaTypeTvShow "s",          true,  36902, 36903, 36902, 36903)));
-  mediaTypes.insert(std::make_pair(MediaTypeSeason,           MediaTypes::MediaTypeInfo(MediaTypeSeason,          MediaTypeSeason "s",          true,  36904, 36905, 20373, 33054)));
-  mediaTypes.insert(std::make_pair(MediaTypeEpisode,          MediaTypes::MediaTypeInfo(MediaTypeEpisode,         MediaTypeEpisode "s",         false, 36906, 36907, 20359, 20360)));
+  mediaTypes.insert(std::make_pair(MediaTypeMusic,            CMediaTypes::MediaTypeInfo(MediaTypeMusic,           MediaTypeMusic,               true,  36914, 36915,   249,   249)));
+  mediaTypes.insert(std::make_pair(MediaTypeArtist,           CMediaTypes::MediaTypeInfo(MediaTypeArtist,          MediaTypeArtist "s",          true,  36916, 36917,   557,   133)));
+  mediaTypes.insert(std::make_pair(MediaTypeAlbum,            CMediaTypes::MediaTypeInfo(MediaTypeAlbum,           MediaTypeAlbum "s",           true,  36918, 36919,   558,   132)));
+  mediaTypes.insert(std::make_pair(MediaTypeSong,             CMediaTypes::MediaTypeInfo(MediaTypeSong,            MediaTypeSong "s",            false, 36920, 36921,   172,   134)));
+  mediaTypes.insert(std::make_pair(MediaTypeVideo,            CMediaTypes::MediaTypeInfo(MediaTypeVideo,           MediaTypeVideo "s",           true,  36912, 36913,   291,     3)));
+  mediaTypes.insert(std::make_pair(MediaTypeVideoCollection,  CMediaTypes::MediaTypeInfo(MediaTypeVideoCollection, MediaTypeVideoCollection "s", true,  36910, 36911, 20141, 20434)));
+  mediaTypes.insert(std::make_pair(MediaTypeMusicVideo,       CMediaTypes::MediaTypeInfo(MediaTypeMusicVideo,      MediaTypeMusicVideo "s",      false, 36908, 36909, 20391, 20389)));
+  mediaTypes.insert(std::make_pair(MediaTypeMovie,            CMediaTypes::MediaTypeInfo(MediaTypeMovie,           MediaTypeMovie "s",           false, 36900, 36901, 20338, 20342)));
+  mediaTypes.insert(std::make_pair(MediaTypeTvShow,           CMediaTypes::MediaTypeInfo(MediaTypeTvShow,          MediaTypeTvShow "s",          true,  36902, 36903, 36902, 36903)));
+  mediaTypes.insert(std::make_pair(MediaTypeSeason,           CMediaTypes::MediaTypeInfo(MediaTypeSeason,          MediaTypeSeason "s",          true,  36904, 36905, 20373, 33054)));
+  mediaTypes.insert(std::make_pair(MediaTypeEpisode,          CMediaTypes::MediaTypeInfo(MediaTypeEpisode,         MediaTypeEpisode "s",         false, 36906, 36907, 20359, 20360)));
 
   return mediaTypes;
 }
 
-std::map<std::string, MediaTypes::MediaTypeInfo> MediaTypes::m_mediaTypes = fillDefaultMediaTypes();
+std::map<std::string, CMediaTypes::MediaTypeInfo> CMediaTypes::m_mediaTypes = fillDefaultMediaTypes();
 
-bool MediaTypes::IsValidMediaType(const MediaType &mediaType)
+bool CMediaTypes::IsValidMediaType(const MediaType &mediaType)
 {
   return findMediaType(mediaType) != m_mediaTypes.end();
 }
 
-bool MediaTypes::IsMediaType(const std::string &strMediaType, const MediaType &mediaType)
+bool CMediaTypes::IsMediaType(const std::string &strMediaType, const MediaType &mediaType)
 {
   std::map<std::string, MediaTypeInfo>::const_iterator strMediaTypeIt = findMediaType(strMediaType);
   std::map<std::string, MediaTypeInfo>::const_iterator mediaTypeIt = findMediaType(mediaType);
@@ -61,7 +60,7 @@ bool MediaTypes::IsMediaType(const std::string &strMediaType, const MediaType &m
          strMediaTypeIt->first.compare(mediaTypeIt->first) == 0;
 }
 
-MediaType MediaTypes::FromString(const std::string &strMediaType)
+MediaType CMediaTypes::FromString(const std::string &strMediaType)
 {
   std::map<std::string, MediaTypeInfo>::const_iterator mediaTypeIt = findMediaType(strMediaType);
   if (mediaTypeIt == m_mediaTypes.end())
@@ -70,7 +69,7 @@ MediaType MediaTypes::FromString(const std::string &strMediaType)
   return mediaTypeIt->first;
 }
 
-MediaType MediaTypes::ToPlural(const MediaType &mediaType)
+MediaType CMediaTypes::ToPlural(const MediaType &mediaType)
 {
   std::map<std::string, MediaTypeInfo>::const_iterator mediaTypeIt = findMediaType(mediaType);
   if (mediaTypeIt == m_mediaTypes.end())
@@ -79,7 +78,7 @@ MediaType MediaTypes::ToPlural(const MediaType &mediaType)
   return mediaTypeIt->second.plural;
 }
 
-bool MediaTypes::IsContainer(const MediaType &mediaType)
+bool CMediaTypes::IsContainer(const MediaType &mediaType)
 {
   std::map<std::string, MediaTypeInfo>::const_iterator mediaTypeIt = findMediaType(mediaType);
   if (mediaTypeIt == m_mediaTypes.end())
@@ -88,7 +87,7 @@ bool MediaTypes::IsContainer(const MediaType &mediaType)
   return mediaTypeIt->second.container;
 }
 
-std::map<std::string, MediaTypes::MediaTypeInfo>::const_iterator MediaTypes::findMediaType(const std::string &mediaType)
+std::map<std::string, CMediaTypes::MediaTypeInfo>::const_iterator CMediaTypes::findMediaType(const std::string &mediaType)
 {
   std::string strMediaType = mediaType;
   StringUtils::ToLower(strMediaType);
@@ -106,7 +105,7 @@ std::map<std::string, MediaTypes::MediaTypeInfo>::const_iterator MediaTypes::fin
   return m_mediaTypes.end();
 }
 
-std::string MediaTypes::GetLocalization(const MediaType &mediaType)
+std::string CMediaTypes::GetLocalization(const MediaType &mediaType)
 {
   std::map<std::string, MediaTypeInfo>::const_iterator mediaTypeIt = findMediaType(mediaType);
   if (mediaTypeIt == m_mediaTypes.end() ||
@@ -116,7 +115,7 @@ std::string MediaTypes::GetLocalization(const MediaType &mediaType)
   return g_localizeStrings.Get(mediaTypeIt->second.localizationSingular);
 }
 
-std::string MediaTypes::GetPluralLocalization(const MediaType &mediaType)
+std::string CMediaTypes::GetPluralLocalization(const MediaType &mediaType)
 {
   std::map<std::string, MediaTypeInfo>::const_iterator mediaTypeIt = findMediaType(mediaType);
   if (mediaTypeIt == m_mediaTypes.end() ||
@@ -126,7 +125,7 @@ std::string MediaTypes::GetPluralLocalization(const MediaType &mediaType)
   return g_localizeStrings.Get(mediaTypeIt->second.localizationPlural);
 }
 
-std::string MediaTypes::GetCapitalLocalization(const MediaType &mediaType)
+std::string CMediaTypes::GetCapitalLocalization(const MediaType &mediaType)
 {
   std::map<std::string, MediaTypeInfo>::const_iterator mediaTypeIt = findMediaType(mediaType);
   if (mediaTypeIt == m_mediaTypes.end() ||
@@ -136,7 +135,7 @@ std::string MediaTypes::GetCapitalLocalization(const MediaType &mediaType)
   return g_localizeStrings.Get(mediaTypeIt->second.localizationSingularCapital);
 }
 
-std::string MediaTypes::GetCapitalPluralLocalization(const MediaType &mediaType)
+std::string CMediaTypes::GetCapitalPluralLocalization(const MediaType &mediaType)
 {
   std::map<std::string, MediaTypeInfo>::const_iterator mediaTypeIt = findMediaType(mediaType);
   if (mediaTypeIt == m_mediaTypes.end() ||

--- a/xbmc/media/MediaType.h
+++ b/xbmc/media/MediaType.h
@@ -23,7 +23,7 @@
 #include <set>
 #include <string>
 
-typedef std::string MediaType;
+using MediaType = std::string;
 
 #define MediaTypeNone             ""
 #define MediaTypeMusic            "music"
@@ -38,7 +38,7 @@ typedef std::string MediaType;
 #define MediaTypeSeason           "season"
 #define MediaTypeEpisode          "episode"
 
-class MediaTypes
+class CMediaTypes
 {
 public:
   static bool IsValidMediaType(const MediaType &mediaType);

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -904,7 +904,7 @@ std::string CSmartPlaylistRule::FormatWhereClause(const std::string &negate, con
 std::string CSmartPlaylistRule::GetField(int field, const std::string &type) const
 {
   if (field >= FieldUnknown && field < FieldMax)
-    return DatabaseUtils::GetField((Field)field, MediaTypes::FromString(type), DatabaseQueryPartWhere);
+    return DatabaseUtils::GetField((Field)field, CMediaTypes::FromString(type), DatabaseQueryPartWhere);
   return "";
 }
 

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -6189,7 +6189,7 @@ bool CVideoDatabase::GetSortedVideos(const MediaType &mediaType, const std::stri
   else
     return false;
 
-  items.SetContent(MediaTypes::ToPlural(mediaType));
+  items.SetContent(CMediaTypes::ToPlural(mediaType));
   return success;
 }
 

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -351,7 +351,7 @@ void CGUIDialogVideoInfo::SetMovie(const CFileItem *item)
     }
   }
 
-  m_castList->SetContent(MediaTypes::ToPlural(type));
+  m_castList->SetContent(CMediaTypes::ToPlural(type));
 
   CVideoThumbLoader loader;
   loader.LoadItem(m_movieItem.get());
@@ -1851,13 +1851,13 @@ bool CGUIDialogVideoInfo::ManageVideoItemArtwork(const CFileItemPtr &item, const
 
 std::string CGUIDialogVideoInfo::GetLocalizedVideoType(const std::string &strType)
 {
-  if (MediaTypes::IsMediaType(strType, MediaTypeMovie))
+  if (CMediaTypes::IsMediaType(strType, MediaTypeMovie))
     return g_localizeStrings.Get(20342);
-  else if (MediaTypes::IsMediaType(strType, MediaTypeTvShow))
+  else if (CMediaTypes::IsMediaType(strType, MediaTypeTvShow))
     return g_localizeStrings.Get(20343);
-  else if (MediaTypes::IsMediaType(strType, MediaTypeEpisode))
+  else if (CMediaTypes::IsMediaType(strType, MediaTypeEpisode))
     return g_localizeStrings.Get(20359);
-  else if (MediaTypes::IsMediaType(strType, MediaTypeMusicVideo))
+  else if (CMediaTypes::IsMediaType(strType, MediaTypeMusicVideo))
     return g_localizeStrings.Get(20391);
 
   return "";

--- a/xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
+++ b/xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
@@ -233,7 +233,7 @@ bool CVideoLibraryRefreshingJob::Work(CVideoDatabase &db)
     {
       // for a tvshow we need to handle all paths of it
       std::vector<std::string> tvshowPaths;
-      if (MediaTypes::IsMediaType(m_item->GetVideoInfoTag()->m_type, MediaTypeTvShow) && m_refreshAll &&
+      if (CMediaTypes::IsMediaType(m_item->GetVideoInfoTag()->m_type, MediaTypeTvShow) && m_refreshAll &&
           db.GetPathsLinkedToTvShow(m_item->GetVideoInfoTag()->m_iDbId, tvshowPaths))
       {
         for (const auto& tvshowPath : tvshowPaths)


### PR DESCRIPTION
This renames the `MediaTypes` class to `CMediaTypes` to follow our class naming scheme. Purely cosmetic.
