### PR TITLE
videocontrol: don't handle right-click

### DIFF
--- a/xbmc/guilib/GUIVideoControl.cpp
+++ b/xbmc/guilib/GUIVideoControl.cpp
@@ -95,14 +95,6 @@ EVENT_RESULT CGUIVideoControl::OnMouseEvent(const CPoint &point, const CMouseEve
     g_windowManager.SendMessage(message);
     return EVENT_RESULT_HANDLED;
   }
-  else if (event.m_id == ACTION_MOUSE_RIGHT_CLICK)
-  { // toggle the playlist window
-    if (g_windowManager.GetActiveWindow() == WINDOW_VIDEO_PLAYLIST)
-      g_windowManager.PreviousWindow();
-    else
-      g_windowManager.ActivateWindow(WINDOW_VIDEO_PLAYLIST);
-    return EVENT_RESULT_HANDLED;
-  }
   return EVENT_RESULT_UNHANDLED;
 }
 


### PR DESCRIPTION
many skins will display the currently playing video in the background all throughout the skin.

it's currently not possible to navigate through the skin with a mouse during videoplayback,
as a right-click will take you to the videoplaylist instead of the previous window.
you're basically stuck toggling between the current window and the videoplaylist back and forth.
