### PR TITLE
CGUIMediaWindow: properly save item position

### DIFF
--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -79,7 +79,7 @@ void CGUIWindowPictures::OnInitWindow()
     {
       if (wndw && wndw->GetCurrentSlide())
         m_viewControl.SetSelectedItem(wndw->GetCurrentSlide()->GetPath());
-      m_iSelectedItem = m_viewControl.GetSelectedItem();
+      SetMediaSelectedItem(m_vecItems->GetPath(),m_viewControl.GetSelectedItem());
     }
     m_slideShowStarted = false;
   }

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -94,7 +94,6 @@ CGUIMediaWindow::CGUIMediaWindow(int id, const char *xmlFile)
   m_unfilteredItems = new CFileItemList;
   m_vecItems->SetPath("?");
   m_iLastControl = -1;
-  m_iSelectedItem = -1;
   m_canFilterAdvanced = false;
 
   m_guiState.reset(CGUIViewState::GetViewState(GetID(), *m_vecItems));
@@ -229,7 +228,7 @@ bool CGUIMediaWindow::OnMessage(CGUIMessage& message)
   {
   case GUI_MSG_WINDOW_DEINIT:
     {
-      m_iSelectedItem = m_viewControl.GetSelectedItem();
+      SetMediaSelectedItem(m_vecItems->GetPath(), m_viewControl.GetSelectedItem());
       m_iLastControl = GetFocusedControlID();
       CGUIWindow::OnMessage(message);
 
@@ -995,7 +994,7 @@ bool CGUIMediaWindow::OnClick(int iItem, const std::string &player)
 #endif
   else
   {
-    m_iSelectedItem = m_viewControl.GetSelectedItem();
+    SetMediaSelectedItem(m_vecItems->GetPath(), m_viewControl.GetSelectedItem());
 
     if (pItem->GetPath() == "newplaylist://")
     {
@@ -1455,10 +1454,20 @@ void CGUIMediaWindow::OnInitWindow()
 
   m_rootDir.SetAllowThreads(true);
 
-  if (m_iSelectedItem > -1)
-    m_viewControl.SetSelectedItem(m_iSelectedItem);
-
   CGUIWindow::OnInitWindow();
+
+  m_viewControl.SetSelectedItem(GetMediaSelectedItem(m_vecItems->GetPath()));
+}
+
+int CGUIMediaWindow::GetMediaSelectedItem(const std::string& strDirectory)
+{
+  auto it = m_mediaSelectedItems.find(strDirectory);
+  return it != m_mediaSelectedItems.end() ? it->second : 0;
+}
+
+void CGUIMediaWindow::SetMediaSelectedItem(const std::string& strDirectory, int iItem)
+{
+  m_mediaSelectedItems[strDirectory] = iItem;
 }
 
 CGUIControl *CGUIMediaWindow::GetFirstFocusableControl(int id)

--- a/xbmc/windows/GUIMediaWindow.h
+++ b/xbmc/windows/GUIMediaWindow.h
@@ -170,6 +170,16 @@ protected:
    */
   static std::string RemoveParameterFromPath(const std::string &strDirectory, const std::string &strParameter);
 
+  /*! \brief Method to get the last selected item
+  \param strDirectory current Path/URL
+  \return last selected item */
+  int GetMediaSelectedItem(const std::string& strDirectory);
+
+  /*! \brief Method to save the last selected item
+  \param strDirectory current Path/URL
+  \param iItem current selected item */
+  void SetMediaSelectedItem(const std::string& strDirectory, int iItem);
+
   XFILE::CVirtualDirectory m_rootDir;
   CGUIViewControl m_viewControl;
 
@@ -181,7 +191,6 @@ protected:
 
   // save control state on window exit
   int m_iLastControl;
-  int m_iSelectedItem;
   std::string m_startDirectory;
 
   CSmartPlaylist m_filter;
@@ -199,4 +208,7 @@ protected:
    \sa Update
    */
   std::string m_strFilterPath;
+
+ private:
+  std::map<std::string, int> m_mediaSelectedItems;
 };


### PR DESCRIPTION
at moment the value m_i SelectedItem in CGUIMediaWindow is shared between sections videos, tvshows and movies, so if I navigate in tvshows the last selected item will influence also the latest item position of the sections movies and videos

i made some change to specify also the path together with the last selected item

i don't know if in this manner i have broke something else or more in general if you think that the current behavior hasn't any issue

so i opened this PR just for a review
