### PR TITLE
FFmpeg: Bump to 2.8.5-Jarvis-rc1

### DIFF
--- a/tools/depends/target/ffmpeg/FFMPEG-VERSION
+++ b/tools/depends/target/ffmpeg/FFMPEG-VERSION
@@ -1,5 +1,5 @@
 LIBNAME=ffmpeg
 BASE_URL=https://github.com/xbmc/FFmpeg/archive
-VERSION=2.8.4-Jarvis-rc1-mp3
+VERSION=2.8.5-Jarvis-rc1
 ARCHIVE=$(LIBNAME)-$(VERSION).tar.gz
 


### PR DESCRIPTION
This bumps ffmpeg to 2.8.5
One patch was pushed upstreamd.

This release fixes a security flaw with hls streams
