### PR TITLE
Musicinfo interactive scan

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -5091,14 +5091,14 @@ void CApplication::StartMusicScan(const std::string &strDirectory, bool userInit
 }
 
 void CApplication::StartMusicAlbumScan(const std::string& strDirectory,
-                                       bool refresh)
+                                       bool refresh, CGUIDialogProgress* pDialog)
 {
   if (m_musicInfoScanner->IsScanning())
     return;
 
   m_musicInfoScanner->ShowDialog(true);
 
-  m_musicInfoScanner->FetchAlbumInfo(strDirectory,refresh);
+  m_musicInfoScanner->FetchAlbumInfo(strDirectory,refresh,pDialog);
 }
 
 void CApplication::StartMusicArtistScan(const std::string& strDirectory,

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -28,6 +28,8 @@
 #include "utils/GlobalsHandling.h"
 #include "messaging/IMessageTarget.h"
 
+#include "dialogs/GUIDialogProgress.h"
+
 #include <map>
 #include <memory>
 #include <string>
@@ -277,7 +279,7 @@ public:
    \param flags Flags for controlling the scanning process.  See xbmc/music/infoscanner/MusicInfoScanner.h for possible values.
    */
   void StartMusicScan(const std::string &path, bool userInitiated = true, int flags = 0);
-  void StartMusicAlbumScan(const std::string& strDirectory, bool refresh = false);
+  void StartMusicAlbumScan(const std::string& strDirectory, bool refresh = false, CGUIDialogProgress* pDialog = NULL);
   void StartMusicArtistScan(const std::string& strDirectory, bool refresh = false);
 
   void UpdateLibraries();

--- a/xbmc/music/infoscanner/MusicInfoScanner.h
+++ b/xbmc/music/infoscanner/MusicInfoScanner.h
@@ -56,7 +56,7 @@ public:
 
   void Start(const std::string& strDirectory, int flags);
   void StartCleanDatabase();
-  void FetchAlbumInfo(const std::string& strDirectory, bool refresh = false);
+  void FetchAlbumInfo(const std::string& strDirectory, bool refresh = false, CGUIDialogProgress* pDialog = NULL);
   void FetchArtistInfo(const std::string& strDirectory, bool refresh = false);
   bool IsScanning();
   void Stop();
@@ -65,6 +65,9 @@ public:
 
   //! \brief Set whether or not to show a progress dialog
   void ShowDialog(bool show) { m_showDialog = show; }
+
+  //! \brief Check if all albums in database have already been scraped
+  bool CheckAlbumAllScraped();
 
   /*! \brief Categorize FileItems into Albums, Songs, and Artists
    This takes a list of FileItems and turns it into a tree of Albums,
@@ -222,5 +225,6 @@ protected:
   std::set<std::string> m_seenPaths;
   int m_flags;
   CThread m_fileCountReader;
+  CGUIDialogProgress* m_dlgProgress; ///< Progress dialog
 };
 }


### PR DESCRIPTION
This patch combines a few different things:
1. The progress bar display during the Album scan is broken, and this patch is a possible fix
2. The scan type is added as a parameter to the GUI_MSG_SCAN_FINISHED message, allowing the application to trigger different operations after the various scan types.
3. It introduces what I called an "Interactive Scan", when a progress dialog is passed to the StartMusicAlbumScan() function, the library scan will use the same process as the one used when activating the "Refresh" button from the DialogAlbumInfo page, prompting the user to fix the meta data when necessary.

**The way I am using it:**

In my branch I am using this to do three successive scans when updating the library. First the normal, fetch info from files, then a fetch info from the web scan without interactions, and finally if necessary and after a confirmation dialog, I start an interactive scan. I know this is probably not what kodi is supposed to do by default, so I didn't include this in the request, but here is the code I use in CApplication::OnMessage():

```
case GUI_MSG_SCAN_FINISHED:
    // If the scan was a file scan, start an album info scan automatically when completed
    if(message.GetParam1() == 0)
      StartMusicAlbumScan("", true);
    else if(message.GetParam1() == 1)
   {
      CGUIDialogProgress* dlgProgress = (CGUIDialogProgress*)g_windowManager.GetWindow(WINDOW_DIALOG_PROGRESS);
      // Check if all the albums have been scraped
      if(!m_musicInfoScanner->CheckAlbumAllScraped())
      {
          // Ask if we should start an interactive scan
          if(CGUIDialogYesNo::ShowAndGetInput(CVariant{185}, CVariant{39000}, CVariant{""}, CVariant{""}, CVariant{222}, CVariant{186}))
             StartMusicAlbumScan("", false, dlgProgress);
      }
    }
    break;
```
