### PR TITLE
VideoPlayer: gapless playback on stream change

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.h
@@ -104,6 +104,7 @@ protected:
   AVFilterContext* m_pFilterIn;
   AVFilterContext* m_pFilterOut;
   AVFrame*         m_pFilterFrame;
+  bool m_filterEof;
 
   int m_iPictureWidth;
   int m_iPictureHeight;

--- a/xbmc/cores/VideoPlayer/DVDMessageQueue.cpp
+++ b/xbmc/cores/VideoPlayer/DVDMessageQueue.cpp
@@ -29,7 +29,6 @@ CDVDMessageQueue::CDVDMessageQueue(const std::string &owner) : m_hEvent(true), m
   m_iDataSize     = 0;
   m_bAbortRequest = false;
   m_bInitialized = false;
-  m_bCaching = false;
 
   m_TimeBack = DVD_NOPTS_VALUE;
   m_TimeFront = DVD_NOPTS_VALUE;
@@ -157,7 +156,7 @@ MsgQueueReturnCode CDVDMessageQueue::Get(CDVDMsg** pMsg, unsigned int iTimeoutIn
 
   while (!m_bAbortRequest)
   {
-    if (!m_list.empty() && m_list.back().priority >= priority && !m_bCaching)
+    if (!m_list.empty() && m_list.back().priority >= priority)
     {
       DVDMessageListItem& item(m_list.back());
       priority = item.priority;

--- a/xbmc/cores/VideoPlayer/DVDMessageQueue.h
+++ b/xbmc/cores/VideoPlayer/DVDMessageQueue.h
@@ -132,7 +132,6 @@ private:
 
   bool m_bAbortRequest;
   bool m_bInitialized;
-  bool m_bCaching;
 
   int m_iDataSize;
   double m_TimeFront;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -109,7 +109,6 @@ public:
   int source;
   double dts;    // last dts from demuxer, used to find disncontinuities
   double dur;    // last frame expected duration
-  double dts_state; // when did we last send a playback state update
   CDVDStreamInfo hint;   // stream hints, used to notice stream changes
   void* stream; // pointer or integer, identifying stream playing. if it changes stream changed
   int changes; // remembered counter from stream to track codec changes
@@ -137,7 +136,6 @@ public:
     id = -1;
     source = STREAM_SOURCE_NONE;
     dts = DVD_NOPTS_VALUE;
-    dts_state = DVD_NOPTS_VALUE;
     dur = DVD_NOPTS_VALUE;
     hint.Clear();
     stream = NULL;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -124,6 +124,13 @@ public:
   double startpts;
   double lastdts;
 
+  enum
+  {
+    AV_SYNC_NONE,
+    AV_SYNC_CHECK,
+    AV_SYNC_CONT
+  } avsync;
+
   CCurrentStream(StreamType t, int i)
     : type(t)
     , player(i)
@@ -146,6 +153,7 @@ public:
     starttime = DVD_NOPTS_VALUE;
     startpts = DVD_NOPTS_VALUE;
     lastdts = DVD_NOPTS_VALUE;
+    avsync = AV_SYNC_CHECK;
   }
 
   double dts_end()

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
@@ -463,7 +463,7 @@ void CVideoPlayerAudio::OnStartup()
 void CVideoPlayerAudio::UpdatePlayerInfo()
 {
   std::ostringstream s;
-  s << "aq:"     << std::setw(2) << std::min(99,m_messageQueue.GetLevel() + MathUtils::round_int(100.0/8.0*m_dvdAudio.GetCacheTime())) << "%";
+  s << "aq:"     << std::setw(2) << std::min(99,m_messageQueue.GetLevel()) << "%";
   s << ", Kb/s:" << std::fixed << std::setprecision(2) << (double)GetAudioBitrate() / 1024.0;
 
   //print the inverse of the resample ratio, since that makes more sense

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -152,6 +152,8 @@ bool CVideoPlayerVideo::OpenStream( CDVDStreamInfo &hint )
 
 void CVideoPlayerVideo::OpenStream(CDVDStreamInfo &hint, CDVDVideoCodec* codec)
 {
+  CLog::Log(LOGDEBUG, "CVideoPlayerVideo::OpenStream - open stream with codec id: %i", hint.codec);
+
   //reported fps is usually not completely correct
   if (hint.fpsrate && hint.fpsscale)
     m_fFrameRate = DVD_TIME_BASE / CDVDCodecUtils::NormalizeFrameduration((double)DVD_TIME_BASE * hint.fpsscale / hint.fpsrate);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
@@ -531,9 +531,12 @@ void CLinuxRendererGL::Flush()
 
 void CLinuxRendererGL::Update()
 {
-  if (!m_bConfigured) return;
+  if (!m_bConfigured)
+    return;
   ManageDisplay();
   m_scalingMethodGui = (ESCALINGMETHOD)-1;
+
+  ValidateRenderTarget();
 }
 
 void CLinuxRendererGL::RenderUpdate(bool clear, DWORD flags, DWORD alpha)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -413,8 +413,10 @@ void CLinuxRendererGLES::Flush()
 
 void CLinuxRendererGLES::Update()
 {
-  if (!m_bConfigured) return;
+  if (!m_bConfigured)
+    return;
   ManageDisplay();
+  ValidateRenderTarget();
 }
 
 void CLinuxRendererGLES::RenderUpdate(bool clear, DWORD flags, DWORD alpha)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -282,7 +282,7 @@ bool CRenderManager::Configure(DVDVideoPicture& picture, float fps, unsigned fla
   {
     CSingleLock lock(m_presentlock);
     XbmcThreads::EndTime endtime(5000);
-    while(m_presentstep != PRESENT_IDLE && m_presentstep != PRESENT_READY)
+    while (m_presentstep != PRESENT_IDLE)
     {
       if(endtime.IsTimePast())
       {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -307,6 +307,10 @@ bool CRenderManager::Configure(DVDVideoPicture& picture, float fps, unsigned fla
     m_NumberBuffers  = buffers;
     m_renderState = STATE_CONFIGURING;
     m_stateEvent.Reset();
+
+    CSingleLock lock2(m_presentlock);
+    m_presentstep = PRESENT_READY;
+    m_presentevent.notifyAll();
   }
 
   if (!m_stateEvent.WaitMSec(1000))
@@ -400,12 +404,6 @@ bool CRenderManager::IsConfigured() const
     return false;
 }
 
-void CRenderManager::Update()
-{
-  if (m_pRenderer)
-    m_pRenderer->Update();
-}
-
 void CRenderManager::FrameWait(int ms)
 {
   XbmcThreads::EndTime timeout(ms);
@@ -436,6 +434,8 @@ void CRenderManager::FrameMove()
       lock.Leave();
       if (!Configure())
         return;
+
+      FrameWait(50);
 
       if (m_flags & CONF_FLAGS_FULLSCREEN)
       {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
@@ -59,7 +59,6 @@ public:
   // Functions called from render thread
   void GetVideoRect(CRect &source, CRect &dest, CRect &view);
   float GetAspectRatio();
-  void Update();
   void FrameMove();
   void FrameFinish();
   void FrameWait(int ms);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderer.cpp
@@ -218,6 +218,7 @@ bool CWinRenderer::Configure(unsigned int width, unsigned int height, unsigned i
   ManageDisplay();
 
   SelectRenderMethod();
+  ManageTextures();
   m_bConfigured = true;
 
   return true;


### PR DESCRIPTION
this enables gapless video playback for decoders that are capable of drain and allow multiple instances.
credits to @mapfau who has been working with me on this.

@afedchin could you please check dxva if it needs adaption. Configure of renderer now works without an extra cycle
@popcornmix could you please check mmal
