### PR TITLE
[guiinfo] add System.CurrentControlId

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -296,6 +296,7 @@ const infomap system_labels[] =  {{ "hasnetwork",       SYSTEM_ETHERNET_LINK_ACT
                                   { "screenheight",     SYSTEM_SCREEN_HEIGHT },
                                   { "currentwindow",    SYSTEM_CURRENT_WINDOW },
                                   { "currentcontrol",   SYSTEM_CURRENT_CONTROL },
+                                  { "currentcontrolid", SYSTEM_CURRENT_CONTROL_ID },
                                   { "dvdlabel",         SYSTEM_DVD_LABEL },
                                   { "internetstate",    SYSTEM_INTERNET_STATE },
                                   { "osversioninfo",    SYSTEM_OS_VERSION_INFO },
@@ -2104,13 +2105,19 @@ std::string CGUIInfoManager::GetLabel(int info, int contextWindow, std::string *
     strLabel = StringUtils::Format("%i", CSettings::GetInstance().GetInt(CSettings::SETTING_LOOKANDFEEL_STARTUPWINDOW));
     break;
   case SYSTEM_CURRENT_CONTROL:
+  case SYSTEM_CURRENT_CONTROL_ID:
     {
       CGUIWindow *window = g_windowManager.GetWindow(g_windowManager.GetFocusedWindow());
       if (window)
       {
         CGUIControl *control = window->GetFocusedControl();
         if (control)
-          strLabel = control->GetDescription();
+        {
+          if (info == SYSTEM_CURRENT_CONTROL_ID)
+            strLabel = StringUtils::Format("%i", control->GetID());
+          else if (info == SYSTEM_CURRENT_CONTROL)
+            strLabel = control->GetDescription();
+        }
       }
     }
     break;

--- a/xbmc/guiinfo/GUIInfoLabels.h
+++ b/xbmc/guiinfo/GUIInfoLabels.h
@@ -114,6 +114,7 @@
 #define SYSTEM_SCREEN_HEIGHT        134
 #define SYSTEM_CURRENT_WINDOW       135
 #define SYSTEM_CURRENT_CONTROL      136
+#define SYSTEM_CURRENT_CONTROL_ID   137
 #define SYSTEM_DVD_LABEL            138
 #define SYSTEM_HASLOCKS             140
 #define SYSTEM_ISMASTER             141


### PR DESCRIPTION
this adds the infolabel System.CurrentControlId.
Can be especially useful for scripts and debug purposes.
@xhaggi
