### PR TITLE
Add consistency checks to use of musicbrianz id tags

### DIFF
--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -755,6 +755,28 @@ std::vector<std::string> StringUtils::Split(const std::string& input, const char
   return results;
 }
 
+std::vector<std::string> StringUtils::SplitMulti(const std::string& input, const char* delimiters, size_t iMaxStrings /*= 0*/)
+{
+  std::vector<std::string> results;
+  if (input.empty())
+    return results;
+
+  size_t nextDelim;
+  size_t textPos = 0;
+  do
+  {
+    if (--iMaxStrings == 0)
+    {
+      results.push_back(input.substr(textPos));
+      break;
+    }
+    nextDelim = input.find_first_of(delimiters, textPos);
+    results.push_back(input.substr(textPos, nextDelim - textPos));
+    textPos = nextDelim + 1;
+  } while (nextDelim != std::string::npos);
+
+  return results;
+}
 
 // returns the number of occurrences of strFind in strInput.
 int StringUtils::FindNumber(const std::string& strInput, const std::string &strFind)

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -103,6 +103,7 @@ public:
    */
   static std::vector<std::string> Split(const std::string& input, const std::string& delimiter, unsigned int iMaxStrings = 0);
   static std::vector<std::string> Split(const std::string& input, const char delimiter, size_t iMaxStrings = 0);
+  static std::vector<std::string> SplitMulti(const std::string& input, const char* delimiters, size_t iMaxStrings = 0);
   static int FindNumber(const std::string& strInput, const std::string &strFind);
   static int64_t AlphaNumericCompare(const wchar_t *left, const wchar_t *right);
   static long TimeStringToSeconds(const std::string &timeString);


### PR DESCRIPTION
Some users have difficulty tagging their music files consistently. A common problem, even when tagging using Picard, leaves Kodi with a mis-match in the number or artist names compared to the  number of musizbrainz artist Ids. This results in a mess in the artists held in the library that has given Kodi musicbrainz integration a bad reputation (users want to disable it or don't use mbids at all).

Things have improved with the introduction of the ARTISTS and ALBUMARTISTS tag, but there are still issues and older tagged files may not have these tags. Part of the problem is that Kodi only supports a single item separator, and does not accomodate the standard output from Picard (where the delimiter can vary). Some users know how to apply Picard scripts to fix that, but others don't, and they don't understand why music collections are fine in other players (that don't use the mbids) but go wrong in Kodi.

Common example of difficulties where the are multiple mb Ids but Kodi sees only a single artist include: "Artist1 feat. Artist2" or "Composer; Conductor, Orchestra, Soloist". 

Rather than quietly making a mess, it is a simple matter for Kodi to log in debug when a mis-match has occurred and then attempt to rectify the situation and identify the right number of artist names. There will be times when even this fails, but it will catch a majority of the tagging issues.

I am tempted to suggest we back-port this into Javis even at RC1.

@Paxxi check my stringutils addition. @Scott967,@Razzeee and @zag2me  hope this makes sense to you guys. @jjd_uk maybe you will consider using mbids now? Anyway you know the users this will help.
