### PR TITLE
Remove musicbrainzTRMID as obselete

### DIFF
--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -466,8 +466,6 @@ namespace XBMCAddon
             item->GetMusicInfoTag()->SetMusicBrainzAlbumID(value);
           else if (key == "musicbrainzalbumartistid")
             item->GetMusicInfoTag()->SetMusicBrainzAlbumArtistID(StringUtils::Split(value, g_advancedSettings.m_musicItemSeparator));
-          else if (key == "musicbrainztrmid")
-            item->GetMusicInfoTag()->SetMusicBrainzTRMID(value);
           else if (key == "comment")
             item->GetMusicInfoTag()->SetComment(value);
           else if (key == "date")

--- a/xbmc/music/tags/MusicInfoTag.cpp
+++ b/xbmc/music/tags/MusicInfoTag.cpp
@@ -116,7 +116,6 @@ const CMusicInfoTag& CMusicInfoTag::operator =(const CMusicInfoTag& tag)
   m_strMusicBrainzAlbumID = tag.m_strMusicBrainzAlbumID;
   m_musicBrainzAlbumArtistID = tag.m_musicBrainzAlbumArtistID;
   m_musicBrainzAlbumArtistHints = tag.m_musicBrainzAlbumArtistHints;
-  m_strMusicBrainzTRMID = tag.m_strMusicBrainzTRMID;
   m_musicRoles = tag.m_musicRoles;
   m_strComment = tag.m_strComment;
   m_strMood = tag.m_strMood;
@@ -577,11 +576,6 @@ const std::vector<std::string>& CMusicInfoTag::GetMusicBrainzAlbumArtistHints() 
     return m_musicBrainzAlbumArtistHints;
 }
 
-const std::string& CMusicInfoTag::GetMusicBrainzTRMID() const
-{
-  return m_strMusicBrainzTRMID;
-}
-
 void CMusicInfoTag::SetMusicBrainzTrackID(const std::string& strTrackID)
 {
   m_strMusicBrainzTrackID = strTrackID;
@@ -610,12 +604,6 @@ void CMusicInfoTag::SetMusicBrainzAlbumArtistID(const std::vector<std::string>& 
 void CMusicInfoTag::SetMusicBrainzAlbumArtistHints(const std::vector<std::string>& musicBrainzAlbumArtistHints)
 {
     m_musicBrainzAlbumArtistHints = musicBrainzAlbumArtistHints;
-}
-
-
-void CMusicInfoTag::SetMusicBrainzTRMID(const std::string& strTRMID)
-{
-  m_strMusicBrainzTRMID = strTRMID;
 }
 
 void CMusicInfoTag::SetCoverArtInfo(size_t size, const std::string &mimeType)
@@ -760,7 +748,6 @@ void CMusicInfoTag::Serialize(CVariant& value) const
   value["musicbrainzartistid"] = m_musicBrainzArtistID;
   value["musicbrainzalbumid"] = m_strMusicBrainzAlbumID;
   value["musicbrainzalbumartistid"] = m_musicBrainzAlbumArtistID; 
-  value["musicbrainztrmid"] = m_strMusicBrainzTRMID;
   value["comment"] = m_strComment;
   value["contributors"] = CVariant(CVariant::VariantTypeArray);
   for (const auto& role : m_musicRoles)
@@ -845,7 +832,6 @@ void CMusicInfoTag::Archive(CArchive& ar)
     ar << m_musicBrainzArtistID;
     ar << m_strMusicBrainzAlbumID;
     ar << m_musicBrainzAlbumArtistID;
-    ar << m_strMusicBrainzTRMID;
     ar << m_lastPlayed;
     ar << m_dateAdded;
     ar << m_strComment;
@@ -890,7 +876,6 @@ void CMusicInfoTag::Archive(CArchive& ar)
     ar >> m_musicBrainzArtistID;
     ar >> m_strMusicBrainzAlbumID;
     ar >> m_musicBrainzAlbumArtistID;
-    ar >> m_strMusicBrainzTRMID;
     ar >> m_lastPlayed;
     ar >> m_dateAdded;
     ar >> m_strComment;
@@ -941,7 +926,6 @@ void CMusicInfoTag::Clear()
   m_musicBrainzArtistID.clear();
   m_strMusicBrainzAlbumID.clear();
   m_musicBrainzAlbumArtistID.clear();
-  m_strMusicBrainzTRMID.clear();
   m_musicRoles.clear();
   m_iDuration = 0;
   m_iTrack = 0;

--- a/xbmc/music/tags/MusicInfoTag.h
+++ b/xbmc/music/tags/MusicInfoTag.h
@@ -73,7 +73,6 @@ public:
   const std::string& GetMusicBrainzAlbumID() const;
   const std::vector<std::string>& GetMusicBrainzAlbumArtistID() const;
   const std::vector<std::string>& GetMusicBrainzAlbumArtistHints() const;
-  const std::string& GetMusicBrainzTRMID() const;
   const std::string& GetComment() const;
   const std::string& GetMood() const;
   const std::string& GetLyrics() const;
@@ -119,7 +118,6 @@ public:
   void SetMusicBrainzAlbumID(const std::string& strAlbumID);
   void SetMusicBrainzAlbumArtistID(const std::vector<std::string>& musicBrainzAlbumArtistId);
   void SetMusicBrainzAlbumArtistHints(const std::vector<std::string>& musicBrainzAlbumArtistHints);
-  void SetMusicBrainzTRMID(const std::string& strTRMID);
   void SetComment(const std::string& comment);
   void SetMood(const std::string& mood);
   void SetLyrics(const std::string& lyrics);
@@ -193,7 +191,6 @@ protected:
   std::string m_strMusicBrainzAlbumID;
   std::vector<std::string> m_musicBrainzAlbumArtistID;
   std::vector<std::string> m_musicBrainzAlbumArtistHints;
-  std::string m_strMusicBrainzTRMID;
   VECMUSICROLES m_musicRoles; //Artists contributing to the recording and role (from tags other than ARTIST or ALBUMARTIST)
   std::string m_strComment;
   std::string m_strMood;


### PR DESCRIPTION
Musicbrainz have abandoned this approach to muscial digital finger printing. They may come up with something else that we want to include at a later date, but this is obselete and never populated as the tag never scanned, and there was never anywhere in the library to store it.
