### PR TITLE
Add opus tags

### DIFF
--- a/xbmc/music/tags/MusicInfoTagLoaderFactory.cpp
+++ b/xbmc/music/tags/MusicInfoTagLoaderFactory.cpp
@@ -101,7 +101,8 @@ IMusicInfoTagLoader* CMusicInfoTagLoaderFactory::CreateLoader(const CFileItem& i
     CMusicInfoTagLoaderSHN *pTagLoader = new CMusicInfoTagLoaderSHN();
     return (IMusicInfoTagLoader*)pTagLoader;
   }
-  else if (strExtension == "mka" || strExtension == "dsf" || strExtension == "dff")
+  else if (strExtension == "mka" || strExtension == "dsf" ||
+           strExtension == "dff" || strExtension == "opus")
     return new CMusicInfoTagLoaderFFmpeg();
 
   return NULL;


### PR DESCRIPTION
This
- improves the FFmpeg tag loader. Metadata can be attached to streams as well.
- Enables the FFmpeg tag loader for opus files.
