### PR TITLE
VideoPlayer: continue normal playback if seek fails

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.h
@@ -96,6 +96,7 @@ protected:
   }
 
   AVFrame* m_pFrame;
+  AVFrame* m_pDecodedFrame;
   AVCodecContext* m_pCodecContext;
 
   std::string       m_filters;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -2460,7 +2460,13 @@ void CVideoPlayer::HandleMessages()
           FlushBuffers(!msg.GetFlush(), start, msg.GetAccurate(), msg.GetSync());
         }
         else
-          CLog::Log(LOGWARNING, "error while seeking");
+        {
+          CLog::Log(LOGDEBUG, "VideoPlayer: seek failed");
+          if (m_playSpeed != DVD_PLAYSPEED_PAUSE)
+          {
+            SetPlaySpeed(DVD_PLAYSPEED_NORMAL);
+          }
+        }
 
         // set flag to indicate we have finished a seeking request
         if(!msg.GetTrickPlay())


### PR DESCRIPTION
in particular useful when hitting an end of timeshift buffer
