### PR TITLE
[guilib] Fixed: don't unfocus control if it's the one being focused

### DIFF
--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -667,17 +667,17 @@ bool CGUIWindow::OnMessage(CGUIMessage& message)
 //      CLog::Log(LOGDEBUG,"set focus to control:%i window:%i (%i)\n", message.GetControlId(),message.GetSenderId(), GetID());
       if ( message.GetControlId() )
       {
-        // first unfocus the current control
+        // get the control to focus
+        CGUIControl* pFocusedControl = GetFirstFocusableControl(message.GetControlId());
+        if (!pFocusedControl) pFocusedControl = GetControl(message.GetControlId());
+
+        // first unfocus the current control if it's not being focused
         CGUIControl *control = GetFocusedControl();
-        if (control)
+        if (control && control != pFocusedControl)
         {
           CGUIMessage msgLostFocus(GUI_MSG_LOSTFOCUS, GetID(), control->GetID(), message.GetControlId());
           control->OnMessage(msgLostFocus);
         }
-
-        // get the control to focus
-        CGUIControl* pFocusedControl = GetFirstFocusableControl(message.GetControlId());
-        if (!pFocusedControl) pFocusedControl = GetControl(message.GetControlId());
 
         // and focus it
         if (pFocusedControl)


### PR DESCRIPTION
I ran across this working on the controller dialog (#8807). When you're mapping a feature, the dialog focuses the feature's button control and asks for input. I wanted the mouse to quickly interrupt the mapping process, so when it gives focus to another control, an "unfocus" command is sent to the feature's button control, canceling the input prompt.

However, if an already-focused control is told to focus, it will first be sent an "unfocus" message, followed by a "focus" message. The "unfocus" message prematurely aborts the input prompt. If a dialog begins prompting for a feature that is already focused, the prompt will be immediately terminated by the "unfocus" message.

This change removes the "unfocus" message when an already-focused control is told to focus, allowing the user to map buttons in the controller dialog.
