### PR TITLE
VideoPlayer: passthrough improvements

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
@@ -35,6 +35,7 @@ CSoundPacket::CSoundPacket(SampleConfig conf, int samples) : config(conf)
   data = AE.AllocSoundSample(config, samples, bytes_per_sample, planes, linesize);
   max_nb_samples = samples;
   nb_samples = 0;
+  pause_burst_ms = 0;
 }
 
 CSoundPacket::~CSoundPacket()
@@ -107,6 +108,7 @@ CSampleBuffer* CActiveAEBufferPool::GetFreeBuffer()
 void CActiveAEBufferPool::ReturnBuffer(CSampleBuffer *buffer)
 {
   buffer->pkt->nb_samples = 0;
+  buffer->pkt->pause_burst_ms = 0;
   m_freeSamples.push_back(buffer);
 }
 

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.h
@@ -57,6 +57,7 @@ public:
   int planes;                            // 1 for non planar formats, #channels for planar
   int nb_samples;                        // number of frames used
   int max_nb_samples;                    // max number of frames this packet can hold
+  int pause_burst_ms;
 };
 
 class CActiveAEBufferPool;

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -902,6 +902,7 @@ unsigned int CActiveAESink::OutputSamples(CSampleBuffer* samples)
   unsigned int written = 0;
   std::unique_ptr<uint8_t[]> mergebuffer;
   uint8_t* p_mergebuffer = NULL;
+  AEDelayStatus status;
 
   if (m_requestedFormat.m_dataFormat == AE_FMT_RAW)
   {
@@ -984,10 +985,16 @@ unsigned int CActiveAESink::OutputSamples(CSampleBuffer* samples)
         totalFrames = size / m_sinkFormat.m_frameSize;
         frames = totalFrames;
       }
+      if (samples->pkt->pause_burst_ms > 0)
+      {
+        m_sink->AddPause(samples->pkt->pause_burst_ms);
+        m_sink->GetDelay(status);
+        m_stats->UpdateSinkDelay(status, samples->pool ? 1 : 0);
+        return status.delay * 1000;
+      }
     }
   }
 
-  AEDelayStatus status;
   int framesOrPackets;
 
   while (frames > 0)

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -213,7 +213,7 @@ bool CActiveAESink::NeedIECPacking()
       }
     }
   }
-  return false;
+  return true;
 }
 
 enum SINK_STATES
@@ -868,6 +868,11 @@ void CActiveAESink::OpenSink()
   m_sampleOfSilence.pkt->nb_samples = m_sampleOfSilence.pkt->max_nb_samples;
   if (!passthrough)
     GenerateNoise();
+  else
+  {
+    m_sampleOfSilence.pkt->nb_samples = 0;
+    m_sampleOfSilence.pkt->pause_burst_ms = m_sinkFormat.m_streamInfo.GetDuration();
+  }
 
   m_swapState = CHECK_SWAP;
 }
@@ -898,30 +903,51 @@ unsigned int CActiveAESink::OutputSamples(CSampleBuffer* samples)
   std::unique_ptr<uint8_t[]> mergebuffer;
   uint8_t* p_mergebuffer = NULL;
 
-  if (m_requestedFormat.m_dataFormat == AE_FMT_RAW && frames > 0  && samples->pool)
+  if (m_requestedFormat.m_dataFormat == AE_FMT_RAW)
   {
     if (m_needIecPack)
     {
-      if (m_sinkFormat.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_TRUEHD && frames == 61440)
+      if (frames > 0)
       {
-        int offset;
-        int len;
-        m_packer->GetBuffer();
-        for (int i=0; i<24; i++)
+        m_packer->Reset();
+        if (m_sinkFormat.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_TRUEHD)
         {
-          offset = i*2560;
-          len = (*(buffer[0] + offset+2560-2) << 8) + *(buffer[0] + offset+2560-1);
-          m_packer->Pack(m_sinkFormat.m_streamInfo, buffer[0] + offset, len);
+          if (frames == 61440)
+          {
+            int offset;
+            int len;
+            m_packer->GetBuffer();
+            for (int i=0; i<24; i++)
+            {
+              offset = i*2560;
+              len = (*(buffer[0] + offset+2560-2) << 8) + *(buffer[0] + offset+2560-1);
+              m_packer->Pack(m_sinkFormat.m_streamInfo, buffer[0] + offset, len);
+            }
+          }
+          else
+          {
+            m_extError = true;
+            CLog::Log(LOGERROR, "CActiveAESink::OutputSamples - incomplete TrueHD buffer");
+            return 0;
+          }
         }
+        else
+          m_packer->Pack(m_sinkFormat.m_streamInfo, buffer[0], frames);
+      }
+      else if (samples->pkt->pause_burst_ms > 0)
+      {
+        // construct a pause burst
+        m_packer->PackPause(m_sinkFormat.m_streamInfo, samples->pkt->pause_burst_ms);
       }
       else
-        m_packer->Pack(m_sinkFormat.m_streamInfo, buffer[0], frames);
+        m_packer->Reset();
 
       unsigned int size = m_packer->GetSize();
       packBuffer = m_packer->GetBuffer();
       buffer = &packBuffer;
       totalFrames = size / m_sinkFormat.m_frameSize;
       frames = totalFrames;
+
       switch(m_swapState)
       {
         case SKIP_SWAP:
@@ -964,7 +990,7 @@ unsigned int CActiveAESink::OutputSamples(CSampleBuffer* samples)
   AEDelayStatus status;
   int framesOrPackets;
 
-  while(frames > 0)
+  while (frames > 0)
   {
     maxFrames = std::min(frames, m_sinkFormat.m_frames);
     written = m_sink->AddPackets(buffer, maxFrames, totalFrames - frames);
@@ -1005,8 +1031,8 @@ unsigned int CActiveAESink::OutputSamples(CSampleBuffer* samples)
       m_stats->UpdateSinkDelay(status, samples->pool ? written : 0);
   }
 
-  if (m_requestedFormat.m_dataFormat == AE_FMT_RAW && samples->pool)
-    m_stats->UpdateSinkDelay(status, 1);
+  if (m_requestedFormat.m_dataFormat == AE_FMT_RAW)
+    m_stats->UpdateSinkDelay(status, samples->pool ? 1 : 0);
 
   return status.delay * 1000;
 }

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
@@ -296,6 +296,8 @@ unsigned int CActiveAEStream::AddData(uint8_t* const *data, unsigned int offset,
       {
         m_currentBuffer = *((CSampleBuffer**)msg->data);
         m_currentBuffer->timestamp = 0;
+        m_currentBuffer->pkt->nb_samples = 0;
+        m_currentBuffer->pkt->pause_burst_ms = 0;
         msg->Release();
         DecFreeBuffers();
         continue;

--- a/xbmc/cores/AudioEngine/Interfaces/AESink.h
+++ b/xbmc/cores/AudioEngine/Interfaces/AESink.h
@@ -65,6 +65,11 @@ public:
   */
   virtual unsigned int AddPackets(uint8_t **data, unsigned int frames, unsigned int offset) = 0;
 
+  /*!
+   * @brief instruct the sink to add a pause
+   * @param millis ms to pause
+   */
+  virtual void AddPause(unsigned int millis) {};
 
   /*!
    * @brief Return a timestamped status structure with delay and sink info

--- a/xbmc/cores/AudioEngine/Utils/AEBitstreamPacker.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEBitstreamPacker.cpp
@@ -41,7 +41,8 @@ CAEBitstreamPacker::CAEBitstreamPacker() :
   m_eac3Size (0),
   m_eac3FramesCount(0),
   m_eac3FramesPerBurst(0),
-  m_dataSize (0)
+  m_dataSize (0),
+  m_pauseDuration(0)
 {
 }
 
@@ -54,6 +55,7 @@ CAEBitstreamPacker::~CAEBitstreamPacker()
 
 void CAEBitstreamPacker::Pack(CAEStreamInfo &info, uint8_t* data, int size)
 {
+  m_pauseDuration = 0;
   switch (info.m_type)
   {
     case CAEStreamInfo::STREAM_TYPE_TRUEHD:
@@ -90,6 +92,35 @@ void CAEBitstreamPacker::Pack(CAEStreamInfo &info, uint8_t* data, int size)
   }
 }
 
+void CAEBitstreamPacker::PackPause(CAEStreamInfo &info, unsigned int millis)
+{
+  // re-use last buffer
+  if (m_pauseDuration == millis)
+    return;
+
+  switch (info.m_type)
+  {
+    case CAEStreamInfo::STREAM_TYPE_TRUEHD:
+    case CAEStreamInfo::STREAM_TYPE_EAC3:
+      m_dataSize = CAEPackIEC61937::PackPause(m_packedBuffer, millis, GetOutputChannelMap(info).Count() * 2, GetOutputRate(info), 4, info.m_sampleRate);
+      m_pauseDuration = millis;
+      break;
+
+    case CAEStreamInfo::STREAM_TYPE_AC3:
+    case CAEStreamInfo::STREAM_TYPE_DTSHD:
+    case CAEStreamInfo::STREAM_TYPE_DTSHD_CORE:
+    case CAEStreamInfo::STREAM_TYPE_DTS_512:
+    case CAEStreamInfo::STREAM_TYPE_DTS_1024:
+    case CAEStreamInfo::STREAM_TYPE_DTS_2048:
+      m_dataSize = CAEPackIEC61937::PackPause(m_packedBuffer, millis, GetOutputChannelMap(info).Count() * 2, GetOutputRate(info), 3, info.m_sampleRate);
+      m_pauseDuration = millis;
+      break;
+
+    default:
+      CLog::Log(LOGERROR, "CAEBitstreamPacker::Pack - no pack function");
+  }
+}
+
 unsigned int CAEBitstreamPacker::GetSize()
 {
   return m_dataSize;
@@ -97,9 +128,13 @@ unsigned int CAEBitstreamPacker::GetSize()
 
 uint8_t* CAEBitstreamPacker::GetBuffer()
 {
+  return m_packedBuffer;
+}
+
+void CAEBitstreamPacker::Reset()
+{
   m_dataSize = 0;
   m_trueHDPos = 0;
-  return m_packedBuffer;
 }
 
 /* we need to pack 24 TrueHD audio units into the unknown MAT format before packing into IEC61937 */

--- a/xbmc/cores/AudioEngine/Utils/AEBitstreamPacker.h
+++ b/xbmc/cores/AudioEngine/Utils/AEBitstreamPacker.h
@@ -33,6 +33,8 @@ public:
   ~CAEBitstreamPacker();
 
   void Pack(CAEStreamInfo &info, uint8_t* data, int size);
+  void PackPause(CAEStreamInfo &info, unsigned int millis);
+  void Reset();
   uint8_t* GetBuffer();
   unsigned int GetSize();
   static unsigned int GetOutputRate(CAEStreamInfo &info);
@@ -57,5 +59,6 @@ private:
 
   unsigned int  m_dataSize;
   uint8_t       m_packedBuffer[MAX_IEC61937_PACKET];
+  unsigned int m_pauseDuration;
 };
 

--- a/xbmc/cores/AudioEngine/Utils/AEPackIEC61937.h
+++ b/xbmc/cores/AudioEngine/Utils/AEPackIEC61937.h
@@ -48,6 +48,7 @@ public:
   static int PackDTS_2048(uint8_t *data, unsigned int size, uint8_t *dest, bool littleEndian);
   static int PackTrueHD  (uint8_t *data, unsigned int size, uint8_t *dest);
   static int PackDTSHD   (uint8_t *data, unsigned int size, uint8_t *dest, unsigned int period);
+  static int PackPause(uint8_t *dest, unsigned int millis, unsigned int framesize, unsigned int samplerate, unsigned int rep_priod, unsigned int encodedRate);
 private:
 
   static int PackDTS(uint8_t *data, unsigned int size, uint8_t *dest, bool littleEndian,

--- a/xbmc/cores/AudioEngine/Utils/AEStreamInfo.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEStreamInfo.cpp
@@ -136,6 +136,14 @@ CAEStreamParser::~CAEStreamParser()
 {
 }
 
+void CAEStreamParser::Reset()
+{
+  m_skipBytes = 0;
+  m_bufferSize = 0;
+  m_needBytes = 0;
+  m_hasSync = false;
+}
+
 int CAEStreamParser::AddData(uint8_t *data, unsigned int size, uint8_t **buffer/* = NULL */, unsigned int *bufferSize/* = 0 */)
 {
   if (size == 0)

--- a/xbmc/cores/AudioEngine/Utils/AEStreamInfo.h
+++ b/xbmc/cores/AudioEngine/Utils/AEStreamInfo.h
@@ -79,6 +79,7 @@ public:
   bool IsLittleEndian() { return m_info.m_dataIsLE; }
   unsigned int GetBufferSize() { return m_bufferSize; }
   CAEStreamInfo& GetStreamInfo() { return m_info; }
+  void Reset();
 
 private:
   uint8_t m_buffer[MAX_IEC61937_PACKET];

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
@@ -140,7 +140,8 @@ void CDVDAudioCodecFFmpeg::Dispose()
 int CDVDAudioCodecFFmpeg::Decode(uint8_t* pData, int iSize, double dts, double pts)
 {
   int iBytesUsed;
-  if (!m_pCodecContext) return -1;
+  if (!m_pCodecContext)
+    return -1;
 
   AVPacket avpkt;
   av_init_packet(&avpkt);

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.h
@@ -51,9 +51,13 @@ private:
   unsigned int m_bufferSize;
   unsigned int m_dataSize;
   AEAudioFormat m_format;
+  uint8_t m_backlogBuffer[61440];
+  unsigned int m_backlogSize;
+  double m_currentPts;
+  double m_nextPts;
 
   // TrueHD specifics
   std::unique_ptr<uint8_t[]> m_trueHDBuffer;
-  unsigned int       m_trueHDoffset;
+  unsigned int m_trueHDoffset;
 };
 

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
@@ -40,42 +40,6 @@
 // allow audio for slow and fast speeds (but not rewind/fastforward)
 #define ALLOW_AUDIO(speed) ((speed) > 5*DVD_PLAYSPEED_NORMAL/10 && (speed) <= 15*DVD_PLAYSPEED_NORMAL/10)
 
-void CPTSInputQueue::Add(int64_t bytes, double pts)
-{
-  CSingleLock lock(m_sync);
-
-  m_list.insert(m_list.begin(), std::make_pair(bytes, pts));
-}
-
-void CPTSInputQueue::Flush()
-{
-  CSingleLock lock(m_sync);
-
-  m_list.clear();
-}
-double CPTSInputQueue::Get(int64_t bytes, bool consume)
-{
-  CSingleLock lock(m_sync);
-
-  IT it = m_list.begin();
-  for(; it != m_list.end(); ++it)
-  {
-    if(bytes <= it->first)
-    {
-      double pts = it->second;
-      if(consume)
-      {
-        it->second = DVD_NOPTS_VALUE;
-        m_list.erase(++it, m_list.end());
-      }
-      return pts;
-    }
-    bytes -= it->first;
-  }
-  return DVD_NOPTS_VALUE;
-}
-
-
 class CDVDMsgAudioCodecChange : public CDVDMsg
 {
 public:
@@ -244,222 +208,6 @@ void CVideoPlayerAudio::CloseStream(bool bWaitForBuffers)
   }
 }
 
-// decode one audio frame and returns its uncompressed size
-int CVideoPlayerAudio::DecodeFrame(DVDAudioFrame &audioframe)
-{
-  int result = 0;
-
-  // make sure the sent frame is clean
-  audioframe.nb_frames = 0;
-
-  while (!m_bStop)
-  {
-    bool switched = false;
-    /* NOTE: the audio packet can contain several frames */
-    while( !m_bStop && m_decode.size > 0 )
-    {
-      if( !m_pAudioCodec )
-        return DECODE_FLAG_ERROR;
-
-      /* the packet dts refers to the first audioframe that starts in the packet */
-      double dts = m_ptsInput.Get(m_decode.size + m_pAudioCodec->GetBufferSize(), true);
-      if (dts != DVD_NOPTS_VALUE)
-        m_audioClock = dts;
-
-      int len = m_pAudioCodec->Decode(m_decode.data, m_decode.size, m_decode.dts, m_decode.pts);
-      if (len < 0 || len > m_decode.size)
-      {
-        /* if error, we skip the packet */
-        CLog::Log(LOGERROR, "CVideoPlayerAudio::DecodeFrame - Decode Error. Skipping audio packet (%d)", len);
-        m_decode.Release();
-        m_pAudioCodec->Reset();
-        return DECODE_FLAG_ERROR;
-      }
-
-      m_audioStats.AddSampleBytes(len);
-
-      m_decode.data += len;
-      m_decode.size -= len;
-
-      // get decoded data and the size of it
-      m_pAudioCodec->GetData(audioframe);
-
-      if (audioframe.nb_frames == 0)
-        continue;
-
-      audioframe.hasTimestamp = true;
-      if (audioframe.pts == DVD_NOPTS_VALUE)
-      {
-        audioframe.pts = m_audioClock;
-        if (dts == DVD_NOPTS_VALUE)
-          audioframe.hasTimestamp = false;
-      }
-      else
-      {
-        m_audioClock = audioframe.pts;
-      }
-
-      if (audioframe.format.m_sampleRate && m_streaminfo.samplerate != (int) audioframe.format.m_sampleRate)
-      {
-        // The sample rate has changed or we just got it for the first time
-        // for this stream. See if we should enable/disable passthrough due
-        // to it.
-        m_streaminfo.samplerate = audioframe.format.m_sampleRate;
-        if (!switched && SwitchCodecIfNeeded())
-        {
-          // passthrough has been enabled/disabled, reprocess the packet
-          m_decode.data -= len;
-          m_decode.size += len;
-          switched = true;
-          continue;
-        }
-      }
-
-      // increase audioclock to after the packet
-      m_audioClock += audioframe.duration;
-
-      // if demux source want's us to not display this, continue
-      if(m_decode.msg->GetPacketDrop())
-        result |= DECODE_FLAG_DROP;
-
-      return result;
-    }
-    // free the current packet
-    m_decode.Release();
-
-    if (m_messageQueue.ReceivedAbortRequest()) return DECODE_FLAG_ABORT;
-
-    CDVDMsg* pMsg;
-    int timeout  = (int)(1000 * m_dvdAudio.GetCacheTime()) + 100;
-
-    // read next packet and return -1 on error
-    int priority = 1;
-    //Do we want a new audio frame?
-    if (m_syncState == IDVDStreamPlayer::SYNC_STARTING ||              /* when not started */
-        ALLOW_AUDIO(m_speed) || /* when playing normally */
-        m_speed <  DVD_PLAYSPEED_PAUSE  || /* when rewinding */
-       (m_speed >  DVD_PLAYSPEED_NORMAL && m_audioClock < m_pClock->GetClock())) /* when behind clock in ff */
-      priority = 0;
-
-    if (m_syncState == IDVDStreamPlayer::SYNC_WAITSYNC)
-      priority = 1;
-
-    // consider stream stalled if queue is empty
-    // we can't sync audio to clock with an empty queue
-    if (ALLOW_AUDIO(m_speed) && !m_stalled)
-    {
-      timeout = 0;
-    }
-
-    MsgQueueReturnCode ret = m_messageQueue.Get(&pMsg, timeout, priority);
-
-    if (ret == MSGQ_TIMEOUT)
-    {
-      // Flush as the audio output may keep looping if we don't
-      if (ALLOW_AUDIO(m_speed) && !m_stalled && m_syncState == IDVDStreamPlayer::SYNC_INSYNC)
-      {
-        // while AE sync is active, we still have time to fill buffers
-        if (m_syncTimer.IsTimePast())
-        {
-          CLog::Log(LOGNOTICE, "CVideoPlayerAudio::Process - stream stalled");
-          m_stalled = true;
-        }
-      }
-      if (timeout == 0)
-        Sleep(10);
-      continue;
-    }
-    else if (MSGQ_IS_ERROR(ret))
-      return DECODE_FLAG_ABORT;
-
-    if (pMsg->IsType(CDVDMsg::DEMUXER_PACKET))
-    {
-      m_decode.Attach((CDVDMsgDemuxerPacket*)pMsg);
-      m_ptsInput.Add( m_decode.size, m_decode.dts );
-    }
-    else if (pMsg->IsType(CDVDMsg::GENERAL_SYNCHRONIZE))
-    {
-      if(((CDVDMsgGeneralSynchronize*)pMsg)->Wait( 100, SYNCSOURCE_AUDIO ))
-        CLog::Log(LOGDEBUG, "CVideoPlayerAudio - CDVDMsg::GENERAL_SYNCHRONIZE");
-      else
-        m_messageQueue.Put(pMsg->Acquire(), 1); /* push back as prio message, to process other prio messages */
-    }
-    else if (pMsg->IsType(CDVDMsg::GENERAL_RESYNC))
-    { //player asked us to set internal clock
-      double pts = static_cast<CDVDMsgDouble*>(pMsg)->m_value;
-      CLog::Log(LOGDEBUG, "CVideoPlayerAudio - CDVDMsg::GENERAL_RESYNC(%f)", pts);
-
-      m_audioClock = pts + m_dvdAudio.GetDelay();
-      if (m_speed != DVD_PLAYSPEED_PAUSE)
-        m_dvdAudio.Resume();
-      m_syncState = IDVDStreamPlayer::SYNC_INSYNC;
-      m_syncTimer.Set(3000);
-    }
-    else if (pMsg->IsType(CDVDMsg::GENERAL_RESET))
-    {
-      if (m_pAudioCodec)
-        m_pAudioCodec->Reset();
-      m_decode.Release();
-    }
-    else if (pMsg->IsType(CDVDMsg::GENERAL_FLUSH))
-    {
-      bool sync = static_cast<CDVDMsgBool*>(pMsg)->m_value;
-      m_dvdAudio.Flush();
-      m_ptsInput.Flush();
-      m_stalled = true;
-      m_audioClock = 0;
-
-      if (sync)
-      {
-        m_syncState = IDVDStreamPlayer::SYNC_STARTING;
-        m_dvdAudio.Pause();
-      }
-
-      if (m_pAudioCodec)
-        m_pAudioCodec->Reset();
-
-      m_decode.Release();
-    }
-    else if (pMsg->IsType(CDVDMsg::GENERAL_EOF))
-    {
-      CLog::Log(LOGDEBUG, "CVideoPlayerAudio - CDVDMsg::GENERAL_EOF");
-    }
-    else if (pMsg->IsType(CDVDMsg::PLAYER_SETSPEED))
-    {
-      double speed = static_cast<CDVDMsgInt*>(pMsg)->m_value;
-
-      if (ALLOW_AUDIO(speed))
-      {
-        if (speed != m_speed)
-        {
-          if (m_syncState == IDVDStreamPlayer::SYNC_INSYNC)
-            m_dvdAudio.Resume();
-        }
-      }
-      else
-      {
-        m_dvdAudio.Pause();
-      }
-      m_speed = speed;
-    }
-    else if (pMsg->IsType(CDVDMsg::AUDIO_SILENCE))
-    {
-      m_silence = static_cast<CDVDMsgBool*>(pMsg)->m_value;
-      CLog::Log(LOGDEBUG, "CVideoPlayerAudio - CDVDMsg::AUDIO_SILENCE(%f, %d)"
-                        , m_audioClock, m_silence);
-    }
-    else if (pMsg->IsType(CDVDMsg::GENERAL_STREAMCHANGE))
-    {
-      CDVDMsgAudioCodecChange* msg(static_cast<CDVDMsgAudioCodecChange*>(pMsg));
-      OpenStream(msg->m_hints, msg->m_codec);
-      msg->m_codec = NULL;
-    }
-
-    pMsg->Release();
-  }
-  return 0;
-}
-
 void CVideoPlayerAudio::OnStartup()
 {
   m_decode.Release();
@@ -501,86 +249,254 @@ void CVideoPlayerAudio::Process()
 
   while (!m_bStop)
   {
-    int result = DecodeFrame(audioframe);
+    CDVDMsg* pMsg;
+    int timeout  = (int)(1000 * m_dvdAudio.GetCacheTime()) + 100;
 
-    //Drop when not playing normally
-    if (!ALLOW_AUDIO(m_speed) && m_syncState == IDVDStreamPlayer::SYNC_INSYNC)
+    // read next packet and return -1 on error
+    int priority = 1;
+    //Do we want a new audio frame?
+    if (m_syncState == IDVDStreamPlayer::SYNC_STARTING ||              /* when not started */
+        ALLOW_AUDIO(m_speed) || /* when playing normally */
+        m_speed <  DVD_PLAYSPEED_PAUSE  || /* when rewinding */
+        (m_speed >  DVD_PLAYSPEED_NORMAL && m_audioClock < m_pClock->GetClock())) /* when behind clock in ff */
+      priority = 0;
+
+    if (m_syncState == IDVDStreamPlayer::SYNC_WAITSYNC)
+      priority = 1;
+
+    // consider stream stalled if queue is empty
+    // we can't sync audio to clock with an empty queue
+    if (ALLOW_AUDIO(m_speed) && !m_stalled)
     {
-      result |= DECODE_FLAG_DROP;
+      timeout = 0;
     }
 
-    UpdatePlayerInfo();
+    MsgQueueReturnCode ret = m_messageQueue.Get(&pMsg, timeout, priority);
 
-    if (result & DECODE_FLAG_ERROR)
+    if (MSGQ_IS_ERROR(ret))
     {
-      CLog::Log(LOGDEBUG, "CVideoPlayerAudio::Process - Decode Error");
-      continue;
-    }
-
-    if (result & DECODE_FLAG_ABORT)
-    {
-      CLog::Log(LOGDEBUG, "CVideoPlayerAudio::Process - Abort received, exiting thread");
+      CLog::Log(LOGERROR, "Got MSGQ_ABORT or MSGO_IS_ERROR return true");
       break;
     }
-
-    if (audioframe.nb_frames == 0)
-      continue;
-
-    // demuxer reads metatags that influence channel layout
-    if (m_streaminfo.codec == AV_CODEC_ID_FLAC && m_streaminfo.channellayout)
-      audioframe.format.m_channelLayout = CAEUtil::GetAEChannelLayout(m_streaminfo.channellayout);
-    
-    // we have succesfully decoded an audio frame, setup renderer to match
-    if (!m_dvdAudio.IsValidFormat(audioframe))
+    else if (ret == MSGQ_TIMEOUT)
     {
-      if(m_speed)
-        m_dvdAudio.Drain();
-
-      m_dvdAudio.Destroy();
-
-      if(!m_dvdAudio.Create(audioframe, m_streaminfo.codec, m_setsynctype == SYNC_RESAMPLE))
-        CLog::Log(LOGERROR, "%s - failed to create audio renderer", __FUNCTION__);
-
-      if (m_syncState == IDVDStreamPlayer::SYNC_INSYNC)
-        m_dvdAudio.Resume();
-
-      m_streaminfo.channels = audioframe.format.m_channelLayout.Count();
-
-      g_dataCacheCore.SignalAudioInfoChange();
-    }
-
-    // Zero out the frame data if we are supposed to silence the audio
-    if (m_silence)
-    {
-      int size = audioframe.nb_frames * audioframe.framesize / audioframe.planes;
-      for (unsigned int i=0; i<audioframe.planes; i++)
-        memset(audioframe.data[i], 0, size);
-    }
-
-    if(!(result & DECODE_FLAG_DROP))
-    {
-      SetSyncType(audioframe.passthrough);
-
-      OutputPacket(audioframe);
-    }
-
-    // signal to our parent that we have initialized
-    if(m_syncState == IDVDStreamPlayer::SYNC_STARTING && !(result & DECODE_FLAG_DROP))
-    {
-      double cachetotal = DVD_SEC_TO_TIME(m_dvdAudio.GetCacheTotal());
-      double cachetime = m_dvdAudio.GetDelay();
-      if (cachetime >= cachetotal * 0.5)
+      // Flush as the audio output may keep looping if we don't
+      if (ALLOW_AUDIO(m_speed) && !m_stalled && m_syncState == IDVDStreamPlayer::SYNC_INSYNC)
       {
-        m_syncState = IDVDStreamPlayer::SYNC_WAITSYNC;
-        m_stalled = false;
-        SStartMsg msg;
-        msg.player = VideoPlayer_AUDIO;
-        msg.cachetotal = cachetotal;
-        msg.cachetime = cachetime;
-        msg.timestamp = audioframe.hasTimestamp ? audioframe.pts : DVD_NOPTS_VALUE;
-        m_messageParent.Put(new CDVDMsgType<SStartMsg>(CDVDMsg::PLAYER_STARTED, msg));
+        // while AE sync is active, we still have time to fill buffers
+        if (m_syncTimer.IsTimePast())
+        {
+          CLog::Log(LOGNOTICE, "CVideoPlayerAudio::Process - stream stalled");
+          m_stalled = true;
+        }
       }
+      if (timeout == 0)
+        Sleep(10);
+      continue;
     }
+
+    // handle messages
+    if (pMsg->IsType(CDVDMsg::GENERAL_SYNCHRONIZE))
+    {
+      if(((CDVDMsgGeneralSynchronize*)pMsg)->Wait( 100, SYNCSOURCE_AUDIO ))
+        CLog::Log(LOGDEBUG, "CVideoPlayerAudio - CDVDMsg::GENERAL_SYNCHRONIZE");
+      else
+        m_messageQueue.Put(pMsg->Acquire(), 1);  // push back as prio message, to process other prio messages
+    }
+    else if (pMsg->IsType(CDVDMsg::GENERAL_RESYNC))
+    { //player asked us to set internal clock
+      double pts = static_cast<CDVDMsgDouble*>(pMsg)->m_value;
+      CLog::Log(LOGDEBUG, "CVideoPlayerAudio - CDVDMsg::GENERAL_RESYNC(%f)", pts);
+
+      m_audioClock = pts + m_dvdAudio.GetDelay();
+      if (m_speed != DVD_PLAYSPEED_PAUSE)
+        m_dvdAudio.Resume();
+      m_syncState = IDVDStreamPlayer::SYNC_INSYNC;
+      m_syncTimer.Set(3000);
+    }
+    else if (pMsg->IsType(CDVDMsg::GENERAL_RESET))
+    {
+      if (m_pAudioCodec)
+        m_pAudioCodec->Reset();
+      m_decode.Release();
+    }
+    else if (pMsg->IsType(CDVDMsg::GENERAL_FLUSH))
+    {
+      bool sync = static_cast<CDVDMsgBool*>(pMsg)->m_value;
+      m_dvdAudio.Flush();
+      m_stalled = true;
+      m_audioClock = 0;
+
+      if (sync)
+      {
+        m_syncState = IDVDStreamPlayer::SYNC_STARTING;
+        m_dvdAudio.Pause();
+      }
+
+      if (m_pAudioCodec)
+        m_pAudioCodec->Reset();
+
+      m_decode.Release();
+    }
+    else if (pMsg->IsType(CDVDMsg::GENERAL_EOF))
+    {
+      CLog::Log(LOGDEBUG, "CVideoPlayerAudio - CDVDMsg::GENERAL_EOF");
+    }
+    else if (pMsg->IsType(CDVDMsg::PLAYER_SETSPEED))
+    {
+      double speed = static_cast<CDVDMsgInt*>(pMsg)->m_value;
+
+      if (ALLOW_AUDIO(speed))
+      {
+        if (speed != m_speed)
+        {
+          if (m_syncState == IDVDStreamPlayer::SYNC_INSYNC)
+            m_dvdAudio.Resume();
+        }
+      }
+      else
+      {
+        m_dvdAudio.Pause();
+      }
+      m_speed = speed;
+    }
+    else if (pMsg->IsType(CDVDMsg::AUDIO_SILENCE))
+    {
+      m_silence = static_cast<CDVDMsgBool*>(pMsg)->m_value;
+      CLog::Log(LOGDEBUG, "CVideoPlayerAudio - CDVDMsg::AUDIO_SILENCE(%f, %d)"
+                , m_audioClock, m_silence);
+    }
+    else if (pMsg->IsType(CDVDMsg::GENERAL_STREAMCHANGE))
+    {
+      CDVDMsgAudioCodecChange* msg(static_cast<CDVDMsgAudioCodecChange*>(pMsg));
+      OpenStream(msg->m_hints, msg->m_codec);
+      msg->m_codec = NULL;
+    }
+    else if (pMsg->IsType(CDVDMsg::DEMUXER_PACKET))
+    {
+      DemuxPacket* pPacket = ((CDVDMsgDemuxerPacket*)pMsg)->GetPacket();
+      bool bPacketDrop  = ((CDVDMsgDemuxerPacket*)pMsg)->GetPacketDrop();
+
+      int len = m_pAudioCodec->Decode(pPacket->pData, pPacket->iSize, pPacket->dts, pPacket->pts);
+      if (len < 0)
+      {
+        CLog::Log(LOGERROR, "CVideoPlayerAudio::DecodeFrame - Decode Error. Skipping audio packet (%d)", len);
+        m_pAudioCodec->Reset();
+        pMsg->Release();
+        continue;
+      }
+
+      UpdatePlayerInfo();
+
+      // loop while no error and decoder produces output
+      while (!m_bStop)
+      {
+        // get decoded data and the size of it
+        m_pAudioCodec->GetData(audioframe);
+
+        if (audioframe.nb_frames == 0)
+          break;
+
+        audioframe.hasTimestamp = true;
+        if (audioframe.pts == DVD_NOPTS_VALUE)
+        {
+          audioframe.pts = m_audioClock;
+          audioframe.hasTimestamp = false;
+        }
+        else
+        {
+          m_audioClock = audioframe.pts;
+        }
+
+        //Drop when not playing normally
+        if (!ALLOW_AUDIO(m_speed) && m_syncState == IDVDStreamPlayer::SYNC_INSYNC)
+        {
+          break;
+        }
+
+        if (audioframe.format.m_sampleRate && m_streaminfo.samplerate != (int) audioframe.format.m_sampleRate)
+        {
+          // The sample rate has changed or we just got it for the first time
+          // for this stream. See if we should enable/disable passthrough due
+          // to it.
+          m_streaminfo.samplerate = audioframe.format.m_sampleRate;
+          if (SwitchCodecIfNeeded())
+          {
+            break;
+          }
+        }
+
+        // demuxer reads metatags that influence channel layout
+        if (m_streaminfo.codec == AV_CODEC_ID_FLAC && m_streaminfo.channellayout)
+          audioframe.format.m_channelLayout = CAEUtil::GetAEChannelLayout(m_streaminfo.channellayout);
+
+        // we have succesfully decoded an audio frame, setup renderer to match
+        if (!m_dvdAudio.IsValidFormat(audioframe))
+        {
+          if(m_speed)
+            m_dvdAudio.Drain();
+
+          m_dvdAudio.Destroy();
+
+          if (!m_dvdAudio.Create(audioframe, m_streaminfo.codec, m_setsynctype == SYNC_RESAMPLE))
+            CLog::Log(LOGERROR, "%s - failed to create audio renderer", __FUNCTION__);
+
+          if (m_syncState == IDVDStreamPlayer::SYNC_INSYNC)
+            m_dvdAudio.Resume();
+
+          m_streaminfo.channels = audioframe.format.m_channelLayout.Count();
+
+          g_dataCacheCore.SignalAudioInfoChange();
+        }
+
+        // Zero out the frame data if we are supposed to silence the audio
+        if (m_silence)
+        {
+          int size = audioframe.nb_frames * audioframe.framesize / audioframe.planes;
+          for (unsigned int i=0; i<audioframe.planes; i++)
+            memset(audioframe.data[i], 0, size);
+        }
+
+        SetSyncType(audioframe.passthrough);
+
+        if (!bPacketDrop)
+        {
+          OutputPacket(audioframe);
+
+          // signal to our parent that we have initialized
+          if(m_syncState == IDVDStreamPlayer::SYNC_STARTING)
+          {
+            double cachetotal = DVD_SEC_TO_TIME(m_dvdAudio.GetCacheTotal());
+            double cachetime = m_dvdAudio.GetDelay();
+            if (cachetime >= cachetotal * 0.5)
+            {
+              m_syncState = IDVDStreamPlayer::SYNC_WAITSYNC;
+              m_stalled = false;
+              SStartMsg msg;
+              msg.player = VideoPlayer_AUDIO;
+              msg.cachetotal = cachetotal;
+              msg.cachetime = cachetime;
+              msg.timestamp = audioframe.hasTimestamp ? audioframe.pts : DVD_NOPTS_VALUE;
+              m_messageParent.Put(new CDVDMsgType<SStartMsg>(CDVDMsg::PLAYER_STARTED, msg));
+            }
+          }
+        }
+
+        // guess next pts
+        m_audioClock += audioframe.duration;
+
+        int len = m_pAudioCodec->Decode(nullptr, 0, DVD_NOPTS_VALUE, DVD_NOPTS_VALUE);
+        if (len < 0)
+        {
+          CLog::Log(LOGERROR, "CVideoPlayerAudio::DecodeFrame - Decode Error. Skipping audio packet (%d)", len);
+          m_pAudioCodec->Reset();
+          break;
+        }
+      } // while decoder produces output
+
+    } // demuxer packet
+    
+    pMsg->Release();
   }
 }
 

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.h
@@ -35,23 +35,6 @@ class CVideoPlayer;
 class CDVDAudioCodec;
 class CDVDAudioCodec;
 
-#define DECODE_FLAG_DROP    1
-#define DECODE_FLAG_RESYNC  2
-#define DECODE_FLAG_ERROR   4
-#define DECODE_FLAG_ABORT   8
-
-class CPTSInputQueue
-{
-private:
-  typedef std::list<std::pair<int64_t, double> >::iterator IT;
-  std::list<std::pair<int64_t, double> > m_list;
-  CCriticalSection m_sync;
-public:
-  void   Add(int64_t bytes, double pts);
-  double Get(int64_t bytes, bool consume);
-  void   Flush();
-};
-
 class CVideoPlayerAudio : public CThread, public IDVDStreamPlayerAudio
 {
 public:
@@ -86,8 +69,6 @@ public:
   // holds stream information for current playing stream
   CDVDStreamInfo m_streaminfo;
 
-  CPTSInputQueue  m_ptsInput;
-
   double GetCurrentPts()                            { CSingleLock lock(m_info_section); return m_info.pts; }
 
   bool IsStalled() const                            { return m_stalled;  }
@@ -99,8 +80,6 @@ protected:
   virtual void OnStartup();
   virtual void OnExit();
   virtual void Process();
-
-  int DecodeFrame(DVDAudioFrame &audioframe);
 
   void UpdatePlayerInfo();
   void OpenStream(CDVDStreamInfo &hints, CDVDAudioCodec* codec);


### PR DESCRIPTION
this improves sync of passthrough audio
- passthrough decoder handles pts itself, makes error prone PTSInput queue obsolete
- AE sync by using IEC pause bursts
