### PR TITLE
FIX Android: On newer kernels neon cpu feature is represented as asimd

### DIFF
--- a/tools/android/packaging/xbmc/src/org/xbmc/kodi/Splash.java.in
+++ b/tools/android/packaging/xbmc/src/org/xbmc/kodi/Splash.java.in
@@ -737,7 +737,7 @@ public class Splash extends Activity {
           Log.e(TAG, mErrorMsg);
           mState = InError;
         } else {
-          ret = CheckCpuFeature("neon") || CheckCpuFeature("aarch64");  //aarch64 is always neon
+          ret = CheckCpuFeature("neon") || CheckCpuFeature("aarch64") || CheckCpuFeature("asimd");  // aarch64 is always neon; asimd feature also represents neon
           if (!ret) {
             mErrorMsg = "This @APP_NAME@ package is not compatible with your device (NEON).\nPlease check the <a href=\"http://wiki.kodi.tv/index.php?title=XBMC_for_Android_specific_FAQ\">Kodi Android wiki</a> for more information.";
             Log.e(TAG, mErrorMsg);


### PR DESCRIPTION
Newer kernels, for example starting from 3.14.33 kernel; commit:
https://git.kernel.org/cgit/linux/kernel/git/stable/linux-stable.git/diff/?h=linux-3.14.y&id=42b34c73ae40e3158779a5d47dcd514702804613

More on forum thread: http://forum.kodi.tv/showthread.php?tid=257253
