### PR TITLE
[dxva] Fix deinterlacing after 339ce49.

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderer.cpp
@@ -1065,6 +1065,9 @@ bool CWinRenderer::Supports(ESCALINGMETHOD method)
 
 EINTERLACEMETHOD CWinRenderer::AutoInterlaceMethod()
 {
+  if (m_renderMethod == RENDER_DXVA)
+    return VS_INTERLACEMETHOD_RENDER_BOB;
+
   return VS_INTERLACEMETHOD_DEINTERLACE_HALF;
 }
 


### PR DESCRIPTION
After 339ce49 render manager uses only PRESENT_SINGLE method for any rendering methods (I mean windows only). A quick test shows what the single present is enough for dxva for proper deinterlacing. So now dxva takes in account only RENDER_FLAG_TOP/BOTTOM.

@Voyager1 this fixes deinterlacing with dxva renderer for DVDs also.
