### PR TITLE
use 'browse for folder' label for SetPath builtin

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -2879,6 +2879,7 @@ msgid "Browse for playlist"
 msgstr ""
 
 #: xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
+#: xbmc/interfaces/builtins/SkinBuiltins.cpp
 msgctxt "#657"
 msgid "Browse for folder"
 msgstr ""

--- a/xbmc/interfaces/builtins/SkinBuiltins.cpp
+++ b/xbmc/interfaces/builtins/SkinBuiltins.cpp
@@ -205,7 +205,7 @@ static int SetPath(const std::vector<std::string>& params)
     }
   }
 
-  if (CGUIDialogFileBrowser::ShowAndGetDirectory(localShares, g_localizeStrings.Get(1031), value))
+  if (CGUIDialogFileBrowser::ShowAndGetDirectory(localShares, g_localizeStrings.Get(657), value))
     CSkinSettings::GetInstance().SetString(string, value);
 
   CSettings::GetInstance().Save();


### PR DESCRIPTION
use 'Browse for folder' instead of 'Browse for image folder'

skins can use the SetPath for other things then just browsing for an image folder.
