### PR TITLE
[smartplaylists] fix sorting for mixed smartplaylists

### DIFF
--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -350,7 +350,7 @@ bool CGUIWindowMusicNav::GetDirectory(const std::string &strDirectory, CFileItem
   else if (items.IsAddonsPath())
     items.SetContent("addons");
   else if (!items.IsSourcesPath() && !items.IsVirtualDirectoryRoot() &&
-           !items.IsLibraryFolder() && !items.IsPlugin())
+           !items.IsLibraryFolder() && !items.IsPlugin() && !items.IsSmartPlayList())
     items.SetContent("files");
 
   return bResult;

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -470,7 +470,21 @@ std::vector<SortBy> CSmartPlaylistRule::GetOrders(const std::string &type)
 {
   std::vector<SortBy> orders;
   orders.push_back(SortByNone);
-  if (type == "songs")
+  if (type == "mixed")
+  {
+    orders.push_back(SortByGenre);
+    orders.push_back(SortByAlbum);
+    orders.push_back(SortByArtist);
+    orders.push_back(SortByTitle);
+    orders.push_back(SortByYear);
+    orders.push_back(SortByTime);
+    orders.push_back(SortByTrackNumber);
+    orders.push_back(SortByFile);
+    orders.push_back(SortByPath);
+    orders.push_back(SortByPlaycount);
+    orders.push_back(SortByLastPlayed);
+  }
+  else if (type == "songs")
   {
     orders.push_back(SortByGenre);
     orders.push_back(SortByAlbum);


### PR DESCRIPTION
The first commits fixes sorting for mixed smartplaylists as reported broken in http://trac.kodi.tv/ticket/16532. The reason was that we accidentally set the content of music smartplaylists to `files` which resulted in the wrong GUI view state being loaded. This commit could be backported.

The second commit adds support for additional sort methods for mixed smartplaylists which are already available when viewing a mixed smartplaylist but aren't available when creating the smartplaylist.
