### PR TITLE
[profiles] don't save skin settings on master profile when it was only loaded to switch between two other profiles

### DIFF
--- a/xbmc/profiles/ProfilesManager.h
+++ b/xbmc/profiles/ProfilesManager.h
@@ -190,6 +190,7 @@ private:
 
   std::vector<CProfile> m_profiles;
   bool m_usingLoginScreen;
+  bool m_profileLoadedForLogin;
   int m_autoLoginProfile;
   uint32_t m_lastUsedProfile;
   uint32_t m_currentProfile; // do not modify directly, use SetCurrentProfileId() function instead


### PR DESCRIPTION
This is a follow up for #8481 which only covers the case when switching between master profile and another profile. When switching between two non-master profiles we temporarily load the master profile in between which messes things up (because we only load its general settings but not the actual skin or the skin's settings) and results in the old profiles skin settings being written to the master profile. I had to introduce a variable where we can remember that the master profile has only been loaded for switching between other profiles and not save the previous profile's skin settings to the temporarily loaded master profile.
