### PR TITLE
bump skin ABI (backwards compatibility) version

### DIFF
--- a/addons/xbmc.gui/addon.xml
+++ b/addons/xbmc.gui/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="xbmc.gui" version="5.11.0" provider-name="Team Kodi">
-  <backwards-compatibility abi="5.10.0"/>
+  <backwards-compatibility abi="5.11.0"/>
   <requires>
     <import addon="xbmc.core" version="0.1.0"/>
   </requires>


### PR DESCRIPTION
Recent skin changes are breaking skin functionality. Better mark old versions incompatible 
