### PR TITLE
ActiveAE: Increase timeout for sink init to 60 seconds

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -2256,7 +2256,7 @@ bool CActiveAE::Initialize()
   Message *reply;
   if (m_controlPort.SendOutMessageSync(CActiveAEControlProtocol::INIT,
                                                  &reply,
-                                                 10000))
+                                                 60000))
   {
     bool success = reply->signal == CActiveAEControlProtocol::ACC;
     reply->Release();


### PR DESCRIPTION
This fixes some issues when users having > 42 (!) sound cards for which we always test the samplerates / channels and so on. This is Jarvis only for now - a proper fix would be something async, but that needs a good concept.
