### PR TITLE
fix regression after PR8865

### DIFF
--- a/xbmc/addons/GUIDialogAddonSettings.cpp
+++ b/xbmc/addons/GUIDialogAddonSettings.cpp
@@ -188,6 +188,11 @@ void CGUIDialogAddonSettings::OnInitWindow()
   CreateSections();
   CreateControls();
   CGUIDialogBoxBase::OnInitWindow();
+
+  SET_CONTROL_VISIBLE(ID_BUTTON_OK);
+  SET_CONTROL_VISIBLE(ID_BUTTON_CANCEL);
+  SET_CONTROL_VISIBLE(ID_BUTTON_DEFAULT);
+  SET_CONTROL_VISIBLE(CONTROL_HEADING_LABEL);
 }
 
 // \brief Show CGUIDialogOK dialog, then wait for user to dismiss it.


### PR DESCRIPTION
GUIDialogAddonSettings derives from CGUIDialogBoxBase,
so needs to set it's controls to visible.
