### PR TITLE
[darwin] - implement proper ping method

### DIFF
--- a/Kodi.xcodeproj/project.pbxproj
+++ b/Kodi.xcodeproj/project.pbxproj
@@ -932,6 +932,10 @@
 		DFD717611C0A031B0025D964 /* XBMCApplication.m in Sources */ = {isa = PBXBuildFile; fileRef = DFD717511C0A031B0025D964 /* XBMCApplication.m */; };
 		DFD717621C0A031B0025D964 /* XBMCController.mm in Sources */ = {isa = PBXBuildFile; fileRef = DFD717531C0A031B0025D964 /* XBMCController.mm */; };
 		DFD717641C0A03540025D964 /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = DFD717631C0A03540025D964 /* Info.plist */; };
+		DFD810F71C54F25900BEE004 /* darwinICMPPing.m in Sources */ = {isa = PBXBuildFile; fileRef = DFD810F41C54F25900BEE004 /* darwinICMPPing.m */; };
+		DFD810F81C54F25900BEE004 /* darwinICMPPing.m in Sources */ = {isa = PBXBuildFile; fileRef = DFD810F41C54F25900BEE004 /* darwinICMPPing.m */; };
+		DFD810F91C54F25900BEE004 /* SimplePing.m in Sources */ = {isa = PBXBuildFile; fileRef = DFD810F61C54F25900BEE004 /* SimplePing.m */; };
+		DFD810FA1C54F25900BEE004 /* SimplePing.m in Sources */ = {isa = PBXBuildFile; fileRef = DFD810F61C54F25900BEE004 /* SimplePing.m */; };
 		DFD882E817DD189E001516FE /* StringValidation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFD882E517DD189E001516FE /* StringValidation.cpp */; };
 		DFD882E917DD189E001516FE /* StringValidation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFD882E517DD189E001516FE /* StringValidation.cpp */; };
 		DFD882F717DD1A5B001516FE /* AddonPythonInvoker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFD882F417DD1A5B001516FE /* AddonPythonInvoker.cpp */; };
@@ -3801,6 +3805,10 @@
 		DFD717531C0A031B0025D964 /* XBMCController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = XBMCController.mm; sourceTree = "<group>"; };
 		DFD717541C0A031B0025D964 /* XBMCDebugHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XBMCDebugHelpers.h; sourceTree = "<group>"; };
 		DFD717631C0A03540025D964 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		DFD810F31C54F25900BEE004 /* darwinICMPPing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = darwinICMPPing.h; sourceTree = "<group>"; };
+		DFD810F41C54F25900BEE004 /* darwinICMPPing.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = darwinICMPPing.m; sourceTree = "<group>"; };
+		DFD810F51C54F25900BEE004 /* SimplePing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SimplePing.h; sourceTree = "<group>"; };
+		DFD810F61C54F25900BEE004 /* SimplePing.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SimplePing.m; sourceTree = "<group>"; };
 		DFD882E517DD189E001516FE /* StringValidation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StringValidation.cpp; sourceTree = "<group>"; };
 		DFD882E617DD189E001516FE /* StringValidation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StringValidation.h; sourceTree = "<group>"; };
 		DFD882F417DD1A5B001516FE /* AddonPythonInvoker.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = AddonPythonInvoker.cpp; path = python/AddonPythonInvoker.cpp; sourceTree = "<group>"; };
@@ -5648,6 +5656,10 @@
 		4313772312D646E300680C15 /* osx */ = {
 			isa = PBXGroup;
 			children = (
+				DFD810F31C54F25900BEE004 /* darwinICMPPing.h */,
+				DFD810F41C54F25900BEE004 /* darwinICMPPing.m */,
+				DFD810F51C54F25900BEE004 /* SimplePing.h */,
+				DFD810F61C54F25900BEE004 /* SimplePing.m */,
 				E49ACD9D10074A4000A86ECD /* ZeroconfBrowserOSX.cpp */,
 				E49ACD9E10074A4000A86ECD /* ZeroconfBrowserOSX.h */,
 				E46F7C2C0F77219700C25D29 /* ZeroconfOSX.cpp */,
@@ -9275,6 +9287,7 @@
 				E38E206D0D25F9FD00618676 /* DirectoryNodeTitleMusicVideos.cpp in Sources */,
 				E38E206E0D25F9FD00618676 /* DirectoryNodeTitleTvShows.cpp in Sources */,
 				E38E206F0D25F9FD00618676 /* DirectoryNodeTvShowsOverview.cpp in Sources */,
+				DFD810F71C54F25900BEE004 /* darwinICMPPing.m in Sources */,
 				E38E20720D25F9FD00618676 /* QueryParams.cpp in Sources */,
 				E38E20730D25F9FD00618676 /* VideoDatabaseDirectory.cpp in Sources */,
 				E38E20740D25F9FD00618676 /* VirtualDirectory.cpp in Sources */,
@@ -9767,6 +9780,7 @@
 				F5E1053E140AA38100175026 /* PeripheralDisk.cpp in Sources */,
 				F5E1053F140AA38100175026 /* PeripheralHID.cpp in Sources */,
 				F5E10540140AA38100175026 /* PeripheralNIC.cpp in Sources */,
+				DFD810F91C54F25900BEE004 /* SimplePing.m in Sources */,
 				F5E10541140AA38100175026 /* PeripheralNyxboard.cpp in Sources */,
 				39520F911C3174EE00272121 /* AddonSystemSettings.cpp in Sources */,
 				F5E10542140AA38100175026 /* PeripheralTuner.cpp in Sources */,
@@ -10274,6 +10288,7 @@
 				E499118B174E5CE000741B6D /* Service.cpp in Sources */,
 				E499118C174E5CE000741B6D /* Skin.cpp in Sources */,
 				E499118D174E5CE000741B6D /* Visualisation.cpp in Sources */,
+				DFD810F81C54F25900BEE004 /* darwinICMPPing.m in Sources */,
 				E499118E174E5CE400741B6D /* CDDARipJob.cpp in Sources */,
 				E499118F174E5CE400741B6D /* CDDARipper.cpp in Sources */,
 				E4991190174E5CE400741B6D /* Encoder.cpp in Sources */,
@@ -10476,6 +10491,7 @@
 				E499127E174E5D9900741B6D /* DirectoryNodeAlbumCompilations.cpp in Sources */,
 				E499127F174E5D9900741B6D /* DirectoryNodeAlbumCompilationsSongs.cpp in Sources */,
 				E4991280174E5D9900741B6D /* DirectoryNodeAlbumRecentlyAdded.cpp in Sources */,
+				DFD810FA1C54F25900BEE004 /* SimplePing.m in Sources */,
 				395F6DDE1A8133360088CC74 /* GUIDialogSimpleMenu.cpp in Sources */,
 				E4991281174E5D9900741B6D /* DirectoryNodeAlbumRecentlyAddedSong.cpp in Sources */,
 				E4991282174E5D9900741B6D /* DirectoryNodeAlbumRecentlyPlayed.cpp in Sources */,

--- a/xbmc/network/osx/Makefile
+++ b/xbmc/network/osx/Makefile
@@ -1,7 +1,11 @@
-SRCS=ZeroconfBrowserOSX.cpp \
+.SUFFIXES : .m
+
+SRCS=SimplePing.m \
+     darwinICMPPing.m \
+     ZeroconfBrowserOSX.cpp \
      ZeroconfOSX.cpp
 
 LIB=network.a
 
 include ../../../Makefile.include
--include $(patsubst %.cpp,%.P,$(patsubst %.c,%.P,$(SRCS)))
+-include $(patsubst %.m,%.P,$(patsubst %.mm,%.P,$(patsubst %.cpp,%.P,$(patsubst %.c,%.P,$(SRCS)))))

--- a/xbmc/network/osx/SimplePing.h
+++ b/xbmc/network/osx/SimplePing.h
@@ -1,0 +1,196 @@
+/*
+    File:       SimplePing.h
+
+    Contains:   Implements ping.
+
+    Written by: DTS
+
+    Copyright:  Copyright (c) 2010-2012 Apple Inc. All Rights Reserved.
+
+    Disclaimer: IMPORTANT: This Apple software is supplied to you by Apple Inc.
+                ("Apple") in consideration of your agreement to the following
+                terms, and your use, installation, modification or
+                redistribution of this Apple software constitutes acceptance of
+                these terms.  If you do not agree with these terms, please do
+                not use, install, modify or redistribute this Apple software.
+
+                In consideration of your agreement to abide by the following
+                terms, and subject to these terms, Apple grants you a personal,
+                non-exclusive license, under Apple's copyrights in this
+                original Apple software (the "Apple Software"), to use,
+                reproduce, modify and redistribute the Apple Software, with or
+                without modifications, in source and/or binary forms; provided
+                that if you redistribute the Apple Software in its entirety and
+                without modifications, you must retain this notice and the
+                following text and disclaimers in all such redistributions of
+                the Apple Software. Neither the name, trademarks, service marks
+                or logos of Apple Inc. may be used to endorse or promote
+                products derived from the Apple Software without specific prior
+                written permission from Apple.  Except as expressly stated in
+                this notice, no other rights or licenses, express or implied,
+                are granted by Apple herein, including but not limited to any
+                patent rights that may be infringed by your derivative works or
+                by other works in which the Apple Software may be incorporated.
+
+                The Apple Software is provided by Apple on an "AS IS" basis. 
+                APPLE MAKES NO WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+                WITHOUT LIMITATION THE IMPLIED WARRANTIES OF NON-INFRINGEMENT,
+                MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, REGARDING
+                THE APPLE SOFTWARE OR ITS USE AND OPERATION ALONE OR IN
+                COMBINATION WITH YOUR PRODUCTS.
+
+                IN NO EVENT SHALL APPLE BE LIABLE FOR ANY SPECIAL, INDIRECT,
+                INCIDENTAL OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+                TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+                DATA, OR PROFITS; OR BUSINESS INTERRUPTION) ARISING IN ANY WAY
+                OUT OF THE USE, REPRODUCTION, MODIFICATION AND/OR DISTRIBUTION
+                OF THE APPLE SOFTWARE, HOWEVER CAUSED AND WHETHER UNDER THEORY
+                OF CONTRACT, TORT (INCLUDING NEGLIGENCE), STRICT LIABILITY OR
+                OTHERWISE, EVEN IF APPLE HAS BEEN ADVISED OF THE POSSIBILITY OF
+                SUCH DAMAGE.
+
+*/
+
+#import <Foundation/Foundation.h>
+
+#if TARGET_OS_EMBEDDED || TARGET_IPHONE_SIMULATOR
+    #import <CFNetwork/CFNetwork.h>
+#else
+    #import <CoreServices/CoreServices.h>
+#endif
+
+#include <AssertMacros.h>
+
+#pragma mark * SimplePing
+
+// The SimplePing class is a very simple class that lets you send and receive pings.
+
+@protocol SimplePingDelegate;
+
+@interface SimplePing : NSObject
+
++ (SimplePing *)simplePingWithHostName:(NSString *)hostName;        // chooses first IPv4 address
++ (SimplePing *)simplePingWithHostAddress:(NSData *)hostAddress;    // contains (struct sockaddr)
+
+@property (nonatomic, assign, readwrite) id<SimplePingDelegate> delegate;
+
+@property (nonatomic, copy,   readonly ) NSString *             hostName;
+@property (nonatomic, copy,   readonly ) NSData *               hostAddress;
+@property (nonatomic, assign, readonly ) uint16_t               identifier;
+@property (nonatomic, assign, readonly ) uint16_t               nextSequenceNumber;
+
+- (void)start;
+    // Starts the pinger object pinging.  You should call this after 
+    // you've setup the delegate and any ping parameters.
+
+- (void)sendPingWithData:(NSData *)data;
+    // Sends an actual ping.  Pass nil for data to use a standard 56 byte payload (resulting in a 
+    // standard 64 byte ping).  Otherwise pass a non-nil value and it will be appended to the 
+    // ICMP header.
+    //
+    // Do not try to send a ping before you receive the -simplePing:didStartWithAddress: delegate 
+    // callback.
+
+- (void)stop;
+    // Stops the pinger object.  You should call this when you're done 
+    // pinging.
+
++ (const struct ICMPHeader *)icmpInPacket:(NSData *)packet;
+    // Given a valid IP packet contains an ICMP , returns the address of the ICMP header that 
+    // follows the IP header.  This doesn't do any significant validation of the packet.
+
+@end
+
+@protocol SimplePingDelegate <NSObject>
+
+@optional
+
+- (void)simplePing:(SimplePing *)pinger didStartWithAddress:(NSData *)address;
+    // Called after the SimplePing has successfully started up.  After this callback, you 
+    // can start sending pings via -sendPingWithData:
+    
+- (void)simplePing:(SimplePing *)pinger didFailWithError:(NSError *)error;
+    // If this is called, the SimplePing object has failed.  By the time this callback is 
+    // called, the object has stopped (that is, you don't need to call -stop yourself).
+
+// IMPORTANT: On the send side the packet does not include an IP header. 
+// On the receive side, it does.  In that case, use +[SimplePing icmpInPacket:] 
+// to find the ICMP header within the packet.
+
+- (void)simplePing:(SimplePing *)pinger didSendPacket:(NSData *)packet;
+    // Called whenever the SimplePing object has successfully sent a ping packet. 
+    
+- (void)simplePing:(SimplePing *)pinger didFailToSendPacket:(NSData *)packet error:(NSError *)error;
+    // Called whenever the SimplePing object tries and fails to send a ping packet.
+
+- (void)simplePing:(SimplePing *)pinger didReceivePingResponsePacket:(NSData *)packet;
+    // Called whenever the SimplePing object receives an ICMP packet that looks like 
+    // a response to one of our pings (that is, has a valid ICMP checksum, has 
+    // an identifier that matches our identifier, and has a sequence number in 
+    // the range of sequence numbers that we've sent out).
+
+- (void)simplePing:(SimplePing *)pinger didReceiveUnexpectedPacket:(NSData *)packet;
+    // Called whenever the SimplePing object receives an ICMP packet that does not 
+    // look like a response to one of our pings.
+
+@end
+
+#pragma mark * IP and ICMP On-The-Wire Format
+
+// The following declarations specify the structure of ping packets on the wire.
+
+// IP header structure:
+
+struct IPHeader {
+    uint8_t     versionAndHeaderLength;
+    uint8_t     differentiatedServices;
+    uint16_t    totalLength;
+    uint16_t    identification;
+    uint16_t    flagsAndFragmentOffset;
+    uint8_t     timeToLive;
+    uint8_t     protocol;
+    uint16_t    headerChecksum;
+    uint8_t     sourceAddress[4];
+    uint8_t     destinationAddress[4];
+    // options...
+    // data...
+};
+typedef struct IPHeader IPHeader;
+
+check_compile_time(sizeof(IPHeader) == 20);
+check_compile_time(offsetof(IPHeader, versionAndHeaderLength) == 0);
+check_compile_time(offsetof(IPHeader, differentiatedServices) == 1);
+check_compile_time(offsetof(IPHeader, totalLength) == 2);
+check_compile_time(offsetof(IPHeader, identification) == 4);
+check_compile_time(offsetof(IPHeader, flagsAndFragmentOffset) == 6);
+check_compile_time(offsetof(IPHeader, timeToLive) == 8);
+check_compile_time(offsetof(IPHeader, protocol) == 9);
+check_compile_time(offsetof(IPHeader, headerChecksum) == 10);
+check_compile_time(offsetof(IPHeader, sourceAddress) == 12);
+check_compile_time(offsetof(IPHeader, destinationAddress) == 16);
+
+// ICMP type and code combinations:
+
+enum {
+    kICMPTypeEchoReply   = 0,           // code is always 0
+    kICMPTypeEchoRequest = 8            // code is always 0
+};
+
+// ICMP header structure:
+
+struct ICMPHeader {
+    uint8_t     type;
+    uint8_t     code;
+    uint16_t    checksum;
+    uint16_t    identifier;
+    uint16_t    sequenceNumber;
+    // data...
+};
+typedef struct ICMPHeader ICMPHeader;
+
+check_compile_time(sizeof(ICMPHeader) == 8);
+check_compile_time(offsetof(ICMPHeader, type) == 0);
+check_compile_time(offsetof(ICMPHeader, code) == 1);
+check_compile_time(offsetof(ICMPHeader, checksum) == 2);
+check_compile_time(offsetof(ICMPHeader, identifier) == 4);
+check_compile_time(offsetof(ICMPHeader, sequenceNumber) == 6);

--- a/xbmc/network/osx/SimplePing.m
+++ b/xbmc/network/osx/SimplePing.m
@@ -1,0 +1,626 @@
+/*
+    File:       SimplePing.m
+
+    Contains:   Implements ping.
+
+    Written by: DTS
+
+    Copyright:  Copyright (c) 2010-2012 Apple Inc. All Rights Reserved.
+
+    Disclaimer: IMPORTANT: This Apple software is supplied to you by Apple Inc.
+                ("Apple") in consideration of your agreement to the following
+                terms, and your use, installation, modification or
+                redistribution of this Apple software constitutes acceptance of
+                these terms.  If you do not agree with these terms, please do
+                not use, install, modify or redistribute this Apple software.
+
+                In consideration of your agreement to abide by the following
+                terms, and subject to these terms, Apple grants you a personal,
+                non-exclusive license, under Apple's copyrights in this
+                original Apple software (the "Apple Software"), to use,
+                reproduce, modify and redistribute the Apple Software, with or
+                without modifications, in source and/or binary forms; provided
+                that if you redistribute the Apple Software in its entirety and
+                without modifications, you must retain this notice and the
+                following text and disclaimers in all such redistributions of
+                the Apple Software. Neither the name, trademarks, service marks
+                or logos of Apple Inc. may be used to endorse or promote
+                products derived from the Apple Software without specific prior
+                written permission from Apple.  Except as expressly stated in
+                this notice, no other rights or licenses, express or implied,
+                are granted by Apple herein, including but not limited to any
+                patent rights that may be infringed by your derivative works or
+                by other works in which the Apple Software may be incorporated.
+
+                The Apple Software is provided by Apple on an "AS IS" basis. 
+                APPLE MAKES NO WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+                WITHOUT LIMITATION THE IMPLIED WARRANTIES OF NON-INFRINGEMENT,
+                MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, REGARDING
+                THE APPLE SOFTWARE OR ITS USE AND OPERATION ALONE OR IN
+                COMBINATION WITH YOUR PRODUCTS.
+
+                IN NO EVENT SHALL APPLE BE LIABLE FOR ANY SPECIAL, INDIRECT,
+                INCIDENTAL OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+                TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+                DATA, OR PROFITS; OR BUSINESS INTERRUPTION) ARISING IN ANY WAY
+                OUT OF THE USE, REPRODUCTION, MODIFICATION AND/OR DISTRIBUTION
+                OF THE APPLE SOFTWARE, HOWEVER CAUSED AND WHETHER UNDER THEORY
+                OF CONTRACT, TORT (INCLUDING NEGLIGENCE), STRICT LIABILITY OR
+                OTHERWISE, EVEN IF APPLE HAS BEEN ADVISED OF THE POSSIBILITY OF
+                SUCH DAMAGE.
+
+*/
+
+#import "SimplePing.h"
+
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <errno.h>
+
+#pragma mark * ICMP On-The-Wire Format
+
+static uint16_t in_cksum(const void *buffer, size_t bufferLen)
+    // This is the standard BSD checksum code, modified to use modern types.
+{
+	size_t           bytesLeft;
+  int32_t          sum;
+	const uint16_t  *cursor;
+	union {
+		uint16_t        us;
+		uint8_t         uc[2];
+	} last;
+	uint16_t          answer;
+
+	bytesLeft = bufferLen;
+	sum = 0;
+	cursor = (const uint16_t*)buffer;
+
+	/*
+	 * Our algorithm is simple, using a 32 bit accumulator (sum), we add
+	 * sequential 16 bit words to it, and at the end, fold back all the
+	 * carry bits from the top 16 bits into the lower 16 bits.
+	 */
+	while (bytesLeft > 1) {
+		sum += *cursor;
+        cursor += 1;
+		bytesLeft -= 2;
+	}
+
+	/* mop up an odd byte, if necessary */
+	if (bytesLeft == 1) {
+		last.uc[0] = * (const uint8_t *) cursor;
+		last.uc[1] = 0;
+		sum += last.us;
+	}
+
+	/* add back carry outs from top 16 bits to low 16 bits */
+	sum = (sum >> 16) + (sum & 0xffff);	/* add hi 16 to low 16 */
+	sum += (sum >> 16);			/* add carry */
+	answer = (uint16_t) ~sum;   /* truncate to 16 bits */
+
+	return answer;
+}
+
+#pragma mark * SimplePing
+
+@interface SimplePing ()
+
+@property (nonatomic, copy,   readwrite) NSData *           hostAddress;
+@property (nonatomic, assign, readwrite) uint16_t           nextSequenceNumber;
+
+- (void)stopHostResolution;
+- (void)stopDataTransfer;
+
+@end
+
+@implementation SimplePing
+{
+    CFHostRef               _host;
+    CFSocketRef             _socket;
+}
+
+@synthesize hostName           = _hostName;
+@synthesize hostAddress        = _hostAddress;
+
+@synthesize delegate           = _delegate;
+@synthesize identifier         = _identifier;
+@synthesize nextSequenceNumber = _nextSequenceNumber;
+
+- (id)initWithHostName:(NSString *)hostName address:(NSData *)hostAddress
+    // The initialiser common to both of our construction class methods.
+{
+    assert( (hostName != nil) == (hostAddress == nil) );
+    self = [super init];
+    if (self != nil) {
+        self->_hostName    = [hostName copy];
+        self->_hostAddress = [hostAddress copy];
+        self->_identifier  = (uint16_t) arc4random();
+    }
+    return self;
+}
+
+- (void)dealloc
+{
+    // -stop takes care of _host and _socket.
+    [self stop];
+    assert(self->_host == NULL);
+    assert(self->_socket == NULL);
+}
+
++ (SimplePing *)simplePingWithHostName:(NSString *)hostName
+    // See comment in header.
+{
+    return [[SimplePing alloc] initWithHostName:hostName address:nil];
+}
+
++ (SimplePing *)simplePingWithHostAddress:(NSData *)hostAddress
+    // See comment in header.
+{
+    return [[SimplePing alloc] initWithHostName:NULL address:hostAddress];
+}
+
+- (void)noop
+{
+}
+
+- (void)didFailWithError:(NSError *)error
+    // Shut down the pinger object and tell the delegate about the error.
+{
+    assert(error != nil);
+    
+    // We retain ourselves temporarily because it's common for the delegate method 
+    // to release its last reference to use, which causes -dealloc to be called here. 
+    // If we then reference self on the return path, things go badly.  I don't think 
+    // that happens currently, but I've got into the habit of doing this as a 
+    // defensive measure.
+    
+    [self performSelector:@selector(noop) withObject:nil afterDelay:0.0];
+    
+    [self stop];
+    if ( (self.delegate != nil) && [self.delegate respondsToSelector:@selector(simplePing:didFailWithError:)] ) {
+        [self.delegate simplePing:self didFailWithError:error];
+    }
+}
+
+- (void)didFailWithHostStreamError:(CFStreamError)streamError
+    // Convert the CFStreamError to an NSError and then call through to 
+    // -didFailWithError: to shut down the pinger object and tell the 
+    // delegate about the error.
+{
+    NSDictionary *  userInfo;
+    NSError *       error;
+
+    if (streamError.domain == kCFStreamErrorDomainNetDB) {
+        userInfo = [NSDictionary dictionaryWithObjectsAndKeys:
+            [NSNumber numberWithInteger:streamError.error], kCFGetAddrInfoFailureKey,
+            nil
+        ];
+    } else {
+        userInfo = nil;
+    }
+    error = [NSError errorWithDomain:(NSString *)kCFErrorDomainCFNetwork code:kCFHostErrorUnknown userInfo:userInfo];
+    assert(error != nil);
+
+    [self didFailWithError:error];
+}
+
+- (void)sendPingWithData:(NSData *)data
+    // See comment in header.
+{
+    int             err;
+    NSData *        payload;
+    NSMutableData * packet;
+    ICMPHeader *    icmpPtr;
+    ssize_t         bytesSent;
+    
+    // Construct the ping packet.
+    payload = data;
+    if (payload == nil) {
+        payload = [[NSString stringWithFormat:@"%28zd bottles of beer on the wall", (ssize_t) 99 - (size_t) (self.nextSequenceNumber % 100) ] dataUsingEncoding:NSASCIIStringEncoding];
+        assert(payload != nil);
+        
+        assert([payload length] == 56);
+    }
+    
+    packet = [NSMutableData dataWithLength:sizeof(*icmpPtr) + [payload length]];
+    assert(packet != nil);
+
+    icmpPtr = (ICMPHeader*)[packet mutableBytes];
+    icmpPtr->type = kICMPTypeEchoRequest;
+    icmpPtr->code = 0;
+    icmpPtr->checksum = 0;
+    icmpPtr->identifier     = OSSwapHostToBigInt16(self.identifier);
+    icmpPtr->sequenceNumber = OSSwapHostToBigInt16(self.nextSequenceNumber);
+    memcpy(&icmpPtr[1], [payload bytes], [payload length]);
+    
+    // The IP checksum returns a 16-bit number that's already in correct byte order 
+    // (due to wacky 1's complement maths), so we just put it into the packet as a 
+    // 16-bit unit.
+    
+    icmpPtr->checksum = in_cksum([packet bytes], [packet length]);
+    
+    // Send the packet.
+    
+    if (self->_socket == NULL) {
+        bytesSent = -1;
+        err = EBADF;
+    } else {
+        bytesSent = sendto(
+            CFSocketGetNative(self->_socket),
+            [packet bytes],
+            [packet length], 
+            0, 
+            (struct sockaddr *) [self.hostAddress bytes], 
+            (socklen_t) [self.hostAddress length]
+        );
+        err = 0;
+        if (bytesSent < 0) {
+            err = errno;
+        }
+    }
+
+    // Handle the results of the send.
+    
+    if ( (bytesSent > 0) && (((NSUInteger) bytesSent) == [packet length]) ) {
+
+        // Complete success.  Tell the client.
+
+        if ( (self.delegate != nil) && [self.delegate respondsToSelector:@selector(simplePing:didSendPacket:)] ) {
+            [self.delegate simplePing:self didSendPacket:packet];
+        }
+    } else {
+        NSError *   error;
+        
+        // Some sort of failure.  Tell the client.
+        
+        if (err == 0) {
+            err = ENOBUFS;          // This is not a hugely descriptor error, alas.
+        }
+        error = [NSError errorWithDomain:NSPOSIXErrorDomain code:err userInfo:nil];
+        if ( (self.delegate != nil) && [self.delegate respondsToSelector:@selector(simplePing:didFailToSendPacket:error:)] ) {
+            [self.delegate simplePing:self didFailToSendPacket:packet error:error];
+        }
+    }
+    
+    self.nextSequenceNumber += 1;
+}
+
++ (NSUInteger)icmpHeaderOffsetInPacket:(NSData *)packet
+    // Returns the offset of the ICMPHeader within an IP packet.
+{
+    NSUInteger              result;
+    const struct IPHeader * ipPtr;
+    size_t                  ipHeaderLength;
+    
+    result = NSNotFound;
+    if ([packet length] >= (sizeof(IPHeader) + sizeof(ICMPHeader))) {
+        ipPtr = (const IPHeader *) [packet bytes];
+        assert((ipPtr->versionAndHeaderLength & 0xF0) == 0x40);     // IPv4
+        assert(ipPtr->protocol == 1);                               // ICMP
+        ipHeaderLength = (ipPtr->versionAndHeaderLength & 0x0F) * sizeof(uint32_t);
+        if ([packet length] >= (ipHeaderLength + sizeof(ICMPHeader))) {
+            result = ipHeaderLength;
+        }
+    }
+    return result;
+}
+
++ (const struct ICMPHeader *)icmpInPacket:(NSData *)packet
+    // See comment in header.
+{
+    const struct ICMPHeader *   result;
+    NSUInteger                  icmpHeaderOffset;
+    
+    result = nil;
+    icmpHeaderOffset = [self icmpHeaderOffsetInPacket:packet];
+    if (icmpHeaderOffset != NSNotFound) {
+        result = (const struct ICMPHeader *) (((const uint8_t *)[packet bytes]) + icmpHeaderOffset);
+    }
+    return result;
+}
+
+- (BOOL)isValidPingResponsePacket:(NSMutableData *)packet
+    // Returns true if the packet looks like a valid ping response packet destined 
+    // for us.
+{
+    BOOL                result;
+    NSUInteger          icmpHeaderOffset;
+    ICMPHeader *        icmpPtr;
+    uint16_t            receivedChecksum;
+    uint16_t            calculatedChecksum;
+    
+    result = NO;
+    
+    icmpHeaderOffset = [[self class] icmpHeaderOffsetInPacket:packet];
+    if (icmpHeaderOffset != NSNotFound) {
+        icmpPtr = (struct ICMPHeader *) (((uint8_t *)[packet mutableBytes]) + icmpHeaderOffset);
+
+        receivedChecksum   = icmpPtr->checksum;
+        icmpPtr->checksum  = 0;
+        calculatedChecksum = in_cksum(icmpPtr, [packet length] - icmpHeaderOffset);
+        icmpPtr->checksum  = receivedChecksum;
+        
+        if (receivedChecksum == calculatedChecksum) {
+            if ( (icmpPtr->type == kICMPTypeEchoReply) && (icmpPtr->code == 0) ) {
+                if ( OSSwapBigToHostInt16(icmpPtr->identifier) == self.identifier ) {
+                    if ( OSSwapBigToHostInt16(icmpPtr->sequenceNumber) < self.nextSequenceNumber ) {
+                        result = YES;
+                    }
+                }
+            }
+        }
+    }
+
+    return result;
+}
+
+- (void)readData
+    // Called by the socket handling code (SocketReadCallback) to process an ICMP 
+    // messages waiting on the socket.
+{
+    int                     err;
+    struct sockaddr_storage addr;
+    socklen_t               addrLen;
+    ssize_t                 bytesRead;
+    void *                  buffer;
+    enum { kBufferSize = 65535 };
+
+    // 65535 is the maximum IP packet size, which seems like a reasonable bound 
+    // here (plus it's what <x-man-page://8/ping> uses).
+    
+    buffer = malloc(kBufferSize);
+    assert(buffer != NULL);
+    
+    // Actually read the data.
+    
+    addrLen = sizeof(addr);
+    bytesRead = recvfrom(CFSocketGetNative(self->_socket), buffer, kBufferSize, 0, (struct sockaddr *) &addr, &addrLen);
+    err = 0;
+    if (bytesRead < 0) {
+        err = errno;
+    }
+    
+    // Process the data we read.
+    
+    if (bytesRead > 0) {
+        NSMutableData *     packet;
+
+        packet = [NSMutableData dataWithBytes:buffer length:(NSUInteger) bytesRead];
+        assert(packet != nil);
+
+        // We got some data, pass it up to our client.
+
+        if ( [self isValidPingResponsePacket:packet] ) {
+            if ( (self.delegate != nil) && [self.delegate respondsToSelector:@selector(simplePing:didReceivePingResponsePacket:)] ) {
+                [self.delegate simplePing:self didReceivePingResponsePacket:packet];
+            }
+        } else {
+            if ( (self.delegate != nil) && [self.delegate respondsToSelector:@selector(simplePing:didReceiveUnexpectedPacket:)] ) {
+                [self.delegate simplePing:self didReceiveUnexpectedPacket:packet];
+            }
+        }
+    } else {
+    
+        // We failed to read the data, so shut everything down.
+        
+        if (err == 0) {
+            err = EPIPE;
+        }
+        [self didFailWithError:[NSError errorWithDomain:NSPOSIXErrorDomain code:err userInfo:nil]];
+    }
+    
+    free(buffer);
+    
+    // Note that we don't loop back trying to read more data.  Rather, we just 
+    // let CFSocket call us again.
+}
+
+static void SocketReadCallback(CFSocketRef s, CFSocketCallBackType type, CFDataRef address, const void *data, void *info)
+    // This C routine is called by CFSocket when there's data waiting on our 
+    // ICMP socket.  It just redirects the call to Objective-C code.
+{
+    SimplePing *    obj;
+    
+    obj = (__bridge SimplePing *) info;
+    assert([obj isKindOfClass:[SimplePing class]]);
+    
+    #pragma unused(s)
+    assert(s == obj->_socket);
+    #pragma unused(type)
+    assert(type == kCFSocketReadCallBack);
+    #pragma unused(address)
+    assert(address == nil);
+    #pragma unused(data)
+    assert(data == nil);
+    
+    [obj readData];
+}
+
+- (void)startWithHostAddress
+    // We have a host address, so let's actually start pinging it.
+{
+    int                     err;
+    int                     fd;
+    const struct sockaddr * addrPtr;
+
+    assert(self.hostAddress != nil);
+
+    // Open the socket.
+    
+    addrPtr = (const struct sockaddr *) [self.hostAddress bytes];
+
+    fd = -1;
+    err = 0;
+    switch (addrPtr->sa_family) {
+        case AF_INET: {
+            fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_ICMP);
+            if (fd < 0) {
+                err = errno;
+            }
+        } break;
+        case AF_INET6:
+            assert(NO);
+            // fall through
+        default: {
+            err = EPROTONOSUPPORT;
+        } break;
+    }
+    
+    if (err != 0) {
+        [self didFailWithError:[NSError errorWithDomain:NSPOSIXErrorDomain code:err userInfo:nil]];
+    } else {
+        CFSocketContext     context = {0, (__bridge void *)(self), NULL, NULL, NULL};
+        CFRunLoopSourceRef  rls;
+        
+        // Wrap it in a CFSocket and schedule it on the runloop.
+        
+        self->_socket = CFSocketCreateWithNative(NULL, fd, kCFSocketReadCallBack, SocketReadCallback, &context);
+        assert(self->_socket != NULL);
+        
+        // The socket will now take care of cleaning up our file descriptor.
+        
+        assert( CFSocketGetSocketFlags(self->_socket) & kCFSocketCloseOnInvalidate );
+        fd = -1;
+        
+        rls = CFSocketCreateRunLoopSource(NULL, self->_socket, 0);
+        assert(rls != NULL);
+        
+        CFRunLoopAddSource(CFRunLoopGetCurrent(), rls, kCFRunLoopDefaultMode);
+        
+        CFRelease(rls);
+
+        if ( (self.delegate != nil) && [self.delegate respondsToSelector:@selector(simplePing:didStartWithAddress:)] ) {
+            [self.delegate simplePing:self didStartWithAddress:self.hostAddress];
+        }
+    }
+    assert(fd == -1);
+}
+
+- (void)hostResolutionDone
+    // Called by our CFHost resolution callback (HostResolveCallback) when host 
+    // resolution is complete.  We just latch the first IPv4 address and kick 
+    // off the pinging process.
+{
+    Boolean     resolved;
+    NSArray *   addresses;
+    
+    // Find the first IPv4 address.
+    
+    addresses = (__bridge NSArray *) CFHostGetAddressing(self->_host, &resolved);
+    if ( resolved && (addresses != nil) ) {
+        resolved = false;
+        for (NSData * address in addresses) {
+            const struct sockaddr * addrPtr;
+            
+            addrPtr = (const struct sockaddr *) [address bytes];
+            if ( [address length] >= sizeof(struct sockaddr) && addrPtr->sa_family == AF_INET) {
+                self.hostAddress = address;
+                resolved = true;
+                break;
+            }
+        }
+    }
+
+    // We're done resolving, so shut that down.
+    
+    [self stopHostResolution];
+    
+    // If all is OK, start pinging, otherwise shut down the pinger completely.
+    
+    if (resolved) {
+        [self startWithHostAddress];
+    } else {
+        [self didFailWithError:[NSError errorWithDomain:(NSString *)kCFErrorDomainCFNetwork code:kCFHostErrorHostNotFound userInfo:nil]];
+    }
+}
+
+static void HostResolveCallback(CFHostRef theHost, CFHostInfoType typeInfo, const CFStreamError *error, void *info)
+    // This C routine is called by CFHost when the host resolution is complete. 
+    // It just redirects the call to the appropriate Objective-C method.
+{
+    SimplePing *    obj;
+
+    //NSLog(@">HostResolveCallback");
+    
+    obj = (__bridge SimplePing *) info;
+    assert([obj isKindOfClass:[SimplePing class]]);
+    
+    #pragma unused(theHost)
+    assert(theHost == obj->_host);
+    #pragma unused(typeInfo)
+    assert(typeInfo == kCFHostAddresses);
+    
+    if ( (error != NULL) && (error->domain != 0) ) {
+        [obj didFailWithHostStreamError:*error];
+    } else {
+        [obj hostResolutionDone];
+    }
+}
+
+- (void)start
+    // See comment in header.
+{
+    // If the user supplied us with an address, just start pinging that.  Otherwise 
+    // start a host resolution.
+    
+    if (self->_hostAddress != nil) {
+        [self startWithHostAddress];
+    } else {
+        Boolean             success;
+        CFHostClientContext context = {0, (__bridge void *)(self), NULL, NULL, NULL};
+        CFStreamError       streamError;
+
+        assert(self->_host == NULL);
+
+        self->_host = CFHostCreateWithName(NULL, (__bridge CFStringRef) self.hostName);
+        assert(self->_host != NULL);
+        
+        CFHostSetClient(self->_host, HostResolveCallback, &context);
+        
+        CFHostScheduleWithRunLoop(self->_host, CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
+        
+        //NSLog(@">CFHostStartInfoResolution");
+        success = CFHostStartInfoResolution(self->_host, kCFHostAddresses, &streamError);
+        //NSLog(@"<CFHostStartInfoResolution");
+        if ( ! success ) {
+            [self didFailWithHostStreamError:streamError];
+        }
+    }
+}
+
+- (void)stopHostResolution
+    // Shut down the CFHost.
+{
+    if (self->_host != NULL) {
+        CFHostSetClient(self->_host, NULL, NULL);
+        CFHostUnscheduleFromRunLoop(self->_host, CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
+        CFRelease(self->_host);
+        self->_host = NULL;
+    }
+}
+
+- (void)stopDataTransfer   
+    // Shut down anything to do with sending and receiving pings.
+{
+    if (self->_socket != NULL) {
+        CFSocketInvalidate(self->_socket);
+        CFRelease(self->_socket);
+        self->_socket = NULL;
+    }
+}
+
+- (void)stop
+    // See comment in header.
+{
+    [self stopHostResolution];
+    [self stopDataTransfer];
+    
+    // If we were started with a host name, junk the host address on stop.  If the 
+    // client calls -start again, we'll re-resolve the host name.
+    
+    if (self.hostName != nil) {
+        self.hostAddress = NULL;
+    }
+}
+
+@end

--- a/xbmc/network/osx/darwinICMPPing.h
+++ b/xbmc/network/osx/darwinICMPPing.h
@@ -1,0 +1,32 @@
+#pragma once
+/*
+ *      Copyright (C) 2015 Team MrMC
+ *      https://github.com/MrMC
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with MrMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int darwinICMPPingHost(const char *host, unsigned int timeout_ms);
+int darwinICMPPing(in_addr_t remote_ip, unsigned int timeout_ms);
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/xbmc/network/osx/darwinICMPPing.m
+++ b/xbmc/network/osx/darwinICMPPing.m
@@ -1,0 +1,221 @@
+/*
+ *      Copyright (C) 2015 Team MrMC
+ *      https://github.com/MrMC
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with MrMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <sysexits.h>
+#include <arpa/inet.h>
+
+#import "SimplePing.h"
+#import "darwinICMPPing.h"
+
+NSString * const kdidStartWithAddress         = @"didStartWithAddress";
+NSString * const kdidFailWithError            = @"didFailWithError";
+NSString * const kdidFailToSendPacket         = @"didFailToSendPacket";
+NSString * const kdidReceiveUnexpectedPacket  = @"didReceiveUnexpectedPacket";
+
+@interface SimplePingClient : NSObject<SimplePingDelegate>
++(void)pingHostname:(NSString*)hostName andResultCallback:(void(^)(NSString* result))result;
++(void)pingHostAddress:(NSData*)hostAddress andResultCallback:(void(^)(NSString* result))result;
+@end
+
+int darwinICMPPingHost(const char *host, unsigned int timeout_ms)
+{
+  // also checks if host is a name or ip address
+  struct sockaddr_in callAddress = {0};
+  callAddress.sin_len = sizeof(callAddress);
+  callAddress.sin_family = AF_INET;
+  callAddress.sin_addr.s_addr = inet_addr(host);
+
+  __block NSString *results = kdidStartWithAddress;
+  if (callAddress.sin_addr.s_addr != INADDR_NONE)
+  {
+    [SimplePingClient pingHostAddress:[NSData dataWithBytes:&callAddress length:sizeof(callAddress)]
+             andResultCallback:^(NSString *callbackresults) {
+      results = callbackresults;
+    }];
+  }
+  else
+  {
+    [SimplePingClient pingHostname:[NSString stringWithCString:host encoding:NSUTF8StringEncoding]
+             andResultCallback:^(NSString *callbackresults) {
+      results = callbackresults;
+    }];
+  }
+  
+  float timout_secs = (float)timeout_ms / 1000.0;
+  [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:timout_secs]];
+
+  if ([results isEqualToString:kdidStartWithAddress])
+  {
+    // host address did not reply, it is not present
+    return -1;
+  }
+  else if ([results isEqualToString:kdidFailWithError])
+  {
+    return -1;
+  }
+  else if ([results isEqualToString:kdidFailToSendPacket])
+  {
+    return -1;
+  }
+  else if ([results isEqualToString:kdidReceiveUnexpectedPacket])
+  {
+    return -1;
+  }
+/*
+  else
+  {
+    NSLog(@"the latency is: %@", results);
+  }
+*/
+  return 0;
+}
+
+int darwinICMPPing(in_addr_t remote_ip, unsigned int timeout_ms)
+{
+  // also checks if host is a name or ip address
+  struct sockaddr_in callAddress = {0};
+  callAddress.sin_len = sizeof(callAddress);
+  callAddress.sin_family = AF_INET;
+  callAddress.sin_addr.s_addr = remote_ip;
+
+  __block NSString *results = kdidStartWithAddress;
+  [SimplePingClient pingHostAddress:[NSData dataWithBytes:&callAddress length:sizeof(callAddress)]
+           andResultCallback:^(NSString *callbackresults) {
+    results = callbackresults;
+  }];
+  
+  float timout_secs = (float)timeout_ms / 1000.0;
+  [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:timout_secs]];
+
+  if ([results isEqualToString:kdidStartWithAddress])
+  {
+    // host address did not reply, it is not present
+    return -1;
+  }
+  else if ([results isEqualToString:kdidFailWithError])
+  {
+    return -1;
+  }
+  else if ([results isEqualToString:kdidFailToSendPacket])
+  {
+    return -1;
+  }
+  else if ([results isEqualToString:kdidReceiveUnexpectedPacket])
+  {
+    return -1;
+  }
+/*
+  else
+  {
+    NSLog(@"the latency is: %@", results);
+  }
+*/
+  return 0;
+}
+
+
+//********************************************************************************************
+@interface SimplePingClient()
+{
+  SimplePing* _pingClient;
+  NSDate* _dateReference;
+}
+@property(nonatomic, strong) void(^resultCallback)(NSString* result);
+@end
+
+@implementation SimplePingClient
+
++(void)pingHostname:(NSString*)hostName andResultCallback:(void(^)(NSString* result))result
+{
+  static SimplePingClient* singletonPC = nil;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+      singletonPC = [[SimplePingClient alloc] init];
+  });
+
+  //ping hostname
+  [singletonPC pingHostname:hostName andResultCallBlock:result];
+}
+
++(void)pingHostAddress:(NSData*)hostAddress andResultCallback:(void(^)(NSString* result))result
+{
+  static SimplePingClient* singletonPC = nil;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+      singletonPC = [[SimplePingClient alloc] init];
+  });
+
+  //ping hostaddress
+  [singletonPC pingHostAddress:hostAddress andResultCallBlock:result];
+}
+
+-(void)pingHostname:(NSString*)hostName andResultCallBlock:(void(^)(NSString* result))result
+{
+  _resultCallback = result;
+  _pingClient = [SimplePing simplePingWithHostName:hostName];
+  _pingClient.delegate = self;
+  [_pingClient start];
+}
+
+-(void)pingHostAddress:(NSData*)hostAddress andResultCallBlock:(void(^)(NSString* result))result
+{
+  _resultCallback = result;
+  _pingClient = [SimplePing simplePingWithHostAddress:hostAddress];
+  _pingClient.delegate = self;
+  [_pingClient start];
+}
+
+#pragma mark - SimplePingDelegate methods
+- (void)simplePing:(SimplePing *)pinger didStartWithAddress:(NSData *)address
+{
+  [pinger sendPingWithData:nil];
+}
+
+- (void)simplePing:(SimplePing *)pinger didFailWithError:(NSError *)error
+{
+  _resultCallback(kdidFailWithError);
+}
+
+- (void)simplePing:(SimplePing *)pinger didSendPacket:(NSData *)packet
+{
+  _dateReference = [NSDate date];
+}
+
+- (void)simplePing:(SimplePing *)pinger didFailToSendPacket:(NSData *)packet error:(NSError *)error
+{
+  [pinger stop];
+  _resultCallback(kdidFailToSendPacket);
+}
+
+- (void)simplePing:(SimplePing *)pinger didReceivePingResponsePacket:(NSData *)packet
+{
+  [pinger stop];
+  NSDate *end = [NSDate date];
+  double result_ms = [end timeIntervalSinceDate:_dateReference] * 1000;
+  _resultCallback([NSString stringWithFormat:@"%.f", result_ms]);
+}
+
+- (void)simplePing:(SimplePing *)pinger didReceiveUnexpectedPacket:(NSData *)packet
+{
+  [pinger stop];
+  _resultCallback(kdidReceiveUnexpectedPacket);
+}
+
+@end


### PR DESCRIPTION
Thx to MrMC who did that one. This implementes a simple ping which can be used throughout all darwin platforms (osx, ios, tvos).

This will be needed for tvos because there are no system calls allowed. And in general it looks prettier having real code behind that ping function if you ask me.

This one only affects osx and ios...
