### PR TITLE
[PVR] handle tv<->radio channel change in database, fixes track #16031

### DIFF
--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -98,7 +98,7 @@ void CPVRDatabase::CreateTables()
 void CPVRDatabase::CreateAnalytics()
 {
   CLog::Log(LOGINFO, "%s - creating indices", __FUNCTION__);
-  m_pDS->exec("CREATE UNIQUE INDEX idx_channels_iClientId_iUniqueId on channels(iClientId, iUniqueId);");
+  m_pDS->exec("CREATE UNIQUE INDEX idx_channels_iClientId_iUniqueId_bIsRadio on channels(iClientId, iUniqueId, bIsRadio);");
   m_pDS->exec("CREATE INDEX idx_channelgroups_bIsRadio on channelgroups(bIsRadio);");
   m_pDS->exec("CREATE UNIQUE INDEX idx_idGroup_idChannel on map_channelgroups_channels(idGroup, idChannel);");
 }
@@ -180,6 +180,9 @@ void CPVRDatabase::UpdateTables(int iVersion)
 
   if (iVersion < 29)
     m_pDS->exec("ALTER TABLE channelgroups ADD iPosition integer");
+
+  if (iVersion < 30)
+    m_pDS->exec("DROP INDEX IF EXISTS idx_channels_iClientId_iUniqueId");
 }
 
 /********** Channel methods **********/
@@ -579,7 +582,7 @@ bool CPVRDatabase::PersistChannels(CPVRChannelGroup &group)
     std::string strValue;
     for (PVR_CHANNEL_GROUP_MEMBERS::iterator it = group.m_members.begin(); it != group.m_members.end(); ++it)
     {
-      strQuery = PrepareSQL("iUniqueId = %u AND iClientId = %u", it->second.channel->UniqueID(), it->second.channel->ClientID());
+      strQuery = PrepareSQL("iUniqueId = %u AND iClientId = %u AND bIsRadio = %u", it->second.channel->UniqueID(), it->second.channel->ClientID(), it->second.channel->IsRadio());
       strValue = GetSingleValue("channels", "idChannel", strQuery);
       if (!strValue.empty() && StringUtils::IsInteger(strValue))
         it->second.channel->SetChannelID(atoi(strValue.c_str()));

--- a/xbmc/pvr/PVRDatabase.h
+++ b/xbmc/pvr/PVRDatabase.h
@@ -56,7 +56,7 @@ namespace PVR
      * @brief Get the minimal database version that is required to operate correctly.
      * @return The minimal database version.
      */
-    virtual int GetSchemaVersion() const { return 29; };
+    virtual int GetSchemaVersion() const { return 30; };
 
     /*!
      * @brief Get the default sqlite database filename.


### PR DESCRIPTION
There are lots of reports of not starting PVR manager and I was also facing this from time time time.
After a bit of debugging, I figured out where the problem lies and how to reproduce.

1) the problem
- Assume the backend has a tv channel with an unique id of "1234".
- So the channel is stored in the Kodi database as tv channel with an unique id of "1234".
- Assume kodi is not running and the user is adding and deleting channels on the backend.
  Let's say we delete the tv channel with id "1234", after this we create a new radio channel, it's possible that the backend assigns id "1234" to that radio channel (as it's free to use now).
- Now we fire up kodi, kodi will first load radio channels (by design)

-> radio channels are loaded from db
-> non existing radio channels (on backend) are deleted from the db
-> new radio channels are added to the db, so radio channel "1234" gets added, but there is still a tv channel in the db with id "1234" -> clash -> PVR manager stops here. 
-> Assume is we still continue (in our mind).
-> tv channels are loaded from db
-> non existing tv channels (on backend) are deleted from the db, so tv channel "1234" gets deleted.
-> new tv channels are added.
- Following this loading order, it's obvious that this only happens when a channel changes from tv to radio and not the other way around.

Some users are reporting that they need to clear the tv database every few hours because of this. 
https://github.com/kodi-pvr/pvr.hts/issues/172

This can be explained that for example some channels are not broadcasting video all the time and are handled as radio, when a video pid comes available, they are television. Also bouquet updates can easily mess things up like this. I mainly see reports when using tvheadend or vdr. 

Some other reports that that are caused by this issue (notice that bIsRadio flag is always "1"):
http://trac.kodi.tv/ticket/16031
http://forum.kodi.tv/showthread.php?tid=189534&page=5
http://forum.kodi.tv/showthread.php?tid=233588&pid=2067509#pid2067509
http://forum.kodi.tv/showthread.php?tid=235246

2) The solution:
- One way to handle this is to check all channels in one time instead (radio+tv), 
  but it's hard to this this with the current way kodi handles channel groups.
- Another way is to let radio and tv channels with the same unique id coexist in the database, this is what I've don in this PR. I'm not sure if this is the best way to handle this.
- If someone has a better alternative?

@ksooo @Jalle19 @xhaggi @opdenkamp 
