### PR TITLE
[osx] - Fix crash when unplugging usb devices

### DIFF
--- a/xbmc/peripherals/bus/osx/PeripheralBusUSB.cpp
+++ b/xbmc/peripherals/bus/osx/PeripheralBusUSB.cpp
@@ -121,7 +121,7 @@ void CPeripheralBusUSB::DeviceDetachCallback(void *refCon, io_service_t service,
 { 
   if (messageType == kIOMessageServiceIsTerminated)
   {
-    std::unique_ptr<USBDevicePrivateData> privateDataRef((USBDevicePrivateData*)refCon);
+    USBDevicePrivateData *privateDataRef = (USBDevicePrivateData*)refCon;
 
     std::vector<PeripheralScanResult>::iterator it = privateDataRef->refCon->m_scan_results.m_results.begin();
     while(it != privateDataRef->refCon->m_scan_results.m_results.end())
@@ -136,6 +136,7 @@ void CPeripheralBusUSB::DeviceDetachCallback(void *refCon, io_service_t service,
     CLog::Log(LOGDEBUG, "USB Device Detach:%s, %s\n",
       privateDataRef->deviceName.c_str(), privateDataRef->result.m_strLocation.c_str());
     IOObjectRelease(privateDataRef->notification);
+    delete privateDataRef;
     //release the service
     IOObjectRelease(service);
   }
@@ -173,9 +174,6 @@ void CPeripheralBusUSB::DeviceAttachCallback(CPeripheralBusUSB* refCon, io_itera
       IOObjectRelease(usbDevice);
       continue;
     }
-
-    // do not need the intermediate plug-in after device interface is created
-    (*devicePlugin)->Release(devicePlugin);
 
     // get vendor/product ids
     UInt16  vendorId;
@@ -218,9 +216,6 @@ void CPeripheralBusUSB::DeviceAttachCallback(CPeripheralBusUSB* refCon, io_itera
         continue;
       }
 
-      // do not need the intermediate plug-in after query
-      (*interfaceInterface)->Release(interfaceInterface);
-
       // finally we can get to the bInterfaceClass
       // we should also check for kHIDKeyboardInterfaceProtocol but
       // some IR remotes that emulate an HID keyboard do not report this.
@@ -230,7 +225,8 @@ void CPeripheralBusUSB::DeviceAttachCallback(CPeripheralBusUSB* refCon, io_itera
       {
         std::string ttlDeviceFilePath;
         CFStringRef deviceFilePathAsCFString;
-        std::unique_ptr<USBDevicePrivateData> privateDataRef(new USBDevicePrivateData);
+        USBDevicePrivateData *privateDataRef;
+        privateDataRef = new USBDevicePrivateData;
         // save the device info to our private data.
         privateDataRef->refCon = refCon;
         privateDataRef->deviceName = deviceName;
@@ -277,7 +273,7 @@ void CPeripheralBusUSB::DeviceAttachCallback(CPeripheralBusUSB* refCon, io_itera
             usbDevice,                      // service
             kIOGeneralInterest,             // interestType
             (IOServiceInterestCallback)DeviceDetachCallback, // callback
-            &privateDataRef,                 // refCon
+            privateDataRef,                 // refCon
             &privateDataRef->notification); // notification
             
           if (result == kIOReturnSuccess)
@@ -286,6 +282,14 @@ void CPeripheralBusUSB::DeviceAttachCallback(CPeripheralBusUSB* refCon, io_itera
             CLog::Log(LOGDEBUG, "USB Device Attach:%s, %s\n",
               deviceName, privateDataRef->result.m_strLocation.c_str());
           }
+          else
+          {
+            delete privateDataRef;
+          }
+        }
+        else
+        {
+          delete privateDataRef;
         }
         // done with this device, only need one notification per device.
         IODestroyPlugInInterface(interfacePlugin);


### PR DESCRIPTION
This reverts commit c6ef89dc4a1ca6e507a53c3039131050780a55c2.

The commit resulted in a crash in the usb detach callback.

Sorry - i somehow thought that this was tested before i backported it from MrMC :/ - i though consider it a critical regression (and it was reported by a user too)
