### PR TITLE
[PVR] Fix crash after selecting 'Add timer' in PVR timer window, closes Trac16539

### DIFF
--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -1457,6 +1457,19 @@ bool CPVRClients::GetClient(const std::string &strId, AddonPtr &addon) const
   return false;
 }
 
+bool CPVRClients::SupportsTimers() const
+{
+  PVR_CLIENTMAP clients;
+  GetConnectedClients(clients);
+
+  for (const auto &entry : clients)
+  {
+    if (entry.second->SupportsTimers())
+      return true;
+  }
+  return false;
+}
+
 bool CPVRClients::SupportsChannelGroups(int iClientId) const
 {
   PVR_CLIENT client;

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -339,6 +339,12 @@ namespace PVR
     //@{
 
     /*!
+     * @brief Check whether there is at least one connected client supporting timers.
+     * @return True if at least one connected client supports timers, false otherwise.
+     */
+    bool SupportsTimers() const;
+
+    /*!
      * @brief Check whether a client supports timers.
      * @param iClientId The id of the client to check.
      * @return True if the supports timers, false otherwise.

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -85,7 +85,7 @@ void CGUIWindowPVRChannels::GetContextButtons(int itemNumber, CContextButtons &b
 
   if (channel->IsRecording())
     buttons.Add(CONTEXT_BUTTON_STOP_RECORD, 19059);  /* Stop recording */
-  else
+  else if (g_PVRClients->SupportsTimers(channel->ClientID()))
     buttons.Add(CONTEXT_BUTTON_START_RECORD, 264);   /* Record */
 
   if (ActiveAE::CActiveAEDSP::GetInstance().IsProcessing())

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -107,7 +107,7 @@ void CGUIWindowPVRGuide::GetContextButtons(int itemNumber, CContextButtons &butt
           buttons.Add(CONTEXT_BUTTON_DELETE_TIMER, 19060);  /* Delete timer */
       }
     }
-    else
+    else if (g_PVRClients->SupportsTimers())
     {
       if (epg->EndAsLocalTime() > CDateTime::GetCurrentDateTime())
         buttons.Add(CONTEXT_BUTTON_START_RECORD, 264);      /* Record */

--- a/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
@@ -73,7 +73,7 @@ void CGUIWindowPVRSearch::GetContextButtons(int itemNumber, CContextButtons &but
           buttons.Add(CONTEXT_BUTTON_DELETE_TIMER, 19060);  /* Delete timer */
       }
     }
-    else
+    else if (g_PVRClients->SupportsTimers())
     {
       if (epg->EndAsLocalTime() > CDateTime::GetCurrentDateTime())
         buttons.Add(CONTEXT_BUTTON_START_RECORD, 264);      /* Record */

--- a/xbmc/pvr/windows/GUIWindowPVRTimersBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRTimersBase.cpp
@@ -360,6 +360,12 @@ bool CGUIWindowPVRTimersBase::ActionDeleteTimer(CFileItem *item)
 
 bool CGUIWindowPVRTimersBase::ActionShowTimer(CFileItem *item)
 {
+  if (!g_PVRClients->SupportsTimers(item->GetPVRTimerInfoTag()->m_iClientId))
+  {
+    CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{19215}); // "Information", "The PVR backend does not support timers."
+    return false;
+  }
+
   bool bReturn = false;
 
   /* Check if "Add timer..." entry is pressed by OK, if yes


### PR DESCRIPTION
http://trac.kodi.tv/ticket/16539

Imo, we need a Jarvis backport for this one. Small code change, low regression risk.

@jalle19 @xhaggi mind taking a look.
