### PR TITLE
disable filedirectories in addonbrowser

### DIFF
--- a/xbmc/addons/GUIWindowAddonBrowser.h
+++ b/xbmc/addons/GUIWindowAddonBrowser.h
@@ -59,6 +59,8 @@ public:
    */
   static int SelectAddonID(ADDON::TYPE type, std::vector<std::string> &addonIDs, bool showNone = false, bool showDetails = true, bool multipleSelection = true, bool showInstalled = true, bool showInstallable = false, bool showMore = true);
   static int SelectAddonID(const std::vector<ADDON::TYPE> &types, std::vector<std::string> &addonIDs, bool showNone = false, bool showDetails = true, bool multipleSelection = true, bool showInstalled = true, bool showInstallable = false, bool showMore = true);
+
+  bool UseFileDirectories() override { return false; }
   
 protected:
   /* \brief set label2 of an item based on the Addon.Status property

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -657,7 +657,7 @@ bool CGUIMediaWindow::GetDirectory(const std::string &strDirectory, CFileItemLis
       SetupShares();
     
     CFileItemList dirItems;
-    if (!m_rootDir.GetDirectory(pathToUrl, dirItems))
+    if (!m_rootDir.GetDirectory(pathToUrl, dirItems, UseFileDirectories()))
       return false;
     
     // assign fetched directory items
@@ -1220,7 +1220,7 @@ void CGUIMediaWindow::SetHistoryForPath(const std::string& strDirectory)
     URIUtils::RemoveSlashAtEnd(strPath);
 
     CFileItemList items;
-    m_rootDir.GetDirectory(CURL(), items);
+    m_rootDir.GetDirectory(CURL(), items, UseFileDirectories());
 
     m_history.ClearPathHistory();
 

--- a/xbmc/windows/GUIMediaWindow.h
+++ b/xbmc/windows/GUIMediaWindow.h
@@ -58,6 +58,7 @@ public:
 
   const CFileItemList &CurrentDirectory() const;
   const CGUIViewState *GetViewState() const;
+  virtual bool UseFileDirectories() { return true; }
 
 protected:
   // specializations of CGUIControlGroup


### PR DESCRIPTION
No reason to do this processing here. Took me a while to figure out why an add-on with the ID "vfs.rar" did not show up.
