### PR TITLE
README.raspberrypi : changed location of gcc- and tools, and the reference to it

### DIFF
--- a/docs/README.raspberrypi
+++ b/docs/README.raspberrypi
@@ -22,7 +22,7 @@ a 32 bit machine requires slightly different setting)
     $ sudo apt-get install git autoconf curl g++ zlib1g-dev libcurl4-openssl-dev gawk gperf libtool autopoint swig default-jre
 
     $ git clone https://github.com/raspberrypi/tools
-    $ sudo cp -r tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64 /opt
+    $ sudo mv tools /opt
 
     $ git clone https://github.com/raspberrypi/firmware
     $ sudo mkdir -p /opt/bcm-rootfs/opt
@@ -35,10 +35,10 @@ a 32 bit machine requires slightly different setting)
 
     $ cd xbmc/tools/depends
     $ ./bootstrap
-    PATH="$PATH:/opt/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin" \
+    PATH="$PATH:/opt/tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin" \
        ./configure --host=arm-linux-gnueabihf \
        --prefix=/opt/xbmc-bcm/xbmc-dbg \
-       --with-toolchain=/usr/local/bcm-gcc/arm-bcm2708hardfp-linux-gnueabi/sysroot \
+       --with-toolchain=/opt/tools/arm-bcm2708/arm-bcm2708hardfp-linux-gnueabi/arm-bcm2708hardfp-linux-gnueabi/sysroot \
        --with-firmware=/opt/bcm-rootfs \
        --with-platform=raspberry-pi \
        --build=i686-linux
@@ -52,7 +52,7 @@ a 32 bit machine requires slightly different setting)
        --disable-optical-drive --disable-dvdcss --disable-joystick \
        --disable-crystalhd --disable-vtbdecoder --disable-vaapi \
        --disable-vdpau --enable-alsa" \
-    $ make -C tools/depends/target/xbmc
+       make -C tools/depends/target/xbmc
 
     $ make
     $ sudo make install


### PR DESCRIPTION
Building for Raspberry failed on these two points:
@ --with-toolchain was pointing to wrong location. For the oversight I propose the entire tools-directory is moved (in stead of copied partially) to /opt, where then both gcc and the toolchain can be found. PATH adapted accordingly.
@ make -C tools/depends/target/xbmc was "dangling"
