### PR TITLE
[TexturePacker][gif] The Graphic Control Extension is optional.

### DIFF
--- a/project/BuildDependencies/scripts/0_package.list
+++ b/project/BuildDependencies/scripts/0_package.list
@@ -49,5 +49,5 @@ python-2.7.10-win32.7z
 sqlite-3.9.2-win32-vc120.7z
 swig-2.0.7-win32-1.7z
 taglib-1.10-win32-vc120.7z
-texturepacker-1.0.5-win32.7z
+texturepacker-1.0.6-win32.7z
 tinyxml-2.6.2_3-win32-vc120.7z


### PR DESCRIPTION
This fixes, e.g., skin re-touced's country flags.

Remaining tasks
- [x] win32: build release and upload it

The same applies to the core implementation, but that will be replaced by FFmpegImge.
