### PR TITLE
Don't show "* all entries" for widgets

### DIFF
--- a/Kodi.xcodeproj/project.pbxproj
+++ b/Kodi.xcodeproj/project.pbxproj
@@ -625,6 +625,10 @@
 		889B4D8E0E0EF86C00FAD25E /* RSSDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 889B4D8C0E0EF86C00FAD25E /* RSSDirectory.cpp */; };
 		9A7368511C401F5F00CA169F /* DirectoryNodeInProgressTvShows.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9A73684F1C401F5F00CA169F /* DirectoryNodeInProgressTvShows.cpp */; };
 		9A7368521C401F5F00CA169F /* DirectoryNodeInProgressTvShows.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9A73684F1C401F5F00CA169F /* DirectoryNodeInProgressTvShows.cpp */; };
+		9AC167B61C5ED478004F0C29 /* MusicFileItemListModifier.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9AC167B41C5ED478004F0C29 /* MusicFileItemListModifier.cpp */; };
+		9AC167B71C5ED478004F0C29 /* MusicFileItemListModifier.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9AC167B41C5ED478004F0C29 /* MusicFileItemListModifier.cpp */; };
+		9AC167BA1C5ED48A004F0C29 /* VideoFileItemListModifier.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9AC167B81C5ED48A004F0C29 /* VideoFileItemListModifier.cpp */; };
+		9AC167BB1C5ED48A004F0C29 /* VideoFileItemListModifier.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9AC167B81C5ED48A004F0C29 /* VideoFileItemListModifier.cpp */; };
 		AE32174218313ADF0003FAFC /* XSLTUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AE4E87A517354C4A00D15206 /* XSLTUtils.cpp */; };
 		AE4E87A717354C4A00D15206 /* XSLTUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AE4E87A517354C4A00D15206 /* XSLTUtils.cpp */; };
 		AE84CB5A15A5B8A600A3810E /* TagLibVFSStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AE84CB5915A5B8A600A3810E /* TagLibVFSStream.cpp */; };
@@ -3280,6 +3284,10 @@
 		8DD76F7E0486A8DE00D96B5E /* Kodi */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = Kodi; sourceTree = BUILT_PRODUCTS_DIR; };
 		9A73684F1C401F5F00CA169F /* DirectoryNodeInProgressTvShows.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DirectoryNodeInProgressTvShows.cpp; sourceTree = "<group>"; };
 		9A7368501C401F5F00CA169F /* DirectoryNodeInProgressTvShows.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DirectoryNodeInProgressTvShows.h; sourceTree = "<group>"; };
+		9AC167B41C5ED478004F0C29 /* MusicFileItemListModifier.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MusicFileItemListModifier.cpp; sourceTree = "<group>"; };
+		9AC167B51C5ED478004F0C29 /* MusicFileItemListModifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MusicFileItemListModifier.h; sourceTree = "<group>"; };
+		9AC167B81C5ED48A004F0C29 /* VideoFileItemListModifier.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VideoFileItemListModifier.cpp; sourceTree = "<group>"; };
+		9AC167B91C5ED48A004F0C29 /* VideoFileItemListModifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VideoFileItemListModifier.h; sourceTree = "<group>"; };
 		AE4E87A517354C4A00D15206 /* XSLTUtils.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = XSLTUtils.cpp; sourceTree = "<group>"; };
 		AE4E87A617354C4A00D15206 /* XSLTUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XSLTUtils.h; sourceTree = "<group>"; };
 		AE84CB5915A5B8A600A3810E /* TagLibVFSStream.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TagLibVFSStream.cpp; sourceTree = "<group>"; };
@@ -5514,6 +5522,8 @@
 		431376DC12D6430600680C15 /* windows */ = {
 			isa = PBXGroup;
 			children = (
+				9AC167B41C5ED478004F0C29 /* MusicFileItemListModifier.cpp */,
+				9AC167B51C5ED478004F0C29 /* MusicFileItemListModifier.h */,
 				E38E180D0D25F9FA00618676 /* GUIWindowMusicBase.cpp */,
 				E38E180E0D25F9FA00618676 /* GUIWindowMusicBase.h */,
 				E38E18110D25F9FA00618676 /* GUIWindowMusicNav.cpp */,
@@ -5843,6 +5853,8 @@
 		43FAC88812D6364800F67914 /* windows */ = {
 			isa = PBXGroup;
 			children = (
+				9AC167B81C5ED48A004F0C29 /* VideoFileItemListModifier.cpp */,
+				9AC167B91C5ED48A004F0C29 /* VideoFileItemListModifier.h */,
 				E38E18050D25F9FA00618676 /* GUIWindowFullScreen.cpp */,
 				E38E18060D25F9FA00618676 /* GUIWindowFullScreen.h */,
 				E38E183B0D25F9FA00618676 /* GUIWindowVideoBase.cpp */,
@@ -9867,6 +9879,7 @@
 				C8482901156CFE4B005A996F /* Observer.cpp in Sources */,
 				DFC6F4C11AFF7E300039A7FA /* rfft.cpp in Sources */,
 				C8482904156CFED9005A996F /* DVDDemuxPVRClient.cpp in Sources */,
+				9AC167BA1C5ED48A004F0C29 /* VideoFileItemListModifier.cpp in Sources */,
 				C8482909156CFF24005A996F /* PVRDirectory.cpp in Sources */,
 				C848290A156CFF24005A996F /* PVRFile.cpp in Sources */,
 				C8482910156CFFA0005A996F /* DVDInputStreamPVRManager.cpp in Sources */,
@@ -10142,6 +10155,7 @@
 				7CCDA7DC192756250074CF51 /* NptList.cpp in Sources */,
 				7CCDA7E5192756250074CF51 /* NptLogging.cpp in Sources */,
 				7CCDA7E8192756250074CF51 /* NptMessaging.cpp in Sources */,
+				9AC167B61C5ED478004F0C29 /* MusicFileItemListModifier.cpp in Sources */,
 				7CCDA7F1192756250074CF51 /* NptNetwork.cpp in Sources */,
 				7CCDA7FA192756250074CF51 /* NptQueue.cpp in Sources */,
 				7CCDA803192756250074CF51 /* NptResults.cpp in Sources */,
@@ -11028,6 +11042,7 @@
 				E4991541174E642900741B6D /* SectionLoader.cpp in Sources */,
 				E4991542174E642900741B6D /* SystemGlobals.cpp in Sources */,
 				E4991544174E642900741B6D /* TextureCache.cpp in Sources */,
+				9AC167B71C5ED478004F0C29 /* MusicFileItemListModifier.cpp in Sources */,
 				E4991545174E642900741B6D /* TextureCacheJob.cpp in Sources */,
 				E4991546174E642900741B6D /* TextureDatabase.cpp in Sources */,
 				E4991547174E642900741B6D /* ThumbLoader.cpp in Sources */,
@@ -11164,6 +11179,7 @@
 				7CCDA151192753E30074CF51 /* PltIconsData.cpp in Sources */,
 				7CCDA15A192753E30074CF51 /* PltMimeType.cpp in Sources */,
 				7CCDA163192753E30074CF51 /* PltProtocolInfo.cpp in Sources */,
+				9AC167BB1C5ED48A004F0C29 /* VideoFileItemListModifier.cpp in Sources */,
 				7CCDA16C192753E30074CF51 /* PltService.cpp in Sources */,
 				7CCDA175192753E30074CF51 /* PltSsdp.cpp in Sources */,
 				7CCDA17E192753E30074CF51 /* PltStateVariable.cpp in Sources */,

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -372,6 +372,7 @@
     <ClCompile Include="..\..\xbmc\filesystem\MultiPathFile.cpp" />
     <ClCompile Include="..\..\xbmc\filesystem\MusicDatabaseDirectory.cpp" />
     <ClCompile Include="..\..\xbmc\filesystem\MusicDatabaseDirectory\DirectoryNodeGrouped.cpp" />
+    <ClCompile Include="..\..\xbmc\music\windows\MusicFileItemListModifier.cpp" />
     <ClCompile Include="..\..\xbmc\filesystem\MusicDatabaseFile.cpp" />
     <ClCompile Include="..\..\xbmc\filesystem\MusicFileDirectory.cpp" />
     <ClCompile Include="..\..\xbmc\filesystem\MusicSearchDirectory.cpp" />
@@ -987,6 +988,7 @@
     <ClInclude Include="..\..\xbmc\filesystem\DAVFile.h" />
     <ClInclude Include="..\..\xbmc\filesystem\ImageFile.h" />
     <ClInclude Include="..\..\xbmc\filesystem\MusicDatabaseDirectory\DirectoryNodeGrouped.h" />
+    <ClInclude Include="..\..\xbmc\music\windows\MusicFileItemListModifier.h" />
     <ClInclude Include="..\..\xbmc\filesystem\OverrideDirectory.h" />
     <ClInclude Include="..\..\xbmc\filesystem\OverrideFile.h" />
     <ClInclude Include="..\..\xbmc\filesystem\ResourceDirectory.h" />
@@ -1607,6 +1609,7 @@
     <ClCompile Include="..\..\xbmc\video\windows\GUIWindowVideoBase.cpp" />
     <ClCompile Include="..\..\xbmc\video\windows\GUIWindowVideoNav.cpp" />
     <ClCompile Include="..\..\xbmc\video\windows\GUIWindowVideoPlaylist.cpp" />
+    <ClCompile Include="..\..\xbmc\video\windows\VideoFileItemListModifier.cpp" />
     <ClCompile Include="..\..\xbmc\view\GUIViewControl.cpp" />
     <ClCompile Include="..\..\xbmc\view\GUIViewState.cpp" />
     <ClCompile Include="..\..\xbmc\view\ViewDatabase.cpp" />
@@ -2236,6 +2239,7 @@
     <ClInclude Include="..\..\xbmc\video\windows\GUIWindowVideoBase.h" />
     <ClInclude Include="..\..\xbmc\video\windows\GUIWindowVideoNav.h" />
     <ClInclude Include="..\..\xbmc\video\windows\GUIWindowVideoPlaylist.h" />
+    <ClInclude Include="..\..\xbmc\video\windows\VideoFileItemListModifier.h" />
     <ClInclude Include="..\..\xbmc\view\GUIViewControl.h" />
     <ClInclude Include="..\..\xbmc\view\GUIViewState.h" />
     <ClInclude Include="..\..\xbmc\view\ViewDatabase.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -3223,6 +3223,12 @@
       <Filter>filesystem\VideoDatabaseDirectory</Filter>
     </ClCompile>
     <ClCompile Include="..\..\xbmc\InfoScanner.cpp" />
+    <ClCompile Include="..\..\xbmc\music\windows\MusicFileItemListModifier.cpp">
+      <Filter>music\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\xbmc\video\windows\VideoFileItemListModifier.cpp">
+      <Filter>video\windows</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\xbmc\win32\pch.h">
@@ -6245,6 +6251,12 @@
       <Filter>filesystem\VideoDatabaseDirectory</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\InfoScanner.h" />
+    <ClInclude Include="..\..\xbmc\music\windows\MusicFileItemListModifier.h">
+      <Filter>music\windows</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\video\windows\VideoFileItemListModifier.h">
+      <Filter>video\windows</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\..\xbmc\win32\XBMC_PC.rc">

--- a/xbmc/FileItemListModification.cpp
+++ b/xbmc/FileItemListModification.cpp
@@ -21,10 +21,14 @@
 #include "FileItemListModification.h"
 
 #include "playlists/SmartPlaylistFileItemListModifier.h"
+#include "music/windows/MusicFileItemListModifier.h"
+#include "video/windows/VideoFileItemListModifier.h"
 
 CFileItemListModification::CFileItemListModification()
 {
   m_modifiers.insert(new CSmartPlaylistFileItemListModifier());
+  m_modifiers.insert(new CMusicFileItemListModifier());
+  m_modifiers.insert(new CVideoFileItemListModifier());
 }
 
 CFileItemListModification::~CFileItemListModification()

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNode.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNode.h
@@ -74,7 +74,9 @@ namespace XFILE
       virtual std::string GetLocalizedName() const;
 
       CDirectoryNode* GetParent() const;
-      bool CanCache() const;
+      virtual bool CanCache() const;
+
+      std::string BuildPath() const;
 
     protected:
       CDirectoryNode(NODE_TYPE Type, const std::string& strName, CDirectoryNode* pParent);
@@ -88,11 +90,6 @@ namespace XFILE
       void RemoveParent();
 
       virtual bool GetContent(CFileItemList& items) const;
-
-      std::string BuildPath() const;
-
-    private:
-      void AddQueuingFolder(CFileItemList& items) const;
 
     private:
       NODE_TYPE m_Type;

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyAdded.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyAdded.h
@@ -30,9 +30,9 @@ namespace XFILE
     public:
       CDirectoryNodeAlbumRecentlyAdded(const std::string& strName, CDirectoryNode* pParent);
     protected:
-      virtual NODE_TYPE GetChildType() const;
-      virtual bool GetContent(CFileItemList& items) const;
-      virtual std::string GetLocalizedName() const;
+      NODE_TYPE GetChildType() const override;
+      bool GetContent(CFileItemList& items) const override;
+      std::string GetLocalizedName() const override;
     };
   }
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyPlayed.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyPlayed.h
@@ -30,9 +30,9 @@ namespace XFILE
     public:
       CDirectoryNodeAlbumRecentlyPlayed(const std::string& strName, CDirectoryNode* pParent);
     protected:
-      virtual NODE_TYPE GetChildType() const;
-      virtual bool GetContent(CFileItemList& items) const;
-      virtual std::string GetLocalizedName() const;
+      NODE_TYPE GetChildType() const override;
+      bool GetContent(CFileItemList& items) const override;
+      std::string GetLocalizedName() const override;
     };
   }
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.cpp
@@ -36,15 +36,10 @@
 #include "DirectoryNodeMusicVideosOverview.h"
 #include "DirectoryNodeRecentlyAddedMusicVideos.h"
 #include "DirectoryNodeTitleMusicVideos.h"
-#include "video/VideoInfoTag.h"
 #include "URL.h"
-#include "settings/AdvancedSettings.h"
 #include "FileItem.h"
 #include "utils/StringUtils.h"
-#include "guilib/LocalizeStrings.h"
-#include "utils/Variant.h"
 #include "video/VideoDatabase.h"
-#include "settings/Settings.h"
 
 using namespace XFILE::VIDEODATABASEDIRECTORY;
 
@@ -150,7 +145,7 @@ CDirectoryNode* CDirectoryNode::CreateNode(NODE_TYPE Type, const std::string& st
     break;
   }
 
-  return NULL;
+  return nullptr;
 }
 
 //  Current node name
@@ -203,7 +198,7 @@ std::string CDirectoryNode::BuildPath() const
     array.insert(array.begin(), m_strName);
 
   CDirectoryNode* pParent=m_pParent;
-  while (pParent != NULL)
+  while (pParent != nullptr)
   {
     const std::string& strNodeName=pParent->GetName();
     if (!strNodeName.empty())
@@ -213,7 +208,7 @@ std::string CDirectoryNode::BuildPath() const
   }
 
   std::string strPath="videodb://";
-  for (int i = 0; i < (int)array.size(); ++i)
+  for (int i = 0; i < static_cast<int>(array.size()); ++i)
     strPath += array[i]+"/";
 
   std::string options = m_options.GetOptionsString();
@@ -239,7 +234,7 @@ void CDirectoryNode::CollectQueryParams(CQueryParams& params) const
   params.SetQueryParam(m_Type, m_strName);
 
   CDirectoryNode* pParent=m_pParent;
-  while (pParent != NULL)
+  while (pParent != nullptr)
   {
     params.SetQueryParam(pParent->GetType(), pParent->GetName());
     pParent = pParent->GetParent();
@@ -268,7 +263,6 @@ bool CDirectoryNode::GetChilds(CFileItemList& items)
     bSuccess = pNode->GetContent(items);
     if (bSuccess)
     {
-      AddQueuingFolder(items);
       if (CanCache())
         items.SetCacheToDisc(CFileItemList::CACHE_ALWAYS);
     }
@@ -279,83 +273,6 @@ bool CDirectoryNode::GetChilds(CFileItemList& items)
   }
 
   return bSuccess;
-}
-
-//  Add an "* All ..." folder to the CFileItemList
-//  depending on the child node
-void CDirectoryNode::AddQueuingFolder(CFileItemList& items) const
-{
-  CFileItemPtr pItem;
-
-  // always show "all" items by default
-  if (!CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOLIBRARY_SHOWALLITEMS))
-    return;
-
-  // no need for "all" item when only one item
-  if (items.GetObjectCount() <= 1)
-    return;
-
-  CVideoDbUrl videoUrl;
-  if (!videoUrl.FromString(BuildPath()))
-    return;
-
-  // hack - as the season node might return episodes
-  std::unique_ptr<CDirectoryNode> pNode(ParseURL(items.GetPath()));
-
-  switch (pNode->GetChildType())
-  {
-    case NODE_TYPE_SEASONS:
-      {
-        std::string strLabel = g_localizeStrings.Get(20366);
-        pItem.reset(new CFileItem(strLabel));  // "All Seasons"
-        videoUrl.AppendPath("-1/");
-        pItem->SetPath(videoUrl.ToString());
-        // set the number of watched and unwatched items accordingly
-        int watched = 0;
-        int unwatched = 0;
-        for (int i = 0; i < items.Size(); i++)
-        {
-          CFileItemPtr item = items[i];
-          watched += (int)item->GetProperty("watchedepisodes").asInteger();
-          unwatched += (int)item->GetProperty("unwatchedepisodes").asInteger();
-        }
-        pItem->SetProperty("totalepisodes", watched + unwatched);
-        pItem->SetProperty("numepisodes", watched + unwatched); // will be changed later to reflect watchmode setting
-        pItem->SetProperty("watchedepisodes", watched);
-        pItem->SetProperty("unwatchedepisodes", unwatched);
-        if (items.Size() && items[0]->GetVideoInfoTag())
-        {
-          *pItem->GetVideoInfoTag() = *items[0]->GetVideoInfoTag();
-          pItem->GetVideoInfoTag()->m_iSeason = -1;
-        }
-        pItem->GetVideoInfoTag()->m_strTitle = strLabel;
-        pItem->GetVideoInfoTag()->m_iEpisode = watched + unwatched;
-        pItem->GetVideoInfoTag()->m_playCount = (unwatched == 0) ? 1 : 0;
-        CVideoDatabase db;
-        if (db.Open())
-        {
-          pItem->GetVideoInfoTag()->m_iDbId = db.GetSeasonId(pItem->GetVideoInfoTag()->m_iIdShow, -1);
-          db.Close();
-        }
-        pItem->GetVideoInfoTag()->m_type = MediaTypeSeason;
-      }
-      break;
-    case NODE_TYPE_MUSICVIDEOS_ALBUM:
-      pItem.reset(new CFileItem(g_localizeStrings.Get(15102)));  // "All Albums"
-      videoUrl.AppendPath("-1/");
-      pItem->SetPath(videoUrl.ToString());
-      break;
-    default:
-      break;
-  }
-
-  if (pItem)
-  {
-    pItem->m_bIsFolder = true;
-    pItem->SetSpecialSort(g_advancedSettings.m_bVideoLibraryAllItemsOnBottom ? SortSpecialOnBottom : SortSpecialOnTop);
-    pItem->SetCanQueue(false);
-    items.Add(pItem);
-  }
 }
 
 bool CDirectoryNode::CanCache() const

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.h
@@ -79,7 +79,9 @@ namespace XFILE
 
       CDirectoryNode* GetParent() const;
 
-      bool CanCache() const;
+      std::string BuildPath() const;
+
+      virtual bool CanCache() const;
     protected:
       CDirectoryNode(NODE_TYPE Type, const std::string& strName, CDirectoryNode* pParent);
       static CDirectoryNode* CreateNode(NODE_TYPE Type, const std::string& strName, CDirectoryNode* pParent);
@@ -93,10 +95,6 @@ namespace XFILE
 
       virtual bool GetContent(CFileItemList& items) const;
 
-      std::string BuildPath() const;
-
-    private:
-      void AddQueuingFolder(CFileItemList& items) const;
 
     private:
       NODE_TYPE m_Type;

--- a/xbmc/music/windows/Makefile
+++ b/xbmc/music/windows/Makefile
@@ -3,6 +3,7 @@ SRCS=GUIWindowMusicBase.cpp \
      GUIWindowMusicPlaylist.cpp \
      GUIWindowMusicPlaylistEditor.cpp \
      GUIWindowVisualisation.cpp \
+     MusicFileItemListModifier.cpp \
 
 LIB=musicwindows.a
 

--- a/xbmc/music/windows/MusicFileItemListModifier.cpp
+++ b/xbmc/music/windows/MusicFileItemListModifier.cpp
@@ -1,0 +1,105 @@
+/*
+*      Copyright (C) 2016 Team Kodi
+*      http://xbmc.org
+*
+*  This Program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2, or (at your option)
+*  any later version.
+*
+*  This Program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with Kodi; see the file COPYING.  If not, see
+*  <http://www.gnu.org/licenses/>.
+*
+*/
+
+#include "MusicFileItemListModifier.h"
+#include "filesystem/MusicDatabaseDirectory/DirectoryNode.h"
+#include "FileItem.h"
+#include "music/MusicDbUrl.h"
+#include "settings/Settings.h"
+#include "guilib/LocalizeStrings.h"
+#include "settings/AdvancedSettings.h"
+
+using namespace XFILE::MUSICDATABASEDIRECTORY;
+
+bool CMusicFileItemListModifier::CanModify(const CFileItemList &items) const
+{
+  if (items.IsMusicDb())
+    return true;
+
+  return false;
+}
+
+bool CMusicFileItemListModifier::Modify(CFileItemList &items) const
+{
+  AddQueuingFolder(items);
+  return true;
+}
+
+//  Add an "* All ..." folder to the CFileItemList
+//  depending on the child node
+void CMusicFileItemListModifier::AddQueuingFolder(CFileItemList& items)
+{
+  if (!items.IsMusicDb())
+    return;
+
+  auto directoryNode = CDirectoryNode::ParseURL(items.GetPath());
+
+  CFileItemPtr pItem;
+
+  CMusicDbUrl musicUrl;
+  if (!musicUrl.FromString(directoryNode->BuildPath()))
+    return;
+
+  // always show "all" items by default
+  if (!CSettings::GetInstance().GetBool(CSettings::SETTING_MUSICLIBRARY_SHOWALLITEMS))
+    return;
+
+  // no need for "all" item when only one item
+  if (items.GetObjectCount() <= 1)
+    return;
+
+  switch (directoryNode->GetChildType())
+  {
+  case NODE_TYPE_ARTIST:
+    if (directoryNode->GetType() == NODE_TYPE_OVERVIEW) return;
+    pItem.reset(new CFileItem(g_localizeStrings.Get(15103)));  // "All Artists"
+    musicUrl.AppendPath("-1/");
+    pItem->SetPath(musicUrl.ToString());
+    break;
+
+    //  All album related nodes
+  case NODE_TYPE_ALBUM:
+    if (directoryNode->GetType() == NODE_TYPE_OVERVIEW) return;
+  case NODE_TYPE_ALBUM_RECENTLY_PLAYED:
+  case NODE_TYPE_ALBUM_RECENTLY_ADDED:
+  case NODE_TYPE_ALBUM_COMPILATIONS:
+  case NODE_TYPE_ALBUM_TOP100:
+  case NODE_TYPE_YEAR_ALBUM:
+    pItem.reset(new CFileItem(g_localizeStrings.Get(15102)));  // "All Albums"
+    musicUrl.AppendPath("-1/");
+    pItem->SetPath(musicUrl.ToString());
+    break;
+
+  default:
+    break;
+  }
+
+  if (pItem)
+  {
+    pItem->m_bIsFolder = true;
+    pItem->SetSpecialSort(g_advancedSettings.m_bMusicLibraryAllItemsOnBottom ? SortSpecialOnBottom : SortSpecialOnTop);
+    pItem->SetCanQueue(false);
+    pItem->SetLabelPreformated(true);
+    if (g_advancedSettings.m_bMusicLibraryAllItemsOnBottom)
+      items.Add(pItem);
+    else
+      items.AddFront(pItem, (items.Size() > 0 && items[0]->IsParentFolder()) ? 1 : 0);
+  }
+}

--- a/xbmc/music/windows/MusicFileItemListModifier.h
+++ b/xbmc/music/windows/MusicFileItemListModifier.h
@@ -1,0 +1,36 @@
+#pragma once
+
+/*
+*      Copyright (C) 2016 Team Kodi
+*      http://xbmc.org
+*
+*  This Program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2, or (at your option)
+*  any later version.
+*
+*  This Program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with Kodi; see the file COPYING.  If not, see
+*  <http://www.gnu.org/licenses/>.
+*
+*/
+
+#include "IFileItemListModifier.h"
+
+class CMusicFileItemListModifier : public IFileItemListModifier
+{
+public:
+  CMusicFileItemListModifier() { }
+  virtual ~CMusicFileItemListModifier() { }
+
+  bool CanModify(const CFileItemList &items) const override;
+  bool Modify(CFileItemList &items) const override;
+
+private:
+  static void AddQueuingFolder(CFileItemList & items);
+};

--- a/xbmc/video/windows/Makefile
+++ b/xbmc/video/windows/Makefile
@@ -2,6 +2,7 @@ SRCS=GUIWindowFullScreen.cpp \
      GUIWindowVideoBase.cpp \
      GUIWindowVideoNav.cpp \
      GUIWindowVideoPlaylist.cpp \
+     VideoFileItemListModifier.cpp \
 
 LIB=videowindows.a
 

--- a/xbmc/video/windows/VideoFileItemListModifier.cpp
+++ b/xbmc/video/windows/VideoFileItemListModifier.cpp
@@ -1,0 +1,126 @@
+/*
+*      Copyright (C) 2016 Team Kodi
+*      http://xbmc.org
+*
+*  This Program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2, or (at your option)
+*  any later version.
+*
+*  This Program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with Kodi; see the file COPYING.  If not, see
+*  <http://www.gnu.org/licenses/>.
+*
+*/
+
+#include "FileItem.h"
+#include "VideoFileItemListModifier.h"
+#include "settings/AdvancedSettings.h"
+#include "video/VideoDatabase.h"
+#include "filesystem/VideoDatabaseDirectory/DirectoryNode.h"
+#include "guilib/LocalizeStrings.h"
+#include "settings/Settings.h"
+#include "video/VideoDbUrl.h"
+
+using namespace XFILE::VIDEODATABASEDIRECTORY;
+
+bool CVideoFileItemListModifier::CanModify(const CFileItemList &items) const
+{
+  if (items.IsVideoDb())
+    return true;
+
+  return false;
+}
+
+bool CVideoFileItemListModifier::Modify(CFileItemList &items) const
+{
+  AddQueuingFolder(items);
+  return true;
+}
+
+//  Add an "* All ..." folder to the CFileItemList
+//  depending on the child node
+void CVideoFileItemListModifier::AddQueuingFolder(CFileItemList& items)
+{
+  if (!items.IsVideoDb())
+    return;
+
+  auto directoryNode = CDirectoryNode::ParseURL(items.GetPath());
+
+  CFileItemPtr pItem;
+
+  // always show "all" items by default
+  if (!CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOLIBRARY_SHOWALLITEMS))
+    return;
+
+  // no need for "all" item when only one item
+  if (items.GetObjectCount() <= 1)
+    return;
+
+  CVideoDbUrl videoUrl;
+  if (!videoUrl.FromString(directoryNode->BuildPath()))
+    return;
+
+  // hack - as the season node might return episodes
+  std::unique_ptr<CDirectoryNode> pNode(directoryNode);
+
+  switch (pNode->GetChildType())
+  {
+  case NODE_TYPE_SEASONS:
+  {
+    std::string strLabel = g_localizeStrings.Get(20366);
+    pItem.reset(new CFileItem(strLabel));  // "All Seasons"
+    videoUrl.AppendPath("-1/");
+    pItem->SetPath(videoUrl.ToString());
+    // set the number of watched and unwatched items accordingly
+    int watched = 0;
+    int unwatched = 0;
+    for (int i = 0; i < items.Size(); i++)
+    {
+      CFileItemPtr item = items[i];
+      watched += static_cast<int>(item->GetProperty("watchedepisodes").asInteger());
+      unwatched += static_cast<int>(item->GetProperty("unwatchedepisodes").asInteger());
+    }
+    pItem->SetProperty("totalepisodes", watched + unwatched);
+    pItem->SetProperty("numepisodes", watched + unwatched); // will be changed later to reflect watchmode setting
+    pItem->SetProperty("watchedepisodes", watched);
+    pItem->SetProperty("unwatchedepisodes", unwatched);
+    if (items.Size() && items[0]->GetVideoInfoTag())
+    {
+      *pItem->GetVideoInfoTag() = *items[0]->GetVideoInfoTag();
+      pItem->GetVideoInfoTag()->m_iSeason = -1;
+    }
+    pItem->GetVideoInfoTag()->m_strTitle = strLabel;
+    pItem->GetVideoInfoTag()->m_iEpisode = watched + unwatched;
+    pItem->GetVideoInfoTag()->m_playCount = (unwatched == 0) ? 1 : 0;
+    CVideoDatabase db;
+    if (db.Open())
+    {
+      pItem->GetVideoInfoTag()->m_iDbId = db.GetSeasonId(pItem->GetVideoInfoTag()->m_iIdShow, -1);
+      db.Close();
+    }
+    pItem->GetVideoInfoTag()->m_type = MediaTypeSeason;
+  }
+  break;
+  case NODE_TYPE_MUSICVIDEOS_ALBUM:
+    pItem.reset(new CFileItem(g_localizeStrings.Get(15102)));  // "All Albums"
+    videoUrl.AppendPath("-1/");
+    pItem->SetPath(videoUrl.ToString());
+    break;
+  default:
+    break;
+  }
+
+  if (pItem)
+  {
+    pItem->m_bIsFolder = true;
+    pItem->SetSpecialSort(g_advancedSettings.m_bVideoLibraryAllItemsOnBottom ? SortSpecialOnBottom : SortSpecialOnTop);
+    pItem->SetCanQueue(false);
+    items.Add(pItem);
+  }
+}

--- a/xbmc/video/windows/VideoFileItemListModifier.h
+++ b/xbmc/video/windows/VideoFileItemListModifier.h
@@ -1,0 +1,36 @@
+#pragma once
+
+/*
+*      Copyright (C) 2016 Team Kodi
+*      http://xbmc.org
+*
+*  This Program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2, or (at your option)
+*  any later version.
+*
+*  This Program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with Kodi; see the file COPYING.  If not, see
+*  <http://www.gnu.org/licenses/>.
+*
+*/
+
+#include "IFileItemListModifier.h"
+
+class CVideoFileItemListModifier : public IFileItemListModifier
+{
+public:
+  CVideoFileItemListModifier() { }
+  virtual ~CVideoFileItemListModifier() { }
+
+  bool CanModify(const CFileItemList &items) const override;
+  bool Modify(CFileItemList &items) const override;
+
+private:
+  static void AddQueuingFolder(CFileItemList & items);
+};


### PR DESCRIPTION
Not sure if I can make any fans with this proposal, but this removes the weird "\* all albums" listing entries from album recently added and album recently played, for starters.

Would be nice if this would be considered, I can also remove the rest if it's wanted. But would prefer it to be another PR.

@xhaggi as it's slightly gui related
@DaveTBlake because of music and user feedback
@phil65 for fun

Edit:
also removed a bunch of comments, where probably nobody knows why they we're commented out.
