### PR TITLE
[gui] new infobool Window.Is()

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -681,6 +681,7 @@ const infomap skin_labels[] =    {{ "currenttheme",     SKIN_THEME },
                                   {"aspectratio",       SKIN_ASPECT_RATIO}};
 
 const infomap window_bools[] =   {{ "ismedia",          WINDOW_IS_MEDIA },
+                                  { "is",               WINDOW_IS },
                                   { "isactive",         WINDOW_IS_ACTIVE },
                                   { "istopmost",        WINDOW_IS_TOPMOST },
                                   { "isvisible",        WINDOW_IS_VISIBLE },
@@ -3177,6 +3178,15 @@ bool CGUIInfoManager::GetMultiInfoBool(const GUIInfo &info, int contextWindow, c
           if (window && StringUtils::EqualsNoCase(URIUtils::GetFileName(window->GetProperty("xmlfile").asString()), m_stringParameters[info.GetData2()]))
             bReturn = true;
         }
+        break;
+      case WINDOW_IS:
+        if (info.GetData1())
+        {
+          CGUIWindow *window = g_windowManager.GetWindow(contextWindow);
+          bReturn = (window && window->GetID() == static_cast<int>(info.GetData1()));
+        }
+        else
+          CLog::Log(LOGERROR, "The window id is required.");
         break;
       case WINDOW_IS_VISIBLE:
         if (info.GetData1())

--- a/xbmc/guiinfo/GUIInfoLabels.h
+++ b/xbmc/guiinfo/GUIInfoLabels.h
@@ -557,6 +557,7 @@
 #define WINDOW_PREVIOUS             9997
 #define WINDOW_IS_MEDIA             9998
 #define WINDOW_IS_ACTIVE            9999
+#define WINDOW_IS                   10000
 
 #define CONTROL_GET_LABEL           29996
 #define CONTROL_IS_ENABLED          29997


### PR DESCRIPTION
After we merged different skin xml's and use it by more than one window/dialog it should be possible to check if the window context is equal to a given window id. This PR introduce a new boolean window condition `Window.Is(windowid)`. This boolean condition makes only sense in shared xml's like `DialogMusicInfo.xml` etc.

**Examples**
1. Display a control only on dialog `songinformation`.

``` xml
<visible>Window.Is(songinformation)</visible>
```
1. Hide a control in dialog `songinformation` if dialog `musicinformation` is active.

``` xml
<visible>Window.Is(songinformation) + !Window.IsActive(musicinformation)</visible>
```

@phil65 @Razzeee @Montellese mind taking a look.
