### PR TITLE
OMXAudio: Handle changes in decoded audio size correctly

### DIFF
--- a/xbmc/cores/omxplayer/OMXAudioCodecOMX.cpp
+++ b/xbmc/cores/omxplayer/OMXAudioCodecOMX.cpp
@@ -159,7 +159,8 @@ int COMXAudioCodecOMX::Decode(BYTE* pData, int iSize, double dts, double pts)
   if (!m_pCodecContext) return -1;
 
   AVPacket avpkt;
-  m_bGotFrame = false;
+  if (m_bGotFrame)
+    return 0;
   av_init_packet(&avpkt);
   avpkt.data = pData;
   avpkt.size = iSize;
@@ -258,6 +259,7 @@ int COMXAudioCodecOMX::GetData(BYTE** dst, double &dts, double &pts)
       outputSize = 0;
     }
   }
+  m_bGotFrame = false;
   int desired_size = AUDIO_DECODE_OUTPUT_BUFFER * (m_pCodecContext->channels * GetBitsPerSample()) >> (rounded_up_channels_shift[m_pCodecContext->channels] + 4);
 
   if (m_bFirstFrame)
@@ -275,7 +277,6 @@ int COMXAudioCodecOMX::GetData(BYTE** dst, double &dts, double &pts)
   if (m_iBufferOutputUsed + outputSize > desired_size || m_bNoConcatenate)
   {
      int ret = m_iBufferOutputUsed;
-     m_bGotFrame = false;
      m_iBufferOutputUsed = 0;
      dts = m_dts;
      pts = m_pts;


### PR DESCRIPTION
Sending audio packets to gpu is somewhat expensive, especially with a codec like TruHD which produces very many small frames. Because of this we concatenate audio frames and send them in chunks.

However this scheme doesn't handle variable sized frames which can happen with Vorbis and WMA which we have previously special cased.

An mp3 with a short first frame showed up https://github.com/popcornmix/omxplayer/issues/411 which can cause a seg-fault. The bug also affects kodi.

I've reorganised the code so we can detect a change in audio frame size before it is too late. This means the special cases for Vorbis and WMA can be removed.
