### PR TITLE
[videoplayer/rbp] Add pi specific option to maintain vsync with pll adjustment

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -18307,3 +18307,35 @@ msgstr ""
 msgctxt "#38041"
 msgid "Mixer"
 msgstr "" 
+
+#. Description of setting "System -> Audio Ouput -> A/V sync method" with label #38200
+#: system/settings/settings.xml
+msgctxt "#38200"
+msgid "PLL adustment to maintain audio/video sync"
+msgstr ""
+
+#. Description of setting "Videos -> Playback -> A/V sync method" with label #38201
+#: system/settings/settings.xml
+msgctxt "#38201"
+msgid "Allows sync adjustment without resampling. Lower the settings if you get audio/video dropouts."
+msgstr ""
+
+msgctxt "#38202"
+msgid "Off"
+msgstr ""
+
+msgctxt "#38203"
+msgid "Low"
+msgstr ""
+
+msgctxt "#38204"
+msgid "Medium"
+msgstr ""
+
+msgctxt "#38205"
+msgid "High"
+msgstr ""
+
+msgctxt "#38206"
+msgid "Max"
+msgstr ""

--- a/system/settings/rbp.xml
+++ b/system/settings/rbp.xml
@@ -90,6 +90,20 @@
         <setting id="audiooutput.processquality">
           <default>101</default> <!-- AE_QUALITY_GPU -->
         </setting>
+        <setting id="audiooutput.plladjust" type="integer" label="38200" help="38201">
+          <level>3</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="38202">0</option> <!-- off -->
+              <option label="38203">1</option> <!-- low -->
+              <option label="38204">2</option> <!-- medium -->
+              <option label="38205">3</option> <!-- high -->
+              <option label="38206">4</option> <!-- max -->
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+        </setting>
       </group>
       <group id="3">
         <setting id="audiooutput.ac3transcode" help="37024">

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -34,6 +34,10 @@ using namespace ActiveAE;
 #include "windowing/WindowingFactory.h"
 #include "utils/log.h"
 
+#if defined(TARGET_RASPBERRY_PI)
+#include "linux/RBP.h"
+#endif
+
 #define MAX_CACHE_LEVEL 0.4   // total cache time of stream in seconds
 #define MAX_WATER_LEVEL 0.2   // buffered time after stream stages in seconds
 #define MAX_BUFFER_TIME 0.1   // max time of a buffer in seconds
@@ -358,11 +362,12 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
           m_sink.m_controlPort.SendOutMessage(CSinkControlProtocol::APPFOCUSED, msg->data, sizeof(bool));
           return;
         case CActiveAEControlProtocol::STREAMRESAMPLEMODE:
-          MsgStreamParameter *par;
-          par = (MsgStreamParameter*)msg->data;
+          MsgStreamResample *par;
+          par = (MsgStreamResample*)msg->data;
           if (par->stream)
           {
-            par->stream->m_resampleMode = par->parameter.int_par;
+            par->stream->m_resampleMode = par->mode;
+            par->stream->m_pllAdjust = par->plladjust;
             par->stream->m_resampleIntegral = 0.0;
           }
           return;
@@ -2448,7 +2453,16 @@ CSampleBuffer* CActiveAE::SyncStream(CActiveAEStream *stream)
   if (!newerror || stream->m_syncState != CAESyncInfo::AESyncState::SYNC_INSYNC)
     return ret;
 
-  if (stream->m_resampleMode)
+  if (stream->m_pllAdjust > 0)  // pll adjust
+  {
+#if defined(TARGET_RASPBERRY_PI)
+    double e = std::max(std::min(error / 50.0, 1.0), -1.0);
+    double m_plladjust = 1.0 + e * stream->m_pllAdjust;
+    double m_last_plladjust = g_RBP.AdjustHDMIClock(m_plladjust);
+    CLog::Log(LOGDEBUG, "CDVDPlayerAudio::%s pll:%.5f (%.5f) error:%.6f e:%.6f a:%f", __FUNCTION__, m_plladjust, m_last_plladjust, error, e * stream->m_pllAdjust, stream->m_pllAdjust );
+#endif
+  }
+  else if (stream->m_resampleMode)
   {
     if (stream->m_resampleBuffers)
     {
@@ -3300,13 +3314,14 @@ void CActiveAE::SetStreamResampleRatio(CActiveAEStream *stream, double ratio)
                                      &msg, sizeof(MsgStreamParameter));
 }
 
-void CActiveAE::SetStreamResampleMode(CActiveAEStream *stream, int mode)
+void CActiveAE::SetStreamResampleMode(CActiveAEStream *stream, int mode, float plladjust)
 {
-  MsgStreamParameter msg;
+  MsgStreamResample msg;
   msg.stream = stream;
-  msg.parameter.int_par = mode;
+  msg.mode = mode;
+  msg.plladjust = plladjust;
   m_controlPort.SendOutMessage(CActiveAEControlProtocol::STREAMRESAMPLEMODE,
-                               &msg, sizeof(MsgStreamParameter));
+                               &msg, sizeof(MsgStreamResample));
 }
 
 void CActiveAE::SetStreamFFmpegInfo(CActiveAEStream *stream, int profile, enum AVMatrixEncoding matrix_encoding, enum AVAudioServiceType audio_service_type)

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
@@ -170,6 +170,13 @@ struct MsgStreamFFmpegInfo
   enum AVAudioServiceType audio_service_type;
 };
 
+struct MsgStreamResample
+{
+  CActiveAEStream *stream;
+  int mode;
+  float plladjust;
+};
+
 class CEngineStats
 {
 public:
@@ -290,7 +297,7 @@ protected:
   void SetStreamReplaygain(CActiveAEStream *stream, float rgain);
   void SetStreamVolume(CActiveAEStream *stream, float volume);
   void SetStreamResampleRatio(CActiveAEStream *stream, double ratio);
-  void SetStreamResampleMode(CActiveAEStream *stream, int mode);
+  void SetStreamResampleMode(CActiveAEStream *stream, int mode, float plladjust);
   void SetStreamFFmpegInfo(CActiveAEStream *stream, int profile, enum AVMatrixEncoding matrix_encoding, enum AVAudioServiceType audio_service_type);
   void SetStreamFade(CActiveAEStream *stream, float from, float target, unsigned int millis);
 

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
@@ -484,11 +484,12 @@ void CActiveAEStream::SetResampleRatio(double ratio)
   m_streamResampleRatio = ratio;
 }
 
-void CActiveAEStream::SetResampleMode(int mode)
+void CActiveAEStream::SetResampleMode(int mode, float plladjust)
 {
-  if (mode != m_streamResampleMode)
-    AE.SetStreamResampleMode(this, mode);
+  if (mode != m_streamResampleMode || plladjust != m_streamPllAdjust)
+    AE.SetStreamResampleMode(this, mode, plladjust);
   m_streamResampleMode = mode;
+  m_streamPllAdjust = plladjust;
 }
 
 void CActiveAEStream::SetFFmpegInfo(int profile, enum AVMatrixEncoding matrix_encoding, enum AVAudioServiceType audio_service_type)

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.h
@@ -136,7 +136,7 @@ public:
   
   virtual double GetResampleRatio();
   virtual void SetResampleRatio(double ratio);
-  virtual void SetResampleMode(int mode);
+  virtual void SetResampleMode(int mode, float plladjust);
   virtual void RegisterAudioCallback(IAudioCallback* pCallback);
   virtual void UnRegisterAudioCallback();
   virtual void FadeVolume(float from, float to, unsigned int time);
@@ -153,6 +153,7 @@ protected:
   float m_streamAmplify;
   double m_streamResampleRatio;
   int m_streamResampleMode;
+  float m_streamPllAdjust;
   unsigned int m_streamSpace;
   bool m_streamDraining;
   bool m_streamDrained;
@@ -190,6 +191,7 @@ protected:
   int m_fadingTime;
   int m_profile;
   int m_resampleMode;
+  float m_pllAdjust;
   double m_resampleIntegral;
   enum AVMatrixEncoding m_matrixEncoding;
   enum AVAudioServiceType m_audioServiceType;

--- a/xbmc/cores/AudioEngine/Interfaces/AEStream.h
+++ b/xbmc/cores/AudioEngine/Interfaces/AEStream.h
@@ -41,6 +41,14 @@ public:
 class CAESyncInfo
 {
 public:
+  CAESyncInfo()
+  {
+    delay = 0.0;
+    error = 0.0;
+    rr = 1.0;
+    errortime = 0;
+    state = SYNC_OFF;
+  }
   double delay;
   double error;
   double rr;
@@ -231,7 +239,7 @@ public:
   /**
    * Sets the resamplling on/ff
    */
-  virtual void SetResampleMode(int mode) = 0;
+  virtual void SetResampleMode(int mode, float plladjust) = 0;
 
   /**
    * Registers the audio callback to call with each block of data, this is used by Audio Visualizations

--- a/xbmc/cores/VideoPlayer/DVDAudio.cpp
+++ b/xbmc/cores/VideoPlayer/DVDAudio.cpp
@@ -308,12 +308,12 @@ double CDVDAudio::GetResampleRatio()
   return m_resampleRatio;
 }
 
-void CDVDAudio::SetResampleMode(int mode)
+void CDVDAudio::SetResampleMode(int mode, float plladjust)
 {
   CSingleLock lock (m_critSection);
   if(m_pAudioStream)
   {
-    m_pAudioStream->SetResampleMode(mode);
+    m_pAudioStream->SetResampleMode(mode, plladjust);
   }
 }
 

--- a/xbmc/cores/VideoPlayer/DVDAudio.h
+++ b/xbmc/cores/VideoPlayer/DVDAudio.h
@@ -60,7 +60,7 @@ public:
   double GetSyncError();
   void SetSyncErrorCorrection(double correction);
   double GetResampleRatio();
-  void SetResampleMode(int mode);
+  void SetResampleMode(int mode, float plladjust);
   void Flush();
   void Drain();
 

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
@@ -102,6 +102,7 @@ bool CVideoPlayerAudio::OpenStream(CDVDStreamInfo &hints)
   bool allowpassthrough = !CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_USEDISPLAYASCLOCK);
   if (hints.realtime)
     allowpassthrough = false;
+  allowpassthrough |= CSettings::GetInstance().GetInt("audiooutput.plladjust") > 0;
   CDVDAudioCodec* codec = CDVDFactoryCodec::CreateAudioCodec(hints, allowpassthrough, AllowDTSHDDecode());
   if(!codec)
   {
@@ -224,8 +225,12 @@ void CVideoPlayerAudio::UpdatePlayerInfo()
 
   //print the inverse of the resample ratio, since that makes more sense
   //if the resample ratio is 0.5, then we're playing twice as fast
+#ifdef TARGET_RASPBERRY_PI
+  s << ", rr:" << std::fixed << std::setprecision(5) << 1.0 / m_dvdAudio.GetResampleRatio() << ", pll:" << std::fixed << std::setprecision(5) << g_RBP.GetAdjustHDMIClock() << ", err:" << std::fixed << std::setprecision(1) << m_dvdAudio.GetSyncError() * 1e-3 << "ms";
+#else
   if (m_synctype == SYNC_RESAMPLE)
     s << ", rr:" << std::fixed << std::setprecision(5) << 1.0 / m_dvdAudio.GetResampleRatio();
+#endif
 
   s << ", att:" << std::fixed << std::setprecision(1) << log(GetCurrentAttenuation()) * 20.0f << " dB";
 
@@ -519,10 +524,12 @@ void CVideoPlayerAudio::SetSyncType(bool passthrough)
     int synctype = (m_synctype >= 0 && m_synctype <= 1) ? m_synctype : 2;
     CLog::Log(LOGDEBUG, "CVideoPlayerAudio:: synctype set to %i: %s", m_synctype, synctypes[synctype]);
     m_prevsynctype = m_synctype;
+    const float plladjusts[] = { 0.0f, 0.00001f, 0.0001f, 0.001f, 0.01f };
+    float plladjust = plladjusts[CSettings::GetInstance().GetInt("audiooutput.plladjust")];
     if (m_synctype == SYNC_RESAMPLE)
-      m_dvdAudio.SetResampleMode(1);
+      m_dvdAudio.SetResampleMode(1, plladjust);
     else
-      m_dvdAudio.SetResampleMode(0);
+      m_dvdAudio.SetResampleMode(0, plladjust);
   }
 }
 
@@ -595,6 +602,7 @@ bool CVideoPlayerAudio::SwitchCodecIfNeeded()
   bool allowpassthrough = !CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_USEDISPLAYASCLOCK);
   if (m_streaminfo.realtime)
     allowpassthrough = false;
+  allowpassthrough |= CSettings::GetInstance().GetInt("audiooutput.plladjust") > 0;
   CDVDAudioCodec *codec = CDVDFactoryCodec::CreateAudioCodec(m_streaminfo, allowpassthrough, AllowDTSHDDecode());
   if (!codec || codec->NeedPassthrough() == m_pAudioCodec->NeedPassthrough()) {
     // passthrough state has not changed

--- a/xbmc/linux/RBP.cpp
+++ b/xbmc/linux/RBP.cpp
@@ -34,6 +34,7 @@ CRBP::CRBP()
   m_DllBcmHost      = new DllBcmHost();
   m_OMX             = new COMXCore();
   m_display = DISPMANX_NO_HANDLE;
+  m_last_pll_adjust = 1.0;
 }
 
 CRBP::~CRBP()
@@ -114,6 +115,7 @@ void CRBP::CloseDisplay(DISPMANX_DISPLAY_HANDLE_T display)
   assert(display == m_display);
   vc_dispmanx_display_close(m_display);
   m_display = DISPMANX_NO_HANDLE;
+  m_last_pll_adjust = 1.0;
 }
 
 void CRBP::GetDisplaySize(int &width, int &height)
@@ -214,5 +216,16 @@ void CRBP::Deinitialize()
   m_omx_image_init  = false;
   m_initialized     = false;
   m_omx_initialized = false;
+}
+
+double CRBP::AdjustHDMIClock(double adjust)
+{
+  char response[80];
+  vc_gencmd(response, sizeof response, "hdmi_adjust_clock %f", adjust);
+  char *p = strchr(response, '=');
+  if (p)
+    m_last_pll_adjust = atof(p+1);
+  CLog::Log(LOGDEBUG, "CRBP::%s(%.4f) = %.4f", __func__, adjust, m_last_pll_adjust);
+  return m_last_pll_adjust;
 }
 #endif

--- a/xbmc/linux/RBP.h
+++ b/xbmc/linux/RBP.h
@@ -63,6 +63,8 @@ public:
   unsigned char *CaptureDisplay(int width, int height, int *stride, bool swap_red_blue, bool video_only = true);
   DllOMX *GetDllOMX() { return m_OMX ? m_OMX->GetDll() : NULL; }
   void WaitVsync();
+  double AdjustHDMIClock(double adjust);
+  double GetAdjustHDMIClock() { return m_last_pll_adjust; }
 
 private:
   DllBcmHost *m_DllBcmHost;
@@ -79,6 +81,7 @@ private:
   CEvent     m_vsync;
   class DllLibOMXCore;
   CCriticalSection m_critSection;
+  double m_last_pll_adjust;
 };
 
 extern CRBP g_RBP;


### PR DESCRIPTION
New A/V sync option in system/audio to do "Adjust PLL".
This uses video clock (so perfect video syncing) but avoids having to resample
or drop/dupe audio packets which is normally required.
