### PR TITLE
Fix AudioLibrary.GetSongs missing songs when using limits

### DIFF
--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -4038,8 +4038,10 @@ bool CMusicDatabase::GetSongsFullByWhere(const std::string &baseDir, const Filte
     int total = -1;
 
     std::string strSQL = "SELECT %s FROM songview ";
-    if (artistData) // Get data from song and song_artist tables to fully populate songs with artists
-      strSQL = "SELECT %s FROM songview JOIN songartistview on songartistview.idsong = songview.idsong ";
+    if (artistData)
+      // Get data from song and song_artist tables to fully populate songs with artists. 
+      //Some songs may not have artists so Left join
+      strSQL = "SELECT %s FROM songview LEFT JOIN songartistview on songartistview.idsong = songview.idsong ";
 
     Filter extFilter = filter;
     CMusicDbUrl musicUrl;
@@ -4063,15 +4065,22 @@ bool CMusicDatabase::GetSongsFullByWhere(const std::string &baseDir, const Filte
     total = (int)strtol(GetSingleValue("SELECT COUNT(1) FROM songview " + strSQLExtra, m_pDS).c_str(), NULL, 10);
 
     // Apply the limiting directly here if there's no special sorting but limiting
-    if (extFilter.limit.empty() &&
-        sortDescription.sortBy == SortByNone &&
-        (sortDescription.limitStart > 0 || sortDescription.limitEnd > 0))
+    bool limited = extFilter.limit.empty() && sortDescription.sortBy == SortByNone &&
+      (sortDescription.limitStart > 0 || sortDescription.limitEnd > 0);
+    if (limited)
       strSQLExtra += DatabaseUtils::BuildLimitClause(sortDescription.limitEnd, sortDescription.limitStart);
 
-    if (artistData)
-      strSQL = PrepareSQL(strSQL, !filter.fields.empty() && filter.fields.compare("*") != 0 ? filter.fields.c_str() : "songview.*, songartistview.* ") + strSQLExtra;
-    else
+    if (!artistData)
       strSQL = PrepareSQL(strSQL, !filter.fields.empty() && filter.fields.compare("*") != 0 ? filter.fields.c_str() : "songview.* ") + strSQLExtra;
+    else
+    {
+      strSQL = PrepareSQL(strSQL, !filter.fields.empty() && filter.fields.compare("*") != 0 ? filter.fields.c_str() : "songview.*, songartistview.* ");
+      if (!limited)
+        strSQL += strSQLExtra;
+      else
+        //Apply where clause and limits to songview, then join as mutiple records in result set per song
+        strSQL += " WHERE songview.idsong in (SELECT idsong FROM songview " + strSQLExtra + ")";
+    }
 
     CLog::Log(LOGDEBUG, "%s query = %s", __FUNCTION__, strSQL.c_str());
     // run query


### PR DESCRIPTION
Problems have been reported in recent builds with AudioLibrary.GetSongs when using limits to return songs in sections. The total number of songs returned not matching the number displayed in Kodi.

The problem was in `CMusicDatabase::GetSongsFullByWhere` introduced by #8306 to return accurate artist data for the songs by querying a join of songview and songartistview. This was not correctly applying the limit criteria (to just songs not the join), and needed to be a left join to cover those songs that do not have artists.

Thanks @Millencolin007 for doing the leg work and pinning this issue down so well for me to fix.

I think this is safe enough to be back ported to Jarvis, but would like some testing first obviously. It is a music library issue, but only shows up when using JSON to get songs from a full library.
