### PR TITLE
ActiveAE: Enable display lost callbacks for EGL

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1892,10 +1892,7 @@ void CApplication::Render()
     g_infoManager.UpdateFPS();
   }
 
-  // TODO: find better solution
-  // if video is rendered to a separate layer, we should not block this thread
-  if (!m_pPlayer->IsRenderingVideoLayer() || hasRendered)
-    g_graphicsContext.Flip(hasRendered);
+  g_graphicsContext.Flip(hasRendered, m_pPlayer->IsRenderingVideoLayer());
 
   CTimeUtils::UpdateFrameTime(hasRendered);
 }

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -296,9 +296,7 @@ CActiveAE::~CActiveAE()
 
 void CActiveAE::Dispose()
 {
-#if defined(HAS_GLX) || defined(TARGET_DARWIN)
   g_Windowing.Unregister(this);
-#endif
 
   m_bStop = true;
   m_outMsgEvent.Set();
@@ -2610,9 +2608,7 @@ bool CActiveAE::Initialize()
   }
 
   // hook into windowing for receiving display reset events
-#if defined(HAS_GLX) || defined(TARGET_DARWIN) 
   g_Windowing.Register(this);
-#endif
 
   m_inMsgEvent.Reset();
   return true;

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
@@ -216,11 +216,7 @@ protected:
   std::vector<StreamStats> m_streamStats;
 };
 
-#if defined(HAS_GLX) || defined(TARGET_DARWIN)
 class CActiveAE : public IAE, public IDispResource, private CThread
-#else
-class CActiveAE : public IAE, private CThread
-#endif
 {
 protected:
   friend class ::CAEFactory;

--- a/xbmc/guilib/GraphicContext.cpp
+++ b/xbmc/guilib/GraphicContext.cpp
@@ -975,12 +975,12 @@ void CGraphicContext::SetMediaDir(const std::string &strMediaDir)
   m_strMediaDir = strMediaDir;
 }
 
-void CGraphicContext::Flip(bool rendered)
+void CGraphicContext::Flip(bool rendered, bool videoLayer)
 {
   if (IsFullScreenVideo())
     g_Windowing.FinishPipeline();
 
-  g_Windowing.PresentRender(rendered);
+  g_Windowing.PresentRender(rendered, videoLayer);
 
   if(m_stereoMode != m_nextStereoMode)
   {

--- a/xbmc/guilib/GraphicContext.h
+++ b/xbmc/guilib/GraphicContext.h
@@ -130,7 +130,7 @@ public:
   void SetRenderingResolution(const RESOLUTION_INFO &res, bool needsScaling);  ///< Sets scaling up for rendering
   void SetScalingResolution(const RESOLUTION_INFO &res, bool needsScaling);    ///< Sets scaling up for skin loading etc.
   float GetScalingPixelRatio() const;
-  void Flip(bool rendered);
+  void Flip(bool rendered, bool videoLayer);
   void InvertFinalCoords(float &x, float &y) const;
   inline float ScaleFinalXCoord(float x, float y) const XBMC_FORCE_INLINE { return m_finalTransform.matrix.TransformXCoord(x, y, 0); }
   inline float ScaleFinalYCoord(float x, float y) const XBMC_FORCE_INLINE { return m_finalTransform.matrix.TransformYCoord(x, y, 0); }

--- a/xbmc/rendering/RenderSystem.h
+++ b/xbmc/rendering/RenderSystem.h
@@ -102,7 +102,7 @@ public:
 
   virtual bool BeginRender() = 0;
   virtual bool EndRender() = 0;
-  virtual void PresentRender(bool rendered) = 0;
+  virtual void PresentRender(bool rendered, bool videoLayer) = 0;
   virtual bool ClearBuffers(color_t color) = 0;
   virtual bool IsExtSupported(const char* extension) = 0;
 

--- a/xbmc/rendering/gl/RenderSystemGL.cpp
+++ b/xbmc/rendering/gl/RenderSystemGL.cpp
@@ -290,7 +290,7 @@ bool CRenderSystemGL::IsExtSupported(const char* extension)
   return m_RenderExtensions.find(name) != std::string::npos;
 }
 
-void CRenderSystemGL::PresentRender(bool rendered)
+void CRenderSystemGL::PresentRender(bool rendered, bool videoLayer)
 {
   SetVSync(true);
 

--- a/xbmc/rendering/gl/RenderSystemGL.h
+++ b/xbmc/rendering/gl/RenderSystemGL.h
@@ -39,7 +39,7 @@ public:
 
   bool BeginRender() override;
   bool EndRender() override;
-  void PresentRender(bool rendered) override;
+  void PresentRender(bool rendered, bool videoLayer) override;
   bool ClearBuffers(color_t color) override;
   bool IsExtSupported(const char* extension) override;
 

--- a/xbmc/rendering/gles/RenderSystemGLES.cpp
+++ b/xbmc/rendering/gles/RenderSystemGLES.cpp
@@ -274,7 +274,7 @@ static int64_t abs64(int64_t a)
   return a;
 }
 
-void CRenderSystemGLES::PresentRender(bool rendered)
+void CRenderSystemGLES::PresentRender(bool rendered, bool videoLayer)
 {
   SetVSync(true);
 
@@ -283,7 +283,8 @@ void CRenderSystemGLES::PresentRender(bool rendered)
 
   PresentRenderImpl(rendered);
 
-  if (!rendered)
+  // if video is rendered to a separate layer, we should not block this thread
+  if (!rendered && !videoLayer)
     Sleep(40);
 }
 

--- a/xbmc/rendering/gles/RenderSystemGLES.h
+++ b/xbmc/rendering/gles/RenderSystemGLES.h
@@ -56,7 +56,7 @@ public:
 
   bool BeginRender() override;
   bool EndRender() override;
-  void PresentRender(bool rendered) override;
+  void PresentRender(bool rendered, bool videoLayer) override;
   bool ClearBuffers(color_t color) override;
   bool IsExtSupported(const char* extension) override;
 

--- a/xbmc/utils/Splash.cpp
+++ b/xbmc/utils/Splash.cpp
@@ -72,6 +72,6 @@ void CSplash::Show()
 
   //show it on screen
   g_Windowing.EndRender();
-  g_graphicsContext.Flip(true);
+  g_graphicsContext.Flip(true, false);
   g_graphicsContext.Unlock();
 }

--- a/xbmc/windowing/X11/WinSystemX11GLContext.cpp
+++ b/xbmc/windowing/X11/WinSystemX11GLContext.cpp
@@ -111,7 +111,7 @@ bool CWinSystemX11GLContext::SetWindow(int width, int height, bool fullscreen, c
     RefreshGLContext(m_currentOutput.compare(output) != 0);
     XSync(m_dpy, FALSE);
     g_graphicsContext.Clear(0);
-    g_graphicsContext.Flip(true);
+    g_graphicsContext.Flip(true, false);
     ResetVSync();
 
     m_windowDirty = false;

--- a/xbmc/windowing/X11/WinSystemX11GLESContext.cpp
+++ b/xbmc/windowing/X11/WinSystemX11GLESContext.cpp
@@ -55,7 +55,7 @@ bool CWinSystemX11GLESContext::SetWindow(int width, int height, bool fullscreen,
     RefreshGLContext(m_currentOutput.compare(output) != 0);
     XSync(m_dpy, FALSE);
     g_graphicsContext.Clear(0);
-    g_graphicsContext.Flip(true);
+    g_graphicsContext.Flip(true, false);
     ResetVSync();
 
     m_windowDirty = false;

--- a/xbmc/windowing/egl/WinSystemEGL.cpp
+++ b/xbmc/windowing/egl/WinSystemEGL.cpp
@@ -56,6 +56,7 @@ CWinSystemEGL::CWinSystemEGL() : CWinSystemBase()
 
   m_egl               = NULL;
   m_iVSyncMode        = 0;
+  m_delayDispReset    = false;
 }
 
 CWinSystemEGL::~CWinSystemEGL()
@@ -286,6 +287,19 @@ bool CWinSystemEGL::CreateNewWindow(const std::string& name, bool fullScreen, RE
     return true;
   }
 
+  int delay = CSettings::GetInstance().GetInt("videoscreen.delayrefreshchange");
+  if (delay > 0)
+  {
+    m_delayDispReset = true;
+    m_dispResetTimer.Set(delay * 100);
+  }
+
+  {
+    CSingleLock lock(m_resourceSection);
+    for (std::vector<IDispResource *>::iterator i = m_resources.begin(); i != m_resources.end(); ++i)
+      (*i)->OnLostDisplay();
+  }
+
   m_stereo_mode = stereo_mode;
   m_bFullScreen   = fullScreen;
   // Destroy any existing window
@@ -300,6 +314,7 @@ bool CWinSystemEGL::CreateNewWindow(const std::string& name, bool fullScreen, RE
     return false;
   }
 
+  if (!m_delayDispReset)
   {
     CSingleLock lock(m_resourceSection);
     // tell any shared resources
@@ -439,6 +454,14 @@ bool CWinSystemEGL::IsExtSupported(const char* extension)
 
 void CWinSystemEGL::PresentRenderImpl(bool rendered)
 {
+  if (m_delayDispReset && m_dispResetTimer.IsTimePast())
+  {
+    m_delayDispReset = false;
+    CSingleLock lock(m_resourceSection);
+    // tell any shared resources
+    for (std::vector<IDispResource *>::iterator i = m_resources.begin(); i != m_resources.end(); ++i)
+      (*i)->OnResetDisplay();
+  }
   if (!rendered)
     return;
   m_egl->SwapBuffers(m_display, m_surface);

--- a/xbmc/windowing/egl/WinSystemEGL.h
+++ b/xbmc/windowing/egl/WinSystemEGL.h
@@ -27,6 +27,7 @@
 #include "utils/GlobalsHandling.h"
 #include <EGL/egl.h>
 #include "windowing/WinSystem.h"
+#include "threads/SystemClock.h"
 
 class CEGLWrapper;
 class IDispResource;
@@ -84,6 +85,8 @@ protected:
   std::string           m_extensions;
   CCriticalSection             m_resourceSection;
   std::vector<IDispResource*>  m_resources;
+  bool m_delayDispReset;
+  XbmcThreads::EndTime m_dispResetTimer;
 };
 
 XBMC_GLOBAL_REF(CWinSystemEGL,g_Windowing);

--- a/xbmc/windowing/windows/WinSystemWin32DX.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32DX.cpp
@@ -40,7 +40,7 @@ CWinSystemWin32DX::~CWinSystemWin32DX()
 
 }
 
-void CWinSystemWin32DX::PresentRender(bool rendered)
+void CWinSystemWin32DX::PresentRender(bool rendered, bool videoLayer)
 {
   if (rendered)
     PresentRenderImpl(rendered);

--- a/xbmc/windowing/windows/WinSystemWin32DX.h
+++ b/xbmc/windowing/windows/WinSystemWin32DX.h
@@ -42,7 +42,7 @@ public:
   virtual bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays);
   virtual bool WindowedMode() { return CRenderSystemDX::m_useWindowedDX; }
   virtual void NotifyAppFocusChange(bool bGaining);
-  virtual void PresentRender(bool rendererd);
+  virtual void PresentRender(bool rendererd, bool videoLayer);
 
   std::string GetClipboardText(void);
 


### PR DESCRIPTION
This adds back in support for "Delay after change of refresh rate"
which was lost in the VideoPlayer rework.
