### PR TITLE
[jenkins/rbpi] - use new toolchain for rbpi and get rid of the unused…

### DIFF
--- a/tools/buildsteps/rbpi/configure-depends
+++ b/tools/buildsteps/rbpi/configure-depends
@@ -6,8 +6,7 @@ if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
 then
   cd $WORKSPACE/tools/depends;
 
-  PATH="$PATH:$JENKINS_RBPI_DEVENV/tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian/bin" \
+  PATH="$PATH:$JENKINS_RBPI_DEVENV/tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin" \
   ./configure --with-platform=raspberry-pi --host=arm-linux-gnueabihf --prefix=$XBMC_DEPENDS_ROOT --with-tarballs=$TARBALLS \
-    --with-toolchain=$JENKINS_RBPI_DEVENV/tools/arm-bcm2708/arm-bcm2708hardfp-linux-gnueabi/arm-bcm2708hardfp-linux-gnueabi/sysroot \
     --with-firmware=$JENKINS_RBPI_DEVENV/firmware --build=i686-linux
 fi


### PR DESCRIPTION
… "--with-toolchain" configure flag

Once jenkins isn't busy anymore i'll switch over to the new toolchain on the jenkins slave and merge this ...

@popcornmix fyi
@tamland fyi (once this is in - your other PR should work on rbpi too)

This bumps to gcc 4.8.3
