### PR TITLE
VideoPlayer: Avoid deadlock with m_StateSelection

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -1290,13 +1290,10 @@ void CVideoPlayer::Process()
 #endif
 
     // check display lost
+    if (m_displayLost)
     {
-      CSingleLock lock(m_StateSection);
-      if (m_displayLost)
-      {
-        Sleep(50);
-        continue;
-      }
+      Sleep(50);
+      continue;
     }
 
     // handle messages send to this thread, like seek or demuxer reset requests
@@ -4978,13 +4975,11 @@ void CVideoPlayer::VideoParamsChange()
 void CVideoPlayer::OnLostDisplay()
 {
   CLog::Log(LOGNOTICE, "VideoPlayer: OnLostDisplay received");
-  CSingleLock lock(m_StateSection);
   m_displayLost = true;
 }
 
 void CVideoPlayer::OnResetDisplay()
 {
   CLog::Log(LOGNOTICE, "VideoPlayer: OnResetDisplay received");
-  CSingleLock lock(m_StateSection);
   m_displayLost = false;
 }

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -20,6 +20,7 @@
  *
  */
 
+#include <atomic>
 #include <utility>
 #include "cores/IPlayer.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderManager.h"
@@ -547,7 +548,7 @@ protected:
   bool m_HasVideo;
   bool m_HasAudio;
 
-  bool m_displayLost;
+  std::atomic<bool> m_displayLost;
 
   // omxplayer variables
   struct SOmxPlayerState m_OmxPlayerState;


### PR DESCRIPTION
Sleeping with the lock held means the OnResetDisplay callback is blocked
which blocks the application thread.

As m_StateSelection is only relased for a very few cycles it appears
that application thread struggles to obtain the lock and can stall
for 30 seconds or more.

Drop the lock and use atomics.
