### PR TITLE
bug fix for http://trac.kodi.tv #16515

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
@@ -151,11 +151,11 @@ public:
 
     // order matters, so pay attention
     // to codec_para_t in codec_types.h
-    CBitstreamConverter::write_bits(&bs, 32, 0);                   // CODEC_HANDLE handle
-    CBitstreamConverter::write_bits(&bs, 32, 0);                   // CODEC_HANDLE cntl_handle
-    CBitstreamConverter::write_bits(&bs, 32, 0);                   // CODEC_HANDLE sub_handle
+    CBitstreamConverter::write_bits(&bs, 32, -1);                   // CODEC_HANDLE handle, init to invalid
+    CBitstreamConverter::write_bits(&bs, 32, -1);                   // CODEC_HANDLE cntl_handle
+    CBitstreamConverter::write_bits(&bs, 32, -1);                   // CODEC_HANDLE sub_handle
 
-    CBitstreamConverter::write_bits(&bs, 32, 0);                   // CODEC_HANDLE audio_utils_handle
+    CBitstreamConverter::write_bits(&bs, 32, -1);                   // CODEC_HANDLE audio_utils_handle
 
     CBitstreamConverter::write_bits(&bs, 32, p_in->stream_type);   // stream_type_t stream_type
 
@@ -200,6 +200,10 @@ public:
 #else
     // direct struct usage, we do not know which flavor
     // so just use what we get from headers and pray.
+    p_out->handle             = -1; //init to invalid
+    p_out->cntl_handle        = -1;
+    p_out->sub_handle         = -1;
+    p_out->audio_utils_handle = -1;
     p_out->has_video          = 1;
     p_out->noblock            = p_in->noblock;
     p_out->video_pid          = p_in->video_pid;
@@ -1392,6 +1396,10 @@ CAMLCodec::CAMLCodec(IVPClockCallback* clock)
     m_dll->Load();
   }
   am_private->m_dll = m_dll;
+  am_private->vcodec.handle             = -1; //init to invalid
+  am_private->vcodec.cntl_handle        = -1;
+  am_private->vcodec.sub_handle         = -1;
+  am_private->vcodec.audio_utils_handle = -1;
 }
 
 
@@ -1670,10 +1678,6 @@ void CAMLCodec::CloseDecoder()
   SysfsUtils::SetInt("/sys/class/tsync/enable", 1);
 
   ShowMainVideo(false);
-
-  // add a little delay after closing in case
-  // we are reopened too fast.
-  usleep(500 * 1000);
 }
 
 void CAMLCodec::Reset()


### PR DESCRIPTION
AMLCodec.cpp altered to init handles to an invalid value. This fixes http://trac.kodi.tv/ticket/16515.
I also removed a previous workaround for this bug by Chris (koying, usleep) which is obsolete then and only worked on some systems.
For details see http://openelec.tv/forum/87-vdr-addon/79303-need-help-live-tv-freeze-after-a-short-play?start=15#156694.

/Zweikeks
