### PR TITLE
AESinkAudiotrack: Reimplement critical parts

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -1212,6 +1212,7 @@ void CActiveAE::Configure(AEAudioFormat *desiredFmt)
         format.m_streamInfo.m_type = CAEStreamInfo::STREAM_TYPE_AC3;
         format.m_streamInfo.m_channels = 2;
         format.m_streamInfo.m_sampleRate = 48000;
+        format.m_streamInfo.m_ac3FrameSize = m_encoderFormat.m_frames;
         // TODO
         if (m_encoderBuffers && initSink)
         {

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -295,10 +295,17 @@ bool CAESinkAUDIOTRACK::Initialize(AEAudioFormat &format, std::string &device)
 
   while (!m_at_jni)
   {
-    m_min_buffer_size = CJNIAudioTrack::getMinBufferSize(m_sink_sampleRate,
+    int min_buffer = CJNIAudioTrack::getMinBufferSize(m_sink_sampleRate,
                                                          atChannelMask,
                                                          m_encoding);
 
+    if (min_buffer < 0)
+    {
+      CLog::Log(LOGERROR, "Minimum Buffer Size was: %d - disable passthrough (?) your hw does not support it", min_buffer);
+      return false;
+    }
+
+    m_min_buffer_size = (unsigned int) min_buffer;
     CLog::Log(LOGDEBUG, "Minimum size we need for stream: %u", m_min_buffer_size);
     double rawlength_in_seconds = 0.0;
     int multiplier = 1;

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -20,7 +20,6 @@
 
 #include "AESinkAUDIOTRACK.h"
 #include "cores/AudioEngine/Utils/AEUtil.h"
-#include "cores/AudioEngine/Utils/AERingBuffer.h"
 #include "platform/android/activity/XBMCApp.h"
 #include "settings/Settings.h"
 #include "utils/log.h"
@@ -30,6 +29,7 @@
 #include "platform/android/jni/AudioManager.h"
 #include "platform/android/jni/AudioTrack.h"
 #include "platform/android/jni/Build.h"
+#include "utils/TimeUtils.h"
 
 #if defined(HAS_LIBAMCODEC)
 #include "utils/AMLUtils.h"
@@ -37,7 +37,18 @@
 
 //#define DEBUG_VERBOSE 1
 
+// This is an alternative to the linear weighted delay smoothing
+// advantages: only one history value needs to be stored
+// in tests the linear weighted average smoother yield better results
+//#define AT_USE_EXPONENTIAL_AVERAGING 1
+
 using namespace jni;
+
+// those are empirical values while the HD buffer
+// is the max TrueHD package
+const unsigned int MAX_RAW_AUDIO_BUFFER_HD = 61440;
+const unsigned int MAX_RAW_AUDIO_BUFFER = 16384;
+const unsigned int MOVING_AVERAGE_MAX_MEMBERS = 20;
 
 /*
  * ADT-1 on L preview as of 2014-10 downmixes all non-5.1/7.1 content
@@ -47,8 +58,6 @@ using namespace jni;
  * this should be disabled or adapted accordingly.
  */
 #define LIMIT_TO_STEREO_AND_5POINT1_AND_7POINT1 1
-
-#define SMOOTHED_DELAY_MAX 10
 
 static const AEChannel KnownChannels[] = { AE_CH_FL, AE_CH_FR, AE_CH_FC, AE_CH_LFE, AE_CH_SL, AE_CH_SR, AE_CH_BL, AE_CH_BR, AE_CH_BC, AE_CH_BLOC, AE_CH_BROC, AE_CH_NULL };
 
@@ -169,11 +178,17 @@ CAESinkAUDIOTRACK::CAESinkAUDIOTRACK()
 {
   m_alignedS16 = NULL;
   m_sink_frameSize = 0;
+  m_encoding = CJNIAudioFormat::ENCODING_PCM_16BIT;
   m_audiotrackbuffer_sec = 0.0;
   m_at_jni = NULL;
   m_duration_written = 0;
-  m_lastHeadPosition = 0;
-  m_ptOffset = 0;
+  m_offset = -1;
+  m_volume = -1;
+  m_sink_sampleRate = 0;
+  m_passthrough = false;
+  m_min_buffer_size = 0;
+  m_lastPlaybackHeadPosition = 0;
+  m_pause_counter = 0;
 }
 
 CAESinkAUDIOTRACK::~CAESinkAUDIOTRACK()
@@ -191,9 +206,10 @@ bool CAESinkAUDIOTRACK::Initialize(AEAudioFormat &format, std::string &device)
 {
   m_format      = format;
   m_volume      = -1;
-  m_smoothedDelayCount = 0;
-  m_smoothedDelayVec.clear();
-
+  m_offset = -1;
+  m_lastPlaybackHeadPosition = 0;
+  m_linearmovingaverage.clear();
+  m_pause_counter = 0;
   CLog::Log(LOGDEBUG, "CAESinkAUDIOTRACK::Initialize requested: sampleRate %u; format: %s; channels: %d", format.m_sampleRate, CAEUtil::DataFormatToStr(format.m_dataFormat), format.m_channelLayout.Count());
 
   int stream = CJNIAudioManager::STREAM_MUSIC;
@@ -279,28 +295,88 @@ bool CAESinkAUDIOTRACK::Initialize(AEAudioFormat &format, std::string &device)
 
   while (!m_at_jni)
   {
-    unsigned int min_buffer_size       = CJNIAudioTrack::getMinBufferSize( m_sink_sampleRate,
-                                                                           atChannelMask,
-                                                                           m_encoding);
+    m_min_buffer_size = CJNIAudioTrack::getMinBufferSize(m_sink_sampleRate,
+                                                         atChannelMask,
+                                                         m_encoding);
+
+    CLog::Log(LOGDEBUG, "Minimum size we need for stream: %u", m_min_buffer_size);
+    double rawlength_in_seconds = 0.0;
+    int multiplier = 1;
+    unsigned int ac3FrameSize = 1;
     if (m_passthrough && !m_info.m_wantsIECPassthrough)
     {
-      m_format.m_frames         = 16384;
-      min_buffer_size         = (min_buffer_size * 4 / (m_format.m_frameSize*m_format.m_frames)+1) * (m_format.m_frameSize*m_format.m_frames);
-      m_format.m_frameSize    = 1;
+      switch (m_format.m_streamInfo.m_type)
+      {
+        case CAEStreamInfo::STREAM_TYPE_TRUEHD:
+          m_min_buffer_size = MAX_RAW_AUDIO_BUFFER_HD;
+          m_format.m_frames = m_min_buffer_size;
+          rawlength_in_seconds = 8 * m_format.m_streamInfo.GetDuration() / 1000; // on average
+          break;
+        case CAEStreamInfo::STREAM_TYPE_DTSHD:
+          // normal frame is max  2012 bytes + 2764 sub frame
+          m_min_buffer_size = 66432; //according to the buffer model of ISO/IEC13818-1
+          m_format.m_frames = m_min_buffer_size;
+          rawlength_in_seconds = 8 * m_format.m_streamInfo.GetDuration() / 1000; // average value
+          break;
+        case CAEStreamInfo::STREAM_TYPE_DTS_512:
+        case CAEStreamInfo::STREAM_TYPE_DTSHD_CORE:
+          // max 2012 bytes
+          // depending on sample rate between 106 ms and 212 ms
+          m_min_buffer_size = 8 * 2012;
+          m_format.m_frames = m_min_buffer_size;
+          rawlength_in_seconds = 8 * m_format.m_streamInfo.GetDuration() / 1000;
+          break;
+        case CAEStreamInfo::STREAM_TYPE_DTS_1024:
+        case CAEStreamInfo::STREAM_TYPE_DTS_2048:
+          m_min_buffer_size = 4 * 5462;
+          m_format.m_frames = m_min_buffer_size;
+          rawlength_in_seconds = 4 * m_format.m_streamInfo.GetDuration() / 1000;
+          break;
+        case CAEStreamInfo::STREAM_TYPE_AC3:
+           ac3FrameSize = m_format.m_streamInfo.m_ac3FrameSize;
+           if (ac3FrameSize == 0)
+             ac3FrameSize = 1536; // fallback if not set, e.g. Transcoding
+           m_min_buffer_size = std::max(m_min_buffer_size * 4, ac3FrameSize * 8);
+           m_format.m_frames = m_min_buffer_size;
+           multiplier = m_min_buffer_size / ac3FrameSize; // int division is wanted
+           rawlength_in_seconds = multiplier * m_format.m_streamInfo.GetDuration() / 1000;
+          break;
+          // EAC3 is currently not supported
+        case CAEStreamInfo::STREAM_TYPE_EAC3:
+           m_min_buffer_size = 10752; // least common multiple of 1792 and 1536
+           m_format.m_frames = m_min_buffer_size; // needs testing
+           rawlength_in_seconds = 4 * m_format.m_streamInfo.GetDuration() / 1000;
+           break;
+        default:
+          m_min_buffer_size = MAX_RAW_AUDIO_BUFFER;
+          m_format.m_frames = m_min_buffer_size;
+          rawlength_in_seconds = 0.4;
+          break;
+      }
+
+      CLog::Log(LOGDEBUG, "Opening Passthrough RAW Format: %s Sink SampleRate: %u", CAEUtil::StreamTypeToStr(m_format.m_streamInfo.m_type), m_sink_sampleRate);
+      m_format.m_frameSize = 1;
     }
     else
     {
-      min_buffer_size           *= 2;
+      m_min_buffer_size           *= 2;
       m_format.m_frameSize    = m_format.m_channelLayout.Count() *
         (CAEUtil::DataFormatToBits(m_format.m_dataFormat) / 8);
-      m_format.m_frames         = (int)(min_buffer_size / m_format.m_frameSize) / 2;
+      m_format.m_frames         = (int)(m_min_buffer_size / m_format.m_frameSize) / 2;
     }
     m_sink_frameSize          = m_format.m_frameSize;
-    m_audiotrackbuffer_sec    = (double)(min_buffer_size / m_sink_frameSize) / (double)m_sink_sampleRate;
 
-    m_at_jni                  = CreateAudioTrack(stream, m_sink_sampleRate,
-                                                 atChannelMask, m_encoding,
-                                                 min_buffer_size);
+    if (m_passthrough && !m_info.m_wantsIECPassthrough)
+      m_audiotrackbuffer_sec = rawlength_in_seconds;
+    else
+     m_audiotrackbuffer_sec = (double)(m_min_buffer_size / m_sink_frameSize) / (double)m_sink_sampleRate;
+
+
+    CLog::Log(LOGDEBUG, "Created Audiotrackbuffer with playing time of %lf ms min buffer size: %u bytes",
+                         m_audiotrackbuffer_sec * 1000, m_min_buffer_size);
+
+    m_at_jni = CreateAudioTrack(stream, m_sink_sampleRate, atChannelMask,
+                                m_encoding, m_min_buffer_size);
 
     if (!IsInitialized())
     {
@@ -324,12 +400,11 @@ bool CAESinkAUDIOTRACK::Initialize(AEAudioFormat &format, std::string &device)
       Deinitialize();
       return false;
     }
-    CLog::Log(LOGDEBUG, "CAESinkAUDIOTRACK::Initialize returned: m_sampleRate %u; format:%s; min_buffer_size %u; m_frames %u; m_frameSize %u; channels: %d", m_format.m_sampleRate, CAEUtil::DataFormatToStr(m_format.m_dataFormat), min_buffer_size, m_format.m_frames, m_format.m_frameSize, m_format.m_channelLayout.Count());
+    CLog::Log(LOGDEBUG, "CAESinkAUDIOTRACK::Initialize returned: m_sampleRate %u; format:%s; min_buffer_size %u; m_frames %u; m_frameSize %u; channels: %d", m_format.m_sampleRate, CAEUtil::DataFormatToStr(m_format.m_dataFormat), m_min_buffer_size, m_format.m_frames, m_format.m_frameSize, m_format.m_channelLayout.Count());
   }
+  format = m_format;
 
-  format                    = m_format;
-
-  // Force volume to 100% for passthrough
+  // Force volume to 100% for IEC passthrough
   if (m_passthrough && m_info.m_wantsIECPassthrough)
   {
     CXBMCApp::AcquireAudioFocus();
@@ -363,8 +438,11 @@ void CAESinkAUDIOTRACK::Deinitialize()
   m_at_jni->release();
 
   m_duration_written = 0;
-  m_lastHeadPosition = 0;
-  m_ptOffset = 0;
+  m_offset = -1;
+  m_pause_counter = 0;
+
+  m_lastPlaybackHeadPosition = 0;
+  m_linearmovingaverage.clear();
 
   delete m_at_jni;
   m_at_jni = NULL;
@@ -386,27 +464,60 @@ void CAESinkAUDIOTRACK::GetDelay(AEDelayStatus& status)
   // In their infinite wisdom, Google decided to make getPlaybackHeadPosition
   // return a 32bit "int" that you should "interpret as unsigned."  As such,
   // for wrap saftey, we need to do all ops on it in 32bit integer math.
+
   uint32_t head_pos = (uint32_t)m_at_jni->getPlaybackHeadPosition();
 
-  double delay;
-  delay = m_duration_written - ((double)head_pos / m_sink_sampleRate);
+  // head_pos does not necessarily start at the beginning
+  if (m_offset == -1 && m_at_jni->getPlayState() == CJNIAudioTrack::PLAYSTATE_PLAYING)
+  {
+    CLog::Log(LOGDEBUG, "Offset updated to %u", head_pos);
+    m_offset = head_pos;
+  }
 
-  m_smoothedDelayVec.push_back(delay);
-  if (m_smoothedDelayCount <= SMOOTHED_DELAY_MAX)
-    m_smoothedDelayCount++;
-  else
-    m_smoothedDelayVec.erase(m_smoothedDelayVec.begin());
+  if (m_offset > head_pos)
+  {
+    CLog::Log(LOGDEBUG, "You did it wrong man - fully wrong! offset %lld head pos %u", m_offset, head_pos);
+    m_offset = 0;
+  }
+  uint32_t normHead_pos = head_pos - m_offset;
 
-  double smootheDelay = 0;
-  for (double d : m_smoothedDelayVec)
-    smootheDelay += d;
-  smootheDelay /= m_smoothedDelayCount;
+  if (m_passthrough && !m_info.m_wantsIECPassthrough)
+  {
+    if (m_pause_counter > 0)
+    {
+      const double d = GetMovingAverageDelay(GetCacheTotal());
+      CLog::Log(LOGDEBUG, "Faking Delay: smooth %lf measured: %lf", d * 1000, GetCacheTotal() * 1000);
+      status.SetDelay(d);
+      return;
+    }
+  }
+  if (normHead_pos > m_lastPlaybackHeadPosition)
+  {
+    unsigned int differencehead = normHead_pos - m_lastPlaybackHeadPosition;
+    CLog::Log(LOGDEBUG, "Sink advanced: %u", differencehead);
+    m_lastPlaybackHeadPosition = normHead_pos;
+  }
 
-#ifdef DEBUG_VERBOSE
-  CLog::Log(LOGDEBUG, "CAESinkAUDIOTRACK::GetDelay m_frames_written/head_pos %f/%u %f", m_duration_written, head_pos, smootheDelay);
-#endif
+  double gone = (double) normHead_pos / (double) m_sink_sampleRate;
 
-  status.SetDelay(smootheDelay);
+  // if sink is run dry without buffer time written anymore
+  if (gone > m_duration_written)
+    gone = m_duration_written;
+
+  double delay = m_duration_written - gone;
+  if (delay < 0)
+    delay = 0;
+
+  const double d = GetMovingAverageDelay(delay);
+
+  CLog::Log(LOGDEBUG, "Calculations duration written: %lf sampleRate: %u gone: %lf", m_duration_written, m_sink_sampleRate, gone);
+
+  bool playing = m_at_jni->getPlayState() == CJNIAudioTrack::PLAYSTATE_PLAYING;
+
+  CLog::Log(LOGDEBUG, "Current-Delay: smoothed: %lf measured: %lf Head Pos: %u Playing: %s", d * 1000, delay * 1000,
+                       normHead_pos, playing ? "yes" : "no");
+
+  status.SetDelay(d);
 }
 
 double CAESinkAUDIOTRACK::GetLatency()
@@ -427,39 +538,111 @@ unsigned int CAESinkAUDIOTRACK::AddPackets(uint8_t **data, unsigned int frames, 
   if (!IsInitialized())
     return INT_MAX;
 
+  // for debugging only - can be removed if everything is really stable
+  uint64_t startTime = CurrentHostCounter();
+  CLog::Log(LOGDEBUG, "Got frames: %u", frames);
+
   uint8_t *buffer = data[0]+offset*m_format.m_frameSize;
   uint8_t *out_buf = buffer;
   int size = frames * m_format.m_frameSize;
 
   // write as many frames of audio as we can fit into our internal buffer.
   int written = 0;
+  int loop_written = 0;
   if (frames)
   {
-    // android will auto pause the playstate when it senses idle,
-    // check it and set playing if it does this. Do this before
-    // writing into its buffer.
+    if (m_pause_counter > 0)
+    {
+      usleep(m_format.m_streamInfo.GetDuration() * 1000);
+      CLog::Log(LOGDEBUG, "Slept: %u", m_pause_counter);
+      m_pause_counter--;
+    }
     if (m_at_jni->getPlayState() != CJNIAudioTrack::PLAYSTATE_PLAYING)
       m_at_jni->play();
-    written = m_at_jni->write((char*)out_buf, 0, size);
-    if (written < 0)
+
+    bool retried = false;
+    int size_left = size;
+    while (written < size)
     {
-      CLog::Log(LOGERROR, "CAESinkAUDIOTRACK::AddPackets write returned error:  %d", written);
-      return INT_MAX;
+      loop_written = m_at_jni->write((char*)out_buf, 0, size_left);
+      written += loop_written;
+      size_left -= loop_written;
+
+      if (loop_written < 0)
+      {
+        CLog::Log(LOGERROR, "CAESinkAUDIOTRACK::AddPackets write returned error:  %d", loop_written);
+        return INT_MAX;
+      }
+
+      CLog::Log(LOGDEBUG, "Size left: %d", size_left);
+      // if we could not add any data - sleep a bit and retry
+      if (loop_written == 0)
+      {
+	if (!retried)
+	{
+          retried = true;
+          double sleep_time = 0;
+          if (m_passthrough && !m_info.m_wantsIECPassthrough)
+          {
+            sleep_time = m_format.m_streamInfo.GetDuration();
+            usleep(sleep_time * 1000);
+          }
+          else
+          {
+            sleep_time = (double) m_format.m_frames / m_sink_frameSize / 2.0 / (double) m_format.m_sampleRate * 1000;
+            usleep(sleep_time * 1000);
+          }
+          bool playing = m_at_jni->getPlayState() == CJNIAudioTrack::PLAYSTATE_PLAYING;
+          CLog::Log(LOGDEBUG, "Retried to write onto the sink - slept: %lf playing: %s", sleep_time, playing ? "yes" : "no");
+          continue;
+	}
+	else
+	{
+	  CLog::Log(LOGDEBUG, "Repeatedly tried to write onto the sink - giving up");
+	  break;
+	}
+      }
+      retried = false; // at least one time there was more than zero data written
+      if (m_passthrough && !m_info.m_wantsIECPassthrough)
+      {
+        if (written == size)
+          m_duration_written += m_format.m_streamInfo.GetDuration() / 1000;
+        else
+        {
+          CLog::Log(LOGDEBUG, "Error writing full package to sink, left: %d", size_left);
+          // Let AE wait some ms to come back
+          unsigned int written_frames = (unsigned int) (written/m_format.m_frameSize);
+          return written_frames;
+        }
+      }
+      else
+        m_duration_written += ((double) loop_written / m_sink_frameSize) / m_format.m_sampleRate;
+
+      // just try again to care for fragmentation
+      if (written < size)
+	out_buf = out_buf + loop_written;
+
+      loop_written = 0;
     }
-    if (m_passthrough && !m_info.m_wantsIECPassthrough)
-    {
-      if (written != m_format.m_frames)
-        m_duration_written += m_format.m_streamInfo.GetDuration() / 1000;
-    }
-    else
-      m_duration_written += ((double)written / m_sink_frameSize) / m_format.m_sampleRate;
   }
+  unsigned int written_frames = (unsigned int) (written/m_format.m_frameSize);
+  double time_to_add_ms = 1000.0 * (CurrentHostCounter() - startTime) / CurrentHostFrequency();
+  CLog::Log(LOGDEBUG, "Time needed for add Packet: %lf ms", time_to_add_ms);
+  return written_frames;
+}
 
-#ifdef DEBUG_VERBOSE
-  CLog::Log(LOGDEBUG, "CAESinkAUDIOTRACK::AddPackets written %d", written);
-#endif
+void CAESinkAUDIOTRACK::AddPause(unsigned int millis)
+{
+  if (!m_at_jni)
+    return;
 
-  return (unsigned int)(written/m_format.m_frameSize);
+  CLog::Log(LOGDEBUG, "AddPause was called with millis: %u and PlayState: %d", millis, m_at_jni->getPlayState());
+
+  // we can cache a maximum amount of m_audiotrackbuffer_sec seconds of silence
+  if ((double) m_pause_counter * millis / 1000.0 <= m_audiotrackbuffer_sec)
+    m_pause_counter++;
+
+    usleep(millis * 1000);
 }
 
 void CAESinkAUDIOTRACK::Drain()
@@ -467,10 +650,13 @@ void CAESinkAUDIOTRACK::Drain()
   if (!m_at_jni)
     return;
 
-  // TODO: does this block until last samples played out?
-  // we should not return from drain as long the device is in playing state
+  CLog::Log(LOGDEBUG, "Draining Audio");
   m_at_jni->stop();
   m_duration_written = 0;
+  m_offset = -1;
+  m_pause_counter = 0;
+  m_lastPlaybackHeadPosition = 0;
+  m_linearmovingaverage.clear();
 }
 
 void CAESinkAUDIOTRACK::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)
@@ -533,7 +719,8 @@ void CAESinkAUDIOTRACK::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)
       if (CJNIAudioManager::GetSDKVersion() >= 21)
       {
         m_info.m_wantsIECPassthrough = false;
-        m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_EAC3);
+        // here only 5.1 would work but we cannot correctly distinguish
+        // m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_EAC3);
 
         if (CJNIAudioManager::GetSDKVersion() >= 23)
         {
@@ -550,5 +737,44 @@ void CAESinkAUDIOTRACK::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)
   }
 
   list.push_back(m_info);
+}
+
+double CAESinkAUDIOTRACK::GetMovingAverageDelay(double newestdelay)
+{
+#if defined AT_USE_EXPONENTIAL_AVERAGING
+  double old = 0.0;
+  if (m_linearmovingaverage.empty()) // just for creating one space in list
+    m_linearmovingaverage.push_back(newestdelay);
+  else
+    old = m_linearmovingaverage.front();
+
+  const double alpha = 0.3;
+  const double beta = 0.7;
+
+  double d = alpha * newestdelay + beta * old;
+  m_linearmovingaverage.at(0) = d;
+
+  return d;
+#endif
+
+  m_linearmovingaverage.push_back(newestdelay);
+
+  // new values are in the back, old values are in the front
+  // oldest value is removed if elements > MOVING_AVERAGE_MAX_MEMBERS
+  // removing first element of a vector sucks - I know that
+  // but hey - 10 elements - not 1 million
+  size_t size = m_linearmovingaverage.size();
+  if (size > MOVING_AVERAGE_MAX_MEMBERS)
+  {
+    m_linearmovingaverage.erase(m_linearmovingaverage.begin());
+    size--;
+  }
+  // m_{LWMA}^{(n)}(t) = \frac{2}{n (n+1)} \sum_{i=1}^n i \; x(t-n+i)
+  const double denom = 2.0 / (size * (size + 1));
+  double sum = 0.0;
+  for (size_t i = 0; i < m_linearmovingaverage.size(); i++)
+    sum += (i + 1) * m_linearmovingaverage.at(i);
+
+  return sum * denom;
 }
 

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
@@ -22,10 +22,11 @@
 #include "cores/AudioEngine/Interfaces/AESink.h"
 #include "cores/AudioEngine/Utils/AEDeviceInfo.h"
 #include "threads/CriticalSection.h"
+#include "threads/Thread.h"
 
+#include <vector>
 #include <set>
 
-class AERingBuffer;
 namespace jni
 {
 class CJNIAudioTrack;
@@ -47,6 +48,7 @@ public:
   virtual double       GetLatency      ();
   virtual double       GetCacheTotal   ();
   virtual unsigned int AddPackets      (uint8_t **data, unsigned int frames, unsigned int offset);
+  virtual void         AddPause        (unsigned int millis);
   virtual void         Drain           ();
   static void          EnumerateDevicesEx(AEDeviceInfoList &list, bool force = false);
 
@@ -56,17 +58,27 @@ protected:
 private:
   jni::CJNIAudioTrack  *m_at_jni;
   double                m_duration_written;
-  uint32_t              m_lastHeadPosition;
-  uint32_t              m_ptOffset;
+  unsigned int          m_min_buffer_size;
+  unsigned int          m_lastPlaybackHeadPosition;
+  int64_t               m_offset;
+  // Moving Average computes the weighted average delay over
+  // a fixed size of a vector - current size: 20 values
+  double                GetMovingAverageDelay(double newestdelay);
+  // When AddPause is called the m_pause_counter is counted up
+  // Whenever a new package is added into the sink and the counter is > 0
+  // we sleep for a GetDuration() period
+  unsigned int          m_pause_counter;
+
+  // We maintain our linear weighted average delay counter in here
+  // The n-th value (timely oldest value) is weighted with 1/n
+  // the newest value gets a weight of 1
+  std::vector<double>   m_linearmovingaverage;
 
   static CAEDeviceInfo m_info;
   static std::set<unsigned int>       m_sink_sampleRates;
-  std::vector<double>                 m_smoothedDelayVec;
-  int                                 m_smoothedDelayCount;
 
   AEAudioFormat      m_format;
   double             m_volume;
-  volatile int       m_min_frames;
   int16_t           *m_alignedS16;
   unsigned int       m_sink_frameSize;
   unsigned int       m_sink_sampleRate;

--- a/xbmc/cores/AudioEngine/Utils/AEStreamInfo.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEStreamInfo.cpp
@@ -78,7 +78,8 @@ CAEStreamInfo::CAEStreamInfo() :
   m_type(STREAM_TYPE_NULL),
   m_dataIsLE(true),
   m_dtsPeriod(0),
-  m_repeat(0)
+  m_repeat(0),
+  m_ac3FrameSize(0)
 {
 }
 
@@ -417,6 +418,7 @@ unsigned int CAEStreamParser::SyncAC3(uint8_t *data, unsigned int size)
       m_info.m_channels = AC3Channels[acmod] + lfeon;
       m_syncFunc = &CAEStreamParser::SyncAC3;
       m_info.m_type = CAEStreamInfo::STREAM_TYPE_AC3;
+      m_info.m_ac3FrameSize = m_fsize;
       m_info.m_repeat = 1;
 
       CLog::Log(LOGINFO, "CAEStreamParser::SyncAC3 - AC3 stream detected (%d channels, %dHz)", m_info.m_channels, m_info.m_sampleRate);
@@ -467,6 +469,7 @@ unsigned int CAEStreamParser::SyncAC3(uint8_t *data, unsigned int size)
       m_info.m_channels = 8; /* FIXME: this should be read out of the stream */
       m_syncFunc = &CAEStreamParser::SyncAC3;
       m_info.m_type = CAEStreamInfo::STREAM_TYPE_EAC3;
+      m_info.m_ac3FrameSize = m_fsize;
       m_fsizeMain = 0;
 
       CLog::Log(LOGINFO, "CAEStreamParser::SyncAC3 - E-AC3 stream detected (%d channels, %dHz)", m_info.m_channels, m_info.m_sampleRate);

--- a/xbmc/cores/AudioEngine/Utils/AEStreamInfo.h
+++ b/xbmc/cores/AudioEngine/Utils/AEStreamInfo.h
@@ -56,6 +56,7 @@ public:
   bool m_dataIsLE;
   unsigned int m_dtsPeriod;
   unsigned int m_repeat;
+  unsigned int m_ac3FrameSize;
 };
 
 class CAEStreamParser

--- a/xbmc/platform/android/jni/AudioFormat.cpp
+++ b/xbmc/platform/android/jni/AudioFormat.cpp
@@ -84,6 +84,7 @@ void CJNIAudioFormat::PopulateStaticFields()
         {
           CJNIAudioFormat::ENCODING_DTS = get_static_field<int>(c, "ENCODING_DTS");
           CJNIAudioFormat::ENCODING_DTS_HD = get_static_field<int>(c, "ENCODING_DTS_HD");
+          CJNIAudioFormat::ENCODING_DOLBY_TRUEHD = 0x0000000d;
         }
       }
     }

--- a/xbmc/platform/android/jni/AudioFormat.cpp
+++ b/xbmc/platform/android/jni/AudioFormat.cpp
@@ -30,6 +30,8 @@ int CJNIAudioFormat::ENCODING_AC3       = 0x00000005;
 int CJNIAudioFormat::ENCODING_E_AC3     = 0x00000006;
 int CJNIAudioFormat::ENCODING_DTS       = 0x00000007;
 int CJNIAudioFormat::ENCODING_DTS_HD    = 0x00000008;
+
+// As of version 22 and Android 5 Nvidia defines this solely for their Shield
 int CJNIAudioFormat::ENCODING_DOLBY_TRUEHD    = 0x00000009;
 
 int CJNIAudioFormat::CHANNEL_OUT_STEREO  = 0x0000000c;
@@ -84,6 +86,9 @@ void CJNIAudioFormat::PopulateStaticFields()
         {
           CJNIAudioFormat::ENCODING_DTS = get_static_field<int>(c, "ENCODING_DTS");
           CJNIAudioFormat::ENCODING_DTS_HD = get_static_field<int>(c, "ENCODING_DTS_HD");
+          // Nvidia Shield v6 firmware uses another ID, which will also be the future ID
+          // though other v23 version would not return a value if we'd use the get_static_field
+          // method to query this value. The hardcoded value can be removed after probably is out
           CJNIAudioFormat::ENCODING_DOLBY_TRUEHD = 0x0000000d;
         }
       }

--- a/xbmc/platform/android/jni/AudioTrack.cpp
+++ b/xbmc/platform/android/jni/AudioTrack.cpp
@@ -140,7 +140,12 @@ int CJNIAudioTrack::write(char* audioData, int offsetInBytes, int sizeInBytes)
       written *= sizeof(float);
     }
     else
-      written = call_method<int>(m_object, "write", "([BII)I", m_buffer, offsetInBytes, sizeInBytes);
+    {
+      if (CJNIBase::GetSDKVersion() >= 23)
+        written = call_method<int>(m_object, "write", "([BII)I", m_buffer, offsetInBytes, sizeInBytes, CJNIAudioTrack::WRITE_BLOCKING);
+      else
+	written = call_method<int>(m_object, "write", "([BII)I", m_buffer, offsetInBytes, sizeInBytes);
+    }
   }
 
   return written;


### PR DESCRIPTION
This ports AESinkAudiotrack to version 17 of kodi.

Features: DTS, AC3, TrueHD, DTS-HD passthrough
Disabled for now: EAC3 does not work in 7.1 version (Android bug)

Implementation of:
- linear weighted average for delay as Android's sink buffer does only advance very rarely
- Disabled exponential alternativ with less computing power
- Calculation of buffer time
- Fragmentation support for non passthrough.
- If zero frames are written we retry ourselves at least once

All in all: Android's Audiotrack API is not one of the nice APIs. If someone representative reads this: It would be nice if you could get your periodSize set correctly, update the HeadPosition more often - or interpolate if not feasible. If you can, support IEC passthrough, that way we could at least send pause bursts to keep sync.

Bug on Nvidia's shield: When seeking AC3, you hear a little br noise, when seeking DTS you get a bigger drrr noise - nobody knows where this is coming from. Nexus 6 is fine.
