### PR TITLE
RenderSystem - cleanup

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1987,8 +1987,7 @@ void CApplication::Render()
       Sleep(singleFrameTime - frameTime);
   }
 
-  if (flip)
-    g_graphicsContext.Flip(dirtyRegions);
+  g_graphicsContext.Flip(flip);
 
   if (!extPlayerActive && g_graphicsContext.IsFullScreenVideo() && !m_pPlayer->IsPausedPlayback())
   {

--- a/xbmc/guilib/GraphicContext.cpp
+++ b/xbmc/guilib/GraphicContext.cpp
@@ -979,9 +979,9 @@ void CGraphicContext::SetMediaDir(const std::string &strMediaDir)
   m_strMediaDir = strMediaDir;
 }
 
-void CGraphicContext::Flip(const CDirtyRegionList& dirty)
+void CGraphicContext::Flip(bool rendered)
 {
-  g_Windowing.PresentRender(dirty);
+  g_Windowing.PresentRender(rendered);
 
   if(m_stereoMode != m_nextStereoMode)
   {

--- a/xbmc/guilib/GraphicContext.h
+++ b/xbmc/guilib/GraphicContext.h
@@ -130,7 +130,7 @@ public:
   void SetRenderingResolution(const RESOLUTION_INFO &res, bool needsScaling);  ///< Sets scaling up for rendering
   void SetScalingResolution(const RESOLUTION_INFO &res, bool needsScaling);    ///< Sets scaling up for skin loading etc.
   float GetScalingPixelRatio() const;
-  void Flip(const CDirtyRegionList& dirty);
+  void Flip(bool rendered);
   void InvertFinalCoords(float &x, float &y) const;
   inline float ScaleFinalXCoord(float x, float y) const XBMC_FORCE_INLINE { return m_finalTransform.matrix.TransformXCoord(x, y, 0); }
   inline float ScaleFinalYCoord(float x, float y) const XBMC_FORCE_INLINE { return m_finalTransform.matrix.TransformYCoord(x, y, 0); }

--- a/xbmc/rendering/RenderSystem.h
+++ b/xbmc/rendering/RenderSystem.h
@@ -102,7 +102,7 @@ public:
 
   virtual bool BeginRender() = 0;
   virtual bool EndRender() = 0;
-  virtual bool PresentRender(const CDirtyRegionList& dirty) = 0;
+  virtual void PresentRender(bool rendered) = 0;
   virtual bool ClearBuffers(color_t color) = 0;
   virtual bool IsExtSupported(const char* extension) = 0;
 

--- a/xbmc/rendering/dx/RenderSystemDX.cpp
+++ b/xbmc/rendering/dx/RenderSystemDX.cpp
@@ -1108,19 +1108,22 @@ bool CRenderSystemDX::CreateStates()
   return true;
 }
 
-bool CRenderSystemDX::PresentRenderImpl(const CDirtyRegionList &dirty)
+void CRenderSystemDX::PresentRenderImpl(bool rendered)
 {
   HRESULT hr;
 
+  if (!rendered)
+    return;
+  
   if (!m_bRenderCreated || m_resizeInProgress)
-    return false;
+    return;
 
   if (m_nDeviceStatus != S_OK)
   {
     // if DXGI_STATUS_OCCLUDED occurred we just clear command queue and return
     if (m_nDeviceStatus == DXGI_STATUS_OCCLUDED)
       FinishCommandList(false);
-    return false;
+    return;
   }
 
   if ( m_stereoMode == RENDER_STEREO_MODE_INTERLACED
@@ -1154,7 +1157,7 @@ bool CRenderSystemDX::PresentRenderImpl(const CDirtyRegionList &dirty)
   if (DXGI_ERROR_DEVICE_REMOVED == hr)
   {
     CLog::Log(LOGDEBUG, "%s - device removed", __FUNCTION__);
-    return false;
+    return;
   }
 
   if (DXGI_ERROR_INVALID_CALL == hr)
@@ -1167,14 +1170,12 @@ bool CRenderSystemDX::PresentRenderImpl(const CDirtyRegionList &dirty)
   if (FAILED(hr))
   {
     CLog::Log(LOGDEBUG, "%s - Present failed. %s", __FUNCTION__, GetErrorDescription(hr).c_str());
-    return false;
+    return;
   }
 
   // after present swapchain unbinds RT view from immediate context, need to restore it because it can be used by something else
   if (m_pContext == m_pImdContext)
     m_pContext->OMSetRenderTargets(1, &m_pRenderTargetView, m_depthStencilView);
-
-  return true;
 }
 
 bool CRenderSystemDX::BeginRender()

--- a/xbmc/rendering/dx/RenderSystemDX.h
+++ b/xbmc/rendering/dx/RenderSystemDX.h
@@ -96,7 +96,7 @@ protected:
   void DeleteDevice();
   void OnDeviceLost();
   void OnDeviceReset();
-  bool PresentRenderImpl(const CDirtyRegionList &dirty);
+  void PresentRenderImpl(bool rendered);
 
   void SetFocusWnd(HWND wnd) { m_hFocusWnd = wnd; }
   void SetDeviceWnd(HWND wnd) { m_hDeviceWnd = wnd; }

--- a/xbmc/rendering/gl/RenderSystemGL.h
+++ b/xbmc/rendering/gl/RenderSystemGL.h
@@ -41,7 +41,7 @@ public:
 
   virtual bool BeginRender();
   virtual bool EndRender();
-  virtual bool PresentRender(const CDirtyRegionList& dirty);
+  virtual void PresentRender(bool rendered);
   virtual bool ClearBuffers(color_t color);
   virtual bool IsExtSupported(const char* extension);
 
@@ -75,14 +75,11 @@ public:
 
 protected:
   virtual void SetVSyncImpl(bool enable) = 0;
-  virtual bool PresentRenderImpl(const CDirtyRegionList& dirty) = 0;
+  virtual void PresentRenderImpl(bool rendered) = 0;
   void CalculateMaxTexturesize();
 
   int        m_iVSyncMode;
   int        m_iVSyncErrors;
-  int64_t    m_iSwapStamp;
-  int64_t    m_iSwapRate;
-  int64_t    m_iSwapTime;
   bool       m_bVsyncInit;
   int        m_width;
   int        m_height;

--- a/xbmc/rendering/gles/RenderSystemGLES.cpp
+++ b/xbmc/rendering/gles/RenderSystemGLES.cpp
@@ -69,9 +69,6 @@ bool CRenderSystemGLES::InitRenderSystem()
   m_maxTextureSize = maxTextureSize;
   m_bVSync = false;
   m_iVSyncMode = 0;
-  m_iSwapStamp = 0;
-  m_iSwapTime = 0;
-  m_iSwapRate = 0;
   m_bVsyncInit = false;
   m_renderCaps = 0;
   // Get the GLES version number
@@ -198,7 +195,7 @@ bool CRenderSystemGLES::DestroyRenderSystem()
 
   ClearBuffers(0);
   glFinish();
-  PresentRenderImpl(dirtyRegions);
+  PresentRenderImpl(true);
 
   m_bRenderCreated = false;
 
@@ -276,48 +273,12 @@ static int64_t abs64(int64_t a)
   return a;
 }
 
-bool CRenderSystemGLES::PresentRender(const CDirtyRegionList &dirty)
+void CRenderSystemGLES::PresentRender(bool rendered)
 {
   if (!m_bRenderCreated)
-    return false;
+    return;
 
-  if (m_iVSyncMode != 0 && m_iSwapRate != 0) 
-  {
-    int64_t curr, diff, freq;
-    curr = CurrentHostCounter();
-    freq = CurrentHostFrequency();
-
-    if(m_iSwapStamp == 0)
-      m_iSwapStamp = curr;
-
-    /* calculate our next swap timestamp */
-    diff = curr - m_iSwapStamp;
-    diff = m_iSwapRate - diff % m_iSwapRate;
-    m_iSwapStamp = curr + diff;
-
-    /* sleep as close as we can before, assume 1ms precision of sleep *
-     * this should always awake so that we are guaranteed the given   *
-     * m_iSwapTime to do our swap                                     */
-    diff = (diff - m_iSwapTime) * 1000 / freq;
-    if (diff > 0)
-      Sleep((DWORD)diff);
-  }
-  
-  bool result = PresentRenderImpl(dirty);
-  
-  if (m_iVSyncMode && m_iSwapRate != 0)
-  {
-    int64_t curr, diff;
-    curr = CurrentHostCounter();
-
-    diff = curr - m_iSwapStamp;
-    m_iSwapStamp = curr;
-
-    if (abs64(diff - m_iSwapRate) < abs64(diff))
-      CLog::Log(LOGDEBUG, "%s - missed requested swap",__FUNCTION__);
-  }
-  
-  return result;
+  PresentRenderImpl(rendered);
 }
 
 void CRenderSystemGLES::SetVSync(bool enable)
@@ -335,7 +296,6 @@ void CRenderSystemGLES::SetVSync(bool enable)
 
   m_iVSyncMode   = 0;
   m_iVSyncErrors = 0;
-  m_iSwapRate    = 0;
   m_bVSync       = enable;
   m_bVsyncInit   = true;
 
@@ -344,28 +304,6 @@ void CRenderSystemGLES::SetVSync(bool enable)
   if (!enable)
     return;
 
-  if (g_advancedSettings.m_ForcedSwapTime != 0.0)
-  {
-    /* some hardware busy wait on swap/glfinish, so we must manually sleep to avoid 100% cpu */
-    double rate = g_graphicsContext.GetFPS();
-    if (rate <= 0.0 || rate > 1000.0)
-    {
-      CLog::Log(LOGWARNING, "Unable to determine a valid horizontal refresh rate, vsync workaround disabled %.2g", rate);
-      m_iSwapRate = 0;
-    }
-    else
-    {
-      int64_t freq;
-      freq = CurrentHostFrequency();
-      m_iSwapRate   = (int64_t)((double)freq / rate);
-      m_iSwapTime   = (int64_t)(0.001 * g_advancedSettings.m_ForcedSwapTime * freq);
-      m_iSwapStamp  = 0;
-      CLog::Log(LOGINFO, "GLES: Using artificial vsync sleep with rate %f", rate);
-      if(!m_iVSyncMode)
-        m_iVSyncMode = 1;
-    }
-  }
-    
   if (!m_iVSyncMode)
     CLog::Log(LOGERROR, "GLES: Vertical Blank Syncing unsupported");
   else

--- a/xbmc/rendering/gles/RenderSystemGLES.h
+++ b/xbmc/rendering/gles/RenderSystemGLES.h
@@ -56,7 +56,7 @@ public:
 
   virtual bool BeginRender();
   virtual bool EndRender();
-  virtual bool PresentRender(const CDirtyRegionList &dirty);
+  virtual void PresentRender(bool rendered);
   virtual bool ClearBuffers(color_t color);
   virtual bool IsExtSupported(const char* extension);
 
@@ -102,14 +102,11 @@ public:
 
 protected:
   virtual void SetVSyncImpl(bool enable) = 0;
-  virtual bool PresentRenderImpl(const CDirtyRegionList &dirty) = 0;
+  virtual void PresentRenderImpl(bool rendered) = 0;
   void CalculateMaxTexturesize();
 
   int        m_iVSyncMode;
   int        m_iVSyncErrors;
-  int64_t    m_iSwapStamp;
-  int64_t    m_iSwapRate;
-  int64_t    m_iSwapTime;
   bool       m_bVsyncInit;
   int        m_width;
   int        m_height;

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -340,13 +340,6 @@ void CAdvancedSettings::Initialize()
   m_bVirtualShares = true;
   m_bAllowDeferredRendering = true;
 
-//caused lots of jerks
-//#ifdef TARGET_WINDOWS
-//  m_ForcedSwapTime = 2.0;
-//#else
-  m_ForcedSwapTime = 0.0;
-//#endif
-
   m_cpuTempCmd = "";
   m_gpuTempCmd = "";
 #if defined(TARGET_DARWIN)
@@ -817,7 +810,6 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
 
   XMLUtils::GetBoolean(pRootElement,"glrectanglehack", m_GLRectangleHack);
   XMLUtils::GetInt(pRootElement,"skiploopfilter", m_iSkipLoopFilter, -16, 48);
-  XMLUtils::GetFloat(pRootElement, "forcedswaptime", m_ForcedSwapTime, 0.0, 100.0);
 
   XMLUtils::GetUInt(pRootElement,"restrictcapsmask", m_RestrictCapsMask);
   XMLUtils::GetFloat(pRootElement,"sleepbeforeflip", m_sleepBeforeFlip, 0.0f, 1.0f);

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -308,7 +308,6 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     int m_playlistTimeout;
     bool m_GLRectangleHack;
     int m_iSkipLoopFilter;
-    float m_ForcedSwapTime; /* if nonzero, set's the explicit time in ms to allocate for buffer swap */
 
     unsigned int m_RestrictCapsMask;
     float m_sleepBeforeFlip; ///< if greather than zero, XBMC waits for raster to be this amount through the frame prior to calling the flip

--- a/xbmc/utils/Splash.cpp
+++ b/xbmc/utils/Splash.cpp
@@ -72,7 +72,6 @@ void CSplash::Show()
 
   //show it on screen
   g_Windowing.EndRender();
-  CDirtyRegionList dirty;
-  g_graphicsContext.Flip(dirty);
+  g_graphicsContext.Flip(true);
   g_graphicsContext.Unlock();
 }

--- a/xbmc/windowing/X11/GLContext.h
+++ b/xbmc/windowing/X11/GLContext.h
@@ -22,7 +22,7 @@
 
 #if defined(HAVE_X11)
 #include "X11/Xlib.h"
-#include "guilib/DirtyRegion.h"
+#include <string>
 
 class CGLContext
 {
@@ -37,7 +37,7 @@ public:
   virtual void Destroy() = 0;
   virtual void Detach() = 0;
   virtual void SetVSync(bool enable, int &mode) = 0;
-  virtual bool SwapBuffers(const CDirtyRegionList& dirty, int &mode) = 0;
+  virtual void SwapBuffers(int &mode) = 0;
   virtual void QueryExtensions() = 0;
   virtual bool IsExtSupported(const char* extension) = 0;
 

--- a/xbmc/windowing/X11/GLContextEGL.cpp
+++ b/xbmc/windowing/X11/GLContextEGL.cpp
@@ -356,14 +356,12 @@ void CGLContextEGL::SetVSync(bool enable, int &mode)
   eglSwapInterval(m_eglDisplay, enable ? 1 : 0);
 }
 
-bool CGLContextEGL::SwapBuffers(const CDirtyRegionList& dirty, int &mode)
+void CGLContextEGL::SwapBuffers(int &mode)
 {
   if ((m_eglDisplay == EGL_NO_DISPLAY) || (m_eglSurface == EGL_NO_SURFACE))
-    return false;
+    return;
 
   eglSwapBuffers(m_eglDisplay, m_eglSurface);
-
-  return true;
 }
 
 void CGLContextEGL::QueryExtensions()

--- a/xbmc/windowing/X11/GLContextEGL.h
+++ b/xbmc/windowing/X11/GLContextEGL.h
@@ -33,7 +33,7 @@ public:
   virtual void Destroy();
   virtual void Detach();
   virtual void SetVSync(bool enable, int &mode);
-  virtual bool SwapBuffers(const CDirtyRegionList& dirty, int &mode);
+  virtual void SwapBuffers(int &mode);
   virtual void QueryExtensions();
   virtual bool IsExtSupported(const char* extension);
   XVisualInfo* GetVisual();

--- a/xbmc/windowing/X11/GLContextGLX.cpp
+++ b/xbmc/windowing/X11/GLContextGLX.cpp
@@ -197,7 +197,7 @@ void CGLContextGLX::SetVSync(bool enable, int &mode)
   }
 }
 
-bool CGLContextGLX::SwapBuffers(const CDirtyRegionList& dirty, int &mode)
+void CGLContextGLX::SwapBuffers(int &mode)
 {
   if(mode == 3)
   {
@@ -264,8 +264,6 @@ bool CGLContextGLX::SwapBuffers(const CDirtyRegionList& dirty, int &mode)
   }
   else
     glXSwapBuffers(m_dpy, m_glxWindow);
-
-  return true;
 }
 
 void CGLContextGLX::QueryExtensions()

--- a/xbmc/windowing/X11/GLContextGLX.h
+++ b/xbmc/windowing/X11/GLContextGLX.h
@@ -32,7 +32,7 @@ public:
   virtual void Destroy();
   virtual void Detach();
   virtual void SetVSync(bool enable, int &mode);
-  virtual bool SwapBuffers(const CDirtyRegionList& dirty, int &mode);
+  virtual void SwapBuffers(int &mode);
   virtual void QueryExtensions();
   virtual bool IsExtSupported(const char* extension);
   GLXWindow m_glxWindow;

--- a/xbmc/windowing/X11/WinSystemX11GLContext.cpp
+++ b/xbmc/windowing/X11/WinSystemX11GLContext.cpp
@@ -45,9 +45,11 @@ CWinSystemX11GLContext::~CWinSystemX11GLContext()
   delete m_pGLContext;
 }
 
-bool CWinSystemX11GLContext::PresentRenderImpl(const CDirtyRegionList& dirty)
+void CWinSystemX11GLContext::PresentRenderImpl(bool rendered)
 {
-  m_pGLContext->SwapBuffers(dirty, m_iVSyncMode);
+  if (rendered)
+    m_pGLContext->SwapBuffers(m_iVSyncMode);
+  
   if (m_delayDispReset && m_dispResetTimer.IsTimePast())
   {
     m_delayDispReset = false;
@@ -56,7 +58,6 @@ bool CWinSystemX11GLContext::PresentRenderImpl(const CDirtyRegionList& dirty)
     for (std::vector<IDispResource *>::iterator i = m_resources.begin(); i != m_resources.end(); ++i)
       (*i)->OnResetDisplay();
   }
-  return true;
 }
 
 void CWinSystemX11GLContext::SetVSyncImpl(bool enable)
@@ -108,11 +109,10 @@ bool CWinSystemX11GLContext::SetWindow(int width, int height, bool fullscreen, c
   CWinSystemX11::SetWindow(width, height, fullscreen, output, &newwin);
   if (newwin)
   {
-    CDirtyRegionList dr;
     RefreshGLContext(m_currentOutput.compare(output) != 0);
     XSync(m_dpy, FALSE);
     g_graphicsContext.Clear(0);
-    g_graphicsContext.Flip(dr);
+    g_graphicsContext.Flip(true);
     ResetVSync();
 
     m_windowDirty = false;

--- a/xbmc/windowing/X11/WinSystemX11GLContext.h
+++ b/xbmc/windowing/X11/WinSystemX11GLContext.h
@@ -52,7 +52,7 @@ public:
 
 protected:
   virtual bool SetWindow(int width, int height, bool fullscreen, const std::string &output, int *winstate = NULL);
-  virtual bool PresentRenderImpl(const CDirtyRegionList& dirty);
+  virtual void PresentRenderImpl(bool rendered);
   virtual void SetVSyncImpl(bool enable);
   virtual bool RefreshGLContext(bool force);
   virtual XVisualInfo* GetVisual();

--- a/xbmc/windowing/X11/WinSystemX11GLESContext.cpp
+++ b/xbmc/windowing/X11/WinSystemX11GLESContext.cpp
@@ -19,9 +19,11 @@ CWinSystemX11GLESContext::~CWinSystemX11GLESContext()
   delete m_pGLContext;
 }
 
-bool CWinSystemX11GLESContext::PresentRenderImpl(const CDirtyRegionList& dirty)
+void CWinSystemX11GLESContext::PresentRenderImpl(bool rendered)
 {
-  m_pGLContext->SwapBuffers(dirty, m_iVSyncMode);
+  if (rendered)
+    m_pGLContext->SwapBuffers(m_iVSyncMode);
+
   if (m_delayDispReset && m_dispResetTimer.IsTimePast())
   {
     m_delayDispReset = false;
@@ -30,7 +32,6 @@ bool CWinSystemX11GLESContext::PresentRenderImpl(const CDirtyRegionList& dirty)
     for (std::vector<IDispResource *>::iterator i = m_resources.begin(); i != m_resources.end(); ++i)
       (*i)->OnResetDisplay();
   }
-  return true;
 }
 
 void CWinSystemX11GLESContext::SetVSyncImpl(bool enable)

--- a/xbmc/windowing/X11/WinSystemX11GLESContext.h
+++ b/xbmc/windowing/X11/WinSystemX11GLESContext.h
@@ -48,7 +48,7 @@ public:
 
 protected:
   virtual bool SetWindow(int width, int height, bool fullscreen, const std::string &output, int *winstate = NULL);
-  virtual bool PresentRenderImpl(const CDirtyRegionList& dirty);
+  virtual void PresentRenderImpl(bool rendered);
   virtual void SetVSyncImpl(bool enable);
   virtual bool RefreshGLContext(bool force);
   virtual XVisualInfo* GetVisual();

--- a/xbmc/windowing/egl/WinSystemEGL.cpp
+++ b/xbmc/windowing/egl/WinSystemEGL.cpp
@@ -441,10 +441,11 @@ bool CWinSystemEGL::IsExtSupported(const char* extension)
   return (m_extensions.find(name) != std::string::npos || CRenderSystemGLES::IsExtSupported(extension));
 }
 
-bool CWinSystemEGL::PresentRenderImpl(const CDirtyRegionList &dirty)
+void CWinSystemEGL::PresentRenderImpl(bool rendered)
 {
+  if (!rendered)
+    return;
   m_egl->SwapBuffers(m_display, m_surface);
-  return true;
 }
 
 void CWinSystemEGL::SetVSyncImpl(bool enable)

--- a/xbmc/windowing/egl/WinSystemEGL.h
+++ b/xbmc/windowing/egl/WinSystemEGL.h
@@ -66,7 +66,7 @@ public:
   EGLDisplay    GetEGLDisplay();
   EGLContext    GetEGLContext();
 protected:
-  virtual bool  PresentRenderImpl(const CDirtyRegionList &dirty);
+  virtual void  PresentRenderImpl(bool rendered);
   virtual void  SetVSyncImpl(bool enable);
 
   bool          CreateWindow(RESOLUTION_INFO &res);

--- a/xbmc/windowing/osx/WinSystemIOS.h
+++ b/xbmc/windowing/osx/WinSystemIOS.h
@@ -75,7 +75,7 @@ public:
           bool IsBackgrounded() const { return m_bIsBackgrounded; }
 
 protected:
-  virtual bool PresentRenderImpl(const CDirtyRegionList &dirty);
+  virtual void PresentRenderImpl(bool rendered);
   virtual void SetVSyncImpl(bool enable);
 
   void        *m_glView; // EAGLView opaque

--- a/xbmc/windowing/osx/WinSystemIOS.mm
+++ b/xbmc/windowing/osx/WinSystemIOS.mm
@@ -419,11 +419,11 @@ void CWinSystemIOS::DeinitDisplayLink(void)
 //------------DispalyLink stuff end
 //--------------------------------------------------------------
 
-bool CWinSystemIOS::PresentRenderImpl(const CDirtyRegionList &dirty)
+void CWinSystemIOS::PresentRenderImpl(bool rendered)
 {
   //glFlush;
-  [g_xbmcController presentFramebuffer];
-  return true;
+  if (rendered)
+    [g_xbmcController presentFramebuffer];
 }
 
 void CWinSystemIOS::SetVSyncImpl(bool enable)

--- a/xbmc/windowing/osx/WinSystemOSXGL.h
+++ b/xbmc/windowing/osx/WinSystemOSXGL.h
@@ -36,7 +36,7 @@ public:
   virtual bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays);
 
 protected:
-  virtual bool PresentRenderImpl(const CDirtyRegionList &dirty);
+  virtual void PresentRenderImpl(bool rendered);
   virtual void SetVSyncImpl(bool enable);  
 };
 

--- a/xbmc/windowing/osx/WinSystemOSXGL.mm
+++ b/xbmc/windowing/osx/WinSystemOSXGL.mm
@@ -37,9 +37,10 @@ CWinSystemOSXGL::~CWinSystemOSXGL()
 {
 }
 
-bool CWinSystemOSXGL::PresentRenderImpl(const CDirtyRegionList &dirty)
+void CWinSystemOSXGL::PresentRenderImpl(bool rendered)
 {
-  return FlushBuffer();
+  if (rendered)
+    FlushBuffer();
 }
 
 void CWinSystemOSXGL::SetVSyncImpl(bool enable)

--- a/xbmc/windowing/windows/WinSystemWin32DX.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32DX.cpp
@@ -38,15 +38,16 @@ CWinSystemWin32DX::~CWinSystemWin32DX()
 
 }
 
-bool CWinSystemWin32DX::PresentRender(const CDirtyRegionList& dirty)
+void CWinSystemWin32DX::PresentRender(bool rendered)
 {
-  bool result = PresentRenderImpl(dirty);
+  if (rendered)
+    PresentRenderImpl(rendered);
+
   if (m_delayDispReset && m_dispResetTimer.IsTimePast())
   {
     m_delayDispReset = false;
     CWinSystemWin32::OnDisplayReset();
   }
-  return result;
 }
 
 bool CWinSystemWin32DX::UseWindowedDX(bool fullScreen)

--- a/xbmc/windowing/windows/WinSystemWin32DX.h
+++ b/xbmc/windowing/windows/WinSystemWin32DX.h
@@ -42,7 +42,7 @@ public:
   virtual bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays);
   virtual bool WindowedMode() { return CRenderSystemDX::m_useWindowedDX; }
   virtual void NotifyAppFocusChange(bool bGaining);
-  virtual bool PresentRender(const CDirtyRegionList &dirty);
+  virtual void PresentRender(bool rendererd);
 
   std::string GetClipboardText(void);
 


### PR DESCRIPTION
Some cleanup for RenderSystem. Parameter dirtyRegions was never used by the implementations. Return value of bool was not used either.

@popcornmix this is an intermediate solution for player starving while waiting on refresh rate switch to be completed. The main thread always calls PresentRenderImpl.
