### PR TITLE
AESinkAudiotrack: Ask Android for the format IDs

### DIFF
--- a/xbmc/platform/android/jni/AudioFormat.cpp
+++ b/xbmc/platform/android/jni/AudioFormat.cpp
@@ -24,18 +24,16 @@
 
 using namespace jni;
 
-int CJNIAudioFormat::ENCODING_PCM_16BIT = 0x00000002;
-int CJNIAudioFormat::ENCODING_PCM_FLOAT = 0x00000004;
-int CJNIAudioFormat::ENCODING_AC3       = 0x00000005;
-int CJNIAudioFormat::ENCODING_E_AC3     = 0x00000006;
-int CJNIAudioFormat::ENCODING_DTS       = 0x00000007;
-int CJNIAudioFormat::ENCODING_DTS_HD    = 0x00000008;
+int CJNIAudioFormat::ENCODING_PCM_16BIT                = 0x00000002;
+int CJNIAudioFormat::ENCODING_PCM_FLOAT                = 0x00000004;
+int CJNIAudioFormat::ENCODING_AC3                      = 0x00000005;
+int CJNIAudioFormat::ENCODING_E_AC3                    = 0x00000006;
+int CJNIAudioFormat::ENCODING_DTS                      = 0x00000007;
+int CJNIAudioFormat::ENCODING_DTS_HD                   = 0x00000008;
+int CJNIAudioFormat::ENCODING_DOLBY_TRUEHD             = 0x00000009;
 
-// As of version 22 and Android 5 Nvidia defines this solely for their Shield
-int CJNIAudioFormat::ENCODING_DOLBY_TRUEHD    = 0x00000009;
-
-int CJNIAudioFormat::CHANNEL_OUT_STEREO  = 0x0000000c;
-int CJNIAudioFormat::CHANNEL_OUT_5POINT1 = 0x000000fc;
+int CJNIAudioFormat::CHANNEL_OUT_STEREO                = 0x0000000c;
+int CJNIAudioFormat::CHANNEL_OUT_5POINT1               = 0x000000fc;
 
 int CJNIAudioFormat::CHANNEL_OUT_FRONT_LEFT            = 0x00000004;
 int CJNIAudioFormat::CHANNEL_OUT_FRONT_LEFT_OF_CENTER  = 0x00000100;
@@ -50,6 +48,18 @@ int CJNIAudioFormat::CHANNEL_OUT_BACK_CENTER           = 0x00000400;
 int CJNIAudioFormat::CHANNEL_OUT_BACK_RIGHT            = 0x00000080;
 
 int CJNIAudioFormat::CHANNEL_INVALID                   = 0x00000000;
+
+void CJNIAudioFormat::GetStaticValue(jhclass& c, int& field, char* value)
+{
+  jfieldID id = get_static_field_id<jclass>(c, value, "I");
+  if (id != NULL)
+    field = get_static_field<int>(c, value);
+  else
+  {
+    xbmc_jnienv()->ExceptionClear();
+    field = -1;
+  }
+}
 
 void CJNIAudioFormat::PopulateStaticFields()
 {
@@ -77,20 +87,13 @@ void CJNIAudioFormat::PopulateStaticFields()
       {
         CJNIAudioFormat::CHANNEL_OUT_SIDE_LEFT = get_static_field<int>(c, "CHANNEL_OUT_SIDE_LEFT");
         CJNIAudioFormat::CHANNEL_OUT_SIDE_RIGHT = get_static_field<int>(c, "CHANNEL_OUT_SIDE_RIGHT");
-
         CJNIAudioFormat::ENCODING_PCM_FLOAT = get_static_field<int>(c, "ENCODING_PCM_FLOAT");
-        CJNIAudioFormat::ENCODING_AC3 = get_static_field<int>(c, "ENCODING_AC3");
-        CJNIAudioFormat::ENCODING_E_AC3 = get_static_field<int>(c, "ENCODING_E_AC3");
 
-        if (sdk >= 23)
-        {
-          CJNIAudioFormat::ENCODING_DTS = get_static_field<int>(c, "ENCODING_DTS");
-          CJNIAudioFormat::ENCODING_DTS_HD = get_static_field<int>(c, "ENCODING_DTS_HD");
-          // Nvidia Shield v6 firmware uses another ID, which will also be the future ID
-          // though other v23 version would not return a value if we'd use the get_static_field
-          // method to query this value. The hardcoded value can be removed after probably is out
-          CJNIAudioFormat::ENCODING_DOLBY_TRUEHD = 0x0000000d;
-        }
+        GetStaticValue(c, CJNIAudioFormat::ENCODING_AC3, "ENCODING_AC3");
+        GetStaticValue(c, CJNIAudioFormat::ENCODING_E_AC3, "ENCODING_E_AC3");
+        GetStaticValue(c, CJNIAudioFormat::ENCODING_DTS, "ENCODING_DTS");
+        GetStaticValue(c, CJNIAudioFormat::ENCODING_DTS_HD, "ENCODING_DTS_HD");
+        GetStaticValue(c, CJNIAudioFormat::ENCODING_DOLBY_TRUEHD, "ENCODING_DOLBY_TRUEHD");
       }
     }
   }

--- a/xbmc/platform/android/jni/AudioFormat.h
+++ b/xbmc/platform/android/jni/AudioFormat.h
@@ -19,6 +19,8 @@
  *
  */
 
+#include "jutils/jutils-details.hpp"
+
 namespace jni
 {
 
@@ -51,6 +53,9 @@ class CJNIAudioFormat
     static int CHANNEL_OUT_BACK_RIGHT;
 
     static int CHANNEL_INVALID;
+
+protected:
+    static void GetStaticValue(jhclass &c, int &field, char *value);
 };
 
 };


### PR DESCRIPTION
This helps implementing unkown formats by not hard coding its values but rather asking directly. It is picked from @koying after he told me of this way on github, minus the AML code that was never PRd to us.
