### PR TITLE
Don't hide parent folder icon when browsing by watched movie/episode

### DIFF
--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -1274,8 +1274,9 @@ bool CGUIWindowVideoNav::ApplyWatchedFilter(CFileItemList &items)
 
     if (filterWatched)
     {
-      if((watchMode==WatchedModeWatched   && item->GetVideoInfoTag()->m_playCount== 0)
-      || (watchMode==WatchedModeUnwatched && item->GetVideoInfoTag()->m_playCount > 0))
+      if(!item->IsParentFolder() && // Don't delete the go to parent folder
+        (watchMode==WatchedModeWatched   && item->GetVideoInfoTag()->m_playCount == 0
+      || watchMode==WatchedModeUnwatched && item->GetVideoInfoTag()->m_playCount > 0))
       {
         items.Remove(i);
         i--;
@@ -1283,6 +1284,10 @@ bool CGUIWindowVideoNav::ApplyWatchedFilter(CFileItemList &items)
       }
     }
   }
+
+  // Remove the parent folder icon, if it's the only thing in the folder. This is needed for hiding seasons.
+  if (items.GetObjectCount() == 0 && items.Get(0)->IsParentFolder())
+      items.Remove(0);
 
   if(node == NODE_TYPE_TITLE_TVSHOWS || node == NODE_TYPE_SEASONS)
   {


### PR DESCRIPTION
When you filter for Watched in the video library. You'll loose the goto parent folder icon, rendering you unable to go up in the hierarchy via the menu.

This fixes the problem.
