### PR TITLE
Bump to SQLite 3100200 (aka 3.10.2)

### DIFF
--- a/project/BuildDependencies/scripts/0_package.list
+++ b/project/BuildDependencies/scripts/0_package.list
@@ -45,7 +45,7 @@ mysqlclient-6.1.3-win32-vc120.7z
 pcre-8.34-win32-vc120.7z
 PIL-1.1.7p-win32.7z
 python-2.7.10-win32.7z
-sqlite-3.9.2-win32-vc120.7z
+sqlite-3.10.2-win32-vc140.7z
 swig-2.0.7-win32-1.7z
 taglib-1.10-win32-vc120.7z
 texturepacker-1.0.6-win32.7z

--- a/tools/depends/target/sqlite3/Makefile
+++ b/tools/depends/target/sqlite3/Makefile
@@ -3,7 +3,7 @@ DEPS= ../../Makefile.include Makefile
 
 # lib name, version
 LIBNAME=sqlite
-VERSION=3090200
+VERSION=3100200
 SOURCE=$(LIBNAME)-autoconf-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
 


### PR DESCRIPTION
Needs to be tested, as I haven't done that yet.

Also need to be uploaded to our mirrors. https://www.dropbox.com/s/x6cube0xt5nca2z/sqlite-3.10.2-win32-vc140.7z?dl=0

Not sure about those patches, for the android version in the makefile. 
