### PR TITLE
AESinkAudiotrack: Fixups

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -251,11 +251,17 @@ bool CAESinkAUDIOTRACK::Initialize(AEAudioFormat &format, std::string &device)
         case CAEStreamInfo::STREAM_TYPE_DTSHD:
           m_encoding              = CJNIAudioFormat::ENCODING_DTS_HD;
           m_format.m_channelLayout = AE_CH_LAYOUT_7_1;
+          // Shield v5 workaround
+          if (CJNIAudioManager::GetSDKVersion() == 22 && m_sink_sampleRate > 48000)
+            m_sink_sampleRate = 48000;
           break;
 
         case CAEStreamInfo::STREAM_TYPE_TRUEHD:
           m_encoding              = CJNIAudioFormat::ENCODING_DOLBY_TRUEHD;
           m_format.m_channelLayout = AE_CH_LAYOUT_7_1;
+          // Shield v5 workaround
+          if (CJNIAudioManager::GetSDKVersion() == 22 && m_sink_sampleRate > 48000)
+            m_sink_sampleRate = 48000;
           break;
 
         default:
@@ -407,7 +413,7 @@ bool CAESinkAUDIOTRACK::Initialize(AEAudioFormat &format, std::string &device)
       Deinitialize();
       return false;
     }
-    CLog::Log(LOGDEBUG, "CAESinkAUDIOTRACK::Initialize returned: m_sampleRate %u; format:%s; min_buffer_size %u; m_frames %u; m_frameSize %u; channels: %d", m_format.m_sampleRate, CAEUtil::DataFormatToStr(m_format.m_dataFormat), m_min_buffer_size, m_format.m_frames, m_format.m_frameSize, m_format.m_channelLayout.Count());
+    CLog::Log(LOGDEBUG, "CAESinkAUDIOTRACK::Initialize returned: m_sampleRate %u; format:%s; min_buffer_size %u; m_frames %u; m_frameSize %u; channels: %d", m_sink_sampleRate, CAEUtil::DataFormatToStr(m_format.m_dataFormat), m_min_buffer_size, m_format.m_frames, m_format.m_frameSize, m_format.m_channelLayout.Count());
   }
   format = m_format;
 

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -343,7 +343,7 @@ bool CAESinkAUDIOTRACK::Initialize(AEAudioFormat &format, std::string &device)
            ac3FrameSize = m_format.m_streamInfo.m_ac3FrameSize;
            if (ac3FrameSize == 0)
              ac3FrameSize = 1536; // fallback if not set, e.g. Transcoding
-           m_min_buffer_size = std::max(m_min_buffer_size * 4, ac3FrameSize * 8);
+           m_min_buffer_size = std::max(m_min_buffer_size * 3, ac3FrameSize * 8);
            m_format.m_frames = m_min_buffer_size;
            multiplier = m_min_buffer_size / ac3FrameSize; // int division is wanted
            rawlength_in_seconds = multiplier * m_format.m_streamInfo.GetDuration() / 1000;

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -773,7 +773,7 @@ double CAESinkAUDIOTRACK::GetMovingAverageDelay(double newestdelay)
   size_t size = m_linearmovingaverage.size();
   if (size > MOVING_AVERAGE_MAX_MEMBERS)
   {
-    m_linearmovingaverage.erase(m_linearmovingaverage.begin());
+    m_linearmovingaverage.pop_front();
     size--;
   }
   // m_{LWMA}^{(n)}(t) = \frac{2}{n (n+1)} \sum_{i=1}^n i \; x(t-n+i)

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
@@ -64,10 +64,9 @@ private:
   // Moving Average computes the weighted average delay over
   // a fixed size of delay values - current size: 20 values
   double                GetMovingAverageDelay(double newestdelay);
-  // When AddPause is called the m_pause_counter is counted up
-  // Whenever a new package is added into the sink and the counter is > 0
-  // we sleep for a GetDuration() period
-  unsigned int          m_pause_counter;
+  // When AddPause is called the m_pause_time is increased
+  // by the package duration. This is only used for non IEC passthrough
+  double          m_pause_time;
 
   // We maintain our linear weighted average delay counter in here
   // The n-th value (timely oldest value) is weighted with 1/n

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
@@ -24,7 +24,7 @@
 #include "threads/CriticalSection.h"
 #include "threads/Thread.h"
 
-#include <vector>
+#include <deque>
 #include <set>
 
 namespace jni
@@ -62,7 +62,7 @@ private:
   unsigned int          m_lastPlaybackHeadPosition;
   int64_t               m_offset;
   // Moving Average computes the weighted average delay over
-  // a fixed size of a vector - current size: 20 values
+  // a fixed size of delay values - current size: 20 values
   double                GetMovingAverageDelay(double newestdelay);
   // When AddPause is called the m_pause_counter is counted up
   // Whenever a new package is added into the sink and the counter is > 0
@@ -72,7 +72,7 @@ private:
   // We maintain our linear weighted average delay counter in here
   // The n-th value (timely oldest value) is weighted with 1/n
   // the newest value gets a weight of 1
-  std::vector<double>   m_linearmovingaverage;
+  std::deque<double>   m_linearmovingaverage;
 
   static CAEDeviceInfo m_info;
   static std::set<unsigned int>       m_sink_sampleRates;

--- a/xbmc/platform/android/jni/AudioTrack.cpp
+++ b/xbmc/platform/android/jni/AudioTrack.cpp
@@ -166,6 +166,14 @@ int CJNIAudioTrack::getPlaybackHeadPosition()
   return call_method<int>(m_object, "getPlaybackHeadPosition", "()I");
 }
 
+// Can be used in v23 for comparing with the opened buffer amount
+int CJNIAudioTrack::getBufferSizeInFrames()
+{
+  if (CJNIBase::GetSDKVersion() >= 23)
+    return call_method<int>(m_object, "getBufferSizeInFrames", "()I");
+  return -1;
+}
+
 int CJNIAudioTrack::getMinBufferSize(int sampleRateInHz, int channelConfig, int audioFormat)
 {
   return call_static_method<int>( "android/media/AudioTrack", "getMinBufferSize", "(III)I",

--- a/xbmc/platform/android/jni/AudioTrack.h
+++ b/xbmc/platform/android/jni/AudioTrack.h
@@ -44,6 +44,7 @@ class CJNIAudioTrack : public CJNIBase
     int   getState();
     int   getPlayState();
     int   getPlaybackHeadPosition();
+    int   getBufferSizeInFrames();
 
     static int  MODE_STREAM;
     static int  STATE_INITIALIZED;


### PR DESCRIPTION
- Use a deque for delay, saves us the recration time of the vector while access is still constant O(1)
- When filling the first packages after AddPause, we only slept the pause away, but did not incorporate the blocking behaviour of the sink. This reduces playback start while properly syncing
- getBufferSizeInFrames can be used with v23 to see how many frames or in PT case Buffers AT uses internally
- TrueHD 96 khz does not open - works fine when telling it is 48 khz
- After intensive study of GetPlaybackHeadPosition it seems that it does not block n-1 times and blocks once at the end. This is evil for delay. So help AT sleeping a bit.

The latter commit I tried before during development but did not see a real good effect. In combination with the properly computed delay it is okay.
