### PR TITLE
[depends][win32] Updated ogg and vorbis

### DIFF
--- a/project/BuildDependencies/scripts/0_package.list
+++ b/project/BuildDependencies/scripts/0_package.list
@@ -28,7 +28,6 @@ libjpeg-turbo-1.2.0-win32.7z
 liblzo-2.04-win32.7z
 libmicrohttpd-svn-35533-win32-vc120.7z
 libnfs-1.10.0-win32.7z
-libogg-vc100-1.2.0-win32.7z
 libplist-1.7-win32-3.7z
 libpng-1.5.13-win32.7z
 librtmp-20150114-git-a107ce-win32.7z
@@ -36,12 +35,12 @@ libsdl-1.2.10-win32.7z
 libsdl_image-1.2.14-win32.7z
 libshairplay-52fd9db-win32.7z
 libssh-0.5.0-1-win32.zip
-libvorbis-vc100-1.3.1-win32.7z
 libxml2-2.7.8_1-win32.7z
 libxslt-1.1.26_1-win32.7z
 libyajl-2.0.1-win32.7z
 libzlib-vc100-1.2.5-win32.7z
 mysqlclient-6.1.3-win32-vc120.7z
+ogg-23264e-win32-vc140.7z
 pcre-8.34-win32-vc120.7z
 PIL-1.1.7p-win32.7z
 python-2.7.10-win32.7z
@@ -50,3 +49,4 @@ swig-2.0.7-win32-1.7z
 taglib-1.10-win32-vc120.7z
 texturepacker-1.0.6-win32.7z
 tinyxml-2.6.2_3-win32-vc120.7z
+vorbis-3a4d44-win32-vc140.7z


### PR DESCRIPTION
This is mainly to clean up the situation on Windows. We currently ship vcredist for 4 versions of Visual Studio. With these updated and libnfs done by @Razzeee we only need to update libssh before we can drop the vcredist for vc100 and that's coming in a separate pr.

There doesn't seem to be any tags or branches for releases so I picked the current master and tagged with commit.
