### PR TITLE
[backport] Fix Xbox controller crash on Windows. #16279

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2358,6 +2358,8 @@ bool CApplication::OnAction(const CAction &action)
       {
         // calculate the speed based on the amount the button is held down
         int iPower = (int)(action.GetAmount() * MAX_FFWD_SPEED + 0.5f);
+        // amount can be negative, for example rewind and forward share the same axis
+        iPower = std::abs(iPower);
         // returns 0 -> MAX_FFWD_SPEED
         int iSpeed = 1 << iPower;
         if (iSpeed != 1 && action.GetID() == ACTION_ANALOG_REWIND)


### PR DESCRIPTION
Fast forwarding using the right trigger on an Xbox controller on Windows causes Kodi to freeze. An incorrect sign causes undefined behavior that eventually leads to an infinite loop. Fixed by making sure iPower is positive. Fixes http://trac.kodi.tv/ticket/16279
