### PR TITLE
FFmpeg: Bump to 2.8.6-Jarvis-16.1

### DIFF
--- a/tools/depends/target/ffmpeg/FFMPEG-VERSION
+++ b/tools/depends/target/ffmpeg/FFMPEG-VERSION
@@ -1,5 +1,5 @@
 LIBNAME=ffmpeg
 BASE_URL=https://github.com/xbmc/FFmpeg/archive
-VERSION=2.8.6-Jarvis-rc2-dxva
+VERSION=2.8.6-Jarvis-16.1
 ARCHIVE=$(LIBNAME)-$(VERSION).tar.gz
 


### PR DESCRIPTION
This bumps Jarvis to the final 2.8.6 ffmpeg version. It includes an upstream patch for Windows, which cares for display artifacts.
