### PR TITLE
[PVR] PVR Windows: Only the active window must update the shared selected item path.

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -87,7 +87,13 @@ std::string CGUIWindowPVRBase::GetSelectedItemPath(bool bRadio)
 
 void CGUIWindowPVRBase::Notify(const Observable &obs, const ObservableMessage msg)
 {
-  UpdateSelectedItemPath();
+  if (IsActive())
+  {
+    // Only the active window must set the selected item path which is shared
+    // between all PVR windows, not the last notified window (observer).
+    UpdateSelectedItemPath();
+  }
+
   CGUIMessage m(GUI_MSG_REFRESH_LIST, GetID(), 0, msg);
   CApplicationMessenger::GetInstance().SendGUIMessage(m);
 }


### PR DESCRIPTION
Under some circumstances, the channel selected in the channel window is not the channel one would expect. Example:
1. open channel window, select channel A
2. open guide window -> A is selected. okay
3. in the guide window, select channel B
4. close guide window
5. open channel window -> B is selected. okay
6. in the channel window, select channel C
7. start watching channel C
8. after some minutes watching (this delay is important), stop watching -> go back to channel window
   => Bug: If you have watched channel C long enough, channel window selection will be at channel B (the one you last selected in the guide window), not at C as one would expect

@xhaggi @Jalle19 mind taking a look.
