### PR TITLE
FFmpeg: Use 2.8.6-kodi-1

### DIFF
--- a/tools/depends/target/ffmpeg/FFMPEG-VERSION
+++ b/tools/depends/target/ffmpeg/FFMPEG-VERSION
@@ -1,5 +1,5 @@
 LIBNAME=ffmpeg
 BASE_URL=https://github.com/xbmc/FFmpeg/archive
-VERSION=2.8.6-Jarvis-16.1
+VERSION=2.8.6-Jarvis-16.0
 ARCHIVE=$(LIBNAME)-$(VERSION).tar.gz
 


### PR DESCRIPTION
New naming scheme for our ffmpeg. We won't add the release name anymore, but the upstream version in this case 2.8.6 the kodi identifier to show this is not vanilla ffmpeg and a running number starting with 1.
