### PR TITLE
Revert "FFmpeg: Bump to 2.8.6-Jarvis-16.1"

### DIFF
--- a/project/Win32BuildSetup/buildffmpeg.sh
+++ b/project/Win32BuildSetup/buildffmpeg.sh
@@ -6,7 +6,7 @@ BGPROCESSFILE="$2"
 BASE_URL=$(grep "BASE_URL=" ../../tools/depends/target/ffmpeg/FFMPEG-VERSION | sed 's/BASE_URL=//g')
 VERSION=$(grep "VERSION=" ../../tools/depends/target/ffmpeg/FFMPEG-VERSION | sed 's/VERSION=//g')
 LIBNAME=ffmpeg
-ARCHIVE=$LIBNAME-$VERSION.tar.gz
+ARCHIVE=$LIBNAME-$(echo "${VERSION}" | sed 's/\//-/g').tar.gz
 
 CUR_DIR=`pwd`
 DEPS_DIR=$CUR_DIR/../BuildDependencies
@@ -16,7 +16,7 @@ UNZIP=$CUR_DIR/tools/7z/7za
 
 cd $LIB_DIR
 
-if [ "$1" == "clean" ]
+if [ -n "$1" ] && [ "$1" == "clean" ]
 then
   echo removing $LIBNAME
   if [ -d $LIBNAME ]
@@ -26,13 +26,13 @@ then
 fi
 
 if [ ! -d $LIBNAME ]; then
-  if [ ! -f $VERSION.tar.gz ]; then
-    $WGET --no-check-certificate $BASE_URL/$VERSION.tar.gz -O $VERSION.tar.gz
+  if [ ! -f $ARCHIVE ]; then
+    $WGET --no-check-certificate $BASE_URL/$VERSION.tar.gz -O $ARCHIVE
   fi
-  $UNZIP x -y $VERSION.tar.gz
-  $UNZIP x -y $VERSION.tar
-  mv $LIBNAME-$VERSION $LIBNAME
-  cd $LIBNAME
+  $UNZIP e -y $ARCHIVE
+  mkdir $LIBNAME && cd $LIBNAME
+  $UNZIP x -y ../${ARCHIVE%.gz}
+  mv */* .
 else
   cd $LIBNAME
   if [ -d .libs ]; then
@@ -90,6 +90,7 @@ OPTIONS="
 --enable-libdcadec"
 
 echo configuring $LIBNAME
+[ -x configure ] || chmod +x configure
 ./configure --extra-cflags="-fno-common -I/xbmc/lib/win32/ffmpeg_dxva2 -DNDEBUG" --extra-ldflags="-L/xbmc/system/players/VideoPlayer -L/xbmc/system/players/dvdplayer" ${OPTIONS} &&
 
 make $MAKEFLAGS &&

--- a/tools/depends/target/ffmpeg/FFMPEG-VERSION
+++ b/tools/depends/target/ffmpeg/FFMPEG-VERSION
@@ -1,5 +1,5 @@
 LIBNAME=ffmpeg
 BASE_URL=https://github.com/xbmc/FFmpeg/archive
-VERSION=2.8.6-Jarvis-rc2-dxva
+VERSION=release/2.8-xbmc
 ARCHIVE=$(LIBNAME)-$(VERSION).tar.gz
 


### PR DESCRIPTION
This reverts commit 3e9e7d202b3a5b7dc16bbec7da1219cd6c9a6b4b.
Reason: It did not match the intended semantics - further discussion ongoing
