### PR TITLE
Revert "FFmpeg: Bump to 2.8.6-Jarvis-16.1"

### DIFF
--- a/tools/depends/target/ffmpeg/FFMPEG-VERSION
+++ b/tools/depends/target/ffmpeg/FFMPEG-VERSION
@@ -1,5 +1,5 @@
 LIBNAME=ffmpeg
 BASE_URL=https://github.com/xbmc/FFmpeg/archive
-VERSION=2.8.6-Jarvis-16.1
+VERSION=2.8.6-Jarvis-rc2-dxva
 ARCHIVE=$(LIBNAME)-$(VERSION).tar.gz
 


### PR DESCRIPTION
This reverts commit 3e9e7d202b3a5b7dc16bbec7da1219cd6c9a6b4b.
Reason: It did not match the intended semantics - further discussion ongoing

Let's do a fast revert as the 16.1 ffmpeg version was deleted already.
