### PR TITLE
[rfc][depends] bump giflib but mainly to include static libs for texturepacker

### DIFF
--- a/project/BuildDependencies/scripts/0_package.list
+++ b/project/BuildDependencies/scripts/0_package.list
@@ -13,7 +13,7 @@ dnssd-541-win32.zip
 doxygen-1.8.2-win32.7z
 fontconfig-2.8.0-win32.7z
 freetype-2.4.6-win32-3.7z
-giflib-5.1.1-win32.7z
+giflib-5.1.2-win32-vc120.7z
 gnutls-3.2.3-win32.zip
 jsonschemabuilder-1.0.0-win32-3.7z
 libass-0.12.1-win32.7z


### PR DESCRIPTION
@fetzerch asked yesterday about having a static library version of giflib for texturepacker so I rebuilt the package including static versions as well as the dll versions.

I haven't uploaded the package yet as I'm thinking we might get rid of the dll versions. They're currently only used by texturepacker and if that is built statically we can get rid of the dll's and avoid having them be included in the distribution.

Thoughts? @ace20022 @Montellese as you're familiar with giflib and texturepacker.
