### PR TITLE
[PVR] PVR Windows: Only the active window must update the shared selected item path.

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -87,7 +87,13 @@ std::string CGUIWindowPVRBase::GetSelectedItemPath(bool bRadio)
 
 void CGUIWindowPVRBase::Notify(const Observable &obs, const ObservableMessage msg)
 {
-  UpdateSelectedItemPath();
+  if (IsActive())
+  {
+    // Only the active window must set the selected item path which is shared
+    // between all PVR windows, not the last notified window (observer).
+    UpdateSelectedItemPath();
+  }
+
   CGUIMessage m(GUI_MSG_REFRESH_LIST, GetID(), 0, msg);
   CApplicationMessenger::GetInstance().SendGUIMessage(m);
 }


### PR DESCRIPTION
Backport of #9070

@xhaggi @Jalle19 good to go? Cherry-picked this from #9070 master branch
