### PR TITLE
AESinkAUDIOTrack: Force sleep also in pcm case

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -648,6 +648,16 @@ unsigned int CAESinkAUDIOTRACK::AddPackets(uint8_t **data, unsigned int frames, 
     if (m_pause_time < 0)
       m_pause_time = 0;
   }
+  else
+  {
+    double time_should_ms = written_frames / (double) m_sink_sampleRate * 1000.0;
+    double time_off = time_should_ms - time_to_add_ms;
+    if (time_off > 0 && time_off > time_should_ms / 2.0)
+    {
+      usleep(time_should_ms / 4.0 * 1000);
+      time_to_add_ms += time_should_ms / 4.0;
+    }
+  }
 
   CLog::Log(LOGDEBUG, "Time needed for add Packet: %lf ms", time_to_add_ms);
   return written_frames;


### PR DESCRIPTION
We have the same issue on AT with pcm data, meaning: Data is added n times without blocking and then the n+1th package blocks the sink for a long time (100 ms +), this is bad to sync against. So also delay writing a bit.
