### PR TITLE
[texturepacker] make disabling dxt/lzo actualy work.

### DIFF
--- a/addons/skin.confluence/media/Makefile.in
+++ b/addons/skin.confluence/media/Makefile.in
@@ -10,7 +10,7 @@ all: $(TARGET)
 
 $(TARGET): $(IMAGES)
 ifeq (@ARCH@,arm)
-	@TEXTUREPACKER@ -dupecheck -use_none -input . -output $(TARGET)
+	@TEXTUREPACKER@ -dupecheck -disable_dxt -input . -output $(TARGET)
 else
 	@TEXTUREPACKER@ -dupecheck -input . -output $(TARGET)
 

--- a/tools/depends/native/TexturePacker/src/TexturePacker.cpp
+++ b/tools/depends/native/TexturePacker/src/TexturePacker.cpp
@@ -287,9 +287,8 @@ void Usage()
   puts("  -input <dir>     Input directory. Default: current dir");
   puts("  -output <dir>    Output directory/filename. Default: Textures.xpr");
   puts("  -dupecheck       Enable duplicate file detection. Reduces output file size. Default: off");
-  puts("  -use_lzo         Use lz0 packing.     Default: on");
-  puts("  -use_dxt         Use DXT compression. Default: on");
-  puts("  -use_none        Use No  compression. Default: off");
+  puts("  -disable_lzo     Disable lz0 packing");
+  puts("  -disable_dxt     Disable DXT compression");
 }
 
 static bool checkDupe(struct MD5Context* ctx,
@@ -466,18 +465,14 @@ int main(int argc, char* argv[])
       while ((c = (char *)strchr(OutputFilename.c_str(), '\\')) != NULL) *c = '/';
 #endif
     }
-    else if (!platform_stricmp(args[i], "-use_none"))
+    else if (!platform_stricmp(args[i], "-disable_dxt"))
     {
       flags &= ~FLAGS_USE_DXT;
     }
-    else if (!platform_stricmp(args[i], "-use_dxt"))
-    {
-      flags |= FLAGS_USE_DXT;
-    }
 #ifdef USE_LZO_PACKING
-    else if (!platform_stricmp(args[i], "-use_lzo"))
+    else if (!platform_stricmp(args[i], "-disable_lzo"))
     {
-      flags |= FLAGS_USE_LZO;
+      flags &= ~FLAGS_USE_LZO;
     }
 #endif
     else


### PR DESCRIPTION
current texturepacker cmdline opts do not make much sense:

-use_none disables only dxt. lzo is still used.
-use_lzo and -use_dxt are no-op

this PR allows skinners to have fine control over lzo/dxt. 

for some reason, on arm, dxt was disabled. I adjusted the makefile. 
