### PR TITLE
AESinkAUDIOTrack: Adjustments for AML

### DIFF
--- a/tools/android/packaging/xbmc/AndroidManifest.xml.in
+++ b/tools/android/packaging/xbmc/AndroidManifest.xml.in
@@ -12,6 +12,7 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.GET_TASKS" />
     <uses-permission android:name="android.permission.BLUETOOTH" />
+    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
 
     <uses-feature android:name="android.hardware.bluetooth" android:required="false" />
     <uses-feature android:name="android.hardware.screen.landscape" android:required="true" />

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -2711,6 +2711,7 @@ bool CActiveAE::IsSettingVisible(const std::string &settingId)
     AEAudioFormat format;
     format.m_dataFormat = AE_FMT_RAW;
     format.m_streamInfo.m_type = CAEStreamInfo::STREAM_TYPE_TRUEHD;
+    format.m_streamInfo.m_sampleRate = 192000;
     if (m_sink.SupportsFormat(CSettings::GetInstance().GetString(CSettings::SETTING_AUDIOOUTPUT_PASSTHROUGHDEVICE), format) &&
         CSettings::GetInstance().GetInt(CSettings::SETTING_AUDIOOUTPUT_CONFIG) != AE_CONFIG_FIXED)
       return true;

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
@@ -54,6 +54,7 @@ public:
 
 protected:
   static bool IsSupported(int sampleRateInHz, int channelConfig, int audioFormat);
+  static bool HasAmlHD();
 
 private:
   jni::CJNIAudioTrack  *m_at_jni;

--- a/xbmc/platform/android/jni/AudioFormat.cpp
+++ b/xbmc/platform/android/jni/AudioFormat.cpp
@@ -94,6 +94,19 @@ void CJNIAudioFormat::PopulateStaticFields()
         GetStaticValue(c, CJNIAudioFormat::ENCODING_DTS, "ENCODING_DTS");
         GetStaticValue(c, CJNIAudioFormat::ENCODING_DTS_HD, "ENCODING_DTS_HD");
         GetStaticValue(c, CJNIAudioFormat::ENCODING_DOLBY_TRUEHD, "ENCODING_DOLBY_TRUEHD");
+
+        // This is ugly and a nicer solution is needed
+        int value = -1;
+        GetStaticValue(c, value, "ENCODING_DTSHD");
+        if (value != -1)
+          CJNIAudioFormat::ENCODING_DTS_HD = value;
+        GetStaticValue(c, value, "ENCODING_DTSHD_MA");
+        if (value != -1)
+          CJNIAudioFormat::ENCODING_DTS_HD = value;
+
+        GetStaticValue(c, value, "ENCODING_TRUEHD");
+        if (value != -1)
+          CJNIAudioFormat::ENCODING_DOLBY_TRUEHD = value;
       }
     }
   }


### PR DESCRIPTION
This brings AMLogic back in line with the version around by wetek, minix and others. I ported the code to v17 with extraordinary support by @koying. @ChristianTroy helped testing and provided valuable feedback.
