### PR TITLE
[PVR] Timer settings dialog: Fix crash on ActivateWindow if dialog was not initialized properly.

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -95,6 +95,16 @@ CGUIDialogPVRTimerSettings::~CGUIDialogPVRTimerSettings()
 {
 }
 
+bool CGUIDialogPVRTimerSettings::CanBeActivated() const
+{
+  if (!m_timerInfoTag)
+  {
+    CLog::Log(LOGERROR, "CGUIDialogPVRTimerSettings::CanBeActivated - no timer info tag");
+    return false;
+  }
+  return true;
+}
+
 void CGUIDialogPVRTimerSettings::SetTimer(CFileItem *item)
 {
   if (item == NULL)

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.h
@@ -44,6 +44,8 @@ namespace PVR
     CGUIDialogPVRTimerSettings();
     virtual ~CGUIDialogPVRTimerSettings();
 
+    virtual bool CanBeActivated() const;
+
     void SetTimer(CFileItem *item);
 
   protected:


### PR DESCRIPTION
Fixes crash reported here: http://forum.kodi.tv/showthread.php?tid=258708&pid=2239216#pid2239216
Closes trac#16577: http://trac.kodi.tv/ticket/16577

@Jalle19 @xhaggi good to go?
