### PR TITLE
Update RssFeeds.xml to point to kodi.tv instead of xbmc.org

### DIFF
--- a/userdata/RssFeeds.xml
+++ b/userdata/RssFeeds.xml
@@ -3,8 +3,8 @@
   <!-- RSS feeds. To have multiple feeds, just add a feed to the set. You can also have multiple sets. 	!-->
   <!-- To use different sets in your skin, each must be called from skin with a unique id.             	!-->
   <set id="1">
-    <feed updateinterval="30">http://feeds.xbmc.org/xbmc</feed>
-    <feed updateinterval="30">http://feeds.xbmc.org/latest_xbmc_addons</feed>
-    <feed updateinterval="30">http://feeds.xbmc.org/updated_xbmc_addons</feed>
+    <feed updateinterval="30">http://feeds.kodi.tv/xbmc</feed>
+    <feed updateinterval="30">http://feeds.kodi.tv/latest_xbmc_addons</feed>
+    <feed updateinterval="30">http://feeds.kodi.tv/updated_xbmc_addons</feed>
   </set>
 </rssfeeds>


### PR DESCRIPTION
Update RssFeeds.xml to point to feeds.kodi.tv instead of feeds.xbmc.org

Maybe also update website with feeds to read "kodi" instead of "xbmc"?

That is, with this update RssFeeds.xml to point will point to:

http://feeds.kodi.tv/xbmc
http://feeds.kodi.tv/latest_xbmc_addons
http://feeds.kodi.tv/updated_xbmc_addons

But maybe the website should be updated too and then point to example:

http://feeds.kodi.tv/kodi
http://feeds.kodi.tv/latest_kodi_addons
http://feeds.kodi.tv/updated_kodi_addons
