### PR TITLE
[depends] Bump samba-gplv3 to version 4.0.26

### DIFF
--- a/tools/depends/target/samba-gplv3/Makefile
+++ b/tools/depends/target/samba-gplv3/Makefile
@@ -1,9 +1,9 @@
 include ../../Makefile.include
-DEPS= ../../Makefile.include Makefile samba_android.patch no_fork_and_exec.patch
+DEPS= ../../Makefile.include Makefile configureEndian.patch samba_android.patch samba_off64_t.patch no_fork_and_exec.patch
 
 # lib name, version
 LIBNAME=samba
-VERSION=3.6.12
+VERSION=4.0.26
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
 
@@ -16,11 +16,12 @@ endif
 
 CONFIGURE= cp -f $(CONFIG_SUB) $(CONFIG_GUESS) .; \
           ./configure --prefix=$(PREFIX) \
-          --without-cluster-support --disable-swat --without-ldap \
-          --without-pam --without-pam_smbpass --with-fhs --with-libtalloc=no \
-          --with-libtdb=no --without-winbind --disable-cups --without-ads \
-          --disable-avahi --disable-fam --without-libaddns --without-libnetapi \
-          --without-dnsupdate --without-libsmbsharemodes \
+          --without-cluster-support --without-ldap \
+          --without-pam --without-pam_smbpass --enable-fhs \
+          --without-winbind --disable-cups --without-ads \
+          --disable-avahi \
+          --without-dnsupdate \
+          --without-ad-dc --without-acl-support \
           --with-libiconv=$(STAGING_DIR)
 
 # configuration settings
@@ -48,6 +49,8 @@ $(TARBALLS_LOCATION)/$(ARCHIVE):
 $(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
 	rm -rf $(PLATFORM); mkdir -p $(PLATFORM)
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
+	cd $(PLATFORM); patch -p0 -i ../configureEndian.patch
+	cd $(PLATFORM)/source3; ./autogen.sh
 ifeq ($(OS),android)
 	cd $(PLATFORM); patch -p0 < ../samba_android.patch
 	cd $(PLATFORM); patch -p1 < ../samba_off64_t.patch

--- a/tools/depends/target/samba-gplv3/configureEndian.patch
+++ b/tools/depends/target/samba-gplv3/configureEndian.patch
@@ -1,0 +1,42 @@
+--- lib/ccan/libccan.m4
++++ lib/ccan/libccan.m4
+@@ -121,16 +121,9 @@
+ 	     [whether we can compile with __attribute__((used))])
+ fi
+ 
+-# FIXME: We could use endian.h or sys/endian.h here, and __BYTE_ORDER for
+-# cross-compiling.
+-AC_CACHE_CHECK([whether we are big endian],samba_cv_big_endian,[
+-AC_TRY_RUN([int main(void) {
+-union { int i; char c[sizeof(int)]; } u;
+-	  u.i = 0x01020304;
+-	  return u.c[0] == 0x01 && u.c[1] == 0x02 && u.c[2] == 0x03 && u.c[3] == 0x04 ? 0 : 1;
+-}],
+-samba_cv_big_endian=yes,
+-samba_cv_big_endian=no)])
++AC_C_BIGENDIAN(
++	samba_cv_big_endian=yes,
++	samba_cv_big_endian=no)
+ if test x"$samba_cv_big_endian" = xyes ; then
+    AC_DEFINE(HAVE_BIG_ENDIAN, 1,
+ 	     [whether we are big endian])
+@@ -300,16 +293,9 @@
+ 	     [whether we have isblank])
+ fi
+ 
+-# FIXME: We could use endian.h or sys/endian.h here, and __BYTE_ORDER for
+-# cross-compiling.
+-AC_CACHE_CHECK([whether we are little endian],samba_cv_little_endian,[
+-AC_TRY_RUN([int main(void) {
+-union { int i; char c[sizeof(int)]; } u;
+-	  u.i = 0x01020304;
+-	  return u.c[0] == 0x04 && u.c[1] == 0x03 && u.c[2] == 0x02 && u.c[3] == 0x01 ? 0 : 1;
+-}],
+-samba_cv_little_endian=yes,
+-samba_cv_little_endian=no)])
++AC_C_BIGENDIAN(
++	samba_cv_little_endian=no,
++	samba_cv_little_endian=yes)
+ if test x"$samba_cv_little_endian" = xyes ; then
+    AC_DEFINE(HAVE_LITTLE_ENDIAN, 1,
+ 	     [whether we are little endian])

--- a/tools/depends/target/samba-gplv3/no_fork_and_exec.patch
+++ b/tools/depends/target/samba-gplv3/no_fork_and_exec.patch
@@ -1,29 +1,69 @@
---- lib/util/system.c.orig	2015-12-12 17:56:12.000000000 +0100
-+++ lib/util/system.c	2015-12-12 17:56:46.000000000 +0100
-@@ -96,7 +96,7 @@
- 
- _PUBLIC_ pid_t sys_fork(void)
+--- lib/util/become_daemon.c
++++ lib/util/become_daemon.c
+@@ -76,7 +76,7 @@
+ _PUBLIC_ void become_daemon(bool do_fork, bool no_process_group, bool log_stdout)
  {
--	pid_t forkret = fork();
-+	pid_t forkret = (pid_t)-1;
+ 	if (do_fork) {
+-		if (fork()) {
++		if (-1) {
+ 			_exit(0);
+ 		}
+ 	}
+--- lib/util/fault.c
++++ lib/util/fault.c
+@@ -131,7 +131,7 @@
+ 			snprintf(pidstr, sizeof(pidstr), "%d", (int) getpid());
+ 			all_string_sub(cmdstring, "%d", pidstr, sizeof(cmdstring));
+ 			DEBUG(0, ("smb_panic(): calling panic action [%s]\n", cmdstring));
+-			result = system(cmdstring);
++			result = -1;
  
- 	if (forkret == (pid_t)0) {
- 		/* Child - reset mypid so sys_getpid does a system call. */
+ 			if (result == -1)
+ 				DEBUG(0, ("smb_panic(): fork failed in panic action: %s\n",
+--- source3/lib/server_prefork.c
++++ source3/lib/server_prefork.c
+@@ -106,7 +106,7 @@
+ 		pfp->pool[i].allowed_clients = 1;
+ 		pfp->pool[i].started = now;
+ 
+-		pid = fork();
++		pid = -1;
+ 		switch (pid) {
+ 		case -1:
+ 			DEBUG(1, ("Failed to prefork child n. %d !\n", i));
+@@ -194,7 +194,7 @@
+ 		pfp->pool[i].allowed_clients = 1;
+ 		pfp->pool[i].started = now;
+ 
+-		pid = fork();
++		pid = -1;
+ 		switch (pid) {
+ 		case -1:
+ 			DEBUG(1, ("Failed to prefork child n. %d !\n", j));
 --- source3/lib/system.orig	2015-12-12 17:58:30.000000000 +0100
 +++ source3/lib/system.c	2015-12-12 17:58:45.000000000 +0100
-@@ -1506,7 +1506,7 @@
+@@ -1198,7 +1198,7 @@
+ 		goto err_exit;
+ 	}
+ 
+-	entry->child_pid = fork();
++	entry->child_pid = -1;
+ 
+ 	if (entry->child_pid == -1) {
+ 		DEBUG(0, ("sys_popen: fork failed: %s\n", strerror(errno)));
+@@ -1229,7 +1229,7 @@
  		for (p = popen_chain; p; p = p->next)
  			close(p->fd);
  
--		execv(argl[0], argl);
-+		//execv(argl[0], argl);
- 		_exit (127);
- 	}
- 
+-		ret = execv(argl[0], argl);
++		ret = -1;
+ 		if (ret == -1) {
+ 			DEBUG(0, ("sys_popen: ERROR executing command "
+ 				  "'%s': %s\n", command, strerror(errno)));
 --- source3/lib/util.c.orig	2015-12-12 18:01:38.000000000 +0100
 +++ source3/lib/util.c	2015-12-12 18:01:58.000000000 +0100
-@@ -1120,7 +1120,7 @@
- 	cmd = lp_panic_action();
+@@ -820,7 +820,7 @@
+ 	cmd = lp_panic_action(talloc_tos());
  	if (cmd && *cmd) {
  		DEBUG(0, ("smb_panic(): calling panic action [%s]\n", cmd));
 -		result = system(cmd);
@@ -53,7 +93,16 @@
  	return fd[0];
 --- source3/lib/smbrun.c.orig	2015-12-12 18:00:04.000000000 +0100
 +++ source3/lib/smbrun.c	2015-12-12 18:00:57.000000000 +0100
-@@ -192,8 +192,8 @@
+@@ -93,7 +93,7 @@
+ 
+ 	saved_handler = CatchChildLeaveStatus();
+                                    	
+-	if ((pid=fork()) < 0) {
++	if ((pid=-1) < 0) {
+ 		DEBUG(0,("smbrun: fork failed with error %s\n", strerror(errno) ));
+ 		(void)CatchSignal(SIGCLD, saved_handler);
+ 		if (outfd) {
+@@ -193,8 +193,8 @@
  				exit(82);
  		}
  
@@ -64,7 +113,16 @@
  
  		SAFE_FREE(newcmd);
  	}
-@@ -343,7 +343,7 @@
+@@ -257,7 +257,7 @@
+ 
+ 	saved_handler = CatchChildLeaveStatus();
+                                    	
+-	if ((pid=fork()) < 0) {
++	if ((pid=-1) < 0) {
+ 		DEBUG(0, ("smbrunsecret: fork failed with error %s\n", strerror(errno)));
+ 		(void)CatchSignal(SIGCLD, saved_handler);
+ 		return errno;
+@@ -345,7 +345,7 @@
  	}
  #endif
  

--- a/tools/depends/target/samba-gplv3/samba_android.patch
+++ b/tools/depends/target/samba-gplv3/samba_android.patch
@@ -1,10 +1,10 @@
 diff -ru lib/util/charset/iconv.c lib/util/charset/iconv.c
 --- lib/util/charset/iconv.c	2013-01-29 09:49:31.000000000 +0100
 +++ lib/util/charset/iconv.c	2015-03-28 08:30:53.191217266 +0100
-@@ -23,6 +23,11 @@
- #include "system/iconv.h"
+@@ -24,6 +24,11 @@
  #include "system/filesys.h"
-
+ #include "charset_proto.h"
+ 
 +#if defined(ANDROID)
 +#include <stdint.h>
 +#include <byteswap.h>
@@ -13,7 +13,7 @@ diff -ru lib/util/charset/iconv.c lib/util/charset/iconv.c
  #ifdef strcasecmp
  #undef strcasecmp
  #endif
-@@ -502,6 +507,19 @@ static size_t ucs2hex_push(void *cd, con
+@@ -546,6 +551,19 @@
  	return 0;
  }
 
@@ -33,49 +33,10 @@ diff -ru lib/util/charset/iconv.c lib/util/charset/iconv.c
  static size_t iconv_swab(void *cd, const char **inbuf, size_t *inbytesleft,
  			 char **outbuf, size_t *outbytesleft)
  {
-diff -ru lib/util/system.c lib/util/system.c
---- lib/util/system.c	2013-01-29 09:49:31.000000000 +0100
-+++ lib/util/system.c	2015-03-28 08:30:53.843217274 +0100
-@@ -83,7 +83,9 @@
- {
- 	struct in_addr in;
- 	struct in_addr in2;
-+#if !defined(ANDROID)
- 	in = inet_makeaddr(net, host);
-+#endif
- 	in2.s_addr = in.s_addr;
- 	return in2;
- }
 diff -ru lib/util/util_pw.c lib/util/util_pw.c
 --- lib/util/util_pw.c	2013-01-29 09:49:31.000000000 +0100
 +++ lib/util/util_pw.c	2015-03-28 08:30:53.843217274 +0100
-@@ -34,17 +34,25 @@
- 
- void sys_setpwent(void)
- {
-+#if !defined(ANDROID)
- 	setpwent();
-+#endif
- }
- 
- struct passwd *sys_getpwent(void)
- {
-+#if !defined(ANDROID)
- 	return getpwent();
-+#else
-+	return NULL;
-+#endif
- }
- 
- void sys_endpwent(void)
- {
-+#if !defined(ANDROID)
- 	endpwent();
-+#endif
- }
- 
- /**************************************************************************
-@@ -83,7 +91,9 @@
+@@ -40,7 +40,9 @@
  	ret->pw_passwd = talloc_strdup(ret, from->pw_passwd);
  	ret->pw_uid = from->pw_uid;
  	ret->pw_gid = from->pw_gid;
@@ -114,7 +75,7 @@ diff -ru nsswitch/libwbclient/wbc_pwd.c nsswitch/libwbclient/wbc_pwd.c
 diff -ru nsswitch/libwbclient/wbc_sid.c nsswitch/libwbclient/wbc_sid.c
 --- nsswitch/libwbclient/wbc_sid.c	2013-01-29 09:49:31.000000000 +0100
 +++ nsswitch/libwbclient/wbc_sid.c	2015-03-28 08:30:53.847217275 +0100
-@@ -950,9 +950,11 @@
+@@ -957,9 +957,11 @@
  
  		wbcFreeMemory(name);
  
@@ -129,7 +90,7 @@ diff -ru nsswitch/libwbclient/wbc_sid.c nsswitch/libwbclient/wbc_sid.c
 diff -ru source3/configure source3/configure
 --- source3/configure	2013-01-29 10:21:59.000000000 +0100
 +++ source3/configure	2015-03-28 08:43:34.903227582 +0100
-@@ -20894,7 +20894,7 @@
+@@ -22645,7 +22645,7 @@
  LIBSMBCLIENT_SOVER=0
  LIBSMBCLIENT_FULLVER=$LIBSMBCLIENT_SOVER
  
@@ -138,7 +99,7 @@ diff -ru source3/configure source3/configure
  LIBSMBCLIENT_SHARED_TARGET_FULLVER=$LIBSMBCLIENT_SHARED_TARGET.$LIBSMBCLIENT_FULLVER
  
  
-@@ -36540,19 +36540,19 @@
+@@ -37803,19 +37803,19 @@
  if test "x$ac_cv_lib_pthread_pthread_attr_init" = xyes; then :
  
  	     PTHREAD_CFLAGS="-D_REENTRANT -D_POSIX_PTHREAD_SEMANTICS"
@@ -162,7 +123,7 @@ diff -ru source3/configure source3/configure
  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
  /* end confdefs.h.  */
  
-@@ -36585,7 +36585,7 @@
+@@ -37848,7 +37848,7 @@
  if test "x$ac_cv_lib_pthreads_pthread_attr_init" = xyes; then :
  
  	     PTHREAD_CFLAGS="-D_THREAD_SAFE"
@@ -171,10 +132,10 @@ diff -ru source3/configure source3/configure
  fi
  
  fi
-diff -ru source3/lib/fault.c source3/lib/fault.c
---- source3/lib/fault.c	2013-01-29 09:49:31.000000000 +0100
-+++ source3/lib/fault.c	2015-03-28 08:30:54.539217284 +0100
-@@ -375,7 +375,7 @@
+diff -ru source3/lib/dumpcore.c source3/lib/dumpcore.c
+--- source3/lib/dumpcore.c
++++ source3/lib/dumpcore.c
+@@ -320,7 +320,7 @@
  	umask(~(0700));
  	dbgflush();
  
@@ -183,37 +144,10 @@ diff -ru source3/lib/fault.c source3/lib/fault.c
  	/* On Linux we lose the ability to dump core when we change our user
  	 * ID. We know how to dump core safely, so let's make sure we have our
  	 * dumpable flag set.
-diff -ru source3/lib/system.c source3/lib/system.c
---- source3/lib/system.c	2013-01-29 09:49:31.000000000 +0100
-+++ source3/lib/system.c	2015-03-28 08:30:54.543217284 +0100
-@@ -921,8 +921,11 @@
- #if defined(HAVE_EXPLICIT_LARGEFILE_SUPPORT) && defined(HAVE_SEEKDIR64)
- 	seekdir64(dirp, offset);
- #else
-+#if !defined(ANDROID)
- 	seekdir(dirp, offset);
- #endif
-+	return;
-+#endif
- }
- 
- /*******************************************************************
-@@ -934,7 +937,11 @@
- #if defined(HAVE_EXPLICIT_LARGEFILE_SUPPORT) && defined(HAVE_TELLDIR64)
- 	return (long)telldir64(dirp);
- #else
-+#if !defined(ANDROID)
- 	return (long)telldir(dirp);
-+#else
-+	return(0);
-+#endif
- #endif
- }
- 
-diff -ru source3/libads/dns.c source3/libads/dns.c
---- source3/libads/dns.c	2013-01-29 09:49:31.000000000 +0100
-+++ source3/libads/dns.c	2015-03-28 08:30:54.543217284 +0100
-@@ -40,6 +40,16 @@
+diff -ru lib/addns/dnsquery.c lib/addns/dnsquery.c
+--- lib/addns/dnsquery.c
++++ lib/addns/dnsquery.c
+@@ -41,6 +41,16 @@
  
  #define MAX_DNS_PACKET_SIZE 0xffff
  
@@ -233,7 +167,7 @@ diff -ru source3/libads/dns.c source3/libads/dns.c
 diff -ru source3/passdb/passdb.c source3/passdb/passdb.c
 --- source3/Makefile.in
 +++ source3/Makefile.in
-@@ -2507,8 +2507,6 @@
+@@ -2410,8 +2410,6 @@
  		@SONAMEFLAG@`basename $@`
  
  $(LIBSMBCLIENT_SHARED_TARGET): $(LIBSMBCLIENT_SHARED_TARGET_SONAME)
@@ -242,7 +176,7 @@ diff -ru source3/passdb/passdb.c source3/passdb/passdb.c
  
  $(LIBSMBCLIENT_STATIC_TARGET): $(BINARY_PREREQS) $(LIBSMBCLIENT_OBJ1)
  	@echo Linking non-shared library $@
-@@ -2525,11 +2523,6 @@
+@@ -2428,11 +2426,6 @@
  installlibsmbclient:: installdirs libsmbclient
  	@$(SHELL) $(srcdir)/script/installdirs.sh $(INSTALLPERMS_BIN) $(DESTDIR) $(LIBDIR)
  	-$(INSTALLLIBCMD_SH) $(LIBSMBCLIENT_SHARED_TARGET_SONAME) $(DESTDIR)$(LIBDIR)
@@ -282,23 +216,19 @@ diff -ru source3/passdb/passdb.c source3/passdb/passdb.c
 diff -ru source3/passdb/pdb_interface.c source3/passdb/pdb_interface.c
 --- source3/passdb/pdb_interface.c	2013-01-29 09:49:31.000000000 +0100
 +++ source3/passdb/pdb_interface.c	2015-03-28 08:30:54.547217284 +0100
-@@ -1464,8 +1464,8 @@
+@@ -1563,6 +1563,7 @@
  	}
  
  	/* Primary group members */
--	setpwent();
--	while ((pwd = getpwent()) != NULL) {
-+	sys_setpwent();
-+	while ((pwd = sys_getpwent()) != NULL) {
++#if !defined(ANDROID)
+ 	setpwent();
+ 	while ((pwd = getpwent()) != NULL) {
  		if (pwd->pw_gid == gid) {
- 			if (!add_uid_to_array_unique(mem_ctx, pwd->pw_uid,
- 						pp_uids, p_num)) {
-@@ -1473,7 +1473,7 @@
- 			}
+@@ -1573,6 +1574,7 @@
  		}
  	}
--	endpwent();
-+	sys_endpwent();
+ 	endpwent();
++#endif
  
  	/* Secondary group members */
  	for (gr = grp->gr_mem; (*gr != NULL) && ((*gr)[0] != '\0'); gr += 1) {

--- a/tools/depends/target/samba-gplv3/samba_off64_t.patch
+++ b/tools/depends/target/samba-gplv3/samba_off64_t.patch
@@ -1,7 +1,7 @@
 diff -pur samba-3.6.12/lib/util/util.c arm-linux-androideabi-21/lib/util/util.c
 --- samba-3.6.12/lib/util/util.c	2013-01-29 09:49:31.000000000 +0100
 +++ arm-linux-androideabi-21/lib/util/util.c	2016-07-27 20:01:54.128052081 +0200
-@@ -255,7 +255,7 @@ _PUBLIC_ bool process_exists_by_pid(pid_
+@@ -341,7 +341,7 @@ _PUBLIC_ bool process_exists_by_pid(pid_
   is dealt with in posix.c
  **/
  
@@ -10,9 +10,8 @@ diff -pur samba-3.6.12/lib/util/util.c arm-linux-androideabi-21/lib/util/util.c
  {
  	struct flock lock;
  	int ret;
-diff -pur samba-3.6.12/lib/util/util.h arm-linux-androideabi-21/lib/util/util.h
---- samba-3.6.12/lib/util/util.h	2013-01-29 09:49:31.000000000 +0100
-+++ arm-linux-androideabi-21/lib/util/util.h	2016-07-27 20:01:44.155992544 +0200
+--- a/lib/util/samba_util.h
++++ b/lib/util/samba_util.h
 @@ -674,7 +674,7 @@ _PUBLIC_ bool process_exists_by_pid(pid_
   Simple routine to do POSIX file locking. Cruft in NFS and 64->32 bit mapping
   is dealt with in posix.c
@@ -25,7 +24,7 @@ diff -pur samba-3.6.12/lib/util/util.h arm-linux-androideabi-21/lib/util/util.h
 diff -pur samba-3.6.12/source3/include/libsmb_internal.h arm-linux-androideabi-21/source3/include/libsmb_internal.h
 --- samba-3.6.12/source3/include/libsmb_internal.h	2013-01-29 09:49:31.000000000 +0100
 +++ arm-linux-androideabi-21/source3/include/libsmb_internal.h	2016-07-27 20:07:42.306136381 +0200
-@@ -300,14 +300,14 @@ int
+@@ -304,14 +304,14 @@ int
  SMBC_rmdir_ctx(SMBCCTX *context,
                 const char *fname);
  
@@ -42,7 +41,7 @@ diff -pur samba-3.6.12/source3/include/libsmb_internal.h arm-linux-androideabi-2
  
  int
  SMBC_fstatdir_ctx(SMBCCTX *context,
-@@ -383,16 +383,16 @@ SMBC_setatr(SMBCCTX * context, SMBCSRV *
+@@ -387,16 +387,16 @@ SMBC_setatr(SMBCCTX * context, SMBCSRV *
              time_t change_time,
              uint16 mode);
  
@@ -65,7 +64,7 @@ diff -pur samba-3.6.12/source3/include/libsmb_internal.h arm-linux-androideabi-2
 diff -pur samba-3.6.12/source3/include/libsmbclient.h arm-linux-androideabi-21/source3/include/libsmbclient.h
 --- samba-3.6.12/source3/include/libsmbclient.h	2013-01-29 09:49:31.000000000 +0100
 +++ arm-linux-androideabi-21/source3/include/libsmbclient.h	2016-07-28 10:21:20.267305706 +0200
-@@ -862,9 +862,9 @@ typedef int (*smbc_rename_fn)(SMBCCTX *o
+@@ -870,9 +870,9 @@ typedef int (*smbc_rename_fn)(SMBCCTX *o
  smbc_rename_fn smbc_getFunctionRename(SMBCCTX *c);
  void smbc_setFunctionRename(SMBCCTX *c, smbc_rename_fn fn);
  
@@ -77,7 +76,7 @@ diff -pur samba-3.6.12/source3/include/libsmbclient.h arm-linux-androideabi-21/s
                                 int whence);
  smbc_lseek_fn smbc_getFunctionLseek(SMBCCTX *c);
  void smbc_setFunctionLseek(SMBCCTX *c, smbc_lseek_fn fn);
-@@ -895,7 +895,7 @@ void smbc_setFunctionFstatVFS(SMBCCTX *c
+@@ -903,7 +903,7 @@ void smbc_setFunctionFstatVFS(SMBCCTX *c
  
  typedef int (*smbc_ftruncate_fn)(SMBCCTX *c,
                                   SMBCFILE *f,
@@ -86,7 +85,7 @@ diff -pur samba-3.6.12/source3/include/libsmbclient.h arm-linux-androideabi-21/s
  smbc_ftruncate_fn smbc_getFunctionFtruncate(SMBCCTX *c);
  void smbc_setFunctionFtruncate(SMBCCTX *c, smbc_ftruncate_fn fn);
  
-@@ -945,14 +945,14 @@ typedef int (*smbc_rmdir_fn)(SMBCCTX *c,
+@@ -953,14 +953,14 @@ typedef int (*smbc_rmdir_fn)(SMBCCTX *c,
  smbc_rmdir_fn smbc_getFunctionRmdir(SMBCCTX *c);
  void smbc_setFunctionRmdir(SMBCCTX *c, smbc_rmdir_fn fn);
  
@@ -103,7 +102,7 @@ diff -pur samba-3.6.12/source3/include/libsmbclient.h arm-linux-androideabi-21/s
  smbc_lseekdir_fn smbc_getFunctionLseekdir(SMBCCTX *c);
  void smbc_setFunctionLseekdir(SMBCCTX *c, smbc_lseekdir_fn fn);
  
-@@ -1324,7 +1324,7 @@ ssize_t smbc_write(int fd, const void *b
+@@ -1332,7 +1332,7 @@ ssize_t smbc_write(int fd, const void *b
   * @return          Upon successful completion, lseek returns the 
   *                  resulting offset location as measured in bytes 
   *                  from the beginning  of the file. Otherwise, a value
@@ -112,7 +111,7 @@ diff -pur samba-3.6.12/source3/include/libsmbclient.h arm-linux-androideabi-21/s
   *                  indicate the error:
   *                  - EBADF  Fildes is not an open file descriptor.
   *                  - EINVAL Whence is not a proper value or smbc_init
-@@ -1334,7 +1334,7 @@ ssize_t smbc_write(int fd, const void *b
+@@ -1342,7 +1342,7 @@ ssize_t smbc_write(int fd, const void *b
   * 
   * @todo Are errno values complete and correct?
   */
@@ -121,7 +120,7 @@ diff -pur samba-3.6.12/source3/include/libsmbclient.h arm-linux-androideabi-21/s
  
  
  /**@ingroup file
-@@ -1518,7 +1518,7 @@ struct smbc_dirent* smbc_readdir(unsigne
+@@ -1526,7 +1526,7 @@ struct smbc_dirent* smbc_readdir(unsigne
   * @see             smbc_readdir()
   *
   */
@@ -130,7 +129,7 @@ diff -pur samba-3.6.12/source3/include/libsmbclient.h arm-linux-androideabi-21/s
  
  
  /**@ingroup directory
-@@ -1543,7 +1543,7 @@ off_t smbc_telldir(int dh);
+@@ -1551,7 +1551,7 @@ off_t smbc_telldir(int dh);
   *
   * @todo In what does the reture and errno values mean?
   */
@@ -139,7 +138,7 @@ diff -pur samba-3.6.12/source3/include/libsmbclient.h arm-linux-androideabi-21/s
  
  /**@ingroup directory
   * Create a directory.
-@@ -1700,7 +1700,7 @@ smbc_fstatvfs(int fd,
+@@ -1708,7 +1708,7 @@ smbc_fstatvfs(int fd,
   * @see             , Unix ftruncate()
   *
   */
@@ -148,10 +147,21 @@ diff -pur samba-3.6.12/source3/include/libsmbclient.h arm-linux-androideabi-21/s
  
  
  /**@ingroup attribute
+--- a/source3/include/proto.h
++++ b/source3/include/proto.h
+@@ -418,7 +418,7 @@
+ bool is_in_path(const char *name, name_compare_entry *namelist, bool case_sensitive);
+ void set_namearray(name_compare_entry **ppname_array, const char *namelist);
+ void free_namearray(name_compare_entry *name_array);
+-bool fcntl_lock(int fd, int op, off_t offset, off_t count, int type);
++bool fcntl_lock(int fd, int op, off64_t offset, off64_t count, int type);
+ bool fcntl_getlock(int fd, off_t *poffset, off_t *pcount, int *ptype, pid_t *ppid);
+ bool is_myname(const char *s);
+ void ra_lanman_string( const char *native_lanman );
 diff -pur samba-3.6.12/source3/libsmb/clireadwrite.c arm-linux-androideabi-21/source3/libsmb/clireadwrite.c
 --- samba-3.6.12/source3/libsmb/clireadwrite.c	2013-01-29 09:49:31.000000000 +0100
 +++ arm-linux-androideabi-21/source3/libsmb/clireadwrite.c	2016-07-27 20:08:06.134279334 +0200
-@@ -102,7 +102,7 @@ static void cli_read_andx_done(struct te
+@@ -125,7 +125,7 @@ static void cli_read_andx_done(struct te
  struct tevent_req *cli_read_andx_create(TALLOC_CTX *mem_ctx,
  					struct event_context *ev,
  					struct cli_state *cli, uint16_t fnum,
@@ -160,7 +170,7 @@ diff -pur samba-3.6.12/source3/libsmb/clireadwrite.c arm-linux-androideabi-21/so
  					struct tevent_req **psmbreq)
  {
  	struct tevent_req *req, *subreq;
-@@ -160,7 +160,7 @@ struct tevent_req *cli_read_andx_create(
+@@ -176,7 +176,7 @@ struct tevent_req *cli_read_andx_create(
  struct tevent_req *cli_read_andx_send(TALLOC_CTX *mem_ctx,
  				      struct event_context *ev,
  				      struct cli_state *cli, uint16_t fnum,
@@ -169,7 +179,7 @@ diff -pur samba-3.6.12/source3/libsmb/clireadwrite.c arm-linux-androideabi-21/so
  {
  	struct tevent_req *req, *subreq;
  	NTSTATUS status;
-@@ -257,7 +257,7 @@ struct cli_readall_state {
+@@ -273,7 +273,7 @@ struct cli_readall_state {
  	struct tevent_context *ev;
  	struct cli_state *cli;
  	uint16_t fnum;
@@ -178,7 +188,7 @@ diff -pur samba-3.6.12/source3/libsmb/clireadwrite.c arm-linux-androideabi-21/so
  	size_t size;
  	size_t received;
  	uint8_t *buf;
-@@ -269,7 +269,7 @@ static struct tevent_req *cli_readall_se
+@@ -285,7 +285,7 @@ static struct tevent_req *cli_readall_se
  					   struct event_context *ev,
  					   struct cli_state *cli,
  					   uint16_t fnum,
@@ -187,43 +197,43 @@ diff -pur samba-3.6.12/source3/libsmb/clireadwrite.c arm-linux-androideabi-21/so
  {
  	struct tevent_req *req, *subreq;
  	struct cli_readall_state *state;
-@@ -392,7 +392,7 @@ struct cli_pull_state {
+@@ -408,7 +408,7 @@ struct cli_pull_state {
  	struct event_context *ev;
  	struct cli_state *cli;
  	uint16_t fnum;
 -	off_t start_offset;
 +	off64_t start_offset;
- 	SMB_OFF_T size;
+ 	off_t size;
  
  	NTSTATUS (*sink)(char *buf, size_t n, void *priv);
-@@ -451,7 +451,7 @@ static void cli_pull_read_done(struct te
+@@ -468,7 +468,7 @@ static void cli_pull_read_done(struct te
  struct tevent_req *cli_pull_send(TALLOC_CTX *mem_ctx,
  				 struct event_context *ev,
  				 struct cli_state *cli,
 -				 uint16_t fnum, off_t start_offset,
 +				 uint16_t fnum, off64_t start_offset,
- 				 SMB_OFF_T size, size_t window_size,
+ 				 off_t size, size_t window_size,
  				 NTSTATUS (*sink)(char *buf, size_t n,
  						  void *priv),
-@@ -649,7 +649,7 @@ NTSTATUS cli_pull_recv(struct tevent_req
+@@ -672,7 +672,7 @@ NTSTATUS cli_pull_recv(struct tevent_req
  }
  
  NTSTATUS cli_pull(struct cli_state *cli, uint16_t fnum,
--		  off_t start_offset, SMB_OFF_T size, size_t window_size,
-+		  off64_t start_offset, SMB_OFF_T size, size_t window_size,
+-		  off_t start_offset, off_t size, size_t window_size,
++		  off64_t start_offset, off_t size, size_t window_size,
  		  NTSTATUS (*sink)(char *buf, size_t n, void *priv),
- 		  void *priv, SMB_OFF_T *received)
+ 		  void *priv, off_t *received)
  {
-@@ -699,7 +699,7 @@ static NTSTATUS cli_read_sink(char *buf,
+@@ -722,7 +722,7 @@ static NTSTATUS cli_read_sink(char *buf,
  }
  
- ssize_t cli_read(struct cli_state *cli, uint16_t fnum, char *buf,
--		 off_t offset, size_t size)
-+		 off64_t offset, size_t size)
+ NTSTATUS cli_read(struct cli_state *cli, uint16_t fnum,
+-		 char *buf, off_t offset, size_t size,
++		 char *buf, off64_t offset, size_t size,
+ 		 size_t *nread)
  {
  	NTSTATUS status;
- 	SMB_OFF_T ret;
-@@ -717,7 +717,7 @@ ssize_t cli_read(struct cli_state *cli,
+@@ -746,7 +746,7 @@ ssize_t cli_read(struct cli_state *cli,
  ****************************************************************************/
  
  NTSTATUS cli_smbwrite(struct cli_state *cli, uint16_t fnum, char *buf,
@@ -232,7 +242,7 @@ diff -pur samba-3.6.12/source3/libsmb/clireadwrite.c arm-linux-androideabi-21/so
  {
  	uint8_t *bytes;
  	ssize_t total = 0;
-@@ -797,7 +797,7 @@ struct tevent_req *cli_write_andx_create
+@@ -827,7 +827,7 @@ struct tevent_req *cli_write_andx_create
  					 struct event_context *ev,
  					 struct cli_state *cli, uint16_t fnum,
  					 uint16_t mode, const uint8_t *buf,
@@ -241,7 +251,7 @@ diff -pur samba-3.6.12/source3/libsmb/clireadwrite.c arm-linux-androideabi-21/so
  					 struct tevent_req **reqs_before,
  					 int num_reqs_before,
  					 struct tevent_req **psmbreq)
-@@ -860,7 +860,7 @@ struct tevent_req *cli_write_andx_send(T
+@@ -890,7 +890,7 @@ struct tevent_req *cli_write_andx_send(T
  				       struct event_context *ev,
  				       struct cli_state *cli, uint16_t fnum,
  				       uint16_t mode, const uint8_t *buf,
@@ -250,7 +260,7 @@ diff -pur samba-3.6.12/source3/libsmb/clireadwrite.c arm-linux-androideabi-21/so
  {
  	struct tevent_req *req, *subreq;
  	NTSTATUS status;
-@@ -931,7 +931,7 @@ struct cli_writeall_state {
+@@ -962,7 +962,7 @@ struct cli_writeall_state {
  	uint16_t fnum;
  	uint16_t mode;
  	const uint8_t *buf;
@@ -259,7 +269,7 @@ diff -pur samba-3.6.12/source3/libsmb/clireadwrite.c arm-linux-androideabi-21/so
  	size_t size;
  	size_t written;
  };
-@@ -944,7 +944,7 @@ static struct tevent_req *cli_writeall_s
+@@ -975,7 +975,7 @@ static struct tevent_req *cli_writeall_s
  					    uint16_t fnum,
  					    uint16_t mode,
  					    const uint8_t *buf,
@@ -268,7 +278,7 @@ diff -pur samba-3.6.12/source3/libsmb/clireadwrite.c arm-linux-androideabi-21/so
  {
  	struct tevent_req *req, *subreq;
  	struct cli_writeall_state *state;
-@@ -1028,7 +1028,7 @@ static NTSTATUS cli_writeall_recv(struct
+@@ -1059,7 +1059,7 @@ static NTSTATUS cli_writeall_recv(struct
  }
  
  NTSTATUS cli_writeall(struct cli_state *cli, uint16_t fnum, uint16_t mode,
@@ -277,7 +287,7 @@ diff -pur samba-3.6.12/source3/libsmb/clireadwrite.c arm-linux-androideabi-21/so
  		      size_t *pwritten)
  {
  	TALLOC_CTX *frame = talloc_stackframe();
-@@ -1064,7 +1064,7 @@ NTSTATUS cli_writeall(struct cli_state *
+@@ -1095,7 +1095,7 @@ NTSTATUS cli_writeall(struct cli_state *
  struct cli_push_write_state {
  	struct tevent_req *req;/* This is the main request! Not the subreq */
  	uint32_t idx;
@@ -286,7 +296,7 @@ diff -pur samba-3.6.12/source3/libsmb/clireadwrite.c arm-linux-androideabi-21/so
  	uint8_t *buf;
  	size_t size;
  };
-@@ -1074,7 +1074,7 @@ struct cli_push_state {
+@@ -1105,7 +1105,7 @@ struct cli_push_state {
  	struct cli_state *cli;
  	uint16_t fnum;
  	uint16_t mode;
@@ -295,7 +305,7 @@ diff -pur samba-3.6.12/source3/libsmb/clireadwrite.c arm-linux-androideabi-21/so
  	size_t window_size;
  
  	size_t (*source)(uint8_t *buf, size_t n, void *priv);
-@@ -1083,7 +1083,7 @@ struct cli_push_state {
+@@ -1114,7 +1114,7 @@ struct cli_push_state {
  	bool eof;
  
  	size_t chunk_size;
@@ -304,7 +314,7 @@ diff -pur samba-3.6.12/source3/libsmb/clireadwrite.c arm-linux-androideabi-21/so
  
  	/*
  	 * Outstanding requests
-@@ -1146,7 +1146,7 @@ static bool cli_push_write_setup(struct
+@@ -1178,7 +1178,7 @@ static bool cli_push_write_setup(struct
  struct tevent_req *cli_push_send(TALLOC_CTX *mem_ctx, struct event_context *ev,
  				 struct cli_state *cli,
  				 uint16_t fnum, uint16_t mode,
@@ -313,7 +323,7 @@ diff -pur samba-3.6.12/source3/libsmb/clireadwrite.c arm-linux-androideabi-21/so
  				 size_t (*source)(uint8_t *buf, size_t n,
  						  void *priv),
  				 void *priv)
-@@ -1249,7 +1249,7 @@ NTSTATUS cli_push_recv(struct tevent_req
+@@ -1287,7 +1287,7 @@ NTSTATUS cli_push_recv(struct tevent_req
  }
  
  NTSTATUS cli_push(struct cli_state *cli, uint16_t fnum, uint16_t mode,
@@ -367,7 +377,7 @@ diff -pur samba-3.6.12/source3/libsmb/libsmb_compat.c arm-linux-androideabi-21/s
 diff -pur samba-3.6.12/source3/libsmb/libsmb_dir.c arm-linux-androideabi-21/source3/libsmb/libsmb_dir.c
 --- samba-3.6.12/source3/libsmb/libsmb_dir.c	2013-01-29 09:49:31.000000000 +0100
 +++ arm-linux-androideabi-21/source3/libsmb/libsmb_dir.c	2016-07-27 20:08:51.646552457 +0200
-@@ -1383,7 +1383,7 @@ SMBC_rmdir_ctx(SMBCCTX *context,
+@@ -1386,7 +1386,7 @@ SMBC_rmdir_ctx(SMBCCTX *context,
   * Routine to return the current directory position
   */
  
@@ -376,7 +386,7 @@ diff -pur samba-3.6.12/source3/libsmb/libsmb_dir.c arm-linux-androideabi-21/sour
  SMBC_telldir_ctx(SMBCCTX *context,
                   SMBCFILE *dir)
  {
-@@ -1424,7 +1424,7 @@ SMBC_telldir_ctx(SMBCCTX *context,
+@@ -1427,7 +1427,7 @@ SMBC_telldir_ctx(SMBCCTX *context,
  	 * We return the pointer here as the offset
  	 */
  	TALLOC_FREE(frame);
@@ -385,7 +395,7 @@ diff -pur samba-3.6.12/source3/libsmb/libsmb_dir.c arm-linux-androideabi-21/sour
  }
  
  /*
-@@ -1465,7 +1465,7 @@ check_dir_ent(struct smbc_dir_list *list
+@@ -1468,7 +1468,7 @@ check_dir_ent(struct smbc_dir_list *list
  int
  SMBC_lseekdir_ctx(SMBCCTX *context,
                    SMBCFILE *dir,
@@ -397,7 +407,7 @@ diff -pur samba-3.6.12/source3/libsmb/libsmb_dir.c arm-linux-androideabi-21/sour
 diff -pur samba-3.6.12/source3/libsmb/libsmb_file.c arm-linux-androideabi-21/source3/libsmb/libsmb_file.c
 --- samba-3.6.12/source3/libsmb/libsmb_file.c	2013-01-29 09:49:31.000000000 +0100
 +++ arm-linux-androideabi-21/source3/libsmb/libsmb_file.c	2016-07-27 20:09:06.190639760 +0200
-@@ -235,12 +235,12 @@ SMBC_read_ctx(SMBCCTX *context,
+@@ -237,12 +237,12 @@ SMBC_read_ctx(SMBCCTX *context,
           * offset:
           *
           * Compiler bug (possibly) -- gcc (GCC) 3.3.5 (Debian 1:3.3.5-2) --
@@ -413,7 +423,7 @@ diff -pur samba-3.6.12/source3/libsmb/libsmb_file.c arm-linux-androideabi-21/sou
  
  	if (!context || !context->internal->initialized) {
  		errno = EINVAL;
-@@ -319,7 +319,7 @@ SMBC_write_ctx(SMBCCTX *context,
+@@ -322,7 +322,7 @@ SMBC_write_ctx(SMBCCTX *context,
                 const void *buf,
                 size_t count)
  {
@@ -422,7 +432,7 @@ diff -pur samba-3.6.12/source3/libsmb/libsmb_file.c arm-linux-androideabi-21/sou
  	char *server = NULL, *share = NULL, *user = NULL, *password = NULL;
  	char *path = NULL;
  	char *targetpath = NULL;
-@@ -665,10 +665,10 @@ SMBC_setatr(SMBCCTX * context, SMBCSRV *
+@@ -673,10 +673,10 @@ SMBC_setatr(SMBCCTX * context, SMBCSRV *
   * A routine to lseek() a file
   */
  
@@ -434,20 +444,20 @@ diff -pur samba-3.6.12/source3/libsmb/libsmb_file.c arm-linux-androideabi-21/sou
 +               off64_t offset,
                 int whence)
  {
- 	SMB_OFF_T size;
-@@ -763,7 +763,7 @@ SMBC_lseek_ctx(SMBCCTX *context,
+ 	off_t size;
+@@ -773,7 +767,7 @@ SMBC_lseek_ctx(SMBCCTX *context,
  int
  SMBC_ftruncate_ctx(SMBCCTX *context,
                     SMBCFILE *file,
 -                   off_t length)
 +                   off64_t length)
  {
- 	SMB_OFF_T size = length;
+ 	off_t size = length;
  	char *server = NULL;
 diff -pur samba-3.6.12/source3/libsmb/proto.h arm-linux-androideabi-21/source3/libsmb/proto.h
 --- samba-3.6.12/source3/libsmb/proto.h	2013-01-29 09:49:31.000000000 +0100
 +++ arm-linux-androideabi-21/source3/libsmb/proto.h	2016-07-27 20:08:33.766445144 +0200
-@@ -691,36 +691,36 @@ NTSTATUS cli_set_fs_quota_info(struct cl
+@@ -732,37 +732,37 @@ NTSTATUS cli_set_fs_quota_info(struct cl
  struct tevent_req *cli_read_andx_create(TALLOC_CTX *mem_ctx,
  					struct event_context *ev,
  					struct cli_state *cli, uint16_t fnum,
@@ -466,19 +476,20 @@ diff -pur samba-3.6.12/source3/libsmb/proto.h arm-linux-androideabi-21/source3/l
  				 struct cli_state *cli,
 -				 uint16_t fnum, off_t start_offset,
 +				 uint16_t fnum, off64_t start_offset,
- 				 SMB_OFF_T size, size_t window_size,
+ 				 off_t size, size_t window_size,
  				 NTSTATUS (*sink)(char *buf, size_t n,
  						  void *priv),
  				 void *priv);
- NTSTATUS cli_pull_recv(struct tevent_req *req, SMB_OFF_T *received);
+ NTSTATUS cli_pull_recv(struct tevent_req *req, off_t *received);
  NTSTATUS cli_pull(struct cli_state *cli, uint16_t fnum,
--		  off_t start_offset, SMB_OFF_T size, size_t window_size,
-+		  off64_t start_offset, SMB_OFF_T size, size_t window_size,
+-		  off_t start_offset, off_t size, size_t window_size,
++		  off64_t start_offset, off_t size, size_t window_size,
  		  NTSTATUS (*sink)(char *buf, size_t n, void *priv),
- 		  void *priv, SMB_OFF_T *received);
- ssize_t cli_read(struct cli_state *cli, uint16_t fnum, char *buf,
--		 off_t offset, size_t size);
-+		 off64_t offset, size_t size);
+ 		  void *priv, off_t *received);
+ NTSTATUS cli_read(struct cli_state *cli, uint16_t fnum,
+-		  char *buf, off_t offset, size_t size,
++		  char *buf, off64_t offset, size_t size,
+ 		  size_t *nread);
  NTSTATUS cli_smbwrite(struct cli_state *cli, uint16_t fnum, char *buf,
 -		      off_t offset, size_t size1, size_t *ptotal);
 +		      off64_t offset, size_t size1, size_t *ptotal);
@@ -491,7 +502,7 @@ diff -pur samba-3.6.12/source3/libsmb/proto.h arm-linux-androideabi-21/source3/l
  					 struct tevent_req **reqs_before,
  					 int num_reqs_before,
  					 struct tevent_req **psmbreq);
-@@ -728,23 +728,23 @@ struct tevent_req *cli_write_andx_send(T
+@@ -770,23 +770,23 @@ struct tevent_req *cli_write_andx_send(T
  				       struct event_context *ev,
  				       struct cli_state *cli, uint16_t fnum,
  				       uint16_t mode, const uint8_t *buf,
@@ -519,10 +530,21 @@ diff -pur samba-3.6.12/source3/libsmb/proto.h arm-linux-androideabi-21/source3/l
  		  size_t (*source)(uint8_t *buf, size_t n, void *priv),
  		  void *priv);
  
+--- a/source3/locking/posix.c
++++ b/source3/locking/posix.c
+@@ -182,7 +182,7 @@
+  broken NFS implementations.
+ ****************************************************************************/
+ 
+-static bool posix_fcntl_lock(files_struct *fsp, int op, off_t offset, off_t count, int type)
++static bool posix_fcntl_lock(files_struct *fsp, int op, off64_t offset, off_t count, int type)
+ {
+ 	bool ret;
+ 
 diff -pur samba-3.6.12/source3/registry/regfio.c arm-linux-androideabi-21/source3/registry/regfio.c
 --- samba-3.6.12/source3/registry/regfio.c	2013-01-29 09:49:31.000000000 +0100
 +++ arm-linux-androideabi-21/source3/registry/regfio.c	2016-07-27 20:09:31.246790183 +0200
-@@ -492,7 +492,7 @@ static bool read_regf_block( REGF_FILE *
+@@ -493,7 +493,7 @@ static bool read_regf_block( REGF_FILE *
  /*******************************************************************
  *******************************************************************/
  


### PR DESCRIPTION
Bump latest release of samba3.
Maybe android or other platforms need `libtevent` too, but I've only tested for OSX.
The source file may must be uploaded to the server.
