### PR TITLE
fix loading of shared libraries on POSIX systems

### DIFF
--- a/xbmc/cores/DllLoader/DllLoaderContainer.cpp
+++ b/xbmc/cores/DllLoader/DllLoaderContainer.cpp
@@ -239,16 +239,12 @@ LibraryLoader* DllLoaderContainer::LoadDll(const char* sName, bool bLoadSymbols)
 
   LibraryLoader* pLoader;
 #ifdef TARGET_POSIX
-  if (strstr(sName, ".so") != NULL || strstr(sName, ".vis") != NULL || strstr(sName, ".xbs") != NULL
-      || strstr(sName, ".mvis") != NULL || strstr(sName, ".dylib") != NULL || strstr(sName, ".framework") != NULL || strstr(sName, ".pvr") != NULL)
-    pLoader = new SoLoader(sName, bLoadSymbols);
-  else
+  pLoader = new SoLoader(sName, bLoadSymbols);
 #elif defined(TARGET_WINDOWS)
-  if (1)
-    pLoader = new Win32DllLoader(sName);
-  else
+  pLoader = new Win32DllLoader(sName);
+#else
+  pLoader = new DllLoader(sName, m_bTrack, false, bLoadSymbols);
 #endif
-    pLoader = new DllLoader(sName, m_bTrack, false, bLoadSymbols);
 
   if (!pLoader)
   {


### PR DESCRIPTION
grrr

It took me hours to locate this hack. My lib was named after Linux convention something like bla.so.1.0.0 and DllLoader was chosen instead of SoLoader.
@wsnipex pvr libs did only work by change because strstr found "pvr" in the middle of the library name.
