### PR TITLE
AESinkAUDIOTrack: Only use non IEC passthrough when it's needed

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -732,21 +732,18 @@ void CAESinkAUDIOTRACK::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)
           CLog::Log(LOGDEBUG, "AESinkAUDIOTRACK - %d supported", test_sample[i]);
         }
       }
-      if (CJNIAudioManager::GetSDKVersion() >= 21)
+      if (CJNIAudioManager::GetSDKVersion() >= 23)
       {
         m_info.m_wantsIECPassthrough = false;
         // here only 5.1 would work but we cannot correctly distinguish
         // m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_EAC3);
-
-        if (CJNIAudioManager::GetSDKVersion() >= 23)
-        {
+        m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTSHD);
+      }
+      if (StringUtils::StartsWithNoCase(CJNIBuild::DEVICE, "foster")) // SATV is ahead of API
+      {
+        if (CJNIAudioManager::GetSDKVersion() == 22)
           m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTSHD);
-        }
-        if (StringUtils::StartsWithNoCase(CJNIBuild::DEVICE, "foster")) // SATV is ahead of API
-        {
-          m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTSHD);
-          m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_TRUEHD);
-        }
+        m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_TRUEHD);
       }
     }
     std::copy(m_sink_sampleRates.begin(), m_sink_sampleRates.end(), std::back_inserter(m_info.m_sampleRates));


### PR DESCRIPTION
... really, really, really needs to be used

This will basically keep old behavior and only use the API on v23 and later with the shield on v22 being an exception.
