### PR TITLE
[PVR] Refactor: Encapsulate recording path

### DIFF
--- a/Kodi.xcodeproj/project.pbxproj
+++ b/Kodi.xcodeproj/project.pbxproj
@@ -147,6 +147,8 @@
 		2AC7EB5B1C21F6BA00BDAA95 /* GUIWindowPVRTimersBase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2AC7EB581C21F6BA00BDAA95 /* GUIWindowPVRTimersBase.cpp */; };
 		2AC7EB5C1C2330B300BDAA95 /* GUIWindowPVRTimerRules.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2AC7EB561C21F6BA00BDAA95 /* GUIWindowPVRTimerRules.cpp */; };
 		2AC7EB5D1C2330BC00BDAA95 /* GUIWindowPVRTimersBase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2AC7EB581C21F6BA00BDAA95 /* GUIWindowPVRTimersBase.cpp */; };
+		2AC7EB601C34893700BDAA95 /* PVRRecordingsPath.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2AC7EB5F1C34893700BDAA95 /* PVRRecordingsPath.cpp */; };
+		2AC7EB611C34893700BDAA95 /* PVRRecordingsPath.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2AC7EB5F1C34893700BDAA95 /* PVRRecordingsPath.cpp */; };
 		2F4564D51970129A00396109 /* GUIFontCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2F4564D31970129A00396109 /* GUIFontCache.cpp */; };
 		2F4564D61970129A00396109 /* GUIFontCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2F4564D31970129A00396109 /* GUIFontCache.cpp */; };
 		36A9443D15821E2800727135 /* DatabaseUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 36A9443B15821E2800727135 /* DatabaseUtils.cpp */; };
@@ -2526,6 +2528,8 @@
 		2AC7EB571C21F6BA00BDAA95 /* GUIWindowPVRTimerRules.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GUIWindowPVRTimerRules.h; sourceTree = "<group>"; };
 		2AC7EB581C21F6BA00BDAA95 /* GUIWindowPVRTimersBase.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GUIWindowPVRTimersBase.cpp; sourceTree = "<group>"; };
 		2AC7EB591C21F6BA00BDAA95 /* GUIWindowPVRTimersBase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GUIWindowPVRTimersBase.h; sourceTree = "<group>"; };
+		2AC7EB5E1C34892100BDAA95 /* PVRRecordingsPath.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PVRRecordingsPath.h; sourceTree = "<group>"; };
+		2AC7EB5F1C34893700BDAA95 /* PVRRecordingsPath.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PVRRecordingsPath.cpp; sourceTree = "<group>"; };
 		2F4564D31970129A00396109 /* GUIFontCache.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GUIFontCache.cpp; sourceTree = "<group>"; };
 		2F4564D41970129A00396109 /* GUIFontCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GUIFontCache.h; sourceTree = "<group>"; };
 		36A9443B15821E2800727135 /* DatabaseUtils.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DatabaseUtils.cpp; sourceTree = "<group>"; };
@@ -6696,6 +6700,8 @@
 				C84828A4156CFCD8005A996F /* PVRRecording.h */,
 				C84828A5156CFCD8005A996F /* PVRRecordings.cpp */,
 				C84828A6156CFCD8005A996F /* PVRRecordings.h */,
+				2AC7EB5F1C34893700BDAA95 /* PVRRecordingsPath.cpp */,
+				2AC7EB5E1C34892100BDAA95 /* PVRRecordingsPath.h */,
 			);
 			path = recordings;
 			sourceTree = "<group>";
@@ -9815,6 +9821,7 @@
 				DF93D6AD1444A8B1007C6459 /* SMBFile.cpp in Sources */,
 				DF93D6AE1444A8B1007C6459 /* SpecialProtocolFile.cpp in Sources */,
 				DF6A0D811A4584E80075BBFC /* OverrideDirectory.cpp in Sources */,
+				2AC7EB601C34893700BDAA95 /* PVRRecordingsPath.cpp in Sources */,
 				DF93D6B11444A8B1007C6459 /* UDFFile.cpp in Sources */,
 				DF93D6B21444A8B1007C6459 /* UPnPFile.cpp in Sources */,
 				DF93D6B31444A8B1007C6459 /* ZipFile.cpp in Sources */,
@@ -11208,6 +11215,7 @@
 				7CCDA242192753E30074CF51 /* PltMediaServer.cpp in Sources */,
 				7CCDA24B192753E30074CF51 /* PltSyncMediaBrowser.cpp in Sources */,
 				7CCDA77A192756250074CF51 /* Neptune.cpp in Sources */,
+				2AC7EB611C34893700BDAA95 /* PVRRecordingsPath.cpp in Sources */,
 				7CCDA783192756250074CF51 /* NptAutomaticCleaner.cpp in Sources */,
 				7CCDA786192756250074CF51 /* NptBase64.cpp in Sources */,
 				7CCDA78F192756250074CF51 /* NptBufferedStreams.cpp in Sources */,

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -827,6 +827,7 @@
     <ClCompile Include="..\..\xbmc\pvr\PVRSettings.cpp" />
     <ClCompile Include="..\..\xbmc\pvr\recordings\PVRRecording.cpp" />
     <ClCompile Include="..\..\xbmc\pvr\recordings\PVRRecordings.cpp" />
+    <ClCompile Include="..\..\xbmc\pvr\recordings\PVRRecordingsPath.cpp" />
     <ClCompile Include="..\..\xbmc\pvr\timers\PVRTimerInfoTag.cpp" />
     <ClCompile Include="..\..\xbmc\pvr\timers\PVRTimers.cpp" />
     <ClCompile Include="..\..\xbmc\pvr\timers\PVRTimerType.cpp" />
@@ -1157,6 +1158,7 @@
     <ClInclude Include="..\..\xbmc\profiles\ProfilesManager.h" />
     <ClInclude Include="..\..\xbmc\profiles\windows\GUIWindowSettingsProfile.h" />
     <ClInclude Include="..\..\xbmc\pvr\PVRSettings.h" />
+    <ClInclude Include="..\..\xbmc\pvr\recordings\PVRRecordingsPath.h" />
     <ClInclude Include="..\..\xbmc\pvr\timers\PVRTimerType.h" />
     <ClInclude Include="..\..\xbmc\pvr\windows\GUIWindowPVRTimerRules.h" />
     <ClInclude Include="..\..\xbmc\pvr\windows\GUIWindowPVRTimersBase.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -3261,6 +3261,8 @@
     </ClCompile>
     <ClCompile Include="..\..\xbmc\threads\test\TestHelpers.h">
       <Filter>test\threads</Filter>
+    <ClCompile Include="..\..\xbmc\pvr\recordings\PVRRecordingsPath.cpp">
+      <Filter>pvr\recordings</Filter>
     </ClCompile>
      <ClCompile Include="..\..\xbmc\addons\AddonBuilder.cpp">
       <Filter>addons</Filter>
@@ -6298,6 +6300,8 @@
     </ClInclude>
     <ClInclude Include="..\..\xbmc\addons\AddonBuilder.h">
       <Filter>addons</Filter>
+    <ClInclude Include="..\..\xbmc\pvr\recordings\PVRRecordingsPath.h">
+      <Filter>pvr\recordings</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/xbmc/dialogs/GUIDialogMediaSource.cpp
+++ b/xbmc/dialogs/GUIDialogMediaSource.cpp
@@ -39,6 +39,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "PasswordManager.h"
 #include "URL.h"
+#include "pvr/recordings/PVRRecordingsPath.h"
 
 #if defined(TARGET_ANDROID)
 #include "platform/android/activity/XBMCApp.h"
@@ -283,13 +284,13 @@ void CGUIDialogMediaSource::OnPathBrowse(int item)
     // add the recordings dir as needed
     if (CPVRDirectory::HasRecordings())
     {
-      share1.strPath = "pvr://recordings/active/";
+      share1.strPath = PVR::CPVRRecordingsPath::PATH_ACTIVE_RECORDINGS;
       share1.strName = g_localizeStrings.Get(19017); // TV Recordings
       extraShares.push_back(share1);
     }
     if (CPVRDirectory::HasDeletedRecordings())
     {
-      share1.strPath = "pvr://recordings/deleted/";
+      share1.strPath = PVR::CPVRRecordingsPath::PATH_DELETED_RECORDINGS;
       share1.strName = g_localizeStrings.Get(19108); // Deleted TV Recordings
       extraShares.push_back(share1);
     }

--- a/xbmc/filesystem/PVRFile.cpp
+++ b/xbmc/filesystem/PVRFile.cpp
@@ -23,6 +23,7 @@
 #include "pvr/PVRManager.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/recordings/PVRRecordings.h"
+#include "pvr/recordings/PVRRecordingsPath.h"
 #include "pvr/addons/PVRClients.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
@@ -67,7 +68,7 @@ bool CPVRFile::Open(const CURL& url)
       return false;
     }
   }
-  else if (StringUtils::StartsWith(strURL, "pvr://recordings/active"))
+  else if (CPVRRecordingsPath(strURL).IsActive())
   {
     CFileItemPtr tag = g_PVRRecordings->GetByPath(strURL);
     if (tag && tag->HasPVRRecordingInfoTag())
@@ -84,7 +85,7 @@ bool CPVRFile::Open(const CURL& url)
       return false;
     }
   }
-  else if (StringUtils::StartsWith(strURL, "pvr://recordings/deleted/"))
+  else if (CPVRRecordingsPath(strURL).IsDeleted())
   {
     CLog::Log(LOGNOTICE, "PVRFile - Playback of deleted recordings is not possible (%s)", strURL.c_str());
     return false;

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -50,6 +50,7 @@
 #include "pvr/PVRDatabase.h"
 #include "pvr/PVRGUIInfo.h"
 #include "pvr/recordings/PVRRecordings.h"
+#include "pvr/recordings/PVRRecordingsPath.h"
 #include "pvr/timers/PVRTimers.h"
 #include "pvr/windows/GUIWindowPVRBase.h"
 #include "settings/lib/Setting.h"
@@ -823,7 +824,7 @@ void CPVRManager::ResetDatabase(bool bResetEPGOnly /* = false */)
       if (videoDatabase.Open())
       {
         videoDatabase.EraseVideoSettings("pvr://channels/");
-        videoDatabase.EraseVideoSettings("pvr://recordings/");
+        videoDatabase.EraseVideoSettings(CPVRRecordingsPath::PATH_RECORDINGS);
         videoDatabase.Close();
       }
 

--- a/xbmc/pvr/recordings/Makefile
+++ b/xbmc/pvr/recordings/Makefile
@@ -1,5 +1,6 @@
 SRCS=PVRRecording.cpp \
-     PVRRecordings.cpp
+     PVRRecordings.cpp \
+     PVRRecordingsPath.cpp
 
 LIB=pvrrecordings.a
 

--- a/xbmc/pvr/recordings/PVRRecording.h
+++ b/xbmc/pvr/recordings/PVRRecording.h
@@ -39,10 +39,6 @@
 #include "addons/include/xbmc_pvr_types.h"
 #include "video/VideoInfoTag.h"
 
-#define PVR_RECORDING_BASE_PATH     "recordings"
-#define PVR_RECORDING_DELETED_PATH  "deleted"
-#define PVR_RECORDING_ACTIVE_PATH   "active"
-
 class CVideoDatabase;
 class CVariant;
 

--- a/xbmc/pvr/recordings/PVRRecordings.h
+++ b/xbmc/pvr/recordings/PVRRecordings.h
@@ -25,10 +25,10 @@
 
 #include "PVRRecording.h"
 
-#define PVR_ALL_RECORDINGS_PATH_EXTENSION "-1"
-
 namespace PVR
 {
+  class CPVRRecordingsPath;
+
   class CPVRRecordings : public Observable
   {
   private:
@@ -46,9 +46,8 @@ namespace PVR
 
     virtual void UpdateFromClients(void);
     virtual std::string TrimSlashes(const std::string &strOrig) const;
-    virtual const std::string GetDirectoryFromPath(const std::string &strPath, const std::string &strBase) const;
     virtual bool IsDirectoryMember(const std::string &strDirectory, const std::string &strEntryDirectory) const;
-    virtual void GetSubDirectories(const std::string &strBase, CFileItemList *results);
+    virtual void GetSubDirectories(const CPVRRecordingsPath &recParentPath, CFileItemList *results);
 
     /**
      * @brief recursively deletes all recordings in the specified directory

--- a/xbmc/pvr/recordings/PVRRecordingsPath.cpp
+++ b/xbmc/pvr/recordings/PVRRecordingsPath.cpp
@@ -1,0 +1,181 @@
+/*
+ *      Copyright (C) 2012-2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "system.h"
+#include "utils/RegExp.h"
+#include "utils/StringUtils.h"
+#include "utils/URIUtils.h"
+
+#include "PVRRecordingsPath.h"
+
+using namespace PVR;
+
+const std::string CPVRRecordingsPath::PATH_RECORDINGS         = "pvr://recordings/";
+const std::string CPVRRecordingsPath::PATH_ACTIVE_RECORDINGS  = "pvr://recordings/active/";
+const std::string CPVRRecordingsPath::PATH_DELETED_RECORDINGS = "pvr://recordings/deleted/";
+
+CPVRRecordingsPath::CPVRRecordingsPath(const std::string &strPath)
+{
+  Init(strPath);
+}
+
+CPVRRecordingsPath::CPVRRecordingsPath(bool bDeleted)
+: m_bValid(true),
+  m_bRoot(true),
+  m_bActive(!bDeleted),
+  m_path(StringUtils::Format("pvr://recordings/%s/", bDeleted ? "deleted" : "active"))
+{
+}
+
+CPVRRecordingsPath::CPVRRecordingsPath(bool bDeleted,
+                       const std::string &strDirectory, const std::string &strTitle,
+                       int iSeason, int iEpisode, int iYear,
+                       const std::string &strSubtitle, const std::string &strChannelName,
+                       const CDateTime &recordingTime)
+: m_bValid(true),
+  m_bRoot(false),
+  m_bActive(!bDeleted)
+{
+  std::string strDirectoryN;
+  if (!strDirectory.empty() && strDirectory != "/")
+    strDirectoryN = StringUtils::Format("%s/", strDirectory.c_str());
+
+  std::string strTitleN(strTitle);
+  StringUtils::Replace(strTitleN, '/', ' ');
+
+  std::string strSeasonEpisodeN;
+  if ((iSeason > -1 && iEpisode > -1 && (iSeason > 0 || iEpisode > 0)))
+    strSeasonEpisodeN = StringUtils::Format("s%02de%02d", iSeason, iEpisode);
+  if (!strSeasonEpisodeN.empty())
+    strSeasonEpisodeN = StringUtils::Format(" %s", strSeasonEpisodeN.c_str());
+
+  std::string strYearN(iYear > 0 ? StringUtils::Format(" (%i)", iYear) : "");
+
+  std::string strSubtitleN;
+  if (!strSubtitle.empty())
+  {
+    strSubtitleN = StringUtils::Format(" %s", strSubtitle.c_str());
+    StringUtils::Replace(strSubtitleN, '/', ' ');
+  }
+
+  std::string strChannelNameN;
+  if (!strChannelName.empty())
+  {
+    strChannelNameN = StringUtils::Format(" (%s)", strChannelName.c_str());
+    StringUtils::Replace(strChannelNameN, '/', ' ');
+  }
+
+  m_directoryPath = StringUtils::Format("%s%s%s%s%s",
+                                        strDirectoryN.c_str(), strTitleN.c_str(), strSeasonEpisodeN.c_str(),
+                                        strYearN.c_str(), strSubtitleN.c_str());
+  m_params = StringUtils::Format(", TV%s, %s.pvr", strChannelNameN.c_str(), recordingTime.GetAsSaveString().c_str());
+  m_path   = StringUtils::Format("pvr://recordings/%s/%s%s", bDeleted ? "deleted" : "active", m_directoryPath.c_str(), m_params.c_str());
+}
+
+void CPVRRecordingsPath::Init(const std::string &strPath)
+{
+  std::string strVarPath(strPath);
+  URIUtils::RemoveSlashAtEnd(strVarPath);
+
+  const std::vector<std::string> segments = URIUtils::SplitPath(strVarPath);
+
+  m_bValid  = ((segments.size() >= 3) && // at least pvr://recordings/[active|deleted]
+               (segments.at(1) == "recordings") &&
+               ((segments.at(2) == "active") || (segments.at(2) == "deleted")));
+  m_bRoot   = (m_bValid && (segments.size() == 3));
+  m_bActive = (m_bValid && (segments.at(2) == "active"));
+
+  if (m_bRoot)
+    strVarPath.append("/");
+  else
+  {
+    size_t paramStart = m_path.find(", TV");
+    if (paramStart == std::string::npos)
+      m_directoryPath = strVarPath.substr(m_bActive ? PATH_ACTIVE_RECORDINGS.size(): PATH_DELETED_RECORDINGS.size());
+    else
+    {
+      size_t dirStart = m_bActive ? PATH_ACTIVE_RECORDINGS.size(): PATH_DELETED_RECORDINGS.size();
+      m_directoryPath = strVarPath.substr(dirStart, paramStart - dirStart);
+      m_params = strVarPath.substr(paramStart);
+    }
+  }
+
+  m_path = strVarPath;
+}
+
+std::string CPVRRecordingsPath::GetSubDirectoryPath(const std::string &strPath) const
+{
+  std::string strReturn;
+
+  std::string strUsePath(strPath);
+  while (!strUsePath.empty() && strUsePath.at(0) == '/')
+    strUsePath.erase(0, 1);
+
+  URIUtils::RemoveSlashAtEnd(strUsePath);
+
+  /* adding "/" to make sure that base matches the complete folder name and not only parts of it */
+  if (strUsePath.size() <= m_directoryPath.size() || !StringUtils::StartsWith(strUsePath, m_directoryPath + "/"))
+      return strReturn;
+
+  strUsePath.erase(0, m_directoryPath.size());
+
+  /* check for more occurences */
+  size_t iDelimiter = strUsePath.find('/');
+  if (iDelimiter == std::string::npos)
+    strReturn = strUsePath;
+  else if (iDelimiter == 0)
+    strReturn = strUsePath.substr(1);
+  else
+    strReturn = strUsePath.substr(0, iDelimiter);
+
+  return strReturn;
+}
+
+const std::string CPVRRecordingsPath::GetTitle() const
+{
+  if (m_bValid)
+  {
+    CRegExp reg(true);
+    if (reg.RegComp("pvr://recordings/(.*/)*(.*), TV( \\(.*\\))?, "
+                    "(19[0-9][0-9]|20[0-9][0-9])[0-9][0-9][0-9][0-9]_[0-9][0-9][0-9][0-9][0-9][0-9].pvr"))
+    {
+      if (reg.RegFind(m_path.c_str()) >= 0)
+        return reg.GetMatch(2);
+    }
+  }
+  return "";
+}
+
+void CPVRRecordingsPath::AppendSegment(const std::string &strSegment)
+{
+  m_directoryPath += strSegment;
+
+  size_t paramStart = m_path.find(", TV");
+  if (paramStart == std::string::npos)
+  {
+    // append the segment
+    m_path += strSegment;
+  }
+  else
+  {
+    // insert the segment between end of current directory path and parameters
+    m_path.insert(paramStart, strSegment);
+  }
+}

--- a/xbmc/pvr/recordings/PVRRecordingsPath.h
+++ b/xbmc/pvr/recordings/PVRRecordingsPath.h
@@ -1,0 +1,67 @@
+#pragma once
+/*
+ *      Copyright (C) 2012-2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <string>
+
+class CDateTime;
+
+namespace PVR
+{
+  class CPVRRecordingsPath
+  {
+  public:
+    static const std::string PATH_RECORDINGS;
+    static const std::string PATH_ACTIVE_RECORDINGS;
+    static const std::string PATH_DELETED_RECORDINGS;
+
+    CPVRRecordingsPath(const std::string &strPath);
+    CPVRRecordingsPath(bool bDeleted);
+    CPVRRecordingsPath(bool bDeleted,
+                       const std::string &strDirectory, const std::string &strTitle,
+                       int iSeason, int iEpisode, int iYear,
+                       const std::string &strSubtitle, const std::string &strChannelName,
+                       const CDateTime &recordingTime);
+
+    operator std::string() const { return m_path; }
+
+    bool IsValid() const { return m_bValid; }
+
+    const std::string &GetPath() const { return m_path; }
+    bool IsRecordingsRoot() const { return m_bRoot; }
+    bool IsActive() const { return m_bActive; }
+    bool IsDeleted() const { return !IsActive(); }
+    std::string GetDirectoryPath() const { return m_directoryPath; }
+    std::string GetSubDirectoryPath(const std::string &strPath) const;
+
+    const std::string GetTitle() const;
+    void AppendSegment(const std::string &strSegment);
+
+  private:
+    void Init(const std::string &strPath);
+
+    bool m_bValid;
+    bool m_bRoot;
+    bool m_bActive;
+    std::string m_directoryPath;
+    std::string m_params;
+    std::string m_path;
+  };
+}

--- a/xbmc/pvr/windows/GUIViewStatePVR.cpp
+++ b/xbmc/pvr/windows/GUIViewStatePVR.cpp
@@ -22,6 +22,7 @@
 #include "settings/Settings.h"
 #include "view/ViewStateSettings.h"
 
+#include "pvr/recordings/PVRRecordingsPath.h"
 #include "pvr/timers/PVRTimers.h"
 
 #include "GUIViewStatePVR.h"
@@ -64,7 +65,7 @@ void CGUIViewStateWindowPVRRecordings::SaveViewState(void)
 
 bool CGUIViewStateWindowPVRRecordings::HideParentDirItems(void)
 {
-  return (CGUIViewState::HideParentDirItems() || m_items.GetPath() == "pvr://recordings/active/" || m_items.GetPath() == "pvr://recordings/deleted/");
+  return (CGUIViewState::HideParentDirItems() || CPVRRecordingsPath(m_items.GetPath()).IsRecordingsRoot());
 }
 
 CGUIViewStateWindowPVRGuide::CGUIViewStateWindowPVRGuide(const int windowId, const CFileItemList& items) : CGUIViewStatePVR(windowId, items)

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -35,6 +35,7 @@
 #include "pvr/PVRManager.h"
 #include "pvr/addons/PVRClients.h"
 #include "pvr/recordings/PVRRecordings.h"
+#include "pvr/recordings/PVRRecordingsPath.h"
 #include "pvr/timers/PVRTimers.h"
 
 #include "GUIWindowPVRRecordings.h"
@@ -73,12 +74,8 @@ void CGUIWindowPVRRecordings::OnWindowLoaded()
 
 std::string CGUIWindowPVRRecordings::GetDirectoryPath(void)
 {
-  std::string basePath = StringUtils::Format("pvr://recordings/%s/", m_bShowDeletedRecordings ? "deleted" : "active");
-
-  if (StringUtils::StartsWith(m_vecItems->GetPath(), basePath))
-    return m_vecItems->GetPath();
-
-  return basePath;
+  const std::string basePath = CPVRRecordingsPath(m_bShowDeletedRecordings);
+  return StringUtils::StartsWith(m_vecItems->GetPath(), basePath) ? m_vecItems->GetPath() : basePath;
 }
 
 std::string CGUIWindowPVRRecordings::GetResumeString(const CFileItem& item)
@@ -182,7 +179,8 @@ bool CGUIWindowPVRRecordings::OnAction(const CAction &action)
   if (action.GetID() == ACTION_PARENT_DIR ||
       action.GetID() == ACTION_NAV_BACK)
   {
-    if (m_vecItems->GetPath() != "pvr://recordings/active/" && m_vecItems->GetPath() != "pvr://recordings/deleted/")
+    CPVRRecordingsPath path(m_vecItems->GetPath());
+    if (path.IsValid() && !path.IsRecordingsRoot())
     {
       GoParentFolder();
       return true;
@@ -361,8 +359,8 @@ bool CGUIWindowPVRRecordings::ActionDeleteRecording(CFileItem *item)
     m_vecItems->Remove(item);
 
     /* go to the parent folder if we're in a subdirectory and just deleted the last item */
-    if (m_vecItems->GetPath() != "pvr://recordings/active/" &&
-        m_vecItems->GetPath() != "pvr://recordings/deleted/" && m_vecItems->GetObjectCount() == 0)
+    CPVRRecordingsPath path(m_vecItems->GetPath());
+    if (path.IsValid() && !path.IsRecordingsRoot() && m_vecItems->GetObjectCount() == 0)
       GoParentFolder();
   }
 
@@ -392,7 +390,8 @@ bool CGUIWindowPVRRecordings::OnContextButtonUndelete(CFileItem *item, CONTEXT_B
     m_vecItems->Remove(item);
 
     /* go to the parent folder if we're in a subdirectory and just deleted the last item */
-    if (m_vecItems->GetPath() != "pvr://recordings/deleted/" && m_vecItems->GetObjectCount() == 0)
+    CPVRRecordingsPath path(m_vecItems->GetPath());
+    if (path.IsValid() && !path.IsRecordingsRoot() && m_vecItems->GetObjectCount() == 0)
       GoParentFolder();
   }
 
@@ -434,7 +433,8 @@ bool CGUIWindowPVRRecordings::OnContextButtonDeleteAll(CFileItem *item, CONTEXT_
     m_vecItems->Clear();
 
     /* go to the parent folder if we're in a subdirectory and just deleted the last item */
-    if (m_vecItems->GetPath() != "pvr://recordings/deleted/" && m_vecItems->GetObjectCount() == 0)
+    CPVRRecordingsPath path(m_vecItems->GetPath());
+    if (path.IsValid() && !path.IsRecordingsRoot() && m_vecItems->GetObjectCount() == 0)
       GoParentFolder();
   }
   return bReturn;

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -56,6 +56,7 @@
 #include "utils/Variant.h"
 #include "pvr/PVRManager.h"
 #include "pvr/recordings/PVRRecordings.h"
+#include "pvr/recordings/PVRRecordingsPath.h"
 #include "utils/URIUtils.h"
 #include "GUIUserMessages.h"
 #include "storage/MediaManager.h"
@@ -1125,7 +1126,9 @@ bool CGUIWindowVideoBase::OnPlayMedia(int iItem, const std::string &player)
   }
   CLog::Log(LOGDEBUG, "%s %s", __FUNCTION__, CURL::GetRedacted(item.GetPath()).c_str());
 
-  if (StringUtils::StartsWith(item.GetPath(), "pvr://recordings/active/"))
+
+  CPVRRecordingsPath path(item.GetPath());
+  if (path.IsValid() && path.IsActive())
   {
     if (!g_PVRManager.IsStarted())
       return false;


### PR DESCRIPTION
No functional changes, only refactoring. Put all recordings path string manipulation magic into one specialized class.

@Jalle19 @xhaggi mind taking a look
@Razzeee maybe you can supply the needed VS project files update?
