### PR TITLE
AESinkAUDIOTrack: Use a more intelligent pause timer

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
@@ -66,7 +66,7 @@ private:
   double                GetMovingAverageDelay(double newestdelay);
   // When AddPause is called the m_pause_time is increased
   // by the package duration. This is only used for non IEC passthrough
-  double          m_pause_time;
+  XbmcThreads::EndTime  m_extTimer;
 
   // We maintain our linear weighted average delay counter in here
   // The n-th value (timely oldest value) is weighted with 1/n


### PR DESCRIPTION
This adds a pause timer for AddPause. It has the advantage that it can "run down" by itself and therefore we are more accurate. 

At the beginning when the sink is "empty", e.g. m_offset == -1 we can add the silence without blocking. While seeking we assume a full buffer and add it blocking.

It was tested by @keithah - it decreases the starting time of a raw passthrough track by ~ 500 ms while still being in sync.
