### PR TITLE
[guilib] - change include definition syntax

### DIFF
--- a/addons/skin.estuary/1080i/AddonBrowser.xml
+++ b/addons/skin.estuary/1080i/AddonBrowser.xml
@@ -54,7 +54,7 @@
 					<include>MediaMenuNowPlaying</include>
 				</control>
 			</control>
-			<include name="TopBar">
+			<include content="TopBar">
 				<param name="breadcrumbs_label" value="$LOCALIZE[24001]" />
 				<param name="breadcrumbs_icon" value="icons/settings/addons.png" />
 			</include>
@@ -62,7 +62,7 @@
 			<control type="group">
 				<top>1002</top>
 				<visible>$EXP[sidebar_focused]</visible>
-				<include name="LeftAlignedInfo">
+				<include content="LeftAlignedInfo">
 					<param name="main_label" value="$INFO[Window(AddonBrowser).Property(Updated)]" />
 					<param name="sub_label" value="$LOCALIZE[31069]" />
 				</include>

--- a/addons/skin.estuary/1080i/Custom_1100_AddonLauncher.xml
+++ b/addons/skin.estuary/1080i/Custom_1100_AddonLauncher.xml
@@ -246,43 +246,43 @@
 			</control>
 			<control type="group" id="400">
 				<include>OpenClose_Right</include>
-				<include name="AddonLauncherPanel">
+				<include content="AddonLauncherPanel">
 					<param name="container_id" value="500" />
 					<param name="visible" value="Container(9000).HasFocus(1)" />
 					<param name="container_path" value="addons://sources/video/" />
 					<param name="container_target" value="videos" />
 				</include>
-				<include name="AddonLauncherPanel">
+				<include content="AddonLauncherPanel">
 					<param name="container_id" value="501" />
 					<param name="visible" value="Container(9000).HasFocus(2)" />
 					<param name="container_path" value="addons://sources/audio/" />
 					<param name="container_target" value="music" />
 				</include>
-				<include name="AddonLauncherPanel">
+				<include content="AddonLauncherPanel">
 					<param name="container_id" value="502" />
 					<param name="visible" value="Container(9000).HasFocus(3)" />
 					<param name="container_path" value="addons://sources/executable/" />
 					<param name="container_target" value="programs" />
 				</include>
-				<include name="AddonLauncherPanel" condition="System.Platform.Android">
+				<include content="AddonLauncherPanel" condition="System.Platform.Android">
 					<param name="container_id" value="506" />
 					<param name="visible" value="Container(9000).HasFocus(4)" />
 					<param name="container_path" value="androidapps://" />
 					<param name="container_target" value="programs" />
 				</include>
-				<include name="AddonLauncherPanel">
+				<include content="AddonLauncherPanel">
 					<param name="container_id" value="503" />
 					<param name="visible" value="Container(9000).HasFocus(5)" />
 					<param name="container_path" value="addons://sources/image/" />
 					<param name="container_target" value="pictures" />
 				</include>
-				<!-- 			<include name="AddonLauncherPanel">
+				<!-- 			<include content="AddonLauncherPanel">
 				     <param name="container_id" value="504" />
 				     <param name="visible" value="Container(9000).HasFocus(6)" />
 				     <param name="container_path" value="addons://outdated/" />
 				     <param name="container_target" value="" />
 				     </include>
-				     <include name="AddonLauncherPanel">
+				     <include content="AddonLauncherPanel">
 				     <param name="container_id" value="505" />
 				     <param name="visible" value="Container(9000).HasFocus(7)" />
 				     <param name="container_path" value="addons://all/" />
@@ -303,36 +303,36 @@
 				<animation effect="fade" start="0" end="100" delay="300" time="320">WindowOpen</animation>
 				<animation effect="fade" start="100" end="0" time="150">WindowClose</animation>
 			</control>
-			<include name="TopBar">
+			<include content="TopBar">
 				<param name="breadcrumbs_label" value="$LOCALIZE[24001]" />
 				<param name="breadcrumbs_icon" value="icons/settings/addons.png" />
 			</include>
 			<include>BottomBar</include>
-			<include name="UpDownArrows">
+			<include content="UpDownArrows">
 				<param name="container_id" value="500" />
 				<param name="visible" value="!System.HasModalDialog" />
 			</include>
-			<include name="UpDownArrows">
+			<include content="UpDownArrows">
 				<param name="container_id" value="501" />
 				<param name="visible" value="!System.HasModalDialog" />
 			</include>
-			<include name="UpDownArrows">
+			<include content="UpDownArrows">
 				<param name="container_id" value="502" />
 				<param name="visible" value="!System.HasModalDialog" />
 			</include>
-			<include name="UpDownArrows">
+			<include content="UpDownArrows">
 				<param name="container_id" value="503" />
 				<param name="visible" value="!System.HasModalDialog" />
 			</include>
-			<include name="UpDownArrows">
+			<include content="UpDownArrows">
 				<param name="container_id" value="504" />
 				<param name="visible" value="!System.HasModalDialog" />
 			</include>
-			<include name="UpDownArrows">
+			<include content="UpDownArrows">
 				<param name="container_id" value="505" />
 				<param name="visible" value="!System.HasModalDialog" />
 			</include>
-			<include name="InfoList">
+			<include content="InfoList">
 				<param name="path" value="addons://outdated/" />
 				<param name="height" value="1" />
 				<param name="width" value="1" />

--- a/addons/skin.estuary/1080i/Custom_1102_TextViewer.xml
+++ b/addons/skin.estuary/1080i/Custom_1102_TextViewer.xml
@@ -6,7 +6,7 @@
 		<control type="group">
 			<left>260</left>
 			<top>150</top>
-			<include name="DialogBackgroundCommons">
+			<include content="DialogBackgroundCommons">
 				<param name="DialogBackgroundWidth" value="1400" />
 				<param name="DialogBackgroundHeight" value="770" />
 				<param name="DialogHeaderLabel" value="$INFO[Window(home).Property(TextViewer_Header)]" />

--- a/addons/skin.estuary/1080i/Custom_1103_SourcesDialog.xml
+++ b/addons/skin.estuary/1080i/Custom_1103_SourcesDialog.xml
@@ -7,7 +7,7 @@
 	</coordinates>
 	<include>Animation_DialogPopupOpenClose</include>
 	<controls>
-		<include name="DialogBackgroundCommons">
+		<include content="DialogBackgroundCommons">
 			<param name="DialogBackgroundWidth" value="500" />
 			<param name="DialogBackgroundHeight" value="550" />
 			<param name="DialogHeaderLabel" value="$LOCALIZE[31070]" />
@@ -33,7 +33,7 @@
 			<ondown>5000</ondown>
 			<onleft>99</onleft>
 			<onright>61</onright>
-			<include name="DefaultSimpleListLayout">
+			<include content="DefaultSimpleListLayout">
 				<param name="width" value="500" />
 				<param name="list_id" value="5000" />
 				<param name="align" value="center" />

--- a/addons/skin.estuary/1080i/Custom_1105_MusicOSDSettings.xml
+++ b/addons/skin.estuary/1080i/Custom_1105_MusicOSDSettings.xml
@@ -7,7 +7,7 @@
 	</coordinates>
 	<include>Animation_DialogPopupOpenClose</include>
 	<controls>
-		<include name="DialogBackgroundCommons">
+		<include content="DialogBackgroundCommons">
 			<param name="DialogBackgroundWidth" value="600" />
 			<param name="DialogBackgroundHeight" value="550" />
 			<param name="DialogHeaderLabel" value="$LOCALIZE[5]" />
@@ -22,7 +22,7 @@
 			<ondown>5000</ondown>
 			<onleft>99</onleft>
 			<onright>61</onright>
-			<include name="DefaultSimpleListLayout">
+			<include content="DefaultSimpleListLayout">
 				<param name="width" value="600" />
 				<param name="list_id" value="5000" />
 				<param name="align" value="center" />

--- a/addons/skin.estuary/1080i/Custom_1107_SearchDialog.xml
+++ b/addons/skin.estuary/1080i/Custom_1107_SearchDialog.xml
@@ -7,7 +7,7 @@
 	</coordinates>
 	<include>Animation_DialogPopupOpenClose</include>
 	<controls>
-		<include name="DialogBackgroundCommons">
+		<include content="DialogBackgroundCommons">
 			<param name="DialogBackgroundWidth" value="600" />
 			<param name="DialogBackgroundHeight" value="340" />
 			<param name="DialogHeaderLabel" value="$LOCALIZE[137]" />
@@ -22,7 +22,7 @@
 			<ondown>5000</ondown>
 			<onleft>99</onleft>
 			<onright>61</onright>
-			<include name="DefaultSimpleListLayout">
+			<include content="DefaultSimpleListLayout">
 				<param name="width" value="600" />
 				<param name="list_id" value="5000" />
 				<param name="align" value="center" />

--- a/addons/skin.estuary/1080i/Custom_1108_PVROverlay.xml
+++ b/addons/skin.estuary/1080i/Custom_1108_PVROverlay.xml
@@ -87,16 +87,16 @@
 			<align>right</align>
 			<orientation>horizontal</orientation>
 			<itemgap>10</itemgap>
-			<include name="MediaFlag">
+			<include content="MediaFlag">
 				<param name="texture" value="$INFO[VideoPlayer.AudioChannels,flags/audiochannel/,.png]" />
 			</include>
-			<include name="MediaFlag">
+			<include content="MediaFlag">
 				<param name="texture" value="$INFO[VideoPlayer.AudioCodec,flags/audiocodec/,.png]" />
 			</include>
-			<include name="MediaFlag">
+			<include content="MediaFlag">
 				<param name="texture" value="$INFO[VideoPlayer.VideoAspect,flags/aspectratio/,.png]" />
 			</include>
-			<include name="MediaFlag">
+			<include content="MediaFlag">
 				<param name="texture" value="$INFO[VideoPlayer.VideoCodec,flags/videocodec/,.png]" />
 			</include>
 		</control>

--- a/addons/skin.estuary/1080i/DialogAddonInfo.xml
+++ b/addons/skin.estuary/1080i/DialogAddonInfo.xml
@@ -51,17 +51,17 @@
 				<align>center</align>
 				<itemgap>-18</itemgap>
 				<orientation>horizontal</orientation>
-				<include name="InfoDialogButton">
+				<include content="InfoDialogButton">
 					<param name="id" value="12" />
 					<param name="icon" value="icons/infodialogs/launch.png" />
 					<param name="label" value="$LOCALIZE[518]" />
 				</include>
-				<include name="InfoDialogButton">
+				<include content="InfoDialogButton">
 					<param name="id" value="9" />
 					<param name="icon" value="icons/infodialogs/configure.png" />
 					<param name="label" value="$LOCALIZE[24020]" />
 				</include>
-				<include name="InfoDialogButton">
+				<include content="InfoDialogButton">
 					<param name="id" value="8" />
 					<param name="icon" value="icons/infodialogs/update.png" />
 					<param name="label" value="$LOCALIZE[24069]" />
@@ -79,19 +79,19 @@
 					<font>font12</font>
 					<visible>Control.IsEnabled(13)</visible>
 				</control>
-				<include name="InfoDialogButton">
+				<include content="InfoDialogButton">
 					<param name="id" value="10" />
 					<param name="icon" value="icons/infodialogs/changelog.png" />
 					<param name="label" value="$LOCALIZE[24036]" />
 				</include>
-				<include name="InfoDialogToggleButton">
+				<include content="InfoDialogToggleButton">
 					<param name="id" value="7" />
 					<param name="icon_on" value="icons/infodialogs/disable.png" />
 					<param name="icon_off" value="icons/infodialogs/enabled.png" />
 					<param name="selected" value="!String.StartsWith(Control.GetLabel(7),$LOCALIZE[24022]) | !Window.IsActive(addonbrowser)" />
 					<param name="label" value="" />
 				</include>
-				<include name="InfoDialogToggleButton">
+				<include content="InfoDialogToggleButton">
 					<param name="id" value="6" />
 					<param name="icon_on" value="icons/infodialogs/uninstall.png" />
 					<param name="icon_off" value="icons/infodialogs/install.png" />
@@ -143,7 +143,7 @@
 				</control>
 			</control>
 		</control>
-		<include name="InfoDialogTopBarInfo">
+		<include content="InfoDialogTopBarInfo">
 			<param name="main_label" value="$INFO[ListItem.AddonName]" />
 			<param name="sub_label" value="$INFO[ListItem.AddonVersion,[COLOR grey],[/COLOR]]$INFO[ListItem.AddonCreator, $LOCALIZE[31071] ]" />
 		</include>

--- a/addons/skin.estuary/1080i/DialogAddonSettings.xml
+++ b/addons/skin.estuary/1080i/DialogAddonSettings.xml
@@ -7,7 +7,7 @@
 	</coordinates>
 	<include>Animation_DialogPopupOpenClose</include>
 	<controls>
-		<include name="DialogBackgroundCommons">
+		<include content="DialogBackgroundCommons">
 			<param name="DialogBackgroundWidth" value="1720" />
 			<param name="DialogBackgroundHeight" value="800" />
 			<param name="DialogHeaderLabel" value="-" />
@@ -27,7 +27,7 @@
 			<onup>9</onup>
 			<ondown>9</ondown>
 		</control>
-		<include name="UpDownArrows">
+		<include content="UpDownArrows">
 			<param name="container_id" value="2" />
 			<param name="posx" value="830" />
 			<param name="up_posy" value="-42" />
@@ -63,15 +63,15 @@
 			<ondown>9001</ondown>
 			<onleft>2</onleft>
 			<onright>9</onright>
-			<include name="DefaultDialogButton">
+			<include content="DefaultDialogButton">
 				<param name="id" value="10" />
 				<param name="label" value="$LOCALIZE[186]" />
 			</include>
-			<include name="DefaultDialogButton">
+			<include content="DefaultDialogButton">
 				<param name="id" value="11" />
 				<param name="label" value="$LOCALIZE[222]" />
 			</include>
-			<include name="DefaultDialogButton">
+			<include content="DefaultDialogButton">
 				<param name="id" value="12" />
 				<param name="label" value="$LOCALIZE[409]" />
 			</include>

--- a/addons/skin.estuary/1080i/DialogAudioDSPManager.xml
+++ b/addons/skin.estuary/1080i/DialogAudioDSPManager.xml
@@ -8,7 +8,7 @@
 		<top>140</top>
 	</coordinates>
 	<controls>
-		<include name="DialogBackgroundCommons">
+		<include content="DialogBackgroundCommons">
 			<param name="DialogBackgroundWidth" value="1780" />
 			<param name="DialogBackgroundHeight" value="700" />
 			<param name="DialogHeaderLabel" value="$LOCALIZE[15020]" />
@@ -105,7 +105,7 @@
 			<control type="group">
 				<left>320</left>
 				<description>available modes group</description>
-				<include name="AudioDSPModeList">
+				<include content="AudioDSPModeList">
 					<param name="sublabel" value="$LOCALIZE[15050]: $INFO[Container(20).NumItems]" />
 					<param name="scrollbar_id" value="60" />
 					<param name="list_id" value="20" />
@@ -117,7 +117,7 @@
 				<description>active modes group</description>
 				<left>810</left>
 				<top>0</top>
-				<include name="AudioDSPModeList">
+				<include content="AudioDSPModeList">
 					<param name="sublabel" value="$LOCALIZE[15051]: $INFO[Container(21).NumItems]" />
 					<param name="scrollbar_id" value="61" />
 					<param name="list_id" value="21" />
@@ -141,12 +141,12 @@
 				<texturefocus border="40" colordiffuse="button_focus">buttons/dialogbutton-fo.png</texturefocus>
 				<texturenofocus border="40">buttons/dialogbutton-nofo.png</texturenofocus>
 			</control>
-			<include name="DefaultDialogButton">
+			<include content="DefaultDialogButton">
 				<param name="id" value="23" />
 				<param name="label" value="$LOCALIZE[14070]" />
 				<param name="width" value="470" />
 			</include>
-			<include name="DefaultDialogButton">
+			<include content="DefaultDialogButton">
 				<param name="id" value="24" />
 				<param name="label" value="$LOCALIZE[15066]" />
 				<param name="width" value="470" />

--- a/addons/skin.estuary/1080i/DialogButtonMenu.xml
+++ b/addons/skin.estuary/1080i/DialogButtonMenu.xml
@@ -7,7 +7,7 @@
 	</coordinates>
 	<include>Animation_DialogPopupOpenClose</include>
 	<controls>
-		<include name="DialogBackgroundCommons">
+		<include content="DialogBackgroundCommons">
 			<param name="DialogBackgroundWidth" value="500" />
 			<param name="DialogBackgroundHeight" value="100" />
 			<param name="DialogHeaderLabel" value="$LOCALIZE[31072]" />

--- a/addons/skin.estuary/1080i/DialogConfirm.xml
+++ b/addons/skin.estuary/1080i/DialogConfirm.xml
@@ -7,7 +7,7 @@
 	<include>Animation_DialogPopupOpenClose</include>
 	<depth>DepthDialog+</depth>
 	<controls>
-		<include name="DialogBackgroundCommons">
+		<include content="DialogBackgroundCommons">
 			<param name="DialogBackgroundWidth" value="915" />
 			<param name="DialogBackgroundHeight" value="380" />
 			<param name="DialogHeaderLabel" value="" />
@@ -34,15 +34,15 @@
 			<top>280</top>
 			<width>915</width>
 			<align>center</align>
-			<include name="DefaultDialogButton">
+			<include content="DefaultDialogButton">
 				<param name="id" value="11" />
 				<param name="label" value="" />
 			</include>
-			<include name="DefaultDialogButton">
+			<include content="DefaultDialogButton">
 				<param name="id" value="10" />
 				<param name="label" value="" />
 			</include>
-			<include name="DefaultDialogButton">
+			<include content="DefaultDialogButton">
 				<param name="id" value="12" />
 				<param name="label" value="" />
 			</include>

--- a/addons/skin.estuary/1080i/DialogContextMenu.xml
+++ b/addons/skin.estuary/1080i/DialogContextMenu.xml
@@ -44,7 +44,7 @@
 			<texturefocus colordiffuse="button_focus">lists/focus.png</texturefocus>
 			<texturenofocus>lists/separator.png</texturenofocus>
 		</control>
-		<include name="UpDownArrows">
+		<include content="UpDownArrows">
 			<param name="container_id" value="996" />
 			<param name="posx" value="201" />
 			<param name="up_posy" value="-40" />

--- a/addons/skin.estuary/1080i/DialogFavourites.xml
+++ b/addons/skin.estuary/1080i/DialogFavourites.xml
@@ -7,13 +7,13 @@
 	</coordinates>
 	<include>Animation_DialogPopupOpenClose</include>
 	<controls>
-		<include name="DialogBackgroundCommons">
+		<include content="DialogBackgroundCommons">
 			<param name="DialogBackgroundWidth" value="1500" />
 			<param name="DialogBackgroundHeight" value="800" />
 			<param name="DialogHeaderLabel" value="$LOCALIZE[1036]" />
 			<param name="DialogHeaderId" value="2" />
 		</include>
-		<include name="UpDownArrows">
+		<include content="UpDownArrows">
 			<param name="container_id" value="450" />
 			<param name="posx" value="726" />
 			<param name="up_posy" value="-40" />

--- a/addons/skin.estuary/1080i/DialogFullScreenInfo.xml
+++ b/addons/skin.estuary/1080i/DialogFullScreenInfo.xml
@@ -50,16 +50,16 @@
 				<orientation>horizontal</orientation>
 				<itemgap>10</itemgap>
 				<visible>Control.HasFocus(5552)</visible>
-				<include name="MediaFlag">
+				<include content="MediaFlag">
 					<param name="texture" value="$INFO[VideoPlayer.AudioChannels,flags/audiochannel/,.png]" />
 				</include>
-				<include name="MediaFlag">
+				<include content="MediaFlag">
 					<param name="texture" value="$INFO[VideoPlayer.AudioCodec,flags/audiocodec/,.png]" />
 				</include>
-				<include name="MediaFlag">
+				<include content="MediaFlag">
 					<param name="texture" value="$INFO[VideoPlayer.VideoAspect,flags/aspectratio/,.png]" />
 				</include>
-				<include name="MediaFlag">
+				<include content="MediaFlag">
 					<param name="texture" value="$INFO[VideoPlayer.VideoCodec,flags/videocodec/,.png]" />
 				</include>
 			</control>

--- a/addons/skin.estuary/1080i/DialogGameControllers.xml
+++ b/addons/skin.estuary/1080i/DialogGameControllers.xml
@@ -6,7 +6,7 @@
         <control type="group">
             <left>100</left>
             <top>200</top>
-            <include name="DialogBackgroundCommons">
+            <include content="DialogBackgroundCommons">
                 <param name="DialogBackgroundWidth" value="1720" />
                 <param name="DialogBackgroundHeight" value="690" />
                 <param name="DialogHeaderLabel" value="$LOCALIZE[35058]" />
@@ -116,22 +116,22 @@
                 <onleft>5</onleft>
                 <onright>3</onright>
                 <itemgap>-20</itemgap>
-                <include name="DefaultDialogButton">
+                <include content="DefaultDialogButton">
                     <param name="width" value="350" />
                     <param name="id" value="20" />
                     <param name="label" value="$LOCALIZE[21452]" />
                 </include>
-                <include name="DefaultDialogButton">
+                <include content="DefaultDialogButton">
                     <param name="width" value="350" />
                     <param name="id" value="19" />
                     <param name="label" value="$LOCALIZE[10035]" />
                 </include>
-                <include name="DefaultDialogButton">
+                <include content="DefaultDialogButton">
                     <param name="width" value="350" />
                     <param name="id" value="18" />
                     <param name="label" value="$LOCALIZE[186]" />
                 </include>
-                <include name="DefaultDialogButton">
+                <include content="DefaultDialogButton">
                     <param name="width" value="350" />
                     <param name="id" value="17" />
                     <param name="label" value="$LOCALIZE[10043]" />

--- a/addons/skin.estuary/1080i/DialogKeyboard.xml
+++ b/addons/skin.estuary/1080i/DialogKeyboard.xml
@@ -17,7 +17,7 @@
 			<animation type="Conditional" condition="!Control.HasFocus(502) + System.HasAddon(plugin.program.autocompletion)">
 				<effect type="slide" start="0,0" end="0,-80" time="700" tween="cubic" easing="inout" />
 			</animation>
-			<include name="DialogBackgroundCommons">
+			<include content="DialogBackgroundCommons">
 				<param name="DialogBackgroundWidth" value="1610" />
 				<param name="DialogBackgroundHeight" value="709" />
 				<param name="DialogHeaderLabel" value="" />

--- a/addons/skin.estuary/1080i/DialogMediaSource.xml
+++ b/addons/skin.estuary/1080i/DialogMediaSource.xml
@@ -7,7 +7,7 @@
 	</coordinates>
 	<include>Animation_DialogPopupOpenClose</include>
 	<controls>
-		<include name="DialogBackgroundCommons">
+		<include content="DialogBackgroundCommons">
 			<param name="DialogBackgroundWidth" value="1200" />
 			<param name="DialogBackgroundHeight" value="750" />
 			<param name="DialogHeaderLabel" value="$LOCALIZE[13406]" />
@@ -106,15 +106,15 @@
 			<onright>10</onright>
 			<ondown>12</ondown>
 			<itemgap>7</itemgap>
-			<include name="DefaultDialogButton">
+			<include content="DefaultDialogButton">
 				<param name="id" value="11" />
 				<param name="label" value="$LOCALIZE[1024]" />
 			</include>
-			<include name="DefaultDialogButton">
+			<include content="DefaultDialogButton">
 				<param name="id" value="13" />
 				<param name="label" value="$LOCALIZE[15019]" />
 			</include>
-			<include name="DefaultDialogButton">
+			<include content="DefaultDialogButton">
 				<param name="id" value="14" />
 				<param name="label" value="$LOCALIZE[1210]" />
 			</include>
@@ -151,11 +151,11 @@
 			<align>center</align>
 			<orientation>horizontal</orientation>
 			<onup>12</onup>
-			<include name="DefaultDialogButton">
+			<include content="DefaultDialogButton">
 				<param name="id" value="18" />
 				<param name="label" value="$LOCALIZE[186]" />
 			</include>
-			<include name="DefaultDialogButton">
+			<include content="DefaultDialogButton">
 				<param name="id" value="19" />
 				<param name="label" value="$LOCALIZE[222]" />
 			</include>

--- a/addons/skin.estuary/1080i/DialogMusicInfo.xml
+++ b/addons/skin.estuary/1080i/DialogMusicInfo.xml
@@ -290,7 +290,7 @@
 					<width>262</width>
 					<visible>String.IsEqual(ListItem.DBType,album) | String.IsEqual(ListItem.DBType,song)</visible>
 					<control type="button" id="7">
-						<include name="VideoInfoButtonsCommon">
+						<include content="VideoInfoButtonsCommon">
 							<param name="icon" value="" />
 						</include>
 						<label>$LOCALIZE[31033]</label>
@@ -319,7 +319,7 @@
 					</control>
 				</control>
 				<control type="radiobutton" id="120">
-					<include name="VideoInfoButtonsCommon">
+					<include content="VideoInfoButtonsCommon">
 						<param name="icon" value="icons/infodialogs/image.png" />
 					</include>
 					<label>$LOCALIZE[31028]</label>
@@ -328,24 +328,24 @@
 					<onclick>ActivateWindow(1104)</onclick>
 					<visible>String.IsEqual(ListItem.DBType,artist) | String.IsEqual(ListItem.DBType,album)</visible>
 				</control>
-				<include name="InfoDialogButton">
+				<include content="InfoDialogButton">
 					<param name="id" value="6" />
 					<param name="icon" value="icons/infodialogs/update.png" />
 					<param name="label" value="$LOCALIZE[184]" />
 				</include>
-				<include name="InfoDialogButton">
+				<include content="InfoDialogButton">
 					<param name="id" value="10" />
 					<param name="icon" value="icons/infodialogs/choose_image.png" />
 					<param name="label" value="$LOCALIZE[13405]" />
 				</include>
-				<include name="InfoDialogButton">
+				<include content="InfoDialogButton">
 					<param name="id" value="12" />
 					<param name="icon" value="icons/infodialogs/choose_image.png" />
 					<param name="label" value="$LOCALIZE[20413]" />
 				</include>
 				<control type="radiobutton" id="440">
 					<label>$LOCALIZE[31114]</label>
-					<include name="VideoInfoButtonsCommon">
+					<include content="VideoInfoButtonsCommon">
 						<param name="icon" value="icons/infodialogs/trailer.png" />
 					</include>
 					<onclick>Action(close)</onclick>
@@ -354,7 +354,7 @@
 					<onclick condition="String.IsEqual(ListItem.DBType,song)">RunScript(script.extendedinfo,info=youtubebrowser,id=$INFO[ListItem.Artist] $INFO[ListItem.Title])</onclick>
 				</control>
 			</control>
-			<include name="LeftRightArrows">
+			<include content="LeftRightArrows">
 				<param name="list_id" value="50" />
 				<param name="left_posx" value="574" />
 				<param name="right_posx" value="1780" />
@@ -364,7 +364,7 @@
 		</control>
 		<control type="group">
 			<visible>String.IsEqual(ListItem.DBType,artist)</visible>
-			<include name="InfoDialogTopBarInfo">
+			<include content="InfoDialogTopBarInfo">
 				<param name="main_label" value="$INFO[ListItem.Artist]" />
 				<param name="sub_label" value="$INFO[ListItem.Genre]" />
 				<param name="id" value="33333" />
@@ -372,7 +372,7 @@
 		</control>
 		<control type="group">
 			<visible>String.IsEqual(ListItem.DBType,album)</visible>
-			<include name="InfoDialogTopBarInfo">
+			<include content="InfoDialogTopBarInfo">
 				<param name="main_label" value="$INFO[ListItem.Album]$INFO[ListItem.Year, ([COLOR grey],[/COLOR])]" />
 				<param name="sub_label" value="$INFO[ListItem.Artist]" />
 				<param name="id" value="33334" />
@@ -380,7 +380,7 @@
 		</control>
 		<control type="group">
 			<visible>String.IsEqual(ListItem.DBType,song) + !Window.IsActive(musicinformation)</visible>
-			<include name="InfoDialogTopBarInfo">
+			<include content="InfoDialogTopBarInfo">
 				<param name="main_label" value="[COLOR button_focus]$INFO[ListItem.TrackNumber]. [/COLOR]$INFO[ListItem.Title]" />
 				<param name="sub_label" value="$INFO[ListItem.Artist,, - ]$INFO[ListItem.Album]$INFO[ListItem.Year, ([COLOR grey],[/COLOR])]" />
 				<param name="id" value="33335" />

--- a/addons/skin.estuary/1080i/DialogNumeric.xml
+++ b/addons/skin.estuary/1080i/DialogNumeric.xml
@@ -8,7 +8,7 @@
 		<top>213</top>
 	</coordinates>
 	<controls>
-		<include name="DialogBackgroundCommons">
+		<include content="DialogBackgroundCommons">
 			<param name="DialogBackgroundWidth" value="545" />
 			<param name="DialogBackgroundHeight" value="600" />
 			<param name="DialogHeaderLabel" value="" />

--- a/addons/skin.estuary/1080i/DialogPVRChannelManager.xml
+++ b/addons/skin.estuary/1080i/DialogPVRChannelManager.xml
@@ -7,7 +7,7 @@
 	</coordinates>
 	<include>Animation_DialogPopupOpenClose</include>
 	<controls>
-		<include name="DialogBackgroundCommons">
+		<include content="DialogBackgroundCommons">
 			<param name="DialogBackgroundWidth" value="1720" />
 			<param name="DialogBackgroundHeight" value="830" />
 			<param name="DialogHeaderLabel" value="$VAR[PVRChannelMgrHeader]" />
@@ -249,17 +249,17 @@
 			<onleft>9002</onleft>
 			<onright>20</onright>
 			<itemgap>-20</itemgap>
-			<include name="DefaultDialogButton">
+			<include content="DefaultDialogButton">
 				<param name="width" value="350" />
 				<param name="id" value="4" />
 				<param name="label" value="$LOCALIZE[186]" />
 			</include>
-			<include name="DefaultDialogButton">
+			<include content="DefaultDialogButton">
 				<param name="width" value="350" />
 				<param name="id" value="5" />
 				<param name="label" value="$LOCALIZE[14070]" />
 			</include>
-			<include name="DefaultDialogButton">
+			<include content="DefaultDialogButton">
 				<param name="width" value="350" />
 				<param name="id" value="6" />
 				<param name="label" value="$LOCALIZE[222]" />

--- a/addons/skin.estuary/1080i/DialogPVRGroupManager.xml
+++ b/addons/skin.estuary/1080i/DialogPVRGroupManager.xml
@@ -6,7 +6,7 @@
 		<control type="group">
 			<left>100</left>
 			<top>100</top>
-			<include name="DialogBackgroundCommons">
+			<include content="DialogBackgroundCommons">
 				<param name="DialogBackgroundWidth" value="1720" />
 				<param name="DialogBackgroundHeight" value="880" />
 				<param name="DialogHeaderLabel" value="$LOCALIZE[19143]" />
@@ -95,7 +95,7 @@
 					<onright>73</onright>
 					<pagecontrol>73</pagecontrol>
 					<scrolltime>200</scrolltime>
-					<include name="DefaultSimpleListLayout">
+					<include content="DefaultSimpleListLayout">
 						<param name="width" value="320" />
 						<param name="list_id" value="13" />
 					</include>
@@ -116,7 +116,7 @@
 				<description>Channels list</description>
 				<left>700</left>
 				<top>80</top>
-				<include name="ChannelManagerList">
+				<include content="ChannelManagerList">
 					<param name="header_id" value="21" />
 					<param name="list_id" value="11" />
 					<param name="scrollbar_id" value="71" />
@@ -128,7 +128,7 @@
 				<description>Grouped Channels list</description>
 				<left>1200</left>
 				<top>80</top>
-				<include name="ChannelManagerList">
+				<include content="ChannelManagerList">
 					<param name="header_id" value="22" />
 					<param name="list_id" value="12" />
 					<param name="scrollbar_id" value="72" />

--- a/addons/skin.estuary/1080i/DialogPVRGuideSearch.xml
+++ b/addons/skin.estuary/1080i/DialogPVRGuideSearch.xml
@@ -7,7 +7,7 @@
 	</coordinates>
 	<include>Animation_DialogPopupOpenClose</include>
 	<controls>
-		<include name="DialogBackgroundCommons">
+		<include content="DialogBackgroundCommons">
 			<param name="DialogBackgroundWidth" value="1720" />
 			<param name="DialogBackgroundHeight" value="780" />
 			<param name="DialogHeaderLabel" value="$LOCALIZE[19142]" />
@@ -165,15 +165,15 @@
 			<width>1320</width>
 			<align>left</align>
 			<orientation>vertical</orientation>
-			<include name="DefaultDialogButton">
+			<include content="DefaultDialogButton">
 				<param name="id" value="26" />
 				<param name="label" value="$LOCALIZE[137]" />
 			</include>
-			<include name="DefaultDialogButton">
+			<include content="DefaultDialogButton">
 				<param name="id" value="28" />
 				<param name="label" value="$LOCALIZE[10035]" />
 			</include>
-			<include name="DefaultDialogButton">
+			<include content="DefaultDialogButton">
 				<param name="id" value="25" />
 				<param name="label" value="$LOCALIZE[222]" />
 			</include>

--- a/addons/skin.estuary/1080i/DialogPVRInfo.xml
+++ b/addons/skin.estuary/1080i/DialogPVRInfo.xml
@@ -56,30 +56,30 @@
 				<onright>9000</onright>
 				<onup>49</onup>
 				<ondown>49</ondown>
-				<include name="InfoDialogButton">
+				<include content="InfoDialogButton">
 					<param name="id" value="5" />
 					<param name="icon" value="icons/infodialogs/launch.png" />
 					<param name="label" value="$LOCALIZE[19165]" />
 					<param name="visible" value="Window.IsActive(PVRGuideInfo)" />
 				</include>
-				<include name="InfoDialogButton">
+				<include content="InfoDialogButton">
 					<param name="id" value="4" />
 					<param name="icon" value="icons/infodialogs/similar.png" />
 					<param name="label" value="$LOCALIZE[19003]" />
 					<param name="visible" value="Window.IsActive(PVRGuideInfo)" />
 				</include>
-				<include name="InfoDialogButton">
+				<include content="InfoDialogButton">
 					<param name="id" value="8" />
 					<param name="icon" value="icons/infodialogs/play_record.png" />
 					<param name="label" value="$LOCALIZE[19687]" />
 					<param name="visible" value="Window.IsActive(PVRGuideInfo)" />
 				</include>
-				<include name="InfoDialogButton">
+				<include content="InfoDialogButton">
 					<param name="id" value="6" />
 					<param name="icon" value="icons/infodialogs/record.png" />
 					<param name="visible" value="Window.IsActive(PVRGuideInfo)" />
 				</include>
-				<include name="InfoDialogButton">
+				<include content="InfoDialogButton">
 					<param name="id" value="5010" />
 					<param name="icon" value="icons/infodialogs/play_record.png" />
 					<param name="label" value="$LOCALIZE[19687]" />
@@ -87,7 +87,7 @@
 					<param name="onclick_2" value="Action(select)" />
 					<param name="visible" value="Window.IsActive(PVRRecordingInfo)" />
 				</include>
-				<include name="InfoDialogButton">
+				<include content="InfoDialogButton">
 					<param name="id" value="440" />
 					<param name="icon" value="icons/infodialogs/trailer.png" />
 					<param name="label" value="$LOCALIZE[31114]" />
@@ -97,7 +97,7 @@
 				</include>
 			</control>
 		</control>
-		<include name="InfoDialogTopBarInfo">
+		<include content="InfoDialogTopBarInfo">
 			<param name="main_label" value="$INFO[ListItem.Title]$INFO[ListItem.Season, ]$INFO[ListItem.Episode,[COLOR grey]x[/COLOR]]" />
 			<param name="sub_label" value="$INFO[ListItem.ChannelName]" />
 			<param name="posy" value="40" />

--- a/addons/skin.estuary/1080i/DialogPVRRadioRDSInfo.xml
+++ b/addons/skin.estuary/1080i/DialogPVRRadioRDSInfo.xml
@@ -7,7 +7,7 @@
 	</coordinates>
 	<include>Animation_DialogPopupOpenClose</include>
 	<controls>
-		<include name="DialogBackgroundCommons">
+		<include content="DialogBackgroundCommons">
 			<param name="DialogBackgroundWidth" value="1300" />
 			<param name="DialogBackgroundHeight" value="920" />
 			<param name="DialogHeaderLabel" value="-" />
@@ -660,7 +660,7 @@
 			<onright>60</onright>
 			<onup>21</onup>
 			<ondown>21</ondown>
-			<include name="DefaultDialogButton">
+			<include content="DefaultDialogButton">
 				<param name="id" value="10" />
 				<param name="label" value="$LOCALIZE[186]" />
 			</include>

--- a/addons/skin.estuary/1080i/DialogPictureInfo.xml
+++ b/addons/skin.estuary/1080i/DialogPictureInfo.xml
@@ -34,7 +34,7 @@
 				<height>820</height>
 				<texture border="22">dialogs/dialog-bg.png</texture>
 			</control>
-			<include name="UpDownArrows">
+			<include content="UpDownArrows">
 				<param name="container_id" value="5" />
 				<param name="posx" value="1590" />
 				<param name="up_posy" value="-20" />
@@ -114,7 +114,7 @@
 			</control>
 			</control>
 		</control>
-		<include name="InfoDialogTopBarInfo">
+		<include content="InfoDialogTopBarInfo">
 			<param name="main_label" value="$INFO[ListItem.Label]" />
 			<param name="sub_label" value="$INFO[ListItem.PictureDateTime]" />
 		</include>

--- a/addons/skin.estuary/1080i/DialogSelect.xml
+++ b/addons/skin.estuary/1080i/DialogSelect.xml
@@ -9,7 +9,7 @@
 	<depth>DepthOSD</depth>
 	<controls>
 		<control type="group">
-			<include name="DialogBackgroundCommons">
+			<include content="DialogBackgroundCommons">
 				<param name="DialogBackgroundWidth" value="1220" />
 				<param name="DialogBackgroundHeight" value="742" />
 				<param name="DialogHeaderLabel" value="" />
@@ -33,7 +33,7 @@
 				<onright>61</onright>
 				<pagecontrol>61</pagecontrol>
 				<scrolltime>200</scrolltime>
-				<include name="DefaultSimpleListLayout">
+				<include content="DefaultSimpleListLayout">
 					<param name="width" value="880" />
 					<param name="height" value="69" />
 					<param name="list_id" value="3" />
@@ -161,11 +161,11 @@
 					<onleft>61</onleft>
 					<itemgap>-20</itemgap>
 					<onright>3</onright>
-					<include name="DefaultDialogButton">
+					<include content="DefaultDialogButton">
 						<param name="id" value="5" />
 						<param name="label" value="-" />
 					</include>
-					<include name="DefaultDialogButton">
+					<include content="DefaultDialogButton">
 						<param name="id" value="7" />
 						<param name="label" value="$LOCALIZE[222]" />
 						<param name="onclick" value="Dialog.Close(selectdialog)" />

--- a/addons/skin.estuary/1080i/DialogSettings.xml
+++ b/addons/skin.estuary/1080i/DialogSettings.xml
@@ -10,7 +10,7 @@
 		<control type="group">
 			<include>Animation_DialogPopupVisible</include>
 			<visible>!Window.IsVisible(sliderdialog)</visible>
-			<include name="DialogBackgroundCommons">
+			<include content="DialogBackgroundCommons">
 				<param name="DialogBackgroundWidth" value="1520" />
 				<param name="DialogBackgroundHeight" value="870" />
 				<param name="DialogHeaderLabel" value="-" />
@@ -71,15 +71,15 @@
 				<itemgap>-10</itemgap>
 				<onleft>5</onleft>
 				<onright>5</onright>
-				<include name="DefaultDialogButton">
+				<include content="DefaultDialogButton">
 					<param name="id" value="28" />
 					<param name="label" value="-" />
 				</include>
-				<include name="DefaultDialogButton">
+				<include content="DefaultDialogButton">
 					<param name="id" value="29" />
 					<param name="label" value="-" />
 				</include>
-				<include name="DefaultDialogButton">
+				<include content="DefaultDialogButton">
 					<param name="id" value="30" />
 					<param name="label" value="-" />
 				</include>

--- a/addons/skin.estuary/1080i/DialogSubtitles.xml
+++ b/addons/skin.estuary/1080i/DialogSubtitles.xml
@@ -7,7 +7,7 @@
 	<include>Animation_DialogPopupOpenClose</include>
 	<controls>
 		<control type="group" id="250">
-			<include name="DialogBackgroundCommons">
+			<include content="DialogBackgroundCommons">
 				<param name="DialogBackgroundWidth" value="1720" />
 				<param name="DialogBackgroundHeight" value="750" />
 				<param name="DialogHeaderLabel" value="$LOCALIZE[24012]" />
@@ -21,7 +21,7 @@
 					<onright>150</onright>
 					<onleft>73</onleft>
 					<orientation>vertical</orientation>
-					<include name="DefaultDialogButton">
+					<include content="DefaultDialogButton">
 						<param name="id" value="160" />
 						<param name="label" value="$LOCALIZE[24120]" />
 						<param name="width" value="420" />
@@ -278,7 +278,7 @@
 				<onup>150</onup>
 				<ondown>150</ondown>
 				<scrolltime>200</scrolltime>
-				<include name="DefaultSimpleListLayout">
+				<include content="DefaultSimpleListLayout">
 					<param name="width" value="320" />
 					<param name="height" value="80" />
 					<param name="list_id" value="150" />

--- a/addons/skin.estuary/1080i/DialogTextViewer.xml
+++ b/addons/skin.estuary/1080i/DialogTextViewer.xml
@@ -6,7 +6,7 @@
 		<control type="group">
 			<left>260</left>
 			<top>150</top>
-			<include name="DialogBackgroundCommons">
+			<include content="DialogBackgroundCommons">
 				<param name="DialogBackgroundWidth" value="1400" />
 				<param name="DialogBackgroundHeight" value="770" />
 				<param name="DialogHeaderLabel" value="$LOCALIZE[13406]" />

--- a/addons/skin.estuary/1080i/DialogVideoInfo.xml
+++ b/addons/skin.estuary/1080i/DialogVideoInfo.xml
@@ -147,67 +147,67 @@
 					<onup>50</onup>
 					<onright>140</onright>
 					<onleft>140</onleft>
-					<include name="InfoDialogMetadata">
+					<include content="InfoDialogMetadata">
 						<param name="control_id" value="147" />
 						<param name="label" value="$INFO[ListItem.Director,[COLOR button_focus]$LOCALIZE[20339]: [/COLOR]]" />
 						<param name="visible" value="!String.IsEmpty(ListItem.Director)" />
 					</include>
-					<include name="InfoDialogMetadata">
+					<include content="InfoDialogMetadata">
 						<param name="control_id" value="148" />
 						<param name="label" value="$INFO[ListItem.Writer,[COLOR button_focus]$LOCALIZE[20417]: [/COLOR]]" />
 						<param name="visible" value="!String.IsEmpty(ListItem.Writer)" />
 					</include>
-					<include name="InfoDialogMetadata">
+					<include content="InfoDialogMetadata">
 						<param name="control_id" value="149" />
 						<param name="label" value="[COLOR button_focus]$LOCALIZE[563]: [/COLOR]$INFO[ListItem.RatingAndVotes]" />
 						<param name="visible" value="!String.IsEmpty(ListItem.RatingAndVotes)" />
 					</include>
-					<include name="InfoDialogMetadata">
+					<include content="InfoDialogMetadata">
 						<param name="control_id" value="150" />
 						<param name="label" value="[COLOR button_focus]$LOCALIZE[515]: [/COLOR]$INFO[ListItem.Genre]" />
 						<param name="visible" value="!String.IsEmpty(ListItem.Genre) + Stringcompare(ListItem.DBType,movie)" />
 					</include>
-					<include name="InfoDialogMetadata">
+					<include content="InfoDialogMetadata">
 						<param name="control_id" value="151" />
 						<param name="label" value="[COLOR button_focus]$LOCALIZE[180]: [/COLOR]$INFO[ListItem.Duration] $LOCALIZE[31060]" />
 						<param name="visible" value="!String.IsEmpty(ListItem.Duration)" />
 					</include>
-					<include name="InfoDialogMetadata">
+					<include content="InfoDialogMetadata">
 						<param name="control_id" value="152" />
 						<param name="label" value="[COLOR button_focus]$LOCALIZE[21875]: [/COLOR]$INFO[ListItem.Country]" />
 						<param name="visible" value="!String.IsEmpty(ListItem.Country)" />
 					</include>
-					<include name="InfoDialogMetadata">
+					<include content="InfoDialogMetadata">
 						<param name="control_id" value="153" />
 						<param name="label" value="[COLOR button_focus]$LOCALIZE[29909]: [/COLOR]$INFO[ListItem.Studio]" />
 						<param name="visible" value="!String.IsEmpty(ListItem.Studio)" />
 					</include>
-					<include name="InfoDialogMetadata">
+					<include content="InfoDialogMetadata">
 						<param name="control_id" value="154" />
 						<param name="label" value="[COLOR button_focus]$LOCALIZE[20416]: [/COLOR]$INFO[ListItem.Premiered]" />
 						<param name="visible" value="!String.IsEmpty(ListItem.Premiered)" />
 					</include>
-					<include name="InfoDialogMetadata">
+					<include content="InfoDialogMetadata">
 						<param name="control_id" value="155" />
 						<param name="label" value="[COLOR button_focus]$LOCALIZE[31048]: [/COLOR]$INFO[ListItem.Season,, $LOCALIZE[36905]]$INFO[ListItem.Episode, (, $LOCALIZE[20453])]" />
 						<param name="visible" value="!String.IsEmpty(ListItem.Season) + !Stringcompare(ListItem.DBType,episode)" />
 					</include>
-					<include name="InfoDialogMetadata">
+					<include content="InfoDialogMetadata">
 						<param name="control_id" value="156" />
 						<param name="label" value="[COLOR button_focus]$LOCALIZE[31017]: [/COLOR]$INFO[ListItem.Mpaa]" />
 						<param name="visible" value="!String.IsEmpty(ListItem.Mpaa)" />
 					</include>
-					<include name="InfoDialogMetadata">
+					<include content="InfoDialogMetadata">
 						<param name="control_id" value="157" />
 						<param name="label" value="[COLOR button_focus]$LOCALIZE[20141]: [/COLOR]$INFO[ListItem.Set]" />
 						<param name="visible" value="!String.IsEmpty(ListItem.Set)" />
 					</include>
-					<include name="InfoDialogMetadata">
+					<include content="InfoDialogMetadata">
 						<param name="control_id" value="157" />
 						<param name="label" value="[COLOR button_focus]$LOCALIZE[20459]: [/COLOR]$INFO[ListItem.Tag]" />
 						<param name="visible" value="!String.IsEmpty(ListItem.Tag)" />
 					</include>
-					<include name="InfoDialogMetadata">
+					<include content="InfoDialogMetadata">
 						<param name="control_id" value="157" />
 						<param name="label" value="[COLOR button_focus]$LOCALIZE[126]: [/COLOR]$INFO[ListItem.Status]" />
 						<param name="visible" value="!String.IsEmpty(ListItem.Status)" />
@@ -381,18 +381,18 @@
 					<align>center</align>
 					<orientation>horizontal</orientation>
 					<scrolltime tween="quadratic">200</scrolltime>
-					<include name="InfoDialogButton">
+					<include content="InfoDialogButton">
 						<param name="id" value="8" />
 						<param name="icon" value="icons/infodialogs/play.png" />
 						<param name="label" value="$LOCALIZE[208]" />
 					</include>
-					<include name="InfoDialogButton">
+					<include content="InfoDialogButton">
 						<param name="id" value="11" />
 						<param name="icon" value="icons/infodialogs/trailer.png" />
 						<param name="label" value="$LOCALIZE[20410]" />
 						<param name="visible" value="!String.IsEmpty(ListItem.Trailer) + ![String.StartsWith(Container.FolderPath,plugin://) + String.Contains(Container.FolderPath,trailer)]" />
 					</include>
-					<include name="InfoDialogButton">
+					<include content="InfoDialogButton">
 						<param name="id" value="441" />
 						<param name="icon" value="icons/infodialogs/cinema.png" />
 						<param name="onclick_1" value="Dialog.Close(MovieInformation)" />
@@ -400,7 +400,7 @@
 						<param name="label" value="$LOCALIZE[31003]" />
 						<param name="visible" value="System.HasAddon(script.cinemavision) + [String.IsEqual(ListItem.DBType,movie) | String.IsEqual(ListItem.DBType,tvshow) | String.IsEqual(ListItem.DBType,season) | String.IsEqual(ListItem.DBType,episode)]" />
 					</include>
-					<include name="InfoDialogButton">
+					<include content="InfoDialogButton">
 						<param name="id" value="440" />
 						<param name="icon" value="icons/infodialogs/trailer.png" />
 						<param name="label" value="$LOCALIZE[31090]" />
@@ -412,7 +412,7 @@
 						<width>262</width>
 						<visible>Control.IsEnabled(7)</visible>
 						<control type="button" id="7">
-							<include name="VideoInfoButtonsCommon">
+							<include content="VideoInfoButtonsCommon">
 								<param name="icon" value="" />
 							</include>
 							<label>$LOCALIZE[31033]</label>
@@ -443,14 +443,14 @@
 							<visible>String.IsEmpty(ListItem.UserRating)</visible>
 						</control>
 					</control>
-					<include name="InfoDialogButton">
+					<include content="InfoDialogButton">
 						<param name="id" value="101" />
 						<param name="icon" value="icons/infodialogs/info.png" />
 						<param name="label" value="$LOCALIZE[31034]" />
 						<param name="onclick_1" value="RunScript(script.extendedinfo,info=openinfodialog)" />
 						<param name="visible" value="System.hasAddon(script.extendedinfo)" />
 					</include>
-					<include name="InfoDialogButton">
+					<include content="InfoDialogButton">
 						<param name="id" value="102" />
 						<param name="icon" value="icons/infodialogs/image.png" />
 						<param name="label" value="$LOCALIZE[31028]" />
@@ -458,32 +458,32 @@
 						<param name="onclick_2" value="ActivateWindow(1104)" />
 						<param name="visible" value="!String.IsEmpty(ListItem.Art(fanart))" />
 					</include>
-					<include name="InfoDialogButton">
+					<include content="InfoDialogButton">
 						<param name="id" value="13" />
 						<param name="icon" value="icons/infodialogs/director.png" />
 						<param name="label" value="$LOCALIZE[31123]" />
 						<param name="visible" value="!String.IsEmpty(ListItem.Director)" />
 					</include>
-					<include name="InfoDialogButton">
+					<include content="InfoDialogButton">
 						<param name="id" value="10" />
 						<param name="icon" value="icons/infodialogs/choose_image.png" />
 						<param name="label" value="$LOCALIZE[13511]" />
 					</include>
-					<include name="InfoDialogButton">
+					<include content="InfoDialogButton">
 						<param name="id" value="6" />
 						<param name="icon" value="icons/infodialogs/update.png" />
 						<param name="label" value="$LOCALIZE[184]" />
 						<param name="visible" value="Control.IsEnabled(6)" />
 					</include>
 				</control>
-				<include name="LeftRightArrows">
+				<include content="LeftRightArrows">
 					<param name="list_id" value="5000" />
 					<param name="left_posx" value="-15" />
 					<param name="right_posx" value="1240" />
 					<param name="posy" value="924" />
 					<param name="visible" value="true" />
 				</include>
-				<include name="LeftRightArrows">
+				<include content="LeftRightArrows">
 					<param name="list_id" value="50" />
 					<param name="left_posx" value="-15" />
 					<param name="right_posx" value="1240" />
@@ -536,7 +536,7 @@
 					</control>
 				</control>
 			</control>
-			<include name="InfoDialogTopBarInfo">
+			<include content="InfoDialogTopBarInfo">
 				<param name="main_label" value="$VAR[VideoInfoMainLabelVar]" />
 				<param name="sub_label" value="$VAR[VideoInfoSubLabelVar]" />
 			</include>

--- a/addons/skin.estuary/1080i/EventLog.xml
+++ b/addons/skin.estuary/1080i/EventLog.xml
@@ -39,7 +39,7 @@
 						<texture>icons/eventlog/order.png</texture>
 					</control>
 				</control>
-				<include name="PlaylistWindowButton">
+				<include content="PlaylistWindowButton">
 					<param name="control_id" value="21" />
 					<param name="onclick" value="" />
 					<param name="label" value="" />
@@ -55,7 +55,7 @@
 					<textoffsety>35</textoffsety>
 					<radioposx>-1</radioposx>
 				</control>
-				<include name="PlaylistWindowButton">
+				<include content="PlaylistWindowButton">
 					<param name="control_id" value="20" />
 					<param name="onclick" value="" />
 					<param name="label" value="$LOCALIZE[192]" />
@@ -204,7 +204,7 @@
 					</focusedlayout>
 				</control>
 			</control>
-			<include name="UpDownArrows">
+			<include content="UpDownArrows">
 				<param name="container_id" value="50" />
 				<param name="visible" value="!System.HasModalDialog" />
 			</include>
@@ -219,7 +219,7 @@
 				<visible>Control.IsVisible(50)</visible>
 			</control>
 		</control>
-		<include name="TopBar">
+		<include content="TopBar">
 			<param name="breadcrumbs_label" value="$LOCALIZE[31067]" />
 			<param name="breadcrumbs_icon" value="icons/settings/video.png" />
 		</include>

--- a/addons/skin.estuary/1080i/FileBrowser.xml
+++ b/addons/skin.estuary/1080i/FileBrowser.xml
@@ -6,7 +6,7 @@
 		<control type="group">
 			<left>310</left>
 			<top>100</top>
-			<include name="DialogBackgroundCommons">
+			<include content="DialogBackgroundCommons">
 				<param name="DialogBackgroundWidth" value="1300" />
 				<param name="DialogBackgroundHeight" value="850" />
 				<param name="DialogHeaderLabel" value="-" />
@@ -24,20 +24,20 @@
 				<onright>450</onright>
 				<onup>9000</onup>
 				<ondown>9000</ondown>
-				<include name="DefaultDialogButton">
+				<include content="DefaultDialogButton">
 					<param name="id" value="413" />
 					<param name="label" value="$LOCALIZE[186]" />
 				</include>
-				<include name="DefaultDialogButton">
+				<include content="DefaultDialogButton">
 					<param name="id" value="414" />
 					<param name="label" value="$LOCALIZE[222]" />
 				</include>
-				<include name="DefaultDialogButton">
+				<include content="DefaultDialogButton">
 					<param name="id" value="415" />
 					<param name="label" value="$LOCALIZE[119]" />
 					<param name="visible" value="Control.IsEnabled(415)" />
 				</include>
-				<include name="DefaultDialogButton">
+				<include content="DefaultDialogButton">
 					<param name="id" value="416" />
 					<param name="label" value="$LOCALIZE[749]" />
 					<param name="visible" value="Control.IsEnabled(416)" />
@@ -256,7 +256,7 @@
 				<visible>Control.IsVisible(451)</visible>
 			</control>
 		</control>
-		<include name="UpDownArrows">
+		<include content="UpDownArrows">
 			<param name="container_id" value="450" />
 			<param name="posx" value="830" />
 			<param name="up_posy" value="50" />

--- a/addons/skin.estuary/1080i/FileManager.xml
+++ b/addons/skin.estuary/1080i/FileManager.xml
@@ -17,7 +17,7 @@
 			<top>190</top>
 			<left>100</left>
 			<include>OpenClose_Left</include>
-			<include name="FileManagerPanel">
+			<include content="FileManagerPanel">
 				<param name="header_id" value="101" />
 				<param name="header_label" value="" />
 				<param name="list_id" value="20" />
@@ -33,7 +33,7 @@
 			<left>1020</left>
 			<top>190</top>
 			<include>OpenClose_Right</include>
-			<include name="FileManagerPanel">
+			<include content="FileManagerPanel">
 				<param name="header_id" value="102" />
 				<param name="header_label" value="" />
 				<param name="list_id" value="21" />
@@ -45,12 +45,12 @@
 				<param name="header_haspath" value="true" />
 			</include>
 		</control>
-		<include name="TopBar">
+		<include content="TopBar">
 			<param name="breadcrumbs_label" value="$LOCALIZE[7]" />
 			<param name="breadcrumbs_icon" value="icons/settings/filemanager.png" />
 		</include>
 		<include>BottomBar</include>
-		<include name="BottomBarTwoListInfo">
+		<include content="BottomBarTwoListInfo">
 			<param name="left_container_id">20</param>
 			<param name="left_scrollbar_id">60</param>
 			<param name="right_container_id">21</param>

--- a/addons/skin.estuary/1080i/Home.xml
+++ b/addons/skin.estuary/1080i/Home.xml
@@ -66,7 +66,7 @@
 						<height>922</height>
 						<scrolltime tween="cubic" easing="out">500</scrolltime>
 						<itemgap>-2</itemgap>
-						<include name="SubMenu">
+						<include content="SubMenu">
 							<param name="list_id" value="5900"/>
 							<param name="ondown_id" value="5100"/>
 							<param name="visible" value="Library.HasContent(movies)"/>
@@ -95,7 +95,7 @@
 							<param name="item8_icon" value="updatelibrary.png" />
 							<param name="item8_label" value="$LOCALIZE[653]" />
 						</include>
-						<include name="WidgetListMovies">
+						<include content="WidgetListMovies">
 							<param name="content_path" value="special://skin/playlists/inprogress_movies.xsp"/>
 							<param name="widget_header" value="$LOCALIZE[31010]"/>
 							<param name="widget_target" value="videos"/>
@@ -103,7 +103,7 @@
 							<param name="onup_id" value="5900"/>
 							<param name="ondown_id" value="5200"/>
 						</include>
-						<include name="WidgetListMovies">
+						<include content="WidgetListMovies">
 							<param name="content_path" value="videodb://recentlyaddedmovies/"/>
 							<param name="widget_header" value="$LOCALIZE[20386]"/>
 							<param name="widget_target" value="videos"/>
@@ -111,7 +111,7 @@
 							<param name="onup_id" value="5100"/>
 							<param name="ondown_id" value="5300"/>
 						</include>
-						<include name="WidgetListMovies">
+						<include content="WidgetListMovies">
 							<param name="content_path" value="special://skin/playlists/unwatched_movies.xsp"/>
 							<param name="widget_header" value="$LOCALIZE[31007]"/>
 							<param name="widget_target" value="videos"/>
@@ -119,7 +119,7 @@
 							<param name="onup_id" value="5200"/>
 							<param name="ondown_id" value="5400"/>
 						</include>
-						<include name="WidgetListMovies">
+						<include content="WidgetListMovies">
 							<param name="content_path" value="special://skin/playlists/random_movies.xsp"/>
 							<param name="widget_header" value="$LOCALIZE[31006]"/>
 							<param name="widget_target" value="videos"/>
@@ -127,11 +127,11 @@
 							<param name="onup_id" value="5300"/>
 							<param name="ondown_id" value="20001"/>
 						</include>
-						<include name="ImageWidgetHeader">
+						<include content="ImageWidgetHeader">
 							<param name="widget_header" value="$LOCALIZE[342]" />
 							<param name="visible" value="!Library.HasContent(movies)"/>
 						</include>
-						<include name="ImageWidget">
+						<include content="ImageWidget">
 							<param name="image_path" value="special://skin/extras/home-images/movie.jpg"/>
 							<param name="text_label" value="$LOCALIZE[31104]" />
 							<param name="button_label" value="$LOCALIZE[31110]" />
@@ -160,7 +160,7 @@
 						<orientation>vertical</orientation>
 						<height>922</height>
 						<scrolltime tween="cubic" easing="out">500</scrolltime>
-						<include name="SubMenu">
+						<include content="SubMenu">
 							<param name="list_id" value="6900"/>
 							<param name="ondown_id" value="6100"/>
 							<param name="visible" value="Library.HasContent(tvshows)"/>
@@ -189,7 +189,7 @@
 							<param name="item8_icon" value="updatelibrary.png" />
 							<param name="item8_label" value="$LOCALIZE[653]" />
 						</include>
-						<include name="WidgetListEpisodes">
+						<include content="WidgetListEpisodes">
 							<param name="content_path" value="videodb://inprogresstvshows"/>
 							<param name="sortby" value="lastplayed"/>
 							<param name="sortorder" value="descending"/>
@@ -201,7 +201,7 @@
 							<param name="onup_id" value="6900"/>
 							<param name="ondown_id" value="6200"/>
 						</include>
-						<include name="WidgetListEpisodes">
+						<include content="WidgetListEpisodes">
 							<param name="content_path" value="videodb://recentlyaddedepisodes/"/>
 							<param name="widget_header" value="$LOCALIZE[20387]"/>
 							<param name="item_image" value="$INFO[ListItem.Art(thumb)]" />
@@ -211,7 +211,7 @@
 							<param name="onup_id" value="6100"/>
 							<param name="ondown_id" value="6300"/>
 						</include>
-						<include name="WidgetListEpisodes">
+						<include content="WidgetListEpisodes">
 							<param name="content_path" value="special://skin/playlists/unwatched_tvshows.xsp"/>
 							<param name="widget_header" value="$LOCALIZE[31122]"/>
 							<param name="item_image" value="$VAR[TVShowWidgetImageVar]" />
@@ -221,11 +221,11 @@
 							<param name="onup_id" value="6200"/>
 							<param name="ondown_id" value="20001"/>
 						</include>
-						<include name="ImageWidgetHeader">
+						<include content="ImageWidgetHeader">
 							<param name="widget_header" value="$LOCALIZE[20343]" />
 							<param name="visible" value="!Library.HasContent(tvshows)"/>
 						</include>
-						<include name="ImageWidget">
+						<include content="ImageWidget">
 							<param name="image_path" value="special://skin/extras/home-images/tv.jpg"/>
 							<param name="text_label" value="$LOCALIZE[31104]" />
 							<param name="button_label" value="$LOCALIZE[31110]" />
@@ -253,7 +253,7 @@
 						<orientation>vertical</orientation>
 						<height>922</height>
 						<scrolltime tween="cubic" easing="out">500</scrolltime>
-						<include name="SubMenu">
+						<include content="SubMenu">
 							<param name="list_id" value="7900"/>
 							<param name="ondown_id" value="7100"/>
 							<param name="item1_onclick" value="ActivateWindow(Music,RecentlyAddedAlbums,return)" />
@@ -286,7 +286,7 @@
 							<param name="item8_label" value="$LOCALIZE[653]" />
 							<param name="item8_vis" value="Library.HasContent(music)" />
 						</include>
-						<include name="WidgetListSquare">
+						<include content="WidgetListSquare">
 							<param name="content_path" value="musicdb://recentlyplayedalbums"/>
 							<param name="widget_header" value="$LOCALIZE[517]"/>
 							<param name="widget_target" value="music"/>
@@ -294,7 +294,7 @@
 							<param name="onup_id" value="7900"/>
 							<param name="ondown_id" value="7200"/>
 						</include>
-						<include name="WidgetListSquare">
+						<include content="WidgetListSquare">
 							<param name="content_path" value="musicdb://recentlyaddedalbums/"/>
 							<param name="widget_header" value="$LOCALIZE[359]"/>
 							<param name="widget_target" value="music"/>
@@ -302,7 +302,7 @@
 							<param name="onup_id" value="7100"/>
 							<param name="ondown_id" value="7300"/>
 						</include>
-						<include name="WidgetListSquare">
+						<include content="WidgetListSquare">
 							<param name="content_path" value="special://skin/playlists/random_albums.xsp"/>
 							<param name="widget_header" value="$LOCALIZE[31012]"/>
 							<param name="widget_target" value="music"/>
@@ -310,7 +310,7 @@
 							<param name="onup_id" value="7200"/>
 							<param name="ondown_id" value="7400"/>
 						</include>
-						<include name="WidgetListSquare">
+						<include content="WidgetListSquare">
 							<param name="content_path" value="special://skin/playlists/random_artists.xsp"/>
 							<param name="widget_header" value="$LOCALIZE[31013]"/>
 							<param name="widget_target" value="music"/>
@@ -321,7 +321,7 @@
 							<param name="main_label" value=""/>
 							<param name="sub_label" value=""/>
 						</include>
-						<include name="WidgetListSquare">
+						<include content="WidgetListSquare">
 							<param name="content_path" value="special://skin/playlists/unplayed_albums.xsp"/>
 							<param name="widget_header" value="$LOCALIZE[31014]"/>
 							<param name="widget_target" value="music"/>
@@ -329,7 +329,7 @@
 							<param name="onup_id" value="7400"/>
 							<param name="ondown_id" value="7600"/>
 						</include>
-						<include name="WidgetListSquare">
+						<include content="WidgetListSquare">
 							<param name="content_path" value="special://skin/playlists/mostplayed_albums.xsp"/>
 							<param name="widget_header" value="$LOCALIZE[31011]"/>
 							<param name="widget_target" value="music"/>
@@ -339,7 +339,7 @@
 							<param name="sortby" value="playcount"/>
 							<param name="sortorder" value="descending"/>
 						</include>
-						<include name="ImageWidget">
+						<include content="ImageWidget">
 							<param name="image_path" value="special://skin/extras/home-images/music.jpg"/>
 							<param name="text_label" value="$LOCALIZE[31104]" />
 							<param name="button_label" value="$LOCALIZE[31110]" />
@@ -368,7 +368,7 @@
 						<orientation>vertical</orientation>
 						<height>922</height>
 						<scrolltime tween="cubic" easing="out">500</scrolltime>
-						<include name="SubMenu">
+						<include content="SubMenu">
 							<param name="list_id" value="8900"/>
 							<param name="ondown_id" value="8100"/>
 							<param name="item1_onclick" value="ActivateWindow(addonbrowser,root)" />
@@ -384,7 +384,7 @@
 							<param name="item7_vis" value="False" />
 							<param name="item8_vis" value="False" />
 						</include>
-						<include name="WidgetListSquare">
+						<include content="WidgetListSquare">
 							<param name="content_path" value="addons://sources/video/"/>
 							<param name="widget_header" value="$LOCALIZE[1037]"/>
 							<param name="widget_target" value="videos"/>
@@ -397,7 +397,7 @@
 							<param name="main_label" value=""/>
 							<param name="sub_label" value=""/>
 						</include>
-						<include name="WidgetListSquare">
+						<include content="WidgetListSquare">
 							<param name="content_path" value="addons://sources/audio/"/>
 							<param name="widget_header" value="$LOCALIZE[1038]"/>
 							<param name="widget_target" value="music"/>
@@ -410,7 +410,7 @@
 							<param name="main_label" value=""/>
 							<param name="sub_label" value=""/>
 						</include>
-						<include name="WidgetListSquare">
+						<include content="WidgetListSquare">
 							<param name="content_path" value="addons://sources/executable/"/>
 							<param name="widget_header" value="$LOCALIZE[1043]"/>
 							<param name="widget_target" value="programs"/>
@@ -423,7 +423,7 @@
 							<param name="main_label" value=""/>
 							<param name="sub_label" value=""/>
 						</include>
-						<include name="WidgetListSquare">
+						<include content="WidgetListSquare">
 							<param name="content_path" value="androidapp://sources/apps/"/>
 							<param name="widget_header" value="$LOCALIZE[20244]"/>
 							<param name="widget_target" value="programs"/>
@@ -437,7 +437,7 @@
 							<param name="sub_label" value=""/>
 							<param name="visible" value="System.Platform.Android"/>
 						</include>
-						<include name="WidgetListSquare">
+						<include content="WidgetListSquare">
 							<param name="content_path" value="addons://sources/image/"/>
 							<param name="widget_header" value="$LOCALIZE[1039]"/>
 							<param name="widget_target" value="pictures"/>
@@ -450,7 +450,7 @@
 							<param name="main_label" value=""/>
 							<param name="sub_label" value=""/>
 						</include>
-						<include name="ImageWidget">
+						<include content="ImageWidget">
 							<param name="image_path" value="special://skin/extras/home-images/add-ons.jpg"/>
 							<param name="text_label" value="$LOCALIZE[31119]" />
 							<param name="button_label" value="$LOCALIZE[31118]" />
@@ -479,7 +479,7 @@
 						<orientation>vertical</orientation>
 						<height>922</height>
 						<scrolltime tween="cubic" easing="out">500</scrolltime>
-						<include name="SubMenu">
+						<include content="SubMenu">
 							<param name="list_id" value="11900"/>
 							<param name="ondown_id" value="11100"/>
 							<param name="item1_onclick" value="ActivateWindow(Videos,Files,return)" />
@@ -500,7 +500,7 @@
 							<param name="item7_vis" value="False" />
 							<param name="item8_vis" value="False" />
 						</include>
-						<include name="WidgetListText">
+						<include content="WidgetListText">
 							<param name="content_path" value="sources://video/"/>
 							<param name="widget_header" value="$LOCALIZE[20094]"/>
 							<param name="widget_target" value="videos"/>
@@ -508,7 +508,7 @@
 							<param name="onup_id" value="11900"/>
 							<param name="ondown_id" value="11200"/>
 						</include>
-						<include name="WidgetListText">
+						<include content="WidgetListText">
 							<param name="content_path" value="special://videoplaylists/"/>
 							<param name="widget_header" value="$LOCALIZE[136]"/>
 							<param name="widget_target" value="videos"/>
@@ -517,7 +517,7 @@
 							<param name="ondown_id" value="20001"/>
 							<param name="icon" value="icons/defaulticons/DefaultPlaylist.png"/>
 						</include>
-						<include name="ImageWidget">
+						<include content="ImageWidget">
 							<param name="image_path" value="special://skin/extras/home-images/tv.jpg"/>
 							<param name="text_label" value="$LOCALIZE[31105]" />
 							<param name="button_label" value="$LOCALIZE[31110]" />
@@ -547,7 +547,7 @@
 						<height>922</height>
 						<scrolltime tween="cubic" easing="out">500</scrolltime>
 						<usecontrolcoords>true</usecontrolcoords>
-						<include name="SubMenu">
+						<include content="SubMenu">
 							<param name="list_id" value="12900"/>
 							<param name="ondown_id" value="12200"/>
 							<param name="item1_onclick" value="ActivateWindow(TVChannels)" />
@@ -571,7 +571,7 @@
 							<param name="item7_vis" value="False" />
 							<param name="item8_vis" value="False" />
 						</include>
-						<include name="WidgetListChannels" condition="PVR.HasTVChannels">
+						<include content="WidgetListChannels" condition="PVR.HasTVChannels">
 							<param name="content_path" value="pvr://channels/tv/All channels/"/>
 							<param name="widget_header" value="$LOCALIZE[31016]"/>
 							<param name="widget_target" value="pvr"/>
@@ -590,7 +590,7 @@
 							<control type="group">
 								<width>680</width>
 								<visible>PVR.IsRecording</visible>
-								<include name="PVRWidget">
+								<include content="PVRWidget">
 									<param name="icon" value="$INFO[PVR.NowRecordingChannelIcon]" />
 									<param name="header" value="$LOCALIZE[19158]" />
 									<param name="label1" value="$INFO[PVR.NowRecordingDateTime,$LOCALIZE[19126] - ]" />
@@ -600,7 +600,7 @@
 							<control type="group">
 								<visible>PVR.HasNonRecordingTimer</visible>
 								<width>680</width>
-								<include name="PVRWidget">
+								<include content="PVRWidget">
 									<param name="icon" value="$INFO[PVR.NextRecordingChannelIcon]" />
 									<param name="header" value="$LOCALIZE[19157]" />
 									<param name="label1" value="$INFO[PVR.NextRecordingDateTime,$LOCALIZE[19126] - ]" />
@@ -627,7 +627,7 @@
 						<orientation>vertical</orientation>
 						<height>922</height>
 						<scrolltime tween="cubic" easing="out">500</scrolltime>
-						<include name="SubMenu">
+						<include content="SubMenu">
 							<param name="list_id" value="13900"/>
 							<param name="ondown_id" value="13200"/>
 							<param name="item1_onclick" value="ActivateWindow(RadioChannels)" />
@@ -651,7 +651,7 @@
 							<param name="item7_vis" value="False" />
 							<param name="item8_vis" value="False" />
 						</include>
-						<include name="WidgetListChannels" condition="PVR.HasRadioChannels">
+						<include content="WidgetListChannels" condition="PVR.HasRadioChannels">
 							<param name="content_path" value="pvr://channels/radio/All channels/"/>
 							<param name="widget_header" value="$LOCALIZE[31018]"/>
 							<param name="widget_target" value="files"/>
@@ -679,7 +679,7 @@
 						<orientation>vertical</orientation>
 						<height>922</height>
 						<scrolltime tween="cubic" easing="out">500</scrolltime>
-						<include name="SubMenu">
+						<include content="SubMenu">
 							<param name="list_id" value="15900"/>
 							<param name="ondown_id" value="15100"/>
 							<param name="item1_onclick" value="Weather.Refresh" />
@@ -744,34 +744,34 @@
 								<orientation>horizontal</orientation>
 								<align>justify</align>
 								<itemgap>-50</itemgap>
-								<include name="WeatherIcon">
+								<include content="WeatherIcon">
 									<param name="label" value="Window(weather).Property(Current.Wind)" />
 									<param name="texture" value="icons/weather/wind.png" />
 									<param name="header" value="404" />
 								</include>
-								<include name="WeatherIcon">
+								<include content="WeatherIcon">
 									<param name="label" value="Window(weather).Property(Current.Humidity)" />
 									<param name="texture" value="icons/weather/humidity.png" />
 									<param name="header" value="406" />
 								</include>
-								<include name="WeatherIcon">
+								<include content="WeatherIcon">
 									<param name="label" value="Window(weather).Property(Current.Precipitation)" />
 									<param name="texture" value="icons/weather/rain.png" />
 									<param name="header" value="33021" />
 								</include>
-								<include name="WeatherIcon">
+								<include content="WeatherIcon">
 									<param name="label" value="Window(weather).Property(Today.Sunrise)" />
 									<param name="texture" value="icons/weather/sunrise.png" />
 									<param name="header" value="405" />
 								</include>
-								<include name="WeatherIcon">
+								<include content="WeatherIcon">
 									<param name="label" value="Window(weather).Property(Today.Sunset)" />
 									<param name="texture" value="icons/weather/sunset.png" />
 									<param name="header" value="403" />
 								</include>
 							</control>
 						</control>
-						<include name="WeatherWidget">
+						<include content="WeatherWidget">
 							<param name="content_include" value="HourlyItems" />
 							<param name="list_id" value="15100" />
 							<param name="onup_id" value="15900" />
@@ -779,7 +779,7 @@
 							<param name="widget_header" value="$LOCALIZE[33036]"/>
 							<param name="visible" value="!String.IsEmpty(Window(weather).Property(Hourly.IsFetched))" />
 						</include>
-						<include name="WeatherWidget">
+						<include content="WeatherWidget">
 							<param name="content_include" value="DailyItems" />
 							<param name="list_id" value="15200" />
 							<param name="onup_id" value="15100" />
@@ -787,11 +787,11 @@
 							<param name="widget_header" value="$LOCALIZE[31019]"/>
 							<param name="visible" value="!String.IsEmpty(Window(weather).Property(Daily.IsFetched))" />
 						</include>
-						<include name="ImageWidgetHeader">
+						<include content="ImageWidgetHeader">
 							<param name="widget_header" value="$LOCALIZE[12600]" />
 							<param name="visible" value="String.IsEmpty(Weather.plugin)"/>
 						</include>
-						<include name="ImageWidget">
+						<include content="ImageWidget">
 							<param name="image_path" value="special://skin/extras/home-images/weather.jpg"/>
 							<param name="text_label" value="$LOCALIZE[31120]" />
 							<param name="button_label" value="$LOCALIZE[31121]" />
@@ -808,11 +808,11 @@
 					<include>Visible_Right_Delayed</include>
 					<control type="grouplist" id="4001">
 						<orientation>vertical</orientation>
-						<include name="ImageWidgetHeader">
+						<include content="ImageWidgetHeader">
 							<param name="widget_header" value="$LOCALIZE[1]" />
 							<param name="visible" value="true"/>
 						</include>
-						<include name="ImageWidget">
+						<include content="ImageWidget">
 							<param name="image_path" value="special://skin/extras/home-images/pictures.jpg"/>
 							<param name="text_label" value="$LOCALIZE[31111]" />
 							<param name="button_label" value="" />
@@ -825,7 +825,7 @@
 					</control>
 				</control>
 			</control>
-			<include name="TopBar">
+			<include content="TopBar">
 				<param name="breadcrumbs_label" value="" />
 				<param name="breadcrumbs_icon" value="" />
 			</include>
@@ -1104,22 +1104,22 @@
 					<onup>9000</onup>
 					<ondown>14200</ondown>
 					<onright>2000</onright>
-					<include name="BottomMainMenuItem">
+					<include content="BottomMainMenuItem">
 						<param name="control_id" value="803" />
 						<param name="onclick" value="ActivateWindow(favourites)" />
 						<param name="icon" value="icons/favourites.png" />
 					</include>
-					<include name="BottomMainMenuItem">
+					<include content="BottomMainMenuItem">
 						<param name="control_id" value="801" />
 						<param name="onclick" value="ActivateWindow(filemanager)" />
 						<param name="icon" value="icons/filemanager.png" />
 					</include>
-					<include name="BottomMainMenuItem">
+					<include content="BottomMainMenuItem">
 						<param name="control_id" value="802" />
 						<param name="onclick" value="ActivateWindow(settings)" />
 						<param name="icon" value="icons/settings.png" />
 					</include>
-					<include name="BottomMainMenuItem">
+					<include content="BottomMainMenuItem">
 						<param name="control_id" value="804" />
 						<param name="onclick" value="ActivateWindow(shutdownmenu)" />
 						<param name="icon" value="icons/power.png" />

--- a/addons/skin.estuary/1080i/Includes.xml
+++ b/addons/skin.estuary/1080i/Includes.xml
@@ -407,10 +407,10 @@
 			<left>100</left>
 			<itemgap>5</itemgap>
 			<width>1720</width>
-			<include name="MediaFlag">
+			<include content="MediaFlag">
 				<param name="texture" value="$INFO[ListItem.AudioChannels,flags/audiochannel/,.png]" />
 			</include>
-			<include name="MediaFlag">
+			<include content="MediaFlag">
 				<param name="texture" value="$INFO[ListItem.AudioCodec,flags/audiocodec/,.png]" />
 			</include>
 		</control>
@@ -420,10 +420,10 @@
 			<itemgap>5</itemgap>
 			<width>1720</width>
 			<align>right</align>
-			<include name="MediaFlag">
+			<include content="MediaFlag">
 				<param name="texture" value="$INFO[ListItem.VideoAspect,flags/aspectratio/,.png]" />
 			</include>
-			<include name="MediaFlag">
+			<include content="MediaFlag">
 				<param name="texture" value="$VAR[ResolutionFlagVar]" />
 			</include>
 		</control>

--- a/addons/skin.estuary/1080i/Includes_Buttons.xml
+++ b/addons/skin.estuary/1080i/Includes_Buttons.xml
@@ -161,28 +161,28 @@
 					<ondown>700</ondown>
 					<onleft>50</onleft>
 					<onright>50</onright>
-					<include name="PlaylistWindowButton">
+					<include content="PlaylistWindowButton">
 						<param name="control_id" value="20" />
 						<param name="onclick" value="" />
 						<param name="label" value="$LOCALIZE[191]$INFO[Playlist.Random, : ]" />
 						<param name="icon" value="osd/fullscreen/buttons/random-on.png" />
 						<param name="width" value="$PARAM[width]" />
 					</include>
-					<include name="PlaylistWindowButton">
+					<include content="PlaylistWindowButton">
 						<param name="control_id" value="26" />
 						<param name="onclick" value="" />
 						<param name="label" value="" />
 						<param name="icon" value="osd/fullscreen/buttons/repeat-all.png" />
 						<param name="width" value="$PARAM[width]" />
 					</include>
-					<include name="PlaylistWindowButton">
+					<include content="PlaylistWindowButton">
 						<param name="control_id" value="21" />
 						<param name="onclick" value="" />
 						<param name="label" value="$LOCALIZE[190]" />
 						<param name="icon" value="icons/playlist/save.png" />
 						<param name="width" value="$PARAM[width]" />
 					</include>
-					<include name="PlaylistWindowButton">
+					<include content="PlaylistWindowButton">
 						<param name="control_id" value="22" />
 						<param name="onclick" value="" />
 						<param name="label" value="$LOCALIZE[192]" />

--- a/addons/skin.estuary/1080i/Includes_Home.xml
+++ b/addons/skin.estuary/1080i/Includes_Home.xml
@@ -166,7 +166,7 @@
 			<left>0</left>
 			<top>0</top>
 			<visible>Integer.IsGreater(Container($PARAM[list_id]).NumItems,0) | Container($PARAM[list_id]).IsUpdating</visible>
-			<include name="LeftRightArrows">
+			<include content="LeftRightArrows">
 				<param name="posy" value="221" />
 				<param name="list_id" value="$PARAM[list_id]" />
 			</include>
@@ -398,7 +398,7 @@
 				<left>0</left>
 				<top>0</top>
 				<visible>Integer.IsGreater(Container($PARAM[list_id]).NumItems,0) | Container($PARAM[list_id]).IsUpdating</visible>
-				<include name="LeftRightArrows">
+				<include content="LeftRightArrows">
 					<param name="posy" value="210" />
 					<param name="list_id" value="$PARAM[list_id]" />
 				</include>
@@ -557,7 +557,7 @@
 				<left>0</left>
 				<visible>$PARAM[visible]</visible>
 				<visible>Integer.IsGreater(Container($PARAM[list_id]).NumItems,0) | Container($PARAM[list_id]).IsUpdating</visible>
-				<include name="LeftRightArrows">
+				<include content="LeftRightArrows">
 					<param name="posy" value="200" />
 					<param name="list_id" value="$PARAM[list_id]" />
 				</include>
@@ -736,7 +736,7 @@
 					<label>$PARAM[widget_header]</label>
 					<shadowcolor>text_shadow</shadowcolor>
 				</control>
-				<include name="LeftRightArrows">
+				<include content="LeftRightArrows">
 					<param name="posy" value="200" />
 					<param name="list_id" value="$PARAM[list_id]" />
 				</include>
@@ -863,7 +863,7 @@
 					<label>$PARAM[widget_header]</label>
 					<shadowcolor>text_shadow</shadowcolor>
 				</control>
-				<include name="LeftRightArrows">
+				<include content="LeftRightArrows">
 					<param name="posy" value="300" />
 					<param name="list_id" value="$PARAM[list_id]" />
 				</include>
@@ -1138,34 +1138,34 @@
 				<onclick>noop</onclick>
 				<visible>String.IsEmpty(Window(weather).Property(Hourly.IsFetched))</visible>
 			</item>
-			<include name="WeatherHourlyItem">
+			<include content="WeatherHourlyItem">
 				<param name="item_index" value="1" />
 			</include>
-			<include name="WeatherHourlyItem">
+			<include content="WeatherHourlyItem">
 				<param name="item_index" value="2" />
 			</include>
-			<include name="WeatherHourlyItem">
+			<include content="WeatherHourlyItem">
 				<param name="item_index" value="3" />
 			</include>
-			<include name="WeatherHourlyItem">
+			<include content="WeatherHourlyItem">
 				<param name="item_index" value="4" />
 			</include>
-			<include name="WeatherHourlyItem">
+			<include content="WeatherHourlyItem">
 				<param name="item_index" value="5" />
 			</include>
-			<include name="WeatherHourlyItem">
+			<include content="WeatherHourlyItem">
 				<param name="item_index" value="6" />
 			</include>
-			<include name="WeatherHourlyItem">
+			<include content="WeatherHourlyItem">
 				<param name="item_index" value="7" />
 			</include>
-			<include name="WeatherHourlyItem">
+			<include content="WeatherHourlyItem">
 				<param name="item_index" value="8" />
 			</include>
-			<include name="WeatherHourlyItem">
+			<include content="WeatherHourlyItem">
 				<param name="item_index" value="9" />
 			</include>
-			<include name="WeatherHourlyItem">
+			<include content="WeatherHourlyItem">
 				<param name="item_index" value="10" />
 			</include>
 		</content>
@@ -1177,51 +1177,51 @@
 				<onclick>noop</onclick>
 				<visible>String.IsEmpty(Window(weather).Property(Daily.IsFetched))</visible>
 			</item>
-			<include name="WeatherDailyItem">
+			<include content="WeatherDailyItem">
 				<param name="item_index" value="1" />
 			</include>
-			<include name="WeatherDailyItem">
+			<include content="WeatherDailyItem">
 				<param name="item_index" value="2" />
 			</include>
-			<include name="WeatherDailyItem">
+			<include content="WeatherDailyItem">
 				<param name="item_index" value="3" />
 			</include>
-			<include name="WeatherDailyItem">
+			<include content="WeatherDailyItem">
 				<param name="item_index" value="4" />
 			</include>
-			<include name="WeatherDailyItem">
+			<include content="WeatherDailyItem">
 				<param name="item_index" value="5" />
 			</include>
-			<include name="WeatherDailyItem">
+			<include content="WeatherDailyItem">
 				<param name="item_index" value="6" />
 			</include>
-			<include name="WeatherDailyItem">
+			<include content="WeatherDailyItem">
 				<param name="item_index" value="7" />
 			</include>
-			<include name="WeatherDailyItem">
+			<include content="WeatherDailyItem">
 				<param name="item_index" value="8" />
 			</include>
-			<include name="WeatherDailyItem">
+			<include content="WeatherDailyItem">
 				<param name="item_index" value="9" />
 			</include>
-			<include name="WeatherDailyItem">
+			<include content="WeatherDailyItem">
 				<param name="item_index" value="10" />
 			</include>
-			<include name="WeatherDailyItem">
+			<include content="WeatherDailyItem">
 				<param name="item_index" value="11" />
 			</include>
-			<include name="WeatherDailyItem">
+			<include content="WeatherDailyItem">
 				<param name="item_index" value="12" />
 			</include>
-			<include name="WeatherDailyItem">
+			<include content="WeatherDailyItem">
 				<param name="item_index" value="13" />
 			</include>
-			<include name="WeatherDailyItem">
+			<include content="WeatherDailyItem">
 				<param name="item_index" value="14" />
 			</include>
 		</content>
 	</include>
-	<!-- <include name="WeatherDailyItem">
+	<!-- <include content="WeatherDailyItem">
 	     <item id="$PARAM[item_index]">
 	     <label>$INFO[Window(weather).Property(Daily.$PARAM[item_index].LongDay)]</label>
 	     <label2>$INFO[Window(weather).Property(Daily.$PARAM[item_index].LongDate)]</label2>

--- a/addons/skin.estuary/1080i/Includes_MediaMenu.xml
+++ b/addons/skin.estuary/1080i/Includes_MediaMenu.xml
@@ -89,32 +89,32 @@
 						<onup>14100</onup>
 						<ondown>6054</ondown>
 						<width>1000</width>
-						<include name="PVRQuickNavItemsCommon">
+						<include content="PVRQuickNavItemsCommon">
 							<param name="control_id" value="100" />
 							<param name="area" value="Channels" />
 							<param name="icon" value="icons/submenu/channels.png" />
 						</include>
-						<include name="PVRQuickNavItemsCommon">
+						<include content="PVRQuickNavItemsCommon">
 							<param name="control_id" value="101" />
 							<param name="area" value="Guide" />
 							<param name="icon" value="icons/submenu/guide.png" />
 						</include>
-						<include name="PVRQuickNavItemsCommon">
+						<include content="PVRQuickNavItemsCommon">
 							<param name="control_id" value="102" />
 							<param name="area" value="Recordings" />
 							<param name="icon" value="icons/submenu/recordings.png" />
 						</include>
-						<include name="PVRQuickNavItemsCommon">
+						<include content="PVRQuickNavItemsCommon">
 							<param name="control_id" value="103" />
 							<param name="area" value="Timers" />
 							<param name="icon" value="icons/submenu/timers.png" />
 						</include>
-						<include name="PVRQuickNavItemsCommon">
+						<include content="PVRQuickNavItemsCommon">
 							<param name="control_id" value="104" />
 							<param name="area" value="TimerRules" />
 							<param name="icon" value="icons/submenu/timer-rules.png" />
 						</include>
-						<include name="PVRQuickNavItemsCommon">
+						<include content="PVRQuickNavItemsCommon">
 							<param name="control_id" value="105" />
 							<param name="area" value="Search" />
 							<param name="icon" value="icons/submenu/tv-search.png" />
@@ -209,25 +209,25 @@
 						<ondown>6056</ondown>
 						<visible>Player.HasMedia + [$EXP[sidebar_focused]]</visible>
 						<visible>!System.HasModalDialog</visible>
-						<include name="BottomMainMenuItem">
+						<include content="BottomMainMenuItem">
 							<param name="control_id" value="14101" />
 							<param name="height" value="95" />
 							<param name="onclick" value="Pause" />
 							<param name="icon" value="icons/now-playing/pause.png" />
 						</include>
-						<include name="BottomMainMenuItem">
+						<include content="BottomMainMenuItem">
 							<param name="control_id" value="14102" />
 							<param name="height" value="95" />
 							<param name="onclick" value="Stop" />
 							<param name="icon" value="icons/now-playing/stop.png" />
 						</include>
-						<include name="BottomMainMenuItem">
+						<include content="BottomMainMenuItem">
 							<param name="control_id" value="14104" />
 							<param name="height" value="95" />
 							<param name="onclick" value="Next" />
 							<param name="icon" value="icons/now-playing/next.png" />
 						</include>
-						<include name="BottomMainMenuItem">
+						<include content="BottomMainMenuItem">
 							<param name="control_id" value="14105" />
 							<param name="height" value="95" />
 							<param name="onclick" value="Fullscreen" />
@@ -287,25 +287,25 @@
 			<onleft>14100</onleft>
 			<visible>Player.HasMedia + [$EXP[sidebar_focused]]</visible>
 			<visible>!System.HasModalDialog</visible>
-			<include name="BottomMainMenuItem">
+			<include content="BottomMainMenuItem">
 				<param name="control_id" value="14101" />
 				<param name="height" value="95" />
 				<param name="onclick" value="Pause" />
 				<param name="icon" value="icons/now-playing/pause.png" />
 			</include>
-			<include name="BottomMainMenuItem">
+			<include content="BottomMainMenuItem">
 				<param name="control_id" value="14102" />
 				<param name="height" value="95" />
 				<param name="onclick" value="Stop" />
 				<param name="icon" value="icons/now-playing/stop.png" />
 			</include>
-			<include name="BottomMainMenuItem">
+			<include content="BottomMainMenuItem">
 				<param name="control_id" value="14104" />
 				<param name="height" value="95" />
 				<param name="onclick" value="Next" />
 				<param name="icon" value="icons/now-playing/next.png" />
 			</include>
-			<include name="BottomMainMenuItem">
+			<include content="BottomMainMenuItem">
 				<param name="control_id" value="14105" />
 				<param name="height" value="95" />
 				<param name="onclick" value="Fullscreen" />

--- a/addons/skin.estuary/1080i/Includes_PVR.xml
+++ b/addons/skin.estuary/1080i/Includes_PVR.xml
@@ -276,7 +276,7 @@
 					</focusedlayout>
 				</control>
 			</control>
-			<include name="UpDownArrows">
+			<include content="UpDownArrows">
 				<param name="container_id" value="$PARAM[container_id]" />
 				<param name="posx" value="830" />
 				<param name="up_posy" value="-50" />

--- a/addons/skin.estuary/1080i/MusicOSD.xml
+++ b/addons/skin.estuary/1080i/MusicOSD.xml
@@ -32,7 +32,7 @@
 				<onleft>5000</onleft>
 				<onright>620</onright>
 				<control type="radiobutton" id="600">
-					<include name="OSDButton">
+					<include content="OSDButton">
 						<param name="texture" value="osd/fullscreen/buttons/previous.png"/>
 					</include>
 					<onclick>PlayerControl(Previous)</onclick>
@@ -54,13 +54,13 @@
 					<onclick>PlayerControl(Play)</onclick>
 				</control>
 				<control type="radiobutton" id="603">
-					<include name="OSDButton">
+					<include content="OSDButton">
 						<param name="texture" value="osd/fullscreen/buttons/stop.png"/>
 					</include>
 					<onclick>PlayerControl(Stop)</onclick>
 				</control>
 				<control type="radiobutton" id="605">
-					<include name="OSDButton">
+					<include content="OSDButton">
 						<param name="texture" value="osd/fullscreen/buttons/next.png"/>
 					</include>
 					<onclick>PlayerControl(Next)</onclick>
@@ -81,7 +81,7 @@
 				<onleft>605</onleft>
 				<onright>600</onright>
 				<control type="radiobutton" id="620">
-					<include name="OSDButton">
+					<include content="OSDButton">
 						<param name="texture" value="osd/fullscreen/buttons/rating.png"/>
 					</include>
 					<onclick>SetRating</onclick>
@@ -137,7 +137,7 @@
 					<onclick>PlayerControl(Random)</onclick>
 				</control>
 				<control type="radiobutton" id="703">
-					<include name="OSDButton">
+					<include content="OSDButton">
 						<param name="texture" value="osd/fullscreen/buttons/settings-subtitle.png"/>
 					</include>
 					<onclick>Close</onclick>
@@ -147,7 +147,7 @@
 					<onclick condition="String.IsEmpty(Skin.String(LyricScript_Path))">RunScript($INFO[Skin.String(LyricScript_Path)])</onclick>
 				</control>
 				<control type="radiobutton" id="5000">
-					<include name="OSDButton">
+					<include content="OSDButton">
 						<param name="texture" value="osd/fullscreen/buttons/settings.png"/>
 					</include>
 					<onclick>ActivateWindow(1105)</onclick>

--- a/addons/skin.estuary/1080i/MusicVisualisation.xml
+++ b/addons/skin.estuary/1080i/MusicVisualisation.xml
@@ -174,7 +174,7 @@
 			<visible>Player.ShowInfo | Window.IsActive(musicosd)</visible>
 			<animation effect="fade" start="0" end="100" time="200">Visible</animation>
 			<animation effect="fade" end="0" time="200">Hidden</animation>
-			<include name="TopBar">
+			<include content="TopBar">
 				<param name="breadcrumbs_label" value="$LOCALIZE[250]" />
 				<param name="breadcrumbs_icon" value="icons/settings/music.png" />
 			</include>

--- a/addons/skin.estuary/1080i/MyMusicNav.xml
+++ b/addons/skin.estuary/1080i/MyMusicNav.xml
@@ -113,11 +113,11 @@
 					<include>MediaMenuNowPlaying</include>
 				</control>
 			</control>
-			<include name="TopBar">
+			<include content="TopBar">
 				<param name="breadcrumbs_label" value="$LOCALIZE[2]" />
 				<param name="breadcrumbs_icon" value="icons/settings/music.png" />
 			</include>
-			<include name="BottomBar">
+			<include content="BottomBar">
 				<param name="info_visible" value="true" />
 			</include>
 		</control>

--- a/addons/skin.estuary/1080i/MyMusicPlaylistEditor.xml
+++ b/addons/skin.estuary/1080i/MyMusicPlaylistEditor.xml
@@ -14,21 +14,21 @@
 				<onleft>100</onleft>
 				<align>left</align>
 				<itemgap>-20</itemgap>
-				<include name="DefaultDialogButton">
+				<include content="DefaultDialogButton">
 					<param name="id" value="6" />
 					<param name="label" value="$LOCALIZE[502]" />
 					<param name="width" value="200" />
 					<param name="height" value="200" />
 					<param name="wrapmultiline" value="true" />
 				</include>
-				<include name="DefaultDialogButton">
+				<include content="DefaultDialogButton">
 					<param name="id" value="7" />
 					<param name="label" value="$LOCALIZE[190]" />
 					<param name="width" value="200" />
 					<param name="height" value="200" />
 					<param name="wrapmultiline" value="true" />
 				</include>
-				<include name="DefaultDialogButton">
+				<include content="DefaultDialogButton">
 					<param name="id" value="8" />
 					<param name="label" value="$LOCALIZE[192]" />
 					<param name="width" value="200" />
@@ -41,7 +41,7 @@
 			<include>OpenClose_Left</include>
 			<left>300</left>
 			<top>180</top>
-			<include name="FileManagerPanel">
+			<include content="FileManagerPanel">
 				<param name="header_id" value="22" />
 				<param name="header_label" value="$LOCALIZE[20094]" />
 				<param name="list_id" value="50" />
@@ -56,7 +56,7 @@
 			<include>OpenClose_Right</include>
 			<left>1070</left>
 			<top>180</top>
-			 <include name="FileManagerPanel">
+			 <include content="FileManagerPanel">
 				<param name="header_id" value="23" />
 				<param name="header_label" value="$LOCALIZE[13350]" />
 				<param name="list_id" value="100" />
@@ -67,12 +67,12 @@
 				<param name="bg_width" value="780" />
 			</include>
 		</control>
-		<include name="TopBar">
+		<include content="TopBar">
 			<param name="breadcrumbs_label" value="$LOCALIZE[10503][COLOR=button_focus][/COLOR]" />
 			<param name="breadcrumbs_icon" value="icons/settings/music.png" />
 		</include>
 		<include>BottomBar</include>
-		<include name="BottomBarTwoListInfo">
+		<include content="BottomBarTwoListInfo">
 			<param name="left_container_id">50</param>
 			<param name="left_scrollbar_id">60</param>
 			<param name="right_container_id">100</param>

--- a/addons/skin.estuary/1080i/MyPVRChannels.xml
+++ b/addons/skin.estuary/1080i/MyPVRChannels.xml
@@ -322,12 +322,12 @@
 				<visible>Control.IsVisible(50)</visible>
 				<include>Visible_Right</include>
 				<include>OpenClose_Right</include>
-				<include name="PVRInfoPanel">
+				<include content="PVRInfoPanel">
 					<param name="bottom_label1" value="$INFO[ListItem.NextTitle,[COLOR button_focus]$LOCALIZE[19031]:[/COLOR] ]" />
 					<param name="bottom_label2" value="$INFO[ListItem.NextStartTime]" />
 				</include>
 			</control>
-			<include name="UpDownArrows">
+			<include content="UpDownArrows">
 				<param name="container_id" value="50" />
 				<param name="posx" value="936" />
 				<param name="up_posy" value="132" />
@@ -339,7 +339,7 @@
 				<include>MediaMenuCommon</include>
 				<include>PVRSideBar</include>
 			</control>
-			<include name="TopBar">
+			<include content="TopBar">
 				<param name="breadcrumbs_label" value="TV$INFO[Control.GetLabel(29), / ]$INFO[Control.GetLabel(30), / ]" />
 				<param name="breadcrumbs_icon" value="icons/settings/tvremote.png" />
 			</include>

--- a/addons/skin.estuary/1080i/MyPVRGuide.xml
+++ b/addons/skin.estuary/1080i/MyPVRGuide.xml
@@ -202,11 +202,11 @@
 					</control>
 				</control>
 			</control>
-			<include name="PVRGuideListViewtype">
+			<include content="PVRGuideListViewtype">
 				<param name="container_id" value="11" />
 				<param name="container_name" value="19030" />
 			</include>
-			<include name="PVRGuideListViewtype">
+			<include content="PVRGuideListViewtype">
 				<param name="container_id" value="12" />
 				<param name="container_name" value="19031" />
 			</include>
@@ -324,22 +324,22 @@
 				<visible>Control.IsVisible(13)</visible>
 				<include>Visible_Right</include>
 				<include>OpenClose_Right</include>
-				<include name="PVRInfoPanel">
+				<include content="PVRInfoPanel">
 					<param name="bottom_label1" value="$INFO[ListItem.NextTitle,[COLOR button_focus]$LOCALIZE[19031]:[/COLOR] ]" />
 					<param name="bottom_label2" value="$INFO[ListItem.NextStartTime]" />
 				</include>
 			</control>
 			<control type="group">
 				<include>MediaMenuCommon</include>
-				<include name="PVRSideBar">
+				<include content="PVRSideBar">
 					<param name="group_label2" value="$INFO[Control.GetLabel(30)]" />
 				</include>
 			</control>
-			<include name="TopBar">
+			<include content="TopBar">
 				<param name="breadcrumbs_label" value="$INFO[Control.GetLabel(29)] - $INFO[Control.GetLabel(30)]" />
 				<param name="breadcrumbs_icon" value="icons/settings/tvguide.png" />
 			</include>
-			<include name="BottomBar">
+			<include content="BottomBar">
 				<param name="PageLabel" value="$INFO[Container.NumItems,$LOCALIZE[19019]: ]" />
 			</include>
 		</control>

--- a/addons/skin.estuary/1080i/MyPVRRecordings.xml
+++ b/addons/skin.estuary/1080i/MyPVRRecordings.xml
@@ -248,7 +248,7 @@
 						<left>-10</left>
 						<top>60</top>
 						<visible>ListItem.IsFolder</visible>
-						<include name="InfoList">
+						<include content="InfoList">
 							<param name="path" value="$INFO[ListItem.Path]/$INFO[ListItem.Label]" />
 							<param name="height" value="362" />
 							<param name="width" value="560" />
@@ -262,7 +262,7 @@
 				<include>MediaMenuCommon</include>
 				<include>PVRSideBar</include>
 			</control>
-			<include name="TopBar">
+			<include content="TopBar">
 				<param name="breadcrumbs_label" value="$LOCALIZE[19017]" />
 				<param name="breadcrumbs_icon" value="icons/settings/tvguide.png" />
 			</include>

--- a/addons/skin.estuary/1080i/MyPVRSearch.xml
+++ b/addons/skin.estuary/1080i/MyPVRSearch.xml
@@ -171,7 +171,7 @@
 				<visible>!String.IsEmpty(ListItem.Date)</visible>
 				<include>Visible_Right</include>
 				<include>OpenClose_Right</include>
-				<include name="PVRInfoPanel">
+				<include content="PVRInfoPanel">
 					<param name="bottom_label1" value="$INFO[ListItem.NextTitle,[COLOR button_focus]$LOCALIZE[19031]:[/COLOR] ]" />
 					<param name="bottom_label2" value="$INFO[ListItem.NextStartTime]" />
 				</include>
@@ -180,7 +180,7 @@
 				<include>MediaMenuCommon</include>
 				<include>PVRSideBar</include>
 			</control>
-			<include name="TopBar">
+			<include content="TopBar">
 				<param name="breadcrumbs_label" value="$LOCALIZE[137]" />
 				<param name="breadcrumbs_icon" value="icons/settings/tvguide.png" />
 			</include>

--- a/addons/skin.estuary/1080i/MyPVRTimers.xml
+++ b/addons/skin.estuary/1080i/MyPVRTimers.xml
@@ -170,7 +170,7 @@
 				<visible>!String.IsEmpty(ListItem.Date)</visible>
 				<include>Visible_Right</include>
 				<include>OpenClose_Right</include>
-				<include name="PVRInfoPanel">
+				<include content="PVRInfoPanel">
 					<param name="bottom_label1" value="$INFO[PVR.NextTimer]" />
 					<param name="bottom_label2" value="" />
 				</include>
@@ -180,7 +180,7 @@
 			<include>MediaMenuCommon</include>
 			<include>PVRSideBar</include>
 		</control>
-		<include name="TopBar">
+		<include content="TopBar">
 			<param name="breadcrumbs_label" value="$VAR[BreadcrumbsPVRTimerVar]" />
 			<param name="breadcrumbs_icon" value="icons/settings/tvguide.png" />
 		</include>

--- a/addons/skin.estuary/1080i/MyPics.xml
+++ b/addons/skin.estuary/1080i/MyPics.xml
@@ -43,147 +43,147 @@
 					<width>450</width>
 					<height>600</height>
 					<orientation>vertical</orientation>
-					<include name="PicsInfoLine">
+					<include content="PicsInfoLine">
 						<param name="label" value="$LOCALIZE[21820]"/>
 						<param name="value" value="ListItem.PictureDatetime" />
 					</include>
-					<include name="PicsInfoLine">
+					<include content="PicsInfoLine">
 						<param name="label" value="$LOCALIZE[21805]"/>
 						<param name="value" value="ListItem.PictureResolution" />
 					</include>
-					<include name="PicsInfoLine">
+					<include content="PicsInfoLine">
 						<param name="label" value="$LOCALIZE[21826]"/>
 						<param name="value" value="ListItem.PictureAperture" />
 					</include>
-					<include name="PicsInfoLine">
+					<include content="PicsInfoLine">
 						<param name="label" value="$LOCALIZE[21863]"/>
 						<param name="value" value="ListItem.PictureAuthor" />
 					</include>
-					<include name="PicsInfoLine">
+					<include content="PicsInfoLine">
 						<param name="label" value="$LOCALIZE[21867]"/>
 						<param name="value" value="ListItem.PictureByline" />
 					</include>
-					<include name="PicsInfoLine">
+					<include content="PicsInfoLine">
 						<param name="label" value="$LOCALIZE[21868]"/>
 						<param name="value" value="ListItem.PictureBylineTitle" />
 					</include>
-					<include name="PicsInfoLine">
+					<include content="PicsInfoLine">
 						<param name="label" value="$LOCALIZE[31041]"/>
 						<param name="value" value="ListItem.PictureCamMake" />
 					</include>
-					<include name="PicsInfoLine">
+					<include content="PicsInfoLine">
 						<param name="label" value="$LOCALIZE[21823]"/>
 						<param name="value" value="ListItem.PictureCamModel" />
 					</include>
-					<include name="PicsInfoLine">
+					<include content="PicsInfoLine">
 						<param name="label" value="$LOCALIZE[21862]"/>
 						<param name="value" value="ListItem.PictureCaption" />
 					</include>
-					<include name="PicsInfoLine">
+					<include content="PicsInfoLine">
 						<param name="label" value="$LOCALIZE[21866]"/>
 						<param name="value" value="ListItem.PictureCategory" />
 					</include>
-					<include name="PicsInfoLine">
+					<include content="PicsInfoLine">
 						<param name="label" value="$LOCALIZE[21839]"/>
 						<param name="value" value="ListItem.PictureCCDWidth" />
 					</include>
-					<include name="PicsInfoLine">
+					<include content="PicsInfoLine">
 						<param name="label" value="$LOCALIZE[21873]"/>
 						<param name="value" value="ListItem.PictureCity" />
 					</include>
-					<include name="PicsInfoLine">
+					<include content="PicsInfoLine">
 						<param name="label" value="$LOCALIZE[21807]"/>
 						<param name="value" value="ListItem.PictureColour" />
 					</include>
-					<include name="PicsInfoLine">
+					<include content="PicsInfoLine">
 						<param name="label" value="$LOCALIZE[21839]"/>
 						<param name="value" value="ListItem.PictureComment" />
 					</include>
-					<include name="PicsInfoLine">
+					<include content="PicsInfoLine">
 						<param name="label" value="$LOCALIZE[21871]"/>
 						<param name="value" value="ListItem.PictureCopyrightNotice" />
 					</include>
-					<include name="PicsInfoLine">
+					<include content="PicsInfoLine">
 						<param name="label" value="$LOCALIZE[21875]"/>
 						<param name="value" value="ListItem.PictureCountry" />
 					</include>
-					<include name="PicsInfoLine">
+					<include content="PicsInfoLine">
 						<param name="label" value="$LOCALIZE[21879]"/>
 						<param name="value" value="ListItem.PictureCountryCode" />
 					</include>
-					<include name="PicsInfoLine">
+					<include content="PicsInfoLine">
 						<param name="label" value="$LOCALIZE[21869]"/>
 						<param name="value" value="ListItem.PictureCredit" />
 					</include>
-					<include name="PicsInfoLine">
+					<include content="PicsInfoLine">
 						<param name="label" value="$LOCALIZE[21821]"/>
 						<param name="value" value="ListItem.PictureDesc" />
 					</include>
-					<include name="PicsInfoLine">
+					<include content="PicsInfoLine">
 						<param name="label" value="$LOCALIZE[21838]"/>
 						<param name="value" value="ListItem.PictureDigitalZoom" />
 					</include>
-					<include name="PicsInfoLine">
+					<include content="PicsInfoLine">
 						<param name="label" value="$LOCALIZE[21832]"/>
 						<param name="value" value="ListItem.PictureExpMode" />
 					</include>
-					<include name="PicsInfoLine">
+					<include content="PicsInfoLine">
 						<param name="label" value="$LOCALIZE[21829]"/>
 						<param name="value" value="ListItem.PictureExposure" />
 					</include>
-					<include name="PicsInfoLine">
+					<include content="PicsInfoLine">
 						<param name="label" value="$LOCALIZE[21831]"/>
 						<param name="value" value="ListItem.PictureExposureBias" />
 					</include>
-					<include name="PicsInfoLine">
+					<include content="PicsInfoLine">
 						<param name="label" value="$LOCALIZE[21830]"/>
 						<param name="value" value="ListItem.PictureExpTime" />
 					</include>
-					<include name="PicsInfoLine">
+					<include content="PicsInfoLine">
 						<param name="label" value="$LOCALIZE[21833]"/>
 						<param name="value" value="ListItem.PictureFlashUsed" />
 					</include>
-					<include name="PicsInfoLine">
+					<include content="PicsInfoLine">
 						<param name="label" value="$LOCALIZE[21827]"/>
 						<param name="value" value="ListItem.PictureFocalLen" />
 					</include>
-					<include name="PicsInfoLine">
+					<include content="PicsInfoLine">
 						<param name="label" value="$LOCALIZE[21828]"/>
 						<param name="value" value="ListItem.PictureFocusDist" />
 					</include>
-					<include name="PicsInfoLine">
+					<include content="PicsInfoLine">
 						<param name="label" value="$LOCALIZE[21840]"/>
 						<param name="value" value="ListItem.PictureGPSLat" />
 					</include>
-					<include name="PicsInfoLine">
+					<include content="PicsInfoLine">
 						<param name="label" value="$LOCALIZE[21841]"/>
 						<param name="value" value="ListItem.PictureGPSLon" />
 					</include>
-					<include name="PicsInfoLine">
+					<include content="PicsInfoLine">
 						<param name="label" value="$LOCALIZE[21842]"/>
 						<param name="value" value="ListItem.PictureGPSAlt" />
 					</include>
-					<include name="PicsInfoLine">
+					<include content="PicsInfoLine">
 						<param name="label" value="$LOCALIZE[21864]"/>
 						<param name="value" value="ListItem.PictureHeadline" />
 					</include>
-					<include name="PicsInfoLine">
+					<include content="PicsInfoLine">
 						<param name="label" value="$LOCALIZE[21858]"/>
 						<param name="value" value="ListItem.PictureImageType" />
 					</include>
-					<include name="PicsInfoLine">
+					<include content="PicsInfoLine">
 						<param name="label" value="$LOCALIZE[21837]"/>
 						<param name="value" value="ListItem.PictureISO" />
 					</include>
-					<include name="PicsInfoLine">
+					<include content="PicsInfoLine">
 						<param name="label" value="$LOCALIZE[21861]"/>
 						<param name="value" value="ListItem.PictureKeywords" />
 					</include>
-					<include name="PicsInfoLine">
+					<include content="PicsInfoLine">
 						<param name="label" value="$LOCALIZE[21843]"/>
 						<param name="value" value="$INFO[ListItem.PictureOrientation]" />
 					</include>
-					<include name="PicsInfoLine">
+					<include content="PicsInfoLine">
 						<param name="label" value="$LOCALIZE[21808]"/>
 						<param name="value" value="$INFO[ListItem.PictureProcess]" />
 					</include>
@@ -242,7 +242,7 @@
 					<include>MediaMenuNowPlaying</include>
 				</control>
 			</control>
-			<include name="TopBar">
+			<include content="TopBar">
 				<param name="breadcrumbs_label" value="$LOCALIZE[1213]" />
 				<param name="breadcrumbs_icon" value="icons/settings/pictures.png" />
 			</include>

--- a/addons/skin.estuary/1080i/MyPlaylist.xml
+++ b/addons/skin.estuary/1080i/MyPlaylist.xml
@@ -7,7 +7,7 @@
 		<include>DefaultBackground</include>
 		<control type="group">
 			<animation effect="fade" start="100" end="0" time="200" tween="sine" condition="$EXP[infodialog_active]">Conditional</animation>
-			<include name="PlaylistWindowButtons">
+			<include content="PlaylistWindowButtons">
 				<param name="width" value="400" />
 			</include>
 			<control type="group">
@@ -144,11 +144,11 @@
 				<include>MediaFlags</include>
 			</control>
 		</control>
-		<include name="TopBar" condition="Window.IsActive(videoplaylist)">
+		<include content="TopBar" condition="Window.IsActive(videoplaylist)">
 			<param name="breadcrumbs_label" value="$LOCALIZE[31065]" />
 			<param name="breadcrumbs_icon" value="icons/settings/video.png" />
 		</include>
-		<include name="TopBar" condition="Window.IsActive(musicplaylist)">
+		<include content="TopBar" condition="Window.IsActive(musicplaylist)">
 			<param name="breadcrumbs_label" value="$LOCALIZE[31066]" />
 			<param name="breadcrumbs_icon" value="icons/settings/music.png" />
 		</include>

--- a/addons/skin.estuary/1080i/MyPrograms.xml
+++ b/addons/skin.estuary/1080i/MyPrograms.xml
@@ -47,11 +47,11 @@
 				</control>
 				<include>MediaMenuNowPlaying</include>
 			</control>
-			<include name="TopBar">
+			<include content="TopBar">
 				<param name="breadcrumbs_label" value="$LOCALIZE[10001]" />
 				<param name="breadcrumbs_icon" value="icons/settings/addons.png" />
 			</include>
-			<include name="BottomBar">
+			<include content="BottomBar">
 				<param name="info_visible" value="true" />
 			</include>
 		</control>

--- a/addons/skin.estuary/1080i/MyVideoNav.xml
+++ b/addons/skin.estuary/1080i/MyVideoNav.xml
@@ -83,7 +83,7 @@
 					<left>1350</left>
 					<top>244</top>
 					<visible>ListItem.IsCollection</visible>
-					<include name="InfoList">
+					<include content="InfoList">
 						<param name="height" value="322" />
 						<param name="width" value="429" />
 						<param name="sortby" value="year" />
@@ -115,22 +115,22 @@
 						<orientation>horizontal</orientation>
 						<width>360</width>
 						<align>center</align>
-						<include name="InfoFlag">
+						<include content="InfoFlag">
 							<param name="visible" value="!String.IsEmpty(ListItem.duration)" />
 							<param name="icon" value="frame/clock.png" />
 							<param name="label" value="$INFO[ListItem.Duration,, $LOCALIZE[31132]]" />
 						</include>
-						<include name="InfoFlag">
+						<include content="InfoFlag">
 							<param name="visible" value="!String.IsEmpty(ListItem.Property(TotalEpisodes))" />
 							<param name="icon" value="lists/played-total.png" />
 							<param name="label" value="$INFO[ListItem.Property(WatchedEpisodes)]$INFO[ListItem.Property(TotalEpisodes), / ,]" />
 						</include>
-						<include name="InfoFlag">
+						<include content="InfoFlag">
 							<param name="visible" value="!String.IsEmpty(ListItem.Year) + String.IsEmpty(ListItem.Premiered)" />
 							<param name="icon" value="lists/year.png" />
 							<param name="label" value="$INFO[ListItem.Year]" />
 						</include>
-						<include name="InfoFlag">
+						<include content="InfoFlag">
 							<param name="visible" value="!String.IsEmpty(ListItem.Premiered) + String.IsEmpty(ListItem.Property(TotalEpisodes))" />
 							<param name="icon" value="lists/year.png" />
 							<param name="label" value="$INFO[ListItem.Premiered]" />
@@ -175,7 +175,7 @@
 				<control type="group">
 					<left>415</left>
 					<top>10</top>
-					<include name="UserRatingCircle">
+					<include content="UserRatingCircle">
 						<param name="animation" value="True" />
 					</include>
 					<visible>Control.IsVisible(51) | Control.IsVisible(50) | Control.IsVisible(55)</visible>
@@ -252,11 +252,11 @@
 					<include>MediaMenuNowPlaying</include>
 				</control>
 			</control>
-			<include name="TopBar">
+			<include content="TopBar">
 				<param name="breadcrumbs_label" value="$VAR[BreadcrumbsVideoVar]" />
 				<param name="breadcrumbs_icon" value="icons/settings/video.png" />
 			</include>
-			<include name="BottomBar">
+			<include content="BottomBar">
 				<param name="info_visible" value="true" />
 			</include>
 		</control>

--- a/addons/skin.estuary/1080i/MyWeather.xml
+++ b/addons/skin.estuary/1080i/MyWeather.xml
@@ -59,7 +59,7 @@
 				<ondown>20</ondown>
 				<onleft>16001</onleft>
 				<onright>16001</onright>
-				<include name="DefaultSimpleListLayout">
+				<include content="DefaultSimpleListLayout">
 					<param name="align" value="center" />
 					<param name="width" value="340" />
 					<param name="height" value="120" />
@@ -254,46 +254,46 @@
 					</control>
 				</itemlayout>
 				<content>
-					<include name="WeatherDailyItem">
+					<include content="WeatherDailyItem">
 						<param name="item_index" value="1" />
 					</include>
-					<include name="WeatherDailyItem">
+					<include content="WeatherDailyItem">
 						<param name="item_index" value="2" />
 					</include>
-					<include name="WeatherDailyItem">
+					<include content="WeatherDailyItem">
 						<param name="item_index" value="3" />
 					</include>
-					<include name="WeatherDailyItem">
+					<include content="WeatherDailyItem">
 						<param name="item_index" value="4" />
 					</include>
-					<include name="WeatherDailyItem">
+					<include content="WeatherDailyItem">
 						<param name="item_index" value="5" />
 					</include>
-					<include name="WeatherDailyItem">
+					<include content="WeatherDailyItem">
 						<param name="item_index" value="6" />
 					</include>
-					<include name="WeatherDailyItem">
+					<include content="WeatherDailyItem">
 						<param name="item_index" value="7" />
 					</include>
-					<include name="WeatherDailyItem">
+					<include content="WeatherDailyItem">
 						<param name="item_index" value="8" />
 					</include>
-					<include name="WeatherDailyItem">
+					<include content="WeatherDailyItem">
 						<param name="item_index" value="9" />
 					</include>
-					<include name="WeatherDailyItem">
+					<include content="WeatherDailyItem">
 						<param name="item_index" value="10" />
 					</include>
-					<include name="WeatherDailyItem">
+					<include content="WeatherDailyItem">
 						<param name="item_index" value="11" />
 					</include>
-					<include name="WeatherDailyItem">
+					<include content="WeatherDailyItem">
 						<param name="item_index" value="12" />
 					</include>
-					<include name="WeatherDailyItem">
+					<include content="WeatherDailyItem">
 						<param name="item_index" value="13" />
 					</include>
-					<include name="WeatherDailyItem">
+					<include content="WeatherDailyItem">
 						<param name="item_index" value="14" />
 					</include>
 				</content>
@@ -401,46 +401,46 @@
 					</control>
 				</itemlayout>
 				<content>
-					<include name="WeatherHourlyItem">
+					<include content="WeatherHourlyItem">
 						<param name="item_index" value="1" />
 					</include>
-					<include name="WeatherHourlyItem">
+					<include content="WeatherHourlyItem">
 						<param name="item_index" value="2" />
 					</include>
-					<include name="WeatherHourlyItem">
+					<include content="WeatherHourlyItem">
 						<param name="item_index" value="3" />
 					</include>
-					<include name="WeatherHourlyItem">
+					<include content="WeatherHourlyItem">
 						<param name="item_index" value="4" />
 					</include>
-					<include name="WeatherHourlyItem">
+					<include content="WeatherHourlyItem">
 						<param name="item_index" value="5" />
 					</include>
-					<include name="WeatherHourlyItem">
+					<include content="WeatherHourlyItem">
 						<param name="item_index" value="6" />
 					</include>
-					<include name="WeatherHourlyItem">
+					<include content="WeatherHourlyItem">
 						<param name="item_index" value="7" />
 					</include>
-					<include name="WeatherHourlyItem">
+					<include content="WeatherHourlyItem">
 						<param name="item_index" value="8" />
 					</include>
-					<include name="WeatherHourlyItem">
+					<include content="WeatherHourlyItem">
 						<param name="item_index" value="9" />
 					</include>
-					<include name="WeatherHourlyItem">
+					<include content="WeatherHourlyItem">
 						<param name="item_index" value="10" />
 					</include>
-					<include name="WeatherHourlyItem">
+					<include content="WeatherHourlyItem">
 						<param name="item_index" value="11" />
 					</include>
-					<include name="WeatherHourlyItem">
+					<include content="WeatherHourlyItem">
 						<param name="item_index" value="12" />
 					</include>
-					<include name="WeatherHourlyItem">
+					<include content="WeatherHourlyItem">
 						<param name="item_index" value="13" />
 					</include>
-					<include name="WeatherHourlyItem">
+					<include content="WeatherHourlyItem">
 						<param name="item_index" value="14" />
 					</include>
 				</content>
@@ -521,27 +521,27 @@
 					<top>650</top>
 					<left>70</left>
 					<orientation>horizontal</orientation>
-					<include name="WeatherIcon">
+					<include content="WeatherIcon">
 						<param name="label" value="Window(weather).Property(Current.Wind)" />
 						<param name="texture" value="icons/weather/wind.png" />
 						<param name="header" value="$LOCALIZE[404]" />
 					</include>
-					<include name="WeatherIcon">
+					<include content="WeatherIcon">
 						<param name="label" value="Window(weather).Property(Current.Humidity)" />
 						<param name="texture" value="icons/weather/humidity.png" />
 						<param name="header" value="$LOCALIZE[406]" />
 					</include>
-					<include name="WeatherIcon">
+					<include content="WeatherIcon">
 						<param name="label" value="Window(weather).Property(Current.Precipitation)" />
 						<param name="texture" value="icons/weather/rain.png" />
 						<param name="header" value="$LOCALIZE[33021]" />
 					</include>
-					<include name="WeatherIcon">
+					<include content="WeatherIcon">
 						<param name="label" value="Window(weather).Property(Today.Sunrise)" />
 						<param name="texture" value="icons/weather/sunrise.png" />
 						<param name="header" value="$LOCALIZE[405]" />
 					</include>
-					<include name="WeatherIcon">
+					<include content="WeatherIcon">
 						<param name="label" value="Window(weather).Property(Today.Sunset)" />
 						<param name="texture" value="icons/weather/sunset.png" />
 						<param name="header" value="$LOCALIZE[403]" />
@@ -653,25 +653,25 @@
 					</control>
 				</focusedlayout>
 				<content>
-					<include name="WeatherMapItem">
+					<include content="WeatherMapItem">
 						<param name="item_id" value="1" />
 					</include>
-					<include name="WeatherMapItem">
+					<include content="WeatherMapItem">
 						<param name="item_id" value="2" />
 					</include>
-					<include name="WeatherMapItem">
+					<include content="WeatherMapItem">
 						<param name="item_id" value="3" />
 					</include>
-					<include name="WeatherMapItem">
+					<include content="WeatherMapItem">
 						<param name="item_id" value="4" />
 					</include>
-					<include name="WeatherMapItem">
+					<include content="WeatherMapItem">
 						<param name="item_id" value="5" />
 					</include>
 				</content>
 			</control>
 		</control>
-		<include name="TopBar">
+		<include content="TopBar">
 			<param name="breadcrumbs_label" value="$LOCALIZE[8]" />
 			<param name="breadcrumbs_icon" value="icons/settings/weather.png" />
 		</include>

--- a/addons/skin.estuary/1080i/PlayerControls.xml
+++ b/addons/skin.estuary/1080i/PlayerControls.xml
@@ -8,7 +8,7 @@
 	</coordinates>
 	<include>Animation_DialogPopupOpenClose</include>
 	<controls>
-		<include name="DialogBackgroundCommons">
+		<include content="DialogBackgroundCommons">
 			<param name="DialogBackgroundWidth" value="1115" />
 			<param name="DialogBackgroundHeight" value="380" />
 			<param name="DialogHeaderLabel" value="16003" />
@@ -137,7 +137,7 @@
 			<orientation>horizontal</orientation>
 			<onup>87</onup>
 			<control type="radiobutton" id="600">
-				<include name="OSDButton">
+				<include content="OSDButton">
 					<param name="texture" value="osd/fullscreen/buttons/previous.png"/>
 				</include>
 				<onclick>PlayerControl(Previous)</onclick>
@@ -160,13 +160,13 @@
 				<onclick>PlayerControl(Play)</onclick>
 			</control>
 			<control type="radiobutton" id="603">
-				<include name="OSDButton">
+				<include content="OSDButton">
 					<param name="texture" value="osd/fullscreen/buttons/stop.png"/>
 				</include>
 				<onclick>PlayerControl(Stop)</onclick>
 			</control>
 			<control type="radiobutton" id="605">
-				<include name="OSDButton">
+				<include content="OSDButton">
 					<param name="texture" value="osd/fullscreen/buttons/next.png"/>
 				</include>
 				<onclick>PlayerControl(Next)</onclick>

--- a/addons/skin.estuary/1080i/Settings.xml
+++ b/addons/skin.estuary/1080i/Settings.xml
@@ -153,7 +153,7 @@
 				</item>
 			</content>
 		</control>
-		<include name="TopBar">
+		<include content="TopBar">
 			<param name="breadcrumbs_label" value="$LOCALIZE[5]" />
 			<param name="breadcrumbs_icon" value="icons/settings/settings.png" />
 		</include>

--- a/addons/skin.estuary/1080i/SettingsCategory.xml
+++ b/addons/skin.estuary/1080i/SettingsCategory.xml
@@ -143,7 +143,7 @@
 			<textcolor>grey</textcolor>
 			<shadowcolor>black</shadowcolor>
 		</control>
-		<include name="UpDownArrows">
+		<include content="UpDownArrows">
 			<param name="container_id" value="5" />
 			<param name="posx" value="1141" />
 			<param name="up_posy" value="105" />
@@ -159,7 +159,7 @@
 			<aspectratio>keep</aspectratio>
 			<texture>icon_system.png</texture>
 		</control>
-		<include name="TopBar">
+		<include content="TopBar">
 			<param name="breadcrumbs_label" value="$LOCALIZE[5]$INFO[Control.GetLabel(2), / ]" />
 			<param name="breadcrumbs_icon" value="$VAR[SettingsSectionIcon]" />
 		</include>

--- a/addons/skin.estuary/1080i/SettingsProfile.xml
+++ b/addons/skin.estuary/1080i/SettingsProfile.xml
@@ -201,7 +201,7 @@
 				</control>
 			</control>
 		</control>
-		<include name="TopBar">
+		<include content="TopBar">
 			<param name="breadcrumbs_label" value="$LOCALIZE[10034]" />
 			<param name="breadcrumbs_icon" value="icons/settings/profiles.png" />
 		</include>

--- a/addons/skin.estuary/1080i/SettingsSystemInfo.xml
+++ b/addons/skin.estuary/1080i/SettingsSystemInfo.xml
@@ -23,7 +23,7 @@
 				<ondown>9000</ondown>
 				<control type="button" id="95">
 					<description>Button Summary Values</description>
-					<include name="DefaultSettingButton">
+					<include content="DefaultSettingButton">
 						<param name="height" value="88" />
 					</include>
 					<width>400</width>
@@ -31,7 +31,7 @@
 				</control>
 				<control type="button" id="94">
 					<description>Button Storage</description>
-					<include name="DefaultSettingButton">
+					<include content="DefaultSettingButton">
 						<param name="height" value="88" />
 					</include>
 					<width>400</width>
@@ -39,7 +39,7 @@
 				</control>
 				<control type="button" id="96">
 					<description>Button Network</description>
-					<include name="DefaultSettingButton">
+					<include content="DefaultSettingButton">
 						<param name="height" value="88" />
 					</include>
 					<width>400</width>
@@ -47,7 +47,7 @@
 				</control>
 				<control type="button" id="97">
 					<description>Button Video</description>
-					<include name="DefaultSettingButton">
+					<include content="DefaultSettingButton">
 						<param name="height" value="88" />
 					</include>
 					<width>400</width>
@@ -55,7 +55,7 @@
 				</control>
 				<control type="button" id="98">
 					<description>Button Hardware</description>
-					<include name="DefaultSettingButton">
+					<include content="DefaultSettingButton">
 						<param name="height" value="88" />
 					</include>
 					<width>400</width>
@@ -63,7 +63,7 @@
 				</control>
 				<control type="button" id="99">
 					<description>Button PVR</description>
-					<include name="DefaultSettingButton">
+					<include content="DefaultSettingButton">
 						<param name="height" value="88" />
 					</include>
 					<width>400</width>
@@ -243,7 +243,7 @@
 				</control>
 			</control>
 		</control>
-		<include name="TopBar">
+		<include content="TopBar">
 			<param name="breadcrumbs_label" value="$LOCALIZE[130]" />
 			<param name="breadcrumbs_icon" value="icons/settings/system.png" />
 		</include>

--- a/addons/skin.estuary/1080i/SkinSettings.xml
+++ b/addons/skin.estuary/1080i/SkinSettings.xml
@@ -25,7 +25,7 @@
 				<onright>10000</onright>
 				<onup>9000</onup>
 				<ondown>9000</ondown>
-				<include name="DefaultSimpleListLayout">
+				<include content="DefaultSimpleListLayout">
 					<param name="align" value="center" />
 					<param name="width" value="400" />
 					<param name="height" value="120" />
@@ -60,7 +60,7 @@
 				<height>3</height>
 				<texture colordiffuse="button_focus" border="2">dialogs/separator.png</texture>
 			</control>
-			<include name="UpDownArrows">
+			<include content="UpDownArrows">
 				<param name="container_id" value="600" />
 				<param name="posx" value="1045" />
 				<param name="up_posy" value="130" />
@@ -210,7 +210,7 @@
 				<autoscroll time="3000" delay="4000" repeat="5000">true</autoscroll>
 			</control>
 		</control>
-		<include name="TopBar">
+		<include content="TopBar">
 			<param name="breadcrumbs_label" value="$LOCALIZE[5] / $LOCALIZE[20077]" />
 			<param name="breadcrumbs_icon" value="icons/settings/skin.png" />
 		</include>

--- a/addons/skin.estuary/1080i/SmartPlaylistEditor.xml
+++ b/addons/skin.estuary/1080i/SmartPlaylistEditor.xml
@@ -8,7 +8,7 @@
 	<include>Animation_DialogPopupOpenClose</include>
 	<controls>
 		<control type="group">
-			<include name="DialogBackgroundCommons">
+			<include content="DialogBackgroundCommons">
 				<param name="DialogBackgroundWidth" value="1300" />
 				<param name="DialogBackgroundHeight" value="920" />
 				<param name="DialogHeaderLabel" value="-" />
@@ -86,11 +86,11 @@
 				<top>820</top>
 				<onup>24</onup>
 				<ondown>22</ondown>
-				<include name="DefaultDialogButton">
+				<include content="DefaultDialogButton">
 					<param name="id" value="20" />
 					<param name="label" value="$LOCALIZE[186]" />
 				</include>
-				<include name="DefaultDialogButton">
+				<include content="DefaultDialogButton">
 					<param name="id" value="21" />
 					<param name="label" value="$LOCALIZE[222]" />
 				</include>
@@ -112,7 +112,7 @@
 				<onright>500</onright>
 				<ondown>9001</ondown>
 				<onup>9001</onup>
-				<include name="DefaultSimpleListLayout">
+				<include content="DefaultSimpleListLayout">
 					<param name="width" value="600" />
 					<param name="list_id" value="10" />
 				</include>

--- a/addons/skin.estuary/1080i/SmartPlaylistRule.xml
+++ b/addons/skin.estuary/1080i/SmartPlaylistRule.xml
@@ -7,7 +7,7 @@
 	</coordinates>
 	<include>Animation_DialogPopupOpenClose</include>
 	<controls>
-		<include name="DialogBackgroundCommons">
+		<include content="DialogBackgroundCommons">
 			<param name="DialogBackgroundWidth" value="960" />
 			<param name="DialogBackgroundHeight" value="500" />
 			<param name="DialogHeaderLabel" value="$LOCALIZE[21421]" />
@@ -65,11 +65,11 @@
 			<align>center</align>
 			<onup>9002</onup>
 			<ondown>15</ondown>
-			<include name="DefaultDialogButton">
+			<include content="DefaultDialogButton">
 				<param name="id" value="18" />
 				<param name="label" value="$LOCALIZE[186]" />
 			</include>
-			<include name="DefaultDialogButton">
+			<include content="DefaultDialogButton">
 				<param name="id" value="19" />
 				<param name="label" value="$LOCALIZE[222]" />
 			</include>

--- a/addons/skin.estuary/1080i/VideoFullScreen.xml
+++ b/addons/skin.estuary/1080i/VideoFullScreen.xml
@@ -54,15 +54,15 @@
 					<orientation>vertical</orientation>
 					<left>20</left>
 					<top>90</top>
-					<include name="LeftRightAlignedInfoLine">
+					<include content="LeftRightAlignedInfoLine">
 						<param name="label" value="$LOCALIZE[19012]" />
 						<param name="value" value="$INFO[PVR.ActStreamClient]" />
 					</include>
-					<include name="LeftRightAlignedInfoLine">
+					<include content="LeftRightAlignedInfoLine">
 						<param name="label" value="$LOCALIZE[19006]" />
 						<param name="value" value="$INFO[PVR.ActStreamDevice]" />
 					</include>
-					<include name="LeftRightAlignedInfoLine">
+					<include content="LeftRightAlignedInfoLine">
 						<param name="label" value="$LOCALIZE[19007]" />
 						<param name="value" value="$INFO[PVR.ActStreamStatus]" />
 					</include>
@@ -106,15 +106,15 @@
 					<orientation>vertical</orientation>
 					<left>800</left>
 					<top>90</top>
-					<include name="LeftRightAlignedInfoLine">
+					<include content="LeftRightAlignedInfoLine">
 						<param name="label" value="$LOCALIZE[19010]" />
 						<param name="value" value="$INFO[PVR.ActStreamBER]" />
 					</include>
-					<include name="LeftRightAlignedInfoLine">
+					<include content="LeftRightAlignedInfoLine">
 						<param name="label" value="$LOCALIZE[19011]" />
 						<param name="value" value="$INFO[PVR.ActStreamUNC]" />
 					</include>
-					<include name="LeftRightAlignedInfoLine">
+					<include content="LeftRightAlignedInfoLine">
 						<param name="label" value="$LOCALIZE[19015]" />
 						<param name="value" value="$INFO[PVR.ActStreamEncryptionName]" />
 					</include>

--- a/addons/skin.estuary/1080i/VideoOSD.xml
+++ b/addons/skin.estuary/1080i/VideoOSD.xml
@@ -67,7 +67,7 @@
 					<onleft>70043</onleft>
 					<onright>70011</onright>
 					<control type="radiobutton" id="600">
-						<include name="OSDButton">
+						<include content="OSDButton">
 							<param name="texture" value="osd/fullscreen/buttons/previous.png"/>
 						</include>
 						<onclick>PlayerControl(Previous)</onclick>
@@ -91,20 +91,20 @@
 						<visible>Player.PauseEnabled</visible>
 					</control>
 					<control type="radiobutton" id="603">
-						<include name="OSDButton">
+						<include content="OSDButton">
 							<param name="texture" value="osd/fullscreen/buttons/stop.png"/>
 						</include>
 						<onclick>PlayerControl(Stop)</onclick>
 					</control>
 					<control type="radiobutton" id="605">
-						<include name="OSDButton">
+						<include content="OSDButton">
 							<param name="texture" value="osd/fullscreen/buttons/next.png"/>
 						</include>
 						<onclick>PlayerControl(Next)</onclick>
 						<visible>!VideoPlayer.Content(livetv) + Integer.IsGreater(Playlist.Length(video),1)</visible>
 					</control>
 					<control type="radiobutton" id="804">
-						<include name="OSDButton">
+						<include content="OSDButton">
 							<param name="texture" value="osd/fullscreen/buttons/home.png"/>
 						</include>
 						<onclick>PlayerControl(ShowVideoMenu)</onclick>
@@ -147,13 +147,13 @@
 					<onleft>606</onleft>
 					<onright>600</onright>
 					<control type="radiobutton" id="70011">
-						<include name="OSDButton">
+						<include content="OSDButton">
 							<param name="texture" value="osd/fullscreen/buttons/information.png"/>
 						</include>
 						<onclick>ActivateWindow(fullscreeninfo)</onclick>
 					</control>
 					<control type="radiobutton" id="70040">
-						<include name="OSDButton">
+						<include content="OSDButton">
 							<param name="texture" value="osd/fullscreen/buttons/channels.png"/>
 						</include>
 						<onclick>Dialog.Close(VideoOSD)</onclick>
@@ -161,7 +161,7 @@
 						<visible>VideoPlayer.Content(livetv)</visible>
 					</control>
 					<control type="radiobutton" id="70041">
-						<include name="OSDButton">
+						<include content="OSDButton">
 							<param name="texture" value="osd/fullscreen/buttons/guide.png"/>
 						</include>
 						<onclick>Dialog.Close(VideoOSD)</onclick>
@@ -169,14 +169,14 @@
 						<visible>VideoPlayer.Content(livetv)</visible>
 					</control>
 					<control type="radiobutton" id="700">
-						<include name="OSDButton">
+						<include content="OSDButton">
 							<param name="texture" value="osd/fullscreen/buttons/bookmarks.png"/>
 						</include>
 						<onclick>ActivateWindow(videobookmarks)</onclick>
 						<visible>!VideoPlayer.Content(livetv)</visible>
 					</control>
 					<control type="radiobutton" id="703">
-						<include name="OSDButton">
+						<include content="OSDButton">
 							<param name="texture" value="osd/fullscreen/buttons/teletext.png"/>
 						</include>
 						<onclick>Dialog.Close(VideoOSD)</onclick>
@@ -184,18 +184,18 @@
 						<visible>VideoPlayer.Content(livetv)</visible>
 					</control>
 					<control type="radiobutton" id="704">
-						<include name="OSDButton">
+						<include content="OSDButton">
 							<param name="texture" value="osd/fullscreen/buttons/settings-subtitle.png"/>
 						</include>
 					</control>
 					<control type="radiobutton" id="255">
-						<include name="OSDButton">
+						<include content="OSDButton">
 							<param name="texture" value="osd/fullscreen/buttons/stereoscopic.png"/>
 						</include>
 						<visible>VideoPlayer.IsStereoscopic</visible>
 					</control>
 					<control type="radiobutton" id="70043">
-						<include name="OSDButton">
+						<include content="OSDButton">
 							<param name="texture" value="osd/fullscreen/buttons/settings.png"/>
 						</include>
 						<onclick>SetFocus(11000)</onclick>

--- a/addons/skin.estuary/1080i/VideoOSDBookmarks.xml
+++ b/addons/skin.estuary/1080i/VideoOSDBookmarks.xml
@@ -7,7 +7,7 @@
 	</coordinates>
 	<include>Animation_DialogPopupOpenClose</include>
 	<controls>
-		<include name="DialogBackgroundCommons">
+		<include content="DialogBackgroundCommons">
 			<param name="DialogBackgroundWidth" value="1500" />
 			<param name="DialogBackgroundHeight" value="800" />
 			<param name="DialogHeaderLabel" value="$LOCALIZE[298]" />
@@ -94,24 +94,24 @@
 			<height>800</height>
 			<onleft>11</onleft>
 			<onright>11</onright>
-			<include name="DefaultDialogButton">
+			<include content="DefaultDialogButton">
 				<param name="id" value="2" />
 				<param name="label" value="$LOCALIZE[294]" />
 				<param name="width" value="350" />
 			</include>
-			<include name="DefaultDialogButton">
+			<include content="DefaultDialogButton">
 				<param name="id" value="3" />
 				<param name="label" value="$LOCALIZE[296]" />
 				<param name="width" value="350" />
 			</include>
-			<include name="DefaultDialogButton">
+			<include content="DefaultDialogButton">
 				<param name="id" value="4" />
 				<param name="label" value="$LOCALIZE[20406]" />
 				<param name="width" value="350" />
 				<param name="visible" value="Control.IsEnabled(4)" />
 			</include>
 		</control>
-		<include name="UpDownArrows">
+		<include content="UpDownArrows">
 			<param name="container_id" value="11" />
 			<param name="posx" value="726" />
 			<param name="up_posy" value="-40" />

--- a/addons/skin.estuary/1080i/View_500_SmallThumb.xml
+++ b/addons/skin.estuary/1080i/View_500_SmallThumb.xml
@@ -25,7 +25,7 @@
 		</control>
 	</include>
 	<include name="View_500_SmallThumb">
-		<include name="UpDownArrows">
+		<include content="UpDownArrows">
 			<param name="container_id" value="500" />
 			<param name="visible" value="!System.HasModalDialog" />
 		</include>
@@ -131,12 +131,12 @@
 						<top>15</top>
 						<animation effect="fade" start="0" end="100" time="200" delay="250">Focus</animation>
 						<animation effect="fade" start="100" end="0" time="50">UnFocus</animation>
-						<include name="SmallThumbInfoFlag">
+						<include content="SmallThumbInfoFlag">
 							<param name="icon" value="lists/rating.png" />
 							<param name="infolabel" value="ListItem.Rating" />
 							<param name="posy" value="20" />
 						</include>
-						<include name="SmallThumbInfoFlag">
+						<include content="SmallThumbInfoFlag">
 							<param name="icon" value="lists/year.png" />
 							<param name="infolabel" value="ListItem.Year" />
 							<param name="posy" value="140" />
@@ -307,12 +307,12 @@
 						<right>-10</right>
 						<animation effect="fade" start="0" end="100" time="200" delay="250">Focus</animation>
 						<animation effect="fade" start="100" end="0" time="50">UnFocus</animation>
-						<include name="SmallThumbInfoFlag">
+						<include content="SmallThumbInfoFlag">
 							<param name="icon" value="lists/rating.png" />
 							<param name="infolabel" value="ListItem.Rating" />
 							<param name="posy" value="20" />
 						</include>
-						<include name="SmallThumbInfoFlag">
+						<include content="SmallThumbInfoFlag">
 							<param name="icon" value="lists/year.png" />
 							<param name="infolabel" value="ListItem.Year" />
 							<param name="posy" value="140" />

--- a/addons/skin.estuary/1080i/View_501_Banner.xml
+++ b/addons/skin.estuary/1080i/View_501_Banner.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <includes>
 	<include name="View_501_Banner">
-		<include name="UpDownArrows">
+		<include content="UpDownArrows">
 			<param name="container_id" value="501" />
 			<param name="visible" value="!System.HasModalDialog" />
 		</include>
@@ -132,12 +132,12 @@
 						<animation effect="fade" start="100" end="0" time="50">UnFocus</animation>
 						<top>13</top>
 						<right>0</right>
-						<include name="SmallThumbInfoFlag">
+						<include content="SmallThumbInfoFlag">
 							<param name="icon" value="lists/rating.png" />
 							<param name="infolabel" value="ListItem.Rating" />
 							<param name="posy" value="5" />
 						</include>
-						<include name="SmallThumbInfoFlag">
+						<include content="SmallThumbInfoFlag">
 							<param name="icon" value="lists/year.png" />
 							<param name="infolabel" value="ListItem.Year" />
 							<param name="posy" value="84" />

--- a/addons/skin.estuary/1080i/View_502_FanArt.xml
+++ b/addons/skin.estuary/1080i/View_502_FanArt.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <includes>
 	<include name="View_502_FanArt">
-		<include name="UpDownArrows">
+		<include content="UpDownArrows">
 			<param name="container_id" value="502" />
 			<param name="visible" value="!System.HasModalDialog" />
 		</include>
@@ -55,7 +55,7 @@
 				<top>18</top>
 				<visible>Control.IsVisible(502)</visible>
 				<include>Visible_Left</include>
-				<include name="ListContainer">
+				<include content="ListContainer">
 					<param name="list_id" value="502" />
 					<param name="viewtype_label" value="$LOCALIZE[20445]" />
 				</include>

--- a/addons/skin.estuary/1080i/View_50_List.xml
+++ b/addons/skin.estuary/1080i/View_50_List.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <includes>
 	<include name="View_50_List">
-		<include name="UpDownArrows">
+		<include content="UpDownArrows">
 			<param name="container_id" value="50" />
 			<param name="visible" value="!System.HasModalDialog" />
 		</include>
@@ -11,7 +11,7 @@
 			<top>182</top>
 			<visible>Control.IsVisible(50)</visible>
 			<include>Visible_Right</include>
-			<include name="ListContainer">
+			<include content="ListContainer">
 				<param name="list_id" value="50" />
 				<param name="viewtype_label" value="$LOCALIZE[535]" />
 			</include>

--- a/addons/skin.estuary/1080i/View_51_Poster.xml
+++ b/addons/skin.estuary/1080i/View_51_Poster.xml
@@ -12,7 +12,7 @@
 				<onclick>noop</onclick>
 				<visible>Control.IsVisible(51)</visible>
 			</control>
-			<include name="LeftRightArrows">
+			<include content="LeftRightArrows">
 				<param name="list_id" value="51" />
 				<param name="left_posx" value="45" />
 				<param name="right_posx" value="1849" />
@@ -97,7 +97,7 @@
 					<left>635</left>
 					<top>475</top>
 					<visible>ListItem.IsCollection</visible>
-					<include name="InfoList">
+					<include content="InfoList">
 						<param name="sortby" value="year" />
 						<param name="sortorder" value="descending" />
 						<param name="font" value="font12" />

--- a/addons/skin.estuary/1080i/View_52_IconWall.xml
+++ b/addons/skin.estuary/1080i/View_52_IconWall.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <includes>
 	<include name="View_52_IconWall">
-		<include name="UpDownArrows">
+		<include content="UpDownArrows">
 			<param name="container_id" value="52" />
 			<param name="visible" value="!System.HasModalDialog" />
 		</include>

--- a/addons/skin.estuary/1080i/View_53_Shift.xml
+++ b/addons/skin.estuary/1080i/View_53_Shift.xml
@@ -6,7 +6,7 @@
 			<height>424</height>
 			<left>0</left>
 			<top>180</top>
-			<include name="LeftRightArrows">
+			<include content="LeftRightArrows">
 				<param name="list_id" value="53" />
 				<param name="left_posx" value="45" />
 				<param name="right_posx" value="1849" />
@@ -117,13 +117,13 @@
 				<visible>Control.IsVisible(53)</visible>
 				<include>Visible_Right</include>
 				<include>OpenClose_Right</include>
-				<include name="ShiftTextbox">
+				<include content="ShiftTextbox">
 					<param name="textbox_id" value="53200" />
 					<param name="textbox_content" value="$VAR[ShiftLeftTextBoxVar]" />
 				</include>
 				<control type="group">
 					<left>860</left>
-					<include name="ShiftTextbox">
+					<include content="ShiftTextbox">
 						<param name="textbox_id" value="53300" />
 						<param name="textbox_content" value="$VAR[ShiftRightTextBoxVar]" />
 					</include>

--- a/addons/skin.estuary/1080i/View_54_InfoWall.xml
+++ b/addons/skin.estuary/1080i/View_54_InfoWall.xml
@@ -77,7 +77,7 @@
 		</control>
 	</include>
 	<include name="View_54_InfoWall">
-		<include name="UpDownArrows">
+		<include content="UpDownArrows">
 			<param name="container_id" value="54" />
 			<param name="visible" value="!System.HasModalDialog" />
 		</include>

--- a/addons/skin.estuary/1080i/View_55_WideList.xml
+++ b/addons/skin.estuary/1080i/View_55_WideList.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <includes>
 	<include name="View_55_WideList">
-		<include name="UpDownArrows">
+		<include content="UpDownArrows">
 			<param name="container_id" value="55" />
 			<param name="visible" value="!System.HasModalDialog" />
 		</include>

--- a/xbmc/guilib/GUIIncludes.cpp
+++ b/xbmc/guilib/GUIIncludes.cpp
@@ -304,7 +304,7 @@ void CGUIIncludes::ResolveIncludesForNode(TiXmlElement *node, std::map<INFO::Inf
     Params params;
     std::string tagName;
     // determine which form of include call we have
-    const char *name = include->Attribute("name");
+    const char *name = include->Attribute("content");
     if (name)
     {
       // 1. <include name="MyControl" />


### PR DESCRIPTION
The final way people decided on in https://github.com/xbmc/xbmc/pull/4876 is flawed. It´s confusing to search for includes, and it´s impossible to write a proper syntax highlighting definition in case lookahead is not supported properly.
This changes the way includes have to be defined by changing the attribute from name="" to definition="".
That way definitions and references can be distinguished easily.
As discussed with @ronie @BigNoid @HitcherUK 

Warning: This causes major skin breakage. That can easily get fixed by a search and replace thourgh all files though:
exchange

```
<EOL><tab><include name=
```

with

```
<EOL><tab><include definition=
```

(exchange < tab > with x amount of spaces if needed. This assumes that your skinning files are formatted correctly)
