### PR TITLE
allow sorting of install date/last updated/used in directory providers

### DIFF
--- a/xbmc/listproviders/DirectoryProvider.cpp
+++ b/xbmc/listproviders/DirectoryProvider.cpp
@@ -371,6 +371,7 @@ bool CDirectoryProvider::UpdateSort()
 
   m_currentSort.sortBy = sortMethod;
   m_currentSort.sortOrder = sortOrder;
+  m_currentSort.sortAttributes = SortAttributeIgnoreFolders;
 
   if (CSettings::GetInstance().GetBool(CSettings::SETTING_FILELISTS_IGNORETHEWHENSORTING))
     m_currentSort.sortAttributes = static_cast<SortAttribute>(m_currentSort.sortAttributes | SortAttributeIgnoreArticle);

--- a/xbmc/utils/SortUtils.cpp
+++ b/xbmc/utils/SortUtils.cpp
@@ -1034,7 +1034,10 @@ const std::map<std::string, SortBy> sortMethods = {
   { "channel",          SortByChannel },
   { "channelnumber",    SortByChannelNumber },
   { "datetaken",        SortByDateTaken },
-  { "userrating",       SortByUserRating }
+  { "userrating",       SortByUserRating },
+  { "installdate",      SortByInstallDate },
+  { "lastupdated",      SortByLastUpdated },
+  { "lastused",         SortByLastUsed },
 };
 
 SortBy SortUtils::SortMethodFromString(const std::string& sortMethod)


### PR DESCRIPTION
missing from 85dd674.

This also sets the 'ignore folders' attribute for all directory providers (needed to correctly sort program addons). Couldn't see any issues, but if there is I can add an attribute options to directory providers.
