### PR TITLE
[PVR] Recordings window: Fix recordings in folders not displayed

### DIFF
--- a/xbmc/pvr/recordings/PVRRecordingsPath.cpp
+++ b/xbmc/pvr/recordings/PVRRecordingsPath.cpp
@@ -131,8 +131,8 @@ std::string CPVRRecordingsPath::GetSubDirectoryPath(const std::string &strPath) 
   URIUtils::RemoveSlashAtEnd(strUsePath);
 
   /* adding "/" to make sure that base matches the complete folder name and not only parts of it */
-  if (strUsePath.size() <= m_directoryPath.size() || !StringUtils::StartsWith(strUsePath, m_directoryPath + "/"))
-      return strReturn;
+  if (!m_directoryPath.empty() && (strUsePath.size() <= m_directoryPath.size() || !StringUtils::StartsWith(strUsePath, m_directoryPath + "/")))
+    return strReturn;
 
   strUsePath.erase(0, m_directoryPath.size());
 


### PR DESCRIPTION
Recordings contained in recording folders (and the folders itself) are not displayed any longer in non-flattened recordings window view.

Regression introduced by #9105 
Brought up in the forum: http://forum.kodi.tv/showthread.php?tid=250817&pid=2243101#pid2243101
