### PR TITLE
[Android] Fix cpu count on some Android devices

### DIFF
--- a/xbmc/platform/android/activity/AndroidFeatures.cpp
+++ b/xbmc/platform/android/activity/AndroidFeatures.cpp
@@ -63,3 +63,14 @@ int CAndroidFeatures::GetVersion()
   return version;
 }
 
+int CAndroidFeatures::GetCPUCount()
+{
+  static int count = -1;
+
+  if (count == -1)
+  {
+    count = android_getCpuCount();
+  }
+  return count;
+}
+

--- a/xbmc/platform/android/activity/AndroidFeatures.h
+++ b/xbmc/platform/android/activity/AndroidFeatures.h
@@ -27,4 +27,5 @@ class CAndroidFeatures
 
   static bool         HasNeon();
   static int          GetVersion();
+  static int          GetCPUCount();
 };

--- a/xbmc/utils/CPUInfo.cpp
+++ b/xbmc/utils/CPUInfo.cpp
@@ -412,6 +412,14 @@ CCPUInfo::CCPUInfo(void)
       }
     }
     fclose(fCPUInfo);
+    //  /proc/cpuinfo is not reliable on some Android platforms
+    //  At least we should get the correct cpu count for multithreaded decoding
+#if defined(TARGET_ANDROID)
+    if (CAndroidFeatures::GetCPUCount() > m_cpuCount)
+    {
+      m_cpuCount = CAndroidFeatures::GetCPUCount();
+    }
+#endif
   }
   else
   {


### PR DESCRIPTION
On some Android devices, like SATV, the old way of reading /proc/cpuinfo may report less CPUs than the devices actually have. See: https://code.google.com/p/android/issues/detail?id=26490

In xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp, the number of CPUs is used to determine the number of decoding threads. So on affected devices, Kodi may not be able to use full CPU power.

I had some discussion about this performance issue here: http://forum.kodi.tv/showthread.php?tid=257629&page=2
I have tried my build on my SATV, and it solved the decoding performance problem for me.

Still, CPUs missing from /proc/cpuinfo won't appear in OSD / system info screen. But at least they can be utilized.
