### PR TITLE
[cmake] Guard inclusion of config.h

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxBXA.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxBXA.h
@@ -21,13 +21,12 @@
 
 #include "DVDDemux.h"
 
-#ifdef TARGET_WINDOWS
-#define __attribute__(dummy_val)
-#else
-#include <config.h>
+#if defined(HAVE_CONFIG_H)
+  #include "config.h"
 #endif
 
 #ifdef TARGET_WINDOWS
+#define __attribute__(dummy_val)
 #pragma pack(push)
 #pragma pack(1)
 #endif

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCDDA.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCDDA.h
@@ -23,8 +23,10 @@
 
 #ifdef TARGET_WINDOWS
 #define __attribute__(dummy_val)
-#else
-#include <config.h>
+#endif
+
+#if defined(HAVE_CONFIG_H)
+  #include "config.h"
 #endif
 
 class CDemuxStreamAudioCDDA;

--- a/xbmc/cores/VideoPlayer/VideoPlayerSubtitle.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerSubtitle.cpp
@@ -27,8 +27,8 @@
 #include "DVDCodecs/DVDFactoryCodec.h"
 #include "utils/log.h"
 #include "threads/SingleLock.h"
-#ifdef TARGET_POSIX
-#include "config.h"
+#if defined(HAVE_CONFIG_H)
+  #include "config.h"
 #endif
 
 CVideoPlayerSubtitle::CVideoPlayerSubtitle(CDVDOverlayContainer* pOverlayContainer)

--- a/xbmc/threads/platform/pthreads/ThreadImpl.cpp
+++ b/xbmc/threads/platform/pthreads/ThreadImpl.cpp
@@ -18,7 +18,9 @@
  *
  */
 
-#include "config.h"
+#if defined(HAVE_CONFIG_H)
+  #include "config.h"
+#endif
 #include <limits.h>
 #if defined(TARGET_ANDROID)
 #include <unistd.h>


### PR DESCRIPTION
Some files unconditionally included config.h which does not exist when building with CMake. This just happened to work because libsquish's config.h was in the global include directories.
