### PR TITLE
[peripherals] don't show the settings dialog if there are no settings available

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -15245,9 +15245,9 @@ msgctxt "#35003"
 msgid "Generic disk"
 msgstr ""
 
-#: addons/skin.confluence/720p/DialogPeripheralSettings.xml
+#: xbmc/peripherals/Peripherals.cpp
 msgctxt "#35004"
-msgid "There are no settings available\nfor this peripheral."
+msgid "There are no settings available for this peripheral."
 msgstr ""
 
 #: xbmc/peripherals/Peripherals.cpp

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -33,6 +33,7 @@
 #include "devices/PeripheralNyxboard.h"
 #include "devices/PeripheralTuner.h"
 #include "dialogs/GUIDialogKaiToast.h"
+#include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogPeripheralSettings.h"
 #include "dialogs/GUIDialogSelect.h"
 #include "FileItem.h"
@@ -744,6 +745,15 @@ void CPeripherals::OnSettingAction(const CSetting *setting)
       if (iPos >= 0)
       {
         CFileItemPtr pItem = items.Get(iPos);
+
+        // show an error if the peripheral doesn't have any settings
+        CPeripheral *peripheral = GetByPath(pItem->GetPath());
+        if (peripheral == nullptr || peripheral->GetSettings().empty())
+        {
+          CGUIDialogOK::ShowAndGetInput(CVariant{35000}, CVariant{35004});
+          continue;
+        }
+
         CGUIDialogPeripheralSettings *pSettingsDialog = (CGUIDialogPeripheralSettings *)g_windowManager.GetWindow(WINDOW_DIALOG_PERIPHERAL_SETTINGS);
         if (pItem && pSettingsDialog)
         {

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -708,7 +708,7 @@ void CPeripherals::OnSettingChanged(const CSetting *setting)
   {
     // user set language, no longer use the TV's language
     std::vector<CPeripheral *> cecDevices;
-    if (g_peripherals.GetPeripheralsWithFeature(cecDevices, FEATURE_CEC) > 0)
+    if (GetPeripheralsWithFeature(cecDevices, FEATURE_CEC) > 0)
     {
       for (std::vector<CPeripheral *>::iterator it = cecDevices.begin(); it != cecDevices.end(); ++it)
         (*it)->SetSetting("use_tv_menu_language", false);


### PR DESCRIPTION
These two commits are taken from the controller input PR #8807 from @garbear.
- The first commit introduces an error dialog if the user tries to open the settings dialog for a peripheral device that doesn't have any settings instead of showing an empty dialog with focus problems. The string being used seems to have been in use by Confluence at one point but I checked and it isn't used there anymore.
- The second commit removes a usage of `g_peripherals` inside `CPeripherals` which doesn't make any sense.
