### PR TITLE
CAddonMgr: split FindAddons() into FindAddons() and FindAddonsAndNotify()

### DIFF
--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -637,6 +637,9 @@ bool CAddonInstallJob::DoWork()
     });
   }
 
+  // notify any observers that add-ons have changed
+  CAddonMgr::GetInstance().NotifyObservers(ObservableMessageAddons);
+
   CEventLog::GetInstance().Add(
     EventPtr(new CAddonManagementEvent(m_addon, m_update ? 24065 : 24064)),
     !IsModal() && CSettings::GetInstance().GetBool(CSettings::SETTING_ADDONS_NOTIFICATIONS), false);

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -333,7 +333,7 @@ bool CAddonMgr::Init()
     return false;
   }
 
-  FindAddons();
+  FindAddonsAndNotify();
 
   // disable some system addons by default because they are optional
   VECADDONS addons;
@@ -651,8 +651,11 @@ bool CAddonMgr::SetDefault(const TYPE &type, const std::string &addonID)
   return true;
 }
 
-void CAddonMgr::FindAddons()
+bool CAddonMgr::FindAddons()
 {
+  bool result = false;
+  CSingleLock lock(m_critSection);
+  if (m_cpluff && m_cp_context)
   {
     CSingleLock lock(m_critSection);
     if (m_cpluff && m_cp_context)
@@ -674,7 +677,18 @@ void CAddonMgr::FindAddons()
       SetChanged();
     }
   }
+
+  return result;
+}
+
+bool CAddonMgr::FindAddonsAndNotify()
+{
+  if (!FindAddons())
+    return false;
+
   NotifyObservers(ObservableMessageAddons);
+
+  return true;
 }
 
 void CAddonMgr::UnregisterAddon(const std::string& ID)

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -117,7 +117,17 @@ namespace ADDON
 
     std::string GetTranslatedString(const cp_cfg_element_t *root, const char *tag);
     static AddonPtr AddonFromProps(AddonProps& props);
-    void FindAddons();
+
+    /*! \brief Checks for new / updated add-ons
+     \return True if everything went ok, false otherwise
+     */
+    bool FindAddons();
+
+    /*! \brief Checks for new / updated add-ons and notifies all observers
+    \return True if everything went ok, false otherwise
+    */
+    bool FindAddonsAndNotify();
+
     void UnregisterAddon(const std::string& ID);
 
     /*! Hook for clearing internal state after uninstall. */

--- a/xbmc/interfaces/builtins/AddonBuiltins.cpp
+++ b/xbmc/interfaces/builtins/AddonBuiltins.cpp
@@ -302,7 +302,7 @@ static int UpdateRepos(const std::vector<std::string>& params)
  */
 static int UpdateLocals(const std::vector<std::string>& params)
 {
-  CAddonMgr::GetInstance().FindAddons();
+  CAddonMgr::GetInstance().FindAddonsAndNotify();
 
   return 0;
 }


### PR DESCRIPTION
This commit is from the controller input PR #8807 from @garbear. It splits `CAddonMgr::FindAddons()` into `CAddonMgr::FindAddons()` and `CAddonMgr::FindAddonsAndNotify()`. This allows us to call `FindAddons()` in `CAddonInstallJob::DoWork()` without automatically notifying all
observers, then load all strings and make sure the addon is enabled before finally notifying observers.

Right now we notify observers before having fully loaded and initialised a newly installed/updated addon which can lead to issues if these observers try to access properties of the addon that haven't been initialised yet.
