### PR TITLE
RenderManager: Maintain counters correctly

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -802,7 +802,10 @@ bool CRenderManager::RenderCaptureGetPixels(unsigned int captureId, unsigned int
     
     CSingleExit exitlock(m_captCritSect);
     if (!it->second->GetEvent().WaitMSec(millis))
+    {
+      m_captureWaitCounter--;
       return false;
+    }
   }
 
   m_captureWaitCounter--;


### PR DESCRIPTION
This solves the issue when pressing stop with boblight / ambilight / hue that we run into a hang. Thx to @FernetMenta for pointing out the proper fix.
