### PR TITLE
[cmake] Fix finding FXC.exe on Windows

### DIFF
--- a/project/cmake/modules/FindD3DX11Effects.cmake
+++ b/project/cmake/modules/FindD3DX11Effects.cmake
@@ -27,11 +27,23 @@ mark_as_advanced(D3DX11EFFECTS_FOUND)
 find_file(D3DCOMPILER_DLL
           NAMES d3dcompiler_47.dll d3dcompiler_46.dll
           PATHS
+            "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\Microsoft\\Microsoft SDKs\\Windows\\v10.0;InstallationFolder]/Redist/D3D/x86"
             "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\Microsoft\\Microsoft SDKs\\Windows\\v8.1;InstallationFolder]/Redist/D3D/x86"
             "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\Microsoft\\Microsoft SDKs\\Windows\\v8.0;InstallationFolder]/Redist/D3D/x86"
-            "$ENV{WindowsSdkDir}redist/d3d/x86"
+            "$ENV{WindowsSdkDir}Redist/d3d/x86"
           NO_DEFAULT_PATH)
 if(NOT D3DCOMPILER_DLL)
   message(WARNING "Could NOT find Direct3D Compiler")
 endif()
 mark_as_advanced(D3DCOMPILER_DLL)
+
+find_program(FXC fxc
+             PATHS
+               "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\Microsoft\\Microsoft SDKs\\Windows\\v10.0;InstallationFolder]/bin/x86"
+               "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\Microsoft\\Microsoft SDKs\\Windows\\v8.1;InstallationFolder]/bin/x86"
+               "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\Microsoft\\Microsoft SDKs\\Windows\\v8.0;InstallationFolder]/bin/x86"
+               "$ENV{WindowsSdkDir}bin/x86")
+if(NOT FXC)
+  message(WARNING "Could NOT find DirectX Effects Compiler (FXC)")
+endif()
+mark_as_advanced(FXC)

--- a/project/cmake/scripts/windows/macros.cmake
+++ b/project/cmake/scripts/windows/macros.cmake
@@ -108,7 +108,6 @@ endfunction()
 #   entrypoint Shader entry point
 # On return:
 #   FXC_FILE is set to the name of the generated header file.
-find_program(FXC fxc)
 function(add_shader_dx target hlsl profile entrypoint)
   get_filename_component(file ${hlsl} NAME_WE)
   add_custom_command(OUTPUT ${file}.h


### PR DESCRIPTION
Properly find FXC.exe when it's not in the PATH.
Confirmed to work by @Razzeee and @AchimTuran
