### PR TITLE
[addons] CAddonMgr: add GetInstallableAddons() and use it in CGUIWindowAddonBrowser::SelectAddonID()

### DIFF
--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -493,6 +493,36 @@ bool CAddonMgr::GetDisabledAddons(VECADDONS& addons, const TYPE& type)
   return false;
 }
 
+bool CAddonMgr::GetInstallableAddons(VECADDONS& addons)
+{
+  return GetInstallableAddons(addons, ADDON_UNKNOWN);
+}
+
+bool CAddonMgr::GetInstallableAddons(VECADDONS& addons, const TYPE &type)
+{
+  CSingleLock lock(m_critSection);
+
+  // get all addons
+  VECADDONS installableAddons;
+  if (!m_database.GetRepositoryContent(installableAddons))
+    return false;
+
+  // go through all addons and remove all that are already installed
+  for (const auto& addon : installableAddons)
+  {
+    // check if the addon matches the provided addon type
+    if (type != ADDON::ADDON_UNKNOWN && addon->Type() != type && !addon->IsType(type))
+      continue;
+
+    if (!CanAddonBeInstalled(addon))
+      continue;
+
+    addons.push_back(addon);
+  }
+
+  return true;
+}
+
 bool CAddonMgr::GetAddonsInternal(const TYPE &type, VECADDONS &addons, bool enabledOnly)
 {
   CSingleLock lock(m_critSection);

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -105,6 +105,11 @@ namespace ADDON
 
     bool GetDisabledAddons(VECADDONS& addons, const TYPE& type);
 
+    /*! Get all installable addons */
+    bool GetInstallableAddons(VECADDONS& addons);
+
+    bool GetInstallableAddons(VECADDONS& addons, const TYPE &type);
+
     void AddToUpdateableAddons(AddonPtr &pAddon);
     void RemoveFromUpdateableAddons(AddonPtr &pAddon);    
     bool ReloadSettings(const std::string &id);

--- a/xbmc/addons/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/GUIWindowAddonBrowser.cpp
@@ -477,8 +477,7 @@ int CGUIWindowAddonBrowser::SelectAddonID(const std::vector<ADDON::TYPE> &types,
   if (showInstallable || showMore)
   {
     VECADDONS installableAddons;
-    CAddonDatabase database;
-    if (database.Open() && database.GetRepositoryContent(installableAddons))
+    if (CAddonMgr::GetInstance().GetInstallableAddons(installableAddons))
     {
       for (ADDON::IVECADDONS addon = installableAddons.begin(); addon != installableAddons.end();)
       {
@@ -495,18 +494,10 @@ int CGUIWindowAddonBrowser::SelectAddonID(const std::vector<ADDON::TYPE> &types,
           }
         }
 
-        // only show addons that match one of the provided addon types and that aren't disabled
-        if (matchesType && !CAddonMgr::GetInstance().IsAddonDisabled(pAddon->ID()))
+        if (matchesType)
         {
-          // check if the addon is installed
-          bool isInstalled = CAddonMgr::GetInstance().IsAddonInstalled(pAddon->ID());
-
-          // check if the addon is installed or can be installed
-          if ((showInstallable || showMore) && !isInstalled && CAddonMgr::GetInstance().CanAddonBeInstalled(pAddon))
-          {
-            ++addon;
-            continue;
-          }
+          ++addon;
+          continue;
         }
 
         addon = installableAddons.erase(addon);


### PR DESCRIPTION
This commit is from the controller input PR #8807 from @garbear. It moves the logic to get a list of installable addons (for a specific addon type) from `CGUIWindowAddonBrowser::SelectAddonID()` into `CAddonMgr::GetInstallableAddons()` because we will also need this in the input controller configuration GUI and I don't like duplicating code.
