### PR TITLE
CMake Readme Fixes

### DIFF
--- a/project/cmake/README.md
+++ b/project/cmake/README.md
@@ -72,14 +72,14 @@ cmake --build . -- VERBOSE=1 -j$(nproc)  # or: make VERBOSE=1 -j$(nproc)
 ./kodi.bin
 ```
 
-`CMAKE_BUILD_TYPE` defaults to `Debug`.
+`CMAKE_BUILD_TYPE` defaults to `Release`.
 
 ### Windows with NMake Makefiles
 
 ```
 cmake -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release <KODI_SRC>/project/cmake/
 cmake --build .  # or: nmake
-./kodi.bin
+kodi.exe
 ```
 
 ### Windows with Visual Studio project files
@@ -87,7 +87,7 @@ cmake --build .  # or: nmake
 ```
 cmake -G "Visual Studio 12" <KODI_SRC>/project/cmake/
 cmake --build . --config "Debug"  # or: Build solution with Visual Studio
-KODI_HOME=%CD% Debug/kodi.bin
+set KODI_HOME="%CD%" && Debug\kodi.exe
 ```
 
 ### OSX with GNU Makefiles

--- a/project/cmake/README.md
+++ b/project/cmake/README.md
@@ -29,7 +29,8 @@ The dependencies required to build on Linux can be found in
 ### Windows
 
 For Windows the dependencies can be found in the
-[Wiki](http://kodi.wiki/view/HOW-TO:Compile_Kodi_for_Windows) (Step 1-4).
+[Wiki](http://kodi.wiki/view/HOW-TO:Compile_Kodi_for_Windows) (Step 1-4). If not already available on your pc, you should
+install the [Windows Software Development Kit (SDK)](https://dev.windows.com/en-us/downloads/sdk-archive) for your Windows version. This is required for HLSL shader offline compiling with the [Effect-Compiler Tool](https://msdn.microsoft.com/de-de/library/windows/desktop/bb232919(v=vs.85).aspx) (fxc.exe).
 
 On Windows, the CMake based buildsystem requires that the binary dependencies
 are downloaded using `DownloadBuildDeps.bat` and `DownloadMingwBuildEnv.bat`


### PR DESCRIPTION
During my first tests with our new CMake based build system I noticed that the instructions for Windows are not entirely correct.

@fetzerch 
This PR includes the fixes we discussed. Can you have a look at it?

@afedchin 
Do you know since when we use fxc.exe for shader compilation? I noticed that this part is missing in the CMake build instructions.
Can you confirm that we have to install the Windows SDK for Windows 7, 8.0, 8.1 or 10 to get our build working? I think this is the best MS link for downloading the SDK's, because it shows all available downloads. Or do you have a better link?
