### PR TITLE
"Home Theatre" => "Home Theater" spelling change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build Status](https://travis-ci.org/xbmc/xbmc.svg?branch=master)](https://travis-ci.org/xbmc/xbmc)
 
 ![Kodi logo](https://raw.githubusercontent.com/xbmc/xbmc-forum/master/xbmc/images/logo-sbs-black.png)
-# Kodi Home Theatre Software
+# Kodi Home Theater Software
 
 **Welcome to Kodi!**
 


### PR DESCRIPTION
English-language spelling reform change from "Home Theatre" to "Home Theater".

Changed both for consistency (media centre vs media center) and common use.

For more info see forum thread: http://forum.kodi.tv/showthread.php?tid=258911
