### PR TITLE
[EGLIMX] add support for EDID provided in binary form from /sys

### DIFF
--- a/xbmc/windowing/egl/EGLNativeTypeIMX.cpp
+++ b/xbmc/windowing/egl/EGLNativeTypeIMX.cpp
@@ -348,6 +348,19 @@ float CEGLNativeTypeIMX::GetMonitorSAR()
   if(!f_edid)
     return 0;
 
+  // first check if EDID is in binary format by reading 512bytes, compare 1st 8bytes
+  // against EDID 1.4 identificator [0x0,0xff,0xff,0xff,0xff,0xff,0xff,0x0]
+  // if no match, seek to 0 input file and continue with previous method.
+  if (((done = fread(m_edid, 1, EDID_MAXSIZE, f_edid)) % 128) == 0 && done)
+    if (!memcmp(m_edid, EDID_HEADER, EDID_HEADERSIZE))
+    {
+      fclose(f_edid);
+      return true;
+    }
+
+  done = 0;
+  memset(m_edid, 0, EDID_MAXSIZE);
+  fseek(f_edid, 0L, SEEK_SET);
   // we need to convert mxc_hdmi output format to binary array
   // mxc_hdmi provides the EDID as space delimited 1bytes blocks
   // exported as text with format specifier %x eg:
@@ -364,7 +377,7 @@ float CEGLNativeTypeIMX::GetMonitorSAR()
   while(getline(&str, &n, f_edid) > 0)
   {
     char *c = str;
-    while(*c != '\n' && done < 512)
+    while(*c != '\n' && done < EDID_MAXSIZE)
     {
       c += 2;
       sscanf(c, "%hhx", &p);

--- a/xbmc/windowing/egl/EGLNativeTypeIMX.h
+++ b/xbmc/windowing/egl/EGLNativeTypeIMX.h
@@ -25,6 +25,10 @@
 #include "EGLNativeType.h"
 
 #define EDID_STRUCT_DISPLAY     0x14
+#define EDID_MAXSIZE            512
+#define EDID_HEADERSIZE         8
+
+static const char EDID_HEADER[EDID_HEADERSIZE] = { 0x0, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x0 };
 
 class CEGLNativeTypeIMX : public CEGLNativeType
 {
@@ -62,5 +66,5 @@ protected:
 
   EGLNativeDisplayType m_display;
   EGLNativeWindowType  m_window;
-  uint8_t              m_edid[512];
+  uint8_t              m_edid[EDID_MAXSIZE];
 };


### PR DESCRIPTION
@fritsch 

this is to provide compatibility with imx-hdmi versions providing EDID in binary format.
binary format is tried first, previous method (text 0xXX format) still used as fallback.

mk
