### PR TITLE
[PVR] Recordings window: Fix recordings in nested folders not displayed

### DIFF
--- a/xbmc/pvr/recordings/PVRRecordingsPath.cpp
+++ b/xbmc/pvr/recordings/PVRRecordingsPath.cpp
@@ -96,6 +96,7 @@ void CPVRRecordingsPath::Init(const std::string &strPath)
   const std::vector<std::string> segments = URIUtils::SplitPath(strVarPath);
 
   m_bValid  = ((segments.size() >= 3) && // at least pvr://recordings/[active|deleted]
+               StringUtils::StartsWith(strVarPath, "pvr://") &&
                (segments.at(1) == "recordings") &&
                ((segments.at(2) == "active") || (segments.at(2) == "deleted")));
   m_bRoot   = (m_bValid && (segments.size() == 3));

--- a/xbmc/pvr/recordings/PVRRecordingsPath.h
+++ b/xbmc/pvr/recordings/PVRRecordingsPath.h
@@ -55,7 +55,6 @@ namespace PVR
     void AppendSegment(const std::string &strSegment);
 
   private:
-    void Init(const std::string &strPath);
     static std::string TrimSlashes(const std::string &strString);
 
     bool m_bValid;

--- a/xbmc/pvr/recordings/PVRRecordingsPath.h
+++ b/xbmc/pvr/recordings/PVRRecordingsPath.h
@@ -56,6 +56,7 @@ namespace PVR
 
   private:
     void Init(const std::string &strPath);
+    static std::string TrimSlashes(const std::string &strString);
 
     bool m_bValid;
     bool m_bRoot;


### PR DESCRIPTION
Recordings contained in nested recording folders (and the folders itself) are not displayed any longer in non-flattened recordings window view.

Regression introduced by #9105 
Brought up in the forum: http://forum.kodi.tv/showthread.php?tid=250817&pid=2244138#pid2244138

@MilhouseVH ping
