### PR TITLE
[cmake] Fix tests (/ static initialization order)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ install:
 # Linux dependencies
 #
   - if [[ "$TRAVIS_OS_NAME" == "linux" && "$BUILD" == "Kodi" ]]; then
-      sudo apt-get install -qq automake autopoint build-essential cmake curl dcadec-dev default-jre gawk gdc
+      sudo apt-get install -qq automake autopoint build-essential cmake curl dcadec-dev default-jre gawk gdb gdc
       gettext git-core gperf libasound2-dev libass-dev libbz2-dev libcap-dev libcdio-dev libcrossguid-dev libcurl3
       libcurl4-openssl-dev libdbus-1-dev libfontconfig-dev libegl1-mesa-dev libfreetype6-dev libfribidi-dev libgif-dev
       libiso9660-dev libjpeg-dev libltdl-dev liblzo2-dev libmicrohttpd-dev libmodplug-dev libmysqlclient-dev libnfs-dev
@@ -86,6 +86,7 @@ before_script:
 # Linux
 #
   - if [[ "$TRAVIS_OS_NAME" == "linux" && "$BUILD" == "Kodi" ]]; then
+      ulimit -c unlimited -S;
       if [[ "$TOOLS" == "Autotools" ]]; then
         cd $TRAVIS_BUILD_DIR &&
         ./bootstrap;
@@ -136,6 +137,12 @@ script:
       mkdir -p build &&
       cmake -DADDONS_TO_BUILD="$ADDONS".* -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=../addons $TRAVIS_BUILD_DIR/project/cmake/addons &&
       make -j3;
+    fi
+
+after_failure:
+  - COREFILE=$(find . -maxdepth 1 -name "core*" | head -n 1)
+  - if [[ -f "$COREFILE" ]]; then
+      gdb -c "$COREFILE" kodi-test -ex "thread apply all bt" -ex "set pagination 0" -batch;
     fi
 
 # Disable annoying emails

--- a/.travis.yml
+++ b/.travis.yml
@@ -96,9 +96,9 @@ before_script:
     fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" && "$BUILD" == "Kodi" && "$CXX" == "g++" ]]; then
       if [[ "$TOOLS" == "Autotools" ]]; then
-        ./configure;
+        ./configure --enable-debug;
       elif [[ "$TOOLS" == "CMake" ]]; then
-        cmake ../project/cmake;
+        cmake -DCMAKE_BUILD_TYPE=Debug ../project/cmake;
       fi
     fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" && "$BUILD" == "Kodi" && "$CXX" == "clang++" ]]; then

--- a/xbmc/SystemGlobals.cpp
+++ b/xbmc/SystemGlobals.cpp
@@ -35,6 +35,10 @@
 #include "interfaces/python/XBPython.h"
 #endif
 
+// Guarantee that CSpecialProtocol is initialized before and uninitialized after RarManager
+#include "filesystem/SpecialProtocol.h"
+std::map<std::string, std::string> CSpecialProtocol::m_pathMap;
+
 #if defined(HAS_FILESYSTEM_RAR)
 #include "filesystem/RarManager.h"
 #endif

--- a/xbmc/filesystem/SpecialProtocol.cpp
+++ b/xbmc/filesystem/SpecialProtocol.cpp
@@ -34,8 +34,6 @@
 #include "utils/StringUtils.h"
 #endif
 
-std::map<std::string, std::string> CSpecialProtocol::m_pathMap;
-
 void CSpecialProtocol::SetProfilePath(const std::string &dir)
 {
   SetPath("profile", dir);

--- a/xbmc/test/xbmc-test.cpp
+++ b/xbmc/test/xbmc-test.cpp
@@ -29,20 +29,10 @@
 #include <cstdio>
 #include <cstdlib>
 
-class NullLogger : public XbmcCommons::ILogger
-{
-public:
-  void log(int loglevel, const char* message) {}
-};
-
 int main(int argc, char **argv)
 {
   testing::InitGoogleTest(&argc, argv);
   CXBMCTestUtils::Instance().ParseArgs(argc, argv);
-
-  // we need to configure CThread to use a dummy logger
-  NullLogger* nullLogger = new NullLogger();
-  CThread::SetLogger(nullLogger);
 
   if (!testing::AddGlobalTestEnvironment(new TestBasicEnvironment()))
   {
@@ -50,8 +40,6 @@ int main(int argc, char **argv)
     exit(EXIT_FAILURE);
   }
   int ret = RUN_ALL_TESTS();
-
-  delete nullLogger;
 
   return ret;
 }


### PR DESCRIPTION
This is an attempt to fix the unit tests when building with CMake.

79fe295 Fixes the static initialization order of CSpecialProtocol/RarManager:
The destructor of RarManager uses CSpecialProtocol (a class with only statics). Therefore we have to make sure that CSpecialProtocol is destructed after RarManager. According to the C++ standard, the order of con/destruction for statics is only guaranteed within the same compilation unit. Not a nice fix, I'm happy if anyone has a better idea.

Valgrind:

```
Invalid read of size 8
  in CSpecialProtocol::GetPath(std::string const&amp;) in /home/jcf/develop/kodi/kodi17/xbmc/filesystem/SpecialProtocol.cpp:268
  1: std::string::compare(std::string const&amp;) const in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.20
  2: bool std::operator&lt; &lt;char, std::char_traits&lt;char&gt;, std::allocator&lt;char&gt; &gt;(std::basic_string&lt;char, std::char_traits&lt;char&gt;, std::allocator&lt;char&gt; &gt; const&amp;, std::basic_string&lt;char, std::char_traits&lt;char&gt;, std::allocator&lt;char&gt; &gt; const&amp;) in /usr/include/c++/4.9/bits/basic_string.h:2590
  3: std::less&lt;std::string&gt;::operator()(std::string const&amp;, std::string const&amp;) const in /usr/include/c++/4.9/bits/stl_function.h:371
  4: std::_Rb_tree&lt;std::string, std::pair&lt;std::string const, std::string&gt;, std::_Select1st&lt;std::pair&lt;std::string const, std::string&gt; &gt;, std::less&lt;std::string&gt;, std::allocator&lt;std::pair&lt;std::string const, std::string&gt; &gt; &gt;::_M_lower_bound(std::_Rb_tree_node&lt;std::pair&lt;std::string const, std::string&gt; &gt;*, std::_Rb_tree_node&lt;std::pair&lt;std::string const, std::string&gt; &gt;*, std::string const&amp;) in /usr/include/c++/4.9/bits/stl_tree.h:1261
  5: std::_Rb_tree&lt;std::string, std::pair&lt;std::string const, std::string&gt;, std::_Select1st&lt;std::pair&lt;std::string const, std::string&gt; &gt;, std::less&lt;std::string&gt;, std::allocator&lt;std::pair&lt;std::string const, std::string&gt; &gt; &gt;::find(std::string const&amp;) in /usr/include/c++/4.9/bits/stl_tree.h:1913
  6: std::map&lt;std::string, std::string, std::less&lt;std::string&gt;, std::allocator&lt;std::pair&lt;std::string const, std::string&gt; &gt; &gt;::find(std::string const&amp;) in /usr/include/c++/4.9/bits/stl_map.h:860
  7: CSpecialProtocol::GetPath(std::string const&amp;) in /home/jcf/develop/kodi/kodi17/xbmc/filesystem/SpecialProtocol.cpp:268
  8: CSpecialProtocol::TranslatePath(CURL const&amp;) in /home/jcf/develop/kodi/kodi17/xbmc/filesystem/SpecialProtocol.cpp:166
  9: XFILE::CSpecialProtocolFile::TranslatePath(CURL const&amp;) in /home/jcf/develop/kodi/kodi17/xbmc/filesystem/SpecialProtocolFile.cpp:36
  10: XFILE::COverrideFile::Delete(CURL const&amp;) in /home/jcf/develop/kodi/kodi17/xbmc/filesystem/OverrideFile.cpp:61
  11: XFILE::CFile::Delete(CURL const&amp;) in /home/jcf/develop/kodi/kodi17/xbmc/filesystem/File.cpp:798
  12: XFILE::CFile::Delete(std::string const&amp;) in /home/jcf/develop/kodi/kodi17/xbmc/filesystem/File.cpp:785
  13: CRarManager::ClearCache(bool) in /home/jcf/develop/kodi/kodi17/xbmc/filesystem/RarManager.cpp:472
  14: CRarManager::~CRarManager() in /home/jcf/develop/kodi/kodi17/xbmc/filesystem/RarManager.cpp:67
  15: __run_exit_handlers in /build/buildd/glibc-2.21/stdlib/exit.c:82
  16: exit in /build/buildd/glibc-2.21/stdlib/exit.c:104
  17: (below main) in /build/buildd/glibc-2.21/csu/libc-start.c:323
Address 0x1d3d8bf0 is 32 bytes inside a block of size 48 free'd  1: operator delete(void*) in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so
  2: __gnu_cxx::new_allocator&lt;std::_Rb_tree_node&lt;std::pair&lt;std::string const, std::string&gt; &gt; &gt;::deallocate(std::_Rb_tree_node&lt;std::pair&lt;std::string const, std::string&gt; &gt;*, unsigned long) in /usr/include/c++/4.9/ext/new_allocator.h:110
  3: std::allocator_traits&lt;std::allocator&lt;std::_Rb_tree_node&lt;std::pair&lt;std::string const, std::string&gt; &gt; &gt; &gt;::deallocate(std::allocator&lt;std::_Rb_tree_node&lt;std::pair&lt;std::string const, std::string&gt; &gt; &gt;&amp;, std::_Rb_tree_node&lt;std::pair&lt;std::string const, std::string&gt; &gt;*, unsigned long) in /usr/include/c++/4.9/bits/alloc_traits.h:383
  4: std::_Rb_tree&lt;std::string, std::pair&lt;std::string const, std::string&gt;, std::_Select1st&lt;std::pair&lt;std::string const, std::string&gt; &gt;, std::less&lt;std::string&gt;, std::allocator&lt;std::pair&lt;std::string const, std::string&gt; &gt; &gt;::_M_put_node(std::_Rb_tree_node&lt;std::pair&lt;std::string const, std::string&gt; &gt;*) in /usr/include/c++/4.9/bits/stl_tree.h:389
  5: std::_Rb_tree&lt;std::string, std::pair&lt;std::string const, std::string&gt;, std::_Select1st&lt;std::pair&lt;std::string const, std::string&gt; &gt;, std::less&lt;std::string&gt;, std::allocator&lt;std::pair&lt;std::string const, std::string&gt; &gt; &gt;::_M_destroy_node(std::_Rb_tree_node&lt;std::pair&lt;std::string const, std::string&gt; &gt;*) in /usr/include/c++/4.9/bits/stl_tree.h:438
  6: std::_Rb_tree&lt;std::string, std::pair&lt;std::string const, std::string&gt;, std::_Select1st&lt;std::pair&lt;std::string const, std::string&gt; &gt;, std::less&lt;std::string&gt;, std::allocator&lt;std::pair&lt;std::string const, std::string&gt; &gt; &gt;::_M_erase(std::_Rb_tree_node&lt;std::pair&lt;std::string const, std::string&gt; &gt;*) in /usr/include/c++/4.9/bits/stl_tree.h:1247
  7: std::_Rb_tree&lt;std::string, std::pair&lt;std::string const, std::string&gt;, std::_Select1st&lt;std::pair&lt;std::string const, std::string&gt; &gt;, std::less&lt;std::string&gt;, std::allocator&lt;std::pair&lt;std::string const, std::string&gt; &gt; &gt;::~_Rb_tree() in /usr/include/c++/4.9/bits/stl_tree.h:715
  8: std::map&lt;std::string, std::string, std::less&lt;std::string&gt;, std::allocator&lt;std::pair&lt;std::string const, std::string&gt; &gt; &gt;::~map() in /usr/include/c++/4.9/bits/stl_map.h:96
  9: __run_exit_handlers in /build/buildd/glibc-2.21/stdlib/exit.c:82
  10: exit in /build/buildd/glibc-2.21/stdlib/exit.c:104
  11: (below main) in /build/buildd/glibc-2.21/csu/libc-start.c:323
```

We've seen already a couple of problems with the global initialization order. With this fix, the test execute is stable now at least on my local machine. Still it's not 100% sure that there are not more problems.

@notspiff, @afedchin ping.
