### PR TITLE
Fix CTagLoaderTagLib::AddArtistRole to check values size

### DIFF
--- a/xbmc/music/tags/TagLoaderTagLib.cpp
+++ b/xbmc/music/tags/TagLoaderTagLib.cpp
@@ -938,7 +938,7 @@ void CTagLoaderTagLib::AddArtistRole(CMusicInfoTag &tag, const std::vector<std::
   if (values.size() % 2 != 0) // Must contain an even number of entries 
     return;
 
-  for (size_t i = 0; i < values.size() - 1; i += 2)
+  for (size_t i = 0; i + 1 < values.size(); i += 2)
     tag.AddArtistRole(values[i], StringUtils::Split(values[i + 1], ","));
 }
 


### PR DESCRIPTION
@fritsch as discussed here https://github.com/xbmc/xbmc/commit/28914ca0680a5e77ed938546a3ba1eb62073cd07#commitcomment-16140794
