### PR TITLE
[addons] label2 cleanup

### DIFF
--- a/xbmc/addons/GUIViewStateAddonBrowser.cpp
+++ b/xbmc/addons/GUIViewStateAddonBrowser.cpp
@@ -40,7 +40,7 @@ CGUIViewStateAddonBrowser::CGUIViewStateAddonBrowser(const CFileItemList& items)
   }
   else
   {
-    AddSortMethod(SortByLabel, SortAttributeIgnoreFolders, 551, LABEL_MASKS("%L", "%I", "%L", ""));  // Filename, Size | Foldername, empty
+    AddSortMethod(SortByLabel, SortAttributeIgnoreFolders, 551, LABEL_MASKS("%L", "%s", "%L", "%s"));
 
     if (URIUtils::PathStarts(items.GetPath(), "addons://sources/"))
       AddSortMethod(SortByLastUsed, 12012, LABEL_MASKS("%L", "%u", "%L", "%u"),

--- a/xbmc/addons/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/GUIWindowAddonBrowser.cpp
@@ -138,7 +138,7 @@ bool CGUIWindowAddonBrowser::OnMessage(CGUIMessage& message)
           CFileItemPtr item = m_vecItems->Get(i);
           if (item->GetProperty("Addon.ID") == message.GetStringParam())
           {
-            SetItemLabel2(item);
+            UpdateStatus(item);
             return true;
           }
         }
@@ -369,14 +369,16 @@ bool CGUIWindowAddonBrowser::GetDirectory(const std::string& strDirectory, CFile
   }
 
   for (int i = 0; i < items.Size(); ++i)
-    SetItemLabel2(items[i]);
+    UpdateStatus(items[i]);
 
   return result;
 }
 
-void CGUIWindowAddonBrowser::SetItemLabel2(CFileItemPtr item)
+void CGUIWindowAddonBrowser::UpdateStatus(const CFileItemPtr& item)
 {
-  if (!item || item->m_bIsFolder) return;
+  if (!item || item->m_bIsFolder)
+    return;
+
   unsigned int percent;
   if (CAddonInstaller::GetInstance().GetProgress(item->GetProperty("Addon.ID").asString(), percent))
   {
@@ -386,9 +388,6 @@ void CGUIWindowAddonBrowser::SetItemLabel2(CFileItemPtr item)
   }
   else
     item->ClearProperty("Addon.Downloading");
-  item->SetLabel2(item->GetProperty("Addon.Status").asString());
-  // to avoid the view state overriding label 2
-  item->SetLabelPreformated(true);
 }
 
 bool CGUIWindowAddonBrowser::Update(const std::string &strDirectory, bool updateFilterPath /* = true */)

--- a/xbmc/addons/GUIWindowAddonBrowser.h
+++ b/xbmc/addons/GUIWindowAddonBrowser.h
@@ -61,11 +61,6 @@ public:
   static int SelectAddonID(const std::vector<ADDON::TYPE> &types, std::vector<std::string> &addonIDs, bool showNone = false, bool showDetails = true, bool multipleSelection = true, bool showInstalled = true, bool showInstallable = false, bool showMore = true);
   
 protected:
-  /* \brief set label2 of an item based on the Addon.Status property
-   \param item the item to update
-   */
-  void SetItemLabel2(CFileItemPtr item);
-
   virtual void GetContextButtons(int itemNumber, CContextButtons &buttons) override;
   virtual bool OnContextButton(int itemNumber, CONTEXT_BUTTON button) override;
   virtual bool OnClick(int iItem, const std::string &player = "") override;
@@ -76,6 +71,7 @@ protected:
 
 private:
   void SetProperties();
+  void UpdateStatus(const CFileItemPtr& item);
   CProgramThumbLoader m_thumbLoader;
 };
 

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -528,7 +528,6 @@ CFileItemPtr CAddonsDirectory::FileItemFromAddon(const AddonPtr &addon,
     strLabel = StringUtils::Format("%s - %s", TranslateType(addon->Type(), true).c_str(), addon->Name().c_str());
   item->SetLabel(strLabel);
   item->SetArt("thumb", addon->Icon());
-  item->SetLabelPreformated(true);
   item->SetIconImage("DefaultAddon.png");
   if (URIUtils::IsInternetStream(addon->FanArt()) || CFile::Exists(addon->FanArt()))
     item->SetArt("fanart", addon->FanArt());

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -501,13 +501,13 @@ void CAddonsDirectory::GenerateAddonListing(const CURL &path,
     if (installed)
       pItem->SetProperty("Addon.Status", g_localizeStrings.Get(305));
     if (disabled)
-      pItem->SetProperty("Addon.Status",g_localizeStrings.Get(24023));
-    if (addon->Broken() == "DEPSNOTMET")
-      pItem->SetProperty("Addon.Status",g_localizeStrings.Get(24049));
-    else if (!addon->Broken().empty())
-      pItem->SetProperty("Addon.Status",g_localizeStrings.Get(24098));
+      pItem->SetProperty("Addon.Status", g_localizeStrings.Get(24023));
     if (hasUpdate)
-      pItem->SetProperty("Addon.Status",g_localizeStrings.Get(24068));
+      pItem->SetProperty("Addon.Status", g_localizeStrings.Get(24068));
+    if (addon->Broken() == "DEPSNOTMET")
+      pItem->SetProperty("Addon.Status", g_localizeStrings.Get(24049));
+    else if (!addon->Broken().empty())
+      pItem->SetProperty("Addon.Status", g_localizeStrings.Get(24098));
 
     items.Add(pItem);
   }

--- a/xbmc/programs/GUIWindowPrograms.cpp
+++ b/xbmc/programs/GUIWindowPrograms.cpp
@@ -173,24 +173,6 @@ bool CGUIWindowPrograms::OnPlayMedia(int iItem)
   return false;
 }
 
-bool CGUIWindowPrograms::GetDirectory(const std::string &strDirectory, CFileItemList &items)
-{
-  if (!CGUIMediaWindow::GetDirectory(strDirectory, items))
-    return false;
-
-  // don't allow the view state to change these
-  if (StringUtils::StartsWithNoCase(strDirectory, "addons://"))
-  {
-    for (int i=0;i<items.Size();++i)
-    {
-      items[i]->SetLabel2(items[i]->GetProperty("Addon.Version").asString());
-      items[i]->SetLabelPreformated(true);
-    }
-  }
-
-  return true;
-}
-
 std::string CGUIWindowPrograms::GetStartFolder(const std::string &dir)
 {
   std::string lower(dir); StringUtils::ToLower(lower);

--- a/xbmc/programs/GUIWindowPrograms.h
+++ b/xbmc/programs/GUIWindowPrograms.h
@@ -36,7 +36,6 @@ protected:
   virtual void OnItemLoaded(CFileItem* pItem) {};
   virtual bool Update(const std::string& strDirectory, bool updateFilterPath = true);
   virtual bool OnPlayMedia(int iItem);
-  virtual bool GetDirectory(const std::string &strDirectory, CFileItemList &items);
   virtual void GetContextButtons(int itemNumber, CContextButtons &buttons);
   virtual bool OnContextButton(int itemNumber, CONTEXT_BUTTON button);
   virtual std::string GetStartFolder(const std::string &dir);

--- a/xbmc/utils/LabelFormatter.cpp
+++ b/xbmc/utils/LabelFormatter.cpp
@@ -108,7 +108,7 @@ using namespace MUSIC_INFO;
  *  *t - Date Taken (suitable for Pictures)
  */
 
-#define MASK_CHARS "NSATBGYFLDIJRCKMEPHZOQUVXWacdiprtuv"
+#define MASK_CHARS "NSATBGYFLDIJRCKMEPHZOQUVXWacdiprstuv"
 
 CLabelFormatter::CLabelFormatter(const std::string &mask, const std::string &mask2)
 {
@@ -347,6 +347,10 @@ std::string CLabelFormatter::GetMaskContent(const CMaskString &mask, const CFile
   case 't': // Date Taken
     if (pic && pic->GetDateTimeTaken().IsValid())
       value = pic->GetDateTimeTaken().GetAsLocalizedDate();
+    break;
+  case 's': // Addon status
+    if (item->HasProperty("Addon.Status"))
+      value = item->GetProperty("Addon.Status").asString();
     break;
   case 'i': // Install date
     if (item->HasAddonInfo() && item->GetAddonInfo()->InstallDate().IsValid())

--- a/xbmc/utils/LabelFormatter.cpp
+++ b/xbmc/utils/LabelFormatter.cpp
@@ -349,16 +349,16 @@ std::string CLabelFormatter::GetMaskContent(const CMaskString &mask, const CFile
       value = pic->GetDateTimeTaken().GetAsLocalizedDate();
     break;
   case 'i': // Install date
-    if (item->HasAddonInfo())
-      value = item->GetAddonInfo()->InstallDate().GetAsLocalizedDateTime();
+    if (item->HasAddonInfo() && item->GetAddonInfo()->InstallDate().IsValid())
+      value = item->GetAddonInfo()->InstallDate().GetAsLocalizedDate();
     break;
   case 'u': // Last used
-    if (item->HasAddonInfo())
-      value = item->GetAddonInfo()->LastUsed().GetAsLocalizedDateTime();
+    if (item->HasAddonInfo() && item->GetAddonInfo()->LastUsed().IsValid())
+      value = item->GetAddonInfo()->LastUsed().GetAsLocalizedDate();
     break;
   case 'v': // Last updated
-    if (item->HasAddonInfo())
-      value = item->GetAddonInfo()->LastUpdated().GetAsLocalizedDateTime();
+    if (item->HasAddonInfo() && item->GetAddonInfo()->LastUpdated().IsValid())
+      value = item->GetAddonInfo()->LastUpdated().GetAsLocalizedDate();
     break;
   }
   if (!value.empty())


### PR DESCRIPTION
Fixes the label2 values for addon listings. It should now use the label mask from sorting as we do everywhere else.
