### PR TITLE
Move all log entries from addons to a component log

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -4947,7 +4947,13 @@ msgctxt "#10524"
 msgid "Movie information"
 msgstr ""
 
-#empty strings from id 10525 to 11999
+#empty strings from id 10525
+
+#: xbmc/settings/AdvancedSettings.cpp
+msgctxt "#10526"
+msgid "Verbose logging for the [B]Addon[/B] component"
+
+#empty strings from id 10527 to 11999
 
 #: xbmc/guilib/WindowIDs.h
 msgctxt "#12000"

--- a/xbmc/commons/ilog.h
+++ b/xbmc/commons/ilog.h
@@ -53,6 +53,7 @@
 #define LOGUPNP     (1 << (LOGMASKBIT + 8))
 #define LOGCEC      (1 << (LOGMASKBIT + 9))
 #define LOGVIDEO    (1 << (LOGMASKBIT + 10))
+#define LOGADDONS   (1 << (LOGMASKBIT + 12))
 
 #include "utils/params_check_macros.h"
 

--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -29,7 +29,6 @@
 
 #include "Application.h"
 #include "messaging/ApplicationMessenger.h"
-#include "utils/URIUtils.h"
 #include "aojsonrpc.h"
 #ifndef TARGET_WINDOWS
 #include "XTimeUtils.h"
@@ -135,7 +134,7 @@ namespace XBMCAddon
       XbmcThreads::EndTime endTime(timemillis);
       while (!endTime.IsTimePast())
       {
-        LanguageHook* lh = NULL;
+        LanguageHook* lh;
         {
           DelayedCallGuard dcguard;
           lh = dcguard.getLanguageHook(); // borrow this
@@ -144,7 +143,7 @@ namespace XBMCAddon
             nextSleep = 100; // only sleep for 100 millis
           ::Sleep(nextSleep);
         }
-        if (lh != NULL)
+        if (lh != nullptr)
           lh->MakePendingCalls();
       }
     }
@@ -180,8 +179,7 @@ namespace XBMCAddon
         {
           if (region)
           {
-            std::string region = "-" + g_langInfo.GetCurrentRegion();
-            return (lang += region);
+            return (lang += "-" + g_langInfo.GetCurrentRegion());
           }
           return lang;
         }
@@ -191,9 +189,8 @@ namespace XBMCAddon
           g_LangCodeExpander.ConvertToISO6391(lang, langCode);
           if (region)
           {
-            std::string region = g_langInfo.GetRegionLocale();
             std::string region2Code;
-            g_LangCodeExpander.ConvertToISO6391(region, region2Code);
+            g_LangCodeExpander.ConvertToISO6391(g_langInfo.GetRegionLocale(), region2Code);
             region2Code = "-" + region2Code;
             return (langCode += region2Code);
           }
@@ -205,9 +202,8 @@ namespace XBMCAddon
           g_LangCodeExpander.ConvertToISO6392T(lang, langCode);
           if (region)
           {
-            std::string region = g_langInfo.GetRegionLocale();
             std::string region3Code;
-            g_LangCodeExpander.ConvertToISO6392T(region, region3Code);
+            g_LangCodeExpander.ConvertToISO6392T(g_langInfo.GetRegionLocale(), region3Code);
             region3Code = "-" + region3Code;
             return (langCode += region3Code);
           }
@@ -243,41 +239,9 @@ namespace XBMCAddon
       MEMORYSTATUSEX stat;
       stat.dwLength = sizeof(MEMORYSTATUSEX);
       GlobalMemoryStatusEx(&stat);
-      return (long)(stat.ullAvailPhys  / ( 1024 * 1024 ));
+      return static_cast<long>(stat.ullAvailPhys  / ( 1024 * 1024 ));
     }
 
-    // getCpuTemp() method
-    // ## Doesn't work right, use getInfoLabel('System.CPUTemperature') instead.
-    /*PyDoc_STRVAR(getCpuTemp__doc__,
-      "getCpuTemp() -- Returns the current cpu temperature as an integer."
-      ""
-      "example:"
-      "  - cputemp = xbmc.getCpuTemp()");
-
-      PyObject* XBMC_GetCpuTemp(PyObject *self, PyObject *args)
-      {
-      unsigned short cputemp;
-      unsigned short cpudec;
-
-      _outp(0xc004, (0x4c<<1)|0x01);
-      _outp(0xc008, 0x01);
-      _outpw(0xc000, _inpw(0xc000));
-      _outp(0xc002, (0) ? 0x0b : 0x0a);
-      while ((_inp(0xc000) & 8));
-      cputemp = _inpw(0xc006);
-
-      _outp(0xc004, (0x4c<<1)|0x01);
-      _outp(0xc008, 0x10);
-      _outpw(0xc000, _inpw(0xc000));
-      _outp(0xc002, (0) ? 0x0b : 0x0a);
-      while ((_inp(0xc000) & 8));
-      cpudec = _inpw(0xc006);
-
-      if (cpudec<10) cpudec = cpudec * 100;
-      if (cpudec<100) cpudec = cpudec *10;
-
-      return PyInt_FromLong((long)(cputemp + cpudec / 1000.0f));
-      }*/
 
     String getInfoLabel(const char* cLine)
     {
@@ -364,7 +328,7 @@ namespace XBMCAddon
       XBMC_TRACE;
       Crc32 crc;
       crc.ComputeFromLowerCase(path);
-      return StringUtils::Format("%08x.tbn", (unsigned __int32)crc);
+      return StringUtils::Format("%08x.tbn", static_cast<unsigned __int32>(crc));
     }
 
     String makeLegalFilename(const String& filename, bool fatX)
@@ -476,7 +440,7 @@ namespace XBMCAddon
     {
       XBMC_TRACE;
       DelayedCallGuard dg;
-      return g_application.StartServer((CApplication::ESERVERS)iTyp, bStart != 0, bWait != 0);
+      return g_application.StartServer(static_cast<CApplication::ESERVERS>(iTyp), bStart != 0, bWait != 0);
     }
 
     void audioSuspend()

--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -72,10 +72,7 @@ namespace XBMCAddon
      *****************************************************************/
     void log(const char* msg, int level)
     {
-      // check for a valid loglevel
-      if (level < LOGDEBUG || level > LOGNONE)
-        level = LOGDEBUG;
-      CLog::Log(level, "%s", msg);
+      CLog::Log(LOGADDONS, "%s", msg);
     }
 
     void shutdown()
@@ -553,6 +550,6 @@ namespace XBMCAddon
     int getISO_639_2(){ return CLangCodeExpander::ISO_639_2; }
     int getENGLISH_NAME() { return CLangCodeExpander::ENGLISH_NAME; }
 
-    const int lLOGDEBUG = LOGDEBUG;
+    const int lLOGADDONS = LOGADDONS;
   }
 }

--- a/xbmc/interfaces/legacy/ModuleXbmc.h
+++ b/xbmc/interfaces/legacy/ModuleXbmc.h
@@ -24,7 +24,7 @@
 
 #include "utils/LangCodeExpander.h"
 #include "swighelper.h"
-#include <vector>
+//#include <vector>
 
 namespace XBMCAddon
 {
@@ -32,13 +32,13 @@ namespace XBMCAddon
   {
 #ifndef SWIG
     // This is a bit of a hack to get around a SWIG problem
-    extern const int lLOGDEBUG;
+    extern const int lLOGADDONS;
 #endif
 
     /**
      * log(msg[, level]) -- Write a string to XBMC's log file and the debug window.\n
      *     msg            : string - text to output.\n
-     *     level          : [opt] integer - log level to ouput at. (default=LOGDEBUG)\n
+     *     level          : [opt] integer - deprecated - log level to ouput at. (default=LOGADDONS)\n
      *     \n
      * *Note, You can use the above as keywords for arguments and skip certain optional arguments.\n
      *        Once you use a keyword, all following arguments require the keyword.\n
@@ -52,7 +52,7 @@ namespace XBMCAddon
      *           example:
      *             - xbmc.log(msg='This is a test string.', level=xbmc.LOGDEBUG);
      */
-    void log(const char* msg, int level = lLOGDEBUG);
+    void log(const char* msg, int level = lLOGADDONS);
 
     /**
      * Shutdown() -- Shutdown the htpc.

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -1319,6 +1319,7 @@ void CAdvancedSettings::SettingOptionsLoggingComponentsFiller(const CSetting *se
   list.push_back(std::make_pair(g_localizeStrings.Get(672), LOGFFMPEG));
   list.push_back(std::make_pair(g_localizeStrings.Get(676), LOGAUDIO));
   list.push_back(std::make_pair(g_localizeStrings.Get(680), LOGVIDEO));
+  list.push_back(std::make_pair(g_localizeStrings.Get(10526), LOGADDONS));
 #ifdef HAS_LIBRTMP
   list.push_back(std::make_pair(g_localizeStrings.Get(673), LOGRTMP));
 #endif

--- a/xbmc/utils/log.cpp
+++ b/xbmc/utils/log.cpp
@@ -24,6 +24,7 @@
 #include "threads/Thread.h"
 #include "utils/StringUtils.h"
 #include "CompileInfo.h"
+#include "settings/AdvancedSettings.h"
 
 static const char* const levelNames[] =
 {"DEBUG", "INFO", "NOTICE", "WARNING", "ERROR", "SEVERE", "FATAL", "NONE"};
@@ -166,25 +167,24 @@ int CLog::GetLogLevel()
 void CLog::SetExtraLogLevels(int level)
 {
   CSingleLock waitLock(s_globals.critSec);
-  s_globals.m_extraLogLevels = level;
+  s_globals.m_extraLogLevels = level & ~LOGMASK;
 }
 
 bool CLog::IsLogLevelLogged(int loglevel)
 {
   const int extras = (loglevel & ~LOGMASK);
-  if (extras != 0 && (s_globals.m_extraLogLevels & extras) == 0)
-    return false;
+  const bool canlog = (extras ? g_advancedSettings.CanLogComponent(extras) : true);
 
 #if defined(_DEBUG) || defined(PROFILE)
   return true;
 #else
   if (s_globals.m_logLevel >= LOG_LEVEL_DEBUG)
-    return true;
+    return canlog;
   if (s_globals.m_logLevel <= LOG_LEVEL_NONE)
     return false;
 
   // "m_logLevel" is "LOG_LEVEL_NORMAL"
-  return (loglevel & LOGMASK) >= LOGNOTICE;
+  return ((loglevel & LOGMASK) >= LOGNOTICE) && canlog;
 #endif
 }
 
@@ -212,7 +212,7 @@ bool CLog::WriteLogString(int logLevel, const std::string& logString)
                                   minute,
                                   second,
                                   (uint64_t)CThread::GetCurrentThreadId(),
-                                  levelNames[logLevel]) + strData;
+                                  levelNames[logLevel & LOGMASK]) + strData;
 
   return s_globals.m_platform.WriteStringToLog(strData);
 }


### PR DESCRIPTION
Will completely remove addons logging to the logfile without the component logging for addons enabled. If you enable it, it should be similiar to before.

In order to not break the api, I've left the parameter for the loglevel in the definition and maked it as deprecated.

This relies on https://github.com/xbmc/xbmc/pull/8562
specifically https://github.com/mk01/xbmc/commit/2e7d7943b284a62ae19847cd2da9d3025bafdecb
being merged.

Not sure if I like the wording/naming, so please let me know.
