### PR TITLE
mmal: Use correct pool destroy functions

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
@@ -145,7 +145,6 @@ CMMALVideo::~CMMALVideo()
 
   if (m_dec_input && m_dec_input->is_enabled)
     mmal_port_disable(m_dec_input);
-  m_dec_input = NULL;
 
   if (m_dec_output && m_dec_output->is_enabled)
     mmal_port_disable(m_dec_output);
@@ -162,8 +161,9 @@ CMMALVideo::~CMMALVideo()
       mmal_component_disable(m_dec);
 
   if (m_dec_input_pool)
-    mmal_pool_destroy(m_dec_input_pool);
+    mmal_port_pool_destroy(m_dec_input, m_dec_input_pool);
   m_dec_input_pool = NULL;
+  m_dec_input = NULL;
 
   if (m_deint)
     mmal_component_destroy(m_deint);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.cpp
@@ -565,16 +565,16 @@ void CMMALRenderer::UnInitMMAL()
   {
     mmal_port_flush(m_vout_input);
     mmal_port_disable(m_vout_input);
-    m_vout_input = NULL;
   }
 
   ReleaseBuffers();
 
   if (m_vout_input_pool)
   {
-    mmal_pool_destroy(m_vout_input_pool);
+    mmal_port_pool_destroy(m_vout_input, m_vout_input_pool);
     m_vout_input_pool = NULL;
   }
+  m_vout_input = NULL;
 
   if (m_vout)
   {


### PR DESCRIPTION
Currently cosmetic only as mmal_port_pool_destroy calls mmal_pool_destroy
but best to use the coerrect API in case the implementation changes.
