### PR TITLE
SinkPi: Correct setting of passthrough flag

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkPi.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPi.cpp
@@ -186,7 +186,7 @@ bool CAESinkPi::Initialize(AEAudioFormat &format, std::string &device)
   g_RBP.Initialize();
 
   /* if we are raw need to let gpu know */
-  m_passthrough = m_format.m_dataFormat == AE_FMT_RAW;
+  m_passthrough = format.m_dataFormat == AE_FMT_RAW;
 
   m_initDevice = device;
   m_initFormat = format;


### PR DESCRIPTION
This got broken in the VideoPlayer refactorisation.
m_format hasn't been updated when it is used.
