### PR TITLE
Avoid multiple queries in GetFoosByWhere when gathering details

### DIFF
--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -33,6 +33,7 @@
 #include <stdint.h>
 #include <string>
 #include <vector>
+#include <map>
 
 #include "XBDateTime.h"
 #include "utils/params_check_macros.h"
@@ -92,6 +93,19 @@ public:
   static bool EndsWithNoCase(const std::string &str1, const char *s2);
 
   static std::string Join(const std::vector<std::string> &strings, const std::string& delimiter);
+  template <typename T, typename U>
+  static std::string Join(const std::map<T, U>& input_map, const std::string& delimiter = ",") {
+    if (input_map.empty())
+      return "";
+
+    std::ostringstream ss;
+    for (auto const& element : input_map)
+      ss << element.first << delimiter;
+    std::string result = ss.str();
+    result.erase(result.size() - delimiter.size());
+    return result;
+  }
+
   /*! \brief Splits the given input string using the given delimiter into separate strings.
 
    If the given input string is empty the result will be an empty array (not

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -596,6 +596,7 @@ public:
   void DeleteBookMarkForEpisode(const CVideoInfoTag& tag);
   bool GetResumePoint(CVideoInfoTag& tag);
   bool GetStreamDetails(CFileItem& item);
+  bool GetStreamDetails(const std::string &media_type, std::map<int, CVideoInfoTag>& details);
   bool GetStreamDetails(CVideoInfoTag& tag) const;
 
   // scraper settings
@@ -698,6 +699,7 @@ public:
   bool LinkMovieToTvshow(int idMovie, int idShow, bool bRemove);
   bool IsLinkedToTvshow(int idMovie);
   bool GetLinksToTvShow(int idMovie, std::vector<int>& ids);
+  bool GetLinksToTvShow(std::map<int, CVideoInfoTag>& details);
 
   // general browsing
   bool GetGenresNav(const std::string& strBaseDir, CFileItemList& items, int idContent=-1, const Filter &filter = Filter(), bool countOnly = false);
@@ -900,8 +902,11 @@ protected:
   bool GetPeopleNav(const std::string& strBaseDir, CFileItemList& items, const char *type, int idContent = -1, const Filter &filter = Filter(), bool countOnly = false);
   bool GetNavCommon(const std::string& strBaseDir, CFileItemList& items, const char *type, int idContent=-1, const Filter &filter = Filter(), bool countOnly = false);
   void GetCast(int media_id, const std::string &media_type, std::vector<SActorInfo> &cast);
+  void GetCast(const std::string &media_type, std::map<int, CVideoInfoTag>& details);
   void GetTags(int media_id, const std::string &media_type, std::vector<std::string> &tags);
+  void GetTags(const std::string &media_type, std::map<int, CVideoInfoTag>& details);
   void GetRatings(int media_id, const std::string &media_type, RatingMap &ratings);
+  void GetRatings(const std::string &media_type, std::map<int, CVideoInfoTag>& details);
 
   void GetDetailsFromDB(std::unique_ptr<dbiplus::Dataset> &pDS, int min, int max, const SDbTableOffsets *offsets, CVideoInfoTag &details, int idxOffset = 2);
   void GetDetailsFromDB(const dbiplus::sql_record* const record, int min, int max, const SDbTableOffsets *offsets, CVideoInfoTag &details, int idxOffset = 2);


### PR DESCRIPTION
The goal of this pr is to avoid to query the database details for every item individually to improve speed with big requests.
To do that I collect the ids and gather the details all in one query organising them with a map.

This pr needs testing because different database structures can give different performance results..

According to my test on my database (on the getFoosByWhere so without json-rpc overhead) I get a HUGE improvement in MySQL in every media type (the connection is a big overhead for the database) and some improvement in SQLite.
In sqlite I have slightly slower performance for movies but 4 times faster for tv shows and 2 times faster for episodes (requesting all details)

This is only for details. If details aren't requested performance should be the same as before..

@Tolriq can you please do some performance test?
