### PR TITLE
IMX: Do not call non existing method SetSkipMode()

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
@@ -782,8 +782,6 @@ int CDVDVideoCodecIMX::Decode(BYTE *pData, int iSize, double dts, double pts)
       if (m_frameReported)
         m_bytesToBeConsumed += inData.nSize;
 
-      SetSkipMode();
-
       ret = VPU_DecDecodeBuf(m_vpuHandle, &inData, &decRet);
 #ifdef IMX_PROFILE_BUFFERS
       unsigned long long dec_single_call = XbmcThreads::SystemClockMillis()-before_dec;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecIMX.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecIMX.h
@@ -308,7 +308,6 @@ public:
   virtual bool Open(CDVDStreamInfo &hints, CDVDCodecOptions &options);
   virtual void Dispose();
   virtual int  Decode(BYTE *pData, int iSize, double dts, double pts);
-  virtual void SetSkipMode();
   virtual void Reset();
   virtual bool ClearPicture(DVDVideoPicture *pDvdVideoPicture);
   virtual bool GetPicture(DVDVideoPicture *pDvdVideoPicture);


### PR DESCRIPTION
Fix up after: 65b5e57172cc66e143bb577e9fcb4041cbcc7c1c

It did not compile anymore - seems interest on IMX6 is converging against zero :-)
