### PR TITLE
[gui] change CGUIEditControl to use CVariant

### DIFF
--- a/xbmc/guilib/GUIEditControl.cpp
+++ b/xbmc/guilib/GUIEditControl.cpp
@@ -30,6 +30,7 @@
 #include "XBDateTime.h"
 #include "windowing/WindowingFactory.h"
 #include "utils/md5.h"
+#include "utils/Variant.h"
 #include "GUIUserMessages.h"
 
 #if defined(TARGET_DARWIN)
@@ -59,7 +60,7 @@ void CGUIEditControl::DefaultConstructor()
   m_textWidth = GetWidth();
   m_cursorPos = 0;
   m_cursorBlink = 0;
-  m_inputHeading = 0;
+  m_inputHeading = g_localizeStrings.Get(16028);
   m_inputType = INPUT_TYPE_TEXT;
   m_smsLastKey = 0;
   m_smsKeyIndex = 0;
@@ -303,14 +304,13 @@ void CGUIEditControl::OnClick()
   std::string utf8;
   g_charsetConverter.wToUTF8(m_text2, utf8);
   bool textChanged = false;
-  std::string heading = g_localizeStrings.Get(m_inputHeading ? m_inputHeading : 16028);
   switch (m_inputType)
   {
     case INPUT_TYPE_READONLY:
       textChanged = false;
       break;
     case INPUT_TYPE_NUMBER:
-      textChanged = CGUIDialogNumeric::ShowAndGetNumber(utf8, heading);
+      textChanged = CGUIDialogNumeric::ShowAndGetNumber(utf8, m_inputHeading);
       break;
     case INPUT_TYPE_SECONDS:
       textChanged = CGUIDialogNumeric::ShowAndGetSeconds(utf8, g_localizeStrings.Get(21420));
@@ -321,7 +321,7 @@ void CGUIEditControl::OnClick()
       dateTime.SetFromDBTime(utf8);
       SYSTEMTIME time;
       dateTime.GetAsSystemTime(time);
-      if (CGUIDialogNumeric::ShowAndGetTime(time, !heading.empty() ? heading : g_localizeStrings.Get(21420)))
+      if (CGUIDialogNumeric::ShowAndGetTime(time, !m_inputHeading.empty() ? m_inputHeading : g_localizeStrings.Get(21420)))
       {
         dateTime = CDateTime(time);
         utf8 = dateTime.GetAsLocalizedTime("", false);
@@ -337,7 +337,7 @@ void CGUIEditControl::OnClick()
         dateTime = CDateTime(2000, 1, 1, 0, 0, 0);
       SYSTEMTIME date;
       dateTime.GetAsSystemTime(date);
-      if (CGUIDialogNumeric::ShowAndGetDate(date, !heading.empty() ? heading : g_localizeStrings.Get(21420)))
+      if (CGUIDialogNumeric::ShowAndGetDate(date, !m_inputHeading.empty() ? m_inputHeading : g_localizeStrings.Get(21420)))
       {
         dateTime = CDateTime(date);
         utf8 = dateTime.GetAsDBDate();
@@ -346,7 +346,7 @@ void CGUIEditControl::OnClick()
       break;
     }
     case INPUT_TYPE_IPADDRESS:
-      textChanged = CGUIDialogNumeric::ShowAndGetIPAddress(utf8, heading);
+      textChanged = CGUIDialogNumeric::ShowAndGetIPAddress(utf8, m_inputHeading);
       break;
     case INPUT_TYPE_SEARCH:
       textChanged = CGUIKeyboardFactory::ShowAndGetFilter(utf8, true);
@@ -362,7 +362,7 @@ void CGUIEditControl::OnClick()
       // fallthrough
     case INPUT_TYPE_TEXT:
     default:
-      textChanged = CGUIKeyboardFactory::ShowAndGetInput(utf8, CVariant{heading}, true, m_inputType == INPUT_TYPE_PASSWORD || m_inputType == INPUT_TYPE_PASSWORD_MD5);
+      textChanged = CGUIKeyboardFactory::ShowAndGetInput(utf8, m_inputHeading, true, m_inputType == INPUT_TYPE_PASSWORD || m_inputType == INPUT_TYPE_PASSWORD_MD5);
       break;
   }
   if (textChanged)
@@ -390,10 +390,13 @@ void CGUIEditControl::UpdateText(bool sendUpdate)
   SetInvalid();
 }
 
-void CGUIEditControl::SetInputType(CGUIEditControl::INPUT_TYPE type, int heading)
+void CGUIEditControl::SetInputType(CGUIEditControl::INPUT_TYPE type, CVariant heading)
 {
   m_inputType = type;
-  m_inputHeading = heading;
+  if (heading.isString())
+    m_inputHeading = heading.asString();
+  else if (heading.isInteger() && heading.asInteger())
+    m_inputHeading = g_localizeStrings.Get(static_cast<uint32_t>(heading.asInteger()));
   // TODO: Verify the current input string?
 }
 

--- a/xbmc/guilib/GUIEditControl.h
+++ b/xbmc/guilib/GUIEditControl.h
@@ -31,6 +31,7 @@
 #include "GUIButtonControl.h"
 #include "utils/Stopwatch.h"
 #include "utils/StringValidation.h"
+#include "utils/Variant.h"
 
 /*!
  \ingroup controls
@@ -75,7 +76,7 @@ public:
   unsigned int GetCursorPosition() const;
   void SetCursorPosition(unsigned int iPosition);
 
-  void SetInputType(INPUT_TYPE type, int heading);
+  void SetInputType(INPUT_TYPE type, CVariant heading);
 
   void SetTextChangeActions(const CGUIAction& textChangeActions) { m_textChangeActions = textChangeActions; };
 
@@ -119,7 +120,7 @@ protected:
   unsigned int m_cursorPos;
   unsigned int m_cursorBlink;
 
-  int m_inputHeading;
+  std::string m_inputHeading;
   INPUT_TYPE m_inputType;
   bool m_isMD5;
 


### PR DESCRIPTION
This change is a independent part of my binary add-on lib rework.

There becomes the use of integer string value replaced with CVariant to allow the use of a complete string from add-on.
