### PR TITLE
[builtins] add doxygen related documentation

### DIFF
--- a/xbmc/interfaces/builtins/AddonBuiltins.cpp
+++ b/xbmc/interfaces/builtins/AddonBuiltins.cpp
@@ -307,6 +307,106 @@ static int UpdateLocals(const std::vector<std::string>& params)
   return 0;
 }
 
+// Note: For new Texts with comma add a "\" before!!! Is used for table text.
+//
+/// \page page_List_of_built_in_functions
+/// \section built_in_functions_1 Add-on built-in's
+///
+/// -----------------------------------------------------------------------------
+///
+/// \table_start
+///   \table_h2_l{
+///     Function,
+///     Description }
+///   \table_row2_l{
+///     <b>`Addon.Default.OpenSettings(extensionpoint)`</b>
+///     ,
+///     Open a settings dialog for the default addon of the given type
+///     (extensionpoint)
+///     @param[in] extensionpoint        The add-on type
+///   }
+///   \table_row2_l{
+///     <b>`Addon.Default.Set(extensionpoint)`</b>
+///     ,
+///     Open a select dialog to allow choosing the default addon of the given type
+///     (extensionpoint)
+///     @param[in] extensionpoint        The add-on type
+///   }
+///   \table_row2_l{
+///     <b>`Addon.OpenSettings(id)`</b>
+///     ,
+///     Open a settings dialog for the addon of the given id
+///     @param[in] id                    The add-on ID
+///   }
+///   \table_row2_l{
+///     <b>`InstallAddon(id)`</b>
+///     ,
+///     Install the specified plugin/script
+///     @param[in] id                    The add-on id
+///   }
+///   \table_row2_l{
+///     <b>`RunAddon(id[\,opt])`</b>
+///     ,
+///     Runs the specified plugin/script
+///     @param[in] id                    The add-on id.
+///     @param[in] opt                   is blank for no add-on parameters\n
+///     or
+///     @param[in] opt                   Add-on parameters in url format\n
+///     or
+///     @param[in] opt[\,...]            Additional parameters in format param=value.
+///   }
+///   \table_row2_l{
+///     <b>`RunAppleScript(script[\,args]*)`</b>
+///     ,
+///     Run the specified AppleScript command
+///     @param[in] script                Is the URL to the apple script\n
+///     or
+///     @param[in] script                Is the addon-ID to the script add-on\n
+///     or
+///     @param[in] script                Is the URL to the python script.
+///
+///     @note Set the OnlyApple template parameter to true to only attempt
+///     execution of applescripts.
+///   }
+///   \table_row2_l{
+///     <b>`RunPlugin(plugin)`</b>
+///     ,
+///     Runs the plugin. Full path must be specified. Does not work for folder
+///     plugins
+///     @param[in] plugin                plugin:// URL to script.
+///   }
+///   \table_row2_l{
+///     <b>`RunScript(script[\,args]*)`</b>
+///     ,
+///     Runs the python script. You must specify the full path to the script. If
+///     the script is an add-on\, you can also execute it using its add-on id. As
+///     of 2007/02/24\, all extra parameters are passed to the script as arguments
+///     and can be accessed by python using sys.argv
+///     @param[in] script                Is the addon-ID to the script add-on\n
+///     or
+///     @param[in] script                Is the URL to the python script.
+///   }
+///   \table_row2_l{
+///     <b>`StopScript(id)`</b>
+///     ,
+///     Stop the script by ID or path\, if running
+///     @param[in] id                    The add-on ID of the script to stop\n
+///     or
+///     @param[in] id                    The URL of the script to stop.
+///   }
+///   \table_row2_l{
+///     <b>`UpdateAddonRepos`</b>
+///     ,
+///     Triggers a forced update of enabled add-on repositories.
+///   }
+///   \table_row2_l{
+///     <b>`UpdateLocalAddons`</b>
+///     ,
+///     Triggers a scan of local add-on directories.
+///   }
+///  \table_end
+///
+
 CBuiltins::CommandMap CAddonBuiltins::GetOperations() const
 {
   return {

--- a/xbmc/interfaces/builtins/AndroidBuiltins.cpp
+++ b/xbmc/interfaces/builtins/AndroidBuiltins.cpp
@@ -37,6 +37,30 @@ static int LaunchAndroidActivity(const std::vector<std::string>& params)
   return 0;
 }
 
+// Note: For new Texts with comma add a "\" before!!! Is used for table text.
+//
+/// \page page_List_of_built_in_functions
+/// \section built_in_functions_2 Android built-in's
+///
+/// -----------------------------------------------------------------------------
+///
+/// \table_start
+///   \table_h2_l{
+///     Function,
+///     Description }
+///   \table_row2_l{
+///     <b>`StartAndroidActivity(package\,[intent\,dataType\,dataURI])`</b>
+///     ,
+///     Launch an Android native app with the given package name. Optional parms
+///     (in order): intent\, dataType\, dataURI.
+///     @param[in] package
+///     @param[in] intent (optional)
+///     @param[in] datatype (optional)
+///     @param[in] dataURI (optional)
+///   }
+/// \table_end
+///
+
 CBuiltins::CommandMap CAndroidBuiltins::GetOperations() const
 {
   return {

--- a/xbmc/interfaces/builtins/ApplicationBuiltins.cpp
+++ b/xbmc/interfaces/builtins/ApplicationBuiltins.cpp
@@ -149,6 +149,66 @@ static int WakeOnLAN(const std::vector<std::string>& params)
   return 0;
 }
 
+// Note: For new Texts with comma add a "\" before!!! Is used for table text.
+//
+/// \page page_List_of_built_in_functions
+/// \section built_in_functions_3 Application built-in's
+///
+/// -----------------------------------------------------------------------------
+///
+/// \table_start
+///   \table_h2_l{
+///     Function,
+///     Description }
+///   \table_row2_l{
+///     <b>`Extract(url [\, dest])`</b>
+///     ,
+///     Extracts a specified archive to an optionally specified 'absolute' path.
+///     @param[in] url                   The archive URL.
+///     @param[in] dest                  Destination path (optional).
+///             @note If not given\, extracts to folder with archive.
+///   }
+///   \table_row2_l{
+///     <b>`Mute`</b>
+///     ,
+///     Mutes (or unmutes) the volume.
+///   }
+///   \table_row2_l{
+///     <b>`NotifyAll(sender\, data [\, json])`</b>
+///     ,
+///     Notify all connected clients
+///     @param[in] sender                 Sender.
+///     @param[in] data                   Data.
+///     @param[in] json                   JSON with extra parameters (optional).
+///   }
+///   \table_row2_l{
+///     <b>`SetVolume(percent[\,showvolumebar])`</b>
+///     ,
+///     Sets the volume to the percentage specified. Optionally\, show the Volume
+///     Dialog in Kodi when setting the volume.
+///     @param[in] percent               Volume level.
+///     @param[in] showvolumebar         Add "showVolumeBar" to show volume bar (optional).
+///   }
+///   \table_row2_l{
+///     <b>`Skin.ToggleDebug`</b>
+///     ,
+///     Toggles skin debug info on/off
+///   }
+///   \table_row2_l{
+///     <b>`ToggleDPMS`</b>
+///     ,
+///     Toggle DPMS mode manually
+///   }
+///   \table_row2_l{
+///     <b>`WakeOnLan(mac)`</b>
+///     ,
+///     Sends the wake-up packet to the broadcast address for the specified MAC
+///     address (Format: FF:FF:FF:FF:FF:FF or FF-FF-FF-FF-FF-FF).
+///     @param[in] mac                   The MAC of the host to wake.
+///   }
+///  \table_end
+///
+
 CBuiltins::CommandMap CApplicationBuiltins::GetOperations() const
 {
   return {

--- a/xbmc/interfaces/builtins/CECBuiltins.cpp
+++ b/xbmc/interfaces/builtins/CECBuiltins.cpp
@@ -55,6 +55,35 @@ static int ToggleState(const std::vector<std::string>& params)
   return 0;
 }
 
+// Note: For new Texts with comma add a "\" before!!! Is used for table text.
+//
+/// \page page_List_of_built_in_functions
+/// \section built_in_functions_4 CEC built-in's
+///
+/// -----------------------------------------------------------------------------
+///
+/// \table_start
+///   \table_h2_l{
+///     Function,
+///     Description }
+///   \table_row2_l{
+///     <b>`CECActivateSource`</b>
+///     ,
+///     Wake up playing device via a CEC peripheral
+///   }
+///   \table_row2_l{
+///     <b>`CECStandby`</b>
+///     ,
+///     Put playing device on standby via a CEC peripheral
+///   }
+///   \table_row2_l{
+///     <b>`CECToggleState`</b>
+///     ,
+///     Toggle state of playing device via a CEC peripheral
+///   }
+///  \table_end
+///
+
 CBuiltins::CommandMap CCECBuiltins::GetOperations() const
 {
   return {

--- a/xbmc/interfaces/builtins/GUIBuiltins.cpp
+++ b/xbmc/interfaces/builtins/GUIBuiltins.cpp
@@ -411,6 +411,177 @@ static int ToggleDirty(const std::vector<std::string>&)
   return 0;
 }
 
+// Note: For new Texts with comma add a "\" before!!! Is used for table text.
+//
+/// \page page_List_of_built_in_functions
+/// \section built_in_functions_5 GUI built-in's
+///
+/// -----------------------------------------------------------------------------
+///
+/// \table_start
+///   \table_h2_l{
+///     Function,
+///     Description }
+///   \table_row2_l{
+///     <b>`Action(action[\,window])`</b>
+///     ,
+///     Executes an action (same as in keymap) for the given window or the
+///     active window if the parameter window is omitted. The parameter window
+///     can either be the window's id\, or in the case of a standard window\, the
+///     window's name. See here for a list of window names\, and their respective
+///     ids.
+///     @param[in] action                Action to execute.
+///     @param[in] window                Window to send action to (optional).
+///   }
+///   \table_row2_l{
+///     <b>`CancelAlarm(name[\,silent])`</b>
+///     ,
+///     Cancel a running alarm. Set silent to true to hide the alarm notification.
+///     @param[in] silent                Send "true" or "silent" to silently cancel alarm (optional).
+///   }
+///   \table_row2_l{
+///     <b>`AlarmClock(name\,command\,time[\,silent\,loop])`</b>
+///     ,
+///     Pops up a dialog asking for the length of time for the alarm (unless the
+///     parameter time is specified)\, and starts a timer. When the timer runs out\,
+///     it'll execute the built-in command (the parameter command) if it is
+///     specified\, otherwise it'll pop up an alarm notice. Add silent to hide the
+///     alarm notification. Add loop for the alarm to execute the command each
+///     time the specified time interval expires.
+///     @param[in] name                  name
+///     @param[in] command               command
+///     @param[in] time                  Length in seconds (optional).
+///     @param[in] silent                Send "silent" to suppress notifications.
+///     @param[in] loop                  Send "loop" to loop the alarm.
+///   }
+///   \table_row2_l{
+///     <b>`ActivateWindow(window[\,dir])`</b>
+///     ,
+///     Opens the given window. The parameter window can either be the window's id\,
+///     or in the case of a standard window\, the window's name. See here for a list
+///     of window names\, and their respective ids. If\, furthermore\, the window is
+///     Music\, Video\, Pictures\, or Program files\, then the optional dir parameter
+///     specifies which folder Kodi should default to once the window is opened.
+///     This must be a source as specified in sources.xml\, or a subfolder of a
+///     valid source. For some windows (MusicLibrary and VideoLibrary)\, the return
+///     parameter may be specified\, which indicates that Kodi should use this
+///     folder as the "root" of the level\, and thus the "parent directory" action
+///     from within this folder will return the user to where they were prior to
+///     the window activating.
+///     @param[in] window                The window name.
+///     @param[in] dir                   Window starting folder (optional).
+///   }
+///   \table_row2_l{
+///     <b>`ActivateWindowAndFocus(id1\, id2\,item1\, id3\,item2)`</b>
+///     ,
+///     Activate window with id1\, first focus control id2 and then focus control
+///     id3. if either of the controls is a container\, you can specify which
+///     item to focus (else\, set it to 0).
+///     @param[in] id1                   The window name.
+///     @param[in] params[1\,...]         Pair of (container ID\, focus item).
+///   }
+///   \table_row2_l{
+///     <b>`ClearProperty(key[\,id])`</b>
+///     ,
+///     Clears a window property for the current focused window/dialog(key)\, or
+///     the specified window (key\,id).
+///     @param[in] key                   The property to clear.
+///     @param[in] id                    The window to clear property in (optional).
+///   }
+///   \table_row2_l{
+///     <b>`Dialog.Close(dialog[\,force])`</b>
+///     ,
+///     Close a dialog. Set force to true to bypass animations. Use (all\,true)
+///     to close all opened dialogs at once.
+///     @param[in] dialog                Send "all" to close all dialogs\, or dialog name.
+///     @param[in] force                 Send "true" to force close (skip animations) (optional).
+///   }
+///   \table_row2_l{
+///     <b>`Notification(header\,message[\,time\,image])`</b>
+///     ,
+///     Will display a notification dialog with the specified header and message\,
+///     in addition you can set the length of time it displays in milliseconds
+///     and a icon image.
+///     @param[in] header                Notification title.
+///     @param[in] message               Notification text.
+///     @param[in] time                  Display time in milliseconds (optional).
+///     @param[in] image                 Notification icon (optional).
+///   }
+///   \table_row2_l{
+///     <b>`RefreshRSS`</b>
+///     ,
+///     Reload RSS feeds from RSSFeeds.xml
+///   }
+///   \table_row2_l{
+///     <b>`ReplaceWindow(window\,dir)`</b>
+///     ,
+///     Replaces the current window with the given window. This is the same as
+///     ActivateWindow() but it doesn't update the window history list\, so when
+///     you go back from the new window it will not return to the previous
+///     window\, rather will return to the previous window's previous window.
+///     @param[in] window                The window name.
+///     @param[in] dir                   Window starting folder (optional).
+///   }
+///   \table_row2_l{
+///     <b>`ReplaceWindowAndFocus(id1\, id2\,item1\, id3\,item2)`</b>
+///     ,
+///     Replace window with id1\, first focus control id2 and then focus control
+///     id3. if either of the controls is a container\, you can specify which
+///     item to focus (else\, set it to 0).
+///     @param[in] id1                   The window name.
+///     @param[in] params[1\,...]        Pair of (container ID\, focus item).
+///   }
+///   \table_row2_l{
+///     <b>`Resolution(resIdent)`</b>
+///     ,
+///     Change Kodi's Resolution (default is 4x3).
+///     param[in] resIdent               A resolution identifier.
+///     |          | Identifiers |          |
+///     |:--------:|:-----------:|:--------:|
+///     | pal      | pal16x9     | ntsc     |
+///     | ntsc16x9 | 720p        | 720psbs  |
+///     | 720ptb   | 1080psbs    | 1080ptb  |
+///     | 1080i    |             |          |
+///   }
+///   \table_row2_l{
+///     <b>`SetGUILanguage(lang)`</b>
+///     ,
+///     Set GUI Language
+///     @param[in] lang                  The language to use.
+///   }
+///   \table_row2_l{
+///     <b>`SetProperty(key\,value[\,id])`</b>
+///     ,
+///     Sets a window property for the current window (key\,value)\, or the 
+///     specified window (key\,value\,id).
+///     @param[in] key                   The property to set.
+///     @param[in] value                 The property value.
+///     @param[in] id                    The window to set property in (optional).
+///   }
+///   \table_row2_l{
+///     <b>`SetStereoMode(ident)`</b>
+///     ,
+///     Changes the stereo mode of the GUI.
+///     Params can be:
+///     toggle\, next\, previous\, select\, tomono or any of the supported stereomodes (off\,
+///     split_vertical\, split_horizontal\, row_interleaved\, hardware_based\, anaglyph_cyan_red\, anaglyph_green_magenta\, monoscopic)
+///     @param[in] ident                 Stereo mode identifier.
+///   }
+///   \table_row2_l{
+///     <b>`TakeScreenshot(url[\,sync)`</b>
+///     ,
+///     Takes a Screenshot
+///     @param[in] url                   URL to save file to. Blank to use default.
+///     @param[in] sync                  Add "sync" to run synchronously (optional).
+///   }
+///   \table_row2_l{
+///     <b>`ToggleDirtyRegionVisualization`</b>
+///     ,
+///     makes dirty regions visible for debugging proposes.
+///   }
+///  \table_end
+///
+
 CBuiltins::CommandMap CGUIBuiltins::GetOperations() const
 {
   return {

--- a/xbmc/interfaces/builtins/GUIContainerBuiltins.cpp
+++ b/xbmc/interfaces/builtins/GUIContainerBuiltins.cpp
@@ -119,6 +119,70 @@ static int Update(const std::vector<std::string>& params)
   return 0;
 }
 
+// Note: For new Texts with comma add a "\" before!!! Is used for table text.
+//
+/// \page page_List_of_built_in_functions
+/// \section built_in_functions_6 GUI container built-in's
+///
+/// -----------------------------------------------------------------------------
+///
+/// \table_start
+///   \table_h2_l{
+///     Function,
+///     Description }
+///   \table_row2_l{
+///     <b>`Container.NextSortMethod`</b>
+///     ,
+///     Change to the next sort method.
+///   }
+///   \table_row2_l{
+///     <b>`Container.NextViewMode`</b>
+///     ,
+///     Select the next view mode.
+///   }
+///   \table_row2_l{
+///     <b>`Container.PreviousSortMethod`</b>
+///     ,
+///     Change to the previous sort method.
+///   }
+///   \table_row2_l{
+///     <b>`Container.PreviousViewMode`</b>
+///     ,
+///     Select the previous view mode.
+///   }
+///   \table_row2_l{
+///     <b>`Container.Refresh(url)`</b>
+///     ,
+///     Refresh current listing
+///     @param[in] url                   The URL to refresh window at.
+///   }
+///   \table_row2_l{
+///     <b>`Container.SetSortMethod(id)`</b>
+///     ,
+///     Change to the specified sort method. (For list of ID's \ref SortBy "see List" of sort methods below)
+///     @param[in] id                    ID of sort method.
+///   }
+///   \table_row2_l{
+///     <b>`Container.SetViewMode(id)`</b>
+///     ,
+///     Set the current view mode (list\, icons etc.) to the given container id.
+///     @param[in] id                    ID of view mode.
+///   }
+///   \table_row2_l{
+///     <b>`Container.SortDirection`</b>
+///     ,
+///     Toggle the sort direction
+///   }
+///   \table_row2_l{
+///     <b>`Container.Update(url\,[replace])`</b>
+///     ,
+///     Update current listing. Send `Container.Update(path\,replace)` to reset the path history.
+///     @param[in] url                   The URL to update listing at.
+///     @param[in] replace               "replace" to reset history (optional).
+///   }
+/// \table_end
+///
+
 CBuiltins::CommandMap CGUIContainerBuiltins::GetOperations() const
 {
   return {

--- a/xbmc/interfaces/builtins/GUIControlBuiltins.cpp
+++ b/xbmc/interfaces/builtins/GUIControlBuiltins.cpp
@@ -115,6 +115,68 @@ static int ShiftPage(const std::vector<std::string>& params)
   return 0;
 }
 
+// Note: For new Texts with comma add a "\" before!!! Is used for table text.
+//
+/// \page page_List_of_built_in_functions
+/// \section built_in_functions_7 GUI control built-in's
+///
+/// -----------------------------------------------------------------------------
+///
+/// \table_start
+///   \table_h2_l{
+///     Function,
+///     Description }
+///   \table_row2_l{
+///     <b>`control.message(controlId\, action[\, windowId])`</b>
+///     ,
+///     Send a given message to a control within a given window
+///     @param[in] controlId             ID of control.
+///     @param[in] action                Action name.
+///     @param[in] windowId              ID of window with control (optional).
+///   }
+///   \table_row2_l{
+///     <b>`control.move(id\, offset)`</b>
+///     ,
+///     Tells the specified control to 'move' to another entry specified by offset
+///     @param[in] id                    ID of control.
+///     @param[in] offset                Offset of move.
+///   }
+///   \table_row2_l{
+///     <b>`control.setfocus(controlId[\, subitemId])`</b>
+///     ,
+///     Change current focus to a different control id
+///     @param[in] controlId             ID of control.
+///     @param[in] subitemId             ID of subitem of control (optional).
+///   }
+///   \table_row2_l{
+///     <b>`pagedown(controlId)`</b>
+///     ,
+///     Send a page down event to the pagecontrol with given id
+///     @param[in] controlId             ID of control.
+///   }
+///   \table_row2_l{
+///     <b>`pageup(controlId)`</b>
+///     ,
+///     Send a page up event to the pagecontrol with given id
+///     @param[in] controlId             ID of control.
+///   }
+///   \table_row2_l{
+///     <b>`sendclick(controlId [\, windowId])`</b>
+///     ,
+///     Send a click message from the given control to the given window
+///     @param[in] controlId             ID of control.
+///     @param[in] windowId              ID for window with control (optional).
+///   }
+///   \table_row2_l{
+///     <b>`setfocus`</b>
+///     ,
+///     Change current focus to a different control id
+///     @param[in] controlId             ID of control.
+///     @param[in] subitemId             ID of subitem of control (optional).
+///   }
+///  \table_end
+///
+
 CBuiltins::CommandMap CGUIControlBuiltins::GetOperations() const
 {
   return {

--- a/xbmc/interfaces/builtins/LibraryBuiltins.cpp
+++ b/xbmc/interfaces/builtins/LibraryBuiltins.cpp
@@ -211,6 +211,48 @@ static int SearchVideoLibrary(const std::vector<std::string>& params)
   return 0;
 }
 
+// Note: For new Texts with comma add a "\" before!!! Is used for table text.
+//
+/// \page page_List_of_built_in_functions
+/// \section built_in_functions_8 Library built-in's
+///
+/// -----------------------------------------------------------------------------
+///
+/// \table_start
+///   \table_h2_l{
+///     Function,
+///     Description }
+///   \table_row2_l{
+///     <b>`cleanlibrary(type)`</b>
+///     ,
+///      Clean the video/music library
+///     @param[in] type                  "video" or "music".
+///   }
+///   \table_row2_l{
+///     <b>`exportlibrary(type [\, exportSingeFile\, exportThumbs\, overwrite\, exportActorThumbs])`</b>
+///     ,
+///     Export the video/music library
+///     @param[in] type                  "video" or "music".
+///     @param[in] exportSingleFile      Add "true" to export to a single file (optional).
+///     @param[in] exportThumbs          Add "true" to export thumbs (optional).
+///     @param[in] overwrite             Add "true" to overwrite existing files (optional).
+///     @param[in] exportActorThumbs     Add "true" to export actor thumbs (optional).
+///   }
+///   \table_row2_l{
+///     <b>`updatelibrary([type\, suppressDialogs])`</b>
+///     ,
+///     Update the selected library (music or video)
+///     @param[in] type                  "video" or "music".
+///     @param[in] suppressDialogs       Add "true" to suppress dialogs (optional).
+///   }
+///   \table_row2_l{
+///     <b>`videolibrary.search`</b>
+///     ,
+///     Brings up a search dialog which will search the library
+///   }
+///  \table_end
+///
+
 CBuiltins::CommandMap CLibraryBuiltins::GetOperations() const
 {
   return {

--- a/xbmc/interfaces/builtins/OpticalBuiltins.cpp
+++ b/xbmc/interfaces/builtins/OpticalBuiltins.cpp
@@ -54,6 +54,30 @@ static int RipCD(const std::vector<std::string>& params)
   return 0;
 }
 
+// Note: For new Texts with comma add a "\" before!!! Is used for table text.
+//
+/// \page page_List_of_built_in_functions
+/// \section built_in_functions_9 Optical container built-in's
+///
+/// -----------------------------------------------------------------------------
+///
+/// \table_start
+///   \table_h2_l{
+///     Function,
+///     Description }
+///   \table_row2_l{
+///     <b>`EjectTray`</b>
+///     ,
+///     Either opens or closes the DVD tray\, depending on its current state.
+///   }
+///   \table_row2_l{
+///     <b>`RipCD`</b>
+///     ,
+///     Will rip the inserted CD from the DVD-ROM drive.
+///   }
+/// \table_end
+///
+
 CBuiltins::CommandMap COpticalBuiltins::GetOperations() const
 {
   return {

--- a/xbmc/interfaces/builtins/PVRBuiltins.cpp
+++ b/xbmc/interfaces/builtins/PVRBuiltins.cpp
@@ -53,6 +53,37 @@ static int SearchMissingIcons(const std::vector<std::string>& params)
   return 0;
 }
 
+// Note: For new Texts with comma add a "\" before!!! Is used for table text.
+//
+/// \page page_List_of_built_in_functions
+/// \section built_in_functions_10 PVR built-in's
+///
+/// -----------------------------------------------------------------------------
+///
+/// \table_start
+///   \table_h2_l{
+///     Function,
+///     Description }
+///   \table_row2_l{
+///     <b>`PVR.StartManager`</b>\n
+///     <b>`StartPVRManager`</b> (deprecated)
+///     ,
+///     (Re)Starts the PVR manager
+///   }
+///   \table_row2_l{
+///     <b>`PVR.StartManager`</b>\n
+///     <b>`StopPVRManager`</b> (deprecated)
+///     ,
+///     Stops the PVR manager
+///   }
+///   \table_row2_l{
+///     <b>`PVR.SearchMissingChannelIcons`</b>
+///     ,
+///     Will start a search for missing channel icons
+///   }
+/// \table_end
+///
+
 CBuiltins::CommandMap CPVRBuiltins::GetOperations() const
 {
   return {

--- a/xbmc/interfaces/builtins/PictureBuiltins.cpp
+++ b/xbmc/interfaces/builtins/PictureBuiltins.cpp
@@ -91,6 +91,50 @@ static int Slideshow(const std::vector<std::string>& params)
   return 0;
 }
 
+// Note: For new Texts with comma add a "\" before!!! Is used for table text 
+//
+/// \page page_List_of_built_in_functions
+/// \section built_in_functions_11 Picture built-in's
+///
+/// -----------------------------------------------------------------------------
+///
+/// \table_start
+///   \table_h2_l{
+///     Function,
+///     Description }
+///   \table_row2_l{
+///     <b>`RecursiveSlideShow(dir)`</b>
+///     ,
+///     Run a slideshow from the specified directory\, including all subdirs.
+///     @param[in] dir                   Path to run slideshow for.
+///     @param[in] random                Add "random" to randomize slideshow (optional).
+///     @param[in] notrandom             Add "notrandom" to not randomize slideshow (optional).
+///     @param[in] pause                 Add "pause" to start slideshow paused (optional).
+///     @param[in] beginslide            Add "beginslide=<number>" to start at a given slide (optional).
+///   }
+///   \table_row2_l{
+///     <b>`ShowPicture(picture)`</b>
+///     ,
+///     Display a picture by file path.
+///     @param[in] url                    URL of picture.
+///   }
+///   \table_row2_l{
+///     <b>`SlideShow(dir [\,recursive\, [not]random])`</b>
+///     ,
+///     Starts a slideshow of pictures in the folder dir. Optional parameters are
+///     <b>recursive</b>\, and **random** or **notrandom** slideshow\, adding images
+///     from sub-folders. The **random** and **notrandom** parameters override
+///     the Randomize setting found in the pictures media window.
+///     @param[in] dir                   Path to run slideshow for.
+///     @param[in] recursive             Add "recursive" to run a recursive slideshow (optional).
+///     @param[in] random                Add "random" to randomize slideshow (optional).
+///     @param[in] notrandom             Add "notrandom" to not randomize slideshow (optional).
+///     @param[in] pause                 Add "pause" to start slideshow paused (optional).
+///     @param[in] beginslide            Add "beginslide=<number>" to start at a given slide (optional).
+///   }
+/// \table_end
+///
+
 CBuiltins::CommandMap CPictureBuiltins::GetOperations() const
 {
   return {

--- a/xbmc/interfaces/builtins/PlayerBuiltins.cpp
+++ b/xbmc/interfaces/builtins/PlayerBuiltins.cpp
@@ -484,10 +484,91 @@ static int Seek(const std::vector<std::string>& params)
   return 0;
 }
 
+// Note: For new Texts with comma add a "\" before!!! Is used for table text.
+//
+/// \page page_List_of_built_in_functions
+/// \section built_in_functions_12 Player built-in's
+///
+/// -----------------------------------------------------------------------------
+///
+/// \table_start
+///   \table_h2_l{
+///     Function,
+///     Description }
+///   \table_row2_l{
+///     <b>`PlaysDisc(parm)`</b>\n
+///     <b>`PlayDVD(param)`</b>(deprecated)
+///     ,
+///     Plays the inserted disc\, like CD\, DVD or Blu-ray\, in the disc drive.
+///     @param[in] param                 "restart" to restart from resume point (optional)
+///   }
+///   \table_row2_l{
+///     <b>`PlayerControl(command[\,param])`</b>
+///     ,
+///     Allows control of music and videos. The command may be one of Play\, Stop\,
+///     Forward\, Rewind\, Next\, Previous\, BigSkipForward\, BigSkipBackward\,
+///     SmallSkipForward\, SmallSkipBackward\, Random\, RandomOn\, RandomOff\,
+///     Repeat\, RepeatOne\, RepeatAll\, RepeatOff\, Partymode(music) or
+///     Partymode(video) or Partymode(path to .xsp file)\, and Record. Play will
+///     either pause\, resume\, or stop ffwding or rewinding. Random toggles random
+///     playback and Repeat cycles through the repeat modes (these both take an
+///     optional second parameter\, Notify\, that notifies the user of the new
+///     state). Partymode(music/video) toggles the appropriate partymode\,
+///     defaults to music if no parameter is given\, besides the default music or
+///     video partymode you can also pass a path to a custom smartplaylist (.xsp)
+///     as parameter.
+///     @param[in] control               Control to execute.
+///     @param[in] param                 "notify" to notify user (optional\, certain controls).
+///   }
+///   \table_row2_l{
+///     <b>`Playlist.Clear`</b>
+///     ,
+///     Clear the current playlist
+///     @param[in]                       (ignored)
+///   }
+///   \table_row2_l{
+///     <b>`Playlist.PlayOffset(positionType[\,position])`</b>
+///     ,
+///     Start playing from a particular offset in the playlist 
+///     @param[in] positionType          Position in playlist or playlist type.
+///     @param[in] position              Position in playlist if params[0] is playlist type (optional).
+///   }
+///   \table_row2_l{
+///     <b>`PlayMedia(media[\,isdir][\,1]\,[playoffset=xx])`</b>
+///     ,
+///     Plays the media. This can be a playlist\, music\, or video file\, directory\,
+///     plugin or an Url. The optional parameter "\,isdir" can be used for playing
+///     a directory. "\,1" will start a video in a preview window\, instead of
+///     fullscreen. If media is a playlist\, you can use playoffset=xx where xx is
+///     the position to start playback from.
+///     @param[in] media                 URL to media to play (optional).
+///     @param[in] isdir                 Set "isdir" if media is a directory (optional).
+///     @param[in] fullscreen            Set "1" to start playback in fullscreen (optional).
+///     @param[in] resume                Set "resume" to force resuming (optional).
+///     @param[in] noresume              Set "noresume" to force not resuming (optional).
+///     @param[in] playeroffset          Set "playoffset=<offset>" to start playback from a given position in a playlist (optional).
+///   }
+///   \table_row2_l{
+///     <b>`PlayWith(core)`</b>
+///     ,
+///     Play the selected item with the specified player core.
+///     @param[in] core                  Name of playback core.
+///   }
+///   \table_row2_l{
+///     <b>`Seek(seconds)`</b>
+///     ,
+///     Seeks to the specified relative amount of seconds within the current
+///     playing media. A negative value will seek backward and a positive value forward.
+///     @param[in] seconds               Number of seconds to seek.
+///   }
+/// \table_end
+///
+
 CBuiltins::CommandMap CPlayerBuiltins::GetOperations() const
 {
   return {
-           {"playdvd",             {"Plays the inserted CD or DVD media from the DVD-ROM Drive!", 0, PlayDVD}},
+           {"playdisc",            {"Plays the inserted disc, like CD, DVD or Blu-ray, in the disc drive.", 0, PlayDVD}},
+           {"playdvd",             {"Plays the inserted disc, like CD, DVD or Blu-ray, in the disc drive.", 0, PlayDVD}},
            {"playlist.clear",      {"Clear the current playlist", 0, ClearPlaylist}},
            {"playlist.playoffset", {"Start playing from a particular offset in the playlist", 1, PlayOffset}},
            {"playercontrol",       {"Control the music or video player", 1, PlayerControl}},

--- a/xbmc/interfaces/builtins/ProfileBuiltins.cpp
+++ b/xbmc/interfaces/builtins/ProfileBuiltins.cpp
@@ -115,6 +115,41 @@ static int MasterMode(const std::vector<std::string>& params)
   return 0;
 }
 
+
+// Note: For new Texts with comma add a "\" before!!! Is used for table text.
+//
+/// \page page_List_of_built_in_functions
+/// \section built_in_functions_13 Profile built-in's
+///
+/// -----------------------------------------------------------------------------
+///
+/// \table_start
+///   \table_h2_l{
+///     Function,
+///     Description }
+///   \table_row2_l{
+///     <b>`LoadProfile(profilename\,[prompt])`</b>
+///     ,
+///     Load the specified profile. If prompt is not specified\, and a password
+///     would be required for the requested profile\, this command will silently
+///     fail. If promp' is specified and a password is required\, a password
+///     dialog will be shown.
+///     @param[in] profilename           The profile name.
+///     @param[in] prompt                Add "prompt" to allow unlocking dialogs (optional)
+///   }
+///   \table_row2_l{
+///     <b>`Mastermode`</b>
+///     ,
+///     Runs Kodi in master mode
+///   }
+///   \table_row2_l{
+///     <b>`System.LogOff`</b>
+///     ,
+///     Log off current user.
+///   }
+/// \table_end
+///
+
 CBuiltins::CommandMap CProfileBuiltins::GetOperations() const
 {
   return {

--- a/xbmc/interfaces/builtins/SkinBuiltins.cpp
+++ b/xbmc/interfaces/builtins/SkinBuiltins.cpp
@@ -437,6 +437,142 @@ static int SkinDebug(const std::vector<std::string>& params)
   return 0;
 }
 
+// Note: For new Texts with comma add a "\" before!!! Is used for table text.
+//
+/// \page page_List_of_built_in_functions
+/// \section built_in_functions_14 Skin built-in's
+///
+/// -----------------------------------------------------------------------------
+///
+/// \table_start
+///   \table_h2_l{
+///     Function,
+///     Description }
+///   \table_row2_l{
+///     <b>`ReloadSkin(reload)`</b>
+///     ,
+///     Reloads the current skin – useful for Skinners to use after they upload
+///     modified skin files (saves power cycling)
+///     @param[in] reload                <b>"confirm"</b> to show a confirmation dialog (optional).
+///   }
+///   \table_row2_l{
+///     <b>`UnloadSkin()`</b>
+///     ,
+///     Unloads the current skin
+///   }
+///   \table_row2_l{
+///     <b>`Skin.Reset(setting)`</b>
+///     ,
+///     Resets the skin `setting`. If `setting` is a bool setting (i.e. set via
+///     `SetBool` or `ToggleSetting`) then the setting is reset to false. If
+///     `setting`  is a string (Set via <c>SetString</c>\, <c>SetImage</c> or
+///     <c>SetPath</c>) then it is set to empty.
+///     @param[in] setting               Name of setting to reset.
+///   }
+///   \table_row2_l{
+///     <b>`Skin.ResetSettings()`</b>
+///     ,
+///     Resets all the above skin settings to their defaults (toggles all set to
+///     false\, strings all set to empty.)
+///   }
+///   \table_row2_l{
+///     <b>`Skin.SetAddon(string\,type)`</b>
+///     ,
+///     Pops up a select dialog and allows the user to select an add-on of the
+///     given type to be used elsewhere in the skin via the info tag
+///     `Skin.String(string)`. The most common types are xbmc.addon.video\,
+///     xbmc.addon.audio\, xbmc.addon.image and xbmc.addon.executable.
+///     @param[in] string[0]             Skin setting to store result in.
+///     @param[in] type[1\,...]           Add-on types to allow selecting.
+///   }
+///   \table_row2_l{
+///     <b>`Skin.SetBool(setting[\,value)`</b>
+///     ,
+///     Sets the skin `setting` to true\, for use with the conditional visibility
+///     tags containing `Skin.HasSetting(setting)`. The settings are saved
+///     per-skin in settings.xml just like all the other Kodi settings.
+///     @param[in] setting               Name of skin setting.
+///     @param[in] value                 Value to set ("false"\, or "true") (optional).
+///   }
+///   \table_row2_l{
+///     <b>`Skin.SetFile(string\,mask\,folderpath)`</b>
+///     ,
+///     \" minus quotes. If the folderpath parameter is set the file browser will
+///     start in that folder.
+///     @param[in] string                Name of skin setting.
+///     @param[in] mask                  File mask or add-on type (optional).
+///     @param[in] folderpath            Extra URL to allow selection from or.
+///                                      content type if mask is an addon-on type (optional).
+///   }
+///   \table_row2_l{
+///     <b>`Skin.SetImage(string[\,url])`</b>
+///     ,
+///     Pops up a file browser and allows the user to select an image file to be
+///     used in an image control elsewhere in the skin via the info tag
+///     `Skin.String(string)`. If the value parameter is specified\, then the
+///     file browser dialog does not pop up\, and the image path is set directly.
+///     The path option allows you to open the file browser in the specified
+///     folder.
+///     @param[in] string                Name of skin setting.
+///     @param[in] url                   Extra URL to allow selection from (optional).
+///   }
+///   \table_row2_l{
+///     <b>`Skin.SetLargeImage(string)`</b>
+///     ,
+///     Pops up a file browser and allows the user to select an large image file
+///     to be used in an image control else where in the skin via the info tag
+///     `Skin.String(string)`. If the value parameter is specified\, then the
+///     file browser dialog does not pop up\, and the image path is set directly.
+///     @param[in] string                Name of skin setting.
+///   }
+///   \table_row2_l{
+///     <b>`Skin.SetNumeric(numeric[\,value])`</b>
+///     ,
+///     Pops up a keyboard dialog and allows the user to input a numerical.
+///     @param[in] numeric               Name of skin setting.
+///     @param[in] value                 Value of skin setting (optional).
+///   }
+///   \table_row2_l{
+///     <b>`Skin.SetPath(string[\,value])`</b>
+///     ,
+///     Pops up a folder browser and allows the user to select a folder of images
+///     to be used in a multi image control else where in the skin via the info
+///     tag `Skin.String(string)`. If the value parameter is specified\, then the
+///     file browser dialog does not pop up\, and the path is set directly.
+///     @param[in] string                Name of skin setting.
+///     @param[in] value                 Extra URL to allow selection from (optional).
+///   }
+///   \table_row2_l{
+///     <b>`Skin.SetString(string[\,value])`</b>
+///     ,
+///     Pops up a keyboard dialog and allows the user to input a string which can
+///     be used in a label control elsewhere in the skin via the info tag
+///     `Skin.String(string)`. If the value parameter is specified\, then the
+///     keyboard dialog does not pop up\, and the string is set directly.
+///     @param[in] string                Name of skin setting.
+///     @param[in] value                 Value of skin setting (optional).
+///   }
+///   \table_row2_l{
+///     <b>`Skin.Theme(cycle)`</b>
+///     ,
+///     Cycles the skin theme. Skin.theme(-1) will go backwards.
+///     @param[in] cycle                 0 or 1 to increase theme\, -1 to decrease.
+///   }
+///   \table_row2_l{
+///     <b>`Skin.ToggleDebug`</b>
+///     ,
+///     Toggles skin debug info on/off
+///   }
+///   \table_row2_l{
+///     <b>`Skin.ToggleSetting(setting)`</b>
+///     ,
+///     Toggles the skin `setting` for use with conditional visibility tags
+///     containing `Skin.HasSetting(setting)`.
+///     @param[in] setting               Skin setting to toggle
+///  }
+/// \table_end
+///
+
 CBuiltins::CommandMap CSkinBuiltins::GetOperations() const
 {
   return {

--- a/xbmc/interfaces/builtins/SystemBuiltins.cpp
+++ b/xbmc/interfaces/builtins/SystemBuiltins.cpp
@@ -142,6 +142,94 @@ static int Suspend(const std::vector<std::string>& params)
   return 0;
 }
 
+
+// Note: For new Texts with comma add a "\" before!!! Is used for table text.
+//
+/// \page page_List_of_built_in_functions
+/// \section built_in_functions_15 System built-in's
+///
+/// -----------------------------------------------------------------------------
+///
+/// \table_start
+///   \table_h2_l{
+///     Function,
+///     Description }
+///   \table_row2_l{
+///     <b>`ActivateScreensaver`</b>
+///     ,
+///     Starts the screensaver
+///   }
+///   \table_row2_l{
+///     <b>`Hibernate`</b>
+///     ,
+///     Hibernate (S4) the System
+///   }
+///   \table_row2_l{
+///     <b>`InhibitIdleShutdown(true/false)`</b>
+///     ,
+///     Prevent the system to shutdown on idle.
+///     @param[in] value                 "true" to inhibit shutdown timer (optional).
+///   }
+///   \table_row2_l{
+///     <b>`Minimize`</b>
+///     ,
+///     Minimizes Kodi
+///   }
+///   \table_row2_l{
+///     <b>`Powerdown`</b>
+///     ,
+///     Powerdown system
+///   }
+///   \table_row2_l{
+///     <b>`Quit`</b>
+///     ,
+///     Quits Kodi
+///   }
+///   \table_row2_l{
+///     <b>`Reboot`</b>
+///     ,
+///     Cold reboots the system (power cycle)
+///   }
+///   \table_row2_l{
+///     <b>`Reset`</b>
+///     ,
+///     Reset the system (same as reboot)
+///   }
+///   \table_row2_l{
+///     <b>`Restart`</b>
+///     ,
+///     Restart the system (same as reboot)
+///   }
+///   \table_row2_l{
+///     <b>`RestartApp`</b>
+///     ,
+///     Restarts Kodi (only implemented under Windows and Linux)
+///   }
+///   \table_row2_l{
+///     <b>`ShutDown`</b>
+///     ,
+///     Trigger default Shutdown action defined in System Settings
+///   }
+///   \table_row2_l{
+///     <b>`Suspend`</b>
+///     ,
+///     Suspends (S3 / S1 depending on bios setting) the System
+///   }
+///   \table_row2_l{
+///     <b>`System.Exec(exec)`</b>
+///     ,
+///     Execute shell commands
+///     @param[in] exec                  The path to the executable
+///   }
+///   \table_row2_l{
+///     <b>`System.ExecWait(exec)`</b>
+///     ,
+///     Execute shell commands and freezes Kodi until shell is closed
+///     @param[in] exec                  The path to the executable
+///   }
+/// \table_end
+///
+
 CBuiltins::CommandMap CSystemBuiltins::GetOperations() const
 {
   return {

--- a/xbmc/interfaces/builtins/WeatherBuiltins.cpp
+++ b/xbmc/interfaces/builtins/WeatherBuiltins.cpp
@@ -50,6 +50,41 @@ static int SwitchLocation(const std::vector<std::string>& params)
   return 0;
 }
 
+// Note: For new Texts with comma add a "\" before!!! Is used for table text.
+//
+/// \page page_List_of_built_in_functions
+/// \section built_in_functions_16 Weather built-in's
+///
+/// -----------------------------------------------------------------------------
+///
+/// \table_start
+///   \table_h2_l{
+///     Function,
+///     Description }
+///   \table_row2_l{
+///     <b>`Weather.Refresh`</b>
+///     ,
+///     Force weather data refresh.
+///   }
+///   \table_row2_l{
+///     <b>`Weather.LocationNext`</b>
+///     ,
+///     Switch to next weather location
+///   }
+///   \table_row2_l{
+///     <b>`Weather.LocationPrevious`</b>
+///     ,
+///     Switch to previous weather location
+///   }
+///   \table_row2_l{
+///     <b>`Weather.LocationSet`</b>
+///     ,
+///     Switch to given weather location (parameter can be 1-3).
+///     @param[in] parameter             1-3
+///   }
+/// \table_end
+///
+
 CBuiltins::CommandMap CWeatherBuiltins::GetOperations() const
 {
   return {


### PR DESCRIPTION
This is also a independent change related to the binary add-on library rework.

This add a doxygen documentation by the use of a macro of them to allow better table text.

Want to insert this earlier to reduce size of the rework version and to have on code updates there the related documentation direct changed.
