### PR TITLE
[python] - fix WindowXML().setProperty()

### DIFF
--- a/xbmc/interfaces/legacy/WindowXML.cpp
+++ b/xbmc/interfaces/legacy/WindowXML.cpp
@@ -256,7 +256,7 @@ namespace XBMCAddon
       A(UpdateButtons());
     }
 
-    void WindowXML::setProperty(const String& key, const String& value)
+    void WindowXML::setContainerProperty(const String& key, const String& value)
     {
       XBMC_TRACE;
       A(m_vecItems)->SetProperty(key, value);

--- a/xbmc/interfaces/legacy/WindowXML.h
+++ b/xbmc/interfaces/legacy/WindowXML.h
@@ -140,7 +140,7 @@ namespace XBMCAddon
       SWIGHIDDENVIRTUAL void clearList();
 
       /**
-       * setProperty(key, value) -- Sets a container property, similar to an infolabel.
+       * setContainerProperty(key, value) -- Sets a container property, similar to an infolabel.
        * 
        * key            : string - property name.\n
        * value          : string or unicode - value of property.
@@ -150,9 +150,9 @@ namespace XBMCAddon
        *        Once you use a keyword, all following arguments require the keyword.
        * 
        * example:\n
-       *   - self.setProperty('Category', 'Newest')
+       *   - self.setContainerProperty('Category', 'Newest')
        */
-      SWIGHIDDENVIRTUAL void setProperty(const String &strProperty, const String &strValue);
+      SWIGHIDDENVIRTUAL void setContainerProperty(const String &strProperty, const String &strValue);
 
 #ifndef SWIG
       // CGUIWindow


### PR DESCRIPTION
Not sure if I am missing something, but it always seemed weird to me that I could not use self.setProperty() for WindowXML objects. Instead, I always had to do

```
        self.window = xbmcgui.Window(xbmcgui.getCurrentWindowId())
        self.window.setProperty('somekey', 'somevalue')
```

in onInit() which feels totally weird :)

This PR fixes this.
@jimfcarroll    @ronie          
