### PR TITLE
Update MusicOSD controls alignment

### DIFF
--- a/addons/skin.confluence/720p/MusicOSD.xml
+++ b/addons/skin.confluence/720p/MusicOSD.xml
@@ -258,6 +258,10 @@
 				<visible>!MusicPlayer.Content(LiveTV)</visible>
 				<onclick>PlayerControl(Random)</onclick>
 			</control>
+			<control type="image" id="2300">
+				<width>105</width>
+				<texture>-</texture>
+			</control>
 			<control type="image" id="2400">
 				<width>55</width>
 				<texture>-</texture>


### PR DESCRIPTION
Regarding to this:

https://github.com/xbmc/xbmc/pull/9094

and saw, that the alignment wasn't correct, I guess adding those lines again might help.
