### PR TITLE
[PVR] PVRManager::Cleanup - do not destruct addons with pvr manager mutex locked

### DIFF
--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -366,6 +366,9 @@ bool CPVRManager::UpgradeOutdatedAddons(void)
 
 void CPVRManager::Cleanup(void)
 {
+  if (m_addons)
+    m_addons->Unload();
+
   CSingleLock lock(m_critSection);
 
   SAFE_DELETE(m_addons);


### PR DESCRIPTION
Holding pvr manager mutex while destructing pvr client addons easily can lead to deadlocks. 

Annotated example: http://paste.ubuntu.com/15182871/

@Jalle19 what do you think?
