### PR TITLE
[AudioEngine] allow external check of played background sound

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -691,6 +691,9 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
             m_state = AE_TOP_CONFIGURED_PLAY;
           }
           return;
+        case CActiveAEDataProtocol::ISPLAYINGSOUND:
+          msg->Reply(m_sounds_playing.empty() ? CActiveAEDataProtocol::ERR : CActiveAEDataProtocol::ACC);
+          return;
         case CActiveAEDataProtocol::NEWSTREAM:
           MsgStreamNew *streamMsg;
           CActiveAEStream *stream;
@@ -3086,6 +3089,19 @@ void CActiveAE::FreeSound(IAESound *sound)
 void CActiveAE::PlaySound(CActiveAESound *sound)
 {
   m_dataPort.SendOutMessage(CActiveAEDataProtocol::PLAYSOUND, &sound, sizeof(CActiveAESound*));
+}
+
+bool CActiveAE::IsPlayingSound()
+{
+  Message *reply;
+  if (m_dataPort.SendOutMessageSync(CActiveAEDataProtocol::ISPLAYINGSOUND,
+                                           &reply, 2000))
+  {
+    bool success = reply->signal == CActiveAEControlProtocol::ACC;
+    reply->Release();
+    return success;
+  }
+  return false;
 }
 
 void CActiveAE::StopSound(CActiveAESound *sound)

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
@@ -115,6 +115,7 @@ public:
   {
     NEWSOUND = 0,
     PLAYSOUND,
+    ISPLAYINGSOUND,
     FREESOUND,
     NEWSTREAM,
     FREESTREAM,
@@ -277,6 +278,7 @@ public:
 
 protected:
   void PlaySound(CActiveAESound *sound);
+  bool IsPlayingSound();
   uint8_t **AllocSoundSample(SampleConfig &config, int &samples, int &bytes_per_sample, int &planes, int &linesize);
   void FreeSoundSample(uint8_t **data);
   void GetDelay(AEDelayStatus& status, CActiveAEStream *stream) { m_stats.GetDelay(status, stream); }


### PR DESCRIPTION
The next part of my binary lib rework.

This is also partly independent of the rest and used to play sound on add-ons without block of function and allow to check for still playing.

@FernetMenta is this way acceptable?

The goal is to have as base on library the same functionality like on python, but the system from binary is a bit bigger (more functionallity) and used this way.
