### PR TITLE
[VideoPlayer] d3d11va improvements.

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/DVDCodecUtils.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/DVDCodecUtils.cpp
@@ -415,7 +415,7 @@ static const EFormatMap g_format_map[] = {
 ,  { AV_PIX_FMT_UYVY422,     RENDER_FMT_UYVY422    }
 ,  { AV_PIX_FMT_YUYV422,     RENDER_FMT_YUYV422    }
 ,  { AV_PIX_FMT_VAAPI_VLD,   RENDER_FMT_VAAPI      }
-,  { AV_PIX_FMT_DXVA2_VLD,   RENDER_FMT_DXVA       }
+,  { AV_PIX_FMT_D3D11VA_VLD, RENDER_FMT_DXVA       }
 ,  { AV_PIX_FMT_NONE     ,   RENDER_FMT_NONE       }
 };
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
@@ -101,7 +101,7 @@ static const dxva2_mode_t dxva2_modes[] = {
 
     /* HEVC / H.265 */
     { "HEVC / H.265 variable-length decoder, main",   &D3D11_DECODER_PROFILE_HEVC_VLD_MAIN,   AV_CODEC_ID_HEVC },
-    { "HEVC / H.265 variable-length decoder, main10", &D3D11_DECODER_PROFILE_HEVC_VLD_MAIN10, 0 },
+    { "HEVC / H.265 variable-length decoder, main10", &D3D11_DECODER_PROFILE_HEVC_VLD_MAIN10, AV_CODEC_ID_HEVC },
 
 #ifdef FF_DXVA2_WORKAROUND_INTEL_CLEARVIDEO
     /* Intel specific modes (only useful on older GPUs) */
@@ -328,7 +328,7 @@ void CDXVAContext::QueryCaps()
   }
 }
 
-bool CDXVAContext::GetInputAndTarget(int codec, GUID &inGuid, DXGI_FORMAT &outFormat)
+bool CDXVAContext::GetInputAndTarget(int codec, bool bHighBitdepth, GUID &inGuid, DXGI_FORMAT &outFormat)
 {
   outFormat = DXGI_FORMAT_UNKNOWN;
 
@@ -341,13 +341,26 @@ bool CDXVAContext::GetInputAndTarget(int codec, GUID &inGuid, DXGI_FORMAT &outFo
 
     for (unsigned i = 0; i < m_input_count && outFormat == DXGI_FORMAT_UNKNOWN; i++)
     {
-      if (!IsEqualGUID(m_input_list[i], *mode->guid))
+      bool supported = IsEqualGUID(m_input_list[i], *mode->guid);
+      if (codec == AV_CODEC_ID_HEVC)
+      {
+        if (bHighBitdepth && !IsEqualGUID(m_input_list[i], D3D11_DECODER_PROFILE_HEVC_VLD_MAIN10))
+          supported = false;
+        else if (!bHighBitdepth && IsEqualGUID(m_input_list[i], D3D11_DECODER_PROFILE_HEVC_VLD_MAIN10))
+          supported = false;
+      }
+      if (!supported)
         continue;
 
       CLog::Log(LOGDEBUG, "DXVA - trying '%s'", mode->name);
       for (unsigned j = 0; render_targets_dxgi[j] != DXGI_FORMAT_UNKNOWN && outFormat == DXGI_FORMAT_UNKNOWN; j++)
       {
         BOOL supported;
+        if (bHighBitdepth && render_targets_dxgi[j] != DXGI_FORMAT_P010 && render_targets_dxgi[j] != DXGI_FORMAT_P016)
+          continue;
+        if (!bHighBitdepth && (render_targets_dxgi[j] == DXGI_FORMAT_P010 || render_targets_dxgi[j] == DXGI_FORMAT_P016))
+          continue;
+
         HRESULT res = m_service->CheckVideoDecoderFormat(&m_input_list[i], render_targets_dxgi[j], &supported);
         if (FAILED(res))
         {
@@ -826,7 +839,8 @@ bool CDecoder::Open(AVCodecContext *avctx, AVCodecContext* mainctx, enum AVPixel
   if (!CDXVAContext::EnsureContext(&m_dxva_context, this))
     return false;
 
-  if (!m_dxva_context->GetInputAndTarget(avctx->codec_id, m_format.Guid, m_format.OutputFormat))
+  bool bHighBitdepth = (avctx->codec_id == AV_CODEC_ID_HEVC && (avctx->sw_pix_fmt == AV_PIX_FMT_YUV420P10 || avctx->profile == FF_PROFILE_HEVC_MAIN_10));
+  if (!m_dxva_context->GetInputAndTarget(avctx->codec_id, bHighBitdepth, m_format.Guid, m_format.OutputFormat))
   {
     CLog::Log(LOGDEBUG, "DXVA - unable to find an input/output format combination");
     return false;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
@@ -210,79 +210,6 @@ static const dxva2_mode_t *dxva2_find_mode(const GUID *guid)
 }
 
 //-----------------------------------------------------------------------------
-// DXVA to D3D11 Video API Wrapper
-//-----------------------------------------------------------------------------
-
-CDXVADecoderWrapper::CDXVADecoderWrapper(ID3D11VideoContext* pContext, ID3D11VideoDecoder* pDecoder)
-  : m_refs(1), m_pContext(pContext), m_pDecoder(pDecoder)
-{
-  assert(pContext != nullptr);
-  assert(pDecoder != nullptr);
-  m_pContext->AddRef();
-  m_pDecoder->AddRef();
-};
-
-CDXVADecoderWrapper::~CDXVADecoderWrapper()
-{
-  SAFE_RELEASE(m_pContext);
-  SAFE_RELEASE(m_pDecoder);
-};
-
-STDMETHODIMP_(ULONG) CDXVADecoderWrapper::AddRef(void) 
-{
-  return AtomicIncrement(&m_refs); 
-}
-
-STDMETHODIMP_(ULONG) CDXVADecoderWrapper::Release(void)
-{
-  long refs = AtomicDecrement(&m_refs);
-  assert(refs >= 0);
-  if (refs == 0) delete this;
-  return refs;
-};
-
-STDMETHODIMP CDXVADecoderWrapper::GetBuffer(UINT BufferType, void **ppBuffer, UINT *pBufferSize)
-{
-  return m_pContext->GetDecoderBuffer(m_pDecoder, (D3D11_VIDEO_DECODER_BUFFER_TYPE)BufferType, pBufferSize, ppBuffer);
-};
-
-STDMETHODIMP CDXVADecoderWrapper::ReleaseBuffer(UINT BufferType)
-{
-  return m_pContext->ReleaseDecoderBuffer(m_pDecoder, (D3D11_VIDEO_DECODER_BUFFER_TYPE)BufferType);
-};
-
-STDMETHODIMP CDXVADecoderWrapper::BeginFrame(IDirect3DSurface9 *pRenderTarget, void *pvPVPData)
-{
-  return m_pContext->DecoderBeginFrame(m_pDecoder, reinterpret_cast<ID3D11VideoDecoderOutputView*>(pRenderTarget), 0, pvPVPData);
-};
-
-STDMETHODIMP CDXVADecoderWrapper::EndFrame(HANDLE *pHandleComplete)
-{
-  return m_pContext->DecoderEndFrame(m_pDecoder);
-};
-
-STDMETHODIMP CDXVADecoderWrapper::Execute(const DXVA2_DecodeExecuteParams *pExecuteParams)
-{
-  D3D11_VIDEO_DECODER_BUFFER_DESC buffer[4];
-  for (size_t i = 0; i < pExecuteParams->NumCompBuffers; i++)
-  {
-    ZeroMemory(&buffer[i], sizeof(D3D11_VIDEO_DECODER_BUFFER_DESC));
-    buffer[i].BufferType      = (D3D11_VIDEO_DECODER_BUFFER_TYPE)pExecuteParams->pCompressedBuffers[i].CompressedBufferType;
-    buffer[i].BufferIndex     = pExecuteParams->pCompressedBuffers[i].BufferIndex;
-    buffer[i].DataOffset      = pExecuteParams->pCompressedBuffers[i].DataOffset;
-    buffer[i].DataSize        = pExecuteParams->pCompressedBuffers[i].DataSize;
-    buffer[i].FirstMBaddress  = pExecuteParams->pCompressedBuffers[i].FirstMBaddress;
-    buffer[i].NumMBsInBuffer  = pExecuteParams->pCompressedBuffers[i].NumMBsInBuffer;
-    buffer[i].Width           = pExecuteParams->pCompressedBuffers[i].Width;
-    buffer[i].Height          = pExecuteParams->pCompressedBuffers[i].Height;
-    buffer[i].Stride          = pExecuteParams->pCompressedBuffers[i].Stride;
-    buffer[i].ReservedBits    = pExecuteParams->pCompressedBuffers[i].ReservedBits;
-    buffer[i].pIV             = pExecuteParams->pCompressedBuffers[i].pvPVPState;
-  }
-  return m_pContext->SubmitDecoderBuffers(m_pDecoder, pExecuteParams->NumCompBuffers, buffer);
-}
-
-//-----------------------------------------------------------------------------
 // DXVA Context
 //-----------------------------------------------------------------------------
 
@@ -533,7 +460,7 @@ bool CDXVAContext::CreateSurfaces(D3D11_VIDEO_DECODER_DESC format, unsigned int 
   return SUCCEEDED(hr);
 }
 
-bool CDXVAContext::CreateDecoder(D3D11_VIDEO_DECODER_DESC *format, const D3D11_VIDEO_DECODER_CONFIG *config, CDXVADecoderWrapper **decoder)
+bool CDXVAContext::CreateDecoder(D3D11_VIDEO_DECODER_DESC *format, const D3D11_VIDEO_DECODER_CONFIG *config, ID3D11VideoDecoder **decoder, ID3D11VideoContext **context)
 {
   CSingleLock lock(m_section);
 
@@ -546,8 +473,9 @@ bool CDXVAContext::CreateDecoder(D3D11_VIDEO_DECODER_DESC *format, const D3D11_V
       HRESULT res = m_service->CreateVideoDecoder(format, config, &pDecoder);
       if (!FAILED(res))
       {
-        *decoder = new CDXVADecoderWrapper(m_vcontext, pDecoder);
-        SAFE_RELEASE(pDecoder);
+        *decoder = pDecoder;
+        *context = m_vcontext;
+        m_vcontext->AddRef();
         return true;
       }
     }
@@ -755,15 +683,16 @@ CDecoder::CDecoder()
   m_state     = DXVA_OPEN;
   m_device    = nullptr;
   m_decoder   = nullptr;
+  m_vcontext  = nullptr;
   m_refs         = 0;
   m_shared       = 0;
   m_surface_context = nullptr;
   m_presentPicture = nullptr;
   m_dxva_context = nullptr;
   memset(&m_format, 0, sizeof(m_format));
-  m_context          = (dxva_context*)calloc(1, sizeof(dxva_context));
-  m_context->cfg     = reinterpret_cast<DXVA2_ConfigPictureDecode*>(calloc(1, sizeof(DXVA2_ConfigPictureDecode)));
-  m_context->surface = reinterpret_cast<IDirect3DSurface9**>(calloc(32, sizeof(IDirect3DSurface9*)));
+  m_context          = (AVD3D11VAContext*)calloc(1, sizeof(AVD3D11VAContext));
+  m_context->cfg     = reinterpret_cast<D3D11_VIDEO_DECODER_CONFIG*>(calloc(1, sizeof(D3D11_VIDEO_DECODER_CONFIG)));
+  m_context->surface = reinterpret_cast<ID3D11VideoDecoderOutputView**>(calloc(32, sizeof(ID3D11VideoDecoderOutputView*)));
   m_surface_alignment = 16;
   g_Windowing.Register(this);
 }
@@ -774,7 +703,7 @@ CDecoder::~CDecoder()
   g_Windowing.Unregister(this);
   Close();
   free(m_context->surface);
-  free(const_cast<DXVA2_ConfigPictureDecode*>(m_context->cfg)); // yes this is foobar
+  free(m_context->cfg);
   free(m_context);
 }
 
@@ -792,6 +721,7 @@ void CDecoder::Close()
 {
   CSingleLock lock(m_section);
   SAFE_RELEASE(m_decoder);
+  SAFE_RELEASE(m_vcontext);
   SAFE_RELEASE(m_surface_context);
   SAFE_RELEASE(m_presentPicture);
   memset(&m_format, 0, sizeof(m_format));
@@ -941,12 +871,8 @@ bool CDecoder::Open(AVCodecContext *avctx, AVCodecContext* mainctx, enum AVPixel
   else
     m_surface_alignment = 16;
 
-
-  D3D11_VIDEO_DECODER_CONFIG config = {0};
-  if (!m_dxva_context->GetConfig(&m_format, config))
+  if (!m_dxva_context->GetConfig(&m_format, *m_context->cfg))
     return false;
-
-  memcpy((void *)m_context->cfg, &config, sizeof(DXVA2_ConfigPictureDecode));
 
   m_surface_context = new CSurfaceContext();
 
@@ -1082,7 +1008,7 @@ int CDecoder::Check(AVCodecContext* avctx)
   data.pPrivateOutputData    = &status;
   data.PrivateOutputDataSize = avctx->codec_id == AV_CODEC_ID_H264 ? sizeof(DXVA_Status_H264) : sizeof(DXVA_Status_VC1);
   HRESULT hr;
-  if (FAILED(hr = m_dxva_context->GetVideoContext()->DecoderExtension(m_decoder->m_pDecoder, &data)))
+  if (FAILED(hr = m_dxva_context->GetVideoContext()->DecoderExtension(m_decoder, &data)))
   {
     CLog::Log(LOGWARNING, "DXVA - failed to get decoder status - 0x%08X", hr);
     return VC_ERROR;
@@ -1104,32 +1030,34 @@ int CDecoder::Check(AVCodecContext* avctx)
 bool CDecoder::OpenDecoder()
 {
   SAFE_RELEASE(m_decoder);
+  SAFE_RELEASE(m_vcontext);
   m_context->decoder = nullptr;
+  m_context->video_context = nullptr;
 
   m_context->surface_count = m_refs + 1 + 1 + m_shared; // refs + 1 decode + 1 libavcodec safety + processor buffer
 
   CLog::Log(LOGDEBUG, "DXVA - allocating %d surfaces with format %d", m_context->surface_count, m_format.OutputFormat);
 
-  if (!m_dxva_context->CreateSurfaces(m_format, m_context->surface_count, m_surface_alignment, 
-                                      reinterpret_cast<ID3D11VideoDecoderOutputView**>(m_context->surface)))
+  if (!m_dxva_context->CreateSurfaces(m_format, m_context->surface_count, m_surface_alignment, m_context->surface))
     return false;
 
   for(unsigned i = 0; i < m_context->surface_count; i++)
   {
-    m_surface_context->AddSurface(reinterpret_cast<ID3D11VideoDecoderOutputView*>(m_context->surface[i]));
+    m_surface_context->AddSurface(m_context->surface[i]);
   }
 
-  if (!m_dxva_context->CreateDecoder(&m_format, reinterpret_cast<D3D11_VIDEO_DECODER_CONFIG*>((DXVA2_ConfigPictureDecode*)m_context->cfg), &m_decoder))
+  if (!m_dxva_context->CreateDecoder(&m_format, m_context->cfg, &m_decoder, &m_vcontext))
     return false;
 
   m_context->decoder = m_decoder;
+  m_context->video_context = m_vcontext;
 
   return true;
 }
 
 bool CDecoder::Supports(enum AVPixelFormat fmt)
 {
-  if(fmt == AV_PIX_FMT_DXVA2_VLD)
+  if(fmt == AV_PIX_FMT_D3D11VA_VLD)
     return true;
   return false;
 }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.h
@@ -25,7 +25,7 @@
 #include "DVDResource.h"
 #include "guilib/D3DResource.h"
 #include "libavcodec/avcodec.h"
-#include "libavcodec/dxva2.h"
+#include "libavcodec/d3d11va.h"
 #include "threads/Event.h"
 
 namespace DXVA {
@@ -76,35 +76,6 @@ protected:
   CSurfaceContext *surface_context;
 };
 
-//-----------------------------------------------------------------------------
-// DXVA to D3D11 Video API Wrapper
-//-----------------------------------------------------------------------------
-class CDXVADecoderWrapper : public IDirectXVideoDecoder
-{
-public:
-  CDXVADecoderWrapper(ID3D11VideoContext* pContext, ID3D11VideoDecoder* pDecoder);
-  ~CDXVADecoderWrapper();
-  // unused
-  STDMETHODIMP         QueryInterface(REFIID riid, void** ppvObject) { return E_NOTIMPL; };
-  STDMETHODIMP_(ULONG) AddRef(void);
-  STDMETHODIMP_(ULONG) Release(void);
-  // unused
-  STDMETHODIMP GetVideoDecoderService(IDirectXVideoDecoderService **ppService) { return E_NOTIMPL; };
-  // unused
-  STDMETHODIMP GetCreationParameters(GUID *pDeviceGuid, DXVA2_VideoDesc *pVideoDesc, DXVA2_ConfigPictureDecode *pConfig,
-                                     IDirect3DSurface9 ***pDecoderRenderTargets, UINT *pNumSurfaces)  { return E_NOTIMPL; };
-  STDMETHODIMP GetBuffer(UINT BufferType, void **ppBuffer, UINT *pBufferSize);
-  STDMETHODIMP ReleaseBuffer(UINT BufferType);
-  STDMETHODIMP BeginFrame(IDirect3DSurface9 *pRenderTarget, void *pvPVPData);
-  STDMETHODIMP EndFrame(HANDLE *pHandleComplete);
-  STDMETHODIMP Execute(const DXVA2_DecodeExecuteParams *pExecuteParams);
-
-  ID3D11VideoDecoder*  m_pDecoder;
-private:
-  volatile long        m_refs;
-  ID3D11VideoContext*  m_pContext;
-};
-
 class CDecoder;
 class CDXVAContext
 {
@@ -113,7 +84,7 @@ public:
   bool GetInputAndTarget(int codec, GUID &inGuid, DXGI_FORMAT &outFormat);
   bool GetConfig(const D3D11_VIDEO_DECODER_DESC *format, D3D11_VIDEO_DECODER_CONFIG &config);
   bool CreateSurfaces(D3D11_VIDEO_DECODER_DESC format, unsigned int count, unsigned int alignment, ID3D11VideoDecoderOutputView **surfaces);
-  bool CreateDecoder(D3D11_VIDEO_DECODER_DESC *format, const D3D11_VIDEO_DECODER_CONFIG *config, CDXVADecoderWrapper **decoder);
+  bool CreateDecoder(D3D11_VIDEO_DECODER_DESC *format, const D3D11_VIDEO_DECODER_CONFIG *config, ID3D11VideoDecoder **decoder, ID3D11VideoContext **context);
   void Release(CDecoder *decoder);
   ID3D11VideoContext* GetVideoContext() { return m_vcontext; }
 private:
@@ -146,7 +117,7 @@ public:
   virtual bool GetPicture(AVCodecContext* avctx, AVFrame* frame, DVDVideoPicture* picture);
   virtual int  Check     (AVCodecContext* avctx);
   virtual void Close();
-  virtual const std::string Name() { return "dxva2"; }
+  virtual const std::string Name() { return "d3d11va"; }
   virtual unsigned GetAllowedReferences();
   virtual long Release();
 
@@ -170,13 +141,14 @@ protected:
   virtual void OnLostDevice()    { CSingleLock lock(m_section); m_state = DXVA_LOST;  m_event.Reset(); }
   virtual void OnResetDevice()   { CSingleLock lock(m_section); m_state = DXVA_RESET; m_event.Set();   }
 
-  CDXVADecoderWrapper*         m_decoder;
+  ID3D11VideoDecoder*          m_decoder;
+  ID3D11VideoContext*          m_vcontext;
   HANDLE                       m_device;
   D3D11_VIDEO_DECODER_DESC     m_format;
   int                          m_refs;
   CRenderPicture              *m_presentPicture;
 
-  struct dxva_context*         m_context;
+  struct AVD3D11VAContext*     m_context;
 
   CSurfaceContext*             m_surface_context;
   CDXVAContext*                m_dxva_context;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.h
@@ -81,7 +81,7 @@ class CDXVAContext
 {
 public:
   static bool EnsureContext(CDXVAContext **ctx, CDecoder *decoder);
-  bool GetInputAndTarget(int codec, GUID &inGuid, DXGI_FORMAT &outFormat);
+  bool GetInputAndTarget(int codec, bool bHighBitdepth, GUID &inGuid, DXGI_FORMAT &outFormat);
   bool GetConfig(const D3D11_VIDEO_DECODER_DESC *format, D3D11_VIDEO_DECODER_CONFIG &config);
   bool CreateSurfaces(D3D11_VIDEO_DECODER_DESC format, unsigned int count, unsigned int alignment, ID3D11VideoDecoderOutputView **surfaces);
   bool CreateDecoder(D3D11_VIDEO_DECODER_DESC *format, const D3D11_VIDEO_DECODER_CONFIG *config, ID3D11VideoDecoder **decoder, ID3D11VideoContext **context);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
@@ -127,14 +127,12 @@ void CProcessorHD::ApplySupportedFormats(std::vector<ERenderFormat> *formats)
   if (SUCCEEDED(m_pEnumerator->CheckVideoProcessorFormat(DXGI_FORMAT_P010, &flags))
     && (flags & D3D11_VIDEO_PROCESSOR_FORMAT_SUPPORT_INPUT))
   {
-    // TODO: temporary disabled
-    //formats->push_back(RENDER_FMT_YUV420P10);
+    formats->push_back(RENDER_FMT_YUV420P10);
   }
   if (SUCCEEDED(m_pEnumerator->CheckVideoProcessorFormat(DXGI_FORMAT_P016, &flags))
     && (flags & D3D11_VIDEO_PROCESSOR_FORMAT_SUPPORT_INPUT))
   {
-    // TODO: temporary disabled
-    //formats->push_back(RENDER_FMT_YUV420P16);
+    formats->push_back(RENDER_FMT_YUV420P16);
   }
 }
 
@@ -476,39 +474,18 @@ CRenderPicture *CProcessorHD::Convert(DVDVideoPicture* picture)
     return nullptr;
   }
 
+  uint8_t*  pData = static_cast<uint8_t*>(rectangle.pData);
+  uint8_t*  dst[] = { pData, pData + m_texDesc.Height * rectangle.RowPitch };
+  int dstStride[] = { rectangle.RowPitch, rectangle.RowPitch };
+
   if (picture->format == RENDER_FMT_YUV420P)
   {
-    uint8_t*  pData = static_cast<uint8_t*>(rectangle.pData);
-    uint8_t*  dst[] = { pData, pData + m_texDesc.Height * rectangle.RowPitch };
-    int dstStride[] = { rectangle.RowPitch, rectangle.RowPitch };
     convert_yuv420_nv12(picture->data, picture->iLineSize, picture->iHeight, picture->iWidth, dst, dstStride);
   }
   else
   {
-    // TODO: Optimize this later using sse2/sse4
-    uint16_t * d_y = static_cast<uint16_t*>(rectangle.pData);
-    uint16_t * d_uv = d_y + m_texDesc.Height * rectangle.RowPitch;
-    // Convert to NV12 - Luma
-    for (size_t line = 0; line < picture->iHeight; ++line)
-    {
-      uint16_t * y = (uint16_t*)(picture->data[0] + picture->iLineSize[0] * line);
-      uint16_t * d = d_y + rectangle.RowPitch * line;
-      memcpy(d, y, picture->iLineSize[0]);
-    }
-    // Convert to NV12 - Chroma
-    size_t chromaWidth = (picture->iWidth + 1) >> 1;
-    size_t chromaHeight = picture->iHeight >> 1;
-    for (size_t line = 0; line < chromaHeight; ++line)
-    {
-      uint16_t * u = (uint16_t*)picture->data[1] + line * picture->iLineSize[1];
-      uint16_t * v = (uint16_t*)picture->data[2] + line * picture->iLineSize[2];
-      uint16_t * d = d_uv + line * rectangle.RowPitch;
-      for (size_t x = 0; x < chromaWidth; x++)
-      {
-        *d++ = *u++; 
-        *d++ = *v++;
-      }
-    }
+    convert_yuv420_p01x(picture->data, picture->iLineSize, picture->iHeight, picture->iWidth, dst, dstStride
+                      , picture->format == RENDER_FMT_YUV420P10 ? 10 : 16);
   }
   pContext->Unmap(pResource, subresource);
   SAFE_RELEASE(pResource);

--- a/xbmc/utils/win32/memcpy_sse2.h
+++ b/xbmc/utils/win32/memcpy_sse2.h
@@ -20,14 +20,28 @@
 
 #include <emmintrin.h>
 
-inline void* memcpy_aligned(void* dst, const void* src, size_t size)
+inline void* memcpy_aligned(void* dst, const void* src, size_t size, uint8_t bpp = 0)
 {
   size_t i;
+  uint8_t shift = 16 - bpp;
   __m128i xmm1, xmm2, xmm3, xmm4;
 
   // if memory is not aligned, use memcpy
   if ((((size_t)(src) | (size_t)(dst)) & 0xF))
-    return memcpy(dst, src, size);
+  {
+    if (bpp == 0 || bpp == 16)
+      return memcpy(dst, src, size);
+    else
+    {
+      uint16_t * y = (uint16_t*)(src);
+      uint16_t * d = (uint16_t*)(dst);
+      for (size_t x = 0; x < (size >> 1); x++)
+      {
+        d[x] = y[x] << shift;
+      }
+      return dst;
+    }
+  }
 
   uint8_t* d = (uint8_t*)(dst);
   uint8_t* s = (uint8_t*)(src);
@@ -38,6 +52,15 @@ inline void* memcpy_aligned(void* dst, const void* src, size_t size)
     xmm2 = _mm_load_si128((__m128i*)(s + i + 16));
     xmm3 = _mm_load_si128((__m128i*)(s + i + 32));
     xmm4 = _mm_load_si128((__m128i*)(s + i + 48));
+
+    if (bpp != 0 && bpp != 16)
+    {
+      xmm1 = _mm_slli_epi16(xmm1, shift);
+      xmm2 = _mm_slli_epi16(xmm2, shift);
+      xmm3 = _mm_slli_epi16(xmm3, shift);
+      xmm4 = _mm_slli_epi16(xmm4, shift);
+    }
+
     _mm_stream_si128((__m128i*)(d + i +  0), xmm1);
     _mm_stream_si128((__m128i*)(d + i + 16), xmm2);
     _mm_stream_si128((__m128i*)(d + i + 32), xmm3);
@@ -129,6 +152,74 @@ inline void convert_yuv420_nv12(uint8_t *const src[], const int srcStride[], int
 
         _mm_stream_si128((__m128i *)(d + (i << 1) + 0), xmm0);
         _mm_stream_si128((__m128i *)(d + (i << 1) + 16), xmm2);
+      }
+    }
+  }
+}
+
+inline void convert_yuv420_p01x(uint8_t *const src[], const int srcStride[], int height, int width, uint8_t *const dst[], const int dstStride[], uint8_t bpp)
+{
+  uint8_t shift = 16 - bpp;
+  __m128i xmm0, xmm1, xmm2, xmm3, xmm4;
+  _mm_sfence();
+
+  // Convert to P01x - Luma
+  if (srcStride[0] == dstStride[0])
+    memcpy_aligned(dst[0], src[0], srcStride[0] * height, bpp);
+  else
+  {
+    for (size_t line = 0; line < height; ++line)
+    {
+      uint8_t * s = src[0] + srcStride[0] * line;
+      uint8_t * d = dst[0] + dstStride[0] * line;
+      memcpy_aligned(d, s, srcStride[0], bpp);
+    }
+  }
+  // Convert to P01x - Chroma
+  size_t chromaWidth = (width + 1) >> 1;
+  size_t chromaHeight = height >> 1;
+  for (size_t line = 0; line < chromaHeight; ++line)
+  {
+    size_t i;
+    uint16_t * u = (uint16_t*)(src[1] + line * srcStride[1]);
+    uint16_t * v = (uint16_t*)(src[2] + line * srcStride[2]);
+    uint16_t * d = (uint16_t*)(dst[1] + line * dstStride[1]);
+
+    // if memory is not aligned use memcpy
+    if (((size_t)(u) | (size_t)(v) | (size_t)(d)) & 0xF)
+    {
+      for (i = 0; i < chromaWidth; ++i)
+      {
+        *d++ = *u++ << shift;
+        *d++ = *v++ << shift;
+      }
+    }
+    else
+    {
+      for (i = 0; i < chromaWidth; i += 16)
+      {
+        xmm0 = _mm_load_si128((__m128i*)(v + i));
+        xmm1 = _mm_load_si128((__m128i*)(u + i));
+        xmm2 = _mm_load_si128((__m128i*)(v + i + 8));
+        xmm3 = _mm_load_si128((__m128i*)(u + i + 8));
+
+        xmm0 = _mm_slli_epi16(xmm0, shift);
+        xmm1 = _mm_slli_epi16(xmm1, shift);
+        xmm2 = _mm_slli_epi16(xmm2, shift);
+        xmm3 = _mm_slli_epi16(xmm3, shift);
+
+        xmm4 = xmm0;
+        xmm0 = _mm_unpacklo_epi16(xmm1, xmm0);
+        xmm4 = _mm_unpackhi_epi16(xmm1, xmm4);
+
+        xmm1 = xmm2;
+        xmm2 = _mm_unpacklo_epi16(xmm3, xmm2);
+        xmm1 = _mm_unpackhi_epi16(xmm3, xmm1);
+
+        _mm_stream_si128((__m128i *)(d + (i << 1) + 0), xmm0);
+        _mm_stream_si128((__m128i *)(d + (i << 1) + 8), xmm4);
+        _mm_stream_si128((__m128i *)(d + (i << 1) + 16), xmm2);
+        _mm_stream_si128((__m128i *)(d + (i << 1) + 24), xmm1);
       }
     }
   }


### PR DESCRIPTION
1. dropped unneeded dxva->d3d11va wrapper. Now we build ffmpeg with d3d11va support and can use it directly.
2. Added support of hevc main10 profile to our dxva decoder. Still needs to updated ffmpeg.
3. Added support 10/16 bit video output through dxva renderer.

@FernetMenta @fritsch ping.
