### PR TITLE
[win32] build-mingwlibs: remove parallelism for `make install`.

### DIFF
--- a/tools/buildsteps/win32/buildhelpers.sh
+++ b/tools/buildsteps/win32/buildhelpers.sh
@@ -42,7 +42,7 @@ do_wget() {
 
 do_makeinstall() {
   make -j"$cpuCount" "$@"
-  make -j"$cpuCount" install
+  make install
 }
 
 do_makelib() {


### PR DESCRIPTION
In some cases this causes an error during build mingw libs.
