### PR TITLE
[videoplayer] changed: Ignore chapters for large step if there's only one

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -2915,7 +2915,7 @@ void CVideoPlayer::Seek(bool bPlus, bool bLargeStep, bool bChapterOverride)
   if (!m_State.canseek)
     return;
 
-  if (bLargeStep && bChapterOverride && GetChapter() > 0)
+  if (bLargeStep && bChapterOverride && GetChapter() > 0 && GetChapterCount() > 1)
   {
     if (!bPlus)
     {


### PR DESCRIPTION
It makes no sense to handle chapters with large steps, if there's only one (big) chapter. In that case simply fall back to normal large stepping.
