### PR TITLE
[dxva] Added advanced setting to workaround dxva color range issues o…

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderer.cpp
@@ -796,7 +796,7 @@ void CWinRenderer::RenderHQ()
 {
   m_scalerShader->Render(m_IntermediateTarget, m_sourceWidth, m_sourceHeight, m_destWidth, m_destHeight
                        , m_sourceRect, g_graphicsContext.StereoCorrection(m_destRect)
-                       , (m_renderMethod == RENDER_DXVA && g_Windowing.UseLimitedColor()));
+                       , (m_renderMethod == RENDER_DXVA && g_Windowing.UseLimitedColor() && !g_advancedSettings.m_DXVAPassColorRange));
 }
 
 void CWinRenderer::RenderHW(DWORD flags)
@@ -888,8 +888,11 @@ void CWinRenderer::RenderHW(DWORD flags)
     }
 
     // render frame
+    SHADER_METHOD method = g_advancedSettings.m_DXVAPassColorRange 
+                         ? SHADER_METHOD_RENDER_TEXTURE_NOBLEND
+                         : SHADER_METHOD_RENDER_TEXTURE_BLEND;
     CRect tu = { dst.x1 / m_destWidth, dst.y1 / m_destHeight, dst.x2 / m_destWidth, dst.y2 / m_destHeight };
-    CD3DTexture::DrawQuad(dst, 0xFFFFFF, &m_IntermediateTarget, &tu, SHADER_METHOD_RENDER_TEXTURE_BLEND);
+    CD3DTexture::DrawQuad(dst, 0xFFFFFF, &m_IntermediateTarget, &tu, method);
 
     if (stereoHack)
       g_Windowing.SetViewPort(oldViewPort);

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -158,6 +158,7 @@ void CAdvancedSettings::Initialize()
   m_DXVAForceProcessorRenderer = true;
   m_DXVANoDeintProcForProgressive = false;
   m_DXVAAllowHqScaling = true;
+  m_DXVAPassColorRange = false;
   m_videoFpsDetect = 1;
   m_videoBusyDialogDelay_ms = 500;
 
@@ -644,6 +645,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetBoolean(pElement,"forcedxvarenderer", m_DXVAForceProcessorRenderer);
     XMLUtils::GetBoolean(pElement,"dxvanodeintforprogressive", m_DXVANoDeintProcForProgressive);
     XMLUtils::GetBoolean(pElement, "dxvaallowhqscaling", m_DXVAAllowHqScaling);
+    XMLUtils::GetBoolean(pElement, "dxvapasscolorrange", m_DXVAPassColorRange);
     //0 = disable fps detect, 1 = only detect on timestamps with uniform spacing, 2 detect on all timestamps
     XMLUtils::GetInt(pElement, "fpsdetect", m_videoFpsDetect, 0, 2);
 

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -184,6 +184,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     bool m_DXVAForceProcessorRenderer;
     bool m_DXVANoDeintProcForProgressive;
     bool m_DXVAAllowHqScaling;
+    bool m_DXVAPassColorRange;
     int  m_videoFpsDetect;
     int  m_videoBusyDialogDelay_ms;
     bool m_mediacodecForceSoftwareRendring;


### PR DESCRIPTION
…n some setups.

The main idea of setting is don't do color range conversion by Kodi and let's output frame as driver decides. Default value is false so it needs to be changed only if current output is wrong.

I don't like idea to introduce a new advanced setting, but I don't see any other solution.

@FernetMenta @phate89 @MartijnKaijser ping
