### PR TITLE
[osx] - fix crash on osx 10.7 when trying to resolve hdd names

### DIFF
--- a/xbmc/platform/darwin/DarwinUtils.h
+++ b/xbmc/platform/darwin/DarwinUtils.h
@@ -32,6 +32,7 @@ class CDarwinUtils
 public:
   static const char *getIosPlatformString(void);
   static bool        IsMavericks(void);
+  static bool        IsLion(void); 
   static bool        IsSnowLeopard(void);
   static bool        DeviceHasRetina(double &scale);
   static bool        DeviceHasLeakyVDA(void);

--- a/xbmc/platform/darwin/DarwinUtils.mm
+++ b/xbmc/platform/darwin/DarwinUtils.mm
@@ -206,6 +206,20 @@ bool CDarwinUtils::IsMavericks(void)
   return isMavericks == 1;
 }
 
+bool CDarwinUtils::IsLion(void)  
+{  
+  static int isLion = -1;  
+#if defined(TARGET_DARWIN_OSX)  
+  if (isLion == -1)  
+  {  
+    double appKitVersion = floor(NSAppKitVersionNumber);  
+    // everything lower 10.8 is 10.7.x because 10.7 is deployment target...  
+    isLion = (appKitVersion < NSAppKitVersionNumber10_8) ? 1 : 0;  
+  }  
+#endif  
+  return isLion == 1;  
+}
+
 bool CDarwinUtils::IsSnowLeopard(void)
 {
   static int isSnowLeopard = -1;

--- a/xbmc/storage/osx/DarwinStorageProvider.cpp
+++ b/xbmc/storage/osx/DarwinStorageProvider.cpp
@@ -29,6 +29,7 @@
 #include <DiskArbitration/DiskArbitration.h>
 #include <IOKit/storage/IOCDMedia.h>
 #include <IOKit/storage/IODVDMedia.h>
+#include "platform/darwin/DarwinUtils.h"  
 #endif
 #include "platform/darwin/osx/CocoaInterface.h"
 
@@ -62,6 +63,9 @@ void CDarwinStorageProvider::GetLocalDrives(VECSOURCES &localDrives)
   share.strName = "Volumes";
   share.m_ignore = true;
   localDrives.push_back(share);
+  
+  if (CDarwinUtils::IsLion())  
+   return; //temp workaround for crash in Cocoa_GetVolumeNameFromMountPoint on 10.7.x  
 
   // This will pick up all local non-removable disks including the Root Disk.
   DASessionRef session = DASessionCreate(kCFAllocatorDefault);
@@ -106,6 +110,10 @@ void CDarwinStorageProvider::GetLocalDrives(VECSOURCES &localDrives)
 void CDarwinStorageProvider::GetRemovableDrives(VECSOURCES &removableDrives)
 {
 #if defined(TARGET_DARWIN_OSX)
+
+  if (CDarwinUtils::IsLion())  
+    return; //temp workaround for crash in Cocoa_GetVolumeNameFromMountPoint on 10.7.x  
+
   DASessionRef session = DASessionCreate(kCFAllocatorDefault);
   if (session)
   {


### PR DESCRIPTION
This is a backport from a temp workaround done in the Isengard branch. As i never found a sane fix for this and osx 10.7 will vanish as supported platform at some point (and hasn't that much userbase i figured) - i will use this temp workaround for real in mainline now.

Backport of #7911 

Will merge this after user verification. PR for Jarvis coming in a minute too.
