### PR TITLE
[fix] binary-addons on linux/aarch64

### DIFF
--- a/addons/library.xbmc.addon/libXBMC_addon.h
+++ b/addons/library.xbmc.addon/libXBMC_addon.h
@@ -63,6 +63,8 @@ typedef intptr_t      ssize_t;
 #define ADDON_HELPER_ARCH       "powerpc64-linux"
 #elif defined(__ARMEL__)
 #define ADDON_HELPER_ARCH       "arm"
+#elif defined(__aarch64__)
+#define ADDON_HELPER_ARCH       "aarch64"
 #elif defined(__mips__)
 #define ADDON_HELPER_ARCH       "mips"
 #else


### PR DESCRIPTION
this allows (at least) pvr clients to load on linux/aarch64

imo, the entire ADDON_HELPER_ARCH ifdefery should be removed, but this is a quick fix.
