### PR TITLE
Fix out of memory crash in CArchive

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1048,7 +1048,7 @@ bool CApplication::InitDirectoriesWin32()
 #endif
 }
 
-void CApplication::CreateUserDirs()
+void CApplication::CreateUserDirs() const
 {
   CDirectory::Create("special://home/");
   CDirectory::Create("special://home/addons");
@@ -1059,6 +1059,12 @@ void CApplication::CreateUserDirs()
   CDirectory::Create("special://temp/");
   CDirectory::Create("special://logpath");
   CDirectory::Create("special://temp/temp"); // temp directory for python and dllGetTempPathA
+
+  //Let's clear our archive cache before starting up anything more
+  auto archiveCachePath = CSpecialProtocol::TranslatePath("special://temp/archive_cache/");
+  CDirectory::Remove(archiveCachePath);
+  CDirectory::Create(archiveCachePath);
+
 }
 
 bool CApplication::Initialize()

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -506,7 +506,7 @@ protected:
   bool InitDirectoriesLinux();
   bool InitDirectoriesOSX();
   bool InitDirectoriesWin32();
-  void CreateUserDirs();
+  void CreateUserDirs() const;
 
   /*! \brief Helper method to determine how to handle TMSG_SHUTDOWN
   */

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -876,7 +876,6 @@ bool CFileItem::IsFileFolder(EFileFolderType types) const
   if(IsInternetStream())
     always_type = EFILEFOLDER_TYPE_ONCLICK;
 
-
   if(types & always_type)
   {
     if(IsSmartPlayList()
@@ -902,7 +901,6 @@ bool CFileItem::IsFileFolder(EFileFolderType types) const
 
   return false;
 }
-
 
 bool CFileItem::IsSmartPlayList() const
 {
@@ -1379,7 +1377,7 @@ bool CFileItem::IsSamePath(const CFileItem *item) const
   {
     if (m_videoInfoTag->m_iDbId != -1 && item->m_videoInfoTag->m_iDbId != -1)
       return ((m_videoInfoTag->m_iDbId == item->m_videoInfoTag->m_iDbId) &&
-        (m_videoInfoTag->m_type == item->m_videoInfoTag->m_type));        
+        (m_videoInfoTag->m_type == item->m_videoInfoTag->m_type));
   }
   if (IsMusicDb() && HasMusicInfoTag())
   {
@@ -1472,7 +1470,7 @@ void CFileItem::SetFromVideoInfoTag(const CVideoInfoTag &video)
     m_strPath = video.m_strFileNameAndPath;
     m_bIsFolder = false;
   }
-  
+
   *GetVideoInfoTag() = video;
   if (video.m_iSeason == 0)
     SetProperty("isspecial", "true");
@@ -1643,13 +1641,13 @@ bool CFileItem::LoadTracksFromCueDocument(CFileItemList& scannedItems)
       {
         if (song.strAlbum.empty() && !tag.GetAlbum().empty())
           song.strAlbum = tag.GetAlbum();
-        //Pass album artist to final MusicInfoTag object via setting song album artist vector. 
+        //Pass album artist to final MusicInfoTag object via setting song album artist vector.
         if (song.GetAlbumArtist().empty() && !tag.GetAlbumArtist().empty())
-          song.SetAlbumArtist(tag.GetAlbumArtist());        
+          song.SetAlbumArtist(tag.GetAlbumArtist());
         if (song.genre.empty() && !tag.GetGenre().empty())
           song.genre = tag.GetGenre();
         //Pass artist to final MusicInfoTag object via setting song artist description string only.
-        //Artist credits not used during loading from cue sheet. 
+        //Artist credits not used during loading from cue sheet.
         if (song.strArtistDesc.empty() && !tag.GetArtistString().empty())
           song.strArtistDesc = tag.GetArtistString();
         if (tag.GetDiscNumber())
@@ -1683,7 +1681,6 @@ bool CFileItem::LoadTracksFromCueDocument(CFileItemList& scannedItems)
   }
   return tracksFound != 0;
 }
-
 
 /////////////////////////////////////////////////////////////////////////////////
 /////
@@ -2433,7 +2430,7 @@ void CFileItemList::StackFolders()
       // 1. rars and zips may be on slow sources? is this supposed to be allowed?
       if( !item->IsRemote()
         || item->IsSmb()
-        || item->IsNfs() 
+        || item->IsNfs()
         || URIUtils::IsInRAR(item->GetPath())
         || URIUtils::IsInZIP(item->GetPath())
         || URIUtils::IsOnLAN(item->GetPath())
@@ -2676,15 +2673,23 @@ void CFileItemList::StackFiles()
 bool CFileItemList::Load(int windowID)
 {
   CFile file;
-  if (file.Open(GetDiscFileCache(windowID)))
+  auto path = GetDiscFileCache(windowID);
+  try
   {
-    CArchive ar(&file, CArchive::load);
-    ar >> *this;
-    CLog::Log(LOGDEBUG,"Loading items: %i, directory: %s sort method: %i, ascending: %s", Size(), CURL::GetRedacted(GetPath()).c_str(), m_sortDescription.sortBy,
-      m_sortDescription.sortOrder == SortOrderAscending ? "true" : "false");
-    ar.Close();
-    file.Close();
-    return true;
+    if (file.Open(path))
+    {
+      CArchive ar(&file, CArchive::load);
+      ar >> *this;
+      CLog::Log(LOGDEBUG,"Loading items: %i, directory: %s sort method: %i, ascending: %s", Size(), CURL::GetRedacted(GetPath()).c_str(), m_sortDescription.sortBy,
+        m_sortDescription.sortOrder == SortOrderAscending ? "true" : "false");
+      ar.Close();
+      file.Close();
+      return true;
+    }
+  }
+  catch(std::out_of_range ex)
+  {
+    CLog::Log(LOGERROR, "Corrupt archive: %s", CURL::GetRedacted(path).c_str());
   }
 
   return false;

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -2732,23 +2732,25 @@ std::string CFileItemList::GetDiscFileCache(int windowID) const
   std::string strPath(GetPath());
   URIUtils::RemoveSlashAtEnd(strPath);
 
-  Crc32 crc;
-  crc.ComputeFromLowerCase(strPath);
+  uint32_t crc = Crc32::ComputeFromLowerCase(strPath);
 
   std::string cacheFile;
   if (IsCDDA() || IsOnDVD())
-    cacheFile = StringUtils::Format("special://temp/r-%08x.fi", (unsigned __int32)crc);
-  else if (IsMusicDb())
-    cacheFile = StringUtils::Format("special://temp/mdb-%08x.fi", (unsigned __int32)crc);
-  else if (IsVideoDb())
-    cacheFile = StringUtils::Format("special://temp/vdb-%08x.fi", (unsigned __int32)crc);
-  else if (IsSmartPlayList())
-    cacheFile = StringUtils::Format("special://temp/sp-%08x.fi", (unsigned __int32)crc);
-  else if (windowID)
-    cacheFile = StringUtils::Format("special://temp/%i-%08x.fi", windowID, (unsigned __int32)crc);
-  else
-    cacheFile = StringUtils::Format("special://temp/%08x.fi", (unsigned __int32)crc);
-  return cacheFile;
+    return StringUtils::Format("special://temp/archive_cache/r-%08x.fi", crc);
+
+  if (IsMusicDb())
+    return StringUtils::Format("special://temp/archive_cache/mdb-%08x.fi", crc);
+
+  if (IsVideoDb())
+    return StringUtils::Format("special://temp/archive_cache/vdb-%08x.fi", crc);
+
+  if (IsSmartPlayList())
+    return StringUtils::Format("special://temp/archive_cache/sp-%08x.fi", crc);
+
+  if (windowID)
+    return StringUtils::Format("special://temp/archive_cache/%i-%08x.fi", windowID, crc);
+
+  return StringUtils::Format("special://temp/archive_cache/%08x.fi", crc);
 }
 
 bool CFileItemList::AlwaysCache() const

--- a/xbmc/filesystem/MusicDatabaseDirectory.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory.cpp
@@ -117,10 +117,9 @@ void CMusicDatabaseDirectory::ClearDirectoryCache(const std::string& strDirector
   std::string path = CLegacyPathTranslation::TranslateMusicDbPath(strDirectory);
   URIUtils::RemoveSlashAtEnd(path);
 
-  Crc32 crc;
-  crc.ComputeFromLowerCase(path);
+  uint32_t crc = Crc32::ComputeFromLowerCase(path);
 
-  std::string strFileName = StringUtils::Format("special://temp/%08x.fi", (unsigned __int32) crc);
+  std::string strFileName = StringUtils::Format("special://temp/%archive_cache/08x.fi", crc);
   CFile::Delete(strFileName);
 }
 

--- a/xbmc/filesystem/VideoDatabaseDirectory.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory.cpp
@@ -123,10 +123,9 @@ void CVideoDatabaseDirectory::ClearDirectoryCache(const std::string& strDirector
   std::string path = CLegacyPathTranslation::TranslateVideoDbPath(strDirectory);
   URIUtils::RemoveSlashAtEnd(path);
 
-  Crc32 crc;
-  crc.ComputeFromLowerCase(path);
+  uint32_t crc = Crc32::ComputeFromLowerCase(path);
 
-  std::string strFileName = StringUtils::Format("special://temp/%08x.fi", (unsigned __int32) crc);
+  std::string strFileName = StringUtils::Format("special://temp/archive_cache/%08x.fi", crc);
   CFile::Delete(strFileName);
 }
 

--- a/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
@@ -108,7 +108,7 @@ bool CGUIWindowMusicPlayList::OnMessage(CGUIMessage& message)
   case GUI_MSG_WINDOW_INIT:
     {
       // Setup item cache for tagloader
-      m_musicInfoLoader.UseCacheOnHD("special://temp/MusicPlaylist.fi");
+      m_musicInfoLoader.UseCacheOnHD("special://temp/archive_cache/MusicPlaylist.fi");
 
       m_vecItems->SetPath("playlistmusic://");
 

--- a/xbmc/utils/Archive.h
+++ b/xbmc/utils/Archive.h
@@ -41,9 +41,9 @@ public:
 
   /* CArchive support storing and loading of all C basic integer types
    * C basic types was chosen instead of fixed size ints (int16_t - int64_t) to support all integer typedefs
-   * For example size_t can be typedef of unsigned int, long or long long depending on platform 
-   * while int32_t and int64_t are usually unsigned short, int or long long, but not long 
-   * and even if int and long can have same binary representation they are different types for compiler 
+   * For example size_t can be typedef of unsigned int, long or long long depending on platform
+   * while int32_t and int64_t are usually unsigned short, int or long long, but not long
+   * and even if int and long can have same binary representation they are different types for compiler
    * According to section 5.2.4.2.1 of C99 http://www.open-std.org/jtc1/sc22/wg14/www/docs/n1256.pdf
    * minimal size of short int is 16 bits
    * minimal size of int is 16 bits (usually 32 or 64 bits, larger or equal to short int)

--- a/xbmc/utils/Archive.h
+++ b/xbmc/utils/Archive.h
@@ -21,6 +21,7 @@
  */
 
 #include <string>
+#include <memory>
 #include <vector>
 #include "PlatformDefs.h" // for SYSTEMTIME
 
@@ -149,7 +150,7 @@ public:
 protected:
   inline CArchive &streamout(const void *dataPtr, size_t size)
   {
-    const uint8_t *ptr = (const uint8_t *) dataPtr;
+    auto ptr = static_cast<const uint8_t *>(dataPtr);
     /* Note, the buffer is flushed as soon as it is full (m_BufferRemain == size) rather
      * than waiting until we attempt to put more data into an already full buffer */
     if (m_BufferRemain > size)
@@ -159,15 +160,13 @@ protected:
       m_BufferRemain -= size;
       return *this;
     }
-    else
-    {
-      return streamout_bufferwrap(ptr, size);
-    }
+
+    return streamout_bufferwrap(ptr, size);
   }
 
   inline CArchive &streamin(void *dataPtr, size_t size)
   {
-    uint8_t *ptr = (uint8_t *) dataPtr;
+    auto ptr = static_cast<uint8_t *>(dataPtr);
     /* Note, refilling the buffer is deferred until we know we need to read more from it */
     if (m_BufferRemain >= size)
     {
@@ -176,15 +175,13 @@ protected:
       m_BufferRemain -= size;
       return *this;
     }
-    else
-    {
-      return streamin_bufferwrap(ptr, size);
-    }
+
+    return streamin_bufferwrap(ptr, size);
   }
 
-  XFILE::CFile* m_pFile;
+  XFILE::CFile* m_pFile; //non-owning
   int m_iMode;
-  uint8_t *m_pBuffer;
+  std::unique_ptr<uint8_t[]> m_pBuffer;
   uint8_t *m_BufferPos;
   size_t m_BufferRemain;
 

--- a/xbmc/utils/Crc32.cpp
+++ b/xbmc/utils/Crc32.cpp
@@ -105,15 +105,17 @@ void Crc32::Compute(const char* buffer, size_t count)
       m_crc = (m_crc << 8) ^ crc_tab[((m_crc >> 24) ^ *buffer++) & 0xFF];
 }
 
-void Crc32::Compute(const std::string& strValue)
+uint32_t Crc32::Compute(const std::string& strValue)
 {
-  Compute(strValue.c_str(), strValue.size());
+  Crc32 crc;
+  crc.Compute(strValue.c_str(), strValue.size());
+  return crc;
 }
 
-void Crc32::ComputeFromLowerCase(const std::string& strValue)
+uint32_t Crc32::ComputeFromLowerCase(const std::string& strValue)
 {
   std::string strLower = strValue;
   StringUtils::ToLower(strLower);
-  Compute(strLower.c_str(), strLower.size());
+  return Compute(strLower.c_str());
 }
 

--- a/xbmc/utils/Crc32.h
+++ b/xbmc/utils/Crc32.h
@@ -29,8 +29,8 @@ public:
   Crc32();
   void Reset();
   void Compute(const char* buffer, size_t count);
-  void Compute(const std::string& strValue);
-  void ComputeFromLowerCase(const std::string& strValue);
+  static uint32_t Compute(const std::string& strValue);
+  static uint32_t ComputeFromLowerCase(const std::string& strValue);
 
   operator uint32_t () const
   {


### PR DESCRIPTION
This should fix this issue

```
Thread 1 (Thread 0x7f6369ff3700 (LWP 13304)):
#0  0x00007f63da306cc9 in __GI_raise (sig=sig@entry=6) at ../nptl/sysdeps/unix/sysv/linux/raise.c:56
#1  0x00007f63da30a0d8 in __GI_abort () at abort.c:89
#2  0x00007f63da90b535 in __gnu_cxx::__verbose_terminate_handler() () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#3  0x00007f63da9096d6 in ?? () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#4  0x00007f63da909703 in std::terminate() () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#5  0x00007f63da909922 in __cxa_throw () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#6  0x00007f63da909e0d in operator new(unsigned long) () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#7  0x00007f63da909ea9 in operator new[](unsigned long) () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#8  0x0000000000ff265c in CArchive::operator>>(std::string&) ()
#9  0x0000000000e6fb6f in CFileItemList::Archive(CArchive&) ()
#10 0x0000000000ff19ff in CArchive::operator>>(IArchivable&) ()
#11 0x0000000000e67bb3 in CFileItemList::Load(int) ()
#12 0x0000000000f5942f in UPNP::CUPnPServer::OnBrowseDirectChildren(NPT_Reference<PLT_Action>&, char const*, char const*, unsigned int, unsigned int, char const*, PLT_HttpRequestContext const&) ()
```

size_t is variable sized and if someone copies userdata from a 32-bit to a 64-bit system some string sizes could be quite large as 4 bytes from the string are added onto the size.

I limited everything to 32bit as we likely won't need large items in our archives, also it seems safest compatibility wise.
