### PR TITLE
fix stringcompare against 'true' or 'false'

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -968,21 +968,25 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
   const Property &cat = info[0];
   if (info.size() == 1)
   { // single category
-    if (cat.name == "false" || cat.name == "no" || cat.name == "off")
+    if (cat.name == "false" || cat.name == "no")
       return SYSTEM_ALWAYS_FALSE;
-    else if (cat.name == "true" || cat.name == "yes" || cat.name == "on")
+    else if (cat.name == "true" || cat.name == "yes")
       return SYSTEM_ALWAYS_TRUE;
     if (cat.name == "isempty" && cat.num_params() == 1)
       return AddMultiInfo(GUIInfo(STRING_IS_EMPTY, TranslateSingleString(cat.param(), listItemDependent)));
     else if (cat.name == "stringcompare" && cat.num_params() == 2)
     {
       int info = TranslateSingleString(cat.param(0), listItemDependent);
-      int info2 = TranslateSingleString(cat.param(1), listItemDependent);
-      if (info2 > 0)
-        return AddMultiInfo(GUIInfo(STRING_COMPARE, info, -info2));
       // pipe our original string through the localize parsing then make it lowercase (picks up $LBRACKET etc.)
       std::string label = CGUIInfoLabel::GetLabel(cat.param(1));
       StringUtils::ToLower(label);
+      // 'true', 'false', 'yes', 'no' are valid strings, do not resolve them to SYSTEM_ALWAYS_TRUE or SYSTEM_ALWAYS_FALSE
+      if (label != "true" && label != "false" && label != "yes" && label != "no")
+      {
+        int info2 = TranslateSingleString(cat.param(1), listItemDependent);
+        if (info2 > 0)
+          return AddMultiInfo(GUIInfo(STRING_COMPARE, info, -info2));
+      }
       int compareString = ConditionalStringParameter(label);
       return AddMultiInfo(GUIInfo(STRING_COMPARE, info, compareString));
     }


### PR DESCRIPTION
comparing a string against 'true', 'false', 'yes', 'no', 'on', 'off' has been broken for a long time.
http://forum.kodi.tv/showthread.php?tid=162948&pid=1402461#pid1402461

this has been pretty confusing for a lot of skinners.

this fixes it by
- remove the ability to use 'on', 'off' as a boolean condition
- not resolving 'true', 'false', 'yes', 'no' to SYSTEM_ALWAYS_TRUE or SYSTEM_ALWAYS_FALSE
