### PR TITLE
[cmake] Fix FFMPEG build and usage on Linux

### DIFF
--- a/project/cmake/CMakeLists.txt
+++ b/project/cmake/CMakeLists.txt
@@ -272,6 +272,9 @@ add_custom_target(pack-skins ALL
                   DEPENDS TexturePacker::TexturePacker export-files ${XBT_FILES})
 
 core_link_library(exif system/libexif)
+if(CORE_SYSTEM_NAME STREQUAL linux)
+  core_link_library(sse4 system/libsse4)
+endif()
 
 core_link_library(XBMC_addon addons/library.xbmc.addon/libXBMC_addon)
 core_link_library(XBMC_codec addons/library.xbmc.codec/libXBMC_codec)

--- a/project/cmake/installdata/common/addons.txt
+++ b/project/cmake/installdata/common/addons.txt
@@ -1,3 +1,4 @@
+addons/kodi.adsp/*
 addons/kodi.audiodecoder/*
 addons/kodi.resource/*
 addons/kodi.vfs/*
@@ -8,6 +9,7 @@ addons/xbmc.gui/*
 addons/xbmc.metadata/*
 addons/xbmc.pvr/*
 addons/xbmc.python/*
+addons/xbmc.webinterface/*
 addons/library.xbmc.addon/*
 addons/library.xbmc.codec/*
 addons/library.xbmc.gui/*

--- a/project/cmake/installdata/common/common.txt
+++ b/project/cmake/installdata/common/common.txt
@@ -6,6 +6,7 @@ system/players/VideoPlayer/etc/*
 system/shaders/*
 system/settings/*
 userdata/*
+system/addon-manifest.xml
 system/colors.xml
 system/peripherals.xml
 system/playercorefactory.xml

--- a/project/cmake/modules/FindFFMPEG.cmake
+++ b/project/cmake/modules/FindFFMPEG.cmake
@@ -31,6 +31,9 @@ if(ENABLE_INTERNAL_FFMPEG)
                       URL ${FFMPEG_BASE_URL}/${FFMPEG_VER}.tar.gz
                       PREFIX ${CORE_BUILD_DIR}/ffmpeg
                       CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}
+                                 -DCMAKE_BUILD_TYPE=${DCMAKE_BUILD_TYPE}
+                                 -DFFMPEG_VER=${FFMPEG_VER}
+                                 -DCORE_SYSTEM_NAME=${CORE_SYSTEM_NAME}
                                  ${CROSS_ARGS}
                       PATCH_COMMAND ${CMAKE_COMMAND} -E copy
                                     ${CORE_SOURCE_DIR}/tools/depends/target/ffmpeg/CMakeLists.txt

--- a/project/cmake/treedata/linux/subdirs.txt
+++ b/project/cmake/treedata/linux/subdirs.txt
@@ -1,4 +1,5 @@
 xbmc/linux                 linuxsupport
+xbmc/linux/sse4            sse4
 xbmc/input/linux           input/linux
 xbmc/input/touch           input/touch
 xbmc/input/touch/generic   input/touch/generic

--- a/tools/depends/target/ffmpeg/CMakeLists.txt
+++ b/tools/depends/target/ffmpeg/CMakeLists.txt
@@ -4,13 +4,7 @@ cmake_minimum_required(VERSION 2.8)
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR})
 
-
 set(ffmpeg_conf "")
-#if(CMAKE_BUILD_TYPE STREQUAL "Release")
-  #  list(APPEND ffmpeg_conf --enable-optimizations)
-  #else()
-  #  list(APPEND ffmpeg_conf --disable-optimizations)
-  #endif()
 
 if(CROSSCOMPILING)
   set(pkgconf "PKG_CONFIG_LIBDIR=${DEPENDS_PATH}/lib/pkgconfig")
@@ -21,19 +15,33 @@ if(CROSSCOMPILING)
   message(STATUS "CROSS: ${ffmpeg_conf}")
 endif()
 
-if(CPU MATCHES "arm")
-  list(APPEND ffmpeg_conf --disable-armv5te --disable-armv6t2)
-elseif(CPU MATCHES "mips")
-  list(APPEND ffmpeg_conf --disable-mips32r2 --disable-mipsdspr1 --disable-mipsdspr2)
-endif()
-
-if(CORE_SYSTEM_NAME STREQUAL "android")
-  if(CPU MATCHES "arm")
+if(CORE_SYSTEM_NAME STREQUAL linux)
+  list(APPEND ffmpeg_conf --enable-vdpau --enable-vaapi
+                          --enable-libvorbis --enable-muxer=ogg --enable-encoder=libvorbis)
+elseif(CORE_SYSTEM_NAME STREQUAL android)
+  if(CPU MATCHES arm)
     list(APPEND ffmpeg_conf --cpu=cortex-a9)
   else()
     list(APPEND ffmpeg_conf --cpu=i686 --disable-mmx)
   endif()
   list(APPEND ffmpeg_conf --target-os=linux)
+elseif(CORE_SYSTEM_NAME STREQUAL ios)
+  if(NOT CPU MATCHES arm64)
+    list(APPEND ffmpeg_conf --cpu=cortex-a8)
+  endif()
+  list(APPEND ffmpeg_conf --disable-decoder=mpeg_xvmc --disable-vda --disable-crystalhd
+                          --target-os=darwin)
+elseif(CORE_SYSTEM_NAME STREQUAL osx)
+  list(APPEND ffmpeg_conf --disable-outdev=sdl
+                          --disable-decoder=mpeg_xvmc --enable-vda --disable-crystalhd --disable-videotoolbox
+                          --target-os=darwin
+                          --disable-securetransport)
+endif()
+
+if(CPU MATCHES arm)
+  list(APPEND ffmpeg_conf --enable-pic --disable-armv5te --disable-armv6t2)
+elseif(CPU MATCHES mips)
+  list(APPEND ffmpeg_conf --disable-mips32r2 --disable-mipsdspr1 --disable-mipsdspr2)
 endif()
 
 find_package(GnuTls)
@@ -51,36 +59,30 @@ include(ExternalProject)
 externalproject_add(ffmpeg
                     SOURCE_DIR ${CMAKE_SOURCE_DIR}
                     CONFIGURE_COMMAND ${pkgconf} <SOURCE_DIR>/configure
-                      --disable-muxers
-                      --enable-zlib
-                      --enable-bzlib
+                      --prefix=${CMAKE_INSTALL_PREFIX}
+                      --extra-version="kodi-${FFMPEG_VER}"
+                      --disable-devices
+                      --disable-doc
+                      --disable-ffplay
+                      --disable-ffmpeg
+                      --disable-ffprobe
+                      --disable-ffserver
+                      --disable-sdl
+                      --enable-gpl
+                      --enable-runtime-cpudetect
+                      --enable-postproc
+                      --enable-pthreads
                       --enable-muxer=spdif
                       --enable-muxer=adts
                       --enable-muxer=asf
                       --enable-muxer=ipod
-                      --disable-encoders
                       --enable-encoder=ac3
                       --enable-encoder=aac
                       --enable-encoder=wmav2
-                      --disable-decoder=mpeg_xvmc
-                      --disable-devices
-                      --disable-ffprobe
-                      --disable-ffplay
-                      --disable-ffserver
-                      --disable-ffmpeg
-                      --disable-crystalhd
-                      --enable-static
-                      --disable-shared
-                      --disable-doc
-                      --enable-postproc
-                      --enable-gpl
-                      --enable-vdpau
-                      --enable-vaapi
                       --enable-protocol=http
-                      --enable-pthreads
-                      --enable-runtime-cpudetect
-                      --enable-pic
-                      --prefix=${CMAKE_INSTALL_PREFIX}
+                      --enable-libdcadec
+                      --enable-encoder=png
+                      --enable-encoder=mjpeg
                       ${ffmpeg_conf}
                     BUILD_COMMAND make ${PARALLEL_FLAGS})
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.cpp
@@ -60,24 +60,15 @@ bool CDVDVideoCodec::IsSettingVisible(const std::string &condition, const std::s
   return true;
 }
 
-bool CDVDVideoCodec::IsCodecDisabled(DVDCodecAvailableType* map, unsigned int size, AVCodecID id)
+bool CDVDVideoCodec::IsCodecDisabled(const std::map<AVCodecID, std::string> &map, AVCodecID id)
 {
-  int index = -1;
-  for (unsigned int i = 0; i < size; ++i)
+  auto codec = map.find(id);
+  if (codec != map.end())
   {
-    if (map[i].codec == id)
-    {
-      index = (int) i;
-      break;
-    }
-  }
-  if (index > -1)
-  {
-    return (!CSettings::GetInstance().GetBool(map[index].setting) ||
+    return (!CSettings::GetInstance().GetBool(codec->second) ||
             !CDVDVideoCodec::IsSettingVisible("unused", "unused",
-                                              CSettings::GetInstance().GetSetting(map[index].setting),
+                                              CSettings::GetInstance().GetSetting(codec->second),
                                               NULL));
   }
-
   return false; // don't disable what we don't have
 }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h
@@ -29,14 +29,9 @@ extern "C" {
 
 #include <vector>
 #include <string>
+#include <map>
 
 class CSetting;
-
-struct DVDCodecAvailableType
-{
-  AVCodecID codec;
-  const char* setting;
-};
 
 // when modifying these structures, make sure you update all codecs accordingly
 #define FRAME_TYPE_UNDEF 0
@@ -268,7 +263,7 @@ public:
   /**
    * Interact with user settings so that user disabled codecs are disabled
    */
-  static bool IsCodecDisabled(DVDCodecAvailableType* map, unsigned int size, AVCodecID id);
+  static bool IsCodecDisabled(const std::map<AVCodecID, std::string> &map, AVCodecID id);
 
   /**
    * For calculation of dropping requirements player asks for some information.

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecVDA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecVDA.cpp
@@ -18,7 +18,9 @@
  *
  */
 
-#include "config.h"
+#if defined(HAVE_CONFIG_H)
+  #include "config.h"
+#endif
 
 #if defined(TARGET_DARWIN_OSX)
 #include "system_gl.h"

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
@@ -448,16 +448,6 @@ bool CVideoSurfaces::HasRefs()
 // VAAPI
 //-----------------------------------------------------------------------------
 
-// settings codecs mapping
-DVDCodecAvailableType g_vaapi_available[] = {
-  { AV_CODEC_ID_H263, CSettings::SETTING_VIDEOPLAYER_USEVAAPIMPEG4.c_str() },
-  { AV_CODEC_ID_MPEG4, CSettings::SETTING_VIDEOPLAYER_USEVAAPIMPEG4.c_str() },
-  { AV_CODEC_ID_WMV3, CSettings::SETTING_VIDEOPLAYER_USEVAAPIVC1.c_str() },
-  { AV_CODEC_ID_VC1, CSettings::SETTING_VIDEOPLAYER_USEVAAPIVC1.c_str() },
-  { AV_CODEC_ID_MPEG2VIDEO, CSettings::SETTING_VIDEOPLAYER_USEVAAPIMPEG2.c_str() },
-};
-const size_t settings_count = sizeof(g_vaapi_available) / sizeof(DVDCodecAvailableType);
-
 CDecoder::CDecoder() : m_vaapiOutput(&m_inMsgEvent)
 {
   m_vaapiConfig.videoSurfaces = &m_videoSurfaces;
@@ -497,7 +487,14 @@ bool CDecoder::Open(AVCodecContext* avctx, AVCodecContext* mainctx, const enum A
   }
 
   // check if user wants to decode this format with VAAPI
-  if (CDVDVideoCodec::IsCodecDisabled(g_vaapi_available, settings_count, avctx->codec_id))
+  std::map<AVCodecID, std::string> settings_map = {
+    { AV_CODEC_ID_H263, CSettings::SETTING_VIDEOPLAYER_USEVAAPIMPEG4 },
+    { AV_CODEC_ID_MPEG4, CSettings::SETTING_VIDEOPLAYER_USEVAAPIMPEG4 },
+    { AV_CODEC_ID_WMV3, CSettings::SETTING_VIDEOPLAYER_USEVAAPIVC1 },
+    { AV_CODEC_ID_VC1, CSettings::SETTING_VIDEOPLAYER_USEVAAPIVC1 },
+    { AV_CODEC_ID_MPEG2VIDEO, CSettings::SETTING_VIDEOPLAYER_USEVAAPIMPEG2 },
+  };
+  if (CDVDVideoCodec::IsCodecDisabled(settings_map, avctx->codec_id))
     return false;
 
   if (g_advancedSettings.CanLogComponent(LOGVIDEO))

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDPAU.cpp
@@ -45,16 +45,6 @@ using namespace VDPAU;
 
 #define ARSIZE(x) (sizeof(x) / sizeof((x)[0]))
 
-// settings codecs mapping
-DVDCodecAvailableType g_vdpau_available[] = {
-  { AV_CODEC_ID_H263, CSettings::SETTING_VIDEOPLAYER_USEVDPAUMPEG4.c_str() },
-  { AV_CODEC_ID_MPEG4, CSettings::SETTING_VIDEOPLAYER_USEVDPAUMPEG4.c_str() },
-  { AV_CODEC_ID_WMV3, CSettings::SETTING_VIDEOPLAYER_USEVDPAUVC1.c_str() },
-  { AV_CODEC_ID_VC1, CSettings::SETTING_VIDEOPLAYER_USEVDPAUVC1.c_str() },
-  { AV_CODEC_ID_MPEG2VIDEO, CSettings::SETTING_VIDEOPLAYER_USEVDPAUMPEG2.c_str() },
-};
-const size_t settings_count = sizeof(g_vdpau_available) / sizeof(DVDCodecAvailableType);
-
 CDecoder::Desc decoder_profiles[] = {
 {"MPEG1",        VDP_DECODER_PROFILE_MPEG1},
 {"MPEG2_SIMPLE", VDP_DECODER_PROFILE_MPEG2_SIMPLE},
@@ -494,7 +484,14 @@ bool CDecoder::Open(AVCodecContext* avctx, AVCodecContext* mainctx, const enum A
   // nvidia is whitelisted despite for mpeg-4 we need to query user settings
   if ((gpuvendor.compare(0, 6, "nvidia") != 0)  || (avctx->codec_id == AV_CODEC_ID_MPEG4) || (avctx->codec_id == AV_CODEC_ID_H263))
   {
-    if (CDVDVideoCodec::IsCodecDisabled(g_vdpau_available, settings_count, avctx->codec_id))
+    std::map<AVCodecID, std::string> settings_map = {
+      { AV_CODEC_ID_H263, CSettings::SETTING_VIDEOPLAYER_USEVDPAUMPEG4 },
+      { AV_CODEC_ID_MPEG4, CSettings::SETTING_VIDEOPLAYER_USEVDPAUMPEG4 },
+      { AV_CODEC_ID_WMV3, CSettings::SETTING_VIDEOPLAYER_USEVDPAUVC1 },
+      { AV_CODEC_ID_VC1, CSettings::SETTING_VIDEOPLAYER_USEVDPAUVC1 },
+      { AV_CODEC_ID_MPEG2VIDEO, CSettings::SETTING_VIDEOPLAYER_USEVDPAUMPEG2 },
+    };
+    if (CDVDVideoCodec::IsCodecDisabled(settings_map, avctx->codec_id))
       return false;
   }
 

--- a/xbmc/linux/sse4/CMakeLists.txt
+++ b/xbmc/linux/sse4/CMakeLists.txt
@@ -1,0 +1,8 @@
+set(SOURCES CopyFrame.cpp)
+
+set(HEADERS DllLibSSE4.h)
+
+set(CMAKE_POSITION_INDEPENDENT_CODE 1)
+
+core_add_library(sse4 NO_MAIN_DEPENDS)
+target_compile_options(sse4 PRIVATE -msse4.1)


### PR DESCRIPTION
Some fixes related to FFMPEG / Video Playback:
- Fix problem with IsCodecDisabled that prevented the usage of VDPAU and VAAPI on Linux. (@FernetMenta: mind checking a81208e, maybe also @xhaggi) 
- Restructured the FFMPEG CMake file so that it is closer to the Makefile and differences can be spotted more easily
- Build FFMPEG with exactly the same options as when using the Makefile (mostly: enable mjpeg and png which fixes thumbnails and other images in kodi)
- Build the SSE4 shared library

Unrelated:
- Fix installation of a few files for out of source build
