### PR TITLE
[EPG] Notify observers on epg updates

### DIFF
--- a/xbmc/epg/Epg.h
+++ b/xbmc/epg/Epg.h
@@ -215,10 +215,11 @@ namespace EPG
     /*!
      * @brief Update an entry in this EPG.
      * @param tag The tag to update.
+     * @param bNotifyObservers True if observers should be notified
      * @param bUpdateDatabase If set to true, this event will be persisted in the database.
      * @return True if it was updated successfully, false otherwise.
      */
-    bool UpdateEntry(const CEpgInfoTagPtr &tag, bool bUpdateDatabase = false);
+    bool UpdateEntry(const CEpgInfoTagPtr &tag, bool bNotifyObservers, bool bUpdateDatabase = false);
 
     /*!
      * @brief Update an entry in this EPG.


### PR DESCRIPTION
We need to notify observers whenever an event is inserted in/removed from EPG. This is very important for async epg data transfer PVR API 5.0.0 feature. Otherwise, if you for instance open the TV Guide window very early after kodi startup it will initially show no/only a few epg events and only refresh if kodi pulls(!) next time for epg data (which can be quite a long time interval). With this change, PVR windows (Guide, Channels, ...) update it content "live", as soon as async epg data arrive. 

BTW: Although one could suspect that the many <code>NotifyObserver</code> calls would have negative impact, runtime testing did not reveal any noticeable performance changes.

@xhaggi mind taking a look. 
