### PR TITLE
VideoPlayer: some cleanup for dropping video frames

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h
@@ -273,16 +273,19 @@ public:
   /**
    * For calculation of dropping requirements player asks for some information.
    * - pts : right after decoder, used to detect gaps (dropped frames in decoder)
-   * - droppedPics : indicates if decoder has dropped a picture
+   * - droppedFrames : indicates if decoder has dropped a frame
+   *                 -1 means that decoder has no info on this.
+   * - skippedPics : indicates if postproc has skipped a already decoded picture
    *                 -1 means that decoder has no info on this.
    *
    * If codec does not implement this method, pts of decoded frame at input
    * video player is used. In case decoder does post-proc and de-interlacing there
    * may be quite some frames queued up between exit decoder and entry player.
    */
-  virtual bool GetCodecStats(double &pts, int &droppedPics)
+  virtual bool GetCodecStats(double &pts, int &droppedFrames, int &skippedPics)
   {
-    droppedPics = -1;
+    droppedFrames = -1;
+    skippedPics = -1;
     return false;
   }
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.h
@@ -59,22 +59,22 @@ public:
 
   CDVDVideoCodecFFmpeg();
   virtual ~CDVDVideoCodecFFmpeg();
-  virtual bool Open(CDVDStreamInfo &hints, CDVDCodecOptions &options);
-  virtual void Dispose();
-  virtual int Decode(uint8_t* pData, int iSize, double dts, double pts);
-  virtual void Reset();
-  virtual void Reopen();
+  virtual bool Open(CDVDStreamInfo &hints, CDVDCodecOptions &options) override;
+  virtual void Dispose() override;
+  virtual int Decode(uint8_t* pData, int iSize, double dts, double pts) override;
+  virtual void Reset() override;
+  virtual void Reopen() override;
   bool GetPictureCommon(DVDVideoPicture* pDvdVideoPicture);
-  virtual bool GetPicture(DVDVideoPicture* pDvdVideoPicture);
-  virtual void SetDropState(bool bDrop);
-  virtual const char* GetName() { return m_name.c_str(); }; // m_name is never changed after open
-  virtual unsigned GetConvergeCount();
-  virtual unsigned GetAllowedReferences();
-  virtual bool GetCodecStats(double &pts, int &droppedPics);
-  virtual void SetCodecControl(int flags);
+  virtual bool GetPicture(DVDVideoPicture* pDvdVideoPicture) override;
+  virtual void SetDropState(bool bDrop) override;
+  virtual const char* GetName() override { return m_name.c_str(); }; // m_name is never changed after open
+  virtual unsigned GetConvergeCount() override;
+  virtual unsigned GetAllowedReferences() override;
+  virtual bool GetCodecStats(double &pts, int &droppedFrames, int &skippedPics) override;
+  virtual void SetCodecControl(int flags) override;
 
-  IHardwareDecoder * GetHardware()                           { return m_pHardware; };
-  void               SetHardware(IHardwareDecoder* hardware);
+  IHardwareDecoder * GetHardware() { return m_pHardware; };
+  void SetHardware(IHardwareDecoder* hardware);
 
 protected:
   static enum AVPixelFormat GetFormat(struct AVCodecContext * avctx, const AVPixelFormat * fmt);
@@ -125,8 +125,10 @@ protected:
   std::vector<AVPixelFormat> m_formats;
   double m_decoderPts;
   int    m_skippedDeint;
+  int    m_droppedFrames;
   bool   m_requestSkipDeint;
   int    m_codecControlFlags;
+  bool m_interlaced;
   CDVDStreamInfo m_hints;
   CDVDCodecOptions m_options;
 };

--- a/xbmc/cores/VideoPlayer/DVDMessage.h
+++ b/xbmc/cores/VideoPlayer/DVDMessage.h
@@ -83,7 +83,6 @@ public:
 
     // video related messages
 
-    VIDEO_NOSKIP,                   // next pictures is not to be skipped by the video renderer
     VIDEO_SET_ASPECT,               // set aspectratio of video
     VIDEO_DRAIN,                    // wait for decoder to output last frame
 

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -1328,10 +1328,6 @@ void CVideoPlayer::Process()
           !m_SelectionStreams.m_Streams.empty())
         OpenDefaultStreams();
 
-      // never allow first frames after open to be skipped
-      if( m_VideoPlayerVideo->IsInited() )
-        m_VideoPlayerVideo->SendMessage(new CDVDMsg(CDVDMsg::VIDEO_NOSKIP));
-
       UpdateApplication(0);
       UpdatePlayState(0);
     }
@@ -3821,7 +3817,6 @@ void CVideoPlayer::FlushBuffers(bool queued, double pts, bool accurate, bool syn
   {
     m_VideoPlayerAudio->SendMessage(new CDVDMsg(CDVDMsg::GENERAL_RESET));
     m_VideoPlayerVideo->SendMessage(new CDVDMsg(CDVDMsg::GENERAL_RESET));
-    m_VideoPlayerVideo->SendMessage(new CDVDMsg(CDVDMsg::VIDEO_NOSKIP));
     m_VideoPlayerSubtitle->SendMessage(new CDVDMsg(CDVDMsg::GENERAL_RESET));
     m_VideoPlayerTeletext->SendMessage(new CDVDMsg(CDVDMsg::GENERAL_RESET));
     m_VideoPlayerRadioRDS->SendMessage(new CDVDMsg(CDVDMsg::GENERAL_RESET));

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.h
@@ -52,7 +52,6 @@ public:
   };
   std::deque<CGain> m_gain;
   double m_totalGain;
-  double m_lastDecoderPts;
   double m_lastPts;
   unsigned int m_lateFrames;
   unsigned int m_dropRequests;
@@ -117,7 +116,7 @@ protected:
 
   void ResetFrameRateCalc();
   void CalcFrameRate();
-  int CalcDropRequirement(double pts, bool updateOnly);
+  int CalcDropRequirement(double pts);
 
   double m_iVideoDelay;
   double m_iSubtitleDelay;
@@ -141,7 +140,6 @@ protected:
   bool m_bAllowFullscreen;
   bool m_bRenderSubs;
   float m_fForcedAspectRatio;
-  int m_iNrOfPicturesNotToSkip;
   int m_speed;
   bool m_stalled;
   IDVDStreamPlayer::ESyncState m_syncState;


### PR DESCRIPTION
thanks to @popcornmix for bringing this up. There's bee situations where decoder dropping did not work. If skipping in renderer did not work too, video lag increases.

@Memphiz maybe the reason for some old cases we were investigating
