### PR TITLE
WebDAV directory listing should be compressed

### DIFF
--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -593,6 +593,9 @@ void CCurlFile::SetCommonOptions(CReadState* state)
   if( m_contentencoding.length() > 0 )
     g_curlInterface.easy_setopt(h, CURLOPT_ENCODING, m_contentencoding.c_str());
 
+  if (m_acceptencoding.length() > 0)
+    g_curlInterface.easy_setopt(h, CURLOPT_ACCEPT_ENCODING, m_acceptencoding.c_str());
+    
   if (!m_useOldHttpVersion && !m_acceptCharset.empty())
     SetRequestHeader("Accept-Charset", m_acceptCharset);
 

--- a/xbmc/filesystem/CurlFile.h
+++ b/xbmc/filesystem/CurlFile.h
@@ -4,7 +4,7 @@
  *      http://xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Pcoublic License as published by
+ *  it under the terms of the GNU General Public License as published by
  *  the Free Software Foundation; either version 2, or (at your option)
  *  any later version.
  *

--- a/xbmc/filesystem/CurlFile.h
+++ b/xbmc/filesystem/CurlFile.h
@@ -79,6 +79,7 @@ namespace XFILE
       void SetCustomRequest(const std::string &request)          { m_customrequest = request; }
       void UseOldHttpVersion(bool bUse)                          { m_useOldHttpVersion = bUse; }
       void SetContentEncoding(const std::string& encoding)       { m_contentencoding = encoding; }
+      void SetAcceptEncoding(const std::string& encoding)        { m_acceptencoding = encoding; }
       void SetAcceptCharset(const std::string& charset)          { m_acceptCharset = charset; }
       void SetTimeout(int connecttimeout)                        { m_connecttimeout = connecttimeout; }
       void SetLowSpeedTime(int lowspeedtime)                     { m_lowspeedtime = lowspeedtime; }

--- a/xbmc/filesystem/CurlFile.h
+++ b/xbmc/filesystem/CurlFile.h
@@ -4,7 +4,7 @@
  *      http://xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
+ *  it under the terms of the GNU General Pcoublic License as published by
  *  the Free Software Foundation; either version 2, or (at your option)
  *  any later version.
  *
@@ -170,6 +170,7 @@ namespace XFILE
       ProxyType       m_proxytype;
       std::string     m_customrequest;
       std::string     m_contentencoding;
+      std::string     m_acceptencoding;
       std::string     m_acceptCharset;
       std::string     m_ftpauth;
       std::string     m_ftpport;

--- a/xbmc/filesystem/DAVDirectory.cpp
+++ b/xbmc/filesystem/DAVDirectory.cpp
@@ -116,7 +116,7 @@ bool CDAVDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   dav.SetCustomRequest(strRequest);
   dav.SetMimeType("text/xml; charset=\"utf-8\"");
   dav.SetRequestHeader("depth", 1);
-  dav.SetRequestHeader("Accept-Encoding", "gzip, deflate");
+  dav.SetAcceptEncoding"(gzip, deflate");
   dav.SetPostData(
     "<?xml version=\"1.0\" encoding=\"utf-8\" ?>"
     " <D:propfind xmlns:D=\"DAV:\">"

--- a/xbmc/filesystem/DAVDirectory.cpp
+++ b/xbmc/filesystem/DAVDirectory.cpp
@@ -116,6 +116,7 @@ bool CDAVDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   dav.SetCustomRequest(strRequest);
   dav.SetMimeType("text/xml; charset=\"utf-8\"");
   dav.SetRequestHeader("depth", 1);
+  dav.SetRequestHeader("Accept-Encoding", "gzip, deflate");
   dav.SetPostData(
     "<?xml version=\"1.0\" encoding=\"utf-8\" ?>"
     " <D:propfind xmlns:D=\"DAV:\">"

--- a/xbmc/filesystem/DAVDirectory.cpp
+++ b/xbmc/filesystem/DAVDirectory.cpp
@@ -116,7 +116,7 @@ bool CDAVDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   dav.SetCustomRequest(strRequest);
   dav.SetMimeType("text/xml; charset=\"utf-8\"");
   dav.SetRequestHeader("depth", 1);
-  dav.SetAcceptEncoding"(gzip, deflate");
+  dav.SetAcceptEncoding("gzip, deflate");
   dav.SetPostData(
     "<?xml version=\"1.0\" encoding=\"utf-8\" ?>"
     " <D:propfind xmlns:D=\"DAV:\">"


### PR DESCRIPTION
As explained in http://forum.kodi.tv/showthread.php?tid=253090.

PROPFIND response is XML very easily compressible. Even considering the compression/decompresion CPU cycles, it should be faster in the network.
