### PR TITLE
VideoPlayer: drop streamInfo

### DIFF
--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -683,20 +683,6 @@ void CApplicationPlayer::GetSubtitleCapabilities(std::vector<int> &subCaps)
     player->GetSubtitleCapabilities(subCaps);
 }
 
-void CApplicationPlayer::GetAudioInfo(std::string& strAudioInfo)
-{
-  std::shared_ptr<IPlayer> player = GetInternal();
-  if (player)
-    player->GetAudioInfo(strAudioInfo);
-}
-
-void CApplicationPlayer::GetVideoInfo(std::string& strVideoInfo)
-{
-  std::shared_ptr<IPlayer> player = GetInternal();
-  if (player)
-    player->GetVideoInfo(strVideoInfo);
-}
-
 void CApplicationPlayer::GetGeneralInfo(std::string& strVideoInfo)
 {
   std::shared_ptr<IPlayer> player = GetInternal();

--- a/xbmc/ApplicationPlayer.h
+++ b/xbmc/ApplicationPlayer.h
@@ -111,7 +111,6 @@ public:
   bool  ControlsVolume() const;
   void  DoAudioWork();
   void  GetAudioCapabilities(std::vector<int> &audioCaps);
-  void  GetAudioInfo(std::string& strAudioInfo);
   int   GetAudioStream();
   int   GetAudioStreamCount();
   void  GetAudioStreamInfo(int index, SPlayerAudioStreamInfo &info);
@@ -140,7 +139,6 @@ public:
   std::string GetRadioText(unsigned int line);
   int64_t GetTime() const;
   int64_t GetTotalTime() const;
-  void  GetVideoInfo(std::string& strVideoInfo);
   int   GetVideoStream();
   int   GetVideoStreamCount();
   void  GetVideoStreamInfo(int streamId, SPlayerVideoStreamInfo &info);

--- a/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
+++ b/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
@@ -530,16 +530,6 @@ void CExternalPlayer::Seek(bool bPlus, bool bLargeStep, bool bChapterOverride)
 {
 }
 
-void CExternalPlayer::GetAudioInfo(std::string& strAudioInfo)
-{
-  strAudioInfo = "CExternalPlayer:GetAudioInfo";
-}
-
-void CExternalPlayer::GetVideoInfo(std::string& strVideoInfo)
-{
-  strVideoInfo = "CExternalPlayer:GetVideoInfo";
-}
-
 void CExternalPlayer::GetGeneralInfo(std::string& strGeneralInfo)
 {
   strGeneralInfo = "CExternalPlayer:GetGeneralInfo";

--- a/xbmc/cores/ExternalPlayer/ExternalPlayer.h
+++ b/xbmc/cores/ExternalPlayer/ExternalPlayer.h
@@ -55,8 +55,6 @@ public:
   virtual void SetBrightness(bool bPlus) {}
   virtual void SetHue(bool bPlus) {}
   virtual void SetSaturation(bool bPlus) {}
-  virtual void GetAudioInfo(std::string& strAudioInfo);
-  virtual void GetVideoInfo(std::string& strVideoInfo);
   virtual void GetGeneralInfo(std::string& strVideoInfo);
   virtual void SwitchToNextAudioLanguage();
   virtual bool CanRecord() { return false; }

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -258,8 +258,6 @@ public:
   virtual void SetVolume(float volume){}
   virtual bool ControlsVolume(){ return false;}
   virtual void SetDynamicRangeCompression(long drc){}
-  virtual void GetAudioInfo(std::string& strAudioInfo) = 0;
-  virtual void GetVideoInfo(std::string& strVideoInfo) = 0;
   virtual void GetGeneralInfo(std::string& strGeneralInfo) = 0;
   virtual bool CanRecord() { return false;};
   virtual bool IsRecording() { return false;};

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.cpp
@@ -20,16 +20,6 @@
 
 #include "DVDDemux.h"
 
-std::string CDemuxStreamTeletext::GetStreamInfo()
-{
-  return "Teletext Data Stream";
-}
-
-std::string CDemuxStreamRadioRDS::GetStreamInfo()
-{
-  return "Radio Data Stream (RDS)";
-}
-
 std::string CDemuxStreamAudio::GetStreamType()
 {
   char sInfo[64] = {0};

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
@@ -100,11 +100,6 @@ public:
     delete [] ExtraData;
   }
 
-  virtual std::string GetStreamInfo()
-  {
-    return "";
-  }
-
   virtual std::string GetStreamName();
 
   virtual void      SetDiscard(AVDiscard discard);
@@ -222,7 +217,6 @@ public:
   {
     type = STREAM_TELETEXT;
   }
-  virtual std::string GetStreamInfo();
 };
 
 class CDemuxStreamRadioRDS : public CDemuxStream
@@ -232,7 +226,6 @@ public:
   {
     type = STREAM_RADIO_RDS;
   }
-  virtual std::string GetStreamInfo();
 };
 
 class CDVDDemux

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxBXA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxBXA.cpp
@@ -37,10 +37,6 @@ public:
     , m_codec(codec)
 
   {}
-  void GetStreamInfo(std::string& strInfo)
-  {
-    strInfo = StringUtils::Format("%s", m_codec.c_str());
-  }
 };
 
 CDVDDemuxBXA::CDVDDemuxBXA() : CDVDDemux()

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCDDA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCDDA.cpp
@@ -28,11 +28,6 @@
 class CDemuxStreamAudioCDDA
   : public CDemuxStreamAudio
 {
-public:
-  void GetStreamInfo(std::string& strInfo)
-  {
-    strInfo = "pcm";
-  }
 };
 
 CDVDDemuxCDDA::CDVDDemuxCDDA() : CDVDDemux()

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
@@ -68,7 +68,6 @@ class CDemuxStreamVideoClient
 {
 public:
   CDemuxStreamVideoClient() {}
-  virtual std::string GetStreamInfo() override;
 };
 
 class CDemuxStreamAudioClient
@@ -77,7 +76,6 @@ class CDemuxStreamAudioClient
 {
 public:
   CDemuxStreamAudioClient() {}
-  virtual std::string GetStreamInfo() override;
 };
 
 class CDemuxStreamSubtitleClient
@@ -86,61 +84,7 @@ class CDemuxStreamSubtitleClient
 {
 public:
   CDemuxStreamSubtitleClient() {}
-  virtual std::string GetStreamInfo() override;
 };
-
-std::string CDemuxStreamVideoClient::GetStreamInfo()
-{
-  std::string strInfo;
-  switch (codec)
-  {
-    case AV_CODEC_ID_MPEG2VIDEO:
-      strInfo = "mpeg2video";
-      break;
-    case AV_CODEC_ID_H264:
-      strInfo = "h264";
-      break;
-    case AV_CODEC_ID_HEVC:
-      strInfo = "hevc";
-      break;
-    default:
-      break;
-  }
-
-  return strInfo;
-}
-
-std::string CDemuxStreamAudioClient::GetStreamInfo()
-{
-  std::string strInfo;
-  switch (codec)
-  {
-    case AV_CODEC_ID_AC3:
-      strInfo = "ac3";
-      break;
-    case AV_CODEC_ID_EAC3:
-      strInfo = "eac3";
-      break;
-    case AV_CODEC_ID_MP2:
-      strInfo = "mpeg2audio";
-      break;
-    case AV_CODEC_ID_AAC:
-      strInfo = "aac";
-      break;
-    case AV_CODEC_ID_DTS:
-      strInfo = "dts";
-      break;
-    default:
-      break;
-  }
-
-  return strInfo;
-}
-
-std::string CDemuxStreamSubtitleClient::GetStreamInfo()
-{
-  return "";
-}
 
 CDVDDemuxClient::CDVDDemuxClient() : CDVDDemux()
 {

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -77,16 +77,6 @@ static const struct StereoModeConversionMap WmvToInternalStereoModeMap[] =
 
 #define FF_MAX_EXTRADATA_SIZE ((1 << 28) - FF_INPUT_BUFFER_PADDING_SIZE)
 
-std::string CDemuxStreamAudioFFmpeg::GetStreamInfo()
-{
-  if(!m_stream)
-    return "";
-  char temp[128];
-  avcodec_string(temp, 128, m_stream->codec, 0);
-
-  return temp;
-}
-
 std::string CDemuxStreamAudioFFmpeg::GetStreamName()
 {
   if(!m_stream)
@@ -107,16 +97,6 @@ std::string CDemuxStreamSubtitleFFmpeg::GetStreamName()
     return CDemuxStream::GetStreamName();
 }
 
-std::string CDemuxStreamVideoFFmpeg::GetStreamInfo()
-{
-  if(!m_stream)
-    return "";
-  char temp[128];
-  avcodec_string(temp, 128, m_stream->codec, 0);
-  
-  return temp;
-}
-
 std::string CDemuxStreamVideoFFmpeg::GetStreamName()
 {
   if (!m_stream)
@@ -125,16 +105,6 @@ std::string CDemuxStreamVideoFFmpeg::GetStreamName()
     return m_description;
   else
     return CDemuxStream::GetStreamName();
-}
-
-std::string CDemuxStreamSubtitleFFmpeg::GetStreamInfo()
-{
-  if(!m_stream)
-    return "";
-  char temp[128];
-  avcodec_string(temp, 128, m_stream->codec, 0);
-  
-  return temp;
 }
 
 static int interrupt_cb(void* ctx)

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
@@ -45,7 +45,6 @@ public:
   {}
   std::string      m_description;
 
-  virtual std::string GetStreamInfo() override;
   virtual std::string GetStreamName() override;
 };
 
@@ -62,7 +61,6 @@ public:
   {}
   std::string m_description;
 
-  virtual std::string GetStreamInfo() override;
   virtual std::string GetStreamName() override;
 };
 
@@ -78,7 +76,6 @@ public:
   {}
   std::string m_description;
 
-  virtual std::string GetStreamInfo() override;
   virtual std::string GetStreamName() override;
 
 };

--- a/xbmc/cores/VideoPlayer/IVideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/IVideoPlayer.h
@@ -56,8 +56,6 @@ struct SPlayerState
     recording     = false;
     canpause      = false;
     canseek       = false;
-    demux_video   = "";
-    demux_audio   = "";
     cache_bytes   = 0;
     cache_level   = 0.0;
     cache_delay   = 0.0;
@@ -85,9 +83,6 @@ struct SPlayerState
 
   bool canpause;            // pvr: can pause the current playing item
   bool canseek;             // pvr: can seek in the current playing item
-
-  std::string demux_video;
-  std::string demux_audio;
 
   int64_t cache_bytes;   // number of bytes current's cached
   double  cache_level;   // current estimated required cache level

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -3076,22 +3076,6 @@ bool CVideoPlayer::SeekScene(bool bPlus)
   return false;
 }
 
-void CVideoPlayer::GetAudioInfo(std::string& strAudioInfo)
-{
-  { CSingleLock lock(m_StateSection);
-    strAudioInfo = StringUtils::Format("D(%s)", m_State.demux_audio.c_str());
-  }
-  strAudioInfo += StringUtils::Format("\nP(%s)", m_VideoPlayerAudio->GetPlayerInfo().c_str());
-}
-
-void CVideoPlayer::GetVideoInfo(std::string& strVideoInfo)
-{
-  { CSingleLock lock(m_StateSection);
-    strVideoInfo = StringUtils::Format("D(%s)", m_State.demux_video.c_str());
-  }
-  strVideoInfo += StringUtils::Format("\nP(%s)", m_VideoPlayerVideo->GetPlayerInfo().c_str());
-}
-
 void CVideoPlayer::GetGeneralInfo(std::string& strGeneralInfo)
 {
   if (!m_bStop)
@@ -4704,24 +4688,6 @@ void CVideoPlayer::UpdatePlayState(double timeout)
 
   if(state.time_total <= 0)
     state.canseek  = false;
-
-  if (m_CurrentAudio.id >= 0 && m_pDemuxer)
-  {
-    CDemuxStream* pStream = m_pDemuxer->GetStream(m_CurrentAudio.id);
-    if (pStream && pStream->type == STREAM_AUDIO)
-      state.demux_audio = ((CDemuxStreamAudio*)pStream)->GetStreamInfo();
-  }
-  else
-    state.demux_audio = "";
-
-  if (m_CurrentVideo.id >= 0 && m_pDemuxer)
-  {
-    CDemuxStream* pStream = m_pDemuxer->GetStream(m_CurrentVideo.id);
-    if (pStream && pStream->type == STREAM_VIDEO)
-      state.demux_video = ((CDemuxStreamVideo*)pStream)->GetStreamInfo();
-  }
-  else
-    state.demux_video = "";
 
   double level, delay, offset;
   if(GetCachingTimes(level, delay, offset))

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -251,8 +251,6 @@ public:
   virtual void SetVolume(float nVolume)                         { m_VideoPlayerAudio->SetVolume(nVolume); }
   virtual void SetMute(bool bOnOff)                             { m_VideoPlayerAudio->SetMute(bOnOff); }
   virtual void SetDynamicRangeCompression(long drc)             { m_VideoPlayerAudio->SetDynamicRangeCompression(drc); }
-  virtual void GetAudioInfo(std::string& strAudioInfo);
-  virtual void GetVideoInfo(std::string& strVideoInfo);
   virtual void GetGeneralInfo(std::string& strVideoInfo);
   virtual bool CanRecord();
   virtual bool IsRecording();

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -380,20 +380,7 @@ void CGUIWindowFullScreen::FrameMove()
   if (m_showCodec)
   {
     // show audio codec info
-    std::string strAudio, strVideo, strGeneral;
-    g_application.m_pPlayer->GetAudioInfo(strAudio);
-    {
-      CGUIMessage msg(GUI_MSG_LABEL_SET, GetID(), LABEL_ROW1);
-      msg.SetLabel(strAudio);
-      OnMessage(msg);
-    }
-    // show video codec info
-    g_application.m_pPlayer->GetVideoInfo(strVideo);
-    {
-      CGUIMessage msg(GUI_MSG_LABEL_SET, GetID(), LABEL_ROW2);
-      msg.SetLabel(strVideo);
-      OnMessage(msg);
-    }
+    std::string strGeneral;
     // show general info
     g_application.m_pPlayer->GetGeneralInfo(strGeneral);
     {


### PR DESCRIPTION
fighting spaghetti code
too much dependencies just for displaying redundant info on a debugging screen. all this info is available to the GUI and most of the info is displayed by the OSD anyway.
