### PR TITLE
Replace httpproxy= url protocol option with CProxy class

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -20,6 +20,7 @@
 
 #include "DVDDemuxFFmpeg.h"
 
+#include <sstream>
 #include <utility>
 
 #include "commons/Exception.h"
@@ -638,6 +639,31 @@ AVDictionary *CDVDDemuxFFmpeg::GetFFMpegOptionsFromURL(const CURL &url)
       av_dict_set(&options, "cookies", cookies.c_str(), 0);
 
   }
+
+  const CProxy proxy = url.GetProxy();
+  if (proxy)
+  {
+    if (proxy.GetType() == CProxy::ProxyHttp)
+    {
+      std::ostringstream urlStream;
+
+      urlStream << "http://";
+
+      if (!proxy.GetUser().empty()) {
+        urlStream << proxy.GetUser();
+	if (!proxy.GetPassword().empty())
+          urlStream << ":" << proxy.GetPassword();
+        urlStream << "@";
+      }
+
+      urlStream << proxy.GetHost();
+      if (proxy.GetPort())
+        urlStream << ':' << proxy.GetPort();
+
+      av_dict_set(&options, "http_proxy", urlStream.str().c_str(), 0);
+    }
+  }
+
   return options;
 }
 

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFFmpeg.cpp
@@ -50,18 +50,18 @@ bool CDVDInputStreamFFmpeg::IsEOF()
 
 bool CDVDInputStreamFFmpeg::Open()
 {
-  std::string selected;
   if (m_item.IsInternetStream() && (m_item.IsType(".m3u8") || m_item.GetMimeType() == "application/vnd.apple.mpegurl"))
   {
     // get the available bandwidth and  determine the most appropriate stream
     int bandwidth = CSettings::GetInstance().GetInt(CSettings::SETTING_NETWORK_BANDWIDTH);
     if(bandwidth <= 0)
       bandwidth = INT_MAX;
-    selected = PLAYLIST::CPlayListM3U::GetBestBandwidthStream(m_item.GetPath(), bandwidth);
-    if (selected.compare(m_item.GetPath()) != 0)
+    const CURL playlist_url = m_item.GetURL();
+    const CURL selected = PLAYLIST::CPlayListM3U::GetBestBandwidthStream(playlist_url, bandwidth);
+    if (selected.Get().compare(playlist_url.Get()) != 0)
     {
-      CLog::Log(LOGINFO, "CDVDInputStreamFFmpeg: Auto-selecting %s based on configured bandwidth.", selected.c_str());
-      m_item.SetPath(selected.c_str());
+      CLog::Log(LOGINFO, "CDVDInputStreamFFmpeg: Auto-selecting %s based on configured bandwidth.", selected.Get().c_str());
+      m_item.SetURL(selected);
     }
   }
 

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -428,7 +428,7 @@ CCurlFile::CCurlFile()
   m_password = "";
   m_httpauth = "";
   m_cipherlist = "";
-  m_proxytype = PROXY_HTTP;
+  m_proxytype = CProxy::ProxyHttp;
   m_state = new CReadState();
   m_oldState = NULL;
   m_skipshout = false;
@@ -766,7 +766,7 @@ void CCurlFile::ParseAndCorrectUrl(CURL &url2)
         m_proxyuserpass = CSettings::GetInstance().GetString(CSettings::SETTING_NETWORK_HTTPPROXYUSERNAME);
         m_proxyuserpass += ":" + CSettings::GetInstance().GetString(CSettings::SETTING_NETWORK_HTTPPROXYPASSWORD);
       }
-      m_proxytype = (ProxyType)CSettings::GetInstance().GetInt(CSettings::SETTING_NETWORK_HTTPPROXYTYPE);
+      m_proxytype = (CProxy::Type)CSettings::GetInstance().GetInt(CSettings::SETTING_NETWORK_HTTPPROXYTYPE);
       CLog::Log(LOGDEBUG, "Using proxy %s, type %d", m_proxy.c_str(), proxyType2CUrlProxyType[m_proxytype]);
     }
 

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -406,6 +406,8 @@ CCurlFile::~CCurlFile()
 
 CCurlFile::CCurlFile()
  : m_writeOffset(0)
+ , m_proxytype(CProxy::ProxyHttp)
+ , m_proxyport(3128)
  , m_overflowBuffer(NULL)
  , m_overflowSize(0)
 {
@@ -428,7 +430,6 @@ CCurlFile::CCurlFile()
   m_password = "";
   m_httpauth = "";
   m_cipherlist = "";
-  m_proxytype = CProxy::ProxyHttp;
   m_state = new CReadState();
   m_oldState = NULL;
   m_skipshout = false;
@@ -607,13 +608,16 @@ void CCurlFile::SetCommonOptions(CReadState* state)
   if (g_advancedSettings.m_curlDisableIPV6)
     g_curlInterface.easy_setopt(h, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
 
-  if (m_proxy.length() > 0)
+  if (!m_proxyhost.empty())
   {
-    g_curlInterface.easy_setopt(h, CURLOPT_PROXY, m_proxy.c_str());
+    const std::string hostport = m_proxyhost +
+      StringUtils::Format(":%d", m_proxyport);
+    g_curlInterface.easy_setopt(h, CURLOPT_PROXY, hostport.c_str());
     g_curlInterface.easy_setopt(h, CURLOPT_PROXYTYPE, proxyType2CUrlProxyType[m_proxytype]);
-    if (m_proxyuserpass.length() > 0)
-      g_curlInterface.easy_setopt(h, CURLOPT_PROXYUSERPWD, m_proxyuserpass.c_str());
-
+    const std::string userpass =
+      m_proxyuser + std::string(":") + m_proxypassword;
+    if (!userpass.empty())
+      g_curlInterface.easy_setopt(h, CURLOPT_PROXYUSERPWD, userpass.c_str());
   }
   if (m_customrequest.length() > 0)
     g_curlInterface.easy_setopt(h, CURLOPT_CUSTOMREQUEST, m_customrequest.c_str());
@@ -754,20 +758,19 @@ void CCurlFile::ParseAndCorrectUrl(CURL &url2)
   else if( url2.IsProtocol("http")
        ||  url2.IsProtocol("https"))
   {
-    if (CSettings::GetInstance().GetBool(CSettings::SETTING_NETWORK_USEHTTPPROXY)
-        && !CSettings::GetInstance().GetString(CSettings::SETTING_NETWORK_HTTPPROXYSERVER).empty()
-        && CSettings::GetInstance().GetInt(CSettings::SETTING_NETWORK_HTTPPROXYPORT) > 0
-        && m_proxy.empty())
+    const CSettings &s = CSettings::GetInstance();
+    if (m_proxyhost.empty()
+        && s.GetBool(CSettings::SETTING_NETWORK_USEHTTPPROXY)
+        && !s.GetString(CSettings::SETTING_NETWORK_HTTPPROXYSERVER).empty()
+        && s.GetInt(CSettings::SETTING_NETWORK_HTTPPROXYPORT) > 0)
     {
-      m_proxy = CSettings::GetInstance().GetString(CSettings::SETTING_NETWORK_HTTPPROXYSERVER);
-      m_proxy += StringUtils::Format(":%d", CSettings::GetInstance().GetInt(CSettings::SETTING_NETWORK_HTTPPROXYPORT));
-      if (CSettings::GetInstance().GetString(CSettings::SETTING_NETWORK_HTTPPROXYUSERNAME).length() > 0 && m_proxyuserpass.empty())
-      {
-        m_proxyuserpass = CSettings::GetInstance().GetString(CSettings::SETTING_NETWORK_HTTPPROXYUSERNAME);
-        m_proxyuserpass += ":" + CSettings::GetInstance().GetString(CSettings::SETTING_NETWORK_HTTPPROXYPASSWORD);
-      }
-      m_proxytype = (CProxy::Type)CSettings::GetInstance().GetInt(CSettings::SETTING_NETWORK_HTTPPROXYTYPE);
-      CLog::Log(LOGDEBUG, "Using proxy %s, type %d", m_proxy.c_str(), proxyType2CUrlProxyType[m_proxytype]);
+      m_proxytype = (CProxy::Type)s.GetInt(CSettings::SETTING_NETWORK_HTTPPROXYTYPE);
+      m_proxyhost = s.GetString(CSettings::SETTING_NETWORK_HTTPPROXYSERVER);
+      m_proxyport = s.GetInt(CSettings::SETTING_NETWORK_HTTPPROXYPORT);
+      m_proxyuser = s.GetString(CSettings::SETTING_NETWORK_HTTPPROXYUSERNAME);
+      m_proxypassword = s.GetString(CSettings::SETTING_NETWORK_HTTPPROXYPASSWORD);
+      CLog::Log(LOGDEBUG, "Using proxy %s, type %d", m_proxyhost.c_str(),
+                proxyType2CUrlProxyType[m_proxytype]);
     }
 
     // get username and password
@@ -923,6 +926,16 @@ void CCurlFile::Cancel()
 void CCurlFile::Reset()
 {
   m_state->m_cancelled = false;
+}
+
+void CCurlFile::SetProxy(CProxy::Type type, const std::string &host,
+  uint16_t port, const std::string &user, const std::string &password)
+{
+  m_proxytype = type;
+  m_proxyhost = host;
+  m_proxyport = port;
+  m_proxyuser = user;
+  m_proxypassword = password;
 }
 
 bool CCurlFile::Open(const CURL& url)

--- a/xbmc/filesystem/CurlFile.h
+++ b/xbmc/filesystem/CurlFile.h
@@ -24,6 +24,7 @@
 #include <map>
 #include <string>
 #include "utils/HttpHeader.h"
+#include "utils/Proxy.h"
 
 namespace XCURL
 {
@@ -37,15 +38,6 @@ namespace XFILE
   class CCurlFile : public IFile
   {
     public:
-      typedef enum
-      {
-        PROXY_HTTP = 0,
-        PROXY_SOCKS4,
-        PROXY_SOCKS4A,
-        PROXY_SOCKS5,
-        PROXY_SOCKS5_REMOTE,
-      } ProxyType;
-    
       CCurlFile();
       virtual ~CCurlFile();
       virtual bool Open(const CURL& url);
@@ -75,7 +67,7 @@ namespace XFILE
       void SetUserAgent(const std::string& sUserAgent)           { m_userAgent = sUserAgent; }
       void SetProxy(const std::string &proxy)                    { m_proxy = proxy; }
       void SetProxyUserPass(const std::string &proxyuserpass)    { m_proxyuserpass = proxyuserpass; }
-      void SetProxyType(ProxyType proxytype)                     { m_proxytype = proxytype; }
+      void SetProxyType(CProxy::Type proxytype)                  { m_proxytype = proxytype; }
       void SetCustomRequest(const std::string &request)          { m_customrequest = request; }
       void UseOldHttpVersion(bool bUse)                          { m_useOldHttpVersion = bUse; }
       void SetAcceptEncoding(const std::string& encoding)        { m_acceptencoding = encoding; }
@@ -166,7 +158,7 @@ namespace XFILE
       std::string     m_userAgent;
       std::string     m_proxy;
       std::string     m_proxyuserpass;
-      ProxyType       m_proxytype;
+      CProxy::Type    m_proxytype;
       std::string     m_customrequest;
       std::string     m_acceptencoding;
       std::string     m_acceptCharset;

--- a/xbmc/filesystem/CurlFile.h
+++ b/xbmc/filesystem/CurlFile.h
@@ -65,9 +65,8 @@ namespace XFILE
       void Cancel();
       void Reset();
       void SetUserAgent(const std::string& sUserAgent)           { m_userAgent = sUserAgent; }
-      void SetProxy(const std::string &proxy)                    { m_proxy = proxy; }
-      void SetProxyUserPass(const std::string &proxyuserpass)    { m_proxyuserpass = proxyuserpass; }
-      void SetProxyType(CProxy::Type proxytype)                  { m_proxytype = proxytype; }
+      void SetProxy(CProxy::Type type, const std::string &host, uint16_t port,
+                    const std::string &user, const std::string &password);
       void SetCustomRequest(const std::string &request)          { m_customrequest = request; }
       void UseOldHttpVersion(bool bUse)                          { m_useOldHttpVersion = bUse; }
       void SetAcceptEncoding(const std::string& encoding)        { m_acceptencoding = encoding; }
@@ -156,9 +155,11 @@ namespace XFILE
 
       std::string     m_url;
       std::string     m_userAgent;
-      std::string     m_proxy;
-      std::string     m_proxyuserpass;
       CProxy::Type    m_proxytype;
+      std::string     m_proxyhost;
+      uint16_t        m_proxyport;
+      std::string     m_proxyuser;
+      std::string     m_proxypassword;
       std::string     m_customrequest;
       std::string     m_acceptencoding;
       std::string     m_acceptCharset;

--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -263,6 +263,7 @@ bool CFile::Open(const CURL& file, const unsigned int flags)
     bool bPathInCache;
 
     CURL url(URIUtils::SubstitutePath(file)), url2(url);
+    url.SetProxy(file.GetProxy());
 
     if (url2.IsProtocol("apk") || url2.IsProtocol("zip") )
       url2.SetOptions("");

--- a/xbmc/filesystem/FileCache.cpp
+++ b/xbmc/filesystem/FileCache.cpp
@@ -166,10 +166,8 @@ bool CFileCache::Open(const CURL& url)
 
   CLog::Log(LOGDEBUG,"CFileCache::Open - opening <%s> using cache", url.GetFileName().c_str());
 
-  m_sourcePath = url.Get();
-
   // opening the source file.
-  if (!m_source.Open(m_sourcePath, READ_NO_CACHE | READ_TRUNCATED | READ_CHUNKED))
+  if (!m_source.Open(url, READ_NO_CACHE | READ_TRUNCATED | READ_CHUNKED))
   {
     CLog::Log(LOGERROR,"%s - failed to open source <%s>", __FUNCTION__, url.GetRedacted().c_str());
     Close();

--- a/xbmc/filesystem/FileCache.h
+++ b/xbmc/filesystem/FileCache.h
@@ -67,7 +67,6 @@ namespace XFILE
     bool      m_bDeleteCache;
     int        m_seekPossible;
     CFile      m_source;
-    std::string    m_sourcePath;
     CEvent      m_seekEvent;
     CEvent      m_seekEnded;
     int64_t      m_nSeekResult;

--- a/xbmc/playlists/PlayListM3U.cpp
+++ b/xbmc/playlists/PlayListM3U.cpp
@@ -226,7 +226,7 @@ void CPlayListM3U::Save(const std::string& strFileName) const
   file.Close();
 }
 
-std::string CPlayListM3U::GetBestBandwidthStream(const std::string &strFileName, size_t bandwidth)
+CURL CPlayListM3U::GetBestBandwidthStream(const CURL &url, size_t bandwidth)
 {
   // we may be passed a playlist that does not contain playlists of different
   // bitrates (eg: this playlist is really the HLS video). So, default the
@@ -237,20 +237,17 @@ std::string CPlayListM3U::GetBestBandwidthStream(const std::string &strFileName,
 
   // open the file, and if it fails, return
   CFile file;
-  if (!file.Open(strFileName) )
+  if (!file.Open(url))
   {
     file.Close();
-    return strFileName;
+    return url;
   }
 
-  // get protocol options if they were set, so we can restore them again at the end
-  CURL playlistUrl(strFileName);
-  
   // and set the fallback value
-  CURL subStreamUrl = CURL(strFileName);
+  CURL subStreamUrl(url);
   
   // determine the base
-  CURL basePlaylistUrl(URIUtils::GetParentPath(strFileName));
+  CURL basePlaylistUrl(URIUtils::GetParentPath(url.Get()));
   basePlaylistUrl.SetOptions("");
   basePlaylistUrl.SetProtocolOptions("");
   std::string basePart = basePlaylistUrl.Get();
@@ -303,8 +300,8 @@ std::string CPlayListM3U::GetBestBandwidthStream(const std::string &strFileName,
   }
 
   // if any protocol options were set, restore them
-  subStreamUrl.SetProtocolOptions(playlistUrl.GetProtocolOptions());
-  return subStreamUrl.Get();
+  subStreamUrl.SetProtocolOptions(url.GetProtocolOptions());
+  return subStreamUrl;
 }
 
 std::map< std::string, std::string > CPlayListM3U::ParseStreamLine(const std::string &streamLine)

--- a/xbmc/playlists/PlayListM3U.h
+++ b/xbmc/playlists/PlayListM3U.h
@@ -18,6 +18,7 @@
  *  <http://www.gnu.org/licenses/>.
  *
  */
+#include "URL.h"
 #include "PlayList.h"
 
 namespace PLAYLIST
@@ -31,7 +32,7 @@ public:
   virtual bool Load(const std::string& strFileName);
   virtual void Save(const std::string& strFileName) const;
 
-  static std::string GetBestBandwidthStream(const std::string &strFileName, size_t bandwidth);
+  static CURL GetBestBandwidthStream(const CURL &url, size_t bandwidth);
 
 protected:
 

--- a/xbmc/utils/CMakeLists.txt
+++ b/xbmc/utils/CMakeLists.txt
@@ -40,6 +40,7 @@ set(SOURCES ActorProtocol.cpp
             PerformanceSample.cpp
             PerformanceStats.cpp
             POUtils.cpp
+            Proxy.cpp
             RecentlyAddedJob.cpp
             RegExp.cpp
             rfft.cpp

--- a/xbmc/utils/Proxy.h
+++ b/xbmc/utils/Proxy.h
@@ -1,0 +1,33 @@
+#pragma once
+/*
+ *      Copyright (C) 2016 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+class CProxy
+{
+public:
+  typedef enum
+  {
+    ProxyHttp = 0,
+    ProxySocks4,
+    ProxySocks4A,
+    ProxySocks5,
+    ProxySocks5Remote,
+  } Type;
+};


### PR DESCRIPTION
This pull request supercedes an earlier attempt (#8680) to fix issues with per-stream proxy servers when used with HLS streams.

Previous discussion (#8434) revealed that the `httpproxy` url parameter is a potential security hazard. If an attacker can insert a malicious URL into Kodi, for example via a malicious playlist served over the internet, the attacker can command the application to make a connection to a malicious proxy, potentially leaking sensitive information.

Therefore, this patch set removes the `httpproxy` url option altogether, replaces it with a new out-of-band method of handling proxy servers: the `CProxy` class.

The `CProxy` class handles parsing, formatting and storing proxy server descriptions, and supports the `IArchivable` and `ISerializable` interfaces.

Storing the server description in a single object reduces boiler-plate, as seen in `CCurlFile`, which has the `m_proxy`, `m_proxyuserpass` and `m_proxytype` member variables and accessor methods. These are replaced by a single member variable, and a single set of accessor methods.

A `CProxy` member variable has been added to `CURL`, because now that the proxy server description is carried outside the url, if `CProxy` were not added to `CURL`, the two objects would typically be handled as a pair throughout the code-base in method arguments and member variables.

Support for HTTP proxies has been added to `CDVDDemuxFFmpeg` via the `http_proxy` option which has been available since v3.0.

Finally, a new `proxy` property has been added to `XBMCAddon::CListItem`, so that add-ons may set the proxy through the Python `getProxy`/`setProxy` interface.

In future, this work can be extended by adding per-stream proxy support to more of the DVDDemuxers, and by extending support for the SOCKS protocols.
