### PR TITLE
Fix some logic flaws in NetworkServices settings change

### DIFF
--- a/xbmc/network/NetworkServices.cpp
+++ b/xbmc/network/NetworkServices.cpp
@@ -398,6 +398,9 @@ bool CNetworkServices::OnSettingChanging(const CSetting *setting)
 #ifdef HAS_JSONRPC
     if (CSettings::GetInstance().GetBool(CSettings::SETTING_SERVICES_ESENABLED))
     {
+      if (!StopJSONRPCServer(true))
+        return false;
+
       if (!StartJSONRPCServer())
       {
         CGUIDialogOK::ShowAndGetInput(CVariant{33103}, CVariant{33100});

--- a/xbmc/network/NetworkServices.cpp
+++ b/xbmc/network/NetworkServices.cpp
@@ -328,31 +328,37 @@ bool CNetworkServices::OnSettingChanging(const CSetting *setting)
 
   if (settingId == CSettings::SETTING_SERVICES_ESENABLED)
   {
-#ifdef HAS_EVENT_SERVER
     if (((CSettingBool*)setting)->GetValue())
     {
+      bool result = true;
+#ifdef HAS_EVENT_SERVER
       if (!StartEventServer())
       {
         CGUIDialogOK::ShowAndGetInput(CVariant{33102}, CVariant{33100});
-        return false;
+        result = false;
       }
-    }
-    else
-      return StopEventServer(true, true);
 #endif // HAS_EVENT_SERVER
 
 #ifdef HAS_JSONRPC
-    if (CSettings::GetInstance().GetBool(CSettings::SETTING_SERVICES_ESENABLED))
-    {
       if (!StartJSONRPCServer())
       {
         CGUIDialogOK::ShowAndGetInput(CVariant{33103}, CVariant{33100});
-        return false;
+        result = false;
       }
+#endif // HAS_JSONRPC
+      return result;
     }
     else
-      return StopJSONRPCServer(false);
+    {
+      bool result = true;
+#ifdef HAS_EVENT_SERVER
+      result = StopEventServer(true, true);
+#endif // HAS_EVENT_SERVER
+#ifdef HAS_JSONRPC
+      result &= StopJSONRPCServer(false);
 #endif // HAS_JSONRPC
+      return result;
+    }
   }
   else if (settingId == CSettings::SETTING_SERVICES_ESPORT)
   {


### PR DESCRIPTION
- When changing the SETTING_SERVICES_ESALLINTERFACES, JSONRPCServer needs to be restarted to apply the change, just a start is not enough since it first check if it's running.
- When toggling SETTING_SERVICES_ESENABLED, JSONRPCServer was never stopped since the there's a return after EventServer and before reaching this part of the code.

cc @Montellese 

Edit : And with a question also for @Montellese Is there a way in OnSettingChanging to detect if the change is from the GUI or from JSON ?

Because right now the EventServer restart code shows a dialog even when changed from JSON and this sounds problematic no ? (Same for Webserver start error for example and surely other cases)
