### PR TITLE
Fix stuttering on Android

### DIFF
--- a/xbmc/filesystem/FileDirectoryFactory.cpp
+++ b/xbmc/filesystem/FileDirectoryFactory.cpp
@@ -64,20 +64,22 @@ IFileDirectory* CFileDirectoryFactory::Create(const CURL& url, CFileItem* pItem,
 
   std::string strExtension=URIUtils::GetExtension(url);
   StringUtils::ToLower(strExtension);
-  VECADDONS codecs;
-  CAddonMgr::GetInstance().GetAddons(codecs, ADDON_AUDIODECODER);
-  for (size_t i=0;i<codecs.size();++i)
+  if (!strExtension.empty())
   {
-    std::shared_ptr<CAudioDecoder> dec(std::static_pointer_cast<CAudioDecoder>(codecs[i]));
-    if (!strExtension.empty() && dec->HasTracks() &&
-        dec->GetExtensions().find(strExtension) != std::string::npos)
+    VECADDONS codecs;
+    CAddonMgr::GetInstance().GetAddons(codecs, ADDON_AUDIODECODER);
+    for (size_t i=0;i<codecs.size();++i)
     {
-      CAudioDecoder* result = new CAudioDecoder(*dec);
-      static_cast<AudioDecoderDll&>(*result).Create();
-      if (result->ContainsFiles(url))
-        return result;
-      delete result;
-      return NULL;
+      std::shared_ptr<CAudioDecoder> dec(std::static_pointer_cast<CAudioDecoder>(codecs[i]));
+      if (dec->HasTracks() && dec->GetExtensions().find(strExtension) != std::string::npos)
+      {
+        CAudioDecoder* result = new CAudioDecoder(*dec);
+        static_cast<AudioDecoderDll&>(*result).Create();
+        if (result->ContainsFiles(url))
+          return result;
+        delete result;
+        return NULL;
+      }
     }
   }
 

--- a/xbmc/storage/android/AndroidStorageProvider.cpp
+++ b/xbmc/storage/android/AndroidStorageProvider.cpp
@@ -56,7 +56,6 @@ static const char * deviceWL[] = {
 
 CAndroidStorageProvider::CAndroidStorageProvider()
 {
-  m_removableLength = 0;
   PumpDriveChangeEvents(NULL);
 }
 
@@ -118,8 +117,10 @@ void CAndroidStorageProvider::GetLocalDrives(VECSOURCES &localDrives)
   localDrives.push_back(share);
 }
 
-void CAndroidStorageProvider::GetRemovableDrives(VECSOURCES &removableDrives)
+std::set<std::string> CAndroidStorageProvider::GetRemovableDrives()
 {
+  std::set<std::string> result;
+
   // mounted usb disks
   char*                               buf     = NULL;
   FILE*                               pipe;
@@ -211,21 +212,30 @@ void CAndroidStorageProvider::GetRemovableDrives(VECSOURCES &removableDrives)
 
           if(devok && (fsok || mountok))
           {
-            // Reject unreadable
-            if (XFILE::CDirectory::Exists(mountStr))
-            {
-              CMediaSource share;
-              share.strPath = unescape(mountStr);
-              share.strName = URIUtils::GetFileName(mountStr);
-              share.m_ignore = true;
-              removableDrives.push_back(share);
-            }
+            result.insert(mountStr);
           }
         }
       }
       line = strtok_r(NULL, "\n", &saveptr);
     }
     free(buf);
+  }
+  return result;
+}
+
+void CAndroidStorageProvider::GetRemovableDrives(VECSOURCES &removableDrives)
+{
+  for (const auto& mountStr : GetRemovableDrives())
+  {
+    // Reject unreadable
+    if (XFILE::CDirectory::Exists(mountStr))
+    {
+      CMediaSource share;
+      share.strPath = unescape(mountStr);
+      share.strName = URIUtils::GetFileName(mountStr);
+      share.m_ignore = true;
+      removableDrives.push_back(share);
+    }
   }
 }
 
@@ -270,9 +280,8 @@ bool CAndroidStorageProvider::Eject(const std::string& mountpath)
 
 bool CAndroidStorageProvider::PumpDriveChangeEvents(IStorageEventsCallback *callback)
 {
-  VECSOURCES drives;
-  GetRemovableDrives(drives);
-  bool changed = drives.size() != m_removableLength;
-  m_removableLength = drives.size();
+  auto drives = GetRemovableDrives();
+  bool changed = m_removableDrives != drives;
+  m_removableDrives = std::move(drives);
   return changed;
 }

--- a/xbmc/storage/android/AndroidStorageProvider.cpp
+++ b/xbmc/storage/android/AndroidStorageProvider.cpp
@@ -45,7 +45,8 @@ static const char * mountBL[] = {
   "/mnt/media_rw/extSdCard",
   "/mnt/media_rw/sdcard",
   "/mnt/media_rw/usbdisk",
-  "/storage/emulated"
+  "/storage/emulated",
+  "/mnt/runtime"
 };
 static const char * deviceWL[] = {
   "/dev/block/vold",

--- a/xbmc/storage/android/AndroidStorageProvider.h
+++ b/xbmc/storage/android/AndroidStorageProvider.h
@@ -19,6 +19,7 @@
  *
  */
 
+#include <set>
 #include "storage/IStorageProvider.h"
 
 class CAndroidStorageProvider : public IStorageProvider
@@ -40,6 +41,7 @@ public:
   virtual bool PumpDriveChangeEvents(IStorageEventsCallback *callback);
 
 private:
+  static std::set<std::string> GetRemovableDrives();
   std::string unescape(const std::string& str);
-  unsigned int m_removableLength;
+  std::set<std::string> m_removableDrives;
 };


### PR DESCRIPTION
The  StorageProvider on android works with polling. Every time fstab is parsed, the Exists method is called for every entry. This happens constantly. Exists method calls the factory's create method and directly runs into a GetAddons() call which might need > 20 ms ....

As this constantly happens during videoplayback, video started to stutter.

Thanks to @tamland for the investigation.
