### PR TITLE
Create AppVeyor CI configuration file

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,115 @@
+os: Visual Studio 2013
+
+shallow_clone: true
+
+environment:
+  CONFIG: Release
+  matrix:
+    - BUILD: Kodi
+    - ADDONS: adsp
+    - ADDONS: audiodecoder
+    - ADDONS: audioencoder
+    - ADDONS: pvr
+    - ADDONS: screensaver
+    - ADDONS: visualization
+
+install:
+  - SET PATH=C:\Program Files (x86)\CMake\bin;C:\msys64\bin;C:\msys64\usr\bin;%PATH%
+  - bash -lc "pacman --needed --noconfirm -Sy"
+  - bash -lc "pacman --needed --noconfirm -S curl"
+  - mklink /j %APPVEYOR_BUILD_FOLDER%\project\BuildDependencies\msys64 C:\msys64
+
+build_script:
+  # Setup Visual Studio compiler environment 
+  - ps: $ErrorActionPreference= 'silentlycontinue'
+  
+  # Setup Visual Studio compiler environment 
+  - call "%VS120COMNTOOLS%..\..\VC\bin\vcvars32.bat"
+  
+  #
+  # Build Kodi
+  #
+  - ps: |
+      if ($env:BUILD -eq "Kodi") {
+        # Download dependencies
+        cd $env:APPVEYOR_BUILD_FOLDER\project\BuildDependencies
+        & .\DownloadBuildDeps.bat
+        
+        # We are using AppVeyor's already installed msys64 environment,
+        # no need to install msys/mingw environment.
+        
+        # Download precompiled mingw32 libraries
+        # To run make-mingwlibs.bat on AppVeyor takes too long, 
+        # we must use precompiled libs to speed up build
+        bash -c "curl http://repo.msys2.org/mingw/i686/mingw-w64-i686-ffmpeg-2.8.5-2-any.pkg.tar.xz | tar xJv"
+        bash -c "curl http://repo.msys2.org/mingw/i686/mingw-w64-i686-libdvdcss-1.4.0-1-any.pkg.tar.xz | tar xJv"
+        bash -c "curl http://repo.msys2.org/mingw/i686/mingw-w64-i686-libdvdnav-5.0.3-1-any.pkg.tar.xz | tar xJv"
+        bash -c "curl http://repo.msys2.org/mingw/i686/mingw-w64-i686-libdvdread-5.0.3-1-any.pkg.tar.xz | tar xJv"
+        # Rename all precompiled lib*.dll.a -> *.lib, so MSVC will find them
+        Get-ChildItem mingw32\lib\lib*.dll.a | %{
+          $new_name = $_.Name.SubString(3) -replace ".dll.a", ".lib"
+          $new_fullname = Join-Path $_.DirectoryName $new_name
+          Rename-Item $_.FullName $new_fullname
+        }
+        # Copy all libs and includes under Kodi's dependencies folder
+        xcopy /s /y mingw32\*.* .
+        xcopy /s /y mingw32\bin\*.dll $env:APPVEYOR_BUILD_FOLDER\system\players\VideoPlayer
+        # Build  
+        cd $env:APPVEYOR_BUILD_FOLDER\project\Win32BuildSetup
+        msbuild "$env:APPVEYOR_BUILD_FOLDER\project\VS2010Express\XBMC for Windows.sln" /p:Configuration="$env:CONFIG"
+      }
+  
+  #
+  # Build Addons
+  #
+  - ps: |
+      if ($env:ADDONS.length -ne 0 -and $env:BUILD -ne "Kodi") {
+        # Bootstrap
+        cd $env:APPVEYOR_BUILD_FOLDER\tools\buildsteps\win32
+        & .\bootstrap-addons.bat
+        
+        # Create build folder
+        md -Force $env:APPVEYOR_BUILD_FOLDER\build | out-null
+        cd $env:APPVEYOR_BUILD_FOLDER\build
+        # Configure
+        cmake -DADDONS_TO_BUILD="$env:ADDONS".* `
+              -G "NMake Makefiles" `
+              -DCMAKE_BUILD_TYPE="$env:CONFIG" `
+              -DCMAKE_INSTALL_PREFIX="$env:APPVEYOR_BUILD_FOLDER"\addons `
+              $env:APPVEYOR_BUILD_FOLDER\project\cmake\addons
+        # Build selected addons one by one
+        $addons_success=""
+        $addons_failed=""
+        nmake supported_addons | %{
+          if ($_ -like "ALL_ADDONS_BUILDING: *") {
+            $_.SubString(21).Split(" ") | %{
+              Write-Host "Building " $_
+              nmake $_
+              if ($LASTEXITCODE -eq 0) {
+                $addons_success += $_ + " "
+              } else {
+                $addons_failed += $_  + " "
+              }
+            }
+          }
+        }
+        # Print succesful and failed addons
+        Write-Host "--------------------------------------------------"
+        if ($addons_success -ne "") {
+          $addons_success.Split(" ") | %{
+            if ($_ -ne "") { 
+              Write-Host [SUCCESS] $_ -ForegroundColor Green 
+            }
+          }
+        }
+        if ($addons_failed -ne "") {
+          $addons_failed.Split(" ") | %{
+            if ($_ -ne "") { 
+              Write-Host [ ERROR ] $_ -ForegroundColor Red
+            }
+          } 
+          exit 1
+        }
+      }
+
+test: off


### PR DESCRIPTION
Adds to support AppVeyor CI (CI for Windows). It uses the same build matrix as Travis CI, like build Kodi and all the addons.

Check out the build status @ https://ci.appveyor.com/project/zcsizmadia/xbmc. Everything builds, except pvr.dvblink and pvr.dvbviewer.
