### PR TITLE
[addons] disallow uninstalling / disabling of system addons

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -13869,7 +13869,10 @@ msgctxt "#24083"
 msgid "Information libraries"
 msgstr ""
 
-#empty string with id 24084
+#: xbmc/addons/GUIDialogAddonInfo.cpp
+msgctxt "#24084"
+msgid "%s is a system add-on"
+msgstr ""
 
 #. Used as a text in the progress dialog when installing an add-on
 #: xbmc/addons/AddonInstaller.cpp

--- a/xbmc/addons/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/GUIDialogAddonInfo.cpp
@@ -365,6 +365,21 @@ bool CGUIDialogAddonInfo::CanUse() const
     m_localAddon->Type() == ADDON_RESOURCE_UISOUNDS);
 }
 
+bool CGUIDialogAddonInfo::PromptIfSystem(int heading, int line2)
+{
+  if (!m_localAddon)
+    return false;
+
+  if (CAddonMgr::GetInstance().IsSystemAddon(m_localAddon->ID()))
+  {
+    std::string line0 = StringUtils::Format(g_localizeStrings.Get(24084).c_str(), m_localAddon->Name().c_str());
+    std::string line1 = "";
+    CGUIDialogOK::ShowAndGetInput(CVariant{heading}, CVariant{std::move(line0)}, CVariant{std::move(line1)}, CVariant{line2});
+    return true;
+  }
+  return false;
+}
+
 bool CGUIDialogAddonInfo::PromptIfDependency(int heading, int line2)
 {
   if (!m_localAddon)
@@ -399,6 +414,10 @@ void CGUIDialogAddonInfo::OnUninstall()
   if (!g_passwordManager.CheckMenuLock(WINDOW_ADDON_BROWSER))
     return;
 
+  // ensure the addon is not a system addon
+  if (PromptIfSystem(24037, 24047))
+    return;
+
   // ensure the addon is not a dependency of other installed addons
   if (PromptIfDependency(24037, 24047))
     return;
@@ -422,6 +441,9 @@ void CGUIDialogAddonInfo::OnEnableDisable()
 
   if (m_addonEnabled)
   {
+    if (PromptIfSystem(24075, 24091))
+      return; //system. can't disable
+
     if (PromptIfDependency(24075, 24091))
       return; //required. can't disable
 

--- a/xbmc/addons/GUIDialogAddonInfo.h
+++ b/xbmc/addons/GUIDialogAddonInfo.h
@@ -79,6 +79,13 @@ private:
    */
   bool PromptIfDependency(int heading, int line2);
 
+  /*! \brief check if the add-on is a system addon, and if so prompt the user
+   \param heading the label for the heading of the prompt dialog
+   \param line2 the action that could not be completed.
+   \return true if prompted, false otherwise.
+   */
+  bool PromptIfSystem(int heading, int line2);
+
   CFileItemPtr m_item;
   ADDON::AddonPtr m_localAddon;
   bool m_addonEnabled;


### PR DESCRIPTION
skins can set &lt;enabled&gt; on a control, so uninstall / disable buttons may be
(always) enabled. show a warning if user tries to uninstall or disable a system addon

@tamland 
