### PR TITLE
FIX: [longpress] do not eat keypress after a longpress

### DIFF
--- a/xbmc/input/InputManager.cpp
+++ b/xbmc/input/InputManager.cpp
@@ -459,13 +459,13 @@ bool CInputManager::OnEvent(XBMC_Event& newEvent)
   {
   case XBMC_KEYDOWN:
   {
-    if (m_LastKey.GetButtonCode() & CKey::MODIFIER_LONG)
+    m_Keyboard.ProcessKeyDown(newEvent.key.keysym);
+    CKey key = m_Keyboard.TranslateKey(newEvent.key.keysym);
+    if (key.GetButtonCode() == m_LastKey.GetButtonCode() && m_LastKey.GetButtonCode() & CKey::MODIFIER_LONG)
     {
       // Do not repeat long presses
       break;
     }
-    m_Keyboard.ProcessKeyDown(newEvent.key.keysym);
-    CKey key = m_Keyboard.TranslateKey(newEvent.key.keysym);
     if (!CButtonTranslator::GetInstance().HasLonpressMapping(g_windowManager.GetActiveWindowID(), key))
     {
       m_LastKey.Reset();


### PR DESCRIPTION
A longpress triggers the action before the keyup, which is not called at all if a window/dialog is popped up.
Result is m_Lastkey not being reset, and whatever keypress after returning to the original window being ignored.
