### PR TITLE
bootstrap.mk pointing to lib/libdvd/libdvdread

### DIFF
--- a/bootstrap.mk
+++ b/bootstrap.mk
@@ -2,23 +2,8 @@ BOOTSTRAP_SUBDIRS += configure.ac
 BOOTSTRAP_SUBDIRS += lib/cpluff/configure.ac
 BOOTSTRAP_SUBDIRS += lib/gtest/configure.ac
 
-ifneq ($(wildcard lib/libdvd/libdvdcss/configure.ac),)
-BOOTSTRAP_SUBDIRS += lib/libdvd/libdvdcss/configure.ac
-DVD_CSS=lib/libdvd/libdvdcss/configure
-endif
-BOOTSTRAP_SUBDIRS += lib/libdvd/libdvdread/configure.ac
-BOOTSTRAP_SUBDIRS += lib/libdvd/libdvdnav/configure.ac
-
-ifneq ($(wildcard pvr-addons/Makefile.am),)
-BOOTSTRAP_SUBDIRS += pvr-addons/configure.ac
-endif
-
 BOOTSTRAP_TARGETS=$(basename $(BOOTSTRAP_SUBDIRS))
 all: $(BOOTSTRAP_TARGETS)
-
-#preserve order for libdvd. dvdcss (if present) -> dvdread -> dvdnav.
-lib/libdvd/libdvdread/configure: $(DVD_CSS)
-lib/libdvd/libdvdnav/configure: lib/libdvd/libdvdread/configure
 
 %: %.ac
 	autoreconf -vif $(@D)


### PR DESCRIPTION
Current git master fails to build due to bootstrap.mk still pointing to lib/libdvd/libdvdread.

Related:
- http://trac.kodi.tv/ticket/16616#no2
- https://bugs.gentoo.org/show_bug.cgi?id=576252
