### PR TITLE
[EPG] Fix lockup when entering epg grid (endless loop)

### DIFF
--- a/xbmc/epg/GUIEPGGridContainer.cpp
+++ b/xbmc/epg/GUIEPGGridContainer.cpp
@@ -199,7 +199,7 @@ void CGUIEPGGridContainer::ProcessChannels(unsigned int currentTime, CDirtyRegio
   if (!m_focusedChannelLayout || !m_channelLayout)
     return;
 
-  int chanOffset  = (int)floorf(m_channelScrollOffset / m_programmeLayout->Size(VERTICAL));
+  int chanOffset = MathUtils::round_int(m_channelScrollOffset / m_programmeLayout->Size(VERTICAL));
 
   int cacheBeforeChannel, cacheAfterChannel;
   GetChannelCacheOffsets(cacheBeforeChannel, cacheAfterChannel);
@@ -244,7 +244,7 @@ void CGUIEPGGridContainer::RenderChannels()
   if (!m_focusedChannelLayout || !m_channelLayout)
     return;
 
-  int chanOffset  = (int)floorf(m_channelScrollOffset / m_programmeLayout->Size(VERTICAL));
+  int chanOffset = MathUtils::round_int(m_channelScrollOffset / m_programmeLayout->Size(VERTICAL));
 
   /// Render channel names
   int cacheBeforeChannel, cacheAfterChannel;
@@ -304,7 +304,7 @@ void CGUIEPGGridContainer::ProcessRuler(unsigned int currentTime, CDirtyRegionLi
   if (!m_rulerLayout || m_rulerItems.size()<=1 || (m_gridEnd - m_gridStart) == CDateTimeSpan(0, 0, 0, 0))
     return;
 
-  int rulerOffset = (int)floorf(m_programmeScrollOffset / m_blockSize);
+  int rulerOffset = MathUtils::round_int(m_programmeScrollOffset / m_blockSize);
   CGUIListItemPtr item = m_rulerItems[0];
   item->SetLabel(m_rulerItems[rulerOffset/m_rulerUnit+1]->GetLabel2());
   CGUIListItem* lastitem = NULL; // dummy pointer needed to be passed as reference to ProcessItem() method
@@ -351,7 +351,7 @@ void CGUIEPGGridContainer::RenderRuler()
   if (!m_rulerLayout || m_rulerItems.size()<=1 || (m_gridEnd - m_gridStart) == CDateTimeSpan(0, 0, 0, 0))
     return;
 
-  int rulerOffset = (int)floorf(m_programmeScrollOffset / m_blockSize);
+  int rulerOffset = MathUtils::round_int(m_programmeScrollOffset / m_blockSize);
 
   /// Render single ruler item with date of selected programme
   g_graphicsContext.SetClipRegion(m_posX, m_posY, m_width, m_height);
@@ -399,8 +399,8 @@ void CGUIEPGGridContainer::ProcessProgrammeGrid(unsigned int currentTime, CDirty
   if (!m_focusedProgrammeLayout || !m_programmeLayout || m_rulerItems.size()<=1 || (m_gridEnd - m_gridStart) == CDateTimeSpan(0, 0, 0, 0))
     return;
 
-  int blockOffset = (int)floorf(m_programmeScrollOffset / m_blockSize);
-  int chanOffset  = (int)floorf(m_channelScrollOffset / m_programmeLayout->Size(VERTICAL));
+  int blockOffset = MathUtils::round_int(m_programmeScrollOffset / m_blockSize);
+  int chanOffset  = MathUtils::round_int(m_channelScrollOffset / m_programmeLayout->Size(VERTICAL));
 
   int cacheBeforeProgramme, cacheAfterProgramme;
   GetProgrammeCacheOffsets(cacheBeforeProgramme, cacheAfterProgramme);
@@ -469,7 +469,7 @@ void CGUIEPGGridContainer::ProcessProgrammeGrid(unsigned int currentTime, CDirty
 
       // increment our X position
       posA2 += m_gridIndex[channel][block].width; // assumes focused & unfocused layouts have equal length
-      block += (int)(m_gridIndex[channel][block].originWidth / m_blockSize);
+      block += MathUtils::round_int(m_gridIndex[channel][block].originWidth / m_blockSize);
     }
 
     // increment our Y position
@@ -483,8 +483,8 @@ void CGUIEPGGridContainer::RenderProgrammeGrid()
   if (!m_focusedProgrammeLayout || !m_programmeLayout || m_rulerItems.size()<=1 || (m_gridEnd - m_gridStart) == CDateTimeSpan(0, 0, 0, 0))
     return;
 
-  int blockOffset = (int)floorf(m_programmeScrollOffset / m_blockSize);
-  int chanOffset  = (int)floorf(m_channelScrollOffset / m_programmeLayout->Size(VERTICAL));
+  int blockOffset = MathUtils::round_int(m_programmeScrollOffset / m_blockSize);
+  int chanOffset  = MathUtils::round_int(m_channelScrollOffset / m_programmeLayout->Size(VERTICAL));
 
   /// Render programmes
   int cacheBeforeProgramme, cacheAfterProgramme;
@@ -555,7 +555,7 @@ void CGUIEPGGridContainer::RenderProgrammeGrid()
 
       // increment our X position
       posA2 += m_gridIndex[channel][block].width; // assumes focused & unfocused layouts have equal length
-      block += (int)(m_gridIndex[channel][block].originWidth / m_blockSize);
+      block += MathUtils::round_int(m_gridIndex[channel][block].originWidth / m_blockSize);
     }
 
     // increment our Y position
@@ -1310,8 +1310,8 @@ bool CGUIEPGGridContainer::SelectItemFromPoint(const CPoint &point, bool justGri
   if (!m_focusedProgrammeLayout || !m_programmeLayout || (justGrid && point.x < 0))
     return false;
 
-  int channel = (int)(point.y / m_channelHeight);
-  int block   = (int)(point.x / m_blockSize);
+  int channel = MathUtils::round_int(point.y / m_channelHeight);
+  int block   = MathUtils::round_int(point.x / m_blockSize);
 
   if (channel > m_channelsPerPage) channel = m_channelsPerPage - 1;
   if (channel >= m_channels) channel = m_channels - 1;
@@ -1516,7 +1516,7 @@ CGUIListItemPtr CGUIEPGGridContainer::GetListItem(int offset, unsigned int flag)
 
   int item = m_channelCursor + m_channelOffset + offset;
   if (flag & INFOFLAG_LISTITEM_POSITION)
-    item = (int)(m_channelScrollOffset / m_channelLayout->Size(VERTICAL));
+    item = MathUtils::round_int(m_channelScrollOffset / m_channelLayout->Size(VERTICAL));
 
   if (flag & INFOFLAG_LISTITEM_WRAP)
   {
@@ -1592,9 +1592,9 @@ GridItemsPtr *CGUIEPGGridContainer::GetClosestItem(const int &channel)
 int CGUIEPGGridContainer::GetItemSize(GridItemsPtr *item)
 {
   if (!item)
-    return (int) m_blockSize; /// stops it crashing
+    return MathUtils::round_int(m_blockSize); /// stops it crashing
 
-  return (int) (item->width / m_blockSize);
+  return MathUtils::round_int(item->width / m_blockSize);
 }
 
 int CGUIEPGGridContainer::GetBlock(const CGUIListItemPtr &item, const int &channel)
@@ -1948,8 +1948,8 @@ void CGUIEPGGridContainer::UpdateLayout()
   m_channelPosY       = m_posY + m_rulerHeight;
   m_rulerPosX         = m_posX + m_channelWidth;
   m_rulerPosY         = m_posY;
-  m_channelsPerPage   = (int)(m_gridHeight / m_channelHeight);
-  m_programmesPerPage = (int)(m_gridWidth / m_blockSize) + 1;
+  m_channelsPerPage   = MathUtils::round_int(m_gridHeight / m_channelHeight);
+  m_programmesPerPage = MathUtils::round_int(m_gridWidth / m_blockSize) + 1;
 
   // ensure that the scroll offsets are a multiple of our sizes
   m_channelScrollOffset   = m_channelOffset * m_programmeLayout->Size(VERTICAL);


### PR DESCRIPTION
This fixes the lockup of kodi when entering the PVR Guide window. Was mostly reported for Estuary, but root cause is a general off-by-one bug due to incorrect rounding (float -> int) that causes an endless loop when rendering the epg grid.

@xhaggi mind taking a look.

@phil65 @ronie fyi
