### PR TITLE
[python-api] add some get-methods to xbmc.InfoTagVideo

### DIFF
--- a/xbmc/interfaces/legacy/InfoTagVideo.cpp
+++ b/xbmc/interfaces/legacy/InfoTagVideo.cpp
@@ -82,6 +82,11 @@ namespace XBMCAddon
       return infoTag->m_strTitle;
     }
 
+    String InfoTagVideo::getMediaType()
+    {
+      return infoTag->m_type;
+    }
+
     String InfoTagVideo::getVotes()
     {
       return StringUtils::Format("%i", infoTag->GetRating().votes);

--- a/xbmc/interfaces/legacy/InfoTagVideo.cpp
+++ b/xbmc/interfaces/legacy/InfoTagVideo.cpp
@@ -42,6 +42,11 @@ namespace XBMCAddon
       delete infoTag;
     }
 
+    int InfoTagVideo::getDbId()
+    {
+      return infoTag->m_iDbId;
+    }
+
     String InfoTagVideo::getDirector()
     {
       return StringUtils::Join(infoTag->m_director, g_advancedSettings.m_videoItemSeparator);

--- a/xbmc/interfaces/legacy/InfoTagVideo.cpp
+++ b/xbmc/interfaces/legacy/InfoTagVideo.cpp
@@ -117,6 +117,16 @@ namespace XBMCAddon
       return infoTag->m_strIMDBNumber;
     }
 
+    int InfoTagVideo::getSeason()
+    {
+      return infoTag->m_iSeason;
+    }
+
+    int InfoTagVideo::getEpisode()
+    {
+      return infoTag->m_iEpisode;
+    }
+
     int InfoTagVideo::getYear()
     {
       return infoTag->m_iYear;

--- a/xbmc/interfaces/legacy/InfoTagVideo.cpp
+++ b/xbmc/interfaces/legacy/InfoTagVideo.cpp
@@ -77,6 +77,11 @@ namespace XBMCAddon
       return infoTag->m_strPictureURL.GetFirstThumb().m_url;
     }
 
+    String InfoTagVideo::getTVShowTitle()
+    {
+      return infoTag->m_strShowTitle;
+    }
+
     String InfoTagVideo::getTitle()
     {
       return infoTag->m_strTitle;

--- a/xbmc/interfaces/legacy/InfoTagVideo.h
+++ b/xbmc/interfaces/legacy/InfoTagVideo.h
@@ -72,6 +72,10 @@ namespace XBMCAddon
        */
       String getTitle();
       /**
+       * getMediaType() - returns a string.
+       */
+      String getMediaType();
+      /**
        * getVotes() - returns a string.
        */
       String getVotes();

--- a/xbmc/interfaces/legacy/InfoTagVideo.h
+++ b/xbmc/interfaces/legacy/InfoTagVideo.h
@@ -72,6 +72,10 @@ namespace XBMCAddon
        */
       String getTitle();
       /**
+       * getTVShowTitle() - returns a string.
+       */
+      String getTVShowTitle();
+      /**
        * getMediaType() - returns a string.
        */
       String getMediaType();

--- a/xbmc/interfaces/legacy/InfoTagVideo.h
+++ b/xbmc/interfaces/legacy/InfoTagVideo.h
@@ -40,6 +40,10 @@ namespace XBMCAddon
       virtual ~InfoTagVideo();
 
       /**
+       * getDbId() - returns an integer.
+       */
+      int getDbId();
+      /**
        * getDirector() - returns a string.
        */
       String getDirector();

--- a/xbmc/interfaces/legacy/InfoTagVideo.h
+++ b/xbmc/interfaces/legacy/InfoTagVideo.h
@@ -100,6 +100,14 @@ namespace XBMCAddon
        */
       String getIMDBNumber();
       /**
+       * getSeason() - returns an integer.
+       */
+      int getSeason();
+      /**
+       * getEpisode() - returns an integer.
+       */
+      int getEpisode();
+      /**
        * getYear() - returns an integer.
        */
       int getYear();


### PR DESCRIPTION
Allows to fetch the media type from a listitem.

@tamland 

EDIT: added some more getter-methods. They become more important once contextmenu can get opened at home (up to now using getInfoLabel("Listitem.xxx") worked fine for context item add-ons since it was used exclusively in MediaWindows, but for home we need to use sys.listitem)
