### PR TITLE
libdvd/Makefile: rename LDFLAGS to SO_LDFLAGS

### DIFF
--- a/lib/libdvd/Makefile.in
+++ b/lib/libdvd/Makefile.in
@@ -22,9 +22,9 @@ WRAPPER_DEF = @abs_top_srcdir@/xbmc/cores/DllLoader/exports/wrapper.def
 WRAPPER_MACH_ALIAS = @abs_top_srcdir@/xbmc/cores/DllLoader/exports/wrapper_mach_alias
 
 ifeq ($(findstring osx,$(ARCH)),osx)
-  LDFLAGS +=-bundle -undefined dynamic_lookup -read_only_relocs suppress
+  SO_LDFLAGS = $(LDFLAGS) -bundle -undefined dynamic_lookup -read_only_relocs suppress
 else
-  LDFLAGS += -shared -fPIC -rdynamic
+  SO_LDFLAGS = $(LDFLAGS) -shared -fPIC -rdynamic
 endif
 
 ifeq ($(ARCH), powerpc-osx)
@@ -55,7 +55,7 @@ ifeq ($(findstring osx,$(ARCH)), osx)
 $(SYSDIR)/libdvdcss-$(ARCH).so:  $(WRAPPER) $(DVDREAD_DEPS)
 	[ -d libdvdcss ] || mkdir libdvdcss
 	cd libdvdcss; ar x $(DVDCSS_A)
-	$(CC) $(LDFLAGS) -Wl,-alias_list,$(WRAPPER_MACH_ALIAS) -o $@ \
+	$(CC) $(SO_LDFLAGS) -Wl,-alias_list,$(WRAPPER_MACH_ALIAS) -o $@ \
                 $(WRAPPER) $(DVDCSS_OBJS) $(BUNDLE1_O)
 
 $(SYSDIR)/libdvdnav-$(ARCH).so: $(WRAPPER) $(DVDNAV_A) $(DVDREAD_A) $(DVDREAD_DEPS)
@@ -65,14 +65,14 @@ $(SYSDIR)/libdvdnav-$(ARCH).so: $(WRAPPER) $(DVDNAV_A) $(DVDREAD_A) $(DVDREAD_DE
 	[ $(BUILD_DVDCSS) -eq 1 ] && { cd libdvdcss && ar x $(DVDCSS_A); } || :
 	cd libdvdnav; ar x $(DVDNAV_A)
 	cd libdvdread; ar x $(DVDREAD_A)
-	$(CC) $(LDFLAGS) -Wl,-alias_list,$(WRAPPER_MACH_ALIAS) -o $@ \
+	$(CC) $(SO_LDFLAGS) -Wl,-alias_list,$(WRAPPER_MACH_ALIAS) -o $@ \
                 $(WRAPPER) libdvdread/*.o libdvdnav/*.o $(DVDCSS_OBJS) $(BUNDLE1_O)
 
 else
 $(SYSDIR)/libdvdcss-$(ARCH).so: $(WRAPPER) $(WRAPPER_DEF) $(DVDCSS_A)
 	[ -d libdvdcss ] || mkdir libdvdcss
 	cd libdvdcss; ar x $(DVDCSS_A)
-	$(CC) -o $@ $(LDFLAGS) -Wl,--soname,$@ $(DVDCSS_OBJS) -Wl,--unresolved-symbols=ignore-all -lm \
+	$(CC) -o $@ $(SO_LDFLAGS) -Wl,--soname,$@ $(DVDCSS_OBJS) -Wl,--unresolved-symbols=ignore-all -lm \
         `cat $(WRAPPER_DEF)` $(WRAPPER)
 
 $(SYSDIR)/libdvdnav-$(ARCH).so: $(WRAPPER) $(WRAPPER_DEF) $(DVDNAV_A) $(DVDREAD_A) $(DVDCSS_A)
@@ -82,7 +82,7 @@ $(SYSDIR)/libdvdnav-$(ARCH).so: $(WRAPPER) $(WRAPPER_DEF) $(DVDNAV_A) $(DVDREAD_
 	[ $(BUILD_DVDCSS) -eq 1 ] && { cd libdvdcss && ar x $(DVDCSS_A); } || :
 	cd libdvdnav; ar x $(DVDNAV_A)
 	cd libdvdread; ar x $(DVDREAD_A)
-	$(CC) -o $@ $(LDFLAGS) -Wl,--soname,$@ libdvdread/*.o libdvdnav/*.o $(DVDCSS_OBJS) -lm -Wl,--unresolved-symbols=ignore-all \
+	$(CC) -o $@ $(SO_LDFLAGS) -Wl,--soname,$@ libdvdread/*.o libdvdnav/*.o $(DVDCSS_OBJS) -lm -Wl,--unresolved-symbols=ignore-all \
                 `cat  $(WRAPPER_DEF)` $(WRAPPER)
 endif
 


### PR DESCRIPTION
Under certain circumstances, these flags can leak into the
environment, where "-shared" will break all linker calls which produce
executables, leading to segmentation faults.

This is not a "generic" LDFLAGS variable to be used everywhere; this
is just one special variable for local use.
