### PR TITLE
Cleanup music window names

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -4964,14 +4964,11 @@ msgctxt "#10500"
 msgid "Music / Playlist"
 msgstr ""
 
-#: xbmc/guilib/WindowIDs.h
-msgctxt "#10501"
-msgid "Music / Files"
-msgstr ""
+#empty string with id 10501
 
 #: xbmc/guilib/WindowIDs.h
 msgctxt "#10502"
-msgid "Music / Library"
+msgid "Music"
 msgstr ""
 
 #: xbmc/guilib/WindowIDs.h


### PR DESCRIPTION
I noticed that the window names for music and video are inconsistent, with video library displaying "Videos" and music library displaying "Music / Library". Checked WindowIDs.h and noticed that WINDOW_VIDEO_FILES points to a string that no longer exists. This commit changes the string to the same one used for WINDOW_VIDEO_NAV and changes the music window names in a similar fashion.

This is untested, feel free to disregard if there if a better solution. Thanks!

See forum discussion here: http://forum.kodi.tv/showthread.php?tid=237267&pid=2270572#pid2270572
