### PR TITLE
[EPG] Fix: Only notify observers for async epg event state changes, not for 'polled' events

### DIFF
--- a/xbmc/epg/Epg.cpp
+++ b/xbmc/epg/Epg.cpp
@@ -329,7 +329,7 @@ bool CEpg::UpdateEntry(const EPG_TAG *data, bool bUpdateDatabase /* = false */)
     return false;
 
   CEpgInfoTagPtr tag(new CEpgInfoTag(*data));
-  return UpdateEntry(tag, true, bUpdateDatabase);
+  return UpdateEntry(tag, false, bUpdateDatabase);
 }
 
 bool CEpg::UpdateEntry(const CEpgInfoTagPtr &tag, bool bNotifyObeservers, bool bUpdateDatabase /* = false */)


### PR DESCRIPTION
Fixes problem reported here: http://forum.kodi.tv/showthread.php?tid=263031

@FernetMenta fyi, was just a typo/brain fart on my side.
