### PR TITLE
[osx] - remove DVDVideoCodecVDA.cpp for real - fixes unit tests

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/Makefile.in
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/Makefile.in
@@ -11,7 +11,6 @@ ifeq (@USE_VAAPI@,1)
 SRCS += VAAPI.cpp
 endif
 ifeq ($(findstring osx,@ARCH@),osx)
-SRCS += DVDVideoCodecVDA.cpp
 SRCS += VDA.cpp
 endif
 ifeq (@USE_OPENMAX@,1)


### PR DESCRIPTION
your  button @FernetMenta please try to think on the makefiles for osx ... they are used for unit tests...
