### PR TITLE
[python-api] add xbmc.InfoTagPicture

### DIFF
--- a/xbmc/interfaces/legacy/CMakeLists.txt
+++ b/xbmc/interfaces/legacy/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SOURCES AddonCallback.cpp
             InfoTagMusic.cpp
             InfoTagRadioRDS.cpp
             InfoTagVideo.cpp
+            InfoTagPicture.cpp
             Keyboard.cpp
             LanguageHook.cpp
             ListItem.cpp
@@ -43,6 +44,7 @@ set(HEADERS Addon.h
             InfoTagMusic.h
             InfoTagRadioRDS.h
             InfoTagVideo.h
+            InfoTagPicture.h
             Keyboard.h
             LanguageHook.h
             List.h

--- a/xbmc/interfaces/legacy/InfoTagPicture.cpp
+++ b/xbmc/interfaces/legacy/InfoTagPicture.cpp
@@ -1,0 +1,38 @@
+/*
+*      Copyright (C) 2005-2016 Team Kodi
+*      http://kodi.tv
+*
+*  This Program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2, or (at your option)
+*  any later version.
+*
+*  This Program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with XBMC; see the file COPYING.  If not, see
+*  <http://www.gnu.org/licenses/>.
+*
+*/
+
+#include "InfoTagPicture.h"
+#include "pictures/PictureInfoTag.h"
+
+namespace XBMCAddon
+{
+  namespace xbmc
+  {
+    InfoTagPicture::InfoTagPicture(const CPictureInfoTag& tag)
+    {
+      infoTag.reset(new CPictureInfoTag(tag));
+    }
+
+    String InfoTagPicture::getInfo(const String& info)
+    {
+      return infoTag->GetInfo(CPictureInfoTag::TranslateString(info));
+    }
+  }
+}

--- a/xbmc/interfaces/legacy/InfoTagPicture.h
+++ b/xbmc/interfaces/legacy/InfoTagPicture.h
@@ -1,0 +1,91 @@
+/*
+*      Copyright (C) 2005-2016 Team Kodi
+*      http://kodi.tv
+*
+*  This Program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2, or (at your option)
+*  any later version.
+*
+*  This Program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with XBMC; see the file COPYING.  If not, see
+*  <http://www.gnu.org/licenses/>.
+*
+*/
+
+#pragma once
+#include "pictures/PictureInfoTag.h"
+#include "AddonClass.h"
+
+#include <memory>
+
+namespace XBMCAddon
+{
+  namespace xbmc
+  {
+
+    ///
+    /// \defgroup python_InfoTagPicture InfoTagPicture
+    /// \ingroup python_xbmc
+    /// @{
+    /// @brief **Kodi's picture info tag class.**
+    ///
+    /// \python_class{ InfoTagPicture() }
+    ///
+    /// To get picture info tag data of currently played source or listitem.
+    ///
+    ///
+    ///
+    ///-------------------------------------------------------------------------
+      /// @python_v18 New class added.
+    ///
+    /// **Example:**
+    /// ~~~~~~~~~~~~~{.py}
+    /// ...
+    /// tag = listitem.getPictureInfoTag()
+    ///
+    /// gps_lat = tag.getInfo("latitude")
+    /// exposure_time = tag.getInfo("exposuretime")
+    /// ...
+    /// ~~~~~~~~~~~~~
+    ///
+    class InfoTagPicture : public AddonClass
+    {
+    private:
+      std::unique_ptr<CPictureInfoTag> infoTag;
+
+    public:
+#ifndef SWIG
+      InfoTagPicture(const CPictureInfoTag& tag);
+#endif
+      InfoTagPicture() = default;
+      virtual ~InfoTagPicture() = default;
+
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagPicture
+      /// @brief \python_func{ getInfo(info) }
+      ///-----------------------------------------------------------------------
+      /// Get picture information
+      /// For a list of all available info tags, see xbmc/pictures/PictureInfoTag.cpp in code
+      ///
+      /// @return [string] picture info.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v18 New function added.
+      ///
+      ///
+      getInfo(...);
+#else
+      String getInfo(const String& info);
+#endif
+    };
+  }
+}

--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -797,5 +797,14 @@ namespace XBMCAddon
         return new xbmc::InfoTagMusic(*item->GetMusicInfoTag());
       return new xbmc::InfoTagMusic();
     }
+
+    xbmc::InfoTagPicture* ListItem::getPictureInfoTag()
+    {
+      LOCKGUI;
+      if (item->HasPictureInfoTag())
+        return new xbmc::InfoTagPicture(*item->GetPictureInfoTag());
+      return new xbmc::InfoTagPicture();
+    }
+
   }
 }

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -33,6 +33,7 @@
 #include "commons/Exception.h"
 #include "InfoTagVideo.h"
 #include "InfoTagMusic.h"
+#include "InfoTagPicture.h"
 
 
 namespace XBMCAddon
@@ -1016,6 +1017,22 @@ namespace XBMCAddon
       getMusicInfoTag();
 #else
       xbmc::InfoTagMusic* getMusicInfoTag();
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmcgui_listitem
+      /// @brief \python_func{ getPictureInfoTag() }
+      ///-----------------------------------------------------------------------
+      /// Returns the PictureInfoTag for this item.
+      ///
+      /// @return     picture info tag
+      ///-----------------------------------------------------------------------
+      /// @python_v17 New method added.
+      ///
+      getPictureInfoTag();
+#else
+      xbmc::InfoTagPicture* getPictureInfoTag();
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS

--- a/xbmc/interfaces/swig/AddonModuleXbmc.i
+++ b/xbmc/interfaces/swig/AddonModuleXbmc.i
@@ -60,6 +60,7 @@ using namespace xbmc;
 %include "interfaces/legacy/InfoTagMusic.h"
 %include "interfaces/legacy/InfoTagRadioRDS.h"
 %include "interfaces/legacy/InfoTagVideo.h"
+%include "interfaces/legacy/InfoTagPicture.h"
 %include "interfaces/legacy/Keyboard.h"
 %include "interfaces/legacy/PlayList.h"
 

--- a/xbmc/interfaces/swig/AddonModuleXbmcgui.i
+++ b/xbmc/interfaces/swig/AddonModuleXbmcgui.i
@@ -43,7 +43,7 @@ using namespace xbmcgui;
 // not part of what swig parses.
 %feature("knownbasetypes") XBMCAddon::xbmcgui "AddonClass,AddonCallback"
 
-%feature("knownapitypes") XBMCAddon::xbmcgui "XBMCAddon::xbmc::InfoTagVideo,xbmc::InfoTagMusic"
+%feature("knownapitypes") XBMCAddon::xbmcgui "XBMCAddon::xbmc::InfoTagVideo,xbmc::InfoTagMusic,xbmc::InfoTagPicture"
 
 %include "interfaces/legacy/swighelper.h"
 %include "interfaces/legacy/AddonString.h"


### PR DESCRIPTION
This is the basework to allow reading imageinfo from a listitem object.
Up to now I only added 2 methods to allow fetching GPS EXIF data. Will add more once I need them. :)
@tamland @xhaggi 
I would also need an xcode sync.. Could someone step up for that? :)    
