### PR TITLE
hide separator image in networksettings

### DIFF
--- a/xbmc/network/GUIDialogNetworkSetup.h
+++ b/xbmc/network/GUIDialogNetworkSetup.h
@@ -55,6 +55,7 @@ protected:
   virtual void OnSettingAction(const CSetting *setting);
 
   // specialization of CGUIDialogSettingsBase
+  bool AllowResettingSettings() const override { return false; }
   virtual void Save() { }
   virtual void SetupView();
 


### PR DESCRIPTION
fixes a small regression after the settings dialogs merge.
hide the separator at the bottom of the settings list.

@HitcherUK 
