### PR TITLE
re-add player.showcodec infobool for skins

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2132,6 +2132,13 @@ bool CApplication::OnAction(const CAction &action)
     return true;
   }
 
+  // codec info : Shows the current song, video or picture codec information
+  if (action.GetID() == ACTION_SHOW_CODEC)
+  {
+    g_infoManager.ToggleShowCodec();
+    return true;
+  }
+
   if ((action.GetID() == ACTION_INCREASE_RATING || action.GetID() == ACTION_DECREASE_RATING) && m_pPlayer->IsPlayingAudio())
   {
     const CMusicInfoTag *tag = g_infoManager.GetCurrentSongTag();

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -143,6 +143,7 @@ CGUIInfoManager::CGUIInfoManager(void) :
   m_frameCounter = 0;
   m_lastFPSTime = 0;
   m_playerShowTime = false;
+  m_playerShowCodec = false;
   m_playerShowInfo = false;
   m_fps = 0.0f;
   ResetLibraryBools();
@@ -2585,6 +2586,8 @@ bool CGUIInfoManager::GetBool(int condition1, int contextWindow, const CGUIListI
 
   else if (condition == PLAYER_SHOWINFO)
     bReturn = m_playerShowInfo;
+  else if (condition == PLAYER_SHOWCODEC)
+    bReturn = m_playerShowCodec;
   else if (condition == PLAYER_IS_CHANNEL_PREVIEW_ACTIVE)
     bReturn = IsPlayerChannelPreviewActive();
   else if (condition >= MULTI_INFO_START && condition <= MULTI_INFO_END)

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -198,6 +198,7 @@ public:
   void SetShowTime(bool showtime) { m_playerShowTime = showtime; };
   void SetShowInfo(bool showinfo) { m_playerShowInfo = showinfo; };
   bool GetShowInfo() const { return m_playerShowInfo; }
+  void ToggleShowCodec() { m_playerShowCodec = !m_playerShowCodec; };
   bool ToggleShowInfo() { m_playerShowInfo = !m_playerShowInfo; return m_playerShowInfo; };
   bool IsPlayerChannelPreviewActive() const;
 
@@ -323,6 +324,7 @@ protected:
   unsigned int m_AfterSeekTimeout;
   int m_seekOffset;
   bool m_playerShowTime;
+  bool m_playerShowCodec;
   bool m_playerShowInfo;
 
   // FPS counters

--- a/xbmc/input/Key.h
+++ b/xbmc/input/Key.h
@@ -140,7 +140,7 @@
 #define ACTION_SHOW_OSD               24 //!< show/hide OSD. Can b used in videoFullScreen.xml window id=2005
 #define ACTION_SHOW_SUBTITLES         25 //!< turn subtitles on/off. Can b used in videoFullScreen.xml window id=2005
 #define ACTION_NEXT_SUBTITLE          26 //!< switch to next subtitle of movie. Can b used in videoFullScreen.xml window id=2005
-#define ACTION_SHOW_CODEC             27 //!< show debug info for VideoPlayer
+#define ACTION_SHOW_CODEC             27 //!< show debug info for VideoPlayer, music/visualisation or picture info
 #define ACTION_NEXT_PICTURE           28 //!< show next picture of slideshow. Can b used in slideshow.xml window id=2007
 #define ACTION_PREV_PICTURE           29 //!< show previous picture of slideshow. Can b used in slideshow.xml window id=2007
 #define ACTION_ZOOM_OUT               30 //!< zoom in picture during slideshow. Can b used in slideshow.xml window id=2007


### PR DESCRIPTION
skins use the Player.Showcodec infobool to display audio codec / visualisation info.
see: https://github.com/xbmc/xbmc/blob/d50303cba81bb0577756db53af430e7f50da2425/addons/skin.estuary/1080i/MusicVisualisation.xml#L182-L223

this re-adds the infobool after it was removed as part of https://github.com/xbmc/xbmc/pull/9272

@FernetMenta would this be ok for you?
