### PR TITLE
[PVR] Addon API: Add PVR_PROPERTIES.iEpgMaxDays, PVR_RECORDING.channelType

### DIFF
--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_dll.h
@@ -639,8 +639,8 @@ extern "C"
   /*!
    * Tell the client the time frame to use when notifying epg events back to Kodi. The client might push epg events asynchronously
    * to Kodi using the callback function EpgEventStateChange. To be able to only push events that are actually of interest for Kodi,
-   * client needs to know about the epg time frame Kodi uses. Kodi calls this function once after the client add-on has been sucessfully
-   * initialized and then everytime the time frame value changes.
+   * client needs to know about the epg time frame Kodi uses. Kodi supplies the current epg time frame value in PVR_PROPERTIES.iEpgMaxDays
+   * when creating the addon and calls SetEPGTimeFrame later whenever Kodi's epg time frame value changes.
    * @param iDays number of days from "now". EPG_TIMEFRAME_UNLIMITED means that Kodi is interested in all epg events, regardless of event times.
    * @return PVR_ERROR_NO_ERROR if new value was successfully set.
    * @remarks Required if bSupportsEPG is set to true. Return PVR_ERROR_NOT_IMPLEMENTED if this add-on won't provide this function.

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
@@ -231,6 +231,16 @@ extern "C" {
   } PVR_CONNECTION_STATE;
 
   /*!
+   * @brief PVR recording channel types
+   */
+  typedef enum
+  {
+    PVR_RECORDING_CHANNEL_TYPE_UNKNOWN = 0, /*!< @brief unknown */
+    PVR_RECORDING_CHANNEL_TYPE_TV      = 1, /*!< @brief TV channel */
+    PVR_RECORDING_CHANNEL_TYPE_RADIO   = 2, /*!< @brief radio channel */
+  } PVR_RECORDING_CHANNEL_TYPE;
+
+  /*!
    * @brief Properties passed to the Create() method of an add-on.
    */
   typedef struct PVR_PROPERTIES
@@ -480,6 +490,7 @@ extern "C" {
     bool   bIsDeleted;                                    /*!< @brief (optional) shows this recording is deleted and can be undelete */
     unsigned int iEpgEventId;                             /*!< @brief (optional) EPG event id associated with this recording. Valid ids must be greater than EPG_TAG_INVALID_UID. */
     int    iChannelUid;                                   /*!< @brief (optional) unique identifier of the channel for this recording. PVR_CHANNEL_INVALID_UID denotes that channel uid is not available. */
+    PVR_RECORDING_CHANNEL_TYPE channelType;               /*!< @brief (optional) channel type. Set to PVR_RECORDING_CHANNEL_TYPE_UNKNOWN if the type cannot be determined. */
   } ATTRIBUTE_PACKED PVR_RECORDING;
 
   /*!

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
@@ -237,6 +237,7 @@ extern "C" {
   {
     const char* strUserPath;           /*!< @brief path to the user profile */
     const char* strClientPath;         /*!< @brief path to this add-on */
+    int iEpgMaxDays;                   /*!< @brief if > EPG_TIMEFRAME_UNLIMITED, in async epg mode, deliver only events in the range from 'end time > now' to 'start time < now + iEpgMaxDays. EPG_TIMEFRAME_UNLIMITED, notify all events. */
   } PVR_PROPERTIES;
 
   /*!

--- a/xbmc/epg/GUIEPGGridContainer.cpp
+++ b/xbmc/epg/GUIEPGGridContainer.cpp
@@ -1442,15 +1442,18 @@ bool CGUIEPGGridContainer::OnMouseWheel(char wheel, const CPoint &point)
   return true;
 }
 
-CPVRChannelPtr CGUIEPGGridContainer::GetChannel(int iIndex)
+CPVRChannelPtr CGUIEPGGridContainer::GetSelectedChannel()
 {
-  if (iIndex >= 0 && (size_t) iIndex < m_channelItems.size())
+  CFileItemPtr fileItem;
   {
-    CFileItemPtr fileItem = m_channelItems[iIndex];
-    if (fileItem->HasPVRChannelInfoTag())
-      return fileItem->GetPVRChannelInfoTag();
+    CSingleLock lock(m_critSection);
+    if (m_channelCursor + m_channelOffset < m_channels)
+      fileItem = m_channelItems[m_channelCursor + m_channelOffset];
   }
-  
+
+  if (fileItem && fileItem->HasPVRChannelInfoTag())
+    return fileItem->GetPVRChannelInfoTag();
+
   return CPVRChannelPtr();
 }
 
@@ -1472,11 +1475,6 @@ int CGUIEPGGridContainer::GetSelectedItem() const
       return i;
   }
   return -1;
-}
-
-const int CGUIEPGGridContainer::GetSelectedChannel() const
-{
-  return m_channelCursor + m_channelOffset;
 }
 
 CFileItemPtr CGUIEPGGridContainer::GetSelectedChannelItem() const

--- a/xbmc/epg/GUIEPGGridContainer.h
+++ b/xbmc/epg/GUIEPGGridContainer.h
@@ -65,9 +65,8 @@ namespace EPG
     virtual std::string GetDescription() const;
     const int GetNumChannels()   { return m_channels; };
     virtual int GetSelectedItem() const;
-    const int GetSelectedChannel() const;
     CFileItemPtr GetSelectedChannelItem() const;
-    PVR::CPVRChannelPtr GetChannel(int iIndex);
+    PVR::CPVRChannelPtr GetSelectedChannel();
     virtual EVENT_RESULT OnMouseEvent(const CPoint &point, const CMouseEvent &event);
 
     virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -159,6 +159,7 @@ void CPVRClient::ResetProperties(int iClientId /* = PVR_INVALID_CLIENT_ID */)
   m_pInfo->strUserPath    = m_strUserPath.c_str();
   m_strClientPath         = CSpecialProtocol::TranslatePath(Path());
   m_pInfo->strClientPath  = m_strClientPath.c_str();
+  m_pInfo->iEpgMaxDays    = CSettings::GetInstance().GetInt(CSettings::SETTING_EPG_DAYSTODISPLAY);
   m_menuhooks.clear();
   m_timertypes.clear();
   m_bReadyToUse           = false;
@@ -195,9 +196,6 @@ ADDON_STATUS CPVRClient::Create(int iClientId)
   catch (std::exception &e) { LogException(e, __FUNCTION__); }
 
   m_bReadyToUse = bReadyToUse;
-
-  SetEPGTimeFrame(CSettings::GetInstance().GetInt(CSettings::SETTING_EPG_DAYSTODISPLAY));
-
   return status;
 }
 

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -143,7 +143,7 @@ void CGUIWindowPVRGuide::UpdateSelectedItemPath()
     CGUIEPGGridContainer *epgGridContainer = (CGUIEPGGridContainer*) GetControl(m_viewControl.GetCurrentControl());
     if (epgGridContainer)
     {
-      CPVRChannelPtr channel(epgGridContainer->GetChannel(epgGridContainer->GetSelectedChannel()));
+      CPVRChannelPtr channel(epgGridContainer->GetSelectedChannel());
       if (channel)
         SetSelectedItemPath(m_bRadio, channel->Path());
     }


### PR DESCRIPTION
This PR introduces a PVR addon API change. It will get merged immediately after #9290 to keep number of api bumps for Krypton small.

1) Epg max days (number of days the user wants Kodi to hold epg event data) now will be transferred along with PVR_PROPERTIES to Addon_Create function. Thus, the pvr addon knows the correct value immediately when it gets created. Before, the value was transferred some time after the addon got created, making it impossible for the addon to initialize it's backend connection with the correct epg max days value without deferring connecting to the backend until epg max days values got set by Kodi, making a true asynchronous backend connection setup impossible.

2) Introduce PVR_RECORDING.channelType. This way, addons can flag recordings as TV or radio recordings making it possible to distinguish in kodi between these types, for instance to provide separate listings of tv and radio recordings, implement separate next recording widgets for radio and tv, .... It must be up to the addons/backend to supply this information as it is not always possible to obtain the type of a given channel at runtime, because the channel the recoding has been done may no longer be available at the time the channel type is needed. Kodi core implementation will be done in a followup PR.

Due to this API change, all PVR addons need to be recompiled, no other changes are required,  unless async epg data transfer including addon-side filtering of transferred epg data according to epg max days value shall be implemented.

Second commit fixes crash due to a multithreading issue with CGUIEPGGridContainer that occured while testing the API change.
