### PR TITLE
[PVR] Fix time displayed in pvr shutdown warning dialog

### DIFF
--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -1502,10 +1502,9 @@ bool CPVRManager::CanSystemPowerdown(bool bAskUser /*= true*/) const
             const CDateTime now(CDateTime::GetUTCDateTime());
             const CDateTime start(cause->StartAsUTC());
             const CDateTimeSpan prestart(0, 0, cause->MarginStart(), 0);
-            const CDateTimeSpan prewakeup(0, 0, CSettings::GetInstance().GetInt(CSettings::SETTING_PVRPOWERMANAGEMENT_PREWAKEUP), 0);
 
             CDateTimeSpan diff(start - now);
-            diff -= prestart - prewakeup;
+            diff -= prestart;
             int mins = diff.GetSecondsTotal() / 60;
 
             std::string dueStr;


### PR DESCRIPTION
Reported in the forum: http://forum.kodi.tv/showthread.php?tid=262798

Calculation of the minutes left until the next recording starts was wrong: The time the machine should start from suspend before a recording (pre recording wakeup time) is not of concern for the actual recording start time.

@xhaggi makes sense?
