### PR TITLE
[PVR] Separate TV and Radio recordings

### DIFF
--- a/xbmc/dialogs/GUIDialogMediaSource.cpp
+++ b/xbmc/dialogs/GUIDialogMediaSource.cpp
@@ -253,6 +253,20 @@ void CGUIDialogMediaSource::OnPathBrowse(int item)
     share1.m_ignore = true;
     extraShares.push_back(share1);
 
+    // add the recordings dir as needed
+    if (CPVRDirectory::HasRadioRecordings())
+    {
+      share1.strPath = PVR::CPVRRecordingsPath::PATH_ACTIVE_RADIO_RECORDINGS;
+      share1.strName = g_localizeStrings.Get(19017); // Recordings
+      extraShares.push_back(share1);
+    }
+    if (CPVRDirectory::HasDeletedRadioRecordings())
+    {
+      share1.strPath = PVR::CPVRRecordingsPath::PATH_DELETED_RADIO_RECORDINGS;
+      share1.strName = g_localizeStrings.Get(19184); // Deleted recordings
+      extraShares.push_back(share1);
+    }
+
     if (CSettings::GetInstance().GetString(CSettings::SETTING_AUDIOCDS_RECORDINGPATH) != "")
     {
       share1.strPath = "special://recordings/";
@@ -282,16 +296,16 @@ void CGUIDialogMediaSource::OnPathBrowse(int item)
     extraShares.push_back(share1);
 
     // add the recordings dir as needed
-    if (CPVRDirectory::HasRecordings())
+    if (CPVRDirectory::HasTVRecordings())
     {
-      share1.strPath = PVR::CPVRRecordingsPath::PATH_ACTIVE_RECORDINGS;
-      share1.strName = g_localizeStrings.Get(19017); // TV Recordings
+      share1.strPath = PVR::CPVRRecordingsPath::PATH_ACTIVE_TV_RECORDINGS;
+      share1.strName = g_localizeStrings.Get(19017); // Recordings
       extraShares.push_back(share1);
     }
-    if (CPVRDirectory::HasDeletedRecordings())
+    if (CPVRDirectory::HasDeletedTVRecordings())
     {
-      share1.strPath = PVR::CPVRRecordingsPath::PATH_DELETED_RECORDINGS;
-      share1.strName = g_localizeStrings.Get(19108); // Deleted TV Recordings
+      share1.strPath = PVR::CPVRRecordingsPath::PATH_DELETED_TV_RECORDINGS;
+      share1.strName = g_localizeStrings.Get(19184); // Deleted recordings
       extraShares.push_back(share1);
     }
   }

--- a/xbmc/filesystem/PVRDirectory.cpp
+++ b/xbmc/filesystem/PVRDirectory.cpp
@@ -122,14 +122,26 @@ bool CPVRDirectory::IsLiveTV(const std::string& strPath)
   return URIUtils::IsLiveTV(filename);
 }
 
-bool CPVRDirectory::HasRecordings()
-{
-  return g_PVRManager.IsStarted() ? 
-    g_PVRRecordings->GetNumRecordings() > 0 : false;
-}
-
-bool CPVRDirectory::HasDeletedRecordings()
+bool CPVRDirectory::HasTVRecordings()
 {
   return g_PVRManager.IsStarted() ?
-    g_PVRRecordings->HasDeletedRecordings() : false;
+    g_PVRRecordings->GetNumTVRecordings() > 0 : false;
+}
+
+bool CPVRDirectory::HasDeletedTVRecordings()
+{
+  return g_PVRManager.IsStarted() ?
+    g_PVRRecordings->HasDeletedTVRecordings() : false;
+}
+
+bool CPVRDirectory::HasRadioRecordings()
+{
+  return g_PVRManager.IsStarted() ?
+    g_PVRRecordings->GetNumRadioRecordings() > 0 : false;
+}
+
+bool CPVRDirectory::HasDeletedRadioRecordings()
+{
+  return g_PVRManager.IsStarted() ?
+    g_PVRRecordings->HasDeletedRadioRecordings() : false;
 }

--- a/xbmc/filesystem/PVRDirectory.h
+++ b/xbmc/filesystem/PVRDirectory.h
@@ -37,8 +37,10 @@ public:
 
   static bool SupportsWriteFileOperations(const std::string& strPath);
   static bool IsLiveTV(const std::string& strPath);
-  static bool HasRecordings();
-  static bool HasDeletedRecordings();
+  static bool HasTVRecordings();
+  static bool HasDeletedTVRecordings();
+  static bool HasRadioRecordings();
+  static bool HasDeletedRadioRecordings();
 
   virtual bool Exists(const CURL& url);
 

--- a/xbmc/pvr/PVRGUIInfo.cpp
+++ b/xbmc/pvr/PVRGUIInfo.cpp
@@ -64,7 +64,8 @@ void CPVRGUIInfo::ResetProperties(void)
   m_strNextRecordingChannelIcon .clear();
   m_strNextRecordingTime        .clear();
   m_iTimerAmount                = 0;
-  m_bHasRecordings              = false;
+  m_bHasTVRecordings            = false;
+  m_bHasRadioRecordings         = false;
   m_iRecordingTimerAmount       = 0;
   m_iCurrentActiveClient        = 0;
   m_strPlayingClientName        .clear();
@@ -265,7 +266,8 @@ void CPVRGUIInfo::UpdateMisc(void)
 {
   bool bStarted = g_PVRManager.IsStarted();
   std::string strPlayingClientName     = bStarted ? g_PVRClients->GetPlayingClientName() : "";
-  bool       bHasRecordings            = bStarted && g_PVRRecordings->GetNumRecordings() > 0;
+  bool       bHasTVRecordings          = bStarted && g_PVRRecordings->GetNumTVRecordings() > 0;
+  bool       bHasRadioRecordings       = bStarted && g_PVRRecordings->GetNumRadioRecordings() > 0;
   bool       bIsPlayingTV              = bStarted && g_PVRClients->IsPlayingTV();
   bool       bIsPlayingRadio           = bStarted && g_PVRClients->IsPlayingRadio();
   bool       bIsPlayingRecording       = bStarted && g_PVRClients->IsPlayingRecording();
@@ -279,7 +281,8 @@ void CPVRGUIInfo::UpdateMisc(void)
 
   CSingleLock lock(m_critSection);
   m_strPlayingClientName      = strPlayingClientName;
-  m_bHasRecordings            = bHasRecordings;
+  m_bHasTVRecordings          = bHasTVRecordings;
+  m_bHasRadioRecordings       = bHasRadioRecordings;
   m_bHasNonRecordingTimers    = bHasNonRecordingTimers;
   m_bIsPlayingTV              = bIsPlayingTV;
   m_bIsPlayingRadio           = bIsPlayingRadio;

--- a/xbmc/pvr/PVRGUIInfo.h
+++ b/xbmc/pvr/PVRGUIInfo.h
@@ -155,7 +155,8 @@ namespace PVR
     std::string                     m_strNextRecordingChannelName;
     std::string                     m_strNextRecordingChannelIcon;
     std::string                     m_strNextRecordingTime;
-    bool                            m_bHasRecordings;
+    bool                            m_bHasTVRecordings;
+    bool                            m_bHasRadioRecordings;
     unsigned int                    m_iTimerAmount;
     unsigned int                    m_iRecordingTimerAmount;
     unsigned int                    m_iCurrentActiveClient;

--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -114,6 +114,7 @@ CPVRRecording::CPVRRecording(const PVR_RECORDING &recording, unsigned int iClien
   m_bIsDeleted                     = recording.bIsDeleted;
   m_iEpgEventId                    = recording.iEpgEventId;
   m_iChannelUid                    = recording.iChannelUid;
+  m_bRadio                         = recording.channelType == PVR_RECORDING_CHANNEL_TYPE_RADIO; // everything else is considered TV
 }
 
 bool CPVRRecording::operator ==(const CPVRRecording& right) const
@@ -142,7 +143,8 @@ bool CPVRRecording::operator ==(const CPVRRecording& right) const
        m_iRecordingId       == right.m_iRecordingId &&
        m_bIsDeleted         == right.m_bIsDeleted &&
        m_iEpgEventId        == right.m_iEpgEventId &&
-       m_iChannelUid        == right.m_iChannelUid);
+       m_iChannelUid        == right.m_iChannelUid &&
+       m_bRadio             == right.m_bRadio);
 }
 
 bool CPVRRecording::operator !=(const CPVRRecording& right) const
@@ -166,6 +168,7 @@ void CPVRRecording::Serialize(CVariant& value) const
   value["deleted"] = m_bIsDeleted;
   value["epgevent"] = m_iEpgEventId;
   value["channeluid"] = m_iChannelUid;
+  value["radio"] = m_bRadio;
 
   if (!value.isMember("art"))
     value["art"] = CVariant(CVariant::VariantTypeObject);
@@ -195,6 +198,7 @@ void CPVRRecording::Reset(void)
   m_iSeason            = -1;
   m_iEpisode           = -1;
   m_iChannelUid        = PVR_CHANNEL_INVALID_UID;
+  m_bRadio             = false;
 
   m_recordingTime.Reset();
   CVideoInfoTag::Reset();
@@ -374,6 +378,7 @@ void CPVRRecording::Update(const CPVRRecording &tag)
   m_bIsDeleted        = tag.m_bIsDeleted;
   m_iEpgEventId       = tag.m_iEpgEventId;
   m_iChannelUid       = tag.m_iChannelUid;
+  m_bRadio            = tag.m_bRadio;
 
   if (g_PVRClients->SupportsRecordingPlayCount(m_iClientId))
     m_playCount       = tag.m_playCount;
@@ -416,7 +421,7 @@ void CPVRRecording::UpdatePath(void)
   else
   {
     m_strFileNameAndPath = CPVRRecordingsPath(
-      m_bIsDeleted, m_strDirectory, m_strTitle, m_iSeason, m_iEpisode, m_iYear, m_strShowTitle, m_strChannelName, m_recordingTime);
+      m_bIsDeleted, m_bRadio, m_strDirectory, m_strTitle, m_iSeason, m_iEpisode, m_iYear, m_strShowTitle, m_strChannelName, m_recordingTime);
   }
 }
 

--- a/xbmc/pvr/recordings/PVRRecording.h
+++ b/xbmc/pvr/recordings/PVRRecording.h
@@ -203,6 +203,12 @@ namespace PVR
     bool IsDeleted() const { return m_bIsDeleted; }
 
     /*!
+     * @brief Check whether this is a tv or radio recording
+     * @return true if this is a radio recording, false if this is a tv recording
+     */
+    bool IsRadio() const { return m_bRadio; }
+
+    /*!
      * @return Broadcast id of the EPG event associated with this recording or EPG_TAG_INVALID_UID
      */
     unsigned int BroadcastUid(void) const { return m_iEpgEventId; }
@@ -236,6 +242,7 @@ namespace PVR
     bool         m_bIsDeleted;    /*!< set if entry is a deleted recording which can be undelete */
     unsigned int m_iEpgEventId;   /*!< epg broadcast id associated with this recording */
     int          m_iChannelUid;   /*!< channel uid associated with this recording */
+    bool         m_bRadio;        /*!< radio or tv recording */
 
     void UpdatePath(void);
     void DisplayError(PVR_ERROR err) const;

--- a/xbmc/pvr/recordings/PVRRecordings.cpp
+++ b/xbmc/pvr/recordings/PVRRecordings.cpp
@@ -195,24 +195,6 @@ bool CPVRRecordings::HasDeletedRadioRecordings() const
   return m_bDeletedRadioRecordings;
 }
 
-int CPVRRecordings::GetRecordings(CFileItemList* results, bool bDeleted) // @@@ TODO radio?
-{
-  CSingleLock lock(m_critSection);
-
-  int iRecCount = 0;
-  for (PVR_RECORDINGMAP_CITR it = m_recordings.begin(); it != m_recordings.end(); it++)
-  {
-    if (it->second->IsDeleted() != bDeleted)
-      continue;
-
-    CFileItemPtr pFileItem(new CFileItem(it->second));
-    results->Add(pFileItem);
-    iRecCount++;
-  }
-
-  return iRecCount;
-}
-
 bool CPVRRecordings::Delete(const CFileItem& item)
 {
   return item.m_bIsFolder ? DeleteDirectory(item) : DeleteRecording(item);

--- a/xbmc/pvr/recordings/PVRRecordings.cpp
+++ b/xbmc/pvr/recordings/PVRRecordings.cpp
@@ -39,7 +39,10 @@ CPVRRecordings::CPVRRecordings(void) :
     m_bIsUpdating(false),
     m_iLastId(0),
     m_bGroupItems(true),
-    m_bHasDeleted(false)
+    m_bDeletedTVRecordings(false),
+    m_bDeletedRadioRecordings(false),
+    m_iTVRecordings(0),
+    m_iRadioRecordings(0)
 {
   m_database.Open();
 }
@@ -86,11 +89,15 @@ void CPVRRecordings::GetSubDirectories(const CPVRRecordingsPath &recParentPath, 
   // Only active recordings are fetched to provide sub directories.
   // Not applicable for deleted view which is supposed to be flattened.
   std::set<CFileItemPtr> unwatchedFolders;
+  bool bRadio = recParentPath.IsRadio();
 
   for (PVR_RECORDINGMAP_CITR it = m_recordings.begin(); it != m_recordings.end(); it++)
   {
     CPVRRecordingPtr current = it->second;
     if (current->IsDeleted())
+      continue;
+
+    if (current->IsRadio() != bRadio)
       continue;
 
     const std::string strCurrent = recParentPath.GetSubDirectoryPath(current->m_strDirectory);
@@ -119,9 +126,9 @@ void CPVRRecordings::GetSubDirectories(const CPVRRecordingsPath &recParentPath, 
     }
     else
     {
-      pFileItem=results->Get(strFilePath);
+      pFileItem = results->Get(strFilePath);
       if (pFileItem->m_dateTime<current->RecordingTimeAsLocalTime())
-        pFileItem->m_dateTime  = current->RecordingTimeAsLocalTime();
+        pFileItem->m_dateTime = current->RecordingTimeAsLocalTime();
     }
 
     if (current->m_playCount == 0)
@@ -164,19 +171,31 @@ void CPVRRecordings::Update(void)
   NotifyObservers(ObservableMessageRecordings);
 }
 
-int CPVRRecordings::GetNumRecordings()
+int CPVRRecordings::GetNumTVRecordings() const
 {
   CSingleLock lock(m_critSection);
-  return m_recordings.size();
+  return m_iTVRecordings;
 }
 
-bool CPVRRecordings::HasDeletedRecordings()
+bool CPVRRecordings::HasDeletedTVRecordings() const
 {
   CSingleLock lock(m_critSection);
-  return m_bHasDeleted;
+  return m_bDeletedTVRecordings;
 }
 
-int CPVRRecordings::GetRecordings(CFileItemList* results, bool bDeleted)
+int CPVRRecordings::GetNumRadioRecordings() const
+{
+  CSingleLock lock(m_critSection);
+  return m_iRadioRecordings;
+}
+
+bool CPVRRecordings::HasDeletedRadioRecordings() const
+{
+  CSingleLock lock(m_critSection);
+  return m_bDeletedRadioRecordings;
+}
+
+int CPVRRecordings::GetRecordings(CFileItemList* results, bool bDeleted) // @@@ TODO radio?
 {
   CSingleLock lock(m_critSection);
 
@@ -330,8 +349,10 @@ bool CPVRRecordings::GetDirectory(const std::string& strPath, CFileItemList &ite
     {
       CPVRRecordingPtr current = it->second;
 
-      // skip items that are not members of the target directory
-      if (!IsDirectoryMember(strDirectory, current->m_strDirectory) || current->IsDeleted() != recPath.IsDeleted())
+      // Omit recordings not matching criteria
+      if (!IsDirectoryMember(strDirectory, current->m_strDirectory) ||
+          current->IsDeleted() != recPath.IsDeleted() ||
+          current->IsRadio() != recPath.IsRadio())
         continue;
 
       if (m_database.IsOpen())
@@ -410,13 +431,15 @@ CFileItemPtr CPVRRecordings::GetByPath(const std::string &path)
   CPVRRecordingsPath recPath(path);
   if (recPath.IsValid())
   {
-    // Check directory name is for deleted recordings
     bool bDeleted = recPath.IsDeleted();
+    bool bRadio   = recPath.IsRadio();
 
     for (PVR_RECORDINGMAP_CITR it = m_recordings.begin(); it != m_recordings.end(); it++)
     {
       CPVRRecordingPtr current = it->second;
-      if (!URIUtils::PathEquals(path, current->m_strFileNameAndPath) || bDeleted != current->IsDeleted())
+      // Omit recordings not matching criteria
+      if (!URIUtils::PathEquals(path, current->m_strFileNameAndPath) ||
+          bDeleted != current->IsDeleted() || bRadio != current->IsRadio())
         continue;
 
       CFileItemPtr fileItem(new CFileItem(current));
@@ -442,7 +465,10 @@ CPVRRecordingPtr CPVRRecordings::GetById(int iClientId, const std::string &strRe
 void CPVRRecordings::Clear()
 {
   CSingleLock lock(m_critSection);
-  m_bHasDeleted = false;
+  m_bDeletedTVRecordings = false;
+  m_bDeletedRadioRecordings = false;
+  m_iTVRecordings = 0;
+  m_iRadioRecordings = 0;
   m_recordings.clear();
 }
 
@@ -451,7 +477,12 @@ void CPVRRecordings::UpdateFromClient(const CPVRRecordingPtr &tag)
   CSingleLock lock(m_critSection);
 
   if (tag->IsDeleted())
-    m_bHasDeleted = true;
+  {
+    if (tag->IsRadio())
+      m_bDeletedRadioRecordings = true;
+    else
+      m_bDeletedTVRecordings = true;
+  }
 
   CPVRRecordingPtr newTag = GetById(tag->m_iClientId, tag->m_strRecordingId);
   if (newTag)
@@ -474,6 +505,10 @@ void CPVRRecordings::UpdateFromClient(const CPVRRecordingPtr &tag)
     }
     newTag->m_iRecordingId = ++m_iLastId;
     m_recordings.insert(std::make_pair(CPVRRecordingUid(newTag->m_iClientId, newTag->m_strRecordingId), newTag));
+    if (newTag->IsRadio())
+      m_iRadioRecordings++;
+    else
+      m_iTVRecordings++;
   }
 }
 

--- a/xbmc/pvr/recordings/PVRRecordings.h
+++ b/xbmc/pvr/recordings/PVRRecordings.h
@@ -42,7 +42,10 @@ namespace PVR
     unsigned int                 m_iLastId;
     bool                         m_bGroupItems;
     CVideoDatabase               m_database;
-    bool                         m_bHasDeleted;
+    bool                         m_bDeletedTVRecordings;
+    bool                         m_bDeletedRadioRecordings;
+    unsigned int                 m_iTVRecordings;
+    unsigned int                 m_iRadioRecordings;
 
     virtual void UpdateFromClients(void);
     virtual std::string TrimSlashes(const std::string &strOrig) const;
@@ -72,8 +75,10 @@ namespace PVR
      */
     void Update(void);
 
-    int GetNumRecordings();
-    bool HasDeletedRecordings();
+    int GetNumTVRecordings() const;
+    bool HasDeletedTVRecordings() const;
+    int GetNumRadioRecordings() const;
+    bool HasDeletedRadioRecordings() const;
     int GetRecordings(CFileItemList* results, bool bDeleted = false);
 
     /**

--- a/xbmc/pvr/recordings/PVRRecordings.h
+++ b/xbmc/pvr/recordings/PVRRecordings.h
@@ -79,7 +79,6 @@ namespace PVR
     bool HasDeletedTVRecordings() const;
     int GetNumRadioRecordings() const;
     bool HasDeletedRadioRecordings() const;
-    int GetRecordings(CFileItemList* results, bool bDeleted = false);
 
     /**
      * Deletes the item in question, be it a directory or a file

--- a/xbmc/pvr/recordings/PVRRecordingsPath.h
+++ b/xbmc/pvr/recordings/PVRRecordingsPath.h
@@ -29,12 +29,14 @@ namespace PVR
   {
   public:
     static const std::string PATH_RECORDINGS;
-    static const std::string PATH_ACTIVE_RECORDINGS;
-    static const std::string PATH_DELETED_RECORDINGS;
+    static const std::string PATH_ACTIVE_TV_RECORDINGS;
+    static const std::string PATH_ACTIVE_RADIO_RECORDINGS;
+    static const std::string PATH_DELETED_TV_RECORDINGS;
+    static const std::string PATH_DELETED_RADIO_RECORDINGS;
 
     CPVRRecordingsPath(const std::string &strPath);
-    CPVRRecordingsPath(bool bDeleted);
-    CPVRRecordingsPath(bool bDeleted,
+    CPVRRecordingsPath(bool bDeleted, bool bRadio);
+    CPVRRecordingsPath(bool bDeleted, bool bRadio,
                        const std::string &strDirectory, const std::string &strTitle,
                        int iSeason, int iEpisode, int iYear,
                        const std::string &strSubtitle, const std::string &strChannelName,
@@ -48,6 +50,8 @@ namespace PVR
     bool IsRecordingsRoot() const { return m_bRoot; }
     bool IsActive() const { return m_bActive; }
     bool IsDeleted() const { return !IsActive(); }
+    bool IsRadio() const { return m_bRadio; }
+    bool IsTV() const { return !IsRadio(); }
     std::string GetDirectoryPath() const { return m_directoryPath; }
     std::string GetSubDirectoryPath(const std::string &strPath) const;
 
@@ -56,10 +60,12 @@ namespace PVR
 
   private:
     static std::string TrimSlashes(const std::string &strString);
+    size_t GetDirectoryPathPosition() const;
 
     bool m_bValid;
     bool m_bRoot;
     bool m_bActive;
+    bool m_bRadio;
     std::string m_directoryPath;
     std::string m_params;
     std::string m_path;

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -74,7 +74,7 @@ void CGUIWindowPVRRecordings::OnWindowLoaded()
 
 std::string CGUIWindowPVRRecordings::GetDirectoryPath(void)
 {
-  const std::string basePath = CPVRRecordingsPath(m_bShowDeletedRecordings);
+  const std::string basePath = CPVRRecordingsPath(m_bShowDeletedRecordings, m_bRadio);
   return StringUtils::StartsWith(m_vecItems->GetPath(), basePath) ? m_vecItems->GetPath() : basePath;
 }
 
@@ -228,7 +228,7 @@ void CGUIWindowPVRRecordings::UpdateButtons(void)
   CGUIRadioButtonControl *btnShowDeleted = (CGUIRadioButtonControl*) GetControl(CONTROL_BTNSHOWDELETED);
   if (btnShowDeleted)
   {
-    btnShowDeleted->SetVisible(g_PVRRecordings->HasDeletedRecordings());
+    btnShowDeleted->SetVisible(m_bRadio ? g_PVRRecordings->HasDeletedRadioRecordings() : g_PVRRecordings->HasDeletedTVRecordings());
     btnShowDeleted->SetSelected(m_bShowDeletedRecordings);
   }
 


### PR DESCRIPTION
With PVR API 5.1.0 pvr clients may provide the channel type (radio/tv) for recordings making it finally possible to distinguish between radio and tv recordings.

@xhaggi mind taking a look
