### PR TITLE
[addon] use abs_top_builddir to refer to Makefile.include in xbmc/addons/binary/interfaces/Makefile.in

### DIFF
--- a/xbmc/addons/binary/interfaces/Makefile.in
+++ b/xbmc/addons/binary/interfaces/Makefile.in
@@ -2,5 +2,5 @@ SRCS=AddonInterfaces.cpp \
 
 LIB=addon-interfaces.a
 
-include @abs_top_srcdir@/Makefile.include
+include @abs_top_builddir@/Makefile.include
 -include $(patsubst %.cpp,%.P,$(patsubst %.c,%.P,$(SRCS)))


### PR DESCRIPTION
Related to rework of @MaxKellermann and a node from him here https://github.com/xbmc/xbmc/commit/cc5100913c891e9b1dba2bcac75da09c7df6d43f#commitcomment-16610372 comes here a change for parts of #9252.
