### PR TITLE
Add option to call TMDB scraper from an addon

### DIFF
--- a/addons/metadata.common.themoviedb.org/addon.xml
+++ b/addons/metadata.common.themoviedb.org/addon.xml
@@ -8,6 +8,7 @@
   </requires>
   <extension point="xbmc.metadata.scraper.library"
              library="tmdb.xml"/>
+  <extension point="xbmc.python.module" library="lib" />
   <extension point="xbmc.addon.metadata">
     <platform>all</platform>
     <summary lang="bg">Библиотека за сваляне на инф. от TMDb</summary>

--- a/addons/metadata.common.themoviedb.org/lib/tmdb/__init__.py
+++ b/addons/metadata.common.themoviedb.org/lib/tmdb/__init__.py
@@ -1,0 +1,6 @@
+
+from tmdb import TMDB
+
+__all__ = [
+    'TMDB'
+]

--- a/addons/metadata.common.themoviedb.org/lib/tmdb/tmdb.py
+++ b/addons/metadata.common.themoviedb.org/lib/tmdb/tmdb.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+import urllib2
+import xbmc
+
+
+class TMDB():
+    def __init__(self, api_key='f7f51775877e0bb6703520952b3c7840'):
+        self.api_key = api_key
+        self.url_prefix = 'http://api.themoviedb.org/3'
+        self.lang = xbmc.getLanguage(xbmc.ISO_639_1)
+
+    def __clean_name(self, mystring):
+        newstring = ''
+        for word in mystring.split(' '):
+            if word.isalnum() is False:
+                w = ""
+                for i in range(len(word)):
+                    if(word[i].isalnum()):
+                        w += word[i]
+                word = w
+            newstring += ' ' + word
+        return newstring.strip()
+
+    def get_by_name(self, name, year=''):
+        clean_name = urllib2.quote(self.__clean_name(name))
+        query = 'query=%s' % clean_name
+
+        if year not in [None, '']:
+            query = '%s&year=%s' % (query, str(year))
+
+        json_details = None
+        url = "%s/%s?language=%s&api_key=%s&%s" % (self.url_prefix, 'search/movie', self.lang, self.api_key, query)
+        try:
+            req = urllib2.Request(url)
+            req.add_header('Accept', 'application/json')
+            response = urllib2.urlopen(req)
+            json_details = response.read()
+            try:
+                response.close()
+            except:
+                pass
+        except:
+            return None
+
+        return json_details


### PR DESCRIPTION
There is occasionally a need for addons to find out things like the ID of a movie on a particular site, the addon can't just read the ID used within Kodi as it will not know which scraper was used to create that Id. So I thought, could a module be added to existing scrapers that did a simple select when given the "name" and "year" of a movie.

So to call it you would just put the dependency in your addon.xml as usual, then do something like:
Code:

```
from tmdb import TMDB
tmdb = TMDB()
details = tmdb.get_by_name(title, year)
```

This actually returns a json response for you to do whatever you like with. (So if there is more information in the response than normally scraped, the addon can make use of it)

If people think this is OK, I can add something similar for the other scrapers.
