### PR TITLE
[adsp] fix kodi frezze if no add-on present

### DIFF
--- a/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSP.cpp
+++ b/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSP.cpp
@@ -738,8 +738,8 @@ bool CActiveAEDSP::UpdateAddons(void)
     CGUIDialogOK::ShowAndGetInput(CVariant{19273}, CVariant{19274});
     CSettings::GetInstance().SetBool(CSettings::SETTING_AUDIOOUTPUT_DSPADDONSENABLED, false);
     CGUIMessage msg(GUI_MSG_UPDATE, WINDOW_SETTINGS_SYSTEM, 0);
-    g_windowManager.SendThreadMessage(msg, WINDOW_SETTINGS_SYSTEM);
-    CApplicationMessenger::GetInstance().SendMsg(TMSG_SETAUDIODSPSTATE, ACTIVE_AE_DSP_STATE_OFF);
+    CApplicationMessenger::GetInstance().SendGUIMessage(msg);
+    CApplicationMessenger::GetInstance().PostMsg(TMSG_SETAUDIODSPSTATE, ACTIVE_AE_DSP_STATE_OFF);
   }
 
   return bReturn;


### PR DESCRIPTION
This fix the thread locks if no dsp add-ons are present and dsp system is enabled

**Here the messages of gdb:**

```
Thread 18 (Thread 0x7f9c867fb700 (LWP 7290)):
#0  pthread_cond_wait@@GLIBC_2.3.2 () at ../sysdeps/unix/sysv/linux/x86_64/pthread_cond_wait.S:185
#1  0x0000000000cbaa76 in KODI::MESSAGING::CApplicationMessenger::SendMsg(KODI::MESSAGING::ThreadMessage&&, bool) ()
#2  0x0000000000cbb294 in KODI::MESSAGING::CApplicationMessenger::SendMsg(unsigned int, int, int, void*) ()
#3  0x0000000000a9e18b in ActiveAE::CActiveAEDSP::UpdateAddons() ()
#4  0x0000000000a9e318 in ActiveAE::CActiveAEDSP::Process() ()
#5  0x0000000001d2d02f in CThread::Action() ()
#6  0x0000000001d2d2ef in CThread::staticThread(void*) ()
#7  0x00007f9cb93fd6aa in start_thread (arg=0x7f9c867fb700) at pthread_create.c:333
#8  0x00007f9cb339ce9d in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:109

Thread 1 (Thread 0x7f9cbabb9880 (LWP 7275)):
#0  pthread_cond_timedwait@@GLIBC_2.3.2 () at ../sysdeps/unix/sysv/linux/x86_64/pthread_cond_timedwait.S:238
#1  0x0000000001d2beaf in CThread::WaitForThreadExit(unsigned int) ()
#2  0x0000000000a9b044 in ActiveAE::CActiveAEDSP::Deactivate() ()
#3  0x0000000000eaabad in CApplication::OnApplicationMessage(KODI::MESSAGING::ThreadMessage*) ()
#4  0x0000000000cb96b5 in KODI::MESSAGING::CApplicationMessenger::ProcessMessage(KODI::MESSAGING::ThreadMessage*) ()
#5  0x0000000000cb9b2a in KODI::MESSAGING::CApplicationMessenger::ProcessMessages() ()
#6  0x0000000000eab9d2 in CApplication::Process() ()
#7  0x0000000000f3b49d in CXBApplicationEx::Run() ()
#8  0x0000000000f40eac in XBMC_Run ()
#9  0x00000000007c47a2 in main ()
```
