### PR TITLE
[guilib] introduce reusable expression definitions

### DIFF
--- a/xbmc/guilib/GUIIncludes.cpp
+++ b/xbmc/guilib/GUIIncludes.cpp
@@ -83,6 +83,13 @@ CGUIIncludes::CGUIIncludes()
   m_constantNodes.insert("fadetime");
   m_constantNodes.insert("pauseatend");
   m_constantNodes.insert("depth");
+
+  m_expressionAttributes.insert("condition");
+
+  m_expressionNodes.insert("visible");
+  m_expressionNodes.insert("enable");
+  m_expressionNodes.insert("usealttexture");
+  m_expressionNodes.insert("selected");
 }
 
 CGUIIncludes::~CGUIIncludes()
@@ -195,6 +202,17 @@ bool CGUIIncludes::LoadIncludesFromXML(const TiXmlElement *root)
       m_skinvariables.insert(make_pair(tagName, *node));
     }
     node = node->NextSiblingElement("variable");
+  }
+
+  node = root->FirstChildElement("expression");
+  while (node)
+  {
+    if (node->Attribute("name") && node->FirstChild())
+    {
+      std::string tagName = node->Attribute("name");
+      m_expressions.insert(make_pair(tagName, node->FirstChild()->ValueStr()));
+    }
+    node = node->NextSiblingElement("expression");
   }
 
   return true;
@@ -341,11 +359,15 @@ void CGUIIncludes::ResolveIncludesForNode(TiXmlElement *node, std::map<INFO::Inf
   { // check the attribute against our set
     if (m_constantAttributes.count(attribute->Name()))
       attribute->SetValue(ResolveConstant(attribute->ValueStr()));
+    if (m_expressionAttributes.count(attribute->Name()))
+      attribute->SetValue(ResolveExpressions(attribute->ValueStr()));
     attribute = attribute->Next();
   }
   // also do the value
   if (node->FirstChild() && node->FirstChild()->Type() == TiXmlNode::TINYXML_TEXT && m_constantNodes.count(node->ValueStr()))
     node->FirstChild()->SetValue(ResolveConstant(node->FirstChild()->ValueStr()));
+  if (node->FirstChild() && node->FirstChild()->Type() == TiXmlNode::TINYXML_TEXT && m_expressionNodes.count(node->ValueStr()))
+    node->FirstChild()->SetValue(ResolveExpressions(node->FirstChild()->ValueStr()));
 }
 
 bool CGUIIncludes::GetParameters(const TiXmlElement *include, const char *valueAttribute, Params& params)
@@ -488,6 +510,19 @@ std::string CGUIIncludes::ResolveConstant(const std::string &constant) const
       *i = it->second;
   }
   return StringUtils::Join(values, ",");
+}
+
+std::string CGUIIncludes::ResolveExpressions(const std::string &expression) const
+{
+  std::string work(expression);
+  CGUIInfoLabel::ReplaceSpecialKeywordReferences(work, "EXP", [&](const std::string &str) -> std::string {
+    std::map<std::string, std::string>::const_iterator it = m_expressions.find(str);
+    if (it != m_expressions.end())
+      return it->second;
+    return "";
+  });
+
+  return work;
 }
 
 const INFO::CSkinVariableString* CGUIIncludes::CreateSkinVariable(const std::string& name, int context)

--- a/xbmc/guilib/GUIIncludes.h
+++ b/xbmc/guilib/GUIIncludes.h
@@ -67,14 +67,19 @@ private:
   static void ResolveParametersForNode(TiXmlElement *node, const Params& params);
   static ResolveParamsResult ResolveParameters(const std::string& strInput, std::string& strOutput, const Params& params);
   std::string ResolveConstant(const std::string &constant) const;
+  std::string ResolveExpressions(const std::string &expression) const;
   bool HasIncludeFile(const std::string &includeFile) const;
   std::map<std::string, std::pair<TiXmlElement, Params>> m_includes;
   std::map<std::string, TiXmlElement> m_defaults;
   std::map<std::string, TiXmlElement> m_skinvariables;
   std::map<std::string, std::string> m_constants;
+  std::map<std::string, std::string> m_expressions;
   std::vector<std::string> m_files;
   typedef std::vector<std::string>::const_iterator iFiles;
 
   std::set<std::string> m_constantAttributes;
   std::set<std::string> m_constantNodes;
+
+  std::set<std::string> m_expressionAttributes;
+  std::set<std::string> m_expressionNodes;
 };


### PR DESCRIPTION
This PR will introduce reusable expression definitions for skins. It is possible to combine both expression definitions and expressions. 

**How to define an expression definition**

``` xml
<expression name="expression_name">expressions</expression>
```

**How to use an expression definition**
You can use expression definitions within the following elements and attributes:
- visible (element)
- enable (element)
- usealttexture (element)
- selected (element)
- condition (attribute)

``` xml
<visible>$EXP[expression_name1] + $EXP[expression_name2]</visible>
<onclick condition="$EXP[expression_name]">Notification(Expression,Hello World!)</onclick>
```

**Examples**

``` xml
<?xml version="1.0" encoding="UTF-8"?>
<includes>
    <expression name="HasInfoDialog">Window.IsActive(musicinformation) | Window.IsActive(movieinformation) | Window.IsActive(addoninformation)</expression>
    <expression name="PluginAdvancedLauncher">substring(Container.FolderPath,plugin://plugin.program.advanced.launcher/,left)</expression>
</includes>
```

Now you can re-use these definitions

``` xml
<animation condition="$EXP[HasInfoDialog]" effect="fade" start="100" end="0" time="200" tween="sine">Conditional</animation>
```

``` xml
<visible>$EXP[PluginAdvancedLauncher] + !Window.IsActive(Home)</visible>
```

@HitcherUK @BigNoid @ronie @phil65 @tamland @Razzeee mind taking a look
