### PR TITLE
[addon] fix wrong way to set addon version and level

### DIFF
--- a/xbmc/addons/binary/interfaces/api1/Addon/AddonCallbacksAddon.cpp
+++ b/xbmc/addons/binary/interfaces/api1/Addon/AddonCallbacksAddon.cpp
@@ -47,7 +47,7 @@ namespace AddOn
 {
 
 CAddonCallbacksAddon::CAddonCallbacksAddon(CAddon* addon)
-  : ADDON::IAddonInterface(addon, APILevel(), Version()),
+  : ADDON::IAddonInterface(addon, 1, KODI_ADDON_API_VERSION),
     m_callbacks(new CB_AddOnLib)
 {
   /* write XBMC addon-on specific add-on function addresses to the callback table */

--- a/xbmc/addons/binary/interfaces/api1/Addon/AddonCallbacksAddon.h
+++ b/xbmc/addons/binary/interfaces/api1/Addon/AddonCallbacksAddon.h
@@ -124,9 +124,6 @@ public:
   CAddonCallbacksAddon(ADDON::CAddon* addon);
   virtual ~CAddonCallbacksAddon();
 
-  static int APILevel()        { return 1; }
-  static std::string Version() { return "0.0.1"; }
-
   /*!
    * @return The callback table.
    */

--- a/xbmc/addons/binary/interfaces/api1/AudioDSP/AddonCallbacksAudioDSP.cpp
+++ b/xbmc/addons/binary/interfaces/api1/AudioDSP/AddonCallbacksAudioDSP.cpp
@@ -41,7 +41,7 @@ namespace AudioDSP
 {
 
 CAddonCallbacksADSP::CAddonCallbacksADSP(ADDON::CAddon* addon)
-  : ADDON::IAddonInterface(addon, APILevel(), Version()),
+  : ADDON::IAddonInterface(addon, 1, KODI_AE_DSP_API_VERSION),
     m_callbacks(new CB_ADSPLib)
 {
   /* write KODI audio DSP specific add-on function addresses to callback table */

--- a/xbmc/addons/binary/interfaces/api1/AudioDSP/AddonCallbacksAudioDSP.h
+++ b/xbmc/addons/binary/interfaces/api1/AudioDSP/AddonCallbacksAudioDSP.h
@@ -84,9 +84,6 @@ public:
   CAddonCallbacksADSP(ADDON::CAddon* addon);
   virtual ~CAddonCallbacksADSP(void);
 
-  static int APILevel() { return 1; }
-  static std::string Version() { return KODI_AE_DSP_API_VERSION; }
-
   /*!
    * @return The callback table.
    */

--- a/xbmc/addons/binary/interfaces/api1/AudioEngine/AddonCallbacksAudioEngine.cpp
+++ b/xbmc/addons/binary/interfaces/api1/AudioEngine/AddonCallbacksAudioEngine.cpp
@@ -37,7 +37,7 @@ namespace AudioEngine
 {
 
 CAddonCallbacksAudioEngine::CAddonCallbacksAudioEngine(CAddon* addon)
-  : ADDON::IAddonInterface(addon, APILevel(), Version()),
+  : ADDON::IAddonInterface(addon, 1, KODI_AUDIOENGINE_API_VERSION),
     m_callbacks(new CB_AudioEngineLib)
 {
   // write KODI audio DSP specific add-on function addresses to callback table

--- a/xbmc/addons/binary/interfaces/api1/AudioEngine/AddonCallbacksAudioEngine.h
+++ b/xbmc/addons/binary/interfaces/api1/AudioEngine/AddonCallbacksAudioEngine.h
@@ -102,9 +102,6 @@ public:
   CAddonCallbacksAudioEngine(ADDON::CAddon* Addon);
   virtual ~CAddonCallbacksAudioEngine();
 
-  static int APILevel() { return 1; }
-  static std::string Version() { return KODI_AUDIOENGINE_API_VERSION; }
-
   /*!
    * @return The callback table.
    */

--- a/xbmc/addons/binary/interfaces/api1/Codec/AddonCallbacksCodec.cpp
+++ b/xbmc/addons/binary/interfaces/api1/Codec/AddonCallbacksCodec.cpp
@@ -102,7 +102,7 @@ private:
 };
 
 CAddonCallbacksCodec::CAddonCallbacksCodec(CAddon* addon)
-  : ADDON::IAddonInterface(addon, APILevel(), Version()),
+  : ADDON::IAddonInterface(addon, 1, KODI_CODEC_API_VERSION),
     m_callbacks(new CB_CodecLib)
 {
   /* write XBMC addon-on specific add-on function addresses to the callback table */

--- a/xbmc/addons/binary/interfaces/api1/Codec/AddonCallbacksCodec.h
+++ b/xbmc/addons/binary/interfaces/api1/Codec/AddonCallbacksCodec.h
@@ -44,9 +44,6 @@ public:
   CAddonCallbacksCodec(ADDON::CAddon* addon);
   virtual ~CAddonCallbacksCodec();
 
-  static int APILevel() { return 1; }
-  static std::string Version() { return "0.0.1"; }
-
   /*!
    * @return The callback table.
    */

--- a/xbmc/addons/binary/interfaces/api1/GUI/AddonCallbacksGUI.cpp
+++ b/xbmc/addons/binary/interfaces/api1/GUI/AddonCallbacksGUI.cpp
@@ -64,7 +64,7 @@ namespace GUI
 static int iXBMCGUILockRef = 0;
 
 CAddonCallbacksGUI::CAddonCallbacksGUI(CAddon* addon)
-  : ADDON::IAddonInterface(addon, APILevel(), Version()),
+  : ADDON::IAddonInterface(addon, 1, KODI_GUILIB_API_VERSION),
     m_callbacks(new CB_GUILib)
 {
   /* GUI Helper functions */

--- a/xbmc/addons/binary/interfaces/api1/GUI/AddonCallbacksGUI.h
+++ b/xbmc/addons/binary/interfaces/api1/GUI/AddonCallbacksGUI.h
@@ -302,9 +302,6 @@ public:
   CAddonCallbacksGUI(ADDON::CAddon* addon);
   virtual ~CAddonCallbacksGUI();
 
-  static int APILevel() { return 1; }
-  static std::string Version() { return KODI_GUILIB_API_VERSION; }
-
   /**! \name General Functions */
   CB_GUILib *GetCallbacks() { return m_callbacks; }
 

--- a/xbmc/addons/binary/interfaces/api1/InputStream/AddonCallbacksInputStream.cpp
+++ b/xbmc/addons/binary/interfaces/api1/InputStream/AddonCallbacksInputStream.cpp
@@ -32,7 +32,7 @@ namespace InputStream
 {
 
 CAddonCallbacksInputStream::CAddonCallbacksInputStream(ADDON::CAddon* addon)
-  : ADDON::IAddonInterface(addon, APILevel(), Version()),
+  : ADDON::IAddonInterface(addon, 1, KODI_INPUTSTREAM_API_VERSION),
     m_callbacks(new CB_INPUTSTREAMLib)
 {
   m_callbacks->FreeDemuxPacket = InputStreamFreeDemuxPacket;

--- a/xbmc/addons/binary/interfaces/api1/PVR/AddonCallbacksPVR.cpp
+++ b/xbmc/addons/binary/interfaces/api1/PVR/AddonCallbacksPVR.cpp
@@ -51,7 +51,7 @@ namespace PVR
 {
 
 CAddonCallbacksPVR::CAddonCallbacksPVR(CAddon* addon)
-  : ADDON::IAddonInterface(addon, APILevel(), Version()),
+  : ADDON::IAddonInterface(addon, 1, XBMC_PVR_API_VERSION),
     m_callbacks(new CB_PVRLib)
 {
   /* write XBMC PVR specific add-on function addresses to callback table */

--- a/xbmc/addons/binary/interfaces/api1/PVR/AddonCallbacksPVR.h
+++ b/xbmc/addons/binary/interfaces/api1/PVR/AddonCallbacksPVR.h
@@ -96,9 +96,6 @@ public:
   CAddonCallbacksPVR(ADDON::CAddon* addon);
   virtual ~CAddonCallbacksPVR(void);
 
-  static int APILevel() { return 1; }
-  static std::string Version() { return XBMC_PVR_API_VERSION; }
-
   /*!
    * @return The callback table.
    */

--- a/xbmc/addons/binary/interfaces/api1/Peripheral/AddonCallbacksPeripheral.cpp
+++ b/xbmc/addons/binary/interfaces/api1/Peripheral/AddonCallbacksPeripheral.cpp
@@ -37,7 +37,7 @@ namespace Peripheral
 {
 
 CAddonCallbacksPeripheral::CAddonCallbacksPeripheral(ADDON::CAddon* addon)
-  : ADDON::IAddonInterface(addon, APILevel(), Version()),
+  : ADDON::IAddonInterface(addon, 1, PERIPHERAL_API_VERSION),
     m_callbacks(new CB_PeripheralLib)
 {
   /* write XBMC peripheral specific add-on function addresses to callback table */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/libKODI_inputstream.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/libKODI_inputstream.h
@@ -40,6 +40,9 @@
 #define INPUTSTREAM_HELPER_DLL "/library.kodi.inputstream/" INPUTSTREAM_HELPER_DLL_NAME
 #endif
 
+/* current input stream API version */
+#define KODI_INPUTSTREAM_API_VERSION "1.0.0"
+
 class CHelper_libKODI_inputstream
 {
 public:

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/libXBMC_addon.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/libXBMC_addon.h
@@ -101,6 +101,9 @@ struct __stat64;
 #undef LOG_ERROR
 #endif
 
+/* current addon API version */
+#define KODI_ADDON_API_VERSION "1.0.0"
+
 namespace ADDON
 {
   typedef enum addon_log

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_codec_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_codec_types.h
@@ -24,6 +24,9 @@
 extern "C" {
 #endif
 
+/* current codec API version */
+#define KODI_CODEC_API_VERSION "1.0.0"
+
 typedef unsigned int xbmc_codec_id_t;
 
 typedef enum


### PR DESCRIPTION
This fix a from me wrong inserted way to set Library Version and Level inside Kodi.

Also fixes this two libraries where it was not set before on right way (InputStream and Peripheral)
