### PR TITLE
[cmake] Fix controller input on android

### DIFF
--- a/xbmc/peripherals/bus/android/CMakeLists.txt
+++ b/xbmc/peripherals/bus/android/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(SOURCES AndroidJoystickState.cpp
+            PeripheralBusAndroid.cpp)
+
+set(HEADERS AndroidJoystickState.h
+            PeripheralBusAndroid.h)
+
+core_add_library(peripherals_bus_android)

--- a/xbmc/platform/android/jni/CMakeLists.txt
+++ b/xbmc/platform/android/jni/CMakeLists.txt
@@ -24,6 +24,7 @@ set(SOURCES Activity.cpp
             File.cpp
             Intent.cpp
             IntentFilter.cpp
+            InputManager.cpp
             JNIBase.cpp
             JNIThreading.cpp
             jutils.cpp
@@ -87,6 +88,7 @@ set(HEADERS Activity.h
             Environment.h
             File.h
             IntentFilter.h
+            InputManager.h
             Intent.h
             JNIBase.h
             JNIThreading.h


### PR DESCRIPTION
Fixes cmake build for android after controller-input merge.
See http://jenkins.kodi.tv/job/Android-x86/6885/ and http://jenkins.kodi.tv/job/Android-arm/7526/
