### PR TITLE
[chg] add advancedsetting to configure number of volume control steps

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2388,7 +2388,7 @@ bool CApplication::OnAction(const CAction &action)
 #if defined(TARGET_ANDROID)
       float step = (VOLUME_MAXIMUM - VOLUME_MINIMUM) / CXBMCApp::GetMaxSystemVolume();
 #else
-      float step   = (VOLUME_MAXIMUM - VOLUME_MINIMUM) / VOLUME_CONTROL_STEPS;
+      float step   = (VOLUME_MAXIMUM - VOLUME_MINIMUM) / g_advancedSettings.m_volumeSteps;
 
       if (action.GetRepeat())
         step *= action.GetRepeat() * 50; // 50 fps

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -92,7 +92,6 @@ namespace MUSIC_INFO
 #define VOLUME_MINIMUM 0.0f        // -60dB
 #define VOLUME_MAXIMUM 1.0f        // 0dB
 #define VOLUME_DYNAMIC_RANGE 90.0f // 60dB
-#define VOLUME_CONTROL_STEPS 90    // 90 steps
 
 // replay gain settings struct for quick access by the player multiple
 // times per second (saves doing settings lookup)

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -117,6 +117,7 @@ void CAdvancedSettings::Initialize()
   //default hold time of 25 ms, this allows a 20 hertz sine to pass undistorted
   m_limiterHold = 0.025f;
   m_limiterRelease = 0.1f;
+  m_volumeSteps = 90;
 
   m_seekSteps = { 10, 30, 60, 180, 300, 600, 1800 };
 
@@ -489,6 +490,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
 
     XMLUtils::GetFloat(pElement, "limiterhold", m_limiterHold, 0.0f, 100.0f);
     XMLUtils::GetFloat(pElement, "limiterrelease", m_limiterRelease, 0.001f, 100.0f);
+    XMLUtils::GetInt(pElement, "volumesteps", m_volumeSteps, 10, 90);
   }
 
   pElement = pRootElement->FirstChildElement("omx");

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -136,6 +136,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     bool m_VideoPlayerIgnoreDTSinWAV;
     float m_limiterHold;
     float m_limiterRelease;
+    int m_volumeSteps;
 
     bool  m_omxDecodeStartWithValidFrame;
 


### PR DESCRIPTION
remotes that dont support repeat on volup/down keys are not uncommon, after sdl is gone, this may be an issue for platforms like rpi/amlogic, as we dont implement "software repeat" as xorg does itself.

besides that, imo, it doesnt make sense to have so much volume control steps anyway, you wont see an os / DE having > 20.

EDIT: now an advancedsetting
