### PR TITLE
[PVR] prevent crash on .. when recordings list empty

### DIFF
--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -474,7 +474,8 @@ void CPVRManager::Stop(void)
   SetState(ManagerStateStopping);
 
   /* stop the EPG updater, since it might be using the pvr add-ons */
-  g_EpgContainer.Stop();
+  if (g_EpgContainer.IsStarted())
+    g_EpgContainer.Stop();
 
   CLog::Log(LOGNOTICE, "PVRManager - stopping");
 

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -172,7 +172,7 @@ CEpgPtr CPVRChannel::GetEPG(void) const
       iEpgId = m_iEpgId;
   }
 
-  return iEpgId > 0 ? g_EpgContainer.GetById(iEpgId) : NULL;
+  return (iEpgId > 0 && g_EpgContainer.IsStarted()) ? g_EpgContainer.GetById(iEpgId) : NULL;
 }
 
 bool CPVRChannel::UpdateFromClient(const CPVRChannelPtr &channel)

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -72,6 +72,26 @@ void CGUIWindowPVRRecordings::OnWindowLoaded()
   CONTROL_SELECT(CONTROL_BTNGROUPITEMS);
 }
 
+bool CGUIWindowPVRRecordings::OnClick(int iItem, const std::string &player)
+{
+  if ( iItem < 0 || iItem >= (int)m_vecItems->Size() ) return true;
+    CFileItemPtr pItem = m_vecItems->Get(iItem);
+
+  if (pItem->IsParentFolder())
+  {
+    CPVRRecordingsPath path(m_vecItems->GetPath());
+    if (path.IsRecordingsRoot())
+    {
+      // don't call CGUIWindowPVRBase as it will attempt to go to the parent folder which we don't want.
+      CLog::Log(LOGDEBUG, "PVR - %s - back to home folder", __FUNCTION__);
+      g_windowManager.ActivateWindow(WINDOW_HOME);
+      return true;
+    }
+  }
+
+  return CGUIMediaWindow::OnClick(iItem, player);
+}
+
 std::string CGUIWindowPVRRecordings::GetDirectoryPath(void)
 {
   const std::string basePath = CPVRRecordingsPath(m_bShowDeletedRecordings);

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.h
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.h
@@ -45,6 +45,7 @@ namespace PVR
     virtual void ResetObservers(void) override;
 
   protected:
+    virtual bool OnClick(int iItem, const std::string &player = "");
     virtual std::string GetDirectoryPath(void) override;
     virtual void OnPrepareFileItems(CFileItemList &items) override;
 

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -1819,7 +1819,7 @@ void CGUIMediaWindow::OnFilterItems(const std::string &filter)
   // The idea here is to ensure we have something to focus if our file list
   // is empty.  As such, this check MUST be last and ignore the hide parent
   // fileitems settings.
-  if (m_vecItems->IsEmpty())
+  if (m_vecItems->IsEmpty() && !m_history.GetParentPath().empty())
   {
     CFileItemPtr pItem(new CFileItem(".."));
     pItem->SetPath(m_history.GetParentPath());


### PR DESCRIPTION
Currently when the pvr.mythtv client starts up it returns an empty recordings list until backend sync is complete. If you enter the recordings list during this time, you end up with only .. present.
If you select .., Kodi crashes.
![screenshot043](https://cloud.githubusercontent.com/assets/12870817/13725215/e5a12adc-e892-11e5-8e70-0bba931efb6b.png)

With commit 1 you get taken back to the home screen instead, which is what I expected would happen.

Commit 2 contains some 'robustness' additions I made while debugging.
It seems kodi tries to exit when it can't follow the .. path. These changes let it carry on trying to exit for a little longer, which makes it easier to work out what's happening from the log.
Happy to drop this commit if it isn't seen as useful.

pings @ksooo @janbar
