### PR TITLE
[gui] fix media source workarounds

### DIFF
--- a/xbmc/addons/GUIViewStateAddonBrowser.cpp
+++ b/xbmc/addons/GUIViewStateAddonBrowser.cpp
@@ -33,7 +33,7 @@ using namespace ADDON;
 
 CGUIViewStateAddonBrowser::CGUIViewStateAddonBrowser(const CFileItemList& items) : CGUIViewState(items)
 {
-  if (items.IsVirtualDirectoryRoot())
+  if (URIUtils::PathEquals(items.GetPath(), "addons://"))
   {
     AddSortMethod(SortByNone, 551, LABEL_MASKS("%F", "", "%L", ""));
     SetSortMethod(SortByNone);
@@ -67,53 +67,3 @@ std::string CGUIViewStateAddonBrowser::GetExtensions()
 {
   return "";
 }
-
-VECSOURCES& CGUIViewStateAddonBrowser::GetSources()
-{
-  m_sources.clear();
-  {
-    CMediaSource share;
-    share.strPath = "addons://user/";
-    share.m_iDriveType = CMediaSource::SOURCE_TYPE_LOCAL;
-    share.m_strThumbnailImage = "DefaultAddonsInstalled.png";
-    share.strName = g_localizeStrings.Get(24998);
-    m_sources.push_back(share);
-  }
-  if (CAddonMgr::GetInstance().HasAvailableUpdates())
-  {
-    CMediaSource share;
-    share.strPath = "addons://outdated/";
-    share.m_iDriveType = CMediaSource::SOURCE_TYPE_LOCAL;
-    share.m_strThumbnailImage = "DefaultAddonsUpdates.png";
-    share.strName = g_localizeStrings.Get(24043); // "Available updates"
-    m_sources.push_back(share);
-  }
-  if (CAddonMgr::GetInstance().HasAddons(ADDON_REPOSITORY))
-  {
-    CMediaSource share;
-    share.strPath = "addons://repos/";
-    share.m_iDriveType = CMediaSource::SOURCE_TYPE_LOCAL;
-    share.m_strThumbnailImage = "DefaultAddonsRepo.png";
-    share.strName = g_localizeStrings.Get(24033);
-    m_sources.push_back(share);
-  }
-  {
-    CMediaSource share;
-    share.strPath = "addons://install/";
-    share.m_iDriveType = CMediaSource::SOURCE_TYPE_LOCAL;
-    share.m_strThumbnailImage = "DefaultAddonsZip.png";
-    share.strName = g_localizeStrings.Get(24041);
-    m_sources.push_back(share);
-  }
-  {
-    CMediaSource share;
-    share.strPath = "addons://search/";
-    share.m_iDriveType = CMediaSource::SOURCE_TYPE_LOCAL;
-    share.m_strThumbnailImage = "DefaultAddonsSearch.png";
-    share.strName = g_localizeStrings.Get(137);
-    m_sources.push_back(share);
-  }
-
-  return CGUIViewState::GetSources();
-}
-

--- a/xbmc/addons/GUIViewStateAddonBrowser.h
+++ b/xbmc/addons/GUIViewStateAddonBrowser.h
@@ -30,6 +30,5 @@ public:
 protected:
   virtual void SaveViewState();
   virtual std::string GetExtensions();
-  virtual VECSOURCES& GetSources();
 };
 

--- a/xbmc/addons/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/GUIWindowAddonBrowser.cpp
@@ -77,12 +77,6 @@ bool CGUIWindowAddonBrowser::OnMessage(CGUIMessage& message)
     break;
   case GUI_MSG_WINDOW_INIT:
     {
-      m_rootDir.AllowNonLocalSources(false);
-
-      // is this the first time the window is opened?
-      if (m_vecItems->GetPath() == "?" && message.GetStringParam().empty())
-        m_vecItems->SetPath("");
-
       SetProperties();
     }
     break;
@@ -358,15 +352,6 @@ bool CGUIWindowAddonBrowser::GetDirectory(const std::string& strDirectory, CFile
         }
       }
     }
-  }
-
-  if (strDirectory.empty() && CAddonInstaller::GetInstance().IsDownloading())
-  {
-    CFileItemPtr item(new CFileItem("addons://downloading/", true));
-    item->SetLabel(g_localizeStrings.Get(24067));
-    item->SetLabelPreformated(true);
-    item->SetIconImage("DefaultNetwork.png");
-    items.Add(item);
   }
 
   for (int i = 0; i < items.Size(); ++i)

--- a/xbmc/addons/GUIWindowAddonBrowser.h
+++ b/xbmc/addons/GUIWindowAddonBrowser.h
@@ -69,6 +69,8 @@ protected:
   virtual bool Update(const std::string &strDirectory, bool updateFilterPath = true) override;
   virtual std::string GetStartFolder(const std::string &dir) override;
 
+  std::string GetRootPath() const override { return "addons://"; }
+
 private:
   void SetProperties();
   void UpdateStatus(const CFileItemPtr& item);

--- a/xbmc/events/windows/GUIViewStateEventLog.cpp
+++ b/xbmc/events/windows/GUIViewStateEventLog.cpp
@@ -46,11 +46,3 @@ std::string CGUIViewStateEventLog::GetExtensions()
 {
   return "";
 }
-
-VECSOURCES& CGUIViewStateEventLog::GetSources()
-{
-  m_sources.clear();
-
-  return CGUIViewState::GetSources();
-}
-

--- a/xbmc/events/windows/GUIViewStateEventLog.h
+++ b/xbmc/events/windows/GUIViewStateEventLog.h
@@ -36,6 +36,5 @@ protected:
   // specializations of CGUIViewState
   virtual void SaveViewState();
   virtual std::string GetExtensions();
-  virtual VECSOURCES& GetSources();
 };
 

--- a/xbmc/events/windows/GUIWindowEventLog.cpp
+++ b/xbmc/events/windows/GUIWindowEventLog.cpp
@@ -48,17 +48,6 @@ bool CGUIWindowEventLog::OnMessage(CGUIMessage& message)
 {
   switch (message.GetMessage())
   {
-  case GUI_MSG_WINDOW_INIT:
-  {
-    m_rootDir.AllowNonLocalSources(false);
-
-    // is this the first time the window is opened?
-    if (m_vecItems->GetPath() == "?" && message.GetStringParam().empty())
-      m_vecItems->SetPath("");
-
-    break;
-  }
-
   case GUI_MSG_CLICKED:
   {
     int iControl = message.GetSenderId();
@@ -248,17 +237,6 @@ bool CGUIWindowEventLog::GetDirectory(const std::string &strDirectory, CFileItem
   items.Append(filteredItems);
 
   return result;
-}
-
-std::string CGUIWindowEventLog::GetStartFolder(const std::string &dir)
-{
-  if (dir.empty())
-    return "events://";
-
-  if (URIUtils::PathStarts(dir, "events://"))
-    return dir;
-
-  return CGUIMediaWindow::GetStartFolder(dir);
 }
 
 bool CGUIWindowEventLog::OnSelect(CFileItemPtr item)

--- a/xbmc/events/windows/GUIWindowEventLog.h
+++ b/xbmc/events/windows/GUIWindowEventLog.h
@@ -37,7 +37,7 @@ protected:
   bool OnContextButton(int itemNumber, CONTEXT_BUTTON button) override;
   void UpdateButtons() override;
   bool GetDirectory(const std::string &strDirectory, CFileItemList &items) override;
-  std::string GetStartFolder(const std::string &dir) override;
+  std::string GetRootPath() const override { return "events://"; }
 
   bool OnSelect(CFileItemPtr item);
   bool OnDelete(CFileItemPtr item);

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -522,6 +522,13 @@ bool CAddonsDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   {
     return GetSearchResults(path, items);
   }
+  else if (endpoint == "downloading")
+  {
+    VECADDONS addons;
+    CAddonInstaller::GetInstance().GetInstallList(addons);
+    CAddonsDirectory::GenerateAddonListing(path, addons, items, g_localizeStrings.Get(24067));
+    return true;
+  }
   else if (endpoint == "more")
   {
     std::string type = path.GetFileName();

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -411,16 +411,66 @@ static bool Repos(const CURL& path, CFileItemList &items)
   return true;
 }
 
+static void RootDirectory(CFileItemList& items)
+{
+  items.SetLabel(g_localizeStrings.Get(24033));
+  {
+    CFileItemPtr item(new CFileItem("addons://user/", true));
+    item->SetLabel(g_localizeStrings.Get(24998));
+    item->SetIconImage("DefaultAddonsInstalled.png");
+    items.Add(item);
+  }
+  if (CAddonMgr::GetInstance().HasAvailableUpdates())
+  {
+    CFileItemPtr item(new CFileItem("addons://outdated/", true));
+    item->SetLabel(g_localizeStrings.Get(24043));
+    item->SetIconImage("DefaultAddonsUpdates.png");
+    items.Add(item);
+  }
+  if (CAddonInstaller::GetInstance().IsDownloading())
+  {
+    CFileItemPtr item(new CFileItem("addons://downloading/", true));
+    item->SetLabel(g_localizeStrings.Get(24067));
+    item->SetIconImage("DefaultNetwork.png");
+    items.Add(item);
+  }
+  if (CAddonMgr::GetInstance().HasAddons(ADDON_REPOSITORY))
+  {
+    CFileItemPtr item(new CFileItem("addons://repos/", true));
+    item->SetLabel(g_localizeStrings.Get(24033));
+    item->SetIconImage("DefaultAddonsRepo.png");
+    items.Add(item);
+  }
+  {
+    CFileItemPtr item(new CFileItem("addons://install/", false));
+    item->SetLabel(g_localizeStrings.Get(24041));
+    item->SetIconImage("DefaultAddonsZip.png");
+    items.Add(item);
+  }
+  {
+    CFileItemPtr item(new CFileItem("addons://search/", true));
+    item->SetLabel(g_localizeStrings.Get(137));
+    item->SetIconImage("DefaultAddonsSearch.png");
+    items.Add(item);
+  }
+}
+
 bool CAddonsDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 {
   std::string tmp(url.Get());
   URIUtils::RemoveSlashAtEnd(tmp);
   CURL path(tmp);
   const std::string endpoint = path.GetHostName();
+  items.ClearItems();
   items.ClearProperties();
   items.SetPath(path.Get());
 
-  if (endpoint == "user")
+  if (endpoint.empty())
+  {
+    RootDirectory(items);
+    return true;
+  }
+  else if (endpoint == "user")
   {
     UserInstalledAddons(path, items);
     return true;

--- a/xbmc/music/windows/GUIWindowMusicPlaylist.h
+++ b/xbmc/music/windows/GUIWindowMusicPlaylist.h
@@ -37,7 +37,7 @@ public:
   void MoveItem(int iStart, int iDest);
 
 protected:
-  virtual void GoParentFolder() override {};
+  virtual bool GoParentFolder() override { return false; };
   virtual void UpdateButtons() override;
   virtual void OnItemLoaded(CFileItem* pItem) override;
   virtual bool Update(const std::string& strDirectory, bool updateFilterPath = true) override;

--- a/xbmc/windows/GUIMediaWindow.h
+++ b/xbmc/windows/GUIMediaWindow.h
@@ -57,6 +57,8 @@ public:
   virtual bool IsFiltered();
   virtual bool IsSameStartFolder(const std::string &dir);
 
+  virtual std::string GetRootPath() const { return ""; }
+
   const CFileItemList &CurrentDirectory() const;
   const CGUIViewState *GetViewState() const;
 
@@ -69,7 +71,7 @@ protected:
 
   // custom methods
   virtual void SetupShares();
-  virtual void GoParentFolder();
+  virtual bool GoParentFolder();
   virtual bool OnClick(int iItem, const std::string &player = "");
 
   /* \brief React to a "Select" action on an item in a view.


### PR DESCRIPTION
This basically a workaround to allows using real VFS path as roots in media windows instead of the current workaround of using media sources to emulate it. This is the cause for a lot of performance issues gui quirks, primarily seen in the addon browser.

By using the VFS it will behave as a regular directory without special 'sources' root node.
