### PR TITLE
[gui] refactor string and integer comparison boolean conditions

### DIFF
--- a/xbmc/guiinfo/GUIInfoLabels.h
+++ b/xbmc/guiinfo/GUIInfoLabels.h
@@ -331,11 +331,23 @@
 #define VISUALISATION_HAS_PRESETS   404
 
 #define STRING_IS_EMPTY             410
-#define STRING_COMPARE              411
-#define STRING_STR                  412
-#define INTEGER_GREATER_THAN        413
-#define STRING_STR_LEFT             414
-#define STRING_STR_RIGHT            415
+#define STRING_IS_EQUAL             411
+#define STRING_STARTS_WITH          412
+#define STRING_ENDS_WITH            413
+#define STRING_CONTAINS             414
+// deprecated begin
+// should be removed before L*** v18
+#define STRING_COMPARE              415
+#define STRING_STR                  416
+#define STRING_STR_LEFT             418
+#define STRING_STR_RIGHT            419
+// deprecated end
+
+#define INTEGER_IS_EQUAL            450
+#define INTEGER_GREATER_THAN        451
+#define INTEGER_GREATER_OR_EQUAL    452
+#define INTEGER_LESS_THAN           453
+#define INTEGER_LESS_OR_EQUAL       454
 
 #define SKIN_BOOL                   600
 #define SKIN_STRING                 601


### PR DESCRIPTION
This PR refactors the handling of our boolean conditions for strings and integers. It adds two new namespaces `String` and `Integer` to separate them like we do on other boolean conditions. I'm leaving the old boolean conditions in for backward compatibility reason but mark them as deprecated.

**New boolean conditions for strings**

```
String.IsEmpty(str)
String.IsEqual(str1,str2)
String.StartsWith(str,substring)
String.EndsWith(str,substring)
String.Contains(str,substring)
```

**New boolean conditions for integers**

```
Integer.IsEqual(argument,integer)
Integer.IsGreater(argument,integer)
Integer.IsGreaterOrEqual(argument,integer)
Integer.IsLess(argument,integer)
Integer.IsLessOrEqual(argument,integer)
```

@phil65 @ronie @BigNoid @HitcherUK
@tamland for a review of the code part, thank you again already ;)
