### PR TITLE
Fix covery issues from Controller Input PR

### DIFF
--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -56,17 +56,6 @@
 #include "utils/XBMCTinyXML.h"
 #include "ServiceBroker.h"
 
-#ifdef HAS_VISUALISATION
-#include "Visualisation.h"
-#endif
-#ifdef HAS_SCREENSAVER
-#include "ScreenSaver.h"
-#endif
-
-#include "addons/PVRClient.h"
-#include "games/controllers/Controller.h"
-#include "peripherals/addons/PeripheralAddon.h"
-
 using namespace XFILE;
 
 namespace ADDON

--- a/xbmc/games/controllers/windows/GUIControllerList.cpp
+++ b/xbmc/games/controllers/windows/GUIControllerList.cpp
@@ -188,7 +188,7 @@ bool CGUIControllerList::RefreshControllers(void)
       [controller](const ControllerPtr& ctrl)
       {
         return ctrl->ID() == controller->ID();
-      }) == newControllers.end())
+      }) == controllers.end())
     {
       it = m_controllers.erase(it); // Not found, remove it
       bChanged = true;

--- a/xbmc/peripherals/addons/AddonButtonMapping.cpp
+++ b/xbmc/peripherals/addons/AddonButtonMapping.cpp
@@ -27,12 +27,7 @@
 using namespace JOYSTICK;
 using namespace PERIPHERALS;
 
-#ifndef SAFE_DELETE
-  #define SATE_DELETE(x)  do { delete (x); (x) = NULL; } while (0)
-#endif
-
 CAddonButtonMapping::CAddonButtonMapping(CPeripheral* peripheral, IButtonMapper* mapper)
-  : m_driverHandler(NULL)
 {
   PeripheralAddonPtr addon = g_peripherals.GetAddon(peripheral);
 
@@ -42,18 +37,18 @@ CAddonButtonMapping::CAddonButtonMapping(CPeripheral* peripheral, IButtonMapper*
   }
   else
   {
-    m_buttonMap = new CAddonButtonMap(peripheral, addon, mapper->ControllerID());
+    m_buttonMap.reset(new CAddonButtonMap(peripheral, addon, mapper->ControllerID()));
     if (m_buttonMap->Load())
-      m_driverHandler = new CButtonMapping(mapper, m_buttonMap);
+      m_driverHandler.reset(new CButtonMapping(mapper, m_buttonMap.get()));
     else
-      SAFE_DELETE(m_buttonMap);
+      m_buttonMap.reset();
   }
 }
 
 CAddonButtonMapping::~CAddonButtonMapping(void)
 {
-  delete m_driverHandler;
-  delete m_buttonMap;
+  m_driverHandler.reset();
+  m_buttonMap.reset();
 }
 
 bool CAddonButtonMapping::OnButtonMotion(unsigned int buttonIndex, bool bPressed)

--- a/xbmc/peripherals/addons/AddonButtonMapping.h
+++ b/xbmc/peripherals/addons/AddonButtonMapping.h
@@ -21,6 +21,8 @@
 
 #include "input/joysticks/IDriverHandler.h"
 
+#include <memory>
+
 namespace JOYSTICK
 {
   class IButtonMap;
@@ -45,7 +47,7 @@ namespace PERIPHERALS
     virtual void ProcessAxisMotions(void) override;
 
   private:
-    JOYSTICK::IDriverHandler* m_driverHandler;
-    JOYSTICK::IButtonMap*     m_buttonMap;
+    std::unique_ptr<JOYSTICK::IDriverHandler> m_driverHandler;
+    std::unique_ptr<JOYSTICK::IButtonMap>     m_buttonMap;
   };
 }

--- a/xbmc/peripherals/addons/AddonInputHandling.cpp
+++ b/xbmc/peripherals/addons/AddonInputHandling.cpp
@@ -27,12 +27,7 @@
 using namespace JOYSTICK;
 using namespace PERIPHERALS;
 
-#ifndef SAFE_DELETE
-  #define SATE_DELETE(x)  do { delete (x); (x) = NULL; } while (0)
-#endif
-
 CAddonInputHandling::CAddonInputHandling(CPeripheral* peripheral, IInputHandler* handler)
-  : m_driverHandler(NULL)
 {
   PeripheralAddonPtr addon = g_peripherals.GetAddon(peripheral);
 
@@ -42,18 +37,18 @@ CAddonInputHandling::CAddonInputHandling(CPeripheral* peripheral, IInputHandler*
   }
   else
   {
-    m_buttonMap = new CAddonButtonMap(peripheral, addon, handler->ControllerID());
+    m_buttonMap.reset(new CAddonButtonMap(peripheral, addon, handler->ControllerID()));
     if (m_buttonMap->Load())
-      m_driverHandler = new CInputHandling(handler, m_buttonMap);
+      m_driverHandler.reset(new CInputHandling(handler, m_buttonMap.get()));
     else
-      SAFE_DELETE(m_buttonMap);
+      m_buttonMap.reset();
   }
 }
 
 CAddonInputHandling::~CAddonInputHandling(void)
 {
-  delete m_driverHandler;
-  delete m_buttonMap;
+  m_driverHandler.reset();
+  m_buttonMap.reset();
 }
 
 bool CAddonInputHandling::OnButtonMotion(unsigned int buttonIndex, bool bPressed)

--- a/xbmc/peripherals/addons/AddonInputHandling.h
+++ b/xbmc/peripherals/addons/AddonInputHandling.h
@@ -21,6 +21,8 @@
 
 #include "input/joysticks/IDriverHandler.h"
 
+#include <memory>
+
 namespace JOYSTICK
 {
   class IButtonMap;
@@ -45,7 +47,7 @@ namespace PERIPHERALS
     virtual void ProcessAxisMotions(void) override;
 
   private:
-    JOYSTICK::IDriverHandler* m_driverHandler;
-    JOYSTICK::IButtonMap*     m_buttonMap;
+    std::unique_ptr<JOYSTICK::IDriverHandler> m_driverHandler;
+    std::unique_ptr<JOYSTICK::IButtonMap>     m_buttonMap;
   };
 }


### PR DESCRIPTION
Coverty also reported the following issues that I can't find a fix for:

MY CODE (controller input PR):

```
________________________________________________________________________________________________________
*** CID 1355590:  Performance inefficiencies  (PASS_BY_VALUE)
/xbmc/games/controllers/Controller.cpp: 32 in GAME::CController::FromExtension(ADDON::AddonProps, const cp_extension_t *)()
26     #include "utils/XBMCTinyXML.h"
27
28     using namespace GAME;
29
30     const ControllerPtr CController::EmptyPtr;
31
>>>     CID 1355590:  Performance inefficiencies  (PASS_BY_VALUE)
>>>     Passing parameter props of type "ADDON::AddonProps" (size 352 bytes) by value.
32     std::unique_ptr<CController> CController::FromExtension(ADDON::AddonProps props, const cp_extension_t* ext)
33     {
34       return std::unique_ptr<CController>(new CController(std::move(props)));
35     }
36
37     CController::CController(ADDON::AddonProps addonprops) :


________________________________________________________________________________________________________
*** CID 1355589:  Performance inefficiencies  (PASS_BY_VALUE)
/xbmc/games/controllers/Controller.cpp: 37 in GAME::CController::CController(ADDON::AddonProps)()
31
32     std::unique_ptr<CController> CController::FromExtension(ADDON::AddonProps props, const cp_extension_t* ext)
33     {
34       return std::unique_ptr<CController>(new CController(std::move(props)));
35     }
36
>>>     CID 1355589:  Performance inefficiencies  (PASS_BY_VALUE)
>>>     Passing parameter addonprops of type "ADDON::AddonProps" (size 352 bytes) by value.
37     CController::CController(ADDON::AddonProps addonprops) :
38       CAddon(std::move(addonprops)),
39       m_bLoaded(false)
40     {
41     }
42


________________________________________________________________________________________________________
*** CID 1355588:  Performance inefficiencies  (PASS_BY_VALUE)
/xbmc/peripherals/addons/PeripheralAddon.cpp: 50 in PERIPHERALS::CPeripheralAddon::FromExtension(ADDON::AddonProps, const cp_extension_t *)()
44     using namespace XFILE;
45
46     #ifndef SAFE_DELETE
47       #define SAFE_DELETE(p)  do { delete (p); (p) = NULL; } while (0)
48     #endif
49
>>>     CID 1355588:  Performance inefficiencies  (PASS_BY_VALUE)
>>>     Passing parameter props of type "ADDON::AddonProps" (size 352 bytes) by value.
50     std::unique_ptr<CPeripheralAddon> CPeripheralAddon::FromExtension(ADDON::AddonProps props, const cp_extension_t* ext)
51     {
52       std::string strProvidesJoysticks = ADDON::CAddonMgr::GetInstance().GetExtValue(ext->configuration, "@provides_joysticks");
53       std::string strProvidesButtonMaps = ADDON::CAddonMgr::GetInstance().GetExtValue(ext->configuration, "@provides_buttonmaps");
54
55       bool bProvidesJoysticks = StringUtils::EqualsNoCase(strProvidesJoysticks, "true");


________________________________________________________________________________________________________
*** CID 1355587:  Performance inefficiencies  (PASS_BY_VALUE)
/xbmc/peripherals/addons/PeripheralAddon.cpp: 61 in PERIPHERALS::CPeripheralAddon::CPeripheralAddon(ADDON::AddonProps, bool, bool)()
55       bool bProvidesJoysticks = StringUtils::EqualsNoCase(strProvidesJoysticks, "true");
56       bool bProvidesButtonMaps = StringUtils::EqualsNoCase(strProvidesButtonMaps, "true");
57
58       return std::unique_ptr<CPeripheralAddon>(new CPeripheralAddon(std::move(props), bProvidesJoysticks, bProvidesButtonMaps));
59     }
60
>>>     CID 1355587:  Performance inefficiencies  (PASS_BY_VALUE)
>>>     Passing parameter props of type "ADDON::AddonProps" (size 352 bytes) by value.
61     CPeripheralAddon::CPeripheralAddon(ADDON::AddonProps props, bool bProvidesJoysticks, bool bProvidesButtonMaps) :
62       CAddonDll<DllPeripheral, PeripheralAddon, PERIPHERAL_PROPERTIES>(std::move(props)),
63       m_apiVersion("0.0.0"),
64       m_bProvidesJoysticks(bProvidesJoysticks),
65       m_bProvidesButtonMaps(bProvidesButtonMaps)
66     {

** CID 1355585:  Control flow issues  (DEADCODE)
/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamMultiSource.cpp: 112 in CInputStreamMultiSource::NextStream()()



________________________________________________________________________________________________________
*** CID 1355584:  Control flow issues  (DEADCODE)
/xbmc/addons/AddonBuilder.cpp: 140 in ADDON::CAddonBuilder::Build()()
134             return CAudioDecoder::FromExtension(std::move(m_props), m_extPoint);
135           else if (type == ADDON_INPUTSTREAM)
136             return CInputStream::FromExtension(std::move(m_props), m_extPoint);
137           else if (type == ADDON_SCREENSAVER)
138             return std::make_shared<CScreenSaver>(std::move(m_props));
139           else if (type == ADDON_PERIPHERALDLL)
>>>     CID 1355584:  Control flow issues  (DEADCODE)
>>>     Execution cannot reach the expression "~unique_ptr" inside this statement: "<temporary>.~unique_ptr();".
140             return PERIPHERALS::CPeripheralAddon::FromExtension(std::move(m_props), m_extPoint);
141           break;
142         }
143         case ADDON_SKIN:
144           return CSkinInfo::FromExtension(std::move(m_props), m_extPoint);
145         case ADDON_RESOURCE_IMAGES:
```

OTHER CODE:

```
________________________________________________________________________________________________________
*** CID 1355585:  Control flow issues  (DEADCODE)
/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamMultiSource.cpp: 112 in CInputStreamMultiSource::NextStream()()
106         if (next != NEXTSTREAM_NONE)
107           return next;
108       }
109       if (!eOF)
110         return NEXTSTREAM_RETRY;
111
>>>     CID 1355585:  Control flow issues  (DEADCODE)
>>>     Execution cannot reach this statement: "return CDVDInputStream::NEX...".
112       return NEXTSTREAM_NONE;
113     }
114
115     bool CInputStreamMultiSource::Open()
116     {


________________________________________________________________________________________________________
*** CID 1355583:  Error handling issues  (CHECKED_RETURN)
/xbmc/input/InputCodingTableBaiduPY.cpp: 50 in CInputCodingTableBaiduPY::Process()()
44
45     void CInputCodingTableBaiduPY::Process()
46     {
47       m_initialized = true;
48       while (!m_bStop) //Make sure we don't exit the thread
49       {
>>>     CID 1355583:  Error handling issues  (CHECKED_RETURN)
>>>     Calling "AbortableWait" without checking return value (as is done elsewhere 8 out of 10 times).
50         AbortableWait(m_Event, -1); //Wait for work to appear
51         while (!m_bStop) //Process all queued work before going back to wait on the event
52         {
53           CSingleLock lock(m_CS);
54           if (m_work.empty())
55             break;


________________________________________________________________________________________________________
*** CID 1288117:  Error handling issues  (CHECKED_RETURN)
/xbmc/filesystem/RarFile.cpp: 62 in XFILE::CRarFileExtractThread::~CRarFileExtractThread()()
56       Create();
57     }
58
59     CRarFileExtractThread::~CRarFileExtractThread()
60     {
61       hQuit.Set();
>>>     CID 1288117:  Error handling issues  (CHECKED_RETURN)
>>>     Calling "AbortableWait" without checking return value (as is done elsewhere 8 out of 10 times).
62       AbortableWait(hRestart);
63       StopThread();
64     }
65
66     void CRarFileExtractThread::Start(Archive* pArc, CommandData* pCmd, CmdExtract* pExtract, int iSize)
67     {



________________________________________________________________________________________________________
*** CID 1228822:  Error handling issues  (CHECKED_RETURN)
/xbmc/utils/ScraperParser.cpp: 458 in CScraperParser::Parse(const std::basic_string<char, std::char_traits<char>, std::allocator<char>>&, ADDON::CScraper *)()
452       if(pChildElement == NULL)
453       {
454         CLog::Log(LOGERROR,"%s: Could not find scraper function %s",__FUNCTION__,strTag.c_str());
455         return "";
456       }
457       int iResult = 1; // default to param 1
>>>     CID 1228822:  Error handling issues  (CHECKED_RETURN)
>>>     Calling "QueryIntAttribute" without checking return value (as is done elsewhere 12 out of 15 times).
458       pChildElement->QueryIntAttribute("dest",&iResult);
459       TiXmlElement* pChildStart = FirstChildScraperElement(pChildElement);
460       m_scraper = scraper;
461       ParseNext(pChildStart);
462       std::string tmp = m_param[iResult-1];
463
```
