### PR TITLE
[aml] add rendercapture

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderCapture.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderCapture.cpp
@@ -130,6 +130,60 @@ void CRenderCaptureDispmanX::ReadOut()
 {
 }
 
+#elif defined(HAS_LIBAMCODEC)
+
+CRenderCaptureAml::CRenderCaptureAml()
+{
+  if (amcodec_runing())
+    m_pVideoCap = new CAmVideoCap();
+}
+
+CRenderCaptureAml::~CRenderCaptureAml()
+{
+  delete[] m_pixels;
+  if (amcodec_runing())
+    delete m_pVideoCap;
+}
+
+int CRenderCaptureAml::GetCaptureFormat()
+{
+  return CAPTUREFORMAT_BGRA;
+}
+
+void CRenderCaptureAml::BeginRender()
+{
+  if (m_bufferSize != m_width * m_height * 4)
+  {
+    m_bufferSize = m_width * m_height * 4;
+    delete[] m_pixels;
+    m_pixels = new uint8_t[m_bufferSize];
+  }
+
+  if (amcodec_runing())
+  {
+    if (m_pVideoCap->CaptureVideoFrame(m_width, m_height, m_pixels))
+      SetState(CAPTURESTATE_DONE);
+    else
+      SetState(CAPTURESTATE_FAILED);
+  }
+}
+
+void CRenderCaptureAml::EndRender()
+{
+  if (amcodec_runing())
+    m_pVideoCap->CancelCapture();
+  SetState(CAPTURESTATE_DONE);
+}
+
+void* CRenderCaptureAml::GetRenderBuffer()
+{
+  return m_pixels;
+}
+
+void CRenderCaptureAml::ReadOut()
+{
+}
+
 #elif defined(HAS_GL) || defined(HAS_GLES)
 
 CRenderCaptureGL::CRenderCaptureGL()

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderCapture.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderCapture.h
@@ -164,6 +164,35 @@ class CRenderCapture : public CRenderCaptureDispmanX
     CRenderCapture() {};
 };
 
+#elif defined(HAS_LIBAMCODEC)
+#include "xbmc/linux/AmVideoCap.h"
+#include "xbmc/utils/AMLUtils.h"
+
+class CRenderCaptureAml : public CRenderCaptureBase
+{
+  public:
+    CRenderCaptureAml();
+    ~CRenderCaptureAml();
+
+    int   GetCaptureFormat();
+
+    void  BeginRender();
+    void  EndRender();
+    void  ReadOut();
+
+    void* GetRenderBuffer();
+  private:
+    CAmVideoCap *m_pVideoCap;
+};
+
+//used instead of typedef CRenderCaptureGL CRenderCapture
+//since C++ doesn't allow you to forward declare a typedef
+class CRenderCapture : public CRenderCaptureAml
+{
+  public:
+    CRenderCapture() {};
+};
+
 #elif defined(HAS_GL) || defined(HAS_GLES)
 #include "system_gl.h"
 

--- a/xbmc/linux/AmVideoCap.cpp
+++ b/xbmc/linux/AmVideoCap.cpp
@@ -1,0 +1,88 @@
+/*
+ *      Copyright (C) 2015 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Kodi; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "system.h"
+#if defined(HAS_LIBAMCODEC)
+#include "AmVideoCap.h"
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+#include <sys/ioctl.h>
+
+// taken from linux/amlogic/amports/amvideocap.h - needs to be synced - no changes expected though
+#define AMVIDEOCAP_IOC_MAGIC  'V'
+#define AMVIDEOCAP_IOW_SET_WANTFRAME_WIDTH      _IOW(AMVIDEOCAP_IOC_MAGIC, 0x02, int)
+#define AMVIDEOCAP_IOW_SET_WANTFRAME_HEIGHT     _IOW(AMVIDEOCAP_IOC_MAGIC, 0x03, int)
+#define AMVIDEOCAP_IOW_SET_CANCEL_CAPTURE       _IOW(AMVIDEOCAP_IOC_MAGIC, 0x33, int)
+
+#define CAPTURE_DEVICEPATH "/dev/amvideocap0"
+
+CAmVideoCap::CAmVideoCap()
+{
+  m_deviceOpen = false;
+}
+
+CAmVideoCap::~CAmVideoCap()
+{
+  if (m_deviceOpen)
+    close(m_captureFd);
+  m_deviceOpen = false;
+}
+
+bool CAmVideoCap::CaptureVideoFrame(int destWidth, int destHeight, unsigned char *pixels)
+{
+  int buffSize = destWidth * destHeight * 3;
+  int readSize = 0;
+  unsigned char *videoBuffer = new unsigned char[buffSize];
+
+  if (!m_deviceOpen)
+  {
+    m_captureFd = open(CAPTURE_DEVICEPATH, O_RDWR, 0);
+    if (m_captureFd >= 0)
+      fcntl(m_captureFd, F_SETFL, fcntl(m_captureFd, F_GETFL) | O_NONBLOCK);
+  }
+
+  if (m_captureFd >= 0)
+  {
+    m_deviceOpen = true;
+    // configure destination
+    ioctl(m_captureFd, AMVIDEOCAP_IOW_SET_WANTFRAME_WIDTH, destWidth);
+    ioctl(m_captureFd, AMVIDEOCAP_IOW_SET_WANTFRAME_HEIGHT, destHeight);
+    readSize = pread(m_captureFd, videoBuffer, buffSize, 0);
+
+    unsigned char *videoPtr = videoBuffer;
+    for (int processedBytes = 0; processedBytes < buffSize; processedBytes += 3, pixels+=4)
+    {
+      memcpy(pixels, videoPtr, 3);
+      videoPtr += 3;
+    }
+  }
+  delete [] videoBuffer;
+  return readSize == buffSize;
+}
+
+void CAmVideoCap::CancelCapture()
+{
+  if (m_deviceOpen)
+    ioctl(m_captureFd, AMVIDEOCAP_IOW_SET_CANCEL_CAPTURE, NULL);
+}
+
+#endif //defined(HAS_LIBAMCODEC)

--- a/xbmc/linux/AmVideoCap.h
+++ b/xbmc/linux/AmVideoCap.h
@@ -1,0 +1,40 @@
+/*
+ *      Copyright (C) 2015 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Kodi; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef AMVIDEOCAP_H_
+#define AMVIDEOCAP_H_
+#if defined(HAS_LIBAMCODEC)
+
+class CAmVideoCap
+{
+  public:
+    CAmVideoCap();
+    ~CAmVideoCap();
+
+    bool CaptureVideoFrame(int destWidth, int destHeight, unsigned char *pixels);
+    void CancelCapture();
+
+  private:
+    int m_captureFd;
+    bool m_deviceOpen;
+    int m_bufferSize;
+};
+#endif //defined(HAS_LIBAMCODEC)
+#endif //AMVIDEOCAP_H_

--- a/xbmc/linux/CMakeLists.txt
+++ b/xbmc/linux/CMakeLists.txt
@@ -1,4 +1,5 @@
-set(SOURCES ConvUtils.cpp
+set(SOURCES AmVideoCap.cpp
+            ConvUtils.cpp
             DBusMessage.cpp
             DBusReserve.cpp
             DBusUtil.cpp
@@ -12,7 +13,8 @@ set(SOURCES ConvUtils.cpp
             XMemUtils.cpp
             XTimeUtils.cpp)
 
-set(HEADERS ConvUtils.h
+set(HEADERS AmVideoCap.h
+            ConvUtils.h
             DBusMessage.h
             DBusReserve.h
             DBusUtil.h

--- a/xbmc/linux/Makefile.in
+++ b/xbmc/linux/Makefile.in
@@ -20,6 +20,10 @@ SRCS += OMXClock.cpp
 SRCS += OMXCore.cpp
 endif
 
+ifeq (@USE_LIBAMCODEC@,1)
+SRCS += AmVideoCap.cpp
+endif
+
 LIB = linux.a
 
 include @abs_top_srcdir@/Makefile.include

--- a/xbmc/utils/AMLUtils.cpp
+++ b/xbmc/utils/AMLUtils.cpp
@@ -536,3 +536,23 @@ bool aml_mode_to_resolution(const char *mode, RESOLUTION_INFO *res)
   return res->iWidth > 0 && res->iHeight> 0;
 }
 
+// dirty hack to check if amcodec is runing
+// TODO: remove when rendercapture gets easy access to codec info
+bool amcodec_runing()
+{
+  int fd = open("/sys/class/tsync/pts_video", O_RDONLY);
+  if (fd >= 0)
+  {
+    char pts_str[16];
+    int size = read(fd, pts_str, sizeof(pts_str));
+    close(fd);
+    if (size > 0)
+    {
+      unsigned long pts = strtoul(pts_str, NULL, 16);
+      if (pts > 0)
+        return true;
+    }
+  }
+
+  return false;
+}

--- a/xbmc/utils/AMLUtils.h
+++ b/xbmc/utils/AMLUtils.h
@@ -51,3 +51,4 @@ bool aml_support_h264_4k2k();
 void aml_set_audio_passthrough(bool passthrough);
 bool aml_IsHdmiConnected();
 bool aml_mode_to_resolution(const char *mode, RESOLUTION_INFO *res);
+bool amcodec_runing();


### PR DESCRIPTION
this implements rendercapture for amlogic.

I could pull few defines from ge2d.h and ask amvidecap for GE2D_FORMAT_S32_ARGB, and avoid a conversion, that works for me, but reserved memory for all boxes I've seen is fb width \* height \* 3 so I am not sure it is good idea

@Memphiz for review, after this your boblight-aml client is not needed anymore. most of it is your code anyway ;)
