### PR TITLE
[guilib] Resolution::FindClosestResolution: don't switch between scre…

### DIFF
--- a/xbmc/guilib/Resolution.cpp
+++ b/xbmc/guilib/Resolution.cpp
@@ -227,7 +227,8 @@ RESOLUTION CResolutionUtils::FindClosestResolution(float fps, int width, bool is
       if ((width < orig.iScreenWidth) || // orig res large enough
          (info.iScreenWidth < orig.iScreenWidth) || // new res is smaller
          (info.iScreenHeight < orig.iScreenHeight) || // new height would be smaller
-         (info.dwFlags & D3DPRESENTFLAG_MODEMASK) != (curr.dwFlags & D3DPRESENTFLAG_MODEMASK)) // don't switch to interlaced modes
+         (info.dwFlags & D3DPRESENTFLAG_MODEMASK) != (curr.dwFlags & D3DPRESENTFLAG_MODEMASK) || // don't switch to interlaced modes
+         (info.iScreen != curr.iScreen)) // skip not current displays
       {
         continue;
       }


### PR DESCRIPTION
…ens.

In some cases FindClosestResolution may select resolution on different display.

@FernetMenta @fritsch ping
