### PR TITLE
[addon] fix cmake install for kodi_peripheral_*

### DIFF
--- a/project/cmake/installdata/addon-bindings.txt
+++ b/project/cmake/installdata/addon-bindings.txt
@@ -13,10 +13,10 @@ xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_epg_types.h
 xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_inputstream_dll.h
 xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_inputstream_types.h
 xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_vfs_types.h
-xbmc/addons/kodi-addon-dev-kit/include/kodi_peripheral_callbacks.h
-xbmc/addons/kodi-addon-dev-kit/include/kodi_peripheral_dll.h
-xbmc/addons/kodi-addon-dev-kit/include/kodi_peripheral_types.h
-xbmc/addons/kodi-addon-dev-kit/include/kodi_peripheral_utils.hpp
+xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_callbacks.h
+xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_dll.h
+xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_types.h
+xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_utils.hpp
 xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_dll.h
 xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
 xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_scr_dll.h


### PR DESCRIPTION
fix the wrong header path for cmake's install.
