### PR TITLE
addons: add kodi.game.controller to system add-ons

### DIFF
--- a/system/addon-manifest.xml
+++ b/system/addon-manifest.xml
@@ -1,10 +1,13 @@
 <addons>
   <addon>audioencoder.xbmc.builtin.aac</addon>
   <addon>audioencoder.xbmc.builtin.wma</addon>
+  <addon>game.controller.default</addon>
   <addon>kodi.adsp</addon>
   <addon>kodi.audiodecoder</addon>
+  <addon>kodi.game</addon>
   <addon>kodi.guilib</addon>
   <addon>kodi.inputstream</addon>
+  <addon>kodi.peripheral</addon>
   <addon>kodi.resource</addon>
   <addon>metadata.album.universal</addon>
   <addon>metadata.artists.universal</addon>


### PR DESCRIPTION
Because i saw #9373 and it looked like a good idea

Should the same be done for peripheral.joystick?
