### PR TITLE
addons: Fix segfault on shutdown

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2793,6 +2793,8 @@ bool CApplication::Cleanup()
   {
     g_windowManager.DestroyWindows();
 
+    m_binaryAddonCache.Deinit();
+
     CAddonMgr::GetInstance().DeInit();
 
     CLog::Log(LOGNOTICE, "closing down remote control service");

--- a/xbmc/addons/BinaryAddonCache.cpp
+++ b/xbmc/addons/BinaryAddonCache.cpp
@@ -27,7 +27,7 @@ namespace ADDON
 
 CBinaryAddonCache::~CBinaryAddonCache()
 {
-  CAddonMgr::GetInstance().UnregisterObserver(this);
+  Deinit();
 }
 
 void CBinaryAddonCache::Init()
@@ -35,6 +35,11 @@ void CBinaryAddonCache::Init()
   m_addonsToCache = {ADDON_AUDIODECODER, ADDON_INPUTSTREAM};
   CAddonMgr::GetInstance().RegisterObserver(this);
   Update();
+}
+
+void CBinaryAddonCache::Deinit()
+{
+  CAddonMgr::GetInstance().UnregisterObserver(this);
 }
 
 void CBinaryAddonCache::GetAddons(VECADDONS& addons, const TYPE& type)

--- a/xbmc/addons/BinaryAddonCache.h
+++ b/xbmc/addons/BinaryAddonCache.h
@@ -33,6 +33,7 @@ class CBinaryAddonCache : public Observer
 public:
   virtual ~CBinaryAddonCache();
   void Init();
+  void Deinit();
   void GetAddons(VECADDONS& addons, const TYPE& type);
   virtual void Notify(const Observable &obs, const ObservableMessage msg) override;
 


### PR DESCRIPTION
Fixes #9362 when add-on cache is destructed way too late
