### PR TITLE
context menu cleanup after #9257

### DIFF
--- a/xbmc/ContextMenuItem.cpp
+++ b/xbmc/ContextMenuItem.cpp
@@ -46,11 +46,15 @@ bool CContextMenuItem::IsGroup() const
 
 bool CContextMenuItem::Execute(const CFileItemPtr& item) const
 {
-  if (!item || !m_addon || m_library.empty() || IsGroup())
+  if (!item || m_library.empty() || IsGroup())
+    return false;
+
+  ADDON::AddonPtr addon;
+  if (!ADDON::CAddonMgr::GetInstance().GetAddon(m_addonId, addon))
     return false;
 
   LanguageInvokerPtr invoker(new CContextItemAddonInvoker(&g_pythonParser, item));
-  return (CScriptInvocationManager::GetInstance().ExecuteAsync(m_library, invoker, m_addon) != -1);
+  return (CScriptInvocationManager::GetInstance().ExecuteAsync(m_library, invoker, addon) != -1);
 }
 
 bool CContextMenuItem::operator==(const CContextMenuItem& other) const
@@ -61,34 +65,38 @@ bool CContextMenuItem::operator==(const CContextMenuItem& other) const
   return (IsGroup() == other.IsGroup())
       && (m_parent == other.m_parent)
       && (m_library == other.m_library)
-      && ((!m_addon && !other.m_addon) || (m_addon && other.m_addon && m_addon->ID() == other.m_addon->ID()));
+      && (m_addonId == other.m_addonId);
 }
 
 std::string CContextMenuItem::ToString() const
 {
   if (IsGroup())
     return StringUtils::Format("CContextMenuItem[group, id=%s, parent=%s, addon=%s]",
-        m_groupId.c_str(), m_parent.c_str(), m_addon ? m_addon->ID().c_str() : "null");
+        m_groupId.c_str(), m_parent.c_str(), m_addonId.c_str());
   else
     return StringUtils::Format("CContextMenuItem[item, parent=%s, library=%s, addon=%s]",
-        m_parent.c_str(), m_library.c_str(), m_addon ? m_addon->ID().c_str() : "null");
+        m_parent.c_str(), m_library.c_str(), m_addonId.c_str());
 }
 
-CContextMenuItem CContextMenuItem::CreateGroup(const std::string& label, const std::string& parent, const std::string& groupId)
+CContextMenuItem CContextMenuItem::CreateGroup(const std::string& label, const std::string& parent,
+    const std::string& groupId, const std::string& addonId)
 {
   CContextMenuItem menuItem;
   menuItem.m_label = label;
   menuItem.m_parent = parent;
   menuItem.m_groupId = groupId;
+  menuItem.m_addonId = addonId;
   return menuItem;
 }
 
-CContextMenuItem CContextMenuItem::CreateItem(const std::string& label, const std::string& parent, const std::string& library, const INFO::InfoPtr& condition)
+CContextMenuItem CContextMenuItem::CreateItem(const std::string& label, const std::string& parent,
+    const std::string& library, const INFO::InfoPtr& condition, const std::string& addonId)
 {
   CContextMenuItem menuItem;
   menuItem.m_label = label;
   menuItem.m_parent = parent;
   menuItem.m_library = library;
   menuItem.m_condition = condition;
+  menuItem.m_addonId = addonId;
   return menuItem;
 }

--- a/xbmc/ContextMenuItem.h
+++ b/xbmc/ContextMenuItem.h
@@ -72,13 +72,15 @@ public:
   static CContextMenuItem CreateGroup(
     const std::string& label,
     const std::string& parent,
-    const std::string& groupId);
+    const std::string& groupId,
+    const std::string& addonId);
 
   static CContextMenuItem CreateItem(
     const std::string& label,
     const std::string& parent,
     const std::string& library,
-    const INFO::InfoPtr& condition);
+    const INFO::InfoPtr& condition,
+    const std::string& addonId);
 
   friend class ADDON::CContextMenuAddon;
 
@@ -88,5 +90,5 @@ private:
   std::string m_groupId;
   std::string m_library;
   INFO::InfoPtr m_condition;
-  ADDON::AddonPtr m_addon;
+  std::string m_addonId; // The owner of this menu item
 };

--- a/xbmc/ContextMenuManager.cpp
+++ b/xbmc/ContextMenuManager.cpp
@@ -33,8 +33,8 @@ using namespace ADDON;
 
 typedef std::pair<unsigned int, CContextMenuItem> Item;
 
-const CContextMenuItem CContextMenuManager::MAIN = CContextMenuItem::CreateGroup("", "", "kodi.core.main");
-const CContextMenuItem CContextMenuManager::MANAGE = CContextMenuItem::CreateGroup("", "", "kodi.core.manage");
+const CContextMenuItem CContextMenuManager::MAIN = CContextMenuItem::CreateGroup("", "", "kodi.core.main", "");
+const CContextMenuItem CContextMenuManager::MANAGE = CContextMenuItem::CreateGroup("", "", "kodi.core.manage", "");
 
 
 CContextMenuManager::CContextMenuManager()

--- a/xbmc/ContextMenuManager.h
+++ b/xbmc/ContextMenuManager.h
@@ -42,26 +42,6 @@ public:
   ContextMenuView GetAddonItems(const CFileItem& item, const CContextMenuItem& root = MAIN) const;
 
   /*!
-   * Deprecated.
-   * \param id - id of the context button clicked on.
-   * \param item - the selected file item.
-   * \return true on success, otherwise false.
-   */
-  bool OnClick(unsigned int id, const CFileItemPtr& item);
-
-  /*!
-   * Deprecated.
-   * \brief Adds all registered context item to the list.
-   * \param item - the currently selected item.
-   * \param list - the context menu.
-   * \param root - the context menu responsible for this call.
-   */
-  void AddVisibleItems(
-    const CFileItemPtr& item,
-    CContextButtons& list,
-    const CContextMenuItem& root = MAIN) const;
-
-  /*!
    * \brief Adds a context item to this manager.
    * NOTE: only 'enabled' context addons should be added.
    */
@@ -84,14 +64,9 @@ private:
     const CContextMenuItem& root,
     const CFileItem& fileItem) const;
 
-  /*! Deprecated. */
-  std::vector<std::pair<unsigned int, CContextMenuItem>> GetAddonItemsWithId(const CFileItem& fileItem,
-      const CContextMenuItem& root = CContextMenuManager::MAIN) const;
-
   CCriticalSection m_criticalSection;
-  std::vector<std::pair<unsigned int, CContextMenuItem>> m_addonItems;
+  std::vector<CContextMenuItem> m_addonItems;
   std::vector<std::shared_ptr<IContextMenuItem>> m_items;
-  unsigned int m_nextButtonId;
 };
 
 namespace CONTEXTMENU

--- a/xbmc/addons/ContextMenuAddon.cpp
+++ b/xbmc/addons/ContextMenuAddon.cpp
@@ -52,7 +52,7 @@ void CContextMenuAddon::ParseMenu(
     menuId = ss.str();
   }
 
-  items.push_back(CContextMenuItem::CreateGroup(menuLabel, parent, menuId));
+  items.push_back(CContextMenuItem::CreateGroup(menuLabel, parent, menuId, props.id));
 
   ELEMENTS subMenus;
   if (CAddonMgr::GetInstance().GetExtElements(elem, "menu", subMenus))
@@ -73,7 +73,7 @@ void CContextMenuAddon::ParseMenu(
       if (!label.empty() && !library.empty() && !visCondition.empty())
       {
         auto menu = CContextMenuItem::CreateItem(label, menuId,
-            URIUtils::AddFileToFolder(props.path, library), g_infoManager.Register(visCondition, 0));
+            URIUtils::AddFileToFolder(props.path, library), g_infoManager.Register(visCondition, 0), props.id);
         items.push_back(menu);
       }
     }
@@ -111,7 +111,7 @@ std::unique_ptr<CContextMenuAddon> CContextMenuAddon::FromExtension(AddonProps p
 
       CContextMenuItem menuItem = CContextMenuItem::CreateItem(label, parent,
           URIUtils::AddFileToFolder(props.path, props.libname),
-          g_infoManager.Register(visCondition, 0));
+          g_infoManager.Register(visCondition, 0), props.id);
 
       items.push_back(menuItem);
     }
@@ -125,13 +125,9 @@ CContextMenuAddon::CContextMenuAddon(AddonProps props, std::vector<CContextMenuI
 {
 }
 
-std::vector<CContextMenuItem> CContextMenuAddon::GetItems()
+std::vector<CContextMenuItem> CContextMenuAddon::GetItems() const
 {
-  //Return a copy which owns `this`
-  std::vector<CContextMenuItem> ret = m_items;
-  for (CContextMenuItem& menuItem : ret)
-    menuItem.m_addon = this->shared_from_this();
-  return ret;
+  return m_items;
 }
 
 }

--- a/xbmc/addons/ContextMenuAddon.h
+++ b/xbmc/addons/ContextMenuAddon.h
@@ -37,7 +37,7 @@ namespace ADDON
     explicit CContextMenuAddon(AddonProps props) : CAddon(std::move(props)) {}
     CContextMenuAddon(AddonProps props, std::vector<CContextMenuItem> items);
 
-    std::vector<CContextMenuItem> GetItems();
+    std::vector<CContextMenuItem> GetItems() const;
 
   private:
     static void ParseMenu(const AddonProps& props, cp_cfg_element_t* elem, const std::string& parent,
@@ -46,5 +46,5 @@ namespace ADDON
     std::vector<CContextMenuItem> m_items;
   };
 
-  typedef std::shared_ptr<CContextMenuAddon> ContextItemAddonPtr;
+  typedef std::shared_ptr<const CContextMenuAddon> ContextItemAddonPtr;
 }

--- a/xbmc/dialogs/GUIDialogContextMenu.h
+++ b/xbmc/dialogs/GUIDialogContextMenu.h
@@ -144,10 +144,6 @@ enum CONTEXT_BUTTON { CONTEXT_BUTTON_CANCELLED = 0,
                       CONTEXT_BUTTON_USER8,
                       CONTEXT_BUTTON_USER9,
                       CONTEXT_BUTTON_USER10,
-
-                      //NOTE: this has to be the last in this enum,
-                      //because this one, and the ones higher will be used by context addons
-                      CONTEXT_BUTTON_FIRST_ADDON
                     };
 
 class CContextButtons : public std::vector< std::pair<unsigned int, std::string> >

--- a/xbmc/dialogs/GUIDialogFavourites.cpp
+++ b/xbmc/dialogs/GUIDialogFavourites.cpp
@@ -133,7 +133,12 @@ void CGUIDialogFavourites::OnPopupMenu(int item)
   choices.Add(5, 20019);
 
   CFileItemPtr itemPtr = m_favourites->Get(item);
-  CContextMenuManager::GetInstance().AddVisibleItems(itemPtr, choices);
+
+  //temporary workaround until the context menu ids are removed
+  const int addonItemOffset = 10000;
+  auto addonItems = CContextMenuManager::GetInstance().GetAddonItems(*itemPtr);
+  for (int i = 0; i < addonItems.size(); ++i)
+    choices.Add(addonItemOffset + i, addonItems[i]->GetLabel(*itemPtr));
 
   int button = CGUIDialogContextMenu::ShowAndGetChoice(choices);
 
@@ -150,8 +155,8 @@ void CGUIDialogFavourites::OnPopupMenu(int item)
     OnRename(item);
   else if (button == 5)
     OnSetThumb(item);
-  else if (button >= CONTEXT_BUTTON_FIRST_ADDON)
-    CContextMenuManager::GetInstance().OnClick(button, itemPtr);
+  else if (button >= addonItemOffset)
+    CONTEXTMENU::LoopFrom(*addonItems.at(button - addonItemOffset), itemPtr);
 }
 
 void CGUIDialogFavourites::OnMoveItem(int item, int amount)

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -1035,7 +1035,11 @@ int CGUIDialogVideoInfo::ManageVideoItem(const CFileItemPtr &item)
   if (type != MediaTypeSeason)
     buttons.Add(CONTEXT_BUTTON_DELETE, 646);
 
-  CContextMenuManager::GetInstance().AddVisibleItems(item, buttons, CContextMenuManager::MANAGE);
+  //temporary workaround until the context menu ids are removed
+  const int addonItemOffset = 10000;
+  auto addonItems = CContextMenuManager::GetInstance().GetAddonItems(*item, CContextMenuManager::MANAGE);
+  for (int i = 0; i < addonItems.size(); ++i)
+    buttons.Add(addonItemOffset + i, addonItems[i]->GetLabel(*item));
 
   bool result = false;
   int button = CGUIDialogContextMenu::ShowAndGetChoice(buttons);
@@ -1094,7 +1098,8 @@ int CGUIDialogVideoInfo::ManageVideoItem(const CFileItemPtr &item)
         break;
 
       default:
-        result = CContextMenuManager::GetInstance().OnClick(button, item);
+        if (button >= addonItemOffset)
+          result = CONTEXTMENU::LoopFrom(*addonItems[button - addonItemOffset], item);
         break;
     }
   }


### PR DESCRIPTION
Just some code clean up after myself which removes the remaining 'button id' logic from the manager as it's only used 2 places. Plan is to get rid of the rest once all menus are moved.
