### PR TITLE
[mmal] Add zero copy interface to ffmpeg

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -924,7 +924,7 @@ if test "$use_gles" = "yes"; then
       AC_DEFINE([HAVE_LIBEGL],[1],["Define to 1 if you have the `EGL' library (-lEGL)."])
       AC_DEFINE([HAVE_LIBGLESV2],[1],["Define to 1 if you have the `GLESv2' library (-lGLESv2)."])
       AC_MSG_RESULT(== WARNING: OpenGLES support is assumed.)
-      LIBS="$LIBS -lEGL -lGLESv2 -lbcm_host -lvcos -lvchiq_arm -lmmal -lmmal_core -lmmal_util"
+      LIBS="$LIBS -lEGL -lGLESv2 -lbcm_host -lvcos -lvchiq_arm -lmmal -lmmal_core -lmmal_util -lvcsm"
     else
       AC_CHECK_LIB([EGL],   [main],, AC_MSG_ERROR($missing_library))
       AC_CHECK_LIB([GLESv2],[main],, AC_MSG_ERROR($missing_library))

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/CMakeLists.txt
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/CMakeLists.txt
@@ -54,6 +54,8 @@ endif()
 if(MMAL_FOUND)
   list(APPEND SOURCES MMALCodec.cpp)
   list(APPEND HEADERS MMALCodec.h)
+  list(APPEND SOURCES MMALFFmpeg.cpp)
+  list(APPEND HEADERS MMALFFmpeg.h)
 endif()
 
 if(IMX_FOUND)

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h
@@ -49,7 +49,7 @@ class COpenMaxVideo;
 struct OpenMaxVideoBufferHolder;
 class CDVDMediaCodecInfo;
 class CDVDVideoCodecIMXBuffer;
-class CMMALVideoBuffer;
+class CMMALBuffer;
 class CDVDAmlogicInfo;
 
 
@@ -93,7 +93,7 @@ struct DVDVideoPicture
     };
 
     struct {
-      CMMALVideoBuffer *MMALBuffer;
+      CMMALBuffer *MMALBuffer;
     };
 
     struct {

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
@@ -42,6 +42,7 @@
 #include "cores/VideoPlayer/VideoRenderers/RenderFlags.h"
 #include "settings/DisplaySettings.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderManager.h"
+#include "cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.h"
 #include "settings/AdvancedSettings.h"
 
 #include "linux/RBP.h"
@@ -51,44 +52,25 @@ using namespace KODI::MESSAGING;
 #define CLASSNAME "CMMALVideoBuffer"
 
 CMMALVideoBuffer::CMMALVideoBuffer(CMMALVideo *omv)
-    : m_omv(omv), m_refs(0)
+    : m_omv(omv)
 {
   if (g_advancedSettings.CanLogComponent(LOGVIDEO))
     CLog::Log(LOGDEBUG, "%s::%s %p", CLASSNAME, __func__, this);
   mmal_buffer = NULL;
-  width = 0;
-  height = 0;
+  m_width = 0;
+  m_height = 0;
+  m_aligned_width = 0;
+  m_aligned_height = 0;
   m_aspect_ratio = 0.0f;
+  m_refs = 0;
 }
 
 CMMALVideoBuffer::~CMMALVideoBuffer()
 {
+  if (mmal_buffer)
+    mmal_buffer_header_release(mmal_buffer);
   if (g_advancedSettings.CanLogComponent(LOGVIDEO))
     CLog::Log(LOGDEBUG, "%s::%s %p", CLASSNAME, __func__, this);
-}
-
-
-CMMALVideoBuffer* CMMALVideoBuffer::Acquire()
-{
-  long count = AtomicIncrement(&m_refs);
-  if (g_advancedSettings.CanLogComponent(LOGVIDEO))
-    CLog::Log(LOGDEBUG, "%s::%s %p (%p) ref:%ld", CLASSNAME, __func__, this, mmal_buffer, count);
-  (void)count;
-  return this;
-}
-
-long CMMALVideoBuffer::Release()
-{
-  long count = AtomicDecrement(&m_refs);
-  if (g_advancedSettings.CanLogComponent(LOGVIDEO))
-    CLog::Log(LOGDEBUG, "%s::%s %p (%p) ref:%ld", CLASSNAME, __func__, this, mmal_buffer, count);
-  if (count == 0)
-  {
-    mmal_buffer_header_release(mmal_buffer);
-    delete this;
-  }
-  else assert(count > 0);
-  return count;
 }
 
 #undef CLASSNAME
@@ -101,6 +83,8 @@ CMMALVideo::CMMALVideo(CProcessInfo &processInfo) : CDVDVideoCodec(processInfo)
 
   m_decoded_width = 0;
   m_decoded_height = 0;
+  m_decoded_aligned_width = 0;
+  m_decoded_aligned_height = 0;
 
   m_finished = false;
   m_pFormatName = "mmal-xxxx";
@@ -114,7 +98,7 @@ CMMALVideo::CMMALVideo(CProcessInfo &processInfo) : CDVDVideoCodec(processInfo)
   m_dec_input = NULL;
   m_dec_output = NULL;
   m_dec_input_pool = NULL;
-  m_vout_input_pool = NULL;
+  m_renderer = NULL;
 
   m_deint = NULL;
   m_deint_connection = NULL;
@@ -188,11 +172,13 @@ void CMMALVideo::PortSettingsChanged(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *bu
       m_aspect_ratio = (float)(m_es_format->es->video.par.num * m_es_format->es->video.crop.width) / (m_es_format->es->video.par.den * m_es_format->es->video.crop.height);
     m_decoded_width = m_es_format->es->video.crop.width;
     m_decoded_height = m_es_format->es->video.crop.height;
+    m_decoded_aligned_width = m_es_format->es->video.width;
+    m_decoded_aligned_height = m_es_format->es->video.height;
     if (g_advancedSettings.CanLogComponent(LOGVIDEO))
-      CLog::Log(LOGDEBUG, "%s::%s format changed: %dx%d %.2f", CLASSNAME, __func__, m_decoded_width, m_decoded_height, m_aspect_ratio);
+      CLog::Log(LOGDEBUG, "%s::%s format changed: %dx%d (%dx%d) %.2f", CLASSNAME, __func__, m_decoded_width, m_decoded_height, m_decoded_aligned_width, m_decoded_aligned_height, m_aspect_ratio);
   }
   else
-    CLog::Log(LOGERROR, "%s::%s format changed: Unexpected %dx%d", CLASSNAME, __func__, m_es_format->es->video.crop.width, m_es_format->es->video.crop.height);
+    CLog::Log(LOGERROR, "%s::%s format changed: Unexpected %dx%d (%dx%d)", CLASSNAME, __func__, m_es_format->es->video.crop.width, m_es_format->es->video.crop.height, m_decoded_aligned_width, m_decoded_aligned_height);
 
   if (!change_dec_output_format())
     CLog::Log(LOGERROR, "%s::%s - change_dec_output_format() failed", CLASSNAME, __func__);
@@ -276,8 +262,10 @@ void CMMALVideo::dec_output_port_cb(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buf
       {
         omvb->mmal_buffer = buffer;
         buffer->user_data = (void *)omvb;
-        omvb->width = m_decoded_width;
-        omvb->height = m_decoded_height;
+        omvb->m_width = m_decoded_width;
+        omvb->m_height = m_decoded_height;
+        omvb->m_aligned_width = m_decoded_aligned_width;
+        omvb->m_aligned_height = m_decoded_aligned_height;
         omvb->m_aspect_ratio = m_aspect_ratio;
         {
           CSingleLock lock(m_output_mutex);
@@ -511,7 +499,7 @@ bool CMMALVideo::SendCodecConfigData()
   buffer->cmd = 0;
   buffer->length = std::min(m_hints.extrasize, buffer->alloc_size);
   memcpy(buffer->data, m_hints.extradata, buffer->length);
-  buffer->flags |= MMAL_BUFFER_HEADER_FLAG_FRAME_END | MMAL_BUFFER_HEADER_FLAG_CONFIG;
+  buffer->flags = MMAL_BUFFER_HEADER_FLAG_FRAME_END | MMAL_BUFFER_HEADER_FLAG_CONFIG;
   if (g_advancedSettings.CanLogComponent(LOGVIDEO))
     CLog::Log(LOGDEBUG, "%s::%s - %-8p %-6d flags:%x", CLASSNAME, __func__, buffer, buffer->length, buffer->flags);
   status = mmal_port_send_buffer(m_dec_input, buffer);
@@ -527,18 +515,18 @@ bool CMMALVideo::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
 {
   CSingleLock lock(m_sharedSection);
   if (g_advancedSettings.CanLogComponent(LOGVIDEO))
-    CLog::Log(LOGDEBUG, "%s::%s usemmal:%d software:%d %dx%d pool:%p", CLASSNAME, __func__, CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_USEMMAL), hints.software, hints.width, hints.height, options.m_opaque_pointer);
+    CLog::Log(LOGDEBUG, "%s::%s usemmal:%d software:%d %dx%d renderer:%p", CLASSNAME, __func__, CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_USEMMAL), hints.software, hints.width, hints.height, options.m_opaque_pointer);
 
   // we always qualify even if DVDFactoryCodec does this too.
   if (!CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_USEMMAL) || hints.software)
     return false;
 
   m_hints = hints;
-  m_vout_input_pool = (MMAL_POOL_T *)options.m_opaque_pointer;
+  m_renderer = (CMMALRenderer *)options.m_opaque_pointer;
   MMAL_STATUS_T status;
 
-  m_decoded_width  = hints.width;
-  m_decoded_height = hints.height;
+  m_decoded_width = m_decoded_aligned_width = hints.width;
+  m_decoded_height = m_decoded_aligned_height = hints.height;
 
   // use aspect in stream if available
   if (m_hints.forced_aspect)
@@ -882,10 +870,12 @@ int CMMALVideo::Decode(uint8_t* pData, int iSize, double dts, double pts)
 void CMMALVideo::Prime()
 {
   MMAL_BUFFER_HEADER_T *buffer;
+  assert(m_renderer);
+  MMAL_POOL_T *render_pool = m_renderer->GetPool(RENDER_FMT_MMAL, true);
+  assert(render_pool);
   if (g_advancedSettings.CanLogComponent(LOGVIDEO))
-    CLog::Log(LOGDEBUG, "%s::%s - queue(%p)", CLASSNAME, __func__, m_vout_input_pool);
-  assert(m_vout_input_pool);
-  while (buffer = mmal_queue_get(m_vout_input_pool->queue), buffer)
+    CLog::Log(LOGDEBUG, "%s::%s - queue(%p)", CLASSNAME, __func__, render_pool);
+  while (buffer = mmal_queue_get(render_pool->queue), buffer)
     Recycle(buffer);
 }
 
@@ -997,11 +987,11 @@ bool CMMALVideo::GetPicture(DVDVideoPicture* pDvdVideoPicture)
     pDvdVideoPicture->MMALBuffer = buffer;
     pDvdVideoPicture->color_range  = 0;
     pDvdVideoPicture->color_matrix = 4;
-    pDvdVideoPicture->iWidth  = buffer->width ? buffer->width : m_decoded_width;
-    pDvdVideoPicture->iHeight = buffer->height ? buffer->height : m_decoded_height;
+    pDvdVideoPicture->iWidth  = buffer->m_width ? buffer->m_width : m_decoded_width;
+    pDvdVideoPicture->iHeight = buffer->m_height ? buffer->m_height : m_decoded_height;
     pDvdVideoPicture->iDisplayWidth  = pDvdVideoPicture->iWidth;
     pDvdVideoPicture->iDisplayHeight = pDvdVideoPicture->iHeight;
-    //CLog::Log(LOGDEBUG, "%s::%s -  %dx%d %dx%d %dx%d %dx%d %f,%f", CLASSNAME, __func__, pDvdVideoPicture->iWidth, pDvdVideoPicture->iHeight, pDvdVideoPicture->iDisplayWidth, pDvdVideoPicture->iDisplayHeight, m_decoded_width, m_decoded_height, buffer->width, buffer->height, buffer->m_aspect_ratio, m_hints.aspect);
+    //CLog::Log(LOGDEBUG, "%s::%s -  %dx%d %dx%d %dx%d %dx%d %f,%f", CLASSNAME, __func__, pDvdVideoPicture->iWidth, pDvdVideoPicture->iHeight, pDvdVideoPicture->iDisplayWidth, pDvdVideoPicture->iDisplayHeight, m_decoded_width, m_decoded_height, buffer->m_width, buffer->m_height, buffer->m_aspect_ratio, m_hints.aspect);
 
     if (buffer->m_aspect_ratio > 0.0)
     {

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.h
@@ -40,26 +40,31 @@
 #include "guilib/Geometry.h"
 #include "rendering/RenderSystem.h"
 #include "cores/VideoPlayer/VideoRenderers/BaseRenderer.h"
-
-class CMMALVideo;
+#include "cores/VideoPlayer/DVDResource.h"
 
 // a mmal video frame
-class CMMALVideoBuffer
+class CMMALBuffer : public IDVDResourceCounted<CMMALBuffer>
+{
+public:
+  virtual ~CMMALBuffer() {}
+  MMAL_BUFFER_HEADER_T *mmal_buffer;
+  unsigned int m_width;
+  unsigned int m_height;
+  unsigned int m_aligned_width;
+  unsigned int m_aligned_height;
+  float m_aspect_ratio;
+};
+
+class CMMALVideo;
+class CMMALRenderer;
+
+// a mmal video frame
+class CMMALVideoBuffer : public CMMALBuffer
 {
 public:
   CMMALVideoBuffer(CMMALVideo *omv);
   virtual ~CMMALVideoBuffer();
-
-  MMAL_BUFFER_HEADER_T *mmal_buffer;
-  int width;
-  int height;
-  float m_aspect_ratio;
-  // reference counting
-  CMMALVideoBuffer* Acquire();
-  long              Release();
   CMMALVideo *m_omv;
-  long m_refs;
-private:
 };
 
 class CMMALVideo : public CDVDVideoCodec
@@ -97,8 +102,10 @@ protected:
   void Prime();
 
   // Video format
-  int               m_decoded_width;
-  int               m_decoded_height;
+  unsigned int      m_decoded_width;
+  unsigned int      m_decoded_height;
+  unsigned int      m_decoded_aligned_width;
+  unsigned int      m_decoded_aligned_height;
   unsigned int      m_egl_buffer_count;
   bool              m_finished;
   float             m_aspect_ratio;
@@ -131,7 +138,7 @@ protected:
   MMAL_PORT_T *m_dec_input;
   MMAL_PORT_T *m_dec_output;
   MMAL_POOL_T *m_dec_input_pool;
-  MMAL_POOL_T *m_vout_input_pool;
+  CMMALRenderer *m_renderer;
 
   MMAL_ES_FORMAT_T *m_es_format;
   MMAL_COMPONENT_T *m_deint;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALFFmpeg.cpp
@@ -1,0 +1,345 @@
+/*
+ *      Copyright (C) 2016 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "system.h"
+#ifdef HAS_MMAL
+
+#include "cores/VideoPlayer/VideoRenderers/RenderManager.h"
+#include "cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.h"
+#include "../DVDCodecUtils.h"
+#include "MMALFFmpeg.h"
+#include "utils/log.h"
+#include "utils/StringUtils.h"
+#include "linux/RBP.h"
+#include "settings/AdvancedSettings.h"
+
+extern "C" {
+#include "libavutil/imgutils.h"
+}
+
+using namespace MMAL;
+
+//-----------------------------------------------------------------------------
+// MMAL Buffers
+//-----------------------------------------------------------------------------
+
+#define CLASSNAME "CMMALYUVBuffer"
+
+CMMALYUVBuffer::CMMALYUVBuffer(CDecoder *dec, unsigned int width, unsigned int height, unsigned int aligned_width, unsigned int aligned_height)
+  : m_dec(dec)
+{
+  dec->Acquire();
+  m_width = width;
+  m_height = height;
+  m_aligned_width = aligned_width;
+  m_aligned_height = aligned_height;
+  m_aspect_ratio = 0.0f;
+  mmal_buffer = nullptr;
+  unsigned int size_pic = (m_aligned_width * m_aligned_height * 3) >> 1;
+  gmem = m_dec->AllocateBuffer(size_pic);
+  if (gmem)
+    gmem->m_opaque = (void *)this;
+  if (g_advancedSettings.CanLogComponent(LOGVIDEO))
+    CLog::Log(LOGDEBUG, "%s::%s buf:%p gmem:%p mmal:%p", CLASSNAME, __FUNCTION__, this, gmem, mmal_buffer);
+}
+
+CMMALYUVBuffer::~CMMALYUVBuffer()
+{
+  if (g_advancedSettings.CanLogComponent(LOGVIDEO))
+    CLog::Log(LOGDEBUG, "%s::%s buf:%p gmem:%p", CLASSNAME, __FUNCTION__, this, gmem);
+  if (gmem)
+    m_dec->ReleaseBuffer(gmem);
+  gmem = nullptr;
+  if (mmal_buffer)
+    mmal_buffer_header_release(mmal_buffer);
+  m_dec->Release();
+}
+
+CGPUMEM *CDecoder::AllocateBuffer(unsigned int size_pic)
+{
+  CSingleLock lock(m_section);
+  CGPUMEM *gmem = nullptr;
+  while (!m_freeBuffers.empty())
+  {
+    gmem = m_freeBuffers.front();
+    m_freeBuffers.pop_front();
+    if (gmem->m_numbytes == size_pic)
+      return gmem;
+    delete gmem;
+  }
+
+  gmem = new CGPUMEM(size_pic, true);
+  if (!gmem)
+    CLog::Log(LOGERROR, "%s::%s GCPUMEM(%d) failed", CLASSNAME, __FUNCTION__, size_pic);
+  return gmem;
+}
+
+void CDecoder::ReleaseBuffer(CGPUMEM *gmem)
+{
+  if (m_closing)
+    delete gmem;
+  else
+    m_freeBuffers.push_back(gmem);
+}
+
+void CDecoder::AlignedSize(AVCodecContext *avctx, int &w, int &h)
+{
+  AVPicture picture;
+  int unaligned;
+  int stride_align[AV_NUM_DATA_POINTERS];
+
+  avcodec_align_dimensions2(avctx, &w, &h, stride_align);
+  // gpu requirements
+  w = (w + 31) & ~31;
+  h = (h + 15) & ~15;
+
+  do {
+    // NOTE: do not align linesizes individually, this breaks e.g. assumptions
+    // that linesize[0] == 2*linesize[1] in the MPEG-encoder for 4:2:2
+    av_image_fill_linesizes(picture.linesize, avctx->pix_fmt, w);
+    // increase alignment of w for next try (rhs gives the lowest bit set in w)
+    w += w & ~(w - 1);
+
+    unaligned = 0;
+    for (int i = 0; i < 4; i++)
+      unaligned |= picture.linesize[i] % stride_align[i];
+  } while (unaligned);
+}
+
+CMMALYUVBuffer *CDecoder::GetBuffer(unsigned int width, unsigned int height, AVCodecContext *avctx)
+{
+  CSingleLock lock(m_section);
+  // ffmpeg requirements
+  int aligned_width = width;
+  int aligned_height = height;
+  AlignedSize(avctx, aligned_width, aligned_height);
+  return new CMMALYUVBuffer(this, width, height, aligned_width, aligned_height);
+}
+
+//-----------------------------------------------------------------------------
+// MMAL Decoder
+//-----------------------------------------------------------------------------
+
+#undef CLASSNAME
+#define CLASSNAME "CDecoder"
+
+CDecoder::CDecoder()
+{
+  if (g_advancedSettings.CanLogComponent(LOGVIDEO))
+    CLog::Log(LOGDEBUG, "%s::%s - create %p", CLASSNAME, __FUNCTION__, this);
+  m_shared = 0;
+  m_avctx = nullptr;
+  m_renderer = nullptr;
+  m_closing = false;
+}
+
+CDecoder::~CDecoder()
+{
+  if (g_advancedSettings.CanLogComponent(LOGVIDEO))
+    CLog::Log(LOGDEBUG, "%s::%s - destroy %p", CLASSNAME, __FUNCTION__, this);
+  Close();
+}
+
+long CDecoder::Release()
+{
+  if (g_advancedSettings.CanLogComponent(LOGVIDEO))
+    CLog::Log(LOGDEBUG, "%s::%s - m_refs:%ld", CLASSNAME, __FUNCTION__, m_refs);
+  return IHardwareDecoder::Release();
+}
+
+void CDecoder::Close()
+{
+  CSingleLock lock(m_section);
+
+  m_closing = true;
+  if (g_advancedSettings.CanLogComponent(LOGVIDEO))
+    CLog::Log(LOGDEBUG, "%s::%s - close %p", CLASSNAME, __FUNCTION__, this);
+
+  while (!m_freeBuffers.empty())
+  {
+    CGPUMEM *gmem = m_freeBuffers.front();
+    m_freeBuffers.pop_front();
+    delete gmem;
+  }
+  assert(m_freeBuffers.empty());
+
+  if (g_advancedSettings.CanLogComponent(LOGVIDEO))
+    CLog::Log(LOGDEBUG,"%s::%s", CLASSNAME, __FUNCTION__);
+}
+
+void CDecoder::FFReleaseBuffer(void *opaque, uint8_t *data)
+{
+  CGPUMEM *gmem = (CGPUMEM *)opaque;
+  CMMALYUVBuffer *YUVBuffer = (CMMALYUVBuffer *)gmem->m_opaque;
+  if (g_advancedSettings.CanLogComponent(LOGVIDEO))
+    CLog::Log(LOGDEBUG,"%s::%s buf:%p gmem:%p", CLASSNAME, __FUNCTION__, YUVBuffer, gmem);
+
+  YUVBuffer->Release();
+}
+
+int CDecoder::FFGetBuffer(AVCodecContext *avctx, AVFrame *frame, int flags)
+{
+  CDVDVideoCodecFFmpeg *ctx = (CDVDVideoCodecFFmpeg*)avctx->opaque;
+  CDecoder *dec = (CDecoder*)ctx->GetHardware();
+  if (g_advancedSettings.CanLogComponent(LOGVIDEO))
+    CLog::Log(LOGDEBUG,"%s::%s %dx%d format:%x flags:%x", CLASSNAME, __FUNCTION__, frame->width, frame->height, frame->format, flags);
+
+  if ((avctx->codec->capabilities & AV_CODEC_CAP_DR1) == 0 || frame->format != AV_PIX_FMT_YUV420P)
+  {
+    assert(0);
+    return avcodec_default_get_buffer2(avctx, frame, flags);
+  }
+
+  CSingleLock lock(dec->m_section);
+
+  CMMALYUVBuffer *YUVBuffer = dec->GetBuffer(frame->width, frame->height, dec->m_avctx);
+
+  CGPUMEM *gmem = YUVBuffer->gmem;
+  AVBufferRef *buf = av_buffer_create((uint8_t *)gmem->m_arm, (YUVBuffer->m_aligned_width * YUVBuffer->m_aligned_height * 3)>>1, CDecoder::FFReleaseBuffer, gmem, AV_BUFFER_FLAG_READONLY);
+  if (!buf)
+  {
+    CLog::Log(LOGERROR, "%s::%s av_buffer_create() failed", CLASSNAME, __FUNCTION__);
+    YUVBuffer->Release();
+    return -1;
+  }
+
+  for (int i = 0; i < AV_NUM_DATA_POINTERS; i++)
+  {
+    frame->buf[i] = NULL;
+    frame->data[i] = NULL;
+    frame->linesize[i] = 0;
+  }
+
+  frame->buf[0] = buf;
+  frame->linesize[0] = YUVBuffer->m_aligned_width;
+  frame->linesize[1] = YUVBuffer->m_aligned_width>>1;
+  frame->linesize[2] = YUVBuffer->m_aligned_width>>1;
+  frame->data[0] = (uint8_t *)gmem->m_arm;
+  frame->data[1] = frame->data[0] + YUVBuffer->m_aligned_width * YUVBuffer->m_aligned_height;
+  frame->data[2] = frame->data[1] + (YUVBuffer->m_aligned_width>>1) * (YUVBuffer->m_aligned_height>>1);
+  frame->extended_data = frame->data;
+  // Leave extended buf alone
+
+  if (g_advancedSettings.CanLogComponent(LOGVIDEO))
+    CLog::Log(LOGDEBUG,"%s::%s buf:%p gmem:%p avbuf:%p:%p:%p", CLASSNAME, __FUNCTION__, YUVBuffer, gmem, frame->data[0], frame->data[1], frame->data[2]);
+
+  return 0;
+}
+
+
+bool CDecoder::Open(AVCodecContext *avctx, AVCodecContext* mainctx, enum AVPixelFormat fmt, unsigned int surfaces)
+{
+  CSingleLock lock(m_section);
+
+  m_renderer = (CMMALRenderer *)mainctx->hwaccel_context;
+
+  CLog::Log(LOGNOTICE, "%s::%s - m_renderer:%p", CLASSNAME, __FUNCTION__, m_renderer);
+  assert(m_renderer);
+  mainctx->hwaccel_context = nullptr;
+
+  if (surfaces > m_shared)
+    m_shared = surfaces;
+
+  CLog::Log(LOGDEBUG, "%s::%s MMAL - source requires %d references", CLASSNAME, __FUNCTION__, avctx->refs);
+
+  avctx->get_buffer2 = CDecoder::FFGetBuffer;
+  mainctx->get_buffer2 = CDecoder::FFGetBuffer;
+
+  m_avctx = mainctx;
+  return true;
+}
+
+int CDecoder::Decode(AVCodecContext* avctx, AVFrame* frame)
+{
+  int status = Check(avctx);
+  if(status)
+    return status;
+
+  if(frame)
+    return VC_BUFFER | VC_PICTURE;
+  else
+    return VC_BUFFER;
+}
+
+MMAL_BUFFER_HEADER_T *CDecoder::GetMmal()
+{
+  MMAL_POOL_T *render_pool = m_renderer->GetPool(RENDER_FMT_MMAL, false);
+  assert(render_pool);
+  MMAL_BUFFER_HEADER_T *mmal_buffer = mmal_queue_timedwait(render_pool->queue, 500);
+  if (!mmal_buffer)
+  {
+    CLog::Log(LOGERROR, "%s::%s - mmal_queue_get failed", CLASSNAME, __FUNCTION__);
+    return nullptr;
+  }
+  mmal_buffer_header_reset(mmal_buffer);
+  mmal_buffer->cmd = 0;
+  mmal_buffer->offset = 0;
+  mmal_buffer->flags = 0;
+  mmal_buffer->user_data = NULL;
+  return mmal_buffer;
+}
+
+bool CDecoder::GetPicture(AVCodecContext* avctx, AVFrame* frame, DVDVideoPicture* picture)
+{
+  CDVDVideoCodecFFmpeg* ctx = (CDVDVideoCodecFFmpeg*)avctx->opaque;
+  bool ret = ctx->GetPictureCommon(picture);
+  if (!ret)
+    return false;
+
+  if (frame->format != AV_PIX_FMT_YUV420P || frame->buf[1] != nullptr || frame->buf[0] == nullptr)
+    return false;
+
+  MMAL_BUFFER_HEADER_T *mmal_buffer = GetMmal();
+  if (!mmal_buffer)
+    return false;
+
+  CSingleLock lock(m_section);
+
+  AVBufferRef *buf = frame->buf[0];
+  CGPUMEM *gmem = (CGPUMEM *)av_buffer_get_opaque(buf);
+  mmal_buffer->data = (uint8_t *)gmem->m_vc_handle;
+  mmal_buffer->alloc_size = mmal_buffer->length = gmem->m_numbytes;
+
+  picture->MMALBuffer = (CMMALYUVBuffer *)gmem->m_opaque;
+  assert(picture->MMALBuffer);
+  picture->format = RENDER_FMT_MMAL;
+  assert(!picture->MMALBuffer->mmal_buffer);
+  picture->MMALBuffer->mmal_buffer = mmal_buffer;
+
+  // need to flush ARM cache so GPU can see it
+  gmem->Flush();
+
+  if (g_advancedSettings.CanLogComponent(LOGVIDEO))
+    CLog::Log(LOGDEBUG, "%s::%s - mmal:%p dts:%.3f pts:%.3f buf:%p gpu:%p", CLASSNAME, __FUNCTION__, picture->MMALBuffer->mmal_buffer, 1e-6*picture->dts, 1e-6*picture->pts, picture->MMALBuffer, gmem);
+  return true;
+}
+
+int CDecoder::Check(AVCodecContext* avctx)
+{
+  CSingleLock lock(m_section);
+  return 0;
+}
+
+unsigned CDecoder::GetAllowedReferences()
+{
+  return m_shared;
+}
+
+#endif

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALFFmpeg.h
@@ -1,0 +1,82 @@
+/*
+ *      Copyright (C) 2016 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <memory>
+#include <queue>
+#include "DVDCodecs/Video/DVDVideoCodecFFmpeg.h"
+#include "libavcodec/avcodec.h"
+#include "MMALCodec.h"
+
+class CMMALRenderer;
+struct MMAL_BUFFER_HEADER_T;
+class CGPUMEM;
+
+namespace MMAL {
+
+class CDecoder;
+
+// a mmal video frame
+class CMMALYUVBuffer : public CMMALBuffer
+{
+public:
+  CMMALYUVBuffer(CDecoder *dec, unsigned int width, unsigned int height, unsigned int aligned_width, unsigned int aligned_height);
+  virtual ~CMMALYUVBuffer();
+
+  CGPUMEM *gmem;
+private:
+  CDecoder *m_dec;
+};
+
+class CDecoder
+  : public CDVDVideoCodecFFmpeg::IHardwareDecoder
+{
+public:
+  CDecoder();
+  virtual ~CDecoder();
+  virtual bool Open(AVCodecContext* avctx, AVCodecContext* mainctx, const enum AVPixelFormat, unsigned int surfaces);
+  virtual int Decode(AVCodecContext* avctx, AVFrame* frame);
+  virtual bool GetPicture(AVCodecContext* avctx, AVFrame* frame, DVDVideoPicture* picture);
+  virtual int Check(AVCodecContext* avctx);
+  virtual void Close();
+  virtual const std::string Name() { return "mmal"; }
+  virtual unsigned GetAllowedReferences();
+  virtual long Release();
+
+  static void FFReleaseBuffer(void *opaque, uint8_t *data);
+  static int FFGetBuffer(AVCodecContext *avctx, AVFrame *pic, int flags);
+
+  static void AlignedSize(AVCodecContext *avctx, int &w, int &h);
+  CMMALYUVBuffer *GetBuffer(unsigned int width, unsigned int height, AVCodecContext *avctx);
+  CGPUMEM *AllocateBuffer(unsigned int numbytes);
+  void ReleaseBuffer(CGPUMEM *gmem);
+  unsigned sizeFree() { return m_freeBuffers.size(); }
+protected:
+  MMAL_BUFFER_HEADER_T *GetMmal();
+  AVCodecContext *m_avctx;
+  unsigned int m_shared;
+  CCriticalSection m_section;
+  CMMALRenderer *m_renderer;
+  std::deque<CGPUMEM *> m_freeBuffers;
+  bool m_closing;
+};
+
+};

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/Makefile.in
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/Makefile.in
@@ -33,7 +33,7 @@ SRCS += DVDVideoCodecAndroidMediaCodec.cpp
 endif
 
 ifeq (@USE_MMAL@,1)
-SRCS += MMALCodec.cpp
+SRCS += MMALCodec.cpp MMALFFmpeg.cpp
 endif
 
 LIB=Video.a

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.cpp
@@ -62,11 +62,6 @@ CRenderInfo CMMALRenderer::GetRenderInfo()
   return info;
 }
 
-static void vout_control_port_cb(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer)
-{
-  mmal_buffer_header_release(buffer);
-}
-
 void CMMALRenderer::vout_input_port_cb(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer)
 {
   assert(!(buffer->flags & MMAL_BUFFER_HEADER_FLAG_TRANSMISSION_FAILED));
@@ -110,13 +105,6 @@ bool CMMALRenderer::init_vout(ERenderFormat format, bool opaque)
     return false;
   }
 
-  m_vout->control->userdata = (struct MMAL_PORT_USERDATA_T *)this;
-  status = mmal_port_enable(m_vout->control, vout_control_port_cb);
-  if(status != MMAL_SUCCESS)
-  {
-    CLog::Log(LOGERROR, "%s::%s Failed to enable vout control port (status=%x %s)", CLASSNAME, __func__, status, mmal_status_to_string(status));
-    return false;
-  }
   m_vout_input = m_vout->input[0];
   m_vout_input->userdata = (struct MMAL_PORT_USERDATA_T *)this;
   MMAL_ES_FORMAT_T *es_format = m_vout_input->format;
@@ -409,7 +397,6 @@ void CMMALRenderer::UnInitMMAL()
   if (m_vout)
   {
     mmal_component_disable(m_vout);
-    mmal_port_disable(m_vout->control);
   }
 
   if (m_vout_input)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.cpp
@@ -33,43 +33,18 @@
 #include "windowing/WindowingFactory.h"
 #include "cores/VideoPlayer/DVDCodecs/Video/MMALCodec.h"
 #include "xbmc/Application.h"
+#include "linux/RBP.h"
 
 #define CLASSNAME "CMMALRenderer"
 
 
-CYUVVideoBuffer::CYUVVideoBuffer()
+MMAL_POOL_T *CMMALRenderer::GetPool(ERenderFormat format, bool opaque)
 {
-  m_refs = 0;
-  mmal_buffer = 0;
-}
+  CSingleLock lock(m_sharedSection);
+  if (!m_bMMALConfigured)
+    m_bMMALConfigured = init_vout(format, opaque);
 
-CYUVVideoBuffer::~CYUVVideoBuffer()
-{
-  m_refs = 0;
-  mmal_buffer = 0;
-}
-
-CYUVVideoBuffer *CYUVVideoBuffer::Acquire()
-{
-  long count = AtomicIncrement(&m_refs);
-  if (g_advancedSettings.CanLogComponent(LOGVIDEO))
-    CLog::Log(LOGDEBUG, "%s::%s omvb:%p mmal:%p ref:%ld", CLASSNAME, __func__, this, mmal_buffer, count);
-  (void)count;
-  return this;
-}
-
-long CYUVVideoBuffer::Release()
-{
-  long count = AtomicDecrement(&m_refs);
-  if (g_advancedSettings.CanLogComponent(LOGVIDEO))
-    CLog::Log(LOGDEBUG, "%s::%s omvb:%p mmal:%p ref:%ld", CLASSNAME, __func__, this, mmal_buffer, count);
-  if (count == 0)
-  {
-    mmal_buffer_header_release(mmal_buffer);
-    delete this;
-  }
-  else assert(count > 0);
-  return count;
+  return m_vout_input_pool;
 }
 
 CRenderInfo CMMALRenderer::GetRenderInfo()
@@ -77,17 +52,12 @@ CRenderInfo CMMALRenderer::GetRenderInfo()
   CSingleLock lock(m_sharedSection);
   CRenderInfo info;
 
-  // we'll assume that video is accelerated (RENDER_FMT_MMAL) for now
-  // we will reconfigure renderer later if necessary
-  if (!m_bMMALConfigured)
-    m_bMMALConfigured = init_vout(RENDER_FMT_MMAL);
-
   if (g_advancedSettings.CanLogComponent(LOGVIDEO))
     CLog::Log(LOGDEBUG, "%s::%s cookie:%p", CLASSNAME, __func__, (void *)m_vout_input_pool);
 
   info.max_buffer_size = NUM_BUFFERS;
   info.optimal_buffer_size = NUM_BUFFERS;
-  info.opaque_pointer = (void *)m_vout_input_pool;
+  info.opaque_pointer = (void *)this;
   info.formats = m_formats;
   return info;
 }
@@ -101,24 +71,12 @@ void CMMALRenderer::vout_input_port_cb(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *
 {
   assert(!(buffer->flags & MMAL_BUFFER_HEADER_FLAG_TRANSMISSION_FAILED));
   buffer->flags &= ~MMAL_BUFFER_HEADER_FLAG_USER2;
-  if (m_format == RENDER_FMT_MMAL)
-  {
-    CMMALVideoBuffer *omvb = (CMMALVideoBuffer *)buffer->user_data;
-    assert(buffer == omvb->mmal_buffer);
-    if (g_advancedSettings.CanLogComponent(LOGVIDEO))
-      CLog::Log(LOGDEBUG, "%s::%s port:%p omvb:%p mmal:%p len:%d cmd:%x flags:%x flight:%d", CLASSNAME, __func__, port, omvb, omvb->mmal_buffer, buffer->length, buffer->cmd, buffer->flags, m_inflight);
-    omvb->Release();
-  }
-  else if (m_format == RENDER_FMT_YUV420P)
-  {
-    CYUVVideoBuffer *omvb = (CYUVVideoBuffer *)buffer->user_data;
-    assert(buffer == omvb->mmal_buffer);
-    if (g_advancedSettings.CanLogComponent(LOGVIDEO))
-      CLog::Log(LOGDEBUG, "%s::%s port:%p omvb:%p mmal:%p len:%d cmd:%x flags:%x flight:%d", CLASSNAME, __func__, port, omvb, omvb->mmal_buffer, buffer->length, buffer->cmd, buffer->flags, m_inflight);
-    m_inflight--;
-    omvb->Release();
-  }
-  else assert(0);
+  CMMALBuffer *omvb = (CMMALBuffer *)buffer->user_data;
+  if (g_advancedSettings.CanLogComponent(LOGVIDEO))
+    CLog::Log(LOGDEBUG, "%s::%s YUV port:%p omvb:%p mmal:%p:%p len:%d cmd:%x flags:%x flight:%d", CLASSNAME, __func__, port, omvb, buffer, omvb->mmal_buffer, buffer->length, buffer->cmd, buffer->flags, m_inflight);
+  assert(buffer == omvb->mmal_buffer);
+  m_inflight--;
+  omvb->Release();
 }
 
 static void vout_input_port_cb_static(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer)
@@ -127,13 +85,13 @@ static void vout_input_port_cb_static(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *b
   mmal->vout_input_port_cb(port, buffer);
 }
 
-bool CMMALRenderer::init_vout(ERenderFormat format)
+bool CMMALRenderer::init_vout(ERenderFormat format, bool opaque)
 {
   CSingleLock lock(m_sharedSection);
-  bool formatChanged = m_format != format;
+  bool formatChanged = m_format != format || m_opaque != opaque;
   MMAL_STATUS_T status;
 
-  CLog::Log(LOGDEBUG, "%s::%s configured:%d format:%d->%d", CLASSNAME, __func__, m_bConfigured, m_format, format);
+  CLog::Log(LOGDEBUG, "%s::%s configured:%d format %d->%d opaque %d->%d", CLASSNAME, __func__, m_bConfigured, m_format, format, m_opaque, opaque);
 
   if (m_bMMALConfigured && formatChanged)
     UnInitMMAL();
@@ -142,8 +100,7 @@ bool CMMALRenderer::init_vout(ERenderFormat format)
     return true;
 
   m_format = format;
-  if (m_format != RENDER_FMT_MMAL && m_format != RENDER_FMT_YUV420P)
-    return true;
+  m_opaque = opaque;
 
   /* Create video renderer */
   status = mmal_component_create(MMAL_COMPONENT_DEFAULT_VIDEO_RENDERER, &m_vout);
@@ -165,38 +122,24 @@ bool CMMALRenderer::init_vout(ERenderFormat format)
   MMAL_ES_FORMAT_T *es_format = m_vout_input->format;
 
   es_format->type = MMAL_ES_TYPE_VIDEO;
+  if (CONF_FLAGS_YUVCOEF_MASK(m_iFlags) == CONF_FLAGS_YUVCOEF_BT709)
+    es_format->es->video.color_space = MMAL_COLOR_SPACE_ITUR_BT709;
+  else if (CONF_FLAGS_YUVCOEF_MASK(m_iFlags) == CONF_FLAGS_YUVCOEF_BT601)
+    es_format->es->video.color_space = MMAL_COLOR_SPACE_ITUR_BT601;
+  else if (CONF_FLAGS_YUVCOEF_MASK(m_iFlags) == CONF_FLAGS_YUVCOEF_240M)
+    es_format->es->video.color_space = MMAL_COLOR_SPACE_SMPTE240M;
+
   es_format->es->video.crop.width = m_sourceWidth;
   es_format->es->video.crop.height = m_sourceHeight;
+  es_format->es->video.width = m_sourceWidth;
+  es_format->es->video.height = m_sourceHeight;
 
-  if (m_format == RENDER_FMT_MMAL)
-  {
-    es_format->encoding = MMAL_ENCODING_OPAQUE;
-    es_format->es->video.width = m_sourceWidth;
-    es_format->es->video.height = m_sourceHeight;
-  }
-  else if (m_format == RENDER_FMT_YUV420P)
-  {
-    const int pitch = ALIGN_UP(m_sourceWidth, 32);
-    const int aligned_height = ALIGN_UP(m_sourceHeight, 16);
+  es_format->encoding = m_opaque ? MMAL_ENCODING_OPAQUE : MMAL_ENCODING_I420;
 
-    es_format->encoding = MMAL_ENCODING_I420;
-    es_format->es->video.width = pitch;
-    es_format->es->video.height = aligned_height;
+  status = mmal_port_parameter_set_boolean(m_vout_input, MMAL_PARAMETER_ZERO_COPY,  MMAL_TRUE);
+  if (status != MMAL_SUCCESS)
+     CLog::Log(LOGERROR, "%s::%s Failed to enable zero copy mode on %s (status=%x %s)", CLASSNAME, __func__, m_vout_input->name, status, mmal_status_to_string(status));
 
-    if (CONF_FLAGS_YUVCOEF_MASK(m_iFlags) == CONF_FLAGS_YUVCOEF_BT709)
-      es_format->es->video.color_space = MMAL_COLOR_SPACE_ITUR_BT709;
-    else if (CONF_FLAGS_YUVCOEF_MASK(m_iFlags) == CONF_FLAGS_YUVCOEF_BT601)
-      es_format->es->video.color_space = MMAL_COLOR_SPACE_ITUR_BT601;
-    else if (CONF_FLAGS_YUVCOEF_MASK(m_iFlags) == CONF_FLAGS_YUVCOEF_240M)
-      es_format->es->video.color_space = MMAL_COLOR_SPACE_SMPTE240M;
-  }
-
-  if (m_format == RENDER_FMT_MMAL)
-  {
-    status = mmal_port_parameter_set_boolean(m_vout_input, MMAL_PARAMETER_ZERO_COPY,  MMAL_TRUE);
-    if (status != MMAL_SUCCESS)
-       CLog::Log(LOGERROR, "%s::%s Failed to enable zero copy mode on %s (status=%x %s)", CLASSNAME, __func__, m_vout_input->name, status, mmal_status_to_string(status));
-  }
   status = mmal_port_format_commit(m_vout_input);
   if (status != MMAL_SUCCESS)
   {
@@ -204,7 +147,7 @@ bool CMMALRenderer::init_vout(ERenderFormat format)
     return false;
   }
 
-  m_vout_input->buffer_num = std::max(m_vout_input->buffer_num_recommended, (uint32_t)m_NumYV12Buffers);
+  m_vout_input->buffer_num = std::max(m_vout_input->buffer_num_recommended, (uint32_t)m_NumYV12Buffers+(m_opaque?0:32));
   m_vout_input->buffer_size = m_vout_input->buffer_size_recommended;
 
   status = mmal_port_enable(m_vout_input, vout_input_port_cb_static);
@@ -221,7 +164,8 @@ bool CMMALRenderer::init_vout(ERenderFormat format)
     return false;
   }
 
-  m_vout_input_pool = mmal_port_pool_create(m_vout_input , m_vout_input->buffer_num, m_vout_input->buffer_size);
+  CLog::Log(LOGDEBUG, "%s::%s Created pool of size %d x %d", CLASSNAME, __func__, m_vout_input->buffer_num, m_vout_input->buffer_size);
+  m_vout_input_pool = mmal_port_pool_create(m_vout_input , m_vout_input->buffer_num, m_opaque ? m_vout_input->buffer_size:0);
   if (!m_vout_input_pool)
   {
     CLog::Log(LOGERROR, "%s::%s Failed to create pool for decoder input port (status=%x %s)", CLASSNAME, __func__, status, mmal_status_to_string(status));
@@ -239,6 +183,7 @@ CMMALRenderer::CMMALRenderer()
   memset(m_buffers, 0, sizeof m_buffers);
   m_iFlags = 0;
   m_format = RENDER_FMT_NONE;
+  m_opaque = true;
   m_bConfigured = false;
   m_bMMALConfigured = false;
   m_iYV12RenderBuffer = 0;
@@ -254,14 +199,18 @@ CMMALRenderer::~CMMALRenderer()
 
 void CMMALRenderer::AddVideoPictureHW(DVDVideoPicture& pic, int index)
 {
-  CMMALVideoBuffer *buffer = pic.MMALBuffer;
-  if (g_advancedSettings.CanLogComponent(LOGVIDEO))
-    CLog::Log(LOGDEBUG, "%s::%s - %p (%p) %i", CLASSNAME, __func__, buffer, buffer->mmal_buffer, index);
+  if (m_format != RENDER_FMT_MMAL)
+  {
+    assert(0);
+    return;
+  }
 
-  YUVBUFFER &buf = m_buffers[index];
-  assert(!buf.MMALBuffer);
-  memset(&buf, 0, sizeof buf);
-  buf.MMALBuffer = buffer->Acquire();
+  CMMALBuffer *buffer = pic.MMALBuffer;
+  assert(buffer);
+  if (g_advancedSettings.CanLogComponent(LOGVIDEO))
+    CLog::Log(LOGDEBUG, "%s::%s MMAL - %p (%p) %i", CLASSNAME, __func__, buffer, buffer->mmal_buffer, index);
+
+  m_buffers[index] = buffer->Acquire();
 }
 
 bool CMMALRenderer::Configure(unsigned int width, unsigned int height, unsigned int d_width, unsigned int d_height, float fps, unsigned flags, ERenderFormat format, unsigned extended_format, unsigned int orientation)
@@ -281,7 +230,7 @@ bool CMMALRenderer::Configure(unsigned int width, unsigned int height, unsigned 
   m_dst_rect.SetRect(0, 0, 0, 0);
 
   CLog::Log(LOGDEBUG, "%s::%s - %dx%d->%dx%d@%.2f flags:%x format:%d ext:%x orient:%d", CLASSNAME, __func__, width, height, d_width, d_height, fps, flags, format, extended_format, orientation);
-  if (format != RENDER_FMT_YUV420P && format != RENDER_FMT_BYPASS && format != RENDER_FMT_MMAL)
+  if (format != RENDER_FMT_BYPASS && format != RENDER_FMT_MMAL)
   {
     CLog::Log(LOGERROR, "%s::%s - format:%d not supported", CLASSNAME, __func__, format);
     return false;
@@ -292,7 +241,7 @@ bool CMMALRenderer::Configure(unsigned int width, unsigned int height, unsigned 
   SetViewMode(CMediaSettings::GetInstance().GetCurrentVideoSettings().m_ViewMode);
   ManageDisplay();
 
-  m_bMMALConfigured = init_vout(format);
+  m_bMMALConfigured = init_vout(format, m_opaque);
   m_bConfigured = m_bMMALConfigured;
   assert(m_bConfigured);
   return m_bConfigured;
@@ -300,101 +249,32 @@ bool CMMALRenderer::Configure(unsigned int width, unsigned int height, unsigned 
 
 int CMMALRenderer::GetImage(YV12Image *image, int source, bool readonly)
 {
-  if (!image || source < 0)
+  if (!image || source < 0 || m_format != RENDER_FMT_MMAL)
   {
     if (g_advancedSettings.CanLogComponent(LOGVIDEO))
-      CLog::Log(LOGDEBUG, "%s::%s - invalid: image:%p source:%d ro:%d flight:%d", CLASSNAME, __func__, image, source, readonly, m_inflight);
+      CLog::Log(LOGDEBUG, "%s::%s - invalid: format:%d image:%p source:%d ro:%d flight:%d", CLASSNAME, __func__, m_format, image, source, readonly, m_inflight);
     return -1;
   }
-
-  if (m_format == RENDER_FMT_MMAL)
-  {
-    if (g_advancedSettings.CanLogComponent(LOGVIDEO))
-      CLog::Log(LOGDEBUG, "%s::%s - MMAL: image:%p source:%d ro:%d flight:%d", CLASSNAME, __func__, image, source, readonly, m_inflight);
-  }
-  else if (m_format == RENDER_FMT_YUV420P)
-  {
-    const int pitch = ALIGN_UP(m_sourceWidth, 32);
-    const int aligned_height = ALIGN_UP(m_sourceHeight, 16);
-
-    MMAL_BUFFER_HEADER_T *buffer = mmal_queue_timedwait(m_vout_input_pool->queue, 500);
-    if (!buffer)
-    {
-      CLog::Log(LOGERROR, "%s::%s - mmal_queue_get failed", CLASSNAME, __func__);
-      return -1;
-    }
-
-    m_inflight++;
-    mmal_buffer_header_reset(buffer);
-
-    buffer->length = 3 * pitch * aligned_height >> 1;
-    assert(buffer->length <= buffer->alloc_size);
-
-    image->width    = m_sourceWidth;
-    image->height   = m_sourceHeight;
-    image->flags    = 0;
-    image->cshift_x = 1;
-    image->cshift_y = 1;
-    image->bpp      = 1;
-
-    image->stride[0] = pitch;
-    image->stride[1] = image->stride[2] = pitch>>image->cshift_x;
-
-    image->planesize[0] = pitch * aligned_height;
-    image->planesize[1] = image->planesize[2] = (pitch>>image->cshift_x)*(aligned_height>>image->cshift_y);
-
-    image->plane[0] = (uint8_t *)buffer->data;
-    image->plane[1] = image->plane[0] + image->planesize[0];
-    image->plane[2] = image->plane[1] + image->planesize[1];
-
-    YUVBUFFER &buf = m_buffers[source];
-    memset(&buf, 0, sizeof buf);
-    buf.YUVBuffer = new CYUVVideoBuffer;
-    if (!buf.YUVBuffer)
-      return -1;
-    buf.YUVBuffer->mmal_buffer = buffer;
-    if (g_advancedSettings.CanLogComponent(LOGVIDEO))
-      CLog::Log(LOGDEBUG, "%s::%s - YUV: image:%p source:%d ro:%d omvb:%p mmal:%p flight:%d", CLASSNAME, __func__, image, source, readonly, buf.YUVBuffer, buffer, m_inflight);
-    buf.YUVBuffer->Acquire();
-  }
-  else assert(0);
-
+  if (g_advancedSettings.CanLogComponent(LOGVIDEO))
+    CLog::Log(LOGDEBUG, "%s::%s - MMAL: image:%p source:%d ro:%d flight:%d", CLASSNAME, __func__, image, source, readonly, m_inflight);
   return source;
 }
 
 void CMMALRenderer::ReleaseBuffer(int idx)
 {
   CSingleLock lock(m_sharedSection);
-  if (!m_bMMALConfigured)
+  if (!m_bMMALConfigured || m_format != RENDER_FMT_MMAL)
   {
     if (g_advancedSettings.CanLogComponent(LOGVIDEO))
       CLog::Log(LOGDEBUG, "%s::%s - not configured: source:%d", CLASSNAME, __func__, idx);
     return;
   }
-  if (m_format == RENDER_FMT_BYPASS)
-  {
-    if (g_advancedSettings.CanLogComponent(LOGVIDEO))
-      CLog::Log(LOGDEBUG, "%s::%s - bypass: source:%d", CLASSNAME, __func__, idx);
-    return;
-  }
 
-  YUVBUFFER *buffer = &m_buffers[idx];
-  if (m_format == RENDER_FMT_MMAL)
-  {
-    CMMALVideoBuffer *omvb = buffer->MMALBuffer;
-    if (g_advancedSettings.CanLogComponent(LOGVIDEO))
-      CLog::Log(LOGDEBUG, "%s::%s - MMAL: source:%d omvb:%p mmal:%p", CLASSNAME, __func__, idx, omvb, omvb ? omvb->mmal_buffer:NULL);
-    SAFE_RELEASE(buffer->MMALBuffer);
-  }
-  else if (m_format == RENDER_FMT_YUV420P)
-  {
-    CYUVVideoBuffer *omvb = buffer->YUVBuffer;
-    if (g_advancedSettings.CanLogComponent(LOGVIDEO))
-      CLog::Log(LOGDEBUG, "%s::%s - YUV: source:%d omvb:%p mmal:%p flight:%d", CLASSNAME, __func__, idx, omvb, omvb ? omvb->mmal_buffer:NULL, m_inflight);
-    if (omvb && omvb->mmal_buffer)
-      SAFE_RELEASE(buffer->YUVBuffer);
-  }
-  else assert(0);
+  CMMALBuffer *omvb = m_buffers[idx];
+  if (g_advancedSettings.CanLogComponent(LOGVIDEO))
+    CLog::Log(LOGDEBUG, "%s::%s - MMAL: source:%d omvb:%p mmal:%p flight:%d", CLASSNAME, __func__, idx, omvb, omvb ? omvb->mmal_buffer:NULL, m_inflight);
+  if (omvb)
+    SAFE_RELEASE(m_buffers[idx]);
 }
 
 void CMMALRenderer::ReleaseImage(int source, bool preserve)
@@ -434,61 +314,58 @@ void CMMALRenderer::RenderUpdate(bool clear, DWORD flags, DWORD alpha)
 
   ManageDisplay();
 
-  if (m_format == RENDER_FMT_BYPASS)
+  if (m_format != RENDER_FMT_MMAL)
   {
     if (g_advancedSettings.CanLogComponent(LOGVIDEO))
-      CLog::Log(LOGDEBUG, "%s::%s - bypass: clear:%d flags:%x alpha:%d source:%d", CLASSNAME, __func__, clear, flags, alpha, source);
+      CLog::Log(LOGDEBUG, "%s::%s - bypass: clear:%d flags:%x alpha:%d source:%d format:%d", CLASSNAME, __func__, clear, flags, alpha, source, m_format);
     return;
   }
   SetVideoRect(m_sourceRect, m_destRect);
 
-  YUVBUFFER *buffer = &m_buffers[source];
-  if (m_format == RENDER_FMT_MMAL)
+  CMMALBuffer *omvb = m_buffers[source];
+  if (omvb && omvb->mmal_buffer)
   {
-    CMMALVideoBuffer *omvb = buffer->MMALBuffer;
-    if (omvb && omvb->mmal_buffer)
+    if (g_advancedSettings.CanLogComponent(LOGVIDEO))
+      CLog::Log(LOGDEBUG, "%s::%s - MMAL: clear:%d flags:%x alpha:%d source:%d omvb:%p mmal:%p mflags:%x", CLASSNAME, __func__, clear, flags, alpha, source, omvb, omvb->mmal_buffer, omvb->mmal_buffer->flags);
+    // we only want to upload frames once
+    if (omvb->mmal_buffer->flags & MMAL_BUFFER_HEADER_FLAG_USER1)
+      return;
+    // check for changes in aligned sizes
+    if (omvb->m_width != (uint32_t)m_vout_input->format->es->video.crop.width || omvb->m_height != (uint32_t)m_vout_input->format->es->video.crop.height ||
+        omvb->m_aligned_width != m_vout_input->format->es->video.width || omvb->m_aligned_height != m_vout_input->format->es->video.height)
     {
-      if (g_advancedSettings.CanLogComponent(LOGVIDEO))
-        CLog::Log(LOGDEBUG, "%s::%s - MMAL: clear:%d flags:%x alpha:%d source:%d omvb:%p mmal:%p mflags:%x", CLASSNAME, __func__, clear, flags, alpha, source, omvb, omvb->mmal_buffer, omvb->mmal_buffer->flags);
-      // we only want to upload frames once
-      if (omvb->mmal_buffer->flags & MMAL_BUFFER_HEADER_FLAG_USER1)
+      CLog::Log(LOGDEBUG, "%s::%s Changing dimensions from %dx%d (%dx%d) to %dx%d (%dx%d)", CLASSNAME, __func__,
+          m_vout_input->format->es->video.crop.width, m_vout_input->format->es->video.crop.height, omvb->m_width, omvb->m_height,
+          m_vout_input->format->es->video.width, m_vout_input->format->es->video.height, omvb->m_aligned_width, omvb->m_aligned_height);
+      m_vout_input->format->es->video.width = omvb->m_aligned_width;
+      m_vout_input->format->es->video.height = omvb->m_aligned_height;
+      m_vout_input->format->es->video.crop.width = omvb->m_width;
+      m_vout_input->format->es->video.crop.height = omvb->m_height;
+      MMAL_STATUS_T status = mmal_port_format_commit(m_vout_input);
+      if (status != MMAL_SUCCESS)
+      {
+        CLog::Log(LOGERROR, "%s::%s Failed to commit vout input format (status=%x %s)", CLASSNAME, __func__, status, mmal_status_to_string(status));
         return;
-      omvb->Acquire();
-      omvb->mmal_buffer->flags |= MMAL_BUFFER_HEADER_FLAG_USER1 | MMAL_BUFFER_HEADER_FLAG_USER2;
-      mmal_port_send_buffer(m_vout_input, omvb->mmal_buffer);
+      }
     }
-    else
-      CLog::Log(LOGDEBUG, "%s::%s - No buffer to update", CLASSNAME, __func__);
+    m_inflight++;
+    assert(omvb->mmal_buffer && omvb->mmal_buffer->data && omvb->mmal_buffer->length);
+    omvb->Acquire();
+    omvb->mmal_buffer->flags |= MMAL_BUFFER_HEADER_FLAG_USER1 | MMAL_BUFFER_HEADER_FLAG_USER2;
+    omvb->mmal_buffer->user_data = omvb;
+    mmal_port_send_buffer(m_vout_input, omvb->mmal_buffer);
   }
-  else if (m_format == RENDER_FMT_YUV420P)
-  {
-    CYUVVideoBuffer *omvb = buffer->YUVBuffer;
-    if (omvb && omvb->mmal_buffer)
-    {
-      if (g_advancedSettings.CanLogComponent(LOGVIDEO))
-        CLog::Log(LOGDEBUG, "%s::%s - YUV: clear:%d flags:%x alpha:%d source:%d omvb:%p mmal:%p mflags:%x", CLASSNAME, __func__, clear, flags, alpha, source, omvb, omvb->mmal_buffer, omvb->mmal_buffer->flags);
-      // we only want to upload frames once
-      if (omvb->mmal_buffer->flags & MMAL_BUFFER_HEADER_FLAG_USER1)
-        return;
-      // sanity check it is not on display
-      omvb->Acquire();
-      omvb->mmal_buffer->flags |= MMAL_BUFFER_HEADER_FLAG_USER1 | MMAL_BUFFER_HEADER_FLAG_USER2;
-      omvb->mmal_buffer->user_data = omvb;
-      mmal_port_send_buffer(m_vout_input, omvb->mmal_buffer);
-    }
-    else
-      CLog::Log(LOGDEBUG, "%s::%s - No buffer to update: clear:%d flags:%x alpha:%d source:%d", CLASSNAME, __func__, clear, flags, alpha, source);
-  }
-  else assert(0);
+  else
+    CLog::Log(LOGDEBUG, "%s::%s - MMAL: No buffer to update clear:%d flags:%x alpha:%d source:%d omvb:%p mmal:%p", CLASSNAME, __func__, clear, flags, alpha, source, omvb, omvb ? omvb->mmal_buffer : nullptr);
 }
 
 void CMMALRenderer::FlipPage(int source)
 {
   CSingleLock lock(m_sharedSection);
-  if (!m_bConfigured || m_format == RENDER_FMT_BYPASS)
+  if (!m_bConfigured || m_format != RENDER_FMT_MMAL)
   {
     if (g_advancedSettings.CanLogComponent(LOGVIDEO))
-      CLog::Log(LOGDEBUG, "%s::%s - not configured: source:%d", CLASSNAME, __func__, source);
+      CLog::Log(LOGDEBUG, "%s::%s - not configured: source:%d format:%d", CLASSNAME, __func__, source, m_format);
     return;
   }
 
@@ -509,7 +386,6 @@ void CMMALRenderer::PreInit()
   CLog::Log(LOGDEBUG, "%s::%s", CLASSNAME, __func__);
 
   m_formats.clear();
-  m_formats.push_back(RENDER_FMT_YUV420P);
   m_formats.push_back(RENDER_FMT_MMAL);
   m_formats.push_back(RENDER_FMT_BYPASS);
 
@@ -602,13 +478,6 @@ bool CMMALRenderer::Supports(EDEINTERLACEMODE mode)
 
 bool CMMALRenderer::Supports(EINTERLACEMETHOD method)
 {
-  if (m_format == RENDER_FMT_YUV420P)
-  {
-    if (method == VS_INTERLACEMETHOD_DEINTERLACE_HALF)
-      return true;
-    else
-      return false;
-  }
   if (method == VS_INTERLACEMETHOD_AUTO)
     return true;
   if (method == VS_INTERLACEMETHOD_MMAL_ADVANCED)
@@ -642,8 +511,6 @@ bool CMMALRenderer::Supports(ESCALINGMETHOD method)
 
 EINTERLACEMETHOD CMMALRenderer::AutoInterlaceMethod()
 {
-  if (m_format == RENDER_FMT_YUV420P)
-    return VS_INTERLACEMETHOD_DEINTERLACE_HALF;
   return m_sourceWidth * m_sourceHeight <= 576 * 720 ? VS_INTERLACEMETHOD_MMAL_ADVANCED : VS_INTERLACEMETHOD_MMAL_BOB;
 }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.h
@@ -38,30 +38,12 @@
 #define AUTOSOURCE -1
 
 class CBaseTexture;
-class CMMALVideoBuffer;
+class CMMALBuffer;
 
 struct DVDVideoPicture;
 
-class CYUVVideoBuffer
-{
-public:
-  CYUVVideoBuffer();
-  ~CYUVVideoBuffer();
-  // reference counting
-  CYUVVideoBuffer *Acquire();
-  long Release();
-  MMAL_BUFFER_HEADER_T *mmal_buffer;
-protected:
-  long m_refs;
-};
-
 class CMMALRenderer : public CBaseRenderer
 {
-  struct YUVBUFFER
-  {
-    CMMALVideoBuffer *MMALBuffer; // used for hw decoded buffers
-    CYUVVideoBuffer  *YUVBuffer;  // used for sw decoded buffers
-  };
 public:
   CMMALRenderer();
   ~CMMALRenderer();
@@ -99,13 +81,14 @@ public:
   virtual bool         IsGuiLayer() { return false; }
 
   void vout_input_port_cb(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer);
+  MMAL_POOL_T *GetPool(ERenderFormat format, bool opaque);
 protected:
   int m_iYV12RenderBuffer;
   int m_NumYV12Buffers;
 
   std::vector<ERenderFormat> m_formats;
 
-  YUVBUFFER            m_buffers[NUM_BUFFERS];
+  CMMALBuffer         *m_buffers[NUM_BUFFERS];
   bool                 m_bConfigured;
   bool                 m_bMMALConfigured;
   unsigned int         m_extended_format;
@@ -117,13 +100,14 @@ protected:
   RENDER_STEREO_MODE        m_display_stereo_mode;
   bool                      m_StereoInvert;
   int                       m_inflight;
+  bool                      m_opaque;
 
   CCriticalSection m_sharedSection;
   MMAL_COMPONENT_T *m_vout;
   MMAL_PORT_T *m_vout_input;
   MMAL_POOL_T *m_vout_input_pool;
 
-  bool init_vout(ERenderFormat format);
+  bool init_vout(ERenderFormat format, bool opaque);
   void ReleaseBuffers();
   void UnInitMMAL();
 };

--- a/xbmc/linux/RBP.cpp
+++ b/xbmc/linux/RBP.cpp
@@ -27,6 +27,16 @@
 
 #include "cores/omxplayer/OMXImage.h"
 
+#include <sys/ioctl.h>
+#include "rpi/rpi_user_vcsm.h"
+
+#define MAJOR_NUM 100
+#define IOCTL_MBOX_PROPERTY _IOWR(MAJOR_NUM, 0, char *)
+#define DEVICE_FILE_NAME "/dev/vcio"
+
+static int mbox_open();
+static void mbox_close(int file_desc);
+
 CRBP::CRBP()
 {
   m_initialized     = false;
@@ -34,6 +44,8 @@ CRBP::CRBP()
   m_DllBcmHost      = new DllBcmHost();
   m_OMX             = new COMXCore();
   m_display = DISPMANX_NO_HANDLE;
+  m_mb = mbox_open();
+  vcsm_init();
 }
 
 CRBP::~CRBP()
@@ -214,5 +226,107 @@ void CRBP::Deinitialize()
   m_omx_image_init  = false;
   m_initialized     = false;
   m_omx_initialized = false;
+  if (m_mb)
+    mbox_close(m_mb);
+  m_mb = 0;
+  vcsm_exit();
 }
+
+static int mbox_property(int file_desc, void *buf)
+{
+   int ret_val = ioctl(file_desc, IOCTL_MBOX_PROPERTY, buf);
+
+   if (ret_val < 0)
+   {
+     CLog::Log(LOGERROR, "%s: ioctl_set_msg failed:%d", __FUNCTION__, ret_val);
+   }
+   return ret_val;
+}
+
+static int mbox_open()
+{
+   int file_desc;
+
+   // open a char device file used for communicating with kernel mbox driver
+   file_desc = open(DEVICE_FILE_NAME, 0);
+   if (file_desc < 0)
+     CLog::Log(LOGERROR, "%s: Can't open device file: %s (%d)", __FUNCTION__, DEVICE_FILE_NAME, file_desc);
+
+   return file_desc;
+}
+
+static void mbox_close(int file_desc)
+{
+  close(file_desc);
+}
+
+static unsigned mem_lock(int file_desc, unsigned handle)
+{
+   int i=0;
+   unsigned p[32];
+   p[i++] = 0; // size
+   p[i++] = 0x00000000; // process request
+
+   p[i++] = 0x3000d; // (the tag id)
+   p[i++] = 4; // (size of the buffer)
+   p[i++] = 4; // (size of the data)
+   p[i++] = handle;
+
+   p[i++] = 0x00000000; // end tag
+   p[0] = i*sizeof *p; // actual size
+
+   mbox_property(file_desc, p);
+   return p[5];
+}
+
+unsigned mem_unlock(int file_desc, unsigned handle)
+{
+   int i=0;
+   unsigned p[32];
+   p[i++] = 0; // size
+   p[i++] = 0x00000000; // process request
+
+   p[i++] = 0x3000e; // (the tag id)
+   p[i++] = 4; // (size of the buffer)
+   p[i++] = 4; // (size of the data)
+   p[i++] = handle;
+
+   p[i++] = 0x00000000; // end tag
+   p[0] = i*sizeof *p; // actual size
+
+   mbox_property(file_desc, p);
+   return p[5];
+}
+
+CGPUMEM::CGPUMEM(unsigned int numbytes, bool cached)
+{
+  m_numbytes = numbytes;
+  m_vcsm_handle = vcsm_malloc_cache(numbytes, cached ? VCSM_CACHE_TYPE_HOST : VCSM_CACHE_TYPE_NONE, (char *)"CGPUMEM");
+  assert(m_vcsm_handle);
+  m_vc_handle = vcsm_vc_hdl_from_hdl(m_vcsm_handle);
+  assert(m_vc_handle);
+  m_arm = vcsm_lock(m_vcsm_handle);
+  assert(m_arm);
+  m_vc = mem_lock(g_RBP.GetMBox(), m_vc_handle);
+  assert(m_vc);
+}
+
+CGPUMEM::~CGPUMEM()
+{
+  mem_unlock(g_RBP.GetMBox(), m_vc_handle);
+  vcsm_unlock_ptr(m_arm);
+  vcsm_free(m_vcsm_handle);
+}
+
+// Call this to clean and invalidate a region of memory
+void CGPUMEM::Flush()
+{
+  struct vcsm_user_clean_invalid_s iocache = {};
+  iocache.s[0].handle = m_vcsm_handle;
+  iocache.s[0].cmd = 3; // clean+invalidate
+  iocache.s[0].addr = (int) m_arm;
+  iocache.s[0].size  = m_numbytes;
+  vcsm_clean_invalid( &iocache );
+}
+
 #endif

--- a/xbmc/linux/RBP.h
+++ b/xbmc/linux/RBP.h
@@ -41,6 +41,20 @@
 #include "threads/CriticalSection.h"
 #include "threads/Event.h"
 
+class CGPUMEM
+{
+public:
+  CGPUMEM(unsigned int numbytes, bool cached = true);
+  ~CGPUMEM();
+  void Flush();
+  void *m_arm; // Pointer to memory mapped on ARM side
+  int m_vc_handle;   // Videocore handle of relocatable memory
+  int m_vcsm_handle; // Handle for use by VCSM
+  unsigned int m_vc;       // Address for use in GPU code
+  unsigned int m_numbytes; // Size of memory block
+  void *m_opaque;
+};
+
 class CRBP
 {
 public:
@@ -63,6 +77,7 @@ public:
   unsigned char *CaptureDisplay(int width, int height, int *stride, bool swap_red_blue, bool video_only = true);
   DllOMX *GetDllOMX() { return m_OMX ? m_OMX->GetDll() : NULL; }
   void WaitVsync();
+  int GetMBox() { return m_mb; }
 
 private:
   DllBcmHost *m_DllBcmHost;
@@ -79,6 +94,8 @@ private:
   CEvent     m_vsync;
   class DllLibOMXCore;
   CCriticalSection m_critSection;
+
+  int m_mb;
 };
 
 extern CRBP g_RBP;

--- a/xbmc/linux/rpi/rpi_user_vcsm.h
+++ b/xbmc/linux/rpi/rpi_user_vcsm.h
@@ -1,0 +1,437 @@
+/*
+ *  Copyright (C) 2015-2016 Raspberry Pi (Trading) Ltd.
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+/* VideoCore Shared Memory - user interface library.
+**
+** This library provides all the necessary abstraction for any application to
+** make use of the shared memory service which is distributed accross a kernel
+** driver and a videocore service.
+**
+** It is an application design decision to choose or not to use this service.
+**
+** The logical flow of operations that a user application needs to follow when
+** using this service is:
+**
+**       1) Initialize the service.
+**       2) Allocate shared memory blocks.
+**       3) Start using the allocated blocks.
+**          - In order to gain ownership on a block, lock the allocated block,
+**            locking a block returns a valid address that the user application
+**            can access.
+**          - When finished with using the block for the current execution cycle
+**            or function, and so when giving up the ownership, unlock the block.
+**       4) A block can be locked/unlocked as many times required - within or outside
+**          of - a specific execution context.
+**       5) To completely release an allocated block, free it.
+**       6) If the service is no longer required, terminate it.
+**
+**
+** Some generic considerations:
+
+** Allocating memory blocks.
+**
+**   Memory blocks can be allocated in different manners depending on the cache
+**   behavior desired.  A given block can either be:
+
+**       - Allocated in a non cached fashion all the way through host and videocore.
+**       - Allocated in a cached fashion on host OR videocore.
+**       - Allocated in a cached fashion on host AND videocore.
+**
+**   It is an application decision to determine how to allocate a block.  Evidently
+**   if the application will be doing substantial read/write accesses to a given block,
+**   it is recommended to allocate the block at least in a 'host cached' fashion for
+**   better results.
+**
+**
+** Locking memory blocks.
+**
+**   When the memory block has been allocated in a host cached fashion, locking the
+**   memory block (and so taking ownership of it) will trigger a cache invalidation.
+**
+**   For the above reason and when using host cached allocation, it is important that
+**   an application properly implements the lock/unlock mechanism to ensure cache will
+**   stay coherent, otherwise there is no guarantee it will at all be.
+**
+**   It is possible to dynamically change the host cache behavior (ie cached or non
+**   cached) of a given allocation without needing to free and re-allocate the block.
+**   This feature can be useful for such application which requires access to the block
+**   only at certain times and not otherwise.  By changing the cache behavior dynamically
+**   the application can optimize performances for a given duration of use.
+**   Such dynamic cache behavior remapping only applies to host cache and not videocore
+**   cache.  If one requires to change the videocore cache behavior, then a new block
+**   must be created to replace the old one.
+**
+**   On successful locking, a valid pointer is returned that the application can use
+**   to access to data inside the block.  There is no guarantee that the pointer will
+**   stay valid following the unlock action corresponding to this lock.
+**
+**
+** Unocking memory blocks.
+**
+**   When the memory block has been allocated in a host cached fashion, unlocking the
+**   memory block (and so forgiving its ownership) will trigger a cache flush unless
+**   explicitely asked not to flush the cache for performances reasons.
+**
+**   For the above reason and when using host cached allocation, it is important that
+**   an application properly implements the lock/unlock mechanism to ensure cache will
+**   stay coherent, otherwise there is no guarantee it will at all be.
+**
+**
+** A complete API is defined below.
+*/
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/* Different status that can be dumped.
+*/
+typedef enum
+{
+   VCSM_STATUS_VC_WALK_ALLOC = 0,   // Walks *all* the allocation on videocore.
+                                    // Result of the walk is seen in the videocore
+                                    // log.
+   VCSM_STATUS_HOST_WALK_MAP,       // Walks the *full* mapping allocation on host
+                                    // driver (ie for all processes).  Result of
+                                    // the walk is seen in the kernel log.
+   VCSM_STATUS_HOST_WALK_PID_MAP,   // Walks the per process mapping allocation on host
+                                    // driver (for current process).  Result of
+                                    // the walk is seen in the kernel log.
+   VCSM_STATUS_HOST_WALK_PID_ALLOC, // Walks the per process host allocation on host
+                                    // driver (for current process).  Result of
+                                    // the walk is seen in the kernel log.
+   VCSM_STATUS_VC_MAP_ALL,          // Equivalent to both VCSM_STATUS_VC_WALK_ALLOC and
+                                    // VCSM_STATUS_HOST_WALK_MAP.
+                                    //
+   VCSM_STATUS_NONE,                // Must be last - invalid.
+
+} VCSM_STATUS_T;
+
+/* Different kind of cache behavior.
+*/
+typedef enum
+{
+   VCSM_CACHE_TYPE_NONE = 0,        // No caching applies.
+   VCSM_CACHE_TYPE_HOST,            // Allocation is cached on host (user space).
+   VCSM_CACHE_TYPE_VC,              // Allocation is cached on videocore.
+   VCSM_CACHE_TYPE_HOST_AND_VC,     // Allocation is cached on both host and videocore.
+
+} VCSM_CACHE_TYPE_T;
+
+/* Initialize the vcsm processing.
+**
+** Must be called once before attempting to do anything else.
+**
+** Returns 0 on success, -1 on error.
+*/
+int vcsm_init( void );
+
+
+/* Terminates the vcsm processing.
+**
+** Must be called vcsm services are no longer needed, it will
+** take care of removing any allocation under the current process
+** control if deemed necessary.
+*/
+void vcsm_exit( void );
+
+
+/* Queries the status of the the vcsm.
+**
+** Triggers dump of various kind of information, see the
+** different variants specified in VCSM_STATUS_T.
+**
+** Pid is optional.
+*/
+void vcsm_status( VCSM_STATUS_T status, int pid );
+
+
+/* Allocates a non-cached block of memory of size 'size' via the vcsm memory
+** allocator.
+**
+** Returns:        0 on error
+**                 a non-zero opaque handle on success.
+**
+** On success, the user must invoke vcsm_lock with the returned opaque
+** handle to gain access to the memory associated with the opaque handle.
+** When finished using the memory, the user calls vcsm_unlock_xx (see those
+** function definition for more details on the one that can be used).
+** 
+** A well behaved application should make every attempt to lock/unlock
+** only for the duration it needs to access the memory data associated with
+** the opaque handle.
+*/
+unsigned int vcsm_malloc( unsigned int size, char *name );
+
+
+/* Allocates a cached block of memory of size 'size' via the vcsm memory
+** allocator, the type of caching requested is passed as argument of the
+** function call.
+**
+** Returns:        0 on error
+**                 a non-zero opaque handle on success.
+**
+** On success, the user must invoke vcsm_lock with the returned opaque
+** handle to gain access to the memory associated with the opaque handle.
+** When finished using the memory, the user calls vcsm_unlock_xx (see those
+** function definition for more details on the one that can be used).
+** 
+** A well behaved application should make every attempt to lock/unlock
+** only for the duration it needs to access the memory data associated with
+** the opaque handle.
+*/
+unsigned int vcsm_malloc_cache( unsigned int size, VCSM_CACHE_TYPE_T cache, char *name );
+
+
+/* Shares an allocated block of memory via the vcsm memory allocator.
+**
+** Returns:        0 on error
+**                 a non-zero opaque handle on success.
+**
+** On success, the user must invoke vcsm_lock with the returned opaque
+** handle to gain access to the memory associated with the opaque handle.
+** When finished using the memory, the user calls vcsm_unlock_xx (see those
+** function definition for more details on the one that can be used).
+**
+** A well behaved application should make every attempt to lock/unlock
+** only for the duration it needs to access the memory data associated with
+** the opaque handle.
+*/
+unsigned int vcsm_malloc_share( unsigned int handle );
+
+
+/* Resizes a block of memory allocated previously by vcsm_alloc.
+**
+** Returns:        0 on success
+**                 -errno on error.
+**
+** The handle must be unlocked by user prior to attempting any
+** resize action.
+**
+** On error, the original size allocated against the handle
+** remains available the same way it would be following a
+** successful vcsm_malloc.
+*/
+int vcsm_resize( unsigned int handle, unsigned int new_size );
+
+
+/* Frees a block of memory that was successfully allocated by
+** a prior call the vcms_alloc.
+**
+** The handle should be considered invalid upon return from this
+** call.
+**
+** Whether any memory is actually freed up or not as the result of
+** this call will depends on many factors, if all goes well it will
+** be freed.  If something goes wrong, the memory will likely end up
+** being freed up as part of the vcsm_exit process.  In the end the
+** memory is guaranteed to be freed one way or another.
+*/
+void vcsm_free( unsigned int handle );
+
+
+/* Retrieves a videocore opaque handle from a mapped user address
+** pointer.  The videocore handle will correspond to the actual
+** memory mapped in videocore.
+**
+** Returns:        0 on error
+**                 a non-zero opaque handle on success.
+**
+** Note: the videocore opaque handle is distinct from the user
+**       opaque handle (allocated via vcsm_malloc) and it is only
+**       significant for such application which knows what to do
+**       with it, for the others it is just a number with little
+**       use since nothing can be done with it (in particular
+**       for safety reason it cannot be used to map anything).
+*/
+unsigned int vcsm_vc_hdl_from_ptr( void *usr_ptr );
+
+
+/* Retrieves a videocore opaque handle from a opaque handle
+** pointer.  The videocore handle will correspond to the actual
+** memory mapped in videocore.
+**
+** Returns:        0 on error
+**                 a non-zero opaque handle on success.
+**
+** Note: the videocore opaque handle is distinct from the user
+**       opaque handle (allocated via vcsm_malloc) and it is only
+**       significant for such application which knows what to do
+**       with it, for the others it is just a number with little
+**       use since nothing can be done with it (in particular
+**       for safety reason it cannot be used to map anything).
+*/
+unsigned int vcsm_vc_hdl_from_hdl( unsigned int handle );
+
+
+/* Retrieves a user opaque handle from a mapped user address
+** pointer.
+**
+** Returns:        0 on error
+**                 a non-zero opaque handle on success.
+*/
+unsigned int vcsm_usr_handle( void *usr_ptr );
+
+
+/* Retrieves a mapped user address from an opaque user
+** handle.
+**
+** Returns:        0 on error
+**                 a non-zero address on success.
+**
+** On success, the address corresponds to the pointer
+** which can access the data allocated via the vcsm_malloc
+** call.
+*/
+void *vcsm_usr_address( unsigned int handle );
+
+
+/* Locks the memory associated with this opaque handle.
+**
+** Returns:        NULL on error
+**                 a valid pointer on success.
+**
+** A user MUST lock the handle received from vcsm_malloc
+** in order to be able to use the memory associated with it.
+**
+** On success, the pointer returned is only valid within
+** the lock content (ie until a corresponding vcsm_unlock_xx
+** is invoked).
+*/
+void *vcsm_lock( unsigned int handle );
+
+
+/* Locks the memory associated with this opaque handle.  The lock
+** also gives a chance to update the *host* cache behavior of the
+** allocated buffer if so desired.  The *videocore* cache behavior
+** of the allocated buffer cannot be changed by this call and such
+** attempt will be ignored.
+**
+** The system will attempt to honour the cache_update mode request,
+** the cache_result mode will provide the final answer on which cache
+** mode is really in use.  Failing to change the cache mode will not
+** result in a failure to lock the buffer as it is an application
+** decision to choose what to do if (cache_result != cache_update)
+**
+** The value returned in cache_result can only be considered valid if
+** the returned pointer is non NULL.  The cache_result pointer may be
+** NULL if the application does not care about the actual outcome of
+** its action with regards to the cache behavior change.
+**
+** Returns:        NULL on error
+**                 a valid pointer on success.
+**
+** A user MUST lock the handle received from vcsm_malloc
+** in order to be able to use the memory associated with it.
+**
+** On success, the pointer returned is only valid within
+** the lock content (ie until a corresponding vcsm_unlock_xx
+** is invoked).
+*/
+void *vcsm_lock_cache( unsigned int handle,
+                       VCSM_CACHE_TYPE_T cache_update,
+                       VCSM_CACHE_TYPE_T *cache_result );
+
+
+/* Unlocks the memory associated with this user mapped address.
+**
+** Returns:        0 on success
+**                 -errno on error.
+**
+** After unlocking a mapped address, the user should no longer
+** attempt to reference it.
+*/
+int vcsm_unlock_ptr( void *usr_ptr );
+
+
+/* Unlocks the memory associated with this user mapped address.
+** Apply special processing that would override the otherwise
+** default behavior.
+**
+** If 'cache_no_flush' is specified:
+**    Do not flush cache as the result of the unlock (if cache
+**    flush was otherwise applicable in this case).
+**
+** Returns:        0 on success
+**                 -errno on error.
+**
+** After unlocking a mapped address, the user should no longer
+** attempt to reference it.
+*/
+int vcsm_unlock_ptr_sp( void *usr_ptr, int cache_no_flush );
+
+
+/* Unlocks the memory associated with this user opaque handle.
+**
+** Returns:        0 on success
+**                 -errno on error.
+**
+** After unlocking an opaque handle, the user should no longer
+** attempt to reference the mapped addressed once associated
+** with it.
+*/
+int vcsm_unlock_hdl( unsigned int handle );
+
+
+/* Unlocks the memory associated with this user opaque handle.
+** Apply special processing that would override the otherwise
+** default behavior.
+**
+** If 'cache_no_flush' is specified:
+**    Do not flush cache as the result of the unlock (if cache
+**    flush was otherwise applicable in this case).
+**
+** Returns:        0 on success
+**                 -errno on error.
+**
+** After unlocking an opaque handle, the user should no longer
+** attempt to reference the mapped addressed once associated
+** with it.
+*/
+int vcsm_unlock_hdl_sp( unsigned int handle, int cache_no_flush );
+
+/* Clean and/or invalidate the memory associated with this user opaque handle
+**
+** Returns:        non-zero on error
+**
+** structure contains a list of flush/invalidate commands. Commands are:
+** 0: nop
+** 1: invalidate       given virtual range in L1/L2
+** 2: clean            given virtual range in L1/L2
+** 3: clean+invalidate given virtual range in L1/L2
+** 4: flush all L1/L2
+*/
+struct vcsm_user_clean_invalid_s {
+   struct {
+      unsigned int cmd;
+      unsigned int handle;
+      unsigned int addr;
+      unsigned int size;
+   } s[8];
+};
+
+int vcsm_clean_invalid( struct vcsm_user_clean_invalid_s *s );
+
+#ifdef __cplusplus
+}
+#endif
+


### PR DESCRIPTION
This allows the allocation of buffers used by ffmpeg to come from the gpu.
Then we use MMALRenderer to display the buffers through an opaque pointer.
This avoids two copies of the pixel data (on in kodi and one in transfer to GPU) with software decode.

There is a quite a big performance benefit for this, and allows for example 1080p BluRay decode of MPEG-2 without a hardware codec licence, and improves HEVC support.
