### PR TITLE
[Jarvis] partly backport of PR 9231 to fix segfault

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodec.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodec.cpp
@@ -60,19 +60,15 @@ bool CDVDVideoCodec::IsSettingVisible(const std::string &condition, const std::s
   return true;
 }
 
-bool CDVDVideoCodec::IsCodecDisabled(DVDCodecAvailableType* map, unsigned int size, AVCodecID id)
+bool CDVDVideoCodec::IsCodecDisabled(const std::map<AVCodecID, std::string> &map, AVCodecID id)
 {
-  int index = -1;
-  for (unsigned int i = 0; i < size; ++i)
+  auto codec = map.find(id);
+  if (codec != map.end())
   {
-    if(map[i].codec == id)
-    {
-      index = (int) i;
-      break;
-    }
+    return (!CSettings::GetInstance().GetBool(codec->second) ||
+            !CDVDVideoCodec::IsSettingVisible("unused", "unused",
+                                              CSettings::GetInstance().GetSetting(codec->second),
+                                              NULL));
   }
-  if(index > -1)
-    return (!CSettings::GetInstance().GetBool(map[index].setting) || !CDVDVideoCodec::IsSettingVisible("unused", "unused", CSettings::GetInstance().GetSetting(map[index].setting), NULL));
-
   return false; //don't disable what we don't have
 }

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodec.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodec.h
@@ -24,6 +24,7 @@
 
 #include <vector>
 #include <string>
+#include <map>
 #include "cores/VideoRenderers/RenderFormats.h"
 
 
@@ -33,12 +34,6 @@ extern "C" {
 }
 
 class CSetting;
-
-struct DVDCodecAvailableType 
-{
-  AVCodecID codec;
-  const char* setting;
-};
 
 // when modifying these structures, make sure you update all codecs accordingly
 #define FRAME_TYPE_UNDEF 0
@@ -290,7 +285,7 @@ public:
   /**
   * Interact with user settings so that user disabled codecs are disabled
   */
-  static bool IsCodecDisabled(DVDCodecAvailableType* map, unsigned int size, AVCodecID id);
+  static bool IsCodecDisabled(const std::map<AVCodecID, std::string> &map, AVCodecID id);
 
    /* For calculation of dropping requirements player asks for some information.
    *

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.cpp
@@ -451,16 +451,6 @@ bool CVideoSurfaces::HasRefs()
 // VAAPI
 //-----------------------------------------------------------------------------
 
-// settings codecs mapping
-DVDCodecAvailableType g_vaapi_available[] = {
-  { AV_CODEC_ID_H263, CSettings::SETTING_VIDEOPLAYER_USEVAAPIMPEG4.c_str() },
-  { AV_CODEC_ID_MPEG4, CSettings::SETTING_VIDEOPLAYER_USEVAAPIMPEG4.c_str() },
-  { AV_CODEC_ID_WMV3, CSettings::SETTING_VIDEOPLAYER_USEVAAPIVC1.c_str() },
-  { AV_CODEC_ID_VC1, CSettings::SETTING_VIDEOPLAYER_USEVAAPIVC1.c_str() },
-  { AV_CODEC_ID_MPEG2VIDEO, CSettings::SETTING_VIDEOPLAYER_USEVAAPIMPEG2.c_str() },
-};
-const size_t settings_count = sizeof(g_vaapi_available) / sizeof(DVDCodecAvailableType);
-
 CDecoder::CDecoder() : m_vaapiOutput(&m_inMsgEvent)
 {
   m_vaapiConfig.videoSurfaces = &m_videoSurfaces;
@@ -500,7 +490,14 @@ bool CDecoder::Open(AVCodecContext* avctx, AVCodecContext* mainctx, const enum P
   }
 
   // check if user wants to decode this format with VAAPI
-  if (CDVDVideoCodec::IsCodecDisabled(g_vaapi_available, settings_count, avctx->codec_id))
+  std::map<AVCodecID, std::string> settings_map = {
+    { AV_CODEC_ID_H263, CSettings::SETTING_VIDEOPLAYER_USEVAAPIMPEG4 },
+    { AV_CODEC_ID_MPEG4, CSettings::SETTING_VIDEOPLAYER_USEVAAPIMPEG4 },
+    { AV_CODEC_ID_WMV3, CSettings::SETTING_VIDEOPLAYER_USEVAAPIVC1 },
+    { AV_CODEC_ID_VC1, CSettings::SETTING_VIDEOPLAYER_USEVAAPIVC1 },
+    { AV_CODEC_ID_MPEG2VIDEO, CSettings::SETTING_VIDEOPLAYER_USEVAAPIMPEG2 },
+  };
+  if (CDVDVideoCodec::IsCodecDisabled(settings_map, avctx->codec_id))
     return false;
 
   if (g_advancedSettings.CanLogComponent(LOGVIDEO))

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
@@ -45,16 +45,6 @@ using namespace VDPAU;
 
 #define ARSIZE(x) (sizeof(x) / sizeof((x)[0]))
 
-// settings codecs mapping
-DVDCodecAvailableType g_vdpau_available[] = {
-  { AV_CODEC_ID_H263, CSettings::SETTING_VIDEOPLAYER_USEVDPAUMPEG4.c_str() },
-  { AV_CODEC_ID_MPEG4, CSettings::SETTING_VIDEOPLAYER_USEVDPAUMPEG4.c_str() },
-  { AV_CODEC_ID_WMV3, CSettings::SETTING_VIDEOPLAYER_USEVDPAUVC1.c_str() },
-  { AV_CODEC_ID_VC1, CSettings::SETTING_VIDEOPLAYER_USEVDPAUVC1.c_str() },
-  { AV_CODEC_ID_MPEG2VIDEO, CSettings::SETTING_VIDEOPLAYER_USEVDPAUMPEG2.c_str() },
-};
-const size_t settings_count = sizeof(g_vdpau_available) / sizeof(DVDCodecAvailableType);
-
 CDecoder::Desc decoder_profiles[] = {
 {"MPEG1",        VDP_DECODER_PROFILE_MPEG1},
 {"MPEG2_SIMPLE", VDP_DECODER_PROFILE_MPEG2_SIMPLE},
@@ -494,7 +484,14 @@ bool CDecoder::Open(AVCodecContext* avctx, AVCodecContext* mainctx, const enum P
   // nvidia is whitelisted despite for mpeg-4 we need to query user settings
   if ((gpuvendor.compare(0, 6, "nvidia") != 0)  || (avctx->codec_id == AV_CODEC_ID_MPEG4) || (avctx->codec_id == AV_CODEC_ID_H263))
   {
-    if (CDVDVideoCodec::IsCodecDisabled(g_vdpau_available, settings_count, avctx->codec_id))
+    std::map<AVCodecID, std::string> settings_map = {
+      { AV_CODEC_ID_H263, CSettings::SETTING_VIDEOPLAYER_USEVDPAUMPEG4 },
+      { AV_CODEC_ID_MPEG4, CSettings::SETTING_VIDEOPLAYER_USEVDPAUMPEG4 },
+      { AV_CODEC_ID_WMV3, CSettings::SETTING_VIDEOPLAYER_USEVDPAUVC1 },
+      { AV_CODEC_ID_VC1, CSettings::SETTING_VIDEOPLAYER_USEVDPAUVC1 },
+      { AV_CODEC_ID_MPEG2VIDEO, CSettings::SETTING_VIDEOPLAYER_USEVDPAUMPEG2 },
+    };
+    if (CDVDVideoCodec::IsCodecDisabled(settings_map, avctx->codec_id))
       return false;
   }
 


### PR DESCRIPTION
This patch is a backport of
https://github.com/xbmc/xbmc/commit/a81208e3b53b84763fb9f20d8642ffc7bc63c9a7
to fix a segfault during playback of vaapi-accelerated mpeg2 content:

terminate called after throwing an instance of 'std::logic_error'
  what():  basic_string::_S_construct null not valid
[New LWP 3743]

Program received signal SIGABRT, Aborted.
[Switching to LWP 3743]
0xb5664a9b in raise () from /lib/libc.so.0
(gdb) bt full
No symbol table info available.
No symbol table info available.
No symbol table info available.
No symbol table info available.
No symbol table info available.
No symbol table info available.
No symbol table info available.
No symbol table info available.
No symbol table info available.
    at DVDVideoCodec.cpp:75
        index = <optimized out>
    surfaces=6) at VAAPI.cpp:503
        gpuvendor = {static npos = <optimized out>,
          _M_dataplus = {std::allocator<char> = {<__gnu_cxx::new_allocator<char>> = {<No data fields>}, <No data fields>}, _M_p = 0xceb267c "intel open source technology center"}}
        profile = <optimized out>
        dec = 0xd09e5e8
        ctx = <optimized out>
        cur = 0x986d9c0
