### PR TITLE
cores/VideoPlayer/ProcessInfo: make GetFallbackDeintMethod() virtual

### DIFF
--- a/xbmc/cores/VideoPlayer/Process/ProcessInfo.h
+++ b/xbmc/cores/VideoPlayer/Process/ProcessInfo.h
@@ -26,7 +26,7 @@ class CProcessInfo
 public:
   static CProcessInfo* CreateInstance();
   virtual ~CProcessInfo();
-  EINTERLACEMETHOD GetFallbackDeintMethod();
+  virtual EINTERLACEMETHOD GetFallbackDeintMethod();
 
 protected:
   CProcessInfo();

--- a/xbmc/cores/VideoPlayer/Process/overrides/rbpi/ProcessInfoPi.h
+++ b/xbmc/cores/VideoPlayer/Process/overrides/rbpi/ProcessInfoPi.h
@@ -26,7 +26,7 @@ class CProcessInfoPi : public CProcessInfo
 {
 public:
   virtual ~CProcessInfoPi();
-  EINTERLACEMETHOD GetFallbackDeintMethod();
+  EINTERLACEMETHOD GetFallbackDeintMethod() override;
 
 //protected:
   CProcessInfoPi();


### PR DESCRIPTION
As stated in https://github.com/xbmc/xbmc/pull/9390, Kodi's way of
"overrides" at build time doesn't work at all, because the compiler
doesn't use magic fairy dust to invoke
CProcessInfoPi::GetFallbackDeintMethod() instead of
CProcessInfo::GetFallbackDeintMethod().  Making the method virtual is
the only way to call CProcessInfoPi's method through the interface
CProcessInfo.

Note that this adds a tiny amount of overhead.  What I would do is add
an "#ifdef TARGET_RASPBERRY_PI" to
CProcessInfo::GetFallbackDeintMethod(), but Team Kodi prefers moving
that #ifdef into a dedicated Raspberry Pi specific source code, along
with pathname wildcards and obscure variables in Makefile.  That's
pretty complicated, but so be it.
