### PR TITLE
[pvr] infodialogs: close dialogs with "info" action.

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
@@ -203,6 +203,12 @@ bool CGUIDialogPVRGuideInfo::OnMessage(CGUIMessage& message)
   return CGUIDialog::OnMessage(message);
 }
 
+bool CGUIDialogPVRGuideInfo::OnInfo(int actionID)
+{
+  Close();
+  return true;
+}
+
 void CGUIDialogPVRGuideInfo::SetProgInfo(const CFileItem *item)
 {
   *m_progItem = *item;

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.h
@@ -38,6 +38,7 @@ namespace PVR
     CGUIDialogPVRGuideInfo(void);
     virtual ~CGUIDialogPVRGuideInfo(void);
     virtual bool OnMessage(CGUIMessage& message);
+    virtual bool OnInfo(int actionID) override;
     virtual bool HasListItems() const { return true; };
     virtual CFileItemPtr GetCurrentListItem(int offset = 0);
 

--- a/xbmc/pvr/dialogs/GUIDialogPVRRecordingInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRRecordingInfo.cpp
@@ -48,6 +48,12 @@ bool CGUIDialogPVRRecordingInfo::OnMessage(CGUIMessage& message)
   return CGUIDialog::OnMessage(message);
 }
 
+bool CGUIDialogPVRRecordingInfo::OnInfo(int actionID)
+{
+  Close();
+  return true;
+}
+
 void CGUIDialogPVRRecordingInfo::SetRecording(const CFileItem *item)
 {
   *m_recordItem = *item;

--- a/xbmc/pvr/dialogs/GUIDialogPVRRecordingInfo.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRRecordingInfo.h
@@ -29,6 +29,7 @@ namespace PVR
     CGUIDialogPVRRecordingInfo(void);
     virtual ~CGUIDialogPVRRecordingInfo(void) {}
     virtual bool OnMessage(CGUIMessage& message);
+    virtual bool OnInfo(int actionID) override;
     virtual bool HasListItems() const { return true; };
     virtual CFileItemPtr GetCurrentListItem(int offset = 0);
 


### PR DESCRIPTION
This makes PVR infodialogs close when pressing oninfo to make it consistent with other infodialogs.
@xhaggi         
