### PR TITLE
Fix MySQL issue cloning artist on music library conversion to version 60

### DIFF
--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -4718,14 +4718,16 @@ void CMusicDatabase::UpdateTables(int version)
     { 
       // When BLANKARTIST_ID (=1) is already in use, move the record
       try
-      { //Use temp table to move record
-        strSQL = PrepareSQL("CREATE TEMPORARY TABLE tmp_artist AS SELECT * FROM artist WHERE artist.idArtist = %i", BLANKARTIST_ID);
+      { //No mbid index yet, so can have record for artist twice even with mbid
+        strSQL = PrepareSQL("INSERT INTO artist SELECT null, "
+          "strArtist, strMusicBrainzArtistID, "
+          "strBorn, strFormed, strGenres, strMoods, "
+          "strStyles, strInstruments, strBiography, "
+          "strDied, strDisbanded, strYearsActive, "
+          "strImage, strFanart, lastScraped "
+          "FROM artist WHERE artist.idArtist = %i", BLANKARTIST_ID);
         m_pDS->exec(strSQL);
-        m_pDS->exec("UPDATE tmp_artist SET idArtist = NULL");
-        //No mbid index yet, so can have record for artist twice even with mbid
-        m_pDS->exec("INSERT INTO artist SELECT * FROM tmp_artist");
         int idArtist = (int)m_pDS->lastinsertid();
-        m_pDS->exec("DROP TABLE tmp_artist");
         //No triggers, so can delete artist without effecting other tables.
         strSQL = PrepareSQL("DELETE FROM artist WHERE artist.idArtist = %i", BLANKARTIST_ID);
         m_pDS->exec(strSQL);


### PR DESCRIPTION
This fixes ticket http://trac.kodi.tv/ticket/16633
Caught out by differences between MySQL and SQLite again, that causes update from earlier music library database versions to fail on MySQL. 

This follows on from #9205  that modifies user data during update, and uses a temp table to clone artist record with idartist = 1 to make space for the missing tag artist. In SQLite temporay tables created from a table don't gain any of the column constraints, in MySQL they do. So in MySQL you need to modify the idartist column of the temp table to allow null, but SQLite does not support that syntax.

Solution is to use column names and avoid temp table entirely.

Not sure how we missed this last time @MilhouseVH, I guess testing didn't involve moving an existing artist, or is it a MySQL version thing?

Unable to get into trac at the moment to update there and inform poster
