### PR TITLE
Support per-stream proxies in HLS streams (attempt 3)

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -54,6 +54,7 @@
 #include "URL.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
+#include "utils/Proxy.h"
 #include "utils/RegExp.h"
 #include "utils/log.h"
 #include "utils/Variant.h"
@@ -1564,6 +1565,37 @@ bool CFileItem::IsURL(const CURL& url) const
 bool CFileItem::IsPath(const std::string& path, bool ignoreURLOptions /* = false */) const
 {
   return URIUtils::PathEquals(m_strPath, path, false, ignoreURLOptions);
+}
+
+CProxy CFileItem::GetProxy() const
+{
+  CProxy proxy;
+  if (HasProperty("proxy.type"))
+  {
+    const std::string value = GetProperty("proxy.type").asString();
+    if (value == "http")
+      proxy.SetType(CProxy::ProxyHttp);
+    else if (value == "socks4")
+      proxy.SetType(CProxy::ProxySocks4);
+    else if (value == "socks4a")
+      proxy.SetType(CProxy::ProxySocks4A);
+    else if (value == "socks5")
+      proxy.SetType(CProxy::ProxySocks5);
+    else if (value == "socks5-remote")
+      proxy.SetType(CProxy::ProxySocks5Remote);
+    else
+      CLog::Log(LOGERROR,"Invalid proxy type \"%s\"", value.c_str());
+  }
+  if (HasProperty("proxy.host"))
+    proxy.SetHost(GetProperty("proxy.host").asString());
+  if (HasProperty("proxy.port"))
+    proxy.SetPort(GetProperty("proxy.port").asInteger());
+  if (HasProperty("proxy.user"))
+    proxy.SetUser(GetProperty("proxy.user").asString());
+  if (HasProperty("proxy.password"))
+    proxy.SetPassword(GetProperty("proxy.password").asString());
+
+  return proxy;
 }
 
 void CFileItem::SetCueDocument(const CCueDocumentPtr& cuePtr)

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -36,6 +36,7 @@
 #include "utils/ISerializable.h"
 #include "utils/ISortable.h"
 #include "utils/SortUtils.h"
+#include "utils/Proxy.h"
 #include "XBDateTime.h"
 
 namespace MUSIC_INFO
@@ -129,6 +130,8 @@ public:
   const std::string &GetPath() const { return m_strPath; };
   void SetPath(const std::string &path) { m_strPath = path; };
   bool IsPath(const std::string& path, bool ignoreURLOptions = false) const;
+
+  CProxy GetProxy() const;
 
   /*! \brief reset class to it's default values as per construction.
    Free's all allocated memory.

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -20,6 +20,7 @@
 
 #include "DVDDemuxFFmpeg.h"
 
+#include <sstream>
 #include <utility>
 
 #include "commons/Exception.h"
@@ -638,6 +639,31 @@ AVDictionary *CDVDDemuxFFmpeg::GetFFMpegOptionsFromInput()
       av_dict_set(&options, "cookies", cookies.c_str(), 0);
 
   }
+
+  const CProxy proxy = m_pInput->GetProxy();
+  if (proxy)
+  {
+    if (proxy.GetType() == CProxy::ProxyHttp)
+    {
+      std::ostringstream urlStream;
+
+      urlStream << "http://";
+
+      if (!proxy.GetUser().empty()) {
+        urlStream << proxy.GetUser();
+	if (!proxy.GetPassword().empty())
+          urlStream << ":" << proxy.GetPassword();
+        urlStream << "@";
+      }
+
+      urlStream << proxy.GetHost();
+      if (proxy.GetPort())
+        urlStream << ':' << proxy.GetPort();
+
+      av_dict_set(&options, "http_proxy", urlStream.str().c_str(), 0);
+    }
+  }
+
   return options;
 }
 

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -230,9 +230,9 @@ bool CDVDDemuxFFmpeg::Open(CDVDInputStream* pInput, bool streaminfo, bool filein
   {
     // special stream type that makes avformat handle file opening
     // allows internal ffmpeg protocols to be used
-    CURL url = m_pInput->GetURL();
+    AVDictionary *options = GetFFMpegOptionsFromInput();
 
-    AVDictionary *options = GetFFMpegOptionsFromURL(url);
+    CURL url = m_pInput->GetURL();
 
     int result=-1;
     if (url.IsProtocol("mms"))
@@ -599,9 +599,9 @@ void CDVDDemuxFFmpeg::SetSpeed(int iSpeed)
   }
 }
 
-AVDictionary *CDVDDemuxFFmpeg::GetFFMpegOptionsFromURL(const CURL &url)
+AVDictionary *CDVDDemuxFFmpeg::GetFFMpegOptionsFromInput()
 {
-
+  const CURL url = m_pInput->GetURL();
   AVDictionary *options = NULL;
 
   if (url.IsProtocol("http") || url.IsProtocol("https"))

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
@@ -133,7 +133,7 @@ protected:
   bool IsVideoReady();
   void ResetVideoStreams();
 
-  AVDictionary *GetFFMpegOptionsFromURL(const CURL &url);
+  AVDictionary *GetFFMpegOptionsFromInput();
   double ConvertTimestamp(int64_t pts, int den, int num);
   void UpdateCurrentPTS();
   bool IsProgramChange();

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.cpp
@@ -53,8 +53,3 @@ std::string CDVDInputStream::GetFileName()
   url.SetProtocolOptions("");
   return url.Get();
 }
-
-CURL CDVDInputStream::GetURL()
-{
-  return m_item.GetURL();
-}

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
@@ -22,7 +22,9 @@
 
 #include <string>
 #include <vector>
+
 #include "utils/BitstreamStats.h"
+#include "utils/Proxy.h"
 #include "filesystem/IFileTypes.h"
 
 #include "FileItem.h"
@@ -157,6 +159,7 @@ public:
   virtual bool CanPause() { return true; }
 
   CURL GetURL() { return m_item.GetURL(); }
+  CProxy GetProxy() { return m_item.GetProxy(); }
 
   /*! \brief Indicate expected read rate in bytes per second.
    *  This could be used to throttle caching rate. Should

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
@@ -149,13 +149,14 @@ public:
   virtual int64_t GetLength() = 0;
   virtual std::string& GetContent() { return m_content; };
   virtual std::string GetFileName();
-  virtual CURL GetURL();
   virtual ENextStream NextStream() { return NEXTSTREAM_NONE; }
   virtual void Abort() {}
   virtual int GetBlockSize() { return 0; }
   virtual void ResetScanTimeout(unsigned int iTimeoutMs) { }
   virtual bool CanSeek() { return true; }
   virtual bool CanPause() { return true; }
+
+  CURL GetURL() { return m_item.GetURL(); }
 
   /*! \brief Indicate expected read rate in bytes per second.
    *  This could be used to throttle caching rate. Should

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFFmpeg.cpp
@@ -50,18 +50,18 @@ bool CDVDInputStreamFFmpeg::IsEOF()
 
 bool CDVDInputStreamFFmpeg::Open()
 {
-  std::string selected;
   if (m_item.IsInternetStream() && (m_item.IsType(".m3u8") || m_item.GetMimeType() == "application/vnd.apple.mpegurl"))
   {
     // get the available bandwidth and  determine the most appropriate stream
     int bandwidth = CSettings::GetInstance().GetInt(CSettings::SETTING_NETWORK_BANDWIDTH);
     if(bandwidth <= 0)
       bandwidth = INT_MAX;
-    selected = PLAYLIST::CPlayListM3U::GetBestBandwidthStream(m_item.GetPath(), bandwidth);
-    if (selected.compare(m_item.GetPath()) != 0)
+    const CURL playlist_url = m_item.GetURL();
+    const CURL selected = PLAYLIST::CPlayListM3U::GetBestBandwidthStream(playlist_url, bandwidth);
+    if (selected.Get().compare(playlist_url.Get()) != 0)
     {
-      CLog::Log(LOGINFO, "CDVDInputStreamFFmpeg: Auto-selecting %s based on configured bandwidth.", selected.c_str());
-      m_item.SetPath(selected.c_str());
+      CLog::Log(LOGINFO, "CDVDInputStreamFFmpeg: Auto-selecting %s based on configured bandwidth.", selected.Get().c_str());
+      m_item.SetURL(selected);
     }
   }
 

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFFmpeg.cpp
@@ -57,7 +57,8 @@ bool CDVDInputStreamFFmpeg::Open()
     if(bandwidth <= 0)
       bandwidth = INT_MAX;
     const CURL playlist_url = m_item.GetURL();
-    const CURL selected = PLAYLIST::CPlayListM3U::GetBestBandwidthStream(playlist_url, bandwidth);
+    const CProxy proxy = m_item.GetProxy();
+    const CURL selected = PLAYLIST::CPlayListM3U::GetBestBandwidthStream(playlist_url, bandwidth, proxy);
     if (selected.Get().compare(playlist_url.Get()) != 0)
     {
       CLog::Log(LOGINFO, "CDVDInputStreamFFmpeg: Auto-selecting %s based on configured bandwidth.", selected.Get().c_str());

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -428,7 +428,7 @@ CCurlFile::CCurlFile()
   m_password = "";
   m_httpauth = "";
   m_cipherlist = "";
-  m_proxytype = PROXY_HTTP;
+  m_proxytype = CProxy::ProxyHttp;
   m_state = new CReadState();
   m_oldState = NULL;
   m_skipshout = false;
@@ -766,7 +766,7 @@ void CCurlFile::ParseAndCorrectUrl(CURL &url2)
         m_proxyuserpass = CSettings::GetInstance().GetString(CSettings::SETTING_NETWORK_HTTPPROXYUSERNAME);
         m_proxyuserpass += ":" + CSettings::GetInstance().GetString(CSettings::SETTING_NETWORK_HTTPPROXYPASSWORD);
       }
-      m_proxytype = (ProxyType)CSettings::GetInstance().GetInt(CSettings::SETTING_NETWORK_HTTPPROXYTYPE);
+      m_proxytype = (CProxy::Type)CSettings::GetInstance().GetInt(CSettings::SETTING_NETWORK_HTTPPROXYTYPE);
       CLog::Log(LOGDEBUG, "Using proxy %s, type %d", m_proxy.c_str(), proxyType2CUrlProxyType[m_proxytype]);
     }
 

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -754,19 +754,20 @@ void CCurlFile::ParseAndCorrectUrl(CURL &url2)
   else if( url2.IsProtocol("http")
        ||  url2.IsProtocol("https"))
   {
-    if (CSettings::GetInstance().GetBool(CSettings::SETTING_NETWORK_USEHTTPPROXY)
-        && !CSettings::GetInstance().GetString(CSettings::SETTING_NETWORK_HTTPPROXYSERVER).empty()
-        && CSettings::GetInstance().GetInt(CSettings::SETTING_NETWORK_HTTPPROXYPORT) > 0
+    const CSettings &s = CSettings::GetInstance();
+    if (s.GetBool(CSettings::SETTING_NETWORK_USEHTTPPROXY)
+        && !s.GetString(CSettings::SETTING_NETWORK_HTTPPROXYSERVER).empty()
+        && s.GetInt(CSettings::SETTING_NETWORK_HTTPPROXYPORT) > 0
         && m_proxy.empty())
     {
-      m_proxy = CSettings::GetInstance().GetString(CSettings::SETTING_NETWORK_HTTPPROXYSERVER);
-      m_proxy += StringUtils::Format(":%d", CSettings::GetInstance().GetInt(CSettings::SETTING_NETWORK_HTTPPROXYPORT));
-      if (CSettings::GetInstance().GetString(CSettings::SETTING_NETWORK_HTTPPROXYUSERNAME).length() > 0 && m_proxyuserpass.empty())
+      m_proxy = s.GetString(CSettings::SETTING_NETWORK_HTTPPROXYSERVER);
+      m_proxy += StringUtils::Format(":%d", s.GetInt(CSettings::SETTING_NETWORK_HTTPPROXYPORT));
+      if (s.GetString(CSettings::SETTING_NETWORK_HTTPPROXYUSERNAME).length() > 0 && m_proxyuserpass.empty())
       {
-        m_proxyuserpass = CSettings::GetInstance().GetString(CSettings::SETTING_NETWORK_HTTPPROXYUSERNAME);
-        m_proxyuserpass += ":" + CSettings::GetInstance().GetString(CSettings::SETTING_NETWORK_HTTPPROXYPASSWORD);
+        m_proxyuserpass = s.GetString(CSettings::SETTING_NETWORK_HTTPPROXYUSERNAME);
+        m_proxyuserpass += ":" + s.GetString(CSettings::SETTING_NETWORK_HTTPPROXYPASSWORD);
       }
-      m_proxytype = (CProxy::Type)CSettings::GetInstance().GetInt(CSettings::SETTING_NETWORK_HTTPPROXYTYPE);
+      m_proxytype = (CProxy::Type)s.GetInt(CSettings::SETTING_NETWORK_HTTPPROXYTYPE);
       CLog::Log(LOGDEBUG, "Using proxy %s, type %d", m_proxy.c_str(), proxyType2CUrlProxyType[m_proxytype]);
     }
 

--- a/xbmc/filesystem/CurlFile.h
+++ b/xbmc/filesystem/CurlFile.h
@@ -24,6 +24,7 @@
 #include <map>
 #include <string>
 #include "utils/HttpHeader.h"
+#include "utils/Proxy.h"
 
 namespace XCURL
 {
@@ -37,15 +38,6 @@ namespace XFILE
   class CCurlFile : public IFile
   {
     public:
-      typedef enum
-      {
-        PROXY_HTTP = 0,
-        PROXY_SOCKS4,
-        PROXY_SOCKS4A,
-        PROXY_SOCKS5,
-        PROXY_SOCKS5_REMOTE,
-      } ProxyType;
-    
       CCurlFile();
       virtual ~CCurlFile();
       virtual bool Open(const CURL& url);
@@ -75,7 +67,7 @@ namespace XFILE
       void SetUserAgent(const std::string& sUserAgent)           { m_userAgent = sUserAgent; }
       void SetProxy(const std::string &proxy)                    { m_proxy = proxy; }
       void SetProxyUserPass(const std::string &proxyuserpass)    { m_proxyuserpass = proxyuserpass; }
-      void SetProxyType(ProxyType proxytype)                     { m_proxytype = proxytype; }
+      void SetProxyType(CProxy::Type proxytype)                  { m_proxytype = proxytype; }
       void SetCustomRequest(const std::string &request)          { m_customrequest = request; }
       void UseOldHttpVersion(bool bUse)                          { m_useOldHttpVersion = bUse; }
       void SetAcceptEncoding(const std::string& encoding)        { m_acceptencoding = encoding; }
@@ -166,7 +158,7 @@ namespace XFILE
       std::string     m_userAgent;
       std::string     m_proxy;
       std::string     m_proxyuserpass;
-      ProxyType       m_proxytype;
+      CProxy::Type    m_proxytype;
       std::string     m_customrequest;
       std::string     m_acceptencoding;
       std::string     m_acceptCharset;

--- a/xbmc/filesystem/CurlFile.h
+++ b/xbmc/filesystem/CurlFile.h
@@ -56,6 +56,7 @@ namespace XFILE
       virtual int IoControl(EIoControl request, void* param);
       virtual std::string GetContentCharset(void)                { return GetServerReportedCharset(); }
       virtual double GetDownloadSpeed();
+      virtual void SetProxy(const CProxy &proxy)                 { m_proxy = proxy; };
 
       bool Post(const std::string& strURL, const std::string& strPostData, std::string& strHTML);
       bool Get(const std::string& strURL, std::string& strHTML);
@@ -65,9 +66,6 @@ namespace XFILE
       void Cancel();
       void Reset();
       void SetUserAgent(const std::string& sUserAgent)           { m_userAgent = sUserAgent; }
-      void SetProxy(const std::string &proxy)                    { m_proxy = proxy; }
-      void SetProxyUserPass(const std::string &proxyuserpass)    { m_proxyuserpass = proxyuserpass; }
-      void SetProxyType(CProxy::Type proxytype)                  { m_proxytype = proxytype; }
       void SetCustomRequest(const std::string &request)          { m_customrequest = request; }
       void UseOldHttpVersion(bool bUse)                          { m_useOldHttpVersion = bUse; }
       void SetAcceptEncoding(const std::string& encoding)        { m_acceptencoding = encoding; }
@@ -156,9 +154,7 @@ namespace XFILE
 
       std::string     m_url;
       std::string     m_userAgent;
-      std::string     m_proxy;
-      std::string     m_proxyuserpass;
-      CProxy::Type    m_proxytype;
+      CProxy          m_proxy;
       std::string     m_customrequest;
       std::string     m_acceptencoding;
       std::string     m_acceptCharset;

--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -291,6 +291,8 @@ bool CFile::Open(const CURL& file, const unsigned int flags)
     if (!m_pFile)
       return false;
 
+    m_pFile->SetProxy(m_proxy);
+
     try
     {
       if (!m_pFile->Open(url))

--- a/xbmc/filesystem/File.h
+++ b/xbmc/filesystem/File.h
@@ -33,6 +33,7 @@
 #include <stdio.h>
 #include <string>
 #include "utils/auto_buffer.h"
+#include "utils/Proxy.h"
 #include "IFileTypes.h"
 #include "PlatformDefs.h"
 #include "URL.h"
@@ -63,6 +64,9 @@ public:
   bool CURLCreate(const std::string &url);
   bool CURLAddOption(XFILE::CURLOPTIONTYPE type, const char* name, const char * value);
   bool CURLOpen(unsigned int flags);
+
+  void SetProxy(const CProxy &proxy) { m_proxy = proxy; };
+  const CProxy& GetProxy() const { return m_proxy; };
 
   bool Open(const CURL& file, const unsigned int flags = 0);
   bool OpenForWrite(const CURL& file, bool bOverWrite = false);
@@ -174,6 +178,7 @@ public:
 private:
   unsigned int        m_flags;
   CURL                m_curl;
+  CProxy              m_proxy;
   IFile*              m_pFile;
   CFileStreamBuffer*  m_pBuffer;
   BitstreamStats*     m_bitStreamStats;

--- a/xbmc/filesystem/FileCache.cpp
+++ b/xbmc/filesystem/FileCache.cpp
@@ -166,10 +166,8 @@ bool CFileCache::Open(const CURL& url)
 
   CLog::Log(LOGDEBUG,"CFileCache::Open - opening <%s> using cache", url.GetFileName().c_str());
 
-  m_sourcePath = url.Get();
-
   // opening the source file.
-  if (!m_source.Open(m_sourcePath, READ_NO_CACHE | READ_TRUNCATED | READ_CHUNKED))
+  if (!m_source.Open(url, READ_NO_CACHE | READ_TRUNCATED | READ_CHUNKED))
   {
     CLog::Log(LOGERROR,"%s - failed to open source <%s>", __FUNCTION__, url.GetRedacted().c_str());
     Close();

--- a/xbmc/filesystem/FileCache.h
+++ b/xbmc/filesystem/FileCache.h
@@ -67,7 +67,6 @@ namespace XFILE
     bool      m_bDeleteCache;
     int        m_seekPossible;
     CFile      m_source;
-    std::string    m_sourcePath;
     CEvent      m_seekEvent;
     CEvent      m_seekEnded;
     int64_t      m_nSeekResult;

--- a/xbmc/filesystem/IFile.h
+++ b/xbmc/filesystem/IFile.h
@@ -49,6 +49,7 @@
 #include "IFileTypes.h"
 
 class CURL;
+class CProxy;
 
 namespace XFILE
 {
@@ -132,6 +133,8 @@ public:
 
   virtual std::string GetContent()                           { return "application/octet-stream"; }
   virtual std::string GetContentCharset(void)                { return ""; }
+
+  virtual void SetProxy(const CProxy &proxy) {};
 };
 
 class CRedirectException

--- a/xbmc/playlists/PlayListM3U.cpp
+++ b/xbmc/playlists/PlayListM3U.cpp
@@ -226,7 +226,7 @@ void CPlayListM3U::Save(const std::string& strFileName) const
   file.Close();
 }
 
-std::string CPlayListM3U::GetBestBandwidthStream(const std::string &strFileName, size_t bandwidth)
+CURL CPlayListM3U::GetBestBandwidthStream(const CURL &url, size_t bandwidth)
 {
   // we may be passed a playlist that does not contain playlists of different
   // bitrates (eg: this playlist is really the HLS video). So, default the
@@ -237,20 +237,17 @@ std::string CPlayListM3U::GetBestBandwidthStream(const std::string &strFileName,
 
   // open the file, and if it fails, return
   CFile file;
-  if (!file.Open(strFileName) )
+  if (!file.Open(url))
   {
     file.Close();
-    return strFileName;
+    return url;
   }
 
-  // get protocol options if they were set, so we can restore them again at the end
-  CURL playlistUrl(strFileName);
-  
   // and set the fallback value
-  CURL subStreamUrl = CURL(strFileName);
+  CURL subStreamUrl(url);
   
   // determine the base
-  CURL basePlaylistUrl(URIUtils::GetParentPath(strFileName));
+  CURL basePlaylistUrl(URIUtils::GetParentPath(url.Get()));
   basePlaylistUrl.SetOptions("");
   basePlaylistUrl.SetProtocolOptions("");
   std::string basePart = basePlaylistUrl.Get();
@@ -303,8 +300,8 @@ std::string CPlayListM3U::GetBestBandwidthStream(const std::string &strFileName,
   }
 
   // if any protocol options were set, restore them
-  subStreamUrl.SetProtocolOptions(playlistUrl.GetProtocolOptions());
-  return subStreamUrl.Get();
+  subStreamUrl.SetProtocolOptions(url.GetProtocolOptions());
+  return subStreamUrl;
 }
 
 std::map< std::string, std::string > CPlayListM3U::ParseStreamLine(const std::string &streamLine)

--- a/xbmc/playlists/PlayListM3U.cpp
+++ b/xbmc/playlists/PlayListM3U.cpp
@@ -226,7 +226,7 @@ void CPlayListM3U::Save(const std::string& strFileName) const
   file.Close();
 }
 
-CURL CPlayListM3U::GetBestBandwidthStream(const CURL &url, size_t bandwidth)
+CURL CPlayListM3U::GetBestBandwidthStream(const CURL &url, size_t bandwidth, const CProxy &proxy)
 {
   // we may be passed a playlist that does not contain playlists of different
   // bitrates (eg: this playlist is really the HLS video). So, default the
@@ -237,6 +237,7 @@ CURL CPlayListM3U::GetBestBandwidthStream(const CURL &url, size_t bandwidth)
 
   // open the file, and if it fails, return
   CFile file;
+  file.SetProxy(proxy);
   if (!file.Open(url))
   {
     file.Close();

--- a/xbmc/playlists/PlayListM3U.h
+++ b/xbmc/playlists/PlayListM3U.h
@@ -18,6 +18,7 @@
  *  <http://www.gnu.org/licenses/>.
  *
  */
+#include "URL.h"
 #include "PlayList.h"
 
 namespace PLAYLIST
@@ -31,7 +32,7 @@ public:
   virtual bool Load(const std::string& strFileName);
   virtual void Save(const std::string& strFileName) const;
 
-  static std::string GetBestBandwidthStream(const std::string &strFileName, size_t bandwidth);
+  static CURL GetBestBandwidthStream(const CURL &url, size_t bandwidth);
 
 protected:
 

--- a/xbmc/playlists/PlayListM3U.h
+++ b/xbmc/playlists/PlayListM3U.h
@@ -21,6 +21,8 @@
 #include "URL.h"
 #include "PlayList.h"
 
+#include "utils/Proxy.h"
+
 namespace PLAYLIST
 {
 class CPlayListM3U :
@@ -32,7 +34,7 @@ public:
   virtual bool Load(const std::string& strFileName);
   virtual void Save(const std::string& strFileName) const;
 
-  static CURL GetBestBandwidthStream(const CURL &url, size_t bandwidth);
+  static CURL GetBestBandwidthStream(const CURL &url, size_t bandwidth, const CProxy &proxy = CProxy());
 
 protected:
 

--- a/xbmc/utils/CMakeLists.txt
+++ b/xbmc/utils/CMakeLists.txt
@@ -40,6 +40,7 @@ set(SOURCES ActorProtocol.cpp
             PerformanceSample.cpp
             PerformanceStats.cpp
             POUtils.cpp
+            Proxy.cpp
             RecentlyAddedJob.cpp
             RegExp.cpp
             rfft.cpp

--- a/xbmc/utils/Makefile.in
+++ b/xbmc/utils/Makefile.in
@@ -43,6 +43,7 @@ SRCS += PerformanceStats.cpp
 SRCS += posix/PosixInterfaceForCLog.cpp
 SRCS += POUtils.cpp
 SRCS += ProgressJob.cpp
+SRCS += Proxy.cpp
 SRCS += RecentlyAddedJob.cpp
 SRCS += RegExp.cpp
 SRCS += rfft.cpp

--- a/xbmc/utils/Proxy.cpp
+++ b/xbmc/utils/Proxy.cpp
@@ -1,0 +1,44 @@
+/*
+ *      Copyright (C) 2016 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "Proxy.h"
+
+CProxy::CProxy()
+  : m_type(ProxyHttp)
+  , m_port(3128)
+{
+}
+
+CProxy::CProxy(Type type,
+  const std::string& host,
+  uint16_t port,
+  const std::string& user,
+  const std::string& password)
+  : m_type(type)
+  , m_host(host)
+  , m_port(port)
+  , m_user(user)
+  , m_password(password)
+{
+}
+
+CProxy::~CProxy()
+{
+}

--- a/xbmc/utils/Proxy.h
+++ b/xbmc/utils/Proxy.h
@@ -1,0 +1,33 @@
+#pragma once
+/*
+ *      Copyright (C) 2016 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+class CProxy
+{
+public:
+  typedef enum
+  {
+    ProxyHttp = 0,
+    ProxySocks4,
+    ProxySocks4A,
+    ProxySocks5,
+    ProxySocks5Remote,
+  } Type;
+};

--- a/xbmc/utils/Proxy.h
+++ b/xbmc/utils/Proxy.h
@@ -19,6 +19,14 @@
  *
  */
 
+#include <cstdint>
+#include <memory>
+#include <string>
+
+class CProxy;
+
+typedef std::shared_ptr<CProxy> CProxyPtr;
+
 class CProxy
 {
 public:
@@ -30,4 +38,34 @@ public:
     ProxySocks5,
     ProxySocks5Remote,
   } Type;
+
+public:
+  CProxy();
+
+  CProxy(Type type, const std::string& host, uint16_t port,
+    const std::string& user, const std::string& password);
+
+  ~CProxy();
+
+public:
+  operator bool() const { return !m_host.empty(); }
+
+  Type GetType() const { return m_type; }
+  void SetType(Type type) { m_type = type; }
+  const std::string& GetHost() const { return m_host; }
+  void SetHost(const std::string &host) { m_host = host; }
+  const std::string& GetUser() const { return m_user; }
+  void SetPort(const uint16_t port) { m_port = port; }
+  uint16_t GetPort() const { return m_port; }
+  void SetUser(const std::string &user) { m_user = user; }
+  const std::string& GetPassword() const { return m_password; }
+  void SetPassword(const std::string &password) { m_password = password; }
+
+
+private:
+  Type m_type;
+  std::string m_host;
+  uint16_t m_port;
+  std::string m_user;
+  std::string m_password;
 };


### PR DESCRIPTION
This branch supercedes #9240 and #8680, providing another attempt to add the ability for plugins to provide per-stream proxy configuration, including support for proxies with HLS.

The flow of URL information from plugins to HTTP requests for HLS streams is as follows:

```
[Plugin]
  -> CListItem
      -> CFileItem
          -> CDVDInputStream/CDVDInputStreamFFmpeg
              -> CPlayListM3U::GetBestBandwidthStream
                  -> CFile::Open
                      -> IFile/CCurlFile
                          -> libcurl
                              [HTTP Request playlist M3U8 file]

          -> CDVDInputStream
              -> CDVDDemuxFFmpeg
                  -> libffmpeg http_proxy stream option
                      [HTTP Request media chunks]
```

To enable per-stream proxy configuration, the five config values (proxy protocol, host, port, user-name and password) must follow the same path-ways.

The proxy configs are carried from the plugin to `CFileItem` via the existing `CListItem::SetProperty` mechanism. Thereafter, the configs are carried from `CFileItem` to `CCurlFile` and to `CDVDDemuxFFmpeg` via `CProxy` objects.

The `CProxy` class provided here has been simplified since #9640. All the proxy url parsing, and formatting, archiving and serialization methods have been removed, so that the `CProxy` is now just a simple data structure.

The class is still necessary, because without it, a large amount of boiler-plate code would be needed to pass the five proxy config values among the classes/methods in the call-flow beyond `CFileItem`. `CProxy` provides simple package in which the information can be passed around.

Furthermore, this pull request differs from #9640 in that it doesn't add a `CProxy` member to the `CURL` class. Instead it passes `CProxy` object side-by-side with URLs in `CPlayListM3U::GetBestBandwidthStream` and within the `CFile` family.
