### PR TITLE
Commercial skipping notifications and toggle action

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -14327,7 +14327,22 @@ msgctxt "#25010"
 msgid "Chapter %u"
 msgstr ""
 
-#empty strings from id 25011 to 29800
+#: xbmc/cores/VideoPlayer/VideoPlayer.cpp
+msgctxt "#25011"
+msgid "Commercial"
+msgstr ""
+
+#: xbmc/cores/VideoPlayer/VideoPlayer.cpp
+msgctxt "#25012"
+msgid "Auto-skip off"
+msgstr ""
+
+#: xbmc/cores/VideoPlayer/VideoPlayer.cpp
+msgctxt "#25013"
+msgid "Auto-skip on"
+msgstr ""
+
+#empty strings from id 25014 to 29800
 
 #: unused
 msgctxt "#29801"

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -526,6 +526,7 @@ protected:
   CEvent m_ready;
 
   CEdl m_Edl;
+  bool m_SkipCommercials;
 
   struct SEdlAutoSkipMarkers {
 

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -236,6 +236,7 @@ static const ActionMapping actions[] =
     { "playpvrtv"                , ACTION_PVR_PLAY_TV },
     { "playpvrradio"             , ACTION_PVR_PLAY_RADIO },
     { "record"                   , ACTION_RECORD },
+    { "togglecommskip"           , ACTION_TOGGLE_COMMSKIP },
 
     // Mouse actions
     { "leftclick"                , ACTION_MOUSE_LEFT_CLICK },

--- a/xbmc/input/Key.h
+++ b/xbmc/input/Key.h
@@ -384,6 +384,7 @@
 #define ACTION_TRIGGER_OSD            243 //!< show autoclosing OSD. Can b used in videoFullScreen.xml window id=2005
 #define ACTION_INPUT_TEXT             244
 #define ACTION_VOLUME_SET             245
+#define ACTION_TOGGLE_COMMSKIP        246
 
 #define ACTION_TOUCH_TAP              401 //!< touch actions
 #define ACTION_TOUCH_TAP_TEN          410 //!< touch actions


### PR DESCRIPTION
An implementation to address this feature request from the forums: http://forum.kodi.tv/showthread.php?tid=208206

This adds a new action, TOGGLE_COMMSKIP which turns Commercial Skipping on/off for the current recording only (next record starts back at the default setting from advancedsettings.xml).

Also adds an option to display notifications of commercials and their lengths.

This is a resubmit of #7330 and #7520.
