### PR TITLE
Only use surface rendering for content > 1080p

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.cpp
@@ -18,7 +18,6 @@
  *
  */
 
-#include "system.h"
 #include "utils/log.h"
 
 #include "DVDFactoryCodec.h"
@@ -51,8 +50,6 @@
 
 #include "DVDStreamInfo.h"
 #include "settings/AdvancedSettings.h"
-#include "settings/Settings.h"
-#include "settings/VideoSettings.h"
 #include "utils/StringUtils.h"
 
 CDVDVideoCodec* CDVDFactoryCodec::OpenCodec(CDVDVideoCodec* pCodec, CDVDStreamInfo &hints, CDVDCodecOptions &options )
@@ -175,7 +172,7 @@ CDVDVideoCodec* CDVDFactoryCodec::CreateVideoCodec(CDVDStreamInfo &hint, CProces
 
 CDVDAudioCodec* CDVDFactoryCodec::CreateAudioCodec(CDVDStreamInfo &hint, CProcessInfo &processInfo, bool allowpassthrough, bool allowdtshddecode)
 {
-  CDVDAudioCodec* pCodec = NULL;
+  CDVDAudioCodec* pCodec;
   CDVDCodecOptions options;
 
   if (!allowdtshddecode)
@@ -198,7 +195,7 @@ CDVDAudioCodec* CDVDFactoryCodec::CreateAudioCodec(CDVDStreamInfo &hint, CProces
 
 CDVDOverlayCodec* CDVDFactoryCodec::CreateOverlayCodec( CDVDStreamInfo &hint )
 {
-  CDVDOverlayCodec* pCodec = NULL;
+  CDVDOverlayCodec* pCodec;
   CDVDCodecOptions options;
 
   switch (hint.codec)

--- a/xbmc/cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.h
@@ -20,9 +20,7 @@
  *
  */
 
-#include <vector>
 #include "cores/VideoPlayer/VideoRenderers/RenderFormats.h"
-#include "cores/VideoPlayer/VideoRenderers/BaseRenderer.h"
 #include "cores/VideoPlayer/Process/ProcessInfo.h"
 
 class CDVDVideoCodec;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -320,7 +320,7 @@ void CDVDMediaCodecInfo::RenderUpdate(const CRect &SrcRect, const CRect &DestRec
 
 /*****************************************************************************/
 /*****************************************************************************/
-CDVDVideoCodecAndroidMediaCodec::CDVDVideoCodecAndroidMediaCodec(CProcessInfo &processInfo, bool surface_render)
+CDVDVideoCodecAndroidMediaCodec::CDVDVideoCodecAndroidMediaCodec(CProcessInfo &processInfo)
 : CDVDVideoCodec(processInfo)
 , m_formatname("mediacodec")
 , m_opened(false)
@@ -328,7 +328,9 @@ CDVDVideoCodecAndroidMediaCodec::CDVDVideoCodecAndroidMediaCodec(CProcessInfo &p
 , m_textureId(0)
 , m_bitstream(NULL)
 , m_render_sw(false)
-, m_render_surface(surface_render)
+, m_render_surface(false)
+, m_drop(false)
+, m_colorFormat(-1)
 {
   memset(&m_videobuffer, 0x00, sizeof(DVDVideoPicture));
   memset(&m_demux_pkt, 0x00, sizeof(m_demux_pkt));
@@ -353,7 +355,26 @@ bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
            !CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_USEMEDIACODECSURFACE))
     return false;
 
-  m_render_surface = CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_USEMEDIACODECSURFACE);
+  // Avoid h/w decoder for SD; Those files might use features
+  // not supported and can easily be soft-decoded
+  switch (hints.codec)
+  {
+  case AV_CODEC_ID_MPEG4:
+  case AV_CODEC_ID_MSMPEG4V2:
+  case AV_CODEC_ID_MSMPEG4V3:
+    if (hints.width <= 800)
+    {
+      CLog::Log(LOGINFO, "MediaCodec Falling back to SW acceleration...");
+      return false;
+    }
+  }
+  // only use surface rendering for content larger FullHD
+  if ((hints.width > 1920 || hints.height > 1080) && CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_USEMEDIACODECSURFACE))
+  {
+    CLog::Log(LOGINFO, "MediaCodec (Surface) Video Decoder...");
+    m_render_surface = true;
+  }
+  
   m_drop = false;
   m_codecControlFlags = 0;
   m_hints = hints;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
@@ -91,7 +91,7 @@ private:
 class CDVDVideoCodecAndroidMediaCodec : public CDVDVideoCodec
 {
 public:
-  CDVDVideoCodecAndroidMediaCodec(CProcessInfo &processInfo, bool surface_render = false);
+  CDVDVideoCodecAndroidMediaCodec(CProcessInfo &processInfo);
   virtual ~CDVDVideoCodecAndroidMediaCodec();
 
   // required overrides

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.cpp
@@ -158,16 +158,16 @@ bool CRendererMediaCodecSurface::RenderUpdateVideoHook(bool clear, DWORD flags, 
 
 bool CRendererMediaCodecSurface::CreateTexture(int index)
 {
-  return true; // nothing todo
+  return true;
 }
 
 void CRendererMediaCodecSurface::DeleteTexture(int index)
 {
-  return; // nothing todo
+  return;
 }
 
 bool CRendererMediaCodecSurface::UploadTexture(int index)
 {
-  return true; // nothing todo
+  return true;
 }
 #endif


### PR DESCRIPTION
This changes behavior for android codec handling.
For content smaller than 800 in width we will use software decoding.

And use surface rendering for anything HD, if wanted by the user.
It builds fine on each platform, http://jenkins.kodi.tv/view/Helpers/job/BuildMulti-All/1259/

Thanks to @fritsch for showing me the ropes.

@mazeyx please test http://mirrors.kodi.tv/test-builds/android/arm/kodi-20160319-24736ff-android-surface-rendering-armeabi-v7a.apk and let us know if it fixes your problem.
