### PR TITLE
[darwin/WebServer] - fixed crash under json. double thread stack size…

### DIFF
--- a/xbmc/network/WebServer.cpp
+++ b/xbmc/network/WebServer.cpp
@@ -30,6 +30,10 @@
 #include <stdexcept>
 #include <utility>
 
+#if defined(TARGET_POSIX)
+#include <pthread.h>
+#endif
+
 #include "filesystem/File.h"
 #include "network/httprequesthandler/IHTTPRequestHandler.h"
 #include "settings/Settings.h"
@@ -90,9 +94,22 @@ CWebServer::CWebServer()
     m_daemon_ip4(NULL),
     m_running(false),
     m_needcredentials(false),
+    m_thread_stacksize(0),
     m_Credentials64Encoded("eGJtYzp4Ym1j") // xbmc:xbmc
-
-{ }
+{
+#if defined(TARGET_DARWIN)
+  void *stack_addr;
+  pthread_attr_t attr;
+  pthread_attr_init(&attr);
+  pthread_attr_getstack(&attr, &stack_addr, &m_thread_stacksize);
+  pthread_attr_destroy(&attr);
+  // double the stack size under darwin, not sure why yet
+  // but it stoped crashing using Kodi iOS remote -> play video.
+  // non-darwin will pass a value of zero which means 'system default'
+  m_thread_stacksize *= 2;
+  CLog::Log(LOGDEBUG, "CWebServer: increasing thread stack to %zu", m_thread_stacksize);
+#endif
+}
 
 HTTPMethod CWebServer::GetMethod(const char *method)
 {
@@ -1133,6 +1150,7 @@ struct MHD_Daemon* CWebServer::StartMHD(unsigned int flags, int port)
 #if (MHD_VERSION >= 0x00040001)
                           MHD_OPTION_EXTERNAL_LOGGER, &logFromMHD, NULL,
 #endif // MHD_VERSION >= 0x00040001
+                          MHD_OPTION_THREAD_STACK_SIZE, m_thread_stacksize,
                           MHD_OPTION_END);
 }
 

--- a/xbmc/network/WebServer.h
+++ b/xbmc/network/WebServer.h
@@ -121,6 +121,7 @@ private:
   struct MHD_Daemon *m_daemon_ip4;
   bool m_running;
   bool m_needcredentials;
+  size_t m_thread_stacksize;
   std::string m_Credentials64Encoded;
   CCriticalSection m_critSection;
   static std::vector<IHTTPRequestHandler *> m_requestHandlers;


### PR DESCRIPTION
… for libmicrohttpd for osx/ios

backport of https://github.com/xbmc/xbmc/pull/9403
