### PR TITLE
run Announcements on thread with lower priority, required changes to init of PVR and Python

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2974,9 +2974,6 @@ void CApplication::Stop(int exitCode)
     CLog::Log(LOGERROR, "Exception in CApplication::Stop()");
   }
 
-  // we may not get to finish the run cycle but exit immediately after a call to g_application.Stop()
-  // so we may never get to Destroy() in CXBApplicationEx::Run(), we call it here.
-  Destroy();
   cleanup_emu_environ();
 
   Sleep(200);

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -429,6 +429,12 @@ bool CApplication::SetupNetwork()
 
 bool CApplication::Create()
 {
+  m_ServiceManager.reset(new CServiceManager());
+  if (!m_ServiceManager->Init1())
+  {
+    return false;
+  }
+
   SetupNetwork();
   Preflight();
 
@@ -593,12 +599,6 @@ bool CApplication::Create()
   avfilter_register_all();
   // set avutil callback
   av_log_set_callback(ff_avutil_log);
-
-  m_ServiceManager.reset(new CServiceManager());
-  if (!m_ServiceManager->Init1())
-  {
-    return false;
-  }
 
   g_powerManager.Initialize();
 

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -594,6 +594,12 @@ bool CApplication::Create()
   // set avutil callback
   av_log_set_callback(ff_avutil_log);
 
+  m_ServiceManager.reset(new CServiceManager());
+  if (!m_ServiceManager->Init1())
+  {
+    return false;
+  }
+
   g_powerManager.Initialize();
 
   // Load the AudioEngine before settings as they need to query the engine
@@ -653,12 +659,7 @@ bool CApplication::Create()
   // initialize the addon database (must be before the addon manager is init'd)
   CDatabaseManager::GetInstance().Initialize(true);
 
-#ifdef HAS_PYTHON
-  CScriptInvocationManager::GetInstance().RegisterLanguageInvocationHandler(&g_pythonParser, ".py");
-#endif // HAS_PYTHON
-
-  m_ServiceManager.reset(new CServiceManager());
-  if (!m_ServiceManager->Init())
+  if (!m_ServiceManager->Init2())
   {
     return false;
   }
@@ -2905,8 +2906,6 @@ void CApplication::Stop(int exitCode)
 
     CLog::Log(LOGNOTICE, "stop player");
     m_pPlayer->ClosePlayer();
-
-    CAnnouncementManager::GetInstance().Deinitialize();
 
     StopPVRManager();
     StopServices();

--- a/xbmc/ServiceBroker.cpp
+++ b/xbmc/ServiceBroker.cpp
@@ -30,3 +30,18 @@ ADDON::CBinaryAddonCache &CServiceBroker::GetBinaryAddonCache()
 {
   return g_application.m_ServiceManager->GetBinaryAddonCache();
 }
+
+ANNOUNCEMENT::CAnnouncementManager &CServiceBroker::GetAnnouncementManager()
+{
+  return g_application.m_ServiceManager->GetAnnouncementManager();
+}
+
+XBPython& CServiceBroker::GetXBPython()
+{
+  return g_application.m_ServiceManager->GetXBPython();
+}
+
+PVR::CPVRManager &CServiceBroker::GetPVRManager()
+{
+  return g_application.m_ServiceManager->GetPVRManager();
+}

--- a/xbmc/ServiceBroker.h
+++ b/xbmc/ServiceBroker.h
@@ -25,9 +25,24 @@ class CAddonMgr;
 class CBinaryAddonCache;
 }
 
+namespace ANNOUNCEMENT
+{
+  class CAnnouncementManager;
+}
+
+namespace PVR
+{
+  class CPVRManager;
+}
+
+class XBPython;
+
 class CServiceBroker
 {
 public:
   static ADDON::CAddonMgr &GetAddonMgr();
   static ADDON::CBinaryAddonCache &GetBinaryAddonCache();
+  static ANNOUNCEMENT::CAnnouncementManager &GetAnnouncementManager();
+  static XBPython &GetXBPython();
+  static PVR::CPVRManager &GetPVRManager();
 };

--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -20,8 +20,23 @@
 
 #include "ServiceManager.h"
 #include "utils/log.h"
+#include "interfaces/AnnouncementManager.h"
+#include "interfaces/generic/ScriptInvocationManager.h"
 
-bool CServiceManager::Init()
+bool CServiceManager::Init1()
+{
+  m_announcementManager.reset(new ANNOUNCEMENT::CAnnouncementManager());
+  m_announcementManager->Start();
+
+  m_XBPython.reset(new XBPython());
+  CScriptInvocationManager::GetInstance().RegisterLanguageInvocationHandler(m_XBPython.get(), ".py");
+
+  m_PVRManager.reset(new PVR::CPVRManager());
+
+  return true;
+}
+
+bool CServiceManager::Init2()
 {
   m_addonMgr.reset(new ADDON::CAddonMgr());
   if (!m_addonMgr->Init())
@@ -39,6 +54,9 @@ void CServiceManager::Deinit()
 {
   m_binaryAddonCache.reset();
   m_addonMgr.reset();
+  m_PVRManager.reset();
+  m_XBPython.reset();
+  m_announcementManager.reset();
 }
 
 ADDON::CAddonMgr &CServiceManager::GetAddonMgr()
@@ -49,4 +67,19 @@ ADDON::CAddonMgr &CServiceManager::GetAddonMgr()
 ADDON::CBinaryAddonCache &CServiceManager::GetBinaryAddonCache()
 {
   return *m_binaryAddonCache.get();
+}
+
+ANNOUNCEMENT::CAnnouncementManager& CServiceManager::GetAnnouncementManager()
+{
+  return *m_announcementManager;
+}
+
+XBPython& CServiceManager::GetXBPython()
+{
+  return *m_XBPython;
+}
+
+PVR::CPVRManager& CServiceManager::GetPVRManager()
+{
+  return *m_PVRManager;
 }

--- a/xbmc/ServiceManager.h
+++ b/xbmc/ServiceManager.h
@@ -22,6 +22,8 @@
 
 #include "addons/AddonManager.h"
 #include "addons/BinaryAddonCache.h"
+#include "interfaces/python/XBPython.h"
+#include "pvr/PVRManager.h"
 #include <memory>
 
 namespace ADDON {
@@ -29,15 +31,32 @@ class CAddonMgr;
 class CBinaryAddonCache;
 }
 
+namespace ANNOUNCEMENT
+{
+class CAnnouncementManager;
+}
+
+namespace PVR
+{
+class CPVRManager;
+}
+
 class CServiceManager
 {
 public:
-  bool Init();
+  bool Init1();
+  bool Init2();
   void Deinit();
   ADDON::CAddonMgr& GetAddonMgr();
   ADDON::CBinaryAddonCache& GetBinaryAddonCache();
+  ANNOUNCEMENT::CAnnouncementManager& GetAnnouncementManager();
+  XBPython& GetXBPython();
+  PVR::CPVRManager& GetPVRManager();
 
 protected:
   std::unique_ptr<ADDON::CAddonMgr> m_addonMgr;
   std::unique_ptr<ADDON::CBinaryAddonCache> m_binaryAddonCache;
+  std::unique_ptr<ANNOUNCEMENT::CAnnouncementManager> m_announcementManager;
+  std::unique_ptr<XBPython> m_XBPython;
+  std::unique_ptr<PVR::CPVRManager> m_PVRManager;
 };

--- a/xbmc/SystemGlobals.cpp
+++ b/xbmc/SystemGlobals.cpp
@@ -63,9 +63,6 @@ std::map<std::string, std::string> CSpecialProtocol::m_pathMap;
   XCURL::DllLibCurlGlobal g_curlInterface;
   CPartyModeManager     g_partyModeManager;
 
-#ifdef HAS_PYTHON
-  XBPython           g_pythonParser;
-#endif
   CAlarmClock        g_alarmClock;
   PLAYLIST::CPlayListPlayer g_playlistPlayer;
 

--- a/xbmc/interfaces/AnnouncementManager.cpp
+++ b/xbmc/interfaces/AnnouncementManager.cpp
@@ -30,13 +30,15 @@
 #include "video/VideoDatabase.h"
 #include "pvr/channels/PVRChannel.h"
 #include "PlayListPlayer.h"
+#include "ServiceBroker.h"
 
 #define LOOKUP_PROPERTY "database-lookup"
 
 using namespace ANNOUNCEMENT;
 
-CAnnouncementManager::CAnnouncementManager()
-{ }
+CAnnouncementManager::CAnnouncementManager() : CThread("Announce")
+{
+}
 
 CAnnouncementManager::~CAnnouncementManager()
 {
@@ -45,12 +47,19 @@ CAnnouncementManager::~CAnnouncementManager()
 
 CAnnouncementManager& CAnnouncementManager::GetInstance()
 {
-  static CAnnouncementManager s_instance;
-  return s_instance;
+  return CServiceBroker::GetAnnouncementManager();
+}
+
+void CAnnouncementManager::Start()
+{
+  Create();
 }
 
 void CAnnouncementManager::Deinitialize()
 {
+  m_bStop = true;
+  m_queueEvent.Set();
+  StopThread();
   CSingleLock lock (m_critSection);
   m_announcers.clear();
 }
@@ -83,19 +92,12 @@ void CAnnouncementManager::RemoveAnnouncer(IAnnouncer *listener)
 void CAnnouncementManager::Announce(AnnouncementFlag flag, const char *sender, const char *message)
 {
   CVariant data;
-  Announce(flag, sender, message, data);
+  Announce(flag, sender, message, nullptr, data);
 }
 
 void CAnnouncementManager::Announce(AnnouncementFlag flag, const char *sender, const char *message, CVariant &data)
 {
-  CLog::Log(LOGDEBUG, "CAnnouncementManager - Announcement: %s from %s", message, sender);
-
-  CSingleLock lock (m_critSection);
-
-  // Make a copy of announers. They may be removed or even remove themselves during execution of IAnnouncer::Announce()!
-  std::vector<IAnnouncer *> announcers(m_announcers); 
-  for (unsigned int i = 0; i < announcers.size(); i++)
-    announcers[i]->Announce(flag, sender, message, data);
+  Announce(flag, sender, message, nullptr, data);
 }
 
 void CAnnouncementManager::Announce(AnnouncementFlag flag, const char *sender, const char *message, CFileItemPtr item)
@@ -106,9 +108,37 @@ void CAnnouncementManager::Announce(AnnouncementFlag flag, const char *sender, c
 
 void CAnnouncementManager::Announce(AnnouncementFlag flag, const char *sender, const char *message, CFileItemPtr item, CVariant &data)
 {
+  CAnnounceData announcement;
+  announcement.flag = flag;
+  announcement.sender = sender;
+  announcement.message = message;
+  announcement.item = item;
+  announcement.data = data;
+
+  {
+    CSingleLock lock (m_critSection);
+    m_announcementQueue.push_back(announcement);
+  }
+  m_queueEvent.Set();
+}
+
+void CAnnouncementManager::DoAnnounce(AnnouncementFlag flag, const char *sender, const char *message, CVariant &data)
+{
+  CLog::Log(LOGDEBUG, "CAnnouncementManager - Announcement: %s from %s", message, sender);
+
+  CSingleLock lock (m_critSection);
+
+  // Make a copy of announers. They may be removed or even remove themselves during execution of IAnnouncer::Announce()!
+  std::vector<IAnnouncer *> announcers(m_announcers);
+  for (unsigned int i = 0; i < announcers.size(); i++)
+    announcers[i]->Announce(flag, sender, message, data);
+}
+
+void CAnnouncementManager::DoAnnounce(AnnouncementFlag flag, const char *sender, const char *message, CFileItemPtr item, CVariant &data)
+{
   if (!item.get())
   {
-    Announce(flag, sender, message, data);
+    DoAnnounce(flag, sender, message, data);
     return;
   }
 
@@ -248,5 +278,29 @@ void CAnnouncementManager::Announce(AnnouncementFlag flag, const char *sender, c
   if (id > 0)
     object["item"]["id"] = id;
 
-  Announce(flag, sender, message, object);
+  DoAnnounce(flag, sender, message, object);
+}
+
+void CAnnouncementManager::Process()
+{
+  SetPriority(GetMinPriority());
+
+  while (!m_bStop)
+  {
+    CSingleLock lock (m_critSection);
+    if (!m_announcementQueue.empty())
+    {
+      auto announcement = m_announcementQueue.front();
+      m_announcementQueue.pop_front();
+      {
+        CSingleExit ex(m_critSection);
+        DoAnnounce(announcement.flag, announcement.sender.c_str(), announcement.message.c_str(), announcement.item, announcement.data);
+      }
+    }
+    else
+    {
+      CSingleExit ex(m_critSection);
+      m_queueEvent.Wait();
+    }
+  }
 }

--- a/xbmc/interfaces/AnnouncementManager.h
+++ b/xbmc/interfaces/AnnouncementManager.h
@@ -23,19 +23,23 @@
 #include "IAnnouncer.h"
 #include "FileItem.h"
 #include "threads/CriticalSection.h"
-#include "utils/GlobalsHandling.h"
+#include "threads/Thread.h"
+#include "threads/Event.h"
+#include "utils/Variant.h"
 
 class CVariant;
 
 namespace ANNOUNCEMENT
 {
-  class CAnnouncementManager
+  class CAnnouncementManager : public CThread
   {
   public:
+    CAnnouncementManager();
     virtual ~CAnnouncementManager();
 
     static CAnnouncementManager& GetInstance();
 
+    void Start();
     void Deinitialize();
 
     void AddAnnouncer(IAnnouncer *listener);
@@ -45,8 +49,24 @@ namespace ANNOUNCEMENT
     void Announce(AnnouncementFlag flag, const char *sender, const char *message, CVariant &data);
     void Announce(AnnouncementFlag flag, const char *sender, const char *message, CFileItemPtr item);
     void Announce(AnnouncementFlag flag, const char *sender, const char *message, CFileItemPtr item, CVariant &data);
+
+  protected:
+    void Process();
+    void DoAnnounce(AnnouncementFlag flag, const char *sender, const char *message, CFileItemPtr item, CVariant &data);
+    void DoAnnounce(AnnouncementFlag flag, const char *sender, const char *message, CVariant &data);
+
+    struct CAnnounceData
+    {
+      AnnouncementFlag flag;
+      std::string sender;
+      std::string message;
+      CFileItemPtr item;
+      CVariant data;
+    };
+    std::list<CAnnounceData> m_announcementQueue;
+    CEvent m_queueEvent;
+
   private:
-    CAnnouncementManager();
     CAnnouncementManager(const CAnnouncementManager&);
     CAnnouncementManager const& operator=(CAnnouncementManager const&);
 

--- a/xbmc/interfaces/python/XBPython.h
+++ b/xbmc/interfaces/python/XBPython.h
@@ -26,9 +26,12 @@
 #include "threads/Thread.h"
 #include "interfaces/IAnnouncer.h"
 #include "interfaces/generic/ILanguageInvocationHandler.h"
+#include "ServiceBroker.h"
 
 #include <memory>
 #include <vector>
+
+#define g_pythonParser CServiceBroker::GetXBPython()
 
 class CPythonInvoker;
 class CVariant;
@@ -132,5 +135,3 @@ private:
   // loaded by it and unload them first (not done by finalize)
   PythonExtensionLibraries m_extensions;
 };
-
-extern XBPython g_pythonParser;

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -65,6 +65,7 @@
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
 #include "video/VideoDatabase.h"
+#include "ServiceBroker.h"
 
 using namespace MUSIC_INFO;
 using namespace PVR;
@@ -139,8 +140,7 @@ void CPVRManager::Announce(AnnouncementFlag flag, const char *sender, const char
 
 CPVRManager &CPVRManager::GetInstance()
 {
-  static CPVRManager pvrManagerInstance;
-  return pvrManagerInstance;
+  return CServiceBroker::GetPVRManager();
 }
 
 bool CPVRManager::RestartManagerOnAddonDisabled(void) const

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -97,6 +97,7 @@ CPVRManager::CPVRManager(void) :
     m_timers(NULL),
     m_addons(NULL),
     m_guiInfo(NULL),
+    m_parentalTimer(nullptr),
     m_triggerEvent(true),
     m_currentFile(NULL),
     m_database(NULL),

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -94,11 +94,13 @@ namespace PVR
   {
     friend class CPVRClients;
 
-  private:
+public:
     /*!
      * @brief Create a new CPVRManager instance, which handles all PVR related operations in XBMC.
      */
     CPVRManager(void);
+
+private:
 
     /*!
      * @brief Updates the last watched timestamps of the channel and group which are currently playing.


### PR DESCRIPTION
now that we more control we can do further improvements. Announcements did block main/render thread for several seconds when video was started or stopped because this does DB lookups.

This PR is based on https://github.com/xbmc/xbmc/pull/9389
@Montellese please have a look.
