### PR TITLE
[guilib] fix: clear m_expressions in ClearIncludes()

### DIFF
--- a/xbmc/guilib/GUIIncludes.cpp
+++ b/xbmc/guilib/GUIIncludes.cpp
@@ -103,6 +103,7 @@ void CGUIIncludes::ClearIncludes()
   m_constants.clear();
   m_skinvariables.clear();
   m_files.clear();
+  m_expressions.clear();
 }
 
 bool CGUIIncludes::LoadIncludes(const std::string &includeFile)


### PR DESCRIPTION
Also adds missing handling of expressions in ClearIncludes().
@xhaggi         
