### PR TITLE
[addons] recently updated directory

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -5101,7 +5101,12 @@ msgctxt "#12013"
 msgid "Install date"
 msgstr ""
 
-#empty strings from id 12014 to 12020
+#: xbmc/addons/GUIViewStateAddonBrowser.cpp
+msgctxt "#12014"
+msgid "Last updated"
+msgstr ""
+
+#empty strings from id 12015 to 12020
 
 #. Label of various controls for starting playback from the beginning
 #: xbmc/Autorun.cpp
@@ -13467,7 +13472,11 @@ msgctxt "#24003"
 msgid "Add-on information"
 msgstr ""
 
-#empty string with id 24004
+#. Name of menu in the add-on browser
+#: xbmc/filesystem/AddonsDirectory.cpp
+msgctxt "#24004"
+msgid "Recently updated"
+msgstr ""
 
 #: xbmc/addons/Addon.cpp
 msgctxt "#24005"

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2910,7 +2910,7 @@
         </setting>
         <setting id="general.addonnotifications" type="boolean" label="36609" help="36612">
           <level>0</level>
-          <default>true</default>
+          <default>false</default>
           <control type="toggle" />
           <dependencies>
             <dependency type="enable" setting="general.addonupdates">0</dependency>

--- a/xbmc/addons/GUIViewStateAddonBrowser.cpp
+++ b/xbmc/addons/GUIViewStateAddonBrowser.cpp
@@ -38,6 +38,11 @@ CGUIViewStateAddonBrowser::CGUIViewStateAddonBrowser(const CFileItemList& items)
     AddSortMethod(SortByNone, 551, LABEL_MASKS("%F", "", "%L", ""));
     SetSortMethod(SortByNone);
   }
+  else if (URIUtils::PathEquals(items.GetPath(), "addons://recently_updated/", true))
+  {
+    AddSortMethod(SortByLastUpdated, 12014, LABEL_MASKS("%L", "%v", "%L", "%v"),
+        SortAttributeIgnoreFolders, SortOrderDescending);
+  }
   else
   {
     AddSortMethod(SortByLabel, SortAttributeIgnoreFolders, 551, LABEL_MASKS("%L", "%s", "%L", "%s"));

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -24,6 +24,7 @@
 #include <set>
 #include "AddonsDirectory.h"
 #include "addons/AddonDatabase.h"
+#include "addons/AddonSystemSettings.h"
 #include "interfaces/generic/ScriptInvocationManager.h"
 #include "FileItem.h"
 #include "addons/AddonInstaller.h"
@@ -32,6 +33,7 @@
 #include "dialogs/GUIDialogOK.h"
 #include "guilib/TextureManager.h"
 #include "File.h"
+#include "settings/Settings.h"
 #include "SpecialProtocol.h"
 #include "utils/URIUtils.h"
 #include "utils/StringUtils.h"
@@ -387,6 +389,22 @@ static bool Browse(const CURL& path, CFileItemList &items)
   return true;
 }
 
+static bool GetRecentlyUpdatedAddons(VECADDONS& addons)
+{
+  if (!CAddonMgr::GetInstance().GetInstalledAddons(addons))
+    return false;
+
+  auto limit = CDateTime::GetCurrentDateTime() - CDateTimeSpan(14, 0, 0, 0);
+  auto isOld = [limit](const AddonPtr& addon){ return addon->LastUpdated() < limit; };
+  addons.erase(std::remove_if(addons.begin(), addons.end(), isOld), addons.end());
+  return true;
+}
+
+static bool HasRecentlyUpdatedAddons()
+{
+  VECADDONS addons;
+  return GetRecentlyUpdatedAddons(addons) && !addons.empty();
+}
 
 static bool Repos(const CURL& path, CFileItemList &items)
 {
@@ -432,6 +450,14 @@ static void RootDirectory(CFileItemList& items)
     CFileItemPtr item(new CFileItem("addons://downloading/", true));
     item->SetLabel(g_localizeStrings.Get(24067));
     item->SetIconImage("DefaultNetwork.png");
+    items.Add(item);
+  }
+  if (CSettings::GetInstance().GetInt(CSettings::SETTING_ADDONS_AUTOUPDATES) == ADDON::AUTO_UPDATES_ON
+      && HasRecentlyUpdatedAddons())
+  {
+    CFileItemPtr item(new CFileItem("addons://recently_updated/", true));
+    item->SetLabel(g_localizeStrings.Get(24004));
+    item->SetIconImage("DefaultAddonsRecentlyUpdated.png");
     items.Add(item);
   }
   if (CAddonMgr::GetInstance().HasAddons(ADDON_REPOSITORY))
@@ -521,6 +547,19 @@ bool CAddonsDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   else if (endpoint == "search")
   {
     return GetSearchResults(path, items);
+  }
+  else if (endpoint == "recently_updated")
+  {
+    VECADDONS addons;
+    if (!GetRecentlyUpdatedAddons(addons))
+      return false;
+
+    std::sort(addons.begin(), addons.end(),
+        [](const AddonPtr& a, const AddonPtr& b){ return a->LastUpdated() > b->LastUpdated(); });
+
+    CAddonsDirectory::GenerateAddonListing(path, addons, items, g_localizeStrings.Get(24004));
+    return true;
+
   }
   else if (endpoint == "downloading")
   {


### PR DESCRIPTION
This adds a new directory for showing the most recently installed updates. Useful if you have auto updates on and want to see what has updated/check the changelogs.

It also flips notifications to off by default. I don't find it very useful anymore as you can simply go to the addon browser instead if you want to know what has updated.
