### PR TITLE
Support per-stream proxies in HLS streams (attempt 4)

### DIFF
--- a/xbmc/Proxy.h
+++ b/xbmc/Proxy.h
@@ -1,0 +1,29 @@
+#pragma once
+/*
+ *      Copyright (C) 2016 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+typedef enum
+{
+  PROXY_HTTP = 0,
+  PROXY_SOCKS4,
+  PROXY_SOCKS4A,
+  PROXY_SOCKS5,
+  PROXY_SOCKS5_REMOTE,
+} ProxyType;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -20,6 +20,7 @@
 
 #include "DVDDemuxFFmpeg.h"
 
+#include <sstream>
 #include <utility>
 
 #include "commons/Exception.h"
@@ -638,6 +639,30 @@ AVDictionary *CDVDDemuxFFmpeg::GetFFMpegOptionsFromInput()
       av_dict_set(&options, "cookies", cookies.c_str(), 0);
 
   }
+
+  const std::string host = m_pInput->GetProxyHost();
+  if (!host.empty() && m_pInput->GetProxyType() == PROXY_HTTP)
+  {
+    std::ostringstream urlStream;
+
+    const uint16_t port = m_pInput->GetProxyPort();
+    const std::string user = m_pInput->GetProxyUser();
+    const std::string password = m_pInput->GetProxyPassword();
+
+    urlStream << "http://";
+
+    if (!user.empty()) {
+      urlStream << user;
+      if (!password.empty())
+        urlStream << ":" << password;
+      urlStream << "@";
+    }
+
+    urlStream << host << ':' << port;
+
+    av_dict_set(&options, "http_proxy", urlStream.str().c_str(), 0);
+  }
+
   return options;
 }
 

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -230,9 +230,9 @@ bool CDVDDemuxFFmpeg::Open(CDVDInputStream* pInput, bool streaminfo, bool filein
   {
     // special stream type that makes avformat handle file opening
     // allows internal ffmpeg protocols to be used
-    CURL url = m_pInput->GetURL();
+    AVDictionary *options = GetFFMpegOptionsFromInput();
 
-    AVDictionary *options = GetFFMpegOptionsFromURL(url);
+    CURL url = m_pInput->GetURL();
 
     int result=-1;
     if (url.IsProtocol("mms"))
@@ -599,9 +599,9 @@ void CDVDDemuxFFmpeg::SetSpeed(int iSpeed)
   }
 }
 
-AVDictionary *CDVDDemuxFFmpeg::GetFFMpegOptionsFromURL(const CURL &url)
+AVDictionary *CDVDDemuxFFmpeg::GetFFMpegOptionsFromInput()
 {
-
+  const CURL url = m_pInput->GetURL();
   AVDictionary *options = NULL;
 
   if (url.IsProtocol("http") || url.IsProtocol("https"))

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
@@ -133,7 +133,7 @@ protected:
   bool IsVideoReady();
   void ResetVideoStreams();
 
-  AVDictionary *GetFFMpegOptionsFromURL(const CURL &url);
+  AVDictionary *GetFFMpegOptionsFromInput();
   double ConvertTimestamp(int64_t pts, int den, int num);
   void UpdateCurrentPTS();
   bool IsProgramChange();

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.cpp
@@ -20,6 +20,7 @@
 
 #include "DVDInputStream.h"
 #include "URL.h"
+#include "utils/log.h"
 
 CDVDInputStream::CDVDInputStream(DVDStreamType streamType, CFileItem& fileitem)
 {
@@ -52,4 +53,62 @@ std::string CDVDInputStream::GetFileName()
 
   url.SetProtocolOptions("");
   return url.Get();
+}
+
+ProxyType CDVDInputStream::GetProxyType() const
+{
+  if (m_item.HasProperty("proxy.type"))
+  {
+    const std::string value = m_item.GetProperty("proxy.type").asString();
+    if (value == "http")
+      return PROXY_HTTP;
+    else if (value == "socks4")
+      return PROXY_SOCKS4;
+    else if (value == "socks4a")
+      return PROXY_SOCKS4A;
+    else if (value == "socks5")
+      return PROXY_SOCKS5;
+    else if (value == "socks5-remote")
+      return PROXY_SOCKS5_REMOTE;
+    else
+      CLog::Log(LOGERROR,"Invalid proxy type \"%s\"", value.c_str());
+  }
+
+  return PROXY_HTTP;
+}
+
+std::string CDVDInputStream::GetProxyHost() const
+{
+  return m_item.HasProperty("proxy.host") ?
+    m_item.GetProperty("proxy.host").asString() : std::string();
+}
+
+uint16_t CDVDInputStream::GetProxyPort() const
+{
+  if (m_item.HasProperty("proxy.port"))
+    return m_item.GetProperty("proxy.port").asInteger();
+
+  // Select the standard port
+  switch (GetProxyType()) {
+  case PROXY_SOCKS4:
+  case PROXY_SOCKS4A:
+  case PROXY_SOCKS5:
+  case PROXY_SOCKS5_REMOTE:
+    return 1080;
+  case PROXY_HTTP:
+  default:
+    return 3128;
+  }
+}
+
+std::string CDVDInputStream::GetProxyUser() const
+{
+  return m_item.HasProperty("proxy.user") ?
+    m_item.GetProperty("proxy.user").asString() : std::string();
+}
+
+std::string CDVDInputStream::GetProxyPassword() const
+{
+  return m_item.HasProperty("proxy.password") ?
+    m_item.GetProperty("proxy.password").asString() : std::string();
 }

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.cpp
@@ -53,8 +53,3 @@ std::string CDVDInputStream::GetFileName()
   url.SetProtocolOptions("");
   return url.Get();
 }
-
-CURL CDVDInputStream::GetURL()
-{
-  return m_item.GetURL();
-}

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
@@ -149,13 +149,14 @@ public:
   virtual int64_t GetLength() = 0;
   virtual std::string& GetContent() { return m_content; };
   virtual std::string GetFileName();
-  virtual CURL GetURL();
   virtual ENextStream NextStream() { return NEXTSTREAM_NONE; }
   virtual void Abort() {}
   virtual int GetBlockSize() { return 0; }
   virtual void ResetScanTimeout(unsigned int iTimeoutMs) { }
   virtual bool CanSeek() { return true; }
   virtual bool CanPause() { return true; }
+
+  CURL GetURL() const { return m_item.GetURL(); }
 
   /*! \brief Indicate expected read rate in bytes per second.
    *  This could be used to throttle caching rate. Should

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
@@ -26,6 +26,7 @@
 #include "filesystem/IFileTypes.h"
 
 #include "FileItem.h"
+#include "Proxy.h"
 #include "URL.h"
 #include "guilib/Geometry.h"
 
@@ -157,6 +158,12 @@ public:
   virtual bool CanPause() { return true; }
 
   CURL GetURL() const { return m_item.GetURL(); }
+
+  ProxyType GetProxyType() const;
+  std::string GetProxyHost() const;
+  uint16_t GetProxyPort() const;
+  std::string GetProxyUser() const;
+  std::string GetProxyPassword() const;
 
   /*! \brief Indicate expected read rate in bytes per second.
    *  This could be used to throttle caching rate. Should

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFFmpeg.cpp
@@ -50,18 +50,18 @@ bool CDVDInputStreamFFmpeg::IsEOF()
 
 bool CDVDInputStreamFFmpeg::Open()
 {
-  std::string selected;
   if (m_item.IsInternetStream() && (m_item.IsType(".m3u8") || m_item.GetMimeType() == "application/vnd.apple.mpegurl"))
   {
     // get the available bandwidth and  determine the most appropriate stream
     int bandwidth = CSettings::GetInstance().GetInt(CSettings::SETTING_NETWORK_BANDWIDTH);
     if(bandwidth <= 0)
       bandwidth = INT_MAX;
-    selected = PLAYLIST::CPlayListM3U::GetBestBandwidthStream(m_item.GetPath(), bandwidth);
-    if (selected.compare(m_item.GetPath()) != 0)
+    const CURL playlist_url = m_item.GetURL();
+    const CURL selected = PLAYLIST::CPlayListM3U::GetBestBandwidthStream(playlist_url, bandwidth);
+    if (selected.Get().compare(playlist_url.Get()) != 0)
     {
-      CLog::Log(LOGINFO, "CDVDInputStreamFFmpeg: Auto-selecting %s based on configured bandwidth.", selected.c_str());
-      m_item.SetPath(selected.c_str());
+      CLog::Log(LOGINFO, "CDVDInputStreamFFmpeg: Auto-selecting %s based on configured bandwidth.", selected.Get().c_str());
+      m_item.SetURL(selected);
     }
   }
 

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFFmpeg.cpp
@@ -20,7 +20,7 @@
 
 #include "DVDInputStreamFFmpeg.h"
 
-#include "filesystem/File.h"
+#include "filesystem/CurlFile.h"
 #include "playlists/PlayListM3U.h"
 #include "settings/Settings.h"
 #include "utils/log.h"
@@ -125,8 +125,20 @@ CURL CDVDInputStreamFFmpeg::GetM3UBestBandwidthStream(const CURL &url, size_t ba
   string strLine;
   size_t maxBandwidth = 0;
 
+  CCurlFile file;
+
+  // set the proxy configuration
+  const string host = GetProxyHost();
+  if (!host.empty())
+  {
+    const ProxyType type = GetProxyType();
+    const uint16_t port = GetProxyPort();
+    const string user = GetProxyUser();
+    const string password = GetProxyPassword();
+    file.SetProxy(type, host, port, user, password);
+  }
+
   // open the file, and if it fails, return
-  CFile file;
   if (!file.Open(url))
   {
     file.Close();

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFFmpeg.cpp
@@ -19,12 +19,18 @@
  */
 
 #include "DVDInputStreamFFmpeg.h"
+
+#include "filesystem/File.h"
 #include "playlists/PlayListM3U.h"
 #include "settings/Settings.h"
 #include "utils/log.h"
+#include "utils/StringUtils.h"
+#include "utils/URIUtils.h"
+
 #include <limits.h>
 
 using namespace XFILE;
+using PLAYLIST::CPlayListM3U;
 
 CDVDInputStreamFFmpeg::CDVDInputStreamFFmpeg(CFileItem& fileitem)
   : CDVDInputStream(DVDSTREAM_TYPE_FFMPEG, fileitem)
@@ -54,7 +60,7 @@ bool CDVDInputStreamFFmpeg::Open()
     if(bandwidth <= 0)
       bandwidth = INT_MAX;
     const CURL playlist_url = m_item.GetURL();
-    const CURL selected = PLAYLIST::CPlayListM3U::GetBestBandwidthStream(playlist_url, bandwidth);
+    const CURL selected = GetM3UBestBandwidthStream(playlist_url, bandwidth);
     if (selected.Get().compare(playlist_url.Get()) != 0)
     {
       CLog::Log(LOGINFO, "CDVDInputStreamFFmpeg: Auto-selecting %s based on configured bandwidth.", selected.Get().c_str());
@@ -106,3 +112,84 @@ int64_t CDVDInputStreamFFmpeg::Seek(int64_t offset, int whence)
   return -1;
 }
 
+CURL CDVDInputStreamFFmpeg::GetM3UBestBandwidthStream(const CURL &url, size_t bandwidth)
+{
+  typedef CPlayListM3U M3U;
+  using std::string;
+  using std::map;
+
+  // we may be passed a playlist that does not contain playlists of different
+  // bitrates (eg: this playlist is really the HLS video). So, default the
+  // return to the filename so it can be played
+  char szLine[4096];
+  string strLine;
+  size_t maxBandwidth = 0;
+
+  // open the file, and if it fails, return
+  CFile file;
+  if (!file.Open(url))
+  {
+    file.Close();
+    return url;
+  }
+
+  // and set the fallback value
+  CURL subStreamUrl(url);
+
+  // determine the base
+  CURL basePlaylistUrl(URIUtils::GetParentPath(url.Get()));
+  basePlaylistUrl.SetOptions("");
+  basePlaylistUrl.SetProtocolOptions("");
+  const string basePart = basePlaylistUrl.Get();
+
+  // convert bandwidth specified in kbps to bps used by the m3u8
+  bandwidth *= 1000;
+
+  while (file.ReadString(szLine, 1024))
+  {
+    // read and trim a line
+    strLine = szLine;
+    StringUtils::Trim(strLine);
+
+    // skip the first line
+    if (strLine == M3U::StartMarker)
+        continue;
+    else if (StringUtils::StartsWith(strLine, M3U::StreamMarker))
+    {
+      // parse the line so we can pull out the bandwidth
+      const map< string, string > params = M3U::ParseStreamLine(strLine);
+      const map< string, string >::const_iterator it = params.find(M3U::BandwidthMarker);
+
+      if (it != params.end())
+      {
+        const size_t streamBandwidth = atoi(it->second.c_str());
+        if ((maxBandwidth < streamBandwidth) && (streamBandwidth <= bandwidth))
+        {
+          // read the next line
+          if (!file.ReadString(szLine, 1024))
+            continue;
+
+          strLine = szLine;
+          StringUtils::Trim(strLine);
+
+          // this line was empty
+          if (strLine.empty())
+            continue;
+
+          // store the max bandwidth
+          maxBandwidth = streamBandwidth;
+
+          // if the path is absolute just use it
+          if (CURL::IsFullPath(strLine))
+            subStreamUrl = CURL(strLine);
+          else
+            subStreamUrl = CURL(basePart + strLine);
+        }
+      }
+    }
+  }
+
+  // if any protocol options were set, restore them
+  subStreamUrl.SetProtocolOptions(url.GetProtocolOptions());
+  return subStreamUrl;
+}

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFFmpeg.cpp
@@ -42,10 +42,7 @@ CDVDInputStreamFFmpeg::~CDVDInputStreamFFmpeg()
 
 bool CDVDInputStreamFFmpeg::IsEOF()
 {
-  if(m_aborted)
-    return true;
-  else
-    return false;
+  return m_aborted;
 }
 
 bool CDVDInputStreamFFmpeg::Open()

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFFmpeg.h
@@ -43,7 +43,7 @@ public:
   bool CanPause() { return m_can_pause; }
 
 private:
-  static CURL GetM3UBestBandwidthStream(const CURL &url, size_t bandwidth);
+  CURL GetM3UBestBandwidthStream(const CURL &url, size_t bandwidth);
 
 protected:
   bool m_can_pause;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFFmpeg.h
@@ -42,6 +42,9 @@ public:
   bool CanSeek() { return m_can_seek; }
   bool CanPause() { return m_can_pause; }
 
+private:
+  static CURL GetM3UBestBandwidthStream(const CURL &url, size_t bandwidth);
+
 protected:
   bool m_can_pause;
   bool m_can_seek;

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -766,19 +766,20 @@ void CCurlFile::ParseAndCorrectUrl(CURL &url2)
   else if( url2.IsProtocol("http")
        ||  url2.IsProtocol("https"))
   {
-    if (CSettings::GetInstance().GetBool(CSettings::SETTING_NETWORK_USEHTTPPROXY)
-        && !CSettings::GetInstance().GetString(CSettings::SETTING_NETWORK_HTTPPROXYSERVER).empty()
-        && CSettings::GetInstance().GetInt(CSettings::SETTING_NETWORK_HTTPPROXYPORT) > 0
+    const CSettings &s = CSettings::GetInstance();
+    if (s.GetBool(CSettings::SETTING_NETWORK_USEHTTPPROXY)
+        && !s.GetString(CSettings::SETTING_NETWORK_HTTPPROXYSERVER).empty()
+        && s.GetInt(CSettings::SETTING_NETWORK_HTTPPROXYPORT) > 0
         && m_proxy.empty())
     {
-      m_proxy = CSettings::GetInstance().GetString(CSettings::SETTING_NETWORK_HTTPPROXYSERVER);
-      m_proxy += StringUtils::Format(":%d", CSettings::GetInstance().GetInt(CSettings::SETTING_NETWORK_HTTPPROXYPORT));
-      if (CSettings::GetInstance().GetString(CSettings::SETTING_NETWORK_HTTPPROXYUSERNAME).length() > 0 && m_proxyuserpass.empty())
+      m_proxy = s.GetString(CSettings::SETTING_NETWORK_HTTPPROXYSERVER);
+      m_proxy += StringUtils::Format(":%d", s.GetInt(CSettings::SETTING_NETWORK_HTTPPROXYPORT));
+      if (s.GetString(CSettings::SETTING_NETWORK_HTTPPROXYUSERNAME).length() > 0 && m_proxyuserpass.empty())
       {
-        m_proxyuserpass = CSettings::GetInstance().GetString(CSettings::SETTING_NETWORK_HTTPPROXYUSERNAME);
-        m_proxyuserpass += ":" + CSettings::GetInstance().GetString(CSettings::SETTING_NETWORK_HTTPPROXYPASSWORD);
+        m_proxyuserpass = s.GetString(CSettings::SETTING_NETWORK_HTTPPROXYUSERNAME);
+        m_proxyuserpass += ":" + s.GetString(CSettings::SETTING_NETWORK_HTTPPROXYPASSWORD);
       }
-      m_proxytype = (ProxyType)CSettings::GetInstance().GetInt(CSettings::SETTING_NETWORK_HTTPPROXYTYPE);
+      m_proxytype = (ProxyType)s.GetInt(CSettings::SETTING_NETWORK_HTTPPROXYTYPE);
       CLog::Log(LOGDEBUG, "Using proxy %s, type %d", m_proxy.c_str(), convert_proxy_type(m_proxytype));
     }
 

--- a/xbmc/filesystem/CurlFile.h
+++ b/xbmc/filesystem/CurlFile.h
@@ -24,6 +24,7 @@
 #include <map>
 #include <string>
 #include "utils/HttpHeader.h"
+#include "Proxy.h"
 
 namespace XCURL
 {
@@ -37,15 +38,6 @@ namespace XFILE
   class CCurlFile : public IFile
   {
     public:
-      typedef enum
-      {
-        PROXY_HTTP = 0,
-        PROXY_SOCKS4,
-        PROXY_SOCKS4A,
-        PROXY_SOCKS5,
-        PROXY_SOCKS5_REMOTE,
-      } ProxyType;
-    
       CCurlFile();
       virtual ~CCurlFile();
       virtual bool Open(const CURL& url);

--- a/xbmc/filesystem/CurlFile.h
+++ b/xbmc/filesystem/CurlFile.h
@@ -65,9 +65,8 @@ namespace XFILE
       void Cancel();
       void Reset();
       void SetUserAgent(const std::string& sUserAgent)           { m_userAgent = sUserAgent; }
-      void SetProxy(const std::string &proxy)                    { m_proxy = proxy; }
-      void SetProxyUserPass(const std::string &proxyuserpass)    { m_proxyuserpass = proxyuserpass; }
-      void SetProxyType(ProxyType proxytype)                     { m_proxytype = proxytype; }
+      void SetProxy(ProxyType proxytype, const std::string &host, uint16_t port,
+                    const std::string &user, const std::string &password);
       void SetCustomRequest(const std::string &request)          { m_customrequest = request; }
       void UseOldHttpVersion(bool bUse)                          { m_useOldHttpVersion = bUse; }
       void SetAcceptEncoding(const std::string& encoding)        { m_acceptencoding = encoding; }
@@ -156,9 +155,11 @@ namespace XFILE
 
       std::string     m_url;
       std::string     m_userAgent;
-      std::string     m_proxy;
-      std::string     m_proxyuserpass;
       ProxyType       m_proxytype;
+      std::string     m_proxyhost;
+      uint16_t        m_proxyport;
+      std::string     m_proxyuser;
+      std::string     m_proxypassword;
       std::string     m_customrequest;
       std::string     m_acceptencoding;
       std::string     m_acceptCharset;

--- a/xbmc/filesystem/FileCache.cpp
+++ b/xbmc/filesystem/FileCache.cpp
@@ -166,10 +166,8 @@ bool CFileCache::Open(const CURL& url)
 
   CLog::Log(LOGDEBUG,"CFileCache::Open - opening <%s> using cache", url.GetFileName().c_str());
 
-  m_sourcePath = url.Get();
-
   // opening the source file.
-  if (!m_source.Open(m_sourcePath, READ_NO_CACHE | READ_TRUNCATED | READ_CHUNKED))
+  if (!m_source.Open(url, READ_NO_CACHE | READ_TRUNCATED | READ_CHUNKED))
   {
     CLog::Log(LOGERROR,"%s - failed to open source <%s>", __FUNCTION__, url.GetRedacted().c_str());
     Close();

--- a/xbmc/filesystem/FileCache.h
+++ b/xbmc/filesystem/FileCache.h
@@ -67,7 +67,6 @@ namespace XFILE
     bool      m_bDeleteCache;
     int        m_seekPossible;
     CFile      m_source;
-    std::string    m_sourcePath;
     CEvent      m_seekEvent;
     CEvent      m_seekEnded;
     int64_t      m_nSeekResult;

--- a/xbmc/playlists/PlayListM3U.cpp
+++ b/xbmc/playlists/PlayListM3U.cpp
@@ -226,7 +226,7 @@ void CPlayListM3U::Save(const std::string& strFileName) const
   file.Close();
 }
 
-std::string CPlayListM3U::GetBestBandwidthStream(const std::string &strFileName, size_t bandwidth)
+CURL CPlayListM3U::GetBestBandwidthStream(const CURL &url, size_t bandwidth)
 {
   // we may be passed a playlist that does not contain playlists of different
   // bitrates (eg: this playlist is really the HLS video). So, default the
@@ -237,20 +237,17 @@ std::string CPlayListM3U::GetBestBandwidthStream(const std::string &strFileName,
 
   // open the file, and if it fails, return
   CFile file;
-  if (!file.Open(strFileName) )
+  if (!file.Open(url))
   {
     file.Close();
-    return strFileName;
+    return url;
   }
 
-  // get protocol options if they were set, so we can restore them again at the end
-  CURL playlistUrl(strFileName);
-  
   // and set the fallback value
-  CURL subStreamUrl = CURL(strFileName);
+  CURL subStreamUrl(url);
   
   // determine the base
-  CURL basePlaylistUrl(URIUtils::GetParentPath(strFileName));
+  CURL basePlaylistUrl(URIUtils::GetParentPath(url.Get()));
   basePlaylistUrl.SetOptions("");
   basePlaylistUrl.SetProtocolOptions("");
   std::string basePart = basePlaylistUrl.Get();
@@ -303,8 +300,8 @@ std::string CPlayListM3U::GetBestBandwidthStream(const std::string &strFileName,
   }
 
   // if any protocol options were set, restore them
-  subStreamUrl.SetProtocolOptions(playlistUrl.GetProtocolOptions());
-  return subStreamUrl.Get();
+  subStreamUrl.SetProtocolOptions(url.GetProtocolOptions());
+  return subStreamUrl;
 }
 
 std::map< std::string, std::string > CPlayListM3U::ParseStreamLine(const std::string &streamLine)

--- a/xbmc/playlists/PlayListM3U.cpp
+++ b/xbmc/playlists/PlayListM3U.cpp
@@ -22,7 +22,6 @@
 #include "filesystem/File.h"
 #include "URL.h"
 #include "Util.h"
-#include "utils/StringUtils.h"
 #include "utils/CharsetConverter.h"
 #include "utils/log.h"
 #include "utils/URIUtils.h"
@@ -32,13 +31,13 @@
 using namespace PLAYLIST;
 using namespace XFILE;
 
-#define M3U_START_MARKER "#EXTM3U"
-#define M3U_INFO_MARKER  "#EXTINF"
-#define M3U_ARTIST_MARKER  "#EXTART"
-#define M3U_ALBUM_MARKER  "#EXTALB"
-#define M3U_STREAM_MARKER  "#EXT-X-STREAM-INF"
-#define M3U_BANDWIDTH_MARKER  "BANDWIDTH"
-#define M3U_OFFSET_MARKER  "#EXT-KX-OFFSET"
+const char* CPlayListM3U::StartMarker = "#EXTCPlayListM3U::M3U";
+const char* CPlayListM3U::InfoMarker = "#EXTINF";
+const char* CPlayListM3U::ArtistMarker = "#EXTART";
+const char* CPlayListM3U::AlbumMarker = "#EXTALB";
+const char* CPlayListM3U::StreamMarker = "#EXT-X-STREAM-INF";
+const char* CPlayListM3U::BandwidthMarker = "BANDWIDTH";
+const char* CPlayListM3U::OffsetMarker = "#EXT-KX-OFFSET";
 
 // example m3u file:
 //   #EXTM3U
@@ -93,7 +92,7 @@ bool CPlayListM3U::Load(const std::string& strFileName)
     strLine = szLine;
     StringUtils::Trim(strLine);
 
-    if (StringUtils::StartsWith(strLine, M3U_INFO_MARKER))
+    if (StringUtils::StartsWith(strLine, InfoMarker))
     {
       // start of info
       size_t iColon = strLine.find(":");
@@ -111,7 +110,7 @@ bool CPlayListM3U::Load(const std::string& strFileName)
         g_charsetConverter.unknownToUTF8(strInfo);
       }
     }
-    else if (StringUtils::StartsWith(strLine, M3U_OFFSET_MARKER))
+    else if (StringUtils::StartsWith(strLine, OffsetMarker))
     {
       size_t iColon = strLine.find(":");
       size_t iComma = strLine.find(",");
@@ -126,9 +125,9 @@ bool CPlayListM3U::Load(const std::string& strFileName)
         iEndOffset = atoi(strLine.substr(iComma).c_str());
       }
     }
-    else if (strLine != M3U_START_MARKER &&
-             !StringUtils::StartsWith(strLine, M3U_ARTIST_MARKER) &&
-             !StringUtils::StartsWith(strLine, M3U_ALBUM_MARKER))
+    else if (strLine != StartMarker &&
+             !StringUtils::StartsWith(strLine, ArtistMarker) &&
+             !StringUtils::StartsWith(strLine, AlbumMarker))
     {
       std::string strFileName = strLine;
 
@@ -200,7 +199,7 @@ void CPlayListM3U::Save(const std::string& strFileName) const
     CLog::Log(LOGERROR, "Could not save M3U playlist: [%s]", strPlaylist.c_str());
     return;
   }
-  std::string strLine = StringUtils::Format("%s\n",M3U_START_MARKER);
+  std::string strLine = StringUtils::Format("%s\n",StartMarker);
   if (file.Write(strLine.c_str(), strLine.size()) != static_cast<ssize_t>(strLine.size()))
     return; // error
 
@@ -209,12 +208,12 @@ void CPlayListM3U::Save(const std::string& strFileName) const
     CFileItemPtr item = m_vecItems[i];
     std::string strDescription=item->GetLabel();
     g_charsetConverter.utf8ToStringCharset(strDescription);
-    strLine = StringUtils::Format( "%s:%i,%s\n", M3U_INFO_MARKER, item->GetMusicInfoTag()->GetDuration() / 1000, strDescription.c_str() );
+    strLine = StringUtils::Format( "%s:%i,%s\n", InfoMarker, item->GetMusicInfoTag()->GetDuration() / 1000, strDescription.c_str() );
     if (file.Write(strLine.c_str(), strLine.size()) != static_cast<ssize_t>(strLine.size()))
       return; // error
     if (item->m_lStartOffset != 0 || item->m_lEndOffset != 0)
     {
-      strLine = StringUtils::Format("%s:%i,%i\n", M3U_OFFSET_MARKER, item->m_lStartOffset, item->m_lEndOffset);
+      strLine = StringUtils::Format("%s:%i,%i\n", OffsetMarker, item->m_lStartOffset, item->m_lEndOffset);
       file.Write(strLine.c_str(),strLine.size());
     }
     std::string strFileName = ResolveURL(item);
@@ -226,94 +225,16 @@ void CPlayListM3U::Save(const std::string& strFileName) const
   file.Close();
 }
 
-CURL CPlayListM3U::GetBestBandwidthStream(const CURL &url, size_t bandwidth)
-{
-  // we may be passed a playlist that does not contain playlists of different
-  // bitrates (eg: this playlist is really the HLS video). So, default the
-  // return to the filename so it can be played
-  char szLine[4096];
-  std::string strLine;
-  size_t maxBandwidth = 0;
-
-  // open the file, and if it fails, return
-  CFile file;
-  if (!file.Open(url))
-  {
-    file.Close();
-    return url;
-  }
-
-  // and set the fallback value
-  CURL subStreamUrl(url);
-  
-  // determine the base
-  CURL basePlaylistUrl(URIUtils::GetParentPath(url.Get()));
-  basePlaylistUrl.SetOptions("");
-  basePlaylistUrl.SetProtocolOptions("");
-  std::string basePart = basePlaylistUrl.Get();
-
-  // convert bandwidth specified in kbps to bps used by the m3u8
-  bandwidth *= 1000;
-
-  while (file.ReadString(szLine, 1024))
-  {
-    // read and trim a line
-    strLine = szLine;
-    StringUtils::Trim(strLine);
-
-    // skip the first line
-    if (strLine == M3U_START_MARKER)
-        continue;
-    else if (StringUtils::StartsWith(strLine, M3U_STREAM_MARKER))
-    {
-      // parse the line so we can pull out the bandwidth
-      std::map< std::string, std::string > params = ParseStreamLine(strLine);
-      std::map< std::string, std::string >::iterator it = params.find(M3U_BANDWIDTH_MARKER);
-
-      if (it != params.end())
-      {
-        size_t streamBandwidth = atoi(it->second.c_str());
-        if ((maxBandwidth < streamBandwidth) && (streamBandwidth <= bandwidth))
-        {
-          // read the next line
-          if (!file.ReadString(szLine, 1024))
-            continue;
-
-          strLine = szLine;
-          StringUtils::Trim(strLine);
-
-          // this line was empty
-          if (strLine.empty())
-            continue;
-
-          // store the max bandwidth
-          maxBandwidth = streamBandwidth;
-
-          // if the path is absolute just use it
-          if (CURL::IsFullPath(strLine))
-            subStreamUrl = CURL(strLine);
-          else
-            subStreamUrl = CURL(basePart + strLine);
-        }
-      }
-    }
-  }
-
-  // if any protocol options were set, restore them
-  subStreamUrl.SetProtocolOptions(url.GetProtocolOptions());
-  return subStreamUrl;
-}
-
 std::map< std::string, std::string > CPlayListM3U::ParseStreamLine(const std::string &streamLine)
 {
   std::map< std::string, std::string > params;
 
   // ensure the line has something beyond the stream marker and ':'
-  if (streamLine.size() < strlen(M3U_STREAM_MARKER) + 2)
+  if (streamLine.size() < strlen(StreamMarker) + 2)
     return params;
 
   // get the actual params following the :
-  std::string strParams(streamLine.substr(strlen(M3U_STREAM_MARKER) + 1));
+  std::string strParams(streamLine.substr(strlen(StreamMarker) + 1));
 
   // separate the parameters
   std::vector<std::string> vecParams = StringUtils::Split(strParams, ",");

--- a/xbmc/playlists/PlayListM3U.h
+++ b/xbmc/playlists/PlayListM3U.h
@@ -18,6 +18,7 @@
  *  <http://www.gnu.org/licenses/>.
  *
  */
+#include "URL.h"
 #include "PlayList.h"
 
 namespace PLAYLIST
@@ -31,7 +32,7 @@ public:
   virtual bool Load(const std::string& strFileName);
   virtual void Save(const std::string& strFileName) const;
 
-  static std::string GetBestBandwidthStream(const std::string &strFileName, size_t bandwidth);
+  static CURL GetBestBandwidthStream(const CURL &url, size_t bandwidth);
 
 protected:
 

--- a/xbmc/playlists/PlayListM3U.h
+++ b/xbmc/playlists/PlayListM3U.h
@@ -27,14 +27,19 @@ class CPlayListM3U :
       public CPlayList
 {
 public:
+  static const char *StartMarker;
+  static const char *InfoMarker;
+  static const char *ArtistMarker;
+  static const char *AlbumMarker;
+  static const char *StreamMarker;
+  static const char *BandwidthMarker;
+  static const char *OffsetMarker;
+
+public:
   CPlayListM3U(void);
   virtual ~CPlayListM3U(void);
   virtual bool Load(const std::string& strFileName);
   virtual void Save(const std::string& strFileName) const;
-
-  static CURL GetBestBandwidthStream(const CURL &url, size_t bandwidth);
-
-protected:
 
   static std::map<std::string,std::string> ParseStreamLine(const std::string &streamLine);
 };


### PR DESCRIPTION
This branch supercedes #9398, #9240 and #8680, providing another attempt to add the ability for plugins to provide per-stream proxy configuration, including support for proxies with HLS.

The flow of URL information from plugins to HTTP requests for HLS streams is as follows:

```
[Plugin]
  -> CListItem
      -> CFileItem
          -> CDVDInputStream/CDVDInputStreamFFmpeg
              -> CPlayListM3U::GetBestBandwidthStream
                  -> CFile::Open
                      -> IFile/CCurlFile
                          -> libcurl
                              [HTTP Request playlist M3U8 file]

          -> CDVDInputStream
              -> CDVDDemuxFFmpeg
                  -> libffmpeg
                      [HTTP Request media chunks]
```

To enable per-stream proxy configuration, the five config values (proxy protocol, host, port, user-name and password) must follow the same path-ways.
- The proxy configurations are carried by five new `CFileItem` properties: `proxy.type`, `proxy.host`, `proxy.port`, `proxy.user` and `proxy.password`.
- Accessor methods (`GetProxyType` etc.) have been added to `CDVDInputStream`, which expose these property values.
- `enum CCurlFile::ProxyType` has been moved to a common header so that it can be used in code beyond `CCurlFile`
- `CPlayListM3U::GetBestBandwidthStream` has been moved to `CDVDInputStreamFFmpeg`, so that it can gain access to the proxy information from `CDVDInputStream`.
- Use of the `CFile::Open` factory mechanism has been removed from this method. Instead `CCurlFile` is created directly, so that the proxy values can be applied to the object.
- `CDVDDemuxFFmpeg` has access to `CDVDInputStream`, and adds the `http_proxy` string to the options dictionary if one has been specified.
- Various other tidying patches are included.
