### PR TITLE
never cache addons directories

### DIFF
--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -463,6 +463,7 @@ bool CAddonsDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   const std::string endpoint = path.GetHostName();
   items.ClearItems();
   items.ClearProperties();
+  items.SetCacheToDisc(CFileItemList::CACHE_NEVER);
   items.SetPath(path.Get());
 
   if (endpoint.empty())


### PR DESCRIPTION
Can cause the directories to get 'stuck' in a bad state.
