### PR TITLE
stereoscopicmanager: Don't treat mono as stereoscopic

### DIFF
--- a/xbmc/guilib/StereoscopicsManager.cpp
+++ b/xbmc/guilib/StereoscopicsManager.cpp
@@ -513,7 +513,8 @@ std::string CStereoscopicsManager::GetVideoStereoMode()
 
 bool CStereoscopicsManager::IsVideoStereoscopic()
 {
-  return !GetVideoStereoMode().empty();
+  std::string mode = GetVideoStereoMode();
+  return !mode.empty() && mode != "mono";
 }
 
 void CStereoscopicsManager::OnPlaybackStarted(void)


### PR DESCRIPTION
Sometimes "mono" is set in stereoMode which causes the
3D "Select playback mode" dialog to pop up unwantedly.

Treat "mono" the same as an empty string as done elsewhere.
