### PR TITLE
[StringUtils] performance tweak for EqualsNoCase(std::string, std::string)

### DIFF
--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -403,6 +403,10 @@ void StringUtils::ToCapitalize(std::wstring &str)
 
 bool StringUtils::EqualsNoCase(const std::string &str1, const std::string &str2)
 {
+  // before we do the char-by-char comparison, first compare sizes of both strings.
+  // This led to a 33% improvement in benchmarking on average. (size() just returns a member of std::string)
+  if (str1.size() != str2.size())
+    return false;
   return EqualsNoCase(str1.c_str(), str2.c_str());
 }
 


### PR DESCRIPTION
This is based on a small discussion with @ronie who pointed me to some comments by @jmarshallnz where he explained that Stringcompare() should be avoided for skins because of performance reasons.  I was curious because of that and had a look at the implementation and came up with this tweak.
I am not sure how this behaves on all the  different platforms, but at least on windows std::string.size() just returns a member from std::string which makes me think that this check is worth it.
std::string.size() on windows:

```
    size_type size() const _NOEXCEPT
        {   // return length of sequence
        return (this->_Mysize);
        }
```

Some team members already assured me that this check probably is a good thing, opinion from @davilla for example is  still welcome for this since I am not really an expert when it comes to this low-level stuff. :) I also didnt do any benchmarking.
