### PR TITLE
python: use kodi provided cert if available

### DIFF
--- a/xbmc/interfaces/python/XBPython.cpp
+++ b/xbmc/interfaces/python/XBPython.cpp
@@ -595,9 +595,12 @@ bool XBPython::OnScriptInitialized(ILanguageInvoker *invoker)
     CEnvironment::putenv(buf);
     buf = "OS=win32";
     CEnvironment::putenv(buf);
+#endif
 
-#elif defined(TARGET_ANDROID)
-   setenv("SSL_CERT_FILE", CSpecialProtocol::TranslatePath("special://xbmc/system/certs/cacert.pem").c_str(), 1);
+#if !defined(TARGET_WINDOWS)
+    // use Kodi provided cert if available
+    if (XFILE::CFile::Exists("special://xbmc/system/certs/cacert.pem"))
+      setenv("SSL_CERT_FILE", CSpecialProtocol::TranslatePath("special://xbmc/system/certs/cacert.pem").c_str(), 1);
 #endif
 
     if (PyEval_ThreadsInitialized())


### PR DESCRIPTION
fix ssl on systems having no OpenSLL, i.e. Pi and OSX
