### PR TITLE
[Python-api] allow setting country via setInfo()

### DIFF
--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -350,6 +350,8 @@ namespace XBMCAddon
           }
           else if (key == "genre")
             item->GetVideoInfoTag()->m_genre = StringUtils::Split(value, g_advancedSettings.m_videoItemSeparator);
+          else if (key == "country")
+            item->GetVideoInfoTag()->m_country = StringUtils::Split(value, g_advancedSettings.m_videoItemSeparator);
           else if (key == "director")
             item->GetVideoInfoTag()->m_director = StringUtils::Split(value, g_advancedSettings.m_videoItemSeparator);
           else if (key == "mpaa")

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -190,6 +190,7 @@ namespace XBMCAddon
        *     - date          : string (%d.%m.%Y / 01.01.2009) - file date
        * - Video Values:
        *     - genre         : string (Comedy)
+       *     - country       : string (Germany)
        *     - year          : integer (2009)
        *     - episode       : integer (4)
        *     - season        : integer (1)


### PR DESCRIPTION
Python add-ons couldnt set the "country" infolabel up to now. This fixes it.
@tamland    
