### PR TITLE
remove pvr clients from addon repository table

### DIFF
--- a/xbmc/addons/AddonDatabase.cpp
+++ b/xbmc/addons/AddonDatabase.cpp
@@ -185,6 +185,14 @@ void CAddonDatabase::UpdateTables(int version)
   {
     m_pDS->exec("DROP TABLE system");
   }
+  if (version < 23)
+  {
+    m_pDS->exec("DELETE FROM addon");
+    m_pDS->exec("DELETE FROM addonextra");
+    m_pDS->exec("DELETE FROM dependencies");
+    m_pDS->exec("DELETE FROM addonlinkrepo");
+    m_pDS->exec("DELETE FROM repo");
+  }
 }
 
 void CAddonDatabase::SyncInstalled(const std::set<std::string>& ids)
@@ -296,14 +304,7 @@ bool CAddonDatabase::SetLastUsed(const std::string& addonId, const CDateTime& da
   return false;
 }
 
-int CAddonDatabase::GetAddonId(const ADDON::AddonPtr& item)
-{
-  std::string value = GetSingleValue("addon", "id", StringUtils::Format("name = '%s'", item->Name().c_str()), "id desc");
-  return value.empty() || !StringUtils::IsInteger(value) ? -1 : atoi(value.c_str());
-}
-
-int CAddonDatabase::AddAddon(const AddonPtr& addon,
-                             int idRepo)
+int CAddonDatabase::AddAddon(const AddonPtr& addon, int idRepo)
 {
   try
   {

--- a/xbmc/addons/AddonDatabase.cpp
+++ b/xbmc/addons/AddonDatabase.cpp
@@ -49,6 +49,16 @@ bool CAddonDatabase::Open()
   return CDatabase::Open();
 }
 
+int CAddonDatabase::GetMinSchemaVersion() const
+{
+  return 15;
+}
+
+int CAddonDatabase::GetSchemaVersion() const
+{
+  return 23;
+}
+
 void CAddonDatabase::CreateTables()
 {
   CLog::Log(LOGINFO, "create addon table");

--- a/xbmc/addons/AddonDatabase.h
+++ b/xbmc/addons/AddonDatabase.h
@@ -34,8 +34,6 @@ public:
   virtual ~CAddonDatabase();
   virtual bool Open();
 
-  int GetAddonId(const ADDON::AddonPtr& item);
-  int AddAddon(const ADDON::AddonPtr& item, int idRepo);
   bool GetAddon(const std::string& addonID, ADDON::AddonPtr& addon);
 
   /*! \brief Get an addon with a specific version and repository. */
@@ -151,10 +149,11 @@ protected:
   virtual void CreateAnalytics();
   virtual void UpdateTables(int version);
   virtual int GetMinSchemaVersion() const { return 15; }
-  virtual int GetSchemaVersion() const { return 22; }
+  virtual int GetSchemaVersion() const { return 23; }
   const char *GetBaseDBName() const { return "Addons"; }
 
   bool GetAddon(int id, ADDON::AddonPtr& addon);
+  int AddAddon(const ADDON::AddonPtr& item, int idRepo);
 
   /* keep in sync with the addon table */
   enum AddonFields

--- a/xbmc/addons/AddonDatabase.h
+++ b/xbmc/addons/AddonDatabase.h
@@ -148,8 +148,8 @@ protected:
   virtual void CreateTables();
   virtual void CreateAnalytics();
   virtual void UpdateTables(int version);
-  virtual int GetMinSchemaVersion() const { return 15; }
-  virtual int GetSchemaVersion() const { return 23; }
+  virtual int GetMinSchemaVersion() const;
+  virtual int GetSchemaVersion() const;
   const char *GetBaseDBName() const { return "Addons"; }
 
   bool GetAddon(int id, ADDON::AddonPtr& addon);

--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -139,42 +139,6 @@ void CPVRDatabase::UpdateTables(int iVersion)
 
   if (iVersion < 28)
   {
-    VECADDONS addons;
-    CAddonDatabase database;
-    if (database.Open() && CAddonMgr::GetInstance().GetAddons(addons, ADDON_PVRDLL))
-    {
-      /** find all old client IDs */
-      std::string strQuery(PrepareSQL("SELECT idClient, sUid FROM clients"));
-      m_pDS->query(strQuery);
-      while (!m_pDS->eof() && !addons.empty())
-      {
-        /** try to find an add-on that matches the sUid */
-        for (VECADDONS::iterator it = addons.begin(); it != addons.end(); ++it)
-        {
-          if ((*it)->ID() == m_pDS->fv(1).get_asString())
-          {
-            /** try to get the current ID from the database */
-            int iAddonId = database.GetAddonId(*it);
-            /** register a new id if it didn't exist */
-            if (iAddonId <= 0)
-              iAddonId = database.AddAddon(*it, 0);
-            if (iAddonId > 0)
-            {
-              // this fails when an id becomes the id of one that's being replaced next iteration
-              // but since almost everyone only has 1 add-on enabled...
-              /** update the iClientId in the channels table */
-              strQuery = PrepareSQL("UPDATE channels SET iClientId = %u WHERE iClientId = %u", iAddonId, m_pDS->fv(0).get_asInt());
-              m_pDS->exec(strQuery);
-
-              /** no need to check this add-on again */
-              it = addons.erase(it);
-              break;
-            }
-          }
-        }
-        m_pDS->next();
-      }
-    }
     m_pDS->exec("DROP TABLE clients");
   }
 


### PR DESCRIPTION
Continuing #9429. this gets rid of an old hack that pollutes the tables used for repository data with pvr clients.
