### PR TITLE
[cmake][addons] Internal absolute path for ADDON_SRC_PREFIX

### DIFF
--- a/project/cmake/addons/CMakeLists.txt
+++ b/project/cmake/addons/CMakeLists.txt
@@ -132,6 +132,7 @@ endif()
 get_filename_component(ADDONS_DEFINITION_DIR "${ADDONS_DEFINITION_DIR}" ABSOLUTE)
 
 if(ADDON_SRC_PREFIX)
+  get_filename_component(ADDON_SRC_PREFIX "${ADDON_SRC_PREFIX}" ABSOLUTE)
   message(STATUS "Overriding addon source directory prefix: ${ADDON_SRC_PREFIX}")
 endif()
 


### PR DESCRIPTION
@wsnipex @Montellese @fetzerch @notspiff @Tadly

I had an [issue](https://github.com/kodi-adsp/adsp.biquad.filters/pull/8) when I try to build my adsp.biquad.filters add-on with `ADDON_SRC_PREFIX`, which always failed because it couldn't find a dependency.
The issue occurred because I used a relative path for `ADDON_SRC_PREFIX`, which is completely wrong in some situations. 
That is the reason why I changed `ADDON_SRC_PREFIX` internal into an absolute path.

See my latest [PR](https://github.com/kodi-adsp/adsp.biquad.filters/pull/11) against adsp.biquad.filters
