### PR TITLE
[cmake][addons] Internal absolute path for ADDON_SRC_PREFIX

### DIFF
--- a/project/cmake/addons/CMakeLists.txt
+++ b/project/cmake/addons/CMakeLists.txt
@@ -132,6 +132,7 @@ endif()
 get_filename_component(ADDONS_DEFINITION_DIR "${ADDONS_DEFINITION_DIR}" ABSOLUTE)
 
 if(ADDON_SRC_PREFIX)
+  get_filename_component(ADDON_SRC_PREFIX "${ADDON_SRC_PREFIX}" ABSOLUTE)
   message(STATUS "Overriding addon source directory prefix: ${ADDON_SRC_PREFIX}")
 endif()
 


### PR DESCRIPTION
I also need this fix for Jarvis. For a detailed description see https://github.com/xbmc/xbmc/pull/9445.
