### PR TITLE
FIX: [droid] disable libcec

### DIFF
--- a/tools/depends/target/xbmc/Makefile
+++ b/tools/depends/target/xbmc/Makefile
@@ -13,7 +13,7 @@ CONFIGURE = cp -f $(CONFIG_SUB) $(CONFIG_GUESS) build-aux/ ;\
   ./configure --prefix=$(PREFIX) $(DEBUG)
 
 ifeq ($(OS),android)
-CONFIGURE += --enable-codec=amcodec --enable-breakpad
+CONFIGURE += --enable-codec=amcodec --enable-breakpad --disable-libcec
 endif
 
 ifeq ($(Configuration),Release)


### PR DESCRIPTION
Library was never shipped, and would never work anyway

/cc @MartijnKaijser @Razzeee @fritsch 
