### PR TITLE
[PVR] pvr guide & search windows: fix wrong context menu entries

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -8926,49 +8926,7 @@ msgctxt "#19085"
 msgid "Unknown channel %u"
 msgstr ""
 
-msgctxt "#19086"
-msgid "Mo-__-__-__-__-__-__"
-msgstr ""
-
-msgctxt "#19087"
-msgid "__-Tu-__-__-__-__-__"
-msgstr ""
-
-msgctxt "#19088"
-msgid "__-__-We-__-__-__-__"
-msgstr ""
-
-msgctxt "#19089"
-msgid "__-__-__-Th-__-__-__"
-msgstr ""
-
-msgctxt "#19090"
-msgid "__-__-__-__-Fr-__-__"
-msgstr ""
-
-msgctxt "#19091"
-msgid "__-__-__-__-__-Sa-__"
-msgstr ""
-
-msgctxt "#19092"
-msgid "__-__-__-__-__-__-Su"
-msgstr ""
-
-msgctxt "#19093"
-msgid "Mo-Tu-We-Th-Fr-__-__"
-msgstr ""
-
-msgctxt "#19094"
-msgid "Mo-Tu-We-Th-Fr-Sa-__"
-msgstr ""
-
-msgctxt "#19095"
-msgid "Mo-Tu-We-Th-Fr-Sa-Su"
-msgstr ""
-
-msgctxt "#19096"
-msgid "__-__-__-__-__-Sa-Su"
-msgstr ""
+#empty strings from id 19086 to 19096
 
 msgctxt "#19097"
 msgid "Enter the name for the recording"

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -85,7 +85,6 @@
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/channels/PVRRadioRDSInfoTag.h"
 #include "epg/EpgContainer.h"
-#include "pvr/timers/PVRTimers.h"
 #include "pvr/recordings/PVRRecording.h"
 
 #include "addons/AddonManager.h"
@@ -6206,14 +6205,7 @@ bool CGUIInfoManager::GetItemBool(const CGUIListItem *item, int condition) const
       }
       else if (pItem->HasEPGInfoTag())
       {
-        CEpgInfoTagPtr epgTag = pItem->GetEPGInfoTag();
-
-        // Check if the tag has a currently recording timer associated
-        if (epgTag->HasTimer())
-          return epgTag->Timer()->IsRecording();
-
-        // Search all timers for something that matches the tag
-        CPVRTimerInfoTagPtr timer = g_PVRTimers->GetTimerForEpgTag(epgTag);
+        const CPVRTimerInfoTagPtr timer = pItem->GetEPGInfoTag()->Timer();
         if (timer)
           return timer->IsRecording();
       }
@@ -6229,13 +6221,13 @@ bool CGUIInfoManager::GetItemBool(const CGUIListItem *item, int condition) const
     else if (condition == LISTITEM_HASTIMER)
     {
       if (pItem->HasEPGInfoTag())
-        return g_PVRTimers->GetTimerForEpgTag(pItem->GetEPGInfoTag()).get() != nullptr;
+        return pItem->GetEPGInfoTag()->HasTimer();
     }
     else if (condition == LISTITEM_HASTIMERSCHEDULE)
     {
       if (pItem->HasEPGInfoTag())
       {
-        CPVRTimerInfoTagPtr timer = g_PVRTimers->GetTimerForEpgTag(pItem->GetEPGInfoTag());
+        CPVRTimerInfoTagPtr timer = pItem->GetEPGInfoTag()->Timer();
         if (timer)
           return timer->GetTimerRuleId() != PVR_TIMER_NO_PARENT;
       }
@@ -6244,7 +6236,7 @@ bool CGUIInfoManager::GetItemBool(const CGUIListItem *item, int condition) const
     {
       if (pItem->HasEPGInfoTag())
       {
-        CPVRTimerInfoTagPtr timer = g_PVRTimers->GetTimerForEpgTag(pItem->GetEPGInfoTag());
+        CPVRTimerInfoTagPtr timer = pItem->GetEPGInfoTag()->Timer();
         if (timer)
           return timer->IsActive();
       }
@@ -6253,7 +6245,7 @@ bool CGUIInfoManager::GetItemBool(const CGUIListItem *item, int condition) const
     {
       if (pItem->HasEPGInfoTag())
       {
-        CPVRTimerInfoTagPtr timer = g_PVRTimers->GetTimerForEpgTag(pItem->GetEPGInfoTag());
+        CPVRTimerInfoTagPtr timer = pItem->GetEPGInfoTag()->Timer();
         if (timer)
           return timer->HasConflict();
       }
@@ -6262,7 +6254,7 @@ bool CGUIInfoManager::GetItemBool(const CGUIListItem *item, int condition) const
     {
       if (pItem->HasEPGInfoTag())
       {
-        CPVRTimerInfoTagPtr timer = g_PVRTimers->GetTimerForEpgTag(pItem->GetEPGInfoTag());
+        CPVRTimerInfoTagPtr timer = pItem->GetEPGInfoTag()->Timer();
         if (timer)
           return (timer->IsBroken() && !timer->HasConflict());
       }

--- a/xbmc/epg/Epg.cpp
+++ b/xbmc/epg/Epg.cpp
@@ -28,6 +28,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "pvr/addons/PVRClients.h"
 #include "pvr/PVRManager.h"
+#include "pvr/timers/PVRTimers.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "threads/SingleLock.h"
@@ -320,6 +321,7 @@ void CEpg::AddEntry(const CEpgInfoTag &tag)
     newTag->Update(tag);
     newTag->SetPVRChannel(m_pvrChannel);
     newTag->SetEpg(this);
+    newTag->SetTimer(g_PVRTimers->GetTimerForEpgTag(newTag));
   }
 }
 
@@ -433,6 +435,7 @@ bool CEpg::UpdateEntry(const CEpgInfoTagPtr &tag, EPG_EVENT_STATE newState, std:
   infoTag->Update(*tag, bNewTag);
   infoTag->SetEpg(this);
   infoTag->SetPVRChannel(m_pvrChannel);
+  infoTag->SetTimer(g_PVRTimers->GetTimerForEpgTag(infoTag));
 
   if (bUpdateDatabase)
     m_changedTags.insert(std::make_pair(infoTag->UniqueBroadcastID(), infoTag));

--- a/xbmc/epg/EpgInfoTag.cpp
+++ b/xbmc/epg/EpgInfoTag.cpp
@@ -713,9 +713,9 @@ const int CEpgInfoTag::EpgID(void) const
   return m_epg ? m_epg->EpgID() : -1;
 }
 
-void CEpgInfoTag::SetTimer(unsigned int iTimerId)
+void CEpgInfoTag::SetTimer(const CPVRTimerInfoTagPtr &timer)
 {
-  m_timer = g_PVRTimers->GetById(iTimerId);
+  m_timer = timer;
 }
 
 void CEpgInfoTag::ClearTimer(void)

--- a/xbmc/epg/EpgInfoTag.h
+++ b/xbmc/epg/EpgInfoTag.h
@@ -321,9 +321,9 @@ namespace EPG
 
     /*!
      * @brief Set a timer for this event.
-     * @param iTimerId The id of the new timer.
+     * @param timer The timer.
      */
-    void SetTimer(unsigned int iTimerId);
+    void SetTimer(const PVR::CPVRTimerInfoTagPtr &timer);
 
     /*!
      * @brief Clear the timer for this event.

--- a/xbmc/interfaces/json-rpc/PVROperations.cpp
+++ b/xbmc/interfaces/json-rpc/PVROperations.cpp
@@ -422,14 +422,15 @@ JSONRPC_STATUS CPVROperations::ToggleTimer(const std::string &method, ITransport
 
   bool repeating = parameterObject["repeating"].asBoolean(false);
   bool sentOkay = false;
-  if (epgTag->HasTimer())
+  CPVRTimerInfoTagPtr timer(epgTag->Timer());
+  if (timer)
   {
-    sentOkay = g_PVRTimers->DeleteTimer(g_PVRTimers->GetTimerForEpgTag(epgTag), false, repeating);
+    sentOkay = g_PVRTimers->DeleteTimer(timer, false, repeating);
   }
   else
   {
-    CPVRTimerInfoTagPtr newTimer = CPVRTimerInfoTag::CreateFromEpg(epgTag, repeating);
-    sentOkay = g_PVRTimers->AddTimer(newTimer);
+    timer = CPVRTimerInfoTag::CreateFromEpg(epgTag, repeating);
+    sentOkay = g_PVRTimers->AddTimer(timer);
   }
 
   if (sentOkay)

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
@@ -30,7 +30,6 @@
 
 #include "pvr/PVRManager.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
-#include "pvr/timers/PVRTimers.h"
 #include "pvr/timers/PVRTimerInfoTag.h"
 #include "pvr/windows/GUIWindowPVRBase.h"
 
@@ -114,7 +113,7 @@ bool CGUIDialogPVRGuideInfo::OnClickButtonRecord(CGUIMessage &message)
       return bReturn;
     }
 
-    CPVRTimerInfoTagPtr timerTag = g_PVRTimers->GetTimerForEpgTag(m_progItem);
+    CPVRTimerInfoTagPtr timerTag = m_progItem->Timer();
     if (timerTag)
       ActionCancelTimer(CFileItemPtr(new CFileItem(timerTag)));
     else

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -968,7 +968,7 @@ std::string CPVRTimerInfoTag::GetDeletedNotificationText() const
   case PVR_TIMER_STATE_SCHEDULED:
   default:
     if (IsRepeating())
-      stringID = 828; // Repeating timer deleted
+      stringID = 828; // Timer rule deleted
     else
       stringID = 19228; // Timer deleted
   }

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -171,6 +171,7 @@ CPVRTimerInfoTag::CPVRTimerInfoTag(const PVR_TIMER &timer, const CPVRChannelPtr 
   }
 
   UpdateSummary();
+  UpdateEpgInfoTag();
 }
 
 bool CPVRTimerInfoTag::operator ==(const CPVRTimerInfoTag& right) const
@@ -344,6 +345,13 @@ int CPVRTimerInfoTag::Compare(const CPVRTimerInfoTag &timer) const
   return iTimerDelta == 0 ?
     timer.m_iPriority - m_iPriority :
     iTimerDelta;
+}
+
+void CPVRTimerInfoTag::UpdateEpgInfoTag(void)
+{
+  CSingleLock lock(m_critSection);
+  m_epgTag.reset();
+  GetEpgInfoTag();
 }
 
 void CPVRTimerInfoTag::UpdateSummary(void)
@@ -633,6 +641,8 @@ bool CPVRTimerInfoTag::UpdateEntry(const CPVRTimerInfoTagPtr &tag)
   if (m_strSummary.empty())
     UpdateSummary();
 
+  UpdateEpgInfoTag();
+
   return true;
 }
 
@@ -789,6 +799,9 @@ CPVRTimerInfoTagPtr CPVRTimerInfoTag::CreateInstantTimerTag(const CPVRChannelPtr
   /* update summary string according to changed start/end time */
   newTimer->UpdateSummary();
 
+  /* set epg tag at timer & timer at epg tag */
+  newTimer->UpdateEpgInfoTag();
+
   /* unused only for reference */
   newTimer->m_strFileNameAndPath = CPVRTimersPath::PATH_NEW;
 
@@ -853,6 +866,7 @@ CPVRTimerInfoTagPtr CPVRTimerInfoTag::CreateFromEpg(const CEpgInfoTagPtr &tag, b
 
   newTag->SetTimerType(timerType);
   newTag->UpdateSummary();
+  newTag->UpdateEpgInfoTag();
 
   /* unused only for reference */
   newTag->m_strFileNameAndPath = CPVRTimersPath::PATH_NEW;
@@ -964,16 +978,14 @@ std::string CPVRTimerInfoTag::GetDeletedNotificationText() const
 
 CEpgInfoTagPtr CPVRTimerInfoTag::GetEpgInfoTag(void) const
 {
-  return GetEpgInfoTag(true);
-}
-
-CEpgInfoTagPtr CPVRTimerInfoTag::GetEpgInfoTag(bool bSetTimer) const
-{
-  CSingleLock lock(m_critSection);
+  CPVRChannelPtr channel;
   if (!m_epgTag)
+    channel = g_PVRChannelGroups->GetByUniqueID(m_iClientChannelUid, m_iClientId);
+
+  if (channel)
   {
-    const CPVRChannelPtr channel(g_PVRChannelGroups->GetByUniqueID(m_iClientChannelUid, m_iClientId));
-    if (channel)
+    CSingleLock lock(m_critSection);
+    if (!m_epgTag)
     {
       const CEpgPtr epg(channel->GetEPG());
       if (epg)
@@ -988,8 +1000,8 @@ CEpgInfoTagPtr CPVRTimerInfoTag::GetEpgInfoTag(bool bSetTimer) const
           m_epgTag = epg->GetTagBetween(StartAsUTC() - CDateTimeSpan(0, 0, 2, 0), EndAsUTC() + CDateTimeSpan(0, 0, 2, 0));
         }
 
-        if (m_epgTag && bSetTimer)
-          m_epgTag->SetTimer(m_iTimerId);
+        if (m_epgTag)
+          m_epgTag->SetTimer(g_PVRTimers->GetById(m_iTimerId));
       }
     }
   }
@@ -1000,15 +1012,12 @@ CEpgInfoTagPtr CPVRTimerInfoTag::GetEpgInfoTag(bool bSetTimer) const
 bool CPVRTimerInfoTag::HasEpgInfoTag(void) const
 {
   CSingleLock lock(m_critSection);
-  GetEpgInfoTag();
-  return m_epgTag.get() != NULL;
+  return m_epgTag != nullptr;
 }
 
 bool CPVRTimerInfoTag::HasSeriesEpgInfoTag(void) const
 {
   CSingleLock lock(m_critSection);
-  GetEpgInfoTag();
-
   if (m_epgTag &&
       (m_epgTag->IsSeries() ||
        m_epgTag->SeriesNumber() > 0 ||
@@ -1022,15 +1031,9 @@ bool CPVRTimerInfoTag::HasSeriesEpgInfoTag(void) const
 void CPVRTimerInfoTag::ClearEpgTag(void)
 {
   CEpgInfoTagPtr deletedTag;
-
   {
-    // important: do not just check for m_epgtag here, but do actually obtain it.
-    // epg tag may have 'this' set as timer. we need to clear the timer explicitely.
-    // otherwise epg tags with dangling timers will float around until kodi restart.
-
     CSingleLock lock(m_critSection);
-    deletedTag = GetEpgInfoTag(false); // get the tag, but do not set 'this' as timer at the tag, otherwise stack overflow ;-)
-
+    deletedTag = m_epgTag;
     m_epgTag.reset();
   }
 

--- a/xbmc/pvr/timers/PVRTimerInfoTag.h
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.h
@@ -298,7 +298,7 @@ namespace PVR
 
   private:
     std::string GetWeekdaysString() const;
-    EPG::CEpgInfoTagPtr GetEpgInfoTag(bool bSetTimer) const;
+    void UpdateEpgInfoTag(void);
 
     CCriticalSection      m_critSection;
     unsigned int          m_iEpgUid;   /*!< id of epg event associated with this timer, EPG_TAG_INVALID_UID if none. */

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -674,9 +674,9 @@ CPVRTimerInfoTagPtr CPVRTimers::GetTimerForEpgTag(const CEpgInfoTagPtr &epgTag) 
           if (!timer->IsRepeating() &&
               (timer->GetEpgInfoTag() == epgTag ||
                (timer->m_iClientChannelUid == channel->UniqueID() &&
-               timer->m_bIsRadio == channel->IsRadio() &&
-               timer->StartAsUTC() <= epgTag->StartAsUTC() &&
-               timer->EndAsUTC() >= epgTag->EndAsUTC())))
+                timer->m_bIsRadio == channel->IsRadio() &&
+                timer->StartAsUTC() <= epgTag->StartAsUTC() &&
+                timer->EndAsUTC() >= epgTag->EndAsUTC())))
           {
             return timer;
           }

--- a/xbmc/pvr/timers/PVRTimers.h
+++ b/xbmc/pvr/timers/PVRTimers.h
@@ -159,7 +159,7 @@ namespace PVR
      */
     static bool RenameTimer(CFileItem &item, const std::string &strNewName);
 
-    /**
+    /*!
      * @brief Update the timer on the client. Doesn't update the timer in the container. The backend will do this.
      * @return True if it was sent correctly, false if not.
      */

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -552,7 +552,7 @@ bool CGUIWindowPVRBase::AddTimer(CFileItem *item, bool bCreateRule, bool bShowTi
     return false;
   }
 
-  CPVRTimerInfoTagPtr timer(bCreateRule || !epgTag ? nullptr : g_PVRTimers->GetTimerForEpgTag(epgTag));
+  CPVRTimerInfoTagPtr timer(bCreateRule || !epgTag ? nullptr : epgTag->Timer());
   CPVRTimerInfoTagPtr rule (bCreateRule ? g_PVRTimers->GetTimerRule(timer) : nullptr);
   if (timer || rule)
   {
@@ -587,8 +587,6 @@ bool CGUIWindowPVRBase::EditTimer(CFileItem *item)
   else if (item->IsEPG())
   {
     timer = item->GetEPGInfoTag()->Timer();
-    if (!timer)
-      timer = g_PVRTimers->GetTimerForEpgTag(item->GetEPGInfoTag());
   }
 
   if (!timer)
@@ -638,8 +636,6 @@ bool CGUIWindowPVRBase::DeleteTimer(CFileItem *item, bool bIsRecording, bool bDe
   else if (item->IsEPG())
   {
     timer = item->GetEPGInfoTag()->Timer();
-    if (!timer)
-      timer = g_PVRTimers->GetTimerForEpgTag(item->GetEPGInfoTag());
   }
 
   if (!timer)


### PR DESCRIPTION
Under certain circumstances, context menu for items in pvr guide and search window contain for example "Record" although there's already a timer set for these items. This is because CEpgInfoTag::Timer() does not always return a timer if it should. This PR fixes this.

The other two commits are just some cleanup (removal of unused string resources, a corrected comment).

@xhaggi @Jalle19 mind taking a look.
