### PR TITLE
[EPG] Guide window: fetch timeline items asyncronously.

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -949,7 +949,8 @@ void CGUIWindowPVRBase::UpdateButtons(void)
 
 void CGUIWindowPVRBase::UpdateSelectedItemPath()
 {
-  if (!m_viewControl.GetSelectedItemPath().empty()) {
+  if (!m_viewControl.GetSelectedItemPath().empty())
+  {
     CSingleLock lock(m_selectedItemPathsLock);
     m_selectedItemPaths[m_bRadio] = m_viewControl.GetSelectedItemPath();
   }

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.h
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.h
@@ -19,12 +19,16 @@
  *
  */
 
+#include <memory>
+#include "threads/Thread.h"
 #include "GUIWindowPVRBase.h"
 
 class CSetting;
 
 namespace PVR
 {
+  class CPVRRefreshTimelineItemsThread;
+
   class CGUIWindowPVRGuide : public CGUIWindowPVRBase
   {
   public:
@@ -32,12 +36,16 @@ namespace PVR
     virtual ~CGUIWindowPVRGuide(void);
 
     virtual void OnInitWindow() override;
+    virtual void OnDeinitWindow(int nextWindowID) override;
     virtual bool OnMessage(CGUIMessage& message) override;
     virtual bool OnAction(const CAction &action) override;
     virtual void GetContextButtons(int itemNumber, CContextButtons &buttons) override;
     virtual bool OnContextButton(int itemNumber, CONTEXT_BUTTON button) override;
     virtual bool Update(const std::string &strDirectory, bool updateFilterPath = true) override;
     virtual void UpdateButtons(void) override;
+    virtual void Notify(const Observable &obs, const ObservableMessage msg) override;
+
+    bool RefreshTimelineItems();
 
   protected:
     virtual void UpdateSelectedItemPath() override;
@@ -63,11 +71,25 @@ namespace PVR
     void GetViewNextItems(CFileItemList &items);
     void GetViewTimelineItems(CFileItemList &items);
 
+    void StartRefreshTimelineItemsThread();
+    void StopRefreshTimelineItemsThread();
+
+    std::unique_ptr<CPVRRefreshTimelineItemsThread> m_refreshTimelineItemsThread;
+    bool m_bRefreshTimelineItems;
+
     CFileItemList      *m_cachedTimeline;
     CPVRChannelGroupPtr m_cachedChannelGroup;
+  };
 
-    bool m_bUpdateRequired;
+  class CPVRRefreshTimelineItemsThread : public CThread
+  {
+  public:
+    CPVRRefreshTimelineItemsThread(CGUIWindowPVRGuide *pGuideWindow);
+    virtual ~CPVRRefreshTimelineItemsThread() {}
 
-    XbmcThreads::EndTime m_nextUpdateTimeout;
+    virtual void Process();
+
+  private:
+    CGUIWindowPVRGuide *m_pGuideWindow;
   };
 }


### PR DESCRIPTION
On every open/refresh of the pvr guide window all epg items for the active channel group are obtained synchronously in the render thread. On my test environment, obtaining 40K epg events takes up to 250 ms. This (among other problems I will try to tackle with a followup PR) causes noticeable delays when opening the guide window and on updating the active guide window. This can easily take several seconds for larger amounts of epg events. Imagine 800 channels, 30 days epg data => easily 400K events.

My approach to solve this is to fetch the epg events asynchronously, in a dedicated thread. The thread is only created if the guide window becomes activated, to safe some resources. If an epg event data update is signaled, a certain flag is set.  The thread polls every 5 seconds, whether the flag was set. If so, the thread fetches the new epg events and stores them for later use. On open/refresh of the guide window, the prefetched data will be taken instead of fetching them. Quite simple and effective, I'd say. 

On my test system with ~40K epg events the change done in this PR reduces the time to open the guide window from ~400 ms to ~160 ms.

@xhaggi @Jalle19 what do you think?
