### PR TITLE
[depends] Bump libdcadec to version 0.2.0

### DIFF
--- a/tools/depends/target/libdcadec/Makefile
+++ b/tools/depends/target/libdcadec/Makefile
@@ -3,7 +3,7 @@ DEPS= Makefile
 
 # lib name, version
 LIBNAME=libdcadec
-VERSION=git-2a9186e3
+VERSION=0.2.0
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
 

--- a/tools/depends/target/libdcadec/Makefile
+++ b/tools/depends/target/libdcadec/Makefile
@@ -1,5 +1,5 @@
 -include ../../Makefile.include
-DEPS= Makefile
+DEPS= Makefile arm-saturation.patch libdcadec_android.patch
 
 # lib name, version
 LIBNAME=libdcadec
@@ -43,6 +43,7 @@ endif
 
 	rm -rf $(PLATFORM)/*; mkdir -p $(PLATFORM)
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
+	cd $(PLATFORM); patch -p0 < ../arm-saturation.patch
 ifeq ($(OS),android)
 	cd $(PLATFORM); patch -p1 < ../libdcadec_android.patch
 endif

--- a/tools/depends/target/libdcadec/arm-saturation.patch
+++ b/tools/depends/target/libdcadec/arm-saturation.patch
@@ -1,0 +1,19 @@
+--- libdcadec/fixed_math.h
++++ libdcadec/fixed_math.h
+@@ -42,16 +42,10 @@
+ 
+ static inline int32_t clip__(int32_t a, int bits)
+ {
+-#ifdef __ARM_FEATURE_SAT
+-    int x;
+-    __asm__("ssat %0, %2, %1" : "=r"(x) : "r"(a), "i"(bits + 1));
+-    return x;
+-#else
+     if ((a + (1 << bits)) & ~((1 << (bits + 1)) - 1))
+         return (a >> 31) ^ ((1 << bits) - 1);
+     else
+         return a;
+-#endif
+ }
+ 
+ static inline int64_t round20(int64_t a) { return round__(a, 20); }

--- a/tools/depends/target/libdcadec/libdcadec_android.patch
+++ b/tools/depends/target/libdcadec/libdcadec_android.patch
@@ -2,7 +2,7 @@ diff --git a/libdcadec/dca_stream.c b/libdcadec/dca_stream.c
 index 156f874..acbd139 100644
 --- a/libdcadec/dca_stream.c
 +++ b/libdcadec/dca_stream.c
-@@ -37,7 +37,7 @@
+@@ -38,7 +38,7 @@
  #if (defined _WIN32)
  #define DCA_FGETC   _fgetc_nolock
  #elif (defined _BSD_SOURCE)


### PR DESCRIPTION
FFmpeg 3.0 requires libdcadec >= 0.1.0
