### PR TITLE
[database] fix old queries not cleared after multiple execute

### DIFF
--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -186,6 +186,7 @@ bool CDatabase::DeleteValues(const std::string &strTable, const Filter &filter /
 bool CDatabase::BeginMultipleExecute()
 {
   m_multipleExecute = true;
+  m_multipleQueries.clear();
   return true;
 }
 
@@ -201,7 +202,7 @@ bool CDatabase::CommitMultipleExecute()
       return false;
     }
   }
-
+  m_multipleQueries.clear();
   return CommitTransaction();
 }
 


### PR DESCRIPTION
Currently it re-executes old queries when using Begin/CommitMultipleExecute more than once on the same db object.
