### PR TITLE
PVR - connection handling

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -15661,7 +15661,13 @@ msgctxt "#35508"
 msgid "Access denied."
 msgstr ""
 
-#empty strings from id 35509 to 35999
+#. connection state "connecting" (asynchronous addon start)
+#: xbmc/addons/AddonCallbacksPVR.cpp
+msgctxt "#35509"
+msgid "Connecting to backend."
+msgstr ""
+
+#empty strings from id 35510 to 35999
 
 #: xbmc/peripherals/devices/PeripheralCecAdapter.cpp
 msgctxt "#36000"

--- a/addons/xbmc.pvr/addon.xml
+++ b/addons/xbmc.pvr/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="xbmc.pvr" version="5.1.0" provider-name="Team-Kodi">
-  <backwards-compatibility abi="5.1.0"/>
+<addon id="xbmc.pvr" version="5.1.1" provider-name="Team-Kodi">
+  <backwards-compatibility abi="5.1.1"/>
   <requires>
     <import addon="xbmc.core" version="0.1.0"/>
   </requires>

--- a/xbmc/addons/PVRClient.cpp
+++ b/xbmc/addons/PVRClient.cpp
@@ -218,18 +218,16 @@ bool CPVRClient::ReadyToUse(void) const
   return m_bReadyToUse;
 }
 
+PVR_CONNECTION_STATE CPVRClient::GetConnectionState(void) const
+{
+  CSingleLock lock(m_critSection);
+  return m_connectionState;
+}
+
 void CPVRClient::SetConnectionState(PVR_CONNECTION_STATE state)
 {
-  if (m_connectionState != state)
-  {
-    m_connectionState = state;
-
-    if (state == PVR_CONNECTION_STATE_CONNECTED)
-    {
-      CLog::Log(LOGDEBUG, "PVRClient - %s - refetching addon properties", __FUNCTION__);
-      GetAddonProperties();
-    }
-  }
+  CSingleLock lock(m_critSection);
+  m_connectionState = state;
 }
 
 int CPVRClient::GetID(void) const

--- a/xbmc/addons/PVRClient.h
+++ b/xbmc/addons/PVRClient.h
@@ -109,7 +109,7 @@ namespace PVR
      * @brief Gets the backend connection state.
      * @return the backend connection state.
      */
-    PVR_CONNECTION_STATE GetConnectionState(void) const { return m_connectionState; }
+    PVR_CONNECTION_STATE GetConnectionState(void) const;
 
     /*!
      * @brief Sets the backend connection state.
@@ -617,6 +617,11 @@ namespace PVR
      */
     bool IsRealTimeStream() const;
 
+    /*!
+     * @brief reads the client's properties
+     */
+    bool GetAddonProperties(void);
+
   private:
     /*!
      * @brief Checks whether the provided API version is compatible with XBMC
@@ -644,8 +649,6 @@ namespace PVR
      * @brief Resets all class members to their defaults. Called by the constructors.
      */
     void ResetProperties(int iClientId = PVR_INVALID_CLIENT_ID);
-
-    bool GetAddonProperties(void);
 
     /*!
      * @brief Copy over group info from xbmcGroup to addonGroup.

--- a/xbmc/addons/binary/interfaces/api1/PVR/AddonCallbacksPVR.cpp
+++ b/xbmc/addons/binary/interfaces/api1/PVR/AddonCallbacksPVR.cpp
@@ -341,53 +341,7 @@ void CAddonCallbacksPVR::PVRConnectionStateChange(void* addonData, const char* s
 
   client->SetConnectionState(newState);
 
-  int iMsg(-1);
-  bool bError(true);
-  bool bNotify(true);
-
-  switch (newState)
-  {
-    case PVR_CONNECTION_STATE_SERVER_UNREACHABLE:
-      iMsg = 35505; // Server is unreachable
-      break;
-    case PVR_CONNECTION_STATE_SERVER_MISMATCH:
-      iMsg = 35506; // Server does not respond properly
-      break;
-    case PVR_CONNECTION_STATE_VERSION_MISMATCH:
-      iMsg = 35507; // Server version is not compatible
-      break;
-    case PVR_CONNECTION_STATE_ACCESS_DENIED:
-      iMsg = 35508; // Access denied
-      break;
-    case PVR_CONNECTION_STATE_CONNECTED:
-      iMsg = 36034; // Connection established
-      bError = false;
-      // No notification for the first successful connect.
-      bNotify = (prevState != PVR_CONNECTION_STATE_UNKNOWN);
-      break;
-    case PVR_CONNECTION_STATE_DISCONNECTED:
-      iMsg = 36030; // Connection lost
-      break;
-    default:
-      CLog::Log(LOGERROR, "PVR - %s - unknown connection state", __FUNCTION__);
-      return;
-  }
-
-  // Use addon-supplied message, if present
-  std::string strMsg;
-  if (strMessage && strlen(strMessage) > 0)
-    strMsg = strMessage;
-  else
-    strMsg = g_localizeStrings.Get(iMsg);
-
-  // Notify user.
-  if (bNotify && !CSettings::GetInstance().GetBool(CSettings::SETTING_PVRMANAGER_HIDECONNECTIONLOSTWARNING))
-    CGUIDialogKaiToast::QueueNotification(
-      bError ? CGUIDialogKaiToast::Error : CGUIDialogKaiToast::Info, client->Name().c_str(), strMsg, 5000, true);
-
-  // Write event log entry.
-  CEventLog::GetInstance().Add(EventPtr(new CNotificationEvent(
-    client->Name(), strMsg, client->Icon(), bError ? EventLevel::Error : EventLevel::Information)));
+  g_PVRManager.ConnectionStateChange(client->GetID(), std::string(strConnectionString), newState, std::string(strMessage));
 }
 
 typedef struct EpgEventStateChange

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
@@ -77,10 +77,10 @@ struct DemuxPacket;
 #define PVR_STREAM_MAX_STREAMS 20
 
 /* current PVR API version */
-#define XBMC_PVR_API_VERSION "5.1.0"
+#define XBMC_PVR_API_VERSION "5.1.1"
 
 /* min. PVR API version */
-#define XBMC_PVR_MIN_API_VERSION "5.1.0"
+#define XBMC_PVR_MIN_API_VERSION "5.1.1"
 
 #ifdef __cplusplus
 extern "C" {

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
@@ -228,6 +228,7 @@ extern "C" {
     PVR_CONNECTION_STATE_ACCESS_DENIED      = 4,  /*!< @brief backend server is reachable, but denies client access (e.g. due to wrong credentials) */
     PVR_CONNECTION_STATE_CONNECTED          = 5,  /*!< @brief connection to backend server is established */
     PVR_CONNECTION_STATE_DISCONNECTED       = 6,  /*!< @brief no connection to backend server (e.g. due to network errors or client initiated disconnect)*/
+    PVR_CONNECTION_STATE_CONNECTING         = 7,  /*!< @brief connecting to backend */
   } PVR_CONNECTION_STATE;
 
   /*!

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -1690,6 +1690,11 @@ void CPVRManager::TriggerSearchMissingChannelIcons(void)
   CJobManager::GetInstance().AddJob(new CPVRSearchMissingChannelIconsJob(), NULL);
 }
 
+void CPVRManager::ConnectionStateChange(int clientId, std::string connectString, PVR_CONNECTION_STATE state, std::string message)
+{
+  CJobManager::GetInstance().AddJob(new CPVRClientConnectionJob(clientId, connectString, state, message), NULL);
+}
+
 void CPVRManager::ExecutePendingJobs(void)
 {
   CSingleLock lock(m_critSectionTriggers);
@@ -1734,6 +1739,12 @@ bool CPVRChannelSwitchJob::DoWork(void)
 bool CPVRSearchMissingChannelIconsJob::DoWork(void)
 {
   g_PVRManager.SearchMissingChannelIcons();
+  return true;
+}
+
+bool CPVRClientConnectionJob::DoWork(void)
+{
+  g_PVRClients->ConnectionStateChange(m_clientId, m_connectString, m_state, m_message);
   return true;
 }
 

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -583,6 +583,11 @@ private:
     */
     std::string GetPlayingTVGroupName();
 
+    /*!
+     * @brief Signal a connection change of a client
+     */
+    void ConnectionStateChange(int clientId, std::string connectString, PVR_CONNECTION_STATE state, std::string message);
+
   protected:
     /*!
      * @brief Start the PVRManager, which loads all PVR data and starts some threads to update the PVR data.
@@ -763,5 +768,21 @@ private:
     virtual const char *GetType() const { return "pvr-search-missing-channel-icons"; }
 
     bool DoWork();
+  };
+
+  class CPVRClientConnectionJob : public CJob
+  {
+  public:
+    CPVRClientConnectionJob(int clientId, std::string connectString, PVR_CONNECTION_STATE state, std::string message) :
+    m_clientId(clientId), m_connectString(connectString), m_state(state), m_message(message) {}
+    virtual ~CPVRClientConnectionJob() {}
+    virtual const char *GetType() const { return "pvr-client-connection"; }
+
+    virtual bool DoWork();
+  private:
+    int m_clientId;
+    std::string m_connectString;
+    PVR_CONNECTION_STATE m_state;
+    std::string m_message;
   };
 }

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -29,6 +29,9 @@
 #include "dialogs/GUIDialogExtendedProgressBar.h"
 #include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogSelect.h"
+#include "dialogs/GUIDialogKaiToast.h"
+#include "events/EventLog.h"
+#include "events/NotificationEvent.h"
 #include "guilib/GUIWindowManager.h"
 #include "GUIUserMessages.h"
 #include "messaging/ApplicationMessenger.h"
@@ -235,7 +238,11 @@ bool CPVRClients::HasCreatedClients(void) const
 
   for (PVR_CLIENTMAP_CITR itr = m_clientMap.begin(); itr != m_clientMap.end(); itr++)
     if (itr->second->ReadyToUse())
-      return true;
+    {
+      PVR_CONNECTION_STATE state = itr->second->GetConnectionState();
+      if (state != PVR_CONNECTION_STATE_CONNECTING)
+        return true;
+    }
 
   return false;
 }
@@ -330,6 +337,10 @@ int CPVRClients::GetCreatedClients(PVR_CLIENTMAP &clients) const
   {
     if (itr->second->ReadyToUse())
     {
+      PVR_CONNECTION_STATE state = itr->second->GetConnectionState();
+      if (state == PVR_CONNECTION_STATE_CONNECTING)
+        continue;
+      
       clients.insert(std::make_pair(itr->second->GetID(), itr->second));
       ++iReturn;
     }
@@ -1520,3 +1531,80 @@ bool CPVRClients::IsRealTimeStream(void) const
   return false;
 }
 
+void CPVRClients::ConnectionStateChange(int clientId, std::string &strConnectionString, PVR_CONNECTION_STATE newState,
+                                        std::string &strMessage)
+{
+  PVR_CLIENT client;
+  if (!GetClient(clientId, client))
+  {
+    CLog::Log(LOGDEBUG, "PVR - %s - invalid client id", __FUNCTION__);
+    return;
+  }
+
+  if (strConnectionString.empty())
+  {
+    CLog::Log(LOGERROR, "PVR - %s - invalid handler data", __FUNCTION__);
+    return;
+  }
+
+  int iMsg(-1);
+  bool bError(true);
+  bool bNotify(true);
+
+  switch (newState)
+  {
+    case PVR_CONNECTION_STATE_SERVER_UNREACHABLE:
+      iMsg = 35505; // Server is unreachable
+      break;
+    case PVR_CONNECTION_STATE_SERVER_MISMATCH:
+      iMsg = 35506; // Server does not respond properly
+      break;
+    case PVR_CONNECTION_STATE_VERSION_MISMATCH:
+      iMsg = 35507; // Server version is not compatible
+      break;
+    case PVR_CONNECTION_STATE_ACCESS_DENIED:
+      iMsg = 35508; // Access denied
+      break;
+    case PVR_CONNECTION_STATE_CONNECTED:
+      bError = false;
+      iMsg = 36034; // Connection established
+      break;
+    case PVR_CONNECTION_STATE_DISCONNECTED:
+      iMsg = 36030; // Connection lost
+      break;
+    case PVR_CONNECTION_STATE_CONNECTING:
+      bError = false;
+      iMsg = 35509; // Connecting
+      bNotify = false;
+      break;
+    default:
+      CLog::Log(LOGERROR, "PVR - %s - unknown connection state", __FUNCTION__);
+      return;
+  }
+
+  // Use addon-supplied message, if present
+  std::string strMsg;
+  if (!strMessage.empty())
+    strMsg = strMessage;
+  else
+    strMsg = g_localizeStrings.Get(iMsg);
+
+  // Notify user.
+  if (bNotify && !CSettings::GetInstance().GetBool(CSettings::SETTING_PVRMANAGER_HIDECONNECTIONLOSTWARNING))
+    CGUIDialogKaiToast::QueueNotification(bError ? CGUIDialogKaiToast::Error : CGUIDialogKaiToast::Info, client->Name().c_str(),
+                                          strMsg, 5000, true);
+
+  // Write event log entry.
+  CEventLog::GetInstance().Add(EventPtr(new CNotificationEvent(client->Name(), strMsg, client->Icon(),
+                                                               bError ? EventLevel::Error : EventLevel::Information)));
+
+  if (newState == PVR_CONNECTION_STATE_CONNECTED)
+  {
+    // update properties on connect
+    if (!client->GetAddonProperties())
+    {
+      CLog::Log(LOGERROR, "PVR - %s - error reading properties", __FUNCTION__);
+    }
+    g_PVRManager.Start();
+  }
+}

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -676,6 +676,9 @@ namespace PVR
 
     bool IsRealTimeStream() const;
 
+    void ConnectionStateChange(int clientId, std::string &strConnectionString, PVR_CONNECTION_STATE newState,
+                               std::string &strMessage);
+
   private:
     /*!
      * @brief Update add-ons from the AddonManager


### PR DESCRIPTION
- fix of connection handling: a callback must not call into the addon again
- add new connection state PVR_CONNECTION_STATE_CONNECTING addon in this state are ignored during startup process. This improves asynchronous startup sequence.

@ksooo please have a look
