### PR TITLE
Music artist scraping more selectively

### DIFF
--- a/xbmc/filesystem/MusicDatabaseDirectory.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory.cpp
@@ -112,13 +112,6 @@ bool CMusicDatabaseDirectory::IsArtistDir(const std::string& strDirectory)
   return (node==NODE_TYPE_ARTIST);
 }
 
-bool CMusicDatabaseDirectory::HasAlbumInfo(const std::string& strDirectory)
-{
-  NODE_TYPE node=GetDirectoryType(strDirectory);
-  return (node!=NODE_TYPE_OVERVIEW && node!=NODE_TYPE_TOP100 &&
-          node!=NODE_TYPE_GENRE && node!=NODE_TYPE_ARTIST && node!=NODE_TYPE_YEAR);
-}
-
 void CMusicDatabaseDirectory::ClearDirectoryCache(const std::string& strDirectory)
 {
   std::string path = CLegacyPathTranslation::TranslateMusicDbPath(strDirectory);

--- a/xbmc/filesystem/MusicDatabaseDirectory.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory.h
@@ -37,7 +37,6 @@ namespace XFILE
     static MUSICDATABASEDIRECTORY::NODE_TYPE GetDirectoryType(const std::string& strPath);
     static MUSICDATABASEDIRECTORY::NODE_TYPE GetDirectoryParentType(const std::string& strPath);
     bool IsArtistDir(const std::string& strDirectory);
-    bool HasAlbumInfo(const std::string& strDirectory);
     void ClearDirectoryCache(const std::string& strDirectory);
     static bool IsAllItem(const std::string& strDirectory);
     static bool GetLabel(const std::string& strDirectory, std::string& strLabel);

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -35,6 +35,7 @@
 #include "filesystem/File.h"
 #include "filesystem/MusicDatabaseDirectory.h"
 #include "filesystem/MusicDatabaseDirectory/DirectoryNode.h"
+#include "filesystem/SmartPlaylistDirectory.h" 
 #include "GUIInfoManager.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "guilib/GUIWindowManager.h"
@@ -73,6 +74,7 @@ CMusicInfoScanner::CMusicInfoScanner() : CThread("MusicInfoScanner"), m_fileCoun
   m_currentItem=0;
   m_itemCount=0;
   m_flags = 0;
+  m_bClean = false;
 }
 
 CMusicInfoScanner::~CMusicInfoScanner()
@@ -316,8 +318,14 @@ void CMusicInfoScanner::FetchAlbumInfo(const std::string& strDirectory,
   }
   else
   {
-    if (URIUtils::HasSlashAtEnd(strDirectory)) // directory
+    if (URIUtils::IsMusicDb(strDirectory))
       CDirectory::GetDirectory(strDirectory,items);
+    else if (StringUtils::EndsWith(strDirectory, ".xsp"))
+    {
+      CURL url(strDirectory);
+      CSmartPlaylistDirectory dir;
+      dir.GetDirectory(url, items);
+    }
     else
     {
       CFileItemPtr item(new CFileItem(strDirectory,false));
@@ -355,13 +363,19 @@ void CMusicInfoScanner::FetchArtistInfo(const std::string& strDirectory,
   if (strDirectory.empty())
   {
     m_musicDatabase.Open();
-    m_musicDatabase.GetArtistsNav("musicdb://artists/", items, false, -1);
+    m_musicDatabase.GetArtistsNav("musicdb://artists/", items, !CSettings::GetInstance().GetBool(CSettings::SETTING_MUSICLIBRARY_SHOWCOMPILATIONARTISTS), -1);
     m_musicDatabase.Close();
   }
   else
   {
-    if (URIUtils::HasSlashAtEnd(strDirectory)) // directory
+    if (URIUtils::IsMusicDb(strDirectory))
       CDirectory::GetDirectory(strDirectory,items);
+    else if (StringUtils::EndsWith(strDirectory, ".xsp"))
+    {
+      CURL url(strDirectory);
+      CSmartPlaylistDirectory dir;
+      dir.GetDirectory(url, items);
+    }
     else
     {
       CFileItemPtr newItem(new CFileItem(strDirectory,false));
@@ -795,6 +809,8 @@ int CMusicInfoScanner::RetrieveMusicInfo(const std::string& strDirectory, CFileI
       if (!albumScraper || !artistScraper)
         continue;
 
+      bool albumartistsonly = !CSettings::GetInstance().GetBool(CSettings::SETTING_MUSICLIBRARY_SHOWCOMPILATIONARTISTS);
+
       INFO_RET albumScrapeStatus = INFO_NOT_FOUND;
       if (!m_musicDatabase.HasAlbumBeenScraped(album->idAlbum))
         albumScrapeStatus = UpdateDatabaseAlbumInfo(*album, albumScraper, false);
@@ -815,27 +831,29 @@ int CMusicInfoScanner::RetrieveMusicInfo(const std::string& strDirectory, CFileI
             UpdateDatabaseArtistInfo(artist, artistScraper, false);
           }
         }
-
-        for (VECSONGS::iterator song  = album->songs.begin();
-                                song != album->songs.end();
-                                ++song)
+        if (!albumartistsonly)
         {
-          if (m_bStop)
-            break;
-
-          for (VECARTISTCREDITS::const_iterator artistCredit  = song->artistCredits.begin();
-                                                artistCredit != song->artistCredits.end();
-                                              ++artistCredit)
+          for (VECSONGS::iterator song = album->songs.begin();
+            song != album->songs.end();
+            ++song)
           {
             if (m_bStop)
               break;
 
-            CMusicArtistInfo musicArtistInfo;
-            if (!m_musicDatabase.HasArtistBeenScraped(artistCredit->GetArtistId()))
+            for (VECARTISTCREDITS::const_iterator artistCredit = song->artistCredits.begin();
+              artistCredit != song->artistCredits.end();
+              ++artistCredit)
             {
-              CArtist artist;
-              m_musicDatabase.GetArtist(artistCredit->GetArtistId(), artist);
-              UpdateDatabaseArtistInfo(artist, artistScraper, false);
+              if (m_bStop)
+                break;
+
+              CMusicArtistInfo musicArtistInfo;
+              if (!m_musicDatabase.HasArtistBeenScraped(artistCredit->GetArtistId()))
+              {
+                CArtist artist;
+                m_musicDatabase.GetArtist(artistCredit->GetArtistId(), artist);
+                UpdateDatabaseArtistInfo(artist, artistScraper, false);
+              }
             }
           }
         }

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -317,12 +317,10 @@ void CGUIWindowMusicBase::OnItemInfoAll(int iItem, bool bCurrent /* = false */, 
   std::string strPath = m_vecItems->GetPath();
   if (bCurrent)
     strPath = m_vecItems->Get(iItem)->GetPath();
-
-  if (dir.HasAlbumInfo(strPath) ||
-      CMusicDatabaseDirectory::GetDirectoryChildType(strPath) == 
-      MUSICDATABASEDIRECTORY::NODE_TYPE_ALBUM)
+  
+  if (StringUtils::EqualsNoCase(m_vecItems->GetContent(), "albums"))
     g_application.StartMusicAlbumScan(strPath,refresh);
-  else
+  else if (StringUtils::EqualsNoCase(m_vecItems->GetContent(), "artists"))
     g_application.StartMusicArtistScan(strPath,refresh);
 }
 

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -185,7 +185,7 @@ bool CGUIWindowMusicNav::OnAction(const CAction& action)
     int item = m_viewControl.GetSelectedItem();
     CMusicDatabaseDirectory dir;
     if (item > -1 && m_vecItems->Get(item)->m_bIsFolder
-                  && (dir.HasAlbumInfo(m_vecItems->Get(item)->GetPath())||
+                  && (m_vecItems->Get(item)->IsAlbum()||
                       dir.IsArtistDir(m_vecItems->Get(item)->GetPath())))
     {
       OnContextButton(item,CONTEXT_BUTTON_INFO);
@@ -482,14 +482,14 @@ void CGUIWindowMusicNav::GetContextButtons(int itemNumber, CContextButtons &butt
       CMusicDatabaseDirectory dir;
 
       // enable query all albums button only in album view
-      if (dir.HasAlbumInfo(item->GetPath()) && !dir.IsAllItem(item->GetPath()) &&
+      if (item->IsAlbum() && !dir.IsAllItem(item->GetPath()) &&
           item->m_bIsFolder && !item->IsVideoDb() && !item->IsParentFolder()   &&
          !item->IsPlugin() && !StringUtils::StartsWithNoCase(item->GetPath(), "musicsearch://"))
       {
         buttons.Add(CONTEXT_BUTTON_INFO_ALL, 20059);
       }
 
-      // enable query all artist button only in album view
+      // enable query all artist button only in artist view
       if (dir.IsArtistDir(item->GetPath()) && !dir.IsAllItem(item->GetPath()) &&
         item->m_bIsFolder && !item->IsVideoDb())
       {


### PR DESCRIPTION
Some initial steps to improve the scraping of artist info from online metadata sites, reducing network traffic and speeding things up, by being more desciminating about which artists Kodi attempts to scrape. Discussed here http://forum.kodi.tv/showthread.php?tid=264719

We need to take more care over unnecessary data requests or we risk breaking the metadata source sites or being blocked from them, and a quicker user experience is always desireable.

1) Use the albumartistonly flag to avoid unecessarily automated attemps to fetch song artist data when the user does not list these artists and thus can not see the information retrieved. 

2) Initialise variables  so that "Query Info for all" works even when having not done a library update since last after power-up. This facilitates later user selected scraping separate from loading music into the music library.

3) Get elective scraping of artists working for all screens with "artists" content. The user can then use "Query Info for all artists" item from any list of artists produced by custom nodes (including filtering by role) or in smart playlists to fetch info for those artists.

These simple changes improve both the automated scraping that ocurrs when "Fetch additional information during updates" is enabled, and gives the user greater control over elective scraping from "Query Info for all" of selected artists.

There is more to do to improve efficiency, but this is a hopefully an uncontrovertial start.
