### PR TITLE
[AMLogic] Increase abs_error threshold to prevent video stutter on pl…

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/AMLCodec.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/AMLCodec.cpp
@@ -1992,7 +1992,7 @@ void CAMLCodec::Process()
         if (abs_error > 0.125)
         {
           //CLog::Log(LOGDEBUG, "CAMLCodec::Process pts diff = %f", error);
-          if (abs_error > 0.150)
+          if (abs_error > 0.300)
           {
             // big error so try to reset pts_pcrscr
             SetVideoPtsSeconds(app_pts);


### PR DESCRIPTION
…ay/pause. As advised by Amlogic this value has to be set to 0.300, instead of 0.150.
