### PR TITLE
[cmake] Switch to msbuild instead of devenv for Windows libs

### DIFF
--- a/project/cmake/modules/FindCpluff.cmake
+++ b/project/cmake/modules/FindCpluff.cmake
@@ -34,11 +34,9 @@ else()
                       CONFIGURE_COMMAND ""
                       # TODO: Building the project directly from lib/cpluff/libcpluff/win32/cpluff.vcxproj
                       #       fails becaue it imports XBMC.defaults.props
-                      BUILD_COMMAND devenv /build ${CORE_BUILD_CONFIG}
-                                           ${CORE_SOURCE_DIR}/project/VS2010Express/XBMC\ for\ Windows.sln
-                                           /project cpluff
+                      BUILD_COMMAND msbuild ${CORE_SOURCE_DIR}/project/VS2010Express/XBMC\ for\ Windows.sln
+                                            /t:cpluff /p:Configuration=${CORE_BUILD_CONFIG}
                       INSTALL_COMMAND "")
-  # TODO: core_link_library
 endif()
 
 set(CPLUFF_INCLUDE_DIRS ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/cpluff/include)

--- a/project/cmake/modules/FindD3DX11Effects.cmake
+++ b/project/cmake/modules/FindD3DX11Effects.cmake
@@ -10,8 +10,8 @@ ExternalProject_Add(d3dx11effects
             SOURCE_DIR ${CORE_SOURCE_DIR}/lib/win32/Effects11
             PREFIX ${CORE_BUILD_DIR}/Effects11
             CONFIGURE_COMMAND ""
-            BUILD_COMMAND devenv /build ${CORE_BUILD_CONFIG}
-                          ${CORE_SOURCE_DIR}/lib/win32/Effects11/Effects11_2013.sln
+            BUILD_COMMAND msbuild ${CORE_SOURCE_DIR}/lib/win32/Effects11/Effects11_2013.sln
+                                  /t:Effects11 /p:Configuration=${CORE_BUILD_CONFIG}
             INSTALL_COMMAND "")
 
 set(D3DX11EFFECTS_FOUND 1)


### PR DESCRIPTION
Use msbuild instead of devenv to build cpluff and effects11.

@MartijnKaijser: This should get us one step closer to a successful build on jenkins. (http://jenkins.kodi.tv/view/Helpers/job/WIN-32-CoverityScan/8)
