### PR TITLE
EncoderFFmpeg: Do not use deprecated attribute coded_frame

### DIFF
--- a/xbmc/cdrip/EncoderFFmpeg.cpp
+++ b/xbmc/cdrip/EncoderFFmpeg.cpp
@@ -316,9 +316,6 @@ bool CEncoderFFmpeg::WriteFrame()
 
   if (got_output)
   {
-    if (m_CodecCtx->coded_frame && m_CodecCtx->coded_frame->pts != AV_NOPTS_VALUE)
-      m_Pkt.pts = av_rescale_q(m_CodecCtx->coded_frame->pts, m_Stream->time_base, m_CodecCtx->time_base);
-
     if (av_write_frame(m_Format, &m_Pkt) < 0) {
       CLog::Log(LOGERROR, "CEncoderFFMmpeg::WriteFrame - Failed to write the frame data");
       return false;


### PR DESCRIPTION
Looking through the ffmpeg source. This is not needed at all for our audio encoders. Needs runtime testing.
