### PR TITLE
[library] Add missing role translations

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -14800,7 +14800,49 @@ msgctxt "#29987"
 msgid "Send present traffic messages around and can be handled from add-ons (nothing inside Kodi)"
 msgstr ""
 
-#empty strings from id 29988 to 33000
+#. Music role category
+#: system/library/music/musicroles/Arrangers.xml
+msgctxt "#29988"
+msgid "Arrangers"
+msgstr ""
+
+#. Music role category
+#: system/library/music/musicroles/Composers.xml
+msgctxt "#29989"
+msgid "Composers"
+msgstr ""
+
+#. Music role category
+#: system/library/music/musicroles/Conductors.xml
+msgctxt "#29990"
+msgid "Conductors"
+msgstr ""
+
+#. Music role category
+#: system/library/music/musicroles/DJ.xml
+msgctxt "#29991"
+msgid "DJ Mixers"
+msgstr ""
+
+#. Music role category
+#: system/library/music/musicroles/Lyricists.xml
+msgctxt "#29992"
+msgid "Lyricists"
+msgstr ""
+
+#. Music role category
+#: system/library/music/musicroles/Orchestras.xml
+msgctxt "#29993"
+msgid "Orchestras"
+msgstr ""
+
+#. Roles from music contributor
+#: system/library/music/musicroles/index.xml
+msgctxt "#29994"
+msgid "Roles"
+msgstr ""
+
+#empty strings from id 29995 to 33000
 #strings 30000 thru 30999 reserved for plug-ins and plug-in settings
 #strings 31000 thru 31999 reserved for skins
 #strings 32000 thru 32999 reserved for scripts
@@ -18668,32 +18710,32 @@ msgstr ""
 #. Remixer of the song (if present)
 msgctxt "#38036"
 msgid "Remixer"
-msgstr "" 
+msgstr ""
 
 #. Arranger of the song (if present)
 msgctxt "#38037"
 msgid "Arranger"
-msgstr "" 
+msgstr ""
 
 #. Engineer of the song (if present)
 msgctxt "#38038"
 msgid "Engineer"
-msgstr "" 
+msgstr ""
 
 #. Producer of the song (if present)
 msgctxt "#38039"
 msgid "Producer"
-msgstr "" 
+msgstr ""
 
 #. DJMixer of the song (if present)
 msgctxt "#38040"
 msgid "DJMixer"
-msgstr "" 
+msgstr ""
 
 #. Mixer of the song (if present)
 msgctxt "#38041"
 msgid "Mixer"
-msgstr "" 
+msgstr ""
 
 #. Missing artist name
 #: music/MusicDatabase.cpp

--- a/system/library/music/musicroles/Arrangers.xml
+++ b/system/library/music/musicroles/Arrangers.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <node order="5" type="folder" visible="Library.HasContent(Role, Arranger)">
-	<label>Arrangers</label>
+	<label>29988</label>
         <icon>DefaultMusicGenres.png</icon>
 	<path>musicdb://artists/?role=Arranger</path>
 </node>

--- a/system/library/music/musicroles/Arrangers.xml
+++ b/system/library/music/musicroles/Arrangers.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <node order="5" type="folder" visible="Library.HasContent(Role, Arranger)">
 	<label>29988</label>
-        <icon>DefaultMusicGenres.png</icon>
+	<icon>DefaultMusicGenres.png</icon>
 	<path>musicdb://artists/?role=Arranger</path>
 </node>

--- a/system/library/music/musicroles/Composers.xml
+++ b/system/library/music/musicroles/Composers.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <node order="1" type="folder" visible="Library.HasContent(Role, Composer)">
-	<label>Composers</label>
+	<label>29989</label>
       	<icon>DefaultMusicGenres.png</icon>
 	<path>musicdb://artists/?role=Composer</path>
 </node>

--- a/system/library/music/musicroles/Composers.xml
+++ b/system/library/music/musicroles/Composers.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <node order="1" type="folder" visible="Library.HasContent(Role, Composer)">
 	<label>29989</label>
-      	<icon>DefaultMusicGenres.png</icon>
+	<icon>DefaultMusicGenres.png</icon>
 	<path>musicdb://artists/?role=Composer</path>
 </node>

--- a/system/library/music/musicroles/Conductors.xml
+++ b/system/library/music/musicroles/Conductors.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <node order="2" type="folder" visible="Library.HasContent(Role, Conductor)">
 	<label>29990</label>
-      <icon>DefaultMusicGenres.png</icon>
+	<icon>DefaultMusicGenres.png</icon>
 	<path>musicdb://artists/?role=Conductor</path>
 </node>

--- a/system/library/music/musicroles/Conductors.xml
+++ b/system/library/music/musicroles/Conductors.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <node order="2" type="folder" visible="Library.HasContent(Role, Conductor)">
-	<label>Conductors</label>
+	<label>29990</label>
       <icon>DefaultMusicGenres.png</icon>
 	<path>musicdb://artists/?role=Conductor</path>
 </node>

--- a/system/library/music/musicroles/DJMixers.xml
+++ b/system/library/music/musicroles/DJMixers.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <node order="6" type="folder" visible="Library.HasContent(Role, DJMixer)">
-	<label>DJ Mixers</label>
+	<label>29991</label>
       <icon>DefaultMusicGenres.png</icon>
 	<path>musicdb://artists/?role=DJMixer</path>
 </node>

--- a/system/library/music/musicroles/DJMixers.xml
+++ b/system/library/music/musicroles/DJMixers.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <node order="6" type="folder" visible="Library.HasContent(Role, DJMixer)">
 	<label>29991</label>
-      <icon>DefaultMusicGenres.png</icon>
+	<icon>DefaultMusicGenres.png</icon>
 	<path>musicdb://artists/?role=DJMixer</path>
 </node>

--- a/system/library/music/musicroles/Lyricists.xml
+++ b/system/library/music/musicroles/Lyricists.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <node order="4" type="folder" visible="Library.HasContent(Role, Lyricist)">
-	<label>Lyricists</label>
+	<label>29992</label>
       <icon>DefaultMusicGenres.png</icon>
 	<path>musicdb://artists/?role=Lyricist</path>
 </node>

--- a/system/library/music/musicroles/Lyricists.xml
+++ b/system/library/music/musicroles/Lyricists.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <node order="4" type="folder" visible="Library.HasContent(Role, Lyricist)">
 	<label>29992</label>
-      <icon>DefaultMusicGenres.png</icon>
+	<icon>DefaultMusicGenres.png</icon>
 	<path>musicdb://artists/?role=Lyricist</path>
 </node>

--- a/system/library/music/musicroles/Orchestras.xml
+++ b/system/library/music/musicroles/Orchestras.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <node order="3" type="folder" visible="Library.HasContent(Role, Orchestra)">
-	<label>Orchestras</label>
+	<label>29993</label>
         <icon>DefaultMusicGenres.png</icon>
 	<path>musicdb://artists/?role=Orchestra</path>
 </node>

--- a/system/library/music/musicroles/Orchestras.xml
+++ b/system/library/music/musicroles/Orchestras.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <node order="3" type="folder" visible="Library.HasContent(Role, Orchestra)">
 	<label>29993</label>
-        <icon>DefaultMusicGenres.png</icon>
+	<icon>DefaultMusicGenres.png</icon>
 	<path>musicdb://artists/?role=Orchestra</path>
 </node>

--- a/system/library/music/musicroles/index.xml
+++ b/system/library/music/musicroles/index.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <node order="15" type="folder" visible="Library.HasContent(Music)">
-	<label>Roles</label>
+	<label>29994</label>
 	<icon>DefaultMusicSongs.png</icon>
 </node>


### PR DESCRIPTION
The labels for music roles were hardcoded into the library xmls. This PR translates those labels and also fixes some whitespace/tab quirks in the process.

@ronie  @DaveTBlake
