### PR TITLE
[adsp] rework to new system who already on PVR

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -7633,15 +7633,7 @@ msgctxt "#15047"
 msgid "Audio DSP settings"
 msgstr ""
 
-#: xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSP.cpp
-msgctxt "#15048"
-msgid "No audio DSP add-on enabled"
-msgstr ""
-
-#: xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSP.cpp
-msgctxt "#15049"
-msgid "The audio DSP manager has been enabled without any enabled DSP add-on. Enable at least one add-on in order to use the DSP functionality."
-msgstr ""
+#empty strings from id 15048 to 15049
 
 #. Name of a list with amount of entries behind on GUI
 msgctxt "#15050"
@@ -9765,17 +9757,7 @@ msgctxt "#19272"
 msgid "You need a tuner, backend software, and an add-on for the backend to be able to use PVR. Please visit http://kodi.wiki/view/PVR to learn more."
 msgstr ""
 
-#. Header on DialogOK
-#: xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSP.cpp
-msgctxt "#19273"
-msgid "No audio DSP add-ons could be found"
-msgstr ""
-
-#. DialogOK for no installed ADSP add-on available
-#: xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSP.cpp
-msgctxt "#19274"
-msgid "You need an add-on installed to be able to use audio digital signal processing (DSP)."
-msgstr ""
+#empty strings from id 19273 to 19274
 
 #: xbmc/pvr/timers/PVRTimerInfoTag.cpp
 msgctxt "#19275"

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2492,9 +2492,9 @@ void CApplication::OnApplicationMessage(ThreadMessage* pMsg)
 
   case TMSG_SETAUDIODSPSTATE:
     if(pMsg->param1 == ACTIVE_AE_DSP_STATE_ON)
-      ActiveAE::CActiveAEDSP::GetInstance().Activate(pMsg->param2 == ACTIVE_AE_DSP_ASYNC_ACTIVATE);
+      CServiceBroker::GetADSP().Activate(pMsg->param2 == ACTIVE_AE_DSP_ASYNC_ACTIVATE);
     else if(pMsg->param1 == ACTIVE_AE_DSP_STATE_OFF)
-      ActiveAE::CActiveAEDSP::GetInstance().Deactivate();
+      CServiceBroker::GetADSP().Deactivate();
     break;
 
   case TMSG_START_ANDROID_ACTIVITY:

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -638,6 +638,14 @@ bool CApplication::Create()
   CWIN32Util::SetThreadLocalLocale(true); // enable independent locale for each thread, see https://connect.microsoft.com/VisualStudio/feedback/details/794122
 #endif // TARGET_WINDOWS
 
+  // initialize the addon database (must be before the addon manager is init'd)
+  CDatabaseManager::GetInstance().Initialize(true);
+
+  if (!m_ServiceManager->Init2())
+  {
+    return false;
+  }
+
   // start the AudioEngine
   if (!CAEFactory::StartEngine())
   {
@@ -655,14 +663,6 @@ bool CApplication::Create()
   m_replayGainSettings.iPreAmp = CSettings::GetInstance().GetInt(CSettings::SETTING_MUSICPLAYER_REPLAYGAINPREAMP);
   m_replayGainSettings.iNoGainPreAmp = CSettings::GetInstance().GetInt(CSettings::SETTING_MUSICPLAYER_REPLAYGAINNOGAINPREAMP);
   m_replayGainSettings.bAvoidClipping = CSettings::GetInstance().GetBool(CSettings::SETTING_MUSICPLAYER_REPLAYGAINAVOIDCLIPPING);
-
-  // initialize the addon database (must be before the addon manager is init'd)
-  CDatabaseManager::GetInstance().Initialize(true);
-
-  if (!m_ServiceManager->Init2())
-  {
-    return false;
-  }
 
   // Create the Mouse, Keyboard, Remote, and Joystick devices
   // Initialize after loading settings to get joystick deadzone setting
@@ -1162,7 +1162,6 @@ bool CApplication::Initialize()
       uiInitializationFinished = firstWindow != WINDOW_STARTUP_ANIM;
 
       CStereoscopicsManager::GetInstance().Initialize();
-      CApplicationMessenger::GetInstance().SendMsg(TMSG_SETAUDIODSPSTATE, ACTIVE_AE_DSP_STATE_ON, ACTIVE_AE_DSP_SYNC_ACTIVATE); // send a blocking message to active AudioDSP engine
 
       if (!m_ServiceManager->Init3())
       {
@@ -2492,7 +2491,7 @@ void CApplication::OnApplicationMessage(ThreadMessage* pMsg)
 
   case TMSG_SETAUDIODSPSTATE:
     if(pMsg->param1 == ACTIVE_AE_DSP_STATE_ON)
-      CServiceBroker::GetADSP().Activate(pMsg->param2 == ACTIVE_AE_DSP_ASYNC_ACTIVATE);
+      CServiceBroker::GetADSP().Activate();
     else if(pMsg->param1 == ACTIVE_AE_DSP_STATE_OFF)
       CServiceBroker::GetADSP().Deactivate();
     break;
@@ -2896,7 +2895,7 @@ void CApplication::Stop(int exitCode)
     if (CVideoLibraryQueue::GetInstance().IsRunning())
       CVideoLibraryQueue::GetInstance().CancelAllJobs();
 
-    CApplicationMessenger::GetInstance().SendMsg(TMSG_SETAUDIODSPSTATE, ACTIVE_AE_DSP_STATE_OFF); // send a blocking message to deactivate AudioDSP engine
+    CServiceBroker::GetADSP().Deactivate();
     CApplicationMessenger::GetInstance().Cleanup();
 
     CLog::Log(LOGNOTICE, "stop player");

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -5716,7 +5716,7 @@ std::string CGUIInfoManager::GetLabel(int info, int contextWindow, std::string *
   case ADSP_MASTER_INFO:
   case ADSP_MASTER_OWN_ICON:
   case ADSP_MASTER_OVERRIDE_ICON:
-    ActiveAE::CActiveAEDSP::GetInstance().TranslateCharInfo(info, strLabel);
+    CServiceBroker::GetADSP().TranslateCharInfo(info, strLabel);
     break;
   case WEATHER_CONDITIONS:
     strLabel = g_weatherManager.GetInfo(WEATHER_LABEL_CURRENT_COND);
@@ -6732,7 +6732,7 @@ bool CGUIInfoManager::GetBool(int condition1, int contextWindow, const CGUIListI
   else if (condition >= PVR_CONDITIONS_START && condition <= PVR_CONDITIONS_END)
     bReturn = g_PVRManager.TranslateBoolInfo(condition);
   else if (condition >= ADSP_CONDITIONS_START && condition <= ADSP_CONDITIONS_END)
-    bReturn = ActiveAE::CActiveAEDSP::GetInstance().TranslateBoolInfo(condition);
+    bReturn = CServiceBroker::GetADSP().TranslateBoolInfo(condition);
   else if (condition == SYSTEM_INTERNET_STATE)
   {
     g_sysinfo.GetInfo(condition);

--- a/xbmc/ServiceBroker.cpp
+++ b/xbmc/ServiceBroker.cpp
@@ -45,3 +45,8 @@ PVR::CPVRManager &CServiceBroker::GetPVRManager()
 {
   return g_application.m_ServiceManager->GetPVRManager();
 }
+
+ActiveAE::CActiveAEDSP &CServiceBroker::GetADSP()
+{
+  return g_application.m_ServiceManager->GetADSPManager();
+}

--- a/xbmc/ServiceBroker.h
+++ b/xbmc/ServiceBroker.h
@@ -25,6 +25,10 @@ class CAddonMgr;
 class CBinaryAddonCache;
 }
 
+namespace ActiveAE {
+class CActiveAEDSP;
+}
+
 namespace ANNOUNCEMENT
 {
   class CAnnouncementManager;
@@ -45,4 +49,5 @@ public:
   static ANNOUNCEMENT::CAnnouncementManager &GetAnnouncementManager();
   static XBPython &GetXBPython();
   static PVR::CPVRManager &GetPVRManager();
+  static ActiveAE::CActiveAEDSP& GetADSP();
 };

--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "ServiceManager.h"
+#include "cores/AudioEngine/DSPAddons/ActiveAEDSP.h"
 #include "utils/log.h"
 #include "interfaces/AnnouncementManager.h"
 #include "interfaces/generic/ScriptInvocationManager.h"
@@ -42,7 +43,8 @@ bool CServiceManager::Init2()
     CLog::Log(LOGFATAL, "CServiceManager::Init: Unable to start CAddonMgr");
     return false;
   }
-  
+
+  m_ADSPManager.reset(new ActiveAE::CActiveAEDSP());
   m_PVRManager.reset(new PVR::CPVRManager());
 
   m_binaryAddonCache.reset( new ADDON::CBinaryAddonCache());
@@ -62,6 +64,7 @@ void CServiceManager::Deinit()
 {
   m_binaryAddonCache.reset();
   m_PVRManager.reset();
+  m_ADSPManager.reset();
   m_addonMgr.reset();
   CScriptInvocationManager::GetInstance().UnregisterLanguageInvocationHandler(m_XBPython.get());
   m_XBPython.reset();
@@ -91,4 +94,9 @@ XBPython& CServiceManager::GetXBPython()
 PVR::CPVRManager& CServiceManager::GetPVRManager()
 {
   return *m_PVRManager;
+}
+
+ActiveAE::CActiveAEDSP& CServiceManager::GetADSPManager()
+{
+  return *m_ADSPManager;
 }

--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -55,6 +55,7 @@ bool CServiceManager::Init2()
 
 bool CServiceManager::Init3()
 {
+  m_ADSPManager->Init();
   m_PVRManager->Init();
 
   return true;

--- a/xbmc/ServiceManager.h
+++ b/xbmc/ServiceManager.h
@@ -31,6 +31,10 @@ class CAddonMgr;
 class CBinaryAddonCache;
 }
 
+namespace ActiveAE {
+class CActiveAEDSP;
+}
+
 namespace ANNOUNCEMENT
 {
 class CAnnouncementManager;
@@ -53,6 +57,7 @@ public:
   ANNOUNCEMENT::CAnnouncementManager& GetAnnouncementManager();
   XBPython& GetXBPython();
   PVR::CPVRManager& GetPVRManager();
+  ActiveAE::CActiveAEDSP& GetADSPManager();
 
 protected:
   std::unique_ptr<ADDON::CAddonMgr> m_addonMgr;
@@ -60,4 +65,5 @@ protected:
   std::unique_ptr<ANNOUNCEMENT::CAnnouncementManager> m_announcementManager;
   std::unique_ptr<XBPython> m_XBPython;
   std::unique_ptr<PVR::CPVRManager> m_PVRManager;
+  std::unique_ptr<ActiveAE::CActiveAEDSP> m_ADSPManager;
 };

--- a/xbmc/addons/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/GUIDialogAddonInfo.cpp
@@ -96,7 +96,7 @@ bool CGUIDialogAddonInfo::OnMessage(CGUIMessage& message)
       {
         if (m_localAddon)
         {
-          if (m_localAddon->Type() == ADDON_ADSPDLL && ActiveAE::CActiveAEDSP::GetInstance().IsProcessing())
+          if (m_localAddon->Type() == ADDON_ADSPDLL && CServiceBroker::GetADSP().IsProcessing())
           {
             CGUIDialogOK::ShowAndGetInput(24137, 0, 24138, 0);
             return true;
@@ -124,7 +124,7 @@ bool CGUIDialogAddonInfo::OnMessage(CGUIMessage& message)
         //FIXME: should be moved to somewhere appropriate (e.g CAddonMgs::CanAddonBeDisabled or IsInUse) and button should be disabled
         if (m_localAddon)
         {
-          if (m_localAddon->Type() == ADDON_ADSPDLL && ActiveAE::CActiveAEDSP::GetInstance().IsProcessing())
+          if (m_localAddon->Type() == ADDON_ADSPDLL && CServiceBroker::GetADSP().IsProcessing())
           {
             CGUIDialogOK::ShowAndGetInput(24137, 0, 24138, 0);
             return true;

--- a/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSP.cpp
+++ b/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSP.cpp
@@ -21,6 +21,7 @@
 #include "ActiveAEDSP.h"
 
 #include <utility>
+#include <functional>
 
 extern "C" {
 #include "libavutil/channel_layout.h"
@@ -63,9 +64,7 @@ using KODI::MESSAGING::HELPERS::DialogResponse;
 /*! @name Master audio dsp control class */
 //@{
 CActiveAEDSP::CActiveAEDSP()
-  : CThread("ActiveAEDSP")
-  , m_isActive(false)
-  , m_noAddonWarningDisplayed(false)
+  : m_isActive(false)
   , m_usedProcessesCnt(0)
   , m_activeProcessId(-1)
   , m_isValidAudioDSPSettings(false)
@@ -75,36 +74,31 @@ CActiveAEDSP::CActiveAEDSP()
 
 CActiveAEDSP::~CActiveAEDSP()
 {
-  /* Deactivate all present dsp addons */
   Deactivate();
+  CAddonMgr::GetInstance().UnregisterAddonMgrCallback(ADDON_ADSPDLL);
+  CSettings::GetInstance().UnregisterCallback(this);
   CLog::Log(LOGDEBUG, "ActiveAE DSP - destroyed");
+}
+
+void CActiveAEDSP::Init(void)
+{
+  std::set<std::string> settingSet;
+  settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_DSPADDONSENABLED);
+  settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_DSPSETTINGS);
+  settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_DSPRESETDB);
+  CSettings::GetInstance().RegisterCallback(this, settingSet);
+
+  CAddonMgr::GetInstance().RegisterAddonMgrCallback(ADDON_ADSPDLL, this);
+
+  if (CSettings::GetInstance().GetBool(CSettings::SETTING_AUDIOOUTPUT_DSPADDONSENABLED))
+    Activate();
 }
 //@}
 
 /*! @name initialization and configuration methods */
 //@{
-class CActiveAEDSPStartJob : public CJob
+void CActiveAEDSP::Activate(void)
 {
-public:
-  CActiveAEDSPStartJob() {}
-  ~CActiveAEDSPStartJob(void) {}
-
-  bool DoWork(void)
-  {
-    CServiceBroker::GetADSP().Activate(false);
-    return true;
-  }
-};
-
-void CActiveAEDSP::Activate(bool bAsync /* = false */)
-{
-  if (bAsync)
-  {
-    CActiveAEDSPStartJob *job = new CActiveAEDSPStartJob();
-    CJobManager::GetInstance().AddJob(job, NULL);
-    return;
-  }
-
   /* first stop and remove any audio dsp add-on's */
   Deactivate();
 
@@ -112,17 +106,8 @@ void CActiveAEDSP::Activate(bool bAsync /* = false */)
 
   CLog::Log(LOGNOTICE, "ActiveAE DSP - starting");
 
-  /* don't start if Settings->System->Audio->Audio DSP isn't checked */
-  if (!CSettings::GetInstance().GetBool(CSettings::SETTING_AUDIOOUTPUT_DSPADDONSENABLED))
-    return;
-
-  Cleanup();
-
-  /* create and open database */
-  m_databaseDSP.Open();
-
-  Create();
-  SetPriority(-1);
+  UpdateAddons();
+  m_isActive = true;
 }
 
 class CActiveAEDSPModeUpdateJob : public CJob
@@ -177,16 +162,9 @@ void CActiveAEDSP::Deactivate(void)
   if (!m_isActive)
     return;
 
-  /* stop thread */
-  StopThread();
-
   CSingleLock lock(m_critSection);
 
   CLog::Log(LOGNOTICE, "ActiveAE DSP - stopping");
-
-  /* destroy all addons */
-  for (AE_DSP_ADDONMAP_ITR itr = m_addonMap.begin(); itr != m_addonMap.end(); ++itr)
-    itr->second->Destroy();
 
   m_addonMap.clear();
 
@@ -207,8 +185,6 @@ void CActiveAEDSP::Cleanup(void)
   m_isActive                  = false;
   m_usedProcessesCnt          = 0;
   m_isValidAudioDSPSettings   = false;
-  m_noAddonWarningDisplayed   = false;
-  m_outdatedAddons.clear();
 
   for (unsigned int i = 0; i < AE_DSP_MODE_TYPE_MAX; ++i)
     m_modes[i].clear();
@@ -221,26 +197,6 @@ bool CActiveAEDSP::InstallAddonAllowed(const std::string &strAddonId) const
          m_usedProcessesCnt == 0;
 }
 
-void CActiveAEDSP::MarkAsOutdated(const std::string& strAddonId)
-{
-  if (IsActivated() && CSettings::GetInstance().GetInt(CSettings::SETTING_ADDONS_AUTOUPDATES) == AUTO_UPDATES_ON)
-  {
-    CSingleLock lock(m_critSection);
-    m_outdatedAddons.push_back(strAddonId);
-  }
-}
-
-bool CActiveAEDSP::HasOutdatedAddons(std::vector<std::string> &outdatedAddons)
-{
-  CSingleLock lock(m_critSection);
-  if (!m_outdatedAddons.empty())
-  {
-    outdatedAddons = m_outdatedAddons;
-    return true;
-  }
-  return false;
-}
-
 void CActiveAEDSP::ResetDatabase(void)
 {
   CLog::Log(LOGNOTICE, "ActiveAE DSP - clearing the audio DSP database");
@@ -251,7 +207,7 @@ void CActiveAEDSP::ResetDatabase(void)
     CApplicationMessenger::GetInstance().PostMsg(TMSG_MEDIA_STOP);
   }
 
-  /* stop the thread */
+  /* stop the system */
   Deactivate();
 
   if (m_databaseDSP.Open())
@@ -265,13 +221,10 @@ void CActiveAEDSP::ResetDatabase(void)
 
   CLog::Log(LOGNOTICE, "ActiveAE DSP - database cleared");
 
-  if (CSettings::GetInstance().GetBool(CSettings::SETTING_AUDIOOUTPUT_DSPADDONSENABLED))
-  {
-    CLog::Log(LOGNOTICE, "ActiveAE DSP - restarting the audio DSP handler");
-    m_databaseDSP.Open();
-    Cleanup();
-    Activate();
-  }
+  CLog::Log(LOGNOTICE, "ActiveAE DSP - restarting the audio DSP handler");
+  m_databaseDSP.Open();
+  Cleanup();
+  Activate();
 }
 //@}
 
@@ -283,6 +236,7 @@ void CActiveAEDSP::OnSettingAction(const CSetting *setting)
     return;
 
   const std::string &settingId = setting->GetId();
+
   if (settingId == CSettings::SETTING_AUDIOOUTPUT_DSPSETTINGS)
   {
     if (IsActivated())
@@ -336,10 +290,12 @@ int CActiveAEDSP::GetAudioDSPAddonId(const AddonPtr &addon) const
 {
   CSingleLock lock(m_critUpdateSection);
 
-  for (AE_DSP_ADDONMAP_CITR citr = m_addonMap.begin(); citr != m_addonMap.end(); ++citr)
+  for (auto &entry : m_addonMap)
   {
-    if (citr->second->ID() == addon->ID())
-      return citr->first;
+    if (entry.second->ID() == addon->ID())
+    {
+      return entry.first;
+    }
   }
 
   return -1;
@@ -603,244 +559,57 @@ bool CActiveAEDSP::StopAudioDSPAddon(AddonPtr addon, bool bRestart)
   return false;
 }
 
-bool CActiveAEDSP::UpdateAndInitialiseAudioDSPAddons(bool bInitialiseAllAudioDSPAddons /* = false */)
-{
-  bool bReturn(true);
-  VECADDONS map;
-  VECADDONS disableAddons;
-  {
-    CSingleLock lock(m_critUpdateSection);
-    map = m_addons;
-  }
-
-  if (map.empty())
-    return false;
-
-  for (unsigned iAddonPtr = 0; iAddonPtr < map.size(); ++iAddonPtr)
-  {
-    const AddonPtr dspAddon = map.at(iAddonPtr);
-    bool bEnabled = !CAddonMgr::GetInstance().IsAddonDisabled(dspAddon->ID());
-
-    if (!bEnabled && IsKnownAudioDSPAddon(dspAddon))
-    {
-      CSingleLock lock(m_critUpdateSection);
-      /* stop the dsp addon and remove it from the db */
-      StopAudioDSPAddon(dspAddon, false);
-      VECADDONS::iterator addonPtr = std::find(m_addons.begin(), m_addons.end(), dspAddon);
-      if (addonPtr != m_addons.end())
-        m_addons.erase(addonPtr);
-
-    }
-    else if (bEnabled && (bInitialiseAllAudioDSPAddons || !IsKnownAudioDSPAddon(dspAddon) || !IsReadyAudioDSPAddon(dspAddon)))
-    {
-      bool bDisabled(false);
-
-      /* register the add-on in the audio dsp db, and create the CActiveAEDSPAddon instance */
-      int iAddonId = RegisterAudioDSPAddon(dspAddon);
-      if (iAddonId < 0)
-      {
-        /* failed to register or create the add-on, disable it */
-        CLog::Log(LOGWARNING, "ActiveAE DSP - %s - failed to register add-on %s, disabling it", __FUNCTION__, dspAddon->Name().c_str());
-        disableAddons.push_back(dspAddon);
-        bDisabled = true;
-      }
-      else
-      {
-        ADDON_STATUS status(ADDON_STATUS_UNKNOWN);
-        AE_DSP_ADDON addon;
-        {
-          CSingleLock lock(m_critUpdateSection);
-          if (!GetAudioDSPAddon(iAddonId, addon))
-          {
-            CLog::Log(LOGWARNING, "ActiveAE DSP - %s - failed to find add-on %s, disabling it", __FUNCTION__, dspAddon->Name().c_str());
-            disableAddons.push_back(dspAddon);
-            bDisabled = true;
-          }
-        }
-
-        /* re-check the enabled status. newly installed dsps get disabled when they're added to the db */
-        if (!bDisabled && !CAddonMgr::GetInstance().IsAddonDisabled(addon->ID()) && (status = addon->Create(iAddonId)) != ADDON_STATUS_OK)
-        {
-          CLog::Log(LOGWARNING, "ActiveAE DSP - %s - failed to create add-on %s, status = %d", __FUNCTION__, dspAddon->Name().c_str(), status);
-          if (!addon.get() || !addon->DllLoaded() || status == ADDON_STATUS_PERMANENT_FAILURE)
-          {
-            /* failed to load the dll of this add-on, disable it */
-            CLog::Log(LOGWARNING, "ActiveAE DSP - %s - failed to load the dll for add-on %s, disabling it", __FUNCTION__, dspAddon->Name().c_str());
-            disableAddons.push_back(dspAddon);
-            bDisabled = true;
-          }
-        }
-      }
-
-      if (bDisabled && IsActivated())
-        CGUIDialogOK::ShowAndGetInput(24070, 24071, 16029, 0);
-    }
-  }
-
-  /* disable add-ons that failed to initialise */
-  if (!disableAddons.empty())
-  {
-    CSingleLock lock(m_critUpdateSection);
-    for (VECADDONS::iterator itr = disableAddons.begin(); itr != disableAddons.end(); ++itr)
-    {
-      /* disable in the add-on db */
-      CAddonMgr::GetInstance().DisableAddon((*itr)->ID());
-
-      /* remove from the audio dsp add-on list */
-      VECADDONS::iterator addonPtr = std::find(m_addons.begin(), m_addons.end(), *itr);
-      if (addonPtr != m_addons.end())
-        m_addons.erase(addonPtr);
-    }
-  }
-
-  return bReturn;
-}
-
-bool CActiveAEDSP::UpdateAddons(void)
+void CActiveAEDSP::UpdateAddons()
 {
   VECADDONS addons;
   AE_DSP_ADDON dspAddon;
-  bool bReturn(CAddonMgr::GetInstance().GetAddons(addons, ADDON_ADSPDLL));
-  size_t usableAddons;
 
-  if (bReturn)
-  {
-    CSingleLock lock(m_critUpdateSection);
-    m_addons = addons;
-  }
+  CAddonMgr::GetInstance().GetAddons(addons, ADDON_ADSPDLL);
 
-  usableAddons = m_addons.size();
-
-  /* handle "new" addons which aren't yet in the db - these have to be added first */
-  for (VECADDONS::const_iterator itr = addons.begin(); itr != addons.end(); ++itr)
-  {
-    dspAddon = std::dynamic_pointer_cast<CActiveAEDSPAddon>(*itr);
-
-    if (RegisterAudioDSPAddon(dspAddon) < 0)
-    {
-      CAddonMgr::GetInstance().DisableAddon(dspAddon->ID());
-      --usableAddons;
-    }
-  }
-
-  if ((!bReturn || usableAddons == 0) && !m_noAddonWarningDisplayed &&
-      !CAddonMgr::GetInstance().HasInstalledAddons(ADDON_ADSPDLL) &&
-      IsActivated())
-  {
-    // No audio DSP add-ons could be found
-    // You need a add-on installed for the process of audio DSP signal. System becomes disabled.
-    m_noAddonWarningDisplayed = true;
-    CGUIDialogOK::ShowAndGetInput(CVariant{19273}, CVariant{19274});
-    CSettings::GetInstance().SetBool(CSettings::SETTING_AUDIOOUTPUT_DSPADDONSENABLED, false);
-    CGUIMessage msg(GUI_MSG_UPDATE, WINDOW_SETTINGS_SYSTEM, 0);
-    CApplicationMessenger::GetInstance().SendGUIMessage(msg);
-    CApplicationMessenger::GetInstance().PostMsg(TMSG_SETAUDIODSPSTATE, ACTIVE_AE_DSP_STATE_OFF);
-  }
-
-  return bReturn;
-}
-
-void CActiveAEDSP::Notify(const Observable &obs, const ObservableMessage msg)
-{
-  if (msg == ObservableMessageAddons)
-    UpdateAddons();
-}
-
-void CActiveAEDSP::Process(void)
-{
-  bool bCheckedEnabledAddonsOnStartup(false);
-
-  CAddonMgr::GetInstance().RegisterAddonMgrCallback(ADDON_ADSPDLL, this);
-  CAddonMgr::GetInstance().RegisterObserver(this);
-
-  m_isActive = true;
-
-  UpdateAddons();
-
-  while (!g_application.m_bStop && !m_bStop)
-  {
-    UpdateAndInitialiseAudioDSPAddons();
-
-    if (!bCheckedEnabledAddonsOnStartup)
-    {
-      bCheckedEnabledAddonsOnStartup = true;
-      if (HasEnabledAudioDSPAddons())
-        TriggerModeUpdate(false);
-      else if (!m_noAddonWarningDisplayed)
-        ShowDialogNoAddonsEnabled();
-    }
-    else
-    {
-      Sleep(1000);
-    }
-  }
-
-  m_isActive = false;
-}
-
-void CActiveAEDSP::ShowDialogNoAddonsEnabled(void)
-{
-  if (!IsActivated())
+  if (addons.empty())
     return;
 
-  CGUIDialogOK::ShowAndGetInput(15048, 15049, 0, 0);
-
-  std::vector<std::string> params;
-  params.push_back("addons://disabled/kodi.adsp");
-  params.push_back("return");
-  g_windowManager.ActivateWindow(WINDOW_ADDON_BROWSER, params);
-}
-
-int CActiveAEDSP::RegisterAudioDSPAddon(AddonPtr addon)
-{
-  int iAddonId(-1);
-
-  if (CAddonMgr::GetInstance().IsAddonDisabled(addon->ID()))
-    return -1;
-
-  CLog::Log(LOGDEBUG, "ActiveAE DSP - %s - registering add-on '%s'", __FUNCTION__, addon->Name().c_str());
-
-  if (!m_databaseDSP.IsOpen())
+  for (auto &addon : addons)
   {
-    CLog::Log(LOGERROR, "ActiveAE DSP - %s - failed to get the database", __FUNCTION__);
-    return -1;
-  }
-
-  /* check whether we already know this dsp addon */
-  iAddonId = m_databaseDSP.GetAudioDSPAddonId(addon->ID());
-
-  /* try to register the new dsp addon in the db */
-  if (iAddonId < 0)
-  {
-    if ((iAddonId = m_databaseDSP.Persist(addon)) < 0)
+    bool bEnabled = !CAddonMgr::GetInstance().IsAddonDisabled(addon->ID());
+    if (bEnabled && (!IsKnownAudioDSPAddon(addon) || !IsReadyAudioDSPAddon(addon)))
     {
-      CLog::Log(LOGERROR, "ActiveAE DSP - %s - can't add dsp addon '%s' to the database", __FUNCTION__, addon->Name().c_str());
-      return -1;
+      std::hash<std::string> hasher;
+      int iAddonId = static_cast<int>(hasher(addon->ID()));
+      if (iAddonId < 0)
+        iAddonId = -iAddonId;
+
+      /* create and open database */
+      if (!m_databaseDSP.IsOpen())
+        m_databaseDSP.Open();
+
+      if (IsKnownAudioDSPAddon(addon))
+      {
+        AE_DSP_ADDON dspAddon;
+        GetAudioDSPAddon(iAddonId, dspAddon);
+        dspAddon->Create(iAddonId);
+      }
+      else
+      {
+        AE_DSP_ADDON dspAddon = std::dynamic_pointer_cast<CActiveAEDSPAddon>(addon);
+        if (!dspAddon)
+        {
+          CLog::Log(LOGERROR, "CActiveAEDSP::UpdateAndInitialiseAddons - severe error, incorrect add type");
+          continue;
+        }
+
+        dspAddon.get()->Create(iAddonId);
+        // register the add-on
+        if (m_addonMap.find(iAddonId) == m_addonMap.end())
+        {
+          m_addonMap.insert(std::make_pair(iAddonId, dspAddon));
+          m_addonNameIds.insert(make_pair(addon->ID(), iAddonId));
+        }
+      }
     }
   }
 
-  AE_DSP_ADDON dspAddon;
-  /* load and initialise the dsp addon libraries */
-  {
-    CSingleLock lock(m_critSection);
-    AE_DSP_ADDONMAP_CITR existingAddon = m_addonMap.find(iAddonId);
-    if (existingAddon != m_addonMap.end())
-    {
-      /* return existing addon */
-      dspAddon = existingAddon->second;
-    }
-    else
-    {
-      /* create a new addon instance */
-      dspAddon = std::dynamic_pointer_cast<CActiveAEDSPAddon> (addon);
-      m_addonMap.insert(std::make_pair(iAddonId, dspAddon));
-    }
-  }
-
-  if (iAddonId < 0)
-    CLog::Log(LOGERROR, "ActiveAE DSP - %s - can't register dsp add-on '%s'", __FUNCTION__, addon->Name().c_str());
-
-  return iAddonId;
+  TriggerModeUpdate();
 }
 //@}
 
@@ -958,21 +727,11 @@ bool CActiveAEDSP::IsReadyAudioDSPAddon(const AddonPtr &addon)
   return false;
 }
 
-int CActiveAEDSP::GetReadyAddons(AE_DSP_ADDONMAP &addons) const
+int CActiveAEDSP::GetAddonId(const std::string& strId) const
 {
-  int iReturn(0);
   CSingleLock lock(m_critSection);
-
-  for (AE_DSP_ADDONMAP_CITR citr = m_addonMap.begin(); citr != m_addonMap.end(); ++citr)
-  {
-    if (citr->second->ReadyToUse())
-    {
-      addons.insert(std::make_pair(citr->second->GetID(), citr->second));
-      ++iReturn;
-    }
-  }
-
-  return iReturn;
+  std::map<std::string, int>::const_iterator it = m_addonNameIds.find(strId);
+  return it != m_addonNameIds.end() ? it->second : -1;
 }
 
 bool CActiveAEDSP::GetReadyAudioDSPAddon(int iAddonId, AE_DSP_ADDON &addon) const

--- a/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSP.cpp
+++ b/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSP.cpp
@@ -79,12 +79,6 @@ CActiveAEDSP::~CActiveAEDSP()
   Deactivate();
   CLog::Log(LOGDEBUG, "ActiveAE DSP - destroyed");
 }
-
-CActiveAEDSP &CActiveAEDSP::GetInstance()
-{
-  static CActiveAEDSP activeAEDSPManagerInstance;
-  return activeAEDSPManagerInstance;
-}
 //@}
 
 /*! @name initialization and configuration methods */
@@ -97,7 +91,7 @@ public:
 
   bool DoWork(void)
   {
-    CActiveAEDSP::GetInstance().Activate(false);
+    CServiceBroker::GetADSP().Activate(false);
     return true;
   }
 };
@@ -139,7 +133,7 @@ public:
 
   bool DoWork(void)
   {
-    CActiveAEDSP::GetInstance().TriggerModeUpdate(false);
+    CServiceBroker::GetADSP().TriggerModeUpdate(false);
     return true;
   }
 };
@@ -420,7 +414,7 @@ bool CActiveAEDSP::TranslateCharInfo(DWORD dwInfo, std::string &strValue) const
       int modeId = activeMaster->ModeID();
       if (modeId == AE_DSP_MASTER_MODE_ID_PASSOVER || modeId >= AE_DSP_MASTER_MODE_ID_INTERNAL_TYPES)
         strValue = g_localizeStrings.Get(activeMaster->ModeName());
-      else if (CActiveAEDSP::GetInstance().GetAudioDSPAddon(activeMaster->AddonID(), addon))
+      else if (CServiceBroker::GetADSP().GetAudioDSPAddon(activeMaster->AddonID(), addon))
         strValue = g_localizeStrings.GetAddonString(addon->ID(), activeMaster->ModeName());
     }
     break;

--- a/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSP.h
+++ b/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSP.h
@@ -19,6 +19,7 @@
  *
  */
 
+#include "ServiceBroker.h"
 #include "addons/AddonDatabase.h"
 #include "cores/AudioEngine/Utils/AEAudioFormat.h"
 #include "cores/AudioEngine/Interfaces/AE.h"
@@ -53,8 +54,6 @@ namespace ActiveAE
   typedef std::map< int, AE_DSP_ADDON >::iterator         AE_DSP_ADDONMAP_ITR;
   typedef std::map< int, AE_DSP_ADDON >::const_iterator   AE_DSP_ADDONMAP_CITR;
 
-  #define g_AEDSPManager       CActiveAEDSP::GetInstance()
-
   //@{
   /*!
    * Static dsp handling class
@@ -66,23 +65,16 @@ namespace ActiveAE
   {
   /*! @name Master audio dsp control class */
   //@{
-  private:
+  public:
     /*!
      * @brief Create a new CActiveAEDSP instance, which handles all audio DSP related operations in KODI.
      */
     CActiveAEDSP(void);
 
-  public:
     /*!
      * @brief Stop the ActiveAEDSP and destroy all objects it created.
      */
     virtual ~CActiveAEDSP();
-
-    /*!
-     * @brief Get the instance of the ActiveAEDSP.
-     * @return The ActiveAEDSP instance.
-     */
-    static CActiveAEDSP &GetInstance();
   //@}
 
   /*! @name initialization and configuration methods */

--- a/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSP.h
+++ b/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSP.h
@@ -20,7 +20,6 @@
  */
 
 #include "ServiceBroker.h"
-#include "addons/AddonDatabase.h"
 #include "cores/AudioEngine/Utils/AEAudioFormat.h"
 #include "cores/AudioEngine/Interfaces/AE.h"
 #include "threads/CriticalSection.h"
@@ -59,9 +58,7 @@ namespace ActiveAE
    * Static dsp handling class
    */
   class CActiveAEDSP : public ADDON::IAddonMgrCallback,
-                       public ISettingCallback,
-                       public Observer,
-                       private CThread
+                       public ISettingCallback
   {
   /*! @name Master audio dsp control class */
   //@{
@@ -75,14 +72,16 @@ namespace ActiveAE
      * @brief Stop the ActiveAEDSP and destroy all objects it created.
      */
     virtual ~CActiveAEDSP();
+
+    void Init(void);
   //@}
 
   /*! @name initialization and configuration methods */
   //@{
     /*!
-     * @brief Activate the addon dsp processing and start the backend info update thread.
+     * @brief Activate the addon dsp processing.
      */
-    void Activate(bool bAsync = false);
+    void Activate(void);
 
     /*!
      * @brief Stops dsp processing and the backend info update thread.
@@ -107,19 +106,6 @@ namespace ActiveAE
     bool InstallAddonAllowed(const std::string& strAddonId) const;
 
     /*!
-     * @brief Mark an add-on as outdated so it will be upgrade when it's possible again
-     * @param strAddonId The add-on to mark as outdated
-     */
-    void MarkAsOutdated(const std::string& strAddonId);
-
-    /*!
-     * @brief Mark an add-on as outdated so it will be upgrade when it's possible again
-     * @param outdatedAddons The generated list of outdated add-on's
-     * @return True when outdated addons are present.
-     */
-    bool HasOutdatedAddons(std::vector<std::string> &outdatedAddons);
-
-    /*!
      * @brief Get the audio dsp database pointer.
      * @return The audio dsp database.
      */
@@ -142,13 +128,6 @@ namespace ActiveAE
      * @return True when processing is active
      */
     bool IsProcessing(void) const;
-
-    /*!
-     * @brief Get all ready audio dsp addons.
-     * @param addons Store the active addons in this map.
-     * @return The amount of added audio dsp addons.
-     */
-    int GetReadyAddons(AE_DSP_ADDONMAP &addons) const;
   //@}
 
   /*! @name addon installation callback methods */
@@ -182,13 +161,6 @@ namespace ActiveAE
      * @return True if the it was found, false otherwise.
      */
     bool StopAudioDSPAddon(ADDON::AddonPtr addon, bool bRestart);
-
-    /*!
-     * @brief Notify about required messages
-     * @param obs
-     * @param msg The observed message type
-     */
-    void Notify(const Observable &obs, const ObservableMessage msg) override;
 
     /*!
      * @return The amount of enabled audio dsp addons.
@@ -255,6 +227,13 @@ namespace ActiveAE
      * @return True if it was found, false otherwise.
      */
     bool GetAudioDSPAddonName(int iAddonId, std::string &strName) const;
+
+    /*!
+     * @brief Update add-ons from the AddonManager
+     */
+    void UpdateAddons(void);
+
+    int GetAddonId(const std::string& strId) const;
   //@}
 
   /*! @name GUIInfoManager calls */
@@ -388,43 +367,11 @@ namespace ActiveAE
 
   protected:
     /*!
-     * @brief Thread to which updates the backend information
-     */
-    virtual void Process(void) override;
-
-  private:
-    /*!
-     * @brief Update add-ons from the AddonManager
-     * @return True when updated, false otherwise
-     */
-    bool UpdateAddons(void);
-
-    /*!
-     * @brief Show a dialog to guide new users who have no dsp addons enabled.
-     */
-    void ShowDialogNoAddonsEnabled(void);
-
-    /*!
      * @brief Check whether a dsp addon is registered.
      * @param addon The dsp addon to check.
      * @return True if this addon is registered, false otherwise.
      */
     bool IsKnownAudioDSPAddon(const ADDON::AddonPtr& addon) const;
-
-    /*!
-     * @brief Check whether there are any new audio dsp add-ons enabled or whether any of the known addons has been disabled.
-     * @param bInitialiseAllAudioDSPAddons True to initialise all dsp addons, false to only initialise new dsp addons.
-     * @return True if all addons were updated successfully, false otherwise.
-     */
-    bool UpdateAndInitialiseAudioDSPAddons(bool bInitialiseAllAudioDSPAddons = false);
-
-    /*!
-     * @brief Initialise and connect a dsp addon.
-     * @param addon The dsp addon to initialise.
-     * @param newRegistration pass in pointer to bool to return whether the client was newly registered.
-     * @return The id of the addon if it was created or found in the existing addon map, -1 otherwise.
-     */
-    int RegisterAudioDSPAddon(ADDON::AddonPtr addon);
 
     /*!
      * @brief Get the instance of the dsp addon, if it's ready.
@@ -441,11 +388,10 @@ namespace ActiveAE
      */
     int GetAudioDSPAddonId(const ADDON::AddonPtr& addon) const;
 
+
     static const int        m_StreamTypeNameTable[];                    /*!< Table for stream type strings related to type id */
     bool                    m_isActive;                                 /*!< set to true if all available dsp addons are loaded */
-    ADDON::VECADDONS        m_addons;                                   /*!< List of all currently usable addons */
     AE_DSP_ADDONMAP         m_addonMap;                                 /*!< a map of all known audio dsp addons */
-    bool                    m_noAddonWarningDisplayed;                  /*!< true when a warning was displayed that no add-ons were found, false otherwise */
     CActiveAEDSPDatabase    m_databaseDSP;                              /*!< the database for all audio DSP related data */
     CCriticalSection        m_critSection;                              /*!< Critical lock for control functions */
     CCriticalSection        m_critUpdateSection;                        /*!< Critical lock for update thread related functions */
@@ -454,7 +400,7 @@ namespace ActiveAE
     unsigned int            m_activeProcessId;                          /*!< The currently active audio stream id of a playing file source */
     bool                    m_isValidAudioDSPSettings;                  /*!< if settings load was successfull it becomes true */
     AE_DSP_MODELIST         m_modes[AE_DSP_MODE_TYPE_MAX];              /*!< list of currently used dsp processing calls */
-    std::vector<std::string> m_outdatedAddons;
+    std::map<std::string, int> m_addonNameIds; /*!< map add-on names to IDs */
   };
   //@}
 }

--- a/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSPAddon.cpp
+++ b/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSPAddon.cpp
@@ -50,22 +50,22 @@ CActiveAEDSPAddon::~CActiveAEDSPAddon(void)
 void CActiveAEDSPAddon::OnDisabled()
 {
   // restart the ADSP manager if we're disabling a client
-  if (CActiveAEDSP::GetInstance().IsActivated())
-    CActiveAEDSP::GetInstance().Activate(true);
+  if (CServiceBroker::GetADSP().IsActivated())
+    CServiceBroker::GetADSP().Activate(true);
 }
 
 void CActiveAEDSPAddon::OnEnabled()
 {
   // restart the ADSP manager if we're enabling a client
-  CActiveAEDSP::GetInstance().Activate(true);
+  CServiceBroker::GetADSP().Activate(true);
 }
 
 AddonPtr CActiveAEDSPAddon::GetRunningInstance() const
 {
-  if (CActiveAEDSP::GetInstance().IsActivated())
+  if (CServiceBroker::GetADSP().IsActivated())
   {
     AddonPtr adspAddon;
-    if (CActiveAEDSP::GetInstance().GetAudioDSPAddon(ID(), adspAddon))
+    if (CServiceBroker::GetADSP().GetAudioDSPAddon(ID(), adspAddon))
       return adspAddon;
   }
   return CAddon::GetRunningInstance();
@@ -74,32 +74,32 @@ AddonPtr CActiveAEDSPAddon::GetRunningInstance() const
 void CActiveAEDSPAddon::OnPreInstall()
 {
   // stop the ADSP manager, so running ADSP add-ons are stopped and closed
-  CActiveAEDSP::GetInstance().Deactivate();
+  CServiceBroker::GetADSP().Deactivate();
 }
 
 void CActiveAEDSPAddon::OnPostInstall(bool restart, bool update)
 {
   // (re)start the ADSP manager
-  CActiveAEDSP::GetInstance().Activate(true);
+  CServiceBroker::GetADSP().Activate(true);
 }
 
 void CActiveAEDSPAddon::OnPreUnInstall()
 {
   // stop the ADSP manager, so running ADSP add-ons are stopped and closed
-  CActiveAEDSP::GetInstance().Deactivate();
+  CServiceBroker::GetADSP().Deactivate();
 }
 
 void CActiveAEDSPAddon::OnPostUnInstall()
 {
   if (CSettings::GetInstance().GetBool(CSettings::SETTING_AUDIOOUTPUT_DSPADDONSENABLED))
-    CActiveAEDSP::GetInstance().Activate(true);
+    CServiceBroker::GetADSP().Activate(true);
 }
 
 bool CActiveAEDSPAddon::CanInstall()
 {
-  if (!CActiveAEDSP::GetInstance().InstallAddonAllowed(ID()))
+  if (!CServiceBroker::GetADSP().InstallAddonAllowed(ID()))
   {
-    CActiveAEDSP::GetInstance().MarkAsOutdated(ID());
+    CServiceBroker::GetADSP().MarkAsOutdated(ID());
     return false;
   }
   return CAddon::CanInstall();

--- a/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSPAddon.cpp
+++ b/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSPAddon.cpp
@@ -49,15 +49,12 @@ CActiveAEDSPAddon::~CActiveAEDSPAddon(void)
 
 void CActiveAEDSPAddon::OnDisabled()
 {
-  // restart the ADSP manager if we're disabling a client
-  if (CServiceBroker::GetADSP().IsActivated())
-    CServiceBroker::GetADSP().Activate(true);
+  CServiceBroker::GetADSP().UpdateAddons();
 }
 
 void CActiveAEDSPAddon::OnEnabled()
 {
-  // restart the ADSP manager if we're enabling a client
-  CServiceBroker::GetADSP().Activate(true);
+  CServiceBroker::GetADSP().UpdateAddons();
 }
 
 AddonPtr CActiveAEDSPAddon::GetRunningInstance() const
@@ -73,14 +70,12 @@ AddonPtr CActiveAEDSPAddon::GetRunningInstance() const
 
 void CActiveAEDSPAddon::OnPreInstall()
 {
-  // stop the ADSP manager, so running ADSP add-ons are stopped and closed
-  CServiceBroker::GetADSP().Deactivate();
+  CServiceBroker::GetADSP().UpdateAddons();
 }
 
 void CActiveAEDSPAddon::OnPostInstall(bool restart, bool update)
 {
-  // (re)start the ADSP manager
-  CServiceBroker::GetADSP().Activate(true);
+  CServiceBroker::GetADSP().UpdateAddons();
 }
 
 void CActiveAEDSPAddon::OnPreUnInstall()
@@ -91,15 +86,13 @@ void CActiveAEDSPAddon::OnPreUnInstall()
 
 void CActiveAEDSPAddon::OnPostUnInstall()
 {
-  if (CSettings::GetInstance().GetBool(CSettings::SETTING_AUDIOOUTPUT_DSPADDONSENABLED))
-    CServiceBroker::GetADSP().Activate(true);
+  CServiceBroker::GetADSP().UpdateAddons();
 }
 
 bool CActiveAEDSPAddon::CanInstall()
 {
   if (!CServiceBroker::GetADSP().InstallAddonAllowed(ID()))
   {
-    CServiceBroker::GetADSP().MarkAsOutdated(ID());
     return false;
   }
   return CAddon::CanInstall();

--- a/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSPDatabase.cpp
+++ b/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSPDatabase.cpp
@@ -335,7 +335,7 @@ int CActiveAEDSPDatabase::GetModes(AE_DSP_MODELIST &results, int modeType)
         CLog::Log(LOGDEBUG, "Audio DSP - %s - mode '%s' loaded from the database", __FUNCTION__, mode->m_strModeName.c_str());
 #endif
         AE_DSP_ADDON addon;
-        if (CActiveAEDSP::GetInstance().GetAudioDSPAddon(mode->m_iAddonId, addon))
+        if (CServiceBroker::GetADSP().GetAudioDSPAddon(mode->m_iAddonId, addon))
           results.push_back(AE_DSP_MODEPAIR(mode, addon));
 
         m_pDS->next();

--- a/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSPMode.cpp
+++ b/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSPMode.cpp
@@ -338,7 +338,7 @@ int CActiveAEDSPMode::AddUpdate(bool force)
       return m_iModeId;
   }
 
-  CActiveAEDSPDatabase *database = CActiveAEDSP::GetInstance().GetADSPDatabase();
+  CActiveAEDSPDatabase *database = CServiceBroker::GetADSP().GetADSPDatabase();
   if (!database || !database->IsOpen())
   {
     CLog::Log(LOGERROR, "ActiveAE DSP - failed to open the database");
@@ -353,7 +353,7 @@ int CActiveAEDSPMode::AddUpdate(bool force)
 
 bool CActiveAEDSPMode::Delete(void)
 {
-  CActiveAEDSPDatabase *database = CActiveAEDSP::GetInstance().GetADSPDatabase();
+  CActiveAEDSPDatabase *database = CServiceBroker::GetADSP().GetADSPDatabase();
   if (!database || !database->IsOpen())
   {
     CLog::Log(LOGERROR, "ActiveAE DSP - failed to open the database");
@@ -365,7 +365,7 @@ bool CActiveAEDSPMode::Delete(void)
 
 bool CActiveAEDSPMode::IsKnown(void) const
 {
-  CActiveAEDSPDatabase *database = CActiveAEDSP::GetInstance().GetADSPDatabase();
+  CActiveAEDSPDatabase *database = CServiceBroker::GetADSP().GetADSPDatabase();
   if (!database || !database->IsOpen())
   {
     CLog::Log(LOGERROR, "ActiveAE DSP - failed to open the database");

--- a/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSPProcess.cpp
+++ b/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSPProcess.cpp
@@ -305,7 +305,7 @@ bool CActiveAEDSPProcess::Create(const AEAudioFormat &inputFormat, const AEAudio
    * Load all selected processing types, stored in a database and available from addons
    */
   AE_DSP_ADDONMAP addonMap;
-  if (CActiveAEDSP::GetInstance().GetEnabledAudioDSPAddons(addonMap) > 0)
+  if (CServiceBroker::GetADSP().GetEnabledAudioDSPAddons(addonMap) > 0)
   {
     int foundInputResamplerId = -1; /*!< Used to prevent double call of StreamCreate if input stream resampling is together with outer processing types */
 
@@ -314,7 +314,7 @@ bool CActiveAEDSPProcess::Create(const AEAudioFormat &inputFormat, const AEAudio
      * load one allowed before master processing & final resample addon
      */
     CLog::Log(LOGDEBUG, "  ---- DSP input resample addon ---");
-    const AE_DSP_MODELIST listInputResample = CActiveAEDSP::GetInstance().GetAvailableModes(AE_DSP_MODE_TYPE_INPUT_RESAMPLE);
+    const AE_DSP_MODELIST listInputResample = CServiceBroker::GetADSP().GetAvailableModes(AE_DSP_MODE_TYPE_INPUT_RESAMPLE);
     if (listInputResample.empty())
       CLog::Log(LOGDEBUG, "  | - no input resample addon present or enabled");
     for (unsigned int i = 0; i < listInputResample.size(); ++i)
@@ -406,7 +406,7 @@ bool CActiveAEDSPProcess::Create(const AEAudioFormat &inputFormat, const AEAudio
      * Load all required pre process dsp addon functions
      */
     CLog::Log(LOGDEBUG, "  ---- DSP active pre process modes ---");
-    const AE_DSP_MODELIST listPreProcess = CActiveAEDSP::GetInstance().GetAvailableModes(AE_DSP_MODE_TYPE_PRE_PROCESS);
+    const AE_DSP_MODELIST listPreProcess = CServiceBroker::GetADSP().GetAvailableModes(AE_DSP_MODE_TYPE_PRE_PROCESS);
     for (unsigned int i = 0; i < listPreProcess.size(); ++i)
     {
       CActiveAEDSPModePtr pMode = listPreProcess[i].first;
@@ -436,7 +436,7 @@ bool CActiveAEDSPProcess::Create(const AEAudioFormat &inputFormat, const AEAudio
      * Load all available master modes from addons and put together with database
      */
     CLog::Log(LOGDEBUG, "  ---- DSP active master process modes ---");
-    const AE_DSP_MODELIST listMasterProcess = CActiveAEDSP::GetInstance().GetAvailableModes(AE_DSP_MODE_TYPE_MASTER_PROCESS);
+    const AE_DSP_MODELIST listMasterProcess = CServiceBroker::GetADSP().GetAvailableModes(AE_DSP_MODE_TYPE_MASTER_PROCESS);
     for (unsigned int i = 0; i < listMasterProcess.size(); ++i)
     {
       CActiveAEDSPModePtr pMode = listMasterProcess[i].first;
@@ -510,7 +510,7 @@ bool CActiveAEDSPProcess::Create(const AEAudioFormat &inputFormat, const AEAudio
      * Load all required post process dsp addon functions
      */
     CLog::Log(LOGDEBUG, "  ---- DSP active post process modes ---");
-    const AE_DSP_MODELIST listPostProcess = CActiveAEDSP::GetInstance().GetAvailableModes(AE_DSP_MODE_TYPE_POST_PROCESS);
+    const AE_DSP_MODELIST listPostProcess = CServiceBroker::GetADSP().GetAvailableModes(AE_DSP_MODE_TYPE_POST_PROCESS);
     for (unsigned int i = 0; i < listPostProcess.size(); ++i)
     {
       CActiveAEDSPModePtr pMode = listPostProcess[i].first;
@@ -543,7 +543,7 @@ bool CActiveAEDSPProcess::Create(const AEAudioFormat &inputFormat, const AEAudio
     CLog::Log(LOGDEBUG, "  ---- DSP post resample addon ---");
     if (m_addonSettings.iProcessSamplerate != m_outputFormat.m_sampleRate)
     {
-      const AE_DSP_MODELIST listOutputResample = CActiveAEDSP::GetInstance().GetAvailableModes(AE_DSP_MODE_TYPE_OUTPUT_RESAMPLE);
+      const AE_DSP_MODELIST listOutputResample = CServiceBroker::GetADSP().GetAvailableModes(AE_DSP_MODE_TYPE_OUTPUT_RESAMPLE);
       if (listOutputResample.empty())
         CLog::Log(LOGDEBUG, "  | - no final post resample addon present or enabled, becomes performed by KODI");
       for (unsigned int i = 0; i < listOutputResample.size(); ++i)
@@ -820,7 +820,7 @@ void CActiveAEDSPProcess::Destroy()
 {
   CSingleLock lock(m_restartSection);
 
-  if (!CActiveAEDSP::GetInstance().IsActivated())
+  if (!CServiceBroker::GetADSP().IsActivated())
     return;
 
   for (AE_DSP_ADDONMAP_ITR itr = m_usedMap.begin(); itr != m_usedMap.end(); ++itr)

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -1657,7 +1657,7 @@ void CActiveAE::ApplySettingsToFormat(AEAudioFormat &format, AudioSettings &sett
       CAEChannelInfo stdLayout(stdChannelLayout);
 
       if (m_settings.config == AE_CONFIG_FIXED || settings.dspaddonsenabled || (settings.stereoupmix && format.m_channelLayout.Count() <= 2))
-        format.m_channelLayout = CActiveAEDSP::GetInstance().GetInternalChannelLayout(stdChannelLayout);
+        format.m_channelLayout = CServiceBroker::GetADSP().GetInternalChannelLayout(stdChannelLayout);
       else if (m_extKeepConfig && (settings.config == AE_CONFIG_AUTO) && (oldMode != MODE_RAW))
         format.m_channelLayout = m_internalFormat.m_channelLayout;
       else

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
@@ -182,7 +182,7 @@ CActiveAEBufferPoolResample::~CActiveAEBufferPoolResample()
 {
   delete m_resampler;
   if (m_useDSP)
-    CActiveAEDSP::GetInstance().DestroyDSPs(m_streamId);
+    CServiceBroker::GetADSP().DestroyDSPs(m_streamId);
   if (m_dspBuffer)
     delete m_dspBuffer;
 }
@@ -216,12 +216,12 @@ bool CActiveAEBufferPoolResample::Create(unsigned int totaltime, bool remap, boo
    * stream with the basic data to have best quality like for surround upmix.
    *
    * The value m_streamId and address pointer m_processor are passed a pointers
-   * to CActiveAEDSP::GetInstance().CreateDSPs and set from it.
+   * to CServiceBroker::GetADSP().CreateDSPs and set from it.
    */
   if ((useDSP || m_changeDSP) && !m_bypassDSP)
   {
     m_dspFormat = m_inputFormat;
-    m_useDSP = CActiveAEDSP::GetInstance().CreateDSPs(m_streamId, m_processor, m_dspFormat, m_format, upmix, m_resampleQuality, m_MatrixEncoding, m_AudioServiceType, m_Profile);
+    m_useDSP = CServiceBroker::GetADSP().CreateDSPs(m_streamId, m_processor, m_dspFormat, m_format, upmix, m_resampleQuality, m_MatrixEncoding, m_AudioServiceType, m_Profile);
     if (m_useDSP)
     {
 
@@ -330,7 +330,7 @@ void CActiveAEBufferPoolResample::ChangeAudioDSP()
     wasActive = true;
   }
 
-  m_useDSP = CActiveAEDSP::GetInstance().CreateDSPs(m_streamId, m_processor, m_dspFormat, m_format, m_stereoUpmix, m_resampleQuality, m_MatrixEncoding, m_AudioServiceType, m_Profile, wasActive);
+  m_useDSP = CServiceBroker::GetADSP().CreateDSPs(m_streamId, m_processor, m_dspFormat, m_format, m_stereoUpmix, m_resampleQuality, m_MatrixEncoding, m_AudioServiceType, m_Profile, wasActive);
   if (m_useDSP)
   {
     m_inputFormat.m_channelLayout = m_processor->GetChannelLayout();    /* Overide input format with DSP's supported format */
@@ -360,7 +360,7 @@ void CActiveAEBufferPoolResample::ChangeAudioDSP()
       m_changeResampler = true;
 
     m_useDSP = false;
-    CActiveAEDSP::GetInstance().DestroyDSPs(m_streamId);
+    CServiceBroker::GetADSP().DestroyDSPs(m_streamId);
   }
   else
   {

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -898,7 +898,7 @@ void CGUIWindowMusicBase::GetContextButtons(int itemNumber, CContextButtons &but
 
 void CGUIWindowMusicBase::GetNonContextButtons(CContextButtons &buttons)
 {
-  if (ActiveAE::CActiveAEDSP::GetInstance().IsProcessing())
+  if (CServiceBroker::GetADSP().IsProcessing())
     buttons.Add(CONTEXT_BUTTON_ACTIVE_ADSP_SETTINGS, 15047);
 }
 

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -295,7 +295,7 @@ bool CGUIWindowPVRBase::OnContextButtonActiveAEDSPSettings(CFileItem *item, CONT
   {
     bReturn = true;
 
-    if (ActiveAE::CActiveAEDSP::GetInstance().IsProcessing())
+    if (CServiceBroker::GetADSP().IsProcessing())
       g_windowManager.ActivateWindow(WINDOW_DIALOG_AUDIO_DSP_OSD_SETTINGS);
   }
 

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -87,7 +87,7 @@ void CGUIWindowPVRChannels::GetContextButtons(int itemNumber, CContextButtons &b
   else if (g_PVRClients->SupportsTimers(channel->ClientID()))
     buttons.Add(CONTEXT_BUTTON_START_RECORD, 264);   /* Record */
 
-  if (ActiveAE::CActiveAEDSP::GetInstance().IsProcessing())
+  if (CServiceBroker::GetADSP().IsProcessing())
     buttons.Add(CONTEXT_BUTTON_ACTIVE_ADSP_SETTINGS, 15047);                        /* Audio DSP settings */
 
   if (g_PVRClients->HasMenuHooks(channel->ClientID(), PVR_MENUHOOK_CHANNEL))

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -157,7 +157,7 @@ void CGUIWindowPVRRecordings::GetContextButtons(int itemNumber, CContextButtons 
     buttons.Add(CONTEXT_BUTTON_DELETE, 117);        /* Delete */
   }
 
-  if (ActiveAE::CActiveAEDSP::GetInstance().IsProcessing())
+  if (CServiceBroker::GetADSP().IsProcessing())
     buttons.Add(CONTEXT_BUTTON_ACTIVE_ADSP_SETTINGS, 15047);  /* Audio DSP settings */
 
   if (recording)

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -616,7 +616,7 @@ void CSettings::Uninitialize()
 #if defined(TARGET_DARWIN_OSX)
   m_settingsManager->UnregisterCallback(&XBMCHelper::GetInstance());
 #endif
-  m_settingsManager->UnregisterCallback(&ActiveAE::CActiveAEDSP::GetInstance());
+  m_settingsManager->UnregisterCallback(&CServiceBroker::GetADSP());
   m_settingsManager->UnregisterCallback(&CWakeOnAccess::GetInstance());
 
   // cleanup the settings manager
@@ -1175,7 +1175,7 @@ void CSettings::InitializeISettingCallbacks()
   settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_DSPADDONSENABLED);
   settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_DSPSETTINGS);
   settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_DSPRESETDB);
-  m_settingsManager->RegisterCallback(&ActiveAE::CActiveAEDSP::GetInstance(), settingSet);
+  m_settingsManager->RegisterCallback(&CServiceBroker::GetADSP(), settingSet);
 
   settingSet.clear();
   settingSet.insert(CSettings::SETTING_ADDONS_AUTOUPDATES);

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -30,7 +30,6 @@
 #include "addons/RepositoryUpdater.h"
 #include "addons/Skin.h"
 #include "cores/AudioEngine/AEFactory.h"
-#include "cores/AudioEngine/DSPAddons/ActiveAEDSP.h"
 #include "cores/playercorefactory/PlayerCoreFactory.h"
 #include "cores/VideoPlayer/VideoRenderers/BaseRenderer.h"
 #include "filesystem/File.h"
@@ -616,7 +615,6 @@ void CSettings::Uninitialize()
 #if defined(TARGET_DARWIN_OSX)
   m_settingsManager->UnregisterCallback(&XBMCHelper::GetInstance());
 #endif
-  m_settingsManager->UnregisterCallback(&CServiceBroker::GetADSP());
   m_settingsManager->UnregisterCallback(&CWakeOnAccess::GetInstance());
 
   // cleanup the settings manager
@@ -1170,12 +1168,6 @@ void CSettings::InitializeISettingCallbacks()
   settingSet.insert(CSettings::SETTING_INPUT_APPLEREMOTEALWAYSON);
   m_settingsManager->RegisterCallback(&XBMCHelper::GetInstance(), settingSet);
 #endif
-
-  settingSet.clear();
-  settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_DSPADDONSENABLED);
-  settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_DSPSETTINGS);
-  settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_DSPRESETDB);
-  m_settingsManager->RegisterCallback(&CServiceBroker::GetADSP(), settingSet);
 
   settingSet.clear();
   settingSet.insert(CSettings::SETTING_ADDONS_AUTOUPDATES);

--- a/xbmc/settings/dialogs/GUIDialogAudioDSPManager.cpp
+++ b/xbmc/settings/dialogs/GUIDialogAudioDSPManager.cpp
@@ -559,7 +559,7 @@ bool CGUIDialogAudioDSPManager::OnContextButton(int itemNumber, CONTEXT_BUTTON b
     * Open audio dsp addon mode help text dialog
     */
     AE_DSP_ADDON addon;
-    if (CActiveAEDSP::GetInstance().GetAudioDSPAddon((int)pItem->GetProperty("AddonId").asInteger(), addon))
+    if (CServiceBroker::GetADSP().GetAudioDSPAddon((int)pItem->GetProperty("AddonId").asInteger(), addon))
     {
       CGUIDialogTextViewer* pDlgInfo = (CGUIDialogTextViewer*)g_windowManager.GetWindow(WINDOW_DIALOG_TEXT_VIEWER);
       pDlgInfo->SetHeading(g_localizeStrings.Get(15062) + " - " + pItem->GetProperty("Name").asString());
@@ -655,7 +655,7 @@ bool CGUIDialogAudioDSPManager::OnContextButton(int itemNumber, CONTEXT_BUTTON b
     if (hookId > 0)
     {
       AE_DSP_ADDON addon;
-      if (CActiveAEDSP::GetInstance().GetAudioDSPAddon((int)pItem->GetProperty("AddonId").asInteger(), addon))
+      if (CServiceBroker::GetADSP().GetAudioDSPAddon((int)pItem->GetProperty("AddonId").asInteger(), addon))
       {
         AE_DSP_MENUHOOK       hook;
         AE_DSP_MENUHOOK_DATA  hookData;
@@ -792,7 +792,7 @@ void CGUIDialogAudioDSPManager::SaveList(void)
   /* persist all modes */
   if (UpdateDatabase(pDlgBusy))
   {
-    CActiveAEDSP::GetInstance().TriggerModeUpdate();
+    CServiceBroker::GetADSP().TriggerModeUpdate();
 
     m_bContainsChanges = false;
     SetItemsUnchanged();
@@ -959,13 +959,13 @@ CFileItem *CGUIDialogAudioDSPManager::helper_CreateModeListItem(CActiveAEDSPMode
   const int AddonID = ModePointer->AddonID();
 
   std::string addonName;
-  if (!CActiveAEDSP::GetInstance().GetAudioDSPAddonName(AddonID, addonName))
+  if (!CServiceBroker::GetADSP().GetAudioDSPAddonName(AddonID, addonName))
   {
     return pItem;
   }
 
   AE_DSP_ADDON addon;
-  if (!CActiveAEDSP::GetInstance().GetAudioDSPAddon(AddonID, addon))
+  if (!CServiceBroker::GetADSP().GetAudioDSPAddon(AddonID, addon))
   {
     return pItem;
   }
@@ -1033,7 +1033,7 @@ int CGUIDialogAudioDSPManager::helper_GetDialogId(CActiveAEDSPModePtr &ModePoint
     AE_DSP_MENUHOOKS hooks;
 
     // Find first general settings dialog about mode
-    if (CActiveAEDSP::GetInstance().GetMenuHooks(ModePointer->AddonID(), AE_DSP_MENUHOOK_SETTING, hooks))
+    if (CServiceBroker::GetADSP().GetMenuHooks(ModePointer->AddonID(), AE_DSP_MENUHOOK_SETTING, hooks))
     {
       for (unsigned int i = 0; i < hooks.size() && dialogId == 0; i++)
       {
@@ -1045,7 +1045,7 @@ int CGUIDialogAudioDSPManager::helper_GetDialogId(CActiveAEDSPModePtr &ModePoint
     }
 
     // If nothing was present, check for playback settings
-    if (dialogId == 0 && CActiveAEDSP::GetInstance().GetMenuHooks(ModePointer->AddonID(), MenuHook, hooks))
+    if (dialogId == 0 && CServiceBroker::GetADSP().GetMenuHooks(ModePointer->AddonID(), MenuHook, hooks))
     {
       for (unsigned int i = 0; i < hooks.size() && (dialogId == 0 || dialogId != -1); i++)
       {

--- a/xbmc/settings/dialogs/GUIDialogAudioDSPSettings.cpp
+++ b/xbmc/settings/dialogs/GUIDialogAudioDSPSettings.cpp
@@ -229,11 +229,11 @@ void CGUIDialogAudioDSPSettings::FrameMove()
       m_settingsManager->SetNumber(SETTING_AUDIO_POST_PROC_AUDIO_DELAY, videoSettings.m_AudioDelay);
 
     bool forceReload = false;
-    unsigned int  streamId = CActiveAEDSP::GetInstance().GetActiveStreamId();
+    unsigned int  streamId = CServiceBroker::GetADSP().GetActiveStreamId();
     if (m_ActiveStreamId != streamId)
     {
       m_ActiveStreamId      = streamId;
-      m_ActiveStreamProcess = CActiveAEDSP::GetInstance().GetDSPProcess(m_ActiveStreamId);
+      m_ActiveStreamProcess = CServiceBroker::GetADSP().GetDSPProcess(m_ActiveStreamId);
       if (m_ActiveStreamId == (unsigned int)-1 || !m_ActiveStreamProcess)
       {
         Close(true);
@@ -447,8 +447,8 @@ void CGUIDialogAudioDSPSettings::InitializeSettings()
   if (g_application.m_pPlayer->HasPlayer())
     g_application.m_pPlayer->GetAudioCapabilities(m_audioCaps);
 
-  m_ActiveStreamId      = CActiveAEDSP::GetInstance().GetActiveStreamId();
-  m_ActiveStreamProcess = CActiveAEDSP::GetInstance().GetDSPProcess(m_ActiveStreamId);
+  m_ActiveStreamId      = CServiceBroker::GetADSP().GetActiveStreamId();
+  m_ActiveStreamProcess = CServiceBroker::GetADSP().GetDSPProcess(m_ActiveStreamId);
   if (m_ActiveStreamId == (unsigned int)-1 || !m_ActiveStreamProcess)
   {
     m_iCategory = FindCategoryIndex(SETTING_AUDIO_CAT_MAIN);
@@ -472,21 +472,21 @@ void CGUIDialogAudioDSPSettings::InitializeSettings()
     /* about size() > 1, it is always the fallback (ignore of master processing) present. */
     StaticIntegerSettingOptions modeEntries;
     if (m_MasterModes[AE_DSP_ASTREAM_BASIC].size() > 1)
-      modeEntries.push_back(std::pair<int, int>(CActiveAEDSP::GetInstance().GetStreamTypeName(AE_DSP_ASTREAM_BASIC),   AE_DSP_ASTREAM_BASIC));
+      modeEntries.push_back(std::pair<int, int>(CServiceBroker::GetADSP().GetStreamTypeName(AE_DSP_ASTREAM_BASIC),   AE_DSP_ASTREAM_BASIC));
     if (m_MasterModes[AE_DSP_ASTREAM_MUSIC].size() > 1)
-      modeEntries.push_back(std::pair<int, int>(CActiveAEDSP::GetInstance().GetStreamTypeName(AE_DSP_ASTREAM_MUSIC),   AE_DSP_ASTREAM_MUSIC));
+      modeEntries.push_back(std::pair<int, int>(CServiceBroker::GetADSP().GetStreamTypeName(AE_DSP_ASTREAM_MUSIC),   AE_DSP_ASTREAM_MUSIC));
     if (m_MasterModes[AE_DSP_ASTREAM_MOVIE].size() > 1)
-      modeEntries.push_back(std::pair<int, int>(CActiveAEDSP::GetInstance().GetStreamTypeName(AE_DSP_ASTREAM_MOVIE),   AE_DSP_ASTREAM_MOVIE));
+      modeEntries.push_back(std::pair<int, int>(CServiceBroker::GetADSP().GetStreamTypeName(AE_DSP_ASTREAM_MOVIE),   AE_DSP_ASTREAM_MOVIE));
     if (m_MasterModes[AE_DSP_ASTREAM_GAME].size() > 1)
-      modeEntries.push_back(std::pair<int, int>(CActiveAEDSP::GetInstance().GetStreamTypeName(AE_DSP_ASTREAM_GAME),    AE_DSP_ASTREAM_GAME));
+      modeEntries.push_back(std::pair<int, int>(CServiceBroker::GetADSP().GetStreamTypeName(AE_DSP_ASTREAM_GAME),    AE_DSP_ASTREAM_GAME));
     if (m_MasterModes[AE_DSP_ASTREAM_APP].size() > 1)
-      modeEntries.push_back(std::pair<int, int>(CActiveAEDSP::GetInstance().GetStreamTypeName(AE_DSP_ASTREAM_APP),     AE_DSP_ASTREAM_APP));
+      modeEntries.push_back(std::pair<int, int>(CServiceBroker::GetADSP().GetStreamTypeName(AE_DSP_ASTREAM_APP),     AE_DSP_ASTREAM_APP));
     if (m_MasterModes[AE_DSP_ASTREAM_MESSAGE].size() > 1)
-      modeEntries.push_back(std::pair<int, int>(CActiveAEDSP::GetInstance().GetStreamTypeName(AE_DSP_ASTREAM_MESSAGE), AE_DSP_ASTREAM_MESSAGE));
+      modeEntries.push_back(std::pair<int, int>(CServiceBroker::GetADSP().GetStreamTypeName(AE_DSP_ASTREAM_MESSAGE), AE_DSP_ASTREAM_MESSAGE));
     if (m_MasterModes[AE_DSP_ASTREAM_PHONE].size() > 1)
-      modeEntries.push_back(std::pair<int, int>(CActiveAEDSP::GetInstance().GetStreamTypeName(AE_DSP_ASTREAM_PHONE),   AE_DSP_ASTREAM_PHONE));
+      modeEntries.push_back(std::pair<int, int>(CServiceBroker::GetADSP().GetStreamTypeName(AE_DSP_ASTREAM_PHONE),   AE_DSP_ASTREAM_PHONE));
     if (modesAvailable > 1 && m_MasterModes[m_streamTypeUsed].size() > 1)
-      modeEntries.insert(modeEntries.begin(), std::pair<int, int>(CActiveAEDSP::GetInstance().GetStreamTypeName(AE_DSP_ASTREAM_AUTO), AE_DSP_ASTREAM_AUTO));
+      modeEntries.insert(modeEntries.begin(), std::pair<int, int>(CServiceBroker::GetADSP().GetStreamTypeName(AE_DSP_ASTREAM_AUTO), AE_DSP_ASTREAM_AUTO));
 
     AddSpinner(groupAudioModeSel,
                 SETTING_AUDIO_MAIN_STREAMTYPE, 15021, 0,
@@ -506,7 +506,7 @@ void CGUIDialogAudioDSPSettings::InitializeSettings()
       {
         m_ModeList.push_back(make_pair(g_localizeStrings.Get(m_MasterModes[m_streamTypeUsed][i]->ModeName()), modeId));
       }
-      else if (CActiveAEDSP::GetInstance().GetAudioDSPAddon(m_MasterModes[m_streamTypeUsed][i]->AddonID(), addon))
+      else if (CServiceBroker::GetADSP().GetAudioDSPAddon(m_MasterModes[m_streamTypeUsed][i]->AddonID(), addon))
       {
         m_ModeList.push_back(make_pair(g_localizeStrings.GetAddonString(addon->ID(), m_MasterModes[m_streamTypeUsed][i]->ModeName()), modeId));
         if (!AddonMasterModeSetupPresent)
@@ -572,10 +572,10 @@ void CGUIDialogAudioDSPSettings::InitializeSettings()
       if (m_MasterModes[m_streamTypeUsed][i]->HasSettingsDialog())
       {
         AE_DSP_ADDON addon;
-        if (CActiveAEDSP::GetInstance().GetAudioDSPAddon(m_MasterModes[m_streamTypeUsed][i]->AddonID(), addon))
+        if (CServiceBroker::GetADSP().GetAudioDSPAddon(m_MasterModes[m_streamTypeUsed][i]->AddonID(), addon))
         {
           AE_DSP_MENUHOOKS hooks;
-          if (CActiveAEDSP::GetInstance().GetMenuHooks(m_MasterModes[m_streamTypeUsed][i]->AddonID(), AE_DSP_MENUHOOK_MASTER_PROCESS, hooks))
+          if (CServiceBroker::GetADSP().GetMenuHooks(m_MasterModes[m_streamTypeUsed][i]->AddonID(), AE_DSP_MENUHOOK_MASTER_PROCESS, hooks))
           {
             for (unsigned int j = 0; j < hooks.size(); j++)
             {
@@ -746,7 +746,7 @@ void CGUIDialogAudioDSPSettings::InitializeSettings()
     for (unsigned int i = 0; i < m_ActiveModes.size(); i++)
     {
       AE_DSP_ADDON addon;
-      if (CActiveAEDSP::GetInstance().GetAudioDSPAddon(m_ActiveModes[i]->AddonID(), addon))
+      if (CServiceBroker::GetADSP().GetAudioDSPAddon(m_ActiveModes[i]->AddonID(), addon))
       {
         std::string label;
         switch (m_ActiveModes[i]->ModeType())
@@ -793,7 +793,7 @@ void CGUIDialogAudioDSPSettings::InitializeSettings()
 
         AE_DSP_MENUHOOKS hooks;
         m_ActiveModesData[i].MenuListPtr = -1;
-        if (CActiveAEDSP::GetInstance().GetMenuHooks(m_ActiveModes[i]->AddonID(), AE_DSP_MENUHOOK_INFORMATION, hooks))
+        if (CServiceBroker::GetADSP().GetMenuHooks(m_ActiveModes[i]->AddonID(), AE_DSP_MENUHOOK_INFORMATION, hooks))
         {
           for (unsigned int j = 0; j < hooks.size(); j++)
           {
@@ -875,13 +875,13 @@ bool CGUIDialogAudioDSPSettings::HaveActiveMenuHooks(AE_DSP_MENUHOOK_CAT categor
 {
   /*!> Check menus are active on current stream */
   AE_DSP_ADDONMAP addonMap;
-  if (CActiveAEDSP::GetInstance().HaveMenuHooks(category) &&
-      CActiveAEDSP::GetInstance().GetEnabledAudioDSPAddons(addonMap) > 0)
+  if (CServiceBroker::GetADSP().HaveMenuHooks(category) &&
+      CServiceBroker::GetADSP().GetEnabledAudioDSPAddons(addonMap) > 0)
   {
     for (AE_DSP_ADDONMAP_ITR itr = addonMap.begin(); itr != addonMap.end(); itr++)
     {
       AE_DSP_MENUHOOKS hooks;
-      if (CActiveAEDSP::GetInstance().GetMenuHooks(itr->second->GetID(), category, hooks))
+      if (CServiceBroker::GetADSP().GetMenuHooks(itr->second->GetID(), category, hooks))
       {
         for (unsigned int i = 0; i < hooks.size(); i++)
         {
@@ -909,7 +909,7 @@ std::string CGUIDialogAudioDSPSettings::GetSettingsLabel(CSetting *pSetting)
     if (settingId.substr(0, 27) == SETTING_STREAM_INFO_MODE_CPU_USAGE)
     {
       ptr = strtol(settingId.substr(27).c_str(), NULL, 0);
-      if (ptr >= 0 && CActiveAEDSP::GetInstance().GetAudioDSPAddon(m_ActiveModes[ptr]->AddonID(), addon))
+      if (ptr >= 0 && CServiceBroker::GetADSP().GetAudioDSPAddon(m_ActiveModes[ptr]->AddonID(), addon))
         return m_ActiveModesData[ptr].MenuName;
     }
     else
@@ -919,7 +919,7 @@ std::string CGUIDialogAudioDSPSettings::GetSettingsLabel(CSetting *pSetting)
       else if (settingId.substr(0, 19) == SETTING_AUDIO_PROC_SETTINGS_MENUS)
         ptr = strtol(settingId.substr(19).c_str(), NULL, 0);
 
-      if (ptr >= 0 && CActiveAEDSP::GetInstance().GetAudioDSPAddon(m_Menus[ptr].addonId, addon))
+      if (ptr >= 0 && CServiceBroker::GetADSP().GetAudioDSPAddon(m_Menus[ptr].addonId, addon))
         return g_localizeStrings.GetAddonString(addon->ID(), m_Menus[ptr].hook.iLocalizedStringId);
     }
   }
@@ -930,12 +930,12 @@ std::string CGUIDialogAudioDSPSettings::GetSettingsLabel(CSetting *pSetting)
 void CGUIDialogAudioDSPSettings::GetAudioDSPMenus(CSettingGroup *group, AE_DSP_MENUHOOK_CAT category)
 {
   AE_DSP_ADDONMAP addonMap;
-  if (CActiveAEDSP::GetInstance().GetEnabledAudioDSPAddons(addonMap) > 0)
+  if (CServiceBroker::GetADSP().GetEnabledAudioDSPAddons(addonMap) > 0)
   {
     for (AE_DSP_ADDONMAP_ITR itr = addonMap.begin(); itr != addonMap.end(); itr++)
     {
       AE_DSP_MENUHOOKS hooks;
-      if (CActiveAEDSP::GetInstance().GetMenuHooks(itr->second->GetID(), category, hooks))
+      if (CServiceBroker::GetADSP().GetMenuHooks(itr->second->GetID(), category, hooks))
       {
         for (unsigned int i = 0; i < hooks.size(); i++)
         {
@@ -958,7 +958,7 @@ void CGUIDialogAudioDSPSettings::GetAudioDSPMenus(CSettingGroup *group, AE_DSP_M
   for (unsigned int i = 0; i < m_Menus.size(); i++)
   {
     AE_DSP_ADDON addon;
-    if (CActiveAEDSP::GetInstance().GetAudioDSPAddon(m_Menus[i].addonId, addon) && category == m_Menus[i].hook.category)
+    if (CServiceBroker::GetADSP().GetAudioDSPAddon(m_Menus[i].addonId, addon) && category == m_Menus[i].hook.category)
     {
       std::string modeName = g_localizeStrings.GetAddonString(addon->ID(), m_Menus[i].hook.iLocalizedStringId);
       if (modeName.empty())
@@ -976,7 +976,7 @@ bool CGUIDialogAudioDSPSettings::OpenAudioDSPMenu(unsigned int setupEntry)
     return false;
 
   AE_DSP_ADDON addon;
-  if (!CActiveAEDSP::GetInstance().GetAudioDSPAddon(m_Menus[setupEntry].addonId, addon))
+  if (!CServiceBroker::GetADSP().GetAudioDSPAddon(m_Menus[setupEntry].addonId, addon))
     return false;
 
   AE_DSP_MENUHOOK       hook;

--- a/xbmc/test/TestBasicEnvironment.cpp
+++ b/xbmc/test/TestBasicEnvironment.cpp
@@ -20,6 +20,7 @@
 
 #include "TestBasicEnvironment.h"
 #include "TestUtils.h"
+#include "cores/AudioEngine/DSPAddons/ActiveAEDSP.h"
 #include "filesystem/Directory.h"
 #include "filesystem/File.h"
 #include "filesystem/SpecialProtocol.h"

--- a/xbmc/utils/SaveFileStateJob.cpp
+++ b/xbmc/utils/SaveFileStateJob.cpp
@@ -203,7 +203,7 @@ bool CSaveFileStateJob::DoWork()
       }
     }
 
-    if (ActiveAE::CActiveAEDSP::GetInstance().IsProcessing())
+    if (CServiceBroker::GetADSP().IsProcessing())
     {
       std::string redactPath = CURL::GetRedacted(progressTrackingFile);
       CLog::Log(LOGDEBUG, "%s - Saving file state for dsp audio item %s", __FUNCTION__, redactPath.c_str());

--- a/xbmc/windows/GUIWindowLoginScreen.cpp
+++ b/xbmc/windows/GUIWindowLoginScreen.cpp
@@ -278,7 +278,7 @@ void CGUIWindowLoginScreen::LoadProfile(unsigned int profile)
   g_application.StopPVRManager();
 
   // stop audio DSP services with a blocking message
-  CApplicationMessenger::GetInstance().SendMsg(TMSG_SETAUDIODSPSTATE, ACTIVE_AE_DSP_STATE_OFF);
+  CServiceBroker::GetADSP().Deactivate();
 
   if (profile != 0 || !CProfilesManager::GetInstance().IsMasterProfile())
   {
@@ -332,9 +332,6 @@ void CGUIWindowLoginScreen::LoadProfile(unsigned int profile)
 
   g_application.UpdateLibraries();
   CStereoscopicsManager::GetInstance().Initialize();
-
-  // start audio DSP related services with a blocking message
-  CApplicationMessenger::GetInstance().SendMsg(TMSG_SETAUDIODSPSTATE, ACTIVE_AE_DSP_STATE_ON, ACTIVE_AE_DSP_SYNC_ACTIVATE);
 
   // if the user interfaces has been fully initialized let everyone know
   if (uiInitializationFinished)


### PR DESCRIPTION
This add also the changes already present on PVR to the ADSP system.

Has found during this a fault on PVR system. With the `m_PVRManager.reset(new PVR::CPVRManager());`called on `Init2` comes a fault during settings creation where PVR pointer was null!

@FernetMenta can you recheck it, the fix for PVR is on last commit here.
@AchimTuran can you review the rest.
