### PR TITLE
[addons] enable dependencies when enabling addon

### DIFF
--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -264,6 +264,7 @@ namespace ADDON
     static bool PlatformSupportsAddon(const cp_plugin_info_t *info);
 
     bool GetAddonsInternal(const TYPE &type, VECADDONS &addons, bool enabledOnly);
+    bool EnableSingle(const std::string& id);
 
     std::set<std::string> m_disabled;
     std::set<std::string> m_updateBlacklist;


### PR DESCRIPTION
Currently it only enables the one addon, ignoring any dependencies that are disabled or not install. This changes it to attempt enabling of all dependencies as well. And for the time being, at least log in case any dependencies are missing.
