### PR TITLE
[Announcer/iOS]: - move init and deinit of the announce receiver from…

### DIFF
--- a/xbmc/platform/darwin/ios/IOSEAGLView.mm
+++ b/xbmc/platform/darwin/ios/IOSEAGLView.mm
@@ -47,6 +47,7 @@
 #import "IOSScreenManager.h"
 #import "platform/darwin/AutoPool.h"
 #import "platform/darwin/DarwinUtils.h"
+#import "platform/darwin/ios-common/AnnounceReceiver.h"
 #import "XBMCDebugHelpers.h"
 
 using namespace KODI::MESSAGING;
@@ -357,6 +358,9 @@ using namespace KODI::MESSAGING;
     {
       CApplicationMessenger::GetInstance().PostMsg(TMSG_QUIT);
     }
+    
+    CAnnounceReceiver::GetInstance()->DeInitialize();
+      
     // wait for animation thread to die
     if ([animationThread isFinished] == NO)
       [animationThreadLock lockWhenCondition:TRUE];
@@ -400,6 +404,8 @@ using namespace KODI::MESSAGING;
     readyToRun = false;
     ELOG(@"%sUnable to create application", __PRETTY_FUNCTION__);
   }
+  
+  CAnnounceReceiver::GetInstance()->Initialize();
 
   if (!g_application.CreateGUI())
   {

--- a/xbmc/platform/darwin/ios/XBMCController.mm
+++ b/xbmc/platform/darwin/ios/XBMCController.mm
@@ -70,7 +70,6 @@ const NSString *MPNowPlayingInfoPropertyPlaybackQueueCount = @"MPNowPlayingInfoP
 #import "IOSEAGLView.h"
 
 #import "XBMCController.h"
-#import "platform/darwin/ios-common/AnnounceReceiver.h"
 #import "IOSScreenManager.h"
 #import "XBMCApplication.h"
 #import "XBMCDebugHelpers.h"
@@ -612,9 +611,7 @@ XBMCController *g_xbmcController;
   }
 
   [m_window makeKeyAndVisible];
-  g_xbmcController = self;  
-  
-  CAnnounceReceiver::GetInstance()->Initialize();
+  g_xbmcController = self;
 
   return self;
 }
@@ -653,7 +650,6 @@ XBMCController *g_xbmcController;
   [m_networkAutoSuspendTimer invalidate];
   [self enableNetworkAutoSuspend:nil];
 
-  CAnnounceReceiver::GetInstance()->DeInitialize();
   [m_glView stopAnimation];
   [m_glView release];
   [m_window release];


### PR DESCRIPTION
… XBMCController to eaglView because its only save to call into CAnnouncementManager::GetInstance() after CApplication.Create was called

Well i guess this is due to recent changes with the ServiceBroker stuff. This fixes the instant crash on iOS because the AnnouncementManager instance was accessed prior application creation.
