### PR TITLE
[pvr] - do not show connected message on startup

### DIFF
--- a/xbmc/addons/PVRClient.cpp
+++ b/xbmc/addons/PVRClient.cpp
@@ -144,6 +144,8 @@ void CPVRClient::ResetProperties(int iClientId /* = PVR_INVALID_CLIENT_ID */)
   m_timertypes.clear();
   m_bReadyToUse           = false;
   m_connectionState       = PVR_CONNECTION_STATE_UNKNOWN;
+  m_prevConnectionState   = PVR_CONNECTION_STATE_UNKNOWN;
+  m_ignoreClient          = false;
   m_iClientId             = iClientId;
   m_strBackendVersion     = DEFAULT_INFO_STRING_VALUE;
   m_strConnectionString   = DEFAULT_INFO_STRING_VALUE;
@@ -227,7 +229,27 @@ PVR_CONNECTION_STATE CPVRClient::GetConnectionState(void) const
 void CPVRClient::SetConnectionState(PVR_CONNECTION_STATE state)
 {
   CSingleLock lock(m_critSection);
+
+  m_prevConnectionState = m_connectionState;
   m_connectionState = state;
+
+  if (m_connectionState == PVR_CONNECTION_STATE_CONNECTED)
+    m_ignoreClient = false;
+  else if (m_connectionState == PVR_CONNECTION_STATE_CONNECTING &&
+           m_prevConnectionState == PVR_CONNECTION_STATE_UNKNOWN)
+    m_ignoreClient = true;
+}
+
+PVR_CONNECTION_STATE CPVRClient::GetPreviousConnectionState(void) const
+{
+  CSingleLock lock(m_critSection);
+  return m_prevConnectionState;
+}
+
+bool CPVRClient::IgnoreClient(void) const
+{
+  CSingleLock lock(m_critSection);
+  return m_ignoreClient;
 }
 
 int CPVRClient::GetID(void) const

--- a/xbmc/addons/PVRClient.h
+++ b/xbmc/addons/PVRClient.h
@@ -118,6 +118,18 @@ namespace PVR
     void SetConnectionState(PVR_CONNECTION_STATE state);
 
     /*!
+     * @brief Gets the backend's previous connection state.
+     * @return the backend's previous  connection state.
+     */
+    PVR_CONNECTION_STATE GetPreviousConnectionState(void) const;
+
+    /*!
+     * @brief signal to PVRMananager this client should be ignored
+     * @return true if this client should be ignored
+     */
+    bool IgnoreClient(void) const;
+
+    /*!
      * @return The ID of this instance.
      */
     int GetID(void) const;
@@ -690,6 +702,8 @@ namespace PVR
 
     bool                   m_bReadyToUse;          /*!< true if this add-on is initialised (ADDON_Create returned true), false otherwise */
     PVR_CONNECTION_STATE   m_connectionState;      /*!< the backend connection state */
+    PVR_CONNECTION_STATE   m_prevConnectionState;  /*!< the previous backend connection state */
+    bool                   m_ignoreClient;         /*!< signals to PVRManager to ignore this client until it has been connected */
     PVR_MENUHOOKS          m_menuhooks;            /*!< the menu hooks for this add-on */
     CPVRTimerTypes         m_timertypes;           /*!< timer types supported by this backend */
     int                    m_iClientId;            /*!< database ID of the client */

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -239,8 +239,7 @@ bool CPVRClients::HasCreatedClients(void) const
   for (PVR_CLIENTMAP_CITR itr = m_clientMap.begin(); itr != m_clientMap.end(); itr++)
     if (itr->second->ReadyToUse())
     {
-      PVR_CONNECTION_STATE state = itr->second->GetConnectionState();
-      if (state != PVR_CONNECTION_STATE_CONNECTING)
+      if (itr->second->IgnoreClient())
         return true;
     }
 
@@ -337,8 +336,7 @@ int CPVRClients::GetCreatedClients(PVR_CLIENTMAP &clients) const
   {
     if (itr->second->ReadyToUse())
     {
-      PVR_CONNECTION_STATE state = itr->second->GetConnectionState();
-      if (state == PVR_CONNECTION_STATE_CONNECTING)
+      if (itr->second->IgnoreClient())
         continue;
       
       clients.insert(std::make_pair(itr->second->GetID(), itr->second));
@@ -1562,6 +1560,9 @@ void CPVRClients::ConnectionStateChange(int clientId, std::string &strConnection
     case PVR_CONNECTION_STATE_CONNECTED:
       bError = false;
       iMsg = 36034; // Connection established
+      if (client->GetPreviousConnectionState() == PVR_CONNECTION_STATE_UNKNOWN ||
+          client->GetPreviousConnectionState() == PVR_CONNECTION_STATE_CONNECTING)
+        bNotify = false;
       break;
     case PVR_CONNECTION_STATE_DISCONNECTED:
       iMsg = 36030; // Connection lost


### PR DESCRIPTION
see title

@ksooo this restores the old behaviour and enables clients to benefit from async startup sequence.
