### PR TITLE
[cmake] Fix missing add_dependencies for d3dx11effects

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/CMakeLists.txt
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/CMakeLists.txt
@@ -51,3 +51,7 @@ core_add_library(videorenderers)
 if(ENABLE_INTERNAL_FFMPEG)
   add_dependencies(videorenderers ffmpeg)
 endif()
+
+if(CORE_SYSTEM_NAME STREQUAL windows)
+  add_dependencies(videorenderers d3dx11effects)
+endif()

--- a/xbmc/guilib/CMakeLists.txt
+++ b/xbmc/guilib/CMakeLists.txt
@@ -241,4 +241,5 @@ if(CORE_SYSTEM_NAME STREQUAL windows)
                   ps_4_0_level_9_1
                   PS)
   endforeach()
+  add_dependencies(guilib d3dx11effects)
 endif()

--- a/xbmc/rendering/dx/CMakeLists.txt
+++ b/xbmc/rendering/dx/CMakeLists.txt
@@ -5,3 +5,7 @@ set(HEADERS GUIWindowTestPatternDX.h
             RenderSystemDX.h)
 
 core_add_library(rendering_dx)
+
+if(CORE_SYSTEM_NAME STREQUAL windows)
+  add_dependencies(rendering_dx d3dx11effects)
+endif()

--- a/xbmc/video/CMakeLists.txt
+++ b/xbmc/video/CMakeLists.txt
@@ -36,3 +36,7 @@ add_dependencies(video libcpluff)
 if(ENABLE_INTERNAL_FFMPEG)
   add_dependencies(video ffmpeg)
 endif()
+
+if(CORE_SYSTEM_NAME STREQUAL windows)
+  add_dependencies(video d3dx11effects)
+endif()

--- a/xbmc/video/videosync/CMakeLists.txt
+++ b/xbmc/video/videosync/CMakeLists.txt
@@ -32,4 +32,7 @@ endif()
 
 if(SOURCES AND HEADERS)
   core_add_library(video_sync)
+  if(CORE_SYSTEM_NAME STREQUAL "windows")
+    add_dependencies(video_sync d3dx11effects)
+  endif()
 endif()


### PR DESCRIPTION
Fix missing dependencies to d3dx11effects. Solves windows compilation when built with the nmake generator (which does a non parallelized build).  

```
[100%] Building CXX object CMakeFiles/kodi.dir/xbmc/platform/posix/main.cpp.obj
main.cpp
NMAKE : fatal error U1073: don't know how to make 'lib\win32\Effects11\libs\Effects11\Debug\Effects11.lib'
Stop.
NMAKE : fatal error U1077: '"C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\BIN\nmake.exe"' : return code '0x2'
Stop.
NMAKE : fatal error U1077: '"C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\BIN\nmake.exe"' : return code '0x2'
Stop.
[WARNING] Build command nmake.exe exited with code 2. Please verify that the build completed successfully.
```

@MartijnKaijser: The Coverity build fails without this.
