### PR TITLE
fixed: Low readrate error toast could show when performing e.g. small stepping

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -12690,11 +12690,11 @@ msgid "Root filesystem"
 msgstr ""
 
 msgctxt "#21454"
-msgid "Cache full"
+msgid "Source too slow"
 msgstr ""
 
 msgctxt "#21455"
-msgid "Cache filled before reaching required amount for continuous playback"
+msgid "Read rate too low for continuous playback"
 msgstr ""
 
 #: xbmc/playlists/SmartPlaylist.cpp

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFile.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFile.cpp
@@ -186,7 +186,9 @@ int CDVDInputStreamFile::GetBlockSize()
 
 void CDVDInputStreamFile::SetReadRate(unsigned rate)
 {
-  unsigned maxrate = rate + 1024 * 1024 / 8;
+  // Increase requested rate by 10%:
+  unsigned maxrate = (unsigned) (1.1 * rate);
+
   if(m_pFile->IoControl(IOCTRL_CACHE_SETRATE, &maxrate) >= 0)
     CLog::Log(LOGDEBUG, "CDVDInputStreamFile::SetReadRate - set cache throttle rate to %u bytes per second", maxrate);
 }

--- a/xbmc/filesystem/FileCache.cpp
+++ b/xbmc/filesystem/FileCache.cpp
@@ -48,7 +48,6 @@ public:
   {
     m_stamp = XbmcThreads::SystemClockMillis();
     m_pos   = 0;
-    m_pause = 0;
     m_size = 0;
     m_time = 0;
   }
@@ -80,21 +79,9 @@ public:
     return (unsigned)(1000 * (m_size / (m_time + time_bias)));
   }
 
-  void Pause()
-  {
-    m_pause = XbmcThreads::SystemClockMillis();
-  }
-
-  void Resume()
-  {
-    m_stamp += XbmcThreads::SystemClockMillis() - m_pause;
-    m_pause  = 0;
-  }
-
 private:
   unsigned m_stamp;
   int64_t  m_pos;
-  unsigned m_pause;
   unsigned m_time;
   int64_t  m_size;
 };
@@ -325,9 +312,7 @@ void CFileCache::Process()
      */
     if (maxWrite == 0 && !cacheReachEOF)
     {
-      average.Pause();
       m_pCache->m_space.WaitMSec(5);
-      average.Resume();
       continue;
     }
 
@@ -367,9 +352,7 @@ void CFileCache::Process()
       }
       else if (iWrite == 0)
       {
-        average.Pause();
         m_pCache->m_space.WaitMSec(5);
-        average.Resume();
       }
 
       iTotalWrite += iWrite;

--- a/xbmc/filesystem/FileCache.h
+++ b/xbmc/filesystem/FileCache.h
@@ -77,7 +77,7 @@ namespace XFILE
     unsigned     m_chunkSize;
     unsigned     m_writeRate;
     unsigned     m_writeRateActual;
-    bool         m_cacheFull;
+    int64_t      m_forwardCacheSize;
     std::atomic<int64_t> m_fileSize;
     unsigned int m_flags;
     CCriticalSection m_sync;

--- a/xbmc/filesystem/IFileTypes.h
+++ b/xbmc/filesystem/IFileTypes.h
@@ -60,7 +60,7 @@ struct SCacheStatus
   uint64_t forward;  /**< number of bytes cached forward of current position */
   unsigned maxrate;  /**< maximum number of bytes per second cache is allowed to fill */
   unsigned currate;  /**< average read rate from source file since last position change */
-  bool     full;     /**< is the cache full */
+  float    level;    /**< cache level (0.0 - 1.0) */
 };
 
 typedef enum {


### PR DESCRIPTION
This issue has been bugging me for quite some time but until now I never figured out the cause. 

The problem is that we can only reliably test for low readrate, when the cache is not \* already _near_ full. This is because as soon as it's full the average-rate will become approximately the current-rate which can flag false low read-rate conditions.
