### PR TITLE
[cmake][addons] Raise an error when ADDON_SRC_PREFIX is an relative path

### DIFF
--- a/project/cmake/addons/CMakeLists.txt
+++ b/project/cmake/addons/CMakeLists.txt
@@ -132,7 +132,9 @@ endif()
 get_filename_component(ADDONS_DEFINITION_DIR "${ADDONS_DEFINITION_DIR}" ABSOLUTE)
 
 if(ADDON_SRC_PREFIX)
-  get_filename_component(ADDON_SRC_PREFIX "${ADDON_SRC_PREFIX}" ABSOLUTE)
+  if(NOT IS_ABSOLUTE ${ADDON_SRC_PREFIX})
+    message(FATAL_ERROR "ADDON_SRC_PREFIX must be an absolute path!")
+  endif()
   message(STATUS "Overriding addon source directory prefix: ${ADDON_SRC_PREFIX}")
 endif()
 

--- a/project/cmake/addons/README
+++ b/project/cmake/addons/README
@@ -44,8 +44,9 @@ specific paths:
   * ADDONS_DEFINITION_DIR points to the directory containing the definitions
     for the addons to be built.
   * ADDON_SRC_PREFIX can be used to override the addon repository location.
-    It must point to the locally available parent directory of the addon(s) to build
-    <addon-id> will be appended to this path automatically
+    It must point to the locally available parent directory of the addon(s) 
+	to build and must be an absolute path. <addon-id> will be appended to 
+	this path automatically.
   * CMAKE_BUILD_TYPE specifies the type of the build. This can be either "Debug"
     or "Release" (default is "Release").
   * CMAKE_INSTALL_PREFIX points to the directory where the built addons and their


### PR DESCRIPTION
@wsnipex @ksooo @AlwinEsch @FernetMenta @Jalle19 @mapfau 

After having a chat with @FernetMenta we decided that `ADDON_SRC_PREFIX` has to be an absolute path, because relative paths can easily break and you can search the issue for hours.

Furthermore I adapted the README to mention that we have to use absolute paths in the future.

Hopefully this will keep it simple and stop confusing our devs with relative paths. But we have to adapt our Travis CI and AppVeyor scripts.
