### PR TITLE
CompileWarnings: Fix some signed / unsigned vs unused variables

### DIFF
--- a/xbmc/ContextMenuManager.cpp
+++ b/xbmc/ContextMenuManager.cpp
@@ -174,11 +174,11 @@ bool CONTEXTMENU::ShowFor(const CFileItemPtr& fileItem, const CContextMenuItem& 
     return true;
 
   CContextButtons buttons;
-  for (int i = 0; i < menuItems.size(); ++i)
+  for (size_t i = 0; i < menuItems.size(); ++i)
     buttons.Add(i, menuItems[i]->GetLabel(*fileItem));
 
   int selected = CGUIDialogContextMenu::Show(buttons);
-  if (selected < 0 || selected >= menuItems.size())
+  if (selected < 0 || selected >= static_cast<int>(menuItems.size()))
     return false;
 
   return menuItems[selected]->IsGroup() ?

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
@@ -130,12 +130,11 @@ bool CGUIDialogPVRGuideInfo::OnClickButtonPlay(CGUIMessage &message)
   if (message.GetSenderId() == CONTROL_BTN_SWITCH || message.GetSenderId() == CONTROL_BTN_PLAY_RECORDING)
   {
     Close();
-    PlayBackRet ret = PLAYBACK_CANCELED;
 
     if (m_progItem)
     {
       if (message.GetSenderId() == CONTROL_BTN_PLAY_RECORDING && m_progItem->HasRecording())
-        ret = g_application.PlayFile(CFileItem(m_progItem->Recording()), "videoplayer");
+        g_application.PlayFile(CFileItem(m_progItem->Recording()), "videoplayer");
       else if (m_progItem->HasPVRChannel())
       {
         CPVRChannelPtr channel = m_progItem->ChannelTag();

--- a/xbmc/rendering/gl/RenderSystemGL.cpp
+++ b/xbmc/rendering/gl/RenderSystemGL.cpp
@@ -353,8 +353,7 @@ void CRenderSystemGL::CaptureStateBlock()
   glMatrixTexture.Push();
 
   glDisable(GL_SCISSOR_TEST); // fixes FBO corruption on Macs
-  if (glActiveTextureARB)
-    glActiveTextureARB(GL_TEXTURE0_ARB);
+  glActiveTextureARB(GL_TEXTURE0_ARB);
   glDisable(GL_TEXTURE_2D);
   glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE);
   glColor3f(1.0, 1.0, 1.0);
@@ -371,8 +370,7 @@ void CRenderSystemGL::ApplyStateBlock()
   glMatrixModview.PopLoad();
   glMatrixTexture.PopLoad();
 
-  if (glActiveTextureARB)
-    glActiveTextureARB(GL_TEXTURE0_ARB);
+  glActiveTextureARB(GL_TEXTURE0_ARB);
   glEnable(GL_TEXTURE_2D);
   glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE);
   glEnable(GL_BLEND);


### PR DESCRIPTION
Some stuff I saw (long hanging fruits) while checking for ffmpeg deprecated messages ..
