### PR TITLE
[android] Fixed PeripheralBusAndroid crashing

### DIFF
--- a/tools/android/packaging/xbmc/AndroidManifest.xml.in
+++ b/tools/android/packaging/xbmc/AndroidManifest.xml.in
@@ -5,7 +5,7 @@
     android:versionCode="@APP_VERSION_CODE@"
     android:versionName="@APP_VERSION@" >
 
-    <uses-sdk android:minSdkVersion="17" android:targetSdkVersion="22" />
+    <uses-sdk android:minSdkVersion="19" android:targetSdkVersion="22" />
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.INTERNET" />

--- a/xbmc/peripherals/bus/android/PeripheralBusAndroid.cpp
+++ b/xbmc/peripherals/bus/android/PeripheralBusAndroid.cpp
@@ -339,13 +339,14 @@ bool CPeripheralBusAndroid::GetDeviceId(const std::string& deviceLocation, int& 
 bool CPeripheralBusAndroid::ConvertToPeripheralScanResult(const CJNIViewInputDevice& inputDevice, PeripheralScanResult& peripheralScanResult)
 {
   int deviceId = inputDevice.getId();
+  int sources = inputDevice.getSources();
   std::string deviceName = inputDevice.getName();
   if (inputDevice.isVirtual())
   {
     CLog::Log(LOGDEBUG, "CPeripheralBusAndroid: ignoring virtual input device \"%s\" with ID %d", deviceName.c_str(), deviceId);
     return false;
   }
-  if (!inputDevice.supportsSource(CJNIViewInputDevice::SOURCE_JOYSTICK) && !inputDevice.supportsSource(CJNIViewInputDevice::SOURCE_GAMEPAD))
+  if (!((sources & inputDevice.SOURCE_GAMEPAD)==inputDevice.SOURCE_GAMEPAD) && !((sources & inputDevice.SOURCE_JOYSTICK)==inputDevice.SOURCE_JOYSTICK))
   {
     CLog::Log(LOGDEBUG, "CPeripheralBusAndroid: ignoring unknown input device \"%s\" with ID %d", deviceName.c_str(), deviceId);
     return false;


### PR DESCRIPTION
Fixed crashing on android devices with API Level 19 and higher.
Bumped minimum required android SDK to version 19. (due to usage of functions from API 19).
Modified functions from API 21 to API 19.
