### PR TITLE
DVD_NOPTS_VALUE: fix double representation

### DIFF
--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/libXBMC_pvr.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/libXBMC_pvr.h
@@ -37,7 +37,7 @@
 #define DVD_TIME_BASE 1000000
 
 //TODO original definition is in DVDClock.h
-#define DVD_NOPTS_VALUE 0xFFF0000000000000
+#define DVD_NOPTS_VALUE (int64_t) 0xFFF0000000000000
 
 class CHelper_libXBMC_pvr
 {

--- a/xbmc/cores/VideoPlayer/DVDClock.h
+++ b/xbmc/cores/VideoPlayer/DVDClock.h
@@ -24,7 +24,7 @@
 #include "threads/CriticalSection.h"
 
 #define DVD_TIME_BASE 1000000
-#define DVD_NOPTS_VALUE 0xFFF0000000000000 // should be possible to represent in both double and int64_t
+#define DVD_NOPTS_VALUE (int64_t) 0xFFF0000000000000 // should be possible to represent in both double and int64_t
 
 #define DVD_TIME_TO_SEC(x)  ((int)((double)(x) / DVD_TIME_BASE))
 #define DVD_TIME_TO_MSEC(x) ((int)((double)(x) * 1000 / DVD_TIME_BASE))


### PR DESCRIPTION
Thanks to @MrMc for the tipp.
