### PR TITLE
[android] Bumped min. SDK to 19, Fixed PeripherialBusAndroid crash

### DIFF
--- a/tools/android/packaging/xbmc/AndroidManifest.xml.in
+++ b/tools/android/packaging/xbmc/AndroidManifest.xml.in
@@ -5,7 +5,7 @@
     android:versionCode="@APP_VERSION_CODE@"
     android:versionName="@APP_VERSION@" >
 
-    <uses-sdk android:minSdkVersion="17" android:targetSdkVersion="22" />
+    <uses-sdk android:minSdkVersion="19" android:targetSdkVersion="22" />
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.INTERNET" />
@@ -21,7 +21,7 @@
     <uses-feature android:name="android.hardware.type.television" android:required="false" />
     <uses-feature android:name="android.hardware.usb.host" android:required="false" />
     <uses-feature android:name="android.hardware.wifi" android:required="false" />
-	
+
     <application android:icon="@drawable/ic_launcher"
 				android:logo="@drawable/banner"
 				android:label="@string/app_name"
@@ -96,4 +96,3 @@
     </application>
 
 </manifest><!-- END_INCLUDE(manifest) -->
-

--- a/xbmc/peripherals/bus/android/PeripheralBusAndroid.cpp
+++ b/xbmc/peripherals/bus/android/PeripheralBusAndroid.cpp
@@ -339,13 +339,15 @@ bool CPeripheralBusAndroid::GetDeviceId(const std::string& deviceLocation, int& 
 bool CPeripheralBusAndroid::ConvertToPeripheralScanResult(const CJNIViewInputDevice& inputDevice, PeripheralScanResult& peripheralScanResult)
 {
   int deviceId = inputDevice.getId();
+  int sources = inputDevice.getSources();
   std::string deviceName = inputDevice.getName();
   if (inputDevice.isVirtual())
   {
     CLog::Log(LOGDEBUG, "CPeripheralBusAndroid: ignoring virtual input device \"%s\" with ID %d", deviceName.c_str(), deviceId);
     return false;
   }
-  if (!inputDevice.supportsSource(CJNIViewInputDevice::SOURCE_JOYSTICK) && !inputDevice.supportsSource(CJNIViewInputDevice::SOURCE_GAMEPAD))
+  if ((sources & CJNIViewInputDevice::SOURCE_JOYSTICK) != CJNIViewInputDevice::SOURCE_JOYSTICK &&
+      (sources & CJNIViewInputDevice::SOURCE_GAMEPAD) != CJNIViewInputDevice::SOURCE_GAMEPAD)
   {
     CLog::Log(LOGDEBUG, "CPeripheralBusAndroid: ignoring unknown input device \"%s\" with ID %d", deviceName.c_str(), deviceId);
     return false;

--- a/xbmc/platform/android/jni/View.cpp
+++ b/xbmc/platform/android/jni/View.cpp
@@ -155,12 +155,14 @@ bool CJNIViewInputDevice::isVirtual() const
     "isVirtual", "()Z");
 }
 
+/* unavailable in API-19
 bool CJNIViewInputDevice::supportsSource(int source) const
 {
   return call_method<jboolean>(m_object,
     "supportsSource", "(I)Z",
     source);
 }
+*/
 
 const CJNIList<CJNIViewInputDeviceMotionRange> CJNIViewInputDevice::getMotionRanges() const
 {

--- a/xbmc/platform/android/jni/View.h
+++ b/xbmc/platform/android/jni/View.h
@@ -66,7 +66,7 @@ public:
   const CJNIOsVibrator getVibrator() const;
   bool         hasMicrophone() const;
   bool         isVirtual() const;
-  bool         supportsSource(int source) const;
+  //bool         supportsSource(int source) const; /* unavailable in API-19 */
 
   static void PopulateStaticFields();
   static int SOURCE_GAMEPAD;


### PR DESCRIPTION
- Bumped minimum required SDK from 17 to 19 (due to usage of some functions that are not available in lower levels)
- Fixed PeripherialBusAndroid crash on affected devices
- Changed used function from SDK 21 to one available in SDK 19
- Commented functions/methods unavailable in SDK 19
