### PR TITLE
VideoPlayer: fix counting dropped frames

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -582,7 +582,7 @@ int CDVDVideoCodecFFmpeg::Decode(uint8_t* pData, int iSize, double dts, double p
 
   if (!iGotPicture)
   {
-    if (pData)
+    if (pData && m_pCodecContext->skip_frame > AVDISCARD_DEFAULT)
     {
       m_droppedFrames++;
       if (m_interlaced)


### PR DESCRIPTION
@popcornmix this is still not 100% correct. For many interlaced material we have separate packets for fields. Means that 2 fields go in for one picture coming out. Do you have an idea?
