### PR TITLE
[jenkins/android] - fix hash calculation

### DIFF
--- a/tools/buildsteps/README
+++ b/tools/buildsteps/README
@@ -11,6 +11,5 @@ $XBMC_DEPENDS_ROOT - root for installing the xbmc build depends and toolchain he
 Additional ENV variables might be specified by the buildnodes. For android buildslaves these are:
 
 TOOLCHAIN - the used toolchain dir
-TOOLCHAIN_X86 - this is the toolchain dir for x86 toolchain of android. This needs this extra var for beeing able to specify both toolchains (arm & x86) at the same slave.
 NDK_PATH  - the path to the android native ndk
 SDK_PATH  - the path to the android sdk

--- a/tools/buildsteps/android/configure-depends
+++ b/tools/buildsteps/android/configure-depends
@@ -4,8 +4,8 @@ XBMC_PLATFORM_DIR=android
 
 NDK_ARCH="arm"
 #the following pathes must exist on the slave and use the defined scheme here!
-CURRENT_NDK_PATH=$ANDROID_DEV_ROOT/android-ndk-r$NDK_VERSION
-CURRENT_TOOLCHAIN=$ANDROID_DEV_ROOT/android-toolchain-$NDK_ARCH-$SDK_VERSION-r$NDK_VERSION
+NDK_PATH=$ANDROID_DEV_ROOT/android-ndk-r$NDK_VERSION
+TOOLCHAIN=$ANDROID_DEV_ROOT/android-toolchain-$NDK_ARCH-$SDK_VERSION-r$NDK_VERSION
 
 if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
 then
@@ -13,9 +13,9 @@ then
     --with-tarballs=$TARBALLS \
     --host=arm-linux-androideabi \
     --with-sdk-path=$SDK_PATH \
-    --with-ndk=$CURRENT_NDK_PATH \
+    --with-ndk=$NDK_PATH \
     $(if [ "$SDK_VERSION" != "Default" ]; then echo --with-sdk=android-$SDK_VERSION;fi) \
-    --with-toolchain=$CURRENT_TOOLCHAIN \
+    --with-toolchain=$TOOLCHAIN \
     --prefix=$XBMC_DEPENDS_ROOT \
     --enable-neon
 fi

--- a/tools/buildsteps/androidx86/configure-depends
+++ b/tools/buildsteps/androidx86/configure-depends
@@ -4,8 +4,8 @@ XBMC_PLATFORM_DIR=android
 
 NDK_ARCH=x86
 #the following pathes must exist on the slave and use the defined scheme here!
-CURRENT_NDK_PATH=$ANDROID_DEV_ROOT/android-ndk-r$NDK_VERSION
-CURRENT_TOOLCHAIN=$ANDROID_DEV_ROOT/android-toolchain-$NDK_ARCH-$SDK_VERSION-r$NDK_VERSION
+NDK_PATH=$ANDROID_DEV_ROOT/android-ndk-r$NDK_VERSION
+TOOLCHAIN=$ANDROID_DEV_ROOT/android-toolchain-$NDK_ARCH-$SDK_VERSION-r$NDK_VERSION
 
 if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
 then
@@ -13,8 +13,8 @@ then
     --with-tarballs=$TARBALLS \
     --host=i686-linux-android \
     --with-sdk-path=$SDK_PATH \
-    --with-ndk=$CURRENT_NDK_PATH \
+    --with-ndk=$NDK_PATH \
     $(if [ "$SDK_VERSION" != "Default" ]; then echo --with-sdk=android-$SDK_VERSION;fi) \
-    --with-toolchain=$CURRENT_TOOLCHAIN \
+    --with-toolchain=$TOOLCHAIN \
     --prefix=$XBMC_DEPENDS_ROOT
 fi

--- a/tools/buildsteps/defaultenv
+++ b/tools/buildsteps/defaultenv
@@ -75,7 +75,7 @@ fi
 
 #helper functions
 
-#hash a dir based on the git revision, SDK_PATH, NDK_PATH, NDK_VERSION, SDK_VERSION, TOOLCHAIN TOOLCHAIN_X86 (for droidx86) and XBMC_DEPENDS_ROOT
+#hash a dir based on the git revision, SDK_PATH, NDK_PATH, NDK_VERSION, SDK_VERSION, TOOLCHAIN and XBMC_DEPENDS_ROOT
 #param1 path to be hashed
 function getBuildHash ()
 {
@@ -83,7 +83,7 @@ function getBuildHash ()
   checkPath="$1"
   local hashStr
   hashStr="$(git rev-list HEAD --max-count=1  -- $checkPath)"
-  hashStr="$hashStr $SDK_PATH $NDK_PATH $NDK_VERSION $SDK_VERSION $TOOLCHAIN $TOOLCHAIN_X86 $XBMC_DEPENDS_ROOT"
+  hashStr="$hashStr $SDK_PATH $NDK_PATH $NDK_VERSION $SDK_VERSION $TOOLCHAIN $XBMC_DEPENDS_ROOT"
   echo $hashStr
 }
 


### PR DESCRIPTION
This fix some stail variables which were defined in the jenkins node before but since a while we build the ndk and toolchain path based on the NDK_VERSION and SDK_VERSION dynamically.

This fixes hash calculation for the depends build (which needs to be rebuilt by jenkins if either sdk or ndk version changes), by obeying the dynamic variables here instead of the stale ones from the jenkins node (which i've removed now ...)
