### PR TITLE
[pvr] delay initial check for enabled addons

### DIFF
--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -404,7 +404,9 @@ void CPVRManager::Init()
   settingSet.insert(CSettings::SETTING_PVRPARENTAL_ENABLED);
   CSettings::GetInstance().RegisterCallback(this, settingSet);
 
-  m_addons->Start();
+  // initial check for enabled addons
+  // if at least one pvr addon is enabled, PVRManager start up
+  CJobManager::GetInstance().AddJob(new CPVRStartupJob(), nullptr);
 }
 
 void CPVRManager::Start()
@@ -988,6 +990,12 @@ CPVRChannelGroupPtr CPVRManager::GetPlayingGroup(bool bRadio /* = false */)
     return m_channelGroups->GetSelectedGroup(bRadio);
 
   return CPVRChannelGroupPtr();
+}
+
+bool CPVRStartupJob::DoWork(void)
+{
+  g_PVRClients->Start();
+  return true;
 }
 
 bool CPVREpgsCreateJob::DoWork(void)

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -687,6 +687,16 @@ private:
     static const int                m_pvrWindowIds[12];
   };
 
+  class CPVRStartupJob : public CJob
+  {
+  public:
+    CPVRStartupJob(void) {}
+    virtual ~CPVRStartupJob() {}
+    virtual const char *GetType() const { return "pvr-startup"; }
+
+    virtual bool DoWork();
+  };
+
   class CPVREpgsCreateJob : public CJob
   {
   public:


### PR DESCRIPTION
make PVR not blocking system startup
@tamland here we go
@ksooo should not change anything in normal operational behaviour
