### PR TITLE
[cmake] Add cmake parameter to BuildSetup.bat

### DIFF
--- a/project/cmake/CMakeLists.txt
+++ b/project/cmake/CMakeLists.txt
@@ -57,6 +57,9 @@ endif()
 get_filename_component(CORE_SOURCE_DIR ${PROJECT_SOURCE_DIR}/../.. ABSOLUTE)
 set(CORE_BUILD_DIR build)
 
+message(STATUS "Source directory: ${CORE_SOURCE_DIR}")
+message(STATUS "Build directory: ${CMAKE_BINARY_DIR}")
+
 include(scripts/common/generatorsetup.cmake)
 include(scripts/common/addoptions.cmake)
 include(scripts/common/archsetup.cmake)

--- a/project/cmake/README.md
+++ b/project/cmake/README.md
@@ -8,7 +8,7 @@ executable (but no packaging or dependency management yet) for the following
 platforms:
 
 - Linux (GNU Makefiles)
-- Windows (NMake Makefiles, Visual Studio 12 (2013))
+- Windows (NMake Makefiles, Visual Studio 14 (2015))
 - OSX (GNU Makefiles, Xcode)
 - Android (GNU Makefiles)
 
@@ -107,7 +107,7 @@ kodi.exe
 ### Windows with Visual Studio project files
 
 ```
-cmake -G "Visual Studio 12" <KODI_SRC>/project/cmake/
+cmake -G "Visual Studio 14" <KODI_SRC>/project/cmake/
 cmake --build . --config "Debug"  # or: Build solution with Visual Studio
 set KODI_HOME="%CD%" && Debug\kodi.exe
 ```

--- a/project/cmake/modules/FindD3DX11Effects.cmake
+++ b/project/cmake/modules/FindD3DX11Effects.cmake
@@ -10,7 +10,7 @@ ExternalProject_Add(d3dx11effects
             SOURCE_DIR ${CORE_SOURCE_DIR}/lib/win32/Effects11
             PREFIX ${CORE_BUILD_DIR}/Effects11
             CONFIGURE_COMMAND ""
-            BUILD_COMMAND msbuild ${CORE_SOURCE_DIR}/lib/win32/Effects11/Effects11_2015.sln
+            BUILD_COMMAND msbuild ${CORE_SOURCE_DIR}/lib/win32/Effects11/Effects11_2013.sln
                                   /t:Effects11 /p:Configuration=${CORE_BUILD_CONFIG}
             INSTALL_COMMAND "")
 

--- a/project/cmake/scripts/windows/macros.cmake
+++ b/project/cmake/scripts/windows/macros.cmake
@@ -87,11 +87,13 @@ function(add_precompiled_header target pch_header pch_source)
     # As own target for usage in multiple libraries
     if(NOT TARGET ${PCH_PCH_TARGET}_pch)
       add_library(${PCH_PCH_TARGET}_pch STATIC ${pch_source})
-      set_target_properties(${PCH_PCH_TARGET}_pch PROPERTIES COMPILE_PDB_OUTPUT_DIRECTORY ${PRECOMPILEDHEADER_DIR})
+      set_target_properties(${PCH_PCH_TARGET}_pch PROPERTIES COMPILE_PDB_NAME vc140
+                                                             COMPILE_PDB_OUTPUT_DIRECTORY ${PRECOMPILEDHEADER_DIR})
     endif()
     # From VS2012 onwards, precompiled headers have to be linked against (LNK2011).
     target_link_libraries(${target} PUBLIC ${PCH_PCH_TARGET}_pch)
-    set_target_properties(${target} PROPERTIES COMPILE_PDB_OUTPUT_DIRECTORY ${PRECOMPILEDHEADER_DIR})
+    set_target_properties(${target} PROPERTIES COMPILE_PDB_NAME vc140
+                                               COMPILE_PDB_OUTPUT_DIRECTORY ${PRECOMPILEDHEADER_DIR})
   else()
     # As part of the target
     target_sources(${target} PRIVATE ${pch_source})


### PR DESCRIPTION
First attempt to integrate cmake into the BuildSetup.bat script. This is not perfect as the packaging only takes the main executable from the cmake build and nothing more. Still good enough for the beginning to verify the build on Jenkins.

Would be happy to get some reviews from people that know batch scripting.
@paxxi, @Montellese, @ace20022 maybe
