### PR TITLE
[Peripherals] m_bNeedsPolling broken for busses where it is set outsi…

### DIFF
--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -115,10 +115,7 @@ void CPeripherals::Initialise()
 
     /* initialise all known busses and run an initial scan for devices */
     for (auto& bus : m_busses)
-    {
       bus->Initialise();
-      bus->TriggerDeviceScan();
-    }
   }
 
   m_eventScanner.Start();

--- a/xbmc/peripherals/bus/PeripheralBus.cpp
+++ b/xbmc/peripherals/bus/PeripheralBus.cpp
@@ -214,6 +214,13 @@ void CPeripheralBus::Process(void)
     if (!ScanForDevices())
       break;
 
+    // depending on bus implementation
+    // needsPolling can be set properly
+    // only after unitial scan.
+    // if this is the case, bail out.
+    if (!m_bNeedsPolling)
+      break;
+
     if (!m_bStop)
       m_triggerEvent.WaitMSec(m_iRescanTime);
   }


### PR DESCRIPTION
…de constructor

@Montellese 
commit https://github.com/xbmc/xbmc/commit/cb9cb00793537259d166e390f4e05d45fb069ef6 is introducing this issue for bus types where m_bNeedsPolling is initially set only after initial device scan - based on search results (for instance CEC).
