### PR TITLE
[gui] fix bug when opening playlists with smartplaylisteditor several times

### DIFF
--- a/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
@@ -182,6 +182,11 @@ bool CGUIDialogSmartPlaylistEditor::OnMessage(CGUIMessage& message)
       }
     }
     break;
+    case GUI_MSG_WINDOW_DEINIT:
+    {
+      m_playlist.Reset();
+    }
+    break;
   }
   return CGUIDialog::OnMessage(message);
 }


### PR DESCRIPTION
Example: call

```
ActivateWindow(smartplaylisteditor,special://skin/playlists/inprogress_movies.xsp)
```

several times and you will notice that the rule list gets longer and longer because the previous rules were not cleared.
@Montellese for guidance please, not sure what the best place is to do the .Reset()
