### PR TITLE
[win32][fix] vector iterator not incrementable

### DIFF
--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -817,14 +817,9 @@ void CGUIWindowManager::CloseDialogs(bool forceClose) const
 {
   CSingleLock lock(g_graphicsContext);
 
-  //This is to avoid an assert about out of bounds iterator
-  //when m_activeDialogs happens to be empty
-  if (m_activeDialogs.empty())
-    return;
-
-  for (const auto& dialog : m_activeDialogs)
+  while (!m_activeDialogs.empty())
   {
-    dialog->Close(forceClose);
+    m_activeDialogs[0]->Close(forceClose);
   }
 }
 
@@ -834,10 +829,12 @@ void CGUIWindowManager::CloseInternalModalDialogs(bool forceClose) const
   if (m_activeDialogs.empty())
     return;
 
-  for (const auto& dialog : m_activeDialogs)
+  for (size_t i = 0; i < m_activeDialogs.size();)
   {
-    if (dialog->IsModalDialog() && !IsAddonWindow(dialog->GetID()) && !IsPythonWindow(dialog->GetID()))
-      dialog->Close(forceClose);
+    if (m_activeDialogs[i]->IsModalDialog() && !IsAddonWindow(m_activeDialogs[i]->GetID()) && !IsPythonWindow(m_activeDialogs[i]->GetID()))
+      m_activeDialogs[i]->Close(forceClose);
+    else
+      ++i;
   }
 }
 


### PR DESCRIPTION
I found one of the problem that probably in the next days will come out since now the _ITERATOR_DEBUG_LEVEL is set to 2

after stopped a video  there is a Debug message  "vector iterator not incrementable" 

this because in CGUIWindowManager::CloseInternalModalDialogs and CGUIWindowManager::CloseDialogs

is called dialog->close() that ends with an erased element of m_activeDialogs (or more) by calling CGUIWindowManager::RemoveDialog 

that should not be done while iterating

usually we can use the item that return from .erase() but in this case i think that it's too complicated return the item through  alot of methods

so this is my solution

@Paxxi 
