### PR TITLE
Format numbers with localized separators

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -11577,7 +11577,7 @@ msgstr ""
 #. Label for showing media rating and votes (combined), for example: "9.1 (87 votes)"
 #: xbmc/GUIInfoManager.cpp
 msgctxt "#20350"
-msgid "%.1f (%i votes)"
+msgid "%s (%s votes)"
 msgstr ""
 
 #: xbmc/video/jobs/VideoLibraryRefreshingJob.cpp

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -8377,12 +8377,10 @@ std::string CGUIInfoManager::GetMusicTagLabel(int info, const CFileItem *item)
     if (m_currentFile->GetMusicInfoTag()->GetRating() > 0.f)
     {
       if (m_currentFile->GetMusicInfoTag()->GetRating() > 0)
-        strRatingAndVotes = StringUtils::Format("%.1f",
-          m_currentFile->GetMusicInfoTag()->GetRating());
+        strRatingAndVotes = StringUtils::FormatNumber(m_currentFile->GetMusicInfoTag()->GetRating());
       else
-        strRatingAndVotes = StringUtils::Format(g_localizeStrings.Get(20350).c_str(),
-          m_currentFile->GetMusicInfoTag()->GetRating(),
-          m_currentFile->GetMusicInfoTag()->GetVotes());
+        strRatingAndVotes = FormatRatingAndVotes(m_currentFile->GetMusicInfoTag()->GetRating(),
+                                                 m_currentFile->GetMusicInfoTag()->GetVotes());
     }
     return strRatingAndVotes;
   }
@@ -8607,7 +8605,7 @@ std::string CGUIInfoManager::GetVideoLabel(int item)
         std::string strRating;
         float rating = m_currentFile->GetVideoInfoTag()->GetRating().rating;
         if (rating > 0.f)
-          strRating = StringUtils::Format("%.1f", rating);
+          strRating = StringUtils::FormatNumber(rating);
         return strRating;
       }
       break;
@@ -8618,12 +8616,9 @@ std::string CGUIInfoManager::GetVideoLabel(int item)
         if (rating.rating > 0.f)
         {
           if (rating.votes == 0)
-            strRatingAndVotes = StringUtils::Format("%.1f",
-                                                    rating.rating);
+            strRatingAndVotes = StringUtils::FormatNumber(rating.rating);
           else
-            strRatingAndVotes = StringUtils::Format(g_localizeStrings.Get(20350).c_str(),
-                                                    rating.rating,
-                                                    rating.votes);
+            strRatingAndVotes = FormatRatingAndVotes(rating.rating, rating.votes);
         }
         return strRatingAndVotes;
       }
@@ -8636,8 +8631,7 @@ std::string CGUIInfoManager::GetVideoLabel(int item)
       return strUserRating;
     }
     case VIDEOPLAYER_VOTES:
-      return StringUtils::Format("%i",
-        m_currentFile->GetVideoInfoTag()->GetRating().votes);
+      return StringUtils::FormatNumber(m_currentFile->GetVideoInfoTag()->GetRating().votes);
     case VIDEOPLAYER_YEAR:
       {
         std::string strYear;
@@ -9210,13 +9204,13 @@ std::string CGUIInfoManager::GetItemLabel(const CFileItem *item, int info, std::
   if (info >= LISTITEM_PROPERTY_START + LISTITEM_RATING_OFFSET && info - (LISTITEM_PROPERTY_START + LISTITEM_RATING_OFFSET) < (int)m_listitemProperties.size())
   { // grab the rating
     std::string rating = m_listitemProperties[info - (LISTITEM_PROPERTY_START + LISTITEM_RATING_OFFSET)];
-    return StringUtils::Format("%.1f", item->GetVideoInfoTag()->GetRating(rating).rating);
+    return StringUtils::FormatNumber(item->GetVideoInfoTag()->GetRating(rating).rating);
   }
 
   if (info >= LISTITEM_PROPERTY_START + LISTITEM_VOTES_OFFSET && info - (LISTITEM_PROPERTY_START + LISTITEM_VOTES_OFFSET) < (int)m_listitemProperties.size())
   { // grab the votes
     std::string votes = m_listitemProperties[info - (LISTITEM_PROPERTY_START + LISTITEM_VOTES_OFFSET)];
-    return StringUtils::Format("%i", item->GetVideoInfoTag()->GetRating(votes).votes);
+    return StringUtils::FormatNumber(item->GetVideoInfoTag()->GetRating(votes).votes);
   }
 
   if (info >= LISTITEM_PROPERTY_START + LISTITEM_RATING_AND_VOTES_OFFSET && info - (LISTITEM_PROPERTY_START + LISTITEM_RATING_AND_VOTES_OFFSET) < (int)m_listitemProperties.size())
@@ -9228,9 +9222,9 @@ std::string CGUIInfoManager::GetItemLabel(const CFileItem *item, int info, std::
       return "";
     
     if (rating.votes == 0)
-      return StringUtils::Format("%.1f", rating.rating);
+      return StringUtils::FormatNumber(rating.rating);
     else
-      return StringUtils::Format(g_localizeStrings.Get(20350).c_str(), rating.rating, rating.votes);
+      return FormatRatingAndVotes(rating.rating, rating.votes);
   }
 
   if (info >= LISTITEM_PROPERTY_START && info - LISTITEM_PROPERTY_START < (int)m_listitemProperties.size())
@@ -9484,9 +9478,9 @@ std::string CGUIInfoManager::GetItemLabel(const CFileItem *item, int info, std::
       if (item->HasVideoInfoTag()) // movie rating
         r = item->GetVideoInfoTag()->GetRating().rating;
       if (r > 0.f)
-        rating = StringUtils::Format("%.1f", r);
+        rating = StringUtils::FormatNumber(r);
       else if (item->HasMusicInfoTag() && item->GetMusicInfoTag()->GetRating() > 0.f) // song rating
-        rating = StringUtils::Format("%.1f", item->GetMusicInfoTag()->GetRating());
+        rating = StringUtils::FormatNumber(item->GetMusicInfoTag()->GetRating());
       return rating;
     }
   case LISTITEM_RATING_AND_VOTES:
@@ -9498,23 +9492,19 @@ std::string CGUIInfoManager::GetItemLabel(const CFileItem *item, int info, std::
       {
         std::string strRatingAndVotes;
         if (r.votes == 0)
-          strRatingAndVotes = StringUtils::Format("%.1f",
-                                                  r.rating);
+          strRatingAndVotes = StringUtils::FormatNumber(r.rating);
         else
-          strRatingAndVotes = StringUtils::Format(g_localizeStrings.Get(20350).c_str(),
-                                                  r.rating,
-                                                  r.votes);
+          strRatingAndVotes = FormatRatingAndVotes(r.rating, r.votes);
         return strRatingAndVotes;
       }
       else if (item->HasMusicInfoTag() && item->GetMusicInfoTag()->GetRating() > 0.f) // music rating & votes
       {
         std::string strRatingAndVotes;
         if (item->GetMusicInfoTag()->GetVotes() <= 0)
-          strRatingAndVotes = StringUtils::Format("%.1f", item->GetMusicInfoTag()->GetRating());
+          strRatingAndVotes = StringUtils::FormatNumber(item->GetMusicInfoTag()->GetRating());
         else
-          strRatingAndVotes = StringUtils::Format(g_localizeStrings.Get(20350).c_str(),
-            item->GetMusicInfoTag()->GetRating(),
-            item->GetMusicInfoTag()->GetVotes());
+          strRatingAndVotes = FormatRatingAndVotes(item->GetMusicInfoTag()->GetRating(), 
+                                                   item->GetMusicInfoTag()->GetVotes());
         return strRatingAndVotes;
       }
     }
@@ -9531,10 +9521,9 @@ std::string CGUIInfoManager::GetItemLabel(const CFileItem *item, int info, std::
     break;
   case LISTITEM_VOTES:
     if (item->HasVideoInfoTag())
-      return StringUtils::Format("%i",
-                                 item->GetVideoInfoTag()->GetRating().votes);
+      return StringUtils::FormatNumber(item->GetVideoInfoTag()->GetRating().votes);
     else if (item->HasMusicInfoTag())
-      return StringUtils::Format("%i", item->GetMusicInfoTag()->GetVotes());
+      return StringUtils::FormatNumber(item->GetMusicInfoTag()->GetVotes());
     break;
   case LISTITEM_PROGRAM_COUNT:
     {
@@ -10760,4 +10749,11 @@ void CGUIInfoManager::OnApplicationMessage(KODI::MESSAGING::ThreadMessage* pMsg)
   default:
     break;
   }
+}
+
+std::string CGUIInfoManager::FormatRatingAndVotes(float rating, int votes)
+{
+  return StringUtils::Format(g_localizeStrings.Get(20350).c_str(),
+                             StringUtils::FormatNumber(rating).c_str(),
+                             StringUtils::FormatNumber(votes).c_str());
 }

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -353,6 +353,9 @@ protected:
   SPlayerAudioStreamInfo m_audioInfo;
 
   CCriticalSection m_critInfo;
+
+private:
+  static std::string FormatRatingAndVotes(float rating, int votes);
 };
 
 /*!

--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -20,6 +20,7 @@
 
 #include "LangInfo.h"
 
+#include <stdexcept>
 #include <algorithm>
 
 #include "addons/AddonInstaller.h"
@@ -273,6 +274,16 @@ void CLangInfo::CRegion::SetGlobalLocale()
 #ifdef TARGET_POSIX
     strLocale += ".UTF-8";
 #endif
+  }
+
+  try
+  {
+    g_langInfo.m_originalLocale = std::locale(strLocale.c_str());
+  }
+  catch (std::runtime_error) 
+  {
+    CLog::Log(LOGERROR, "failed to set m_originalLocale to %s", strLocale.c_str());
+    g_langInfo.m_originalLocale = std::locale("");
   }
 
   CLog::Log(LOGDEBUG, "trying to set locale to %s", strLocale.c_str());
@@ -814,6 +825,11 @@ const CLocale& CLangInfo::GetLocale() const
 const std::string& CLangInfo::GetRegionLocale() const
 {
   return m_currentRegion->m_strRegionLocaleName;
+}
+
+const std::locale& CLangInfo::GetOriginalLocale() const
+{
+  return m_originalLocale;
 }
 
 // Returns the format string for the date of the current language

--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -256,8 +256,6 @@ void CLangInfo::CRegion::SetTimeZone(const std::string& strTimeZone)
   m_strTimeZone = strTimeZone;
 }
 
-// set the locale associated with this region global. This affects string
-// sorting & transformations
 void CLangInfo::CRegion::SetGlobalLocale()
 {
   std::string strLocale;

--- a/xbmc/LangInfo.h
+++ b/xbmc/LangInfo.h
@@ -216,6 +216,12 @@ protected:
     void SetTemperatureUnit(const std::string& strUnit);
     void SetSpeedUnit(const std::string& strUnit);
     void SetTimeZone(const std::string& strTimeZone);
+
+    /*! \brief Set the locale associated with this region global.
+
+    Set the locale associated with this region global. This affects string
+    sorting & transformations.
+    */
     void SetGlobalLocale();
     std::string m_strLangLocaleName;
     std::string m_strLangLocaleCodeTwoChar;

--- a/xbmc/LangInfo.h
+++ b/xbmc/LangInfo.h
@@ -130,6 +130,8 @@ public:
 
   const std::string& GetRegionLocale() const;
 
+  const std::locale& GetOriginalLocale() const;
+
   /*!
   \brief Returns the full locale of the current language.
   */
@@ -237,6 +239,7 @@ protected:
   CRegion* m_currentRegion; // points to the current region
   CRegion m_defaultRegion; // default, will be used if no region available via langinfo.xml
   std::locale m_systemLocale;     // current locale, matching GUI settings
+  std::locale m_originalLocale; // original locale, without changes of collate
 
   LanguageResourcePtr m_languageAddon;
 

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -37,13 +37,10 @@
 #endif
 #include "utils/fstrcmp.h"
 #include "Util.h"
-#include "LangInfo.h"
-#include <locale>
 #include <functional>
 
 #include <assert.h>
 #include <math.h>
-#include <sstream>
 #include <time.h>
 #include <stdlib.h>
 #include <string.h>

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -33,7 +33,10 @@
 #include <stdint.h>
 #include <string>
 #include <vector>
+#include <sstream>
+#include <locale>
 
+#include "LangInfo.h"
 #include "XBDateTime.h"
 #include "utils/params_check_macros.h"
 
@@ -173,6 +176,24 @@ public:
   static double CompareFuzzy(const std::string &left, const std::string &right);
   static int FindBestMatch(const std::string &str, const std::vector<std::string> &strings, double &matchscore);
   static bool ContainsKeyword(const std::string &str, const std::vector<std::string> &keywords);
+
+  /*! \brief Format the string with locale separators.
+
+  Format the string with locale separators.
+  For example 10000.57 in en-us is '10,000.57' but in italian is '10.000,57'
+
+  \param param String to format
+  \return Formatted string
+  */
+  template<typename T>
+  static std::string FormatNumber(T num)
+  {
+    std::stringstream ss;
+    ss.imbue(g_langInfo.GetOriginalLocale());
+    ss.precision(1);
+    ss << std::fixed << num;
+    return ss.str();
+  }
 
   /*! \brief Escapes the given string to be able to be used as a parameter.
 


### PR DESCRIPTION
With this change the number of votes string will use localized separators (for example '10,000 in english, '10.000' in italian)
