### PR TITLE
small syntax typo

### DIFF
--- a/tools/darwin/Support/Codesign.command
+++ b/tools/darwin/Support/Codesign.command
@@ -41,12 +41,12 @@ if [ "${PLATFORM_NAME}" == "iphoneos" ] || [ "${PLATFORM_NAME}" == "appletvos" ]
   
   #if user has set a code_sign_identity different from iPhone Developer we do a real codesign (for deployment on non-jailbroken devices)
   if ! [ -z "${CODE_SIGN_IDENTITY}" ] && [ "${CODE_SIGN_IDENTITY}" == "iPhone Developer" ] && [ "${CODE_SIGN_IDENTITY}" != "Don't Code Sign"  ]; then
-    echo Doing a full bundle sign using genuine identity "${CODE_SIGN_IDENTITY}"
+    echo "Doing a full bundle sign using genuine identity ${CODE_SIGN_IDENTITY}"
     for binext in $LIST_BINARY_EXTENSIONS
     do
       codesign --deep -fvvv -s "${CODE_SIGN_IDENTITY_FOR_ITEMS}" -i "${BUNDLEID}" `find ${CODESIGNING_FOLDER_PATH} -name "*.$binext" -type f` ${CODESIGNING_FOLDER_PATH}
     done
-    echo In case your app crashes with SIG_SIGN check the variable LIST_BINARY_EXTENSIONS in tools/darwin/Support/Codesign.command
+    echo "In case your app crashes with SIG_SIGN check the variable LIST_BINARY_EXTENSIONS in tools/darwin/Support/Codesign.command"
 
     #repackage python eggs
     EGGS=`find ${CODESIGNING_FOLDER_PATH} -name "*.egg" -type f`


### PR DESCRIPTION
syntax highlight will highlight "in" and "case"...
And quotes can be helpful sometimes in situations like this:

```
for i in $something; do
    echo almost done
done
```

this can cause a bug on some systems
