### PR TITLE
[cmake] Fix passing CMAKE_BUILD_TYPE in FindFFMPEG

### DIFF
--- a/project/cmake/modules/FindFFMPEG.cmake
+++ b/project/cmake/modules/FindFFMPEG.cmake
@@ -31,7 +31,7 @@ if(ENABLE_INTERNAL_FFMPEG)
                       URL ${FFMPEG_BASE_URL}/${FFMPEG_VER}.tar.gz
                       PREFIX ${CORE_BUILD_DIR}/ffmpeg
                       CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}
-                                 -DCMAKE_BUILD_TYPE=${DCMAKE_BUILD_TYPE}
+                                 -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
                                  -DFFMPEG_VER=${FFMPEG_VER}
                                  -DCORE_SYSTEM_NAME=${CORE_SYSTEM_NAME}
                                  ${CROSS_ARGS}


### PR DESCRIPTION
Small c&p error: Thanks @AlwinEsch for pointing that out.
