### PR TITLE
[utils] CMime: make parseMimeType() private

### DIFF
--- a/xbmc/utils/Mime.h
+++ b/xbmc/utils/Mime.h
@@ -49,8 +49,9 @@ public:
   };
   static EFileType GetFileTypeFromMime(const std::string& mimeType);
   static EFileType GetFileTypeFromContent(const std::string& fileContent);
-  static bool parseMimeType(const std::string& mimeType, std::string& type, std::string& subtype);
 
 private:
+  static bool parseMimeType(const std::string& mimeType, std::string& type, std::string& subtype);
+
   static std::map<std::string, std::string> m_mimetypes;
 };


### PR DESCRIPTION
Came across this while looking into another issue. The method should have never been public.
