### PR TITLE
[win32] fix unit test environment

### DIFF
--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -134,7 +134,7 @@
       <IgnoreSpecificDefaultLibraries>libc;msvcrt;libcmt;msvcrtd;msvcprtd;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
       <ModuleDefinitionFile>
       </ModuleDefinitionFile>
-      <DelayLoadDLLs>libxslt.dll;dnssd.dll;dwmapi.dll;ssh.dll;sqlite3.dll;avcodec-57.dll;avfilter-6.dll;avformat-57.dll;avutil-55.dll;postproc-54.dll;swresample-2.dll;swscale-4.dll;d3dcompiler_47.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
+      <DelayLoadDLLs>zlib.dll;libmysql.dll;libxslt.dll;dnssd.dll;dwmapi.dll;ssh.dll;sqlite3.dll;avcodec-57.dll;avfilter-6.dll;avformat-57.dll;avutil-55.dll;postproc-54.dll;swresample-2.dll;swscale-4.dll;d3dcompiler_47.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
       <ProgramDatabaseFile>$(OutDir)$(ProjectName).pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
       <EntryPointSymbol>

--- a/xbmc/test/TestBasicEnvironment.cpp
+++ b/xbmc/test/TestBasicEnvironment.cpp
@@ -69,9 +69,6 @@ void TestBasicEnvironment::SetUp()
   g_powerManager.Initialize();
   CSettings::GetInstance().Initialize();
 
-  if (!g_application.m_ServiceManager->Init2())
-    exit(1);
-
   /* Create a temporary directory and set it to be used throughout the
    * test suite run.
    */
@@ -95,6 +92,9 @@ void TestBasicEnvironment::SetUp()
     SetUpError();
   CSpecialProtocol::SetTempPath(tmp);
 #endif
+
+  if (!g_application.m_ServiceManager->Init2())
+	  exit(1);
 
   /* Create and delete a tempfile to initialize the VFS (really to initialize
    * CLibcdio). This is done so that the initialization of the VFS does not


### PR DESCRIPTION
This fixes the unit test environment for win32. Right now it crashes on startup because it can't find `libmysql.dll` which is fixed in the first commit. Then it silently crashes because it can't resolve `special://temp/` because through `CServiceManager::Init2()` we try to load `cpluff.dll` before properly initializing `CSpecialProtocol`.
