### PR TITLE
[network] improvements to the webserver implementation

### DIFF
--- a/Kodi.xcodeproj/project.pbxproj
+++ b/Kodi.xcodeproj/project.pbxproj
@@ -139,6 +139,8 @@
 		228FA65E1C53F9D50023BBF0 /* InfoScanner.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 228FA65C1C53F9D50023BBF0 /* InfoScanner.cpp */; };
 		2A7B2BDC1BD6F16600044BCD /* PVRSettings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2A7B2BDB1BD6F16600044BCD /* PVRSettings.cpp */; };
 		2A7B2BDD1BD6F16600044BCD /* PVRSettings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2A7B2BDB1BD6F16600044BCD /* PVRSettings.cpp */; };
+		2AB491701CDDF1920004C263 /* HTTPRequestHandlerUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2AB4916E1CDDF1920004C263 /* HTTPRequestHandlerUtils.cpp */; };
+		2AB491711CDDF1920004C263 /* HTTPRequestHandlerUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2AB4916E1CDDF1920004C263 /* HTTPRequestHandlerUtils.cpp */; };
 		2AC7EB5A1C21F6BA00BDAA95 /* GUIWindowPVRTimerRules.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2AC7EB561C21F6BA00BDAA95 /* GUIWindowPVRTimerRules.cpp */; };
 		2AC7EB5B1C21F6BA00BDAA95 /* GUIWindowPVRTimersBase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2AC7EB581C21F6BA00BDAA95 /* GUIWindowPVRTimersBase.cpp */; };
 		2AC7EB5C1C2330B300BDAA95 /* GUIWindowPVRTimerRules.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2AC7EB561C21F6BA00BDAA95 /* GUIWindowPVRTimerRules.cpp */; };
@@ -2580,6 +2582,8 @@
 		228FA65C1C53F9D50023BBF0 /* InfoScanner.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = InfoScanner.cpp; sourceTree = "<group>"; };
 		2A7B2BDB1BD6F16600044BCD /* PVRSettings.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PVRSettings.cpp; sourceTree = "<group>"; };
 		2A7B2BDE1BD6F18B00044BCD /* PVRSettings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PVRSettings.h; sourceTree = "<group>"; };
+		2AB4916E1CDDF1920004C263 /* HTTPRequestHandlerUtils.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = HTTPRequestHandlerUtils.cpp; sourceTree = "<group>"; };
+		2AB4916F1CDDF1920004C263 /* HTTPRequestHandlerUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HTTPRequestHandlerUtils.h; sourceTree = "<group>"; };
 		2AC7EB561C21F6BA00BDAA95 /* GUIWindowPVRTimerRules.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GUIWindowPVRTimerRules.cpp; sourceTree = "<group>"; };
 		2AC7EB571C21F6BA00BDAA95 /* GUIWindowPVRTimerRules.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GUIWindowPVRTimerRules.h; sourceTree = "<group>"; };
 		2AC7EB581C21F6BA00BDAA95 /* GUIWindowPVRTimersBase.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GUIWindowPVRTimersBase.cpp; sourceTree = "<group>"; };
@@ -7482,6 +7486,8 @@
 				DFCA6ABC152245CD000BFAAE /* HTTPJsonRpcHandler.h */,
 				395C29E11A98A15700EBC7AD /* HTTPPythonHandler.cpp */,
 				395C29E21A98A15700EBC7AD /* HTTPPythonHandler.h */,
+				2AB4916E1CDDF1920004C263 /* HTTPRequestHandlerUtils.cpp */,
+				2AB4916F1CDDF1920004C263 /* HTTPRequestHandlerUtils.h */,
 				DFCA6ABD152245CD000BFAAE /* HTTPVfsHandler.cpp */,
 				DFCA6ABE152245CD000BFAAE /* HTTPVfsHandler.h */,
 				DFCA6ABF152245CD000BFAAE /* HTTPWebinterfaceAddonsHandler.cpp */,
@@ -10160,6 +10166,7 @@
 				18B7C7CD1294222E009E7A26 /* GUIListItemLayout.cpp in Sources */,
 				18B7C7CE1294222E009E7A26 /* GUIListLabel.cpp in Sources */,
 				18B7C7CF1294222E009E7A26 /* GUIMessage.cpp in Sources */,
+				2AB491701CDDF1920004C263 /* HTTPRequestHandlerUtils.cpp in Sources */,
 				18B7C7D01294222E009E7A26 /* GUIMoverControl.cpp in Sources */,
 				18B7C7D11294222E009E7A26 /* GUIMultiImage.cpp in Sources */,
 				18B7C7D21294222E009E7A26 /* GUIMultiSelectText.cpp in Sources */,
@@ -11321,6 +11328,7 @@
 				E49913B2174E5F3700741B6D /* WebSocket.cpp in Sources */,
 				E49913B3174E5F3700741B6D /* WebSocketManager.cpp in Sources */,
 				E49913B4174E5F3700741B6D /* WebSocketV13.cpp in Sources */,
+				2AB491711CDDF1920004C263 /* HTTPRequestHandlerUtils.cpp in Sources */,
 				E49913B5174E5F3700741B6D /* WebSocketV8.cpp in Sources */,
 				E49913B6174E5F3C00741B6D /* AirPlayServer.cpp in Sources */,
 				E49913B7174E5F3C00741B6D /* AirTunesServer.cpp in Sources */,

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -3069,7 +3069,12 @@ msgctxt "#680"
 msgid "Verbose logging for the [B]Video[/B] component"
 msgstr ""
 
-#empty strings from id 681 to 699
+#: xbmc/settings/AdvancedSettings.cpp
+msgctxt "#681"
+msgid "Verbose logging for the [B]Webserver[/B] component"
+msgstr ""
+
+#empty strings from id 682 to 699
 
 msgctxt "#700"
 msgid "Cleaning up library"

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -714,6 +714,7 @@ copy "..\Win32BuildSetup\dependencies\python27.dll" "$(TargetDir)"</Command>
     <ClCompile Include="..\..\xbmc\peripherals\devices\PeripheralJoystick.cpp" />
     <ClCompile Include="..\..\xbmc\peripherals\EventScanner.cpp" />
     <ClCompile Include="..\..\xbmc\peripherals\EventScanRate.cpp" />
+    <ClCompile Include="..\..\xbmc\network\httprequesthandler\HTTPRequestHandlerUtils.cpp" />
     <ClCompile Include="..\..\xbmc\platform\posix\main.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug Testsuite|Win32'">true</ExcludedFromBuild>
     </ClCompile>
@@ -1267,6 +1268,7 @@ copy "..\Win32BuildSetup\dependencies\python27.dll" "$(TargetDir)"</Command>
     <ClInclude Include="..\..\xbmc\peripherals\devices\PeripheralJoystick.h" />
     <ClInclude Include="..\..\xbmc\peripherals\EventScanner.h" />
     <ClInclude Include="..\..\xbmc\peripherals\EventScanRate.h" />
+    <ClInclude Include="..\..\xbmc\network\httprequesthandler\HTTPRequestHandlerUtils.h" />
     <ClInclude Include="..\..\xbmc\platform\MessagePrinter.h" />
     <ClInclude Include="..\..\xbmc\media\MediaType.h" />
     <ClInclude Include="..\..\xbmc\messaging\ApplicationMessenger.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -2842,6 +2842,11 @@
     <ClCompile Include="..\..\xbmc\cores\FFmpeg.cpp">
       <Filter>cores</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\network\httprequesthandler\HTTPRequestHandlerUtils.cpp">
+      <Filter>network\httprequesthandler</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
     <ClCompile Include="..\..\xbmc\media\MediaType.cpp">
       <Filter>media</Filter>
     </ClCompile>
@@ -6722,6 +6727,9 @@
     </ClInclude>
     <ClInclude Include="..\..\xbmc\dialogs\GUIDialogKeyboardTouch.h">
       <Filter>dialogs</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\network\httprequesthandler\HTTPRequestHandlerUtils.h">
+      <Filter>network\httprequesthandler</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/xbmc/commons/ilog.h
+++ b/xbmc/commons/ilog.h
@@ -39,20 +39,21 @@
 #define LOGNONE    7
 
 // extra masks - from bit 5
-#define LOGMASKBIT  5
-#define LOGMASK     ((1 << LOGMASKBIT) - 1)
+#define LOGMASKBIT    5
+#define LOGMASK       ((1 << LOGMASKBIT) - 1)
 
-#define LOGSAMBA    (1 << (LOGMASKBIT + 0))
-#define LOGCURL     (1 << (LOGMASKBIT + 1))
-#define LOGFFMPEG   (1 << (LOGMASKBIT + 2))
-#define LOGRTMP     (1 << (LOGMASKBIT + 3))
-#define LOGDBUS     (1 << (LOGMASKBIT + 4))
-#define LOGJSONRPC  (1 << (LOGMASKBIT + 5))
-#define LOGAUDIO    (1 << (LOGMASKBIT + 6))
-#define LOGAIRTUNES (1 << (LOGMASKBIT + 7))
-#define LOGUPNP     (1 << (LOGMASKBIT + 8))
-#define LOGCEC      (1 << (LOGMASKBIT + 9))
-#define LOGVIDEO    (1 << (LOGMASKBIT + 10))
+#define LOGSAMBA      (1 << (LOGMASKBIT + 0))
+#define LOGCURL       (1 << (LOGMASKBIT + 1))
+#define LOGFFMPEG     (1 << (LOGMASKBIT + 2))
+#define LOGRTMP       (1 << (LOGMASKBIT + 3))
+#define LOGDBUS       (1 << (LOGMASKBIT + 4))
+#define LOGJSONRPC    (1 << (LOGMASKBIT + 5))
+#define LOGAUDIO      (1 << (LOGMASKBIT + 6))
+#define LOGAIRTUNES   (1 << (LOGMASKBIT + 7))
+#define LOGUPNP       (1 << (LOGMASKBIT + 8))
+#define LOGCEC        (1 << (LOGMASKBIT + 9))
+#define LOGVIDEO      (1 << (LOGMASKBIT + 10))
+#define LOGWEBSERVER  (1 << (LOGMASKBIT + 11))
 
 #include "utils/params_check_macros.h"
 

--- a/xbmc/network/NetworkServices.cpp
+++ b/xbmc/network/NetworkServices.cpp
@@ -119,18 +119,18 @@ CNetworkServices::CNetworkServices()
 #endif // HAS_WEB_SERVER
 {
 #ifdef HAS_WEB_SERVER
-  CWebServer::RegisterRequestHandler(&m_httpImageHandler);
-  CWebServer::RegisterRequestHandler(&m_httpImageTransformationHandler);
-  CWebServer::RegisterRequestHandler(&m_httpVfsHandler);
+  m_webserver.RegisterRequestHandler(&m_httpImageHandler);
+  m_webserver.RegisterRequestHandler(&m_httpImageTransformationHandler);
+  m_webserver.RegisterRequestHandler(&m_httpVfsHandler);
 #ifdef HAS_JSONRPC
-  CWebServer::RegisterRequestHandler(&m_httpJsonRpcHandler);
+  m_webserver.RegisterRequestHandler(&m_httpJsonRpcHandler);
 #endif // HAS_JSONRPC
 #ifdef HAS_WEB_INTERFACE
 #ifdef HAS_PYTHON
-  CWebServer::RegisterRequestHandler(&m_httpPythonHandler);
+  m_webserver.RegisterRequestHandler(&m_httpPythonHandler);
 #endif
-  CWebServer::RegisterRequestHandler(&m_httpWebinterfaceAddonsHandler);
-  CWebServer::RegisterRequestHandler(&m_httpWebinterfaceHandler);
+  m_webserver.RegisterRequestHandler(&m_httpWebinterfaceAddonsHandler);
+  m_webserver.RegisterRequestHandler(&m_httpWebinterfaceHandler);
 #endif // HAS_WEB_INTERFACE
 #endif // HAS_WEB_SERVER
 }
@@ -138,25 +138,25 @@ CNetworkServices::CNetworkServices()
 CNetworkServices::~CNetworkServices()
 {
 #ifdef HAS_WEB_SERVER
-  CWebServer::UnregisterRequestHandler(&m_httpImageHandler);
+  m_webserver.UnregisterRequestHandler(&m_httpImageHandler);
   delete &m_httpImageHandler;
-  CWebServer::UnregisterRequestHandler(&m_httpImageTransformationHandler);
+  m_webserver.UnregisterRequestHandler(&m_httpImageTransformationHandler);
   delete &m_httpImageTransformationHandler;
-  CWebServer::UnregisterRequestHandler(&m_httpVfsHandler);
+  m_webserver.UnregisterRequestHandler(&m_httpVfsHandler);
   delete &m_httpVfsHandler;
 #ifdef HAS_JSONRPC
-  CWebServer::UnregisterRequestHandler(&m_httpJsonRpcHandler);
+  m_webserver.UnregisterRequestHandler(&m_httpJsonRpcHandler);
   delete &m_httpJsonRpcHandler;
   CJSONRPC::Cleanup();
 #endif // HAS_JSONRPC
 #ifdef HAS_WEB_INTERFACE
 #ifdef HAS_PYTHON
-  CWebServer::UnregisterRequestHandler(&m_httpPythonHandler);
+  m_webserver.UnregisterRequestHandler(&m_httpPythonHandler);
   delete &m_httpPythonHandler;
 #endif
-  CWebServer::UnregisterRequestHandler(&m_httpWebinterfaceAddonsHandler);
+  m_webserver.UnregisterRequestHandler(&m_httpWebinterfaceAddonsHandler);
   delete &m_httpWebinterfaceAddonsHandler;
-  CWebServer::UnregisterRequestHandler(&m_httpWebinterfaceHandler);
+  m_webserver.UnregisterRequestHandler(&m_httpWebinterfaceHandler);
   delete &m_httpWebinterfaceHandler;
 #endif // HAS_WEB_INTERFACE
   delete &m_webserver;

--- a/xbmc/network/WebServer.cpp
+++ b/xbmc/network/WebServer.cpp
@@ -1220,35 +1220,6 @@ void CWebServer::SetCredentials(const std::string &username, const std::string &
   m_needcredentials = !password.empty();
 }
 
-bool CWebServer::PrepareDownload(const char *path, CVariant &details, std::string &protocol)
-{
-  if (!XFILE::CFile::Exists(path))
-    return false;
-
-  protocol = "http";
-  std::string url;
-  std::string strPath = path;
-  if (StringUtils::StartsWith(strPath, "image://") ||
-      (StringUtils::StartsWith(strPath, "special://") && StringUtils::EndsWith(strPath, ".tbn")))
-    url = "image/";
-  else
-    url = "vfs/";
-  url += CURL::Encode(strPath);
-  details["path"] = url;
-
-  return true;
-}
-
-bool CWebServer::Download(const char *path, CVariant &result)
-{
-  return false;
-}
-
-int CWebServer::GetCapabilities()
-{
-  return JSONRPC::Response | JSONRPC::FileDownloadRedirect;
-}
-
 void CWebServer::RegisterRequestHandler(IHTTPRequestHandler *handler)
 {
   if (handler == nullptr)

--- a/xbmc/network/WebServer.cpp
+++ b/xbmc/network/WebServer.cpp
@@ -1243,27 +1243,4 @@ int CWebServer::AddHeader(struct MHD_Response *response, const std::string &name
 #endif
   return MHD_add_response_header(response, name.c_str(), value.c_str());
 }
-
-bool CWebServer::GetLastModifiedDateTime(XFILE::CFile *file, CDateTime &lastModified)
-{
-  if (file == nullptr)
-    return false;
-
-  struct __stat64 statBuffer;
-  if (file->Stat(&statBuffer) != 0)
-    return false;
-
-  struct tm *time;
-#ifdef HAVE_LOCALTIME_R
-  struct tm result = {};
-  time = localtime_r((time_t*)&statBuffer.st_mtime, &result);
-#else
-  time = localtime((time_t *)&statBuffer.st_mtime);
-#endif
-  if (time == nullptr)
-    return false;
-
-  lastModified = *time;
-  return true;
-}
 #endif

--- a/xbmc/network/WebServer.cpp
+++ b/xbmc/network/WebServer.cpp
@@ -68,10 +68,6 @@
 
 #define HEADER_NEWLINE        "\r\n"
 
-static const std::string HTTPMethodHead = "HEAD";
-static const std::string HTTPMethodGet = "GET";
-static const std::string HTTPMethodPost = "POST";
-
 typedef struct {
   std::shared_ptr<XFILE::CFile> file;
   CHttpRanges ranges;
@@ -105,35 +101,6 @@ CWebServer::CWebServer()
   m_thread_stacksize *= 2;
   CLog::Log(LOGDEBUG, "CWebServer: increasing thread stack to %zu", m_thread_stacksize);
 #endif
-}
-
-HTTPMethod CWebServer::GetMethod(const char *method)
-{
-  if (HTTPMethodGet.compare(method) == 0)
-    return GET;
-  if (HTTPMethodPost.compare(method) == 0)
-    return POST;
-  if (HTTPMethodHead.compare(method) == 0)
-    return HEAD;
-
-  return UNKNOWN;
-}
-
-std::string CWebServer::GetMethod(HTTPMethod method)
-{
-  switch (method)
-  {
-  case HEAD:
-    return HTTPMethodHead;
-
-  case GET:
-    return HTTPMethodGet;
-
-  case POST:
-    return HTTPMethodPost;
-  }
-
-  return "";
 }
 
 int CWebServer::AskForAuthentication(struct MHD_Connection *connection)
@@ -211,7 +178,7 @@ int CWebServer::AnswerToConnection(void *cls, struct MHD_Connection *connection,
   }
 
   ConnectionHandler* connectionHandler = reinterpret_cast<ConnectionHandler*>(*con_cls);
-  HTTPMethod methodType = GetMethod(method);
+  HTTPMethod methodType = GetHTTPMethod(method);
   HTTPRequest request = { webServer, connection, connectionHandler->fullUri, url, methodType, version };
 
 #if defined(WEBSERVER_DEBUG)
@@ -222,7 +189,7 @@ int CWebServer::AnswerToConnection(void *cls, struct MHD_Connection *connection,
     std::multimap<std::string, std::string> getValues;
     HTTPRequestHandlerUtils::GetRequestHeaderValues(connection, MHD_GET_ARGUMENT_KIND, getValues);
 
-    CLog::Log(LOGDEBUG, "webserver[%hu]  [IN] %s %s %s", webServer->m_port, version, GetMethod(request.method), request.pathUrlFull.c_str());
+    CLog::Log(LOGDEBUG, "webserver[%hu]  [IN] %s %s %s", webServer->m_port, version, GetHTTPMethod(request.method), request.pathUrlFull.c_str());
     if (!getValues.empty())
     {
       std::string tmp;

--- a/xbmc/network/WebServer.h
+++ b/xbmc/network/WebServer.h
@@ -76,9 +76,25 @@ protected:
 
 private:
   struct MHD_Daemon* StartMHD(unsigned int flags, int port);
-  static int AskForAuthentication (struct MHD_Connection *connection);
-  static bool IsAuthenticated (CWebServer *server, struct MHD_Connection *connection);
 
+  int AskForAuthentication(struct MHD_Connection *connection) const;
+  bool IsAuthenticated(struct MHD_Connection *connection) const;
+
+  int CreateMemoryDownloadResponse(const std::shared_ptr<IHTTPRequestHandler>& handler, struct MHD_Response *&response) const;
+  int CreateRangedMemoryDownloadResponse(const std::shared_ptr<IHTTPRequestHandler>& handler, struct MHD_Response *&response) const;
+
+  int CreateRedirect(struct MHD_Connection *connection, const std::string &strURL, struct MHD_Response *&response) const;
+  int CreateFileDownloadResponse(const std::shared_ptr<IHTTPRequestHandler>& handler, struct MHD_Response *&response) const;
+  int CreateErrorResponse(struct MHD_Connection *connection, int responseType, HTTPMethod method, struct MHD_Response *&response) const;
+  int CreateMemoryDownloadResponse(struct MHD_Connection *connection, const void *data, size_t size, bool free, bool copy, struct MHD_Response *&response) const;
+
+  int SendErrorResponse(struct MHD_Connection *connection, int errorType, HTTPMethod method) const;
+
+  int AddHeader(struct MHD_Response *response, const std::string &name, const std::string &value) const;
+
+  static std::string CreateMimeTypeFromExtension(const char *ext);
+
+  // MHD callback implementations
   static void* UriRequestLogger(void *cls, const char *uri);
 
 #if (MHD_VERSION >= 0x00090200)
@@ -109,20 +125,6 @@ private:
                              const char *transfer_encoding, const char *data, uint64_t off,
                              unsigned int size);
 #endif
-
-  static int CreateMemoryDownloadResponse(const std::shared_ptr<IHTTPRequestHandler>& handler, struct MHD_Response *&response);
-  static int CreateRangedMemoryDownloadResponse(const std::shared_ptr<IHTTPRequestHandler>& handler, struct MHD_Response *&response);
-
-  static int CreateRedirect(struct MHD_Connection *connection, const std::string &strURL, struct MHD_Response *&response);
-  static int CreateFileDownloadResponse(const std::shared_ptr<IHTTPRequestHandler>& handler, struct MHD_Response *&response);
-  static int CreateErrorResponse(struct MHD_Connection *connection, int responseType, HTTPMethod method, struct MHD_Response *&response);
-  static int CreateMemoryDownloadResponse(struct MHD_Connection *connection, const void *data, size_t size, bool free, bool copy, struct MHD_Response *&response);
-
-  static int SendErrorResponse(struct MHD_Connection *connection, int errorType, HTTPMethod method);
-
-  static std::string CreateMimeTypeFromExtension(const char *ext);
-
-  static int AddHeader(struct MHD_Response *response, const std::string &name, const std::string &value);
 
   uint16_t m_port;
   struct MHD_Daemon *m_daemon_ip6;

--- a/xbmc/network/WebServer.h
+++ b/xbmc/network/WebServer.h
@@ -123,7 +123,6 @@ private:
   static std::string CreateMimeTypeFromExtension(const char *ext);
 
   static int AddHeader(struct MHD_Response *response, const std::string &name, const std::string &value);
-  static bool GetLastModifiedDateTime(XFILE::CFile *file, CDateTime &lastModified);
 
   uint16_t m_port;
   struct MHD_Daemon *m_daemon_ip6;

--- a/xbmc/network/WebServer.h
+++ b/xbmc/network/WebServer.h
@@ -25,7 +25,6 @@
 #include <memory>
 #include <vector>
 
-#include "interfaces/json-rpc/ITransportLayer.h"
 #include "network/httprequesthandler/IHTTPRequestHandler.h"
 #include "threads/CriticalSection.h"
 
@@ -36,16 +35,11 @@ namespace XFILE
 class CDateTime;
 class CVariant;
 
-class CWebServer : public JSONRPC::ITransportLayer
+class CWebServer
 {
 public:
   CWebServer();
   virtual ~CWebServer() { }
-
-  // implementation of JSONRPC::ITransportLayer
-  virtual bool PrepareDownload(const char *path, CVariant &details, std::string &protocol);
-  virtual bool Download(const char *path, CVariant &result);
-  virtual int GetCapabilities();
 
   bool Start(int port, const std::string &username, const std::string &password);
   bool Stop();

--- a/xbmc/network/WebServer.h
+++ b/xbmc/network/WebServer.h
@@ -49,12 +49,6 @@ public:
   void RegisterRequestHandler(IHTTPRequestHandler *handler);
   void UnregisterRequestHandler(IHTTPRequestHandler *handler);
 
-  static std::string GetRequestHeaderValue(struct MHD_Connection *connection, enum MHD_ValueKind kind, const std::string &key);
-  static int GetRequestHeaderValues(struct MHD_Connection *connection, enum MHD_ValueKind kind, std::map<std::string, std::string> &headerValues);
-  static int GetRequestHeaderValues(struct MHD_Connection *connection, enum MHD_ValueKind kind, std::multimap<std::string, std::string> &headerValues);
-
-  static bool GetRequestedRanges(struct MHD_Connection *connection, uint64_t totalLength, CHttpRanges &ranges);
-
 protected:
   typedef struct ConnectionHandler
   {
@@ -128,9 +122,6 @@ private:
   
   static HTTPMethod GetMethod(const char *method);
   static std::string GetMethod(HTTPMethod method);
-
-  static int FillArgumentMap(void *cls, enum MHD_ValueKind kind, const char *key, const char *value);
-  static int FillArgumentMultiMap(void *cls, enum MHD_ValueKind kind, const char *key, const char *value);
 
   static std::string CreateMimeTypeFromExtension(const char *ext);
 

--- a/xbmc/network/WebServer.h
+++ b/xbmc/network/WebServer.h
@@ -119,9 +119,6 @@ private:
   static int CreateMemoryDownloadResponse(struct MHD_Connection *connection, const void *data, size_t size, bool free, bool copy, struct MHD_Response *&response);
 
   static int SendErrorResponse(struct MHD_Connection *connection, int errorType, HTTPMethod method);
-  
-  static HTTPMethod GetMethod(const char *method);
-  static std::string GetMethod(HTTPMethod method);
 
   static std::string CreateMimeTypeFromExtension(const char *ext);
 

--- a/xbmc/network/httprequesthandler/CMakeLists.txt
+++ b/xbmc/network/httprequesthandler/CMakeLists.txt
@@ -3,6 +3,7 @@ set(SOURCES HTTPFileHandler.cpp
             HTTPImageTransformationHandler.cpp
             HTTPJsonRpcHandler.cpp
             HTTPPythonHandler.cpp
+            HTTPRequestHandlerUtils.cpp
             HTTPVfsHandler.cpp
             HTTPWebinterfaceAddonsHandler.cpp
             HTTPWebinterfaceHandler.cpp
@@ -13,6 +14,7 @@ set(HEADERS HTTPFileHandler.h
             HTTPImageTransformationHandler.h
             HTTPJsonRpcHandler.h
             HTTPPythonHandler.h
+            HTTPRequestHandlerUtils.h
             HTTPVfsHandler.h
             HTTPWebinterfaceAddonsHandler.h
             HTTPWebinterfaceHandler.h

--- a/xbmc/network/httprequesthandler/HTTPImageTransformationHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPImageTransformationHandler.cpp
@@ -25,6 +25,7 @@
 #include "URL.h"
 #include "filesystem/ImageFile.h"
 #include "network/WebServer.h"
+#include "network/httprequesthandler/HTTPRequestHandlerUtils.h"
 #include "utils/Mime.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
@@ -109,7 +110,7 @@ bool CHTTPImageTransformationHandler::CanHandleRequest(const HTTPRequest &reques
 
   // get the transformation options
   std::map<std::string, std::string> options;
-  CWebServer::GetRequestHeaderValues(request.connection, MHD_GET_ARGUMENT_KIND, options);
+  HTTPRequestHandlerUtils::GetRequestHeaderValues(request.connection, MHD_GET_ARGUMENT_KIND, options);
 
   return (options.find(TRANSFORMATION_OPTION_WIDTH) != options.end() ||
           options.find(TRANSFORMATION_OPTION_HEIGHT) != options.end());
@@ -131,7 +132,7 @@ int CHTTPImageTransformationHandler::HandleRequest()
 
   // get the transformation options
   std::map<std::string, std::string> options;
-  CWebServer::GetRequestHeaderValues(m_request.connection, MHD_GET_ARGUMENT_KIND, options);
+  HTTPRequestHandlerUtils::GetRequestHeaderValues(m_request.connection, MHD_GET_ARGUMENT_KIND, options);
 
   std::vector<std::string> urlOptions;
   std::map<std::string, std::string>::const_iterator option = options.find(TRANSFORMATION_OPTION_WIDTH);

--- a/xbmc/network/httprequesthandler/HTTPJsonRpcHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPJsonRpcHandler.cpp
@@ -25,6 +25,7 @@
 #include "interfaces/json-rpc/JSONServiceDescription.h"
 #include "interfaces/json-rpc/JSONUtils.h"
 #include "network/WebServer.h"
+#include "network/httprequesthandler/HTTPRequestHandlerUtils.h"
 #include "utils/JSONVariantWriter.h"
 #include "utils/log.h"
 #include "utils/Variant.h"
@@ -44,11 +45,11 @@ int CHTTPJsonRpcHandler::HandleRequest()
 
   // get all query arguments
   std::map<std::string, std::string> arguments;
-  CWebServer::GetRequestHeaderValues(m_request.connection, MHD_GET_ARGUMENT_KIND, arguments);
+  HTTPRequestHandlerUtils::GetRequestHeaderValues(m_request.connection, MHD_GET_ARGUMENT_KIND, arguments);
 
   if (m_request.method == POST)
   {
-    std::string contentType = CWebServer::GetRequestHeaderValue(m_request.connection, MHD_HEADER_KIND, MHD_HTTP_HEADER_CONTENT_TYPE);
+    std::string contentType = HTTPRequestHandlerUtils::GetRequestHeaderValue(m_request.connection, MHD_HEADER_KIND, MHD_HTTP_HEADER_CONTENT_TYPE);
     // If the content-type of the m_request was specified, it must be application/json-rpc, application/json, or application/jsonrequest
     // http://www.jsonrpc.org/historical/json-rpc-over-http.html
     if (!contentType.empty() && contentType.compare("application/json-rpc") != 0 &&

--- a/xbmc/network/httprequesthandler/HTTPJsonRpcHandler.h
+++ b/xbmc/network/httprequesthandler/HTTPJsonRpcHandler.h
@@ -22,6 +22,7 @@
 #include <string>
 
 #include "interfaces/json-rpc/IClient.h"
+#include "interfaces/json-rpc/ITransportLayer.h"
 #include "network/httprequesthandler/IHTTPRequestHandler.h"
 
 class CHTTPJsonRpcHandler : public IHTTPRequestHandler
@@ -30,6 +31,7 @@ public:
   CHTTPJsonRpcHandler() { }
   virtual ~CHTTPJsonRpcHandler() { }
   
+  // implementations of IHTTPRequestHandler
   virtual IHTTPRequestHandler* Create(const HTTPRequest &request) { return new CHTTPJsonRpcHandler(request); }
   virtual bool CanHandleRequest(const HTTPRequest &request);
 
@@ -54,6 +56,19 @@ private:
   std::string m_requestData;
   std::string m_responseData;
   CHttpResponseRange m_responseRange;
+
+  class CHTTPTransportLayer : public JSONRPC::ITransportLayer
+  {
+  public:
+    CHTTPTransportLayer() = default;
+    ~CHTTPTransportLayer() = default;
+
+    // implementations of JSONRPC::ITransportLayer
+    bool PrepareDownload(const char *path, CVariant &details, std::string &protocol) override;
+    bool Download(const char *path, CVariant &result) override;
+    int GetCapabilities() override;
+  };
+  CHTTPTransportLayer m_transportLayer;
 
   class CHTTPClient : public JSONRPC::IClient
   {

--- a/xbmc/network/httprequesthandler/HTTPPythonHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPPythonHandler.cpp
@@ -25,6 +25,7 @@
 #include "interfaces/python/XBPython.h"
 #include "filesystem/File.h"
 #include "network/WebServer.h"
+#include "network/httprequesthandler/HTTPRequestHandlerUtils.h"
 #include "network/httprequesthandler/HTTPWebinterfaceHandler.h"
 #include "network/httprequesthandler/python/HTTPPythonInvoker.h"
 #include "network/httprequesthandler/python/HTTPPythonWsgiInvoker.h"
@@ -136,8 +137,8 @@ int CHTTPPythonHandler::HandleRequest()
     HTTPPythonRequest* pythonRequest = new HTTPPythonRequest();
     pythonRequest->connection = m_request.connection;
     pythonRequest->file = URIUtils::GetFileName(m_request.pathUrl);
-    CWebServer::GetRequestHeaderValues(m_request.connection, MHD_GET_ARGUMENT_KIND, pythonRequest->getValues);
-    CWebServer::GetRequestHeaderValues(m_request.connection, MHD_HEADER_KIND, pythonRequest->headerValues);
+    HTTPRequestHandlerUtils::GetRequestHeaderValues(m_request.connection, MHD_GET_ARGUMENT_KIND, pythonRequest->getValues);
+    HTTPRequestHandlerUtils::GetRequestHeaderValues(m_request.connection, MHD_HEADER_KIND, pythonRequest->headerValues);
     pythonRequest->method = m_request.method;
     pythonRequest->postValues = m_postFields;
     pythonRequest->requestContent = m_requestData;

--- a/xbmc/network/httprequesthandler/HTTPRequestHandlerUtils.cpp
+++ b/xbmc/network/httprequesthandler/HTTPRequestHandlerUtils.cpp
@@ -1,0 +1,96 @@
+/*
+ *      Copyright (C) 2016 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <map>
+
+#include "HTTPRequestHandlerUtils.h"
+#include "utils/StringUtils.h"
+
+std::string HTTPRequestHandlerUtils::GetRequestHeaderValue(struct MHD_Connection *connection, enum MHD_ValueKind kind, const std::string &key)
+{
+  if (connection == nullptr)
+    return "";
+
+  const char* value = MHD_lookup_connection_value(connection, kind, key.c_str());
+  if (value == nullptr)
+    return "";
+
+  if (StringUtils::EqualsNoCase(key, MHD_HTTP_HEADER_CONTENT_TYPE))
+  {
+    // Work around a bug in firefox (see https://bugzilla.mozilla.org/show_bug.cgi?id=416178)
+    // by cutting of anything that follows a ";" in a "Content-Type" header field
+    std::string strValue(value);
+    size_t pos = strValue.find(';');
+    if (pos != std::string::npos)
+      strValue = strValue.substr(0, pos);
+
+    return strValue;
+  }
+
+  return value;
+}
+
+int HTTPRequestHandlerUtils::GetRequestHeaderValues(struct MHD_Connection *connection, enum MHD_ValueKind kind, std::map<std::string, std::string> &headerValues)
+{
+  if (connection == nullptr)
+    return -1;
+
+  return MHD_get_connection_values(connection, kind, FillArgumentMap, &headerValues);
+}
+
+int HTTPRequestHandlerUtils::GetRequestHeaderValues(struct MHD_Connection *connection, enum MHD_ValueKind kind, std::multimap<std::string, std::string> &headerValues)
+{
+  if (connection == nullptr)
+    return -1;
+
+  return MHD_get_connection_values(connection, kind, FillArgumentMultiMap, &headerValues);
+}
+
+bool HTTPRequestHandlerUtils::GetRequestedRanges(struct MHD_Connection *connection, uint64_t totalLength, CHttpRanges &ranges)
+{
+  ranges.Clear();
+
+  if (connection == nullptr)
+    return false;
+
+  return ranges.Parse(GetRequestHeaderValue(connection, MHD_HEADER_KIND, MHD_HTTP_HEADER_RANGE), totalLength);
+}
+
+int HTTPRequestHandlerUtils::FillArgumentMap(void *cls, enum MHD_ValueKind kind, const char *key, const char *value)
+{
+  if (cls == nullptr || key == nullptr)
+    return MHD_NO;
+
+  std::map<std::string, std::string> *arguments = reinterpret_cast<std::map<std::string, std::string>*>(cls);
+  arguments->insert(std::make_pair(key, value != nullptr ? value : ""));
+
+  return MHD_YES;
+}
+
+int HTTPRequestHandlerUtils::FillArgumentMultiMap(void *cls, enum MHD_ValueKind kind, const char *key, const char *value)
+{
+  if (cls == nullptr || key == nullptr)
+    return MHD_NO;
+
+  std::multimap<std::string, std::string> *arguments = reinterpret_cast<std::multimap<std::string, std::string>*>(cls);
+  arguments->insert(std::make_pair(key, value != nullptr ? value : ""));
+
+  return MHD_YES;
+}

--- a/xbmc/network/httprequesthandler/HTTPRequestHandlerUtils.h
+++ b/xbmc/network/httprequesthandler/HTTPRequestHandlerUtils.h
@@ -1,0 +1,41 @@
+#pragma once
+/*
+ *      Copyright (C) 2016 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <stdint.h>
+#include <string>
+
+#include "network/httprequesthandler/IHTTPRequestHandler.h"
+
+class HTTPRequestHandlerUtils
+{
+public:
+  static std::string GetRequestHeaderValue(struct MHD_Connection *connection, enum MHD_ValueKind kind, const std::string &key);
+  static int GetRequestHeaderValues(struct MHD_Connection *connection, enum MHD_ValueKind kind, std::map<std::string, std::string> &headerValues);
+  static int GetRequestHeaderValues(struct MHD_Connection *connection, enum MHD_ValueKind kind, std::multimap<std::string, std::string> &headerValues);
+
+  static bool GetRequestedRanges(struct MHD_Connection *connection, uint64_t totalLength, CHttpRanges &ranges);
+
+private:
+  HTTPRequestHandlerUtils() = delete;
+
+  static int FillArgumentMap(void *cls, enum MHD_ValueKind kind, const char *key, const char *value);
+  static int FillArgumentMultiMap(void *cls, enum MHD_ValueKind kind, const char *key, const char *value);
+};

--- a/xbmc/network/httprequesthandler/IHTTPRequestHandler.cpp
+++ b/xbmc/network/httprequesthandler/IHTTPRequestHandler.cpp
@@ -26,6 +26,39 @@
 #include "network/httprequesthandler/HTTPRequestHandlerUtils.h"
 #include "utils/StringUtils.h"
 
+static const std::string HTTPMethodHead = "HEAD";
+static const std::string HTTPMethodGet = "GET";
+static const std::string HTTPMethodPost = "POST";
+
+HTTPMethod GetHTTPMethod(const char *method)
+{
+  if (HTTPMethodGet.compare(method) == 0)
+    return GET;
+  if (HTTPMethodPost.compare(method) == 0)
+    return POST;
+  if (HTTPMethodHead.compare(method) == 0)
+    return HEAD;
+
+  return UNKNOWN;
+}
+
+std::string GetHTTPMethod(HTTPMethod method)
+{
+  switch (method)
+  {
+  case HEAD:
+    return HTTPMethodHead;
+
+  case GET:
+    return HTTPMethodGet;
+
+  case POST:
+    return HTTPMethodPost;
+  }
+
+  return "";
+}
+
 IHTTPRequestHandler::IHTTPRequestHandler()
   : m_request(),
     m_response(),

--- a/xbmc/network/httprequesthandler/IHTTPRequestHandler.cpp
+++ b/xbmc/network/httprequesthandler/IHTTPRequestHandler.cpp
@@ -19,12 +19,12 @@
  */
 
 #include <limits>
+#include <utility>
 
 #include "IHTTPRequestHandler.h"
 #include "network/WebServer.h"
+#include "network/httprequesthandler/HTTPRequestHandlerUtils.h"
 #include "utils/StringUtils.h"
-
-#include <utility>
 
 IHTTPRequestHandler::IHTTPRequestHandler()
   : m_request(),
@@ -97,7 +97,7 @@ bool IHTTPRequestHandler::GetRequestedRanges(uint64_t totalLength)
   if (totalLength == 0)
     return true;
 
-  return m_request.webserver->GetRequestedRanges(m_request.connection, totalLength, m_request.ranges);
+  return HTTPRequestHandlerUtils::GetRequestedRanges(m_request.connection, totalLength, m_request.ranges);
 }
 
 bool IHTTPRequestHandler::GetHostnameAndPort(std::string& hostname, uint16_t &port)
@@ -105,7 +105,7 @@ bool IHTTPRequestHandler::GetHostnameAndPort(std::string& hostname, uint16_t &po
   if (m_request.webserver == NULL || m_request.connection == NULL)
     return false;
 
-  std::string hostnameAndPort = m_request.webserver->GetRequestHeaderValue(m_request.connection, MHD_HEADER_KIND, MHD_HTTP_HEADER_HOST);
+  std::string hostnameAndPort = HTTPRequestHandlerUtils::GetRequestHeaderValue(m_request.connection, MHD_HEADER_KIND, MHD_HTTP_HEADER_HOST);
   if (hostnameAndPort.empty())
     return false;
 

--- a/xbmc/network/httprequesthandler/IHTTPRequestHandler.h
+++ b/xbmc/network/httprequesthandler/IHTTPRequestHandler.h
@@ -44,6 +44,9 @@ enum HTTPMethod
   HEAD
 };
 
+HTTPMethod GetHTTPMethod(const char *method);
+std::string GetHTTPMethod(HTTPMethod method);
+
 typedef enum HTTPResponseType
 {
   HTTPNone,

--- a/xbmc/network/httprequesthandler/Makefile
+++ b/xbmc/network/httprequesthandler/Makefile
@@ -3,6 +3,7 @@ SRCS=HTTPFileHandler.cpp \
      HTTPImageTransformationHandler.cpp \
      HTTPJsonRpcHandler.cpp \
      HTTPPythonHandler.cpp \
+     HTTPRequestHandlerUtils.cpp \
      HTTPVfsHandler.cpp \
      HTTPWebinterfaceAddonsHandler.cpp \
      HTTPWebinterfaceHandler.cpp \

--- a/xbmc/network/test/TestWebServer.cpp
+++ b/xbmc/network/test/TestWebServer.cpp
@@ -28,6 +28,10 @@
 #include "filesystem/File.h"
 #include "interfaces/json-rpc/JSONRPC.h"
 #include "network/WebServer.h"
+#include "network/httprequesthandler/HTTPVfsHandler.h"
+#ifdef HAS_JSONRPC
+#include "network/httprequesthandler/HTTPJsonRpcHandler.h"
+#endif // HAS_JSONRPC
 #include "settings/MediaSourceSettings.h"
 #include "test/TestUtils.h"
 #include "utils/JSONVariantParser.h"
@@ -63,12 +67,17 @@ protected:
     SetupMediaSources();
 
     webserver.Start(WEBSERVER_PORT, "", "");
+    webserver.RegisterRequestHandler(&m_jsonRpcHandler);
+    webserver.RegisterRequestHandler(&m_vfsHandler);
   }
 
   virtual void TearDown()
   {
     if (webserver.IsStarted())
       webserver.Stop();
+
+    webserver.UnregisterRequestHandler(&m_vfsHandler);
+    webserver.UnregisterRequestHandler(&m_jsonRpcHandler);
 
     TearDownMediaSources();
   }
@@ -331,6 +340,8 @@ protected:
   }
 
   CWebServer webserver;
+  CHTTPJsonRpcHandler m_jsonRpcHandler;
+  CHTTPVfsHandler m_vfsHandler;
   std::string baseUrl;
   std::string sourcePath;
 };

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -1335,6 +1335,9 @@ void CAdvancedSettings::SettingOptionsLoggingComponentsFiller(const CSetting *se
 #ifdef HAS_JSONRPC
   list.push_back(std::make_pair(g_localizeStrings.Get(675), LOGJSONRPC));
 #endif
+#ifdef HAS_WEB_SERVER
+  list.push_back(std::make_pair(g_localizeStrings.Get(681), LOGWEBSERVER));
+#endif
 #ifdef HAS_AIRTUNES
   list.push_back(std::make_pair(g_localizeStrings.Get(677), LOGAIRTUNES));
 #endif


### PR DESCRIPTION
These commits don't really contain any new features but improve the implementation of and around `CWebServer` and also makes it possible to run multiple webservers with different configurations and different request handlers (which are currently statically configured).
Furthermore it introduces component logging for the webserver which is currently not possible because it has to be compiled with a special flag. This should make it easier to track down issues with webserver requests.
