### PR TITLE
[win32] VS2015 fix for libdvd

### DIFF
--- a/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
+++ b/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
@@ -1273,7 +1273,7 @@ extern "C"
 
   int dll_fputc(int character, FILE* stream)
   {
-    if (IS_STDOUT_STREAM(stream) || IS_STDERR_STREAM(stream))
+    if (IS_STDOUT_STREAM(stream) || IS_STDERR_STREAM(stream) || !IS_VALID_STREAM(stream))
     {
       unsigned char tmp[2] = { (unsigned char)character, 0 };
       dllputs((char *)tmp);
@@ -1305,7 +1305,7 @@ extern "C"
 
   int dll_fputs(const char * szLine, FILE* stream)
   {
-    if (IS_STDOUT_STREAM(stream) || IS_STDERR_STREAM(stream))
+    if (IS_STDOUT_STREAM(stream) || IS_STDERR_STREAM(stream) || !IS_VALID_STREAM(stream))
     {
       dllputs(szLine);
       return 0;
@@ -1470,7 +1470,7 @@ extern "C"
     if (size == 0 || count == 0)
       return 0;
 
-    if (IS_STDOUT_STREAM(stream) || IS_STDERR_STREAM(stream))
+    if (IS_STDOUT_STREAM(stream) || IS_STDERR_STREAM(stream) || !IS_VALID_STREAM(stream))
     {
       char* buf = (char*)malloc(size * count + 1);
       if (buf)
@@ -1561,7 +1561,7 @@ extern "C"
     }
     tmp[2048 - 1] = 0;
 
-    if (IS_STDOUT_STREAM(stream) || IS_STDERR_STREAM(stream))
+    if (IS_STDOUT_STREAM(stream) || IS_STDERR_STREAM(stream) || !IS_VALID_STREAM(stream))
     {
       CLog::Log(LOGINFO, "  msg: %s", tmp);
       return strlen(tmp);

--- a/xbmc/cores/DllLoader/exports/emu_msvcrt.h
+++ b/xbmc/cores/DllLoader/exports/emu_msvcrt.h
@@ -45,8 +45,10 @@ typedef void ( *PFV)(void);
 #define IS_STDIN_STREAM(stream)     (stream != NULL && __IS_STDIN_STREAM(stream))
 #define IS_STDOUT_STREAM(stream)    (stream != NULL && __IS_STDOUT_STREAM(stream))
 #define IS_STDERR_STREAM(stream)    (stream != NULL && __IS_STDERR_STREAM(stream))
-#if defined(TARGET_WINDOWS) && _MSC_VER < 1900
+#if defined(TARGET_WINDOWS) && (_MSC_VER < 1900)
 #define IS_VALID_STREAM(stream)     (stream != NULL && (stream->_ptr != NULL))
+#elif defined(TARGET_WINDOWS) && (_MSC_VER >= 1900)
+#define IS_VALID_STREAM(stream)     (stream != nullptr && (stream->_Placeholder != nullptr))
 #else
 #define IS_VALID_STREAM(stream)     true
 #endif

--- a/xbmc/cores/DllLoader/exports/util/EmuFileWrapper.h
+++ b/xbmc/cores/DllLoader/exports/util/EmuFileWrapper.h
@@ -39,7 +39,7 @@ namespace XFILE
   class CFile;
 }
 
-#if defined(TARGET_WINDOWS)
+#if defined(TARGET_WINDOWS) && _MSC_VER >= 1900
 struct kodi_iobuf {
   int   _file;
 };


### PR DESCRIPTION
Since VC++ 2015 made FILE an opaque object, the internals of File cannot be modified by any code outside the CLR. This means that FILE objects passed from a library such as Libdvd has nullified placeholder members which are unusable by our emulation layer. This is the case for standard streams such as stdout and stderr. This PR fixes the segfaults caused by these nullified placeholders.
