### PR TITLE
[python-api] add xbmcgui.Dialog().contextmenu()

### DIFF
--- a/xbmc/interfaces/legacy/Dialog.cpp
+++ b/xbmc/interfaces/legacy/Dialog.cpp
@@ -22,6 +22,7 @@
 #include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogYesNo.h"
 #include "dialogs/GUIDialogSelect.h"
+#include "dialogs/GUIDialogContextMenu.h"
 #include "dialogs/GUIDialogTextViewer.h"
 #include "guilib/GUIWindowManager.h"
 #include "dialogs/GUIDialogFileBrowser.h"
@@ -83,6 +84,22 @@ namespace XBMCAddon
 
       return pDialog->IsConfirmed();
     }
+
+    int Dialog::contextmenu(const std::vector<String>& list)
+    {
+      DelayedCallGuard dcguard(languageHook);
+      CGUIDialogContextMenu* pDialog= (CGUIDialogContextMenu*)g_windowManager.GetWindow(WINDOW_DIALOG_CONTEXT_MENU);
+      if (pDialog == NULL)
+        throw WindowException("Error: Window is NULL, this is not possible :-)");
+
+      CContextButtons choices;
+      for(unsigned int i = 0; i < list.size(); i++)
+      {
+        choices.Add(i, list[i]);
+      }
+      return pDialog->Show(choices);
+    }
+
 
     int Dialog::select(const String& heading, const std::vector<String>& list, int autoclose)
     {

--- a/xbmc/interfaces/legacy/Dialog.h
+++ b/xbmc/interfaces/legacy/Dialog.h
@@ -78,6 +78,19 @@ namespace XBMCAddon
                  int autoclose = 0);
 
       /**
+       * contextmenu(list) -- Show a context menu.\n
+       * \n
+       * list           : string list - list of items.\n
+       * \n
+       * *Note, Returns the position of the highlighted item as an integer (-1 if cancelled).\n
+       * \n
+       * example:\n
+       *   - dialog = xbmcgui.Dialog()\n
+       *   - ret = dialog.contextmenu(['Option #1', 'Option #2', 'Option #3'])\n\n
+       */
+      int contextmenu(const std::vector<String>& list);
+
+      /**
        * select(heading, list) -- Show a select dialog.\n
        * \n
        * heading        : string or unicode - dialog heading.\n

--- a/xbmc/interfaces/legacy/Dialog.h
+++ b/xbmc/interfaces/legacy/Dialog.h
@@ -68,7 +68,7 @@ namespace XBMCAddon
        * \n
        * example:\n
        *   - dialog = xbmcgui.Dialog()\n
-       *   - ret = dialog.yesno('Kodi', 'Do you want to exit this script?')n\n
+       *   - ret = dialog.yesno('Kodi', 'Do you want to exit this script?')\n\n
        */
       bool yesno(const String& heading, const String& line1, 
                  const String& line2 = emptyString,
@@ -88,7 +88,7 @@ namespace XBMCAddon
        * \n
        * example:\n
        *   - dialog = xbmcgui.Dialog()\n
-       *   - ret = dialog.select('Choose a playlist', ['Playlist #1', 'Playlist #2, 'Playlist #3'])n\n
+       *   - ret = dialog.select('Choose a playlist', ['Playlist #1', 'Playlist #2, 'Playlist #3'])\n\n
        */
       int select(const String& heading, const std::vector<String>& list, int autoclose=0);
 
@@ -120,7 +120,7 @@ namespace XBMCAddon
        * \n
        * example:\n
        *   - dialog = xbmcgui.Dialog()\n
-       *   - ok = dialog.ok('XBMC', 'There was an error.')n\n
+       *   - ok = dialog.ok('XBMC', 'There was an error.')\n\n
        */
       bool ok(const String& heading, const String& line1, 
               const String& line2 = emptyString,
@@ -134,7 +134,7 @@ namespace XBMCAddon
       * \n
       * example:\n
       *   - dialog = xbmcgui.Dialog()\n
-      *   - dialog.textviewer('Plot', 'Some movie plot.')n\n
+      *   - dialog.textviewer('Plot', 'Some movie plot.')\n\n
       */
       void textviewer(const String& heading, const String& text);
 
@@ -304,7 +304,7 @@ namespace XBMCAddon
        *\n
        * example:
        *   - dialog = xbmcgui.Dialog()
-       *   - d = dialog.input('Enter secret code', type=xbmcgui.INPUT_ALPHANUM, option=xbmcgui.ALPHANUM_HIDE_INPUT)n
+       *   - d = dialog.input('Enter secret code', type=xbmcgui.INPUT_ALPHANUM, option=xbmcgui.ALPHANUM_HIDE_INPUT)\n
        */
       String input(const String& heading,
                    const String& defaultt = emptyString,


### PR DESCRIPTION
When workin with WindowXML objects, creating some sort of contextmenu is quite painful. Both me and @ronie workarounded that in some ways (by either using DialogSelect() or by using a custom script window XML)
This should allow to get rid of these workarounds.

@tamland

EDIT: renamed to contextmenu() which suits better to overall naming.
