### PR TITLE
VideoPlayer: InputStream

### DIFF
--- a/xbmc/addons/InputStream.cpp
+++ b/xbmc/addons/InputStream.cpp
@@ -27,8 +27,7 @@
 namespace ADDON
 {
 
-bool CInputStream::m_hasConfig = false;
-std::vector<std::string> CInputStream::m_pathList;
+std::map<std::string, CInputStream::Config> CInputStream::m_configMap;
 CCriticalSection CInputStream::m_parentSection;
 
 std::unique_ptr<CInputStream> CInputStream::FromExtension(AddonProps props, const cp_extension_t* ext)
@@ -58,7 +57,15 @@ CInputStream::CInputStream(AddonProps props, std::string name, std::string listi
     StringUtils::Trim(ext);
   }
 
-  if (!m_bIsChild && !m_hasConfig)
+  bool hasConfig = false;
+
+  {
+    CSingleLock lock(m_parentSection);
+    auto it = m_configMap.find(ID());
+    hasConfig = it != m_configMap.end();
+  }
+
+  if (!m_bIsChild && !hasConfig)
     UpdateConfig();
 }
 
@@ -83,13 +90,15 @@ void CInputStream::UpdateConfig()
   }
   Destroy();
 
-  CSingleLock lock(m_parentSection);
-  m_pathList = StringUtils::Tokenize(pathList, "|");
-  for (auto &path : m_pathList)
+  Config config;
+  config.m_pathList = StringUtils::Tokenize(pathList, "|");
+  for (auto &path : config.m_pathList)
   {
     StringUtils::Trim(path);
   }
-  m_hasConfig = true;
+
+  CSingleLock lock(m_parentSection);
+  m_configMap[ID()] = config;
 }
 
 bool CInputStream::Supports(const CFileItem &fileitem)
@@ -106,9 +115,12 @@ bool CInputStream::Supports(const CFileItem &fileitem)
 
   // check paths
   CSingleLock lock(m_parentSection);
+  auto it = m_configMap.find(ID());
+  if (it == m_configMap.end())
+    return false;
 
   bool match = false;
-  for (auto &path : m_pathList)
+  for (auto &path : it->second.m_pathList)
   {
     if (path.empty())
       continue;

--- a/xbmc/addons/InputStream.h
+++ b/xbmc/addons/InputStream.h
@@ -47,6 +47,7 @@ namespace ADDON
 
     virtual void SaveSettings() override;
 
+    bool UseParent();
     bool Supports(const CFileItem &fileitem);
     bool Open(CFileItem &fileitem);
     void Close();
@@ -101,6 +102,7 @@ namespace ADDON
     struct Config
     {
       std::vector<std::string> m_pathList;
+      bool m_parentBusy;
     };
     static std::map<std::string, Config> m_configMap;
   };

--- a/xbmc/addons/InputStream.h
+++ b/xbmc/addons/InputStream.h
@@ -97,8 +97,12 @@ namespace ADDON
     std::map<int, CDemuxStream*> m_streams;
 
     static CCriticalSection m_parentSection;
-    static bool m_hasConfig;
-    static std::vector<std::string> m_pathList;
+
+    struct Config
+    {
+      std::vector<std::string> m_pathList;
+    };
+    static std::map<std::string, Config> m_configMap;
   };
 
 } /*namespace ADDON*/

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp
@@ -67,16 +67,19 @@ CDVDInputStream* CDVDFactoryInputStream::CreateInputStream(IVideoPlayer* pPlayer
   for (size_t i=0; i<addons.size(); ++i)
   {
     std::shared_ptr<ADDON::CInputStream> input(std::static_pointer_cast<ADDON::CInputStream>(addons[i]));
-    ADDON::CInputStream* clone = new ADDON::CInputStream(*input);
-    ADDON_STATUS status = clone->Supports(fileitem) ? clone->Create() : ADDON_STATUS_PERMANENT_FAILURE;
-    if (status == ADDON_STATUS_OK)
+
+    if (input->Supports(fileitem))
     {
-      if (clone->Supports(fileitem))
+      std::shared_ptr<ADDON::CInputStream> addon = input;
+      if (!input->UseParent())
+        addon = std::shared_ptr<ADDON::CInputStream>(new ADDON::CInputStream(*input));
+
+      ADDON_STATUS status = addon->Create();
+      if (status == ADDON_STATUS_OK)
       {
-        return new CInputStreamAddon(fileitem, clone);
+        return new CInputStreamAddon(fileitem, addon);
       }
     }
-    delete clone;
   }
 
   if (fileitem.IsDiscImage())

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
@@ -22,7 +22,7 @@
 #include "addons/InputStream.h"
 #include "cores/VideoPlayer/DVDClock.h"
 
-CInputStreamAddon::CInputStreamAddon(const CFileItem& fileitem, ADDON::CInputStream *inputStream)
+CInputStreamAddon::CInputStreamAddon(const CFileItem& fileitem, std::shared_ptr<ADDON::CInputStream> inputStream)
 : CDVDInputStream(DVDSTREAM_TYPE_ADDON, fileitem), m_addon(inputStream)
 {
   m_hasDemux = false;
@@ -32,7 +32,7 @@ CInputStreamAddon::~CInputStreamAddon()
 {
   Close();
   m_addon->Stop();
-  delete m_addon;
+  m_addon.reset();
 }
 
 bool CInputStreamAddon::Open()

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.h
@@ -32,7 +32,7 @@ class CInputStreamAddon :
 {
 public:
   //! \brief constructor
-  CInputStreamAddon(const CFileItem& fileitem, ADDON::CInputStream *inputStream);
+  CInputStreamAddon(const CFileItem& fileitem, std::shared_ptr<ADDON::CInputStream> inputStream);
 
   //! \brief Destructor.
   virtual ~CInputStreamAddon();
@@ -86,7 +86,7 @@ public:
   virtual void SetVideoResolution(int width, int height) override;
 
 protected:
-  ADDON::CInputStream *m_addon;
+  std::shared_ptr<ADDON::CInputStream> m_addon;
   bool m_hasDemux;
   bool m_hasDisplayTime;
   bool m_hasPosTime;


### PR DESCRIPTION
- fix use of multiple types of InputStream addons
- use parent, if not busy. safes copying the dll every time on open

@mapfau could you test this with your second addon?
