### PR TITLE
[mmalrenderer] Wait for vsync before submitting to mmal when display sync is disabled

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.h
@@ -80,7 +80,7 @@ public:
   virtual void Reset(void);
   virtual bool GetPicture(DVDVideoPicture *pDvdVideoPicture);
   virtual bool ClearPicture(DVDVideoPicture* pDvdVideoPicture);
-  virtual unsigned GetAllowedReferences() { return 3; }
+  virtual unsigned GetAllowedReferences() { return 4; }
   virtual void SetDropState(bool bDrop);
   virtual const char* GetName(void) { return m_pFormatName ? m_pFormatName:"mmal-xxx"; }
   virtual bool GetCodecStats(double &pts, int &droppedPics);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.h
@@ -28,6 +28,7 @@
 #include "settings/VideoSettings.h"
 #include "cores/VideoPlayer/DVDStreamInfo.h"
 #include "guilib/Geometry.h"
+#include "threads/Thread.h"
 
 #include <interface/mmal/mmal.h>
 #include <interface/mmal/util/mmal_util.h>
@@ -42,12 +43,13 @@ class CMMALBuffer;
 
 struct DVDVideoPicture;
 
-class CMMALRenderer : public CBaseRenderer
+class CMMALRenderer : public CBaseRenderer, public CThread
 {
 public:
   CMMALRenderer();
   ~CMMALRenderer();
 
+  void Process();
   virtual void Update();
 
   bool RenderCapture(CRenderCapture* capture);
@@ -106,6 +108,8 @@ protected:
   MMAL_COMPONENT_T *m_vout;
   MMAL_PORT_T *m_vout_input;
   MMAL_POOL_T *m_vout_input_pool;
+  MMAL_QUEUE_T *m_queue;
+  double m_error;
 
   bool init_vout(ERenderFormat format, bool opaque);
   void ReleaseBuffers();

--- a/xbmc/linux/RBP.h
+++ b/xbmc/linux/RBP.h
@@ -76,7 +76,10 @@ public:
   // stride can be null for packed output
   unsigned char *CaptureDisplay(int width, int height, int *stride, bool swap_red_blue, bool video_only = true);
   DllOMX *GetDllOMX() { return m_OMX ? m_OMX->GetDll() : NULL; }
-  void WaitVsync();
+  uint32_t LastVsync(int64_t &time);
+  uint32_t LastVsync();
+  uint32_t WaitVsync(uint32_t target = ~0U);
+  void VSyncCallback();
   int GetMBox() { return m_mb; }
 
 private:
@@ -91,7 +94,10 @@ private:
   bool       m_codec_wvc1_enabled;
   COMXCore   *m_OMX;
   DISPMANX_DISPLAY_HANDLE_T m_display;
-  CEvent     m_vsync;
+  CCriticalSection m_vsync_lock;
+  XbmcThreads::ConditionVariable m_vsync_cond;
+  uint32_t m_vsync_count;
+  int64_t m_vsync_time;
   class DllLibOMXCore;
   CCriticalSection m_critSection;
 


### PR DESCRIPTION
This avoids an issue where video occasionally goes stuttery after a seek, until the next pause/play or seek. The issue is when display sync is disabled, and framerate of video matches display, and render times are coincident with vsync you find that depending on timestamp/scheduling jitter, you may or may not get an update each vsync resulting in stuttery video.

Some scheme to force render times to be dependent on vsync is required. We do this by using a queue that is popped following vsyncs. We ensure the queue always has 1 or 2 frames so it doesn't underrun with a late frame, but this adds a frame of latency.

This also add blocking to RenderUpdate and increases the number of buffers in RenderManager to work with PR9542.
