### PR TITLE
Revert "[epg] avoid PVR thread to persist epg tables directly (sync i…

### DIFF
--- a/xbmc/epg/EpgContainer.cpp
+++ b/xbmc/epg/EpgContainer.cpp
@@ -50,7 +50,6 @@ CEpgContainer::CEpgContainer(void) :
   m_bIsInitialising = true;
   m_iNextEpgId = 0;
   m_bPreventUpdates = false;
-  m_bMarkForPersist = false;
   m_updateEvent.Reset();
   m_bStarted = false;
   m_bLoaded = false;
@@ -266,14 +265,6 @@ void CEpgContainer::LoadFromDB(void)
   m_bLoaded = bLoaded;
 }
 
-bool CEpgContainer::MarkTablesForPersist(void)
-{
-  /* Set m_bMarkForPersist to persist tables on the next Process() run but only
-  if epg.ignoredbforclient is set, otherwise persistAll does already persisting. */
-  CSingleLock lock(m_critSection);
-  return m_bMarkForPersist = CSettings::GetInstance().GetBool(CSettings::SETTING_EPG_IGNOREDBFORCLIENT);
-}
-
 bool CEpgContainer::PersistTables(void)
 {
   m_critSection.lock();
@@ -363,13 +354,6 @@ void CEpgContainer::Process(void)
     /* check for updated active tag */
     if (!m_bStop)
       CheckPlayingEvents();
-
-    /* Check if PVR requests an update of Epg Channels */
-    if (m_bMarkForPersist)
-    {
-      PersistTables();
-      m_bMarkForPersist = false;
-    }
 
     /* check for changes that need to be saved every 60 seconds */
     if (iNow - iLastSave > 60)

--- a/xbmc/epg/EpgContainer.h
+++ b/xbmc/epg/EpgContainer.h
@@ -234,21 +234,11 @@ namespace EPG
     bool IsInitialising(void) const;
 
     /*!
-     * @brief Set m_bMarkForPersist to force PersistTables() on next Process() run
-     * @return True when m_bMarkForPersist was set.
-     */
-    bool MarkTablesForPersist(void);
-
-    /*!
      * @brief Call Persist() on each table
      * @return True when they all were persisted, false otherwise.
      */
     bool PersistAll(void);
 
-    /*!
-     * @brief Call Persist() on each table
-     * @return True when they all were persisted, false otherwise.
-     */
     bool PersistTables(void);
 
     /*!
@@ -309,7 +299,6 @@ namespace EPG
     bool         m_bStarted;               /*!< true if EpgContainer has fully started */
     bool         m_bLoaded;                /*!< true after epg data is initially loaded from the database */
     bool         m_bPreventUpdates;        /*!< true to prevent EPG updates */
-    bool         m_bMarkForPersist;        /*!< true to update channel Epgs called from PVR  */
     int          m_pendingUpdates;         /*!< count of pending manual updates */
     time_t       m_iLastEpgCleanup;        /*!< the time the EPG was cleaned up */
     time_t       m_iNextEpgUpdate;         /*!< the time the EPG will be updated */

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
@@ -342,7 +342,6 @@ bool CPVRChannelGroupInternal::CreateChannelEpgs(bool bForce /* = false */)
 
   if (HasChangedChannels())
   {
-    g_EpgContainer.PersistTables();
     return Persist();
   }
 

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
@@ -342,7 +342,7 @@ bool CPVRChannelGroupInternal::CreateChannelEpgs(bool bForce /* = false */)
 
   if (HasChangedChannels())
   {
-    g_EpgContainer.MarkTablesForPersist();
+    g_EpgContainer.PersistTables();
     return Persist();
   }
 


### PR DESCRIPTION
…ssue with epg thread)"

this change makes no sense. It triggers Persist for systems that want to ignore DB

This reverts commit be24ceb3211aa5b1d0cc6a8395ba29a0b005f0be.

reverts https://github.com/xbmc/xbmc/pull/7367

fixes very slow EPG loading for VNSI that does nor require DB. 
