### PR TITLE
fix CGUIWindowMedia::OnClick() overrides

### DIFF
--- a/xbmc/addons/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/GUIWindowAddonBrowser.cpp
@@ -212,7 +212,7 @@ bool CGUIWindowAddonBrowser::OnClick(int iItem, const std::string &player)
   if (item->IsPath("addons://search/"))
     return Update(item->GetPath());
 
-  return CGUIMediaWindow::OnClick(iItem);
+  return CGUIMediaWindow::OnClick(iItem, player);
 }
 
 void CGUIWindowAddonBrowser::UpdateButtons()

--- a/xbmc/interfaces/legacy/WindowXML.cpp
+++ b/xbmc/interfaces/legacy/WindowXML.cpp
@@ -66,7 +66,7 @@ namespace XBMCAddon
       { XBMC_TRACE; if(up()) CGUIMediaWindow::AllocResources(forceLoad); else checkedv(AllocResources(forceLoad)); }
       virtual  void FreeResources(bool forceUnLoad = false)
       { XBMC_TRACE; if(up()) CGUIMediaWindow::FreeResources(forceUnLoad); else checkedv(FreeResources(forceUnLoad)); }
-      virtual bool OnClick(int iItem) { XBMC_TRACE; return up() ? CGUIMediaWindow::OnClick(iItem) : checkedb(OnClick(iItem)); }
+      virtual bool OnClick(int iItem, const std::string &player = "") override { XBMC_TRACE; return up() ? CGUIMediaWindow::OnClick(iItem, player) : checkedb(OnClick(iItem)); }
 
       virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
       { XBMC_TRACE; if(up()) CGUIMediaWindow::Process(currentTime,dirtyregions); else checkedv(Process(currentTime,dirtyregions)); }

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -233,7 +233,7 @@ std::string CGUIWindowMusicNav::GetQuickpathName(const std::string& strPath) con
   }
 }
 
-bool CGUIWindowMusicNav::OnClick(int iItem)
+bool CGUIWindowMusicNav::OnClick(int iItem, const std::string &player /* = "" */)
 {
   if (iItem < 0 || iItem >= m_vecItems->Size()) return false;
 
@@ -253,7 +253,7 @@ bool CGUIWindowMusicNav::OnClick(int iItem)
   if (item->IsMusicDb() && !item->m_bIsFolder)
     m_musicdatabase.SetPropertiesForFileItem(*item);
     
-  return CGUIWindowMusicBase::OnClick(iItem);
+  return CGUIWindowMusicBase::OnClick(iItem, player);
 }
 
 bool CGUIWindowMusicNav::Update(const std::string &strDirectory, bool updateFilterPath /* = true */)

--- a/xbmc/music/windows/GUIWindowMusicNav.h
+++ b/xbmc/music/windows/GUIWindowMusicNav.h
@@ -46,7 +46,7 @@ protected:
   virtual void OnWindowLoaded();
   virtual void GetContextButtons(int itemNumber, CContextButtons &buttons);
   virtual bool OnContextButton(int itemNumber, CONTEXT_BUTTON button);
-  virtual bool OnClick(int iItem);
+  virtual bool OnClick(int iItem, const std::string &player = "") override;
   virtual std::string GetStartFolder(const std::string &url);
 
   bool GetSongsFromPlayList(const std::string& strPlayList, CFileItemList &items);

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -285,7 +285,7 @@ bool CGUIWindowPictures::OnClick(int iItem, const std::string &player)
     OnShowPictureRecursive(pathToUrl.Get());
     return true;
   }
-  else if (CGUIMediaWindow::OnClick(iItem))
+  else if (CGUIMediaWindow::OnClick(iItem, player))
     return true;
 
   return false;


### PR DESCRIPTION
Someone forgot to fix some of the overrides and some of the calls related to `CGUIWindowMedia::OnClick()` when the signature of the method was changed.

Right now the overrides in `CGUIWindowMusicNav` and `xbmcgui::WindowXMLInterceptor` don't work at all resulting in wrong behaviour due to the overrides not being called.
