### PR TITLE
[python-api] - do not use core context menus for WindowXML containers

### DIFF
--- a/xbmc/interfaces/legacy/WindowXML.cpp
+++ b/xbmc/interfaces/legacy/WindowXML.cpp
@@ -374,6 +374,9 @@ namespace XBMCAddon
                 PulseActionEvent();
                 return true;
               }
+              // the core context menu can lead to all sort of issues right now when used with WindowXMLs, so lets intercept the corresponding message
+              else if (controlClicked->IsContainer() && message.GetParam1() == ACTION_CONTEXT_MENU)
+                return true;
             }
           }
         }

--- a/xbmc/interfaces/legacy/WindowXML.cpp
+++ b/xbmc/interfaces/legacy/WindowXML.cpp
@@ -319,6 +319,10 @@ namespace XBMCAddon
         }
         break;
 
+      case GUI_MSG_NOTIFY_ALL:
+        // GUI_MSG_NOTIFY_ALL breaks container content, so intercept it.
+        return true;
+
       case GUI_MSG_CLICKED:
         {
           int iControl=message.GetSenderId();


### PR DESCRIPTION
@tamland  
This fixes the issues I mentioned in https://github.com/xbmc/xbmc/pull/9595 
Core context menu doesnt really work with listitems added to WindowXML instances, so let script authors deal with that via onAction().
