### PR TITLE
drop outdated nvidia GL hack

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -711,13 +711,6 @@ bool CApplication::CreateGUI()
 
 #endif // HAS_SDL
 
-#ifdef TARGET_POSIX
-  // for nvidia cards - vsync currently ALWAYS enabled.
-  // the reason is that after screen has been setup changing this env var will make no difference.
-  setenv("__GL_SYNC_TO_VBLANK", "1", 0);
-  setenv("__GL_YIELD", "USLEEP", 0);
-#endif
-
   m_bSystemScreenSaverEnable = g_Windowing.IsSystemScreenSaverEnabled();
   g_Windowing.EnableSystemScreenSaver(false);
 


### PR DESCRIPTION
this old stuff does more harm than any good. we don't want the render thread do a busy loop when waiting for events like swapBuffers.
