### PR TITLE
fix description label in select dialog

### DIFF
--- a/addons/skin.estuary/1080i/DialogSelect.xml
+++ b/addons/skin.estuary/1080i/DialogSelect.xml
@@ -83,7 +83,7 @@
 						<height>60</height>
 						<font>font12</font>
 						<textcolor>grey</textcolor>
-						<label>$INFO[ListItem.AddonSummary]</label>
+						<label>$INFO[ListItem.Label2]</label>
 					</control>
 				</itemlayout>
 				<focusedlayout height="125" width="880">
@@ -128,7 +128,7 @@
 						<height>60</height>
 						<font>font12</font>
 						<textcolor>grey</textcolor>
-						<label>$INFO[ListItem.AddonSummary]</label>
+						<label>$INFO[ListItem.Label2]</label>
 					</control>
 				</focusedlayout>
 			</control>

--- a/xbmc/addons/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/GUIDialogAddonInfo.cpp
@@ -283,13 +283,13 @@ void CGUIDialogAddonInfo::OnUpdate()
     AddonPtr repo;
     if (versionInfo.second == LOCAL_CACHE)
     {
-      item.SetProperty("Addon.Summary", g_localizeStrings.Get(24095));
+      item.SetLabel2(g_localizeStrings.Get(24095));
       item.SetIconImage("DefaultAddonRepository.png");
       dialog->Add(item);
     }
     else if (CAddonMgr::GetInstance().GetAddon(versionInfo.second, repo, ADDON_REPOSITORY))
     {
-      item.SetProperty("Addon.Summary", repo->Name());
+      item.SetLabel2(repo->Name());
       item.SetIconImage(repo->Icon());
       dialog->Add(item);
     }

--- a/xbmc/addons/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/GUIWindowAddonBrowser.cpp
@@ -431,6 +431,7 @@ int CGUIWindowAddonBrowser::SelectAddonID(const std::vector<ADDON::TYPE> &types,
   for (ADDON::IVECADDONS addon = addons.begin(); addon != addons.end(); ++addon)
   {
     CFileItemPtr item(CAddonsDirectory::FileItemFromAddon(*addon, (*addon)->ID()));
+    item->SetLabel2((*addon)->Summary());
     if (!items.Contains(item->GetPath()))
     {
       items.Add(item);

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -656,8 +656,6 @@ CFileItemPtr CAddonsDirectory::FileItemFromAddon(const AddonPtr &addon,
   //TODO: fix hacks that depends on these
   item->SetProperty("Addon.ID", addon->ID());
   item->SetProperty("Addon.Name", addon->Name());
-  item->SetProperty("Addon.Version", addon->Version().asString());
-  item->SetProperty("Addon.Summary", addon->Summary());
   const auto it = addon->ExtraInfo().find("language");
   if (it != addon->ExtraInfo().end())
     item->SetProperty("Addon.Language", it->second);

--- a/xbmc/filesystem/BlurayDirectory.cpp
+++ b/xbmc/filesystem/BlurayDirectory.cpp
@@ -74,7 +74,7 @@ CFileItemPtr CBlurayDirectory::GetTitle(const BLURAY_TITLE_INFO* title, const st
   item->m_strTitle = buf;
   item->SetLabel(buf);
   chap = StringUtils::Format(g_localizeStrings.Get(25007).c_str(), title->chapter_count, StringUtils::SecondsToTimeString(duration).c_str());
-  item->SetProperty("Addon.Summary", chap);
+  item->SetProperty("Description", chap);
   item->m_dwSize = 0;
   item->SetIconImage("DefaultVideo.png");
   for(unsigned int i = 0; i < title->clip_count; ++i)

--- a/xbmc/peripherals/bus/PeripheralBus.cpp
+++ b/xbmc/peripherals/bus/PeripheralBus.cpp
@@ -301,7 +301,7 @@ void CPeripheralBus::GetDirectory(const std::string &strPath, CFileItemList &ite
       strDetails = StringUtils::Format("%s: %s", g_localizeStrings.Get(126).c_str(), g_localizeStrings.Get(13106).c_str());
 
     peripheralFile->SetProperty("version", strVersion);
-    peripheralFile->SetProperty("Addon.Summary", strDetails);
+    peripheralFile->SetLabel2(strDetails);
     peripheralFile->SetIconImage("DefaultAddon.png");
     items.Add(peripheralFile);
   }

--- a/xbmc/profiles/windows/GUIWindowSettingsProfile.cpp
+++ b/xbmc/profiles/windows/GUIWindowSettingsProfile.cpp
@@ -251,7 +251,7 @@ bool CGUIWindowSettingsProfile::GetAutoLoginProfileChoice(int &iProfile)
     const CProfile *profile = CProfilesManager::GetInstance().GetProfile(i);
     std::string locked = g_localizeStrings.Get(profile->getLockMode() > 0 ? 20166 : 20165);
     CFileItemPtr item(new CFileItem(profile->getName()));
-    item->SetProperty("Addon.Summary", locked); // lock setting
+    item->SetLabel2(locked); // lock setting
     std::string thumb = profile->getThumb();
     if (thumb.empty())
       thumb = "DefaultUser.png";
@@ -261,6 +261,7 @@ bool CGUIWindowSettingsProfile::GetAutoLoginProfileChoice(int &iProfile)
 
   dialog->SetHeading(CVariant{20093}); // Profile name
   dialog->Reset();
+  dialog->SetUseDetails(true);
   dialog->SetItems(items);
   dialog->SetSelected(autoLoginProfileId);
   dialog->Open();


### PR DESCRIPTION
Removes the 'addon.summary' properties abused by non-addon items in the select dialog which (surprise!) broke in a recent skin refactor. @phil65 fyi.
