### PR TITLE
[cmake] Add missing dependencies to libcpluff

### DIFF
--- a/xbmc/input/joysticks/CMakeLists.txt
+++ b/xbmc/input/joysticks/CMakeLists.txt
@@ -18,3 +18,4 @@ set(HEADERS DefaultJoystick.h
             KeymapHandler.h)
 
 core_add_library(input_joystick)
+add_dependencies(input_joystick libcpluff)

--- a/xbmc/listproviders/CMakeLists.txt
+++ b/xbmc/listproviders/CMakeLists.txt
@@ -7,3 +7,4 @@ set(HEADERS DirectoryProvider.h
             StaticProvider.h)
 
 core_add_library(listproviders)
+add_dependencies(listproviders libcpluff)

--- a/xbmc/messaging/CMakeLists.txt
+++ b/xbmc/messaging/CMakeLists.txt
@@ -5,3 +5,4 @@ set(HEADERS ApplicationMessenger.h
             ThreadMessage.h)
 
 core_add_library(messaging)
+add_dependencies(messaging libcpluff)

--- a/xbmc/network/upnp/CMakeLists.txt
+++ b/xbmc/network/upnp/CMakeLists.txt
@@ -23,5 +23,6 @@ include_directories(${CORE_SOURCE_DIR}/lib/libUPnP
                     ${CORE_SOURCE_DIR}/lib/libUPnP/Neptune/Source/Core)
 
 add_definitions(-DNPT_CONFIG_ENABLE_LOGGING)
-  
+
 core_add_library(network_upnp)
+add_dependencies(network_upnp libcpluff)

--- a/xbmc/platform/CMakeLists.txt
+++ b/xbmc/platform/CMakeLists.txt
@@ -6,3 +6,4 @@ set(HEADERS MessagePrinter.h
             XbmcContext.h)
 
 core_add_library(platform_common)
+add_dependencies(platform_common libcpluff)

--- a/xbmc/profiles/CMakeLists.txt
+++ b/xbmc/profiles/CMakeLists.txt
@@ -5,3 +5,4 @@ set(HEADERS Profile.h
             ProfilesManager.h)
 
 core_add_library(profiles)
+add_dependencies(profiles libcpluff)

--- a/xbmc/profiles/windows/CMakeLists.txt
+++ b/xbmc/profiles/windows/CMakeLists.txt
@@ -3,3 +3,4 @@ set(SOURCES GUIWindowSettingsProfile.cpp)
 set(HEADERS GUIWindowSettingsProfile.h)
 
 core_add_library(profiles_windows)
+add_dependencies(profiles_windows libcpluff)

--- a/xbmc/pvr/addons/CMakeLists.txt
+++ b/xbmc/pvr/addons/CMakeLists.txt
@@ -3,3 +3,4 @@ set(SOURCES PVRClients.cpp)
 set(HEADERS PVRClients.h)
 
 core_add_library(pvr_addons)
+add_dependencies(pvr_addons libcpluff)

--- a/xbmc/windowing/CMakeLists.txt
+++ b/xbmc/windowing/CMakeLists.txt
@@ -22,3 +22,4 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
 endif()
 
 core_add_library(windowing)
+add_dependencies(windowing libcpluff)

--- a/xbmc/windowing/X11/CMakeLists.txt
+++ b/xbmc/windowing/X11/CMakeLists.txt
@@ -15,3 +15,4 @@ set(HEADERS GLContext.h
             XRandR.h)
 
 core_add_library(windowing_X11)
+add_dependencies(windowing_X11 libcpluff)


### PR DESCRIPTION
Some more missing add_dependencies(target libcpluff) lines were
missing. Fixes errors like the following when doing parallel build:

In file included from xbmc/addons/AddonManager.h:33:0,
                 from xbmc/ServiceManager.h:23,
                 from xbmc/Application.h:30,
                 from xbmc/windowing/X11/WinSystemX11GLContext.cpp:36
lib/cpluff/libcpluff/cpluff.h:44:23:
fatal error: cpluffdef.h: No such file or directory
