### PR TITLE
Stop scanning directory if scan is cancelled.

### DIFF
--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -139,7 +139,11 @@ namespace VIDEO
          * occurs.
          */
         std::string directory = *m_pathsToScan.begin();
-        if (!CDirectory::Exists(directory))
+        if (m_bStop)
+        {
+          bCancelled = true;
+        }
+        else if (!CDirectory::Exists(directory))
         {
           /*
            * Note that this will skip clean (if m_bClean is enabled) if the directory really


### PR DESCRIPTION
If the list of paths are remote directories which are unreachable it won't enter the DoScan function (because the directories will be seen as non-existent) and it continues the scan of the directories. So we allow the possibility to exit the directory scan loop at each iteration.

For example if there is 10 remote directories and we are stopping the scan after 6, it would avoid to have 4 connections timeout before exiting the loop.
