### PR TITLE
Use aligned_malloc when using buffers with sws_scale

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/DVDCodecUtils.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/DVDCodecUtils.cpp
@@ -76,7 +76,7 @@ DVDVideoPicture* CDVDCodecUtils::AllocatePicture(int iWidth, int iHeight)
 
 void CDVDCodecUtils::FreePicture(DVDVideoPicture* pPicture)
 {
-  delete[] pPicture->data[0];
+  av_free(pPicture->data[0]);
   delete pPicture;
 }
 
@@ -185,7 +185,7 @@ DVDVideoPicture* CDVDCodecUtils::ConvertToNV12Picture(DVDVideoPicture *pSrc)
     int h = pPicture->iHeight / 2;
     int size = w * h;
     int totalsize = (pPicture->iWidth * pPicture->iHeight) + size * 2;
-    uint8_t* data = new uint8_t[totalsize];
+    uint8_t* data = (uint8_t*) av_malloc(totalsize);
     if (data)
     {
       pPicture->data[0] = data;
@@ -239,7 +239,7 @@ DVDVideoPicture* CDVDCodecUtils::ConvertToYUV422PackedPicture(DVDVideoPicture *p
     *pPicture = *pSrc;
 
     int totalsize = pPicture->iWidth * pPicture->iHeight * 2;
-    uint8_t* data = new uint8_t[totalsize];
+    uint8_t* data = (uint8_t*) av_malloc(totalsize);
 
     if (data)
     {

--- a/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
@@ -272,7 +272,7 @@ bool CDVDFileInfo::ExtractThumb(const std::string &strPath,
               aspect = hint.aspect;
             unsigned int nHeight = (unsigned int)((double)g_advancedSettings.m_imageRes / aspect);
 
-            uint8_t *pOutBuf = new uint8_t[nWidth * nHeight * 4];
+            uint8_t *pOutBuf = (uint8_t*)av_malloc(nWidth * nHeight * 4);
             struct SwsContext *context = sws_getContext(picture.iWidth, picture.iHeight,
                   AV_PIX_FMT_YUV420P, nWidth, nHeight, AV_PIX_FMT_BGRA, SWS_FAST_BILINEAR, NULL, NULL, NULL);
 
@@ -291,8 +291,7 @@ bool CDVDFileInfo::ExtractThumb(const std::string &strPath,
               CPicture::CacheTexture(pOutBuf, nWidth, nHeight, nWidth * 4, orientation, nWidth, nHeight, CTextureCache::GetCachedPath(details.file));
               bOk = true;
             }
-
-            delete [] pOutBuf;
+            av_free(pOutBuf);
           }
         }
         else

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
@@ -170,7 +170,7 @@ CLinuxRendererGL::~CLinuxRendererGL()
   }
   else
   {
-    delete [] m_rgbBuffer;
+    av_free(m_rgbBuffer);
     m_rgbBuffer = NULL;
   }
 
@@ -1003,7 +1003,7 @@ void CLinuxRendererGL::UnInit()
   }
   else
   {
-    delete [] m_rgbBuffer;
+    av_free(m_rgbBuffer);
     m_rgbBuffer = NULL;
   }
   m_rgbBufferSize = 0;
@@ -2581,7 +2581,7 @@ void CLinuxRendererGL::SetupRGBBuffer()
   m_rgbBufferSize = m_sourceWidth * m_sourceHeight * 4;
 
   if (!m_rgbPbo)
-    delete [] m_rgbBuffer;
+    av_free(m_rgbBuffer);
 
   if (m_pboSupported)
   {
@@ -2610,7 +2610,7 @@ void CLinuxRendererGL::SetupRGBBuffer()
   }
 
   if (!m_rgbPbo)
-    m_rgbBuffer = new BYTE[m_rgbBufferSize];
+    m_rgbBuffer = (BYTE*) av_malloc(m_rgbBufferSize);
 }
 
 bool CLinuxRendererGL::UploadRGBTexture(int source)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -128,7 +128,7 @@ CLinuxRendererGLES::~CLinuxRendererGLES()
   UnInit();
 
   if (m_rgbBuffer != NULL) {
-    delete [] m_rgbBuffer;
+    av_free(m_rgbBuffer);
     m_rgbBuffer = NULL;
   }
 
@@ -690,7 +690,7 @@ void CLinuxRendererGLES::UnInit()
 
   if (m_rgbBuffer != NULL)
   {
-    delete [] m_rgbBuffer;
+    av_free(m_rgbBuffer);
     m_rgbBuffer = NULL;
   }
   m_rgbBufferSize = 0;
@@ -1272,9 +1272,9 @@ void CLinuxRendererGLES::UploadYV12Texture(int source)
   {
     if(m_rgbBufferSize < m_sourceWidth * m_sourceHeight * 4)
     {
-      delete [] m_rgbBuffer;
+      av_free(m_rgbBuffer);
       m_rgbBufferSize = m_sourceWidth*m_sourceHeight*4;
-      m_rgbBuffer = new BYTE[m_rgbBufferSize];
+      m_rgbBuffer = (BYTE*) av_malloc(m_rgbBufferSize);
     }
 
 #if defined(__ARM_NEON__) && !defined(__LP64__)


### PR DESCRIPTION
Since ffmpeg 3 we heavily segfault under certain conditions as ffmpeg sometimes asumes 16 byte aligned memory adresses, which are normally guaranteed when using ffmpeg's alloc methods. As we supply external buffers we need to take great care.

Let's see which includes are missing for Windows, OSX and so on.

Edit: To add, I talked with the ffmpeg guys and they highly, highly suggest to use proper alignment as it will be totally slow when not doing so.
