### PR TITLE
Better handling of mis-matching musicbrianz album artist id and hints tags

### DIFF
--- a/xbmc/music/Song.cpp
+++ b/xbmc/music/Song.cpp
@@ -36,12 +36,17 @@ CSong::CSong(CFileItem& item)
   strTitle = tag.GetTitle();
   genre = tag.GetGenre();
   std::vector<std::string> artist = tag.GetArtist();
-  std::vector<std::string> musicBrainArtistHints = tag.GetMusicBrainzArtistHints();
+  std::vector<std::string> musicBrainzArtistHints = tag.GetMusicBrainzArtistHints();
   strArtistDesc = tag.GetArtistString();
+
   if (!tag.GetMusicBrainzArtistID().empty())
   { // Have musicbrainz artist info, so use it
+
+    // Vector of possible separators in the order least likely to be part of artist name
+    const std::vector<std::string> separators{ " feat. ", ";", ":", "|", "#", "/", ",", "&" };
+
     // Establish tag consistency - do the number of musicbrainz ids and number of names in hints or artist match
-    if (tag.GetMusicBrainzArtistID().size() != musicBrainArtistHints.size() &&
+    if (tag.GetMusicBrainzArtistID().size() != musicBrainzArtistHints.size() &&
         tag.GetMusicBrainzArtistID().size() != artist.size())
     {
       // Tags mis-match - report it and then try to fix
@@ -53,18 +58,39 @@ CSong::CSong(CFileItem& item)
         expected single item separator (default = space-slash-space) as not been used.
         Comma and slash (no spaces) are poor delimiters as could be in name e.g. AC/DC,
         but here treat them as such in attempt to find artist names.
+        When there are hints they could be poorly formatted using unexpected separators,
+        so attempt to split them. Or we could have more hints or artist names than
+        musicbrainz so ingore them but raise warning.
       */
-      if (artist.size() == 1)
+      // Do hints exist yet mis-match
+      if (musicBrainzArtistHints.size() > 0 &&
+        musicBrainzArtistHints.size() != tag.GetMusicBrainzArtistID().size())
       {
-        std::vector<std::string> names;
-        if (artist[0].find(" feat. ") != std::string::npos)
-          names = StringUtils::Split(artist[0], " feat. ");
-        else 
-          names = StringUtils::SplitMulti(artist[0], "/;:|#,");
-        //If we have extracted the right number of names then use them as hints
-        if (tag.GetMusicBrainzArtistID().size() == names.size())
-          musicBrainArtistHints = names;
-      }     
+        if (tag.GetArtist().size() == tag.GetMusicBrainzArtistID().size())
+          // Artist name count matches, use that as hints
+          musicBrainzArtistHints = tag.GetArtist();
+        else if (musicBrainzArtistHints.size() < tag.GetMusicBrainzArtistID().size())
+        { // Try splitting the hints until have matching number
+          musicBrainzArtistHints = StringUtils::SplitMulti(musicBrainzArtistHints, separators, tag.GetMusicBrainzArtistID().size());
+        }
+        else
+          // Extra hints, discard them.
+          musicBrainzArtistHints.resize(tag.GetMusicBrainzArtistID().size());
+      }
+      // Do hints not exist or still mis-match, try artists
+      if (musicBrainzArtistHints.size() != tag.GetMusicBrainzArtistID().size())
+        musicBrainzArtistHints = tag.GetArtist();
+      // Still mis-match, try splitting the hints (now artists) until have matching number
+      if (musicBrainzArtistHints.size() < tag.GetMusicBrainzArtistID().size())
+      {
+        musicBrainzArtistHints = StringUtils::SplitMulti(musicBrainzArtistHints, separators, tag.GetMusicBrainzArtistID().size());
+      }
+    }
+    else
+    { // Either hints or artist names (or both) matches number of musicbrainz id
+      // If hints mis-match, use artists
+      if (musicBrainzArtistHints.size() != tag.GetMusicBrainzArtistID().size())
+        musicBrainzArtistHints = tag.GetAlbumArtist();
     }
 
     for (size_t i = 0; i < tag.GetMusicBrainzArtistID().size(); i++)
@@ -73,16 +99,13 @@ CSong::CSong(CFileItem& item)
       std::string artistName;
       /*
        We try and get the corresponding artist name from the hints list.
-       If the hints list is missing or the wrong length, it will try the artist list.
-       We match on the same index, and if that fails just use the first name we have.
-       Failing all else use musicbrainz id as the name and hope later on we can update that entry.
-       If we have more names than musicbrainz id they are ingored, but raise warning.
+       Having already attempted to make the number of hints match, if they
+       still don't then use musicbrainz id as the name and hope later on we
+       can update that entry.
       */
-      if (i < musicBrainArtistHints.size())
-        artistName = musicBrainArtistHints[i];
-      else if (!artist.empty())
-        artistName = (i < artist.size()) ? artist[i] : artist[0];
-      if (artistName.empty())
+      if (i < musicBrainzArtistHints.size())
+        artistName = musicBrainzArtistHints[i];
+      else
         artistName = artistId;
       artistCredits.emplace_back(StringUtils::Trim(artistName), artistId);
     }

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -759,26 +759,56 @@ std::vector<std::string> StringUtils::Split(const std::string& input, const char
   return results;
 }
 
-std::vector<std::string> StringUtils::SplitMulti(const std::string& input, const char* delimiters, size_t iMaxStrings /*= 0*/)
+std::vector<std::string> StringUtils::SplitMulti(const std::vector<std::string> &input, const std::vector<std::string> &delimiters, unsigned int iMaxStrings /* = 0 */)
 {
-  std::vector<std::string> results;
   if (input.empty())
+    return std::vector<std::string>(); 
+
+  std::vector<std::string> results(input);
+
+  if (delimiters.empty() || (iMaxStrings > 0 && iMaxStrings <= input.size()))
     return results;
 
-  size_t nextDelim;
-  size_t textPos = 0;
-  do
+  std::vector<std::string> strings1;
+  if (iMaxStrings == 0)
   {
-    if (--iMaxStrings == 0)
+    for (size_t di = 0; di < delimiters.size(); di++)
     {
-      results.push_back(input.substr(textPos));
-      break;
+      for (size_t i = 0; i < results.size(); i++)
+      {
+        std::vector<std::string> substrings = StringUtils::Split(results[i], delimiters[di]);
+        for (size_t j = 0; j < substrings.size(); j++)
+          strings1.push_back(substrings[j]);
+      }
+      results = strings1;
+      strings1.clear();
     }
-    nextDelim = input.find_first_of(delimiters, textPos);
-    results.push_back(input.substr(textPos, nextDelim - textPos));
-    textPos = nextDelim + 1;
-  } while (nextDelim != std::string::npos);
+    return results;
+  }
 
+  // Control the number of strings input is split into, keeping the original strings. 
+  // Note iMaxStrings > input.size() 
+  int iNew = iMaxStrings - results.size();
+  for (size_t di = 0; di < delimiters.size(); di++)
+  {
+    for (size_t i = 0; i < results.size(); i++)
+    {
+      if (iNew > 0)
+      {
+        std::vector<std::string> substrings = StringUtils::Split(results[i], delimiters[di], iNew + 1);
+        iNew = iNew - substrings.size() + 1;
+        for (size_t j = 0; j < substrings.size(); j++)
+          strings1.push_back(substrings[j]);
+      }
+      else
+        strings1.push_back(results[i]);
+    }
+    results = strings1;
+    iNew = iMaxStrings - results.size();
+    strings1.clear();
+    if ((iNew <= 0))
+      break;  //Stop trying any more delimiters
+  }
   return results;
 }
 

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -103,7 +103,22 @@ public:
    */
   static std::vector<std::string> Split(const std::string& input, const std::string& delimiter, unsigned int iMaxStrings = 0);
   static std::vector<std::string> Split(const std::string& input, const char delimiter, size_t iMaxStrings = 0);
-  static std::vector<std::string> SplitMulti(const std::string& input, const char* delimiters, size_t iMaxStrings = 0);
+  
+  /*! \brief Splits the given input strings using the given delimiters into further separate strings.
+
+  If the given input string vector is empty the result will be an empty array (not
+  an array containing an empty string).
+
+  Delimiter strings are applied in order, so once the (optional) maximum number of 
+  items is produced no other delimters are applied. This produces different results
+  to applying all delimiters at once e.g. "a/b#c/d" becomes "a", "b#c", "d" rather
+  than "a", "b", "c/d"
+
+  \param input Input vector of strings each to be split
+  \param delimiters Delimiter strings to be used to split the input strings
+  \param iMaxStrings (optional) Maximum number of resulting split strings
+  */
+  static std::vector<std::string> SplitMulti(const std::vector<std::string> &input, const std::vector<std::string> &delimiters, unsigned int iMaxStrings = 0);
   static int FindNumber(const std::string& strInput, const std::string &strFind);
   static int64_t AlphaNumericCompare(const wchar_t *left, const wchar_t *right);
   static long TimeStringToSeconds(const std::string &timeString);


### PR DESCRIPTION
A follow on from #8904 with more improved handling of mis-matching numbers of Musicbrainz (Album) Artist Ids and (Album) Artist tags when creating songs and albums.

Primarily this was to fix an issue where missing hints (ALBUMARTISTS tag) was causing the album artist tag to be ignored (even when matched mbid) and artist hints and names to be used instead to get album artist names to match the number of mbid. If there was  a mis-match of artist names and mbid then the results were quite confusing. 
For example:
ARTIST = "artist1 feat. artist2"
MUSICBRAINZ ARTISTID = mbid1
MUSICBRAINZ ARTISTID = mbid2
ALBUMARTIST = "artist1"
MUSICBRAINZ ALBUMARTISTID = mbid1

resulted in an artist named "artist1 feat. artist2" with mbid1 for the album even though the number of album artist names and mbids matched, and the lack of ARTISTS tag and mis-match of mbid <-> name count would have been repaired for the song.

Also a user managed to have ARTISTS and ALBUMARTISTS tags present but as single string with an unexpected separator. If one user can do it so can others, so a more flexible approach to parsing both (ALBUM)ARTIST and (ALBUM)ARTISTS tags when the number of names does not match the number of Musicbrainz ids seems worthwhile.

Hence when an inconsistency in the number of artist names to mbid occurrs this applies improved parsing to both hints and names, using multiple item separators progressively, in an attempt to correctly interpret the way music files have been tagged.

@Razzeee got some time to look at this? The sooner it is out there getting more real user data through it the better
