### PR TITLE
[python-api] - several additions

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -10090,11 +10090,15 @@ std::string CGUIInfoManager::GetItemLabel(const CFileItem *item, int info, std::
   case LISTITEM_DBID:
     if (item->HasVideoInfoTag())
       {
-        return StringUtils::Format("%i", item->GetVideoInfoTag()->m_iDbId);
+        int dbId = item->GetVideoInfoTag()->m_iDbId;
+        if (dbId > -1)
+          return StringUtils::Format("%i", dbId);
       }
     if (item->HasMusicInfoTag())
       {
-        return StringUtils::Format("%i", item->GetMusicInfoTag()->GetDatabaseId());
+        int dbId = item->GetMusicInfoTag()->GetDatabaseId();
+        if (dbId > -1)
+          return StringUtils::Format("%i", dbId);
       }
     break;
   case LISTITEM_STEREOSCOPIC_MODE:

--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -284,7 +284,9 @@ namespace XBMCAddon
           const InfoLabelValue& alt = it->second;
           const String value(alt.which() == first ? alt.former() : emptyString);
 
-          if (key == "year")
+          if (key == "dbid")
+            item->GetVideoInfoTag()->m_iDbId = strtol(value.c_str(), NULL, 10);
+          else if (key == "year")
             item->GetVideoInfoTag()->m_iYear = strtol(value.c_str(), NULL, 10);
           else if (key == "episode")
             item->GetVideoInfoTag()->m_iEpisode = strtol(value.c_str(), NULL, 10);

--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -224,6 +224,13 @@ namespace XBMCAddon
       return value;
     }
 
+    String ListItem::getArt(const char* key)
+    {
+      LOCKGUI;
+      return item->GetArt(key);
+    }
+
+
     void ListItem::setPath(const String& path)
     {
       LOCKGUI;

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -333,6 +333,27 @@ namespace XBMCAddon
       String getProperty(const char* key);
 
       /**
+       * getArt(key) -- Returns a listitem art path as a string, similar to an infolabel.\n
+       * \n
+       * key            : string - art name.\n
+       * \n
+       *
+       * - Some default art values (any string possible):
+       *     - thumb         : string - image path
+       *     - poster        : string - image path
+       *     - banner        : string - image path
+       *     - fanart        : string - image path
+       *     - clearart      : string - image path
+       *     - clearlogo     : string - image path
+       *     - landscape     : string - image path
+       *     - icon          : string - image path
+       *
+       * example:
+       *   - poster = self.list.getSelectedItem().getArt('poster')
+       */
+      String getArt(const char* key);
+
+      /**
        * setPath(path) -- Sets the listitem's path.\n
        * \n
        * path           : string or unicode - path, activated when item is clicked.\n

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -230,6 +230,7 @@ namespace XBMCAddon
        *     - trailer       : string (/home/user/trailer.avi)
        *     - dateadded     : string (%Y-%m-%d %h:%m:%s = 2009-04-05 23:16:04)
        *     - mediatype     : string - "video", "movie", "tvshow", "season", "episode" or "musicvideo"
+       *     - dbid          : integer (23) - Only add this for items which are part of the local db. You also need to set the correct 'mediatype'!
        * - Music Values:
        *     - tracknumber   : integer (8)
        *     - discnumber    : integer (2)

--- a/xbmc/interfaces/legacy/WindowXML.cpp
+++ b/xbmc/interfaces/legacy/WindowXML.cpp
@@ -262,6 +262,13 @@ namespace XBMCAddon
       A(m_vecItems)->SetProperty(key, value);
     }
 
+    int WindowXML::getCurrentContainerId()
+    {
+      XBMC_TRACE;
+      LOCKGUI;
+      return A(m_viewControl.GetCurrentControl());
+    }
+
     bool WindowXML::OnAction(const CAction &action)
     {
       XBMC_TRACE;

--- a/xbmc/interfaces/legacy/WindowXML.h
+++ b/xbmc/interfaces/legacy/WindowXML.h
@@ -154,6 +154,17 @@ namespace XBMCAddon
        */
       SWIGHIDDENVIRTUAL void setContainerProperty(const String &strProperty, const String &strValue);
 
+      /**
+       * getCurrentContainerId() -- Get the id of the currently visible container
+       * 
+       * 
+       * example:\n
+       *   - container_id = self.getCurrentContainerId()
+       */
+
+      SWIGHIDDENVIRTUAL int getCurrentContainerId();
+
+
 #ifndef SWIG
       // CGUIWindow
       SWIGHIDDENVIRTUAL bool      OnMessage(CGUIMessage& message);


### PR DESCRIPTION
- getCurrentContainerId() allows to properly use the core viewtype management for WindowXML instances.
- setInfo("dbid", xxx) allows to properly emulate database items. This is especially important for stuff like the dataprovider script from @BigNoid. Several context item add-ons depend on listitem.dbid for example.
- getArt() should also be self-explaining.  

@tamland        
