### PR TITLE
AE: fix going to idle state after change of refresh rate

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -1521,7 +1521,6 @@ void CActiveAE::ClearDiscardedBuffers()
       delete (*it);
       CLog::Log(LOGDEBUG, "CActiveAE::ClearDiscardedBuffers - buffer pool deleted");
       m_discardBufferPools.erase(it);
-      return;
     }
   }
 }


### PR DESCRIPTION
There been cases that audio stopped working after a change of refresh rate and video got into slowmo.
