### PR TITLE
VideoPlayer: consider offset to vsync

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1883,8 +1883,6 @@ void CApplication::Render()
     g_infoManager.UpdateFPS();
   }
 
-  m_pPlayer->AfterRender();
-
   // TODO: find better solution
   // if video is rendered to a separate layer, we should not block this thread
   if (!m_pPlayer->IsRenderingVideoLayer() || hasRendered)

--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -790,13 +790,6 @@ void CApplicationPlayer::Render(bool clear, uint32_t alpha, bool gui)
     player->Render(clear, alpha, gui);
 }
 
-void CApplicationPlayer::AfterRender()
-{
-  std::shared_ptr<IPlayer> player = GetInternal();
-  if (player)
-    player->AfterRender();
-}
-
 void CApplicationPlayer::FlushRenderer()
 {
   std::shared_ptr<IPlayer> player = GetInternal();

--- a/xbmc/ApplicationPlayer.h
+++ b/xbmc/ApplicationPlayer.h
@@ -82,7 +82,6 @@ public:
   void FrameMove();
   bool HasFrame();
   void Render(bool clear, uint32_t alpha = 255, bool gui = true);
-  void AfterRender();
   void FlushRenderer();
   void SetRenderViewMode(int mode);
   float GetRenderAspectRatio();

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -394,8 +394,6 @@ public:
 
   virtual void Render(bool clear, uint32_t alpha = 255, bool gui = true) {};
 
-  virtual void AfterRender() {};
-
   virtual void FlushRenderer() {};
 
   virtual void SetRenderViewMode(int mode) {};

--- a/xbmc/cores/VideoPlayer/DVDAudio.cpp
+++ b/xbmc/cores/VideoPlayer/DVDAudio.cpp
@@ -332,9 +332,8 @@ void CDVDAudio::SetResampleMode(int mode)
 
 double CDVDAudio::GetClock()
 {
-  double absolute;
   if (m_pClock)
-    return m_pClock->GetClock(absolute) / DVD_TIME_BASE * 1000;
+    return (m_pClock->GetClock() + m_pClock->GetVsyncAdjust()) / DVD_TIME_BASE * 1000;
   else
     return 0.0;
 }

--- a/xbmc/cores/VideoPlayer/DVDClock.h
+++ b/xbmc/cores/VideoPlayer/DVDClock.h
@@ -47,7 +47,7 @@ public:
   double GetClock(bool interpolated = true);
   double GetClock(double& absolute, bool interpolated = true);
 
-  bool Update(double clock, double absolute, double limit, const char* log);
+  double ErrorAdjust(double error, const char* log);
   void Discontinuity(double clock, double absolute);
   void Discontinuity(double clock = 0LL)
   {
@@ -72,6 +72,8 @@ public:
 
   double GetRefreshRate();
   bool GetClockInfo(int& MissedVblanks, double& ClockSpeed, double& RefreshRate) const;
+  void SetVsyncAdjust(double adjustment);
+  double GetVsyncAdjust();
 
 protected:
   double SystemToAbsolute(int64_t system);
@@ -93,6 +95,8 @@ protected:
   int64_t m_systemAdjust;
   int64_t m_lastSystemTime;
   double m_speedAdjust;
+  double m_vSyncAdjust;
+  double m_frameTime;
 
   double m_maxspeedadjust;
   CCriticalSection m_speedsection;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -4933,11 +4933,6 @@ void CVideoPlayer::Render(bool clear, uint32_t alpha, bool gui)
   m_renderManager.Render(clear, 0, alpha, gui);
 }
 
-void CVideoPlayer::AfterRender()
-{
-  m_renderManager.FrameFinish();
-}
-
 void CVideoPlayer::FlushRenderer()
 {
   m_renderManager.Flush();

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -317,7 +317,6 @@ public:
   virtual void FrameMove();
   virtual bool HasFrame();
   virtual void Render(bool clear, uint32_t alpha = 255, bool gui = true);
-  virtual void AfterRender();
   virtual void FlushRenderer();
   virtual void SetRenderViewMode(int mode);
   float GetRenderAspectRatio();

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
@@ -530,14 +530,12 @@ bool CVideoPlayerAudio::OutputPacket(DVDAudioFrame &audioframe)
   if (m_synctype == SYNC_DISCON)
   {
     double limit, error;
-    limit = DVD_MSEC_TO_TIME(10);
     error = syncerror;
 
-    double absolute;
-    double clock = m_pClock->GetClock(absolute);
-    if (m_pClock->Update(clock + error, absolute, limit - 0.001, "CVideoPlayerAudio::OutputPacket"))
+    double correction = m_pClock->ErrorAdjust(error, "CVideoPlayerAudio::OutputPacket");
+    if (correction != 0)
     {
-      m_dvdAudio.SetSyncErrorCorrection(-error);
+      m_dvdAudio.SetSyncErrorCorrection(-correction);
     }
   }
   m_dvdAudio.AddPackets(audioframe);

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.h
@@ -45,17 +45,15 @@ class CDroppingStats
 {
 public:
   void Reset();
-  void AddOutputDropGain(double pts, double frametime);
+  void AddOutputDropGain(double pts, int frames);
   struct CGain
   {
-    double gain;
+    int frames;
     double pts;
   };
   std::deque<CGain> m_gain;
   double m_totalGain;
   double m_lastPts;
-  unsigned int m_lateFrames;
-  unsigned int m_dropRequests;
 };
 
 class CVideoPlayerVideo : public CThread, public IDVDStreamPlayerVideo

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
@@ -44,8 +44,6 @@ namespace VAAPI { class CSurfaceHolder; }
 namespace VDPAU { class CVdpauRenderPicture; }
 struct DVDVideoPicture;
 
-#define ERRORBUFFSIZE 30
-
 class CWinRenderer;
 class CMMALRenderer;
 class CLinuxRenderer;
@@ -249,6 +247,16 @@ protected:
   CEvent m_flushEvent;
   CDVDClock &m_dvdClock;
   IRenderMsg *m_playerPort;
+
+  struct CClockSync
+  {
+    void Reset();
+    double m_error;
+    int m_errCount;
+    double m_syncOffset;
+    bool m_enabled;
+  };
+  CClockSync m_clockSync;
 
   void RenderCapture(CRenderCapture* capture);
   void RemoveCaptures();

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
@@ -71,7 +71,6 @@ public:
   void GetVideoRect(CRect &source, CRect &dest, CRect &view);
   float GetAspectRatio();
   void FrameMove();
-  void FrameFinish();
   void FrameWait(int ms);
   bool HasFrame();
   void Render(bool clear, DWORD flags = 0, DWORD alpha = 255, bool gui = true);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
@@ -147,7 +147,7 @@ public:
    * Can be called by player for lateness detection. This is done best by
    * looking at the end of the queue.
    */
-  bool GetStats(double &sleeptime, double &pts, int &queued, int &discard);
+  bool GetStats(int &lateframes, double &pts, int &queued, int &discard);
 
   /**
    * Video player call this on flush in oder to discard any queued frames
@@ -172,6 +172,7 @@ protected:
   void ManageCaptures();
 
   void UpdateDisplayLatency();
+  void CheckEnableClockSync();
 
   CBaseRenderer *m_pRenderer;
   OVERLAY::CRenderer m_overlays;
@@ -239,7 +240,7 @@ protected:
   unsigned int m_orientation;
   int m_NumberBuffers;
 
-  double m_sleeptime;
+  int m_lateframes;
   double m_presentpts;
   EPRESENTSTEP m_presentstep;
   int m_presentsource;

--- a/xbmc/video/VideoReferenceClock.cpp
+++ b/xbmc/video/VideoReferenceClock.cpp
@@ -93,8 +93,6 @@ void CVideoReferenceClock::CBUpdateClock(int NrVBlanks, uint64_t time, CVideoRef
     clock->m_VblankTime = time;
     clock->UpdateClock(NrVBlanks, true);
   }
-
-  clock->SendVblankSignal();
 }
 
 void CVideoReferenceClock::Process()
@@ -309,11 +307,6 @@ double CVideoReferenceClock::GetRefreshRate(double* interval /*= NULL*/)
   }
   else
     return -1;
-}
-
-void CVideoReferenceClock::SendVblankSignal()
-{
-  m_VblankEvent.Set();
 }
 
 #define MAXVBLANKDELAY 13LL

--- a/xbmc/video/VideoReferenceClock.h
+++ b/xbmc/video/VideoReferenceClock.h
@@ -40,7 +40,6 @@ class CVideoReferenceClock : public CThread
     void    Process() override;
     void Start();
     void    UpdateRefreshrate();
-    void    SendVblankSignal();
     void    UpdateClock(int NrVBlanks, bool CheckMissed);
     double  UpdateInterval() const;
     int64_t TimeOfNextVblank() const;
@@ -58,8 +57,6 @@ class CVideoReferenceClock : public CThread
     int     m_MissedVblanks;     //number of clock updates missed by the vblank clock
     int     m_TotalMissedVblanks;//total number of clock updates missed, used by codec information screen
     int64_t m_VblankTime;        //last time the clock was updated when using vblank as clock
-
-    CEvent  m_VblankEvent;        //set when a vblank happens
 
     CCriticalSection m_CritSection;
 


### PR DESCRIPTION
PTS of a video frame refers to the time the frames comes to display. But this time depends on vsync. This change determines the offset from video player's clock to vsync and adjusts audio sync.

Render thread looks at the middle of the the timespan of a frame. This reduces the chance that it doesn't pick a frame because it is not due by i.e. a 1ms. This resulted in rendering a frames twice and having to drop /skip next frames.
