### PR TITLE
[linux] support for simple xselection pasting

### DIFF
--- a/xbmc/windowing/WinEventsX11.cpp
+++ b/xbmc/windowing/WinEventsX11.cpp
@@ -344,6 +344,10 @@ bool CWinEventsX11Imp::MessagePump()
 
     switch (xevent.type)
     {
+      case SelectionNotify:
+        ret = true;
+        break;
+
       case MapNotify:
       {
         g_application.SetRenderGUI(true);

--- a/xbmc/windowing/X11/WinSystemX11.cpp
+++ b/xbmc/windowing/X11/WinSystemX11.cpp
@@ -48,6 +48,8 @@
 
 using namespace KODI::MESSAGING;
 
+#include <limits.h>
+
 #define EGL_NO_CONFIG (EGLConfig)0
 
 CWinSystemX11::CWinSystemX11() : CWinSystemBase()
@@ -1068,6 +1070,62 @@ void CWinSystemX11::UpdateCrtc()
 
   m_crtc = g_xrandr.GetCrtc(posx+winattr.width/2, posy+winattr.height/2, fps);
   g_graphicsContext.SetFPS(fps);
+}
+
+std::string CWinSystemX11::GetClipboardText(void)
+{
+  if (!m_dpy)
+     return "";
+
+  Atom utf8_string = XInternAtom(m_dpy, "UTF8_STRING", False);
+  if (utf8_string == None)
+    return "";
+
+  Atom clipboard = XInternAtom(m_dpy, "CLIPBOARD", False);
+  if (clipboard == None)
+    return "";
+
+  // if no selection or there is no owner for the selection (ancient X ?!)
+  if (XGetSelectionOwner(m_dpy, clipboard) == None)
+    return "";
+
+  std::string result = "";
+  XConvertSelection(m_dpy, clipboard, utf8_string, None, m_glWindow, CurrentTime);
+//  Wait for clipboard event (SelectionNotify) sync, code copied from
+//  https://github.com/vinniefalco/SimpleDJ/blob/master/Extern/JUCE/modules/juce_gui_basics/native/juce_linux_Clipboard.cpp
+//  clipboard content requesting is inherently slow on x11, it
+//  often takes 50ms or more so...
+  int count = 20; // will wait at most for 200 ms
+  while (--count >= 0)
+  {
+    CLog::Log(LOGNOTICE, "GetClipboardText calls MessagePump count = %d ", count);
+    if (CWinEventsX11Imp::MessagePump())
+      break;
+    Sleep(10);
+  }
+
+  Atom real_type = None;
+  int real_format = 0;
+  for (unsigned long offset = 0;;)
+  {
+    unsigned long items_read = 0;
+    unsigned long items_left = 0;
+    unsigned char *data;
+
+    if (XGetWindowProperty(m_dpy, m_glWindow, utf8_string, offset, INT_MAX, 
+      False, AnyPropertyType, &real_type, &real_format, &items_read,
+      &items_left, &data) == Success) 
+    {
+      result.append(reinterpret_cast<const char*>(data), items_read);
+      offset += items_read;
+      XFree(data);
+    } else 
+      break;
+    if (!items_left)
+      break;
+  }
+
+  return result;
 }
 
 #endif

--- a/xbmc/windowing/X11/WinSystemX11.h
+++ b/xbmc/windowing/X11/WinSystemX11.h
@@ -68,6 +68,7 @@ public:
   bool IsCurrentOutput(std::string output);
   void RecreateWindow();
   int GetCrtc() { return m_crtc; }
+  std::string GetClipboardText(void);
 
 protected:
   virtual bool SetWindow(int width, int height, bool fullscreen, const std::string &output, int *winstate = NULL) = 0;


### PR DESCRIPTION
From: Matthias Kortstiege mkortstiege@kodi.tv
Date: Sat, 4 Jul 2015 16:51:06 +0200
Subject: [PATCH] [linux] support for simple xselection pasting

in http://forum.kodi.tv/showthread.php?tid=231227 says to patch kodi with 
https://github.com/mkortstiege/xbmc/commit/62e56b7e8f0d944439a3f60eaa6a2bc41cdce67b 

I test it works and no regressions noted . Kodi don't have copy and paste working on Linux ! 
