### PR TITLE
[PVR] EPG data import performance tuning.

### DIFF
--- a/xbmc/pvr/timers/PVRTimerInfoTag.h
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.h
@@ -114,9 +114,10 @@ namespace PVR
 
     /*!
      * @brief get the epg info tag associated with this timer, if any
+     * @param bCreate if true, try to find the epg tag if not yet set (lazy evaluation)
      * @return the epg info tag associated with this timer or null if there is no tag
      */
-    EPG::CEpgInfoTagPtr GetEpgInfoTag(void) const;
+    EPG::CEpgInfoTagPtr GetEpgInfoTag(bool bCreate = true) const;
 
     /*!
      * @brief check whether there is an epg info tag associated with this timer

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -672,7 +672,8 @@ CPVRTimerInfoTagPtr CPVRTimers::GetTimerForEpgTag(const CEpgInfoTagPtr &epgTag) 
           timer = *timerIt;
 
           if (!timer->IsRepeating() &&
-              (timer->GetEpgInfoTag() == epgTag ||
+              (timer->GetEpgInfoTag(false) == epgTag ||
+               (timer->m_iEpgUid != EPG_TAG_INVALID_UID && timer->m_iEpgUid == epgTag->UniqueBroadcastID()) ||
                (timer->m_iClientChannelUid == channel->UniqueID() &&
                 timer->m_bIsRadio == channel->IsRadio() &&
                 timer->StartAsUTC() <= epgTag->StartAsUTC() &&


### PR DESCRIPTION
This patch increases the performance of (initial) epg data import by refraining from expensive eager evaluation of the epg tag that might belong to a timer tag.

Of course I double checked that the epg tag will be created later when it is actually needed.

@xhaggi @Jalle19 mind taking a look.
