### PR TITLE
fixed: Wrong parent path comparisons + cleanup

### DIFF
--- a/xbmc/TextureCache.cpp
+++ b/xbmc/TextureCache.cpp
@@ -64,11 +64,11 @@ bool CTextureCache::IsCachedImage(const std::string &url) const
 {
   if (url != "-" && !CURL::IsFullPath(url))
     return true;
-  if (URIUtils::IsInPath(url, "special://skin/") ||
-      URIUtils::IsInPath(url, "special://temp/") ||
-      URIUtils::IsInPath(url, "resource://") ||
-      URIUtils::IsInPath(url, "androidapp://")   ||
-      URIUtils::IsInPath(url, CProfilesManager::GetInstance().GetThumbnailsFolder()))
+  if (URIUtils::PathHasParent(url, "special://skin", true) ||
+      URIUtils::PathHasParent(url, "special://temp", true) ||
+      URIUtils::PathHasParent(url, "resource://", true) ||
+      URIUtils::PathHasParent(url, "androidapp://", true)   ||
+      URIUtils::PathHasParent(url, CProfilesManager::GetInstance().GetThumbnailsFolder(), true))
     return true;
   return false;
 }

--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -738,7 +738,7 @@ bool CURL::IsFullPath(const std::string &url)
   if (url.size() && url[0] == '/') return true;     //   /foo/bar.ext
   if (url.find("://") != std::string::npos) return true;                 //   foo://bar.ext
   if (url.size() > 1 && url[1] == ':') return true; //   c:\\foo\\bar\\bar.ext
-  if (URIUtils::PathStarts(url, "\\\\")) return true;    //   \\UNC\path\to\file
+  if (StringUtils::StartsWith(url, "\\\\")) return true;    //   \\UNC\path\to\file
   return false;
 }
 

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -172,11 +172,11 @@ std::string CUtil::GetTitleFromPath(const CURL& url, bool bIsFolder /* = false *
     strFilename = g_localizeStrings.Get(744);
 
   // Music Playlists
-  else if (URIUtils::PathStarts(path, "special://musicplaylists"))
+  else if (StringUtils::StartsWith(path, "special://musicplaylists"))
     strFilename = g_localizeStrings.Get(136);
 
   // Video Playlists
-  else if (URIUtils::PathStarts(path, "special://videoplaylists"))
+  else if (StringUtils::StartsWith(path, "special://videoplaylists"))
     strFilename = g_localizeStrings.Get(136);
 
   else if (URIUtils::HasParentInHostname(url) && strFilename.empty())

--- a/xbmc/addons/GUIViewStateAddonBrowser.cpp
+++ b/xbmc/addons/GUIViewStateAddonBrowser.cpp
@@ -27,6 +27,7 @@
 #include "guilib/WindowIDs.h"
 #include "view/ViewState.h"
 #include "utils/URIUtils.h"
+#include "utils/StringUtils.h"
 
 using namespace XFILE;
 using namespace ADDON;
@@ -47,11 +48,11 @@ CGUIViewStateAddonBrowser::CGUIViewStateAddonBrowser(const CFileItemList& items)
   {
     AddSortMethod(SortByLabel, SortAttributeIgnoreFolders, 551, LABEL_MASKS("%L", "%s", "%L", "%s"));
 
-    if (URIUtils::PathStarts(items.GetPath(), "addons://sources/"))
+    if (StringUtils::StartsWith(items.GetPath(), "addons://sources/"))
       AddSortMethod(SortByLastUsed, 12012, LABEL_MASKS("%L", "%u", "%L", "%u"),
           SortAttributeIgnoreFolders, SortOrderDescending); //Label, Last used
 
-    if (URIUtils::PathStarts(items.GetPath(), "addons://user/") && items.GetContent() == "addons")
+    if (StringUtils::StartsWith(items.GetPath(), "addons://user/") && items.GetContent() == "addons")
       AddSortMethod(SortByInstallDate, 12013, LABEL_MASKS("%L", "%i", "%L", "%i"),
           SortAttributeIgnoreFolders, SortOrderDescending);
 

--- a/xbmc/addons/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/GUIWindowAddonBrowser.cpp
@@ -528,7 +528,7 @@ int CGUIWindowAddonBrowser::SelectAddonID(const std::vector<ADDON::TYPE> &types,
 
 std::string CGUIWindowAddonBrowser::GetStartFolder(const std::string &dir)
 {
-  if (URIUtils::PathStarts(dir, "addons://"))
+  if (StringUtils::StartsWith(dir, "addons://"))
     return dir;
   return CGUIMediaWindow::GetStartFolder(dir);
 }

--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -131,7 +131,7 @@ std::string CRepository::GetAddonHash(const AddonPtr& addon) const
   std::string checksum;
   DirList::const_iterator it;
   for (it = m_dirs.begin();it != m_dirs.end(); ++it)
-    if (URIUtils::IsInPath(addon->Path(), it->datadir))
+    if (URIUtils::PathHasParent(addon->Path(), it->datadir, true))
       break;
   if (it != m_dirs.end() && it->hashes)
   {

--- a/xbmc/filesystem/APKFile.cpp
+++ b/xbmc/filesystem/APKFile.cpp
@@ -251,7 +251,7 @@ int CAPKFile::Stat(const CURL& url, struct __stat64* buffer)
     for (int i = 0; i < numFiles; i++)
     {
       std::string name = zip_get_name(zip_archive, i, zip_flags);
-      if (!name.empty() && StringUtils::StartsWith(name, path))
+      if (!name.empty() && URIUtils::PathHasParent(name, path))
       {
         buffer->st_gid  = 0;
         buffer->st_mode = _S_IFDIR;

--- a/xbmc/filesystem/DirectoryCache.cpp
+++ b/xbmc/filesystem/DirectoryCache.cpp
@@ -151,12 +151,11 @@ void CDirectoryCache::ClearSubPaths(const std::string& strPath)
 
   // Get rid of any URL options, else the compare may be wrong
   std::string storedPath = CURL(strPath).GetWithoutOptions();
-  URIUtils::RemoveSlashAtEnd(storedPath);
 
   iCache i = m_cache.begin();
   while (i != m_cache.end())
   {
-    if (StringUtils::StartsWith(i->first, storedPath))
+    if (URIUtils::PathHasParent(i->first, storedPath))
       Delete(i++);
     else
       i++;

--- a/xbmc/filesystem/NFSFile.cpp
+++ b/xbmc/filesystem/NFSFile.cpp
@@ -28,6 +28,7 @@
 #include "threads/SingleLock.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
+#include "utils/URIUtils.h"
 #include "network/DNSNameCache.h"
 #include "threads/SystemClock.h"
 
@@ -260,12 +261,13 @@ bool CNfsConnection::splitUrlIntoExportAndPath(const CURL& url,std::string &expo
       for(it=exportList.begin();it!=exportList.end();++it)
       {
         //if path starts with the current export path
-        if(StringUtils::StartsWith(path, *it))
+        if(URIUtils::PathHasParent(path, *it))
         {
-          //its possible that StartsWith may not find the correct match first
-          //as an example, if /path/ & and /path/sub/ are exported, but
-          //the user specifies the path /path/subdir/ (from /path/ export).
-          //If the path is longer than the exportpath, make sure / is next.
+          /* It's possible that PathHasParent() may not find the correct match first/
+           * As an example, if /path/ & and /path/sub/ are exported, but
+           * the user specifies the path /path/subdir/ (from /path/ export).
+           * If the path is longer than the exportpath, make sure / is next.
+           */
           if( (path.length() > (*it).length()) &&
               (path[(*it).length()] != '/') && (*it) != "/")
             continue;

--- a/xbmc/filesystem/ResourceDirectory.cpp
+++ b/xbmc/filesystem/ResourceDirectory.cpp
@@ -47,7 +47,7 @@ bool CResourceDirectory::GetDirectory(const CURL& url, CFileItemList &items)
     for (int i = 0; i < items.Size(); i++)
     {
       CFileItemPtr item = items[i];
-      if (StringUtils::StartsWith(item->GetPath(), translatedPath))
+      if (URIUtils::PathHasParent(item->GetPath(), translatedPath))
         item->SetPath(URIUtils::AddFileToFolder(pathToUrl, item->GetPath().substr(translatedPath.size())));
     }
 

--- a/xbmc/filesystem/SpecialProtocolDirectory.cpp
+++ b/xbmc/filesystem/SpecialProtocolDirectory.cpp
@@ -46,7 +46,7 @@ bool CSpecialProtocolDirectory::GetDirectory(const CURL& url, CFileItemList &ite
     for (int i = 0; i < items.Size(); i++)
     {
       CFileItemPtr item = items[i];
-      if (StringUtils::StartsWith(item->GetPath(), translatedPath))
+      if (URIUtils::PathHasParent(item->GetPath(), translatedPath))
         item->SetPath(URIUtils::AddFileToFolder(pathToUrl, item->GetPath().substr(translatedPath.size())));
     }
     return true;

--- a/xbmc/filesystem/VirtualDirectory.cpp
+++ b/xbmc/filesystem/VirtualDirectory.cpp
@@ -150,7 +150,7 @@ bool CVirtualDirectory::IsInSource(const std::string &path) const
     {
       CMediaSource &share = shares[i];
       if (URIUtils::IsOnDVD(share.strPath) &&
-          StringUtils::StartsWith(path, share.strPath))
+          URIUtils::PathHasParent(path, share.strPath))
         return true;
     }
     return false;

--- a/xbmc/network/httprequesthandler/HTTPPythonHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPPythonHandler.cpp
@@ -76,7 +76,7 @@ CHTTPPythonHandler::CHTTPPythonHandler(const HTTPRequest &request)
 
   // we need to map any requests to a specific WSGI webinterface to the root path
   std::string baseLocation = webinterface->GetBaseLocation();
-  if (!StringUtils::StartsWith(m_request.pathUrl, baseLocation))
+  if (!URIUtils::PathHasParent(m_request.pathUrl, baseLocation))
   {
     m_response.type = HTTPRedirect;
     m_response.status = MHD_HTTP_MOVED_PERMANENTLY;

--- a/xbmc/network/httprequesthandler/HTTPVfsHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPVfsHandler.cpp
@@ -67,7 +67,7 @@ CHTTPVfsHandler::CHTTPVfsHandler(const HTTPRequest &request)
             for (std::vector<std::string>::const_iterator path = source->vecPaths.begin(); path != source->vecPaths.end(); ++path)
             {
               std::string realSourcePath = URIUtils::GetRealPath(*path);
-              if (URIUtils::IsInPath(realPath, realSourcePath))
+              if (URIUtils::PathHasParent(realPath, realSourcePath, true))
               {
                 accessible = true;
                 break;

--- a/xbmc/network/httprequesthandler/HTTPWebinterfaceHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPWebinterfaceHandler.cpp
@@ -125,7 +125,7 @@ bool CHTTPWebinterfaceHandler::ResolveAddon(const std::string &url, ADDON::Addon
   // by checking if the resolved absolute path is inside the addon path
   std::string realPath = URIUtils::GetRealPath(addonPath);
   std::string realAddonPath = URIUtils::GetRealPath(addon->Path());
-  if (!URIUtils::IsInPath(realPath, realAddonPath))
+  if (!URIUtils::PathHasParent(realPath, realAddonPath, true))
     return false;
 
   return true;

--- a/xbmc/profiles/dialogs/GUIDialogProfileSettings.cpp
+++ b/xbmc/profiles/dialogs/GUIDialogProfileSettings.cpp
@@ -101,7 +101,7 @@ bool CGUIDialogProfileSettings::ShowForProfile(unsigned int iProfile, bool first
     std::string userDir = defaultDir;
     if (GetProfilePath(userDir, false)) // can't be the master user
     {
-      if (!StringUtils::StartsWith(userDir, defaultDir)) // user chose a different folder
+      if (!URIUtils::PathHasParent(userDir, defaultDir)) // user chose a different folder
         XFILE::CDirectory::Remove(URIUtils::AddFileToFolder("special://masterprofile/", defaultDir));
     }
     dialog->m_directory = userDir;

--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -142,7 +142,7 @@ CFileItemPtr CPVRChannelGroups::GetByPath(const std::string &strPath) const
   {
     // check if the path matches
     strCheckPath = StringUtils::Format("channels/%s/%s/", (*it)->IsRadio() ? "radio" : "tv", (*it)->GroupName().c_str());
-    if (StringUtils::StartsWith(strFileName, strCheckPath))
+    if (URIUtils::PathHasParent(strFileName, strCheckPath))
     {
       strFileName.erase(0, strCheckPath.length());
       std::vector<std::string> split(StringUtils::Split(strFileName, '_', 2));

--- a/xbmc/pvr/recordings/PVRRecordingsPath.cpp
+++ b/xbmc/pvr/recordings/PVRRecordingsPath.cpp
@@ -126,7 +126,7 @@ std::string CPVRRecordingsPath::GetSubDirectoryPath(const std::string &strPath) 
   std::string strUsePath(TrimSlashes(strPath));
 
   /* adding "/" to make sure that base matches the complete folder name and not only parts of it */
-  if (!m_directoryPath.empty() && (strUsePath.size() <= m_directoryPath.size() || !StringUtils::StartsWith(strUsePath, m_directoryPath + "/")))
+  if (!m_directoryPath.empty() && (strUsePath.size() <= m_directoryPath.size() || !URIUtils::PathHasParent(strUsePath, m_directoryPath)))
     return strReturn;
 
   strUsePath.erase(0, m_directoryPath.size());

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -29,6 +29,7 @@
 #include "input/Key.h"
 #include "threads/SingleLock.h"
 #include "utils/StringUtils.h"
+#include "utils/URIUtils.h"
 #include "utils/Variant.h"
 #include "video/windows/GUIWindowVideoNav.h"
 
@@ -74,7 +75,7 @@ void CGUIWindowPVRRecordings::OnWindowLoaded()
 std::string CGUIWindowPVRRecordings::GetDirectoryPath(void)
 {
   const std::string basePath = CPVRRecordingsPath(m_bShowDeletedRecordings, m_bRadio);
-  return StringUtils::StartsWith(m_vecItems->GetPath(), basePath) ? m_vecItems->GetPath() : basePath;
+  return URIUtils::PathHasParent(m_vecItems->GetPath(), basePath) ? m_vecItems->GetPath() : basePath;
 }
 
 std::string CGUIWindowPVRRecordings::GetResumeString(const CFileItem& item)

--- a/xbmc/pvr/windows/GUIWindowPVRTimerRules.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRTimerRules.cpp
@@ -18,7 +18,7 @@
  *
  */
 
-#include "utils/StringUtils.h"
+#include "utils/URIUtils.h"
 #include "pvr/timers/PVRTimers.h"
 
 #include "GUIWindowPVRTimerRules.h"
@@ -33,5 +33,5 @@ CGUIWindowPVRTimerRules::CGUIWindowPVRTimerRules(bool bRadio) :
 std::string CGUIWindowPVRTimerRules::GetDirectoryPath(void)
 {
   const std::string basePath(CPVRTimersPath(m_bRadio, true).GetPath());
-  return StringUtils::StartsWith(m_vecItems->GetPath(), basePath) ? m_vecItems->GetPath() : basePath;
+  return URIUtils::PathHasParent(m_vecItems->GetPath(), basePath) ? m_vecItems->GetPath() : basePath;
 }

--- a/xbmc/pvr/windows/GUIWindowPVRTimers.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRTimers.cpp
@@ -18,7 +18,7 @@
  *
  */
 
-#include "utils/StringUtils.h"
+#include "utils/URIUtils.h"
 #include "pvr/timers/PVRTimers.h"
 
 #include "GUIWindowPVRTimers.h"
@@ -33,5 +33,5 @@ CGUIWindowPVRTimers::CGUIWindowPVRTimers(bool bRadio) :
 std::string CGUIWindowPVRTimers::GetDirectoryPath(void)
 {
   const std::string basePath(CPVRTimersPath(m_bRadio, false).GetPath());
-  return StringUtils::StartsWith(m_vecItems->GetPath(), basePath) ? m_vecItems->GetPath() : basePath;
+  return URIUtils::PathHasParent(m_vecItems->GetPath(), basePath) ? m_vecItems->GetPath() : basePath;
 }

--- a/xbmc/pvr/windows/GUIWindowPVRTimersBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRTimersBase.cpp
@@ -28,6 +28,7 @@
 #include "settings/Settings.h"
 #include "threads/SingleLock.h"
 #include "utils/StringUtils.h"
+#include "utils/URIUtils.h"
 #include "utils/Variant.h"
 
 #include "pvr/PVRManager.h"

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -29,7 +29,6 @@ class URIUtils
 public:
   URIUtils(void);
   virtual ~URIUtils(void);
-  static bool IsInPath(const std::string &uri, const std::string &baseURI);
 
   static std::string GetDirectory(const std::string &strFilePath);
 
@@ -95,19 +94,20 @@ public:
    \param url a std::string path.
    \param type a lower-case scheme name, e.g. "smb".
    \return true if the url is of the given scheme, false otherwise.
-   \sa PathStarts, PathEquals
+   \sa PathHasParent, PathEquals
    */
   static bool IsProtocol(const std::string& url, const std::string& type);
 
-  /*! \brief Check whether a path starts with a given start.
+  /*! \brief Check whether a path has a given parent.
    Comparison is case-sensitive.
    Use IsProtocol() to compare the protocol portion only.
    \param path a std::string path.
-   \param start the string the start of the path should be compared against.
-   \return true if the path starts with the given string, false otherwise.
+   \param parent the string the parent of the path should be compared against.
+   \param translate whether to translate any special paths into real paths
+   \return true if the path has the given parent string, false otherwise.
    \sa IsProtocol, PathEquals
    */
-  static bool PathStarts(const std::string& path, const char *start);
+  static bool PathHasParent(std::string path, std::string parent, bool translate = false);
 
   /*! \brief Check whether a path equals another path.
    Comparison is case-sensitive.
@@ -115,9 +115,9 @@ public:
    \param path2 the second path the path should be compared against.
    \param ignoreTrailingSlash ignore any trailing slashes in both paths
    \return true if the paths are equal, false otherwise.
-   \sa IsProtocol, PathStarts
+   \sa IsProtocol, PathHasParent
    */
-  static bool PathEquals(const std::string& path1, const std::string &path2, bool ignoreTrailingSlash = false, bool ignoreURLOptions = false);
+  static bool PathEquals(std::string path1, std::string path2, bool ignoreTrailingSlash = false, bool ignoreURLOptions = false);
 
   static bool IsAddonsPath(const std::string& strFile);
   static bool IsSourcesPath(const std::string& strFile);

--- a/xbmc/utils/test/TestURIUtils.cpp
+++ b/xbmc/utils/test/TestURIUtils.cpp
@@ -39,10 +39,10 @@ protected:
   }
 };
 
-TEST_F(TestURIUtils, IsInPath)
+TEST_F(TestURIUtils, PathHasParent)
 {
-  EXPECT_TRUE(URIUtils::IsInPath("/path/to/movie.avi", "/path/to/"));
-  EXPECT_FALSE(URIUtils::IsInPath("/path/to/movie.avi", "/path/2/"));
+  EXPECT_TRUE(URIUtils::PathHasParent("/path/to/movie.avi", "/path/to/"));
+  EXPECT_FALSE(URIUtils::PathHasParent("/path/to/movie.avi", "/path/2/"));
 }
 
 TEST_F(TestURIUtils, GetDirectory)

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -1603,7 +1603,7 @@ void CGUIMediaWindow::GetContextButtons(int itemNumber, CContextButtons &buttons
   if (!item->IsParentFolder() && !item->IsPath("add") && !item->IsPath("newplaylist://") &&
       !URIUtils::IsProtocol(item->GetPath(), "newsmartplaylist") && !URIUtils::IsProtocol(item->GetPath(), "newtag") &&
       !URIUtils::IsProtocol(item->GetPath(), "musicsearch") &&
-      !URIUtils::PathStarts(item->GetPath(), "pvr://guide/") && !URIUtils::PathStarts(item->GetPath(), "pvr://timers/"))
+      !StringUtils::StartsWith(item->GetPath(), "pvr://guide/") && !StringUtils::StartsWith(item->GetPath(), "pvr://timers/"))
   {
     if (XFILE::CFavouritesDirectory::IsFavourite(item.get(), GetID()))
       buttons.Add(CONTEXT_BUTTON_ADD_FAVOURITE, 14077);     // Remove Favourite
@@ -1959,7 +1959,7 @@ bool CGUIMediaWindow::IsFiltered()
 bool CGUIMediaWindow::IsSameStartFolder(const std::string &dir)
 {
   const std::string startFolder = GetStartFolder(dir);
-  return StringUtils::StartsWith(m_vecItems->GetPath(), startFolder);
+  return URIUtils::PathHasParent(m_vecItems->GetPath(), startFolder);
 }
 
 bool CGUIMediaWindow::Filter(bool advanced /* = true */)


### PR DESCRIPTION
There are several ways we use to look for a certain base/parent path. Not all of these methods are correct. When we use StringUtils::StartsWith() and URIUtils:PathStarts(), one can only reliably check for a certain parent path if the parent path has a trailing slash, else when looking for e.g. "/parent", "/parent2" will also match which is obviously wrong. The only exception here are our  internal (special/pvr/addon) paths which only have a fixed non-overlapping set of parent paths, for those comparisons we can safely use StartsWith(). Furthermore we have URIUtils::IsInpath() and URIUtils::PathStarts() which almost do the same thing, so I have merged those into the (imho) better named and fixed "PathHasParent()".
