### PR TITLE
CDebugRenderer: fix debug info overlays alignment

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp
@@ -107,15 +107,15 @@ void CDebugRenderer::CRenderer::Render(int idx)
 {
   std::vector<COverlay*> render;
   std::vector<SElement>& list = m_buffers[idx];
-  int posY = 40;
-  for(std::vector<SElement>::iterator it = list.begin(); it != list.end(); ++it)
+  int posY = 0;
+  for (std::vector<SElement>::iterator it = list.begin(); it != list.end(); ++it)
   {
     COverlay* o = nullptr;
 
     if (it->overlay_dvd)
       o = Convert(it->overlay_dvd, it->pts);
 
-    if(!o)
+    if (!o)
       continue;
 
     COverlayText *text = dynamic_cast<COverlayText*>(o);
@@ -125,11 +125,11 @@ void CDebugRenderer::CRenderer::Render(int idx)
     o->m_pos = COverlay::POSITION_ABSOLUTE;
     o->m_align = COverlay::ALIGN_SCREEN;
     o->m_x = 10 + o->m_width / 2;
-    o->m_y = posY;
+    o->m_y = posY + o->m_height;
     OVERLAY::CRenderer::Render(o, 0);
 
-    posY += 40;
+    posY = o->m_y;
   }
-  
+
   ReleaseUnused();
 }


### PR DESCRIPTION
just a cosmetic thing for the debug info lines alignment that have a strange behavior when kodi is resized while is windowed

before the the PR

<img src='https://s24.postimg.org/d9hy1yvid/1.png' border='0' alt="1"/>
<img src='https://s24.postimg.org/g4v18tzid/2.png' border='0' alt="2"/>

after PR

<img src='https://s24.postimg.org/giwd8fjlx/3.png' border='0' alt="3"/>
<img src='https://s24.postimg.org/wv6ey5xxh/4.png' border='0' alt="4"/>

@FernetMenta 
