### PR TITLE
[gui] Use SelectDialog for SortMethod selection

### DIFF
--- a/xbmc/view/GUIViewState.cpp
+++ b/xbmc/view/GUIViewState.cpp
@@ -33,6 +33,7 @@
 #include "GUIPassword.h"
 #include "ViewDatabase.h"
 #include "AutoSwitch.h"
+#include "dialogs/GUIDialogSelect.h"
 #include "guilib/GUIWindowManager.h"
 #include "addons/Addon.h"
 #include "addons/AddonManager.h"
@@ -342,6 +343,32 @@ void CGUIViewState::SetSortMethod(SortBy sortBy, SortOrder sortOrder /* = SortOr
 void CGUIViewState::SetSortMethod(SortDescription sortDescription)
 {
   return SetSortMethod(sortDescription.sortBy, sortDescription.sortOrder);
+}
+
+bool CGUIViewState::ChooseSortMethod()
+{
+  
+  CGUIDialogSelect *dialog = static_cast<CGUIDialogSelect *>(g_windowManager.GetWindow(WINDOW_DIALOG_SELECT));
+  if (dialog)
+  {
+    dialog->Reset();
+    dialog->SetHeading(CVariant{ 32104 }); // Label "Sort by"
+    for (int i = 0; i < m_sortMethods.size(); ++i)
+    {
+      dialog->Add(g_localizeStrings.Get(m_sortMethods[i].m_buttonLabel));
+    }
+    dialog->SetSelected(m_currentSortMethod);
+    dialog->Open();
+    int newSelected = dialog->GetSelectedItem();
+    // check if selection has changed
+    if (!dialog->IsConfirmed() || newSelected < 0 || newSelected == m_currentSortMethod)
+      return false;
+
+    m_currentSortMethod = newSelected;
+
+    SaveViewState();
+  }
+  return true;
 }
 
 SortDescription CGUIViewState::SetNextSortMethod(int direction /* = 1 */)

--- a/xbmc/view/GUIViewState.cpp
+++ b/xbmc/view/GUIViewState.cpp
@@ -349,25 +349,21 @@ bool CGUIViewState::ChooseSortMethod()
 {
   
   CGUIDialogSelect *dialog = static_cast<CGUIDialogSelect *>(g_windowManager.GetWindow(WINDOW_DIALOG_SELECT));
-  if (dialog)
-  {
-    dialog->Reset();
-    dialog->SetHeading(CVariant{ 32104 }); // Label "Sort by"
-    for (int i = 0; i < m_sortMethods.size(); ++i)
-    {
-      dialog->Add(g_localizeStrings.Get(m_sortMethods[i].m_buttonLabel));
-    }
-    dialog->SetSelected(m_currentSortMethod);
-    dialog->Open();
-    int newSelected = dialog->GetSelectedItem();
-    // check if selection has changed
-    if (!dialog->IsConfirmed() || newSelected < 0 || newSelected == m_currentSortMethod)
-      return false;
+  if (!dialog)
+    return false;
+  dialog->Reset();
+  dialog->SetHeading(CVariant{ 32104 }); // Label "Sort by"
+  for (auto &sortMethod : m_sortMethods)
+    dialog->Add(g_localizeStrings.Get(sortMethod.m_buttonLabel));
+  dialog->SetSelected(m_currentSortMethod);
+  dialog->Open();
+  int newSelected = dialog->GetSelectedItem();
+  // check if selection has changed
+  if (!dialog->IsConfirmed() || newSelected < 0 || newSelected == m_currentSortMethod)
+    return false;
 
-    m_currentSortMethod = newSelected;
-
-    SaveViewState();
-  }
+  m_currentSortMethod = newSelected;
+  SaveViewState();
   return true;
 }
 

--- a/xbmc/view/GUIViewState.h
+++ b/xbmc/view/GUIViewState.h
@@ -37,6 +37,7 @@ public:
   void SaveViewAsControl(int viewAsControl);
   int GetViewAsControl() const;
 
+  bool ChooseSortMethod();
   SortDescription SetNextSortMethod(int direction = 1);
   void SetCurrentSortMethod(int method);
   SortDescription GetSortMethod() const;

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -281,9 +281,8 @@ bool CGUIMediaWindow::OnMessage(CGUIMessage& message)
       }
       else if (iControl == CONTROL_BTNSORTBY) // sort by
       {
-        if (m_guiState.get())
-          m_guiState->SetNextSortMethod();
-        UpdateFileList();
+        if (m_guiState.get() && m_guiState->ChooseSortMethod())
+          UpdateFileList();
         return true;
       }
       else if (iControl == CONTROL_BTN_FILTER)


### PR DESCRIPTION
![screenshot005](https://cloud.githubusercontent.com/assets/110931/14623617/2431cec4-05d4-11e6-950f-b732f0f2d221.png)

This exchanges the default action of the sortmethod button in MediaWindows from "choose next" to "open selectdialog". Feels more convenient esp. when the amount of sortmethods is high. There are content types with more than 10 sortmethods ("songs" has 12 for example), handling those with a single togglebutton is quite painful.

What might be worth considering is to choose between one of these two methods automatically based on the amount of available viewtypes. (let´s say SelectDialog for >= 3 sortmethods, old behaviour for less).

@ronie @da-anda @BigNoid for opinions and @tamland for code.    

EDIT: header is only wrong in screenshot, PR contains correct one.          
