### PR TITLE
[RFC] [ffmpeg] Fix memleaks

### DIFF
--- a/xbmc/cdrip/EncoderFFmpeg.cpp
+++ b/xbmc/cdrip/EncoderFFmpeg.cpp
@@ -159,8 +159,8 @@ bool CEncoderFFmpeg::Init(audioenc_callbacks &callbacks)
   if(!m_BufferFrame || !m_Buffer)
   {
     CLog::Log(LOGERROR, "CEncoderFFmpeg::Init - Failed to allocate necessary buffers");
-    if(m_BufferFrame) av_frame_free(&m_BufferFrame);
-    if(m_Buffer) av_freep(&m_Buffer);
+    av_frame_free(&m_BufferFrame);
+    av_freep(&m_Buffer);
     av_freep(&m_Stream);
     av_freep(&m_Format->pb);
     av_freep(&m_Format);
@@ -196,9 +196,9 @@ bool CEncoderFFmpeg::Init(audioenc_callbacks &callbacks)
     if(!m_ResampledBuffer || !m_ResampledFrame)
     {
       CLog::Log(LOGERROR, "CEncoderFFmpeg::Init - Failed to allocate a frame for resampling");
-      if (m_ResampledFrame)  av_frame_free(&m_ResampledFrame);
-      if (m_ResampledBuffer) av_freep(&m_ResampledBuffer);
-      if (m_SwrCtx)          swr_free(&m_SwrCtx);
+      av_frame_free(&m_ResampledFrame);
+      av_freep(&m_ResampledBuffer);
+      swr_free(&m_SwrCtx);
       av_frame_free(&m_BufferFrame);
       av_freep(&m_Buffer);
       av_freep(&m_Stream);
@@ -224,9 +224,9 @@ bool CEncoderFFmpeg::Init(audioenc_callbacks &callbacks)
   if (avformat_write_header(m_Format, NULL) != 0)
   {
     CLog::Log(LOGERROR, "CEncoderFFmpeg::Init - Failed to write the header");
-    if (m_ResampledFrame ) av_frame_free(&m_ResampledFrame);
-    if (m_ResampledBuffer) av_freep(&m_ResampledBuffer);
-    if (m_SwrCtx)          swr_free(&m_SwrCtx);
+    av_frame_free(&m_ResampledFrame);
+    av_freep(&m_ResampledBuffer);
+    swr_free(&m_SwrCtx);
     av_frame_free(&m_BufferFrame);
     av_freep(&m_Buffer);
     av_freep(&m_Stream);
@@ -344,9 +344,9 @@ bool CEncoderFFmpeg::Close()
     av_freep(&m_Buffer);
     av_frame_free(&m_BufferFrame);
 
-    if (m_SwrCtx)          swr_free(&m_SwrCtx);
-    if (m_ResampledFrame ) av_frame_free(&m_ResampledFrame);
-    if (m_ResampledBuffer) av_freep(&m_ResampledBuffer);
+    swr_free(&m_SwrCtx);
+    av_frame_free(&m_ResampledFrame);
+    av_freep(&m_ResampledBuffer);
     m_NeedConversion = false;
 
     WriteFrame();

--- a/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSPProcess.cpp
+++ b/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSPProcess.cpp
@@ -88,10 +88,8 @@ CActiveAEDSPProcess::~CActiveAEDSPProcess()
       free(m_processArray[1][i]);
   }
 
-  if (m_convertInput)
-    swr_free(&m_convertInput);
-  if (m_convertOutput)
-    swr_free(&m_convertOutput);
+  swr_free(&m_convertInput);
+  swr_free(&m_convertOutput);
 }
 
 void CActiveAEDSPProcess::ResetStreamFunctionsSelection()

--- a/xbmc/cores/AudioEngine/Encoders/AEEncoderFFmpeg.cpp
+++ b/xbmc/cores/AudioEngine/Encoders/AEEncoderFFmpeg.cpp
@@ -37,9 +37,7 @@ CAEEncoderFFmpeg::CAEEncoderFFmpeg():
   m_OutputRatio   (0.0  ),
   m_SampleRateMul (0.0  ),
   m_NeededFrames  (0    ),
-  m_NeedConversion(false),
-  m_ResampBuffer  (NULL ),
-  m_ResampBufferSize(0  )
+  m_NeedConversion(false)
 {
 }
 
@@ -47,7 +45,6 @@ CAEEncoderFFmpeg::~CAEEncoderFFmpeg()
 {
   Reset();
   av_freep(&m_CodecCtx);
-  av_freep(&m_ResampBuffer);
   swr_free(&m_SwrCtx);
 }
 

--- a/xbmc/cores/AudioEngine/Encoders/AEEncoderFFmpeg.cpp
+++ b/xbmc/cores/AudioEngine/Encoders/AEEncoderFFmpeg.cpp
@@ -44,8 +44,8 @@ CAEEncoderFFmpeg::CAEEncoderFFmpeg():
 CAEEncoderFFmpeg::~CAEEncoderFFmpeg()
 {
   Reset();
-  av_freep(&m_CodecCtx);
   swr_free(&m_SwrCtx);
+  avcodec_free_context(&m_CodecCtx);
 }
 
 bool CAEEncoderFFmpeg::IsCompatible(const AEAudioFormat& format)
@@ -200,7 +200,7 @@ bool CAEEncoderFFmpeg::Initialize(AEAudioFormat &format, bool allow_planar_input
   /* open the codec */
   if (avcodec_open2(m_CodecCtx, codec, NULL))
   {
-    av_freep(&m_CodecCtx);
+    avcodec_free_context(&m_CodecCtx);
     return false;
   }
 

--- a/xbmc/cores/AudioEngine/Encoders/AEEncoderFFmpeg.cpp
+++ b/xbmc/cores/AudioEngine/Encoders/AEEncoderFFmpeg.cpp
@@ -48,8 +48,7 @@ CAEEncoderFFmpeg::~CAEEncoderFFmpeg()
   Reset();
   av_freep(&m_CodecCtx);
   av_freep(&m_ResampBuffer);
-  if (m_SwrCtx)
-    swr_free(&m_SwrCtx);
+  swr_free(&m_SwrCtx);
 }
 
 bool CAEEncoderFFmpeg::IsCompatible(const AEAudioFormat& format)

--- a/xbmc/cores/AudioEngine/Encoders/AEEncoderFFmpeg.cpp
+++ b/xbmc/cores/AudioEngine/Encoders/AEEncoderFFmpeg.cpp
@@ -116,6 +116,9 @@ bool CAEEncoderFFmpeg::Initialize(AEAudioFormat &format, bool allow_planar_input
     return false;
 
   m_CodecCtx = avcodec_alloc_context3(codec);
+  if (!m_CodecCtx)
+    return false;
+
   m_CodecCtx->bit_rate = m_BitRate;
   m_CodecCtx->sample_rate = format.m_sampleRate;
   m_CodecCtx->channel_layout = AV_CH_LAYOUT_5POINT1_BACK;
@@ -191,6 +194,7 @@ bool CAEEncoderFFmpeg::Initialize(AEAudioFormat &format, bool allow_planar_input
     else
     {
       CLog::Log(LOGERROR, "CAEEncoderFFmpeg::Initialize - Unable to find a suitable data format for the codec (%s)", m_CodecName.c_str());
+      avcodec_free_context(&m_CodecCtx);
       return false;
     }
   }
@@ -222,6 +226,8 @@ bool CAEEncoderFFmpeg::Initialize(AEAudioFormat &format, bool allow_planar_input
     if (!m_SwrCtx || swr_init(m_SwrCtx) < 0)
     {
       CLog::Log(LOGERROR, "CAEEncoderFFmpeg::Initialize - Failed to initialise resampler.");
+      swr_free(&m_SwrCtx);
+      avcodec_free_context(&m_CodecCtx);
       return false;
     }
   }

--- a/xbmc/cores/AudioEngine/Encoders/AEEncoderFFmpeg.h
+++ b/xbmc/cores/AudioEngine/Encoders/AEEncoderFFmpeg.h
@@ -63,7 +63,5 @@ private:
   double m_SampleRateMul;
   unsigned int  m_NeededFrames;
   bool m_NeedConversion;
-  uint8_t *m_ResampBuffer;
-  int m_ResampBufferSize;
 };
 

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -3057,6 +3057,7 @@ IAESound *CActiveAE::MakeSound(const std::string& file)
         sound->StoreSound(true, decoded_frame->extended_data,
                           decoded_frame->nb_samples, decoded_frame->linesize[0]);
       }
+      av_packet_unref(&avpkt);
     }
   }
 

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -3033,9 +3033,8 @@ IAESound *CActiveAE::MakeSound(const std::string& file)
       len = avcodec_decode_audio4(dec_ctx, decoded_frame, &got_frame, &avpkt);
       if (len < 0)
       {
-        avcodec_close(dec_ctx);
-        av_free(dec_ctx);
         av_frame_free(&decoded_frame);
+        avcodec_free_context(&dec_ctx);
         avformat_close_input(&fmt_ctx);
         if (io_ctx)
         {
@@ -3059,11 +3058,10 @@ IAESound *CActiveAE::MakeSound(const std::string& file)
                           decoded_frame->nb_samples, decoded_frame->linesize[0]);
       }
     }
-    avcodec_close(dec_ctx);
   }
 
-  av_free(dec_ctx);
   av_frame_free(&decoded_frame);
+  avcodec_free_context(&dec_ctx);
   avformat_close_input(&fmt_ctx);
   if (io_ctx)
   {

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -3035,7 +3035,7 @@ IAESound *CActiveAE::MakeSound(const std::string& file)
       {
         avcodec_close(dec_ctx);
         av_free(dec_ctx);
-        av_free(&decoded_frame);
+        av_frame_free(&decoded_frame);
         avformat_close_input(&fmt_ctx);
         if (io_ctx)
         {
@@ -3063,7 +3063,7 @@ IAESound *CActiveAE::MakeSound(const std::string& file)
   }
 
   av_free(dec_ctx);
-  av_free(decoded_frame);
+  av_frame_free(&decoded_frame);
   avformat_close_input(&fmt_ctx);
   if (io_ctx)
   {

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResampleFFMPEG.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResampleFFMPEG.cpp
@@ -38,8 +38,7 @@ CActiveAEResampleFFMPEG::CActiveAEResampleFFMPEG()
 
 CActiveAEResampleFFMPEG::~CActiveAEResampleFFMPEG()
 {
-  if (m_pContext)
-    swr_free(&m_pContext);
+  swr_free(&m_pContext);
 }
 
 bool CActiveAEResampleFFMPEG::Init(uint64_t dst_chan_layout, int dst_channels, int dst_rate, AVSampleFormat dst_fmt, int dst_bits, int dst_dither, uint64_t src_chan_layout, int src_channels, int src_rate, AVSampleFormat src_fmt, int src_bits, int src_dither, bool upmix, bool normalize, CAEChannelInfo *remapLayout, AEQuality quality, bool force_resample)

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
@@ -75,6 +75,9 @@ bool CDVDAudioCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options
   }
 
   m_pCodecContext = avcodec_alloc_context3(pCodec);
+  if (!m_pCodecContext)
+    return false;
+
   m_pCodecContext->debug_mv = 0;
   m_pCodecContext->debug = 0;
   m_pCodecContext->workaround_bugs = 1;
@@ -114,6 +117,12 @@ bool CDVDAudioCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options
   }
 
   m_pFrame1 = av_frame_alloc();
+  if (!m_pFrame1)
+  {
+    Dispose();
+    return false;
+  }
+
   m_iSampleFormat = AV_SAMPLE_FMT_NONE;
   m_matrixEncoding = AV_MATRIX_ENCODING_NONE;
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
@@ -125,8 +125,7 @@ bool CDVDAudioCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options
 
 void CDVDAudioCodecFFmpeg::Dispose()
 {
-  if (m_pFrame1) av_free(m_pFrame1);
-  m_pFrame1 = NULL;
+  av_frame_free(&m_pFrame1);
 
   if (m_pCodecContext)
   {

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
@@ -38,7 +38,6 @@ extern "C" {
 CDVDAudioCodecFFmpeg::CDVDAudioCodecFFmpeg() : CDVDAudioCodec()
 {
   m_pCodecContext = NULL;
-  m_bOpenedCodec = false;
 
   m_channels = 0;
   m_layout = 0;
@@ -56,7 +55,6 @@ CDVDAudioCodecFFmpeg::~CDVDAudioCodecFFmpeg()
 bool CDVDAudioCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
 {
   AVCodec* pCodec = NULL;
-  m_bOpenedCodec = false;
   bool allowdtshddecode = true;
 
   // set any special options
@@ -116,7 +114,6 @@ bool CDVDAudioCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options
   }
 
   m_pFrame1 = av_frame_alloc();
-  m_bOpenedCodec = true;
   m_iSampleFormat = AV_SAMPLE_FMT_NONE;
   m_matrixEncoding = AV_MATRIX_ENCODING_NONE;
 
@@ -126,14 +123,7 @@ bool CDVDAudioCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options
 void CDVDAudioCodecFFmpeg::Dispose()
 {
   av_frame_free(&m_pFrame1);
-
-  if (m_pCodecContext)
-  {
-    if (m_bOpenedCodec) avcodec_close(m_pCodecContext);
-    m_bOpenedCodec = false;
-    av_free(m_pCodecContext);
-    m_pCodecContext = NULL;
-  }
+  avcodec_free_context(&m_pCodecContext);
 }
 
 int CDVDAudioCodecFFmpeg::Decode(uint8_t* pData, int iSize, double dts, double pts)

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.h
@@ -62,7 +62,6 @@ protected:
   AVFrame* m_pFrame1;
   int m_gotFrame;
 
-  bool m_bOpenedCodec;
   int m_channels;
   uint64_t m_layout;
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecFFmpeg.h
@@ -43,8 +43,6 @@ public:
   virtual CDVDOverlay* GetOverlay();
 
 private:
-  void FreeSubtitle(AVSubtitle &sub);
-
   AVCodecContext* m_pCodecContext;
   AVSubtitle      m_Subtitle;
   int             m_SubtitleIndex;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -379,21 +379,7 @@ void CDVDVideoCodecFFmpeg::Dispose()
   av_frame_free(&m_pFrame);
   av_frame_free(&m_pDecodedFrame);
   av_frame_free(&m_pFilterFrame);
-
-  if (m_pCodecContext)
-  {
-    if (m_pCodecContext->codec)
-      avcodec_close(m_pCodecContext);
-
-    if (m_pCodecContext->extradata)
-    {
-      av_free(m_pCodecContext->extradata);
-      m_pCodecContext->extradata = NULL;
-      m_pCodecContext->extradata_size = 0;
-    }
-    av_free(m_pCodecContext);
-    m_pCodecContext = NULL;
-  }
+  avcodec_free_context(&m_pCodecContext);
   SAFE_RELEASE(m_pHardware);
 
   FilterClose();

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -263,6 +263,9 @@ bool CDVDVideoCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options
   CLog::Log(LOGNOTICE,"CDVDVideoCodecFFmpeg::Open() Using codec: %s",pCodec->long_name ? pCodec->long_name : pCodec->name);
 
   m_pCodecContext = avcodec_alloc_context3(pCodec);
+  if (!m_pCodecContext)
+    return false;
+
   m_pCodecContext->opaque = (void*)this;
   m_pCodecContext->debug_mv = 0;
   m_pCodecContext->debug = 0;
@@ -355,20 +358,33 @@ bool CDVDVideoCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options
   if (avcodec_open2(m_pCodecContext, pCodec, nullptr) < 0)
   {
     CLog::Log(LOGDEBUG,"CDVDVideoCodecFFmpeg::Open() Unable to open codec");
+    avcodec_free_context(&m_pCodecContext);
     return false;
   }
 
   m_pFrame = av_frame_alloc();
   if (!m_pFrame)
+  {
+    avcodec_free_context(&m_pCodecContext);
     return false;
+  }
 
   m_pDecodedFrame = av_frame_alloc();
   if (!m_pDecodedFrame)
+  {
+    av_frame_free(&m_pFrame);
+    avcodec_free_context(&m_pCodecContext);
     return false;
+  }
 
   m_pFilterFrame = av_frame_alloc();
   if (!m_pFilterFrame)
+  {
+    av_frame_free(&m_pFrame);
+    av_frame_free(&m_pDecodedFrame);
+    avcodec_free_context(&m_pCodecContext);
     return false;
+  }
 
   UpdateName();
   return true;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
@@ -52,7 +52,7 @@ public:
     }
     if (m_context)
     {
-      avcodec_close(m_context);
+      avcodec_free_context(&m_context);
       m_context = nullptr;
     }
   }

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1776,9 +1776,8 @@ void CDVDDemuxFFmpeg::ResetVideoStreams()
     st = m_pFormatContext->streams[i];
     if (st->codec->codec_type == AVMEDIA_TYPE_VIDEO)
     {
-      if (st->codec->extradata)
-        av_free(st->codec->extradata);
-      st->codec->extradata = NULL;
+      av_freep(&st->codec->extradata);
+      st->codec->extradata_size = 0;
       st->codec->width = 0;
     }
   }

--- a/xbmc/cores/omxplayer/OMXAudioCodecOMX.cpp
+++ b/xbmc/cores/omxplayer/OMXAudioCodecOMX.cpp
@@ -133,8 +133,7 @@ void COMXAudioCodecOMX::Dispose()
   if (m_pFrame1) av_free(m_pFrame1);
   m_pFrame1 = NULL;
 
-  if (m_pConvert)
-    swr_free(&m_pConvert);
+  swr_free(&m_pConvert);
 
   if (m_pCodecContext)
   {

--- a/xbmc/cores/omxplayer/OMXAudioCodecOMX.cpp
+++ b/xbmc/cores/omxplayer/OMXAudioCodecOMX.cpp
@@ -130,8 +130,7 @@ bool COMXAudioCodecOMX::Open(CDVDStreamInfo &hints)
 
 void COMXAudioCodecOMX::Dispose()
 {
-  if (m_pFrame1) av_free(m_pFrame1);
-  m_pFrame1 = NULL;
+  av_frame_free(&m_pFrame1);
 
   swr_free(&m_pConvert);
 

--- a/xbmc/cores/omxplayer/OMXAudioCodecOMX.cpp
+++ b/xbmc/cores/omxplayer/OMXAudioCodecOMX.cpp
@@ -107,9 +107,12 @@ bool COMXAudioCodecOMX::Open(CDVDStreamInfo &hints)
 
   if( hints.extradata && hints.extrasize > 0 )
   {
-    m_pCodecContext->extradata_size = hints.extrasize;
     m_pCodecContext->extradata = (uint8_t*)av_mallocz(hints.extrasize + FF_INPUT_BUFFER_PADDING_SIZE);
-    memcpy(m_pCodecContext->extradata, hints.extradata, hints.extrasize);
+    if(m_pCodecContext->extradata)
+    {
+      m_pCodecContext->extradata_size = hints.extrasize;
+      memcpy(m_pCodecContext->extradata, hints.extradata, hints.extrasize);
+    }
   }
 
   if (avcodec_open2(m_pCodecContext, pCodec, NULL) < 0)

--- a/xbmc/cores/omxplayer/OMXAudioCodecOMX.cpp
+++ b/xbmc/cores/omxplayer/OMXAudioCodecOMX.cpp
@@ -79,6 +79,9 @@ bool COMXAudioCodecOMX::Open(CDVDStreamInfo &hints)
 
   m_bFirstFrame = true;
   m_pCodecContext = avcodec_alloc_context3(pCodec);
+  if (!m_pCodecContext)
+    return false;
+
   m_pCodecContext->debug_mv = 0;
   m_pCodecContext->debug = 0;
   m_pCodecContext->workaround_bugs = 1;
@@ -123,6 +126,12 @@ bool COMXAudioCodecOMX::Open(CDVDStreamInfo &hints)
   }
 
   m_pFrame1 = av_frame_alloc();
+  if (!m_pFrame1)
+  {
+    Dispose();
+    return false;
+  }
+
   m_iSampleFormat = AV_SAMPLE_FMT_NONE;
   m_desiredSampleFormat = m_pCodecContext->sample_fmt == AV_SAMPLE_FMT_S16 ? AV_SAMPLE_FMT_S16 : AV_SAMPLE_FMT_FLTP;
   return true;

--- a/xbmc/cores/omxplayer/OMXAudioCodecOMX.cpp
+++ b/xbmc/cores/omxplayer/OMXAudioCodecOMX.cpp
@@ -41,7 +41,6 @@ COMXAudioCodecOMX::COMXAudioCodecOMX()
 
   m_pCodecContext = NULL;
   m_pConvert = NULL;
-  m_bOpenedCodec = false;
 
   m_channels = 0;
   m_pFrame1 = NULL;
@@ -65,7 +64,6 @@ COMXAudioCodecOMX::~COMXAudioCodecOMX()
 bool COMXAudioCodecOMX::Open(CDVDStreamInfo &hints)
 {
   AVCodec* pCodec = NULL;
-  m_bOpenedCodec = false;
 
   if (hints.codec == AV_CODEC_ID_DTS && g_RBP.RasberryPiVersion() > 1)
     pCodec = avcodec_find_decoder_by_name("dcadec");
@@ -122,7 +120,6 @@ bool COMXAudioCodecOMX::Open(CDVDStreamInfo &hints)
   }
 
   m_pFrame1 = av_frame_alloc();
-  m_bOpenedCodec = true;
   m_iSampleFormat = AV_SAMPLE_FMT_NONE;
   m_desiredSampleFormat = m_pCodecContext->sample_fmt == AV_SAMPLE_FMT_S16 ? AV_SAMPLE_FMT_S16 : AV_SAMPLE_FMT_FLTP;
   return true;
@@ -131,19 +128,8 @@ bool COMXAudioCodecOMX::Open(CDVDStreamInfo &hints)
 void COMXAudioCodecOMX::Dispose()
 {
   av_frame_free(&m_pFrame1);
-
   swr_free(&m_pConvert);
-
-  if (m_pCodecContext)
-  {
-    if (m_pCodecContext->extradata) av_free(m_pCodecContext->extradata);
-    m_pCodecContext->extradata = NULL;
-    if (m_bOpenedCodec) avcodec_close(m_pCodecContext);
-    m_bOpenedCodec = false;
-    av_free(m_pCodecContext);
-    m_pCodecContext = NULL;
-  }
-
+  avcodec_free_context(&m_pCodecContext);
   m_bGotFrame = false;
 }
 

--- a/xbmc/cores/omxplayer/OMXAudioCodecOMX.h
+++ b/xbmc/cores/omxplayer/OMXAudioCodecOMX.h
@@ -63,8 +63,6 @@ protected:
   int   m_iBufferOutputUsed;
   int   m_iBufferOutputAlloced;
 
-  bool m_bOpenedCodec;
-
   int     m_channels;
   CAEChannelInfo m_channelLayout;
   bool m_bFirstFrame;


### PR DESCRIPTION
This PR should fix some ffmpeg memleaks I discovered while doing some debugging, grateful for feedback from someone with more ffmpeg knowledge.

Changes to use `av_frame_free` (ffmpeg 2.2) and `avcodec_free_context` (ffmpeg 2.3) to free resources instead of `av_free`/`av_freep`.
Note: `avcodec_free_context` will call `avcodec_close` if the codec is open, free extradata and any other internal resources used by the context.

The change to use `avsubtitle_free` changes behavior and keeps the subtitle images in memory until next Decode call.
