### PR TITLE
ADDON: revert announcement interface, not thread safe

### DIFF
--- a/xbmc/addons/AddonDll.h
+++ b/xbmc/addons/AddonDll.h
@@ -31,8 +31,6 @@
 #include "filesystem/SpecialProtocol.h"
 #include "filesystem/Directory.h"
 #include "utils/log.h"
-#include "interfaces/IAnnouncer.h"
-#include "interfaces/AnnouncementManager.h"
 #include "utils/XMLUtils.h"
 #include "utils/Variant.h"
 #include "Util.h"
@@ -40,7 +38,7 @@
 namespace ADDON
 {
   template<class TheDll, typename TheStruct, typename TheProps>
-  class CAddonDll : public CAddon, public ANNOUNCEMENT::IAnnouncer
+  class CAddonDll : public CAddon
   {
   public:
     CAddonDll(AddonProps props);
@@ -60,8 +58,6 @@ namespace ADDON
     void Destroy();
 
     bool DllLoaded(void) const;
-
-    void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data);
 
   protected:
     void HandleException(std::exception &e, const char* context);
@@ -235,7 +231,6 @@ ADDON_STATUS CAddonDll<TheDll, TheStruct, TheProps>::Create()
     if (status == ADDON_STATUS_OK)
     {
       m_initialized = true;
-      ANNOUNCEMENT::CAnnouncementManager::GetInstance().AddAnnouncer(this);
     }
     else if ((status == ADDON_STATUS_NEED_SETTINGS) || (status == ADDON_STATUS_NEED_SAVEDSETTINGS))
     {
@@ -298,8 +293,6 @@ void CAddonDll<TheDll, TheStruct, TheProps>::Stop()
 template<class TheDll, typename TheStruct, typename TheProps>
 void CAddonDll<TheDll, TheStruct, TheProps>::Destroy()
 {
-  ANNOUNCEMENT::CAnnouncementManager::GetInstance().RemoveAnnouncer(this);
-
   /* Unload library file */
   try
   {
@@ -535,19 +528,6 @@ ADDON_STATUS CAddonDll<TheDll, TheStruct, TheProps>::TransferSettings()
   }
 
   return ADDON_STATUS_OK;
-}
-
-template<class TheDll, typename TheStruct, typename TheProps>
-void CAddonDll<TheDll, TheStruct, TheProps>::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data)
-{
-  try
-  {
-    m_pDll->Announce(ANNOUNCEMENT::AnnouncementFlagToString(flag), sender, message, &data);
-  }
-  catch (std::exception &e)
-  {
-    HandleException(e, "m_pDll->Announce()");
-  }
 }
 
 template<class TheDll, typename TheStruct, typename TheProps>

--- a/xbmc/addons/DllAddon.h
+++ b/xbmc/addons/DllAddon.h
@@ -36,7 +36,6 @@ public:
   virtual unsigned int GetSettings(ADDON_StructSetting*** sSet)=0;
   virtual void FreeSettings()=0;
   virtual ADDON_STATUS SetSetting(const char *settingName, const void *settingValue) =0;
-  virtual void Announce(const char *flag, const char *sender, const char *message, const void *data) =0;
 };
 
 template <typename TheStruct, typename Props>
@@ -53,7 +52,6 @@ public:
   DEFINE_METHOD0(void, FreeSettings)
   DEFINE_METHOD2(ADDON_STATUS, SetSetting, (const char *p1, const void *p2))
   DEFINE_METHOD1(void, GetAddon, (TheStruct* p1))
-  DEFINE_METHOD4(void, Announce, (const char *p1, const char *p2, const char *p3, const void *p4))
   BEGIN_METHOD_RESOLVE()
     RESOLVE_METHOD_RENAME(get_addon,GetAddon)
     RESOLVE_METHOD_RENAME(ADDON_Create, Create)
@@ -64,7 +62,6 @@ public:
     RESOLVE_METHOD_RENAME(ADDON_SetSetting, SetSetting)
     RESOLVE_METHOD_RENAME(ADDON_GetSettings, GetSettings)
     RESOLVE_METHOD_RENAME(ADDON_FreeSettings, FreeSettings)
-    RESOLVE_METHOD_RENAME(ADDON_Announce, Announce)
   END_METHOD_RESOLVE()
 };
 

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_addon_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_addon_dll.h
@@ -45,7 +45,6 @@ extern "C" {
   unsigned int __declspec(dllexport) ADDON_GetSettings(ADDON_StructSetting ***sSet);
   ADDON_STATUS __declspec(dllexport) ADDON_SetSetting(const char *settingName, const void *settingValue);
   void         __declspec(dllexport) ADDON_FreeSettings();
-  void         __declspec(dllexport) ADDON_Announce(const char *flag, const char *sender, const char *message, const void *data);
 
 #ifdef __cplusplus
 };


### PR DESCRIPTION
The addon dll interface is not designed for thread safety. Only the owning object is supposed to use this interface.
reverts: https://github.com/xbmc/xbmc/pull/2250

@fetzerch @ksooo @Jalle19 
afaik only a few pvr addons make use of this. PVRManager implements IAnnouncer already. No need for the short cut.
