### PR TITLE
[PVR] CPVRClients::GetTimers: Improve error handling.

### DIFF
--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -458,9 +458,9 @@ bool CPVRClients::HasTimerSupport(int iClientId)
   return false;
 }
 
-PVR_ERROR CPVRClients::GetTimers(CPVRTimers *timers)
+bool CPVRClients::GetTimers(CPVRTimers *timers, std::vector<int> &failedClients)
 {
-  PVR_ERROR error(PVR_ERROR_NO_ERROR);
+  bool bSuccess(true);
   PVR_CLIENTMAP clients;
   GetCreatedClients(clients);
 
@@ -472,11 +472,12 @@ PVR_ERROR CPVRClients::GetTimers(CPVRTimers *timers)
         currentError != PVR_ERROR_NO_ERROR)
     {
       CLog::Log(LOGERROR, "PVR - %s - cannot get timers from client '%d': %s",__FUNCTION__, (*itrClients).first, CPVRClient::ToString(currentError));
-      error = currentError;
+      bSuccess = false;
+      failedClients.push_back((*itrClients).first);
     }
   }
 
-  return error;
+  return bSuccess;
 }
 
 PVR_ERROR CPVRClients::AddTimer(const CPVRTimerInfoTag &timer)

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -348,9 +348,10 @@ namespace PVR
     /*!
      * @brief Get all timers from clients
      * @param timers Store the timers in this container.
-     * @return The amount of timers that were added.
+     * @param failedClients in case of errors will contain the ids of the clients for which the timers could not be obtained.
+     * @return true on success for all clients, false in case of error for at least one client.
      */
-    PVR_ERROR GetTimers(CPVRTimers *timers);
+    bool GetTimers(CPVRTimers *timers, std::vector<int> &failedClients);
 
     /*!
      * @brief Add a new timer to a backend.

--- a/xbmc/pvr/timers/PVRTimers.h
+++ b/xbmc/pvr/timers/PVRTimers.h
@@ -205,7 +205,7 @@ namespace PVR
     typedef std::vector<CPVRTimerInfoTagPtr> VecTimerInfoTag;
 
     void Unload(void);
-    bool UpdateEntries(const CPVRTimers &timers);
+    bool UpdateEntries(const CPVRTimers &timers, const std::vector<int> &failedClients);
     CPVRTimerInfoTagPtr GetByClient(int iClientId, unsigned int iClientTimerId) const;
     bool GetRootDirectory(const CPVRTimersPath &path, CFileItemList &items) const;
     bool GetSubDirectory(const CPVRTimersPath &path, CFileItemList &items) const;


### PR DESCRIPTION
Ever wondered about strange timer notifications - namely "deleted timer blah" and the like - and you are sure that actually no timer was deleted? 

So far, Kodi effectively ignores errors that occurred when timers should be obtained from clients. Especially, if on first call timers could be obtained successfully and on second call not, thus list of returned timers will be empty, and the timer sync algo here https://github.com/xbmc/xbmc/blob/master/xbmc/pvr/timers/PVRTimers.cpp#L189 erroneously will treat the empty list as "all timers got deleted on pvr client".

All other "wrong" notifications are followups of the problem just described.

@Jalle19 mind taking a look. btw, for pvr.hts I discovered an additional problem that can also trigger wrong timer notifications. Will come up with a PR for this as well.
