### PR TITLE
[OSX] Fix non working apple remote / universal ir remote / harmony

### DIFF
--- a/system/keymaps/universalremote.AppleRemote.xml
+++ b/system/keymaps/universalremote.AppleRemote.xml
@@ -1,0 +1,200 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This file contains the mapping of keys (gamepad,remote and keyboard) to actions within XBMC -->
+<!-- The <global> section is a fall through - they will only be used if the button is not        -->
+<!-- used in the current window's section.  Note that there is only handling                     -->
+<!-- for a single action per button at this stage.                                               -->
+<!-- For joystick/gamepad configuration under linux/win32, see below as it differs from xbox     -->
+<!-- gamepads.                                                                                   -->
+
+<!-- The format is:                                                                              -->
+<!--    <device>                                                                                 -->
+<!--      <obc#>xbmc action</obc#>                                                    -->
+<!--    </device>                                                                                -->
+
+<!-- To map keys from other remotes using the RCA protocol, you may add <universalremote> blocks -->
+<!-- In this case, the tags used are <obc#> where # is the original button code (OBC) of the key -->
+<!-- You set it up by adding a <universalremote> block to the window or <global> section:        -->
+<!--    <universalremote>                                                                        -->
+<!--       <obc45>Stop</obc45>                                                                   -->
+<!--    </universalremote>                                                                       -->
+
+<!-- Note that the action can be a built-in function.                                            -->
+<!--            eg <obc6>ActivateWindow(Favourites)</obc6>                       -->
+<!-- would bring up Favourites when the button with the id of 6 is press. In this case, "Menu"   -->
+
+<!--                                                                                             -->
+<!--  Button Ids:                                                                                -->
+<!--  'id' is the button ID used by SDL. The key ids recognized from your remote appears      -->
+<!--  in /var/log/syslog on the ATV2 for each button pressed and when debug mode is enabled      -->
+<!--  Use your log to discover and map custom buttons to actions.                                -->
+
+<keymap>
+  <global>
+    <universalremote>
+      <!-- plus       -->      <obc1>Up</obc1>
+      <!-- minus      -->      <obc2>Down</obc2>
+      <!-- left       -->      <obc3>Left</obc3>
+      <!-- right      -->      <obc4>Right</obc4>
+      <!-- center     -->      <obc5>Select</obc5>
+      <!-- menu       -->      <obc6>ParentDir</obc6>
+      <!-- hold center-->      <obc7>Fullscreen</obc7>
+      <!-- hold menu  -->      <obc8>ContextMenu</obc8>
+
+      <!-- old buttons for ATV1 <2.2, used on OSX  -->
+      <!-- hold left  -->      <obc9>Left</obc9>
+      <!-- hold right -->      <obc10>Right</obc10>
+
+      <!-- new aluminium remote buttons  -->
+      <!-- play/pause -->      <obc12>PlayPause</obc12>
+
+      <!-- Additional buttons via Harmony Apple TV remote profile - these are also the learned buttons on Apple TV 2gen-->
+      <!-- pageup     -->      <obc13>PageUp</obc13>
+      <!-- pagedown   -->      <obc14>PageDown</obc14>
+      <!-- pause      -->      <obc15>Pause</obc15><!-- work? -->
+      <!-- play2      -->      <obc16>Play</obc16>
+      <!-- stop       -->      <obc17>Stop</obc17>
+      <!-- fast fwd   -->      <obc18>FastForward</obc18><!-- work? -->
+      <!-- rewind     -->      <obc19>Rewind</obc19>
+      <!-- skip fwd   -->      <obc20>SkipNext</obc20>
+      <!-- skip back  -->      <obc21>SkipPrevious</obc21>
+
+      <!-- Learned remote buttons (ATV1 >2.3) -->
+      <!-- Play       -->      <obc70>Play</obc70>
+      <!-- Pause      -->      <obc71>Pause</obc71>
+      <!-- Stop       -->      <obc72>Stop</obc72>
+      <!-- Previous   -->      <obc73>SkipPrevious</obc73>
+      <!-- Next       -->      <obc74>SkipNext</obc74>
+      <!-- Rewind     -->      <obc75>Rewind</obc75>
+      <!-- Forward    -->      <obc76>FastForward</obc76>
+      <!-- Return     -->      <obc77>OSD</obc77>
+      <!-- Enter      -->      <obc78>ShowVideoMenu</obc78>
+
+      <!-- few gestures from Apple's iPhone Remote (ATV1 > 2.3 ?) -->
+      <!-- SwipeLeft  -->      <obc80>Left</obc80>
+      <!-- SwipeRight -->      <obc81>Right</obc81>
+      <!-- SwipeUp    -->      <obc82>Up</obc82>
+      <!-- SwipeDown  -->      <obc83>Down</obc83>
+
+      <!-- FlickLeft  -->      <obc85>Left</obc85>
+      <!-- FlickRight -->      <obc86>Right</obc86>
+      <!-- FlickUp    -->      <obc87>Up</obc87>
+      <!-- FlickDown  -->      <obc88>Down</obc88>
+
+    </universalremote>
+  </global>
+  <Home>
+    <universalremote>
+      <obc6>ActivateWindow(Favourites)</obc6>
+      <obc8>ActivateWindow(shutdownmenu)</obc8>
+    </universalremote>
+  </Home>
+  <FullscreenVideo>
+    <universalremote>
+      <obc1>VolumeUp</obc1>
+      <obc2>VolumeDown</obc2>
+      <obc3>StepBack</obc3>
+      <obc4>StepForward</obc4>
+      <obc5>Pause</obc5>
+      <obc6>Stop</obc6>
+      <obc7>OSD</obc7>
+      <obc8>Fullscreen</obc8>
+      <obc9>Rewind</obc9>
+      <obc10>FastForward</obc10>
+      <!-- pageup     -->      <obc13>ChapterOrBigStepForward</obc13>
+      <!-- pagedown   -->      <obc14>ChapterOrBigStepBack</obc14>
+      <!-- SwipeLeft  -->      <obc80>StepBack</obc80>
+      <!-- SwipeRight -->      <obc81>StepForward</obc81>
+      <!-- SwipeUp    -->      <obc82>BigStepForward</obc82>
+      <!-- SwipeDown  -->      <obc83>BigStepBack</obc83>
+      <!-- FlickLeft  -->      <obc85>Rewind</obc85>
+      <!-- FlickRight -->      <obc86>FastForward</obc86>
+      <!-- FlickUp    -->      <obc87>BigStepForward</obc87>
+      <!-- FlickDown  -->      <obc88>BigStepBack</obc88>
+    </universalremote>
+  </FullscreenVideo>
+  <FullscreenLiveTV>
+    <universalremote>
+      <obc3>ChannelDown</obc3>
+      <obc4>ChannelUp</obc4>
+      <!-- pageup     -->      <obc13>ChannelUp</obc13>
+      <!-- pagedown   -->      <obc14>ChannelDown</obc14>
+    </universalremote>
+  </FullscreenLiveTV>
+  <FullscreenRadio>
+    <universalremote>
+      <obc3>ChannelDown</obc3>
+      <obc4>ChannelUp</obc4>
+      <!-- pageup     -->      <obc13>ChannelUp</obc13>
+      <!-- pagedown   -->      <obc14>ChannelDown</obc14>
+    </universalremote>
+  </FullscreenRadio>
+  <Visualisation>
+    <universalremote>
+      <obc1>VolumeUp</obc1>
+      <obc2>VolumeDown</obc2>
+      <obc3>SkipPrevious</obc3>
+      <obc4>SkipNext</obc4>
+      <obc5>Pause</obc5>
+      <obc6>Fullscreen</obc6>
+      <obc7>OSD</obc7>
+      <obc8>Stop</obc8>
+      <!-- SwipeLeft  -->      <obc80>SkipPrevious</obc80>
+      <!-- SwipeRight -->      <obc81>SkipNext</obc81>
+      <!-- FlickLeft  -->      <obc85>SkipPrevious</obc85>
+      <!-- FlickRight -->      <obc86>SkipNext</obc86>
+    </universalremote>
+  </Visualisation>
+  <SlideShow>
+    <universalremote>
+      <obc1>ZoomIn</obc1>
+      <obc2>ZoomOut</obc2>
+      <obc3>PreviousPicture</obc3>
+      <obc4>NextPicture</obc4>
+      <obc6>Stop</obc6>
+      <obc7>Info</obc7>
+      <obc8>Rotate</obc8>
+      <!-- SwipeLeft  -->      <obc80>PreviousPicture</obc80>
+      <!-- SwipeRight -->      <obc81>NextPicture</obc81>
+      <!-- FlickLeft  -->      <obc85>PreviousPicture</obc85>
+      <!-- FlickRight -->      <obc86>NextPicture</obc86>
+    </universalremote>
+  </SlideShow>
+  <ScreenCalibration>
+    <universalremote>
+      <obc5>NextCalibration</obc5>
+    </universalremote>
+  </ScreenCalibration>
+  <VideoOSD>
+    <universalremote>
+      <obc7>Back</obc7>
+    </universalremote>
+  </VideoOSD>
+  <VideoMenu>
+    <universalremote>
+      <obc5>Select</obc5>
+      <obc6>Stop</obc6>
+      <obc7>OSD</obc7>
+      <obc8/>
+    </universalremote>
+  </VideoMenu>
+  <MyVideoLibrary>
+    <universalremote>
+      <obc7>Info</obc7>
+    </universalremote>
+  </MyVideoLibrary>
+  <MyVideoFiles>
+    <universalremote>
+      <obc7>Info</obc7>
+    </universalremote>
+  </MyVideoFiles>
+  <PictureInfo>
+    <universalremote>
+      <obc3>Left</obc3>
+      <obc4>Right</obc4>
+      <!-- SwipeLeft  -->      <obc80>Left</obc80>
+      <!-- SwipeRight -->      <obc81>Right</obc81>
+      <!-- FlickLeft  -->      <obc85>Left</obc85>
+      <!-- FlickRight -->      <obc86>Right</obc86>
+    </universalremote>
+  </PictureInfo>
+</keymap>

--- a/system/keymaps/universalremote.Harmony.xml
+++ b/system/keymaps/universalremote.Harmony.xml
@@ -1,0 +1,393 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This file contains the mapping of keys (gamepad, remote, and keyboard) to actions within XBMC -->
+<!-- The <global> section is a fall through - they will only be used if the button is not          -->
+<!-- used in the current window's section.  Note that there is only handling                       -->
+<!-- for a single action per button at this stage.                                                 -->
+<!-- For joystick/gamepad configuration under linux/win32, see below as it differs from xbox       -->
+<!-- gamepads.                                                                                     -->
+
+<!-- The format is:                      -->
+<!--    <device>                         -->
+<!--      <button>action</key>        -->
+<!--    </device>                        -->
+
+<!-- To map keys from other remotes using the RCA protocol, you may add <universalremote> blocks -->
+<!-- In this case, the tags used are <obc#> where # is the original button code (OBC) of the key -->
+<!-- You set it up by adding a <universalremote> block to the window or <global> section:       -->
+<!--    <universalremote>             -->
+<!--       <obc45>Stop</obc45>         -->
+<!--    </universalremote>            -->
+
+<!-- Note that the action can be a built-in function.                 -->
+<!--  eg <B>ActivateWindow(MyMusic)</B>                         -->
+<!-- would automatically go to My Music on the press of the B button. -->
+
+<!-- Joysticks / Gamepads:                                                                    -->
+<!--   See the sample PS3 controller configuration below for the format.                      -->
+<!--                                                                                          -->
+<!--  Joystick Name:                                                                          -->
+<!--   Do 'cat /proc/bus/input/devices' or see your xbmc log file  to find the names of       -->
+<!--   detected joysticks. The name used in the configuration should match the detected name. -->
+<!--                                                                                          -->
+<!--  Button Ids:                                                                             -->
+<!--   'id' is the button ID used by SDL. Joystick key ids of connected joysticks appear   -->
+<!--   in xbmc.log when they are pressed. Use your log to map custom buttons to actions.      -->
+<!--                                                                                          -->
+<!--  Axis Ids / Analog Controls                                                              -->
+<!--   Coming soon.                                                                           -->
+<keymap>
+  <global>
+    <universalremote>
+      <!-- up       	-->      <obc101>Up</obc101>
+      <!-- minus      	-->      <obc102>Down</obc102>
+      <!-- left       	-->      <obc103>Left</obc103>
+      <!-- right      	-->      <obc104>Right</obc104>
+      <!-- OK		-->      <obc105>Select</obc105>
+      <!-- menu       	-->      <obc106>ContextMenu</obc106>
+      <!-- hold play  	-->      <obc107>Fullscreen</obc107>
+      <!-- hold menu  	-->      <obc108>ContextMenu</obc108>
+      <!-- hold right 	-->      <obc109>Right</obc109>
+      <!-- hold left  	-->      <obc110>Left</obc110>
+      <!-- Stop       	-->      <obc115>Stop</obc115>
+      <!-- Stop Hold   	-->      <key id="117"/>
+      <!-- Play       	-->      <obc116>Play</obc116>
+      <!-- Play Hold   	-->      <key id="118"/>
+      <!-- Replay       -->      <obc191>SkipPrevious</obc191>
+      <!-- Skip      	-->      <obc192>SkipNext</obc192>
+      <!-- Record	-->      <obc152>Screenshot</obc152>
+      <!-- Rew       	-->      <obc141>Rewind</obc141>
+      <!-- Fwd  	-->      <obc142>FastForward</obc142>
+      <!-- Pause	-->      <obc126>Pause</obc126>
+      <!-- Prev		-->      <obc132>ParentDir</obc132>
+      <!-- Guide  	-->      <obc165>FullScreen</obc165>
+      <!-- Info  	-->      <obc131>Info</obc131>
+      <!-- Exit 	-->      <obc151>PreviousMenu</obc151>
+      <!-- Channel Up  	-->      <obc171>PageUp</obc171>
+      <!-- Channel Down -->      <obc172>PageDown</obc172>
+      <!-- looks like buttons below are duplicates of those above
+      Arrow Up  	 <obc171></obc171>
+      Arrow Down 	 <obc172></obc172>
+	  -->
+      <!-- Volume + 	-->  <obc121>VolumeUp</obc121>
+      <!-- Volume - 	-->  <obc122>VolumeDown</obc122>
+      <!-- 1 		-->      <obc111>Number1</obc111>
+      <!-- 2 		-->      <obc112>Number2</obc112>
+      <!-- 3 		-->      <obc113>Number3</obc113>
+      <!-- 4 		-->      <obc114>Number4</obc114>
+      <!-- 5 		-->      <obc123>Number5</obc123>
+      <!-- 6 		-->      <obc124>Number6</obc124>
+      <!-- 7 		-->      <obc133>Number7</obc133>
+      <!-- 8 		-->      <obc134>Number8</obc134>
+      <!-- 9 		-->      <obc143>Number9</obc143>
+      <!-- 0 		-->      <obc144>Number0</obc144>
+      <!-- * clear 	-->      <obc145>Back</obc145>
+      <!-- # enter 	-->      <obc136>Select</obc136>
+      <!-- Mute		-->      <obc125>Mute</obc125>
+      <!-- Aspect	-->      <obc161>AspectRatio</obc161>
+      <!-- F1		-->      <obc153>ActivateWindow(Music)</obc153>
+      <!-- F3		-->      <obc155>ActivateWindow(videolibrary,tvshowtitles,return)</obc155>
+      <!-- F2		-->      <obc154>ActivateWindow(videolibrary,movietitles,return)</obc154>
+      <!-- F4		-->      <obc156>ActivateWindow(Weather)</obc156>
+      <!-- F5			-->  <obc193>OSD</obc193>
+      <!-- F7			-->  <obc195>ActivateWindow(Home)</obc195>
+      <!-- F6			-->  <obc194>ActivateWindow(Scripts)</obc194>
+      <!-- F8			-->  <obc196>ActivateWindow(favourites)</obc196>
+      <!-- F9			-->  <obc173>ShowVideoMenu</obc173>
+      <!-- F10			-->  <obc174>ShowSubtitles</obc174>
+      <!-- F11			-->  <obc175>NextSubtitle</obc175>
+      <!-- F12			-->  <obc176>ActivateWindow(VideoFiles)</obc176>
+      <!-- F13			-->  <obc163>Playlist</obc163>
+      <!-- F14			-->  <obc164>AudioNextLanguage</obc164>
+      <!-- Large Down	-->  <obc182>PageDown</obc182>
+      <!-- Large Up	-->      <obc181>PageUp</obc181>
+      <!-- pwrToggle   -->   <obc166>ShutDown()</obc166>
+      <!-- Queue	-->      <obc162>Queue</obc162>
+      <!-- Sleep	-->      <obc146>Suspend()</obc146>
+      <!-- Red		-->      <obc183>CodecInfo</obc183>
+      <!-- Green	-->      <obc184>ActivateWindow(Settings)</obc184>
+      <!-- Yellow	-->      <obc185>xbmc.ActivateWindow(SystemSettings)</obc185>
+      <!-- Blue		-->      <obc186>ActivateWindow(SystemInfo)</obc186>
+    </universalremote>
+  </global>
+  <Home>
+    <universalremote>
+      <!-- menu       	-->      <obc16>ActivateWindow(PlayerControls)</obc16>
+      <!-- Info  	-->      <obc131>ActivateWindow(Settings)</obc131>
+      <!-- Exit 	-->      <obc151>ActivateWindow(ShutdownMenu)</obc151>
+      <!-- #enter	-->      <obc136>ActivateWindow(SystemInfo)</obc136>
+      <!-- 1 		-->      <obc111>ToggleFullScreen</obc111>
+    </universalremote>
+  </Home>
+  <MyFiles>
+    <universalremote>
+      <!-- 1 		-->      <obc111>Highlight</obc111>
+      <!-- 4 		-->      <obc114>Copy</obc114>
+      <!-- 7 		-->      <obc133>Move</obc133>
+      <!-- * clear 	-->      <obc145>Delete</obc145>
+    </universalremote>
+  </MyFiles>
+  <MyMusicPlaylist>
+    <universalremote>
+      <!-- * clear 	-->      <obc145>Delete</obc145>
+      <!-- Channel Up  	-->      <obc171>MoveItemUp</obc171>
+      <!-- Channel Down -->      <obc172>MoveItemDown</obc172>
+    </universalremote>
+  </MyMusicPlaylist>
+  <MyMusicFiles>
+    <universalremote>
+      <!-- * clear 	-->      <obc145>Delete</obc145>
+      <!-- 1 		-->      <obc111>JumpSMS1</obc111>
+      <!-- 2 		-->      <obc112>JumpSMS2</obc112>
+      <!-- 3 		-->      <obc113>JumpSMS3</obc113>
+      <!-- 4 		-->      <obc114>JumpSMS4</obc114>
+      <!-- 5 		-->      <obc123>JumpSMS5</obc123>
+      <!-- 6 		-->      <obc124>JumpSMS6</obc124>
+      <!-- 7 		-->      <obc133>JumpSMS7</obc133>
+      <!-- 8 		-->      <obc134>JumpSMS8</obc134>
+      <!-- 9 		-->      <obc143>JumpSMS9</obc143>
+    </universalremote>
+  </MyMusicFiles>
+  <MyMusicLibrary>
+    <universalremote>
+      <!-- 1 		-->      <obc111>JumpSMS1</obc111>
+      <!-- 2 		-->      <obc112>JumpSMS2</obc112>
+      <!-- 3 		-->      <obc113>JumpSMS3</obc113>
+      <!-- 4 		-->      <obc114>JumpSMS4</obc114>
+      <!-- 5 		-->      <obc123>JumpSMS5</obc123>
+      <!-- 6 		-->      <obc124>JumpSMS6</obc124>
+      <!-- 7 		-->      <obc133>JumpSMS7</obc133>
+      <!-- 8 		-->      <obc134>JumpSMS8</obc134>
+      <!-- 9 		-->      <obc143>JumpSMS9</obc143>
+    </universalremote>
+  </MyMusicLibrary>
+  <FullscreenVideo>
+    <universalremote>
+      <!-- up       	-->      <obc101>ChapterOrBigStepForward</obc101>
+      <!-- down      	-->      <obc102>ChapterOrBigStepBack</obc102>
+      <!-- left       	-->      <obc103>StepBack</obc103>
+      <!-- right      	-->      <obc104>StepForward</obc104>
+      <!-- menu       	-->      <obc106>OSD</obc106>
+      <!-- Prev		-->      <obc132>SmallStepBack</obc132>
+      <!-- Info  	-->      <obc131>Info</obc131>
+      <!-- F7		-->      <obc195>NextSubtitle</obc195>
+      <!-- F6		-->      <obc194>ShowSubtitles</obc194>
+    </universalremote>
+  </FullscreenVideo>
+  <FullscreenLiveTV>
+    <universalremote>
+      <!-- up       	-->      <obc101>ChannelUp</obc101>
+      <!-- down      	-->      <obc102>ChannelDown</obc102>
+      <!-- left       	-->      <obc103>PreviousChannelGroup</obc103>
+      <!-- right      	-->      <obc104>NextChannelGroup</obc104>
+    </universalremote>
+  </FullscreenLiveTV>
+  <FullscreenRadio>
+    <universalremote>
+      <!-- up       	-->      <obc101>ChannelUp</obc101>
+      <!-- down      	-->      <obc102>ChannelDown</obc102>
+      <!-- left       	-->      <obc103>PreviousChannelGroup</obc103>
+      <!-- right      	-->      <obc104>NextChannelGroup</obc104>
+    </universalremote>
+  </FullscreenRadio>
+  <FullscreenInfo>
+    <universalremote>
+      <!-- Info  	-->      <obc131>Back</obc131>
+    </universalremote>
+  </FullscreenInfo>
+  <PlayerControls>
+    <universalremote>
+      <!-- menu       	-->      <obc106>Back</obc106>
+    </universalremote>
+  </PlayerControls>
+  <Visualisation>
+    <universalremote>
+      <!-- up       	-->      <obc101>IncreaseRating</obc101>
+      <!-- minus      	-->      <obc102>DecreaseRating</obc102>
+      <!-- left       	-->      <obc103>PreviousPreset</obc103>
+      <!-- right      	-->      <obc104>NextPreset</obc104>
+      <!-- menu       	-->      <obc106>OSD</obc106>
+      <!-- Prev		-->      <obc132>LockPreset</obc132>
+      <!-- Info  	-->      <obc131>Info</obc131>
+      <!-- F8		-->      <obc196>ActivateWindow(VisualisationPresetList)</obc196>
+      <!-- F9		-->      <obc173>ActivateWindow(VisualisationSettings)</obc173>
+    </universalremote>
+  </Visualisation>
+  <MusicOSD>
+    <universalremote>
+      <!-- menu       	-->      <obc106>Back</obc106>
+      <!-- Info  	-->      <obc131>CodecInfo</obc131>
+    </universalremote>
+  </MusicOSD>
+  <VisualisationSettings>
+    <universalremote>
+      <!-- menu       	-->      <obc106>Back</obc106>
+    </universalremote>
+  </VisualisationSettings>
+  <VisualisationPresetList>
+    <universalremote>
+      <!-- menu       	-->      <obc106>Back</obc106>
+    </universalremote>
+  </VisualisationPresetList>
+  <SlideShow>
+    <universalremote>
+      <!-- 1 		-->      <obc111>ZoomLevel1</obc111>
+      <!-- 2 		-->      <obc112>ZoomLevel2</obc112>
+      <!-- 3 		-->      <obc113>ZoomLevel3</obc113>
+      <!-- 4 		-->      <obc114>ZoomLevel4</obc114>
+      <!-- 5 		-->      <obc123>ZoomLevel5</obc123>
+      <!-- 6 		-->      <obc124>ZoomLevel6</obc124>
+      <!-- 7 		-->      <obc133>ZoomLevel7</obc133>
+      <!-- 8 		-->      <obc134>ZoomLevel8</obc134>
+      <!-- 9 		-->      <obc143>ZoomLevel9</obc143>
+      <!-- 0 		-->      <obc144>ZoomNormal</obc144>
+      <!-- Skip      	-->      <obc192>NextPicture</obc192>
+      <!-- Replay       -->      <obc191>PreviousPicture</obc191>
+      <!-- Info  	-->      <obc131>Info</obc131>
+      <!-- OK		-->      <obc105>Rotate</obc105>
+    </universalremote>
+  </SlideShow>
+  <ScreenCalibration>
+    <universalremote>
+      <!-- OK		-->      <obc105>NextCalibration</obc105>
+      <!-- 0 		-->      <obc144>ResetCalibration</obc144>
+      <!-- # enter 	-->      <obc136>NextCalibration</obc136>
+      <!-- Guide  	-->      <obc165>NextResolution</obc165>
+    </universalremote>
+  </ScreenCalibration>
+  <GUICalibration>
+    <universalremote>
+      <!-- OK		-->      <obc105>NextCalibration</obc105>
+      <!-- 0 		-->      <obc144>ResetCalibration</obc144>
+      <!-- # enter 	-->      <obc136>NextCalibration</obc136>
+    </universalremote>
+  </GUICalibration>
+  <VideoOSD>
+    <universalremote>
+      <!-- menu       	-->      <obc106>Back</obc106>
+    </universalremote>
+  </VideoOSD>
+  <VideoMenu>
+    <universalremote>
+      <!-- menu       	-->      <obc106>OSD</obc106>
+      <!-- Info  	-->      <obc131>Info</obc131>
+    </universalremote>
+  </VideoMenu>
+  <OSDVideoSettings>
+    <universalremote>
+      <!-- menu       	-->      <obc106>Back</obc106>
+    </universalremote>
+  </OSDVideoSettings>
+  <OSDAudioSettings>
+    <universalremote>
+      <!-- menu       	-->      <obc106>Back</obc106>
+    </universalremote>
+  </OSDAudioSettings>
+  <VideoBookmarks>
+    <universalremote>
+      <!-- menu       	-->      <obc106>Back</obc106>
+      <!-- * clear 	-->      <obc145>Delete</obc145>
+    </universalremote>
+  </VideoBookmarks>
+  <MyVideoLibrary>
+    <universalremote>
+      <!-- * clear 	-->      <obc145>Delete</obc145>
+      <!-- # enter 	-->      <obc136>ToggleWatched</obc136>
+      <!-- 1 		-->      <obc111>JumpSMS1</obc111>
+      <!-- 2 		-->      <obc112>JumpSMS2</obc112>
+      <!-- 3 		-->      <obc113>JumpSMS3</obc113>
+      <!-- 4 		-->      <obc114>JumpSMS4</obc114>
+      <!-- 5 		-->      <obc123>JumpSMS5</obc123>
+      <!-- 6 		-->      <obc124>JumpSMS6</obc124>
+      <!-- 7 		-->      <obc133>JumpSMS7</obc133>
+      <!-- 8 		-->      <obc134>JumpSMS8</obc134>
+      <!-- 9 		-->      <obc143>JumpSMS9</obc143>
+    </universalremote>
+  </MyVideoLibrary>
+  <MyVideoFiles>
+    <universalremote>
+      <!-- * clear 	-->      <obc145>Delete</obc145>
+      <!-- 1 		-->      <obc111>JumpSMS1</obc111>
+      <!-- 2 		-->      <obc112>JumpSMS2</obc112>
+      <!-- 3 		-->      <obc113>JumpSMS3</obc113>
+      <!-- 4 		-->      <obc114>JumpSMS4</obc114>
+      <!-- 5 		-->      <obc123>JumpSMS5</obc123>
+      <!-- 6 		-->      <obc124>JumpSMS6</obc124>
+      <!-- 7 		-->      <obc133>JumpSMS7</obc133>
+      <!-- 8 		-->      <obc134>JumpSMS8</obc134>
+      <!-- 9 		-->      <obc143>JumpSMS9</obc143>
+    </universalremote>
+  </MyVideoFiles>
+  <MyVideoPlaylist>
+    <universalremote>
+      <!-- * clear 	-->      <obc145>Delete</obc145>
+      <!-- Channel Up  	-->      <obc171>MoveItemUp</obc171>
+      <!-- Channel Down -->      <obc172>MoveItemDown</obc172>
+    </universalremote>
+  </MyVideoPlaylist>
+  <VirtualKeyboard>
+    <universalremote>
+      <!-- Prev		-->      <obc132>BackSpace</obc132>
+      <!-- * clear 	-->      <obc145>Shift</obc145>
+      <!-- # enter 	-->      <obc136>Symbols</obc136>
+      <!-- 1 		-->      <obc111>Number1</obc111>
+      <!-- 2 		-->      <obc112>Number2</obc112>
+      <!-- 3 		-->      <obc113>Number3</obc113>
+      <!-- 4 		-->      <obc114>Number4</obc114>
+      <!-- 5 		-->      <obc123>Number5</obc123>
+      <!-- 6 		-->      <obc124>Number6</obc124>
+      <!-- 7 		-->      <obc133>Number7</obc133>
+      <!-- 8 		-->      <obc134>Number8</obc134>
+      <!-- 9 		-->      <obc143>Number9</obc143>
+      <!-- 0 		-->      <obc144>Number0</obc144>
+      <!-- Rew       	-->      <obc141>CursorLeft</obc141>
+      <!-- Fwd  	-->      <obc142>CursorRight</obc142>
+    </universalremote>
+  </VirtualKeyboard>
+  <Scripts>
+    <universalremote>
+      <!-- Info  	-->      <obc131>info</obc131>
+    </universalremote>
+  </Scripts>
+  <NumericInput>
+    <universalremote>
+      <!-- 1 		-->      <obc111>Number1</obc111>
+      <!-- 2 		-->      <obc112>Number2</obc112>
+      <!-- 3 		-->      <obc113>Number3</obc113>
+      <!-- 4 		-->      <obc114>Number4</obc114>
+      <!-- 5 		-->      <obc123>Number5</obc123>
+      <!-- 6 		-->      <obc124>Number6</obc124>
+      <!-- 7 		-->      <obc133>Number7</obc133>
+      <!-- 8 		-->      <obc134>Number8</obc134>
+      <!-- 9 		-->      <obc143>Number9</obc143>
+      <!-- 0 		-->      <obc144>Number0</obc144>
+      <!-- Prev		-->      <obc132>BackSpace</obc132>
+    </universalremote>
+  </NumericInput>
+  <MusicInformation>
+    <universalremote>
+      <!-- menu       	-->      <obc106>Back</obc106>
+    </universalremote>
+  </MusicInformation>
+  <MovieInformation>
+    <universalremote>
+      <!-- menu       	-->      <obc106>Back</obc106>
+    </universalremote>
+  </MovieInformation>
+  <LockSettings>
+    <universalremote>
+      <!-- menu       	-->      <obc106>Back</obc106>
+    </universalremote>
+  </LockSettings>
+  <ProfileSettings>
+    <universalremote>
+      <!-- menu       	-->      <obc106>Back</obc106>
+    </universalremote>
+  </ProfileSettings>
+  <PictureInfo>
+    <universalremote>
+      <!-- Replay       -->      <obc191>PreviousPicture</obc191>
+      <!-- Skip      	-->      <obc192>NextPicture</obc192>
+      <!-- Info  	-->      <obc131>Back</obc131>
+    </universalremote>
+  </PictureInfo>
+</keymap>

--- a/tools/EventClients/Clients/OSXRemote/XBMCHelper.xcodeproj/project.pbxproj
+++ b/tools/EventClients/Clients/OSXRemote/XBMCHelper.xcodeproj/project.pbxproj
@@ -188,6 +188,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_WARN_CXX0X_EXTENSIONS = YES;
 				CONFIGURATION_BUILD_DIR = ../../../darwin/runtime;
 				COPY_PHASE_STRIP = NO;
 				GCC_DYNAMIC_NO_PIC = NO;
@@ -197,7 +200,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = DEBUG;
 				GCC_VERSION = "";
 				INSTALL_PATH = /usr/local/bin;
-				MACOSX_DEPLOYMENT_TARGET = 10.6;
+				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_NAME = XBMCHelper;
 				SDKROOT = macosx;
@@ -210,12 +213,15 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_WARN_CXX0X_EXTENSIONS = YES;
 				CONFIGURATION_BUILD_DIR = ../../../darwin/runtime;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_MODEL_TUNING = G5;
 				GCC_VERSION = "";
 				INSTALL_PATH = /usr/local/bin;
-				MACOSX_DEPLOYMENT_TARGET = 10.6;
+				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_NAME = XBMCHelper;
 				SDKROOT = macosx;

--- a/tools/EventClients/Clients/OSXRemote/xbmcclientwrapper.mm
+++ b/tools/EventClients/Clients/OSXRemote/xbmcclientwrapper.mm
@@ -261,106 +261,112 @@ void XBMCClientWrapperImpl::handleEvent(eATVClientEvent f_event){
 void XBMCClientWrapperImpl::populateEventMap(){
 	tEventMap& lr_map = m_event_map;
   
-	lr_map.insert(std::make_pair(ATV_BUTTON_CENTER,          new CPacketBUTTON(5, "JS0:AppleRemote", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
-	lr_map.insert(std::make_pair(ATV_BUTTON_RIGHT,         new CPacketBUTTON(4, "JS0:AppleRemote", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
-	lr_map.insert(std::make_pair(ATV_BUTTON_RIGHT_RELEASE, new CPacketBUTTON(4, "JS0:AppleRemote", BTN_UP | BTN_NO_REPEAT | BTN_QUEUE)));
-	lr_map.insert(std::make_pair(ATV_BUTTON_LEFT,          new CPacketBUTTON(3, "JS0:AppleRemote", BTN_DOWN | BTN_NO_REPEAT| BTN_QUEUE)));
-	lr_map.insert(std::make_pair(ATV_BUTTON_LEFT_RELEASE,  new CPacketBUTTON(3, "JS0:AppleRemote", BTN_UP | BTN_NO_REPEAT | BTN_QUEUE)));
-	lr_map.insert(std::make_pair(ATV_BUTTON_MENU,          new CPacketBUTTON(6, "JS0:AppleRemote", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
-	lr_map.insert(std::make_pair(ATV_BUTTON_MENU_H,        new CPacketBUTTON(8, "JS0:AppleRemote", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
-	lr_map.insert(std::make_pair(ATV_BUTTON_UP,            new CPacketBUTTON(1, "JS0:AppleRemote", BTN_DOWN | BTN_QUEUE)));
-	lr_map.insert(std::make_pair(ATV_BUTTON_UP_RELEASE,    new CPacketBUTTON(1, "JS0:AppleRemote", BTN_UP | BTN_QUEUE)));
-	lr_map.insert(std::make_pair(ATV_BUTTON_DOWN,          new CPacketBUTTON(2, "JS0:AppleRemote", BTN_DOWN | BTN_QUEUE)));
-	lr_map.insert(std::make_pair(ATV_BUTTON_DOWN_RELEASE,  new CPacketBUTTON(2, "JS0:AppleRemote", BTN_UP | BTN_QUEUE)));
+	lr_map.insert(std::make_pair(ATV_BUTTON_CENTER,          new CPacketBUTTON("obc5", "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+	lr_map.insert(std::make_pair(ATV_BUTTON_RIGHT,         new CPacketBUTTON("obc4", "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+	lr_map.insert(std::make_pair(ATV_BUTTON_RIGHT_RELEASE, new CPacketBUTTON("obc4", "R2", BTN_UP | BTN_NO_REPEAT | BTN_QUEUE)));
+	lr_map.insert(std::make_pair(ATV_BUTTON_LEFT,          new CPacketBUTTON("obc3", "R2", BTN_DOWN | BTN_NO_REPEAT| BTN_QUEUE)));
+	lr_map.insert(std::make_pair(ATV_BUTTON_LEFT_RELEASE,  new CPacketBUTTON("obc3", "R2", BTN_UP | BTN_NO_REPEAT | BTN_QUEUE)));
+	lr_map.insert(std::make_pair(ATV_BUTTON_MENU,          new CPacketBUTTON("obc6", "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+	lr_map.insert(std::make_pair(ATV_BUTTON_MENU_H,        new CPacketBUTTON("obc8", "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+	lr_map.insert(std::make_pair(ATV_BUTTON_UP,            new CPacketBUTTON("obc1", "R2", BTN_DOWN | BTN_QUEUE)));
+	lr_map.insert(std::make_pair(ATV_BUTTON_UP_RELEASE,    new CPacketBUTTON("obc1", "R2", BTN_UP | BTN_QUEUE)));
+	lr_map.insert(std::make_pair(ATV_BUTTON_DOWN,          new CPacketBUTTON("obc2", "R2", BTN_DOWN | BTN_QUEUE)));
+	lr_map.insert(std::make_pair(ATV_BUTTON_DOWN_RELEASE,  new CPacketBUTTON("obc2", "R2", BTN_UP | BTN_QUEUE)));
 	
 	// only present on ATV <= 2.1 <--- check that; OSX seems to have the release parts
-	lr_map.insert(std::make_pair(ATV_BUTTON_RIGHT_H, new CPacketBUTTON(10, "JS0:AppleRemote", BTN_DOWN | BTN_QUEUE)));	
-	lr_map.insert(std::make_pair(ATV_BUTTON_RIGHT_H_RELEASE, new CPacketBUTTON(10, "JS0:AppleRemote", BTN_UP | BTN_QUEUE)));	
-	lr_map.insert(std::make_pair(ATV_BUTTON_LEFT_H,  new CPacketBUTTON(9, "JS0:AppleRemote", BTN_DOWN | BTN_QUEUE)));
-	lr_map.insert(std::make_pair(ATV_BUTTON_LEFT_H_RELEASE, new CPacketBUTTON(9, "JS0:AppleRemote", BTN_UP | BTN_QUEUE)));	
+	lr_map.insert(std::make_pair(ATV_BUTTON_RIGHT_H, new CPacketBUTTON("obc10", "R2", BTN_DOWN | BTN_QUEUE)));	
+	lr_map.insert(std::make_pair(ATV_BUTTON_RIGHT_H_RELEASE, new CPacketBUTTON("obc10", "R2", BTN_UP | BTN_QUEUE)));	
+	lr_map.insert(std::make_pair(ATV_BUTTON_LEFT_H,  new CPacketBUTTON("obc9", "R2", BTN_DOWN | BTN_QUEUE)));
+	lr_map.insert(std::make_pair(ATV_BUTTON_LEFT_H_RELEASE, new CPacketBUTTON("obc9", "R2", BTN_UP | BTN_QUEUE)));	
 
 	//new aluminium remote buttons
-	lr_map.insert(std::make_pair(ATV_BUTTON_PLAY,  new CPacketBUTTON(12, "JS0:AppleRemote", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
-	lr_map.insert(std::make_pair(ATV_BUTTON_PLAY_H, new CPacketBUTTON(13, "JS0:AppleRemote", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+	lr_map.insert(std::make_pair(ATV_BUTTON_PLAY,  new CPacketBUTTON("obc12", "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+	lr_map.insert(std::make_pair(ATV_BUTTON_PLAY_H, new CPacketBUTTON("obc13", "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
 
 	// only present on atv >= 2.2
-	lr_map.insert(std::make_pair(ATV_BUTTON_CENTER_H,  new CPacketBUTTON(7, "JS0:AppleRemote", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+	lr_map.insert(std::make_pair(ATV_BUTTON_CENTER_H,  new CPacketBUTTON("obc7", "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
   
   //learned remote buttons (ATV >=2.3)
-  lr_map.insert(std::make_pair(ATV_LEARNED_PLAY,  new CPacketBUTTON(70, "JS0:AppleRemote", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
-  lr_map.insert(std::make_pair(ATV_LEARNED_PAUSE,  new CPacketBUTTON(71, "JS0:AppleRemote", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
-  lr_map.insert(std::make_pair(ATV_LEARNED_STOP,  new CPacketBUTTON(72, "JS0:AppleRemote", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
-  lr_map.insert(std::make_pair(ATV_LEARNED_PREVIOUS,  new CPacketBUTTON(73, "JS0:AppleRemote", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
-  lr_map.insert(std::make_pair(ATV_LEARNED_NEXT,  new CPacketBUTTON(74, "JS0:AppleRemote", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
-  lr_map.insert(std::make_pair(ATV_LEARNED_REWIND,  new CPacketBUTTON(75, "JS0:AppleRemote", BTN_DOWN | BTN_QUEUE)));
-  lr_map.insert(std::make_pair(ATV_LEARNED_REWIND_RELEASE,  new CPacketBUTTON(75, "JS0:AppleRemote", BTN_UP | BTN_QUEUE)));
-  lr_map.insert(std::make_pair(ATV_LEARNED_FORWARD,  new CPacketBUTTON(76, "JS0:AppleRemote", BTN_DOWN | BTN_QUEUE)));
-  lr_map.insert(std::make_pair(ATV_LEARNED_FORWARD_RELEASE,  new CPacketBUTTON(76, "JS0:AppleRemote", BTN_UP | BTN_QUEUE)));
-  lr_map.insert(std::make_pair(ATV_LEARNED_RETURN,  new CPacketBUTTON(77, "JS0:AppleRemote", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
-  lr_map.insert(std::make_pair(ATV_LEARNED_ENTER,  new CPacketBUTTON(78, "JS0:AppleRemote", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+  lr_map.insert(std::make_pair(ATV_LEARNED_PLAY,  new CPacketBUTTON("obc70", "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+  lr_map.insert(std::make_pair(ATV_LEARNED_PAUSE,  new CPacketBUTTON("obc71", "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+  lr_map.insert(std::make_pair(ATV_LEARNED_STOP,  new CPacketBUTTON("obc72", "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+  lr_map.insert(std::make_pair(ATV_LEARNED_PREVIOUS,  new CPacketBUTTON("obc73", "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+  lr_map.insert(std::make_pair(ATV_LEARNED_NEXT,  new CPacketBUTTON("obc74", "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+  lr_map.insert(std::make_pair(ATV_LEARNED_REWIND,  new CPacketBUTTON("obc75", "R2", BTN_DOWN | BTN_QUEUE)));
+  lr_map.insert(std::make_pair(ATV_LEARNED_REWIND_RELEASE,  new CPacketBUTTON("obc75", "R2", BTN_UP | BTN_QUEUE)));
+  lr_map.insert(std::make_pair(ATV_LEARNED_FORWARD,  new CPacketBUTTON("obc76", "R2", BTN_DOWN | BTN_QUEUE)));
+  lr_map.insert(std::make_pair(ATV_LEARNED_FORWARD_RELEASE,  new CPacketBUTTON("obc76", "R2", BTN_UP | BTN_QUEUE)));
+  lr_map.insert(std::make_pair(ATV_LEARNED_RETURN,  new CPacketBUTTON("obc77", "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+  lr_map.insert(std::make_pair(ATV_LEARNED_ENTER,  new CPacketBUTTON("obc78", "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
 }
 
 void XBMCClientWrapperImpl::populateSequenceMap(){
   XBMCClientEventSequence sequence_prefix;
   sequence_prefix << ATV_BUTTON_MENU_H;
-  m_sequence_map.insert(std::make_pair(sequence_prefix, new CPacketBUTTON(8, "JS0:AppleRemote", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
-  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_CENTER, new CPacketBUTTON(20, "JS0:AppleRemote", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
-  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_RIGHT, new CPacketBUTTON(21, "JS0:AppleRemote", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
-  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_LEFT, new CPacketBUTTON(22, "JS0:AppleRemote", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
-  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_UP, new CPacketBUTTON(23, "JS0:AppleRemote", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
-  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_DOWN, new CPacketBUTTON(24, "JS0:AppleRemote", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
-  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_MENU, new CPacketBUTTON(25, "JS0:AppleRemote", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+  m_sequence_map.insert(std::make_pair(sequence_prefix, new CPacketBUTTON("obc8", "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_CENTER, new CPacketBUTTON("obc20", "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_RIGHT, new CPacketBUTTON("obc21", "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_LEFT, new CPacketBUTTON("obc22", "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_UP, new CPacketBUTTON("obc23", "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_DOWN, new CPacketBUTTON("obc24", "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_MENU, new CPacketBUTTON("obc25", "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
   
   sequence_prefix.clear();
   sequence_prefix << ATV_BUTTON_MENU_H << ATV_BUTTON_CENTER;
-  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_CENTER, new CPacketBUTTON(26, "JS0:AppleRemote", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
-  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_RIGHT, new CPacketBUTTON(27, "JS0:AppleRemote", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
-  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_LEFT, new CPacketBUTTON(28, "JS0:AppleRemote", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
-  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_UP, new CPacketBUTTON(29, "JS0:AppleRemote", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
-  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_DOWN, new CPacketBUTTON(30, "JS0:AppleRemote", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
-  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_MENU, new CPacketBUTTON(31, "JS0:AppleRemote", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_CENTER, new CPacketBUTTON("obc26", "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_RIGHT, new CPacketBUTTON("obc27", "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_LEFT, new CPacketBUTTON("obc28", "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_UP, new CPacketBUTTON("obc29", "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_DOWN, new CPacketBUTTON("obc30", "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_MENU, new CPacketBUTTON("obc31", "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
   
   sequence_prefix.clear();
   sequence_prefix << ATV_BUTTON_MENU_H << ATV_BUTTON_UP;
-  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_CENTER, new CPacketBUTTON(32, "JS0:AppleRemote", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
-  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_RIGHT, new CPacketBUTTON(33, "JS0:AppleRemote", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
-  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_LEFT, new CPacketBUTTON(34, "JS0:AppleRemote", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
-  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_UP, new CPacketBUTTON(35, "JS0:AppleRemote", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
-  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_DOWN, new CPacketBUTTON(36, "JS0:AppleRemote", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
-  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_MENU, new CPacketBUTTON(37, "JS0:AppleRemote", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_CENTER, new CPacketBUTTON("obc32", "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_RIGHT, new CPacketBUTTON("obc33", "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_LEFT, new CPacketBUTTON("obc34", "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_UP, new CPacketBUTTON("obc35", "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_DOWN, new CPacketBUTTON("obc36", "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_MENU, new CPacketBUTTON("obc37", "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
   
   sequence_prefix.clear();
   sequence_prefix << ATV_BUTTON_MENU_H << ATV_BUTTON_DOWN;
-  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_CENTER, new CPacketBUTTON(38, "JS0:AppleRemote", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
-  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_RIGHT, new CPacketBUTTON(39, "JS0:AppleRemote", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
-  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_LEFT, new CPacketBUTTON(40, "JS0:AppleRemote", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
-  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_UP, new CPacketBUTTON(41, "JS0:AppleRemote", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
-  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_DOWN, new CPacketBUTTON(42, "JS0:AppleRemote", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
-  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_MENU, new CPacketBUTTON(43, "JS0:AppleRemote", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_CENTER, new CPacketBUTTON("obc38", "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_RIGHT, new CPacketBUTTON("obc39", "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_LEFT, new CPacketBUTTON("obc40", "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_UP, new CPacketBUTTON("obc41", "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_DOWN, new CPacketBUTTON("obc42", "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_MENU, new CPacketBUTTON("obc43", "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
   
   sequence_prefix.clear();
   sequence_prefix << ATV_BUTTON_MENU_H << ATV_BUTTON_RIGHT;
-  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_CENTER, new CPacketBUTTON(44, "JS0:AppleRemote", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
-  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_RIGHT, new CPacketBUTTON(45, "JS0:AppleRemote", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
-  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_LEFT, new CPacketBUTTON(46, "JS0:AppleRemote", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
-  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_UP, new CPacketBUTTON(47, "JS0:AppleRemote", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
-  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_DOWN, new CPacketBUTTON(48, "JS0:AppleRemote", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
-  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_MENU, new CPacketBUTTON(49, "JS0:AppleRemote", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_CENTER, new CPacketBUTTON("obc44", "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_RIGHT, new CPacketBUTTON("obc45", "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_LEFT, new CPacketBUTTON("obc46", "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_UP, new CPacketBUTTON("obc47", "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_DOWN, new CPacketBUTTON("obc48", "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_MENU, new CPacketBUTTON("obc49", "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
   
   sequence_prefix.clear();
   sequence_prefix << ATV_BUTTON_MENU_H << ATV_BUTTON_LEFT;
-  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_CENTER, new CPacketBUTTON(50, "JS0:AppleRemote", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
-  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_RIGHT, new CPacketBUTTON(51, "JS0:AppleRemote", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
-  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_LEFT, new CPacketBUTTON(52, "JS0:AppleRemote", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
-  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_UP, new CPacketBUTTON(53, "JS0:AppleRemote", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
-  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_DOWN, new CPacketBUTTON(54, "JS0:AppleRemote", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
-  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_MENU, new CPacketBUTTON(55, "JS0:AppleRemote", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_CENTER, new CPacketBUTTON("obc50", "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_RIGHT, new CPacketBUTTON("obc51", "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_LEFT, new CPacketBUTTON("obc52", "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_UP, new CPacketBUTTON("obc53", "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_DOWN, new CPacketBUTTON("obc54", "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+  m_sequence_map.insert(std::make_pair( sequence_prefix + ATV_BUTTON_MENU, new CPacketBUTTON("obc55", "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+}
+
+const char * GetObcString(int obcCode)
+{
+    std::string ret =   "obc" + std::to_string(obcCode);
+    return ret.c_str();
 }
 
 void XBMCClientWrapperImpl::populateMultiRemoteModeMap(){
   //the example of harmony as a multi-remote uses a few key device-id's paired with the normal buttons
   static int device_ids[] = {150, 151, 152, 153, 154, 155, 157, 158, 159, 160};
-  int offset = 0;
+  int offset = 100;// to distinguish them from the other ids as we only have one keyboard map for all inputs
   for(int* device_id = device_ids; device_id != device_ids + sizeof(device_ids)/sizeof(*device_ids); ++device_id, offset += 10)
   {
     // keymaps for mult-apple-remote, including the device-key sent after remote-switch
@@ -373,26 +379,26 @@ void XBMCClientWrapperImpl::populateMultiRemoteModeMap(){
     // pro: custom tweaks. e.g. button 1 on the harmony may be  (153, ATV_BUTTON_LEFT) and this should not get a repeat
     //      maybe use the loop and tweak individual buttons later; plex maps here to strings, and later in keymap.xml to other strings,
     //      but this may need another kind of remote in XBMC source
-    m_multiremote_map.insert(std::make_pair(std::make_pair(*device_id,ATV_BUTTON_UP),            new CPacketBUTTON(1 + offset, "JS0:Harmony", BTN_DOWN | BTN_QUEUE)));
-    m_multiremote_map.insert(std::make_pair(std::make_pair(*device_id,ATV_BUTTON_UP_RELEASE),    new CPacketBUTTON(1 + offset, "JS0:Harmony", BTN_UP | BTN_QUEUE)));
-    m_multiremote_map.insert(std::make_pair(std::make_pair(*device_id,ATV_BUTTON_DOWN),          new CPacketBUTTON(2 + offset, "JS0:Harmony", BTN_DOWN | BTN_QUEUE)));
-    m_multiremote_map.insert(std::make_pair(std::make_pair(*device_id,ATV_BUTTON_DOWN_RELEASE),  new CPacketBUTTON(2 + offset, "JS0:Harmony", BTN_UP | BTN_QUEUE)));
+    m_multiremote_map.insert(std::make_pair(std::make_pair(*device_id,ATV_BUTTON_UP),            new CPacketBUTTON(GetObcString(1 + offset), "R2", BTN_DOWN | BTN_QUEUE)));
+    m_multiremote_map.insert(std::make_pair(std::make_pair(*device_id,ATV_BUTTON_UP_RELEASE),    new CPacketBUTTON(GetObcString(1 + offset), "R2", BTN_UP | BTN_QUEUE)));
+    m_multiremote_map.insert(std::make_pair(std::make_pair(*device_id,ATV_BUTTON_DOWN),          new CPacketBUTTON(GetObcString(2 + offset), "R2", BTN_DOWN | BTN_QUEUE)));
+    m_multiremote_map.insert(std::make_pair(std::make_pair(*device_id,ATV_BUTTON_DOWN_RELEASE),  new CPacketBUTTON(GetObcString(2 + offset), "R2", BTN_UP | BTN_QUEUE)));
     
-    m_multiremote_map.insert(std::make_pair(std::make_pair(*device_id,ATV_BUTTON_LEFT),          new CPacketBUTTON(3 + offset, "JS0:Harmony", BTN_DOWN | BTN_QUEUE)));
-    m_multiremote_map.insert(std::make_pair(std::make_pair(*device_id,ATV_BUTTON_LEFT_RELEASE),  new CPacketBUTTON(3 + offset, "JS0:Harmony", BTN_UP | BTN_QUEUE)));
-    m_multiremote_map.insert(std::make_pair(std::make_pair(*device_id,ATV_BUTTON_RIGHT),         new CPacketBUTTON(4 + offset, "JS0:Harmony", BTN_DOWN | BTN_QUEUE)));
-    m_multiremote_map.insert(std::make_pair(std::make_pair(*device_id,ATV_BUTTON_RIGHT_RELEASE), new CPacketBUTTON(4 + offset, "JS0:Harmony", BTN_UP | BTN_QUEUE)));
+    m_multiremote_map.insert(std::make_pair(std::make_pair(*device_id,ATV_BUTTON_LEFT),          new CPacketBUTTON(GetObcString(3 + offset), "R2", BTN_DOWN | BTN_QUEUE)));
+    m_multiremote_map.insert(std::make_pair(std::make_pair(*device_id,ATV_BUTTON_LEFT_RELEASE),  new CPacketBUTTON(GetObcString(3 + offset), "R2", BTN_UP | BTN_QUEUE)));
+    m_multiremote_map.insert(std::make_pair(std::make_pair(*device_id,ATV_BUTTON_RIGHT),         new CPacketBUTTON(GetObcString(4 + offset), "R2", BTN_DOWN | BTN_QUEUE)));
+    m_multiremote_map.insert(std::make_pair(std::make_pair(*device_id,ATV_BUTTON_RIGHT_RELEASE), new CPacketBUTTON(GetObcString(4 + offset), "R2", BTN_UP | BTN_QUEUE)));
     
-    m_multiremote_map.insert(std::make_pair(std::make_pair(*device_id,ATV_BUTTON_CENTER),          new CPacketBUTTON(5 + offset, "JS0:Harmony", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
-    m_multiremote_map.insert(std::make_pair(std::make_pair(*device_id,ATV_BUTTON_MENU),          new CPacketBUTTON(6 + offset, "JS0:Harmony", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
-    m_multiremote_map.insert(std::make_pair(std::make_pair(*device_id,ATV_BUTTON_CENTER_H),        new CPacketBUTTON(7 + offset, "JS0:Harmony", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
-    m_multiremote_map.insert(std::make_pair(std::make_pair(*device_id,ATV_BUTTON_MENU_H),        new CPacketBUTTON(8 + offset, "JS0:Harmony", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+    m_multiremote_map.insert(std::make_pair(std::make_pair(*device_id,ATV_BUTTON_CENTER),          new CPacketBUTTON(GetObcString(5 + offset), "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE))); 
+    m_multiremote_map.insert(std::make_pair(std::make_pair(*device_id,ATV_BUTTON_MENU),          new CPacketBUTTON(GetObcString(6 + offset), "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+    m_multiremote_map.insert(std::make_pair(std::make_pair(*device_id,ATV_BUTTON_CENTER_H),        new CPacketBUTTON(GetObcString(7 + offset), "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
+    m_multiremote_map.insert(std::make_pair(std::make_pair(*device_id,ATV_BUTTON_MENU_H),        new CPacketBUTTON(GetObcString(8 + offset), "R2", BTN_DOWN | BTN_NO_REPEAT | BTN_QUEUE)));
     
-    m_multiremote_map.insert(std::make_pair(std::make_pair(*device_id,ATV_BUTTON_RIGHT_H),       new CPacketBUTTON(9 + offset, "JS0:Harmony", BTN_DOWN | BTN_QUEUE)));
-    m_multiremote_map.insert(std::make_pair(std::make_pair(*device_id,ATV_BUTTON_RIGHT_H_RELEASE),new CPacketBUTTON(9 + offset, "JS0:Harmony", BTN_UP | BTN_QUEUE)));
+    m_multiremote_map.insert(std::make_pair(std::make_pair(*device_id,ATV_BUTTON_RIGHT_H),       new CPacketBUTTON(GetObcString(9 + offset), "R2", BTN_DOWN | BTN_QUEUE)));
+    m_multiremote_map.insert(std::make_pair(std::make_pair(*device_id,ATV_BUTTON_RIGHT_H_RELEASE),new CPacketBUTTON(GetObcString(9 + offset), "R2", BTN_UP | BTN_QUEUE)));
         
-    m_multiremote_map.insert(std::make_pair(std::make_pair(*device_id,ATV_BUTTON_LEFT_H),        new CPacketBUTTON(10 + offset, "JS0:Harmony", BTN_DOWN | BTN_QUEUE)));    
-    m_multiremote_map.insert(std::make_pair(std::make_pair(*device_id,ATV_BUTTON_LEFT_H_RELEASE),new CPacketBUTTON(10 + offset, "JS0:Harmony", BTN_UP | BTN_QUEUE)));    
+    m_multiremote_map.insert(std::make_pair(std::make_pair(*device_id,ATV_BUTTON_LEFT_H),        new CPacketBUTTON(GetObcString(10 + offset), "R2", BTN_DOWN | BTN_QUEUE)));    
+    m_multiremote_map.insert(std::make_pair(std::make_pair(*device_id,ATV_BUTTON_LEFT_H_RELEASE),new CPacketBUTTON(GetObcString(10 + offset), "R2", BTN_UP | BTN_QUEUE)));    
   }
 }
 

--- a/xbmc/input/KeyboardStat.cpp
+++ b/xbmc/input/KeyboardStat.cpp
@@ -225,11 +225,20 @@ std::string CKeyboardStat::GetKeyName(int KeyID)
 // Now get the key name
 
   keyid = KeyID & 0xFF;
-  if (KeyTableLookupVKeyName(keyid, &keytable))
+  bool VKeyFound = KeyTableLookupVKeyName(keyid, &keytable);
+  if (VKeyFound)
     keyname.append(keytable.keyname);
   else
     keyname += StringUtils::Format("%i", keyid);
-  keyname += StringUtils::Format(" (0x%02x)", KeyID);
+  
+  // in case this might be an universalremote keyid
+  // we also print the possile corresponding obc code
+  // so users can easily find it in their universalremote
+  // map xml
+  if (VKeyFound || keyid > 255)
+    keyname += StringUtils::Format(" (0x%02x)", KeyID);
+  else// obc keys are 255 -rawid
+    keyname += StringUtils::Format(" (0x%02x, obc%i)", KeyID, 255 - KeyID);
 
   return keyname;
 }


### PR DESCRIPTION
This finally brings back remote control support on osx which was lost during joystick refactor.

@garbear fyi

This needs to go into 17 - there are a lot of macmini users relying on using the small silver apple remote for example (or other ir remotes) which would not work without this.

I verified that those key ids don't conflict with normal keyboard codes (which are vkeys and have a much higher value).

Any concerns?
