### PR TITLE
[EPG] EPG grid window performance improvements

### DIFF
--- a/Kodi.xcodeproj/project.pbxproj
+++ b/Kodi.xcodeproj/project.pbxproj
@@ -146,6 +146,8 @@
 		2AC7EB5D1C2330BC00BDAA95 /* GUIWindowPVRTimersBase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2AC7EB581C21F6BA00BDAA95 /* GUIWindowPVRTimersBase.cpp */; };
 		2AC7EB601C34893700BDAA95 /* PVRRecordingsPath.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2AC7EB5F1C34893700BDAA95 /* PVRRecordingsPath.cpp */; };
 		2AC7EB611C34893700BDAA95 /* PVRRecordingsPath.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2AC7EB5F1C34893700BDAA95 /* PVRRecordingsPath.cpp */; };
+		2AFBB94C1CC608A200BAB340 /* GUIEPGGridContainerModel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2AFBB94B1CC608A200BAB340 /* GUIEPGGridContainerModel.cpp */; };
+		2AFBB94D1CC608A200BAB340 /* GUIEPGGridContainerModel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2AFBB94B1CC608A200BAB340 /* GUIEPGGridContainerModel.cpp */; };
 		2F4564D51970129A00396109 /* GUIFontCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2F4564D31970129A00396109 /* GUIFontCache.cpp */; };
 		2F4564D61970129A00396109 /* GUIFontCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2F4564D31970129A00396109 /* GUIFontCache.cpp */; };
 		36A9443D15821E2800727135 /* DatabaseUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 36A9443B15821E2800727135 /* DatabaseUtils.cpp */; };
@@ -2585,6 +2587,8 @@
 		2AC7EB591C21F6BA00BDAA95 /* GUIWindowPVRTimersBase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GUIWindowPVRTimersBase.h; sourceTree = "<group>"; };
 		2AC7EB5E1C34892100BDAA95 /* PVRRecordingsPath.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PVRRecordingsPath.h; sourceTree = "<group>"; };
 		2AC7EB5F1C34893700BDAA95 /* PVRRecordingsPath.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PVRRecordingsPath.cpp; sourceTree = "<group>"; };
+		2AFBB94A1CC6088000BAB340 /* GUIEPGGridContainerModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GUIEPGGridContainerModel.h; sourceTree = "<group>"; };
+		2AFBB94B1CC608A200BAB340 /* GUIEPGGridContainerModel.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GUIEPGGridContainerModel.cpp; sourceTree = "<group>"; };
 		2F4564D31970129A00396109 /* GUIFontCache.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GUIFontCache.cpp; sourceTree = "<group>"; };
 		2F4564D41970129A00396109 /* GUIFontCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GUIFontCache.h; sourceTree = "<group>"; };
 		36A9443B15821E2800727135 /* DatabaseUtils.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DatabaseUtils.cpp; sourceTree = "<group>"; };
@@ -7057,6 +7061,8 @@
 				C84828F1156CFD5E005A996F /* EpgSearchFilter.h */,
 				C84828F2156CFD5E005A996F /* GUIEPGGridContainer.cpp */,
 				C84828F3156CFD5E005A996F /* GUIEPGGridContainer.h */,
+				2AFBB94B1CC608A200BAB340 /* GUIEPGGridContainerModel.cpp */,
+				2AFBB94A1CC6088000BAB340 /* GUIEPGGridContainerModel.h */,
 			);
 			path = epg;
 			sourceTree = "<group>";
@@ -9684,6 +9690,7 @@
 				E38E1FEC0D25F9FD00618676 /* RenderManager.cpp in Sources */,
 				E38E1FF00D25F9FD00618676 /* VideoFilterShader.cpp in Sources */,
 				E38E1FF10D25F9FD00618676 /* YUV2RGBShader.cpp in Sources */,
+				2AFBB94C1CC608A200BAB340 /* GUIEPGGridContainerModel.cpp in Sources */,
 				E38E1FF70D25F9FD00618676 /* CueDocument.cpp in Sources */,
 				E38E1FF80D25F9FD00618676 /* Database.cpp in Sources */,
 				68AE5C0B1C92437900C4D527 /* GUIControllerWindow.cpp in Sources */,
@@ -11174,6 +11181,7 @@
 				E4991318174E5DAD00741B6D /* GUITextureD3D.cpp in Sources */,
 				E4991319174E5DAD00741B6D /* GUITextureGL.cpp in Sources */,
 				E499131A174E5DAD00741B6D /* GUITextureGLES.cpp in Sources */,
+				2AFBB94D1CC608A200BAB340 /* GUIEPGGridContainerModel.cpp in Sources */,
 				E499131B174E5DAD00741B6D /* GUIToggleButtonControl.cpp in Sources */,
 				7C4B64A41C86F6D8000E1F74 /* InputStream.cpp in Sources */,
 				E499131C174E5DAD00741B6D /* GUIVideoControl.cpp in Sources */,

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -358,6 +358,7 @@ copy "..\Win32BuildSetup\dependencies\python27.dll" "$(TargetDir)"</Command>
     <ClCompile Include="..\..\xbmc\epg\EpgInfoTag.cpp" />
     <ClCompile Include="..\..\xbmc\epg\EpgSearchFilter.cpp" />
     <ClCompile Include="..\..\xbmc\epg\GUIEPGGridContainer.cpp" />
+    <ClCompile Include="..\..\xbmc\epg\GUIEPGGridContainerModel.cpp" />
     <ClCompile Include="..\..\xbmc\events\AddonEvent.cpp" />
     <ClCompile Include="..\..\xbmc\events\AddonManagementEvent.cpp" />
     <ClCompile Include="..\..\xbmc\events\BaseEvent.cpp" />
@@ -1090,6 +1091,7 @@ copy "..\Win32BuildSetup\dependencies\python27.dll" "$(TargetDir)"</Command>
     <ClInclude Include="..\..\xbmc\DbUrl.h" />
     <ClInclude Include="..\..\xbmc\dialogs\GUIDialogMediaFilter.h" />
     <ClInclude Include="..\..\xbmc\dialogs\GUIDialogSimpleMenu.h" />
+    <ClInclude Include="..\..\xbmc\epg\GUIEPGGridContainerModel.h" />
     <ClInclude Include="..\..\xbmc\events\AddonEvent.h" />
     <ClInclude Include="..\..\xbmc\events\AddonManagementEvent.h" />
     <ClInclude Include="..\..\xbmc\events\BaseEvent.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -3459,6 +3459,9 @@
     <ClCompile Include="..\..\xbmc\addons\PVRClient.cpp">
       <Filter>addons</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\epg\GUIEPGGridContainerModel.cpp">
+      <Filter>epg</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\xbmc\win32\pch.h">
@@ -6716,6 +6719,9 @@
     <ClInclude Include="..\..\xbmc\ServiceManager.h" />
     <ClInclude Include="..\..\xbmc\addons\PVRClient.h">
       <Filter>addons</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\epg\GUIEPGGridContainerModel.h">
+      <Filter>epg</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/xbmc/epg/CMakeLists.txt
+++ b/xbmc/epg/CMakeLists.txt
@@ -3,14 +3,16 @@ set(SOURCES EpgContainer.cpp
             EpgDatabase.cpp
             EpgInfoTag.cpp
             EpgSearchFilter.cpp
-            GUIEPGGridContainer.cpp)
+            GUIEPGGridContainer.cpp
+            GUIEPGGridContainerModel.cpp)
 
 set(HEADERS Epg.h
             EpgContainer.h
             EpgDatabase.h
             EpgInfoTag.h
             EpgSearchFilter.h
-            GUIEPGGridContainer.h)
+            GUIEPGGridContainer.h
+            GUIEPGGridContainerModel.h)
 
 core_add_library(epg)
 add_dependencies(epg libcpluff)

--- a/xbmc/epg/GUIEPGGridContainer.cpp
+++ b/xbmc/epg/GUIEPGGridContainer.cpp
@@ -98,7 +98,6 @@ CGUIEPGGridContainer::CGUIEPGGridContainer(int parentID, int controlID, float po
   m_cacheChannelItems     = preloadItems;
   m_cacheRulerItems       = preloadItems;
   m_cacheProgrammeItems   = preloadItems;
-  m_wasReset              = false;
 }
 
 CGUIEPGGridContainer::CGUIEPGGridContainer(const CGUIEPGGridContainer &other)
@@ -120,7 +119,6 @@ CGUIEPGGridContainer::CGUIEPGGridContainer(const CGUIEPGGridContainer &other)
   m_programmeLayout         = other.m_programmeLayout;
   m_focusedProgrammeLayout  = other.m_focusedProgrammeLayout;
   m_rulerLayout             = other.m_rulerLayout;
-  m_wasReset                = other.m_wasReset;
   m_rulerUnit               = other.m_rulerUnit;
   m_channels                = other.m_channels;
   m_channelsPerPage         = other.m_channelsPerPage;
@@ -1661,12 +1659,6 @@ void CGUIEPGGridContainer::SetFocus(bool focus)
   CGUIControl::SetFocus(focus);
 }
 
-void CGUIEPGGridContainer::DoRender()
-{
-  CGUIControl::DoRender();
-  m_wasReset = false;
-}
-
 void CGUIEPGGridContainer::ScrollToChannelOffset(int offset)
 {
   CSingleLock lock(m_critSection);
@@ -1831,7 +1823,6 @@ void CGUIEPGGridContainer::Reset()
 {
   ClearGridIndex();
 
-  m_wasReset = true;
   m_channelItems.clear();
   m_programmeItems.clear();
   m_rulerItems.clear();

--- a/xbmc/epg/GUIEPGGridContainer.cpp
+++ b/xbmc/epg/GUIEPGGridContainer.cpp
@@ -1415,7 +1415,7 @@ int CGUIEPGGridContainer::GetRealBlock(const CGUIListItemPtr &item, int channel)
   int channelIndex = channel + m_channelOffset;
   int block = 0;
 
-  while (m_gridModel->GetGridItem(channelIndex, block) != item && block < m_gridModel->GetBlockCount())
+  while (block < m_gridModel->GetBlockCount() && m_gridModel->GetGridItem(channelIndex, block) != item)
     block++;
 
   return block;
@@ -1432,6 +1432,9 @@ GridItemsPtr *CGUIEPGGridContainer::GetNextItem(int channel)
 
   while (i < m_blocksPerPage && m_gridModel->GetGridItem(channelIndex, i + m_blockOffset) == m_gridModel->GetGridItem(channelIndex, blockIndex))
     i++;
+
+  if (i + m_blockOffset >= m_gridModel->GetBlockCount())
+    i = m_gridModel->GetBlockCount() - m_blockOffset - 1;
 
   return m_gridModel->GetGridItemPtr(channelIndex, i + m_blockOffset);
 }

--- a/xbmc/epg/GUIEPGGridContainer.cpp
+++ b/xbmc/epg/GUIEPGGridContainer.cpp
@@ -1272,16 +1272,7 @@ int CGUIEPGGridContainer::GetSelectedItem() const
       m_blockCursor + m_blockOffset >= m_gridModel->GetBlockCount())
     return -1;
 
-  CGUIListItemPtr currentItem = m_gridModel->GetGridItem(m_channelCursor + m_channelOffset, m_blockCursor + m_blockOffset);
-  if (!currentItem)
-    return -1;
-
-  for (int i = 0; i < m_gridModel->ProgrammeItemsSize(); i++)
-  {
-    if (currentItem == m_gridModel->GetProgrammeItem(i))
-      return i;
-  }
-  return -1;
+  return m_gridModel->GetGridItemIndex(m_channelCursor + m_channelOffset, m_blockCursor + m_blockOffset);
 }
 
 CFileItemPtr CGUIEPGGridContainer::GetSelectedChannelItem() const

--- a/xbmc/epg/GUIEPGGridContainer.cpp
+++ b/xbmc/epg/GUIEPGGridContainer.cpp
@@ -70,8 +70,6 @@ CGUIEPGGridContainer::CGUIEPGGridContainer(int parentID, int controlID, float po
   m_channelsPerPage       = 0;
   m_scrollTime            = scrollTime ? scrollTime : 1;
   m_item                  = NULL;
-  m_lastItem              = NULL;
-  m_lastChannel           = NULL;
   m_programmeLayout       = NULL;
   m_focusedProgrammeLayout= NULL;
   m_channelLayout         = NULL;
@@ -136,7 +134,6 @@ CGUIEPGGridContainer::CGUIEPGGridContainer(const CGUIEPGGridContainer &other)
   m_gridHeight              = other.m_gridHeight;
   m_blockSize               = other.m_blockSize;
   m_analogScrollCount       = other.m_analogScrollCount;
-  m_item                    = other.m_item;
   m_lastItem                = other.m_lastItem;
   m_lastChannel             = other.m_lastChannel;
   m_scrollTime              = other.m_scrollTime;
@@ -146,9 +143,13 @@ CGUIEPGGridContainer::CGUIEPGGridContainer(const CGUIEPGGridContainer &other)
   m_channelScrollLastTime   = other.m_channelScrollLastTime;
   m_channelScrollSpeed      = other.m_channelScrollSpeed;
   m_channelScrollOffset     = other.m_channelScrollOffset;
-  m_gridModel               = other.m_gridModel;
-  m_updatedGridModel        = other.m_updatedGridModel;
-  m_outdatedGridModel       = other.m_outdatedGridModel;
+
+  m_gridModel.reset(new CGUIEPGGridContainerModel(*other.m_gridModel));
+  m_updatedGridModel.reset(new CGUIEPGGridContainerModel(*other.m_updatedGridModel));
+  m_outdatedGridModel.reset(new CGUIEPGGridContainerModel(*other.m_outdatedGridModel));
+
+  // pointer to grid model internal data.
+  m_item = GetItem(m_channelCursor);
 }
 
 void CGUIEPGGridContainer::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
@@ -203,6 +204,7 @@ void CGUIEPGGridContainer::ProcessChannels(unsigned int currentTime, CDirtyRegio
   pos += drawOffset;
   end += cacheAfterChannel * m_channelLayout->Size(VERTICAL);
 
+  CFileItemPtr item;
   int current = chanOffset;// - cacheBeforeChannel;
   while (pos < end && m_gridModel->HasChannelItems())
   {
@@ -212,9 +214,9 @@ void CGUIEPGGridContainer::ProcessChannels(unsigned int currentTime, CDirtyRegio
     bool focused = (current == m_channelOffset + m_channelCursor);
     if (itemNo >= 0)
     {
-      CGUIListItemPtr item(m_gridModel->GetChannelItem(itemNo));
+      item = m_gridModel->GetChannelItem(itemNo);
       // process our item
-      ProcessItem(originChannel.x, pos, item.get(), m_lastItem, focused, m_channelLayout, m_focusedChannelLayout, currentTime, dirtyregions);
+      ProcessItem(originChannel.x, pos, item, m_lastItem, focused, m_channelLayout, m_focusedChannelLayout, currentTime, dirtyregions);
     }
     // increment our position
     pos += focused ? m_focusedChannelLayout->Size(VERTICAL) : m_channelLayout->Size(VERTICAL);
@@ -288,10 +290,10 @@ void CGUIEPGGridContainer::ProcessRuler(unsigned int currentTime, CDirtyRegionLi
     return;
 
   int rulerOffset = MathUtils::round_int(m_programmeScrollOffset / m_blockSize);
-  CGUIListItemPtr item(m_gridModel->GetRulerItem(0));
+  CFileItemPtr item(m_gridModel->GetRulerItem(0));
   item->SetLabel(m_gridModel->GetRulerItem(rulerOffset / m_rulerUnit + 1)->GetLabel2());
-  CGUIListItem* lastitem = NULL; // dummy pointer needed to be passed as reference to ProcessItem() method
-  ProcessItem(m_posX, m_posY, item.get(), lastitem, false, m_rulerLayout, m_rulerLayout, currentTime, dirtyregions, m_channelWidth);
+  CFileItemPtr lastitem; // dummy pointer needed to be passed as reference to ProcessItem() method
+  ProcessItem(m_posX, m_posY, item, lastitem, false, m_rulerLayout, m_rulerLayout, currentTime, dirtyregions, m_channelWidth);
 
   // render ruler items
   int cacheBeforeRuler, cacheAfterRuler;
@@ -323,7 +325,7 @@ void CGUIEPGGridContainer::ProcessRuler(unsigned int currentTime, CDirtyRegionLi
   while (pos < end && (rulerOffset / m_rulerUnit + 1) < m_gridModel->RulerItemsSize())
   {
     item = m_gridModel->GetRulerItem(rulerOffset / m_rulerUnit + 1);
-    ProcessItem(pos, originRuler.y, item.get(), lastitem, false, m_rulerLayout, m_rulerLayout, currentTime, dirtyregions, m_rulerWidth);
+    ProcessItem(pos, originRuler.y, item, lastitem, false, m_rulerLayout, m_rulerLayout, currentTime, dirtyregions, m_rulerWidth);
     pos += m_rulerWidth;
     rulerOffset += m_rulerUnit;
   }
@@ -402,7 +404,7 @@ void CGUIEPGGridContainer::ProcessProgrammeGrid(unsigned int currentTime, CDirty
 
   int channel = chanOffset;
 
-  CGUIListItemPtr item;
+  CFileItemPtr item;
   while (posB < endB && m_gridModel->HasChannelItems())
   {
     if (channel >= m_gridModel->ChannelItemsSize())
@@ -452,7 +454,7 @@ void CGUIEPGGridContainer::ProcessProgrammeGrid(unsigned int currentTime, CDirty
         m_gridModel->SetGridItemWidth(channel, block, m_gridModel->GetGridItemOriginWidth(channel, block) - truncateSize);
       }
 
-      ProcessItem(posA2, posB, item.get(), m_lastChannel, focused, m_programmeLayout, m_focusedProgrammeLayout, currentTime, dirtyregions, m_gridModel->GetGridItemWidth(channel, block));
+      ProcessItem(posA2, posB, item, m_lastChannel, focused, m_programmeLayout, m_focusedProgrammeLayout, currentTime, dirtyregions, m_gridModel->GetGridItemWidth(channel, block));
 
       // increment our X position
       posA2 += m_gridModel->GetGridItemWidth(channel, block); // assumes focused & unfocused layouts have equal length
@@ -594,7 +596,7 @@ void CGUIEPGGridContainer::RenderProgressIndicator()
   }
 }
 
-void CGUIEPGGridContainer::ProcessItem(float posX, float posY, CGUIListItem* item, CGUIListItem *&lastitem,
+void CGUIEPGGridContainer::ProcessItem(float posX, float posY, const CFileItemPtr &item, CFileItemPtr &lastitem,
   bool focused, CGUIListItemLayout* normallayout, CGUIListItemLayout* focusedlayout,
   unsigned int currentTime, CDirtyRegionList &dirtyregions, float resize /* = -1.0f */)
 {
@@ -630,7 +632,7 @@ void CGUIEPGGridContainer::ProcessItem(float posX, float posY, CGUIListItem* ite
       item->GetFocusedLayout()->SetFocusedItem(subItem ? subItem : 1);
     }
 
-    item->GetFocusedLayout()->Process(item, m_parentID, currentTime, dirtyregions);
+    item->GetFocusedLayout()->Process(item.get(), m_parentID, currentTime, dirtyregions);
     lastitem = item;
   }
   else
@@ -650,9 +652,9 @@ void CGUIEPGGridContainer::ProcessItem(float posX, float posY, CGUIListItem* ite
       item->GetFocusedLayout()->SetFocusedItem(0);
 
     if (item->GetFocusedLayout() && item->GetFocusedLayout()->IsAnimating(ANIM_TYPE_UNFOCUS))
-      item->GetFocusedLayout()->Process(item, m_parentID, currentTime, dirtyregions);
+      item->GetFocusedLayout()->Process(item.get(), m_parentID, currentTime, dirtyregions);
     else
-      item->GetLayout()->Process(item, m_parentID, currentTime, dirtyregions);
+      item->GetLayout()->Process(item.get(), m_parentID, currentTime, dirtyregions);
   }
   g_graphicsContext.RestoreOrigin();
 }
@@ -1658,9 +1660,9 @@ void CGUIEPGGridContainer::SetTimelineItems(const std::unique_ptr<CFileItemList>
     fBlockSize = m_blockSize;
   }
 
-  std::shared_ptr<CGUIEPGGridContainerModel> oldOutdatedGridModel;
-  std::shared_ptr<CGUIEPGGridContainerModel> oldUpdatedGridModel;
-  std::shared_ptr<CGUIEPGGridContainerModel> newUpdatedGridModel(new CGUIEPGGridContainerModel);
+  std::unique_ptr<CGUIEPGGridContainerModel> oldOutdatedGridModel;
+  std::unique_ptr<CGUIEPGGridContainerModel> oldUpdatedGridModel;
+  std::unique_ptr<CGUIEPGGridContainerModel> newUpdatedGridModel(new CGUIEPGGridContainerModel);
   // can be very expensive. never call with lock acquired.
   newUpdatedGridModel->Refresh(items, gridStart, gridEnd, iRulerUnit, iBlocksPerPage, fBlockSize);
 

--- a/xbmc/epg/GUIEPGGridContainer.h
+++ b/xbmc/epg/GUIEPGGridContainer.h
@@ -27,16 +27,8 @@
 
 namespace EPG
 {
-  #define MAXBLOCKS   (33 * 24 * 60 / 5) //! 33 days of 5 minute blocks (31 days for upcoming data + 1 day for past data + 1 day for fillers)
-
-  struct GridItemsPtr
-  {
-    CFileItemPtr item;
-    float originWidth;
-    float originHeight;
-    float width;
-    float height;
-  };
+  class GridItemsPtr;
+  class CGUIEPGGridContainerModel;
 
   class CGUIEPGGridContainer : public IGUIContainer
   {
@@ -46,7 +38,6 @@ namespace EPG
                          int rulerUnit, const CTextureInfo& progressIndicatorTexture);
     CGUIEPGGridContainer(const CGUIEPGGridContainer &other);
 
-    virtual ~CGUIEPGGridContainer(void);
     virtual CGUIEPGGridContainer *Clone() const { return new CGUIEPGGridContainer(*this); }
 
     virtual bool OnAction(const CAction &action);
@@ -62,7 +53,6 @@ namespace EPG
     virtual void SetFocus(bool focus);
 
     virtual std::string GetDescription() const;
-    const int GetNumChannels()   { return m_channels; };
     virtual int GetSelectedItem() const;
     CFileItemPtr GetSelectedChannelItem() const;
     PVR::CPVRChannelPtr GetSelectedChannel();
@@ -101,8 +91,6 @@ namespace EPG
     void ProgrammesScroll(int amount);
     void ValidateOffset();
     void UpdateLayout();
-    void Reset();
-    void ClearGridIndex(void);
 
     GridItemsPtr *GetItem(int channel);
     GridItemsPtr *GetNextItem(int channel);
@@ -136,15 +124,6 @@ namespace EPG
 
     CPoint m_renderOffset; ///< \brief render offset of the first item in the list \sa SetRenderOffset
 
-    struct ItemsPtr
-    {
-      long start;
-      long stop;
-    };
-    std::vector<ItemsPtr> m_epgItemsPtr;
-    std::vector<CFileItemPtr> m_channelItems;
-    std::vector<CFileItemPtr> m_rulerItems;
-    std::vector<CFileItemPtr> m_programmeItems;
     std::vector<CGUIListItemLayout> m_channelLayouts;
     std::vector<CGUIListItemLayout> m_focusedChannelLayouts;
     std::vector<CGUIListItemLayout> m_focusedProgrammeLayouts;
@@ -157,11 +136,6 @@ namespace EPG
     CGUIListItemLayout *m_focusedProgrammeLayout;
     CGUIListItemLayout *m_rulerLayout;
 
-    void FreeItemsMemory();
-    void FreeChannelMemory(int keepStart, int keepEnd);
-    void FreeProgrammeMemory(int channel, int keepStart, int keepEnd);
-    void FreeRulerMemory(int keepStart, int keepEnd);
-
     void GetChannelCacheOffsets(int &cacheBefore, int &cacheAfter);
     void GetProgrammeCacheOffsets(int &cacheBefore, int &cacheAfter);
 
@@ -171,12 +145,10 @@ namespace EPG
     EPG::CEpgInfoTagPtr GetSelectedEpgInfoTag() const;
 
     int m_rulerUnit; //! number of blocks that makes up one element of the ruler
-    int m_channels;
     int m_channelsPerPage;
     int m_programmesPerPage;
     int m_channelCursor;
     int m_channelOffset;
-    int m_blocks;
     int m_blocksPerPage;
     int m_blockCursor;
     int m_blockOffset;
@@ -199,12 +171,8 @@ namespace EPG
     float m_blockSize;      //! a block's width in pixels
     float m_analogScrollCount;
 
-    CDateTime m_gridStart;
-    CDateTime m_gridEnd;
-
     CGUITexture m_guiProgressIndicatorTexture;
 
-    std::vector<std::vector<GridItemsPtr> > m_gridIndex;
     GridItemsPtr *m_item;
     CGUIListItem *m_lastItem;
     CGUIListItem *m_lastChannel;
@@ -220,5 +188,6 @@ namespace EPG
     float m_channelScrollOffset;
 
     CCriticalSection m_critSection;
+    std::shared_ptr<CGUIEPGGridContainerModel> m_gridModel;
   };
 }

--- a/xbmc/epg/GUIEPGGridContainer.h
+++ b/xbmc/epg/GUIEPGGridContainer.h
@@ -76,7 +76,7 @@ namespace EPG
     void GoToBegin();
     void GoToEnd();
     void GoToNow();
-    void SetStartEnd(CDateTime start, CDateTime end);
+    void SetTimelineItems(const std::unique_ptr<CFileItemList> &items, const CDateTime &gridStart, const CDateTime &gridEnd);
     void SetChannel(const PVR::CPVRChannelPtr &channel);
     void SetChannel(const std::string &channel);
     void ResetCoordinates();
@@ -140,7 +140,7 @@ namespace EPG
     void GetProgrammeCacheOffsets(int &cacheBefore, int &cacheAfter);
 
   private:
-    void UpdateItems(CFileItemList *items);
+    void UpdateItems();
 
     EPG::CEpgInfoTagPtr GetSelectedEpgInfoTag() const;
 
@@ -189,5 +189,7 @@ namespace EPG
 
     CCriticalSection m_critSection;
     std::shared_ptr<CGUIEPGGridContainerModel> m_gridModel;
+    std::shared_ptr<CGUIEPGGridContainerModel> m_updatedGridModel;
+    std::shared_ptr<CGUIEPGGridContainerModel> m_outdatedGridModel;
   };
 }

--- a/xbmc/epg/GUIEPGGridContainer.h
+++ b/xbmc/epg/GUIEPGGridContainer.h
@@ -109,7 +109,7 @@ namespace EPG
     void GoToBlock(int blockIndex);
     void GoToChannel(int channelIndex);
     void UpdateScrollOffset(unsigned int currentTime);
-    void ProcessItem(float posX, float posY, CGUIListItem *item, CGUIListItem *&lastitem, bool focused, CGUIListItemLayout* normallayout, CGUIListItemLayout* focusedlayout, unsigned int currentTime, CDirtyRegionList &dirtyregions, float resize = -1.0f);
+    void ProcessItem(float posX, float posY, const CFileItemPtr &item, CFileItemPtr &lastitem, bool focused, CGUIListItemLayout* normallayout, CGUIListItemLayout* focusedlayout, unsigned int currentTime, CDirtyRegionList &dirtyregions, float resize = -1.0f);
     void RenderItem(float posX, float posY, CGUIListItem *item, bool focused);
     void GetCurrentLayouts();
 
@@ -174,8 +174,8 @@ namespace EPG
     CGUITexture m_guiProgressIndicatorTexture;
 
     GridItemsPtr *m_item;
-    CGUIListItem *m_lastItem;
-    CGUIListItem *m_lastChannel;
+    CFileItemPtr m_lastItem;
+    CFileItemPtr m_lastChannel;
 
     int m_scrollTime;
 
@@ -188,8 +188,8 @@ namespace EPG
     float m_channelScrollOffset;
 
     CCriticalSection m_critSection;
-    std::shared_ptr<CGUIEPGGridContainerModel> m_gridModel;
-    std::shared_ptr<CGUIEPGGridContainerModel> m_updatedGridModel;
-    std::shared_ptr<CGUIEPGGridContainerModel> m_outdatedGridModel;
+    std::unique_ptr<CGUIEPGGridContainerModel> m_gridModel;
+    std::unique_ptr<CGUIEPGGridContainerModel> m_updatedGridModel;
+    std::unique_ptr<CGUIEPGGridContainerModel> m_outdatedGridModel;
   };
 }

--- a/xbmc/epg/GUIEPGGridContainer.h
+++ b/xbmc/epg/GUIEPGGridContainer.h
@@ -69,7 +69,6 @@ namespace EPG
     virtual EVENT_RESULT OnMouseEvent(const CPoint &point, const CMouseEvent &event);
 
     virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
-    virtual void DoRender();
     virtual void Render();
     void LoadLayout(TiXmlElement *layout);
     void LoadContent(TiXmlElement *content);
@@ -157,11 +156,6 @@ namespace EPG
     CGUIListItemLayout *m_programmeLayout;
     CGUIListItemLayout *m_focusedProgrammeLayout;
     CGUIListItemLayout *m_rulerLayout;
-
-    bool m_wasReset;  // true if we've received a Reset message until we've rendered once.  Allows
-                      // us to make sure we don't tell the infomanager that we've been moving when
-                      // the "movement" was simply due to the list being repopulated (thus cursor position
-                      // changing around)
 
     void FreeItemsMemory();
     void FreeChannelMemory(int keepStart, int keepEnd);

--- a/xbmc/epg/GUIEPGGridContainer.h
+++ b/xbmc/epg/GUIEPGGridContainer.h
@@ -140,6 +140,10 @@ namespace EPG
     void GetProgrammeCacheOffsets(int &cacheBefore, int &cacheAfter);
 
   private:
+    void HandleChannels(bool bRender, unsigned int currentTime, CDirtyRegionList &dirtyregions);
+    void HandleRuler(bool bRender, unsigned int currentTime, CDirtyRegionList &dirtyregions);
+    void HandleProgrammeGrid(bool bRender, unsigned int currentTime, CDirtyRegionList &dirtyregions);
+
     void UpdateItems();
 
     EPG::CEpgInfoTagPtr GetSelectedEpgInfoTag() const;

--- a/xbmc/epg/GUIEPGGridContainerModel.cpp
+++ b/xbmc/epg/GUIEPGGridContainerModel.cpp
@@ -1,0 +1,387 @@
+/*
+ *      Copyright (C) 2012-2016 Team Kodi
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "FileItem.h"
+#include "epg/EpgInfoTag.h"
+#include "utils/Variant.h"
+#include "pvr/channels/PVRChannel.h"
+
+#include "GUIEPGGridContainerModel.h"
+
+class CGUIListItem;
+typedef std::shared_ptr<CGUIListItem> CGUIListItemPtr;
+
+using namespace EPG;
+using namespace PVR;
+
+void CGUIEPGGridContainerModel::SetInvalid()
+{
+  for (const auto &programme : m_programmeItems)
+    programme->SetInvalid();
+  for (const auto &channel : m_channelItems)
+    channel->SetInvalid();
+  for (const auto &ruler : m_rulerItems)
+    ruler->SetInvalid();
+}
+
+void CGUIEPGGridContainerModel::Reset()
+{
+  for (auto &channel : m_gridIndex)
+  {
+    for (const auto &block : channel)
+    {
+      if (block.item)
+        block.item->ClearProperties();
+    }
+    channel.clear();
+  }
+  m_gridIndex.clear();
+
+  m_channelItems.clear();
+  m_programmeItems.clear();
+  m_rulerItems.clear();
+  m_epgItemsPtr.clear();
+}
+
+void CGUIEPGGridContainerModel::Refresh(CFileItemList *items, int iRulerUnit, int iBlocksPerPage, float fBlockSize)
+{
+  Reset();
+
+  ////////////////////////////////////////////////////////////////////////
+  // Create programme & channel items
+  m_programmeItems.reserve(items->Size());
+  CFileItemPtr fileItem;
+  int iLastChannelID = -1;
+  ItemsPtr itemsPointer;
+  itemsPointer.start = 0;
+  CPVRChannelPtr channel;
+  int j = 0;
+  for (int i = 0; i < items->Size(); ++i)
+  {
+    fileItem = items->Get(i);
+    if (!fileItem->HasEPGInfoTag() || !fileItem->GetEPGInfoTag()->HasPVRChannel())
+      continue;
+
+    m_programmeItems.emplace_back(fileItem);
+
+    channel = fileItem->GetEPGInfoTag()->ChannelTag();
+    int iCurrentChannelID = channel->ChannelID();
+    if (iCurrentChannelID != iLastChannelID)
+    {
+      if (j > 0)
+      {
+        itemsPointer.stop = j - 1;
+        m_epgItemsPtr.emplace_back(itemsPointer);
+        itemsPointer.start = j;
+      }
+      iLastChannelID = iCurrentChannelID;
+      m_channelItems.emplace_back(CFileItemPtr(new CFileItem(channel)));
+    }
+    ++j;
+  }
+  if (!m_programmeItems.empty())
+  {
+    itemsPointer.stop = m_programmeItems.size() - 1;
+    m_epgItemsPtr.emplace_back(itemsPointer);
+  }
+
+  /* check for invalid start and end time */
+  if (m_gridStart >= m_gridEnd)
+  {
+    // default to start "now minus 30 minutes" and end "start plus one page".
+    m_gridStart = CDateTime::GetCurrentDateTime().GetAsUTCDateTime() - CDateTimeSpan(0, 0, 30, 0);
+    m_gridEnd = m_gridStart + CDateTimeSpan(0, 0, iBlocksPerPage * MINSPERBLOCK, 0);
+  }
+
+  ////////////////////////////////////////////////////////////////////////
+  // Create ruler items
+  CDateTime ruler;
+  ruler.SetFromUTCDateTime(m_gridStart);
+  CDateTime rulerEnd;
+  rulerEnd.SetFromUTCDateTime(m_gridEnd);
+  CFileItemPtr rulerItem(new CFileItem(ruler.GetAsLocalizedDate(true)));
+  rulerItem->SetProperty("DateLabel", true);
+  m_rulerItems.emplace_back(rulerItem);
+
+  const CDateTimeSpan unit(0, 0, iRulerUnit * MINSPERBLOCK, 0);
+  for (; ruler < rulerEnd; ruler += unit)
+  {
+    rulerItem.reset(new CFileItem(ruler.GetAsLocalizedTime("", false)));
+    rulerItem->SetLabel2(ruler.GetAsLocalizedDate(true));
+    m_rulerItems.emplace_back(rulerItem);
+  }
+
+  FreeItemsMemory();
+
+  ////////////////////////////////////////////////////////////////////////
+  // Create epg grid
+  const CDateTimeSpan blockDuration(0, 0, MINSPERBLOCK, 0);
+  const CDateTimeSpan gridDuration(m_gridEnd - m_gridStart);
+  m_blocks = (gridDuration.GetDays() * 24 * 60 + gridDuration.GetHours() * 60 + gridDuration.GetMinutes()) / MINSPERBLOCK;
+  if (m_blocks >= MAXBLOCKS)
+    m_blocks = MAXBLOCKS;
+
+  m_gridIndex.reserve(m_channelItems.size());
+  const std::vector<GridItemsPtr> blocks(m_blocks);
+
+  for (size_t channel = 0; channel < m_channelItems.size(); ++channel)
+  {
+    m_gridIndex.emplace_back(blocks);
+
+    CDateTime gridCursor(m_gridStart); //reset cursor for new channel
+    unsigned long progIdx = m_epgItemsPtr[channel].start;
+    unsigned long lastIdx = m_epgItemsPtr[channel].stop;
+    int iEpgId            = m_programmeItems[progIdx]->GetEPGInfoTag()->EpgID();
+    int itemSize          = 1; // size of the programme in blocks
+    int savedBlock        = 0;
+    CFileItemPtr item;
+    CEpgInfoTagPtr tag;
+
+    for (int block = 0; block < m_blocks; ++block)
+    {
+      while (progIdx <= lastIdx)
+      {
+        item = m_programmeItems[progIdx];
+        tag = item->GetEPGInfoTag();
+
+        if (tag->EpgID() != iEpgId || gridCursor < tag->StartAsUTC() || m_gridEnd <= tag->StartAsUTC())
+          break;
+
+        if (gridCursor < tag->EndAsUTC())
+        {
+          m_gridIndex[channel][block].item = item;
+          break;
+        }
+
+        progIdx++;
+      }
+
+      gridCursor += blockDuration;
+
+      if (block == 0)
+        continue;
+
+      const CFileItemPtr prevItem(m_gridIndex[channel][block - 1].item);
+      const CFileItemPtr currItem(m_gridIndex[channel][block].item);
+
+      if (block == m_blocks - 1 || prevItem != currItem)
+      {
+        // special handling for last block.
+        int blockDelta = -1;
+        int sizeDelta = 0;
+        if (block == m_blocks - 1 && prevItem == currItem)
+        {
+          itemSize++;
+          blockDelta = 0;
+          sizeDelta = 1;
+        }
+
+        if (prevItem)
+        {
+          m_gridIndex[channel][savedBlock].item->SetProperty("GenreType", prevItem->GetEPGInfoTag()->GenreType());
+        }
+        else
+        {
+          CEpgInfoTagPtr gapTag(CEpgInfoTag::CreateDefaultTag());
+          gapTag->SetPVRChannel(m_channelItems[channel]->GetPVRChannelInfoTag());
+          CFileItemPtr gapItem(new CFileItem(gapTag));
+          for (int i = block + blockDelta; i >= block - itemSize + sizeDelta; --i)
+          {
+            m_gridIndex[channel][i].item = gapItem;
+          }
+        }
+
+        float fItemWidth = itemSize * fBlockSize;
+        m_gridIndex[channel][savedBlock].originWidth = fItemWidth;
+        m_gridIndex[channel][savedBlock].width = fItemWidth;
+
+        itemSize = 1;
+        savedBlock = block;
+
+        // special handling for last block.
+        if (block == m_blocks - 1 && prevItem != currItem)
+        {
+          if (currItem)
+          {
+            m_gridIndex[channel][savedBlock].item->SetProperty("GenreType", currItem->GetEPGInfoTag()->GenreType());
+          }
+          else
+          {
+            CEpgInfoTagPtr gapTag(CEpgInfoTag::CreateDefaultTag());
+            gapTag->SetPVRChannel(m_channelItems[channel]->GetPVRChannelInfoTag());
+            CFileItemPtr gapItem(new CFileItem(gapTag));
+            m_gridIndex[channel][block].item = gapItem;
+          }
+
+          m_gridIndex[channel][savedBlock].originWidth = fBlockSize; // size always 1 block here
+          m_gridIndex[channel][savedBlock].width = fBlockSize;
+        }
+      }
+      else
+      {
+        itemSize++;
+      }
+    }
+  }
+}
+
+void CGUIEPGGridContainerModel::FindChannelAndBlockIndex(int channelUid, unsigned int broadcastUid, int eventOffset, int &newChannelIndex, int &newBlockIndex) const
+{
+  const CDateTimeSpan blockDuration(0, 0, MINSPERBLOCK, 0);
+
+  bool bFoundPrevTag     = false;
+  bool bFoundPrevChannel = false;
+
+  for (size_t channel = 0; channel < m_channelItems.size(); ++channel)
+  {
+    CDateTime gridCursor(m_gridStart); //reset cursor for new channel
+    unsigned long progIdx = m_epgItemsPtr[channel].start;
+    unsigned long lastIdx = m_epgItemsPtr[channel].stop;
+    int iEpgId            = m_programmeItems[progIdx]->GetEPGInfoTag()->EpgID();
+    CEpgInfoTagPtr tag;
+
+    for (int block = 0; block < m_blocks; ++block)
+    {
+      while (progIdx <= lastIdx)
+      {
+        tag = m_programmeItems[progIdx]->GetEPGInfoTag();
+
+        if (tag->EpgID() != iEpgId || gridCursor < tag->StartAsUTC() || m_gridEnd <= tag->StartAsUTC())
+          break; // next block
+
+        if (gridCursor < tag->EndAsUTC())
+        {
+          if (!bFoundPrevTag && broadcastUid > 0 && tag->UniqueBroadcastID() == broadcastUid)
+          {
+            newChannelIndex = channel;
+            newBlockIndex   = block + eventOffset;
+            if (bFoundPrevChannel)
+              return; // both found; done.
+
+            bFoundPrevTag = true;
+          }
+          if (!bFoundPrevTag && !bFoundPrevChannel && channelUid > -1 && tag->ChannelTag()->UniqueID() == channelUid)
+          {
+            newChannelIndex = channel;
+            if (bFoundPrevTag)
+              return; // both found; done.
+
+            bFoundPrevChannel = true;
+          }
+          break; // next block
+        }
+        progIdx++;
+      }
+      gridCursor += blockDuration;
+    }
+  }
+}
+
+void CGUIEPGGridContainerModel::FreeChannelMemory(int keepStart, int keepEnd)
+{
+  if (keepStart < keepEnd)
+  {
+    // remove before keepStart and after keepEnd
+    for (int i = 0; i < keepStart && i < ChannelItemsSize(); ++i)
+      m_channelItems[i]->FreeMemory();
+    for (int i = keepEnd + 1; i < ChannelItemsSize(); ++i)
+      m_channelItems[i]->FreeMemory();
+  }
+  else
+  {
+    // wrapping
+    for (int i = keepEnd + 1; i < keepStart && i < ChannelItemsSize(); ++i)
+      m_channelItems[i]->FreeMemory();
+  }
+}
+
+void CGUIEPGGridContainerModel::FreeProgrammeMemory(int channel, int keepStart, int keepEnd)
+{
+  if (keepStart < keepEnd)
+  {
+    // remove before keepStart and after keepEnd
+    if (keepStart > 0 && keepStart < m_blocks)
+    {
+      // if item exist and block is not part of visible item
+      CGUIListItemPtr last(m_gridIndex[channel][keepStart].item);
+      for (int i = keepStart - 1; i > 0; --i)
+      {
+        if (m_gridIndex[channel][i].item && m_gridIndex[channel][i].item != last)
+        {
+          m_gridIndex[channel][i].item->FreeMemory();
+          // FreeMemory() is smart enough to not cause any problems when called multiple times on same item
+          // but we can make use of condition needed to not call FreeMemory() on item that is partially visible
+          // to avoid calling FreeMemory() multiple times on item that ocupy few blocks in a row
+          last = m_gridIndex[channel][i].item;
+        }
+      }
+    }
+
+    if (keepEnd > 0 && keepEnd < m_blocks)
+    {
+      CGUIListItemPtr last(m_gridIndex[channel][keepEnd].item);
+      for (int i = keepEnd + 1; i < m_blocks; ++i)
+      {
+        // if item exist and block is not part of visible item
+        if (m_gridIndex[channel][i].item && m_gridIndex[channel][i].item != last)
+        {
+          m_gridIndex[channel][i].item->FreeMemory();
+          // FreeMemory() is smart enough to not cause any problems when called multiple times on same item
+          // but we can make use of condition needed to not call FreeMemory() on item that is partially visible
+          // to avoid calling FreeMemory() multiple times on item that ocupy few blocks in a row
+          last = m_gridIndex[channel][i].item;
+        }
+      }
+    }
+  }
+}
+
+void CGUIEPGGridContainerModel::FreeRulerMemory(int keepStart, int keepEnd)
+{
+  if (keepStart < keepEnd)
+  {
+    // remove before keepStart and after keepEnd
+    for (int i = 1; i < keepStart && i < RulerItemsSize(); ++i)
+      m_rulerItems[i]->FreeMemory();
+    for (int i = keepEnd + 1; i < RulerItemsSize(); ++i)
+      m_rulerItems[i]->FreeMemory();
+  }
+  else
+  {
+    // wrapping
+    for (int i = keepEnd + 1; i < keepStart && i < RulerItemsSize(); ++i)
+    {
+      if (i == 0)
+        continue;
+
+      m_rulerItems[i]->FreeMemory();
+    }
+  }
+}
+
+void CGUIEPGGridContainerModel::FreeItemsMemory()
+{
+  for (const auto &programme : m_programmeItems)
+    programme->FreeMemory();
+  for (const auto &channel : m_channelItems)
+    channel->FreeMemory();
+  for (const auto &ruler : m_rulerItems)
+    ruler->FreeMemory();
+}

--- a/xbmc/epg/GUIEPGGridContainerModel.cpp
+++ b/xbmc/epg/GUIEPGGridContainerModel.cpp
@@ -60,7 +60,7 @@ void CGUIEPGGridContainerModel::Reset()
   m_epgItemsPtr.clear();
 }
 
-void CGUIEPGGridContainerModel::Refresh(CFileItemList *items, int iRulerUnit, int iBlocksPerPage, float fBlockSize)
+void CGUIEPGGridContainerModel::Refresh(const std::unique_ptr<CFileItemList> &items, const CDateTime &gridStart, const CDateTime &gridEnd, int iRulerUnit, int iBlocksPerPage, float fBlockSize)
 {
   Reset();
 
@@ -103,11 +103,16 @@ void CGUIEPGGridContainerModel::Refresh(CFileItemList *items, int iRulerUnit, in
   }
 
   /* check for invalid start and end time */
-  if (m_gridStart >= m_gridEnd)
+  if (gridStart >= gridEnd)
   {
     // default to start "now minus 30 minutes" and end "start plus one page".
     m_gridStart = CDateTime::GetCurrentDateTime().GetAsUTCDateTime() - CDateTimeSpan(0, 0, 30, 0);
     m_gridEnd = m_gridStart + CDateTimeSpan(0, 0, iBlocksPerPage * MINSPERBLOCK, 0);
+  }
+  else
+  {
+    m_gridStart = CDateTime(gridStart.GetYear(), gridStart.GetMonth(), gridStart.GetDay(), gridStart.GetHour(), gridStart.GetMinute() >= 30 ? 30 : 0, 0);
+    m_gridEnd = CDateTime(gridEnd.GetYear(), gridEnd.GetMonth(), gridEnd.GetDay(), gridEnd.GetHour(), gridEnd.GetMinute() >= 30 ? 30 : 0, 0);
   }
 
   ////////////////////////////////////////////////////////////////////////

--- a/xbmc/epg/GUIEPGGridContainerModel.cpp
+++ b/xbmc/epg/GUIEPGGridContainerModel.cpp
@@ -172,6 +172,7 @@ void CGUIEPGGridContainerModel::Refresh(const std::unique_ptr<CFileItemList> &it
         if (gridCursor < tag->EndAsUTC())
         {
           m_gridIndex[channel][block].item = item;
+          m_gridIndex[channel][block].progIndex = progIdx;
           break;
         }
 

--- a/xbmc/epg/GUIEPGGridContainerModel.h
+++ b/xbmc/epg/GUIEPGGridContainerModel.h
@@ -36,6 +36,9 @@ namespace EPG
     CFileItemPtr item;
     float originWidth;
     float width;
+    int progIndex;
+
+    GridItemsPtr() : originWidth(0.0), width(0.0), progIndex(-1) {}
   };
 
   class CGUIEPGGridContainerModel
@@ -73,6 +76,7 @@ namespace EPG
     CFileItemPtr GetGridItem(int iChannel, int iBlock) const { return m_gridIndex[iChannel][iBlock].item; }
     float GetGridItemWidth(int iChannel, int iBlock) const { return m_gridIndex[iChannel][iBlock].width; }
     float GetGridItemOriginWidth(int iChannel, int iBlock) const { return m_gridIndex[iChannel][iBlock].originWidth; }
+    int GetGridItemIndex(int iChannel, int iBlock) const { return m_gridIndex[iChannel][iBlock].progIndex; }
     void SetGridItemWidth(int iChannel, int iBlock, float fWidth) { m_gridIndex[iChannel][iBlock].width = fWidth; }
 
     bool IsZeroGridDuration() const { return (m_gridEnd - m_gridStart) == CDateTimeSpan(0, 0, 0, 0); }

--- a/xbmc/epg/GUIEPGGridContainerModel.h
+++ b/xbmc/epg/GUIEPGGridContainerModel.h
@@ -47,7 +47,7 @@ namespace EPG
     CGUIEPGGridContainerModel() : m_blocks(0) {}
     virtual ~CGUIEPGGridContainerModel() { Reset(); }
 
-    void Refresh(CFileItemList *items, int iRulerUnit, int iBlocksPerPage, float fBlockSize);
+    void Refresh(const std::unique_ptr<CFileItemList> &items, const CDateTime &gridStart, const CDateTime &gridEnd, int iRulerUnit, int iBlocksPerPage, float fBlockSize);
     void SetInvalid();
 
     void FindChannelAndBlockIndex(int channelUid, unsigned int broadcastUid, int eventOffset, int &newChannelIndex, int &newBlockIndex) const;
@@ -78,8 +78,6 @@ namespace EPG
     bool IsZeroGridDuration() const { return (m_gridEnd - m_gridStart) == CDateTimeSpan(0, 0, 0, 0); }
     const CDateTime &GetGridStart() const { return m_gridStart; }
     const CDateTime &GetGridEnd() const { return m_gridEnd; }
-    void SetGridStart(const CDateTime &gridStart) { m_gridStart = gridStart; }
-    void SetGridEnd(const CDateTime &gridEnd) { m_gridEnd = gridEnd; }
 
   private:
     void FreeItemsMemory();

--- a/xbmc/epg/GUIEPGGridContainerModel.h
+++ b/xbmc/epg/GUIEPGGridContainerModel.h
@@ -1,0 +1,105 @@
+#pragma once
+/*
+ *      Copyright (C) 2012-2016 Team Kodi
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <memory>
+#include <vector>
+
+#include "XBDateTime.h"
+
+class CFileItem;
+typedef std::shared_ptr<CFileItem> CFileItemPtr;
+
+class CFileItemList;
+
+namespace EPG
+{
+  struct GridItemsPtr
+  {
+    CFileItemPtr item;
+    float originWidth;
+    float width;
+  };
+
+  class CGUIEPGGridContainerModel
+  {
+  public:
+    static const int MINSPERBLOCK = 5; // minutes
+    static const int MAXBLOCKS    = 33 * 24 * 60 / MINSPERBLOCK; //! 33 days of 5 minute blocks (31 days for upcoming data + 1 day for past data + 1 day for fillers)
+
+    CGUIEPGGridContainerModel() : m_blocks(0) {}
+    virtual ~CGUIEPGGridContainerModel() { Reset(); }
+
+    void Refresh(CFileItemList *items, int iRulerUnit, int iBlocksPerPage, float fBlockSize);
+    void SetInvalid();
+
+    void FindChannelAndBlockIndex(int channelUid, unsigned int broadcastUid, int eventOffset, int &newChannelIndex, int &newBlockIndex) const;
+
+    void FreeChannelMemory(int keepStart, int keepEnd);
+    void FreeProgrammeMemory(int channel, int keepStart, int keepEnd);
+    void FreeRulerMemory(int keepStart, int keepEnd);
+
+    CFileItemPtr GetProgrammeItem(int iIndex) const { return m_programmeItems[iIndex]; }
+    bool HasProgrammeItems() const { return !m_programmeItems.empty(); }
+    int ProgrammeItemsSize() const { return static_cast<int>(m_programmeItems.size()); }
+
+    CFileItemPtr GetChannelItem(int iIndex) const { return m_channelItems[iIndex]; }
+    bool HasChannelItems() const { return !m_channelItems.empty(); }
+    int ChannelItemsSize() const { return static_cast<int>(m_channelItems.size()); }
+
+    CFileItemPtr GetRulerItem(int iIndex) const { return m_rulerItems[iIndex]; }
+    int RulerItemsSize() const { return static_cast<int>(m_rulerItems.size()); }
+
+    int GetBlockCount() const { return m_blocks; }
+    bool HasGridItems() const { return !m_gridIndex.empty(); }
+    GridItemsPtr *GetGridItemPtr(int iChannel, int iBlock) { return &m_gridIndex[iChannel][iBlock]; }
+    CFileItemPtr GetGridItem(int iChannel, int iBlock) const { return m_gridIndex[iChannel][iBlock].item; }
+    float GetGridItemWidth(int iChannel, int iBlock) const { return m_gridIndex[iChannel][iBlock].width; }
+    float GetGridItemOriginWidth(int iChannel, int iBlock) const { return m_gridIndex[iChannel][iBlock].originWidth; }
+    void SetGridItemWidth(int iChannel, int iBlock, float fWidth) { m_gridIndex[iChannel][iBlock].width = fWidth; }
+
+    bool IsZeroGridDuration() const { return (m_gridEnd - m_gridStart) == CDateTimeSpan(0, 0, 0, 0); }
+    const CDateTime &GetGridStart() const { return m_gridStart; }
+    const CDateTime &GetGridEnd() const { return m_gridEnd; }
+    void SetGridStart(const CDateTime &gridStart) { m_gridStart = gridStart; }
+    void SetGridEnd(const CDateTime &gridEnd) { m_gridEnd = gridEnd; }
+
+  private:
+    void FreeItemsMemory();
+    void Reset();
+
+    struct ItemsPtr
+    {
+      long start;
+      long stop;
+    };
+
+    CDateTime m_gridStart;
+    CDateTime m_gridEnd;
+
+    std::vector<CFileItemPtr> m_programmeItems;
+    std::vector<CFileItemPtr> m_channelItems;
+    std::vector<CFileItemPtr> m_rulerItems;
+    std::vector<ItemsPtr> m_epgItemsPtr;
+    std::vector<std::vector<GridItemsPtr> > m_gridIndex;
+
+    int m_blocks;
+  };
+}

--- a/xbmc/epg/Makefile
+++ b/xbmc/epg/Makefile
@@ -5,7 +5,8 @@ SRCS=EpgInfoTag.cpp \
 	Epg.cpp \
 	EpgContainer.cpp \
 	EpgDatabase.cpp \
-	GUIEPGGridContainer.cpp
+	GUIEPGGridContainer.cpp \
+	GUIEPGGridContainerModel.cpp
 
 LIB=epg.a
 

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -63,7 +63,10 @@ void CGUIWindowPVRGuide::OnInitWindow()
   CGUIEPGGridContainer *epgGridContainer =
     dynamic_cast<CGUIEPGGridContainer*>(GetControl(m_viewControl.GetCurrentControl()));
   if (epgGridContainer)
+  {
+    epgGridContainer->SetChannel(GetSelectedItemPath(m_bRadio));
     epgGridContainer->GoToNow();
+  }
 
   m_bRefreshTimelineItems = true;
   StartRefreshTimelineItemsThread();
@@ -199,25 +202,6 @@ void CGUIWindowPVRGuide::UpdateSelectedItemPath()
   }
   else
     CGUIWindowPVRBase::UpdateSelectedItemPath();
-}
-
-bool CGUIWindowPVRGuide::Update(const std::string &strDirectory, bool updateFilterPath /* = true */)
-{
-  bool bReturn = CGUIWindowPVRBase::Update(strDirectory, updateFilterPath);
-
-  switch (m_viewControl.GetCurrentControl())
-  {
-    case GUIDE_VIEW_TIMELINE: {
-      CGUIEPGGridContainer* epgGridContainer = (CGUIEPGGridContainer*) GetControl(m_viewControl.GetCurrentControl());
-      if (epgGridContainer)
-        epgGridContainer->SetChannel(GetSelectedItemPath(m_bRadio));
-      break;
-    }
-    default:
-      break;
-  }
-
-  return bReturn;
 }
 
 void CGUIWindowPVRGuide::UpdateButtons(void)

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.h
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.h
@@ -42,7 +42,6 @@ namespace PVR
     virtual bool OnAction(const CAction &action) override;
     virtual void GetContextButtons(int itemNumber, CContextButtons &buttons) override;
     virtual bool OnContextButton(int itemNumber, CONTEXT_BUTTON button) override;
-    virtual bool Update(const std::string &strDirectory, bool updateFilterPath = true) override;
     virtual void UpdateButtons(void) override;
     virtual void Notify(const Observable &obs, const ObservableMessage msg) override;
 

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.h
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.h
@@ -78,9 +78,8 @@ namespace PVR
     std::unique_ptr<CPVRRefreshTimelineItemsThread> m_refreshTimelineItemsThread;
     std::atomic_bool m_bRefreshTimelineItems;
 
-    std::shared_ptr<CFileItemList> m_cachedTimeline;
     CPVRChannelGroupPtr m_cachedChannelGroup;
-    std::shared_ptr<CFileItemList> m_newTimeline;
+    std::unique_ptr<CFileItemList> m_newTimeline;
   };
 
   class CPVRRefreshTimelineItemsThread : public CThread

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -1089,6 +1089,10 @@ bool URIUtils::HasSlashAtEnd(const std::string& strFile, bool checkURL /* = fals
 
 void URIUtils::RemoveSlashAtEnd(std::string& strFolder)
 {
+  // performance optimization. pvr guide items are mass objects, uri never has a slash at end, and this method is quite expensive...
+  if (IsPVRGuideItem(strFolder))
+    return;
+
   if (IsURL(strFolder))
   {
     CURL url(strFolder);


### PR DESCRIPTION
Simple approach gaining great performance improvements:

Factor grid data model out of the rest of the grid, recalculate it in a separate (the already existing grid window refresh) thread and in the render thread just "switch" the model on demand.

Also contained in this PR, general performance improvements for the grid model recalculation algorithm and some other tweaks positively influencing grid window performance.

Still not perfect, but a big step forward. Feels slick on my test machines with usually only 80+ channels but 31 days epg data.

Imo, better results are only achievable with a complete rewrite of the grid control (and larger changes in gui media window, where now most of the time is "wasted")

@Jalle19 mind taking a look. For the review I would suggest to go through the changes commit by commit. Makes understanding stuff more easy.

@Razzeee for the VS project file updates?
