### PR TITLE
SubtitleDialog, remember last service/search.

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -143,6 +143,7 @@
 
 // Dialog includes
 #include "video/dialogs/GUIDialogVideoBookmarks.h"
+#include "video/dialogs/GUIDialogSubtitles.h"
 #include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogKaiToast.h"
 #include "dialogs/GUIDialogSubMenu.h"
@@ -3794,6 +3795,12 @@ void CApplication::StopPlaying()
   if ( m_pPlayer->IsPlaying() )
   {
     m_pPlayer->CloseFile();
+
+    // When playback stops we must clear the saved subtitle search from the SubtitleDialog since the dialog is preserved in memory
+    // Otherwise the next time the dialogs open any previous search from a previous movie will be shown
+    CGUIDialogSubtitles *dialog = (CGUIDialogSubtitles*)g_windowManager.GetWindow(WINDOW_DIALOG_SUBTITLES);
+    CGUIMessage msg(GUI_MSG_WINDOW_RESET, dialog->GetID(), 0);
+    dialog->OnMessage(msg);
 
     // turn off visualisation window when stopping
     if ((iWin == WINDOW_VISUALISATION

--- a/xbmc/video/dialogs/GUIDialogSubtitles.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitles.cpp
@@ -162,8 +162,14 @@ bool CGUIDialogSubtitles::OnMessage(CGUIMessage& message)
 
     CGUIDialog::OnMessage(message);
 
+    return true;
+  }
+  else if (message.GetMessage() == GUI_MSG_WINDOW_RESET)
+  {
+    CGUIDialog::OnMessage(message);
+    
+    // Clear saved subtitles from any previous subtitle search
     ClearSubtitles();
-    ClearServices();
     return true;
   }
   return CGUIDialog::OnMessage(message);
@@ -181,7 +187,10 @@ void CGUIDialogSubtitles::OnInitWindow()
 
   FillServices();
   CGUIWindow::OnInitWindow();
-  Search();
+
+  // Only do a inital search for subtitles if there isn't a saved search
+  if (m_subtitles->IsEmpty())
+    Search();
 }
 
 void CGUIDialogSubtitles::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
@@ -231,6 +240,7 @@ void CGUIDialogSubtitles::Process(unsigned int currentTime, CDirtyRegionList &di
 
 void CGUIDialogSubtitles::FillServices()
 {
+  std::string previousService = m_currentService;
   ClearServices();
 
   VECADDONS addons;
@@ -257,7 +267,8 @@ void CGUIDialogSubtitles::FillServices()
   {
     CFileItemPtr item(CAddonsDirectory::FileItemFromAddon(*addonIt, "plugin://" + (*addonIt)->ID(), false));
     m_serviceItems->Add(item);
-    if ((*addonIt)->ID() == defaultService)
+    // If we don't have used a previous service use the default service, otherwise use the previous service
+    if ((previousService.empty() && (*addonIt)->ID() == defaultService) || (*addonIt)->ID() == previousService)
       service = (*addonIt)->ID();
   }
 


### PR DESCRIPTION
My first attempt to make a little change to Kodi that I think is a improvement.
This makes the SubtitleDialog remember the last service used, and also the last search instead of always using, and searching, the first service in the list.

The intent is that last search should only be remembered for the current video playing, and if the playback is stopped and the SubtitleDialog is opened for another video only the last service is remembered.

But I do think that what I do in StopPlaying isn't the right way to do it, or if I even use CGUIMessage the right way?
