### PR TITLE
FFmpegImage: Fix memory leak

### DIFF
--- a/xbmc/guilib/FFmpegImage.cpp
+++ b/xbmc/guilib/FFmpegImage.cpp
@@ -459,7 +459,7 @@ bool CFFmpegImage::DecodeFrame(AVFrame* frame, unsigned int width, unsigned int 
     if (minPitch < 0)
     {
       CLog::LogFunction(LOGERROR, __FUNCTION__, "negative pitch or height");
-      av_free(pictureRGB);
+      av_frame_free(&pictureRGB);
       return false;
     }
     const unsigned char *src = pictureRGB->data[0];


### PR DESCRIPTION
After recent ffmpeg fixes, there was also an issue found in our Picture implementation.
