### PR TITLE
Haptics and Controller power-off

### DIFF
--- a/Kodi.xcodeproj/project.pbxproj
+++ b/Kodi.xcodeproj/project.pbxproj
@@ -253,6 +253,8 @@
 		5EB3113C1A978B9B00551907 /* CueInfoLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5EB3113A1A978B9B00551907 /* CueInfoLoader.cpp */; };
 		5EE4F9181A9FF36F002E20F8 /* CueInfoLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5EB3113A1A978B9B00551907 /* CueInfoLoader.cpp */; };
 		5EF801001A97892A0035AA4D /* ReplayGain.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5EF800FE1A97892A0035AA4D /* ReplayGain.cpp */; };
+		6815C1411CC7BADB000DB91A /* RumbleGenerator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6815C13F1CC7BADB000DB91A /* RumbleGenerator.cpp */; };
+		6815C1421CC7BADB000DB91A /* RumbleGenerator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6815C13F1CC7BADB000DB91A /* RumbleGenerator.cpp */; };
 		6861B9EA1CC248EE00F62655 /* DriverReceiving.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6861B9E81CC248EE00F62655 /* DriverReceiving.cpp */; };
 		6861B9EB1CC248EE00F62655 /* DriverReceiving.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6861B9E81CC248EE00F62655 /* DriverReceiving.cpp */; };
 		68AE5BA51C92412900C4D527 /* AddonCallbacksPeripheral.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 68AE5BA31C92412900C4D527 /* AddonCallbacksPeripheral.cpp */; };
@@ -2745,6 +2747,8 @@
 		5EB3113B1A978B9B00551907 /* CueInfoLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CueInfoLoader.h; sourceTree = "<group>"; };
 		5EF800FE1A97892A0035AA4D /* ReplayGain.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ReplayGain.cpp; sourceTree = "<group>"; };
 		5EF800FF1A97892A0035AA4D /* ReplayGain.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ReplayGain.h; sourceTree = "<group>"; };
+		6815C13F1CC7BADB000DB91A /* RumbleGenerator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = RumbleGenerator.cpp; path = joysticks/RumbleGenerator.cpp; sourceTree = "<group>"; };
+		6815C1401CC7BADB000DB91A /* RumbleGenerator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RumbleGenerator.h; path = joysticks/RumbleGenerator.h; sourceTree = "<group>"; };
 		6861B9E81CC248EE00F62655 /* DriverReceiving.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DriverReceiving.cpp; path = joysticks/generic/DriverReceiving.cpp; sourceTree = "<group>"; };
 		6861B9E91CC248EE00F62655 /* DriverReceiving.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DriverReceiving.h; path = joysticks/generic/DriverReceiving.h; sourceTree = "<group>"; };
 		6861B9EC1CC248F600F62655 /* IDriverReceiver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = IDriverReceiver.h; path = joysticks/IDriverReceiver.h; sourceTree = "<group>"; };
@@ -6141,6 +6145,8 @@
 				68AE5BBA1C9241DF00C4D527 /* JoystickUtils.h */,
 				68AE5BBB1C9241DF00C4D527 /* KeymapHandler.cpp */,
 				68AE5BBC1C9241DF00C4D527 /* KeymapHandler.h */,
+				6815C13F1CC7BADB000DB91A /* RumbleGenerator.cpp */,
+				6815C1401CC7BADB000DB91A /* RumbleGenerator.h */,
 			);
 			name = joysticks;
 			sourceTree = "<group>";
@@ -10260,6 +10266,7 @@
 				7C4705AE12EF584C00369E51 /* AddonInstaller.cpp in Sources */,
 				18C1D22D13033F6A00CFFE59 /* GLUtils.cpp in Sources */,
 				F56579AF13060D1E0085ED7F /* RenderCapture.cpp in Sources */,
+				6815C1411CC7BADB000DB91A /* RumbleGenerator.cpp in Sources */,
 				7C84A59E12FA3C1600CD1714 /* SourcesDirectory.cpp in Sources */,
 				7C99B6A4133D342100FC2B16 /* CircularCache.cpp in Sources */,
 				7C99B7951340723F00FC2B16 /* GUIDialogPlayEject.cpp in Sources */,
@@ -11099,6 +11106,7 @@
 				E49912B3174E5D9900741B6D /* SMBDirectory.cpp in Sources */,
 				E49912B4174E5D9900741B6D /* SMBFile.cpp in Sources */,
 				E49912B5174E5D9900741B6D /* SourcesDirectory.cpp in Sources */,
+				6815C1421CC7BADB000DB91A /* RumbleGenerator.cpp in Sources */,
 				DF6A0D821A4584E80075BBFC /* OverrideDirectory.cpp in Sources */,
 				E49912B6174E5D9900741B6D /* SpecialProtocol.cpp in Sources */,
 				E49912B7174E5D9900741B6D /* SpecialProtocolDirectory.cpp in Sources */,

--- a/Kodi.xcodeproj/project.pbxproj
+++ b/Kodi.xcodeproj/project.pbxproj
@@ -253,6 +253,8 @@
 		5EB3113C1A978B9B00551907 /* CueInfoLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5EB3113A1A978B9B00551907 /* CueInfoLoader.cpp */; };
 		5EE4F9181A9FF36F002E20F8 /* CueInfoLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5EB3113A1A978B9B00551907 /* CueInfoLoader.cpp */; };
 		5EF801001A97892A0035AA4D /* ReplayGain.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5EF800FE1A97892A0035AA4D /* ReplayGain.cpp */; };
+		6861B9EA1CC248EE00F62655 /* DriverReceiving.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6861B9E81CC248EE00F62655 /* DriverReceiving.cpp */; };
+		6861B9EB1CC248EE00F62655 /* DriverReceiving.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6861B9E81CC248EE00F62655 /* DriverReceiving.cpp */; };
 		68AE5BA51C92412900C4D527 /* AddonCallbacksPeripheral.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 68AE5BA31C92412900C4D527 /* AddonCallbacksPeripheral.cpp */; };
 		68AE5BA61C92412900C4D527 /* AddonCallbacksPeripheral.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 68AE5BA31C92412900C4D527 /* AddonCallbacksPeripheral.cpp */; };
 		68AE5BBD1C9241DF00C4D527 /* DefaultJoystick.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 68AE5BAC1C9241DF00C4D527 /* DefaultJoystick.cpp */; };
@@ -2743,6 +2745,10 @@
 		5EB3113B1A978B9B00551907 /* CueInfoLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CueInfoLoader.h; sourceTree = "<group>"; };
 		5EF800FE1A97892A0035AA4D /* ReplayGain.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ReplayGain.cpp; sourceTree = "<group>"; };
 		5EF800FF1A97892A0035AA4D /* ReplayGain.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ReplayGain.h; sourceTree = "<group>"; };
+		6861B9E81CC248EE00F62655 /* DriverReceiving.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DriverReceiving.cpp; path = joysticks/generic/DriverReceiving.cpp; sourceTree = "<group>"; };
+		6861B9E91CC248EE00F62655 /* DriverReceiving.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DriverReceiving.h; path = joysticks/generic/DriverReceiving.h; sourceTree = "<group>"; };
+		6861B9EC1CC248F600F62655 /* IDriverReceiver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = IDriverReceiver.h; path = joysticks/IDriverReceiver.h; sourceTree = "<group>"; };
+		6861B9ED1CC248F600F62655 /* IInputReceiver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = IInputReceiver.h; path = joysticks/IInputReceiver.h; sourceTree = "<group>"; };
 		68AE5BA01C923E5300C4D527 /* kodi_vfs_utils.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = kodi_vfs_utils.hpp; path = "kodi-addon-dev-kit/include/kodi/kodi_vfs_utils.hpp"; sourceTree = "<group>"; };
 		68AE5BA31C92412900C4D527 /* AddonCallbacksPeripheral.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = AddonCallbacksPeripheral.cpp; path = addons/binary/interfaces/api1/Peripheral/AddonCallbacksPeripheral.cpp; sourceTree = "<group>"; };
 		68AE5BA41C92412900C4D527 /* AddonCallbacksPeripheral.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AddonCallbacksPeripheral.h; path = addons/binary/interfaces/api1/Peripheral/AddonCallbacksPeripheral.h; sourceTree = "<group>"; };
@@ -6123,7 +6129,9 @@
 				68AE5BB01C9241DF00C4D527 /* IButtonMap.h */,
 				68AE5BB11C9241DF00C4D527 /* IButtonMapper.h */,
 				68AE5BB21C9241DF00C4D527 /* IDriverHandler.h */,
+				6861B9EC1CC248F600F62655 /* IDriverReceiver.h */,
 				68AE5BB31C9241DF00C4D527 /* IInputHandler.h */,
+				6861B9ED1CC248F600F62655 /* IInputReceiver.h */,
 				68AE5BB41C9241DF00C4D527 /* IKeymapHandler.h */,
 				68AE5BB51C9241DF00C4D527 /* JoystickMonitor.cpp */,
 				68AE5BB61C9241DF00C4D527 /* JoystickMonitor.h */,
@@ -6142,6 +6150,8 @@
 			children = (
 				68AE5BC81C9241F800C4D527 /* ButtonMapping.cpp */,
 				68AE5BC91C9241F800C4D527 /* ButtonMapping.h */,
+				6861B9E81CC248EE00F62655 /* DriverReceiving.cpp */,
+				6861B9E91CC248EE00F62655 /* DriverReceiving.h */,
 				68AE5BCA1C9241F800C4D527 /* FeatureHandling.cpp */,
 				68AE5BCB1C9241F800C4D527 /* FeatureHandling.h */,
 				68AE5BCC1C9241F800C4D527 /* InputHandling.cpp */,
@@ -10014,6 +10024,7 @@
 				8883CEA10DD817D1004E8B72 /* DVDOverlayCodecSSA.cpp in Sources */,
 				8883CEA70DD81807004E8B72 /* DVDSubtitleParserSSA.cpp in Sources */,
 				8883CEA80DD81807004E8B72 /* DVDSubtitlesLibass.cpp in Sources */,
+				6861B9EA1CC248EE00F62655 /* DriverReceiving.cpp in Sources */,
 				5EF801001A97892A0035AA4D /* ReplayGain.cpp in Sources */,
 				8863281D0E07B37200BB3DAB /* GUIDialogFullScreenInfo.cpp in Sources */,
 				8863281E0E07B37200BB3DAB /* GUIViewStatePictures.cpp in Sources */,
@@ -10847,6 +10858,7 @@
 				E49911AE174E5CFE00741B6D /* AEStreamInfo.cpp in Sources */,
 				E49911AF174E5CFE00741B6D /* AEUtil.cpp in Sources */,
 				E49911B1174E5CFE00741B6D /* AEFactory.cpp in Sources */,
+				6861B9EB1CC248EE00F62655 /* DriverReceiving.cpp in Sources */,
 				E49911B2174E5D0A00741B6D /* EmuFileWrapper.cpp in Sources */,
 				E49911B3174E5D0A00741B6D /* emu_dummy.cpp in Sources */,
 				E49911B4174E5D0A00741B6D /* emu_kernel32.cpp in Sources */,

--- a/addons/game.controller.default/resources/layout.xml
+++ b/addons/game.controller.default/resources/layout.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <layout name="default" label="30000" image="layout.png">
-  <face>
+  <category name="face">
     <button name="a" type="digital" label="30001" geometry="circle" x="651" y="266" radius="32"/>
     <button name="b" type="digital" label="30002" geometry="circle" x="709" y="210" radius="32"/>
     <button name="x" type="digital" label="30003" geometry="circle" x="583" y="210" radius="32"/>
@@ -9,22 +9,26 @@
     <button name="back" type="digital" label="30006" geometry="ellipse" x="290" y="227" rx="22" ry="16"/>
     <button name="guide" type="digital" label="30007" geometry="circle" x="386" y="221" radius="50"/>
     <button name="up" type="digital" label="30010" geometry="circle" x="117" y="234" r="52"/>
-    <button name="down" type="digital" label="30011" geometry="circle" x="500" y="342" r="52"/>
     <button name="right" type="digital" label="30012" geometry="rectangle" x1="233" y1="288" x2="281" y2="332"/>
+    <button name="down" type="digital" label="30011" geometry="circle" x="500" y="342" r="52"/>
     <button name="left" type="digital" label="30013" geometry="rectangle" x1="233" y1="353" x2="281" y2="397"/>
     <button name="leftthumb" type="digital" label="30008" geometry="rectangle" x1="131" y1="0" x2="194" y2="40"/>
     <button name="rightthumb" type="digital" label="30009" geometry="rectangle" x1="567" y1="0" x2="631" y2="40"/>
-  </face>
-  <shoulder>
+  </category>
+  <category name="shoulder">
     <button name="leftbumper" type="digital" label="30014" geometry="rectangle" x1="272" y1="321" x2="316" y2="365"/>
     <button name="rightbumper" type="digital" label="30015" geometry="rectangle" x1="198" y1="321" x2="242" y2="365"/>
-  </shoulder>
-  <triggers>
+  </category>
+  <category name="triggers">
     <button name="lefttrigger" type="analog" label="30016" geometry="rectangle" x1="36" y1="40" x2="207" y2="108"/>
     <button name="righttrigger" type="analog" label="30017" geometry="rectangle" x1="556" y1="40" x2="728" y2="108"/>
-  </triggers>
-  <analogsticks>
+  </category>
+  <category name="analogsticks">
     <analogstick name="leftstick" label="30008" geometry="circle" x="500" y="342" r="52"/>
     <analogstick name="rightstick" label="30009" geometry="circle" x="500" y="342" r="52"/>
-  </analogsticks>
+  </category>
+  <category name="haptics">
+    <motor name="leftmotor"/>
+    <motor name="rightmotor"/>
+  </category>
 </layout>

--- a/addons/kodi.peripheral/addon.xml
+++ b/addons/kodi.peripheral/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="kodi.peripheral" version="1.0.17" provider-name="Team-Kodi">
-	<backwards-compatibility abi="1.0.16"/>
+<addon id="kodi.peripheral" version="1.0.18" provider-name="Team-Kodi">
+	<backwards-compatibility abi="1.0.18"/>
 	<requires>
 		<import addon="xbmc.core" version="0.1.0"/>
 	</requires>

--- a/addons/kodi.peripheral/addon.xml
+++ b/addons/kodi.peripheral/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="kodi.peripheral" version="1.0.18" provider-name="Team-Kodi">
-	<backwards-compatibility abi="1.0.18"/>
+<addon id="kodi.peripheral" version="1.0.19" provider-name="Team-Kodi">
+	<backwards-compatibility abi="1.0.19"/>
 	<requires>
 		<import addon="xbmc.core" version="0.1.0"/>
 	</requires>

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -15950,7 +15950,19 @@ msgctxt "#35050"
 msgid "Controller profiles"
 msgstr ""
 
-#empty strings from id 35051 to 35054
+#. Setting to test rumble
+#: system/settings/settings.xml
+msgctxt "#35051"
+msgid "Test rumble"
+msgstr ""
+
+#. Description of setting to test rumble
+#: system/settings/settings.xml
+msgctxt "#35052"
+msgid "Activate the rumble motors of all controllers."
+msgstr ""
+
+#empty strings from id 35053 to 35054
 
 #. Help text for controller window
 #: xbmc/games/controllers/windows/GUIControllerWindow.cpp

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -16024,7 +16024,19 @@ msgctxt "#35064"
 msgid "Pair your controllers with the various input devices of different game systems."
 msgstr ""
 
-#empty strings from id 35065 to 35089
+#empty strings from id 35065 to 35087
+
+#. Name of the setting that enables/disables powering off controllers on exit
+#: system/settings/settings.xml
+msgctxt "#35088"
+msgid "Power off controllers on exit"
+msgstr ""
+
+#. Description for the setting that enables/disables powering off controllers on exit
+#: system/settings/settings.xml
+msgctxt "#35089"
+msgid "Powers off any controller that supports it on exit."
+msgstr ""
 
 #. Button prompt without timeout. %s - button name
 #: xbmc/games/controllers/guicontrols/GUIScalarFeatureButton.cpp

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2608,6 +2608,14 @@
           </dependencies>
           <control type="button" format="action" />
         </setting>
+        <setting id="input.controllerpoweroff" type="boolean" label="35088" help="35089">
+          <level>0</level>
+          <default>false</default>
+          <dependencies>
+            <dependency type="enable" on="property" name="SupportsPeripheralControllers" />
+          </dependencies>
+          <control type="toggle" />
+        </setting>
       </group>
     </category>
     <category id="network" label="798" help="36379">

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2601,6 +2601,13 @@
           </dependencies>
           <control type="button" format="action" />
         </setting>
+        <setting id="input.testrumble" type="action" label="35051" help="35052">
+          <level>2</level>
+          <dependencies>
+            <dependency type="enable" on="property" name="HasRumbleFeature" />
+          </dependencies>
+          <control type="button" format="action" />
+        </setting>
       </group>
     </category>
     <category id="network" label="798" help="36379">

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_dll.h
@@ -100,6 +100,14 @@ extern "C"
    * @param events       The array of allocated events
    */
   void FreeEvents(unsigned int event_count, PERIPHERAL_EVENT* events);
+
+  /*!
+   * @brief Send an input event to the specified peripheral
+   * @param peripheralIndex The index of the device receiving the input event
+   * @param event The input event
+   * @return true if the event was handled, false otherwise
+   */
+  bool SendEvent(const PERIPHERAL_EVENT* event);
   ///}
 
   /// @name Joystick operations
@@ -180,6 +188,7 @@ extern "C"
     pClient->FreeScanResults                = FreeScanResults;
     pClient->GetEvents                      = GetEvents;
     pClient->FreeEvents                     = FreeEvents;
+    pClient->SendEvent                      = SendEvent;
 
 #ifdef PERIPHERAL_ADDON_JOYSTICKS
     pClient->GetJoystickInfo                = GetJoystickInfo;

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_dll.h
@@ -171,6 +171,12 @@ extern "C"
    * @param controller_id The game controller profile being reset
    */
   void ResetButtonMap(const JOYSTICK_INFO* joystick, const char* controller_id);
+  
+  /*!
+   * @brief Powers off the given joystick if supported
+   * @param index  The joystick's driver index
+   */
+  void PowerOffJoystick(unsigned int index);
 #endif
   ///}
 
@@ -197,6 +203,7 @@ extern "C"
     pClient->FreeFeatures                   = FreeFeatures;
     pClient->MapFeatures                    = MapFeatures;
     pClient->ResetButtonMap                 = ResetButtonMap;
+    pClient->PowerOffJoystick               = PowerOffJoystick;
 #endif
   }
 

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_types.h
@@ -50,10 +50,10 @@
 #endif
 
 /* current Peripheral API version */
-#define PERIPHERAL_API_VERSION "1.0.17"
+#define PERIPHERAL_API_VERSION "1.0.18"
 
 /* min. Peripheral API version */
-#define PERIPHERAL_MIN_API_VERSION "1.0.16"
+#define PERIPHERAL_MIN_API_VERSION "1.0.18"
 
 /* indicates a joystick has no preference for port number */
 #define NO_PORT_REQUESTED     (-1)
@@ -122,6 +122,7 @@ extern "C"
     PERIPHERAL_EVENT_TYPE_DRIVER_BUTTON,  /*!< @brief state changed for joystick driver button */
     PERIPHERAL_EVENT_TYPE_DRIVER_HAT,     /*!< @brief state changed for joystick driver hat */
     PERIPHERAL_EVENT_TYPE_DRIVER_AXIS,    /*!< @brief state changed for joystick driver axis */
+    PERIPHERAL_EVENT_TYPE_SET_MOTOR,      /*!< @brief set the state for joystick rumble motor */
   } PERIPHERAL_EVENT_TYPE;
 
   typedef enum JOYSTICK_STATE_BUTTON
@@ -152,6 +153,8 @@ extern "C"
    */
   typedef float JOYSTICK_STATE_AXIS;
 
+  typedef float JOYSTICK_STATE_MOTOR;
+
   typedef struct PERIPHERAL_EVENT
   {
     unsigned int             peripheral_index;
@@ -160,6 +163,7 @@ extern "C"
     JOYSTICK_STATE_BUTTON    driver_button_state;
     JOYSTICK_STATE_HAT       driver_hat_state;
     JOYSTICK_STATE_AXIS      driver_axis_state;
+    JOYSTICK_STATE_MOTOR     motor_state;
   } ATTRIBUTE_PACKED PERIPHERAL_EVENT;
   ///}
 
@@ -173,6 +177,7 @@ extern "C"
     unsigned int    button_count;       /*!< @brief number of buttons reported by the driver */
     unsigned int    hat_count;          /*!< @brief number of hats reported by the driver */
     unsigned int    axis_count;         /*!< @brief number of axes reported by the driver */
+    unsigned int    motor_count;        /*!< @brief number of motors reported by the driver */
   } ATTRIBUTE_PACKED JOYSTICK_INFO;
 
   typedef enum JOYSTICK_DRIVER_PRIMITIVE_TYPE
@@ -181,6 +186,7 @@ extern "C"
     JOYSTICK_DRIVER_PRIMITIVE_TYPE_BUTTON,
     JOYSTICK_DRIVER_PRIMITIVE_TYPE_HAT_DIRECTION,
     JOYSTICK_DRIVER_PRIMITIVE_TYPE_SEMIAXIS,
+    JOYSTICK_DRIVER_PRIMITIVE_TYPE_MOTOR,
   } JOYSTICK_DRIVER_PRIMITIVE_TYPE;
 
   typedef struct JOYSTICK_DRIVER_BUTTON
@@ -216,6 +222,11 @@ extern "C"
     JOYSTICK_DRIVER_SEMIAXIS_DIRECTION direction;
   } ATTRIBUTE_PACKED JOYSTICK_DRIVER_SEMIAXIS;
 
+  typedef struct JOYSTICK_DRIVER_MOTOR
+  {
+    int              index;
+  } ATTRIBUTE_PACKED JOYSTICK_DRIVER_MOTOR;
+
   typedef struct JOYSTICK_DRIVER_PRIMITIVE
   {
     JOYSTICK_DRIVER_PRIMITIVE_TYPE    type;
@@ -224,6 +235,7 @@ extern "C"
       struct JOYSTICK_DRIVER_BUTTON   button;
       struct JOYSTICK_DRIVER_HAT      hat;
       struct JOYSTICK_DRIVER_SEMIAXIS semiaxis;
+      struct JOYSTICK_DRIVER_MOTOR    motor;
     };
   } ATTRIBUTE_PACKED JOYSTICK_DRIVER_PRIMITIVE;
 
@@ -233,6 +245,7 @@ extern "C"
     JOYSTICK_FEATURE_TYPE_SCALAR,
     JOYSTICK_FEATURE_TYPE_ANALOG_STICK,
     JOYSTICK_FEATURE_TYPE_ACCELEROMETER,
+    JOYSTICK_FEATURE_TYPE_MOTOR,
   } JOYSTICK_FEATURE_TYPE;
 
   typedef struct JOYSTICK_FEATURE_SCALAR
@@ -255,6 +268,11 @@ extern "C"
     struct JOYSTICK_DRIVER_PRIMITIVE positive_z;
   } ATTRIBUTE_PACKED JOYSTICK_FEATURE_ACCELEROMETER;
 
+  typedef struct JOYSTICK_FEATURE_MOTOR
+  {
+    struct JOYSTICK_DRIVER_PRIMITIVE primitive;
+  } ATTRIBUTE_PACKED JOYSTICK_FEATURE_MOTOR;
+
   typedef struct JOYSTICK_FEATURE
   {
     char*                                   name;
@@ -264,6 +282,7 @@ extern "C"
       struct JOYSTICK_FEATURE_SCALAR        scalar;
       struct JOYSTICK_FEATURE_ANALOG_STICK  analog_stick;
       struct JOYSTICK_FEATURE_ACCELEROMETER accelerometer;
+      struct JOYSTICK_FEATURE_MOTOR         motor;
     };
   } ATTRIBUTE_PACKED JOYSTICK_FEATURE;
   ///}
@@ -282,6 +301,7 @@ extern "C"
     void             (__cdecl* FreeScanResults)(unsigned int, PERIPHERAL_INFO*);
     PERIPHERAL_ERROR (__cdecl* GetEvents)(unsigned int*, PERIPHERAL_EVENT**);
     void             (__cdecl* FreeEvents)(unsigned int, PERIPHERAL_EVENT*);
+    bool             (__cdecl* SendEvent)(const PERIPHERAL_EVENT*);
 
     /// @name Joystick operations
     ///{

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_types.h
@@ -50,10 +50,10 @@
 #endif
 
 /* current Peripheral API version */
-#define PERIPHERAL_API_VERSION "1.0.18"
+#define PERIPHERAL_API_VERSION "1.0.19"
 
 /* min. Peripheral API version */
-#define PERIPHERAL_MIN_API_VERSION "1.0.18"
+#define PERIPHERAL_MIN_API_VERSION "1.0.19"
 
 /* indicates a joystick has no preference for port number */
 #define NO_PORT_REQUESTED     (-1)
@@ -178,6 +178,7 @@ extern "C"
     unsigned int    hat_count;          /*!< @brief number of hats reported by the driver */
     unsigned int    axis_count;         /*!< @brief number of axes reported by the driver */
     unsigned int    motor_count;        /*!< @brief number of motors reported by the driver */
+    bool            supports_poweroff;  /*!< @brief whether the joystick supports being powered off */
   } ATTRIBUTE_PACKED JOYSTICK_INFO;
 
   typedef enum JOYSTICK_DRIVER_PRIMITIVE_TYPE
@@ -311,6 +312,7 @@ extern "C"
     void             (__cdecl* FreeFeatures)(unsigned int, JOYSTICK_FEATURE*);
     PERIPHERAL_ERROR (__cdecl* MapFeatures)(const JOYSTICK_INFO*, const char*, unsigned int, JOYSTICK_FEATURE*);
     void             (__cdecl* ResetButtonMap)(const JOYSTICK_INFO*, const char*);
+    void             (__cdecl* PowerOffJoystick)(unsigned int);
     ///}
   } PeripheralAddon;
 

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_utils.hpp
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_utils.hpp
@@ -21,6 +21,7 @@
 
 #include "kodi_peripheral_types.h"
 
+#include <array> // Requires c++11
 #include <cstring>
 #include <map>
 #include <string>
@@ -359,7 +360,7 @@ namespace ADDON
    *    Motor:
    *       - driver index
    */
-  class DriverPrimitive
+  struct DriverPrimitive
   {
   protected:
     /*!
@@ -569,19 +570,12 @@ namespace ADDON
   class JoystickFeature
   {
   public:
-    const unsigned int MAX_PRIMITIVES = 4;
+    enum { MAX_PRIMITIVES = 4 };
 
-    JoystickFeature(void) :
-      m_type(JOYSTICK_FEATURE_TYPE_UNKNOWN)
-    {
-      m_primitives.resize(MAX_PRIMITIVES);
-    }
-
-    JoystickFeature(const std::string& name, JOYSTICK_FEATURE_TYPE type) :
+    JoystickFeature(const std::string& name = "", JOYSTICK_FEATURE_TYPE type = JOYSTICK_FEATURE_TYPE_UNKNOWN) :
       m_name(name),
       m_type(type)
     {
-      m_primitives.resize(MAX_PRIMITIVES);
     }
 
     JoystickFeature(const JoystickFeature& other)
@@ -593,7 +587,6 @@ namespace ADDON
       m_name(feature.name ? feature.name : ""),
       m_type(feature.type)
     {
-      m_primitives.resize(MAX_PRIMITIVES);
       switch (m_type)
       {
         case JOYSTICK_FEATURE_TYPE_SCALAR:
@@ -701,7 +694,7 @@ namespace ADDON
   private:
     std::string                  m_name;
     JOYSTICK_FEATURE_TYPE        m_type;
-    std::vector<DriverPrimitive> m_primitives;
+    std::array<DriverPrimitive, MAX_PRIMITIVES> m_primitives;
   };
 
   typedef PeripheralVector<JoystickFeature, JOYSTICK_FEATURE> JoystickFeatures;

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_utils.hpp
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_utils.hpp
@@ -247,7 +247,8 @@ namespace ADDON
       m_buttonCount(0),
       m_hatCount(0),
       m_axisCount(0),
-      m_motorCount(0)
+      m_motorCount(0),
+      m_supportsPowerOff(false)
     {
     }
 
@@ -263,7 +264,8 @@ namespace ADDON
       m_buttonCount(info.button_count),
       m_hatCount(info.hat_count),
       m_axisCount(info.axis_count),
-      m_motorCount(info.motor_count)
+      m_motorCount(info.motor_count),
+      m_supportsPowerOff(info.supports_poweroff)
     {
     }
 
@@ -281,6 +283,7 @@ namespace ADDON
         m_hatCount      = rhs.m_hatCount;
         m_axisCount     = rhs.m_axisCount;
         m_motorCount    = rhs.m_motorCount;
+        m_supportsPowerOff = rhs.m_supportsPowerOff;
       }
       return *this;
     }
@@ -291,6 +294,7 @@ namespace ADDON
     unsigned int       HatCount(void) const      { return m_hatCount; }
     unsigned int       AxisCount(void) const     { return m_axisCount; }
     unsigned int       MotorCount(void) const    { return m_motorCount; }
+    bool               SupportsPowerOff(void) const { return m_supportsPowerOff; }
 
     // Derived property: Counts are unknown if all are zero
     bool AreElementCountsKnown(void) const { return m_buttonCount != 0 || m_hatCount != 0 || m_axisCount != 0; }
@@ -301,6 +305,7 @@ namespace ADDON
     void SetHatCount(unsigned int hatCount)           { m_hatCount      = hatCount; }
     void SetAxisCount(unsigned int axisCount)         { m_axisCount     = axisCount; }
     void SetMotorCount(unsigned int motorCount)       { m_motorCount    = motorCount; }
+    void SetSupportsPowerOff(bool supportsPowerOff)   { m_supportsPowerOff = supportsPowerOff; }
 
     void ToStruct(JOYSTICK_INFO& info) const
     {
@@ -312,6 +317,7 @@ namespace ADDON
       info.hat_count      = m_hatCount;
       info.axis_count     = m_axisCount;
       info.motor_count    = m_motorCount;
+      info.supports_poweroff = m_supportsPowerOff;
 
       std::strcpy(info.provider, m_provider.c_str());
     }
@@ -330,6 +336,7 @@ namespace ADDON
     unsigned int                  m_hatCount;
     unsigned int                  m_axisCount;
     unsigned int                  m_motorCount;
+    bool                          m_supportsPowerOff;
   };
 
   typedef PeripheralVector<Joystick, JOYSTICK_INFO> Joysticks;

--- a/xbmc/dialogs/GUIDialogKaiToast.cpp
+++ b/xbmc/dialogs/GUIDialogKaiToast.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "GUIDialogKaiToast.h"
+#include "peripherals/Peripherals.h"
 #include "threads/SingleLock.h"
 #include "utils/TimeUtils.h"
 
@@ -133,6 +134,9 @@ bool CGUIDialogKaiToast::DoWork()
 
     //  Play the window specific init sound for each notification queued
     SetSound(toast.withSound);
+
+    // Activate haptics for this notification
+    PERIPHERALS::g_peripherals.OnUserNotification();
 
     ResetTimer();
     return true;

--- a/xbmc/games/controllers/ControllerDefinitions.h
+++ b/xbmc/games/controllers/ControllerDefinitions.h
@@ -21,13 +21,24 @@
 
 #define LAYOUT_XML_ROOT                    "layout"
 
+#define LAYOUT_XML_ELM_CATEGORY            "category"
+
 #define LAYOUT_XML_ELM_BUTTON              "button"
 #define LAYOUT_XML_ELM_ANALOG_STICK        "analogstick"
 #define LAYOUT_XML_ELM_ACCELEROMETER       "accelerometer"
+#define LAYOUT_XML_ELM_MOTOR               "motor"
 
 #define LAYOUT_XML_ATTR_LAYOUT_LABEL       "label"
 #define LAYOUT_XML_ATTR_LAYOUT_IMAGE       "image"
 #define LAYOUT_XML_ATTR_LAYOUT_OVERLAY     "overlay"
+
+#define LAYOUT_XML_ATTR_CATEGORY_NAME      "name"
+
+#define LAYOUT_XML_VALUE_CATEGORY_FACE          "face"
+#define LAYOUT_XML_VALUE_CATEGORY_SHOULDER      "shoulder"
+#define LAYOUT_XML_VALUE_CATEGORY_TRIGGERS      "triggers"
+#define LAYOUT_XML_VALUE_CATEGORY_ANALOG_STICKS "analogsticks"
+#define LAYOUT_XML_VALUE_CATEGORY_HAPTICS       "haptics"
 
 #define LAYOUT_XML_ATTR_FEATURE_NAME       "name"
 #define LAYOUT_XML_ATTR_FEATURE_LABEL      "label"

--- a/xbmc/games/controllers/ControllerFeature.h
+++ b/xbmc/games/controllers/ControllerFeature.h
@@ -40,15 +40,17 @@ public:
   CControllerFeature& operator=(const CControllerFeature& rhs);
 
   JOYSTICK::FEATURE_TYPE Type(void) const       { return m_type; }
+  JOYSTICK::FEATURE_CATEGORY Category(void) const { return m_category; }
   const std::string&     Name(void) const       { return m_strName; }
   const std::string&     Label(void) const      { return m_strLabel; }
   unsigned int           LabelID(void) const    { return m_labelId; }
   JOYSTICK::INPUT_TYPE   InputType(void) const  { return m_inputType; }
 
-  bool Deserialize(const TiXmlElement* pElement, const CController* controller);
+  bool Deserialize(const TiXmlElement* pElement, const CController* controller, const std::string& strCategory);
 
 private:
   JOYSTICK::FEATURE_TYPE m_type;
+  JOYSTICK::FEATURE_CATEGORY m_category;
   std::string            m_strName;
   std::string            m_strLabel;
   unsigned int           m_labelId;

--- a/xbmc/games/controllers/ControllerLayout.cpp
+++ b/xbmc/games/controllers/ControllerLayout.cpp
@@ -100,17 +100,18 @@ bool CControllerLayout::Deserialize(const TiXmlElement* pElement, const CControl
     CLog::Log(LOGDEBUG, "<%s> tag has no \"%s\" attribute", LAYOUT_XML_ROOT, LAYOUT_XML_ATTR_LAYOUT_OVERLAY);
 
   // Features
-  for (const TiXmlElement* pCategory = pElement->FirstChildElement(); pCategory != NULL; pCategory = pCategory->NextSiblingElement())
+  for (const TiXmlElement* pCategory = pElement->FirstChildElement(); pCategory != nullptr; pCategory = pCategory->NextSiblingElement())
   {
-    std::string strCategory = pElement->Value();
+    if (std::string(pCategory->Value()) != std::string(LAYOUT_XML_ELM_CATEGORY))
+      continue;
 
-    //! @todo Something with category
+    const std::string strCategoryName = XMLUtils::GetAttribute(pCategory, LAYOUT_XML_ATTR_CATEGORY_NAME);
 
-    for (const TiXmlElement* pFeature = pCategory->FirstChildElement(); pFeature != NULL; pFeature = pFeature->NextSiblingElement())
+    for (const TiXmlElement* pFeature = pCategory->FirstChildElement(); pFeature != nullptr; pFeature = pFeature->NextSiblingElement())
     {
       CControllerFeature feature;
 
-      if (!feature.Deserialize(pFeature, controller))
+      if (!feature.Deserialize(pFeature, controller, strCategoryName))
         return false;
 
       m_features.push_back(feature);

--- a/xbmc/games/controllers/ControllerTranslator.cpp
+++ b/xbmc/games/controllers/ControllerTranslator.cpp
@@ -31,6 +31,7 @@ const char* CControllerTranslator::TranslateFeatureType(FEATURE_TYPE type)
     case FEATURE_TYPE::SCALAR:           return LAYOUT_XML_ELM_BUTTON;
     case FEATURE_TYPE::ANALOG_STICK:     return LAYOUT_XML_ELM_ANALOG_STICK;
     case FEATURE_TYPE::ACCELEROMETER:    return LAYOUT_XML_ELM_ACCELEROMETER;
+    case FEATURE_TYPE::MOTOR:            return LAYOUT_XML_ELM_MOTOR;
     default:
       break;
   }
@@ -42,8 +43,35 @@ FEATURE_TYPE CControllerTranslator::TranslateFeatureType(const std::string& strT
   if (strType == LAYOUT_XML_ELM_BUTTON)           return FEATURE_TYPE::SCALAR;
   if (strType == LAYOUT_XML_ELM_ANALOG_STICK)     return FEATURE_TYPE::ANALOG_STICK;
   if (strType == LAYOUT_XML_ELM_ACCELEROMETER)    return FEATURE_TYPE::ACCELEROMETER;
+  if (strType == LAYOUT_XML_ELM_MOTOR)            return FEATURE_TYPE::MOTOR;
 
   return FEATURE_TYPE::UNKNOWN;
+}
+
+const char* CControllerTranslator::TranslateCategory(FEATURE_CATEGORY category)
+{
+  switch (category)
+  {
+  case FEATURE_CATEGORY::FACE:             return LAYOUT_XML_VALUE_CATEGORY_FACE;
+  case FEATURE_CATEGORY::SHOULDER:         return LAYOUT_XML_VALUE_CATEGORY_SHOULDER;
+  case FEATURE_CATEGORY::TRIGGERS:         return LAYOUT_XML_VALUE_CATEGORY_TRIGGERS;
+  case FEATURE_CATEGORY::ANALOG_STICKS:    return LAYOUT_XML_VALUE_CATEGORY_ANALOG_STICKS;
+  case FEATURE_CATEGORY::HAPTICS:          return LAYOUT_XML_VALUE_CATEGORY_HAPTICS;
+  default:
+    break;
+  }
+  return "";
+}
+
+FEATURE_CATEGORY CControllerTranslator::TranslateCategory(const std::string& strCategory)
+{
+  if (strCategory == LAYOUT_XML_VALUE_CATEGORY_FACE)           return FEATURE_CATEGORY::FACE;
+  if (strCategory == LAYOUT_XML_VALUE_CATEGORY_SHOULDER)       return FEATURE_CATEGORY::SHOULDER;
+  if (strCategory == LAYOUT_XML_VALUE_CATEGORY_TRIGGERS)       return FEATURE_CATEGORY::TRIGGERS;
+  if (strCategory == LAYOUT_XML_VALUE_CATEGORY_ANALOG_STICKS)  return FEATURE_CATEGORY::ANALOG_STICKS;
+  if (strCategory == LAYOUT_XML_VALUE_CATEGORY_HAPTICS)        return FEATURE_CATEGORY::HAPTICS;
+
+  return FEATURE_CATEGORY::UNKNOWN;
 }
 
 const char* CControllerTranslator::TranslateInputType(INPUT_TYPE type)

--- a/xbmc/games/controllers/ControllerTranslator.h
+++ b/xbmc/games/controllers/ControllerTranslator.h
@@ -33,6 +33,9 @@ public:
   static const char* TranslateFeatureType(JOYSTICK::FEATURE_TYPE type);
   static JOYSTICK::FEATURE_TYPE TranslateFeatureType(const std::string& strType);
 
+  static const char* TranslateCategory(JOYSTICK::FEATURE_CATEGORY category);
+  static JOYSTICK::FEATURE_CATEGORY TranslateCategory(const std::string& strCategory);
+
   static const char* TranslateInputType(JOYSTICK::INPUT_TYPE type);
   static JOYSTICK::INPUT_TYPE TranslateInputType(const std::string& strType);
 };

--- a/xbmc/games/controllers/windows/GUIConfigurationWizard.cpp
+++ b/xbmc/games/controllers/windows/GUIConfigurationWizard.cpp
@@ -137,7 +137,7 @@ bool CGUIConfigurationWizard::MapPrimitive(JOYSTICK::IButtonMap* buttonMap, cons
   bool bHandled = false;
 
   // Handle esc key separately
-  if (primitive.Type() == CDriverPrimitive::BUTTON &&
+  if (primitive.Type() == PRIMITIVE_TYPE::BUTTON &&
       primitive.Index() == ESC_KEY_CODE)
   {
     bHandled = Abort(false);

--- a/xbmc/input/joysticks/CMakeLists.txt
+++ b/xbmc/input/joysticks/CMakeLists.txt
@@ -9,7 +9,9 @@ set(HEADERS DefaultJoystick.h
             IButtonMap.h
             IButtonMapper.h
             IDriverHandler.h
+            IDriverReceiver.h
             IInputHandler.h
+            IInputReceiver.h
             IKeymapHandler.h
             JoystickMonitor.h
             JoystickTranslator.h

--- a/xbmc/input/joysticks/CMakeLists.txt
+++ b/xbmc/input/joysticks/CMakeLists.txt
@@ -2,7 +2,8 @@ set(SOURCES DefaultJoystick.cpp
             DriverPrimitive.cpp
             JoystickMonitor.cpp
             JoystickTranslator.cpp
-            KeymapHandler.cpp)
+            KeymapHandler.cpp
+            RumbleGenerator.cpp)
 
 set(HEADERS DefaultJoystick.h
             DriverPrimitive.h
@@ -17,6 +18,7 @@ set(HEADERS DefaultJoystick.h
             JoystickTranslator.h
             JoystickTypes.h
             JoystickUtils.h
-            KeymapHandler.h)
+            KeymapHandler.h
+            RumbleGenerator.h)
 
 core_add_library(input_joystick)

--- a/xbmc/input/joysticks/DefaultJoystick.cpp
+++ b/xbmc/input/joysticks/DefaultJoystick.cpp
@@ -32,7 +32,8 @@
 using namespace JOYSTICK;
 
 CDefaultJoystick::CDefaultJoystick(void) :
-  m_handler(new CKeymapHandler)
+  m_handler(new CKeymapHandler),
+  m_rumbleGenerator(ControllerID())
 {
 }
 

--- a/xbmc/input/joysticks/DefaultJoystick.h
+++ b/xbmc/input/joysticks/DefaultJoystick.h
@@ -21,6 +21,7 @@
 
 #include "IInputHandler.h"
 #include "JoystickTypes.h"
+#include "RumbleGenerator.h"
 
 #include <vector>
 
@@ -51,6 +52,10 @@ namespace JOYSTICK
     virtual bool OnAnalogStickMotion(const FeatureName& feature, float x, float y) override;
     virtual bool OnAccelerometerMotion(const FeatureName& feature, float x, float y, float z) override;
 
+    // Forward rumble commands to rumble generator
+    bool TestRumble(void) { return m_rumbleGenerator.DoTest(InputReceiver()); }
+    void AbortRumble() { return m_rumbleGenerator.AbortRumble(); }
+
   private:
     bool ActivateDirection(const FeatureName& feature, float magnitude, CARDINAL_DIRECTION dir);
     void DeactivateDirection(const FeatureName& feature, CARDINAL_DIRECTION dir);
@@ -72,5 +77,7 @@ namespace JOYSTICK
     static const std::vector<CARDINAL_DIRECTION>& GetDirections(void);
 
     IKeymapHandler* const  m_handler;
+
+    CRumbleGenerator m_rumbleGenerator;
   };
 }

--- a/xbmc/input/joysticks/DefaultJoystick.h
+++ b/xbmc/input/joysticks/DefaultJoystick.h
@@ -53,6 +53,7 @@ namespace JOYSTICK
     virtual bool OnAccelerometerMotion(const FeatureName& feature, float x, float y, float z) override;
 
     // Forward rumble commands to rumble generator
+    void NotifyUser(void) { m_rumbleGenerator.NotifyUser(InputReceiver()); }
     bool TestRumble(void) { return m_rumbleGenerator.DoTest(InputReceiver()); }
     void AbortRumble() { return m_rumbleGenerator.AbortRumble(); }
 

--- a/xbmc/input/joysticks/DriverPrimitive.cpp
+++ b/xbmc/input/joysticks/DriverPrimitive.cpp
@@ -30,9 +30,9 @@ CDriverPrimitive::CDriverPrimitive(void)
 {
 }
 
-CDriverPrimitive::CDriverPrimitive(unsigned int buttonIndex)
-  : m_type(BUTTON),
-    m_driverIndex(buttonIndex),
+CDriverPrimitive::CDriverPrimitive(PRIMITIVE_TYPE type, unsigned int index)
+  : m_type(type),
+    m_driverIndex(index),
     m_hatDirection(),
     m_semiAxisDirection()
 {
@@ -61,6 +61,7 @@ bool CDriverPrimitive::operator==(const CDriverPrimitive& rhs) const
     switch (m_type)
     {
     case BUTTON:
+    case MOTOR:
       return m_driverIndex == rhs.m_driverIndex;
     case HAT:
       return m_driverIndex == rhs.m_driverIndex && m_hatDirection == rhs.m_hatDirection;
@@ -102,7 +103,7 @@ bool CDriverPrimitive::operator<(const CDriverPrimitive& rhs) const
 
 bool CDriverPrimitive::IsValid(void) const
 {
-  if (m_type == BUTTON)
+  if (m_type == BUTTON || m_type == MOTOR)
     return true;
 
   if (m_type == HAT)

--- a/xbmc/input/joysticks/DriverPrimitive.h
+++ b/xbmc/input/joysticks/DriverPrimitive.h
@@ -55,6 +55,9 @@ namespace JOYSTICK
    *       - driver index
    *       - semiaxis direction (positive/negative)
    *
+   *    Motor:
+   *       - driver index
+   *
    * For more info, see "Chapter 2. Joystick drivers" in the documentation
    * thread: http://forum.kodi.tv/showthread.php?tid=257764
    */
@@ -62,25 +65,14 @@ namespace JOYSTICK
   {
   public:
     /*!
-     * \brief Type of driver primitive
-     */
-    enum PrimitiveType
-    {
-      UNKNOWN = 0, // primitive has no type (invalid)
-      BUTTON,      // a digital button
-      HAT,         // one of the four direction arrows on a D-pad
-      SEMIAXIS,    // the positive or negative half of an axis
-    };
-
-    /*!
      * \brief Construct an invalid driver primitive
      */
     CDriverPrimitive(void);
 
     /*!
-     * \brief Construct a driver primitive representing a button
+     * \brief Construct a driver primitive representing a button or motor
      */
-    CDriverPrimitive(unsigned int buttonIndex);
+    CDriverPrimitive(PRIMITIVE_TYPE type, unsigned int index);
 
     /*!
      * \brief Construct a driver primitive representing one of the four
@@ -105,7 +97,7 @@ namespace JOYSTICK
     /*!
      * \brief The type of driver primitive
      */
-    PrimitiveType Type(void) const { return m_type; }
+    PRIMITIVE_TYPE Type(void) const { return m_type; }
 
     /*!
      * \brief The index used by the driver (valid for all types)
@@ -133,7 +125,7 @@ namespace JOYSTICK
     bool IsValid(void) const;
 
   private:
-    PrimitiveType      m_type;
+    PRIMITIVE_TYPE     m_type;
     unsigned int       m_driverIndex;
     HAT_DIRECTION      m_hatDirection;
     SEMIAXIS_DIRECTION m_semiAxisDirection;

--- a/xbmc/input/joysticks/IDriverReceiver.h
+++ b/xbmc/input/joysticks/IDriverReceiver.h
@@ -1,0 +1,42 @@
+/*
+*      Copyright (C) 2016 Team Kodi
+*      http://kodi.tv
+*
+*  This Program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2, or (at your option)
+*  any later version.
+*
+*  This Program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with this Program; see the file COPYING.  If not, see
+*  <http://www.gnu.org/licenses/>.
+*
+*/
+#pragma once
+
+namespace JOYSTICK
+{
+  /*!
+  * \brief Interface for sending input events to joystick drivers
+  */
+  class IDriverReceiver
+  {
+  public:
+    virtual ~IDriverReceiver(void) { }
+
+    /*!
+    * \brief Set the value of a rumble motor
+    *
+    * \param motorIndex   The driver index of the motor to rumble
+    * \param magnitude    The motor's new magnitude of vibration in the closed interval [0, 1]
+    *
+    * \return True if the event was handled otherwise false
+    */
+    virtual bool SetMotorState(unsigned int motorIndex, float magnitude) = 0;
+  };
+}

--- a/xbmc/input/joysticks/IInputHandler.h
+++ b/xbmc/input/joysticks/IInputHandler.h
@@ -25,12 +25,16 @@
 
 namespace JOYSTICK
 {
+  class IInputReceiver;
+
   /*!
    * \brief Interface for handling input events for game controllers
    */
   class IInputHandler
   {
   public:
+    IInputHandler(void) : m_receiver(nullptr) { }
+
     virtual ~IInputHandler(void) { }
 
     /*!
@@ -93,5 +97,13 @@ namespace JOYSTICK
      * \return True if the event was handled otherwise false
      */
     virtual bool OnAccelerometerMotion(const FeatureName& feature, float x, float y, float z) { return false; }
+
+    // Input receiver interface
+    void SetInputReceiver(IInputReceiver* receiver) { m_receiver = receiver; }
+    void ResetInputReceiver(void) { m_receiver = nullptr; }
+    IInputReceiver* InputReceiver(void) { return m_receiver; }
+
+  private:
+    IInputReceiver* m_receiver;
   };
 }

--- a/xbmc/input/joysticks/IInputReceiver.h
+++ b/xbmc/input/joysticks/IInputReceiver.h
@@ -1,0 +1,44 @@
+/*
+ *      Copyright (C) 2014-2016 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include "JoystickTypes.h"
+
+namespace JOYSTICK
+{
+  /*!
+   * \brief Interface for sending input events to game controllers
+   */
+  class IInputReceiver
+  {
+  public:
+    virtual ~IInputReceiver(void) { }
+
+    /*!
+     * \brief Set the value of a rumble motor
+     *
+     * \param feature      The name of the motor to rumble
+     * \param magnitude    The motor's new magnitude of vibration in the closed interval [0, 1]
+     *
+     * \return True if the event was handled otherwise false
+     */
+    virtual bool SetRumbleState(const FeatureName& feature, float magnitude) = 0;
+  };
+}

--- a/xbmc/input/joysticks/JoystickTypes.h
+++ b/xbmc/input/joysticks/JoystickTypes.h
@@ -36,6 +36,7 @@ namespace JOYSTICK
    *   1) scalar[1]
    *   2) analog stick
    *   3) accelerometer
+   *   4) rumble motor
    *
    * [1] All three driver primitives (buttons, hats and axes) have a state that
    *     can be represented using a single scalar value. For this reason,
@@ -47,6 +48,22 @@ namespace JOYSTICK
     SCALAR,
     ANALOG_STICK,
     ACCELEROMETER,
+    MOTOR,
+  };
+
+  /*!
+   * \brief Types of categories that features can belong to
+   *
+   * Used to separate lists of features in the GUI.
+   */
+  enum class FEATURE_CATEGORY
+  {
+    UNKNOWN,
+    FACE,
+    SHOULDER,
+    TRIGGERS,
+    ANALOG_STICKS,
+    HAPTICS,
   };
 
   /*!

--- a/xbmc/input/joysticks/JoystickTypes.h
+++ b/xbmc/input/joysticks/JoystickTypes.h
@@ -123,4 +123,16 @@ namespace JOYSTICK
     DIGITAL,
     ANALOG,
   };
+
+  /*!
+  * \brief Type of driver primitive
+  */
+  enum PRIMITIVE_TYPE
+  {
+    UNKNOWN = 0, // primitive has no type (invalid)
+    BUTTON,      // a digital button
+    HAT,         // one of the four direction arrows on a D-pad
+    SEMIAXIS,    // the positive or negative half of an axis
+    MOTOR,       // a rumble motor
+  };
 }

--- a/xbmc/input/joysticks/Makefile
+++ b/xbmc/input/joysticks/Makefile
@@ -3,6 +3,7 @@ SRCS=DefaultJoystick.cpp \
      JoystickMonitor.cpp \
      JoystickTranslator.cpp \
      KeymapHandler.cpp \
+     RumbleGenerator.cpp \
 
 LIB=input_joysticks.a
 

--- a/xbmc/input/joysticks/RumbleGenerator.cpp
+++ b/xbmc/input/joysticks/RumbleGenerator.cpp
@@ -1,0 +1,90 @@
+/*
+ *      Copyright (C) 2016 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "RumbleGenerator.h"
+#include "addons/AddonManager.h"
+#include "games/controllers/Controller.h"
+#include "games/controllers/ControllerFeature.h"
+#include "input/joysticks/IInputReceiver.h"
+
+#define RUMBLE_DURATION_MS     1000
+
+using namespace JOYSTICK;
+
+CRumbleGenerator::CRumbleGenerator(const std::string& controllerId) :
+  CThread("RumbleGenerator"),
+  m_motors(GetMotors(controllerId)),
+  m_receiver(nullptr)
+{
+}
+
+bool CRumbleGenerator::DoTest(IInputReceiver* receiver)
+{
+  if (receiver && !m_motors.empty())
+  {
+    if (IsRunning())
+      StopThread(true);
+
+    m_receiver = receiver;
+    Create();
+
+    return true;
+  }
+  return  false;
+}
+
+void CRumbleGenerator::Process(void)
+{
+  for (const std::string& motor : m_motors)
+  {
+    m_receiver->SetRumbleState(motor, 1.0f);
+
+    Sleep(1000);
+
+    m_receiver->SetRumbleState(motor, 0.0f);
+
+    if (m_bStop)
+      break;
+  }
+}
+
+std::vector<std::string> CRumbleGenerator::GetMotors(const std::string& controllerId)
+{
+  using namespace ADDON;
+  using namespace GAME;
+
+  std::vector<std::string> motors;
+
+  AddonPtr addon;
+  if (CAddonMgr::GetInstance().GetAddon(controllerId, addon, ADDON_GAME_CONTROLLER))
+  {
+    ControllerPtr controller = std::static_pointer_cast<CController>(addon);
+    if (controller->LoadLayout())
+    {
+      for (const CControllerFeature& feature : controller->Layout().Features())
+      {
+        if (feature.Type() == JOYSTICK::FEATURE_TYPE::MOTOR)
+          motors.push_back(feature.Name());
+      }
+    }
+  }
+
+  return motors;
+}

--- a/xbmc/input/joysticks/RumbleGenerator.cpp
+++ b/xbmc/input/joysticks/RumbleGenerator.cpp
@@ -48,6 +48,7 @@ void CRumbleGenerator::NotifyUser(IInputReceiver* receiver)
     Create();
   }
 }
+
 bool CRumbleGenerator::DoTest(IInputReceiver* receiver)
 {
   if (receiver && !m_motors.empty())
@@ -75,6 +76,9 @@ void CRumbleGenerator::Process(void)
 
     Sleep(1000);
 
+    if (m_bStop)
+      break;
+
     for (const std::string& motor : m_motors)
       m_receiver->SetRumbleState(motor, 0.0f);
 
@@ -88,10 +92,10 @@ void CRumbleGenerator::Process(void)
 
       Sleep(1000);
 
-      m_receiver->SetRumbleState(motor, 0.0f);
-
       if (m_bStop)
         break;
+
+      m_receiver->SetRumbleState(motor, 0.0f);
     }
     break;
   }

--- a/xbmc/input/joysticks/RumbleGenerator.h
+++ b/xbmc/input/joysticks/RumbleGenerator.h
@@ -1,0 +1,52 @@
+/*
+ *      Copyright (C) 2016 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include "threads/Thread.h"
+
+namespace JOYSTICK
+{
+  class IInputReceiver;
+
+  class CRumbleGenerator : public CThread
+  {
+  public:
+    CRumbleGenerator(const std::string& controllerId);
+
+    virtual ~CRumbleGenerator(void) { AbortRumble(); }
+
+    bool DoTest(IInputReceiver* receiver);
+
+    void AbortRumble(void) { StopThread(); }
+
+  protected:
+    // implementation of CThread
+    void Process(void);
+
+  private:
+    static std::vector<std::string> GetMotors(const std::string& controllerId);
+
+    // Construction param
+    const std::vector<std::string> m_motors;
+
+    // Test param
+    IInputReceiver* m_receiver;
+  };
+}

--- a/xbmc/input/joysticks/RumbleGenerator.h
+++ b/xbmc/input/joysticks/RumbleGenerator.h
@@ -32,6 +32,7 @@ namespace JOYSTICK
 
     virtual ~CRumbleGenerator(void) { AbortRumble(); }
 
+    void NotifyUser(IInputReceiver* receiver);
     bool DoTest(IInputReceiver* receiver);
 
     void AbortRumble(void) { StopThread(); }
@@ -41,6 +42,13 @@ namespace JOYSTICK
     void Process(void);
 
   private:
+    enum RUMBLE_TYPE
+    {
+      RUMBLE_UNKNOWN,
+      RUMBLE_NOTIFICATION,
+      RUMBLE_TEST,
+    };
+
     static std::vector<std::string> GetMotors(const std::string& controllerId);
 
     // Construction param
@@ -48,5 +56,6 @@ namespace JOYSTICK
 
     // Test param
     IInputReceiver* m_receiver;
+    RUMBLE_TYPE     m_type;
   };
 }

--- a/xbmc/input/joysticks/generic/ButtonMapping.cpp
+++ b/xbmc/input/joysticks/generic/ButtonMapping.cpp
@@ -49,7 +49,7 @@ bool CButtonMapping::OnButtonMotion(unsigned int buttonIndex, bool bPressed)
 {
   if (bPressed)
   {
-    CDriverPrimitive buttonPrimitive(buttonIndex);
+    CDriverPrimitive buttonPrimitive(PRIMITIVE_TYPE::BUTTON, buttonIndex);
     if (buttonPrimitive.IsValid())
     {
       MapPrimitive(buttonPrimitive);

--- a/xbmc/input/joysticks/generic/CMakeLists.txt
+++ b/xbmc/input/joysticks/generic/CMakeLists.txt
@@ -1,8 +1,10 @@
 set(SOURCES ButtonMapping.cpp
+            DriverReceiving.cpp
             FeatureHandling.cpp
             InputHandling.cpp)
 
 set(HEADERS ButtonMapping.h
+            DriverReceiving.h
             FeatureHandling.h
             InputHandling.h)
 

--- a/xbmc/input/joysticks/generic/DriverReceiving.cpp
+++ b/xbmc/input/joysticks/generic/DriverReceiving.cpp
@@ -1,0 +1,49 @@
+/*
+ *      Copyright (C) 2016 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "DriverReceiving.h"
+#include "input/joysticks/DriverPrimitive.h"
+#include "input/joysticks/IButtonMap.h"
+#include "input/joysticks/IDriverReceiver.h"
+
+using namespace JOYSTICK;
+
+CDriverReceiving::CDriverReceiving(IDriverReceiver* receiver, IButtonMap* buttonMap)
+ : m_receiver(receiver),
+   m_buttonMap(buttonMap)
+{
+}
+
+bool CDriverReceiving::SetRumbleState(const FeatureName& feature, float magnitude)
+{
+  bool bHandled = false;
+
+  if (m_receiver != nullptr && m_buttonMap != nullptr)
+  {
+    CDriverPrimitive primitive;
+    if (m_buttonMap->GetScalar(feature, primitive))
+    {
+      if (primitive.Type() == PRIMITIVE_TYPE::MOTOR)
+        bHandled = m_receiver->SetMotorState(primitive.Index(), magnitude);
+    }
+  }
+
+  return bHandled;
+}

--- a/xbmc/input/joysticks/generic/DriverReceiving.h
+++ b/xbmc/input/joysticks/generic/DriverReceiving.h
@@ -1,0 +1,53 @@
+/*
+ *      Copyright (C) 2016 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include "input/joysticks/IInputReceiver.h"
+#include "input/joysticks/JoystickTypes.h"
+
+#include <map>
+
+namespace JOYSTICK
+{
+  class IDriverReceiver;
+  class IButtonMap;
+
+  /*!
+   * \brief Class to translate input events from higher-level features to driver primitives
+   *
+   * A button map is used to translate controller features to driver primitives.
+   * The button map has been abstracted away behind the IButtonMap interface
+   * so that it can be provided by an add-on.
+   */
+  class CDriverReceiving : public IInputReceiver
+  {
+  public:
+    CDriverReceiving(IDriverReceiver* receiver, IButtonMap* buttonMap);
+
+    virtual ~CDriverReceiving(void) { }
+
+    // implementation of IInputReceiver
+    virtual bool SetRumbleState(const FeatureName& feature, float magnitude) override;
+
+  private:
+    IDriverReceiver* const m_receiver;
+    IButtonMap*      const m_buttonMap;
+  };
+}

--- a/xbmc/input/joysticks/generic/InputHandling.cpp
+++ b/xbmc/input/joysticks/generic/InputHandling.cpp
@@ -21,7 +21,6 @@
 #include "InputHandling.h"
 #include "input/joysticks/DriverPrimitive.h"
 #include "input/joysticks/IButtonMap.h"
-#include "input/joysticks/IInputHandler.h"
 #include "input/joysticks/JoystickUtils.h"
 
 using namespace JOYSTICK;
@@ -38,7 +37,7 @@ CInputHandling::~CInputHandling(void)
 
 bool CInputHandling::OnButtonMotion(unsigned int buttonIndex, bool bPressed)
 {
-  return OnDigitalMotion(CDriverPrimitive(buttonIndex), bPressed);
+  return OnDigitalMotion(CDriverPrimitive(PRIMITIVE_TYPE::BUTTON, buttonIndex), bPressed);
 }
 
 bool CInputHandling::OnHatMotion(unsigned int hatIndex, HAT_STATE state)

--- a/xbmc/input/joysticks/generic/Makefile
+++ b/xbmc/input/joysticks/generic/Makefile
@@ -1,4 +1,5 @@
 SRCS=ButtonMapping.cpp \
+     DriverReceiving.cpp \
      FeatureHandling.cpp \
      InputHandling.cpp \
 

--- a/xbmc/peripherals/PeripheralTypes.h
+++ b/xbmc/peripherals/PeripheralTypes.h
@@ -59,6 +59,7 @@ namespace PERIPHERALS
     FEATURE_TUNER,
     FEATURE_IMON,
     FEATURE_JOYSTICK,
+    FEATURE_RUMBLE,
   };
 
   enum PeripheralType

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -727,6 +727,20 @@ bool CPeripherals::GetNextKeypress(float frameTime, CKey &key)
   return false;
 }
 
+bool CPeripherals::TestFeature(PeripheralFeature feature)
+{
+  std::vector<CPeripheral*> peripherals;
+  GetPeripheralsWithFeature(peripherals, feature);
+
+  if (!peripherals.empty())
+  {
+    for (CPeripheral* peripheral : peripherals)
+      peripheral->TestFeature(feature);
+    return true;
+  }
+  return false;
+}
+
 void CPeripherals::ProcessEvents(void)
 {
   std::vector<PeripheralBusPtr> busses;
@@ -876,6 +890,8 @@ void CPeripherals::OnSettingAction(const CSetting *setting)
   }
   else if (settingId == CSettings::SETTING_INPUT_CONTROLLERCONFIG)
     g_windowManager.ActivateWindow(WINDOW_DIALOG_GAME_CONTROLLERS);
+  else if (settingId == CSettings::SETTING_INPUT_TESTRUMBLE)
+    TestFeature(FEATURE_RUMBLE);
 }
 
 void CPeripherals::OnApplicationMessage(KODI::MESSAGING::ThreadMessage* pMsg)

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -727,6 +727,15 @@ bool CPeripherals::GetNextKeypress(float frameTime, CKey &key)
   return false;
 }
 
+void CPeripherals::OnUserNotification()
+{
+  std::vector<CPeripheral*> peripherals;
+  GetPeripheralsWithFeature(peripherals, FEATURE_RUMBLE);
+
+  for (CPeripheral* peripheral : peripherals)
+    peripheral->OnUserNotification();
+}
+
 bool CPeripherals::TestFeature(PeripheralFeature feature)
 {
   std::vector<CPeripheral*> peripherals;

--- a/xbmc/peripherals/Peripherals.h
+++ b/xbmc/peripherals/Peripherals.h
@@ -216,6 +216,12 @@ namespace PERIPHERALS
      */
     EventRateHandle SetEventScanRate(float rateHz) { return m_eventScanner.SetRate(rateHz); }
 
+    /*!
+     * @brief Request peripherals with the specified feature to perform a quick test
+     * @return true if any peripherals support the feature, false otherwise
+     */
+    bool TestFeature(PeripheralFeature feature);
+
     bool SupportsCEC() const
     {
 #if defined(HAVE_LIBCEC)

--- a/xbmc/peripherals/Peripherals.h
+++ b/xbmc/peripherals/Peripherals.h
@@ -217,6 +217,11 @@ namespace PERIPHERALS
     EventRateHandle SetEventScanRate(float rateHz) { return m_eventScanner.SetRate(rateHz); }
 
     /*!
+     * 
+     */
+    void OnUserNotification();
+
+    /*!
      * @brief Request peripherals with the specified feature to perform a quick test
      * @return true if any peripherals support the feature, false otherwise
      */

--- a/xbmc/peripherals/addons/AddonButtonMap.cpp
+++ b/xbmc/peripherals/addons/AddonButtonMap.cpp
@@ -107,7 +107,8 @@ bool CAddonButtonMap::GetScalar(const FeatureName& feature, CDriverPrimitive& pr
   {
     const ADDON::JoystickFeature& addonFeature = it->second;
 
-    if (addonFeature.Type() == JOYSTICK_FEATURE_TYPE_SCALAR)
+    if (addonFeature.Type() == JOYSTICK_FEATURE_TYPE_SCALAR ||
+        addonFeature.Type() == JOYSTICK_FEATURE_TYPE_MOTOR)
     {
       primitive = CPeripheralAddonTranslator::TranslatePrimitive(addonFeature.Primitive());
       retVal = true;
@@ -129,7 +130,9 @@ bool CAddonButtonMap::AddScalar(const FeatureName& feature, const CDriverPrimiti
   {
     UnmapPrimitive(primitive);
 
-    ADDON::JoystickFeature scalar(feature, JOYSTICK_FEATURE_TYPE_SCALAR);
+    const bool bMotor = (primitive.Type() == PRIMITIVE_TYPE::MOTOR);
+
+    ADDON::JoystickFeature scalar(feature, bMotor ? JOYSTICK_FEATURE_TYPE_MOTOR : JOYSTICK_FEATURE_TYPE_SCALAR);
     scalar.SetPrimitive(CPeripheralAddonTranslator::TranslatePrimitive(primitive));
 
     m_features[feature] = scalar;

--- a/xbmc/peripherals/addons/AddonInputHandling.h
+++ b/xbmc/peripherals/addons/AddonInputHandling.h
@@ -20,12 +20,14 @@
 #pragma once
 
 #include "input/joysticks/IDriverHandler.h"
+#include "input/joysticks/IInputReceiver.h"
 
 #include <memory>
 
 namespace JOYSTICK
 {
   class IButtonMap;
+  class IDriverReceiver;
   class IInputHandler;
 }
 
@@ -33,10 +35,11 @@ namespace PERIPHERALS
 {
   class CPeripheral;
 
-  class CAddonInputHandling : public JOYSTICK::IDriverHandler
+  class CAddonInputHandling : public JOYSTICK::IDriverHandler,
+                              public JOYSTICK::IInputReceiver
   {
   public:
-    CAddonInputHandling(CPeripheral* peripheral, JOYSTICK::IInputHandler* handler);
+    CAddonInputHandling(CPeripheral* peripheral, JOYSTICK::IInputHandler* handler, JOYSTICK::IDriverReceiver* receiver);
 
     virtual ~CAddonInputHandling(void);
 
@@ -46,8 +49,12 @@ namespace PERIPHERALS
     virtual bool OnAxisMotion(unsigned int axisIndex, float position) override;
     virtual void ProcessAxisMotions(void) override;
 
+    // implementation of IInputReceiver
+    virtual bool SetRumbleState(const JOYSTICK::FeatureName& feature, float magnitude) override;
+
   private:
     std::unique_ptr<JOYSTICK::IDriverHandler> m_driverHandler;
+    std::unique_ptr<JOYSTICK::IInputReceiver> m_inputReceiver;
     std::unique_ptr<JOYSTICK::IButtonMap>     m_buttonMap;
   };
 }

--- a/xbmc/peripherals/addons/PeripheralAddon.cpp
+++ b/xbmc/peripherals/addons/PeripheralAddon.cpp
@@ -455,6 +455,23 @@ bool CPeripheralAddon::ProcessEvents(void)
   return false;
 }
 
+bool CPeripheralAddon::SendRumbleEvent(unsigned int peripheralIndex, unsigned int driverIndex, float magnitude)
+{
+  bool bHandled = false;
+
+  PERIPHERAL_EVENT eventStruct = { };
+
+  eventStruct.peripheral_index = peripheralIndex;
+  eventStruct.type             = PERIPHERAL_EVENT_TYPE_SET_MOTOR;
+  eventStruct.driver_index     = driverIndex;
+  eventStruct.motor_state      = magnitude;
+
+  try { bHandled = m_pStruct->SendEvent(&eventStruct); }
+  catch (std::exception &e) { LogException(e, "SendEvent()"); }
+
+  return bHandled;
+}
+
 bool CPeripheralAddon::GetJoystickProperties(unsigned int index, CPeripheralJoystick& joystick)
 {
   if (!m_bProvidesJoysticks)
@@ -622,6 +639,7 @@ void CPeripheralAddon::GetJoystickInfo(const CPeripheral* device, ADDON::Joystic
     joystickInfo.SetButtonCount(joystick->ButtonCount());
     joystickInfo.SetHatCount(joystick->HatCount());
     joystickInfo.SetAxisCount(joystick->AxisCount());
+    joystickInfo.SetMotorCount(joystick->MotorCount());
   }
 }
 
@@ -632,6 +650,7 @@ void CPeripheralAddon::SetJoystickInfo(CPeripheralJoystick& joystick, const ADDO
   joystick.SetButtonCount(joystickInfo.ButtonCount());
   joystick.SetHatCount(joystickInfo.HatCount());
   joystick.SetAxisCount(joystickInfo.AxisCount());
+  joystick.SetMotorCount(joystickInfo.MotorCount());
 }
 
 bool CPeripheralAddon::LogError(const PERIPHERAL_ERROR error, const char *strMethod) const

--- a/xbmc/peripherals/addons/PeripheralAddon.cpp
+++ b/xbmc/peripherals/addons/PeripheralAddon.cpp
@@ -590,6 +590,15 @@ void CPeripheralAddon::ResetButtonMap(const CPeripheral* device, const std::stri
   catch (std::exception &e) { LogException(e, "ResetButtonMap()"); return; }
 }
 
+void CPeripheralAddon::PowerOffJoystick(unsigned int index)
+{
+  if (!HasFeature(FEATURE_JOYSTICK))
+    return;
+
+  try { m_pStruct->PowerOffJoystick(index); }
+  catch (std::exception &e) { LogException(e, "PowerOffJoystick()"); return; }
+}
+
 void CPeripheralAddon::RegisterButtonMap(CPeripheral* device, IButtonMap* buttonMap)
 {
   UnregisterButtonMap(buttonMap);
@@ -640,6 +649,7 @@ void CPeripheralAddon::GetJoystickInfo(const CPeripheral* device, ADDON::Joystic
     joystickInfo.SetHatCount(joystick->HatCount());
     joystickInfo.SetAxisCount(joystick->AxisCount());
     joystickInfo.SetMotorCount(joystick->MotorCount());
+    joystickInfo.SetSupportsPowerOff(joystick->SupportsPowerOff());
   }
 }
 
@@ -651,6 +661,7 @@ void CPeripheralAddon::SetJoystickInfo(CPeripheralJoystick& joystick, const ADDO
   joystick.SetHatCount(joystickInfo.HatCount());
   joystick.SetAxisCount(joystickInfo.AxisCount());
   joystick.SetMotorCount(joystickInfo.MotorCount());
+  joystick.SetSupportsPowerOff(joystickInfo.SupportsPowerOff());
 }
 
 bool CPeripheralAddon::LogError(const PERIPHERAL_ERROR error, const char *strMethod) const

--- a/xbmc/peripherals/addons/PeripheralAddon.cpp
+++ b/xbmc/peripherals/addons/PeripheralAddon.cpp
@@ -32,6 +32,7 @@
 #include "peripherals/Peripherals.h"
 #include "peripherals/bus/virtual/PeripheralBusAddon.h"
 #include "peripherals/devices/PeripheralJoystick.h"
+#include "settings/Settings.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
 
@@ -71,7 +72,20 @@ CPeripheralAddon::~CPeripheralAddon(void)
 {
   // delete all peripherals provided by this addon
   for (const auto& peripheral : m_peripherals)
+  {
+    if (CSettings::GetInstance().GetBool(CSettings::SETTING_INPUT_CONTROLLERPOWEROFF))
+    {
+      // shutdown the joystick if it is supported
+      if (peripheral.second->Type() == PERIPHERAL_JOYSTICK)
+      {
+        CPeripheralJoystick* joystick = static_cast<CPeripheralJoystick*>(peripheral.second);
+        if (joystick->SupportsPowerOff())
+          PowerOffJoystick(peripheral.first);
+      }
+    }
+
     delete peripheral.second;
+  }
   m_peripherals.clear();
 
   // only clear buttonMaps but don't delete them as they are owned by a CAddonJoystickInputHandling instance

--- a/xbmc/peripherals/addons/PeripheralAddon.h
+++ b/xbmc/peripherals/addons/PeripheralAddon.h
@@ -75,6 +75,7 @@ namespace PERIPHERALS
     //@{
     bool PerformDeviceScan(PeripheralScanResults &results);
     bool ProcessEvents(void);
+    bool SendRumbleEvent(unsigned int index, unsigned int driverIndex, float magnitude);
     //@}
 
     /** @name Joystick methods */

--- a/xbmc/peripherals/addons/PeripheralAddon.h
+++ b/xbmc/peripherals/addons/PeripheralAddon.h
@@ -85,6 +85,7 @@ namespace PERIPHERALS
     bool GetFeatures(const CPeripheral* device, const std::string& strControllerId, FeatureMap& features);
     bool MapFeatures(const CPeripheral* device, const std::string& strControllerId, const FeatureMap& features);
     void ResetButtonMap(const CPeripheral* device, const std::string& strControllerId);
+    void PowerOffJoystick(unsigned int index);
     //@}
 
     void RegisterButtonMap(CPeripheral* device, JOYSTICK::IButtonMap* buttonMap);

--- a/xbmc/peripherals/addons/PeripheralAddonTranslator.cpp
+++ b/xbmc/peripherals/addons/PeripheralAddonTranslator.cpp
@@ -63,7 +63,7 @@ CDriverPrimitive CPeripheralAddonTranslator::TranslatePrimitive(const ADDON::Dri
   {
     case JOYSTICK_DRIVER_PRIMITIVE_TYPE_BUTTON:
     {
-      retVal = CDriverPrimitive(primitive.DriverIndex());
+      retVal = CDriverPrimitive(PRIMITIVE_TYPE::BUTTON, primitive.DriverIndex());
       break;
     }
     case JOYSTICK_DRIVER_PRIMITIVE_TYPE_HAT_DIRECTION:
@@ -74,6 +74,11 @@ CDriverPrimitive CPeripheralAddonTranslator::TranslatePrimitive(const ADDON::Dri
     case JOYSTICK_DRIVER_PRIMITIVE_TYPE_SEMIAXIS:
     {
       retVal = CDriverPrimitive(primitive.DriverIndex(), TranslateSemiAxisDirection(primitive.SemiAxisDirection()));
+      break;
+    }
+    case JOYSTICK_DRIVER_PRIMITIVE_TYPE_MOTOR:
+    {
+      retVal = CDriverPrimitive(PRIMITIVE_TYPE::MOTOR, primitive.DriverIndex());
       break;
     }
     default:
@@ -89,19 +94,24 @@ ADDON::DriverPrimitive CPeripheralAddonTranslator::TranslatePrimitive(const CDri
 
   switch (primitive.Type())
   {
-    case CDriverPrimitive::BUTTON:
+    case BUTTON:
     {
-      retVal = ADDON::DriverPrimitive(primitive.Index());
+      retVal = ADDON::DriverPrimitive::CreateButton(primitive.Index());
       break;
     }
-    case CDriverPrimitive::HAT:
+    case HAT:
     {
       retVal = ADDON::DriverPrimitive(primitive.Index(), TranslateHatDirection(primitive.HatDirection()));
       break;
     }
-    case CDriverPrimitive::SEMIAXIS:
+    case SEMIAXIS:
     {
       retVal = ADDON::DriverPrimitive(primitive.Index(), TranslateSemiAxisDirection(primitive.SemiAxisDirection()));
+      break;
+    }
+    case MOTOR:
+    {
+      retVal = ADDON::DriverPrimitive::CreateMotor(primitive.Index());
       break;
     }
     default:
@@ -182,6 +192,7 @@ JOYSTICK::FEATURE_TYPE CPeripheralAddonTranslator::TranslateFeatureType(JOYSTICK
     case JOYSTICK_FEATURE_TYPE_SCALAR:        return JOYSTICK::FEATURE_TYPE::SCALAR;
     case JOYSTICK_FEATURE_TYPE_ANALOG_STICK:  return JOYSTICK::FEATURE_TYPE::ANALOG_STICK;
     case JOYSTICK_FEATURE_TYPE_ACCELEROMETER: return JOYSTICK::FEATURE_TYPE::ACCELEROMETER;
+    case JOYSTICK_FEATURE_TYPE_MOTOR:         return JOYSTICK::FEATURE_TYPE::MOTOR;
     default:
       break;
   }
@@ -195,6 +206,7 @@ JOYSTICK_FEATURE_TYPE CPeripheralAddonTranslator::TranslateFeatureType(JOYSTICK:
     case JOYSTICK::FEATURE_TYPE::SCALAR:        return JOYSTICK_FEATURE_TYPE_SCALAR;
     case JOYSTICK::FEATURE_TYPE::ANALOG_STICK:  return JOYSTICK_FEATURE_TYPE_ANALOG_STICK;
     case JOYSTICK::FEATURE_TYPE::ACCELEROMETER: return JOYSTICK_FEATURE_TYPE_ACCELEROMETER;
+    case JOYSTICK::FEATURE_TYPE::MOTOR:         return JOYSTICK_FEATURE_TYPE_MOTOR;
     default:
       break;
   }

--- a/xbmc/peripherals/bus/virtual/PeripheralBusAddon.cpp
+++ b/xbmc/peripherals/bus/virtual/PeripheralBusAddon.cpp
@@ -135,6 +135,18 @@ bool CPeripheralBusAddon::InitializeProperties(CPeripheral* peripheral)
   return bSuccess;
 }
 
+bool CPeripheralBusAddon::SendRumbleEvent(const std::string& strLocation, unsigned int motorIndex, float magnitude)
+{
+  bool bHandled = false;
+
+  PeripheralAddonPtr addon;
+  unsigned int peripheralIndex;
+  if (SplitLocation(strLocation, addon, peripheralIndex))
+    bHandled = addon->SendRumbleEvent(peripheralIndex, motorIndex, magnitude);
+
+  return bHandled;
+}
+
 void CPeripheralBusAddon::ProcessEvents(void)
 {
   PeripheralAddonVector addons;

--- a/xbmc/peripherals/bus/virtual/PeripheralBusAddon.h
+++ b/xbmc/peripherals/bus/virtual/PeripheralBusAddon.h
@@ -60,6 +60,19 @@ namespace PERIPHERALS
      */
     bool InitializeProperties(CPeripheral* peripheral);
 
+    /*!
+     * \brief Set the rumble state of a rumble motor
+     *
+     * \param strLocation The location of the peripheral with the motor
+     * \param motorIndex  The index of the motor being rumbled
+     * \param magnitude   The amount of vibration in the closed interval [0.0, 1.0]
+     *
+     * \return true if the rumble motor's state is set, false otherwise
+     *
+     * TODO: Move declaration to parent class
+     */
+    bool SendRumbleEvent(const std::string& strLocation, unsigned int motorIndex, float magnitude);
+
     // Inherited from CPeripheralBus
     virtual void         Register(CPeripheral *peripheral) override;
     virtual void         GetFeatures(std::vector<PeripheralFeature> &features) const override;
@@ -70,6 +83,7 @@ namespace PERIPHERALS
     virtual size_t       GetNumberOfPeripherals(void) const override;
     virtual size_t       GetNumberOfPeripheralsWithId(const int iVendorId, const int iProductId) const override;
     virtual void         GetDirectory(const std::string &strPath, CFileItemList &items) const override;
+    virtual void         ProcessEvents(void) override;
 
     // implementation of IAddonMgrCallback
     bool RequestRestart(ADDON::AddonPtr addon, bool datachanged) override;
@@ -81,7 +95,6 @@ namespace PERIPHERALS
     // Inherited from CPeripheralBus
     virtual bool PerformDeviceScan(PeripheralScanResults &results) override;
     virtual void UnregisterRemovedDevices(const PeripheralScanResults &results) override;
-    virtual void ProcessEvents(void) override;
 
   private:
     void UpdateAddons(void);

--- a/xbmc/peripherals/devices/Peripheral.cpp
+++ b/xbmc/peripherals/devices/Peripheral.cpp
@@ -23,6 +23,7 @@
 #include <utility>
 
 #include "guilib/LocalizeStrings.h"
+#include "input/joysticks/IInputHandler.h"
 #include "peripherals/Peripherals.h"
 #include "settings/lib/Setting.h"
 #include "peripherals/addons/AddonButtonMapping.h"
@@ -543,22 +544,21 @@ void CPeripheral::ClearSettings(void)
 
 void CPeripheral::RegisterJoystickInputHandler(IInputHandler* handler)
 {
-  std::map<IInputHandler*, IDriverHandler*>::iterator it = m_inputHandlers.find(handler);
+  auto it = m_inputHandlers.find(handler);
   if (it == m_inputHandlers.end())
   {
-    CAddonInputHandling* inputHandling = new CAddonInputHandling(this, handler);
-    RegisterJoystickDriverHandler(inputHandling, false);
-    m_inputHandlers[handler] = inputHandling;
+    CAddonInputHandling* addonInput = new CAddonInputHandling(this, handler, GetDriverReceiver());
+    RegisterJoystickDriverHandler(addonInput, false);
+    m_inputHandlers[handler].reset(addonInput);
   }
 }
 
 void CPeripheral::UnregisterJoystickInputHandler(IInputHandler* handler)
 {
-  std::map<IInputHandler*, IDriverHandler*>::iterator it = m_inputHandlers.find(handler);
+  auto it = m_inputHandlers.find(handler);
   if (it != m_inputHandlers.end())
   {
-    UnregisterJoystickDriverHandler(it->second);
-    delete it->second;
+    UnregisterJoystickDriverHandler(it->second.get());
     m_inputHandlers.erase(it);
   }
 }
@@ -568,7 +568,7 @@ void CPeripheral::RegisterJoystickButtonMapper(IButtonMapper* mapper)
   std::map<IButtonMapper*, IDriverHandler*>::iterator it = m_buttonMappers.find(mapper);
   if (it == m_buttonMappers.end())
   {
-    CAddonButtonMapping* addonMapping = new CAddonButtonMapping(this, mapper);
+    IDriverHandler* addonMapping = new CAddonButtonMapping(this, mapper);
     RegisterJoystickDriverHandler(addonMapping, false);
     m_buttonMappers[mapper] = addonMapping;
   }

--- a/xbmc/peripherals/devices/Peripheral.h
+++ b/xbmc/peripherals/devices/Peripheral.h
@@ -101,6 +101,11 @@ namespace PERIPHERALS
     virtual bool InitialiseFeature(const PeripheralFeature feature) { return true; }
 
     /*!
+    * @brief Briefly activate a feature to notify the user
+    */
+    virtual void OnUserNotification() { }
+
+    /*!
      * @brief Briefly test one of the features of this peripheral.
      * @param feature The feature to test.
      * @return True if the test succeeded, false otherwise.

--- a/xbmc/peripherals/devices/Peripheral.h
+++ b/xbmc/peripherals/devices/Peripheral.h
@@ -101,6 +101,13 @@ namespace PERIPHERALS
     virtual bool InitialiseFeature(const PeripheralFeature feature) { return true; }
 
     /*!
+     * @brief Briefly test one of the features of this peripheral.
+     * @param feature The feature to test.
+     * @return True if the test succeeded, false otherwise.
+     */
+    virtual bool TestFeature(PeripheralFeature feature) { return false; }
+
+    /*!
      * @brief Called when a setting changed.
      * @param strChangedSetting The changed setting.
      */

--- a/xbmc/peripherals/devices/Peripheral.h
+++ b/xbmc/peripherals/devices/Peripheral.h
@@ -32,6 +32,7 @@ namespace JOYSTICK
 {
   class IButtonMapper;
   class IDriverHandler;
+  class IDriverReceiver;
   class IInputHandler;
 }
 
@@ -181,6 +182,8 @@ namespace PERIPHERALS
     virtual void RegisterJoystickButtonMapper(JOYSTICK::IButtonMapper* mapper);
     virtual void UnregisterJoystickButtonMapper(JOYSTICK::IButtonMapper* mapper);
 
+    virtual JOYSTICK::IDriverReceiver* GetDriverReceiver() { return nullptr; }
+
   protected:
     virtual void ClearSettings(void);
 
@@ -204,7 +207,7 @@ namespace PERIPHERALS
     std::map<std::string, PeripheralDeviceSetting> m_settings;
     std::set<std::string>             m_changedSettings;
     CPeripheralBus*                  m_bus;
-    std::map<JOYSTICK::IInputHandler*, JOYSTICK::IDriverHandler*> m_inputHandlers;
+    std::map<JOYSTICK::IInputHandler*, std::unique_ptr<JOYSTICK::IDriverHandler>> m_inputHandlers;
     std::map<JOYSTICK::IButtonMapper*, JOYSTICK::IDriverHandler*> m_buttonMappers;
   };
 }

--- a/xbmc/peripherals/devices/PeripheralJoystick.cpp
+++ b/xbmc/peripherals/devices/PeripheralJoystick.cpp
@@ -36,7 +36,8 @@ CPeripheralJoystick::CPeripheralJoystick(const PeripheralScanResult& scanResult,
   m_buttonCount(0),
   m_hatCount(0),
   m_axisCount(0),
-  m_motorCount(0)
+  m_motorCount(0),
+  m_supportsPowerOff(false)
 {
   m_features.push_back(FEATURE_JOYSTICK);
   // FEATURE_RUMBLE conditionally added via SetMotorCount()

--- a/xbmc/peripherals/devices/PeripheralJoystick.cpp
+++ b/xbmc/peripherals/devices/PeripheralJoystick.cpp
@@ -35,9 +35,11 @@ CPeripheralJoystick::CPeripheralJoystick(const PeripheralScanResult& scanResult,
   m_requestedPort(JOYSTICK_PORT_UNKNOWN),
   m_buttonCount(0),
   m_hatCount(0),
-  m_axisCount(0)
+  m_axisCount(0),
+  m_motorCount(0)
 {
   m_features.push_back(FEATURE_JOYSTICK);
+  // FEATURE_RUMBLE conditionally added via SetMotorCount()
 }
 
 CPeripheralJoystick::~CPeripheralJoystick(void)
@@ -78,6 +80,10 @@ bool CPeripheralJoystick::InitialiseFeature(const PeripheralFeature feature)
         }
       }
 #endif
+    }
+    else if (feature == FEATURE_RUMBLE)
+    {
+      bSuccess = true; // Nothing to do
     }
   }
 
@@ -218,4 +224,29 @@ void CPeripheralJoystick::ProcessAxisMotions(void)
 
   for (std::vector<DriverHandler>::iterator it = m_driverHandlers.begin(); it != m_driverHandlers.end(); ++it)
     it->handler->ProcessAxisMotions();
+}
+
+bool CPeripheralJoystick::SetMotorState(unsigned int motorIndex, float magnitude)
+{
+  bool bHandled = false;
+
+  if (m_mappedBusType == PERIPHERAL_BUS_ADDON)
+  {
+    CPeripheralBusAddon* addonBus = static_cast<CPeripheralBusAddon*>(m_bus);
+    if (addonBus)
+    {
+      bHandled = addonBus->SendRumbleEvent(m_strLocation, motorIndex, magnitude);
+    }
+  }
+  return bHandled;
+}
+
+void CPeripheralJoystick::SetMotorCount(unsigned int motorCount)
+{
+  m_motorCount = motorCount;
+
+  if (m_motorCount == 0)
+    m_features.erase(std::remove(m_features.begin(), m_features.end(), FEATURE_RUMBLE), m_features.end());
+  else if (std::find(m_features.begin(), m_features.end(), FEATURE_RUMBLE) == m_features.end())
+    m_features.push_back(FEATURE_RUMBLE);
 }

--- a/xbmc/peripherals/devices/PeripheralJoystick.cpp
+++ b/xbmc/peripherals/devices/PeripheralJoystick.cpp
@@ -98,6 +98,11 @@ bool CPeripheralJoystick::InitialiseFeature(const PeripheralFeature feature)
   return bSuccess;
 }
 
+void CPeripheralJoystick::OnUserNotification()
+{
+  m_defaultInputHandler.NotifyUser();
+}
+
 bool CPeripheralJoystick::TestFeature(PeripheralFeature feature)
 {
   bool bSuccess = false;

--- a/xbmc/peripherals/devices/PeripheralJoystick.cpp
+++ b/xbmc/peripherals/devices/PeripheralJoystick.cpp
@@ -44,6 +44,7 @@ CPeripheralJoystick::CPeripheralJoystick(const PeripheralScanResult& scanResult,
 
 CPeripheralJoystick::~CPeripheralJoystick(void)
 {
+  m_defaultInputHandler.AbortRumble();
   UnregisterJoystickInputHandler(&m_defaultInputHandler);
   UnregisterJoystickDriverHandler(&m_joystickMonitor);
 }
@@ -92,6 +93,22 @@ bool CPeripheralJoystick::InitialiseFeature(const PeripheralFeature feature)
     // Give joystick monitor priority over default controller
     RegisterJoystickInputHandler(&m_defaultInputHandler);
     RegisterJoystickDriverHandler(&m_joystickMonitor, false);
+  }
+
+  return bSuccess;
+}
+
+bool CPeripheralJoystick::TestFeature(PeripheralFeature feature)
+{
+  bool bSuccess = false;
+
+  switch (feature)
+  {
+  case FEATURE_RUMBLE:
+    bSuccess = m_defaultInputHandler.TestRumble();
+    break;
+  default:
+    break;
   }
 
   return bSuccess;

--- a/xbmc/peripherals/devices/PeripheralJoystick.h
+++ b/xbmc/peripherals/devices/PeripheralJoystick.h
@@ -45,6 +45,7 @@ namespace PERIPHERALS
 
     // implementation of CPeripheral
     virtual bool InitialiseFeature(const PeripheralFeature feature) override;
+    virtual bool TestFeature(PeripheralFeature feature) override;
     virtual void RegisterJoystickDriverHandler(IDriverHandler* handler, bool bPromiscuous) override;
     virtual void UnregisterJoystickDriverHandler(IDriverHandler* handler) override;
     virtual JOYSTICK::IDriverReceiver* GetDriverReceiver() override { return this; }

--- a/xbmc/peripherals/devices/PeripheralJoystick.h
+++ b/xbmc/peripherals/devices/PeripheralJoystick.h
@@ -45,6 +45,7 @@ namespace PERIPHERALS
 
     // implementation of CPeripheral
     virtual bool InitialiseFeature(const PeripheralFeature feature) override;
+    virtual void OnUserNotification() override;
     virtual bool TestFeature(PeripheralFeature feature) override;
     virtual void RegisterJoystickDriverHandler(IDriverHandler* handler, bool bPromiscuous) override;
     virtual void UnregisterJoystickDriverHandler(IDriverHandler* handler) override;

--- a/xbmc/peripherals/devices/PeripheralJoystick.h
+++ b/xbmc/peripherals/devices/PeripheralJoystick.h
@@ -83,6 +83,7 @@ namespace PERIPHERALS
     unsigned int HatCount(void) const    { return m_hatCount; }
     unsigned int AxisCount(void) const   { return m_axisCount; }
     unsigned int MotorCount(void) const  { return m_motorCount; }
+    bool SupportsPowerOff(void) const    { return m_supportsPowerOff; }
 
     /*!
      * \brief Set joystick properties
@@ -93,6 +94,7 @@ namespace PERIPHERALS
     void SetHatCount(unsigned int hatCount)       { m_hatCount      = hatCount; }
     void SetAxisCount(unsigned int axisCount)     { m_axisCount     = axisCount; }
     void SetMotorCount(unsigned int motorCount); // specialized to update m_features
+    void SetSupportsPowerOff(bool supportsPowerOff) { m_supportsPowerOff = supportsPowerOff; }
 
   protected:
     struct DriverHandler
@@ -107,6 +109,7 @@ namespace PERIPHERALS
     unsigned int                        m_hatCount;
     unsigned int                        m_axisCount;
     unsigned int                        m_motorCount;
+    bool                                m_supportsPowerOff;
     JOYSTICK::CDefaultJoystick          m_defaultInputHandler;
     JOYSTICK::CJoystickMonitor          m_joystickMonitor;
     std::vector<DriverHandler>          m_driverHandlers;

--- a/xbmc/peripherals/devices/PeripheralJoystick.h
+++ b/xbmc/peripherals/devices/PeripheralJoystick.h
@@ -22,6 +22,7 @@
 #include "Peripheral.h"
 #include "input/joysticks/DefaultJoystick.h"
 #include "input/joysticks/IDriverHandler.h"
+#include "input/joysticks/IDriverReceiver.h"
 #include "input/joysticks/JoystickMonitor.h"
 #include "input/joysticks/JoystickTypes.h"
 #include "threads/CriticalSection.h"
@@ -34,7 +35,8 @@
 namespace PERIPHERALS
 {
   class CPeripheralJoystick : public CPeripheral, //! @todo extend CPeripheralHID
-                              public JOYSTICK::IDriverHandler
+                              public JOYSTICK::IDriverHandler,
+                              public JOYSTICK::IDriverReceiver
   {
   public:
     CPeripheralJoystick(const PeripheralScanResult& scanResult, CPeripheralBus* bus);
@@ -45,12 +47,16 @@ namespace PERIPHERALS
     virtual bool InitialiseFeature(const PeripheralFeature feature) override;
     virtual void RegisterJoystickDriverHandler(IDriverHandler* handler, bool bPromiscuous) override;
     virtual void UnregisterJoystickDriverHandler(IDriverHandler* handler) override;
+    virtual JOYSTICK::IDriverReceiver* GetDriverReceiver() override { return this; }
 
     // implementation of IDriverHandler
     virtual bool OnButtonMotion(unsigned int buttonIndex, bool bPressed) override;
     virtual bool OnHatMotion(unsigned int hatIndex, JOYSTICK::HAT_STATE state) override;
     virtual bool OnAxisMotion(unsigned int axisIndex, float position) override;
     virtual void ProcessAxisMotions(void) override;
+
+    // implementation of IDriverReceiver
+    virtual bool SetMotorState(unsigned int motorIndex, float magnitude) override;
 
     /*!
      * \brief Get the name of the driver or API providing this joystick
@@ -74,18 +80,23 @@ namespace PERIPHERALS
     unsigned int ButtonCount(void) const { return m_buttonCount; }
     unsigned int HatCount(void) const    { return m_hatCount; }
     unsigned int AxisCount(void) const   { return m_axisCount; }
+    unsigned int MotorCount(void) const  { return m_motorCount; }
 
+    /*!
+     * \brief Set joystick properties
+     */
     void SetProvider(const std::string& provider) { m_strProvider   = provider; }
     void SetRequestedPort(int port)               { m_requestedPort = port; }
     void SetButtonCount(unsigned int buttonCount) { m_buttonCount   = buttonCount; }
     void SetHatCount(unsigned int hatCount)       { m_hatCount      = hatCount; }
     void SetAxisCount(unsigned int axisCount)     { m_axisCount     = axisCount; }
+    void SetMotorCount(unsigned int motorCount); // specialized to update m_features
 
   protected:
     struct DriverHandler
     {
       JOYSTICK::IDriverHandler* handler;
-      bool                              bPromiscuous;
+      bool                      bPromiscuous;
     };
 
     std::string                         m_strProvider;
@@ -93,6 +104,7 @@ namespace PERIPHERALS
     unsigned int                        m_buttonCount;
     unsigned int                        m_hatCount;
     unsigned int                        m_axisCount;
+    unsigned int                        m_motorCount;
     JOYSTICK::CDefaultJoystick          m_defaultInputHandler;
     JOYSTICK::CJoystickMonitor          m_joystickMonitor;
     std::vector<DriverHandler>          m_driverHandlers;

--- a/xbmc/settings/SettingConditions.cpp
+++ b/xbmc/settings/SettingConditions.cpp
@@ -88,6 +88,15 @@ bool SupportsPeripheralControllers(const std::string &condition, const std::stri
   return bus != nullptr && bus->HasFeature(FEATURE_JOYSTICK);
 }
 
+bool HasRumbleFeature(const std::string &condition, const std::string &value, const CSetting *setting, void *data)
+{
+  using namespace PERIPHERALS;
+
+  std::vector<CPeripheral*> results;
+  g_peripherals.GetPeripheralsWithFeature(results, FEATURE_RUMBLE);
+  return !results.empty();
+}
+
 bool IsFullscreen(const std::string &condition, const std::string &value, const CSetting *setting, void *data)
 {
   return g_Windowing.IsFullScreen();
@@ -342,6 +351,7 @@ void CSettingConditions::Initialize()
   m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("checkpvrparentalpin",           CheckPVRParentalPin));
   m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("hasperipherals",                HasPeripherals));
   m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("supportsperipheralcontrollers", SupportsPeripheralControllers));
+  m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("hasrumblefeature",              HasRumbleFeature));
   m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("isfullscreen",                  IsFullscreen));
   m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("ismasteruser",                  IsMasterUser));
   m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("isusingttfsubtitles",           IsUsingTTFSubtitles));

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -372,6 +372,7 @@ const std::string CSettings::SETTING_INPUT_PERIPHERALS = "input.peripherals";
 const std::string CSettings::SETTING_INPUT_ENABLEMOUSE = "input.enablemouse";
 const std::string CSettings::SETTING_INPUT_CONTROLLERCONFIG = "input.controllerconfig";
 const std::string CSettings::SETTING_INPUT_TESTRUMBLE = "input.testrumble";
+const std::string CSettings::SETTING_INPUT_CONTROLLERPOWEROFF = "input.controllerpoweroff";
 const std::string CSettings::SETTING_INPUT_APPLEREMOTEMODE = "input.appleremotemode";
 const std::string CSettings::SETTING_INPUT_APPLEREMOTEALWAYSON = "input.appleremotealwayson";
 const std::string CSettings::SETTING_INPUT_APPLEREMOTESEQUENCETIME = "input.appleremotesequencetime";

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -371,6 +371,7 @@ const std::string CSettings::SETTING_AUDIOOUTPUT_VOLUMESTEPS = "audiooutput.volu
 const std::string CSettings::SETTING_INPUT_PERIPHERALS = "input.peripherals";
 const std::string CSettings::SETTING_INPUT_ENABLEMOUSE = "input.enablemouse";
 const std::string CSettings::SETTING_INPUT_CONTROLLERCONFIG = "input.controllerconfig";
+const std::string CSettings::SETTING_INPUT_TESTRUMBLE = "input.testrumble";
 const std::string CSettings::SETTING_INPUT_APPLEREMOTEMODE = "input.appleremotemode";
 const std::string CSettings::SETTING_INPUT_APPLEREMOTEALWAYSON = "input.appleremotealwayson";
 const std::string CSettings::SETTING_INPUT_APPLEREMOTESEQUENCETIME = "input.appleremotesequencetime";
@@ -1176,6 +1177,7 @@ void CSettings::InitializeISettingCallbacks()
   settingSet.clear();
   settingSet.insert(CSettings::SETTING_INPUT_PERIPHERALS);
   settingSet.insert(CSettings::SETTING_INPUT_CONTROLLERCONFIG);
+  settingSet.insert(CSettings::SETTING_INPUT_TESTRUMBLE);
   settingSet.insert(CSettings::SETTING_LOCALE_LANGUAGE);
   m_settingsManager->RegisterCallback(&PERIPHERALS::CPeripherals::GetInstance(), settingSet);
 

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -329,6 +329,7 @@ public:
   static const std::string SETTING_INPUT_ENABLEMOUSE;
   static const std::string SETTING_INPUT_CONTROLLERCONFIG;
   static const std::string SETTING_INPUT_TESTRUMBLE;
+  static const std::string SETTING_INPUT_CONTROLLERPOWEROFF;
   static const std::string SETTING_INPUT_APPLEREMOTEMODE;
   static const std::string SETTING_INPUT_APPLEREMOTEALWAYSON;
   static const std::string SETTING_INPUT_APPLEREMOTESEQUENCETIME;

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -328,6 +328,7 @@ public:
   static const std::string SETTING_INPUT_PERIPHERALS;
   static const std::string SETTING_INPUT_ENABLEMOUSE;
   static const std::string SETTING_INPUT_CONTROLLERCONFIG;
+  static const std::string SETTING_INPUT_TESTRUMBLE;
   static const std::string SETTING_INPUT_APPLEREMOTEMODE;
   static const std::string SETTING_INPUT_APPLEREMOTEALWAYSON;
   static const std::string SETTING_INPUT_APPLEREMOTESEQUENCETIME;


### PR DESCRIPTION
This PR activates controller rumble motors when the user receives a notification. Also, thanks to Montellese, we have the ability to power off controllers on exit.

Two settings are added:
- "Test rumble"
- "Power off controllers on exit"

This PR currently relies on the [retroplayer](https://github.com/kodi-game/peripheral.joystick/tree/retroplayer) branch of peripheral.joystick. These changes will be merged to master when this PR is merged.

ATM, rumble and power-off-on-exit are only supported via the XInput API on windows. Additional APIs can be added at a later date independent of Kodi.
