### PR TITLE
Add support for musl-based toolchains

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -526,7 +526,7 @@ case $host in
      use_x11=no
      build_shared_lib=yes
      ;;
-  i*86*-linux-gnu*|i*86*-*-linux-uclibc*)
+  i*86*-linux-gnu*|i*86*-*-linux-uclibc*|i*86*-*-linux-musl*)
      target_platform=target_linux
      CORE_SYSTEM_NAME=linux
      ARCH="i486-linux"
@@ -549,7 +549,7 @@ case $host in
        fi
      fi
      ;;
-  x86_64-*-linux-gnu*|x86_64-*-linux-uclibc*)
+  x86_64-*-linux-gnu*|x86_64-*-linux-uclibc*|x86_64-*-linux-musl*)
      target_platform=target_linux
      CORE_SYSTEM_NAME=linux
      ARCH="x86_64-linux"
@@ -601,17 +601,17 @@ case $host in
      DEPENDS_ROOT_FOR_XCODE=$(echo ${prefix%/*})
      AC_SUBST([DEPENDS_ROOT_FOR_XCODE])
      ;;
-  powerpc-*-linux-gnu*|powerpc-*-linux-uclibc*)
+  powerpc-*-linux-gnu*|powerpc-*-linux-uclibc*|powerpc-*-linux-musl*)
      target_platform=target_linux
      CORE_SYSTEM_NAME=linux
      ARCH="powerpc-linux"
      ;;
-  powerpc64*-*-linux-gnu*|powerpc64*-*-linux-uclibc*)
+  powerpc64*-*-linux-gnu*|powerpc64*-*-linux-uclibc*|powerpc64*-*-linux-musl*)
      target_platform=target_linux
      CORE_SYSTEM_NAME=linux
      ARCH="powerpc64-linux"
      ;;
-  arm*-*-linux-gnu*|arm*-*-linux-uclibc*)
+  arm*-*-linux-gnu*|arm*-*-linux-uclibc*|arm*-*-linux-musl*)
      target_platform=target_linux
      CORE_SYSTEM_NAME=linux
      ARCH="arm"

--- a/m4/xbmc_arch.m4
+++ b/m4/xbmc_arch.m4
@@ -2,8 +2,14 @@ AC_DEFUN([XBMC_SETUP_ARCH_DEFINES],[
 
 # build detection and setup - this is the native arch
 case $build in
+  i*86*-*-linux-musl*)
+     AC_SUBST(NATIVE_ARCH_DEFINES, "-DTARGET_POSIX -DTARGET_LINUX -D_LINUX -D_MUSL")
+     ;;
   i*86*-linux-gnu*|i*86*-*-linux-uclibc*)
      AC_SUBST(NATIVE_ARCH_DEFINES, "-DTARGET_POSIX -DTARGET_LINUX -D_LINUX")
+     ;;
+  x86_64-*-linux-musl*)
+     AC_SUBST(NATIVE_ARCH_DEFINES, "-DTARGET_POSIX -DTARGET_LINUX -D_LINUX -D_MUSL")
      ;;
   x86_64-*-linux-gnu*|x86_64-*-linux-uclibc*)
      AC_SUBST(NATIVE_ARCH_DEFINES, "-DTARGET_POSIX -DTARGET_LINUX -D_LINUX")
@@ -17,11 +23,20 @@ case $build in
   *86*-apple-darwin*)
      AC_SUBST(NATIVE_ARCH_DEFINES, "-DTARGET_POSIX -DTARGET_DARWIN -DTARGET_DARWIN_OSX -D_LINUX")
      ;;
+  powerpc-*-linux-musl*)
+     AC_SUBST(NATIVE_ARCH_DEFINES, "-DTARGET_POSIX -DTARGET_LINUX -D_LINUX -D_POWERPC -D_MUSL")
+     ;;
   powerpc-*-linux-gnu*|powerpc-*-linux-uclibc*)
      AC_SUBST(NATIVE_ARCH_DEFINES, "-DTARGET_POSIX -DTARGET_LINUX -D_LINUX -D_POWERPC")
      ;;
+  powerpc64-*-linux-musl*)
+     AC_SUBST(NATIVE_ARCH_DEFINES, "-DTARGET_POSIX -DTARGET_LINUX -D_LINUX -D_POWERPC64 -D_MUSL")
+     ;;
   powerpc64-*-linux-gnu*|powerpc64-*-linux-uclibc*)
      AC_SUBST(NATIVE_ARCH_DEFINES, "-DTARGET_POSIX -DTARGET_LINUX -D_LINUX -D_POWERPC64")
+     ;;
+  arm*-*-linux-musl*)
+     AC_SUBST(NATIVE_ARCH_DEFINES, "-DTARGET_POSIX -DTARGET_LINUX -D_LINUX -D_MUSL")
      ;;
   arm*-*-linux-gnu*|arm*-*-linux-uclibc*)
      AC_SUBST(NATIVE_ARCH_DEFINES, "-DTARGET_POSIX -DTARGET_LINUX -D_LINUX")
@@ -33,8 +48,14 @@ esac
 
 # host detection and setup - this is the target arch
 case $host in
+  i*86*-*-linux-musl*)
+     AC_SUBST(ARCH_DEFINES, "-DTARGET_POSIX -DTARGET_LINUX -D_LINUX -D_MUSL")
+     ;;
   i*86*-linux-gnu*|i*86*-*-linux-uclibc*)
      AC_SUBST(ARCH_DEFINES, "-DTARGET_POSIX -DTARGET_LINUX -D_LINUX")
+     ;;
+  x86_64-*-linux-musl*)
+     AC_SUBST(ARCH_DEFINES, "-DTARGET_POSIX -DTARGET_LINUX -D_LINUX -D_MUSL")
      ;;
   x86_64-*-linux-gnu*|x86_64-*-linux-uclibc*)
      AC_SUBST(ARCH_DEFINES, "-DTARGET_POSIX -DTARGET_LINUX -D_LINUX")
@@ -54,14 +75,26 @@ case $host in
   powerpc-apple-darwin*)
      AC_SUBST(ARCH_DEFINES, "-DTARGET_POSIX -DTARGET_DARWIN -DTARGET_DARWIN_OSX -D_LINUX")
      ;;
+  powerpc-*-linux-musl*)
+     AC_SUBST(ARCH_DEFINES, "-DTARGET_POSIX -DTARGET_LINUX -D_LINUX -D_POWERPC -D_MUSL")
+     ;;
   powerpc-*-linux-gnu*|powerpc-*-linux-uclibc*)
      AC_SUBST(ARCH_DEFINES, "-DTARGET_POSIX -DTARGET_LINUX -D_LINUX -D_POWERPC")
+     ;;
+  powerpc64*-*-linux-musl*)
+     AC_SUBST(ARCH_DEFINES, "-DTARGET_POSIX -DTARGET_LINUX -D_LINUX -D_POWERPC64 -D_MUSL")
      ;;
   powerpc64*-*-linux-gnu*|powerpc64*-*-linux-uclibc*)
      AC_SUBST(ARCH_DEFINES, "-DTARGET_POSIX -DTARGET_LINUX -D_LINUX -D_POWERPC64")
      ;;
+  arm*-*-linux-musl*|aarch64*-*-linux-musl*)
+     AC_SUBST(ARCH_DEFINES, "-DTARGET_POSIX -DTARGET_LINUX -D_LINUX -D_MUSL")
+     ;;
   arm*-*-linux-gnu*|arm*-*-linux-uclibc*|aarch64*-*-linux-gnu*|aarch64*-*-linux-uclibc*)
      AC_SUBST(ARCH_DEFINES, "-DTARGET_POSIX -DTARGET_LINUX -D_LINUX")
+     ;;
+  mips*-*-linux-musl*)
+     AC_SUBST(ARCH_DEFINES, "-DTARGET_POSIX -DTARGET_LINUX -D_LINUX -D_MUSL")
      ;;
   mips*-*-linux-gnu*|mips*-*-linux-uclibc*)
      AC_SUBST(ARCH_DEFINES, "-DTARGET_POSIX -DTARGET_LINUX -D_LINUX")

--- a/xbmc/cores/DllLoader/exports/emu_msvcrt.h
+++ b/xbmc/cores/DllLoader/exports/emu_msvcrt.h
@@ -24,7 +24,7 @@
 #define _onexit_t void*
 #endif
 
-#if defined(TARGET_DARWIN) || defined(TARGET_FREEBSD) || defined(TARGET_ANDROID)
+#if defined(TARGET_DARWIN) || defined(TARGET_FREEBSD) || defined(TARGET_ANDROID) || defined(_MUSL)
 typedef off_t __off_t;
 typedef int64_t off64_t;
 typedef off64_t __off64_t;

--- a/xbmc/cores/DllLoader/exports/util/EmuFileWrapper.h
+++ b/xbmc/cores/DllLoader/exports/util/EmuFileWrapper.h
@@ -25,14 +25,7 @@
 #include "system.h"
 #include "threads/CriticalSection.h"
 
-#if defined(TARGET_POSIX) && !defined(TARGET_DARWIN) && !defined(TARGET_FREEBSD) && !defined(TARGET_ANDROID) && !defined(__UCLIBC__)
-#define _file _fileno
-#elif defined(__UCLIBC__)
-#define _file __filedes
-#endif
-
 #define MAX_EMULATED_FILES    50
-#define FILE_WRAPPER_OFFSET   0x00000200
 
 namespace XFILE
 {
@@ -47,12 +40,9 @@ struct kodi_iobuf {
 
 typedef struct stEmuFileObject
 {
-  FILE    file_emu;
   XFILE::CFile*  file_xbmc;
   CCriticalSection *file_lock;
   int mode;
-  //Stick this last to avoid 3-7 bytes of padding
-  bool    used;
 } EmuFileObject;
 
 class CEmuFileWrapper
@@ -67,22 +57,22 @@ public:
   void CleanUp();
 
   EmuFileObject* RegisterFileObject(XFILE::CFile* pFile);
+  void UnRegisterFileObject(EmuFileObject*, bool free_file);
   void UnRegisterFileObjectByDescriptor(int fd);
   void UnRegisterFileObjectByStream(FILE* stream);
   void LockFileObjectByDescriptor(int fd);
   bool TryLockFileObjectByDescriptor(int fd);
   void UnlockFileObjectByDescriptor(int fd);
   EmuFileObject* GetFileObjectByDescriptor(int fd);
+  int GetDescriptorByFileObject(EmuFileObject*);
   EmuFileObject* GetFileObjectByStream(FILE* stream);
+  FILE* GetStreamByFileObject(EmuFileObject*);
   XFILE::CFile* GetFileXbmcByDescriptor(int fd);
   XFILE::CFile* GetFileXbmcByStream(FILE* stream);
-  static int GetDescriptorByStream(FILE* stream);
+  int GetDescriptorByStream(FILE* stream);
   FILE* GetStreamByDescriptor(int fd);
-  static constexpr bool DescriptorIsEmulatedFile(int fd)
-  {
-    return fd >= FILE_WRAPPER_OFFSET && fd < FILE_WRAPPER_OFFSET + MAX_EMULATED_FILES;
-  }
-  static bool StreamIsEmulatedFile(FILE* stream);
+  bool DescriptorIsEmulatedFile(int fd);
+  bool StreamIsEmulatedFile(FILE* stream);
 private:
   EmuFileObject m_files[MAX_EMULATED_FILES];
   CCriticalSection m_criticalSection;

--- a/xbmc/cores/DllLoader/exports/wrapper.c
+++ b/xbmc/cores/DllLoader/exports/wrapper.c
@@ -39,7 +39,7 @@
 #endif
 #include <dlfcn.h>
 
-#if defined(TARGET_DARWIN) || defined(TARGET_FREEBSD) || defined(TARGET_ANDROID)
+#if defined(TARGET_DARWIN) || defined(TARGET_FREEBSD) || defined(TARGET_ANDROID) || defined(_MUSL)
 typedef off_t     __off_t;
 typedef int64_t   off64_t;
 typedef off64_t   __off64_t;

--- a/xbmc/cores/DllLoader/ldt_keeper.c
+++ b/xbmc/cores/DllLoader/ldt_keeper.c
@@ -31,6 +31,7 @@
 #include <sys/types.h>
 #include <stdio.h>
 #include <unistd.h>
+#include <syscall.h>
 #include "mmap_anon.h"
 #if defined( __linux__ ) && !defined(__powerpc__)
 #include <asm/unistd.h>
@@ -202,7 +203,7 @@ ldt_fs_t* Setup_LDT_Keeper(void)
   array.limit_in_pages = 0;
 #ifdef __linux__
   /* ret=LDT_Modify(0x1, &array, sizeof(struct modify_ldt_ldt_s)); */
-  ret = modify_ldt(0x1, &array, sizeof(struct modify_ldt_ldt_s));
+  ret = syscall(SYS_modify_ldt, 0x1, &array, sizeof(struct modify_ldt_ldt_s));
   if (ret < 0)
   {
 	  perror("install_fs");

--- a/xbmc/utils/posix/PosixInterfaceForCLog.cpp
+++ b/xbmc/utils/posix/PosixInterfaceForCLog.cpp
@@ -29,10 +29,6 @@
 #include "platform/android/activity/XBMCApp.h"
 #endif // TARGET_ANDROID
 
-struct FILEWRAP : public FILE
-{};
-
-
 CPosixInterfaceForCLog::CPosixInterfaceForCLog() :
   m_file(NULL)
 { }
@@ -52,7 +48,7 @@ bool CPosixInterfaceForCLog::OpenLogFile(const std::string &logFilename, const s
   (void)remove(backupOldLogToFilename.c_str()); // if it's failed, try to continue
   (void)rename(logFilename.c_str(), backupOldLogToFilename.c_str()); // if it's failed, try to continue
 
-  m_file = (FILEWRAP*)fopen(logFilename.c_str(), "wb");
+  m_file = fopen(logFilename.c_str(), "wb");
   if (!m_file)
     return false; // error, can't open log file
 

--- a/xbmc/utils/posix/PosixInterfaceForCLog.h
+++ b/xbmc/utils/posix/PosixInterfaceForCLog.h
@@ -21,8 +21,6 @@
 
 #include <string>
 
-struct FILEWRAP; // forward declaration, wrapper for FILE
-
 class CPosixInterfaceForCLog
 {
 public:
@@ -34,5 +32,5 @@ public:
   void PrintDebugString(const std::string& debugString);
   static void GetCurrentLocalTime(int& hour, int& minute, int& second, double& millisecond);
 private:
-  FILEWRAP* m_file;
+  FILE * m_file;
 };


### PR DESCRIPTION
https://www.musl-libc.org/faq.html
`musl is a “libc”, an implementation of the standard library functionality described in the ISO C and POSIX standards, plus common extensions, intended for use on Linux-based systems.`

This PR contains patches downloaded from
https://github.com/voidlinux/void-packages/tree/master/srcpkgs/kodi/patches
which I tried to port to the current master branch. Using a buildroot-compiled
musl toolchain I could compile current Kodi master with these patches.
Unfortunately I am unable to do runtime testing.

Please note that I did not code the patches so I can not judge their technical
quality. Therefore I consider these patches, especially the fileemu patch,
as WIP to start a discussion.
