### PR TITLE
Avoid compiling cdrip when build with --disable-optical-drive

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -34,7 +34,6 @@ DIRECTORY_ARCHIVES=$(VideoPlayer_ARCHIVES) \
                    xbmc/addons/binary/interfaces/api1/InputStream/addon-callbacks-inputstream.a \
                    xbmc/addons/binary/interfaces/api1/Peripheral/addon-callbacks-peripheral.a \
                    xbmc/addons/binary/interfaces/api1/PVR/addon-callbacks-pvr.a \
-                   xbmc/cdrip/cdrip.a \
                    xbmc/contrib/kissfft/kissfft.a \
                    xbmc/cores/AudioEngine/audioengine.a \
                    xbmc/cores/DllLoader/dllloader.a \
@@ -119,6 +118,9 @@ DIRECTORY_ARCHIVES=$(VideoPlayer_ARCHIVES) \
 NWAOBJSXBMC=	xbmc/threads/threads.a \
 		xbmc/commons/commons.a
 
+ifeq (@USE_OPTICAL_DRIVE@,1)
+DIRECTORY_ARCHIVES += xbmc/cdrip/cdrip.a 
+endif
 
 ifeq (@USE_WEB_SERVER@,1)
 DIRECTORY_ARCHIVES += xbmc/interfaces/legacy/wsgi/legacy-wsgi.a

--- a/configure.ac
+++ b/configure.ac
@@ -1179,6 +1179,9 @@ fi
 # Optical
 if test "$use_optical_drive" = "yes"; then
   AC_DEFINE([HAS_DVD_DRIVE], [1], [Define to 1 to have optical drive support])
+  USE_OPTICAL_DRIVE=1
+else
+  USE_OPTICAL_DRIVE=0
 fi
 
 # Alsa
@@ -2334,6 +2337,7 @@ AC_SUBST(UPNP_DEFINES)
 AC_SUBST(USE_SSE4)
 AC_SUBST(USE_MMAL)
 AC_SUBST(USE_X11)
+AC_SUBST(USE_OPTICAL_DRIVE)
 AC_SUBST(USE_BREAKPAD)
 AC_SUBST(CROSS_COMPILING)
 


### PR DESCRIPTION
Replaces https://github.com/xbmc/xbmc/pull/5957
