### PR TITLE
xbmc_pvr_types.h: Fix compilation with gcc6

### DIFF
--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
@@ -32,6 +32,7 @@
 #endif
 #include <string.h>
 #include <stdint.h>
+#include <stdio.h>
 
 #include "xbmc_addon_types.h"
 #include "xbmc_epg_types.h"


### PR DESCRIPTION
Using gcc-Version 6.0.1 20160415 (prerelease)
 (Buildroot 2016.05-git-01066-gdcf7e2a)

a build error occurs when compiling current git HEAD of kodi-pvr-vbox:

/home/buildroot/br2_kodi17/output/host/usr/i586-buildroot-linux-uclibc/sysroot/usr/include/kodi/xbmc_pvr_dll.h:424:63: error: 'SEEK_SET' was not declared in this scope
   long long SeekLiveStream(long long iPosition, int iWhence = SEEK_SET);
                                                               ^~~~~~~~
/home/buildroot/br2_kodi17/output/host/usr/i586-buildroot-linux-uclibc/sysroot/usr/include/kodi/xbmc_pvr_dll.h:505:67: error: 'SEEK_SET' was not declared in this scope
   long long SeekRecordedStream(long long iPosition, int iWhence = SEEK_SET);
                                                                   ^~~~~~~~
This commit fixes the problem by including stdio.h.
