### PR TITLE
[RendererAML] Wait for Vsync in RenderUpdateVideoHook to avoid high CPU usage after render loop changes

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererAML.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererAML.cpp
@@ -31,14 +31,17 @@
 #include "windowing/WindowingFactory.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderCapture.h"
 
+#include <sys/ioctl.h>
+#include <linux/fb.h>
+
 CRendererAML::CRendererAML()
 {
-
+  m_fbHandle = open("/dev/fb0", O_RDWR);
 }
 
 CRendererAML::~CRendererAML()
 {
-
+  close(m_fbHandle);
 }
 
 bool CRendererAML::RenderCapture(CRenderCapture* capture)
@@ -139,7 +142,15 @@ bool CRendererAML::RenderUpdateVideoHook(bool clear, DWORD flags, DWORD alpha)
       amlcodec->SetVideoRect(m_sourceRect, m_destRect);
   }
 
+  WaitVsync();
+
   return true;
+}
+
+void CRendererAML::WaitVsync()
+{
+  if (m_fbHandle >= 0)
+    ioctl(m_fbHandle, FBIO_WAITFORVSYNC, 0);
 }
 
 #endif

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererAML.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererAML.h
@@ -55,6 +55,11 @@ protected:
   virtual bool RenderHook(int index);  
   virtual int  GetImageHook(YV12Image *image, int source = AUTOSOURCE, bool readonly = false);
   virtual bool RenderUpdateVideoHook(bool clear, DWORD flags = 0, DWORD alpha = 255);
+
+private:
+  void WaitVsync();
+
+  int m_fbHandle;
 };
 
 #endif


### PR DESCRIPTION
Recent changes in render loop caused high CPU usage and video stuttering during playback on Amlogic-based devices. This PR fixes the issue by blocking CRendererAML::RenderUpdateVideoHook() until next Vsync.
