### PR TITLE
File cache improvements

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFile.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFile.cpp
@@ -67,14 +67,11 @@ bool CDVDInputStreamFile::Open()
    */
   if (!URIUtils::IsOnDVD(m_item.GetPath()) && !URIUtils::IsBluray(m_item.GetPath())) // Never cache these
   {
-    if (g_advancedSettings.m_networkBufferMode == 0 || g_advancedSettings.m_networkBufferMode == 2)
+    if ((g_advancedSettings.m_cacheBufferMode == CACHE_BUFFER_MODE_INTERNET && URIUtils::IsInternetStream(m_item.GetPath(), false))
+     || (g_advancedSettings.m_cacheBufferMode == CACHE_BUFFER_MODE_TRUE_INTERNET && URIUtils::IsInternetStream(m_item.GetPath(), true))
+     || (g_advancedSettings.m_cacheBufferMode == CACHE_BUFFER_MODE_ALL))
     {
-      if (URIUtils::IsInternetStream(CURL(m_item.GetPath()), (g_advancedSettings.m_networkBufferMode == 0) ) )
-        flags |= READ_CACHED;
-    }
-    else if (g_advancedSettings.m_networkBufferMode == 1)
-    {
-      flags |= READ_CACHED; // In buffer mode 1 force cache for (almost) all files
+      flags |= READ_CACHED;
     }
   }
 

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFile.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFile.cpp
@@ -69,6 +69,7 @@ bool CDVDInputStreamFile::Open()
   {
     if ((g_advancedSettings.m_cacheBufferMode == CACHE_BUFFER_MODE_INTERNET && URIUtils::IsInternetStream(m_item.GetPath(), false))
      || (g_advancedSettings.m_cacheBufferMode == CACHE_BUFFER_MODE_TRUE_INTERNET && URIUtils::IsInternetStream(m_item.GetPath(), true))
+     || (g_advancedSettings.m_cacheBufferMode == CACHE_BUFFER_MODE_REMOTE && URIUtils::IsRemote(m_item.GetPath()))
      || (g_advancedSettings.m_cacheBufferMode == CACHE_BUFFER_MODE_ALL))
     {
       flags |= READ_CACHED;

--- a/xbmc/filesystem/FileCache.cpp
+++ b/xbmc/filesystem/FileCache.cpp
@@ -179,7 +179,7 @@ bool CFileCache::Open(const CURL& url)
 
   if (!m_pCache)
   {
-    if (g_advancedSettings.m_cacheMemBufferSize == 0)
+    if (g_advancedSettings.m_cacheMemSize == 0)
     {
       // Use cache on disk
       m_pCache = new CSimpleFileCache();
@@ -188,14 +188,14 @@ bool CFileCache::Open(const CURL& url)
     else
     {
       size_t cacheSize;
-      if (m_fileSize > 0 && m_fileSize < g_advancedSettings.m_cacheMemBufferSize && !(m_flags & READ_AUDIO_VIDEO))
+      if (m_fileSize > 0 && m_fileSize < g_advancedSettings.m_cacheMemSize && !(m_flags & READ_AUDIO_VIDEO))
       {
         // NOTE: We don't need to take into account READ_MULTI_STREAM here as it's only used for audio/video
         cacheSize = m_fileSize;
       }
       else
       {
-        cacheSize = g_advancedSettings.m_cacheMemBufferSize;
+        cacheSize = g_advancedSettings.m_cacheMemSize;
       }
 
       size_t back = cacheSize / 4;
@@ -296,13 +296,13 @@ void CFileCache::Process()
 
     while (m_writeRate)
     {
-      if (m_writePos - m_readPos < m_writeRate * g_advancedSettings.m_readBufferFactor)
+      if (m_writePos - m_readPos < m_writeRate * g_advancedSettings.m_cacheReadFactor)
       {
         limiter.Reset(m_writePos);
         break;
       }
 
-      if (limiter.Rate(m_writePos) < m_writeRate * g_advancedSettings.m_readBufferFactor)
+      if (limiter.Rate(m_writePos) < m_writeRate * g_advancedSettings.m_cacheReadFactor)
         break;
 
       if (m_seekEvent.WaitMSec(100))

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -751,7 +751,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
   if (pElement)
   {
     XMLUtils::GetUInt(pElement, "memorysize", m_cacheMemSize);
-    XMLUtils::GetUInt(pElement, "buffermode", m_cacheBufferMode, 0, 3);
+    XMLUtils::GetUInt(pElement, "buffermode", m_cacheBufferMode, 0, 4);
     XMLUtils::GetFloat(pElement, "readfactor", m_cacheReadFactor);
   }
 

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -355,11 +355,12 @@ void CAdvancedSettings::Initialize()
   m_bPVRAutoScanIconsUserSet       = false;
   m_iPVRNumericChannelSwitchTimeout = 1000;
 
-  m_cacheMemBufferSize = 1024 * 1024 * 20;
-  m_networkBufferMode = 0; // Default (buffer all internet streams/filesystems)
+  m_cacheMemSize = 1024 * 1024 * 20;
+  m_cacheBufferMode = CACHE_BUFFER_MODE_INTERNET; // Default (buffer all internet streams/filesystems)
   // the following setting determines the readRate of a player data
   // as multiply of the default data read rate
-  m_readBufferFactor = 4.0f;
+  m_cacheReadFactor = 4.0f;
+
   m_addonPackageFolderSize = 200;
 
   m_jsonOutputCompact = true;
@@ -744,9 +745,14 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetInt(pElement, "curllowspeedtime", m_curllowspeedtime, 1, 1000);
     XMLUtils::GetInt(pElement, "curlretries", m_curlretries, 0, 10);
     XMLUtils::GetBoolean(pElement,"disableipv6", m_curlDisableIPV6);
-    XMLUtils::GetUInt(pElement, "cachemembuffersize", m_cacheMemBufferSize);
-    XMLUtils::GetUInt(pElement, "buffermode", m_networkBufferMode, 0, 3);
-    XMLUtils::GetFloat(pElement, "readbufferfactor", m_readBufferFactor);
+  }
+
+  pElement = pRootElement->FirstChildElement("cache");
+  if (pElement)
+  {
+    XMLUtils::GetUInt(pElement, "memorysize", m_cacheMemSize);
+    XMLUtils::GetUInt(pElement, "buffermode", m_cacheBufferMode, 0, 3);
+    XMLUtils::GetFloat(pElement, "readfactor", m_cacheReadFactor);
   }
 
   pElement = pRootElement->FirstChildElement("jsonrpc");

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -29,6 +29,11 @@
 #include "settings/lib/ISettingsHandler.h"
 #include "utils/GlobalsHandling.h"
 
+#define CACHE_BUFFER_MODE_INTERNET      0
+#define CACHE_BUFFER_MODE_ALL           1
+#define CACHE_BUFFER_MODE_TRUE_INTERNET 2
+#define CACHE_BUFFER_MODE_NONE          3
+
 class CVariant;
 
 class TiXmlElement;
@@ -335,9 +340,9 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     int  m_guiAlgorithmDirtyRegions;
     unsigned int m_addonPackageFolderSize;
 
-    unsigned int m_cacheMemBufferSize;
-    unsigned int m_networkBufferMode;
-    float m_readBufferFactor;
+    unsigned int m_cacheMemSize;
+    unsigned int m_cacheBufferMode;
+    float m_cacheReadFactor;
 
     bool m_jsonOutputCompact;
     unsigned int m_jsonTcpPort;

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -33,6 +33,7 @@
 #define CACHE_BUFFER_MODE_ALL           1
 #define CACHE_BUFFER_MODE_TRUE_INTERNET 2
 #define CACHE_BUFFER_MODE_NONE          3
+#define CACHE_BUFFER_MODE_REMOTE        4
 
 class CVariant;
 

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -526,7 +526,7 @@ std::string CVideoThumbLoader::GetLocalArt(const CFileItem &item, const std::str
      thumbloader thread accesses the streamed filesystem at the same time as the
      App thread and the latter has to wait for it.
    */
-  if (item.m_bIsFolder && (item.IsInternetStream(true) || g_advancedSettings.m_networkBufferMode == 1))
+  if (item.m_bIsFolder && (item.IsInternetStream(true) || g_advancedSettings.m_cacheBufferMode == CACHE_BUFFER_MODE_ALL))
   {
     CFileItemList items; // Dummy list
     CDirectory::GetDirectory(item.GetPath(), items, "", DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_READ_CACHE | DIR_FLAG_NO_FILE_INFO);


### PR DESCRIPTION
This PR brings a couple of improvements concerning our filecache. The most important change is the move of cache related settings in as.xml from the network-section to its own cache-section + proper (re)naming of the settings. The way it has evolved no longer made any sense (cache is not only used by network) and the names were rather cumbersome. I also added an additional caching mode ("remote") and did some cleaning/refactoring.
