### PR TITLE
configure.ac: Add target_platform=target_linux for powerpc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -616,10 +616,12 @@ case $host in
      AC_SUBST([DEPENDS_ROOT_FOR_XCODE])
      ;;
   powerpc-*-linux-gnu*|powerpc-*-linux-uclibc*)
+     target_platform=target_linux
      CORE_SYSTEM_NAME=linux
      ARCH="powerpc-linux"
      ;;
   powerpc64-*-linux-gnu*|powerpc64-*-linux-uclibc*)
+     target_platform=target_linux
      CORE_SYSTEM_NAME=linux
      ARCH="powerpc64-linux"
      ;;


### PR DESCRIPTION
Checking for libuuid only occurs with target_platform set to a sane value. Without libuuid being added to LIBS, the check for libcrossguid fails because libcrossguid is linked to libuuid.
