### PR TITLE
[cleanup] remove not need ogg/vorbis check from configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -963,8 +963,6 @@ if test "$use_mysql" = "yes"; then
   fi
 fi
 AC_CHECK_HEADER([ass/ass.h],, AC_MSG_ERROR($missing_library))
-AC_CHECK_HEADER([ogg/ogg.h],,        AC_MSG_ERROR($missing_library))
-AC_CHECK_HEADER([vorbis/vorbisfile.h],, AC_MSG_ERROR($missing_library))
 
 PKG_CHECK_MODULES([LIBCURL], [libcurl],, AC_MSG_ERROR([libcurl not found]))
 XB_FIND_SONAME([CURL], [curl])


### PR DESCRIPTION
kodi has no direct dependency on libogg / libvorbis anymore. makes no sense to check those headers in configure

a side note: ffmpeg has native ogg decoder (my samples play fine with ffmpeg compiled without libogg/libvorbis). we dont use vorbisenc in ffmpeg anymore (audioencoder.vorbis exists), so it seems libogg/libvorbis can be removed from depends, too.
