### PR TITLE
[doxygen] add code guidelines

### DIFF
--- a/CODING_GUIDELINES.dox
+++ b/CODING_GUIDELINES.dox
@@ -1,0 +1,372 @@
+/*!
+
+\page code_guidelines Code guidelines and formatting conventions
+
+@brief \doc_header{ Code guidelines and formatting conventions }
+
+\tableofcontents
+
+These are conventions which we try to follow when writing code for Kodi. They
+are this way mainly for reasons of taste, however, sticking to a common set of
+formatting rules also makes it slightly easier to read through our sources. If
+you want to submit patches, please try to follow these rules.
+
+As such we don't follow these rules slavishly, in certain cases it is ok (and
+in fact favorable) to stray from them.
+
+================================================================================
+\section code_guidelines_1 Indentation
+
+Use spaces as tab policy with an indentation size of 2
+
+--------------------------------------------------------------------------------
+\subsection code_guidelines_1_1 Statements
+
+No multiple statements on a single line, like this:
+~~~~~~~~~~~~~
+std::vector<std::string> test; test.push_back("foobar"); // This is the bad way
+~~~~~~~~~~~~~
+
+Always use a new line for a new statement:
+~~~~~~~~~~~~~
+std::vector<std::string> test;
+test.push_back("foobar");
+~~~~~~~~~~~~~
+
+With them becomes it much more easy for debugging of faults to see direct on the
+line what has created the fault.
+
+
+--------------------------------------------------------------------------------
+\subsection code_guidelines_1_2 Namespaces
+
+Namespaces are not required to use any indentation to simplify nested namespaces
+and wrapping `.cpp` files in a namespace
+
+~~~~~~~~~~~~~
+namespace KODI
+{
+namespace UTILS
+{
+class ILogger
+{
+  void Log(...) = 0;
+}
+}
+}
+~~~~~~~~~~~~~
+
+\subsection code_guidelines_1_3 Headers
+
+Included header files `*.h`, are to sort alphabetical to prevent double used file
+definition and allow better overview
+
+- On cpp define used header first to confirm needed headers are present on them itself
+- As next use the global system headers e.g. `<cassert>` or `"system.h"`
+- Then insert all the headers needed for the file itself
+
+~~~~~~~~~~~~~
+#include "PVRManager.h"
+
+#include <cassert>
+#include <utility>
+
+#include "Application.h"
+#include "Util.h"
+#include "addons/AddonInstaller.h"
+#include "dialogs/GUIDialogExtendedProgressBar.h"
+#include "messaging/helpers/DialogHelper.h"
+#include "music/tags/MusicInfoTag.h"
+#include "network/Network.h"
+#include "pvr/addons/PVRClients.h"
+#include "pvr/channels/PVRChannel.h"
+#include "settings/Settings.h"
+#include "threads/SingleLock.h"
+#include "utils/JobManager.h"
+#include "utils/log.h"
+#include "utils/Variant.h"
+#include "video/VideoDatabase.h"
+~~~~~~~~~~~~~
+
+================================================================================
+\section code_guidelines_2 Braces
+
+Braces should go to newline and your code should look like the following example:
+
+~~~~~~~~~~~~~
+if (int i = 0; i < t; i++)
+{
+  [...]
+}
+else
+{
+  [...]
+}
+
+class Dummy()
+{
+  [...]
+}
+~~~~~~~~~~~~~
+
+================================================================================
+\section code_guidelines_3 Whitespaces
+
+Conventional operators should be surrounded by a whitespace.
+
+~~~~~~~~~~~~~
+a = (b + c) * d;
+~~~~~~~~~~~~~
+
+Reserved words should be separated from opening parentheses by a whitespace.
+
+~~~~~~~~~~~~~
+while (true)
+for (int i = 0; i < x; ++i)
+~~~~~~~~~~~~~
+
+Commas should be followed by a whitespace.
+
+~~~~~~~~~~~~~
+void Dummy::Method(int a, int b, int c);
+int d, e;
+~~~~~~~~~~~~~
+
+Semicolons should be followed by a whitespace if there is more than one
+expression per line.
+
+~~~~~~~~~~~~~
+for (int i = 0; i < x; ++i)
+doSomething(e); doSomething(f); // this is probably bad style anyway
+~~~~~~~~~~~~~
+
+--------------------------------------------------------------------------------
+\subsection code_guidelines_3_1 No vertical alignment
+
+Do not use whitespaces to align value names together, this becomes problematic
+on updates to see the change, if the whitspaces need to change on all.
+
+This should be not used:
+~~~~~~~~~~~~~
+...
+
+int                  value1             = 0;
+int                  value2             = 0;
+CExampleClass       *exampleClass       = nullptr;
+CBiggerExampleClass *biggerExampleClass = nullptr;
+
+exampleClass       = new CExampleClass      (value1, value2);
+biggerExampleClass = new CBiggerExampleClass(value1, value2);
+
+exampleClass      ->InitExample();
+biggerExampleClass->InitExample();
+
+...
+~~~~~~~~~~~~~
+
+Use it as:
+~~~~~~~~~~~~~
+...
+
+int value1 = 0;
+int value2 = 0;
+CExampleClass *exampleClass = nullptr;
+CBiggerExampleClass *biggerExampleClass = nullptr;
+
+exampleClass = new CExampleClass(value1, value2);
+biggerExampleClass = new CBiggerExampleClass(value1, value2);
+
+exampleClass->InitExample();
+biggerExampleClass->InitExample();
+
+...
+~~~~~~~~~~~~~
+
+================================================================================
+\section code_guidelines_4 Control statements
+
+Insert new line before
+
+- else in an if statement
+- catch in a try statement
+- while in a do statement
+
+
+--------------------------------------------------------------------------------
+\subsection code_guidelines_4_1 if else
+
+- put then statement, return or throw to new line
+- keep else if on one line 
+
+~~~~~~~~~~~~~
+if (true)
+  return;
+
+if (true)
+{
+  [...]
+} 
+else if (false)
+{
+  return;
+} 
+else
+  return;
+~~~~~~~~~~~~~
+
+--------------------------------------------------------------------------------
+\subsection code_guidelines_4_2 switch / case
+
+~~~~~~~~~~~~~[.cpp}
+switch (cmd)
+{
+  case x:
+  {
+    doSomething();
+    break;
+  }
+  case x:
+  case z:
+    return true;
+  default:
+    doSomething();
+}
+~~~~~~~~~~~~~
+
+================================================================================
+\section code_guidelines_5 Naming
+\subsection code_guidelines_5_1 Namespaces
+
+Namespaces should be in uppercase letters
+
+~~~~~~~~~~~~~
+namespace KODI
+{
+...
+}
+~~~~~~~~~~~~~
+
+\subsection code_guidelines_5_2 Constants
+
+Use upper case with underscore spacing where necessary.
+
+~~~~~~~~~~~~~
+const int MY_CONSTANT = 1;
+~~~~~~~~~~~~~
+
+--------------------------------------------------------------------------------
+\subsection code_guidelines_5_3 Enums
+
+Use CamelCase for the enum name and upper case for the values.
+
+~~~~~~~~~~~~~
+enum Dummy
+{
+  VALUE_X,
+  VALUE_Y
+};
+~~~~~~~~~~~~~
+
+--------------------------------------------------------------------------------
+\subsection code_guidelines_5_4 Interfaces
+
+We use CamelCase for interface names and they should be prefixed with an
+uppercase I. Filename should match the interface name, e.g. `ILogger.h`
+
+~~~~~~~~~~~~~
+class ILogger
+{
+  void Log(...) = 0;
+}
+~~~~~~~~~~~~~
+
+--------------------------------------------------------------------------------
+\subsection code_guidelines_5_5 Classes
+
+We use CamelCase for class names and they should be prefixed with an uppercase C.
+Filename should match the class name without the prefixed C, e.g. `Logger.cpp`
+
+~~~~~~~~~~~~~
+class CLogger : public ILogger
+{
+  void Log(...)
+}
+~~~~~~~~~~~~~
+
+--------------------------------------------------------------------------------
+\subsection code_guidelines_5_6 Methods
+
+We use CamelCase for method names and first letter should always be upper case.
+Even if the methods are private or protected.
+
+~~~~~~~~~~~~~
+void MyDummyClass::DoSomething();
+~~~~~~~~~~~~~
+
+--------------------------------------------------------------------------------
+\subsection code_guidelines_5_7 Variables
+
+We use CamelCase for variables. Type prefixing is optional.
+\subsubsection code_guidelines_5_7_1 Global Variables
+
+Prefix global variables with g_
+
+~~~~~~~~~~~~~
+int g_globalVariableA;
+~~~~~~~~~~~~~
+
+\warning Use of globals reduces the chance of submitted code to be accepted to a minimum
+
+\subsubsection code_guidelines_5_7_2 Member Variables
+
+Prefix member variables with m_
+
+~~~~~~~~~~~~~
+int m_variableA;
+~~~~~~~~~~~~~
+
+================================================================================
+\section code_guidelines_6 Conventions
+
+--------------------------------------------------------------------------------
+\subsection code_guidelines_6_1 Casts
+
+New code should use C++ style casts and not older C style casts. When modifying
+existing code the developer can choose to update it to C++ style casts or leave
+as is. Remember that whenever a dynamic_cast is used the result can be a nullptr
+and needs to be checked accordingly.
+
+--------------------------------------------------------------------------------
+\subsection code_guidelines_6_2 NULL vs nullptr
+
+Prefer the use of nullptr instead of NULL. nullptr is a typesafe version and as
+such can't be implicitly converted to int or anything else.
+
+--------------------------------------------------------------------------------
+\subsection code_guidelines_6_3 auto
+
+Feel free to use auto wherever it improves readability. Good places are
+iterators or when dealing with containers.
+
+~~~~~~~~~~~~~
+std::map<std::string, std::vector<int>>::iterator i = var.begin();
+vs
+auto i = var.being();
+~~~~~~~~~~~~~
+
+--------------------------------------------------------------------------------
+\subsection code_guidelines_6_4 for loops
+
+Use newer style foreach loops whenever it makes sense. If iterators are used see
+above about using auto.
+
+~~~~~~~~~~~~~
+for (auto& : var)
+{
+  ...
+}
+~~~~~~~~~~~~~
+
+Use const auto& if there's no reason to modify the value.
+
+*/

--- a/doxygen_resources/Doxyfile.doxy
+++ b/doxygen_resources/Doxyfile.doxy
@@ -790,6 +790,7 @@ WARN_LOGFILE           =
 # Note: If this tag is empty the current directory is searched.
 
 INPUT                  = ../xbmc \
+                         ../CODING_GUIDELINES.dox \
                          .
 
 # This tag can be used to specify the character encoding of the source files

--- a/xbmc/addons/kodi-addon-dev-kit/doxygen/Doxyfile
+++ b/xbmc/addons/kodi-addon-dev-kit/doxygen/Doxyfile
@@ -777,6 +777,9 @@ WARN_LOGFILE           =
 # Note: If this tag is empty the current directory is searched.
 
 INPUT                  = main.txt \
+                         General/General.dox \
+                         General/DoxygenOnAddon.dox \
+                         ../../../../CODING_GUIDELINES.dox \
                          ../../../GUIInfoManager.cpp \
                          Modules/modules_general.dox \
                          Skin/skin.dox \

--- a/xbmc/addons/kodi-addon-dev-kit/doxygen/General/DoxygenOnAddon.dox
+++ b/xbmc/addons/kodi-addon-dev-kit/doxygen/General/DoxygenOnAddon.dox
@@ -1,0 +1,90 @@
+/*!
+
+@page Doxygen_On_Addon Doxygen on Kodi's Add-On headers
+
+### This page is for notes on using Doxygen to document the Kodi's Add-On headers source code.
+
+[Doxygen](http://www.stack.nl/~dimitri/doxygen/index.html), is a documentation
+system for C++, C, Java, and some other weird languages. It can generate html
+docs documenting a projects source code, by either extracting special tags from
+the source code (put there by people wanting to make use of doxygen), or doxygen
+attempts to build documentation from existing source.
+
+Doxygen seems to be installed on the NMR systems, type:
+~~~~~~~~~~~~~
+doxygen --version
+~~~~~~~~~~~~~
+
+
+_ _ _
+
+Start doxygen documentation for add-ons always with `///` and on Kodi itself with `/*!`, this makes it more easy to see for which place the documentation is.
+
+<b>Here a axample on add-on about function coding style:</b>
+
+\verbatim
+#ifdef DOXYGEN_SHOULD_USE_THIS
+  ///
+  /// \ingroup python_xbmcgui_window
+  /// @brief Sets the resolution
+  ///
+  /// That the coordinates of all controls are defined in.  Allows Kodi
+  /// to scale control positions and width/heights to whatever resolution
+  /// Kodi is currently using.
+  ///
+  /// @param[in] res                Coordinate resolution to set
+  ///  Resolution is one of the following:
+  ///  | value | Resolution                |
+  ///  |:-----:|:--------------------------|
+  ///  |   0   | 1080i      (1920x1080)
+  ///  |   1   | 720p       (1280x720)
+  ///  |   2   | 480p 4:3   (720x480)
+  ///  |   3   | 480p 16:9  (720x480)
+  ///  |   4   | NTSC 4:3   (720x480)
+  ///  |   5   | NTSC 16:9  (720x480)
+  ///  |   6   | PAL 4:3    (720x576)
+  ///  |   7   | PAL 16:9   (720x576)
+  ///  |   8   | PAL60 4:3  (720x480)
+  ///  |   9   | PAL60 16:9 (720x480)
+  /// @return                       Nothing only added as example here :)
+  /// @param[out] nothingExample    Example here, if on value pointer data becomes
+  ///                               returned.
+  /// @throws TypeError             If supplied argument is not of List type, or a
+  ///                               control is not of Control type
+  /// @throws ReferenceError        If control is already used in another window
+  /// @throws RuntimeError          Should not happen :-)
+  ///
+  ///
+  ///--------------------------------------------------------------------------
+  ///
+  /// **Example:**
+  /// ~~~~~~~~~~~~~{.py}
+  /// ..
+  /// win = xbmcgui.Window(xbmcgui.getCurrentWindowId())
+  /// win.setCoordinateResolution(0)
+  /// ..
+  /// ~~~~~~~~~~~~~
+  ///
+  setCoordinateResolution(...);
+#else
+  SWIGHIDDENVIRTUAL bool setCoordinateResolution(long res, int &nothingExample);
+#endif
+\endverbatim
+- \verbatim /// \ingroup\endverbatim - Define the group where the documentation part comes in.
+- \verbatim /// @brief\endverbatim - Add a small text of part there.
+- \verbatim /// TEXT_FIELD\endverbatim - Add a bigger text there if needed.
+- \verbatim /// @param[in] VALUE_NAME                 VALUE_TEXT\endverbatim - To set input paramter defined by name and add a description. There the example also add a small table which is useful to descripe values.
+- \verbatim /// @param[out] VALUE_NAME                VALUE_TEXT\endverbatim - To set output paramter defined by name and add a description.
+- \verbatim /// @return                               VALUE_TEXT\endverbatim - To add a description of return value.
+- \verbatim /// @throws ERROR_TYPE                    ERROR_TEXT\endverbatim - If also exception becomes handled, can you use this for description.
+- \verbatim /// TEXT_FIELD\endverbatim - Add a much bigger text there if needed.
+- \verbatim /// ------------------\endverbatim - Use this to define a field line, e.g. if you add example add this always before, further must you make two empty lines before to prevent add of them on string before!
+- \verbatim /// ~~~~~~~~~~~~~ \endverbatim - Here can you define a code example which must start and end with the defination string, also can you define the code style with e.g. <b>{.py}</b> for Python or <b>{.cpp}</b> for CPP code on the first line of them.
+
+@note Start all `VALUE_TEXT` at same character to hold a clean code on <c>*.cpp</c> or <c>*.h</c> files.\n\n
+      The `#ifdef DOXYGEN_SHOULD_USE_THIS` on example above can be becomes used
+      if for Doxygen another function is needed to descripe.
+
+If you want to prevent a part from doxygen can you define <b>`#ifndef DOXYGEN_SHOULD_SKIP_THIS`</b>
+or <b>`#ifdef DOXYGEN_SHOULD_USE_THIS`</b> on the related code.
+*/

--- a/xbmc/addons/kodi-addon-dev-kit/doxygen/General/General.dox
+++ b/xbmc/addons/kodi-addon-dev-kit/doxygen/General/General.dox
@@ -1,0 +1,18 @@
+/*!
+
+\page general General
+\brief \doc_header{ General descriptions }
+
+The used code guidelines from Kodi
+@note Is not direct needed on C++ add-ons but makes it more easy for reviews and
+changes from the others.
+
+\subpage code_guidelines
+
+--------------------------------------------------------------------------------
+
+Guideline for Kodi's developers to create documentation
+
+\subpage Doxygen_On_Addon
+
+*/

--- a/xbmc/addons/kodi-addon-dev-kit/doxygen/main.txt
+++ b/xbmc/addons/kodi-addon-dev-kit/doxygen/main.txt
@@ -39,6 +39,7 @@ Kodi is distributed under a [GNU General Public License version 2](./LICENSE.GPL
 <div style="display:none">
 \endhtmlonly
 
+\subpage general
 \subpage general_parts
 
 \htmlonly


### PR DESCRIPTION
This add the guidelines from http://kodi.wiki/view/Official:Code_guidelines_and_formatting_conventions to Kodi itself.

Also becomes my guideline for Add-on related documents added.

Plan from me is to use for code from Kodi itself a `/*!` and for Code related also for add-on developers a `///`. The last mark it as field to know also needed alone on add-on development kit.
