### PR TITLE
Chop out anything before Android 5 and don't build with amlogic

### DIFF
--- a/tools/android/packaging/xbmc/AndroidManifest.xml.in
+++ b/tools/android/packaging/xbmc/AndroidManifest.xml.in
@@ -5,7 +5,7 @@
     android:versionCode="@APP_VERSION_CODE@"
     android:versionName="@APP_VERSION@" >
 
-    <uses-sdk android:minSdkVersion="19" android:targetSdkVersion="22" />
+    <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="22" />
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.INTERNET" />

--- a/tools/depends/target/xbmc/Makefile
+++ b/tools/depends/target/xbmc/Makefile
@@ -13,7 +13,7 @@ CONFIGURE = cp -f $(CONFIG_SUB) $(CONFIG_GUESS) build-aux/ ;\
   ./configure --prefix=$(PREFIX) $(DEBUG)
 
 ifeq ($(OS),android)
-CONFIGURE += --enable-codec=amcodec --enable-breakpad --disable-libcec
+CONFIGURE += --enable-breakpad --disable-libcec
 endif
 
 ifeq ($(Configuration),Release)


### PR DESCRIPTION
Reasoning:
- Android only started maturing after Android 5.0 as well as the devices
- AMLogic was the main codec used in the initial Android port however now it's now time to follow the official Android API. AMLogic doesn't completely follow this and that causes a lot of IFDEF / hacks to support both.
- We are too low on manpower to keep supporting hacks on this platform and the only sane way forward is following the official Android API.

The code is still there for now. This patch will simply stop compiling AMLogic for the Android platform. Should no one pick this up it will be completely removed for Android but could still be used for Linux. AMLogic code needs a complete rewrite anyway.
