### PR TITLE
configure.ac / xbmc_arch.m4: add support for powerpc64 little endian

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -618,7 +618,7 @@ case $host in
      CORE_SYSTEM_NAME=linux
      ARCH="powerpc-linux"
      ;;
-  powerpc64-*-linux-gnu*|powerpc64-*-linux-uclibc*)
+  powerpc64*-*-linux-gnu*|powerpc64*-*-linux-uclibc*)
      target_platform=target_linux
      CORE_SYSTEM_NAME=linux
      ARCH="powerpc64-linux"

--- a/m4/xbmc_arch.m4
+++ b/m4/xbmc_arch.m4
@@ -57,7 +57,7 @@ case $host in
   powerpc-*-linux-gnu*|powerpc-*-linux-uclibc*)
      AC_SUBST(ARCH_DEFINES, "-DTARGET_POSIX -DTARGET_LINUX -D_LINUX -D_POWERPC")
      ;;
-  powerpc64-*-linux-gnu*|powerpc64-*-linux-uclibc*)
+  powerpc64*-*-linux-gnu*|powerpc64*-*-linux-uclibc*)
      AC_SUBST(ARCH_DEFINES, "-DTARGET_POSIX -DTARGET_LINUX -D_LINUX -D_POWERPC64")
      ;;
   arm*-*-linux-gnu*|arm*-*-linux-uclibc*)


### PR DESCRIPTION
Fixes:
configure: error: unsupported host (powerpc64le-buildroot-linux-gnu)
configure: error: unsupported build target: powerpc64le-buildroot-linux-gnu

Cross-compiling Kodi git master using buildroot was successful.
