### PR TITLE
cmake: Handle generated files in core_add_test correctly

### DIFF
--- a/project/cmake/README.md
+++ b/project/cmake/README.md
@@ -135,6 +135,17 @@ cmake -DCMAKE_TOOLCHAIN_FILE=<KODI_SRC>/tools/depends/target/Toolchain.cmake <KO
 cmake --build . -- VERBOSE=1 -j$(nproc)  # or: make VERBOSE=1 -j$(nproc)
 ```
 
+## Tests
+
+Kodi uses Google Test as its testing framework. Each test file is scanned for tests and these
+are added to CTest, which is the native test driver for CMake.
+
+This scanning happens at configuration time. If tests depend on generated support files which
+should not be scanned, then those support files should be added to the SUPPORT_SOURCES
+variable as opposed to SOURCES before calling core_add_test. You might want to do this where
+the generated support files would not exist at configure time, or if they are so large that
+scanning them would take up an unreasonable amount of configure time.
+
 ## Extra targets
 
 When using the makefile builds a few extra targets are defined:

--- a/project/cmake/scripts/common/macros.cmake
+++ b/project/cmake/scripts/common/macros.cmake
@@ -41,9 +41,12 @@ endfunction()
 
 # Add a test library, and add sources to list for gtest integration macros
 function(core_add_test_library name)
+  # Backup the old SOURCES variable, since we'll append SUPPORT_SOURCES to it
+  set(TEST_ONLY_SOURCES ${SOURCES})
+  set(SOURCES ${SOURCES} ${SUPPORT_SOURCES})
   core_add_library(${name} NO_MAIN_DEPENDS)
   set_target_properties(${name} PROPERTIES EXCLUDE_FROM_ALL 1)
-  foreach(src ${SOURCES})
+  foreach(src ${TEST_ONLY_SOURCES})
     # This will prepend CMAKE_CURRENT_SOURCE_DIR if the path is relative,
     # otherwise use the absolute path.
     get_filename_component(src_path "${src}" ABSOLUTE)

--- a/project/cmake/scripts/common/macros.cmake
+++ b/project/cmake/scripts/common/macros.cmake
@@ -44,7 +44,10 @@ function(core_add_test_library name)
   core_add_library(${name} NO_MAIN_DEPENDS)
   set_target_properties(${name} PROPERTIES EXCLUDE_FROM_ALL 1)
   foreach(src ${SOURCES})
-    set(test_sources ${CMAKE_CURRENT_SOURCE_DIR}/${src} ${test_sources} CACHE STRING "" FORCE)
+    # This will prepend CMAKE_CURRENT_SOURCE_DIR if the path is relative,
+    # otherwise use the absolute path.
+    get_filename_component(src_path "${src}" ABSOLUTE)
+    set(test_sources "${src_path}" ${test_sources} CACHE STRING "" FORCE)
   endforeach()
   set(test_archives ${test_archives} ${name} CACHE STRING "" FORCE)
 endfunction()

--- a/project/cmake/scripts/common/projectmacros.cmake
+++ b/project/cmake/scripts/common/projectmacros.cmake
@@ -54,6 +54,9 @@ function(GTEST_ADD_TESTS executable extra_args)
         message(FATAL_ERROR "Missing ARGN: Read the documentation for GTEST_ADD_TESTS")
     endif()
     foreach(source ${ARGN})
+        # This assumes that every source file passed in exists. Consider using
+        # SUPPORT_SOURCES for source files which do not contain tests and might
+        # have to be generated.
         file(READ "${source}" contents)
         string(REGEX MATCHALL "TEST_?[F]?\\(([A-Za-z_0-9 ,]+)\\)" found_tests ${contents})
         foreach(hit ${found_tests})


### PR DESCRIPTION
Fixes #16708
