### PR TITLE
[python-api] - deprecate listitem.getduration(), .getfilename(), .getdescription()

### DIFF
--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -277,6 +277,12 @@ namespace XBMCAddon
       return item->GetPath();
     }
 
+    String ListItem::getPath()
+    {
+      LOCKGUI;
+      return item->GetPath();
+    }
+
     void ListItem::setInfo(const char* type, const InfoLabelDict& infoLabels)
     {
       LOCKGUI;

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -620,7 +620,7 @@ namespace XBMCAddon
       /// **Example:**
       /// ~~~~~~~~~~~~~{.py}
       /// ...
-      /// self.list.getSelectedItem().setPath(path='ActivateWindow(Weather)')
+      /// self.list.getSelectedItem().setPath(path='/path/to/some/file.ext')
       /// ...
       /// ~~~~~~~~~~~~~
       ///
@@ -691,9 +691,8 @@ namespace XBMCAddon
       /// \ingroup python_xbmcgui_listitem
       /// @brief \python_func{ getdescription() }
       ///-----------------------------------------------------------------------
-      /// Returns the description of this PlayListItem.
+      /// @warning Deprecated.
       ///
-      /// @return Description string of play list item
       ///
       getdescription();
 #else
@@ -705,9 +704,8 @@ namespace XBMCAddon
       /// \ingroup python_xbmcgui_listitem
       /// @brief \python_func{ getduration() }
       ///-----------------------------------------------------------------------
-      /// Returns the duration of this PlayListItem
+      /// @warning Deprecated.
       ///
-      /// @return duration as string
       ///
       getduration();
 #else
@@ -719,13 +717,26 @@ namespace XBMCAddon
       /// \ingroup python_xbmcgui_listitem
       /// @brief \python_func{ getfilename() }
       ///-----------------------------------------------------------------------
-      /// Returns the filename of this PlayListItem.
+      /// @warning Deprecated.
       ///
-      /// @return [string] filename
       ///
       getfilename();
 #else
       String getfilename();
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmcgui_listitem
+      /// @brief \python_func{ getPath() }
+      ///-----------------------------------------------------------------------
+      /// Returns the path of this listitem.
+      ///
+      /// @return [string] filename
+      ///
+      getPath();
+#else
+      String getPath();
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS


### PR DESCRIPTION
- getdescription() is basically getLabel(), just without locking, but with confusing naming instead. 
- getduration() should be done via InfoTagMusic
- no idea what getfilename() should be used for at all (docs from setPath() tell me that this is not the filename, and InfoTagVideo already has .getPath() and .getFile() available)

Also, all use wrong upper/lowercasing.

From my side we could remove all those directly. I guess @tamland wants them depracated for now?    
