### PR TITLE
[gui] - change lock for CGUIWindowManager::Render() to CSingleLock

### DIFF
--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -1063,7 +1063,7 @@ void CGUIWindowManager::RenderEx() const
 bool CGUIWindowManager::Render()
 {
   assert(g_application.IsCurrentThread());
-  CSingleExit lock(g_graphicsContext);
+  CSingleLock lock(g_graphicsContext);
 
   CDirtyRegionList dirtyRegions = m_tracker.GetDirtyRegions();
 


### PR DESCRIPTION
While playing with MediaWindow functionality of our Python interface, I noticed quite some regular crashing when using WindowXML.addItem(). 
@mapfau helped me finding the issue and it seems to be a wrong lock for our WindowManager Render() method. (LOCKGUI in WindowXML.cpp doesnt seem to kick in without this change)
@jimfcarroll and @FernetMenta may be able to provide valuable input here if this is a correct fix.
I guess the issue can happen for lot more methods, addItem() just makes it more likely for it to appear.

DISCLAIMER: I dont really have experience in this area, so I am completely dependent on the help of the experienced guys here. :) I opened this PR anyways to get a discussion going, would be great to get this fixed.

The 2 conflicting callstacks can be found here: http://pastebin.com/UQM2gNuL
