### PR TITLE
[python-api] remove checkmark control

### DIFF
--- a/xbmc/interfaces/legacy/Control.cpp
+++ b/xbmc/interfaces/legacy/Control.cpp
@@ -28,7 +28,6 @@
 #include "guilib/GUIFadeLabelControl.h"
 #include "guilib/GUITextBox.h"
 #include "guilib/GUIButtonControl.h"
-#include "guilib/GUICheckMarkControl.h"
 #include "guilib/GUIImage.h"
 #include "guilib/GUIListContainer.h"
 #include "guilib/GUIProgressControl.h"
@@ -304,115 +303,6 @@ namespace XBMCAddon
 
       pGuiButtonControl->SetLabel(strText);
       pGuiButtonControl->SetLabel2(strText2);
-
-      return pGUIControl;
-    }
-
-    // ============================================================
-
-    // ============================================================
-    // ============================================================
-    ControlCheckMark::ControlCheckMark(long x, long y, long width, long height, const String& label,
-                                       const char* focusTexture, const char* noFocusTexture,
-                                       long _checkWidth, long _checkHeight,
-                                       long _alignment, const char* font,
-                                       const char* _textColor, const char* _disabledColor) :
-      strFont("font13"), checkWidth(_checkWidth), checkHeight(_checkHeight),
-      align(_alignment), textColor(0xffffffff), disabledColor(0x60ffffff)
-    {
-      dwPosX = x;
-      dwPosY = y;
-      dwWidth = width;
-      dwHeight = height;
-
-      strText = label;
-      if (font) strFont = font;
-      if (_textColor) sscanf(_textColor, "%x", &textColor);
-      if (_disabledColor) sscanf( _disabledColor, "%x", &disabledColor );
-
-      strTextureFocus = focusTexture ?  focusTexture :
-        XBMCAddonUtils::getDefaultImage((char*)"checkmark", (char*)"texturefocus", (char*)"check-box.png");
-      strTextureNoFocus = noFocusTexture ? noFocusTexture :
-        XBMCAddonUtils::getDefaultImage((char*)"checkmark", (char*)"texturenofocus", (char*)"check-boxNF.png");
-    }
-
-    bool ControlCheckMark::getSelected()
-    {
-      bool isSelected = false;
-
-      if (pGUIControl)
-      {
-        LOCKGUI;
-        isSelected = ((CGUICheckMarkControl*)pGUIControl)->GetSelected();
-      }
-
-      return isSelected;
-    }
-
-    void ControlCheckMark::setSelected(bool selected)
-    {
-      if (pGUIControl)
-      {
-        LOCKGUI;
-        ((CGUICheckMarkControl*)pGUIControl)->SetSelected(selected);
-      }
-    }
-
-    void ControlCheckMark::setLabel(const String& label,
-                                    const char* font,
-                                    const char* _textColor,
-                                    const char* _disabledColor,
-                                    const char* _shadowColor,
-                                    const char* _focusedColor,
-                                    const String& label2)
-    {
-
-      if (font) strFont = font;
-      if (_textColor) sscanf(_textColor, "%x", &textColor);
-      if (_disabledColor) sscanf(_disabledColor, "%x", &disabledColor);
-
-      if (pGUIControl)
-      {
-        LOCKGUI;
-        ((CGUICheckMarkControl*)pGUIControl)->PythonSetLabel(strFont,strText,textColor);
-        ((CGUICheckMarkControl*)pGUIControl)->PythonSetDisabledColor(disabledColor);
-      }
-    }
-
-    void ControlCheckMark::setDisabledColor(const char* color)
-    {
-      if (color) sscanf(color, "%x", &disabledColor);
-
-      if (pGUIControl)
-      {
-        LOCKGUI;
-        ((CGUICheckMarkControl*)pGUIControl)->PythonSetDisabledColor( disabledColor );
-      }
-    }
-
-    CGUIControl* ControlCheckMark::Create()
-    {
-      CLabelInfo label;
-      label.disabledColor = disabledColor;
-      label.textColor = label.focusedColor = textColor;
-      label.font = g_fontManager.GetFont(strFont);
-      label.align = align;
-      CTextureInfo imageFocus(strTextureFocus);
-      CTextureInfo imageNoFocus(strTextureNoFocus);
-      pGUIControl = new CGUICheckMarkControl(
-        iParentId,
-        iControlId,
-        (float)dwPosX,
-        (float)dwPosY,
-        (float)dwWidth,
-        (float)dwHeight,
-        imageFocus, imageNoFocus,
-        (float)checkWidth,
-        (float)checkHeight,
-        label );
-
-      CGUICheckMarkControl* pGuiCheckMarkControl = (CGUICheckMarkControl*)pGUIControl;
-      pGuiCheckMarkControl->SetLabel(strText);
 
       return pGUIControl;
     }

--- a/xbmc/interfaces/legacy/Control.h
+++ b/xbmc/interfaces/legacy/Control.h
@@ -1189,117 +1189,6 @@ namespace XBMCAddon
 #endif
     };
 
-    // ControlCheckMark class
-    /**
-     * ControlCheckMark class.
-     * 
-     * ControlCheckMark(x, y, width, height, label[, focusTexture, noFocusTexture,
-     *                  checkWidth, checkHeight, alignment, font, textColor, disabledColor])
-     * 
-     * x              : integer - x coordinate of control.\n
-     * y              : integer - y coordinate of control.\n
-     * width          : integer - width of control.\n
-     * height         : integer - height of control.\n
-     * label          : string or unicode - text string.\n
-     * focusTexture   : [opt] string - filename for focus texture.\n
-     * noFocusTexture : [opt] string - filename for no focus texture.\n
-     * checkWidth     : [opt] integer - width of checkmark.\n
-     * checkHeight    : [opt] integer - height of checkmark.\n
-     * alignment      : [opt] integer - alignment of label - *Note, see xbfont.h\n
-     * font           : [opt] string - font used for label text. (e.g. 'font13')\n
-     * textColor      : [opt] hexstring - color of enabled checkmark's label. (e.g. '0xFFFFFFFF')\n
-     * disabledColor  : [opt] hexstring - color of disabled checkmark's label. (e.g. '0xFFFF3300')
-     * 
-     * *Note, You can use the above as keywords for arguments and skip certain optional arguments.\n
-     *        Once you use a keyword, all following arguments require the keyword.\n
-     *        After you create the control, you need to add it to the window with addControl().
-     * 
-     * example:
-     *   - self.checkmark = xbmcgui.ControlCheckMark(100, 250, 200, 50, 'Status', font='font14')
-     */
-    class ControlCheckMark : public Control
-    {
-    public:
-
-      ControlCheckMark(long x, long y, long width, long height, const String& label,
-                       const char* focusTexture = NULL, const char* noFocusTexture = NULL, 
-                       long checkWidth = 30, long checkHeight = 30,
-                       long _alignment = XBFONT_RIGHT, const char* font = NULL, 
-                       const char* textColor = NULL, const char* disabledColor = NULL);
-
-      // getSelected() Method
-      /**
-       * getSelected() -- Returns the selected status for this checkmark as a bool.
-       * 
-       * example:
-       *   - selected = self.checkmark.getSelected()
-       */
-      virtual bool getSelected();
-
-      // setSelected() Method
-      /**
-       * setSelected(isOn) -- Sets this checkmark status to on or off.
-       * 
-       * isOn           : bool - True=selected (on) / False=not selected (off)
-       * 
-       * example:
-       *   - self.checkmark.setSelected(True)
-       */
-      virtual void setSelected(bool selected);
-
-      // setLabel() Method
-      /**
-       * setLabel(label[, font, textColor, disabledColor]) -- Set's this controls text attributes.
-       * 
-       * label          : string or unicode - text string.\n
-       * font           : [opt] string - font used for label text. (e.g. 'font13')\n
-       * textColor      : [opt] hexstring - color of enabled checkmark's label. (e.g. '0xFFFFFFFF')\n
-       * disabledColor  : [opt] hexstring - color of disabled checkmark's label. (e.g. '0xFFFF3300')
-       * 
-       * example:
-       *   - self.checkmark.setLabel('Status', 'font14', '0xFFFFFFFF', '0xFFFF3300')
-       */
-      virtual void setLabel(const String& label = emptyString, 
-                            const char* font = NULL,
-                            const char* textColor = NULL,
-                            const char* disabledColor = NULL,
-                            const char* shadowColor = NULL,
-                            const char* focusedColor = NULL,
-                            const String& label2 = emptyString);
-
-      // setDisabledColor() Method
-      /**
-       * setDisabledColor(disabledColor) -- Set's this controls disabled color.
-       * 
-       * disabledColor  : hexstring - color of disabled checkmark's label. (e.g. '0xFFFF3300')
-       * 
-       * example:
-       *   - self.checkmark.setDisabledColor('0xFFFF3300')
-       */
-      virtual void setDisabledColor(const char* color);
-
-#ifndef SWIG
-      SWIGHIDDENVIRTUAL bool canAcceptMessages(int actionId) { return true; }
-
-      std::string strFont;
-      int checkWidth;
-      int checkHeight;
-      uint32_t align;
-      color_t textColor;
-      color_t disabledColor;
-      std::string strTextureFocus;
-      std::string strTextureNoFocus;
-      std::string strText;
-
-      SWIGHIDDENVIRTUAL CGUIControl* Create();
-
-      ControlCheckMark() :
-        checkWidth  (0),
-        checkHeight (0)
-      {}
-#endif
-    };
-
     // ControlGroup class
     /**
      * ControlGroup class.
@@ -1348,8 +1237,8 @@ namespace XBMCAddon
      * textOffsetY       : [opt] integer - vertical text offset\n
      * alignment         : [opt] integer - alignment of label - *Note, see xbfont.h\n
      * font              : [opt] string - font used for label text. (e.g. 'font13')\n
-     * textColor         : [opt] hexstring - color of enabled checkmark's label. (e.g. '0xFFFFFFFF')\n
-     * disabledColor     : [opt] hexstring - color of disabled checkmark's label. (e.g. '0xFFFF3300')
+     * textColor         : [opt] hexstring - color of label when control is enabled. (e.g. '0xFFFFFFFF')\n
+     * disabledColor     : [opt] hexstring - color of label when control is disabled. (e.g. '0xFFFF3300')
      * 
      * *Note, You can use the above as keywords for arguments and skip certain optional arguments.\n
      *        Once you use a keyword, all following arguments require the keyword.\n

--- a/xbmc/interfaces/legacy/Window.cpp
+++ b/xbmc/interfaces/legacy/Window.cpp
@@ -22,7 +22,6 @@
 #include "WindowInterceptor.h"
 #include "guilib/GUIButtonControl.h"
 #include "guilib/GUIEditControl.h"
-#include "guilib/GUICheckMarkControl.h"
 #include "guilib/GUIRadioButtonControl.h"
 #include "guilib/GUIWindowManager.h"
 #include "Application.h"
@@ -292,18 +291,6 @@ namespace XBMCAddon
         ((ControlButton*)pControl)->shadowColor   = li.shadowColor;
         if (li.font) ((ControlButton*)pControl)->strFont = li.font->GetFontName();
         ((ControlButton*)pControl)->align = li.align;
-        break;
-      case CGUIControl::GUICONTROL_CHECKMARK:
-        pControl = new ControlCheckMark();
-
-        li = ((CGUICheckMarkControl *)pGUIControl)->GetLabelInfo();
-
-        // note: conversion to plain colors from infocolors.
-        ((ControlCheckMark*)pControl)->disabledColor = li.disabledColor;
-        //((ControlCheckMark*)pControl)->shadowColor = li.shadowColor;
-        ((ControlCheckMark*)pControl)->textColor  = li.textColor;
-        if (li.font) ((ControlCheckMark*)pControl)->strFont = li.font->GetFontName();
-        ((ControlCheckMark*)pControl)->align = li.align;
         break;
       case CGUIControl::GUICONTROL_LABEL:
         pControl = new ControlLabel();

--- a/xbmc/interfaces/legacy/Window.h
+++ b/xbmc/interfaces/legacy/Window.h
@@ -440,7 +440,6 @@ namespace XBMCAddon
        *   -ControlFadeLabel
        *   -ControlTextBox
        *   -ControlButton
-       *   -ControlCheckMark
        *   -ControlList
        *   -ControlGroup
        *   -ControlImage


### PR DESCRIPTION
Removes the checkmark control stuff from our Python interface.
Checkmark controls are deprecated since a long time and should get ripped from core completely (Most skinners also dont define them in defaults.xml) . This is a first small step.
@ronie @tamland         
