### PR TITLE
[addondb] Enable addons by type when syncing the database with the filesystem

### DIFF
--- a/xbmc/addons/AddonDatabase.cpp
+++ b/xbmc/addons/AddonDatabase.cpp
@@ -240,8 +240,11 @@ void CAddonDatabase::SyncInstalled(const std::set<std::string>& ids, const std::
     std::string now = CDateTime::GetCurrentDateTime().GetAsDBDateTime();
     BeginTransaction();
     for (const auto& id : added)
+    {
+      int enable = CAddonMgr::GetInstance().EnabledOnSync(id) ? 1 : 0;
       m_pDS->exec(PrepareSQL("INSERT INTO installed(addonID, enabled, installDate) "
-          "VALUES('%s', 0, '%s')", id.c_str(), now.c_str()));
+          "VALUES('%s', %d, '%s')", id.c_str(), enable, now.c_str()));
+    }
 
     for (const auto& id : removed)
     {

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -1158,6 +1158,38 @@ void CAddonMgr::StopServices(const bool onlylogin)
   }
 }
 
+bool CAddonMgr::EnabledOnSync(const std::string& id)
+{
+  CSingleLock lock(m_critSection);
+
+  bool bEnabled = false;
+
+  cp_status_t status;
+  cp_plugin_info_t *cpaddon = m_cpluff->get_plugin_info(m_cp_context, id.c_str(), &status);
+  if (status == CP_OK && cpaddon)
+  {
+    AddonPtr addon = Factory(cpaddon, ADDON_UNKNOWN);
+    if (addon)
+    {
+      switch (addon->Type())
+      {
+      case ADDON_PERIPHERALDLL:
+        bEnabled = true; // Enabled by default until addon-manifest.xml supports "optional" add-ons
+        break;
+      case ADDON_GAME_CONTROLLER:
+        bEnabled = true;
+        break;
+      default:
+        break;
+      }
+    }
+  }
+  if (cpaddon)
+    m_cpluff->release_info(m_cp_context, cpaddon);
+
+  return bEnabled;
+}
+
 int cp_to_clog(cp_log_severity_t lvl)
 {
   if (lvl >= CP_LOG_ERROR)

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -250,6 +250,11 @@ namespace ADDON
     static AddonPtr Factory(const cp_plugin_info_t* plugin, TYPE type, CAddonBuilder& builder);
     static void FillCpluffMetadata(const cp_plugin_info_t* plugin, CAddonBuilder& builder);
 
+    /*! \brief Return true if the addon should be enabled when syncing
+               installed add-ons to the database
+    */
+    bool EnabledOnSync(const std::string& id);
+
   private:
 
     /* libcpluff */


### PR DESCRIPTION
Kodi keeps the add-on database in sync with the filesystem. This means that when an add-on is copied manually, Kodi adds it to the database. This also means that when the database is deleted or Kodi is first run, all add-ons are added to the database.

The current behavior is that Kodi sets all add-ons to disabled when they are added to the database. Then, if the add-on is a system add-on (appears in [addon-manifest.xml](https://github.com/xbmc/xbmc/blob/master/system/addon-manifest.xml)), it is enabled.

This PR causes Peripheral add-ons (and harmless controller profiles) to be enabled when syncing to the database.

Going forward, an "optional" parameter should be added to addon-manifest.xml. Optional add-ons shouldn't prevent Kodi from starting, and the user should be allowed to disable them.

Once that's possible, we can remove the peripheral add-ons special case added here. 
