### PR TITLE
Optional addons

### DIFF
--- a/system/addon-manifest.xml
+++ b/system/addon-manifest.xml
@@ -42,4 +42,5 @@
   <addon>xbmc.pvr</addon>
   <addon>xbmc.python</addon>
   <addon>xbmc.webinterface</addon>
+  <addon optional="true">peripheral.joystick</addon>
 </addons>

--- a/xbmc/addons/AddonDatabase.h
+++ b/xbmc/addons/AddonDatabase.h
@@ -129,7 +129,9 @@ public:
   /*! Clear internal fields that shouldn't be kept around indefinitely */
   void OnPostUnInstall(const std::string& addonId);
 
-  void SyncInstalled(const std::set<std::string>& ids, const std::set<std::string>& enabled);
+  void SyncInstalled(const std::set<std::string>& ids,
+                     const std::set<std::string>& system,
+                     const std::set<std::string>& optional);
 
   void GetInstalled(std::vector<ADDON::CAddonBuilder>& addons);
 

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -272,6 +272,7 @@ namespace ADDON
     CCriticalSection m_critSection;
     CAddonDatabase m_database;
     std::set<std::string> m_systemAddons;
+    std::set<std::string> m_optionalAddons;
   };
 
 }; /* namespace ADDON */


### PR DESCRIPTION
Adds optional add-ons to addon-manifest.xml

Optional add-ons are only used to set the enabled bit when add-ons are synced from the filesystem to the database. They do not participate in the other functions of system add-ons, such as preventing Kodi from starting or blocking being disabled in the GUI.

Replaces #9700
