### PR TITLE
[adsp] remove usage of list item entries on skins

### DIFF
--- a/addons/skin.estouchy/xml/DialogAudioDSPManager.xml
+++ b/addons/skin.estouchy/xml/DialogAudioDSPManager.xml
@@ -116,43 +116,6 @@
 					<aligny>center</aligny>
 				</control>
 			</focusedlayout>
-			<content>
-				<item id="91">
-					<label>1. $LOCALIZE[15057]</label>
-					<label2>$LOCALIZE[15114]</label2>
-					<visible>true</visible>
-					<onclick>noop</onclick>
-					<property name="currentMode">InputResampling</property>
-				</item>
-				<item id="92">
-					<label>2. $LOCALIZE[15058]</label>
-					<label2>$LOCALIZE[15113]</label2>
-					<visible>true</visible>
-					<onclick>noop</onclick>
-					<property name="currentMode">Preprocessing</property>
-				</item>
-				<item id="93">
-					<label>3. $LOCALIZE[15059]</label>
-					<label2>$LOCALIZE[15115]</label2>
-					<visible>true</visible>
-					<onclick>noop</onclick>
-					<property name="currentMode">Masterprocessing</property>
-				</item>
-				<item id="94">
-					<label>4. $LOCALIZE[15060]</label>
-					<label2>$LOCALIZE[15117]</label2>
-					<visible>true</visible>
-					<onclick>noop</onclick>
-					<property name="currentMode">Postprocessing</property>
-				</item>
-				<item id="95">
-					<label>5. $LOCALIZE[15061]</label>
-					<label2>$LOCALIZE[15116]</label2>
-					<visible>true</visible>
-					<onclick>noop</onclick>
-					<property name="currentMode">OutputResampling</property>
-				</item>
-			</content>
 		</control>
 		<control type="textbox">
 			<posx>20</posx>

--- a/addons/skin.estuary/1080i/DialogAudioDSPManager.xml
+++ b/addons/skin.estuary/1080i/DialogAudioDSPManager.xml
@@ -66,38 +66,6 @@
 					<label>$INFO[ListItem.Label]</label>
 				</control>
 			</focusedlayout>
-			<content>
-				<item id="91">
-					<label>$LOCALIZE[15057]</label>
-					<label2>$LOCALIZE[15114]</label2>
-					<onclick>noop</onclick>
-					<property name="currentMode">InputResampling</property>
-				</item>
-				<item id="92">
-					<label>$LOCALIZE[15058]</label>
-					<label2>$LOCALIZE[15113]</label2>
-					<onclick>noop</onclick>
-					<property name="currentMode">Preprocessing</property>
-				</item>
-				<item id="93">
-					<label>$LOCALIZE[15059]</label>
-					<label2>$LOCALIZE[15115]</label2>
-					<onclick>noop</onclick>
-					<property name="currentMode">Masterprocessing</property>
-				</item>
-				<item id="94">
-					<label>$LOCALIZE[15060]</label>
-					<label2>$LOCALIZE[15117]</label2>
-					<onclick>noop</onclick>
-					<property name="currentMode">Postprocessing</property>
-				</item>
-				<item id="95">
-					<label>$LOCALIZE[15061]</label>
-					<label2>$LOCALIZE[15116]</label2>
-					<onclick>noop</onclick>
-					<property name="currentMode">OutputResampling</property>
-				</item>
-			</content>
 		</control>
 		<control type="group" id="200">
 			<description>available- and active mode lists</description>

--- a/xbmc/settings/dialogs/GUIDialogAudioDSPManager.cpp
+++ b/xbmc/settings/dialogs/GUIDialogAudioDSPManager.cpp
@@ -55,15 +55,17 @@ typedef struct
 {
   const char* sModeType;
   int iModeType;
+  int iName;
+  int iDescription;
 } DSP_MODE_TYPES;
 
 static const DSP_MODE_TYPES dsp_mode_types[] = {
-  { "preprocessing",    AE_DSP_MODE_TYPE_PRE_PROCESS },
-  { "inputresampling",  AE_DSP_MODE_TYPE_INPUT_RESAMPLE },
-  { "masterprocessing", AE_DSP_MODE_TYPE_MASTER_PROCESS },
-  { "outputresampling", AE_DSP_MODE_TYPE_OUTPUT_RESAMPLE },
-  { "postprocessing",   AE_DSP_MODE_TYPE_POST_PROCESS },
-  { "undefined",        AE_DSP_MODE_TYPE_UNDEFINED }
+  { "inputresampling",  AE_DSP_MODE_TYPE_INPUT_RESAMPLE,  15057, 15114 },
+  { "preprocessing",    AE_DSP_MODE_TYPE_PRE_PROCESS,     15058, 15113 },
+  { "masterprocessing", AE_DSP_MODE_TYPE_MASTER_PROCESS,  15059, 15115 },
+  { "postprocessing",   AE_DSP_MODE_TYPE_POST_PROCESS,    15060, 15117 },
+  { "outputresampling", AE_DSP_MODE_TYPE_OUTPUT_RESAMPLE, 15061, 15116 },
+  { "undefined",        AE_DSP_MODE_TYPE_UNDEFINED,       0,     0 }
 };
 
 CGUIDialogAudioDSPManager::CGUIDialogAudioDSPManager(void)
@@ -704,14 +706,24 @@ void CGUIDialogAudioDSPManager::Update()
     return;
   }
 
-  for (int iModeType = 0; iModeType < AE_DSP_MODE_TYPE_MAX; iModeType++)
+  // construct a CFileItemList to pass 'em on to the list
+  CFileItemList items;
+  for (int i = 0; i < AE_DSP_MODE_TYPE_MAX; ++i)
   {
+    int iModeType = dsp_mode_types[i].iModeType;
+
     modes.clear();
     db.GetModes(modes, iModeType);
 
     // No modes available, nothing to do.
     if (!modes.empty())
     {
+      CFileItemPtr item(new CFileItem());
+      item->SetLabel(g_localizeStrings.Get(dsp_mode_types[i].iName));
+      item->SetLabel2(g_localizeStrings.Get(dsp_mode_types[i].iDescription));
+      item->SetProperty("currentMode", dsp_mode_types[i].sModeType);
+      items.Add(item);
+
       AE_DSP_MENUHOOK_CAT menuHook = helper_GetMenuHookCategory(iModeType);
       int continuesNo = 1;
       for (unsigned int iModePtr = 0; iModePtr < modes.size(); iModePtr++)
@@ -741,6 +753,9 @@ void CGUIDialogAudioDSPManager::Update()
 
     }
   }
+
+  CGUIMessage msg(GUI_MSG_LABEL_BIND, GetID(), CONTROL_LIST_MODE_SELECTION, 0, 0, &items);
+  OnMessage(msg);
 
   db.Close();
 


### PR DESCRIPTION
This remove the set of list entries on skin itself and do this on code side.

Further becomes with this way only the Mode type shown who is present.

Here screenshots about the changes
![screenshot](https://cloud.githubusercontent.com/assets/6879739/14914422/4716c000-0e0a-11e6-9efa-6563f0e9b348.png)

![screenshot1](https://cloud.githubusercontent.com/assets/6879739/14914430/4c493fda-0e0a-11e6-86f7-0c3976b79b11.png)

![screenshot2](https://cloud.githubusercontent.com/assets/6879739/14914431/52374266-0e0a-11e6-82e4-304942f8d599.png)
