### PR TITLE
[guilib] - fix for multiimage controls in case imagepath switches to empty

### DIFF
--- a/xbmc/guilib/GUIMultiImage.cpp
+++ b/xbmc/guilib/GUIMultiImage.cpp
@@ -103,7 +103,7 @@ void CGUIMultiImage::UpdateInfo(const CGUIListItem *item)
       texturePath = m_texturePath.GetItemLabel(item, true);
     else
       texturePath = m_texturePath.GetLabel(m_parentID);
-    if (texturePath != m_currentPath && !texturePath.empty())
+    if (texturePath != m_currentPath)
     {
       // a new path - set our current path and tell ourselves to load our directory
       m_currentPath = texturePath;
@@ -138,6 +138,8 @@ void CGUIMultiImage::Process(unsigned int currentTime, CDirtyRegionList &dirtyre
       }
     }
   }
+  else
+    m_image.SetFileName("");
 
   if (g_graphicsContext.SetClipRegion(m_posX, m_posY, m_width, m_height))
   {


### PR DESCRIPTION
At the moment the content of multiimage controls does not clear when switching to an empty path, so you still get the image(s) of the previous path. 
I think @BigNoid also stumbled over this one already.  
@ronie for confirmation and perhaps @mkortstiege for code in case you have some minutes :)      
