### PR TITLE
wrap skin debug info

### DIFF
--- a/xbmc/windows/GUIWindowDebugInfo.cpp
+++ b/xbmc/windows/GUIWindowDebugInfo.cpp
@@ -141,7 +141,7 @@ void CGUIWindowDebugInfo::Process(unsigned int currentTime, CDirtyRegionList &di
         windowName += " (" + std::string(window->GetProperty("xmlfile").asString()) + ")";
       else
         windowName = window->GetProperty("xmlfile").asString();
-      info += "Window: " + windowName + "  ";
+      info += "Window: " + windowName + "\n";
       // transform the mouse coordinates to this window's coordinates
       g_graphicsContext.SetScalingResolution(window->GetCoordsRes(), true);
       point.x *= g_graphicsContext.GetGUIScaleX();


### PR DESCRIPTION
wrap skin debug info across multiple lines, to avoid running off screen.

![skindebug](https://cloud.githubusercontent.com/assets/687265/14941564/41dc2796-0fa0-11e6-93d2-29492a45406b.jpg)
