### PR TITLE
[python] - whitelist some GUI_MSG_NOTIFY_ALL messages for WindowXML windows

### DIFF
--- a/xbmc/interfaces/legacy/WindowXML.cpp
+++ b/xbmc/interfaces/legacy/WindowXML.cpp
@@ -327,7 +327,9 @@ namespace XBMCAddon
         break;
 
       case GUI_MSG_NOTIFY_ALL:
-        // GUI_MSG_NOTIFY_ALL breaks container content, so intercept it.
+        // most messages from GUI_MSG_NOTIFY_ALL break container content, whitelist working ones.
+        if (message.GetParam1() == GUI_MSG_PAGE_CHANGE || message.GetParam1() == GUI_MSG_WINDOW_RESIZE)
+          return A(CGUIMediaWindow::OnMessage(message));
         return true;
 
       case GUI_MSG_CLICKED:


### PR DESCRIPTION
Turns out that intercepting all GUI_MSG_NOTIFY_ALL  messages , as done in https://github.com/xbmc/xbmc/pull/9605, was a bit too restrictive, since we need GUI_MSG_PAGE_CHANGE  for scrollbar navigation. This fixes it by whitelisting some workin messages ( think that´s easier than blacklisting in this case).
@ronie and @tamland 
