### PR TITLE
cosmetics - display correct window name

### DIFF
--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -331,8 +331,8 @@ static const ActionMapping windows[] =
     { "screencalibration"        , WINDOW_SCREEN_CALIBRATION },
     { "guicalibration"           , WINDOW_SCREEN_CALIBRATION },        // backward compat
     { "systemsettings"           , WINDOW_SETTINGS_SYSTEM },
-    { "networksettings"          , WINDOW_SETTINGS_SERVICE },          // backward compat
     { "servicesettings"          , WINDOW_SETTINGS_SERVICE },
+    { "networksettings"          , WINDOW_SETTINGS_SERVICE },          // backward compat
     { "pvrsettings"              , WINDOW_SETTINGS_MYPVR },
     { "tvsettings"               , WINDOW_SETTINGS_MYPVR },            // backward compat
     { "playersettings"           , WINDOW_SETTINGS_PLAYER },


### PR DESCRIPTION
the first name assigned to WINDOW_SETTINGS_SERVICE is shown in the GUI (when debugging is enabled). it should be servicesettings, not the deprecated networksettings.

@HitcherUK 
