### PR TITLE
fix rating / votes infolabels

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -11898,7 +11898,7 @@ msgstr ""
 #. Label for showing media rating and votes (combined), for example: "9.1 (87 votes)"
 #: xbmc/GUIInfoManager.cpp
 msgctxt "#20350"
-msgid "%.1f (%i votes)"
+msgid "%s (%s votes)"
 msgstr ""
 
 #: xbmc/video/jobs/VideoLibraryRefreshingJob.cpp


### PR DESCRIPTION
this (accidentally?) slipped in with the settings shuffle and breaks rating / votes in the gui.
see: http://forum.kodi.tv/showthread.php?tid=272322

@jjd-uk
