### PR TITLE
[aml] Fix includes in amcodec/codec.h to make them relative

### DIFF
--- a/tools/depends/target/libamplayer/libamplayer/include/amcodec/codec.h
+++ b/tools/depends/target/libamplayer/libamplayer/include/amcodec/codec.h
@@ -12,8 +12,8 @@
 #ifndef CODEC_CTRL_H_
 #define CODEC_CTRL_H_
 
-#include <codec_type.h>
-#include <codec_error.h>
+#include "codec_type.h"
+#include "codec_error.h"
 
 
 int codec_init(codec_para_t *);

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/Makefile.in
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/Makefile.in
@@ -24,8 +24,6 @@ endif
 ifeq (@USE_LIBAMCODEC@,1)
 SRCS += AMLCodec.cpp
 SRCS += DVDVideoCodecAmlogic.cpp
-INCLUDES += -I$(prefix)/include/amcodec
-INCLUDES += -I$(prefix)/include/amplayer
 endif
 
 ifeq (@USE_ANDROID@,1)


### PR DESCRIPTION
Fix includes in amcodec/codec.h to make them relative. This will allow to drop the patches like https://github.com/OpenELEC/OpenELEC.tv/blob/master/projects/WeTek_Core/patches/kodi/0005-aml-Fix-compiler-badness-when-compiling-with-amcodec.patch in OpenELEC while still have successful Android builds with amcodec.
