### PR TITLE
Fix CEC not being detected in master tree builds

### DIFF
--- a/project/cmake/modules/FindCEC.cmake
+++ b/project/cmake/modules/FindCEC.cmake
@@ -15,7 +15,7 @@
 #   CEC::CEC   - The libCEC library
 
 if(PKG_CONFIG_FOUND)
-  pkg_check_modules(PC_CEC libCEC>=3.0.0 QUIET)
+  pkg_check_modules(PC_CEC libCEC>=3.1.0 QUIET)
 endif()
 
 find_path(CEC_INCLUDE_DIR libCEC/CEC.h


### PR DESCRIPTION
libcec3 3.0.1 would not work.
once I upgraded the build to libcec 3.1.0 it was fine.

If this is coincidence due to this new version using p8-platform as a build-dep (name rebrand only I thought), please just close the PR.
