### PR TITLE
fixed: regression from a00a747b6c1ba633e8d83adcf50f93ce888f65dd

### DIFF
--- a/xbmc/input/InputManager.cpp
+++ b/xbmc/input/InputManager.cpp
@@ -609,6 +609,17 @@ bool CInputManager::ExecuteInputAction(const CAction &action)
   return bResult;
 }
 
+bool CInputManager::HasBuiltin(const std::string& command)
+{
+#if defined(HAS_LIRC) || defined(HAS_IRSERVERSUITE)
+  return command == "lirc.stop"  ||
+         command ==" lirc.start" ||
+         command == "lirc.send";
+#endif
+
+  return false;
+}
+
 int CInputManager::ExecuteBuiltin(const std::string& execute, const std::vector<std::string>& params)
 {
 #if defined(HAS_LIRC) || defined(HAS_IRSERVERSUITE)

--- a/xbmc/input/InputManager.h
+++ b/xbmc/input/InputManager.h
@@ -204,6 +204,10 @@ public:
    */
   void SetRemoteControlName(const std::string& name);
 
+  /*! \brief Returns whether or not we can handle a given built-in command. */
+
+  bool HasBuiltin(const std::string& command);
+
   /*! \brief Parse a builtin command and execute any input action
    *  currently only LIRC commands implemented
    *

--- a/xbmc/interfaces/builtins/Builtins.cpp
+++ b/xbmc/interfaces/builtins/Builtins.cpp
@@ -92,6 +92,10 @@ bool CBuiltins::HasCommand(const std::string& execString)
   std::vector<std::string> parameters;
   CUtil::SplitExecFunction(execString, function, parameters);
   StringUtils::ToLower(function);
+
+  if (CInputManager::GetInstance().HasBuiltin(function))
+    return true;
+
   const auto& it = m_command.find(function);
   if (it != m_command.end())
   {


### PR DESCRIPTION
LIRC commands would not be recognized. This was due to my
refactoring happening before the move of the LIRC-related
input builtins to the InputManager.
