### PR TITLE
[linux] mk-debian-package. Remove tar -h flag, causes issues with dpkg-source

### DIFF
--- a/tools/Linux/packaging/mk-debian-package.sh
+++ b/tools/Linux/packaging/mk-debian-package.sh
@@ -104,7 +104,7 @@ function archiveRepo {
     DEST="kodi-${RELEASEV}~git${BUILD_DATE}-${TAG}"
     [[ -d debian ]] && rm -rf debian
     cd ..
-    tar -czf ${DEST}.tar.gz -h --exclude .git $(basename $REPO_DIR)
+    tar -czf ${DEST}.tar.gz --exclude .git $(basename $REPO_DIR)
     ln -s ${DEST}.tar.gz ${DEST/-/_}.orig.tar.gz
     echo "Output Archive: ${DEST}.tar.gz"
 


### PR DESCRIPTION
 mk-debian-package.sh uses -h on tar, which causes conflicts during the operations of dpkg-source :

See: http://forum.kodi.tv/showthread.php?tid=272185&pid=2325530#pid2325530

Example:

```
dpkg-source -b kodi-source
dpkg-source: info: using source format `3.0 (quilt)'
dpkg-source: info: building kodi using existing ./kodi_17.0a1-Krypton~git20160501.1203-bee0201.orig.tar.gz
dpkg-source: error: cannot represent change to project/cmake/scripts/ios/install.cmake:
dpkg-source: error:   new version is symlink to ../darwin/install.cmake
dpkg-source: error:   old version is plain file
```

Snip from 'man tar'

```
-h, --dereference
              don’t dump symlinks; dump the files they point to
```
