### PR TITLE
RenderManager: Fix use of unitialized variables

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -126,24 +126,37 @@ void CRenderManager::CClockSync::Reset()
 
 unsigned int CRenderManager::m_nextCaptureId = 0;
 
-CRenderManager::CRenderManager(CDVDClock &clock, IRenderMsg *player) : m_dvdClock(clock)
+CRenderManager::CRenderManager(CDVDClock &clock, IRenderMsg *player) :
+  m_pRenderer(nullptr),
+  m_bTriggerUpdateResolution(false),
+  m_bRenderGUI(true),
+  m_waitForBufferCount(0),
+  m_rendermethod(0),
+  m_renderedOverlay(false),
+  m_renderDebug(false),
+  m_renderState(STATE_UNCONFIGURED),
+  m_displayLatency(0.0),
+  m_videoDelay(0),
+  m_QueueSize(2),
+  m_QueueSkip(0),
+  m_format(RENDER_FMT_NONE),
+  m_width(0),
+  m_height(0),
+  m_dwidth(0),
+  m_dheight(0),
+  m_fps(0.0f),
+  m_extended_format(0),
+  m_orientation(0),
+  m_NumberBuffers(0),
+  m_lateframes(-1),
+  m_presentpts(0.0),
+  m_presentstep(PRESENT_IDLE),
+  m_presentsource(0),
+  m_dvdClock(clock),
+  m_playerPort(player),
+  m_captureWaitCounter(0),
+  m_hasCaptures(false)
 {
-  m_pRenderer = nullptr;
-  m_renderState = STATE_UNCONFIGURED;
-
-  m_presentstep = PRESENT_IDLE;
-  m_rendermethod = 0;
-  m_presentsource = 0;
-  m_bTriggerUpdateResolution = false;
-  m_hasCaptures = false;
-  m_displayLatency = 0.0f;
-  m_QueueSize   = 2;
-  m_QueueSkip   = 0;
-  m_format      = RENDER_FMT_NONE;
-  m_renderedOverlay = false;
-  m_captureWaitCounter = 0;
-  m_playerPort = player;
-  m_renderDebug = false;
 }
 
 CRenderManager::~CRenderManager()


### PR DESCRIPTION
RenderManager relies on VideoPlayer to initialize m_videoDelay, but this caused loss of video in my RetroPlayer branch. Also, m_width and m_height are first used uninitialized in a `!=` comparison, so uninitialized values are unlikely to cause an issue.

 Still, better to be correct than lucky.
