### PR TITLE
[pvr] improvement for independent API levels

### DIFF
--- a/xbmc/addons/PVRClient.cpp
+++ b/xbmc/addons/PVRClient.cpp
@@ -417,8 +417,8 @@ bool CPVRClient::GetAddonProperties(void)
   try
   {
     memset(&addonCapabilities, 0, sizeof(addonCapabilities));
-    PVR_ERROR retVal = m_pStruct->GetAddonCapabilities(&addonCapabilities);
-    if (retVal != PVR_ERROR_NO_ERROR)
+    PVRError retVal = TranslateError(m_pStruct->GetAddonCapabilities(&addonCapabilities));
+    if (retVal != PVRError_NO_ERROR)
     {
       CLog::Log(LOGERROR, "PVR - couldn't get the capabilities for add-on '%s'. Please contact the developer of this add-on: %s", GetFriendlyName().c_str(), Author().c_str());
       return false;
@@ -453,9 +453,9 @@ bool CPVRClient::GetAddonProperties(void)
       std::unique_ptr<PVR_TIMER_TYPE[]> types_array(new PVR_TIMER_TYPE[PVR_ADDON_TIMERTYPE_ARRAY_SIZE]);
       int size = PVR_ADDON_TIMERTYPE_ARRAY_SIZE;
 
-      PVR_ERROR retval = m_pStruct->GetTimerTypes(types_array.get(), &size);
+      PVRError retval = TranslateError(m_pStruct->GetTimerTypes(types_array.get(), &size));
 
-      if (retval == PVR_ERROR_NOT_IMPLEMENTED)
+      if (retval == PVRError_NOT_IMPLEMENTED)
       {
         // begin compat section
         CLog::Log(LOGWARNING, "%s - Addon %s does not support timer types. It will work, but not benefit from the timer features introduced with PVR Addon API 2.0.0", __FUNCTION__, strFriendlyName.c_str());
@@ -513,11 +513,11 @@ bool CPVRClient::GetAddonProperties(void)
           ++size;
         }
 
-        retval = PVR_ERROR_NO_ERROR;
+        retval = PVRError_NO_ERROR;
         // end compat section
       }
 
-      if (retval == PVR_ERROR_NO_ERROR)
+      if (retval == PVRError_NO_ERROR)
       {
         timerTypes.reserve(size);
         for (int i = 0; i < size; ++i)
@@ -601,50 +601,50 @@ const std::string& CPVRClient::GetFriendlyName(void) const
   return m_strFriendlyName;
 }
 
-PVR_ERROR CPVRClient::GetDriveSpace(long long *iTotal, long long *iUsed)
+PVRError CPVRClient::GetDriveSpace(long long *iTotal, long long *iUsed)
 {
   if (!m_bReadyToUse)
-    return PVR_ERROR_SERVER_ERROR;
+    return PVRError_SERVER_ERROR;
 
-  try { return m_pStruct->GetDriveSpace(iTotal, iUsed); }
+  try { return TranslateError(m_pStruct->GetDriveSpace(iTotal, iUsed)); }
   catch (std::exception &e) { LogException(e, __FUNCTION__); }
 
   /* default to 0 on error */
   *iTotal = 0;
   *iUsed  = 0;
 
-  return PVR_ERROR_UNKNOWN;
+  return PVRError_UNKNOWN;
 }
 
-PVR_ERROR CPVRClient::StartChannelScan(void)
+PVRError CPVRClient::StartChannelScan(void)
 {
   if (!m_bReadyToUse)
-    return PVR_ERROR_SERVER_ERROR;
+    return PVRError_SERVER_ERROR;
 
   if (!m_addonCapabilities.bSupportsChannelScan)
-    return PVR_ERROR_NOT_IMPLEMENTED;
+    return PVRError_NOT_IMPLEMENTED;
 
-  try { return m_pStruct->OpenDialogChannelScan(); }
+  try { return TranslateError(m_pStruct->OpenDialogChannelScan()); }
   catch (std::exception &e) { LogException(e, __FUNCTION__); }
 
-  return PVR_ERROR_UNKNOWN;
+  return PVRError_UNKNOWN;
 }
 
-PVR_ERROR CPVRClient::OpenDialogChannelAdd(const CPVRChannelPtr &channel)
+PVRError CPVRClient::OpenDialogChannelAdd(const CPVRChannelPtr &channel)
 {
   if (!m_bReadyToUse)
-    return PVR_ERROR_SERVER_ERROR;
+    return PVRError_SERVER_ERROR;
 
   if (!m_addonCapabilities.bSupportsChannelSettings)
-    return PVR_ERROR_NOT_IMPLEMENTED;
+    return PVRError_NOT_IMPLEMENTED;
 
-  PVR_ERROR retVal(PVR_ERROR_UNKNOWN);
+  PVRError retVal(PVRError_UNKNOWN);
   try
   {
     PVR_CHANNEL addonChannel;
     WriteClientChannelInfo(channel, addonChannel);
 
-    retVal = m_pStruct->OpenDialogChannelAdd(addonChannel);
+    retVal = TranslateError(m_pStruct->OpenDialogChannelAdd(addonChannel));
     LogError(retVal, __FUNCTION__);
   }
   catch (std::exception &e)
@@ -655,21 +655,21 @@ PVR_ERROR CPVRClient::OpenDialogChannelAdd(const CPVRChannelPtr &channel)
   return retVal;
 }
 
-PVR_ERROR CPVRClient::OpenDialogChannelSettings(const CPVRChannelPtr &channel)
+PVRError CPVRClient::OpenDialogChannelSettings(const CPVRChannelPtr &channel)
 {
   if (!m_bReadyToUse)
-    return PVR_ERROR_SERVER_ERROR;
+    return PVRError_SERVER_ERROR;
 
   if (!m_addonCapabilities.bSupportsChannelSettings)
-    return PVR_ERROR_NOT_IMPLEMENTED;
+    return PVRError_NOT_IMPLEMENTED;
 
-  PVR_ERROR retVal(PVR_ERROR_UNKNOWN);
+  PVRError retVal(PVRError_UNKNOWN);
   try
   {
     PVR_CHANNEL addonChannel;
     WriteClientChannelInfo(channel, addonChannel);
 
-    retVal = m_pStruct->OpenDialogChannelSettings(addonChannel);
+    retVal = TranslateError(m_pStruct->OpenDialogChannelSettings(addonChannel));
     LogError(retVal, __FUNCTION__);
   }
   catch (std::exception &e)
@@ -680,21 +680,21 @@ PVR_ERROR CPVRClient::OpenDialogChannelSettings(const CPVRChannelPtr &channel)
   return retVal;
 }
 
-PVR_ERROR CPVRClient::DeleteChannel(const CPVRChannelPtr &channel)
+PVRError CPVRClient::DeleteChannel(const CPVRChannelPtr &channel)
 {
   if (!m_bReadyToUse)
-    return PVR_ERROR_SERVER_ERROR;
+    return PVRError_SERVER_ERROR;
 
   if (!m_addonCapabilities.bSupportsChannelSettings)
-    return PVR_ERROR_NOT_IMPLEMENTED;
+    return PVRError_NOT_IMPLEMENTED;
 
-  PVR_ERROR retVal(PVR_ERROR_UNKNOWN);
+  PVRError retVal(PVRError_UNKNOWN);
   try
   {
     PVR_CHANNEL addonChannel;
     WriteClientChannelInfo(channel, addonChannel);
 
-    retVal = m_pStruct->DeleteChannel(addonChannel);
+    retVal = TranslateError(m_pStruct->DeleteChannel(addonChannel));
     LogError(retVal, __FUNCTION__);
   }
   catch (std::exception &e)
@@ -705,21 +705,21 @@ PVR_ERROR CPVRClient::DeleteChannel(const CPVRChannelPtr &channel)
   return retVal;
 }
 
-PVR_ERROR CPVRClient::RenameChannel(const CPVRChannelPtr &channel)
+PVRError CPVRClient::RenameChannel(const CPVRChannelPtr &channel)
 {
   if (!m_bReadyToUse)
-    return PVR_ERROR_SERVER_ERROR;
+    return PVRError_SERVER_ERROR;
 
   if (!m_addonCapabilities.bSupportsChannelSettings)
-    return PVR_ERROR_NOT_IMPLEMENTED;
+    return PVRError_NOT_IMPLEMENTED;
 
-  PVR_ERROR retVal(PVR_ERROR_UNKNOWN);
+  PVRError retVal(PVRError_UNKNOWN);
   try
   {
     PVR_CHANNEL addonChannel;
     WriteClientChannelInfo(channel, addonChannel);
 
-    retVal = m_pStruct->RenameChannel(addonChannel);
+    retVal = TranslateError(m_pStruct->RenameChannel(addonChannel));
     LogError(retVal, __FUNCTION__);
   }
   catch (std::exception &e)
@@ -773,15 +773,15 @@ void CPVRClient::CallMenuHook(const PVR_MENUHOOK &hook, const CFileItem *item)
   catch (std::exception &e) { LogException(e, __FUNCTION__); }
 }
 
-PVR_ERROR CPVRClient::GetEPGForChannel(const CPVRChannelPtr &channel, CEpg *epg, time_t start /* = 0 */, time_t end /* = 0 */, bool bSaveInDb /* = false*/)
+PVRError CPVRClient::GetEPGForChannel(const CPVRChannelPtr &channel, CEpg *epg, time_t start /* = 0 */, time_t end /* = 0 */, bool bSaveInDb /* = false*/)
 {
   if (!m_bReadyToUse)
-    return PVR_ERROR_SERVER_ERROR;
+    return PVRError_SERVER_ERROR;
 
   if (!m_addonCapabilities.bSupportsEPG)
-    return PVR_ERROR_NOT_IMPLEMENTED;
+    return PVRError_NOT_IMPLEMENTED;
 
-  PVR_ERROR retVal(PVR_ERROR_UNKNOWN);
+  PVRError retVal(PVRError_UNKNOWN);
   try
   {
     PVR_CHANNEL addonChannel;
@@ -791,10 +791,10 @@ PVR_ERROR CPVRClient::GetEPGForChannel(const CPVRChannelPtr &channel, CEpg *epg,
     handle.callerAddress  = this;
     handle.dataAddress    = epg;
     handle.dataIdentifier = bSaveInDb ? 1 : 0; // used by the callback method CAddonCallbacksPVR::PVRTransferEpgEntry()
-    retVal = m_pStruct->GetEpg(&handle,
+    retVal = TranslateError(m_pStruct->GetEpg(&handle,
         addonChannel,
         start ? start - g_advancedSettings.m_iPVRTimeCorrection : 0,
-        end ? end - g_advancedSettings.m_iPVRTimeCorrection : 0);
+        end ? end - g_advancedSettings.m_iPVRTimeCorrection : 0));
 
     LogError(retVal, __FUNCTION__);
   }
@@ -806,18 +806,18 @@ PVR_ERROR CPVRClient::GetEPGForChannel(const CPVRChannelPtr &channel, CEpg *epg,
   return retVal;
 }
 
-PVR_ERROR CPVRClient::SetEPGTimeFrame(int iDays)
+PVRError CPVRClient::SetEPGTimeFrame(int iDays)
 {
   if (!m_bReadyToUse)
-    return PVR_ERROR_SERVER_ERROR;
+    return PVRError_SERVER_ERROR;
 
   if (!m_addonCapabilities.bSupportsEPG)
-    return PVR_ERROR_NOT_IMPLEMENTED;
+    return PVRError_NOT_IMPLEMENTED;
 
-  PVR_ERROR retVal(PVR_ERROR_UNKNOWN);
+  PVRError retVal(PVRError_UNKNOWN);
   try
   {
-    retVal = m_pStruct->SetEPGTimeFrame(iDays);
+    retVal = TranslateError(m_pStruct->SetEPGTimeFrame(iDays));
 
     LogError(retVal, __FUNCTION__);
   }
@@ -845,21 +845,21 @@ int CPVRClient::GetChannelGroupsAmount(void)
   return iReturn;
 }
 
-PVR_ERROR CPVRClient::GetChannelGroups(CPVRChannelGroups *groups)
+PVRError CPVRClient::GetChannelGroups(CPVRChannelGroups *groups)
 {
   if (!m_bReadyToUse)
-    return PVR_ERROR_SERVER_ERROR;
+    return PVRError_SERVER_ERROR;
 
   if (!m_addonCapabilities.bSupportsChannelGroups)
-    return PVR_ERROR_NOT_IMPLEMENTED;
+    return PVRError_NOT_IMPLEMENTED;
 
-  PVR_ERROR retVal(PVR_ERROR_UNKNOWN);
+  PVRError retVal(PVRError_UNKNOWN);
   try
   {
     ADDON_HANDLE_STRUCT handle;
     handle.callerAddress = this;
     handle.dataAddress = groups;
-    retVal = m_pStruct->GetChannelGroups(&handle, groups->IsRadio());
+    retVal = TranslateError(m_pStruct->GetChannelGroups(&handle, groups->IsRadio()));
 
     LogError(retVal, __FUNCTION__);
   }
@@ -871,15 +871,15 @@ PVR_ERROR CPVRClient::GetChannelGroups(CPVRChannelGroups *groups)
   return retVal;
 }
 
-PVR_ERROR CPVRClient::GetChannelGroupMembers(CPVRChannelGroup *group)
+PVRError CPVRClient::GetChannelGroupMembers(CPVRChannelGroup *group)
 {
   if (!m_bReadyToUse)
-    return PVR_ERROR_SERVER_ERROR;
+    return PVRError_SERVER_ERROR;
 
   if (!m_addonCapabilities.bSupportsChannelGroups)
-    return PVR_ERROR_NOT_IMPLEMENTED;
+    return PVRError_NOT_IMPLEMENTED;
 
-  PVR_ERROR retVal(PVR_ERROR_UNKNOWN);
+  PVRError retVal(PVRError_UNKNOWN);
   try
   {
     ADDON_HANDLE_STRUCT handle;
@@ -891,7 +891,7 @@ PVR_ERROR CPVRClient::GetChannelGroupMembers(CPVRChannelGroup *group)
 
     CLog::Log(LOGDEBUG, "PVR - %s - get group members for group '%s' from add-on '%s'",
         __FUNCTION__, tag.strGroupName, GetFriendlyName().c_str());
-    retVal = m_pStruct->GetChannelGroupMembers(&handle, tag);
+    retVal = TranslateError(m_pStruct->GetChannelGroupMembers(&handle, tag));
 
     LogError(retVal, __FUNCTION__);
   }
@@ -915,23 +915,23 @@ int CPVRClient::GetChannelsAmount(void)
   return iReturn;
 }
 
-PVR_ERROR CPVRClient::GetChannels(CPVRChannelGroup &channels, bool radio)
+PVRError CPVRClient::GetChannels(CPVRChannelGroup &channels, bool radio)
 {
   if (!m_bReadyToUse)
-    return PVR_ERROR_SERVER_ERROR;
+    return PVRError_SERVER_ERROR;
 
   if ((!m_addonCapabilities.bSupportsRadio && radio) ||
       (!m_addonCapabilities.bSupportsTV && !radio))
-    return PVR_ERROR_NOT_IMPLEMENTED;
+    return PVRError_NOT_IMPLEMENTED;
 
-  PVR_ERROR retVal(PVR_ERROR_UNKNOWN);
+  PVRError retVal(PVRError_UNKNOWN);
 
   try
   {
     ADDON_HANDLE_STRUCT handle;
     handle.callerAddress = this;
     handle.dataAddress = (CPVRChannelGroup*) &channels;
-    retVal = m_pStruct->GetChannels(&handle, radio);
+    retVal = TranslateError(m_pStruct->GetChannels(&handle, radio));
 
     LogError(retVal, __FUNCTION__);
   }
@@ -962,21 +962,21 @@ int CPVRClient::GetRecordingsAmount(bool deleted)
   return iReturn;
 }
 
-PVR_ERROR CPVRClient::GetRecordings(CPVRRecordings *results, bool deleted)
+PVRError CPVRClient::GetRecordings(CPVRRecordings *results, bool deleted)
 {
   if (!m_bReadyToUse)
-    return PVR_ERROR_SERVER_ERROR;
+    return PVRError_SERVER_ERROR;
 
   if (!m_addonCapabilities.bSupportsRecordings || (deleted && !m_addonCapabilities.bSupportsRecordingsUndelete))
-    return PVR_ERROR_NOT_IMPLEMENTED;
+    return PVRError_NOT_IMPLEMENTED;
 
-  PVR_ERROR retVal(PVR_ERROR_UNKNOWN);
+  PVRError retVal(PVRError_UNKNOWN);
   try
   {
     ADDON_HANDLE_STRUCT handle;
     handle.callerAddress = this;
     handle.dataAddress = (CPVRRecordings*) results;
-    retVal = m_pStruct->GetRecordings(&handle, deleted);
+    retVal = TranslateError(m_pStruct->GetRecordings(&handle, deleted));
 
     LogError(retVal, __FUNCTION__);
   }
@@ -988,21 +988,21 @@ PVR_ERROR CPVRClient::GetRecordings(CPVRRecordings *results, bool deleted)
   return retVal;
 }
 
-PVR_ERROR CPVRClient::DeleteRecording(const CPVRRecording &recording)
+PVRError CPVRClient::DeleteRecording(const CPVRRecording &recording)
 {
   if (!m_bReadyToUse)
-    return PVR_ERROR_SERVER_ERROR;
+    return PVRError_SERVER_ERROR;
 
   if (!m_addonCapabilities.bSupportsRecordings)
-    return PVR_ERROR_NOT_IMPLEMENTED;
+    return PVRError_NOT_IMPLEMENTED;
 
-  PVR_ERROR retVal(PVR_ERROR_UNKNOWN);
+  PVRError retVal(PVRError_UNKNOWN);
   try
   {
     PVR_RECORDING tag;
     WriteClientRecordingInfo(recording, tag);
 
-    retVal = m_pStruct->DeleteRecording(tag);
+    retVal = TranslateError(m_pStruct->DeleteRecording(tag));
 
     LogError(retVal, __FUNCTION__);
   }
@@ -1014,21 +1014,21 @@ PVR_ERROR CPVRClient::DeleteRecording(const CPVRRecording &recording)
   return retVal;
 }
 
-PVR_ERROR CPVRClient::UndeleteRecording(const CPVRRecording &recording)
+PVRError CPVRClient::UndeleteRecording(const CPVRRecording &recording)
 {
   if (!m_bReadyToUse)
-    return PVR_ERROR_SERVER_ERROR;
+    return PVRError_SERVER_ERROR;
 
   if (!m_addonCapabilities.bSupportsRecordingsUndelete)
-    return PVR_ERROR_NOT_IMPLEMENTED;
+    return PVRError_NOT_IMPLEMENTED;
 
-  PVR_ERROR retVal(PVR_ERROR_UNKNOWN);
+  PVRError retVal(PVRError_UNKNOWN);
   try
   {
     PVR_RECORDING tag;
     WriteClientRecordingInfo(recording, tag);
 
-    retVal = m_pStruct->UndeleteRecording(tag);
+    retVal = TranslateError(m_pStruct->UndeleteRecording(tag));
 
     LogError(retVal, __FUNCTION__);
   }
@@ -1040,18 +1040,18 @@ PVR_ERROR CPVRClient::UndeleteRecording(const CPVRRecording &recording)
   return retVal;
 }
 
-PVR_ERROR CPVRClient::DeleteAllRecordingsFromTrash()
+PVRError CPVRClient::DeleteAllRecordingsFromTrash()
 {
   if (!m_bReadyToUse)
-    return PVR_ERROR_SERVER_ERROR;
+    return PVRError_SERVER_ERROR;
 
   if (!m_addonCapabilities.bSupportsRecordingsUndelete)
-    return PVR_ERROR_NOT_IMPLEMENTED;
+    return PVRError_NOT_IMPLEMENTED;
 
-  PVR_ERROR retVal(PVR_ERROR_UNKNOWN);
+  PVRError retVal(PVRError_UNKNOWN);
   try
   {
-    retVal = m_pStruct->DeleteAllRecordingsFromTrash();
+    retVal = TranslateError(m_pStruct->DeleteAllRecordingsFromTrash());
 
     LogError(retVal, __FUNCTION__);
   }
@@ -1063,21 +1063,21 @@ PVR_ERROR CPVRClient::DeleteAllRecordingsFromTrash()
   return retVal;
 }
 
-PVR_ERROR CPVRClient::RenameRecording(const CPVRRecording &recording)
+PVRError CPVRClient::RenameRecording(const CPVRRecording &recording)
 {
   if (!m_bReadyToUse)
-    return PVR_ERROR_SERVER_ERROR;
+    return PVRError_SERVER_ERROR;
 
   if (!m_addonCapabilities.bSupportsRecordings)
-    return PVR_ERROR_NOT_IMPLEMENTED;
+    return PVRError_NOT_IMPLEMENTED;
 
-  PVR_ERROR retVal(PVR_ERROR_UNKNOWN);
+  PVRError retVal(PVRError_UNKNOWN);
   try
   {
     PVR_RECORDING tag;
     WriteClientRecordingInfo(recording, tag);
 
-    retVal = m_pStruct->RenameRecording(tag);
+    retVal = TranslateError(m_pStruct->RenameRecording(tag));
 
     LogError(retVal, __FUNCTION__);
   }
@@ -1089,21 +1089,21 @@ PVR_ERROR CPVRClient::RenameRecording(const CPVRRecording &recording)
   return retVal;
 }
 
-PVR_ERROR CPVRClient::SetRecordingPlayCount(const CPVRRecording &recording, int count)
+PVRError CPVRClient::SetRecordingPlayCount(const CPVRRecording &recording, int count)
 {
   if (!m_bReadyToUse)
-    return PVR_ERROR_SERVER_ERROR;
+    return PVRError_SERVER_ERROR;
 
   if (!m_addonCapabilities.bSupportsRecordingPlayCount)
-    return PVR_ERROR_NOT_IMPLEMENTED;
+    return PVRError_NOT_IMPLEMENTED;
 
-  PVR_ERROR retVal(PVR_ERROR_UNKNOWN);
+  PVRError retVal(PVRError_UNKNOWN);
   try
   {
     PVR_RECORDING tag;
     WriteClientRecordingInfo(recording, tag);
 
-    retVal = m_pStruct->SetRecordingPlayCount(tag, count);
+    retVal = TranslateError(m_pStruct->SetRecordingPlayCount(tag, count));
 
     LogError(retVal, __FUNCTION__);
   }
@@ -1115,21 +1115,21 @@ PVR_ERROR CPVRClient::SetRecordingPlayCount(const CPVRRecording &recording, int 
   return retVal;
 }
 
-PVR_ERROR CPVRClient::SetRecordingLastPlayedPosition(const CPVRRecording &recording, int lastplayedposition)
+PVRError CPVRClient::SetRecordingLastPlayedPosition(const CPVRRecording &recording, int lastplayedposition)
 {
   if (!m_bReadyToUse)
-    return PVR_ERROR_SERVER_ERROR;
+    return PVRError_SERVER_ERROR;
 
   if (!m_addonCapabilities.bSupportsLastPlayedPosition)
-    return PVR_ERROR_NOT_IMPLEMENTED;
+    return PVRError_NOT_IMPLEMENTED;
 
-  PVR_ERROR retVal(PVR_ERROR_UNKNOWN);
+  PVRError retVal(PVRError_UNKNOWN);
   try
   {
     PVR_RECORDING tag;
     WriteClientRecordingInfo(recording, tag);
 
-    retVal = m_pStruct->SetRecordingLastPlayedPosition(tag, lastplayedposition);
+    retVal = TranslateError(m_pStruct->SetRecordingLastPlayedPosition(tag, lastplayedposition));
 
     LogError(retVal, __FUNCTION__);
   }
@@ -1181,8 +1181,8 @@ std::vector<PVR_EDL_ENTRY> CPVRClient::GetRecordingEdl(const CPVRRecording &reco
 
     PVR_EDL_ENTRY edl_array[PVR_ADDON_EDL_LENGTH];
     int size = PVR_ADDON_EDL_LENGTH;
-    PVR_ERROR retval = m_pStruct->GetRecordingEdl(tag, edl_array, &size);
-    if (retval == PVR_ERROR_NO_ERROR)
+    PVRError retval = TranslateError(m_pStruct->GetRecordingEdl(tag, edl_array, &size));
+    if (retval == PVRError_NO_ERROR)
     {
       edl.reserve(size);
       for (int i = 0; i < size; ++i)
@@ -1214,21 +1214,21 @@ int CPVRClient::GetTimersAmount(void)
   return iReturn;
 }
 
-PVR_ERROR CPVRClient::GetTimers(CPVRTimers *results)
+PVRError CPVRClient::GetTimers(CPVRTimers *results)
 {
   if (!m_bReadyToUse)
-    return PVR_ERROR_SERVER_ERROR;
+    return PVRError_SERVER_ERROR;
 
   if (!m_addonCapabilities.bSupportsTimers)
-    return PVR_ERROR_NOT_IMPLEMENTED;
+    return PVRError_NOT_IMPLEMENTED;
 
-  PVR_ERROR retVal(PVR_ERROR_UNKNOWN);
+  PVRError retVal(PVRError_UNKNOWN);
   try
   {
     ADDON_HANDLE_STRUCT handle;
     handle.callerAddress = this;
     handle.dataAddress = (CPVRTimers*) results;
-    retVal = m_pStruct->GetTimers(&handle);
+    retVal = TranslateError(m_pStruct->GetTimers(&handle));
 
     LogError(retVal, __FUNCTION__);
   }
@@ -1240,21 +1240,21 @@ PVR_ERROR CPVRClient::GetTimers(CPVRTimers *results)
   return retVal;
 }
 
-PVR_ERROR CPVRClient::AddTimer(const CPVRTimerInfoTag &timer)
+PVRError CPVRClient::AddTimer(const CPVRTimerInfoTag &timer)
 {
   if (!m_bReadyToUse)
-    return PVR_ERROR_SERVER_ERROR;
+    return PVRError_SERVER_ERROR;
 
   if (!m_addonCapabilities.bSupportsTimers)
-    return PVR_ERROR_NOT_IMPLEMENTED;
+    return PVRError_NOT_IMPLEMENTED;
 
-  PVR_ERROR retVal(PVR_ERROR_UNKNOWN);
+  PVRError retVal(PVRError_UNKNOWN);
   try
   {
     PVR_TIMER tag;
     WriteClientTimerInfo(timer, tag);
 
-    retVal = m_pStruct->AddTimer(tag);
+    retVal = TranslateError(m_pStruct->AddTimer(tag));
 
     LogError(retVal, __FUNCTION__);
   }
@@ -1266,21 +1266,21 @@ PVR_ERROR CPVRClient::AddTimer(const CPVRTimerInfoTag &timer)
   return retVal;
 }
 
-PVR_ERROR CPVRClient::DeleteTimer(const CPVRTimerInfoTag &timer, bool bForce /* = false */)
+PVRError CPVRClient::DeleteTimer(const CPVRTimerInfoTag &timer, bool bForce /* = false */)
 {
   if (!m_bReadyToUse)
-    return PVR_ERROR_SERVER_ERROR;
+    return PVRError_SERVER_ERROR;
 
   if (!m_addonCapabilities.bSupportsTimers)
-    return PVR_ERROR_NOT_IMPLEMENTED;
+    return PVRError_NOT_IMPLEMENTED;
 
-  PVR_ERROR retVal(PVR_ERROR_UNKNOWN);
+  PVRError retVal(PVRError_UNKNOWN);
   try
   {
     PVR_TIMER tag;
     WriteClientTimerInfo(timer, tag);
 
-    retVal = m_pStruct->DeleteTimer(tag, bForce);
+    retVal = TranslateError(m_pStruct->DeleteTimer(tag, bForce));
 
     LogError(retVal, __FUNCTION__);
   }
@@ -1292,21 +1292,21 @@ PVR_ERROR CPVRClient::DeleteTimer(const CPVRTimerInfoTag &timer, bool bForce /* 
   return retVal;
 }
 
-PVR_ERROR CPVRClient::RenameTimer(const CPVRTimerInfoTag &timer, const std::string &strNewName)
+PVRError CPVRClient::RenameTimer(const CPVRTimerInfoTag &timer, const std::string &strNewName)
 {
   if (!m_bReadyToUse)
-    return PVR_ERROR_SERVER_ERROR;
+    return PVRError_SERVER_ERROR;
 
   if (!m_addonCapabilities.bSupportsTimers)
-    return PVR_ERROR_NOT_IMPLEMENTED;
+    return PVRError_NOT_IMPLEMENTED;
 
-  PVR_ERROR retVal(PVR_ERROR_UNKNOWN);
+  PVRError retVal(PVRError_UNKNOWN);
   try
   {
     PVR_TIMER tag;
     WriteClientTimerInfo(timer, tag);
 
-    retVal = m_pStruct->UpdateTimer(tag);
+    retVal = TranslateError(m_pStruct->UpdateTimer(tag));
 
     LogError(retVal, __FUNCTION__);
   }
@@ -1318,21 +1318,21 @@ PVR_ERROR CPVRClient::RenameTimer(const CPVRTimerInfoTag &timer, const std::stri
   return retVal;
 }
 
-PVR_ERROR CPVRClient::UpdateTimer(const CPVRTimerInfoTag &timer)
+PVRError CPVRClient::UpdateTimer(const CPVRTimerInfoTag &timer)
 {
   if (!m_bReadyToUse)
-    return PVR_ERROR_SERVER_ERROR;
+    return PVRError_SERVER_ERROR;
 
   if (!m_addonCapabilities.bSupportsTimers)
-    return PVR_ERROR_NOT_IMPLEMENTED;
+    return PVRError_NOT_IMPLEMENTED;
 
-  PVR_ERROR retVal(PVR_ERROR_UNKNOWN);
+  PVRError retVal(PVRError_UNKNOWN);
   try
   {
     PVR_TIMER tag;
     WriteClientTimerInfo(timer, tag);
 
-    retVal = m_pStruct->UpdateTimer(tag);
+    retVal = TranslateError(m_pStruct->UpdateTimer(tag));
 
     LogError(retVal, __FUNCTION__);
   }
@@ -1344,13 +1344,13 @@ PVR_ERROR CPVRClient::UpdateTimer(const CPVRTimerInfoTag &timer)
   return retVal;
 }
 
-PVR_ERROR CPVRClient::GetTimerTypes(CPVRTimerTypes& results) const
+PVRError CPVRClient::GetTimerTypes(CPVRTimerTypes& results) const
 {
   if (!m_bReadyToUse)
-    return PVR_ERROR_SERVER_ERROR;
+    return PVRError_SERVER_ERROR;
 
   results = m_timertypes;
-  return PVR_ERROR_NO_ERROR;
+  return PVRError_NO_ERROR;
 }
 
 int CPVRClient::ReadStream(void* lpBuf, int64_t uiBufSize)
@@ -1485,15 +1485,15 @@ std::string CPVRClient::GetLiveStreamURL(const CPVRChannelPtr &channel)
   return strReturn;
 }
 
-PVR_ERROR CPVRClient::GetStreamProperties(PVR_STREAM_PROPERTIES *props)
+PVRError CPVRClient::GetStreamProperties(PVR_STREAM_PROPERTIES *props)
 {
   if (!IsPlaying())
-    return PVR_ERROR_REJECTED;
+    return PVRError_REJECTED;
 
-  try { return m_pStruct->GetStreamProperties(props); }
+  try { return TranslateError(m_pStruct->GetStreamProperties(props)); }
   catch (std::exception &e) { LogException(e, __FUNCTION__); }
 
-  return PVR_ERROR_UNKNOWN;
+  return PVRError_UNKNOWN;
 }
 
 void CPVRClient::DemuxReset(void)
@@ -1555,37 +1555,9 @@ PVR_MENUHOOKS *CPVRClient::GetMenuHooks(void)
   return &m_menuhooks;
 }
 
-const char *CPVRClient::ToString(const PVR_ERROR error)
+bool CPVRClient::LogError(const PVRError error, const char *strMethod) const
 {
-  switch (error)
-  {
-  case PVR_ERROR_NO_ERROR:
-    return "no error";
-  case PVR_ERROR_NOT_IMPLEMENTED:
-    return "not implemented";
-  case PVR_ERROR_SERVER_ERROR:
-    return "server error";
-  case PVR_ERROR_SERVER_TIMEOUT:
-    return "server timeout";
-  case PVR_ERROR_RECORDING_RUNNING:
-    return "recording already running";
-  case PVR_ERROR_ALREADY_PRESENT:
-    return "already present";
-  case PVR_ERROR_REJECTED:
-    return "rejected by the backend";
-  case PVR_ERROR_INVALID_PARAMETERS:
-    return "invalid parameters for this method";
-  case PVR_ERROR_FAILED:
-    return "the command failed";
-  case PVR_ERROR_UNKNOWN:
-  default:
-    return "unknown error";
-  }
-}
-
-bool CPVRClient::LogError(const PVR_ERROR error, const char *strMethod) const
-{
-  if (error != PVR_ERROR_NO_ERROR)
+  if (error != PVRError_NO_ERROR)
   {
     CLog::Log(LOGERROR, "PVR - %s - addon '%s' returned an error: %s",
         strMethod, GetFriendlyName().c_str(), ToString(error));
@@ -2070,4 +2042,43 @@ void CPVRClient::OnPowerSavingDeactivated(void)
     m_pStruct->OnPowerSavingDeactivated();
   }
   catch (std::exception &e) { LogException(e, __FUNCTION__); }
+}
+
+PVRError CPVRClient::TranslateError(PVR_ERROR addonError)
+{
+  PVRError error;
+  switch (addonError)
+  {
+  case PVR_ERROR_NO_ERROR:
+    error = PVRError_NO_ERROR;
+    break;
+  case PVR_ERROR_NOT_IMPLEMENTED:
+    error = PVRError_NOT_IMPLEMENTED;
+    break;
+  case PVR_ERROR_SERVER_ERROR:
+    error = PVRError_SERVER_ERROR;
+    break;
+  case PVR_ERROR_SERVER_TIMEOUT:
+    error = PVRError_SERVER_TIMEOUT;
+    break;
+  case PVR_ERROR_REJECTED:
+    error = PVRError_REJECTED;
+    break;
+  case PVR_ERROR_ALREADY_PRESENT:
+    error = PVRError_ALREADY_PRESENT;
+    break;
+  case PVR_ERROR_INVALID_PARAMETERS:
+    error = PVRError_INVALID_PARAMETERS;
+    break;
+  case PVR_ERROR_RECORDING_RUNNING:
+    error = PVRError_RECORDING_RUNNING;
+    break;
+  case PVR_ERROR_FAILED:
+    error = PVRError_FAILED;
+    break;
+  case PVR_ERROR_UNKNOWN:
+  default:
+    error = PVRError_UNKNOWN;
+  }
+  return error;
 }

--- a/xbmc/addons/PVRClient.h
+++ b/xbmc/addons/PVRClient.h
@@ -22,6 +22,7 @@
 #include "addons/Addon.h"
 #include "addons/AddonDll.h"
 #include "addons/DllPVRClient.h"
+#include "addons/binary/interfaces/PVRClientBase.h"
 #include "network/ZeroconfBrowser.h"
 
 #include "pvr/channels/PVRChannel.h"
@@ -56,7 +57,8 @@ namespace PVR
    *
    * Also translates XBMC's C++ structures to the addon's C structures.
    */
-  class CPVRClient : public ADDON::CAddonDll<DllPVRClient, PVRClient, PVR_PROPERTIES>
+  class CPVRClient
+    : public ADDON::CAddonDll<DllPVRClient, PVRClient, PVR_PROPERTIES>
   {
   public:
     static std::unique_ptr<CPVRClient> FromExtension(ADDON::AddonProps props, const cp_extension_t* ext);
@@ -145,9 +147,9 @@ namespace PVR
     /*!
      * @brief Get the stream properties of the stream that's currently being read.
      * @param pProperties The properties.
-     * @return PVR_ERROR_NO_ERROR if the properties have been fetched successfully.
+     * @return PVRError_NO_ERROR if the properties have been fetched successfully.
      */
-    PVR_ERROR GetStreamProperties(PVR_STREAM_PROPERTIES *pProperties);
+    PVRError GetStreamProperties(PVR_STREAM_PROPERTIES *pProperties);
 
     /*!
      * @return The name reported by the backend.
@@ -178,43 +180,43 @@ namespace PVR
      * @brief Get the disk space reported by the server.
      * @param iTotal The total disk space.
      * @param iUsed The used disk space.
-     * @return PVR_ERROR_NO_ERROR if the drive space has been fetched successfully.
+     * @return PVRError_NO_ERROR if the drive space has been fetched successfully.
      */
-    PVR_ERROR GetDriveSpace(long long *iTotal, long long *iUsed);
+    PVRError GetDriveSpace(long long *iTotal, long long *iUsed);
 
     /*!
      * @brief Start a channel scan on the server.
-     * @return PVR_ERROR_NO_ERROR if the channel scan has been started successfully.
+     * @return PVRError_NO_ERROR if the channel scan has been started successfully.
      */
-    PVR_ERROR StartChannelScan(void);
+    PVRError StartChannelScan(void);
 
     /*!
      * @brief Request the client to open dialog about given channel to add
      * @param channel The channel to add
-     * @return PVR_ERROR_NO_ERROR if the add has been fetched successfully.
+     * @return PVRError_NO_ERROR if the add has been fetched successfully.
      */
-    PVR_ERROR OpenDialogChannelAdd(const CPVRChannelPtr &channel);
+    PVRError OpenDialogChannelAdd(const CPVRChannelPtr &channel);
 
     /*!
      * @brief Request the client to open dialog about given channel settings
      * @param channel The channel to edit
-     * @return PVR_ERROR_NO_ERROR if the edit has been fetched successfully.
+     * @return PVRError_NO_ERROR if the edit has been fetched successfully.
      */
-    PVR_ERROR OpenDialogChannelSettings(const CPVRChannelPtr &channel);
+    PVRError OpenDialogChannelSettings(const CPVRChannelPtr &channel);
 
     /*!
      * @brief Request the client to delete given channel
      * @param channel The channel to delete
-     * @return PVR_ERROR_NO_ERROR if the delete has been fetched successfully.
+     * @return PVRError_NO_ERROR if the delete has been fetched successfully.
      */
-    PVR_ERROR DeleteChannel(const CPVRChannelPtr &channel);
+    PVRError DeleteChannel(const CPVRChannelPtr &channel);
 
     /*!
      * @brief Request the client to rename given channel
      * @param channel The channel to rename
-     * @return PVR_ERROR_NO_ERROR if the rename has been fetched successfully.
+     * @return PVRError_NO_ERROR if the rename has been fetched successfully.
      */
-    PVR_ERROR RenameChannel(const CPVRChannelPtr &channel);
+    PVRError RenameChannel(const CPVRChannelPtr &channel);
 
     /*!
      * @return True if this add-on has menu hooks, false otherwise.
@@ -244,18 +246,18 @@ namespace PVR
      * @param start The start time to use.
      * @param end The end time to use.
      * @param bSaveInDb If true, tell the callback method to save any new entry in the database or not. see CAddonCallbacksPVR::PVRTransferEpgEntry()
-     * @return PVR_ERROR_NO_ERROR if the table has been fetched successfully.
+     * @return PVRError_NO_ERROR if the table has been fetched successfully.
      */
-    PVR_ERROR GetEPGForChannel(const CPVRChannelPtr &channel, EPG::CEpg *epg, time_t start = 0, time_t end = 0, bool bSaveInDb = false);
+    PVRError GetEPGForChannel(const CPVRChannelPtr &channel, EPG::CEpg *epg, time_t start = 0, time_t end = 0, bool bSaveInDb = false);
 
     /*!
      * Tell the client the time frame to use when notifying epg events back to Kodi. The client might push epg events asynchronously
      * to Kodi using the callback function EpgEventStateChange. To be able to only push events that are actually of interest for Kodi,
      * client needs to know about the epg time frame Kodi uses.
      * @param iDays number of days from "now". EPG_TIMEFRAME_UNLIMITED means that Kodi is interested in all epg events, regardless of event times.
-     * @return PVR_ERROR_NO_ERROR if new value was successfully set.
+     * @return PVRError_NO_ERROR if new value was successfully set.
      */
-    PVR_ERROR SetEPGTimeFrame(int iDays);
+    PVRError SetEPGTimeFrame(int iDays);
 
     //@}
     /** @name PVR channel group methods */
@@ -269,16 +271,16 @@ namespace PVR
     /*!
      * @brief Request the list of all channel groups from the backend.
      * @param groups The groups container to get the groups for.
-     * @return PVR_ERROR_NO_ERROR if the list has been fetched successfully.
+     * @return PVRError_NO_ERROR if the list has been fetched successfully.
      */
-    PVR_ERROR GetChannelGroups(CPVRChannelGroups *groups);
+    PVRError GetChannelGroups(CPVRChannelGroups *groups);
 
     /*!
      * @brief Request the list of all group members from the backend.
      * @param groups The group to get the members for.
-     * @return PVR_ERROR_NO_ERROR if the list has been fetched successfully.
+     * @return PVRError_NO_ERROR if the list has been fetched successfully.
      */
-    PVR_ERROR GetChannelGroupMembers(CPVRChannelGroup *group);
+    PVRError GetChannelGroupMembers(CPVRChannelGroup *group);
 
     //@}
     /** @name PVR channel methods */
@@ -293,9 +295,9 @@ namespace PVR
      * @brief Request the list of all channels from the backend.
      * @param channels The channel group to add the channels to.
      * @param bRadio True to get the radio channels, false to get the TV channels.
-     * @return PVR_ERROR_NO_ERROR if the list has been fetched successfully.
+     * @return PVRError_NO_ERROR if the list has been fetched successfully.
      */
-    PVR_ERROR GetChannels(CPVRChannelGroup &channels, bool bRadio);
+    PVRError GetChannels(CPVRChannelGroup &channels, bool bRadio);
 
     //@}
     /** @name PVR recording methods */
@@ -311,52 +313,52 @@ namespace PVR
      * @brief Request the list of all recordings from the backend.
      * @param results The container to add the recordings to.
      * @param deleted if set return deleted recording
-     * @return PVR_ERROR_NO_ERROR if the list has been fetched successfully.
+     * @return PVRError_NO_ERROR if the list has been fetched successfully.
      */
-    PVR_ERROR GetRecordings(CPVRRecordings *results, bool deleted);
+    PVRError GetRecordings(CPVRRecordings *results, bool deleted);
 
     /*!
      * @brief Delete a recording on the backend.
      * @param recording The recording to delete.
-     * @return PVR_ERROR_NO_ERROR if the recording has been deleted successfully.
+     * @return PVRError_NO_ERROR if the recording has been deleted successfully.
      */
-    PVR_ERROR DeleteRecording(const CPVRRecording &recording);
+    PVRError DeleteRecording(const CPVRRecording &recording);
 
     /*!
      * @brief Undelete a recording on the backend.
      * @param recording The recording to undelete.
-     * @return PVR_ERROR_NO_ERROR if the recording has been undeleted successfully.
+     * @return PVRError_NO_ERROR if the recording has been undeleted successfully.
      */
-    PVR_ERROR UndeleteRecording(const CPVRRecording &recording);
+    PVRError UndeleteRecording(const CPVRRecording &recording);
 
     /*!
      * @brief Delete all recordings permanent which in the deleted folder on the backend.
-     * @return PVR_ERROR_NO_ERROR if the recordings has been deleted successfully.
+     * @return PVRError_NO_ERROR if the recordings has been deleted successfully.
      */
-    PVR_ERROR DeleteAllRecordingsFromTrash();
+    PVRError DeleteAllRecordingsFromTrash();
 
     /*!
      * @brief Rename a recording on the backend.
      * @param recording The recording to rename.
-     * @return PVR_ERROR_NO_ERROR if the recording has been renamed successfully.
+     * @return PVRError_NO_ERROR if the recording has been renamed successfully.
      */
-    PVR_ERROR RenameRecording(const CPVRRecording &recording);
+    PVRError RenameRecording(const CPVRRecording &recording);
 
     /*!
      * @brief Set the play count of a recording on the backend.
      * @param recording The recording to set the play count.
      * @param count Play count.
-     * @return PVR_ERROR_NO_ERROR if the recording's play count has been set successfully.
+     * @return PVRError_NO_ERROR if the recording's play count has been set successfully.
      */
-    PVR_ERROR SetRecordingPlayCount(const CPVRRecording &recording, int count);
+    PVRError SetRecordingPlayCount(const CPVRRecording &recording, int count);
 
     /*!
     * @brief Set the last watched position of a recording on the backend.
     * @param recording The recording.
     * @param position The last watched position in seconds
-    * @return PVR_ERROR_NO_ERROR if the position has been stored successfully.
+    * @return PVRError_NO_ERROR if the position has been stored successfully.
     */
-    PVR_ERROR SetRecordingLastPlayedPosition(const CPVRRecording &recording, int lastplayedposition);
+    PVRError SetRecordingLastPlayedPosition(const CPVRRecording &recording, int lastplayedposition);
 
     /*!
     * @brief Retrieve the last watched position of a recording on the backend.
@@ -384,46 +386,46 @@ namespace PVR
     /*!
      * @brief Request the list of all timers from the backend.
      * @param results The container to store the result in.
-     * @return PVR_ERROR_NO_ERROR if the list has been fetched successfully.
+     * @return PVRError_NO_ERROR if the list has been fetched successfully.
      */
-    PVR_ERROR GetTimers(CPVRTimers *results);
+    PVRError GetTimers(CPVRTimers *results);
 
     /*!
      * @brief Add a timer on the backend.
      * @param timer The timer to add.
-     * @return PVR_ERROR_NO_ERROR if the timer has been added successfully.
+     * @return PVRError_NO_ERROR if the timer has been added successfully.
      */
-    PVR_ERROR AddTimer(const CPVRTimerInfoTag &timer);
+    PVRError AddTimer(const CPVRTimerInfoTag &timer);
 
     /*!
      * @brief Delete a timer on the backend.
      * @param timer The timer to delete.
      * @param bForce Set to true to delete a timer that is currently recording a program.
-     * @return PVR_ERROR_NO_ERROR if the timer has been deleted successfully.
+     * @return PVRError_NO_ERROR if the timer has been deleted successfully.
      */
-    PVR_ERROR DeleteTimer(const CPVRTimerInfoTag &timer, bool bForce = false);
+    PVRError DeleteTimer(const CPVRTimerInfoTag &timer, bool bForce = false);
 
     /*!
      * @brief Rename a timer on the server.
      * @param timer The timer to rename.
      * @param strNewName The new name of the timer.
-     * @return PVR_ERROR_NO_ERROR if the timer has been renamed successfully.
+     * @return PVRError_NO_ERROR if the timer has been renamed successfully.
      */
-    PVR_ERROR RenameTimer(const CPVRTimerInfoTag &timer, const std::string &strNewName);
+    PVRError RenameTimer(const CPVRTimerInfoTag &timer, const std::string &strNewName);
 
     /*!
      * @brief Update the timer information on the server.
      * @param timer The timer to update.
-     * @return PVR_ERROR_NO_ERROR if the timer has been updated successfully.
+     * @return PVRError_NO_ERROR if the timer has been updated successfully.
      */
-    PVR_ERROR UpdateTimer(const CPVRTimerInfoTag &timer);
+    PVRError UpdateTimer(const CPVRTimerInfoTag &timer);
 
     /*!
      * @brief Get all timer types supported by the backend.
      * @param results The container to store the result in.
-     * @return PVR_ERROR_NO_ERROR if the list has been fetched successfully.
+     * @return PVRError_NO_ERROR if the list has been fetched successfully.
      */
-    PVR_ERROR GetTimerTypes(CPVRTimerTypes& results) const;
+    PVRError GetTimerTypes(CPVRTimerTypes& results) const;
 
     //@}
     /** @name PVR live stream methods */
@@ -583,8 +585,6 @@ namespace PVR
     CPVRRecordingPtr GetPlayingRecording(void) const;
     CPVRChannelPtr GetPlayingChannel() const;
 
-    static const char *ToString(const PVR_ERROR error);
-
     /*!
      * @brief is timeshift active?
      */
@@ -641,6 +641,14 @@ namespace PVR
     void OnPowerSavingDeactivated();
 
   private:
+    /*!
+     * @brief Translate a from add-on system used error code to a on Kodi
+     * standardized error value
+     * @param error The from current add-on API level used error code
+     * @return On Kodi used error value used for all levels
+     */
+    static PVRError TranslateError(PVR_ERROR error);
+
     /*!
      * @brief Checks whether the provided API version is compatible with XBMC
      * @param minVersion The add-on's XBMC_PVR_MIN_API_VERSION version
@@ -703,7 +711,7 @@ namespace PVR
      */
     bool CanPlayChannel(const CPVRChannelPtr &channel) const;
 
-    bool LogError(const PVR_ERROR error, const char *strMethod) const;
+    bool LogError(const PVRError error, const char *strMethod) const;
     void LogException(const std::exception &e, const char *strFunctionName) const;
 
     bool                   m_bReadyToUse;          /*!< true if this add-on is initialised (ADDON_Create returned true), false otherwise */

--- a/xbmc/addons/binary/interfaces/CMakeLists.txt
+++ b/xbmc/addons/binary/interfaces/CMakeLists.txt
@@ -1,7 +1,9 @@
-set(SOURCES AddonInterfaces.cpp)
+set(SOURCES AddonInterfaces.cpp
+            PVRClientBase.cpp)
 
 set(HEADERS AddonInterfaces.h
-            IAddonInterface.h)
+            IAddonInterface.h
+            PVRClientBase.h)
 
 core_add_library(addonsBinaryInterfaces)
 

--- a/xbmc/addons/binary/interfaces/Makefile.in
+++ b/xbmc/addons/binary/interfaces/Makefile.in
@@ -1,4 +1,5 @@
 SRCS=AddonInterfaces.cpp \
+     PVRClientBase.cpp \
 
 LIB=addon-interfaces.a
 

--- a/xbmc/addons/binary/interfaces/PVRClientBase.cpp
+++ b/xbmc/addons/binary/interfaces/PVRClientBase.cpp
@@ -1,0 +1,54 @@
+/*
+ *      Copyright (C) 2016 Team KODI
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "PVRClientBase.h"
+
+namespace PVR
+{
+
+const char *CPVRClientBase::ToString(const PVRError error)
+{
+  switch (error)
+  {
+  case PVRError_NO_ERROR:
+    return "no error";
+  case PVRError_NOT_IMPLEMENTED:
+    return "not implemented";
+  case PVRError_SERVER_ERROR:
+    return "server error";
+  case PVRError_SERVER_TIMEOUT:
+    return "server timeout";
+  case PVRError_RECORDING_RUNNING:
+    return "recording already running";
+  case PVRError_ALREADY_PRESENT:
+    return "already present";
+  case PVRError_REJECTED:
+    return "rejected by the backend";
+  case PVRError_INVALID_PARAMETERS:
+    return "invalid parameters for this method";
+  case PVRError_FAILED:
+    return "the command failed";
+  case PVRError_UNKNOWN:
+  default:
+    return "unknown error";
+  }
+}
+
+};

--- a/xbmc/addons/binary/interfaces/PVRClientBase.h
+++ b/xbmc/addons/binary/interfaces/PVRClientBase.h
@@ -1,0 +1,48 @@
+#pragma once
+/*
+ *      Copyright (C) 2016 Team KODI
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace PVR
+{
+
+  /*!
+   * @brief PVR add-on error codes used on Kodi
+   */
+  typedef enum
+  {
+    PVRError_NO_ERROR           = 0,  /*!< no error occurred */
+    PVRError_UNKNOWN            = -1, /*!< an unknown error occurred */
+    PVRError_NOT_IMPLEMENTED    = -2, /*!< the method that Kodi called is not implemented by the add-on */
+    PVRError_SERVER_ERROR       = -3, /*!< the backend reported an error, or the add-on isn't connected */
+    PVRError_SERVER_TIMEOUT     = -4, /*!< the command was sent to the backend, but the response timed out */
+    PVRError_REJECTED           = -5, /*!< the command was rejected by the backend */
+    PVRError_ALREADY_PRESENT    = -6, /*!< the requested item can not be added, because it's already present */
+    PVRError_INVALID_PARAMETERS = -7, /*!< the parameters of the method that was called are invalid for this operation */
+    PVRError_RECORDING_RUNNING  = -8, /*!< a recording is running, so the timer can't be deleted without doing a forced delete */
+    PVRError_FAILED             = -9, /*!< the command failed */
+  } PVRError;
+
+  class CPVRClientBase
+  {
+  public:
+    static const char *ToString(const PVRError error);
+  };
+
+}

--- a/xbmc/epg/Epg.cpp
+++ b/xbmc/epg/Epg.cpp
@@ -760,7 +760,7 @@ bool CEpg::UpdateFromScraper(time_t start, time_t end)
     else
     {
       CLog::Log(LOGDEBUG, "EPG - %s - updating EPG for channel '%s' from client '%i'", __FUNCTION__, channel->ChannelName().c_str(), channel->ClientID());
-      bGrabSuccess = (g_PVRClients->GetEPGForChannel(channel, this, start, end) == PVR_ERROR_NO_ERROR);
+      bGrabSuccess = (g_PVRClients->GetEPGForChannel(channel, this, start, end) == PVRError_NO_ERROR);
     }
   }
   else if (m_strScraperName.empty()) /* no grabber defined */

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -299,7 +299,7 @@ std::vector<SBackend> CPVRClients::GetBackendProperties() const
 
     SBackend properties;
 
-    if (client->GetDriveSpace(&properties.diskTotal, &properties.diskUsed) == PVR_ERROR_NO_ERROR)
+    if (client->GetDriveSpace(&properties.diskTotal, &properties.diskUsed) == PVRError_NO_ERROR)
     {
       properties.diskTotal *= 1024;  
       properties.diskUsed *= 1024;
@@ -466,9 +466,9 @@ bool CPVRClients::GetTimers(CPVRTimers *timers, std::vector<int> &failedClients)
   /* get the timer list from each client */
   for (const auto &client : clients)
   {
-    PVR_ERROR currentError = client.second->GetTimers(timers);
-    if (currentError != PVR_ERROR_NOT_IMPLEMENTED &&
-        currentError != PVR_ERROR_NO_ERROR)
+    PVRError currentError = client.second->GetTimers(timers);
+    if (currentError != PVRError_NOT_IMPLEMENTED &&
+        currentError != PVRError_NO_ERROR)
     {
       CLog::Log(LOGERROR, "PVR - %s - cannot get timers from client '%d': %s",__FUNCTION__, client.first, CPVRClient::ToString(currentError));
       bSuccess = false;
@@ -479,37 +479,37 @@ bool CPVRClients::GetTimers(CPVRTimers *timers, std::vector<int> &failedClients)
   return bSuccess;
 }
 
-PVR_ERROR CPVRClients::AddTimer(const CPVRTimerInfoTag &timer)
+PVRError CPVRClients::AddTimer(const CPVRTimerInfoTag &timer)
 {
-  PVR_ERROR error(PVR_ERROR_UNKNOWN);
+  PVRError error(PVRError_UNKNOWN);
 
   PVR_CLIENT client;
   if (GetCreatedClient(timer.m_iClientId, client))
     error = client->AddTimer(timer);
 
-  if (error != PVR_ERROR_NO_ERROR)
+  if (error != PVRError_NO_ERROR)
     CLog::Log(LOGERROR, "PVR - %s - cannot add timer to client '%d': %s",__FUNCTION__, timer.m_iClientId, CPVRClient::ToString(error));
 
   return error;
 }
 
-PVR_ERROR CPVRClients::UpdateTimer(const CPVRTimerInfoTag &timer)
+PVRError CPVRClients::UpdateTimer(const CPVRTimerInfoTag &timer)
 {
-  PVR_ERROR error(PVR_ERROR_UNKNOWN);
+  PVRError error(PVRError_UNKNOWN);
 
   PVR_CLIENT client;
   if (GetCreatedClient(timer.m_iClientId, client))
     error = client->UpdateTimer(timer);
 
-  if (error != PVR_ERROR_NO_ERROR)
+  if (error != PVRError_NO_ERROR)
     CLog::Log(LOGERROR, "PVR - %s - cannot update timer on client '%d': %s",__FUNCTION__, timer.m_iClientId, CPVRClient::ToString(error));
 
   return error;
 }
 
-PVR_ERROR CPVRClients::DeleteTimer(const CPVRTimerInfoTag &timer, bool bForce)
+PVRError CPVRClients::DeleteTimer(const CPVRTimerInfoTag &timer, bool bForce)
 {
-  PVR_ERROR error(PVR_ERROR_UNKNOWN);
+  PVRError error(PVRError_UNKNOWN);
   PVR_CLIENT client;
 
   if (GetCreatedClient(timer.m_iClientId, client))
@@ -518,23 +518,23 @@ PVR_ERROR CPVRClients::DeleteTimer(const CPVRTimerInfoTag &timer, bool bForce)
   return error;
 }
 
-PVR_ERROR CPVRClients::RenameTimer(const CPVRTimerInfoTag &timer, const std::string &strNewName)
+PVRError CPVRClients::RenameTimer(const CPVRTimerInfoTag &timer, const std::string &strNewName)
 {
-  PVR_ERROR error(PVR_ERROR_UNKNOWN);
+  PVRError error(PVRError_UNKNOWN);
 
   PVR_CLIENT client;
   if (GetCreatedClient(timer.m_iClientId, client))
     error = client->RenameTimer(timer, strNewName);
 
-  if (error != PVR_ERROR_NO_ERROR)
+  if (error != PVRError_NO_ERROR)
     CLog::Log(LOGERROR, "PVR - %s - cannot rename timer on client '%d': %s",__FUNCTION__, timer.m_iClientId, CPVRClient::ToString(error));
 
   return error;
 }
 
-PVR_ERROR CPVRClients::GetTimerTypes(CPVRTimerTypes& results) const
+PVRError CPVRClients::GetTimerTypes(CPVRTimerTypes& results) const
 {
-  PVR_ERROR error(PVR_ERROR_NO_ERROR);
+  PVRError error(PVRError_NO_ERROR);
 
   PVR_CLIENTMAP clients;
   GetCreatedClients(clients);
@@ -542,9 +542,9 @@ PVR_ERROR CPVRClients::GetTimerTypes(CPVRTimerTypes& results) const
   for (const auto &clientEntry : clients)
   {
     CPVRTimerTypes types;
-    PVR_ERROR currentError = clientEntry.second->GetTimerTypes(types);
-    if (currentError != PVR_ERROR_NOT_IMPLEMENTED &&
-        currentError != PVR_ERROR_NO_ERROR)
+    PVRError currentError = clientEntry.second->GetTimerTypes(types);
+    if (currentError != PVRError_NOT_IMPLEMENTED &&
+        currentError != PVRError_NO_ERROR)
     {
       CLog::Log(LOGERROR, "PVR - %s - cannot get timer types from client '%d': %s",__FUNCTION__, clientEntry.first, CPVRClient::ToString(currentError));
       error = currentError;
@@ -559,31 +559,31 @@ PVR_ERROR CPVRClients::GetTimerTypes(CPVRTimerTypes& results) const
   return error;
 }
 
-PVR_ERROR CPVRClients::GetTimerTypes(CPVRTimerTypes& results, int iClientId) const
+PVRError CPVRClients::GetTimerTypes(CPVRTimerTypes& results, int iClientId) const
 {
-  PVR_ERROR error(PVR_ERROR_UNKNOWN);
+  PVRError error(PVRError_UNKNOWN);
 
   PVR_CLIENT client;
   if (GetCreatedClient(iClientId, client))
     error = client->GetTimerTypes(results);
 
-  if (error != PVR_ERROR_NO_ERROR)
+  if (error != PVRError_NO_ERROR)
     CLog::Log(LOGERROR, "PVR - %s - cannot get timer types from client '%d': %s",__FUNCTION__, iClientId, CPVRClient::ToString(error));
 
   return error;
 }
 
-PVR_ERROR CPVRClients::GetRecordings(CPVRRecordings *recordings, bool deleted)
+PVRError CPVRClients::GetRecordings(CPVRRecordings *recordings, bool deleted)
 {
-  PVR_ERROR error(PVR_ERROR_NO_ERROR);
+  PVRError error(PVRError_NO_ERROR);
   PVR_CLIENTMAP clients;
   GetCreatedClients(clients);
 
   for (const auto &client : clients)
   {
-    PVR_ERROR currentError = client.second->GetRecordings(recordings, deleted);
-    if (currentError != PVR_ERROR_NOT_IMPLEMENTED &&
-        currentError != PVR_ERROR_NO_ERROR)
+    PVRError currentError = client.second->GetRecordings(recordings, deleted);
+    if (currentError != PVRError_NOT_IMPLEMENTED &&
+        currentError != PVRError_NO_ERROR)
     {
       CLog::Log(LOGERROR, "PVR - %s - cannot get recordings from client '%d': %s",__FUNCTION__, client.first, CPVRClient::ToString(currentError));
       error = currentError;
@@ -593,37 +593,37 @@ PVR_ERROR CPVRClients::GetRecordings(CPVRRecordings *recordings, bool deleted)
   return error;
 }
 
-PVR_ERROR CPVRClients::RenameRecording(const CPVRRecording &recording)
+PVRError CPVRClients::RenameRecording(const CPVRRecording &recording)
 {
-  PVR_ERROR error(PVR_ERROR_UNKNOWN);
+  PVRError error(PVRError_UNKNOWN);
 
   PVR_CLIENT client;
   if (GetCreatedClient(recording.m_iClientId, client))
     error = client->RenameRecording(recording);
 
-  if (error != PVR_ERROR_NO_ERROR)
+  if (error != PVRError_NO_ERROR)
     CLog::Log(LOGERROR, "PVR - %s - cannot rename recording on client '%d': %s",__FUNCTION__, recording.m_iClientId, CPVRClient::ToString(error));
 
   return error;
 }
 
-PVR_ERROR CPVRClients::DeleteRecording(const CPVRRecording &recording)
+PVRError CPVRClients::DeleteRecording(const CPVRRecording &recording)
 {
-  PVR_ERROR error(PVR_ERROR_UNKNOWN);
+  PVRError error(PVRError_UNKNOWN);
 
   PVR_CLIENT client;
   if (GetCreatedClient(recording.m_iClientId, client))
     error = client->DeleteRecording(recording);
 
-  if (error != PVR_ERROR_NO_ERROR)
+  if (error != PVRError_NO_ERROR)
     CLog::Log(LOGERROR, "PVR - %s - cannot delete recording from client '%d': %s",__FUNCTION__, recording.m_iClientId, CPVRClient::ToString(error));
 
   return error;
 }
 
-PVR_ERROR CPVRClients::UndeleteRecording(const CPVRRecording &recording)
+PVRError CPVRClients::UndeleteRecording(const CPVRRecording &recording)
 {
-  PVR_ERROR error(PVR_ERROR_UNKNOWN);
+  PVRError error(PVRError_UNKNOWN);
 
   if (!recording.IsDeleted())
     return error;
@@ -632,15 +632,15 @@ PVR_ERROR CPVRClients::UndeleteRecording(const CPVRRecording &recording)
   if (GetCreatedClient(recording.m_iClientId, client))
     error = client->UndeleteRecording(recording);
 
-  if (error != PVR_ERROR_NO_ERROR)
+  if (error != PVRError_NO_ERROR)
     CLog::Log(LOGERROR, "PVR - %s - cannot undelete recording from client '%d': %s",__FUNCTION__, recording.m_iClientId, CPVRClient::ToString(error));
 
   return error;
 }
 
-PVR_ERROR CPVRClients::DeleteAllRecordingsFromTrash()
+PVRError CPVRClients::DeleteAllRecordingsFromTrash()
 {
-  PVR_ERROR error(PVR_ERROR_NO_ERROR);
+  PVRError error(PVRError_NO_ERROR);
   PVR_CLIENTMAP clients;
   GetCreatedClients(clients);
 
@@ -673,8 +673,8 @@ PVR_ERROR CPVRClients::DeleteAllRecordingsFromTrash()
   {
     for (const auto &client : suppClients)
     {
-      PVR_ERROR currentError = client->DeleteAllRecordingsFromTrash();
-      if (currentError != PVR_ERROR_NO_ERROR)
+      PVRError currentError = client->DeleteAllRecordingsFromTrash();
+      if (currentError != PVRError_NO_ERROR)
       {
         CLog::Log(LOGERROR, "PVR - %s - cannot delete all recordings from client '%d': %s",__FUNCTION__, client->GetID(), CPVRClient::ToString(currentError));
         error = currentError;
@@ -683,8 +683,8 @@ PVR_ERROR CPVRClients::DeleteAllRecordingsFromTrash()
   }
   else if (selection >= 1 && selection <= (int)suppClients.size())
   {
-    PVR_ERROR currentError = suppClients[selection-1]->DeleteAllRecordingsFromTrash();
-    if (currentError != PVR_ERROR_NO_ERROR)
+    PVRError currentError = suppClients[selection-1]->DeleteAllRecordingsFromTrash();
+    if (currentError != PVRError_NO_ERROR)
     {
       CLog::Log(LOGERROR, "PVR - %s - cannot delete all recordings from client '%d': %s",__FUNCTION__, suppClients[selection-1]->GetID(), CPVRClient::ToString(currentError));
       error = currentError;
@@ -694,16 +694,16 @@ PVR_ERROR CPVRClients::DeleteAllRecordingsFromTrash()
   return error;
 }
 
-bool CPVRClients::SetRecordingLastPlayedPosition(const CPVRRecording &recording, int lastplayedposition, PVR_ERROR *error)
+bool CPVRClients::SetRecordingLastPlayedPosition(const CPVRRecording &recording, int lastplayedposition, PVRError *error)
 {
-  *error = PVR_ERROR_UNKNOWN;
+  *error = PVRError_UNKNOWN;
   PVR_CLIENT client;
   if (GetCreatedClient(recording.m_iClientId, client) && client->SupportsRecordings())
     *error = client->SetRecordingLastPlayedPosition(recording, lastplayedposition);
   else
     CLog::Log(LOGERROR, "PVR - %s - client %d does not support recordings",__FUNCTION__, recording.m_iClientId);
 
-  return *error == PVR_ERROR_NO_ERROR;
+  return *error == PVRError_NO_ERROR;
 }
 
 int CPVRClients::GetRecordingLastPlayedPosition(const CPVRRecording &recording)
@@ -719,16 +719,16 @@ int CPVRClients::GetRecordingLastPlayedPosition(const CPVRRecording &recording)
   return rc;
 }
 
-bool CPVRClients::SetRecordingPlayCount(const CPVRRecording &recording, int count, PVR_ERROR *error)
+bool CPVRClients::SetRecordingPlayCount(const CPVRRecording &recording, int count, PVRError *error)
 {
-  *error = PVR_ERROR_UNKNOWN;
+  *error = PVRError_UNKNOWN;
   PVR_CLIENT client;
   if (GetCreatedClient(recording.m_iClientId, client) && client->SupportsRecordingPlayCount())
     *error = client->SetRecordingPlayCount(recording, count);
   else
     CLog::Log(LOGERROR, "PVR - %s - client %d does not support setting recording's play count",__FUNCTION__, recording.m_iClientId);
 
-  return *error == PVR_ERROR_NO_ERROR;
+  return *error == PVRError_NO_ERROR;
 }
 
 std::vector<PVR_EDL_ENTRY> CPVRClients::GetRecordingEdl(const CPVRRecording &recording)
@@ -778,31 +778,31 @@ bool CPVRClients::CanSeekStream(void) const
   return false;
 }
 
-PVR_ERROR CPVRClients::GetEPGForChannel(const CPVRChannelPtr &channel, CEpg *epg, time_t start, time_t end)
+PVRError CPVRClients::GetEPGForChannel(const CPVRChannelPtr &channel, CEpg *epg, time_t start, time_t end)
 {
   assert(channel.get());
 
-  PVR_ERROR error(PVR_ERROR_UNKNOWN);
+  PVRError error(PVRError_UNKNOWN);
   PVR_CLIENT client;
   if (GetCreatedClient(channel->ClientID(), client))
     error = client->GetEPGForChannel(channel, epg, start, end);
 
-  if (error != PVR_ERROR_NO_ERROR)
+  if (error != PVRError_NO_ERROR)
     CLog::Log(LOGERROR, "PVR - %s - cannot get EPG for channel '%s' from client '%d': %s",__FUNCTION__, channel->ChannelName().c_str(), channel->ClientID(), CPVRClient::ToString(error));
   return error;
 }
 
-PVR_ERROR CPVRClients::SetEPGTimeFrame(int iDays)
+PVRError CPVRClients::SetEPGTimeFrame(int iDays)
 {
-  PVR_ERROR error(PVR_ERROR_NO_ERROR);
+  PVRError error(PVRError_NO_ERROR);
   PVR_CLIENTMAP clients;
   GetCreatedClients(clients);
 
   for (const auto &client : clients)
   {
-    PVR_ERROR currentError = client.second->SetEPGTimeFrame(iDays);
-    if (currentError != PVR_ERROR_NOT_IMPLEMENTED &&
-        currentError != PVR_ERROR_NO_ERROR)
+    PVRError currentError = client.second->SetEPGTimeFrame(iDays);
+    if (currentError != PVRError_NOT_IMPLEMENTED &&
+        currentError != PVRError_NO_ERROR)
     {
       error = currentError;
       CLog::Log(LOGERROR, "PVR - %s - cannot set epg time frame for client '%d': %s",__FUNCTION__, client.first, CPVRClient::ToString(error));
@@ -812,18 +812,18 @@ PVR_ERROR CPVRClients::SetEPGTimeFrame(int iDays)
   return error;
 }
 
-PVR_ERROR CPVRClients::GetChannels(CPVRChannelGroupInternal *group)
+PVRError CPVRClients::GetChannels(CPVRChannelGroupInternal *group)
 {
-  PVR_ERROR error(PVR_ERROR_NO_ERROR);
+  PVRError error(PVRError_NO_ERROR);
   PVR_CLIENTMAP clients;
   GetCreatedClients(clients);
 
   /* get the channel list from each client */
   for (const auto &client : clients)
   {
-    PVR_ERROR currentError = client.second->GetChannels(*group, group->IsRadio());
-    if (currentError != PVR_ERROR_NOT_IMPLEMENTED &&
-        currentError != PVR_ERROR_NO_ERROR)
+    PVRError currentError = client.second->GetChannels(*group, group->IsRadio());
+    if (currentError != PVRError_NOT_IMPLEMENTED &&
+        currentError != PVRError_NO_ERROR)
     {
       error = currentError;
       CLog::Log(LOGERROR, "PVR - %s - cannot get channels from client '%d': %s",__FUNCTION__, client.first, CPVRClient::ToString(error));
@@ -833,17 +833,17 @@ PVR_ERROR CPVRClients::GetChannels(CPVRChannelGroupInternal *group)
   return error;
 }
 
-PVR_ERROR CPVRClients::GetChannelGroups(CPVRChannelGroups *groups)
+PVRError CPVRClients::GetChannelGroups(CPVRChannelGroups *groups)
 {
-  PVR_ERROR error(PVR_ERROR_NO_ERROR);
+  PVRError error(PVRError_NO_ERROR);
   PVR_CLIENTMAP clients;
   GetCreatedClients(clients);
 
   for (const auto &client : clients)
   {
-    PVR_ERROR currentError = client.second->GetChannelGroups(groups);
-    if (currentError != PVR_ERROR_NOT_IMPLEMENTED &&
-        currentError != PVR_ERROR_NO_ERROR)
+    PVRError currentError = client.second->GetChannelGroups(groups);
+    if (currentError != PVRError_NOT_IMPLEMENTED &&
+        currentError != PVRError_NO_ERROR)
     {
       error = currentError;
       CLog::Log(LOGERROR, "PVR - %s - cannot get groups from client '%d': %s",__FUNCTION__, client.first, CPVRClient::ToString(error));
@@ -853,18 +853,18 @@ PVR_ERROR CPVRClients::GetChannelGroups(CPVRChannelGroups *groups)
   return error;
 }
 
-PVR_ERROR CPVRClients::GetChannelGroupMembers(CPVRChannelGroup *group)
+PVRError CPVRClients::GetChannelGroupMembers(CPVRChannelGroup *group)
 {
-  PVR_ERROR error(PVR_ERROR_NO_ERROR);
+  PVRError error(PVRError_NO_ERROR);
   PVR_CLIENTMAP clients;
   GetCreatedClients(clients);
 
   /* get the member list from each client */
   for (const auto &client : clients)
   {
-    PVR_ERROR currentError = client.second->GetChannelGroupMembers(group);
-    if (currentError != PVR_ERROR_NOT_IMPLEMENTED &&
-        currentError != PVR_ERROR_NO_ERROR)
+    PVRError currentError = client.second->GetChannelGroupMembers(group);
+    if (currentError != PVRError_NOT_IMPLEMENTED &&
+        currentError != PVRError_NO_ERROR)
     {
       error = currentError;
       CLog::Log(LOGERROR, "PVR - %s - cannot get group members from client '%d': %s",__FUNCTION__, client.first, CPVRClient::ToString(error));
@@ -1030,7 +1030,7 @@ void CPVRClients::StartChannelScan(void)
   long perfCnt = XbmcThreads::SystemClockMillis();
 
   /* do the scan */
-  if (scanClient->StartChannelScan() != PVR_ERROR_NO_ERROR)
+  if (scanClient->StartChannelScan() != PVRError_NO_ERROR)
     /* an error occured */
     CGUIDialogOK::ShowAndGetInput(CVariant{19111}, CVariant{19193});
 
@@ -1058,7 +1058,7 @@ std::vector<PVR_CLIENT> CPVRClients::GetClientsSupportingChannelSettings(bool bR
 
 bool CPVRClients::OpenDialogChannelAdd(const CPVRChannelPtr &channel)
 {
-  PVR_ERROR error = PVR_ERROR_UNKNOWN;
+  PVRError error = PVRError_UNKNOWN;
 
   PVR_CLIENT client;
   if (GetCreatedClient(channel->ClientID(), client))
@@ -1066,18 +1066,18 @@ bool CPVRClients::OpenDialogChannelAdd(const CPVRChannelPtr &channel)
   else
     CLog::Log(LOGERROR, "PVR - %s - cannot find client %d",__FUNCTION__, channel->ClientID());
 
-  if (error == PVR_ERROR_NOT_IMPLEMENTED)
+  if (error == PVRError_NOT_IMPLEMENTED)
   {
     CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{19038});
     return true;
   }
 
-  return error == PVR_ERROR_NO_ERROR;
+  return error == PVRError_NO_ERROR;
 }
 
 bool CPVRClients::OpenDialogChannelSettings(const CPVRChannelPtr &channel)
 {
-  PVR_ERROR error = PVR_ERROR_UNKNOWN;
+  PVRError error = PVRError_UNKNOWN;
 
   PVR_CLIENT client;
   if (GetCreatedClient(channel->ClientID(), client))
@@ -1085,18 +1085,18 @@ bool CPVRClients::OpenDialogChannelSettings(const CPVRChannelPtr &channel)
   else
     CLog::Log(LOGERROR, "PVR - %s - cannot find client %d",__FUNCTION__, channel->ClientID());
 
-  if (error == PVR_ERROR_NOT_IMPLEMENTED)
+  if (error == PVRError_NOT_IMPLEMENTED)
   {
     CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{19038});
     return true;
   }
 
-  return error == PVR_ERROR_NO_ERROR;
+  return error == PVRError_NO_ERROR;
 }
 
 bool CPVRClients::DeleteChannel(const CPVRChannelPtr &channel)
 {
-  PVR_ERROR error = PVR_ERROR_UNKNOWN;
+  PVRError error = PVRError_UNKNOWN;
 
   PVR_CLIENT client;
   if (GetCreatedClient(channel->ClientID(), client))
@@ -1104,18 +1104,18 @@ bool CPVRClients::DeleteChannel(const CPVRChannelPtr &channel)
   else
     CLog::Log(LOGERROR, "PVR - %s - cannot find client %d",__FUNCTION__, channel->ClientID());
 
-  if (error == PVR_ERROR_NOT_IMPLEMENTED)
+  if (error == PVRError_NOT_IMPLEMENTED)
   {
     CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{19038});
     return true;
   }
 
-  return error == PVR_ERROR_NO_ERROR;
+  return error == PVRError_NO_ERROR;
 }
 
 bool CPVRClients::RenameChannel(const CPVRChannelPtr &channel)
 {
-  PVR_ERROR error = PVR_ERROR_UNKNOWN;
+  PVRError error = PVRError_UNKNOWN;
 
   PVR_CLIENT client;
   if (GetCreatedClient(channel->ClientID(), client))
@@ -1123,7 +1123,7 @@ bool CPVRClients::RenameChannel(const CPVRChannelPtr &channel)
   else
     CLog::Log(LOGERROR, "PVR - %s - cannot find client %d",__FUNCTION__, channel->ClientID());
 
-  return (error == PVR_ERROR_NO_ERROR || error == PVR_ERROR_NOT_IMPLEMENTED);
+  return (error == PVRError_NO_ERROR || error == PVRError_NOT_IMPLEMENTED);
 }
 
 bool CPVRClients::IsKnownClient(const AddonPtr client) const

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -359,7 +359,7 @@ namespace PVR
      * @param error An error if it occured.
      * @return True if the timer was added successfully, false otherwise.
      */
-    PVR_ERROR AddTimer(const CPVRTimerInfoTag &timer);
+    PVRError AddTimer(const CPVRTimerInfoTag &timer);
 
     /*!
      * @brief Update a timer on the backend.
@@ -367,7 +367,7 @@ namespace PVR
      * @param error An error if it occured.
      * @return True if the timer was updated successfully, false otherwise.
      */
-    PVR_ERROR UpdateTimer(const CPVRTimerInfoTag &timer);
+    PVRError UpdateTimer(const CPVRTimerInfoTag &timer);
 
     /*!
      * @brief Delete a timer from the backend.
@@ -376,7 +376,7 @@ namespace PVR
      * @param error An error if it occured.
      * @return True if the timer was deleted successfully, false otherwise.
      */
-    PVR_ERROR DeleteTimer(const CPVRTimerInfoTag &timer, bool bForce);
+    PVRError DeleteTimer(const CPVRTimerInfoTag &timer, bool bForce);
 
     /*!
      * @brief Rename a timer on the backend.
@@ -385,22 +385,22 @@ namespace PVR
      * @param error An error if it occured.
      * @return True if the timer was renamed successfully, false otherwise.
      */
-    PVR_ERROR RenameTimer(const CPVRTimerInfoTag &timer, const std::string &strNewName);
+    PVRError RenameTimer(const CPVRTimerInfoTag &timer, const std::string &strNewName);
 
     /*!
      * @brief Get all supported timer types.
      * @param results The container to store the result in.
-     * @return PVR_ERROR_NO_ERROR if the list has been fetched successfully.
+     * @return PVRError_NO_ERROR if the list has been fetched successfully.
      */
-    PVR_ERROR GetTimerTypes(CPVRTimerTypes& results) const;
+    PVRError GetTimerTypes(CPVRTimerTypes& results) const;
 
     /*!
      * @brief Get all timer types supported by a certain client.
      * @param iClientId The id of the client.
      * @param results The container to store the result in.
-     * @return PVR_ERROR_NO_ERROR if the list has been fetched successfully.
+     * @return PVRError_NO_ERROR if the list has been fetched successfully.
      */
-    PVR_ERROR GetTimerTypes(CPVRTimerTypes& results, int iClientId) const;
+    PVRError GetTimerTypes(CPVRTimerTypes& results, int iClientId) const;
 
     //@}
 
@@ -427,7 +427,7 @@ namespace PVR
      * @param deleted Return deleted recordings
      * @return The amount of recordings that were added.
      */
-    PVR_ERROR GetRecordings(CPVRRecordings *recordings, bool deleted);
+    PVRError GetRecordings(CPVRRecordings *recordings, bool deleted);
 
     /*!
      * @brief Rename a recordings on the backend.
@@ -435,7 +435,7 @@ namespace PVR
      * @param error An error if it occured.
      * @return True if the recording was renamed successfully, false otherwise.
      */
-    PVR_ERROR RenameRecording(const CPVRRecording &recording);
+    PVRError RenameRecording(const CPVRRecording &recording);
 
     /*!
      * @brief Delete a recording from the backend.
@@ -443,7 +443,7 @@ namespace PVR
      * @param error An error if it occured.
      * @return True if the recordings was deleted successfully, false otherwise.
      */
-    PVR_ERROR DeleteRecording(const CPVRRecording &recording);
+    PVRError DeleteRecording(const CPVRRecording &recording);
 
     /*!
      * @brief Undelete a recording from the backend.
@@ -451,13 +451,13 @@ namespace PVR
      * @param error An error if it occured.
      * @return True if the recording was undeleted successfully, false otherwise.
      */
-    PVR_ERROR UndeleteRecording(const CPVRRecording &recording);
+    PVRError UndeleteRecording(const CPVRRecording &recording);
 
     /*!
      * @brief Delete all recordings permanent which in the deleted folder on the backend.
-     * @return PVR_ERROR_NO_ERROR if the recordings has been deleted successfully.
+     * @return PVRError_NO_ERROR if the recordings has been deleted successfully.
      */
-    PVR_ERROR DeleteAllRecordingsFromTrash();
+    PVRError DeleteAllRecordingsFromTrash();
 
     /*!
      * @brief Set play count of a recording on the backend.
@@ -466,7 +466,7 @@ namespace PVR
      * @param error An error if it occured.
      * @return True if the recording's play count was set successfully, false otherwise.
      */
-    bool SetRecordingPlayCount(const CPVRRecording &recording, int count, PVR_ERROR *error);
+    bool SetRecordingPlayCount(const CPVRRecording &recording, int count, PVRError *error);
 
     /*!
      * @brief Set the last watched position of a recording on the backend.
@@ -475,7 +475,7 @@ namespace PVR
      * @param error An error if it occured.
      * @return True if the last played position was updated successfully, false otherwise
     */
-    bool SetRecordingLastPlayedPosition(const CPVRRecording &recording, int lastplayedposition, PVR_ERROR *error);
+    bool SetRecordingLastPlayedPosition(const CPVRRecording &recording, int lastplayedposition, PVRError *error);
 
     /*!
     * @brief Retrieve the last watched position of a recording on the backend.
@@ -524,16 +524,16 @@ namespace PVR
      * @param error An error if it occured.
      * @return True if the EPG was transfered successfully, false otherwise.
      */
-    PVR_ERROR GetEPGForChannel(const CPVRChannelPtr &channel, EPG::CEpg *epg, time_t start, time_t end);
+    PVRError GetEPGForChannel(const CPVRChannelPtr &channel, EPG::CEpg *epg, time_t start, time_t end);
 
     /*!
      * Tell the client the time frame to use when notifying epg events back to Kodi. The client might push epg events asynchronously
      * to Kodi using the callback function EpgEventStateChange. To be able to only push events that are actually of interest for Kodi,
      * client needs to know about the epg time frame Kodi uses.
      * @param iDays number of days from "now". EPG_TIMEFRAME_UNLIMITED means that Kodi is interested in all epg events, regardless of event times.
-     * @return PVR_ERROR_NO_ERROR if new value was successfully set.
+     * @return PVRError_NO_ERROR if new value was successfully set.
      */
-    PVR_ERROR SetEPGTimeFrame(int iDays);
+    PVRError SetEPGTimeFrame(int iDays);
 
     //@}
 
@@ -546,7 +546,7 @@ namespace PVR
      * @param error An error if it occured.
      * @return The amount of channels that were added.
      */
-    PVR_ERROR GetChannels(CPVRChannelGroupInternal *group);
+    PVRError GetChannels(CPVRChannelGroupInternal *group);
 
     /*!
      * @brief Check whether a client supports channel groups.
@@ -561,7 +561,7 @@ namespace PVR
      * @param error An error if it occured.
      * @return The amount of groups that were added.
      */
-    PVR_ERROR GetChannelGroups(CPVRChannelGroups *groups);
+    PVRError GetChannelGroups(CPVRChannelGroups *groups);
 
     /*!
      * @brief Get all group members of a channel group.
@@ -569,7 +569,7 @@ namespace PVR
      * @param error An error if it occured.
      * @return The amount of channels that were added.
      */
-    PVR_ERROR GetChannelGroupMembers(CPVRChannelGroup *group);
+    PVRError GetChannelGroupMembers(CPVRChannelGroup *group);
 
     //@}
 

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -607,7 +607,7 @@ int CPVRChannelGroup::LoadFromDb(bool bCompress /* = false */)
 bool CPVRChannelGroup::LoadFromClients(void)
 {
   /* get the channels from the backends */
-  return g_PVRClients->GetChannelGroupMembers(this) == PVR_ERROR_NO_ERROR;
+  return g_PVRClients->GetChannelGroupMembers(this) == PVRError_NO_ERROR;
 }
 
 bool CPVRChannelGroup::AddAndUpdateChannels(const CPVRChannelGroup &channels, bool bUseBackendChannelNumbers)

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
@@ -245,7 +245,7 @@ int CPVRChannelGroupInternal::LoadFromDb(bool bCompress /* = false */)
 bool CPVRChannelGroupInternal::LoadFromClients(void)
 {
   /* get the channels from the backends */
-  return g_PVRClients->GetChannels(this) == PVR_ERROR_NO_ERROR;
+  return g_PVRClients->GetChannels(this) == PVRError_NO_ERROR;
 }
 
 bool CPVRChannelGroupInternal::IsGroupMember(const CPVRChannelPtr &channel) const

--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -56,7 +56,7 @@ bool CPVRChannelGroups::GetGroupsFromClients(void)
   if (! CSettings::GetInstance().GetBool(CSettings::SETTING_PVRMANAGER_SYNCCHANNELGROUPS))
     return true;
 
-  return g_PVRClients->GetChannelGroups(this) == PVR_ERROR_NO_ERROR;
+  return g_PVRClients->GetChannelGroups(this) == PVRError_NO_ERROR;
 }
 
 bool CPVRChannelGroups::Update(const CPVRChannelGroup &group, bool bUpdateFromClient /* = false */)

--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -241,8 +241,8 @@ int CPVRRecording::GetDuration() const
 
 bool CPVRRecording::Delete(void)
 {
-  PVR_ERROR error = g_PVRClients->DeleteRecording(*this);
-  if (error != PVR_ERROR_NO_ERROR)
+  PVRError error = g_PVRClients->DeleteRecording(*this);
+  if (error != PVRError_NO_ERROR)
   {
     DisplayError(error);
     return false;
@@ -267,8 +267,8 @@ void CPVRRecording::OnDelete(void)
 
 bool CPVRRecording::Undelete(void)
 {
-  PVR_ERROR error = g_PVRClients->UndeleteRecording(*this);
-  if (error != PVR_ERROR_NO_ERROR)
+  PVRError error = g_PVRClients->UndeleteRecording(*this);
+  if (error != PVRError_NO_ERROR)
   {
     DisplayError(error);
     return false;
@@ -280,8 +280,8 @@ bool CPVRRecording::Undelete(void)
 bool CPVRRecording::Rename(const std::string &strNewName)
 {
   m_strTitle = StringUtils::Format("%s", strNewName.c_str());
-  PVR_ERROR error = g_PVRClients->RenameRecording(*this);
-  if (error != PVR_ERROR_NO_ERROR)
+  PVRError error = g_PVRClients->RenameRecording(*this);
+  if (error != PVRError_NO_ERROR)
   {
     DisplayError(error);
     return false;
@@ -292,7 +292,7 @@ bool CPVRRecording::Rename(const std::string &strNewName)
 
 bool CPVRRecording::SetPlayCount(int count)
 {
-  PVR_ERROR error;
+  PVRError error;
   m_playCount = count;
   if (g_PVRClients->SupportsRecordingPlayCount(m_iClientId) &&
       !g_PVRClients->SetRecordingPlayCount(*this, count, &error))
@@ -331,7 +331,7 @@ bool CPVRRecording::IncrementPlayCount()
 
 bool CPVRRecording::SetLastPlayedPosition(int lastplayedposition)
 {
-  PVR_ERROR error;
+  PVRError error;
 
   CBookmark bookmark;
   bookmark.timeInSeconds = lastplayedposition;
@@ -354,7 +354,7 @@ int CPVRRecording::GetLastPlayedPosition() const
   {
     rc = g_PVRClients->GetRecordingLastPlayedPosition(*this);
     if (rc < 0)
-      DisplayError(PVR_ERROR_SERVER_ERROR);
+      DisplayError(PVRError_SERVER_ERROR);
   }
   return rc;
 }
@@ -368,11 +368,11 @@ std::vector<PVR_EDL_ENTRY> CPVRRecording::GetEdl() const
   return std::vector<PVR_EDL_ENTRY>();
 }
 
-void CPVRRecording::DisplayError(PVR_ERROR err) const
+void CPVRRecording::DisplayError(PVRError err) const
 {
-  if (err == PVR_ERROR_SERVER_ERROR)
+  if (err == PVRError_SERVER_ERROR)
     CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{19111}); /* print info dialog "Server error!" */
-  else if (err == PVR_ERROR_REJECTED)
+  else if (err == PVRError_REJECTED)
     CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{19068}); /* print info dialog "Couldn't delete recording!" */
   else
     CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{19147}); /* print info dialog "Unknown error!" */

--- a/xbmc/pvr/recordings/PVRRecording.h
+++ b/xbmc/pvr/recordings/PVRRecording.h
@@ -36,6 +36,7 @@
  */
 
 #include "XBDateTime.h"
+#include "addons/binary/interfaces/PVRClientBase.h"
 #include "addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h"
 #include "video/VideoInfoTag.h"
 
@@ -245,6 +246,6 @@ namespace PVR
     bool         m_bRadio;        /*!< radio or tv recording */
 
     void UpdatePath(void);
-    void DisplayError(PVR_ERROR err) const;
+    void DisplayError(PVRError err) const;
   };
 }

--- a/xbmc/pvr/recordings/PVRRecordings.cpp
+++ b/xbmc/pvr/recordings/PVRRecordings.cpp
@@ -254,7 +254,7 @@ bool CPVRRecordings::RenameRecording(CFileItem &item, std::string &strNewName)
 
 bool CPVRRecordings::DeleteAllRecordingsFromTrash()
 {
-  return g_PVRClients->DeleteAllRecordingsFromTrash() == PVR_ERROR_NO_ERROR;
+  return g_PVRClients->DeleteAllRecordingsFromTrash() == PVRError_NO_ERROR;
 }
 
 bool CPVRRecordings::SetRecordingsPlayCount(const CFileItemPtr &item, int count)

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -552,8 +552,8 @@ std::string CPVRTimerInfoTag::GetWeekdaysString() const
 
 bool CPVRTimerInfoTag::AddToClient(void) const
 {
-  PVR_ERROR error = g_PVRClients->AddTimer(*this);
-  if (error != PVR_ERROR_NO_ERROR)
+  PVRError error = g_PVRClients->AddTimer(*this);
+  if (error != PVRError_NO_ERROR)
   {
     DisplayError(error);
     return false;
@@ -564,8 +564,8 @@ bool CPVRTimerInfoTag::AddToClient(void) const
 
 bool CPVRTimerInfoTag::DeleteFromClient(bool bForce /* = false */) const
 {
-  PVR_ERROR error = g_PVRClients->DeleteTimer(*this, bForce);
-  if (error == PVR_ERROR_RECORDING_RUNNING)
+  PVRError error = g_PVRClients->DeleteTimer(*this, bForce);
+  if (error == PVRError_RECORDING_RUNNING)
   {
     // recording running. ask the user if it should be deleted anyway
     if (HELPERS::ShowYesNoDialogText(CVariant{122}, CVariant{19122}) != DialogResponse::YES)
@@ -574,7 +574,7 @@ bool CPVRTimerInfoTag::DeleteFromClient(bool bForce /* = false */) const
     error = g_PVRClients->DeleteTimer(*this, true);
   }
 
-  if (error != PVR_ERROR_NO_ERROR)
+  if (error != PVRError_NO_ERROR)
   {
     DisplayError(error);
     return false;
@@ -591,10 +591,10 @@ bool CPVRTimerInfoTag::RenameOnClient(const std::string &strNewName)
     m_strTitle = strNewName;
   }
 
-  PVR_ERROR error = g_PVRClients->RenameTimer(*this, strNewName);
-  if (error != PVR_ERROR_NO_ERROR)
+  PVRError error = g_PVRClients->RenameTimer(*this, strNewName);
+  if (error != PVRError_NO_ERROR)
   {
-    if (error == PVR_ERROR_NOT_IMPLEMENTED)
+    if (error == PVRError_NOT_IMPLEMENTED)
       return UpdateOnClient();
 
     DisplayError(error);
@@ -688,8 +688,8 @@ void CPVRTimerInfoTag::ResetChildState()
 
 bool CPVRTimerInfoTag::UpdateOnClient()
 {
-  PVR_ERROR error = g_PVRClients->UpdateTimer(*this);
-  if (error != PVR_ERROR_NO_ERROR)
+  PVRError error = g_PVRClients->UpdateTimer(*this);
+  if (error != PVRError_NO_ERROR)
   {
     DisplayError(error);
     return false;
@@ -698,13 +698,13 @@ bool CPVRTimerInfoTag::UpdateOnClient()
   return true;
 }
 
-void CPVRTimerInfoTag::DisplayError(PVR_ERROR err) const
+void CPVRTimerInfoTag::DisplayError(PVRError err) const
 {
-  if (err == PVR_ERROR_SERVER_ERROR)
+  if (err == PVRError_SERVER_ERROR)
     CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{19111}); /* print info dialog "Server error!" */
-  else if (err == PVR_ERROR_REJECTED)
+  else if (err == PVRError_REJECTED)
     CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{19109}); /* print info dialog "Couldn't save timer!" */
-  else if (err == PVR_ERROR_ALREADY_PRESENT)
+  else if (err == PVRError_ALREADY_PRESENT)
     CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{19067}); /* print info dialog */
   else
     CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{19110}); /* print info dialog "Unknown error!" */

--- a/xbmc/pvr/timers/PVRTimerInfoTag.h
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.h
@@ -39,7 +39,7 @@
 
 #include <memory>
 
-#include "addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h"
+#include "addons/binary/interfaces/PVRClientBase.h"
 #include "pvr/timers/PVRTimerType.h"
 #include "threads/CriticalSection.h"
 #include "utils/ISerializable.h"
@@ -90,7 +90,7 @@ namespace PVR
 
     void UpdateSummary(void);
 
-    void DisplayError(PVR_ERROR err) const;
+    void DisplayError(PVRError err) const;
 
     std::string GetStatus() const;
     std::string GetTypeAsString() const;

--- a/xbmc/pvr/timers/PVRTimerType.cpp
+++ b/xbmc/pvr/timers/PVRTimerType.cpp
@@ -45,8 +45,8 @@ const CPVRTimerTypePtr CPVRTimerType::GetFirstAvailableType()
 CPVRTimerTypePtr CPVRTimerType::CreateFromIds(unsigned int iTypeId, int iClientId)
 {
   std::vector<CPVRTimerTypePtr> types;
-  PVR_ERROR error = g_PVRClients->GetTimerTypes(types, iClientId);
-  if (error == PVR_ERROR_NO_ERROR)
+  PVRError error = g_PVRClients->GetTimerTypes(types, iClientId);
+  if (error == PVRError_NO_ERROR)
   {
     for (const auto &type : types)
     {
@@ -63,8 +63,8 @@ CPVRTimerTypePtr CPVRTimerType::CreateFromAttributes(
   unsigned int iMustHaveAttr, unsigned int iMustNotHaveAttr, int iClientId)
 {
   std::vector<CPVRTimerTypePtr> types;
-  PVR_ERROR error = g_PVRClients->GetTimerTypes(types, iClientId);
-  if (error == PVR_ERROR_NO_ERROR)
+  PVRError error = g_PVRClients->GetTimerTypes(types, iClientId);
+  if (error == PVRError_NO_ERROR)
   {
     for (const auto &type : types)
     {


### PR DESCRIPTION
This is a small part to bring in binary add-ons independent.

The goal on end is to handle parts from add-on headers only on PVRClient.h and for all other binary add-ons the same way.

With this are changes of levels only be needed on the add-on classes with `ADDON::CAddonDll`.

@ksooo @FernetMenta a way like this here OK.

Has not made it now to all to have a better overview.
