### PR TITLE
addons: enable/disable callback interface for pvr

### DIFF
--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -23,9 +23,12 @@
 #include "utils/log.h"
 #include "interfaces/AnnouncementManager.h"
 #include "interfaces/generic/ScriptInvocationManager.h"
+#include "addons/binary/interfaces/api1/PVR/AddonCallbacksPVR.h"
 
 bool CServiceManager::Init1()
 {
+  V1::KodiAPI::PVR::CAddonCallbacksPVR::EnableInterface(false);
+
   m_announcementManager.reset(new ANNOUNCEMENT::CAnnouncementManager());
   m_announcementManager->Start();
 
@@ -46,6 +49,7 @@ bool CServiceManager::Init2()
 
   m_ADSPManager.reset(new ActiveAE::CActiveAEDSP());
   m_PVRManager.reset(new PVR::CPVRManager());
+  V1::KodiAPI::PVR::CAddonCallbacksPVR::EnableInterface(true);
 
   m_binaryAddonCache.reset( new ADDON::CBinaryAddonCache());
   m_binaryAddonCache->Init();
@@ -63,6 +67,8 @@ bool CServiceManager::Init3()
 
 void CServiceManager::Deinit()
 {
+  V1::KodiAPI::PVR::CAddonCallbacksPVR::EnableInterface(false);
+
   m_binaryAddonCache.reset();
   m_PVRManager.reset();
   m_ADSPManager.reset();

--- a/xbmc/addons/binary/interfaces/IAddonInterface.h
+++ b/xbmc/addons/binary/interfaces/IAddonInterface.h
@@ -36,7 +36,7 @@ namespace ADDON
   {
   public:
     IAddonInterface(CAddon *addon, int apiLevel, const std::string& version) :
-      m_addon(addon), m_apiLevel(apiLevel), m_version(version)  {}
+      m_addon(addon), m_apiLevel(apiLevel), m_version(version) {}
 
     CAddon*            GetAddon()       { return m_addon;    }
     const CAddon*      GetAddon() const { return m_addon;    }

--- a/xbmc/addons/binary/interfaces/api1/PVR/AddonCallbacksPVR.cpp
+++ b/xbmc/addons/binary/interfaces/api1/PVR/AddonCallbacksPVR.cpp
@@ -50,6 +50,8 @@ namespace KodiAPI
 namespace PVR
 {
 
+std::atomic_bool CAddonCallbacksPVR::m_enabled;
+
 CAddonCallbacksPVR::CAddonCallbacksPVR(CAddon* addon)
   : ADDON::IAddonInterface(addon, 1, XBMC_PVR_API_VERSION),
     m_callbacks(new CB_PVRLib)
@@ -82,6 +84,9 @@ CAddonCallbacksPVR::~CAddonCallbacksPVR()
 
 CPVRClient *CAddonCallbacksPVR::GetPVRClient(void *addonData)
 {
+  if (!m_enabled)
+    return nullptr;
+
   CAddonInterfaces *addon = static_cast<CAddonInterfaces *>(addonData);
   if (!addon || !addon->PVRLib_GetHelper())
   {
@@ -94,6 +99,9 @@ CPVRClient *CAddonCallbacksPVR::GetPVRClient(void *addonData)
 
 void CAddonCallbacksPVR::PVRTransferChannelGroup(void *addonData, const ADDON_HANDLE handle, const PVR_CHANNEL_GROUP *group)
 {
+  if (!m_enabled)
+    return;
+
   if (!handle)
   {
     CLog::Log(LOGERROR, "PVR - %s - invalid handler data", __FUNCTION__);
@@ -120,6 +128,9 @@ void CAddonCallbacksPVR::PVRTransferChannelGroup(void *addonData, const ADDON_HA
 
 void CAddonCallbacksPVR::PVRTransferChannelGroupMember(void *addonData, const ADDON_HANDLE handle, const PVR_CHANNEL_GROUP_MEMBER *member)
 {
+  if (!m_enabled)
+    return;
+
   if (!handle)
   {
     CLog::Log(LOGERROR, "PVR - %s - invalid handler data", __FUNCTION__);
@@ -148,6 +159,9 @@ void CAddonCallbacksPVR::PVRTransferChannelGroupMember(void *addonData, const AD
 
 void CAddonCallbacksPVR::PVRTransferEpgEntry(void *addonData, const ADDON_HANDLE handle, const EPG_TAG *epgentry)
 {
+  if (!m_enabled)
+    return;
+
   if (!handle)
   {
     CLog::Log(LOGERROR, "PVR - %s - invalid handler data", __FUNCTION__);
@@ -167,6 +181,9 @@ void CAddonCallbacksPVR::PVRTransferEpgEntry(void *addonData, const ADDON_HANDLE
 
 void CAddonCallbacksPVR::PVRTransferChannelEntry(void *addonData, const ADDON_HANDLE handle, const PVR_CHANNEL *channel)
 {
+  if (!m_enabled)
+    return;
+
   if (!handle)
   {
     CLog::Log(LOGERROR, "PVR - %s - invalid handler data", __FUNCTION__);
@@ -188,6 +205,9 @@ void CAddonCallbacksPVR::PVRTransferChannelEntry(void *addonData, const ADDON_HA
 
 void CAddonCallbacksPVR::PVRTransferRecordingEntry(void *addonData, const ADDON_HANDLE handle, const PVR_RECORDING *recording)
 {
+  if (!m_enabled)
+    return;
+
   if (!handle)
   {
     CLog::Log(LOGERROR, "PVR - %s - invalid handler data", __FUNCTION__);
@@ -209,6 +229,9 @@ void CAddonCallbacksPVR::PVRTransferRecordingEntry(void *addonData, const ADDON_
 
 void CAddonCallbacksPVR::PVRTransferTimerEntry(void *addonData, const ADDON_HANDLE handle, const PVR_TIMER *timer)
 {
+  if (!m_enabled)
+    return;
+
   if (!handle)
   {
     CLog::Log(LOGERROR, "PVR - %s - invalid handler data", __FUNCTION__);
@@ -233,6 +256,9 @@ void CAddonCallbacksPVR::PVRTransferTimerEntry(void *addonData, const ADDON_HAND
 
 void CAddonCallbacksPVR::PVRAddMenuHook(void *addonData, PVR_MENUHOOK *hook)
 {
+  if (!m_enabled)
+    return;
+
   CPVRClient *client = GetPVRClient(addonData);
   if (!hook || !client)
   {
@@ -255,6 +281,9 @@ void CAddonCallbacksPVR::PVRAddMenuHook(void *addonData, PVR_MENUHOOK *hook)
 
 void CAddonCallbacksPVR::PVRRecording(void *addonData, const char *strName, const char *strFileName, bool bOnOff)
 {
+  if (!m_enabled)
+    return;
+
   CPVRClient *client = GetPVRClient(addonData);
   if (!client || !strFileName)
   {
@@ -279,30 +308,45 @@ void CAddonCallbacksPVR::PVRRecording(void *addonData, const char *strName, cons
 
 void CAddonCallbacksPVR::PVRTriggerChannelUpdate(void *addonData)
 {
+  if (!m_enabled)
+    return;
+
   /* update the channels table in the next iteration of the pvrmanager's main loop */
   g_PVRManager.TriggerChannelsUpdate();
 }
 
 void CAddonCallbacksPVR::PVRTriggerTimerUpdate(void *addonData)
 {
+  if (!m_enabled)
+    return;
+
   /* update the timers table in the next iteration of the pvrmanager's main loop */
   g_PVRManager.TriggerTimersUpdate();
 }
 
 void CAddonCallbacksPVR::PVRTriggerRecordingUpdate(void *addonData)
 {
+  if (!m_enabled)
+    return;
+
   /* update the recordings table in the next iteration of the pvrmanager's main loop */
   g_PVRManager.TriggerRecordingsUpdate();
 }
 
 void CAddonCallbacksPVR::PVRTriggerChannelGroupsUpdate(void *addonData)
 {
+  if (!m_enabled)
+    return;
+
   /* update all channel groups in the next iteration of the pvrmanager's main loop */
   g_PVRManager.TriggerChannelGroupsUpdate();
 }
 
 void CAddonCallbacksPVR::PVRTriggerEpgUpdate(void *addonData, unsigned int iChannelUid)
 {
+  if (!m_enabled)
+    return;
+
   // get the client
   CPVRClient *client = GetPVRClient(addonData);
   if (!client)
@@ -316,16 +360,25 @@ void CAddonCallbacksPVR::PVRTriggerEpgUpdate(void *addonData, unsigned int iChan
 
 void CAddonCallbacksPVR::PVRFreeDemuxPacket(void *addonData, DemuxPacket* pPacket)
 {
+  if (!m_enabled)
+    return;
+
   CDVDDemuxUtils::FreeDemuxPacket(pPacket);
 }
 
 DemuxPacket* CAddonCallbacksPVR::PVRAllocateDemuxPacket(void *addonData, int iDataSize)
 {
+  if (!m_enabled)
+    return nullptr;
+
   return CDVDDemuxUtils::AllocateDemuxPacket(iDataSize);
 }
 
 void CAddonCallbacksPVR::PVRConnectionStateChange(void* addonData, const char* strConnectionString, PVR_CONNECTION_STATE newState, const char *strMessage)
 {
+  if (!m_enabled)
+    return;
+
   CPVRClient *client = GetPVRClient(addonData);
   if (!client || !strConnectionString)
   {
@@ -365,6 +418,9 @@ typedef struct EpgEventStateChange
 
 void CAddonCallbacksPVR::UpdateEpgEvent(const EpgEventStateChange &ch, bool bQueued)
 {
+  if (!m_enabled)
+    return;
+
   const CPVRChannelPtr channel(g_PVRChannelGroups->GetByUniqueID(ch.iUniqueChannelId, ch.iClientId));
   if (channel)
   {
@@ -388,6 +444,9 @@ void CAddonCallbacksPVR::UpdateEpgEvent(const EpgEventStateChange &ch, bool bQue
 
 void CAddonCallbacksPVR::PVREpgEventStateChange(void* addonData, EPG_TAG* tag, unsigned int iUniqueChannelId, EPG_EVENT_STATE newState)
 {
+  if (!m_enabled)
+    return;
+
   CPVRClient *client = GetPVRClient(addonData);
   if (!client || !tag)
   {

--- a/xbmc/addons/binary/interfaces/api1/PVR/AddonCallbacksPVR.h
+++ b/xbmc/addons/binary/interfaces/api1/PVR/AddonCallbacksPVR.h
@@ -20,6 +20,7 @@
  *
  */
 
+#include <atomic>
 #include "addons/binary/interfaces/AddonInterfaces.h"
 #include "addons/kodi-addon-dev-kit/include/kodi/xbmc_epg_types.h"
 #include "addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h"
@@ -95,6 +96,8 @@ class CAddonCallbacksPVR : public ADDON::IAddonInterface
 public:
   CAddonCallbacksPVR(ADDON::CAddon* addon);
   virtual ~CAddonCallbacksPVR(void);
+
+  static void EnableInterface(bool enable) { m_enabled = enable; }
 
   /*!
    * @return The callback table.
@@ -237,6 +240,7 @@ private:
   static void UpdateEpgEvent(const EpgEventStateChange &ch, bool bQueued);
 
   CB_PVRLib    *m_callbacks; /*!< callback addresses */
+  static std::atomic_bool m_enabled;
 };
 
 } /* namespace PVR */


### PR DESCRIPTION
fix crash on exit when PVR addons still want to use the callback interface

@AlwinEsch other interface suffer from the same issue.
