### PR TITLE
[pvr] destroy all created clients on unload

### DIFF
--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -168,6 +168,10 @@ void CPVRClients::Unload(void)
   m_bIsPlayingRecording  = false;
   m_strPlayingClientName = "";
 
+  for (const auto &client : m_clientMap)
+  {
+    client.second->Destroy();
+  }
   m_clientMap.clear();
 }
 


### PR DESCRIPTION
this also fixes the crash reported in https://github.com/xbmc/xbmc/pull/9758
