### PR TITLE
addons: fix death spiral of recursion

### DIFF
--- a/xbmc/addons/AddonDll.h
+++ b/xbmc/addons/AddonDll.h
@@ -243,7 +243,6 @@ ADDON_STATUS CAddonDll<TheDll, TheStruct, TheProps>::Create()
     else
     { // Addon failed initialization
       CLog::Log(LOGERROR, "ADDON: Dll %s - Client returned bad status (%i) from Create and is not usable", Name().c_str(), status);
-      new CAddonStatusHandler(shared_from_this(), status, "", false);
     }
   }
   catch (std::exception &e)

--- a/xbmc/addons/AddonDll.h
+++ b/xbmc/addons/AddonDll.h
@@ -191,7 +191,7 @@ bool CAddonDll<TheDll, TheStruct, TheProps>::LoadDll()
   {
     delete m_pDll;
     m_pDll = NULL;
-    new CAddonStatusHandler(ID(), ADDON_STATUS_UNKNOWN, "Can't load Dll", false);
+    new CAddonStatusHandler(shared_from_this(), ADDON_STATUS_UNKNOWN, "Can't load Dll", false);
     return false;
   }
 
@@ -238,12 +238,12 @@ ADDON_STATUS CAddonDll<TheDll, TheStruct, TheProps>::Create()
       if ((status = TransferSettings()) == ADDON_STATUS_OK)
         m_initialized = true;
       else
-        new CAddonStatusHandler(ID(), status, "", false);
+        new CAddonStatusHandler(shared_from_this(), status, "", false);
     }
     else
     { // Addon failed initialization
       CLog::Log(LOGERROR, "ADDON: Dll %s - Client returned bad status (%i) from Create and is not usable", Name().c_str(), status);
-      new CAddonStatusHandler(ID(), status, "", false);
+      new CAddonStatusHandler(shared_from_this(), status, "", false);
     }
   }
   catch (std::exception &e)
@@ -524,7 +524,7 @@ ADDON_STATUS CAddonDll<TheDll, TheStruct, TheProps>::TransferSettings()
 
   if (restart || reportStatus != ADDON_STATUS_OK)
   {
-    new CAddonStatusHandler(ID(), restart ? ADDON_STATUS_NEED_RESTART : reportStatus, "", true);
+    new CAddonStatusHandler(shared_from_this(), restart ? ADDON_STATUS_NEED_RESTART : reportStatus, "", true);
   }
 
   return ADDON_STATUS_OK;

--- a/xbmc/addons/AddonStatusHandler.cpp
+++ b/xbmc/addons/AddonStatusHandler.cpp
@@ -46,12 +46,11 @@ namespace ADDON
 
 CCriticalSection CAddonStatusHandler::m_critSection;
 
-CAddonStatusHandler::CAddonStatusHandler(const std::string &addonID, ADDON_STATUS status, std::string message, bool sameThread)
-  : CThread(("AddonStatus " + addonID).c_str()),
+CAddonStatusHandler::CAddonStatusHandler(AddonPtr addon, ADDON_STATUS status, std::string message, bool sameThread)
+  : CThread(("AddonStatus " + addon->ID()).c_str()),
     m_status(ADDON_STATUS_UNKNOWN)
 {
-  if (!CAddonMgr::GetInstance().GetAddon(addonID, m_addon))
-    return;
+  m_addon = addon;
 
   CLog::Log(LOGINFO, "Called Add-on status handler for '%u' of clientName:%s, clientID:%s (same Thread=%s)", status, m_addon->Name().c_str(), m_addon->ID().c_str(), sameThread ? "yes" : "no");
 

--- a/xbmc/addons/AddonStatusHandler.h
+++ b/xbmc/addons/AddonStatusHandler.h
@@ -37,7 +37,7 @@ namespace ADDON
   class CAddonStatusHandler : private CThread
   {
     public:
-      CAddonStatusHandler(const std::string &addonID, ADDON_STATUS status, std::string message, bool sameThread = true);
+      CAddonStatusHandler(AddonPtr addon, ADDON_STATUS status, std::string message, bool sameThread = true);
       ~CAddonStatusHandler();
 
       /* Thread handling */

--- a/xbmc/addons/InputStream.h
+++ b/xbmc/addons/InputStream.h
@@ -37,7 +37,7 @@ namespace ADDON
   {
   public:
 
-    static std::unique_ptr<CInputStream> FromExtension(AddonProps props, const cp_extension_t* ext);
+    static std::shared_ptr<CInputStream> FromExtension(AddonProps props, const cp_extension_t* ext);
 
     explicit CInputStream(AddonProps props)
       : InputStreamDll(std::move(props))
@@ -91,6 +91,7 @@ namespace ADDON
     void UpdateStreams();
     void DisposeStreams();
     void UpdateConfig();
+    void CheckConfig();
 
     std::vector<std::string> m_fileItemProps;
     std::vector<std::string> m_extensionsList;


### PR DESCRIPTION
fix crash on startup if load of addon fails. having status handler operate on the class instead of the object was wrong.

credits to @mapfau for tracking this down

@MartijnKaijser this may also cure the crash you observed on Android
