### PR TITLE
[EPG] Fix crash on opening epg grid window directly after channel(s) got deleted.

### DIFF
--- a/xbmc/epg/GUIEPGGridContainer.cpp
+++ b/xbmc/epg/GUIEPGGridContainer.cpp
@@ -501,8 +501,12 @@ void CGUIEPGGridContainer::UpdateItems()
     if (prevSelectedEpgTag->StartAsUTC().IsValid()) // "normal" tag selected
     {
       newBlockIndex = (prevSelectedEpgTag->StartAsUTC() - m_gridModel->GetGridStart()).GetSecondsTotal() / 60 / CGUIEPGGridContainerModel::MINSPERBLOCK + eventOffset;
-      channelUid    = prevSelectedEpgTag->ChannelTag()->UniqueID();
-      broadcastUid  = prevSelectedEpgTag->UniqueBroadcastID();
+
+      const CPVRChannelPtr channel(prevSelectedEpgTag->ChannelTag());
+      if (channel)
+        channelUid = channel->UniqueID();
+
+      broadcastUid = prevSelectedEpgTag->UniqueBroadcastID();
     }
     else // "gap" tag seleceted
     {
@@ -513,8 +517,12 @@ void CGUIEPGGridContainer::UpdateItems()
         if (tag && tag->EndAsUTC().IsValid())
         {
           newBlockIndex = (tag->EndAsUTC() - m_gridModel->GetGridStart()).GetSecondsTotal() / 60 / CGUIEPGGridContainerModel::MINSPERBLOCK + eventOffset;
-          channelUid    = tag->ChannelTag()->UniqueID();
-          broadcastUid  = tag->UniqueBroadcastID();
+
+          const CPVRChannelPtr channel(tag->ChannelTag());
+          if (channel)
+            channelUid = channel->UniqueID();
+
+          broadcastUid = tag->UniqueBroadcastID();
         }
       }
     }

--- a/xbmc/epg/GUIEPGGridContainerModel.cpp
+++ b/xbmc/epg/GUIEPGGridContainerModel.cpp
@@ -82,6 +82,9 @@ void CGUIEPGGridContainerModel::Refresh(const std::unique_ptr<CFileItemList> &it
     m_programmeItems.emplace_back(fileItem);
 
     channel = fileItem->GetEPGInfoTag()->ChannelTag();
+    if (!channel)
+      continue;
+
     int iCurrentChannelID = channel->ChannelID();
     if (iCurrentChannelID != iLastChannelID)
     {
@@ -258,8 +261,9 @@ void CGUIEPGGridContainerModel::FindChannelAndBlockIndex(int channelUid, unsigne
     CDateTime gridCursor(m_gridStart); //reset cursor for new channel
     unsigned long progIdx = m_epgItemsPtr[channel].start;
     unsigned long lastIdx = m_epgItemsPtr[channel].stop;
-    int iEpgId            = m_programmeItems[progIdx]->GetEPGInfoTag()->EpgID();
+    int iEpgId = m_programmeItems[progIdx]->GetEPGInfoTag()->EpgID();
     CEpgInfoTagPtr tag;
+    CPVRChannelPtr chan;
 
     for (int block = 0; block < m_blocks; ++block)
     {
@@ -278,10 +282,14 @@ void CGUIEPGGridContainerModel::FindChannelAndBlockIndex(int channelUid, unsigne
             newBlockIndex   = block + eventOffset;
             return; // both found. done.
           }
-          if (!bFoundPrevChannel && channelUid > -1 && tag->ChannelTag()->UniqueID() == channelUid)
+          if (!bFoundPrevChannel && channelUid > -1)
           {
-            newChannelIndex = channel;
-            bFoundPrevChannel = true;
+            chan = tag->ChannelTag();
+            if (chan && chan->UniqueID() == channelUid)
+            {
+              newChannelIndex = channel;
+              bFoundPrevChannel = true;
+            }
           }
           break; // next block
         }


### PR DESCRIPTION
Difficult to reproduce, but fix is obvious, I guess.

@Jalle19 mind taking a look.
