### PR TITLE
configure: add support for aarch64

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -622,6 +622,16 @@ case $host in
      use_gl=no
      USE_STATIC_FFMPEG=1
      ;;
+  aarch64*-*-linux-gnu*|aarch64*-*-linux-uclibc*)
+     target_platform=target_linux
+     ARCH="aarch64"
+     use_arch="aarch64"
+     use_neon=yes
+     use_gles=yes
+     use_gl=no
+     use_wayland=no
+     USE_STATIC_FFMPEG=1
+     ;;
   arm*-*linux-android*)
      target_platform=target_android
      CORE_SYSTEM_NAME=android

--- a/m4/xbmc_arch.m4
+++ b/m4/xbmc_arch.m4
@@ -60,7 +60,7 @@ case $host in
   powerpc64*-*-linux-gnu*|powerpc64*-*-linux-uclibc*)
      AC_SUBST(ARCH_DEFINES, "-DTARGET_POSIX -DTARGET_LINUX -D_LINUX -D_POWERPC64")
      ;;
-  arm*-*-linux-gnu*|arm*-*-linux-uclibc*)
+  arm*-*-linux-gnu*|arm*-*-linux-uclibc*|aarch64*-*-linux-gnu*|aarch64*-*-linux-uclibc*)
      AC_SUBST(ARCH_DEFINES, "-DTARGET_POSIX -DTARGET_LINUX -D_LINUX")
      ;;
   mips*-*-linux-gnu*|mips*-*-linux-uclibc*)


### PR DESCRIPTION
Downloaded from:
https://github.com/OpenELEC/OpenELEC.tv/blob/master/packages/mediacenter/kodi/patches/kodi-999.10-aarch64-support.patch

and added uClibc support.
