### PR TITLE
[droid] clean binary addons to prevent them from repackaging even if …

### DIFF
--- a/tools/buildsteps/android/prepare-depends
+++ b/tools/buildsteps/android/prepare-depends
@@ -4,7 +4,7 @@ XBMC_PLATFORM_DIR=android
 
 #clean without depends for skipping depends build if possible
 #also skip binary addons (pvr, audioencoder) as long as they are deployed in tree
-cd $WORKSPACE;git clean -xfd -e "project/cmake/.last_success_revision" -e "tools/depends" ${DEPLOYED_BINARY_ADDONS}
+cd $WORKSPACE;git clean -xfd -e "project/cmake/.last_success_revision" -e "tools/depends"
 
 # if depends path has changed - cleanout everything and do a full rebuild
 if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]

--- a/tools/buildsteps/androidx86/prepare-depends
+++ b/tools/buildsteps/androidx86/prepare-depends
@@ -4,7 +4,7 @@ XBMC_PLATFORM_DIR=android
 
 #clean without depends for skipping depends build if possible
 #also skip binary addons (pvr, audioencoder) as long as they are deployed in tree
-cd $WORKSPACE;git clean -xfd -e "project/cmake/.last_success_revision" -e "tools/depends" ${DEPLOYED_BINARY_ADDONS}
+cd $WORKSPACE;git clean -xfd -e "project/cmake/.last_success_revision" -e "tools/depends"
 
 # if depends path has changed - cleanout everything and do a full rebuild
 if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]


### PR DESCRIPTION
…they should not be build

While testing the inpustream addons i found out that when you disable certain add-ons in binary repo they are still packaged in the final APK although they are not build. So they are likely floating around and then moved to final packaging again.

thx to @Memphiz for the pointer. I gave it a quick test and it indeed seems to solve the problem.

@wsnipex @Montellese for comments if this is correct. Not sure if the comment line also has to be removed.
