### PR TITLE
allow addons to retrieve to current mouse position

### DIFF
--- a/xbmc/interfaces/legacy/ModuleXbmcgui.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmcgui.cpp
@@ -22,6 +22,7 @@
 #include "LanguageHook.h"
 #include "guilib/GraphicContext.h"
 #include "guilib/GUIWindowManager.h"
+#include "utils/MathUtils.h"
 
 #define NOTIFICATION_INFO     "info"
 #define NOTIFICATION_WARNING  "warning"
@@ -43,6 +44,30 @@ namespace XBMCAddon
       DelayedCallGuard dg;
       CSingleLock gl(g_graphicsContext);
       return g_windowManager.GetTopMostModalDialogID();
+    }
+
+    std::vector<int> getMousePosition()
+    {
+      std::vector<int> pos(2);
+
+      DelayedCallGuard dg;
+      CSingleLock gl(g_graphicsContext);
+      CGUIWindow *window = g_windowManager.GetWindow(g_windowManager.GetFocusedWindow());
+      CGUIWindow *pointer = g_windowManager.GetWindow(WINDOW_DIALOG_POINTER);
+      CPoint point;
+      if (pointer)
+        point = CPoint(pointer->GetXPosition(), pointer->GetYPosition());
+      if (window)
+      {
+        // transform the mouse coordinates to this window's coordinates
+        g_graphicsContext.SetScalingResolution(window->GetCoordsRes(), true);
+        point.x *= g_graphicsContext.GetGUIScaleX();
+        point.y *= g_graphicsContext.GetGUIScaleY();
+        g_graphicsContext.SetRenderingResolution(g_graphicsContext.GetResInfo(), false);
+      }
+      pos[0] = MathUtils::round_int(point.x);
+      pos[1] = MathUtils::round_int(point.y);
+      return pos;
     }
 
     const char* getNOTIFICATION_INFO()    { return NOTIFICATION_INFO; }

--- a/xbmc/interfaces/legacy/ModuleXbmcgui.h
+++ b/xbmc/interfaces/legacy/ModuleXbmcgui.h
@@ -19,6 +19,7 @@
  */
 
 #include "swighelper.h"
+#include <vector>
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 namespace XBMCAddon
@@ -84,6 +85,30 @@ namespace XBMCAddon
     long getCurrentWindowDialogId();
 #endif
     ///@}
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+    ///
+    /// \ingroup python_xbmcgui
+    /// @brief \python_func{ xbmcgui.getMousePosition() }
+    ///-------------------------------------------------------------------------
+    /// Returns the current mouse position as a x,y integer tuple.
+    ///
+    /// @return                        The current mouse position
+    ///
+    ///
+    ///--------------------------------------------------------------------------
+    ///
+    /// **Example:**
+    /// ~~~~~~~~~~~~~{.py}
+    /// ..
+    /// pos = xbmcgui.getMousePosition()
+    /// ..
+    /// ~~~~~~~~~~~~~
+    ///
+getMousePosition()
+#else
+    std::vector<int> getMousePosition();
+#endif
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
     SWIG_CONSTANT2(int,ICON_OVERLAY_NONE, CGUIListItem::ICON_OVERLAY_NONE);


### PR DESCRIPTION
usecase: i'm working on an addon where i want to add/position controls to a window by simply clicking in the window (instead of manually adding the coordinates through a keyboard).

@tamland for the python bits
