### PR TITLE
[aml] add gui setting to enable/disable mpeg2 hw decoding

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -6741,7 +6741,18 @@ msgctxt "#13452"
 msgid "Enable this option to use hardware acceleration for VC-1 based codecs. If disabled the CPU will be used instead. Especially VC-1 interlaced fails hard on Intel hardware."
 msgstr ""
 
-#empty strings from id 13453 to 13456
+#: system/settings/settings.xml
+msgctxt "#13453"
+msgid "Use amcodec for SD content"
+msgstr ""
+
+#. Description of setting with label #13453 "Use amcodec for SD content"
+#: system/settings/settings.xml
+msgctxt "#13454"
+msgid "Enable this option to use hardware acceleration for MPEG-(1 / 2) SD content. If disabled the CPU will be used instead."
+msgstr ""
+
+#empty strings from id 13455 to 13456
 
 #. Option for video related setting #13454: sw filter
 #: system/settings/settings.xml

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -6743,16 +6743,25 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#13453"
-msgid "Use amcodec for SD content"
+msgid "Use amcodec for MPEG-2 SD content"
 msgstr ""
 
-#. Description of setting with label #13453 "Use amcodec for SD content"
+#. Description of setting with label #13453 "Use amcodec for MPEG-2 SD content"
 #: system/settings/settings.xml
 msgctxt "#13454"
 msgid "Enable this option to use hardware acceleration for MPEG-(1 / 2) SD content. If disabled the CPU will be used instead."
 msgstr ""
 
-#empty strings from id 13455 to 13456
+#: system/settings/settings.xml
+msgctxt "#13455"
+msgid "Use amcodec for MPEG-4 SD content"
+msgstr ""
+
+#. Description of setting with label #13455 "Use amcodec for MPEG-4 SD content"
+#: system/settings/settings.xml
+msgctxt "#13456"
+msgid "Enable this option to use hardware acceleration for MPEG-4 SD content. If disabled the CPU will be used instead."
+msgstr ""
 
 #. Option for video related setting #13454: sw filter
 #: system/settings/settings.xml

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -133,6 +133,20 @@
           </dependencies>
           <control type="toggle" />
         </setting>
+        <setting id="videoplayer.useamcodecmpeg4" type="boolean" label="13455" help="13456">
+          <requirement>HAVE_AMCODEC</requirement>
+          <level>2</level>
+          <default>false</default>
+          <updates>
+            <update type="change" />
+          </updates>
+          <dependencies>
+            <dependency type="enable">
+              <condition setting="videoplayer.useamcodec" operator="is">true</condition> <!-- USE AMCODEC -->
+            </dependency>
+          </dependencies>
+          <control type="toggle" />
+        </setting>
         <setting id="videoplayer.usemediacodecsurface" type="boolean" label="13440" help="36544">
           <requirement>HAS_MEDIACODEC</requirement>
           <level>2</level>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -119,6 +119,20 @@
           </updates>
           <control type="toggle" />
         </setting>
+        <setting id="videoplayer.useamcodecmpeg2" type="boolean" label="13453" help="13454">
+          <requirement>HAVE_AMCODEC</requirement>
+          <level>2</level>
+          <default>true</default>
+          <updates>
+            <update type="change" />
+          </updates>
+          <dependencies>
+            <dependency type="enable">
+              <condition setting="videoplayer.useamcodec" operator="is">true</condition> <!-- USE AMCODEC -->
+            </dependency>
+          </dependencies>
+          <control type="toggle" />
+        </setting>
         <setting id="videoplayer.usemediacodecsurface" type="boolean" label="13440" help="36544">
           <requirement>HAS_MEDIACODEC</requirement>
           <level>2</level>

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
@@ -84,6 +84,11 @@ bool CDVDVideoCodecAmlogic::Open(CDVDStreamInfo &hints, CDVDCodecOptions &option
     case AV_CODEC_ID_MPEG1VIDEO:
     case AV_CODEC_ID_MPEG2VIDEO:
     case AV_CODEC_ID_MPEG2VIDEO_XVMC:
+      if (!CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_USEAMCODEC_MPEG2))
+      {
+        if (hints.width <= 800)
+          return false;
+      }
       m_mpeg2_sequence_pts = 0;
       m_mpeg2_sequence = new mpeg2_sequence;
       m_mpeg2_sequence->width  = m_hints.width;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
@@ -127,8 +127,11 @@ bool CDVDVideoCodecAmlogic::Open(CDVDStreamInfo &hints, CDVDCodecOptions &option
     case AV_CODEC_ID_MPEG4:
     case AV_CODEC_ID_MSMPEG4V2:
     case AV_CODEC_ID_MSMPEG4V3:
-      if (hints.width <= 800)
-        return false;
+      if (!CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_USEAMCODEC_MPEG4))
+      {
+        if (hints.width <= 800)
+          return false;
+      }
       m_pFormatName = "am-mpeg4";
       break;
     case AV_CODEC_ID_H263:

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -159,6 +159,7 @@ const std::string CSettings::SETTING_VIDEOPLAYER_QUITSTEREOMODEONSTOP = "videopl
 const std::string CSettings::SETTING_VIDEOPLAYER_RENDERMETHOD = "videoplayer.rendermethod";
 const std::string CSettings::SETTING_VIDEOPLAYER_HQSCALERS = "videoplayer.hqscalers";
 const std::string CSettings::SETTING_VIDEOPLAYER_USEAMCODEC = "videoplayer.useamcodec";
+const std::string CSettings::SETTING_VIDEOPLAYER_USEAMCODEC_MPEG2 = "videoplayer.useamcodecmpeg2";
 const std::string CSettings::SETTING_VIDEOPLAYER_USEMEDIACODEC = "videoplayer.usemediacodec";
 const std::string CSettings::SETTING_VIDEOPLAYER_USEMEDIACODECSURFACE = "videoplayer.usemediacodecsurface";
 const std::string CSettings::SETTING_VIDEOPLAYER_USEVDPAU = "videoplayer.usevdpau";
@@ -1077,6 +1078,7 @@ void CSettings::InitializeISettingCallbacks()
   settingSet.insert(CSettings::SETTING_VIDEOSCREEN_GUICALIBRATION);
   settingSet.insert(CSettings::SETTING_VIDEOSCREEN_TESTPATTERN);
   settingSet.insert(CSettings::SETTING_VIDEOPLAYER_USEAMCODEC);
+  settingSet.insert(CSettings::SETTING_VIDEOPLAYER_USEAMCODEC_MPEG2);
   settingSet.insert(CSettings::SETTING_VIDEOPLAYER_USEMEDIACODEC);
   settingSet.insert(CSettings::SETTING_VIDEOPLAYER_USEMEDIACODECSURFACE);
   settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_VOLUMESTEPS);

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -160,6 +160,7 @@ const std::string CSettings::SETTING_VIDEOPLAYER_RENDERMETHOD = "videoplayer.ren
 const std::string CSettings::SETTING_VIDEOPLAYER_HQSCALERS = "videoplayer.hqscalers";
 const std::string CSettings::SETTING_VIDEOPLAYER_USEAMCODEC = "videoplayer.useamcodec";
 const std::string CSettings::SETTING_VIDEOPLAYER_USEAMCODEC_MPEG2 = "videoplayer.useamcodecmpeg2";
+const std::string CSettings::SETTING_VIDEOPLAYER_USEAMCODEC_MPEG4 = "videoplayer.useamcodecmpeg4";
 const std::string CSettings::SETTING_VIDEOPLAYER_USEMEDIACODEC = "videoplayer.usemediacodec";
 const std::string CSettings::SETTING_VIDEOPLAYER_USEMEDIACODECSURFACE = "videoplayer.usemediacodecsurface";
 const std::string CSettings::SETTING_VIDEOPLAYER_USEVDPAU = "videoplayer.usevdpau";
@@ -1079,6 +1080,7 @@ void CSettings::InitializeISettingCallbacks()
   settingSet.insert(CSettings::SETTING_VIDEOSCREEN_TESTPATTERN);
   settingSet.insert(CSettings::SETTING_VIDEOPLAYER_USEAMCODEC);
   settingSet.insert(CSettings::SETTING_VIDEOPLAYER_USEAMCODEC_MPEG2);
+  settingSet.insert(CSettings::SETTING_VIDEOPLAYER_USEAMCODEC_MPEG4);
   settingSet.insert(CSettings::SETTING_VIDEOPLAYER_USEMEDIACODEC);
   settingSet.insert(CSettings::SETTING_VIDEOPLAYER_USEMEDIACODECSURFACE);
   settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_VOLUMESTEPS);

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -116,6 +116,7 @@ public:
   static const std::string SETTING_VIDEOPLAYER_RENDERMETHOD;
   static const std::string SETTING_VIDEOPLAYER_HQSCALERS;
   static const std::string SETTING_VIDEOPLAYER_USEAMCODEC;
+  static const std::string SETTING_VIDEOPLAYER_USEAMCODEC_MPEG2;
   static const std::string SETTING_VIDEOPLAYER_USEMEDIACODEC;
   static const std::string SETTING_VIDEOPLAYER_USEMEDIACODECSURFACE;
   static const std::string SETTING_VIDEOPLAYER_USEVDPAU;

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -117,6 +117,7 @@ public:
   static const std::string SETTING_VIDEOPLAYER_HQSCALERS;
   static const std::string SETTING_VIDEOPLAYER_USEAMCODEC;
   static const std::string SETTING_VIDEOPLAYER_USEAMCODEC_MPEG2;
+  static const std::string SETTING_VIDEOPLAYER_USEAMCODEC_MPEG4;
   static const std::string SETTING_VIDEOPLAYER_USEMEDIACODEC;
   static const std::string SETTING_VIDEOPLAYER_USEMEDIACODECSURFACE;
   static const std::string SETTING_VIDEOPLAYER_USEVDPAU;


### PR DESCRIPTION
amlogic's mpeg2 decoder does not always work good for all videos, let's expose a gui option to enable/disable it to the user

on faster platforms (m8/gxbb) users may want this option disabled, while on m6 decoding in software may be slow. distros are free to ship their defaults via appliance.xml

fyi @codesnake @koying 
