### PR TITLE
fix Compile Kodi for Windows

### DIFF
--- a/tools/buildsteps/win32/make-mingwlibs.sh
+++ b/tools/buildsteps/win32/make-mingwlibs.sh
@@ -84,8 +84,8 @@ setfilepath /xbmc/system/players/VideoPlayer
 checkfiles avcodec-57.dll avformat-57.dll avutil-55.dll postproc-54.dll swscale-4.dll avfilter-6.dll swresample-2.dll
 echo "-------------------------------------------------"
 echo " building of FFmpeg $BITS done..."
-echo "-------------------------------------------------"
 
+echo "-------------------------------------------------"
 echo -ne "\033]0;building libdvd $BITS\007"
 echo "-------------------------------------------------"
 echo " building libdvd $BITS"

--- a/tools/depends/target/ffmpeg/FFMPEG-VERSION
+++ b/tools/depends/target/ffmpeg/FFMPEG-VERSION
@@ -3,3 +3,5 @@ BASE_URL=https://github.com/xbmc/FFmpeg/archive
 VERSION=release/3.0-xbmc
 ARCHIVE=$(LIBNAME)-$(VERSION).tar.gz
 GNUTLS_VER=3.4.9
+REMOTE=https://github.com/xbmc/FFmpeg/archive/release/3.0-xbmc.tar.gz
+LOCAL=ffmpeg-release-3.0-xbmc.tar.gz

--- a/tools/depends/target/libdvdcss/DVDCSS-VERSION
+++ b/tools/depends/target/libdvdcss/DVDCSS-VERSION
@@ -1,4 +1,6 @@
 LIBNAME=libdvdcss
-BASE_URL=https://github.com/xbmc/libdvdcss
+BASE_URL=https://github.com/xbmc/libdvdcss/archive
 VERSION=master
-
+ARCHIVE=$(LIBNAME)-$(VERSION).zip
+REMOTE=https://github.com/xbmc/libdvdcss/archive/master.zip
+LOCAL=libdvdcss-master.zip

--- a/tools/depends/target/libdvdnav/DVDNAV-VERSION
+++ b/tools/depends/target/libdvdnav/DVDNAV-VERSION
@@ -1,4 +1,6 @@
 LIBNAME=libdvdnav
 BASE_URL=https://github.com/xbmc/libdvdnav
 VERSION=master
-
+ARCHIVE=$(LIBNAME)-$(VERSION).zip
+REMOTE=https://github.com/xbmc/libdvdnav/archive/master.zip
+LOCAL=libdvdnav-master.zip

--- a/tools/depends/target/libdvdread/DVDREAD-VERSION
+++ b/tools/depends/target/libdvdread/DVDREAD-VERSION
@@ -1,4 +1,6 @@
 LIBNAME=libdvdread
 BASE_URL=https://github.com/xbmc/libdvdread
 VERSION=master
-
+ARCHIVE=$(LIBNAME)-$(VERSION).zip
+REMOTE=https://github.com/xbmc/libdvdread/archive/master.zip
+LOCAL=libdvdread-master.zip


### PR DESCRIPTION
buildhelpers.sh expected archive to be always .tar.gz, but for some projects github does not provide .tar.gz, but does provide .zip. This remains undetected until somebody does a fresh checkout following the instructions on http://kodi.wiki/view/HOW-TO:Compile_Kodi_for_Windows
