### PR TITLE
fix frameMoveGuard intruduced here by 82218b570c8d5e7d2ace70cbe71f24e…

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -307,8 +307,6 @@ CApplication::CApplication(void)
 
   m_muted = false;
   m_volumeLevel = VOLUME_MAXIMUM;
-
-  m_frameMoveGuard.lock();
 }
 
 CApplication::~CApplication(void)
@@ -693,6 +691,8 @@ bool CApplication::Create()
 
 bool CApplication::CreateGUI()
 {
+  m_frameMoveGuard.lock();
+
   m_renderGUI = true;
 #ifdef HAS_SDL
   CLog::Log(LOGNOTICE, "Setup SDL");


### PR DESCRIPTION
…101e72163

@mapfau grabbing the lock in the constructor is wrong, we want to lock the render thread.

@MartijnKaijser I am almost sure this fixes the issue on Android
