### PR TITLE
Use separators from language addon

### DIFF
--- a/addons/resource.language.en_gb/addon.xml
+++ b/addons/resource.language.en_gb/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.en_gb"
-  version="2.0.0"
+  version="2.0.1"
   name="English"
   provider-name="Team Kodi">
   <requires>

--- a/addons/resource.language.en_gb/resources/langinfo.xml
+++ b/addons/resource.language.en_gb/resources/langinfo.xml
@@ -54,6 +54,8 @@
       <time symbolAM="AM" symbolPM="PM">h:mm:ss xx</time>
       <tempunit>F</tempunit>
       <speedunit>mph</speedunit>
+      <thousandsseparator groupingformat="\3">,</thousandsseparator>
+      <decimalseparator>.</decimalseparator>
     </region>
 
     <region name="USA (24h)" locale="US">
@@ -62,6 +64,8 @@
       <time symbolAM="" symbolPM="">H:mm:ss</time>
       <tempunit>F</tempunit>
       <speedunit>mph</speedunit>
+      <thousandsseparator groupingformat="\3">,</thousandsseparator>
+      <decimalseparator>.</decimalseparator>
     </region>
 
     <region name="UK (12h)" locale="GB">
@@ -71,6 +75,8 @@
       <tempunit>C</tempunit>
       <speedunit>mph</speedunit>
       <timezone>GMT</timezone>
+      <thousandsseparator groupingformat="\3">,</thousandsseparator>
+      <decimalseparator>.</decimalseparator>
     </region>
 
     <region name="UK (24h)" locale="GB">
@@ -80,6 +86,8 @@
       <tempunit>C</tempunit>
       <speedunit>mph</speedunit>
       <timezone>GMT</timezone>
+      <thousandsseparator groupingformat="\3">,</thousandsseparator>
+      <decimalseparator>.</decimalseparator>
     </region>
 
     <region name="Canada" locale="CA">
@@ -88,6 +96,8 @@
       <time symbolAM="AM" symbolPM="PM">h:mm:ss xx</time>
       <tempunit>C</tempunit>
       <speedunit>kmh</speedunit>
+      <thousandsseparator groupingformat="\3">,</thousandsseparator>
+      <decimalseparator>.</decimalseparator>
     </region>
 
     <region name="Australia (12h)" locale="AU">
@@ -97,6 +107,8 @@
       <tempunit>C</tempunit>
       <speedunit>kmh</speedunit>
       <timezone>GMT</timezone>
+      <thousandsseparator groupingformat="\3">,</thousandsseparator>
+      <decimalseparator>.</decimalseparator>
     </region>
 
     <region name="Australia (24h)" locale="AU">
@@ -106,6 +118,8 @@
       <tempunit>C</tempunit>
       <speedunit>kmh</speedunit>
       <timezone>GMT</timezone>
+      <thousandsseparator groupingformat="\3">,</thousandsseparator>
+      <decimalseparator>.</decimalseparator>
     </region>
     
     <region name="Central Europe" locale="DE">
@@ -115,6 +129,8 @@
       <tempunit>C</tempunit>
       <speedunit>kmh</speedunit>
       <timezone>CET</timezone>
+      <thousandsseparator groupingformat="\3">,</thousandsseparator>
+      <decimalseparator>.</decimalseparator>
     </region>
 
     <region name="India (12h)" locale="IN">
@@ -124,6 +140,8 @@
       <tempunit>C</tempunit>
       <speedunit>kmh</speedunit>
       <timezone>GMT</timezone>
+      <thousandsseparator groupingformat="\3\2">,</thousandsseparator>
+      <decimalseparator>.</decimalseparator>
     </region>
 
     <region name="India (24h)" locale="IN">
@@ -133,6 +151,8 @@
       <tempunit>C</tempunit>
       <speedunit>kmh</speedunit>
       <timezone>IST</timezone>
+      <thousandsseparator groupingformat="\3\2">,</thousandsseparator>
+      <decimalseparator>.</decimalseparator>
     </region>
   </regions>
 </language>

--- a/xbmc/LangInfo.h
+++ b/xbmc/LangInfo.h
@@ -217,6 +217,21 @@ protected:
     void SetSpeedUnit(const std::string& strUnit);
     void SetTimeZone(const std::string& strTimeZone);
 
+    class custom_numpunct : public std::numpunct<char>
+    {
+    public:
+      custom_numpunct(const char decimal_point, const char thousands_sep, const std::string grouping)
+        : cDecimalPoint(decimal_point), cThousandsSep(thousands_sep), sGroup(grouping) {}
+    protected:
+      virtual char do_decimal_point() const { return cDecimalPoint; }
+      virtual char do_thousands_sep() const { return cThousandsSep; }
+      virtual std::string do_grouping() const { return sGroup; }
+    private:
+      const char cDecimalPoint;
+      const char cThousandsSep;
+      const std::string sGroup;
+    };
+
     /*! \brief Set the locale associated with this region global.
 
     Set the locale associated with this region global. This affects string
@@ -232,6 +247,9 @@ protected:
     std::string m_strTimeFormat;
     std::string m_strMeridiemSymbols[2];
     std::string m_strTimeZone;
+    std::string m_strGrouping;
+    char m_cDecimalSep;
+    char m_cThousandsSep;
 
     CTemperature::Unit m_tempUnit;
     CSpeed::Unit m_speedUnit;

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -1032,6 +1032,29 @@ std::string StringUtils::SizeToString(int64_t size)
   return strLabel;
 }
 
+std::string StringUtils::BinaryStringToString(const std::string& in)
+{
+  std::string out;
+  out.reserve(in.size() / 2);
+  for (const char *cur = in.c_str(), *end = cur + in.size(); cur != end; ++cur) {
+    if (*cur == '\\') {
+      ++cur;                                                                             
+      if (cur == end) {
+        break;
+      }
+      if (isdigit(*cur)) {                                                             
+        char* end;
+        unsigned long num = strtol(cur, &end, 10);
+        cur = end - 1;
+        out.push_back(num);
+        continue;
+      }
+    }
+    out.push_back(*cur);
+  }
+  return out;
+}
+
 // return -1 if not, else return the utf8 char length.
 int IsUTF8Letter(const unsigned char *str)
 {

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -192,6 +192,15 @@ public:
   static int FindBestMatch(const std::string &str, const std::vector<std::string> &strings, double &matchscore);
   static bool ContainsKeyword(const std::string &str, const std::vector<std::string> &keywords);
 
+  /*! \brief Convert the string of binary chars to the actual string.
+
+  Convert the string representation of binary chars to the actual string.
+  For example \1\2\3 is converted to a string with binary char \1, \2 and \3
+
+  \param param String to convert
+  \return Converted string
+  */
+  static std::string BinaryStringToString(const std::string& in);
   /*! \brief Format the string with locale separators.
 
   Format the string with locale separators.
@@ -204,7 +213,11 @@ public:
   static std::string FormatNumber(T num)
   {
     std::stringstream ss;
+// ifdef is needed because when you set _ITERATOR_DEBUG_LEVEL=0 and you use custom numpunct you will get runtime error in debug mode
+// for more info https://connect.microsoft.com/VisualStudio/feedback/details/2655363
+#if !(defined(_DEBUG) && defined(TARGET_WINDOWS))
     ss.imbue(g_langInfo.GetOriginalLocale());
+#endif
     ss.precision(1);
     ss << std::fixed << num;
     return ss.str();


### PR DESCRIPTION
Since some system doesn't have a locale I changed the number formatting to use an option in the language addon.
If there's not that option in the language addon it will fall back to en-us (like 100,000.45)
@stefansaraev @MilhouseVH This should make it work also for Open/LibreElec

I'm not sure if we want an option to let the user choose like for dates (and what other options there are, I know only 1,000.4 and 1.000,4)
