### PR TITLE
[exif] Fix for out-of-memory errors with large numbers of jpegs

### DIFF
--- a/lib/libexif/libexif.h
+++ b/lib/libexif/libexif.h
@@ -81,7 +81,7 @@ typedef struct {
 #define EXIF_COMMENT_CHARSET_UNICODE    3 // Exif: Unicode (UTF-16)
 #define EXIF_COMMENT_CHARSET_JIS        4 // Exif: JIS X208-1990
 
-#define MAX_COMMENT 65533 // 2 bytes - 2 for the length param
+#define MAX_COMMENT 2000
 #define MAX_DATE_COPIES 10
 
 typedef struct {


### PR DESCRIPTION
This reverts part of https://github.com/xbmc/xbmc/pull/7472

Basically the commit made the 4 comments in the exif block increase
from 2K to 64K each, so you now need 256K per photo.

When opening a folder exif information for all photos is extracted.
So, for a folder of 5000 jpegs, 1.2GB of RAM is needed just for
the comments.

As a 64K comment string is of no use to kodi, just truncate them to 2K
like we used to.

See:
http://trac.kodi.tv/ticket/16193
http://forum.kodi.tv/showthread.php?tid=251908
