### PR TITLE
[PeripheralCecAdapter] fix playback stopping on screensaver deactivated

### DIFF
--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -1185,7 +1185,8 @@ void CPeripheralCecAdapter::CecSourceActivated(void *cbParam, const CEC::cec_log
         // pause/resume player
         CApplicationMessenger::GetInstance().SendMsg(TMSG_MEDIA_PAUSE);
     }
-    else if (adapter->GetSettingInt("pause_or_stop_playback_on_deactivate") == LOCALISED_ID_STOP)
+    else if (bPlayingAndDeactivated
+      && adapter->GetSettingInt("pause_or_stop_playback_on_deactivate") == LOCALISED_ID_STOP)
     {
       if (pSlideShow)
         pSlideShow->OnAction(CAction(ACTION_STOP));


### PR DESCRIPTION
(cherry picked from commit 295504a80423d8291ee0a661707cdc2503c28951)

situation: playback is paused, screensaver kicks in, CEC is set to STOP playback on CEC going not-active device, ... then later when screensaver deactivates, (paused) playback is wrongly stopped.
