### PR TITLE
[python] fix seq fault if optional list is leaved empty

### DIFF
--- a/xbmc/interfaces/python/typemaps/python.vector.intm
+++ b/xbmc/interfaces/python/typemaps/python.vector.intm
@@ -24,6 +24,8 @@
     String accessor = ispointer ? '->' : '.'
     int seq = sequence.increment()
 %>
+    // check ${slarg} to confirm available data present if a optional list is not used.
+    if (${slarg} != nullptr)
     {
       bool isTuple = PyObject_TypeCheck(${slarg},&PyTuple_Type);
       if (!isTuple && !PyObject_TypeCheck(${slarg},&PyList_Type))


### PR DESCRIPTION
This is a fix related to request #9666.

If the optional list entry (vector) was leaved empty was a `nullptr` given to `AddonModuleXbmcgui.cpp` who has created the crash.

This fix add a check of the value to confirm it is present.
