### PR TITLE
[cmake/addons] Make relative ADDON_SRC_PREFIX relative to the build dir

### DIFF
--- a/project/cmake/addons/CMakeLists.txt
+++ b/project/cmake/addons/CMakeLists.txt
@@ -138,7 +138,9 @@ endif()
 get_filename_component(ADDONS_DEFINITION_DIR "${ADDONS_DEFINITION_DIR}" ABSOLUTE)
 
 if(ADDON_SRC_PREFIX)
-  get_filename_component(ADDON_SRC_PREFIX "${ADDON_SRC_PREFIX}" ABSOLUTE)
+  if(NOT IS_ABSOLUTE ${ADDON_SRC_PREFIX})
+    get_filename_component(ADDON_SRC_PREFIX "${CMAKE_BINARY_DIR}/${ADDON_SRC_PREFIX}" ABSOLUTE)
+  endif()
   message(STATUS "Overriding addon source directory prefix: ${ADDON_SRC_PREFIX}")
 endif()
 


### PR DESCRIPTION
This is a counter proposal for https://github.com/xbmc/xbmc/pull/9501 as the discussion stalled.
As discussed in that PR, instead of forcing the user to provide an absolute directory, we make ADDON_SRC_PREFIX relative to the root build directory, aka the directory from where you issue the cmake command. This is both consistent with CMake and with any other shell commands where path parameters are usually taken relative to the current working directory.

I'm not aware of further issues this might cause. But if there are, please let me know and let's fix the root causes. The addon system is already difficult enough for developers. They shouldn't have to deal with restrictions, that we can fix in the system. 

pings: @notspiff, @wsnipex, @FernetMenta, @AchimTuran, @Montellese, @hudokkow 
