### PR TITLE
[cmake/win32] Fix syncing cpluff.dll to build tree

### DIFF
--- a/project/cmake/modules/FindCpluff.cmake
+++ b/project/cmake/modules/FindCpluff.cmake
@@ -38,6 +38,8 @@ else()
                       BUILD_COMMAND msbuild ${CORE_SOURCE_DIR}/project/VS2010Express/XBMC\ for\ Windows.sln
                                             /t:cpluff /p:Configuration=${CORE_BUILD_CONFIG}
                       INSTALL_COMMAND "")
+  copy_file_to_buildtree(${CORE_SOURCE_DIR}/system/cpluff.dll ${CORE_SOURCE_DIR})
+  add_dependencies(export-files libcpluff)
 endif()
 
 set(CPLUFF_INCLUDE_DIRS ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/cpluff/include)


### PR DESCRIPTION
A clean build with CMake will cause an error when trying to run Kodi,
because cpluff.dll is not found in the synced tree. Reason is that the
list of files that are synced (from installdata directory) is done at
configure time but cpluff.dll is only compiled at build time.

These lines would be obsolete if we could properly compile cpluff in the
build tree.

for @AchimTuran 
