### PR TITLE
[cmake] Small binary-addon build system improvements

### DIFF
--- a/project/cmake/addons/CMakeLists.txt
+++ b/project/cmake/addons/CMakeLists.txt
@@ -224,6 +224,10 @@ if(NOT addons)
   endif()
 endif()
 
+# Track if at least one addon has been found. Everything else is likely an
+# error either in ADDONS_TO_BUILD or in the directory configuration.
+set(SUPPORTED_ADDON_FOUND FALSE)
+
 foreach(addon ${addons})
   if(NOT (addon MATCHES platforms.txt))
     file(STRINGS ${addon} def)
@@ -243,6 +247,7 @@ foreach(addon ${addons})
 
     if(ADDON_FOUND)
       message(STATUS "\n-- ---- Configuring addon ${addon} ----")
+      set(SUPPORTED_ADDON_FOUND TRUE)
 
       get_filename_component(dir ${addon} PATH)
 
@@ -418,6 +423,12 @@ if(NEED_SUDO)
                     COMMAND sudo ${CMAKE_COMMAND} -E copy_directory ${ADDON_INSTALL_DIR}/ ${CMAKE_INSTALL_PREFIX}/
                     COMMAND sudo ${CMAKE_COMMAND} -E remove_directory ${ADDON_INSTALL_DIR}/
                     COMMAND sudo -k)
+endif()
+
+if(NOT SUPPORTED_ADDON_FOUND)
+  message(FATAL_ERROR "${ADDONS_TO_BUILD} did not match any of the supported addons. \
+                       A list of supported addons can be viewed by building the 'supported_addons' target. \
+                       Addon definitions are loaded from ADDONS_DEFINITION_DIR (${ADDONS_DEFINITION_DIR}).")
 endif()
 
 # add custom target "supported_addons" that returns all addons that are supported on this platform

--- a/project/cmake/addons/CMakeLists.txt
+++ b/project/cmake/addons/CMakeLists.txt
@@ -184,6 +184,7 @@ list(APPEND CMAKE_MODULE_PATH ${APP_LIB_DIR})
 include(prepare-env)
 
 ### add the depends subdirectory for any general dependencies
+message(STATUS "\n-- ---- Preparing general dependencies ----")
 add_subdirectory(depends)
 
 # add a custom target "package-addons" which will package and install all addons
@@ -241,6 +242,8 @@ foreach(addon ${addons})
     endif()
 
     if(ADDON_FOUND)
+      message(STATUS "\n-- ---- Configuring addon ${addon} ----")
+
       get_filename_component(dir ${addon} PATH)
 
       # check if the addon has a platforms.txt
@@ -406,6 +409,7 @@ foreach(addon ${addons})
     endif()
   endif()
 endforeach()
+message(STATUS "")
 
 if(NEED_SUDO)
   add_custom_target(install


### PR DESCRIPTION
Let's try to make the addon build system a bit more user friendly.

For the moment, issue an error when the addon config file couldn't be found. I think it would be also convenient that if `ADDON_SRC_PREFIX` contains the source directory of the addon specified in `ADDONS_TO_BUILD`, then just use it even without config. That makes the bootstrap process for addon devs a bit easier.

ping: @notspiff, @wsnipex, @hudokkow, @AchimTuran 
