### PR TITLE
AddonsDirectory.cpp: Fix root folder name

### DIFF
--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -431,7 +431,7 @@ static bool Repos(const CURL& path, CFileItemList &items)
 
 static void RootDirectory(CFileItemList& items)
 {
-  items.SetLabel(g_localizeStrings.Get(24033));
+  items.SetLabel(g_localizeStrings.Get(10040));
   {
     CFileItemPtr item(new CFileItem("addons://user/", true));
     item->SetLabel(g_localizeStrings.Get(24998));


### PR DESCRIPTION
Root folder name must be "Addon Browser" and not "Install from repository".

See : http://forum.kodi.tv/showthread.php?tid=274235
