### PR TITLE
[cmake] Force Python version to 2.7

### DIFF
--- a/project/cmake/modules/FindPython.cmake
+++ b/project/cmake/modules/FindPython.cmake
@@ -27,7 +27,7 @@ if(NOT PYTHON_FOUND)
     set(PYTHON_LIBRARIES ${PYTHON_LIBRARY} ${FFI_LIBRARY} ${EXPAT_LIBRARY} ${INTL_LIBRARY} ${PYTHON_DEP_LIBRARIES}
         CACHE INTERNAL "python libraries" FORCE)
   else()
-    find_package(PythonLibs)
+    find_package(PythonLibs 2.7 REQUIRED)
   endif()
 endif()
 


### PR DESCRIPTION
When I try to build Kodi with CMake on Arch Linux, CMake finds version 3.5 of Python and tries to use it. The build then fails with this error:

`/home/mark/Coding/Repos/kodi-git/src/xbmc/xbmc/interfaces/python/LanguageHook.cpp: In member function 'virtual XBMCAddon::String XBMCAddon::Python::PythonLanguageHook::GetAddonId()':
/home/mark/Coding/Repos/kodi-git/src/xbmc/xbmc/interfaces/python/LanguageHook.cpp:140:38: error: 'PyString_AsString' was not declared in this scope
         return PyString_AsString(pyid);
                                      ^
/home/mark/Coding/Repos/kodi-git/src/xbmc/xbmc/interfaces/python/LanguageHook.cpp: In member function 'virtual XBMCAddon::String XBMCAddon::Python::PythonLanguageHook::GetAddonVersion()':
/home/mark/Coding/Repos/kodi-git/src/xbmc/xbmc/interfaces/python/LanguageHook.cpp:155:43: error: 'PyString_AsString' was not declared in this scope
         return PyString_AsString(pyversion);
                                           ^
build/interfaces/python/CMakeFiles/python_interface.dir/build.make:134: recipe for target 'build/interfaces/python/CMakeFiles/python_interface.dir/LanguageHook.cpp.o' failed
make[2]: *** [build/interfaces/python/CMakeFiles/python_interface.dir/LanguageHook.cpp.o] Error 1
CMakeFiles/Makefile2:3066: recipe for target 'build/interfaces/python/CMakeFiles/python_interface.dir/all' failed`

If I force the Python version to 2.7 in FindPython.cmake, everything builds fine.
