### PR TITLE
fix 'unknown sources' setting visibility when opened from dialog

### DIFF
--- a/xbmc/addons/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/GUIWindowAddonBrowser.cpp
@@ -174,7 +174,8 @@ bool CGUIWindowAddonBrowser::OnClick(int iItem, const std::string &player)
     if (!CSettings::GetInstance().GetBool(CSettings::SETTING_ADDONS_ALLOW_UNKNOWN_SOURCES))
     {
       if (ShowYesNoDialogText(13106, 36617, 186, 10004) == DialogResponse::YES)
-        g_windowManager.ActivateWindow(WINDOW_SETTINGS_SYSTEM, "addons");
+        g_windowManager.ActivateWindow(WINDOW_SETTINGS_SYSTEM,
+            {"addons", CSettings::SETTING_ADDONS_ALLOW_UNKNOWN_SOURCES});
     }
     else
     {

--- a/xbmc/settings/windows/GUIWindowSettingsCategory.h
+++ b/xbmc/settings/windows/GUIWindowSettingsCategory.h
@@ -39,9 +39,6 @@ public:
   virtual bool IsDialog() const { return false; }
 
 protected:
-  // specialization of CGUIWindow
-  virtual void OnWindowLoaded();
-
   // implementation of CGUIDialogSettingsBase
   virtual int GetSettingLevel() const;
   virtual CSettingSection* GetSection();


### PR DESCRIPTION
This make sure the setting is actually visible and focues when going from the warning dialog.
