### PR TITLE
Fix joysticks on android

### DIFF
--- a/xbmc/peripherals/bus/PeripheralBus.cpp
+++ b/xbmc/peripherals/bus/PeripheralBus.cpp
@@ -249,6 +249,11 @@ void CPeripheralBus::Initialise(void)
     Create();
     SetPriority(-1);
   }
+  else
+  {
+    lock.Leave();
+    ScanForDevices();
+  }
 }
 
 void CPeripheralBus::Register(CPeripheral *peripheral)


### PR DESCRIPTION
The android peripheral bus doesn't rely on polling, so no thread is created. The thread scans for joysticks on creation, but if no thread is created, no initial scan is done.

This change runs an initial scan in the main thread when Kodi initializes the android bus. This should allow joysticks to work on startup.

-- untested --
