### PR TITLE
Player fixes

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3238,20 +3238,12 @@ PlayBackRet CApplication::PlayFile(CFileItem item, const std::string& player, bo
     options.startpercent = item.GetProperty("StartPercent").asDouble(fallback);
   }
 
-  std::string newPlayer;
   if (bRestart)
   {
     // have to be set here due to playstack using this for starting the file
     options.starttime = item.m_lStartOffset / 75.0;
     if (m_itemCurrentFile->IsStack() && m_currentStack->Size() > 0 && m_itemCurrentFile->m_lStartOffset != 0)
       m_itemCurrentFile->m_lStartOffset = STARTOFFSET_RESUME; // to force fullscreen switching
-
-    if (!player.empty() && player != "default")
-      newPlayer = player;
-    else if (m_pPlayer->GetCurrentPlayer().empty())
-      newPlayer = CPlayerCoreFactory::GetInstance().GetDefaultPlayer(item);
-    else
-      newPlayer = m_pPlayer->GetCurrentPlayer();
   }
   else
   {
@@ -3315,11 +3307,6 @@ PlayBackRet CApplication::PlayFile(CFileItem item, const std::string& player, bo
 
       dbs.Close();
     }
-
-    if (player.empty())
-      newPlayer = CPlayerCoreFactory::GetInstance().GetDefaultPlayer(item);
-    else
-      newPlayer = player;
   }
 
   // this really aught to be inside !bRestart, but since PlayStack
@@ -3370,6 +3357,14 @@ PlayBackRet CApplication::PlayFile(CFileItem item, const std::string& player, bo
     if (dMsgCount > 0)
       CLog::LogF(LOGDEBUG,"Ignored %d playback thread messages", dMsgCount);
   }
+
+  std::string newPlayer;
+  if (!player.empty())
+    newPlayer = player;
+  else if (bRestart && !m_pPlayer->GetCurrentPlayer().empty())
+    newPlayer = m_pPlayer->GetCurrentPlayer();
+  else
+    newPlayer = CPlayerCoreFactory::GetInstance().GetDefaultPlayer(item);
 
   // We should restart the player, unless the previous and next tracks are using
   // one of the players that allows gapless playback (paplayer, VideoPlayer)

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -6478,16 +6478,16 @@ bool CGUIInfoManager::GetInt(int &value, int info, int contextWindow, const CGUI
             {
               const CEpgInfoTagPtr tag(GetEpgInfoTag());
               if (tag)
-                value = static_cast<int>(tag->ProgressPercentage());
+                value = MathUtils::round_int(tag->ProgressPercentage());
               else
-                value = static_cast<int>(g_application.GetPercentage());
+                value = MathUtils::round_int(g_application.GetPercentage());
               break;
             }
           case PLAYER_PROGRESS_CACHE:
-            value = (int)(g_application.GetCachePercentage());
+            value = MathUtils::round_int(g_application.GetCachePercentage());
             break;
           case PLAYER_SEEKBAR:
-            value = (int)GetSeekPercent();
+            value = MathUtils::round_int(GetSeekPercent());
             break;
           case PLAYER_CACHELEVEL:
             value = (int)(g_application.m_pPlayer->GetCacheLevel());
@@ -7978,7 +7978,7 @@ std::string CGUIInfoManager::GetDuration(TIME_FORMAT format) const
   }
   if (g_application.m_pPlayer->IsPlayingVideo() && !m_currentMovieDuration.empty())
     return m_currentMovieDuration;
-  unsigned int iTotal = (unsigned int)g_application.GetTotalTime();
+  unsigned int iTotal = MathUtils::round_int(g_application.GetTotalTime());
   if (iTotal > 0)
     return StringUtils::SecondsToTimeString(iTotal, format);
   return "";
@@ -8761,7 +8761,7 @@ std::string CGUIInfoManager::GetCurrentPlayTime(TIME_FORMAT format) const
   if (format == TIME_FORMAT_GUESS && GetTotalPlayTime() >= 3600)
     format = TIME_FORMAT_HH_MM_SS;
   if (g_application.m_pPlayer->IsPlaying())
-    return StringUtils::SecondsToTimeString((int)(GetPlayTime()/1000), format);
+    return StringUtils::SecondsToTimeString(MathUtils::round_int(GetPlayTime()/1000.0), format);
   return "";
 }
 
@@ -8774,13 +8774,13 @@ std::string CGUIInfoManager::GetCurrentSeekTime(TIME_FORMAT format) const
 
 int CGUIInfoManager::GetTotalPlayTime() const
 {
-  int iTotalTime = (int)g_application.GetTotalTime();
+  int iTotalTime = MathUtils::round_int(g_application.GetTotalTime());
   return iTotalTime > 0 ? iTotalTime : 0;
 }
 
 int CGUIInfoManager::GetPlayTimeRemaining() const
 {
-  int iReverse = GetTotalPlayTime() - (int)g_application.GetTime();
+  int iReverse = GetTotalPlayTime() - MathUtils::round_int(g_application.GetTime());
   return iReverse > 0 ? iReverse : 0;
 }
 

--- a/xbmc/addons/AudioDecoder.cpp
+++ b/xbmc/addons/AudioDecoder.cpp
@@ -46,19 +46,19 @@ CAudioDecoder::CAudioDecoder(AddonProps props, std::string extension, std::strin
   m_strExt = std::move(strExt);
 }
 
-bool CAudioDecoder::Init(const std::string& strFile, unsigned int filecache)
+bool CAudioDecoder::Init(const CFileItem& file, unsigned int filecache)
 {
   if (!Initialized())
     return false;
 
   // for replaygain
   CTagLoaderTagLib tag;
-  tag.Load(strFile, XFILE::CMusicFileDirectory::m_tag, NULL);
+  tag.Load(file.GetPath(), XFILE::CMusicFileDirectory::m_tag, NULL);
 
   int channels;
   int sampleRate;
 
-  m_context = m_pStruct->Init(strFile.c_str(), filecache,
+  m_context = m_pStruct->Init(file.GetPath().c_str(), filecache,
                               &channels, &sampleRate,
                               &m_bitsPerSample, &m_TotalTime,
                               &m_bitRate, &m_format.m_dataFormat, &m_channel);

--- a/xbmc/addons/AudioDecoder.h
+++ b/xbmc/addons/AudioDecoder.h
@@ -59,7 +59,7 @@ namespace ADDON
     virtual ~CAudioDecoder() {}
 
     // Things that MUST be supplied by the child classes
-    bool Init(const std::string& strFile, unsigned int filecache);
+    bool Init(const CFileItem& file, unsigned int filecache) override;
     int ReadPCM(uint8_t* buffer, int size, int* actualsize);
     bool Seek(int64_t time);
     bool CanInit() { return true; }

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
@@ -230,12 +230,12 @@ unsigned int CActiveAEStream::GetSpace()
     return m_streamFreeBuffers * m_streamSpace;
 }
 
-unsigned int CActiveAEStream::AddData(uint8_t* const *data, unsigned int offset, unsigned int frames, double pts)
+unsigned int CActiveAEStream::AddData(const uint8_t* const *data, unsigned int offset, unsigned int frames, double pts)
 {
   Message *msg;
   unsigned int copied = 0;
   int sourceFrames = frames;
-  uint8_t* const *buf = data;
+  const uint8_t* const *buf = data;
 
   m_streamIsFlushed = false;
 

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.h
@@ -107,7 +107,7 @@ protected:
 
 public:
   virtual unsigned int GetSpace();
-  virtual unsigned int AddData(uint8_t* const *data, unsigned int offset, unsigned int frames, double pts = 0.0);
+  virtual unsigned int AddData(const uint8_t* const *data, unsigned int offset, unsigned int frames, double pts = 0.0);
   virtual double GetDelay();
   virtual CAESyncInfo GetSyncInfo();
   virtual bool IsBuffering();

--- a/xbmc/cores/AudioEngine/Interfaces/AEStream.h
+++ b/xbmc/cores/AudioEngine/Interfaces/AEStream.h
@@ -81,7 +81,7 @@ public:
    * @param pts timestamp
    * @return The number of frames consumed
    */
-  virtual unsigned int AddData(uint8_t* const *data, unsigned int offset, unsigned int frames, double pts = 0.0) = 0;
+  virtual unsigned int AddData(const uint8_t* const *data, unsigned int offset, unsigned int frames, double pts = 0.0) = 0;
 
   /**
    * Returns the time in seconds that it will take

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -302,7 +302,6 @@ public:
   virtual int  SeekChapter(int iChapter)                       { return -1; }
 //  virtual bool GetChapterInfo(int chapter, SChapterInfo &info) { return false; }
 
-  virtual float GetActualFPS() { return 0.0f; };
   virtual void SeekTime(int64_t iTime = 0){};
   /*
    \brief seek relative to current time, returns false if not implemented by player

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -152,11 +152,15 @@ void CVideoPlayerVideo::OpenStream(CDVDStreamInfo &hint, CDVDVideoCodec* codec)
 
   //reported fps is usually not completely correct
   if (hint.fpsrate && hint.fpsscale)
+  {
     m_fFrameRate = DVD_TIME_BASE / CDVDCodecUtils::NormalizeFrameduration((double)DVD_TIME_BASE * hint.fpsscale / hint.fpsrate);
+    m_bFpsInvalid = false;
+  }
   else
+  {
     m_fFrameRate = 25;
-
-  m_bFpsInvalid = (hint.fpsrate == 0 || hint.fpsscale == 0);
+    m_bFpsInvalid = true;
+  }
 
   m_pullupCorrection.ResetVFRDetection();
   m_bCalcFrameRate = CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_USEDISPLAYASCLOCK) ||

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderFormats.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderFormats.h
@@ -20,6 +20,7 @@
  *
  */
 
+#include <cstddef>
 #include <vector>
 
 enum ERenderFormat {

--- a/xbmc/cores/paplayer/AudioDecoder.cpp
+++ b/xbmc/cores/paplayer/AudioDecoder.cpp
@@ -83,9 +83,9 @@ bool CAudioDecoder::Create(const CFileItem &file, int64_t seekOffset)
     filecache = CSettings::GetInstance().GetInt(CSettings::SETTING_CACHEAUDIO_LAN);
 
   // create our codec
-  m_codec=CodecFactory::CreateCodecDemux(file.GetPath(), file.GetMimeType(), filecache * 1024);
+  m_codec=CodecFactory::CreateCodecDemux(file, filecache * 1024);
 
-  if (!m_codec || !m_codec->Init(file.GetPath(), filecache * 1024))
+  if (!m_codec || !m_codec->Init(file, filecache * 1024))
   {
     CLog::Log(LOGERROR, "CAudioDecoder: Unable to Init Codec while loading file %s", file.GetPath().c_str());
     Destroy();

--- a/xbmc/cores/paplayer/CodecFactory.cpp
+++ b/xbmc/cores/paplayer/CodecFactory.cpp
@@ -52,10 +52,10 @@ ICodec* CodecFactory::CreateCodec(const std::string &strFileType)
   return dvdcodec;
 }
 
-ICodec* CodecFactory::CreateCodecDemux(const std::string& strFile, const std::string& strContent, unsigned int filecache)
+ICodec* CodecFactory::CreateCodecDemux(const CFileItem& file, unsigned int filecache)
 {
-  CURL urlFile(strFile);
-  std::string content = strContent;
+  CURL urlFile(file.GetPath());
+  std::string content = file.GetMimeType();
   StringUtils::ToLower(content);
   if (!content.empty())
   {
@@ -107,7 +107,7 @@ ICodec* CodecFactory::CreateCodecDemux(const std::string& strFile, const std::st
   {
     VideoPlayerCodec *dvdcodec = new VideoPlayerCodec();
     dvdcodec->SetContentType("audio/x-spdif-compressed");
-    if (dvdcodec->Init(strFile, filecache))
+    if (dvdcodec->Init(file, filecache))
     {
       return dvdcodec;
     }

--- a/xbmc/cores/paplayer/CodecFactory.h
+++ b/xbmc/cores/paplayer/CodecFactory.h
@@ -22,12 +22,14 @@
 
 #include "ICodec.h"
 
+class CFileItem;
+
 class CodecFactory
 {
 public:
   CodecFactory() {}
   virtual ~CodecFactory() {}
   static ICodec* CreateCodec(const std::string &type);
-  static ICodec* CreateCodecDemux(const std::string& strFile, const std::string& strContent,unsigned int filecache);
+  static ICodec* CreateCodecDemux(const CFileItem& file, unsigned int filecache);
 };
 

--- a/xbmc/cores/paplayer/ICodec.h
+++ b/xbmc/cores/paplayer/ICodec.h
@@ -31,6 +31,8 @@
 #define READ_SUCCESS   0
 #define READ_ERROR     1
 
+class CFileItem;
+
 class ICodec
 {
 public:
@@ -53,7 +55,7 @@ public:
   // 2.  If it's using a filereader, initialize it with the appropriate cache size.
   // 3.  Load the file (or at least attempt to load it)
   // 4.  Fill in the m_TotalTime, m_SampleRate, m_BitsPerSample and m_Channels parameters.
-  virtual bool Init(const std::string &strFile, unsigned int filecache)=0;
+  virtual bool Init(const CFileItem &file, unsigned int filecache)=0;
 
   // DeInit()
   // Should just cleanup anything as necessary.  No need to free buffers here if they

--- a/xbmc/cores/paplayer/VideoPlayerCodec.cpp
+++ b/xbmc/cores/paplayer/VideoPlayerCodec.cpp
@@ -69,8 +69,10 @@ void VideoPlayerCodec::SetContentType(const std::string &strContent)
   StringUtils::ToLower(m_strContentType);
 }
 
-bool VideoPlayerCodec::Init(const std::string &strFile, unsigned int filecache)
+bool VideoPlayerCodec::Init(const CFileItem &file, unsigned int filecache)
 {
+  const std::string &strFile = file.GetPath();
+
   // take precaution if Init()ialized earlier
   if (m_bInited)
   {
@@ -90,7 +92,7 @@ bool VideoPlayerCodec::Init(const std::string &strFile, unsigned int filecache)
   if (urlFile.IsProtocol("shout") )
     strFileToOpen.replace(0, 8, "http://");
 
-  CFileItem fileitem(urlFile, false);
+  CFileItem fileitem(file);
   fileitem.SetMimeType(m_strContentType);
   fileitem.SetMimeTypeForInternetFile();
   m_pInputStream = CDVDFactoryInputStream::CreateInputStream(NULL, fileitem);

--- a/xbmc/cores/paplayer/VideoPlayerCodec.h
+++ b/xbmc/cores/paplayer/VideoPlayerCodec.h
@@ -38,7 +38,7 @@ public:
   VideoPlayerCodec();
   virtual ~VideoPlayerCodec();
 
-  virtual bool Init(const std::string &strFile, unsigned int filecache);
+  virtual bool Init(const CFileItem &file, unsigned int filecache) override;
   virtual void DeInit();
   virtual bool Seek(int64_t iSeekTime);
   virtual int ReadPCM(BYTE *pBuffer, int size, int *actualsize);

--- a/xbmc/utils/SeekHandler.cpp
+++ b/xbmc/utils/SeekHandler.cpp
@@ -20,6 +20,7 @@
 
 #include "SeekHandler.h"
 
+#include <cmath>
 #include <stdlib.h>
 
 #include "Application.h"
@@ -30,6 +31,7 @@
 #include "settings/lib/Setting.h"
 #include "settings/Settings.h"
 #include "utils/log.h"
+#include "utils/MathUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
 
@@ -78,7 +80,7 @@ void CSeekHandler::Configure()
     std::vector<CVariant> seekSteps = CSettings::GetInstance().GetList(it->second);
     for (std::vector<CVariant>::iterator it = seekSteps.begin(); it != seekSteps.end(); ++it)
     {
-      int stepSeconds = (*it).asInteger();
+      int stepSeconds = static_cast<int>((*it).asInteger());
       if (stepSeconds < 0)
         backwardSeekSteps.insert(backwardSeekSteps.begin(), stepSeconds);
       else
@@ -156,7 +158,7 @@ void CSeekHandler::Seek(bool forward, float amount, float duration /* = 0 */, bo
     if (totalTime < 0)
       totalTime = 0;
 
-    int seekSize = (amount * amount * speed) * totalTime / 100;
+    double seekSize = (amount * amount * speed) * totalTime / 100;
     if (forward)
       m_seekSize += seekSize;
     else
@@ -197,7 +199,7 @@ void CSeekHandler::SeekSeconds(int seconds)
 
 int CSeekHandler::GetSeekSize() const
 {
-  return m_seekSize;
+  return MathUtils::round_int(m_seekSize);
 }
 
 bool CSeekHandler::InProgress() const

--- a/xbmc/utils/SeekHandler.h
+++ b/xbmc/utils/SeekHandler.h
@@ -68,7 +68,7 @@ private:
   std::map<SeekType, int > m_seekDelays;
   bool m_requireSeek;
   bool m_analogSeek;
-  int m_seekSize;
+  double m_seekSize;
   int m_seekStep;
   std::map<SeekType, std::vector<int> > m_forwardSeekSteps;
   std::map<SeekType, std::vector<int> > m_backwardSeekSteps;


### PR DESCRIPTION
Here's a collection of random improvements to the video and audio players I've done over the past month.

The `GUIInfoManager` and `SeekHandler` commits deal with casting time amounts into ints. The commits replace an int with a double and use proper rounding for casts of time amounts.
