### PR TITLE
FFmpeg: Make usable from add-ons

### DIFF
--- a/tools/depends/target/ffmpeg/CMakeLists.txt
+++ b/tools/depends/target/ffmpeg/CMakeLists.txt
@@ -16,7 +16,7 @@ if(CROSSCOMPILING)
 endif()
 
 if(CORE_SYSTEM_NAME STREQUAL linux)
-  list(APPEND ffmpeg_conf --enable-vdpau --enable-vaapi)
+  list(APPEND ffmpeg_conf --enable-vdpau --enable-vaapi --enable-pic)
 elseif(CORE_SYSTEM_NAME STREQUAL android)
   if(CPU MATCHES arm)
     list(APPEND ffmpeg_conf --cpu=cortex-a9)

--- a/tools/depends/target/ffmpeg/Makefile
+++ b/tools/depends/target/ffmpeg/Makefile
@@ -26,7 +26,7 @@ ifeq ($(CROSS_COMPILING), yes)
 endif
 ifeq ($(OS), linux)
   ffmpg_config += --target-os=$(OS) --cpu=$(CPU)
-  ffmpg_config += --enable-vdpau --enable-vaapi
+  ffmpg_config += --enable-vdpau --enable-vaapi --enable-pic
 endif
 ifeq ($(OS), android)
   ifeq ($(findstring arm, $(CPU)), arm)

--- a/tools/depends/target/ffmpeg/autobuild.sh
+++ b/tools/depends/target/ffmpeg/autobuild.sh
@@ -156,6 +156,7 @@ CFLAGS="$CFLAGS" CXXFLAGS="$CXXFLAGS" LDFLAGS="$LDFLAGS" \
 	--enable-encoder=mjpeg \
 	--enable-nonfree \
 	--enable-pthreads \
+	--enable-pic \
 	--enable-zlib \
 	--disable-mipsdsp \
 	--disable-mipsdspr2 \


### PR DESCRIPTION
This contains two alternative ways to enable the use of internal ffmpeg in add-ons, ref https://github.com/notspiff/screensaver.electricsheep
- either by always enabling PIC so the .a files can be linked into the .so file
- or by making sure the entirety of ffmpeg is included in the kodi binary, accompanied by lazy linking in the add-on. as-is lazy linking cannot work since the lnker will prune unused symbols, and if the add-on use other functionality than kodi core, the code won't be around (happens with electric sheep).

choose your poison. note autotools is lacking, i didn't want to do that before the preferred solution is agreed on.
