### PR TITLE
[linux] redirect stderr when calling lsb_release fixes #16729

### DIFF
--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -218,6 +218,7 @@ static std::string getValueFromLsb_release(enum lsb_rel_info_type infoType)
   default:
     return "";
   }
+  command += " 2>/dev/null";
   FILE* lsb_rel = popen(command.c_str(), "r");
   if (lsb_rel == NULL)
     return "";


### PR DESCRIPTION
fixes "sh: lsb_release: command not found" errors
if the command does not exist
