### PR TITLE
[PVR] Fix 'Stop recording' from inside PVR channel window.

### DIFF
--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -666,6 +666,23 @@ bool CPVRTimers::IsRecordingOnChannel(const CPVRChannel &channel) const
   return false;
 }
 
+CPVRTimerInfoTagPtr CPVRTimers::GetActiveTimerForChannel(const CPVRChannelPtr &channel) const
+{
+  CSingleLock lock(m_critSection);
+  for (const auto &tagsEntry : m_tags)
+  {
+    for (const auto &timersEntry : *tagsEntry.second)
+    {
+      if (timersEntry->IsRecording() &&
+          timersEntry->m_iClientChannelUid == channel->UniqueID() &&
+          timersEntry->m_iClientId == channel->ClientID())
+        return timersEntry;
+    }
+  }
+
+  return CPVRTimerInfoTagPtr();
+}
+
 CPVRTimerInfoTagPtr CPVRTimers::GetTimerForEpgTag(const CEpgInfoTagPtr &epgTag) const
 {
   if (epgTag)

--- a/xbmc/pvr/timers/PVRTimers.h
+++ b/xbmc/pvr/timers/PVRTimers.h
@@ -107,6 +107,13 @@ namespace PVR
     bool IsRecordingOnChannel(const CPVRChannel &channel) const;
 
     /*!
+     * @brief Obtain the active timer for a given channel.
+     * @param channel The channel to check.
+     * @return the timer, null otherwise.
+     */
+    CPVRTimerInfoTagPtr GetActiveTimerForChannel(const CPVRChannelPtr &channel) const;
+
+    /*!
      * @return The amount of timers that are currently recording
      */
     int AmountActiveRecordings(void) const;

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -609,6 +609,14 @@ bool CGUIWindowPVRBase::DeleteTimer(CFileItem *item, bool bIsRecording, bool bDe
   {
     timer = item->GetEPGInfoTag()->Timer();
   }
+  else if (item->IsPVRChannel())
+  {
+    const CEpgInfoTagPtr epgTag(item->GetPVRChannelInfoTag()->GetEPGNow());
+    if (epgTag)
+      timer = epgTag->Timer();
+    else
+      timer = g_PVRTimers->GetActiveTimerForChannel(item->GetPVRChannelInfoTag());
+  }
 
   if (!timer)
   {


### PR DESCRIPTION
"Stop recording" from inside PVR channel window did not work at all, because this case was forgotten to handle in <code>CGUIWindowPVRBase::DeleteTimer</code>.

@Jalle19 @xhaggi mind taking a look. Almost a no brainer.
