### PR TITLE
Reinstate the correct behaviour for 'menu' (single press)

### DIFF
--- a/system/keymaps/remote.xml
+++ b/system/keymaps/remote.xml
@@ -57,7 +57,7 @@
       <pageplus>PageUp</pageplus>
       <pageminus>PageDown</pageminus>
       <back>Back</back>
-      <menu>ContextMenu</menu>
+      <menu>PreviousMenu</menu>
       <menu mod="longpress">Menu</menu>
       <contentsmenu>PreviousMenu</contentsmenu>
       <rootmenu>PreviousMenu</rootmenu>


### PR DESCRIPTION
This behaviour was broken in 779c7c4c and an attempt was made to fix it in b702e6b4. The fix didn't reinstate the original button function though, causing the menu button to change the behaviour it has had for the last decade. This change should reinstate the correct behaviour.
