### PR TITLE
Fix API pkgconfig install issue

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -594,6 +594,7 @@ endif
 	  install -d $(DESTDIR)$(includedir)/@APP_NAME_LC@/$$d; \
 	  (find xbmc/addons/kodi-addon-dev-kit/include/kodi/$$d -maxdepth 1 -not -type d -type f -exec install -m 0644 "{}" $(DESTDIR)$(includedir)/@APP_NAME_LC@/$$d \;) \
 	done
+	@install -d $(DESTDIR)$(libdir)/pkgconfig
 	@install -m 0644 xbmc/addons/kodi-addon-dev-kit/src/api2/kodi-addon-sharedlibrary/kodi-addon-sharedlibrary-api2-config.cmake $(DESTDIR)$(libdir)/@APP_NAME_LC@;
 	@install -m 0644 xbmc/addons/kodi-addon-dev-kit/src/api2/kodi-addon-sharedlibrary/kodi-addon-sharedlibrary-api2.pc $(DESTDIR)$(libdir)/pkgconfig;
 	@install -m 0644 xbmc/addons/kodi-addon-dev-kit/src/api3/kodi-addon-sharedlibrary/kodi-addon-sharedlibrary-api3-config.cmake $(DESTDIR)$(libdir)/@APP_NAME_LC@;


### PR DESCRIPTION
When $(DESTDIR)$(libdir)/pkgconfig did not exist, the install command
would just rename the files.
