### PR TITLE
[cmake][addon-devkit] cmake fixes to bring back the Windows build

### DIFF
--- a/project/cmake/addons/CMakeLists.txt
+++ b/project/cmake/addons/CMakeLists.txt
@@ -228,10 +228,22 @@ endif()
 # error either in ADDONS_TO_BUILD or in the directory configuration.
 set(SUPPORTED_ADDON_FOUND FALSE)
 
+message(STATUS "BUILD_ARGS=${BUILD_ARGS}")
+if(platformdefines)
+  set(KODI_ADDON_DEV_KIT_BUILD_ARGS ${BUILD_ARGS})
+  set(__C_FLAGS "${CMAKE_C_FLAGS} ${ARCH_DEFINES}")
+  set(__CXX_FLAGS "${CMAKE_CXX_FLAGS} ${ARCH_DEFINES}")
+  list(APPEND KODI_ADDON_DEV_KIT_BUILD_ARGS -DCMAKE_C_FLAGS=${__C_FLAGS}
+                                            -DCMAKE_CXX_FLAGS=${__CXX_FLAGS})
+else()
+  set(KODI_ADDON_DEV_KIT_BUILD_ARGS ${BUILD_ARGS})
+endif()
+
 ExternalProject_Add(kodi-addon-dev-kit
                     SOURCE_DIR ${CORE_SOURCE_DIR}/xbmc/addons/kodi-addon-dev-kit
                     INSTALL_DIR ${DEPENDS_PATH}
-                    CMAKE_ARGS ${BUILD_ARGS})
+                    CMAKE_ARGS ${KODI_ADDON_DEV_KIT_BUILD_ARGS})
+message(STATUS "KODI_ADDON_DEV_KIT_BUILD_ARGS=${KODI_ADDON_DEV_KIT_BUILD_ARGS}")
 
 foreach(addon ${addons})
   if(NOT (addon MATCHES platforms.txt))

--- a/xbmc/addons/kodi-addon-dev-kit/src/api2/kodi-addon-sharedlibrary/CMakeLists.txt
+++ b/xbmc/addons/kodi-addon-dev-kit/src/api2/kodi-addon-sharedlibrary/CMakeLists.txt
@@ -17,54 +17,92 @@ set(kodi-addon-sharedlibrary_VERSION ${ADDON_API_VERSION})
 add_definitions(-DUSE_DEMUX)
 add_definitions(-DADDON_API_LEVEL=${ADDON_API_LEVEL})
 
-list(APPEND LIB_SOURCES InterProcess.cpp
-                        AddonLib.cpp
-                        ErrorCodeNames.cpp
-                        addon/AddonLib_Addon_General.cpp
-                        addon/AddonLib_Addon_Network.cpp
-                        addon/AddonLib_Addon_SoundPlay.cpp
-                        addon/AddonLib_Addon_VFSUtils.cpp
-                        audioengine/AddonLib_AudioEngine_General.cpp
-                        audioengine/AddonLib_AudioEngine_Stream.cpp
-                        gui/AddonLib_GUI_General.cpp
-                        gui/AddonLib_GUI_ControlButton.cpp
-                        gui/AddonLib_GUI_ControlEdit.cpp
-                        gui/AddonLib_GUI_ControlFadeLabel.cpp
-                        gui/AddonLib_GUI_ControlImage.cpp
-                        gui/AddonLib_GUI_ControlLabel.cpp
-                        gui/AddonLib_GUI_ControlProgress.cpp
-                        gui/AddonLib_GUI_ControlRadioButton.cpp
-                        gui/AddonLib_GUI_ControlRendering.cpp
-                        gui/AddonLib_GUI_ControlSettingsSlider.cpp
-                        gui/AddonLib_GUI_ControlSlider.cpp
-                        gui/AddonLib_GUI_ControlSpin.cpp
-                        gui/AddonLib_GUI_ControlTextBox.cpp
-                        gui/AddonLib_GUI_DialogContextMenu.cpp
-                        gui/AddonLib_GUI_DialogExtendedProgress.cpp
-                        gui/AddonLib_GUI_DialogFileBrowser.cpp
-                        gui/AddonLib_GUI_DialogKeyboard.cpp
-                        gui/AddonLib_GUI_DialogNumeric.cpp
-                        gui/AddonLib_GUI_DialogOK.cpp
-                        gui/AddonLib_GUI_DialogProgress.cpp
-                        gui/AddonLib_GUI_DialogSelect.cpp
-                        gui/AddonLib_GUI_DialogTextViewer.cpp
-                        gui/AddonLib_GUI_DialogYesNo.cpp
-                        gui/AddonLib_GUI_ListItem.cpp
-                        gui/AddonLib_GUI_Window.cpp
-                        inputstream/AddonLib_InputStream.cpp
-                        peripheral/AddonLib_Peripheral.cpp
-                        player/AddonLib_Player_InfoTagMusic.cpp
-                        player/AddonLib_Player_InfoTagVideo.cpp
-                        player/AddonLib_Player_Player.cpp
-                        player/AddonLib_Player_PlayList.cpp
-                        pvr/AddonLib_PVR_General.cpp
-                        pvr/AddonLib_PVR_Stream.cpp
-                        pvr/AddonLib_PVR_Transfer.cpp
-                        pvr/AddonLib_PVR_Trigger.cpp)
+set(SOURCES InterProcess.cpp
+            AddonLib.cpp
+            ErrorCodeNames.cpp
+            addon/AddonLib_Addon_General.cpp
+            addon/AddonLib_Addon_Network.cpp
+            addon/AddonLib_Addon_SoundPlay.cpp
+            addon/AddonLib_Addon_VFSUtils.cpp
+            audioengine/AddonLib_AudioEngine_General.cpp
+            audioengine/AddonLib_AudioEngine_Stream.cpp
+            gui/AddonLib_GUI_General.cpp
+            gui/AddonLib_GUI_ControlButton.cpp
+            gui/AddonLib_GUI_ControlEdit.cpp
+            gui/AddonLib_GUI_ControlFadeLabel.cpp
+            gui/AddonLib_GUI_ControlImage.cpp
+            gui/AddonLib_GUI_ControlLabel.cpp
+            gui/AddonLib_GUI_ControlProgress.cpp
+            gui/AddonLib_GUI_ControlRadioButton.cpp
+            gui/AddonLib_GUI_ControlRendering.cpp
+            gui/AddonLib_GUI_ControlSettingsSlider.cpp
+            gui/AddonLib_GUI_ControlSlider.cpp
+            gui/AddonLib_GUI_ControlSpin.cpp
+            gui/AddonLib_GUI_ControlTextBox.cpp
+            gui/AddonLib_GUI_DialogContextMenu.cpp
+            gui/AddonLib_GUI_DialogExtendedProgress.cpp
+            gui/AddonLib_GUI_DialogFileBrowser.cpp
+            gui/AddonLib_GUI_DialogKeyboard.cpp
+            gui/AddonLib_GUI_DialogNumeric.cpp
+            gui/AddonLib_GUI_DialogOK.cpp
+            gui/AddonLib_GUI_DialogProgress.cpp
+            gui/AddonLib_GUI_DialogSelect.cpp
+            gui/AddonLib_GUI_DialogTextViewer.cpp
+            gui/AddonLib_GUI_DialogYesNo.cpp
+            gui/AddonLib_GUI_ListItem.cpp
+            gui/AddonLib_GUI_Window.cpp
+            inputstream/AddonLib_InputStream.cpp
+            peripheral/AddonLib_Peripheral.cpp
+            player/AddonLib_Player_InfoTagMusic.cpp
+            player/AddonLib_Player_InfoTagVideo.cpp
+            player/AddonLib_Player_Player.cpp
+            player/AddonLib_Player_PlayList.cpp
+            pvr/AddonLib_PVR_General.cpp
+            pvr/AddonLib_PVR_Stream.cpp
+            pvr/AddonLib_PVR_Transfer.cpp
+            pvr/AddonLib_PVR_Trigger.cpp)
+            
+set(HEADERS InterProcess.h
+            ErrorCodeNames.h
+            ../../../include/kodi/kodi_adsp_dll.h
+            ../../../include/kodi/kodi_adsp_types.h
+            ../../../include/kodi/kodi_audiodec_dll.h
+            ../../../include/kodi/kodi_audiodec_types.h
+            ../../../include/kodi/kodi_audioengine_types.h
+            ../../../include/kodi/kodi_inputstream_dll.h
+            ../../../include/kodi/kodi_inputstream_types.h
+            ../../../include/kodi/kodi_peripheral_callbacks.h
+            ../../../include/kodi/kodi_peripheral_dll.h
+            ../../../include/kodi/kodi_peripheral_types.h
+            ../../../include/kodi/kodi_peripheral_utils.hpp
+            ../../../include/kodi/kodi_vfs_types.h
+            ../../../include/kodi/kodi_vfs_utils.hpp
+            ../../../include/kodi/libKODI_adsp.h
+            ../../../include/kodi/libKODI_audioengine.h
+            ../../../include/kodi/libKODI_guilib.h
+            ../../../include/kodi/libKODI_inputstream.h
+            ../../../include/kodi/libKODI_peripheral.h
+            ../../../include/kodi/libXBMC_addon.h
+            ../../../include/kodi/libXBMC_codec.h
+            ../../../include/kodi/libXBMC_pvr.h
+            ../../../include/kodi/xbmc_addon_cpp_dll.h
+            ../../../include/kodi/xbmc_addon_dll.h
+            ../../../include/kodi/xbmc_addon_types.h
+            ../../../include/kodi/xbmc_audioenc_dll.h
+            ../../../include/kodi/xbmc_audioenc_types.h
+            ../../../include/kodi/xbmc_codec_types.h
+            ../../../include/kodi/xbmc_epg_types.h
+            ../../../include/kodi/xbmc_pvr_dll.h
+            ../../../include/kodi/xbmc_pvr_types.h
+            ../../../include/kodi/xbmc_scr_dll.h
+            ../../../include/kodi/xbmc_scr_types.h
+            ../../../include/kodi/xbmc_vis_dll.h
+            ../../../include/kodi/xbmc_vis_types.h)
 
 if(WIN32)
   list(APPEND DEPLIBS ws2_32)
-  list(APPEND LIB_SOURCES dlfcn-win32.cpp)
+  list(APPEND SOURCES dlfcn-win32.cpp)
+  list(APPEND HEADERS dlfcn-win32.h)
 else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -std=c++11")
 endif()
@@ -80,7 +118,7 @@ include_directories(${INCLUDES}
                     ../../../include/
                     .)
 
-add_library(kodi.addon.sharedlibrary.api${ADDON_API_LEVEL} STATIC ${LIB_SOURCES})
+add_library(kodi.addon.sharedlibrary.api${ADDON_API_LEVEL} STATIC ${SOURCES} ${HEADERS})
 target_link_libraries(kodi.addon.sharedlibrary.api${ADDON_API_LEVEL} ${DEPLIBS})
 set_target_properties(kodi.addon.sharedlibrary.api${ADDON_API_LEVEL} PROPERTIES OUTPUT_NAME kodi.addon.sharedlibrary.api${ADDON_API_LEVEL})
 


### PR DESCRIPTION
After https://github.com/xbmc/xbmc/pull/9659 went in my binary add-on Windows build was broken. These are the fixes to properly build my AudioDSP add-ons.

@AlwinEsch 
Furthermore it adds the header files to show them in VS.
