### PR TITLE
[PVR] Feature: Make instant recording behavior configurable

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -9298,7 +9298,13 @@ msgctxt "#19092"
 msgid "Record next show (%s)"
 msgstr ""
 
-#empty strings from id 19093 to 19096
+#. Instant recording summary. Expands to "Instant recording: <recording start and end times>", for example "Instant recording: 31/05/2016 from 9:00 to 11:00"
+#: xbmc/pvr/PVRTimerInfoTag.cpp
+msgctxt "#19093"
+msgid "Instant recording: %s"
+msgstr ""
+
+#empty strings from id 19094 to 19096
 
 msgctxt "#19097"
 msgid "Enter the name for the recording"

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -9255,7 +9255,50 @@ msgctxt "#19085"
 msgid "Unknown channel %u"
 msgstr ""
 
-#empty strings from id 19086 to 19096
+#. Label for "Instant recording action" setting
+#: system/settings/settings.xml
+#: xbmc/pvr/PVRMananger.cpp
+msgctxt "#19086"
+msgid "Instant recording action"
+msgstr ""
+
+#. Label for "Instant recording action" settings value
+#: system/settings/settings.xml
+msgctxt "#19087"
+msgid "Record current show (if guide data available)"
+msgstr ""
+
+#. Label for "Instant recording action" settings value
+#: system/settings/settings.xml
+msgctxt "#19088"
+msgid "Record for a fixed period of time (Instant recording duration)"
+msgstr ""
+
+#. Label for "Instant recording action" settings value
+#: system/settings/settings.xml
+msgctxt "#19089"
+msgid "Ask what to do"
+msgstr ""
+
+#. Label for "Instant recording action" dialog settings value
+#: xbmc/pvr/PVRMananger.cpp
+msgctxt "#19090"
+msgid "Record the next %d minutes"
+msgstr ""
+
+#. Label for "Instant recording action" dialog settings value
+#: xbmc/pvr/PVRMananger.cpp
+msgctxt "#19091"
+msgid "Record current show (%s)"
+msgstr ""
+
+#. Label for "Instant recording action" dialog settings value
+#: xbmc/pvr/PVRMananger.cpp
+msgctxt "#19092"
+msgid "Record next show (%s)"
+msgstr ""
+
+#empty strings from id 19093 to 19096
 
 msgctxt "#19097"
 msgid "Enter the name for the recording"
@@ -17033,7 +17076,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#36234"
-msgid "Duration of instant recordings when pressing the record button."
+msgid "Duration of instant recordings when pressing the record button. This value will be taken into account if \"Instant recording action\" is set to \"Record for a fixed period of time\""
 msgstr ""
 
 #: system/settings/settings.xml
@@ -17132,7 +17175,10 @@ msgctxt "#36253"
 msgid "Section that contains settings related to music files and how they are handled."
 msgstr ""
 
-#empty string with id 36254
+#: system/settings/settings.xml
+msgctxt "#36254"
+msgid "Action to perform when pressing the record button. [Record current show] will record the current show from \"now\" to the end of the show. If no TV guide data is currently available a fixed length recording starting \"now\", with the value set for \"Instant recording duration\" will be scheduled. [Record for a fixed period of time] will schedule a fixed length recording starting \"now\", with the value set for \"Instant recording duration\". [Ask what to do] will open a dialogue containing different recording actions to choose from, like \"Record current show\", \"Record next show\" and some fixed duration recordings."
+msgstr ""
 
 #. Description of setting with label #13414 "Include artists who appear only on compilations"
 #: system/settings/settings.xml

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1478,6 +1478,18 @@
     </category>
     <category id="pvrrecord" label="19043" help="36233">
       <group id="1" label="128">
+        <setting id="pvrrecord.instantrecordaction" type="integer" label="19086" help="36254">
+          <level>1</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="19087">0</option>   <!-- Record current show -->
+              <option label="19088">1</option>   <!-- Record for a fixed time period -->
+              <option label="19089">2</option>   <!-- Ask what to do -->
+            </options>
+          </constraints>
+          <control type="list" format="string" />
+        </setting>
         <setting id="pvrrecord.instantrecordtime" type="integer" label="19172" help="36234">
           <level>1</level>
           <default>120</default>

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamPVRManager.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamPVRManager.cpp
@@ -418,9 +418,9 @@ bool CDVDInputStreamPVRManager::IsRecording()
   return g_PVRClients->IsRecordingOnPlayingChannel();
 }
 
-bool CDVDInputStreamPVRManager::Record(bool bOnOff)
+void CDVDInputStreamPVRManager::Record(bool bOnOff)
 {
-  return g_PVRManager.StartRecordingOnPlayingChannel(bOnOff);
+  g_PVRManager.StartRecordingOnPlayingChannel(bOnOff);
 }
 
 bool CDVDInputStreamPVRManager::CanPause()

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamPVRManager.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamPVRManager.h
@@ -70,7 +70,7 @@ public:
 
   bool CanRecord();
   bool IsRecording();
-  bool Record(bool bOnOff);
+  void Record(bool bOnOff);
   bool CanSeek() override;
   bool CanPause() override;
   void Pause(bool bPaused);

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -785,7 +785,8 @@ bool CPVRManager::SetRecordingOnChannel(const CPVRChannelPtr &channel, bool bOnO
     /* timers are supported on this channel */
     if (bOnOff && !channel->IsRecording())
     {
-      const CPVRTimerInfoTagPtr newTimer(CPVRTimerInfoTag::CreateInstantTimerTag(channel));
+      const CEpgInfoTagPtr epgTag(channel->GetEPGNow());
+      const CPVRTimerInfoTagPtr newTimer(epgTag ? CPVRTimerInfoTag::CreateFromEpg(epgTag, false) : CPVRTimerInfoTag::CreateInstantTimerTag(channel));
 
       if (newTimer)
         bReturn = newTimer->AddToClient();

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -29,6 +29,7 @@
 #include "dialogs/GUIDialogNumeric.h"
 #include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogProgress.h"
+#include "dialogs/GUIDialogSelect.h"
 #include "epg/EpgContainer.h"
 #include "GUIInfoManager.h"
 #include "guilib/GUIWindowManager.h"
@@ -765,10 +766,120 @@ bool CPVRManager::ToggleRecordingOnChannel(unsigned int iChannelId)
   return SetRecordingOnChannel(channel, !channel->IsRecording());
 }
 
-bool CPVRManager::StartRecordingOnPlayingChannel(bool bOnOff)
+void CPVRManager::StartRecordingOnPlayingChannel(bool bOnOff)
 {
-  return SetRecordingOnChannel(m_addons->GetPlayingChannel(), bOnOff);
+  // can be called from VideoPlayer thread. SetRecordingOnChannel can open a dialog. Thus, execute async.
+  CJobManager::GetInstance().AddJob(new CPVRSetRecordingOnChannelJob(m_addons->GetPlayingChannel(), bOnOff), NULL);
 }
+
+namespace
+{
+enum PVRRECORD_INSTANTRECORDACTION
+{
+  NONE = -1,
+  RECORD_CURRENT_SHOW = 0,
+  RECORD_INSTANTRECORDTIME = 1,
+  ASK = 2,
+  RECORD_30_MINUTES = 3,
+  RECORD_60_MINUTES = 4,
+  RECORD_120_MINUTES = 5,
+  RECORD_NEXT_SHOW = 6
+};
+
+class InstantRecordingActionSelector
+{
+public:
+  InstantRecordingActionSelector();
+  virtual ~InstantRecordingActionSelector() {}
+
+  void AddAction(PVRRECORD_INSTANTRECORDACTION eAction, const std::string &title);
+  void PreSelectAction(PVRRECORD_INSTANTRECORDACTION eAction);
+  PVRRECORD_INSTANTRECORDACTION Select();
+
+private:
+  CGUIDialogSelect *m_pDlgSelect; // not owner!
+  std::map<PVRRECORD_INSTANTRECORDACTION, int> m_actions;
+};
+
+InstantRecordingActionSelector::InstantRecordingActionSelector()
+: m_pDlgSelect(dynamic_cast<CGUIDialogSelect *>(g_windowManager.GetWindow(WINDOW_DIALOG_SELECT)))
+{
+  if (m_pDlgSelect)
+  {
+    m_pDlgSelect->SetMultiSelection(false);
+    m_pDlgSelect->SetHeading(CVariant{19086}); // Instant recording action
+  }
+  else
+  {
+    CLog::Log(LOGERROR, "InstantRecordingActionSelector - %s - unable to obtain WINDOW_DIALOG_SELECT instance", __FUNCTION__);
+  }
+}
+
+void InstantRecordingActionSelector::AddAction(PVRRECORD_INSTANTRECORDACTION eAction, const std::string &title)
+{
+  if (m_actions.find(eAction) == m_actions.end())
+  {
+    switch (eAction)
+    {
+      case RECORD_INSTANTRECORDTIME:
+        m_pDlgSelect->Add(StringUtils::Format(g_localizeStrings.Get(19090).c_str(),
+                                              CSettings::GetInstance().GetInt(CSettings::SETTING_PVRRECORD_INSTANTRECORDTIME))); // Record next <default duration> minutes
+        break;
+      case RECORD_30_MINUTES:
+        m_pDlgSelect->Add(StringUtils::Format(g_localizeStrings.Get(19090).c_str(), 30));  // Record next 30 minutes
+        break;
+      case RECORD_60_MINUTES:
+        m_pDlgSelect->Add(StringUtils::Format(g_localizeStrings.Get(19090).c_str(), 60));  // Record next 60 minutes
+        break;
+      case RECORD_120_MINUTES:
+        m_pDlgSelect->Add(StringUtils::Format(g_localizeStrings.Get(19090).c_str(), 120)); // Record next 120 minutes
+        break;
+      case RECORD_CURRENT_SHOW:
+        m_pDlgSelect->Add(StringUtils::Format(g_localizeStrings.Get(19091).c_str(), title.c_str())); // Record current show (<title>)
+        break;
+      case RECORD_NEXT_SHOW:
+        m_pDlgSelect->Add(StringUtils::Format(g_localizeStrings.Get(19092).c_str(), title.c_str())); // Record next show (<title>)
+        break;
+      case NONE:
+      case ASK:
+      default:
+        return;
+    }
+
+    m_actions.insert(std::make_pair(eAction, m_actions.size()));
+  }
+}
+
+void InstantRecordingActionSelector::PreSelectAction(PVRRECORD_INSTANTRECORDACTION eAction)
+{
+  const auto &it = m_actions.find(eAction);
+  if (it != m_actions.end())
+    m_pDlgSelect->SetSelected(it->second);
+}
+
+PVRRECORD_INSTANTRECORDACTION InstantRecordingActionSelector::Select()
+{
+  PVRRECORD_INSTANTRECORDACTION eAction = NONE;
+
+  m_pDlgSelect->Open();
+
+  if (m_pDlgSelect->IsConfirmed())
+  {
+    int iSelection = m_pDlgSelect->GetSelectedItem();
+    for (const auto &action : m_actions)
+    {
+      if (action.second == iSelection)
+      {
+        eAction = action.first;
+        break;
+      }
+    }
+  }
+
+  return eAction;
+}
+
+} // unnamed namespace
 
 bool CPVRManager::SetRecordingOnChannel(const CPVRChannelPtr &channel, bool bOnOff)
 {
@@ -785,8 +896,104 @@ bool CPVRManager::SetRecordingOnChannel(const CPVRChannelPtr &channel, bool bOnO
     /* timers are supported on this channel */
     if (bOnOff && !channel->IsRecording())
     {
-      const CEpgInfoTagPtr epgTag(channel->GetEPGNow());
-      const CPVRTimerInfoTagPtr newTimer(epgTag ? CPVRTimerInfoTag::CreateFromEpg(epgTag, false) : CPVRTimerInfoTag::CreateInstantTimerTag(channel));
+      CEpgInfoTagPtr epgTag;
+      int iDuration = CSettings::GetInstance().GetInt(CSettings::SETTING_PVRRECORD_INSTANTRECORDTIME);
+
+      int iAction = CSettings::GetInstance().GetInt(CSettings::SETTING_PVRRECORD_INSTANTRECORDACTION);
+      switch (iAction)
+      {
+        case RECORD_CURRENT_SHOW:
+          epgTag = channel->GetEPGNow();
+          break;
+
+        case RECORD_INSTANTRECORDTIME:
+          epgTag.reset();
+          break;
+
+        case ASK:
+        {
+          PVRRECORD_INSTANTRECORDACTION ePreselect = RECORD_INSTANTRECORDTIME;
+          InstantRecordingActionSelector selector;
+          CEpgInfoTagPtr epgTagNext;
+
+          // fixed length recordings
+          selector.AddAction(RECORD_30_MINUTES, "");
+          selector.AddAction(RECORD_60_MINUTES, "");
+          selector.AddAction(RECORD_120_MINUTES, "");
+
+          const int iDurationDefault = CSettings::GetInstance().GetInt(CSettings::SETTING_PVRRECORD_INSTANTRECORDTIME);
+          if (iDurationDefault != 30 && iDurationDefault != 60 && iDurationDefault != 120)
+            selector.AddAction(RECORD_INSTANTRECORDTIME, "");
+
+          // epg-based recordings
+          epgTag = channel->GetEPGNow();
+          if (epgTag)
+          {
+            // "now"
+            selector.AddAction(RECORD_CURRENT_SHOW, epgTag->Title());
+            ePreselect = RECORD_CURRENT_SHOW;
+
+            // "next"
+            epgTagNext = channel->GetEPGNext();
+            if (epgTagNext)
+            {
+              selector.AddAction(RECORD_NEXT_SHOW, epgTagNext->Title());
+
+              // be smart. if current show is almost over, preselect next show.
+              if (epgTag->ProgressPercentage() > 90.0f)
+                ePreselect = RECORD_NEXT_SHOW;
+            }
+          }
+
+          selector.PreSelectAction(ePreselect);
+
+          PVRRECORD_INSTANTRECORDACTION eSelected = selector.Select();
+          switch (eSelected)
+          {
+            case NONE:
+              return false; // dialog canceled
+
+            case RECORD_30_MINUTES:
+              iDuration = 30;
+              epgTag.reset();
+              break;
+
+            case RECORD_60_MINUTES:
+              iDuration = 60;
+              epgTag.reset();
+              break;
+
+            case RECORD_120_MINUTES:
+              iDuration = 120;
+              epgTag.reset();
+              break;
+
+            case RECORD_INSTANTRECORDTIME:
+              iDuration = iDurationDefault;
+              epgTag.reset();
+              break;
+
+            case RECORD_CURRENT_SHOW:
+              break;
+
+            case RECORD_NEXT_SHOW:
+              epgTag = epgTagNext;
+              break;
+
+            default:
+              CLog::Log(LOGERROR, "PVRManager - %s - unknown instant record action selection (%d), defaulting to fixed length recording.", __FUNCTION__, eSelected);
+              epgTag.reset();
+              break;
+          }
+          break;
+        }
+
+        default:
+          CLog::Log(LOGERROR, "PVRManager - %s - unknown instant record action setting value (%d), defaulting to fixed length recording.", __FUNCTION__, iAction);
+          break;
+      }
+
+      const CPVRTimerInfoTagPtr newTimer(epgTag ? CPVRTimerInfoTag::CreateFromEpg(epgTag, false) : CPVRTimerInfoTag::CreateInstantTimerTag(channel, iDuration));
 
       if (newTimer)
         bReturn = newTimer->AddToClient();
@@ -1644,6 +1851,12 @@ bool CPVRSearchMissingChannelIconsJob::DoWork(void)
 bool CPVRClientConnectionJob::DoWork(void)
 {
   g_PVRClients->ConnectionStateChange(m_clientId, m_connectString, m_state, m_message);
+  return true;
+}
+
+bool CPVRSetRecordingOnChannelJob::DoWork(void)
+{
+  g_PVRManager.SetRecordingOnChannel(m_channel, m_bOnOff);
   return true;
 }
 

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -250,7 +250,6 @@ private:
       return GetState() == ManagerStateStarted;
     }
 
-
     /*!
      * @brief Check whether the PVRManager is stopping
      * @return True while the PVRManager is stopping.
@@ -342,9 +341,16 @@ private:
     /*!
      * @brief Start or stop recording on the channel that is currently being played.
      * @param bOnOff True to start recording, false to stop.
+     */
+    void StartRecordingOnPlayingChannel(bool bOnOff);
+
+    /*!
+     * @brief Start or stop recording on a given channel.
+     * @param channel the channel to start/stop recording.
+     * @param bOnOff True to start recording, false to stop.
      * @return True if the recording was started or stopped successfully, false otherwise.
      */
-    bool StartRecordingOnPlayingChannel(bool bOnOff);
+    bool SetRecordingOnChannel(const CPVRChannelPtr &channel, bool bOnOff);
 
     /*!
      * @brief Check whether there are active timers.
@@ -643,14 +649,6 @@ private:
      */
     void QueueJob(CJob *job);
 
-     /*!
-     * @brief Start or stop recording on a given channel.
-     * @param channel the channel to start/stop recording.
-     * @param bOnOff True to start recording, false to stop.
-     * @return True if the recording was started or stopped successfully, false otherwise.
-     */
-    bool SetRecordingOnChannel(const CPVRChannelPtr &channel, bool bOnOff);
-
     ManagerState GetState(void) const;
 
     void SetState(ManagerState state);
@@ -783,5 +781,19 @@ private:
     std::string m_connectString;
     PVR_CONNECTION_STATE m_state;
     std::string m_message;
+  };
+
+  class CPVRSetRecordingOnChannelJob : public CJob
+  {
+  public:
+    CPVRSetRecordingOnChannelJob(const CPVRChannelPtr &channel, bool bOnOff) :
+    m_channel(channel), m_bOnOff(bOnOff) {}
+    virtual ~CPVRSetRecordingOnChannelJob() {}
+    virtual const char *GetType() const { return "pvr-set-recording-on-channel"; }
+
+    bool DoWork();
+  private:
+    CPVRChannelPtr m_channel;
+    bool m_bOnOff;
   };
 }

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -643,6 +643,14 @@ private:
      */
     void QueueJob(CJob *job);
 
+     /*!
+     * @brief Start or stop recording on a given channel.
+     * @param channel the channel to start/stop recording.
+     * @param bOnOff True to start recording, false to stop.
+     * @return True if the recording was started or stopped successfully, false otherwise.
+     */
+    bool SetRecordingOnChannel(const CPVRChannelPtr &channel, bool bOnOff);
+
     ManagerState GetState(void) const;
 
     void SetState(ManagerState state);

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -749,6 +749,8 @@ bool CPVRTimerInfoTag::SetDuration(int iDuration)
   return false;
 }
 
+static const time_t INSTANT_TIMER_START = 0; // PVR addon API: special start time value to denote an instant timer
+
 CPVRTimerInfoTagPtr CPVRTimerInfoTag::CreateInstantTimerTag(const CPVRChannelPtr &channel, int iDuration /* = DEFAULT_PVRRECORD_INSTANTRECORDTIME */)
 {
   if (!channel)
@@ -787,19 +789,24 @@ CPVRTimerInfoTagPtr CPVRTimerInfoTag::CreateInstantTimerTag(const CPVRChannelPtr
     newTimer->SetTimerType(timerType);
   }
 
-  // no matter the timer was created from an epg tag, set special instant timer start and end times.
-  CDateTime startTime(0);
-  newTimer->SetStartFromUTC(startTime);
-  newTimer->m_iMarginStart = 0; /* set the start margin to 0 for instant timers */
+  /* no matter the timer was created from an epg tag, overwrite timer start and end times. */
+  CDateTime now(CDateTime::GetUTCDateTime());
+  newTimer->SetStartFromUTC(now);
 
   if (iDuration == DEFAULT_PVRRECORD_INSTANTRECORDTIME)
     iDuration = CSettings::GetInstance().GetInt(CSettings::SETTING_PVRRECORD_INSTANTRECORDTIME);
 
-  CDateTime endTime = CDateTime::GetUTCDateTime() + CDateTimeSpan(0, 0, iDuration ? iDuration : 120, 0);
+  CDateTime endTime = now + CDateTimeSpan(0, 0, iDuration ? iDuration : 120, 0);
   newTimer->SetEndFromUTC(endTime);
 
-  /* update summary string according to changed start/end time */
+  /* update summary string according to instant recording start/end time */
   newTimer->UpdateSummary();
+  newTimer->m_strSummary = StringUtils::Format(g_localizeStrings.Get(19093).c_str(), newTimer->Summary().c_str());
+
+  CDateTime startTime(INSTANT_TIMER_START);
+  newTimer->SetStartFromUTC(startTime);
+  newTimer->m_iMarginStart = 0;
+  newTimer->m_iMarginEnd = 0;
 
   /* set epg tag at timer & timer at epg tag */
   newTimer->UpdateEpgInfoTag();

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -749,7 +749,7 @@ bool CPVRTimerInfoTag::SetDuration(int iDuration)
   return false;
 }
 
-CPVRTimerInfoTagPtr CPVRTimerInfoTag::CreateInstantTimerTag(const CPVRChannelPtr &channel)
+CPVRTimerInfoTagPtr CPVRTimerInfoTag::CreateInstantTimerTag(const CPVRChannelPtr &channel, int iDuration /* = DEFAULT_PVRRECORD_INSTANTRECORDTIME */)
 {
   if (!channel)
   {
@@ -792,7 +792,9 @@ CPVRTimerInfoTagPtr CPVRTimerInfoTag::CreateInstantTimerTag(const CPVRChannelPtr
   newTimer->SetStartFromUTC(startTime);
   newTimer->m_iMarginStart = 0; /* set the start margin to 0 for instant timers */
 
-  int iDuration = CSettings::GetInstance().GetInt(CSettings::SETTING_PVRRECORD_INSTANTRECORDTIME);
+  if (iDuration == DEFAULT_PVRRECORD_INSTANTRECORDTIME)
+    iDuration = CSettings::GetInstance().GetInt(CSettings::SETTING_PVRRECORD_INSTANTRECORDTIME);
+
   CDateTime endTime = CDateTime::GetUTCDateTime() + CDateTimeSpan(0, 0, iDuration ? iDuration : 120, 0);
   newTimer->SetEndFromUTC(endTime);
 

--- a/xbmc/pvr/timers/PVRTimerInfoTag.h
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.h
@@ -97,12 +97,15 @@ namespace PVR
 
     bool SetDuration(int iDuration);
 
+    static const int DEFAULT_PVRRECORD_INSTANTRECORDTIME = -1;
+
     /*!
      * @brief create a tag for an instant timer for a given channel
-     * @parame the channel the instant timer is be created for
+     * @param channel is the channel the instant timer is to be created for
+     * @param iDuration is the duration for the instant timer, DEFAULT_PVRRECORD_INSTANTRECORDTIME denotes system default (setting value)
      * @return the timer or null if timer could not be created
      */
-    static CPVRTimerInfoTagPtr CreateInstantTimerTag(const CPVRChannelPtr &channel);
+    static CPVRTimerInfoTagPtr CreateInstantTimerTag(const CPVRChannelPtr &channel, int iDuration = DEFAULT_PVRRECORD_INSTANTRECORDTIME);
 
     /*!
      * @brief create a timer or timer rule for the given epg info tag.

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -547,25 +547,6 @@ bool CPVRTimers::DeleteTimersOnChannel(const CPVRChannelPtr &channel, bool bDele
   return bReturn;
 }
 
-bool CPVRTimers::InstantTimer(const CPVRChannelPtr &channel)
-{
-  assert(channel.get());
-
-  if (!g_PVRManager.CheckParentalLock(channel))
-    return false;
-
-  CPVRTimerInfoTagPtr newTimer(CPVRTimerInfoTag::CreateInstantTimerTag(channel));
-
-  bool bReturn(false);
-  if (newTimer)
-    bReturn = newTimer->AddToClient();
-
-  if (!bReturn)
-    CLog::Log(LOGERROR, "PVRTimers - %s - unable to add an instant timer on the client", __FUNCTION__);
-
-  return bReturn;
-}
-
 /********** static methods **********/
 
 bool CPVRTimers::AddTimer(const CPVRTimerInfoTagPtr &item)

--- a/xbmc/pvr/timers/PVRTimers.h
+++ b/xbmc/pvr/timers/PVRTimers.h
@@ -136,13 +136,6 @@ namespace PVR
     bool DeleteTimersOnChannel(const CPVRChannelPtr &channel, bool bDeleteRepeating = true, bool bCurrentlyActiveOnly = false);
 
     /*!
-     * @brief Create a new instant timer on a channel.
-     * @param channel The channel to create the timer on.
-     * @return True if the timer was created, false otherwise.
-     */
-    bool InstantTimer(const CPVRChannelPtr &channel);
-
-    /*!
      * @return Next event time (timer or daily wake up)
      */
     CDateTime GetNextEventTime(void) const;

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -242,6 +242,7 @@ const std::string CSettings::SETTING_PVRPLAYBACK_SCANTIME = "pvrplayback.scantim
 const std::string CSettings::SETTING_PVRPLAYBACK_CONFIRMCHANNELSWITCH = "pvrplayback.confirmchannelswitch";
 const std::string CSettings::SETTING_PVRPLAYBACK_CHANNELENTRYTIMEOUT = "pvrplayback.channelentrytimeout";
 const std::string CSettings::SETTING_PVRPLAYBACK_FPS = "pvrplayback.fps";
+const std::string CSettings::SETTING_PVRRECORD_INSTANTRECORDACTION = "pvrrecord.instantrecordaction";
 const std::string CSettings::SETTING_PVRRECORD_INSTANTRECORDTIME = "pvrrecord.instantrecordtime";
 const std::string CSettings::SETTING_PVRRECORD_DEFAULTPRIORITY = "pvrrecord.defaultpriority";
 const std::string CSettings::SETTING_PVRRECORD_DEFAULTLIFETIME = "pvrrecord.defaultlifetime";

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -199,6 +199,7 @@ public:
   static const std::string SETTING_PVRPLAYBACK_CONFIRMCHANNELSWITCH;
   static const std::string SETTING_PVRPLAYBACK_CHANNELENTRYTIMEOUT;
   static const std::string SETTING_PVRPLAYBACK_FPS;
+  static const std::string SETTING_PVRRECORD_INSTANTRECORDACTION;
   static const std::string SETTING_PVRRECORD_INSTANTRECORDTIME;
   static const std::string SETTING_PVRRECORD_DEFAULTPRIORITY;
   static const std::string SETTING_PVRRECORD_DEFAULTLIFETIME;


### PR DESCRIPTION
This feature has been requested in at least two different forum threads.

Currently, when pressing the "record" button in Live TV OSD, on the remote control or on keyboard a fixed length recording starting "now", ending after the time set as "Instant timer duration" setting value will be scheduled.

People want more flexibility here, especially the possibility to let instant recording record the currently playing show.

This PR implements configurable instant recording behavior.

First, there is a new settings value in PVR->Recording, "Instant recordig action":

![screenshot000](https://cloud.githubusercontent.com/assets/3226626/15440568/68282888-1ed6-11e6-871c-03a2a6482b29.png)

Three values are available:

![screenshot001](https://cloud.githubusercontent.com/assets/3226626/15440589/88b603d6-1ed6-11e6-8452-9bc66dfd0850.png)
- [Record current show] will record the current show from "now" to the end of the show. If no TV guide data is currently available a fixed length recording starting "now", with the value set for "Instant recording duration" will be scheduled.
- [Record for a fixed period of time] will schedule a fixed length recording starting "now", with the value set for "Instant recording duration". 
- [Ask what to do] will open a dialogue containing different recording actions to choose from, like "Record current show", "Record next show" and some fixed duration recordings.

The first two options will immediately start recording without any user interaction, the third option will open a dialog with a couple of choices:

![screenshot003](https://cloud.githubusercontent.com/assets/3226626/15441174/a414ff76-1ed9-11e6-8c12-9f96810cb487.png)

The options currently implemented for the dialog as well as the wording are only a suggestion and can easily be changed.

@da-anda we discussed this on last Devcon
@Jalle19, @xhaggi mind taking a look at the code
