### PR TITLE
[webinterface.default] tvshows: default to poster view and use sorttitle

### DIFF
--- a/addons/webinterface.default/js/MediaLibrary.js
+++ b/addons/webinterface.default/js/MediaLibrary.js
@@ -867,7 +867,11 @@ MediaLibrary.prototype = {
             'studio',
             'mpaa',
             'premiered'
-          ]
+          ],
+          'sort': {
+            'method': 'sorttitle',
+            'ignorearticle': true
+          }
         },
         'success': function (data) {
           if (data && data.result && data.result.tvshows) {

--- a/addons/webinterface.default/js/MediaLibrary.js
+++ b/addons/webinterface.default/js/MediaLibrary.js
@@ -477,13 +477,6 @@ MediaLibrary.prototype = {
     $("#togglePoster").removeClass('activeMode');
     $("#toggleLandscape").removeClass('activeMode');
     switch(view) {
-      case 'poster':
-        xbmc.core.setCookie('TVView','poster');
-        wthumblist='135px';
-        hthumblist='199px';
-        hthumbdetails='559px';
-        $("#togglePoster").addClass('activeMode');
-        break;
       case 'landscape':
         xbmc.core.setCookie('TVView','landscape');
         wthumblist='210px';
@@ -491,14 +484,21 @@ MediaLibrary.prototype = {
         hthumbdetails='213px';
         $("#toggleLandscape").addClass('activeMode');
         break;
-      default:
+      case 'banner':
         xbmc.core.setCookie('TVView','banner');
         wthumblist='379px';
         hthumblist='70px';
         hthumbdetails='70px';
         $("#toggleBanner").addClass('activeMode');
         break;
-    }
+      default:
+        xbmc.core.setCookie('TVView','poster');
+        wthumblist='135px';
+        hthumblist='199px';
+        hthumbdetails='559px';
+        $("#togglePoster").addClass('activeMode');
+        break;
+  }
     $(".floatableTVShowCover, .floatableTVShowCover div.imgWrapper, .floatableTVShowCover img, .floatableTVShowCover div.imgWrapper div.inner").css('width',wthumblist).css('height',hthumblist);
     $(".floatableTVShowCoverSeason div.imgWrapper, .floatableTVShowCoverSeason div.imgWrapper div.inner,.floatableTVShowCoverSeason img, .floatableTVShowCoverSeason").css('height',hthumbdetails);
   },


### PR DESCRIPTION
The TVShows view has a "banner - poster - landscape" toggle at the top of the page. The toggle does not retrieve different images it simply resizes the same poster image to different sizes. Removing the toggle completely is beyond my code fu so this PR simply sets the default to poster so the page displays correctly. It also sorts using sorttitle (same as the movie page) else tvshows appear in the unsorted order they were added to the library which makes no sense.
