### PR TITLE
[cmake] Don't run autoreconf as UPDATE_COMMAND

### DIFF
--- a/project/cmake/modules/FindCpluff.cmake
+++ b/project/cmake/modules/FindCpluff.cmake
@@ -13,8 +13,6 @@ if(NOT WIN32)
   ExternalProject_Add(libcpluff SOURCE_DIR ${CORE_SOURCE_DIR}/lib/cpluff
                       BUILD_IN_SOURCE 1
                       PREFIX ${CORE_BUILD_DIR}/cpluff
-                      PATCH_COMMAND rm -f config.status
-                      UPDATE_COMMAND PATH=${NATIVEPREFIX}/bin:$ENV{PATH} autoreconf -vif
                       CONFIGURE_COMMAND CC=${CMAKE_C_COMPILER} ${CORE_SOURCE_DIR}/lib/cpluff/configure
                                         --disable-nls
                                         --enable-static
@@ -25,6 +23,13 @@ if(NOT WIN32)
                                         CFLAGS=${defines}
                                         LDFLAGS=${ldflags}
                       BUILD_COMMAND make V=1)
+  ExternalProject_Add_Step(libcpluff autoreconf
+                                     DEPENDEES download update patch
+                                     DEPENDERS configure
+                                     COMMAND rm -f config.status
+                                     COMMAND PATH=${NATIVEPREFIX}/bin:$ENV{PATH} autoreconf -vif
+                                     WORKING_DIRECTORY <SOURCE_DIR>)
+
   set(ldflags "${ldflags};-lexpat")
   core_link_library(${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/cpluff/lib/libcpluff.a
                     system/libcpluff libcpluff extras "${ldflags}")

--- a/project/cmake/modules/FindLibDvd.cmake
+++ b/project/cmake/modules/FindLibDvd.cmake
@@ -25,20 +25,24 @@ if(NOT WIN32)
   endif()
 
   if(ENABLE_DVDCSS)
-    ExternalProject_ADD(dvdcss URL ${libdvdcss_BASE_URL}/archive/${libdvdcss_VER}.tar.gz
+    ExternalProject_Add(dvdcss URL ${libdvdcss_BASE_URL}/archive/${libdvdcss_VER}.tar.gz
                                PREFIX ${CORE_BUILD_DIR}/libdvd
-                               UPDATE_COMMAND PATH=${NATIVEPREFIX}/bin:$ENV{PATH} autoreconf -vif
                                CONFIGURE_COMMAND ac_cv_path_GIT= <SOURCE_DIR>/configure
-                                          --target=${ARCH}
-                                          --host=${ARCH}
-                                          --disable-doc
-                                          --enable-static
-                                          --disable-shared
-                                          --with-pic
-                                          --prefix=<INSTALL_DIR>
-                                          "${EXTRA_FLAGS}"
-                                          "CFLAGS=${CMAKE_C_FLAGS} ${DVDREAD_CFLAGS}"
-                                          "LDFLAGS=${CMAKE_LD_FLAGS}")
+                                                 --target=${ARCH}
+                                                 --host=${ARCH}
+                                                 --disable-doc
+                                                 --enable-static
+                                                 --disable-shared
+                                                 --with-pic
+                                                 --prefix=<INSTALL_DIR>
+                                                 "${EXTRA_FLAGS}"
+                                                 "CFLAGS=${CMAKE_C_FLAGS} ${DVDREAD_CFLAGS}"
+                                                 "LDFLAGS=${CMAKE_LD_FLAGS}")
+    ExternalProject_Add_Step(dvdcss autoreconf
+                                    DEPENDEES download update patch
+                                    DEPENDERS configure
+                                    COMMAND PATH=${NATIVEPREFIX}/bin:$ENV{PATH} autoreconf -vif
+                                    WORKING_DIRECTORY <SOURCE_DIR>)
 
     core_link_library(${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/libdvd/lib/libdvdcss.a
                       system/players/VideoPlayer/libdvdcss dvdcss)
@@ -49,19 +53,23 @@ if(NOT WIN32)
     set(DVDREAD_CFLAGS "${DVDREAD_CFLAGS} -DHAVE_DVDCSS_DVDCSS_H -I${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/libdvd/include")
   endif(ENABLE_DVDCSS)
 
-  ExternalProject_ADD(dvdread URL ${libdvdread_BASE_URL}/archive/${libdvdread_VER}.tar.gz
+  ExternalProject_Add(dvdread URL ${libdvdread_BASE_URL}/archive/${libdvdread_VER}.tar.gz
                               PREFIX ${CORE_BUILD_DIR}/libdvd
-                              UPDATE_COMMAND PATH=${NATIVEPREFIX}/bin:$ENV{PATH} autoreconf -vif
                               CONFIGURE_COMMAND ac_cv_path_GIT= <SOURCE_DIR>/configure
-                                        --target=${ARCH}
-                                        --host=${ARCH}
-                                        --enable-static
-                                        --disable-shared
-                                        --with-pic
-                                        --prefix=<INSTALL_DIR>
-                                        "${EXTRA_FLAGS}"
-                                        "CFLAGS=${CMAKE_C_FLAGS} ${DVDREAD_CFLAGS}"
-                                        "LDFLAGS=${CMAKE_LD_FLAGS}")
+                                                --target=${ARCH}
+                                                --host=${ARCH}
+                                                --enable-static
+                                                --disable-shared
+                                                --with-pic
+                                                --prefix=<INSTALL_DIR>
+                                                "${EXTRA_FLAGS}"
+                                                "CFLAGS=${CMAKE_C_FLAGS} ${DVDREAD_CFLAGS}"
+                                                "LDFLAGS=${CMAKE_LD_FLAGS}")
+  ExternalProject_Add_Step(dvdread autoreconf
+                                   DEPENDEES download update patch
+                                   DEPENDERS configure
+                                   COMMAND PATH=${NATIVEPREFIX}/bin:$ENV{PATH} autoreconf -vif
+                                   WORKING_DIRECTORY <SOURCE_DIR>)
   if(ENABLE_DVDCSS)
     add_dependencies(dvdread dvdcss)
   endif()
@@ -73,22 +81,26 @@ if(NOT WIN32)
     set(DVDNAV_LIBS -ldvdcss)
   endif(ENABLE_DVDCSS)
 
-  ExternalProject_ADD(dvdnav URL ${libdvdnav_BASE_URL}/archive/${libdvdnav_VER}.tar.gz
+  ExternalProject_Add(dvdnav URL ${libdvdnav_BASE_URL}/archive/${libdvdnav_VER}.tar.gz
                              PREFIX ${CORE_BUILD_DIR}/libdvd
-                             UPDATE_COMMAND PATH=${NATIVEPREFIX}/bin:$ENV{PATH} autoreconf -vif
                              CONFIGURE_COMMAND ac_cv_path_GIT= <SOURCE_DIR>/configure
-                                        --target=${ARCH}
-                                        --host=${ARCH}
-                                        --enable-static
-                                        --disable-shared
-                                        --with-pic
-                                        --prefix=${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/libdvd
-                                        "${EXTRA_FLAGS}"
-                                        "LDFLAGS=${CMAKE_LD_FLAGS} -L${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/libdvd/lib"
-                                        "CFLAGS=${CMAKE_C_FLAGS} ${DVDREAD_CFLAGS}"
-                                        "DVDREAD_CFLAGS=${DVDREAD_CFLAGS}"
-                                        "DVDREAD_LIBS=${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/libdvd/lib/libdvdread.la"
-                                        "LIBS=${DVDNAV_LIBS}")
+                                               --target=${ARCH}
+                                               --host=${ARCH}
+                                               --enable-static
+                                               --disable-shared
+                                               --with-pic
+                                               --prefix=${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/libdvd
+                                               "${EXTRA_FLAGS}"
+                                               "LDFLAGS=${CMAKE_LD_FLAGS} -L${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/libdvd/lib"
+                                               "CFLAGS=${CMAKE_C_FLAGS} ${DVDREAD_CFLAGS}"
+                                               "DVDREAD_CFLAGS=${DVDREAD_CFLAGS}"
+                                               "DVDREAD_LIBS=${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/libdvd/lib/libdvdread.la"
+                                               "LIBS=${DVDNAV_LIBS}")
+  ExternalProject_Add_Step(dvdnav autoreconf
+                                  DEPENDEES download update patch
+                                  DEPENDERS configure
+                                  COMMAND PATH=${NATIVEPREFIX}/bin:$ENV{PATH} autoreconf -vif
+                                  WORKING_DIRECTORY <SOURCE_DIR>)
   add_dependencies(dvdnav dvdread)
   core_link_library(${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/libdvd/lib/libdvdnav.a
                     system/players/VideoPlayer/libdvdnav dvdnav)


### PR DESCRIPTION
This fixes an issue that I've been struggling with the last 2 days: make always rebuilt libdvd and cpluff even if nothing changed at all in the sources.

I've tracked down the issue to this:
The ExternalProject_Add's UPDATE_COMMAND changed recently in CMake upstream to be always executed when set (https://github.com/Kitware/CMake/commit/bdca68388bd57f8302d3c1d83d691034b7ffa70c). This is because it's meant to be used for updating the sources. Kodi currently uses it however to run autoreconf and because of the upstream change, libdvd and libcpluff are considered always outdated and are always rebuilt.

Note that currently probably only I am affected, because I'm running a self compiled CMake from master as the one that ships with Ubuntu 16.04 (3.5.1) crashes due to: https://bugs.launchpad.net/ubuntu/+source/cmake/+bug/1564741

Nevertheless I think it's a good idea to include this patch as more people will be hit in future and this version also improves logging (it will mention the step autoreconf).

Ping: @notspiff, @hudokkow, @wsnipex: A bunch of binary addons are affected as well unfortunately.
