### PR TITLE
VideoPlayerVideo: Need to clear pictures before switching decoder

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.cpp
@@ -67,7 +67,6 @@ CDVDVideoCodec* CDVDFactoryCodec::OpenCodec(CDVDVideoCodec* pCodec, CDVDStreamIn
     }
 
     CLog::Log(LOGDEBUG, "FactoryCodec - Video: %s - Failed", pCodec->GetName());
-    pCodec->Dispose();
     delete pCodec;
   }
   catch(...)
@@ -89,7 +88,6 @@ CDVDAudioCodec* CDVDFactoryCodec::OpenCodec(CDVDAudioCodec* pCodec, CDVDStreamIn
     }
 
     CLog::Log(LOGDEBUG, "FactoryCodec - Audio: %s - Failed", pCodec->GetName());
-    pCodec->Dispose();
     delete pCodec;
   }
   catch(...)
@@ -111,7 +109,6 @@ CDVDOverlayCodec* CDVDFactoryCodec::OpenCodec(CDVDOverlayCodec* pCodec, CDVDStre
     }
 
     CLog::Log(LOGDEBUG, "FactoryCodec - Overlay: %s - Failed", pCodec->GetName());
-    pCodec->Dispose();
     delete pCodec;
   }
   catch(...)

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h
@@ -180,11 +180,6 @@ public:
   virtual bool Open(CDVDStreamInfo &hints, CDVDCodecOptions &options) = 0;
 
   /**
-   * Dispose, Free all resources
-   */
-  virtual void Dispose() = 0;
-
-  /**
    * returns one or a combination of VC_ messages
    * pData and iSize can be NULL, this means we should flush the rest of the data.
    */

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.h
@@ -63,7 +63,6 @@ public:
 
   // Required overrides
   virtual bool Open(CDVDStreamInfo &hints, CDVDCodecOptions &options);
-  virtual void Dispose(void);
   virtual int  Decode(uint8_t *pData, int iSize, double dts, double pts);
   virtual void Reset(void);
   virtual bool GetPicture(DVDVideoPicture *pDvdVideoPicture);
@@ -75,6 +74,7 @@ public:
   virtual const char* GetName(void) { return (const char*)m_pFormatName; }
 
 protected:
+  void            Dispose(void);
   void            FrameQueuePop(void);
   void            FrameQueuePush(double dts, double pts);
   void            FrameRateTracking(uint8_t *pData, int iSize, double dts, double pts);

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
@@ -96,7 +96,6 @@ public:
 
   // required overrides
   virtual bool    Open(CDVDStreamInfo &hints, CDVDCodecOptions &options);
-  virtual void    Dispose();
   virtual int     Decode(uint8_t *pData, int iSize, double dts, double pts);
   virtual void    Reset();
   virtual bool    GetPicture(DVDVideoPicture *pDvdVideoPicture);
@@ -108,6 +107,7 @@ public:
   virtual unsigned GetAllowedReferences();
 
 protected:
+  void            Dispose();
   void            FlushInternal(void);
   bool            ConfigureMediaCodec(void);
   int             GetOutputPicture(void);

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.h
@@ -60,7 +60,6 @@ public:
   CDVDVideoCodecFFmpeg(CProcessInfo &processInfo);
   virtual ~CDVDVideoCodecFFmpeg();
   virtual bool Open(CDVDStreamInfo &hints, CDVDCodecOptions &options) override;
-  virtual void Dispose() override;
   virtual int Decode(uint8_t* pData, int iSize, double dts, double pts) override;
   virtual void Reset() override;
   virtual void Reopen() override;
@@ -77,6 +76,7 @@ public:
   void SetHardware(IHardwareDecoder* hardware);
 
 protected:
+  void Dispose();
   static enum AVPixelFormat GetFormat(struct AVCodecContext * avctx, const AVPixelFormat * fmt);
 
   int  FilterOpen(const std::string& filters, bool scale);

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecIMX.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecIMX.h
@@ -177,7 +177,6 @@ private:
 
   void SetFieldData(uint8_t fieldFmt);
 
-  void Dispose();
   void MemMap(struct fb_fix_screeninfo *fb_fix = NULL);
 
   virtual void OnStartup();
@@ -186,6 +185,7 @@ private:
   virtual void Process();
 
 private:
+  void Dispose();
   typedef std::vector<IPUTask> TaskQueue;
 
   int                            m_fbHandle;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecOpenMax.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecOpenMax.h
@@ -32,7 +32,6 @@ public:
 
   // Required overrides
   virtual bool Open(CDVDStreamInfo &hints, CDVDCodecOptions &options);
-  virtual void Dispose(void);
   virtual int  Decode(uint8_t *pData, int iSize, double dts, double pts);
   virtual void Reset(void);
   virtual bool GetPicture(DVDVideoPicture *pDvdVideoPicture);
@@ -41,6 +40,7 @@ public:
   virtual const char* GetName(void) { return (const char*)m_pFormatName; }
   
 protected:
+  void Dispose(void);
   const char        *m_pFormatName;
   COpenMaxVideo     *m_omx_decoder;
   DVDVideoPicture   m_videobuffer;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.h
@@ -75,7 +75,6 @@ public:
 
   // Required overrides
   virtual bool Open(CDVDStreamInfo &hints, CDVDCodecOptions &options);
-  virtual void Dispose(void);
   virtual int  Decode(uint8_t *pData, int iSize, double dts, double pts);
   virtual void Reset(void);
   virtual bool GetPicture(DVDVideoPicture *pDvdVideoPicture);
@@ -100,6 +99,7 @@ protected:
   bool CreateDeinterlace(EINTERLACEMETHOD interlace_method);
   bool DestroyDeinterlace();
   void Prime();
+  void Dispose(void);
 
   // Video format
   unsigned int      m_decoded_width;

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -210,7 +210,6 @@ void CVideoPlayerVideo::CloseStream(bool bWaitForBuffers)
   CLog::Log(LOGNOTICE, "deleting video codec");
   if (m_pVideoCodec)
   {
-    m_pVideoCodec->Dispose();
     delete m_pVideoCodec;
     m_pVideoCodec = NULL;
   }

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -179,8 +179,10 @@ void CVideoPlayerVideo::OpenStream(CDVDStreamInfo &hint, CDVDVideoCodec* codec)
     m_fForcedAspectRatio = 0.0;
 
   if (m_pVideoCodec)
+  {
+    m_pVideoCodec->ClearPicture(&m_picture);
     delete m_pVideoCodec;
-
+  }
   m_pVideoCodec = codec;
   m_hints   = hint;
   m_stalled = m_messageQueue.GetPacketCount(CDVDMsg::DEMUXER_PACKET) == 0;
@@ -210,6 +212,7 @@ void CVideoPlayerVideo::CloseStream(bool bWaitForBuffers)
   CLog::Log(LOGNOTICE, "deleting video codec");
   if (m_pVideoCodec)
   {
+    m_pVideoCodec->ClearPicture(&m_picture);
     delete m_pVideoCodec;
     m_pVideoCodec = NULL;
   }


### PR DESCRIPTION
The new decoder may not know how clear a picture initialised from a different decoder.
For example MMALCodec wants Release() called on clear, but VideoCodecFFMPEG does not.
