### PR TITLE
make libxml2 / libxslt optional

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -399,6 +399,12 @@ AC_ARG_ENABLE([libbluray],
   [use_libbluray=$enableval],
   [use_libbluray=auto])
 
+AC_ARG_ENABLE([libxslt],
+  [AS_HELP_STRING([--disable-libxslt],
+  [enable libxslt (XSLT scrapers) support (default is enabled)])],
+  [use_libxslt=$enableval],
+  [use_libxslt=yes])
+
 AC_ARG_ENABLE([texturepacker],
   [AS_HELP_STRING([--enable-texturepacker],
   [enable texturepacker support (default is auto)])],
@@ -1059,12 +1065,22 @@ if test "$target_platform" = "target_android" ; then
   AC_CHECK_LIB([log],         [__android_log_vprint],, AC_MSG_ERROR($missing_library))
   AC_CHECK_LIB([jnigraphics],     [main],, AC_MSG_ERROR($missing_library))
 fi
-PKG_CHECK_MODULES([LIBXML], [libxml-2.0],
-  [INCLUDES="$INCLUDES $LIBXML_CFLAGS"; LIBS="$LIBS $LIBXML_LIBS"],
-  AC_MSG_ERROR($missing_library))
-PKG_CHECK_MODULES([LIBXSLT], [libxslt],
-  [INCLUDES="$INCLUDES $LIBXSLT_CFLAGS"; LIBS="$LIBS $LIBXSLT_LIBS"],
-  AC_MSG_ERROR($missing_library))
+
+# check for libbxslt
+AS_CASE([x$use_libxslt],
+  [xyes],[
+    PKG_CHECK_MODULES([LIBXML], [libxml-2.0],
+      [INCLUDES="$INCLUDES $LIBXML_CFLAGS"; LIBS="$LIBS $LIBXML_LIBS"],
+      AC_MSG_ERROR($missing_library))
+    PKG_CHECK_MODULES([LIBXSLT], [libxslt],
+      [INCLUDES="$INCLUDES $LIBXSLT_CFLAGS"; LIBS="$LIBS $LIBXSLT_LIBS"],
+      AC_MSG_ERROR($missing_library))
+    AC_DEFINE([HAVE_LIBXSLT], 1, [System has libxslt library])
+    AC_SUBST([HAVE_LIBXSLT], 1)
+  ],[
+    AC_SUBST([HAVE_LIBXSLT], 0)
+  ]
+)
 PKG_CHECK_MODULES([FRIBIDI],    [fribidi],
   [INCLUDES="$INCLUDES $FRIBIDI_CFLAGS"; LIBS="$LIBS $FRIBIDI_LIBS"],
   AC_MSG_ERROR($missing_library))
@@ -1856,6 +1872,12 @@ if test "$use_libbluray" = "yes"; then
   final_message="$final_message\n  Bluray:\tYes"
 else
   final_message="$final_message\n  Bluray:\tNo"
+fi
+
+if test "$use_libxslt" = "yes"; then
+  final_message="$final_message\n  XSLT scrapers:\tYes"
+else
+  final_message="$final_message\n  XSLT scrapers:\tNo"
 fi
 
 if test "x$use_texturepacker" != "xno"; then

--- a/project/cmake/CMakeLists.txt
+++ b/project/cmake/CMakeLists.txt
@@ -19,6 +19,7 @@ option(ENABLE_MICROHTTPD  "Enable MicroHttpd webserver?" ON)
 option(ENABLE_MYSQLCLIENT "Enable MySql support?" ON)
 option(ENABLE_AVAHI       "Enable Avahi support?" ON)
 option(ENABLE_BLURAY      "Enable BluRay support?" ON)
+option(ENABLE_XSLT        "Enable XSLT scrapers support?" ON)
 option(ENABLE_PLIST       "Enable AirPlay support?" ON)
 option(ENABLE_NFS         "Enable NFS support?" ON)
 option(ENABLE_AIRTUNES    "Enable AirTunes support?" ON)
@@ -94,7 +95,7 @@ list(APPEND DEPLIBS ${CMAKE_THREAD_LIBS_INIT})
 
 # Required dependencies
 set(required_deps Sqlite3 FreeType PCRE Cpluff LibDvd
-                  TinyXML Python Yajl Xslt
+                  TinyXML Python Yajl
                   Lzo2 Fribidi TagLib FFMPEG CrossGUID)
 if(NOT WIN32)
   list(APPEND required_deps LibSmbClient ZLIB)
@@ -106,7 +107,7 @@ if(CORE_SYSTEM_NAME STREQUAL android)
 endif()
 
 # Optional dependencies
-set(optional_deps MicroHttpd MySqlClient SSH
+set(optional_deps MicroHttpd MySqlClient SSH Xslt
                   Alsa UDev Dbus Avahi
                   PulseAudio VDPAU VAAPI)
 

--- a/project/cmake/modules/FindXslt.cmake
+++ b/project/cmake/modules/FindXslt.cmake
@@ -15,4 +15,8 @@ endif()
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(Xslt DEFAULT_MSG XSLT_INCLUDE_DIRS XSLT_LIBRARIES)
 
+if(XSLT_FOUND)
+  set(XSLT_DEFINITIONS -DHAVE_LIBXSLT=1)
+endif()
+
 mark_as_advanced(XSLT_INCLUDE_DIRS XSLT_LIBRARIES)

--- a/xbmc/utils/Makefile.in
+++ b/xbmc/utils/Makefile.in
@@ -74,7 +74,9 @@ SRCS += Weather.cpp
 SRCS += XBMCTinyXML.cpp
 SRCS += XMLUtils.cpp
 SRCS += Utf8Utils.cpp
+ifeq (@HAVE_LIBXSLT@,1)
 SRCS += XSLTUtils.cpp
+endif
 SRCS += ActorProtocol.cpp 
 SRCS += SysfsUtils.cpp
 

--- a/xbmc/utils/ScraperParser.cpp
+++ b/xbmc/utils/ScraperParser.cpp
@@ -28,7 +28,9 @@
 #include "utils/StringUtils.h"
 #include "log.h"
 #include "CharsetConverter.h"
+#ifdef HAVE_LIBXSLT
 #include "utils/XSLTUtils.h"
+#endif
 #include "utils/XMLUtils.h"
 #include <sstream>
 #include <cstring>
@@ -338,6 +340,7 @@ void CScraperParser::ParseExpression(const std::string& input, std::string& dest
 
 void CScraperParser::ParseXSLT(const std::string& input, std::string& dest, TiXmlElement* element, bool bAppend)
 {
+#ifdef HAVE_LIBXSLT
   TiXmlElement* pSheet = element->FirstChildElement();
   if (pSheet)
   {
@@ -354,13 +357,18 @@ void CScraperParser::ParseXSLT(const std::string& input, std::string& dest, TiXm
 
     xsltUtils.XSLTTransform(dest);
   }
+#endif
 }
 
 TiXmlElement *FirstChildScraperElement(TiXmlElement *element)
 {
   for (TiXmlElement *child = element->FirstChildElement(); child; child = child->NextSiblingElement())
   {
-    if (child->ValueStr() == "RegExp" || child->ValueStr() == "XSLT")
+#ifdef HAVE_LIBXSLT
+    if (child->ValueStr() == "XSLT")
+      return child;
+#endif
+    if (child->ValueStr() == "RegExp")
       return child;
   }
   return NULL;
@@ -370,7 +378,11 @@ TiXmlElement *NextSiblingScraperElement(TiXmlElement *element)
 {
   for (TiXmlElement *next = element->NextSiblingElement(); next; next = next->NextSiblingElement())
   {
-    if (next->ValueStr() == "RegExp" || next->ValueStr() == "XSLT")
+#ifdef HAVE_LIBXSLT
+    if (next->ValueStr() == "XSLT")
+      return next;
+#endif
+    if (next->ValueStr() == "RegExp")
       return next;
   }
   return NULL;
@@ -432,9 +444,11 @@ void CScraperParser::ParseNext(TiXmlElement* element)
     {
       if (iDest-1 < MAX_SCRAPER_BUFFERS && iDest-1 > -1)
       {
+#ifdef HAVE_LIBXSLT
         if (pReg->ValueStr() == "XSLT")
           ParseXSLT(strInput, m_param[iDest - 1], pReg, bAppend);
         else
+#endif
           ParseExpression(strInput, m_param[iDest - 1],pReg,bAppend);
       }
       else


### PR DESCRIPTION
support for xslt scrapers was added in #3758 more than 2 years agom but if I am not mistaken, atm there is no working xslt scraper in kodi repo (I installed all and they all use regexps), there was an attempt to make one (http://forum.kodi.tv/showthread.php?tid=188738) but it has gone nowhere.

this PR makes libxml/libxslt optional, for use in distributions that prefer less dependencies. it is enabled (and required) by default, so no change to our official builds.

@fetzerch I am not sure I did cmake right..

comments ?
