### PR TITLE
[tests] Fix some of the issues with the test suite on win32

### DIFF
--- a/xbmc/SystemGlobals.cpp
+++ b/xbmc/SystemGlobals.cpp
@@ -70,9 +70,6 @@ std::map<std::string, std::string> CSpecialProtocol::m_pathMap;
   CRBP               g_RBP;
 #endif
 
-#ifdef HAS_FILESYSTEM_RAR
-  CRarManager g_RarManager;
-#endif
   CZipManager g_ZipManager;
 
   CDataCacheCore g_dataCacheCore;

--- a/xbmc/filesystem/RarManager.h
+++ b/xbmc/filesystem/RarManager.h
@@ -27,6 +27,7 @@
 #include "threads/CriticalSection.h"
 #include "UnrarXLib/UnrarX.hpp"
 #include "utils/Stopwatch.h"
+#include "utils/GlobalsHandling.h"
 
 class CFileItemList;
 
@@ -86,5 +87,6 @@ protected:
   int64_t CheckFreeSpace(const std::string& strDrive);
 };
 
-extern CRarManager g_RarManager;
+XBMC_GLOBAL_REF(CRarManager, g_RarManager);
+#define g_RarManager XBMC_GLOBAL_USE(CRarManager)
 

--- a/xbmc/test/TestBasicEnvironment.cpp
+++ b/xbmc/test/TestBasicEnvironment.cpp
@@ -31,6 +31,10 @@
 #include "Application.h"
 #include "interfaces/AnnouncementManager.h"
 
+#if defined(TARGET_WINDOWS)
+#include "win32/WIN32Util.h"
+#endif
+
 #include <cstdio>
 #include <cstdlib>
 #include <climits>
@@ -84,6 +88,7 @@ void TestBasicEnvironment::SetUp()
   if (!CreateDirectory(lpTempPathBuffer, NULL))
     SetUpError();
   CSpecialProtocol::SetTempPath(lpTempPathBuffer);
+  CWIN32Util::ExtendDllPath(); //Needed for delay loading on windows
 #else
   char buf[MAX_PATH];
   char *tmp;

--- a/xbmc/win32/Win32DelayedDllLoad.cpp
+++ b/xbmc/win32/Win32DelayedDllLoad.cpp
@@ -24,6 +24,7 @@
 
 static const std::string dlls[] = {
   "ssh.dll",
+  "zlib.dll",
   "sqlite3.dll",
   "dnssd.dll",
   "libxslt.dll",


### PR DESCRIPTION
Delay loading wasn't properly initialized during the tests
Changed how rarmanager global is handled to get rid of a crash during shutdown because of ordering.
Still crashes during shutdown but at least now all the tests run fine
