### PR TITLE
Changing android ndk directory existence test

### DIFF
--- a/tools/depends/configure.ac
+++ b/tools/depends/configure.ac
@@ -456,7 +456,7 @@ if test "$platform_os" == "android"; then
     AC_MSG_ERROR("NDK path is required for android")
   fi
 
-  if ! test -f "$use_ndk/RELEASE.TXT" ; then
+  if ! test -f "$use_ndk/source.properties" ; then
     AC_MSG_ERROR("$use_ndk is not an NDK directory")
   fi
 


### PR DESCRIPTION
Starting ndk 11 ndk_dir/RELEASE.TXT was removed.
The new file to test is ndk_dir/source.properties according to a proposal at
http://forum.kodi.tv/showthread.php?tid=274621&pid=2337598#pid2337598
