### PR TITLE
[cmake][Windows] Fix wrong output directory of add-on callback libraries for Windows

### DIFF
--- a/project/cmake/scripts/windows/Macros.cmake
+++ b/project/cmake/scripts/windows/Macros.cmake
@@ -14,9 +14,15 @@ function(core_link_library lib wraplib)
     endforeach()
 
     add_library(wrap_${lib} SHARED ${SOURCES_ABS})
-    set_target_properties(wrap_${lib} PROPERTIES OUTPUT_NAME ${wraplib})
+    set_target_properties(wrap_${lib} PROPERTIES OUTPUT_NAME lib${lib})
     target_include_directories(wrap_${lib} PRIVATE ${INCLUDES})
     target_compile_definitions(wrap_${lib} PRIVATE ${DEFINITIONS})
+    
+    if(MSVC)
+      string(REPLACE "/lib${lib}" "" libdir ${wraplib})
+      set_target_properties(wrap_${lib} PROPERTIES RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_BINARY_DIR}/${libdir}"
+                                                   RUNTIME_OUTPUT_DIRECTORY_DEBUG   "${CMAKE_BINARY_DIR}/${libdir}")
+    endif()
   endif()
 endfunction()
 


### PR DESCRIPTION
@fetzerch 
This is the extracted PR from https://github.com/xbmc/xbmc/pull/9855.

Feel free to merge.
