### PR TITLE
GUISliderControl & AudioDSP music OSD

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -7841,6 +7841,7 @@ msgid "Add"
 msgstr ""
 
 #: addons/skin.estuary/1080i/Custom_1106_VideoOSDSettings.xml
+#: addons/skin.estuary/1080i/Custom_1105_MusicOSDSettings.xml
 msgctxt "#15020"
 msgid "Audio DSP manager"
 msgstr ""
@@ -7955,6 +7956,7 @@ msgstr ""
 #: xbmc/pvr/windows/GUIWindowPVRChannels.cpp
 #: xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
 #: xbmc/music/windows/GUIWindowMusicBase.cpp
+#: addons/skin.estuary/1080i/Custom_1105_MusicOSDSettings.xml
 msgctxt "#15047"
 msgid "Audio DSP settings"
 msgstr ""

--- a/addons/skin.estuary/1080i/Custom_1105_MusicOSDSettings.xml
+++ b/addons/skin.estuary/1080i/Custom_1105_MusicOSDSettings.xml
@@ -29,6 +29,16 @@
 			</include>
 			<content>
 				<item>
+					<label>$LOCALIZE[15047]</label>
+					<onclick>ActivateWindow(OSDAudioDSPSettings)</onclick>
+					<visible>system.getbool(audiooutput.dspaddonsenabled)</visible>
+				</item>
+				<item>
+					<label>$LOCALIZE[15020]</label>
+					<onclick>ActivateWindow(AudioDSPManager)</onclick>
+					<visible>system.getbool(audiooutput.dspaddonsenabled)</visible>
+				</item>
+				<item>
 					<label>$LOCALIZE[250]: [COLOR button_focus]$INFO[Visualisation.Name][/COLOR]</label>
 					<onclick>Dialog.Close(all)</onclick>
 					<onclick>SendClick(500)</onclick>

--- a/xbmc/guilib/GUISliderControl.cpp
+++ b/xbmc/guilib/GUISliderControl.cpp
@@ -80,21 +80,26 @@ void CGUISliderControl::Process(unsigned int currentTime, CDirtyRegionList &dirt
       SetIntValue(val);
   }
 
-  float fScale;
-  if (m_orientation == HORIZONTAL)
-    fScale = m_height == 0 ? 1.0f : m_height / m_guiBackground.GetTextureHeight();
-  else
-    fScale = m_width == 0 ? 1.0f : m_width / m_guiBackground.GetTextureWidth();
 
   dirty |= m_guiBackground.SetHeight(m_height);
   dirty |= m_guiBackground.SetWidth(m_width);
   dirty |= m_guiBackground.Process(currentTime);
 
   CGUITexture &nibLower = (m_bHasFocus && !IsDisabled() && m_currentSelector == RangeSelectorLower) ? m_guiSelectorLowerFocus : m_guiSelectorLower;
+  float fScale;
+  if (m_orientation == HORIZONTAL)
+    fScale = m_height == 0 ? 1.0f : m_height / m_guiBackground.GetTextureHeight();
+  else
+    fScale = m_width == 0 ? 1.0f : m_width / nibLower.GetTextureWidth();
+
   dirty |= ProcessSelector(nibLower, currentTime, fScale, RangeSelectorLower);
   if (m_rangeSelection)
   {
     CGUITexture &nibUpper = (m_bHasFocus && !IsDisabled() && m_currentSelector == RangeSelectorUpper) ? m_guiSelectorUpperFocus : m_guiSelectorUpper;
+    if (m_orientation == HORIZONTAL)
+      fScale = m_height == 0 ? 1.0f : m_height / m_guiBackground.GetTextureHeight();
+    else
+      fScale = m_width == 0 ? 1.0f : m_width / nibUpper.GetTextureWidth();;
     dirty |= ProcessSelector(nibUpper, currentTime, fScale, RangeSelectorUpper);
   }
 
@@ -539,7 +544,8 @@ void CGUISliderControl::SetFromPosition(const CPoint &point, bool guessSelector 
   if (m_orientation == HORIZONTAL)
     fPercent = (point.x - m_guiBackground.GetXPosition()) / m_guiBackground.GetWidth();
   else
-    fPercent = (point.y - m_guiBackground.GetYPosition()) / m_guiBackground.GetHeight();
+    fPercent = (m_guiBackground.GetYPosition() + m_guiBackground.GetHeight() - point.y) / m_guiBackground.GetHeight();
+
   if (fPercent < 0) fPercent = 0;
   if (fPercent > 1) fPercent = 1;
 


### PR DESCRIPTION
@ronie @phil65

Here is the extracted PR from https://github.com/xbmc/xbmc/pull/9855 that adds AudioDSP to music OSD and fixes scaling issues with vertical sliders. Futhermore it sets default orientation to vertical for CGUIControl::GUICONTROL_SLIDER and CGUIControl::GUICONTROL_SETTINGS_SLIDER (I will need this later for adsp.biquad.filters).

EDIT:
Fixed wrong title, sorry it was a copy paste issue.
