### PR TITLE
CD3DVertexShader::Release: Use SAFE_DELETE_ARRAY with m_vertexLayout

### DIFF
--- a/xbmc/guilib/D3DResource.cpp
+++ b/xbmc/guilib/D3DResource.cpp
@@ -843,7 +843,7 @@ void CD3DVertexShader::Release()
   g_Windowing.Unregister(this);
   ReleaseShader();
   SAFE_RELEASE(m_VSBuffer);
-  SAFE_DELETE(m_vertexLayout);
+  SAFE_DELETE_ARRAY(m_vertexLayout);
 }
 
 void CD3DVertexShader::ReleaseShader()


### PR DESCRIPTION
`m_vertexLayout` is an array. It's created like:
`m_vertexLayout = new D3D11_INPUT_ELEMENT_DESC[vertexLayoutSize];`

This array was deleted with `SAFE_DELETE`.
`#define SAFE_DELETE(p)        { delete (p); p = nullptr;  }`

Arrays should be deleted with `SAFE_DELETE_ARRAY`:
`#define SAFE_DELETE_ARRAY(p)  { delete [](p); p = nullptr; }`

(sorry, branch name is a little bit confusing, since it's not about allocating but freeing)
