### PR TITLE
[guilib] Add disabled controls to numitems for grouplists

### DIFF
--- a/xbmc/guilib/GUIControlGroupList.cpp
+++ b/xbmc/guilib/GUIControlGroupList.cpp
@@ -455,7 +455,7 @@ std::string CGUIControlGroupList::GetLabel(int info) const
 int CGUIControlGroupList::GetNumItems() const
 {
   return std::count_if(m_children.begin(), m_children.end(), [&](const CGUIControl *child) {
-    return (child->IsVisible() && child->CanFocus());
+    return (child->IsVisible() && (child->CanFocus() || child->IsDisabled()));
   });
 }
 


### PR DESCRIPTION
See http://forum.kodi.tv/showthread.php?tid=224074
As disabled controls still show up in the grouplist, it makes sense to count them as part of the list.

@ronie @HitcherUK 
