### PR TITLE
[PVR] add recording id to recording path

### DIFF
--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -448,7 +448,7 @@ void CPVRRecording::UpdatePath(void)
   else
   {
     m_strFileNameAndPath = CPVRRecordingsPath(
-      m_bIsDeleted, m_bRadio, m_strDirectory, m_strTitle, m_iSeason, m_iEpisode, m_iYear, m_strShowTitle, m_strChannelName, m_recordingTime);
+      m_bIsDeleted, m_bRadio, m_strDirectory, m_strTitle, m_iSeason, m_iEpisode, m_iYear, m_strShowTitle, m_strChannelName, m_recordingTime, m_strRecordingId);
   }
 }
 

--- a/xbmc/pvr/recordings/PVRRecordingsPath.cpp
+++ b/xbmc/pvr/recordings/PVRRecordingsPath.cpp
@@ -78,7 +78,7 @@ CPVRRecordingsPath::CPVRRecordingsPath(bool bDeleted, bool bRadio,
                        const std::string &strDirectory, const std::string &strTitle,
                        int iSeason, int iEpisode, int iYear,
                        const std::string &strSubtitle, const std::string &strChannelName,
-                       const CDateTime &recordingTime)
+                       const CDateTime &recordingTime, const std::string &strId)
 : m_bValid(true),
   m_bRoot(false),
   m_bActive(!bDeleted),
@@ -116,7 +116,7 @@ CPVRRecordingsPath::CPVRRecordingsPath(bool bDeleted, bool bRadio,
   m_directoryPath = StringUtils::Format("%s%s%s%s%s",
                                         strDirectoryN.c_str(), strTitleN.c_str(), strSeasonEpisodeN.c_str(),
                                         strYearN.c_str(), strSubtitleN.c_str());
-  m_params = StringUtils::Format(", TV%s, %s.pvr", strChannelNameN.c_str(), recordingTime.GetAsSaveString().c_str());
+  m_params = StringUtils::Format(", TV%s, %s, %s.pvr", strChannelNameN.c_str(), recordingTime.GetAsSaveString().c_str(), strId.c_str());
   m_path   = StringUtils::Format("pvr://recordings/%s/%s/%s%s", bRadio ? "radio" : "tv", bDeleted ? "deleted" : "active", m_directoryPath.c_str(), m_params.c_str());
 }
 
@@ -149,7 +149,7 @@ const std::string CPVRRecordingsPath::GetTitle() const
   {
     CRegExp reg(true);
     if (reg.RegComp("pvr://recordings/(.*/)*(.*), TV( \\(.*\\))?, "
-                    "(19[0-9][0-9]|20[0-9][0-9])[0-9][0-9][0-9][0-9]_[0-9][0-9][0-9][0-9][0-9][0-9].pvr"))
+                    "(19[0-9][0-9]|20[0-9][0-9])[0-9][0-9][0-9][0-9]_[0-9][0-9][0-9][0-9][0-9][0-9], (.*).pvr"))
     {
       if (reg.RegFind(m_path.c_str()) >= 0)
         return reg.GetMatch(2);

--- a/xbmc/pvr/recordings/PVRRecordingsPath.h
+++ b/xbmc/pvr/recordings/PVRRecordingsPath.h
@@ -40,7 +40,7 @@ namespace PVR
                        const std::string &strDirectory, const std::string &strTitle,
                        int iSeason, int iEpisode, int iYear,
                        const std::string &strSubtitle, const std::string &strChannelName,
-                       const CDateTime &recordingTime);
+                       const CDateTime &recordingTime, const std::string &strId);
 
     operator std::string() const { return m_path; }
 


### PR DESCRIPTION
The recording path should be unique.

This fixes the following issue when using a pvr client with demuxer (tested pvr.hts)
1) start recording show A
2) abort recording show A
3) resume recording show A
4) show A is shown 2 times in the recordings view, but only 1 in playable...

There is a small regression as bookmarks aren't migrated (only when using a pvr client with internal demuxer and no backend support for played position). Migration isn't easy without introducing a hack into the code... The path was changed in the past without migrating the bookmarks, so I don't think this is a big deal?

@ksooo @Jalle19 
