### PR TITLE
[PVR] Fix deadlock in PVR channel window.

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -96,13 +96,6 @@ void CGUIWindowPVRBase::ResetObservers(void)
 
 void CGUIWindowPVRBase::Notify(const Observable &obs, const ObservableMessage msg)
 {
-  if (IsActive())
-  {
-    // Only the active window must set the selected item path which is shared
-    // between all PVR windows, not the last notified window (observer).
-    UpdateSelectedItemPath();
-  }
-
   CGUIMessage m(GUI_MSG_REFRESH_LIST, GetID(), 0, msg);
   CApplicationMessenger::GetInstance().SendGUIMessage(m);
 }
@@ -173,6 +166,7 @@ void CGUIWindowPVRBase::OnDeinitWindow(int nextWindowID)
 
 bool CGUIWindowPVRBase::OnMessage(CGUIMessage& message)
 {
+  bool bReturn = false;
   switch (message.GetMessage())
   {
     case GUI_MSG_CLICKED:
@@ -184,9 +178,21 @@ bool CGUIWindowPVRBase::OnMessage(CGUIMessage& message)
       }
     }
     break;
+
+    case GUI_MSG_REFRESH_LIST:
+    {
+      if (IsActive())
+      {
+        // Only the active window must set the selected item path which is shared
+        // between all PVR windows, not the last notified window (observer).
+        UpdateSelectedItemPath();
+      }
+      bReturn = true;
+    }
+    break;
   }
 
-  return CGUIMediaWindow::OnMessage(message);
+  return bReturn || CGUIMediaWindow::OnMessage(message);
 }
 
 bool CGUIWindowPVRBase::IsValidMessage(CGUIMessage& message)

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -243,13 +243,11 @@ bool CGUIWindowPVRChannels::OnMessage(CGUIMessage& message)
         case ObservableMessageCurrentItem:
         {
           SetInvalid();
-          bReturn = true;
           break;
         }
         case ObservableMessageChannelGroupReset:
         {
           Refresh(true);
-          bReturn = true;
           break;
         }
       }

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -110,13 +110,6 @@ void CGUIWindowPVRGuide::Notify(const Observable &obs, const ObservableMessage m
        msg == ObservableMessageEpgContainer ||
        msg == ObservableMessageChannelGroup))
   {
-    if (IsActive())
-    {
-      // Only the active window must set the selected item path which is shared
-      // between all PVR windows, not the last notified window (observer).
-      UpdateSelectedItemPath();
-    }
-
     CSingleLock lock(m_critSection);
     m_bRefreshTimelineItems = true;
   }
@@ -398,7 +391,6 @@ bool CGUIWindowPVRGuide::OnMessage(CGUIMessage& message)
         case ObservableMessageEpgContainer:
         {
           Refresh(true);
-          bReturn = true;
           break;
         }
         case ObservableMessageEpgActiveItem:
@@ -406,7 +398,6 @@ bool CGUIWindowPVRGuide::OnMessage(CGUIMessage& message)
           if (m_viewControl.GetCurrentControl() != GUIDE_VIEW_TIMELINE)
             SetInvalid();
 
-          bReturn = true;
           break;
         }
       }

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -303,14 +303,12 @@ bool CGUIWindowPVRRecordings::OnMessage(CGUIMessage &message)
         case ObservableMessageCurrentItem:
         {
           SetInvalid();
-          bReturn = true;
           break;
         }
         case ObservableMessageRecordings:
         case ObservableMessageTimersReset:
         {
           Refresh(true);
-          bReturn = true;
           break;
         }
       }

--- a/xbmc/pvr/windows/GUIWindowPVRTimersBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRTimersBase.cpp
@@ -232,13 +232,11 @@ bool CGUIWindowPVRTimersBase::OnMessage(CGUIMessage &message)
         case ObservableMessageCurrentItem:
         {
           SetInvalid();
-          bReturn = true;
           break;
         }
         case ObservableMessageTimersReset:
         {
           Refresh(true);
-          bReturn = true;
           break;
         }
       }


### PR DESCRIPTION
Fixes a deadlock that could happen under very special circumstances when closing pvr channel window or clicking on a channel to play it (which in fact also closes the channel window and opens the video fullscreen window).

Annotated stack traces:
- [observers-deadlock.txt](https://github.com/xbmc/xbmc/files/282593/observers-deadlock.txt)
- [observers-deadlock-2.txt](https://github.com/xbmc/xbmc/files/282596/observers-deadlock-2.txt)

Ghist of the fix is to move the gui code that needs global graphics mutex out of arbitrary thread scope  and to execute it in render thread instead (<code>CGUIWindowPVRBase::Notify</code> => <code>CGUIWindowPVRBase::OnMessage</code>).

@FernetMenta We discussed this offline. I decided to go for option 2)  I will put option 1) in my personal backlog. ;-)
