### PR TITLE
SendClick() should operate on the focused window/dialog

### DIFF
--- a/xbmc/interfaces/builtins/GUIControlBuiltins.cpp
+++ b/xbmc/interfaces/builtins/GUIControlBuiltins.cpp
@@ -52,8 +52,8 @@ static int SendClick(const std::vector<std::string>& params)
     g_windowManager.SendMessage(message);
   }
   else
-  { // single param - assume you meant the active window
-    CGUIMessage message(GUI_MSG_CLICKED, atoi(params[0].c_str()), g_windowManager.GetActiveWindow());
+  { // single param - assume you meant the focused window
+    CGUIMessage message(GUI_MSG_CLICKED, atoi(params[0].c_str()), g_windowManager.GetFocusedWindow());
     g_windowManager.SendMessage(message);
   }
 


### PR DESCRIPTION
when SendClick(controlID) is run from a dialog, the message is send to the underlying window instead of to the dialog itself. this commit fixes that.

as reported on the forum: http://forum.kodi.tv/showthread.php?tid=277216

@BigNoid / @HitcherUK / @phil65 if you can think of any possible regressions, let me know
