### PR TITLE
remove deprecated windows

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -7001,7 +7001,6 @@ msgid "Change area code 3"
 msgstr ""
 
 #: system/settings/settings.xml
-#: xbmc/music/windows/GUIWindowMusicBase.cpp
 #: xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
 #: xbmc/vide/windows/GUIWindowVideoBase.cpp
 msgctxt "#14022"
@@ -17353,12 +17352,7 @@ msgctxt "#36291"
 msgid "Auto eject disc after rip is complete."
 msgstr ""
 
-#empty strings from id 36292 to 36300
-
-#: system/settings/settings.xml
-msgctxt "#36301"
-msgid "No info available yet."
-msgstr ""
+#empty strings from id 36292 to 36301
 
 #: system/settings/settings.xml
 msgctxt "#36302"

--- a/addons/skin.estouchy/xml/Includes.xml
+++ b/addons/skin.estouchy/xml/Includes.xml
@@ -62,7 +62,7 @@
 	</variable>
 	<variable name="Breadcrumb-Icon">
 		<value condition="Window.IsVisible(Videos) | Window.IsVisible(VideoPlaylist)">icon_breadcrumb_video.png</value>
-		<value condition="Window.IsVisible(MusicLibrary) | Window.IsVisible(MusicPlaylist)">icon_breadcrumb_music.png</value>
+		<value condition="Window.IsVisible(Music) | Window.IsVisible(MusicPlaylist)">icon_breadcrumb_music.png</value>
 		<value condition="Window.IsVisible(Weather)">icon_breadcrumb_weather.png</value>
 		<value condition="Window.IsVisible(Pictures)">icon_breadcrumb_pictures.png</value>
 		<value condition="Window.IsVisible(Programs) | Window.IsVisible(AddonBrowser)">icon_breadcrumb_addons.png</value>
@@ -1127,7 +1127,7 @@
 					<itemgap>0</itemgap>
 					<include condition="Window.IsVisible(AddonBrowser)">AddonsMenu</include>
 					<include condition="Window.IsVisible(EventLog)">EventLogMenu</include>
-					<include condition="Window.IsVisible(MusicLibrary)">MusicMenu</include>
+					<include condition="Window.IsVisible(Music)">MusicMenu</include>
 					<include condition="Window.IsVisible(MusicOSD)">MusicOSDMenu</include>
 					<include condition="Window.IsVisible(MusicPlaylist)">MusicPlaylistMenu</include>
 					<include condition="Window.IsVisible(MusicPlaylistEditor)">MusicPlaylistEditorMenu</include>

--- a/addons/skin.estouchy/xml/Includes.xml
+++ b/addons/skin.estouchy/xml/Includes.xml
@@ -1135,7 +1135,7 @@
 					<include condition="Window.IsVisible(Programs)">ProgramsMenu</include>
 					<include condition="Window.IsVisible(TVChannels) | Window.IsVisible(RadioChannels) | Window.IsVisible(TVGuide) | Window.IsVisible(RadioGuide) | Window.IsVisible(TVRecordings) | Window.IsVisible(RadioRecordings) | Window.IsVisible(TVTimers) | Window.IsVisible(RadioTimers) | Window.IsVisible(TVTimerRules) | Window.IsVisible(RadioTimerRules) | Window.IsVisible(TVSearch) | Window.IsVisible(RadioSearch)">PVRMenu</include>
 					<include condition="Window.IsVisible(PicturesSettings) | Window.IsVisible(ProgramsSettings) | Window.IsVisible(WeatherSettings) | Window.IsVisible(MusicSettings) | Window.IsVisible(SystemSettings) | Window.IsVisible(VideosSettings) | Window.IsVisible(ServiceSettings) | Window.IsVisible(AppearanceSettings)">SettingsMenu</include>
-					<include condition="Window.IsVisible(VideoLibrary)">VideosMenu</include>
+					<include condition="Window.IsVisible(Videos)">VideosMenu</include>
 					<include condition="Window.IsVisible(VideoOSD)">VideoOSDMenu</include>
 					<include condition="Window.IsVisible(VideoPlaylist)">VideoPlaylistMenu</include>
 				</control>

--- a/addons/skin.estouchy/xml/IncludesHomeRecentlyAdded.xml
+++ b/addons/skin.estouchy/xml/IncludesHomeRecentlyAdded.xml
@@ -497,7 +497,7 @@
 						<item id="1">
 							<label>$INFO[Window.Property(LatestAlbum.1.Title)]</label>
 							<label2>-</label2>
-							<onclick>ActivateWindow(MusicLibrary,$INFO[Window.Property(LatestAlbum.1.Path)])</onclick>
+							<onclick>ActivateWindow(Music,$INFO[Window.Property(LatestAlbum.1.Path)])</onclick>
 							<icon>$INFO[Window.Property(LatestAlbum.1.Thumb)]</icon>
 							<thumb>-</thumb>
 							<visible>!String.IsEmpty(Window.Property(LatestAlbum.1.Title))</visible>
@@ -505,7 +505,7 @@
 						<item id="2">
 							<label>$INFO[Window.Property(LatestAlbum.2.Title)]</label>
 							<label2>-</label2>
-							<onclick>ActivateWindow(MusicLibrary,$INFO[Window.Property(LatestAlbum.2.Path)])</onclick>
+							<onclick>ActivateWindow(Music,$INFO[Window.Property(LatestAlbum.2.Path)])</onclick>
 							<icon>$INFO[Window.Property(LatestAlbum.2.Thumb)]</icon>
 							<thumb>-</thumb>
 							<visible>!String.IsEmpty(Window.Property(LatestAlbum.2.Title))</visible>
@@ -513,7 +513,7 @@
 						<item id="3">
 							<label>$INFO[Window.Property(LatestAlbum.3.Title)]</label>
 							<label2>-</label2>
-							<onclick>ActivateWindow(MusicLibrary,$INFO[Window.Property(LatestAlbum.3.Path)])</onclick>
+							<onclick>ActivateWindow(Music,$INFO[Window.Property(LatestAlbum.3.Path)])</onclick>
 							<icon>$INFO[Window.Property(LatestAlbum.3.Thumb)]</icon>
 							<thumb>-</thumb>
 							<visible>!String.IsEmpty(Window.Property(LatestAlbum.3.Title))</visible>
@@ -521,7 +521,7 @@
 						<item id="4">
 							<label>$INFO[Window.Property(LatestAlbum.4.Title)]</label>
 							<label2>-</label2>
-							<onclick>ActivateWindow(MusicLibrary,$INFO[Window.Property(LatestAlbum.4.Path)])</onclick>
+							<onclick>ActivateWindow(Music,$INFO[Window.Property(LatestAlbum.4.Path)])</onclick>
 							<icon>$INFO[Window.Property(LatestAlbum.4.Thumb)]</icon>
 							<thumb>-</thumb>
 							<visible>!String.IsEmpty(Window.Property(LatestAlbum.4.Title))</visible>
@@ -529,7 +529,7 @@
 						<item id="5">
 							<label>$INFO[Window.Property(LatestAlbum.5.Title)]</label>
 							<label2>-</label2>
-							<onclick>ActivateWindow(MusicLibrary,$INFO[Window.Property(LatestAlbum.5.Path)])</onclick>
+							<onclick>ActivateWindow(Music,$INFO[Window.Property(LatestAlbum.5.Path)])</onclick>
 							<icon>$INFO[Window.Property(LatestAlbum.5.Thumb)]</icon>
 							<thumb>-</thumb>
 							<visible>!String.IsEmpty(Window.Property(LatestAlbum.5.Title))</visible>
@@ -537,7 +537,7 @@
 						<item id="6">
 							<label>$INFO[Window.Property(LatestAlbum.6.Title)]</label>
 							<label2>-</label2>
-							<onclick>ActivateWindow(MusicLibrary,$INFO[Window.Property(LatestAlbum.6.Path)])</onclick>
+							<onclick>ActivateWindow(Music,$INFO[Window.Property(LatestAlbum.6.Path)])</onclick>
 							<icon>$INFO[Window.Property(LatestAlbum.6.Thumb)]</icon>
 							<thumb>-</thumb>
 							<visible>!String.IsEmpty(Window.Property(LatestAlbum.6.Title))</visible>
@@ -545,7 +545,7 @@
 						<item id="7">
 							<label>$INFO[Window.Property(LatestAlbum.7.Title)]</label>
 							<label2>-</label2>
-							<onclick>ActivateWindow(MusicLibrary,$INFO[Window.Property(LatestAlbum.7.Path)])</onclick>
+							<onclick>ActivateWindow(Music,$INFO[Window.Property(LatestAlbum.7.Path)])</onclick>
 							<icon>$INFO[Window.Property(LatestAlbum.7.Thumb)]</icon>
 							<thumb>-</thumb>
 							<visible>!String.IsEmpty(Window.Property(LatestAlbum.7.Title))</visible>
@@ -553,7 +553,7 @@
 						<item id="8">
 							<label>$INFO[Window.Property(LatestAlbum.8.Title)]</label>
 							<label2>-</label2>
-							<onclick>ActivateWindow(MusicLibrary,$INFO[Window.Property(LatestAlbum.8.Path)])</onclick>
+							<onclick>ActivateWindow(Music,$INFO[Window.Property(LatestAlbum.8.Path)])</onclick>
 							<icon>$INFO[Window.Property(LatestAlbum.8.Thumb)]</icon>
 							<thumb>-</thumb>
 							<visible>!String.IsEmpty(Window.Property(LatestAlbum.8.Title))</visible>
@@ -561,7 +561,7 @@
 						<item id="9">
 							<label>$INFO[Window.Property(LatestAlbum.9.Title)]</label>
 							<label2>-</label2>
-							<onclick>ActivateWindow(MusicLibrary,$INFO[Window.Property(LatestAlbum.9.Path)])</onclick>
+							<onclick>ActivateWindow(Music,$INFO[Window.Property(LatestAlbum.9.Path)])</onclick>
 							<icon>$INFO[Window.Property(LatestAlbum.9.Thumb)]</icon>
 							<thumb>-</thumb>
 							<visible>!String.IsEmpty(Window.Property(LatestAlbum.9.Title))</visible>
@@ -569,7 +569,7 @@
 						<item id="10">
 							<label>$INFO[Window.Property(LatestAlbum.10.Title)]</label>
 							<label2>-</label2>
-							<onclick>ActivateWindow(MusicLibrary,$INFO[Window.Property(LatestAlbum.10.Path)])</onclick>
+							<onclick>ActivateWindow(Music,$INFO[Window.Property(LatestAlbum.10.Path)])</onclick>
 							<icon>$INFO[Window.Property(LatestAlbum.10.Thumb)]</icon>
 							<thumb>-</thumb>
 							<visible>!String.IsEmpty(Window.Property(LatestAlbum.10.Title))</visible>
@@ -577,7 +577,7 @@
 						<item id="11">
 							<label>$INFO[Window.Property(LatestAlbum.11.Title)]</label>
 							<label2>-</label2>
-							<onclick>ActivateWindow(MusicLibrary,$INFO[Window.Property(LatestAlbum.11.Path)])</onclick>
+							<onclick>ActivateWindow(Music,$INFO[Window.Property(LatestAlbum.11.Path)])</onclick>
 							<icon>$INFO[Window.Property(LatestAlbum.11.Thumb)]</icon>
 							<thumb>-</thumb>
 							<visible>!String.IsEmpty(Window.Property(LatestAlbum.11.Title))</visible>
@@ -585,7 +585,7 @@
 						<item id="12">
 							<label>$INFO[Window.Property(LatestAlbum.12.Title)]</label>
 							<label2>-</label2>
-							<onclick>ActivateWindow(MusicLibrary,$INFO[Window.Property(LatestAlbum.12.Path)])</onclick>
+							<onclick>ActivateWindow(Music,$INFO[Window.Property(LatestAlbum.12.Path)])</onclick>
 							<icon>$INFO[Window.Property(LatestAlbum.12.Thumb)]</icon>
 							<thumb>-</thumb>
 							<visible>!String.IsEmpty(Window.Property(LatestAlbum.12.Title))</visible>

--- a/addons/skin.estuary/1080i/Includes.xml
+++ b/addons/skin.estuary/1080i/Includes.xml
@@ -1040,7 +1040,7 @@
 			</control>
 			<control type="visualisation">
 				<include>FullScreenDimensions</include>
-				<visible>Player.HasAudio + String.IsEmpty(Window(videolibrary).Property(PlayingBackgroundMedia))</visible>
+				<visible>Player.HasAudio + String.IsEmpty(Window(Videos).Property(PlayingBackgroundMedia))</visible>
 			</control>
 			<control type="group">
 				<animation effect="zoom" center="960,540" end="102,102" time="0" condition="Integer.IsGreater(System.StereoscopicMode,0)">conditional</animation>
@@ -1048,7 +1048,7 @@
 					<depth>DepthBackground</depth>
 					<include>FullScreenDimensions</include>
 					<aspectratio>scale</aspectratio>
-					<animation effect="fade" start="100" end="bg_alpha" time="0" condition="Player.HasMedia + String.IsEmpty(Window(videolibrary).Property(PlayingBackgroundMedia))">Conditional</animation>
+					<animation effect="fade" start="100" end="bg_alpha" time="0" condition="Player.HasMedia + String.IsEmpty(Window(Videos).Property(PlayingBackgroundMedia))">Conditional</animation>
 					<animation effect="fade" start="0" end="100" time="300" condition="Window.Previous(fullscreenvideo) | Window.Previous(startup)">WindowOpen</animation>
 					<texture fallback="special://skin/extras/backgrounds/SKINDEFAULT.jpg">$VAR[GlobalFanartVar]</texture>
 				</control>
@@ -1061,7 +1061,7 @@
 					<animation effect="fade" start="100" end="0" time="300">WindowClose</animation>
 					<animation effect="fade" time="400">VisibleChange</animation>
 					<texture background="true" colordiffuse="35FFFFFF">$VAR[MediaFanartVar]</texture>
-					<visible>!Player.HasMedia | !String.IsEmpty(Window(videolibrary).Property(PlayingBackgroundMedia))</visible>
+					<visible>!Player.HasMedia | !String.IsEmpty(Window(Videos).Property(PlayingBackgroundMedia))</visible>
 				</control>
 			</control>
 		</definition>
@@ -1131,13 +1131,13 @@
 						<texture colordiffuse="button_focus">frame/menu-fo.png</texture>
 						<animation effect="fade" time="200">VisibleChange</animation>
 						<visible>$EXP[sidebar_focused]</visible>
-						<visible>!Player.HasMedia | !String.IsEmpty(Window(videolibrary).Property(PlayingBackgroundMedia))</visible>
+						<visible>!Player.HasMedia | !String.IsEmpty(Window(Videos).Property(PlayingBackgroundMedia))</visible>
 					</control>
 				</control>
 				<control type="group">
 					<left>450</left>
 					<top>1005</top>
-					<visible>Player.HasMedia + String.IsEmpty(Window(videolibrary).Property(PlayingBackgroundMedia))</visible>
+					<visible>Player.HasMedia + String.IsEmpty(Window(Videos).Property(PlayingBackgroundMedia))</visible>
 					<animation effect="fade" time="200">VisibleChange</animation>
 					<control type="grouplist">
 						<orientation>horizontal</orientation>

--- a/addons/skin.estuary/1080i/View_55_WideList.xml
+++ b/addons/skin.estuary/1080i/View_55_WideList.xml
@@ -152,7 +152,7 @@
 						<texture colordiffuse="grey">$VAR[ListWatchedIconVar]</texture>
 					</control>
 				</itemlayout>
-				<include condition="Window.IsActive(musiclibrary) | Window.IsActive(musicfiles)">SongsListLayout</include>
+				<include condition="Window.IsActive(music)">SongsListLayout</include>
 				<include>AddonsListLayout</include>
 			</control>
 		</control>

--- a/system/keymaps/appcommand.xml
+++ b/system/keymaps/appcommand.xml
@@ -17,9 +17,9 @@
       <stop>Stop</stop>
       <play_pause>PlayPause</play_pause>
       <launch_mail/>
-      <launch_media_select>ActivateWindow(MyMusic)</launch_media_select>
-      <launch_app1>ActivateWindow(MyPrograms)</launch_app1>
-      <launch_app2>ActivateWindow(MyPrograms)</launch_app2>
+      <launch_media_select>ActivateWindow(Music)</launch_media_select>
+      <launch_app1>ActivateWindow(Programs)</launch_app1>
+      <launch_app2>ActivateWindow(Programs)</launch_app2>
       <play>Play</play>
       <pause>Pause</pause>
       <fastforward>FastForward</fastforward>

--- a/system/keymaps/customcontroller.AppleRemote.xml
+++ b/system/keymaps/customcontroller.AppleRemote.xml
@@ -8,18 +8,18 @@
 
 <!-- The format is:                                                                              -->
 <!--    <device>                                                                                 -->
-<!--      <button id=""#>xbmc action</button>
+<!--      <button id=""#>xbmc action</button>                                                    -->
 <!--    </device>                                                                                -->
 
 <!-- To map keys from other remotes using the RCA protocol, you may add <customcontroller name="AppleRemote"> blocks -->
 <!-- In this case, the tags used are <button id=""#> where # is the original button code (OBC) of the key -->
 <!-- You set it up by adding a <customcontroller name="AppleRemote"> block to the window or <global> section:        -->
 <!--    <customcontroller name="AppleRemote">                                                                        -->
-<!--       <button id="45">Stop</button>
+<!--       <button id="45">Stop</button>                                                          -->
 <!--    </customcontroller>                                                                       -->
 
 <!-- Note that the action can be a built-in function.                                            -->
-<!--            eg <button id="6">ActivateWindow(Favourites)</button>
+<!--            eg <button id="6">ActivateWindow(Favourites)</button>                            -->
 <!-- would bring up Favourites when the button with the id of 6 is press. In this case, "Menu"   -->
 
 <!--                                                                                             -->
@@ -177,16 +177,11 @@
       <button id="8"/>
     </customcontroller>
   </VideoMenu>
-  <MyVideoLibrary>
+  <Videos>
     <customcontroller name="AppleRemote">
       <button id="7">Info</button>
     </customcontroller>
-  </MyVideoLibrary>
-  <MyVideoFiles>
-    <customcontroller name="AppleRemote">
-      <button id="7">Info</button>
-    </customcontroller>
-  </MyVideoFiles>
+  </Videos>
   <PictureInfo>
     <customcontroller name="AppleRemote">
       <button id="3">Left</button>

--- a/system/keymaps/customcontroller.Harmony.xml
+++ b/system/keymaps/customcontroller.Harmony.xml
@@ -15,11 +15,11 @@
 <!-- In this case, the tags used are <button id=""#> where # is the original button code (OBC) of the key -->
 <!-- You set it up by adding a <customcontroller name="Harmony"> block to the window or <global> section:       -->
 <!--    <customcontroller name="Harmony">             -->
-<!--       <button id="45">Stop</button>
+<!--       <button id="45">Stop</button>            -->
 <!--    </customcontroller>            -->
 
 <!-- Note that the action can be a built-in function.                 -->
-<!--  eg <B>ActivateWindow(MyMusic)</B>                         -->
+<!--  eg <B>ActivateWindow(Music)</B>                         -->
 <!-- would automatically go to My Music on the press of the B button. -->
 
 <!-- Joysticks / Gamepads:                                                                    -->
@@ -85,17 +85,17 @@
       <!-- Mute		-->      <button id="125">Mute</button>
       <!-- Aspect	-->      <button id="161">AspectRatio</button>
       <!-- F1		-->      <button id="153">ActivateWindow(Music)</button>
-      <!-- F3		-->      <button id="155">ActivateWindow(videolibrary,tvshowtitles,return)</button>
-      <!-- F2		-->      <button id="154">ActivateWindow(videolibrary,movietitles,return)</button>
+      <!-- F3		-->      <button id="155">ActivateWindow(Videos,tvshowtitles,return)</button>
+      <!-- F2		-->      <button id="154">ActivateWindow(Videos,movietitles,return)</button>
       <!-- F4		-->      <button id="156">ActivateWindow(Weather)</button>
       <!-- F5			-->  <button id="193">OSD</button>
       <!-- F7			-->  <button id="195">ActivateWindow(Home)</button>
-      <!-- F6			-->  <button id="194">ActivateWindow(Scripts)</button>
+      <!-- F6			-->  <button id="194">ActivateWindow(Programs)</button>
       <!-- F8			-->  <button id="196">ActivateWindow(favourites)</button>
       <!-- F9			-->  <button id="173">ShowVideoMenu</button>
       <!-- F10			-->  <button id="174">ShowSubtitles</button>
       <!-- F11			-->  <button id="175">NextSubtitle</button>
-      <!-- F12			-->  <button id="176">ActivateWindow(VideoFiles)</button>
+      <!-- F12			-->  <button id="176">ActivateWindow(Videos)</button>
       <!-- F13			-->  <button id="163">Playlist</button>
       <!-- F14			-->  <button id="164">AudioNextLanguage</button>
       <!-- Large Down	-->  <button id="182">PageDown</button>
@@ -118,14 +118,14 @@
       <!-- 1 		-->      <button id="111">ToggleFullScreen</button>
     </customcontroller>
   </Home>
-  <MyFiles>
+  <FileManager>
     <customcontroller name="Harmony">
       <!-- 1 		-->      <button id="111">Highlight</button>
       <!-- 4 		-->      <button id="114">Copy</button>
       <!-- 7 		-->      <button id="133">Move</button>
       <!-- * clear 	-->      <button id="145">Delete</button>
     </customcontroller>
-  </MyFiles>
+  </FileManager>
   <MyMusicPlaylist>
     <customcontroller name="Harmony">
       <!-- * clear 	-->      <button id="145">Delete</button>
@@ -133,21 +133,7 @@
       <!-- Channel Down -->      <button id="172">MoveItemDown</button>
     </customcontroller>
   </MyMusicPlaylist>
-  <MyMusicFiles>
-    <customcontroller name="Harmony">
-      <!-- * clear 	-->      <button id="145">Delete</button>
-      <!-- 1 		-->      <button id="111">number1</button>
-      <!-- 2 		-->      <button id="112">JumpSMS2</button>
-      <!-- 3 		-->      <button id="113">JumpSMS3</button>
-      <!-- 4 		-->      <button id="114">JumpSMS4</button>
-      <!-- 5 		-->      <button id="123">JumpSMS5</button>
-      <!-- 6 		-->      <button id="124">JumpSMS6</button>
-      <!-- 7 		-->      <button id="133">JumpSMS7</button>
-      <!-- 8 		-->      <button id="134">JumpSMS8</button>
-      <!-- 9 		-->      <button id="143">JumpSMS9</button>
-    </customcontroller>
-  </MyMusicFiles>
-  <MyMusicLibrary>
+  <Music>
     <customcontroller name="Harmony">
       <!-- 1 		-->      <button id="111">number1</button>
       <!-- 2 		-->      <button id="112">JumpSMS2</button>
@@ -159,7 +145,7 @@
       <!-- 8 		-->      <button id="134">JumpSMS8</button>
       <!-- 9 		-->      <button id="143">JumpSMS9</button>
     </customcontroller>
-  </MyMusicLibrary>
+  </Music>
   <FullscreenVideo>
     <customcontroller name="Harmony">
       <!-- up       	-->      <button id="101">ChapterOrBigStepForward</button>
@@ -209,7 +195,7 @@
       <!-- Prev		-->      <button id="132">LockPreset</button>
       <!-- Info  	-->      <button id="131">Info</button>
       <!-- F8		-->      <button id="196">ActivateWindow(VisualisationPresetList)</button>
-      <!-- F9		-->      <button id="173">ActivateWindow(VisualisationSettings)</button>
+      <!-- F9		-->      <button id="173">ActivateWindow(AddonSettings)</button>
     </customcontroller>
   </Visualisation>
   <MusicOSD>
@@ -218,11 +204,11 @@
       <!-- Info  	-->      <button id="131">CodecInfo</button>
     </customcontroller>
   </MusicOSD>
-  <VisualisationSettings>
+  <AddonSettings>
     <customcontroller name="Harmony">
       <!-- menu       	-->      <button id="106">Back</button>
     </customcontroller>
-  </VisualisationSettings>
+  </AddonSettings>
   <VisualisationPresetList>
     <customcontroller name="Harmony">
       <!-- menu       	-->      <button id="106">Back</button>
@@ -254,13 +240,13 @@
       <!-- Guide  	-->      <button id="165">NextResolution</button>
     </customcontroller>
   </ScreenCalibration>
-  <GUICalibration>
+  <ScreenCalibration>
     <customcontroller name="Harmony">
       <!-- OK		-->      <button id="105">NextCalibration</button>
       <!-- 0 		-->      <button id="144">ResetCalibration</button>
       <!-- # enter 	-->      <button id="136">NextCalibration</button>
     </customcontroller>
-  </GUICalibration>
+  </ScreenCalibration>
   <VideoOSD>
     <customcontroller name="Harmony">
       <!-- menu       	-->      <button id="106">Back</button>
@@ -288,7 +274,7 @@
       <!-- * clear 	-->      <button id="145">Delete</button>
     </customcontroller>
   </VideoBookmarks>
-  <MyVideoLibrary>
+  <Videos>
     <customcontroller name="Harmony">
       <!-- * clear 	-->      <button id="145">Delete</button>
       <!-- # enter 	-->      <button id="136">ToggleWatched</button>
@@ -302,21 +288,7 @@
       <!-- 8 		-->      <button id="134">JumpSMS8</button>
       <!-- 9 		-->      <button id="143">JumpSMS9</button>
     </customcontroller>
-  </MyVideoLibrary>
-  <MyVideoFiles>
-    <customcontroller name="Harmony">
-      <!-- * clear 	-->      <button id="145">Delete</button>
-      <!-- 1 		-->      <button id="111">number1</button>
-      <!-- 2 		-->      <button id="112">JumpSMS2</button>
-      <!-- 3 		-->      <button id="113">JumpSMS3</button>
-      <!-- 4 		-->      <button id="114">JumpSMS4</button>
-      <!-- 5 		-->      <button id="123">JumpSMS5</button>
-      <!-- 6 		-->      <button id="124">JumpSMS6</button>
-      <!-- 7 		-->      <button id="133">JumpSMS7</button>
-      <!-- 8 		-->      <button id="134">JumpSMS8</button>
-      <!-- 9 		-->      <button id="143">JumpSMS9</button>
-    </customcontroller>
-  </MyVideoFiles>
+  </Videos>
   <MyVideoPlaylist>
     <customcontroller name="Harmony">
       <!-- * clear 	-->      <button id="145">Delete</button>
@@ -343,11 +315,11 @@
       <!-- Fwd  	-->      <button id="142">CursorRight</button>
     </customcontroller>
   </VirtualKeyboard>
-  <Scripts>
+  <Programs>
     <customcontroller name="Harmony">
       <!-- Info  	-->      <button id="131">info</button>
     </customcontroller>
-  </Scripts>
+  </Programs>
   <NumericInput>
     <customcontroller name="Harmony">
       <!-- 1 		-->      <button id="111">Number1</button>

--- a/system/keymaps/gamepad.xml
+++ b/system/keymaps/gamepad.xml
@@ -19,7 +19,7 @@
 <!--    </universalremote>            -->
 
 <!-- Note that the action can be a built-in function.                                         -->
-<!--  eg <B>ActivateWindow(MyMusic)</B>                                                       -->
+<!--  eg <B>ActivateWindow(Music)</B>                                                       -->
 <!-- would automatically go to My Music on the press of the B button.                         -->
 <!-- An empty action removes the corresponding mapping from the default keymap                -->
 
@@ -61,16 +61,11 @@
       <rightthumbstickdown>VolumeDown</rightthumbstickdown>
     </gamepad>
   </global>
-  <Home>
-    <gamepad>
-      <black>Skin.ToggleSetting(HomeViewToggle)</black>
-    </gamepad>
-  </Home>
-  <MyFiles>
+  <FileManager>
     <gamepad>
       <Y>Highlight</Y>
     </gamepad>
-  </MyFiles>
+  </FileManager>
   <MyMusicPlaylist>
     <gamepad>
       <Y>Delete</Y>
@@ -82,18 +77,12 @@
       <Y>Queue</Y>
     </gamepad>
   </MyMusicPlaylistEditor>
-  <MyMusicFiles>
+  <Music>
     <gamepad>
       <Y>Queue</Y>
       <black>Playlist</black>
     </gamepad>
-  </MyMusicFiles>
-  <MyMusicLibrary>
-    <gamepad>
-      <Y>Queue</Y>
-      <black>Playlist</black>
-    </gamepad>
-  </MyMusicLibrary>
+  </Music>
   <FullscreenVideo>
     <gamepad>
       <A>Pause</A>
@@ -167,13 +156,13 @@
       <rightanalogtrigger>AnalogFastForward</rightanalogtrigger>
     </gamepad>
   </MusicOSD>
-  <VisualisationSettings>
+  <AddonSettings>
     <gamepad>
       <start>Back</start>
       <leftanalogtrigger>AnalogRewind</leftanalogtrigger>
       <rightanalogtrigger>AnalogFastForward</rightanalogtrigger>
     </gamepad>
-  </VisualisationSettings>
+  </AddonSettings>
   <VisualisationPresetList>
     <gamepad>
       <start>Back</start>
@@ -208,13 +197,13 @@
       <white>NextResolution</white>
     </gamepad>
   </ScreenCalibration>
-  <GUICalibration>
+  <ScreenCalibration>
     <gamepad>
       <leftthumbstick>AnalogMove</leftthumbstick>
       <A>NextCalibration</A>
       <black>ResetCalibration</black>
     </gamepad>
-  </GUICalibration>
+  </ScreenCalibration>
   <VideoOSD>
     <gamepad>
       <start>Back</start>
@@ -266,17 +255,11 @@
       <rightanalogtrigger>AnalogFastForward</rightanalogtrigger>
     </gamepad>
   </VideoBookmarks>
-  <MyVideoLibrary>
+  <Videos>
     <gamepad>
       <black>Delete</black>
     </gamepad>
-  </MyVideoLibrary>
-  <MyVideoFiles>
-    <gamepad>
-      <Y>Queue</Y>
-      <black>Playlist</black>
-    </gamepad>
-  </MyVideoFiles>
+  </Videos>
   <MyVideoPlaylist>
     <gamepad>
       <Y>Delete</Y>
@@ -298,11 +281,11 @@
       <white>Back</white>
     </gamepad>
   </ContextMenu>
-  <Scripts>
+  <Programs>
     <gamepad>
       <black>info</black>
     </gamepad>
-  </Scripts>
+  </Programs>
   <NumericInput>
     <gamepad>
       <B>BackSpace</B>

--- a/system/keymaps/joystick.xml
+++ b/system/keymaps/joystick.xml
@@ -29,25 +29,18 @@
       <rightstickdown>VolumeDown</rightstickdown>
     </joystick>
   </global>
-  <Home>
-    <joystick>
-      <start>Skin.ToggleSetting(HomeViewToggle)</start>
-    </joystick>
-  </Home>
-  <MyFiles>
+  <FileManager>
     <joystick>
       <rightbumper>Highlight</rightbumper>
     </joystick>
-  </MyFiles>
+  </FileManager>
   <MyMusicPlaylist>
     <joystick>
       <leftbumper>Delete</leftbumper>
     </joystick>
   </MyMusicPlaylist>
-  <MyMusicFiles>
-  </MyMusicFiles>
-  <MyMusicLibrary>
-  </MyMusicLibrary>
+  <Music>
+  </Music>
   <FullscreenVideo>
     <joystick>
       <a>Pause</a>
@@ -115,7 +108,7 @@
     <joystick>
       <a>Pause</a>
       <b>Stop</b>
-      <x>ActivateWindow(VisualisationSettings)</x>
+      <x>ActivateWindow(AddonSettings)</x>
       <y>ActivateWindow(VisualisationPresetList)</y>
       <start>Info</start>
       <rightthumb>ActivateWindow(MusicOSD)</rightthumb>
@@ -137,11 +130,6 @@
       <start>Info</start>
     </joystick>
   </MusicOSD>
-  <VisualisationSettings>
-    <joystick>
-      <b>Close</b>
-    </joystick>
-  </VisualisationSettings>
   <VisualisationPresetList>
     <joystick>
       <b>Close</b>
@@ -173,13 +161,13 @@
       <rightbumper>NextCalibration</rightbumper>
     </joystick>
   </ScreenCalibration>
-  <GUICalibration>
+  <ScreenCalibration>
     <joystick>
       <x>ResetCalibration</x>
       <leftbumper>NextResolution</leftbumper>
       <rightbumper>NextCalibration</rightbumper>
     </joystick>
-  </GUICalibration>
+  </ScreenCalibration>
   <VideoOSD>
     <joystick>
       <b>Close</b>
@@ -210,10 +198,8 @@
       <leftbumper>Delete</leftbumper>
     </joystick>
   </VideoBookmarks>
-  <MyVideoLibrary>
-  </MyVideoLibrary>
-  <MyVideoFiles>
-  </MyVideoFiles>
+  <Videos>
+  </Videos>
   <MyVideoPlaylist>
     <joystick>
       <leftbumper>Delete</leftbumper>
@@ -234,11 +220,11 @@
       <b>Close</b>
     </joystick>
   </ContextMenu>
-  <Scripts>
+  <Programs>
     <joystick>
       <x>ContextMenu</x>
     </joystick>
-  </Scripts>
+  </Programs>
   <Settings>
     <joystick>
       <b>PreviousMenu</b>

--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -12,7 +12,7 @@
 <!-- not used in the current window's section.                                            -->
 <!--                                                                                      -->
 <!-- Actions can be built-in functions.                                                   -->
-<!--  eg <B>ActivateWindow(MyMusic)</B>                                                   -->
+<!--  eg <B>ActivateWindow(Music)</B>                                                   -->
 <!-- would automatically go to Music on the press of the B button.                        -->
 <!--                                                                                      -->
 <!--  Long presses                                                                        -->
@@ -102,9 +102,9 @@
       <b>ActivateWindow(TVTimers)</b>
       <!-- PVR -->
       <red>ActivateWindow(TVChannels)</red>
-      <green>ActivateWindow(MyVideos)</green>
-      <yellow>ActivateWindow(MyMusic)</yellow>
-      <blue>ActivateWindow(MyPictures)</blue>
+      <green>ActivateWindow(Videos)</green>
+      <yellow>ActivateWindow(Music)</yellow>
+      <blue>ActivateWindow(Pictures)</blue>
       <!-- Multimedia keyboard keys -->
       <browser_back>Back</browser_back>
       <browser_forward/>
@@ -127,9 +127,9 @@
       <rewind>Rewind</rewind>
       <record/>
       <launch_mail></launch_mail>
-      <launch_media_select>ActivateWindow(MyMusic)</launch_media_select>
-      <launch_app1_pc_icon>ActivateWindow(MyPrograms)</launch_app1_pc_icon>
-      <launch_app2_pc_icon>ActivateWindow(MyPrograms)</launch_app2_pc_icon>
+      <launch_media_select>ActivateWindow(Music)</launch_media_select>
+      <launch_app1_pc_icon>ActivateWindow(Programs)</launch_app1_pc_icon>
+      <launch_app2_pc_icon>ActivateWindow(Programs)</launch_app2_pc_icon>
       <launch_file_browser/>
       <launch_media_center/>
       <!-- ****************************************************** -->
@@ -257,7 +257,7 @@
       <t>ShowTimerRule</t>
     </keyboard>
   </RadioGuide>
-  <MyFiles>
+  <FileManager>
     <keyboard>
       <space>Highlight</space>
       <delete>Delete</delete>
@@ -266,7 +266,7 @@
       <play_pause mod="longpress">Highlight</play_pause>
       <backspace mod="longpress">ActivateWindow(Home)</backspace>
     </keyboard>
-  </MyFiles>
+  </FileManager>
   <MyMusicPlaylist>
     <keyboard>
       <n>Back</n>
@@ -284,21 +284,13 @@
       <backspace mod="longpress">ActivateWindow(Home)</backspace>
     </keyboard>
   </MyMusicPlaylistEditor>
-  <MyMusicFiles>
-    <keyboard>
-      <n>Playlist</n>
-      <q>Queue</q>
-      <delete>Delete</delete>
-      <backspace mod="longpress">ActivateWindow(Home)</backspace>
-    </keyboard>
-  </MyMusicFiles>
-  <MyMusicLibrary>
+  <Music>
     <keyboard>
       <n>Playlist</n>
       <q>Queue</q>
       <backspace mod="longpress">ActivateWindow(Home)</backspace>
     </keyboard>
-  </MyMusicLibrary>
+  </Music>
   <FullscreenVideo>
     <keyboard>
       <f>FastForward</f>
@@ -411,21 +403,6 @@
       <n>ActivateWindow(MusicPlaylist)</n>
     </keyboard>
   </MusicOSD>
-  <VisualisationSettings>
-    <keyboard>
-      <f>FastForward</f>
-      <r>Rewind</r>
-      <period>SkipNext</period>
-      <comma>SkipPrevious</comma>
-      <m>Back</m>
-      <i>Info</i>
-      <o>CodecInfo</o>
-      <p>ActivateWindow(VisualisationPresetList)</p>
-      <v>Back</v>
-      <text>Back</text>
-      <n>ActivateWindow(MusicPlaylist)</n>
-    </keyboard>
-  </VisualisationSettings>
   <VisualisationPresetList>
     <keyboard>
       <f>FastForward</f>
@@ -473,13 +450,13 @@
       <r>NextResolution</r>
     </keyboard>
   </ScreenCalibration>
-  <GUICalibration>
+  <ScreenCalibration>
     <keyboard>
       <return>NextCalibration</return>
       <enter>NextCalibration</enter>
       <d>ResetCalibration</d>
     </keyboard>
-  </GUICalibration>
+  </ScreenCalibration>
   <VideoOSD>
     <keyboard>
       <m>Back</m>
@@ -526,22 +503,14 @@
       <delete>Delete</delete>
     </keyboard>
   </VideoBookmarks>
-  <MyVideoLibrary>
+  <Videos>
     <keyboard>
       <delete>Delete</delete>
       <n>Playlist</n>
       <w>ToggleWatched</w>
       <backspace mod="longpress">ActivateWindow(Home)</backspace>
     </keyboard>
-  </MyVideoLibrary>
-  <MyVideoFiles>
-    <keyboard>
-      <n>Playlist</n>
-      <q>Queue</q>
-      <w>ToggleWatched</w>
-      <backspace mod="longpress">ActivateWindow(Home)</backspace>
-    </keyboard>
-  </MyVideoFiles>
+  </Videos>
   <MyVideoPlaylist>
     <keyboard>
       <n>Back</n>
@@ -655,12 +624,12 @@
       <browser_back>Close</browser_back>
     </keyboard>
   </PVROSDGuide>
-  <MyTVSettings>
+  <PVRSettings>
     <keyboard>
       <backspace>PreviousMenu</backspace>
       <browser_back>PreviousMenu</browser_back>
     </keyboard>
-  </MyTVSettings>
+  </PVRSettings>
   <FileBrowser>
     <keyboard>
       <space>Highlight</space>

--- a/system/keymaps/remote.xml
+++ b/system/keymaps/remote.xml
@@ -19,7 +19,7 @@
 <!--    </universalremote>            -->
 
 <!-- Note that the action can be a built-in function.                                         -->
-<!--  eg <B>ActivateWindow(MyMusic)</B>                                                       -->
+<!--  eg <B>ActivateWindow(Music)</B>                                                       -->
 <!-- would automatically go to My Music on the press of the B button.                         -->
 <!-- An empty action removes the corresponding mapping from the default keymap                -->
 
@@ -73,9 +73,9 @@
       <volumeminus>VolumeDown</volumeminus>
       <mute>Mute</mute>
       <power>ShutDown()</power>
-      <myvideo>ActivateWindow(MyVideos)</myvideo>
-      <mymusic>ActivateWindow(MyMusic)</mymusic>
-      <mypictures>ActivateWindow(MyPictures)</mypictures>
+      <myvideo>ActivateWindow(Videos)</myvideo>
+      <mymusic>ActivateWindow(Music)</mymusic>
+      <mypictures>ActivateWindow(Pictures)</mypictures>
       <mytv>ActivateWindow(Videos,TvShows)</mytv>
       <guide>ActivateWindow(TVGuide)</guide>
       <livetv>ActivateWindow(TVChannels)</livetv>
@@ -83,9 +83,9 @@
       <recordedtv>ActivateWindow(TVRecordings)</recordedtv>
       <epgsearch>ActivateWindow(TVSearch)</epgsearch>
       <red>ActivateWindow(TVChannels)</red>
-      <green>ActivateWindow(MyVideos)</green>
-      <yellow>ActivateWindow(MyMusic)</yellow>
-      <blue>ActivateWindow(MyPictures)</blue>
+      <green>ActivateWindow(Videos)</green>
+      <yellow>ActivateWindow(Music)</yellow>
+      <blue>ActivateWindow(Pictures)</blue>
       <zero>Number0</zero>
       <one>Number1</one>
       <two>JumpSMS2</two>
@@ -142,14 +142,14 @@
       <blue>Blue</blue>
     </remote>
   </MyRadioTimers>
-  <MyFiles>
+  <FileManager>
     <remote>
       <clear>Delete</clear>
       <zero>Highlight</zero>
       <star>Move</star>
       <hash>Rename</hash>
     </remote>
-  </MyFiles>
+  </FileManager>
   <MyMusicPlaylist>
     <remote>
       <clear>Delete</clear>
@@ -161,18 +161,12 @@
       <zero>Queue</zero>
     </remote>
   </MyMusicPlaylistEditor>
-  <MyMusicFiles>
+  <Music>
     <remote>
       <zero>Queue</zero>
       <star>Queue</star>
     </remote>
-  </MyMusicFiles>
-  <MyMusicLibrary>
-    <remote>
-      <zero>Queue</zero>
-      <star>Queue</star>
-    </remote>
-  </MyMusicLibrary>
+  </Music>
   <MyPictures>
     <remote>
       <clear>Delete</clear>
@@ -264,13 +258,6 @@
       <info>CodecInfo</info>
     </remote>
   </MusicOSD>
-  <VisualisationSettings>
-    <remote>
-      <menu>Back</menu>
-      <contentsmenu>Back</contentsmenu>
-      <rootmenu>Back</rootmenu>
-    </remote>
-  </VisualisationSettings>
   <VisualisationPresetList>
     <remote>
       <menu>Back</menu>
@@ -305,12 +292,12 @@
       <xbox>NextResolution</xbox>
     </remote>
   </ScreenCalibration>
-  <GUICalibration>
+  <ScreenCalibration>
     <remote>
       <select>NextCalibration</select>
       <zero>ResetCalibration</zero>
     </remote>
-  </GUICalibration>
+  </ScreenCalibration>
   <VideoOSD>
     <remote>
       <menu>Back</menu>
@@ -366,18 +353,12 @@
       <zero>Delete</zero>
     </remote>
   </VideoBookmarks>
-  <MyVideoLibrary>
+  <Videos>
     <remote>
       <zero>Queue</zero>
       <clear>Delete</clear>
     </remote>
-  </MyVideoLibrary>
-  <MyVideoFiles>
-    <remote>
-      <zero>Queue</zero>
-      <star>Queue</star>
-    </remote>
-  </MyVideoFiles>
+  </Videos>
   <MyVideoPlaylist>
     <remote>
       <clear>Delete</clear>
@@ -409,11 +390,11 @@
       <title>Back</title>
     </remote>
   </ContextMenu>
-  <Scripts>
+  <Programs>
     <remote>
       <info>info</info>
     </remote>
-  </Scripts>
+  </Programs>
   <NumericInput>
     <remote>
       <zero>Number0</zero>
@@ -474,11 +455,11 @@
       <back>PreviousMenu</back>
     </remote>
   </SystemSettings>
-  <NetworkSettings>
+  <ServiceSettings>
     <remote>
       <back>PreviousMenu</back>
     </remote>
-  </NetworkSettings>
+  </ServiceSettings>
   <InterfaceSettings>
     <remote>
       <back>PreviousMenu</back>
@@ -680,16 +661,11 @@
       <nine>number9</nine>
     </remote>
   </RadioGuide>
-  <MyTVSettings>
+  <PVRSettings>
     <remote>
       <back>PreviousMenu</back>
     </remote>
-  </MyTVSettings>
-  <AddonSettings>
-    <remote>
-      <clear>Delete</clear>
-    </remote>
-  </AddonSettings>
+  </PVRSettings>
   <Addon>
     <remote>
       <red>Red</red>

--- a/system/keymaps/touchscreen.xml
+++ b/system/keymaps/touchscreen.xml
@@ -15,13 +15,13 @@
       <swipe direction="down" pointers="3">ActivateWindow(PlayerControls)</swipe>
     </touch>
   </global>
-  <MyFiles>
+  <FileManager>
     <touch>
       <tap>Select</tap>
       <swipe direction="left">Highlight</swipe>
       <swipe direction="right">Highlight</swipe>
     </touch>
-  </MyFiles>
+  </FileManager>
   <FullScreenVideo>
     <touch>
       <swipe direction="left">StepBack</swipe>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1103,10 +1103,6 @@
     </category>
     <category id="mymusic" label="0" help="0">
       <group id="1">
-        <setting id="mymusic.startwindow" type="integer" label="0" help="36301">
-          <level>4</level>
-          <default>10501</default> <!-- WINDOW_MUSIC_FILES -->
-        </setting>
         <setting id="mymusic.songthumbinvis" type="boolean" label="0" help="36302">
           <level>4</level>
           <default>false</default>

--- a/xbmc/AutoSwitch.cpp
+++ b/xbmc/AutoSwitch.cpp
@@ -48,13 +48,6 @@ int CAutoSwitch::GetView(const CFileItemList &vecItems)
 
   switch (iCurrentWindow)
   {
-  case WINDOW_MUSIC_FILES:
-    {
-      iSortMethod = METHOD_BYFOLDERTHUMBS;
-      iPercent = 50;
-    }
-    break;
-
   case WINDOW_PICTURES:
     {
       iSortMethod = METHOD_BYFILECOUNT;

--- a/xbmc/AutoSwitch.cpp
+++ b/xbmc/AutoSwitch.cpp
@@ -55,13 +55,6 @@ int CAutoSwitch::GetView(const CFileItemList &vecItems)
     }
     break;
 
-  case WINDOW_VIDEO_FILES:
-    {
-      iSortMethod = METHOD_BYTHUMBPERCENT;
-      iPercent = 50;  // 50% of thumbs -> use thumbs.
-    }
-    break;
-
   case WINDOW_PICTURES:
     {
       iSortMethod = METHOD_BYFILECOUNT;

--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -399,9 +399,8 @@ bool CAutorun::RunDisc(IDirectory* pDir, const std::string& strDrive, int& nAdde
         if (!bypassSettings)
           return false;
 
-        if (g_windowManager.GetActiveWindow() != WINDOW_VIDEO_FILES)
-          if (!g_passwordManager.IsMasterLockUnlocked(true))
-            return false;
+        if (!g_passwordManager.IsMasterLockUnlocked(true))
+          return false;
       }
       g_playlistPlayer.ClearPlaylist(PLAYLIST_VIDEO);
       g_playlistPlayer.Add(PLAYLIST_VIDEO, itemlist);

--- a/xbmc/GUIPassword.cpp
+++ b/xbmc/GUIPassword.cpp
@@ -373,13 +373,9 @@ bool CGUIPassword::CheckMenuLock(int iWindowID)
       iSwitch = WINDOW_SETTINGS_MENU;
   }
 
-  if (iWindowID == WINDOW_MUSIC_FILES)
-    if (g_windowManager.GetActiveWindow() == WINDOW_MUSIC_NAV)
-      iSwitch = WINDOW_HOME;
-
   if (iWindowID == WINDOW_MUSIC_NAV)
     if (g_windowManager.GetActiveWindow() == WINDOW_HOME)
-      iSwitch = WINDOW_MUSIC_FILES;
+      iSwitch = WINDOW_MUSIC_NAV;
 
   if (iWindowID == WINDOW_VIDEO_NAV)
     if (g_windowManager.GetActiveWindow() == WINDOW_HOME)
@@ -399,7 +395,7 @@ bool CGUIPassword::CheckMenuLock(int iWindowID)
     case WINDOW_PROGRAMS:       // Programs
       bCheckPW = CProfilesManager::GetInstance().GetCurrentProfile().programsLocked();
       break;
-    case WINDOW_MUSIC_FILES:    // Music
+    case WINDOW_MUSIC_NAV:      // Music
       bCheckPW = CProfilesManager::GetInstance().GetCurrentProfile().musicLocked();
       break;
     case WINDOW_VIDEO_NAV:      // Video

--- a/xbmc/GUIPassword.cpp
+++ b/xbmc/GUIPassword.cpp
@@ -383,11 +383,7 @@ bool CGUIPassword::CheckMenuLock(int iWindowID)
 
   if (iWindowID == WINDOW_VIDEO_NAV)
     if (g_windowManager.GetActiveWindow() == WINDOW_HOME)
-      iSwitch = WINDOW_VIDEO_FILES;
-
-  if (iWindowID == WINDOW_VIDEO_FILES)
-    if (g_windowManager.GetActiveWindow() == WINDOW_VIDEO_NAV)
-      iSwitch = WINDOW_HOME;
+      iSwitch = WINDOW_VIDEO_NAV;
 
   switch (iSwitch)
   {
@@ -406,7 +402,7 @@ bool CGUIPassword::CheckMenuLock(int iWindowID)
     case WINDOW_MUSIC_FILES:    // Music
       bCheckPW = CProfilesManager::GetInstance().GetCurrentProfile().musicLocked();
       break;
-    case WINDOW_VIDEO_FILES:    // Video
+    case WINDOW_VIDEO_NAV:      // Video
       bCheckPW = CProfilesManager::GetInstance().GetCurrentProfile().videoLocked();
       break;
     case WINDOW_PICTURES:       // Pictures

--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -311,7 +311,7 @@ bool CSkinInfo::LoadStartupWindows(const cp_extension_t *ext)
   m_startupWindows.emplace_back(WINDOW_RADIO_CHANNELS, "19183");
   m_startupWindows.emplace_back(WINDOW_PROGRAMS, "0");
   m_startupWindows.emplace_back(WINDOW_PICTURES, "1");
-  m_startupWindows.emplace_back(WINDOW_MUSIC, "2");
+  m_startupWindows.emplace_back(WINDOW_MUSIC_NAV, "2");
   m_startupWindows.emplace_back(WINDOW_VIDEO_NAV, "3");
   m_startupWindows.emplace_back(WINDOW_FILES, "7");
   m_startupWindows.emplace_back(WINDOW_SETTINGS_MENU, "5");

--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -312,7 +312,7 @@ bool CSkinInfo::LoadStartupWindows(const cp_extension_t *ext)
   m_startupWindows.emplace_back(WINDOW_PROGRAMS, "0");
   m_startupWindows.emplace_back(WINDOW_PICTURES, "1");
   m_startupWindows.emplace_back(WINDOW_MUSIC, "2");
-  m_startupWindows.emplace_back(WINDOW_VIDEOS, "3");
+  m_startupWindows.emplace_back(WINDOW_VIDEO_NAV, "3");
   m_startupWindows.emplace_back(WINDOW_FILES, "7");
   m_startupWindows.emplace_back(WINDOW_SETTINGS_MENU, "5");
   m_startupWindows.emplace_back(WINDOW_WEATHER, "8");

--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -621,7 +621,7 @@ void CGUIDialogContextMenu::SwitchMedia(const std::string& strType, const std::s
   // create menu
   CContextButtons choices;
   if (strType != "music")
-    choices.Add(WINDOW_MUSIC_FILES, 2);
+    choices.Add(WINDOW_MUSIC_NAV, 2);
   if (strType != "video")
     choices.Add(WINDOW_VIDEO_NAV, 3);
   if (strType != "pictures")

--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -623,7 +623,7 @@ void CGUIDialogContextMenu::SwitchMedia(const std::string& strType, const std::s
   if (strType != "music")
     choices.Add(WINDOW_MUSIC_FILES, 2);
   if (strType != "video")
-    choices.Add(WINDOW_VIDEO_FILES, 3);
+    choices.Add(WINDOW_VIDEO_NAV, 3);
   if (strType != "pictures")
     choices.Add(WINDOW_PICTURES, 1);
   if (strType != "files")

--- a/xbmc/events/MediaLibraryEvent.cpp
+++ b/xbmc/events/MediaLibraryEvent.cpp
@@ -111,10 +111,7 @@ bool CMediaLibraryEvent::Execute() const
         path = URIUtils::GetDirectory(path);
     }
 
-    if (URIUtils::IsMusicDb(path))
-      windowId = WINDOW_MUSIC_NAV;
-    else
-      windowId = WINDOW_MUSIC_FILES;
+    windowId = WINDOW_MUSIC_NAV;
   }
 
   if (windowId < 0)

--- a/xbmc/events/MediaLibraryEvent.cpp
+++ b/xbmc/events/MediaLibraryEvent.cpp
@@ -88,10 +88,7 @@ bool CMediaLibraryEvent::Execute() const
         path = URIUtils::GetDirectory(path);
     }
 
-    if (URIUtils::IsVideoDb(path))
-      windowId = WINDOW_VIDEO_NAV;
-    else
-      windowId = WINDOW_VIDEO_FILES;
+    windowId = WINDOW_VIDEO_NAV;
   }
   else if (m_mediaType == MediaTypeMusic || m_mediaType == MediaTypeArtist ||
            m_mediaType == MediaTypeAlbum || m_mediaType == MediaTypeSong)

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -727,10 +727,6 @@ void CGUIWindowManager::ActivateWindow(int iWindowID, const std::vector<std::str
 void CGUIWindowManager::ActivateWindow_Internal(int iWindowID, const std::vector<std::string>& params, bool swappingWindows, bool force /* = false */)
 {
   // translate virtual windows
-  if (iWindowID == WINDOW_SCRIPTS)
-  { // backward compatibility for pre-Dharma
-    iWindowID = WINDOW_PROGRAMS;
-  }
   if (iWindowID == WINDOW_START)
   { // virtual start window
     iWindowID = g_SkinInfo->GetStartWindow();

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -301,7 +301,6 @@ bool CGUIWindowManager::DestroyWindows()
     Delete(WINDOW_SPLASH);
     Delete(WINDOW_MUSIC_PLAYLIST);
     Delete(WINDOW_MUSIC_PLAYLIST_EDITOR);
-    Delete(WINDOW_MUSIC_FILES);
     Delete(WINDOW_MUSIC_NAV);
     Delete(WINDOW_DIALOG_MUSIC_INFO);
     Delete(WINDOW_DIALOG_VIDEO_INFO);
@@ -729,7 +728,7 @@ void CGUIWindowManager::ActivateWindow_Internal(int iWindowID, const std::vector
 {
   // translate virtual windows
   // virtual music window which returns the last open music window (aka the music start window)
-  if (iWindowID == WINDOW_MUSIC || iWindowID == WINDOW_MUSIC_FILES)
+  if (iWindowID == WINDOW_MUSIC)
   { // backward compatibility for pre-something
     iWindowID = WINDOW_MUSIC_NAV;
   }

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -727,11 +727,6 @@ void CGUIWindowManager::ActivateWindow(int iWindowID, const std::vector<std::str
 void CGUIWindowManager::ActivateWindow_Internal(int iWindowID, const std::vector<std::string>& params, bool swappingWindows, bool force /* = false */)
 {
   // translate virtual windows
-  // virtual music window which returns the last open music window (aka the music start window)
-  if (iWindowID == WINDOW_MUSIC)
-  { // backward compatibility for pre-something
-    iWindowID = WINDOW_MUSIC_NAV;
-  }
   if (iWindowID == WINDOW_SCRIPTS)
   { // backward compatibility for pre-Dharma
     iWindowID = WINDOW_PROGRAMS;

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -733,11 +733,6 @@ void CGUIWindowManager::ActivateWindow_Internal(int iWindowID, const std::vector
   { // backward compatibility for pre-something
     iWindowID = WINDOW_MUSIC_NAV;
   }
-  // virtual video window which returns the last open video window (aka the video start window)
-  if (iWindowID == WINDOW_VIDEOS)
-  { // backward compatibility for pre-Eden
-    iWindowID = WINDOW_VIDEO_NAV;
-  }
   if (iWindowID == WINDOW_SCRIPTS)
   { // backward compatibility for pre-Dharma
     iWindowID = WINDOW_PROGRAMS;

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -305,7 +305,6 @@ bool CGUIWindowManager::DestroyWindows()
     Delete(WINDOW_MUSIC_NAV);
     Delete(WINDOW_DIALOG_MUSIC_INFO);
     Delete(WINDOW_DIALOG_VIDEO_INFO);
-    Delete(WINDOW_VIDEO_FILES);
     Delete(WINDOW_VIDEO_PLAYLIST);
     Delete(WINDOW_VIDEO_NAV);
     Delete(WINDOW_FILES);
@@ -735,7 +734,7 @@ void CGUIWindowManager::ActivateWindow_Internal(int iWindowID, const std::vector
     iWindowID = WINDOW_MUSIC_NAV;
   }
   // virtual video window which returns the last open video window (aka the video start window)
-  if (iWindowID == WINDOW_VIDEOS || iWindowID == WINDOW_VIDEO_FILES)
+  if (iWindowID == WINDOW_VIDEOS)
   { // backward compatibility for pre-Eden
     iWindowID = WINDOW_VIDEO_NAV;
   }

--- a/xbmc/guilib/WindowIDs.h
+++ b/xbmc/guilib/WindowIDs.h
@@ -104,7 +104,6 @@
 #define WINDOW_DIALOG_KEYBOARD_TOUCH      10156
 
 #define WINDOW_MUSIC_PLAYLIST             10500
-#define WINDOW_MUSIC_FILES                10501
 #define WINDOW_MUSIC_NAV                  10502
 #define WINDOW_MUSIC_PLAYLIST_EDITOR      10503
 

--- a/xbmc/guilib/WindowIDs.h
+++ b/xbmc/guilib/WindowIDs.h
@@ -27,7 +27,6 @@
 #define WINDOW_PICTURES                   10002
 #define WINDOW_FILES                      10003
 #define WINDOW_SETTINGS_MENU              10004
-#define WINDOW_MUSIC                      10005 // virtual window to return the music start window.
 #define WINDOW_SYSTEM_INFORMATION         10007
 #define WINDOW_TEST_PATTERN               10008
 #define WINDOW_SCREEN_CALIBRATION         10011

--- a/xbmc/guilib/WindowIDs.h
+++ b/xbmc/guilib/WindowIDs.h
@@ -40,7 +40,6 @@
 #define WINDOW_SCRIPTS                    10020 // virtual window for backward compatibility
 #define WINDOW_SETTINGS_MYPVR             10021
 
-#define WINDOW_VIDEO_FILES                10024
 #define WINDOW_VIDEO_NAV                  10025
 #define WINDOW_VIDEO_PLAYLIST             10028
 

--- a/xbmc/guilib/WindowIDs.h
+++ b/xbmc/guilib/WindowIDs.h
@@ -35,7 +35,6 @@
 #define WINDOW_SETTINGS_SYSTEM            10016
 #define WINDOW_SETTINGS_SERVICE           10018 // former (Eden) WINDOW_SETTINGS_NETWORK
 
-#define WINDOW_SCRIPTS                    10020 // virtual window for backward compatibility
 #define WINDOW_SETTINGS_MYPVR             10021
 
 #define WINDOW_VIDEO_NAV                  10025

--- a/xbmc/guilib/WindowIDs.h
+++ b/xbmc/guilib/WindowIDs.h
@@ -33,7 +33,7 @@
 
 #define WINDOW_SETTINGS_START             10016
 #define WINDOW_SETTINGS_SYSTEM            10016
-#define WINDOW_SETTINGS_SERVICE           10018 // former (Eden) WINDOW_SETTINGS_NETWORK
+#define WINDOW_SETTINGS_SERVICE           10018
 
 #define WINDOW_SETTINGS_MYPVR             10021
 

--- a/xbmc/guilib/WindowIDs.h
+++ b/xbmc/guilib/WindowIDs.h
@@ -28,7 +28,6 @@
 #define WINDOW_FILES                      10003
 #define WINDOW_SETTINGS_MENU              10004
 #define WINDOW_MUSIC                      10005 // virtual window to return the music start window.
-#define WINDOW_VIDEOS                     10006
 #define WINDOW_SYSTEM_INFORMATION         10007
 #define WINDOW_TEST_PATTERN               10008
 #define WINDOW_SCREEN_CALIBRATION         10011

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -297,11 +297,9 @@ static const ActionMapping windows[] =
     { "programs"                 , WINDOW_PROGRAMS },
     { "pictures"                 , WINDOW_PICTURES },
     { "filemanager"              , WINDOW_FILES },
-    { "files"                    , WINDOW_FILES },                      // backward compat
     { "settings"                 , WINDOW_SETTINGS_MENU },
     { "music"                    , WINDOW_MUSIC_NAV },
     { "videos"                   , WINDOW_VIDEO_NAV },
-    { "pvr"                      , WINDOW_TV_CHANNELS },                // backward compat
     { "tvchannels"               , WINDOW_TV_CHANNELS },
     { "tvrecordings"             , WINDOW_TV_RECORDINGS },
     { "tvguide"                  , WINDOW_TV_GUIDE },
@@ -328,17 +326,12 @@ static const ActionMapping windows[] =
     { "systeminfo"               , WINDOW_SYSTEM_INFORMATION },
     { "testpattern"              , WINDOW_TEST_PATTERN },
     { "screencalibration"        , WINDOW_SCREEN_CALIBRATION },
-    { "guicalibration"           , WINDOW_SCREEN_CALIBRATION },        // backward compat
     { "systemsettings"           , WINDOW_SETTINGS_SYSTEM },
     { "servicesettings"          , WINDOW_SETTINGS_SERVICE },
-    { "networksettings"          , WINDOW_SETTINGS_SERVICE },          // backward compat
     { "pvrsettings"              , WINDOW_SETTINGS_MYPVR },
-    { "tvsettings"               , WINDOW_SETTINGS_MYPVR },            // backward compat
     { "playersettings"           , WINDOW_SETTINGS_PLAYER },
     { "librarysettings"          , WINDOW_SETTINGS_LIBRARY },
     { "interfacesettings"        , WINDOW_SETTINGS_INTERFACE },	
-    { "scripts"                  , WINDOW_PROGRAMS },                  // backward compat
-    { "videolibrary"             , WINDOW_VIDEO_NAV },
     { "videoplaylist"            , WINDOW_VIDEO_PLAYLIST },
     { "loginscreen"              , WINDOW_LOGIN_SCREEN },
     { "profiles"                 , WINDOW_SETTINGS_PROFILES },
@@ -352,7 +345,6 @@ static const ActionMapping windows[] =
     { "favourites"               , WINDOW_DIALOG_FAVOURITES },
     { "contextmenu"              , WINDOW_DIALOG_CONTEXT_MENU },
     { "notification"             , WINDOW_DIALOG_KAI_TOAST },
-    { "infodialog"               , WINDOW_DIALOG_KAI_TOAST },          // backward compat
     { "numericinput"             , WINDOW_DIALOG_NUMERIC },
     { "gamepadinput"             , WINDOW_DIALOG_GAMEPAD },
     { "shutdownmenu"             , WINDOW_DIALOG_BUTTON_MENU },
@@ -360,7 +352,6 @@ static const ActionMapping windows[] =
     { "seekbar"                  , WINDOW_DIALOG_SEEK_BAR },
     { "musicosd"                 , WINDOW_DIALOG_MUSIC_OSD },
     { "addonsettings"            , WINDOW_DIALOG_ADDON_SETTINGS },
-    { "visualisationsettings"    , WINDOW_DIALOG_ADDON_SETTINGS },     // backward compat
     { "visualisationpresetlist"  , WINDOW_DIALOG_VIS_PRESET_LIST },
     { "osdvideosettings"         , WINDOW_DIALOG_VIDEO_OSD_SETTINGS },
     { "osdaudiosettings"         , WINDOW_DIALOG_AUDIO_OSD_SETTINGS },
@@ -384,7 +375,6 @@ static const ActionMapping windows[] =
     { "addoninformation"         , WINDOW_DIALOG_ADDON_INFO },
     { "subtitlesearch"           , WINDOW_DIALOG_SUBTITLES },
     { "musicplaylist"            , WINDOW_MUSIC_PLAYLIST },
-    { "musiclibrary"             , WINDOW_MUSIC_NAV },
     { "musicplaylisteditor"      , WINDOW_MUSIC_PLAYLIST_EDITOR },
     { "teletext"                 , WINDOW_DIALOG_OSD_TELETEXT },
     { "selectdialog"             , WINDOW_DIALOG_SELECT },

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -300,7 +300,6 @@ static const ActionMapping windows[] =
     { "files"                    , WINDOW_FILES },                      // backward compat
     { "settings"                 , WINDOW_SETTINGS_MENU },
     { "music"                    , WINDOW_MUSIC },
-    { "video"                    , WINDOW_VIDEOS },
     { "videos"                   , WINDOW_VIDEO_NAV },
     { "pvr"                      , WINDOW_TV_CHANNELS },                // backward compat
     { "tvchannels"               , WINDOW_TV_CHANNELS },

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -299,7 +299,7 @@ static const ActionMapping windows[] =
     { "filemanager"              , WINDOW_FILES },
     { "files"                    , WINDOW_FILES },                      // backward compat
     { "settings"                 , WINDOW_SETTINGS_MENU },
-    { "music"                    , WINDOW_MUSIC },
+    { "music"                    , WINDOW_MUSIC_NAV },
     { "videos"                   , WINDOW_VIDEO_NAV },
     { "pvr"                      , WINDOW_TV_CHANNELS },                // backward compat
     { "tvchannels"               , WINDOW_TV_CHANNELS },

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -339,7 +339,6 @@ static const ActionMapping windows[] =
     { "librarysettings"          , WINDOW_SETTINGS_LIBRARY },
     { "interfacesettings"        , WINDOW_SETTINGS_INTERFACE },	
     { "scripts"                  , WINDOW_PROGRAMS },                  // backward compat
-    { "videofiles"               , WINDOW_VIDEO_FILES },
     { "videolibrary"             , WINDOW_VIDEO_NAV },
     { "videoplaylist"            , WINDOW_VIDEO_PLAYLIST },
     { "loginscreen"              , WINDOW_LOGIN_SCREEN },

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -384,7 +384,6 @@ static const ActionMapping windows[] =
     { "addoninformation"         , WINDOW_DIALOG_ADDON_INFO },
     { "subtitlesearch"           , WINDOW_DIALOG_SUBTITLES },
     { "musicplaylist"            , WINDOW_MUSIC_PLAYLIST },
-    { "musicfiles"               , WINDOW_MUSIC_FILES },
     { "musiclibrary"             , WINDOW_MUSIC_NAV },
     { "musicplaylisteditor"      , WINDOW_MUSIC_PLAYLIST_EDITOR },
     { "teletext"                 , WINDOW_DIALOG_OSD_TELETEXT },

--- a/xbmc/interfaces/builtins/PlayerBuiltins.cpp
+++ b/xbmc/interfaces/builtins/PlayerBuiltins.cpp
@@ -424,7 +424,7 @@ static int PlayMedia(const std::vector<std::string>& params)
         break;
     }
 
-    std::unique_ptr<CGUIViewState> state(CGUIViewState::GetViewState(containsVideo ? WINDOW_VIDEO_NAV : WINDOW_MUSIC, items));
+    std::unique_ptr<CGUIViewState> state(CGUIViewState::GetViewState(containsVideo ? WINDOW_VIDEO_NAV : WINDOW_MUSIC_NAV, items));
     if (state.get())
       items.Sort(state->GetSortMethod());
     else

--- a/xbmc/music/GUIViewStateMusic.cpp
+++ b/xbmc/music/GUIViewStateMusic.cpp
@@ -417,12 +417,12 @@ CGUIViewStateMusicPlaylist::CGUIViewStateMusicPlaylist(const CFileItemList& item
   SetViewAsControl(viewState->m_viewMode);
   SetSortOrder(viewState->m_sortDescription.sortOrder);
 
-  LoadViewState(items.GetPath(), WINDOW_MUSIC_FILES);
+  LoadViewState(items.GetPath(), WINDOW_MUSIC_NAV);
 }
 
 void CGUIViewStateMusicPlaylist::SaveViewState()
 {
-  SaveViewToDb(m_items.GetPath(), WINDOW_MUSIC_FILES);
+  SaveViewToDb(m_items.GetPath(), WINDOW_MUSIC_NAV);
 }
 
 CGUIViewStateWindowMusicNav::CGUIViewStateWindowMusicNav(const CFileItemList& items) : CGUIViewStateWindowMusic(items)
@@ -534,54 +534,6 @@ VECSOURCES& CGUIViewStateWindowMusicNav::GetSources()
   AddOnlineShares();
 
   return CGUIViewStateWindowMusic::GetSources();
-}
-
-CGUIViewStateWindowMusicSongs::CGUIViewStateWindowMusicSongs(const CFileItemList& items) : CGUIViewStateWindowMusic(items)
-{
-  if (items.IsVirtualDirectoryRoot())
-  {
-    AddSortMethod(SortByLabel, 551, LABEL_MASKS()); // Preformated
-    AddSortMethod(SortByDriveType, 564, LABEL_MASKS()); // Preformated
-    SetSortMethod(SortByLabel);
-
-    SetViewAsControl(DEFAULT_VIEW_LIST);
-
-    SetSortOrder(SortOrderAscending);
-  }
-  else if (items.GetPath() == "special://musicplaylists/")
-  { // playlists list sorts by label only, ignoring folders
-    AddSortMethod(SortByLabel, SortAttributeIgnoreFolders, 551, LABEL_MASKS("%F", "%D", "%L", ""));  // Filename, Duration | Foldername, empty
-    SetSortMethod(SortByLabel);
-  }
-  else
-  {
-    std::string strTrack=CSettings::GetInstance().GetString(CSettings::SETTING_MUSICFILES_TRACKFORMAT);
-    AddSortMethod(SortByLabel, 551, LABEL_MASKS(strTrack, "%D", "%L", ""),  // Userdefined, Duration | FolderName, empty
-      CSettings::GetInstance().GetBool(CSettings::SETTING_FILELISTS_IGNORETHEWHENSORTING) ? SortAttributeIgnoreArticle : SortAttributeNone);
-    AddSortMethod(SortBySize, 553, LABEL_MASKS(strTrack, "%I", "%L", "%I"));  // Userdefined, Size | FolderName, Size
-    AddSortMethod(SortByBitrate, 623, LABEL_MASKS(strTrack, "%X", "%L", "%X"));  // Userdefined, Bitrate | FolderName, Bitrate  
-    AddSortMethod(SortByDate, 552, LABEL_MASKS(strTrack, "%J", "%L", "%J"));  // Userdefined, Date | FolderName, Date
-    AddSortMethod(SortByFile, 561, LABEL_MASKS(strTrack, "%F", "%L", ""));  // Userdefined, FileName | FolderName, empty
-    AddSortMethod(SortByListeners, 20455,LABEL_MASKS(strTrack, "%W", "%L", "%W"));
-    
-    const CViewState *viewState = CViewStateSettings::GetInstance().Get("musicfiles");
-    SetSortMethod(viewState->m_sortDescription);
-    SetViewAsControl(viewState->m_viewMode);
-    SetSortOrder(viewState->m_sortDescription.sortOrder);
-  }
-  LoadViewState(items.GetPath(), WINDOW_MUSIC_FILES);
-}
-
-void CGUIViewStateWindowMusicSongs::SaveViewState()
-{
-  SaveViewToDb(m_items.GetPath(), WINDOW_MUSIC_FILES, CViewStateSettings::GetInstance().Get("musicfiles"));
-}
-
-VECSOURCES& CGUIViewStateWindowMusicSongs::GetSources()
-{
-  VECSOURCES *musicSources = CMediaSourceSettings::GetInstance().GetSources("music");
-  AddOrReplace(*musicSources, CGUIViewStateWindowMusic::GetSources());
-  return *musicSources;
 }
 
 CGUIViewStateWindowMusicPlaylist::CGUIViewStateWindowMusicPlaylist(const CFileItemList& items) : CGUIViewStateWindowMusic(items)

--- a/xbmc/music/GUIViewStateMusic.h
+++ b/xbmc/music/GUIViewStateMusic.h
@@ -83,16 +83,6 @@ private:
   void AddOnlineShares();
 };
 
-class CGUIViewStateWindowMusicSongs : public CGUIViewStateWindowMusic
-{
-public:
-  CGUIViewStateWindowMusicSongs(const CFileItemList& items);
-
-protected:
-  virtual void SaveViewState();
-  virtual VECSOURCES& GetSources();
-};
-
 class CGUIViewStateWindowMusicPlaylist : public CGUIViewStateWindowMusic
 {
 public:

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -80,7 +80,6 @@ using namespace MUSIC_INFO;
 #define CONTROL_BTNVIEWASICONS  2
 #define CONTROL_BTNSORTBY       3
 #define CONTROL_BTNSORTASC      4
-#define CONTROL_BTNTYPE         5
 #define CONTROL_BTNPLAYLISTS    7
 #define CONTROL_BTNSCAN         9
 #define CONTROL_BTNREC          10
@@ -122,7 +121,6 @@ bool CGUIWindowMusicBase::OnBack(int actionID)
    ... the base class reacts on the following controls:\n
     Buttons:\n
     - #CONTROL_BTNVIEWASICONS - switch between list, thumb and with large items
-    - #CONTROL_BTNTYPE - switch between music windows
     - #CONTROL_BTNSEARCH - Search for items\n
     Other Controls:
     - The container controls\n
@@ -152,14 +150,6 @@ bool CGUIWindowMusicBase::OnMessage(CGUIMessage& message)
       if (!CGUIMediaWindow::OnMessage(message))
         return false;
 
-      // save current window, unless the current window is the music playlist window
-      if (GetID() != WINDOW_MUSIC_PLAYLIST &&
-          CSettings::GetInstance().GetInt(CSettings::SETTING_MYMUSIC_STARTWINDOW) != GetID())
-      {
-        CSettings::GetInstance().SetInt(CSettings::SETTING_MYMUSIC_STARTWINDOW, GetID());
-        CSettings::GetInstance().Save();
-      }
-
       return true;
     }
     break;
@@ -187,26 +177,7 @@ bool CGUIWindowMusicBase::OnMessage(CGUIMessage& message)
   case GUI_MSG_CLICKED:
     {
       int iControl = message.GetSenderId();
-      if (iControl == CONTROL_BTNTYPE)
-      {
-        CGUIMessage msg(GUI_MSG_ITEM_SELECTED, GetID(), CONTROL_BTNTYPE);
-        g_windowManager.SendMessage(msg);
-
-        int nWindow = WINDOW_MUSIC_FILES + msg.GetParam1();
-
-        if (nWindow == GetID())
-          return true;
-
-        CSettings::GetInstance().SetInt(CSettings::SETTING_MYMUSIC_STARTWINDOW, nWindow);
-        CSettings::GetInstance().Save();
-        g_windowManager.ChangeActiveWindow(nWindow);
-
-        CGUIMessage msg2(GUI_MSG_SETFOCUS, CSettings::GetInstance().GetInt(CSettings::SETTING_MYMUSIC_STARTWINDOW), CONTROL_BTNTYPE);
-        g_windowManager.SendMessage(msg2);
-
-        return true;
-      }
-      else if (iControl == CONTROL_BTNRIP)
+      if (iControl == CONTROL_BTNRIP)
       {
         OnRipCD();
       }
@@ -251,13 +222,6 @@ bool CGUIWindowMusicBase::OnMessage(CGUIMessage& message)
           // must be at the playlists directory
           if (m_vecItems->IsPath("special://musicplaylists/"))
             OnDeleteItem(iItem);
-
-          // or be at the files window and have file deletion enabled
-          else if (GetID() == WINDOW_MUSIC_FILES &&
-                   CSettings::GetInstance().GetBool(CSettings::SETTING_FILELISTS_ALLOWFILEDELETION))
-          {
-            OnDeleteItem(iItem);
-          }
 
           else
             return false;
@@ -767,26 +731,6 @@ void CGUIWindowMusicBase::AddItemToPlayList(const CFileItemPtr &pItem, CFileItem
 
 void CGUIWindowMusicBase::UpdateButtons()
 {
-  // Update window selection control
-
-  // Remove labels from the window selection
-  CGUIMessage msg(GUI_MSG_LABEL_RESET, GetID(), CONTROL_BTNTYPE);
-  g_windowManager.SendMessage(msg);
-
-  // Add labels to the window selection
-  CGUIMessage msg2(GUI_MSG_LABEL_ADD, GetID(), CONTROL_BTNTYPE);
-  msg2.SetLabel(g_localizeStrings.Get(744)); // Files
-  g_windowManager.SendMessage(msg2);
-
-  msg2.SetLabel(g_localizeStrings.Get(14022)); // Library
-  g_windowManager.SendMessage(msg2);
-
-  msg2.SetLabel(g_localizeStrings.Get(20389)); // Music Videos
-  g_windowManager.SendMessage(msg2);
-
-  // Select the current window as default item
-  CONTROL_SELECT_ITEM(CONTROL_BTNTYPE, CSettings::GetInstance().GetInt(CSettings::SETTING_MYMUSIC_STARTWINDOW) - WINDOW_MUSIC_FILES);
-
   CONTROL_ENABLE_ON_CONDITION(CONTROL_BTNRIP, g_mediaManager.IsAudio());
 
   CONTROL_ENABLE_ON_CONDITION(CONTROL_BTNSCAN,

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -294,7 +294,6 @@ const std::string CSettings::SETTING_AUDIOCDS_TRACKPATHFORMAT = "audiocds.trackp
 const std::string CSettings::SETTING_AUDIOCDS_ENCODER = "audiocds.encoder";
 const std::string CSettings::SETTING_AUDIOCDS_SETTINGS = "audiocds.settings";
 const std::string CSettings::SETTING_AUDIOCDS_EJECTONRIP = "audiocds.ejectonrip";
-const std::string CSettings::SETTING_MYMUSIC_STARTWINDOW = "mymusic.startwindow";
 const std::string CSettings::SETTING_MYMUSIC_SONGTHUMBINVIS = "mymusic.songthumbinvis";
 const std::string CSettings::SETTING_MYMUSIC_DEFAULTLIBVIEW = "mymusic.defaultlibview";
 const std::string CSettings::SETTING_PICTURES_GENERATETHUMBS = "pictures.generatethumbs";

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -251,7 +251,6 @@ public:
   static const std::string SETTING_AUDIOCDS_ENCODER;
   static const std::string SETTING_AUDIOCDS_SETTINGS;
   static const std::string SETTING_AUDIOCDS_EJECTONRIP;
-  static const std::string SETTING_MYMUSIC_STARTWINDOW;
   static const std::string SETTING_MYMUSIC_SONGTHUMBINVIS;
   static const std::string SETTING_MYMUSIC_DEFAULTLIBVIEW;
   static const std::string SETTING_PICTURES_GENERATETHUMBS;

--- a/xbmc/storage/AutorunMediaJob.cpp
+++ b/xbmc/storage/AutorunMediaJob.cpp
@@ -67,7 +67,7 @@ const char *CAutorunMediaJob::GetWindowString(int selection)
   switch (selection)
   {
     case 0:
-      return "VideoFiles";
+      return "Videos";
     case 1:
       return "MusicFiles";
     case 2:

--- a/xbmc/storage/AutorunMediaJob.cpp
+++ b/xbmc/storage/AutorunMediaJob.cpp
@@ -69,7 +69,7 @@ const char *CAutorunMediaJob::GetWindowString(int selection)
     case 0:
       return "Videos";
     case 1:
-      return "MusicFiles";
+      return "Music";
     case 2:
       return "Pictures";
     case 3:

--- a/xbmc/video/GUIViewStateVideo.cpp
+++ b/xbmc/video/GUIViewStateVideo.cpp
@@ -56,46 +56,6 @@ VECSOURCES& CGUIViewStateWindowVideo::GetSources()
   return CGUIViewState::GetSources();
 }
 
-CGUIViewStateWindowVideoFiles::CGUIViewStateWindowVideoFiles(const CFileItemList& items) : CGUIViewStateWindowVideo(items)
-{
-  if (items.IsVirtualDirectoryRoot())
-  {
-    AddSortMethod(SortByLabel, 551, LABEL_MASKS()); // Preformated
-    AddSortMethod(SortByDriveType, 564, LABEL_MASKS()); // Preformated
-    SetSortMethod(SortByLabel);
-
-    SetViewAsControl(DEFAULT_VIEW_LIST);
-
-    SetSortOrder(SortOrderAscending);
-  }
-  else
-  {
-    AddSortMethod(SortByLabel, 551, LABEL_MASKS("%L", "%I", "%L", ""),  // Label, Size | Label, empty
-      CSettings::GetInstance().GetBool(CSettings::SETTING_FILELISTS_IGNORETHEWHENSORTING) ? SortAttributeIgnoreArticle : SortAttributeNone);
-    AddSortMethod(SortBySize, 553, LABEL_MASKS("%L", "%I", "%L", "%I"));  // Label, Size | Label, Size
-    AddSortMethod(SortByDate, 552, LABEL_MASKS("%L", "%J", "%L", "%J"));  // Label, Date | Label, Date
-    AddSortMethod(SortByFile, 561, LABEL_MASKS("%L", "%I", "%L", ""));  // Label, Size | Label, empty
-
-    const CViewState *viewState = CViewStateSettings::GetInstance().Get("videofiles");
-    SetSortMethod(viewState->m_sortDescription);
-    SetViewAsControl(viewState->m_viewMode);
-    SetSortOrder(viewState->m_sortDescription.sortOrder);
-  }
-  LoadViewState(items.GetPath(), WINDOW_VIDEO_FILES);
-}
-
-void CGUIViewStateWindowVideoFiles::SaveViewState()
-{
-  SaveViewToDb(m_items.GetPath(), WINDOW_VIDEO_FILES, CViewStateSettings::GetInstance().Get("videofiles"));
-}
-
-VECSOURCES& CGUIViewStateWindowVideoFiles::GetSources()
-{
-  VECSOURCES *videoSources = CMediaSourceSettings::GetInstance().GetSources("video");
-  AddOrReplace(*videoSources, CGUIViewStateWindowVideo::GetSources());
-  return *videoSources;
-}
-
 CGUIViewStateWindowVideoNav::CGUIViewStateWindowVideoNav(const CFileItemList& items) : CGUIViewStateWindowVideo(items)
 {
   SortAttribute sortAttributes = SortAttributeNone;

--- a/xbmc/video/GUIViewStateVideo.h
+++ b/xbmc/video/GUIViewStateVideo.h
@@ -34,16 +34,6 @@ protected:
   virtual std::string GetExtensions();
 };
 
-class CGUIViewStateWindowVideoFiles : public CGUIViewStateWindowVideo
-{
-public:
-  CGUIViewStateWindowVideoFiles(const CFileItemList& items);
-
-protected:
-  virtual void SaveViewState();
-  virtual VECSOURCES& GetSources();
-};
-
 class CGUIViewStateWindowVideoNav : public CGUIViewStateWindowVideo
 {
 public:

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -180,10 +180,6 @@ bool CGUIWindowVideoBase::OnMessage(CGUIMessage& message)
             if (GetID() == WINDOW_VIDEO_NAV)
               OnDeleteItem(iItem);
 
-            // or be at the files window and have file deletion enabled
-            else if (GetID() == WINDOW_VIDEO_FILES && CSettings::GetInstance().GetBool(CSettings::SETTING_FILELISTS_ALLOWFILEDELETION))
-              OnDeleteItem(iItem);
-
             // or be at the video playlists location
             else if (m_vecItems->IsPath("special://videoplaylists/"))
               OnDeleteItem(iItem);
@@ -261,8 +257,7 @@ void CGUIWindowVideoBase::OnItemInfo(const CFileItem& fileItem, ADDON::ScraperPt
 
   bool modified = ShowIMDB(CFileItemPtr(new CFileItem(item)), scraper, fromDB);
   if (modified &&
-     (g_windowManager.GetActiveWindow() == WINDOW_VIDEO_FILES ||
-      g_windowManager.GetActiveWindow() == WINDOW_VIDEO_NAV)) // since we can be called from the music library we need this check
+     (g_windowManager.GetActiveWindow() == WINDOW_VIDEO_NAV)) // since we can be called from the music library we need this check
   {
     int itemNumber = m_viewControl.GetSelectedItem();
     Refresh();

--- a/xbmc/view/GUIViewState.cpp
+++ b/xbmc/view/GUIViewState.cpp
@@ -101,7 +101,7 @@ CGUIViewState* CGUIViewState::GetViewState(int windowId, const CFileItemList& it
     return new CGUIViewStateMusicPlaylist(items);
 
   if (items.GetPath() == "special://musicplaylists/")
-    return new CGUIViewStateWindowMusicSongs(items);
+    return new CGUIViewStateWindowMusicNav(items);
 
   if (url.IsProtocol("androidapp"))
     return new CGUIViewStateWindowPrograms(items);
@@ -112,14 +112,11 @@ CGUIViewState* CGUIViewState::GetViewState(int windowId, const CFileItemList& it
   if (windowId == WINDOW_MUSIC_NAV)
     return new CGUIViewStateWindowMusicNav(items);
 
-  if (windowId == WINDOW_MUSIC_FILES)
-    return new CGUIViewStateWindowMusicSongs(items);
-
   if (windowId == WINDOW_MUSIC_PLAYLIST)
     return new CGUIViewStateWindowMusicPlaylist(items);
 
   if (windowId == WINDOW_MUSIC_PLAYLIST_EDITOR)
-    return new CGUIViewStateWindowMusicSongs(items);
+    return new CGUIViewStateWindowMusicNav(items);
 
   if (windowId == WINDOW_VIDEO_NAV)
     return new CGUIViewStateWindowVideoNav(items);

--- a/xbmc/view/GUIViewState.cpp
+++ b/xbmc/view/GUIViewState.cpp
@@ -121,9 +121,6 @@ CGUIViewState* CGUIViewState::GetViewState(int windowId, const CFileItemList& it
   if (windowId == WINDOW_MUSIC_PLAYLIST_EDITOR)
     return new CGUIViewStateWindowMusicSongs(items);
 
-  if (windowId == WINDOW_VIDEO_FILES)
-    return new CGUIViewStateWindowVideoFiles(items);
-
   if (windowId == WINDOW_VIDEO_NAV)
     return new CGUIViewStateWindowVideoNav(items);
 

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -711,7 +711,7 @@ bool CGUIMediaWindow::GetDirectory(const std::string &strDirectory, CFileItemLis
   // TODO: Do we want to limit the directories we apply the video ones to?
   if (iWindow == WINDOW_VIDEO_NAV)
     regexps = g_advancedSettings.m_videoExcludeFromListingRegExps;
-  if (iWindow == WINDOW_MUSIC_FILES || iWindow == WINDOW_MUSIC_NAV)
+  if (iWindow == WINDOW_MUSIC_NAV)
     regexps = g_advancedSettings.m_audioExcludeFromListingRegExps;
   if (iWindow == WINDOW_PICTURES)
     regexps = g_advancedSettings.m_pictureExcludeFromListingRegExps;
@@ -789,8 +789,6 @@ bool CGUIMediaWindow::Update(const std::string &strDirectory, bool updateFilterP
   {
     if (iWindow == WINDOW_PICTURES)
       showLabel = 997;
-    else if (iWindow == WINDOW_MUSIC_FILES)
-      showLabel = 998;
     else if (iWindow == WINDOW_FILES)
       showLabel = 1026;
   }


### PR DESCRIPTION
remove all (references to) deprecated windows and related code.

most of these are from the time we had separate files/library windows for music and videos,
that were wrapped under a virtual window.

needs review & testing!

@Montellese for settings change
@mkortstiege for gui stuff

@phil65 / @BigNoid / @HitcherUK for regression testing
