### PR TITLE
[pvr] add instance pointer value to all add-on calls

### DIFF
--- a/addons/xbmc.pvr/addon.xml
+++ b/addons/xbmc.pvr/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="xbmc.pvr" version="5.2.0" provider-name="Team-Kodi">
-  <backwards-compatibility abi="5.2.0"/>
+<addon id="xbmc.pvr" version="5.3.0" provider-name="Team-Kodi">
+  <backwards-compatibility abi="5.3.0"/>
   <requires>
     <import addon="xbmc.core" version="0.1.0"/>
   </requires>

--- a/lib/addons/library.xbmc.pvr/libXBMC_pvr.cpp
+++ b/lib/addons/library.xbmc.pvr/libXBMC_pvr.cpp
@@ -197,4 +197,12 @@ DLLEXPORT void PVR_transfer_channel_group_member(void *hdl, void* cb, const ADDO
   ((CB_PVRLib*)cb)->TransferChannelGroupMember(((AddonCB*)hdl)->addonData, handle, member);
 }
 
+DLLEXPORT void PVR_register_addon_instance(void *hdl, void* cb, void* addonInstance)
+{
+  if (cb == nullptr)
+    return;
+
+  ((CB_PVRLib*)cb)->RegisterAddonInstance(((AddonCB*)hdl)->addonData, addonInstance);
+}
+
 };

--- a/xbmc/addons/PVRClient.h
+++ b/xbmc/addons/PVRClient.h
@@ -137,6 +137,12 @@ namespace PVR
     //@{
 
     /*!
+     * @brief To register addon instance handle pointer who are used from add-on to get his working class
+     * @param handle the handle pointer to store
+     */
+    void RegisterAddonInstance(void* addonInstance);
+
+    /*!
      * @brief Query this add-on's capabilities.
      * @return pCapabilities The add-on's capabilities.
      */
@@ -738,5 +744,8 @@ namespace PVR
     CPVRRecordingPtr    m_playingRecording;
     ADDON::AddonVersion m_apiVersion;
     bool                m_bAvahiServiceAdded;
+
+    /*! From add-on given handle data, used on all add-on calls as first value. */
+    void* m_addonInstance;
   };
 }

--- a/xbmc/addons/binary/interfaces/api1/PVR/AddonCallbacksPVR.cpp
+++ b/xbmc/addons/binary/interfaces/api1/PVR/AddonCallbacksPVR.cpp
@@ -72,6 +72,7 @@ CAddonCallbacksPVR::CAddonCallbacksPVR(CAddon* addon)
   m_callbacks->TransferChannelGroupMember = PVRTransferChannelGroupMember;
   m_callbacks->ConnectionStateChange      = PVRConnectionStateChange;
   m_callbacks->EpgEventStateChange        = PVREpgEventStateChange;
+  m_callbacks->RegisterAddonInstance      = PVRRegisterAddonInstance;
 }
 
 CAddonCallbacksPVR::~CAddonCallbacksPVR()
@@ -424,6 +425,18 @@ void CAddonCallbacksPVR::PVREpgEventStateChange(void* addonData, EPG_TAG* tag, u
     CSingleLock lock(queueMutex);
     queuedChanges.push_back(EpgEventStateChange(client->GetID(), iUniqueChannelId, tag, newState));
   }
+}
+
+void CAddonCallbacksPVR::PVRRegisterAddonInstance(void* addonData, void* addonInstance)
+{
+  CPVRClient *client = GetPVRClient(addonData);
+  if (!client || !addonInstance)
+  {
+    CLog::Log(LOGERROR, "PVR - %s - invalid handler data", __FUNCTION__);
+    return;
+  }
+
+  client->RegisterAddonInstance(addonInstance);
 }
 
 } /* namespace PVR */

--- a/xbmc/addons/binary/interfaces/api1/PVR/AddonCallbacksPVR.h
+++ b/xbmc/addons/binary/interfaces/api1/PVR/AddonCallbacksPVR.h
@@ -62,6 +62,8 @@ typedef DemuxPacket* (*PVRAllocateDemuxPacket)(void *addonData, int iDataSize);
 typedef void (*PVRConnectionStateChange)(void* addonData, const char* strConnectionString, PVR_CONNECTION_STATE newState, const char *strMessage);
 typedef void (*PVREpgEventStateChange)(void* addonData, EPG_TAG* tag, unsigned int iUniqueChannelId, EPG_EVENT_STATE newState);
 
+typedef void (*PVRRegisterAddonInstance)(void* addonData, void* addonInstance);
+
 typedef struct CB_PVRLib
 {
   PVRTransferEpgEntry           TransferEpgEntry;
@@ -81,6 +83,7 @@ typedef struct CB_PVRLib
   PVRTransferChannelGroupMember TransferChannelGroupMember;
   PVRConnectionStateChange      ConnectionStateChange;
   PVREpgEventStateChange        EpgEventStateChange;
+  PVRRegisterAddonInstance      RegisterAddonInstance;
 } CB_PVRLib;
 
 struct EpgEventStateChange;
@@ -231,6 +234,13 @@ public:
    *        event data, not just a delta. For EPG_EVENT_DELETED, it is sufficient to fill EPG_TAG.iUniqueBroadcastId
    */
   static void PVREpgEventStateChange(void* addonData, EPG_TAG* tag, unsigned int iUniqueChannelId, EPG_EVENT_STATE newState);
+
+  /*!
+   * @brief To register handle address who becomes passed on all add-on calls
+   * @param addonData A pointer to the add-on.
+   * @param addonInstance pointer used on all kodi to add-on calls
+   */
+  static void PVRRegisterAddonInstance(void* addonData, void* addonInstance);
 
 private:
   static ::PVR::CPVRClient* GetPVRClient(void* addonData);

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/libXBMC_pvr.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/libXBMC_pvr.h
@@ -164,6 +164,10 @@ public:
       dlsym(m_libXBMC_pvr, "PVR_epg_event_state_change");
     if (PVR_epg_event_state_change == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
+    PVR_register_addon_instance = (void (*)(void* HANDLE, void* CB, void* hdl))
+      dlsym(m_libXBMC_pvr, "PVR_register_addon_instance");
+    if (PVR_register_addon_instance == nullptr) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+
     m_Callbacks = PVR_register_me(m_Handle);
     return m_Callbacks != NULL;
   }
@@ -334,6 +338,15 @@ public:
     return PVR_epg_event_state_change(m_Handle, m_Callbacks, tag, iUniqueChannelId, newState);
   }
 
+  /*!
+   * @brief To register handle pointer who are used from add-on to get his working class
+   * @param addonInstance the instance pointer from addon to store
+   */
+  void RegisterAddonInstance(void* addonInstance)
+  {
+    PVR_register_addon_instance(m_Handle, m_Callbacks, addonInstance);
+  }
+
 protected:
   void* (*PVR_register_me)(void*);
   void (*PVR_unregister_me)(void*, void*);
@@ -356,6 +369,7 @@ protected:
 #endif
   void (*PVR_connection_state_change)(void*, void*, const char*, PVR_CONNECTION_STATE, const char*);
   void (*PVR_epg_event_state_change)(void*, void*, EPG_TAG*, unsigned int, EPG_EVENT_STATE);
+  void (*PVR_register_addon_instance)(void*, void*, void*);
 
 private:
   void* m_libXBMC_pvr;

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_dll.h
@@ -36,84 +36,111 @@ extern "C"
   /*!
    * Get the XBMC_PVR_API_VERSION that was used to compile this add-on.
    * Used to check if this add-on is compatible with XBMC.
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @return The XBMC_PVR_API_VERSION that was used to compile this add-on.
    * @remarks Valid implementation required.
    */
-  const char* GetPVRAPIVersion(void);
+  const char* GetPVRAPIVersion(void* addonInstance);
 
   /*!
    * Get the XBMC_PVR_MIN_API_VERSION that was used to compile this add-on.
    * Used to check if this add-on is compatible with XBMC.
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @return The XBMC_PVR_MIN_API_VERSION that was used to compile this add-on.
    * @remarks Valid implementation required.
    */
-  const char* GetMininumPVRAPIVersion(void);
+  const char* GetMininumPVRAPIVersion(void* addonInstance);
 
   /*!
    * Get the XBMC_GUI_API_VERSION that was used to compile this add-on.
    * Used to check if this add-on is compatible with XBMC.
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @return The XBMC_GUI_API_VERSION that was used to compile this add-on or empty string if this add-on does not depend on Kodi GUI API.
    * @remarks Valid implementation required.
    * @note see libKODI_guilib.h about related parts
    */
-  const char* GetGUIAPIVersion(void);
+  const char* GetGUIAPIVersion(void* addonInstance);
 
   /*!
    * Get the XBMC_GUI_MIN_API_VERSION that was used to compile this add-on.
    * Used to check if this add-on is compatible with XBMC.
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @return The XBMC_GUI_MIN_API_VERSION that was used to compile this add-on or empty string if this add-on does not depend on Kodi GUI API.
    * @remarks Valid implementation required.
    * @note see libKODI_guilib.h about related parts
    */
-  const char* GetMininumGUIAPIVersion(void);
+  const char* GetMininumGUIAPIVersion(void* addonInstance);
 
   /*!
    * Get the list of features that this add-on provides.
    * Called by XBMC to query the add-on's capabilities.
    * Used to check which options should be presented in the UI, which methods to call, etc.
    * All capabilities that the add-on supports should be set to true.
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @param pCapabilities The add-on's capabilities.
    * @return PVR_ERROR_NO_ERROR if the properties were fetched successfully.
    * @remarks Valid implementation required.
    */
-  PVR_ERROR GetAddonCapabilities(PVR_ADDON_CAPABILITIES *pCapabilities);
+  PVR_ERROR GetAddonCapabilities(void* addonInstance, PVR_ADDON_CAPABILITIES *pCapabilities);
 
   /*!
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @return The name reported by the backend that will be displayed in the UI.
    * @remarks Valid implementation required.
    */
-  const char* GetBackendName(void);
+  const char* GetBackendName(void* addonInstance);
 
   /*!
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @return The version string reported by the backend that will be displayed in the UI.
    * @remarks Valid implementation required.
    */
-  const char* GetBackendVersion(void);
+  const char* GetBackendVersion(void* addonInstance);
 
   /*!
    * @return The connection string reported by the backend that will be displayed in the UI.
    * @remarks Valid implementation required.
    */
-  const char* GetConnectionString(void);
+  const char* GetConnectionString(void* addonInstance);
 
   /*!
    * Get the disk space reported by the backend (if supported).
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @param iTotal The total disk space in bytes.
    * @param iUsed The used disk space in bytes.
    * @return PVR_ERROR_NO_ERROR if the drive space has been fetched successfully.
    * @remarks Optional. Return PVR_ERROR_NOT_IMPLEMENTED if this add-on won't provide this function.
    */
-  PVR_ERROR GetDriveSpace(long long* iTotal, long long* iUsed);
+  PVR_ERROR GetDriveSpace(void* addonInstance, long long* iTotal, long long* iUsed);
 
   /*!
    * Call one of the menu hooks (if supported).
    * Supported PVR_MENUHOOK instances have to be added in ADDON_Create(), by calling AddMenuHook() on the callback.
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @param menuhook The hook to call.
    * @param item The selected item for which the hook was called.
    * @return PVR_ERROR_NO_ERROR if the hook was called successfully.
    * @remarks Optional. Return PVR_ERROR_NOT_IMPLEMENTED if this add-on won't provide this function.
    */
-  PVR_ERROR CallMenuHook(const PVR_MENUHOOK& menuhook, const PVR_MENUHOOK_DATA &item);
+  PVR_ERROR CallMenuHook(void* addonInstance, const PVR_MENUHOOK& menuhook, const PVR_MENUHOOK_DATA &item);
   //@}
 
   /*! @name PVR EPG methods
@@ -123,6 +150,9 @@ extern "C"
   /*!
    * Request the EPG for a channel from the backend.
    * EPG entries are added to XBMC by calling TransferEpgEntry() on the callback.
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @param handle Handle to pass to the callback method.
    * @param channel The channel to get the EPG table for.
    * @param iStart Get events after this time (UTC).
@@ -130,7 +160,7 @@ extern "C"
    * @return PVR_ERROR_NO_ERROR if the table has been fetched successfully.
    * @remarks Required if bSupportsEPG is set to true. Return PVR_ERROR_NOT_IMPLEMENTED if this add-on won't provide this function.
    */
-  PVR_ERROR GetEPGForChannel(ADDON_HANDLE handle, const PVR_CHANNEL& channel, time_t iStart, time_t iEnd);
+  PVR_ERROR GetEPGForChannel(void* addonInstance, ADDON_HANDLE handle, const PVR_CHANNEL& channel, time_t iStart, time_t iEnd);
   //@}
 
   /*! @name PVR channel group methods
@@ -141,30 +171,39 @@ extern "C"
   //@{
   /*!
    * Get the total amount of channel groups on the backend if it supports channel groups.
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @return The amount of channels, or -1 on error.
    * @remarks Required if bSupportsChannelGroups is set to true. Return -1 if this add-on won't provide this function.
    */
-  int GetChannelGroupsAmount(void);
+  int GetChannelGroupsAmount(void* addonInstance);
 
   /*!
    * Request the list of all channel groups from the backend if it supports channel groups.
    * Channel group entries are added to XBMC by calling TransferChannelGroup() on the callback.
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @param handle Handle to pass to the callback method.
    * @param bRadio True to get the radio channel groups, false to get the TV channel groups.
    * @return PVR_ERROR_NO_ERROR if the list has been fetched successfully.
    * @remarks Required if bSupportsChannelGroups is set to true. Return PVR_ERROR_NOT_IMPLEMENTED if this add-on won't provide this function.
    */
-  PVR_ERROR GetChannelGroups(ADDON_HANDLE handle, bool bRadio);
+  PVR_ERROR GetChannelGroups(void* addonInstance, ADDON_HANDLE handle, bool bRadio);
 
   /*!
    * Request the list of all group members of a group from the backend if it supports channel groups.
    * Member entries are added to XBMC by calling TransferChannelGroupMember() on the callback.
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @param handle Handle to pass to the callback method.
    * @param group The group to get the members for.
    * @return PVR_ERROR_NO_ERROR if the list has been fetched successfully.
    * @remarks Required if bSupportsChannelGroups is set to true. Return PVR_ERROR_NOT_IMPLEMENTED if this add-on won't provide this function.
    */
-  PVR_ERROR GetChannelGroupMembers(ADDON_HANDLE handle, const PVR_CHANNEL_GROUP& group);
+  PVR_ERROR GetChannelGroupMembers(void* addonInstance, ADDON_HANDLE handle, const PVR_CHANNEL_GROUP& group);
   //@}
 
   /** @name PVR channel methods
@@ -175,21 +214,30 @@ extern "C"
   //@{
   /*!
    * Show the channel scan dialog if this backend supports it.
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @return PVR_ERROR_NO_ERROR if the dialog was displayed successfully.
    * @remarks Required if bSupportsChannelScan is set to true. Return PVR_ERROR_NOT_IMPLEMENTED if this add-on won't provide this function.
    * @note see libKODI_guilib.h about related parts
    */
-  PVR_ERROR OpenDialogChannelScan(void);
+  PVR_ERROR OpenDialogChannelScan(void* addonInstance);
 
   /*!
     * @return The total amount of channels on the backend, or -1 on error.
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
     * @remarks Valid implementation required.
     */
-  int GetChannelsAmount(void);
+  int GetChannelsAmount(void* addonInstance);
 
   /*!
    * Request the list of all channels from the backend.
    * Channel entries are added to XBMC by calling TransferChannelEntry() on the callback.
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @param handle Handle to pass to the callback method.
    * @param bRadio True to get the radio channels, false to get the TV channels.
    * @return PVR_ERROR_NO_ERROR if the list has been fetched successfully.
@@ -197,49 +245,64 @@ extern "C"
    *          If bSupportsRadio is set to true, a valid result set needs to be provided for bRadio = true.
    *          At least one of these two must provide a valid result set.
    */
-  PVR_ERROR GetChannels(ADDON_HANDLE handle, bool bRadio);
+  PVR_ERROR GetChannels(void* addonInstance, ADDON_HANDLE handle, bool bRadio);
 
   /*!
    * Delete a channel from the backend.
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @param channel The channel to delete.
    * @return PVR_ERROR_NO_ERROR if the channel has been deleted successfully.
    * @remarks Required if bSupportsChannelSettings is set to true.
    */
-  PVR_ERROR DeleteChannel(const PVR_CHANNEL& channel);
+  PVR_ERROR DeleteChannel(void* addonInstance, const PVR_CHANNEL& channel);
 
   /*!
    * Rename a channel on the backend.
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @param channel The channel to rename, containing the new channel name.
    * @return PVR_ERROR_NO_ERROR if the channel has been renamed successfully.
    * @remarks Optional, and only used if bSupportsChannelSettings is set to true. Return PVR_ERROR_NOT_IMPLEMENTED if this add-on won't provide this function.
    */
-  PVR_ERROR RenameChannel(const PVR_CHANNEL& channel);
+  PVR_ERROR RenameChannel(void* addonInstance, const PVR_CHANNEL& channel);
 
   /*!
    * Move a channel to another channel number on the backend.
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @param channel The channel to move, containing the new channel number.
    * @return PVR_ERROR_NO_ERROR if the channel has been moved successfully.
    * @remarks Optional, and only used if bSupportsChannelSettings is set to true. Return PVR_ERROR_NOT_IMPLEMENTED if this add-on won't provide this function.
    */
-  PVR_ERROR MoveChannel(const PVR_CHANNEL& channel);
+  PVR_ERROR MoveChannel(void* addonInstance, const PVR_CHANNEL& channel);
 
   /*!
    * Show the channel settings dialog, if supported by the backend.
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @param channel The channel to show the dialog for.
    * @return PVR_ERROR_NO_ERROR if the dialog has been displayed successfully.
    * @remarks Required if bSupportsChannelSettings is set to true.
    * @note see libKODI_guilib.h about related parts
    */
-  PVR_ERROR OpenDialogChannelSettings(const PVR_CHANNEL& channel);
+  PVR_ERROR OpenDialogChannelSettings(void* addonInstance, const PVR_CHANNEL& channel);
 
   /*!
    * Show the dialog to add a channel on the backend, if supported by the backend.
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @param channel The channel to add.
    * @return PVR_ERROR_NO_ERROR if the channel has been added successfully.
    * @remarks Required if bSupportsChannelSettings is set to true.
    * @note see libKODI_guilib.h about related parts
    */
-  PVR_ERROR OpenDialogChannelAdd(const PVR_CHANNEL& channel);
+  PVR_ERROR OpenDialogChannelAdd(void* addonInstance, const PVR_CHANNEL& channel);
   //@}
 
   /** @name PVR recording methods
@@ -249,96 +312,129 @@ extern "C"
    */
   //@{
   /*!
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @return The total amount of recordings on the backend or -1 on error.
    * @param deleted if set return deleted recording (called if bSupportsRecordingsUndelete set to true)
    * @remarks Required if bSupportsRecordings is set to true. Return PVR_ERROR_NOT_IMPLEMENTED if this add-on won't provide this function.
    */
-  int GetRecordingsAmount(bool deleted);
+  int GetRecordingsAmount(void* addonInstance, bool deleted);
 
   /*!
    * Request the list of all recordings from the backend, if supported.
    * Recording entries are added to XBMC by calling TransferRecordingEntry() on the callback.
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @param handle Handle to pass to the callback method.
    * @param deleted if set return deleted recording (called if bSupportsRecordingsUndelete set to true)
    * @return PVR_ERROR_NO_ERROR if the recordings have been fetched successfully.
    * @remarks Required if bSupportsRecordings is set to true. Return PVR_ERROR_NOT_IMPLEMENTED if this add-on won't provide this function.
    */
-  PVR_ERROR GetRecordings(ADDON_HANDLE handle, bool deleted);
+  PVR_ERROR GetRecordings(void* addonInstance, ADDON_HANDLE handle, bool deleted);
 
   /*!
    * Delete a recording on the backend.
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @param recording The recording to delete.
    * @return PVR_ERROR_NO_ERROR if the recording has been deleted successfully.
    * @remarks Optional, and only used if bSupportsRecordings is set to true. Return PVR_ERROR_NOT_IMPLEMENTED if this add-on won't provide this function.
    */
-  PVR_ERROR DeleteRecording(const PVR_RECORDING& recording);
+  PVR_ERROR DeleteRecording(void* addonInstance, const PVR_RECORDING& recording);
 
   /*!
    * Undelete a recording on the backend.
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @param recording The recording to undelete.
    * @return PVR_ERROR_NO_ERROR if the recording has been undeleted successfully.
    * @remarks Optional, and only used if bSupportsRecordingsUndelete is set to true. Return PVR_ERROR_NOT_IMPLEMENTED if this add-on won't provide this function.
    */
-  PVR_ERROR UndeleteRecording(const PVR_RECORDING& recording);
+  PVR_ERROR UndeleteRecording(void* addonInstance, const PVR_RECORDING& recording);
 
   /*!
    * @brief Delete all recordings permanent which in the deleted folder on the backend.
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @return PVR_ERROR_NO_ERROR if the recordings has been deleted successfully.
    */
-  PVR_ERROR DeleteAllRecordingsFromTrash();
+  PVR_ERROR DeleteAllRecordingsFromTrash(void* addonInstance);
 
   /*!
    * Rename a recording on the backend.
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @param recording The recording to rename, containing the new name.
    * @return PVR_ERROR_NO_ERROR if the recording has been renamed successfully.
    * @remarks Optional, and only used if bSupportsRecordings is set to true. Return PVR_ERROR_NOT_IMPLEMENTED if this add-on won't provide this function.
    */
-  PVR_ERROR RenameRecording(const PVR_RECORDING& recording);
+  PVR_ERROR RenameRecording(void* addonInstance, const PVR_RECORDING& recording);
 
   /*!
    * Set the play count of a recording on the backend.
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @param recording The recording to change the play count.
    * @param count Play count.
    * @return PVR_ERROR_NO_ERROR if the recording's play count has been set successfully.
    * @remarks Required if bSupportsRecordingPlayCount is set to true. Return PVR_ERROR_NOT_IMPLEMENTED if this add-on won't provide this function.
    */
-  PVR_ERROR SetRecordingPlayCount(const PVR_RECORDING& recording, int count);
+  PVR_ERROR SetRecordingPlayCount(void* addonInstance, const PVR_RECORDING& recording, int count);
 
   /*!
   * Set the last watched position of a recording on the backend.
+  * @param[in] addonInstance [opt] The during add-on creation with
+  *            `RegisterAddonInstance` set pointer to have for related sub
+  *            parts, gives `NULL` if not set during creation.
   * @param recording The recording.
   * @param position The last watched position in seconds
   * @return PVR_ERROR_NO_ERROR if the position has been stored successfully.
   * @remarks Required if bSupportsLastPlayedPosition is set to true. Return PVR_ERROR_NOT_IMPLEMENTED if this add-on won't provide this function.
   */
-  PVR_ERROR SetRecordingLastPlayedPosition(const PVR_RECORDING& recording, int lastplayedposition);
+  PVR_ERROR SetRecordingLastPlayedPosition(void* addonInstance, const PVR_RECORDING& recording, int lastplayedposition);
 
   /*!
   * Retrieve the last watched position of a recording on the backend.
+  * @param[in] addonInstance [opt] The during add-on creation with
+  *            `RegisterAddonInstance` set pointer to have for related sub
+  *            parts, gives `NULL` if not set during creation.
   * @param recording The recording.
   * @return The last watched position in seconds or -1 on error
   * @remarks Required if bSupportsRecordingPlayCount is set to true. Return -1 if this add-on won't provide this function.
   */
-  int GetRecordingLastPlayedPosition(const PVR_RECORDING& recording);
+  int GetRecordingLastPlayedPosition(void* addonInstance, const PVR_RECORDING& recording);
 
   /*!
   * Retrieve the edit decision list (EDL) of a recording on the backend.
+  * @param[in] addonInstance [opt] The during add-on creation with
+  *            `RegisterAddonInstance` set pointer to have for related sub
+  *            parts, gives `NULL` if not set during creation.
   * @param recording The recording.
   * @param edl out: The function has to write the EDL list into this array.
   * @param size in: The maximum size of the EDL, out: the actual size of the EDL.
   * @return PVR_ERROR_NO_ERROR if the EDL was successfully read.
   * @remarks Required if bSupportsRecordingEdl is set to true. Return PVR_ERROR_NOT_IMPLEMENTED if this add-on won't provide this function.
   */
-  PVR_ERROR GetRecordingEdl(const PVR_RECORDING&, PVR_EDL_ENTRY edl[], int *size);
+  PVR_ERROR GetRecordingEdl(void* addonInstance, const PVR_RECORDING&, PVR_EDL_ENTRY edl[], int *size);
 
   /*!
   * Retrieve the timer types supported by the backend.
+  * @param[in] addonInstance [opt] The during add-on creation with
+  *            `RegisterAddonInstance` set pointer to have for related sub
+  *            parts, gives `NULL` if not set during creation.
   * @param types out: The function has to write the definition of the supported timer types into this array.
   * @param typesCount in: The maximum size of the list, out: the actual size of the list. default: PVR_ADDON_TIMERTYPE_ARRAY_SIZE
   * @return PVR_ERROR_NO_ERROR if the types were successfully written to the array.
   * @remarks Required if bSupportsTimers is set to true. Return PVR_ERROR_NOT_IMPLEMENTED if this add-on won't provide this function.
   */
-  PVR_ERROR GetTimerTypes(PVR_TIMER_TYPE types[], int *typesCount);
+  PVR_ERROR GetTimerTypes(void* addonInstance, PVR_TIMER_TYPE types[], int *typesCount);
 
   //@}
   /** @name PVR timer methods
@@ -348,44 +444,59 @@ extern "C"
    */
   //@{
   /*!
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @return The total amount of timers on the backend or -1 on error.
    * @remarks Required if bSupportsTimers is set to true. Return -1 if this add-on won't provide this function.
    */
-  int GetTimersAmount(void);
+  int GetTimersAmount(void* addonInstance);
 
   /*!
    * Request the list of all timers from the backend if supported.
    * Timer entries are added to XBMC by calling TransferTimerEntry() on the callback.
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @param handle Handle to pass to the callback method.
    * @return PVR_ERROR_NO_ERROR if the list has been fetched successfully.
    * @remarks Required if bSupportsTimers is set to true. Return PVR_ERROR_NOT_IMPLEMENTED if this add-on won't provide this function.
    */
-  PVR_ERROR GetTimers(ADDON_HANDLE handle);
+  PVR_ERROR GetTimers(void* addonInstance, ADDON_HANDLE handle);
 
   /*!
    * Add a timer on the backend.
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @param timer The timer to add.
    * @return PVR_ERROR_NO_ERROR if the timer has been added successfully.
    * @remarks Required if bSupportsTimers is set to true. Return PVR_ERROR_NOT_IMPLEMENTED if this add-on won't provide this function.
    */
-  PVR_ERROR AddTimer(const PVR_TIMER& timer);
+  PVR_ERROR AddTimer(void* addonInstance, const PVR_TIMER& timer);
 
   /*!
    * Delete a timer on the backend.
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @param timer The timer to delete.
    * @param bForceDelete Set to true to delete a timer that is currently recording a program.
    * @return PVR_ERROR_NO_ERROR if the timer has been deleted successfully.
    * @remarks Required if bSupportsTimers is set to true. Return PVR_ERROR_NOT_IMPLEMENTED if this add-on won't provide this function.
    */
-  PVR_ERROR DeleteTimer(const PVR_TIMER& timer, bool bForceDelete);
+  PVR_ERROR DeleteTimer(void* addonInstance, const PVR_TIMER& timer, bool bForceDelete);
 
   /*!
    * Update the timer information on the backend.
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @param timer The timer to update.
    * @return PVR_ERROR_NO_ERROR if the timer has been updated successfully.
    * @remarks Required if bSupportsTimers is set to true. Return PVR_ERROR_NOT_IMPLEMENTED if this add-on won't provide this function.
    */
-  PVR_ERROR UpdateTimer(const PVR_TIMER& timer);
+  PVR_ERROR UpdateTimer(void* addonInstance, const PVR_TIMER& timer);
 
   //@}
 
@@ -393,79 +504,109 @@ extern "C"
   //@{
   /*!
    * Open a live stream on the backend.
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @param channel The channel to stream.
    * @return True if the stream has been opened successfully, false otherwise.
    * @remarks Required if bHandlesInputStream or bHandlesDemuxing is set to true. Return false if this add-on won't provide this function.
    */
-  bool OpenLiveStream(const PVR_CHANNEL& channel);
+  bool OpenLiveStream(void* addonInstance, const PVR_CHANNEL& channel);
 
   /*!
    * Close an open live stream.
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @remarks Required if bHandlesInputStream or bHandlesDemuxing is set to true.
    */
-  void CloseLiveStream(void);
+  void CloseLiveStream(void* addonInstance);
 
   /*!
    * Read from an open live stream.
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @param pBuffer The buffer to store the data in.
    * @param iBufferSize The amount of bytes to read.
    * @return The amount of bytes that were actually read from the stream.
    * @remarks Required if bHandlesInputStream is set to true. Return -1 if this add-on won't provide this function.
    */
-  int ReadLiveStream(unsigned char* pBuffer, unsigned int iBufferSize);
+  int ReadLiveStream(void* addonInstance, unsigned char* pBuffer, unsigned int iBufferSize);
 
   /*!
    * Seek in a live stream on a backend that supports timeshifting.
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @param iPosition The position to seek to.
    * @param iWhence ?
    * @return The new position.
    * @remarks Optional, and only used if bHandlesInputStream is set to true. Return -1 if this add-on won't provide this function.
    */
-  long long SeekLiveStream(long long iPosition, int iWhence = SEEK_SET);
+  long long SeekLiveStream(void* addonInstance, long long iPosition, int iWhence = SEEK_SET);
 
   /*!
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @return The position in the stream that's currently being read.
    * @remarks Optional, and only used if bHandlesInputStream is set to true. Return -1 if this add-on won't provide this function.
    */
-  long long PositionLiveStream(void);
+  long long PositionLiveStream(void* addonInstance);
 
   /*!
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @return The total length of the stream that's currently being read.
    * @remarks Optional, and only used if bHandlesInputStream is set to true. Return -1 if this add-on won't provide this function.
    */
-  long long LengthLiveStream(void);
+  long long LengthLiveStream(void* addonInstance);
 
   /*!
    * Switch to another channel. Only to be called when a live stream has already been opened.
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @param channel The channel to switch to.
    * @return True if the switch was successful, false otherwise.
    * @remarks Required if bHandlesInputStream or bHandlesDemuxing is set to true. Return false if this add-on won't provide this function.
    */
-  bool SwitchChannel(const PVR_CHANNEL& channel);
+  bool SwitchChannel(void* addonInstance, const PVR_CHANNEL& channel);
 
   /*!
    * Get the signal status of the stream that's currently open.
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @param signalStatus The signal status.
    * @return True if the signal status has been read successfully, false otherwise.
    * @remarks Optional, and only used if bHandlesInputStream or bHandlesDemuxing is set to true. Return PVR_ERROR_NOT_IMPLEMENTED if this add-on won't provide this function.
    */
-  PVR_ERROR SignalStatus(PVR_SIGNAL_STATUS& signalStatus);
+  PVR_ERROR SignalStatus(void* addonInstance, PVR_SIGNAL_STATUS& signalStatus);
 
   /*!
    * Get the stream URL for a channel from the backend. Used by the MediaPortal add-on.
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @param channel The channel to get the stream URL for.
    * @return The requested URL.
    * @remarks Optional, and only used if bHandlesInputStream is set to true. Return NULL if this add-on won't provide this function.
    */
-  const char* GetLiveStreamURL(const PVR_CHANNEL& channel);
+  const char* GetLiveStreamURL(void* addonInstance, const PVR_CHANNEL& channel);
 
   /*!
    * Get the stream properties of the stream that's currently being read.
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @param pProperties The properties of the currently playing stream.
    * @return PVR_ERROR_NO_ERROR if the properties have been fetched successfully.
    * @remarks Required if bHandlesInputStream or bHandlesDemuxing is set to true. Return PVR_ERROR_NOT_IMPLEMENTED if this add-on won't provide this function.
    */
-  PVR_ERROR GetStreamProperties(PVR_STREAM_PROPERTIES* pProperties);
+  PVR_ERROR GetStreamProperties(void* addonInstance, PVR_STREAM_PROPERTIES* pProperties);
   //@}
 
   /** @name PVR recording stream methods, used to open and close a stream to a recording, and perform read operations on the stream.
@@ -474,47 +615,65 @@ extern "C"
   //@{
   /*!
    * Open a stream to a recording on the backend.
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @param recording The recording to open.
    * @return True if the stream has been opened successfully, false otherwise.
    * @remarks Optional, and only used if bSupportsRecordings is set to true. Return false if this add-on won't provide this function.
    */
-  bool OpenRecordedStream(const PVR_RECORDING& recording);
+  bool OpenRecordedStream(void* addonInstance, const PVR_RECORDING& recording);
 
   /*!
    * Close an open stream from a recording.
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @remarks Optional, and only used if bSupportsRecordings is set to true.
    */
-  void CloseRecordedStream(void);
+  void CloseRecordedStream(void* addonInstance);
 
   /*!
    * Read from a recording.
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @param pBuffer The buffer to store the data in.
    * @param iBufferSize The amount of bytes to read.
    * @return The amount of bytes that were actually read from the stream.
    * @remarks Optional, and only used if bSupportsRecordings is set to true, but required if OpenRecordedStream() is implemented. Return -1 if this add-on won't provide this function.
    */
-  int ReadRecordedStream(unsigned char* pBuffer, unsigned int iBufferSize);
+  int ReadRecordedStream(void* addonInstance, unsigned char* pBuffer, unsigned int iBufferSize);
 
   /*!
    * Seek in a recorded stream.
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @param iPosition The position to seek to.
    * @param iWhence ?
    * @return The new position.
    * @remarks Optional, and only used if bSupportsRecordings is set to true. Return -1 if this add-on won't provide this function.
    */
-  long long SeekRecordedStream(long long iPosition, int iWhence = SEEK_SET);
+  long long SeekRecordedStream(void* addonInstance, long long iPosition, int iWhence = SEEK_SET);
 
   /*!
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @return The position in the stream that's currently being read.
    * @remarks Optional, and only used if bSupportsRecordings is set to true. Return -1 if this add-on won't provide this function.
    */
-  long long PositionRecordedStream(void);
+  long long PositionRecordedStream(void* addonInstance);
 
   /*!
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @return The total length of the stream that's currently being read.
    * @remarks Optional, and only used if bSupportsRecordings is set to true. Return -1 if this add-on won't provide this function.
    */
-  long long LengthRecordedStream(void);
+  long long LengthRecordedStream(void* addonInstance);
   //@}
 
   /** @name PVR demultiplexer methods
@@ -523,24 +682,36 @@ extern "C"
   //@{
   /*!
    * Reset the demultiplexer in the add-on.
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @remarks Required if bHandlesDemuxing is set to true.
    */
-  void DemuxReset(void);
+  void DemuxReset(void* addonInstance);
 
   /*!
    * Abort the demultiplexer thread in the add-on.
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @remarks Required if bHandlesDemuxing is set to true.
    */
-  void DemuxAbort(void);
+  void DemuxAbort(void* addonInstance);
 
   /*!
    * Flush all data that's currently in the demultiplexer buffer in the add-on.
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @remarks Required if bHandlesDemuxing is set to true.
    */
-  void DemuxFlush(void);
+  void DemuxFlush(void* addonInstance);
 
   /*!
    * Read the next packet from the demultiplexer, if there is one.
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @return The next packet.
    *         If there is no next packet, then the add-on should return the
    *         packet created by calling AllocateDemuxPacket(0) on the callback.
@@ -551,109 +722,174 @@ extern "C"
    *         The add-on should return NULL if an error occured.
    * @remarks Required if bHandlesDemuxing is set to true. Return NULL if this add-on won't provide this function.
    */
-  DemuxPacket* DemuxRead(void);
+  DemuxPacket* DemuxRead(void* addonInstance);
   //@}
 
   /*!
    * Delay to use when using switching channels for add-ons not providing an input stream.
    * If the add-on does provide an input stream, then this method will not be called.
    * Those add-ons can do that in OpenLiveStream() if needed.
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @return The delay in milliseconds.
    */
-  unsigned int GetChannelSwitchDelay(void);
+  unsigned int GetChannelSwitchDelay(void* addonInstance);
 
   /*!
    * Check if the backend support pausing the currently playing stream
    * This will enable/disable the pause button in XBMC based on the return value
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @return false if the PVR addon/backend does not support pausing, true if possible
    */
-  bool CanPauseStream();
+  bool CanPauseStream(void* addonInstance);
 
   /*!
    * Check if the backend supports seeking for the currently playing stream
    * This will enable/disable the rewind/forward buttons in XBMC based on the return value
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @return false if the PVR addon/backend does not support seeking, true if possible
    */
-  bool CanSeekStream();
+  bool CanSeekStream(void* addonInstance);
 
   /*!
    * @brief Notify the pvr addon that XBMC (un)paused the currently playing stream
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    */
-  void PauseStream(bool bPaused);
+  void PauseStream(void* addonInstance, bool bPaused);
 
   /*!
    * Notify the pvr addon/demuxer that XBMC wishes to seek the stream by time
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @param time The absolute time since stream start
    * @param backwards True to seek to keyframe BEFORE time, else AFTER
    * @param startpts can be updated to point to where display should start
    * @return True if the seek operation was possible
    * @remarks Optional, and only used if addon has its own demuxer. Return False if this add-on won't provide this function.
    */
-  bool SeekTime(int time, bool backwards, double *startpts);
+  bool SeekTime(void* addonInstance, int time, bool backwards, double *startpts);
 
   /*!
    * Notify the pvr addon/demuxer that XBMC wishes to change playback speed
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @param speed The requested playback speed
    * @remarks Optional, and only used if addon has its own demuxer.
    */
-  void SetSpeed(int speed);
+  void SetSpeed(void* addonInstance, int speed);
 
   /*!
    *  Get actual playing time from addon. With timeshift enabled this is
    *  different to live.
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    *  @return time as UTC
    */
-  time_t GetPlayingTime();
+  time_t GetPlayingTime(void* addonInstance);
 
   /*!
    *  Get time of oldest packet in timeshift buffer
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    *  @return time as UTC
    */
-  time_t GetBufferTimeStart();
+  time_t GetBufferTimeStart(void* addonInstance);
 
   /*!
    *  Get time of latest packet in timeshift buffer
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    *  @return time as UTC
    */
-  time_t GetBufferTimeEnd();
+  time_t GetBufferTimeEnd(void* addonInstance);
 
   /*!
    *  Get the hostname of the pvr backend server
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    *  @return hostname as ip address or alias. If backend does not
    *          utilize a server, return empty string.
    */
-  const char* GetBackendHostname();
+  const char* GetBackendHostname(void* addonInstance);
 
   /*!
    *  Check if timeshift is active
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    *  @return true if timeshift is active
    */
-  bool IsTimeshifting();
+  bool IsTimeshifting(void* addonInstance);
 
   /*!
    *  Check for real-time streaming
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    *  @return true if current stream is real-time
    */
-  bool IsRealTimeStream();
+  bool IsRealTimeStream(void* addonInstance);
 
   /*!
    * Tell the client the time frame to use when notifying epg events back to Kodi. The client might push epg events asynchronously
    * to Kodi using the callback function EpgEventStateChange. To be able to only push events that are actually of interest for Kodi,
    * client needs to know about the epg time frame Kodi uses. Kodi supplies the current epg time frame value in PVR_PROPERTIES.iEpgMaxDays
    * when creating the addon and calls SetEPGTimeFrame later whenever Kodi's epg time frame value changes.
+   *
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    * @param iDays number of days from "now". EPG_TIMEFRAME_UNLIMITED means that Kodi is interested in all epg events, regardless of event times.
    * @return PVR_ERROR_NO_ERROR if new value was successfully set.
+   *
    * @remarks Required if bSupportsEPG is set to true. Return PVR_ERROR_NOT_IMPLEMENTED if this add-on won't provide this function.
    */
-  PVR_ERROR SetEPGTimeFrame(int iDays);
+  PVR_ERROR SetEPGTimeFrame(void* addonInstance, int iDays);
 
   /*!
-   * Notify the pvr addon for power management events
+   * Notify the pvr addon for power management event to sleep
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
    */
-  void OnSystemSleep();
-  void OnSystemWake();
-  void OnPowerSavingActivated();
-  void OnPowerSavingDeactivated();
+  void OnSystemSleep(void* addonInstance);
+
+  /*!
+   * Notify the pvr addon for power management event to wake up
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
+   */
+  void OnSystemWake(void* addonInstance);
+
+  /*!
+   * Notify the pvr addon for power management saving activated
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
+   */
+  void OnPowerSavingActivated(void* addonInstance);
+
+  /*!
+   * Notify the pvr addon for power management saving deactivated
+   * @param[in] addonInstance [opt] The during add-on creation with
+   *            `RegisterAddonInstance` set pointer to have for related sub
+   *            parts, gives `NULL` if not set during creation.
+   */
+  void OnPowerSavingDeactivated(void* addonInstance);
 
   /*!
    * Called by XBMC to assign the function pointers of this add-on to pClient.

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
@@ -78,10 +78,10 @@ struct DemuxPacket;
 #define PVR_STREAM_MAX_STREAMS 20
 
 /* current PVR API version */
-#define XBMC_PVR_API_VERSION "5.2.0"
+#define XBMC_PVR_API_VERSION "5.3.0"
 
 /* min. PVR API version */
-#define XBMC_PVR_MIN_API_VERSION "5.2.0"
+#define XBMC_PVR_MIN_API_VERSION "5.3.0"
 
 #ifdef __cplusplus
 extern "C" {
@@ -532,81 +532,81 @@ extern "C" {
    */
   typedef struct PVRClient
   {
-    const char*  (__cdecl* GetPVRAPIVersion)(void);
-    const char*  (__cdecl* GetMininumPVRAPIVersion)(void);
-    const char*  (__cdecl* GetGUIAPIVersion)(void);
-    const char*  (__cdecl* GetMininumGUIAPIVersion)(void);
-    PVR_ERROR    (__cdecl* GetAddonCapabilities)(PVR_ADDON_CAPABILITIES*);
-    PVR_ERROR    (__cdecl* GetStreamProperties)(PVR_STREAM_PROPERTIES*);
-    const char*  (__cdecl* GetBackendName)(void);
-    const char*  (__cdecl* GetBackendVersion)(void);
-    const char*  (__cdecl* GetConnectionString)(void);
-    PVR_ERROR    (__cdecl* GetDriveSpace)(long long*, long long*);
-    PVR_ERROR    (__cdecl* MenuHook)(const PVR_MENUHOOK&, const PVR_MENUHOOK_DATA&);
-    PVR_ERROR    (__cdecl* GetEpg)(ADDON_HANDLE, const PVR_CHANNEL&, time_t, time_t);
-    int          (__cdecl* GetChannelGroupsAmount)(void);
-    PVR_ERROR    (__cdecl* GetChannelGroups)(ADDON_HANDLE, bool);
-    PVR_ERROR    (__cdecl* GetChannelGroupMembers)(ADDON_HANDLE, const PVR_CHANNEL_GROUP&);
-    PVR_ERROR    (__cdecl* OpenDialogChannelScan)(void);
-    int          (__cdecl* GetChannelsAmount)(void);
-    PVR_ERROR    (__cdecl* GetChannels)(ADDON_HANDLE, bool);
-    PVR_ERROR    (__cdecl* DeleteChannel)(const PVR_CHANNEL&);
-    PVR_ERROR    (__cdecl* RenameChannel)(const PVR_CHANNEL&);
-    PVR_ERROR    (__cdecl* MoveChannel)(const PVR_CHANNEL&);
-    PVR_ERROR    (__cdecl* OpenDialogChannelSettings)(const PVR_CHANNEL&);
-    PVR_ERROR    (__cdecl* OpenDialogChannelAdd)(const PVR_CHANNEL&);
-    int          (__cdecl* GetRecordingsAmount)(bool);
-    PVR_ERROR    (__cdecl* GetRecordings)(ADDON_HANDLE, bool);
-    PVR_ERROR    (__cdecl* DeleteRecording)(const PVR_RECORDING&);
-    PVR_ERROR    (__cdecl* UndeleteRecording)(const PVR_RECORDING&);
-    PVR_ERROR    (__cdecl* DeleteAllRecordingsFromTrash)(void);
-    PVR_ERROR    (__cdecl* RenameRecording)(const PVR_RECORDING&);
-    PVR_ERROR    (__cdecl* SetRecordingPlayCount)(const PVR_RECORDING&, int);
-    PVR_ERROR    (__cdecl* SetRecordingLastPlayedPosition)(const PVR_RECORDING&, int);
-    int          (__cdecl* GetRecordingLastPlayedPosition)(const PVR_RECORDING&);
-    PVR_ERROR    (__cdecl* GetRecordingEdl)(const PVR_RECORDING&, PVR_EDL_ENTRY[], int*);
-    PVR_ERROR    (__cdecl* GetTimerTypes)(PVR_TIMER_TYPE[], int*);
-    int          (__cdecl* GetTimersAmount)(void);
-    PVR_ERROR    (__cdecl* GetTimers)(ADDON_HANDLE);
-    PVR_ERROR    (__cdecl* AddTimer)(const PVR_TIMER&);
-    PVR_ERROR    (__cdecl* DeleteTimer)(const PVR_TIMER&, bool);
-    PVR_ERROR    (__cdecl* UpdateTimer)(const PVR_TIMER&);
-    bool         (__cdecl* OpenLiveStream)(const PVR_CHANNEL&);
-    void         (__cdecl* CloseLiveStream)(void);
-    int          (__cdecl* ReadLiveStream)(unsigned char*, unsigned int);
-    long long    (__cdecl* SeekLiveStream)(long long, int);
-    long long    (__cdecl* PositionLiveStream)(void);
-    long long    (__cdecl* LengthLiveStream)(void);
-    bool         (__cdecl* SwitchChannel)(const PVR_CHANNEL&);
-    PVR_ERROR    (__cdecl* SignalStatus)(PVR_SIGNAL_STATUS&);
-    const char*  (__cdecl* GetLiveStreamURL)(const PVR_CHANNEL&);
-    bool         (__cdecl* OpenRecordedStream)(const PVR_RECORDING&);
-    void         (__cdecl* CloseRecordedStream)(void);
-    int          (__cdecl* ReadRecordedStream)(unsigned char*, unsigned int);
-    long long    (__cdecl* SeekRecordedStream)(long long, int);
-    long long    (__cdecl* PositionRecordedStream)(void);
-    long long    (__cdecl* LengthRecordedStream)(void);
-    void         (__cdecl* DemuxReset)(void);
-    void         (__cdecl* DemuxAbort)(void);
-    void         (__cdecl* DemuxFlush)(void);
-    DemuxPacket* (__cdecl* DemuxRead)(void);
-    unsigned int (__cdecl* GetChannelSwitchDelay)(void);
-    bool         (__cdecl* CanPauseStream)(void);
-    void         (__cdecl* PauseStream)(bool);
-    bool         (__cdecl* CanSeekStream)(void);
-    bool         (__cdecl* SeekTime)(int, bool, double*);
-    void         (__cdecl* SetSpeed)(int);
-    time_t       (__cdecl* GetPlayingTime)(void);
-    time_t       (__cdecl* GetBufferTimeStart)(void);
-    time_t       (__cdecl* GetBufferTimeEnd)(void);
-    const char*  (__cdecl* GetBackendHostname)(void);
-    bool         (__cdecl* IsTimeshifting)(void);
-    bool         (__cdecl* IsRealTimeStream)(void);
-    PVR_ERROR    (__cdecl* SetEPGTimeFrame)(int);
-    void         (__cdecl* OnSystemSleep)(void);
-    void         (__cdecl* OnSystemWake)(void);
-    void         (__cdecl* OnPowerSavingActivated)(void);
-    void         (__cdecl* OnPowerSavingDeactivated)(void);
+    const char*  (__cdecl* GetPVRAPIVersion)(void*);
+    const char*  (__cdecl* GetMininumPVRAPIVersion)(void*);
+    const char*  (__cdecl* GetGUIAPIVersion)(void*);
+    const char*  (__cdecl* GetMininumGUIAPIVersion)(void*);
+    PVR_ERROR    (__cdecl* GetAddonCapabilities)(void*, PVR_ADDON_CAPABILITIES*);
+    PVR_ERROR    (__cdecl* GetStreamProperties)(void*, PVR_STREAM_PROPERTIES*);
+    const char*  (__cdecl* GetBackendName)(void*);
+    const char*  (__cdecl* GetBackendVersion)(void*);
+    const char*  (__cdecl* GetConnectionString)(void*);
+    PVR_ERROR    (__cdecl* GetDriveSpace)(void*, long long*, long long*);
+    PVR_ERROR    (__cdecl* MenuHook)(void*, const PVR_MENUHOOK&, const PVR_MENUHOOK_DATA&);
+    PVR_ERROR    (__cdecl* GetEpg)(void*, ADDON_HANDLE, const PVR_CHANNEL&, time_t, time_t);
+    int          (__cdecl* GetChannelGroupsAmount)(void*);
+    PVR_ERROR    (__cdecl* GetChannelGroups)(void*, ADDON_HANDLE, bool);
+    PVR_ERROR    (__cdecl* GetChannelGroupMembers)(void*, ADDON_HANDLE, const PVR_CHANNEL_GROUP&);
+    PVR_ERROR    (__cdecl* OpenDialogChannelScan)(void*);
+    int          (__cdecl* GetChannelsAmount)(void*);
+    PVR_ERROR    (__cdecl* GetChannels)(void*, ADDON_HANDLE, bool);
+    PVR_ERROR    (__cdecl* DeleteChannel)(void*, const PVR_CHANNEL&);
+    PVR_ERROR    (__cdecl* RenameChannel)(void*, const PVR_CHANNEL&);
+    PVR_ERROR    (__cdecl* MoveChannel)(void*, const PVR_CHANNEL&);
+    PVR_ERROR    (__cdecl* OpenDialogChannelSettings)(void*, const PVR_CHANNEL&);
+    PVR_ERROR    (__cdecl* OpenDialogChannelAdd)(void*, const PVR_CHANNEL&);
+    int          (__cdecl* GetRecordingsAmount)(void*, bool);
+    PVR_ERROR    (__cdecl* GetRecordings)(void*, ADDON_HANDLE, bool);
+    PVR_ERROR    (__cdecl* DeleteRecording)(void*, const PVR_RECORDING&);
+    PVR_ERROR    (__cdecl* UndeleteRecording)(void*, const PVR_RECORDING&);
+    PVR_ERROR    (__cdecl* DeleteAllRecordingsFromTrash)(void*);
+    PVR_ERROR    (__cdecl* RenameRecording)(void*, const PVR_RECORDING&);
+    PVR_ERROR    (__cdecl* SetRecordingPlayCount)(void*, const PVR_RECORDING&, int);
+    PVR_ERROR    (__cdecl* SetRecordingLastPlayedPosition)(void*, const PVR_RECORDING&, int);
+    int          (__cdecl* GetRecordingLastPlayedPosition)(void*, const PVR_RECORDING&);
+    PVR_ERROR    (__cdecl* GetRecordingEdl)(void*, const PVR_RECORDING&, PVR_EDL_ENTRY[], int*);
+    PVR_ERROR    (__cdecl* GetTimerTypes)(void*, PVR_TIMER_TYPE[], int*);
+    int          (__cdecl* GetTimersAmount)(void*);
+    PVR_ERROR    (__cdecl* GetTimers)(void*, ADDON_HANDLE);
+    PVR_ERROR    (__cdecl* AddTimer)(void*, const PVR_TIMER&);
+    PVR_ERROR    (__cdecl* DeleteTimer)(void*, const PVR_TIMER&, bool);
+    PVR_ERROR    (__cdecl* UpdateTimer)(void*, const PVR_TIMER&);
+    bool         (__cdecl* OpenLiveStream)(void*, const PVR_CHANNEL&);
+    void         (__cdecl* CloseLiveStream)(void*);
+    int          (__cdecl* ReadLiveStream)(void*, unsigned char*, unsigned int);
+    long long    (__cdecl* SeekLiveStream)(void*, long long, int);
+    long long    (__cdecl* PositionLiveStream)(void*);
+    long long    (__cdecl* LengthLiveStream)(void*);
+    bool         (__cdecl* SwitchChannel)(void*, const PVR_CHANNEL&);
+    PVR_ERROR    (__cdecl* SignalStatus)(void*, PVR_SIGNAL_STATUS&);
+    const char*  (__cdecl* GetLiveStreamURL)(void*, const PVR_CHANNEL&);
+    bool         (__cdecl* OpenRecordedStream)(void*, const PVR_RECORDING&);
+    void         (__cdecl* CloseRecordedStream)(void*);
+    int          (__cdecl* ReadRecordedStream)(void*, unsigned char*, unsigned int);
+    long long    (__cdecl* SeekRecordedStream)(void*, long long, int);
+    long long    (__cdecl* PositionRecordedStream)(void*);
+    long long    (__cdecl* LengthRecordedStream)(void*);
+    void         (__cdecl* DemuxReset)(void*);
+    void         (__cdecl* DemuxAbort)(void*);
+    void         (__cdecl* DemuxFlush)(void*);
+    DemuxPacket* (__cdecl* DemuxRead)(void*);
+    unsigned int (__cdecl* GetChannelSwitchDelay)(void*);
+    bool         (__cdecl* CanPauseStream)(void*);
+    void         (__cdecl* PauseStream)(void*, bool);
+    bool         (__cdecl* CanSeekStream)(void*);
+    bool         (__cdecl* SeekTime)(void*, int, bool, double*);
+    void         (__cdecl* SetSpeed)(void*, int);
+    time_t       (__cdecl* GetPlayingTime)(void*);
+    time_t       (__cdecl* GetBufferTimeStart)(void*);
+    time_t       (__cdecl* GetBufferTimeEnd)(void*);
+    const char*  (__cdecl* GetBackendHostname)(void*);
+    bool         (__cdecl* IsTimeshifting)(void*);
+    bool         (__cdecl* IsRealTimeStream)(void*);
+    PVR_ERROR    (__cdecl* SetEPGTimeFrame)(void*, int);
+    void         (__cdecl* OnSystemSleep)(void*);
+    void         (__cdecl* OnSystemWake)(void*);
+    void         (__cdecl* OnPowerSavingActivated)(void*);
+    void         (__cdecl* OnPowerSavingDeactivated)(void*);
   } PVRClient;
 
 #ifdef __cplusplus


### PR DESCRIPTION
This is also one part needed for reworked binary PVR add-ons, it add a handle pointer to all calls from Kodi to add-on. This handle is also usable for the current version and can be set during add-on create with `RegisterHandle` call on libPVR.

Goal from them is to identify a from add-on headers defined parent class (comes in future) on calls to Kodi, further is another coming goal to allow more as one client connection on a add-on.

If this way is Ok becomes from me for all add-ons a request created. Also becomes this way added to other types.
