### PR TITLE
fix library-music settings label

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1019,7 +1019,7 @@
       </group>
     </category>	
     <category id="music" label="14216" help="38108">
-	  <group id="1" label="14230">
+	  <group id="1" label="14240">
         <setting id="musiclibrary.showallitems" type="boolean" label="38011" help="38012">
           <level>2</level>
           <default>true</default>


### PR DESCRIPTION
settings > library > music

settings label of the first group should be 'lists & views', instead of 'actions'.
