### PR TITLE
[python] add support for image border

### DIFF
--- a/xbmc/interfaces/legacy/Window.cpp
+++ b/xbmc/interfaces/legacy/Window.cpp
@@ -305,6 +305,7 @@ namespace XBMCAddon
         pControl = new ControlTextBox();
         break;
       case CGUIControl::GUICONTROL_IMAGE:
+      case CGUIControl::GUICONTROL_BORDEREDIMAGE:
         pControl = new ControlImage();
         break;
       case CGUIControl::GUICONTROL_PROGRESS:


### PR DESCRIPTION
scripts using WindowXML would crash if they use an image control with a bordertexture and/or bordersize tag.
`RuntimeError: Unknown control type for python`

let's fix that.

@tamland 
