### PR TITLE
[aml] Use amlvideo driver for audio/video sync

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.h
@@ -25,10 +25,14 @@
 #include "guilib/Geometry.h"
 #include "rendering/RenderSystem.h"
 #include "threads/Thread.h"
+#include <deque>
 
 typedef struct am_private_t am_private_t;
 
 class DllLibAmCodec;
+
+class PosixFile;
+typedef std::shared_ptr<PosixFile> PosixFilePtr;
 
 class CAMLCodec : public CThread
 {
@@ -47,6 +51,7 @@ public:
   int           GetDataSize();
   double        GetTimeSize();
   void          SetVideoRect(const CRect &SrcRect, const CRect &DestRect);
+  int64_t       GetCurPts() const { return m_cur_pts; }
 
 protected:
   virtual void  Process();
@@ -60,6 +65,11 @@ private:
   void          SetVideoSaturation(const int saturation);
   void          SetVideo3dMode(const int mode3d);
   std::string   GetStereoMode();
+  bool          OpenAmlVideo(const CDVDStreamInfo &hints);
+  void          CloseAmlVideo();
+  std::string   GetVfmMap(const std::string &name);
+  void          SetVfmMap(const std::string &name, const std::string &map);
+  int           DequeueBuffer(int &pts);
 
   DllLibAmCodec   *m_dll;
   bool             m_opened;
@@ -68,8 +78,6 @@ private:
   volatile int     m_speed;
   volatile int64_t m_1st_pts;
   volatile int64_t m_cur_pts;
-  volatile int64_t m_cur_pictcnt;
-  volatile int64_t m_old_pictcnt;
   volatile double  m_timesize;
   volatile int64_t m_vbufsize;
   int64_t          m_start_dts;
@@ -86,5 +94,8 @@ private:
   int              m_contrast;
   int              m_brightness;
 
-  double m_player_pts;
+  PosixFilePtr     m_amlVideoFile;
+  std::string      m_defaultVfmMap;
+  std::deque<int>  m_ptsQueue;
+  CCriticalSection m_ptsQueueMutex;
 };

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
@@ -296,7 +296,7 @@ bool CDVDVideoCodecAmlogic::GetPicture(DVDVideoPicture* pDvdVideoPicture)
     m_Codec->GetPicture(&m_videobuffer);
   *pDvdVideoPicture = m_videobuffer;
 
-  CDVDAmlogicInfo* info = new CDVDAmlogicInfo(this, m_Codec);
+  CDVDAmlogicInfo* info = new CDVDAmlogicInfo(this, m_Codec, (int)m_Codec->GetCurPts());
 
   {
     CSingleLock lock(m_secure);
@@ -577,10 +577,11 @@ void CDVDVideoCodecAmlogic::RemoveInfo(CDVDAmlogicInfo *info)
   m_inflight.erase(m_inflight.find(info));
 }
 
-CDVDAmlogicInfo::CDVDAmlogicInfo(CDVDVideoCodecAmlogic *codec, CAMLCodec *amlcodec)
+CDVDAmlogicInfo::CDVDAmlogicInfo(CDVDVideoCodecAmlogic *codec, CAMLCodec *amlcodec, int omxPts)
   : m_refs(0)
   , m_codec(codec)
   , m_amlCodec(amlcodec)
+  , m_omxPts(omxPts)
 {
 }
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.h
@@ -36,13 +36,14 @@ class CDVDVideoCodecAmlogic;
 class CDVDAmlogicInfo
 {
 public:
-  CDVDAmlogicInfo(CDVDVideoCodecAmlogic *codec, CAMLCodec *amlcodec);
+  CDVDAmlogicInfo(CDVDVideoCodecAmlogic *codec, CAMLCodec *amlcodec, int omxPts);
 
   // reference counting
   CDVDAmlogicInfo* Retain();
   long             Release();
 
   CAMLCodec *getAmlCodec() const;
+  int GetOmxPts() const { return m_omxPts; }
   void invalidate();
 
 protected:
@@ -51,6 +52,7 @@ protected:
 
   CDVDVideoCodecAmlogic* m_codec;
   CAMLCodec* m_amlCodec;
+  int m_omxPts;
 };
 
 class CDVDVideoCodecAmlogic : public CDVDVideoCodec

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererAML.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererAML.cpp
@@ -27,18 +27,18 @@
 #include "cores/VideoPlayer/DVDCodecs/Video/AMLCodec.h"
 #include "utils/log.h"
 #include "utils/GLUtils.h"
+#include "utils/SysfsUtils.h"
 #include "settings/MediaSettings.h"
 #include "windowing/WindowingFactory.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderCapture.h"
 
 CRendererAML::CRendererAML()
 {
-
+  m_prevPts = -1;
 }
 
 CRendererAML::~CRendererAML()
 {
-
 }
 
 bool CRendererAML::RenderCapture(CRenderCapture* capture)
@@ -118,7 +118,7 @@ bool CRendererAML::LoadShadersHook()
 {
   CLog::Log(LOGNOTICE, "GL: Using AML render method");
   m_textureTarget = GL_TEXTURE_2D;
-  m_renderMethod = RENDER_FMT_AML;
+  m_renderMethod = RENDER_BYPASS;
   return false;
 }
 
@@ -132,15 +132,19 @@ bool CRendererAML::RenderUpdateVideoHook(bool clear, DWORD flags, DWORD alpha)
   ManageRenderArea();
 
   CDVDAmlogicInfo *amli = static_cast<CDVDAmlogicInfo *>(m_buffers[m_iYV12RenderBuffer].hwDec);
-  if (amli)
+  if (amli && amli->GetOmxPts() != m_prevPts)
   {
+    m_prevPts = amli->GetOmxPts();
+    SysfsUtils::SetInt("/sys/module/amvideo/parameters/omx_pts", amli->GetOmxPts());
+
     CAMLCodec *amlcodec = amli->getAmlCodec();
     if (amlcodec)
       amlcodec->SetVideoRect(m_sourceRect, m_destRect);
   }
 
+  usleep(10000);
+
   return true;
 }
 
 #endif
-

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererAML.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererAML.h
@@ -55,6 +55,9 @@ protected:
   virtual bool RenderHook(int index);  
   virtual int  GetImageHook(YV12Image *image, int source = AUTOSOURCE, bool readonly = false);
   virtual bool RenderUpdateVideoHook(bool clear, DWORD flags = 0, DWORD alpha = 255);
+
+private:
+  int m_prevPts;
 };
 
 #endif

--- a/xbmc/utils/AMLUtils.cpp
+++ b/xbmc/utils/AMLUtils.cpp
@@ -118,6 +118,21 @@ bool aml_permissions()
       CLog::Log(LOGERROR, "AML: no rw on /sys/class/tsync/pts_pcrscr");
       permissions_ok = 0;
     }
+    if (!SysfsUtils::HasRW("/dev/video10"))
+    {
+      CLog::Log(LOGERROR, "AML: no rw on /dev/video10");
+      permissions_ok = 0;
+    }
+    if (!SysfsUtils::HasRW("/sys/module/amvideo/parameters/omx_pts"))
+    {
+      CLog::Log(LOGERROR, "AML: no rw on /sys/module/amvideo/parameters/omx_pts");
+      permissions_ok = 0;
+    }
+    if (!SysfsUtils::HasRW("/sys/module/amlvideodri/parameters/freerun_mode"))
+    {
+      CLog::Log(LOGERROR, "AML: no rw on /sys/module/amlvideodri/parameters/freerun_mode");
+      permissions_ok = 0;
+    }
     if (!SysfsUtils::HasRW("/sys/class/audiodsp/digital_raw"))
     {
       CLog::Log(LOGERROR, "AML: no rw on /sys/class/audiodsp/digital_raw");


### PR DESCRIPTION
This PR fixes A/V sync issues in amcodec after master clock removal. Requires CONFIG_V4L_AMLOGIC_VIDEO to be enabled in kernel config.
