### PR TITLE
[audiodsp] Use label/label2/icon instead of properties

### DIFF
--- a/addons/skin.estuary/1080i/Includes.xml
+++ b/addons/skin.estuary/1080i/Includes.xml
@@ -193,7 +193,7 @@
 					<top>8</top>
 					<width>64</width>
 					<height>64</height>
-					<texture fallback="DefaultAudioDSP.png">$INFO[ListItem.Property(Icon)]</texture>
+					<texture>$INFO[ListItem.Icon]</texture>
 					<aspectratio aligny="center" align="left">keep</aspectratio>
 				</control>
 				<control type="label">
@@ -203,7 +203,7 @@
 					<height>40</height>
 					<font>font12</font>
 					<aligny>center</aligny>
-					<label>$INFO[ListItem.Property(AddonName)]</label>
+					<label>$INFO[ListItem.Label]</label>
 				</control>
 				<control type="label">
 					<left>82</left>
@@ -213,7 +213,7 @@
 					<font>font10</font>
 					<aligny>center</aligny>
 					<textcolor>grey</textcolor>
-					<label>$INFO[ListItem.Property(Name)]</label>
+					<label>$INFO[ListItem.Label2]</label>
 				</control>
 			</itemlayout>
 			<focusedlayout height="80" width="470">
@@ -238,7 +238,7 @@
 					<top>8</top>
 					<width>64</width>
 					<height>64</height>
-					<texture fallback="DefaultAudioDSP.png">$INFO[ListItem.Property(Icon)]</texture>
+					<texture>$INFO[ListItem.Icon]</texture>
 					<aspectratio aligny="center" align="left">keep</aspectratio>
 				</control>
 				<control type="label">
@@ -248,7 +248,7 @@
 					<height>40</height>
 					<font>font12</font>
 					<aligny>center</aligny>
-					<label>$INFO[ListItem.Property(AddonName)]</label>
+					<label>$INFO[ListItem.Label]</label>
 				</control>
 				<control type="label">
 					<left>82</left>
@@ -258,7 +258,7 @@
 					<font>font10</font>
 					<aligny>center</aligny>
 					<textcolor>grey</textcolor>
-					<label>$INFO[ListItem.Property(Name)]</label>
+					<label>$INFO[ListItem.Label2]</label>
 				</control>
 			</focusedlayout>
 		</control>

--- a/xbmc/settings/dialogs/GUIDialogAudioDSPManager.cpp
+++ b/xbmc/settings/dialogs/GUIDialogAudioDSPManager.cpp
@@ -1026,14 +1026,17 @@ CFileItem *CGUIDialogAudioDSPManager::helper_CreateModeListItem(CActiveAEDSPMode
   // set list item properties
   pItem->SetProperty("ActiveMode", isActive);
   pItem->SetProperty("Number", number);
-  pItem->SetProperty("Name", modeName);
+  pItem->SetLabel(modeName);
   pItem->SetProperty("Description", description);
   pItem->SetProperty("Help", ModePointer->ModeHelp());
-  pItem->SetProperty("Icon", ModePointer->IconOwnModePath());
+  if (ModePointer->IconOwnModePath().empty())
+    pItem->SetIconImage("DefaultAddonAudioDSP.png");
+  else
+    pItem->SetIconImage(ModePointer->IconOwnModePath());
   pItem->SetProperty("SettingsDialog", dialogId);
   pItem->SetProperty("AddonId", AddonID);
   pItem->SetProperty("AddonModeNumber", ModePointer->AddonModeNumber());
-  pItem->SetProperty("AddonName", addonName);
+  pItem->SetLabel2(addonName);
   pItem->SetProperty("Changed", false);
 
   return pItem;


### PR DESCRIPTION
To be consistent I changed the list properties to common label/label2/icon.
Also added a check if the icon is empty to use `DefaultAddonAudioDSP.png` instead so no fallbacks have to be used in skin code.

@phil65 @AchimTuran 
