### PR TITLE
[guilib] Remove cache before opening plugin urls from shortcut - Fixes #16560

### DIFF
--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -656,8 +656,9 @@ bool CGUIMediaWindow::GetDirectory(const std::string &strDirectory, CFileItemLis
     CAddonMgr::GetInstance().UpdateLastUsed(pathToUrl.GetHostName());
 
   // see if we can load a previously cached folder
+  // skip in case of plugin content as this needs the latest content
   CFileItemList cachedItems(strDirectory);
-  if (!strDirectory.empty() && cachedItems.Load(GetID()))
+  if (!strDirectory.empty() && cachedItems.Load(GetID()) && !pathToUrl.IsProtocol("plugin"))
   {
     items.Assign(cachedItems);
   }


### PR DESCRIPTION
As a plugin is mostly online content the cache should be removed before opening to make sure we get latest content.
