### PR TITLE
[addons] revert default value change for notification setting

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2464,7 +2464,7 @@
         </setting>
         <setting id="general.addonnotifications" type="boolean" label="36609" help="36612">
           <level>0</level>
-          <default>false</default>
+          <default>true</default>
           <control type="toggle" />
           <dependencies>
             <dependency type="enable" setting="general.addonupdates">0</dependency>


### PR DESCRIPTION
"Temporary workaround". Setting is too broken as it hides notifications used for manual installs as well. Fixing it requires more extensive changes to the addon installer.
