### PR TITLE
fix database version after premiered date missed bump

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -4970,7 +4970,7 @@ void CVideoDatabase::UpdateTables(int iVersion)
 
 int CVideoDatabase::GetSchemaVersion() const
 {
-  return 104;
+  return 105;
 }
 
 bool CVideoDatabase::LookupByFolders(const std::string &path, bool shows)


### PR DESCRIPTION
I missed that the database version bump was lost during the premiere date pr rebase (because another pr bumped it in the mean time)
