### PR TITLE
fix failing activation of startup window

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1153,6 +1153,9 @@ bool CApplication::Initialize()
       int firstWindow = g_SkinInfo->GetFirstWindow();
       g_windowManager.ActivateWindow(firstWindow);
 
+      if (g_windowManager.GetActiveWindowID() == WINDOW_STARTUP_ANIM)
+        g_windowManager.ActivateWindow(WINDOW_HOME);
+
       // the startup window is considered part of the initialization as it most likely switches to the final window
       uiInitializationFinished = firstWindow != WINDOW_STARTUP_ANIM;
 


### PR DESCRIPTION
@MilhouseVH 
This cures the problem mentioned in this ticket http://trac.kodi.tv/ticket/16754

@ksooo @Jalle19 
But the actual problem is that setting PVR (TV) window as startup window is wrong by design. A window that is not available at startup and that depends on other services can't be a startup window. I see those options:

1) Fix PVR window and allow activation (as empty window) if there are no connected PVR clients. Currently it would crash.

2) Add a setting to PVR that makes Kodi switch to PVR window as soon the first PVR clients becomes available. Remove TV window form the list of startup windows.

3) Do nothing and just remove PVR from the list of startup windows.
