### PR TITLE
Default Scale for HQ scaling above

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -16647,7 +16647,7 @@ msgstr ""
 #. Description of setting with label #13435 "Enable HQ Scalers for scaling above"
 #: system/settings/settings.xml
 msgctxt "#36154"
-msgid "Use high quality scalers when upscaling a video by at least this percentage."
+msgid "Use high quality scalers when upscaling a video by at least this percentage. A value below 5% makes little sense as video is processed with high GPU load without any visible picture quality improvements."
 msgstr ""
 
 #. Description of setting with label #13425 "Allow hardware acceleration (VDPAU)"

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -100,7 +100,7 @@
         </setting>
         <setting id="videoplayer.hqscalers" type="integer" parent="videoplayer.rendermethod" label="13435" help="36154">
           <level>2</level>
-          <default>0</default>
+          <default>20</default>
           <constraints>
             <minimum>0</minimum>
             <step>10</step>


### PR DESCRIPTION
This setting is fully confusing for users as hq scaling is a waste of resources if source and target nearly have the very same dimensions. It puts immense load on the GPU while visual quality improvement is not given at all. There is no need to process a 1080p file with a 6x6 convolution shader if the output image is still ~ 1080p.

Also the barely existing documentation is confusing to the user, too.

Example:
1080p Output resolution.

Video: 1280x720
(1920 - 1280) / 1920 = 33%
(1080 - 720) / 1080 = 33 %

Video: 1920x1080
(1920 - 1920) / 1920 = 0 %
(1080 - 1080) / 1080 = 0%

In code the minimum of both values is chosen.

In short a default value of 20% will use HQ scaling when scaling 720p to 1080p or when scaling 576i to 1080p. It won't use hq scalers starting with (1536 width) for this 1080p example.
