### PR TITLE
[cmake] Re-order scripts/linux/Install.cmake and make paths relative

### DIFF
--- a/project/cmake/scripts/linux/Install.cmake
+++ b/project/cmake/scripts/linux/Install.cmake
@@ -14,8 +14,11 @@ else()
   set(USE_OPENGLES 0)
 endif()
 
-configure_file(${CORE_SOURCE_DIR}/tools/Linux/kodi.sh.in
-               ${CORE_BUILD_DIR}/scripts/${APP_NAME_LC} @ONLY)
+# CMake config
+set(APP_LIB_DIR ${CMAKE_INSTALL_PREFIX}/lib/${APP_NAME_LC})
+set(APP_PREFIX ${CMAKE_INSTALL_PREFIX})
+set(APP_INCLUDE_DIR ${CMAKE_INSTALL_PREFIX}/include/${APP_NAME_LC})
+set(CXX11_SWITCH "-std=c++11")
 
 # Set XBMC_STANDALONE_SH_PULSE so we can insert PulseAudio block into kodi-standalone
 if(EXISTS ${CORE_SOURCE_DIR}/tools/Linux/kodi-standalone.sh.pulse)
@@ -25,87 +28,118 @@ if(EXISTS ${CORE_SOURCE_DIR}/tools/Linux/kodi-standalone.sh.pulse)
   endif()
 endif()
 
+# Configure startup scripts
+configure_file(${CORE_SOURCE_DIR}/tools/Linux/kodi.sh.in
+               ${CORE_BUILD_DIR}/scripts/${APP_NAME_LC} @ONLY)
 configure_file(${CORE_SOURCE_DIR}/tools/Linux/kodi-standalone.sh.in
                ${CORE_BUILD_DIR}/scripts/${APP_NAME_LC}-standalone @ONLY)
 
-# cmake config
 
-set(APP_LIB_DIR ${CMAKE_INSTALL_PREFIX}/lib/${APP_NAME_LC})
-set(APP_PREFIX ${CMAKE_INSTALL_PREFIX})
-set(APP_INCLUDE_DIR ${CMAKE_INSTALL_PREFIX}/include/${APP_NAME_LC})
-set(CXX11_SWITCH "-std=c++11")
+# Configure cmake files
 configure_file(${PROJECT_SOURCE_DIR}/KodiConfig.cmake.in
                ${CORE_BUILD_DIR}/scripts/${APP_NAME}Config.cmake @ONLY)
+
+# Configure xsession entry
+configure_file(${CORE_SOURCE_DIR}/tools/Linux/kodi-xsession.desktop.in
+               ${CORE_BUILD_DIR}/${APP_NAME_LC}.desktop @ONLY)
+
+# Install cmake files
+# TODO: revisit, refactor and nuke txt file globbing
+install(FILES ${cmake_files} DESTINATION lib/${APP_NAME_LC})
 install(FILES ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/scripts/${APP_NAME}Config.cmake
               ${PROJECT_SOURCE_DIR}/scripts/common/AddOptions.cmake
               ${PROJECT_SOURCE_DIR}/scripts/common/AddonHelpers.cmake
               ${PROJECT_SOURCE_DIR}/scripts/linux/PathSetup.cmake
         DESTINATION lib/${APP_NAME_LC})
-install(FILES ${cmake_files} DESTINATION ${libdir}/${APP_NAME_LC})
-install(TARGETS ${APP_NAME_LC} DESTINATION ${libdir}/${APP_NAME_LC})
+
+# Install app
+install(TARGETS ${APP_NAME_LC} DESTINATION lib/${APP_NAME_LC})
 if(ENABLE_X11 AND XRANDR_FOUND)
-  install(TARGETS ${APP_NAME_LC}-xrandr DESTINATION ${libdir}/${APP_NAME_LC})
+  install(TARGETS ${APP_NAME_LC}-xrandr DESTINATION lib/${APP_NAME_LC})
 endif()
 
-if(NOT EXISTS ${libdir}/xbmc)
-install(CODE "execute_process(COMMAND ln -sf ${APP_NAME_LC}/ xbmc WORKING_DIRECTORY ${libdir})")
-endif()
-install(FILES ${addon_bindings} DESTINATION ${includedir}/${APP_NAME_LC})
-if(NOT EXISTS ${includedir}/xbmc)
-install(CODE "execute_process(COMMAND ln -sf ${APP_NAME_LC}/ xbmc WORKING_DIRECTORY ${includedir})")
-endif()
-
+# Install scripts
 install(PROGRAMS ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/scripts/${APP_NAME_LC}
                  ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/scripts/${APP_NAME_LC}-standalone
-        DESTINATION ${bindir})
-install(CODE "execute_process(COMMAND ln -sf ${APP_NAME_LC} xbmc WORKING_DIRECTORY ${bindir})")
-install(CODE "execute_process(COMMAND ln -sf ${APP_NAME_LC}-standalone xbmc-standalone WORKING_DIRECTORY ${bindir})")
+        DESTINATION bin)
 
-configure_file(${CORE_SOURCE_DIR}/tools/Linux/kodi-xsession.desktop.in
-               ${CORE_BUILD_DIR}/${APP_NAME_LC}.desktop)
+# Install libraries
+foreach(wraplib ${WRAP_FILES})
+  get_filename_component(dir ${wraplib} PATH)
+  install(PROGRAMS ${CMAKE_BINARY_DIR}/${wraplib}
+          DESTINATION lib/${APP_NAME_LC}/${dir})
+endforeach()
+
+# Install add-ons, fonts, icons, keyboard maps, keymaps, etc
+# (addons, media, system, userdata folders in share/kodi/)
+foreach(file ${install_data})
+  get_filename_component(dir ${file} PATH)
+  install(FILES ${CMAKE_BINARY_DIR}/${file}
+          DESTINATION share/${APP_NAME_LC}/${dir})
+endforeach()
+
+# Install add-on bindings
+install(FILES ${addon_bindings} DESTINATION include/${APP_NAME_LC})
+
+# Install xsession entry
 install(FILES ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/${APP_NAME_LC}.desktop
-        DESTINATION ${datarootdir}/xsessions)
-install(CODE "execute_process(COMMAND ln -sf ${APP_NAME_LC}.desktop xbmc.desktop WORKING_DIRECTORY ${datarootdir}/xsessions/)")
+        DESTINATION share/xsessions)
 
-if(NOT EXISTS ${datarootdir}/xbmc)
-install(CODE "execute_process(COMMAND ln -sf ${APP_NAME_LC}/ xbmc WORKING_DIRECTORY ${datarootdir})")
-endif()
+# Install desktop entry
+install(FILES ${CORE_SOURCE_DIR}/tools/Linux/kodi.desktop
+        DESTINATION share/applications/${APP_NAME_LC}.desktop)
 
+# Install icons
+install(FILES ${CORE_SOURCE_DIR}/tools/Linux/packaging/media/icon16x16.png
+        RENAME ${APP_NAME_LC}.png
+        DESTINATION share/icons/hicolor/16x16/apps)
+install(FILES ${CORE_SOURCE_DIR}/tools/Linux/packaging/media/icon22x22.png
+        RENAME ${APP_NAME_LC}.png
+        DESTINATION share/icons/hicolor/22x22/apps)
+install(FILES ${CORE_SOURCE_DIR}/tools/Linux/packaging/media/icon24x24.png
+        RENAME ${APP_NAME_LC}.png
+        DESTINATION share/icons/hicolor/24x24/apps)
+install(FILES ${CORE_SOURCE_DIR}/tools/Linux/packaging/media/icon32x32.png
+        RENAME ${APP_NAME_LC}.png
+        DESTINATION share/icons/hicolor/32x32/apps)
+install(FILES ${CORE_SOURCE_DIR}/tools/Linux/packaging/media/icon48x48.png
+        RENAME ${APP_NAME_LC}.png
+        DESTINATION share/icons/hicolor/48x48/apps)
+install(FILES ${CORE_SOURCE_DIR}/tools/Linux/packaging/media/icon64x64.png
+        RENAME ${APP_NAME_LC}.png
+        DESTINATION share/icons/hicolor/64x64/apps)
+install(FILES ${CORE_SOURCE_DIR}/tools/Linux/packaging/media/icon128x128.png
+        RENAME ${APP_NAME_LC}.png
+        DESTINATION share/icons/hicolor/128x128/apps)
+install(FILES ${CORE_SOURCE_DIR}/tools/Linux/packaging/media/icon256x256.png
+        RENAME ${APP_NAME_LC}.png
+        DESTINATION share/icons/hicolor/256x256/apps)
+install(CODE "execute_process(COMMAND gtk-update-icon-cache -f -q -t
+        $ENV{DESTDIR}${datarootdir}/icons/hicolor ERROR_QUIET)")
+
+# Install docs
 install(FILES ${CORE_SOURCE_DIR}/copying.txt
               ${CORE_SOURCE_DIR}/LICENSE.GPL
               ${CORE_SOURCE_DIR}/version.txt
               ${CORE_SOURCE_DIR}/docs/README.linux
-        DESTINATION ${datarootdir}/doc/${APP_NAME_LC})
+        DESTINATION share/doc/${APP_NAME_LC})
 
-install(FILES ${CORE_SOURCE_DIR}/tools/Linux/kodi.desktop
-        DESTINATION ${datarootdir}/applications/${APP_NAME_LC}.desktop)
-
+# Install XBT skin files
 foreach(texture ${XBT_FILES})
   string(REPLACE "${CMAKE_BINARY_DIR}/" "" dir ${texture})
   get_filename_component(dir ${dir} PATH)
   install(FILES ${texture}
-          DESTINATION ${datarootdir}/${APP_NAME_LC}/${dir})
+          DESTINATION share/${APP_NAME_LC}/${dir})
 endforeach()
 
-foreach(wraplib ${WRAP_FILES})
-  get_filename_component(dir ${wraplib} PATH)
-  install(PROGRAMS ${CMAKE_BINARY_DIR}/${wraplib}
-          DESTINATION ${libdir}/${APP_NAME_LC}/${dir})
-endforeach()
-
-foreach(file ${install_data})
-  get_filename_component(dir ${file} PATH)
-  install(FILES ${CMAKE_BINARY_DIR}/${file}
-          DESTINATION ${datarootdir}/${APP_NAME_LC}/${dir})
-endforeach()
-
+# Install extra stuff if it exists
 if(EXISTS ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/extra-installs)
   install(CODE "file(STRINGS ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/extra-installs dirs)
               foreach(dir \${dirs})
                 file(GLOB_RECURSE FILES RELATIVE ${CMAKE_BINARY_DIR} \${dir}/*)
                 foreach(file \${FILES})
                   get_filename_component(dir \${file} PATH)
-                  file(INSTALL \${file} DESTINATION ${datarootdir}/${APP_NAME_LC}/\${dir})
+                  file(INSTALL \${file} DESTINATION share/${APP_NAME_LC}/\${dir})
                 endforeach()
               endforeach()")
 endif()
@@ -121,29 +155,29 @@ foreach(subdir ${build_dirs})
   endif()
 endforeach()
 
-install(FILES ${CORE_SOURCE_DIR}/tools/Linux/packaging/media/icon16x16.png
-        RENAME ${APP_NAME_LC}.png
-        DESTINATION ${datarootdir}/icons/hicolor/16x16/apps)
-install(FILES ${CORE_SOURCE_DIR}/tools/Linux/packaging/media/icon22x22.png
-        RENAME ${APP_NAME_LC}.png
-        DESTINATION ${datarootdir}/icons/hicolor/22x22/apps)
-install(FILES ${CORE_SOURCE_DIR}/tools/Linux/packaging/media/icon24x24.png
-        RENAME ${APP_NAME_LC}.png
-        DESTINATION ${datarootdir}/icons/hicolor/24x24/apps)
-install(FILES ${CORE_SOURCE_DIR}/tools/Linux/packaging/media/icon32x32.png
-        RENAME ${APP_NAME_LC}.png
-        DESTINATION ${datarootdir}/icons/hicolor/32x32/apps)
-install(FILES ${CORE_SOURCE_DIR}/tools/Linux/packaging/media/icon48x48.png
-        RENAME ${APP_NAME_LC}.png
-        DESTINATION ${datarootdir}/icons/hicolor/48x48/apps)
-install(FILES ${CORE_SOURCE_DIR}/tools/Linux/packaging/media/icon64x64.png
-        RENAME ${APP_NAME_LC}.png
-        DESTINATION ${datarootdir}/icons/hicolor/64x64/apps)
-install(FILES ${CORE_SOURCE_DIR}/tools/Linux/packaging/media/icon128x128.png
-        RENAME ${APP_NAME_LC}.png
-        DESTINATION ${datarootdir}/icons/hicolor/128x128/apps)
-install(FILES ${CORE_SOURCE_DIR}/tools/Linux/packaging/media/icon256x256.png
-        RENAME ${APP_NAME_LC}.png
-        DESTINATION ${datarootdir}/icons/hicolor/256x256/apps)
+# Create xbmc -> kodi symlinks
+if(NOT EXISTS ${libdir}/xbmc)
+  install(CODE "execute_process(COMMAND ln -sf ${APP_NAME_LC}/ xbmc
+          WORKING_DIRECTORY ${libdir})")
+endif()
+if(NOT EXISTS ${includedir}/xbmc)
+  install(CODE "execute_process(COMMAND ln -sf ${APP_NAME_LC}/ xbmc
+          WORKING_DIRECTORY ${includedir})")
+endif()
+if(NOT EXISTS ${bindir}/xbmc)
+  install(CODE "execute_process(COMMAND ln -sf ${APP_NAME_LC} xbmc
+          WORKING_DIRECTORY ${bindir})")
+endif()
+if(NOT EXISTS ${bindir}/xbmc-standalone)
+  install(CODE "execute_process(COMMAND ln -sf ${APP_NAME_LC}-standalone xbmc-standalone
+          WORKING_DIRECTORY ${bindir})")
+endif()
+if(NOT EXISTS ${datarootdir}/xsessions/xbmc.desktop)
+  install(CODE "execute_process(COMMAND ln -sf ${APP_NAME_LC}.desktop xbmc.desktop
+          WORKING_DIRECTORY ${datarootdir}/xsessions/)")
+endif()
+if(NOT EXISTS ${datarootdir}/xbmc)
+  install(CODE "execute_process(COMMAND ln -sf ${APP_NAME_LC}/ xbmc
+          WORKING_DIRECTORY ${datarootdir})")
+endif()
 
-install(CODE "execute_process(COMMAND gtk-update-icon-cache -f -q -t $ENV{DESTDIR}${datarootdir}/icons/hicolor ERROR_QUIET)")


### PR DESCRIPTION
First step to make CPack DEB a reality.
Change install paths to relative to make CPack DEB generation usable.
By now I can generate a monolithic kodi-_-_.deb package with correct paths.

Next step, generate deb packages separated by component. Now the fun begins. CPack docs are amazing!!

cc/ @fetzerch, @wsnipex 

Sorry, diff is basically unreadable...
