### PR TITLE
Speed up startup time for movies in split rar archives.

### DIFF
--- a/lib/UnrarXLib/volume.cpp
+++ b/lib/UnrarXLib/volume.cpp
@@ -20,8 +20,23 @@ bool MergeArchive(Archive &Arc,ComprDataIO *DataIO,bool ShowFileName,char Comman
   Arc.Close();
 
   char NextName[NM];
-  strcpy(NextName,Arc.FileName);
-  NextVolumeName(NextName,(Arc.NewMhd.Flags & MHD_NEWNUMBERING)==0 || Arc.OldFormat);
+  if(DataIO != NULL && (DataIO->m_iSeekTo > Arc.NewLhd.FullPackSize)){
+    if (Arc.Volume && Arc.NotFirstVolume)
+      VolNameToFirstName(Arc.FileName,NextName,(Arc.NewMhd.Flags & MHD_NEWNUMBERING));
+    else
+      strcpy(NextName,Arc.FileName);
+
+    Int64 FastSeek = 0;
+    while(FastSeek+Arc.NewLhd.FullPackSize < DataIO->m_iSeekTo){
+      NextVolumeName(NextName,(Arc.NewMhd.Flags & MHD_NEWNUMBERING)==0 || Arc.OldFormat);
+      FastSeek += Arc.NewLhd.FullPackSize;
+    }
+    DataIO->CurUnpRead = FastSeek;
+
+  }else{
+    strcpy(NextName,Arc.FileName);
+    NextVolumeName(NextName,(Arc.NewMhd.Flags & MHD_NEWNUMBERING)==0 || Arc.OldFormat);
+  }
 
 #if !defined(SFX_MODULE) && !defined(RARDLL)
   bool RecoveryDone=false;


### PR DESCRIPTION
This patch cuts down on the seek time for files in stored rar archives.

Usually, when seeking in split rar archives, Kodi needs to open every
file until it reaches the right seek address.

When seeking, Kodi usually needs to go through every single archive r01,r02,r03,r04...r80,81.. until it reaches the address its seeking. But with this patch, Kodi is able to jump directly to the right file. Instead of going trough for example r01-r84. It opens only the right file, r85, right away.

This improves the start-up time a whole lot, especially when playing video over FTP or NFS.
