### PR TITLE
add MusicAddons as a library xml node

### DIFF
--- a/system/library/music/addons.xml
+++ b/system/library/music/addons.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<node order="22" type="folder">
+  <label>1038</label>
+  <icon>DefaultAddonMusic.png</icon>
+  <path>addons://sources/audio/</path>
+</node>

--- a/xbmc/music/GUIViewStateMusic.cpp
+++ b/xbmc/music/GUIViewStateMusic.cpp
@@ -61,7 +61,6 @@ std::string CGUIViewStateWindowMusic::GetExtensions()
 
 VECSOURCES& CGUIViewStateWindowMusic::GetSources()
 {
-  AddAddonsSource("audio", g_localizeStrings.Get(1038), "DefaultAddonMusic.png");
   return CGUIViewState::GetSources();
 }
 


### PR DESCRIPTION
not sure why one was forgotten when we moved to library xml nodes for music in https://github.com/xbmc/xbmc/pull/6772

ping @mkortstiege 
