### PR TITLE
Speed up subtitle search

### DIFF
--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -252,6 +252,13 @@ private:
                                              const std::vector<std::string>& item_exts,
                                              std::vector<std::string>& associatedFiles);
 
+    /** \brief Remove RAR Volumes associated with the movie strMovie from items.
+    *   \param[in]  strMovie The full path to the Movie.
+    *   \param[in]  items The list of items to filter
+    */
+    static void ExcludeMovieRar(const std::string& strMovie,
+                                CFileItemList& items);
+
 };
 
 


### PR DESCRIPTION
If the main video is in rar archives, then exclude the video rar archives from subtitle search.
This improves the video startup time by excluding all the rarfiles associated with the video, from the subtitle search.
