### PR TITLE
reduce impact of touching VideoDatabase.h, PVRRecordings.h

### DIFF
--- a/xbmc/ThumbnailCache.cpp
+++ b/xbmc/ThumbnailCache.cpp
@@ -23,7 +23,6 @@
 #include "threads/SingleLock.h"
 
 #include "FileItem.h"
-#include "video/VideoDatabase.h"
 
 using namespace XFILE;
 using namespace MUSIC_INFO;

--- a/xbmc/addons/AddonBuilder.cpp
+++ b/xbmc/addons/AddonBuilder.cpp
@@ -27,6 +27,7 @@
 #include "addons/LanguageResource.h"
 #include "addons/PluginSource.h"
 #include "addons/Repository.h"
+#include "addons/Scraper.h"
 #include "addons/ScreenSaver.h"
 #include "addons/Service.h"
 #include "addons/Skin.h"

--- a/xbmc/addons/PVRClient.h
+++ b/xbmc/addons/PVRClient.h
@@ -25,7 +25,6 @@
 #include "network/ZeroconfBrowser.h"
 
 #include "pvr/channels/PVRChannel.h"
-#include "pvr/recordings/PVRRecordings.h"
 
 namespace EPG
 {

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDFactoryDemuxer.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDFactoryDemuxer.cpp
@@ -30,7 +30,8 @@
 #include "DVDDemuxClient.h"
 #include "DemuxMultiSource.h"
 #include "pvr/PVRManager.h"
-#include "pvr/addons/PVRClients.h"
+#include "utils/log.h"
+#include "utils/URIUtils.h"
 
 using namespace PVR;
 

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamPVRManager.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamPVRManager.cpp
@@ -29,6 +29,7 @@
 #include "pvr/addons/PVRClients.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/recordings/PVRRecordingsPath.h"
+#include "pvr/recordings/PVRRecordings.h"
 #include "settings/Settings.h"
 #include "cores/VideoPlayer/DVDDemuxers/DVDDemux.h"
 

--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -42,10 +42,10 @@
 #include "filesystem/File.h"
 #include "guilib/LocalizeStrings.h"
 #include "TextureCache.h"
-#include "video/windows/GUIWindowVideoBase.h"
 #include "URL.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
+#include "addons/Scraper.h"
 
 #define BACKGROUND_IMAGE       999
 #define GROUP_LIST             996

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.cpp
@@ -39,7 +39,6 @@
 #include "URL.h"
 #include "FileItem.h"
 #include "utils/StringUtils.h"
-#include "video/VideoDatabase.h"
 
 using namespace XFILE::VIDEODATABASEDIRECTORY;
 

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -33,7 +33,6 @@
 #include "filesystem/StackDirectory.h"
 #include "filesystem/MusicDatabaseDirectory.h"
 #include "filesystem/VideoDatabaseDirectory.h"
-#include "video/VideoDatabase.h"
 #include "video/VideoInfoTag.h"
 #include "music/MusicDatabase.h"
 #include "music/tags/MusicInfoTag.h"

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -26,6 +26,7 @@
 
 #include "SmartPlayList.h"
 #include "Util.h"
+#include "dbwrappers/Database.h"
 #include "filesystem/File.h"
 #include "filesystem/SmartPlaylistDirectory.h"
 #include "guilib/LocalizeStrings.h"
@@ -33,12 +34,12 @@
 #include "utils/JSONVariantParser.h"
 #include "utils/JSONVariantWriter.h"
 #include "utils/log.h"
+#include "utils/StreamDetails.h"
 #include "utils/StringUtils.h"
 #include "utils/StringValidation.h"
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
 #include "utils/XMLUtils.h"
-#include "video/VideoDatabase.h"
 
 using namespace XFILE;
 

--- a/xbmc/video/ContextMenus.cpp
+++ b/xbmc/video/ContextMenus.cpp
@@ -22,6 +22,7 @@
 #include "Application.h"
 #include "Autorun.h"
 #include "video/dialogs/GUIDialogVideoInfo.h"
+#include "video/windows/GUIWindowVideoBase.h"
 
 
 namespace CONTEXTMENU

--- a/xbmc/video/ContextMenus.h
+++ b/xbmc/video/ContextMenus.h
@@ -21,7 +21,6 @@
 
 #include "ContextMenuItem.h"
 #include "guilib/GUIWindowManager.h"
-#include "video/windows/GUIWindowVideoNav.h"
 #include "VideoLibraryQueue.h"
 
 namespace CONTEXTMENU

--- a/xbmc/video/VideoLibraryQueue.cpp
+++ b/xbmc/video/VideoLibraryQueue.cpp
@@ -31,7 +31,6 @@
 #include "video/jobs/VideoLibraryMarkWatchedJob.h"
 #include "video/jobs/VideoLibraryRefreshingJob.h"
 #include "video/jobs/VideoLibraryScanningJob.h"
-#include "video/VideoDatabase.h"
 
 CVideoLibraryQueue::CVideoLibraryQueue()
   : CJobQueue(false, 1, CJob::PRIORITY_LOW),


### PR DESCRIPTION
touch xbmc/video/VideoDatabase.h ->

Before PR: 99 objects rebuilt
After PR: 75 objects rebuilt

touch xbmc/pvr/recordings/PVRRecordings.h

Before PR: 36 object rebuilt
After PR:  15 objects rebuilt

real-life impact is probably small but fake dependency is fake. needs a jenkins run as header shuffles tend to bite on other platforms.

motivated by the ugly warning gcc 5.3 throws due to the hacky offset mapping stuff.
