### PR TITLE
Show album artist name(s) correctly on music infomation dialog

### DIFF
--- a/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
@@ -171,16 +171,7 @@ void CGUIDialogMusicInfo::SetAlbum(const CAlbum& album, const std::string &path)
   m_album = album;
   SetSongs(m_album.infoSongs);
   *m_albumItem = CFileItem(path, true);
-  m_albumItem->GetMusicInfoTag()->SetAlbum(m_album.strAlbum);
-  m_albumItem->GetMusicInfoTag()->SetAlbumArtist(m_album.GetAlbumArtist());
-  m_albumItem->GetMusicInfoTag()->SetArtist(m_album.GetAlbumArtist());
-  m_albumItem->GetMusicInfoTag()->SetYear(m_album.iYear);
-  m_albumItem->GetMusicInfoTag()->SetLoaded(true);
-  m_albumItem->GetMusicInfoTag()->SetRating(m_album.fRating);
-  m_albumItem->GetMusicInfoTag()->SetVotes(m_album.iVotes);
-  m_albumItem->GetMusicInfoTag()->SetUserrating(m_album.iUserrating);
-  m_albumItem->GetMusicInfoTag()->SetGenre(m_album.genre);
-  m_albumItem->GetMusicInfoTag()->SetDatabaseId(m_album.idAlbum, MediaTypeAlbum);
+  m_albumItem->GetMusicInfoTag()->SetAlbum(m_album);
   CMusicDatabase::SetPropertiesFromAlbum(*m_albumItem,m_album);
 
   CMusicThumbLoader loader;


### PR DESCRIPTION
Album artist(s) as shown of the album info dialog is not always the same as that in the albums node - only noticed when the album artist description (from ALBUMARTIST tag) is not just a simple union of the separate artist names (from ALBUMARTISTS tag).
e.g. ALBUMARTIST = "B.B. Kind & Eric Claption"
ALBUMARTISTS = "B.B. Kind / Eric Claption"

CGUIDialogMusicInfo::SetAlbum was not correctly or fully populating the album details. Better to set all album details using CMusicInfoTag.SetAlbum method

Thanks to Scott for spotting this during testing. 
