### PR TITLE
[WIP] AudioDSP fixes

### DIFF
--- a/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSPProcess.cpp
+++ b/xbmc/cores/AudioEngine/DSPAddons/ActiveAEDSPProcess.cpp
@@ -1275,7 +1275,7 @@ bool CActiveAEDSPProcess::Process(CSampleBuffer *in, CSampleBuffer *out)
   /**
    * Convert to required planar float format inside dsp system
    */
-  if (swr_convert(m_convertInput, (uint8_t **)m_ffMpegConvertArray[0], m_processArraySize, (const uint8_t **)in->pkt->data , frames) < 0)
+  if (swr_convert(m_convertInput, (uint8_t **)m_ffMpegConvertArray[0], m_processArraySize, (const uint8_t **)in->pkt->data, in->pkt->nb_samples) < 0)
   {
     CLog::Log(LOGERROR, "ActiveAE DSP - %s - input audio convert failed", __FUNCTION__);
     return false;
@@ -1428,7 +1428,7 @@ bool CActiveAEDSPProcess::Process(CSampleBuffer *in, CSampleBuffer *out)
   /**
    * Convert back to required output format
    */
-  if (swr_convert(m_convertOutput, (uint8_t **)out->pkt->data, m_processArraySize, (const uint8_t **)m_ffMpegConvertArray[1], frames) < 0)
+  if (swr_convert(m_convertOutput, (uint8_t **)out->pkt->data, out->pkt->max_nb_samples, (const uint8_t **)m_ffMpegConvertArray[FFMPEG_PROC_ARRAY_OUT], frames) < 0)
   {
     CLog::Log(LOGERROR, "ActiveAE DSP - %s - output audio convert failed", __FUNCTION__);
     return false;

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
@@ -436,9 +436,10 @@ bool CActiveAEBufferPoolResample::ResampleBuffers(int64_t timestamp)
         if (!m_dspSample)
           m_dspSample = m_dspBuffer->GetFreeBuffer();
 
+        m_dspSample->timestamp = in->timestamp;
+        m_dspSample->pkt_start_offset = in->pkt_start_offset;
         if (m_dspSample && m_processor->Process(in, m_dspSample))
         {
-          m_dspSample->timestamp = in->timestamp;
           in->Return();
           in = m_dspSample;
           m_dspSample = NULL;

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
@@ -233,7 +233,7 @@ bool CActiveAEBufferPoolResample::Create(unsigned int totaltime, bool remap, boo
       if (m_processor->GetChannelLayout().Count() > 2)                    /* Disable upmix for CActiveAEResample if DSP layout > 2.0, becomes perfomed by DSP */
         upmix = false;
 
-      m_dspBuffer = new CActiveAEBufferPool(m_inputFormat);               /* Get dsp processing buffer class, based on dsp output format */
+      m_dspBuffer = new CActiveAEBufferPool(m_format);               /* Get dsp processing buffer class, based on dsp output format */
       m_dspBuffer->Create(totaltime);
     }
   }


### PR DESCRIPTION
@FernetMenta @popcornmix @MilhouseVH @AlwinEsch @fritsch 
These are fixes to prevent Kodi crashing when adsp is enabled on RPi and probably Android (it's currently not tested from my side). I don't know why this has worked before on Windows, Linux and OS X because the speaker layout and buffer sizes could be wrong in some cases.
I already tested these fixes on Windows and it's fine.

But currently I stock, all video frames are dropped and I don't know why. Maybe adsp does something wrong with the picture time stamp. So it would be nice if @AlwinEsch, @FernetMenta or @fritsch could have a look at it.
