### PR TITLE
[cmake] Fix GenerateVersionedFiles

### DIFF
--- a/project/cmake/scripts/common/GenerateVersionedFiles.cmake
+++ b/project/cmake/scripts/common/GenerateVersionedFiles.cmake
@@ -3,9 +3,16 @@ include(${CORE_SOURCE_DIR}/project/cmake/scripts/common/Macros.cmake)
 core_find_versions()
 file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/addons/xbmc.addon)
 file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/addons/kodi.guilib)
-configure_file(${CORE_SOURCE_DIR}/addons/xbmc.addon/addon.xml.in
-               ${CMAKE_BINARY_DIR}/addons/xbmc.addon/addon.xml @ONLY)
-configure_file(${CORE_SOURCE_DIR}/addons/kodi.guilib/addon.xml.in
-               ${CMAKE_BINARY_DIR}/addons/kodi.guilib/addon.xml @ONLY)
-configure_file(${CORE_SOURCE_DIR}/xbmc/CompileInfo.cpp.in
-               ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/xbmc/CompileInfo.cpp @ONLY)
+
+# configure_file without dependency tracking
+# configure_file would register additional file dependencies that interfere
+# with the ones from add_custom_command (and the generation would happen twice)
+function(generate_versioned_file _SRC _DEST)
+  file(READ ${CORE_SOURCE_DIR}/${_SRC} file_content)
+  string(CONFIGURE "${file_content}" file_content @ONLY)
+  file(WRITE ${CMAKE_BINARY_DIR}/${_DEST} "${file_content}")
+endfunction()
+
+generate_versioned_file(addons/xbmc.addon/addon.xml.in addons/xbmc.addon/addon.xml)
+generate_versioned_file(addons/kodi.guilib/addon.xml.in addons/kodi.guilib/addon.xml)
+generate_versioned_file(xbmc/CompileInfo.cpp.in ${CORE_BUILD_DIR}/xbmc/CompileInfo.cpp)


### PR DESCRIPTION
This commit fixes issues with GenerateVersionedFiles:
- The generation step is called twice when a dependent file is changed.
- The generated files are always outdated when the input file is not modified but the timestamp is updated (touch).
- On OSX the compileinfo target fails with "Problem configuring file" when using the Xcode generator.

GenerateVersionedFiles internally used configure_file to generate the output files. configure_file itself does dependency tracking which seems to interfere with the dependencies of add_custom_command. When an input file is changed, the script is executed and generates the
files. This however causes the other files to appear outdated as well and the generation is triggered again.

cc: @hudokkow 
