### PR TITLE
[cmake] Allow building with Ninja generator

### DIFF
--- a/project/cmake/modules/FindCrossGUID.cmake
+++ b/project/cmake/modules/FindCrossGUID.cmake
@@ -5,6 +5,7 @@ if(ENABLE_INTERNAL_CROSSGUID)
   list(GET CGUID_VER 0 CGUID_VER)
   string(SUBSTRING "${CGUID_VER}" 8 -1 CGUID_VER)
 
+  set(CROSSGUID_LIBRARY ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/lib/libcrossguid.a)
   externalproject_add(crossguid
                       URL http://mirrors.kodi.tv/build-deps/sources/crossguid-${CGUID_VER}.tar.gz
                       PREFIX ${CORE_BUILD_DIR}/crossguid
@@ -18,10 +19,11 @@ if(ENABLE_INTERNAL_CROSSGUID)
                                     <SOURCE_DIR> &&
                                     ${CMAKE_COMMAND} -E copy
                                     ${CORE_SOURCE_DIR}/tools/depends/target/crossguid/FindCXX11.cmake
-                                    <SOURCE_DIR>)
+                                    <SOURCE_DIR>
+                      BUILD_BYPRODUCTS ${CROSSGUID_LIBRARY})
 
   set(CROSSGUID_FOUND 1)
-  set(CROSSGUID_LIBRARIES ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/lib/libcrossguid.a)
+  set(CROSSGUID_LIBRARIES ${CROSSGUID_LIBRARY})
   set(CROSSGUID_INCLUDE_DIRS ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/include)
 
   include(FindPackageHandleStandardArgs)

--- a/project/cmake/modules/FindD3DX11Effects.cmake
+++ b/project/cmake/modules/FindD3DX11Effects.cmake
@@ -6,19 +6,20 @@
 # D3DCOMPILER_DLL - Path to the Direct3D Compiler
 
 include(ExternalProject)
+set(D3DX11EFFECTS_LIBRARY_RELEASE ${CORE_SOURCE_DIR}/lib/win32/Effects11/libs/Effects11/Release/Effects11.lib)
+set(D3DX11EFFECTS_LIBRARY_DEBUG ${CORE_SOURCE_DIR}/lib/win32/Effects11/libs/Effects11/Debug/Effects11.lib)
 ExternalProject_Add(d3dx11effects
             SOURCE_DIR ${CORE_SOURCE_DIR}/lib/win32/Effects11
             PREFIX ${CORE_BUILD_DIR}/Effects11
             CONFIGURE_COMMAND ""
             BUILD_COMMAND msbuild ${CORE_SOURCE_DIR}/lib/win32/Effects11/Effects11_2013.sln
                                   /t:Effects11 /p:Configuration=${CORE_BUILD_CONFIG}
-            INSTALL_COMMAND "")
+            INSTALL_COMMAND ""
+            BUILD_BYPRODUCTS ${D3DX11EFFECTS_LIBRARY_RELEASE} ${D3DX11EFFECTS_LIBRARY_DEBUG})
 
 set(D3DX11EFFECTS_FOUND 1)
 set(D3DX11EFFECTS_INCLUDE_DIRS ${CORE_SOURCE_DIR}/lib/win32/Effects11/inc)
 
-set(D3DX11EFFECTS_LIBRARY_RELEASE ${CORE_SOURCE_DIR}/lib/win32/Effects11/libs/Effects11/Release/Effects11.lib)
-set(D3DX11EFFECTS_LIBRARY_DEBUG ${CORE_SOURCE_DIR}/lib/win32/Effects11/libs/Effects11/Debug/Effects11.lib)
 include(SelectLibraryConfigurations)
 select_library_configurations(D3DX11EFFECTS)
 

--- a/project/cmake/modules/FindLibDvd.cmake
+++ b/project/cmake/modules/FindLibDvd.cmake
@@ -34,6 +34,7 @@ if(NOT WIN32)
   endif()
 
   if(ENABLE_DVDCSS)
+    set(DVDCSS_LIBRARY ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/libdvd/lib/libdvdcss.a)
     ExternalProject_Add(dvdcss URL ${libdvdcss_BASE_URL}/archive/${libdvdcss_VER}.tar.gz
                                PREFIX ${CORE_BUILD_DIR}/libdvd
                                CONFIGURE_COMMAND ac_cv_path_GIT= <SOURCE_DIR>/configure
@@ -46,15 +47,15 @@ if(NOT WIN32)
                                                  --prefix=<INSTALL_DIR>
                                                  "${EXTRA_FLAGS}"
                                                  "CFLAGS=${CMAKE_C_FLAGS} ${DVDREAD_CFLAGS}"
-                                                 "LDFLAGS=${CMAKE_LD_FLAGS}")
+                                                 "LDFLAGS=${CMAKE_LD_FLAGS}"
+                               BUILD_BYPRODUCTS ${DVDCSS_LIBRARY})
     ExternalProject_Add_Step(dvdcss autoreconf
                                     DEPENDEES download update patch
                                     DEPENDERS configure
                                     COMMAND PATH=${NATIVEPREFIX}/bin:$ENV{PATH} autoreconf -vif
                                     WORKING_DIRECTORY <SOURCE_DIR>)
 
-    core_link_library(${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/libdvd/lib/libdvdcss.a
-                      system/players/VideoPlayer/libdvdcss dvdcss)
+    core_link_library(${DVDCSS_LIBRARY} system/players/VideoPlayer/libdvdcss dvdcss)
   endif()
 
   set(DVDREAD_CFLAGS "-D_XBMC")
@@ -62,6 +63,7 @@ if(NOT WIN32)
     set(DVDREAD_CFLAGS "${DVDREAD_CFLAGS} -DHAVE_DVDCSS_DVDCSS_H -I${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/libdvd/include")
   endif()
 
+  set(DVDREAD_LIBRARY ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/libdvd/lib/libdvdread.a)
   ExternalProject_Add(dvdread URL ${libdvdread_BASE_URL}/archive/${libdvdread_VER}.tar.gz
                               PREFIX ${CORE_BUILD_DIR}/libdvd
                               CONFIGURE_COMMAND ac_cv_path_GIT= <SOURCE_DIR>/configure
@@ -73,7 +75,8 @@ if(NOT WIN32)
                                                 --prefix=<INSTALL_DIR>
                                                 "${EXTRA_FLAGS}"
                                                 "CFLAGS=${CMAKE_C_FLAGS} ${DVDREAD_CFLAGS}"
-                                                "LDFLAGS=${CMAKE_LD_FLAGS}")
+                                                "LDFLAGS=${CMAKE_LD_FLAGS}"
+                              BUILD_BYPRODUCTS ${DVDREAD_LIBRARY})
   ExternalProject_Add_Step(dvdread autoreconf
                                    DEPENDEES download update patch
                                    DEPENDERS configure
@@ -83,13 +86,13 @@ if(NOT WIN32)
     add_dependencies(dvdread dvdcss)
   endif()
 
-  core_link_library(${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/libdvd/lib/libdvdread.a
-                    system/players/VideoPlayer/libdvdread dvdread)
+  core_link_library(${DVDREAD_LIBRARY} system/players/VideoPlayer/libdvdread dvdread)
 
   if(ENABLE_DVDCSS)
     set(DVDNAV_LIBS -ldvdcss)
   endif()
 
+  set(DVDNAV_LIBRARY ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/libdvd/lib/libdvdnav.a)
   ExternalProject_Add(dvdnav URL ${libdvdnav_BASE_URL}/archive/${libdvdnav_VER}.tar.gz
                              PREFIX ${CORE_BUILD_DIR}/libdvd
                              CONFIGURE_COMMAND ac_cv_path_GIT= <SOURCE_DIR>/configure
@@ -104,23 +107,22 @@ if(NOT WIN32)
                                                "CFLAGS=${CMAKE_C_FLAGS} ${DVDREAD_CFLAGS}"
                                                "DVDREAD_CFLAGS=${DVDREAD_CFLAGS}"
                                                "DVDREAD_LIBS=${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/libdvd/lib/libdvdread.la"
-                                               "LIBS=${DVDNAV_LIBS}")
+                                               "LIBS=${DVDNAV_LIBS}"
+                             BUILD_BYPRODUCTS ${DVDNAV_LIBRARY})
   ExternalProject_Add_Step(dvdnav autoreconf
                                   DEPENDEES download update patch
                                   DEPENDERS configure
                                   COMMAND PATH=${NATIVEPREFIX}/bin:$ENV{PATH} autoreconf -vif
                                   WORKING_DIRECTORY <SOURCE_DIR>)
   add_dependencies(dvdnav dvdread)
-  core_link_library(${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/libdvd/lib/libdvdnav.a
-                    system/players/VideoPlayer/libdvdnav dvdnav)
+  core_link_library(${DVDNAV_LIBRARY} system/players/VideoPlayer/libdvdnav dvdnav)
 
   set(WRAP_FILES ${WRAP_FILES} PARENT_SCOPE)
 
   set(LIBDVD_INCLUDE_DIRS ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/libdvd/include)
-  set(LIBDVD_LIBRARIES ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/libdvd/lib/libdvdnav.a
-                       ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/libdvd/lib/libdvdread.a)
+  set(LIBDVD_LIBRARIES ${DVDNAV_LIBRARY} ${DVDREAD_LIBRARY})
   if(ENABLE_DVDCSS)
-     list(APPEND LIBDVD_LIBRARIES ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/libdvd/lib/libdvdcss.a)
+    list(APPEND LIBDVD_LIBRARIES ${DVDCSS_LIBRARY})
   endif()
   set(LIBDVD_LIBRARIES ${LIBDVD_LIBRARIES} CACHE STRING "libdvd libraries" FORCE)
   set(LIBDVD_FOUND 1 CACHE BOOL "libdvd found" FORCE)

--- a/project/cmake/scripts/common/GeneratorSetup.cmake
+++ b/project/cmake/scripts/common/GeneratorSetup.cmake
@@ -22,3 +22,8 @@ else()
   set(CORE_BUILD_CONFIG ${CMAKE_BUILD_TYPE})
   message(STATUS "Generator: Single-configuration: ${CMAKE_BUILD_TYPE} (${CMAKE_GENERATOR})")
 endif()
+
+# Ninja needs CMake 3.2 due to ExternalProject BUILD_BYPRODUCTS usage
+if(CMAKE_GENERATOR STREQUAL Ninja AND CMAKE_VERSION VERSION_LESS 3.2)
+  message(FATAL_ERROR "Generator: Ninja requires CMake 3.2 or later")
+endif()

--- a/project/cmake/scripts/osx/Macros.cmake
+++ b/project/cmake/scripts/osx/Macros.cmake
@@ -1,5 +1,5 @@
 function(core_link_library lib wraplib)
-  if(CMAKE_GENERATOR MATCHES "Unix Makefiles")
+  if(CMAKE_GENERATOR MATCHES "Unix Makefiles" OR CMAKE_GENERATOR STREQUAL Ninja)
     set(wrapper_obj cores/dll-loader/exports/CMakeFiles/wrapper.dir/wrapper.c.o)
   elseif(CMAKE_GENERATOR MATCHES "Xcode")
     set(wrapper_obj cores/dll-loader/exports/kodi.build/$(CONFIGURATION)/wrapper.build/Objects-$(CURRENT_VARIANT)/$(CURRENT_ARCH)/wrapper.o)


### PR DESCRIPTION
Small fixes to enable building with Ninja. Tested on OSX and Linux.
The build with Ninja is only a little faster (couple of seconds for a full build), but Ninja has a few nice things like generating a dependency graph.

Might be interesting for: @hudokkow, @notspiff, @wsnipex.
