### PR TITLE
[cmake] Don't link against libpng

### DIFF
--- a/project/cmake/CMakeLists.txt
+++ b/project/cmake/CMakeLists.txt
@@ -118,7 +118,7 @@ set(required_dyload Curl ASS)
 set(dyload_optional RTMP CEC Bluray Plist NFS)
 
 # Required by shared objects we link
-set(required_dep_libs PNG EXPAT)
+set(required_dep_libs EXPAT)
 
 # Required tools
 find_package(TexturePacker REQUIRED)


### PR DESCRIPTION
No need to link against libpng as it is no direct dependency of Kodi anymore.

Align with removal from configure.ac: https://github.com/xbmc/xbmc/pull/9850

This also fixes the CMake build on Windows, because CMake's built-in
FindPNG.cmake module doesn't find it in the Windows build-dependencies.

pings: @stefansaraev, @wsnipex

build: http://jenkins.kodi.tv/job/WIN-32/9099/
