### PR TITLE
[xbmc][cleanup] Some minor cleanup of texture handling

### DIFF
--- a/xbmc/guilib/TextureBundle.cpp
+++ b/xbmc/guilib/TextureBundle.cpp
@@ -18,15 +18,10 @@
  *
  */
 
-#include "system.h"
 #include "TextureBundle.h"
 
-CTextureBundle::CTextureBundle(void)
-{
-  m_useXBT = false;
-}
-
-CTextureBundle::~CTextureBundle(void)
+CTextureBundle::CTextureBundle()
+  : m_useXBT{false}
 {
 }
 
@@ -36,15 +31,14 @@ bool CTextureBundle::HasFile(const std::string& Filename)
   {
     return m_tbXBT.HasFile(Filename);
   }
-  else if (m_tbXBT.HasFile(Filename))
+
+  if (m_tbXBT.HasFile(Filename))
   {
     m_useXBT = true;
     return true;
   }
-  else
-  {
-    return false;
-  }
+
+  return false;
 }
 
 void CTextureBundle::GetTexturesFromPath(const std::string &path, std::vector<std::string> &textures)
@@ -62,10 +56,8 @@ bool CTextureBundle::LoadTexture(const std::string& Filename, CBaseTexture** ppT
   {
     return m_tbXBT.LoadTexture(Filename, ppTexture, width, height);
   }
-  else
-  {
-    return false;
-  }
+
+  return false;
 }
 
 int CTextureBundle::LoadAnim(const std::string& Filename, CBaseTexture*** ppTextures,
@@ -75,16 +67,8 @@ int CTextureBundle::LoadAnim(const std::string& Filename, CBaseTexture*** ppText
   {
     return m_tbXBT.LoadAnim(Filename, ppTextures, width, height, nLoops, ppDelays);
   }
-  else
-  {
-    return 0;
-  }
-}
 
-void CTextureBundle::Cleanup()
-{
-  m_tbXBT.Cleanup();
-  m_useXBT = false;
+  return 0;
 }
 
 void CTextureBundle::SetThemeBundle(bool themeBundle)

--- a/xbmc/guilib/TextureBundle.h
+++ b/xbmc/guilib/TextureBundle.h
@@ -27,10 +27,8 @@
 class CTextureBundle
 {
 public:
-  CTextureBundle(void);
-  ~CTextureBundle(void);
-
-  void Cleanup();
+  CTextureBundle();
+  ~CTextureBundle() = default;
 
   void SetThemeBundle(bool themeBundle);
   bool HasFile(const std::string& Filename);

--- a/xbmc/guilib/TextureBundleXBT.cpp
+++ b/xbmc/guilib/TextureBundleXBT.cpp
@@ -18,18 +18,19 @@
  *
  */
 
-#include "system.h"
 #include "TextureBundleXBT.h"
+
+#include "system.h"
 #include "Texture.h"
 #include "GraphicContext.h"
 #include "utils/log.h"
-#include "addons/Skin.h"
 #include "settings/Settings.h"
 #include "filesystem/SpecialProtocol.h"
 #include "filesystem/XbtManager.h"
 #include "utils/URIUtils.h"
 #include "utils/StringUtils.h"
 #include "XBTF.h"
+#include "XBTFReader.h"
 #include <lzo/lzo1x.h>
 
 #ifdef TARGET_WINDOWS
@@ -41,20 +42,22 @@
 #endif
 
 CTextureBundleXBT::CTextureBundleXBT(void)
+  : m_TimeStamp{0}
+  , m_themeBundle{false}
 {
-  m_themeBundle = false;
-  m_TimeStamp = 0;
 }
 
 CTextureBundleXBT::~CTextureBundleXBT(void)
 {
-  Cleanup();
+  if (m_XBTFReader != nullptr && m_XBTFReader->IsOpen())
+  {
+    XFILE::CXbtManager::GetInstance().Release(CURL(m_path));
+    CLog::Log(LOGDEBUG, "%s - Closed %sbundle", __FUNCTION__, m_themeBundle ? "theme " : "");
+  }
 }
 
 bool CTextureBundleXBT::OpenBundle()
 {
-  Cleanup();
-
   // Find the correct texture file (skin or theme)
   if (m_themeBundle)
   {
@@ -240,15 +243,6 @@ bool CTextureBundleXBT::ConvertFrameToTexture(const std::string& name, CXBTFFram
   delete[] buffer;
 
   return true;
-}
-
-void CTextureBundleXBT::Cleanup()
-{
-  if (m_XBTFReader != nullptr && m_XBTFReader->IsOpen())
-  {
-    XFILE::CXbtManager::GetInstance().Release(CURL(m_path));
-    CLog::Log(LOGDEBUG, "%s - Closed %sbundle", __FUNCTION__, m_themeBundle ? "theme " : "");
-  }
 }
 
 void CTextureBundleXBT::SetThemeBundle(bool themeBundle)

--- a/xbmc/guilib/TextureBundleXBT.h
+++ b/xbmc/guilib/TextureBundleXBT.h
@@ -21,18 +21,20 @@
  */
 
 #include <map>
+#include <memory>
 #include <string>
-#include "XBTFReader.h"
+#include <vector>
 
 class CBaseTexture;
+class CXBTFReader;
+class CXBTFFrame;
 
 class CTextureBundleXBT
 {
 public:
-  CTextureBundleXBT(void);
-  ~CTextureBundleXBT(void);
+  CTextureBundleXBT();
+  ~CTextureBundleXBT();
 
-  void Cleanup();
   void SetThemeBundle(bool themeBundle);
   bool HasFile(const std::string& Filename);
   void GetTexturesFromPath(const std::string &path, std::vector<std::string> &textures);
@@ -54,7 +56,7 @@ private:
 
   bool m_themeBundle;
   std::string m_path;
-  CXBTFReaderPtr m_XBTFReader;
+  std::shared_ptr<CXBTFReader> m_XBTFReader;
 };
 
 

--- a/xbmc/guilib/TextureManager.cpp
+++ b/xbmc/guilib/TextureManager.cpp
@@ -540,7 +540,7 @@ void CGUITextureManager::Cleanup()
     i = m_vecTextures.erase(i);
   }
   for (int i = 0; i < 2; i++)
-    m_TexBundle[i].Cleanup();
+    m_TexBundle[i] = CTextureBundle();
   FreeUnusedTextures();
 }
 


### PR DESCRIPTION
moved some includes into the cpp files.
Got rid of the Cleanup methods as feel ugly, might make sense for an object that's costly to create and can handle a partial reset but these classes have none of this so lets rely on the destructor instead and recreate when needed.
