### PR TITLE
[xbmc][fix][pvr] Fix warning class GridItemPtr already seen as struct. 

### DIFF
--- a/xbmc/epg/GUIEPGGridContainer.cpp
+++ b/xbmc/epg/GUIEPGGridContainer.cpp
@@ -510,7 +510,7 @@ void CGUIEPGGridContainer::UpdateItems()
     }
     else // "gap" tag seleceted
     {
-      const GridItemsPtr *prevItem(GetPrevItem(m_channelCursor));
+      const GridItem *prevItem(GetPrevItem(m_channelCursor));
       if (prevItem)
       {
         const CEpgInfoTagPtr tag(prevItem->item->GetEPGInfoTag());
@@ -1037,9 +1037,9 @@ std::string CGUIEPGGridContainer::GetLabel(int info) const
   return label;
 }
 
-GridItemsPtr *CGUIEPGGridContainer::GetClosestItem(int channel)
+GridItem *CGUIEPGGridContainer::GetClosestItem(int channel)
 {
-  GridItemsPtr *closest = GetItem(channel);
+  GridItem *closest = GetItem(channel);
 
   if (!closest)
     return nullptr;
@@ -1071,7 +1071,7 @@ GridItemsPtr *CGUIEPGGridContainer::GetClosestItem(int channel)
   return m_gridModel->GetGridItemPtr(channel + m_channelOffset, m_blockCursor - left + m_blockOffset);
 }
 
-int CGUIEPGGridContainer::GetItemSize(GridItemsPtr *item)
+int CGUIEPGGridContainer::GetItemSize(GridItem *item)
 {
   if (!item)
     return MathUtils::round_int(m_blockSize); // stops it crashing
@@ -1098,7 +1098,7 @@ int CGUIEPGGridContainer::GetRealBlock(const CGUIListItemPtr &item, int channel)
   return block;
 }
 
-GridItemsPtr *CGUIEPGGridContainer::GetNextItem(int channel)
+GridItem *CGUIEPGGridContainer::GetNextItem(int channel)
 {
   int channelIndex = channel + m_channelOffset;
   int blockIndex = m_blockCursor + m_blockOffset;
@@ -1116,7 +1116,7 @@ GridItemsPtr *CGUIEPGGridContainer::GetNextItem(int channel)
   return m_gridModel->GetGridItemPtr(channelIndex, i + m_blockOffset);
 }
 
-GridItemsPtr *CGUIEPGGridContainer::GetPrevItem(int channel)
+GridItem *CGUIEPGGridContainer::GetPrevItem(int channel)
 {
   int channelIndex = channel + m_channelOffset;
   int blockIndex = m_blockCursor + m_blockOffset;
@@ -1131,7 +1131,7 @@ GridItemsPtr *CGUIEPGGridContainer::GetPrevItem(int channel)
   return m_gridModel->GetGridItemPtr(channelIndex, i + m_blockOffset);
 }
 
-GridItemsPtr *CGUIEPGGridContainer::GetItem(int channel)
+GridItem *CGUIEPGGridContainer::GetItem(int channel)
 {
   int channelIndex = channel + m_channelOffset;
   int blockIndex = m_blockCursor + m_blockOffset;

--- a/xbmc/epg/GUIEPGGridContainer.h
+++ b/xbmc/epg/GUIEPGGridContainer.h
@@ -27,7 +27,7 @@
 
 namespace EPG
 {
-  class GridItemsPtr;
+  struct GridItem;
   class CGUIEPGGridContainerModel;
 
   class CGUIEPGGridContainer : public IGUIContainer
@@ -92,12 +92,12 @@ namespace EPG
     void ValidateOffset();
     void UpdateLayout();
 
-    GridItemsPtr *GetItem(int channel);
-    GridItemsPtr *GetNextItem(int channel);
-    GridItemsPtr *GetPrevItem(int channel);
-    GridItemsPtr *GetClosestItem(int channel);
+    GridItem *GetItem(int channel);
+    GridItem *GetNextItem(int channel);
+    GridItem *GetPrevItem(int channel);
+    GridItem *GetClosestItem(int channel);
 
-    int GetItemSize(GridItemsPtr *item);
+    int GetItemSize(GridItem *item);
     int GetBlock(const CGUIListItemPtr &item, int channel);
     int GetRealBlock(const CGUIListItemPtr &item, int channel);
     void MoveToRow(int row);
@@ -195,6 +195,6 @@ namespace EPG
     std::unique_ptr<CGUIEPGGridContainerModel> m_updatedGridModel;
     std::unique_ptr<CGUIEPGGridContainerModel> m_outdatedGridModel;
 
-    GridItemsPtr *m_item;
+    GridItem *m_item;
   };
 }

--- a/xbmc/epg/GUIEPGGridContainerModel.cpp
+++ b/xbmc/epg/GUIEPGGridContainerModel.cpp
@@ -147,7 +147,7 @@ void CGUIEPGGridContainerModel::Refresh(const std::unique_ptr<CFileItemList> &it
     m_blocks = MAXBLOCKS;
 
   m_gridIndex.reserve(m_channelItems.size());
-  const std::vector<GridItemsPtr> blocks(m_blocks);
+  const std::vector<GridItem> blocks(m_blocks);
 
   for (size_t channel = 0; channel < m_channelItems.size(); ++channel)
   {

--- a/xbmc/epg/GUIEPGGridContainerModel.h
+++ b/xbmc/epg/GUIEPGGridContainerModel.h
@@ -31,14 +31,14 @@ class CFileItemList;
 
 namespace EPG
 {
-  struct GridItemsPtr
+  struct GridItem
   {
     CFileItemPtr item;
     float originWidth;
     float width;
     int progIndex;
 
-    GridItemsPtr() : originWidth(0.0), width(0.0), progIndex(-1) {}
+    GridItem() : originWidth(0.0f), width(0.0f), progIndex(-1) {}
   };
 
   class CGUIEPGGridContainerModel
@@ -72,7 +72,7 @@ namespace EPG
 
     int GetBlockCount() const { return m_blocks; }
     bool HasGridItems() const { return !m_gridIndex.empty(); }
-    GridItemsPtr *GetGridItemPtr(int iChannel, int iBlock) { return &m_gridIndex[iChannel][iBlock]; }
+    GridItem *GetGridItemPtr(int iChannel, int iBlock) { return &m_gridIndex[iChannel][iBlock]; }
     CFileItemPtr GetGridItem(int iChannel, int iBlock) const { return m_gridIndex[iChannel][iBlock].item; }
     float GetGridItemWidth(int iChannel, int iBlock) const { return m_gridIndex[iChannel][iBlock].width; }
     float GetGridItemOriginWidth(int iChannel, int iBlock) const { return m_gridIndex[iChannel][iBlock].originWidth; }
@@ -100,7 +100,7 @@ namespace EPG
     std::vector<CFileItemPtr> m_channelItems;
     std::vector<CFileItemPtr> m_rulerItems;
     std::vector<ItemsPtr> m_epgItemsPtr;
-    std::vector<std::vector<GridItemsPtr> > m_gridIndex;
+    std::vector<std::vector<GridItem> > m_gridIndex;
 
     int m_blocks;
   };


### PR DESCRIPTION
Also rename to GridItem to avoid confusion as the Ptr suffix generally is used for shared_ptr typedefs
