### PR TITLE
[xbmc][cleanup][win32] Silence some warnings and some minor cleanup

### DIFF
--- a/xbmc/rendering/dx/RenderSystemDX.cpp
+++ b/xbmc/rendering/dx/RenderSystemDX.cpp
@@ -177,7 +177,7 @@ void CRenderSystemDX::OnMove()
   m_pOutput->GetDesc(&outputDesc);
   HMONITOR newMonitor = MonitorFromWindow(m_hDeviceWnd, MONITOR_DEFAULTTONULL);
 
-  if (newMonitor != NULL && outputDesc.Monitor != newMonitor)
+  if (newMonitor != nullptr && outputDesc.Monitor != newMonitor)
   {
     SetMonitor(newMonitor);
     if (m_needNewDevice)
@@ -249,12 +249,12 @@ void CRenderSystemDX::GetDisplayMode(DXGI_MODE_DESC *mode, bool useCached /*= fa
 
 inline void DXWait(ID3D11Device* pDevice, ID3D11DeviceContext* pContext)
 {
-  ID3D11Query* wait = NULL;
+  ID3D11Query* wait = nullptr;
   CD3D11_QUERY_DESC qd(D3D11_QUERY_EVENT);
   if (SUCCEEDED(pDevice->CreateQuery(&qd, &wait)))
   {
     pContext->End(wait);
-    while (S_FALSE == pContext->GetData(wait, NULL, 0, 0))
+    while (S_FALSE == pContext->GetData(wait, nullptr, 0, 0))
       Sleep(1);
   }
   SAFE_RELEASE(wait);
@@ -267,7 +267,7 @@ void CRenderSystemDX::SetFullScreenInternal()
 
   HRESULT hr = S_OK;
   BOOL bFullScreen;
-  m_pSwapChain->GetFullscreenState(&bFullScreen, NULL);
+  m_pSwapChain->GetFullscreenState(&bFullScreen, nullptr);
 
   // full-screen to windowed translation. Only change FS state and return
   if (!!bFullScreen && m_useWindowedDX)
@@ -275,7 +275,7 @@ void CRenderSystemDX::SetFullScreenInternal()
     CLog::Log(LOGDEBUG, "%s - Switching swap chain to windowed mode.", __FUNCTION__);
 
     OnDisplayLost();
-    hr = m_pSwapChain->SetFullscreenState(false, NULL);
+    hr = m_pSwapChain->SetFullscreenState(false, nullptr);
     if (SUCCEEDED(hr))
       m_bResizeRequred = true;
     else
@@ -284,7 +284,7 @@ void CRenderSystemDX::SetFullScreenInternal()
   // true full-screen
   else if (m_bFullScreenDevice && !m_useWindowedDX)
   {
-    IDXGIOutput* pOutput = NULL;
+    IDXGIOutput* pOutput = nullptr;
     m_pSwapChain->GetContainingOutput(&pOutput);
 
     DXGI_OUTPUT_DESC trgDesc, currDesc;
@@ -393,7 +393,7 @@ void CRenderSystemDX::DeleteDevice()
     (*i)->OnDestroyDevice();
 
   if (m_pSwapChain)
-    m_pSwapChain->SetFullscreenState(false, NULL);
+    m_pSwapChain->SetFullscreenState(false, nullptr);
 
   SAFE_DELETE(m_pGUIShader);
   SAFE_RELEASE(m_pTextureRight);
@@ -587,7 +587,7 @@ bool CRenderSystemDX::CreateDevice()
 
   // use multi-thread protection on the device context to prevent deadlock issues that can sometimes happen
   // when decoder call ID3D11VideoContext::GetDecoderBuffer or ID3D11VideoContext::ReleaseDecoderBuffer.
-  ID3D10Multithread *pMultiThreading = NULL;
+  ID3D10Multithread *pMultiThreading = nullptr;
   if (SUCCEEDED(m_pD3DDev->QueryInterface(__uuidof(ID3D10Multithread), reinterpret_cast<void**>(&pMultiThreading))))
   {
     pMultiThreading->SetMultithreadProtected(true);
@@ -744,13 +744,13 @@ bool CRenderSystemDX::CreateWindowSizeDependentResources()
     ID3D11RenderTargetView* pRTView; ID3D11DepthStencilView* pDSView;
     m_pContext->OMGetRenderTargets(1, &pRTView, &pDSView);
 
-    bRestoreRTView = NULL != pRTView || NULL != pDSView;
+    bRestoreRTView = (nullptr != pRTView || nullptr != pDSView);
 
     SAFE_RELEASE(pRTView);
     SAFE_RELEASE(pDSView);
   }
 
-  m_pContext->OMSetRenderTargets(0, NULL, NULL);
+  m_pContext->OMSetRenderTargets(0, nullptr, nullptr);
   FinishCommandList(false);
 
   SAFE_RELEASE(m_pRenderTargetView);
@@ -768,9 +768,9 @@ bool CRenderSystemDX::CreateWindowSizeDependentResources()
     }
 
     BOOL fullScreen;
-    m_pSwapChain1->GetFullscreenState(&fullScreen, NULL);
+    m_pSwapChain1->GetFullscreenState(&fullScreen, nullptr);
     if (fullScreen)
-      m_pSwapChain1->SetFullscreenState(false, NULL);
+      m_pSwapChain1->SetFullscreenState(false, nullptr);
 
     // disable/enable stereo 3D on system level
     if (g_advancedSettings.m_useDisplayControlHWStereo)
@@ -794,7 +794,7 @@ bool CRenderSystemDX::CreateWindowSizeDependentResources()
     CLog::Log(LOGDEBUG, "%s - Creating swapchain in %s mode.", __FUNCTION__, bHWStereoEnabled ? "Stereoscopic 3D" : "Mono");
 
     // Create swap chain
-    IDXGIFactory2* dxgiFactory2 = NULL;
+    IDXGIFactory2* dxgiFactory2 = nullptr;
     hr = m_dxgiFactory->QueryInterface(__uuidof(IDXGIFactory2), reinterpret_cast<void**>(&dxgiFactory2));
     if (SUCCEEDED(hr) && dxgiFactory2)
     {
@@ -817,7 +817,7 @@ bool CRenderSystemDX::CreateWindowSizeDependentResources()
       scFSDesc.ScanlineOrdering = m_interlaced ? DXGI_MODE_SCANLINE_ORDER_UPPER_FIELD_FIRST : DXGI_MODE_SCANLINE_ORDER_PROGRESSIVE;
       scFSDesc.Windowed         = m_useWindowedDX;
 
-      hr = dxgiFactory2->CreateSwapChainForHwnd(m_pD3DDev, m_hFocusWnd, &scDesc1, &scFSDesc, NULL, &m_pSwapChain1);
+      hr = dxgiFactory2->CreateSwapChainForHwnd(m_pD3DDev, m_hFocusWnd, &scDesc1, &scFSDesc, nullptr, &m_pSwapChain1);
 
       // some drivers (AMD) are denied to switch in stereoscopic 3D mode, if so then fallback to mono mode
       if (FAILED(hr) && bHWStereoEnabled)
@@ -828,7 +828,7 @@ bool CRenderSystemDX::CreateWindowSizeDependentResources()
 
         scDesc1.Stereo = false;
         bHWStereoEnabled = false;
-        hr = dxgiFactory2->CreateSwapChainForHwnd(m_pD3DDev, m_hFocusWnd, &scDesc1, &scFSDesc, NULL, &m_pSwapChain1);
+        hr = dxgiFactory2->CreateSwapChainForHwnd(m_pD3DDev, m_hFocusWnd, &scDesc1, &scFSDesc, nullptr, &m_pSwapChain1);
 
         // fallback to split_horisontal mode.
         g_graphicsContext.SetStereoMode(RENDER_STEREO_MODE_SPLIT_HORIZONTAL);
@@ -936,11 +936,11 @@ bool CRenderSystemDX::CreateWindowSizeDependentResources()
   else if (IsFormatSupport(DXGI_FORMAT_D24_UNORM_S8_UINT, D3D11_FORMAT_SUPPORT_DEPTH_STENCIL))  zFormat = DXGI_FORMAT_D24_UNORM_S8_UINT;
   else if (IsFormatSupport(DXGI_FORMAT_D16_UNORM, D3D11_FORMAT_SUPPORT_DEPTH_STENCIL))          zFormat = DXGI_FORMAT_D16_UNORM;
 
-  ID3D11Texture2D* depthStencilBuffer = NULL;
+  ID3D11Texture2D* depthStencilBuffer = nullptr;
   // Initialize the description of the depth buffer.
   CD3D11_TEXTURE2D_DESC depthBufferDesc(zFormat, m_nBackBufferWidth, m_nBackBufferHeight, 1, 1, D3D11_BIND_DEPTH_STENCIL);
   // Create the texture for the depth buffer using the filled out description.
-  hr = m_pD3DDev->CreateTexture2D(&depthBufferDesc, NULL, &depthStencilBuffer);
+  hr = m_pD3DDev->CreateTexture2D(&depthBufferDesc, nullptr, &depthStencilBuffer);
   if (FAILED(hr))
   {
     CLog::Log(LOGERROR, "%s - Failed to create depth stencil buffer (%s).", __FUNCTION__, GetErrorDescription(hr).c_str());
@@ -1008,7 +1008,7 @@ void CRenderSystemDX::CheckInterlasedStereoView(void)
     HRESULT hr;
     CD3D11_TEXTURE2D_DESC texDesc(DXGI_FORMAT_B8G8R8A8_UNORM, m_nBackBufferWidth, m_nBackBufferHeight, 1, 1,
                                   D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE);
-    hr = m_pD3DDev->CreateTexture2D(&texDesc, NULL, &m_pTextureRight);
+    hr = m_pD3DDev->CreateTexture2D(&texDesc, nullptr, &m_pTextureRight);
     if (SUCCEEDED(hr))
     {
       CD3D11_RENDER_TARGET_VIEW_DESC rtDesc(D3D11_RTV_DIMENSION_TEXTURE2D);
@@ -1151,7 +1151,7 @@ void CRenderSystemDX::PresentRenderImpl(bool rendered)
                            ? SHADER_METHOD_RENDER_STEREO_INTERLACED_RIGHT
                            : SHADER_METHOD_RENDER_STEREO_CHECKERBOARD_RIGHT;
     SetAlphaBlendEnable(true);
-    CD3DTexture::DrawQuad(destRect, 0, 1, &m_pShaderResourceViewRight, NULL, method);
+    CD3DTexture::DrawQuad(destRect, 0, 1, &m_pShaderResourceViewRight, nullptr, method);
     CD3DHelper::PSClearShaderResources(m_pContext);
   }
 
@@ -1490,7 +1490,7 @@ bool CRenderSystemDX::ScissorsCanEffectClipping()
   if (!m_bRenderCreated)
     return false;
 
-  return m_pGUIShader != NULL && m_pGUIShader->HardwareClipIsPossible();
+  return m_pGUIShader != nullptr && m_pGUIShader->HardwareClipIsPossible();
 }
 
 CRect CRenderSystemDX::ClipRectToScissorRect(const CRect &rect)
@@ -1637,17 +1637,17 @@ bool CRenderSystemDX::GetDisplayStereoEnabled() const
   bool result = false;
 
   IDXGIDisplayControl * pDXGIDisplayControl = nullptr;
-  if (SUCCEEDED(m_dxgiFactory->QueryInterface(__uuidof(IDXGIDisplayControl), (void **)&pDXGIDisplayControl)))
+  if (SUCCEEDED(m_dxgiFactory->QueryInterface(__uuidof(IDXGIDisplayControl), reinterpret_cast<void **>(&pDXGIDisplayControl))))
     result = pDXGIDisplayControl->IsStereoEnabled() == TRUE;
   SAFE_RELEASE(pDXGIDisplayControl);
 
   return result;
 }
 
-void CRenderSystemDX::SetDisplayStereoEnabled(bool enable)
+void CRenderSystemDX::SetDisplayStereoEnabled(bool enable) const
 {
   IDXGIDisplayControl * pDXGIDisplayControl = nullptr;
-  if (SUCCEEDED(m_dxgiFactory->QueryInterface(__uuidof(IDXGIDisplayControl), (void **)&pDXGIDisplayControl)))
+  if (SUCCEEDED(m_dxgiFactory->QueryInterface(__uuidof(IDXGIDisplayControl), reinterpret_cast<void **>(&pDXGIDisplayControl))))
     pDXGIDisplayControl->SetStereoEnabled(enable);
   SAFE_RELEASE(pDXGIDisplayControl);
 }
@@ -1681,7 +1681,7 @@ bool CRenderSystemDX::SupportsStereo(RENDER_STEREO_MODE mode) const
   }
 }
 
-void CRenderSystemDX::FlushGPU()
+void CRenderSystemDX::FlushGPU() const
 {
   if (!m_bRenderCreated)
     return;
@@ -1714,16 +1714,16 @@ void CRenderSystemDX::SetAlphaBlendEnable(bool enable)
     return;
 
   float blendFactors[] = { 0.0f, 0.0f, 0.0f, 0.0f };
-  m_pContext->OMSetBlendState(enable ? m_BlendEnableState : m_BlendDisableState, 0, 0xFFFFFFFF);
+  m_pContext->OMSetBlendState(enable ? m_BlendEnableState : m_BlendDisableState, nullptr, 0xFFFFFFFF);
   m_BlendEnabled = enable;
 }
 
-void CRenderSystemDX::FinishCommandList(bool bExecute /*= true*/)
+void CRenderSystemDX::FinishCommandList(bool bExecute /*= true*/) const
 {
   if (m_pImdContext == m_pContext)
     return;
 
-  ID3D11CommandList* pCommandList = NULL;
+  ID3D11CommandList* pCommandList = nullptr;
   if (FAILED(m_pContext->FinishCommandList(true, &pCommandList)))
   {
     CLog::Log(LOGERROR, "%s - Failed to finish command queue.", __FUNCTION__);
@@ -1736,7 +1736,7 @@ void CRenderSystemDX::FinishCommandList(bool bExecute /*= true*/)
   SAFE_RELEASE(pCommandList);
 }
 
-void CRenderSystemDX::SetMaximumFrameLatency(uint8_t latency)
+void CRenderSystemDX::SetMaximumFrameLatency(uint8_t latency) const
 {
   if (!m_pD3DDev)
     return;

--- a/xbmc/rendering/dx/RenderSystemDX.cpp
+++ b/xbmc/rendering/dx/RenderSystemDX.cpp
@@ -32,9 +32,7 @@
 #include "settings/AdvancedSettings.h"
 #include "threads/SingleLock.h"
 #include "utils/MathUtils.h"
-#include "utils/TimeUtils.h"
 #include "utils/log.h"
-#include "win32/WIN32Util.h"
 #include "win32/dxerr.h"
 
 #pragma comment(lib, "d3d11.lib")
@@ -51,7 +49,6 @@ CRenderSystemDX::CRenderSystemDX() : CRenderSystemBase()
   m_enumRenderingSystem = RENDERING_SYSTEM_DIRECTX;
 
   m_bVSync = true;
-  m_systemFreq = CurrentHostFrequency();
 
   ZeroMemory(&m_cachedMode, sizeof(m_cachedMode));
   ZeroMemory(&m_viewPort, sizeof(m_viewPort));

--- a/xbmc/rendering/dx/RenderSystemDX.h
+++ b/xbmc/rendering/dx/RenderSystemDX.h
@@ -137,7 +137,6 @@ protected:
   float                       m_refreshRate;
   bool                        m_interlaced;
   HRESULT                     m_nDeviceStatus{S_OK};
-  int64_t                     m_systemFreq;
   D3D11_USAGE                 m_defaultD3DUsage{D3D11_USAGE_DEFAULT};
   bool                        m_useWindowedDX;
   CCriticalSection            m_resourceSection;

--- a/xbmc/rendering/dx/RenderSystemDX.h
+++ b/xbmc/rendering/dx/RenderSystemDX.h
@@ -46,47 +46,47 @@ public:
   virtual ~CRenderSystemDX();
 
   // CRenderBase
-  virtual bool InitRenderSystem();
-  virtual bool DestroyRenderSystem();
-  virtual bool ResetRenderSystem(int width, int height, bool fullScreen, float refreshRate);
-  virtual bool BeginRender();
-  virtual bool EndRender();
-  virtual bool ClearBuffers(color_t color);
-  virtual bool IsExtSupported(const char* extension);
+  bool InitRenderSystem() override;
+  bool DestroyRenderSystem() override;
+  bool ResetRenderSystem(int width, int height, bool fullScreen, float refreshRate) override;
+  bool BeginRender() override;
+  bool EndRender() override;
+  bool ClearBuffers(color_t color) override;
+  bool IsExtSupported(const char* extension) override;
   virtual bool IsFormatSupport(DXGI_FORMAT format, unsigned int usage);
   virtual void SetVSync(bool vsync);
-  virtual void SetViewPort(CRect& viewPort);
-  virtual void GetViewPort(CRect& viewPort);
-  virtual void RestoreViewPort();
-  virtual CRect ClipRectToScissorRect(const CRect &rect);
-  virtual bool ScissorsCanEffectClipping();
-  virtual void SetScissors(const CRect &rect);
-  virtual void ResetScissors();
-  virtual void CaptureStateBlock();
-  virtual void ApplyStateBlock();
-  virtual void SetCameraPosition(const CPoint &camera, int screenWidth, int screenHeight, float stereoFactor = 0.f);
-  virtual void ApplyHardwareTransform(const TransformMatrix &matrix);
-  virtual void RestoreHardwareTransform();
-  virtual void SetStereoMode(RENDER_STEREO_MODE mode, RENDER_STEREO_VIEW view);
-  virtual bool SupportsStereo(RENDER_STEREO_MODE mode) const;
-  virtual bool TestRender();
-  virtual void Project(float &x, float &y, float &z);
+  void SetViewPort(CRect& viewPort) override;
+  void GetViewPort(CRect& viewPort) override;
+  void RestoreViewPort() override;
+  CRect ClipRectToScissorRect(const CRect &rect) override;
+  bool ScissorsCanEffectClipping() override;
+  void SetScissors(const CRect &rect) override;
+  void ResetScissors() override;
+  void CaptureStateBlock() override;
+  void ApplyStateBlock() override;
+  void SetCameraPosition(const CPoint &camera, int screenWidth, int screenHeight, float stereoFactor = 0.f) override;
+  void ApplyHardwareTransform(const TransformMatrix &matrix) override;
+  void RestoreHardwareTransform() override;
+  void SetStereoMode(RENDER_STEREO_MODE mode, RENDER_STEREO_VIEW view) override;
+  bool SupportsStereo(RENDER_STEREO_MODE mode) const override;
+  bool TestRender() override;
+  void Project(float &x, float &y, float &z) override;
   virtual CRect GetBackBufferRect() { return CRect(0.f, 0.f, static_cast<float>(m_nBackBufferWidth), static_cast<float>(m_nBackBufferHeight)); }
 
-  IDXGIOutput* GetCurrentOutput(void) { return m_pOutput; }
+  IDXGIOutput* GetCurrentOutput() const { return m_pOutput; }
   void GetDisplayMode(DXGI_MODE_DESC *mode, bool useCached = false);
-  void FinishCommandList(bool bExecute = true);
-  void FlushGPU();
+  void FinishCommandList(bool bExecute = true) const;
+  void FlushGPU() const;
 
-  ID3D11Device*           Get3D11Device()      { return m_pD3DDev; }
-  ID3D11DeviceContext*    Get3D11Context()     { return m_pContext; }
-  ID3D11DeviceContext*    GetImmediateContext(){ return m_pImdContext; }
-  CGUIShaderDX*           GetGUIShader()       { return m_pGUIShader; }
-  unsigned                GetFeatureLevel()    { return m_featureLevel; }
-  D3D11_USAGE             DefaultD3DUsage()    { return m_defaultD3DUsage; }
-  DXGI_ADAPTER_DESC       GetAIdentifier()     { return m_adapterDesc; }
-  bool                    Interlaced()         { return m_interlaced; }
-  int                     GetBackbufferCount() const { return 2; }
+  ID3D11Device*           Get3D11Device() const       { return m_pD3DDev; }
+  ID3D11DeviceContext*    Get3D11Context() const      { return m_pContext; }
+  ID3D11DeviceContext*    GetImmediateContext() const { return m_pImdContext; }
+  CGUIShaderDX*           GetGUIShader() const        { return m_pGUIShader; }
+  unsigned                GetFeatureLevel() const     { return m_featureLevel; }
+  D3D11_USAGE             DefaultD3DUsage() const     { return m_defaultD3DUsage; }
+  DXGI_ADAPTER_DESC       GetAIdentifier() const      { return m_adapterDesc; }
+  bool                    Interlaced() const          { return m_interlaced; }
+  int                     GetBackbufferCount() const  { return 2; }
   void                    SetAlphaBlendEnable(bool enable);
 
   static std::string GetErrorDescription(HRESULT hr);
@@ -110,11 +110,11 @@ protected:
   void SetFullScreenInternal();
   void GetClosestDisplayModeToCurrent(IDXGIOutput* output, DXGI_MODE_DESC* outCurrentDisplayMode, bool useCached = false);
   void CheckInterlasedStereoView(void);
-  void SetMaximumFrameLatency(uint8_t latency = -1);
+  void SetMaximumFrameLatency(uint8_t latency = -1) const;
 
   bool GetStereoEnabled() const;
   bool GetDisplayStereoEnabled() const;
-  void SetDisplayStereoEnabled(bool enable);
+  void SetDisplayStereoEnabled(bool enable) const;
   void UpdateDisplayStereoStatus(bool isfirst = false);
 
   virtual void Register(ID3DResource *resource);

--- a/xbmc/rendering/dx/RenderSystemDX.h
+++ b/xbmc/rendering/dx/RenderSystemDX.h
@@ -125,60 +125,60 @@ protected:
   virtual void OnDisplayBack() {};
 
   // our adapter could change as we go
-  bool                        m_needNewDevice;
+  bool                        m_needNewDevice{false};
   bool                        m_needNewViews;
-  bool                        m_resizeInProgress;
-  unsigned int                m_screenHeight;
-  HWND                        m_hFocusWnd;
-  HWND                        m_hDeviceWnd;
-  unsigned int                m_nBackBufferWidth;
-  unsigned int                m_nBackBufferHeight;
-  bool                        m_bFullScreenDevice;
+  bool                        m_resizeInProgress{false};
+  unsigned int                m_screenHeight{0};
+  HWND                        m_hFocusWnd{nullptr};
+  HWND                        m_hDeviceWnd{nullptr};
+  unsigned int                m_nBackBufferWidth{0};
+  unsigned int                m_nBackBufferHeight{0};
+  bool                        m_bFullScreenDevice{false};
   float                       m_refreshRate;
   bool                        m_interlaced;
-  HRESULT                     m_nDeviceStatus;
+  HRESULT                     m_nDeviceStatus{S_OK};
   int64_t                     m_systemFreq;
-  D3D11_USAGE                 m_defaultD3DUsage;
+  D3D11_USAGE                 m_defaultD3DUsage{D3D11_USAGE_DEFAULT};
   bool                        m_useWindowedDX;
   CCriticalSection            m_resourceSection;
   std::vector<ID3DResource*>  m_resources;
-  bool                        m_inScene; ///< True if we're in a BeginScene()/EndScene() block
-  D3D_DRIVER_TYPE             m_driverType;
-  D3D_FEATURE_LEVEL           m_featureLevel;
-  IDXGIFactory1*              m_dxgiFactory;
-  ID3D11Device*               m_pD3DDev;
-  IDXGIAdapter1*              m_adapter;
-  IDXGIOutput*                m_pOutput;
-  ID3D11DeviceContext*        m_pContext;
-  ID3D11DeviceContext*        m_pImdContext;
-  IDXGISwapChain*             m_pSwapChain;
-  IDXGISwapChain1*            m_pSwapChain1;
-  ID3D11RenderTargetView*     m_pRenderTargetView;
-  ID3D11DepthStencilState*    m_depthStencilState;
-  ID3D11DepthStencilView*     m_depthStencilView;
+  bool                        m_inScene{false}; ///< True if we're in a BeginScene()/EndScene() block
+  D3D_DRIVER_TYPE             m_driverType{D3D_DRIVER_TYPE_HARDWARE};
+  D3D_FEATURE_LEVEL           m_featureLevel{D3D_FEATURE_LEVEL_11_1};
+  IDXGIFactory1*              m_dxgiFactory{nullptr};
+  ID3D11Device*               m_pD3DDev{nullptr};
+  IDXGIAdapter1*              m_adapter{nullptr};
+  IDXGIOutput*                m_pOutput{nullptr};
+  ID3D11DeviceContext*        m_pContext{nullptr};
+  ID3D11DeviceContext*        m_pImdContext{nullptr};
+  IDXGISwapChain*             m_pSwapChain{nullptr};
+  IDXGISwapChain1*            m_pSwapChain1{nullptr};
+  ID3D11RenderTargetView*     m_pRenderTargetView{nullptr};
+  ID3D11DepthStencilState*    m_depthStencilState{nullptr};
+  ID3D11DepthStencilView*     m_depthStencilView{nullptr};
   D3D11_VIEWPORT              m_viewPort;
   CRect                       m_scissor;
-  CGUIShaderDX*               m_pGUIShader;
-  ID3D11BlendState*           m_BlendEnableState;
-  ID3D11BlendState*           m_BlendDisableState;
-  bool                        m_BlendEnabled;
-  ID3D11RasterizerState*      m_RSScissorDisable;
-  ID3D11RasterizerState*      m_RSScissorEnable;
-  bool                        m_ScissorsEnabled;
+  CGUIShaderDX*               m_pGUIShader{nullptr};
+  ID3D11BlendState*           m_BlendEnableState{nullptr};
+  ID3D11BlendState*           m_BlendDisableState{nullptr};
+  bool                        m_BlendEnabled{false};
+  ID3D11RasterizerState*      m_RSScissorDisable{nullptr};
+  ID3D11RasterizerState*      m_RSScissorEnable{nullptr};
+  bool                        m_ScissorsEnabled{false};
   DXGI_ADAPTER_DESC           m_adapterDesc;
   // stereo interlaced/checkerboard intermediate target
-  ID3D11Texture2D*            m_pTextureRight;
-  ID3D11RenderTargetView*     m_pRenderTargetViewRight;
-  ID3D11ShaderResourceView*   m_pShaderResourceViewRight;
-  bool                        m_bResizeRequred;
-  bool                        m_bHWStereoEnabled;
+  ID3D11Texture2D*            m_pTextureRight{nullptr};
+  ID3D11RenderTargetView*     m_pRenderTargetViewRight{nullptr};
+  ID3D11ShaderResourceView*   m_pShaderResourceViewRight{nullptr};
+  bool                        m_bResizeRequred{false};
+  bool                        m_bHWStereoEnabled{false};
   // improve get current mode
   DXGI_MODE_DESC              m_cachedMode;
 #ifdef _DEBUG
-  ID3D11Debug*                m_d3dDebug = NULL;
+  ID3D11Debug*                m_d3dDebug{nullptr};
 #endif
-  bool                        m_bDefaultStereoEnabled;
-  bool                        m_bStereoEnabled;
+  bool                        m_bDefaultStereoEnabled{false};
+  bool                        m_bStereoEnabled{false};
 };
 
 #endif


### PR DESCRIPTION
Moved most initialization to the declaration as it's easier to spot missed members that way when there's so many member variables. There's still a few missing initialization but I'm not sure what's a sane default so leaving them as is.
