### PR TITLE
[win32] disable AppVeyor add-ons building

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,12 +6,12 @@ environment:
   CONFIG: Release
   matrix:
     - BUILD: Kodi
-    - ADDONS: adsp
-    - ADDONS: audiodecoder
-    - ADDONS: audioencoder
-    - ADDONS: pvr
-    - ADDONS: screensaver
-    - ADDONS: visualization
+    # - ADDONS: adsp
+    # - ADDONS: audiodecoder
+    # - ADDONS: audioencoder
+    # - ADDONS: pvr
+    # - ADDONS: screensaver
+    # - ADDONS: visualization
 
 install:
   - SET PATH=C:\Program Files (x86)\CMake\bin;C:\msys64\bin;C:\msys64\usr\bin;%PATH%


### PR DESCRIPTION
AppVeyor building is quite slow and since we only want to know if core build it's best to disable add-on building
