### PR TITLE
mmalffmpeg: Add lock on buffer release and log message

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALFFmpeg.cpp
@@ -82,6 +82,8 @@ CGPUMEM *CDecoder::AllocateBuffer(unsigned int size_pic)
     m_freeBuffers.pop_front();
     if (gmem->m_numbytes == size_pic)
       return gmem;
+    if (g_advancedSettings.CanLogComponent(LOGVIDEO))
+      CLog::Log(LOGDEBUG, "%s::%s discarding gmem:%p size %d/%d", CLASSNAME, __FUNCTION__, gmem, gmem->m_numbytes, size_pic);
     delete gmem;
   }
 
@@ -93,6 +95,7 @@ CGPUMEM *CDecoder::AllocateBuffer(unsigned int size_pic)
 
 void CDecoder::ReleaseBuffer(CGPUMEM *gmem)
 {
+  CSingleLock lock(m_section);
   if (m_closing)
     delete gmem;
   else


### PR DESCRIPTION
There was an occasional crash with software decode in
AllocateBuffer near end of file that appears to be due to
the missing lock in ReleaseBuffer function.

Also add a debug message for the (unusual) case of a buffer
being freed due to a change in resolution of the stream.
