### PR TITLE
mmalrenderer: Add support for more formats

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
@@ -885,7 +885,7 @@ void CMMALVideo::Prime()
 {
   MMAL_BUFFER_HEADER_T *buffer;
   assert(m_renderer);
-  MMAL_POOL_T *render_pool = m_renderer->GetPool(RENDER_FMT_MMAL, true);
+  MMAL_POOL_T *render_pool = m_renderer->GetPool(RENDER_FMT_MMAL, AV_PIX_FMT_YUV420P, true);
   assert(render_pool);
   if (VERBOSE && g_advancedSettings.CanLogComponent(LOGVIDEO))
     CLog::Log(LOGDEBUG, "%s::%s - queue(%p)", CLASSNAME, __func__, render_pool);

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALFFmpeg.cpp
@@ -280,7 +280,7 @@ int CDecoder::Decode(AVCodecContext* avctx, AVFrame* frame)
 
 MMAL_BUFFER_HEADER_T *CDecoder::GetMmal()
 {
-  MMAL_POOL_T *render_pool = m_renderer->GetPool(RENDER_FMT_MMAL, false);
+  MMAL_POOL_T *render_pool = m_renderer->GetPool(RENDER_FMT_MMAL, AV_PIX_FMT_YUV420P, false);
   assert(render_pool);
   MMAL_BUFFER_HEADER_T *mmal_buffer = mmal_queue_timedwait(render_pool->queue, 500);
   if (!mmal_buffer)

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALFFmpeg.cpp
@@ -45,6 +45,7 @@ using namespace MMAL;
 CMMALYUVBuffer::CMMALYUVBuffer(CDecoder *dec, unsigned int width, unsigned int height, unsigned int aligned_width, unsigned int aligned_height)
   : m_dec(dec)
 {
+  unsigned int size_pic = 0;
   dec->Acquire();
   m_width = width;
   m_height = height;
@@ -52,7 +53,13 @@ CMMALYUVBuffer::CMMALYUVBuffer(CDecoder *dec, unsigned int width, unsigned int h
   m_aligned_height = aligned_height;
   m_aspect_ratio = 0.0f;
   mmal_buffer = nullptr;
-  unsigned int size_pic = (m_aligned_width * m_aligned_height * 3) >> 1;
+  if (dec->m_fmt == AV_PIX_FMT_YUV420P)
+    size_pic = (m_aligned_width * m_aligned_height * 3) >> 1;
+  else if (dec->m_fmt == AV_PIX_FMT_BGR0)
+    size_pic = (m_aligned_width << 2) * m_aligned_height;
+  else if (dec->m_fmt == AV_PIX_FMT_RGB565LE)
+    size_pic = (m_aligned_width << 1) * m_aligned_height;
+  else assert(0);
   gmem = m_dec->AllocateBuffer(size_pic);
   if (gmem)
     gmem->m_opaque = (void *)this;
@@ -199,9 +206,9 @@ int CDecoder::FFGetBuffer(AVCodecContext *avctx, AVFrame *frame, int flags)
   CDVDVideoCodecFFmpeg *ctx = (CDVDVideoCodecFFmpeg*)avctx->opaque;
   CDecoder *dec = (CDecoder*)ctx->GetHardware();
   if (g_advancedSettings.CanLogComponent(LOGVIDEO))
-    CLog::Log(LOGDEBUG,"%s::%s %dx%d format:%x flags:%x", CLASSNAME, __FUNCTION__, frame->width, frame->height, frame->format, flags);
+    CLog::Log(LOGDEBUG,"%s::%s %dx%d format:%x:%x flags:%x", CLASSNAME, __FUNCTION__, frame->width, frame->height, frame->format, dec->m_fmt, flags);
 
-  if ((avctx->codec->capabilities & AV_CODEC_CAP_DR1) == 0 || frame->format != AV_PIX_FMT_YUV420P)
+  if ((avctx->codec && (avctx->codec->capabilities & AV_CODEC_CAP_DR1) == 0) || frame->format != dec->m_fmt)
   {
     assert(0);
     return avcodec_default_get_buffer2(avctx, frame, flags);
@@ -227,13 +234,29 @@ int CDecoder::FFGetBuffer(AVCodecContext *avctx, AVFrame *frame, int flags)
     frame->linesize[i] = 0;
   }
 
-  frame->buf[0] = buf;
-  frame->linesize[0] = YUVBuffer->m_aligned_width;
-  frame->linesize[1] = YUVBuffer->m_aligned_width>>1;
-  frame->linesize[2] = YUVBuffer->m_aligned_width>>1;
-  frame->data[0] = (uint8_t *)gmem->m_arm;
-  frame->data[1] = frame->data[0] + YUVBuffer->m_aligned_width * YUVBuffer->m_aligned_height;
-  frame->data[2] = frame->data[1] + (YUVBuffer->m_aligned_width>>1) * (YUVBuffer->m_aligned_height>>1);
+  if (dec->m_fmt == AV_PIX_FMT_YUV420P)
+  {
+    frame->buf[0] = buf;
+    frame->linesize[0] = YUVBuffer->m_aligned_width;
+    frame->linesize[1] = YUVBuffer->m_aligned_width>>1;
+    frame->linesize[2] = YUVBuffer->m_aligned_width>>1;
+    frame->data[0] = (uint8_t *)gmem->m_arm;
+    frame->data[1] = frame->data[0] + YUVBuffer->m_aligned_width * YUVBuffer->m_aligned_height;
+    frame->data[2] = frame->data[1] + (YUVBuffer->m_aligned_width>>1) * (YUVBuffer->m_aligned_height>>1);
+  }
+  else if (dec->m_fmt == AV_PIX_FMT_BGR0)
+  {
+    frame->buf[0] = buf;
+    frame->linesize[0] = YUVBuffer->m_aligned_width << 2;
+    frame->data[0] = (uint8_t *)gmem->m_arm;
+  }
+  else if (dec->m_fmt == AV_PIX_FMT_RGB565LE)
+  {
+    frame->buf[0] = buf;
+    frame->linesize[0] = YUVBuffer->m_aligned_width << 1;
+    frame->data[0] = (uint8_t *)gmem->m_arm;
+  }
+  else assert(0);
   frame->extended_data = frame->data;
   // Leave extended buf alone
 
@@ -263,6 +286,7 @@ bool CDecoder::Open(AVCodecContext *avctx, AVCodecContext* mainctx, enum AVPixel
   mainctx->get_buffer2 = CDecoder::FFGetBuffer;
 
   m_avctx = mainctx;
+  m_fmt = fmt;
   return true;
 }
 
@@ -280,7 +304,7 @@ int CDecoder::Decode(AVCodecContext* avctx, AVFrame* frame)
 
 MMAL_BUFFER_HEADER_T *CDecoder::GetMmal()
 {
-  MMAL_POOL_T *render_pool = m_renderer->GetPool(RENDER_FMT_MMAL, AV_PIX_FMT_YUV420P, false);
+  MMAL_POOL_T *render_pool = m_renderer->GetPool(RENDER_FMT_MMAL, m_fmt, false);
   assert(render_pool);
   MMAL_BUFFER_HEADER_T *mmal_buffer = mmal_queue_timedwait(render_pool->queue, 500);
   if (!mmal_buffer)
@@ -303,7 +327,8 @@ bool CDecoder::GetPicture(AVCodecContext* avctx, AVFrame* frame, DVDVideoPicture
   if (!ret)
     return false;
 
-  if (frame->format != AV_PIX_FMT_YUV420P || frame->buf[1] != nullptr || frame->buf[0] == nullptr)
+  if ((frame->format != AV_PIX_FMT_YUV420P && frame->format != AV_PIX_FMT_BGR0 && frame->format != AV_PIX_FMT_RGB565LE) ||
+      frame->buf[1] != nullptr || frame->buf[0] == nullptr)
     return false;
 
   MMAL_BUFFER_HEADER_T *mmal_buffer = GetMmal();

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALFFmpeg.h
@@ -69,6 +69,7 @@ public:
   CGPUMEM *AllocateBuffer(unsigned int numbytes);
   void ReleaseBuffer(CGPUMEM *gmem);
   unsigned sizeFree() { return m_freeBuffers.size(); }
+  enum AVPixelFormat m_fmt;
 protected:
   MMAL_BUFFER_HEADER_T *GetMmal();
   AVCodecContext *m_avctx;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.cpp
@@ -42,7 +42,8 @@
 MMAL_POOL_T *CMMALRenderer::GetPool(ERenderFormat format, bool opaque)
 {
   CSingleLock lock(m_sharedSection);
-  if (!m_bMMALConfigured)
+  bool formatChanged = m_format != format || m_opaque != opaque;
+  if (!m_bMMALConfigured || formatChanged)
     m_bMMALConfigured = init_vout(format, opaque);
 
   return m_vout_input_pool;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.cpp
@@ -39,12 +39,12 @@
 
 #define VERBOSE 0
 
-MMAL_POOL_T *CMMALRenderer::GetPool(ERenderFormat format, bool opaque)
+MMAL_POOL_T *CMMALRenderer::GetPool(ERenderFormat format, AVPixelFormat pixfmt, bool opaque)
 {
   CSingleLock lock(m_sharedSection);
   bool formatChanged = m_format != format || m_opaque != opaque;
   if (!m_bMMALConfigured || formatChanged)
-    m_bMMALConfigured = init_vout(format, opaque);
+    m_bMMALConfigured = init_vout(format, pixfmt, opaque);
 
   return m_vout_input_pool;
 }
@@ -82,7 +82,7 @@ static void vout_input_port_cb_static(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *b
   mmal->vout_input_port_cb(port, buffer);
 }
 
-bool CMMALRenderer::init_vout(ERenderFormat format, bool opaque)
+bool CMMALRenderer::init_vout(ERenderFormat format, AVPixelFormat pixfmt, bool opaque)
 {
   CSingleLock lock(m_sharedSection);
   bool formatChanged = m_format != format || m_opaque != opaque;
@@ -282,7 +282,7 @@ bool CMMALRenderer::Configure(unsigned int width, unsigned int height, unsigned 
   SetViewMode(CMediaSettings::GetInstance().GetCurrentVideoSettings().m_ViewMode);
   ManageRenderArea();
 
-  m_bMMALConfigured = init_vout(format, m_opaque);
+  m_bMMALConfigured = init_vout(format, AV_PIX_FMT_YUV420P, m_opaque);
   m_bConfigured = m_bMMALConfigured;
   assert(m_bConfigured);
   return m_bConfigured;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.cpp
@@ -82,21 +82,60 @@ static void vout_input_port_cb_static(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *b
   mmal->vout_input_port_cb(port, buffer);
 }
 
+static struct {
+   uint32_t encoding;
+   AVPixelFormat pixfmt;
+} pixfmt_to_encoding_table[] =
+{
+   {MMAL_ENCODING_I420,    AV_PIX_FMT_YUV420P},
+   {MMAL_ENCODING_I422,    AV_PIX_FMT_YUV422P},
+   {MMAL_ENCODING_I420,    AV_PIX_FMT_YUVJ420P}, // FIXME
+   {MMAL_ENCODING_I422,    AV_PIX_FMT_YUVJ422P}, // FIXME
+   {MMAL_ENCODING_RGB16,   AV_PIX_FMT_RGB565},
+   {MMAL_ENCODING_RGB16,   AV_PIX_FMT_RGB565LE},
+   {MMAL_ENCODING_BGR16,   AV_PIX_FMT_BGR565},
+   {MMAL_ENCODING_RGB24,   AV_PIX_FMT_RGB24},
+   {MMAL_ENCODING_BGR24,   AV_PIX_FMT_BGR24},
+   {MMAL_ENCODING_ARGB,    AV_PIX_FMT_ARGB},
+   {MMAL_ENCODING_RGBA,    AV_PIX_FMT_RGBA},
+   {MMAL_ENCODING_ABGR,    AV_PIX_FMT_ABGR},
+   {MMAL_ENCODING_BGRA,    AV_PIX_FMT_BGRA},
+   {MMAL_ENCODING_BGRA,    AV_PIX_FMT_BGR0},
+   {MMAL_ENCODING_UNKNOWN, AV_PIX_FMT_NONE}
+};
+
+static uint32_t pixfmt_to_encoding(AVPixelFormat pixfmt)
+{
+  unsigned int i;
+  for (i = 0; pixfmt_to_encoding_table[i].encoding != MMAL_ENCODING_UNKNOWN; i++)
+    if (pixfmt_to_encoding_table[i].pixfmt == pixfmt)
+      break;
+  return pixfmt_to_encoding_table[i].encoding;
+}
+
 bool CMMALRenderer::init_vout(ERenderFormat format, AVPixelFormat pixfmt, bool opaque)
 {
   CSingleLock lock(m_sharedSection);
-  bool formatChanged = m_format != format || m_opaque != opaque;
+  bool formatChanged = m_format != format || m_opaque != opaque || m_pixfmt != pixfmt;
   MMAL_STATUS_T status;
+  uint32_t encoding = pixfmt_to_encoding(pixfmt);
 
-  CLog::Log(LOGDEBUG, "%s::%s configured:%d format %d->%d opaque %d->%d", CLASSNAME, __func__, m_bConfigured, m_format, format, m_opaque, opaque);
+  CLog::Log(LOGDEBUG, "%s::%s configured:%d format %d->%d pixfmt %x->%x opaque %d->%d", CLASSNAME, __func__, m_bConfigured, m_format, format, m_pixfmt, pixfmt, m_opaque, opaque);
 
   if (m_bMMALConfigured && formatChanged)
     UnInitMMAL();
 
-  if (m_bMMALConfigured || format != RENDER_FMT_MMAL)
+  if (m_bMMALConfigured || format == RENDER_FMT_BYPASS)
     return true;
 
+  if (format != RENDER_FMT_MMAL || encoding == MMAL_ENCODING_UNKNOWN)
+  {
+    CLog::Log(LOGERROR, "%s::%s Unsupported format", CLASSNAME, __func__);
+    return false;
+  }
+
   m_format = format;
+  m_pixfmt = pixfmt;
   m_opaque = opaque;
 
   /* Create video renderer */
@@ -124,7 +163,7 @@ bool CMMALRenderer::init_vout(ERenderFormat format, AVPixelFormat pixfmt, bool o
   es_format->es->video.width = m_sourceWidth;
   es_format->es->video.height = m_sourceHeight;
 
-  es_format->encoding = m_opaque ? MMAL_ENCODING_OPAQUE : MMAL_ENCODING_I420;
+  es_format->encoding = m_opaque ? MMAL_ENCODING_OPAQUE : encoding;
 
   status = mmal_port_parameter_set_boolean(m_vout_input, MMAL_PARAMETER_ZERO_COPY,  MMAL_TRUE);
   if (status != MMAL_SUCCESS)
@@ -178,6 +217,7 @@ CMMALRenderer::CMMALRenderer() : CThread("MMALRenderer")
   memset(m_buffers, 0, sizeof m_buffers);
   m_iFlags = 0;
   m_format = RENDER_FMT_NONE;
+  m_pixfmt = AV_PIX_FMT_YUV420P;
   m_opaque = true;
   m_bConfigured = false;
   m_bMMALConfigured = false;
@@ -282,7 +322,7 @@ bool CMMALRenderer::Configure(unsigned int width, unsigned int height, unsigned 
   SetViewMode(CMediaSettings::GetInstance().GetCurrentVideoSettings().m_ViewMode);
   ManageRenderArea();
 
-  m_bMMALConfigured = init_vout(format, AV_PIX_FMT_YUV420P, m_opaque);
+  m_bMMALConfigured = init_vout(format, m_pixfmt, m_opaque);
   m_bConfigured = m_bMMALConfigured;
   assert(m_bConfigured);
   return m_bConfigured;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.h
@@ -83,7 +83,7 @@ public:
   virtual bool         IsGuiLayer() { return false; }
 
   void vout_input_port_cb(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer);
-  MMAL_POOL_T *GetPool(ERenderFormat format, bool opaque);
+  MMAL_POOL_T *GetPool(ERenderFormat format, AVPixelFormat pixfmt, bool opaque);
 protected:
   int m_iYV12RenderBuffer;
   int m_NumYV12Buffers;
@@ -111,7 +111,7 @@ protected:
   MMAL_QUEUE_T *m_queue;
   double m_error;
 
-  bool init_vout(ERenderFormat format, bool opaque);
+  bool init_vout(ERenderFormat format, AVPixelFormat pixfmt, bool opaque);
   void ReleaseBuffers();
   void UnInitMMAL();
 };

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.h
@@ -103,6 +103,7 @@ protected:
   bool                      m_StereoInvert;
   int                       m_inflight;
   bool                      m_opaque;
+  AVPixelFormat m_pixfmt;
 
   CCriticalSection m_sharedSection;
   MMAL_COMPONENT_T *m_vout;


### PR DESCRIPTION
Currently mmalrenderer only supports YUV420.
This adds support for additional formats, like RGB.
The new formats are not currently used,
but will be useful for retroplayer in the future.
