### PR TITLE
 mmal_renderer: Use shared pointers to maintain the pool until the decoder has been destroyed

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
@@ -885,7 +885,10 @@ void CMMALVideo::Prime()
 {
   MMAL_BUFFER_HEADER_T *buffer;
   assert(m_renderer);
-  MMAL_POOL_T *render_pool = m_renderer->GetPool(RENDER_FMT_MMAL, AV_PIX_FMT_YUV420P, true);
+  if (!m_pool)
+    m_pool = m_renderer->GetPool(RENDER_FMT_MMAL, AV_PIX_FMT_YUV420P, true);
+  assert(m_pool);
+  MMAL_POOL_T *render_pool = m_pool->Get();
   assert(render_pool);
   if (VERBOSE && g_advancedSettings.CanLogComponent(LOGVIDEO))
     CLog::Log(LOGDEBUG, "%s::%s - queue(%p)", CLASSNAME, __func__, render_pool);

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.h
@@ -57,6 +57,7 @@ public:
 
 class CMMALVideo;
 class CMMALRenderer;
+class CMMALPool;
 
 // a mmal video frame
 class CMMALVideoBuffer : public CMMALBuffer
@@ -140,6 +141,7 @@ protected:
   MMAL_PORT_T *m_dec_output;
   MMAL_POOL_T *m_dec_input_pool;
   CMMALRenderer *m_renderer;
+  std::shared_ptr<CMMALPool> m_pool;
 
   MMAL_ES_FORMAT_T *m_es_format;
   MMAL_COMPONENT_T *m_deint;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALFFmpeg.cpp
@@ -307,7 +307,11 @@ int CDecoder::Decode(AVCodecContext* avctx, AVFrame* frame)
 
 MMAL_BUFFER_HEADER_T *CDecoder::GetMmal()
 {
-  MMAL_POOL_T *render_pool = m_renderer->GetPool(RENDER_FMT_MMAL, m_fmt, false);
+  if (!m_pool)
+    m_pool = m_renderer->GetPool(RENDER_FMT_MMAL, m_fmt, false);
+
+  assert(m_pool);
+  MMAL_POOL_T *render_pool = m_pool->Get();
   assert(render_pool);
   MMAL_BUFFER_HEADER_T *mmal_buffer = mmal_queue_timedwait(render_pool->queue, 500);
   if (!mmal_buffer)

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALFFmpeg.h
@@ -27,6 +27,7 @@
 #include "MMALCodec.h"
 
 class CMMALRenderer;
+class CMMALPool;
 struct MMAL_BUFFER_HEADER_T;
 class CGPUMEM;
 
@@ -76,6 +77,7 @@ protected:
   unsigned int m_shared;
   CCriticalSection m_section;
   CMMALRenderer *m_renderer;
+  std::shared_ptr<CMMALPool> m_pool;
   std::deque<CGPUMEM *> m_freeBuffers;
   bool m_closing;
 };

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.h
@@ -43,6 +43,17 @@ class CMMALBuffer;
 
 struct DVDVideoPicture;
 
+class CMMALPool
+{
+public:
+  CMMALPool(MMAL_PORT_T *input, uint32_t num_buffers, uint32_t buffer_size);
+  ~CMMALPool();
+  MMAL_POOL_T *Get() { return m_pool; }
+protected:
+  MMAL_POOL_T *m_pool;
+  MMAL_PORT_T *m_input;
+};
+
 class CMMALRenderer : public CBaseRenderer, public CThread
 {
 public:
@@ -83,7 +94,7 @@ public:
   virtual bool         IsGuiLayer() { return false; }
 
   void vout_input_port_cb(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer);
-  MMAL_POOL_T *GetPool(ERenderFormat format, AVPixelFormat pixfmt, bool opaque);
+  std::shared_ptr<CMMALPool> GetPool(ERenderFormat format, AVPixelFormat pixfmt, bool opaque);
 protected:
   int m_iYV12RenderBuffer;
   int m_NumYV12Buffers;
@@ -108,7 +119,7 @@ protected:
   CCriticalSection m_sharedSection;
   MMAL_COMPONENT_T *m_vout;
   MMAL_PORT_T *m_vout_input;
-  MMAL_POOL_T *m_vout_input_pool;
+  std::shared_ptr<CMMALPool> m_vout_input_pool;
   MMAL_QUEUE_T *m_queue;
   double m_error;
 


### PR DESCRIPTION
This fixes an issue when PVR fast channel switch changes between a SW decoded channel
(e.g. MPEG-2 without a codec licence) and a HW decoded channel (e.g. H.264).

If the pool is destroyed on the reconfigure there may still be pictures from it in the render
queue which can crash if the pool has gone when they are processed.
