### PR TITLE
Add python scrapers

### DIFF
--- a/addons/metadata.demo.albums/addon.xml
+++ b/addons/metadata.demo.albums/addon.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<addon id="metadata.demo.albums"
+       name="Demo albums python scraper"
+       version="1.0.0"
+       provider-name="spiff">
+  <requires>
+    <import addon="xbmc.metadata" version="2.1.0"/>
+  </requires>
+  <extension point="xbmc.metadata.scraper.albums"
+             library="demo.py"/>
+  <extension point="xbmc.addon.metadata">
+    <summary lang="en">Demo albums python scraper</summary>
+    <description lang="en">Demo albums python scraper.</description>
+    <platform>all</platform>
+    <license>GPL v2.0</license>
+  </extension>
+</addon>

--- a/addons/metadata.demo.albums/demo.py
+++ b/addons/metadata.demo.albums/demo.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+
+import xbmcplugin,xbmcgui,xbmc,xbmcaddon
+import os,sys,urllib
+
+def get_params():
+        param=[]
+        paramstring=sys.argv[2]
+        if len(paramstring)>=2:
+                params=sys.argv[2]
+                cleanedparams=params.replace('?','')
+                if (params[len(params)-1]=='/'):
+                        params=params[0:len(params)-2]
+                pairsofparams=cleanedparams.split('&')
+                param={}
+                for i in range(len(pairsofparams)):
+                        splitparams={}
+                        splitparams=pairsofparams[i].split('=')
+                        if (len(splitparams))==2:
+                                param[splitparams[0]]=splitparams[1]
+                                
+        return param
+
+
+params=get_params()
+print params
+
+try:
+    action=urllib.unquote_plus(params["action"])
+except:
+    pass
+
+print ("Action: "+action)
+
+if action == 'find':
+    try:
+        artist=urllib.unquote_plus(params["artist"])
+        album=urllib.unquote_plus(params["title"])
+    except:
+        pass
+
+    print 'Find album with title %s from artist %s' %(album, artist)
+    liz=xbmcgui.ListItem('Demo album 1', thumbnailImage='DefaultAlbum.png', offscreen=True)
+    liz.setProperty('relevance', '0.5')
+    liz.setProperty('album.artist', artist)
+    liz.setProperty('album.year', '2005')
+    xbmcplugin.addDirectoryItem(handle=int(sys.argv[1]), url="/path/to/album", listitem=liz, isFolder=True)
+
+    liz=xbmcgui.ListItem('Demo album 2', thumbnailImage='DefaultVideo.png', offscreen=True)
+    liz.setProperty('relevance', '0.3')
+    liz.setProperty('album.artist', 'spiff')
+    liz.setProperty('album.year', '2016')
+    xbmcplugin.addDirectoryItem(handle=int(sys.argv[1]), url="/path/to/album2", listitem=liz, isFolder=True)
+elif action == 'getdetails':
+    try:
+        url=urllib.unquote_plus(params["url"])
+    except:
+        pass
+
+    if url == '/path/to/album':
+        liz=xbmcgui.ListItem('Demo album 1', offscreen=True)
+        liz.setProperty('album.musicbrainzid', '123')
+        liz.setProperty('album.artists', '2')
+        liz.setProperty('album.artist1.name', 'Jan')
+        liz.setProperty('album.artist1.musicbrainzid', '456')
+        liz.setProperty('album.artist2.name', 'Banan')
+        liz.setProperty('album.artist2.musicbrainzid', '789')
+        liz.setProperty('album.artist_description', 'I hate this album.')
+        liz.setProperty('album.genre', 'rock / pop')
+        liz.setProperty('album.styles', 'light / heavy')
+        liz.setProperty('album.moods', 'angry / happy')
+        liz.setProperty('album.themes', 'Morbid sexual things.. And urmumz.')
+        liz.setProperty('album.compiliation', 'true')
+        liz.setProperty('album.review', 'Somebody should die for making this')
+        liz.setProperty('album.release_date', '2005-01-02')
+        liz.setProperty('album.label', 'ArtistExploitation inc')
+        liz.setProperty('album.type', 'what is this?')
+        liz.setProperty('album.release_type', 'single')
+        liz.setProperty('album.year', '2005')
+        liz.setProperty('album.rating', '2.5')
+        liz.setProperty('album.userrating', '4.5')
+        liz.setProperty('album.votes', '100')
+        liz.setProperty('album.thumbs', '2')
+        liz.setProperty('album.thumb1.url', 'DefaultBackFanart.png')
+        liz.setProperty('album.thumb1.aspect', '1.78')
+        liz.setProperty('album.thumb2.url', '/home/akva/Pictures/hawaii-shirt.png')
+        liz.setProperty('album.thumb2.aspect', '2.35')
+        xbmcplugin.setResolvedUrl(handle=int(sys.argv[1]), succeeded=True, listitem=liz)
+    elif url == '/path/to/album2':
+        liz=xbmcgui.ListItem('Demo album 2', offscreen=True)
+        liz.setProperty('album.musicbrainzid', '123')
+        liz.setProperty('album.artists', '2')
+        liz.setProperty('album.artist1.name', 'Heise')
+        liz.setProperty('album.artist1.musicbrainzid', '456')
+        liz.setProperty('album.artist2.name', 'Kran')
+        liz.setProperty('album.artist2.musicbrainzid', '789')
+        liz.setProperty('album.artist_description', 'I love this album.')
+        liz.setProperty('album.genre', 'classical / jazz')
+        liz.setProperty('album.styles', 'yay / hurrah')
+        liz.setProperty('album.moods', 'sad / excited')
+        liz.setProperty('album.themes', 'Nice things.. And unicorns.')
+        liz.setProperty('album.compiliation', 'false')
+        liz.setProperty('album.review', 'Somebody should be rewarded for making this')
+        liz.setProperty('album.release_date', '2015-01-02')
+        liz.setProperty('album.label', 'Artists inc')
+        liz.setProperty('album.type', 'what is that?')
+        liz.setProperty('album.release_type', 'album')
+        liz.setProperty('album.year', '2015')
+        liz.setProperty('album.rating', '4.5')
+        liz.setProperty('album.userrating', '3.5')
+        liz.setProperty('album.votes', '200')
+        liz.setProperty('album.thumbs', '2')
+        liz.setProperty('album.thumb1.url', 'DefaultBackFanart.png')
+        liz.setProperty('album.thumb1.aspect', '1.78')
+        liz.setProperty('album.thumb2.url', '/home/akva/Pictures/hawaii-shirt.png')
+        liz.setProperty('album.thumb2.aspect', '2.35')
+        xbmcplugin.setResolvedUrl(handle=int(sys.argv[1]), succeeded=True, listitem=liz)
+
+xbmcplugin.endOfDirectory(int(sys.argv[1]))

--- a/addons/metadata.demo.artists/addon.xml
+++ b/addons/metadata.demo.artists/addon.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<addon id="metadata.demo.artists"
+       name="Demo artists python scraper"
+       version="1.0.0"
+       provider-name="spiff">
+  <requires>
+    <import addon="xbmc.metadata" version="2.1.0"/>
+  </requires>
+  <extension point="xbmc.metadata.scraper.artists"
+             library="demo.py"/>
+  <extension point="xbmc.addon.metadata">
+    <summary lang="en">Demo artists python scraper</summary>
+    <description lang="en">Demo artists python scraper</description>
+    <platform>all</platform>
+    <license>GPL v2.0</license>
+  </extension>
+</addon>

--- a/addons/metadata.demo.artists/demo.py
+++ b/addons/metadata.demo.artists/demo.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+
+import xbmcplugin,xbmcgui,xbmc,xbmcaddon
+import os,sys,urllib
+
+def get_params():
+        param=[]
+        paramstring=sys.argv[2]
+        if len(paramstring)>=2:
+                params=sys.argv[2]
+                cleanedparams=params.replace('?','')
+                if (params[len(params)-1]=='/'):
+                        params=params[0:len(params)-2]
+                pairsofparams=cleanedparams.split('&')
+                param={}
+                for i in range(len(pairsofparams)):
+                        splitparams={}
+                        splitparams=pairsofparams[i].split('=')
+                        if (len(splitparams))==2:
+                                param[splitparams[0]]=splitparams[1]
+                                
+        return param
+
+
+params=get_params()
+
+try:
+    action=urllib.unquote_plus(params["action"])
+except:
+    pass
+
+if action == 'find':
+    try:
+        artist=urllib.unquote_plus(params["artist"])
+    except:
+        pass
+
+    print 'Find artist with name %s' %(artist)
+    liz=xbmcgui.ListItem('Demo artist 1', thumbnailImage='DefaultAlbum.png', offscreen=True)
+    liz.setProperty('artist.genre', 'rock / pop')
+    liz.setProperty('artist.born', '2002')
+    xbmcplugin.addDirectoryItem(handle=int(sys.argv[1]), url="/path/to/artist", listitem=liz, isFolder=True)
+
+    liz=xbmcgui.ListItem('Demo artist 2', thumbnailImage='DefaultAlbum.png', offscreen=True)
+    liz.setProperty('artist.genre', 'classical / jazz')
+    liz.setProperty('artist.born', '2012')
+    xbmcplugin.addDirectoryItem(handle=int(sys.argv[1]), url="/path/to/artist2", listitem=liz, isFolder=True)
+elif action == 'getdetails':
+    url=urllib.unquote_plus(params["url"])
+    print 'Artist with url %s' %(url)
+    if url == '/path/to/artist':
+        liz=xbmcgui.ListItem('Demo artist 1', offscreen=True)
+        liz.setProperty('artist.musicbrainzid', '123')
+        liz.setProperty('artist.genre', 'rock / pop')
+        liz.setProperty('artist.styles', 'heavy / light')
+        liz.setProperty('artist.moods', 'angry / happy')
+        liz.setProperty('artist.years_active', '1980 / 2012')
+        liz.setProperty('artist.instruments', 'guitar / drums')
+        liz.setProperty('artist.born', '1/1/2001')
+        liz.setProperty('artist.formed', '1980')
+        liz.setProperty('artist.biography', 'Wrote lots of crap. Likes to torture cats.')
+        liz.setProperty('artist.died', 'Tomorrow.')
+        liz.setProperty('artist.disbanded', 'Dec 21 2012')
+        liz.setProperty('artist.fanarts', '2')
+        liz.setProperty('artist.fanart1.url', 'DefaultBackFanart.png')
+        liz.setProperty('artist.fanart1.preview', 'DefaultBackFanart.png')
+        liz.setProperty('artist.fanart1.dim', '720')
+        liz.setProperty('artist.fanart2.url', '/home/akva/Pictures/hawaii-shirt.png')
+        liz.setProperty('artist.fanart2.preview', '/home/akva/Pictures/hawaii-shirt.png')
+        liz.setProperty('artist.fanart2.dim', '1080')
+        liz.setProperty('artist.albums', '2')
+        liz.setProperty('artist.album1.title', 'Demo album 1')
+        liz.setProperty('artist.album1.year', '2002')
+        liz.setProperty('artist.album2.title', 'Demo album 2')
+        liz.setProperty('artist.album2.year', '2007')
+        liz.setProperty('artist.thumbs', '2')
+        liz.setProperty('artist.thumb1.url', 'DefaultBackFanart.png')
+        liz.setProperty('artist.thumb1.aspect', '1.78')
+        liz.setProperty('artist.thumb2.url', '/home/akva/Pictures/hawaii-shirt.png')
+        liz.setProperty('artist.thumb2.aspect', '2.35')
+        xbmcplugin.setResolvedUrl(handle=int(sys.argv[1]), succeeded=True, listitem=liz)
+    if url == '/path/to/artist2':
+        liz=xbmcgui.ListItem('Demo artist 2', thumbnailImage='DefaultAlbum.png', offscreen=True)
+        liz.setProperty('artist.musicbrainzid', '456')
+        liz.setProperty('artist.genre', 'classical / jazz')
+        liz.setProperty('artist.styles', 'morbid / funny')
+        liz.setProperty('artist.moods', 'fast / dance')
+        liz.setProperty('artist.years_active', '1990 / 2016')
+        liz.setProperty('artist.instruments', 'bass / flute')
+        liz.setProperty('artist.born', '2/2/1971')
+        liz.setProperty('artist.formed', '1990')
+        liz.setProperty('artist.biography', 'Tortured lots of cats. Likes crap.')
+        liz.setProperty('artist.died', 'Yesterday.')
+        liz.setProperty('artist.disbanded', 'Nov 20 1980')
+        liz.setProperty('artist.fanarts', '2')
+        liz.setProperty('artist.fanart1.thumb', 'DefaultBackFanart.png')
+        liz.setProperty('artist.fanart1.dim', '720')
+        liz.setProperty('artist.fanart2.thumb', '/home/akva/Pictures/gnome-tshirt.png')
+        liz.setProperty('artist.fanart2.dim', '1080')
+        liz.setProperty('artist.albums', '2')
+        liz.setProperty('artist.album1.title', 'Demo album 1')
+        liz.setProperty('artist.album1.year', '2002')
+        liz.setProperty('artist.album2.title', 'Demo album 2')
+        liz.setProperty('artist.album2.year', '2005')
+        liz.setProperty('artist.thumbs', '2')
+        liz.setProperty('artist.thumb1.url', 'DefaultBackFanart.png')
+        liz.setProperty('artist.thumb1.aspect', '1.78')
+        liz.setProperty('artist.thumb2.url', '/home/akva/Pictures/hawaii-shirt.png')
+        liz.setProperty('artist.thumb2.aspect', '2.35')
+        xbmcplugin.setResolvedUrl(handle=int(sys.argv[1]), succeeded=True, listitem=liz)
+
+xbmcplugin.endOfDirectory(int(sys.argv[1]))

--- a/addons/metadata.demo.movies/addon.xml
+++ b/addons/metadata.demo.movies/addon.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<addon id="metadata.demo.movies"
+       name="Demo movies python scraper"
+       version="1.0.0"
+       provider-name="spiff">
+  <requires>
+    <import addon="xbmc.metadata" version="2.1.0"/>
+  </requires>
+  <extension point="xbmc.metadata.scraper.movies"
+             library="demo.py"/>
+  <extension point="xbmc.addon.metadata">
+    <summary lang="en">Demo movies python scraper</summary>
+    <description lang="en">Demo movies python scraper.</description>
+    <platform>all</platform>
+    <license>GPL v2.0</license>
+  </extension>
+</addon>

--- a/addons/metadata.demo.movies/demo.py
+++ b/addons/metadata.demo.movies/demo.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+
+import xbmcplugin,xbmcgui,xbmc,xbmcaddon
+import os,sys,urllib
+
+def get_params():
+        param=[]
+        paramstring=sys.argv[2]
+        if len(paramstring)>=2:
+                params=sys.argv[2]
+                cleanedparams=params.replace('?','')
+                if (params[len(params)-1]=='/'):
+                        params=params[0:len(params)-2]
+                pairsofparams=cleanedparams.split('&')
+                param={}
+                for i in range(len(pairsofparams)):
+                        splitparams={}
+                        splitparams=pairsofparams[i].split('=')
+                        if (len(splitparams))==2:
+                                param[splitparams[0]]=splitparams[1]
+                                
+        return param
+
+
+params=get_params()
+
+action=urllib.unquote_plus(params["action"])
+
+if action == 'find':
+    year = 0
+    title=urllib.unquote_plus(params["title"])
+    try:
+        year=int(urllib.unquote_plus(params["year"]))
+    except:
+        pass
+
+    print 'Find movie with title %s from year %i' %(title, int(year))
+    liz=xbmcgui.ListItem('Demo movie 1', thumbnailImage='DefaultVideo.png', offscreen=True)
+    liz.setProperty('relevance', '0.5')
+    xbmcplugin.addDirectoryItem(handle=int(sys.argv[1]), url="/path/to/movie", listitem=liz, isFolder=True)
+    liz=xbmcgui.ListItem('Demo movie 2', thumbnailImage='DefaultVideo.png', offscreen=True)
+    liz.setProperty('relevance', '0.3')
+    xbmcplugin.addDirectoryItem(handle=int(sys.argv[1]), url="/path/to/movie2", listitem=liz, isFolder=True)
+elif action == 'getdetails':
+    url=urllib.unquote_plus(params["url"])
+    if url == '/path/to/movie':
+        liz=xbmcgui.ListItem('Demo movie 1', offscreen=True)
+        liz.setProperty('video.original_title', 'Demo måvie 1')
+        liz.setProperty('video.sort_title', '2')
+        liz.setProperty('video.ratings', '1')
+        liz.setProperty('video.rating1.value', '5')
+        liz.setProperty('video.rating1.votes', '100')
+        liz.setProperty('video.user_rating', '5')
+        liz.setProperty('video.top250', '3')
+        liz.setProperty('video.unique_id', '123')
+        liz.setProperty('video.imdb_id', '456')
+        liz.setProperty('video.plot_outline', 'Outline yo')
+        liz.setProperty('video.plot', 'Plot yo')
+        liz.setProperty('video.tag_line', 'Tag yo')
+        liz.setProperty('video.duration_minutes', '110')
+        liz.setProperty('video.mpaa', 'T')
+        liz.setProperty('video.trailer', '/home/akva/Videos/porn/bukkake.mkv')
+        liz.setProperty('video.thumbs', '2')
+        liz.setProperty('video.thumb1.url', 'DefaultBackFanart.png')
+        liz.setProperty('video.thumb1.aspect', 'poster')
+        liz.setProperty('video.thumb2.url', '/home/akva/Pictures/hawaii-shirt.png')
+        liz.setProperty('video.thumb2.aspect', 'banner')
+        liz.setProperty('video.genre','Action / Comedy')
+        liz.setProperty('video.country', 'Norway / Sweden / China')
+        liz.setProperty('video.writing_credits', 'None / Want / To Admit It')
+        liz.setProperty('video.director', 'spiff / spiff2')
+        liz.setProperty('video.tvshow_links' ,'Demo show 1')
+        liz.setProperty('video.actors', '2')
+        liz.setProperty('video.actor1.name', 'spiff')
+        liz.setProperty('video.actor1.role', 'himself')
+        liz.setProperty('video.actor1.sort_order', '2')
+        liz.setProperty('video.actor1.thumb', '/home/akva/Pictures/fish.jpg')
+        liz.setProperty('video.actor1.thumb_aspect', 'banner')
+        liz.setProperty('video.actor2.name', 'monkey')
+        liz.setProperty('video.actor2.role', 'orange')
+        liz.setProperty('video.actor2.sort_order', '1')
+        liz.setProperty('video.actor1.thumb_aspect', 'poster')
+        liz.setProperty('video.actor2.thumb', '/home/akva/Pictures/coffee.jpg')
+        liz.setProperty('video.set_name', 'Spiffy creations')
+        liz.setProperty('video.set_overview', 'Horrors created by spiff')
+        liz.setProperty('video.tags', 'Very / Bad')
+        liz.setProperty('video.studio', 'Studio1 / Studio2')
+        liz.setProperty('video.fanarts', '2')
+        liz.setProperty('video.fanart1.url', 'DefaultBackFanart.png')
+        liz.setProperty('video.fanart1.preview', 'DefaultBackFanart.png')
+        liz.setProperty('video.fanart1.dim', '720')
+        liz.setProperty('video.fanart2.url', '/home/akva/Pictures/hawaii-shirt.png')
+        liz.setProperty('video.fanart2.preview', '/home/akva/Pictures/hawaii-shirt.png')
+        liz.setProperty('video.fanart2.dim', '1080')
+        liz.setProperty('video.date_added', '2016-01-01')
+        xbmcplugin.setResolvedUrl(handle=int(sys.argv[1]), succeeded=True, listitem=liz)
+elif action == 'getartwork':
+    url=urllib.unquote_plus(params["id"])
+    if url == '456':
+        liz=xbmcgui.ListItem('Demo movie 1', offscreen=True)
+        liz.setProperty('video.thumbs', '2')
+        liz.setProperty('video.thumb1.url', 'DefaultBackFanart.png')
+        liz.setProperty('video.thumb1.aspect', 'poster')
+        liz.setProperty('video.thumb2.url', '/home/akva/Pictures/hawaii-shirt.png')
+        liz.setProperty('video.thumb2.aspect', 'banner')
+        liz.setProperty('video.fanarts', '2')
+        liz.setProperty('video.fanart1.url', 'DefaultBackFanart.png')
+        liz.setProperty('video.fanart1.preview', 'DefaultBackFanart.png')
+        liz.setProperty('video.fanart1.dim', '720')
+        liz.setProperty('video.fanart2.url', '/home/akva/Pictures/hawaii-shirt.png')
+        liz.setProperty('video.fanart2.preview', '/home/akva/Pictures/hawaii-shirt.png')
+        liz.setProperty('video.fanart2.dim', '1080')
+        xbmcplugin.setResolvedUrl(handle=int(sys.argv[1]), succeeded=True, listitem=liz)
+
+xbmcplugin.endOfDirectory(int(sys.argv[1]))

--- a/addons/metadata.demo.tv/addon.xml
+++ b/addons/metadata.demo.tv/addon.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<addon id="metadata.demo.tv"
+       name="Demo TV python scraper"
+       version="1.0.0"
+       provider-name="spiff">
+  <requires>
+    <import addon="xbmc.metadata" version="2.1.0"/>
+  </requires>
+  <extension point="xbmc.metadata.scraper.tvshows"
+             library="demo.py"/>
+  <extension point="xbmc.addon.metadata">
+    <summary lang="en">Demo TV shows python scraper</summary>
+    <description lang="en">Demo TV shows python scraper.</description>
+    <platform>all</platform>
+    <license>GPL v2.0</license>
+  </extension>
+</addon>

--- a/addons/metadata.demo.tv/demo.py
+++ b/addons/metadata.demo.tv/demo.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+
+import xbmcplugin,xbmcgui,xbmc,xbmcaddon
+import os,sys,urllib
+
+def get_params():
+        param=[]
+        paramstring=sys.argv[2]
+        if len(paramstring)>=2:
+                params=sys.argv[2]
+                cleanedparams=params.replace('?','')
+                if (params[len(params)-1]=='/'):
+                        params=params[0:len(params)-2]
+                pairsofparams=cleanedparams.split('&')
+                param={}
+                for i in range(len(pairsofparams)):
+                        splitparams={}
+                        splitparams=pairsofparams[i].split('=')
+                        if (len(splitparams))==2:
+                                param[splitparams[0]]=splitparams[1]
+                                
+        return param
+
+
+params=get_params()
+
+action=urllib.unquote_plus(params["action"])
+
+if action == 'find':
+    year = 0
+    title=urllib.unquote_plus(params["title"])
+    try:
+        year=int(urllib.unquote_plus(params["year"]))
+    except:
+        pass
+
+    print 'Find TV show with title %s from year %i' %(title, int(year))
+    liz=xbmcgui.ListItem('Demo show 1', thumbnailImage='DefaultVideo.png', offscreen=True)
+    liz.setProperty('relevance', '0.5')
+    xbmcplugin.addDirectoryItem(handle=int(sys.argv[1]), url="/path/to/show", listitem=liz, isFolder=True)
+    liz=xbmcgui.ListItem('Demo show 2', thumbnailImage='DefaultVideo.png', offscreen=True)
+    liz.setProperty('relevance', '0.3')
+    xbmcplugin.addDirectoryItem(handle=int(sys.argv[1]), url="/path/to/show2", listitem=liz, isFolder=True)
+elif action == 'getdetails':
+    url=urllib.unquote_plus(params["url"])
+    if url == '/path/to/show':
+        liz=xbmcgui.ListItem('Demo show 1', offscreen=True)
+        liz.setProperty('video.original_title', 'Demo shåvv 1')
+        liz.setProperty('video.sort_title', '2')
+        liz.setProperty('video.ratings', '1')
+        liz.setProperty('video.rating1.value', '5')
+        liz.setProperty('video.rating1.votes', '100')
+        liz.setProperty('video.user_rating', '5')
+        liz.setProperty('video.unique_id', '123')
+        liz.setProperty('video.plot_outline', 'Outline yo')
+        liz.setProperty('video.plot', 'Plot yo')
+        liz.setProperty('video.tag_line', 'Tag yo')
+        liz.setProperty('video.duration_minutes', '110')
+        liz.setProperty('video.mpaa', 'T')
+        liz.setProperty('video.premiere_year', '2007')
+        liz.setProperty('video.status', 'Cancelled')
+        liz.setProperty('video.first_aired', '2007-01-01')
+        liz.setProperty('video.trailer', '/home/akva/Videos/porn/bukkake.mkv')
+        liz.setProperty('video.thumbs', '2')
+        liz.setProperty('video.thumb1.url', 'DefaultBackFanart.png')
+        liz.setProperty('video.thumb1.aspect', '1.78')
+        liz.setProperty('video.thumb2.url', '/home/akva/Pictures/hawaii-shirt.png')
+        liz.setProperty('video.thumb2.aspect', '2.35')
+        liz.setProperty('video.genre','Action / Comedy')
+        liz.setProperty('video.country', 'Norway / Sweden / China')
+        liz.setProperty('video.writing_credits', 'None / Want / To Admit It')
+        liz.setProperty('video.director', 'spiff / spiff2')
+        liz.setProperty('video.seasons', '2')
+        liz.setProperty('video.season1.name', 'Horrible')
+        liz.setProperty('video.season2.name', 'Crap')
+        liz.setProperty('video.actors', '2')
+        liz.setProperty('video.actor1.name', 'spiff')
+        liz.setProperty('video.actor1.role', 'himself')
+        liz.setProperty('video.actor1.sort_order', '2')
+        liz.setProperty('video.actor1.thumb', '/home/akva/Pictures/fish.jpg')
+        liz.setProperty('video.actor1.thumb_aspect', '1.33')
+        liz.setProperty('video.actor2.name', 'monkey')
+        liz.setProperty('video.actor2.role', 'orange')
+        liz.setProperty('video.actor2.sort_order', '1')
+        liz.setProperty('video.actor1.thumb_aspect', '1.78')
+        liz.setProperty('video.actor2.thumb', '/home/akva/Pictures/coffee.jpg')
+        liz.setProperty('video.tag', 'Porn / Umomz')
+        liz.setProperty('video.studio', 'Studio1 / Studio2')
+        liz.setProperty('video.episode_guide_url', '/path/to/show/guide')
+        liz.setProperty('video.fanarts', '2')
+        liz.setProperty('video.fanart1.url', 'DefaultBackFanart.png')
+        liz.setProperty('video.fanart1.preview', 'DefaultBackFanart.png')
+        liz.setProperty('video.fanart1.dim', '720')
+        liz.setProperty('video.fanart2.url', '/home/akva/Pictures/hawaii-shirt.png')
+        liz.setProperty('video.fanart2.preview', '/home/akva/Pictures/hawaii-shirt.png')
+        liz.setProperty('video.fanart2.dim', '1080')
+        liz.setProperty('video.date_added', '2016-01-01')
+        xbmcplugin.setResolvedUrl(handle=int(sys.argv[1]), succeeded=True, listitem=liz)
+elif action == 'getepisodelist':
+    url=urllib.unquote_plus(params["url"])
+    print 'in here yo ' + url
+    if url == '/path/to/show/guide':
+        liz=xbmcgui.ListItem('Demo Episode 1x1', offscreen=True)
+        liz.setProperty('video.episode', '1')
+        liz.setProperty('video.season', '1')
+        liz.setProperty('video.aired', '2015-01-01')
+        liz.setProperty('video.id', '1')
+        liz.setProperty('video.url', '/path/to/episode1')
+        xbmcplugin.addDirectoryItem(handle=int(sys.argv[1]), url="/path/to/episode1", listitem=liz, isFolder=False)
+        liz=xbmcgui.ListItem('Demo Episode 2x2', offscreen=True)
+        liz.setProperty('video.episode', '2')
+        #liz.setProperty('video.sub_episode', '1')
+        liz.setProperty('video.season', '2')
+        liz.setProperty('video.aired', '2014-01-01')
+        liz.setProperty('video.id', '2')
+        liz.setProperty('video.url', '/path/to/episode2')
+        xbmcplugin.addDirectoryItem(handle=int(sys.argv[1]), url="/path/to/episode2", listitem=liz, isFolder=False)
+elif action == 'getepisodedetails':
+    url=urllib.unquote_plus(params["url"])
+    if url == '/path/to/episode1':
+        liz=xbmcgui.ListItem('Demo Episode 1', offscreen=True)
+        liz.setProperty('video.original_title', 'Demo æpisod 1x1')
+        liz.setProperty('video.sort_title', '2')
+        liz.setProperty('video.episode', '1')
+        liz.setProperty('video.season', '1')
+        liz.setProperty('video.ratings', '1')
+        liz.setProperty('video.rating1.value', '5')
+        liz.setProperty('video.rating1.votes', '100')
+        liz.setProperty('video.user_rating', '5')
+        liz.setProperty('video.unique_id', '123')
+        liz.setProperty('video.plot_outline', 'Outline yo')
+        liz.setProperty('video.plot', 'Plot yo')
+        liz.setProperty('video.tag_line', 'Tag yo')
+        liz.setProperty('video.duration_minutes', '110')
+        liz.setProperty('video.mpaa', 'T')
+        liz.setProperty('video.first_aired', '2007-01-01')
+        liz.setProperty('video.thumbs', '2')
+        liz.setProperty('video.thumb1.url', 'DefaultBackFanart.png')
+        liz.setProperty('video.thumb1.aspect', '1.78')
+        liz.setProperty('video.thumb2.url', '/home/akva/Pictures/hawaii-shirt.png')
+        liz.setProperty('video.thumb2.aspect', '2.35')
+        liz.setProperty('video.genre','Action / Comedy')
+        liz.setProperty('video.country', 'Norway / Sweden / China')
+        liz.setProperty('video.writing_credits', 'None / Want / To Admit It')
+        liz.setProperty('video.director', 'spiff / spiff2')
+        liz.setProperty('video.actors', '2')
+        liz.setProperty('video.actor1.name', 'spiff')
+        liz.setProperty('video.actor1.role', 'himself')
+        liz.setProperty('video.actor1.sort_order', '2')
+        liz.setProperty('video.actor1.thumb', '/home/akva/Pictures/fish.jpg')
+        liz.setProperty('video.actor1.thumb_aspect', 'poster')
+        liz.setProperty('video.actor2.name', 'monkey')
+        liz.setProperty('video.actor2.role', 'orange')
+        liz.setProperty('video.actor2.sort_order', '1')
+        liz.setProperty('video.actor1.thumb_aspect', '1.78')
+        liz.setProperty('video.actor2.thumb', '/home/akva/Pictures/coffee.jpg')
+        liz.setProperty('video.date_added', '2016-01-01')
+        xbmcplugin.setResolvedUrl(handle=int(sys.argv[1]), succeeded=True, listitem=liz)
+    elif url == '/path/to/episode2':
+        liz=xbmcgui.ListItem('Demo Episode 2', offscreen=True)
+        liz.setProperty('video.original_title', 'Demo æpisod 2x2')
+        liz.setProperty('video.sort_title', '1')
+        liz.setProperty('video.episode', '2')
+        liz.setProperty('video.season', '2')
+        liz.setProperty('video.ratings', '1')
+        liz.setProperty('video.rating1.value', '5')
+        liz.setProperty('video.rating1.votes', '100')
+        liz.setProperty('video.user_rating', '5')
+        liz.setProperty('video.unique_id', '123')
+        liz.setProperty('video.plot_outline', 'Outline yo')
+        liz.setProperty('video.plot', 'Plot yo')
+        liz.setProperty('video.tag_line', 'Tag yo')
+        liz.setProperty('video.duration_minutes', '110')
+        liz.setProperty('video.mpaa', 'T')
+        liz.setProperty('video.first_aired', '2007-01-01')
+        liz.setProperty('video.thumbs', '2')
+        liz.setProperty('video.thumb1.url', 'DefaultBackFanart.png')
+        liz.setProperty('video.thumb1.aspect', '1.78')
+        liz.setProperty('video.thumb2.url', '/home/akva/Pictures/hawaii-shirt.png')
+        liz.setProperty('video.thumb2.aspect', '2.35')
+        liz.setProperty('video.genre','Action / Comedy')
+        liz.setProperty('video.country', 'Norway / Sweden / China')
+        liz.setProperty('video.writing_credits', 'None / Want / To Admit It')
+        liz.setProperty('video.director', 'spiff / spiff2')
+        liz.setProperty('video.actors', '2')
+        liz.setProperty('video.actor1.name', 'spiff')
+        liz.setProperty('video.actor1.role', 'himself')
+        liz.setProperty('video.actor1.sort_order', '2')
+        liz.setProperty('video.actor1.thumb', '/home/akva/Pictures/fish.jpg')
+        liz.setProperty('video.actor1.thumb_aspect', 'poster')
+        liz.setProperty('video.actor2.name', 'monkey')
+        liz.setProperty('video.actor2.role', 'orange')
+        liz.setProperty('video.actor2.sort_order', '1')
+        liz.setProperty('video.actor1.thumb_aspect', '1.78')
+        liz.setProperty('video.actor2.thumb', '/home/akva/Pictures/coffee.jpg')
+        liz.setProperty('video.date_added', '2016-01-01')
+        xbmcplugin.setResolvedUrl(handle=int(sys.argv[1]), succeeded=True, listitem=liz)
+
+
+
+xbmcplugin.endOfDirectory(int(sys.argv[1]))

--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -19,9 +19,10 @@
  */
 
 #include "Scraper.h"
+#include "filesystem/CurlFile.h"
 #include "filesystem/File.h"
 #include "filesystem/Directory.h"
-#include "filesystem/CurlFile.h"
+#include "filesystem/PluginDirectory.h"
 #include "AddonManager.h"
 #include "utils/ScraperParser.h"
 #include "utils/ScraperUrl.h"
@@ -166,6 +167,7 @@ CScraper::CScraper(AddonProps props)
     m_requiressettings(false),
     m_pathContent(CONTENT_NONE)
 {
+  m_isPython = URIUtils::GetExtension(LibPath()) == ".py";
 }
 
 CScraper::CScraper(AddonProps props, bool requiressettings, CDateTimeSpan persistence, CONTENT_TYPE pathContent)
@@ -175,6 +177,7 @@ CScraper::CScraper(AddonProps props, bool requiressettings, CDateTimeSpan persis
     m_persistence(persistence),
     m_pathContent(pathContent)
 {
+  m_isPython = URIUtils::GetExtension(LibPath()) == ".py";
 }
 
 bool CScraper::Supports(const CONTENT_TYPE &content) const
@@ -292,8 +295,8 @@ std::vector<std::string> CScraper::Run(const std::string& function,
       else
         scrURL2.ParseElement(xchain);
       // Fix for empty chains. $$1 would still contain the
-      // previous value as there is no child of the xml node. 
-      // since $$1 will always either contain the data from an 
+      // previous value as there is no child of the xml node.
+      // since $$1 will always either contain the data from an
       // url or the parameters to a chain, we can safely clear it here
       // to fix this issue
       m_parser.m_param[0].clear();
@@ -305,7 +308,7 @@ std::vector<std::string> CScraper::Run(const std::string& function,
     while (xchain && strcmp(xchain->Value(),"url") && strcmp(xchain->Value(),"chain"))
       xchain = xchain->NextSiblingElement();
   }
-  
+
   return result;
 }
 
@@ -352,7 +355,7 @@ std::string CScraper::InternalRun(const std::string& function,
 
 bool CScraper::Load()
 {
-  if (m_fLoaded)
+  if (m_fLoaded || m_isPython)
     return true;
 
   bool result=m_parser.Load(LibPath());
@@ -369,7 +372,7 @@ bool CScraper::Load()
       {
         ++itr;
         continue;
-      }  
+      }
       AddonPtr dep;
 
       bool bOptional = itr->second.second;
@@ -416,10 +419,10 @@ bool CScraper::IsInUse() const
 
 bool CScraper::IsNoop()
 {
-    if (!Load())
-      throw CScraperError();
+  if (!Load())
+    throw CScraperError();
 
-    return m_parser.IsNoop();
+  return !m_isPython && m_parser.IsNoop();
 }
 
 // pass in contents of .nfo file; returns URL (possibly empty if none found)
@@ -492,7 +495,7 @@ CScraperUrl CScraper::NfoUrl(const std::string &sNfoContent)
 CScraperUrl CScraper::ResolveIDToUrl(const std::string& externalID)
 {
   CScraperUrl scurlRet;
-  
+
   // scraper function takes an external ID, returns XML (see below)
   std::vector<std::string> vcsIn;
   vcsIn.push_back(externalID);
@@ -556,10 +559,335 @@ static bool RelevanceSortFunction(const CScraperUrl &left, const CScraperUrl &ri
   return left.relevance > right.relevance;
 }
 
+template<class T>
+static T FromFileItem(const CFileItem& item);
+
+
+template<>
+CScraperUrl FromFileItem<CScraperUrl>(const CFileItem& item)
+{
+  CScraperUrl url;
+
+  url.strTitle = item.GetLabel();
+  if (item.HasProperty("relevance"))
+    url.relevance = item.GetProperty("relevance").asDouble();
+  CScraperUrl::SUrlEntry surl;
+  surl.m_type = CScraperUrl::URL_TYPE_GENERAL;
+  surl.m_url =  item.GetPath();
+  url.m_url.push_back(surl);
+
+  return url;
+}
+
+template<>
+CMusicAlbumInfo FromFileItem<CMusicAlbumInfo>(const CFileItem& item)
+{
+  CMusicAlbumInfo info;
+  std::string sTitle  = item.GetLabel();
+  std::string sArtist = item.GetProperty("album.artist").asString();
+  std::string sAlbumName;
+  if (!sArtist.empty())
+    sAlbumName = StringUtils::Format("%s - %s", sArtist.c_str(), sTitle.c_str());
+  else
+    sAlbumName = sTitle;
+
+  std::string sYear = item.GetProperty("album.year").asString();
+  if (!sYear.empty())
+    sAlbumName = StringUtils::Format("%s (%s)", sAlbumName.c_str(), sYear.c_str());
+
+  CScraperUrl url;
+  url.m_url.resize(1);
+  url.m_url[0].m_url = item.GetPath();
+
+  info = CMusicAlbumInfo(sTitle, sArtist, sAlbumName, url);
+  if (item.HasProperty("relevance"))
+    info.SetRelevance(item.GetProperty("relevance").asDouble());
+
+  return info;
+}
+
+template<>
+CMusicArtistInfo FromFileItem<CMusicArtistInfo>(const CFileItem& item)
+{
+  CMusicArtistInfo info;
+  std::string sTitle  = item.GetLabel();
+
+  CScraperUrl url;
+  url.m_url.resize(1);
+  url.m_url[0].m_url = item.GetPath();
+
+  info = CMusicArtistInfo(sTitle, url);
+  if (item.HasProperty("artist.genre"))
+    info.GetArtist().genre = StringUtils::Split(item.GetProperty("artist.genre").asString(),
+                                                g_advancedSettings.m_musicItemSeparator);
+  if (item.HasProperty("artist.born"))
+    info.GetArtist().strBorn = item.GetProperty("artist.born").asString();
+
+  return info;
+}
+
+
+template<class T>
+static std::vector<T>
+PythonFind(const std::string& ID,
+           const std::map<std::string, std::string>& additionals)
+{
+  std::vector<T> result;
+  CFileItemList items;
+  std::stringstream str;
+  str << "plugin://" << ID << "?action=find";
+  for (const auto& it : additionals)
+    str << "&" << it.first<< "=" << CURL::Encode(it.second);
+
+  if (XFILE::CDirectory::GetDirectory(str.str(), items))
+  {
+    for (int i = 0; i < items.Size(); ++i)
+      result.emplace_back(std::move(FromFileItem<T>(*items[i])));
+  }
+
+  return result;
+}
+
+static std::string FromString(const CFileItem& item,
+                              const std::string& key)
+{
+    return item.GetProperty(key).asString();
+}
+
+static std::vector<std::string> FromArray(const CFileItem& item,
+                                          const std::string& key,
+                                          int sep)
+{
+    return StringUtils::Split(item.GetProperty(key).asString(),
+                              sep ? g_advancedSettings.m_videoItemSeparator :
+                                    g_advancedSettings.m_musicItemSeparator);
+}
+
+static void ParseThumbs(CScraperUrl& scurl, const CFileItem& item,
+                        int nThumbs, const std::string& tag)
+{
+  for (int i = 0; i < nThumbs; ++i)
+  {
+    std::stringstream prefix;
+    prefix << tag << i+1;
+    std::string url = FromString(item, prefix.str()+".url");
+    std::string aspect = FromString(item, prefix.str()+".aspect");
+    TiXmlElement thumb("thumb");
+    thumb.SetAttribute("aspect", aspect);
+    TiXmlText text(url);
+    thumb.InsertEndChild(text);
+    scurl.ParseElement(&thumb);
+  }
+}
+
+static std::string ParseFanart(const CFileItem& item,
+                               int nFanart, const std::string& tag)
+{
+  std::string result;
+  TiXmlElement fanart("fanart");
+  for (int i = 0; i < nFanart; ++i)
+  {
+    std::stringstream prefix;
+    prefix << tag << i+1;
+    std::string url = FromString(item, prefix.str()+".url");
+    std::string preview = FromString(item, prefix.str()+".preview");
+    std::string res = FromString(item, prefix.str()+".dim");
+    TiXmlElement thumb("thumb");
+    thumb.SetAttribute("dim", res);
+    thumb.SetAttribute("preview", preview);
+    TiXmlText text(url);
+    thumb.InsertEndChild(text);
+    fanart.InsertEndChild(thumb);
+  }
+  result << fanart;
+
+  return result;
+}
+
+template<class T>
+static void DetailsFromFileItem(const CFileItem&, T&);
+
+template<>
+void DetailsFromFileItem<CAlbum>(const CFileItem& item, CAlbum& album)
+{
+  album.strAlbum = item.GetLabel();
+  album.strMusicBrainzAlbumID = FromString(item, "album.musicbrainzid");
+
+  int nArtists = item.GetProperty("album.artists").asInteger();
+  album.artistCredits.reserve(nArtists);
+  for (int i = 0; i < nArtists; ++i)
+  {
+    std::stringstream prefix;
+    prefix << "album.artist" << i+1;
+    CArtistCredit artistCredit;
+    artistCredit.SetArtist(FromString(item, prefix.str()+".name"));
+    artistCredit.SetMusicBrainzArtistID(FromString(item, prefix.str()+".musicbrainzid"));
+    album.artistCredits.push_back(artistCredit);
+  }
+
+  album.strArtistDesc = FromString(item, "album.artist_description");
+  album.genre = FromArray(item, "album.genre", 0);
+  album.styles = FromArray(item, "album.styles", 0);
+  album.moods = FromArray(item, "album.moods", 0);
+  album.themes = FromArray(item, "album.themes", 0);
+  album.bCompilation = item.GetProperty("album.compilation").asBoolean();
+  album.strReview = FromString(item, "album.review");
+  album.m_strDateOfRelease = FromString(item, "album.release_date");
+  album.strLabel = FromString(item, "album.label");
+  album.strType = FromString(item, "album.type");
+  album.SetReleaseType(FromString(item, "album.release_type"));
+  album.iYear = item.GetProperty("album.year").asInteger();
+  album.fRating = item.GetProperty("album.rating").asDouble();
+  album.iUserrating = item.GetProperty("album.user_rating").asInteger();
+  album.iVotes = item.GetProperty("album.votes").asInteger();
+
+  int nThumbs = item.GetProperty("album.thumbs").asInteger();
+  ParseThumbs(album.thumbURL, item, nThumbs, "album.thumb");
+}
+
+template<>
+void DetailsFromFileItem<CArtist>(const CFileItem& item, CArtist& artist)
+{
+  artist.strArtist = item.GetLabel();
+  artist.strMusicBrainzArtistID = FromString(item, "artist.musicbrainzid");
+  artist.genre = FromArray(item, "artist.genre", 0);
+  artist.styles = FromArray(item, "artist.styles", 0);
+  artist.moods = FromArray(item, "artist.moods", 0);
+  artist.yearsActive = FromArray(item, "artist.years_active", 0);
+  artist.instruments = FromArray(item, "artist.instruments", 0);
+  artist.strBorn = FromString(item, "artist.born");
+  artist.strFormed = FromString(item, "artist.formed");
+  artist.strBiography = FromString(item, "artist.biography");
+  artist.strDied = FromString(item, "artist.died");
+  artist.strDisbanded = FromString(item, "artist.disbanded");
+
+  int nAlbums = item.GetProperty("artist.albums").asInteger();
+  artist.discography.reserve(nAlbums);
+  for (int i = 0; i < nAlbums; ++i)
+  {
+    std::stringstream prefix;
+    prefix << "artist.album" << i+1;
+    artist.discography.push_back(std::make_pair(FromString(item, prefix.str()+".title"),
+                                                FromString(item, prefix.str()+".year")));
+  }
+
+  int nThumbs = item.GetProperty("artist.thumbs").asInteger();
+  ParseThumbs(artist.thumbURL, item, nThumbs, "artist.thumb");
+
+  int nFanart = item.GetProperty("artist.fanarts").asInteger();
+  artist.fanart.m_xml = ParseFanart(item, nFanart, "artist.fanart");
+  artist.fanart.Unpack();
+}
+
+template<>
+void DetailsFromFileItem<CVideoInfoTag>(const CFileItem& item, CVideoInfoTag& tag)
+{
+  tag.SetTitle(item.GetLabel());
+  tag.SetOriginalTitle(FromString(item, "video.original_title"));
+  tag.SetShowTitle(FromString(item, "video.show_title"));
+  tag.SetSortTitle(FromString(item, "video.sort_title"));
+  int nRatings = item.GetProperty("video.ratings").asInteger();
+  for (int i = 0; i < nRatings; ++i)
+  {
+    std::stringstream str;
+    str << "video.rating" << i+1;
+    int votes = item.GetProperty(str.str()+".votes").asInteger();
+    float rating = item.GetProperty(str.str()+".value").asDouble();
+    tag.SetRating(rating, votes, "default");
+  }
+  tag.m_iUserRating = item.GetProperty("video.user_rating").asInteger();
+  tag.m_iTop250 = item.GetProperty("video.top250").asInteger();
+  tag.m_iSeason = item.GetProperty("video.season").asInteger();
+  tag.m_iEpisode = item.GetProperty("video.episode").asInteger();
+  tag.m_iTrack = item.GetProperty("video.track").asInteger();
+  tag.SetUniqueIDs({{"IMDB", FromString(item, "video.imdb_id")}});
+  tag.m_iSpecialSortSeason = item.GetProperty("video.display_season").asInteger();
+  tag.m_iSpecialSortEpisode = item.GetProperty("video.display_episode").asInteger();
+  tag.SetPlotOutline(FromString(item, "video.plot_outline"));
+  tag.SetPlot(FromString(item, "video.plot"));
+  tag.SetTagLine(FromString(item, "video.tag_line"));
+  tag.m_duration = item.GetProperty("video.duration_minutes").asInteger();
+  tag.SetMPAARating(FromString(item, "video.mpaa"));
+  tag.SetYear(item.GetProperty("video.premiere_year").asInteger());
+  tag.SetStatus(FromString(item, "video.status"));
+  tag.SetProductionCode(FromString(item, "video.production_code"));
+  tag.m_firstAired.SetFromDBDate(FromString(item, "video.first_aired"));
+  tag.SetAlbum(FromString(item, "video.album"));
+  tag.SetTrailer(FromString(item, "video.trailer"));
+  int nThumbs = item.GetProperty("video.thumbs").asInteger();
+  ParseThumbs(tag.m_strPictureURL, item, nThumbs, "video.thumb");
+  tag.SetGenre(FromArray(item, "video.genre", 1));
+  tag.SetCountry(FromArray(item, "video.country", 1));
+  tag.SetWritingCredits(FromArray(item, "video.writing_credits", 1));
+  tag.SetDirector(FromArray(item, "video.director", 1));
+  tag.SetShowLink(FromArray(item, "video.tvshow_links", 1));
+  int nSeasons = item.GetProperty("video.seasons").asInteger();
+  for (int i = 0; i < nSeasons; ++i)
+  {
+    std::stringstream str;
+    str << "video.season" << i+1;
+    tag.m_namedSeasons.insert(std::make_pair(i+1, FromString(item, str.str()+".name")));
+  }
+  int nActors = item.GetProperty("video.actors").asInteger();
+  for (int i = 0; i< nActors; ++i)
+  {
+    std::stringstream str;
+    str << "video.actor" << i+1;
+    SActorInfo actor;
+    actor.strName = FromString(item, str.str()+".name");
+    actor.strRole = FromString(item, str.str()+".role");
+    actor.order = item.GetProperty(str.str()+".sort_order").asInteger();
+    std::string url = FromString(item, str.str()+".thumb");
+    if (!url.empty())
+    {
+      double aspect = item.GetProperty(str.str()+".thumb_aspect").asDouble();
+      TiXmlElement thumb("thumb");
+      thumb.SetAttribute("aspect", aspect);
+      TiXmlText text(url);
+      thumb.InsertEndChild(text);
+      actor.thumbUrl.ParseElement(&thumb);
+    }
+    tag.m_cast.push_back(actor);
+  }
+
+  tag.SetSet(FromString(item, "video.set_name"));
+  tag.SetSetOverview(FromString(item, "video.set_overview"));
+  tag.SetTags(FromArray(item, "video.tags", 1));
+  tag.SetStudio(FromArray(item, "video.studio", 1));
+  tag.SetArtist(FromArray(item, "video.artist", 1));
+  tag.m_strEpisodeGuide = "<episodeguide>"+FromString(item, "video.episode_guide_url")+"</episodeguide>";
+  int nFanart = item.GetProperty("video.fanarts").asInteger();
+  tag.m_fanart.m_xml = ParseFanart(item, nFanart, "video.fanart");
+  tag.m_fanart.Unpack();
+  tag.m_firstAired.SetFromDBDate(FromString(item, "video.date_added"));
+}
+
+template<class T>
+static bool PythonDetails(const std::string& ID,
+                          const std::string& key,
+                          const std::string& url,
+                          const std::string& action,
+                          T& result)
+{
+  std::stringstream str;
+  str << "plugin://" << ID << "?action=" << action
+      << "&" << key << "=" << CURL::Encode(url);
+
+  CFileItem item(url, false);
+
+  if (!XFILE::CPluginDirectory::GetPluginResult(str.str(), item))
+    return false;
+
+  DetailsFromFileItem(item, result);
+  return true;
+}
+
+
 // fetch list of matching movies sorted by relevance (may be empty);
 // throws CScraperError on error; first called with fFirst set, then unset if first try fails
-std::vector<CScraperUrl> CScraper::FindMovie(XFILE::CCurlFile &fcurl, const std::string &sMovie,
-  bool fFirst)
+std::vector<CScraperUrl> CScraper::FindMovie(XFILE::CCurlFile &fcurl,
+                                             const std::string &sMovie,
+                                             bool fFirst)
 {
   // prepare parameters for URL creation
   std::string sTitle, sTitleYear, sYear;
@@ -576,6 +904,14 @@ std::vector<CScraperUrl> CScraper::FindMovie(XFILE::CCurlFile &fcurl, const std:
 
   if (!fFirst)
     StringUtils::Replace(sTitle, '-',' ');
+
+  if (m_isPython)
+  {
+    std::map<std::string, std::string> additionals{{"title", sTitle}};
+    if (!sYear.empty())
+      additionals.insert({"year", sYear});
+    return PythonFind<CScraperUrl>(ID(), additionals);
+  }
 
   std::vector<std::string> vcsIn(1);
   g_charsetConverter.utf8To(SearchStringEncoding(), sTitle, vcsIn[0]);
@@ -688,8 +1024,9 @@ std::vector<CScraperUrl> CScraper::FindMovie(XFILE::CCurlFile &fcurl, const std:
 
 // find album by artist, using fcurl for web fetches
 // returns a list of albums (empty if no match or failure)
-std::vector<CMusicAlbumInfo> CScraper::FindAlbum(CCurlFile &fcurl, const std::string &sAlbum,
-  const std::string &sArtist)
+std::vector<CMusicAlbumInfo> CScraper::FindAlbum(CCurlFile &fcurl,
+                                                 const std::string &sAlbum,
+                                                 const std::string &sArtist)
 {
   CLog::Log(LOGDEBUG, "%s: Searching for '%s - %s' using %s scraper "
     "(path: '%s', content: '%s', version: '%s')", __FUNCTION__, sArtist.c_str(),
@@ -699,6 +1036,10 @@ std::vector<CMusicAlbumInfo> CScraper::FindAlbum(CCurlFile &fcurl, const std::st
   std::vector<CMusicAlbumInfo> vcali;
   if (IsNoop())
     return vcali;
+
+  if (m_isPython)
+    return PythonFind<CMusicAlbumInfo>(ID(), {{"title", sAlbum},
+                                              {"artist", sArtist}});
 
   // scraper function is given the album and artist as parameters and
   // returns an XML <url> element parseable by CScraperUrl
@@ -786,7 +1127,7 @@ std::vector<CMusicAlbumInfo> CScraper::FindAlbum(CCurlFile &fcurl, const std::st
 // find artist, using fcurl for web fetches
 // returns a list of artists (empty if no match or failure)
 std::vector<CMusicArtistInfo> CScraper::FindArtist(CCurlFile &fcurl,
-  const std::string &sArtist)
+                                                   const std::string &sArtist)
 {
   CLog::Log(LOGDEBUG, "%s: Searching for '%s' using %s scraper "
     "(file: '%s', content: '%s', version: '%s')", __FUNCTION__, sArtist.c_str(),
@@ -796,6 +1137,9 @@ std::vector<CMusicArtistInfo> CScraper::FindArtist(CCurlFile &fcurl,
   std::vector<CMusicArtistInfo> vcari;
   if (IsNoop())
     return vcari;
+
+  if (m_isPython)
+    return PythonFind<CMusicArtistInfo>(ID(), {{"artist", sArtist}});
 
   // scraper function is given the artist as parameter and
   // returns an XML <url> element parseable by CScraperUrl
@@ -870,11 +1214,38 @@ EPISODELIST CScraper::GetEpisodeList(XFILE::CCurlFile &fcurl, const CScraperUrl 
   EPISODELIST vcep;
   if (scurl.m_url.empty())
     return vcep;
-  
+
   CLog::Log(LOGDEBUG, "%s: Searching '%s' using %s scraper "
     "(file: '%s', content: '%s', version: '%s')", __FUNCTION__,
     scurl.m_url[0].m_url.c_str(), Name().c_str(), Path().c_str(),
     ADDON::TranslateContent(Content()).c_str(), Version().asString().c_str());
+
+  if (m_isPython)
+  {
+    std::stringstream str;
+    str << "plugin://" << ID() << "?action=getepisodelist&url="
+        << CURL::Encode(scurl.m_url.front().m_url);
+    CFileItemList items;
+    if (!XFILE::CDirectory::GetDirectory(str.str(), items))
+      return vcep;
+
+    for (int i = 0; i < items.Size(); ++i)
+    {
+      EPISODE ep;
+      ep.strTitle = items[i]->GetLabel();
+      ep.iSeason = items[i]->GetProperty("video.season").asInteger();
+      ep.iEpisode = items[i]->GetProperty("video.episode").asInteger();
+      ep.iSubepisode = items[i]->GetProperty("video.sub_episode").asInteger();
+      CScraperUrl::SUrlEntry surl;
+      surl.m_type = CScraperUrl::URL_TYPE_GENERAL;
+      surl.m_url =  FromString(*items[i], "video.url");
+      ep.cScraperUrl.m_url.push_back(surl);
+      ep.cScraperUrl.strId = FromString(*items[i], "video.unique_id");
+      vcep.push_back(ep);
+    }
+
+    return vcep;
+  }
 
   std::vector<std::string> vcsIn;
   vcsIn.push_back(scurl.m_url[0].m_url);
@@ -930,8 +1301,10 @@ EPISODELIST CScraper::GetEpisodeList(XFILE::CCurlFile &fcurl, const CScraperUrl 
 }
 
 // takes URL; returns true and populates video details on success, false otherwise
-bool CScraper::GetVideoDetails(XFILE::CCurlFile &fcurl, const CScraperUrl &scurl,
-  bool fMovie/*else episode*/, CVideoInfoTag &video)
+bool CScraper::GetVideoDetails(XFILE::CCurlFile &fcurl,
+                               const CScraperUrl &scurl,
+                               bool fMovie/*else episode*/,
+                               CVideoInfoTag &video)
 {
   CLog::Log(LOGDEBUG, "%s: Reading %s '%s' using %s scraper "
     "(file: '%s', content: '%s', version: '%s')", __FUNCTION__,
@@ -939,6 +1312,11 @@ bool CScraper::GetVideoDetails(XFILE::CCurlFile &fcurl, const CScraperUrl &scurl
     ADDON::TranslateContent(Content()).c_str(), Version().asString().c_str());
 
   video.Reset();
+
+  if (m_isPython)
+    return PythonDetails(ID(), "url", scurl.m_url.front().m_url,
+                         fMovie ? "getdetails" : "getepisodedetails", video);
+
   std::string sFunc = fMovie ? "GetDetails" : "GetEpisodeDetails";
   std::vector<std::string> vcsIn;
   vcsIn.push_back(scurl.strId);
@@ -978,6 +1356,10 @@ bool CScraper::GetAlbumDetails(CCurlFile &fcurl, const CScraperUrl &scurl, CAlbu
     scurl.m_url[0].m_url.c_str(), Name().c_str(), Path().c_str(),
     ADDON::TranslateContent(Content()).c_str(), Version().asString().c_str());
 
+  if (m_isPython)
+    return PythonDetails(ID(), "url", scurl.m_url.front().m_url,
+                         "getdetails", album);
+
   std::vector<std::string> vcsOut = RunNoThrow("GetAlbumDetails", scurl, fcurl);
 
   // parse the returned XML into an album object (see CAlbum::Load for details)
@@ -1008,6 +1390,10 @@ bool CScraper::GetArtistDetails(CCurlFile &fcurl, const CScraperUrl &scurl,
     "(file: '%s', content: '%s', version: '%s')", __FUNCTION__,
     scurl.m_url[0].m_url.c_str(), sSearch.c_str(), Name().c_str(), Path().c_str(),
     ADDON::TranslateContent(Content()).c_str(), Version().asString().c_str());
+
+  if (m_isPython)
+    return PythonDetails(ID(), "url", scurl.m_url.front().m_url,
+                         "getdetails", artist);
 
   // pass in the original search string for chaining to search other sites
   std::vector<std::string> vcIn;
@@ -1042,6 +1428,9 @@ bool CScraper::GetArtwork(XFILE::CCurlFile &fcurl, CVideoInfoTag &details)
     "(file: '%s', content: '%s', version: '%s')", __FUNCTION__, details.GetUniqueID().c_str(),
     Name().c_str(), Path().c_str(), ADDON::TranslateContent(Content()).c_str(), Version().asString().c_str());
 
+  if (m_isPython)
+    return PythonDetails(ID(), "id", details.GetUniqueID("IMDB"), "getartwork", details);
+
   std::vector<std::string> vcsIn;
   CScraperUrl scurl;
   vcsIn.push_back(details.GetUniqueID());
@@ -1063,4 +1452,3 @@ bool CScraper::GetArtwork(XFILE::CCurlFile &fcurl, CVideoInfoTag &details)
 }
 
 }
-

--- a/xbmc/addons/Scraper.h
+++ b/xbmc/addons/Scraper.h
@@ -177,6 +177,7 @@ private:
                          const std::vector<std::string>* extras);
 
   bool m_fLoaded;
+  bool m_isPython = false;
   bool m_requiressettings;
   CDateTimeSpan m_persistence;
   CONTENT_TYPE m_pathContent;

--- a/xbmc/interfaces/legacy/AddonUtils.h
+++ b/xbmc/interfaces/legacy/AddonUtils.h
@@ -31,6 +31,7 @@
 
 #include "threads/SingleLock.h"
 
+#include <memory>
 #include <vector>
 
 #ifdef TARGET_WINDOWS
@@ -68,6 +69,9 @@ namespace XBMCAddonUtils
   };
 
 #define LOCKGUI XBMCAddonUtils::GuiLock __gl
+#define LOCKGUIIF(cond) std::unique_ptr<XBMCAddonUtils::GuiLock> __gl; \
+                        if (!(cond)) \
+                          __gl.reset(new XBMCAddonUtils::GuiLock)
 
   /*
    * Looks in references.xml for image name

--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -42,7 +42,9 @@ namespace XBMCAddon
                        const String& label2,
                        const String& iconImage,
                        const String& thumbnailImage,
-                       const String& path)
+                       const String& path,
+                       bool offscreen) :
+      m_offscreen(offscreen)
     {
       item.reset();
 
@@ -74,7 +76,7 @@ namespace XBMCAddon
 
       String ret;
       {
-        LOCKGUI;
+        LOCKGUIIF(m_offscreen);
         ret = item->GetLabel();
       }
 
@@ -87,7 +89,7 @@ namespace XBMCAddon
 
       String ret;
       {
-        LOCKGUI;
+        LOCKGUIIF(m_offscreen);
         ret = item->GetLabel2();
       }
 
@@ -99,7 +101,7 @@ namespace XBMCAddon
       if (!item) return;
       // set label
       {
-        LOCKGUI;
+        LOCKGUIIF(m_offscreen);
         item->SetLabel(label);
       }
     }
@@ -109,7 +111,7 @@ namespace XBMCAddon
       if (!item) return;
       // set label
       {
-        LOCKGUI;
+        LOCKGUIIF(m_offscreen);
         item->SetLabel2(label);
       }
     }
@@ -118,7 +120,7 @@ namespace XBMCAddon
     {
       if (!item) return;
       {
-        LOCKGUI;
+        LOCKGUIIF(m_offscreen);
         item->SetIconImage(iconImage);
       }
     }
@@ -127,7 +129,7 @@ namespace XBMCAddon
     {
       if (!item) return;
       {
-        LOCKGUI;
+        LOCKGUIIF(m_offscreen);
         item->SetArt("thumb", thumbFilename);
       }
     }
@@ -136,7 +138,7 @@ namespace XBMCAddon
     {
       if (!item) return;
       {
-        LOCKGUI;
+        LOCKGUIIF(m_offscreen);
         for (Properties::const_iterator it = dictionary.begin(); it != dictionary.end(); ++it)
         {
           std::string artName = it->first;
@@ -171,7 +173,7 @@ namespace XBMCAddon
     {
       if (!item) return;
       {
-        LOCKGUI;
+        LOCKGUIIF(m_offscreen);
         item->Select(selected);
       }
     }
@@ -183,7 +185,7 @@ namespace XBMCAddon
 
       bool ret;
       {
-        LOCKGUI;
+        LOCKGUIIF(m_offscreen);
         ret = item->IsSelected();
       }
 
@@ -192,7 +194,7 @@ namespace XBMCAddon
 
     void ListItem::setProperty(const char * key, const String& value)
     {
-      LOCKGUI;
+      LOCKGUIIF(m_offscreen);
       String lowerKey = key;
       StringUtils::ToLower(lowerKey);
       if (lowerKey == "startoffset")
@@ -231,7 +233,7 @@ namespace XBMCAddon
 
     String ListItem::getProperty(const char* key)
     {
-      LOCKGUI;
+      LOCKGUIIF(m_offscreen);
       String lowerKey = key;
       StringUtils::ToLower(lowerKey);
       std::string value;
@@ -254,7 +256,7 @@ namespace XBMCAddon
 
     String ListItem::getArt(const char* key)
     {
-      LOCKGUI;
+      LOCKGUIIF(m_offscreen);
       return item->GetArt(key);
     }
 
@@ -278,19 +280,19 @@ namespace XBMCAddon
 
     void ListItem::setPath(const String& path)
     {
-      LOCKGUI;
+      LOCKGUIIF(m_offscreen);
       item->SetPath(path);
     }
 
     void ListItem::setMimeType(const String& mimetype)
     {
-      LOCKGUI;
+      LOCKGUIIF(m_offscreen);
       item->SetMimeType(mimetype);
     }
 
     void ListItem::setContentLookup(bool enable)
     {
-      LOCKGUI;
+      LOCKGUIIF(m_offscreen);
       item->SetContentLookup(enable);
     }
 
@@ -330,7 +332,7 @@ namespace XBMCAddon
 
     void ListItem::setInfo(const char* type, const InfoLabelDict& infoLabels)
     {
-      LOCKGUI;
+      LOCKGUIIF(m_offscreen);
 
       if (strcmpi(type, "video") == 0)
       {
@@ -695,7 +697,7 @@ namespace XBMCAddon
 
     void ListItem::addStreamInfo(const char* cType, const Properties& dictionary)
     {
-      LOCKGUI;
+      LOCKGUIIF(m_offscreen);
 
       if (strcmpi(cType, "video") == 0)
       {
@@ -763,7 +765,7 @@ namespace XBMCAddon
         if (tuple.GetNumValuesSet() != 2)
           throw ListItemException("Must pass in a list of tuples of pairs of strings. One entry in the list only has %d elements.",tuple.GetNumValuesSet());
 
-        LOCKGUI;
+        LOCKGUIIF(m_offscreen);
         item->SetProperty(StringUtils::Format("contextmenulabel(%zu)", i), tuple.first());
         item->SetProperty(StringUtils::Format("contextmenuaction(%zu)", i), tuple.second());
       }
@@ -771,7 +773,7 @@ namespace XBMCAddon
 
     void ListItem::setSubtitles(const std::vector<String>& paths)
     {
-      LOCKGUI;
+      LOCKGUIIF(m_offscreen);
       unsigned int i = 1;
       for (std::vector<String>::const_iterator it = paths.begin(); it != paths.end(); ++it, i++)
       {
@@ -782,7 +784,7 @@ namespace XBMCAddon
 
     xbmc::InfoTagVideo* ListItem::getVideoInfoTag()
     {
-      LOCKGUI;
+      LOCKGUIIF(m_offscreen);
       if (item->HasVideoInfoTag())
         return new xbmc::InfoTagVideo(*item->GetVideoInfoTag());
       return new xbmc::InfoTagVideo();
@@ -790,7 +792,7 @@ namespace XBMCAddon
 
     xbmc::InfoTagMusic* ListItem::getMusicInfoTag()
     {
-      LOCKGUI;
+      LOCKGUIIF(m_offscreen);
       if (item->HasMusicInfoTag())
         return new xbmc::InfoTagMusic(*item->GetMusicInfoTag());
       return new xbmc::InfoTagMusic();

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -83,13 +83,15 @@ namespace XBMCAddon
     public:
 #if !defined SWIG && !defined DOXYGEN_SHOULD_SKIP_THIS
       CFileItemPtr item;
+      bool m_offscreen;
 #endif
 
       ListItem(const String& label = emptyString,
                const String& label2 = emptyString,
                const String& iconImage = emptyString,
                const String& thumbnailImage = emptyString,
-               const String& path = emptyString);
+               const String& path = emptyString,
+               bool offscreen = false);
 
 #ifndef SWIG
       inline ListItem(CFileItemPtr pitem) : item(pitem) {}


### PR DESCRIPTION
I saw this mentioned in some other PR so i figured i would re-offer my implementation.

This adds python based scrapers. I have rebased it and slightly modernized it and it appears to still work fine on the surface at least.

Sure, this is far from optimal. But it has one very obvious strength: it works within the limits set by the current system. There are of course a bunch of things that can be done more sane if XML support is removed (batch episode processing comes to mind, and converting to XML so some classes can parse is kinda stupid) . The idea was that this allows a seamless transition. 
