### PR TITLE
[PVR][guiinfo] Fix 'ListItem.EndTime' for PVR recordings.

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -9937,6 +9937,8 @@ std::string CGUIInfoManager::GetItemLabel(const CFileItem *item, int info, std::
       return item->GetEPGInfoTag()->EndAsLocalTime().GetAsLocalizedTime("", false);
     else if (item->HasPVRTimerInfoTag())
       return item->GetPVRTimerInfoTag()->EndAsLocalTime().GetAsLocalizedTime("", false);
+    else if (item->HasPVRRecordingInfoTag())
+      return (item->GetPVRRecordingInfoTag()->RecordingTimeAsLocalTime() + CDateTimeSpan(0, 0, 0, item->GetPVRRecordingInfoTag()->GetDuration())).GetAsLocalizedTime("", false);
     else if (item->HasVideoInfoTag())
     {
       CDateTimeSpan duration(0, 0, 0, item->GetVideoInfoTag()->GetDuration());


### PR DESCRIPTION
Before:

![screenshot001](https://cloud.githubusercontent.com/assets/3226626/16107906/c986458c-339f-11e6-98ea-725f9145e4b5.png)

After:

![screenshot002](https://cloud.githubusercontent.com/assets/3226626/16107909/d8221a9e-339f-11e6-9915-6e7d5b1395a5.png)

@xhaggi @phil65 might taking a look.
