### PR TITLE
[JSON] JSONServiceDescription is not thread safe

### DIFF
--- a/xbmc/interfaces/json-rpc/JSONServiceDescription.cpp
+++ b/xbmc/interfaces/json-rpc/JSONServiceDescription.cpp
@@ -40,6 +40,7 @@
 #include "FavouritesOperations.h"
 #include "TextureOperations.h"
 #include "SettingsOperations.h"
+#include <mutex>
 
 using namespace JSONRPC;
 
@@ -1154,11 +1155,13 @@ void JSONSchemaTypeDefinition::Print(bool isParameter, bool isGlobal, bool print
   }
 }
 
+std::mutex m;
+
 void JSONSchemaTypeDefinition::Set(const JSONSchemaTypeDefinitionPtr typeDefinition)
 {
   if (typeDefinition.get() == NULL)
     return;
-
+  m.lock();
   std::string origName = name;
   std::string origDescription = description;
   bool origOptional = optional;
@@ -1185,6 +1188,7 @@ void JSONSchemaTypeDefinition::Set(const JSONSchemaTypeDefinitionPtr typeDefinit
     referencedType = referencedTypeDef;
 
   referencedTypeSet = true;
+  m.unlock();
 }
 
 JSONSchemaTypeDefinition::CJsonSchemaPropertiesMap::CJsonSchemaPropertiesMap() :


### PR DESCRIPTION
This commit is not for merge as for the moment does not fix anything.
It's a base commit to have someone help me fix the problem as it's a little (totally) out of my competence.

Took me a lot of time to figure out and reproduce the issue but JSONServiceDescription is not thread safe during the build of it's definition cache.

If 2 JSON queries reach Kodi at the same time and tries to initialize the same description like list.fields.all then Kodi will crash.

Crash occurs in CVariant cleanup that tries to cleanup something that is already cleaned up.
So maybe CVariant should be thread safe I don't know, but for this big issue the problem is easy to trigger by JSON.

Since it's a cache initialization problem, crash can only occurs after a fresh start of Kodi then send the following query 2 or more times at the exact same time.

`{"jsonrpc":"2.0","id":1,"method":"Playlist.GetItems","params":{"playlistid":0,"properties":["title","thumbnail","fanart","rating","genre","artist","track","season","episode","year","duration","album","showtitle","playcount","file"]}}`

Happy to fix myself but I have 0 knowledge of C++ threads locks / mutex or whatever it is. So will need some assistance on this.

@Montellese @notspiff as behind the bear hides knowledge ;)
