### PR TITLE
[xbmc][tests][fix] Fix crash during shutdown

### DIFF
--- a/xbmc/filesystem/RarManager.cpp
+++ b/xbmc/filesystem/RarManager.cpp
@@ -49,15 +49,10 @@
 using namespace XFILE;
 
 CFileInfo::CFileInfo()
-{
-  m_strCachedPath.clear();
-  m_bAutoDel = true;
-  m_iUsed = 0;
-  m_iIsSeekable = -1;
-  m_iOffset = 0;
-}
-
-CFileInfo::~CFileInfo()
+  : m_bAutoDel{true}
+  , m_iUsed{0}
+  , m_iOffset{0}
+  , m_iIsSeekable{-1}
 {
 }
 
@@ -210,8 +205,10 @@ bool CRarManager::CacheRarredFile(std::string& strPathInCache, const std::string
   StringUtils::Replace(strPath, '/', '\\');
 #endif
   //g_charsetConverter.unknownToUTF8(strPath);
-  std::string strCachedPath = URIUtils::AddFileToFolder(strDir + "rarfolder%04d",
-                                           URIUtils::GetFileName(strPathInRar));
+  std::string strCachedPath = URIUtils::AddFileToFolder(
+                               URIUtils::AddFileToFolder(
+                                 CSpecialProtocol::TranslatePath(strDir), "rarfolder%04d"),
+                                 URIUtils::GetFileName(strPathInRar));
   strCachedPath = CUtil::GetNextPathname(strCachedPath, 9999);
   if (strCachedPath.empty())
   {

--- a/xbmc/filesystem/RarManager.h
+++ b/xbmc/filesystem/RarManager.h
@@ -41,7 +41,7 @@ class CFileItemList;
 class CFileInfo{
 public:
   CFileInfo();
-  ~CFileInfo();
+  ~CFileInfo() = default;
   std::string m_strCachedPath;
   std::string m_strPathInRar;
   bool  m_bAutoDel;


### PR DESCRIPTION
Translate the cached path when saving the path instead of during ClearCache. This should prevent tests crashing due to invalid teardown order of our static/globals
