### PR TITLE
Use year in label2 when sorting by year

### DIFF
--- a/xbmc/utils/LabelFormatter.cpp
+++ b/xbmc/utils/LabelFormatter.cpp
@@ -209,8 +209,8 @@ std::string CLabelFormatter::GetMaskContent(const CMaskString &mask, const CFile
     {
       if (movie->m_firstAired.IsValid())
         value = movie->m_firstAired.GetAsLocalizedDate();
-      else if (movie->HasPremiered())
-        value = movie->GetPremiered().GetAsLocalizedDate();
+      else if (movie->HasYear())
+        value = StringUtils::Format("%i", movie->GetYear());
     }
     break;
   case 'F': // filename


### PR DESCRIPTION
Since there's not always a  valid premiered date (at least for now) it's better to use year for label2 when sorting to get a nicer result. skinners can always use premiered field if they want to
