### PR TITLE
[CHG] Settings - Library: groupings

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -6544,7 +6544,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#13414"
-msgid "Include artists who appear only on compilations"
+msgid "Show song and album artists"
 msgstr ""
 
 #: system/settings/settings.xml
@@ -17183,10 +17183,10 @@ msgctxt "#36254"
 msgid "Action to perform when pressing the record button. [Record current show] will record the current show from \"now\" to the end of the show. If no TV guide data is currently available a fixed length recording starting \"now\", with the value set for \"Instant recording duration\" will be scheduled. [Record for a fixed period of time] will schedule a fixed length recording starting \"now\", with the value set for \"Instant recording duration\". [Ask what to do] will open a dialogue containing different recording actions to choose from, like \"Record current show\", \"Record next show\" and some fixed duration recordings."
 msgstr ""
 
-#. Description of setting with label #13414 "Include artists who appear only on compilations"
+#. Description of setting with label #13414 "Show song and album artists"
 #: system/settings/settings.xml
 msgctxt "#36255"
-msgid "Determine if artists that appear only on compilations are shown in the library artist view."
+msgid "When enabled, both song and album artists are shown. When disabled, only album artists are shown and artists that appear only on individual songs from an album are excluded."
 msgstr ""
 
 #. Description of setting with label #20192 "Fetch additional information during updates"

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -848,18 +848,20 @@
   </section>
   <section id="library" label="14202" help="38101">
     <category id="filelists" label="16000" help="36121">
-      <group id="1" label="14240">
+      <group id="1" label="593">
         <setting id="filelists.showparentdiritems" type="boolean" label="13306" help="36122">
           <level>1</level>
           <default>true</default>
           <control type="toggle" />
         </setting>
-        <setting id="filelists.showextensions" type="boolean" label="497" help="36123">
+        <setting id="filelists.ignorethewhensorting" type="boolean" label="13399" help="36124">
           <level>1</level>
           <default>true</default>
           <control type="toggle" />
-        </setting>
-        <setting id="filelists.ignorethewhensorting" type="boolean" label="13399" help="36124">
+        </setting>		
+      </group>
+      <group id="2" label="744">
+        <setting id="filelists.showextensions" type="boolean" label="497" help="36123">
           <level>1</level>
           <default>true</default>
           <control type="toggle" />
@@ -877,6 +879,11 @@
           </dependencies>
           <control type="toggle" />
         </setting>
+        <setting id="filelists.showhidden" type="boolean" label="21330" help="36127">
+          <level>2</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
         <setting id="filelists.allowfiledeletion" type="boolean" label="14071" help="36125">
           <level>2</level>
           <default>false</default>
@@ -890,15 +897,10 @@
           </dependencies>
           <control type="toggle" />
         </setting>
-        <setting id="filelists.showhidden" type="boolean" label="21330" help="36127">
-          <level>2</level>
-          <default>false</default>
-          <control type="toggle" />
-        </setting>
       </group>
     </category>
     <category id="video" label="14215" help="38107">
-	  <group id="1" label="14230">
+	  <group id="1" label="593">
         <setting id="myvideos.selectaction" type="integer" label="22079" help="36177">
           <level>0</level>
           <default>1</default> <!-- SELECT_ACTION_PLAY_OR_RESUME -->
@@ -911,6 +913,67 @@
             </options>
           </constraints>
           <control type="list" format="string" />
+        </setting>
+        <setting id="myvideos.extractflags" type="boolean" label="20433" help="36178">
+          <level>2</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+        <setting id="myvideos.extractthumb" type="boolean" label="20433" help="36180">
+          <level>4</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+        <setting id="myvideos.extractchapterthumbs" type="boolean" label="37044" help="37045">
+          <level>2</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+      </group>		
+	  <group id="2" label="744">
+        <setting id="myvideos.stackvideos" type="boolean" label="20435" help="36182">
+          <level>1</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
+        <setting id="myvideos.replacelabels" type="boolean" label="20419" help="36179">
+          <level>1</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+      </group>	
+      <group id="3" label="14022">
+        <setting id="videolibrary.showallitems" type="boolean" label="38011" help="38012">
+          <level>2</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+        <setting id="videolibrary.showunwatchedplots" type="boolean" label="20369" help="36141">
+          <level>0</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+        <setting id="myvideos.flatten" type="boolean" label="20456" help="36183">
+          <level>2</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
+        <setting id="videolibrary.flattentvshows" type="integer" label="20412" help="36144">
+          <level>2</level>
+          <default>1</default> <!-- if only one season -->
+          <constraints>
+            <options>
+              <option label="20420">0</option> <!-- never -->
+              <option label="20421">1</option> <!-- if only one season -->
+              <option label="20422">2</option> <!-- always -->
+            </options>
+          </constraints>
+          <control type="list" format="string" />
+        </setting>
+        <setting id="videolibrary.showemptytvshows" type="boolean" label="20471" help="36163">
+          <level>2</level>
+          <default>false</default>
+          <control type="toggle" />
         </setting>
         <setting id="videolibrary.tvshowsselectfirstunwatcheditem" type="integer" label="21416" help="21466">
           <level>2</level>
@@ -940,28 +1003,6 @@
           </dependencies>
           <control type="spinner" format="string" />
         </setting>
-      </group>		
-      <group id="2" label="14240">
-        <setting id="videolibrary.showallitems" type="boolean" label="38011" help="38012">
-          <level>2</level>
-          <default>true</default>
-          <control type="toggle" />
-        </setting>
-        <setting id="videolibrary.showemptytvshows" type="boolean" label="20471" help="36163">
-          <level>2</level>
-          <default>false</default>
-          <control type="toggle" />
-        </setting>
-        <setting id="myvideos.stackvideos" type="boolean" label="20435" help="36182">
-          <level>1</level>
-          <default>false</default>
-          <control type="toggle" />
-        </setting>
-        <setting id="myvideos.replacelabels" type="boolean" label="20419" help="36179">
-          <level>1</level>
-          <default>true</default>
-          <control type="toggle" />
-        </setting>
         <setting id="videolibrary.groupmoviesets" type="boolean" label="20458" help="36145">
           <level>1</level>
           <default>false</default>
@@ -972,45 +1013,6 @@
           <default>false</default>
           <control type="toggle" />
         </setting>
-        <setting id="myvideos.flatten" type="boolean" label="20456" help="36183">
-          <level>2</level>
-          <default>false</default>
-          <control type="toggle" />
-        </setting>
-        <setting id="videolibrary.flattentvshows" type="integer" label="20412" help="36144">
-          <level>2</level>
-          <default>1</default> <!-- if only one season -->
-          <constraints>
-            <options>
-              <option label="20420">0</option> <!-- never -->
-              <option label="20421">1</option> <!-- if only one season -->
-              <option label="20422">2</option> <!-- always -->
-            </options>
-          </constraints>
-          <control type="list" format="string" />
-        </setting>
-      </group>	
-      <group id="3" label="14241">
-        <setting id="videolibrary.showunwatchedplots" type="boolean" label="20369" help="36141">
-          <level>0</level>
-          <default>true</default>
-          <control type="toggle" />
-        </setting>
-        <setting id="myvideos.extractflags" type="boolean" label="20433" help="36178">
-          <level>2</level>
-          <default>true</default>
-          <control type="toggle" />
-        </setting>
-        <setting id="myvideos.extractthumb" type="boolean" label="20433" help="36180">
-          <level>4</level>
-          <default>true</default>
-          <control type="toggle" />
-        </setting>
-        <setting id="myvideos.extractchapterthumbs" type="boolean" label="37044" help="37045">
-          <level>2</level>
-          <default>true</default>
-          <control type="toggle" />
-        </setting>
         <setting id="videolibrary.actorthumbs" type="boolean" label="20402" help="36143">
           <level>2</level>
           <default>true</default>
@@ -1019,17 +1021,7 @@
       </group>
     </category>	
     <category id="music" label="14216" help="38108">
-	  <group id="1" label="14240">
-        <setting id="musiclibrary.showallitems" type="boolean" label="38011" help="38012">
-          <level>2</level>
-          <default>true</default>
-          <control type="toggle" />
-        </setting>
-        <setting id="musiclibrary.showcompilationartists" type="boolean" label="13414" help="36255">
-          <level>0</level>
-          <default>true</default>
-          <control type="toggle" />
-        </setting>
+      <group id="1" label="593">
         <setting id="musicfiles.trackformat" type="string" label="13307" help="36275">
           <level>3</level>
           <default>[%N. ]%A - %T</default>
@@ -1057,21 +1049,33 @@
             <heading>16016</heading>
           </control>
         </setting>
-      </group>
-      <group id="2" label="14241">
+        <setting id="musicfiles.findremotethumbs" type="boolean" label="14059" help="36281">
+          <level>2</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+      </group>  
+      <group id="2" label="744">
         <setting id="musicfiles.usetags" type="boolean" label="258" help="36274">
           <level>1</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>	  
+      </group>
+      <group id="3" label="14022">
+        <setting id="musiclibrary.showallitems" type="boolean" label="38011" help="38012">
+          <level>2</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+        <setting id="musiclibrary.showcompilationartists" type="boolean" label="13414" help="36255">
+          <level>0</level>
           <default>true</default>
           <control type="toggle" />
         </setting>
         <setting id="musiclibrary.overridetags" type="boolean" label="20220" help="20221">
           <level>1</level>
           <default>false</default>
-          <control type="toggle" />
-        </setting>
-        <setting id="musicfiles.findremotethumbs" type="boolean" label="14059" help="36281">
-          <level>2</level>
-          <default>true</default>
           <control type="toggle" />
         </setting>
         <setting id="musiclibrary.downloadinfo" type="boolean" label="20192" help="36256">
@@ -1121,7 +1125,7 @@
       </group>
     </category>
     <category id="pictures" label="14217" help="38109">
-      <group id="1" label="14241">
+      <group id="1" label="744">
         <setting id="pictures.generatethumbs" type="boolean" label="13360" help="36307">
           <level>0</level>
           <default>true</default>
@@ -2977,10 +2981,10 @@
       </group>
       <group id="3" label="14275">		
       <requirement>
-        <or>
+          <or>
           <condition>HAS_EVENT_SERVER</condition>
           <condition>HAS_JSONRPC</condition>
-        </or>
+          </or>
       </requirement>
         <setting id="services.esenabled" type="boolean" label="14276" help="36334">
           <level>1</level>


### PR DESCRIPTION
Change the labelling of groupings within the Settings - Library sections and adjust the allocated settings in each group to suit the new labels.

Follow up to https://github.com/xbmc/xbmc/pull/9208

This is the 1st of 3 follow up PR's I want to make, the next 2 rely on this.
