### PR TITLE
[addons] - fix folderpath in case only one repo is available

### DIFF
--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -348,6 +348,7 @@ static bool Browse(const CURL& path, CFileItemList &items)
   const std::string repo = path.GetHostName();
 
   VECADDONS addons;
+  items.SetPath(path.Get());
   if (repo == "all")
   {
     CAddonDatabase database;


### PR DESCRIPTION
Folderpath seems to be wrong atm when only one repo is installed.
@tamland is this the correct place to fix it or should it be done inside Browse()?
