### PR TITLE
[aml] Make CEGLNativeTypeAmlogic compatible with Amlogic S905 SoC

### DIFF
--- a/xbmc/windowing/egl/EGLNativeTypeAmlogic.cpp
+++ b/xbmc/windowing/egl/EGLNativeTypeAmlogic.cpp
@@ -55,8 +55,7 @@ bool CEGLNativeTypeAmlogic::CheckCompatibility()
   std::string modalias = "/sys/class/graphics/" + m_framebuffer_name + "/device/modalias";
 
   SysfsUtils::GetString(modalias, name);
-  StringUtils::Trim(name);
-  if (name == "platform:mesonfb")
+  if (name.find("meson") != std::string::npos)
     return true;
   return false;
 }


### PR DESCRIPTION
Make CEGLNativeTypeAmlogic compatible with Amlogic S905 SoC running kernel 3.14.
