### PR TITLE
[fileutils] allow remote access for addons://

### DIFF
--- a/xbmc/utils/FileUtils.cpp
+++ b/xbmc/utils/FileUtils.cpp
@@ -140,7 +140,7 @@ bool CFileUtils::RemoteAccessAllowed(const std::string &strPath)
     return true;
   else if (StringUtils::StartsWithNoCase(realPath, "special://profile/addon_data"))
     return true;
-  else if (StringUtils::StartsWithNoCase(realPath, "addons://sources"))
+  else if (StringUtils::StartsWithNoCase(realPath, "addons://"))
     return true;
   else if (StringUtils::StartsWithNoCase(realPath, "upnp://"))
     return true;


### PR DESCRIPTION
This would allow some new nice script features like "addons by same author".
Not sure if this is considered insecure because of addons://install/ ? @Montellese might know. :)
