### PR TITLE
[xbmc][fix] Fix dll hooking for VS 2015 update 3 as there's some changes incoming

### DIFF
--- a/xbmc/win32/Win32DelayedDllLoad.cpp
+++ b/xbmc/win32/Win32DelayedDllLoad.cpp
@@ -18,6 +18,13 @@
  *
  */
 
+/**
+* @todo this is to disable a change coming in update 3
+* We should get rid of this and switch the hooks to const
+* once update 3 is rtm and we know our developers have
+* updated
+*/
+#define DELAYIMP_INSECURE_WRITABLE_HOOKS 1
 #include <DelayImp.h>
 #include "Application.h"
 #include "utils/StringUtils.h"
@@ -70,5 +77,11 @@ FARPROC WINAPI delayHookFailureFunc (unsigned dliNotify, PDelayLoadInfo pdli)
 }
 
 // assign hook functions
-//PfnDliHook __pfnDliNotifyHook2 = delayHookNotifyFunc;
-//PfnDliHook __pfnDliFailureHook2 = delayHookFailureFunc;
+#if !defined(DELAYIMP_INSECURE_WRITABLE_HOOKS)
+const
+#endif
+PfnDliHook __pfnDliNotifyHook2 = delayHookNotifyFunc;
+#if !defined(DELAYIMP_INSECURE_WRITABLE_HOOKS)
+const
+#endif
+PfnDliHook __pfnDliFailureHook2 = delayHookFailureFunc;


### PR DESCRIPTION
From the header file
Prior to Visual Studio 2015 Update 3, these hooks were non-const.  They were
made const to improve security (global, writable function pointers are bad).
If for backwards compatibility you require the hooks to be writable, define
the macro DELAYIMP_INSECURE_WRITABLE_HOOKS prior to including this header and
provide your own non-const definition of the hooks.
