### PR TITLE
added: FFmpeg-supplied RTMP support

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -600,6 +600,8 @@ bool CApplication::Create()
   av_register_all();
   // register avfilter
   avfilter_register_all();
+  // initialize network protocols
+  avformat_network_init();
   // set avutil callback
   av_log_set_callback(ff_avutil_log);
 

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
@@ -133,7 +133,7 @@ protected:
   bool IsVideoReady();
   void ResetVideoStreams();
 
-  AVDictionary *GetFFMpegOptionsFromInput();
+  AVDictionary *GetFFMpegOptionsFromURL(CURL &url);
   double ConvertTimestamp(int64_t pts, int den, int num);
   void UpdateCurrentPTS();
   bool IsProgramChange();

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp
@@ -131,6 +131,12 @@ CDVDInputStream* CDVDFactoryInputStream::CreateInputStream(IVideoPlayer* pPlayer
   else if(file.substr(0, 8) == "stack://")
     return new CDVDInputStreamStack(fileitem);
 #endif
+  else if(file.substr(0, 7) == "rtmp://"
+       || file.substr(0, 8) == "rtmpt://"
+       || file.substr(0, 8) == "rtmpe://"
+       || file.substr(0, 9) == "rtmpte://"
+       || file.substr(0, 8) == "rtmps://")
+    return new CDVDInputStreamFFmpeg(fileitem);
   else if (fileitem.IsInternetStream())
   {
     if (fileitem.IsType(".m3u8"))

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFFmpeg.h
@@ -39,6 +39,8 @@ public:
   virtual void  Abort() { m_aborted = true;  }
   bool Aborted() { return m_aborted;  }
 
+  const CFileItem& GetItem() const { return m_item; }
+
   bool CanSeek() { return m_can_seek; }
   bool CanPause() { return m_can_pause; }
 


### PR DESCRIPTION
This enables FFmpeg supplied RTMP.

It is not as capable as librtmp, but does fine in no-crypto situations. The add-on overrides.
