### PR TITLE
[android/packaging] Sync rtmp removal

### DIFF
--- a/tools/android/packaging/Makefile.in
+++ b/tools/android/packaging/Makefile.in
@@ -1,7 +1,6 @@
 include ../../depends/Makefile.include
 
 OBJS = libcurl.so \
-  librtmp.so \
   libplist.so libshairplay.so \
   libnfs.so libass.so \
   libbluray.so libsmbclient.so


### PR DESCRIPTION
RTMP got removed in https://github.com/xbmc/xbmc/pull/9946.

This somehow broke the packaging with CMake even though it uses the same file as the autotools build.
CMake build of current master: http://jenkins.kodi.tv/job/Android-ARM/8496/
CMake build with this change: http://jenkins.kodi.tv/job/Android-ARM/8503/
