### PR TITLE
Quell some warnings

### DIFF
--- a/xbmc/utils/CryptThreading.cpp
+++ b/xbmc/utils/CryptThreading.cpp
@@ -29,7 +29,9 @@
 #if (defined HAVE_CONFIG_H) && (!defined TARGET_WINDOWS)
   #include "config.h"
 #else
+#ifndef HAVE_OPENSSL
 #define HAVE_OPENSSL
+#endif
 #endif
 
 #ifdef HAVE_OPENSSL


### PR DESCRIPTION
- redefinition of HAVE_OPENSSL with cmake builds (comes from command line not config.h)
- avoid deprecated symbol usage in mhd with newer versions

@Montellese for the last one i guess.
