### PR TITLE
[PVR] Fix epg tag <-> timer tag association handling.

### DIFF
--- a/xbmc/epg/EpgInfoTag.cpp
+++ b/xbmc/epg/EpgInfoTag.cpp
@@ -134,8 +134,6 @@ CEpgInfoTag::CEpgInfoTag(const EPG_TAG &data) :
 
 CEpgInfoTag::~CEpgInfoTag()
 {
-  ClearTimer();
-  ClearRecording();
 }
 
 bool CEpgInfoTag::operator ==(const CEpgInfoTag& right) const

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -46,29 +46,28 @@ using KODI::MESSAGING::HELPERS::DialogResponse;
 CPVRTimerInfoTag::CPVRTimerInfoTag(bool bRadio /* = false */) :
   m_strTitle(g_localizeStrings.Get(19056)), // New Timer
   m_bFullTextEpgSearch(false),
+  m_state(PVR_TIMER_STATE_SCHEDULED),
+  m_iClientId(g_PVRClients->GetFirstConnectedClientID()),
+  m_iClientIndex(PVR_TIMER_NO_CLIENT_INDEX),
+  m_iParentClientIndex(PVR_TIMER_NO_PARENT),
+  m_iClientChannelUid(PVR_CHANNEL_INVALID_UID),
+  m_bStartAnyTime(false),
+  m_bEndAnyTime(false),
+  m_iPriority(CSettings::GetInstance().GetInt(CSettings::SETTING_PVRRECORD_DEFAULTPRIORITY)),
+  m_iLifetime(CSettings::GetInstance().GetInt(CSettings::SETTING_PVRRECORD_DEFAULTLIFETIME)),
+  m_iMaxRecordings(0),
+  m_iPreventDupEpisodes(CSettings::GetInstance().GetInt(CSettings::SETTING_PVRRECORD_PREVENTDUPLICATEEPISODES)),
+  m_iRecordingGroup(0),
+  m_iChannelNumber(0),
+  m_bIsRadio(bRadio),
+  m_iTimerId(0),
+  m_iMarginStart(CSettings::GetInstance().GetInt(CSettings::SETTING_PVRRECORD_MARGINSTART)),
+  m_iMarginEnd(CSettings::GetInstance().GetInt(CSettings::SETTING_PVRRECORD_MARGINEND)),
+  m_StartTime(CDateTime::GetUTCDateTime()),
+  m_StopTime(m_StartTime),
   m_iEpgUid(EPG_TAG_INVALID_UID)
 {
-  m_iClientId           = g_PVRClients->GetFirstConnectedClientID();
-  m_iClientIndex        = PVR_TIMER_NO_CLIENT_INDEX;
-  m_iParentClientIndex  = PVR_TIMER_NO_PARENT;
-  m_iClientChannelUid   = PVR_CHANNEL_INVALID_UID;
-  m_iPriority           = CSettings::GetInstance().GetInt(CSettings::SETTING_PVRRECORD_DEFAULTPRIORITY);
-  m_iLifetime           = CSettings::GetInstance().GetInt(CSettings::SETTING_PVRRECORD_DEFAULTLIFETIME);
-  m_iMaxRecordings      = 0;
-  m_iPreventDupEpisodes = CSettings::GetInstance().GetInt(CSettings::SETTING_PVRRECORD_PREVENTDUPLICATEEPISODES);
-  m_iRecordingGroup     = 0;
-  m_iChannelNumber      = 0;
-  m_bIsRadio            = bRadio;
-  m_iMarginStart        = CSettings::GetInstance().GetInt(CSettings::SETTING_PVRRECORD_MARGINSTART);
-  m_iMarginEnd          = CSettings::GetInstance().GetInt(CSettings::SETTING_PVRRECORD_MARGINEND);
-  m_StartTime           = CDateTime::GetUTCDateTime();
-  m_StopTime            = m_StartTime;
-  m_bStartAnyTime       = false;
-  m_bEndAnyTime         = false;
-  m_state               = PVR_TIMER_STATE_SCHEDULED;
   m_FirstDay.SetValid(false);
-  m_iTimerId            = 0;
-  ResetChildState();
 
   if (g_PVRClients->SupportsTimers(m_iClientId))
   {
@@ -90,6 +89,7 @@ CPVRTimerInfoTag::CPVRTimerInfoTag(bool bRadio /* = false */) :
 
   m_iWeekdays = (m_timerType && m_timerType->IsRepeating()) ? PVR_WEEKDAY_ALLDAYS : PVR_WEEKDAY_NONE;
 
+  ResetChildState();
   UpdateSummary();
   UpdateEpgInfoTag();
 }
@@ -99,36 +99,33 @@ CPVRTimerInfoTag::CPVRTimerInfoTag(const PVR_TIMER &timer, const CPVRChannelPtr 
   m_strEpgSearchString(timer.strEpgSearchString),
   m_bFullTextEpgSearch(timer.bFullTextEpgSearch),
   m_strDirectory(timer.strDirectory),
+  m_state(timer.state),
+  m_iClientId(iClientId),
+  m_iClientIndex(timer.iClientIndex),
+  m_iParentClientIndex(timer.iParentClientIndex),
+  m_iClientChannelUid(channel ? channel->UniqueID() : (timer.iClientChannelUid > 0) ? timer.iClientChannelUid : PVR_CHANNEL_INVALID_UID),
+  m_bStartAnyTime(timer.bStartAnyTime),
+  m_bEndAnyTime(timer.bEndAnyTime),
+  m_iPriority(timer.iPriority),
+  m_iLifetime(timer.iLifetime),
+  m_iMaxRecordings(timer.iMaxRecordings),
+  m_iWeekdays(timer.iWeekdays),
+  m_iPreventDupEpisodes(timer.iPreventDuplicateEpisodes),
+  m_iRecordingGroup(timer.iRecordingGroup),
+  m_strFileNameAndPath(StringUtils::Format("pvr://client%i/timers/%i", m_iClientId, m_iClientIndex)),
+  m_iChannelNumber(channel ? g_PVRChannelGroups->GetGroupAll(channel->IsRadio())->GetChannelNumber(channel) : 0),
+  m_bIsRadio(channel && channel->IsRadio()),
+  m_iTimerId(0),
+  m_channel(channel),
+  m_iMarginStart(timer.iMarginStart),
+  m_iMarginEnd(timer.iMarginEnd),
+  m_StartTime(timer.startTime + g_advancedSettings.m_iPVRTimeCorrection),
+  m_StopTime(timer.endTime + g_advancedSettings.m_iPVRTimeCorrection),
+  m_FirstDay(timer.firstDay + g_advancedSettings.m_iPVRTimeCorrection),
   m_iEpgUid(timer.iEpgUid)
 {
-  m_iClientId           = iClientId;
-  m_iClientIndex        = timer.iClientIndex;
-
   if (m_iClientIndex == PVR_TIMER_NO_CLIENT_INDEX)
     CLog::Log(LOGERROR, "%s: invalid client index supplied by client %d (must be > 0)!", __FUNCTION__, m_iClientId);
-
-  m_iParentClientIndex  = timer.iParentClientIndex;
-  m_iClientChannelUid   = channel ? channel->UniqueID() : (timer.iClientChannelUid > 0) ? timer.iClientChannelUid : PVR_CHANNEL_INVALID_UID;
-  m_iChannelNumber      = channel ? g_PVRChannelGroups->GetGroupAll(channel->IsRadio())->GetChannelNumber(channel) : 0;
-  m_StartTime           = timer.startTime + g_advancedSettings.m_iPVRTimeCorrection;
-  m_StopTime            = timer.endTime + g_advancedSettings.m_iPVRTimeCorrection;
-  m_bStartAnyTime       = timer.bStartAnyTime;
-  m_bEndAnyTime         = timer.bEndAnyTime;
-  m_iPreventDupEpisodes = timer.iPreventDuplicateEpisodes;
-  m_iRecordingGroup     = timer.iRecordingGroup;
-  m_FirstDay            = timer.firstDay + g_advancedSettings.m_iPVRTimeCorrection;
-  m_iWeekdays           = timer.iWeekdays;
-  m_iPriority           = timer.iPriority;
-  m_iLifetime           = timer.iLifetime;
-  m_iMaxRecordings      = timer.iMaxRecordings;
-  m_iMarginStart        = timer.iMarginStart;
-  m_iMarginEnd          = timer.iMarginEnd;
-  m_channel             = channel;
-  m_bIsRadio            = channel && channel->IsRadio();
-  m_state               = timer.state;
-  m_strFileNameAndPath  = StringUtils::Format("pvr://client%i/timers/%i", m_iClientId, m_iClientIndex);
-  m_iTimerId            = 0;
-  ResetChildState();
 
   if (g_PVRClients->SupportsTimers(m_iClientId))
   {
@@ -173,6 +170,7 @@ CPVRTimerInfoTag::CPVRTimerInfoTag(const PVR_TIMER &timer, const CPVRChannelPtr 
       CLog::Log(LOGERROR, "%s: no epg tag given for epg based timer type (%d)!", __FUNCTION__, m_timerType->GetTypeId());
   }
 
+  ResetChildState();
   UpdateSummary();
   UpdateEpgInfoTag();
 }

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -89,6 +89,9 @@ CPVRTimerInfoTag::CPVRTimerInfoTag(bool bRadio /* = false */) :
   }
 
   m_iWeekdays = (m_timerType && m_timerType->IsRepeating()) ? PVR_WEEKDAY_ALLDAYS : PVR_WEEKDAY_NONE;
+
+  UpdateSummary();
+  UpdateEpgInfoTag();
 }
 
 CPVRTimerInfoTag::CPVRTimerInfoTag(const PVR_TIMER &timer, const CPVRChannelPtr &channel, unsigned int iClientId) :
@@ -219,7 +222,6 @@ bool CPVRTimerInfoTag::operator ==(const CPVRTimerInfoTag& right) const
 
 CPVRTimerInfoTag::~CPVRTimerInfoTag(void)
 {
-  ClearEpgTag();
 }
 
 /**
@@ -978,10 +980,9 @@ CEpgInfoTagPtr CPVRTimerInfoTag::GetEpgInfoTag(bool bCreate /* = true */) const
           {
             // if no epg uid present, try to find a tag according to timer's start/end time
             m_epgTag = epg->GetTagBetween(StartAsUTC() - CDateTimeSpan(0, 0, 2, 0), EndAsUTC() + CDateTimeSpan(0, 0, 2, 0));
+            if (m_epgTag)
+              m_iEpgUid = m_epgTag->UniqueBroadcastID();
           }
-
-          if (m_epgTag)
-            m_epgTag->SetTimer(g_PVRTimers->GetById(m_iTimerId));
         }
       }
     }

--- a/xbmc/pvr/timers/PVRTimerInfoTag.h
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.h
@@ -283,7 +283,6 @@ namespace PVR
     void UpdateEpgInfoTag(void);
 
     CCriticalSection      m_critSection;
-    unsigned int          m_iEpgUid;   /*!< id of epg event associated with this timer, EPG_TAG_INVALID_UID if none. */
     CDateTime             m_StartTime; /*!< start time */
     CDateTime             m_StopTime;  /*!< stop time */
     CDateTime             m_FirstDay;  /*!< if it is a manual repeating timer the first date it starts */
@@ -294,6 +293,7 @@ namespace PVR
     bool                  m_bHasChildRecording;   /*!< @brief Has at least one child timer with status PVR_TIMER_STATE_RECORDING */
     bool                  m_bHasChildErrors;      /*!< @brief Has at least one child timer with status PVR_TIMER_STATE_ERROR */
 
+    mutable unsigned int  m_iEpgUid;   /*!< id of epg event associated with this timer, EPG_TAG_INVALID_UID if none. */
     mutable EPG::CEpgInfoTagPtr m_epgTag; /*!< epg info tag matching m_iEpgUid. */
   };
 }

--- a/xbmc/pvr/timers/PVRTimers.h
+++ b/xbmc/pvr/timers/PVRTimers.h
@@ -210,6 +210,8 @@ namespace PVR
     CPVRTimerInfoTagPtr GetByClient(int iClientId, unsigned int iClientTimerId) const;
     bool GetRootDirectory(const CPVRTimersPath &path, CFileItemList &items) const;
     bool GetSubDirectory(const CPVRTimersPath &path, CFileItemList &items) const;
+    bool SetEpgTagTimer(const CPVRTimerInfoTagPtr &timer);
+    bool ClearEpgTagTimer(const CPVRTimerInfoTagPtr &timer);
 
     CCriticalSection  m_critSection;
     bool              m_bIsUpdating;

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -53,13 +53,17 @@ CGUIWindowPVRGuide::~CGUIWindowPVRGuide(void)
   StopRefreshTimelineItemsThread();
 }
 
+CGUIEPGGridContainer* CGUIWindowPVRGuide::GetGridControl()
+{
+  return dynamic_cast<CGUIEPGGridContainer*>(GetControl(m_viewControl.GetCurrentControl()));
+}
+
 void CGUIWindowPVRGuide::OnInitWindow()
 {
   if (m_guiState.get())
     m_viewControl.SetCurrentView(m_guiState->GetViewAsControl(), false);
 
-  CGUIEPGGridContainer *epgGridContainer =
-    dynamic_cast<CGUIEPGGridContainer*>(GetControl(m_viewControl.GetCurrentControl()));
+  CGUIEPGGridContainer *epgGridContainer = GetGridControl();
   if (epgGridContainer)
   {
     epgGridContainer->SetChannel(GetSelectedItemPath(m_bRadio));
@@ -119,8 +123,7 @@ void CGUIWindowPVRGuide::Notify(const Observable &obs, const ObservableMessage m
 
 void CGUIWindowPVRGuide::SetInvalid()
 {
-  CGUIEPGGridContainer *epgGridContainer =
-    dynamic_cast<CGUIEPGGridContainer*>(GetControl(m_viewControl.GetCurrentControl()));
+  CGUIEPGGridContainer *epgGridContainer = GetGridControl();
   if (epgGridContainer)
     epgGridContainer->SetInvalid();
 
@@ -358,8 +361,7 @@ bool CGUIWindowPVRGuide::OnMessage(CGUIMessage& message)
             case ACTION_PLAY:
             {
               // EPG "gap" selected => switch to associated channel.
-              CGUIEPGGridContainer *epgGridContainer =
-                dynamic_cast<CGUIEPGGridContainer*>(GetControl(m_viewControl.GetCurrentControl()));
+              CGUIEPGGridContainer *epgGridContainer = GetGridControl();
               if (epgGridContainer)
               {
                 CFileItemPtr item(epgGridContainer->GetSelectedChannelItem());
@@ -491,7 +493,7 @@ bool CGUIWindowPVRGuide::RefreshTimelineItems()
   {
     m_bRefreshTimelineItems = false;
 
-    CGUIEPGGridContainer* epgGridContainer = dynamic_cast<CGUIEPGGridContainer*>(GetControl(m_viewControl.GetCurrentControl()));
+    CGUIEPGGridContainer* epgGridContainer = GetGridControl();
     if (epgGridContainer)
     {
       const CPVRChannelGroupPtr group(GetGroup());
@@ -537,7 +539,7 @@ void CGUIWindowPVRGuide::GetViewTimelineItems(CFileItemList &items)
   // group change detected reset grid coordinates and refresh grid items
   if (!m_bRefreshTimelineItems && *m_cachedChannelGroup != *GetGroup())
   {
-    CGUIEPGGridContainer* epgGridContainer = dynamic_cast<CGUIEPGGridContainer*>(GetControl(m_viewControl.GetCurrentControl()));
+    CGUIEPGGridContainer* epgGridContainer = GetGridControl();
     if (!epgGridContainer)
       return;
 

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -117,6 +117,16 @@ void CGUIWindowPVRGuide::Notify(const Observable &obs, const ObservableMessage m
   }
 }
 
+void CGUIWindowPVRGuide::SetInvalid()
+{
+  CGUIEPGGridContainer *epgGridContainer =
+    dynamic_cast<CGUIEPGGridContainer*>(GetControl(m_viewControl.GetCurrentControl()));
+  if (epgGridContainer)
+    epgGridContainer->SetInvalid();
+
+  CGUIWindowPVRBase::SetInvalid();
+}
+
 void CGUIWindowPVRGuide::GetContextButtons(int itemNumber, CContextButtons &buttons)
 {
   if (itemNumber < 0 || itemNumber >= m_vecItems->Size())
@@ -411,7 +421,8 @@ bool CGUIWindowPVRGuide::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
     return false;
   CFileItemPtr pItem = m_vecItems->Get(itemNumber);
 
-  return OnContextButtonPlay(pItem.get(), button) ||
+  bool bReturn
+    = OnContextButtonPlay(pItem.get(), button) ||
       OnContextButtonInfo(pItem.get(), button) ||
       OnContextButtonStartRecord(pItem.get(), button) ||
       OnContextButtonStopRecord(pItem.get(), button) ||
@@ -423,6 +434,11 @@ bool CGUIWindowPVRGuide::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
       OnContextButtonEnd(pItem.get(), button) ||
       OnContextButtonNow(pItem.get(), button) ||
       CGUIWindowPVRBase::OnContextButton(itemNumber, button);
+
+  if (bReturn)
+    SetInvalid();
+
+  return bReturn;
 }
 
 void CGUIWindowPVRGuide::GetViewChannelItems(CFileItemList &items)

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.h
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.h
@@ -26,6 +26,11 @@
 
 class CSetting;
 
+namespace EPG
+{
+  class CGUIEPGGridContainer;
+}
+
 namespace PVR
 {
   class CPVRRefreshTimelineItemsThread;
@@ -56,6 +61,8 @@ namespace PVR
     virtual void UnregisterObservers(void) override;
 
   private:
+    EPG::CGUIEPGGridContainer* GetGridControl();
+
     bool SelectPlayingFile(void);
 
     bool OnContextButtonBegin(CFileItem *item, CONTEXT_BUTTON button);

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.h
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.h
@@ -44,6 +44,7 @@ namespace PVR
     virtual bool OnContextButton(int itemNumber, CONTEXT_BUTTON button) override;
     virtual void UpdateButtons(void) override;
     virtual void Notify(const Observable &obs, const ObservableMessage msg) override;
+    virtual void SetInvalid() override;
 
     bool RefreshTimelineItems();
 


### PR DESCRIPTION
Under certain circumstances, epg tags did not have the right timer tag associated. Visible effect was for example in EPG grid window, context menu for events to record showing "Record" and "Add timer" instead of "Delete Timer" or vica versa.

Second commit is just non-funtional cleanup. Ctors now use initializer list instead of assignment in ctor body, where possible.

@xhaggi mind taking a look.
