### PR TITLE
[upnp] CUPnP::InvokeUpdateObject: fix case when MediaServer does not support UpdateObject() action

### DIFF
--- a/xbmc/network/upnp/UPnP.cpp
+++ b/xbmc/network/upnp/UPnP.cpp
@@ -275,11 +275,11 @@ public:
         NPT_CHECK_LABEL(FindServer(url.GetHostName().c_str(), device),failed);
         NPT_CHECK_LABEL(device->FindServiceById("urn:upnp-org:serviceId:ContentDirectory", cds),failed);
 
-        NPT_CHECK_SEVERE(m_CtrlPoint->CreateAction(
+        NPT_CHECK_LABEL(m_CtrlPoint->CreateAction(
             device,
             "urn:schemas-upnp-org:service:ContentDirectory:1",
             "UpdateObject",
-            action));
+            action), failed);
 
         NPT_CHECK_LABEL(action->SetArgumentValue("ObjectID", url.GetFileName().c_str()), failed);
         NPT_CHECK_LABEL(action->SetArgumentValue("CurrentTagValue", curr_value), failed);


### PR DESCRIPTION
Right now when a user watches a video from a UPnP MediaServer and stops midway we check if it supports updating metadata like the resume point and the playcount. If it is supported we send the updated values to the MediaServer and don't store any of that information locally. If the MediaServer doesn't support it, we want to store the resume point etc. locally but that fails because `NPT_CHECK_SEVERE()` returns `NPT_FAILED` if the action doesn't exist but `NPT_FAILED` has a value of `1` and `CUPnP::InvokeUpdateObject()` returns a boolean so we misinterpret the return value and don't store the resume point etc.

This should fix http://trac.kodi.tv/ticket/16680. I only tested it with Kodi (where everything is sent to the server) and BubbleUPnP where the information is now stored in Kodi's local database as expected.
