### PR TITLE
Keyboard layout: Slovak QWERTZ, QWERTY, ABC

### DIFF
--- a/system/keyboardlayouts/slovak.xml
+++ b/system/keyboardlayouts/slovak.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+Please use English language names instead.
+Default font lacks support for all characters
+-->
+<keyboardlayouts>
+  <layout language="Slovak" layout="QWERTZ">
+    <keyboard>
+      <row>ĺľščťžýáíéó_</row>
+      <row>qwertzuiopúä</row>
+      <row>asdfghjklôďň</row>
+      <row>/yxcvbnmŕ:.-</row>
+    </keyboard>
+    <keyboard modifiers="shift">
+      <row>ĹĽŠČŤŽÝÁÍÉÓ_</row>
+      <row>QWERTZUIOPÚÄ</row>
+      <row>ASDFGHJKLÔĎŇ</row>
+      <row>\YXCVBNMŔ:.-</row>
+    </keyboard>
+    <keyboard modifiers="symbol,shift+symbol">
+      <row>1234567890%</row>
+      <row>+@#$~^&amp;*{}=</row>
+      <row>[]()/"'`;!</row>
+      <row>\|&lt;&gt;,.?:-_</row>
+    </keyboard>
+  </layout>
+  <layout language="Slovak" layout="QWERTY">
+    <keyboard>
+      <row>ĺľščťžýáíéó_</row>
+      <row>qwertyuiopúä</row>
+      <row>asdfghjklôďň</row>
+      <row>/zxcvbnmŕ:.-</row>
+    </keyboard>
+    <keyboard modifiers="shift">
+      <row>ĹĽŠČŤŽÝÁÍÉÓ_</row>
+      <row>QWERTYUIOPÚÄ</row>
+      <row>ASDFGHJKLÔĎŇ</row>
+      <row>\ZXCVBNMŔ:.-</row>
+    </keyboard>
+    <keyboard modifiers="symbol,shift+symbol">
+      <row>1234567890%</row>
+      <row>+@#$~^&amp;*{}=</row>
+      <row>[]()/"'`;!</row>
+      <row>\|&lt;&gt;,.?:-_</row>
+    </keyboard>
+  </layout>
+  <layout language="Slovak" layout="ABC">
+    <keyboard>
+      <row>aáäbcčdďeéfg</row>
+      <row>hiíjklĺľmnňo</row>
+      <row>óôpqrŕsštťuú</row>
+      <row>vwxyýzž:./\@</row>
+    </keyboard>
+    <keyboard modifiers="shift">
+      <row>AÁÄBCČDĎEÉFG</row>
+      <row>HIÍJKLĹĽMNŇO</row>
+      <row>ÓÔPQRŔSŠTŤUÚ</row>
+      <row>VWXYÝZŽ:./\@</row>
+    </keyboard>
+    <keyboard modifiers="symbol,shift+symbol">
+      <row>1234567890%</row>
+      <row>+@#$~^&amp;*{}=</row>
+      <row>[]()/"'`;!</row>
+      <row>\|&lt;&gt;,.?:-_</row>
+    </keyboard>
+  </layout>
+</keyboardlayouts>


### PR DESCRIPTION
Hello,

I've created a keyboard layout file for Slovak language. As a base I used Czech keymap file, because of a great similarity between both languages. Three layout variants were defined: QWERTZ, QWERTY (swapped Y and Z) and ABC, where the characters are ordered alphabetically, including accented characters.

Where it was possible, character in the layout matches placement on physical keyboard.
Other accented characters were used in place of special characters, and also rows are 12 characters long. The reason was that in Slovak we use a lot of accented characters and there should be a way how to write all of them. To avoid creating layout with too much characters in line, I therefore kept most of special characters accessible under shift+symbol.

Preview [QWERTZ]:

| 01 | 02 | 03 | 04 | 05 | 06 | 07 | 08 | 09 | 10 | 11 | 12 |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Ĺ | Ľ | Š | Č | Ť | Ž | Ý | Á | Í | É | Ó | _ |
| Q | W | E | R | T | Z | U | I | O | P | Ú | Ä |
| A | S | D | F | G | H | J | K | L | Ô | Ď | Ň |
| \ | Y | X | C | V | B | N | M | Ŕ | : | . | - |

Preview [QWERTY] - Swapped Y and Z:

| 01 | 02 | 03 | 04 | 05 | 06 | 07 | 08 | 09 | 10 | 11 | 12 |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Ĺ | Ľ | Š | Č | Ť | Ž | Ý | Á | Í | É | Ó | _ |
| Q | W | E | R | T | Y | U | I | O | P | Ú | Ä |
| A | S | D | F | G | H | J | K | L | Ô | Ď | Ň |
| \ | Z | X | C | V | B | N | M | Ŕ | : | . | - |

Preview [ABC]:

| 01 | 02 | 03 | 04 | 05 | 06 | 07 | 08 | 09 | 10 | 11 | 12 |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| A | Á | Ä | B | C | Č | D | Ď | E | É | F | G |
| H | I | Í | J | K | L | Ĺ | Ľ | M | N | Ň | O |
| Ó | Ô | P | Q | R | Ŕ | S | Š | T | Ť | U | Ú |
| V | W | X | Y | Ý | Z | Ž | : | . | / | \ | @ |

Notes:
- Tested with stable Kodi v16.1 "Jarvis" on ArchLinux.
