### PR TITLE
ZeroconfMDNS.cpp: add header to fix compile with gcc 4.9 & uClibc

### DIFF
--- a/xbmc/network/mdns/ZeroconfMDNS.cpp
+++ b/xbmc/network/mdns/ZeroconfMDNS.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "ZeroconfMDNS.h"
+#include <arpa/inet.h>
 
 #include <string>
 #include <sstream>


### PR DESCRIPTION
Without the patch compilation fails with
ZeroconfMDNS.cpp:133:139: error: ‘htons’ was not declared in this scope

Infos about the toolchain used:
gcc version 4.9.3 (Buildroot 2016.05-00002-g5dabb45), uClibc-NG 1.0.15
