### PR TITLE
[PVR] Guide window: Fix timer icon issues. Fixes #16621

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -388,7 +388,7 @@ CPVRChannelGroupPtr CGUIWindowPVRBase::GetGroup(void)
   return m_group;
 }
 
-void CGUIWindowPVRBase::SetGroup(CPVRChannelGroupPtr group)
+void CGUIWindowPVRBase::SetGroup(const CPVRChannelGroupPtr &group)
 {
   CSingleLock lock(m_critSection);
   if (!group)

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -94,6 +94,20 @@ void CGUIWindowPVRBase::ResetObservers(void)
     RegisterObservers();
 }
 
+void CGUIWindowPVRBase::RegisterObservers(void)
+{
+  CSingleLock lock(m_critSection);
+  if (m_group)
+    m_group->RegisterObserver(this);
+};
+
+void CGUIWindowPVRBase::UnregisterObservers(void)
+{
+  CSingleLock lock(m_critSection);
+  if (m_group)
+    m_group->UnregisterObserver(this);
+};
+
 void CGUIWindowPVRBase::Notify(const Observable &obs, const ObservableMessage msg)
 {
   CGUIMessage m(GUI_MSG_REFRESH_LIST, GetID(), 0, msg);

--- a/xbmc/pvr/windows/GUIWindowPVRBase.h
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.h
@@ -97,7 +97,7 @@ namespace PVR
 
     virtual std::string GetDirectoryPath(void) = 0;
     virtual CPVRChannelGroupPtr GetGroup(void);
-    virtual void SetGroup(CPVRChannelGroupPtr group);
+    virtual void SetGroup(const CPVRChannelGroupPtr &group);
 
     virtual bool ActionShowTimerRule(CFileItem *item);
     virtual bool ActionToggleTimer(CFileItem *item);

--- a/xbmc/pvr/windows/GUIWindowPVRBase.h
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.h
@@ -119,8 +119,8 @@ namespace PVR
     bool OnContextButtonEditTimerRule(CFileItem *item, CONTEXT_BUTTON button);
     bool OnContextButtonDeleteTimerRule(CFileItem *item, CONTEXT_BUTTON button);
 
-    virtual void RegisterObservers(void) {};
-    virtual void UnregisterObservers(void) {};
+    virtual void RegisterObservers(void);
+    virtual void UnregisterObservers(void);
 
     static CCriticalSection m_selectedItemPathsLock;
     static std::string m_selectedItemPaths[2];

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -56,17 +56,20 @@ void CGUIWindowPVRChannels::RegisterObservers(void)
 {
   CSingleLock lock(m_critSection);
   g_EpgContainer.RegisterObserver(this);
-  g_PVRTimers->RegisterObserver(this);
+  if (g_PVRTimers)
+    g_PVRTimers->RegisterObserver(this);
   g_infoManager.RegisterObserver(this);
+  CGUIWindowPVRBase::RegisterObservers();
 }
 
 void CGUIWindowPVRChannels::UnregisterObservers(void)
 {
   CSingleLock lock(m_critSection);
-  g_EpgContainer.UnregisterObserver(this);
+  CGUIWindowPVRBase::UnregisterObservers();
+  g_infoManager.UnregisterObserver(this);
   if (g_PVRTimers)
     g_PVRTimers->UnregisterObserver(this);
-  g_infoManager.UnregisterObserver(this);
+  g_EpgContainer.UnregisterObserver(this);
 }
 
 void CGUIWindowPVRChannels::GetContextButtons(int itemNumber, CContextButtons &buttons)

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -98,10 +98,12 @@ void CGUIWindowPVRGuide::StopRefreshTimelineItemsThread()
 void CGUIWindowPVRGuide::RegisterObservers(void)
 {
   g_EpgContainer.RegisterObserver(this);
+  g_PVRTimers->RegisterObserver(this);
 }
 
 void CGUIWindowPVRGuide::UnregisterObservers(void)
 {
+  g_PVRTimers->UnregisterObserver(this);
   g_EpgContainer.UnregisterObserver(this);
 }
 
@@ -403,6 +405,12 @@ bool CGUIWindowPVRGuide::OnMessage(CGUIMessage& message)
           Refresh(true);
           break;
         }
+        case ObservableMessageTimersReset:
+        case ObservableMessageTimers:
+        {
+          SetInvalid();
+          break;
+        }
         case ObservableMessageEpgActiveItem:
         {
           if (m_viewControl.GetCurrentControl() != GUIDE_VIEW_TIMELINE)
@@ -423,8 +431,7 @@ bool CGUIWindowPVRGuide::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
     return false;
   CFileItemPtr pItem = m_vecItems->Get(itemNumber);
 
-  bool bReturn
-    = OnContextButtonPlay(pItem.get(), button) ||
+  return OnContextButtonPlay(pItem.get(), button) ||
       OnContextButtonInfo(pItem.get(), button) ||
       OnContextButtonStartRecord(pItem.get(), button) ||
       OnContextButtonStopRecord(pItem.get(), button) ||
@@ -436,11 +443,6 @@ bool CGUIWindowPVRGuide::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
       OnContextButtonEnd(pItem.get(), button) ||
       OnContextButtonNow(pItem.get(), button) ||
       CGUIWindowPVRBase::OnContextButton(itemNumber, button);
-
-  if (bReturn)
-    SetInvalid();
-
-  return bReturn;
 }
 
 void CGUIWindowPVRGuide::GetViewChannelItems(CFileItemList &items)

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -97,13 +97,19 @@ void CGUIWindowPVRGuide::StopRefreshTimelineItemsThread()
 
 void CGUIWindowPVRGuide::RegisterObservers(void)
 {
+  CSingleLock lock(m_critSection);
   g_EpgContainer.RegisterObserver(this);
-  g_PVRTimers->RegisterObserver(this);
+  if (g_PVRTimers)
+    g_PVRTimers->RegisterObserver(this);
+  CGUIWindowPVRBase::RegisterObservers();
 }
 
 void CGUIWindowPVRGuide::UnregisterObservers(void)
 {
-  g_PVRTimers->UnregisterObserver(this);
+  CSingleLock lock(m_critSection);
+  CGUIWindowPVRBase::UnregisterObservers();
+  if (g_PVRTimers)
+    g_PVRTimers->UnregisterObserver(this);
   g_EpgContainer.UnregisterObserver(this);
 }
 
@@ -112,6 +118,7 @@ void CGUIWindowPVRGuide::Notify(const Observable &obs, const ObservableMessage m
   if (m_viewControl.GetCurrentControl() == GUIDE_VIEW_TIMELINE &&
       (msg == ObservableMessageEpg ||
        msg == ObservableMessageEpgContainer ||
+       msg == ObservableMessageChannelGroupReset ||
        msg == ObservableMessageChannelGroup))
   {
     CSingleLock lock(m_critSection);
@@ -398,6 +405,7 @@ bool CGUIWindowPVRGuide::OnMessage(CGUIMessage& message)
     case GUI_MSG_REFRESH_LIST:
       switch(message.GetParam1())
       {
+        case ObservableMessageChannelGroupReset:
         case ObservableMessageChannelGroup:
         case ObservableMessageEpg:
         case ObservableMessageEpgContainer:

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -52,19 +52,23 @@ CGUIWindowPVRRecordings::CGUIWindowPVRRecordings(bool bRadio) :
 void CGUIWindowPVRRecordings::RegisterObservers(void)
 {
   CSingleLock lock(m_critSection);
-  g_PVRRecordings->RegisterObserver(this);
-  g_PVRTimers->RegisterObserver(this);
+  if (g_PVRRecordings)
+    g_PVRRecordings->RegisterObserver(this);
+  if (g_PVRTimers)
+    g_PVRTimers->RegisterObserver(this);
   g_infoManager.RegisterObserver(this);
+  CGUIWindowPVRBase::RegisterObservers();
 }
 
 void CGUIWindowPVRRecordings::UnregisterObservers(void)
 {
   CSingleLock lock(m_critSection);
-  if (g_PVRRecordings)
-    g_PVRRecordings->UnregisterObserver(this);
+  CGUIWindowPVRBase::UnregisterObservers();
+  g_infoManager.UnregisterObserver(this);
   if (g_PVRTimers)
     g_PVRTimers->UnregisterObserver(this);
-  g_infoManager.UnregisterObserver(this);
+  if (g_PVRRecordings)
+    g_PVRRecordings->UnregisterObserver(this);
 }
 
 void CGUIWindowPVRRecordings::OnWindowLoaded()

--- a/xbmc/pvr/windows/GUIWindowPVRTimersBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRTimersBase.cpp
@@ -48,16 +48,19 @@ CGUIWindowPVRTimersBase::CGUIWindowPVRTimersBase(bool bRadio, int id, const std:
 void CGUIWindowPVRTimersBase::RegisterObservers(void)
 {
   CSingleLock lock(m_critSection);
-  g_PVRTimers->RegisterObserver(this);
+  if (g_PVRTimers)
+    g_PVRTimers->RegisterObserver(this);
   g_infoManager.RegisterObserver(this);
+  CGUIWindowPVRBase::RegisterObservers();
 }
 
 void CGUIWindowPVRTimersBase::UnregisterObservers(void)
 {
   CSingleLock lock(m_critSection);
+  CGUIWindowPVRBase::UnregisterObservers();
+  g_infoManager.UnregisterObserver(this);
   if (g_PVRTimers)
     g_PVRTimers->UnregisterObserver(this);
-  g_infoManager.UnregisterObserver(this);
 }
 
 void CGUIWindowPVRTimersBase::GetContextButtons(int itemNumber, CContextButtons &buttons)


### PR DESCRIPTION
Fixes issues with not appearing/disappearing timer state icons in PVR Guide window, like discussed here: https://github.com/xbmc/xbmc/pull/10024#issuecomment-228530671 ff. 

Fixes http://trac.kodi.tv/ticket/16621

Code changes are strait forward.

Reported to actually fix the problems by @bas-t and @seo 
