### PR TITLE
[addons] Add Window.Property(Addon.ID) to addon settings dialog

### DIFF
--- a/xbmc/addons/GUIDialogAddonSettings.cpp
+++ b/xbmc/addons/GUIDialogAddonSettings.cpp
@@ -676,6 +676,9 @@ void CGUIDialogAddonSettings::CreateControls()
 
   // set our dialog heading
   SET_CONTROL_LABEL(CONTROL_HEADING_LABEL, m_strHeading);
+  
+  // set addon id as window property
+  SetProperty("Addon.ID", m_addon->ID());
 
   CGUIControl* pControl = NULL;
   int controlId = CONTROL_START_SETTING;


### PR DESCRIPTION
Can be used to show the add-on icon for example in that dialog.

@phil65 
