### PR TITLE
FFmpeg deprecate old API methods

### DIFF
--- a/tools/depends/target/ffmpeg/FFMPEG-VERSION
+++ b/tools/depends/target/ffmpeg/FFMPEG-VERSION
@@ -1,5 +1,5 @@
 LIBNAME=ffmpeg
 BASE_URL=https://github.com/xbmc/FFmpeg/archive
-VERSION=release/3.0-xbmc
+VERSION=release/3.1-xbmc
 ARCHIVE=$(LIBNAME)-$(VERSION).tar.gz
 GNUTLS_VER=3.4.9

--- a/xbmc/cdrip/EncoderFFmpeg.cpp
+++ b/xbmc/cdrip/EncoderFFmpeg.cpp
@@ -287,7 +287,8 @@ int CEncoderFFmpeg::Encode(int nNumBytesRead, uint8_t* pbtStream)
 
 bool CEncoderFFmpeg::WriteFrame()
 {
-  int encoded, got_output;
+  int ret = 0;
+  int got_output = 0;
   AVFrame* frame;
 
   av_init_packet(&m_Pkt);
@@ -305,12 +306,18 @@ bool CEncoderFFmpeg::WriteFrame()
   }
   else frame = m_BufferFrame;
 
-  encoded = avcodec_encode_audio2(m_CodecCtx, &m_Pkt, frame, &got_output);
+  ret = avcodec_send_frame(m_CodecCtx, frame);
+
+  if (ret >= 0)
+    ret = avcodec_receive_packet(m_CodecCtx, &m_Pkt);
+
+  if (ret >= 0)
+    got_output = 1;
 
   m_BufferSize = 0;
 
-  if (encoded < 0) {
-    CLog::Log(LOGERROR, "CEncoderFFmpeg::WriteFrame - Error encoding audio: %i", encoded);
+  if (ret < 0) {
+    CLog::Log(LOGERROR, "CEncoderFFmpeg::WriteFrame - Error encoding audio: %i", ret);
     return false;
   }
 

--- a/xbmc/cores/AudioEngine/Encoders/AEEncoderFFmpeg.cpp
+++ b/xbmc/cores/AudioEngine/Encoders/AEEncoderFFmpeg.cpp
@@ -257,7 +257,7 @@ unsigned int CAEEncoderFFmpeg::GetFrames()
 
 int CAEEncoderFFmpeg::Encode(uint8_t *in, int in_size, uint8_t *out, int out_size)
 {
-  int got_output;
+  int got_output = 0;
   AVFrame *frame;
 
   if (!m_CodecCtx)
@@ -284,7 +284,13 @@ int CAEEncoderFFmpeg::Encode(uint8_t *in, int in_size, uint8_t *out, int out_siz
   m_Pkt.data = out;
 
   /* encode it */
-  int ret = avcodec_encode_audio2(m_CodecCtx, &m_Pkt, frame, &got_output);
+  int ret = avcodec_send_frame(m_CodecCtx, frame);
+
+  if (ret >= 0)
+    ret = avcodec_receive_packet(m_CodecCtx, &m_Pkt);
+
+  if (ret >= 0)
+    got_output = 1;
 
   /* free temporary data */
   av_frame_free(&frame);

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -3036,17 +3036,7 @@ IAESound *CActiveAE::MakeSound(const std::string& file)
       else
         sent = -1;
 
-      if (sent != -1)
-      {
-        receive_frame_error = avcodec_receive_frame(dec_ctx, decoded_frame);
-
-        if (receive_frame_error >= 0)
-          got_frame = 1;
-        else if (receive_frame_error != AVERROR(EAGAIN))
-          received = -1;
-      }
-
-      if (sent == -1 || received == -1)
+      if (sent == -1)
       {
         av_frame_free(&decoded_frame);
         avcodec_free_context(&dec_ctx);
@@ -3058,6 +3048,30 @@ IAESound *CActiveAE::MakeSound(const std::string& file)
         }
         delete sound;
         return NULL;
+      }
+
+      if (sent != -1)
+      {
+        receive_frame_error = avcodec_receive_frame(dec_ctx, decoded_frame);
+
+        if (receive_frame_error >= 0)
+          got_frame = 1;
+        else if (receive_frame_error != AVERROR(EAGAIN))
+          received = -1;
+
+        if (received == -1)
+        {
+          av_frame_free(&decoded_frame);
+          avcodec_free_context(&dec_ctx);
+          avformat_close_input(&fmt_ctx);
+          if (io_ctx)
+          {
+            av_freep(&io_ctx->buffer);
+            av_freep(&io_ctx);
+          }
+          delete sound;
+          return NULL;
+        }
       }
       if (got_frame)
       {

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -3020,19 +3020,33 @@ IAESound *CActiveAE::MakeSound(const std::string& file)
 
     // decode until eof
     av_init_packet(&avpkt);
-    int ret = 0;
+    int send_packet_error = -1;
+    int receive_frame_error = -1;
+    int sent = 0;
+    int received = 0;
     while (av_read_frame(fmt_ctx, &avpkt) >= 0)
     {
       int got_frame = 0;
-      ret = avcodec_send_packet(dec_ctx, &avpkt);
+      send_packet_error = avcodec_send_packet(dec_ctx, &avpkt);
 
-      if (ret >= 0)
-        ret = avcodec_receive_frame(dec_ctx, decoded_frame);
+      if (send_packet_error >= 0)
+        sent = avpkt.size;
+      else if(send_packet_error == AVERROR(EAGAIN))
+        sent = 0;
+      else
+        sent = -1;
 
-      if (ret >= 0)
-        got_frame = 1;
+      if (sent != -1)
+      {
+        receive_frame_error = avcodec_receive_frame(dec_ctx, decoded_frame);
 
-      if (ret < 0)
+        if (receive_frame_error >= 0)
+          got_frame = 1;
+        else if (receive_frame_error != AVERROR(EAGAIN))
+          received = -1;
+      }
+
+      if (sent == -1 || received == -1)
       {
         av_frame_free(&decoded_frame);
         avcodec_free_context(&dec_ctx);

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -3021,12 +3021,19 @@ IAESound *CActiveAE::MakeSound(const std::string& file)
 
     // decode until eof
     av_init_packet(&avpkt);
-    int len;
+    int ret = 0;
     while (av_read_frame(fmt_ctx, &avpkt) >= 0)
     {
       int got_frame = 0;
-      len = avcodec_decode_audio4(dec_ctx, decoded_frame, &got_frame, &avpkt);
-      if (len < 0)
+      ret = avcodec_send_packet(dec_ctx, &avpkt);
+
+      if (ret >= 0)
+        ret = avcodec_receive_frame(dec_ctx, decoded_frame);
+
+      if (ret >= 0)
+        got_frame = 1;
+
+      if (ret < 0)
       {
         av_frame_free(&decoded_frame);
         avcodec_free_context(&dec_ctx);

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -2985,11 +2985,10 @@ IAESound *CActiveAE::MakeSound(const std::string& file)
     fmt_ctx->flags |= AVFMT_FLAG_NOPARSE;
     if (avformat_find_stream_info(fmt_ctx, NULL) >= 0)
     {
-      dec_ctx = fmt_ctx->streams[0]->codec;
-      dec = avcodec_find_decoder(dec_ctx->codec_id);
-      config.sample_rate = dec_ctx->sample_rate;
-      config.channels = dec_ctx->channels;
-      config.channel_layout = dec_ctx->channel_layout;
+      dec = avcodec_find_decoder(fmt_ctx->streams[0]->codecpar->codec_id);
+      config.sample_rate = fmt_ctx->streams[0]->codecpar->sample_rate;
+      config.channels = fmt_ctx->streams[0]->codecpar->channels;
+      config.channel_layout = fmt_ctx->streams[0]->codecpar->channel_layout;
     }
   }
   if (dec == NULL)

--- a/xbmc/guilib/FFmpegImage.cpp
+++ b/xbmc/guilib/FFmpegImage.cpp
@@ -149,12 +149,12 @@ CFFmpegImage::~CFFmpegImage()
   if (m_ioctx)
     FreeIOCtx(&m_ioctx);
   if (m_fctx)
-  {
-    for (unsigned int i = 0; i < m_fctx->nb_streams; i++) {
-      avcodec_close(m_fctx->streams[i]->codec);
-    }
-
     avformat_close_input(&m_fctx);
+
+  if (m_ctx)
+  {
+    avcodec_close(m_ctx);
+    avcodec_free_context(&m_ctx);
   }
 
   m_buf.data = nullptr;
@@ -249,9 +249,12 @@ bool CFFmpegImage::Initialize(unsigned char* buffer, unsigned int bufSize)
     return false;
   }
 
-  AVCodecContext* codec_ctx = m_fctx->streams[0]->codec;
-  AVCodec* codec = avcodec_find_decoder(codec_ctx->codec_id);
-  if (avcodec_open2(codec_ctx, codec, NULL) < 0)
+  AVCodec* codec = avcodec_find_decoder(m_fctx->streams[0]->codecpar->codec_id);
+  m_ctx = avcodec_alloc_context3(codec);
+  if (m_ctx)
+    avcodec_parameters_to_context(m_ctx, m_fctx->streams[0]->codecpar);
+
+  if (avcodec_open2(m_ctx, codec, NULL) < 0)
   {
     avformat_close_input(&m_fctx);
     FreeIOCtx(&m_ioctx);
@@ -274,10 +277,10 @@ AVFrame* CFFmpegImage::ExtractFrame()
   int frame_decoded = 0;
   if (av_read_frame(m_fctx, &pkt) == 0)
   {
-    int ret = avcodec_send_packet(m_fctx->streams[0]->codec, &pkt);
+    int ret = avcodec_send_packet(m_ctx, &pkt);
 
     if (ret >= 0)
-      ret = avcodec_receive_frame(m_fctx->streams[0]->codec, frame);
+      ret = avcodec_receive_frame(m_ctx, frame);
 
     if (ret < 0)
       CLog::Log(LOGDEBUG, "Error [%d] while decoding frame: %s\n", ret, strerror(AVERROR(ret)));

--- a/xbmc/guilib/FFmpegImage.h
+++ b/xbmc/guilib/FFmpegImage.h
@@ -61,6 +61,7 @@ struct MemBuffer
 struct AVFrame;
 struct AVIOContext;
 struct AVFormatContext;
+struct AVCodecContext;
 
 class CFFmpegImage : public IImage
 {
@@ -97,6 +98,7 @@ private:
 
   AVIOContext* m_ioctx = nullptr;
   AVFormatContext* m_fctx = nullptr;
+  AVCodecContext* m_ctx = nullptr;
 
   AVFrame* m_pFrame;
   uint8_t* m_outputBuffer;


### PR DESCRIPTION
This is a placeholder, so that no one needs to start from scratch again. DVDVideoCodecFFmpeg and DVDDemuxFFmpeg I left out, cause these need major rework, including the hw decoder to react on EAGAIN.
