### PR TITLE
FFmpeg: Bump to version 3.1

### DIFF
--- a/tools/depends/target/ffmpeg/FFMPEG-VERSION
+++ b/tools/depends/target/ffmpeg/FFMPEG-VERSION
@@ -1,5 +1,5 @@
 LIBNAME=ffmpeg
 BASE_URL=https://github.com/xbmc/FFmpeg/archive
-VERSION=release/3.0-xbmc
+VERSION=3.1.1-Krypton-Alpha3
 ARCHIVE=$(LIBNAME)-$(VERSION).tar.gz
 GNUTLS_VER=3.4.9


### PR DESCRIPTION
This bumps ffmpeg to version 3.1 while keeping the still supported legacy API.
