### PR TITLE
Revert "[addons] Preserve strings which are not string ids in enum lv…

### DIFF
--- a/xbmc/addons/GUIDialogAddonSettings.cpp
+++ b/xbmc/addons/GUIDialogAddonSettings.cpp
@@ -782,18 +782,15 @@ void CGUIDialogAddonSettings::CreateControls()
           int iAdd = i;
           if (entryVec.size() > i)
             iAdd = atoi(entryVec[i].c_str());
-          std::string replace;
-          if (std::all_of(valuesVec[i].begin(), valuesVec[i].end(), ::isdigit))
+          if (!lvalues.empty())
           {
-            replace = g_localizeStrings.GetAddonString(m_addon->ID(), atoi(valuesVec[i].c_str()));
+            std::string replace = g_localizeStrings.GetAddonString(m_addon->ID(),atoi(valuesVec[i].c_str()));
             if (replace.empty())
               replace = g_localizeStrings.Get(atoi(valuesVec[i].c_str()));
-            if (replace.empty())
-              replace = valuesVec[i];
+            ((CGUISpinControlEx *)pControl)->AddLabel(replace, iAdd);
           }
           else
-            replace = valuesVec[i];
-          ((CGUISpinControlEx *)pControl)->AddLabel(replace, iAdd);
+            ((CGUISpinControlEx *)pControl)->AddLabel(valuesVec[i], iAdd);
         }
         if (type == "labelenum")
         { // need to run through all our settings and find the one that matches


### PR DESCRIPTION
reverts #8271 

This reverts commit c2bd593649ed2493e3502ba15e62c62b1bdbe73f.

This breaks a lot of addon using numerical values in enums. This change
should be resubmitted when the issue is fixed

@LS80 please resubmit when fixed
