### PR TITLE
DVDAudioCodecFFmpeg: Do not access private AVFrame fields

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
@@ -218,11 +218,11 @@ int CDVDAudioCodecFFmpeg::GetData(uint8_t** dst)
 {
   if(m_gotFrame)
   {
-    int planes = av_sample_fmt_is_planar(m_pCodecContext->sample_fmt) ? m_pFrame1->channels : 1;
+    int planes = av_sample_fmt_is_planar(m_pCodecContext->sample_fmt) ? av_frame_get_channels(m_pFrame1) : 1;
     for (int i=0; i<planes; i++)
       dst[i] = m_pFrame1->extended_data[i];
     m_gotFrame = 0;
-    return m_pFrame1->nb_samples * m_pFrame1->channels * av_get_bytes_per_sample(m_pCodecContext->sample_fmt);
+    return m_pFrame1->nb_samples * av_frame_get_channels(m_pFrame1) * av_get_bytes_per_sample(m_pCodecContext->sample_fmt);
   }
 
   return 0;

--- a/xbmc/guilib/FFmpegImage.cpp
+++ b/xbmc/guilib/FFmpegImage.cpp
@@ -284,7 +284,7 @@ AVFrame* CFFmpegImage::ExtractFrame()
     {
       m_frames++;
       //we need milliseconds
-      av_frame_set_pkt_duration(frame, av_rescale_q(frame->pkt_duration, m_fctx->streams[0]->time_base, AVRational{ 1, 1000 }));
+      av_frame_set_pkt_duration(frame, av_rescale_q(av_frame_get_pkt_duration(frame), m_fctx->streams[0]->time_base, AVRational{ 1, 1000 }));
       m_height = frame->height;
       m_width = frame->width;
       m_originalWidth = m_width;


### PR DESCRIPTION
We access some fields that we should not access. Keep it open I think I can find some more.
