### PR TITLE
Advancedsettings: Add a setting to disable resolution up switching

### DIFF
--- a/xbmc/guilib/Resolution.cpp
+++ b/xbmc/guilib/Resolution.cpp
@@ -228,7 +228,8 @@ RESOLUTION CResolutionUtils::FindClosestResolution(float fps, int width, bool is
          (info.iScreenWidth < orig.iScreenWidth) || // new res is smaller
          (info.iScreenHeight < orig.iScreenHeight) || // new height would be smaller
          (info.dwFlags & D3DPRESENTFLAG_MODEMASK) != (curr.dwFlags & D3DPRESENTFLAG_MODEMASK) || // don't switch to interlaced modes
-         (info.iScreen != curr.iScreen)) // skip not current displays
+         (info.iScreen != curr.iScreen) || // skip not current displays
+         (!g_advancedSettings.m_allowResolutionChange)) // user does not want us to switch resolution
       {
         continue;
       }

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -145,6 +145,7 @@ void CAdvancedSettings::Initialize()
   m_videoIgnorePercentAtEnd   = 8.0f;
   m_videoPlayCountMinimumPercent = 90.0f;
   m_videoVDPAUScaling = -1;
+  m_allowResolutionChange = true;
   m_videoVAAPIforced = false;
   m_videoNonLinStretchRatio = 0.5f;
   m_videoEnableHighQualityHwScalers = false;
@@ -563,6 +564,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     TiXmlElement* pAdjustRefreshrate = pElement->FirstChildElement("adjustrefreshrate");
     if (pAdjustRefreshrate)
     {
+      XMLUtils::GetBoolean(pAdjustRefreshrate, "allowresolutionchange", m_allowResolutionChange);
       TiXmlElement* pRefreshOverride = pAdjustRefreshrate->FirstChildElement("override");
       while (pRefreshOverride)
       {

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -175,6 +175,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     float m_audioApplyDrc;
     bool m_useFfmpegVda;
 
+    bool m_allowResolutionChange;
     int   m_videoVDPAUScaling;
     bool  m_videoVAAPIforced;
     float m_videoNonLinStretchRatio;


### PR DESCRIPTION
I have no strong feeling about this. This workarounds:
- 4k TV behind 1080p only AVR (upswitch leads to blackscreen)
- Broken modelines
- 3D SBS issues with Sony TVs (http://forum.kodi.tv/showthread.php?tid=241359&page=4)
- Broken and old intel drivers on windows (chances > 0 that it works with latest drivers)

It only affects a small number of users, so a GUI setting is not needed. Do what you want with it.

Usage:

```
<advancedsettings>
<video>
<adjustrefreshrate>
<allowresolutionchange>false</allowresolutionchange>
</adjustrefreshrate>
</video>
</advancedsettings>
```
