### PR TITLE
[PVR] Cleanup: Make timer internal terminology consistent, step 2

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -3602,13 +3602,13 @@ msgstr ""
 #. Representation of a timer rule
 #: xbmc/pvr/addons/PVRClient.cpp
 msgctxt "#822"
-msgid "Repeating"
+msgid "Timer rule"
 msgstr ""
 
 #. Representation of an epg-based timer rule.
 #: xbmc/pvr/addons/PVRClient.cpp
 msgctxt "#823"
-msgid "Repeating (guide-based)"
+msgid "Timer rule (guide-based)"
 msgstr ""
 
 #empty strings from id 824 to 827

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -202,7 +202,7 @@ CFileItem::CFileItem(const CPVRTimerInfoTagPtr& timer)
 
   Initialize();
 
-  m_bIsFolder = timer->IsRepeating();
+  m_bIsFolder = timer->IsTimerRule();
   m_pvrTimerInfoTag = timer;
   m_strPath = timer->Path();
   SetLabel(timer->Title());

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -3530,7 +3530,7 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///   \table_row3{   <b>`ListItem.HasTimerSchedule`</b>,
 ///                  \anchor ListItem_HasTimerSchedule
 ///                  _boolean_,
-///     Whether the item is part of a repeating timer schedule (PVR). (v16 addition)
+///     Whether the item was scheduled by a timer rule (PVR). (v16 addition)
 ///   }
 ///   \table_row3{   <b>`ListItem.HasRecording`</b>,
 ///                  \anchor ListItem_HasRecording

--- a/xbmc/addons/PVRClient.cpp
+++ b/xbmc/addons/PVRClient.cpp
@@ -468,7 +468,7 @@ bool CPVRClient::GetAddonProperties(void)
         // This code can be removed once all addons actually support the respective PVR Addon API version.
 
         size = 0;
-        // One-shot manual
+        // manual one time
         memset(&types_array[size], 0, sizeof(types_array[size]));
         types_array[size].iId         = size + 1;
         types_array[size].iAttributes = PVR_TIMER_TYPE_IS_MANUAL               |
@@ -481,7 +481,7 @@ bool CPVRClient::GetAddonProperties(void)
                                         PVR_TIMER_TYPE_SUPPORTS_RECORDING_FOLDERS;
         ++size;
 
-        // Repeating manual
+        // manual timer rule
         memset(&types_array[size], 0, sizeof(types_array[size]));
         types_array[size].iId         = size + 1;
         types_array[size].iAttributes = PVR_TIMER_TYPE_IS_MANUAL               |
@@ -534,14 +534,14 @@ bool CPVRClient::GetAddonProperties(void)
             if (types_array[i].iAttributes & PVR_TIMER_TYPE_IS_REPEATING)
             {
               id = (types_array[i].iAttributes & PVR_TIMER_TYPE_IS_MANUAL)
-                 ? 822  // "Repeating"
-                 : 823; // "Repeating (Guide-based)"
+                 ? 822  // "Timer rule"
+                 : 823; // "Timer rule (guide-based)"
             }
             else
             {
               id = (types_array[i].iAttributes & PVR_TIMER_TYPE_IS_MANUAL)
-                 ? 820  // "One Time"
-                 : 821; // "One Time (Guide-based)
+                 ? 820  // "One time"
+                 : 821; // "One time (guide-based)
             }
             std::string descr(g_localizeStrings.Get(id));
             strncpy(types_array[i].strDescription, descr.c_str(), descr.size());

--- a/xbmc/addons/binary/interfaces/api1/PVR/AddonCallbacksPVR.cpp
+++ b/xbmc/addons/binary/interfaces/api1/PVR/AddonCallbacksPVR.cpp
@@ -223,7 +223,7 @@ void CAddonCallbacksPVR::PVRTransferTimerEntry(void *addonData, const ADDON_HAND
     return;
   }
 
-  /* Note: channel can be NULL here, for instance for epg-based repeating timers ("record on any channel" condition). */
+  /* Note: channel can be NULL here, for instance for epg-based timer rules ("record on any channel" condition). */
   CPVRChannelPtr channel = g_PVRChannelGroups->GetByUniqueID(timer->iClientChannelUid, client->GetID());
 
   /* transfer this entry to the timers container */

--- a/xbmc/interfaces/json-rpc/PVROperations.cpp
+++ b/xbmc/interfaces/json-rpc/PVROperations.cpp
@@ -369,12 +369,10 @@ JSONRPC_STATUS CPVROperations::AddTimer(const std::string &method, ITransportLay
   if (!epgTag)
     return InvalidParams;
 
-  bool repeating = parameterObject["repeating"].asBoolean(false);
-
   if (epgTag->HasTimer())
     return InvalidParams;
 
-  CPVRTimerInfoTagPtr newTimer = CPVRTimerInfoTag::CreateFromEpg(epgTag, repeating);
+  CPVRTimerInfoTagPtr newTimer = CPVRTimerInfoTag::CreateFromEpg(epgTag, parameterObject["repeating"].asBoolean(false));
   if (newTimer)
   {
     if (g_PVRTimers->AddTimer(newTimer))
@@ -395,9 +393,7 @@ JSONRPC_STATUS CPVROperations::DeleteTimer(const std::string &method, ITransport
   if (!timer)
     return InvalidParams;
 
-  bool repeating = parameterObject["repeating"].asBoolean(false);
-
-  if (timers->DeleteTimer(timer, false, repeating))
+  if (timers->DeleteTimer(timer, false, parameterObject["repeating"].asBoolean(false)))
     return ACK;
 
   return FailedToExecute;
@@ -420,16 +416,16 @@ JSONRPC_STATUS CPVROperations::ToggleTimer(const std::string &method, ITransport
   if (!epgTag)
     return InvalidParams;
 
-  bool repeating = parameterObject["repeating"].asBoolean(false);
+  bool timerrule = parameterObject["repeating"].asBoolean(false);
   bool sentOkay = false;
   CPVRTimerInfoTagPtr timer(epgTag->Timer());
   if (timer)
   {
-    sentOkay = g_PVRTimers->DeleteTimer(timer, false, repeating);
+    sentOkay = g_PVRTimers->DeleteTimer(timer, false, timerrule);
   }
   else
   {
-    timer = CPVRTimerInfoTag::CreateFromEpg(epgTag, repeating);
+    timer = CPVRTimerInfoTag::CreateFromEpg(epgTag, timerrule);
     sentOkay = g_PVRTimers->AddTimer(timer);
   }
 

--- a/xbmc/pvr/timers/PVRTimerInfoTag.h
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.h
@@ -184,10 +184,10 @@ namespace PVR
     void SetTimerType(const CPVRTimerTypePtr &type);
 
     /*!
-      * @brief Checks whether this is a repeating (vs. one-shot) timer.
-      * @return True if this is a repeating timer, false otherwise.
+      * @brief Checks whether this is a timer rule (vs. one time timer).
+      * @return True if this is a timer rule, false otherwise.
       */
-    bool IsRepeating(void) const { return m_timerType && m_timerType->IsRepeating(); }
+    bool IsTimerRule(void) const { return m_timerType && m_timerType->IsTimerRule(); }
 
     /*!
       * @brief Checks whether this is a manual (vs. epg-based) timer.
@@ -265,7 +265,7 @@ namespace PVR
     unsigned int GetTimerRuleId() const { return m_iParentClientIndex; }
 
     std::string           m_strTitle;            /*!< @brief name of this timer */
-    std::string           m_strEpgSearchString;  /*!< @brief a epg data match string for repeating epg-based timers. Format is backend-dependent, for example regexp */
+    std::string           m_strEpgSearchString;  /*!< @brief a epg data match string for epg-based timer rules. Format is backend-dependent, for example regexp */
     bool                  m_bFullTextEpgSearch;  /*!< @brief indicates whether only epg episode title can be matched by the pvr backend or "more" (backend-dependent") data. */
     std::string           m_strDirectory;        /*!< @brief directory where the recording must be stored */
     std::string           m_strSummary;          /*!< @brief summary string with the time to show inside a GUI list */
@@ -279,8 +279,8 @@ namespace PVR
     int                   m_iPriority;           /*!< @brief priority of the timer */
     int                   m_iLifetime;           /*!< @brief lifetime of the timer in days */
     int                   m_iMaxRecordings;      /*!< @brief (optional) backend setting for maximum number of recordings to keep*/
-    unsigned int          m_iWeekdays;           /*!< @brief bit based store of weekdays for repeating timers */
-    unsigned int          m_iPreventDupEpisodes; /*!< @brief only record new episodes for repeating epg based timers */
+    unsigned int          m_iWeekdays;           /*!< @brief bit based store of weekdays for timer rules */
+    unsigned int          m_iPreventDupEpisodes; /*!< @brief only record new episodes for epg-based timer rules */
     unsigned int          m_iRecordingGroup;     /*!< @brief (optional) if set, the addon/backend stores the recording to a group (sub-folder) */
     std::string           m_strFileNameAndPath;  /*!< @brief file name is only for reference */
     int                   m_iChannelNumber;      /*!< @brief integer value of the channel number */
@@ -298,7 +298,7 @@ namespace PVR
     CCriticalSection      m_critSection;
     CDateTime             m_StartTime; /*!< start time */
     CDateTime             m_StopTime;  /*!< stop time */
-    CDateTime             m_FirstDay;  /*!< if it is a manual repeating timer the first date it starts */
+    CDateTime             m_FirstDay;  /*!< if it is a manual timer rule the first date it starts */
     CPVRTimerTypePtr      m_timerType; /*!< the type of this timer */
 
     unsigned int          m_iActiveChildTimers;   /*!< @brief Number of active timers which have this timer as their m_iParentClientIndex */

--- a/xbmc/pvr/timers/PVRTimerType.h
+++ b/xbmc/pvr/timers/PVRTimerType.h
@@ -94,16 +94,16 @@ namespace PVR
     const std::string& GetDescription() const { return m_strDescription; }
 
     /*!
-     * @brief Check whether this type is for repeating ore one time timers.
-     * @return True if repeating, false otherwise.
+     * @brief Check whether this type is for timer rules or one time timers.
+     * @return True if type represents a timer rule, false otherwise.
      */
-    bool IsRepeating() const { return (m_iAttributes & PVR_TIMER_TYPE_IS_REPEATING) > 0; }
+    bool IsTimerRule() const { return (m_iAttributes & PVR_TIMER_TYPE_IS_REPEATING) > 0; }
 
     /*!
-     * @brief Check whether this type is for repeating ore one time timers.
-     * @return True if one time, false otherwise.
+     * @brief Check whether this type is for timer rules or one time timers.
+     * @return True if type represents a one time timer, false otherwise.
      */
-    bool IsOnetime() const { return !IsRepeating(); }
+    bool IsOnetime() const { return !IsTimerRule(); }
 
     /*!
      * @brief Check whether this type is for epg-based or manual timers.
@@ -118,28 +118,28 @@ namespace PVR
     bool IsEpgBased() const { return !IsManual(); }
 
     /*!
-     * @brief Check whether this type is for repeating epg-based timers.
-     * @return True if repeating epg-based, false otherwise.
+     * @brief Check whether this type is for epg-based timer rules.
+     * @return True if epg-based timer rule, false otherwise.
      */
-    bool IsRepeatingEpgBased() const { return IsRepeating() && IsEpgBased(); }
+    bool IsEpgBasedTimerRule() const { return IsEpgBased() && IsTimerRule(); }
 
     /*!
      * @brief Check whether this type is for one time epg-based timers.
      * @return True if one time epg-based, false otherwise.
      */
-    bool IsOnetimeEpgBased() const { return IsOnetime() && IsEpgBased(); }
+    bool IsEpgBasedOnetime() const { return IsEpgBased() && IsOnetime(); }
 
     /*!
-     * @brief Check whether this type is for repeating manual timers.
-     * @return True if repeating manual, false otherwise.
+     * @brief Check whether this type is for manual timer rules.
+     * @return True if manual timer rule, false otherwise.
      */
-    bool IsRepeatingManual() const { return IsRepeating() && IsManual(); }
+    bool IsManualTimerRule() const { return IsManual() && IsTimerRule(); }
 
     /*!
      * @brief Check whether this type is for one time manual timers.
      * @return True if one time manual, false otherwise.
      */
-    bool IsOnetimeManual() const { return IsOnetime() && IsManual(); }
+    bool IsManualOnetime() const { return IsManual() && IsOnetime(); }
 
     /*!
      * @brief Check whether this type is readonly (must not be modified after initial creation).

--- a/xbmc/pvr/timers/PVRTimers.h
+++ b/xbmc/pvr/timers/PVRTimers.h
@@ -130,11 +130,11 @@ namespace PVR
     /*!
      * @brief Delete all timers on a channel.
      * @param channel The channel to delete the timers for.
-     * @param bDeleteRepeating True to delete repeating events too, false otherwise.
+     * @param bDeleteTimerRules True to delete timer rules too, false otherwise.
      * @param bCurrentlyActiveOnly True to delete timers that are currently running only.
      * @return True if timers any were deleted, false otherwise.
      */
-    bool DeleteTimersOnChannel(const CPVRChannelPtr &channel, bool bDeleteRepeating = true, bool bCurrentlyActiveOnly = false);
+    bool DeleteTimersOnChannel(const CPVRChannelPtr &channel, bool bDeleteTimerRules = true, bool bCurrentlyActiveOnly = false);
 
     /*!
      * @return Next event time (timer or daily wake up)

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -649,7 +649,7 @@ bool CGUIWindowPVRBase::DeleteTimer(CFileItem *item, bool bIsRecording, bool bDe
     return false;
   }
 
-  if (bDeleteRule && !timer->IsRepeating())
+  if (bDeleteRule && !timer->IsTimerRule())
     timer = g_PVRTimers->GetTimerRule(timer);
 
   if (!timer)
@@ -983,7 +983,7 @@ bool CGUIWindowPVRBase::ConfirmDeleteTimer(const CPVRTimerInfoTagPtr &timer, boo
     // prompt user for confirmation for deleting the timer
     bConfirmed = CGUIDialogYesNo::ShowAndGetInput(
                         CVariant{122}, // "Confirm delete"
-                        timer->IsRepeating()
+                        timer->IsTimerRule()
                           ? CVariant{845}  // "Are you sure you want to delete this timer rule and all timers it has scheduled?"
                           : CVariant{846}, // "Are you sure you want to delete this timer?"
                         CVariant{""},


### PR DESCRIPTION
This is a followup to https://github.com/xbmc/xbmc/pull/8713/commits/df2604aa1339ebc4529e784c76f05143e1c73ce0 (Make timer UI terminology consistent: 'repeating timer' / 'timer schedule' -> 'timer rule) and https://github.com/xbmc/xbmc/pull/8713/commits/814b1277891043c1cd74aa18ebadc2456b605c4f (Make timer internal terminology consistent, step 1: 'timer schedule' -> 'timer rule)

Last step in a followup PR will be renaming at API level (PVR addon API, json, guiinfo).

No functional changes here.

@Jalle19 good to go?
