### PR TITLE
[chg] do not allow minimize if runing in standalone mode

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4922,7 +4922,10 @@ bool CApplication::SwitchToFullScreen(bool force /* = false */)
 
 void CApplication::Minimize()
 {
-  g_Windowing.Minimize();
+#if !defined(TARGET_DARWIN_IOS)
+  if (!g_application.IsStandAlone())
+#endif
+    g_Windowing.Minimize();
 }
 
 std::string CApplication::GetCurrentPlayer()


### PR DESCRIPTION
imo, it makes no sense to allow this if runing with --standalone, as in some situations (egl, or x11 without windowmanager), it may not be possible at all to bring kodi back to front

we already check if we are runing in standalone mode and hide "minimize" in powersaving options on non-darwin.

{Open|Libre}ELEC uses a similar patch to disable minimize. this one should be a bit more acceeptable.
