### PR TITLE
[addons] repository code cleanup

### DIFF
--- a/addons/repository.xbmc.org/addon.xml
+++ b/addons/repository.xbmc.org/addon.xml
@@ -6,14 +6,11 @@
   <requires>
     <import addon="xbmc.addon" version="12.0.0"/>
   </requires>
-	<extension point="xbmc.addon.repository"
-		name="Official XBMC.org Add-on Repository">
-		<dir minversion="16.9.0">
-			<info>http://mirrors.kodi.tv/addons/krypton/addons.xml.gz</info>
-			<checksum>http://mirrors.kodi.tv/addons/krypton/addons.xml.gz.md5</checksum>
-			<datadir zip="true">http://mirrors.kodi.tv/addons/krypton</datadir>
-			<hashes>true</hashes>
-		</dir>
+	<extension point="xbmc.addon.repository">
+		<info>http://mirrors.kodi.tv/addons/krypton/addons.xml.gz</info>
+		<checksum>http://mirrors.kodi.tv/addons/krypton/addons.xml.gz.md5</checksum>
+		<datadir>http://mirrors.kodi.tv/addons/krypton</datadir>
+		<hashes>true</hashes>
 	</extension>
 	<extension point="xbmc.addon.metadata">
 		<summary lang="af_ZA">Installeer Byvoegsels vanaf Kodi.tv</summary>

--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -70,11 +70,10 @@ public:
   std::string libname;
   std::string author;
   std::string source;
-  //! @todo fix parts relying on mutating these
-  mutable std::string path;
-  mutable std::string icon;
+  std::string path;
+  std::string icon;
   std::string changelog;
-  mutable std::string fanart;
+  std::string fanart;
   std::string disclaimer;
   ADDONDEPS dependencies;
   std::string broken;
@@ -96,7 +95,6 @@ public:
   TYPE Type() const override { return m_props.type; }
   TYPE FullType() const override { return Type(); }
   bool IsType(TYPE type) const override { return type == m_props.type; }
-  const AddonProps& Props() override { return m_props; }
   std::string ID() const override{ return m_props.id; }
   std::string Name() const override { return m_props.name; }
   bool IsInUse() const override{ return false; };

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -220,7 +220,9 @@ void CAddonInstaller::Install(const std::string& addonId, const AddonVersion& ve
   if (!CAddonMgr::GetInstance().GetAddon(repoId, repo, ADDON_REPOSITORY))
     return;
 
-  std::string hash = std::static_pointer_cast<CRepository>(repo)->GetAddonHash(addon);
+  std::string hash;
+  if (!std::static_pointer_cast<CRepository>(repo)->GetAddonHash(addon, hash))
+    return;
   DoInstall(addon, std::static_pointer_cast<CRepository>(repo), hash, true, false);
 }
 
@@ -497,8 +499,7 @@ bool CAddonInstallJob::GetAddonWithHash(const std::string& addonID, const std::s
   if (!CAddonMgr::GetInstance().GetAddon(repoID, repo, ADDON_REPOSITORY))
     return false;
 
-  hash = std::static_pointer_cast<CRepository>(repo)->GetAddonHash(addon);
-  return true;
+  return std::static_pointer_cast<CRepository>(repo)->GetAddonHash(addon, hash);
 }
 
 bool CAddonInstallJob::DoWork()

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -575,7 +575,8 @@ bool CAddonInstallJob::DoWork()
         {
           CFile::Delete(package);
 
-          CLog::Log(LOGERROR, "CAddonInstallJob[%s]: MD5 mismatch after download %s", m_addon->ID().c_str(), package.c_str());
+          CLog::Log(LOGERROR, "CAddonInstallJob[%s]: MD5 mismatch after download. Expected %s, was %s",
+              m_addon->ID().c_str(), m_hash.c_str(), md5.c_str());
           ReportInstallError(m_addon->ID(), URIUtils::GetFileName(package));
           return false;
         }

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -279,20 +279,9 @@ bool CAddonInstaller::InstallFromZip(const std::string &path)
     return false;
   }
 
-  //! @todo possibly add support for github generated zips here?
-  std::string archive = URIUtils::AddFileToFolder(items[0]->GetPath(), "addon.xml");
-
-  CXBMCTinyXML xml;
   AddonPtr addon;
-  if (xml.LoadFile(archive) && CAddonMgr::GetInstance().LoadAddonDescriptionFromMemory(xml.RootElement(), addon))
-  {
-    // set the correct path
-    addon->Props().path = items[0]->GetPath();
-    addon->Props().icon = URIUtils::AddFileToFolder(items[0]->GetPath(), "icon.png");
-
-    // install the addon
+  if (CAddonMgr::GetInstance().LoadAddonDescription(items[0]->GetPath(), addon))
     return DoInstall(addon, RepositoryPtr());
-  }
 
   CEventLog::GetInstance().AddWithNotification(EventPtr(new CNotificationEvent(24045,
       StringUtils::Format(g_localizeStrings.Get(24143).c_str(), path.c_str()),

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -93,21 +93,23 @@ static cp_extension_t* GetFirstExtPoint(const cp_plugin_info_t* addon, TYPE type
 AddonPtr CAddonMgr::Factory(const cp_plugin_info_t* plugin, TYPE type)
 {
   CAddonBuilder builder;
-  return Factory(plugin, type, builder);
+  if (Factory(plugin, type, builder))
+    return builder.Build();
+  return nullptr;
 }
 
-AddonPtr CAddonMgr::Factory(const cp_plugin_info_t* plugin, TYPE type, CAddonBuilder& builder)
+bool CAddonMgr::Factory(const cp_plugin_info_t* plugin, TYPE type, CAddonBuilder& builder)
 {
   if (!plugin || !plugin->identifier)
-    return nullptr;
+    return false;
 
   if (!PlatformSupportsAddon(plugin))
-    return nullptr;
+    return false;
 
   cp_extension_t* ext = GetFirstExtPoint(plugin, type);
 
   if (ext == nullptr && type != ADDON_UNKNOWN)
-    return nullptr; // no extension point satisfies the type requirement
+    return false; // no extension point satisfies the type requirement
 
   if (ext)
   {
@@ -121,7 +123,7 @@ AddonPtr CAddonMgr::Factory(const cp_plugin_info_t* plugin, TYPE type, CAddonBui
   }
 
   FillCpluffMetadata(plugin, builder);
-  return builder.Build();
+  return true;
 }
 
 void CAddonMgr::FillCpluffMetadata(const cp_plugin_info_t* plugin, CAddonBuilder& builder)
@@ -529,7 +531,9 @@ bool CAddonMgr::GetAddonsInternal(const TYPE &type, VECADDONS &addons, bool enab
         continue;
       }
 
-      AddonPtr addon = Factory(cp_addon, type, builder);
+      AddonPtr addon;
+      if (Factory(cp_addon, type, builder))
+        addon = builder.Build();
       m_cpluff->release_info(m_cp_context, cp_addon);
 
       if (addon)
@@ -1065,17 +1069,30 @@ bool CAddonMgr::LoadAddonDescription(const std::string &path, AddonPtr &addon)
   return false;
 }
 
-bool CAddonMgr::AddonsFromRepoXML(const TiXmlElement *root, VECADDONS &addons)
+bool CAddonMgr::AddonsFromRepoXML(const CRepository::DirInfo& repo, const std::string& xml, VECADDONS& addons)
 {
+  CXBMCTinyXML doc;
+  if (!doc.Parse(xml))
+  {
+    CLog::Log(LOGERROR, "CAddonMgr: Failed to parse addons.xml.");
+    return false;
+  }
+
+  if (doc.RootElement() == nullptr || doc.RootElement()->ValueStr() != "addons")
+  {
+    CLog::Log(LOGERROR, "CAddonMgr: Failed to parse addons.xml. Malformed.");
+    return false;
+  }
+
   // create a context for these addons
   cp_status_t status;
   cp_context_t *context = m_cpluff->create_context(&status);
-  if (!root || !context)
+  if (!context)
     return false;
 
   // each addon XML should have a UTF-8 declaration
   TiXmlDeclaration decl("1.0", "UTF-8", "");
-  const TiXmlElement *element = root->FirstChildElement("addon");
+  auto element = doc.RootElement()->FirstChildElement("addon");
   while (element)
   {
     // dump the XML back to text
@@ -1086,9 +1103,19 @@ bool CAddonMgr::AddonsFromRepoXML(const TiXmlElement *root, VECADDONS &addons)
     cp_plugin_info_t *info = m_cpluff->load_plugin_descriptor_from_memory(context, xml.c_str(), xml.size(), &status);
     if (info)
     {
-      AddonPtr addon = Factory(info, ADDON_UNKNOWN);
-      if (addon.get())
-        addons.push_back(std::move(addon));
+      CAddonBuilder builder;
+      auto basePath = URIUtils::AddFileToFolder(repo.datadir, std::string(info->identifier));
+      info->plugin_path = (char*)malloc(strlen(basePath.c_str()) + 1);
+      strcpy(info->plugin_path, basePath .c_str());
+
+      if (Factory(info, ADDON_UNKNOWN, builder))
+      {
+        builder.SetPath(URIUtils::AddFileToFolder(repo.datadir, StringUtils::Format("%s/%s-%s.zip",
+            info->identifier, info->identifier, builder.GetVersion().asString().c_str())));
+        auto addon = builder.Build();
+        if (addon)
+          addons.push_back(std::move(addon));
+      }
       m_cpluff->release_info(context, info);
     }
     element = element->NextSiblingElement("addon");

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -224,14 +224,6 @@ namespace ADDON
      */
     bool LoadAddonDescription(const std::string &path, AddonPtr &addon);
 
-    /*! \brief Load the addon in the given in-memory xml
-     This loads the addon using c-pluff which parses the addon descriptor file.
-     \param root Root element of an XML document.
-     \param addon [out] returned addon.
-     \return true if addon is set, false otherwise.
-     */
-    bool LoadAddonDescriptionFromMemory(const TiXmlElement *root, AddonPtr &addon);
-
     /*! \brief Parse a repository XML file for addons and load their descriptors
      A repository XML is essentially a concatenated list of addon descriptors.
      \param repo The repository info.

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -26,6 +26,7 @@
 #include <map>
 #include <deque>
 #include "AddonDatabase.h"
+#include "Repository.h"
 
 class DllLibCPluff;
 extern "C"
@@ -233,11 +234,12 @@ namespace ADDON
 
     /*! \brief Parse a repository XML file for addons and load their descriptors
      A repository XML is essentially a concatenated list of addon descriptors.
-     \param root Root element of an XML document.
+     \param repo The repository info.
+     \param xml The XML document from repository.
      \param addons [out] returned list of addons.
      \return true if the repository XML file is parsed, false otherwise.
      */
-    bool AddonsFromRepoXML(const TiXmlElement *root, VECADDONS &addons);
+    bool AddonsFromRepoXML(const CRepository::DirInfo& repo, const std::string& xml, VECADDONS& addons);
 
     /*! \brief Start all services addons.
         \return True is all addons are started, false otherwise
@@ -246,8 +248,9 @@ namespace ADDON
     /*! \brief Stop all services addons.
     */
     void StopServices(const bool onlylogin);
+
     static AddonPtr Factory(const cp_plugin_info_t* plugin, TYPE type);
-    static AddonPtr Factory(const cp_plugin_info_t* plugin, TYPE type, CAddonBuilder& builder);
+    static bool Factory(const cp_plugin_info_t* plugin, TYPE type, CAddonBuilder& builder);
     static void FillCpluffMetadata(const cp_plugin_info_t* plugin, CAddonBuilder& builder);
 
   private:

--- a/xbmc/addons/IAddon.h
+++ b/xbmc/addons/IAddon.h
@@ -94,7 +94,6 @@ namespace ADDON
     virtual TYPE Type() const =0;
     virtual TYPE FullType() const =0;
     virtual bool IsType(TYPE type) const =0;
-    virtual const AddonProps& Props() =0;
     virtual std::string ID() const =0;
     virtual std::string Name() const =0;
     virtual bool IsInUse() const =0;

--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -108,13 +108,6 @@ bool CRepository::FetchChecksum(const std::string& url, std::string& checksum) n
   return true;
 }
 
-#define SET_IF_NOT_EMPTY(x,y) \
-  { \
-    if (!x.empty()) \
-       x = y; \
-  }
-
-
 CRepository::FetchStatus CRepository::FetchIfChanged(const CRepository::DirInfo& repo,
     const std::string& oldChecksum, std::string& checksum, VECADDONS& addons) noexcept
 {
@@ -154,24 +147,7 @@ CRepository::FetchStatus CRepository::FetchIfChanged(const CRepository::DirInfo&
     content = std::move(buffer);
   }
 
-  CXBMCTinyXML doc;
-  if (!doc.Parse(content) || !doc.RootElement()
-      || !CAddonMgr::GetInstance().AddonsFromRepoXML(doc.RootElement(), addons))
-  {
-    CLog::Log(LOGERROR, "CRepository: Failed to parse addons.xml. Malformed.");
-    return STATUS_ERROR;
-  }
-
-  for (IVECADDONS i = addons.begin(); i != addons.end(); ++i)
-  {
-    AddonPtr addon = *i;
-    std::string file = StringUtils::Format("%s/%s-%s.zip", addon->ID().c_str(), addon->ID().c_str(), addon->Version().asString().c_str());
-    addon->Props().path = URIUtils::AddFileToFolder(repo.datadir,file);
-    SET_IF_NOT_EMPTY(addon->Props().icon,URIUtils::AddFileToFolder(repo.datadir,addon->ID()+"/icon.png"))
-    SET_IF_NOT_EMPTY(addon->Props().fanart,URIUtils::AddFileToFolder(repo.datadir,addon->ID()+"/fanart.jpg"))
-  }
-
-  return STATUS_OK;
+  return CAddonMgr::GetInstance().AddonsFromRepoXML(repo, content, addons) ? STATUS_OK : STATUS_ERROR;
 }
 
 CRepositoryUpdateJob::CRepositoryUpdateJob(const RepositoryPtr& repo) : m_repo(repo) {}

--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -56,91 +56,56 @@ using KODI::MESSAGING::HELPERS::DialogResponse;
 
 std::unique_ptr<CRepository> CRepository::FromExtension(AddonProps props, const cp_extension_t* ext)
 {
-  DirList dirs;
-  AddonVersion version("0.0.0");
-  AddonPtr addonver;
-  if (CAddonMgr::GetInstance().GetAddon("xbmc.addon", addonver))
-    version = addonver->Version();
-  for (size_t i = 0; i < ext->configuration->num_children; ++i)
-  {
-    if(ext->configuration->children[i].name &&
-       strcmp(ext->configuration->children[i].name, "dir") == 0)
-    {
-      AddonVersion min_version(CAddonMgr::GetInstance().GetExtValue(&ext->configuration->children[i], "@minversion"));
-      if (min_version <= version)
-      {
-        DirInfo dir;
-        dir.version    = min_version;
-        dir.checksum   = CAddonMgr::GetInstance().GetExtValue(&ext->configuration->children[i], "checksum");
-        dir.compressed = CAddonMgr::GetInstance().GetExtValue(&ext->configuration->children[i], "info@compressed") == "true";
-        dir.info       = CAddonMgr::GetInstance().GetExtValue(&ext->configuration->children[i], "info");
-        dir.datadir    = CAddonMgr::GetInstance().GetExtValue(&ext->configuration->children[i], "datadir");
-        dir.zipped     = CAddonMgr::GetInstance().GetExtValue(&ext->configuration->children[i], "datadir@zip") == "true";
-        dir.hashes     = CAddonMgr::GetInstance().GetExtValue(&ext->configuration->children[i], "hashes") == "true";
-        dirs.push_back(dir);
-      }
-    }
-  }
-  // backward compatibility
-  if (!CAddonMgr::GetInstance().GetExtValue(ext->configuration, "info").empty())
-  {
-    DirInfo info;
-    info.checksum   = CAddonMgr::GetInstance().GetExtValue(ext->configuration, "checksum");
-    info.compressed = CAddonMgr::GetInstance().GetExtValue(ext->configuration, "info@compressed") == "true";
-    info.info       = CAddonMgr::GetInstance().GetExtValue(ext->configuration, "info");
-    info.datadir    = CAddonMgr::GetInstance().GetExtValue(ext->configuration, "datadir");
-    info.zipped     = CAddonMgr::GetInstance().GetExtValue(ext->configuration, "datadir@zip") == "true";
-    info.hashes     = CAddonMgr::GetInstance().GetExtValue(ext->configuration, "hashes") == "true";
-    dirs.push_back(info);
-  }
-
-  return std::unique_ptr<CRepository>(new CRepository(std::move(props), std::move(dirs)));
+  DirInfo info;
+  info.checksum = CAddonMgr::GetInstance().GetExtValue(ext->configuration, "checksum");
+  info.info = CAddonMgr::GetInstance().GetExtValue(ext->configuration, "info");
+  info.datadir = CAddonMgr::GetInstance().GetExtValue(ext->configuration, "datadir");
+  info.hashes = CAddonMgr::GetInstance().GetExtValue(ext->configuration, "hashes") == "true";
+  return std::unique_ptr<CRepository>(new CRepository(std::move(props), std::move(info)));
 }
 
-CRepository::CRepository(AddonProps props, DirList dirs)
-    : CAddon(std::move(props)), m_dirs(std::move(dirs))
+CRepository::CRepository(AddonProps props, DirInfo dir)
+    : CAddon(std::move(props)), m_dir(std::move(dir))
 {
 }
 
-std::string CRepository::FetchChecksum(const std::string& url)
-{
-  CFile file;
-  try
-  {
-    if (file.Open(url))
-    {    
-      // we intentionally avoid using file.GetLength() for 
-      // Transfer-Encoding: chunked servers.
-      std::stringstream str;
-      char temp[1024];
-      int read;
-      while ((read=file.Read(temp, sizeof(temp))) > 0)
-        str.write(temp, read);
-      return str.str();
-    }
-    return "";
-  }
-  catch (...)
-  {
-    return "";
-  }
-}
 
-std::string CRepository::GetAddonHash(const AddonPtr& addon) const
+bool CRepository::GetAddonHash(const AddonPtr& addon, std::string& checksum) const
 {
-  std::string checksum;
-  DirList::const_iterator it;
-  for (it = m_dirs.begin();it != m_dirs.end(); ++it)
-    if (URIUtils::PathHasParent(addon->Path(), it->datadir, true))
-      break;
-  if (it != m_dirs.end() && it->hashes)
+  if (!m_dir.hashes)
   {
-    checksum = FetchChecksum(addon->Path()+".md5");
+    checksum = "";
+    return true;
+  }
+  if (FetchChecksum(addon->Path() + ".md5", checksum))
+  {
     size_t pos = checksum.find_first_of(" \n");
     if (pos != std::string::npos)
-      return checksum.substr(0, pos);
+    {
+      checksum = checksum.substr(0, pos);
+      return true;
+    }
   }
-  return checksum;
+  return false;
+}
+
+bool CRepository::FetchChecksum(const std::string& url, std::string& checksum) noexcept
+{
+  CFile file;
+  if (!file.Open(url))
+    return false;
+
+  // we intentionally avoid using file.GetLength() for
+  // Transfer-Encoding: chunked servers.
+  std::stringstream ss;
+  char temp[1024];
+  int read;
+  while ((read = file.Read(temp, sizeof(temp))) > 0)
+    ss.write(temp, read);
+  if (read <= -1)
+    return false;
+  checksum = ss.str();
+  return true;
 }
 
 #define SET_IF_NOT_EMPTY(x,y) \
@@ -150,22 +115,42 @@ std::string CRepository::GetAddonHash(const AddonPtr& addon) const
   }
 
 
-bool CRepository::FetchIndex(const std::string& url, VECADDONS& addons)
+CRepository::FetchStatus CRepository::FetchIfChanged(const CRepository::DirInfo& repo,
+    const std::string& oldChecksum, std::string& checksum, VECADDONS& addons) noexcept
 {
+  checksum = "";
+  if (!repo.checksum.empty())
+  {
+    if (!FetchChecksum(repo.checksum, checksum))
+    {
+      CLog::Log(LOGERROR, "CRepository: failed read '%s'", repo.checksum.c_str());
+      return STATUS_ERROR;
+    }
+  }
+
+  if (oldChecksum == checksum && !oldChecksum.empty())
+    return STATUS_NOT_MODIFIED;
+
   XFILE::CCurlFile http;
   http.SetAcceptEncoding("gzip");
 
   std::string content;
-  if (!http.Get(url, content))
-    return false;
+  if (!http.Get(repo.info, content))
+  {
+    CLog::Log(LOGERROR, "CRepository: failed to read %s", repo.info.c_str());
+    return STATUS_ERROR;
+  }
 
-  if (URIUtils::HasExtension(url, ".gz")
+  if (URIUtils::HasExtension(repo.info, ".gz")
       || CMime::GetFileTypeFromMime(http.GetMimeType()) == CMime::EFileType::FileTypeGZip)
   {
-    CLog::Log(LOGDEBUG, "CRepository '%s' is gzip. decompressing", url.c_str());
+    CLog::Log(LOGDEBUG, "CRepository '%s' is gzip. decompressing", repo.info.c_str());
     std::string buffer;
     if (!CZipFile::DecompressGzip(content, buffer))
-      return false;
+    {
+      CLog::Log(LOGERROR, "CRepository: failed to decompress gzip from '%s'", repo.info.c_str());
+      return STATUS_ERROR;
+    }
     content = std::move(buffer);
   }
 
@@ -173,40 +158,23 @@ bool CRepository::FetchIndex(const std::string& url, VECADDONS& addons)
   if (!doc.Parse(content) || !doc.RootElement()
       || !CAddonMgr::GetInstance().AddonsFromRepoXML(doc.RootElement(), addons))
   {
-    CLog::Log(LOGERROR, "CRepository: Failed to parse addons.xml. Malformated.");
-    return false;
+    CLog::Log(LOGERROR, "CRepository: Failed to parse addons.xml. Malformed.");
+    return STATUS_ERROR;
   }
-  return true;
+
+  for (IVECADDONS i = addons.begin(); i != addons.end(); ++i)
+  {
+    AddonPtr addon = *i;
+    std::string file = StringUtils::Format("%s/%s-%s.zip", addon->ID().c_str(), addon->ID().c_str(), addon->Version().asString().c_str());
+    addon->Props().path = URIUtils::AddFileToFolder(repo.datadir,file);
+    SET_IF_NOT_EMPTY(addon->Props().icon,URIUtils::AddFileToFolder(repo.datadir,addon->ID()+"/icon.png"))
+    SET_IF_NOT_EMPTY(addon->Props().fanart,URIUtils::AddFileToFolder(repo.datadir,addon->ID()+"/fanart.jpg"))
+  }
+
+  return STATUS_OK;
 }
-
-bool CRepository::Parse(const DirInfo& dir, VECADDONS& addons)
-{
-  if (!FetchIndex(dir.info, addons))
-    return false;
-
-    for (IVECADDONS i = addons.begin(); i != addons.end(); ++i)
-    {
-      AddonPtr addon = *i;
-      if (dir.zipped)
-      {
-        std::string file = StringUtils::Format("%s/%s-%s.zip", addon->ID().c_str(), addon->ID().c_str(), addon->Version().asString().c_str());
-        addon->Props().path = URIUtils::AddFileToFolder(dir.datadir,file);
-        SET_IF_NOT_EMPTY(addon->Props().icon,URIUtils::AddFileToFolder(dir.datadir,addon->ID()+"/icon.png"))
-        SET_IF_NOT_EMPTY(addon->Props().fanart,URIUtils::AddFileToFolder(dir.datadir,addon->ID()+"/fanart.jpg"))
-      }
-      else
-      {
-        addon->Props().path = URIUtils::AddFileToFolder(dir.datadir,addon->ID()+"/");
-        SET_IF_NOT_EMPTY(addon->Props().icon,URIUtils::AddFileToFolder(dir.datadir,addon->ID()+"/icon.png"))
-        SET_IF_NOT_EMPTY(addon->Props().fanart,URIUtils::AddFileToFolder(dir.datadir,addon->ID()+"/fanart.jpg"))
-      }
-    }
-  return true;
-}
-
 
 CRepositoryUpdateJob::CRepositoryUpdateJob(const RepositoryPtr& repo) : m_repo(repo) {}
-
 
 bool CRepositoryUpdateJob::DoWork()
 {
@@ -220,17 +188,17 @@ bool CRepositoryUpdateJob::DoWork()
 
   std::string newChecksum;
   VECADDONS addons;
-  auto status = FetchIfChanged(oldChecksum, newChecksum, addons);
+  auto status = CRepository::FetchIfChanged(m_repo->m_dir, oldChecksum, newChecksum, addons);
 
   database.SetLastChecked(m_repo->ID(), m_repo->Version(),
       CDateTime::GetCurrentDateTime().GetAsDBDateTime());
 
   MarkFinished();
 
-  if (status == STATUS_ERROR)
+  if (status == CRepository::STATUS_ERROR)
     return false;
 
-  if (status == STATUS_NOT_MODIFIED)
+  if (status == CRepository::STATUS_NOT_MODIFIED)
   {
     CLog::Log(LOGDEBUG, "CRepositoryUpdateJob[%s] checksum not changed.", m_repo->ID().c_str());
     return true;
@@ -314,51 +282,3 @@ bool CRepositoryUpdateJob::DoWork()
   database.CommitMultipleExecute();
   return true;
 }
-
-CRepositoryUpdateJob::FetchStatus CRepositoryUpdateJob::FetchIfChanged(const std::string& oldChecksum,
-    std::string& checksum, VECADDONS& addons)
-{
-  SetText(StringUtils::Format(g_localizeStrings.Get(24093).c_str(), m_repo->Name().c_str()));
-  const unsigned int total = m_repo->m_dirs.size() * 2;
-
-  checksum = "";
-  for (auto it = m_repo->m_dirs.cbegin(); it != m_repo->m_dirs.cend(); ++it)
-  {
-    if (!it->checksum.empty())
-    {
-      if (ShouldCancel(std::distance(m_repo->m_dirs.cbegin(), it), total))
-        return STATUS_ERROR;
-
-      auto dirsum = CRepository::FetchChecksum(it->checksum);
-      if (dirsum.empty())
-      {
-        CLog::Log(LOGERROR, "CRepositoryUpdateJob[%s] failed read checksum for "
-            "directory '%s'", m_repo->ID().c_str(), it->info.c_str());
-        return STATUS_ERROR;
-      }
-      checksum += dirsum;
-    }
-  }
-
-  if (oldChecksum == checksum && !oldChecksum.empty())
-    return STATUS_NOT_MODIFIED;
-
-  for (auto it = m_repo->m_dirs.cbegin(); it != m_repo->m_dirs.cend(); ++it)
-  {
-    if (ShouldCancel(m_repo->m_dirs.size() + std::distance(m_repo->m_dirs.cbegin(), it), total))
-      return STATUS_ERROR;
-
-    VECADDONS tmp;
-    if (!CRepository::Parse(*it, tmp))
-    {
-      CLog::Log(LOGERROR, "CRepositoryUpdateJob[%s] failed to read or parse "
-          "directory '%s'", m_repo->ID().c_str(), it->info.c_str());
-      return STATUS_ERROR;
-    }
-    addons.insert(addons.end(), tmp.begin(), tmp.end());
-  }
-
-  SetProgress(total, total);
-  return STATUS_OK;
-}
-


### PR DESCRIPTION
This fixes the last few `mutuable` workarounds and drops the non-zipped/multi-directory 'features' which are no longer used (and really should never be used).
