### PR TITLE
[addons] fix default sort order in recently updated

### DIFF
--- a/xbmc/addons/GUIViewStateAddonBrowser.cpp
+++ b/xbmc/addons/GUIViewStateAddonBrowser.cpp
@@ -60,7 +60,6 @@ CGUIViewStateAddonBrowser::CGUIViewStateAddonBrowser(const CFileItemList& items)
   }
   SetViewAsControl(DEFAULT_VIEW_AUTO);
 
-  SetSortOrder(SortOrderAscending);
   LoadViewState(items.GetPath(), WINDOW_ADDON_BROWSER);
 }
 

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -556,9 +556,6 @@ bool CAddonsDirectory::GetDirectory(const CURL& url, CFileItemList &items)
     if (!GetRecentlyUpdatedAddons(addons))
       return false;
 
-    std::sort(addons.begin(), addons.end(),
-        [](const AddonPtr& a, const AddonPtr& b){ return a->LastUpdated() > b->LastUpdated(); });
-
     CAddonsDirectory::GenerateAddonListing(path, addons, items, g_localizeStrings.Get(24004));
     return true;
 


### PR DESCRIPTION
should have been descending.
@MartijnKaijser
