### PR TITLE
Added navigation controls for EDL (commercials) in PVR playback

### DIFF
--- a/xbmc/cores/VideoPlayer/Edl.cpp
+++ b/xbmc/cores/VideoPlayer/Edl.cpp
@@ -840,6 +840,51 @@ bool CEdl::InCut(const int iSeek, Cut *pCut) const
   return false;
 }
 
+bool CEdl::GetNearestCut(bool bPlus, const int iSeek, Cut *pCut) const
+{
+  if (bPlus) 
+  {
+    // Searching forwards
+    for (auto &cut : m_vecCuts)
+    {
+      if (iSeek >= cut.start && iSeek <= cut.end) // Inside cut.
+      {
+        if (pCut)
+          *pCut = cut;
+        return true;
+      }
+      else if (iSeek < cut.start) // before this cut
+      {
+        if (pCut)
+          *pCut = cut;
+        return true;
+      }
+    }
+    return false;
+  } 
+  else
+  {
+    // Searching backwards
+    for (int i = (int)m_vecCuts.size() - 1; i >= 0; i--)
+    {
+      if (iSeek - 20000 >= m_vecCuts[i].start && iSeek <= m_vecCuts[i].end) 
+        // Inside cut. We ignore if we're closer to 20 seconds inside
+      {
+        if (pCut)
+          *pCut = m_vecCuts[i];
+        return true;
+      }
+      else if (iSeek > m_vecCuts[i].end) // after this cut
+      {
+        if (pCut)
+          *pCut = m_vecCuts[i];
+        return true;
+      }
+    }
+    return false;
+  }
+}
+
 bool CEdl::GetNextSceneMarker(bool bPlus, const int iClock, int *iSceneMarker) const
 {
   if (!HasSceneMarker())

--- a/xbmc/cores/VideoPlayer/Edl.h
+++ b/xbmc/cores/VideoPlayer/Edl.h
@@ -54,6 +54,7 @@ public:
   int RestoreCutTime(int iClock) const;
 
   bool InCut(int iSeek, Cut *pCut = NULL) const;
+  bool GetNearestCut(bool bPlus, const int iSeek, Cut *pCut) const;
 
   bool GetNextSceneMarker(bool bPlus, const int iClock, int *iSceneMarker) const;
 


### PR DESCRIPTION
Added functionality so that when playing from a PVR if there is an EDL, NEXT will go to the end of the next commercial block, and PREV will go to the beginning of the previous commercial block. If no EDL is present, old behavior is preserved.
