### PR TITLE
[PeripheralCecAdapter] Fix: Slovak language code (slo) considered as Slovenian (slv)

### DIFF
--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -594,6 +594,8 @@ void CPeripheralCecAdapter::SetMenuLanguage(const char *strLanguage)
   else if (!strcmp(strLanguage, "srp"))
     strGuiLanguage = "sr_rs@latin";
   else if (!strcmp(strLanguage, "slo"))
+    strGuiLanguage = "sk_sk";
+  else if (!strcmp(strLanguage, "slv"))
     strGuiLanguage = "sl_si";
   else if (!strcmp(strLanguage, "spa"))
     strGuiLanguage = "es_es";


### PR DESCRIPTION
Hello,
current implementation of PeripheralCecAdapter seems to have a bug in CPeripheralCecAdapter::SetMenuLanguage implementation. As a result, when I set menu language in my TV to Slovak, it is reported via HDMI CEC to device and Kodi user interface is actually set to Slovenian.

According to [HDMI specification](http://www.microprocessor.org/HDMISpecification13a.pdf), ISO 639-2 shall be used. For language code table please [look here](http://www.loc.gov/standards/iso639-2/php/code_list.php).

Slovak language is using ISO code **slo** and Slovenian is using ISO code **slv**. I have updated the code for both Slovak and Slovenian.

I have not yet tested this change locally, but I might do that if required. I think that because the change is actually simple, if the code builds, we should be OK.
