### PR TITLE
[AE/OSXSink] - bundle audio device list changes into one final CAEFac…

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.h
@@ -22,6 +22,7 @@
 #include "cores/AudioEngine/Interfaces/AESink.h"
 #include "cores/AudioEngine/Utils/AEDeviceInfo.h"
 #include "cores/AudioEngine/Sinks/osx/CoreAudioDevice.h"
+#include "threads/Timer.h"
 
 class AERingBuffer;
 struct AEDelayStatus;
@@ -64,4 +65,20 @@ private:
   CAESpinSection         m_render_locker;
   volatile int64_t       m_render_tick;
   volatile double        m_render_delay;
+};
+
+// helper class for having a delayed device changed event
+class CDeviceChangeListTimeout : public ITimerCallback
+{
+public:
+  CDeviceChangeListTimeout();
+  ~CDeviceChangeListTimeout();
+  
+  void ResetDeviceListChangedTimer();
+  
+  // ITimerCallback
+  void OnTimeout();
+
+private:
+  CTimer *m_pDeviceListChangedTimer;
 };


### PR DESCRIPTION
…tory::DeviceChange() call by using a timer. Should prevent multiple audio dropouts during hdmi enumeration and stuff like that (which results in multiple events fired by the os but only needs to inform AudioEngine once after all os events are fired).

This is in response to trac ticket http://trac.kodi.tv/ticket/16785

@fritsch something like that?
