### PR TITLE
[addons] Preserve strings which are not string ids in enum lvalues

### DIFF
--- a/xbmc/addons/GUIDialogAddonSettings.cpp
+++ b/xbmc/addons/GUIDialogAddonSettings.cpp
@@ -782,15 +782,18 @@ void CGUIDialogAddonSettings::CreateControls()
           int iAdd = i;
           if (entryVec.size() > i)
             iAdd = atoi(entryVec[i].c_str());
-          if (!lvalues.empty())
+          std::string replace;
+          if (!lvalues.empty() && std::all_of(valuesVec[i].begin(), valuesVec[i].end(), ::isdigit))
           {
-            std::string replace = g_localizeStrings.GetAddonString(m_addon->ID(),atoi(valuesVec[i].c_str()));
+            replace = g_localizeStrings.GetAddonString(m_addon->ID(), atoi(valuesVec[i].c_str()));
             if (replace.empty())
               replace = g_localizeStrings.Get(atoi(valuesVec[i].c_str()));
-            ((CGUISpinControlEx *)pControl)->AddLabel(replace, iAdd);
+            if (replace.empty())
+              replace = valuesVec[i];
           }
           else
-            ((CGUISpinControlEx *)pControl)->AddLabel(valuesVec[i], iAdd);
+            replace = valuesVec[i];
+          ((CGUISpinControlEx *)pControl)->AddLabel(replace, iAdd);
         }
         if (type == "labelenum")
         { // need to run through all our settings and find the one that matches


### PR DESCRIPTION
Fix for https://github.com/xbmc/xbmc/pull/8271.

> Sometimes with addon setting spinners some of the values may be untranslatable, e.g. a proper noun or some kind of identifier. Currently it is impossible to mix string ids to be localized and actual strings because the strings are converted to the string "Programs". This is a result of a lookup of the string id 0 as returned by atoi when it can't convert to an integer.
> 
> This PR fixes that so that the fallback is to preserve the original string.
