### PR TITLE
CRenderManager: fix GetAspectRatio at playback start

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -324,6 +324,7 @@ bool CRenderManager::Configure()
     m_renderState = STATE_UNCONFIGURED;
 
   m_stateEvent.Set();
+  m_playerPort->VideoParamsChange();
   return result;
 }
 


### PR DESCRIPTION
at playbackstart in CGUIInfoManager::UpdateAVInfo() the variables m_videoInfo and m_audioinfo are filled with the info from the player but when these info are requested the rendermanager is not already configured or at least it's not configured on Windows

so when CBaseRenderer::GetAspectRatio()  is called m_sourceWidth and m_sourceHeight are not set with the right value but with 720x480

without this PR i have always the tag with the aspect ratio at 1.33:1

I don't know if this is a proper solution

@FernetMenta @afedchin
