### PR TITLE
[xbmc][fix] Fix theme xbt loading that broke during cleanup.in #9960

### DIFF
--- a/xbmc/guilib/TextureBundle.cpp
+++ b/xbmc/guilib/TextureBundle.cpp
@@ -21,7 +21,14 @@
 #include "TextureBundle.h"
 
 CTextureBundle::CTextureBundle()
-  : m_useXBT{false}
+  : m_tbXBT{false}
+	, m_useXBT{false}
+{
+}
+
+CTextureBundle::CTextureBundle(bool useXBT)
+  : m_tbXBT{useXBT}
+	, m_useXBT{useXBT}
 {
 }
 

--- a/xbmc/guilib/TextureBundle.h
+++ b/xbmc/guilib/TextureBundle.h
@@ -28,6 +28,7 @@ class CTextureBundle
 {
 public:
   CTextureBundle();
+  explicit CTextureBundle(bool useXBT);
   ~CTextureBundle() = default;
 
   void SetThemeBundle(bool themeBundle);

--- a/xbmc/guilib/TextureBundleXBT.cpp
+++ b/xbmc/guilib/TextureBundleXBT.cpp
@@ -41,9 +41,15 @@
 #endif
 #endif
 
-CTextureBundleXBT::CTextureBundleXBT(void)
+CTextureBundleXBT::CTextureBundleXBT()
   : m_TimeStamp{0}
   , m_themeBundle{false}
+{
+}
+
+CTextureBundleXBT::CTextureBundleXBT(bool themeBundle)
+  : m_TimeStamp{0}
+  , m_themeBundle{themeBundle}
 {
 }
 
@@ -59,6 +65,15 @@ CTextureBundleXBT::~CTextureBundleXBT(void)
 bool CTextureBundleXBT::OpenBundle()
 {
   // Find the correct texture file (skin or theme)
+
+  auto mediaDir = g_graphicsContext.GetMediaDir();
+  if (mediaDir.empty())
+  {
+    mediaDir = CSpecialProtocol::TranslatePath(
+      URIUtils::AddFileToFolder("special://home/addons",
+        CSettings::GetInstance().GetString(CSettings::SETTING_LOOKANDFEEL_SKIN)));
+  }
+
   if (m_themeBundle)
   {
     // if we are the theme bundle, we only load if the user has chosen
@@ -67,7 +82,7 @@ bool CTextureBundleXBT::OpenBundle()
     if (!theme.empty() && !StringUtils::EqualsNoCase(theme, "SKINDEFAULT"))
     {
       std::string themeXBT(URIUtils::ReplaceExtension(theme, ".xbt"));
-      m_path = URIUtils::AddFileToFolder(g_graphicsContext.GetMediaDir(), "media");
+      m_path = URIUtils::AddFileToFolder(mediaDir, "media");
       m_path = URIUtils::AddFileToFolder(m_path, themeXBT);
     }
     else
@@ -77,7 +92,7 @@ bool CTextureBundleXBT::OpenBundle()
   }
   else
   {
-    m_path = URIUtils::AddFileToFolder(g_graphicsContext.GetMediaDir(), "media/Textures.xbt");
+    m_path = URIUtils::AddFileToFolder(mediaDir, "media/Textures.xbt");
   }
 
   m_path = CSpecialProtocol::TranslatePathConvertCase(m_path);

--- a/xbmc/guilib/TextureBundleXBT.h
+++ b/xbmc/guilib/TextureBundleXBT.h
@@ -33,6 +33,7 @@ class CTextureBundleXBT
 {
 public:
   CTextureBundleXBT();
+  explicit CTextureBundleXBT(bool themeBundle);
   ~CTextureBundleXBT();
 
   void SetThemeBundle(bool themeBundle);

--- a/xbmc/guilib/TextureManager.cpp
+++ b/xbmc/guilib/TextureManager.cpp
@@ -539,8 +539,9 @@ void CGUITextureManager::Cleanup()
     delete pMap;
     i = m_vecTextures.erase(i);
   }
-  for (int i = 0; i < 2; i++)
-    m_TexBundle[i] = CTextureBundle();
+
+  m_TexBundle[0] = CTextureBundle(true);
+  m_TexBundle[1] = CTextureBundle();
   FreeUnusedTextures();
 }
 


### PR DESCRIPTION
Found a race condition that seems to have been hidden and a screwup during cleanup clobbering state.

The race condition is that g_graphicsContext.GetMediaDir() isn't set to anything when first called, it's only later on during skin loading it's actually populated. If this happens now we fall back to the currently set skin.

@MilhouseVH I've tested with the Titan beta skin, I can't see any difference on the corners when using modern_rounded but works fine setting it to classic so I'm thinking it might be my eyes deceiving me or some change in the beta I tested. Would be great if you or the author can test the changes.
