### PR TITLE
VideoPlayer: check for duplicate filenames when opening multi source …

### DIFF
--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -1770,6 +1770,11 @@ void CUtil::ScanPathsForAssociatedItems(const std::string& videoName,
       continue;
 
     std::string strCandidate = URIUtils::GetFileName(pItem->GetPath());
+
+    // skip duplicates
+    if (std::find(associatedFiles.begin(), associatedFiles.end(), pItem->GetPath()) != associatedFiles.end())
+      continue;
+
     URIUtils::RemoveExtension(strCandidate);
     if (StringUtils::StartsWithNoCase(strCandidate, videoName))
     {


### PR DESCRIPTION
…demuxer

fixes http://forum.kodi.tv/showthread.php?tid=281725

*wtv files can be audio and video. Checking for external audio ended up having the same file twice in the list.

@ace20022 /cc
