### PR TITLE
Revert "[android/packaging] Sync rtmp removal"

### DIFF
--- a/tools/android/packaging/Makefile.in
+++ b/tools/android/packaging/Makefile.in
@@ -1,6 +1,7 @@
 include ../../depends/Makefile.include
 
 OBJS = libcurl.so \
+  librtmp.so \
   libplist.so libshairplay.so \
   libnfs.so libass.so \
   libbluray.so libsmbclient.so


### PR DESCRIPTION
Reverts xbmc/xbmc#10017

The library seems to be still used (see comments in xbmc/xbmc#10017)
