### PR TITLE
[PVR] Extract thumbnails for recordings, if not provided by pvr backend.

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
@@ -103,8 +103,7 @@ bool CDVDFileInfo::ExtractThumb(const std::string &strPath,
   unsigned int nTime = XbmcThreads::SystemClockMillis();
   CFileItem item(strPath, false);
 
-  if (item.IsDiscImage() ||
-      item.IsPVR())
+  if (item.IsDiscImage() || URIUtils::IsLiveTV(strPath))
     return false;
 
   item.SetMimeTypeForInternetFile();

--- a/xbmc/pvr/recordings/PVRRecordings.cpp
+++ b/xbmc/pvr/recordings/PVRRecordings.cpp
@@ -352,9 +352,6 @@ bool CPVRRecordings::GetDirectory(const std::string& strPath, CFileItemList &ite
       if (!current->m_strFanartPath.empty())
         pFileItem->SetArt("fanart", current->m_strFanartPath);
 
-      // Use the channel icon as a fallback when a thumbnail is not available
-      pFileItem->SetArtFallback("thumb", "icon");
-
       pFileItem->SetOverlayImage(CGUIListItem::ICON_OVERLAY_UNWATCHED, pFileItem->GetPVRRecordingInfoTag()->m_playCount > 0);
 
       items.Add(pFileItem);


### PR DESCRIPTION
If a pvr backend does not provide thumbnails for recordings, the thumbnails now will be automatically generated by Kodi.

![screenshot001](https://cloud.githubusercontent.com/assets/3226626/16650925/092c263c-4441-11e6-9056-542c695395da.png)
![screenshot002](https://cloud.githubusercontent.com/assets/3226626/16650924/092990c0-4441-11e6-8406-f46ae37ceb68.png)

This feature has been requested several times in the forum.

Surprisingly, it was more than trivial to implement. ;-)

@Jalle19 for review?
