### PR TITLE
[D3D11] Hack to fix refresh rate issue in full screen exclusive mode.

### DIFF
--- a/project/BuildDependencies/scripts/0_package.list
+++ b/project/BuildDependencies/scripts/0_package.list
@@ -11,6 +11,7 @@ crossguid-8f399e-win32-vc140-v3.7z
 curl-7.48-win32-vc140.7z
 dnssd-541-win32.zip
 doxygen-1.8.2-win32.7z
+easyhook-2.7.5870.0-win32-vc140.7z
 fontconfig-2.8.0-win32.7z
 freetype-2.4.6-win32-3.7z
 giflib-5.1.4-win32-vc140.7z

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -68,11 +68,11 @@
     <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug Testsuite|Win32'">XBMC\$(Configuration)\objs\</IntDir>
     <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">XBMC\$(Configuration)\</OutDir>
     <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">XBMC\$(Configuration)\objs\</IntDir>
-    <IncludePath Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(WindowsSDK_IncludePath);$(DXSDK_DIR)Include;$(IncludePath)</IncludePath>
-    <IncludePath Condition="'$(Configuration)|$(Platform)'=='Debug Testsuite|Win32'">$(WindowsSDK_IncludePath);$(DXSDK_DIR)Include;$(IncludePath)</IncludePath>
+    <IncludePath Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(WindowsSdkDir)Include\km;$(WindowsSDK_IncludePath);$(DXSDK_DIR)Include;$(IncludePath)</IncludePath>
+    <IncludePath Condition="'$(Configuration)|$(Platform)'=='Debug Testsuite|Win32'">$(WindowsSdkDir)Include\km;$(WindowsSDK_IncludePath);$(DXSDK_DIR)Include;$(IncludePath)</IncludePath>
     <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(WindowsSDK_LibraryPath_x86);$(DXSDK_DIR)Lib\x86;$(LibraryPath)</LibraryPath>
     <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Debug Testsuite|Win32'">$(WindowsSDK_LibraryPath_x86);$(DXSDK_DIR)Lib\x86;$(LibraryPath)</LibraryPath>
-    <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(WindowsSDK_IncludePath);$(DXSDK_DIR)Include;$(IncludePath)</IncludePath>
+    <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(WindowsSdkDir)Include\km;$(WindowsSDK_IncludePath);$(DXSDK_DIR)Include;$(IncludePath)</IncludePath>
     <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(WindowsSDK_LibraryPath_x86);$(DXSDK_DIR)Lib\x86;$(LibraryPath)</LibraryPath>
     <TargetName Condition="'$(Configuration)|$(Platform)'=='Debug Testsuite|Win32'">$(ProjectName)-test</TargetName>
     <CustomBuildBeforeTargets Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">

--- a/xbmc/rendering/dx/RenderSystemDX.h
+++ b/xbmc/rendering/dx/RenderSystemDX.h
@@ -29,6 +29,7 @@
 #include "rendering/RenderSystem.h"
 #include "guilib/GUIShaderDX.h"
 #include "threads/CriticalSection.h"
+#include "easyhook/easyhook.h"
 
 enum PCI_Vendors
 {
@@ -38,6 +39,7 @@ enum PCI_Vendors
 };
 
 class ID3DResource;
+struct D3D10DDIARG_CREATERESOURCE;
 
 class CRenderSystemDX : public CRenderSystemBase
 {
@@ -90,6 +92,7 @@ public:
   void                    SetAlphaBlendEnable(bool enable);
 
   static std::string GetErrorDescription(HRESULT hr);
+  void FixRefreshRateIfNecessary(const D3D10DDIARG_CREATERESOURCE* pResource);
 
 protected:
   bool CreateDevice();
@@ -116,6 +119,8 @@ protected:
   bool GetDisplayStereoEnabled() const;
   void SetDisplayStereoEnabled(bool enable) const;
   void UpdateDisplayStereoStatus(bool isfirst = false);
+  void InitHooks();
+  void UninitHooks();
 
   virtual void Register(ID3DResource *resource);
   virtual void Unregister(ID3DResource *resource);
@@ -123,6 +128,8 @@ protected:
   virtual void OnDisplayLost() {};
   virtual void OnDisplayReset() {};
   virtual void OnDisplayBack() {};
+
+  static void GetRefreshRatio(uint32_t refresh, uint32_t* num, uint32_t* den);
 
   // our adapter could change as we go
   bool                        m_needNewDevice{false};
@@ -178,6 +185,8 @@ protected:
 #endif
   bool                        m_bDefaultStereoEnabled{false};
   bool                        m_bStereoEnabled{false};
+  TRACED_HOOK_HANDLE          m_hHook{nullptr};
+  HMODULE                     m_hDriverModule{nullptr};
 };
 
 #endif


### PR DESCRIPTION
There is an ugly "bug" in DX11 which causes DX system is unable switch to desired display mode in full screen exclusive mode

23.976 <-> 24.00
29.970 <-> 30.00
47.952 <-> 48.00
59.940 <-> 60.00

On some system DX is unable to switch to 24.00 on others to 23.976 mode. Some systems has no the issue. This trick fixes the issue.

This also requires:
- WDK 8.1 installed on build machine https://www.microsoft.com/en-us/download/details.aspx?id=42273. (need to edit wiki page as well)
- EasyHook package on our mirrors https://www.dropbox.com/s/y1z8kiqx4s5wll2/easyhook-2.7.5870.0-win32-vc140.7z?dl=0

ping @Voyager1 @Paxxi @FernetMenta 
