### PR TITLE
[depends] build curl without librtmp support

### DIFF
--- a/tools/depends/target/curl/Makefile
+++ b/tools/depends/target/curl/Makefile
@@ -13,7 +13,7 @@ ARCHIVE=$(SOURCE).tar.bz2
 # configuration settings
 CONFIGURE=cp -f $(CONFIG_SUB) $(CONFIG_GUESS) .; \
           ./configure --prefix=$(PREFIX) \
-          --without-libssh2 --disable-ntlm-wb --enable-ipv6
+          --without-libssh2 --disable-ntlm-wb --enable-ipv6 --without-librtmp
 
 LIBDYLIB=$(PLATFORM)/lib/.libs/lib$(LIBNAME).a
 


### PR DESCRIPTION
kodi now uses ffmpeg's own rtmp implementation, and optionaly inputstream.rtmp
rtmp support was picked automaticlay by libcurl configure if librtmp header/libs
are present in sysroot. no point linking our libcurl against librtmp now
