### PR TITLE
[cmake/cpluff] Add generated artefacts to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ config.log
 *.bak
 *.apk
 *.class
+*.dwo
 
 # Windows specific generated files
 *.exp
@@ -181,11 +182,13 @@ cmake_install.cmake
 /lib/cpluff/*/*/*/*/Makefile
 /lib/cpluff/po/*template
 /lib/cpluff/po/*header
+lib/cpluff/console/cpluff-console
 lib/cpluff/examples/cpfile/cpfile
 lib/cpluff/libcpluff/cpluffdef.h
 lib/cpluff/libcpluff/docsrc/Doxyfile-impl
 lib/cpluff/libcpluff/docsrc/Doxyfile-ref
 lib/cpluff/libtool
+lib/cpluff/loader/cpluff-loader
 lib/cpluff/po/POTFILES
 lib/cpluff/stamp-h1
 


### PR DESCRIPTION
With CMake, cpluff is still built in the source directory and we have to ignore a few more files now:
- Ignore dwarf objects files (130d154afdc13101f7265356086beedbdaeb8e7f)
- Ignore cpluff-console and cpluff-loader
