### PR TITLE
[AML] CPU temperature readings for devices with aml_thermal interface

### DIFF
--- a/xbmc/utils/CPUInfo.h
+++ b/xbmc/utils/CPUInfo.h
@@ -111,6 +111,7 @@ private:
   FILE* m_fProcTemperature;
   FILE* m_fCPUFreq;
   bool m_cpuInfoForFreq;
+  bool m_isAmlThermal = false;
 #elif defined(TARGET_WINDOWS)
   PDH_HQUERY m_cpuQueryFreq;
   PDH_HQUERY m_cpuQueryLoad;


### PR DESCRIPTION
Adds correct cpu temp readings for Amlogic devices which have the aml_thermal (AML_PLATFORM_THERMAL) interface enabled in kernel.

It would be great to get some feedback.
