### PR TITLE
Revert "vdpau: refcount decoder with surfaces given to ffmpeg, align with vaa…"

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDPAU.cpp
@@ -112,7 +112,7 @@ void CVDPAUContext::Close()
   DestroyContext();
 }
 
-bool CVDPAUContext::EnsureContext(CVDPAUContext **ctx, CDecoder *decoder)
+bool CVDPAUContext::EnsureContext(CVDPAUContext **ctx)
 {
   CSingleLock lock(m_section);
 
@@ -138,8 +138,6 @@ bool CVDPAUContext::EnsureContext(CVDPAUContext **ctx, CDecoder *decoder)
 
   m_context->m_refCount++;
 
-  if (!m_context->IsValidDecoder(decoder))
-    m_context->m_decoders.push_back(decoder);
   *ctx = m_context;
   return true;
 }
@@ -332,24 +330,6 @@ bool CVDPAUContext::Supports(VdpVideoMixerFeature feature)
   return false;
 }
 
-bool CVDPAUContext::IsValidDecoder(CDecoder *decoder)
-{
-  auto it = find(m_decoders.begin(), m_decoders.end(), decoder);
-  if (it != m_decoders.end())
-    return true;
-
-  return false;
-}
-
-void CVDPAUContext::FFReleaseBuffer(void *opaque, uint8_t *data)
-{
-  CDecoder *vdp = (CDecoder*)opaque;
-  if (m_context && m_context->IsValidDecoder(vdp))
-  {
-    vdp->FFReleaseBuffer(data);
-  }
-}
-
 //-----------------------------------------------------------------------------
 // VDPAU Video Surface states
 //-----------------------------------------------------------------------------
@@ -536,7 +516,7 @@ bool CDecoder::Open(AVCodecContext* avctx, AVCodecContext* mainctx, const enum A
   m_vdpauConfig.numRenderBuffers = surfaces;
   m_decoderThread = CThread::GetCurrentThreadId();
 
-  if (!CVDPAUContext::EnsureContext(&m_vdpauConfig.context, this))
+  if (!CVDPAUContext::EnsureContext(&m_vdpauConfig.context))
     return false;
 
   m_DisplayState = VDPAU_OPEN;
@@ -765,7 +745,7 @@ int CDecoder::Check(AVCodecContext* avctx)
       m_vdpauConfig.context->Release();
     m_vdpauConfig.context = 0;
 
-    if (CVDPAUContext::EnsureContext(&m_vdpauConfig.context, this))
+    if (CVDPAUContext::EnsureContext(&m_vdpauConfig.context))
     {
       m_DisplayState = VDPAU_OPEN;
       m_vdpauConfigured = false;
@@ -1012,7 +992,7 @@ int CDecoder::FFGetBuffer(AVCodecContext *avctx, AVFrame *pic, int flags)
   pic->data[0] = (uint8_t*)(uintptr_t)surf;
   pic->data[3] = (uint8_t*)(uintptr_t)surf;
   pic->linesize[0] = pic->linesize[1] =  pic->linesize[2] = 0;
-  AVBufferRef *buffer = av_buffer_create(pic->data[3], 0, CVDPAUContext::FFReleaseBuffer, ctx, 0);
+  AVBufferRef *buffer = av_buffer_create(pic->data[3], 0, FFReleaseBuffer, ctx, 0);
   if (!buffer)
   {
     CLog::Log(LOGERROR, "CVDPAU::%s - error creating buffer", __FUNCTION__);
@@ -1021,22 +1001,20 @@ int CDecoder::FFGetBuffer(AVCodecContext *avctx, AVFrame *pic, int flags)
   pic->buf[0] = buffer;
 
   pic->reordered_opaque= avctx->reordered_opaque;
-  vdp->Acquire();
   return 0;
 }
 
-void CDecoder::FFReleaseBuffer(uint8_t *data)
+void CDecoder::FFReleaseBuffer(void *opaque, uint8_t *data)
 {
-  {
-    VdpVideoSurface surf;
+  CDecoder *vdp = (CDecoder*)((CDVDVideoCodecFFmpeg*)opaque)->GetHardware();
 
-    CSingleLock lock(m_DecoderSection);
+  VdpVideoSurface surf;
 
-    surf = (VdpVideoSurface)(uintptr_t)data;
-    m_videoSurfaces.ClearReference(surf);
-  }
+  CSingleLock lock(vdp->m_DecoderSection);
 
-  IHardwareDecoder::Release();
+  surf = (VdpVideoSurface)(uintptr_t)data;
+
+  vdp->m_videoSurfaces.ClearReference(surf);
 }
 
 int CDecoder::Render(struct AVCodecContext *s, struct AVFrame *src,

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDPAU.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDPAU.h
@@ -514,14 +514,13 @@ protected:
 class CVDPAUContext
 {
 public:
-  static bool EnsureContext(CVDPAUContext **ctx, CDecoder *decoder);
+  static bool EnsureContext(CVDPAUContext **ctx);
   void Release();
   VDPAU_procs& GetProcs();
   VdpDevice GetDevice();
   bool Supports(VdpVideoMixerFeature feature);
   VdpVideoMixerFeature* GetFeatures();
   int GetFeatureCount();
-  static void FFReleaseBuffer(void *opaque, uint8_t *data);
 private:
   CVDPAUContext();
   void Close();
@@ -530,7 +529,6 @@ private:
   void DestroyContext();
   void QueryProcs();
   void SpewHardwareAvailable();
-  bool IsValidDecoder(CDecoder *decoder);
   static CVDPAUContext *m_context;
   static CCriticalSection m_section;
   static Display *m_display;
@@ -541,7 +539,6 @@ private:
   VdpDevice m_vdpDevice;
   VDPAU_procs m_vdpProcs;
   VdpStatus (*dl_vdp_device_create_x11)(Display* display, int screen, VdpDevice* device, VdpGetProcAddress **get_proc_address);
-  std::vector<CDecoder*> m_decoders;
 };
 
 /**
@@ -583,7 +580,7 @@ public:
   EINTERLACEMETHOD AutoInterlaceMethod();
   static bool IsVDPAUFormat(AVPixelFormat fmt);
 
-  void FFReleaseBuffer(uint8_t *data);
+  static void FFReleaseBuffer(void *opaque, uint8_t *data);
   static int FFGetBuffer(AVCodecContext *avctx, AVFrame *pic, int flags);
   static int Render(struct AVCodecContext *s, struct AVFrame *src,
                     const VdpPictureInfo *info, uint32_t buffers_used,


### PR DESCRIPTION
Reverts xbmc/xbmc#10075

1) mem leak
2) does not fix what it was intended to fix. 
