### PR TITLE
PluginDirectory: dont time out while script is modal/not cancelled

### DIFF
--- a/xbmc/filesystem/PluginDirectory.h
+++ b/xbmc/filesystem/PluginDirectory.h
@@ -22,6 +22,7 @@
 #include "IDirectory.h"
 #include "SortFileItem.h"
 
+#include <atomic>
 #include <string>
 #include <map>
 #include "threads/CriticalSection.h"
@@ -79,7 +80,7 @@ private:
   CFileItem*     m_fileResult;
   CEvent         m_fetchComplete;
 
-  bool          m_cancelled;    // set to true when we are cancelled
+  std::atomic<bool> m_cancelled;
   bool          m_success;      // set by script in EndOfDirectory
   int    m_totalItems;   // set by script in AddDirectoryItem
 


### PR DESCRIPTION
Complete fix for #10080. Nothing in foreground (not just modals) should time out and attempted stopped.

Also, since scripts can end at any time, it should not block the caller for such long time waiting on completion (as it did not do before, so this brings back the old behaviour). 
