### PR TITLE
[cmake/android] Install librtmp

### DIFF
--- a/project/cmake/scripts/android/Install.cmake
+++ b/project/cmake/scripts/android/Install.cmake
@@ -87,6 +87,7 @@ foreach(lib IN LISTS required_dyload dyload_optional ITEMS Shairplay)
   endif()
 endforeach()
 add_bundle_file(${SMBCLIENT_LIBRARY} ${libdir} "")
+add_bundle_file(${DEPENDS_PATH}/lib/librtmp.so ${libdir} "")
 
 # Main targets from Makefile.in
 if(CPU MATCHES i686)


### PR DESCRIPTION
After the removal of RTMP in https://github.com/xbmc/xbmc/pull/10017 the library fails to get packaged for android because it is no more populated in the dyload-libs variables.

As the library is still needed (https://github.com/xbmc/xbmc/pull/10079) we manually add it to the files that we're going to package.

Fixes:
cp: cannot stat 'kodi-build-android/install/lib/librtmp.so': No such file or directory
Makefile:121: recipe for target 'libs' failed

Builds: [Android-ARM](http://jenkins.kodi.tv/job/Android-ARM/8615/), [Android-X86](http://jenkins.kodi.tv/job/Android-X86/7805/)
