### PR TITLE
Smart playlists: fix how song based rules applied to artists and albums lists

### DIFF
--- a/xbmc/dbwrappers/DatabaseQuery.cpp
+++ b/xbmc/dbwrappers/DatabaseQuery.cpp
@@ -333,6 +333,14 @@ std::string CDatabaseQueryRule::GetOperatorString(SEARCH_OPERATOR op) const
   return operatorString;
 }
 
+std::string CDatabaseQueryRule::GetOperatorFormat(const std::string& strType) const
+{
+  SEARCH_OPERATOR op = GetOperator(strType);
+  std::string operatorString = GetOperatorString(op);
+
+  return operatorString;
+}
+
 std::string CDatabaseQueryRule::GetWhereClause(const CDatabase &db, const std::string& strType) const
 {
   SEARCH_OPERATOR op = GetOperator(strType);

--- a/xbmc/dbwrappers/DatabaseQuery.h
+++ b/xbmc/dbwrappers/DatabaseQuery.h
@@ -77,6 +77,7 @@ public:
   void                        SetParameter(const std::vector<std::string> &values);
 
   virtual std::string         GetWhereClause(const CDatabase &db, const std::string& strType) const;
+  virtual std::string         GetOperatorFormat (const std::string& strType) const;
 
   int                         m_field;
   SEARCH_OPERATOR             m_operator;

--- a/xbmc/dialogs/GUIDialogMediaFilter.cpp
+++ b/xbmc/dialogs/GUIDialogMediaFilter.cpp
@@ -100,7 +100,8 @@ static const CGUIDialogMediaFilter::Filter filterList[] = {
   { "artists",      FieldGenre,         515,    SettingTypeList,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
 
   { "albums",       FieldAlbum,         556,    SettingTypeString,  "edit",   "string",   CDatabaseQueryRule::OPERATOR_CONTAINS },
-  { "albums",       FieldArtist,        557,    SettingTypeList,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
+//  { "albums",       FieldArtist,        557,    SettingTypeList,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS }, ####Blake
+  { "albums",       FieldAlbumArtist,   566,    SettingTypeList,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
   { "albums",       FieldRating,        563,    SettingTypeNumber,  "range",  "number",   CDatabaseQueryRule::OPERATOR_BETWEEN },
   { "albums",       FieldUserRating,    38018,  SettingTypeInteger, "range",  "integer",  CDatabaseQueryRule::OPERATOR_BETWEEN },
   { "albums",       FieldAlbumType,     564,    SettingTypeList,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
@@ -680,7 +681,7 @@ int CGUIDialogMediaFilter::GetItems(const Filter &filter, std::vector<std::strin
     
     if (filter.field == FieldGenre)
       musicdb.GetGenresNav(m_dbUrl->ToString(), selectItems, dbfilter, countOnly);
-    else if (filter.field == FieldArtist)
+    else if (filter.field == FieldArtist || filter.field == FieldAlbumArtist)
       musicdb.GetArtistsNav(m_dbUrl->ToString(), selectItems, m_mediaType == "albums", -1, -1, -1, dbfilter, SortDescription(), countOnly);
     else if (filter.field == FieldAlbum)
       musicdb.GetAlbumsNav(m_dbUrl->ToString(), selectItems, -1, -1, dbfilter, SortDescription(), countOnly);

--- a/xbmc/dialogs/GUIDialogMediaFilter.cpp
+++ b/xbmc/dialogs/GUIDialogMediaFilter.cpp
@@ -100,7 +100,7 @@ static const CGUIDialogMediaFilter::Filter filterList[] = {
   { "artists",      FieldGenre,         515,    SettingTypeList,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
 
   { "albums",       FieldAlbum,         556,    SettingTypeString,  "edit",   "string",   CDatabaseQueryRule::OPERATOR_CONTAINS },
-//  { "albums",       FieldArtist,        557,    SettingTypeList,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS }, ####Blake
+//  { "albums",       FieldArtist,        557,    SettingTypeList,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
   { "albums",       FieldAlbumArtist,   566,    SettingTypeList,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
   { "albums",       FieldRating,        563,    SettingTypeNumber,  "range",  "number",   CDatabaseQueryRule::OPERATOR_BETWEEN },
   { "albums",       FieldUserRating,    38018,  SettingTypeInteger, "range",  "integer",  CDatabaseQueryRule::OPERATOR_BETWEEN },
@@ -284,11 +284,6 @@ void CGUIDialogMediaFilter::OnSettingChanged(const CSetting *setting)
         {
           strValueLower = CDateTime(static_cast<time_t>(valueLower)).GetAsDBDate();
           strValueUpper = CDateTime(static_cast<time_t>(valueUpper)).GetAsDBDate();
-        }
-        else if (filter.controlFormat == "time")
-        {
-          strValueLower = CDateTime(static_cast<time_t>(valueLower)).GetAsLocalizedTime("mm:ss");
-          strValueUpper = CDateTime(static_cast<time_t>(valueUpper)).GetAsLocalizedTime("mm:ss");
         }
         else
         {

--- a/xbmc/dialogs/GUIDialogMediaFilter.cpp
+++ b/xbmc/dialogs/GUIDialogMediaFilter.cpp
@@ -469,7 +469,7 @@ void CGUIDialogMediaFilter::InitializeSettings()
 
         // don't create the filter if there's no real range
         if (min == max)
-          break;
+          continue;
 
         int iValueLower = valueLower.isNull() ? min : static_cast<int>(valueLower.asInteger());
         int iValueUpper = valueUpper.isNull() ? max : static_cast<int>(valueUpper.asInteger());
@@ -490,7 +490,7 @@ void CGUIDialogMediaFilter::InitializeSettings()
 
         // don't create the filter if there's no real range
         if (min == max)
-          break;
+          continue;
 
         float fValueLower = valueLower.isNull() ? min : valueLower.asFloat();
         float fValueUpper = valueUpper.isNull() ? max : valueUpper.asFloat();
@@ -797,8 +797,8 @@ void CGUIDialogMediaFilter::GetRange(const Filter &filter, int &min, int &interv
         return;
 
       CDatabase::Filter filter;
-      filter.where = DatabaseUtils::GetField(FieldYear, m_mediaType, DatabaseQueryPartWhere) + " > 0";
-      GetMinMax(table, DatabaseUtils::GetField(FieldYear, m_mediaType, DatabaseQueryPartSelect), min, max, filter);
+      filter.where = DatabaseUtils::GetField(FieldYear, CMediaTypes::FromString(m_mediaType), DatabaseQueryPartWhere) + " > 0";
+      GetMinMax(table, DatabaseUtils::GetField(FieldYear, CMediaTypes::FromString(m_mediaType), DatabaseQueryPartSelect), min, max, filter);
     }
   }
   else if (filter.field == FieldAirDate)

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -6305,13 +6305,13 @@ bool CMusicDatabase::GetFilter(CDbUrl &musicUrl, Filter &filter, SortDescription
       if (CSettings::GetInstance().GetBool(CSettings::SETTING_FILELISTS_IGNORETHEWHENSORTING))
         sorting.sortAttributes = SortAttributeIgnoreArticle;
     }
-    else if (xsp.GetType() == "artists")
+    else if (xsp.GetType() == "artists" || xsp.GetType() == "albums")
     {
-      /* Have navigated down from an "artists" playlist. Any genre, path and role criteria 
-       from this original playlist need to be applied e.g. having previously listed artists
+      /* Have navigated down from an "artists" or "albums" playlist. Any genre, path and artist/role 
+       criteria from the original playlist need to be applied e.g. having previously listed artists
        that composed jazz songs then those are the songs that should play, not all the songs,
        if any, that have this artist as a title artist.
-       Convert the "artists" song based rules to SQL for this type of item e.g. "albums" or "songs".
+       Convert the song based rules from the original list to SQL for this type of item.
       */
       xspSongRulesClause = xsp.GetSongRulesClause(*this, type);
     }

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -3671,11 +3671,13 @@ bool CMusicDatabase::GetCommonNav(const std::string &strBaseDir, const std::stri
       extFilter.order.clear();
     }
     
+    // Do prepare before add where as it could contain a LIKE statement with wild card that upsets format
+    // e.g. LIKE '%symphony%' would be taken as a %s format argument
+    strSQL = PrepareSQL(strSQL, !extFilter.fields.empty() ? extFilter.fields.c_str() : labelField.c_str());
+
     CMusicDbUrl musicUrl;
     if (!BuildSQL(strBaseDir, strSQL, extFilter, strSQL, musicUrl))
       return false;
-    
-    strSQL = PrepareSQL(strSQL, !extFilter.fields.empty() ? extFilter.fields.c_str() : labelField.c_str());
     
     // run query
     CLog::Log(LOGDEBUG, "%s query: %s", __FUNCTION__, strSQL.c_str());

--- a/xbmc/playlists/SmartPlayList.h
+++ b/xbmc/playlists/SmartPlayList.h
@@ -95,10 +95,10 @@ public:
   void AddRule(const CSmartPlaylistRule &rule);
 
   bool HasRuleFields(const std::vector<int> &rulefields, std::set<std::string> &referencedPlaylists) const;
-  std::string GetArtistSongClause(const CDatabase &db, 
-                                  const std::string& strType, 
-                                  std::set<std::string> &referencedPlaylists) const;
-  bool IsArtistSongRule(const int field) const;
+  std::string GetTransSongClause(const CDatabase &db, 
+                                  const std::string& strOrigType, 
+                                  std::set<std::string> &referencedPlaylists,
+                                  const std::string& strType) const;
 };
 
 class CSmartPlaylist : public IDatabaseQueryRuleFactory

--- a/xbmc/playlists/SmartPlayList.h
+++ b/xbmc/playlists/SmartPlayList.h
@@ -95,10 +95,9 @@ public:
   void AddRule(const CSmartPlaylistRule &rule);
 
   bool HasRuleFields(const std::vector<int> &rulefields, std::set<std::string> &referencedPlaylists) const;
-  std::string GetTransSongClause(const CDatabase &db, 
-                                  const std::string& strOrigType, 
-                                  std::set<std::string> &referencedPlaylists,
-                                  const std::string& strType) const;
+  std::string GetTransSongClause(const CDatabase &db, const std::string& strType,  std::set<std::string> &referencedPlaylists,
+    bool albumArtistsOnly = false, int idGenre = -1, int idArtist = -1, int idRole = 1, int idAlbum = -1) const;
+  void AppendRules(CSmartPlaylistRuleCombination &referencedRules);
 };
 
 class CSmartPlaylist : public IDatabaseQueryRuleFactory
@@ -173,9 +172,10 @@ public:
   virtual CDatabaseQueryRuleCombination *CreateCombination() const;
 
   bool HasArtistSongRules() const;
-  std::string GetSongRulesClause(const CDatabase &db, const std::string &type) const;
   bool HasRuleFields(const std::vector<int> &rulefields, std::set<std::string> &referencedPlaylists) const;
   std::string GetArtistSongClause(const CDatabase &db, std::set<std::string> &referencedPlaylists) const;
+  std::string GetSongRulesClause(const CDatabase &db, bool albumArtistsOnly = false, int idGenre = -1, int idArtist = -1, int idRole = 1, int idAlbum = -1) const;
+  void AppendRules(CSmartPlaylist &referencedPlaylist);
 
 private:
   friend class CGUIDialogSmartPlaylistEditor;

--- a/xbmc/playlists/SmartPlayList.h
+++ b/xbmc/playlists/SmartPlayList.h
@@ -93,6 +93,12 @@ public:
                          std::vector<std::string> &virtualFolders) const;
 
   void AddRule(const CSmartPlaylistRule &rule);
+
+  bool HasRuleFields(const std::vector<int> &rulefields, std::set<std::string> &referencedPlaylists) const;
+  std::string GetArtistSongClause(const CDatabase &db, 
+                                  const std::string& strType, 
+                                  std::set<std::string> &referencedPlaylists) const;
+  bool IsArtistSongRule(const int field) const;
 };
 
 class CSmartPlaylist : public IDatabaseQueryRuleFactory
@@ -165,6 +171,12 @@ public:
   // rule creation
   virtual CDatabaseQueryRule *CreateRule() const;
   virtual CDatabaseQueryRuleCombination *CreateCombination() const;
+
+  bool HasArtistSongRules() const;
+  std::string GetSongRulesClause(const CDatabase &db, const std::string &type) const;
+  bool HasRuleFields(const std::vector<int> &rulefields, std::set<std::string> &referencedPlaylists) const;
+  std::string GetArtistSongClause(const CDatabase &db, std::set<std::string> &referencedPlaylists) const;
+
 private:
   friend class CGUIDialogSmartPlaylistEditor;
   friend class CGUIDialogMediaFilter;

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -1896,7 +1896,7 @@ bool CGUIMediaWindow::GetAdvanceFilteredItems(CFileItemList &items)
   std::map<std::string, CFileItemPtr> lookup;
   for (int j = 0; j < resultItems.Size(); j++)
   {
-    std::string itemPath = RemoveParameterFromPath(resultItems[j]->GetPath(), "filter");
+    std::string itemPath = CURL(resultItems[j]->GetPath()).GetWithoutOptions();
     StringUtils::ToLower(itemPath);
 
     lookup[itemPath] = resultItems[j];
@@ -1917,7 +1917,7 @@ bool CGUIMediaWindow::GetAdvanceFilteredItems(CFileItemList &items)
     // check if the item is part of the resultItems list
     // by comparing their paths (but ignoring any special
     // options because they differ from filter to filter)
-    std::string path = RemoveParameterFromPath(item->GetPath(), "filter");
+    std::string path = CURL(item->GetPath()).GetWithoutOptions();
     StringUtils::ToLower(path);
 
     std::map<std::string, CFileItemPtr>::iterator itItem = lookup.find(path);


### PR DESCRIPTION
Since adding role and path rules to "artists" type smart playlists I realised that all the rules based on song criteria e.g. genre, path and role, rather than simply a field in the artist table, need to be combined in SQL rather than left as spearate SQL clauses for each rule.

In logic terms the artists with songs satisfying criteria A and songs satisfying criteria B is not the always same as those artists with songs satisfying criteria A and B.

The effects of this can be seen in Jarvis with an "artists" smart playlist with 2 genre rules: genre = A AND genre = B - what is wanted is all artists with songs that have both genre A and B, what you get is artists that have both at least a song  with genre A and at least a song with genre B. This is not major, but once role and path rule combinations are possible as in v17 then the impact becomes more significant.

Also having selected a playlist of artists using song criteria when that list is played it is the songs that satisfy those criteraia that are wanted. Say for example the artist has some songs of genre Jazz and other songs are Rock. You make a playlist of Jazz artists i.e. artists with songs of genre = Jazz, then currently when you play that list you would get all the songs by that artist rather than just the Jazz ones. Hence song based rules need transfering to filter the subsequent list of albums or songs shown when navigating down from an artist on smart playlist or when playing that list.

This is particularly important when there are role rules e.g. "artist is composer", currently clicking on a composer from such an artist list can result in nothing being displayed despite the fact thay they do compose some songs because the role rule is not passed to the list of albums or artists.
