### PR TITLE
Duplicate include removed

### DIFF
--- a/xbmc/utils/AMLUtils.cpp
+++ b/xbmc/utils/AMLUtils.cpp
@@ -25,7 +25,6 @@
 #include <fcntl.h>
 #include <string>
 
-#include "AMLUtils.h"
 #include "utils/CPUInfo.h"
 #include "utils/log.h"
 #include "utils/SysfsUtils.h"

--- a/xbmc/utils/AMLUtils.cpp
+++ b/xbmc/utils/AMLUtils.cpp
@@ -25,11 +25,11 @@
 #include <fcntl.h>
 #include <string>
 
+#include "AMLUtils.h"
 #include "utils/CPUInfo.h"
 #include "utils/log.h"
 #include "utils/SysfsUtils.h"
 #include "utils/StringUtils.h"
-#include "utils/AMLUtils.h"
 #include "guilib/gui3d.h"
 #include "utils/RegExp.h"
 


### PR DESCRIPTION
The AMLUtils.h was included twice. Don't see a benefit for.

Also <string.h> and <string> are included. Could one of the two statements get removed?
