### PR TITLE
Add ipv6 support to Event Server

### DIFF
--- a/xbmc/network/EventServer.cpp
+++ b/xbmc/network/EventServer.cpp
@@ -153,14 +153,10 @@ void CEventServer::Process()
 
 void CEventServer::Run()
 {
-  CAddress any_addr;
   CSocketListener listener;
   int packetSize = 0;
 
-  if (!CSettings::GetInstance().GetBool(CSettings::SETTING_SERVICES_ESALLINTERFACES))
-    any_addr.SetAddress("127.0.0.1");  // only listen on localhost
-
-  CLog::Log(LOGNOTICE, "ES: Starting UDP Event server on %s:%d", any_addr.Address(), m_iPort);
+  CLog::Log(LOGNOTICE, "ES: Starting UDP Event server on port %d", m_iPort);
 
   Cleanup();
 
@@ -186,7 +182,7 @@ void CEventServer::Run()
     CLog::Log(LOGERROR, "ES: Invalid port range specified %d, defaulting to 10", port_range);
     port_range = 10;
   }
-  if (!m_pSocket->Bind(any_addr, m_iPort, port_range))
+  if (!m_pSocket->Bind(!CSettings::GetInstance().GetBool(CSettings::SETTING_SERVICES_ESALLINTERFACES), m_iPort, port_range))
   {
     CLog::Log(LOGERROR, "ES: Could not listen on port %d", m_iPort);
     return;

--- a/xbmc/network/Socket.cpp
+++ b/xbmc/network/Socket.cpp
@@ -38,13 +38,58 @@ using namespace SOCKETS;
 /* CPosixUDPSocket                                                    */
 /**********************************************************************/
 
-bool CPosixUDPSocket::Bind(CAddress& addr, int port, int range)
+bool CPosixUDPSocket::Bind(bool localOnly, int port, int range)
 {
   // close any existing sockets
   Close();
 
-  // create the socket
-  m_iSock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+  // If we can, create a socket that works with IPv6 and IPv4.
+  // If not, try an IPv4-only socket (we don't want to end up
+  // with an IPv6-only socket).
+  if (!localOnly) // Only bind loopback to ipv4. TODO : Implement dual bindinds.
+  {
+    m_iSock = socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP);
+    if (m_iSock != INVALID_SOCKET)
+    {
+#ifdef WINSOCK_VERSION
+      const char zero = 0;
+#else
+      int zero = 0;
+#endif
+      if (setsockopt(m_iSock, IPPROTO_IPV6, IPV6_V6ONLY, &zero, sizeof(&zero)) == -1)
+      {
+        close(m_iSock);
+        m_iSock = INVALID_SOCKET;
+      }
+      else
+      {
+        m_addr = CAddress("::");
+
+        SOCKET testSocket = socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP);
+        setsockopt(testSocket, IPPROTO_IPV6, IPV6_V6ONLY, &zero, sizeof(&zero));
+        // Try to bind a socket to validate ipv6 status
+        for (m_iPort = port; m_iPort <= port + range; ++m_iPort)
+        {
+          m_addr.saddr.saddr6.sin6_port = htons(port);
+          if (bind(testSocket, (struct sockaddr*)&m_addr.saddr, m_addr.size) >= 0)
+          {
+            closesocket(testSocket);
+            m_ipv6Socket = true;
+            break;
+          }
+        }
+        if (!m_ipv6Socket)
+        {
+          CLog::Log(LOGWARNING, "UDP: Unable to bind to advertised ipv6, fallback to ipv4");
+          close(m_iSock);
+          m_iSock = INVALID_SOCKET;
+        }
+      }
+    }
+  }
+
+  if (m_iSock == INVALID_SOCKET)
+    m_iSock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
 
   if (m_iSock == INVALID_SOCKET)
   {
@@ -52,7 +97,7 @@ bool CPosixUDPSocket::Bind(CAddress& addr, int port, int range)
     int ierr = WSAGetLastError();
     CLog::Log(LOGERROR, "UDP: Could not create socket %d", ierr);
     // hack for broken third party libs
-    if(ierr == WSANOTINITIALISED)
+    if (ierr == WSANOTINITIALISED)
     {
       WSADATA wd;
       if (WSAStartup(MAKEWORD(2,2), &wd) != 0)
@@ -77,24 +122,38 @@ bool CPosixUDPSocket::Bind(CAddress& addr, int port, int range)
     CLog::Log(LOGWARNING, "UDP: %s", strerror(errno));
   }
 
-  // set the port
-  m_addr = addr;
-  m_iPort = port;
-  m_addr.saddr.sin_port = htons(port);
+  // bind to any address or localhost
+  if (m_ipv6Socket)
+  {
+    if (localOnly)
+      m_addr = CAddress("::1");
+    else
+      m_addr = CAddress("::");
+  }
+  else
+  {
+    if (localOnly)
+      m_addr = CAddress("127.0.0.1");
+    else
+      m_addr = CAddress("0.0.0.0");
+  }
 
   // bind the socket ( try from port to port+range )
-  while (m_iPort <= port + range)
+  for (m_iPort = port; m_iPort <= port + range; ++m_iPort)
   {
-    if (bind(m_iSock, (struct sockaddr*)&m_addr.saddr, sizeof(m_addr.saddr)) != 0)
+    if (m_ipv6Socket)
+      m_addr.saddr.saddr6.sin6_port = htons(port);
+    else
+      m_addr.saddr.saddr4.sin_port = htons(port);
+
+    if (bind(m_iSock, (struct sockaddr*)&m_addr.saddr, m_addr.size) != 0)
     {
-      CLog::Log(LOGWARNING, "UDP: Error binding socket on port %d", m_iPort);
+      CLog::Log(LOGWARNING, "UDP: Error binding socket on port %d (ipv6 : %s)", m_iPort, m_ipv6Socket ? "true" : "false" );
       CLog::Log(LOGWARNING, "UDP: %s", strerror(errno));
-      m_iPort++;
-      m_addr.saddr.sin_port = htons(m_iPort);
     }
     else
     {
-      CLog::Log(LOGNOTICE, "UDP: Listening on port %d", m_iPort);
+      CLog::Log(LOGNOTICE, "UDP: Listening on port %d (ipv6 : %s)", m_iPort, m_ipv6Socket ? "true" : "false");
       SetBound();
       SetReady();
       break;
@@ -125,6 +184,8 @@ void CPosixUDPSocket::Close()
 
 int CPosixUDPSocket::Read(CAddress& addr, const int buffersize, void *buffer)
 {
+  if (m_ipv6Socket)
+    addr.SetAddress("::");
   return (int)recvfrom(m_iSock, (char*)buffer, (size_t)buffersize, 0,
                        (struct sockaddr*)&addr.saddr, &addr.size);
 }
@@ -133,8 +194,7 @@ int CPosixUDPSocket::SendTo(const CAddress& addr, const int buffersize,
                           const void *buffer)
 {
   return (int)sendto(m_iSock, (const char *)buffer, (size_t)buffersize, 0,
-                     (const struct sockaddr*)&addr.saddr,
-                     sizeof(addr.saddr));
+                     (const struct sockaddr*)&addr.saddr, addr.size);
 }
 
 /**********************************************************************/


### PR DESCRIPTION
More than inspired by http://trac.kodi.tv/ticket/12491 with some fixes

Use dual stack when possible with fallback to ipv4 if any problem to not end with an ipv6 listener only.

Tested and working on Windows. Needs tests on other platforms.

CC @Montellese / @FernetMenta as I saw some feedback on other ipv6 patch from you.

Had a few report about that missing, and since everything else support ipv6 it should be enabled for event server too.
