### PR TITLE
[darwin] - fix ssl access from python addons

### DIFF
--- a/Kodi.xcodeproj/project.pbxproj
+++ b/Kodi.xcodeproj/project.pbxproj
@@ -814,6 +814,9 @@
 		DF033D381946612400BFC82E /* AEDeviceEnumerationOSX.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF033D361946612400BFC82E /* AEDeviceEnumerationOSX.cpp */; };
 		DF0ABB73183A94A30018445D /* Utf8Utils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF0ABB71183A94A30018445D /* Utf8Utils.cpp */; };
 		DF0ABB74183A94A30018445D /* Utf8Utils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF0ABB71183A94A30018445D /* Utf8Utils.cpp */; };
+		DF0D9F4D1D63931F006A7DBB /* Platform.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF0D9F4B1D63931F006A7DBB /* Platform.cpp */; settings = {COMPILER_FLAGS = "-DPLATFORM_OVERRIDE"; }; };
+		DF0D9F511D63961B006A7DBB /* PlatformDarwinOSX.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF0D9F501D63961B006A7DBB /* PlatformDarwinOSX.cpp */; };
+		DF0D9F551D639898006A7DBB /* PlatformDarwinIOS.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF0D9F531D639893006A7DBB /* PlatformDarwinIOS.cpp */; };
 		DF0DF15C13A3ADA7008ED511 /* NFSDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF0DF15913A3ADA7008ED511 /* NFSDirectory.cpp */; };
 		DF0E4AC51AD597ED00A75430 /* VideoPlayerRadioRDS.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF0E4AC31AD597ED00A75430 /* VideoPlayerRadioRDS.cpp */; };
 		DF0E4AC61AD597ED00A75430 /* VideoPlayerRadioRDS.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF0E4AC31AD597ED00A75430 /* VideoPlayerRadioRDS.cpp */; };
@@ -933,6 +936,7 @@
 		DF89901D1709BB2D00B35C21 /* MediaSourceSettings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF8990181709BB2D00B35C21 /* MediaSourceSettings.cpp */; };
 		DF89901E1709BB2D00B35C21 /* SkinSettings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF89901A1709BB2D00B35C21 /* SkinSettings.cpp */; };
 		DF8990211709BB5400B35C21 /* ViewStateSettings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF89901F1709BB5400B35C21 /* ViewStateSettings.cpp */; };
+		DF8E55971D5F1D7000FD2BA3 /* PlatformDarwin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF8E55951D5F1D7000FD2BA3 /* PlatformDarwin.cpp */; };
 		DF91E9341C0A1C610011084D /* HotKeyController.m in Sources */ = {isa = PBXBuildFile; fileRef = DF91E92A1C0A1C610011084D /* HotKeyController.m */; };
 		DF91E9351C0A1C610011084D /* OSXTextInputResponder.mm in Sources */ = {isa = PBXBuildFile; fileRef = DF91E92E1C0A1C610011084D /* OSXTextInputResponder.mm */; };
 		DF91E9361C0A1C610011084D /* smc.c in Sources */ = {isa = PBXBuildFile; fileRef = DF91E92F1C0A1C610011084D /* smc.c */; };
@@ -3614,6 +3618,10 @@
 		DF033D371946612400BFC82E /* AEDeviceEnumerationOSX.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AEDeviceEnumerationOSX.h; path = Sinks/osx/AEDeviceEnumerationOSX.h; sourceTree = "<group>"; };
 		DF0ABB71183A94A30018445D /* Utf8Utils.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Utf8Utils.cpp; sourceTree = "<group>"; };
 		DF0ABB72183A94A30018445D /* Utf8Utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Utf8Utils.h; sourceTree = "<group>"; };
+		DF0D9F4B1D63931F006A7DBB /* Platform.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Platform.cpp; sourceTree = "<group>"; };
+		DF0D9F4C1D63931F006A7DBB /* Platform.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Platform.h; sourceTree = "<group>"; };
+		DF0D9F501D63961B006A7DBB /* PlatformDarwinOSX.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PlatformDarwinOSX.cpp; sourceTree = "<group>"; };
+		DF0D9F531D639893006A7DBB /* PlatformDarwinIOS.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PlatformDarwinIOS.cpp; sourceTree = "<group>"; };
 		DF0DF15913A3ADA7008ED511 /* NFSDirectory.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = NFSDirectory.cpp; sourceTree = "<group>"; };
 		DF0DF15A13A3ADA7008ED511 /* NFSDirectory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NFSDirectory.h; sourceTree = "<group>"; };
 		DF0E4AC31AD597ED00A75430 /* VideoPlayerRadioRDS.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VideoPlayerRadioRDS.cpp; sourceTree = "<group>"; };
@@ -3842,6 +3850,8 @@
 		DF89901B1709BB2D00B35C21 /* SkinSettings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SkinSettings.h; sourceTree = "<group>"; };
 		DF89901F1709BB5400B35C21 /* ViewStateSettings.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ViewStateSettings.cpp; sourceTree = "<group>"; };
 		DF8990201709BB5400B35C21 /* ViewStateSettings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ViewStateSettings.h; sourceTree = "<group>"; };
+		DF8E55951D5F1D7000FD2BA3 /* PlatformDarwin.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PlatformDarwin.cpp; sourceTree = "<group>"; };
+		DF8E55961D5F1D7000FD2BA3 /* PlatformDarwin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PlatformDarwin.h; sourceTree = "<group>"; };
 		DF91E9291C0A1C610011084D /* HotKeyController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HotKeyController.h; sourceTree = "<group>"; };
 		DF91E92A1C0A1C610011084D /* HotKeyController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HotKeyController.m; sourceTree = "<group>"; };
 		DF91E92B1C0A1C610011084D /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -7107,6 +7117,31 @@
 			path = epg;
 			sourceTree = "<group>";
 		};
+		DF0D9F4E1D63961B006A7DBB /* overrides */ = {
+			isa = PBXGroup;
+			children = (
+				DF0D9F521D639893006A7DBB /* ios */,
+				DF0D9F4F1D63961B006A7DBB /* osx */,
+			);
+			path = overrides;
+			sourceTree = "<group>";
+		};
+		DF0D9F4F1D63961B006A7DBB /* osx */ = {
+			isa = PBXGroup;
+			children = (
+				DF0D9F501D63961B006A7DBB /* PlatformDarwinOSX.cpp */,
+			);
+			path = osx;
+			sourceTree = "<group>";
+		};
+		DF0D9F521D639893006A7DBB /* ios */ = {
+			isa = PBXGroup;
+			children = (
+				DF0D9F531D639893006A7DBB /* PlatformDarwinIOS.cpp */,
+			);
+			path = ios;
+			sourceTree = "<group>";
+		};
 		DF1ACFD015FCE50700E10810 /* generated */ = {
 			isa = PBXGroup;
 			children = (
@@ -7534,9 +7569,12 @@
 		DFD717211C09EDCE0025D964 /* platform */ = {
 			isa = PBXGroup;
 			children = (
+				DF0D9F4E1D63961B006A7DBB /* overrides */,
 				DFD7172E1C09FEC60025D964 /* darwin */,
 				DFD717231C09EDCE0025D964 /* posix */,
 				DFD717221C09EDCE0025D964 /* MessagePrinter.h */,
+				DF0D9F4B1D63931F006A7DBB /* Platform.cpp */,
+				DF0D9F4C1D63931F006A7DBB /* Platform.h */,
 				DF91E9381C0A21D60011084D /* xbmc.cpp */,
 				DF91E9391C0A21D60011084D /* xbmc.h */,
 				DFD7172A1C09F5CF0025D964 /* XbmcContext.cpp */,
@@ -7571,6 +7609,8 @@
 				DF396ED01C42A25F00214C1A /* NSLogDebugHelpers.h */,
 				DFD717341C09FEC60025D964 /* OSXGNUReplacements.c */,
 				DFD717351C09FEC60025D964 /* OSXGNUReplacements.h */,
+				DF8E55951D5F1D7000FD2BA3 /* PlatformDarwin.cpp */,
+				DF8E55961D5F1D7000FD2BA3 /* PlatformDarwin.h */,
 			);
 			path = darwin;
 			sourceTree = "<group>";
@@ -10051,6 +10091,7 @@
 				397877D51AAAF87700F98A45 /* Speed.cpp in Sources */,
 				7C8E02341BA35D0B0072E8B2 /* OpticalBuiltins.cpp in Sources */,
 				68AE5BF51C92431300C4D527 /* EventScanner.cpp in Sources */,
+				DF0D9F4D1D63931F006A7DBB /* Platform.cpp in Sources */,
 				DF29BCF71B5D911800904347 /* MediaLibraryEvent.cpp in Sources */,
 				2F4564D51970129A00396109 /* GUIFontCache.cpp in Sources */,
 				7CEBD8A80F33A0D800CAF6AD /* SpecialProtocolDirectory.cpp in Sources */,
@@ -10232,6 +10273,7 @@
 				18B7C7F91294222E009E7A26 /* TextureGL.cpp in Sources */,
 				18B7C7FA1294222E009E7A26 /* TextureManager.cpp in Sources */,
 				18B7C7FB1294222E009E7A26 /* VisibleEffect.cpp in Sources */,
+				DF8E55971D5F1D7000FD2BA3 /* PlatformDarwin.cpp in Sources */,
 				18B7C7FC1294222E009E7A26 /* XBTF.cpp in Sources */,
 				18B7C7FD1294222E009E7A26 /* XBTFReader.cpp in Sources */,
 				18B7C890129423A7009E7A26 /* MusicInfoTag.cpp in Sources */,
@@ -10664,6 +10706,7 @@
 				7CCDA16B192753E30074CF51 /* PltService.cpp in Sources */,
 				7C2ED53D1C7F7A9800C04032 /* ProcessInfo.cpp in Sources */,
 				7CCDA174192753E30074CF51 /* PltSsdp.cpp in Sources */,
+				DF0D9F511D63961B006A7DBB /* PlatformDarwinOSX.cpp in Sources */,
 				7CCDA17D192753E30074CF51 /* PltStateVariable.cpp in Sources */,
 				7CCDA186192753E30074CF51 /* PltTaskManager.cpp in Sources */,
 				7CCDA18F192753E30074CF51 /* PltThreadTask.cpp in Sources */,
@@ -11117,6 +11160,7 @@
 				E49912BC174E5D9900741B6D /* udf25.cpp in Sources */,
 				E49912BD174E5D9900741B6D /* UDFDirectory.cpp in Sources */,
 				E49912BE174E5D9900741B6D /* UDFFile.cpp in Sources */,
+				DF0D9F551D639898006A7DBB /* PlatformDarwinIOS.cpp in Sources */,
 				E49912BF174E5D9900741B6D /* UPnPDirectory.cpp in Sources */,
 				E49912C0174E5D9900741B6D /* UPnPFile.cpp in Sources */,
 				E49912C1174E5DA000741B6D /* DirectoryNode.cpp in Sources */,

--- a/Makefile.in
+++ b/Makefile.in
@@ -355,6 +355,14 @@ endif
 else
 	$(MAKE) -C tools/EventClients
 endif
+
+certs:
+ifeq ($(findstring osx,@ARCH@), osx)
+	mkdir -p system/certs
+	cp tools/depends/target/openssl/cacert.pem system/certs
+endif
+
+
 libexif: dllloader
 	$(MAKE) -C lib/libexif
 
@@ -365,7 +373,7 @@ libs: $(LIBSSE4) libexif system/libcpluff-@ARCH@.so
 externals: codecs libs libaddon
 
 xcode_depends: \
-	codecs libs eventclients skins libaddon
+	codecs libs eventclients skins libaddon certs
 
 DYNOBJSXBMC= \
 	xbmc/linux/linux.a \

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -458,6 +458,7 @@ bool CApplication::Create()
     g_graphicsContext.ResetOverscan((RESOLUTION)i, CDisplaySettings::GetInstance().GetResolutionInfo(i).Overscan);
   }
 
+  //! @todo - move to CPlatformXXX
 #ifdef TARGET_POSIX
   tzset();   // Initialize timezone information variables
 #endif
@@ -465,6 +466,7 @@ bool CApplication::Create()
   // Grab a handle to our thread to be used later in identifying the render thread.
   m_threadID = CThread::GetCurrentThreadId();
 
+  //! @todo - move to CPlatformXXX
 #ifndef TARGET_POSIX
   //floating point precision to 24 bits (faster performance)
   _controlfp(_PC_24, _MCW_PC);
@@ -474,7 +476,8 @@ bool CApplication::Create()
   win32_exception::install_handler();
 
 #endif
-  
+
+  //! @todo - move to CPlatformXXX
   #if defined(TARGET_POSIX)
     // set special://envhome
     CSpecialProtocol::SetEnvHomePath(getenv("HOME"));
@@ -492,6 +495,7 @@ bool CApplication::Create()
   CopyUserDataIfNeeded("special://masterprofile/", "favourites.xml");
   CopyUserDataIfNeeded("special://masterprofile/", "Lircmap.xml");
   
+  //! @todo - move to CPlatformXXX
   #ifdef TARGET_DARWIN_IOS
     CopyUserDataIfNeeded("special://masterprofile/", "iOS/sources.xml", "sources.xml");
   #endif
@@ -520,6 +524,8 @@ bool CApplication::Create()
   buildType = "Unknown";
 #endif
   std::string specialVersion;
+  
+  //! @todo - move to CPlatformXXX
 #if defined(TARGET_RASPBERRY_PI)
   specialVersion = " (version for Raspberry Pi)";
 //#elif defined(some_ID) // uncomment for special version/fork
@@ -540,6 +546,7 @@ bool CApplication::Create()
     CLog::Log(LOGNOTICE, "Running on %s, kernel: %s %s %d-bit version %s", g_sysinfo.GetOsPrettyNameWithVersion().c_str(),
               g_sysinfo.GetKernelName().c_str(), g_sysinfo.GetKernelCpuFamily().c_str(), g_sysinfo.GetKernelBitness(), g_sysinfo.GetKernelVersionFull().c_str());
 
+  //! @todo - move to CPlatformXXX ???
 #if defined(TARGET_LINUX)
 #if USE_STATIC_FFMPEG
   CLog::Log(LOGNOTICE, "FFmpeg statically linked, version: %s", FFMPEG_VERSION);
@@ -560,6 +567,8 @@ bool CApplication::Create()
     CLog::Log(LOGNOTICE, "Host CPU: %s, %d core%s available", cpuModel.c_str(), g_cpuInfo.getCPUCount(), (g_cpuInfo.getCPUCount() == 1) ? "" : "s");
   else
     CLog::Log(LOGNOTICE, "%d CPU core%s available", g_cpuInfo.getCPUCount(), (g_cpuInfo.getCPUCount() == 1) ? "" : "s");
+  
+  //! @todo - move to CPlatformXXX ???
 #if defined(TARGET_WINDOWS)
   CLog::Log(LOGNOTICE, "%s", CWIN32Util::GetResInfoString().c_str());
   CLog::Log(LOGNOTICE, "Running with %s rights", (CWIN32Util::IsCurrentUserLocalAdministrator() == TRUE) ? "administrator" : "restricted");
@@ -597,6 +606,7 @@ bool CApplication::Create()
   std::string strExecutablePath = CUtil::GetHomePath();
 
   // for python scripts that check the OS
+  //! @todo - move to CPlatformXXX
 #if defined(TARGET_DARWIN)
   setenv("OS","OS X",true);
 #elif defined(TARGET_POSIX)
@@ -652,6 +662,7 @@ bool CApplication::Create()
 
   update_emu_environ();//apply the GUI settings
 
+  //! @todo - move to CPlatformXXX
 #ifdef TARGET_WINDOWS
   CWIN32Util::SetThreadLocalLocale(true); // enable independent locale for each thread, see https://connect.microsoft.com/VisualStudio/feedback/details/794122
 #endif // TARGET_WINDOWS
@@ -693,6 +704,7 @@ bool CApplication::Create()
     return false;
   }
 
+  //! @todo - move to CPlatformXXX
 #if defined(TARGET_DARWIN_OSX)
   // Configure and possible manually start the helper.
   XBMCHelper::GetInstance().Configure();

--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -35,12 +35,16 @@ bool CServiceManager::Init1()
 
   m_XBPython.reset(new XBPython());
   CScriptInvocationManager::GetInstance().RegisterLanguageInvocationHandler(m_XBPython.get(), ".py");
+  
+  m_Platform.reset(CPlatform::CreateInstance());
 
   return true;
 }
 
 bool CServiceManager::Init2()
 {
+  m_Platform->Init();
+  
   m_addonMgr.reset(new ADDON::CAddonMgr());
   if (!m_addonMgr->Init())
   {
@@ -110,6 +114,11 @@ ActiveAE::CActiveAEDSP& CServiceManager::GetADSPManager()
 CDataCacheCore& CServiceManager::GetDataCacheCore()
 {
   return *m_dataCacheCore;
+}
+
+CPlatform& CServiceManager::GetPlatform()
+{
+  return *m_Platform;
 }
 
 // deleters for unique_ptr

--- a/xbmc/ServiceManager.h
+++ b/xbmc/ServiceManager.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <memory>
+#include "platform/Platform.h"
 
 namespace ADDON {
 class CAddonMgr;
@@ -58,6 +59,9 @@ public:
   PVR::CPVRManager& GetPVRManager();
   ActiveAE::CActiveAEDSP& GetADSPManager();
   CDataCacheCore& GetDataCacheCore();
+  /**\brief Get the platform object. This is save to be called after Init1() was called
+   */
+  CPlatform& GetPlatform();
 
 protected:
   struct delete_dataCacheCore
@@ -72,4 +76,5 @@ protected:
   std::unique_ptr<PVR::CPVRManager> m_PVRManager;
   std::unique_ptr<ActiveAE::CActiveAEDSP> m_ADSPManager;
   std::unique_ptr<CDataCacheCore, delete_dataCacheCore> m_dataCacheCore;
+  std::unique_ptr<CPlatform> m_Platform;
 };

--- a/xbmc/interfaces/python/XBPython.cpp
+++ b/xbmc/interfaces/python/XBPython.cpp
@@ -593,9 +593,6 @@ bool XBPython::OnScriptInitialized(ILanguageInvoker *invoker)
     CEnvironment::putenv(buf);
     buf = "OS=win32";
     CEnvironment::putenv(buf);
-
-#elif defined(TARGET_ANDROID)
-   setenv("SSL_CERT_FILE", CSpecialProtocol::TranslatePath("special://xbmc/system/certs/cacert.pem").c_str(), 1);
 #endif
 
     if (PyEval_ThreadsInitialized())

--- a/xbmc/platform/CMakeLists.txt
+++ b/xbmc/platform/CMakeLists.txt
@@ -1,11 +1,13 @@
 file(GLOB OVERRIDES_CPP overrides/${CORE_SYSTEM_NAME}/*.cpp)
 file(GLOB OVERRIDES_H overrides/${CORE_SYSTEM_NAME}/*.h)
 
-set(SOURCES XbmcContext.cpp
+set(SOURCES Platform.cpp
+            XbmcContext.cpp
             xbmc.cpp
             ${OVERRIDES_CPP})
 
 set(HEADERS MessagePrinter.h
+            Platform.h
             xbmc.h
             XbmcContext.h
             ${OVERRIDES_H})

--- a/xbmc/platform/CMakeLists.txt
+++ b/xbmc/platform/CMakeLists.txt
@@ -1,8 +1,17 @@
+file(GLOB OVERRIDES_CPP overrides/${CORE_SYSTEM_NAME}/*.cpp)
+file(GLOB OVERRIDES_H overrides/${CORE_SYSTEM_NAME}/*.h)
+
 set(SOURCES XbmcContext.cpp
-            xbmc.cpp)
+            xbmc.cpp
+            ${OVERRIDES_CPP})
 
 set(HEADERS MessagePrinter.h
             xbmc.h
-            XbmcContext.h)
+            XbmcContext.h
+            ${OVERRIDES_H})
 
 core_add_library(platform_common)
+
+if(OVERRIDES_CPP)
+  target_compile_definitions(${CORE_LIBRARY} PRIVATE -DPLATFORM_OVERRIDE)
+endif()

--- a/xbmc/platform/Makefile.in
+++ b/xbmc/platform/Makefile.in
@@ -1,8 +1,14 @@
 .SUFFIXES : .m .mm .cpp
 
+OVERRIDES = $(wildcard overrides/@CORE_SYSTEM_NAME@/*.cpp) $(wildcard overrides/@CORE_SYSTEM_VARIANT@/*.cpp)
+ifneq ($(strip $(OVERRIDES)),)
+  CXXFLAGS += -DPLATFORM_OVERRIDE
+endif
+  
 SRCS = posix/MessagePrinter.cpp
 SRCS += xbmc.cpp
 SRCS += XbmcContext.cpp
+SRCS += $(OVERRIDES)
 
 ifeq ($(findstring osx,@ARCH@), osx)
 SRCS += darwin/AutoPool.mm

--- a/xbmc/platform/Makefile.in
+++ b/xbmc/platform/Makefile.in
@@ -6,6 +6,7 @@ ifneq ($(strip $(OVERRIDES)),)
 endif
   
 SRCS = posix/MessagePrinter.cpp
+SRCS += Platform.cpp
 SRCS += xbmc.cpp
 SRCS += XbmcContext.cpp
 SRCS += $(OVERRIDES)
@@ -15,6 +16,7 @@ SRCS += darwin/AutoPool.mm
 SRCS += darwin/DarwinUtils.mm
 SRCS += darwin/DictionaryUtils.mm
 SRCS += darwin/DarwinNSUserDefaults.mm
+SRCS += darwin/PlatformDarwin.cpp
 SRCS += darwin/osx/HotKeyController.m
 SRCS += darwin/OSXGNUReplacements.c
 SRCS += darwin/osx/OSXTextInputResponder.mm

--- a/xbmc/platform/Platform.cpp
+++ b/xbmc/platform/Platform.cpp
@@ -1,0 +1,49 @@
+/*
+ *      Copyright (C) 2016 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Kodi; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "Platform.h"
+
+// Override for platform ports
+#if !defined(PLATFORM_OVERRIDE)
+
+CPlatform* CPlatform::CreateInstance()
+{
+  return new CPlatform();
+}
+
+#endif
+
+// base class definitions
+
+CPlatform::CPlatform()
+{
+  
+}
+
+CPlatform::~CPlatform()
+{
+  
+}
+
+void CPlatform::Init()
+{
+  // nothing for now
+}
+

--- a/xbmc/platform/Platform.h
+++ b/xbmc/platform/Platform.h
@@ -1,0 +1,51 @@
+#pragma once
+
+/*
+ *      Copyright (C) 2016 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Kodi; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+/**\brief Class for the Platform object
+ *
+ * Contains method which retrieve platform specific information
+ * and methods for doing platform specific environment preparation/initialisation
+ */
+class CPlatform
+{
+public:
+  /**\brief Creates the Platform object
+   *
+   *@return the platform object 
+  */
+  static CPlatform *CreateInstance();
+  
+  /**\brief C'tor */
+  CPlatform();
+  
+  /**\brief D'tor */
+  virtual ~CPlatform();
+  
+  /**\brief Called at an early stage of application startup
+   *
+   * This method can be used to do platform specific environment preparation
+   * or initialisation (like setting environment variables for example)
+   */
+  virtual void Init();
+  
+};

--- a/xbmc/platform/darwin/CMakeLists.txt
+++ b/xbmc/platform/darwin/CMakeLists.txt
@@ -2,13 +2,15 @@ set(SOURCES AutoPool.mm
             DarwinUtils.mm
             DarwinNSUserDefaults.mm
             DictionaryUtils.mm
-            OSXGNUReplacements.c)
+            OSXGNUReplacements.c
+            PlatformDarwin.cpp)
 
 set(HEADERS AutoPool.h
             DarwinNSUserDefaults.h
             DarwinUtils.h
             DictionaryUtils.h
             NSLogDebugHelpers.h
-            OSXGNUReplacements.h)
+            OSXGNUReplacements.h
+            PlatformDarwin.h)
 
 core_add_library(platform_darwin)

--- a/xbmc/platform/darwin/PlatformDarwin.cpp
+++ b/xbmc/platform/darwin/PlatformDarwin.cpp
@@ -1,0 +1,38 @@
+/*
+ *      Copyright (C) 2016 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Kodi; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "PlatformDarwin.h"
+#include <stdlib.h>
+#include "filesystem/SpecialProtocol.h"
+
+CPlatformDarwin::CPlatformDarwin()
+{
+  
+}
+
+CPlatformDarwin::~CPlatformDarwin()
+{
+  
+}
+
+void CPlatformDarwin::Init()
+{
+    setenv("SSL_CERT_FILE", CSpecialProtocol::TranslatePath("special://xbmc/system/certs/cacert.pem").c_str(), 0);
+}

--- a/xbmc/platform/darwin/PlatformDarwin.h
+++ b/xbmc/platform/darwin/PlatformDarwin.h
@@ -1,0 +1,35 @@
+#pragma once
+
+/*
+ *      Copyright (C) 2016 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Kodi; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "platform/Platform.h"
+
+class CPlatformDarwin : public CPlatform
+{
+  public:
+    /**\brief C'tor */
+    CPlatformDarwin();
+  
+    /**\brief D'tor */
+    virtual ~CPlatformDarwin();
+  
+    void Init() override;
+};

--- a/xbmc/platform/overrides/android/PlatformAndroid.cpp
+++ b/xbmc/platform/overrides/android/PlatformAndroid.cpp
@@ -1,0 +1,43 @@
+/*
+ *      Copyright (C) 2016 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Kodi; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "PlatformAndroid.h"
+#include <stdlib.h>
+#include "filesystem/SpecialProtocol.h"
+
+CPlatform* CPlatform::CreateInstance()
+{
+  return new CPlatformAndroid();
+}
+
+CPlatformAndroid::CPlatformAndroid()
+{
+  
+}
+
+CPlatformAndroid::~CPlatformAndroid()
+{
+  
+}
+
+void CPlatformAndroid::Init()
+{
+    setenv("SSL_CERT_FILE", CSpecialProtocol::TranslatePath("special://xbmc/system/certs/cacert.pem").c_str(), 1);
+}

--- a/xbmc/platform/overrides/android/PlatformAndroid.h
+++ b/xbmc/platform/overrides/android/PlatformAndroid.h
@@ -1,0 +1,35 @@
+#pragma once
+
+/*
+ *      Copyright (C) 2016 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Kodi; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "platform/Platform.h"
+
+class CPlatformAndroid : public CPlatform
+{
+  public:
+    /**\brief C'tor */
+    CPlatformAndroid();
+  
+    /**\brief D'tor */
+    virtual ~CPlatformAndroid();
+  
+    void Init() override;
+};

--- a/xbmc/platform/overrides/ios/PlatformDarwinIOS.cpp
+++ b/xbmc/platform/overrides/ios/PlatformDarwinIOS.cpp
@@ -1,0 +1,28 @@
+/*
+ *      Copyright (C) 2016 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Kodi; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "platform/darwin/PlatformDarwin.h"
+#include <stdlib.h>
+#include "filesystem/SpecialProtocol.h"
+
+CPlatform* CPlatform::CreateInstance()
+{
+  return new CPlatformDarwin();
+}

--- a/xbmc/platform/overrides/osx/PlatformDarwinOSX.cpp
+++ b/xbmc/platform/overrides/osx/PlatformDarwinOSX.cpp
@@ -1,0 +1,28 @@
+/*
+ *      Copyright (C) 2016 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Kodi; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "platform/darwin/PlatformDarwin.h"
+#include <stdlib.h>
+#include "filesystem/SpecialProtocol.h"
+
+CPlatform* CPlatform::CreateInstance()
+{
+  return new CPlatformDarwin();
+}


### PR DESCRIPTION
As pointed out here http://forum.kodi.tv/showthread.php?tid=282604 SSL urls are not working currently from python scripts on all darwin platforms (ios, osx, future tvos).

This PR corrects it by packaging the openssl/cacert.pem and setting the environment variable SSL_CERT_FILE (similar to what is done for android).

@FernetMenta fyi
@fetzerch no clue where to put that Makefile change in the new cmake build sys ... it simply needs to copy the cacert.pem from depends to system/certs ...
