### PR TITLE
MMAL: Move deinterlacer from decoder to renderer

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -189,7 +189,6 @@ enum AVPixelFormat CDVDVideoCodecFFmpeg::GetFormat( struct AVCodecContext * avct
     if (*cur == AV_PIX_FMT_YUV420P)
     {
       MMAL::CDecoder* dec = new MMAL::CDecoder();
-      ctx->m_pCodecContext->hwaccel_context = (void *)ctx->m_options.m_opaque_pointer;
       if(dec->Open(avctx, ctx->m_pCodecContext, *cur, ctx->m_uSurfacesCount))
       {
         ctx->m_processInfo.SetVideoPixelFormat(pixFmtName ? pixFmtName : "");

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
@@ -821,7 +821,7 @@ int CMMALVideo::Decode(uint8_t* pData, int iSize, double dts, double pts)
        if (m_hints.ptsinvalid) buffer->pts = MMAL_TIME_UNKNOWN;
        buffer->length = (uint32_t)iSize > buffer->alloc_size ? buffer->alloc_size : (uint32_t)iSize;
        // set a flag so we can identify primary frames from generated frames (deinterlace)
-       buffer->flags = MMAL_BUFFER_HEADER_FLAG_USER0;
+       buffer->flags = 0;
        if (m_dropState)
          buffer->flags |= MMAL_BUFFER_HEADER_FLAG_USER3;
 
@@ -1078,6 +1078,7 @@ bool CMMALVideo::GetPicture(DVDVideoPicture* pDvdVideoPicture)
           pDvdVideoPicture->dts == DVD_NOPTS_VALUE ? 0.0 : pDvdVideoPicture->dts*1e-6, pDvdVideoPicture->pts == DVD_NOPTS_VALUE ? 0.0 : pDvdVideoPicture->pts*1e-6,
           pDvdVideoPicture->iFlags, buffer->mmal_buffer->flags, pDvdVideoPicture->MMALBuffer, pDvdVideoPicture->MMALBuffer->mmal_buffer);
     assert(!(buffer->mmal_buffer->flags & MMAL_BUFFER_HEADER_FLAG_DECODEONLY));
+    buffer->mmal_buffer->flags &= ~MMAL_BUFFER_HEADER_FLAG_USER3;
   }
   else
   {

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
@@ -254,6 +254,8 @@ void CMMALVideo::dec_output_port_cb(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buf
         omvb->m_aligned_width = m_decoded_aligned_width;
         omvb->m_aligned_height = m_decoded_aligned_height;
         omvb->m_aspect_ratio = m_aspect_ratio;
+        if (m_hints.stills) // disable interlace in dvd stills mode
+          omvb->mmal_buffer->flags &= ~MMAL_BUFFER_HEADER_VIDEO_FLAG_INTERLACED;
         omvb->m_encoding = m_dec_output->format->encoding;
         {
           CSingleLock lock(m_output_mutex);

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
@@ -805,13 +805,14 @@ int CMMALVideo::Decode(uint8_t* pData, int iSize, double dts, double pts)
      {
        // 500ms timeout
        {
-         CSingleExit unlock(m_sharedSection);
+         lock.Leave();
          buffer = mmal_queue_timedwait(m_dec_input_pool->queue, 500);
          if (!buffer)
          {
            CLog::Log(LOGERROR, "%s::%s - mmal_queue_get failed", CLASSNAME, __func__);
            return VC_ERROR;
          }
+         lock.Enter();
        }
        mmal_buffer_header_reset(buffer);
        buffer->cmd = 0;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
@@ -102,7 +102,6 @@ CMMALVideo::CMMALVideo(CProcessInfo &processInfo) : CDVDVideoCodec(processInfo)
   m_dec_input = NULL;
   m_dec_output = NULL;
   m_dec_input_pool = NULL;
-  m_renderer = NULL;
   m_pool = nullptr;
 
   m_codingType = 0;
@@ -366,7 +365,6 @@ bool CMMALVideo::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
   m_processInfo.SetVideoDeintMethod("none");
 
   m_hints = hints;
-  m_renderer = (CMMALRenderer *)options.m_opaque_pointer;
   MMAL_STATUS_T status;
 
   m_decoded_width = hints.width;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.h
@@ -42,6 +42,9 @@
 #include "cores/VideoPlayer/VideoRenderers/BaseRenderer.h"
 #include "cores/VideoPlayer/DVDResource.h"
 
+
+enum MMALState { MMALStateNone, MMALStateHWDec, MMALStateFFDec, MMALStateDeint, };
+
 // a mmal video frame
 class CMMALBuffer : public IDVDResourceCounted<CMMALBuffer>
 {
@@ -52,7 +55,17 @@ public:
   unsigned int m_height;
   unsigned int m_aligned_width;
   unsigned int m_aligned_height;
+  uint32_t m_encoding;
   float m_aspect_ratio;
+  MMALState m_state;
+  bool m_rendered;
+  const char *GetStateName() {
+    static const char *names[] = { "MMALStateNone", "MMALStateHWDec", "MMALStateFFDec", "MMALStateDeint", };
+    if ((size_t)m_state < vcos_countof(names))
+      return names[(size_t)m_state];
+    else
+      return "invalid";
+  }
 };
 
 class CMMALVideo;
@@ -63,9 +76,11 @@ class CMMALPool;
 class CMMALVideoBuffer : public CMMALBuffer
 {
 public:
-  CMMALVideoBuffer(CMMALVideo *omv);
+  CMMALVideoBuffer(CMMALVideo *dec, std::shared_ptr<CMMALPool> pool);
   virtual ~CMMALVideoBuffer();
   CMMALVideo *m_omv;
+protected:
+  std::shared_ptr<CMMALPool> m_pool;
 };
 
 class CMMALVideo : public CDVDVideoCodec
@@ -88,16 +103,12 @@ public:
   virtual void SetSpeed(int iSpeed);
 
   // MMAL decoder callback routines.
-  void Recycle(MMAL_BUFFER_HEADER_T *buffer);
-
-  // MMAL decoder callback routines.
   void dec_output_port_cb(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer);
   void dec_control_port_cb(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer);
   void dec_input_port_cb(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer);
 
 protected:
   void QueryCodec(void);
-  void Prime();
   void Dispose(void);
 
   // Video format

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.h
@@ -97,8 +97,6 @@ public:
 
 protected:
   void QueryCodec(void);
-  bool CreateDeinterlace(EINTERLACEMETHOD interlace_method);
-  bool DestroyDeinterlace();
   void Prime();
   void Dispose(void);
 
@@ -127,7 +125,6 @@ protected:
   unsigned          m_num_decoded;
   // Components
   MMAL_INTERLACETYPE_T m_interlace_mode;
-  EINTERLACEMETHOD  m_interlace_method;
   double            m_demuxerPts;
   double            m_decoderPts;
   int               m_speed;
@@ -147,8 +144,6 @@ protected:
   std::shared_ptr<CMMALPool> m_pool;
 
   MMAL_ES_FORMAT_T *m_es_format;
-  MMAL_COMPONENT_T *m_deint;
-  MMAL_CONNECTION_T *m_deint_connection;
 
   MMAL_FOURCC_T m_codingType;
   bool change_dec_output_format();

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.h
@@ -151,7 +151,6 @@ protected:
   MMAL_PORT_T *m_dec_input;
   MMAL_PORT_T *m_dec_output;
   MMAL_POOL_T *m_dec_input_pool;
-  CMMALRenderer *m_renderer;
   std::shared_ptr<CMMALPool> m_pool;
 
   MMAL_ES_FORMAT_T *m_es_format;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALFFmpeg.cpp
@@ -223,11 +223,7 @@ bool CDecoder::Open(AVCodecContext *avctx, AVCodecContext* mainctx, enum AVPixel
 {
   CSingleLock lock(m_section);
 
-  m_renderer = (CMMALRenderer *)mainctx->hwaccel_context;
-
-  CLog::Log(LOGNOTICE, "%s::%s - m_renderer:%p", CLASSNAME, __FUNCTION__, m_renderer);
-  assert(m_renderer);
-  mainctx->hwaccel_context = nullptr;
+  CLog::Log(LOGNOTICE, "%s::%s - fmt:%d", CLASSNAME, __FUNCTION__, fmt);
 
   if (surfaces > m_shared)
     m_shared = surfaces;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALFFmpeg.h
@@ -70,7 +70,6 @@ protected:
   AVCodecContext *m_avctx;
   unsigned int m_shared;
   CCriticalSection m_section;
-  CMMALRenderer *m_renderer;
   std::shared_ptr<CMMALPool> m_pool;
   enum AVPixelFormat m_fmt;
 };

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALFFmpeg.h
@@ -34,17 +34,18 @@ class CGPUMEM;
 namespace MMAL {
 
 class CDecoder;
+class CGPUPool;
 
 // a mmal video frame
 class CMMALYUVBuffer : public CMMALBuffer
 {
 public:
-  CMMALYUVBuffer(CDecoder *dec, unsigned int width, unsigned int height, unsigned int aligned_width, unsigned int aligned_height);
+  CMMALYUVBuffer(std::shared_ptr<CMMALPool> pool, uint32_t mmal_encoding, uint32_t width, uint32_t height, uint32_t aligned_width, uint32_t aligned_height, uint32_t size);
   virtual ~CMMALYUVBuffer();
 
   CGPUMEM *gmem;
 private:
-  CDecoder *m_dec;
+  std::shared_ptr<CMMALPool> m_pool;
 };
 
 class CDecoder
@@ -65,21 +66,13 @@ public:
   static void FFReleaseBuffer(void *opaque, uint8_t *data);
   static int FFGetBuffer(AVCodecContext *avctx, AVFrame *pic, int flags);
 
-  static void AlignedSize(AVCodecContext *avctx, int &w, int &h);
-  CMMALYUVBuffer *GetBuffer(unsigned int width, unsigned int height, AVCodecContext *avctx);
-  CGPUMEM *AllocateBuffer(unsigned int numbytes);
-  void ReleaseBuffer(CGPUMEM *gmem);
-  unsigned sizeFree() { return m_freeBuffers.size(); }
-  enum AVPixelFormat m_fmt;
 protected:
-  MMAL_BUFFER_HEADER_T *GetMmal();
   AVCodecContext *m_avctx;
   unsigned int m_shared;
   CCriticalSection m_section;
   CMMALRenderer *m_renderer;
   std::shared_ptr<CMMALPool> m_pool;
-  std::deque<CGPUMEM *> m_freeBuffers;
-  bool m_closing;
+  enum AVPixelFormat m_fmt;
 };
 
 };

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.cpp
@@ -35,19 +35,227 @@
 #include "xbmc/Application.h"
 #include "linux/RBP.h"
 
-#define CLASSNAME "CMMALRenderer"
+extern "C" {
+#include "libavutil/imgutils.h"
+}
 
 #define VERBOSE 0
 
-std::shared_ptr<CMMALPool> CMMALRenderer::GetPool(ERenderFormat format, AVPixelFormat pixfmt, bool opaque)
-{
-  CSingleLock lock(m_sharedSection);
-  bool formatChanged = m_format != format || m_opaque != opaque;
-  if (!m_bMMALConfigured || formatChanged)
-    m_bMMALConfigured = init_vout(format, pixfmt, opaque);
+#undef CLASSNAME
+#define CLASSNAME "CMMALPool"
 
-  return m_vout_input_pool;
+CMMALPool::CMMALPool(const char *component_name, bool input, uint32_t num_buffers, uint32_t buffer_size, uint32_t encoding, MMALState state)
+ :  m_input(input)
+{
+  MMAL_STATUS_T status;
+
+  status = mmal_component_create(component_name, &m_component);
+  if (status != MMAL_SUCCESS)
+    CLog::Log(LOGERROR, "%s::%s Failed to create component %s", CLASSNAME, __func__, component_name);
+
+  MMAL_PORT_T *port = m_input ? m_component->input[0] : m_component->output[0];
+
+  // set up initial decoded frame format - may change from this
+  port->format->encoding = encoding;
+
+  status = mmal_port_parameter_set_boolean(port, MMAL_PARAMETER_ZERO_COPY, MMAL_TRUE);
+  if (status != MMAL_SUCCESS)
+    CLog::Log(LOGERROR, "%s::%s Failed to enable zero copy mode on %s (status=%x %s)", CLASSNAME, __func__, port->name, status, mmal_status_to_string(status));
+
+  status = mmal_port_format_commit(port);
+  if (status != MMAL_SUCCESS)
+    CLog::Log(LOGERROR, "%s::%s Failed to commit format for %s (status=%x %s)", CLASSNAME, __func__, port->name, status, mmal_status_to_string(status));
+
+  port->buffer_size = buffer_size;
+  port->buffer_num = std::max(num_buffers, port->buffer_num_recommended);
+
+  m_mmal_pool = mmal_port_pool_create(port, port->buffer_num, port->buffer_size);
+  m_closing = false;
+  m_mmal_format = 0;
+  m_width = 0;
+  m_height = 0;
+  m_aligned_width = 0;
+  m_aligned_height = 0;
+  m_avctx = nullptr;
+  m_dec = nullptr;
+  m_state = state;
+  if (!m_mmal_pool)
+    CLog::Log(LOGERROR, "%s::%s Failed to create pool for port %s", CLASSNAME, __func__, port->name);
+  else
+    CLog::Log(LOGDEBUG, "%s::%s Created pool %p of size %d x %d for port %s", CLASSNAME, __func__, m_mmal_pool, num_buffers, buffer_size, port->name);
 }
+
+CMMALPool::~CMMALPool()
+{
+  MMAL_STATUS_T status;
+
+  MMAL_PORT_T *port = m_input ? m_component->input[0] : m_component->output[0];
+  CLog::Log(LOGDEBUG, "%s::%s Destroying pool %p for port %s", CLASSNAME, __func__, m_mmal_pool, port->name);
+
+  if (port && port->is_enabled)
+  {
+    status = mmal_port_disable(port);
+    if (status != MMAL_SUCCESS)
+       CLog::Log(LOGERROR, "%s::%s Failed to disable port %s (status=%x %s)", CLASSNAME, __func__, port->name, status, mmal_status_to_string(status));
+  }
+
+  if (m_component && m_component->is_enabled)
+  {
+    status = mmal_component_disable(m_component);
+    if (status != MMAL_SUCCESS)
+      CLog::Log(LOGERROR, "%s::%s Failed to disable component %s (status=%x %s)", CLASSNAME, __func__, m_component->name, status, mmal_status_to_string(status));
+  }
+
+  if (m_component)
+    mmal_component_destroy(m_component);
+  m_component = nullptr;
+
+  mmal_port_pool_destroy(port, m_mmal_pool);
+  m_mmal_pool = nullptr;
+  Close();
+}
+
+void CMMALPool::Close()
+{
+  CSingleLock lock(m_section);
+
+  if (g_advancedSettings.CanLogComponent(LOGVIDEO))
+    CLog::Log(LOGDEBUG, "%s::%s - close %p", CLASSNAME, __FUNCTION__, m_mmal_pool);
+
+  m_closing = true;
+  while (!m_freeBuffers.empty())
+  {
+    CGPUMEM *gmem = m_freeBuffers.front();
+    m_freeBuffers.pop_front();
+    delete gmem;
+  }
+  assert(m_freeBuffers.empty());
+}
+
+CGPUMEM *CMMALPool::AllocateBuffer(uint32_t size_pic)
+{
+  CSingleLock lock(m_section);
+  CGPUMEM *gmem = nullptr;
+  while (!m_freeBuffers.empty())
+  {
+    gmem = m_freeBuffers.front();
+    m_freeBuffers.pop_front();
+    if (gmem->m_numbytes == size_pic)
+      return gmem;
+    if (g_advancedSettings.CanLogComponent(LOGVIDEO))
+      CLog::Log(LOGDEBUG, "%s::%s discarding gmem:%p size %d/%d", CLASSNAME, __FUNCTION__, gmem, gmem->m_numbytes, size_pic);
+    delete gmem;
+  }
+
+  gmem = new CGPUMEM(size_pic, true);
+  if (!gmem)
+    CLog::Log(LOGERROR, "%s::%s GCPUMEM(%d) failed", CLASSNAME, __FUNCTION__, size_pic);
+  return gmem;
+}
+
+void CMMALPool::ReleaseBuffer(CGPUMEM *gmem)
+{
+  CSingleLock lock(m_section);
+  if (m_closing)
+    delete gmem;
+  else
+    m_freeBuffers.push_back(gmem);
+}
+
+void CMMALPool::AlignedSize(AVCodecContext *avctx, uint32_t &width, uint32_t &height)
+{
+  if (!avctx)
+    return;
+  int w = width, h = height;
+  AVFrame picture;
+  int unaligned;
+  int stride_align[AV_NUM_DATA_POINTERS];
+
+  avcodec_align_dimensions2(avctx, &w, &h, stride_align);
+  // gpu requirements
+  w = (w + 31) & ~31;
+  h = (h + 15) & ~15;
+
+  do {
+    // NOTE: do not align linesizes individually, this breaks e.g. assumptions
+    // that linesize[0] == 2*linesize[1] in the MPEG-encoder for 4:2:2
+    av_image_fill_linesizes(picture.linesize, avctx->pix_fmt, w);
+    // increase alignment of w for next try (rhs gives the lowest bit set in w)
+    w += w & ~(w - 1);
+
+    unaligned = 0;
+    for (int i = 0; i < 4; i++)
+      unaligned |= picture.linesize[i] % stride_align[i];
+  } while (unaligned);
+  width = w;
+  height = h;
+}
+
+CMMALBuffer *CMMALPool::GetBuffer(uint32_t timeout)
+{
+  MMAL_BUFFER_HEADER_T *mmal_buffer = nullptr;
+  CMMALBuffer *omvb = nullptr;
+  if (m_mmal_pool && m_mmal_pool->queue)
+    mmal_buffer = mmal_queue_timedwait(m_mmal_pool->queue, timeout);
+  if (mmal_buffer)
+  {
+    mmal_buffer_header_reset(mmal_buffer);
+    mmal_buffer->cmd = 0;
+    mmal_buffer->offset = 0;
+    mmal_buffer->flags = 0;
+
+    // ffmpeg requirements
+    uint32_t aligned_width = m_aligned_width, aligned_height = m_aligned_height;
+    AlignedSize(m_avctx, aligned_width, aligned_height);
+    if (m_dec)
+    {
+      CMMALVideoBuffer *vid = new CMMALVideoBuffer(m_dec, shared_from_this());
+      omvb = vid;
+    }
+    else
+    {
+      MMAL::CMMALYUVBuffer *yuv = new MMAL::CMMALYUVBuffer(shared_from_this(), m_mmal_format, m_width, m_height, aligned_width, aligned_height, m_size);
+      if (yuv)
+      {
+        CGPUMEM *gmem = yuv->gmem;
+        mmal_buffer->data = (uint8_t *)gmem->m_vc_handle;
+        mmal_buffer->alloc_size = gmem->m_numbytes;
+      }
+      omvb = yuv;
+    }
+    if (omvb)
+    {
+      omvb->m_rendered = false;
+      omvb->m_state = m_state;
+      mmal_buffer->user_data = omvb;
+      omvb->mmal_buffer = mmal_buffer;
+    }
+  }
+  if (timeout > 0 && (!omvb || !omvb->mmal_buffer))
+    CLog::Log(LOGERROR, "%s::%s - failed pool:%p omvb:%p mmal:%p timeout:%d", CLASSNAME, __FUNCTION__, m_mmal_pool, omvb, mmal_buffer, timeout);
+  else if (VERBOSE && g_advancedSettings.CanLogComponent(LOGVIDEO))
+    CLog::Log(LOGDEBUG, "%s::%s - pool:%p omvb:%p mmal:%p timeout:%d", CLASSNAME, __FUNCTION__, m_mmal_pool, omvb, mmal_buffer, timeout);
+  return omvb;
+}
+
+void CMMALPool::Prime()
+{
+  CMMALBuffer *omvb;
+  if (!m_mmal_pool || !m_component)
+    return;
+  MMAL_PORT_T *port = m_input ? m_component->input[0] : m_component->output[0];
+  while (omvb = GetBuffer(0), omvb)
+  {
+    if (VERBOSE && g_advancedSettings.CanLogComponent(LOGVIDEO))
+      CLog::Log(LOGDEBUG, "%s::%s Send buffer %p from pool %p to %s len:%d cmd:%x flags:%x", CLASSNAME, __func__, omvb->mmal_buffer, m_mmal_pool, port->name, omvb->mmal_buffer->length, omvb->mmal_buffer->cmd, omvb->mmal_buffer->flags);
+    MMAL_STATUS_T status = mmal_port_send_buffer(port, omvb->mmal_buffer);
+    if (status != MMAL_SUCCESS)
+      CLog::Log(LOGERROR, "%s::%s - Failed to send buffer %p from pool %p to %s (status=0%x %s)", CLASSNAME, __func__, omvb->mmal_buffer, m_mmal_pool, port->name, status, mmal_status_to_string(status));
+  }
+}
+
+#undef CLASSNAME
+#define CLASSNAME "CMMALRenderer"
 
 CRenderInfo CMMALRenderer::GetRenderInfo()
 {
@@ -67,12 +275,10 @@ CRenderInfo CMMALRenderer::GetRenderInfo()
 void CMMALRenderer::vout_input_port_cb(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer)
 {
   assert(!(buffer->flags & MMAL_BUFFER_HEADER_FLAG_TRANSMISSION_FAILED));
-  buffer->flags &= ~MMAL_BUFFER_HEADER_FLAG_USER2;
   CMMALBuffer *omvb = (CMMALBuffer *)buffer->user_data;
   if (VERBOSE && g_advancedSettings.CanLogComponent(LOGVIDEO))
-    CLog::Log(LOGDEBUG, "%s::%s port:%p omvb:%p mmal:%p:%p len:%d cmd:%x flags:%x flight:%d", CLASSNAME, __func__, port, omvb, buffer, omvb->mmal_buffer, buffer->length, buffer->cmd, buffer->flags, m_inflight);
+    CLog::Log(LOGDEBUG, "%s::%s port:%p omvb:%p mmal:%p:%p len:%d cmd:%x flags:%x", CLASSNAME, __func__, port, omvb, buffer, omvb->mmal_buffer, buffer->length, buffer->cmd, buffer->flags);
   assert(buffer == omvb->mmal_buffer);
-  m_inflight--;
   omvb->Release();
 }
 
@@ -82,140 +288,105 @@ static void vout_input_port_cb_static(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *b
   mmal->vout_input_port_cb(port, buffer);
 }
 
-static struct {
-   uint32_t encoding;
-   AVPixelFormat pixfmt;
-} pixfmt_to_encoding_table[] =
+bool CMMALRenderer::CheckConfigurationVout(uint32_t width, uint32_t height, uint32_t aligned_width, uint32_t aligned_height, uint32_t encoding)
 {
-   {MMAL_ENCODING_I420,    AV_PIX_FMT_YUV420P},
-   {MMAL_ENCODING_I422,    AV_PIX_FMT_YUV422P},
-   {MMAL_ENCODING_I420,    AV_PIX_FMT_YUVJ420P}, // FIXME
-   {MMAL_ENCODING_I422,    AV_PIX_FMT_YUVJ422P}, // FIXME
-   {MMAL_ENCODING_RGB16,   AV_PIX_FMT_RGB565},
-   {MMAL_ENCODING_RGB16,   AV_PIX_FMT_RGB565LE},
-   {MMAL_ENCODING_BGR16,   AV_PIX_FMT_BGR565},
-   {MMAL_ENCODING_RGB24,   AV_PIX_FMT_RGB24},
-   {MMAL_ENCODING_BGR24,   AV_PIX_FMT_BGR24},
-   {MMAL_ENCODING_ARGB,    AV_PIX_FMT_ARGB},
-   {MMAL_ENCODING_RGBA,    AV_PIX_FMT_RGBA},
-   {MMAL_ENCODING_ABGR,    AV_PIX_FMT_ABGR},
-   {MMAL_ENCODING_BGRA,    AV_PIX_FMT_BGRA},
-   {MMAL_ENCODING_BGRA,    AV_PIX_FMT_BGR0},
-   {MMAL_ENCODING_UNKNOWN, AV_PIX_FMT_NONE}
-};
-
-static uint32_t pixfmt_to_encoding(AVPixelFormat pixfmt)
-{
-  unsigned int i;
-  for (i = 0; pixfmt_to_encoding_table[i].encoding != MMAL_ENCODING_UNKNOWN; i++)
-    if (pixfmt_to_encoding_table[i].pixfmt == pixfmt)
-      break;
-  return pixfmt_to_encoding_table[i].encoding;
-}
-
-CMMALPool::CMMALPool(MMAL_PORT_T *input, uint32_t num_buffers, uint32_t buffer_size)
-{
-  m_input = input;
-  m_pool = mmal_port_pool_create(input, num_buffers, buffer_size);
-  if (!m_pool)
-    CLog::Log(LOGERROR, "%s::%s Failed to create pool for decoder input port", CLASSNAME, __func__);
-  else
-    CLog::Log(LOGDEBUG, "%s::%s Created pool %p of size %d x %d", CLASSNAME, __func__, m_pool, num_buffers, buffer_size);
-}
-
-CMMALPool::~CMMALPool()
-{
-  CLog::Log(LOGDEBUG, "%s::%s destroying pool (%p)", CLASSNAME, __func__, m_pool);
-  mmal_port_pool_destroy(m_input, m_pool);
-  m_pool = nullptr;
-  m_input = nullptr;
-}
-
-bool CMMALRenderer::init_vout(ERenderFormat format, AVPixelFormat pixfmt, bool opaque)
-{
-  CSingleLock lock(m_sharedSection);
-  bool formatChanged = m_format != format || m_opaque != opaque || m_pixfmt != pixfmt;
   MMAL_STATUS_T status;
-  uint32_t encoding = pixfmt_to_encoding(pixfmt);
+  bool sizeChanged = width != m_vout_width || height != m_vout_height || aligned_width != m_vout_aligned_width || aligned_height != m_vout_aligned_height;
+  bool encodingChanged = !m_vout_input || !m_vout_input->format || encoding != m_vout_input->format->encoding;
 
-  CLog::Log(LOGDEBUG, "%s::%s configured:%d format %d->%d pixfmt %x->%x opaque %d->%d", CLASSNAME, __func__, m_bConfigured, m_format, format, m_pixfmt, pixfmt, m_opaque, opaque);
-
-  if (m_bMMALConfigured && formatChanged)
-    UnInitMMAL();
-
-  if (m_bMMALConfigured || format == RENDER_FMT_BYPASS)
-    return true;
-
-  if (format != RENDER_FMT_MMAL || encoding == MMAL_ENCODING_UNKNOWN)
+  if (!m_vout)
   {
-    CLog::Log(LOGERROR, "%s::%s Unsupported format", CLASSNAME, __func__);
-    return false;
+    /* Create video renderer */
+    if (g_advancedSettings.CanLogComponent(LOGVIDEO))
+      CLog::Log(LOGDEBUG, "%s::%s CreateRenderer", CLASSNAME, __func__);
+
+    status = mmal_component_create(MMAL_COMPONENT_DEFAULT_VIDEO_RENDERER, &m_vout);
+    if(status != MMAL_SUCCESS)
+    {
+      CLog::Log(LOGERROR, "%s::%s Failed to create vout component (status=%x %s)", CLASSNAME, __func__, status, mmal_status_to_string(status));
+      return false;
+    }
+
+    m_vout_input = m_vout->input[0];
+
+    status = mmal_port_parameter_set_boolean(m_vout_input, MMAL_PARAMETER_ZERO_COPY, MMAL_TRUE);
+    if (status != MMAL_SUCCESS)
+       CLog::Log(LOGERROR, "%s::%s Failed to enable zero copy mode on %s (status=%x %s)", CLASSNAME, __func__, m_vout_input->name, status, mmal_status_to_string(status));
+
+    m_vout_input->format->type = MMAL_ES_TYPE_VIDEO;
+    if (CONF_FLAGS_YUVCOEF_MASK(m_iFlags) == CONF_FLAGS_YUVCOEF_BT709)
+      m_vout_input->format->es->video.color_space = MMAL_COLOR_SPACE_ITUR_BT709;
+    else if (CONF_FLAGS_YUVCOEF_MASK(m_iFlags) == CONF_FLAGS_YUVCOEF_BT601)
+      m_vout_input->format->es->video.color_space = MMAL_COLOR_SPACE_ITUR_BT601;
+    else if (CONF_FLAGS_YUVCOEF_MASK(m_iFlags) == CONF_FLAGS_YUVCOEF_240M)
+      m_vout_input->format->es->video.color_space = MMAL_COLOR_SPACE_SMPTE240M;
   }
 
-  m_format = format;
-  m_pixfmt = pixfmt;
-  m_opaque = opaque;
-
-  /* Create video renderer */
-  status = mmal_component_create(MMAL_COMPONENT_DEFAULT_VIDEO_RENDERER, &m_vout);
-  if(status != MMAL_SUCCESS)
+  if (m_vout_input && (sizeChanged || encodingChanged))
   {
-    CLog::Log(LOGERROR, "%s::%s Failed to create vout component (status=%x %s)", CLASSNAME, __func__, status, mmal_status_to_string(status));
-    return false;
+    assert(m_vout_input != nullptr && m_vout_input->format != nullptr && m_vout_input->format->es != nullptr);
+    CLog::Log(LOGDEBUG, "%s::%s Changing Vout dimensions from %dx%d (%dx%d) to %dx%d (%dx%d) %.4s", CLASSNAME, __func__,
+        m_vout_input->format->es->video.crop.width, m_vout_input->format->es->video.crop.height,
+        m_vout_input->format->es->video.width, m_vout_input->format->es->video.height, width, height, aligned_width, aligned_height, (char *)&encoding);
+
+    // we need to disable port when encoding changes, but not if just resolution changes
+    if (encodingChanged && m_vout_input->is_enabled)
+    {
+      status = mmal_port_disable(m_vout_input);
+      if (status != MMAL_SUCCESS)
+      {
+        CLog::Log(LOGERROR, "%s::%s Failed to disable vout input port (status=%x %s)", CLASSNAME, __func__, status, mmal_status_to_string(status));
+        return false;
+      }
+    }
+
+    m_vout_width = width;
+    m_vout_height = height;
+    m_vout_aligned_width = aligned_width;
+    m_vout_aligned_height = aligned_height;
+
+    m_vout_input->format->es->video.crop.width = width;
+    m_vout_input->format->es->video.crop.height = height;
+    m_vout_input->format->es->video.width = aligned_width;
+    m_vout_input->format->es->video.height = aligned_height;
+    m_vout_input->format->encoding = encoding;
+
+    status = mmal_port_format_commit(m_vout_input);
+    if (status != MMAL_SUCCESS)
+    {
+      CLog::Log(LOGERROR, "%s::%s Failed to commit vout input format (status=%x %s)", CLASSNAME, __func__, status, mmal_status_to_string(status));
+      return false;
+    }
+
+    if (!m_vout_input->is_enabled)
+    {
+      m_vout_input->buffer_num = MMAL_NUM_OUTPUT_BUFFERS;
+      m_vout_input->buffer_size = m_vout_input->buffer_size_recommended;
+      m_vout_input->userdata = (struct MMAL_PORT_USERDATA_T *)this;
+
+      status = mmal_port_enable(m_vout_input, vout_input_port_cb_static);
+      if (status != MMAL_SUCCESS)
+      {
+        CLog::Log(LOGERROR, "%s::%s Failed to enable vout input port (status=%x %s)", CLASSNAME, __func__, status, mmal_status_to_string(status));
+        return false;
+      }
+    }
   }
 
-  m_vout_input = m_vout->input[0];
-  m_vout_input->userdata = (struct MMAL_PORT_USERDATA_T *)this;
-  MMAL_ES_FORMAT_T *es_format = m_vout_input->format;
-
-  es_format->type = MMAL_ES_TYPE_VIDEO;
-  if (CONF_FLAGS_YUVCOEF_MASK(m_iFlags) == CONF_FLAGS_YUVCOEF_BT709)
-    es_format->es->video.color_space = MMAL_COLOR_SPACE_ITUR_BT709;
-  else if (CONF_FLAGS_YUVCOEF_MASK(m_iFlags) == CONF_FLAGS_YUVCOEF_BT601)
-    es_format->es->video.color_space = MMAL_COLOR_SPACE_ITUR_BT601;
-  else if (CONF_FLAGS_YUVCOEF_MASK(m_iFlags) == CONF_FLAGS_YUVCOEF_240M)
-    es_format->es->video.color_space = MMAL_COLOR_SPACE_SMPTE240M;
-
-  es_format->es->video.crop.width = m_sourceWidth;
-  es_format->es->video.crop.height = m_sourceHeight;
-  es_format->es->video.width = m_sourceWidth;
-  es_format->es->video.height = m_sourceHeight;
-
-  es_format->encoding = m_opaque ? MMAL_ENCODING_OPAQUE : encoding;
-
-  status = mmal_port_parameter_set_boolean(m_vout_input, MMAL_PARAMETER_ZERO_COPY,  MMAL_TRUE);
-  if (status != MMAL_SUCCESS)
-     CLog::Log(LOGERROR, "%s::%s Failed to enable zero copy mode on %s (status=%x %s)", CLASSNAME, __func__, m_vout_input->name, status, mmal_status_to_string(status));
-
-  status = mmal_port_format_commit(m_vout_input);
-  if (status != MMAL_SUCCESS)
+  if (m_vout && !m_vout->is_enabled)
   {
-    CLog::Log(LOGERROR, "%s::%s Failed to commit vout input format (status=%x %s)", CLASSNAME, __func__, status, mmal_status_to_string(status));
-    return false;
-  }
+    status = mmal_component_enable(m_vout);
+    if(status != MMAL_SUCCESS)
+    {
+      CLog::Log(LOGERROR, "%s::%s Failed to enable vout component (status=%x %s)", CLASSNAME, __func__, status, mmal_status_to_string(status));
+      return false;
+    }
 
-  m_vout_input->buffer_num = std::max(m_vout_input->buffer_num_recommended, (uint32_t)m_NumYV12Buffers+(m_opaque?0:32));
-  m_vout_input->buffer_size = m_vout_input->buffer_size_recommended;
-
-  status = mmal_port_enable(m_vout_input, vout_input_port_cb_static);
-  if(status != MMAL_SUCCESS)
-  {
-    CLog::Log(LOGERROR, "%s::%s Failed to vout enable input port (status=%x %s)", CLASSNAME, __func__, status, mmal_status_to_string(status));
-    return false;
-  }
-
-  status = mmal_component_enable(m_vout);
-  if(status != MMAL_SUCCESS)
-  {
-    CLog::Log(LOGERROR, "%s::%s Failed to enable vout component (status=%x %s)", CLASSNAME, __func__, status, mmal_status_to_string(status));
-    return false;
-  }
-
-  m_vout_input_pool = std::make_shared<CMMALPool>(m_vout_input, m_vout_input->buffer_num, m_opaque ? m_vout_input->buffer_size:0);
-  if (!CSettings::GetInstance().GetBool("videoplayer.usedisplayasclock"))
-  {
-    m_queue = mmal_queue_create();
-    Create();
+    if (!m_queue && !CSettings::GetInstance().GetBool("videoplayer.usedisplayasclock"))
+    {
+      m_queue = mmal_queue_create();
+      Create();
+    }
   }
   return true;
 }
@@ -225,19 +396,18 @@ CMMALRenderer::CMMALRenderer() : CThread("MMALRenderer")
   CLog::Log(LOGDEBUG, "%s::%s", CLASSNAME, __func__);
   m_vout = NULL;
   m_vout_input = NULL;
-  m_vout_input_pool = NULL;
   memset(m_buffers, 0, sizeof m_buffers);
   m_iFlags = 0;
   m_format = RENDER_FMT_NONE;
-  m_pixfmt = AV_PIX_FMT_YUV420P;
-  m_opaque = true;
   m_bConfigured = false;
-  m_bMMALConfigured = false;
   m_iYV12RenderBuffer = 0;
-  m_inflight = 0;
   m_queue = nullptr;
   m_error = 0.0;
   m_vsync_count = ~0U;
+  m_vout_width = 0;
+  m_vout_height = 0;
+  m_vout_aligned_width = 0;
+  m_vout_aligned_height = 0;
 }
 
 CMMALRenderer::~CMMALRenderer()
@@ -250,9 +420,10 @@ CMMALRenderer::~CMMALRenderer()
 
 void CMMALRenderer::Process()
 {
+  bool bStop = false;
   SetPriority(THREAD_PRIORITY_ABOVE_NORMAL);
   CLog::Log(LOGDEBUG, "%s::%s - starting", CLASSNAME, __func__);
-  while (!m_bStop)
+  while (!bStop)
   {
     g_RBP.WaitVsync();
     double dfps = g_graphicsContext.GetFPS();
@@ -267,11 +438,12 @@ void CMMALRenderer::Process()
       if (m_error > 1.0)
         m_error -= 1.0;
       MMAL_BUFFER_HEADER_T *buffer = mmal_queue_get(m_queue);
-      if (buffer)
+      if (buffer == &m_quitpacket)
+        bStop = true;
+      else if (buffer)
       {
         CMMALBuffer *omvb = (CMMALBuffer *)buffer->user_data;
         assert(buffer == omvb->mmal_buffer);
-        m_inflight--;
         omvb->Release();
         if (g_advancedSettings.CanLogComponent(LOGVIDEO))
           CLog::Log(LOGDEBUG, "%s::%s - discard buffer:%p vsync:%d queue:%d diff:%f", CLASSNAME, __func__, buffer, g_RBP.LastVsync(), mmal_queue_length(m_queue), m_error);
@@ -282,7 +454,9 @@ void CMMALRenderer::Process()
     {
       m_error -= 1.0;
       MMAL_BUFFER_HEADER_T *buffer = mmal_queue_get(m_queue);
-      if (buffer)
+      if (buffer == &m_quitpacket)
+        bStop = true;
+      else if (buffer)
         mmal_port_send_buffer(m_vout_input, buffer);
       if (g_advancedSettings.CanLogComponent(LOGVIDEO))
         CLog::Log(LOGDEBUG, "%s::%s - buffer:%p vsync:%d queue:%d diff:%f", CLASSNAME, __func__, buffer, g_RBP.LastVsync(), mmal_queue_length(m_queue), m_error);
@@ -335,10 +509,9 @@ bool CMMALRenderer::Configure(unsigned int width, unsigned int height, unsigned 
   SetViewMode(CMediaSettings::GetInstance().GetCurrentVideoSettings().m_ViewMode);
   ManageRenderArea();
 
-  m_bMMALConfigured = init_vout(format, m_pixfmt, m_opaque);
-  m_bConfigured = m_bMMALConfigured;
-  assert(m_bConfigured);
-  return m_bConfigured;
+  m_format = format;
+  m_bConfigured = true;
+  return true;
 }
 
 int CMMALRenderer::GetImage(YV12Image *image, int source, bool readonly)
@@ -346,18 +519,18 @@ int CMMALRenderer::GetImage(YV12Image *image, int source, bool readonly)
   if (!image || source < 0 || m_format != RENDER_FMT_MMAL)
   {
     if (g_advancedSettings.CanLogComponent(LOGVIDEO))
-      CLog::Log(LOGDEBUG, "%s::%s - invalid: format:%d image:%p source:%d ro:%d flight:%d", CLASSNAME, __func__, m_format, image, source, readonly, m_inflight);
+      CLog::Log(LOGDEBUG, "%s::%s - invalid: format:%d image:%p source:%d ro:%d", CLASSNAME, __func__, m_format, image, source, readonly);
     return -1;
   }
   if (g_advancedSettings.CanLogComponent(LOGVIDEO))
-    CLog::Log(LOGDEBUG, "%s::%s - MMAL: image:%p source:%d ro:%d flight:%d", CLASSNAME, __func__, image, source, readonly, m_inflight);
+    CLog::Log(LOGDEBUG, "%s::%s - MMAL: image:%p source:%d ro:%d", CLASSNAME, __func__, image, source, readonly);
   return source;
 }
 
 void CMMALRenderer::ReleaseBuffer(int idx)
 {
   CSingleLock lock(m_sharedSection);
-  if (!m_bMMALConfigured || m_format != RENDER_FMT_MMAL)
+  if (m_format != RENDER_FMT_MMAL)
   {
     if (g_advancedSettings.CanLogComponent(LOGVIDEO))
       CLog::Log(LOGDEBUG, "%s::%s - not configured: source:%d", CLASSNAME, __func__, idx);
@@ -366,7 +539,7 @@ void CMMALRenderer::ReleaseBuffer(int idx)
 
   CMMALBuffer *omvb = m_buffers[idx];
   if (VERBOSE && g_advancedSettings.CanLogComponent(LOGVIDEO))
-    CLog::Log(LOGDEBUG, "%s::%s - MMAL: source:%d omvb:%p mmal:%p flight:%d", CLASSNAME, __func__, idx, omvb, omvb ? omvb->mmal_buffer:NULL, m_inflight);
+    CLog::Log(LOGDEBUG, "%s::%s - MMAL: source:%d omvb:%p mmal:%p", CLASSNAME, __func__, idx, omvb, omvb ? omvb->mmal_buffer:NULL);
   if (omvb)
     SAFE_RELEASE(m_buffers[idx]);
 }
@@ -411,7 +584,7 @@ void CMMALRenderer::RenderUpdate(bool clear, DWORD flags, DWORD alpha)
     omvb = m_buffers[source];
 
   // we only want to upload frames once
-  if (omvb && omvb->mmal_buffer && omvb->mmal_buffer->flags & MMAL_BUFFER_HEADER_FLAG_USER1)
+  if (omvb && omvb->m_rendered)
   {
     if (g_advancedSettings.CanLogComponent(LOGVIDEO))
       CLog::Log(LOGDEBUG, "%s::%s - MMAL: clear:%d flags:%x alpha:%d source:%d omvb:%p mmal:%p mflags:%x skipping", CLASSNAME, __func__, clear, flags, alpha, source, omvb, omvb->mmal_buffer, omvb->mmal_buffer->flags);
@@ -431,30 +604,12 @@ void CMMALRenderer::RenderUpdate(bool clear, DWORD flags, DWORD alpha)
   if (omvb && omvb->mmal_buffer)
   {
     if (g_advancedSettings.CanLogComponent(LOGVIDEO))
-      CLog::Log(LOGDEBUG, "%s::%s - MMAL: clear:%d flags:%x alpha:%d source:%d omvb:%p mmal:%p mflags:%x", CLASSNAME, __func__, clear, flags, alpha, source, omvb, omvb->mmal_buffer, omvb->mmal_buffer->flags);
-    // check for changes in aligned sizes
-    if (omvb->m_width != (uint32_t)m_vout_input->format->es->video.crop.width || omvb->m_height != (uint32_t)m_vout_input->format->es->video.crop.height ||
-        omvb->m_aligned_width != m_vout_input->format->es->video.width || omvb->m_aligned_height != m_vout_input->format->es->video.height)
-    {
-      CLog::Log(LOGDEBUG, "%s::%s Changing dimensions from %dx%d (%dx%d) to %dx%d (%dx%d)", CLASSNAME, __func__,
-          m_vout_input->format->es->video.crop.width, m_vout_input->format->es->video.crop.height, omvb->m_width, omvb->m_height,
-          m_vout_input->format->es->video.width, m_vout_input->format->es->video.height, omvb->m_aligned_width, omvb->m_aligned_height);
-      m_vout_input->format->es->video.width = omvb->m_aligned_width;
-      m_vout_input->format->es->video.height = omvb->m_aligned_height;
-      m_vout_input->format->es->video.crop.width = omvb->m_width;
-      m_vout_input->format->es->video.crop.height = omvb->m_height;
-      MMAL_STATUS_T status = mmal_port_format_commit(m_vout_input);
-      if (status != MMAL_SUCCESS)
-      {
-        CLog::Log(LOGERROR, "%s::%s Failed to commit vout input format (status=%x %s)", CLASSNAME, __func__, status, mmal_status_to_string(status));
-        goto exit;
-      }
-    }
-    m_inflight++;
+      CLog::Log(LOGDEBUG, "%s::%s - MMAL: clear:%d flags:%x alpha:%d source:%d omvb:%p mmal:%p mflags:%x encoding:%.4s", CLASSNAME, __func__, clear, flags, alpha, source, omvb, omvb->mmal_buffer, omvb->mmal_buffer->flags, (char *)&omvb->m_encoding);
+    CheckConfigurationVout(omvb->m_width, omvb->m_height, omvb->m_aligned_width, omvb->m_aligned_height, omvb->m_encoding);
     assert(omvb->mmal_buffer && omvb->mmal_buffer->data && omvb->mmal_buffer->length);
     omvb->Acquire();
-    omvb->mmal_buffer->flags |= MMAL_BUFFER_HEADER_FLAG_USER1 | MMAL_BUFFER_HEADER_FLAG_USER2;
-    omvb->mmal_buffer->user_data = omvb;
+    omvb->m_rendered = true;
+    assert(omvb->mmal_buffer->user_data == omvb);
     if (m_queue && m_fps > 0.0f)
       mmal_queue_put(m_queue, omvb->mmal_buffer);
     else
@@ -521,14 +676,7 @@ void CMMALRenderer::ReleaseBuffers()
 
 void CMMALRenderer::UnInitMMAL()
 {
-  CSingleLock lock(m_sharedSection);
-  CLog::Log(LOGDEBUG, "%s::%s pool(%p)", CLASSNAME, __func__, m_vout_input_pool ? m_vout_input_pool->Get() : nullptr);
-  if (m_queue)
-  {
-    StopThread(true);
-    mmal_queue_destroy(m_queue);
-    m_queue = nullptr;
-  }
+  CLog::Log(LOGDEBUG, "%s::%s", CLASSNAME, __func__);
   if (m_vout)
   {
     mmal_component_disable(m_vout);
@@ -542,7 +690,19 @@ void CMMALRenderer::UnInitMMAL()
 
   ReleaseBuffers();
 
-  m_vout_input_pool = NULL;
+  if (m_queue)
+    mmal_queue_put(m_queue, &m_quitpacket);
+
+  {
+    // leave the lock to allow other threads to exit
+    CSingleExit unlock(m_sharedSection);
+    if (m_queue)
+      StopThread(true);
+  }
+
+  if (m_queue)
+    mmal_queue_destroy(m_queue);
+  m_queue = nullptr;
 
   m_vout_input = NULL;
 
@@ -557,15 +717,18 @@ void CMMALRenderer::UnInitMMAL()
   m_video_stereo_mode = RENDER_STEREO_MODE_OFF;
   m_display_stereo_mode = RENDER_STEREO_MODE_OFF;
   m_StereoInvert = false;
-  m_format = RENDER_FMT_NONE;
-
-  m_bConfigured = false;
-  m_bMMALConfigured = false;
+  m_vout_width = 0;
+  m_vout_height = 0;
+  m_vout_aligned_width = 0;
+  m_vout_aligned_height = 0;
 }
 
 void CMMALRenderer::UnInit()
 {
+  CSingleLock lock(m_sharedSection);
+  m_bConfigured = false;
   UnInitMMAL();
+  m_format = RENDER_FMT_NONE;
 }
 
 bool CMMALRenderer::RenderCapture(CRenderCapture* capture)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.cpp
@@ -407,6 +407,13 @@ CMMALRenderer::CMMALRenderer() : CThread("MMALRenderer"), m_processThread(this, 
   m_vout_height = 0;
   m_vout_aligned_width = 0;
   m_vout_aligned_height = 0;
+  m_deint = NULL;
+  m_deint_input = NULL;
+  m_deint_output = NULL;
+  m_deint_width = 0;
+  m_deint_height = 0;
+  m_deint_aligned_width = 0;
+  m_deint_aligned_height = 0;
 
   m_queue_process = mmal_queue_create();
   m_processThread.Create();
@@ -490,6 +497,7 @@ void CMMALRenderer::Run()
   CLog::Log(LOGDEBUG, "%s::%s - starting", CLASSNAME, __func__);
   while (1)
   {
+    bool prime = false;
     MMAL_BUFFER_HEADER_T *buffer = mmal_queue_wait(m_queue_process);
     assert(buffer);
     if (buffer == &m_quitpacket)
@@ -513,7 +521,37 @@ void CMMALRenderer::Run()
     {
       if (buffer->length > 0)
       {
-        if (m_queue_render)
+        EDEINTERLACEMODE deinterlace_request = CMediaSettings::GetInstance().GetCurrentVideoSettings().m_DeinterlaceMode;
+        EINTERLACEMETHOD interlace_method = CMediaSettings::GetInstance().GetCurrentVideoSettings().m_InterlaceMethod;
+        if (interlace_method == VS_INTERLACEMETHOD_AUTO)
+          interlace_method = AutoInterlaceMethod();
+        bool interlace = (omvb->mmal_buffer->flags & MMAL_BUFFER_HEADER_VIDEO_FLAG_INTERLACED) ? true:false;
+        // we don't keep up when running at 60fps in the background so switch to half rate
+        if (!g_graphicsContext.IsFullScreenVideo())
+        {
+          if (interlace_method == VS_INTERLACEMETHOD_MMAL_ADVANCED)
+            interlace_method = VS_INTERLACEMETHOD_MMAL_ADVANCED_HALF;
+          if (interlace_method == VS_INTERLACEMETHOD_MMAL_BOB)
+            interlace_method = VS_INTERLACEMETHOD_MMAL_BOB_HALF;
+        }
+
+        if (deinterlace_request == VS_DEINTERLACEMODE_OFF || interlace_method == VS_INTERLACEMETHOD_NONE)
+        {
+          if (m_deint_input)
+            DestroyDeinterlace();
+        }
+        else if (m_deint_input || deinterlace_request == VS_DEINTERLACEMODE_FORCE || (deinterlace_request == VS_DEINTERLACEMODE_AUTO && interlace))
+          CheckConfigurationDeint(omvb->m_width, omvb->m_height, omvb->m_aligned_width, omvb->m_aligned_height, omvb->m_encoding, interlace_method);
+
+        if (m_deint_input)
+        {
+          MMAL_STATUS_T status = mmal_port_send_buffer(m_deint_input, omvb->mmal_buffer);
+          if (status != MMAL_SUCCESS)
+            CLog::Log(LOGERROR, "%s::%s - Failed to send buffer %p to %s (status=0%x %s)", CLASSNAME, __func__, omvb->mmal_buffer, m_deint_input->name, status, mmal_status_to_string(status));
+          else
+            kept = true;
+        }
+        else if (m_queue_render)
         {
           mmal_queue_put(m_queue_render, omvb->mmal_buffer);
           kept = true;
@@ -521,12 +559,45 @@ void CMMALRenderer::Run()
         else
         {
           CheckConfigurationVout(omvb->m_width, omvb->m_height, omvb->m_aligned_width, omvb->m_aligned_height, omvb->m_encoding);
-          MMAL_STATUS_T status = mmal_port_send_buffer(m_vout_input, omvb->mmal_buffer);
-          if (status != MMAL_SUCCESS)
-            CLog::Log(LOGERROR, "%s::%s - Failed to send buffer %p to %s (status=0%x %s)", CLASSNAME, __func__, omvb->mmal_buffer, m_vout_input->name, status, mmal_status_to_string(status));
-          else
-            kept = true;
+          if (m_vout_input)
+          {
+            MMAL_STATUS_T status = mmal_port_send_buffer(m_vout_input, omvb->mmal_buffer);
+            if (status != MMAL_SUCCESS)
+              CLog::Log(LOGERROR, "%s::%s - Failed to send buffer %p to %s (status=0%x %s)", CLASSNAME, __func__, omvb->mmal_buffer, m_vout_input->name, status, mmal_status_to_string(status));
+            else
+              kept = true;
+          }
         }
+      }
+      break;
+    }
+    case MMALStateDeint:
+    {
+      if (buffer->length > 0)
+      {
+        if (m_queue_render)
+        {
+          mmal_queue_put(m_queue_render, buffer);
+          CLog::Log(LOGDEBUG, "%s::%s send %p to m_queue_render", CLASSNAME, __func__, omvb);
+          kept = true;
+        }
+        else
+        {
+          CheckConfigurationVout(omvb->m_width, omvb->m_height, omvb->m_aligned_width, omvb->m_aligned_height, omvb->m_encoding);
+          if (m_vout_input)
+          {
+            CLog::Log(LOGDEBUG, "%s::%s send %p to m_vout_input", CLASSNAME, __func__, omvb);
+            MMAL_STATUS_T status = mmal_port_send_buffer(m_vout_input, buffer);
+            if (status != MMAL_SUCCESS)
+              CLog::Log(LOGERROR, "%s::%s - Failed to send buffer %p to %s (status=0%x %s)", CLASSNAME, __func__, buffer, m_vout_input->name, status, mmal_status_to_string(status));
+            else
+              kept = true;
+          }
+        }
+      }
+      else
+      {
+        prime = true;
       }
       break;
     }
@@ -546,6 +617,8 @@ void CMMALRenderer::Run()
         mmal_buffer_header_release(buffer);
       }
     }
+    if (prime && m_deint_output_pool)
+     m_deint_output_pool->Prime();
   }
   CLog::Log(LOGDEBUG, "%s::%s - stopping", CLASSNAME, __func__);
 }
@@ -688,6 +761,10 @@ void CMMALRenderer::RenderUpdate(bool clear, DWORD flags, DWORD alpha)
 
   if (omvb && omvb->mmal_buffer)
   {
+    if (flags & RENDER_FLAG_TOP)
+      omvb->mmal_buffer->flags |= MMAL_BUFFER_HEADER_VIDEO_FLAG_INTERLACED | MMAL_BUFFER_HEADER_VIDEO_FLAG_TOP_FIELD_FIRST;
+    else if (flags & RENDER_FLAG_BOT)
+      omvb->mmal_buffer->flags |= MMAL_BUFFER_HEADER_VIDEO_FLAG_INTERLACED;
     if (g_advancedSettings.CanLogComponent(LOGVIDEO))
       CLog::Log(LOGDEBUG, "%s::%s - MMAL: clear:%d flags:%x alpha:%d source:%d omvb:%p mmal:%p mflags:%x encoding:%.4s", CLASSNAME, __func__, clear, flags, alpha, source, omvb, omvb->mmal_buffer, omvb->mmal_buffer->flags, (char *)&omvb->m_encoding);
     assert(omvb->mmal_buffer && omvb->mmal_buffer->data && omvb->mmal_buffer->length);
@@ -807,6 +884,7 @@ void CMMALRenderer::UnInit()
 {
   CSingleLock lock(m_sharedSection);
   m_bConfigured = false;
+  DestroyDeinterlace();
   UnInitMMAL();
   m_format = RENDER_FMT_NONE;
 }
@@ -1011,4 +1089,238 @@ void CMMALRenderer::SetVideoRect(const CRect& InSrcRect, const CRect& InDestRect
   CLog::Log(LOGDEBUG, "%s::%s %d,%d,%d,%d -> %d,%d,%d,%d t:%x", CLASSNAME, __func__,
       region.src_rect.x, region.src_rect.y, region.src_rect.width, region.src_rect.height,
       region.dest_rect.x, region.dest_rect.y, region.dest_rect.width, region.dest_rect.height, region.transform);
+}
+
+void CMMALRenderer::deint_input_port_cb(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer)
+{
+  if (VERBOSE && g_advancedSettings.CanLogComponent(LOGVIDEO))
+    CLog::Log(LOGDEBUG, "%s::%s omvb:%p mmal:%p dts:%.3f pts:%.3f len:%d cmd:%x flags:%x", CLASSNAME, __func__,
+        buffer->user_data, buffer, buffer->dts*1e-6, buffer->pts*1e-6, buffer->length, buffer->cmd, buffer->flags);
+  mmal_queue_put(m_queue_process, buffer);
+}
+
+static void deint_input_port_cb_static(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer)
+{
+  CMMALRenderer *mmal = reinterpret_cast<CMMALRenderer*>(port->userdata);
+  mmal->deint_input_port_cb(port, buffer);
+}
+
+void CMMALRenderer::deint_output_port_cb(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer)
+{
+  if (VERBOSE && g_advancedSettings.CanLogComponent(LOGVIDEO))
+    CLog::Log(LOGDEBUG, "%s::%s omvb:%p mmal:%p dts:%.3f pts:%.3f len:%d cmd:%x flags:%x", CLASSNAME, __func__,
+        buffer->user_data, buffer, buffer->dts*1e-6, buffer->pts*1e-6, buffer->length, buffer->cmd, buffer->flags);
+  mmal_queue_put(m_queue_process, buffer);
+}
+
+static void deint_output_port_cb_static(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer)
+{
+  CMMALRenderer *mmal = reinterpret_cast<CMMALRenderer*>(port->userdata);
+  mmal->deint_output_port_cb(port, buffer);
+}
+
+void CMMALRenderer::DestroyDeinterlace()
+{
+  MMAL_STATUS_T status;
+
+  if (g_advancedSettings.CanLogComponent(LOGVIDEO))
+    CLog::Log(LOGDEBUG, "%s::%s", CLASSNAME, __func__);
+
+  // (lazily) destroy pool first so new buffers aren't allocated when flushing
+  m_deint_output_pool = nullptr;
+
+  if (m_deint_input && m_deint_input->is_enabled)
+  {
+    status = mmal_port_disable(m_deint_input);
+    if (status != MMAL_SUCCESS)
+      CLog::Log(LOGERROR, "%s::%s Failed to disable deinterlace input port(status=%x %s)", CLASSNAME, __func__, status, mmal_status_to_string(status));
+  }
+  m_deint_input = nullptr;
+  if (m_deint_output && m_deint_output->is_enabled)
+  {
+    status = mmal_port_disable(m_deint_output);
+    if (status != MMAL_SUCCESS)
+      CLog::Log(LOGERROR, "%s::%s Failed to disable deinterlace output port(status=%x %s)", CLASSNAME, __func__, status, mmal_status_to_string(status));
+  }
+  m_deint_output = nullptr;
+  m_interlace_method = VS_INTERLACEMETHOD_NONE;
+  m_deint_width = 0;
+  m_deint_height = 0;
+  m_deint_aligned_width = 0;
+  m_deint_aligned_height = 0;
+  m_deint = nullptr;
+}
+
+bool CMMALRenderer::CheckConfigurationDeint(uint32_t width, uint32_t height, uint32_t aligned_width, uint32_t aligned_height, uint32_t encoding, EINTERLACEMETHOD interlace_method)
+{
+  MMAL_STATUS_T status;
+  bool sizeChanged = width != m_deint_width || height != m_deint_height || aligned_width != m_deint_aligned_width || aligned_height != m_deint_aligned_height;
+  bool deinterlaceChanged = interlace_method != m_interlace_method;
+  bool encodingChanged = !m_deint_input || !m_deint_input->format || m_deint_input->format->encoding != encoding;
+  bool advanced_deinterlace = interlace_method == VS_INTERLACEMETHOD_MMAL_ADVANCED || interlace_method == VS_INTERLACEMETHOD_MMAL_ADVANCED_HALF;
+  bool half_framerate = interlace_method == VS_INTERLACEMETHOD_MMAL_ADVANCED_HALF || interlace_method == VS_INTERLACEMETHOD_MMAL_BOB_HALF;
+
+  if (!m_bConfigured)
+  {
+    CLog::Log(LOGDEBUG, "%s::%s Unconfigured", CLASSNAME, __func__);
+    return false;
+  }
+
+  if (!m_deint)
+  {
+    if (g_advancedSettings.CanLogComponent(LOGVIDEO))
+      CLog::Log(LOGDEBUG, "%s::%s CreateDeinterlace", CLASSNAME, __func__);
+
+    /* Create deinterlace component with attached pool */
+    m_deint_output_pool = std::make_shared<CMMALPool>("vc.ril.image_fx", false, 3, 0, MMAL_ENCODING_I420, MMALStateDeint);
+    if (!m_deint_output_pool)
+    {
+      CLog::Log(LOGERROR, "%s::%s Failed to create pool for deint output", CLASSNAME, __func__);
+      return false;
+    }
+
+    m_deint = m_deint_output_pool->GetComponent();
+    m_deint_output = m_deint->output[0];
+    m_deint_input = m_deint->input[0];
+
+    status = mmal_port_parameter_set_boolean(m_deint_input, MMAL_PARAMETER_ZERO_COPY, MMAL_TRUE);
+    if (status != MMAL_SUCCESS)
+      CLog::Log(LOGERROR, "%s::%s Failed to enable zero copy mode on %s (status=%x %s)", CLASSNAME, __func__, m_deint_input->name, status, mmal_status_to_string(status));
+  }
+
+  if (m_deint_input && (sizeChanged || deinterlaceChanged || encodingChanged))
+  {
+    assert(m_deint_input != nullptr && m_deint_input->format != nullptr && m_deint_input->format->es != nullptr);
+    CLog::Log(LOGDEBUG, "%s::%s Changing Deint dimensions from %dx%d (%dx%d) to %dx%d (%dx%d) %.4s->%.4s mode %d->%d", CLASSNAME, __func__,
+        m_deint_input->format->es->video.crop.width, m_deint_input->format->es->video.crop.height,
+        m_deint_input->format->es->video.width, m_deint_input->format->es->video.height, width, height, aligned_width, aligned_height,
+        (char *)&m_deint_input->format->encoding, (char *)&encoding, m_interlace_method, interlace_method);
+
+    // we need to disable port when parameters change
+    if (m_deint_input && m_deint_input->is_enabled)
+    {
+      status = mmal_port_disable(m_deint_input);
+      if (status != MMAL_SUCCESS)
+      {
+        CLog::Log(LOGERROR, "%s::%s Failed to disable deint input port (status=%x %s)", CLASSNAME, __func__, status, mmal_status_to_string(status));
+        return false;
+      }
+    }
+  }
+
+  if (m_deint_output && (sizeChanged || deinterlaceChanged || encodingChanged))
+  {
+    if (m_deint_output && m_deint_output->is_enabled)
+    {
+      status = mmal_port_disable(m_deint_output);
+      if (status != MMAL_SUCCESS)
+      {
+        CLog::Log(LOGERROR, "%s::%s Failed to disable deint output port (status=%x %s)", CLASSNAME, __func__, status, mmal_status_to_string(status));
+        return false;
+      }
+    }
+  }
+
+  if (m_deint_input && (sizeChanged || deinterlaceChanged || encodingChanged))
+  {
+    m_deint_width = width;
+    m_deint_height = height;
+    m_deint_aligned_width = aligned_width;
+    m_deint_aligned_height = aligned_height;
+
+    m_deint_input->format->es->video.crop.width = width;
+    m_deint_input->format->es->video.crop.height = height;
+    m_deint_input->format->es->video.width = aligned_width;
+    m_deint_input->format->es->video.height = aligned_height;
+    m_deint_input->format->encoding = encoding;
+
+    status = mmal_port_format_commit(m_deint_input);
+    if (status != MMAL_SUCCESS)
+    {
+      CLog::Log(LOGERROR, "%s::%s Failed to commit deint input format (status=%x %s)", CLASSNAME, __func__, status, mmal_status_to_string(status));
+      return false;
+    }
+
+    if (!m_deint_input->is_enabled)
+    {
+      m_deint_input->buffer_num = MMAL_NUM_OUTPUT_BUFFERS;
+      m_deint_input->buffer_size = m_deint_input->buffer_size_recommended;
+      m_deint_input->userdata = (struct MMAL_PORT_USERDATA_T *)this;
+
+      status = mmal_port_enable(m_deint_input, deint_input_port_cb_static);
+      if (status != MMAL_SUCCESS)
+      {
+        CLog::Log(LOGERROR, "%s::%s Failed to enable deint input port (status=%x %s)", CLASSNAME, __func__, status, mmal_status_to_string(status));
+        return false;
+      }
+    }
+  }
+
+  if (m_deint_output && (sizeChanged || deinterlaceChanged || encodingChanged))
+  {
+    MMAL_PARAMETER_IMAGEFX_PARAMETERS_T imfx_param = {{MMAL_PARAMETER_IMAGE_EFFECT_PARAMETERS, sizeof(imfx_param)},
+          advanced_deinterlace ? MMAL_PARAM_IMAGEFX_DEINTERLACE_ADV : MMAL_PARAM_IMAGEFX_DEINTERLACE_FAST, 4, {3, 0, half_framerate, 1 }};
+
+    status = mmal_port_parameter_set(m_deint_output, &imfx_param.hdr);
+    if (status != MMAL_SUCCESS)
+    {
+      CLog::Log(LOGERROR, "%s::%s Failed to set deinterlace parameters (status=%x %s)", CLASSNAME, __func__, status, mmal_status_to_string(status));
+      return false;
+    }
+
+    // Image_fx assumed 3 frames of context. simple deinterlace doesn't require this
+    status = mmal_port_parameter_set_uint32(m_deint_input, MMAL_PARAMETER_EXTRA_BUFFERS, 6 - 5 + advanced_deinterlace ? 2:0);
+    if (status != MMAL_SUCCESS)
+      CLog::Log(LOGERROR, "%s::%s Failed to enable extra buffers on %s (status=%x %s)", CLASSNAME, __func__, m_deint_input->name, status, mmal_status_to_string(status));
+  }
+
+  if (m_deint_output && (sizeChanged || deinterlaceChanged || encodingChanged))
+  {
+    m_deint_output->format->es->video.crop.width = width;
+    m_deint_output->format->es->video.crop.height = height;
+    m_deint_output->format->es->video.width = ALIGN_UP(width, 32);
+    m_deint_output->format->es->video.height = ALIGN_UP(height, 16);
+    m_deint_output->format->encoding = advanced_deinterlace ? MMAL_ENCODING_YUVUV128 : MMAL_ENCODING_I420;
+
+    status = mmal_port_format_commit(m_deint_output);
+    if (status != MMAL_SUCCESS)
+    {
+      CLog::Log(LOGERROR, "%s::%s Failed to commit deint output format (status=%x %s)", CLASSNAME, __func__, status, mmal_status_to_string(status));
+      return false;
+    }
+
+    if (!m_deint_output->is_enabled)
+    {
+      m_deint_output->buffer_num = 3;
+      m_deint_output->buffer_size = m_deint_output->buffer_size_recommended;
+      m_deint_output->userdata = (struct MMAL_PORT_USERDATA_T *)this;
+
+      status = mmal_port_enable(m_deint_output, deint_output_port_cb_static);
+      if (status != MMAL_SUCCESS)
+      {
+        CLog::Log(LOGERROR, "%s::%s Failed to enable deint output port (status=%x %s)", CLASSNAME, __func__, status, mmal_status_to_string(status));
+        return false;
+      }
+    }
+    if (m_deint_output_pool)
+      m_deint_output_pool->SetFormat(m_deint_output->format->encoding,
+        m_deint_output->format->es->video.crop.width, m_deint_output->format->es->video.crop.height,
+        m_deint_output->format->es->video.width, m_deint_output->format->es->video.height, m_deint_output->buffer_size, nullptr);
+  }
+
+  if (m_deint && !m_deint->is_enabled)
+  {
+    status = mmal_component_enable(m_deint);
+    if (status != MMAL_SUCCESS)
+    {
+      CLog::Log(LOGERROR, "%s::%s Failed to enable deinterlacer component %s (status=%x %s)", CLASSNAME, __func__, m_deint->name, status, mmal_status_to_string(status));
+      return false;
+    }
+  }
+  m_interlace_method = interlace_method;
+
+  // give buffers to deint
+  if (m_deint_output_pool)
+    m_deint_output_pool->Prime();
+  return true;
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.h
@@ -29,6 +29,7 @@
 #include "../RenderCapture.h"
 #include "settings/VideoSettings.h"
 #include "cores/VideoPlayer/DVDStreamInfo.h"
+#include "cores/VideoPlayer/DVDCodecs/Video/MMALFFmpeg.h"
 #include "guilib/Geometry.h"
 #include "threads/Thread.h"
 
@@ -40,20 +41,41 @@
 #define NOSOURCE   -2
 #define AUTOSOURCE -1
 
+// worst case number of buffers. 12 for decoder. 8 for multi-threading in ffmpeg. NUM_BUFFERS for renderer.
+// Note, generally these won't necessarily result in allocated pictures
+#define MMAL_NUM_OUTPUT_BUFFERS (12 + 8 + NUM_BUFFERS)
+
 class CBaseTexture;
 class CMMALBuffer;
 
 struct DVDVideoPicture;
 
-class CMMALPool
+class CMMALPool : public std::enable_shared_from_this<CMMALPool>
 {
 public:
-  CMMALPool(MMAL_PORT_T *input, uint32_t num_buffers, uint32_t buffer_size);
+  CMMALPool(const char *component_name, bool input, uint32_t num_buffers, uint32_t buffer_size, uint32_t encoding, MMALState state);
   ~CMMALPool();
-  MMAL_POOL_T *Get() { return m_pool; }
+  MMAL_COMPONENT_T *GetComponent() { return m_component; }
+  static void AlignedSize(AVCodecContext *avctx, uint32_t &w, uint32_t &h);
+  CMMALBuffer *GetBuffer(uint32_t timeout);
+  CGPUMEM *AllocateBuffer(uint32_t numbytes);
+  void ReleaseBuffer(CGPUMEM *gmem);
+  void Close();
+  void Prime();
+  void SetDecoder(CMMALVideo *dec) { m_dec = dec; }
+  void SetFormat(uint32_t mmal_format, uint32_t width, uint32_t height, uint32_t aligned_width, uint32_t aligned_height, uint32_t size, AVCodecContext *avctx)
+    { m_mmal_format = mmal_format; m_width = width; m_height = height; m_aligned_width = aligned_width; m_aligned_height = aligned_height; m_size = size, m_avctx = avctx; }
 protected:
-  MMAL_POOL_T *m_pool;
-  MMAL_PORT_T *m_input;
+  uint32_t m_mmal_format, m_width, m_height, m_aligned_width, m_aligned_height, m_size;
+  AVCodecContext *m_avctx;
+  CMMALVideo *m_dec;
+  MMALState m_state;
+  bool m_input;
+  MMAL_POOL_T *m_mmal_pool;
+  MMAL_COMPONENT_T *m_component;
+  CCriticalSection m_section;
+  std::deque<CGPUMEM *> m_freeBuffers;
+  bool m_closing;
 };
 
 class CMMALRenderer : public CBaseRenderer, public CThread
@@ -96,7 +118,6 @@ public:
   virtual bool         IsGuiLayer() { return false; }
 
   void vout_input_port_cb(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer);
-  std::shared_ptr<CMMALPool> GetPool(ERenderFormat format, AVPixelFormat pixfmt, bool opaque);
 protected:
   int m_iYV12RenderBuffer;
   int m_NumYV12Buffers;
@@ -105,7 +126,6 @@ protected:
 
   CMMALBuffer         *m_buffers[NUM_BUFFERS];
   bool                 m_bConfigured;
-  bool                 m_bMMALConfigured;
   unsigned int         m_extended_format;
   int                  m_neededBuffers;
 
@@ -114,18 +134,16 @@ protected:
   RENDER_STEREO_MODE        m_video_stereo_mode;
   RENDER_STEREO_MODE        m_display_stereo_mode;
   bool                      m_StereoInvert;
-  int                       m_inflight;
-  bool                      m_opaque;
-  AVPixelFormat m_pixfmt;
 
   CCriticalSection m_sharedSection;
   MMAL_COMPONENT_T *m_vout;
   MMAL_PORT_T *m_vout_input;
-  std::shared_ptr<CMMALPool> m_vout_input_pool;
   MMAL_QUEUE_T *m_queue;
+  MMAL_BUFFER_HEADER_T m_quitpacket;
   double m_error;
 
-  bool init_vout(ERenderFormat format, AVPixelFormat pixfmt, bool opaque);
+  uint32_t m_vout_width, m_vout_height, m_vout_aligned_width, m_vout_aligned_height;
+  bool CheckConfigurationVout(uint32_t width, uint32_t height, uint32_t aligned_width, uint32_t aligned_height, uint32_t encoding);
   uint32_t m_vsync_count;
   void ReleaseBuffers();
   void UnInitMMAL();

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.h
@@ -118,6 +118,8 @@ public:
   virtual bool         IsGuiLayer() { return false; }
 
   void vout_input_port_cb(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer);
+  void deint_input_port_cb(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer);
+  void deint_output_port_cb(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer);
 protected:
   int m_iYV12RenderBuffer;
   int m_NumYV12Buffers;
@@ -145,6 +147,18 @@ protected:
   double m_error;
 
   uint32_t m_vout_width, m_vout_height, m_vout_aligned_width, m_vout_aligned_height;
+  // deinterlace
+  MMAL_COMPONENT_T *m_deint;
+  MMAL_PORT_T *m_deint_input;
+  MMAL_PORT_T *m_deint_output;
+  std::shared_ptr<CMMALPool> m_deint_output_pool;
+  MMAL_INTERLACETYPE_T m_interlace_mode;
+  EINTERLACEMETHOD  m_interlace_method;
+  uint32_t m_deint_width, m_deint_height, m_deint_aligned_width, m_deint_aligned_height;
+  MMAL_FOURCC_T m_deinterlace_out_encoding;
+  void DestroyDeinterlace();
+  bool CheckConfigurationDeint(uint32_t width, uint32_t height, uint32_t aligned_width, uint32_t aligned_height, uint32_t encoding, EINTERLACEMETHOD interlace_method);
+
   bool CheckConfigurationVout(uint32_t width, uint32_t height, uint32_t aligned_width, uint32_t aligned_height, uint32_t encoding);
   uint32_t m_vsync_count;
   void ReleaseBuffers();

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.h
@@ -78,7 +78,7 @@ protected:
   bool m_closing;
 };
 
-class CMMALRenderer : public CBaseRenderer, public CThread
+class CMMALRenderer : public CBaseRenderer, public CThread, public IRunnable
 {
 public:
   CMMALRenderer();
@@ -138,7 +138,9 @@ protected:
   CCriticalSection m_sharedSection;
   MMAL_COMPONENT_T *m_vout;
   MMAL_PORT_T *m_vout_input;
-  MMAL_QUEUE_T *m_queue;
+  MMAL_QUEUE_T *m_queue_render;
+  MMAL_QUEUE_T *m_queue_process;
+  CThread m_processThread;
   MMAL_BUFFER_HEADER_T m_quitpacket;
   double m_error;
 
@@ -147,4 +149,5 @@ protected:
   uint32_t m_vsync_count;
   void ReleaseBuffers();
   void UnInitMMAL();
+  virtual void Run() override;
 };


### PR DESCRIPTION
Previously we deinterlaced inside the hardware decoder. This has a few downsides:
-     It doesn't work with software decoded video (e.g. MPEG-2 without a codec licence)
-     The deinterlacer stops aspect ratio changes from being reported by decoder meaning they are missed when they occur mid-stream
-     Enabling/disabling deinterlace adjusts the framerate Kodi's renderer sees, and it takes a number of seconds to lock back on. This can cause issues with dropping/stuttering.
-     Interlaced content drives Kodi's GUI loop at a higher rate which increases CPU.

So the new scheme handles deinterlace in the mmal renderer, meaning kodi is unaware of the change in framerate. This also allows the higher quality gpu deinterlace to work with software decode.

I'd like to get this in this merge window. There will probably some tweaks before it is merged.

TODO: Report deinterlace state and the increased deinterlace framerate through processinfo
