### PR TITLE
CGUIWindowFullScreen: don't call SetDisplayAfterSeek on pause

### DIFF
--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -361,7 +361,7 @@ EVENT_RESULT CGUIWindowFullScreen::OnMouseEvent(const CPoint &point, const CMous
 
 void CGUIWindowFullScreen::FrameMove()
 {
-  if (g_application.m_pPlayer->GetPlaySpeed() != 1)
+  if (g_application.m_pPlayer->GetPlaySpeed() != 1 && !g_application.m_pPlayer->IsPausedPlayback())
     g_infoManager.SetDisplayAfterSeek();
 
   if (!g_application.m_pPlayer->HasPlayer())


### PR DESCRIPTION
Fix for the SeekLabel on pause in Estuary after the PR #10103

before the recent changes in CGUIWindowFullScreen::FrameMove() g_infoManager.SetDisplayAfterSeek() was never called on pause 

instead now with this different behavior Player.DisplayAfterSeek return true on pause and it is shown the label "Seeking" instead of "Paused"

maybe this could create some issue even with other skins

before:
<img src='https://s32.postimg.org/3p9lfp38l/err.png' border='0' alt="err"/>

after:
<img src='https://s32.postimg.org/jos8z8zad/paused.png' border='0' alt="paused"/>

@FernetMenta, @phil65
