### PR TITLE
Improve const correctness and add missing override

### DIFF
--- a/xbmc/addons/AudioDecoder.cpp
+++ b/xbmc/addons/AudioDecoder.cpp
@@ -132,7 +132,7 @@ int CAudioDecoder::GetTrackCount(const std::string& strPath)
   return result;
 }
 
-CAEChannelInfo CAudioDecoder::GetChannelInfo()
+CAEChannelInfo CAudioDecoder::GetChannelInfo() const
 {
   return m_format.m_channelLayout;
 }

--- a/xbmc/addons/AudioDecoder.h
+++ b/xbmc/addons/AudioDecoder.h
@@ -60,16 +60,16 @@ namespace ADDON
 
     // Things that MUST be supplied by the child classes
     bool Init(const CFileItem& file, unsigned int filecache) override;
-    int ReadPCM(uint8_t* buffer, int size, int* actualsize);
-    bool Seek(int64_t time);
-    bool CanInit() { return true; }
-    void DeInit();
+    int ReadPCM(uint8_t* buffer, int size, int* actualsize) override;
+    bool Seek(int64_t time) override;
+    bool CanInit() const override { return true; }
+    void DeInit() override;
     void Destroy();
     bool Load(const std::string& strFileName,
               MUSIC_INFO::CMusicInfoTag& tag,
-              MUSIC_INFO::EmbeddedArt *art = NULL);
-    int GetTrackCount(const std::string& strPath);
-    virtual CAEChannelInfo GetChannelInfo();
+              MUSIC_INFO::EmbeddedArt *art = NULL) override;
+    int GetTrackCount(const std::string& strPath) override;
+    virtual CAEChannelInfo GetChannelInfo() const;
 
     const std::string& GetExtensions() const { return m_extension; }
     const std::string& GetMimetypes() const { return m_mimetype; }

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -72,7 +72,7 @@ void CEngineStats::AddSamples(int samples, std::list<CActiveAEStream*> &streams)
   }
 }
 
-void CEngineStats::GetDelay(AEDelayStatus& status)
+void CEngineStats::GetDelay(AEDelayStatus& status) const
 {
   CSingleLock lock(m_lock);
   status = m_sinkDelay;
@@ -142,7 +142,7 @@ void CEngineStats::UpdateStream(CActiveAEStream *stream)
 }
 
 // this is used to sync a/v so we need to add sink latency here
-void CEngineStats::GetDelay(AEDelayStatus& status, CActiveAEStream *stream)
+void CEngineStats::GetDelay(AEDelayStatus& status, CActiveAEStream *stream) const
 {
   CSingleLock lock(m_lock);
   status = m_sinkDelay;
@@ -165,7 +165,7 @@ void CEngineStats::GetDelay(AEDelayStatus& status, CActiveAEStream *stream)
 }
 
 // this is used to sync a/v so we need to add sink latency here
-void CEngineStats::GetSyncInfo(CAESyncInfo& info, CActiveAEStream *stream)
+void CEngineStats::GetSyncInfo(CAESyncInfo& info, CActiveAEStream *stream) const
 {
   CSingleLock lock(m_lock);
   AEDelayStatus status;
@@ -194,7 +194,7 @@ void CEngineStats::GetSyncInfo(CAESyncInfo& info, CActiveAEStream *stream)
   }
 }
 
-float CEngineStats::GetCacheTime(CActiveAEStream *stream)
+float CEngineStats::GetCacheTime(CActiveAEStream *stream) const
 {
   CSingleLock lock(m_lock);
   float delay = (float)m_bufferedSamples / m_sinkSampleRate;
@@ -214,12 +214,12 @@ float CEngineStats::GetCacheTime(CActiveAEStream *stream)
   return delay;
 }
 
-float CEngineStats::GetCacheTotal(CActiveAEStream *stream)
+float CEngineStats::GetCacheTotal(CActiveAEStream *stream) const
 {
   return MAX_CACHE_LEVEL + m_sinkCacheTotal;
 }
 
-float CEngineStats::GetWaterLevel()
+float CEngineStats::GetWaterLevel() const
 {
   CSingleLock lock(m_lock);
   if (m_pcmOutput)
@@ -234,7 +234,7 @@ void CEngineStats::SetSuspended(bool state)
   m_suspended = state;
 }
 
-bool CEngineStats::IsSuspended()
+bool CEngineStats::IsSuspended() const
 {
   CSingleLock lock(m_lock);
   return m_suspended;
@@ -252,16 +252,17 @@ void CEngineStats::SetCurrentSinkFormat(AEAudioFormat SinkFormat)
   m_sinkFormat = SinkFormat;
 }
 
-bool CEngineStats::HasDSP()
+bool CEngineStats::HasDSP() const
 {
   CSingleLock lock(m_lock);
   return m_hasDSP;
 }
 
-AEAudioFormat CEngineStats::GetCurrentSinkFormat()
+bool CEngineStats::GetCurrentSinkFormat(AEAudioFormat& SinkFormat) const
 {
   CSingleLock lock(m_lock);
-  return m_sinkFormat;
+  SinkFormat = m_sinkFormat;
+  return true;
 }
 
 CActiveAE::CActiveAE() :
@@ -2613,12 +2614,12 @@ bool CActiveAE::Initialize()
   return true;
 }
 
-void CActiveAE::EnumerateOutputDevices(AEDeviceList &devices, bool passthrough)
+void CActiveAE::EnumerateOutputDevices(AEDeviceList &devices, bool passthrough) const
 {
   m_sink.EnumerateOutputDevices(devices, passthrough);
 }
 
-std::string CActiveAE::GetDefaultDevice(bool passthrough)
+std::string CActiveAE::GetDefaultDevice(bool passthrough) const
 {
   return m_sink.GetDefaultDevice(passthrough);
 }
@@ -2647,7 +2648,7 @@ void CActiveAE::OnSettingsChange(const std::string& setting)
   }
 }
 
-bool CActiveAE::SupportsRaw(AEAudioFormat &format)
+bool CActiveAE::SupportsRaw(AEAudioFormat &format) const
 {
   if (!m_sink.SupportsFormat(CSettings::GetInstance().GetString(CSettings::SETTING_AUDIOOUTPUT_PASSTHROUGHDEVICE), format))
     return false;
@@ -2655,12 +2656,12 @@ bool CActiveAE::SupportsRaw(AEAudioFormat &format)
   return true;
 }
 
-bool CActiveAE::SupportsSilenceTimeout()
+bool CActiveAE::SupportsSilenceTimeout() const
 {
   return true;
 }
 
-bool CActiveAE::HasStereoAudioChannelCount()
+bool CActiveAE::HasStereoAudioChannelCount() const
 {
   std::string device = CSettings::GetInstance().GetString(CSettings::SETTING_AUDIOOUTPUT_AUDIODEVICE);
   int numChannels = (m_sink.GetDeviceType(device) == AE_DEVTYPE_IEC958) ? AE_CH_LAYOUT_2_0 : CSettings::GetInstance().GetInt(CSettings::SETTING_AUDIOOUTPUT_CHANNELS);
@@ -2670,14 +2671,14 @@ bool CActiveAE::HasStereoAudioChannelCount()
     CSettings::GetInstance().GetBool(CSettings::SETTING_AUDIOOUTPUT_AC3TRANSCODE));
 }
 
-bool CActiveAE::HasHDAudioChannelCount()
+bool CActiveAE::HasHDAudioChannelCount() const
 {
   std::string device = CSettings::GetInstance().GetString(CSettings::SETTING_AUDIOOUTPUT_AUDIODEVICE);
   int numChannels = (m_sink.GetDeviceType(device) == AE_DEVTYPE_IEC958) ? AE_CH_LAYOUT_2_0 : CSettings::GetInstance().GetInt(CSettings::SETTING_AUDIOOUTPUT_CHANNELS);
   return numChannels > AE_CH_LAYOUT_5_1;
 }
 
-bool CActiveAE::SupportsQualityLevel(enum AEQuality level)
+bool CActiveAE::SupportsQualityLevel(enum AEQuality level) const
 {
   if (level == AE_QUALITY_LOW || level == AE_QUALITY_MID || level == AE_QUALITY_HIGH)
     return true;
@@ -2689,7 +2690,7 @@ bool CActiveAE::SupportsQualityLevel(enum AEQuality level)
   return false;
 }
 
-bool CActiveAE::IsSettingVisible(const std::string &settingId)
+bool CActiveAE::IsSettingVisible(const std::string &settingId) const
 {
   if (settingId == CSettings::SETTING_AUDIOOUTPUT_SAMPLERATE)
   {
@@ -2807,12 +2808,12 @@ bool CActiveAE::Resume()
   return true;
 }
 
-bool CActiveAE::IsSuspended()
+bool CActiveAE::IsSuspended() const
 {
   return m_stats.IsSuspended();
 }
 
-float CActiveAE::GetVolume()
+float CActiveAE::GetVolume() const
 {
   return m_aeVolume;
 }
@@ -2829,7 +2830,7 @@ void CActiveAE::SetMute(const bool enabled)
   m_controlPort.SendOutMessage(CActiveAEControlProtocol::MUTE, &m_aeMuted, sizeof(bool));
 }
 
-bool CActiveAE::IsMuted()
+bool CActiveAE::IsMuted() const
 {
   return m_aeMuted;
 }
@@ -2850,14 +2851,14 @@ void CActiveAE::DeviceChange()
   m_controlPort.SendOutMessage(CActiveAEControlProtocol::DEVICECHANGE);
 }
 
-bool CActiveAE::HasDSP()
+bool CActiveAE::HasDSP() const
 {
   return m_stats.HasDSP();
 };
 
-AEAudioFormat CActiveAE::GetCurrentSinkFormat()
+bool CActiveAE::GetCurrentSinkFormat(AEAudioFormat& SinkFormat) const
 {
-  return m_stats.GetCurrentSinkFormat();
+  return m_stats.GetCurrentSinkFormat(SinkFormat);
 }
 
 void CActiveAE::OnLostDisplay()

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
@@ -180,23 +180,23 @@ public:
   void Reset(unsigned int sampleRate, bool pcm);
   void UpdateSinkDelay(const AEDelayStatus& status, int samples);
   void AddSamples(int samples, std::list<CActiveAEStream*> &streams);
-  void GetDelay(AEDelayStatus& status);
+  void GetDelay(AEDelayStatus& status) const;
   void AddStream(unsigned int streamid);
   void RemoveStream(unsigned int streamid);
   void UpdateStream(CActiveAEStream *stream);
-  void GetDelay(AEDelayStatus& status, CActiveAEStream *stream);
-  void GetSyncInfo(CAESyncInfo& info, CActiveAEStream *stream);
-  float GetCacheTime(CActiveAEStream *stream);
-  float GetCacheTotal(CActiveAEStream *stream);
-  float GetWaterLevel();
+  void GetDelay(AEDelayStatus& status, CActiveAEStream *stream) const;
+  void GetSyncInfo(CAESyncInfo& info, CActiveAEStream *stream) const;
+  float GetCacheTime(CActiveAEStream *stream) const;
+  float GetCacheTotal(CActiveAEStream *stream) const;
+  float GetWaterLevel()const;
   void SetSuspended(bool state);
   void SetDSP(bool state);
   void SetCurrentSinkFormat(AEAudioFormat SinkFormat);
   void SetSinkCacheTotal(float time) { m_sinkCacheTotal = time; }
   void SetSinkLatency(float time) { m_sinkLatency = time; }
-  bool IsSuspended();
-  bool HasDSP();
-  AEAudioFormat GetCurrentSinkFormat();
+  bool IsSuspended() const;
+  bool HasDSP()const;
+  bool GetCurrentSinkFormat(AEAudioFormat &SinkFormat) const;
 protected:
   float m_sinkCacheTotal;
   float m_sinkLatency;
@@ -230,50 +230,50 @@ protected:
   friend class CActiveAEBufferPoolResample;
   CActiveAE();
   virtual ~CActiveAE();
-  virtual bool  Initialize();
+  virtual bool  Initialize() override;
 
 public:
-  virtual void   Shutdown();
-  virtual bool   Suspend();
-  virtual bool   Resume();
-  virtual bool   IsSuspended();
-  virtual void   OnSettingsChange(const std::string& setting);
+  virtual void   Shutdown() override;
+  virtual bool   Suspend() override;
+  virtual bool   Resume() override;
+  virtual bool   IsSuspended() const override;
+  virtual void   OnSettingsChange(const std::string& setting) override;
 
-  virtual float GetVolume();
-  virtual void  SetVolume(const float volume);
-  virtual void  SetMute(const bool enabled);
-  virtual bool  IsMuted();
-  virtual void  SetSoundMode(const int mode);
+  virtual float GetVolume() const  override;
+  virtual void  SetVolume(const float volume) override;
+  virtual void  SetMute(const bool enabled) override;
+  virtual bool  IsMuted() const override;
+  virtual void  SetSoundMode(const int mode) override;
 
   /* returns a new stream for data in the specified format */
-  virtual IAEStream *MakeStream(AEAudioFormat &audioFormat, unsigned int options = 0, IAEClockCallback *clock = NULL);
-  virtual bool FreeStream(IAEStream *stream);
+  virtual IAEStream *MakeStream(AEAudioFormat &audioFormat, unsigned int options = 0, IAEClockCallback *clock = NULL) override;
+  virtual bool FreeStream(IAEStream *stream) override;
 
   /* returns a new sound object */
-  virtual IAESound *MakeSound(const std::string& file);
-  virtual void      FreeSound(IAESound *sound);
+  virtual IAESound *MakeSound(const std::string& file) override;
+  virtual void      FreeSound(IAESound *sound) override;
 
-  virtual void GarbageCollect() {};
+  virtual void GarbageCollect() override {};
 
-  virtual void EnumerateOutputDevices(AEDeviceList &devices, bool passthrough);
-  virtual std::string GetDefaultDevice(bool passthrough);
-  virtual bool SupportsRaw(AEAudioFormat &format);
-  virtual bool SupportsSilenceTimeout();
-  virtual bool HasStereoAudioChannelCount();
-  virtual bool HasHDAudioChannelCount();
-  virtual bool SupportsQualityLevel(enum AEQuality level);
-  virtual bool IsSettingVisible(const std::string &settingId);
-  virtual void KeepConfiguration(unsigned int millis);
-  virtual void DeviceChange();
-  virtual bool HasDSP();
-  virtual AEAudioFormat GetCurrentSinkFormat();
+  virtual void EnumerateOutputDevices(AEDeviceList &devices, bool passthrough) const override;
+  virtual std::string GetDefaultDevice(bool passthrough) const override;
+  virtual bool SupportsRaw(AEAudioFormat &format) const override;
+  virtual bool SupportsSilenceTimeout() const override;
+  virtual bool HasStereoAudioChannelCount() const override;
+  virtual bool HasHDAudioChannelCount() const override;
+  virtual bool SupportsQualityLevel(enum AEQuality level) const override;
+  virtual bool IsSettingVisible(const std::string &settingId) const override;
+  virtual void KeepConfiguration(unsigned int millis) override;
+  virtual void DeviceChange() override;
+  virtual bool HasDSP()const override;
+  virtual bool GetCurrentSinkFormat(AEAudioFormat &SinkFormat) const override;
 
-  virtual void RegisterAudioCallback(IAudioCallback* pCallback);
-  virtual void UnregisterAudioCallback(IAudioCallback* pCallback);
+  virtual void RegisterAudioCallback(IAudioCallback* pCallback) override;
+  virtual void UnregisterAudioCallback(IAudioCallback* pCallback) override;
 
-  virtual void OnLostDisplay();
-  virtual void OnResetDisplay();
-  virtual void OnAppFocusChange(bool focus);
+  virtual void OnLostDisplay() override;
+  virtual void OnResetDisplay() override;
+  virtual void OnAppFocusChange(bool focus) override;
 
 protected:
   void PlaySound(CActiveAESound *sound);
@@ -295,7 +295,7 @@ protected:
   void SetStreamFade(CActiveAEStream *stream, float from, float target, unsigned int millis);
 
 protected:
-  void Process();
+  void Process() override;
   void StateMachine(int signal, Protocol *port, Message *msg);
   bool InitSink();
   void DrainSink();
@@ -349,7 +349,7 @@ protected:
     MODE_PCM
   }m_mode;
 
-  CActiveAESink m_sink;
+  mutable CActiveAESink m_sink;
   AEAudioFormat m_sinkFormat;
   AEAudioFormat m_sinkRequestFormat;
   AEAudioFormat m_encoderFormat;

--- a/xbmc/cores/AudioEngine/Interfaces/AE.h
+++ b/xbmc/cores/AudioEngine/Interfaces/AE.h
@@ -113,7 +113,7 @@ public:
    * Default is true so players drop audio or pause if engine unloaded
    * @return True if processing suspended
    */
-  virtual bool IsSuspended() {return true;}
+  virtual bool IsSuspended() const {return true;}
   
   /**
    * Callback to alert the AudioEngine of setting changes
@@ -125,7 +125,7 @@ public:
    * Returns the current master volume level of the AudioEngine
    * @return The volume level between 0.0 and 1.0
    */
-  virtual float GetVolume() = 0;
+  virtual float GetVolume() const = 0;
 
   /**
    * Sets the master volume level of the AudioEngine
@@ -143,7 +143,7 @@ public:
    * Get the current mute state
    * @return The current mute state
    */
-  virtual bool IsMuted() = 0;
+  virtual bool IsMuted() const = 0;
 
   /**
    * Sets the sound mode
@@ -190,39 +190,39 @@ public:
    * @param devices The device list to append supported devices to
    * @param passthrough True if only passthrough devices are wanted
    */
-  virtual void EnumerateOutputDevices(AEDeviceList &devices, bool passthrough) = 0;
+  virtual void EnumerateOutputDevices(AEDeviceList &devices, bool passthrough) const = 0;
 
   /**
    * Returns the default audio device
    * @param passthrough True if the default passthrough device is wanted
    * @return the default audio device
    */
-  virtual std::string GetDefaultDevice(bool passthrough) { return "default"; }
+  virtual std::string GetDefaultDevice(bool passthrough) const { return "default"; }
 
   /**
    * Returns true if the AudioEngine supports AE_FMT_RAW streams for use with formats such as IEC61937
    * @see CAEPackIEC61937::CAEPackIEC61937()
    * @returns true if the AudioEngine is capable of RAW output
    */
-  virtual bool SupportsRaw(AEAudioFormat &format) { return false; }
+  virtual bool SupportsRaw(AEAudioFormat &format) const { return false; }
 
    /**
    * Returns true if the AudioEngine supports drain mode which is not streaming silence when idle
    * @returns true if the AudioEngine is capable of drain mode
    */
-  virtual bool SupportsSilenceTimeout() { return false; }
+  virtual bool SupportsSilenceTimeout() const { return false; }
 
   /**
    * Returns true if the AudioEngine is currently configured for stereo audio
    * @returns true if the AudioEngine is currently configured for stereo audio
    */
-  virtual bool HasStereoAudioChannelCount() { return false; }
+  virtual bool HasStereoAudioChannelCount() const { return false; }
 
   /**
    * Returns true if the AudioEngine is currently configured for HD audio (more than 5.1)
    * @returns true if the AudioEngine is currently configured for HD audio (more than 5.1)
    */
-  virtual bool HasHDAudioChannelCount() { return true; }
+  virtual bool HasHDAudioChannelCount() const { return true; }
 
   virtual void RegisterAudioCallback(IAudioCallback* pCallback) {}
 
@@ -232,13 +232,13 @@ public:
    * Returns true if AudioEngine supports specified quality level
    * @return true if specified quality level is supported, otherwise false
    */
-  virtual bool SupportsQualityLevel(enum AEQuality level) { return false; }
+  virtual bool SupportsQualityLevel(enum AEQuality level) const { return false; }
 
   /**
    * AE decides whether this settings should be displayed
    * @return true if AudioEngine wants to display this setting
    */
-  virtual bool IsSettingVisible(const std::string &settingId) {return false; }
+  virtual bool IsSettingVisible(const std::string &settingId) const {return false; }
 
   /**
    * Instruct AE to keep configuration for a specified time
@@ -254,7 +254,7 @@ public:
   /**
    * Indicates if dsp addon system is active.
    */
-  virtual bool HasDSP() { return false; };
+  virtual bool HasDSP() const { return false; };
 
   /**
    * Get the current sink data format
@@ -262,6 +262,6 @@ public:
    * @param Current sink data format. For more details see AEAudioFormat.
    * @return Returns true on success, else false.
    */
-  virtual bool GetCurrentSinkFormat(AEAudioFormat &SinkFormat) { return false; }
+  virtual bool GetCurrentSinkFormat(AEAudioFormat &SinkFormat) const { return false; }
 };
 

--- a/xbmc/cores/AudioEngine/Utils/AEStreamInfo.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEStreamInfo.cpp
@@ -83,7 +83,7 @@ CAEStreamInfo::CAEStreamInfo() :
 {
 }
 
-double CAEStreamInfo::GetDuration()
+double CAEStreamInfo::GetDuration() const
 {
   double duration = 0;
   switch (m_type)

--- a/xbmc/cores/AudioEngine/Utils/AEStreamInfo.h
+++ b/xbmc/cores/AudioEngine/Utils/AEStreamInfo.h
@@ -34,7 +34,7 @@ class CAEStreamInfo
 {
 public:
   CAEStreamInfo();
-  double GetDuration();
+  double GetDuration() const;
   bool operator==(const CAEStreamInfo& info) const;
 
   enum DataType

--- a/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
+++ b/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
@@ -516,7 +516,7 @@ void CExternalPlayer::ToggleSubtitles()
 {
 }
 
-bool CExternalPlayer::CanSeek()
+bool CExternalPlayer::CanSeek() const
 {
   return false;
 }
@@ -533,7 +533,7 @@ void CExternalPlayer::SeekPercentage(float iPercent)
 {
 }
 
-float CExternalPlayer::GetPercentage()
+float CExternalPlayer::GetPercentage() const
 {
   int64_t iTime = GetTime();
   int64_t iTotalTime = GetTotalTime();
@@ -551,7 +551,7 @@ void CExternalPlayer::SetAVDelay(float fValue)
 {
 }
 
-float CExternalPlayer::GetAVDelay()
+float CExternalPlayer::GetAVDelay() const
 {
   return 0.0f;
 }
@@ -560,7 +560,7 @@ void CExternalPlayer::SetSubTitleDelay(float fValue)
 {
 }
 
-float CExternalPlayer::GetSubTitleDelay()
+float CExternalPlayer::GetSubTitleDelay() const
 {
   return 0.0;
 }
@@ -569,7 +569,7 @@ void CExternalPlayer::SeekTime(int64_t iTime)
 {
 }
 
-int64_t CExternalPlayer::GetTime() // in millis
+int64_t CExternalPlayer::GetTime() const // in millis
 {
   if ((XbmcThreads::SystemClockMillis() - m_playbackStartTime) / 1000 > m_playCountMinTime)
   {
@@ -579,7 +579,7 @@ int64_t CExternalPlayer::GetTime() // in millis
   return m_time;
 }
 
-int64_t CExternalPlayer::GetTotalTime() // in milliseconds
+int64_t CExternalPlayer::GetTotalTime() const // in milliseconds
 {
   return (int64_t)m_totalTime * 1000;
 }
@@ -589,7 +589,7 @@ void CExternalPlayer::SetSpeed(int iSpeed)
   m_speed = iSpeed;
 }
 
-int CExternalPlayer::GetSpeed()
+int CExternalPlayer::GetSpeed() const
 {
   return m_speed;
 }
@@ -598,7 +598,7 @@ void CExternalPlayer::ShowOSD(bool bOnoff)
 {
 }
 
-std::string CExternalPlayer::GetPlayerState()
+std::string CExternalPlayer::GetPlayerState() const
 {
   return "";
 }

--- a/xbmc/cores/ExternalPlayer/ExternalPlayer.h
+++ b/xbmc/cores/ExternalPlayer/ExternalPlayer.h
@@ -34,46 +34,46 @@ public:
 
   CExternalPlayer(IPlayerCallback& callback);
   virtual ~CExternalPlayer();
-  virtual bool Initialize(TiXmlElement* pConfig);
-  virtual bool OpenFile(const CFileItem& file, const CPlayerOptions &options);
-  virtual bool CloseFile(bool reopen = false);
-  virtual bool IsPlaying() const;
+  virtual bool Initialize(TiXmlElement* pConfig) override;
+  virtual bool OpenFile(const CFileItem& file, const CPlayerOptions &options) override;
+  virtual bool CloseFile(bool reopen = false) override;
+  virtual bool IsPlaying() const override;
   virtual void Pause() override;
-  virtual bool HasVideo() const;
-  virtual bool HasAudio() const;
+  virtual bool HasVideo() const override;
+  virtual bool HasAudio() const override;
   virtual void ToggleOSD() { }; // empty
   virtual void SwitchToNextLanguage();
   virtual void ToggleSubtitles();
-  virtual bool CanSeek();
-  virtual void Seek(bool bPlus, bool bLargeStep, bool bChapterOverride);
-  virtual void SeekPercentage(float iPercent);
-  virtual float GetPercentage();
-  virtual void SetVolume(float volume) {}
-  virtual void SetDynamicRangeCompression(long drc) {}
+  virtual bool CanSeek() const override;
+  virtual void Seek(bool bPlus, bool bLargeStep, bool bChapterOverride) override;
+  virtual void SeekPercentage(float iPercent) override;
+  virtual float GetPercentage()const override;
+  virtual void SetVolume(float volume) override {}
+  virtual void SetDynamicRangeCompression(long drc) override {}
   virtual void SetContrast(bool bPlus) {}
   virtual void SetBrightness(bool bPlus) {}
   virtual void SetHue(bool bPlus) {}
   virtual void SetSaturation(bool bPlus) {}
   virtual void SwitchToNextAudioLanguage();
-  virtual bool CanRecord() { return false; }
-  virtual bool IsRecording() { return false; }
-  virtual bool Record(bool bOnOff) { return false; }
-  virtual void SetAVDelay(float fValue = 0.0f);
-  virtual float GetAVDelay();
+  virtual bool CanRecord() const override{ return false; }
+  virtual bool IsRecording() const override{ return false; }
+  virtual bool Record(bool bOnOff) override { return false; }
+  virtual void SetAVDelay(float fValue = 0.0f) override;
+  virtual float GetAVDelay() const override;
 
-  virtual void SetSubTitleDelay(float fValue = 0.0f);
-  virtual float GetSubTitleDelay();
+  virtual void SetSubTitleDelay(float fValue = 0.0f) override;
+  virtual float GetSubTitleDelay() const override;
 
-  virtual void SeekTime(int64_t iTime);
-  virtual int64_t GetTime();
-  virtual int64_t GetTotalTime();
+  virtual void SeekTime(int64_t iTime) override;
+  virtual int64_t GetTime() const override;
+  virtual int64_t GetTotalTime()const override;
   virtual void SetSpeed(int iSpeed) override;
-  virtual int GetSpeed() override;
+  virtual int GetSpeed() const override;
   virtual void ShowOSD(bool bOnoff);
-  virtual void DoAudioWork() {};
+  virtual void DoAudioWork() override {};
   
-  virtual std::string GetPlayerState();
-  virtual bool SetPlayerState(const std::string& state);
+  virtual std::string GetPlayerState() const override;
+  virtual bool SetPlayerState(const std::string& state) override;
   
 #if defined(TARGET_WINDOWS)
   virtual BOOL ExecuteAppW32(const char* strPath, const char* strSwitches);
@@ -86,7 +86,7 @@ public:
 
 private:
   void GetCustomRegexpReplacers(TiXmlElement *pRootElement, std::vector<std::string>& settings);
-  virtual void Process();
+  virtual void Process() override;
 
   bool m_bAbortRequest;
   bool m_bIsPlaying;
@@ -94,7 +94,7 @@ private:
   int64_t m_playbackStartTime;
   int m_speed;
   int m_totalTime;
-  int m_time;
+  mutable int m_time;
   std::string m_launchFilename;
   HWND m_hwndXbmc; 
 #if defined(TARGET_WINDOWS)

--- a/xbmc/cores/ExternalPlayer/ExternalPlayer.h
+++ b/xbmc/cores/ExternalPlayer/ExternalPlayer.h
@@ -34,6 +34,18 @@ public:
 
   CExternalPlayer(IPlayerCallback& callback);
   virtual ~CExternalPlayer();
+
+  virtual void ToggleOSD() { }; // empty
+  virtual void ShowOSD(bool bOnoff);
+  virtual void SwitchToNextLanguage();
+  virtual void ToggleSubtitles();
+  virtual void SetContrast(bool bPlus) {}
+  virtual void SetBrightness(bool bPlus) {}
+  virtual void SetHue(bool bPlus) {}
+  virtual void SetSaturation(bool bPlus) {}
+  virtual void SwitchToNextAudioLanguage();
+
+  // IPlayer interface
   virtual bool Initialize(TiXmlElement* pConfig) override;
   virtual bool OpenFile(const CFileItem& file, const CPlayerOptions &options) override;
   virtual bool CloseFile(bool reopen = false) override;
@@ -41,37 +53,25 @@ public:
   virtual void Pause() override;
   virtual bool HasVideo() const override;
   virtual bool HasAudio() const override;
-  virtual void ToggleOSD() { }; // empty
-  virtual void SwitchToNextLanguage();
-  virtual void ToggleSubtitles();
   virtual bool CanSeek() const override;
   virtual void Seek(bool bPlus, bool bLargeStep, bool bChapterOverride) override;
   virtual void SeekPercentage(float iPercent) override;
   virtual float GetPercentage()const override;
   virtual void SetVolume(float volume) override {}
   virtual void SetDynamicRangeCompression(long drc) override {}
-  virtual void SetContrast(bool bPlus) {}
-  virtual void SetBrightness(bool bPlus) {}
-  virtual void SetHue(bool bPlus) {}
-  virtual void SetSaturation(bool bPlus) {}
-  virtual void SwitchToNextAudioLanguage();
   virtual bool CanRecord() const override{ return false; }
   virtual bool IsRecording() const override{ return false; }
   virtual bool Record(bool bOnOff) override { return false; }
   virtual void SetAVDelay(float fValue = 0.0f) override;
   virtual float GetAVDelay() const override;
-
   virtual void SetSubTitleDelay(float fValue = 0.0f) override;
   virtual float GetSubTitleDelay() const override;
-
   virtual void SeekTime(int64_t iTime) override;
   virtual int64_t GetTime() const override;
   virtual int64_t GetTotalTime()const override;
   virtual void SetSpeed(int iSpeed) override;
   virtual int GetSpeed() const override;
-  virtual void ShowOSD(bool bOnoff);
   virtual void DoAudioWork() override {};
-  
   virtual std::string GetPlayerState() const override;
   virtual bool SetPlayerState(const std::string& state) override;
   
@@ -86,6 +86,8 @@ public:
 
 private:
   void GetCustomRegexpReplacers(TiXmlElement *pRootElement, std::vector<std::string>& settings);
+
+  // CThread interface
   virtual void Process() override;
 
   bool m_bAbortRequest;

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -242,35 +242,35 @@ public:
   virtual void OnNothingToQueueNotify() {}
   virtual bool CloseFile(bool reopen = false) = 0;
   virtual bool IsPlaying() const { return false;}
-  virtual bool CanPause() { return true; };
+  virtual bool CanPause() const { return true; };
   virtual void Pause() = 0;
   virtual bool HasVideo() const = 0;
   virtual bool HasAudio() const = 0;
   virtual bool HasRDS() const { return false; }
   virtual bool IsPassthrough() const { return false;}
-  virtual bool CanSeek() {return true;}
+  virtual bool CanSeek() const {return true;}
   virtual void Seek(bool bPlus = true, bool bLargeStep = false, bool bChapterOverride = false) = 0;
   virtual bool SeekScene(bool bPlus = true) {return false;}
   virtual void SeekPercentage(float fPercent = 0){}
-  virtual float GetPercentage(){ return 0;}
-  virtual float GetCachePercentage(){ return 0;}
+  virtual float GetPercentage() const { return 0;}
+  virtual float GetCachePercentage() const { return 0;}
   virtual void SetMute(bool bOnOff){}
   virtual void SetVolume(float volume){}
   virtual void SetDynamicRangeCompression(long drc){}
-  virtual bool CanRecord() { return false;};
-  virtual bool IsRecording() { return false;};
+  virtual bool CanRecord() const { return false;};
+  virtual bool IsRecording() const { return false;};
   virtual bool Record(bool bOnOff) { return false;};
 
   virtual void  SetAVDelay(float fValue = 0.0f) { return; }
-  virtual float GetAVDelay()                    { return 0.0f;};
+  virtual float GetAVDelay() const { return 0.0f;};
 
   virtual void SetSubTitleDelay(float fValue = 0.0f){};
-  virtual float GetSubTitleDelay()    { return 0.0f; }
-  virtual int  GetSubtitleCount()     { return 0; }
-  virtual int  GetSubtitle()          { return -1; }
-  virtual void GetSubtitleStreamInfo(int index, SPlayerSubtitleStreamInfo &info){};
-  virtual void SetSubtitle(int iStream){};
-  virtual bool GetSubtitleVisible(){ return false;};
+  virtual float GetSubTitleDelay() const { return 0.0f; }
+  virtual int  GetSubtitleCount() const { return 0; }
+  virtual int  GetSubtitle() const { return -1; }
+  virtual void GetSubtitleStreamInfo(int index, SPlayerSubtitleStreamInfo &info)const {};
+  virtual void SetSubtitle(int iStream) {};
+  virtual bool GetSubtitleVisible() const { return false;};
   virtual void SetSubtitleVisible(bool bVisible){};
 
   /** \brief Adds the subtitle(s) provided by the given file to the available player streams
@@ -279,25 +279,25 @@ public:
   */
   virtual void  AddSubtitle(const std::string& strSubPath) {};
 
-  virtual int  GetAudioStreamCount()  { return 0; }
-  virtual int  GetAudioStream()       { return -1; }
+  virtual int  GetAudioStreamCount() const { return 0; }
+  virtual int  GetAudioStream() const { return -1; }
   virtual void SetAudioStream(int iStream){};
-  virtual void GetAudioStreamInfo(int index, SPlayerAudioStreamInfo &info){};
+  virtual void GetAudioStreamInfo(int index, SPlayerAudioStreamInfo &info) const {};
 
   virtual int GetVideoStream() const { return -1; }
   virtual int GetVideoStreamCount() const { return 0; }
-  virtual void GetVideoStreamInfo(int streamId, SPlayerVideoStreamInfo &info) {}
+  virtual void GetVideoStreamInfo(int streamId, SPlayerVideoStreamInfo &info) const {}
   virtual void SetVideoStream(int iStream) {}
 
-  virtual TextCacheStruct_t* GetTeletextCache() { return NULL; };
+  virtual TextCacheStruct_t* GetTeletextCache() const { return NULL; };
   virtual void LoadPage(int p, int sp, unsigned char* buffer) {};
 
-  virtual std::string GetRadioText(unsigned int line) { return ""; };
+  virtual std::string GetRadioText(unsigned int line) const { return ""; };
 
-  virtual int  GetChapterCount()                               { return 0; }
-  virtual int  GetChapter()                                    { return -1; }
-  virtual void GetChapterName(std::string& strChapterName, int chapterIdx = -1) { return; }
-  virtual int64_t GetChapterPos(int chapterIdx=-1)             { return 0; }
+  virtual int  GetChapterCount() const { return 0; }
+  virtual int  GetChapter() const { return -1; }
+  virtual void GetChapterName(std::string& strChapterName, int chapterIdx = -1) const { return; }
+  virtual int64_t GetChapterPos(int chapterIdx=-1) const { return 0; }
   virtual int  SeekChapter(int iChapter)                       { return -1; }
 //  virtual bool GetChapterInfo(int chapter, SChapterInfo &info) { return false; }
 
@@ -311,7 +311,7 @@ public:
   /*!
    \brief current time in milliseconds
    */
-  virtual int64_t GetTime() { return 0; }
+  virtual int64_t GetTime() const { return 0; }
   /*!
    \brief Sets the current time. This 
    can be used for injecting the current time. 
@@ -323,17 +323,17 @@ public:
   /*!
    \brief total time in milliseconds
    */
-  virtual int64_t GetTotalTime() { return 0; }
+  virtual int64_t GetTotalTime() const { return 0; }
   /*!
    \brief Set the total time  in milliseconds
    this can be used for injecting the duration in case
    its not available in the underlaying decoder (airtunes for example)
    */
   virtual void SetTotalTime(int64_t time) { }
-  virtual int GetSourceBitrate(){ return 0;}
-  virtual bool GetStreamDetails(CStreamDetails &details){ return false;}
+  virtual int GetSourceBitrate() const { return 0;}
+  virtual bool GetStreamDetails(CStreamDetails &details) const { return false;}
   virtual void SetSpeed(int iSpeed) = 0;
-  virtual int GetSpeed() = 0;
+  virtual int GetSpeed() const = 0;
   // Skip to next track/item inside the current media (if supported).
   virtual bool SkipNext(){return false;}
 
@@ -349,10 +349,10 @@ public:
   virtual bool OnAction(const CAction &action) { return false; };
 
   //returns a state that is needed for resuming from a specific time
-  virtual std::string GetPlayerState() { return ""; };
+  virtual std::string GetPlayerState() const { return ""; };
   virtual bool SetPlayerState(const std::string& state) { return false;};
   
-  virtual std::string GetPlayingTitle() { return ""; };
+  virtual std::string GetPlayingTitle() const { return ""; };
 
   virtual bool SwitchChannel(const PVR::CPVRChannelPtr &channel) { return false; }
 
@@ -378,18 +378,18 @@ public:
    \brief define the audio capabilities of the player (default=all)
    */
 
-  virtual void GetAudioCapabilities(std::vector<int> &audioCaps) { audioCaps.assign(1,IPC_AUD_ALL); };
+  virtual void GetAudioCapabilities(std::vector<int> &audioCaps) const { audioCaps.assign(1,IPC_AUD_ALL); };
   /*!
    \brief define the subtitle capabilities of the player
    */
-  virtual void GetSubtitleCapabilities(std::vector<int> &subCaps) { subCaps.assign(1,IPC_SUBS_ALL); };
+  virtual void GetSubtitleCapabilities(std::vector<int> &subCaps) const { subCaps.assign(1,IPC_SUBS_ALL); };
 
   /*!
    \breif hook into render loop of render thread
    */
   virtual void FrameMove() {};
 
-  virtual bool HasFrame() { return false; };
+  virtual bool HasFrame() const { return false; };
 
   virtual void Render(bool clear, uint32_t alpha = 255, bool gui = true) {};
 
@@ -397,25 +397,25 @@ public:
 
   virtual void SetRenderViewMode(int mode) {};
 
-  virtual float GetRenderAspectRatio() { return 1.0; };
+  virtual float GetRenderAspectRatio() const { return 1.0; };
 
   virtual void TriggerUpdateResolution() {};
 
-  virtual bool IsRenderingVideo() { return false; };
+  virtual bool IsRenderingVideo() const { return false; };
 
-  virtual bool IsRenderingGuiLayer() { return false; };
+  virtual bool IsRenderingGuiLayer() const { return false; };
 
-  virtual bool IsRenderingVideoLayer() { return false; };
+  virtual bool IsRenderingVideoLayer() const { return false; };
 
-  virtual bool Supports(EDEINTERLACEMODE mode) { return false; };
-  virtual bool Supports(EINTERLACEMETHOD method) { return false; };
-  virtual bool Supports(ESCALINGMETHOD method) { return false; };
-  virtual bool Supports(ERENDERFEATURE feature) { return false; };
+  virtual bool Supports(EDEINTERLACEMODE mode) const { return false; };
+  virtual bool Supports(EINTERLACEMETHOD method) const { return false; };
+  virtual bool Supports(ESCALINGMETHOD method) const { return false; };
+  virtual bool Supports(ERENDERFEATURE feature) const { return false; };
 
   virtual unsigned int RenderCaptureAlloc() { return 0; };
   virtual void RenderCaptureRelease(unsigned int captureId) {};
   virtual void RenderCapture(unsigned int captureId, unsigned int width, unsigned int height, int flags) {};
-  virtual bool RenderCaptureGetPixels(unsigned int captureId, unsigned int millis, uint8_t *buffer, unsigned int size) { return false; };
+  virtual bool RenderCaptureGetPixels(unsigned int captureId, unsigned int millis, uint8_t *buffer, unsigned int size) const { return false; };
 
   std::string m_name;
   std::string m_type;

--- a/xbmc/cores/VideoPlayer/DVDClock.cpp
+++ b/xbmc/cores/VideoPlayer/DVDClock.cpp
@@ -55,7 +55,7 @@ CDVDClock::~CDVDClock()
 }
 
 // Returns the current absolute clock in units of DVD_TIME_BASE (usually microseconds).
-double CDVDClock::GetAbsoluteClock(bool interpolated /*= true*/)
+double CDVDClock::GetAbsoluteClock(bool interpolated /*= true*/) const
 {
   CSingleLock lock(m_systemsection);
 
@@ -95,7 +95,7 @@ void CDVDClock::SetVsyncAdjust(double adjustment)
   m_vSyncAdjust = adjustment;
 }
 
-double CDVDClock::GetVsyncAdjust()
+double CDVDClock::GetVsyncAdjust() const
 {
   CSingleLock lock(m_critSection);
   return m_vSyncAdjust;
@@ -160,7 +160,7 @@ void CDVDClock::SetSpeedAdjust(double adjust)
   m_speedAdjust = adjust;
 }
 
-double CDVDClock::GetSpeedAdjust()
+double CDVDClock::GetSpeedAdjust() const
 {
   CSingleLock lock(m_critSection);
   return m_speedAdjust;
@@ -260,12 +260,12 @@ bool CDVDClock::GetClockInfo(int& MissedVblanks, double& ClockSpeed, double& Ref
   return m_videoRefClock->GetClockInfo(MissedVblanks, ClockSpeed, RefreshRate);
 }
 
-double CDVDClock::SystemToAbsolute(int64_t system)
+double CDVDClock::SystemToAbsolute(int64_t system) const
 {
   return DVD_TIME_BASE * (double)(system - m_systemOffset) / m_systemFrequency;
 }
 
-int64_t CDVDClock::AbsoluteToSystem(double absolute)
+int64_t CDVDClock::AbsoluteToSystem(double absolute) const
 {
   return (int64_t)(absolute / DVD_TIME_BASE * m_systemFrequency) + m_systemOffset;
 }
@@ -295,7 +295,7 @@ double CDVDClock::SystemToPlaying(int64_t system)
   return DVD_TIME_BASE * (double)(current - m_startClock + m_systemAdjust) / m_systemUsed + m_iDisc;
 }
 
-double CDVDClock::GetClockSpeed()
+double CDVDClock::GetClockSpeed() const
 {
   double speed = (double)m_systemFrequency / m_systemUsed;
   return m_videoRefClock->GetSpeed() * speed;

--- a/xbmc/cores/VideoPlayer/DVDClock.h
+++ b/xbmc/cores/VideoPlayer/DVDClock.h
@@ -57,9 +57,9 @@ public:
   void Reset() { m_bReset = true; }
   void SetSpeed(int iSpeed);
   void SetSpeedAdjust(double adjust);
-  double GetSpeedAdjust();
+  double GetSpeedAdjust() const;
 
-  double GetClockSpeed(); /**< get the current speed of the clock relative normal system time */
+  double GetClockSpeed() const; /**< get the current speed of the clock relative normal system time */
 
   /* tells clock at what framerate video is, to  *
    * allow it to adjust speed for a better match */
@@ -67,18 +67,18 @@ public:
 
   void SetMaxSpeedAdjust(double speed);
 
-  double GetAbsoluteClock(bool interpolated = true);
-  double GetFrequency() { return (double)m_systemFrequency ; }
+  double GetAbsoluteClock(bool interpolated = true) const;
+  double GetFrequency() const { return (double)m_systemFrequency ; }
 
   bool GetClockInfo(int& MissedVblanks, double& ClockSpeed, double& RefreshRate) const;
   void SetVsyncAdjust(double adjustment);
-  double GetVsyncAdjust();
+  double GetVsyncAdjust() const;
 
   void Pause(bool pause);
 
 protected:
-  double SystemToAbsolute(int64_t system);
-  int64_t AbsoluteToSystem(double absolute);
+  double SystemToAbsolute(int64_t system) const;
+  int64_t AbsoluteToSystem(double absolute) const;
   double SystemToPlaying(int64_t system);
 
   CCriticalSection m_critSection;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.cpp
@@ -20,7 +20,7 @@
 
 #include "DVDDemux.h"
 
-std::string CDemuxStreamAudio::GetStreamType()
+std::string CDemuxStreamAudio::GetStreamType() const
 {
   char sInfo[64] = {0};
 
@@ -53,7 +53,7 @@ std::string CDemuxStreamAudio::GetStreamType()
   return sInfo;
 }
 
-int CDVDDemux::GetNrOfStreams(StreamType streamType)
+int CDVDDemux::GetNrOfStreams(StreamType streamType) const
 {
   int iCounter = 0;
 
@@ -65,12 +65,12 @@ int CDVDDemux::GetNrOfStreams(StreamType streamType)
   return iCounter;
 }
 
-int CDVDDemux::GetNrOfSubtitleStreams()
+int CDVDDemux::GetNrOfSubtitleStreams() const
 {
   return GetNrOfStreams(STREAM_SUBTITLE);
 }
 
-std::string CDemuxStream::GetStreamName()
+std::string CDemuxStream::GetStreamName() const
 {
   return "";
 }

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
@@ -101,7 +101,7 @@ public:
     delete [] ExtraData;
   }
 
-  virtual std::string GetStreamName();
+  virtual std::string GetStreamName() const;
 
   int uniqueId;          // unique stream id
   int dvdNavId;
@@ -189,7 +189,7 @@ public:
 
   virtual ~CDemuxStreamAudio() {}
 
-  std::string GetStreamType();
+  std::string GetStreamType() const;
 
   int iChannels;
   int iSampleRate;
@@ -270,25 +270,25 @@ public:
   /*
    * Get the number of chapters available
    */
-  virtual int GetChapterCount() { return 0; }
+  virtual int GetChapterCount() const { return 0; }
 
   /*
    * Get current chapter
    */
-  virtual int GetChapter() { return 0; }
+  virtual int GetChapter() const { return 0; }
 
   /*
    * Get the name of a chapter
    * \param strChapterName[out] Name of chapter
    * \param chapterIdx -1 for current chapter, else a chapter index
    */
-  virtual void GetChapterName(std::string& strChapterName, int chapterIdx=-1) {}
+  virtual void GetChapterName(std::string& strChapterName, int chapterIdx=-1) const {}
 
   /*
    * Get the position of a chapter
    * \param chapterIdx -1 for current chapter, else a chapter index
    */
-  virtual int64_t GetChapterPos(int chapterIdx=-1) { return 0; }
+  virtual int64_t GetChapterPos(int chapterIdx=-1) const { return 0; }
 
   /*
    * Set the playspeed, if demuxer can handle different
@@ -299,7 +299,7 @@ public:
   /*
    * returns the total time in msec
    */
-  virtual int GetStreamLength() = 0;
+  virtual int GetStreamLength() const = 0;
 
   /*
    * returns the stream or NULL on error
@@ -316,22 +316,22 @@ public:
   /*
    * returns opened filename
    */
-  virtual std::string GetFileName() = 0;
+  virtual std::string GetFileName() const = 0;
 
   /*
    * return nr of subtitle streams, 0 if none
    */
-  int GetNrOfSubtitleStreams();
+  int GetNrOfSubtitleStreams() const;
 
   /*
    * return a user-presentable codec name of the given stream
    */
-  virtual std::string GetStreamCodecName(int64_t demuxerId, int iStreamId) { return GetStreamCodecName(iStreamId); };
+  virtual std::string GetStreamCodecName(int64_t demuxerId, int iStreamId) const { return GetStreamCodecName(iStreamId); };
 
   /*
   * return true if demuxer supports enabling at a specific PTS
   */
-  virtual bool SupportsEnableAtPTS(int64_t demuxerId) { return SupportsEnableAtPTS(); };
+  virtual bool SupportsEnableAtPTS(int64_t demuxerId) const { return SupportsEnableAtPTS(); };
 
   /*
    * enable / disable demux stream
@@ -352,16 +352,16 @@ public:
   /*
   * return the id of the demuxer
   */
-  int64_t GetDemuxerId() { return m_demuxerId; };
+  int64_t GetDemuxerId() const { return m_demuxerId; };
 
 protected:
   virtual void EnableStream(int id, bool enable) {};
   virtual void EnableStreamAtPTS(int id, uint64_t pts) {};
-  virtual bool SupportsEnableAtPTS() { return false; };
+  virtual bool SupportsEnableAtPTS() const { return false; };
   virtual CDemuxStream* GetStream(int iStreamId) const = 0;
-  virtual std::string GetStreamCodecName(int iStreamId) { return ""; };
+  virtual std::string GetStreamCodecName(int iStreamId) const { return ""; };
 
-  int GetNrOfStreams(StreamType streamType);
+  int GetNrOfStreams(StreamType streamType) const;
 
   int64_t m_demuxerId;
 

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxBXA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxBXA.cpp
@@ -183,7 +183,7 @@ int CDVDDemuxBXA::GetNrOfStreams() const
   return (m_stream == NULL ? 0 : 1);
 }
 
-std::string CDVDDemuxBXA::GetFileName()
+std::string CDVDDemuxBXA::GetFileName() const
 {
   if(m_pInput)
     return m_pInput->GetFileName();
@@ -191,7 +191,7 @@ std::string CDVDDemuxBXA::GetFileName()
     return "";
 }
 
-std::string CDVDDemuxBXA::GetStreamCodecName(int iStreamId)
+std::string CDVDDemuxBXA::GetStreamCodecName(int iStreamId) const
 {
   if (m_stream && iStreamId == 0)
     return "BXA";

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxBXA.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxBXA.h
@@ -60,18 +60,20 @@ public:
 
   bool Open(CDVDInputStream* pInput);
   void Dispose();
-  void Reset();
-  void Abort();
-  void Flush();
-  DemuxPacket* Read();
-  bool SeekTime(int time, bool backwords = false, double* startpts = NULL) { return false; }
-  void SetSpeed(int iSpeed) {};
-  int GetStreamLength() { return (int)m_header.durationMs; }
+
+  // CDVDDemux implementation
+  void Reset() override;
+  void Abort() override;
+  void Flush() override;
+  DemuxPacket* Read() override;
+  bool SeekTime(int time, bool backwords = false, double* startpts = NULL) override { return false; }
+  void SetSpeed(int iSpeed) override {};
+  int GetStreamLength() const override { return (int)m_header.durationMs; }
   CDemuxStream* GetStream(int iStreamId) const override;
   std::vector<CDemuxStream*> GetStreams() const override;
   int GetNrOfStreams() const override;
-  std::string GetFileName();
-  virtual std::string GetStreamCodecName(int iStreamId) override;
+  std::string GetFileName() const override;
+  virtual std::string GetStreamCodecName(int iStreamId) const override;
 
 protected:
   friend class CDemuxStreamAudioBXA;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.h
@@ -31,17 +31,17 @@ public:
   CDVDDemuxCC(AVCodecID codec);
   virtual ~CDVDDemuxCC();
 
-  virtual void Reset() {};
-  virtual void Abort() {};
-  virtual void Flush() {};
-  virtual DemuxPacket* Read() { return NULL; };
-  virtual bool SeekTime(int time, bool backwords = false, double* startpts = NULL) {return true;};
-  virtual void SetSpeed(int iSpeed) {};
-  virtual int GetStreamLength() {return 0;};
+  virtual void Reset() override {};
+  virtual void Abort() override {};
+  virtual void Flush() override {};
+  virtual DemuxPacket* Read() override { return NULL; };
+  virtual bool SeekTime(int time, bool backwords = false, double* startpts = NULL) override {return true;};
+  virtual void SetSpeed(int iSpeed) override {};
+  virtual int GetStreamLength() const override {return 0;};
   virtual CDemuxStream* GetStream(int iStreamId) const override;
   virtual std::vector<CDemuxStream*> GetStreams() const override;
-  virtual int GetNrOfStreams() const;
-  virtual std::string GetFileName() {return "";};
+  virtual int GetNrOfStreams() const override;
+  virtual std::string GetFileName() const override {return "";};
 
   DemuxPacket* Read(DemuxPacket *packet);
   static void Handler(int service, void *userdata);

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCDDA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCDDA.cpp
@@ -153,7 +153,7 @@ bool CDVDDemuxCDDA::SeekTime(int time, bool backwords, double* startpts)
   return seekPos > 0;
 };
 
-int CDVDDemuxCDDA::GetStreamLength()
+int CDVDDemuxCDDA::GetStreamLength() const
 {
   int64_t num_track_bytes = m_pInput->GetLength();
   int bytes_per_second = (m_stream->iBitRate>>3);
@@ -186,7 +186,7 @@ int CDVDDemuxCDDA::GetNrOfStreams() const
   return (m_stream == NULL ? 0 : 1);
 }
 
-std::string CDVDDemuxCDDA::GetFileName()
+std::string CDVDDemuxCDDA::GetFileName() const
 {
   if(m_pInput)
     return m_pInput->GetFileName();
@@ -194,7 +194,7 @@ std::string CDVDDemuxCDDA::GetFileName()
     return "";
 }
 
-std::string CDVDDemuxCDDA::GetStreamCodecName(int iStreamId)
+std::string CDVDDemuxCDDA::GetStreamCodecName(int iStreamId) const
 {
   if (m_stream && iStreamId == 0)
     return "pcm";

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCDDA.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCDDA.h
@@ -41,18 +41,18 @@ public:
 
   bool Open(CDVDInputStream* pInput);
   void Dispose();
-  void Reset();
-  void Abort();
-  void Flush();
-  DemuxPacket* Read();
-  bool SeekTime(int time, bool backwords = false, double* startpts = NULL);
-  void SetSpeed(int iSpeed) {};
-  int GetStreamLength() ;
+  void Reset() override;
+  void Abort() override;
+  void Flush() override;
+  DemuxPacket* Read() override;
+  bool SeekTime(int time, bool backwords = false, double* startpts = NULL) override;
+  void SetSpeed(int iSpeed) override {};
+  int GetStreamLength() const override;
   CDemuxStream* GetStream(int iStreamId) const override;
   std::vector<CDemuxStream*> GetStreams() const override;
   int GetNrOfStreams() const override;
-  std::string GetFileName();
-  virtual std::string GetStreamCodecName(int iStreamId) override;
+  std::string GetFileName() const override;
+  virtual std::string GetStreamCodecName(int iStreamId) const override;
 
 protected:
   friend class CDemuxStreamAudioCDDA;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
@@ -554,7 +554,7 @@ int CDVDDemuxClient::GetNrOfStreams() const
   return m_streams.size();
 }
 
-std::string CDVDDemuxClient::GetFileName()
+std::string CDVDDemuxClient::GetFileName() const
 {
   if (m_pInput)
     return m_pInput->GetFileName();
@@ -562,7 +562,7 @@ std::string CDVDDemuxClient::GetFileName()
     return "";
 }
 
-std::string CDVDDemuxClient::GetStreamCodecName(int iStreamId)
+std::string CDVDDemuxClient::GetStreamCodecName(int iStreamId) const
 {
   CDemuxStream *stream = GetStream(iStreamId);
   std::string strName;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.h
@@ -43,13 +43,13 @@ public:
   DemuxPacket* Read() override;
   bool SeekTime(int time, bool backwords = false, double* startpts = NULL) override;
   void SetSpeed(int iSpeed) override;
-  int GetStreamLength() override { return 0; }
+  int GetStreamLength() const override { return 0; }
   CDemuxStream* GetStream(int iStreamId) const override;
   std::vector<CDemuxStream*> GetStreams() const override;
   int GetNrOfStreams() const override;
-  std::string GetFileName() override;
-  virtual std::string GetStreamCodecName(int iStreamId) override;
-  virtual bool SupportsEnableAtPTS() override { return m_IDemux ? m_IDemux->SupportsEnableAtPTS():false; };
+  std::string GetFileName() const override;
+  virtual std::string GetStreamCodecName(int iStreamId) const override;
+  virtual bool SupportsEnableAtPTS() const override { return m_IDemux ? m_IDemux->SupportsEnableAtPTS():false; };
   virtual void EnableStream(int id, bool enable) override;
   virtual void EnableStreamAtPTS(int id, uint64_t pts) override;
   virtual void SetVideoResolution(int width, int height) override;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -78,7 +78,7 @@ static const struct StereoModeConversionMap WmvToInternalStereoModeMap[] =
 
 #define FF_MAX_EXTRADATA_SIZE ((1 << 28) - FF_INPUT_BUFFER_PADDING_SIZE)
 
-std::string CDemuxStreamAudioFFmpeg::GetStreamName()
+std::string CDemuxStreamAudioFFmpeg::GetStreamName() const
 {
   if(!m_stream)
     return "";
@@ -88,7 +88,7 @@ std::string CDemuxStreamAudioFFmpeg::GetStreamName()
     return CDemuxStream::GetStreamName();
 }
 
-std::string CDemuxStreamSubtitleFFmpeg::GetStreamName()
+std::string CDemuxStreamSubtitleFFmpeg::GetStreamName() const
 {
   if(!m_stream)
     return "";
@@ -98,7 +98,7 @@ std::string CDemuxStreamSubtitleFFmpeg::GetStreamName()
     return CDemuxStream::GetStreamName();
 }
 
-std::string CDemuxStreamVideoFFmpeg::GetStreamName()
+std::string CDemuxStreamVideoFFmpeg::GetStreamName() const
 {
   if (!m_stream)
     return "";
@@ -177,7 +177,7 @@ CDVDDemuxFFmpeg::~CDVDDemuxFFmpeg()
   ff_flush_avutil_log_buffers();
 }
 
-bool CDVDDemuxFFmpeg::Aborted()
+bool CDVDDemuxFFmpeg::Aborted() const
 {
   if(m_timeout.IsTimePast())
     return true;
@@ -749,7 +749,7 @@ AVDictionary *CDVDDemuxFFmpeg::GetFFMpegOptionsFromURL(CURL &url)
   return options;
 }
 
-double CDVDDemuxFFmpeg::ConvertTimestamp(int64_t pts, int den, int num)
+double CDVDDemuxFFmpeg::ConvertTimestamp(int64_t pts, int den, int num) const
 {
   if (pts == (int64_t)AV_NOPTS_VALUE)
     return DVD_NOPTS_VALUE;
@@ -1109,7 +1109,7 @@ void CDVDDemuxFFmpeg::UpdateCurrentPTS()
   }
 }
 
-int CDVDDemuxFFmpeg::GetStreamLength()
+int CDVDDemuxFFmpeg::GetStreamLength() const
 {
   if (!m_pFormatContext)
     return 0;
@@ -1495,7 +1495,7 @@ void CDVDDemuxFFmpeg::AddStream(int streamIdx, CDemuxStream* stream)
 }
 
 
-std::string CDVDDemuxFFmpeg::GetFileName()
+std::string CDVDDemuxFFmpeg::GetFileName() const
 {
   if(m_pInput)
     return m_pInput->GetFileName();
@@ -1503,7 +1503,7 @@ std::string CDVDDemuxFFmpeg::GetFileName()
     return "";
 }
 
-int CDVDDemuxFFmpeg::GetChapterCount()
+int CDVDDemuxFFmpeg::GetChapterCount() const
 {
   CDVDInputStream::IChapter* ich = dynamic_cast<CDVDInputStream::IChapter*>(m_pInput);
   if(ich)
@@ -1515,7 +1515,7 @@ int CDVDDemuxFFmpeg::GetChapterCount()
   return m_pFormatContext->nb_chapters;
 }
 
-int CDVDDemuxFFmpeg::GetChapter()
+int CDVDDemuxFFmpeg::GetChapter() const
 {
   CDVDInputStream::IChapter* ich = dynamic_cast<CDVDInputStream::IChapter*>(m_pInput);
   if(ich)
@@ -1536,7 +1536,7 @@ int CDVDDemuxFFmpeg::GetChapter()
   return 0;
 }
 
-void CDVDDemuxFFmpeg::GetChapterName(std::string& strChapterName, int chapterIdx)
+void CDVDDemuxFFmpeg::GetChapterName(std::string& strChapterName, int chapterIdx) const
 {
   if (chapterIdx <= 0 || chapterIdx > GetChapterCount())
     chapterIdx = GetChapter();
@@ -1555,7 +1555,7 @@ void CDVDDemuxFFmpeg::GetChapterName(std::string& strChapterName, int chapterIdx
   }
 }
 
-int64_t CDVDDemuxFFmpeg::GetChapterPos(int chapterIdx)
+int64_t CDVDDemuxFFmpeg::GetChapterPos(int chapterIdx) const
 {
   if (chapterIdx <= 0 || chapterIdx > GetChapterCount())
     chapterIdx = GetChapter();
@@ -1601,7 +1601,7 @@ bool CDVDDemuxFFmpeg::SeekChapter(int chapter, double* startpts)
   return SeekTime(DVD_TIME_TO_MSEC(dts), true, startpts);
 }
 
-std::string CDVDDemuxFFmpeg::GetStreamCodecName(int iStreamId)
+std::string CDVDDemuxFFmpeg::GetStreamCodecName(int iStreamId) const
 {
   CDemuxStream *stream = GetStream(iStreamId);
   std::string strName;
@@ -1654,7 +1654,7 @@ std::string CDVDDemuxFFmpeg::GetStreamCodecName(int iStreamId)
   return strName;
 }
 
-bool CDVDDemuxFFmpeg::IsProgramChange()
+bool CDVDDemuxFFmpeg::IsProgramChange() const
 {
   if (m_program == UINT_MAX)
     return false;
@@ -1791,7 +1791,7 @@ void CDVDDemuxFFmpeg::ParsePacket(AVPacket *pkt)
   }
 }
 
-bool CDVDDemuxFFmpeg::IsVideoReady()
+bool CDVDDemuxFFmpeg::IsVideoReady() const
 {
   AVStream *st;
   bool hasVideo = false;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
@@ -45,7 +45,7 @@ public:
   {}
   std::string      m_description;
 
-  virtual std::string GetStreamName() override;
+  virtual std::string GetStreamName() const override;
 };
 
 
@@ -61,7 +61,7 @@ public:
   {}
   std::string m_description;
 
-  virtual std::string GetStreamName() override;
+  virtual std::string GetStreamName() const override;
 };
 
 class CDemuxStreamSubtitleFFmpeg
@@ -76,7 +76,7 @@ public:
   {}
   std::string m_description;
 
-  virtual std::string GetStreamName() override;
+  virtual std::string GetStreamName() const override;
 
 };
 
@@ -92,29 +92,29 @@ public:
 
   bool Open(CDVDInputStream* pInput, bool streaminfo = true, bool fileinfo = false);
   void Dispose();
-  void Reset();
-  void Flush();
-  void Abort();
-  void SetSpeed(int iSpeed);
-  virtual std::string GetFileName();
+  void Reset() override;
+  void Flush() override;
+  void Abort() override;
+  void SetSpeed(int iSpeed) override;
+  virtual std::string GetFileName() const override;
 
-  DemuxPacket* Read();
+  DemuxPacket* Read() override;
 
-  bool SeekTime(int time, bool backwords = false, double* startpts = NULL);
+  bool SeekTime(int time, bool backwords = false, double* startpts = NULL) override;
   bool SeekByte(int64_t pos);
-  int GetStreamLength();
+  int GetStreamLength() const override;
   CDemuxStream* GetStream(int iStreamId) const override;
   std::vector<CDemuxStream*> GetStreams() const override;
   int GetNrOfStreams() const override;
 
-  bool SeekChapter(int chapter, double* startpts = NULL);
-  int GetChapterCount();
-  int GetChapter();
-  void GetChapterName(std::string& strChapterName, int chapterIdx=-1);
-  int64_t GetChapterPos(int chapterIdx=-1);
-  virtual std::string GetStreamCodecName(int iStreamId) override;
+  bool SeekChapter(int chapter, double* startpts = NULL) override;
+  int GetChapterCount() const override;
+  int GetChapter() const override;
+  void GetChapterName(std::string& strChapterName, int chapterIdx=-1) const override;
+  int64_t GetChapterPos(int chapterIdx=-1) const override;
+  virtual std::string GetStreamCodecName(int iStreamId) const override;
 
-  bool Aborted();
+  bool Aborted() const;
 
   AVFormatContext* m_pFormatContext;
   CDVDInputStream* m_pInput;
@@ -130,13 +130,13 @@ protected:
   void CreateStreams(unsigned int program = UINT_MAX);
   void DisposeStreams();
   void ParsePacket(AVPacket *pkt);
-  bool IsVideoReady();
+  bool IsVideoReady() const;
   void ResetVideoStreams();
 
   AVDictionary *GetFFMpegOptionsFromURL(CURL &url);
-  double ConvertTimestamp(int64_t pts, int den, int num);
+  double ConvertTimestamp(int64_t pts, int den, int num) const;
   void UpdateCurrentPTS();
-  bool IsProgramChange();
+  bool IsProgramChange() const;
 
   std::string GetStereoModeFromMetadata(AVDictionary *pMetadata);
   std::string ConvertCodecToInternalStereoMode(const std::string &mode, const StereoModeConversionMap *conversionMap);

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxVobsub.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxVobsub.h
@@ -35,17 +35,17 @@ public:
   CDVDDemuxVobsub();
   virtual ~CDVDDemuxVobsub();
 
-  virtual void          Reset();
-  virtual void          Abort() {};
-  virtual void          Flush();
-  virtual DemuxPacket*  Read();
-  virtual bool          SeekTime(int time, bool backwords, double* startpts = NULL);
-  virtual void          SetSpeed(int speed) {}
+  virtual void          Reset() override;
+  virtual void          Abort() override {};
+  virtual void          Flush() override;
+  virtual DemuxPacket*  Read() override;
+  virtual bool          SeekTime(int time, bool backwords, double* startpts = NULL) override;
+  virtual void          SetSpeed(int speed) override {}
   virtual CDemuxStream* GetStream(int index) const override { return m_Streams[index]; }
   virtual std::vector<CDemuxStream*> GetStreams() const override;
   virtual int           GetNrOfStreams() const override { return m_Streams.size(); }
-  virtual int           GetStreamLength()    { return 0; }
-  virtual std::string   GetFileName()        { return m_Filename; }
+  virtual int           GetStreamLength() const override { return 0; }
+  virtual std::string   GetFileName() const override { return m_Filename; }
 
   bool                  Open(const std::string& filename, int source, const std::string& subfilename);
   virtual void EnableStream(int id, bool enable) override;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DemuxMultiSource.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DemuxMultiSource.cpp
@@ -123,7 +123,7 @@ std::vector<CDemuxStream*> CDemuxMultiSource::GetStreams() const
   return streams;
 }
 
-std::string CDemuxMultiSource::GetStreamCodecName(int64_t demuxerId, int iStreamId)
+std::string CDemuxMultiSource::GetStreamCodecName(int64_t demuxerId, int iStreamId) const
 {
   auto iter = m_demuxerMap.find(demuxerId);
   if (iter != m_demuxerMap.end())
@@ -134,7 +134,7 @@ std::string CDemuxMultiSource::GetStreamCodecName(int64_t demuxerId, int iStream
     return "";
 };
 
-int CDemuxMultiSource::GetStreamLength()
+int CDemuxMultiSource::GetStreamLength() const
 {
   int length = 0;
   for (auto& iter : m_demuxerMap)
@@ -269,7 +269,7 @@ void CDemuxMultiSource::SetMissingStreamDetails(DemuxPtr demuxer)
   }
 }
 
-bool CDemuxMultiSource::SupportsEnableAtPTS(int64_t demuxerId)
+bool CDemuxMultiSource::SupportsEnableAtPTS(int64_t demuxerId) const
 {
   auto iter = m_demuxerMap.find(demuxerId);
   if (iter != m_demuxerMap.end())

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DemuxMultiSource.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DemuxMultiSource.h
@@ -46,23 +46,23 @@ public:
   CDemuxMultiSource();
   virtual ~CDemuxMultiSource();
   
-  void Abort();
+  void Abort() override;
   virtual void EnableStream(int64_t demuxerId, int id, bool enable) override;
   virtual void EnableStreamAtPTS(int64_t demuxerId, int id, uint64_t pts) override;
-  void Flush();
-  virtual std::string GetFileName() { return ""; };
+  void Flush() override;
+  virtual std::string GetFileName() const override { return ""; };
   int GetNrOfStreams() const override;
-  virtual CDemuxStream* GetStream(int iStreamId)const override { return nullptr; } ;
+  virtual CDemuxStream* GetStream(int iStreamId) const override { return nullptr; } ;
   virtual CDemuxStream* GetStream(int64_t demuxerId, int iStreamId) const override;
   virtual std::vector<CDemuxStream*> GetStreams() const override;
-  std::string GetStreamCodecName(int64_t demuxerId, int iStreamId) override;
-  int GetStreamLength();
+  std::string GetStreamCodecName(int64_t demuxerId, int iStreamId) const override;
+  int GetStreamLength() const override;
   bool Open(CDVDInputStream* pInput);
-  DemuxPacket* Read();
-  void Reset();
-  bool SeekTime(int time, bool backwords = false, double* startpts = NULL);
-  virtual void SetSpeed(int iSpeed) {};
-  virtual bool SupportsEnableAtPTS(int64_t demuxerId) override;
+  DemuxPacket* Read() override;
+  void Reset() override;
+  bool SeekTime(int time, bool backwords = false, double* startpts = NULL) override;
+  virtual void SetSpeed(int iSpeed) override {};
+  virtual bool SupportsEnableAtPTS(int64_t demuxerId) const override;
 
 private:
   void Dispose();

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.cpp
@@ -47,7 +47,7 @@ void CDVDInputStream::Close()
 
 }
 
-std::string CDVDInputStream::GetFileName()
+std::string CDVDInputStream::GetFileName() const
 {
   CURL url(m_item.GetPath());
 
@@ -55,7 +55,7 @@ std::string CDVDInputStream::GetFileName()
   return url.Get();
 }
 
-CURL CDVDInputStream::GetURL()
+CURL CDVDInputStream::GetURL() const
 {
   return m_item.GetURL();
 }

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
@@ -66,8 +66,8 @@ public:
   {
     public:
     virtual ~IDisplayTime() {};
-    virtual int GetTotalTime() = 0;
-    virtual int GetTime() = 0;
+    virtual int GetTotalTime() const = 0;
+    virtual int GetTime() const = 0;
   };
 
   class IPosTime
@@ -81,10 +81,10 @@ public:
   {
     public:
     virtual ~IChapter() {};
-    virtual int  GetChapter() = 0;
-    virtual int  GetChapterCount() = 0;
-    virtual void GetChapterName(std::string& name, int ch=-1) = 0;
-    virtual int64_t GetChapterPos(int ch=-1) = 0;
+    virtual int  GetChapter() const = 0;
+    virtual int  GetChapterCount() const = 0;
+    virtual void GetChapterName(std::string& name, int ch=-1) const = 0;
+    virtual int64_t GetChapterPos(int ch=-1) const = 0;
     virtual bool SeekChapter(int ch) = 0;
   };
 
@@ -94,8 +94,8 @@ public:
     virtual ~IMenus() {};
     virtual void ActivateButton() = 0;
     virtual void SelectButton(int iButton) = 0;
-    virtual int  GetCurrentButton() = 0;
-    virtual int  GetTotalButtons() = 0;
+    virtual int  GetCurrentButton() const = 0;
+    virtual int  GetTotalButtons() const = 0;
     virtual void OnUp() = 0;
     virtual void OnDown() = 0;
     virtual void OnLeft() = 0;
@@ -106,11 +106,11 @@ public:
     virtual void OnPrevious() = 0;
     virtual bool OnMouseMove(const CPoint &point) = 0;
     virtual bool OnMouseClick(const CPoint &point) = 0;
-    virtual bool HasMenu() = 0;
-    virtual bool IsInMenu() = 0;
+    virtual bool HasMenu() const = 0;
+    virtual bool IsInMenu() const = 0;
     virtual void SkipStill() = 0;
-    virtual double GetTimeStampCorrection() { return 0.0; };
-    virtual bool GetState(std::string &xmlstate) = 0;
+    virtual double GetTimeStampCorrection() const { return 0.0; };
+    virtual bool GetState(std::string &xmlstate) const = 0;
     virtual bool SetState(const std::string &xmlstate) = 0;
   };
 
@@ -147,16 +147,16 @@ public:
   virtual int Read(uint8_t* buf, int buf_size) = 0;
   virtual int64_t Seek(int64_t offset, int whence) = 0;
   virtual bool Pause(double dTime) = 0;
-  virtual int64_t GetLength() = 0;
+  virtual int64_t GetLength() const = 0;
   virtual std::string& GetContent() { return m_content; };
-  virtual std::string GetFileName();
-  virtual CURL GetURL();
+  virtual std::string GetFileName() const;
+  virtual CURL GetURL() const;
   virtual ENextStream NextStream() { return NEXTSTREAM_NONE; }
   virtual void Abort() {}
-  virtual int GetBlockSize() { return 0; }
+  virtual int GetBlockSize() const { return 0; }
   virtual void ResetScanTimeout(unsigned int iTimeoutMs) { }
-  virtual bool CanSeek() { return true; }
-  virtual bool CanPause() { return true; }
+  virtual bool CanSeek() const { return true; }
+  virtual bool CanPause() const { return true; }
 
   /*! \brief Indicate expected read rate in bytes per second.
    *  This could be used to throttle caching rate. Should
@@ -167,15 +167,15 @@ public:
   /*! \brief Get the cache status
    \return true when cache status was succesfully obtained
    */
-  virtual bool GetCacheStatus(XFILE::SCacheStatus *status) { return false; }
+  virtual bool GetCacheStatus(XFILE::SCacheStatus *status) const { return false; }
 
   bool IsStreamType(DVDStreamType type) const { return m_streamType == type; }
-  virtual bool IsEOF() = 0;
+  virtual bool IsEOF() const = 0;
   virtual BitstreamStats GetBitstreamStats() const { return m_stats; }
 
-  bool ContentLookup() { return m_contentLookup; }
+  bool ContentLookup() const { return m_contentLookup; }
 
-  virtual bool IsRealtime() { return m_realtime; }
+  virtual bool IsRealtime() const { return m_realtime; }
 
   void SetRealtime(bool realtime) { m_realtime = realtime; }
 

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -224,7 +224,7 @@ void CDVDInputStreamBluray::Abort()
   m_hold = HOLD_EXIT;
 }
 
-bool CDVDInputStreamBluray::IsEOF()
+bool CDVDInputStreamBluray::IsEOF() const
 {
   return false;
 }
@@ -892,7 +892,7 @@ void CDVDInputStreamBluray::OverlayCallbackARGB(const struct bd_argb_overlay_s *
 #endif
 
 
-int CDVDInputStreamBluray::GetTotalTime()
+int CDVDInputStreamBluray::GetTotalTime() const
 {
   if(m_title)
     return (int)(m_title->duration / 90);
@@ -900,7 +900,7 @@ int CDVDInputStreamBluray::GetTotalTime()
     return 0;
 }
 
-int CDVDInputStreamBluray::GetTime()
+int CDVDInputStreamBluray::GetTime() const
 {
   return m_dispTimeBeforeRead;
 }
@@ -913,7 +913,7 @@ bool CDVDInputStreamBluray::PosTime(int ms)
     return true;
 }
 
-int CDVDInputStreamBluray::GetChapterCount()
+int CDVDInputStreamBluray::GetChapterCount() const
 {
   if(m_title)
     return m_title->chapter_count;
@@ -921,7 +921,7 @@ int CDVDInputStreamBluray::GetChapterCount()
     return 0;
 }
 
-int CDVDInputStreamBluray::GetChapter()
+int CDVDInputStreamBluray::GetChapter() const
 {
   if(m_title)
     return m_dll->bd_get_current_chapter(m_bd) + 1;
@@ -937,7 +937,7 @@ bool CDVDInputStreamBluray::SeekChapter(int ch)
     return true;
 }
 
-int64_t CDVDInputStreamBluray::GetChapterPos(int ch)
+int64_t CDVDInputStreamBluray::GetChapterPos(int ch) const
 {
   if (ch == -1 || ch > GetChapterCount())
     ch = GetChapter();
@@ -983,7 +983,7 @@ int64_t CDVDInputStreamBluray::Seek(int64_t offset, int whence)
 #endif
 }
 
-int64_t CDVDInputStreamBluray::GetLength()
+int64_t CDVDInputStreamBluray::GetLength() const
 {
   return m_dll->bd_get_title_size(m_bd);
 }
@@ -1002,7 +1002,7 @@ static bool find_stream(int pid, BLURAY_STREAM_INFO *info, int count, char* lang
   return true;
 }
 
-void CDVDInputStreamBluray::GetStreamInfo(int pid, char* language)
+void CDVDInputStreamBluray::GetStreamInfo(int pid, char* language) const
 {
   if(!m_title || m_clip >= m_title->clip_count)
     return;
@@ -1106,7 +1106,7 @@ void CDVDInputStreamBluray::OnMenu()
     CLog::Log(LOGDEBUG, "CDVDInputStreamBluray::OnMenu - root failed");
 }
 
-bool CDVDInputStreamBluray::IsInMenu()
+bool CDVDInputStreamBluray::IsInMenu() const
 {
   if(m_bd == NULL || !m_navmode)
     return false;
@@ -1127,7 +1127,7 @@ void CDVDInputStreamBluray::SkipStill()
   }
 }
 
-bool CDVDInputStreamBluray::HasMenu()
+bool CDVDInputStreamBluray::HasMenu() const
 {
   return m_navmode;
 }

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h
@@ -49,66 +49,66 @@ class CDVDInputStreamBluray
 public:
   CDVDInputStreamBluray(IVideoPlayer* player, const CFileItem& fileitem);
   virtual ~CDVDInputStreamBluray();
-  virtual bool Open();
-  virtual void Close();
-  virtual int Read(uint8_t* buf, int buf_size);
-  virtual int64_t Seek(int64_t offset, int whence);
-  virtual bool Pause(double dTime) { return false; };
-  void Abort();
-  virtual bool IsEOF();
-  virtual int64_t GetLength();
-  virtual int GetBlockSize() { return 6144; }
-  virtual ENextStream NextStream();
+  virtual bool Open() override;
+  virtual void Close() override;
+  virtual int Read(uint8_t* buf, int buf_size) override;
+  virtual int64_t Seek(int64_t offset, int whence) override;
+  virtual bool Pause(double dTime) override { return false; };
+  void Abort() override;
+  virtual bool IsEOF() const  override;
+  virtual int64_t GetLength() const override;
+  virtual int GetBlockSize() const override { return 6144; }
+  virtual ENextStream NextStream() override;
 
 
   /* IMenus */
-  virtual void ActivateButton()          { UserInput(BD_VK_ENTER); }
-  virtual void SelectButton(int iButton)
+  virtual void ActivateButton() override          { UserInput(BD_VK_ENTER); }
+  virtual void SelectButton(int iButton) override
   {
     if(iButton < 10)
       UserInput((bd_vk_key_e)(BD_VK_0 + iButton));
   }
-  virtual int  GetCurrentButton()        { return 0; }
-  virtual int  GetTotalButtons()         { return 0; }
-  virtual void OnUp()                    { UserInput(BD_VK_UP); }
-  virtual void OnDown()                  { UserInput(BD_VK_DOWN); }
-  virtual void OnLeft()                  { UserInput(BD_VK_LEFT); }
-  virtual void OnRight()                 { UserInput(BD_VK_RIGHT); }
-  virtual void OnMenu();
-  virtual void OnBack()
+  virtual int  GetCurrentButton() const override        { return 0; }
+  virtual int  GetTotalButtons() const override         { return 0; }
+  virtual void OnUp() override                    { UserInput(BD_VK_UP); }
+  virtual void OnDown() override                  { UserInput(BD_VK_DOWN); }
+  virtual void OnLeft() override                  { UserInput(BD_VK_LEFT); }
+  virtual void OnRight() override                { UserInput(BD_VK_RIGHT); }
+  virtual void OnMenu() override;
+  virtual void OnBack() override
   {
     if(IsInMenu())
       OnMenu();
   }
-  virtual void OnNext()                  {}
-  virtual void OnPrevious()              {}
-  virtual bool HasMenu();
-  virtual bool IsInMenu();
-  virtual bool OnMouseMove(const CPoint &point)  { return MouseMove(point); }
-  virtual bool OnMouseClick(const CPoint &point) { return MouseClick(point); }
-  virtual void SkipStill();
-  virtual bool GetState(std::string &xmlstate)         { return false; }
-  virtual bool SetState(const std::string &xmlstate)   { return false; }
+  virtual void OnNext() override                  {}
+  virtual void OnPrevious() override              {}
+  virtual bool HasMenu() const override;
+  virtual bool IsInMenu() const override;
+  virtual bool OnMouseMove(const CPoint &point) override  { return MouseMove(point); }
+  virtual bool OnMouseClick(const CPoint &point) override { return MouseClick(point); }
+  virtual void SkipStill() override;
+  virtual bool GetState(std::string &xmlstate) const override         { return false; }
+  virtual bool SetState(const std::string &xmlstate) override   { return false; }
 
 
   void UserInput(bd_vk_key_e vk);
   bool MouseMove(const CPoint &point);
   bool MouseClick(const CPoint &point);
 
-  int GetChapter();
-  int GetChapterCount();
-  void GetChapterName(std::string& name, int ch=-1) {};
-  int64_t GetChapterPos(int ch);
-  bool SeekChapter(int ch);
+  int GetChapter() const override;
+  int GetChapterCount() const override;
+  void GetChapterName(std::string& name, int ch=-1) const override {};
+  int64_t GetChapterPos(int ch) const override;
+  bool SeekChapter(int ch) override;
 
   CDVDInputStream::IDisplayTime* GetIDisplayTime() override { return this; }
-  int GetTotalTime() override;
-  int GetTime() override;
+  int GetTotalTime() const override;
+  int GetTime() const override;
 
   CDVDInputStream::IPosTime* GetIPosTime() override { return this; }
-  bool PosTime(int ms);
+  bool PosTime(int ms) override;
 
-  void GetStreamInfo(int pid, char* language);
+  void GetStreamInfo(int pid, char* language) const;
 
   void OverlayCallback(const BD_OVERLAY * const);
 #ifdef HAVE_LIBBLURAY_BDJ

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFFmpeg.cpp
@@ -46,7 +46,7 @@ CDVDInputStreamFFmpeg::~CDVDInputStreamFFmpeg()
   Close();
 }
 
-bool CDVDInputStreamFFmpeg::IsEOF()
+bool CDVDInputStreamFFmpeg::IsEOF() const
 {
   if(m_aborted)
     return true;
@@ -106,7 +106,7 @@ int CDVDInputStreamFFmpeg::Read(uint8_t* buf, int buf_size)
   return -1;
 }
 
-int64_t CDVDInputStreamFFmpeg::GetLength()
+int64_t CDVDInputStreamFFmpeg::GetLength() const
 {
   return 0;
 }

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFFmpeg.h
@@ -28,21 +28,21 @@ class CDVDInputStreamFFmpeg
 public:
   CDVDInputStreamFFmpeg(const CFileItem& fileitem);
   virtual ~CDVDInputStreamFFmpeg();
-  virtual bool Open();
-  virtual void Close();
-  virtual int Read(uint8_t* buf, int buf_size);
-  virtual int64_t Seek(int64_t offset, int whence);
-  virtual bool Pause(double dTime) { return false; };
-  virtual bool IsEOF();
-  virtual int64_t GetLength();
+  virtual bool Open() override;
+  virtual void Close() override;
+  virtual int Read(uint8_t* buf, int buf_size) override;
+  virtual int64_t Seek(int64_t offset, int whence) override;
+  virtual bool Pause(double dTime) override { return false; };
+  virtual bool IsEOF() const override;
+  virtual int64_t GetLength() const override;
 
-  virtual void  Abort() { m_aborted = true;  }
-  bool Aborted() { return m_aborted;  }
+  virtual void  Abort() override { m_aborted = true;  }
+  bool Aborted() const { return m_aborted;  }
 
   const CFileItem& GetItem() const { return m_item; }
 
-  bool CanSeek() { return m_can_seek; }
-  bool CanPause() { return m_can_pause; }
+  bool CanSeek() const override { return m_can_seek; }
+  bool CanPause() const override { return m_can_pause; }
 
   std::string GetProxyType() const;
   std::string GetProxyHost() const;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFile.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFile.cpp
@@ -38,7 +38,7 @@ CDVDInputStreamFile::~CDVDInputStreamFile()
   Close();
 }
 
-bool CDVDInputStreamFile::IsEOF()
+bool CDVDInputStreamFile::IsEOF() const
 {
   return !m_pFile || m_eof;
 }
@@ -149,14 +149,14 @@ int64_t CDVDInputStreamFile::Seek(int64_t offset, int whence)
   return ret;
 }
 
-int64_t CDVDInputStreamFile::GetLength()
+int64_t CDVDInputStreamFile::GetLength() const
 {
   if (m_pFile)
     return m_pFile->GetLength();
   return 0;
 }
 
-bool CDVDInputStreamFile::GetCacheStatus(XFILE::SCacheStatus *status)
+bool CDVDInputStreamFile::GetCacheStatus(XFILE::SCacheStatus *status) const
 {
   if(m_pFile && m_pFile->IoControl(IOCTRL_CACHE_STATUS, status) >= 0)
     return true;
@@ -175,7 +175,7 @@ BitstreamStats CDVDInputStreamFile::GetBitstreamStats() const
     return m_stats;
 }
 
-int CDVDInputStreamFile::GetBlockSize()
+int CDVDInputStreamFile::GetBlockSize() const
 {
   if(m_pFile)
     return m_pFile->GetChunkSize();

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFile.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFile.h
@@ -27,17 +27,17 @@ class CDVDInputStreamFile : public CDVDInputStream
 public:
   CDVDInputStreamFile(const CFileItem& fileitem);
   virtual ~CDVDInputStreamFile();
-  virtual bool Open();
-  virtual void Close();
-  virtual int Read(uint8_t* buf, int buf_size);
-  virtual int64_t Seek(int64_t offset, int whence);
-  virtual bool Pause(double dTime) { return false; };
-  virtual bool IsEOF();
-  virtual int64_t GetLength();
-  virtual BitstreamStats GetBitstreamStats() const ;
-  virtual int GetBlockSize();
-  virtual void SetReadRate(unsigned rate);
-  virtual bool GetCacheStatus(XFILE::SCacheStatus *status);
+  virtual bool Open() override;
+  virtual void Close() override;
+  virtual int Read(uint8_t* buf, int buf_size) override;
+  virtual int64_t Seek(int64_t offset, int whence) override;
+  virtual bool Pause(double dTime) override { return false; };
+  virtual bool IsEOF() const override;
+  virtual int64_t GetLength() const override;
+  virtual BitstreamStats GetBitstreamStats() const override;
+  virtual int GetBlockSize() const override;
+  virtual void SetReadRate(unsigned rate) override;
+  virtual bool GetCacheStatus(XFILE::SCacheStatus *status) const override;
 
 protected:
   XFILE::CFile* m_pFile;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -672,7 +672,7 @@ void CDVDInputStreamNavigator::SelectButton(int iButton)
   m_dll.dvdnav_button_select(m_dvdnav, m_dll.dvdnav_get_current_nav_pci(m_dvdnav), iButton);
 }
 
-int CDVDInputStreamNavigator::GetCurrentButton()
+int CDVDInputStreamNavigator::GetCurrentButton() const
 {
   int button;
   if (m_dvdnav)
@@ -721,7 +721,7 @@ void CDVDInputStreamNavigator::CheckButtons()
   }
 }
 
-int CDVDInputStreamNavigator::GetTotalButtons()
+int CDVDInputStreamNavigator::GetTotalButtons() const
 {
   if (!m_dvdnav) return 0;
 
@@ -835,7 +835,7 @@ CDVDInputStream::ENextStream CDVDInputStreamNavigator::NextStream()
     return NEXTSTREAM_RETRY;
 }
 
-int CDVDInputStreamNavigator::GetActiveSubtitleStream()
+int CDVDInputStreamNavigator::GetActiveSubtitleStream() const
 {
   int activeStream = 0;
 
@@ -864,7 +864,7 @@ int CDVDInputStreamNavigator::GetActiveSubtitleStream()
   return activeStream;
 }
 
-DVDNavSubtitleStreamInfo CDVDInputStreamNavigator::GetSubtitleStreamInfo(const int iId)
+DVDNavSubtitleStreamInfo CDVDInputStreamNavigator::GetSubtitleStreamInfo(const int iId) const
 {
   DVDNavSubtitleStreamInfo info;
   if (!m_dvdnav)
@@ -920,7 +920,7 @@ void CDVDInputStreamNavigator::SetSubtitleStreamName(DVDNavStreamInfo &info, con
   }
 }
 
-int CDVDInputStreamNavigator::GetSubTitleStreamCount()
+int CDVDInputStreamNavigator::GetSubTitleStreamCount() const
 {
   if (!m_dvdnav) return 0;
 
@@ -1177,13 +1177,13 @@ bool CDVDInputStreamNavigator::GetCurrentButtonInfo(CDVDOverlaySpu* pOverlayPict
   return true;
 }
 
-int CDVDInputStreamNavigator::GetTotalTime()
+int CDVDInputStreamNavigator::GetTotalTime() const
 {
   //We use buffers of this as they can get called from multiple threads, and could block if we are currently reading data
   return m_iTotalTime;
 }
 
-int CDVDInputStreamNavigator::GetTime()
+int CDVDInputStreamNavigator::GetTime() const
 {
   //We use buffers of this as they can get called from multiple threads, and could block if we are currently reading data
   return m_iTime;
@@ -1245,7 +1245,7 @@ bool CDVDInputStreamNavigator::SeekChapter(int iChapter)
   return true;
 }
 
-float CDVDInputStreamNavigator::GetVideoAspectRatio()
+float CDVDInputStreamNavigator::GetVideoAspectRatio() const
 {
   int iAspect = m_dll.dvdnav_get_video_aspect(m_dvdnav);
   int iPerm = m_dll.dvdnav_get_video_scale_permission(m_dvdnav);
@@ -1281,7 +1281,7 @@ void CDVDInputStreamNavigator::EnableSubtitleStream(bool bEnable)
     vm->state.SPST_REG &= ~0x40;
 }
 
-bool CDVDInputStreamNavigator::IsSubtitleStreamEnabled()
+bool CDVDInputStreamNavigator::IsSubtitleStreamEnabled() const
 {
   if (!m_dvdnav)
     return false;
@@ -1297,7 +1297,7 @@ bool CDVDInputStreamNavigator::IsSubtitleStreamEnabled()
     return false;
 }
 
-bool CDVDInputStreamNavigator::GetState(std::string &xmlstate)
+bool CDVDInputStreamNavigator::GetState(std::string &xmlstate) const
 {
   if( !m_dvdnav )
     return false;
@@ -1420,7 +1420,7 @@ int CDVDInputStreamNavigator::ConvertAudioStreamId_ExternalToXBMC(int id)
   }
 }
 
-int CDVDInputStreamNavigator::ConvertSubtitleStreamId_XBMCToExternal(int id)
+int CDVDInputStreamNavigator::ConvertSubtitleStreamId_XBMCToExternal(int id) const
 {
   if (!m_dvdnav)
     return -1;
@@ -1447,7 +1447,7 @@ int CDVDInputStreamNavigator::ConvertSubtitleStreamId_XBMCToExternal(int id)
   return -1;
 }
 
-int CDVDInputStreamNavigator::ConvertSubtitleStreamId_ExternalToXBMC(int id)
+int CDVDInputStreamNavigator::ConvertSubtitleStreamId_ExternalToXBMC(int id) const
 {
   if  (!m_dvdnav) return -1;
   vm_t* vm = m_dll.dvdnav_get_vm(m_dvdnav);
@@ -1491,7 +1491,7 @@ int CDVDInputStreamNavigator::ConvertSubtitleStreamId_ExternalToXBMC(int id)
   }
 }
 
-std::string CDVDInputStreamNavigator::GetDVDTitleString()
+std::string CDVDInputStreamNavigator::GetDVDTitleString() const
 {
   if (!m_dvdnav)
     return "";
@@ -1503,7 +1503,7 @@ std::string CDVDInputStreamNavigator::GetDVDTitleString()
     return "";
 }
 
-std::string CDVDInputStreamNavigator::GetDVDSerialString()
+std::string CDVDInputStreamNavigator::GetDVDSerialString() const
 {
   if (!m_dvdnav)
     return "";
@@ -1515,15 +1515,15 @@ std::string CDVDInputStreamNavigator::GetDVDSerialString()
     return "";
 }
 
-int64_t CDVDInputStreamNavigator::GetChapterPos(int ch)
+int64_t CDVDInputStreamNavigator::GetChapterPos(int ch) const
 {
   if (ch == -1 || ch > GetChapterCount()) 
     ch = GetChapter();
 
-  std::map<int, std::map<int, int64_t>>::iterator title = m_mapTitleChapters.find(m_iTitle);
+  std::map<int, std::map<int, int64_t>>::const_iterator title = m_mapTitleChapters.find(m_iTitle);
   if (title != m_mapTitleChapters.end())
   {
-    std::map<int, int64_t>::iterator chapter = title->second.find(ch);
+    std::map<int, int64_t>::const_iterator chapter = title->second.find(ch);
     if (chapter != title->second.end())
       return chapter->second;
   }

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.h
@@ -110,46 +110,46 @@ public:
   CDVDInputStreamNavigator(IVideoPlayer* player, const CFileItem& fileitem);
   virtual ~CDVDInputStreamNavigator();
 
-  virtual bool Open();
-  virtual void Close();
-  virtual int Read(uint8_t* buf, int buf_size);
-  virtual int64_t Seek(int64_t offset, int whence);
-  virtual bool Pause(double dTime) { return false; };
-  virtual int GetBlockSize() { return DVDSTREAM_BLOCK_SIZE_DVD; }
-  virtual bool IsEOF() { return m_bEOF; }
-  virtual int64_t GetLength()             { return 0; }
-  virtual ENextStream NextStream() ;
+  virtual bool Open() override;
+  virtual void Close() override;
+  virtual int Read(uint8_t* buf, int buf_size) override;
+  virtual int64_t Seek(int64_t offset, int whence) override;
+  virtual bool Pause(double dTime) override { return false; };
+  virtual int GetBlockSize() const override { return DVDSTREAM_BLOCK_SIZE_DVD; }
+  virtual bool IsEOF() const override { return m_bEOF; }
+  virtual int64_t GetLength() const override { return 0; }
+  virtual ENextStream NextStream() override;
 
-  void ActivateButton();
-  void SelectButton(int iButton);
-  void SkipStill();
+  void ActivateButton() override;
+  void SelectButton(int iButton) override;
+  void SkipStill() override;
   void SkipWait();
-  void OnUp();
-  void OnDown();
-  void OnLeft();
-  void OnRight();
-  void OnMenu();
-  void OnBack();
-  void OnNext();
-  void OnPrevious();
-  bool OnMouseMove(const CPoint &point);
-  bool OnMouseClick(const CPoint &point);
+  void OnUp() override;
+  void OnDown() override;
+  void OnLeft() override;
+  void OnRight() override;
+  void OnMenu() override;
+  void OnBack() override;
+  void OnNext() override;
+  void OnPrevious() override;
+  bool OnMouseMove(const CPoint &point) override;
+  bool OnMouseClick(const CPoint &point) override;
 
-  int GetCurrentButton();
-  int GetTotalButtons();
+  int GetCurrentButton() const override;
+  int GetTotalButtons() const override;
   bool GetCurrentButtonInfo(CDVDOverlaySpu* pOverlayPicture, CDVDDemuxSPU* pSPU, int iButtonType /* 0 = selection, 1 = action (clicked)*/);
 
-  bool HasMenu() { return true; }
-  bool IsInMenu() { return m_bInMenu; }
-  double GetTimeStampCorrection() { return (double)(m_iVobUnitCorrection * 1000) / 90; }
+  bool HasMenu() const override { return true; }
+  bool IsInMenu() const override { return m_bInMenu; }
+  double GetTimeStampCorrection() const override { return (double)(m_iVobUnitCorrection * 1000) / 90; }
 
-  int GetActiveSubtitleStream();
-  int GetSubTitleStreamCount();
-  DVDNavSubtitleStreamInfo GetSubtitleStreamInfo(const int iId);
+  int GetActiveSubtitleStream() const;
+  int GetSubTitleStreamCount() const;
+  DVDNavSubtitleStreamInfo GetSubtitleStreamInfo(const int iId) const;
 
   bool SetActiveSubtitleStream(int iId);
   void EnableSubtitleStream(bool bEnable);
-  bool IsSubtitleStreamEnabled();
+  bool IsSubtitleStreamEnabled() const;
 
   int GetActiveAudioStream();
   int GetAudioStreamCount();
@@ -158,26 +158,26 @@ public:
   bool SetActiveAudioStream(int iId);
   DVDNavAudioStreamInfo GetAudioStreamInfo(const int iId);
 
-  bool GetState(std::string &xmlstate);
-  bool SetState(const std::string &xmlstate);
+  bool GetState(std::string &xmlstate) const override;
+  bool SetState(const std::string &xmlstate) override;
 
-  int GetChapter()      { return m_iPart; }      // the current part in the current title
-  int GetChapterCount() { return m_iPartCount; } // the number of parts in the current title
-  void GetChapterName(std::string& name, int idx=-1) {};
-  int64_t GetChapterPos(int ch=-1);
-  bool SeekChapter(int iChapter);
+  int GetChapter() const override      { return m_iPart; }      // the current part in the current title
+  int GetChapterCount() const override { return m_iPartCount; } // the number of parts in the current title
+  void GetChapterName(std::string& name, int idx=-1) const override {};
+  int64_t GetChapterPos(int ch=-1) const override;
+  bool SeekChapter(int iChapter) override;
 
   CDVDInputStream::IDisplayTime* GetIDisplayTime() override { return this; }
-  int GetTotalTime(); // the total time in milli seconds
-  int GetTime(); // the current position in milli seconds
+  int GetTotalTime() const override; // the total time in milli seconds
+  int GetTime() const override; // the current position in milli seconds
 
-  float GetVideoAspectRatio();
+  float GetVideoAspectRatio() const;
 
   CDVDInputStream::IPosTime* GetIPosTime() override { return this; }
-  bool PosTime(int iTimeInMsec); //seek within current pg(c)
+  bool PosTime(int iTimeInMsec) override; //seek within current pg(c)
 
-  std::string GetDVDTitleString();
-  std::string GetDVDSerialString();
+  std::string GetDVDTitleString() const;
+  std::string GetDVDSerialString() const;
 
   void CheckButtons();
 
@@ -198,8 +198,8 @@ protected:
    * XBMC     : the subtitle stream id we use in xbmc
    * external : the subtitle stream id that is used in libdvdnav
    */
-  int ConvertSubtitleStreamId_XBMCToExternal(int id);
-  int ConvertSubtitleStreamId_ExternalToXBMC(int id);
+  int ConvertSubtitleStreamId_XBMCToExternal(int id) const;
+  int ConvertSubtitleStreamId_ExternalToXBMC(int id) const;
 
   static void SetAudioStreamName(DVDNavStreamInfo &info, const audio_attr_t &audio_attributes);
   static void SetSubtitleStreamName(DVDNavStreamInfo &info, const subp_attr_t &subp_attributes);
@@ -207,7 +207,7 @@ protected:
   int GetAngleCount();
   void GetVideoResolution(uint32_t * width, uint32_t * height);
 
-  DllDvdNav m_dll;
+  mutable DllDvdNav m_dll;
   bool m_bCheckButtons;
   bool m_bEOF;
 

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamPVRManager.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamPVRManager.cpp
@@ -71,7 +71,7 @@ void CDVDInputStreamPVRManager::ResetScanTimeout(unsigned int iTimeoutMs)
   m_ScanTimeout.Set(iTimeoutMs);
 }
 
-bool CDVDInputStreamPVRManager::IsEOF()
+bool CDVDInputStreamPVRManager::IsEOF() const
 {
   // don't mark as eof while within the scan timeout
   if (!m_ScanTimeout.IsTimePast())
@@ -287,7 +287,7 @@ int64_t CDVDInputStreamPVRManager::Seek(int64_t offset, int whence)
   }
 }
 
-int64_t CDVDInputStreamPVRManager::GetLength()
+int64_t CDVDInputStreamPVRManager::GetLength() const
 {
   if (m_pOtherStream)
     return m_pOtherStream->GetLength();
@@ -295,14 +295,14 @@ int64_t CDVDInputStreamPVRManager::GetLength()
     return g_PVRClients->GetStreamLength();
 }
 
-int CDVDInputStreamPVRManager::GetTotalTime()
+int CDVDInputStreamPVRManager::GetTotalTime() const
 {
   if (!m_isRecording)
     return g_PVRManager.GetTotalTime();
   return 0;
 }
 
-int CDVDInputStreamPVRManager::GetTime()
+int CDVDInputStreamPVRManager::GetTime() const
 {
   if (!m_isRecording)
     return g_PVRManager.GetStartTime();
@@ -407,14 +407,14 @@ CDVDInputStream::ENextStream CDVDInputStreamPVRManager::NextStream()
   return NEXTSTREAM_NONE;
 }
 
-bool CDVDInputStreamPVRManager::CanRecord()
+bool CDVDInputStreamPVRManager::CanRecord() const
 {
   if (!m_isRecording)
     return g_PVRClients->CanRecordInstantly();
   return false;
 }
 
-bool CDVDInputStreamPVRManager::IsRecording()
+bool CDVDInputStreamPVRManager::IsRecording() const
 {
   return g_PVRClients->IsRecordingOnPlayingChannel();
 }
@@ -424,12 +424,12 @@ void CDVDInputStreamPVRManager::Record(bool bOnOff)
   g_PVRManager.StartRecordingOnPlayingChannel(bOnOff);
 }
 
-bool CDVDInputStreamPVRManager::CanPause()
+bool CDVDInputStreamPVRManager::CanPause() const
 {
   return g_PVRClients->CanPauseStream();
 }
 
-bool CDVDInputStreamPVRManager::CanSeek()
+bool CDVDInputStreamPVRManager::CanSeek() const
 {
   return g_PVRClients->CanSeekStream();
 }
@@ -439,7 +439,7 @@ void CDVDInputStreamPVRManager::Pause(bool bPaused)
   g_PVRClients->PauseStream(bPaused);
 }
 
-std::string CDVDInputStreamPVRManager::GetInputFormat()
+std::string CDVDInputStreamPVRManager::GetInputFormat() const
 {
   if (!m_pOtherStream)
     return g_PVRClients->GetCurrentInputFormat();
@@ -459,12 +459,12 @@ bool CDVDInputStreamPVRManager::CloseAndOpen(const char* strFile)
   return false;
 }
 
-bool CDVDInputStreamPVRManager::IsOtherStreamHack(void)
+bool CDVDInputStreamPVRManager::IsOtherStreamHack(void) const
 {
   return m_isOtherStreamHack;
 }
 
-bool CDVDInputStreamPVRManager::IsRealtime()
+bool CDVDInputStreamPVRManager::IsRealtime() const
 {
   return g_PVRClients->IsRealTimeStream();
 }

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamPVRManager.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamPVRManager.h
@@ -51,13 +51,13 @@ public:
   virtual int Read(uint8_t* buf, int buf_size) override;
   virtual int64_t Seek(int64_t offset, int whence) override;
   virtual bool Pause(double dTime) override { return false; }
-  virtual bool IsEOF() override;
-  virtual int64_t GetLength() override;
+  virtual bool IsEOF() const override;
+  virtual int64_t GetLength() const override;
 
   virtual ENextStream NextStream() override;
-  virtual bool IsRealtime() override;
+  virtual bool IsRealtime() const override;
 
-  bool IsOtherStreamHack(void);
+  bool IsOtherStreamHack(void) const;
   bool SelectChannelByNumber(unsigned int iChannel);
   bool SelectChannel(const PVR::CPVRChannelPtr &channel);
   bool NextChannel(bool preview = false);
@@ -65,14 +65,14 @@ public:
   PVR::CPVRChannelPtr GetSelectedChannel();
 
   CDVDInputStream::IDisplayTime* GetIDisplayTime() override { return this; }
-  int GetTotalTime() override;
-  int GetTime() override;
+  int GetTotalTime() const override;
+  int GetTime() const override;
 
-  bool CanRecord();
-  bool IsRecording();
+  bool CanRecord() const;
+  bool IsRecording() const;
   void Record(bool bOnOff);
-  bool CanSeek() override;
-  bool CanPause() override;
+  bool CanSeek() const override;
+  bool CanPause() const override;
   void Pause(bool bPaused);
 
   bool UpdateItem(CFileItem& item);
@@ -86,7 +86,7 @@ public:
    list of the input formats.
    \return The name of the input format
    */
-  std::string GetInputFormat();
+  std::string GetInputFormat() const;
 
   /* returns m_pOtherStream */
   CDVDInputStream* GetOtherStream();

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
@@ -58,7 +58,7 @@ void CInputStreamAddon::Close()
     return m_addon->Close();
 }
 
-bool CInputStreamAddon::IsEOF()
+bool CInputStreamAddon::IsEOF() const
 {
   return false;
 }
@@ -79,7 +79,7 @@ int64_t CInputStreamAddon::Seek(int64_t offset, int whence)
   return m_addon->SeekStream(offset, whence);
 }
 
-int64_t CInputStreamAddon::GetLength()
+int64_t CInputStreamAddon::GetLength() const
 {
   if (!m_addon)
     return -1;
@@ -96,12 +96,12 @@ bool CInputStreamAddon::Pause(double dTime)
   return true;
 }
 
-bool CInputStreamAddon::CanSeek()
+bool CInputStreamAddon::CanSeek() const
 {
   return m_canSeek;
 }
 
-bool CInputStreamAddon::CanPause()
+bool CInputStreamAddon::CanPause() const
 {
   return m_canPause;
 }
@@ -117,7 +117,7 @@ CDVDInputStream::IDisplayTime* CInputStreamAddon::GetIDisplayTime()
   return this;
 }
 
-int CInputStreamAddon::GetTotalTime()
+int CInputStreamAddon::GetTotalTime() const
 {
   if (!m_addon)
     return 0;
@@ -125,7 +125,7 @@ int CInputStreamAddon::GetTotalTime()
   return m_addon->GetTotalTime();
 }
 
-int CInputStreamAddon::GetTime()
+int CInputStreamAddon::GetTime() const
 {
   if (!m_addon)
     return 0;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.h
@@ -55,18 +55,18 @@ public:
   //! \brief Pause stream
   virtual bool Pause(double dTime) override;
   //! \brief Return true if we have reached EOF
-  virtual bool IsEOF() override;
+  virtual bool IsEOF() const override;
 
-  virtual bool CanSeek() override;
-  virtual bool CanPause() override;
+  virtual bool CanSeek() const override;
+  virtual bool CanPause() const override;
 
   //! \brief Get length of input data
-  virtual int64_t GetLength() override;
+  virtual int64_t GetLength() const override;
 
   // IDisplayTime
   virtual CDVDInputStream::IDisplayTime* GetIDisplayTime() override;
-  virtual int GetTotalTime() override;
-  virtual int GetTime() override;
+  virtual int GetTotalTime() const override;
+  virtual int GetTime() const override;
 
   // IPosTime
   virtual CDVDInputStream::IPosTime* GetIPosTime() override;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamMultiSource.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamMultiSource.cpp
@@ -57,17 +57,17 @@ BitstreamStats CInputStreamMultiSource::GetBitstreamStats() const
   return m_stats;
 }
 
-int CInputStreamMultiSource::GetBlockSize()
+int CInputStreamMultiSource::GetBlockSize() const
 {
   return 0;
 }
 
-bool CInputStreamMultiSource::GetCacheStatus(XFILE::SCacheStatus *status)
+bool CInputStreamMultiSource::GetCacheStatus(XFILE::SCacheStatus *status) const
 {
   return false;
 }
 
-int64_t CInputStreamMultiSource::GetLength()
+int64_t CInputStreamMultiSource::GetLength() const
 {
   int64_t length = 0;
   for (auto iter : m_InputStreams)
@@ -78,7 +78,7 @@ int64_t CInputStreamMultiSource::GetLength()
   return length;
 }
 
-bool CInputStreamMultiSource::IsEOF()
+bool CInputStreamMultiSource::IsEOF() const
 {
   if (m_InputStreams.empty())
     return true;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamMultiSource.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamMultiSource.h
@@ -37,14 +37,14 @@ public:
 
   virtual void Abort() override;
   virtual void Close() override;
-  virtual BitstreamStats GetBitstreamStats() const ;
-  virtual int GetBlockSize();
-  virtual bool GetCacheStatus(XFILE::SCacheStatus *status);
-  int64_t GetLength() override;
-  virtual bool IsEOF() override;
+  virtual BitstreamStats GetBitstreamStats() const override;
+  virtual int GetBlockSize() const  override;
+  virtual bool GetCacheStatus(XFILE::SCacheStatus *status) const override;
+  int64_t GetLength()const override;
+  virtual bool IsEOF() const override;
   virtual CDVDInputStream::ENextStream NextStream() override;
   virtual bool Open() override;
-  virtual bool Pause(double dTime)override { return false; };
+  virtual bool Pause(double dTime) override { return false; };
   virtual int Read(uint8_t* buf, int buf_size) override;
   virtual int64_t Seek(int64_t offset, int whence) override;
   virtual void SetReadRate(unsigned rate) override;

--- a/xbmc/cores/VideoPlayer/DVDMessageQueue.cpp
+++ b/xbmc/cores/VideoPlayer/DVDMessageQueue.cpp
@@ -219,7 +219,7 @@ MsgQueueReturnCode CDVDMessageQueue::Get(CDVDMsg** pMsg, unsigned int iTimeoutIn
   return (MsgQueueReturnCode)ret;
 }
 
-unsigned CDVDMessageQueue::GetPacketCount(CDVDMsg::Message type)
+unsigned CDVDMessageQueue::GetPacketCount(CDVDMsg::Message type) const
 {
   CSingleLock lock(m_section);
 

--- a/xbmc/cores/VideoPlayer/DVDMessageQueue.h
+++ b/xbmc/cores/VideoPlayer/DVDMessageQueue.h
@@ -92,8 +92,8 @@ public:
 
   int GetDataSize() const { return m_iDataSize; }
   int GetTimeSize() const;
-  unsigned GetPacketCount(CDVDMsg::Message type);
-  bool ReceivedAbortRequest() { return m_bAbortRequest; }
+  unsigned GetPacketCount(CDVDMsg::Message type) const;
+  bool ReceivedAbortRequest() const { return m_bAbortRequest; }
   void WaitUntilEmpty();
 
   // non messagequeue related functions

--- a/xbmc/cores/VideoPlayer/DVDTSCorrection.h
+++ b/xbmc/cores/VideoPlayer/DVDTSCorrection.h
@@ -35,13 +35,13 @@ class CPullupCorrection
     void   Flush(); //flush the saved pattern and the ringbuffer
     void   ResetVFRDetection(void);
 
-    double GetCorrection()    { return m_ptscorrection;            }
-    int    GetPatternLength() { return m_patternlength;            }
-    double GetFrameDuration() { return m_frameduration;            }
-    double GetMaxFrameDuration(void) { return m_maxframeduration;  }
-    double GetMinFrameDuration(void) { return m_minframeduration;  }
-    bool   HasFullBuffer()    { return m_ringfill == DIFFRINGSIZE; }
-    bool   VFRDetection(void) { return ((m_VFRCounter >= VFR_DETECTION_THRESHOLD) && (m_patternCounter >= VFR_PATTERN_THRESHOLD)); }
+    double GetCorrection() const    { return m_ptscorrection;            }
+    int    GetPatternLength() const { return m_patternlength;            }
+    double GetFrameDuration() const { return m_frameduration;            }
+    double GetMaxFrameDuration(void) const { return m_maxframeduration;  }
+    double GetMinFrameDuration(void) const { return m_minframeduration;  }
+    bool   HasFullBuffer() const    { return m_ringfill == DIFFRINGSIZE; }
+    bool   VFRDetection(void) const { return ((m_VFRCounter >= VFR_DETECTION_THRESHOLD) && (m_patternCounter >= VFR_PATTERN_THRESHOLD)); }
 
   private:
     double m_prevpts;                //last pts added

--- a/xbmc/cores/VideoPlayer/IVideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/IVideoPlayer.h
@@ -150,20 +150,20 @@ public:
   virtual bool IsInited() const = 0;
   virtual void SendMessage(CDVDMsg* pMsg, int priority = 0) = 0;
   virtual void EnableSubtitle(bool bEnable) = 0;
-  virtual bool IsSubtitleEnabled() = 0;
+  virtual bool IsSubtitleEnabled() const = 0;
   virtual void EnableFullscreen(bool bEnable) = 0;
-  virtual double GetSubtitleDelay() = 0;
+  virtual double GetSubtitleDelay() const = 0;
   virtual void SetSubtitleDelay(double delay) = 0;
   virtual bool IsStalled() const = 0;
-  virtual double GetCurrentPts() = 0;
-  virtual double GetOutputDelay() = 0;
-  virtual std::string GetPlayerInfo() = 0;
-  virtual int GetVideoBitrate() = 0;
-  virtual std::string GetStereoMode() = 0;
+  virtual double GetCurrentPts() const = 0;
+  virtual double GetOutputDelay() const = 0;
+  virtual std::string GetPlayerInfo() const = 0;
+  virtual int GetVideoBitrate() const = 0;
+  virtual std::string GetStereoMode() const = 0;
   virtual void SetSpeed(int iSpeed) = 0;
-  virtual int  GetDecoderBufferSize() { return 0; }
-  virtual int  GetDecoderFreeSpace() = 0;
-  virtual bool IsEOS() { return false; };
+  virtual int  GetDecoderBufferSize() const { return 0; }
+  virtual int  GetDecoderFreeSpace() const = 0;
+  virtual bool IsEOS() const { return false; };
 };
 
 class CDVDAudioCodec;
@@ -184,12 +184,12 @@ public:
   virtual void SetVolume(float fVolume) {};
   virtual void SetMute(bool bOnOff) {};
   virtual void SetDynamicRangeCompression(long drc) = 0;
-  virtual std::string GetPlayerInfo() = 0;
-  virtual int GetAudioBitrate() = 0;
-  virtual int GetAudioChannels() = 0;
-  virtual double GetCurrentPts() = 0;
+  virtual std::string GetPlayerInfo() const = 0;
+  virtual int GetAudioBitrate() const = 0;
+  virtual int GetAudioChannels() const = 0;
+  virtual double GetCurrentPts() const = 0;
   virtual bool IsStalled() const = 0;
   virtual bool IsPassthrough() const = 0;
   virtual float GetDynamicRangeAmplification() const = 0;
-  virtual bool IsEOS() { return false; };
+  virtual bool IsEOS() const { return false; };
 };

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -2969,7 +2969,7 @@ void CVideoPlayer::SetPlaySpeed(int speed)
   }
 }
 
-bool CVideoPlayer::CanPause()
+bool CVideoPlayer::CanPause() const
 {
   CSingleLock lock(m_StateSection);
   return m_State.canpause;
@@ -3010,7 +3010,7 @@ bool CVideoPlayer::IsPassthrough() const
   return m_VideoPlayerAudio->IsPassthrough();
 }
 
-bool CVideoPlayer::CanSeek()
+bool CVideoPlayer::CanSeek() const
 {
   CSingleLock lock(m_StateSection);
   return m_State.canseek;
@@ -3215,7 +3215,7 @@ void CVideoPlayer::SeekPercentage(float iPercent)
   SeekTime((int64_t)(iTotalTime * iPercent / 100));
 }
 
-float CVideoPlayer::GetPercentage()
+float CVideoPlayer::GetPercentage() const
 {
   int64_t iTotalTime = GetTotalTimeInMsec();
 
@@ -3225,7 +3225,7 @@ float CVideoPlayer::GetPercentage()
   return GetTime() * 100 / (float)iTotalTime;
 }
 
-float CVideoPlayer::GetCachePercentage()
+float CVideoPlayer::GetCachePercentage() const
 {
   CSingleLock lock(m_StateSection);
   return (float) (m_State.cache_offset * 100); // NOTE: Percentage returned is relative
@@ -3236,7 +3236,7 @@ void CVideoPlayer::SetAVDelay(float fValue)
   m_renderManager.SetDelay( (fValue * 1000) ) ;
 }
 
-float CVideoPlayer::GetAVDelay()
+float CVideoPlayer::GetAVDelay() const
 {
   return static_cast<float>(m_renderManager.GetDelay()) / 1000;
 }
@@ -3246,18 +3246,18 @@ void CVideoPlayer::SetSubTitleDelay(float fValue)
   m_VideoPlayerVideo->SetSubtitleDelay(-fValue * DVD_TIME_BASE);
 }
 
-float CVideoPlayer::GetSubTitleDelay()
+float CVideoPlayer::GetSubTitleDelay() const
 {
   return (float) -m_VideoPlayerVideo->GetSubtitleDelay() / DVD_TIME_BASE;
 }
 
 // priority: 1: libdvdnav, 2: external subtitles, 3: muxed subtitles
-int CVideoPlayer::GetSubtitleCount()
+int CVideoPlayer::GetSubtitleCount() const
 {
   return m_SelectionStreams.Count(STREAM_SUBTITLE);
 }
 
-int CVideoPlayer::GetSubtitle()
+int CVideoPlayer::GetSubtitle() const
 {
   return m_SelectionStreams.IndexOf(STREAM_SUBTITLE, *this);
 }
@@ -3322,7 +3322,7 @@ void CVideoPlayer::UpdateStreamInfos()
   }
 }
 
-void CVideoPlayer::GetSubtitleStreamInfo(int index, SPlayerSubtitleStreamInfo &info)
+void CVideoPlayer::GetSubtitleStreamInfo(int index, SPlayerSubtitleStreamInfo &info) const
 {
   CSingleLock lock(m_SelectionStreams.m_section);
   if (index < 0 || index > (int) GetSubtitleCount() - 1)
@@ -3343,7 +3343,7 @@ void CVideoPlayer::SetSubtitle(int iStream)
   m_messenger.Put(new CDVDMsgPlayerSetSubtitleStream(iStream));
 }
 
-bool CVideoPlayer::GetSubtitleVisible()
+bool CVideoPlayer::GetSubtitleVisible() const
 {
   if (m_pInputStream && m_pInputStream->IsStreamType(DVDSTREAM_TYPE_DVD))
   {
@@ -3367,12 +3367,12 @@ void CVideoPlayer::SetSubtitleVisibleInternal(bool bVisible)
     static_cast<CDVDInputStreamNavigator*>(m_pInputStream)->EnableSubtitleStream(bVisible);
 }
 
-int CVideoPlayer::GetAudioStreamCount()
+int CVideoPlayer::GetAudioStreamCount() const
 {
   return m_SelectionStreams.Count(STREAM_AUDIO);
 }
 
-int CVideoPlayer::GetAudioStream()
+int CVideoPlayer::GetAudioStream() const
 {
   return m_SelectionStreams.IndexOf(STREAM_AUDIO, *this);
 }
@@ -3441,7 +3441,7 @@ bool CVideoPlayer::SeekTimeRelative(int64_t iTime)
 }
 
 // return the time in milliseconds
-int64_t CVideoPlayer::GetTime()
+int64_t CVideoPlayer::GetTime() const
 {
   CSingleLock lock(m_StateSection);
   double offset = 0;
@@ -3459,14 +3459,14 @@ int64_t CVideoPlayer::GetTime()
 }
 
 // return length in msec
-int64_t CVideoPlayer::GetTotalTimeInMsec()
+int64_t CVideoPlayer::GetTotalTimeInMsec() const
 {
   CSingleLock lock(m_StateSection);
   return llrint(m_State.time_total);
 }
 
 // return length in seconds.. this should be changed to return in milleseconds throughout xbmc
-int64_t CVideoPlayer::GetTotalTime()
+int64_t CVideoPlayer::GetTotalTime() const
 {
   return GetTotalTimeInMsec();
 }
@@ -3485,7 +3485,7 @@ void CVideoPlayer::SetSpeed(int iSpeed)
   SetPlaySpeed(iSpeed * DVD_PLAYSPEED_NORMAL);
 }
 
-int CVideoPlayer::GetSpeed()
+int CVideoPlayer::GetSpeed() const
 {
   if (m_playSpeed != m_newPlaySpeed)
     return m_newPlaySpeed / DVD_PLAYSPEED_NORMAL;
@@ -4521,7 +4521,7 @@ bool CVideoPlayer::HasMenu() const
   return m_State.hasMenu;
 }
 
-std::string CVideoPlayer::GetPlayerState()
+std::string CVideoPlayer::GetPlayerState() const
 {
   CSingleLock lock(m_StateSection);
   return m_State.player_state;
@@ -4533,19 +4533,19 @@ bool CVideoPlayer::SetPlayerState(const std::string& state)
   return true;
 }
 
-int CVideoPlayer::GetChapterCount()
+int CVideoPlayer::GetChapterCount() const
 {
   CSingleLock lock(m_StateSection);
   return m_State.chapters.size();
 }
 
-int CVideoPlayer::GetChapter()
+int CVideoPlayer::GetChapter() const
 {
   CSingleLock lock(m_StateSection);
   return m_State.chapter;
 }
 
-void CVideoPlayer::GetChapterName(std::string& strChapterName, int chapterIdx)
+void CVideoPlayer::GetChapterName(std::string& strChapterName, int chapterIdx) const
 {
   CSingleLock lock(m_StateSection);
   if (chapterIdx == -1 && m_State.chapter > 0 && m_State.chapter <= (int) m_State.chapters.size())
@@ -4571,7 +4571,7 @@ int CVideoPlayer::SeekChapter(int iChapter)
   return 0;
 }
 
-int64_t CVideoPlayer::GetChapterPos(int chapterIdx)
+int64_t CVideoPlayer::GetChapterPos(int chapterIdx) const
 {
   CSingleLock lock(m_StateSection);
   if (chapterIdx > 0 && chapterIdx <= (int) m_State.chapters.size())
@@ -4598,7 +4598,7 @@ double CVideoPlayer::GetQueueTime()
   return std::max(a, v) * 8000.0 / 100;
 }
 
-void CVideoPlayer::GetVideoStreamInfo(int streamId, SPlayerVideoStreamInfo &info)
+void CVideoPlayer::GetVideoStreamInfo(int streamId, SPlayerVideoStreamInfo &info) const
 {
   CSingleLock lock(m_SelectionStreams.m_section);
   if (streamId == CURRENT_STREAM)
@@ -4624,7 +4624,7 @@ void CVideoPlayer::GetVideoStreamInfo(int streamId, SPlayerVideoStreamInfo &info
   info.stereoMode = s.stereo_mode;
 }
 
-int CVideoPlayer::GetSourceBitrate()
+int CVideoPlayer::GetSourceBitrate() const
 {
   if (m_pInputStream)
     return (int)m_pInputStream->GetBitstreamStats().GetBitrate();
@@ -4632,7 +4632,7 @@ int CVideoPlayer::GetSourceBitrate()
   return 0;
 }
 
-void CVideoPlayer::GetAudioStreamInfo(int index, SPlayerAudioStreamInfo &info)
+void CVideoPlayer::GetAudioStreamInfo(int index, SPlayerAudioStreamInfo &info) const
 {
   CSingleLock lock(m_SelectionStreams.m_section);
   if (index == CURRENT_STREAM)
@@ -4898,13 +4898,13 @@ void CVideoPlayer::SetDynamicRangeCompression(long drc)
   m_VideoPlayerAudio->SetDynamicRangeCompression(drc);
 }
 
-bool CVideoPlayer::CanRecord()
+bool CVideoPlayer::CanRecord() const
 {
   CSingleLock lock(m_StateSection);
   return m_State.canrecord;
 }
 
-bool CVideoPlayer::IsRecording()
+bool CVideoPlayer::IsRecording() const
 {
   CSingleLock lock(m_StateSection);
   return m_State.recording;
@@ -4921,7 +4921,7 @@ bool CVideoPlayer::Record(bool bOnOff)
   return false;
 }
 
-bool CVideoPlayer::GetStreamDetails(CStreamDetails &details)
+bool CVideoPlayer::GetStreamDetails(CStreamDetails &details) const
 {
   if (m_pDemuxer)
   {
@@ -4959,7 +4959,7 @@ bool CVideoPlayer::GetStreamDetails(CStreamDetails &details)
     return false;
 }
 
-std::string CVideoPlayer::GetPlayingTitle()
+std::string CVideoPlayer::GetPlayingTitle() const
 {
   /* Currently we support only Title Name from Teletext line 30 */
   TextCacheStruct_t* ttcache = m_VideoPlayerTeletext->GetTeletextCache();
@@ -4995,7 +4995,7 @@ void CVideoPlayer::FrameMove()
   m_renderManager.FrameMove();
 }
 
-bool CVideoPlayer::HasFrame()
+bool CVideoPlayer::HasFrame() const
 {
   return m_renderManager.HasFrame();
 }
@@ -5015,7 +5015,7 @@ void CVideoPlayer::SetRenderViewMode(int mode)
   m_renderManager.SetViewMode(mode);
 }
 
-float CVideoPlayer::GetRenderAspectRatio()
+float CVideoPlayer::GetRenderAspectRatio() const
 {
   return m_renderManager.GetAspectRatio();
 }
@@ -5025,37 +5025,37 @@ void CVideoPlayer::TriggerUpdateResolution()
   m_renderManager.TriggerUpdateResolution(0, 0, 0);
 }
 
-bool CVideoPlayer::IsRenderingVideo()
+bool CVideoPlayer::IsRenderingVideo() const
 {
   return m_renderManager.IsConfigured();
 }
 
-bool CVideoPlayer::IsRenderingGuiLayer()
+bool CVideoPlayer::IsRenderingGuiLayer() const
 {
   return m_renderManager.IsGuiLayer();
 }
 
-bool CVideoPlayer::IsRenderingVideoLayer()
+bool CVideoPlayer::IsRenderingVideoLayer() const
 {
   return m_renderManager.IsVideoLayer();
 }
 
-bool CVideoPlayer::Supports(EDEINTERLACEMODE mode)
+bool CVideoPlayer::Supports(EDEINTERLACEMODE mode) const
 {
   return m_renderManager.Supports(mode);
 }
 
-bool CVideoPlayer::Supports(EINTERLACEMETHOD method)
+bool CVideoPlayer::Supports(EINTERLACEMETHOD method) const
 {
   return m_renderManager.Supports(method);
 }
 
-bool CVideoPlayer::Supports(ESCALINGMETHOD method)
+bool CVideoPlayer::Supports(ESCALINGMETHOD method) const
 {
   return m_renderManager.Supports(method);
 }
 
-bool CVideoPlayer::Supports(ERENDERFEATURE feature)
+bool CVideoPlayer::Supports(ERENDERFEATURE feature) const
 {
   return m_renderManager.Supports(feature);
 }
@@ -5075,7 +5075,7 @@ void CVideoPlayer::RenderCaptureRelease(unsigned int captureId)
   m_renderManager.ReleaseRenderCapture(captureId);
 }
 
-bool CVideoPlayer::RenderCaptureGetPixels(unsigned int captureId, unsigned int millis, uint8_t *buffer, unsigned int size)
+bool CVideoPlayer::RenderCaptureGetPixels(unsigned int captureId, unsigned int millis, uint8_t *buffer, unsigned int size) const
 {
   return m_renderManager.RenderCaptureGetPixels(captureId, millis, buffer, size);
 }

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -239,6 +239,11 @@ class CVideoPlayer : public IPlayer, public CThread, public IVideoPlayer, public
 public:
   CVideoPlayer(IPlayerCallback& callback);
   virtual ~CVideoPlayer();
+
+  virtual TextCacheStruct_t* GetTeletextCache();
+  virtual std::string GetRadioText(unsigned int line);
+
+  // IPlayer Interface
   virtual bool OpenFile(const CFileItem& file, const CPlayerOptions &options) override;
   virtual bool CloseFile(bool reopen = false) override;
   virtual bool IsPlaying() const override;
@@ -253,7 +258,6 @@ public:
   virtual void SeekPercentage(float iPercent) override;
   virtual float GetPercentage() const override;
   virtual float GetCachePercentage() const override;
-
   virtual void SetVolume(float nVolume) override;
   virtual void SetMute(bool bOnOff) override;
   virtual void SetDynamicRangeCompression(long drc) override;
@@ -265,7 +269,6 @@ public:
   virtual float GetAVDelay() const override;
   virtual bool IsInMenu() const override;
   virtual bool HasMenu() const override;
-
   virtual void SetSubTitleDelay(float fValue = 0.0f) override;
   virtual float GetSubTitleDelay() const override;
   virtual int GetSubtitleCount() const override;
@@ -275,27 +278,19 @@ public:
   virtual bool GetSubtitleVisible() const override;
   virtual void SetSubtitleVisible(bool bVisible) override;
   virtual void AddSubtitle(const std::string& strSubPath) override;
-
   virtual int GetAudioStreamCount() const override;
   virtual int GetAudioStream() const override;
   virtual void SetAudioStream(int iStream) override;
-
   virtual int GetVideoStream() const override;
   virtual int GetVideoStreamCount() const override;
   virtual void GetVideoStreamInfo(int streamId, SPlayerVideoStreamInfo &info) const override;
   virtual void SetVideoStream(int iStream) override;
-
-  virtual TextCacheStruct_t* GetTeletextCache();
   virtual void LoadPage(int p, int sp, unsigned char* buffer) override;
-
-  virtual std::string GetRadioText(unsigned int line);
-
   virtual int  GetChapterCount() const override;
   virtual int  GetChapter() const override;
   virtual void GetChapterName(std::string& strChapterName, int chapterIdx=-1) const override;
   virtual int64_t GetChapterPos(int chapterIdx=-1) const override;
   virtual int  SeekChapter(int iChapter) override;
-
   virtual void SeekTime(int64_t iTime) override;
   virtual bool SeekTimeRelative(int64_t iTime) override;
   virtual int64_t GetTime() const override;
@@ -303,23 +298,19 @@ public:
   virtual void SetSpeed(int iSpeed) override;
   virtual int GetSpeed() const override;
   virtual bool OnAction(const CAction &action) override;
-
   virtual int GetSourceBitrate() const override;
   virtual bool GetStreamDetails(CStreamDetails &details) const override;
   virtual void GetAudioStreamInfo(int index, SPlayerAudioStreamInfo &info) const override;
-
-  virtual std::string GetPlayerState() const  override;
+  virtual std::string GetPlayerState() const override;
   virtual bool SetPlayerState(const std::string& state) override;
-
   virtual std::string GetPlayingTitle() const  override;
-
   virtual bool SwitchChannel(const PVR::CPVRChannelPtr &channel) override;
   virtual void FrameMove() override;
   virtual bool HasFrame() const  override;
   virtual void Render(bool clear, uint32_t alpha = 255, bool gui = true) override;
   virtual void FlushRenderer() override;
   virtual void SetRenderViewMode(int mode) override;
-  float GetRenderAspectRatio() const  override;
+  virtual float GetRenderAspectRatio() const  override;
   virtual void TriggerUpdateResolution() override;
   virtual bool IsRenderingVideo() const override;
   virtual bool IsRenderingGuiLayer() const override;
@@ -328,11 +319,12 @@ public:
   virtual bool Supports(EINTERLACEMETHOD method) const  override;
   virtual bool Supports(ESCALINGMETHOD method) const  override;
   virtual bool Supports(ERENDERFEATURE feature) const override;
-
   virtual unsigned int RenderCaptureAlloc() override;
   virtual void RenderCapture(unsigned int captureId, unsigned int width, unsigned int height, int flags) override;
   virtual void RenderCaptureRelease(unsigned int captureId) override;
   virtual bool RenderCaptureGetPixels(unsigned int captureId, unsigned int millis, uint8_t *buffer, unsigned int size) const  override;
+  virtual bool IsCaching() const override { return m_caching > CACHESTATE_DONE && m_caching < CACHESTATE_PLAY; }
+  virtual int GetCacheLevel() const override;
 
   // IDispResource interface
   virtual void OnLostDisplay() override;
@@ -346,18 +338,19 @@ public:
   , CACHESTATE_FLUSH    // temporary state player will choose startup between init or full
   };
 
-  virtual bool IsCaching() const override { return m_caching > CACHESTATE_DONE && m_caching < CACHESTATE_PLAY; }
-  virtual int GetCacheLevel() const override;
-
+  // IVideoPlayer interface
   virtual int OnDVDNavResult(void* pData, int iMessage) override;
   void GetVideoResolution(unsigned int &width, unsigned int &height) override;
 
 protected:
   friend class CSelectionStreams;
 
+  // CThread interface
   virtual void OnStartup() override;
   virtual void OnExit() override;
   virtual void Process() override;
+
+  // IRenderMsg interface
   virtual void VideoParamsChange() override;
   virtual void GetDebugInfo(std::string &audio, std::string &video, std::string &general) override;
 

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -239,105 +239,104 @@ class CVideoPlayer : public IPlayer, public CThread, public IVideoPlayer, public
 public:
   CVideoPlayer(IPlayerCallback& callback);
   virtual ~CVideoPlayer();
-  virtual bool OpenFile(const CFileItem& file, const CPlayerOptions &options);
-  virtual bool CloseFile(bool reopen = false);
-  virtual bool IsPlaying() const;
+  virtual bool OpenFile(const CFileItem& file, const CPlayerOptions &options) override;
+  virtual bool CloseFile(bool reopen = false) override;
+  virtual bool IsPlaying() const override;
   virtual void Pause() override;
-  virtual bool HasVideo() const;
-  virtual bool HasAudio() const;
-  virtual bool HasRDS() const;
-  virtual bool IsPassthrough() const;
-  virtual bool CanSeek();
-  virtual void Seek(bool bPlus, bool bLargeStep, bool bChapterOverride);
-  virtual bool SeekScene(bool bPlus = true);
-  virtual void SeekPercentage(float iPercent);
-  virtual float GetPercentage();
-  virtual float GetCachePercentage();
+  virtual bool HasVideo() const override;
+  virtual bool HasAudio() const override;
+  virtual bool HasRDS() const override;
+  virtual bool IsPassthrough() const override;
+  virtual bool CanSeek() const override;
+  virtual void Seek(bool bPlus, bool bLargeStep, bool bChapterOverride) override;
+  virtual bool SeekScene(bool bPlus = true) override;
+  virtual void SeekPercentage(float iPercent) override;
+  virtual float GetPercentage() const override;
+  virtual float GetCachePercentage() const override;
 
   virtual void SetVolume(float nVolume) override;
   virtual void SetMute(bool bOnOff) override;
   virtual void SetDynamicRangeCompression(long drc) override;
-  virtual bool CanRecord();
-  virtual bool IsRecording();
-  virtual bool CanPause();
-  virtual bool Record(bool bOnOff);
-  virtual void SetAVDelay(float fValue = 0.0f);
-  virtual float GetAVDelay();
+  virtual bool CanRecord() const  override;
+  virtual bool IsRecording() const override;
+  virtual bool CanPause() const override;
+  virtual bool Record(bool bOnOff) override;
+  virtual void SetAVDelay(float fValue = 0.0f) override;
+  virtual float GetAVDelay() const override;
   virtual bool IsInMenu() const override;
   virtual bool HasMenu() const override;
 
-  virtual void SetSubTitleDelay(float fValue = 0.0f);
-  virtual float GetSubTitleDelay();
-  virtual int GetSubtitleCount();
-  virtual int GetSubtitle();
-  virtual void GetSubtitleStreamInfo(int index, SPlayerSubtitleStreamInfo &info);
-  virtual void SetSubtitle(int iStream);
-  virtual bool GetSubtitleVisible();
-  virtual void SetSubtitleVisible(bool bVisible);
-  virtual void AddSubtitle(const std::string& strSubPath);
+  virtual void SetSubTitleDelay(float fValue = 0.0f) override;
+  virtual float GetSubTitleDelay() const override;
+  virtual int GetSubtitleCount() const override;
+  virtual int GetSubtitle() const override;
+  virtual void GetSubtitleStreamInfo(int index, SPlayerSubtitleStreamInfo &info) const override;
+  virtual void SetSubtitle(int iStream) override;
+  virtual bool GetSubtitleVisible() const override;
+  virtual void SetSubtitleVisible(bool bVisible) override;
+  virtual void AddSubtitle(const std::string& strSubPath) override;
 
-  virtual int GetAudioStreamCount();
-  virtual int GetAudioStream();
-  virtual void SetAudioStream(int iStream);
+  virtual int GetAudioStreamCount() const override;
+  virtual int GetAudioStream() const override;
+  virtual void SetAudioStream(int iStream) override;
 
   virtual int GetVideoStream() const override;
   virtual int GetVideoStreamCount() const override;
-  virtual void GetVideoStreamInfo(int streamId, SPlayerVideoStreamInfo &info) override;
-  virtual void SetVideoStream(int iStream);
+  virtual void GetVideoStreamInfo(int streamId, SPlayerVideoStreamInfo &info) const override;
+  virtual void SetVideoStream(int iStream) override;
 
   virtual TextCacheStruct_t* GetTeletextCache();
-  virtual void LoadPage(int p, int sp, unsigned char* buffer);
+  virtual void LoadPage(int p, int sp, unsigned char* buffer) override;
 
   virtual std::string GetRadioText(unsigned int line);
 
-  virtual int  GetChapterCount();
-  virtual int  GetChapter();
-  virtual void GetChapterName(std::string& strChapterName, int chapterIdx=-1);
-  virtual int64_t GetChapterPos(int chapterIdx=-1);
-  virtual int  SeekChapter(int iChapter);
+  virtual int  GetChapterCount() const override;
+  virtual int  GetChapter() const override;
+  virtual void GetChapterName(std::string& strChapterName, int chapterIdx=-1) const override;
+  virtual int64_t GetChapterPos(int chapterIdx=-1) const override;
+  virtual int  SeekChapter(int iChapter) override;
 
-  virtual void SeekTime(int64_t iTime);
-  virtual bool SeekTimeRelative(int64_t iTime);
-  virtual int64_t GetTime();
-  virtual int64_t GetTotalTime();
+  virtual void SeekTime(int64_t iTime) override;
+  virtual bool SeekTimeRelative(int64_t iTime) override;
+  virtual int64_t GetTime() const override;
+  virtual int64_t GetTotalTime() const override;
   virtual void SetSpeed(int iSpeed) override;
-  virtual int GetSpeed() override;
-  virtual bool OnAction(const CAction &action);
+  virtual int GetSpeed() const override;
+  virtual bool OnAction(const CAction &action) override;
 
-  virtual int GetSourceBitrate();
-  virtual bool GetStreamDetails(CStreamDetails &details);
-  virtual void GetAudioStreamInfo(int index, SPlayerAudioStreamInfo &info);
+  virtual int GetSourceBitrate() const override;
+  virtual bool GetStreamDetails(CStreamDetails &details) const override;
+  virtual void GetAudioStreamInfo(int index, SPlayerAudioStreamInfo &info) const override;
 
-  virtual std::string GetPlayerState();
-  virtual bool SetPlayerState(const std::string& state);
+  virtual std::string GetPlayerState() const  override;
+  virtual bool SetPlayerState(const std::string& state) override;
 
-  virtual std::string GetPlayingTitle();
+  virtual std::string GetPlayingTitle() const  override;
 
-  virtual bool SwitchChannel(const PVR::CPVRChannelPtr &channel);
+  virtual bool SwitchChannel(const PVR::CPVRChannelPtr &channel) override;
+  virtual void FrameMove() override;
+  virtual bool HasFrame() const  override;
+  virtual void Render(bool clear, uint32_t alpha = 255, bool gui = true) override;
+  virtual void FlushRenderer() override;
+  virtual void SetRenderViewMode(int mode) override;
+  float GetRenderAspectRatio() const  override;
+  virtual void TriggerUpdateResolution() override;
+  virtual bool IsRenderingVideo() const override;
+  virtual bool IsRenderingGuiLayer() const override;
+  virtual bool IsRenderingVideoLayer() const override;
+  virtual bool Supports(EDEINTERLACEMODE mode) const  override;
+  virtual bool Supports(EINTERLACEMETHOD method) const  override;
+  virtual bool Supports(ESCALINGMETHOD method) const  override;
+  virtual bool Supports(ERENDERFEATURE feature) const override;
 
-  virtual void FrameMove();
-  virtual bool HasFrame();
-  virtual void Render(bool clear, uint32_t alpha = 255, bool gui = true);
-  virtual void FlushRenderer();
-  virtual void SetRenderViewMode(int mode);
-  float GetRenderAspectRatio();
-  virtual void TriggerUpdateResolution();
-  virtual bool IsRenderingVideo();
-  virtual bool IsRenderingGuiLayer();
-  virtual bool IsRenderingVideoLayer();
-  virtual bool Supports(EDEINTERLACEMODE mode);
-  virtual bool Supports(EINTERLACEMETHOD method);
-  virtual bool Supports(ESCALINGMETHOD method);
-  virtual bool Supports(ERENDERFEATURE feature);
-
-  virtual unsigned int RenderCaptureAlloc();
-  virtual void RenderCapture(unsigned int captureId, unsigned int width, unsigned int height, int flags);
-  virtual void RenderCaptureRelease(unsigned int captureId);
-  virtual bool RenderCaptureGetPixels(unsigned int captureId, unsigned int millis, uint8_t *buffer, unsigned int size);
+  virtual unsigned int RenderCaptureAlloc() override;
+  virtual void RenderCapture(unsigned int captureId, unsigned int width, unsigned int height, int flags) override;
+  virtual void RenderCaptureRelease(unsigned int captureId) override;
+  virtual bool RenderCaptureGetPixels(unsigned int captureId, unsigned int millis, uint8_t *buffer, unsigned int size) const  override;
 
   // IDispResource interface
-  virtual void OnLostDisplay();
-  virtual void OnResetDisplay();
+  virtual void OnLostDisplay() override;
+  virtual void OnResetDisplay() override;
 
   enum ECacheState
   { CACHESTATE_DONE = 0
@@ -347,8 +346,8 @@ public:
   , CACHESTATE_FLUSH    // temporary state player will choose startup between init or full
   };
 
-  virtual bool IsCaching() const { return m_caching > CACHESTATE_DONE && m_caching < CACHESTATE_PLAY; }
-  virtual int GetCacheLevel() const ;
+  virtual bool IsCaching() const override { return m_caching > CACHESTATE_DONE && m_caching < CACHESTATE_PLAY; }
+  virtual int GetCacheLevel() const override;
 
   virtual int OnDVDNavResult(void* pData, int iMessage) override;
   void GetVideoResolution(unsigned int &width, unsigned int &height) override;
@@ -356,9 +355,9 @@ public:
 protected:
   friend class CSelectionStreams;
 
-  virtual void OnStartup();
-  virtual void OnExit();
-  virtual void Process();
+  virtual void OnStartup() override;
+  virtual void OnExit() override;
+  virtual void Process() override;
   virtual void VideoParamsChange() override;
   virtual void GetDebugInfo(std::string &audio, std::string &video, std::string &general) override;
 
@@ -399,7 +398,7 @@ protected:
   int GetPlaySpeed() { return m_playSpeed; }
   void SetCaching(ECacheState state);
 
-  int64_t GetTotalTimeInMsec();
+  int64_t GetTotalTimeInMsec() const;
 
   double GetQueueTime();
   bool GetCachingTimes(double& play_left, double& cache_left, double& file_offset);
@@ -455,7 +454,7 @@ protected:
   CCurrentStream m_CurrentTeletext;
   CCurrentStream m_CurrentRadioRDS;
 
-  CSelectionStreams m_SelectionStreams;
+  mutable CSelectionStreams m_SelectionStreams;
 
   std::atomic_int m_playSpeed;
   std::atomic_int m_newPlaySpeed;
@@ -487,7 +486,7 @@ protected:
   CDVDDemux* m_pSubtitleDemuxer;
   CDVDDemuxCC* m_pCCDemuxer;
 
-  CRenderManager m_renderManager;
+  mutable CRenderManager m_renderManager;
 
   struct SDVDInfo
   {

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
@@ -615,18 +615,18 @@ bool CVideoPlayerAudio::SwitchCodecIfNeeded()
   return true;
 }
 
-std::string CVideoPlayerAudio::GetPlayerInfo()
+std::string CVideoPlayerAudio::GetPlayerInfo() const
 {
   CSingleLock lock(m_info_section);
   return m_info.info;
 }
 
-int CVideoPlayerAudio::GetAudioBitrate()
+int CVideoPlayerAudio::GetAudioBitrate() const
 {
   return (int)m_audioStats.GetBitrate();
 }
 
-int CVideoPlayerAudio::GetAudioChannels()
+int CVideoPlayerAudio::GetAudioChannels() const
 {
   return m_streaminfo.channels;
 }

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.h
@@ -41,41 +41,41 @@ public:
   CVideoPlayerAudio(CDVDClock* pClock, CDVDMessageQueue& parent, CProcessInfo &processInfo);
   virtual ~CVideoPlayerAudio();
 
-  bool OpenStream(CDVDStreamInfo &hints);
-  void CloseStream(bool bWaitForBuffers);
+  bool OpenStream(CDVDStreamInfo &hints) override;
+  void CloseStream(bool bWaitForBuffers) override;
 
-  void SetSpeed(int speed);
-  void Flush(bool sync);
+  void SetSpeed(int speed) override;
+  void Flush(bool sync) override;
 
   // waits until all available data has been rendered
-  bool AcceptsData() const;
-  bool HasData() const                                  { return m_messageQueue.GetDataSize() > 0; }
-  int  GetLevel() const                                 { return m_messageQueue.GetLevel(); }
-  bool IsInited() const                                 { return m_messageQueue.IsInited(); }
-  void SendMessage(CDVDMsg* pMsg, int priority = 0)     { m_messageQueue.Put(pMsg, priority); }
-  void FlushMessages()                                  { m_messageQueue.Flush(); }
+  bool AcceptsData() const override;
+  bool HasData() const override                                  { return m_messageQueue.GetDataSize() > 0; }
+  int  GetLevel() const override                                 { return m_messageQueue.GetLevel(); }
+  bool IsInited() const override                                 { return m_messageQueue.IsInited(); }
+  void SendMessage(CDVDMsg* pMsg, int priority = 0)  override    { m_messageQueue.Put(pMsg, priority); }
+  void FlushMessages() override                                  { m_messageQueue.Flush(); }
 
-  void SetDynamicRangeCompression(long drc)             { m_dvdAudio.SetDynamicRangeCompression(drc); }
-  float GetDynamicRangeAmplification() const            { return 0.0f; }
+  void SetDynamicRangeCompression(long drc)  override            { m_dvdAudio.SetDynamicRangeCompression(drc); }
+  float GetDynamicRangeAmplification() const override            { return 0.0f; }
 
 
-  std::string GetPlayerInfo();
-  int GetAudioBitrate();
-  int GetAudioChannels();
+  std::string GetPlayerInfo() const override;
+  int GetAudioBitrate() const override;
+  int GetAudioChannels() const override;
 
   // holds stream information for current playing stream
   CDVDStreamInfo m_streaminfo;
 
-  double GetCurrentPts()                            { CSingleLock lock(m_info_section); return m_info.pts; }
+  double GetCurrentPts() const override                           { CSingleLock lock(m_info_section); return m_info.pts; }
 
-  bool IsStalled() const                            { return m_stalled;  }
-  bool IsPassthrough() const;
+  bool IsStalled() const override                           { return m_stalled;  }
+  bool IsPassthrough() const override;
 
 protected:
 
-  virtual void OnStartup();
-  virtual void OnExit();
-  virtual void Process();
+  virtual void OnStartup() override;
+  virtual void OnExit() override;
+  virtual void Process() override;
 
   void UpdatePlayerInfo();
   void OpenStream(CDVDStreamInfo &hints, CDVDAudioCodec* codec);

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -104,7 +104,7 @@ CVideoPlayerVideo::~CVideoPlayerVideo()
   StopThread();
 }
 
-double CVideoPlayerVideo::GetOutputDelay()
+double CVideoPlayerVideo::GetOutputDelay() const
 {
     double time = m_messageQueue.GetPacketCount(CDVDMsg::DEMUXER_PACKET);
     if( m_fFrameRate )
@@ -728,7 +728,7 @@ void CVideoPlayerVideo::ProcessOverlays(DVDVideoPicture* pSource, double pts)
 }
 #endif
 
-std::string CVideoPlayerVideo::GetStereoMode()
+std::string CVideoPlayerVideo::GetStereoMode() const
 {
   std::string  stereo_mode;
 
@@ -907,7 +907,7 @@ int CVideoPlayerVideo::OutputPicture(const DVDVideoPicture* src, double pts)
   return result;
 }
 
-std::string CVideoPlayerVideo::GetPlayerInfo()
+std::string CVideoPlayerVideo::GetPlayerInfo() const
 {
   std::ostringstream s;
   s << "vq:"   << std::setw(2) << std::min(99,GetLevel()) << "%";
@@ -925,7 +925,7 @@ std::string CVideoPlayerVideo::GetPlayerInfo()
   return s.str();
 }
 
-int CVideoPlayerVideo::GetVideoBitrate()
+int CVideoPlayerVideo::GetVideoBitrate() const
 {
   return (int)m_videoStats.GetBitrate();
 }
@@ -941,7 +941,7 @@ void CVideoPlayerVideo::ResetFrameRateCalc()
                         g_advancedSettings.m_videoFpsDetect == 0;
 }
 
-double CVideoPlayerVideo::GetCurrentPts()
+double CVideoPlayerVideo::GetCurrentPts() const
 {
   double renderPts;
   int sleepTime;

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.h
@@ -66,30 +66,30 @@ public:
                  CProcessInfo &processInfo);
   virtual ~CVideoPlayerVideo();
 
-  bool OpenStream(CDVDStreamInfo &hint);
-  void CloseStream(bool bWaitForBuffers);
+  bool OpenStream(CDVDStreamInfo &hint) override;
+  void CloseStream(bool bWaitForBuffers) override;
 
-  void Flush(bool sync);
-  bool AcceptsData() const;
-  bool HasData() const { return m_messageQueue.GetDataSize() > 0; }
-  int  GetLevel() const { return m_messageQueue.GetLevel(); }
-  bool IsInited() const { return m_messageQueue.IsInited(); }
-  void SendMessage(CDVDMsg* pMsg, int priority = 0) { m_messageQueue.Put(pMsg, priority); }
-  void FlushMessages() { m_messageQueue.Flush(); }
+  void Flush(bool sync) override;
+  bool AcceptsData() const override;
+  bool HasData() const override { return m_messageQueue.GetDataSize() > 0; }
+  int  GetLevel() const override { return m_messageQueue.GetLevel(); }
+  bool IsInited() const override { return m_messageQueue.IsInited(); }
+  void SendMessage(CDVDMsg* pMsg, int priority = 0) override { m_messageQueue.Put(pMsg, priority); }
+  void FlushMessages() override { m_messageQueue.Flush(); }
 
-  void EnableSubtitle(bool bEnable) { m_bRenderSubs = bEnable; }
-  bool IsSubtitleEnabled() { return m_bRenderSubs; }
-  void EnableFullscreen(bool bEnable) { m_bAllowFullscreen = bEnable; }
-  double GetSubtitleDelay() { return m_iSubtitleDelay; }
-  void SetSubtitleDelay(double delay) { m_iSubtitleDelay = delay; }
-  bool IsStalled() const { return m_stalled; }
-  double GetCurrentPts();
-  double GetOutputDelay(); /* returns the expected delay, from that a packet is put in queue */
-  int GetDecoderFreeSpace() { return 0; }
-  std::string GetPlayerInfo();
-  int GetVideoBitrate();
-  std::string GetStereoMode();
-  void SetSpeed(int iSpeed);
+  void EnableSubtitle(bool bEnable) override { m_bRenderSubs = bEnable; }
+  bool IsSubtitleEnabled() const override { return m_bRenderSubs; }
+  void EnableFullscreen(bool bEnable) override { m_bAllowFullscreen = bEnable; }
+  double GetSubtitleDelay() const override { return m_iSubtitleDelay; }
+  void SetSubtitleDelay(double delay) override { m_iSubtitleDelay = delay; }
+  bool IsStalled() const override { return m_stalled; }
+  double GetCurrentPts() const override;
+  double GetOutputDelay() const override; /* returns the expected delay, from that a packet is put in queue */
+  int GetDecoderFreeSpace() const override { return 0; }
+  std::string GetPlayerInfo() const override;
+  int GetVideoBitrate() const override;
+  std::string GetStereoMode() const override;
+  void SetSpeed(int iSpeed) override;
 
   // classes
   CDVDOverlayContainer* m_pOverlayContainer;
@@ -97,8 +97,8 @@ public:
 
 protected:
 
-  virtual void OnExit();
-  virtual void Process();
+  virtual void OnExit() override;
+  virtual void Process() override;
   bool ProcessDecoderOutput(int &decoderState, double &frametime, double &pts);
 
   int OutputPicture(const DVDVideoPicture* src, double pts);

--- a/xbmc/cores/paplayer/AudioDecoder.cpp
+++ b/xbmc/cores/paplayer/AudioDecoder.cpp
@@ -138,7 +138,7 @@ bool CAudioDecoder::Create(const CFileItem &file, int64_t seekOffset)
   return true;
 }
 
-AEAudioFormat CAudioDecoder::GetFormat()
+AEAudioFormat CAudioDecoder::GetFormat() const
 {
   AEAudioFormat format;
   if (!m_codec)
@@ -163,14 +163,14 @@ void CAudioDecoder::SetTotalTime(int64_t time)
     m_codec->m_TotalTime = time;
 }
 
-int64_t CAudioDecoder::TotalTime()
+int64_t CAudioDecoder::TotalTime() const
 {
   if (m_codec)
     return m_codec->m_TotalTime;
   return 0;
 }
 
-unsigned int CAudioDecoder::GetDataSize()
+unsigned int CAudioDecoder::GetDataSize() const
 {
   if (m_status == STATUS_QUEUING || m_status == STATUS_NO_FILE)
     return 0;
@@ -323,7 +323,7 @@ int CAudioDecoder::ReadSamples(int numsamples)
   return RET_SLEEP; // nothing to do
 }
 
-float CAudioDecoder::GetReplayGain()
+float CAudioDecoder::GetReplayGain() const
 {
 #define REPLAY_GAIN_DEFAULT_LEVEL 89.0f
   const ReplayGainSettings &replayGainSettings = g_application.GetReplayGainSettings();

--- a/xbmc/cores/paplayer/AudioDecoder.h
+++ b/xbmc/cores/paplayer/AudioDecoder.h
@@ -60,22 +60,22 @@ public:
 
   int ReadSamples(int numsamples);
 
-  bool CanSeek() { if (m_codec) return m_codec->CanSeek(); else return false; };
+  bool CanSeek() const { if (m_codec) return m_codec->CanSeek(); else return false; };
   int64_t Seek(int64_t time);
-  int64_t TotalTime();
+  int64_t TotalTime() const;
   void SetTotalTime(int64_t time);
   void Start() { m_canPlay = true;}; // cause a pre-buffered stream to start.
-  int GetStatus() { return m_status; };
+  int GetStatus() const { return m_status; };
   void SetStatus(int status) { m_status = status; }
 
-  AEAudioFormat GetFormat();
-  unsigned int GetChannels() { return GetFormat().m_channelLayout.Count(); }
+  AEAudioFormat GetFormat() const;
+  unsigned int GetChannels() const { return GetFormat().m_channelLayout.Count(); }
   // Data management
-  unsigned int GetDataSize();
+  unsigned int GetDataSize() const;
   void *GetData(unsigned int samples);
   uint8_t* GetRawData(int &size);
   ICodec *GetCodec() const { return m_codec; }
-  float GetReplayGain();
+  float GetReplayGain() const;
 
 private:
   // pcm buffer
@@ -93,7 +93,7 @@ private:
 
   // status
   bool m_eof;
-  int m_status;
+  mutable int m_status;
   bool m_canPlay;
 
   // the codec we're using

--- a/xbmc/cores/paplayer/ICodec.h
+++ b/xbmc/cores/paplayer/ICodec.h
@@ -61,7 +61,7 @@ public:
   // are allocated and destroyed in the destructor.
   virtual void DeInit()=0;
 
-  virtual bool CanSeek() {return true;}
+  virtual bool CanSeek() const {return true;}
 
   // Seek()
   // Should seek to the appropriate time (in ms) in the file, and return the
@@ -80,7 +80,7 @@ public:
   // CanInit()
   // Should return true if the codec can be initialized
   // eg. check if a dll needed for the codec exists
-  virtual bool CanInit()=0;
+  virtual bool CanInit() const = 0;
 
   // SkipNext()
   // Skip to next track/item inside the current media (if supported).

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -947,7 +947,7 @@ void PAPlayer::SetSpeed(int iSpeed)
   m_signalSpeedChange = true;
 }
 
-int PAPlayer::GetSpeed()
+int PAPlayer::GetSpeed() const
 {
   return m_playbackSpeed;
 }
@@ -995,7 +995,7 @@ void PAPlayer::SetTime(int64_t time)
   m_newForcedPlayerTime = time;
 }
 
-int64_t PAPlayer::GetTime()
+int64_t PAPlayer::GetTime() const
 {
   return m_playerGUIData.m_time;
 }
@@ -1018,7 +1018,7 @@ void PAPlayer::SetTotalTime(int64_t time)
   m_newForcedTotalTime = time;
 }
 
-int64_t PAPlayer::GetTotalTime()
+int64_t PAPlayer::GetTotalTime() const
 {
   return m_playerGUIData.m_totalTime;
 }
@@ -1037,7 +1037,7 @@ void PAPlayer::GetAudioStreamInfo(int index, SPlayerAudioStreamInfo &info)
   info.bitspersample = m_playerGUIData.m_bitsPerSample;
 }
 
-bool PAPlayer::CanSeek()
+bool PAPlayer::CanSeek() const
 {
   return m_playerGUIData.m_canSeek;
 }
@@ -1093,7 +1093,7 @@ void PAPlayer::SeekPercentage(float fPercent /*=0*/)
   SeekTime((int64_t)(fPercent * 0.01f * (float)GetTotalTime64()));
 }
 
-float PAPlayer::GetPercentage()
+float PAPlayer::GetPercentage() const
 {
   if (m_playerGUIData.m_totalTime > 0)
     return m_playerGUIData.m_time * 100.0f / m_playerGUIData.m_totalTime;

--- a/xbmc/cores/paplayer/PAPlayer.h
+++ b/xbmc/cores/paplayer/PAPlayer.h
@@ -45,6 +45,14 @@ public:
 
   virtual void RegisterAudioCallback(IAudioCallback* pCallback);
   virtual void UnRegisterAudioCallback();
+  virtual void GetAudioInfo( std::string& strAudioInfo) const {}
+  virtual void GetVideoInfo( std::string& strVideoInfo) const {}
+  virtual void GetAudioStreamInfo(int index, SPlayerAudioStreamInfo &info);
+  static bool HandlesType(const std::string &type);
+  virtual bool SkipNext() override;
+  virtual void GetAudioCapabilities(std::vector<int> &audioCaps) {}
+
+  // IPlayer interface
   virtual bool OpenFile(const CFileItem& file, const CPlayerOptions &options) override;
   virtual bool QueueNextFile(const CFileItem &file) override;
   virtual void OnNothingToQueueNotify() override;
@@ -59,22 +67,16 @@ public:
   virtual float GetPercentage() const override;
   virtual void SetVolume(float volume) override;
   virtual void SetDynamicRangeCompression(long drc) override;
-  virtual void GetAudioInfo( std::string& strAudioInfo) const {}
-  virtual void GetVideoInfo( std::string& strVideoInfo) const {}
   virtual void SetSpeed(int iSpeed = 0) override;
   virtual int GetSpeed() const override;
   virtual int GetCacheLevel() const override;
   virtual int64_t GetTotalTime() const override;
   virtual void SetTotalTime(int64_t time) override;
-  virtual void GetAudioStreamInfo(int index, SPlayerAudioStreamInfo &info);
   virtual int64_t GetTime() const override;
   virtual void SetTime(int64_t time) override;
   virtual void SeekTime(int64_t iTime = 0) override;
-  virtual bool SkipNext() override;
-  virtual void GetAudioCapabilities(std::vector<int> &audioCaps) {}
 
-  static bool HandlesType(const std::string &type);
-
+  // IJobCallback interface
   virtual void OnJobComplete(unsigned int jobID, bool success, CJob *job) override;
 
   struct
@@ -91,6 +93,7 @@ public:
   } m_playerGUIData;
 
 protected:
+  // Implementation of CThread
   virtual void OnStartup() override {}
   virtual void Process() override;
   virtual void OnExit() override;

--- a/xbmc/cores/paplayer/PAPlayer.h
+++ b/xbmc/cores/paplayer/PAPlayer.h
@@ -45,37 +45,37 @@ public:
 
   virtual void RegisterAudioCallback(IAudioCallback* pCallback);
   virtual void UnRegisterAudioCallback();
-  virtual bool OpenFile(const CFileItem& file, const CPlayerOptions &options);
-  virtual bool QueueNextFile(const CFileItem &file);
-  virtual void OnNothingToQueueNotify();
-  virtual bool CloseFile(bool reopen = false);
-  virtual bool IsPlaying() const;
+  virtual bool OpenFile(const CFileItem& file, const CPlayerOptions &options) override;
+  virtual bool QueueNextFile(const CFileItem &file) override;
+  virtual void OnNothingToQueueNotify() override;
+  virtual bool CloseFile(bool reopen = false) override;
+  virtual bool IsPlaying() const override;
   virtual void Pause() override;
-  virtual bool HasVideo() const { return false; }
-  virtual bool HasAudio() const { return true; }
-  virtual bool CanSeek();
-  virtual void Seek(bool bPlus = true, bool bLargeStep = false, bool bChapterOverride = false);
-  virtual void SeekPercentage(float fPercent = 0.0f);
-  virtual float GetPercentage();
-  virtual void SetVolume(float volume);
-  virtual void SetDynamicRangeCompression(long drc);
-  virtual void GetAudioInfo( std::string& strAudioInfo) {}
-  virtual void GetVideoInfo( std::string& strVideoInfo) {}
+  virtual bool HasVideo() const override { return false; }
+  virtual bool HasAudio() const override { return true; }
+  virtual bool CanSeek() const override;
+  virtual void Seek(bool bPlus = true, bool bLargeStep = false, bool bChapterOverride = false) override;
+  virtual void SeekPercentage(float fPercent = 0.0f) override;
+  virtual float GetPercentage() const override;
+  virtual void SetVolume(float volume) override;
+  virtual void SetDynamicRangeCompression(long drc) override;
+  virtual void GetAudioInfo( std::string& strAudioInfo) const {}
+  virtual void GetVideoInfo( std::string& strVideoInfo) const {}
   virtual void SetSpeed(int iSpeed = 0) override;
-  virtual int GetSpeed() override;
-  virtual int GetCacheLevel() const;
-  virtual int64_t GetTotalTime();
-  virtual void SetTotalTime(int64_t time);
+  virtual int GetSpeed() const override;
+  virtual int GetCacheLevel() const override;
+  virtual int64_t GetTotalTime() const override;
+  virtual void SetTotalTime(int64_t time) override;
   virtual void GetAudioStreamInfo(int index, SPlayerAudioStreamInfo &info);
-  virtual int64_t GetTime();
-  virtual void SetTime(int64_t time);
-  virtual void SeekTime(int64_t iTime = 0);
-  virtual bool SkipNext();
+  virtual int64_t GetTime() const override;
+  virtual void SetTime(int64_t time) override;
+  virtual void SeekTime(int64_t iTime = 0) override;
+  virtual bool SkipNext() override;
   virtual void GetAudioCapabilities(std::vector<int> &audioCaps) {}
 
   static bool HandlesType(const std::string &type);
 
-  virtual void OnJobComplete(unsigned int jobID, bool success, CJob *job);
+  virtual void OnJobComplete(unsigned int jobID, bool success, CJob *job) override;
 
   struct
   {
@@ -91,9 +91,9 @@ public:
   } m_playerGUIData;
 
 protected:
-  virtual void OnStartup() {}
-  virtual void Process();
-  virtual void OnExit();
+  virtual void OnStartup() override {}
+  virtual void Process() override;
+  virtual void OnExit() override;
 
 private:
   typedef struct

--- a/xbmc/cores/paplayer/VideoPlayerCodec.cpp
+++ b/xbmc/cores/paplayer/VideoPlayerCodec.cpp
@@ -55,7 +55,7 @@ VideoPlayerCodec::~VideoPlayerCodec()
   DeInit();
 }
 
-AEAudioFormat VideoPlayerCodec::GetFormat()
+AEAudioFormat VideoPlayerCodec::GetFormat() const
 {
   AEAudioFormat format;
   if (m_pAudioCodec)
@@ -507,17 +507,17 @@ int VideoPlayerCodec::ReadRaw(uint8_t **pBuffer, int *bufferSize)
   return READ_SUCCESS;
 }
 
-bool VideoPlayerCodec::CanInit()
+bool VideoPlayerCodec::CanInit() const
 {
   return true;
 }
 
-bool VideoPlayerCodec::CanSeek()
+bool VideoPlayerCodec::CanSeek() const
 {
   return m_bCanSeek;
 }
 
-bool VideoPlayerCodec::NeedConvert(AEDataFormat fmt)
+bool VideoPlayerCodec::NeedConvert(AEDataFormat fmt) const
 {
   if (fmt == AE_FMT_RAW)
     return false;

--- a/xbmc/cores/paplayer/VideoPlayerCodec.h
+++ b/xbmc/cores/paplayer/VideoPlayerCodec.h
@@ -39,18 +39,18 @@ public:
   virtual ~VideoPlayerCodec();
 
   virtual bool Init(const CFileItem &file, unsigned int filecache) override;
-  virtual void DeInit();
-  virtual bool Seek(int64_t iSeekTime);
-  virtual int ReadPCM(BYTE *pBuffer, int size, int *actualsize);
-  virtual int ReadRaw(uint8_t **pBuffer, int *bufferSize);
-  virtual bool CanInit();
-  virtual bool CanSeek();
-  virtual CAEChannelInfo GetChannelInfo() {return m_srcFormat.m_channelLayout;}
+  virtual void DeInit() override;
+  virtual bool Seek(int64_t iSeekTime) override;
+  virtual int ReadPCM(BYTE *pBuffer, int size, int *actualsize) override;
+  virtual int ReadRaw(uint8_t **pBuffer, int *bufferSize) override;
+  virtual bool CanInit() const override;
+  virtual bool CanSeek() const override;
+  virtual CAEChannelInfo GetChannelInfo() const {return m_srcFormat.m_channelLayout;}
 
-  AEAudioFormat GetFormat();
+  AEAudioFormat GetFormat() const;
   void SetContentType(const std::string &strContent);
 
-  bool NeedConvert(AEDataFormat fmt);
+  bool NeedConvert(AEDataFormat fmt) const;
 
 private:
   CDVDDemux* m_pDemuxer;

--- a/xbmc/network/upnp/UPnPPlayer.cpp
+++ b/xbmc/network/upnp/UPnPPlayer.cpp
@@ -466,7 +466,7 @@ failed:
   return;
 }
 
-void CUPnPPlayer::SeekTime(__int64 ms)
+void CUPnPPlayer::SeekTime(int64_t ms)
 {
   NPT_CHECK_LABEL(m_control->Seek(m_delegate->m_device
                                 , m_delegate->m_instance
@@ -479,7 +479,7 @@ failed:
   CLog::Log(LOGERROR, "UPNP: CUPnPPlayer::SeekTime - unable to seek playback");
 }
 
-float CUPnPPlayer::GetPercentage()
+float CUPnPPlayer::GetPercentage() const
 {
   int64_t tot = GetTotalTime();
   if(tot)
@@ -564,7 +564,7 @@ failed:
   return;
 }
 
-int64_t CUPnPPlayer::GetTime()
+int64_t CUPnPPlayer::GetTime() const
 {
   NPT_CHECK_POINTER_LABEL_SEVERE(m_delegate, failed);
   return m_delegate->m_posinfo.rel_time.ToMillis();
@@ -572,7 +572,7 @@ failed:
   return 0;
 }
 
-int64_t CUPnPPlayer::GetTotalTime()
+int64_t CUPnPPlayer::GetTotalTime() const
 {
   NPT_CHECK_POINTER_LABEL_SEVERE(m_delegate, failed);
   return m_delegate->m_posinfo.track_duration.ToMillis();
@@ -580,7 +580,7 @@ failed:
   return 0;
 };
 
-std::string CUPnPPlayer::GetPlayingTitle()
+std::string CUPnPPlayer::GetPlayingTitle() const
 {
   return "";
 };
@@ -607,7 +607,7 @@ void CUPnPPlayer::SetSpeed(int iSpeed)
 
 }
 
-int CUPnPPlayer::GetSpeed()
+int CUPnPPlayer::GetSpeed() const
 {
   if (IsPaused())
     return 0;

--- a/xbmc/network/upnp/UPnPPlayer.h
+++ b/xbmc/network/upnp/UPnPPlayer.h
@@ -40,6 +40,11 @@ public:
   CUPnPPlayer(IPlayerCallback& callback, const char* uuid);
   virtual ~CUPnPPlayer();
 
+  virtual void GetAudioInfo(std::string& strAudioInfo) {};
+  virtual void GetVideoInfo(std::string& strVideoInfo) {};
+  int PlayFile(const CFileItem& file, const CPlayerOptions& options, CGUIDialogBusy*& dialog, XbmcThreads::EndTime& timeout);
+
+  // IPlayer interface
   virtual bool OpenFile(const CFileItem& file, const CPlayerOptions& options) override;
   virtual bool QueueNextFile(const CFileItem &file) override;
   virtual bool CloseFile(bool reopen = false) override;
@@ -51,32 +56,24 @@ public:
   virtual void SeekPercentage(float fPercent = 0) override;
   virtual float GetPercentage() const override;
   virtual void SetVolume(float volume) override;
-  virtual void GetAudioInfo(std::string& strAudioInfo) {};
-  virtual void GetVideoInfo(std::string& strVideoInfo) {};
   virtual bool CanRecord() const override { return false;};
   virtual bool IsRecording() const override { return false;};
   virtual bool Record(bool bOnOff) override { return false;};
-
-  virtual int  GetChapterCount() const override                           { return 0; }
-  virtual int  GetChapter() const override                                { return -1; }
+  virtual int  GetChapterCount() const override { return 0; }
+  virtual int  GetChapter() const override { return -1; }
   virtual void GetChapterName(std::string& strChapterName, int chapterIdx = -1) const override { return; }
-  virtual int  SeekChapter(int iChapter) override                         { return -1; }
-
+  virtual int  SeekChapter(int iChapter) override { return -1; }
   virtual void SeekTime(int64_t iTime = 0) override;
   virtual int64_t GetTime() const override;
   virtual int64_t GetTotalTime() const override;
   virtual void SetSpeed(int iSpeed = 0) override;
   virtual int GetSpeed() const override;
-
   virtual bool SkipNext() override {return false;}
   virtual bool IsCaching() const  override {return false;};
   virtual int GetCacheLevel() const override {return -1;};
   virtual void DoAudioWork() override;
   virtual bool OnAction(const CAction &action) override;
-
   virtual std::string GetPlayingTitle() const override;
-
-  int PlayFile(const CFileItem& file, const CPlayerOptions& options, CGUIDialogBusy*& dialog, XbmcThreads::EndTime& timeout);
 
 private:
   bool IsPaused() const;

--- a/xbmc/network/upnp/UPnPPlayer.h
+++ b/xbmc/network/upnp/UPnPPlayer.h
@@ -40,41 +40,41 @@ public:
   CUPnPPlayer(IPlayerCallback& callback, const char* uuid);
   virtual ~CUPnPPlayer();
 
-  virtual bool OpenFile(const CFileItem& file, const CPlayerOptions& options);
-  virtual bool QueueNextFile(const CFileItem &file);
-  virtual bool CloseFile(bool reopen = false);
-  virtual bool IsPlaying() const;
+  virtual bool OpenFile(const CFileItem& file, const CPlayerOptions& options) override;
+  virtual bool QueueNextFile(const CFileItem &file) override;
+  virtual bool CloseFile(bool reopen = false) override;
+  virtual bool IsPlaying() const override;
   virtual void Pause() override;
-  virtual bool HasVideo() const { return false; }
-  virtual bool HasAudio() const { return false; }
-  virtual void Seek(bool bPlus, bool bLargeStep, bool bChapterOverride);
-  virtual void SeekPercentage(float fPercent = 0);
-  virtual float GetPercentage();
-  virtual void SetVolume(float volume);
+  virtual bool HasVideo() const override { return false; }
+  virtual bool HasAudio() const override { return false; }
+  virtual void Seek(bool bPlus, bool bLargeStep, bool bChapterOverride) override;
+  virtual void SeekPercentage(float fPercent = 0) override;
+  virtual float GetPercentage() const override;
+  virtual void SetVolume(float volume) override;
   virtual void GetAudioInfo(std::string& strAudioInfo) {};
   virtual void GetVideoInfo(std::string& strVideoInfo) {};
-  virtual bool CanRecord() { return false;};
-  virtual bool IsRecording() { return false;};
-  virtual bool Record(bool bOnOff) { return false;};
+  virtual bool CanRecord() const override { return false;};
+  virtual bool IsRecording() const override { return false;};
+  virtual bool Record(bool bOnOff) override { return false;};
 
-  virtual int  GetChapterCount()                               { return 0; }
-  virtual int  GetChapter()                                    { return -1; }
-  virtual void GetChapterName(std::string& strChapterName)     { return; }
-  virtual int  SeekChapter(int iChapter)                       { return -1; }
+  virtual int  GetChapterCount() const override                           { return 0; }
+  virtual int  GetChapter() const override                                { return -1; }
+  virtual void GetChapterName(std::string& strChapterName, int chapterIdx = -1) const override { return; }
+  virtual int  SeekChapter(int iChapter) override                         { return -1; }
 
-  virtual void SeekTime(__int64 iTime = 0);
-  virtual int64_t GetTime();
-  virtual int64_t GetTotalTime();
+  virtual void SeekTime(int64_t iTime = 0) override;
+  virtual int64_t GetTime() const override;
+  virtual int64_t GetTotalTime() const override;
   virtual void SetSpeed(int iSpeed = 0) override;
-  virtual int GetSpeed() override;
+  virtual int GetSpeed() const override;
 
-  virtual bool SkipNext(){return false;}
-  virtual bool IsCaching() const {return false;};
-  virtual int GetCacheLevel() const {return -1;};
-  virtual void DoAudioWork();
-  virtual bool OnAction(const CAction &action);
+  virtual bool SkipNext() override {return false;}
+  virtual bool IsCaching() const  override {return false;};
+  virtual int GetCacheLevel() const override {return -1;};
+  virtual void DoAudioWork() override;
+  virtual bool OnAction(const CAction &action) override;
 
-  virtual std::string GetPlayingTitle();
+  virtual std::string GetPlayingTitle() const override;
 
   int PlayFile(const CFileItem& file, const CPlayerOptions& options, CGUIDialogBusy*& dialog, XbmcThreads::EndTime& timeout);
 

--- a/xbmc/utils/RingBuffer.cpp
+++ b/xbmc/utils/RingBuffer.cpp
@@ -222,12 +222,12 @@ bool CRingBuffer::Copy(CRingBuffer &rBuf)
 }
 
 /* Our various 'get' methods */
-char *CRingBuffer::getBuffer()
+char *CRingBuffer::getBuffer() const
 {
   return m_buffer;
 }
 
-unsigned int CRingBuffer::getSize()
+unsigned int CRingBuffer::getSize() const
 {
   CSingleLock lock(m_critSection);
   return m_size;
@@ -238,19 +238,19 @@ unsigned int CRingBuffer::getReadPtr() const
   return m_readPtr;
 }
 
-unsigned int CRingBuffer::getWritePtr()
+unsigned int CRingBuffer::getWritePtr() const
 {
   CSingleLock lock(m_critSection);
   return m_writePtr;
 }
 
-unsigned int CRingBuffer::getMaxReadSize()
+unsigned int CRingBuffer::getMaxReadSize() const
 {
   CSingleLock lock(m_critSection);
   return m_fillCount;
 }
 
-unsigned int CRingBuffer::getMaxWriteSize()
+unsigned int CRingBuffer::getMaxWriteSize() const
 {
   CSingleLock lock(m_critSection);
   return m_size - m_fillCount;

--- a/xbmc/utils/RingBuffer.h
+++ b/xbmc/utils/RingBuffer.h
@@ -42,10 +42,10 @@ public:
   bool SkipBytes(int skipSize);
   bool Append(CRingBuffer &rBuf);
   bool Copy(CRingBuffer &rBuf);
-  char *getBuffer();
-  unsigned int getSize();
+  char *getBuffer() const;
+  unsigned int getSize() const;
   unsigned int getReadPtr() const;
-  unsigned int getWritePtr();
-  unsigned int getMaxReadSize();
-  unsigned int getMaxWriteSize();
+  unsigned int getWritePtr() const;
+  unsigned int getMaxReadSize() const;
+  unsigned int getMaxWriteSize() const;
 };


### PR DESCRIPTION
This makes some of the more regular used interfaces of `xbmc/cores/` const-correct. I also added the override keyword at many places which, excuse my french, silences a shitload of warnings ;-)
