### PR TITLE
set tvshow thumb on *all seasons node

### DIFF
--- a/xbmc/video/windows/VideoFileItemListModifier.cpp
+++ b/xbmc/video/windows/VideoFileItemListModifier.cpp
@@ -77,6 +77,7 @@ void CVideoFileItemListModifier::AddQueuingFolder(CFileItemList& items)
     pItem.reset(new CFileItem(strLabel));  // "All Seasons"
     videoUrl.AppendPath("-1/");
     pItem->SetPath(videoUrl.ToString());
+    pItem->SetArt("thumb", items.GetArt("thumb"));
     // set the number of watched and unwatched items accordingly
     int watched = 0;
     int unwatched = 0;


### PR DESCRIPTION
Can't find when this was lost, but this was default behaviour in previous versions. Without this PR it shows the default folder image.

Not sure how to fix and maybe unrelated but there's an issue when selecting `manage` in the context menu on this node.
It doesn't open the manage section where there should be an entry `Choose art`.
