### PR TITLE
Fix retrieve all the information before update

### DIFF
--- a/xbmc/interfaces/json-rpc/VideoLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/VideoLibrary.cpp
@@ -528,7 +528,7 @@ JSONRPC_STATUS CVideoLibrary::SetMovieDetails(const std::string &method, ITransp
     return InternalError;
 
   CVideoInfoTag infos;
-  if (!videodatabase.GetMovieInfo("", infos, id, RequiresInitialDetails(parameterObject)) || infos.m_iDbId <= 0)
+  if (!videodatabase.GetMovieInfo("", infos, id) || infos.m_iDbId <= 0)
     return InvalidParams;
 
   // get artwork
@@ -605,7 +605,7 @@ JSONRPC_STATUS CVideoLibrary::SetTVShowDetails(const std::string &method, ITrans
     return InternalError;
 
   CVideoInfoTag infos;
-  if (!videodatabase.GetTvShowInfo("", infos, id, (CFileItem *)0, RequiresInitialDetails(parameterObject)) || infos.m_iDbId <= 0)
+  if (!videodatabase.GetTvShowInfo("", infos, id) || infos.m_iDbId <= 0)
     return InvalidParams;
 
   // get artwork
@@ -676,7 +676,7 @@ JSONRPC_STATUS CVideoLibrary::SetEpisodeDetails(const std::string &method, ITran
     return InternalError;
 
   CVideoInfoTag infos;
-  videodatabase.GetEpisodeInfo("", infos, id, RequiresInitialDetails(parameterObject));
+  videodatabase.GetEpisodeInfo("", infos, id);
   if (infos.m_iDbId <= 0)
   {
     videodatabase.Close();
@@ -986,14 +986,6 @@ bool CVideoLibrary::FillFileItemList(const CVariant &parameterObject, CFileItemL
   }
 
   return success;
-}
-
-int CVideoLibrary::RequiresInitialDetails(const CVariant &parameterObject)
-{
-  int details = VideoDbDetailsNone;
-  if (ParameterNotNull(parameterObject, "ratings") || ParameterNotNull(parameterObject, "rating") || ParameterNotNull(parameterObject, "votes"))
-    return VideoDbDetailsRating;
-  return details;
 }
 
 int CVideoLibrary::RequiresAdditionalDetails(const MediaType& mediaType, const CVariant &parameterObject)

--- a/xbmc/interfaces/json-rpc/VideoLibrary.h
+++ b/xbmc/interfaces/json-rpc/VideoLibrary.h
@@ -84,7 +84,6 @@ namespace JSONRPC
 
   private:
     static int RequiresAdditionalDetails(const MediaType& mediaType, const CVariant &parameterObject);
-    static int RequiresInitialDetails(const CVariant &parameterObject);
     static JSONRPC_STATUS HandleItems(const char *idProperty, const char *resultName, CFileItemList &items, const CVariant &parameterObject, CVariant &result, bool limit = true);
     static JSONRPC_STATUS RemoveVideo(const CVariant &parameterObject);
     static void UpdateVideoTag(const CVariant &parameterObject, CVideoInfoTag &details, std::map<std::string, std::string> &artwork, std::set<std::string> &removedArtwork, std::set<std::string>& updatedDetails);


### PR DESCRIPTION
I assumed with update everything was handled as movies (update only if changes occurs) but tv shows doesn't. For now I'll restore the previous behavior (retrieve everything).. I'll try to improve it when I find time..
