### PR TITLE
[depends][xbmc][fix] Get rid of wdk requirement

### DIFF
--- a/lib/addons/library.kodi.adsp/project/VS2010Express/libKODI_adsp.vcxproj
+++ b/lib/addons/library.kodi.adsp/project/VS2010Express/libKODI_adsp.vcxproj
@@ -14,6 +14,7 @@
     <ProjectGuid>{44F93C4D-85DD-4452-99BB-F1D196174024}</ProjectGuid>
     <RootNamespace>KODI_ADSP</RootNamespace>
     <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(SolutionDir)\XBMC.core-defaults.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/lib/addons/library.kodi.audioengine/project/VS2010Express/libKODI_audioengine.vcxproj
+++ b/lib/addons/library.kodi.audioengine/project/VS2010Express/libKODI_audioengine.vcxproj
@@ -20,6 +20,7 @@
     <ProjectGuid>{6B96FD7D-26EE-415B-8858-27757A0B1273}</ProjectGuid>
     <RootNamespace>KODI_ADSP</RootNamespace>
     <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(SolutionDir)\XBMC.core-defaults.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/lib/addons/library.kodi.guilib/project/VS2010Express/libKODI_guilib.vcxproj
+++ b/lib/addons/library.kodi.guilib/project/VS2010Express/libKODI_guilib.vcxproj
@@ -17,6 +17,7 @@
     <ProjectGuid>{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}</ProjectGuid>
     <RootNamespace>XBMC_VDR</RootNamespace>
     <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(SolutionDir)\XBMC.core-defaults.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/lib/addons/library.kodi.inputstream/project/VS2010Express/libKODI_inputstream.vcxproj
+++ b/lib/addons/library.kodi.inputstream/project/VS2010Express/libKODI_inputstream.vcxproj
@@ -17,6 +17,7 @@
     <ProjectGuid>{8BC9CEB8-8B4A-11D0-8D11-00A0CFEBC942}</ProjectGuid>
     <RootNamespace>XBMC_INPUTSTREAM</RootNamespace>
     <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(SolutionDir)\XBMC.core-defaults.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/lib/addons/library.kodi.peripheral/project/VS2010Express/libKODI_peripheral.vcxproj
+++ b/lib/addons/library.kodi.peripheral/project/VS2010Express/libKODI_peripheral.vcxproj
@@ -14,6 +14,7 @@
     <ProjectGuid>{FEA71D39-CB68-486B-A978-246E661A3F89}</ProjectGuid>
     <RootNamespace>XBMC_VDR</RootNamespace>
     <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(SolutionDir)\XBMC.core-defaults.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/lib/addons/library.xbmc.addon/project/VS2010Express/libXBMC_addon.vcxproj
+++ b/lib/addons/library.xbmc.addon/project/VS2010Express/libXBMC_addon.vcxproj
@@ -14,6 +14,7 @@
     <ProjectGuid>{2DCEA60B-4EBC-4DB7-9FBD-297C1EFD95D7}</ProjectGuid>
     <RootNamespace>XBMC_VDR</RootNamespace>
     <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(SolutionDir)\XBMC.core-defaults.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/lib/addons/library.xbmc.addon/project/VS2010Express/libXBMC_addon.vcxproj.filters
+++ b/lib/addons/library.xbmc.addon/project/VS2010Express/libXBMC_addon.vcxproj.filters
@@ -12,8 +12,6 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\..\..\..\addons\library.xbmc.addon\libXBMC_addon.h">
-      <Filter>Source Files</Filter>
-    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\xbmc\addons\kodi-addon-dev-kit\include\kodi\libXBMC_addon.h" />
   </ItemGroup>
 </Project>

--- a/lib/addons/library.xbmc.codec/project/VS2010Express/libXBMC_codec.vcxproj
+++ b/lib/addons/library.xbmc.codec/project/VS2010Express/libXBMC_codec.vcxproj
@@ -14,6 +14,7 @@
     <ProjectGuid>{F8F1290B-1188-4810-86C9-88178A31D2AF}</ProjectGuid>
     <RootNamespace>XBMC_VDR</RootNamespace>
     <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(SolutionDir)\XBMC.core-defaults.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/lib/addons/library.xbmc.pvr/project/VS2010Express/libXBMC_pvr.vcxproj
+++ b/lib/addons/library.xbmc.pvr/project/VS2010Express/libXBMC_pvr.vcxproj
@@ -14,6 +14,7 @@
     <ProjectGuid>{6D8C91F8-992F-4C83-9DE3-485D64EF8420}</ProjectGuid>
     <RootNamespace>XBMC_VDR</RootNamespace>
     <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(SolutionDir)\XBMC.core-defaults.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/lib/cpluff/libcpluff/win32/cpluff.vcxproj
+++ b/lib/cpluff/libcpluff/win32/cpluff.vcxproj
@@ -14,6 +14,7 @@
     <ProjectGuid>{88968763-3D6B-48A8-B495-CC8C187FAC02}</ProjectGuid>
     <RootNamespace>cpluff</RootNamespace>
     <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(SolutionDir)\XBMC.core-defaults.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/lib/gtest/msvc/gtest.vcxproj
+++ b/lib/gtest/msvc/gtest.vcxproj
@@ -13,6 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{C8F6C172-56F2-4E76-B5FA-C3B423B31BE7}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(SolutionDir)\XBMC.core-defaults.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/lib/libexif/libexif.vcxproj
+++ b/lib/libexif/libexif.vcxproj
@@ -15,6 +15,7 @@
     <ProjectGuid>{AD20A3E2-09CB-42DB-9A70-27F7CDC886CE}</ProjectGuid>
     <RootNamespace>libexif_dll</RootNamespace>
     <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(SolutionDir)\XBMC.core-defaults.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/lib/win32/Effects11/Effects11_2013.vcxproj
+++ b/lib/win32/Effects11/Effects11_2013.vcxproj
@@ -31,6 +31,7 @@
     <ProjectGuid>{DF460EAB-570D-4B50-9089-2E2FC801BF38}</ProjectGuid>
     <RootNamespace>Effects11</RootNamespace>
     <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/project/BuildDependencies/scripts/0_package.list
+++ b/project/BuildDependencies/scripts/0_package.list
@@ -31,6 +31,7 @@ libxml2-2.9.4-win32-vc140-v2.7z
 libxslt-1.1.29-win32-vc140.7z
 libyajl-2.0.1-win32.7z
 lzo-2.09-win32-vc140-v3.7z
+mini_wdk-win32.7z
 mysql-connector-c-6.1.6-win32-vc140.7z
 openssl-1.0.2g-win32-vc140-v2.7z
 pcre-8.37-win32-vc140-v3.7z

--- a/project/VS2010Express/UnrarXLib.vcxproj
+++ b/project/VS2010Express/UnrarXLib.vcxproj
@@ -14,6 +14,7 @@
     <ProjectGuid>{FE0A91C0-E30A-47CD-8A92-A508C9292452}</ProjectGuid>
     <RootNamespace>UnrarXLib</RootNamespace>
     <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(SolutionDir)\XBMC.core-defaults.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -19,7 +19,7 @@
     <RootNamespace>XBMC_PC</RootNamespace>
     <Keyword>Win32Proj</Keyword>
     <ProjectName>Kodi</ProjectName>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(SolutionDir)\XBMC.core-defaults.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/project/VS2010Express/XbmcCommons.vcxproj
+++ b/project/VS2010Express/XbmcCommons.vcxproj
@@ -23,6 +23,7 @@
     <ProjectGuid>{87DA0A1E-3F33-4927-A5E5-2D58F2C58E17}</ProjectGuid>
     <RootNamespace>XbmcCommons</RootNamespace>
     <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(SolutionDir)\XBMC.core-defaults.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/project/VS2010Express/XbmcThreads.vcxproj
+++ b/project/VS2010Express/XbmcThreads.vcxproj
@@ -54,6 +54,7 @@
     <ProjectGuid>{034B1D02-CA92-455D-8866-DB95BEE49C10}</ProjectGuid>
     <RootNamespace>XbmcCommons</RootNamespace>
     <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(SolutionDir)\XBMC.core-defaults.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/project/VS2010Express/libPlatinum.vcxproj
+++ b/project/VS2010Express/libPlatinum.vcxproj
@@ -14,6 +14,7 @@
     <ProjectGuid>{B2975495-FBE4-4F94-AAC5-B21A9842BF50}</ProjectGuid>
     <RootNamespace>libPlatinum</RootNamespace>
     <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(SolutionDir)\XBMC.core-defaults.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/xbmc/rendering/dx/RenderSystemDX.cpp
+++ b/xbmc/rendering/dx/RenderSystemDX.cpp
@@ -36,7 +36,7 @@
 #include "win32/dxerr.h"
 #include "utils/SystemInfo.h"
 #pragma warning(disable: 4091)
-#include "d3d10umddi.h"
+#include <d3d10umddi.h>
 #pragma warning(default: 4091)
 #include <algorithm>
 


### PR DESCRIPTION
Bump sdk to Win 10 as cmake defaults to that for addons anyway. Add the few headers we need from wdk as a package to simplify setup
