### PR TITLE
mmalrender: Allow a frame of slop when waiting for vsync

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.h
@@ -126,6 +126,7 @@ protected:
   double m_error;
 
   bool init_vout(ERenderFormat format, AVPixelFormat pixfmt, bool opaque);
+  uint32_t m_vsync_count;
   void ReleaseBuffers();
   void UnInitMMAL();
 };

--- a/xbmc/linux/RBP.cpp
+++ b/xbmc/linux/RBP.cpp
@@ -218,7 +218,7 @@ uint32_t CRBP::WaitVsync(uint32_t target)
     if (!m_vsync_cond.wait(vlock, delay.MillisLeft()))
       break;
   }
-  if (m_vsync_count < target)
+  if ((signed)(m_vsync_count - target) < 0)
     CLog::Log(LOGDEBUG, "CRBP::%s no  vsync %d/%d display:%x(%x) delay:%d", __FUNCTION__, m_vsync_count, target, m_display, display, delay.MillisLeft());
 
   return m_vsync_count;


### PR DESCRIPTION
Previously we would always wait an extra vsync (even if one had been missed) in RenderUpdate.
Now if a single vsync is missed, we won't wait.
