### PR TITLE
Double the backslash in mysql in case we're in 'LIKE'

### DIFF
--- a/xbmc/dbwrappers/mysqldataset.h
+++ b/xbmc/dbwrappers/mysqldataset.h
@@ -93,7 +93,7 @@ private:
   char et_getdigit(double *val, int *cnt);
   void appendSpace(StrAccum *pAccum, int N);
   void mysqlVXPrintf(StrAccum *pAccum, int useExtended, const char *fmt, va_list ap);
-  void mysqlStrAccumAppend(StrAccum *p, const char *z, int N);
+  bool mysqlStrAccumAppend(StrAccum *p, const char *z, int N);
   char * mysqlStrAccumFinish(StrAccum *p);
   void mysqlStrAccumReset(StrAccum *p);
   void mysqlStrAccumInit(StrAccum *p, char *zBase, int n, int mx);


### PR DESCRIPTION
@DaveTBlake spotted a bug in our current mysqldataset. The bug is more a wrong implementation because of a specific case.
Currently db values are passed through PrepareSQL to get the parameters formatted well (for example strings will have backslash doubled and special chars formatted).
Sqlite has a specific function for it but mysql doesn't so in 2010 (!!!) firnsy (not sure if it was a member) ported the sqlite function to mysql (https://github.com/xbmc/xbmc-antiquated/commit/a2ae89c0e79237d4e86ac42bf4ea08c0cc780be5 https://sourceforge.net/p/xbmc/mailman/message/25665578/ )
The main problem is that mysql has a "unique feature" where in like statements ( for eample `SELECT * FROM movie_view WHERE strPath LIKE 'C:\\Film\\%'`) doubling backslash isn't enough because it parse the string twice (explained in the note here http://dev.mysql.com/doc/refman/5.7/en/string-comparison-functions.html#operator_like ). SQlite doesn't work like this so this isn't handled. for example
this query works in both mysql and sqlite:

```
`SELECT * FROM movie_view WHERE strPath='C:\\Film\\Batman\\'
```

but this didn't work in mysql (work of course in sqlite)

```
`SELECT * FROM movie_view WHERE strPath LIKE 'C:\\Film\\Batman\\%'
```

because you need

```
`SELECT * FROM movie_view WHERE strPath LIKE 'C:\\\\Film\\\\Batman\\\\%'
```

This of course breaks every playlist with windows local paths because they all have backslash..
So we need to double backslash but when we have a like we need to quadruple it.
I tried to insert in this current code a check to detect if we're parsing a like parameter.. I'm not sure it's okay to do it like this but I can't think to another way.. Every suggestion is welcome..
@MilhouseVH not sure if it's worth it to add it to your builds.. I tested it quickly and it seems to work but it might break a lot of other things..
