### PR TITLE
[cmake/linux] Move WiiRemote target to ExtraTargets.cmake

### DIFF
--- a/project/cmake/CMakeLists.txt
+++ b/project/cmake/CMakeLists.txt
@@ -365,13 +365,6 @@ if(EXISTS ${PROJECT_SOURCE_DIR}/scripts/${CORE_SYSTEM_NAME}/ExtraTargets.cmake)
   include(${PROJECT_SOURCE_DIR}/scripts/${CORE_SYSTEM_NAME}/ExtraTargets.cmake)
 endif()
 
-# WiiRemote
-if(ENABLE_EVENTCLIENTS)
-  if(CORE_SYSTEM_NAME STREQUAL linux)
-    add_subdirectory(${CORE_SOURCE_DIR}/tools/EventClients/Clients/WiiRemote build/WiiRemote)
-  endif()
-endif()
-
 include(scripts/${CORE_SYSTEM_NAME}/Install.cmake)
 
 # Create target that allows to build binary-addons.

--- a/project/cmake/scripts/linux/ExtraTargets.cmake
+++ b/project/cmake/scripts/linux/ExtraTargets.cmake
@@ -3,3 +3,8 @@ if(ENABLE_X11 AND XRANDR_FOUND)
   add_executable(${APP_NAME_LC}-xrandr ${CORE_SOURCE_DIR}/xbmc-xrandr.c)
   target_link_libraries(kodi-xrandr ${SYSTEM_LDFLAGS} ${X_LIBRARIES} m ${XRANDR_LIBRARIES})
 endif()
+
+# WiiRemote
+if(ENABLE_EVENTCLIENTS AND CORE_SYSTEM_NAME STREQUAL linux)
+  add_subdirectory(${CORE_SOURCE_DIR}/tools/EventClients/Clients/WiiRemote build/WiiRemote)
+endif()


### PR DESCRIPTION
@hudokkow: I forgot to move that one when rebasing my change. There shouldn't be any change needed to the cpack code, right?
