### PR TITLE
Curl: Support version 7.5.0 and upwards

### DIFF
--- a/xbmc/filesystem/DllLibCurl.h
+++ b/xbmc/filesystem/DllLibCurl.h
@@ -52,7 +52,7 @@ namespace XCURL
     virtual CURLMcode multi_fdset(CURLM *multi_handle, fd_set *read_fd_set, fd_set *write_fd_set, fd_set *exc_fd_set, int *max_fd)=0;
     virtual CURLMcode multi_timeout(CURLM *multi_handle, long *timeout)=0;
     virtual CURLMsg*  multi_info_read(CURLM *multi_handle, int *msgs_in_queue)=0;
-    virtual void multi_cleanup(CURL_HANDLE * handle )=0;
+    virtual CURLMcode multi_cleanup(CURLM * handle )=0;
     virtual struct curl_slist* slist_append(struct curl_slist *, const char *)=0;
     virtual void  slist_free_all(struct curl_slist *)=0;
   };
@@ -77,7 +77,7 @@ namespace XCURL
     DEFINE_METHOD5(CURLMcode, multi_fdset, (CURLM *p1, fd_set *p2, fd_set *p3, fd_set *p4, int *p5))
     DEFINE_METHOD2(CURLMcode, multi_timeout, (CURLM *p1, long *p2))
     DEFINE_METHOD2(CURLMsg*,  multi_info_read, (CURLM *p1, int *p2))
-    DEFINE_METHOD1(void, multi_cleanup, (CURLM *p1))
+    DEFINE_METHOD1(CURLMcode, multi_cleanup, (CURLM *p1))
     DEFINE_METHOD2(struct curl_slist*, slist_append, (struct curl_slist * p1, const char * p2))
     DEFINE_METHOD1(void, slist_free_all, (struct curl_slist * p1))
     DEFINE_METHOD1(const char *, easy_strerror, (CURLcode p1))


### PR DESCRIPTION
Yes - it's ugly. But yes going the typesafety route is the correct way.

We are in discussion with upstream for API breakage: https://github.com/curl/curl/commit/9adf3c473a01b289c781aab111f9ad2fc541ed4e

Thanks to @stefansaraev and @paxxi for discussion
