### PR TITLE
AESinkAudiotrack: Do not average over 4 seconds but 200 ms

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -48,7 +48,7 @@ using namespace jni;
 // is the max TrueHD package
 const unsigned int MAX_RAW_AUDIO_BUFFER_HD = 61440;
 const unsigned int MAX_RAW_AUDIO_BUFFER = 16384;
-const unsigned int MOVING_AVERAGE_MAX_MEMBERS = 20;
+const unsigned int MOVING_AVERAGE_MAX_MEMBERS = 5;
 
 /*
  * ADT-1 on L preview as of 2014-10 downmixes all non-5.1/7.1 content


### PR DESCRIPTION
Please someone runtime tests this.

The old 20 worked around the insane flaws of the android delay API by averaging over a very long time. If you send "periodsize" amount of data this was something between 80 ms and 200 ms in PCM mode which made us react very slowly, we needed up to 4 (1.6) seconds in worst case to adjust to audio. After I added the manual blocking (forced usleeps) this should not be needed anymore. 

This could fix Sync Playback to Display's resample ratio.
