### PR TITLE
[cmake] Allow mirroring of additional system specific files to build tree

### DIFF
--- a/project/cmake/CMakeLists.txt
+++ b/project/cmake/CMakeLists.txt
@@ -269,6 +269,11 @@ core_add_optional_subdirs_from_filelist(${PROJECT_SOURCE_DIR}/treedata/optional/
 copy_files_from_filelist_to_buildtree(${PROJECT_SOURCE_DIR}/installdata/common/*.txt
                                       ${PROJECT_SOURCE_DIR}/installdata/${CORE_SYSTEM_NAME}/*.txt)
 
+# copy system specific additional files to build tree
+if(COMMAND copy_additional_files_to_buildtree)
+  copy_additional_files_to_buildtree()
+endif()
+
 list(APPEND SKINS "${CORE_SOURCE_DIR}/addons/skin.estuary\;${CORE_SOURCE_DIR}")
 list(APPEND SKINS "${CORE_SOURCE_DIR}/addons/skin.estouchy\;${CORE_SOURCE_DIR}")
 
@@ -316,7 +321,6 @@ unset(_MAIN_LIBRARIES)
 if(WIN32)
   set_target_properties(${APP_NAME_LC} PROPERTIES WIN32_EXECUTABLE ON)
   set_property(DIRECTORY PROPERTY VS_STARTUP_PROJECT ${APP_NAME_LC})
-  copy_main_dlls_to_buildtree()
 elseif(CORE_SYSTEM_NAME STREQUAL android)
   # Nothing
 else()

--- a/project/cmake/scripts/common/Macros.cmake
+++ b/project/cmake/scripts/common/Macros.cmake
@@ -134,14 +134,18 @@ endfunction()
 #   relative the relative base of file path in the build/install tree
 # Optional Arguments:
 #   NO_INSTALL: exclude file from installation target
+#   SUBDIR:     install file into subdirectory
 # Implicit arguments:
 #   CORE_SOURCE_DIR - root of source tree
 # On return:
 #   Files is mirrored to the build tree and added to ${install_data}
 #   (if NO_INSTALL is not given).
 function(copy_file_to_buildtree file relative)
-  cmake_parse_arguments(arg "NO_INSTALL" "" "" ${ARGN})
+  cmake_parse_arguments(arg "NO_INSTALL" "SUBDIR" "" ${ARGN})
   string(REPLACE "${relative}/" "" outfile ${file})
+  if(arg_SUBDIR)
+    set(outfile "${arg_SUBDIR}/${outfile}")
+  endif()
   get_filename_component(outdir ${outfile} DIRECTORY)
 
   if(NOT CMAKE_BINARY_DIR STREQUAL CORE_SOURCE_DIR)

--- a/project/cmake/scripts/osx/Macros.cmake
+++ b/project/cmake/scripts/osx/Macros.cmake
@@ -105,3 +105,15 @@ function(find_soname lib)
   endif()
   set(${lib}_SONAME ${${lib}_SONAME} PARENT_SCOPE)
 endfunction()
+
+# Copies additional files to the root of the buildtree so that kodi can be
+# started from there.
+# On return:
+#   files added to ${install_data}, mirror in build tree
+function(copy_additional_files_to_buildtree)
+  copy_file_to_buildtree(${CORE_SOURCE_DIR}/tools/depends/target/openssl/cacert.pem
+                         ${CORE_SOURCE_DIR}/tools/depends/target/openssl
+                         SUBDIR system/certs)
+
+  set(install_data ${install_data} PARENT_SCOPE)
+endfunction()

--- a/project/cmake/scripts/windows/Macros.cmake
+++ b/project/cmake/scripts/windows/Macros.cmake
@@ -93,7 +93,7 @@ endfunction()
 # Copies the main dlls to the root of the buildtree
 # On return:
 #   files added to ${install_data}, mirror in build tree
-function(copy_main_dlls_to_buildtree)
+function(copy_additional_files_to_buildtree)
   set(dir ${PROJECT_SOURCE_DIR}/../Win32BuildSetup/dependencies)
   file(GLOB_RECURSE files ${dir}/*)
   foreach(file ${files})


### PR DESCRIPTION
On windows and osx/ios we need to mirror additional files to the build tree. While this is usually done via configuration files in installdata, these files need special treatment (either because they need to go into a different subdir or because they are dynamically generated and their path is not static).
