### PR TITLE
[depends] Install config-binaddons.site and Toolchain_binaddons.cmake

### DIFF
--- a/tools/depends/configure.ac
+++ b/tools/depends/configure.ac
@@ -593,5 +593,7 @@ if test "x$has_localeconv" == "xno" && test "$platform_os" == "android"; then
 fi
 
 cp -vf target/config.site $prefix/$deps_dir/share
+cp -vf target/config-binaddons.site $prefix/$tool_dir/share
 cp -vf target/Toolchain.cmake $prefix/$deps_dir/share
+cp -vf target/Toolchain_binaddons.cmake $prefix/$deps_dir/share
 cp -vf native/config.site.native $prefix/$tool_dir/share/config.site


### PR DESCRIPTION
Installing those two files allows to use xbmc-addons.include to build addons only with the installed depends.

That way multiple versions of depends (android-arm, android-x86, ...) can be built and installed from one kodi source tree. Afterwards the source tree can be cleaned completely.

When building with CMake, this enables to configure with `-DCMAKE_TOOLCHAIN_FILE=/opt/xbmc-depends/<platform>/share/Toolchain.cmake` and compile the binary addons afterwards with `make binary-addons ADDONS="visualization.spectrum"`.

ping: @wsnipex 
